### PR TITLE
#9159: Enable support for FlashDecode, a variant of SDPA

### DIFF
--- a/tests/tt_eager/python_api_testing/unit_testing/misc/test_scaled_dot_product_attention.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/misc/test_scaled_dot_product_attention.py
@@ -3,12 +3,14 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import os
+import math
 import torch
 from tests.tt_eager.python_api_testing.sweep_tests.comparison_funcs import (
     comp_allclose,
     comp_pcc,
 )
 import tt_lib
+import ttnn
 from loguru import logger
 import pytest
 from models.utility_functions import skip_for_grayskull, skip_for_wormhole_b0
@@ -27,6 +29,13 @@ def run_test_sdpa_tt(device, b, nh, nkv, s, d, q_chunk_size, k_chunk_size, dtype
         k_chunk_size=k_chunk_size,
     )
 
+    compute_kernel_config = tt_lib.tensor.WormholeComputeKernelConfig(
+        math_fidelity=tt_lib.tensor.MathFidelity.HiFi2,
+        math_approx_mode=True,
+        fp32_dest_acc_en=True,
+        packer_l1_acc=False,
+    )
+
     Q = torch.randn(b, nh, s, d)
     K = torch.randn(b, nkv, s, d)
     V = torch.randn(b, nkv, s, d)
