### PR TITLE
[Falcon7b] Add top-1/top-5 metrics to perplexity test and add 128/2K seq lengths

### DIFF
--- a/models/datasets/llm_dataset_utils.py
+++ b/models/datasets/llm_dataset_utils.py
@@ -5,6 +5,9 @@
 import torch
 import re
 import datasets
+from sklearn.metrics import top_k_accuracy_score
+import numpy as np
+from loguru import logger
 
 
 def wikitext_detokenizer(string):
@@ -80,3 +83,38 @@ def prepare_textgen_dataloader(
     dataloader = torch.utils.data.DataLoader(dataset, batch_size=batch_size, shuffle=False, drop_last=True)
 
     return dataloader
+
+
+def calculate_acc_metrics(
+    logits: torch.tensor, labels: torch.tensor  # [batch_size * seq_len, vocab_size]  # [batch_size * seq_len]
+):
+    # Calculate negative log-likelihood
+    nll = torch.nn.functional.cross_entropy(logits, labels).item()
+
+    # Calculate top-1/5 accuracy
+    logits = logits.float().detach().numpy()
+    labels = labels.float().detach().numpy()
+    top1 = top_k_accuracy_score(labels, logits, k=1, labels=np.arange(logits.shape[-1]))
+    top5 = top_k_accuracy_score(labels, logits, k=5, labels=np.arange(logits.shape[-1]))
+
+    return nll, top1, top5
+
+
+def verify_acc_metrics(calculated_metrics: dict, expected_metrics: dict):
+    if (
+        calculated_metrics["ppl"] > expected_metrics["ppl"]
+        or calculated_metrics["top1_acc"] < expected_metrics["top1_acc"]
+        or calculated_metrics["top5_acc"] < expected_metrics["top5_acc"]
+    ):
+        assert (
+            False
+        ), f"At least one of Perplexity {calculated_metrics['ppl']}, Top1-Acc {calculated_metrics['top1_acc']}, or Top5-Acc {calculated_metrics['top5_acc']} is worse (higher for perplexity or lower for acc) than {expected_metrics}"
+    elif (
+        calculated_metrics["ppl"] < expected_metrics["ppl"] * 0.96
+        or calculated_metrics["top1_acc"] > expected_metrics["top1_acc"] * 1.04
+        or calculated_metrics["top5_acc"] > expected_metrics["top5_acc"] * 1.04
+    ):
+        assert (
+            False
+        ), f"At least one of Perplexity {calculated_metrics['ppl']}, Top1-Acc {calculated_metrics['top1_acc']}, or Top5-Acc {calculated_metrics['top5_acc']} is better (lower for perplexity or higher for acc) than {expected_metrics}. Please update the expected targets."
+    logger.info("Perplexity/Accuracy Check Passed!")

--- a/tests/scripts/t3000/run_t3000_demo_tests.sh
+++ b/tests/scripts/t3000/run_t3000_demo_tests.sh
@@ -31,8 +31,8 @@ run_t3000_falcon7b_tests(){
   WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml pytest --disable-warnings -q -s --input-method=json --input-path='models/demos/t3000/falcon7b/input_data_t3000.json' models/demos/t3000/falcon7b/demo_t3000.py::test_demo_multichip[user_input0-8-True-default_mode_greedy_verify]
 
   # Falcon7B perplexity test (prefill and decode)
-  WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml pytest models/demos/falcon7b/tests/test_perplexity_falcon.py::test_perplexity[1-True-prefill_seq1024_dram]
-  # WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml pytest models/demos/falcon7b/tests/test_perplexity_falcon.py::test_perplexity[1-True-decode_1024_l1_sharded]  # Disabled due to Issue #9268
+  WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml pytest models/demos/falcon7b/tests/test_perplexity_falcon.py::test_perplexity[True-prefill_seq1024_dram]
+  WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml pytest models/demos/falcon7b/tests/test_perplexity_falcon.py::test_perplexity[True-decode_1024_l1_sharded]
 
   # Record the end time
   end_time=$(date +%s)


### PR DESCRIPTION
### Ticket
- #5383

### Problem description
- 128/2k seq lengths and top1/5 metrics were missing from the falcon7b perplexity test

### What's changed
- Added 128/2k seq lengths for prefill/decode and huggingface/metal models
- Added top1/5 metrics and updated target verification
- Created utility functions for metric calculation and verification in llm_dataset_utils.py
- Re-enabled perplexity test for 1k decode in ci due to #9268 being fixed
- (todo in later PR): add ci tests for 128/2k seq length and move 1k seq tests once there is a pipeline for accuracy benchmarking

### Checklist
- [x] Post commit CI passes (not applicable, changes contained to model)
- [x] Model regression CI testing passes (if applicable)
- [x] New/Existing tests provide coverage for changes
