### PR TITLE
#8482: Trace on remote chips

### DIFF
--- a/tests/scripts/run_cpp_fd2_tests.sh
+++ b/tests/scripts/run_cpp_fd2_tests.sh
@@ -55,20 +55,28 @@ run_test "./build/test/tt_metal/perf_microbenchmark/dispatch/test_prefetcher -t 
 run_test "./build/test/tt_metal/perf_microbenchmark/dispatch/test_prefetcher -t 3 -i 5 -x" # PCIE Test
 run_test "./build/test/tt_metal/perf_microbenchmark/dispatch/test_prefetcher -t 4 -i 5 -x" # Paged DRAM Read Test
 run_test "./build/test/tt_metal/perf_microbenchmark/dispatch/test_prefetcher -t 5 -i 5 -x" # Paged DRAM Write + Read Test
-#run_test "./build/test/tt_metal/perf_microbenchmark/dispatch/test_prefetcher -t 6 -i 5 -x"  # Host Test not supported w/ exec_buf
+run_test "./build/test/tt_metal/perf_microbenchmark/dispatch/test_prefetcher -t 6 -i 5 -x" # Host Test
 
 run_test "./build/test/tt_metal/perf_microbenchmark/dispatch/test_prefetcher -t 1 -i 5 -x -spre" # Smoke Test
 run_test "./build/test/tt_metal/perf_microbenchmark/dispatch/test_prefetcher -t 1 -i 5 -x -spre -sdis" # Smoke Test
 run_test "./build/test/tt_metal/perf_microbenchmark/dispatch/test_prefetcher -t 2 -i 5 -x -spre -sdis" # Random Test
 run_test "./build/test/tt_metal/perf_microbenchmark/dispatch/test_prefetcher -t 6 -i 5 -x -spre -sdis" # Host Test
+run_test "./build/test/tt_metal/perf_microbenchmark/dispatch/test_prefetcher -t 1 -i 1000 -x -rb -spre -sdis"  # Smoke Test
+run_test "./build/test/tt_metal/perf_microbenchmark/dispatch/test_prefetcher -t 2 -i 1000 -x -rb -spre -sdis"  # Random Test
 
-if [[ $ARCH_NAME == "wormhole_b0" ]]; then
-    # packetized path used only on multi-chip WH
-    run_test "./build/test/tt_metal/perf_microbenchmark/dispatch/test_prefetcher -t 0 -i 5 -spre -sdis -packetized_en" # TrueSmoke Test with packetized path
-    run_test "./build/test/tt_metal/perf_microbenchmark/dispatch/test_prefetcher -t 1 -i 5 -spre -sdis -packetized_en" # Smoke Test with packetized path
-    run_test "./build/test/tt_metal/perf_microbenchmark/dispatch/test_prefetcher -t 2 -i 5 -spre -sdis -packetized_en" # Random Test with packetized path
-    run_test "./build/test/tt_metal/perf_microbenchmark/dispatch/test_prefetcher -t 6 -i 5 -spre -sdis -packetized_en" # Host Test with packetized path
-fi
+run_test "./build/test/tt_metal/perf_microbenchmark/dispatch/test_prefetcher -t 0 -i 5 -spre -sdis -packetized_en" # TrueSmoke Test with packetized path
+run_test "./build/test/tt_metal/perf_microbenchmark/dispatch/test_prefetcher -t 1 -i 5 -spre -sdis -packetized_en" # Smoke Test with packetized path
+run_test "./build/test/tt_metal/perf_microbenchmark/dispatch/test_prefetcher -t 2 -i 5 -spre -sdis -packetized_en" # Random Test with packetized path
+run_test "./build/test/tt_metal/perf_microbenchmark/dispatch/test_prefetcher -t 6 -i 5 -spre -sdis -packetized_en" # Host Test with packetized path
+run_test "./build/test/tt_metal/perf_microbenchmark/dispatch/test_prefetcher -t 1 -i 1000 -rb -spre -sdis -packetized_en"  # Smoke Test
+run_test "./build/test/tt_metal/perf_microbenchmark/dispatch/test_prefetcher -t 2 -i 1000 -rb -spre -sdis -packetized_en"  # Random Test
+
+run_test "./build/test/tt_metal/perf_microbenchmark/dispatch/test_prefetcher -t 0 -i 5 -x -spre -sdis -packetized_en" # TrueSmoke Test with packetized path+exec
+run_test "./build/test/tt_metal/perf_microbenchmark/dispatch/test_prefetcher -t 1 -i 5 -x -spre -sdis -packetized_en" # Smoke Test with packetized path+exec
+run_test "./build/test/tt_metal/perf_microbenchmark/dispatch/test_prefetcher -t 2 -i 5 -x -spre -sdis -packetized_en" # Random Test with packetized path+exec
+run_test "./build/test/tt_metal/perf_microbenchmark/dispatch/test_prefetcher -t 6 -i 5 -x -spre -sdis -packetized_en" # Host Test with packetized path+exec
+run_test "./build/test/tt_metal/perf_microbenchmark/dispatch/test_prefetcher -t 1 -i 1000 -x -rb -spre -sdis -packetized_en"  # Smoke Test
+run_test "./build/test/tt_metal/perf_microbenchmark/dispatch/test_prefetcher -t 2 -i 1000 -x -rb -spre -sdis -packetized_en"  # Random Test
 
 
 # Testcase: Paged Write Cmd to DRAM. 256 pages, 224b size.

--- a/tests/scripts/t3000/run_t3000_frequent_tests.sh
+++ b/tests/scripts/t3000/run_t3000_frequent_tests.sh
@@ -86,6 +86,20 @@ run_t3000_tteager_tests() {
   echo "LOG_METAL: run_t3000_tteager_tests $duration seconds to complete"
 }
 
