### PR TITLE
#9417: Skip ttnn shallow unet test due to various failures

### DIFF
--- a/tests/ttnn/integration_tests/unet/test_ttnn_shallow_unet.py
+++ b/tests/ttnn/integration_tests/unet/test_ttnn_shallow_unet.py
@@ -25,6 +25,7 @@ import tt_lib.profiler as profiler
 import ttnn
 
 
+@pytest.mark.skip(reason="#9417: Various failures preventing model from running")
 @skip_for_grayskull()
 @pytest.mark.parametrize("device_params", [{"l1_small_size": 32768}], indirect=True)
 @pytest.mark.parametrize("loop", [0])


### PR DESCRIPTION
### Ticket
- [Link to Github Issue.](https://github.com/tenstorrent/tt-metal/issues/9417)

### Problem description
- Unet test was mistakenly enabled by setting 8x8 grid, and has various bugs/issues.

### What's changed
- Disabling unet test

### Checklist
- [x] Post commit CI passes
- [x] Model regression CI testing passes (if applicable)
- [x] New/Existing tests provide coverage for changes
