### PR TITLE
#8683: Add Unary bitwise XOR, NOT

### DIFF
--- a/docs/source/ttnn/ttnn/dependencies/tt_lib.rst
+++ b/docs/source/ttnn/ttnn/dependencies/tt_lib.rst
@@ -407,6 +407,8 @@ Tensor elementwise operations
 
 .. autofunction:: tt_lib.tensor.bitwise_xor
 
+.. autofunction:: tt_lib.tensor.bitwise_not
+
 .. autofunction:: tt_lib.tensor.right_shift
 
 .. autofunction:: tt_lib.tensor.left_shift

--- a/docs/source/ttnn/ttnn/dependencies/tt_lib.rst
+++ b/docs/source/ttnn/ttnn/dependencies/tt_lib.rst
@@ -405,6 +405,8 @@ Tensor elementwise operations
 
 .. autofunction:: tt_lib.tensor.heaviside
 
+.. autofunction:: tt_lib.tensor.bitwise_xor
+
 .. autofunction:: tt_lib.tensor.right_shift
 
 .. autofunction:: tt_lib.tensor.left_shift

--- a/tests/tt_eager/python_api_testing/sweep_tests/op_map.py
+++ b/tests/tt_eager/python_api_testing/sweep_tests/op_map.py
@@ -492,6 +492,10 @@ op_map = {
         "tt_op": tt_lib_ops.eltwise_heaviside,
         "pytorch_op": pytorch_ops.heaviside,
     },