@@ -43,7 +52,6 @@ def run_test_sdpa_tt(device, b, nh, nkv, s, d, q_chunk_size, k_chunk_size, dtype
     tt_K = tt_lib.tensor.Tensor(K, dtype).to(tt_lib.tensor.Layout.TILE).to(device)
     tt_V = tt_lib.tensor.Tensor(V, dtype).to(tt_lib.tensor.Layout.TILE).to(device)
     tt_attn_mask = tt_lib.tensor.Tensor(attn_mask, dtype).to(tt_lib.tensor.Layout.TILE).to(device)
-
     tt_back = tt_lib.operations.primary.transformers.scaled_dot_product_attention(
         tt_Q, tt_K, tt_V, tt_attn_mask, is_causal=True, program_config=program_config
     )
@@ -56,7 +64,7 @@ def run_test_sdpa_tt(device, b, nh, nkv, s, d, q_chunk_size, k_chunk_size, dtype
     assert out_pass
 
 
-@pytest.mark.skip(reason="ND PCC issues")
+# @pytest.mark.skip(reason="ND PCC issues")
 @pytest.mark.skipif(is_watcher_enabled(), reason="Kernel OOM with watcher enabled")
 @skip_for_grayskull("Unsupported in GS since L1 runs OOM with most configs")
 @pytest.mark.parametrize(
@@ -83,7 +91,7 @@ def test_sdpa_tt(device, b, nh, nkv, s, d, q_chunk_size, k_chunk_size, dtype):
     run_test_sdpa_tt(device, b, nh, nkv, s, d, q_chunk_size, k_chunk_size, dtype)
 
 
-@pytest.mark.skip(reason="ND PCC issues")
+# @pytest.mark.skip(reason="ND PCC issues")
 @pytest.mark.skipif(is_watcher_enabled(), reason="Kernel OOM with watcher enabled")
 @skip_for_grayskull("Unsupported in GS since L1 runs OOM with most configs")
 @pytest.mark.parametrize(
@@ -107,5 +115,292 @@ def test_sdpa_tt_with_program_cache(device, b, nh, nkv, s, d, q_chunk_size, k_ch
 
     for _ in range(2):
         run_test_sdpa_tt(device, b, nh, nkv, s, d, q_chunk_size, k_chunk_size, dtype)
+
+    assert device.num_program_cache_entries() == 1
+
+
+def nearest_n(x, n):
+    return ((x + n - 1) // n) * n
+
+
+def nearest_pow_2(x):
+    if x < 1:
+        raise ValueError("x must be >= 1")
+    import math
+
+    power = math.ceil(math.log2(x))
+    return 1 << power
+
+
+def num_to_corerange(x):
+    assert x < 8 or x % 8 == 0
+    num_x = min(x, 8)
+    num_y = x // num_x
+    assert num_x * num_y == x
+    return ttnn.experimental.tensor.CoreRange(
+        ttnn.experimental.tensor.CoreCoord(0, 0),
+        ttnn.experimental.tensor.CoreCoord(num_x - 1, num_y - 1),
+    )
+
+
+def get_chunk_size(s):
+    # Not sure if optimal
+    if s <= 32:
+        return 32
+    if s <= 64:
+        return 64
+    if s <= 128:
+        return 128
+    if s <= 256:
+        return 256
+    if s <= 2048:
+        return 512
+    return 1024
+
+
+def run_test_sdpa_decode(device, b, nh, nkv, s, d, dtype):
+    padded_num_heads = nearest_pow_2(nearest_n(nh, n=32))
+    torch.manual_seed(1234)
+
+    compute_kernel_config = tt_lib.tensor.WormholeComputeKernelConfig(
+        math_fidelity=tt_lib.tensor.MathFidelity.HiFi4,
+        math_approx_mode=False,
+        fp32_dest_acc_en=True,
+        packer_l1_acc=False,
+    )
+    dram_memcfg = ttnn.types.MemoryConfig(ttnn.types.TensorMemoryLayout.INTERLEAVED, ttnn.types.BufferType.DRAM)
+    shard_grid = ttnn.experimental.tensor.CoreRangeSet({num_to_corerange(b)})
+    shard_spec = ttnn.experimental.tensor.ShardSpec(
+        shard_grid, (padded_num_heads, d), ttnn.experimental.tensor.ShardOrientation.ROW_MAJOR, False
+    )
+
+    height_sharded_memcfg = ttnn.types.MemoryConfig(
+        ttnn.types.TensorMemoryLayout.HEIGHT_SHARDED, ttnn.types.BufferType.L1, shard_spec
+    )
+
+    K = torch.randn(nkv, b, s, d)
+    V = torch.randn(nkv, b, s, d)
+
+    tt_K = ttnn.as_tensor(K, device=device, dtype=dtype, layout=ttnn.TILE_LAYOUT, memory_config=dram_memcfg)
+    tt_V = ttnn.as_tensor(V, device=device, dtype=dtype, layout=ttnn.TILE_LAYOUT, memory_config=dram_memcfg)
+
+    start_idx = 31
+
+    while start_idx < s:
+        scale = d**-0.5
+
+        k_chunk_size = get_chunk_size(start_idx)
+        program_config = tt_lib.operations.primary.transformers.SDPAMultiCoreProgramConfig(
+            compute_with_storage_grid_size=device.compute_with_storage_grid_size(),
+            q_chunk_size=padded_num_heads,
+            k_chunk_size=k_chunk_size,
+        )
+
+        padded_layer_len = nearest_n(start_idx, n=k_chunk_size)
+
+        # Test various sequence lengths
+        logger.debug(f"Testing with sequence length: {start_idx}")
+        logger.debug(f"Using chunk size: {k_chunk_size}")
+        logger.debug(f"Using padded layer length: {padded_layer_len}")
+        logger.debug(f"Using padded num heads: {padded_num_heads}")
+
+        attn_mask = torch.zeros((1, b, padded_num_heads, padded_layer_len))
+        # Assume all users are at same position
+        attn_mask[:, :, :, start_idx:] = torch.finfo(torch.float32).min
+
+        Q = torch.randn(1, b, padded_num_heads, d)
+
+        tt_Q = ttnn.as_tensor(
+            Q, device=device, dtype=dtype, layout=ttnn.TILE_LAYOUT, memory_config=height_sharded_memcfg
+        )
+
+        tt_attn_mask = ttnn.as_tensor(
+            attn_mask, device=device, dtype=dtype, layout=ttnn.TILE_LAYOUT, memory_config=dram_memcfg
+        )
+
+        tt_back = tt_lib.operations.primary.transformers.scaled_dot_product_attention(
+            tt_Q,
+            tt_K,
+            tt_V,
+            tt_attn_mask,
+            is_causal=False,
+            scale=scale,
+            program_config=program_config,
+            valid_seq_len=padded_layer_len,
+            compute_kernel_config=compute_kernel_config,
+            output_mem_config=height_sharded_memcfg,
+        )
+
+        tt_back = ttnn.to_torch(tt_back)
+        tt_back = tt_back[:, :, :nh, :]
+
+        Q_slice = Q[:, :, :nh, :].permute(1, 2, 0, 3)  # b, nh, 1, d
+        K_slice = K[:, :, :padded_layer_len, :].permute(1, 0, 2, 3)  # nh, b, S, d
+        V_slice = V[:, :, :padded_layer_len, :].permute(1, 0, 2, 3)  # nh, b, S, d
+        attn_mask_slice = attn_mask[:, :, :nh, :].permute(1, 2, 0, 3)  # b, nh, 1, S
+        expect = torch.nn.functional.scaled_dot_product_attention(
+            Q_slice, K_slice, V_slice, attn_mask_slice, scale=scale, is_causal=False
+        )  # b, nh, 1, d
+        expect = expect.squeeze().unsqueeze(0)
+
+        out_pass, out_pcc = comp_pcc(expect, tt_back, 0.99)
+
+        logger.debug(f"python vs pytorch: {out_pcc}")
+        assert out_pass
+
+        start_idx += 601
+
+
+@skip_for_grayskull("Unsupported in GS since L1 runs OOM with most configs")
+@pytest.mark.parametrize(
+    "dtype",
+    [tt_lib.tensor.DataType.BFLOAT8_B, tt_lib.tensor.DataType.BFLOAT16],
+    ids=["bfp8", "bf16"],
+)
+@pytest.mark.parametrize(
+    "b, nh, nkv, s, d",
+    (
+        [16, 8, 1, 8192, 128],  # Llama2-70B
+        [32, 16, 1, 2048, 64],  # Falcon-40B
+        [32, 4, 1, 8192, 128],  # Mixtral
+    ),
+)
+def test_sdpa_decode(device, b, nh, nkv, s, d, dtype):
+    tt_lib.device.DisablePersistentKernelCache()
+    run_test_sdpa_decode(device, b, nh, nkv, s, d, dtype)
+
+
+def run_test_sdpa_decode_single_iter(device, b, nh, nkv, s, d, dtype):
+    padded_num_heads = nearest_pow_2(nearest_n(nh, n=32))
+    torch.manual_seed(1234)
+
+    compute_kernel_config = tt_lib.tensor.WormholeComputeKernelConfig(
+        math_fidelity=tt_lib.tensor.MathFidelity.HiFi4,
+        math_approx_mode=False,
+        fp32_dest_acc_en=True,
+        packer_l1_acc=False,
+    )
+    dram_memcfg = ttnn.types.MemoryConfig(ttnn.types.TensorMemoryLayout.INTERLEAVED, ttnn.types.BufferType.DRAM)
+    shard_grid = ttnn.experimental.tensor.CoreRangeSet({num_to_corerange(b)})
+    shard_spec = ttnn.experimental.tensor.ShardSpec(
+        shard_grid, (padded_num_heads, d), ttnn.experimental.tensor.ShardOrientation.ROW_MAJOR, False
+    )
+
+    height_sharded_memcfg = ttnn.types.MemoryConfig(
+        ttnn.types.TensorMemoryLayout.HEIGHT_SHARDED, ttnn.types.BufferType.L1, shard_spec
+    )
+
+    K = torch.randn(nkv, b, s, d)
+    V = torch.randn(nkv, b, s, d)
+
+    tt_K = ttnn.as_tensor(K, device=device, dtype=dtype, layout=ttnn.TILE_LAYOUT, memory_config=dram_memcfg)
+    tt_V = ttnn.as_tensor(V, device=device, dtype=dtype, layout=ttnn.TILE_LAYOUT, memory_config=dram_memcfg)
+
+    start_idx = s // 2
+    scale = d**-0.5
+
+    k_chunk_size = get_chunk_size(start_idx)
+    program_config = tt_lib.operations.primary.transformers.SDPAMultiCoreProgramConfig(
+        compute_with_storage_grid_size=device.compute_with_storage_grid_size(),
+        q_chunk_size=padded_num_heads,
+        k_chunk_size=k_chunk_size,
+    )
+
+    padded_layer_len = nearest_n(start_idx, n=k_chunk_size)
+
+    # Test various sequence lengths
+    logger.debug(f"Testing with sequence length: {start_idx}")
+    logger.debug(f"Using chunk size: {k_chunk_size}")
+    logger.debug(f"Using padded layer length: {padded_layer_len}")
+    logger.debug(f"Using padded num heads: {padded_num_heads}")
+
+    attn_mask = torch.zeros((1, b, padded_num_heads, padded_layer_len))
+    # Assume all users are at same position
+    attn_mask[:, :, :, start_idx:] = torch.finfo(torch.float32).min
+
+    Q = torch.randn(1, b, padded_num_heads, d)
+
+    tt_Q = ttnn.as_tensor(Q, device=device, dtype=dtype, layout=ttnn.TILE_LAYOUT, memory_config=height_sharded_memcfg)
+
+    tt_attn_mask = ttnn.as_tensor(
+        attn_mask, device=device, dtype=dtype, layout=ttnn.TILE_LAYOUT, memory_config=dram_memcfg
+    )
+
+    tt_back = tt_lib.operations.primary.transformers.scaled_dot_product_attention(
+        tt_Q,
+        tt_K,
+        tt_V,
+        tt_attn_mask,
+        is_causal=False,
+        scale=scale,
+        program_config=program_config,
+        valid_seq_len=padded_layer_len,
+        compute_kernel_config=compute_kernel_config,
+        output_mem_config=height_sharded_memcfg,
+    )
+
+    tt_back = ttnn.to_torch(tt_back)
+    tt_back = tt_back[:, :, :nh, :]
+
+    Q_slice = Q[:, :, :nh, :].permute(1, 2, 0, 3)  # b, nh, 1, d
+    K_slice = K[:, :, :padded_layer_len, :].permute(1, 0, 2, 3)  # nh, b, S, d
+    V_slice = V[:, :, :padded_layer_len, :].permute(1, 0, 2, 3)  # nh, b, S, d
+    attn_mask_slice = attn_mask[:, :, :nh, :].permute(1, 2, 0, 3)  # b, nh, 1, S
+    expect = torch.nn.functional.scaled_dot_product_attention(
+        Q_slice, K_slice, V_slice, attn_mask_slice, scale=scale, is_causal=False
+    )  # b, nh, 1, d
+    expect = expect.squeeze().unsqueeze(0)
+
+    out_pass, out_pcc = comp_pcc(expect, tt_back, 0.99)
+
+    logger.debug(f"python vs pytorch: {out_pcc}")
+    assert out_pass
+
+
+@skip_for_grayskull("Unsupported in GS since L1 runs OOM with most configs")
+@pytest.mark.parametrize(
+    "dtype",
+    [tt_lib.tensor.DataType.BFLOAT8_B, tt_lib.tensor.DataType.BFLOAT16],
+    ids=["bfp8", "bf16"],
+)
+@pytest.mark.parametrize(
+    "b, nh, nkv, s, d",
+    ([16, 8, 1, 8192, 128],),  # Llama2-70B
+)
+def test_sdpa_decode_program_cache(device, b, nh, nkv, s, d, dtype, use_program_cache):
+    tt_lib.device.DisablePersistentKernelCache()
+
+    dummy_tensors = []
+    for _ in range(2):
+        dummy_tensors.append(
+            ttnn.as_tensor(
+                torch.zeros(32, 32),
+                device=device,
+                dtype=dtype,
+                layout=ttnn.TILE_LAYOUT,
+                memory_config=ttnn.types.MemoryConfig(
+                    ttnn.types.TensorMemoryLayout.INTERLEAVED, ttnn.types.BufferType.DRAM
+                ),
+            )
+        )
+        dummy_tensors.append(
+            ttnn.as_tensor(
+                torch.zeros(1, 1, 32, 32 * 32),
+                device=device,
+                dtype=dtype,
+                layout=ttnn.TILE_LAYOUT,
+                memory_config=ttnn.types.MemoryConfig(
+                    ttnn.types.TensorMemoryLayout.HEIGHT_SHARDED,
+                    ttnn.types.BufferType.L1,
+                    ttnn.experimental.tensor.ShardSpec(
+                        ttnn.experimental.tensor.CoreRangeSet({num_to_corerange(32)}),
+                        (32, 32),
+                        ttnn.experimental.tensor.ShardOrientation.ROW_MAJOR,
+                        False,
+                    ),
+                ),
+            )
+        )
+        run_test_sdpa_decode_single_iter(device, b, nh, nkv, s, d, dtype)
 
     assert device.num_program_cache_entries() == 1

--- a/tt_eager/tt_dnn/op_library/sdpa/kernels/dataflow/reader_noncausal_interleaved.cpp
+++ b/tt_eager/tt_dnn/op_library/sdpa/kernels/dataflow/reader_noncausal_interleaved.cpp
@@ -1,0 +1,185 @@
+// SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <stdint.h>
+#include "dataflow_api.h"
+#include "debug/dprint.h"
+
+template<uint32_t tile_bytes, uint32_t num_readers>
+constexpr uint32_t get_barrier_read_threshold() {
+     return ((512 / num_readers) * (1024 + 128)) / tile_bytes;
+ }
+
+void kernel_main() {
+    constexpr uint32_t NKH = get_compile_time_arg_val(0);
+    constexpr uint32_t B = get_compile_time_arg_val(1);
+    constexpr uint32_t _unused1 = get_compile_time_arg_val(2);
+    constexpr uint32_t St = get_compile_time_arg_val(3);
+    constexpr uint32_t DHt = get_compile_time_arg_val(4);
+    constexpr uint32_t Sq_chunk_t = get_compile_time_arg_val(5);
+    constexpr uint32_t q_num_chunks = get_compile_time_arg_val(6);
+    constexpr uint32_t Sk_chunk_t = get_compile_time_arg_val(7);
+    constexpr uint32_t k_num_chunks = get_compile_time_arg_val(8); // num chunks in valid_seq_len
+
+    constexpr uint32_t num_cores = get_compile_time_arg_val(9);
+
+    const uint32_t q_addr  = get_arg_val<uint32_t>(0);
+    const uint32_t k_addr  = get_arg_val<uint32_t>(1);
+    const uint32_t v_addr         = get_arg_val<uint32_t>(2);
+    const uint32_t mask_addr         = get_arg_val<uint32_t>(3);
+    const uint32_t core_id    = get_arg_val<uint32_t>(4);
+    const uint32_t local_batch_start = get_arg_val<uint32_t>(5);
+    const uint32_t local_batch_end = get_arg_val<uint32_t>(6);
+    const uint32_t local_nh_start = get_arg_val<uint32_t>(7);
+    const uint32_t local_nh_end = get_arg_val<uint32_t>(8);
+    const uint32_t local_q_start = get_arg_val<uint32_t>(9);
+    const uint32_t local_q_end = get_arg_val<uint32_t>(10);
+
+    const uint32_t q_chunks_per_core = local_q_end - local_q_start;
+
+    constexpr uint32_t q_chunk_tiles = Sq_chunk_t * DHt;
+    constexpr uint32_t k_chunk_tiles = Sk_chunk_t * DHt;
+    constexpr uint32_t mask_chunk_tiles = Sq_chunk_t * Sk_chunk_t;
+    constexpr uint32_t valid_seqlen_tiles = k_num_chunks * Sk_chunk_t;
+
+    constexpr bool is_dram = true;
+
+    constexpr uint32_t cb_q_in = tt::CB::c_in0;
+    constexpr uint32_t cb_k_in = tt::CB::c_in1;
+    constexpr uint32_t cb_v_in = tt::CB::c_in2;
+    constexpr uint32_t cb_mask_in = tt::CB::c_in3;
+
+
+    constexpr uint32_t onetile = 1;
+    constexpr uint32_t k_tile_bytes = get_tile_size(cb_k_in);
+    constexpr DataFormat k_data_format = get_dataformat(cb_k_in);
+    constexpr uint32_t v_tile_bytes = get_tile_size(cb_v_in);
+    constexpr DataFormat v_data_format = get_dataformat(cb_v_in);
+    constexpr uint32_t mask_tile_bytes = get_tile_size(cb_mask_in);
+    constexpr DataFormat mask_data_format = get_dataformat(cb_mask_in);
+
+    constexpr uint32_t barrier_threshold = get_barrier_read_threshold<k_tile_bytes, num_cores>();
+
+    const InterleavedAddrGenFast<is_dram> k_reader = {
+        .bank_base_address = k_addr,
+        .page_size = k_tile_bytes,
+        .data_format = k_data_format
+    };
+
+    const InterleavedAddrGenFast<is_dram> v_reader = {
+        .bank_base_address = v_addr,
+        .page_size = v_tile_bytes,
+        .data_format = v_data_format
+    };
+
+    const InterleavedAddrGenFast<is_dram> mask_reader = {
+        .bank_base_address = mask_addr,
+        .page_size = mask_tile_bytes,
+        .data_format = mask_data_format
+    };
+
+    uint32_t k_tile_id = 0;
+    uint32_t v_tile_id = 0;
+    uint32_t mask_tile_id = 0;
+    uint32_t barrier_count = 0;
+
+    for (uint32_t nb = local_batch_start; nb < local_batch_end; ++nb) {
+        DPRINT << "nb: " << nb << ENDL();
+        const uint32_t q_batch_offset = nb * NKH * St * DHt;
+        const uint32_t k_batch_offset = nb * NKH * St * DHt;
+        const uint32_t v_batch_offset = nb * NKH * St * DHt;
+        const uint32_t mask_batch_offset = nb * NKH * Sq_chunk_t * valid_seqlen_tiles;
+        for (uint32_t nq = local_nh_start; nq < local_nh_end; ++nq) {
+            DPRINT << "nq: " << nq << ENDL();
+            // In decode mode, n1 = q_shape[1] is actually the batch dim
+            const uint32_t kv_nh_offset = nq * St * DHt;
+            const uint32_t mask_nh_offset = nq * Sq_chunk_t * valid_seqlen_tiles;
+
+            for (uint32_t q_iter = 0; q_iter < q_chunks_per_core; ++q_iter) {
+                DPRINT << "q_iter: " << q_iter << ENDL();
+
+                // Q is available because it's a sharded input
+                cb_reserve_back(cb_q_in, q_chunk_tiles);
+                cb_push_back(cb_q_in, q_chunk_tiles);
+
+                // Loop over k_num_chunks, which is the number of chunks in `valid_seq_len`
+                for (uint32_t k_chunk = 0; k_chunk < k_num_chunks; ++k_chunk) {
+                    DPRINT << "k_chunk: " << k_chunk << ENDL();
+                    const uint32_t k_chunk_offset = k_chunk * Sk_chunk_t * DHt;
+                    const uint32_t mask_chunk_offset = k_chunk * Sk_chunk_t;
+
+                    const uint32_t k_start_tile_id = k_batch_offset + kv_nh_offset + k_chunk_offset;
+
+                    // Read K chunk transposed
+                    cb_reserve_back(cb_k_in, k_chunk_tiles);
+                    uint32_t k_write_ptr = get_write_ptr(cb_k_in);
+                    barrier_count = 0;
+                    for (uint32_t col = 0; col < DHt; ++col) {
+                        k_tile_id = k_start_tile_id + col;
+                        for (uint32_t row = 0; row < Sk_chunk_t; ++row) {
+                            DPRINT << "k_tile_id: " << k_tile_id << ENDL();
+                            noc_async_read_tile(k_tile_id, k_reader, k_write_ptr);
+                            k_tile_id += DHt;
+                            k_write_ptr += k_tile_bytes;
+
+                            if (++barrier_count == barrier_threshold) {
+                                noc_async_read_barrier();
+                                barrier_count = 0;
+                            }
+                        }
+                    }
+                    noc_async_read_barrier();
+                    cb_push_back(cb_k_in, k_chunk_tiles);
+
+
+                    // Noncausal, so we always read mask
+                    cb_reserve_back(cb_mask_in, mask_chunk_tiles);
+                    uint32_t mask_write_ptr = get_write_ptr(cb_mask_in);
+                    barrier_count = 0;
+                    mask_tile_id = mask_batch_offset + mask_nh_offset + mask_chunk_offset;
+                    for (uint32_t row = 0; row < Sq_chunk_t; ++row) {
+                        for (uint32_t col = 0; col < Sk_chunk_t; ++col) {
+                            DPRINT << "mask_tile_id: " << mask_tile_id << ENDL();
+                            noc_async_read_tile(mask_tile_id, mask_reader, mask_write_ptr);
+                            mask_tile_id += 1;
+                            mask_write_ptr += mask_tile_bytes;
+
+                            if (++barrier_count == barrier_threshold) {
+                                noc_async_read_barrier();
+                                barrier_count = 0;
+                            }
+                        }
+                        // Strid along columns to get to next row
+                        mask_tile_id -= Sk_chunk_t;
+                        mask_tile_id += valid_seqlen_tiles;
+                    }
+                    noc_async_read_barrier();
+                    cb_push_back(cb_mask_in, mask_chunk_tiles);
+
+
+
+
+                    v_tile_id = v_batch_offset + kv_nh_offset + k_chunk_offset;
+                    // Read V chunk
+                    cb_reserve_back(cb_v_in, k_chunk_tiles);
+                    uint32_t v_write_ptr = get_write_ptr(cb_v_in);
+                    barrier_count = 0;
+                    for (uint32_t tile = 0; tile < k_chunk_tiles; ++tile) {
+                        DPRINT << "v_tile_id: " << v_tile_id << ENDL();
+                        noc_async_read_tile(v_tile_id, v_reader, v_write_ptr);
+                        v_tile_id += 1;
+                        v_write_ptr += v_tile_bytes;
+
+                        if (++barrier_count == barrier_threshold) {
+                            noc_async_read_barrier();
+                            barrier_count = 0;
+                        }
+                    }
+                    noc_async_read_barrier();
+                    cb_push_back(cb_v_in, k_chunk_tiles);
+                }
+            }
+        }
+    }
+}

--- a/tt_eager/tt_dnn/op_library/sdpa/kernels/dataflow/writer_noncausal_interleaved.cpp
+++ b/tt_eager/tt_dnn/op_library/sdpa/kernels/dataflow/writer_noncausal_interleaved.cpp
@@ -1,0 +1,61 @@
+// SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "dataflow_api.h"
+#include "tt_eager/tt_dnn/kernels/dataflow/generate_bcast_scalar.hpp"
+#include "tt_eager/tt_dnn/kernels/dataflow/generate_reduce_scaler.hpp"
+
+template<uint32_t tile_bytes, uint32_t num_readers>
+constexpr uint32_t get_barrier_read_threshold() {
+    return ((512 / num_readers) * (1024 + 128)) / tile_bytes;
+}
+
+void kernel_main() {
+    constexpr uint32_t NKH = get_compile_time_arg_val(0);
+    constexpr uint32_t B = get_compile_time_arg_val(1);
+    constexpr uint32_t _unused1 = get_compile_time_arg_val(2);
+    constexpr uint32_t St = get_compile_time_arg_val(3);
+    constexpr uint32_t DHt = get_compile_time_arg_val(4);
+    constexpr uint32_t Sq_chunk_t = get_compile_time_arg_val(5);
+    constexpr uint32_t q_num_chunks = get_compile_time_arg_val(6);
+    constexpr uint32_t Sk_chunk_t = get_compile_time_arg_val(7);
+    constexpr uint32_t k_num_chunks = get_compile_time_arg_val(8); // num chunks in valid_seq_len
+
+    constexpr uint32_t identity_scalar_packed = get_compile_time_arg_val(9);
+    constexpr uint32_t scale_val = get_compile_time_arg_val(10);
+    constexpr uint32_t num_cores = get_compile_time_arg_val(11);
+
+    const uint32_t out_addr  = get_arg_val<uint32_t>(0);
+    const uint32_t core_id    = get_arg_val<uint32_t>(1);
+    const uint32_t local_batch_start = get_arg_val<uint32_t>(2);
+    const uint32_t local_batch_end = get_arg_val<uint32_t>(3);
+    const uint32_t local_nh_start = get_arg_val<uint32_t>(4);
+    const uint32_t local_nh_end = get_arg_val<uint32_t>(5);
+    const uint32_t local_q_start = get_arg_val<uint32_t>(6);
+    const uint32_t local_q_end = get_arg_val<uint32_t>(7);
+
+    const uint32_t q_chunks_per_core = local_q_end - local_q_start;
+
+    constexpr uint32_t out_chunk_tiles = Sq_chunk_t * DHt;
+
+    constexpr uint32_t cb_out = tt::CB::c_out0;
+
+    constexpr uint32_t cb_scale_in = tt::CB::c_in4;
+    constexpr uint32_t cb_identity_scale_in = tt::CB::c_in5;
+
+    generate_bcast_unary_scalar(cb_scale_in, scale_val);
+    generate_reduce_scaler(cb_identity_scale_in, identity_scalar_packed);
+
+    uint32_t out_tile_id = 0;
+
+    for (uint32_t nb = local_batch_start; nb < local_batch_end; ++nb) {
+        for (uint32_t nq = local_nh_start; nq < local_nh_end; ++nq) {
+            for (uint32_t q_iter = 0; q_iter < q_chunks_per_core; ++q_iter) {
+                // Wait for compute to deliver output chunk
+                cb_wait_front(cb_out, out_chunk_tiles);
+                cb_pop_front(cb_out, out_chunk_tiles);
+            }
+        }
+    }
+}

--- a/tt_eager/tt_dnn/op_library/sdpa/sdpa_op.hpp
+++ b/tt_eager/tt_dnn/op_library/sdpa/sdpa_op.hpp
@@ -51,6 +51,7 @@ struct ScaledDotProductAttention {
     const tt::operations::primary::transformers::SDPAProgramConfig program_config;
     const bool is_causal;
     const DeviceComputeKernelConfig compute_kernel_config;
+    std::optional<const uint32_t> valid_seq_len;
 
     void validate(const std::vector<Tensor> &input_tensors, const std::vector<std::optional<const Tensor>>& optional_input_tensors) const;
     std::vector<Shape> compute_output_shapes(const std::vector<Tensor> &input_tensors) const;
@@ -74,12 +75,13 @@ operation::ProgramWithCallbacks sdpa_multi_core(
     std::size_t q_chunk_size,
     std::size_t k_chunk_size,
     DeviceComputeKernelConfig compute_kernel_config,
-    tt::operations::primary::transformers::SDPAProgramConfig program_config
+    tt::operations::primary::transformers::SDPAProgramConfig program_config,
+    std::optional<const uint32_t> valid_seq_len
 );
 
 namespace transformers {
 
-Tensor scaled_dot_product_attention(Tensor& input_tensor_q, Tensor& input_tensor_k, Tensor& input_tensor_v, std::optional<const Tensor> causal_mask = std::nullopt, const bool is_causal = true, std::optional<float> scale = std::nullopt, const MemoryConfig& output_mem_config = operation::DEFAULT_OUTPUT_MEMORY_CONFIG, const SDPAProgramConfig& program_config = SDPADefaultProgramConfig{}, std::optional<const DeviceComputeKernelConfig> compute_kernel_config = std::nullopt);
+Tensor scaled_dot_product_attention(Tensor& input_tensor_q, Tensor& input_tensor_k, Tensor& input_tensor_v, std::optional<const Tensor> causal_mask = std::nullopt, const bool is_causal = true, std::optional<float> scale = std::nullopt, const MemoryConfig& output_mem_config = operation::DEFAULT_OUTPUT_MEMORY_CONFIG, const SDPAProgramConfig& program_config = SDPADefaultProgramConfig{}, std::optional<const DeviceComputeKernelConfig> compute_kernel_config = std::nullopt, std::optional<const uint32_t> valid_seq_len = std::nullopt);
 
 }   // namespace transformers
 

--- a/tt_eager/tt_lib/csrc/operations/primary/transformers/module.hpp
+++ b/tt_eager/tt_lib/csrc/operations/primary/transformers/module.hpp
@@ -120,6 +120,7 @@ void py_module(py::module& m_transformers) {
         py::arg("output_mem_config").noconvert() = operation::DEFAULT_OUTPUT_MEMORY_CONFIG,
         py::arg("program_config").noconvert() = SDPADefaultProgramConfig{},
         py::arg("compute_kernel_config").noconvert() = std::nullopt,
+        py::arg("valid_seq_len").noconvert() = std::nullopt,
         "Causal scaled dot product attention. This API mimicks the PyTorch API of the same name."
         "The implementation is FlashAttention-2 and it currently only supports MQA with causal masking.\n"
 


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/9159

### Problem description
Long context length decode fails in attention since we don't have enough L1 space to load K and V. This requires a FlashAttention-style op to compute attention by chunks.

### What's changed
- Modify SDPA op to allow for decode-shaped inputs

### Checklist
- [x] Post commit CI passes
- [ ] Model regression CI testing passes (if applicable)
- [x] New/Existing tests provide coverage for changes
