### PR TITLE
#0: Update BERT QA demo

### DIFF
--- a/models/demos/bert/tt/ttnn_bert.py
+++ b/models/demos/bert/tt/ttnn_bert.py
@@ -232,7 +232,7 @@ def preprocess_inputs(
     position_ids = ttnn.from_torch(position_ids, dtype=ttnn.uint32, device=device, memory_config=ttnn.L1_MEMORY_CONFIG)
 
     if attention_mask is not None:
-        attention_mask = get_extended_attention_mask(attention_mask, input_ids.shape)
+        attention_mask = get_extended_attention_mask(attention_mask, input_ids.shape, torch.float32)
         attention_mask = attention_mask.expand((batch_size, -1, -1, -1))
         attention_mask = torch.clamp(attention_mask, min=-100000)
         attention_mask = ttnn.from_torch(

--- a/models/demos/bert/tt/ttnn_optimized_bert.py
+++ b/models/demos/bert/tt/ttnn_optimized_bert.py
@@ -286,7 +286,7 @@ def preprocess_inputs(
     position_ids = ttnn.from_torch(position_ids, dtype=ttnn.uint32, device=device, memory_config=ttnn.L1_MEMORY_CONFIG)
 
     if attention_mask is not None:
-        attention_mask = get_extended_attention_mask(attention_mask, input_ids.shape)
+        attention_mask = get_extended_attention_mask(attention_mask, input_ids.shape, torch.float32)
         attention_mask = attention_mask.expand((batch_size, -1, -1, -1))
         attention_mask = torch.clamp(attention_mask, min=-100000)
         attention_mask = ttnn.from_torch(


### PR DESCRIPTION
### Ticket

### Problem description
- BERT demo for ttnn_optimized_bert fails with `E       RuntimeError: TT_FATAL @ ../ttnn/cpp/ttnn/operations/transformer.hpp:305: attention_mask.has_value()`

### What's changed
- Updated position_ids and attention_mask fed to the model referring to HF BERT pipeline.
- Metrics used - Exact Match: 70.83333333333333 and F1 Score: 78.24074074074075.

### Checklist
- [x] Post commit CI passes
- [x] Model regression CI testing passes (if applicable)
- [x] New/Existing tests provide coverage for changes