+    "eltwise-bitwise_xor": {
+        "tt_op": tt_lib_ops.eltwise_bitwise_xor,
+        "pytorch_op": pytorch_ops.bitwise_xor,
+    },
     "eltwise-right_shift": {
         "tt_op": tt_lib_ops.eltwise_right_shift,
         "pytorch_op": pytorch_ops.right_shift,

--- a/tests/tt_eager/python_api_testing/sweep_tests/op_map.py
+++ b/tests/tt_eager/python_api_testing/sweep_tests/op_map.py
@@ -496,6 +496,10 @@ op_map = {
         "tt_op": tt_lib_ops.eltwise_bitwise_xor,
         "pytorch_op": pytorch_ops.bitwise_xor,
     },
+    "eltwise-bitwise_not": {
+        "tt_op": tt_lib_ops.eltwise_bitwise_not,
+        "pytorch_op": pytorch_ops.bitwise_not,
+    },
     "eltwise-right_shift": {
         "tt_op": tt_lib_ops.eltwise_right_shift,
         "pytorch_op": pytorch_ops.right_shift,

--- a/tests/tt_eager/python_api_testing/sweep_tests/pytests/tt_dnn/test_bitwise_not.py
+++ b/tests/tt_eager/python_api_testing/sweep_tests/pytests/tt_dnn/test_bitwise_not.py
@@ -4,7 +4,6 @@
 
 import pytest
 import torch
-import random
 from functools import partial
 import tt_lib as ttl
 
@@ -26,7 +25,7 @@ mem_configs = [
 
 @pytest.mark.parametrize(
     "scalar",
-    {random.randint(-100, 100) for _ in range(10)},
+    (1, 1),
 )
 @pytest.mark.parametrize(
     "input_shapes",
@@ -41,8 +40,8 @@ mem_configs = [
     mem_configs,
 )
 @skip_for_grayskull("#TODO: GS implementation needs to be done")
-class TestBitwiseXor:
-    def test_run_bitwise_xor_op(
+class TestBitwiseNot:
+    def test_run_bitwise_not_op(
         self,
         scalar,
         input_shapes,
@@ -50,7 +49,9 @@ class TestBitwiseXor:
         device,
     ):
         datagen_func = [
-            generation_funcs.gen_func_with_cast(partial(generation_funcs.gen_rand, low=0, high=2147483647), torch.int)
+            generation_funcs.gen_func_with_cast(
+                partial(generation_funcs.gen_rand, low=-2147483647, high=2147483647), torch.int
+            )
         ]
         test_args = generation_funcs.gen_default_dtype_layout_device(input_shapes)[0]
         test_args.update(
@@ -63,7 +64,7 @@ class TestBitwiseXor:
         comparison_func = comparison_funcs.comp_equal
 
         run_single_pytorch_test(
-            "eltwise-bitwise_xor",
+            "eltwise-bitwise_not",
             input_shapes,
             datagen_func,
             comparison_func,

--- a/tests/tt_eager/python_api_testing/sweep_tests/pytests/tt_dnn/test_bitwise_xor.py
+++ b/tests/tt_eager/python_api_testing/sweep_tests/pytests/tt_dnn/test_bitwise_xor.py
@@ -1,0 +1,71 @@
+# SPDX-FileCopyrightText: © 2023-24 Tenstorrent Inc.
+
+# SPDX-License-Identifier: Apache-2.0
+
+import pytest
+import torch
+from functools import partial
+import tt_lib as ttl
+
+
+from tests.tt_eager.python_api_testing.sweep_tests import (
+    comparison_funcs,
+    generation_funcs,
+)
+from tests.tt_eager.python_api_testing.sweep_tests.run_pytorch_ci_tests import (
+    run_single_pytorch_test,
+)
+from models.utility_functions import skip_for_grayskull
+
+mem_configs = [
+    ttl.tensor.MemoryConfig(ttl.tensor.TensorMemoryLayout.INTERLEAVED, ttl.tensor.BufferType.DRAM),
+    ttl.tensor.MemoryConfig(ttl.tensor.TensorMemoryLayout.INTERLEAVED, ttl.tensor.BufferType.L1),
+]
+
+
+@pytest.mark.parametrize(
+    "scalar",
+    (-465789, -5463, -1, 0, 1, 746, 21474),
+)
+@pytest.mark.parametrize(
+    "input_shapes",
+    [
+        [[1, 1, 32, 32]],
+        [[4, 3, 32, 32]],
+        [[2, 2, 32, 32]],
+    ],
+)
+@pytest.mark.parametrize(
+    "dst_mem_config",
+    mem_configs,
+)
+@skip_for_grayskull("#TODO: GS implementation needs to be done")
+class TestBitwiseXor:
+    def test_run_bitwise_xor_op(
+        self,
+        scalar,
+        input_shapes,
+        dst_mem_config,
+        device,
+    ):
+        datagen_func = [
+            generation_funcs.gen_func_with_cast(partial(generation_funcs.gen_rand, low=0, high=2147483647), torch.int)
+        ]
+        test_args = generation_funcs.gen_default_dtype_layout_device(input_shapes)[0]
+        test_args.update(
+            {
+                "value": scalar,
+                "dtype": [(ttl.tensor.DataType.INT32)],
+            }
+        )
+        test_args.update({"output_mem_config": dst_mem_config})
+        comparison_func = comparison_funcs.comp_equal
+
+        run_single_pytorch_test(
+            "eltwise-bitwise_xor",
+            input_shapes,
+            datagen_func,
+            comparison_func,
+            device,
+            test_args,
+        )

--- a/tests/tt_eager/python_api_testing/sweep_tests/pytorch_ops.py
+++ b/tests/tt_eager/python_api_testing/sweep_tests/pytorch_ops.py
@@ -533,6 +533,11 @@ def bitwise_xor(x, *args, **kwargs):
     return result
 
 
+def bitwise_not(x, *args, **kwargs):
+    result = torch.bitwise_not(x)
+    return result
+
+
 def right_shift(x, *args, **kwargs):
     value = kwargs.pop("value")
     result = torch.bitwise_right_shift(x, value)

--- a/tests/tt_eager/python_api_testing/sweep_tests/pytorch_ops.py
+++ b/tests/tt_eager/python_api_testing/sweep_tests/pytorch_ops.py
@@ -527,6 +527,12 @@ def heaviside(x, *args, **kwargs):
     return result
 
 
+def bitwise_xor(x, *args, **kwargs):
+    value = kwargs.pop("value")
+    result = torch.bitwise_xor(x, value)
+    return result
+
+
 def right_shift(x, *args, **kwargs):
     value = kwargs.pop("value")
     result = torch.bitwise_right_shift(x, value)

--- a/tests/tt_eager/python_api_testing/sweep_tests/tt_lib_ops.py
+++ b/tests/tt_eager/python_api_testing/sweep_tests/tt_lib_ops.py
@@ -1207,6 +1207,24 @@ def lamb_optimizer(
 
 
 @setup_host_and_device
+def eltwise_bitwise_xor(
+    x,
+    *args,
+    value,
+    device,
+    dtype,
+    layout,
+    input_mem_config,
+    output_mem_config,
+    **kwargs,
+):
+    t0 = setup_tt_tensor(x, device, layout[0], input_mem_config[0], dtype[0])
+    t1 = ttl.tensor.bitwise_xor(t0, value, output_mem_config=output_mem_config)
+
+    return tt2torch_tensor(t1)
+
+
+@setup_host_and_device
 def eltwise_right_shift(
     x,
     *args,

--- a/tests/tt_eager/python_api_testing/sweep_tests/tt_lib_ops.py
+++ b/tests/tt_eager/python_api_testing/sweep_tests/tt_lib_ops.py
@@ -1225,6 +1225,24 @@ def eltwise_bitwise_xor(
 
 
 @setup_host_and_device
+def eltwise_bitwise_not(
+    x,
+    *args,
+    value,
+    device,
+    dtype,
+    layout,
+    input_mem_config,
+    output_mem_config,
+    **kwargs,
+):
+    t0 = setup_tt_tensor(x, device, layout[0], input_mem_config[0], dtype[0])
+    t1 = ttl.tensor.bitwise_not(t0, value, output_mem_config=output_mem_config)
+
+    return tt2torch_tensor(t1)
+
+
+@setup_host_and_device
 def eltwise_right_shift(
     x,
     *args,

--- a/tt_eager/tt_dnn/op_library/eltwise_unary/eltwise_unary_op.cpp
+++ b/tt_eager/tt_dnn/op_library/eltwise_unary/eltwise_unary_op.cpp
@@ -65,6 +65,7 @@ void update_macro_defines(UnaryOpType op_type, std::map<std::string, std::string
         case UnaryOpType::NEG: defines["SFPU_OP_NEG_INCLUDE"] = "1"; break;
         case UnaryOpType::SOFTPLUS: defines["SFPU_OP_SOFTPLUS_INCLUDE"] = "1"; break;
         case UnaryOpType::TYPECAST: defines["SFPU_OP_TYPECAST_INCLUDE"] = "1"; break;
+        case UnaryOpType::BITWISE_XOR: defines["SFPU_OP_BITWISE_XOR_INCLUDE"] = "1"; break;
         case UnaryOpType::RIGHT_SHIFT: defines["SFPU_OP_RIGHT_SHIFT_INCLUDE"] = "1"; break;
         case UnaryOpType::FLOOR: defines["SFPU_OP_FLOOR_INCLUDE"] = "1"; break;
         case UnaryOpType::LEFT_SHIFT: defines["SFPU_OP_LEFT_SHIFT_INCLUDE"] = "1"; break;
@@ -111,6 +112,10 @@ std::pair<string, string> get_op_init_and_func_parameterized(
         case UnaryOpType::HEAVISIDE:
             op_init_and_name = {
                 "heaviside_tile_init();", fmt::format("heaviside_tile({}, {}u);", idst, Converter::to_hex(param0))};
+            break;
+        case UnaryOpType::BITWISE_XOR:
+            op_init_and_name = {
+                "bitwise_xor_tile_init();", fmt::format("bitwise_xor_tile({}, {}u);", idst, std::to_string((uint)param0))};
             break;
         case UnaryOpType::RIGHT_SHIFT:
             op_init_and_name = {

--- a/tt_eager/tt_dnn/op_library/eltwise_unary/eltwise_unary_op.cpp
+++ b/tt_eager/tt_dnn/op_library/eltwise_unary/eltwise_unary_op.cpp
@@ -66,6 +66,7 @@ void update_macro_defines(UnaryOpType op_type, std::map<std::string, std::string
         case UnaryOpType::SOFTPLUS: defines["SFPU_OP_SOFTPLUS_INCLUDE"] = "1"; break;
         case UnaryOpType::TYPECAST: defines["SFPU_OP_TYPECAST_INCLUDE"] = "1"; break;
         case UnaryOpType::BITWISE_XOR: defines["SFPU_OP_BITWISE_XOR_INCLUDE"] = "1"; break;
+        case UnaryOpType::BITWISE_NOT: defines["SFPU_OP_BITWISE_NOT_INCLUDE"] = "1"; break;
         case UnaryOpType::RIGHT_SHIFT: defines["SFPU_OP_RIGHT_SHIFT_INCLUDE"] = "1"; break;
         case UnaryOpType::FLOOR: defines["SFPU_OP_FLOOR_INCLUDE"] = "1"; break;
         case UnaryOpType::LEFT_SHIFT: defines["SFPU_OP_LEFT_SHIFT_INCLUDE"] = "1"; break;
@@ -116,6 +117,10 @@ std::pair<string, string> get_op_init_and_func_parameterized(
         case UnaryOpType::BITWISE_XOR:
             op_init_and_name = {
                 "bitwise_xor_tile_init();", fmt::format("bitwise_xor_tile({}, {}u);", idst, std::to_string((uint)param0))};
+            break;
+        case UnaryOpType::BITWISE_NOT:
+            op_init_and_name = {
+                "bitwise_not_tile_init();", fmt::format("bitwise_not_tile({}, {}u);", idst, std::to_string((uint)param0))};
             break;
         case UnaryOpType::RIGHT_SHIFT:
             op_init_and_name = {
@@ -346,13 +351,19 @@ namespace tt {
 
 namespace tt_metal {
 
-inline void validate_supported_arch(tt::ARCH arch, UnaryOpType op_type) {
+inline void validate_supported_arch_dtype(tt::ARCH arch, DataType input_datatype, DataType output_datatype, UnaryOpType op_type) {
     switch (op_type) {
         case UnaryOpType::REMAINDER:
         case UnaryOpType::FLOOR:
         case UnaryOpType::LEFT_SHIFT:
         case UnaryOpType::RIGHT_SHIFT:
             TT_FATAL(arch == tt::ARCH::WORMHOLE_B0, "Op is only supported on Wormhole");
+            break;
+        case UnaryOpType::BITWISE_XOR:
+        case UnaryOpType::BITWISE_NOT:
+            TT_FATAL(arch == tt::ARCH::WORMHOLE_B0, "Op is only supported on Wormhole");
+            TT_FATAL(input_datatype == DataType::INT32, "Data type is not supported for Bitwise operations");
+            TT_FATAL(output_datatype == DataType::INT32, "Data type is not supported for Bitwise operations");
             break;
         default:
             return;
@@ -362,10 +373,15 @@ inline void validate_supported_arch(tt::ARCH arch, UnaryOpType op_type) {
 void EltwiseUnary::validate_with_output_tensors(const std::vector<Tensor> &input_tensors, const std::vector<std::optional<Tensor>> &optional_output_tensors) const {
     const auto& input_tensor_a = input_tensors.at(0);
     auto out_mem_config = (!optional_output_tensors.empty() && optional_output_tensors.at(0).has_value()) ? optional_output_tensors.at(0).value().memory_config() : this->output_mem_config;
-
+    auto output_datatype = output_dtype;
+    if(!optional_output_tensors.empty() && optional_output_tensors.at(0).has_value()){
+        const auto& out = optional_output_tensors.at(0);
+        output_datatype = out->get_dtype();
+    }
     auto arch = input_tensor_a.device()->arch();
+    auto input_datatype = input_tensor_a.get_dtype();
     for (const auto& unary_op : this->op_chain) {
-        validate_supported_arch(arch, unary_op.op_type);
+        validate_supported_arch_dtype(arch, input_datatype, output_datatype, unary_op.op_type);
     }
     TT_FATAL(input_tensor_a.storage_type() == StorageType::DEVICE, "Operands to eltwise unary need to be on device!");
     TT_FATAL(

--- a/tt_eager/tt_dnn/op_library/eltwise_unary/eltwise_unary_op.hpp
+++ b/tt_eager/tt_dnn/op_library/eltwise_unary/eltwise_unary_op.hpp
@@ -79,6 +79,7 @@ enum class UnaryOpType {
     UNARY_LT,
     TILED_PROD,
     TYPECAST,
+    BITWISE_XOR,
     RIGHT_SHIFT,
     FLOOR,
     LEFT_SHIFT,
@@ -110,6 +111,7 @@ bool is_parametrized_type(T val) {
         case UnaryOpType::UNARY_GT:
         case UnaryOpType::UNARY_LT:
         case UnaryOpType::TYPECAST:
+        case UnaryOpType::BITWISE_XOR:
         case UnaryOpType::RIGHT_SHIFT:
         case UnaryOpType::LEFT_SHIFT:
         case UnaryOpType::REMAINDER: return true;
@@ -415,6 +417,7 @@ constexpr auto leaky_relu = make_eltwise_unary_with_param<UnaryOpType::LEAKY_REL
 constexpr auto prelu = leaky_relu;
 constexpr auto elu = make_eltwise_unary_with_param<UnaryOpType::ELU>{};
 constexpr auto heaviside = make_eltwise_unary_with_param<UnaryOpType::HEAVISIDE>{};
+constexpr auto bitwise_xor = make_eltwise_unary_with_param<UnaryOpType::BITWISE_XOR>{};
 constexpr auto right_shift = make_eltwise_unary_with_param<UnaryOpType::RIGHT_SHIFT>{};
 constexpr auto left_shift = make_eltwise_unary_with_param<UnaryOpType::LEFT_SHIFT>{};
 constexpr auto unary_remainder = make_eltwise_unary_with_param<UnaryOpType::REMAINDER>{};

--- a/tt_eager/tt_dnn/op_library/eltwise_unary/eltwise_unary_op.hpp
+++ b/tt_eager/tt_dnn/op_library/eltwise_unary/eltwise_unary_op.hpp
@@ -80,6 +80,7 @@ enum class UnaryOpType {
     TILED_PROD,
     TYPECAST,
     BITWISE_XOR,
+    BITWISE_NOT,
     RIGHT_SHIFT,
     FLOOR,
     LEFT_SHIFT,
@@ -112,6 +113,7 @@ bool is_parametrized_type(T val) {
         case UnaryOpType::UNARY_LT:
         case UnaryOpType::TYPECAST:
         case UnaryOpType::BITWISE_XOR:
+        case UnaryOpType::BITWISE_NOT:
         case UnaryOpType::RIGHT_SHIFT:
         case UnaryOpType::LEFT_SHIFT:
         case UnaryOpType::REMAINDER: return true;
@@ -418,6 +420,7 @@ constexpr auto prelu = leaky_relu;
 constexpr auto elu = make_eltwise_unary_with_param<UnaryOpType::ELU>{};
 constexpr auto heaviside = make_eltwise_unary_with_param<UnaryOpType::HEAVISIDE>{};
 constexpr auto bitwise_xor = make_eltwise_unary_with_param<UnaryOpType::BITWISE_XOR>{};
+constexpr auto bitwise_not = make_eltwise_unary_with_param<UnaryOpType::BITWISE_NOT>{};
 constexpr auto right_shift = make_eltwise_unary_with_param<UnaryOpType::RIGHT_SHIFT>{};
 constexpr auto left_shift = make_eltwise_unary_with_param<UnaryOpType::LEFT_SHIFT>{};
 constexpr auto unary_remainder = make_eltwise_unary_with_param<UnaryOpType::REMAINDER>{};

--- a/tt_eager/tt_lib/csrc/tt_lib_bindings_tensor_xary_ops.cpp
+++ b/tt_eager/tt_lib/csrc/tt_lib_bindings_tensor_xary_ops.cpp
@@ -195,6 +195,23 @@ namespace tt::tt_metal::detail {
 
         )doc");
 
+        m_tensor.def("bitwise_xor",bitwise_xor,
+            py::arg("input").noconvert(),py::arg("value"),py::arg("output_mem_config").noconvert() = operation::DEFAULT_OUTPUT_MEMORY_CONFIG,R"doc(
+            Computes bitwise_xor of input tensor ``input`` by a scalar ``value``. Input tensor needs to be positive. Support provided only for Wormhole_B0.
+
+            Input tensor must have INT32 data type.
+
+            Output tensor will have INT32 data type.
+
+            .. csv-table::
+                :header: "Argument", "Description", "Data type", "Valid range", "Required"
+
+                "input", "Input Tensor", "Tensor", "Tensor of shape [W, Z, Y, X]", "Yes"
+                "value", "scalar value", "int", "", "Yes"
+                "output_mem_config", "Layout of tensor in TT Accelerator device memory banks", "MemoryConfig", "Default is interleaved in DRAM", "No"
+
+        )doc");
+
         m_tensor.def("right_shift",right_shift,
             py::arg("input").noconvert(),py::arg("shift_amt"),py::arg("output_mem_config").noconvert() = operation::DEFAULT_OUTPUT_MEMORY_CONFIG,R"doc(
             Computes right shift of input tensor ``input`` by ``shift_amt`` bits. ``shift_amt`` range must be [0, 31]. Support provided only for Wormhole_B0.

--- a/tt_eager/tt_lib/csrc/tt_lib_bindings_tensor_xary_ops.cpp
+++ b/tt_eager/tt_lib/csrc/tt_lib_bindings_tensor_xary_ops.cpp
@@ -212,6 +212,22 @@ namespace tt::tt_metal::detail {
 
         )doc");
 
+        m_tensor.def("bitwise_not",bitwise_not,
+            py::arg("input").noconvert(),py::arg("value"),py::arg("output_mem_config").noconvert() = operation::DEFAULT_OUTPUT_MEMORY_CONFIG,R"doc(
+            Computes bitwise_not of input tensor ``input``. Input tensor needs to be in the range [-2147483647, 2147483647]. Support provided only for Wormhole_B0.
+
+            Input tensor must have INT32 data type.
+
+            Output tensor will have INT32 data type.
+
+            .. csv-table::
+                :header: "Argument", "Description", "Data type", "Valid range", "Required"
+
+                "input", "Input Tensor", "Tensor", "Tensor of shape [W, Z, Y, X]", "Yes"
+                "output_mem_config", "Layout of tensor in TT Accelerator device memory banks", "MemoryConfig", "Default is interleaved in DRAM", "No"
+
+        )doc");
+
         m_tensor.def("right_shift",right_shift,
             py::arg("input").noconvert(),py::arg("shift_amt"),py::arg("output_mem_config").noconvert() = operation::DEFAULT_OUTPUT_MEMORY_CONFIG,R"doc(
             Computes right shift of input tensor ``input`` by ``shift_amt`` bits. ``shift_amt`` range must be [0, 31]. Support provided only for Wormhole_B0.

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_math_unary_sfpu_api.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_math_unary_sfpu_api.h
@@ -27,5 +27,7 @@
 #include "llk_math_eltwise_unary_sfpu_trigonometry.h"
 #include "llk_math_eltwise_unary_sfpu_unary_comp.h"
 #include "llk_math_eltwise_unary_sfpu_remainder.h"
+#include "llk_math_eltwise_unary_sfpu_bitwise_xor.h"
+#include "llk_math_eltwise_unary_sfpu_bitwise_not.h"
 #include "llk_math_eltwise_unary_sfpu_right_shift.h"
 #include "llk_math_eltwise_unary_sfpu_left_shift.h"

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_bitwise_not.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_bitwise_not.h
@@ -6,8 +6,8 @@
 
 #include "ckernel.h"
 #include "ckernel_defs.h"
+#include "sfpi.h"
 #include "noc_nonblocking_api.h"
-#include "limits.h"
 
 using namespace sfpi;
 
@@ -15,21 +15,26 @@ namespace ckernel {
 namespace sfpu {
 
 template <bool APPROXIMATION_MODE, int ITERATIONS = 8>
-inline void calculate_bitwise_xor(const uint value) {
+inline void calculate_bitwise_not(const uint value) {
 #pragma GCC unroll 0
     for (int d = 0; d < ITERATIONS; d++) {
         vInt input = dst_reg[0];
-        vInt v = value;
-        vInt res = input ^ v;
-        v_if(res > INT_MIN && res < 0)
-        {
-            res = 0 - res;
-            res = setsgn(res, v);
+        vInt res;
+
+        v_if(input < 0) {
+            vInt unsigned_mag = input & 0x7FFFFFFF;
+            res = unsigned_mag - 1;
         }
-        v_endif
+        v_else {
+            res = setsgn(input, -1);
+            res = res + 1;
+        }
+        v_endif;
+
         dst_reg[0] = res;
         dst_reg++;
     }
 }
+
 }  // namespace sfpu
 }  // namespace ckernel

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_bitwise_xor.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_bitwise_xor.h
@@ -1,0 +1,35 @@
+// SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include "ckernel.h"
+#include "ckernel_defs.h"
+#include "noc_nonblocking_api.h"
+
+using namespace sfpi;
+
+namespace ckernel {
+namespace sfpu {
+
+template <bool APPROXIMATION_MODE, int ITERATIONS = 8>
+inline void calculate_bitwise_xor(const uint value) {
+#pragma GCC unroll 0
+    for (int d = 0; d < ITERATIONS; d++) {
+        vInt input = dst_reg[0];
+        vInt val = input;
+        vInt v = value;
+        vInt res = val ^ v;
+        v_if(res > -2147483648 && res < 0)
+        {
+            res = 0 - res;
+            res = setsgn(res, v);
+        }
+        v_endif
+        dst_reg[0] = res;
+        dst_reg++;
+    }
+}
+}  // namespace sfpu
+}  // namespace ckernel

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_bitwise_not.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_bitwise_not.h
@@ -1,0 +1,26 @@
+// SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include "ckernel_sfpu_bitwise_not.h"
+#include "llk_math_eltwise_unary_sfpu_params.h"
+#include "llk_math_eltwise_unary_sfpu_init.h"
+
+namespace ckernel {
+
+// New LLK SFPU APIs
+
+template <bool APPROXIMATE>
+inline void llk_math_eltwise_unary_sfpu_bitwise_not_init() {
+    llk_math_eltwise_unary_sfpu_init<SfpuType::bitwise_not, APPROXIMATE>();
+}
+
+template <bool APPROXIMATE>
+inline void llk_math_eltwise_unary_sfpu_bitwise_not(uint dst_index, uint param0, int vector_mode = (int)VectorMode::RC) {
+    llk_math_eltwise_unary_sfpu_params<APPROXIMATE>
+                                (ckernel::sfpu::calculate_bitwise_not<APPROXIMATE>,
+                                dst_index, vector_mode, param0);
+}
+}

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_bitwise_xor.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_bitwise_xor.h
@@ -1,0 +1,29 @@
+// SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include "ckernel_sfpu_bitwise_xor.h"
+#include "llk_math_eltwise_unary_sfpu_params.h"
+#include "llk_math_eltwise_unary_sfpu_init.h"
+
+namespace ckernel {
+
+// New LLK SFPU APIs
+
+template <bool APPROXIMATE>
+inline void llk_math_eltwise_unary_sfpu_bitwise_xor_init() {
+    llk_math_eltwise_unary_sfpu_init<SfpuType::bitwise_xor, APPROXIMATE>();
+}
+
+template <bool APPROXIMATE>
+inline void llk_math_eltwise_unary_sfpu_bitwise_xor(uint dst_index, uint param0, int vector_mode = (int)VectorMode::RC) {
+    llk_math_eltwise_unary_sfpu_params<APPROXIMATE>(
+        ckernel::sfpu::calculate_bitwise_xor<APPROXIMATE>,
+        dst_index,
+        vector_mode,
+        param0);
+}
+
+}  // namespace ckernel

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu_types.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu_types.h
@@ -76,6 +76,7 @@ enum SfpuType {
     softplus,
     tiled_prod,
     bitwise_xor,
+    bitwise_not,
     right_shift,
     floor,
     left_shift,

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu_types.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu_types.h
@@ -75,6 +75,7 @@ enum SfpuType {
     unary_lt,
     softplus,
     tiled_prod,
+    bitwise_xor,
     right_shift,
     floor,
     left_shift,

--- a/tt_metal/include/compute_kernel_api/eltwise_unary/bitwise_not.h
+++ b/tt_metal/include/compute_kernel_api/eltwise_unary/bitwise_not.h
@@ -1,0 +1,43 @@
+// SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+
+#include "compute_kernel_api/common_globals.h"
+#ifdef TRISC_MATH
+#include "llk_math_eltwise_unary_sfpu_bitwise_not.h"
+#define MAIN math_main()
+#define MATH(x) x
+#else
+#define MATH(x)
+#endif
+
+
+
+namespace ckernel {
+
+/**
+ * Performs element-wise bitwise_not computation on input x , where x is each element of a tile
+ * in DST register at index tile_index. The DST register buffer must be in
+ * acquired state via *acquire_dst* call. This call is blocking and is only
+ * available on the compute engine.
+ *
+ * Return value: None
+ *
+ * | Argument        | Description                                                                | Type     | Valid Range                                           | Required |
+ * |-----------------|----------------------------------------------------------------------------|----------|-------------------------------------------------------|----------|
+ * | idst            | The index of the tile in DST register buffer to modify the computation of  | uint32_t | Must be less than the size of the DST register buffer | True     |
+ */
+ALWI void bitwise_not_tile(uint32_t idst, uint32_t param0) {
+    MATH((llk_math_eltwise_unary_sfpu_bitwise_not<APPROX>(idst, param0)));
+}
+
+/**
+ * Please refer to documentation for any_init.
+ */
+ALWI void bitwise_not_tile_init() {
+    MATH((llk_math_eltwise_unary_sfpu_bitwise_not_init<APPROX>())); }
+
+} // namespace ckernel

--- a/tt_metal/include/compute_kernel_api/eltwise_unary/bitwise_xor.h
+++ b/tt_metal/include/compute_kernel_api/eltwise_unary/bitwise_xor.h
@@ -26,12 +26,10 @@ namespace ckernel {
  *
  * Return value: None
  *
- * | Argument        | Description                                                                | Type     | Valid
- * Range                                           | Required |
+ * | Argument        | Description                                                                | Type     | Valid Range                                           | Required |
  * |-----------------|----------------------------------------------------------------------------|----------|-------------------------------------------------------|----------|
- * | idst            | The index of the tile in DST register buffer to perform the computation on | uint32_t | Must be
- * less than the size of the DST register buffer | True     | | param0          | The value the output is if the input
- * is greater than 0                     | uint32_t |                                                       | True     |
+ * | idst            | The index of the tile in DST register buffer to perform the computation on | uint32_t | Must be less than the size of the DST register buffer | True     |
+ * | param0          | The value the output is if the input is greater than 0                     | uint32_t |                                                       | True     |
  */
 ALWI void bitwise_xor_tile(uint32_t idst, uint32_t param0) {
     MATH((llk_math_eltwise_unary_sfpu_bitwise_xor<APPROX>(idst, param0)));

--- a/tt_metal/include/compute_kernel_api/eltwise_unary/bitwise_xor.h
+++ b/tt_metal/include/compute_kernel_api/eltwise_unary/bitwise_xor.h
@@ -1,0 +1,46 @@
+// SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+
+#include "compute_kernel_api/common_globals.h"
+#ifdef TRISC_MATH
+#include "llk_math_eltwise_unary_sfpu_bitwise_xor.h"
+#define MAIN math_main()
+#define MATH(x) x
+#else
+#define MATH(x)
+#endif
+
+
+
+namespace ckernel {
+
+/**
+ * Performs element-wise bitwise_xor computation on input x , where x is each element of a tile
+ * in DST register at index tile_index. The value is provided as const param0 The DST register buffer must be in
+ * acquired state via *acquire_dst* call. This call is blocking xor is only
+ * available on the compute engine.
+ *
+ * Return value: None
+ *
+ * | Argument        | Description                                                                | Type     | Valid
+ * Range                                           | Required |
+ * |-----------------|----------------------------------------------------------------------------|----------|-------------------------------------------------------|----------|
+ * | idst            | The index of the tile in DST register buffer to perform the computation on | uint32_t | Must be
+ * less than the size of the DST register buffer | True     | | param0          | The value the output is if the input
+ * is greater than 0                     | uint32_t |                                                       | True     |
+ */
+ALWI void bitwise_xor_tile(uint32_t idst, uint32_t param0) {
+    MATH((llk_math_eltwise_unary_sfpu_bitwise_xor<APPROX>(idst, param0)));
+}
+
+/**
+ * Please refer to documentation for any_init.
+ */
+ALWI void bitwise_xor_tile_init() { MATH((llk_math_eltwise_unary_sfpu_bitwise_xor_init<APPROX>())); }
+
+
+} // namespace ckernel

--- a/tt_metal/include/compute_kernel_api/eltwise_unary/sfpu_split_includes.h
+++ b/tt_metal/include/compute_kernel_api/eltwise_unary/sfpu_split_includes.h
@@ -68,6 +68,10 @@
 #include "compute_kernel_api/eltwise_unary/typecast.h"
 #endif
 
+#if SFPU_OP_BITWISE_XOR_INCLUDE
+#include "compute_kernel_api/eltwise_unary/bitwise_xor.h"
+#endif
+
 #if SFPU_OP_RIGHT_SHIFT_INCLUDE
 #include "compute_kernel_api/eltwise_unary/right_shift.h"
 #endif

--- a/tt_metal/include/compute_kernel_api/eltwise_unary/sfpu_split_includes.h
+++ b/tt_metal/include/compute_kernel_api/eltwise_unary/sfpu_split_includes.h
@@ -72,6 +72,10 @@
 #include "compute_kernel_api/eltwise_unary/bitwise_xor.h"
 #endif
 
+#if SFPU_OP_BITWISE_NOT_INCLUDE
+#include "compute_kernel_api/eltwise_unary/bitwise_not.h"
+#endif
+
 #if SFPU_OP_RIGHT_SHIFT_INCLUDE
 #include "compute_kernel_api/eltwise_unary/right_shift.h"
 #endif


### PR DESCRIPTION
Issue #8683
### Unary Bitwise XOR, NOT support for WH_B0
**Test Files :**
- Bitwise XOR : `tests/tt_eager/python_api_testing/sweep_tests/pytests/tt_dnn/test_bitwise_xor.py` - PASSED
    - Tested for below ranges
        - Input Tensor range : [ 0, 2147483647 ] - Int datatype (Input tensor must be positive)
        - Value : (-100, 100) - Int datatype
- Bitwise NOT : `tests/tt_eager/python_api_testing/sweep_tests/pytests/tt_dnn/test_bitwise_not.py` - PASSED
    - Tested for below range
        - Input Tensor range : [ -2147483647, 2147483647 ] - Int datatype

**Comparison criteria :** `comp_equal`

**Issues Faced :**
- Bitwise XOR : Scalar values can be both positive and negative. Input Tensor needs to be positive because negative input tensor gives incorrect results.
- Bitwise NOT : 
    - This op is defined as a function that takes an input tensor with a parameter value because when it is defined as a function that takes only an input tensor, the output differs.
        - Eg: If the input tensor of shape [1, 1, 32, 32] comprises of 10s, then input + 1 should give a result tensor comprising of 11s. But, the TT result tensor comprises of alternating values of 10 and -12 (The first 256 elements are 10s, the second 256 elements are -12s, the third 256 elements are 10s and the last 256 elements are -12s).
        This issue is handled by defining bitwise_not op as a function that takes an input tensor with a parameter value.

**Implemented concept :**
- Bitwise XOR :
     ```
         vInt input = dst_reg[0];
         vInt v = value;
         vInt res = input ^ v;
         v_if(res > INT_MIN && res < 0)
         {
             res = 0 - res;
             res = setsgn(res, v);
         }
         v_endif
         dst_reg[0] = res;
     ```
    - If condition used : 
        For negative scalar value : v_if(value<0 && value!=0). This condition is used to overcome the discrepancy between the actual result and the TT result. This discrepancy occurs due to the following issue in bitwise_or operation:
        - Eg: For 63 | -4 , expected result is -1 but the TT result is -2147483647 which is the negative limit of Int32.
        - Eg: For 38 | -4 , expected result is -2 but the TT result is -2147483646 which is the negative limit of Int32 plus 1.
        We've done the calculation to compensate for the difference in the result. Hence we've subtracted the result from zero and used setsgn to set the sign of the result.

- Bitwise NOT : 
     ```
        vInt input = dst_reg[0];
        vInt res;

        v_if(input < 0) {
            vInt unsigned_mag = input & 0x7FFFFFFF;
            res = unsigned_mag - 1;
        }
        v_else {
            res = setsgn(input, -1);
            res = res + 1;
        }
        v_endif;
        
        dst_reg[0] = res;

     ```
    - If condition used : 
        For negative input range : v_if(value<0 && value!=0). The condition is used to overcome the discrepancy between the actual result and the TT result. This discrepancy is demonstrated below:
       - Eg: For -11 , expected result is 10 but in TT it is 12.
      We've done the calculation by converting the input to unsigned magnitude (masking the input with 0x7FFFFFFF) and subtracting 1 from the result.


**Test File Results :** 
- Bitwise XOR:
  <img width="1147" alt="Screenshot 2024-06-14 at 12 15 11" src="https://github.com/tenstorrent/tt-metal/assets/169137046/1f844e79-f96c-479a-97e4-80d10a887dde">

- Bitwise NOT:
  <img width="1147" alt="Screenshot 2024-06-24 at 12 58 00" src="https://github.com/tenstorrent/tt-metal/assets/169137046/1b4befb8-7c3d-4c15-b5a9-f3f4d4b13262">


**Documentation :**
<img width="1106" alt="Screenshot 2024-06-14 at 15 10 26" src="https://github.com/tenstorrent/tt-metal/assets/169137046/6dd224f9-16e0-4c91-bc3d-e345298c14b1">

<img width="1104" alt="Screenshot 2024-06-24 at 11 51 34" src="https://github.com/tenstorrent/tt-metal/assets/169137046/4b1ce020-4d66-4d56-abbf-a63e73e2d067">


**CI:**
- [All post-commit tests](https://github.com/tenstorrent/tt-metal/actions/runs/9640443632) - PASSED   
- [[post-commit] Fast Dispatch unit tests](https://github.com/tenstorrent/tt-metal/actions/runs/9640324447) - PASSED
- [[post-commit] Slow Dispatch unit tests](https://github.com/tenstorrent/tt-metal/actions/runs/9640434588) - PASSED

