### PR TITLE
#5337: Removed eth_dispatch yaml flag from mistral tests

### DIFF
--- a/models/demos/wormhole/mistral7b/tests/test_mistral_attention.py
+++ b/models/demos/wormhole/mistral7b/tests/test_mistral_attention.py
@@ -11,7 +11,6 @@ if os.getenv("CI") == "true":
     os.environ["MISTRAL_CKPT_DIR"] = "/mnt/MLPerf/ttnn/models/demos/mistral7b/"
     os.environ["MISTRAL_TOKENIZER_PATH"] = "/mnt/MLPerf/ttnn/models/demos/mistral7b/"
     os.environ["MISTRAL_CACHE_PATH"] = "/mnt/MLPerf/ttnn/models/demos/mistral7b/"
-    os.environ["WH_ARCH_YAML"] = "wormhole_b0_80_arch_eth_dispatch.yaml"
 
 import ttnn
 from models.demos.wormhole.mistral7b.tt.mistral_attention import TtMistralAttention

--- a/models/demos/wormhole/mistral7b/tests/test_mistral_decoder.py
+++ b/models/demos/wormhole/mistral7b/tests/test_mistral_decoder.py
@@ -11,7 +11,6 @@ if os.getenv("CI") == "true":
     os.environ["MISTRAL_CKPT_DIR"] = "/mnt/MLPerf/ttnn/models/demos/mistral7b/"
     os.environ["MISTRAL_TOKENIZER_PATH"] = "/mnt/MLPerf/ttnn/models/demos/mistral7b/"
     os.environ["MISTRAL_CACHE_PATH"] = "/mnt/MLPerf/ttnn/models/demos/mistral7b/"
-    os.environ["WH_ARCH_YAML"] = "wormhole_b0_80_arch_eth_dispatch.yaml"
 
 import ttnn
 from models.demos.wormhole.mistral7b.tt.mistral_common import (

--- a/models/demos/wormhole/mistral7b/tests/test_mistral_embedding.py
+++ b/models/demos/wormhole/mistral7b/tests/test_mistral_embedding.py
@@ -11,7 +11,6 @@ if os.getenv("CI") == "true":
     os.environ["MISTRAL_CKPT_DIR"] = "/mnt/MLPerf/ttnn/models/demos/mistral7b/"
     os.environ["MISTRAL_TOKENIZER_PATH"] = "/mnt/MLPerf/ttnn/models/demos/mistral7b/"
     os.environ["MISTRAL_CACHE_PATH"] = "/mnt/MLPerf/ttnn/models/demos/mistral7b/"
-    os.environ["WH_ARCH_YAML"] = "wormhole_b0_80_arch_eth_dispatch.yaml"
 
 import ttnn
 from models.demos.wormhole.mistral7b.tt.model_config import TtModelArgs

--- a/models/demos/wormhole/mistral7b/tests/test_mistral_mlp.py
+++ b/models/demos/wormhole/mistral7b/tests/test_mistral_mlp.py
@@ -12,7 +12,6 @@ if os.getenv("CI") == "true":
     os.environ["MISTRAL_CKPT_DIR"] = "/mnt/MLPerf/ttnn/models/demos/mistral7b/"
     os.environ["MISTRAL_TOKENIZER_PATH"] = "/mnt/MLPerf/ttnn/models/demos/mistral7b/"
     os.environ["MISTRAL_CACHE_PATH"] = "/mnt/MLPerf/ttnn/models/demos/mistral7b/"
-    os.environ["WH_ARCH_YAML"] = "wormhole_b0_80_arch_eth_dispatch.yaml"
 
 import ttnn
 from models.demos.wormhole.mistral7b.tt.model_config import TtModelArgs

--- a/models/demos/wormhole/mistral7b/tests/test_mistral_model.py
+++ b/models/demos/wormhole/mistral7b/tests/test_mistral_model.py
@@ -11,7 +11,6 @@ if os.getenv("CI") == "true":
     os.environ["MISTRAL_CKPT_DIR"] = "/mnt/MLPerf/ttnn/models/demos/mistral7b/"
     os.environ["MISTRAL_TOKENIZER_PATH"] = "/mnt/MLPerf/ttnn/models/demos/mistral7b/"
     os.environ["MISTRAL_CACHE_PATH"] = "/mnt/MLPerf/ttnn/models/demos/mistral7b/"
-    os.environ["WH_ARCH_YAML"] = "wormhole_b0_80_arch_eth_dispatch.yaml"
 
 import ttnn
 from models.demos.wormhole.mistral7b.tt.mistral_common import (

--- a/models/demos/wormhole/mistral7b/tests/test_mistral_perf.py
+++ b/models/demos/wormhole/mistral7b/tests/test_mistral_perf.py
@@ -12,7 +12,6 @@ if os.getenv("CI") == "true":
     os.environ["MISTRAL_CKPT_DIR"] = "/mnt/MLPerf/ttnn/models/demos/mistral7b/"
     os.environ["MISTRAL_TOKENIZER_PATH"] = "/mnt/MLPerf/ttnn/models/demos/mistral7b/"
     os.environ["MISTRAL_CACHE_PATH"] = "/mnt/MLPerf/ttnn/models/demos/mistral7b/"
-    os.environ["WH_ARCH_YAML"] = "wormhole_b0_80_arch_eth_dispatch.yaml"
 
 import ttnn
 from models.demos.wormhole.mistral7b.tt.mistral_common import (

--- a/models/demos/wormhole/mistral7b/tests/test_mistral_rms_norm.py
+++ b/models/demos/wormhole/mistral7b/tests/test_mistral_rms_norm.py
@@ -11,7 +11,6 @@ if os.getenv("CI") == "true":
     os.environ["MISTRAL_CKPT_DIR"] = "/mnt/MLPerf/ttnn/models/demos/mistral7b/"
     os.environ["MISTRAL_TOKENIZER_PATH"] = "/mnt/MLPerf/ttnn/models/demos/mistral7b/"
     os.environ["MISTRAL_CACHE_PATH"] = "/mnt/MLPerf/ttnn/models/demos/mistral7b/"
-    os.environ["WH_ARCH_YAML"] = "wormhole_b0_80_arch_eth_dispatch.yaml"
 
 import ttnn
 from models.demos.wormhole.mistral7b.tt.model_config import TtModelArgs

--- a/tests/scripts/run_performance.sh
+++ b/tests/scripts/run_performance.sh
@@ -39,7 +39,7 @@ run_perf_models_llm_javelin() {
         env pytest models/demos/mamba/tests -m $test_marker
     fi
 
-    env pytest models/demos/wormhole/mistral7b/tests -m $test_marker
+    env  WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml pytest models/demos/wormhole/mistral7b/tests -m $test_marker
 
     ## Merge all the generated reports
     env python models/perf/merge_perf_results.py


### PR DESCRIPTION
Avoids other tests picking up the flag.