### PR TITLE
depthwise conv1d bringup

### DIFF
--- a/tests/ttnn/unit_tests/operations/test_depthwise_conv1d.py
+++ b/tests/ttnn/unit_tests/operations/test_depthwise_conv1d.py
@@ -1,0 +1,226 @@
+# SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+
+# SPDX-License-Identifier: Apache-2.0
+
+from loguru import logger
+
+import torch
+import pytest
+from models.utility_functions import (
+    skip_for_wormhole_b0,
+    skip_for_grayskull,
+    is_grayskull,
+    is_wormhole_b0,
+    is_x2_harvested,
+)
+from tests.ttnn.utils_for_testing import assert_with_pcc, check_with_pcc, check_with_pcc_without_tensor_printout
+import ttnn
+import tt_lib
+import math
+import os
+import torch.nn as nn
+
+
+def run_conv(
+    device,
+    math_fidelity,
+    activations_dtype,
+    weights_dtype,
+    batch_size,
+    output_channels,
+    input_channels,
+    input_height,
+    input_width,
+    filter_height,
+    filter_width,
+    stride_h,
+    stride_w,
+    pad_h,
+    pad_w,
+    use_1d_systolic_array,
+    config_override,
+    use_shallow_conv_variant=False,
+    transpose_mcast=True,
+    enable_auto_formatting=False,
+    padded_input_channels=None,
+    fp32_accum=False,
+    packer_l1_acc=False,
+    output_layout=ttnn.TILE_LAYOUT,
+    deallocate_activation=False,
+    debug=False,
+    groups=1,
+):
+    has_bias = False
+    assert has_bias == False, "Bias is not supported in this test"
+    assert (
+        input_width == 1 and filter_width == 1
+    ), "Input and kernel width must be 1, only 1D convolutions are supported in this test"
+    assert (
+        groups == input_channels
+    ), "Groups must be equal to input channels, only depthwise separable convolutions are supported in this test"
+
+    torch.manual_seed(0)
+    conv_input_shape = [batch_size, input_channels, input_height, input_width]
+    conv_weight_shape = [output_channels, input_channels, filter_height, filter_width]
+    conv_bias_shape = [1, 1, 1, output_channels]
+    torch_input_tensor_nchw = torch.randn(conv_input_shape, dtype=torch.bfloat16).float()
+    torch_input_tensor = torch.permute(torch_input_tensor_nchw, (0, 2, 3, 1))
+    torch_weight_tensor = torch.randn(conv_weight_shape, dtype=torch.bfloat16).float()
+    torch_depthwise_weight_tensor = torch.permute(torch_weight_tensor, (1, 0, 2, 3))
+    torch_bias_tensor = torch.randn(conv_bias_shape, dtype=torch.bfloat16).float() if has_bias else None
+    torch_out_golden_tensor = torch.nn.functional.conv2d(
+        torch_input_tensor_nchw,
+        torch_depthwise_weight_tensor,
+        bias=torch_bias_tensor.reshape(-1) if has_bias else None,
+        stride=(stride_h, stride_w),
+        padding=(pad_h, pad_w),
+        groups=groups,
+    )
+    output_shape_nhwc = [
+        torch_out_golden_tensor.shape[0],
+        torch_out_golden_tensor.shape[2],
+        torch_out_golden_tensor.shape[3],
+        torch_out_golden_tensor.shape[1],
+    ]
+
+    reader_patterns_cache = {}
+
+    torch_weight_tensor = torch_weight_tensor.repeat(32, 1, 1, 1)
+    tt_weight_tensor = ttnn.from_torch(
+        torch_weight_tensor, weights_dtype if weights_dtype != ttnn.bfloat8_b else ttnn.float32
+    )
+    tt_bias_tensor = None
+    if has_bias:
+        tt_bias_tensor = ttnn.from_torch(
+            torch_bias_tensor, weights_dtype if weights_dtype != ttnn.bfloat8_b else ttnn.float32
+        )
+
+    tt_input_tensor = ttnn.from_torch(torch_input_tensor, ttnn.bfloat16)
+
+    conv_config = ttnn.DepthwiseConv1dConfig(
+        dtype=weights_dtype,
+        weights_dtype=weights_dtype,
+        math_fidelity=math_fidelity,
+        height_sharding=use_1d_systolic_array,
+        input_channels_alignment=(16 if use_shallow_conv_variant else 32),
+        deallocate_activation=deallocate_activation,
+    )
+    if config_override and "act_block_h" in config_override:
+        conv_config.act_block_h_override = config_override["act_block_h"]
+        print("Setting Act Block H to ", conv_config.act_block_h_override)
+
+    [tt_output_tensor_on_device, out_height, out_width, weights_device, bias_device] = ttnn.depthwise_conv1d(
+        input_tensor=tt_input_tensor,
+        weight_tensor=tt_weight_tensor,
+        in_channels=input_channels,
+        out_channels=output_channels,
+        device=device,
+        bias_tensor=tt_bias_tensor,
+        kernel_size=(filter_height, filter_width),
+        stride=(stride_h, stride_w),
+        padding=(pad_h, pad_w),
+        batch_size=batch_size,
+        input_height=input_height,
+        input_width=input_width,
+        conv_config=conv_config,
+        conv_op_cache=reader_patterns_cache,
+        debug=debug,
+        groups=groups,
+    )
+
+    tt_output_tensor = ttnn.from_device(tt_output_tensor_on_device)
+    torch_output_tensor = ttnn.to_torch(tt_output_tensor)
+
+    # torch_output_tensor is in row major layout and NHWC shape
+    # NHWC to NCHW
+    torch_output_tensor = torch_output_tensor.reshape(batch_size, out_height, out_width, input_channels)
+
+    torch_output_tensor = torch.permute(torch_output_tensor, (0, 3, 1, 2))
+    reader_patterns_cache.clear()
+
+    if not fp32_accum:
+        pcc = 0.995
+    elif math_fidelity == ttnn.MathFidelity.LoFi and activations_dtype == ttnn.bfloat8_b:
+        pcc = 0.9969
+    else:
+        pcc = 0.998
+    passing, pcc_msg = check_with_pcc_without_tensor_printout(torch_output_tensor, torch_out_golden_tensor, pcc=pcc)
+    print(pcc_msg)
+    assert passing
+
+
+@skip_for_grayskull()
+@pytest.mark.parametrize("device_params", [{"l1_small_size": 16384}], indirect=True)
+@pytest.mark.parametrize(
+    "batch_size, output_channels, input_channels, input_height, input_width, filter_height, filter_width, stride_h, stride_w, pad_h, pad_w, groups, use_1d_systolic_array, config_override",
+    (
+        (1, 1, 32, 1024, 1, 4, 1, 1, 1, 3, 0, 32, True, None),
+        (1, 1, 512, 1024, 1, 4, 1, 1, 1, 3, 0, 512, True, None),
+        (1, 1, 2560, 1760, 1, 4, 1, 1, 1, 3, 0, 2560, True, None),
+        (1, 1, 5120, 1760, 1, 4, 1, 1, 1, 3, 0, 5120, True, None),
+    ),
+)
+@pytest.mark.parametrize(
+    "weights_dtype",
+    [ttnn.bfloat8_b],
+)
+@pytest.mark.parametrize(
+    "activations_dtype",
+    [ttnn.bfloat16],
+)
+@pytest.mark.parametrize(
+    "fp32_accum",
+    [
+        True,
+    ],
+)
+@pytest.mark.parametrize("math_fidelity", [ttnn.MathFidelity.LoFi])
+@pytest.mark.parametrize("enable_auto_formatting", [True])
+def test_mamba_conv_wh(
+    device,
+    use_program_cache,
+    math_fidelity,
+    activations_dtype,
+    weights_dtype,
+    fp32_accum,
+    batch_size,
+    output_channels,
+    input_channels,
+    input_height,
+    input_width,
+    filter_height,
+    filter_width,
+    stride_h,
+    stride_w,
+    pad_h,
+    pad_w,
+    groups,
+    use_1d_systolic_array,
+    config_override,
+    enable_auto_formatting,
+):
+    run_conv(
+        device,
+        math_fidelity,
+        activations_dtype,
+        weights_dtype,
+        batch_size,
+        output_channels,
+        input_channels,
+        input_height,
+        input_width,
+        filter_height,
+        filter_width,
+        stride_h,
+        stride_w,
+        pad_h,
+        pad_w,
+        use_1d_systolic_array,
+        config_override,
+        use_shallow_conv_variant=False,
+        transpose_mcast=use_1d_systolic_array,  ## use RM (transpose_mcast=False) with 2D on WH
+        enable_auto_formatting=enable_auto_formatting,
+        padded_input_channels=None,
+        fp32_accum=fp32_accum,
+        groups=groups,
+    )