+run_t3000_trace_stress_tests() {
+  start_time=$(date +%s)
+
+  echo "LOG_METAL: Running run_t3000_trace_stress_tests"
+
+  NUM_TRACE_LOOPS=30 pytest tests/ttnn/unit_tests/test_multi_device_trace.py
+
+  # Record the end time
+  end_time=$(date +%s)
+  duration=$((end_time - start_time))
+  echo "LOG_METAL: run_t3000_trace_stress_tests $duration seconds to complete"
+}
+
+
 run_t3000_falcon40b_tests() {
   # Record the start time
   start_time=$(date +%s)
@@ -109,6 +123,9 @@ run_t3000_tests() {
 
   # Run tteager tests
   #run_t3000_tteager_tests
+
+  # Run trace tests
+  run_t3000_trace_stress_tests
 
   # Run llama2-70b experimental tests
   run_t3000_llama2_70b_experimental_tests

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/test_dispatcher.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/test_dispatcher.cpp
@@ -449,6 +449,10 @@ int main(int argc, char **argv) {
              0,    // my_downstream_cb_sem_id
              0,    // downstream_cb_sem_id
              0,    // split_dispatch_page_preamble_size
+             false,// split_prefetcher
+             0,    // prefetch noc_xy
+             0,    // prefetch_local_downstream_sem_addr
+             0,    // prefetch_downstream_buffer_pages
              true, // is_dram_variant
              true, // is_host_variant
             };

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/test_prefetcher.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/test_prefetcher.cpp
@@ -47,7 +47,7 @@ constexpr uint32_t DRAM_DATA_ALIGNMENT = 32;
 
 constexpr uint32_t PCIE_TRANSFER_SIZE_DEFAULT = 4096;
 
-constexpr uint32_t dev_hugepage_base_g = 128; // HOST_CQ uses some at the start address
+constexpr uint32_t dev_hugepage_base_g = 2 * (CQ_START * sizeof(uint32_t)); // HOST_CQ uses some at the start address
 
 constexpr uint32_t host_data_dirty_pattern = 0xbaadf00d;
 
@@ -104,7 +104,6 @@ bool perf_test_g = false;
 uint32_t max_xfer_size_bytes_g = dispatch_buffer_page_size_g;
 uint32_t min_xfer_size_bytes_g = 4;
 uint32_t l1_buf_base_g;
-uint32_t prefetch_h_exec_buf_sem_addr_g;
 uint32_t test_device_id_g = 0;
 
 void init(int argc, char **argv) {
@@ -350,6 +349,7 @@ void add_prefetcher_cmd(vector<uint32_t>& cmds,
 
     case CQ_PREFETCH_CMD_RELAY_INLINE:
     case CQ_PREFETCH_CMD_RELAY_INLINE_NOFLUSH:
+    case CQ_PREFETCH_CMD_EXEC_BUF_END:
         cmd.relay_inline.length = payload_length_bytes;
         cmd.relay_inline.stride = round_cmd_size_up(payload_length_bytes + sizeof(CQPrefetchCmd));
         break;
@@ -821,50 +821,32 @@ void gen_rnd_test(Device *device,
 
 void gen_prefetcher_exec_buf_cmd_and_write_to_dram(Device *device,
                                                    vector<uint32_t>& prefetch_cmds,
-                                                   vector<uint32_t> buf_cmds,
+                                                   vector<uint32_t> exec_buf_cmds,
                                                    vector<uint32_t>& cmd_sizes) {
 
     vector<uint32_t> empty_payload; // don't give me grief, it is just a test
 
-    CQPrefetchCmd cmd;
+    // Add the semaphore release for prefetch_h
+    CQDispatchCmd dcmd;
+    memset(&dcmd, 0, sizeof(CQDispatchCmd));
 
-    if (split_prefetcher_g) {
-        // Add the semaphore release for prefetch_h
+    // cmddat_q in prefetch_d is re-used for exec_buf
+    // prefetch_h stalls at start of exec_buf by removing its downstream credits
+    // This command releases prefetch_h from the stall by restoring credits
+    dcmd.base.cmd_id = CQ_DISPATCH_CMD_EXEC_BUF_END;
 
-        CQDispatchCmd dcmd;
-        memset(&dcmd, 0, sizeof(CQDispatchCmd));
+    vector<uint32_t> dispatch_cmds;
+    vector<uint32_t> empty_sizes; // unused for the exec_buf but call below needs it
+    add_bare_dispatcher_cmd(dispatch_cmds, dcmd);
 
-        dcmd.base.cmd_id = CQ_DISPATCH_CMD_WRITE_LINEAR_H;
-        dcmd.write_linear.noc_xy_addr = NOC_XY_ENCODING(phys_prefetch_core_g.x, phys_prefetch_core_g.y);
-        dcmd.write_linear.addr = prefetch_h_exec_buf_sem_addr_g;
-        dcmd.write_linear.length = 16;
-
-        vector<uint32_t> dispatch_cmds;
-        vector<uint32_t> empty_sizes;
-        add_bare_dispatcher_cmd(dispatch_cmds, dcmd);
-        dispatch_cmds.push_back(1);
-        dispatch_cmds.push_back(0);
-        dispatch_cmds.push_back(0);
-        dispatch_cmds.push_back(0);
-
-        // Put the new commands at the front of the set of commands
-        // This tests that back-pressure stall in prefetch_d works
-        vector<uint32_t> tmp_cmds;
-        add_prefetcher_cmd(tmp_cmds, empty_sizes, CQ_PREFETCH_CMD_RELAY_INLINE, dispatch_cmds);
-        auto iter = buf_cmds.begin();
-        buf_cmds.insert(iter, tmp_cmds.begin(), tmp_cmds.end());
-    }
-
-    // Add an end to the list of cmds to run from the buf
-    cmd.base.cmd_id = CQ_PREFETCH_CMD_EXEC_BUF_END;
-    add_bare_prefetcher_cmd(buf_cmds, cmd);
+    add_prefetcher_cmd(exec_buf_cmds, empty_sizes, CQ_PREFETCH_CMD_EXEC_BUF_END, dispatch_cmds);
 
     // writes cmds to dram
     num_dram_banks_g = device->num_banks(BufferType::DRAM);;
 
     uint32_t page_size = 1 << exec_buf_log_page_size_g;
 
-    uint32_t length = buf_cmds.size() * sizeof(uint32_t);
+    uint32_t length = exec_buf_cmds.size() * sizeof(uint32_t);
     length +=
         (page_size - (length & (page_size - 1))) &
         (page_size - 1); // rounded up to full pages
@@ -877,13 +859,14 @@ void gen_prefetcher_exec_buf_cmd_and_write_to_dram(Device *device,
         auto dram_channel = device->dram_channel_from_bank_id(bank_id);
         auto bank_core = device->dram_core_from_dram_channel(dram_channel);
 
-        tt::Cluster::instance().write_core(static_cast<const void*>(&buf_cmds[index / sizeof(uint32_t)]),
+        tt::Cluster::instance().write_core(static_cast<const void*>(&exec_buf_cmds[index / sizeof(uint32_t)]),
             page_size, tt_cxy_pair(device->id(), bank_core), DRAM_EXEC_BUF_DEFAULT_BASE_ADDR + offset + (page_id / num_dram_banks_g) * page_size);
 
         index += page_size;
     }
     tt::Cluster::instance().dram_barrier(device->id());
 
+    CQPrefetchCmd cmd;
     cmd.base.cmd_id = CQ_PREFETCH_CMD_EXEC_BUF;
     cmd.exec_buf.pad1 = 0;
     cmd.exec_buf.pad2 = 0;
@@ -1246,9 +1229,9 @@ void write_prefetcher_cmds(uint32_t iterations,
     if (!is_control_only && use_dram_exec_buf_g) {
         // Write cmds to DRAM, generate a new command to execute those commands
         cmd_sizes.resize(0);
-        vector<uint32_t> buf_cmds = prefetch_cmds;
+        vector<uint32_t> exec_buf_cmds = prefetch_cmds;
         prefetch_cmds.resize(0);
-        gen_prefetcher_exec_buf_cmd_and_write_to_dram(device, prefetch_cmds, buf_cmds, cmd_sizes);
+        gen_prefetcher_exec_buf_cmd_and_write_to_dram(device, prefetch_cmds, exec_buf_cmds, cmd_sizes);
     }
 
     if (initialize_device_g) {
@@ -1421,19 +1404,14 @@ void configure_for_single_chip(Device *device,
         tt_metal::CreateSemaphore(program, {prefetch_relay_demux_core}, 0); // unused
     }
     constexpr uint32_t prefetch_downstream_cb_sem = 1;
-    if (split_prefetcher_g) {
-        tt_metal::CreateSemaphore(program, {prefetch_core}, prefetch_d_buffer_pages);
-        if (packetized_path_en_g) {
-            // for the unpacketize stage, we use rptr/wptr for flow control, and poll semaphore
-            // value only to update the rptr:
-            tt_metal::CreateSemaphore(program, {prefetch_relay_demux_core}, 0);
-        }
-    } else {
-        tt_metal::CreateSemaphore(program, {prefetch_core}, dispatch_buffer_pages);
+    uint32_t prefetch_downstream_buffer_pages = split_prefetcher_g ? prefetch_d_buffer_pages : dispatch_buffer_pages;
+    tt_metal::CreateSemaphore(program, {prefetch_core}, prefetch_downstream_buffer_pages);
+    tt_metal::CreateSemaphore(program, {prefetch_core}, prefetch_d_buffer_pages);
+    if (packetized_path_en_g) {
+        // for the unpacketize stage, we use rptr/wptr for flow control, and poll semaphore
+        // value only to update the rptr:
+        tt_metal::CreateSemaphore(program, {prefetch_relay_demux_core}, 0);
     }
-
-    uint32_t prefetch_h_exec_buf_sem = 2;
-    prefetch_h_exec_buf_sem_addr_g = tt_metal::CreateSemaphore(program, {prefetch_core}, 0);
 
     constexpr uint32_t prefetch_d_upstream_cb_sem = 1;
     constexpr uint32_t prefetch_d_downstream_cb_sem = 2;
@@ -1480,7 +1458,6 @@ void configure_for_single_chip(Device *device,
         prefetch_downstream_cb_sem, // prefetch_d only
         dispatch_constants::PREFETCH_D_BUFFER_LOG_PAGE_SIZE,
         dispatch_constants::PREFETCH_D_BUFFER_BLOCKS, // prefetch_d only
-        prefetch_h_exec_buf_sem,
     };
 
     if (split_prefetcher_g) {
@@ -1698,7 +1675,7 @@ void configure_for_single_chip(Device *device,
          split_prefetcher_g ? prefetch_d_downstream_cb_sem : prefetch_downstream_cb_sem, // overridden below for dispatch_h
          dispatch_constants::DISPATCH_BUFFER_SIZE_BLOCKS,
          prefetch_sync_sem,
-         dev_hugepage_base_g,
+         0, // true base of hugepage
          dev_hugepage_completion_buffer_base,
          DEFAULT_HUGEPAGE_COMPLETION_BUFFER_SIZE,
          dispatch_buffer_base,
@@ -1706,6 +1683,10 @@ void configure_for_single_chip(Device *device,
          0, // unused on hd, filled in below for h and d
          0, // unused on hd, filled in below for h and d
          0, // unused unless tunneler is between h and d
+         split_prefetcher_g,
+         NOC_XY_ENCODING(phys_prefetch_core_g.x, phys_prefetch_core_g.y),
+         prefetch_downstream_cb_sem,
+         prefetch_downstream_buffer_pages,
     };
 
     CoreCoord phys_upstream_from_dispatch_core = split_prefetcher_g ? phys_prefetch_d_core : phys_prefetch_core_g;
@@ -2007,19 +1988,14 @@ void configure_for_multi_chip(Device *device,
         tt_metal::CreateSemaphore(program_r, {prefetch_relay_demux_core}, 0); // unused
     }
     constexpr uint32_t prefetch_downstream_cb_sem = 1;
-    if (split_prefetcher_g) {
-        tt_metal::CreateSemaphore(program, {prefetch_core}, prefetch_d_buffer_pages);
-        if (packetized_path_en_g) {
-            // for the unpacketize stage, we use rptr/wptr for flow control, and poll semaphore
-            // value only to update the rptr:
-            tt_metal::CreateSemaphore(program_r, {prefetch_relay_demux_core}, 0);
-        }
-    } else {
-        tt_metal::CreateSemaphore(program, {prefetch_core}, dispatch_buffer_pages);
+    uint32_t prefetch_downstream_buffer_pages = split_prefetcher_g ? prefetch_d_buffer_pages : dispatch_buffer_pages;
+    tt_metal::CreateSemaphore(program, {prefetch_core}, prefetch_downstream_buffer_pages);
+    tt_metal::CreateSemaphore(program, {prefetch_core}, prefetch_d_buffer_pages);
+    if (packetized_path_en_g) {
+        // for the unpacketize stage, we use rptr/wptr for flow control, and poll semaphore
+        // value only to update the rptr:
+        tt_metal::CreateSemaphore(program_r, {prefetch_relay_demux_core}, 0);
     }
-
-    uint32_t prefetch_h_exec_buf_sem = 2;
-    prefetch_h_exec_buf_sem_addr_g = tt_metal::CreateSemaphore(program, {prefetch_core}, 0);
 
     constexpr uint32_t prefetch_d_upstream_cb_sem = 1;
     constexpr uint32_t prefetch_d_downstream_cb_sem = 2;
@@ -2066,7 +2042,6 @@ void configure_for_multi_chip(Device *device,
         prefetch_downstream_cb_sem, // prefetch_d only
         dispatch_constants::PREFETCH_D_BUFFER_LOG_PAGE_SIZE,
         dispatch_constants::PREFETCH_D_BUFFER_BLOCKS, // prefetch_d only
-        prefetch_h_exec_buf_sem,
     };
 
     if (split_prefetcher_g) {
@@ -2369,7 +2344,7 @@ void configure_for_multi_chip(Device *device,
          split_prefetcher_g ? prefetch_d_downstream_cb_sem : prefetch_downstream_cb_sem,
          dispatch_constants::DISPATCH_BUFFER_SIZE_BLOCKS,
          prefetch_sync_sem,
-         dev_hugepage_base_g,
+         0, // true base of hugepage
          dev_hugepage_completion_buffer_base,
          DEFAULT_HUGEPAGE_COMPLETION_BUFFER_SIZE,
          dispatch_buffer_base,
@@ -2377,6 +2352,10 @@ void configure_for_multi_chip(Device *device,
          0, // unused on hd, filled in below for h and d
          0, // unused on hd, filled in below for h and d
          0, // unused unless tunneler is between h and d
+         split_prefetcher_g,
+         NOC_XY_ENCODING(phys_prefetch_core_g.x, phys_prefetch_core_g.y),
+         prefetch_downstream_cb_sem,
+         prefetch_downstream_buffer_pages,
     };
 
     CoreCoord phys_upstream_from_dispatch_core = split_prefetcher_g ? phys_prefetch_d_core : phys_prefetch_core_g;

--- a/tests/ttnn/unit_tests/test_multi_device_trace.py
+++ b/tests/ttnn/unit_tests/test_multi_device_trace.py
@@ -8,26 +8,31 @@ import pytest
 import ttnn
 import tempfile
 from loguru import logger
+import os
 from tests.ttnn.utils_for_testing import assert_with_pcc
 from ttnn import ShardTensorToMesh, ReplicateTensorToMesh, ConcatMeshToTensor, ListMeshToTensor
 
+NUM_TRACE_LOOPS = int(os.getenv("NUM_TRACE_LOOPS", 10))
 
-@pytest.mark.parametrize("shape", [(1, 1, 512, 512), (1, 1, 32, 32), (1, 3, 512, 512), (1, 3, 32, 32)])
+
+@pytest.mark.parametrize(
+    "shape", [(1, 1, 512, 512), (1, 1, 32, 32), (1, 3, 32, 32), (1, 1, 256, 256), (1, 3, 512, 512), (1, 3, 128, 128)]
+)
 @pytest.mark.parametrize("use_all_gather", [True, False])
-@pytest.mark.parametrize("enable_async", [True, False])
+@pytest.mark.parametrize("enable_async", [True])
 @pytest.mark.parametrize("device_params", [{"trace_region_size": 33792}], indirect=True)
-def test_multi_device_single_trace(pcie_device_mesh, shape, use_all_gather, enable_async):
-    if pcie_device_mesh.get_num_devices() <= 1:
+def test_multi_device_single_trace(t3k_device_mesh, shape, use_all_gather, enable_async):
+    if t3k_device_mesh.get_num_devices() <= 1:
         pytest.skip("This test requires multiple devices")
 
     # Trace requires program cache to be enabled
-    for device_id in pcie_device_mesh.get_device_ids():
-        pcie_device_mesh.get_device(device_id).enable_async(enable_async)
-        pcie_device_mesh.get_device(device_id).enable_program_cache()
+    for device_id in t3k_device_mesh.get_device_ids():
+        t3k_device_mesh.get_device(device_id).enable_async(enable_async)
+        t3k_device_mesh.get_device(device_id).enable_program_cache()
 
     # Preallocate activation tensors. These will be used when capturing and executing the trace
-    input_0_dev = ttnn.allocate_tensor_on_device(ttnn.Shape(shape), ttnn.bfloat16, ttnn.TILE_LAYOUT, pcie_device_mesh)
-    input_1_dev = ttnn.allocate_tensor_on_device(ttnn.Shape(shape), ttnn.bfloat16, ttnn.TILE_LAYOUT, pcie_device_mesh)
+    input_0_dev = ttnn.allocate_tensor_on_device(ttnn.Shape(shape), ttnn.bfloat16, ttnn.TILE_LAYOUT, t3k_device_mesh)
+    input_1_dev = ttnn.allocate_tensor_on_device(ttnn.Shape(shape), ttnn.bfloat16, ttnn.TILE_LAYOUT, t3k_device_mesh)
 
     # Op chains to be traced
     def run_op_chain(input_0, input_1):
@@ -41,17 +46,19 @@ def test_multi_device_single_trace(pcie_device_mesh, shape, use_all_gather, enab
 
     # Capture Trace
     logger.info("Capture Trace")
-    tid = ttnn.begin_trace_capture(pcie_device_mesh, cq_id=0)
-    output_tensor = run_op_chain(input_0_dev, input_1_dev)
-    ttnn.end_trace_capture(pcie_device_mesh, tid, cq_id=0)
 
-    for i in range(50):
+    tid = ttnn.begin_trace_capture(t3k_device_mesh, cq_id=0)
+    output_tensor = run_op_chain(input_0_dev, input_1_dev)
+    ttnn.end_trace_capture(t3k_device_mesh, tid, cq_id=0)
+    logger.info("Done Trace Capture")
+
+    for i in range(NUM_TRACE_LOOPS):
         # Create torch inputs
         torch_input_tensor_0 = torch.rand(
-            (pcie_device_mesh.get_num_devices(), shape[1], shape[2], shape[3]), dtype=torch.bfloat16
+            (t3k_device_mesh.get_num_devices(), shape[1], shape[2], shape[3]), dtype=torch.bfloat16
         )
         torch_input_tensor_1 = torch.rand(
-            (pcie_device_mesh.get_num_devices(), shape[1], shape[2], shape[3]), dtype=torch.bfloat16
+            (t3k_device_mesh.get_num_devices(), shape[1], shape[2], shape[3]), dtype=torch.bfloat16
         )
         # Compute PT Golden
         torch_output_golden = torch.neg(
@@ -62,10 +69,10 @@ def test_multi_device_single_trace(pcie_device_mesh, shape, use_all_gather, enab
         )
         # Convert torch tensors to TTNN Multi-Device Host Tensors
         ttnn_input_tensor_0 = ttnn.from_torch(
-            torch_input_tensor_0, layout=ttnn.TILE_LAYOUT, mesh_mapper=ShardTensorToMesh(pcie_device_mesh, dim=0)
+            torch_input_tensor_0, layout=ttnn.TILE_LAYOUT, mesh_mapper=ShardTensorToMesh(t3k_device_mesh, dim=0)
         )
         ttnn_input_tensor_1 = ttnn.from_torch(
-            torch_input_tensor_1, layout=ttnn.TILE_LAYOUT, mesh_mapper=ShardTensorToMesh(pcie_device_mesh, dim=0)
+            torch_input_tensor_1, layout=ttnn.TILE_LAYOUT, mesh_mapper=ShardTensorToMesh(t3k_device_mesh, dim=0)
         )
 
         # Copy TTNN host tensors into preallocated Mult-Device tensors
@@ -74,7 +81,7 @@ def test_multi_device_single_trace(pcie_device_mesh, shape, use_all_gather, enab
         ttnn.copy_host_to_device_tensor(ttnn_input_tensor_1, input_1_dev)
         logger.info("Execute Trace")
         # Execute trace
-        ttnn.execute_trace(pcie_device_mesh, tid, cq_id=0, blocking=False)
+        ttnn.execute_trace(t3k_device_mesh, tid, cq_id=0, blocking=False)
 
         if use_all_gather:
             # Device All-Gather: Iterate through tensors on all devices. Ensure they match the full tensor
@@ -86,39 +93,40 @@ def test_multi_device_single_trace(pcie_device_mesh, shape, use_all_gather, enab
 
         else:
             # Perform host All-Gather
+            logger.info("Read Back Trace Outputs")
             ttnn_torch_output_tensor = ttnn.to_torch(
-                output_tensor, mesh_composer=ConcatMeshToTensor(pcie_device_mesh, dim=0)
+                output_tensor, mesh_composer=ConcatMeshToTensor(t3k_device_mesh, dim=0), device=t3k_device_mesh
             )
-            assert_with_pcc(ttnn_torch_output_tensor, torch_output_golden, pcc=0.99)
+            assert_with_pcc(ttnn_torch_output_tensor, torch_output_golden, pcc=0.96)
 
     # Release trace buffer once workload is complete
-    ttnn.release_trace(pcie_device_mesh, tid)
+    ttnn.release_trace(t3k_device_mesh, tid)
 
-    for device_id in pcie_device_mesh.get_device_ids():
-        pcie_device_mesh.get_device(device_id).enable_async(False)
+    for device_id in t3k_device_mesh.get_device_ids():
+        t3k_device_mesh.get_device(device_id).enable_async(False)
 
 
 @pytest.mark.parametrize(
     "shape",
-    [(1, 3, 1024, 1024), (1, 1, 1024, 1024), (1, 1, 512, 512), (1, 1, 32, 32), (1, 3, 512, 512), (1, 3, 32, 32)],
+    [(1, 3, 1024, 1024), (1, 1, 512, 512), (1, 1, 32, 32), (1, 3, 512, 512), (1, 3, 32, 32)],
 )
 @pytest.mark.parametrize("use_all_gather", [True, False])
-@pytest.mark.parametrize("enable_async", [True, False])
+@pytest.mark.parametrize("enable_async", [True])
 @pytest.mark.parametrize("device_params", [{"trace_region_size": 99328}], indirect=True)
-def test_multi_device_multi_trace(pcie_device_mesh, shape, use_all_gather, enable_async):
+def test_multi_device_multi_trace(t3k_device_mesh, shape, use_all_gather, enable_async):
     torch.manual_seed(0)
-    if pcie_device_mesh.get_num_devices() <= 1:
+    if t3k_device_mesh.get_num_devices() <= 1:
         pytest.skip("This test requires multiple devices")
 
     # Trace requires program cache to be enabled
-    for device_id in pcie_device_mesh.get_device_ids():
-        pcie_device_mesh.get_device(device_id).enable_async(enable_async)
-        pcie_device_mesh.get_device(device_id).enable_program_cache()
+    for device_id in t3k_device_mesh.get_device_ids():
+        t3k_device_mesh.get_device(device_id).enable_async(enable_async)
+        t3k_device_mesh.get_device(device_id).enable_program_cache()
 
     # Preallocate activation tensors. These will be used when capturing and executing the trace
-    input_0_dev = ttnn.allocate_tensor_on_device(ttnn.Shape(shape), ttnn.bfloat16, ttnn.TILE_LAYOUT, pcie_device_mesh)
-    input_1_dev = ttnn.allocate_tensor_on_device(ttnn.Shape(shape), ttnn.bfloat16, ttnn.TILE_LAYOUT, pcie_device_mesh)
-    weight_dev = ttnn.allocate_tensor_on_device(ttnn.Shape(shape), ttnn.bfloat16, ttnn.TILE_LAYOUT, pcie_device_mesh)
+    input_0_dev = ttnn.allocate_tensor_on_device(ttnn.Shape(shape), ttnn.bfloat16, ttnn.TILE_LAYOUT, t3k_device_mesh)
+    input_1_dev = ttnn.allocate_tensor_on_device(ttnn.Shape(shape), ttnn.bfloat16, ttnn.TILE_LAYOUT, t3k_device_mesh)
+    weight_dev = ttnn.allocate_tensor_on_device(ttnn.Shape(shape), ttnn.bfloat16, ttnn.TILE_LAYOUT, t3k_device_mesh)
 
     # Op chains to be traced
     def run_op_chain(input_0, input_1, weight):
@@ -148,32 +156,32 @@ def test_multi_device_multi_trace(pcie_device_mesh, shape, use_all_gather, enabl
 
     # Capture Trace 0
     logger.info("Capture Trace 0")
-    tid = ttnn.begin_trace_capture(pcie_device_mesh, cq_id=0)
+    tid = ttnn.begin_trace_capture(t3k_device_mesh, cq_id=0)
     output_tensor = run_op_chain(input_0_dev, input_1_dev, weight_dev)
-    ttnn.end_trace_capture(pcie_device_mesh, tid, cq_id=0)
+    ttnn.end_trace_capture(t3k_device_mesh, tid, cq_id=0)
 
     # Capture Trace 1
     logger.info("Capture Trace 1")
-    tid_1 = ttnn.begin_trace_capture(pcie_device_mesh, cq_id=0)
+    tid_1 = ttnn.begin_trace_capture(t3k_device_mesh, cq_id=0)
     output_tensor_1 = run_op_chain_1(input_0_dev, input_1_dev, weight_dev)
-    ttnn.end_trace_capture(pcie_device_mesh, tid_1, cq_id=0)
+    ttnn.end_trace_capture(t3k_device_mesh, tid_1, cq_id=0)
 
     # Capture Trace 1
     logger.info("Capture Trace 2")
-    tid_2 = ttnn.begin_trace_capture(pcie_device_mesh, cq_id=0)
+    tid_2 = ttnn.begin_trace_capture(t3k_device_mesh, cq_id=0)
     output_tensor_2 = run_op_chain_2(input_0_dev, input_1_dev, weight_dev)
-    ttnn.end_trace_capture(pcie_device_mesh, tid_2, cq_id=0)
+    ttnn.end_trace_capture(t3k_device_mesh, tid_2, cq_id=0)
 
     # Execute and verify trace against pytorch
     torch_silu = torch.nn.SiLU()
     torch_softmax = torch.nn.Softmax(dim=1)
-    for i in range(15):
+    for i in range(NUM_TRACE_LOOPS):
         # Create torch inputs
         torch_input_tensor_0 = torch.rand(
-            (pcie_device_mesh.get_num_devices(), shape[1], shape[2], shape[3]), dtype=torch.bfloat16
+            (t3k_device_mesh.get_num_devices(), shape[1], shape[2], shape[3]), dtype=torch.bfloat16
         )
         torch_input_tensor_1 = torch.rand(
-            (pcie_device_mesh.get_num_devices(), shape[1], shape[2], shape[3]), dtype=torch.bfloat16
+            (t3k_device_mesh.get_num_devices(), shape[1], shape[2], shape[3]), dtype=torch.bfloat16
         )
         torch_weight = torch.rand(shape, dtype=torch.bfloat16)
         # Compute PT Golden
@@ -194,13 +202,13 @@ def test_multi_device_multi_trace(pcie_device_mesh, shape, use_all_gather, enabl
 
         # Convert torch tensors to TTNN Multi-Device Host Tensors
         ttnn_input_tensor_0 = ttnn.from_torch(
-            torch_input_tensor_0, layout=ttnn.TILE_LAYOUT, mesh_mapper=ShardTensorToMesh(pcie_device_mesh, dim=0)
+            torch_input_tensor_0, layout=ttnn.TILE_LAYOUT, mesh_mapper=ShardTensorToMesh(t3k_device_mesh, dim=0)
         )
         ttnn_input_tensor_1 = ttnn.from_torch(
-            torch_input_tensor_1, layout=ttnn.TILE_LAYOUT, mesh_mapper=ShardTensorToMesh(pcie_device_mesh, dim=0)
+            torch_input_tensor_1, layout=ttnn.TILE_LAYOUT, mesh_mapper=ShardTensorToMesh(t3k_device_mesh, dim=0)
         )
         ttnn_weight = ttnn.from_torch(
-            torch_weight, layout=ttnn.TILE_LAYOUT, mesh_mapper=ReplicateTensorToMesh(pcie_device_mesh)
+            torch_weight, layout=ttnn.TILE_LAYOUT, mesh_mapper=ReplicateTensorToMesh(t3k_device_mesh)
         )
 
         # Copy TTNN host tensors into preallocated Mult-Device tensors
@@ -211,11 +219,11 @@ def test_multi_device_multi_trace(pcie_device_mesh, shape, use_all_gather, enabl
 
         # Execute trace
         logger.info("Execute Trace 0")
-        ttnn.execute_trace(pcie_device_mesh, tid, cq_id=0, blocking=False)
+        ttnn.execute_trace(t3k_device_mesh, tid, cq_id=0, blocking=False)
         logger.info("Execute Trace 1")
-        ttnn.execute_trace(pcie_device_mesh, tid_1, cq_id=0, blocking=False)
+        ttnn.execute_trace(t3k_device_mesh, tid_1, cq_id=0, blocking=False)
         logger.info("Execute Trace 2")
-        ttnn.execute_trace(pcie_device_mesh, tid_2, cq_id=0, blocking=False)
+        ttnn.execute_trace(t3k_device_mesh, tid_2, cq_id=0, blocking=False)
         if use_all_gather:
             # Device All-Gather: Iterate through tensors on all devices. Ensure they match the full tensor
             logger.info("Read Back Trace 0 Outputs")
@@ -234,28 +242,28 @@ def test_multi_device_multi_trace(pcie_device_mesh, shape, use_all_gather, enabl
             device_tensors: typing.List[ttnn.Tensor] = ttnn.get_device_tensors(output_tensor_2)
             for device_tensor in device_tensors:
                 device_tensor_torch = ttnn.to_torch(device_tensor)
-                assert_with_pcc(device_tensor_torch, torch_output_golden_2, pcc=0.0)
+                assert_with_pcc(device_tensor_torch, torch_output_golden_2, pcc=0.96)
         else:
             # Perform host All-Gather
             ttnn_torch_output_tensor = ttnn.to_torch(
-                output_tensor, mesh_composer=ConcatMeshToTensor(pcie_device_mesh, dim=0)
+                output_tensor, mesh_composer=ConcatMeshToTensor(t3k_device_mesh, dim=0), device=t3k_device_mesh
             )
             assert_with_pcc(ttnn_torch_output_tensor, torch_output_golden, pcc=0.96)
 
             ttnn_torch_output_tensor = ttnn.to_torch(
-                output_tensor_1, mesh_composer=ConcatMeshToTensor(pcie_device_mesh, dim=0)
+                output_tensor_1, mesh_composer=ConcatMeshToTensor(t3k_device_mesh, dim=0), device=t3k_device_mesh
             )
             assert_with_pcc(ttnn_torch_output_tensor, torch_output_golden_1, pcc=0.96)
 
             ttnn_torch_output_tensor = ttnn.to_torch(
-                output_tensor_2, mesh_composer=ConcatMeshToTensor(pcie_device_mesh, dim=0)
+                output_tensor_2, mesh_composer=ConcatMeshToTensor(t3k_device_mesh, dim=0), device=t3k_device_mesh
             )
             assert_with_pcc(ttnn_torch_output_tensor, torch_output_golden_2, pcc=0.96)
 
     # Release trace buffer once workload is complete
-    ttnn.release_trace(pcie_device_mesh, tid)
-    ttnn.release_trace(pcie_device_mesh, tid_1)
-    ttnn.release_trace(pcie_device_mesh, tid_2)
+    ttnn.release_trace(t3k_device_mesh, tid)
+    ttnn.release_trace(t3k_device_mesh, tid_1)
+    ttnn.release_trace(t3k_device_mesh, tid_2)
 
-    for device_id in pcie_device_mesh.get_device_ids():
-        pcie_device_mesh.get_device(device_id).enable_async(False)
+    for device_id in t3k_device_mesh.get_device_ids():
+        t3k_device_mesh.get_device(device_id).enable_async(False)

--- a/tt_metal/impl/device/device.cpp
+++ b/tt_metal/impl/device/device.cpp
@@ -376,7 +376,7 @@ void Device::update_workers_build_settings(std::vector<std::vector<std::tuple<tt
                     uint32_t downstream_cb_base = mux_settings.cb_start_address + mux_settings.cb_size_bytes * mux_sem;
                     settings.upstream_cores.push_back(tt_cxy_pair(0, 0, 0));
                     settings.downstream_cores.push_back(mux_settings.worker_physical_core);
-                    settings.compile_args.resize(23);
+                    settings.compile_args.resize(22);
                     auto& compile_args = settings.compile_args;
                     compile_args[0]  = downstream_cb_base;
                     compile_args[1]  = dispatch_constants::PREFETCH_D_BUFFER_LOG_PAGE_SIZE;
@@ -398,9 +398,8 @@ void Device::update_workers_build_settings(std::vector<std::vector<std::tuple<tt
                     compile_args[17] = 0; //prefetch_downstream_cb_sem, // prefetch_d only
                     compile_args[18] = dispatch_constants::PREFETCH_D_BUFFER_LOG_PAGE_SIZE;
                     compile_args[19] = dispatch_constants::PREFETCH_D_BUFFER_BLOCKS; // prefetch_d only
-                    compile_args[20] = 2; //prefetch_h_exec_buf_sem,
-                    compile_args[21] = false;  // is_dram_variant
-                    compile_args[22] = true;    // is_host_variant
+                    compile_args[20] = false;  // is_dram_variant
+                    compile_args[21] = true;    // is_host_variant
                 }
                 break;
             }
@@ -565,13 +564,15 @@ void Device::update_workers_build_settings(std::vector<std::vector<std::tuple<tt
                 uint32_t num_dispatchers = device_worker_variants[DISPATCH].size();
                 TT_ASSERT(device_worker_variants[DEMUX].size() == 1, "Cannot have more than one Demux.");
                 auto demux_settings = std::get<1>(device_worker_variants[DEMUX][0]);
+                auto prefetch_h_settings = std::get<1>(device_worker_variants[PREFETCH][0]);
+                auto prefetch_physical_core = prefetch_h_settings.worker_physical_core;
                 TT_ASSERT(num_dispatchers == demux_settings.semaphores.size(), "Demux does not have required number of semaphores for Dispatchers. Exptected = {}. Fount = {}", num_dispatchers, demux_settings.semaphores.size());
                 uint32_t demux_sem = demux_settings.producer_semaphore_id;
                 for (auto&[core, settings] : device_worker_variants[DISPATCH]) {
                     auto dispatch_core_type = settings.dispatch_core_type;
                     settings.upstream_cores.push_back(demux_settings.worker_physical_core);
                     settings.downstream_cores.push_back(tt_cxy_pair(0, 0, 0));
-                    settings.compile_args.resize(17);
+                    settings.compile_args.resize(21);
                     auto& compile_args = settings.compile_args;
                     compile_args[0] = settings.cb_start_address;
                     compile_args[1] = settings.cb_log_page_size;
@@ -588,8 +589,12 @@ void Device::update_workers_build_settings(std::vector<std::vector<std::tuple<tt
                     compile_args[12] = 0; // unused: local ds semaphore
                     compile_args[13] = 0; // unused: remote ds semaphore
                     compile_args[14] = 0; // preamble size
-                    compile_args[15] = false; // is_dram_variant
-                    compile_args[16] = true; // is_host_variant
+                    compile_args[15] = true,    // split_prefetcher
+                    compile_args[16] = NOC_XY_ENCODING(prefetch_physical_core.x, prefetch_physical_core.y),
+                    compile_args[17] = prefetch_h_settings.producer_semaphore_id, // sem_id on prefetch_h that dispatch_d is meant to increment, to resume sending of cmds post exec_buf stall
+                    compile_args[18] = dispatch_constants::get(dispatch_core_type).prefetch_d_buffer_pages(), // XXXX should this be mux pages?
+                    compile_args[19] = false; // is_dram_variant
+                    compile_args[20] = true; // is_host_variant
                 }
                 break;
             }
@@ -721,7 +726,7 @@ void Device::update_workers_build_settings(std::vector<std::vector<std::tuple<tt
                 TT_ASSERT(scratch_db_base + scratch_db_size <= l1_size);
 
                 auto& compile_args = prefetch_d_settings.compile_args;
-                compile_args.resize(23);
+                compile_args.resize(22);
                 compile_args[0]  = dispatch_d_settings.cb_start_address;
                 compile_args[1]  = dispatch_d_settings.cb_log_page_size;
                 compile_args[2]  = dispatch_d_settings.cb_pages;
@@ -740,11 +745,10 @@ void Device::update_workers_build_settings(std::vector<std::vector<std::tuple<tt
                 compile_args[15] = prefetch_d_settings.cb_pages; // prefetch_d only
                 compile_args[16] = prefetch_d_settings.consumer_semaphore_id; // prefetch_d only
                 compile_args[17] = demux_d_settings.producer_semaphore_id; //prefetch_downstream_cb_sem, // prefetch_d only
-                compile_args[18] = prefetch_d_settings.cb_log_page_size;;
+                compile_args[18] = prefetch_d_settings.cb_log_page_size;
                 compile_args[19] = dispatch_constants::PREFETCH_D_BUFFER_BLOCKS; // prefetch_d only
-                compile_args[20] = 2; //prefetch_h_exec_buf_sem,
-                compile_args[21] = true;  // is_dram_variant
-                compile_args[22] = false; // is_host_variant
+                compile_args[20] = true;  // is_dram_variant
+                compile_args[21] = false; // is_host_variant
                 break;
             }
             case DISPATCH_D:
@@ -756,11 +760,10 @@ void Device::update_workers_build_settings(std::vector<std::vector<std::tuple<tt
                 uint32_t sem = 0;
                 auto &dispatch_d_settings = std::get<1>(device_worker_variants[DISPATCH_D][0]);
                 auto prefetch_d_settings = std::get<1>(device_worker_variants[PREFETCH_D][0]);
-
                 auto dispatch_core_type = dispatch_d_settings.dispatch_core_type;
                 dispatch_d_settings.upstream_cores.push_back(prefetch_d_settings.worker_physical_core);
                 dispatch_d_settings.downstream_cores.push_back(mux_d_settings.worker_physical_core);
-                dispatch_d_settings.compile_args.resize(17);
+                dispatch_d_settings.compile_args.resize(21);
                 auto& compile_args = dispatch_d_settings.compile_args;
                 compile_args[0] = dispatch_d_settings.cb_start_address;
                 compile_args[1] = dispatch_d_settings.cb_log_page_size;
@@ -777,8 +780,12 @@ void Device::update_workers_build_settings(std::vector<std::vector<std::tuple<tt
                 compile_args[12] = dispatch_d_settings.producer_semaphore_id; // unused: local ds semaphore
                 compile_args[13] = mux_d_settings.consumer_semaphore_id; // unused: remote ds semaphore
                 compile_args[14] = sizeof(dispatch_packet_header_t); // preamble size
-                compile_args[15] = true; // is_dram_variant
-                compile_args[16] = false; // is_host_variant
+                compile_args[15] = true,    // split_prefetcher
+                compile_args[16] = 0;
+                compile_args[17] = 1; //prefetch_downstream_cb_sem,
+                compile_args[18] = dispatch_constants::get(dispatch_core_type).prefetch_d_buffer_pages(), // XXXX should this be mux pages?
+                compile_args[19] = true; // is_dram_variant
+                compile_args[20] = false; // is_host_variant
                 break;
             }
             case MUX_D:
@@ -1106,7 +1113,6 @@ void Device::compile_command_queue_programs() {
     constexpr uint32_t prefetch_d_sync_sem = 0;
     constexpr uint32_t prefetch_d_upstream_cb_sem = 1;
     constexpr uint32_t prefetch_d_downstream_cb_sem = 2;
-    constexpr uint32_t prefetch_h_exec_buf_sem = 2;
     constexpr uint32_t dispatch_downstream_cb_sem = 1;
 
     if (this->is_mmio_capable()) {
@@ -1156,7 +1162,6 @@ void Device::compile_command_queue_programs() {
                 0, //prefetch_downstream_cb_sem, // prefetch_d only
                 dispatch_constants::PREFETCH_D_BUFFER_LOG_PAGE_SIZE,
                 dispatch_constants::PREFETCH_D_BUFFER_BLOCKS, // prefetch_d only
-                prefetch_h_exec_buf_sem,
                 true,   // is_dram_variant
                 true    // is_host_variant
             };
@@ -1173,9 +1178,9 @@ void Device::compile_command_queue_programs() {
                 std::map<string, string> {},
                 noc_index
             );
+
             tt::tt_metal::CreateSemaphore(*command_queue_program_ptr, prefetch_core, 0, dispatch_core_type); // prefetch_sync_sem
             tt::tt_metal::CreateSemaphore(*command_queue_program_ptr, prefetch_core, dispatch_constants::get(dispatch_core_type).dispatch_buffer_pages(), dispatch_core_type); // prefetch_sem
-            tt::tt_metal::CreateSemaphore(*command_queue_program_ptr, prefetch_core, 0, dispatch_core_type); // prefetch_h_exec_buf_sem
 
             std::vector<uint32_t> dispatch_compile_args = {
                 dispatch_constants::DISPATCH_BUFFER_BASE,
@@ -1193,6 +1198,10 @@ void Device::compile_command_queue_programs() {
                 0, // unused
                 0, // unused
                 0, // unused
+                false,  // split_prefetcher
+                0,      // unused prefetch noc_xy
+                0,      // unused prefetch_local_downstream_sem_addr
+                0,      // unused prefetch_downstream_buffer_pages
                 true,   // is_dram_variant
                 true    // is_host_variant
             };
@@ -1209,6 +1218,7 @@ void Device::compile_command_queue_programs() {
                 std::map<string, string> {},
                 noc_index
             );
+
             tt::tt_metal::CreateSemaphore(*command_queue_program_ptr, dispatch_core, 0, dispatch_core_type); // dispatch_sem
         }
         detail::CompileProgram(this, *command_queue_program_ptr);
@@ -1219,8 +1229,6 @@ void Device::compile_command_queue_programs() {
         chip_id_t device_id = this->id();
         chip_id_t mmio_device_id = tt::Cluster::instance().get_associated_mmio_device(device_id);
         Device *mmio_device = tt::DevicePool::instance().get_active_device(mmio_device_id);
-//        uint16_t channel = tt::Cluster::instance().get_assigned_channel_for_device(device_id);
-//        uint32_t cq_size = mmio_device->sysmem_manager().get_cq_size();
         NOC noc_index = this->hw_command_queues_[cq_id]->noc_index;
 
         auto &tunnel_device_dispatch_workers = mmio_device->tunnel_device_dispatch_workers_;
@@ -1442,6 +1450,7 @@ void Device::compile_command_queue_programs() {
             std::map<string, string> {},
             noc_index
         );
+
 
         auto [mux_d_core, mux_d_settings] = device_worker_variants[MUX_D][0];
         for (auto sem : mux_d_settings.semaphores) {

--- a/tt_metal/impl/dispatch/command_queue.cpp
+++ b/tt_metal/impl/dispatch/command_queue.cpp
@@ -283,7 +283,6 @@ void EnqueueWriteBufferCommand::process() {
     this->manager.issue_queue_push_back(cmd_sequence_sizeB, this->command_queue_id);
 
     this->manager.fetch_queue_reserve_back(this->command_queue_id);
-
     this->manager.fetch_queue_write(cmd_sequence_sizeB, this->command_queue_id);
 }
 
@@ -1123,7 +1122,6 @@ void EnqueueRecordEventCommand::process() {
     this->manager.issue_queue_push_back(cmd_sequence_sizeB, this->command_queue_id);
 
     this->manager.fetch_queue_reserve_back(this->command_queue_id);
-
     this->manager.fetch_queue_write(cmd_sequence_sizeB, this->command_queue_id);
 }
 
@@ -1779,7 +1777,8 @@ void HWCommandQueue::enqueue_trace(const uint32_t trace_id, bool blocking) {
 
     if (blocking) {
         this->finish();
-    } else {
+    }
+    else {
         std::shared_ptr<Event> event = std::make_shared<Event>();
         this->enqueue_record_event(event);
     }

--- a/tt_metal/impl/dispatch/cq_commands.hpp
+++ b/tt_metal/impl/dispatch/cq_commands.hpp
@@ -21,7 +21,7 @@ enum CQPrefetchCmdId : uint8_t {
     CQ_PREFETCH_CMD_RELAY_INLINE = 3,         // relay (inline) data from CmdDatQ to dispatcher
     CQ_PREFETCH_CMD_RELAY_INLINE_NOFLUSH = 4, // same as above, but doesn't flush the page to dispatcher
     CQ_PREFETCH_CMD_EXEC_BUF = 5,             // execute commands from a buffer
-    CQ_PREFETCH_CMD_EXEC_BUF_END = 6,         // finish executing commands from a buffer (return)
+    CQ_PREFETCH_CMD_EXEC_BUF_END = 6,         // finish executing commands from a buffer (return), payload like relay_inline
     CQ_PREFETCH_CMD_STALL = 7,                // drain pipe through dispatcher
     CQ_PREFETCH_CMD_DEBUG = 8,                // log waypoint data to watcher, checksum
     CQ_PREFETCH_CMD_TERMINATE = 9,            // quit
@@ -40,7 +40,8 @@ enum CQDispatchCmdId : uint8_t {
     CQ_DISPATCH_CMD_SINK = 8,               // act as a data sink (for testing)
     CQ_DISPATCH_CMD_DEBUG = 9,              // log waypoint data to watcher, checksum
     CQ_DISPATCH_CMD_DELAY = 10,             // insert delay (for testing)
-    CQ_DISPATCH_CMD_TERMINATE = 11,         // quit
+    CQ_DISPATCH_CMD_EXEC_BUF_END = 11,      // dispatch_d notify prefetch_h that exec_buf has completed
+    CQ_DISPATCH_CMD_TERMINATE = 12,         // quit
 };
 
 //////////////////////////////////////////////////////////////////////////////
@@ -137,7 +138,6 @@ struct CQDispatchWritePagedCmd {
     uint32_t page_size;
     uint32_t pages;
 } __attribute__((packed));
-
 
 constexpr uint32_t CQ_DISPATCH_CMD_PACKED_WRITE_FLAG_NONE      = 0x00;
 constexpr uint32_t CQ_DISPATCH_CMD_PACKED_WRITE_FLAG_MCAST     = 0x01;

--- a/tt_metal/impl/dispatch/kernels/cq_prefetch.cpp
+++ b/tt_metal/impl/dispatch/kernels/cq_prefetch.cpp
@@ -44,10 +44,8 @@ constexpr uint32_t upstream_cb_sem_id = get_compile_time_arg_val(17);
 constexpr uint32_t cmddat_q_log_page_size = get_compile_time_arg_val(18);
 constexpr uint32_t cmddat_q_blocks = get_compile_time_arg_val(19);
 
-constexpr uint32_t dispatch_h_exec_buf_sem_id = get_compile_time_arg_val(20);
-
-constexpr uint32_t is_d_variant = get_compile_time_arg_val(21);
-constexpr uint32_t is_h_variant = get_compile_time_arg_val(22);
+constexpr uint32_t is_d_variant = get_compile_time_arg_val(20);
+constexpr uint32_t is_h_variant = get_compile_time_arg_val(21);
 
 constexpr uint32_t my_noc_xy = uint32_t(NOC_XY_ENCODING(MY_NOC_X, MY_NOC_Y));
 constexpr uint32_t upstream_noc_xy = uint32_t(NOC_XY_ENCODING(UPSTREAM_NOC_X, UPSTREAM_NOC_Y));
@@ -116,8 +114,11 @@ void write_downstream(uint32_t& data_ptr,
 
 // If prefetcher must stall after this fetch, wait for data to come back, and move to stalled state.
 FORCE_INLINE
-void barrier_and_stall(uint32_t& pending_read_size, uint32_t& fence) {
+void barrier_and_stall(uint32_t& pending_read_size, uint32_t& fence, uint32_t& cmd_ptr) {
     noc_async_read_barrier();
+    if (fence < cmd_ptr) {
+        cmd_ptr = fence;
+    }
     fence += pending_read_size;
     pending_read_size = 0;
     stall_state = STALLED;
@@ -215,7 +216,11 @@ void fetch_q_get_cmds(uint32_t& fence, uint32_t& cmd_ptr, uint32_t& pcie_read_pt
         read_from_pcie<preamble_size>
             (prefetch_q_rd_ptr, pending_read_size, fence, pcie_read_ptr, cmd_ptr, fetch_size);
         if (stall_state == STALL_NEXT) {
-            barrier_and_stall(pending_read_size, fence); // STALL_NEXT -> STALLED
+            // No pending reads. exec_buf is the first command being fetched and should be offset
+            // by preamble size. After ensuring that the exec_buf command has been read (barrier),
+            // exit.
+            barrier_and_stall(pending_read_size, fence, cmd_ptr); // STALL_NEXT -> STALLED
+            return;
         }
     }
     if (!cmd_ready) {
@@ -239,10 +244,16 @@ void fetch_q_get_cmds(uint32_t& fence, uint32_t& cmd_ptr, uint32_t& pcie_read_pt
                 stall_flag = (prefetch_q_rd_ptr_local & prefetch_q_msb_mask) != 0;
                 stall_state = static_cast<StallState>(stall_flag << 1); // NOT_STALLED -> STALL_NEXT if stall_flag is set
 
-                read_from_pcie<preamble_size>
-                    (prefetch_q_rd_ptr, pending_read_size, fence, pcie_read_ptr, cmd_ptr, fetch_size);
                 if (stall_state == STALL_NEXT) {
-                    barrier_and_stall(pending_read_size, fence); // STALL_NEXT -> STALLED
+                    // If the prefetcher state reached here, it is issuing a read to the same "slot", since for exec_buf commands
+                    // we will insert a read barrier. Hence, the exec_buf command will be concatenated to a previous command, and
+                    // should not be offset by pramble size.
+                    read_from_pcie<0>
+                        (prefetch_q_rd_ptr, pending_read_size, fence, pcie_read_ptr, cmd_ptr, fetch_size);
+                    barrier_and_stall(pending_read_size, fence, cmd_ptr); // STALL_NEXT -> STALLED
+                } else {
+                    read_from_pcie<preamble_size>
+                        (prefetch_q_rd_ptr, pending_read_size, fence, pcie_read_ptr, cmd_ptr, fetch_size);
                 }
             }
         } else {
@@ -605,7 +616,7 @@ uint32_t process_relay_linear_cmd(uint32_t cmd_ptr,
     uint32_t read_addr = cmd->relay_linear.addr;
     uint32_t length = cmd->relay_linear.length;
     uint32_t read_length = length;
-    DPRINT << "relay_linear: " << length << " " << read_addr << " " << noc_xy_addr << ENDL();
+    DPRINT << "relay_linear: " << cmd_ptr << " " << length << " " << read_addr << " " << noc_xy_addr << ENDL();
 
     // First step - read into DB0
     uint32_t scratch_read_addr = scratch_db_top[0];
@@ -711,6 +722,8 @@ void paged_read_into_cmddat_q(uint32_t read_ptr) {
     exec_buf_state.length += read_length;
 }
 
+// processes the relay_inline cmd from an exec_buf
+// ie, reads the data from dram and relays it on
 static uint32_t process_relay_inline_exec_buf_cmd(uint32_t& cmd_ptr,
                                                   uint32_t& downstream_data_ptr) {
 
@@ -719,6 +732,7 @@ static uint32_t process_relay_inline_exec_buf_cmd(uint32_t& cmd_ptr,
     uint32_t length = cmd->relay_inline.length;
     uint32_t data_ptr = cmd_ptr + sizeof(CQPrefetchCmd);
 
+    DPRINT << "relay_inline_exec_buf_cmd:" << length << ENDL();
     uint32_t npages = (length + downstream_cb_page_size - 1) >> downstream_cb_log_page_size;
 
     // Assume the downstream buffer is big relative to cmddat command size that we can
@@ -763,11 +777,6 @@ uint32_t process_exec_buf_cmd(uint32_t cmd_ptr_outer,
     // dispatch on eth cores is memory constrained, so exec_buf re-uses the cmddat_q
     // prefetch_h stalls upon issuing an exec_buf to prevent conflicting use of the cmddat_q,
     // the exec_buf contains the release commands
-    // this takes away all credits from prefetch_h so prefetch_h doesn't begin until this cmd is done
-    if (!is_h_variant) {
-        cb_release_pages<upstream_noc_xy, upstream_cb_sem_id>(-(cmddat_q_pages - 1));
-    }
-
     volatile CQPrefetchCmd tt_l1_ptr *cmd = (volatile CQPrefetchCmd tt_l1_ptr *)cmd_ptr_outer;
 
     exec_buf_state.page_id = 0;
@@ -796,11 +805,6 @@ uint32_t process_exec_buf_cmd(uint32_t cmd_ptr_outer,
             exec_buf_state.length -= stride;
             cmd_ptr += stride;
         }
-    }
-
-    // release the pages acquired above to free up prefetch_h
-    if (!is_h_variant) {
-        cb_release_pages<upstream_noc_xy, upstream_cb_sem_id>(cmddat_q_pages - 1);
     }
 
     return CQ_PREFETCH_CMD_BARE_MIN_SIZE;
@@ -865,6 +869,7 @@ bool process_cmd(uint32_t& cmd_ptr,
     case CQ_PREFETCH_CMD_EXEC_BUF_END:
         DPRINT << "exec buf end: " << cmd_ptr << ENDL();
         ASSERT(exec_buf);
+        stride = process_relay_inline_exec_buf_cmd(cmd_ptr, downstream_data_ptr);
         done = true;
         break;
 
@@ -902,7 +907,7 @@ bool process_cmd(uint32_t& cmd_ptr,
     return done;
 }
 
-static uint32_t process_relay_inline_all(uint32_t data_ptr, uint32_t fence) {
+static uint32_t process_relay_inline_all(uint32_t data_ptr, uint32_t fence, bool is_exec_buf) {
 
     uint32_t length = fence - data_ptr;
 
@@ -917,6 +922,18 @@ static uint32_t process_relay_inline_all(uint32_t data_ptr, uint32_t fence) {
     // Assume the dispatch buffer is big relative to cmddat command size that we can
     // grab what we need in one chunk
     cb_acquire_pages<my_noc_xy, my_downstream_cb_sem_id>(npages);
+    if (is_exec_buf) {
+        // swipe all the downstream page credits from ourselves...
+        // prefetch_h stalls sending commands to prefetch_d until notified by dispatch_d that the exec_buf is done
+        // exec_buf completing on dispatch_h will free the pages and allow sending again
+        volatile tt_l1_ptr uint32_t* sem_addr =
+            reinterpret_cast<volatile tt_l1_ptr uint32_t*>(get_semaphore(my_downstream_cb_sem_id));
+        noc_semaphore_inc(get_noc_addr_helper(my_noc_xy, (uint32_t)sem_addr), -downstream_cb_pages);
+
+        // OK to continue prefetching once the page credits are returned
+        stall_state = NOT_STALLED;
+    }
+
     uint32_t downstream_pages_left = (downstream_cb_end - downstream_data_ptr) >> downstream_cb_log_page_size;
     if (downstream_pages_left >= npages) {
         noc_async_write(data_ptr, get_noc_addr_helper(downstream_noc_xy, downstream_data_ptr), length);
@@ -994,20 +1011,6 @@ inline uint32_t relay_cb_get_cmds(uint32_t& fence, uint32_t& data_ptr) {
     return length - sizeof(CQPrefetchHToPrefetchDHeader);
 }
 
-// prefetch_h stalls sending commands to prefetch_d until notified by dispatch_d that the exec_buf is done
-// future optimization: this routine could pull from fetch_q while stalled. to do so we'd need to parse
-// commands in kernel_main_h
-void process_exec_buf_cmd_h() {
-
-    volatile tt_l1_ptr uint32_t* sem_addr =
-        reinterpret_cast<volatile tt_l1_ptr uint32_t*>(get_semaphore(dispatch_h_exec_buf_sem_id));
-
-    DEBUG_STATUS("EBCW");
-    while (*sem_addr == 0);
-    DEBUG_STATUS("EBCD");
-    *sem_addr = 0;
-}
-
 void kernel_main_h() {
 
     uint32_t cmd_ptr = cmddat_q_base;
@@ -1019,15 +1022,14 @@ void kernel_main_h() {
 
         volatile CQPrefetchCmd tt_l1_ptr *cmd = (volatile CQPrefetchCmd tt_l1_ptr *)(cmd_ptr + sizeof(CQPrefetchHToPrefetchDHeader));
         uint32_t cmd_id = cmd->base.cmd_id;
-        cmd_ptr = process_relay_inline_all(cmd_ptr, fence);
+        // Infer that an exec_buf command is to be executed based on the stall state.
+        bool is_exec_buf = (stall_state == STALLED);
+        cmd_ptr = process_relay_inline_all(cmd_ptr, fence, is_exec_buf);
+
         // Note: one fetch_q entry can contain multiple commands
         // The code below assumes these commands arrive individually, packing them would require parsing all cmds
-        if (cmd_id == CQ_PREFETCH_CMD_EXEC_BUF) {
-            DPRINT << "exec buf\n";
-            process_exec_buf_cmd_h();
-            stall_state = NOT_STALLED; // Stall is no longer required after ExecBuf finished
-        } else if (cmd_id == CQ_PREFETCH_CMD_TERMINATE) {
-            DPRINT << "prefetch terminating_" << is_h_variant << is_d_variant << ENDL();;
+        if (cmd_id == CQ_PREFETCH_CMD_TERMINATE) {
+            DPRINT << "prefetch terminating_10" << ENDL();
             done = true;
         }
 #if defined(COMPILE_FOR_IDLE_ERISC)
@@ -1122,6 +1124,9 @@ void kernel_main_hd() {
 
 void kernel_main() {
     DPRINT << "prefetcher_" << is_h_variant << is_d_variant << ": start" << ENDL();
+
+    volatile tt_l1_ptr uint32_t* sem_addr =
+        reinterpret_cast<volatile tt_l1_ptr uint32_t*>(get_semaphore(my_downstream_cb_sem_id));
 
     if (is_h_variant and is_d_variant) {
         kernel_main_hd();


### PR DESCRIPTION
### Ticket
- https://github.com/tenstorrent/tt-metal/issues/8482

### Problem description
- Trace is not working on remote chips.

### What's changed
 - Changes from @pgkeller:
     Fix host completion write ptr in test_prefetcher
     Was clobbering cmds.
     This enables more prefetcher test configs w/ exec_buf

     Rework split prefetch exec_buf sync mechanism
     prefetch_h now stalls itself at the start of exec_buf by taking away its
     downstream page credits.  After sending the exec_buf, it unstalls the
     prefetch_q so that it can continue to do prefetch work.  dispatch restores
     prefetch_h credits at exec_buf_end.

     Increase test_prefetcher exec_buf test coverage

 - cq_prefetch changes:
   - Modify detection of exec_buf command. Prefetcher no longer looks at the cmd_id, since exec_buf command is not the first command in the Fetch Q. Instead rely on stall flag.
   - prefetch_h should not offset exec_buf command by preamble size, since it belongs to the same entry as a previously offset command (due to barrier_and_stall)
   - Account for wrap in barrier and stall

 - Add T3K trace tests.

### Checklist
- [x] Post commit CI passes
- [ ] Model regression CI testing passes (if applicable)
- [x] New/Existing tests provide coverage for changes
