### PR TITLE
#5562: resolve reduce scatter issues (nd hang and correctness)

### DIFF
--- a/tests/scripts/t3000/run_t3000_frequent_tests.sh
+++ b/tests/scripts/t3000/run_t3000_frequent_tests.sh
@@ -124,7 +124,7 @@ run_t3000_tests() {
   #run_t3000_ethernet_tests
 
   # Run tteager tests
-  #run_t3000_tteager_tests
+  run_t3000_tteager_tests
 
   # Run trace tests
   run_t3000_trace_stress_tests

--- a/tests/scripts/t3000/run_t3000_frequent_tests.sh
+++ b/tests/scripts/t3000/run_t3000_frequent_tests.sh
@@ -79,6 +79,7 @@ run_t3000_tteager_tests() {
   echo "LOG_METAL: Running run_t3000_tteager_tests"
 
   pytest tests/tt_eager/python_api_testing/unit_testing/misc/test_all_gather.py -k post_commit
+  pytest tests/tt_eager/python_api_testing/unit_testing/misc/test_reduce_scatter_post_commit.py
 
   # Record the end time
   end_time=$(date +%s)

--- a/tests/tt_eager/ops/ccl/test_ccl_helpers.cpp
+++ b/tests/tt_eager/ops/ccl/test_ccl_helpers.cpp
@@ -123,6 +123,71 @@ TEST(CclHelper_AdvanceSliceRowMajor, InnerOffset_1_0__InnerShape_1_1__OuterShape
     ASSERT_EQ(result.y, expected.y);
 }
 
+// Test cases pulled from LLama 70B prefill configurations
+// chip 0 worker 0 link 0 reader unidirectional
+TEST(CclHelper_AdvanceSliceRowMajor, InnerOffset_0_0__InnerShape_24_1__OuterShape_32_4__NumWorkers_4) {
+    const auto worker_slice_offset = tt::tt_metal::ccl::coord_t(0, 0);
+    const auto worker_slice_shape = tt::tt_metal::ccl::coord_t(24, 1);
+    const auto tensor_slice_shape = tt::tt_metal::ccl::coord_t(32, 4);
+    const uint32_t num_workers = 4;
+
+    const auto expected = tt::tt_metal::ccl::coord_t(0, 2);
+    auto const& result_offset = tt::tt_metal::ccl::advance_slice_row_major(worker_slice_offset, worker_slice_shape, tensor_slice_shape, num_workers);
+    ASSERT_EQ(result_offset.x, expected.x);
+    ASSERT_EQ(result_offset.y, expected.y);
+
+
+    auto const& result_offset2 = tt::tt_metal::ccl::advance_slice_row_major(result_offset, worker_slice_shape, tensor_slice_shape, num_workers);
+    ASSERT_TRUE(result_offset2.x >= tensor_slice_shape.x || result_offset2.y >= tensor_slice_shape.y);
+}
+
+TEST(CclHelper_AdvanceSliceRowMajor, InnerOffset_24_0__InnerShape_24_1__OuterShape_32_4__NumWorkers_4) {
+    const auto worker_slice_offset = tt::tt_metal::ccl::coord_t(24, 0);
+    const auto worker_slice_shape = tt::tt_metal::ccl::coord_t(24, 1);
+    const auto tensor_slice_shape = tt::tt_metal::ccl::coord_t(32, 4);
+    const uint32_t num_workers = 4;
+
+    const auto expected = tt::tt_metal::ccl::coord_t(24, 2);
+    auto const& result_offset = tt::tt_metal::ccl::advance_slice_row_major(worker_slice_offset, worker_slice_shape, tensor_slice_shape, num_workers);
+    ASSERT_EQ(result_offset.x, expected.x);
+    ASSERT_EQ(result_offset.y, expected.y);
+
+    auto const& result_offset2 = tt::tt_metal::ccl::advance_slice_row_major(result_offset, worker_slice_shape, tensor_slice_shape, num_workers);
+    ASSERT_TRUE(result_offset2.x >= tensor_slice_shape.x || result_offset2.y >= tensor_slice_shape.y);
+}
+
+TEST(CclHelper_AdvanceSliceRowMajor, InnerOffset_0_1__InnerShape_24_1__OuterShape_32_4__NumWorkers_4) {
+    const auto worker_slice_offset = tt::tt_metal::ccl::coord_t(0, 1);
+    const auto worker_slice_shape = tt::tt_metal::ccl::coord_t(24, 1);
+    const auto tensor_slice_shape = tt::tt_metal::ccl::coord_t(32, 4);
+    const uint32_t num_workers = 4;
+
+    const auto expected = tt::tt_metal::ccl::coord_t(0, 3);
+    auto const& result_offset = tt::tt_metal::ccl::advance_slice_row_major(worker_slice_offset, worker_slice_shape, tensor_slice_shape, num_workers);
+    ASSERT_EQ(result_offset.x, expected.x);
+    ASSERT_EQ(result_offset.y, expected.y);
+
+    auto const& result_offset2 = tt::tt_metal::ccl::advance_slice_row_major(result_offset, worker_slice_shape, tensor_slice_shape, num_workers);
+    ASSERT_TRUE(result_offset2.x >= tensor_slice_shape.x || result_offset2.y >= tensor_slice_shape.y);
+}
+
+
+TEST(CclHelper_AdvanceSliceRowMajor, InnerOffset_24_1__InnerShape_24_1__OuterShape_32_4__NumWorkers_4) {
+    const auto worker_slice_offset = tt::tt_metal::ccl::coord_t(24, 1);
+    const auto worker_slice_shape = tt::tt_metal::ccl::coord_t(24, 1);
+    const auto tensor_slice_shape = tt::tt_metal::ccl::coord_t(32, 4);
+    const uint32_t num_workers = 4;
+
+    const auto expected = tt::tt_metal::ccl::coord_t(24, 3);
+    auto const& result_offset = tt::tt_metal::ccl::advance_slice_row_major(worker_slice_offset, worker_slice_shape, tensor_slice_shape, num_workers);
+    ASSERT_EQ(result_offset.x, expected.x);
+    ASSERT_EQ(result_offset.y, expected.y);
+
+    auto const& result_offset2 = tt::tt_metal::ccl::advance_slice_row_major(result_offset, worker_slice_shape, tensor_slice_shape, num_workers);
+    ASSERT_TRUE(result_offset2.x >= tensor_slice_shape.x || result_offset2.y >= tensor_slice_shape.y);
+}
+
+
 // Test that we successfully go out of bounds on the last iteration
 TEST(CclHelper_AdvanceSliceRowMajor, InnerOffset_0_1__InnerShape_1_1__OuterShape_2_2__NumActiveSlices_2) {
     auto const& result = tt::tt_metal::ccl::advance_slice_row_major({0, 1}, {1, 1}, {2, 2}, 2);
@@ -162,33 +227,33 @@ TEST(CclHelper_AdvanceSliceRowMajor, InnerOffset_24_0__InnerShape_24_0__OuterSha
 }
 
 /////////////////////////////////////////
-// Test InterleavedRingReduceScatterTensorSlicer
+// Test RingReduceScatterTensorSlicer
 /////////////////////////////////////////
-TEST(Ccl_InterleavedRingReduceScatterTensorSlicer, ComputeWorkerSliceOffsets_AllWorkersSameRow) {
+TEST(Ccl_RingReduceScatterTensorSlicer, ComputeWorkerSliceOffsets_AllWorkersSameRow) {
     auto worker_slice_shapes = std::vector<tt_xy_pair>(4, {2, 2});
     tt_xy_pair tensor_slice_shape = {8, 4};
-    auto const& worker_slice_offsets = ccl::InterleavedRingReduceScatterTensorSlicer::compute_worker_slice_offsets(
+    auto const& worker_slice_offsets = ccl::RingReduceScatterTensorSlicer::compute_worker_slice_offsets(
         worker_slice_shapes, tensor_slice_shape);
     ASSERT_EQ(worker_slice_offsets.at(0), tt_xy_pair(0, 0));
     ASSERT_EQ(worker_slice_offsets.at(1), tt_xy_pair(2, 0));
     ASSERT_EQ(worker_slice_offsets.at(2), tt_xy_pair(4, 0));
     ASSERT_EQ(worker_slice_offsets.at(3), tt_xy_pair(6, 0));
 }
-TEST(Ccl_InterleavedRingReduceScatterTensorSlicer, ComputeWorkerSliceOffsets_1WorkerWrapToNextRowAligned) {
+TEST(Ccl_RingReduceScatterTensorSlicer, ComputeWorkerSliceOffsets_1WorkerWrapToNextRowAligned) {
     auto worker_slice_shapes = std::vector<tt_xy_pair>(4, {2, 2});
     tt_xy_pair tensor_slice_shape = {6, 4};
-    auto const& worker_slice_offsets = ccl::InterleavedRingReduceScatterTensorSlicer::compute_worker_slice_offsets(
+    auto const& worker_slice_offsets = ccl::RingReduceScatterTensorSlicer::compute_worker_slice_offsets(
         worker_slice_shapes, tensor_slice_shape);
     ASSERT_EQ(worker_slice_offsets.at(0), tt_xy_pair(0, 0));
     ASSERT_EQ(worker_slice_offsets.at(1), tt_xy_pair(2, 0));
     ASSERT_EQ(worker_slice_offsets.at(2), tt_xy_pair(4, 0));
     ASSERT_EQ(worker_slice_offsets.at(3), tt_xy_pair(0, 2));
 }
-TEST(Ccl_InterleavedRingReduceScatterTensorSlicer, ComputeWorkerSliceOffsets_1WorkerWrapToNextRowMisaligned) {
+TEST(Ccl_RingReduceScatterTensorSlicer, ComputeWorkerSliceOffsets_1WorkerWrapToNextRowMisaligned) {
     {
         auto worker_slice_shapes = std::vector<tt_xy_pair>(4, {2, 2});
         tt_xy_pair tensor_slice_shape = {5, 4};
-        auto const& worker_slice_offsets = ccl::InterleavedRingReduceScatterTensorSlicer::compute_worker_slice_offsets(
+        auto const& worker_slice_offsets = ccl::RingReduceScatterTensorSlicer::compute_worker_slice_offsets(
             worker_slice_shapes, tensor_slice_shape);
         ASSERT_EQ(worker_slice_offsets.at(0), tt_xy_pair(0, 0));
         ASSERT_EQ(worker_slice_offsets.at(1), tt_xy_pair(2, 0));
@@ -196,10 +261,10 @@ TEST(Ccl_InterleavedRingReduceScatterTensorSlicer, ComputeWorkerSliceOffsets_1Wo
         ASSERT_EQ(worker_slice_offsets.at(3), tt_xy_pair(0, 2));
     }
 }
-TEST(Ccl_InterleavedRingReduceScatterTensorSlicer, ComputeWorkerSliceOffsets_MultipleWorkersWrapToNextRowAligned) {
+TEST(Ccl_RingReduceScatterTensorSlicer, ComputeWorkerSliceOffsets_MultipleWorkersWrapToNextRowAligned) {
     auto worker_slice_shapes = std::vector<tt_xy_pair>(8, {2, 2});
     tt_xy_pair tensor_slice_shape = {10, 4};
-    auto const& worker_slice_offsets = ccl::InterleavedRingReduceScatterTensorSlicer::compute_worker_slice_offsets(
+    auto const& worker_slice_offsets = ccl::RingReduceScatterTensorSlicer::compute_worker_slice_offsets(
         worker_slice_shapes, tensor_slice_shape);
     ASSERT_EQ(worker_slice_offsets.at(0), tt_xy_pair(0, 0));
     ASSERT_EQ(worker_slice_offsets.at(1), tt_xy_pair(2, 0));
@@ -211,10 +276,10 @@ TEST(Ccl_InterleavedRingReduceScatterTensorSlicer, ComputeWorkerSliceOffsets_Mul
     ASSERT_EQ(worker_slice_offsets.at(7), tt_xy_pair(4, 2));
 }
 
-TEST(Ccl_InterleavedRingReduceScatterTensorSlicer, ComputeWorkerSliceOffsets_MultipleWorkersWrapToNextRowMisaligned) {
+TEST(Ccl_RingReduceScatterTensorSlicer, ComputeWorkerSliceOffsets_MultipleWorkersWrapToNextRowMisaligned) {
     auto worker_slice_shapes = std::vector<tt_xy_pair>(8, {2, 2});
     tt_xy_pair tensor_slice_shape = {9, 4};
-    auto const& worker_slice_offsets = ccl::InterleavedRingReduceScatterTensorSlicer::compute_worker_slice_offsets(
+    auto const& worker_slice_offsets = ccl::RingReduceScatterTensorSlicer::compute_worker_slice_offsets(
         worker_slice_shapes, tensor_slice_shape);
     ASSERT_EQ(worker_slice_offsets.at(0), tt_xy_pair(0, 0));
     ASSERT_EQ(worker_slice_offsets.at(1), tt_xy_pair(2, 0));
@@ -226,20 +291,20 @@ TEST(Ccl_InterleavedRingReduceScatterTensorSlicer, ComputeWorkerSliceOffsets_Mul
     ASSERT_EQ(worker_slice_offsets.at(7), tt_xy_pair(4, 2));
 }
 
-TEST(Ccl_InterleavedRingReduceScatterTensorSlicer, ComputeWorkerSliceOffsets_NMinus1WorkersWrapToNextRowAligned) {
+TEST(Ccl_RingReduceScatterTensorSlicer, ComputeWorkerSliceOffsets_NMinus1WorkersWrapToNextRowAligned) {
     auto worker_slice_shapes = std::vector<tt_xy_pair>(3, {4, 4});
     tt_xy_pair tensor_slice_shape = {4, 12};
-    auto const& worker_slice_offsets = ccl::InterleavedRingReduceScatterTensorSlicer::compute_worker_slice_offsets(
+    auto const& worker_slice_offsets = ccl::RingReduceScatterTensorSlicer::compute_worker_slice_offsets(
         worker_slice_shapes, tensor_slice_shape);
     ASSERT_EQ(worker_slice_offsets.at(0), tt_xy_pair(0, 0));
     ASSERT_EQ(worker_slice_offsets.at(1), tt_xy_pair(0, 4));
     ASSERT_EQ(worker_slice_offsets.at(2), tt_xy_pair(0, 8));
 }
 
-TEST(Ccl_InterleavedRingReduceScatterTensorSlicer, ComputeWorkerSliceOffsets_NMinus1WorkersWrapToNextRowMisaligned) {
+TEST(Ccl_RingReduceScatterTensorSlicer, ComputeWorkerSliceOffsets_NMinus1WorkersWrapToNextRowMisaligned) {
     auto worker_slice_shapes = std::vector<tt_xy_pair>(3, {4, 3});
     tt_xy_pair tensor_slice_shape = {3, 12};
-    auto const& worker_slice_offsets = ccl::InterleavedRingReduceScatterTensorSlicer::compute_worker_slice_offsets(
+    auto const& worker_slice_offsets = ccl::RingReduceScatterTensorSlicer::compute_worker_slice_offsets(
         worker_slice_shapes, tensor_slice_shape);
     ASSERT_EQ(worker_slice_offsets.at(0), tt_xy_pair(0, 0));
     ASSERT_EQ(worker_slice_offsets.at(1), tt_xy_pair(0, 3));

--- a/tests/tt_eager/python_api_testing/unit_testing/misc/test_reduce_scatter_nightly.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/misc/test_reduce_scatter_nightly.py
@@ -1,0 +1,186 @@
+# SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+
+# SPDX-License-Identifier: Apache-2.0
+
+import torch
+import pytest
+from loguru import logger
+import tt_lib as ttl
+from tests.tt_eager.python_api_testing.sweep_tests.comparison_funcs import comp_equal, comp_pcc
+from models.utility_functions import skip_for_grayskull, get_devices_for_t3000
+import itertools
+
+
+def is_unsupported_case(input_shape, scatter_dim, math_op, mem_config, num_devices, num_links, input_dtype, layout):
+    if scatter_dim != 3:
+        return True, "Only support for scatter_dim=3 is tested so far"
+
+    elem_size = 2 if input_dtype == ttl.tensor.DataType.BFLOAT16 else 1
+    tensor_size_bytes = elem_size
+    for i in input_shape:
+        tensor_size_bytes *= i
+    num_l1_banks = 64
+    if mem_config.buffer_type == ttl.tensor.BufferType.L1 and tensor_size_bytes > num_l1_banks * 50 * 1024:
+        return True, "L1 buffer can't support large tensor sizes"
+
+    # if input_dtype == ttl.tensor.DataType.BFLOAT8_B and tuple(input_shape) == (1, 1, 2048, 1024) and scatter_dim == 3:
+    #     return True, "Known failure with bfp8_b data format"
+
+    return False, ""
+
+
+def run_reduce_scatter_test(
+    all_devices,
+    num_devices,
+    per_chip_output_shape,
+    scatter_dim,
+    num_links,
+    math_op,
+    input_dtype,
+    layout,
+    mem_config,
+    use_program_cache,
+    function_level_defaults,
+    num_iters=1,
+):
+    if len(all_devices) != 8:
+        pytest.skip("Not T3000!")
+
+    debug = False
+
+    (is_known_failure, message) = is_unsupported_case(
+        per_chip_output_shape, scatter_dim, math_op, mem_config, num_devices, num_links, input_dtype, layout
+    )
+    if is_known_failure:
+        pytest.skip(f"Skipping unsupported case {message}.")
+    devices = get_devices_for_t3000(all_devices, num_devices)
+
+    # Generate input tensors
+    canonical_input_shape = per_chip_output_shape.copy()
+    canonical_input_shape[scatter_dim] *= num_devices
+    tt_input_tensors = []
+
+    numel = canonical_input_shape[0] * canonical_input_shape[1] * canonical_input_shape[2] * canonical_input_shape[3]
+    input_tensors = [
+        # torch.rand(canonical_input_shape).bfloat16() if not debug else torch.arange(numel).reshape(canonical_input_shape).bfloat16()
+        torch.rand(canonical_input_shape).bfloat16() if not debug else torch.ones(canonical_input_shape).bfloat16()
+        for _ in range(num_devices)
+    ]
+    if debug:
+        input_tensors[-1] = torch.arange(numel).reshape(canonical_input_shape).bfloat16()
+    for i, canonical_input_tensor in enumerate(input_tensors):
+        tt_input_tensors.append(
+            ttl.tensor.Tensor(canonical_input_tensor, input_dtype).to(layout).to(devices[i], mem_config)
+        )
+
+    # Run the op
+    # for i in range(num_iters):
+    tt_out_tensors = ttl.tensor.reduce_scatter(
+        tt_input_tensors,
+        scatter_split_dim=scatter_dim,
+        reduce_op=math_op,
+        num_links=num_links,
+        output_mem_config=mem_config,
+    )
+
+    for d in devices:
+        ttl.device.Synchronize(d)
+    logger.info(f"Done iteration {i}")
+
+    # Compute golden
+    # TODO: Make it model how reduce scatter actually works for numerical correctness/ordering
+    golden_canonical_out_tensor = torch.zeros(canonical_input_shape).bfloat16()
+    for i, t in enumerate(input_tensors):
+        golden_canonical_out_tensor = torch.add(golden_canonical_out_tensor, t).bfloat16()
+
+    golden_output_tensors = torch.chunk(golden_canonical_out_tensor, num_devices, scatter_dim)
+
+    logger.info(f"Compare")
+    # Compare
+    assert len(golden_output_tensors) == len(tt_out_tensors)
+    mismatch = False
+    for i, t in enumerate(tt_out_tensors):
+        tt_output_tensor = t.cpu().to(ttl.tensor.Layout.ROW_MAJOR).to_torch()
+        eq, output = comp_pcc(tt_output_tensor, golden_output_tensors[i])
+        mismatch = mismatch or not eq
+        if not eq:
+            logger.error(f"output mismatch for tensor {i}")
+        else:
+            logger.info(f"output match for tensor {i}")
+        assert not mismatch, f"{i} FAILED: {output}"
+
+
+@pytest.mark.timeout(120)
+@pytest.mark.parametrize(
+    "num_devices, num_links",
+    [
+        (4, 1),
+        (8, 1),
+    ],
+)
+@pytest.mark.parametrize(
+    "per_chip_output_shape, scatter_dim, layout",
+    [
+        ([1, 8, 1024, 1024], 3, ttl.tensor.Layout.TILE),
+        ([1, 4, 1024, 1024], 3, ttl.tensor.Layout.TILE),
+        ([1, 4, 2048, 1024], 3, ttl.tensor.Layout.TILE),
+        ([1, 1, 32, 32], 3, ttl.tensor.Layout.TILE),
+        ([1, 1, 32, 64], 3, ttl.tensor.Layout.TILE),
+        ([1, 1, 64, 64], 3, ttl.tensor.Layout.TILE),
+        ([1, 1, 32, 128], 3, ttl.tensor.Layout.TILE),
+        ([1, 1, 32, 256], 3, ttl.tensor.Layout.TILE),
+        ([1, 1, 32, 512], 3, ttl.tensor.Layout.TILE),
+        ([1, 1, 32, 1024], 3, ttl.tensor.Layout.TILE),
+        ([1, 1, 32, 2048], 3, ttl.tensor.Layout.TILE),
+        ([1, 1, 128, 1024], 3, ttl.tensor.Layout.TILE),
+        # Has worker slice size warning - defaults to 1x1
+        ([1, 1, 128, 8192], 3, ttl.tensor.Layout.TILE),
+        # Always fails with bfp8_b
+        ([1, 1, 2048, 1024], 3, ttl.tensor.Layout.TILE),
+        # Has worker slice size warning - defaults to 1x1
+        ([1, 1, 2048, 8192], 3, ttl.tensor.Layout.TILE),
+    ],
+)
+@pytest.mark.parametrize(
+    "input_dtype",
+    [
+        ttl.tensor.DataType.BFLOAT16,
+        ttl.tensor.DataType.BFLOAT8_B,
+    ],
+)
+@pytest.mark.parametrize(
+    "mem_config",
+    [
+        ttl.tensor.MemoryConfig(buffer_type=ttl.tensor.BufferType.DRAM),
+        ttl.tensor.MemoryConfig(buffer_type=ttl.tensor.BufferType.L1),
+    ],
+)
+@pytest.mark.parametrize("math_op", [ttl.tensor.ReduceOpMath.SUM])
+def test_reduce_scatter_nightly(
+    all_devices,
+    num_devices,
+    per_chip_output_shape,
+    scatter_dim,
+    num_links,
+    math_op,
+    input_dtype,
+    layout,
+    mem_config,
+    use_program_cache,
+    function_level_defaults,
+    num_iters=1,
+):
+    run_reduce_scatter_test(
+        all_devices,
+        num_devices,
+        per_chip_output_shape,
+        scatter_dim,
+        num_links,
+        math_op,
+        input_dtype,
+        layout,
+        mem_config,
+        use_program_cache,
+        function_level_defaults,
+        num_iters,
+    )

--- a/tests/tt_eager/python_api_testing/unit_testing/misc/test_reduce_scatter_post_commit.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/misc/test_reduce_scatter_post_commit.py
@@ -15,6 +15,17 @@ def is_unsupported_case(input_shape, scatter_dim, math_op, mem_config, num_devic
     if scatter_dim != 3:
         return True, "Only support for scatter_dim=3 is tested so far"
 
+    elem_size = 2 if input_dtype == ttl.tensor.DataType.BFLOAT16 else 1
+    tensor_size_bytes = elem_size
+    for i in input_shape:
+        tensor_size_bytes *= i
+    num_l1_banks = 64
+    if mem_config.buffer_type == ttl.tensor.BufferType.L1 and tensor_size_bytes > num_l1_banks * 50 * 1024:
+        return True, "L1 buffer can't support large tensor sizes"
+
+    # if input_dtype == ttl.tensor.DataType.BFLOAT8_B and tuple(input_shape) == (1, 1, 2048, 1024) and scatter_dim == 3:
+    #     return True, "Known failure with bfp8_b data format"
+
     return False, ""
 
 
@@ -35,18 +46,7 @@ def run_reduce_scatter_test(
     if len(all_devices) != 8:
         pytest.skip("Not T3000!")
 
-    # if num_devices != 4:
-    #     pytest.skip("Only testing for 4 devices")
-
     debug = False
-    logger.info(f"num_devices: {num_devices}")
-    logger.info(f"per_chip_output_shape: {per_chip_output_shape}")
-    logger.info(f"scatter_dim: {scatter_dim}")
-    logger.info(f"num_links: {num_links}")
-    logger.info(f"math_op: {math_op}")
-    logger.info(f"input_dtype: {input_dtype}")
-    logger.info(f"layout: {layout}")
-    logger.info(f"mem_config: {mem_config}")
 
     (is_known_failure, message) = is_unsupported_case(
         per_chip_output_shape, scatter_dim, math_op, mem_config, num_devices, num_links, input_dtype, layout
@@ -58,8 +58,6 @@ def run_reduce_scatter_test(
     # Generate input tensors
     canonical_input_shape = per_chip_output_shape.copy()
     canonical_input_shape[scatter_dim] *= num_devices
-    logger.info(f"per_chip_output_shape: {per_chip_output_shape}")
-    logger.info(f"canonical_input_tensor_shape: {canonical_input_shape}")
     tt_input_tensors = []
 
     numel = canonical_input_shape[0] * canonical_input_shape[1] * canonical_input_shape[2] * canonical_input_shape[3]
@@ -71,8 +69,6 @@ def run_reduce_scatter_test(
     if debug:
         input_tensors[-1] = torch.arange(numel).reshape(canonical_input_shape).bfloat16()
     for i, canonical_input_tensor in enumerate(input_tensors):
-        logger.info(f"input_tensor[{i}].shape: {canonical_input_tensor.data.shape}")
-        logger.info(f"input_tensor[{i}]: {canonical_input_tensor.data}")
         tt_input_tensors.append(
             ttl.tensor.Tensor(canonical_input_tensor, input_dtype).to(layout).to(devices[i], mem_config)
         )
@@ -94,14 +90,9 @@ def run_reduce_scatter_test(
     # Compute golden
     # TODO: Make it model how reduce scatter actually works for numerical correctness/ordering
     golden_canonical_out_tensor = torch.zeros(canonical_input_shape).bfloat16()
-    logger.info(f"golden_canonical_out_tensor shape: {golden_canonical_out_tensor.shape}")
-    logger.info(f"canonical_input_shape: {canonical_input_shape}")
     for i, t in enumerate(input_tensors):
-        logger.info(f"t shape: {t.shape}")
         golden_canonical_out_tensor = torch.add(golden_canonical_out_tensor, t).bfloat16()
-        logger.info(f"golden_canonical_out_tensor[{i}]: {golden_canonical_out_tensor.data}")
 
-    logger.info(f"golden_canonical_out_tensor: {golden_canonical_out_tensor.data}")
     golden_output_tensors = torch.chunk(golden_canonical_out_tensor, num_devices, scatter_dim)
 
     logger.info(f"Compare")
@@ -110,8 +101,6 @@ def run_reduce_scatter_test(
     mismatch = False
     for i, t in enumerate(tt_out_tensors):
         tt_output_tensor = t.cpu().to(ttl.tensor.Layout.ROW_MAJOR).to_torch()
-        logger.info(f"golden_output_tensors[i].shape: {golden_output_tensors[i].shape}")
-        logger.info(f"tt_output_tensor.shape: {tt_output_tensor.shape}")
         eq, output = comp_pcc(tt_output_tensor, golden_output_tensors[i])
         mismatch = mismatch or not eq
         if not eq:
@@ -121,31 +110,22 @@ def run_reduce_scatter_test(
         assert not mismatch, f"{i} FAILED: {output}"
 
 
-@pytest.mark.timeout(30)
+# ~2:45 extra time in the current state
+@pytest.mark.timeout(120)
 @pytest.mark.parametrize(
     "num_devices, num_links",
     [
-        (4, 1),
+        # (4, 1),
         (8, 1),
     ],
 )
 @pytest.mark.parametrize(
     "per_chip_output_shape, scatter_dim, layout",
     [
-        ([1, 1, 32, 32], 3, ttl.tensor.Layout.TILE),
-        ([1, 1, 32, 64], 3, ttl.tensor.Layout.TILE),
-        ([1, 1, 64, 64], 3, ttl.tensor.Layout.TILE),
-        ([1, 1, 32, 128], 3, ttl.tensor.Layout.TILE),
-        ([1, 1, 32, 256], 3, ttl.tensor.Layout.TILE),
-        # Hangs... for whatever reason. Seems like a noc sem inc from sender -> EDM gets lost
-        #          somehow at some point
-        # ([1, 1, 32, 512], 3, ttl.tensor.Layout.TILE),
-        ([1, 1, 32, 1024], 3, ttl.tensor.Layout.TILE),
-        ([1, 1, 32, 2048], 3, ttl.tensor.Layout.TILE),
-        ([1, 1, 128, 1024], 3, ttl.tensor.Layout.TILE),
+        ([1, 8, 1024, 1024], 3, ttl.tensor.Layout.TILE),
+        ([1, 4, 2048, 1024], 3, ttl.tensor.Layout.TILE),
+        # # # Has worker slice size warning - defaults to 1x1
         ([1, 1, 128, 8192], 3, ttl.tensor.Layout.TILE),
-        ([1, 1, 2048, 1024], 3, ttl.tensor.Layout.TILE),
-        ([1, 1, 2048, 8192], 3, ttl.tensor.Layout.TILE),
     ],
 )
 @pytest.mark.parametrize(

--- a/tt_eager/tt_dnn/op_library/ccl/ccl_common.cpp
+++ b/tt_eager/tt_dnn/op_library/ccl/ccl_common.cpp
@@ -140,6 +140,374 @@ ccl::EriscDatamoverBuilder create_erisc_datamover_builder(
         termination_mode);
 }
 
+RingReduceScatterTensorSlicer::RingReduceScatterTensorSlicer(
+    Tensor const& input_tensor,
+    Tensor const& output_tensor,
+    int slice_dim,
+    uint32_t ring_index,
+    uint32_t ring_size,
+    uint32_t total_num_workers,
+    uint32_t max_slice_size_in_bytes,
+    uint32_t half_cb_n_pages) :
+    LegacyCclTensorSlicer() {
+    TT_ASSERT(max_slice_size_in_bytes > 0);
+    this->row_major = input_tensor.get_layout() == Layout::ROW_MAJOR;
+    this->slice_dim_is_width = input_tensor.get_legacy_shape().rank() - 1 == slice_dim;
+    this->is_sharded = input_tensor.is_sharded();
+
+    int32_t shard_size_in_bytes =
+        is_sharded ? (input_tensor.buffer()->page_size() * input_tensor.buffer()->shard_spec().tensor2d_shape[0] *
+                        input_tensor.buffer()->shard_spec().tensor2d_shape[1]) /
+                            input_tensor.shard_spec()->num_cores()
+                    : -1;
+    this->input_page_size = is_sharded ? shard_size_in_bytes : input_tensor.buffer()->page_size();
+    if (row_major) {
+        this->num_cols = input_tensor.get_legacy_shape()[-1];
+        auto input_shape = input_tensor.get_legacy_shape();
+        auto output_shape = output_tensor.get_legacy_shape();
+        this->num_rows =
+            std::accumulate(input_shape.begin() + slice_dim, input_shape.end() - 1, 1, std::multiplies<uint32_t>());
+        this->row_offset =
+            std::accumulate(
+                output_shape.begin() + slice_dim, output_shape.end() - 1, 1, std::multiplies<uint32_t>()) -
+            num_rows;
+    } else {
+        const uint32_t num_tiles_x = input_tensor.get_legacy_shape()[-1] / tt::constants::TILE_WIDTH;
+        uint32_t num_tiles_y = (input_tensor.get_legacy_shape()[-2] / tt::constants::TILE_HEIGHT);
+        for (std::size_t i = 0; input_tensor.get_legacy_shape().rank() > 2 && i < input_tensor.get_legacy_shape().rank() - 2; i++) {
+            num_tiles_y *= input_tensor.get_legacy_shape()[i];
+        }
+        TT_ASSERT(num_tiles_x >= ring_size);
+        this->tensor_slice_shape.x = slice_dim == 3 ? (num_tiles_x / ring_size) : num_tiles_x;
+        this->tensor_slice_shape.y = slice_dim != 3 ? num_tiles_y / ring_size : num_tiles_y;
+    }
+
+    // Create the worker schedule
+
+    // The `output_page_offset` will be the starting page offset for this slice index (corresponds to )
+    // ring index). Each worker will operate out of that slice and then advance to the next slice for
+    // for the next ring index/timestep
+    uint32_t slice_size_in_bytes = std::numeric_limits<uint32_t>::max();
+    if (row_major) {
+        if (slice_dim_is_width) {
+            TT_FATAL(false, "Reduce scatter row-major interleaved does not yet support a width dim");
+            this->output_addr_offset = input_page_size;
+        } else {
+            this->output_page_offset = num_rows;
+        }
+        this->worker_slice_shapes = create_worker_slice_shapes_for_row_major_layout(
+            this->tensor_slice_shape, total_num_workers, max_slice_size_in_bytes);
+    } else {
+        log_trace(tt::LogOp, "\tmax_slice_size_in_bytes={}", max_slice_size_in_bytes);
+        log_trace(tt::LogOp, "\tinput_page_size={}", input_page_size);
+        this->worker_slice_shapes = create_worker_slice_shapes_for_tile_layout(
+            input_tensor.get_legacy_shape(),
+            this->tensor_slice_shape,
+            total_num_workers,
+            max_slice_size_in_bytes / input_page_size,
+            half_cb_n_pages);
+    }
+
+    if (row_major) {
+        this->flattened_tensor_shape = tt_xy_pair{
+            input_tensor.get_legacy_shape()[3],
+            input_tensor.get_legacy_shape()[0] * input_tensor.get_legacy_shape()[1] *
+                input_tensor.get_legacy_shape()[2]};
+    } else {
+        this->flattened_tensor_shape = tt_xy_pair{
+            input_tensor.get_legacy_shape()[3] / constants::TILE_WIDTH,
+            (input_tensor.get_legacy_shape()[0] * input_tensor.get_legacy_shape()[1] *
+                input_tensor.get_legacy_shape()[2]) /
+                constants::TILE_HEIGHT};
+    }
+    this->worker_slice_offsets = compute_worker_slice_offsets(this->worker_slice_shapes, this->tensor_slice_shape);
+    TT_ASSERT(this->worker_slice_offsets.size() == this->worker_slice_shapes.size());
+}
+
+std::vector<tt_xy_pair> RingReduceScatterTensorSlicer::compute_worker_slice_offsets(
+    std::vector<tt_xy_pair> const& worker_slice_shapes, tt_xy_pair const& tensor_slice_shape) {
+    std::vector<tt_xy_pair> worker_slice_offsets;
+    worker_slice_offsets.reserve(worker_slice_shapes.size());
+
+    std::size_t offset_x = 0;
+    std::size_t offset_y = 0;
+    std::size_t last_worker_size_y = worker_slice_shapes.at(0).y;  // for validation
+    bool first_in_row = true;
+    for (tt_xy_pair const& worker_slice_shape : worker_slice_shapes) {
+        worker_slice_offsets.emplace_back(offset_x, offset_y);
+
+        TT_ASSERT(offset_y < tensor_slice_shape.y);
+        offset_x += worker_slice_shape.x;
+        if (offset_x < tensor_slice_shape.x) {
+            first_in_row = false;
+        } else {
+            offset_x = 0;
+            first_in_row = true;
+            offset_y += worker_slice_shape.y;
+        }
+        TT_ASSERT(first_in_row || last_worker_size_y == worker_slice_shape.y);
+        last_worker_size_y = worker_slice_shape.y;
+    }
+
+    TT_ASSERT(worker_slice_offsets.size() == worker_slice_shapes.size());
+    return worker_slice_offsets;
+}
+
+std::vector<tt_xy_pair> RingReduceScatterTensorSlicer::create_worker_slice_shapes_for_row_major_layout(
+    tt_xy_pair const& tensor_slice_shape_in_elems, uint32_t num_workers, uint32_t max_slice_size_in_elements) {
+    std::vector<tt_xy_pair> worker_slice_shapes;
+    worker_slice_shapes.reserve(num_workers);
+
+    if (num_workers > tensor_slice_shape_in_elems.y) {
+        log_warning(
+            tt::LogOp,
+            "Reduce Scatter more workers instantiated than is work to be done. Some workers will be idle and do "
+            "nothing");
+        num_workers = tensor_slice_shape_in_elems.y;
+        for (uint32_t w = 0; w < num_workers; ++w) {
+            worker_slice_shapes.emplace_back(tensor_slice_shape_in_elems.x, 1);
+        }
+        for (uint32_t w = num_workers; w < tensor_slice_shape_in_elems.x; ++w) {
+            worker_slice_shapes.emplace_back(0, 0);
+        }
+        return worker_slice_shapes;
+    }
+
+    uint32_t num_elems_accounted_for = 0;
+    // For now we don't support row splitting but we will in the future
+    const uint32_t min_rows_per_worker = tensor_slice_shape_in_elems.y / num_workers;
+    const uint32_t num_workers_with_max_rows = tensor_slice_shape_in_elems.y % num_workers;
+    const uint32_t max_rows_per_worker =
+        num_workers_with_max_rows != 0 ? min_rows_per_worker + 1 : min_rows_per_worker;
+    for (uint32_t w = 0; w < num_workers_with_max_rows; w++) {
+        worker_slice_shapes.emplace_back(tensor_slice_shape_in_elems.x, max_rows_per_worker);
+        num_elems_accounted_for += tensor_slice_shape_in_elems.x * max_rows_per_worker;
+    }
+    for (uint32_t w = num_workers_with_max_rows; w < num_workers; w++) {
+        worker_slice_shapes.emplace_back(tensor_slice_shape_in_elems.x, min_rows_per_worker);
+        num_elems_accounted_for += tensor_slice_shape_in_elems.x * min_rows_per_worker;
+    }
+
+    TT_ASSERT(num_elems_accounted_for == tensor_slice_shape_in_elems.x * tensor_slice_shape_in_elems.y);
+    for (auto& worker_slice_shape : worker_slice_shapes) {
+        TT_ASSERT(max_slice_size_in_elements >= worker_slice_shape.x * worker_slice_shape.y);
+        TT_ASSERT(worker_slice_shape.x * worker_slice_shape.y > 0);
+    }
+    return worker_slice_shapes;
+}
+
+std::vector<tt_xy_pair> RingReduceScatterTensorSlicer::create_worker_slice_shapes_for_tile_layout(
+        Shape const& tensor_shape,
+        tt_xy_pair const& tensor_slice_shape_in_tiles,
+        uint32_t num_workers,
+        uint32_t max_slice_size_in_pages,
+        uint32_t half_cb_n_pages)
+{
+    log_trace(tt::LogOp, "\tmax_slice_size_in_pages={}", max_slice_size_in_pages);
+    TT_ASSERT(max_slice_size_in_pages > 0);
+    std::vector<tt_xy_pair> worker_slice_shapes;
+    worker_slice_shapes.reserve(num_workers);
+    const uint32_t total_num_tiles = tensor_slice_shape_in_tiles.x * tensor_slice_shape_in_tiles.y;
+    if (num_workers > total_num_tiles) {
+        log_warning(
+            tt::LogOp,
+            "Reduce Scatter more workers instantiated than is work to be done. Some workers will be idle and do "
+            "nothing");
+        num_workers = total_num_tiles;
+        for (uint32_t w = 0; w < num_workers; ++w) {
+            worker_slice_shapes.emplace_back(1, 1);
+        }
+        for (uint32_t w = num_workers; w < total_num_tiles; ++w) {
+            worker_slice_shapes.emplace_back(0, 0);
+        }
+        return worker_slice_shapes;
+    }
+
+    std::size_t max_slice_size_in_tiles = max_slice_size_in_pages;
+    // Add padding for filler pages
+
+
+
+    TT_ASSERT(max_slice_size_in_tiles > 0);
+    std::size_t max_width_in_tiles = std::min<std::size_t>(max_slice_size_in_tiles, tensor_slice_shape_in_tiles.x);
+    std::size_t max_height_in_tiles = std::min<std::size_t>(max_slice_size_in_tiles, tensor_slice_shape_in_tiles.y);
+
+    uint32_t num_tiles_accounted_for = 0;  // for validation
+    if (tensor_slice_shape_in_tiles.y >= num_workers) {
+        // slice into rows
+        const uint32_t min_rows_per_worker = tensor_slice_shape_in_tiles.y / num_workers;
+        const uint32_t num_workers_with_max_rows = tensor_slice_shape_in_tiles.y % num_workers;
+        const uint32_t max_rows_per_worker =
+            num_workers_with_max_rows != 0 ? min_rows_per_worker + 1 : min_rows_per_worker;
+        for (uint32_t w = 0; w < num_workers_with_max_rows; w++) {
+            worker_slice_shapes.emplace_back(tensor_slice_shape_in_tiles.x, max_rows_per_worker);
+            num_tiles_accounted_for += tensor_slice_shape_in_tiles.x * max_rows_per_worker;
+        }
+        for (uint32_t w = num_workers_with_max_rows; w < num_workers; w++) {
+            worker_slice_shapes.emplace_back(tensor_slice_shape_in_tiles.x, min_rows_per_worker);
+            num_tiles_accounted_for += tensor_slice_shape_in_tiles.x * min_rows_per_worker;
+        }
+    } else if (tensor_slice_shape_in_tiles.x >= num_workers) {
+        // slice into columns
+        const uint32_t min_cols_per_worker = tensor_slice_shape_in_tiles.x / num_workers;
+        const uint32_t num_workers_with_max_cols = tensor_slice_shape_in_tiles.x % num_workers;
+        const uint32_t max_cols_per_worker =
+            num_workers_with_max_cols != 0 ? min_cols_per_worker + 1 : min_cols_per_worker;
+        for (uint32_t w = 0; w < num_workers_with_max_cols; w++) {
+            worker_slice_shapes.emplace_back(max_cols_per_worker, tensor_slice_shape_in_tiles.y);
+            num_tiles_accounted_for += max_cols_per_worker * tensor_slice_shape_in_tiles.y;
+        }
+        for (uint32_t w = num_workers_with_max_cols; w < num_workers; w++) {
+            worker_slice_shapes.emplace_back(min_cols_per_worker, tensor_slice_shape_in_tiles.y);
+            num_tiles_accounted_for += min_cols_per_worker * tensor_slice_shape_in_tiles.y;
+        }
+
+    } else {
+        const uint32_t min_num_workers_per_row = num_workers / tensor_slice_shape_in_tiles.y;
+        const uint32_t num_rows_with_max_workers = tensor_slice_shape_in_tiles.y % num_workers;
+        const uint32_t max_num_workers_per_row =
+            num_rows_with_max_workers != 0 ? min_num_workers_per_row + 1 : min_num_workers_per_row;
+
+        // 4 "quadrants" to the worker slicing:
+        // 1. Row with max num workers and max columns wide per worker (first part of rows with max num workers)
+        // 2. Row with max num workers and min columns wide per worker (second part of rows with max num workers)
+        // 3. Row with min num workers and max columns wide per worker (first part of rows with min num workers)
+        // 4. Row with min num workers and min columns wide per worker (second part of rows with min num workers)
+        // Depending on specific numbers, some of the above "quadrants" might be 0 sized
+        const uint32_t max_workers_row_min_cols_per_worker =
+            tensor_slice_shape_in_tiles.x / max_num_workers_per_row;
+        const uint32_t max_workers_row_max_col_worker_count =
+            tensor_slice_shape_in_tiles.x % max_num_workers_per_row;
+        const uint32_t max_workers_row_max_cols_per_worker = max_workers_row_max_col_worker_count != 0
+                                                                    ? max_workers_row_min_cols_per_worker + 1
+                                                                    : max_workers_row_min_cols_per_worker;
+        TT_ASSERT(max_workers_row_min_cols_per_worker > 0);
+        TT_ASSERT(max_workers_row_max_cols_per_worker >= max_workers_row_min_cols_per_worker);
+        for (uint32_t w_r = 0; w_r < num_rows_with_max_workers; w_r++) {
+            for (uint32_t w_c = 0; w_c < max_workers_row_max_cols_per_worker; w_c++) {
+                worker_slice_shapes.emplace_back(max_workers_row_max_cols_per_worker, 1);
+                num_tiles_accounted_for += max_workers_row_max_cols_per_worker;
+            }
+            for (uint32_t w_c = max_workers_row_max_col_worker_count; w_c < max_num_workers_per_row; w_c++) {
+                worker_slice_shapes.emplace_back(max_workers_row_min_cols_per_worker, 1);
+                num_tiles_accounted_for += max_workers_row_min_cols_per_worker;
+            }
+        }
+
+        const uint32_t min_workers_row_min_cols_per_worker =
+            tensor_slice_shape_in_tiles.x / min_num_workers_per_row;
+        const uint32_t min_workers_row_max_col_worker_count =
+            tensor_slice_shape_in_tiles.x % min_num_workers_per_row;
+        const uint32_t min_workers_row_max_cols_per_worker = min_workers_row_max_col_worker_count != 0
+                                                                    ? min_workers_row_min_cols_per_worker + 1
+                                                                    : min_workers_row_min_cols_per_worker;
+
+        for (uint32_t w_r = num_rows_with_max_workers; w_r < tensor_slice_shape_in_tiles.y; w_r++) {
+            for (uint32_t w_c = 0; w_c < min_workers_row_max_cols_per_worker; w_c++) {
+                worker_slice_shapes.emplace_back(min_workers_row_max_cols_per_worker, 1);
+                num_tiles_accounted_for += min_workers_row_max_cols_per_worker;
+            }
+            for (uint32_t w_c = min_workers_row_max_col_worker_count; w_c < min_num_workers_per_row; w_c++) {
+                worker_slice_shapes.emplace_back(min_workers_row_min_cols_per_worker, 1);
+                num_tiles_accounted_for += min_workers_row_max_cols_per_worker;
+            }
+        }
+    }
+
+    // For now we do something a little naive - since this becomes an optimization problem otherwise, and the
+    // benefits to nailing it are marginal we expect uniform chunk sizes and just truncate the largest chunk to fit
+    // the max size and then apply that shape to all workers slice shapes
+    tt_xy_pair largest_worker_slice_shape = {0, 0};
+    for (auto const& worker_slice_shape : worker_slice_shapes) {
+        if (largest_worker_slice_shape.x * largest_worker_slice_shape.y <
+            worker_slice_shape.x * worker_slice_shape.y) {
+            largest_worker_slice_shape = worker_slice_shape;
+        }
+    }
+
+    // This is a bit of a hack for now until we support true 4D shapes in our slicer and our indexer (device side)
+    bool has_gt_1_depth_size = false;
+    for (std::size_t i = 0; tensor_shape.rank() > 2 && i < tensor_shape.rank() - 2; i++) {
+        has_gt_1_depth_size = has_gt_1_depth_size || tensor_shape[i] > 1;
+    }
+    if (has_gt_1_depth_size) {
+        largest_worker_slice_shape.y = 1;
+    }
+
+    bool do_truncation = ((largest_worker_slice_shape.x * largest_worker_slice_shape.y) > max_slice_size_in_tiles) || has_gt_1_depth_size;
+    if (do_truncation) {
+        log_trace(tt::LogOp, "Truncating worker slice shapes to fit max slice size in tiles");
+    }
+    log_trace(
+        tt::LogOp,
+        "largest_worker_slice_shape: x={}, y={}",
+        largest_worker_slice_shape.x,
+        largest_worker_slice_shape.y);
+    log_trace(tt::LogOp, "max_slice_size_in_tiles={}", max_slice_size_in_tiles);
+    auto get_padded_worker_slice_size_in_tiles = [](tt_xy_pair const& worker_slice_shape, uint32_t half_cb_n_pages) {
+        return round_up(worker_slice_shape.x * worker_slice_shape.y, half_cb_n_pages);
+    };
+
+    while (get_padded_worker_slice_size_in_tiles(largest_worker_slice_shape, half_cb_n_pages) > max_slice_size_in_tiles) {
+        log_trace(tt::LogOp, "Loop Head");
+        // truncate the largest dim first
+        uint32_t delta = (largest_worker_slice_shape.x * largest_worker_slice_shape.y) - max_slice_size_in_tiles;
+        log_trace(tt::LogOp, "-- delta: {}", delta);
+        uint32_t cols_removed_if_x_truncated = std::max<uint32_t>(1, largest_worker_slice_shape.x / delta);
+        uint32_t tiles_removed_if_x_truncated = cols_removed_if_x_truncated * largest_worker_slice_shape.y;
+        uint32_t rows_removed_if_y_truncated = std::max<uint32_t>(1, largest_worker_slice_shape.y / delta);
+        uint32_t tiles_removed_if_y_truncated = rows_removed_if_y_truncated * largest_worker_slice_shape.x;
+        uint32_t difference_x = tiles_removed_if_x_truncated > delta ? tiles_removed_if_x_truncated - delta
+                                                                        : delta - tiles_removed_if_x_truncated;
+        uint32_t difference_y = tiles_removed_if_y_truncated > delta ? tiles_removed_if_y_truncated - delta
+                                                                        : delta - tiles_removed_if_y_truncated;
+        log_trace(tt::LogOp, "-- cols_removed_if_x_truncated: {}", cols_removed_if_x_truncated);
+        log_trace(tt::LogOp, "-- tiles_removed_if_x_truncated: {}", tiles_removed_if_x_truncated);
+        log_trace(tt::LogOp, "-- rows_removed_if_y_truncated: {}", rows_removed_if_y_truncated);
+        log_trace(tt::LogOp, "-- tiles_removed_if_y_truncated: {}", tiles_removed_if_y_truncated);
+        log_trace(tt::LogOp, "-- difference_x: {}", difference_x);
+        log_trace(tt::LogOp, "-- difference_y: {}", difference_y);
+        if (difference_x < difference_y) {
+            largest_worker_slice_shape.x -= cols_removed_if_x_truncated;
+        } else {
+            largest_worker_slice_shape.y -= rows_removed_if_y_truncated;
+        }
+        log_trace(
+            tt::LogOp,
+            "-- new largest_worker_slice_shape: x={}, y={}",
+            largest_worker_slice_shape.x,
+            largest_worker_slice_shape.y);
+    }
+    if (do_truncation) {
+        log_trace(
+            tt::LogOp,
+            "Truncated worker slice shape to fit max slice size in tiles: ({},{})",
+            largest_worker_slice_shape.x,
+            largest_worker_slice_shape.y);
+        if (!(largest_worker_slice_shape.x * largest_worker_slice_shape.y > 0)) {
+            log_warning(tt::LogOp, "Computing worker slice shape for reduce scatter resulted in 0 sized slice. Defaulting to 1x1 page per worker, which is likely to lead to suboptimal performance");
+            largest_worker_slice_shape.x = 1;
+            largest_worker_slice_shape.y = 1;
+        }
+        TT_ASSERT(largest_worker_slice_shape.x * largest_worker_slice_shape.y > 0);
+        for (auto& worker_slice_shape : worker_slice_shapes) {
+            worker_slice_shape = largest_worker_slice_shape;
+        }
+    }
+
+    TT_ASSERT(
+        num_tiles_accounted_for == total_num_tiles, "All tiles must be accounted for in the worker slice shapes");
+    TT_ASSERT(worker_slice_shapes.size() == num_workers, "Worker slice shapes must match the number of workers");
+    std::for_each(
+        worker_slice_shapes.begin(),
+        worker_slice_shapes.end(),
+        [max_slice_size_in_pages](tt_xy_pair const& worker_slice_shape) {
+            TT_ASSERT(worker_slice_shape.x * worker_slice_shape.y <= max_slice_size_in_pages);
+        });
+    return worker_slice_shapes;
+}
+
+
 }  // namespace ccl
 }  // namespace tt_metal
 }  // namespace tt

--- a/tt_eager/tt_dnn/op_library/ccl/ccl_host_datastructures.hpp
+++ b/tt_eager/tt_dnn/op_library/ccl/ccl_host_datastructures.hpp
@@ -32,7 +32,7 @@ struct EriscDatamoverConfig {
 
     static uint32_t get_edm_handshake_address() { return usable_l1_base_address; }
     static uint32_t get_semaphores_base_address(std::size_t num_edm_channels) {
-        return usable_l1_base_address + handshake_location_size + edm_receiver_first_level_ack_source_word_size;
+        return usable_l1_base_address + (handshake_location_size * 3) + edm_receiver_first_level_ack_source_word_size;
     }
     static uint32_t get_buffers_base_address(std::size_t num_edm_channels) {
         uint32_t base_address = round_up(
@@ -231,6 +231,7 @@ class EriscDatamoverBuilder {
         log_trace(tt::LogOp, "\tis_sender: {}", active_channels.back().is_sender ? 1 : 0);
         log_trace(tt::LogOp, "\tbuffer_address: {}", local_buffer_addresses.at(channel));
         log_trace(tt::LogOp, "\tsemaphore_address: {}", local_semaphore_addresses.at(channel));
+        log_trace(tt::LogOp, "\tnum_workers: {}", worker_coords.size());
 
         return ChannelBufferInterface{channel, local_buffer_addresses.at(channel), local_semaphore_addresses.at(channel)};
     }
@@ -256,6 +257,7 @@ class EriscDatamoverBuilder {
         log_trace(tt::LogOp, "\tworker_semaphore_address: {}", active_channels.back().worker_semaphore_address);
         log_trace(tt::LogOp, "\tnum_eth_messages_to_forward: {}", active_channels.back().num_eth_messages_to_forward);
         log_trace(tt::LogOp, "\tchannel: {}", active_channels.back().channel);
+        log_trace(tt::LogOp, "\tnum_workers: {}", worker_coords.size());
         log_trace(tt::LogOp, "\tis_sender: {}", active_channels.back().is_sender ? 1 : 0);
         return ChannelBufferInterface{channel, local_buffer_addresses.at(channel), local_semaphore_addresses.at(channel)};
     }

--- a/tt_eager/tt_dnn/op_library/ccl/edm/erisc_datamover.cpp
+++ b/tt_eager/tt_dnn/op_library/ccl/edm/erisc_datamover.cpp
@@ -161,8 +161,10 @@ void kernel_main() {
             (volatile tt_l1_ptr uint32_t *const)sender_semaphores_base_address,
             (const WorkerXY *)workers_xy_list_addr,
             true);
-        if (sender_num_messages_to_send == 0) {
-            num_senders_with_no_work++;
+        if constexpr (terminate_on_worker_signal == EriscDataMoverTerminationMode::MESSAGE_COUNT_REACHED) {
+            if (sender_num_messages_to_send == 0) {
+                num_senders_with_no_work++;
+            }
         }
     }
 
@@ -192,8 +194,10 @@ void kernel_main() {
             (const WorkerXY *)workers_xy_list_addr,
             false);
 
-        if (receiver_num_messages_to_send == 0) {
-            num_receivers_with_no_work++;
+        if constexpr (terminate_on_worker_signal == EriscDataMoverTerminationMode::MESSAGE_COUNT_REACHED) {
+            if (receiver_num_messages_to_send == 0) {
+                num_receivers_with_no_work++;
+            }
         }
     }
 

--- a/tt_eager/tt_dnn/op_library/ccl/reduce_scatter/kernels/worker_interleaved_ring_reduce_scatter_reader.cpp
+++ b/tt_eager/tt_dnn/op_library/ccl/reduce_scatter/kernels/worker_interleaved_ring_reduce_scatter_reader.cpp
@@ -37,7 +37,9 @@ struct reduce_scatter_reader_common_args_t {
         input_tensor_shape(tt::tt_metal::ccl::coord_from_args(arg_idx)),
         tensor_slice_shape(tt::tt_metal::ccl::coord_from_args(arg_idx)),
         worker_slice_shape(tt::tt_metal::ccl::coord_from_args(arg_idx)),
-        worker_slice_offset(tt::tt_metal::ccl::coord_from_args(arg_idx)) {
+        worker_slice_offset(tt::tt_metal::ccl::coord_from_args(arg_idx)),
+        total_eltwise_kernel_num_pages(get_arg_val<uint32_t>(arg_idx++))
+         {
         ASSERT(full_chunk_num_pages > 0);
         ASSERT(page_size > 0);
         ASSERT(ring_size > 0);
@@ -65,6 +67,7 @@ struct reduce_scatter_reader_common_args_t {
     coord_t tensor_slice_shape;
     coord_t worker_slice_shape;
     coord_t worker_slice_offset;
+    uint32_t total_eltwise_kernel_num_pages;
 };
 #ifdef RM_INTERLEAVED
 constexpr bool rm_interleaved_addr_gen_mode = true;
@@ -150,14 +153,13 @@ advance_to_next_transfer_slice_result_t advance_to_next_transfer_slice(
     uint32_t const ring_size,
     uint32_t const curr_ring_idx,
     uint32_t const slice_base_page_offset,
-    uint32_t const bank_base_address,
     coord_t const& input_tensor_shape,
     coord_t const& tensor_slice_shape,
     bool const is_clockwise_direction) {
-    bool const sliced_on_width = tensor_slice_shape.x < input_tensor_shape.x;
+    bool const sliced_only_on_width = tensor_slice_shape.x < input_tensor_shape.x && tensor_slice_shape.y == input_tensor_shape.y;
     uint32_t single_ring_idx_stride =
-        sliced_on_width ? tensor_slice_shape.x : tensor_slice_shape.y * input_tensor_shape.x;
-    uint32_t n_minus_one_ring_indices_stride = sliced_on_width
+        sliced_only_on_width ? tensor_slice_shape.x : tensor_slice_shape.y * input_tensor_shape.x;
+    uint32_t n_minus_one_ring_indices_stride = sliced_only_on_width
                                                    ? tensor_slice_shape.x * (ring_size - 1)
                                                    : tensor_slice_shape.y * input_tensor_shape.x * (ring_size - 1);
 
@@ -203,7 +205,6 @@ void kernel_main() {
     constexpr uint32_t cb_id_in1 = tt::CB::c_in1;
     const DataFormat in0_df = get_dataformat(cb_id_in0);
     auto args = reduce_scatter_reader_unique_args_t<is_sharded, src_is_dram>(arg_idx, in0_df);
-    uint32_t total_eltwise_kernel_num_pages = get_arg_val<uint32_t>(arg_idx++);
 
     ASSERT(args.half_cb_n_pages >= args.full_chunk_num_pages);
 
@@ -223,11 +224,20 @@ void kernel_main() {
     // of the output data movement kernel - short-circuiting past the (reducer) math kernel
     // For tile => shape in tiles
     // For RM => shape in elements
+    uint32_t start_ring_index = args.my_ring_idx;
     while (args.worker_slice_offset.x < args.tensor_slice_shape.x &&
            args.worker_slice_offset.y < args.tensor_slice_shape.y) {
+        // Need to reset back to the start ring index because the last iteration of the tranfers read chunks
+        // loop won't increment after the last iteration since the increment is within the loop body
+        args.my_ring_idx = start_ring_index;
         uint32_t curr_ring_slice_start_page_offset =
-            width_sliced ? args.tensor_slice_shape.x * args.my_ring_idx
-                         : args.tensor_slice_shape.y * args.my_ring_idx * args.input_tensor_shape.x;
+            width_sliced ? args.tensor_slice_shape.x * start_ring_index
+                         : args.tensor_slice_shape.y * start_ring_index * args.input_tensor_shape.x;
+
+        auto const& next_slice_offset = advance_slice_row_major(
+            args.worker_slice_offset, args.worker_slice_shape, args.tensor_slice_shape, args.num_concurrent_workers);
+        bool last_slice_of_worker = next_slice_offset.x >= args.tensor_slice_shape.x ||
+                                    next_slice_offset.y >= args.tensor_slice_shape.y;
 
         const uint32_t worker_relative_start_offset_into_slice =
             args.worker_slice_offset.x + (args.worker_slice_offset.y * args.input_tensor_shape.x);
@@ -242,7 +252,7 @@ void kernel_main() {
         uint32_t const worker_slice_n_pages = valid_worker_slice_shape.x * valid_worker_slice_shape.y;
         ASSERT(
             (args.num_transfers - 1) * worker_slice_n_pages + total_cb_pages_pushed_to_math <=
-            total_eltwise_kernel_num_pages);
+            args.total_eltwise_kernel_num_pages);
         {
             coord_t offset_into_worker_slice = {0, 0};
             for (uint32_t p = 0; p < worker_slice_n_pages; p += args.full_chunk_num_pages) {
@@ -261,21 +271,22 @@ void kernel_main() {
                     last_page_of_worker);
                 total_cb_pages_pushed += n_pages;
                 if (n_pages < args.half_cb_n_pages) {
-                    push_filler_pages_to_cb(to_dm_sender_short_circuit_cb, args.half_cb_n_pages - n_pages);
+                    uint32_t num_filler_pages = args.half_cb_n_pages - n_pages;
+                    push_filler_pages_to_cb(to_dm_sender_short_circuit_cb, num_filler_pages);
                     ASSERT(args.half_cb_n_pages > n_pages);
                     ASSERT(p + n_pages == worker_slice_n_pages);
-                    total_cb_pages_pushed += (args.half_cb_n_pages - n_pages);
+                    total_cb_pages_pushed += num_filler_pages;
                 }
             }
         }
 
         for (uint32_t i = 1; i < args.num_transfers; ++i) {
+            bool last_transfer = i == args.num_transfers - 1;
             coord_t offset_into_worker_slice = {0, 0};
             std::tie(args.my_ring_idx, curr_ring_slice_start_page_offset) = advance_to_next_transfer_slice<is_sharded>(
                 args.ring_size,
                 args.my_ring_idx,
                 curr_ring_slice_start_page_offset,
-                args.s.bank_base_address,
                 args.input_tensor_shape,
                 args.tensor_slice_shape,
                 args.is_clockwise_direction);
@@ -306,9 +317,13 @@ void kernel_main() {
                 fetch_chunk(cb_id_in0, n_pages, args.page_size, eth_receiver_l1_base_noc_addr);
                 total_cb_pages_pushed_to_math += n_pages;
                 total_cb_pages_pushed += n_pages;
-                noc_semaphore_inc(
-                    eth_receiver_l1_semaphore_noc_addr,
-                    tt::tt_metal::ccl::EriscDataMoverWorkerSignal::NEXT_MESSAGE_AVAILABLE);
+
+                bool last_worker_message_to_edm = last_transfer && last_slice_of_worker && (p + n_pages >= worker_slice_n_pages);
+                if (!last_worker_message_to_edm) {
+                    noc_semaphore_inc(
+                        eth_receiver_l1_semaphore_noc_addr,
+                        tt::tt_metal::ccl::EriscDataMoverWorkerSignal::NEXT_MESSAGE_AVAILABLE);
+                }
                 if (n_pages < args.half_cb_n_pages) {
                     uint32_t num_filler_pages = args.half_cb_n_pages - n_pages;
                     push_filler_pages_to_cb(cb_id_in0, num_filler_pages);
@@ -320,27 +335,22 @@ void kernel_main() {
             ASSERT(last_page_of_worker);
         }
 
-        args.worker_slice_offset = advance_slice_row_major(
-            args.worker_slice_offset, args.worker_slice_shape, args.tensor_slice_shape, args.num_concurrent_workers);
+        args.worker_slice_offset = next_slice_offset;
     }
 
-    ASSERT(total_eltwise_kernel_num_pages >= total_cb_pages_pushed_to_math);
+    ASSERT(args.total_eltwise_kernel_num_pages >= total_cb_pages_pushed_to_math);
     DEBUG_STATUS("DRN1");
-    // The host code currently doesn't know how ton accuractly count the exact number of pages pushed through the
+    // The host code currently doesn't know how to accuractly count the exact number of pages pushed through the
     // math reduce op so it instead provides a known safe lower bound which may be more than actually required by the
     // op. It passes this number to sender and receiver, who will push/pop junk pages to/from the math op to ensure
     // it will complete
-    for (; total_cb_pages_pushed_to_math < total_eltwise_kernel_num_pages; total_cb_pages_pushed_to_math++) {
+    for (; total_cb_pages_pushed_to_math < args.total_eltwise_kernel_num_pages; total_cb_pages_pushed_to_math++) {
         push_filler_pages_to_cb(cb_id_in0, 1);
         push_filler_pages_to_cb(cb_id_in1, 1);
     }
 
-    static_assert(
-        tt::tt_metal::ccl::EriscDataMoverWorkerSignal::TERMINATE_IMMEDIATELY >
-        tt::tt_metal::ccl::EriscDataMoverWorkerSignal::NEXT_MESSAGE_AVAILABLE);
     noc_semaphore_inc(
         eth_receiver_l1_semaphore_noc_addr,
-        tt::tt_metal::ccl::EriscDataMoverWorkerSignal::TERMINATE_IMMEDIATELY -
-            tt::tt_metal::ccl::EriscDataMoverWorkerSignal::NEXT_MESSAGE_AVAILABLE);
+        tt::tt_metal::ccl::EriscDataMoverWorkerSignal::TERMINATE_IMMEDIATELY);
     DEBUG_STATUS("DONE");
 }


### PR DESCRIPTION
### Ticket
- [Link to Github Issue.Link to Github Issue.](https://github.com/tenstorrent/tt-metal/issues/5562)

### Problem description
- Reduce scatter had some general instability the correctness issues to be resolved before being enabled in testing

### What's changed
- Fix bug with reduce scatter reader with its iteration space. Specifically, an issue with computing the page offset in the storage when looping to the next worker slice offset within the tensor slice

- Patch bug with host ccl tensor slicer that couldn't find a valid, non-zero sized worker slice. In such cases, choose a valid and safe slice shape (1x1) as a fallback - that is slice that is 1 page high by one page wide, *not* one element .

- Fix edm builder builder bug with handshake region size in L1
  - Handshake region needs 3 * 16B

This commit also enables reduce scatter testing in post_commit and nightly

### Checklist
- [x] Post commit CI passes
  - post_commit: https://github.com/tenstorrent/tt-metal/actions/runs/9685442045
  - t3000 frequent tests: https://github.com/tenstorrent/tt-metal/actions/runs/9672662627
- [x] Model regression CI testing passes (if applicable)
  - N/A - this op was stable for use yet  
- [x] New/Existing tests provide coverage for changes
   - This commit enables reduce scatter testing in post_commit and nightly. Some additional gtest cases were also addedd
