### PR TITLE
#8986: Update core descriptor for BH to have 14x9 compute grid 

### DIFF
--- a/tt_metal/core_descriptors/blackhole_140_arch.yaml
+++ b/tt_metal/core_descriptors/blackhole_140_arch.yaml
@@ -12,13 +12,13 @@ blackhole:
 
     compute_with_storage_grid_range: # Logical only start and end [x, y]
       start: [0, 0]
-      end: [7, 6]
+      end: [13, 8]
 
     storage_cores: # Relative to grid of tensix cores
       []
 
     dispatch_cores:
-      [[0, -1], [1, -1], [2, -1], [3, -1], [4, -1], [5, -1], [6, -1], [7, -1]]
+      [[0, -1], [1, -1], [2, -1], [3, -1], [4, -1], [5, -1], [6, -1], [7, -1], [8, -1], [9, -1], [10, -1], [11, -1], [12, -1], [13, -1]]
 
     dispatch_core_type:
       "tensix"
@@ -29,13 +29,13 @@ blackhole:
 
     compute_with_storage_grid_range: # Logical only start and end [x, y]
       start: [0, 0]
-      end: [7, 6]
+      end: [13, 8]
 
     storage_cores: # Relative to grid of tensix cores
       []
 
     dispatch_cores:
-      [[0, -1], [1, -1], [2, -1], [3, -1], [4, -1], [5, -1], [6, -1], [7, -1]]
+      [[0, -1], [1, -1], [2, -1], [3, -1], [4, -1], [5, -1], [6, -1], [7, -1], [8, -1], [9, -1], [10, -1], [11, -1], [12, -1], [13, -1]]
 
     dispatch_core_type:
       "tensix"

--- a/tt_metal/hw/inc/mod_div_lib.h
+++ b/tt_metal/hw/inc/mod_div_lib.h
@@ -53,6 +53,14 @@ inline __attribute__((always_inline)) uint32_t fast_udiv_124(uint32_t n)
     return (((uint64_t) n * 0x08421085) >> 32) >> 2;
 }
 
+inline __attribute__((always_inline)) uint32_t fast_udiv_126(uint32_t n)
+{
+    // Uses embedding style magic number
+    // * fixed point 1/12 then shifting.
+    // https://web.archive.org/web/20190703172151/http://www.hackersdelight.org/magic.htm
+    return (((uint64_t) n * 0x04104105) >> 32) >> 1;
+}
+
 template <uint32_t d>
 inline __attribute__((always_inline)) uint32_t udivsi3_const_divisor(uint32_t n)
 {
@@ -67,6 +75,8 @@ inline __attribute__((always_inline)) uint32_t udivsi3_const_divisor(uint32_t n)
         return fast_udiv_94(n);
     } else if constexpr (d == 124) {
         return fast_udiv_124(n);
+    } else if constexpr (d == 126) {
+        return fast_udiv_126(n);
     } else {
         // generic divide from llvm
         const unsigned n_uword_bits = sizeof(uint32_t) * CHAR_BIT;

--- a/tt_metal/impl/allocator/allocator.cpp
+++ b/tt_metal/impl/allocator/allocator.cpp
@@ -41,7 +41,7 @@ void validate_num_banks(uint32_t num_banks, const BufferType &buffer_type) {
     // Dataflow API does not have a working implementation of generic modulo to determine bank_id for interleaved address gen
     // For non pow2 num banks, special cases need to be added to avoid falling back to generic implementation.
     // See https://github.com/tenstorrent/tt-metal/issues/3321
-    bool custom_mod_bank_id_calculation_exists = (num_banks == 12 or num_banks == 56 or num_banks == 94 or num_banks == 124);
+    bool custom_mod_bank_id_calculation_exists = (num_banks == 12 or num_banks == 56 or num_banks == 94 or num_banks == 124 or num_banks == 126);
     bool doesnt_support_interleaved = buffer_type == BufferType::L1_SMALL;
     bool valid_num_banks = (is_pow2_num_banks or custom_mod_bank_id_calculation_exists or doesnt_support_interleaved);
     if (not valid_num_banks) {


### PR DESCRIPTION
### Ticket
- [8986](https://github.com/tenstorrent/tt-metal/issues/8986)
- Closed because it has been committed to [abhullar/bh-bringup](https://github.com/tenstorrent/tt-metal/tree/abhullar/bh-bringup)

### Problem description
- Previous BH core desc yaml was copied from WH, it did not have the correct number of compute/storage cores.

### What's changed
- Using 14x9 compute grid with last row being used for dispatch

### Checklist
- [x] [Post commit CI](https://github.com/tenstorrent/tt-metal/actions/runs/9506523995) passes
- [x] Model regression CI testing passes (if applicable) --> N/A
- [x] New/Existing tests provide coverage for changes --> N/A
