### PR TITLE
#0: force tracy_tools to use g++ and remove binaries on clean step

### DIFF
--- a/cmake/tracy.cmake
+++ b/cmake/tracy.cmake
@@ -9,6 +9,7 @@ set_target_properties(TracyClient PROPERTIES
     LIBRARY_OUTPUT_DIRECTORY "${PROJECT_BINARY_DIR}/lib"
     ARCHIVE_OUTPUT_DIRECTORY "${PROJECT_BINARY_DIR}/lib"
     POSITION_INDEPENDENT_CODE ON    # this is equivalent to adding -fPIC
+    ADDITIONAL_CLEAN_FILES "${TRACY_HOME}/capture/build/unix/capture-release;${TRACY_HOME}/csvexport/build/unix/csvexport-release"
     OUTPUT_NAME "tracy"
 )
 

--- a/cmake/tracy.cmake
+++ b/cmake/tracy.cmake
@@ -29,7 +29,7 @@ ExternalProject_Add(
     INSTALL_COMMAND
         cp ${TRACY_HOME}/csvexport/build/unix/csvexport-release .
     BUILD_COMMAND
-        cd ${TRACY_HOME}/csvexport/build/unix && TRACY_NO_LTO=1 make -f ${TRACY_HOME}/csvexport/build/unix/Makefile
+        cd ${TRACY_HOME}/csvexport/build/unix && CXX=g++ TRACY_NO_LTO=1 make -f ${TRACY_HOME}/csvexport/build/unix/Makefile
 )
 ExternalProject_Add(
     tracy_capture_tools
@@ -44,6 +44,6 @@ ExternalProject_Add(
     INSTALL_COMMAND
         cp ${TRACY_HOME}/capture/build/unix/capture-release .
     BUILD_COMMAND
-        cd ${TRACY_HOME}/capture/build/unix && TRACY_NO_LTO=1 make -f ${TRACY_HOME}/capture/build/unix/Makefile
+        cd ${TRACY_HOME}/capture/build/unix && CXX=g++ TRACY_NO_LTO=1 make -f ${TRACY_HOME}/capture/build/unix/Makefile
 )
 add_custom_target(tracy_tools ALL DEPENDS tracy_csv_tools tracy_capture_tools)


### PR DESCRIPTION
### Problem description
- `tracy_tools` binaries don't clean right now, not causing any problems, but just for robustness
- seems to encounter linker errors with clang-17 linker as opposed to g++ as observed by @mywoodstock on IRD machines :(

Note: on CI and most if not all dev machines, `tracy_tools` is defaulting to use g++, on IRD this doesn't always seem to be the case

### What's changed
- added to clean target, so `ninja clean` will remove them
- force `tracy_tools` to build with g++ by setting `CXX=g++`

### Checklist
- [x] Post commit CI: https://github.com/tenstorrent/tt-metal/actions/runs/9505302256
- [x] Device Perf: https://github.com/tenstorrent/tt-metal/actions/runs/9505706757
- [x] Metal uBenchmarks: https://github.com/tenstorrent/tt-metal/actions/runs/9505305668
- [x] T3K Profiler: https://github.com/tenstorrent/tt-metal/actions/runs/9505330476