--- a/tt_eager/tt_dnn/op_library/CMakeLists.txt
+++ b/tt_eager/tt_dnn/op_library/CMakeLists.txt
@@ -69,6 +69,8 @@ set(TT_DNN_SRCS
     ${CMAKE_CURRENT_SOURCE_DIR}/conv/multi_core_optimized_conv/optimized_conv_op.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/conv/multi_core_optimized_conv_sharded/optimized_conv_op_sharded.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/conv/multi_core_optimized_conv_sharded/optimized_conv_op_sharded_v2.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/depthwise_conv1d/optimized_depthwise_conv_op.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/depthwise_conv1d/multi_core_optimized_depthwise_conv_sharded/optimized_depthwise_conv_op_sharded.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/tilize/tilize_multi_core/tilize_op_multi_core.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/tilize/tilize_single_core/tilize_op_single_core.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/tilize/tilize_op.cpp

--- a/tt_eager/tt_dnn/op_library/depthwise_conv1d/kernels/conv_bmm_tilize_col_major_out_blocks.cpp
+++ b/tt_eager/tt_dnn/op_library/depthwise_conv1d/kernels/conv_bmm_tilize_col_major_out_blocks.cpp
@@ -1,0 +1,168 @@
+// SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <cstdint>
+
+#include "mod_div_lib.h"
+#include "compute_kernel_api/tilize.h"
+#include "compute_kernel_api/pack_untilize.h"
+#include "compute_kernel_api/tile_move_copy.h"
+#include "compute_kernel_api/matmul.h"
+#include "debug/dprint.h"
+#include "compute_kernel_api/transpose_wh.h"
+
+#ifdef FUSE_BIAS
+#include "compute_kernel_api/bcast.h"
+#endif
+
+#include "compute_kernel_api/eltwise_unary/sfpu_split_includes.h"
+#include "compute_kernel_api/eltwise_binary.h"
+
+#define DEBUG_PRINT 0
+
+ALWI void ACQ() { acquire_dst(tt::DstMode::Half); }
+ALWI void REL() { release_dst(tt::DstMode::Half); }
+
+inline void tilize_in(
+    uint32_t in_cb_id,
+    uint32_t in_subblock_h,
+    uint32_t in_block_w,
+    uint32_t in_num_subblocks,
+    uint32_t out_cb_id
+) {
+    tilize_init_short(in_cb_id, in_block_w);
+    for (uint32_t in_subblock = 0; in_subblock < in_num_subblocks; ++in_subblock) {
+        for (uint32_t h = 0; h < in_subblock_h; ++h) {
+            cb_wait_front(in_cb_id, in_block_w);
+            cb_reserve_back(out_cb_id, in_block_w);
+            tilize_block(in_cb_id, in_block_w, out_cb_id);
+            cb_push_back(out_cb_id, in_block_w);
+            cb_pop_front(in_cb_id, in_block_w);
+        }
+    }
+    tilize_uninit(in_cb_id);
+}
+
+inline void eltwise_mul_and_add_block_v2(uint32_t in0_cb_id, uint32_t in1_cb_id, uint32_t eltwise_mul_partials_cb_cb_id, uint32_t transpose_cb_id, uint32_t temp_sum_cb, uint32_t out_cb_id, uint32_t block_num_tiles, uint32_t idx, uint32_t total_blocks) {
+    uint32_t last_block_idx = total_blocks - 1;
+    for(uint32_t i=0; i<block_num_tiles; i++) {
+        cb_wait_front(in1_cb_id, 1);
+        cb_reserve_back(transpose_cb_id, 1);
+        transpose_wh_init_short(in1_cb_id);
+        ACQ();
+        transpose_wh_tile(in1_cb_id, 0, 0);
+        pack_tile(0, transpose_cb_id);
+        REL();
+        cb_push_back(transpose_cb_id, 1);
+        cb_pop_front(in1_cb_id, 1);
+        cb_wait_front(transpose_cb_id, 1);
+        cb_wait_front(in0_cb_id, 1);
+        cb_reserve_back(eltwise_mul_partials_cb_cb_id, 1);
+        mul_tiles_init(in0_cb_id, transpose_cb_id);
+        ACQ();
+        mul_tiles(in0_cb_id, transpose_cb_id, 0, 0, 0);
+        pack_tile(0, eltwise_mul_partials_cb_cb_id);
+        REL();
+        cb_push_back(eltwise_mul_partials_cb_cb_id, 1);
+        cb_pop_front(in0_cb_id, 1);
+        cb_pop_front(transpose_cb_id, 1);
+        if(idx==0){
+            copy_tile_to_dst_init_short();
+            ACQ();
+            cb_wait_front(eltwise_mul_partials_cb_cb_id, 1);
+            cb_reserve_back(out_cb_id, 1);
+            copy_tile(eltwise_mul_partials_cb_cb_id, 0, 0);
+            pack_tile(0, out_cb_id);
+            REL();
+            cb_push_back(out_cb_id, 1);
+            cb_pop_front(eltwise_mul_partials_cb_cb_id, 1);
+        }
+        else{
+
+            add_tiles_init();
+            cb_wait_front(eltwise_mul_partials_cb_cb_id, 1);
+            cb_wait_front(out_cb_id, 1);
+            ACQ();
+            add_tiles(eltwise_mul_partials_cb_cb_id, out_cb_id, 0, 0, 0);
+            pack_tile(0, temp_sum_cb);
+            REL();
+            cb_push_back(temp_sum_cb, 1);
+            cb_pop_front(eltwise_mul_partials_cb_cb_id, 1);
+            cb_pop_front(out_cb_id, 1);
+
+            copy_tile_to_dst_init_short();
+            ACQ();
+            cb_wait_front(temp_sum_cb, 1);
+            cb_reserve_back(out_cb_id, 1);
+            copy_tile(temp_sum_cb, 0, 0);
+            pack_tile(0, out_cb_id);
+            REL();
+            cb_push_back(out_cb_id, 1);
+            cb_pop_front(temp_sum_cb, 1);
+        }
+    }
+}
+
+namespace NAMESPACE {
+void MAIN {
+
+    constexpr uint32_t in0_block_w            = get_compile_time_arg_val(0); // inner block size in tiles
+    constexpr uint32_t in0_num_subblocks      = get_compile_time_arg_val(1); // outer row block size (in inner row blocks)
+    constexpr uint32_t in0_block_num_tiles    = get_compile_time_arg_val(2); // out_subblock_h*in0_block_w*in0_num_subblocks;
+    constexpr uint32_t in0_subblock_num_tiles = get_compile_time_arg_val(3);  // out_subblock_h*in0_block_w
+    constexpr uint32_t in0_subblock_h         = get_compile_time_arg_val(4);
+    constexpr uint32_t in1_num_subblocks      = get_compile_time_arg_val(5); // outer column block size (in inner column blocks)
+    constexpr uint32_t in1_block_num_tiles    = get_compile_time_arg_val(6); //out_subblock_w*in0_block_w* in1_num_subblocks;
+    constexpr uint32_t in1_block_w            = get_compile_time_arg_val(7); // out_subblock_w*in1_num_subblocks
+    // if these are not defined as volatile, it causes code size for TRISC2 to be too large if num_blocks > 1
+    constexpr uint32_t in0_num_blocks_h       = get_compile_time_arg_val(8);
+    constexpr uint32_t in0_num_blocks_w       = get_compile_time_arg_val(9);
+    constexpr uint32_t in1_num_blocks_w       = get_compile_time_arg_val(10);
+    constexpr uint32_t out_subblock_h         = get_compile_time_arg_val(11); // inner row block size in tiles
+    constexpr uint32_t out_subblock_w         = get_compile_time_arg_val(12); // inner column block size in tiles
+    constexpr uint32_t out_subblock_num_tiles = get_compile_time_arg_val(13); // out_subblock_h * out_subblock_w;
+    constexpr bool tilize_in0                 = get_compile_time_arg_val(14);
+    constexpr bool untilize_out               = get_compile_time_arg_val(15);
+
+    constexpr uint32_t out_block_num_tiles    = in0_num_subblocks * in1_num_subblocks * out_subblock_num_tiles;
+    constexpr uint32_t out_block_w = in1_block_w;
+
+    // CB indices
+    constexpr uint32_t in0_cb_id                                = tt::CB::c_in0;
+    constexpr uint32_t in1_cb_id                                = tt::CB::c_in1;
+    constexpr uint32_t in0_pretilize_cb_id                      = tt::CB::c_in6;
+    constexpr uint32_t in0_cb_second_reader_id                  = tt::CB::c_in7;
+    constexpr uint32_t eltwise_mul_partials_cb                     = tt::CB::c_intermed0;
+    constexpr uint32_t tilized_in0_cb_id                        = tt::CB::c_intermed1;
+    constexpr uint32_t temp_sum_cb                              = tt::CB::c_intermed3;
+    constexpr uint32_t transpose_cb                             = tt::CB::c_intermed4;
+    constexpr uint32_t prev_eltwise_cb                          = tt::CB::c_intermed5;
+    constexpr uint32_t out_cb_id                                = tt::CB::c_out0;
+
+    constexpr uint32_t in0_num_subblocks_read = in0_num_subblocks;
+
+    constexpr uint32_t num_blocks = in0_num_blocks_w; // num_tokens window
+
+    binary_op_init_common(in0_cb_id, in1_cb_id, out_cb_id);
+
+    for(uint32_t in1_block_w_i = 0; in1_block_w_i < in1_num_blocks_w; ++in1_block_w_i) {
+
+        for(uint32_t in0_block_h_i = 0; in0_block_h_i < in0_num_blocks_h; ++in0_block_h_i) {
+
+            for(uint32_t i=0; i < num_blocks; i++) {
+                if constexpr (tilize_in0) {
+                    unpack_reconfig_data_format_srca(in0_cb_id);
+                    pack_reconfig_data_format(tilized_in0_cb_id);
+                    tilize_in(in0_cb_id, in0_subblock_h, in0_block_w, in0_num_subblocks_read, tilized_in0_cb_id);
+                }
+                unpack_reconfig_data_format_srca(tilized_in0_cb_id);
+                pack_reconfig_data_format(transpose_cb);
+                eltwise_mul_and_add_block_v2(tilized_in0_cb_id, in1_cb_id, eltwise_mul_partials_cb, transpose_cb, temp_sum_cb, out_cb_id, in0_block_num_tiles, i, num_blocks);
+
+            }
+
+        } // for in0_num_blocks_h
+    } // for in1_num_blocks_w
+} // MAIN
+} // NAMESPACE

--- a/tt_eager/tt_dnn/op_library/depthwise_conv1d/kernels/reader_conv_activations_padded_with_halo_3x3_weights_v2.cpp
+++ b/tt_eager/tt_dnn/op_library/depthwise_conv1d/kernels/reader_conv_activations_padded_with_halo_3x3_weights_v2.cpp
@@ -1,0 +1,224 @@
+// SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <stdint.h>
+#include "dataflow_api.h"
+#include "firmware_common.h"
+#include "debug/dprint.h"
+
+// conv1D reader kernel
+void kernel_main() {
+    constexpr uint32_t LOCAL_PACKED_READER_INDICES_MAX_SIZE = 128;
+    uint32_t local_packed_reader_indices[LOCAL_PACKED_READER_INDICES_MAX_SIZE];
+
+    constexpr bool act_in_dram = get_compile_time_arg_val(0) == 1;
+    constexpr uint32_t stride_h = get_compile_time_arg_val(1);
+    constexpr uint32_t stride_w = get_compile_time_arg_val(2);
+    constexpr uint32_t conv_act_size_w_ = get_compile_time_arg_val(3);
+    constexpr uint32_t conv_output_w_last_index = get_compile_time_arg_val(4) - 1;
+    constexpr uint32_t conv_act_c_read_bytes = get_compile_time_arg_val(5);
+    // need to have these as compile-time, they are inner loop bouds / unroll loops / constexpr conditionals based on them
+    constexpr uint32_t window_outer = get_compile_time_arg_val(6);
+    constexpr uint32_t window_inner = get_compile_time_arg_val(7);
+    constexpr uint32_t act_block_h_datums = get_compile_time_arg_val(8);
+    constexpr uint32_t act_block_num_tiles = get_compile_time_arg_val(9);
+    constexpr uint32_t weight_size_w = get_compile_time_arg_val(10);
+    constexpr uint32_t conv_act_size_w_padded = get_compile_time_arg_val(11);
+    constexpr uint32_t act_block_w_extra_align_bytes = get_compile_time_arg_val(12);
+    constexpr uint32_t weight_size_h= get_compile_time_arg_val(13);
+    constexpr uint32_t act_num_blocks_h = get_compile_time_arg_val(14);
+
+    uint32_t i = 0;
+    uint32_t noop = get_arg_val<uint32_t>(i); i+=1;
+
+    if(noop) {
+        return;
+    }
+
+    constexpr uint32_t cb_id_act = 0;
+    constexpr uint32_t cb_id_sharded_act = 3;
+
+    // LOOP TO FILL READER OFFSETS
+    /* We can add another loop to read chunks of a stick as well.
+     * - Duplicate reader_offset for same stick X times (window_inner must be 1)
+     * - New loop between outer and inner that loops X times reading from same stick
+     * - Read conv_act_c_read_bytes / X each time
+     * - Update l1_write_addr_act by conv_act_c_read_bytes
+     */
+    uint32_t reader_offsets[weight_size_w*weight_size_h];
+    uint32_t reader_offset = 0; // Constant offset for each pixel within filter window
+    uint32_t reader_offset_idx = 0;
+    for (uint32_t channel_stick_h = 0; channel_stick_h < weight_size_h; channel_stick_h++) {
+        uint32_t reader_offset_row = reader_offset;
+        for (uint32_t channel_stick_w = 0; channel_stick_w < weight_size_w; channel_stick_w++) {
+            reader_offsets[reader_offset_idx++] = reader_offset_row++;
+        }
+        // -1 to go back to previous reader_offset
+        reader_offset += conv_act_size_w_padded;
+    }
+
+    #ifdef SPLIT_READER
+    constexpr uint32_t act_block_h_datums_read = act_block_h_datums / 4; // Extra /2 because of packed uint16 reads
+    constexpr uint32_t act_block_num_tiles_read = act_block_num_tiles / 2;
+    #else
+    constexpr uint32_t act_block_h_datums_read = act_block_h_datums / 2; // packed uint16 reads
+    constexpr uint32_t act_block_num_tiles_read = act_block_num_tiles;
+    #endif
+
+    // LOOP TO FILL READER INDICES
+    constexpr uint32_t cb_reader_indices = tt::CB::c_in4;
+    volatile tt_l1_ptr uint32_t* packed_reader_indices_ptr = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(get_write_ptr(cb_reader_indices));
+
+    uint32_t reader_idx = 0;
+
+    // Copy packed reader indices to local memory for faster access
+    constexpr bool cache_packed_reader_indices = act_block_h_datums_read <= LOCAL_PACKED_READER_INDICES_MAX_SIZE;
+
+    // TODO: need to make the read coalescing optimization cleaner
+    // pass coalesce_window_inner_reads as a compile time arg and num_coalesced_reads so we can constexpr the if
+    // currently works for the case of num_coalesced_reads == weight_size_w since these reads are contiguous on both src/dst side
+    // we check if window_inner == weight_size_w to make sure coalescing is legal along full window_inner so the loop can be removed
+    constexpr bool coalesce_window_inner_reads = true;
+    constexpr uint32_t num_coalesced_reads = weight_size_w;
+    constexpr uint32_t coalesced_read_bytes = num_coalesced_reads * conv_act_c_read_bytes;
+    // the conditional selecting between coalescing and no-colescing must be constexpr to that compiler can optimized the other path away
+    // this has shown to be a big perf win
+    static_assert(act_block_h_datums % 2 == 0); // need to be even to read 2 in the body, due to packing of 2 indices in 1 uint32_t word
+    if constexpr (coalesce_window_inner_reads and window_inner == num_coalesced_reads) {
+        // coalesce reads along weight_size_w
+        reader_offset_idx = 0;
+        uint32_t act_l1_offset = 0;
+        uint32_t act_l1_read_addr = get_read_ptr(cb_id_sharded_act);
+
+        //static_assert(coalesced_read_bytes <= NOC_MAX_BURST_SIZE);
+        // set_state uses just x/y from the get_noc_addr, addr is ignored
+        noc_async_read_one_packet_set_state(get_noc_addr(act_l1_read_addr), coalesced_read_bytes);
+        uint32_t start_reader_idx = 0;
+        for (uint32_t bh = 0; bh < act_num_blocks_h; bh++) {
+            #ifdef SPLIT_READER
+            if constexpr (cache_packed_reader_indices) {
+                for (uint32_t i = 0; i < act_block_h_datums_read; i++) {
+                    local_packed_reader_indices[i] = packed_reader_indices_ptr[start_reader_idx+i];
+                }
+            }
+            #endif
+            for (uint32_t outer = 0; outer < window_outer; outer++) {
+                // Reset reader_idx to finish act_block_h_datums
+                reader_idx = start_reader_idx;
+
+                cb_reserve_back(cb_id_act, act_block_num_tiles_read);
+                uint32_t l1_write_addr_act = get_write_ptr(cb_id_act);
+                uint32_t reader_offset = act_l1_read_addr + (reader_offsets[reader_offset_idx] * conv_act_c_read_bytes);
+                // #pragma GCC unroll 4 // unroll didn't help, but act_block_h_datums (loop bound) being const does help
+                for (uint32_t bhd = 0; bhd < act_block_h_datums_read; bhd++) {
+                    // local read from reader_index + reader_offset;
+                    #ifdef SPLIT_READER
+                    uint32_t two_reader_indices = cache_packed_reader_indices ? local_packed_reader_indices[bhd] : packed_reader_indices_ptr[reader_idx];
+                    #else // no split reader
+                    uint32_t two_reader_indices = packed_reader_indices_ptr[reader_idx];
+                    #endif
+                    uint32_t reader_idx_1 = two_reader_indices & 0xffff;
+                    uint32_t reader_idx_2 = two_reader_indices >> 16;
+
+                    act_l1_offset = reader_offset + (reader_idx_1 * conv_act_c_read_bytes);
+                    // noc_async_read_one_packet_with_state<true>(act_l1_offset, l1_write_addr_act);
+                    noc_async_read(get_noc_addr(act_l1_offset), l1_write_addr_act, coalesced_read_bytes);
+                    l1_write_addr_act += (coalesced_read_bytes + act_block_w_extra_align_bytes);
+
+                    act_l1_offset = reader_offset + (reader_idx_2 * conv_act_c_read_bytes);
+                    // noc_async_read_one_packet_with_state<true>(act_l1_offset, l1_write_addr_act);
+                    noc_async_read(get_noc_addr(act_l1_offset), l1_write_addr_act, coalesced_read_bytes);
+                    l1_write_addr_act += (coalesced_read_bytes + act_block_w_extra_align_bytes);
+
+                    reader_idx++;
+                }
+                noc_async_read_barrier();
+                cb_push_back(cb_id_act, act_block_num_tiles_read);
+
+                reader_offset_idx += window_inner;
+            }
+            reader_offset_idx = 0;
+
+            start_reader_idx = reader_idx;
+            #ifdef SPLIT_READER
+            start_reader_idx += act_block_h_datums_read;
+            #endif
+        }
+
+    } else {
+        // NOTE: This code block expects reader_indices_ptr to be uint32_t (not packed uint16_t)
+        // Inner window dim is usually 3, so reading packed indices is complicated
+        // TODO: We could probably just remove this block is no convs use it
+
+        // no coalescing of reads
+        reader_offset_idx = 0;
+        uint32_t act_l1_offset = 0;
+        uint32_t act_l1_read_addr = get_read_ptr(cb_id_sharded_act);
+
+        //static_assert(conv_act_c_read_bytes <= NOC_MAX_BURST_SIZE);
+        // set_state uses just x/y from the get_noc_addr, addr is ignored
+        noc_async_read_one_packet_set_state(get_noc_addr(act_l1_read_addr), conv_act_c_read_bytes);
+
+        uint32_t start_reader_idx = 0;
+        for (uint32_t bh = 0; bh < act_num_blocks_h; bh++) {
+            // Reset reader_idx to finish act_block_h_datums
+            reader_idx = start_reader_idx;
+            cb_reserve_back(cb_id_act, act_block_num_tiles);
+            uint32_t l1_write_addr_act = get_write_ptr(cb_id_act);
+            for (uint32_t bhd = 0; bhd < act_block_h_datums; bhd++) {
+                // when no read coalesing, main use case is window_inner == 1,
+                // and if window_inner is const this loop should be removed by the compiler
+                #ifdef SPLIT_READER
+                uint32_t packed_reader_idx = packed_reader_indices_ptr[reader_idx];
+                if constexpr (cache_packed_reader_indices) {
+                    local_packed_reader_indices[bhd] = packed_reader_idx;
+                }
+                #else
+                uint32_t packed_reader_idx = packed_reader_indices_ptr[reader_idx];
+                #endif
+                for (uint32_t inner = 0; inner < window_inner; inner++) {
+                    // local read from reader_index + reader_offset;
+                    act_l1_offset = act_l1_read_addr + ((packed_reader_idx + reader_offsets[reader_offset_idx + inner]) * conv_act_c_read_bytes);
+                    noc_async_read_one_packet_with_state<true>(act_l1_offset, l1_write_addr_act);
+                    l1_write_addr_act += conv_act_c_read_bytes;
+
+                }
+                reader_idx++;
+            }
+            noc_async_read_barrier();
+            cb_push_back(cb_id_act, act_block_num_tiles);
+
+            reader_offset_idx += 3*window_inner;
+            for (uint32_t outer = 1; outer < window_outer; outer++) {
+                // Reset reader_idx to finish act_block_h_datums
+                reader_idx = start_reader_idx;
+                cb_reserve_back(cb_id_act, act_block_num_tiles);
+                uint32_t l1_write_addr_act = get_write_ptr(cb_id_act);
+                for (uint32_t bhd = 0; bhd < act_block_h_datums; bhd++) {
+                    // when no read coalesing, main use case is window_inner == 1,
+                    // and if window_inner is const this loop should be removed by the compiler
+                    #ifdef SPLIT_READER
+                    uint32_t packed_reader_idx = cache_packed_reader_indices ? local_packed_reader_indices[bhd] : packed_reader_indices_ptr[reader_idx];
+                    #else
+                    uint32_t packed_reader_idx = packed_reader_indices_ptr[reader_idx];
+                    #endif
+                    for (uint32_t inner = 0; inner < window_inner; inner++) {
+                        // local read from reader_index + reader_offset;
+                        act_l1_offset = act_l1_read_addr + ((packed_reader_idx + reader_offsets[reader_offset_idx + inner]) * conv_act_c_read_bytes);
+                        noc_async_read_one_packet_with_state<true>(act_l1_offset, l1_write_addr_act);
+                        l1_write_addr_act += conv_act_c_read_bytes;
+
+                    }
+                    reader_idx++;
+                }
+                noc_async_read_barrier();
+                cb_push_back(cb_id_act, act_block_num_tiles);
+
+                reader_offset_idx += 3*window_inner;
+            }
+            reader_offset_idx = 0;
+            start_reader_idx = reader_idx;
+        }
+    }
+}

--- a/tt_eager/tt_dnn/op_library/depthwise_conv1d/kernels/writer_tiled_out_1d_mcast_receiver_conv_weights_tiled_col_to_rm_blocks.cpp
+++ b/tt_eager/tt_dnn/op_library/depthwise_conv1d/kernels/writer_tiled_out_1d_mcast_receiver_conv_weights_tiled_col_to_rm_blocks.cpp
@@ -1,0 +1,217 @@
+// SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "dataflow_api.h"
+
+#include "debug/dprint.h"
+
+
+void kernel_main() {
+    // This writer is for output tensor in tile format
+    constexpr bool out_in_dram = get_compile_time_arg_val(0) == 1;
+    constexpr uint32_t cb_id_out0 = get_compile_time_arg_val(1);
+    constexpr uint32_t cb_id_weight = get_compile_time_arg_val(2);
+
+    constexpr uint32_t num_blocks_weight_h = get_compile_time_arg_val(5);
+    constexpr uint32_t weight_block_num_tiles = get_compile_time_arg_val(6);
+    constexpr uint32_t weight_block_height_num_outer = get_compile_time_arg_val(7);
+    constexpr uint32_t weight_block_height_ntiles = get_compile_time_arg_val(8);
+    constexpr uint32_t weight_block_width_ntiles = get_compile_time_arg_val(9);
+    constexpr uint32_t weight_stride_h = get_compile_time_arg_val(10);
+    constexpr uint32_t weight_next_block_stride_h = get_compile_time_arg_val(11);
+    constexpr uint32_t weight_next_block_stride_w = get_compile_time_arg_val(12);
+
+    // Bias arg. Unused if bias fusion is not enabled.
+    constexpr uint32_t bias_ntiles = get_compile_time_arg_val(13);
+
+    constexpr uint32_t out_next_tile_stride_h = get_compile_time_arg_val(14);
+    constexpr uint32_t out_next_tile_stride_w = get_compile_time_arg_val(15);
+    constexpr uint32_t out_next_subblock_stride_h = get_compile_time_arg_val(16);
+    constexpr uint32_t out_next_subblock_stride_w = get_compile_time_arg_val(17);
+    constexpr uint32_t out_next_block_stride_h = get_compile_time_arg_val(18);
+    constexpr uint32_t out_next_block_stride_w = get_compile_time_arg_val(12); // == weight_next_block_stride_w
+    constexpr uint32_t out_subblock_h = get_compile_time_arg_val(19);
+    constexpr uint32_t out_subblock_w = get_compile_time_arg_val(20);
+    constexpr uint32_t out_subblock_tile_count = get_compile_time_arg_val(21);
+    constexpr uint32_t out_num_subblocks_h = get_compile_time_arg_val(22);
+    constexpr uint32_t out_num_subblocks_w = get_compile_time_arg_val(23);
+    constexpr uint32_t out_num_blocks_h = get_compile_time_arg_val(24);
+    constexpr uint32_t out_num_blocks_w = get_compile_time_arg_val(25);
+    constexpr uint32_t out_block_height_num_tiles = get_compile_time_arg_val(26);
+    constexpr uint32_t out_height_num_tiles = get_compile_time_arg_val(27);
+    constexpr uint32_t out_width_num_tiles = get_compile_time_arg_val(28);
+
+    constexpr uint32_t out_addr = get_compile_time_arg_val(29);
+
+    constexpr uint32_t total_weight_num_tiles = weight_block_height_num_outer * num_blocks_weight_h * weight_block_num_tiles;
+
+    uint32_t i = 0;
+    i+=19;
+    uint32_t out_start_tile_id = get_arg_val<uint32_t>(i); i+=1;
+    uint32_t out_start_tile_id_h = get_arg_val<uint32_t>(i); i+=1;
+    uint32_t out_start_tile_id_w = get_arg_val<uint32_t>(i); i+=1;
+    i+=10;
+    uint32_t noop = get_arg_val<uint32_t>(i); i+=1;
+    if(noop) {
+        return;
+    }
+
+    // mcast args
+    uint32_t weights_mcast_sender_noc_x           = get_arg_val<uint32_t>(i); i+=1;
+    uint32_t weights_mcast_sender_noc_y           = get_arg_val<uint32_t>(i); i+=1;
+    uint32_t weights_mcast_sender_semaphore_addr    = get_arg_val<uint32_t>(i); i+=1;
+    uint32_t weights_mcast_receiver_semaphore_addr  = get_arg_val<uint32_t>(i); i+=1;
+
+    volatile tt_l1_ptr uint32_t* weights_mcast_receiver_semaphore_addr_ptr = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(weights_mcast_receiver_semaphore_addr);
+
+    const uint32_t tile_nbytes = get_tile_size(cb_id_out0);
+    const DataFormat out_df = get_dataformat(cb_id_out0);
+
+    const InterleavedAddrGenFast<out_in_dram> s = {
+        .bank_base_address = out_addr,
+        .page_size = tile_nbytes,
+        .data_format = out_df
+    };
+
+    // read in bias if enabled (done only once for all batches)
+    #ifdef FUSE_BIAS
+    constexpr uint32_t bias_cb_id = get_compile_time_arg_val(3);
+    bool load_bias = true;
+    #endif
+
+    // DPRINT << "tile_nbytes - " << tile_nbytes << ENDL();
+    // DPRINT << "out_num_blocks_h - " << out_num_blocks_h << ENDL();
+    // DPRINT << "out_num_blocks_w - " << out_num_blocks_w << ENDL();
+
+    // DPRINT << "out_num_subblocks_h - " << out_num_subblocks_h << ENDL();
+    // DPRINT << "out_num_subblocks_w - " << out_num_subblocks_w << ENDL();
+
+    // DPRINT << "out_subblock_h - " << out_subblock_h << ENDL();
+    // DPRINT << "out_subblock_w - " << out_subblock_w << ENDL();
+
+    // DPRINT << "out_subblock_tile_count - " << out_subblock_tile_count << ENDL();
+
+    // DPRINT << "num_blocks_weight_h - " << num_blocks_weight_h << ENDL();
+    // DPRINT << "weight_block_height_ntiles - " << weight_block_height_ntiles << ENDL();
+    // DPRINT << "weight_block_width_ntiles - " << weight_block_width_ntiles << ENDL();
+
+    // DPRINT << "out_subblock_h - " << out_subblock_h << ENDL();
+    // DPRINT << "out_subblock_w - " << out_subblock_w << ENDL();
+    // DPRINT << "out_block_height_num_tiles - " << out_block_height_num_tiles << ENDL();
+    // DPRINT << "out_height_num_tiles - " << out_height_num_tiles << ENDL();
+    // DPRINT << "out_width_num_tiles - " << out_width_num_tiles << ENDL();
+
+    // OUTER most loop is looping over out blocks in width dim because blocks from compute are in col major order.
+    // Write out col major blocks in row major layout to output
+    uint32_t out_block_w_start_tile_id = out_start_tile_id;
+    //DPRINT << "out_start_tile_id=" << out_start_tile_id << ENDL();
+    uint32_t out_block_w_start_tile_id_w = out_start_tile_id_w;
+    uint32_t weight_start_tile_id = out_start_tile_id_w;
+    //DPRINT << "weight_start_tile_id=" << weight_start_tile_id << ENDL();
+    for (uint32_t bw = 0; bw < out_num_blocks_w; bw++) {
+        uint32_t out_block_h_start_tile_id = out_block_w_start_tile_id;
+        uint32_t out_block_h_start_tile_id_h = out_start_tile_id_h;
+        bool read_weights = true;
+        for(uint32_t bh = 0; bh < out_num_blocks_h; bh++) {
+            if (read_weights) {
+                // MCAST RECEIVE WEIGHTS
+                // read weight blocks inner dim
+                // read weight slice - 1 block of weights in width dim and full weight matrix height
+                // read slice only once for all activation blocks
+                for(uint32_t weight_tile_h_outer_i = 0; weight_tile_h_outer_i < weight_block_height_num_outer; weight_tile_h_outer_i++) {
+                    for(uint32_t block_weight_h = 0; block_weight_h < num_blocks_weight_h; block_weight_h++) {
+                        cb_reserve_back(cb_id_weight, weight_block_num_tiles);
+                        // Set weights semaphore value to INVALID
+                        noc_semaphore_set(weights_mcast_receiver_semaphore_addr_ptr, INVALID);
+
+                        // Atomic increment source core counter
+                        uint64_t weights_mcast_sender_semaphore_noc_addr = get_noc_addr(weights_mcast_sender_noc_x, weights_mcast_sender_noc_y, weights_mcast_sender_semaphore_addr);
+                        noc_semaphore_inc(weights_mcast_sender_semaphore_noc_addr, 1);
+
+                        // wait on weights semaphore value to become VALID (set by mcast sender after it multicasts data)
+                        noc_semaphore_wait(weights_mcast_receiver_semaphore_addr_ptr, VALID);
+
+                        cb_push_back(cb_id_weight, weight_block_num_tiles);
+                    } // for num_blocks_weight_h
+                } // for weight_block_height_num_outer
+
+                #ifdef FUSE_BIAS
+                if (load_bias) {
+                    cb_reserve_back(bias_cb_id, bias_ntiles);
+
+                    // Set weights semaphore value to INVALID
+                    noc_semaphore_set(weights_mcast_receiver_semaphore_addr_ptr, INVALID);
+
+                    // Atomic increment source core counter
+                    uint64_t weights_mcast_sender_semaphore_noc_addr = get_noc_addr(weights_mcast_sender_noc_x, weights_mcast_sender_noc_y, weights_mcast_sender_semaphore_addr);
+                    noc_semaphore_inc(weights_mcast_sender_semaphore_noc_addr, 1);
+
+                    // wait on weights semaphore value to become VALID (set by mcast sender after it multicasts data)
+                    noc_semaphore_wait(weights_mcast_receiver_semaphore_addr_ptr, VALID);
+
+                    cb_push_back(bias_cb_id, bias_ntiles);
+                    load_bias = false;
+                }
+                #endif
+                read_weights = true;
+            } else {
+                cb_reserve_back(cb_id_weight, total_weight_num_tiles);
+                cb_push_back(cb_id_weight, total_weight_num_tiles);
+            }
+            #ifndef SHARDED_OUT
+            uint32_t out_sbh_start_tile_id = out_block_h_start_tile_id;
+            uint32_t out_sbh_start_tile_id_h = out_block_h_start_tile_id_h; //
+            for(uint32_t sbh = 0; sbh < out_num_subblocks_h; sbh++) {
+                uint32_t out_sbw_start_tile_id = out_sbh_start_tile_id;
+                uint32_t out_sbw_start_tile_id_w = out_block_w_start_tile_id_w;
+                for(uint32_t sbw = 0; sbw < out_num_subblocks_w; sbw++) {
+                    uint32_t out_sb_row_start_tile_id = out_sbw_start_tile_id;
+                    // wait for one subblock worth tiles
+                    cb_wait_front(cb_id_out0, out_subblock_tile_count);
+                    uint32_t l1_read_addr = get_read_ptr(cb_id_out0);
+                    for(uint32_t h = 0; h < out_subblock_h; h++) {
+                        uint32_t out_tile_id = out_sb_row_start_tile_id;
+                        uint32_t out_tile_id_h = out_sbh_start_tile_id_h + h;
+                        if (out_tile_id_h >= out_height_num_tiles) { // block shape height padding
+                            break;
+                        }
+                        for(uint32_t w = 0; w < out_subblock_w; w++) {
+                            uint32_t out_tile_id_w = out_sbw_start_tile_id_w + w;
+                            if (out_tile_id_w >= out_width_num_tiles) { // block shape width padding
+                                l1_read_addr += tile_nbytes;
+                            } else {
+                                //DPRINT << "out_tile_id - " << out_tile_id << ENDL();
+                                uint64_t out_tile_noc_addr = get_noc_addr(out_tile_id, s);
+                                //DPRINT << "out_tile_id=" << out_tile_id << ENDL();
+                                noc_async_write(l1_read_addr, out_tile_noc_addr, tile_nbytes);
+                                l1_read_addr += tile_nbytes;
+                                out_tile_id += out_next_tile_stride_w;
+                            }
+                        } // out_subblock_w (ntiles)
+                        out_sb_row_start_tile_id += out_next_tile_stride_h;
+                    } // out_subblock_h (ntiles)
+                    noc_async_write_barrier();
+                    //DPRINT << "Done writing subblock." << ENDL();
+                    cb_pop_front(cb_id_out0, out_subblock_tile_count);
+                    out_sbw_start_tile_id += out_next_subblock_stride_w;
+                    out_sbw_start_tile_id_w += out_subblock_w;
+                } // out_num_subblocks_w
+                out_sbh_start_tile_id += out_next_subblock_stride_h;
+                out_sbh_start_tile_id_h += out_subblock_h;
+            } // out_num_subblocks_h
+            out_block_h_start_tile_id += out_next_block_stride_h;
+            out_block_h_start_tile_id_h += out_block_height_num_tiles;
+            #endif
+        } // out_num_blocks_h
+        out_block_w_start_tile_id += out_next_block_stride_w;
+        out_block_w_start_tile_id_w += weight_block_width_ntiles;
+
+        // Increment weight start tile id for next block in width dim
+        weight_start_tile_id += weight_next_block_stride_w;
+    } // out_num_blocks_w
+
+    #ifdef SHARDED_OUT
+    cb_wait_front(cb_id_out0, out_subblock_tile_count * out_num_subblocks_h * out_num_subblocks_w * out_num_blocks_w * out_num_blocks_h);
+    #endif
+}

--- a/tt_eager/tt_dnn/op_library/depthwise_conv1d/kernels/writer_tiled_out_1d_mcast_sender_conv_weights_tiled_col_to_rm_blocks.cpp
+++ b/tt_eager/tt_dnn/op_library/depthwise_conv1d/kernels/writer_tiled_out_1d_mcast_sender_conv_weights_tiled_col_to_rm_blocks.cpp
@@ -1,0 +1,225 @@
+// SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "dataflow_api.h"
+
+#include "debug/dprint.h"
+
+
+void kernel_main() {
+    // This writer is for output tensor in tile format
+    constexpr bool out_in_dram = get_compile_time_arg_val(0) == 1;
+    constexpr uint32_t cb_id_out0 = get_compile_time_arg_val(1);
+    constexpr uint32_t cb_id_weight = get_compile_time_arg_val(2);
+
+    constexpr uint32_t num_blocks_weight_h = get_compile_time_arg_val(5);
+    constexpr uint32_t weight_block_num_tiles = get_compile_time_arg_val(6);
+    constexpr uint32_t weight_block_height_num_outer = get_compile_time_arg_val(7);
+    constexpr uint32_t weight_block_height_ntiles = get_compile_time_arg_val(8);
+    constexpr uint32_t weight_block_width_ntiles = get_compile_time_arg_val(9);
+    constexpr uint32_t weight_stride_h = get_compile_time_arg_val(10);
+    constexpr uint32_t weight_next_block_stride_h = get_compile_time_arg_val(11);
+    constexpr uint32_t weight_next_block_stride_w = get_compile_time_arg_val(12);
+
+    // Bias arg. Unused if bias fusion is not enabled.
+    constexpr uint32_t bias_ntiles = get_compile_time_arg_val(13);
+
+    constexpr uint32_t out_next_tile_stride_h = get_compile_time_arg_val(14);
+    constexpr uint32_t out_next_tile_stride_w = get_compile_time_arg_val(15);
+    constexpr uint32_t out_next_subblock_stride_h = get_compile_time_arg_val(16);
+    constexpr uint32_t out_next_subblock_stride_w = get_compile_time_arg_val(17);
+    constexpr uint32_t out_next_block_stride_h = get_compile_time_arg_val(18);
+    constexpr uint32_t out_next_block_stride_w = get_compile_time_arg_val(12); // == weight_next_block_stride_w
+    constexpr uint32_t out_subblock_h = get_compile_time_arg_val(19);
+    constexpr uint32_t out_subblock_w = get_compile_time_arg_val(20);
+    constexpr uint32_t out_subblock_tile_count = get_compile_time_arg_val(21);
+    constexpr uint32_t out_num_subblocks_h = get_compile_time_arg_val(22);
+    constexpr uint32_t out_num_subblocks_w = get_compile_time_arg_val(23);
+    constexpr uint32_t out_num_blocks_h = get_compile_time_arg_val(24);
+    constexpr uint32_t out_num_blocks_w = get_compile_time_arg_val(25);
+    constexpr uint32_t out_block_height_num_tiles = get_compile_time_arg_val(26);
+    constexpr uint32_t out_height_num_tiles = get_compile_time_arg_val(27);
+    constexpr uint32_t out_width_num_tiles = get_compile_time_arg_val(28);
+
+    constexpr uint32_t out_addr = get_compile_time_arg_val(29);
+
+    constexpr uint32_t total_weight_num_tiles = weight_block_height_num_outer * num_blocks_weight_h * weight_block_num_tiles;
+
+    uint32_t i = 0;
+    i+=1;
+    const uint32_t weight_addr_dram_base = get_arg_val<uint32_t>(i); i+=1;
+    // Bias arg. Unused if bias fusion is not enabled.
+    const uint32_t bias_addr = get_arg_val<uint32_t>(i); i += 1;
+    i+=16;
+    uint32_t out_start_tile_id = get_arg_val<uint32_t>(i); i+=1;
+    uint32_t out_start_tile_id_h = get_arg_val<uint32_t>(i); i+=1;
+    uint32_t out_start_tile_id_w = get_arg_val<uint32_t>(i); i+=1;
+    i+=9;
+    const uint32_t bias_tile_offset = get_arg_val<uint32_t>(i); i += 1;
+
+    uint32_t noop = get_arg_val<uint32_t>(i); i+=1;
+    if(noop) {
+        return;
+    }
+
+    // mcast args
+    uint32_t weights_mcast_dest_noc_start_x         = get_arg_val<uint32_t>(i); i+=1;
+    uint32_t weights_mcast_dest_noc_start_y         = get_arg_val<uint32_t>(i); i+=1;
+    uint32_t weights_mcast_dest_noc_end_x           = get_arg_val<uint32_t>(i); i+=1;
+    uint32_t weights_mcast_dest_noc_end_y           = get_arg_val<uint32_t>(i); i+=1;
+    uint32_t weights_mcast_num_dests                = get_arg_val<uint32_t>(i); i+=1;
+    uint32_t weights_mcast_num_cores                = get_arg_val<uint32_t>(i); i+=1;
+    uint32_t weights_mcast_sender_semaphore_addr    = get_arg_val<uint32_t>(i); i+=1;
+    uint32_t weights_mcast_receiver_semaphore_addr  = get_arg_val<uint32_t>(i); i+=1;
+
+    #ifndef SKIP_MCAST
+    // Set ur local VALID value, to be mcasted to destinations flag address after the data has been mcasted
+    volatile tt_l1_ptr uint32_t* weights_mcast_receiver_semaphore_addr_ptr = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(weights_mcast_receiver_semaphore_addr);
+    *(weights_mcast_receiver_semaphore_addr_ptr) = VALID;
+    // local address that will be atomically incremented by mcast receivers, to know when all receivers are ready
+    // to receive the mcast
+    volatile tt_l1_ptr uint32_t* weights_mcast_sender_semaphore_addr_ptr = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(weights_mcast_sender_semaphore_addr);
+
+    uint64_t weights_mcast_receiver_semaphore_noc_addr = get_noc_multicast_addr(
+    weights_mcast_dest_noc_start_x,
+    weights_mcast_dest_noc_start_y,
+    weights_mcast_dest_noc_end_x,
+    weights_mcast_dest_noc_end_y,
+    weights_mcast_receiver_semaphore_addr);
+    #endif
+
+    const uint32_t tile_nbytes = get_tile_size(cb_id_out0);
+    const DataFormat out_df = get_dataformat(cb_id_out0);
+
+    const InterleavedAddrGenFast<out_in_dram> s = {
+        .bank_base_address = out_addr,
+        .page_size = tile_nbytes,
+        .data_format = out_df
+    };
+
+    // read in bias if enabled (done only once for all batches)
+
+    // DPRINT << "tile_nbytes - " << tile_nbytes << ENDL();
+
+
+    // DPRINT << "out_num_subblocks_h - " << out_num_subblocks_h << ENDL();
+    // DPRINT << "out_num_subblocks_w - " << out_num_subblocks_w << ENDL();
+
+    // DPRINT << "out_subblock_h - " << out_subblock_h << ENDL();
+    // DPRINT << "out_subblock_w - " << out_subblock_w << ENDL();
+
+    // DPRINT << "out_subblock_tile_count - " << out_subblock_tile_count << ENDL();
+
+    // DPRINT << "num_blocks_weight_h - " << num_blocks_weight_h << ENDL();
+    // DPRINT << "weight_block_height_ntiles - " << weight_block_height_ntiles << ENDL();
+    // DPRINT << "weight_block_width_ntiles - " << weight_block_width_ntiles << ENDL();
+
+    // DPRINT << "out_subblock_h - " << out_subblock_h << ENDL();
+    // DPRINT << "out_subblock_w - " << out_subblock_w << ENDL();
+    // DPRINT << "out_block_height_num_tiles - " << out_block_height_num_tiles << ENDL();
+    // DPRINT << "out_height_num_tiles - " << out_height_num_tiles << ENDL();
+    // DPRINT << "out_width_num_tiles - " << out_width_num_tiles << ENDL();
+
+    const uint32_t weight_tile_nbytes = get_tile_size(cb_id_weight);
+    const DataFormat weight_df = get_dataformat(cb_id_weight);
+    const InterleavedAddrGenFast<true> s_weight = {
+        .bank_base_address = weight_addr_dram_base,
+        .page_size = weight_tile_nbytes,
+        .data_format = weight_df
+    };
+
+    // OUTER most loop is looping over out blocks in width dim because blocks from compute are in col major order.
+    // Write out col major blocks in row major layout to output
+    uint32_t out_block_w_start_tile_id = out_start_tile_id;
+    //DPRINT << "out_start_tile_id=" << out_start_tile_id << ENDL();
+    uint32_t out_block_w_start_tile_id_w = out_start_tile_id_w;
+    uint32_t weight_start_tile_id = out_start_tile_id_w;
+    uint32_t weight_inner_block_stride_h = weight_next_block_stride_h / weight_block_height_num_outer; // TODO: Pass as args
+    //DPRINT << "weight_start_tile_id=" << weight_start_tile_id << ENDL();
+    for (uint32_t bw = 0; bw < out_num_blocks_w; bw++) {
+        uint32_t out_block_h_start_tile_id = out_block_w_start_tile_id;
+        uint32_t out_block_h_start_tile_id_h = out_start_tile_id_h;
+        bool read_weights = true;
+        for(uint32_t bh = 0; bh < out_num_blocks_h; bh++) {
+            // READ WEIGHTS + MCAST SEND WEIGHTS
+            // read weight blocks inner dim
+            // read weight slice - 1 block of weights in width dim and full weight matrix height
+            // read slice only once for all activation blocks
+            if (read_weights) {
+                uint32_t weight_h_offset = 0;
+                for(uint32_t weight_tile_h_outer_i = 0; weight_tile_h_outer_i < weight_block_height_num_outer; weight_tile_h_outer_i++) {
+                    uint32_t weight_current_block_start_tile_id = weight_start_tile_id;
+                    for(uint32_t block_weight_h = 0; block_weight_h < num_blocks_weight_h; block_weight_h++) {
+                        cb_reserve_back(cb_id_weight, weight_block_num_tiles);
+                        uint32_t weight_write_l1_addr = get_write_ptr(cb_id_weight);
+                        uint32_t weight_row_start_tile_id = weight_current_block_start_tile_id + weight_h_offset;
+
+                        // mcast args
+                        uint32_t weights_start_address = weight_write_l1_addr;
+                        uint32_t weights_block_size_bytes = 0;
+
+                        // loop over weight block tiles along h
+                        for(uint32_t weight_tile_h_i = 0; weight_tile_h_i < weight_block_height_ntiles; ++weight_tile_h_i) {
+                            uint32_t weight_tile_id = weight_row_start_tile_id;
+                            // loop over weight block tiles along w
+                            for(uint32_t weight_tile_w_i = 0; weight_tile_w_i < weight_block_width_ntiles; ++weight_tile_w_i) {
+                                //DPRINT << "weight_tile_id=" << weight_tile_id << ENDL();
+                                s_weight.noc_async_read_tile(weight_tile_id, weight_write_l1_addr);
+                                weight_write_l1_addr += weight_tile_nbytes;
+                                weights_block_size_bytes += weight_tile_nbytes;
+                                weight_tile_id += 1;
+                            } // for weight_block_w
+                            weight_row_start_tile_id += weight_stride_h;
+                        } // for weight_block_h
+                        noc_async_read_barrier();
+
+                        #ifndef SKIP_MCAST
+                        // wait until all weights mcast destinations have atomically incremented the weights semaphore_addr (i.e. its value should be weights_mcast_num_dests), then reset
+                        // the semaphore_addr value back to zero for the next block
+                        noc_semaphore_wait(weights_mcast_sender_semaphore_addr_ptr, weights_mcast_num_dests);
+                        noc_semaphore_set(weights_mcast_sender_semaphore_addr_ptr, 0);
+
+                        // Now we have the block in the CB address, we can mcast to dests!
+                        uint64_t weights_multicast_data_addr = get_noc_multicast_addr(
+                        weights_mcast_dest_noc_start_x,
+                        weights_mcast_dest_noc_start_y,
+                        weights_mcast_dest_noc_end_x,
+                        weights_mcast_dest_noc_end_y,
+                        weights_start_address);
+                        // num_dests must not include source, since we are NOT really doing a local copy!
+                        noc_async_write_multicast(weights_start_address, weights_multicast_data_addr, weights_block_size_bytes, weights_mcast_num_cores, false, false);
+
+                        // Note: no need for write barrier, since these two multicasts are done on the same noc id, same vc, same cmd_buf
+                        // Also, this only works because we are setting VCs statically (using NOC_CMD_STATIC_VC).
+
+                        // We should also multicast the flag to destinations
+                        // num_dests must not include source, since we are NOT really doing a local copy!
+                        noc_semaphore_set_multicast(weights_mcast_receiver_semaphore_addr, weights_mcast_receiver_semaphore_noc_addr, weights_mcast_num_cores, false, false);
+                        #endif
+
+                        weight_current_block_start_tile_id += weight_next_block_stride_h;
+
+                        cb_push_back(cb_id_weight, weight_block_num_tiles);
+                    } // for num_blocks_weight_h
+                    weight_h_offset += weight_inner_block_stride_h;
+                } // for weight_block_height_num_outer
+
+                read_weights = true;
+            } else {
+                cb_reserve_back(cb_id_weight, total_weight_num_tiles);
+                cb_push_back(cb_id_weight, total_weight_num_tiles);
+            }
+        } // out_num_blocks_h
+        out_block_w_start_tile_id += out_next_block_stride_w;
+        out_block_w_start_tile_id_w += weight_block_width_ntiles;
+
+        // Increment weight start tile id for next block in width dim
+        weight_start_tile_id += weight_next_block_stride_w;
+    } // out_num_blocks_w
+    #ifdef SHARDED_OUT
+    //cb_wait_front(cb_id_out0, out_subblock_tile_count * out_num_subblocks_h * out_num_subblocks_w * out_num_blocks_w * out_num_blocks_h);
+    //DPRINT << "cb_wait_front(cb_id_out0, " << out_subblock_tile_count << " * " << out_num_subblocks_h << " * " << out_num_subblocks_w << " * " << out_num_blocks_w << " * " << out_num_blocks_h << ")" << ENDL();
+    cb_wait_front(cb_id_out0, weight_block_num_tiles);
+    #endif
+}

--- a/tt_eager/tt_dnn/op_library/depthwise_conv1d/multi_core_optimized_depthwise_conv_sharded/optimized_depthwise_conv_op_sharded.cpp
+++ b/tt_eager/tt_dnn/op_library/depthwise_conv1d/multi_core_optimized_depthwise_conv_sharded/optimized_depthwise_conv_op_sharded.cpp
@@ -1,0 +1,1503 @@
+// SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "tensor/tensor_utils.hpp"
+#include "tt_dnn/op_library/auto_format.hpp"
+#include "tt_dnn/op_library/depthwise_conv1d/optimized_depthwise_conv_op.hpp"
+#include "tt_dnn/op_library/eltwise_unary/eltwise_unary_op.hpp"
+#include "tt_dnn/op_library/sharding_utilities.hpp"
+#include "tt_dnn/op_library/sliding_window_op_infra/sliding_window.hpp"
+#include "tt_dnn/op_library/work_split.hpp"
+#include "tt_metal/common/constants.hpp"
+#include "tt_metal/detail/tt_metal.hpp"
+#include "tt_metal/detail/util.hpp"
+#include "tt_metal/host_api.hpp"
+#include "tt_stl/reflection.hpp"
+
+using namespace tt::constants;
+
+namespace tt {
+
+namespace tt_metal {
+
+const uint32_t act_cb = CB::c_in0;
+const uint32_t weight_cb = CB::c_in1;
+const uint32_t bias_cb = CB::c_in2;
+const uint32_t sharded_act_cb = CB::c_in3;
+const uint32_t cb_for_reader_indices = CB::c_in4;
+const uint32_t cb_for_l1_array = CB::c_in5;
+const uint32_t act_cb_row_major_bfloat16 = CB::c_in6;
+const uint32_t act_cb_second_reader = CB::c_in7;
+const uint32_t matmul_partials_cb = CB::c_intermed0;
+const uint32_t tilize_mode_tilized_act_cb = CB::c_intermed1;
+const uint32_t untilize_mode_reblock_cb = CB::c_intermed2;
+const uint32_t out0_cb = CB::c_out0;
+const uint32_t temp_sum_cb                            = CB::c_intermed3;
+const uint32_t transpose_cb                           = CB::c_intermed4;
+
+// TODO: Add namespace for utilities?
+tuple<CBHandle, CBHandle> create_CBs_for_depthwise_sharded_input(
+    tt_metal::Program& program,
+    const Tensor& input,
+    CoreRange core,
+    uint32_t num_cb0_tiles,
+    uint32_t num_cb1_tiles,
+    uint32_t num_cb0_tilized_tiles,
+    uint32_t num_output_tiles,
+    uint32_t num_reblock_cb_tiles,
+    uint32_t num_writer_output_tiles,
+    bool untilize_out,
+    DataFormat act_df,
+    DataFormat weight_df,
+    DataFormat tilized_act_df,
+    DataFormat out_df,
+    DataFormat bias_df,
+    bool weight_width_sliced,
+    const Tensor& output,
+    uint32_t bias_ntiles,
+    bool with_bias,
+    bool split_reader,
+    bool fp32_dest_acc_en,
+    bool packer_l1_acc_en) {
+    tt::DataFormat interm0_df =
+        packer_l1_acc_en ? (fp32_dest_acc_en ? tt::DataFormat::Float32 : tt::DataFormat::Float16_b) : out_df;
+
+    uint32_t act_tile_size = tt_metal::detail::TileSize(act_df);
+    uint32_t weight_tile_size = tt_metal::detail::TileSize(weight_df);
+    uint32_t tilized_act_tile_size = tt_metal::detail::TileSize(tilized_act_df);
+    uint32_t out_tile_size = tt_metal::detail::TileSize(out_df);
+    uint32_t interm0_single_tile_size = tt_metal::detail::TileSize(interm0_df);
+
+    CBHandle cb_sharded_act = 0;
+    if (input.memory_config().is_sharded()) {
+        uint32_t num_bytes_for_df = datum_size(act_df);
+        auto shard_shape = input.shard_spec().value().shape;
+        // 2D-sys-conv already has uint16_t indicies, TODO: do the same for 1D-sys-conv
+        TT_ASSERT(
+            shard_shape[0] <= (1 << 16), "Shard height must be less than 2^16, read pattern indicies are uint16_t");
+        CircularBufferConfig cb_sharded_act_config =
+            CircularBufferConfig(shard_shape[0] * shard_shape[1] * num_bytes_for_df, {{sharded_act_cb, act_df}})
+                .set_page_size(sharded_act_cb, shard_shape[1] * num_bytes_for_df);
+        // incoming data is the input cb instead of raw l1/dram addr
+        cb_sharded_act_config.set_globally_allocated_address(*input.buffer());
+        cb_sharded_act = tt_metal::CreateCircularBuffer(program, core, cb_sharded_act_config);
+
+        if (weight_width_sliced) {
+            // For 2D convs, each core creates and tilizes full input matrix then mcasts round robin style
+            // Each core receives input into act_cb, so won't need a separate cb to receive
+            // However, we need a separate cb to push ROW_MAJOR BFLOAT16 data for tilizing and configure act cb to be
+            // output df
+
+            // num_cb0_tiles is double buffered
+            CircularBufferConfig cb_act_config =
+                CircularBufferConfig(num_cb0_tiles * tilized_act_tile_size, {{act_cb, tilized_act_df}})
+                    .set_page_size(act_cb, tilized_act_tile_size);
+            auto cb_act = tt_metal::CreateCircularBuffer(program, core, cb_act_config);
+
+            // num_cb0_tilized_tiles is single buffered
+            CircularBufferConfig cb_act_row_major_bfloat16_config =
+                CircularBufferConfig(num_cb0_tilized_tiles * act_tile_size, {{act_cb_row_major_bfloat16, act_df}})
+                    .set_page_size(act_cb_row_major_bfloat16, act_tile_size);
+            auto cb_act_row_major_bfloat16 =
+                tt_metal::CreateCircularBuffer(program, core, cb_act_row_major_bfloat16_config);
+        } else {
+            // For 1D convs, locally create act matrix in act_cb, which is always ROW_MAJOR BFLOAT16
+            // Then, tilize input in compute
+
+            // Extra cb for second reader if we split act reads across two RISCs
+            // In this case, the regular reader only does first half of reads along output block h
+            if (split_reader) {
+                num_cb0_tiles /= 2;
+
+                CircularBufferConfig cb_act_config =
+                    CircularBufferConfig(num_cb0_tiles * act_tile_size, {{act_cb_second_reader, act_df}})
+                        .set_page_size(act_cb_second_reader, act_tile_size);
+                auto cb_act = tt_metal::CreateCircularBuffer(program, core, cb_act_config);
+            }
+
+            CircularBufferConfig cb_act_config = CircularBufferConfig(num_cb0_tiles * act_tile_size, {{act_cb, act_df}})
+                                                     .set_page_size(act_cb, act_tile_size);
+            auto cb_act = tt_metal::CreateCircularBuffer(program, core, cb_act_config);
+        }
+    } else {
+        TT_ASSERT(false, "Input must be sharded!");
+    }
+
+    CircularBufferConfig cb_weight_config =
+        CircularBufferConfig(num_cb1_tiles * weight_tile_size, {{weight_cb, weight_df}})
+            .set_page_size(weight_cb, weight_tile_size);
+    auto cb_weight = tt_metal::CreateCircularBuffer(program, core, cb_weight_config);
+
+    // Used for placing tilized activations
+    CircularBufferConfig cb_src0_tilized_config =
+        CircularBufferConfig(
+            num_cb0_tilized_tiles * tilized_act_tile_size, {{tilize_mode_tilized_act_cb, tilized_act_df}})
+            .set_page_size(tilize_mode_tilized_act_cb, tilized_act_tile_size);
+    auto cb_src0_tilized = tt_metal::CreateCircularBuffer(program, core, cb_src0_tilized_config);
+
+    CBHandle cb_output = 0;
+    if (untilize_out) {
+        CircularBufferConfig cb_matmul_partials_config =
+            CircularBufferConfig(num_output_tiles * interm0_single_tile_size, {{matmul_partials_cb, interm0_df}})
+                .set_page_size(matmul_partials_cb, interm0_single_tile_size);
+        auto cb_matmul_partials = tt_metal::CreateCircularBuffer(program, core, cb_matmul_partials_config);
+
+        // Supposed to be a small CB only responsible for reorganizing
+        // the output blocks to fill the whole "per core output block width"
+        CircularBufferConfig cb_reblock_config =
+            CircularBufferConfig(num_reblock_cb_tiles * out_tile_size, {{untilize_mode_reblock_cb, out_df}})
+                .set_page_size(untilize_mode_reblock_cb, out_tile_size);
+        auto cb_reblock = tt_metal::CreateCircularBuffer(program, core, cb_reblock_config);
+
+        CircularBufferConfig cb_output_config =
+            CircularBufferConfig(num_writer_output_tiles * out_tile_size, {{out0_cb, out_df}})
+                .set_page_size(out0_cb, out_tile_size);
+        if (output.is_sharded()) {
+            cb_output_config = cb_output_config.set_globally_allocated_address(*output.buffer());
+        }
+        cb_output = tt_metal::CreateCircularBuffer(program, core, cb_output_config);
+    } else {
+        // Share buffer if same data format
+        if (interm0_df == out_df) {
+            CoreRangeSet cores(std::set<CoreRange>({core}));
+
+            // breakdown above as separate CBs
+            CircularBufferConfig cb_matmul_partials_config = CircularBufferConfig(1 * out_tile_size, {{matmul_partials_cb, out_df}})
+                .set_page_size(matmul_partials_cb, out_tile_size);
+            auto cb_matmul_partials = tt_metal::CreateCircularBuffer(program, core, cb_matmul_partials_config);
+
+            CircularBufferConfig cb_temp_sum_config = CircularBufferConfig(1 * out_tile_size, {{temp_sum_cb, out_df}})
+                .set_page_size(temp_sum_cb, out_tile_size);
+            auto cb_temp_sum = tt_metal::CreateCircularBuffer(program, core, cb_temp_sum_config);
+
+            CircularBufferConfig cb_transpose_config = CircularBufferConfig(1 * out_tile_size, {{transpose_cb, out_df}})
+                .set_page_size(transpose_cb, out_tile_size);
+            auto cb_transpose = tt_metal::CreateCircularBuffer(program, core, cb_transpose_config);
+
+            std::map<uint8_t, tt::DataFormat> cb_output_data_format_spec = {
+                {out0_cb, out_df}
+            };
+            CircularBufferConfig cb_output_config = CircularBufferConfig(num_output_tiles * out_tile_size, cb_output_data_format_spec)
+                .set_page_size(out0_cb, out_tile_size);
+
+            if (output.is_sharded()) {
+                cb_output_config = cb_output_config.set_globally_allocated_address(*output.buffer());
+            }
+            cb_output = tt_metal::CreateCircularBuffer(program, cores, cb_output_config);
+
+        } else {
+            // Separate buffer if not same data format
+            CircularBufferConfig cb_matmul_partials_config =
+                CircularBufferConfig(num_output_tiles * interm0_single_tile_size, {{matmul_partials_cb, interm0_df}})
+                    .set_page_size(matmul_partials_cb, interm0_single_tile_size);
+            auto cb_matmul_partials = tt_metal::CreateCircularBuffer(program, core, cb_matmul_partials_config);
+
+            CircularBufferConfig cb_output_config =
+                CircularBufferConfig(num_output_tiles * out_tile_size, {{out0_cb, out_df}})
+                    .set_page_size(out0_cb, out_tile_size);
+            if (output.is_sharded()) {
+                cb_output_config = cb_output_config.set_globally_allocated_address(*output.buffer());
+            }
+            cb_output = tt_metal::CreateCircularBuffer(program, core, cb_output_config);
+        }
+    }
+
+    if (with_bias) {
+        uint32_t bias_tile_size = tt_metal::detail::TileSize(bias_df);
+        // bias input
+        uint32_t bias_pagesize = bias_tile_size;
+        CircularBufferConfig cb_bias_config = CircularBufferConfig(bias_ntiles * bias_pagesize, {{bias_cb, bias_df}})
+                                                  .set_page_size(bias_cb, bias_pagesize);
+        auto cb_bias = tt_metal::CreateCircularBuffer(program, core, cb_bias_config);
+
+        log_debug(LogOp, "Bias CB: {}, npages: {}, pagesize: {}", bias_cb, bias_ntiles, bias_pagesize);
+    }
+
+    return {cb_sharded_act, cb_output};
+}
+
+operation::ProgramWithCallbacks multi_core_optimized_depthwise_conv_sharded_v2_impl(
+    tt_metal::Program& program,
+    const Tensor& a,
+    const Tensor& b,
+    const Shape& ashape,
+    std::optional<const Tensor> bias,
+    const std::optional<const Tensor> conv_reader_indices,
+    vector<int> conv_params,
+    uint32_t output_channels,
+    bool untilize_out,
+    bool has_bias,
+    bool fuse_relu,
+    const OptimizedDepthwiseConvParallelizationConfig& parallelization_config,
+    const OptimizedDepthwiseConvBlockConfig& block_config,
+    uint32_t extra_padding_for_32B_alignment,
+    bool use_shallow_conv_variant,
+    bool transpose_mcast,
+    Tensor& output,
+    DeviceComputeKernelConfig compute_kernel_config) {
+    bool pass = true;
+    tt_metal::Device* device = a.device();
+    TT_ASSERT(a.get_layout() == Layout::ROW_MAJOR, "Conv activation should be in row major layout");
+    TT_ASSERT(a.memory_config().is_sharded(), "Conv activation must be sharded.");
+    TT_ASSERT(output_channels <= b.get_legacy_shape()[3], "Invalid weight shape. Incorrect weight tensor.");
+    uint32_t act_block_h_ntiles = block_config.act_block_h_ntiles;
+    uint32_t act_block_w_ntiles = block_config.act_block_w_ntiles;
+    uint32_t weight_block_w_ntiles = parallelization_config.per_core_out_matrix_width_ntiles;
+    uint32_t out_block_h_ntiles = parallelization_config.per_core_out_matrix_height_ntiles;
+    uint32_t out_subblock_h_ntiles = block_config.out_subblock_h_ntiles;
+    uint32_t out_subblock_w_ntiles = block_config.out_subblock_w_ntiles;
+
+    DataFormat act_df = tt_metal::datatype_to_dataformat_converter(a.get_dtype());
+    DataFormat weight_df = tt_metal::datatype_to_dataformat_converter(b.get_dtype());
+    DataFormat out_df = tt_metal::datatype_to_dataformat_converter(output.get_dtype());
+    DataFormat bias_df =
+        has_bias ? tt_metal::datatype_to_dataformat_converter(bias.value().get_dtype()) : DataFormat::Float16_b;
+    DataFormat tilized_act_df = out_df;
+
+    log_debug(LogOp, "act_df: {}", act_df);
+    log_debug(LogOp, "weight_df: {}", weight_df);
+    log_debug(LogOp, "out_df: {}", out_df);
+    log_debug(LogOp, "bias_df: {}", bias_df);
+
+    // compute kernel config
+    MathFidelity math_fidelity;
+    bool math_approx_mode;
+    bool fp32_dest_acc_en;
+    bool packer_l1_acc;
+
+    std::visit(
+        [&](auto&& compute_kernel_config) {
+            using T = std::decay_t<decltype(compute_kernel_config)>;
+            if constexpr (std::is_same_v<T, GrayskullComputeKernelConfig>) {
+                TT_ASSERT(device->arch() == ARCH::GRAYSKULL, "kernel config is not for graykull");
+                math_fidelity = compute_kernel_config.math_fidelity;
+                math_approx_mode = compute_kernel_config.math_approx_mode;
+                fp32_dest_acc_en = false;
+                packer_l1_acc = false;
+            } else if constexpr (std::is_same_v<T, WormholeComputeKernelConfig>) {
+                TT_ASSERT(device->arch() == ARCH::WORMHOLE_B0, "kernel config is not for wormhole_b0");
+                math_fidelity = compute_kernel_config.math_fidelity;
+                math_approx_mode = compute_kernel_config.math_approx_mode;
+                fp32_dest_acc_en = compute_kernel_config.fp32_dest_acc_en;
+                packer_l1_acc = compute_kernel_config.packer_l1_acc;
+            } else {
+                TT_FATAL("arch not supported");
+            }
+        },
+        compute_kernel_config);
+
+    if (fp32_dest_acc_en and (out_subblock_h_ntiles * out_subblock_w_ntiles > 4)) {
+        if (out_subblock_w_ntiles >= 4) {
+            out_subblock_h_ntiles = 1;
+            out_subblock_w_ntiles = find_max_block_size(out_subblock_w_ntiles, 4);
+        } else {
+            while (out_subblock_h_ntiles * out_subblock_w_ntiles > 4) {
+                uint32_t div = find_max_divisor(out_subblock_h_ntiles, out_subblock_h_ntiles - 1);
+                out_subblock_h_ntiles = find_max_block_size(out_subblock_h_ntiles, div);
+            }
+        }
+    }
+    // assert(out_block_h_ntiles == act_block_h_ntiles); // TODO: fix output block sizing
+    TT_ASSERT(
+        out_block_h_ntiles >= act_block_h_ntiles,
+        "Output block height (in # of tiles) should be greater than or equal to activation block height (in # of "
+        "tiles)");
+
+    // Tensor b has weights and it should be tiled layout after converting conv weights into weight matrix
+    TT_ASSERT(b.get_layout() == Layout::TILE, "Conv weights should be in tiled layout");
+    TT_ASSERT(b.get_legacy_shape()[0] == 1, "Conv weight matrix shape is invalid");
+    TT_ASSERT(b.get_legacy_shape()[1] == 1, "Conv weight matrix shape is invalid");
+    uint32_t weight_matrix_height = b.get_legacy_shape()[2];
+    uint32_t weight_matrix_width = b.get_legacy_shape()[3];
+    uint32_t weight_matrix_height_ntiles = weight_matrix_height / TILE_HEIGHT;
+    uint32_t weight_matrix_width_ntiles = weight_matrix_width / TILE_WIDTH;
+
+    // Partitions conv inner dim into blocks to support sharding along this dim
+    // TODO: Only 2D convs with sharded input use this, but we can uplift to support generically
+    // TODO: Only updated variables which is affected, but there may be more that needs to account for this
+    // TODO: Loop naming in reader, writer, and compute kernels could also be cleaned up
+    // TODO: Can conv_act_c_blocks be same as num_blocks_act_w?
+    auto shard_shape = a.shard_spec().value().shape;
+
+    // parallelization config
+    const auto& p_config = parallelization_config;
+    uint32_t num_cores_x = p_config.grid_size.x;
+    uint32_t num_cores_y = p_config.grid_size.y;
+    uint32_t total_num_cores = num_cores_x * num_cores_y;
+    assert(num_cores_x < 13);
+    assert(num_cores_y < 10);
+    uint32_t per_core_out_matrix_height_ntiles = p_config.per_core_out_matrix_height_ntiles;
+    uint32_t per_core_out_matrix_width_ntiles = p_config.per_core_out_matrix_width_ntiles;
+
+    // weight_width_sliced determines is 1d-sysarr-conv or 2d-sysarr-conv
+    bool weight_width_sliced = per_core_out_matrix_width_ntiles < weight_matrix_width_ntiles;
+    uint32_t conv_act_c_blocks = weight_matrix_width_ntiles / per_core_out_matrix_width_ntiles;
+    uint32_t input_channels_padded = 0;
+    if (weight_width_sliced) {
+        if (transpose_mcast) {
+            TT_FATAL(conv_act_c_blocks == num_cores_y, "Expected conv_act_c_blocks to be equal to height of grid");
+            input_channels_padded = shard_shape[1] * num_cores_y;
+        } else {
+            TT_FATAL(conv_act_c_blocks == num_cores_x, "Expected conv_act_c_blocks to be equal to width of grid");
+            input_channels_padded = shard_shape[1] * num_cores_x;
+        }
+    } else {
+        input_channels_padded = shard_shape[1];
+    }
+    TT_FATAL(input_channels_padded >= ashape[3], "Incorrect padding of input channels!");
+    // check is for 16-byte alignment
+    TT_FATAL(
+        input_channels_padded % 16 == 0,
+        "Expected input channels to be padded for 16 byte alignment in L1");  // TODO: For bfp16, check if its divisible
+                                                                              // by 8 not 16.
+    // Always use split reader for first conv in resnet which has input channels = 16
+    // TODO: Expose option to split readers for 1D convs to python?
+    bool split_reader = use_shallow_conv_variant;
+    if (split_reader) {
+        TT_FATAL(
+            block_config.act_block_h_ntiles % block_config.out_subblock_h_ntiles == 0,
+            "Out_block_h must be divisible by out_subblock_h!");
+        TT_FATAL(
+            (block_config.act_block_h_ntiles / block_config.out_subblock_h_ntiles) % 2 == 0,
+            "Number of out_subblock_h must be divisible by 2 for split reader!");
+    }
+    Shape ashape_with_channels_padded = {ashape[0], ashape[1], ashape[2], input_channels_padded};
+    uint32_t conv_act_size_h = ashape_with_channels_padded[1];
+    uint32_t conv_act_size_w = ashape_with_channels_padded[2];
+    uint32_t conv_act_size_c = ashape_with_channels_padded[3];
+    uint32_t weight_size_h = (uint32_t)conv_params[0];  // filter_h
+    uint32_t weight_size_w = (uint32_t)conv_params[1];  // filter_W
+    uint32_t stride_h = (uint32_t)conv_params[2];
+    uint32_t stride_w = (uint32_t)conv_params[3];
+    uint32_t pad_h = (uint32_t)conv_params[4];
+    uint32_t pad_w = (uint32_t)conv_params[5];
+
+    // Compute the 2d matrix shape
+    auto [act_matrix_shape, act_matrix_shape_unpadded] =
+        optimized_depthwise_conv_op_utils::compute_opt_depthwise_conv_activation_as_mm_shape(
+            ashape_with_channels_padded, conv_params, out_block_h_ntiles, extra_padding_for_32B_alignment);
+    assert(act_matrix_shape.size() == 3);
+    assert(act_matrix_shape[0] == 1);
+    uint32_t act_matrix_height = (uint32_t)act_matrix_shape[1];
+    uint32_t act_matrix_width = (uint32_t)act_matrix_shape[2];
+    uint32_t act_matrix_height_unpadded = (uint32_t)act_matrix_shape_unpadded[1];
+    uint32_t act_matrix_width_unpadded = (uint32_t)act_matrix_shape_unpadded[2];
+
+    // TODO: Move all these asserts/checks to validate?
+
+    if (has_bias) {
+        // Tensor bias is of shape {output_channels}
+        TT_ASSERT(bias.has_value());
+        TT_ASSERT(bias.value().buffer() != nullptr);
+        auto bias_shape_without_padding = bias.value().get_legacy_shape().without_padding();
+        TT_ASSERT(bias_shape_without_padding[0] == 1, "Bias should have batch == 1");
+    }
+
+    // Normal matrix shape check
+    TT_ASSERT(act_matrix_width == weight_matrix_height, "The width of tensor a needs to match the height of tensor b");
+
+    // Tile size divisibility checks
+    TT_ASSERT(act_matrix_height % TILE_HEIGHT == 0, "Height of activation matrix needs to be divisible by 32");
+    TT_ASSERT(act_matrix_width % TILE_WIDTH == 0, "Width of activation matrix needs to be divisible by 32");
+    TT_ASSERT(weight_matrix_height % TILE_HEIGHT == 0, "Height of weight matrix needs to be divisible by 32");
+    TT_ASSERT(weight_matrix_width % TILE_WIDTH == 0, "Width of weight matrix needs to be divisible by 32");
+
+    // Device compatibility checks
+    TT_ASSERT(
+        a.storage_type() == StorageType::DEVICE && b.storage_type() == StorageType::DEVICE &&
+        "Operands to large matmul need to be on device!");
+    TT_ASSERT(a.device() == b.device(), "Operands to conv need to be on the same device!");
+    TT_ASSERT(
+        a.buffer() != nullptr && b.buffer() != nullptr, "Operands to conv need to be allocated in buffers on device!");
+    if (has_bias) {
+        TT_ASSERT(bias.value().storage_type() == StorageType::DEVICE, "Bias should be on device");
+        TT_ASSERT(bias.value().device() == a.device(), "Bias should be on the same device as act tensor");
+    }
+
+    // Convert tensor dims to tile dims
+    uint32_t act_matrix_height_ntiles = act_matrix_height / TILE_HEIGHT;
+    uint32_t act_matrix_width_ntiles = act_matrix_width / TILE_WIDTH;
+
+    assert(act_matrix_height_ntiles % act_block_h_ntiles == 0);
+    assert(act_matrix_width_ntiles % act_block_w_ntiles == 0);
+    assert(weight_matrix_width_ntiles % weight_block_w_ntiles == 0);
+    assert(act_matrix_height_ntiles % out_block_h_ntiles == 0);
+
+    uint32_t num_blocks_act_h = act_matrix_height_ntiles / act_block_h_ntiles;
+    uint32_t num_blocks_out_h = act_matrix_height_ntiles / out_block_h_ntiles;
+    uint32_t num_blocks_act_w = act_matrix_width_ntiles / act_block_w_ntiles;
+    uint32_t num_blocks_weight_w = weight_matrix_width_ntiles / weight_block_w_ntiles;
+
+    // act block info
+    uint32_t act_block_w_datums = act_matrix_width / num_blocks_act_w;
+    uint32_t act_block_h_datums = act_matrix_height / num_blocks_act_h;
+    TT_ASSERT(
+        (act_block_w_datums == round_up(conv_act_size_c * weight_size_w, TILE_WIDTH)) ||
+        ((act_block_w_datums <= conv_act_size_c) && (conv_act_size_c % act_block_w_datums == 0)));
+
+    // weight block info
+    uint32_t weight_block_w_datums = weight_matrix_width / num_blocks_weight_w;
+    assert(weight_block_w_ntiles % out_subblock_w_ntiles == 0);
+    uint32_t weight_num_subblocks = weight_block_w_ntiles / out_subblock_w_ntiles;
+    uint32_t weight_block_h_ntiles = act_block_w_ntiles;
+    uint32_t weight_block_num_tiles = weight_block_w_ntiles * weight_block_h_ntiles;
+
+    uint32_t num_groups = num_blocks_act_h * num_blocks_act_w * num_blocks_weight_w;
+    // writer of conv op partially removes padding on the width
+    // it removes the padding done for block width but it doesn't remove padding done for tiled width
+    uint32_t output_channels_padded_to_tile_width = round_up(output_channels, TILE_WIDTH);
+    assert(output_channels_padded_to_tile_width <= weight_matrix_width);
+    uint32_t output_width_num_tiles = output_channels_padded_to_tile_width / TILE_WIDTH;
+    uint32_t num_blocks_output_w =
+        (uint32_t)ceil((double)output_channels_padded_to_tile_width / (double)weight_block_w_datums);
+    uint32_t last_block_width_datums = (output_channels_padded_to_tile_width % weight_block_w_datums == 0)
+                                           ? weight_block_w_datums
+                                           : (output_channels_padded_to_tile_width % weight_block_w_datums);
+    assert(last_block_width_datums % TILE_WIDTH == 0);
+
+    // sanity check
+    assert(num_blocks_output_w == num_blocks_weight_w);
+
+    uint32_t out_block_h_datums = out_block_h_ntiles * TILE_HEIGHT;
+
+    tt_metal::Buffer* src0_dram_buffer = a.buffer();
+    tt_metal::Buffer* src1_dram_buffer = b.buffer();
+
+    tt_metal::Buffer* dst_dram_buffer = output.buffer();
+    TT_ASSERT(dst_dram_buffer != nullptr, "Output buffer should be allocated on device!");
+
+    // out
+    uint32_t out_dram_addr = dst_dram_buffer->address();
+    uint32_t out_subblock_num_tiles = out_subblock_h_ntiles * out_subblock_w_ntiles;
+    TT_ASSERT(out_subblock_num_tiles <= 8, "Need to ensure that matmul partials fit in dst");
+
+    // act
+    uint32_t act_dram_addr = src0_dram_buffer->address();
+    auto act_dram_noc_xy = src0_dram_buffer->noc_coordinates();
+    uint32_t act_noc_x = act_dram_noc_xy.x;
+    uint32_t act_noc_y = act_dram_noc_xy.y;
+
+    assert(act_matrix_width_ntiles % act_block_w_ntiles == 0);
+    assert(act_block_h_ntiles % out_subblock_h_ntiles == 0);
+    assert(out_block_h_ntiles % out_subblock_h_ntiles == 0);
+    uint32_t act_num_subblocks = act_block_h_ntiles / out_subblock_h_ntiles;
+    uint32_t act_block_num_tiles = act_block_h_ntiles * act_block_w_ntiles;
+    uint32_t act_subblock_h_ntiles = out_subblock_h_ntiles;
+    uint32_t act_subblock_num_tiles = act_subblock_h_ntiles * act_block_w_ntiles;
+
+    // weight
+    uint32_t weight_dram_addr = src1_dram_buffer->address();
+
+    // bias
+    Buffer* bias_buffer = nullptr;
+    uint32_t bias_dram_addr = 0;
+    uint32_t bias_ntiles = 0;
+    if (has_bias) {
+        bias_buffer = bias.value().buffer();
+        bias_dram_addr = bias_buffer->address();
+        bias_ntiles =
+            bias.value().get_legacy_shape()[3] / constants::TILE_WIDTH;  // TODO: support non tile multiple sizes
+    }
+
+    auto [conv_output_size_h, conv_output_size_w] = optimized_depthwise_conv_op_utils::compute_opt_depthwise_conv_output_face_shape(
+        conv_act_size_h,
+        conv_act_size_w,
+        weight_size_h,
+        weight_size_w,
+        stride_h,
+        stride_w,
+        pad_h,
+        pad_w,
+        extra_padding_for_32B_alignment);
+
+    std::map<string, string> reader_defines;
+
+    if (act_matrix_height_unpadded < act_matrix_height) {
+        reader_defines["ACT_BLOCK_HEIGHT_PADDING"] = "1";
+    }
+
+    if (conv_act_c_blocks > 1) {
+        reader_defines["ACT_W_OUTER_BLOCKS"] = "1";
+    }
+
+    uint32_t output_height_padded_to_tile_height = round_up(act_matrix_height_unpadded, TILE_HEIGHT);
+    uint32_t output_height_num_tiles = output_height_padded_to_tile_height / TILE_HEIGHT;
+    assert(output_height_num_tiles <= act_matrix_height_ntiles);
+
+    uint32_t src_dram_act_buffer_size_bytes = src0_dram_buffer->size();
+    uint32_t src_dram_weight_buffer_size_bytes = src1_dram_buffer->size();
+    uint32_t dst_l1_act_buffer_size_bytes =
+        out_block_h_ntiles * act_block_w_ntiles * tt::tt_metal::detail::TileSize(act_df);
+    uint32_t dst_l1_weight_buffer_size_bytes =
+        weight_block_h_ntiles * weight_block_w_ntiles * tt::tt_metal::detail::TileSize(weight_df);
+
+    // For debug
+    {
+        log_debug(LogOp, "multi_core_optimized_conv_sharded_v2_");
+        log_debug(LogOp, "conv_act_size_h: {}", conv_act_size_h);
+        log_debug(LogOp, "conv_act_size_w: {}", conv_act_size_w);
+        log_debug(LogOp, "act_matrix_height: {}", act_matrix_height);
+        log_debug(LogOp, "act_matrix_width: {}", act_matrix_width);
+        log_debug(LogOp, "act_matrix_height_unpadded: {}", act_matrix_height_unpadded);
+        log_debug(LogOp, "act_matrix_width_unpadded: {}", act_matrix_width_unpadded);
+        log_debug(LogOp, "act_matrix_height_ntiles: {}", act_matrix_height_ntiles);
+        log_debug(LogOp, "act_matrix_width_ntiles: {}", act_matrix_width_ntiles);
+        log_debug(LogOp, "weight_matrix_width_ntiles: {}", weight_matrix_width_ntiles);
+        log_debug(LogOp, "per_core_out_matrix_height_ntiles: {}", per_core_out_matrix_height_ntiles);
+        log_debug(LogOp, "per_core_out_matrix_width_ntiles: {}", per_core_out_matrix_width_ntiles);
+        log_debug(LogOp, "num_blocks_act_h: {}", num_blocks_act_h);
+        log_debug(LogOp, "num_blocks_act_w: {}", num_blocks_act_w);
+        log_debug(LogOp, "num_blocks_weight_w: {}", num_blocks_weight_w);
+        log_debug(LogOp, "num_blocks_out_h: {}", num_blocks_out_h);
+        log_debug(LogOp, "act_dram_addr: {}", act_dram_addr);
+        log_debug(LogOp, "act_block_h_ntiles: {}", act_block_h_ntiles);
+        log_debug(LogOp, "act_block_h_datums: {}", act_block_h_datums);
+        log_debug(LogOp, "act_block_w_ntiles: {}", act_block_w_ntiles);
+        log_debug(LogOp, "act_block_w_datums: {}", act_block_w_datums);
+        log_debug(LogOp, "out_block_h_ntiles: {}", out_block_h_ntiles);
+        log_debug(LogOp, "act_num_subblocks: {}", act_num_subblocks);
+        log_debug(LogOp, "act_block_num_tiles: {}", act_block_num_tiles);
+        log_debug(LogOp, "act_subblock_h_ntiles: {}", act_subblock_h_ntiles);
+        log_debug(LogOp, "act_subblock_num_tiles: {}", act_subblock_num_tiles);
+        log_debug(LogOp, "out_subblock_num_tiles: {}", out_subblock_num_tiles);
+        log_debug(LogOp, "weight_dram_addr: {}", weight_dram_addr);
+        log_debug(LogOp, "weight_num_subblocks: {}", weight_num_subblocks);
+        log_debug(LogOp, "weight_block_num_tiles: {}", weight_block_num_tiles);
+        log_debug(LogOp, "weight_block_w_ntiles: {}", weight_block_w_ntiles);
+        log_debug(LogOp, "weight_block_h_ntiles: {}", weight_block_h_ntiles);
+        log_debug(LogOp, "has_bias: {}", has_bias);
+        log_debug(LogOp, "bias_dram_addr: {}", bias_dram_addr);
+        log_debug(LogOp, "bias_ntiles: {}", bias_ntiles);
+        log_debug(LogOp, "out_dram_addr: {}", out_dram_addr);
+        log_debug(LogOp, "out_subblock_h_ntiles: {}", out_subblock_h_ntiles);
+        log_debug(LogOp, "out_subblock_w_ntiles: {}", out_subblock_w_ntiles);
+        log_debug(LogOp, "out_subblock_num_tiles: {}", out_subblock_num_tiles);
+        log_debug(LogOp, "num_groups: {}", num_groups);
+        log_debug(LogOp, "math_fidelity: {}", math_fidelity);
+        log_debug(LogOp, "math_approx_mode: {}", math_approx_mode);
+        log_debug(LogOp, "fp32_dest_acc_en: {}", fp32_dest_acc_en);
+        log_debug(LogOp, "packer_l1_acc: {}", packer_l1_acc);
+    }
+
+    uint32_t window_outer;
+    uint32_t window_inner;
+
+    if (weight_width_sliced and weight_size_w == 3) {
+        window_outer = 1;  // window_outer = 1 becasue all of filter window is processed in the inner loop
+        window_inner = 3;  // window_inner = 9 / 3, ie. read 3 width coalesced
+    } else {
+        window_outer = num_blocks_act_w;                                  // window_outer
+        window_inner = weight_size_h * weight_size_w / num_blocks_act_w;  // window_inner
+    }
+
+    reader_defines["WINDOW_INNER"] = std::to_string(window_inner);
+    log_debug(LogOp, "window_outer: {}, window_inner: {}", window_outer, window_inner);
+
+    assert(weight_matrix_width_ntiles % per_core_out_matrix_width_ntiles == 0);
+    assert(per_core_out_matrix_width_ntiles % weight_block_w_ntiles == 0);
+    uint32_t num_blocks_weight_w_per_core = per_core_out_matrix_width_ntiles / weight_block_w_ntiles;
+    if (not weight_width_sliced) {
+        assert(num_blocks_weight_w_per_core == num_blocks_weight_w);
+    }
+    uint32_t num_weight_slices_width = weight_matrix_width_ntiles / per_core_out_matrix_width_ntiles;
+    uint32_t total_num_cores_per_weight_slice = 0;
+    uint32_t total_num_cores_per_act_slice = 0;  // only used when (BLOCK_SHARDING && !transpose_mcast)
+    if (weight_width_sliced) {
+        if (transpose_mcast) {
+            assert(num_cores_y % num_weight_slices_width == 0);
+            uint32_t num_cores_y_per_weight_slice_width = num_cores_y / num_weight_slices_width;
+            total_num_cores_per_weight_slice = num_cores_y_per_weight_slice_width * num_cores_x;
+        } else {
+            assert(num_cores_x % num_weight_slices_width == 0);
+            uint32_t num_cores_x_per_weight_slice_width = num_cores_x / num_weight_slices_width;
+            uint32_t num_act_slices_height = act_matrix_height_ntiles / per_core_out_matrix_height_ntiles;
+            total_num_cores_per_act_slice = num_cores_x * num_cores_y / num_act_slices_height;
+            log_debug(LogOp, "total_num_cores_per_act_slice: {}", total_num_cores_per_act_slice);
+            total_num_cores_per_weight_slice = num_cores_x_per_weight_slice_width * num_cores_y;
+        }
+        assert(total_num_cores_per_weight_slice * per_core_out_matrix_height_ntiles == act_matrix_height_ntiles);
+    } else {
+        assert(num_cores_y % num_weight_slices_width == 0);
+        uint32_t num_cores_y_per_weight_slice_width = num_cores_y / num_weight_slices_width;
+        total_num_cores_per_weight_slice = num_cores_y_per_weight_slice_width * num_cores_x;
+        assert(total_num_cores * per_core_out_matrix_height_ntiles >= act_matrix_height_ntiles);
+    }
+    assert(per_core_out_matrix_height_ntiles % act_block_h_ntiles == 0);
+    uint32_t num_blocks_act_h_per_core = per_core_out_matrix_height_ntiles / act_block_h_ntiles;
+    assert(per_core_out_matrix_height_ntiles % out_block_h_ntiles == 0);
+    uint32_t num_blocks_out_h_per_core = per_core_out_matrix_height_ntiles / out_block_h_ntiles;
+    bool act_height_sliced = per_core_out_matrix_height_ntiles < act_matrix_height_ntiles;
+    if (not act_height_sliced) {
+        assert(num_blocks_act_h_per_core == num_blocks_act_h);
+        assert(num_blocks_out_h_per_core == num_blocks_out_h);
+        assert(num_cores_x == 1);
+    }
+
+    log_debug(LogOp, "total_num_cores_per_weight_slice: {}", total_num_cores_per_weight_slice);
+    log_debug(LogOp, "num_blocks_act_h_per_core: {}", num_blocks_act_h_per_core);
+    log_debug(LogOp, "num_blocks_out_h_per_core: {}", num_blocks_out_h_per_core);
+
+    assert(act_matrix_height_ntiles % per_core_out_matrix_height_ntiles == 0);
+    uint32_t total_active_num_cores_per_weight_slice = act_matrix_height_ntiles / per_core_out_matrix_height_ntiles;
+    assert(total_active_num_cores_per_weight_slice <= total_num_cores_per_weight_slice);
+    uint32_t total_noop_cores = total_num_cores_per_weight_slice - total_active_num_cores_per_weight_slice;
+    uint32_t total_active_num_cores = total_active_num_cores_per_weight_slice * num_weight_slices_width;
+    if (weight_width_sliced) {
+        assert(total_noop_cores == 0);
+        assert(total_active_num_cores == total_num_cores);
+    }
+
+    if (has_bias) {
+        assert(bias_ntiles % num_weight_slices_width == 0);
+        assert(bias_ntiles == weight_matrix_width_ntiles);
+    }
+    uint32_t bias_ntiles_per_core = bias_ntiles / num_weight_slices_width;
+
+    CoreRange all_cores(CoreCoord(0, 0), CoreCoord(num_cores_x - 1, num_cores_y - 1));
+    assert(total_active_num_cores >= num_cores_x);
+    uint32_t num_active_cores_x = num_cores_x;
+    uint32_t num_active_cores_y_with_full_x = total_active_num_cores / num_cores_x;
+    uint32_t num_active_cores_x_last_y = total_active_num_cores % num_cores_x;
+    assert((num_active_cores_x * num_active_cores_y_with_full_x) + num_active_cores_x_last_y == total_active_num_cores);
+
+    std::set<CoreRange> all_active_cores_set;
+    all_active_cores_set.insert(
+        CoreRange(CoreCoord(0, 0), CoreCoord(num_active_cores_x - 1, num_active_cores_y_with_full_x - 1)));
+    if (num_active_cores_x_last_y > 0) {
+        all_active_cores_set.insert(CoreRange(
+            CoreCoord(0, num_active_cores_y_with_full_x),
+            CoreCoord(num_active_cores_x_last_y - 1, num_active_cores_y_with_full_x)));
+    }
+    CoreRangeSet all_active_cores(all_active_cores_set);
+    std::set<CoreRange> noop_cores_set;
+    if (total_noop_cores > 0) {
+        assert(total_noop_cores == (num_cores_x - num_active_cores_x_last_y));
+        noop_cores_set.insert(CoreRange(
+            CoreCoord(num_active_cores_x_last_y, num_active_cores_y_with_full_x),
+            CoreCoord(num_cores_x - 1, num_active_cores_y_with_full_x)));
+    }
+    CoreRangeSet noop_cores(noop_cores_set);
+
+    // Mcast cores
+    // If total_num_cores, there is no mcasting
+    CoreCoord top_left_core = {(std::size_t)0, (std::size_t)0};
+    CoreCoord top_left_core_plus_one = {(std::size_t)1, (std::size_t)1};
+    CoreCoord bottom_right_core = {(std::size_t)num_cores_x - 1, (std::size_t)num_cores_y - 1};
+    auto top_left_core_physical = device->worker_core_from_logical_core(top_left_core);
+    auto top_left_core_plus_one_physical = device->worker_core_from_logical_core(top_left_core_plus_one);
+    auto bottom_right_core_physical = device->worker_core_from_logical_core(bottom_right_core);
+
+    CoreRange mcast_sender_cores(top_left_core, top_left_core);  // If single core, this kernel doesn't do mcasting
+    CoreRangeSet mcast_receiver_cores{{}};
+    uint32_t weights_mcast_sender_semaphore;
+    uint32_t weights_mcast_receiver_semaphore;
+    uint32_t act_mcast_sender_semaphore = 0;
+    uint32_t act_mcast_receiver_semaphore = 0;
+    std::vector<uint32_t> act_mcast_noc_y;
+    if (weight_width_sliced) {
+        // 2D mcast
+        if (transpose_mcast) {
+            mcast_sender_cores = CoreRange(top_left_core, CoreCoord(0, num_cores_y - 1));
+            mcast_receiver_cores = {{CoreRange(CoreCoord(1, 0), bottom_right_core)}};
+        } else {
+            mcast_sender_cores = CoreRange(top_left_core, CoreCoord(num_cores_x - 1, 0));
+            mcast_receiver_cores = {{CoreRange(CoreCoord(0, 1), bottom_right_core)}};
+        }
+        weights_mcast_sender_semaphore = tt_metal::CreateSemaphore(program, all_cores, INVALID);
+        weights_mcast_receiver_semaphore = tt_metal::CreateSemaphore(program, all_cores, INVALID);
+    } else {
+        // 1D mcast
+        if (total_num_cores > 1) {
+            std::set<CoreRange> mcast_receiver_set;
+            if (num_cores_x > 1) {
+                mcast_receiver_set.insert(CoreRange(CoreCoord(1, 0), CoreCoord(num_active_cores_x - 1, 0)));
+            }
+            if (num_cores_y > 1) {
+                mcast_receiver_set.insert(
+                    CoreRange(CoreCoord(0, 1), CoreCoord(num_active_cores_x - 1, num_active_cores_y_with_full_x - 1)));
+                if (num_active_cores_x_last_y > 0) {
+                    mcast_receiver_set.insert(CoreRange(
+                        CoreCoord(0, num_active_cores_y_with_full_x),
+                        CoreCoord(num_active_cores_x_last_y - 1, num_active_cores_y_with_full_x)));
+                }
+            }
+            mcast_receiver_cores = mcast_receiver_set;
+            weights_mcast_sender_semaphore = tt_metal::CreateSemaphore(program, all_cores, INVALID);
+            weights_mcast_receiver_semaphore = tt_metal::CreateSemaphore(program, all_cores, INVALID);
+        }
+    }
+
+    bool read_window_in_inner_loop = false;
+    uint32_t num_weight_cb_tiles = weight_block_h_ntiles * weight_block_w_ntiles / conv_act_c_blocks;
+    bool fully_buffer_weights = false;
+    uint32_t num_act_cb_tiles = act_block_h_ntiles * act_block_w_ntiles / conv_act_c_blocks;
+    // TODO: This flag should be set in kernel logic but need this for create_CB
+    if (a.memory_config().is_sharded() and ((weight_size_h == 3 and weight_size_w == 3 and
+        (stride_h == 1 or stride_h == 2)) or (weight_size_h == 1 and weight_size_w == 1 and stride_h == 2)) and weight_width_sliced) {
+        // If conv_act_c_blocks > 1 and we have 2D conv with sharded input, we always read entire 3x3 window before
+        // pushing in reader/writer
+        // TODO: Generalize this to not make this assumption
+        read_window_in_inner_loop = true;
+        num_weight_cb_tiles *= weight_size_h * weight_size_w;
+        num_act_cb_tiles *= weight_size_h * weight_size_w;
+    } else if (num_blocks_act_h_per_core > 1) {
+        fully_buffer_weights = true;
+    }
+    uint32_t num_cb0_tilized_tiles = num_act_cb_tiles;
+
+    if (fully_buffer_weights) {
+        num_weight_cb_tiles *= window_outer;
+    } else if (per_core_out_matrix_width_ntiles < 5 && per_core_out_matrix_height_ntiles < 22) {  // Q: where are these
+                                                                                                  // numbers from?
+        num_weight_cb_tiles = num_weight_cb_tiles * 1;  // make it single buffered for large num of input channels
+    }
+
+    if (conv_act_size_c / conv_act_c_blocks < 160 &&
+        per_core_out_matrix_height_ntiles < 22) {  // Q: where are these numbers from?
+        num_act_cb_tiles = num_act_cb_tiles * 2;   // double buffered
+    }
+
+    uint32_t writer_output_block_num_tiles = out_block_h_ntiles * weight_block_h_ntiles;
+
+    std::vector<uint32_t> reader_rt_args;
+    std::vector<uint32_t> reader_compile_time_args;
+    std::vector<uint32_t> writer_rt_args;
+    std::vector<uint32_t> writer_compile_time_args;
+
+    uint32_t conv_act_c_read_bytes = conv_act_size_c * a.element_size() / conv_act_c_blocks;
+    uint32_t act_block_w_extra_align_bytes =
+        (round_up(conv_act_size_c * weight_size_w, TILE_WIDTH) - (conv_act_size_c * weight_size_w)) * a.element_size();
+
+    uint32_t in0_block_w = act_block_w_ntiles / conv_act_c_blocks;
+    uint32_t in0_block_num_tiles = act_block_num_tiles / conv_act_c_blocks;
+    uint32_t in0_subblock_num_tiles = act_subblock_num_tiles / conv_act_c_blocks;
+    uint32_t in1_block_num_tiles = weight_block_num_tiles / conv_act_c_blocks;
+    uint32_t in0_num_blocks_w =
+        num_blocks_act_w * conv_act_c_blocks;  // Fold outer c_block loop together with weight_block_num_tiles = 9
+
+    uint32_t tilized_act_tile_size = tt_metal::detail::TileSize(tilized_act_df);
+
+    // Only enable packer l1 accumulation when there are in0_num_blocks_w > 2, otherwise
+    // unnecessary overhead for reconfigs are added. Last iteration of l1 accumulation
+    // does a spill and reload, so need more than 2 blocks to use l1 acc for packer
+    // For bias, last iteration of l1 acc remains in intermediate buffer, does not spill and reload
+    bool packer_l1_acc_en = packer_l1_acc && ((has_bias && in0_num_blocks_w > 1) || (in0_num_blocks_w > 2));
+
+    // TODO: Moving this function call to after kernel logic causes pcc fails
+    // There are additional CBs and semaphores created in 2D conv in kernel logic,
+    // so does order of create_cb calls matter?
+    auto [cb_sharded_act, cb_output] = create_CBs_for_depthwise_sharded_input(
+        program,
+        a,
+        all_cores,
+        num_act_cb_tiles,               // row major act cb
+        num_weight_cb_tiles,            // tiled weight cb
+        num_cb0_tilized_tiles,          // tiled act cb
+        writer_output_block_num_tiles,  // math output cb
+        weight_block_w_ntiles,          // reblock cb
+        writer_output_block_num_tiles,  // writer output cb, double bufferred
+        untilize_out,
+        act_df,
+        weight_df,
+        tilized_act_df,
+        out_df,
+        bias_df,
+        weight_width_sliced,
+        output,
+        bias_ntiles_per_core,
+        has_bias,
+        split_reader,
+        fp32_dest_acc_en,
+        packer_l1_acc_en);
+
+    string reader_kernel;
+    string compute_kernel;
+    string writer_mcast_sender_kernel;
+    string writer_mcast_receiver_kernel;
+    bool tilize_in0 = true;
+
+    compute_kernel = "tt_eager/tt_dnn/op_library/depthwise_conv1d/kernels/conv_bmm_tilize_col_major_out_blocks.cpp";
+    // Input should always be sharded in this conv; always use reader kernel for input shard with halo and padding
+    if (weight_size_h >= 1 and weight_size_w >= 1 and (stride_h == 1 or stride_h == 2)) {
+        if (weight_width_sliced) {
+            // 2D conv
+            assert(read_window_in_inner_loop == true);
+            reader_kernel =
+                "tt_eager/tt_dnn/op_library/conv/kernels/"
+                "reader_conv_activations_2d_mcast_padded_with_halo_3x3_weights_v2.cpp";
+            writer_mcast_sender_kernel =
+                "tt_eager/tt_dnn/op_library/conv/kernels/"
+                "writer_tiled_out_2d_mcast_sender_conv_weights_tiled_col_to_rm_blocks.cpp";
+            writer_mcast_receiver_kernel =
+                "tt_eager/tt_dnn/op_library/conv/kernels/"
+                "writer_tiled_out_2d_mcast_receiver_conv_weights_tiled_col_to_rm_blocks.cpp";
+            act_mcast_sender_semaphore = tt_metal::CreateSemaphore(program, all_cores, INVALID);
+            act_mcast_receiver_semaphore = tt_metal::CreateSemaphore(program, all_cores, INVALID);
+
+            if (transpose_mcast) {
+                act_mcast_noc_y.reserve(num_cores_y);
+                for (uint32_t core_idx_y = 0; core_idx_y < num_cores_y; ++core_idx_y) {
+                    act_mcast_noc_y.push_back(device->worker_core_from_logical_core({0, core_idx_y}).y);
+                }
+            } else {
+                // NOTE: using same var for x as well, this is intentional
+                act_mcast_noc_y.reserve(num_cores_x);
+                for (int32_t core_idx_x = 0; core_idx_x < num_cores_x; ++core_idx_x) {
+                    act_mcast_noc_y.push_back(device->worker_core_from_logical_core({(uint32_t)core_idx_x, 0}).x);
+                }
+            }
+
+            // For 2D convs, pre-tilize input and round robin self-mcast tilized act matrix to other cores
+            tilize_in0 = false;
+        } else {
+            // 1D conv
+            TT_ASSERT(act_block_w_datums == round_up(conv_act_size_c * weight_size_w, TILE_WIDTH));
+
+            reader_kernel =
+                "tt_eager/tt_dnn/op_library/depthwise_conv1d/kernels/reader_conv_activations_padded_with_halo_3x3_weights_v2.cpp";
+            if (split_reader) {
+                writer_mcast_sender_kernel =
+                    "tt_eager/tt_dnn/op_library/conv/kernels/"
+                    "reader_writer_tiled_out_1d_mcast_sender_conv_weights_tiled_col_to_rm_blocks.cpp";
+                writer_mcast_receiver_kernel =
+                    "tt_eager/tt_dnn/op_library/conv/kernels/"
+                    "reader_writer_tiled_out_1d_mcast_receiver_conv_weights_tiled_col_to_rm_blocks.cpp";
+            } else {
+                writer_mcast_sender_kernel =
+                    "tt_eager/tt_dnn/op_library/depthwise_conv1d/kernels/"
+                    "writer_tiled_out_1d_mcast_sender_conv_weights_tiled_col_to_rm_blocks.cpp";
+                writer_mcast_receiver_kernel =
+                    "tt_eager/tt_dnn/op_library/depthwise_conv1d/kernels/"
+                    "writer_tiled_out_1d_mcast_receiver_conv_weights_tiled_col_to_rm_blocks.cpp";
+            }
+        }
+
+        // Local L1 to store array for reader indices
+        // All convs use packed uint16 indices, so each entry can be 2B (not 4)
+        CircularBufferConfig cb_for_reader_indices_config =
+            CircularBufferConfig(out_block_h_datums * 2, {{cb_for_reader_indices, tt::DataFormat::Float16_b}})
+                .set_page_size(cb_for_reader_indices, out_block_h_datums * 2);
+        cb_for_reader_indices_config.set_globally_allocated_address(*conv_reader_indices.value().buffer());
+        auto cb_for_reader_indices_id =
+            tt_metal::CreateCircularBuffer(program, all_cores, cb_for_reader_indices_config);
+
+        // Local L1 to store temp vars
+        CircularBufferConfig cb_for_l1_array_config =
+            CircularBufferConfig(32 * 2, {{cb_for_l1_array, tt::DataFormat::Float16_b}})
+                .set_page_size(cb_for_l1_array, 32 * 2);
+        auto cb_for_l1_array_id = tt_metal::CreateCircularBuffer(program, all_cores, cb_for_l1_array_config);
+    } else {
+        TT_ASSERT(false, "Sharded input not supported for this conv yet!");
+    }
+
+    if (read_window_in_inner_loop) {
+        const uint32_t window_size = weight_size_h * weight_size_w;
+        in0_block_w *= window_size;
+        in0_block_num_tiles *= window_size;
+        in0_subblock_num_tiles *= window_size;
+        in1_block_num_tiles *= window_size;
+        in0_num_blocks_w /= window_size;
+    }
+
+    reader_compile_time_args = {
+        (uint32_t)(src0_dram_buffer->buffer_type() == tt_metal::BufferType::DRAM ? 1 : 0),
+        (uint32_t)stride_h,
+        (uint32_t)stride_w,
+        (uint32_t)conv_act_size_w,
+        (uint32_t)conv_output_size_w,  // conv_output_w_last_index
+        (uint32_t)conv_act_c_read_bytes,
+        (uint32_t)window_outer,
+        (uint32_t)window_inner,
+        (uint32_t)act_block_h_datums,
+        (uint32_t)act_block_num_tiles / conv_act_c_blocks,
+        (uint32_t)weight_size_w,
+        (uint32_t)conv_act_size_w + (2 * pad_w),
+        (uint32_t)act_block_w_extra_align_bytes,  // only used for 1d systolic variant
+        (uint32_t)weight_size_h,
+        (uint32_t)num_blocks_act_h_per_core,                              // act_num_blocks_h
+        (uint32_t)in0_block_num_tiles,                                    // act_block_num_tiles
+        (uint32_t)conv_act_c_blocks,                                      // act_w_num_outer
+        (uint32_t)(transpose_mcast ? num_cores_y - 1 : num_cores_x - 1),  // act_mcast_num_dests
+        (uint32_t)(transpose_mcast ? num_cores_y - 1 : num_cores_x - 1),  // act_mcast_num_cores
+        (uint32_t)act_mcast_sender_semaphore,
+        (uint32_t)act_mcast_receiver_semaphore,
+        (uint32_t)in0_block_num_tiles * tilized_act_tile_size,  // act_mcast_sender_size_bytes
+        (uint32_t)(transpose_mcast ? 1 : 0),
+    };
+
+    // define for bias
+    std::map<string, string> writer_defines;
+    std::map<string, string> writer_mcast_sender_defines;
+    std::map<string, string> compute_defines;
+    if (output.memory_config().is_sharded()) {
+        writer_defines["SHARDED_OUT"] = "1";
+        writer_mcast_sender_defines["SHARDED_OUT"] = "1";
+    }
+    if (total_num_cores == 1) {
+        writer_mcast_sender_defines["SKIP_MCAST"] = "1";
+    }
+    if (has_bias) {
+        writer_defines["FUSE_BIAS"] = "1";
+        writer_mcast_sender_defines["FUSE_BIAS"] = "1";
+        compute_defines["FUSE_BIAS"] = "1";
+    }
+
+    if (fuse_relu) {
+        compute_defines["PACK_RELU"] = "1";
+    }
+
+    if (!tilize_in0) {
+        compute_defines["PRE_TILIZE"] = "1";
+    }
+
+    if (split_reader) {
+        reader_defines["SPLIT_READER"] = "1";
+        compute_defines["SPLIT_READER"] = "1";
+    }
+
+    if (packer_l1_acc_en) {
+        compute_defines["PACKER_L1_ACC"] = "1";
+    }
+
+    writer_compile_time_args = {
+        (uint32_t)(dst_dram_buffer->buffer_type() == tt_metal::BufferType::DRAM ? 1 : 0),
+        out0_cb,
+        weight_cb,
+        bias_cb,
+        (uint32_t)(bias_buffer == nullptr ? 0 : (bias_buffer->buffer_type() == BufferType::DRAM ? 1 : 0)),
+        num_blocks_act_w,  // = number of blocks of weight in height dim
+        in1_block_num_tiles,
+        conv_act_c_blocks,
+        weight_block_h_ntiles / conv_act_c_blocks,
+        weight_block_w_ntiles,
+        weight_matrix_width_ntiles,                          // weight_stride_h
+        weight_matrix_width_ntiles * weight_block_h_ntiles,  // weight_next_block_stride_h,
+        weight_block_w_ntiles,                               // weight_next_block_stride_w
+
+        // bias
+        bias_ntiles_per_core,
+
+        output_width_num_tiles,                          // out_next_tile_stride_h
+        1,                                               // out_next_tile_stride_w
+        out_subblock_h_ntiles * output_width_num_tiles,  // out_next_subblock_stride_h
+        out_subblock_w_ntiles,                           // out_next_subblock_stride_w
+        act_block_h_ntiles * output_width_num_tiles,     // out_next_block_stride_h
+        // weight_block_w_ntiles, // out_next_block_stride_w
+        out_subblock_h_ntiles,
+        out_subblock_w_ntiles,
+        out_subblock_num_tiles,
+        act_block_h_ntiles / out_subblock_h_ntiles,     // out_num_subblocks_h
+        weight_block_w_ntiles / out_subblock_w_ntiles,  // out_num_subblocks_w
+        num_blocks_act_h_per_core,                      // out_num_blocks_h
+        num_blocks_weight_w_per_core,                   // out_num_blocks_w
+        act_block_h_ntiles,                             // out_block_height_num_tiles
+        output_height_num_tiles,                        // out_height_num_tiles without block shape padding
+        output_width_num_tiles,                         // out_width_num_tiles withoug block shape padding
+
+        out_dram_addr,
+        weight_dram_addr,
+        bias_dram_addr,
+    };
+    if (split_reader) {
+        std::vector<uint32_t> split_reader_args = {
+            (uint32_t)act_block_h_datums,
+            (uint32_t)act_block_num_tiles / conv_act_c_blocks,
+            (uint32_t)conv_act_c_read_bytes,
+            (uint32_t)weight_size_w * conv_act_c_read_bytes,                  // coalesced_read_bytes
+            (uint32_t)(conv_act_size_w + 2 * pad_w) * conv_act_c_read_bytes,  // window_outer_offset
+            (uint32_t)act_block_w_extra_align_bytes,                          // only used for 1d systolic variant
+        };
+        writer_compile_time_args.insert(
+            writer_compile_time_args.end(), split_reader_args.begin(), split_reader_args.end());
+    }
+
+    vector<uint32_t> compute_kernel_args = {
+        in0_block_w,
+        act_num_subblocks,
+        in0_block_num_tiles,
+        in0_subblock_num_tiles,
+        act_subblock_h_ntiles,
+
+        weight_num_subblocks,
+        in1_block_num_tiles,
+        weight_block_w_ntiles,
+
+        num_blocks_act_h_per_core,
+        in0_num_blocks_w,
+        num_blocks_weight_w_per_core,
+
+        out_subblock_h_ntiles,
+        out_subblock_w_ntiles,
+        out_subblock_num_tiles,
+
+        tilize_in0,
+        untilize_out,
+
+        bias_ntiles_per_core};
+
+    auto writer_mcast_noc = NOC::NOC_0;
+    auto reader_noc = writer_mcast_noc == NOC::NOC_0 ? NOC::NOC_1 : NOC::NOC_0;
+    auto writer_mcast_sender_id = CreateKernel(
+        program,
+        writer_mcast_sender_kernel,
+        mcast_sender_cores,
+        DataMovementConfig{
+            .processor = DataMovementProcessor::RISCV_0,
+            .noc = writer_mcast_noc,
+            .compile_args = writer_compile_time_args,
+            .defines = writer_mcast_sender_defines});
+
+    KernelHandle writer_mcast_receiver_id = -1;
+    if (total_num_cores > 1) {
+        writer_mcast_receiver_id = CreateKernel(
+            program,
+            writer_mcast_receiver_kernel,
+            mcast_receiver_cores,
+            DataMovementConfig{
+                .processor = DataMovementProcessor::RISCV_0,
+                .noc = writer_mcast_noc,
+                .compile_args = writer_compile_time_args,
+                .defines = writer_defines});
+    }
+
+    auto reader_id = CreateKernel(
+        program,
+        reader_kernel,
+        all_active_cores,
+        DataMovementConfig{
+            .processor = DataMovementProcessor::RISCV_1,
+            .noc = reader_noc,
+            .compile_args = reader_compile_time_args,
+            .defines = reader_defines});
+
+    // Compile compute kernel for active cores only
+    // Compile blank kernel for noop cores
+    auto compute_id = CreateKernel(
+        program,
+        compute_kernel,
+        all_active_cores,
+        ComputeConfig{
+            .math_fidelity = math_fidelity,
+            .fp32_dest_acc_en = fp32_dest_acc_en,
+            .compile_args = compute_kernel_args,
+            .defines = compute_defines});
+
+    for (uint32_t core_i = 0; core_i < total_active_num_cores; core_i++) {
+        uint32_t core_x_i = core_i % num_cores_x;
+        uint32_t core_y_i = core_i / num_cores_x;
+        CoreRange core(CoreCoord(core_x_i, core_y_i), CoreCoord(core_x_i, core_y_i));
+        bool noop_core = false;
+
+        // per core specific args
+        uint32_t act_slice_i;
+        uint32_t weight_slice_i;
+        if (weight_width_sliced && transpose_mcast || !weight_width_sliced) {
+            act_slice_i = core_i % total_num_cores_per_weight_slice;
+            weight_slice_i = core_i / total_num_cores_per_weight_slice;
+        } else {
+            act_slice_i = core_i / total_num_cores_per_act_slice;
+            weight_slice_i = core_i % total_num_cores_per_act_slice;
+        }
+        uint32_t out_start_tile_id = (act_slice_i * per_core_out_matrix_height_ntiles * weight_matrix_width_ntiles) +
+                                     (weight_slice_i * per_core_out_matrix_width_ntiles);
+        uint32_t out_start_tile_id_h = act_slice_i * per_core_out_matrix_height_ntiles;
+        uint32_t out_start_tile_id_w = weight_slice_i * per_core_out_matrix_width_ntiles;
+        uint32_t bias_tile_offset = weight_slice_i * per_core_out_matrix_width_ntiles;
+        if (has_bias) {
+            assert(bias_tile_offset < bias_ntiles);
+        }
+
+        if (weight_width_sliced) {
+            auto shard_shape = a.shard_spec().value().shape;
+            uint32_t tilized_act_tile_size = tt_metal::detail::TileSize(tilized_act_df);
+
+            bool reader_is_noc_0 = reader_noc == NOC::NOC_0;
+
+            TT_ASSERT(!reader_is_noc_0);
+
+            if (transpose_mcast) {
+                CoreCoord bottom_core = {(std::size_t)core_x_i, (std::size_t)num_cores_y - 1};
+                auto bottom_core_physical = device->worker_core_from_logical_core(bottom_core);
+
+                uint32_t act_mcast_dest_noc_start_x = bottom_core_physical.x;
+                uint32_t act_mcast_dest_noc_start_y =
+                    reader_is_noc_0 ? top_left_core_physical.y : bottom_core_physical.y;
+                uint32_t act_mcast_dest_noc_end_x = bottom_core_physical.x;
+                uint32_t act_mcast_dest_noc_end_y = reader_is_noc_0 ? bottom_core_physical.y : top_left_core_physical.y;
+                reader_rt_args = {
+                    (uint32_t)noop_core,
+
+                    // mcast args
+                    act_mcast_dest_noc_start_x,
+                    act_mcast_dest_noc_start_y,
+                    act_mcast_dest_noc_end_x,
+                    act_mcast_dest_noc_end_y,
+                    core_y_i,                          // act_mcast_sender_id (goes down the column)
+                    (uint32_t)bottom_core_physical.x,  // act_mcast_sender_noc_x
+                };
+                reader_rt_args.insert(
+                    reader_rt_args.end(), act_mcast_noc_y.begin(), act_mcast_noc_y.end());  // act_mcast_sender_noc_y
+            } else {
+                CoreCoord core = {core_x_i, core_y_i};
+                auto core_physical = device->worker_core_from_logical_core(core);
+                CoreCoord bottom_right_core = {(std::size_t)num_cores_x - 1, (std::size_t)num_cores_y - 1};
+                auto bottom_right_core_physical = device->worker_core_from_logical_core(bottom_right_core);
+
+                uint32_t act_mcast_dest_noc_start_x =
+                    reader_is_noc_0 ? top_left_core_physical.x : bottom_right_core_physical.x;
+                uint32_t act_mcast_dest_noc_start_y = core_physical.y;
+                uint32_t act_mcast_dest_noc_end_x =
+                    reader_is_noc_0 ? bottom_right_core_physical.x : top_left_core_physical.x;
+                uint32_t act_mcast_dest_noc_end_y = core_physical.y;
+                reader_rt_args = {
+                    (uint32_t)noop_core,
+
+                    // mcast args
+                    act_mcast_dest_noc_start_x,
+                    act_mcast_dest_noc_start_y,
+                    act_mcast_dest_noc_end_x,
+                    act_mcast_dest_noc_end_y,
+                    core_x_i,                   // act_mcast_sender_id (goes along the row)
+                    (uint32_t)core_physical.y,  // act_mcast_sender_noc_x
+                };
+                reader_rt_args.insert(
+                    reader_rt_args.end(), act_mcast_noc_y.begin(), act_mcast_noc_y.end());  // act_mcast_sender_noc_y
+            }
+        } else {
+            reader_rt_args = {(uint32_t)noop_core};
+        }
+
+        // log_debug("Core: {}, READER RT ARGS: {}", core, reader_rt_args.size());
+
+        SetRuntimeArgs(program, reader_id, core, reader_rt_args);
+
+        writer_rt_args = {
+            out_dram_addr,
+            weight_dram_addr,
+            bias_dram_addr,
+
+            output_width_num_tiles,                          // out_next_tile_stride_h
+            1,                                               // out_next_tile_stride_w
+            out_subblock_h_ntiles * output_width_num_tiles,  // out_next_subblock_stride_h
+            out_subblock_w_ntiles,                           // out_next_subblock_stride_w
+            act_block_h_ntiles * output_width_num_tiles,     // out_next_block_stride_h
+            weight_block_w_ntiles,                           // out_next_block_stride_w
+            out_subblock_h_ntiles,
+            out_subblock_w_ntiles,
+            out_subblock_num_tiles,
+            act_block_h_ntiles / out_subblock_h_ntiles,     // out_num_subblocks_h
+            weight_block_w_ntiles / out_subblock_w_ntiles,  // out_num_subblocks_w
+            num_blocks_act_h_per_core,                      // out_num_blocks_h
+            num_blocks_weight_w_per_core,                   // out_num_blocks_w
+            act_block_h_ntiles,                             // out_block_height_num_tiles
+            output_height_num_tiles,                        // out_height_num_tiles without block shape padding
+            output_width_num_tiles,                         // out_width_num_tiles withoug block shape padding
+
+            out_start_tile_id,
+            out_start_tile_id_h,
+            out_start_tile_id_w,
+
+            num_blocks_act_w,  // = number of blocks of weight in height dim
+            in1_block_num_tiles,
+            conv_act_c_blocks,
+            weight_block_h_ntiles / conv_act_c_blocks,
+            weight_block_w_ntiles,
+            weight_matrix_width_ntiles,                          // weight_stride_h
+            weight_matrix_width_ntiles * weight_block_h_ntiles,  // weight_next_block_stride_h,
+            weight_block_w_ntiles,                               // weight_next_block_stride_w
+
+            // bias
+            bias_ntiles_per_core,
+            bias_tile_offset,
+
+            (uint32_t)noop_core};
+
+        // Mcast sender
+        if (weight_width_sliced) {
+            // 2D mcast
+            if (transpose_mcast) {
+                CoreCoord right_core = {(std::size_t)num_cores_x - 1, (std::size_t)core_y_i};
+                auto right_core_physical = device->worker_core_from_logical_core(right_core);
+                if (core_x_i == 0) {
+                    // sender
+                    if (writer_mcast_noc == NOC::NOC_0) {
+                        writer_rt_args.push_back(top_left_core_plus_one_physical.x);  // weights_mcast_dest_noc_start_x
+                        writer_rt_args.push_back(right_core_physical.y);              // weights_mcast_dest_noc_start_y
+                        writer_rt_args.push_back(bottom_right_core_physical.x);       // weights_mcast_dest_noc_end_x
+                        writer_rt_args.push_back(right_core_physical.y);              // weights_mcast_dest_noc_end_y
+                    } else {
+                        writer_rt_args.push_back(bottom_right_core_physical.x);       // weights_mcast_dest_noc_start_x
+                        writer_rt_args.push_back(right_core_physical.y);              // weights_mcast_dest_noc_start_y
+                        writer_rt_args.push_back(top_left_core_plus_one_physical.x);  // weights_mcast_dest_noc_end_x
+                        writer_rt_args.push_back(right_core_physical.y);              // weights_mcast_dest_noc_end_y
+                    }
+
+                    writer_rt_args.push_back(num_cores_x - 1);  // weights_mcast_num_dests
+                    writer_rt_args.push_back(num_cores_x - 1);  // weights_mcast_num_cores
+                    writer_rt_args.push_back(weights_mcast_sender_semaphore);
+                    writer_rt_args.push_back(weights_mcast_receiver_semaphore);
+
+                    SetRuntimeArgs(program, writer_mcast_sender_id, core, writer_rt_args);
+                } else {
+                    // receiver
+                    writer_rt_args.push_back(top_left_core_physical.x);  // weights_mcast_sender_noc_x
+                    writer_rt_args.push_back(right_core_physical.y);     // weights_mcast_sender_noc_y
+                    writer_rt_args.push_back(weights_mcast_sender_semaphore);
+                    writer_rt_args.push_back(weights_mcast_receiver_semaphore);
+
+                    SetRuntimeArgs(program, writer_mcast_receiver_id, core, writer_rt_args);
+                }
+            } else {
+                CoreCoord top_core = {(std::size_t)core_x_i, 0};
+                auto top_core_physical = device->worker_core_from_logical_core(top_core);
+                TT_ASSERT(writer_mcast_noc == NOC::NOC_0);
+                if (core_y_i == 0) {
+                    // sender
+                    if (writer_mcast_noc == NOC::NOC_0) {
+                        writer_rt_args.push_back(top_core_physical.x);                // weights_mcast_dest_noc_start_x
+                        writer_rt_args.push_back(top_left_core_plus_one_physical.y);  // weights_mcast_dest_noc_start_y
+                        writer_rt_args.push_back(top_core_physical.x);                // weights_mcast_dest_noc_end_x
+                        writer_rt_args.push_back(bottom_right_core_physical.y);       // weights_mcast_dest_noc_end_y
+                    } else {
+                        // TODO: ...
+                        TT_ASSERT(false, "TODO: Writer on NOC 1 not supported yet!");
+                        // writer_rt_args.push_back(bottom_right_core_physical.x); // weights_mcast_dest_noc_start_x
+                        // writer_rt_args.push_back(right_core_physical.y); // weights_mcast_dest_noc_start_y
+                        // writer_rt_args.push_back(top_left_core_plus_one_physical.x); // weights_mcast_dest_noc_end_x
+                        // writer_rt_args.push_back(right_core_physical.y); // weights_mcast_dest_noc_end_y
+                    }
+
+                    writer_rt_args.push_back(num_cores_y - 1);  // weights_mcast_num_dests
+                    writer_rt_args.push_back(num_cores_y - 1);  // weights_mcast_num_cores
+                    writer_rt_args.push_back(weights_mcast_sender_semaphore);
+                    writer_rt_args.push_back(weights_mcast_receiver_semaphore);
+
+                    SetRuntimeArgs(program, writer_mcast_sender_id, core, writer_rt_args);
+                } else {
+                    // receiver
+                    writer_rt_args.push_back(top_core_physical.x);       // weights_mcast_sender_noc_x
+                    writer_rt_args.push_back(top_left_core_physical.y);  // weights_mcast_sender_noc_y
+                    writer_rt_args.push_back(weights_mcast_sender_semaphore);
+                    writer_rt_args.push_back(weights_mcast_receiver_semaphore);
+
+                    SetRuntimeArgs(program, writer_mcast_receiver_id, core, writer_rt_args);
+                }
+            }
+        } else {
+            // 1D mcast
+            if (core_x_i == 0 and core_y_i == 0) {
+                // sender
+                if (writer_mcast_noc == NOC::NOC_0) {
+                    writer_rt_args.push_back(top_left_core_physical.x);      // weights_mcast_dest_noc_start_x
+                    writer_rt_args.push_back(top_left_core_physical.y);      // weights_mcast_dest_noc_start_y
+                    writer_rt_args.push_back(bottom_right_core_physical.x);  // weights_mcast_dest_noc_end_x
+                    writer_rt_args.push_back(bottom_right_core_physical.y);  // weights_mcast_dest_noc_end_y
+                } else {
+                    writer_rt_args.push_back(bottom_right_core_physical.x);  // weights_mcast_dest_noc_start_x
+                    writer_rt_args.push_back(bottom_right_core_physical.y);  // weights_mcast_dest_noc_start_y
+                    writer_rt_args.push_back(top_left_core_physical.x);      // weights_mcast_dest_noc_end_x
+                    writer_rt_args.push_back(top_left_core_physical.y);      // weights_mcast_dest_noc_end_y
+                }
+                writer_rt_args.push_back(total_active_num_cores - 1);  // weights_mcast_num_dests
+                writer_rt_args.push_back(total_num_cores - 1);         // weights_mcast_num_cores
+                writer_rt_args.push_back(weights_mcast_sender_semaphore);
+                writer_rt_args.push_back(weights_mcast_receiver_semaphore);
+
+                SetRuntimeArgs(program, writer_mcast_sender_id, core, writer_rt_args);
+            } else {
+                // receiver
+                writer_rt_args.push_back(top_left_core_physical.x);  // weights_mcast_sender_noc_x
+                writer_rt_args.push_back(top_left_core_physical.y);  // weights_mcast_sender_noc_y
+                writer_rt_args.push_back(weights_mcast_sender_semaphore);
+                writer_rt_args.push_back(weights_mcast_receiver_semaphore);
+
+                // log_debug("Core: {}, WRITER RT ARGS: {}", core, writer_rt_args.size());
+                SetRuntimeArgs(program, writer_mcast_receiver_id, core, writer_rt_args);
+            }
+        }
+
+    }  // for num_cores
+
+    auto mcast_sender_cores_vec = grid_to_cores(mcast_sender_cores.start, mcast_sender_cores.end, true);
+    auto mcast_receiver_cores_vec = corerange_to_cores(mcast_receiver_cores, std::nullopt, true);
+    auto override_runtime_arguments_callback =
+        [reader_kernel_id = reader_id,
+         mcast_sender_cores = mcast_sender_cores_vec,
+         writer_mcast_sender_id = writer_mcast_sender_id,
+         mcast_receiver_cores = mcast_receiver_cores_vec,
+         writer_mcast_receiver_id = writer_mcast_receiver_id,
+         cb_sharded_act = cb_sharded_act,
+         cb_output = cb_output,
+         total_active_num_cores = total_active_num_cores,
+         num_cores_x = num_cores_x,
+         num_cores_y = num_cores_y,
+         has_bias = has_bias](
+            const void* operation,
+            Program& program,
+            const std::vector<Tensor>& input_tensors,
+            const std::vector<std::optional<const Tensor>>& optional_input_tensors,
+            const std::vector<Tensor>& output_tensors) {
+            // Reader config indices is an optional static sharded tensor, so no need to update address
+            TT_ASSERT(input_tensors.size() + optional_input_tensors.size() == 4);
+            TT_ASSERT(output_tensors.size() == 1);
+
+            auto src_buffer_a = input_tensors.at(0).buffer();
+            auto src_buffer_b = input_tensors.at(1).buffer();
+            bool src_a_is_sharded = input_tensors[0].is_sharded();
+
+            std::optional<Buffer*> src_buffer_c = std::nullopt;
+            if (has_bias) {
+                src_buffer_c = optional_input_tensors.at(0).value().buffer();
+                TT_ASSERT(src_buffer_c.value() != nullptr);
+            }
+
+            auto dst_buffer = output_tensors.at(0).buffer();
+            bool out_sharded = output_tensors[0].is_sharded();
+
+            auto& reader_kernel_args_by_core = GetRuntimeArgs(program, reader_kernel_id);
+
+            auto& writer_sender_kernel_args_by_core = GetRuntimeArgs(program, writer_mcast_sender_id);
+            for (const auto& core : mcast_sender_cores) {
+                if (!src_a_is_sharded) {
+                    auto& runtime_args = reader_kernel_args_by_core[core.x][core.y];
+                    runtime_args[0] = src_buffer_a->address();
+                }
+                auto& runtime_args = writer_sender_kernel_args_by_core[core.x][core.y];
+                runtime_args[0] = dst_buffer->address();
+                runtime_args[1] = src_buffer_b->address();
+                if (has_bias) {
+                    runtime_args[2] = (*src_buffer_c)->address();
+                }
+            }
+
+            if (mcast_receiver_cores.size() > 0) {
+                auto& writer_receiver_kernel_args_by_core = GetRuntimeArgs(program, writer_mcast_receiver_id);
+                for (const auto& core : mcast_receiver_cores) {
+                    if (!src_a_is_sharded) {
+                        auto& runtime_args = reader_kernel_args_by_core[core.x][core.y];
+                        runtime_args[0] = src_buffer_a->address();
+                    }
+                    auto& runtime_args = writer_receiver_kernel_args_by_core[core.x][core.y];
+                    runtime_args[0] = dst_buffer->address();
+                    runtime_args[1] = src_buffer_b->address();
+                    if (has_bias) {
+                        runtime_args[2] = (*src_buffer_c)->address();
+                    }
+                }
+            }
+
+            if (src_a_is_sharded) {
+                UpdateDynamicCircularBufferAddress(program, cb_sharded_act, *src_buffer_a);
+            }
+
+            if (out_sharded) {
+                UpdateDynamicCircularBufferAddress(program, cb_output, *dst_buffer);
+            }
+        };
+    return {.program = std::move(program), .override_runtime_arguments_callback = override_runtime_arguments_callback};
+}
+
+operation::ProgramWithCallbacks multi_core_optimized_depthwise_conv_sharded(
+    const Tensor& a,
+    const Tensor& b,
+    std::optional<const Tensor> bias,
+    vector<int> conv_params,
+    uint32_t output_channels,
+    bool untilize_out,
+    bool fuse_relu,
+    MathFidelity math_fidelity,
+    const OptimizedDepthwiseConvParallelizationConfig& parallelization_config,
+    const OptimizedDepthwiseConvBlockConfig& block_config,
+    uint32_t extra_padding_for_32B_alignment,
+    DataType output_dtype,
+    std::array<std::uint32_t, 4> input_tensor_shape,
+    bool use_shallow_conv_variant,
+    std::optional<const DeviceComputeKernelConfig> compute_kernel_config,
+    Tensor& output) {
+    tt_metal::Program program = tt_metal::CreateProgram();
+    // TODO: conv params need to be cleaned up and replaced with sliding window config
+    ParallelConfig parallel_config;
+    parallel_config.grid = a.shard_spec().value().grid;
+    parallel_config.shard_scheme = a.memory_config().memory_layout;
+    parallel_config.shard_orientation = a.shard_spec().value().orientation;
+    // TODO: pass sliding window config to the function instead of conv params
+    uint32_t weight_size_h = (uint32_t)conv_params[0];  // filter_h
+    uint32_t weight_size_w = (uint32_t)conv_params[1];  // filter_W
+    uint32_t stride_h = (uint32_t)conv_params[2];
+    uint32_t stride_w = (uint32_t)conv_params[3];
+    uint32_t pad_h = (uint32_t)conv_params[4];
+    uint32_t pad_w = (uint32_t)conv_params[5];
+    SlidingWindowConfig sliding_window_config = SlidingWindowConfig(
+        input_tensor_shape[0],
+        input_tensor_shape[1],
+        input_tensor_shape[2],
+        weight_size_h,
+        weight_size_w,
+        stride_h,
+        stride_w,
+        pad_h,
+        pad_w,
+        1,
+        1,
+        parallelization_config.num_cores_nhw,
+        parallel_config.grid,
+        true);
+
+    // create conv config tensors
+    auto pad_metadata = sliding_window::generate_pad_metadata(sliding_window_config);
+    auto op_trace_metadata = sliding_window::generate_op_trace_metadata(sliding_window_config);
+    auto shard_boundaries = sliding_window::generate_shard_boundaries(sliding_window_config, op_trace_metadata);
+    auto conv_sharded_input_top_left_indices =
+        sliding_window::generate_sliding_window_op_config(op_trace_metadata, shard_boundaries, true, true);
+    // create sharded ttnn config tensors
+    DataType indices_tt_dtype = DataType::UINT16;
+    // For 2d convs, each core in a column or row share the same specs
+    CoreCoord grid_size = parallel_config.grid.bounding_box().grid_size();
+    // if(parallel_config.shard_scheme == TensorMemoryLayout::BLOCK_SHARDED) {
+    //     uint32_t num_shards_nhw = conv_sharded_input_top_left_indices.size();
+    //     TT_ASSERT(sliding_window_config.num_cores_nhw_ == num_shards_nhw);
+    //     uint32_t num_shards_channels = 0;
+    //     if(parallel_config.shard_orientation == ShardOrientation::COL_MAJOR) {
+    //         num_shards_channels = grid_size.y;
+    //     } else {
+    //         num_shards_channels = grid_size.x;
+    //     }
+    //     // replicate across channel shards
+    //     for (uint32_t j = 1; j < num_shards_channels; j++) {
+    //         for (uint32_t i = 0; i < num_shards_nhw; i++) {
+    //             conv_sharded_input_top_left_indices.push_back(conv_sharded_input_top_left_indices[i]);
+    //         }
+    //     }
+    // }
+    bool is_block_sharded = a.memory_config().memory_layout == TensorMemoryLayout::BLOCK_SHARDED;
+    auto conv_reader_indices_tensor = sliding_window::construct_on_host_config_tensor(
+        conv_sharded_input_top_left_indices, sliding_window_config, parallel_config);
+    conv_reader_indices_tensor = sliding_window::move_config_tensor_to_device(
+        conv_reader_indices_tensor, parallel_config, is_block_sharded, a.device());
+
+    // add config tensor to program
+    tt::tt_metal::detail::AddConfigBuffer(program, conv_reader_indices_tensor.device_buffer());
+    return multi_core_optimized_depthwise_conv_sharded_v2_impl(
+        program,
+        a,
+        b,
+        Shape(input_tensor_shape),
+        bias,
+        conv_reader_indices_tensor,
+        conv_params,
+        output_channels,
+        untilize_out,
+        bias.has_value(),
+        fuse_relu,
+        parallelization_config,
+        block_config,
+        extra_padding_for_32B_alignment,
+        use_shallow_conv_variant,
+        parallel_config.shard_orientation == ShardOrientation::COL_MAJOR,
+        output,
+        compute_kernel_config.value());
+}
+}  // namespace tt_metal
+
+}  // namespace tt

--- a/tt_eager/tt_dnn/op_library/depthwise_conv1d/optimized_depthwise_conv_op.cpp
+++ b/tt_eager/tt_dnn/op_library/depthwise_conv1d/optimized_depthwise_conv_op.cpp
@@ -1,0 +1,252 @@
+// SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "tt_dnn/op_library/depthwise_conv1d/optimized_depthwise_conv_op.hpp"
+#include "tt_dnn/op_library/eltwise_unary/eltwise_unary_op.hpp"
+
+#include "tt_metal/host_api.hpp"
+#include "tt_metal/detail/tt_metal.hpp"
+#include "tt_metal/detail/util.hpp"
+#include "tt_metal/common/constants.hpp"
+
+#include "tt_metal/tt_stl/reflection.hpp"
+
+#include "tt_dnn/op_library/work_split.hpp"
+#include "tt_dnn/op_library/sharding_utilities.hpp"
+#include "tt_dnn/op_library/auto_format.hpp"
+
+#include "tensor/tensor_utils.hpp"
+using namespace tt::constants;
+
+namespace optimized_depthwise_conv_op_utils {
+using namespace tt;
+using namespace tt::tt_metal;
+
+pair<uint32_t, uint32_t> compute_opt_depthwise_conv_output_face_shape(uint32_t conv_activation_h, uint32_t conv_activation_w, uint32_t filter_h, uint32_t filter_w, uint32_t stride_h, uint32_t stride_w, uint32_t pad_h, uint32_t pad_w, uint32_t padding_for_32B_alignment) {
+    uint32_t conv_output_h = ((conv_activation_h - filter_h + (2 * pad_h)) / stride_h) + 1;
+    uint32_t conv_output_w = ((conv_activation_w - filter_w + (2 * pad_w) - padding_for_32B_alignment) / stride_w) + 1;
+    return {conv_output_h, conv_output_w};
+}
+pair<vector<uint32_t>, vector<uint32_t>> compute_opt_depthwise_conv_activation_as_mm_shape(Shape conv_activation_shape, vector<int> conv_params, uint32_t act_block_h_ntiles, uint32_t padding_for_32B_alignment) {
+    uint32_t filter_h = (uint32_t) conv_params[0];
+    uint32_t filter_w = (uint32_t) conv_params[1];
+    uint32_t stride_h = (uint32_t) conv_params[2];
+    uint32_t stride_w = (uint32_t) conv_params[3];
+    uint32_t pad_h = (uint32_t) conv_params[4];
+    uint32_t pad_w = (uint32_t) conv_params[5];
+    auto [conv_output_h, conv_output_w] = compute_opt_depthwise_conv_output_face_shape(conv_activation_shape[1], conv_activation_shape[2], filter_h, filter_w, stride_h, stride_w, pad_h, pad_w, padding_for_32B_alignment);
+    uint32_t batch_size = conv_activation_shape[0];
+    // pad height
+    uint32_t num_rows = (uint32_t) batch_size * conv_output_h * conv_output_w;
+    uint32_t act_block_h_datums = act_block_h_ntiles * TILE_HEIGHT;
+    uint32_t num_rows_padded = (uint32_t) (ceil((double) num_rows / (double) act_block_h_datums ) * act_block_h_datums);
+    uint32_t num_cols = conv_activation_shape[3] * filter_h * filter_w;
+    uint32_t num_cols_padded = round_up(conv_activation_shape[3] * filter_w, TILE_WIDTH) * filter_h;
+    return {{1, num_rows_padded, num_cols_padded}, {1, num_rows, num_cols}};
+}
+
+} // optimized_depthwise_conv_op_utils
+
+namespace tt {
+
+namespace tt_metal {
+
+Tensor optimized_depthwise_conv(const Tensor& a, const Tensor &b, std::optional<const Tensor> bias,
+    const vector<int> conv_params,
+    uint32_t output_channels,
+    bool untilize_out, bool fuse_relu, MathFidelity math_fidelity,
+    const OptimizedDepthwiseConvParallelizationConfig& parallelization_config,
+    const OptimizedDepthwiseConvBlockConfig& block_config, uint32_t extra_padding_for_32B_alignment,
+    MemoryConfig output_mem_config,
+    DataType output_dtype,
+    std::array<std::uint32_t, 4> input_tensor_shape,
+    bool use_shallow_conv_variant,
+    std::optional<const DeviceComputeKernelConfig> compute_kernel_config
+) {
+    //TT_ASSERT(!untilize_out, "Optimized conv only supports tiled out");
+    TT_ASSERT(b.get_layout() == Layout::TILE); // Weights should already be formatted
+    const auto& ashape = Shape(input_tensor_shape);
+    auto padded_a_shape = Shape({ashape[0], ashape[1], ashape[2], round_up(ashape[3], 16)});
+    FormatParams input_a_format_params = {.pad_shape=padded_a_shape, .pad_value=0.0, .target_layout=Layout::ROW_MAJOR};
+    FormatParams input_b_format_params = {.pad_shape=b.get_legacy_shape(), .pad_value=0.0, .target_layout=Layout::TILE};
+    FormatParams input_bias_format_params = {};
+    if (bias.has_value()) {
+        input_bias_format_params = {.pad_shape=bias.value().get_legacy_shape(), .pad_value=0, .target_layout=Layout::TILE};
+    }
+    auto output_layout = untilize_out ? Layout::ROW_MAJOR : Layout::TILE;
+    auto arch = a.storage_type() == StorageType::DEVICE ? a.device()->arch() : AutoFormat::GetDefaultDevice()->arch();
+    bool fp32_accum = a.device()->arch() == ARCH::WORMHOLE_B0;  // && compute_kernel_config.has_value()) ? compute_kernel_config.value().fp32_dest_acc_en : false;
+    auto kernel_config_val = init_device_compute_kernel_config(arch, compute_kernel_config, MathFidelity::LoFi, true, fp32_accum, false);
+    return operation::run_without_autoformat(
+        OptimizedDepthwiseConv(conv_params, output_channels, untilize_out, bias.has_value(), fuse_relu, math_fidelity, parallelization_config, block_config, extra_padding_for_32B_alignment, output_mem_config, output_dtype, input_tensor_shape, use_shallow_conv_variant, kernel_config_val
+        ),
+        {a, b},
+        {bias}).at(0);
+}
+
+void OptimizedDepthwiseConv::validate(const std::vector<Tensor>& input_tensors, const std::vector<std::optional<const Tensor>>& optional_input_tensors) const {
+    const auto& input_tensor_a = input_tensors.at(0);
+    const auto& input_tensor_b = input_tensors.at(1);
+    // TODO: ...
+    TT_FATAL(!input_tensor_b.memory_config().is_sharded());
+    if (this->untilize_out) {
+        TT_FATAL((this->output_dtype == DataType::BFLOAT16) || (this->output_dtype == DataType::FLOAT32));
+    }
+    if (this->output_mem_config.is_sharded()) {
+        uint32_t out_block_h_ntiles = parallelization_config.per_core_out_matrix_height_ntiles;
+        auto [act_matrix_shape, act_matrix_shape_unpadded] = optimized_depthwise_conv_op_utils::compute_opt_depthwise_conv_activation_as_mm_shape(input_tensor_a.get_legacy_shape(), conv_params, out_block_h_ntiles, extra_padding_for_32B_alignment);
+        uint32_t out_width_ntiles = this->compute_output_shapes(input_tensors).at(0)[-1] / TILE_WIDTH;
+        if(this->output_mem_config.memory_layout == TensorMemoryLayout::HEIGHT_SHARDED) {
+            // TT_FATAL(this->parallelization_config.per_core_out_matrix_width_ntiles == out_width_ntiles); // we violate this as we don't do matmul
+            TT_FATAL(this->block_config.out_subblock_w_ntiles == out_width_ntiles || this->block_config.out_subblock_h_ntiles == 1);
+        } else if (this->output_mem_config.memory_layout == TensorMemoryLayout::BLOCK_SHARDED) {
+            // For block sharded, out_width per core is shard width, and this is split along row
+            // TODO: We should clean this up and relax constraints on out_subblock h and w
+            if (this->output_mem_config.shard_spec.value().orientation == ShardOrientation::COL_MAJOR) {
+                out_width_ntiles /= this->parallelization_config.grid_size.y;
+            } else {
+                out_width_ntiles /= this->parallelization_config.grid_size.x;
+            }
+            TT_FATAL(this->block_config.out_subblock_w_ntiles == out_width_ntiles || this->block_config.out_subblock_h_ntiles == 1);
+        }
+    }
+}
+
+std::vector<Shape> OptimizedDepthwiseConv::compute_output_shapes(const std::vector<Tensor>& input_tensors) const {
+    const auto& input_tensor_a_shape = this->input_tensor_shape;
+    uint32_t batch_size = input_tensor_a_shape[0];
+    uint32_t conv_activation_h = input_tensor_a_shape[1];
+    uint32_t conv_activation_w = input_tensor_a_shape[2];
+    // TODO: clean up here
+    uint32_t filter_h = (uint32_t) conv_params[0];
+    uint32_t filter_w = (uint32_t) conv_params[1];
+    uint32_t stride_h = (uint32_t) conv_params[2];
+    uint32_t stride_w = (uint32_t) conv_params[3];
+    uint32_t pad_h = (uint32_t) conv_params[4];
+    uint32_t pad_w = (uint32_t) conv_params[5];
+    auto [conv_output_h, conv_output_w] = optimized_depthwise_conv_op_utils::compute_opt_depthwise_conv_output_face_shape(conv_activation_h, conv_activation_w, filter_h, filter_w, stride_h, stride_w, pad_h, pad_w, extra_padding_for_32B_alignment);
+
+    // Tiled output shape is padded shape. Padded to tile shape.
+    auto shape_w = batch_size * conv_output_h * conv_output_w;
+    auto shape_c = input_tensor_a_shape[3];
+    auto padded_shape_w =
+        parallelization_config.num_cores_nhw * parallelization_config.per_core_out_matrix_height_ntiles * TILE_HEIGHT;
+    auto padded_shape_c = round_up(shape_c, TILE_WIDTH);
+    auto output_padding = Padding(
+        {{0, 0}, {0, 0}, {0, (padded_shape_w - shape_w)}, {0, (padded_shape_c - shape_c)}}, Padding::PadValue::Zero);
+    auto output_tensor_shape = Shape({1, 1, padded_shape_w, padded_shape_c}, output_padding);
+    return {output_tensor_shape};
+}
+
+std::vector<Tensor> OptimizedDepthwiseConv::create_output_tensors(const std::vector<Tensor>& input_tensors) const {
+    const auto& input_tensor = input_tensors.at(0);
+    const auto& weight_tensor = input_tensors.at(1);
+    auto output_layout = this->untilize_out ? Layout::ROW_MAJOR : Layout::TILE;
+    if (this->output_mem_config.is_sharded()) {
+        auto output_shape = this->compute_output_shapes(input_tensors).at(0);
+        if (this->output_mem_config.memory_layout == TensorMemoryLayout::HEIGHT_SHARDED) {
+            uint32_t total_height_tiles = tt_metal::compute_volume(output_shape) / output_shape[-1] / TILE_HEIGHT;
+            uint32_t num_cores = total_height_tiles / this->parallelization_config.per_core_out_matrix_height_ntiles;
+            CoreRangeSet shard_grid = num_cores_to_corerange_set(num_cores, this->parallelization_config.grid_size, true);
+
+            std::array<uint32_t, 2> shard_shape = {this->parallelization_config.per_core_out_matrix_height_ntiles * TILE_HEIGHT, output_shape[-1]};
+            auto shard_spec = ShardSpec{shard_grid, shard_shape, ShardOrientation::ROW_MAJOR};
+            auto mem_config = this->output_mem_config;
+            mem_config.shard_spec = shard_spec;
+            return {create_device_tensor(output_shape, this->output_dtype, output_layout, input_tensor.device(), mem_config)};
+        } else {
+            auto [act_matrix_shape, act_matrix_shape_unpadded] = optimized_depthwise_conv_op_utils::compute_opt_depthwise_conv_activation_as_mm_shape(this->input_tensor_shape, conv_params, this->parallelization_config.per_core_out_matrix_height_ntiles, extra_padding_for_32B_alignment);
+            uint32_t act_matrix_height = (uint32_t) act_matrix_shape[1];
+            uint32_t act_matrix_height_ntiles = act_matrix_height / TILE_HEIGHT;
+            uint32_t total_active_num_cores_per_weight_slice = act_matrix_height_ntiles / this->parallelization_config.per_core_out_matrix_height_ntiles;
+            uint32_t weight_matrix_width = weight_tensor.get_legacy_shape()[-1];
+            uint32_t weight_matrix_width_ntiles = weight_matrix_width / TILE_WIDTH;
+            uint32_t num_weight_slices_width = weight_matrix_width_ntiles / this->parallelization_config.per_core_out_matrix_width_ntiles ;
+            uint32_t total_active_num_cores = total_active_num_cores_per_weight_slice * num_weight_slices_width;
+            CoreRangeSet shard_grid = num_cores_to_corerange_set(total_active_num_cores, this->parallelization_config.grid_size, true);
+            std::array<uint32_t, 2> shard_shape = {this->parallelization_config.per_core_out_matrix_height_ntiles * TILE_HEIGHT, this->parallelization_config.per_core_out_matrix_width_ntiles * TILE_WIDTH};
+            auto shard_spec = ShardSpec{shard_grid, shard_shape, this->output_mem_config.shard_spec.value().orientation};
+            auto mem_config = this->output_mem_config;
+            mem_config.shard_spec = shard_spec;
+            return {create_device_tensor(output_shape, this->output_dtype, output_layout, input_tensor.device(), mem_config)};
+        }
+
+    }
+    return operation::generic_create_output_tensors(*this, input_tensors, this->output_dtype, output_layout, this->output_mem_config);
+}
+
+operation::ProgramWithCallbacks OptimizedDepthwiseConv::create_program(const std::vector<Tensor>& input_tensors,
+                                                     const std::vector<std::optional<const Tensor>>& optional_input_tensors,
+                                                     std::vector<Tensor>& output_tensors) const {
+    const auto& input_tensor_a = input_tensors.at(0);
+    const auto& input_tensor_b = input_tensors.at(1);
+    const auto& input_tensor_bias = optional_input_tensors.at(0);
+    auto& output_tensor = output_tensors.at(0);
+    TT_ASSERT(input_tensor_a.memory_config().is_sharded()); // TODO: move this check to validate_input_tensors
+    return multi_core_optimized_depthwise_conv_sharded(
+        input_tensor_a, input_tensor_b, input_tensor_bias,
+        conv_params,
+        output_channels,
+        untilize_out, fuse_relu, math_fidelity,
+        parallelization_config,
+        block_config, extra_padding_for_32B_alignment,
+        output_dtype,
+        input_tensor_shape,
+        use_shallow_conv_variant,
+        compute_kernel_config,
+        output_tensor);
+}
+
+operation::OpPerformanceModel OptimizedDepthwiseConv::create_op_performance_model(const std::vector<Tensor>& input_tensors, const std::vector<std::optional<const Tensor>>& optional_input_tensors, const std::vector<Tensor> &output_tensors) const {
+    const auto& input_tensor_a_shape = this->input_tensor_shape;
+    uint32_t batch_size = input_tensor_a_shape[0];
+    uint32_t conv_activation_h = input_tensor_a_shape[1];
+    uint32_t conv_activation_w = input_tensor_a_shape[2];
+    uint32_t conv_activation_c = input_tensor_a_shape[3];
+    uint32_t filter_h = (uint32_t) conv_params[0];
+    uint32_t filter_w = (uint32_t) conv_params[1];
+    uint32_t stride_h = (uint32_t) conv_params[2];
+    uint32_t stride_w = (uint32_t) conv_params[3];
+    uint32_t pad_h = (uint32_t) conv_params[4];
+    uint32_t pad_w = (uint32_t) conv_params[5];
+
+    const auto& t = output_tensors.at(0);
+    if(t.storage_type() != StorageType::DEVICE) {
+        tt::log_warning(tt::LogOp, "Output tensor not on DEVICE?!");
+    }
+
+    auto arch = t.storage_type() == StorageType::DEVICE ? t.device()->arch() : AutoFormat::GetDefaultDevice()->arch();
+    const int num_cores = (arch == ARCH::WORMHOLE_B0) ? 8 * 8 : 9 * 12;
+    const int tensix_mul_adds_per_cycle_lofi = (arch == ARCH::WORMHOLE_B0) ? 4096 : 2048;
+
+    // Calculate output dimensions: relevant for window/stride based OPs (conv, maxpool, downsample)
+    int output_height = std::floor((conv_activation_h - filter_h + 2 * pad_h) / stride_h + 1);
+    int output_width = std::floor((conv_activation_w - filter_w + 2 * pad_w) / stride_w + 1);
+
+    // Calculate number of mul/add operations
+    // TODO: add bias modeling
+    int64_t num_mul_adds_per_elem = conv_activation_c * filter_h * filter_w * 2; // 1 multiply and 1 add per element
+    int64_t num_mul_adds = num_mul_adds_per_elem * output_height * output_width * this->output_channels * batch_size;
+
+    int ideal_dev_clock_cycles = std::ceil(((float)num_mul_adds / (float)(num_cores * tensix_mul_adds_per_cycle_lofi)) * (float)operation::OpPerformanceModel::fidelity_multiplier(this->math_fidelity));
+
+    operation::OpPerformanceModel result(input_tensors, output_tensors, ideal_dev_clock_cycles);
+
+#if 0
+    tt::log_info(tt::LogOp, "OptimizedConv PerfModel:");
+    tt::log_info(tt::LogOp, "\t Batch: {}", batch_size);
+    tt::log_info(tt::LogOp, "\t In (H, W, C): ({}, {}, {})", conv_activation_h, conv_activation_w, conv_activation_c);
+    tt::log_info(tt::LogOp, "\t Filter (H, W): ({}, {})", filter_h, filter_w);
+    tt::log_info(tt::LogOp, "\t Filter Stride (H, W): ({}, {})", stride_h, stride_w);
+    tt::log_info(tt::LogOp, "\t Pad (H, W): ({}, {})", pad_h, pad_w);
+    tt::log_info(tt::LogOp, "\t Out (H, W, C): ({}, {}, {})", output_height, output_width, this->output_channels);
+    tt::log_info(tt::LogOp, "\t ideal_dev_clock_cycles: {}", ideal_dev_clock_cycles);
+#endif
+
+    return result;
+}
+
+}  // namespace tt_metal
+
+}  // namespace tt

--- a/tt_eager/tt_dnn/op_library/depthwise_conv1d/optimized_depthwise_conv_op.hpp
+++ b/tt_eager/tt_dnn/op_library/depthwise_conv1d/optimized_depthwise_conv_op.hpp
@@ -1,0 +1,178 @@
+// SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include "tensor/tensor.hpp"
+#include "tt_dnn/op_library/run_operation.hpp"
+#include "tt_dnn/op_library/compute_kernel_config.hpp"
+
+namespace tt {
+
+namespace tt_metal {
+
+// TODO: Accept parallelization
+enum class OptimizedDepthwiseConvOpParallelizationStrategy {
+    MULTI_CORE, MULTI_CORE_REUSE, MULTI_CORE_REUSE_MCAST, SINGLE_CORE
+};
+
+struct OptimizedDepthwiseConvParallelizationConfig {
+    CoreCoord grid_size; // (x,y)
+    uint32_t num_cores_nhw;
+    uint32_t per_core_out_matrix_height_ntiles;
+    uint32_t per_core_out_matrix_width_ntiles;
+    // std::size_t in0_block_w;
+    // std::size_t out_subblock_h;
+    // std::size_t out_subblock_w;
+    // std::size_t per_core_M;
+    // std::size_t per_core_N;
+
+    static constexpr auto attribute_names =
+        std::make_tuple("grid_size", "num_cores_nhw", "per_core_out_matrix_height_ntiles", "per_core_weight_matrix_width_ntiles");
+    const auto attribute_values() const {
+        return std::make_tuple(
+            std::cref(this->grid_size),
+            std::cref(this->num_cores_nhw),
+            std::cref(this->per_core_out_matrix_height_ntiles),
+            std::cref(this->per_core_out_matrix_width_ntiles));
+    }
+
+    CoreCoord get_grid_size() const {
+        return this->grid_size;
+    }
+};
+
+struct OptimizedDepthwiseConvBlockConfig {
+    uint32_t act_block_h_ntiles;
+    uint32_t act_block_w_ntiles;
+    uint32_t out_subblock_h_ntiles;
+    uint32_t out_subblock_w_ntiles;
+
+    static constexpr auto attribute_names = std::make_tuple(
+        "act_block_h_ntiles",
+        "act_block_w_ntiles",
+        "out_subblock_h_ntiles",
+        "out_subblock_w_ntiles");
+    const auto attribute_values() const {
+        return std::make_tuple(
+            std::cref(this->act_block_h_ntiles),
+            std::cref(this->act_block_w_ntiles),
+            std::cref(this->out_subblock_h_ntiles),
+            std::cref(this->out_subblock_w_ntiles));
+    }
+};
+
+operation::ProgramWithCallbacks multi_core_optimized_depthwise_conv_sharded(const Tensor& a, const Tensor &b, std::optional<const Tensor> bias,
+    vector<int> conv_params,
+    uint32_t output_channels,
+    bool untilize_out, bool fuse_relu, MathFidelity math_fidelity,
+    const OptimizedDepthwiseConvParallelizationConfig& parallelization_config,
+    const OptimizedDepthwiseConvBlockConfig& block_config, uint32_t extra_padding_for_32B_alignment,
+    DataType output_dtype,
+    std::array<std::uint32_t, 4> input_tensor_shape,
+    bool use_shallow_conv_variant,
+    std::optional<const DeviceComputeKernelConfig> compute_kernel_config,
+    Tensor& output);
+
+// new depthwise conv op
+struct OptimizedDepthwiseConv {
+    OptimizedDepthwiseConvParallelizationConfig parallelization_config;
+    OptimizedDepthwiseConvBlockConfig block_config;
+    const std::vector<int> conv_params;
+    const uint32_t output_channels;
+    bool untilize_out, has_bias, fuse_relu;
+    MathFidelity math_fidelity;
+    uint32_t extra_padding_for_32B_alignment;
+    MemoryConfig output_mem_config;
+    const DataType output_dtype;
+    std::array<std::uint32_t, 4> input_tensor_shape; // For sharded input, input tensor shape is nonsense
+    bool use_shallow_conv_variant;
+    const DeviceComputeKernelConfig compute_kernel_config;
+    OptimizedDepthwiseConv(const vector<int>& c_params,
+        uint32_t output_channels, bool untile_out,
+        bool has_bias, bool fuse_relu,
+        MathFidelity mfidelity, const OptimizedDepthwiseConvParallelizationConfig& p_config,
+        const OptimizedDepthwiseConvBlockConfig& b_config,
+        uint32_t e_padding_for_32B_alignment, MemoryConfig out_mem_config,
+        DataType output_dtype,
+        std::array<std::uint32_t, 4> input_tensor_shape, bool use_shallow_conv_variant,
+        const DeviceComputeKernelConfig compute_kernel_config) :
+            output_channels(output_channels),
+            conv_params(c_params),
+            untilize_out(untile_out),
+            has_bias(has_bias),
+            fuse_relu(fuse_relu),
+            math_fidelity(mfidelity),
+            parallelization_config(p_config),
+            block_config(b_config),
+            extra_padding_for_32B_alignment(e_padding_for_32B_alignment),
+            output_mem_config(out_mem_config),
+            output_dtype(output_dtype), input_tensor_shape(input_tensor_shape),
+            use_shallow_conv_variant(use_shallow_conv_variant),
+            compute_kernel_config(compute_kernel_config) {}
+
+    void validate(const std::vector<Tensor>& input_tensors, const std::vector<std::optional<const Tensor>>& optional_input_tensors) const;
+    std::vector<Shape> compute_output_shapes(const std::vector<Tensor>& input_tensors) const;
+    std::vector<Tensor> create_output_tensors(const std::vector<Tensor>& input_tensors) const;
+    operation::ProgramWithCallbacks create_program(const std::vector<Tensor>& input_tensors, const std::vector<std::optional<const Tensor>>& optional_input_tensors, std::vector<Tensor> &output_tensors) const;
+
+    operation::OpPerformanceModel create_op_performance_model(const std::vector<Tensor>& input_tensors, const std::vector<std::optional<const Tensor>>& optional_input_tensors, const std::vector<Tensor> &output_tensors) const;
+
+    static constexpr auto attribute_names = std::make_tuple(
+        "parallelization_config",
+        "block_config",
+        "conv_params",
+        "output_channels",
+        "untilize_out",
+        "has_bias",
+        "fuse_relu",
+        "math_fidelity",
+        "extra_padding_for_32B_alignment",
+        "output_dtype",
+        "input_tensor_shape",
+        "use_shallow_conv_variant");
+    const auto attribute_values() const {
+        return std::make_tuple(
+            std::cref(this->parallelization_config),
+            std::cref(this->block_config),
+            std::cref(this->conv_params),
+            std::cref(this->output_channels),
+            std::cref(this->untilize_out),
+            std::cref(this->has_bias),
+            std::cref(this->fuse_relu),
+            std::cref(this->math_fidelity),
+            std::cref(this->extra_padding_for_32B_alignment),
+            std::cref(this->output_dtype),
+            std::cref(this->input_tensor_shape),
+            std::cref(this->use_shallow_conv_variant));
+    }
+};
+
+Tensor optimized_depthwise_conv(const Tensor& a, const Tensor &b, std::optional<const Tensor> bias,
+    const vector<int> conv_params,
+    uint32_t output_channels,
+    bool untilize_out, bool fuse_relu, MathFidelity math_fidelity,
+    const OptimizedDepthwiseConvParallelizationConfig& parallelization_config,
+    const OptimizedDepthwiseConvBlockConfig& block_config, uint32_t extra_padding_for_32B_alignment,
+    MemoryConfig output_mem_config,
+    DataType output_dtype,
+    std::array<std::uint32_t, 4> input_tensor_shape,
+    bool use_shallow_conv_variant,
+    std::optional<const DeviceComputeKernelConfig> compute_kernel_config = std::nullopt
+);
+
+}  // namespace tt_metal
+
+}  // namespace tt
+
+
+namespace optimized_depthwise_conv_op_utils {
+using namespace tt;
+using namespace tt::tt_metal;
+
+pair<uint32_t, uint32_t> compute_opt_depthwise_conv_output_face_shape(uint32_t conv_activation_h, uint32_t conv_activation_w, uint32_t filter_h, uint32_t filter_w, uint32_t stride_h, uint32_t stride_w, uint32_t pad_h, uint32_t pad_w, uint32_t padding_for_32B_alignment=0);
+
+pair<vector<uint32_t>, vector<uint32_t>> compute_opt_depthwise_conv_activation_as_mm_shape(Shape conv_activation_shape, vector<int> conv_params, uint32_t act_block_h_ntiles, uint32_t padding_for_32B_alignment);
+
+} // optimized_depthwise_conv_op_utils

--- a/tt_eager/tt_dnn/op_library/untilize/kernels/dataflow/halo_gather.cpp
+++ b/tt_eager/tt_dnn/op_library/untilize/kernels/dataflow/halo_gather.cpp
@@ -102,7 +102,7 @@ void kernel_main() {
     constexpr uint32_t elem_nbytes = sizeof(uint16_t);
     constexpr uint16_t pad_core_id = 0xFFFF;
 
-    static_assert(stick_nbytes <= NOC_MAX_BURST_SIZE);  // stick_nbytes used in noc_async_read_one_packet
+    // static_assert(stick_nbytes <= NOC_MAX_BURST_SIZE);  // stick_nbytes used in noc_async_read_one_packet
 
     const uint16_t my_noc_x = NOC_X(my_x[noc_index]);
     const uint16_t my_noc_y = NOC_Y(my_y[noc_index]);

--- a/ttnn/CMakeLists.txt
+++ b/ttnn/CMakeLists.txt
@@ -3,6 +3,7 @@ set(TTNN_SRCS
     ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/async_runtime.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/op_library/to_layout/to_layout_op.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/conv2d.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/depthwise_conv1d.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/matmul.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/reduction/argmax/device/argmax_op.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/eltwise/binary/device/binary_op.cpp

--- a/ttnn/cpp/pybind11/operations/__init__.hpp
+++ b/ttnn/cpp/pybind11/operations/__init__.hpp
@@ -9,6 +9,7 @@
 
 #include "pybind11/operations/ccl.hpp"
 #include "pybind11/operations/conv2d.hpp"
+#include "pybind11/operations/depthwise_conv1d.hpp"
 #include "pybind11/operations/core.hpp"
 #include "pybind11/operations/creation.hpp"
 #include "pybind11/operations/data_movement.hpp"
@@ -60,6 +61,9 @@ void py_module(py::module& module) {
 
     auto m_conv2d = module.def_submodule("conv2d", "conv2d operation");
     conv2d::py_module(m_conv2d);
+
+    auto m_depthwise_conv1d = module.def_submodule("depthwise_conv1d", "depthwise conv1d operation");
+    depthwise_conv1d::py_module(m_depthwise_conv1d);
 
     auto m_maxpool2d = module.def_submodule("maxpool2d", "maxpool 2d operation");
     maxpool2d::py_module(m_maxpool2d);

--- a/ttnn/cpp/pybind11/operations/depthwise_conv1d.hpp
+++ b/ttnn/cpp/pybind11/operations/depthwise_conv1d.hpp
@@ -1,0 +1,101 @@
+// SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <pybind11/pybind11.h>
+#include <pybind11/stl.h>
+
+#include "ttnn/operations/depthwise_conv1d.hpp"
+#include "ttnn/types.hpp"
+
+namespace py = pybind11;
+
+namespace ttnn {
+namespace operations {
+namespace depthwise_conv1d {
+
+void py_module(py::module& module) {
+    module.def(
+        "depthwise_conv1d",
+        [](const ttnn::Tensor& input_tensor,
+            const ttnn::Tensor& weight_tensor,
+            ttnn::Device& device,
+            uint32_t in_channels,
+            uint32_t out_channels,
+            uint32_t batch_size,
+            uint32_t input_height,
+            uint32_t input_width,
+            std::array<uint32_t, 2> kernel_size,
+            std::array<uint32_t, 2> stride,
+            std::array<uint32_t, 2> padding,
+            std::array<uint32_t, 2> dilation,
+            uint32_t groups,
+            std::optional<const ttnn::Tensor> bias_tensor = std::nullopt,
+            std::optional<const DepthwiseConv1dConfig> conv_config_ = std::nullopt) -> std::tuple<ttnn::Tensor, uint32_t, uint32_t, ttnn::Tensor, std::optional<ttnn::Tensor>> {
+            return ttnn::operations::depthwise_conv1d::depthwise_conv1d(
+                input_tensor, weight_tensor, device, in_channels, out_channels, batch_size, input_height, input_width, kernel_size, stride, padding, dilation,
+                    groups, bias_tensor, conv_config_);
+        },
+        py::kw_only(),
+        py::arg("input_tensor"),
+        py::arg("weight_tensor"),
+        py::arg("device"),
+        py::arg("in_channels"),
+        py::arg("out_channels"),
+        py::arg("batch_size"),
+        py::arg("input_height"),
+        py::arg("input_width"),
+        py::arg("kernel_size"),
+        py::arg("stride"),
+        py::arg("padding"),
+        py::arg("dilation"),
+        py::arg("groups"),
+        py::arg("bias_tensor") = std::nullopt,
+        py::arg("conv_config") = std::nullopt);
+
+    auto py_conv_config = py::class_<DepthwiseConv1dConfig>(module, "DepthwiseConv1dConfig");
+    py_conv_config.def(
+            py::init<MathFidelity, DataType, DataType, bool, bool, bool, string, uint32_t, bool, bool, uint32_t, bool, bool, bool, std::optional<CoreRangeSet>, bool, Layout>(),
+            py::kw_only(),
+            py::arg("math_fidelity") = MathFidelity::HiFi4,
+            py::arg("dtype") = DataType::BFLOAT16,
+            py::arg("weights_dtype") = DataType::BFLOAT16,
+            py::arg("math_approx_mode_enabled") = true,
+            py::arg("fp32_dest_acc_enabled") = false,
+            py::arg("packer_l1_accum_enabled") = false,
+            py::arg("activation") = "",
+            py::arg("input_channels_alignment") = 32,
+            py::arg("deallocate_activation") = false,
+            py::arg("reallocate_halo_output") = false,
+            py::arg("act_block_h_override") = 0,
+            py::arg("reshard_if_not_optimal") = false,
+            py::arg("override_sharding_config") = false,
+            py::arg("height_sharding") = true,
+            py::arg("core_grid") = std::nullopt,
+            py::arg("transpose_shards") = true,
+            py::arg("output_layout") = Layout::TILE
+        );
+        py_conv_config.def_readwrite("math_fidelity", &DepthwiseConv1dConfig::math_fidelity);
+        py_conv_config.def_readwrite("dtype", &DepthwiseConv1dConfig::dtype);
+        py_conv_config.def_readwrite("weights_dtype", &DepthwiseConv1dConfig::weights_dtype);
+        py_conv_config.def_readwrite("math_approx_mode_enabled", &DepthwiseConv1dConfig::math_approx_mode_enabled);
+        py_conv_config.def_readwrite("fp32_dest_acc_enabled", &DepthwiseConv1dConfig::fp32_dest_acc_enabled);
+        py_conv_config.def_readwrite("packer_l1_accum_enabled", &DepthwiseConv1dConfig::packer_l1_accum_enabled);
+        py_conv_config.def_readwrite("activation", &DepthwiseConv1dConfig::activation);
+        py_conv_config.def_readwrite("input_channels_alignment", &DepthwiseConv1dConfig::input_channels_alignment);
+        py_conv_config.def_readwrite("deallocate_activation", &DepthwiseConv1dConfig::deallocate_activation);
+        py_conv_config.def_readwrite("reallocate_halo_output", &DepthwiseConv1dConfig::reallocate_halo_output);
+        py_conv_config.def_readwrite("act_block_h_override", &DepthwiseConv1dConfig::act_block_h_override);
+        py_conv_config.def_readwrite("reshard_if_not_optimal", &DepthwiseConv1dConfig::reshard_if_not_optimal);
+        py_conv_config.def_readwrite("override_sharding_config", &DepthwiseConv1dConfig::override_sharding_config);
+        py_conv_config.def_readwrite("height_sharding", &DepthwiseConv1dConfig::height_sharding);
+        py_conv_config.def_readwrite("core_grid", &DepthwiseConv1dConfig::core_grid);
+        py_conv_config.def_readwrite("transpose_shards", &DepthwiseConv1dConfig::transpose_shards);
+        py_conv_config.def_readwrite("output_layout", &DepthwiseConv1dConfig::output_layout);
+}
+
+}  // namespace depthwise_conv1d
+}  // namespace operations
+}  // namespace ttnn

--- a/ttnn/cpp/ttnn/operations/depthwise_conv1d.cpp
+++ b/ttnn/cpp/ttnn/operations/depthwise_conv1d.cpp
@@ -1,0 +1,730 @@
+// SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "depthwise_conv1d.hpp"
+
+#include "tt_eager/tt_dnn/op_library/downsample/downsample_op.hpp"
+#include "tt_metal/detail/reports/memory_reporter.hpp"
+#include "ttnn/cpp/ttnn/op_library/to_dtype/to_dtype_op.hpp"
+
+using namespace tt;
+namespace ttnn {
+namespace operations {
+
+namespace depthwise_conv1d {
+
+const std::array<ttnn::TensorSchema, 3> input_schemas{
+    ttnn::TensorSchema{
+        4,
+        4,
+        {ttnn::bfloat16, ttnn::bfloat8_b, ttnn::float32},
+        {ttnn::TILE_LAYOUT, ttnn::ROW_MAJOR_LAYOUT},
+        true,
+        true,
+        false},
+    ttnn::TensorSchema{
+        4,
+        4,
+        {ttnn::bfloat16, ttnn::bfloat8_b, ttnn::float32},
+        {ttnn::TILE_LAYOUT, ttnn::ROW_MAJOR_LAYOUT},
+        true,
+        true,
+        false},
+    ttnn::TensorSchema{
+        4,
+        4,
+        {ttnn::bfloat16, ttnn::bfloat8_b, ttnn::float32},
+        {ttnn::TILE_LAYOUT, ttnn::ROW_MAJOR_LAYOUT},
+        true,
+        true,
+        false}};
+
+uint32_t find_closest_largest_divisor(uint32_t num, uint32_t start_divisor) {
+    uint32_t divisor = start_divisor;
+    while (num % divisor != 0) divisor = divisor - 1;
+    return divisor;
+}
+
+uint32_t find_closest_largest_divisor_with_num_padding(uint32_t num, uint32_t start_divisor) {
+    uint32_t divisor = start_divisor;
+    uint32_t padded_num = round_up(num, divisor);
+    while ((padded_num - num) >= (int)(padded_num / divisor)) {
+        divisor = divisor - 1;
+        padded_num = round_up(num, divisor);
+    }
+    return divisor;
+}
+
+uint32_t find_closest_common_largest_divisor(uint32_t num1, uint32_t num2, uint32_t start_divisor) {
+    uint32_t divisor = start_divisor;
+    while (num1 % divisor != 0 or num2 % divisor != 0) divisor = divisor - 1;
+    return divisor;
+}
+
+ParallelConfig determine_parallel_config(
+    bool height_sharding,
+    uint32_t batch_size,
+    uint32_t input_channels,
+    uint32_t output_height,
+    uint32_t output_width,
+    uint32_t output_channels,
+    Device& device,
+    ShardOrientation block_shard_orientation,
+    bool is_out_tiled) {
+    uint32_t conv_out_2d_matrix_height = batch_size * output_height * output_width;
+    // pad height to 32
+    conv_out_2d_matrix_height = round_up(conv_out_2d_matrix_height, 32);
+    uint32_t conv_out_2d_matrix_height_ntiles = 0;
+    uint32_t conv_out_2d_matrix_width_ntiles = 0;
+    if (is_out_tiled) {
+        conv_out_2d_matrix_height_ntiles = (int)(conv_out_2d_matrix_height / 32);
+        conv_out_2d_matrix_width_ntiles = (int)(round_up(output_channels, 32) / 32);
+    } else {
+        conv_out_2d_matrix_height_ntiles = conv_out_2d_matrix_height;
+        conv_out_2d_matrix_width_ntiles = output_channels;
+    }
+    auto compute_with_storage_grid_size = device.compute_with_storage_grid_size();
+    std::vector<uint32_t> device_grid_size = {
+        (uint32_t)compute_with_storage_grid_size.x, (uint32_t)compute_with_storage_grid_size.y};
+    uint32_t max_num_cores = device_grid_size[0] * device_grid_size[1];
+
+    auto calculate_num_cores_nhw = [&]() {
+        uint32_t num_cores_nhw =
+            height_sharding
+                ? find_closest_largest_divisor(conv_out_2d_matrix_height_ntiles, max_num_cores)
+                : find_closest_largest_divisor_with_num_padding(conv_out_2d_matrix_height_ntiles, device_grid_size[0]);
+        return num_cores_nhw;
+    };
+
+    auto calculate_grid = [&](uint32_t num_cores_nhw) {
+        if (height_sharding) {
+            uint32_t cores_x_1 = num_cores_nhw >= device_grid_size[0] ? device_grid_size[0] : num_cores_nhw;
+            uint32_t cores_y_1 = (uint32_t)(num_cores_nhw / device_grid_size[0]);
+            TT_ASSERT(cores_y_1 <= device_grid_size[1], "Internal Error: Incorrect num_cores_nhw");
+            CoreRange core_range1 = CoreRange(CoreCoord({0, 0}), CoreCoord({cores_x_1 - 1, cores_y_1 - 1}));
+            CoreRangeSet grid = CoreRangeSet({core_range1});
+            if (num_cores_nhw >= device_grid_size[0] && num_cores_nhw % device_grid_size[0] != 0) {
+                uint32_t cores_x_2 = num_cores_nhw % device_grid_size[0];
+                TT_ASSERT(cores_y_1 + 1 <= device_grid_size[1], "Internal Error: Incorrect num_cores_nhw");
+                CoreRange core_range2 = CoreRange(CoreCoord({0, cores_y_1}), CoreCoord({cores_x_2 - 1, cores_y_1}));
+                grid = CoreRangeSet({core_range1, core_range2});
+            }
+            return grid;
+        } else {
+            uint32_t total_cores_for_channels =
+                block_shard_orientation == ShardOrientation::COL_MAJOR ? device_grid_size[1] : device_grid_size[0];
+            uint32_t num_cores_channels = find_closest_common_largest_divisor(
+                conv_out_2d_matrix_width_ntiles, ceil((double)input_channels / (double)32), total_cores_for_channels);
+            uint32_t cores_x =
+                block_shard_orientation == ShardOrientation::COL_MAJOR ? num_cores_nhw : num_cores_channels;
+            uint32_t cores_y =
+                block_shard_orientation == ShardOrientation::COL_MAJOR ? num_cores_channels : num_cores_nhw;
+            CoreRange core_range = CoreRange(CoreCoord({0, 0}), CoreCoord({cores_x - 1, cores_y - 1}));
+            CoreRangeSet grid = CoreRangeSet({core_range});
+            return grid;
+        }
+    };
+
+    uint32_t num_cores_nhw = calculate_num_cores_nhw();
+    const CoreRangeSet& grid = calculate_grid(num_cores_nhw);
+    auto shard_scheme = height_sharding ? TensorMemoryLayout::HEIGHT_SHARDED : TensorMemoryLayout::BLOCK_SHARDED;
+    auto shard_orientation = height_sharding ? ShardOrientation::ROW_MAJOR : block_shard_orientation;
+    ParallelConfig pconfig = {.grid = grid, .shard_scheme = shard_scheme, .shard_orientation = shard_orientation};
+    return pconfig;
+}
+
+uint32_t get_num_cores_nhw_from_parallel_config(const ParallelConfig& pconfig) {
+    TT_ASSERT(!pconfig.grid.ranges().empty());
+    TT_ASSERT(
+        pconfig.shard_scheme == TensorMemoryLayout::HEIGHT_SHARDED ||
+        pconfig.shard_scheme == TensorMemoryLayout::BLOCK_SHARDED);
+    auto grid_size = pconfig.grid.bounding_box().grid_size();
+    uint32_t num_cores = pconfig.grid.num_cores();
+    uint32_t num_cores_nhw = 0;
+    if (pconfig.shard_scheme == TensorMemoryLayout::HEIGHT_SHARDED) {
+        num_cores_nhw = num_cores;
+    } else if (pconfig.shard_orientation == ShardOrientation::COL_MAJOR) {
+        num_cores_nhw = grid_size.x;
+    } else {
+        TT_ASSERT(pconfig.shard_orientation == ShardOrientation::ROW_MAJOR);
+        num_cores_nhw = grid_size.y;
+    }
+    TT_ASSERT(num_cores_nhw > 0);
+    return num_cores_nhw;
+}
+
+uint32_t get_num_cores_channels_from_parallel_config(const ParallelConfig& pconfig) {
+    TT_ASSERT(!pconfig.grid.ranges().empty());
+    TT_ASSERT(
+        pconfig.shard_scheme == TensorMemoryLayout::HEIGHT_SHARDED ||
+        pconfig.shard_scheme == TensorMemoryLayout::BLOCK_SHARDED);
+    auto grid_size = pconfig.grid.bounding_box().grid_size();
+    uint32_t num_cores_channels = 0;
+    if (pconfig.shard_scheme == TensorMemoryLayout::HEIGHT_SHARDED) {
+        num_cores_channels = 1;
+    } else if (pconfig.shard_orientation == ShardOrientation::COL_MAJOR) {
+        num_cores_channels = grid_size.y;
+    } else {
+        TT_ASSERT(pconfig.shard_orientation == ShardOrientation::ROW_MAJOR);
+        num_cores_channels = grid_size.x;
+    }
+    TT_ASSERT(num_cores_channels > 0);
+    return num_cores_channels;
+}
+
+MemoryConfig create_sharded_memory_config_from_parallel_config(
+    const Shape& tensor_shape, ParallelConfig& parallel_config, uint32_t tile_size) {
+    // tensor_shape is [N, H, W, C]
+    TT_ASSERT(tensor_shape[0] == 1 && tensor_shape[1] == 1);  // todo: add support for generic non-2d shapes
+    uint32_t channels = tensor_shape[3];
+    uint32_t num_cores_nhw = get_num_cores_nhw_from_parallel_config(parallel_config);
+    uint32_t num_cores_channels = get_num_cores_channels_from_parallel_config(parallel_config);
+    auto shard_scheme = parallel_config.shard_scheme;
+    auto shard_orientation = parallel_config.shard_orientation;
+
+    uint32_t nhw_shape = tensor_shape[0] * tensor_shape[1] * tensor_shape[2];
+    uint32_t nhw_padded = round_up(nhw_shape, num_cores_nhw * tile_size);
+    uint32_t nhw_shard = nhw_padded / num_cores_nhw;
+    TT_ASSERT(channels % num_cores_channels == 0);
+    uint32_t channel_shard = channels / num_cores_channels;
+    auto shard_spec = ShardSpec{parallel_config.grid, {nhw_shard, channel_shard}, shard_orientation};
+    return MemoryConfig{shard_scheme, BufferType::L1, shard_spec};
+}
+
+tt::tt_metal::OptimizedDepthwiseConvParallelizationConfig determine_conv_op_parallel_config_from_conv_output_mem_config(
+    const MemoryConfig& conv_output_mem_config, uint32_t num_cores_nhw) {
+    TT_ASSERT(conv_output_mem_config.shard_spec.has_value());
+    const auto& shard_spec = conv_output_mem_config.shard_spec.value();
+    const auto& shard_shape = shard_spec.shape;
+    TT_ASSERT(shard_shape[0] % 32 == 0);
+    TT_ASSERT(shard_shape[1] % 32 == 0);
+    return {
+        .grid_size = shard_spec.grid.bounding_box().grid_size(),
+        .num_cores_nhw = num_cores_nhw,
+        .per_core_out_matrix_height_ntiles = shard_shape[0] / 32,
+        .per_core_out_matrix_width_ntiles = shard_shape[1] / 32,
+    };
+}
+
+std::pair<uint32_t, uint32_t> determine_largest_subblock_size(
+    uint32_t block_height, uint32_t block_width, bool fp32_accum) {
+    std::vector<std::pair<uint32_t, uint32_t>> subblocks = {
+        {2, 4}, {4, 2}, {1, 8}, {8, 1}, {1, 7}, {7, 1}, {2, 3}, {3, 2}, {1, 6}, {6, 1},
+        {1, 5}, {5, 1}, {2, 2}, {1, 4}, {4, 1}, {1, 3}, {3, 1}, {1, 2}, {2, 1}, {1, 1},
+    };
+    uint32_t subblock_h = 0;
+    uint32_t subblock_w = 0;
+    for (auto [subblock_height, subblock_width] : subblocks) {
+        if (fp32_accum && (subblock_height * subblock_width > 4)) {
+            continue;
+        }
+        if ((block_height % subblock_height == 0) && (block_width % subblock_width == 0)) {
+            if (subblock_width != block_width && subblock_height != 1) {
+                continue;
+            }
+            subblock_h = subblock_height;
+            subblock_w = subblock_width;
+            break;
+        }
+    }
+    TT_ASSERT(subblock_h > 0 && subblock_w > 0);
+    return {subblock_h, subblock_w};
+}
+
+tt::tt_metal::OptimizedDepthwiseConvBlockConfig determine_per_core_conv_block_config(
+    const ParallelConfig& parallel_config,
+    const tt::tt_metal::OptimizedDepthwiseConvParallelizationConfig& conv_op_parallel_config,
+    uint32_t padded_in_channels,
+    uint32_t act_block_h_override,
+    uint32_t window_w,
+    bool fp32_accum,
+    bool use_shallow_conv_variant) {
+    if (act_block_h_override > 0) {
+        TT_ASSERT(
+            act_block_h_override % 32 == 0,
+            "Config Error: act_block_h_override must be a multiple of 32 (tile height).");
+    }
+    auto grid_size = parallel_config.grid.bounding_box().grid_size();
+    uint32_t act_block_h_ntiles = act_block_h_override > 0 ? act_block_h_override / 32
+                                                           : conv_op_parallel_config.per_core_out_matrix_height_ntiles;
+    uint32_t act_block_w = parallel_config.shard_scheme == TensorMemoryLayout::HEIGHT_SHARDED
+                               ? round_up(padded_in_channels * window_w, 32)
+                               : padded_in_channels;
+    TT_ASSERT(act_block_w % 32 == 0);
+    uint32_t act_block_w_ntiles = act_block_w / 32;
+    uint32_t act_c_num_blocks = parallel_config.shard_scheme == TensorMemoryLayout::HEIGHT_SHARDED ? 1
+                                : parallel_config.shard_orientation == ShardOrientation::COL_MAJOR ? grid_size.y
+                                                                                                   : grid_size.x;
+    uint32_t out_block_h_ntiles = conv_op_parallel_config.per_core_out_matrix_height_ntiles;
+    uint32_t weight_block_w_ntiles = conv_op_parallel_config.per_core_out_matrix_width_ntiles;
+    auto [out_subblock_h_ntiles, out_subblock_w_ntiles] =
+        determine_largest_subblock_size(act_block_h_ntiles, weight_block_w_ntiles, fp32_accum);
+    if (use_shallow_conv_variant && ((act_block_h_ntiles / out_subblock_h_ntiles) % 2 != 0)) {
+        TT_ASSERT(parallel_config.shard_scheme == TensorMemoryLayout::HEIGHT_SHARDED);
+        // TODO: do a proper fix and remove this temporary hack for shallow conv
+        TT_ASSERT(act_block_h_ntiles % 2 == 0);
+        out_subblock_h_ntiles = act_block_h_ntiles / 2;
+        TT_ASSERT((out_subblock_h_ntiles * out_subblock_w_ntiles) <= 8);
+    }
+    return {
+        .act_block_h_ntiles = act_block_h_ntiles,
+        .act_block_w_ntiles = act_block_w_ntiles,
+        .out_subblock_h_ntiles = out_subblock_h_ntiles,
+        .out_subblock_w_ntiles = out_subblock_w_ntiles};
+}
+
+std::tuple<ttnn::Tensor, ParallelConfig, bool> shard_or_reshard_tensor_if_required(
+    Device& device,
+    const ttnn::Tensor& input_tensor_,
+    const DepthwiseConv1dConfig& conv_config,
+    uint32_t batch_size,
+    uint32_t height,
+    uint32_t width,
+    uint32_t in_channels,
+    uint32_t out_channels) {
+    ttnn::Tensor input_tensor = input_tensor_;  // tensor to return
+    bool input_tensor_on_device = ttnn::has_storage_type_of(input_tensor_, ttnn::DEVICE_STORAGE_TYPE);
+    bool needs_shard_or_reshard = false;
+    if (conv_config.override_sharding_config && conv_config.reshard_if_not_optimal) {
+        TT_ASSERT(
+            false,
+            "Incorrect config provided: reshard_if_not_optimal and override_sharding_config cannot both be set.");
+    }
+    ParallelConfig input_tensor_parallel_config;
+    if (!input_tensor_on_device) {
+        needs_shard_or_reshard = true;
+    } else {
+        const auto& input_memory_config = input_tensor_.memory_config();
+        if (!input_memory_config.is_sharded()) {
+            needs_shard_or_reshard = true;
+        } else {
+            const auto input_shard_scheme = input_memory_config.memory_layout;
+            const auto input_shard_orientation = input_memory_config.shard_spec.value().orientation;
+            const auto input_shard_grid = input_memory_config.shard_spec.value().grid;
+            ParallelConfig pconfig = {
+                .grid = input_shard_grid,
+                .shard_scheme = input_shard_scheme,
+                .shard_orientation = input_shard_orientation};
+            input_tensor_parallel_config = pconfig;
+            if (input_shard_scheme == TensorMemoryLayout::HEIGHT_SHARDED &&
+                input_shard_orientation != ShardOrientation::ROW_MAJOR) {
+                needs_shard_or_reshard = true;
+            }
+            if (input_shard_scheme != TensorMemoryLayout::HEIGHT_SHARDED &&
+                input_shard_scheme != TensorMemoryLayout::BLOCK_SHARDED) {
+                needs_shard_or_reshard = true;
+            }
+            if (conv_config.override_sharding_config) {
+                TT_FATAL(conv_config.core_grid.has_value());
+                if (conv_config.core_grid.value() != input_shard_grid) {
+                    needs_shard_or_reshard = true;
+                }
+                bool input_tensor_height_sharded = input_shard_scheme == TensorMemoryLayout::HEIGHT_SHARDED;
+                if (conv_config.height_sharding != input_tensor_height_sharded) {
+                    needs_shard_or_reshard = true;
+                }
+                bool input_transpose_shards = input_shard_orientation == ShardOrientation::COL_MAJOR;
+                if (!conv_config.height_sharding && conv_config.transpose_shards != input_transpose_shards) {
+                    needs_shard_or_reshard = true;
+                }
+            }
+        }
+    }
+    ParallelConfig parallel_config = input_tensor_parallel_config;
+    if (conv_config.reshard_if_not_optimal || needs_shard_or_reshard) {
+        auto block_shard_orientation =
+            conv_config.transpose_shards ? ShardOrientation::COL_MAJOR : ShardOrientation::ROW_MAJOR;
+        const ParallelConfig& optimal_parallel_config = determine_parallel_config(
+            conv_config.height_sharding,
+            batch_size,
+            in_channels,
+            height,
+            width,
+            out_channels,
+            device,
+            block_shard_orientation);
+
+        if (conv_config.override_sharding_config) {
+            TT_FATAL(conv_config.core_grid.has_value());
+            // override parallel config
+            auto shard_scheme = conv_config.height_sharding ? TensorMemoryLayout::HEIGHT_SHARDED
+                                                            : TensorMemoryLayout::BLOCK_SHARDED;
+            auto shard_orientation =
+                conv_config.height_sharding ? ShardOrientation::ROW_MAJOR : block_shard_orientation;
+            parallel_config = {
+                .grid = conv_config.core_grid.value(),
+                .shard_scheme = shard_scheme,
+                .shard_orientation = shard_orientation};
+        } else {
+            parallel_config = optimal_parallel_config;
+        }
+        if (input_tensor_parallel_config != parallel_config) {
+            needs_shard_or_reshard = true;
+        }
+    }
+    if (needs_shard_or_reshard) {
+        bool input_is_on_device = ttnn::has_storage_type_of(input_tensor, ttnn::DEVICE_STORAGE_TYPE);
+
+        if (input_tensor.get_shape()[0] != 1 or input_tensor.get_shape()[1] != 1) {
+            // reshape to [1, 1, N*H*W, C]
+            input_tensor = ttnn::operations::core::reshape(
+                input_tensor,
+                Shape(
+                    {1,
+                     1,
+                     input_tensor.get_shape()[0] * input_tensor.get_shape()[1] * input_tensor.get_shape()[2],
+                     input_tensor.get_shape()[3]}));
+        }
+        if (!input_is_on_device) {
+            uint32_t input_num_cores_nhw = get_num_cores_nhw_from_parallel_config(parallel_config);
+            // TT_ASSERT(input_tensor.get_legacy_shape() == input_tensor.get_shape());
+            uint32_t tensor_height = input_tensor.get_shape()[2];
+            uint32_t input_tensor_height_snapped_to_tile = round_up(tensor_height, input_num_cores_nhw * 32);
+            TT_ASSERT(input_tensor_height_snapped_to_tile >= tensor_height);
+            uint32_t tensor_width = input_tensor.get_shape()[3];
+            uint32_t input_tensor_width_snapped_to_channels_alignment =
+                round_up(tensor_width, conv_config.input_channels_alignment);
+            TT_ASSERT(input_tensor_width_snapped_to_channels_alignment >= tensor_width);
+            if (input_tensor_height_snapped_to_tile != tensor_height ||
+                input_tensor_width_snapped_to_channels_alignment != tensor_width) {
+                input_tensor = tt::tt_metal::pad_on_host(
+                    input_tensor,
+                    {input_tensor.get_shape()[0],
+                     input_tensor.get_shape()[1],
+                     input_tensor_height_snapped_to_tile,
+                     input_tensor_width_snapped_to_channels_alignment},
+                    {0, 0, 0, 0},
+                    0);
+            }
+        }
+        auto input_padded_shape = input_tensor.get_legacy_shape();  // TODO: resolve ttnn::types::Shape and
+                                                                    // tt::tt_metal::Shape issue to clean up next line
+        auto input_tensor_sharded_memory_config = create_sharded_memory_config_from_parallel_config(
+            Shape({input_padded_shape[0], input_padded_shape[1], input_padded_shape[2], input_padded_shape[3]}),
+            parallel_config,
+            32);
+
+        if (input_is_on_device) {
+            auto resharded_input_tensor = ttnn::operations::core::ToMemoryConfig::execute_on_worker_thread(
+                input_tensor, input_tensor_sharded_memory_config, {});
+            if (conv_config.deallocate_activation) {
+                input_tensor.deallocate();
+            }
+            input_tensor = resharded_input_tensor;
+        } else {
+            input_tensor = ttnn::operations::core::to_device(
+                input_tensor, const_cast<Device*>(&device), input_tensor_sharded_memory_config);
+        }
+    }
+    return {input_tensor, parallel_config, needs_shard_or_reshard};
+}
+
+void validate_weight_and_bias_tensors(
+    const ttnn::Tensor& weight_tensor, std::optional<const ttnn::Tensor>& bias_tensor) {
+    TT_ASSERT(!ttnn::has_storage_type_of(weight_tensor, ttnn::DEVICE_STORAGE_TYPE));
+    TT_ASSERT(weight_tensor.get_layout() == Layout::ROW_MAJOR);
+    TT_ASSERT(weight_tensor.get_shape().rank() == 4);
+    // TODO: enable this assert
+    // TT_ASSERT(weight_tensor.get_shape() == weight_tensor.get_legacy_shape());
+    if (bias_tensor.has_value()) {
+        TT_ASSERT(!ttnn::has_storage_type_of(bias_tensor.value(), ttnn::DEVICE_STORAGE_TYPE));
+        TT_ASSERT(bias_tensor.value().get_shape().rank() == 4);
+        TT_ASSERT(bias_tensor.value().get_layout() == Layout::ROW_MAJOR);
+        // TODO: enable this assert
+        // TT_ASSERT(bias_tensor.value().get_shape() == bias_tensor.value().get_legacy_shape());
+    }
+}
+
+std::pair<ttnn::Tensor, std::optional<ttnn::Tensor>> prepare_conv_weights_biases_and_move_to_device(
+    const ttnn::Tensor& weight_tensor,
+    std::optional<const ttnn::Tensor>& bias_tensor,
+    uint32_t input_channels_alignment,
+    DataType weights_bias_dtype,
+    uint32_t weight_block_h_ntiles,
+    uint32_t weight_block_w_ntiles,
+    const ParallelConfig& parallel_config,
+    Device& device,
+    uint32_t groups) {
+    validate_weight_and_bias_tensors(weight_tensor, bias_tensor);
+    ttnn::Tensor weight_tensor_;  // tensor to return
+    ttnn::Tensor bias_tensor_;
+
+    // Convert weight tensor to 0 padded shape if groups > 1
+    weight_tensor_ = weight_tensor;
+
+    auto weights_shape = weight_tensor_.get_shape();
+    uint32_t out_channels = weights_shape[0];
+    uint32_t in_channels = weights_shape[1];
+    uint32_t window_h = weights_shape[2];
+    uint32_t window_w = weights_shape[3];
+    tt::tt_metal::Shape weights_channels_padded_shape = tt::tt_metal::Shape(std::array<uint32_t, 4>(
+        {round_up(out_channels, 32), round_up(in_channels, input_channels_alignment), window_h, window_w}));
+
+    if (weights_bias_dtype == DataType::BFLOAT8_B) {
+        TT_ASSERT(weight_tensor_.get_dtype() == DataType::FLOAT32);
+        if (bias_tensor.has_value()) {
+            TT_ASSERT(bias_tensor.value().get_dtype() == DataType::FLOAT32);
+        }
+    } else {
+        // TODO: fix the need to check this. We should be able to accept any datatype and convert
+        TT_ASSERT(weight_tensor_.get_dtype() == weights_bias_dtype);
+        if (bias_tensor.has_value()) {
+            TT_ASSERT(bias_tensor.value().get_dtype() == weights_bias_dtype);
+        }
+    }
+
+    weight_tensor_ = tt::tt_metal::pad_on_host(weight_tensor_, weights_channels_padded_shape, {0, 0, 0, 0}, 0);
+
+    // for conv op, pad the weights to block shape
+    if (parallel_config.shard_scheme == TensorMemoryLayout::HEIGHT_SHARDED) {
+        weight_tensor_ = convert_conv_weight_tensor_to_special_padding_tiled_layout(
+            weight_tensor_, weight_block_h_ntiles, weight_block_w_ntiles, weights_bias_dtype);
+    } else {
+        weight_tensor_ = convert_conv_weight_tensor_to_tiled_layout(
+            weight_tensor_, weight_block_h_ntiles, weight_block_w_ntiles, weights_bias_dtype);
+    }
+    weight_tensor_ = ttnn::operations::core::to_device(weight_tensor_, const_cast<Device*>(&device), nullopt);
+    if (bias_tensor.has_value()) {
+        bias_tensor_ = bias_tensor.value();
+        auto bias_shape = bias_tensor_.get_shape();
+        TT_ASSERT(bias_shape[3] == out_channels && bias_shape[0] == 1 && bias_shape[1] == 1 && bias_shape[2] == 1);
+        tt::tt_metal::Shape bias_channels_padded_shape = tt::tt_metal::Shape(
+            std::array<uint32_t, 4>({1, 1, 32, round_up(out_channels, weight_block_w_ntiles * 32)}));
+        bias_tensor_ = tt::tt_metal::pad_on_host(bias_tensor_, bias_channels_padded_shape, {0, 0, 0, 0}, 0);
+        bias_tensor_ = ttnn::operations::core::ToLayout::execute_on_worker_thread(
+            bias_tensor_, Layout::TILE, {}, {}, (Device*)nullptr);
+        if (bias_tensor_.get_dtype() != weights_bias_dtype) {
+            bias_tensor_ = ttnn::operations::core::ToDtype::execute_on_worker_thread(bias_tensor_, weights_bias_dtype);
+        }
+        bias_tensor_ = ttnn::operations::core::to_device(bias_tensor_, const_cast<Device*>(&device), nullopt);
+    }
+
+    return {weight_tensor_, bias_tensor.has_value() ? bias_tensor_ : std::optional<ttnn::Tensor>()};
+}
+
+MatmulProgramConfig determine_matmul_op_config_from_conv_op_config(
+    tt::tt_metal::OptimizedDepthwiseConvParallelizationConfig conv_parallelization_config,
+    tt::tt_metal::OptimizedDepthwiseConvBlockConfig conv_blocking_config,
+    bool height_sharded,
+    string activation,
+    bool transpose_mcast,
+    uint32_t grid_size_along_c) {
+    if (height_sharded) {
+        MatmulMultiCoreReuseMultiCast1DProgramConfig matmul_config = {
+            .compute_with_storage_grid_size = conv_parallelization_config.grid_size,
+            .in0_block_w = conv_blocking_config.act_block_w_ntiles,
+            .out_subblock_h = conv_blocking_config.out_subblock_h_ntiles,
+            .out_subblock_w = conv_blocking_config.out_subblock_w_ntiles,
+            .per_core_M = conv_parallelization_config.per_core_out_matrix_height_ntiles,
+            .per_core_N = conv_parallelization_config.per_core_out_matrix_width_ntiles,
+            .fuse_batch = true,
+            .mcast_in0 = false};
+        if (activation != "") {
+            matmul_config.fused_activation = string_to_unary_with_param(activation);
+        }
+        return matmul_config;
+    } else {
+        TT_ASSERT(conv_blocking_config.act_block_w_ntiles % grid_size_along_c == 0);
+        MatmulMultiCoreReuseMultiCastProgramConfig matmul_config = {
+            .compute_with_storage_grid_size = conv_parallelization_config.grid_size,
+            .in0_block_w = conv_blocking_config.act_block_w_ntiles / grid_size_along_c,
+            .out_subblock_h = conv_blocking_config.out_subblock_h_ntiles,
+            .out_subblock_w = conv_blocking_config.out_subblock_w_ntiles,
+            .per_core_M = conv_parallelization_config.per_core_out_matrix_height_ntiles,
+            .per_core_N = conv_parallelization_config.per_core_out_matrix_width_ntiles,
+            .transpose_mcast = transpose_mcast};
+        if (activation != "") {
+            matmul_config.fused_activation = string_to_unary_with_param(activation);
+        }
+        return matmul_config;
+    }
+}
+std::tuple<ttnn::Tensor, uint32_t, uint32_t, ttnn::Tensor, std::optional<ttnn::Tensor>> depthwise_conv1d(
+    const ttnn::Tensor& input_tensor,
+    const ttnn::Tensor& weight_tensor,
+    ttnn::Device& device,
+    uint32_t in_channels,
+    uint32_t out_channels,
+    uint32_t batch_size,
+    uint32_t input_height,
+    uint32_t input_width,
+    std::array<uint32_t, 2> kernel_size,
+    std::array<uint32_t, 2> stride,
+    std::array<uint32_t, 2> padding,
+    std::array<uint32_t, 2> dilation,
+    uint32_t groups,
+    std::optional<const ttnn::Tensor> bias_tensor,
+    std::optional<const DepthwiseConv1dConfig> conv_config_) {
+    ttnn::validate_input_tensor("ttnn.depthwise_conv1d", input_tensor, input_schemas[0]);
+    ttnn::validate_input_tensor("ttnn.depthwise_conv1d", weight_tensor, input_schemas[1]);
+    if (bias_tensor.has_value()) {
+        ttnn::validate_input_tensor("ttnn.depthwise_conv1d", bias_tensor.value(), input_schemas[2]);
+    }
+    DepthwiseConv1dConfig conv_config = conv_config_.value_or(DepthwiseConv1dConfig());
+    uint32_t output_height = ((input_height - kernel_size[0] + 2 * padding[0]) / stride[0]) + 1;
+    uint32_t output_width = ((input_width - kernel_size[1] + 2 * padding[1]) / stride[1]) + 1;
+    auto [input_tensor_post_tm, parallel_config, tensor_manipulated] = shard_or_reshard_tensor_if_required(
+        device, input_tensor, conv_config, batch_size, output_height, output_width, in_channels, out_channels);
+    if (tensor_manipulated) {
+        if (conv_config.deallocate_activation) {
+            ttnn::Tensor input_tensor_ = input_tensor;  // TODO: allow in place modification of inputs to the op
+            input_tensor_.deallocate();
+            // ttnn::operations::core::deallocate(input_tensor_);
+        }
+        conv_config.deallocate_activation = true;
+    }
+    auto conv_out_memory_config = create_sharded_memory_config_from_parallel_config(
+        Shape({1, 1, batch_size * output_height * output_width, round_up(out_channels, 32)}), parallel_config, 32);
+    auto opt_conv_op_parallel_config = determine_conv_op_parallel_config_from_conv_output_mem_config(
+        conv_out_memory_config, get_num_cores_nhw_from_parallel_config(parallel_config));
+    auto opt_conv_op_block_config = determine_per_core_conv_block_config(
+        parallel_config,
+        opt_conv_op_parallel_config,
+        round_up(in_channels, conv_config.input_channels_alignment),
+        conv_config.act_block_h_override,
+        kernel_size[1],
+        conv_config.fp32_dest_acc_enabled,
+        conv_config.input_channels_alignment == 16);
+    bool weight_is_on_device = ttnn::has_storage_type_of(weight_tensor, ttnn::DEVICE_STORAGE_TYPE);
+    ttnn::Tensor weight_tensor_on_device = weight_tensor;
+    std::optional<ttnn::Tensor> bias_tensor_on_device = bias_tensor;
+    if (!weight_is_on_device) {
+        // prepare weights in desired layout and move to device
+        tie(weight_tensor_on_device, bias_tensor_on_device) = prepare_conv_weights_biases_and_move_to_device(
+            weight_tensor,
+            bias_tensor,
+            conv_config.input_channels_alignment,
+            conv_config.weights_dtype,
+            opt_conv_op_block_config.act_block_w_ntiles,
+            opt_conv_op_block_config.out_subblock_w_ntiles,
+            parallel_config,
+            device,
+            groups);
+    }
+    // if 1x1 conv w/ stride 1, convert input tensor to tile layout if required
+    bool use_matmul_for_1x1_conv = kernel_size[0] == 1 && kernel_size[1] == 1 && stride[0] == stride[1] && stride[0] == 1 &&
+                                   padding[0] == 0 && padding[1] == 0 && dilation[0] == 1 && dilation[1] == 1 &&
+                                   groups == 1;
+    Tensor input_tensor_post_tm_out;
+    if (use_matmul_for_1x1_conv) {
+        input_tensor_post_tm_out = ttnn::operations::core::ToLayout::execute_on_worker_thread(
+            input_tensor_post_tm, Layout::TILE, conv_config.dtype, input_tensor_post_tm.memory_config(), &device);
+        if (conv_config.deallocate_activation) {
+            input_tensor_post_tm.deallocate();
+            // ttnn::operations::core::deallocate(input_tensor_post_tm);
+        }
+        input_tensor_post_tm = input_tensor_post_tm_out;
+    }
+    // call optimized conv op or matmul micro op
+    bool input_is_on_device = ttnn::has_storage_type_of(input_tensor_post_tm, ttnn::DEVICE_STORAGE_TYPE);
+    TT_ASSERT(input_is_on_device);
+    DeviceComputeKernelConfig compute_kernel_config;
+    if (device.arch() == ARCH::WORMHOLE_B0) {
+        compute_kernel_config = WormholeComputeKernelConfig(
+            {.math_fidelity = conv_config.math_fidelity,
+             .math_approx_mode = conv_config.math_approx_mode_enabled,
+             .fp32_dest_acc_en = conv_config.fp32_dest_acc_enabled,
+             .packer_l1_acc = conv_config.packer_l1_accum_enabled});
+    } else {
+        TT_ASSERT(device.arch() == ARCH::GRAYSKULL);
+        compute_kernel_config = GrayskullComputeKernelConfig(
+            {.math_fidelity = conv_config.math_fidelity, .math_approx_mode = conv_config.math_approx_mode_enabled});
+    }
+    if (!use_matmul_for_1x1_conv) {
+        // call halo op
+        SlidingWindowConfig sliding_window_config = SlidingWindowConfig(
+            batch_size,
+            input_height,
+            input_width,
+            kernel_size[0],
+            kernel_size[1],
+            stride[0],
+            stride[1],
+            padding[0],
+            padding[1],
+            dilation[0],
+            dilation[1],
+            opt_conv_op_parallel_config.num_cores_nhw,
+            input_tensor_post_tm.memory_config().shard_spec.value().grid,
+            true);
+        auto halo_output = ttnn::operations::halo::halo_op(
+            input_tensor_post_tm,
+            sliding_window_config,
+            0,
+            false,
+            parallel_config.shard_orientation == ShardOrientation::COL_MAJOR,
+            0,
+            input_tensor_post_tm.memory_config());
+        if (conv_config.deallocate_activation) {
+            // input_tensor_post_tm.deallocate();
+            ttnn::operations::core::deallocate(input_tensor_post_tm);
+        }
+        if (conv_config.reallocate_halo_output) {
+            auto move_output = ttnn::operations::core::reallocate(halo_output, halo_output.memory_config());
+            ttnn::operations::core::deallocate(halo_output);
+            halo_output = move_output;
+        }
+        // call conv micro op
+        std::vector<int> conv_params = {
+            (int)kernel_size[0], (int)kernel_size[1], (int)stride[0], (int)stride[1], (int)padding[0], (int)padding[1]};
+        auto conv_output = tt::tt_metal::optimized_depthwise_conv(
+            halo_output,
+            weight_tensor_on_device,
+            bias_tensor_on_device,
+            conv_params,
+            out_channels,
+            conv_config.output_layout == Layout::ROW_MAJOR,
+            conv_config.activation == "relu",
+            conv_config.math_fidelity,
+            opt_conv_op_parallel_config,
+            opt_conv_op_block_config,
+            0,
+            conv_out_memory_config,
+            conv_config.dtype,
+            {batch_size, input_height, input_width, in_channels},
+            conv_config.input_channels_alignment == 16,
+            compute_kernel_config);
+        // halo_output.deallocate();
+        ttnn::operations::core::deallocate(halo_output);
+        return {conv_output, output_height, output_width, weight_tensor_on_device, bias_tensor_on_device};
+    } else {
+        // run conv as matmul
+        uint32_t num_cores_c = get_num_cores_channels_from_parallel_config(parallel_config);
+        auto matmul_program_config = determine_matmul_op_config_from_conv_op_config(
+            opt_conv_op_parallel_config,
+            opt_conv_op_block_config,
+            parallel_config.shard_scheme == TensorMemoryLayout::HEIGHT_SHARDED,
+            conv_config.activation,
+            parallel_config.shard_orientation == ShardOrientation::COL_MAJOR,
+            num_cores_c);
+        Tensor matmul_input = input_tensor_post_tm;
+        if (stride[0] > 1) {
+            // run downsample
+            matmul_input = tt::tt_metal::downsample(
+                input_tensor_post_tm, {batch_size, input_height, input_width, stride[0], stride[1]});
+            if (conv_config.deallocate_activation) {
+                // input_tensor_post_tm.deallocate();
+                ttnn::operations::core::deallocate(input_tensor_post_tm);
+            }
+        }
+        auto matmul_output = ttnn::operations::matmul::matmul(
+            matmul_input,
+            weight_tensor_on_device,
+            bias_tensor_on_device,
+            matmul_program_config,
+            conv_out_memory_config,
+            conv_config.dtype,
+            std::nullopt, // activation fused into matmul. part of the matmul config.
+            compute_kernel_config);
+        if (conv_config.deallocate_activation) {
+            // matmul_input.deallocate();
+            ttnn::operations::core::deallocate(matmul_input);
+        }
+        return {matmul_output, output_height, output_width, weight_tensor_on_device, bias_tensor_on_device};
+    }
+}
+
+}  // namespace depthwise_conv1d
+}  // namespace operations
+}  // namespace ttnn

--- a/ttnn/cpp/ttnn/operations/depthwise_conv1d.cpp
+++ b/ttnn/cpp/ttnn/operations/depthwise_conv1d.cpp
@@ -100,7 +100,7 @@ ParallelConfig determine_parallel_config(
     auto calculate_grid = [&](uint32_t num_cores_nhw) {
         if (height_sharding) {
             uint32_t cores_x_1 = num_cores_nhw >= device_grid_size[0] ? device_grid_size[0] : num_cores_nhw;
-            uint32_t cores_y_1 = (uint32_t)(num_cores_nhw / device_grid_size[0]);
+            uint32_t cores_y_1 = num_cores_nhw > device_grid_size[0] ? (uint32_t)(num_cores_nhw / device_grid_size[0]) : 1;
             TT_ASSERT(cores_y_1 <= device_grid_size[1], "Internal Error: Incorrect num_cores_nhw");
             CoreRange core_range1 = CoreRange(CoreCoord({0, 0}), CoreCoord({cores_x_1 - 1, cores_y_1 - 1}));
             CoreRangeSet grid = CoreRangeSet({core_range1});

--- a/ttnn/cpp/ttnn/operations/depthwise_conv1d.hpp
+++ b/ttnn/cpp/ttnn/operations/depthwise_conv1d.hpp
@@ -1,0 +1,142 @@
+// SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+#include <optional>
+#include <unordered_set>
+
+#include "ttnn/core.hpp"
+#include "ttnn/operations/core.hpp"
+#include "ttnn/cpp/ttnn/operations/matmul.hpp"
+#include "ttnn/types.hpp"
+#include "tt_eager/tensor/tensor_utils.hpp"
+#include "tt_metal/impl/dispatch/command_queue.hpp"
+#include "tt_metal/common/math.hpp"
+#include "tt_eager/tt_dnn/op_library/pad/pad_op.hpp"
+#include "tt_eager/tt_dnn/op_library/depthwise_conv1d/optimized_depthwise_conv_op.hpp"
+#include "tt_eager/tensor/tensor.hpp"
+#include "tt_eager/tt_dnn/op_library/sliding_window_op_infra/sliding_window.hpp"
+#include "tt_eager/tt_dnn/op_library/sliding_window_op_infra/halo_op.hpp"
+
+namespace ttnn {
+
+namespace operations {
+namespace depthwise_conv1d {
+
+struct DepthwiseConv1dConfig {
+    MathFidelity math_fidelity = MathFidelity::HiFi4;
+    DataType dtype = DataType::BFLOAT16;
+    DataType weights_dtype = DataType::BFLOAT16;
+    bool math_approx_mode_enabled = true;
+    bool fp32_dest_acc_enabled = false;
+    bool packer_l1_accum_enabled = false;
+    string activation = "";
+    uint32_t input_channels_alignment = 32;
+    bool deallocate_activation = false;
+    bool reallocate_halo_output = false;
+    uint32_t act_block_h_override = 0;
+    bool reshard_if_not_optimal = false; // if true, override_sharding_config should not be set to true
+    bool override_sharding_config = false; // if true, reshard_if_not_optimal should not be set to true
+    bool height_sharding = true; // used only if override_sharding_config is true
+    std::optional<CoreRangeSet> core_grid = std::nullopt; // used only if override_sharding_config is true
+    bool transpose_shards = true; // used only if override_sharding_config is true and if height sharding is false
+    Layout output_layout = Layout::TILE;
+    static constexpr auto attribute_names = std::make_tuple(
+        "math_fidelity",
+        "dtype",
+        "weights_dtype",
+        "math_approx_mode_enabled",
+        "fp32_dest_acc_enabled",
+        "packer_l1_accum_enabled",
+        "activation",
+        "input_channels_alignment",
+        "deallocate_activation",
+        "reallocate_halo_output",
+        "act_block_h_override",
+        "reshard_if_not_optimal",
+        "override_sharding_config",
+        "height_sharding",
+        "core_grid",
+        "transpose_shards",
+        "output_layout");
+    const auto attribute_values() const {
+        return std::make_tuple(
+            std::cref(this->math_fidelity),
+            std::cref(this->dtype),
+            std::cref(this->weights_dtype),
+            std::cref(this->math_approx_mode_enabled),
+            std::cref(this->fp32_dest_acc_enabled),
+            std::cref(this->packer_l1_accum_enabled),
+            std::cref(this->activation),
+            std::cref(this->input_channels_alignment),
+            std::cref(this->deallocate_activation),
+            std::cref(this->reallocate_halo_output),
+            std::cref(this->act_block_h_override),
+            std::cref(this->reshard_if_not_optimal),
+            std::cref(this->override_sharding_config),
+            std::cref(this->height_sharding),
+            std::cref(this->core_grid),
+            std::cref(this->transpose_shards),
+            std::cref(this->output_layout));
+    }
+};
+
+extern const std::array<ttnn::TensorSchema, 3> input_schemas;
+
+uint32_t find_closest_largest_divisor(uint32_t num, uint32_t start_divisor);
+
+uint32_t find_closest_largest_divisor_with_num_padding(uint32_t num, uint32_t start_divisor);
+
+uint32_t find_closest_common_largest_divisor(uint32_t num1, uint32_t num2, uint32_t start_divisor);
+
+ParallelConfig determine_parallel_config(
+        bool height_sharding,
+        uint32_t batch_size,
+        uint32_t input_channels,
+        uint32_t output_height,
+        uint32_t output_width,
+        uint32_t output_channels,
+        Device& device,
+        ShardOrientation block_shard_orientation,
+        bool is_out_tiled=true);
+
+uint32_t get_num_cores_nhw_from_parallel_config(const ParallelConfig& pconfig);
+
+uint32_t get_num_cores_channels_from_parallel_config(const ParallelConfig& pconfig);
+
+MemoryConfig create_sharded_memory_config_from_parallel_config(const Shape& tensor_shape, ParallelConfig& parallel_config, uint32_t tile_size);
+
+tt::tt_metal::OptimizedDepthwiseConvParallelizationConfig determine_conv_op_parallel_config_from_conv_output_mem_config(const MemoryConfig& conv_output_mem_config, uint32_t num_cores_nhw);
+
+std::pair<uint32_t, uint32_t> determine_largest_subblock_size(uint32_t block_height, uint32_t block_width, bool fp32_accum);
+
+tt::tt_metal::OptimizedDepthwiseConvBlockConfig determine_per_core_conv_block_config(const ParallelConfig& parallel_config, const tt::tt_metal::OptimizedDepthwiseConvParallelizationConfig& conv_op_parallel_config, uint32_t padded_in_channels, uint32_t act_block_h_override, uint32_t window_w, bool fp32_accum, bool use_shallow_conv_variant);
+
+std::tuple<ttnn::Tensor, ParallelConfig, bool>  shard_or_reshard_tensor_if_required(Device& device, const ttnn::Tensor& input_tensor_, const DepthwiseConv1dConfig& conv_config, uint32_t batch_size, uint32_t height, uint32_t width, uint32_t in_channels, uint32_t out_channels);
+
+void validate_weight_and_bias_tensors(const ttnn::Tensor& weight_tensor, std::optional<const ttnn::Tensor>& bias_tensor);
+
+std::pair<ttnn::Tensor, std::optional<ttnn::Tensor>> prepare_conv_weights_biases_and_move_to_device(const ttnn::Tensor& weight_tensor, std::optional<const ttnn::Tensor>& bias_tensor, uint32_t input_channels_alignment, DataType weights_bias_dtype, uint32_t weight_block_h_ntiles, uint32_t weight_block_w_ntiles, const ParallelConfig& parallel_config, Device& device);
+std::tuple<ttnn::Tensor, uint32_t, uint32_t, ttnn::Tensor, std::optional<ttnn::Tensor>> depthwise_conv1d(
+    const ttnn::Tensor& input_tensor,
+    const ttnn::Tensor& weight_tensor,
+    ttnn::Device& device,
+    uint32_t in_channels,
+    uint32_t out_channels,
+    uint32_t batch_size,
+    uint32_t input_height,
+    uint32_t input_width,
+    std::array<uint32_t, 2> kernel_size,
+    std::array<uint32_t, 2> stride,
+    std::array<uint32_t, 2> padding,
+    std::array<uint32_t, 2> dilation,
+    uint32_t groups,
+    std::optional<const ttnn::Tensor> bias_tensor = std::nullopt,
+    std::optional<const DepthwiseConv1dConfig> conv_config_ = std::nullopt
+    );
+
+
+}  // namespace depthwise_conv1d
+}  // namespace operations
+}  // namespace ttnn

--- a/ttnn/ttnn/__init__.py
+++ b/ttnn/ttnn/__init__.py
@@ -478,6 +478,7 @@ from ttnn.operations.ccl import all_gather
 from ttnn.operations import transformer
 from ttnn.operations import kv_cache
 from ttnn.operations.conv2d import Conv2d, conv2d, Conv2dConfig, get_conv_output_dim
+from ttnn.operations.depthwise_conv1d import depthwise_conv1d, DepthwiseConv1dConfig
 from ttnn.operations.pool import (
     MaxPool2d,
     global_avg_pool2d,

--- a/ttnn/ttnn/operations/depthwise_conv1d.py
+++ b/ttnn/ttnn/operations/depthwise_conv1d.py
@@ -1,0 +1,87 @@
+# SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+
+# SPDX-License-Identifier: Apache-2.0
+
+from typing import Tuple, Union, Dict, Optional
+import torch
+import warnings
+import math
+import ttnn
+
+import ttnn.experimental
+
+DepthwiseConv1dConfig = ttnn._ttnn.operations.depthwise_conv1d.DepthwiseConv1dConfig
+
+
+def _depthwise_conv_op_validate_input_tensors(operation_name, input_tensor, *args, **kwargs):
+    ttnn.validate_input_tensor(
+        operation_name,
+        input_tensor,
+        ranks=(4,),
+        dtypes=(ttnn.bfloat16, ttnn.bfloat8_b),
+        layouts=(ttnn.TILE_LAYOUT, ttnn.ROW_MAJOR_LAYOUT),
+        can_be_on_device=True,
+        can_be_on_cpu=True,
+    )
+
+
+@ttnn.register_operation(name="ttnn.depthwise_conv1d", validate_input_tensors=_depthwise_conv_op_validate_input_tensors)
+def depthwise_conv1d(
+    *,
+    input_tensor: ttnn.Tensor,  # may or may not be sharded
+    weight_tensor: ttnn.Tensor,
+    device: ttnn.Device,
+    in_channels: int,
+    out_channels: int,
+    batch_size: int,
+    input_height: int,
+    input_width: int,
+    kernel_size: Union[int, Tuple[int, int]],
+    stride: Union[int, Tuple[int, int]],
+    padding: Union[int, Tuple[int, int]],
+    dilation: Union[int, Tuple[int, int]] = (1, 1),
+    groups: int = 1,
+    bias_tensor: ttnn.Tensor = None,
+    conv_config: DepthwiseConv1dConfig = None,  # config overrides by user
+    conv_op_cache={},  # basic conv object caching in python needed for intermediate refactoring. Not needed after full op refactoring in C++.
+    debug=False,
+) -> Tuple[ttnn.Tensor, int, int, ttnn.Tensor, ttnn.Tensor]:
+    run_new_conv = True
+    if debug:
+        deallocate_act_debug_mode = conv_config.deallocate_activation
+        conv_config.deallocate_activation = False
+    if run_new_conv:
+        (
+            output_tensor_new,
+            output_height_new,
+            output_width_new,
+            weight_tensor_on_dev_new,
+            bias_tensor_on_dev_new,
+        ) = ttnn._ttnn.operations.depthwise_conv1d.depthwise_conv1d(
+            input_tensor=input_tensor,
+            weight_tensor=weight_tensor,
+            device=device,
+            in_channels=in_channels,
+            out_channels=out_channels,
+            batch_size=batch_size,
+            input_height=input_height,
+            input_width=input_width,
+            kernel_size=kernel_size,
+            stride=stride,
+            padding=padding,
+            dilation=dilation,
+            groups=groups,
+            bias_tensor=bias_tensor,
+            conv_config=conv_config,
+        )
+        if not debug:
+            return (
+                output_tensor_new,
+                output_height_new,
+                output_width_new,
+                weight_tensor_on_dev_new,
+                bias_tensor_on_dev_new,
+            )
+
+
+__all__ = []


### PR DESCRIPTION
### Ticket
- [Link to Github Issue.](https://github.com/tenstorrent/tt-metal/issues/8937)

### Problem description
- Mamba prefill model has a requirement for depthwise conv1d op. Existing Conv2d op in tt-metal can be used for 1D inputs and 1D kernel but its group convolution feature is insufficient for mamba conv specification. Presently, group convolution is implemented by generating masked convolution weights and then applying normal convolution. This however, makes Conv2D out of L1 for large number input channels (5120 in case of mamba), also its computationally inefficient as it scales with num of masked input channels.

### Design Slides
Please checkout the slides [here](https://tenstorrent-my.sharepoint.com/:p:/p/kpaigwar/EU2ovrHbvfBJoXRobWTGkp0BC5IxwD3TVyasa7Vh9CsFow?e=IgcvNr).

### Describe the approach used to solve the problem.
- Rather recreating the full weight matrix and masking the non-group channels. 
- We used the existing convolution pipeline with output_channels=1. We modified the compute kernel such that weights are multiplied with corresponding input channels and then reduced across filter length.

Summarize the changes made and its impact.
- duplicated `ttnn.conv2d` Op code for `ttnn.depthwise_conv1d`. Once group feature in ttnn.conv2d is optimized, we can delete this Op.
- added `test_depthwiseconv1d.py` to incorporate broadcasting and forcing output channels=1 for weights.
- function `compute_output_shape()` is modified such that `output_channels=input_channels`.
- In hostcode, removed 1d filter constraint, added new buffers for compute kernel, removed double buffering of weights.
- removed `static_assert(coalesced_read_bytes <= NOC_MAX_BURST_SIZE)` from halo and reader kernel to support larger input_channels>=5120.
- replaced ` noc_async_read_one_packet_with_state<true>()` call with `noc_async_read(get_noc_addr()` to fix PCC errors.
- forced rereading of weights to save L1 space.
- added new compute kernel which perform eltwise multiplication and reductions of blocks.


### Test Summary

`PCC = 0.9996` for all the unit tests.
```
================================================================================== short test summary info ==================================================================================
PASSED tests/ttnn/unit_tests/operations/test_depthwise_conv1d.py::test_mamba_conv_wh[enable_auto_formatting=True-math_fidelity=MathFidelity.LoFi-fp32_accum=True-activations_dtype=DataType.B
FLOAT16-weights_dtype=DataType.BFLOAT8_B-batch_size=1-output_channels=1-input_channels=32-input_height=1024-input_width=1-filter_height=4-filter_width=1-stride_h=1-stride_w=1-pad_h=3-pad_w=
0-groups=32-use_1d_systolic_array=True-config_override=None-device_params={'l1_small_size': 16384}]
PASSED tests/ttnn/unit_tests/operations/test_depthwise_conv1d.py::test_mamba_conv_wh[enable_auto_formatting=True-math_fidelity=MathFidelity.LoFi-fp32_accum=True-activations_dtype=DataType.B
FLOAT16-weights_dtype=DataType.BFLOAT8_B-batch_size=1-output_channels=1-input_channels=512-input_height=1024-input_width=1-filter_height=4-filter_width=1-stride_h=1-stride_w=1-pad_h=3-pad_w
=0-groups=512-use_1d_systolic_array=True-config_override=None-device_params={'l1_small_size': 16384}]
PASSED tests/ttnn/unit_tests/operations/test_depthwise_conv1d.py::test_mamba_conv_wh[enable_auto_formatting=True-math_fidelity=MathFidelity.LoFi-fp32_accum=True-activations_dtype=DataType.B
FLOAT16-weights_dtype=DataType.BFLOAT8_B-batch_size=1-output_channels=1-input_channels=2560-input_height=1760-input_width=1-filter_height=4-filter_width=1-stride_h=1-stride_w=1-pad_h=3-pad_
w=0-groups=2560-use_1d_systolic_array=True-config_override=None-device_params={'l1_small_size': 16384}]
PASSED tests/ttnn/unit_tests/operations/test_depthwise_conv1d.py::test_mamba_conv_wh[enable_auto_formatting=True-math_fidelity=MathFidelity.LoFi-fp32_accum=True-activations_dtype=DataType.B
FLOAT16-weights_dtype=DataType.BFLOAT8_B-batch_size=1-output_channels=1-input_channels=5120-input_height=1760-input_width=1-filter_height=4-filter_width=1-stride_h=1-stride_w=1-pad_h=3-pad_
w=0-groups=5120-use_1d_systolic_array=True-config_override=None-device_params={'l1_small_size': 16384}]
==================================================================================== 4 passed in 20.76s =====================================================================================
```

### Perf Summary

Input Channels | Seq Length | Input DF | Weights DF | Output DF | PCC | Duration [ms]
-- | -- | -- | -- | -- | -- | --
2560 | 1760 | BFLOAT16 | BFP8_b | BFP8_b | 0.9996 | 0.262
5120 | 1760 | BFLOAT16 | BFP8_b | BFP8_b | 0.9996 | 0.516

perf report for 5120 input channels : [ops_perf_results_2024_06_07_17_35_48.csv](https://github.com/user-attachments/files/15874778/ops_perf_results_2024_06_07_17_35_48.csv)


