### PR TITLE
#8683: Add Unary bitwise AND, OR

### DIFF
--- a/docs/source/ttnn/ttnn/dependencies/tt_lib.rst
+++ b/docs/source/ttnn/ttnn/dependencies/tt_lib.rst
@@ -406,6 +406,8 @@ Tensor elementwise operations
 .. autofunction:: tt_lib.tensor.bitwise_xor
 
 .. autofunction:: tt_lib.tensor.bitwise_not
+    
+.. autofunction:: tt_lib.tensor.bitwise_and
 
 .. autofunction:: tt_lib.tensor.right_shift
 

--- a/docs/source/ttnn/ttnn/dependencies/tt_lib.rst
+++ b/docs/source/ttnn/ttnn/dependencies/tt_lib.rst
@@ -409,6 +409,8 @@ Tensor elementwise operations
     
 .. autofunction:: tt_lib.tensor.bitwise_and
 
+.. autofunction:: tt_lib.tensor.bitwise_or
+
 .. autofunction:: tt_lib.tensor.right_shift
 
 .. autofunction:: tt_lib.tensor.left_shift

--- a/tests/tt_eager/python_api_testing/sweep_tests/op_map.py
+++ b/tests/tt_eager/python_api_testing/sweep_tests/op_map.py
@@ -499,9 +499,14 @@ op_map = {
     "eltwise-bitwise_not": {
         "tt_op": tt_lib_ops.eltwise_bitwise_not,
         "pytorch_op": pytorch_ops.bitwise_not,
+    },
     "eltwise-bitwise_and": {
         "tt_op": tt_lib_ops.eltwise_bitwise_and,
         "pytorch_op": pytorch_ops.bitwise_and,
+    },
+    "eltwise-bitwise_or": {
+        "tt_op": tt_lib_ops.eltwise_bitwise_or,
+        "pytorch_op": pytorch_ops.bitwise_or,
     },
     "eltwise-right_shift": {
         "tt_op": tt_lib_ops.eltwise_right_shift,

--- a/tests/tt_eager/python_api_testing/sweep_tests/op_map.py
+++ b/tests/tt_eager/python_api_testing/sweep_tests/op_map.py
@@ -499,6 +499,9 @@ op_map = {
     "eltwise-bitwise_not": {
         "tt_op": tt_lib_ops.eltwise_bitwise_not,
         "pytorch_op": pytorch_ops.bitwise_not,
+    "eltwise-bitwise_and": {
+        "tt_op": tt_lib_ops.eltwise_bitwise_and,
+        "pytorch_op": pytorch_ops.bitwise_and,
     },
     "eltwise-right_shift": {
         "tt_op": tt_lib_ops.eltwise_right_shift,

--- a/tests/tt_eager/python_api_testing/sweep_tests/pytests/tt_dnn/test_bitwise_and.py
+++ b/tests/tt_eager/python_api_testing/sweep_tests/pytests/tt_dnn/test_bitwise_and.py
@@ -1,0 +1,71 @@
+# SPDX-FileCopyrightText: © 2023-24 Tenstorrent Inc.
+
+# SPDX-License-Identifier: Apache-2.0
+
+import pytest
+import torch
+from functools import partial
+import tt_lib as ttl
+
+
+from tests.tt_eager.python_api_testing.sweep_tests import (
+    comparison_funcs,
+    generation_funcs,
+)
+from tests.tt_eager.python_api_testing.sweep_tests.run_pytorch_ci_tests import (
+    run_single_pytorch_test,
+)
+from models.utility_functions import skip_for_grayskull
+
+mem_configs = [
+    ttl.tensor.MemoryConfig(ttl.tensor.TensorMemoryLayout.INTERLEAVED, ttl.tensor.BufferType.DRAM),
+    ttl.tensor.MemoryConfig(ttl.tensor.TensorMemoryLayout.INTERLEAVED, ttl.tensor.BufferType.L1),
+]
+
+
+@pytest.mark.parametrize(
+    "scalar",
+    (-3, -2, -1, 0, 1, 2, 3),
+)
+@pytest.mark.parametrize(
+    "input_shapes",
+    [
+        [[1, 1, 32, 32]],
+        [[4, 3, 32, 32]],
+        [[2, 2, 32, 32]],
+    ],
+)
+@pytest.mark.parametrize(
+    "dst_mem_config",
+    mem_configs,
+)
+@skip_for_grayskull("#TODO: GS implementation needs to be done")
+class TestBitwiseAnd:
+    def test_run_bitwise_and_op(
+        self,
+        scalar,
+        input_shapes,
+        dst_mem_config,
+        device,
+    ):
+        datagen_func = [
+            generation_funcs.gen_func_with_cast(partial(generation_funcs.gen_rand, low=0, high=32768), torch.int)
+        ]
+        test_args = generation_funcs.gen_default_dtype_layout_device(input_shapes)[0]
+        test_args.update(
+            {
+                "value": scalar,
+                "dtype": [(ttl.tensor.DataType.INT32)],
+            }
+        )
+        test_args.update({"output_mem_config": dst_mem_config})
+        comparison_func = comparison_funcs.comp_equal
+
+        run_single_pytorch_test(
+            "eltwise-bitwise_and",
+            input_shapes,
+            datagen_func,
+            comparison_func,
+            device,
+            test_args,
+        )

--- a/tests/tt_eager/python_api_testing/sweep_tests/pytests/tt_dnn/test_bitwise_or.py
+++ b/tests/tt_eager/python_api_testing/sweep_tests/pytests/tt_dnn/test_bitwise_or.py
@@ -34,15 +34,15 @@ mem_configs = [
 )
 @pytest.mark.parametrize(
     "scalar",
-    {random.randint(-100, 100) for _ in range(5)},
+    {random.randint(-100, 100) for _ in range(10)},
 )
 @pytest.mark.parametrize(
     "dst_mem_config",
     mem_configs,
 )
 @skip_for_grayskull("#TODO: GS implementation needs to be done")
-class TestBitwiseAnd:
-    def test_run_bitwise_and_op(
+class TestLeftShift:
+    def test_run_bitwise_or_op(
         self,
         input_shapes,
         scalar,
@@ -63,7 +63,7 @@ class TestBitwiseAnd:
         comparison_func = comparison_funcs.comp_equal
 
         run_single_pytorch_test(
-            "eltwise-bitwise_and",
+            "eltwise-bitwise_or",
             input_shapes,
             datagen_func,
             comparison_func,

--- a/tests/tt_eager/python_api_testing/sweep_tests/pytests/tt_dnn/test_div.py
+++ b/tests/tt_eager/python_api_testing/sweep_tests/pytests/tt_dnn/test_div.py
@@ -16,7 +16,7 @@ from tests.tt_eager.python_api_testing.sweep_tests import (
 from tests.tt_eager.python_api_testing.sweep_tests.run_pytorch_ci_tests import (
     run_single_pytorch_test,
 )
-from models.utility_functions import skip_for_grayskull
+from models.utility_functions import is_grayskull
 
 mem_configs = [
     ttl.tensor.MemoryConfig(ttl.tensor.TensorMemoryLayout.INTERLEAVED, ttl.tensor.BufferType.DRAM),
@@ -38,7 +38,6 @@ mem_configs = [
     "dst_mem_config",
     mem_configs,
 )
-@skip_for_grayskull("#ToDo: GS implementation needs to be done for floor and trunc")
 class TestDiv:
     def test_run_div(
         self,
@@ -48,6 +47,9 @@ class TestDiv:
         dst_mem_config,
         device,
     ):
+        if is_grayskull():
+            if round_mode in ["trunc", "floor"]:
+                pytest.skip("does not work for Grayskull -skipping")
         if accurate_mode == False:  # If input_b is non-zero tensor
             datagen_func = [
                 generation_funcs.gen_func_with_cast(

--- a/tests/tt_eager/python_api_testing/sweep_tests/pytests/tt_dnn/test_div_unary.py
+++ b/tests/tt_eager/python_api_testing/sweep_tests/pytests/tt_dnn/test_div_unary.py
@@ -16,7 +16,7 @@ from tests.tt_eager.python_api_testing.sweep_tests import (
 from tests.tt_eager.python_api_testing.sweep_tests.run_pytorch_ci_tests import (
     run_single_pytorch_test,
 )
-from models.utility_functions import skip_for_grayskull
+from models.utility_functions import is_grayskull
 
 mem_configs = [
     ttl.tensor.MemoryConfig(ttl.tensor.TensorMemoryLayout.INTERLEAVED, ttl.tensor.BufferType.DRAM),
@@ -42,7 +42,6 @@ mem_configs = [
     "dst_mem_config",
     mem_configs,
 )
-@skip_for_grayskull("#ToDo: GS implementation needs to be done for floor and trunc")
 class TestUnary_Div:
     def test_run_unary_div(
         self,
@@ -53,6 +52,9 @@ class TestUnary_Div:
         dst_mem_config,
         device,
     ):
+        if is_grayskull():
+            if round_mode in ["trunc", "floor"]:
+                pytest.skip("does not work for Grayskull -skipping")
         datagen_func = [
             generation_funcs.gen_func_with_cast(partial(generation_funcs.gen_rand, low=-1e6, high=1e6), torch.bfloat16)
         ] * 2

--- a/tests/tt_eager/python_api_testing/sweep_tests/pytorch_ops.py
+++ b/tests/tt_eager/python_api_testing/sweep_tests/pytorch_ops.py
@@ -544,6 +544,12 @@ def bitwise_and(x, *args, **kwargs):
     return result
 
 
+def bitwise_or(x, *args, **kwargs):
+    value = kwargs.pop("value")
+    result = torch.bitwise_or(x, value)
+    return result
+
+
 def right_shift(x, *args, **kwargs):
     value = kwargs.pop("value")
     result = torch.bitwise_right_shift(x, value)

--- a/tests/tt_eager/python_api_testing/sweep_tests/pytorch_ops.py
+++ b/tests/tt_eager/python_api_testing/sweep_tests/pytorch_ops.py
@@ -538,6 +538,12 @@ def bitwise_not(x, *args, **kwargs):
     return result
 
 
+def bitwise_and(x, *args, **kwargs):
+    value = kwargs.pop("value")
+    result = torch.bitwise_and(x, value)
+    return result
+
+
 def right_shift(x, *args, **kwargs):
     value = kwargs.pop("value")
     result = torch.bitwise_right_shift(x, value)

--- a/tests/tt_eager/python_api_testing/sweep_tests/tt_lib_ops.py
+++ b/tests/tt_eager/python_api_testing/sweep_tests/tt_lib_ops.py
@@ -1244,6 +1244,24 @@ def eltwise_bitwise_not(
 
 
 @setup_host_and_device
+def eltwise_bitwise_and(
+    x,
+    *args,
+    value,
+    device,
+    dtype,
+    layout,
+    input_mem_config,
+    output_mem_config,
+    **kwargs,
+):
+    t0 = setup_tt_tensor(x, device, layout[0], input_mem_config[0], dtype[0])
+    t1 = ttl.tensor.bitwise_and(t0, value, output_mem_config=output_mem_config)
+
+    return tt2torch_tensor(t1)
+
+
+@setup_host_and_device
 def eltwise_right_shift(
     x,
     *args,

--- a/tests/tt_eager/python_api_testing/sweep_tests/tt_lib_ops.py
+++ b/tests/tt_eager/python_api_testing/sweep_tests/tt_lib_ops.py
@@ -1262,6 +1262,24 @@ def eltwise_bitwise_and(
 
 
 @setup_host_and_device
+def eltwise_bitwise_or(
+    x,
+    *args,
+    value,
+    device,
+    dtype,
+    layout,
+    input_mem_config,
+    output_mem_config,
+    **kwargs,
+):
+    t0 = setup_tt_tensor(x, device, layout[0], input_mem_config[0], dtype[0])
+    t1 = ttl.tensor.bitwise_or(t0, value, output_mem_config=output_mem_config)
+
+    return tt2torch_tensor(t1)
+
+
+@setup_host_and_device
 def eltwise_right_shift(
     x,
     *args,

--- a/tt_eager/tt_dnn/op_library/eltwise_unary/eltwise_unary_op.cpp
+++ b/tt_eager/tt_dnn/op_library/eltwise_unary/eltwise_unary_op.cpp
@@ -68,6 +68,7 @@ void update_macro_defines(UnaryOpType op_type, std::map<std::string, std::string
         case UnaryOpType::BITWISE_XOR: defines["SFPU_OP_BITWISE_XOR_INCLUDE"] = "1"; break;
         case UnaryOpType::BITWISE_NOT: defines["SFPU_OP_BITWISE_NOT_INCLUDE"] = "1"; break;
         case UnaryOpType::BITWISE_AND: defines["SFPU_OP_BITWISE_AND_INCLUDE"] = "1"; break;
+        case UnaryOpType::BITWISE_OR: defines["SFPU_OP_BITWISE_OR_INCLUDE"] = "1"; break;
         case UnaryOpType::RIGHT_SHIFT: defines["SFPU_OP_RIGHT_SHIFT_INCLUDE"] = "1"; break;
         case UnaryOpType::FLOOR: defines["SFPU_OP_FLOOR_INCLUDE"] = "1"; break;
         case UnaryOpType::LEFT_SHIFT: defines["SFPU_OP_LEFT_SHIFT_INCLUDE"] = "1"; break;
@@ -123,9 +124,14 @@ std::pair<string, string> get_op_init_and_func_parameterized(
         case UnaryOpType::BITWISE_NOT:
             op_init_and_name = {
                 "bitwise_not_tile_init();", fmt::format("bitwise_not_tile({}, {}u);", idst, std::to_string((uint)param0))};
+            break;
         case UnaryOpType::BITWISE_AND:
             op_init_and_name = {
                 "bitwise_and_tile_init();", fmt::format("bitwise_and_tile({}, {}u);", idst, std::to_string((uint)param0))};
+            break;
+        case UnaryOpType::BITWISE_OR:
+            op_init_and_name = {
+                "bitwise_or_tile_init();", fmt::format("bitwise_or_tile({}, {}u);", idst, std::to_string((uint)param0))};
             break;
         case UnaryOpType::RIGHT_SHIFT:
             op_init_and_name = {
@@ -371,6 +377,8 @@ inline void validate_supported_arch_dtype(tt::ARCH arch, DataType input_datatype
             break;
         case UnaryOpType::BITWISE_XOR:
         case UnaryOpType::BITWISE_NOT:
+        case UnaryOpType::BITWISE_AND:
+        case UnaryOpType::BITWISE_OR:
             TT_FATAL(arch == tt::ARCH::WORMHOLE_B0, "Op is only supported on Wormhole");
             TT_FATAL(input_datatype == DataType::INT32, "Data type is not supported for Bitwise operations");
             TT_FATAL(output_datatype == DataType::INT32, "Data type is not supported for Bitwise operations");

--- a/tt_eager/tt_dnn/op_library/eltwise_unary/eltwise_unary_op.cpp
+++ b/tt_eager/tt_dnn/op_library/eltwise_unary/eltwise_unary_op.cpp
@@ -67,6 +67,7 @@ void update_macro_defines(UnaryOpType op_type, std::map<std::string, std::string
         case UnaryOpType::TYPECAST: defines["SFPU_OP_TYPECAST_INCLUDE"] = "1"; break;
         case UnaryOpType::BITWISE_XOR: defines["SFPU_OP_BITWISE_XOR_INCLUDE"] = "1"; break;
         case UnaryOpType::BITWISE_NOT: defines["SFPU_OP_BITWISE_NOT_INCLUDE"] = "1"; break;
+        case UnaryOpType::BITWISE_AND: defines["SFPU_OP_BITWISE_AND_INCLUDE"] = "1"; break;
         case UnaryOpType::RIGHT_SHIFT: defines["SFPU_OP_RIGHT_SHIFT_INCLUDE"] = "1"; break;
         case UnaryOpType::FLOOR: defines["SFPU_OP_FLOOR_INCLUDE"] = "1"; break;
         case UnaryOpType::LEFT_SHIFT: defines["SFPU_OP_LEFT_SHIFT_INCLUDE"] = "1"; break;
@@ -122,6 +123,9 @@ std::pair<string, string> get_op_init_and_func_parameterized(
         case UnaryOpType::BITWISE_NOT:
             op_init_and_name = {
                 "bitwise_not_tile_init();", fmt::format("bitwise_not_tile({}, {}u);", idst, std::to_string((uint)param0))};
+        case UnaryOpType::BITWISE_AND:
+            op_init_and_name = {
+                "bitwise_and_tile_init();", fmt::format("bitwise_and_tile({}, {}u);", idst, std::to_string((uint)param0))};
             break;
         case UnaryOpType::RIGHT_SHIFT:
             op_init_and_name = {

--- a/tt_eager/tt_dnn/op_library/eltwise_unary/eltwise_unary_op.hpp
+++ b/tt_eager/tt_dnn/op_library/eltwise_unary/eltwise_unary_op.hpp
@@ -81,6 +81,7 @@ enum class UnaryOpType {
     TYPECAST,
     BITWISE_XOR,
     BITWISE_NOT,
+    BITWISE_AND,
     RIGHT_SHIFT,
     FLOOR,
     LEFT_SHIFT,
@@ -115,6 +116,7 @@ bool is_parametrized_type(T val) {
         case UnaryOpType::TYPECAST:
         case UnaryOpType::BITWISE_XOR:
         case UnaryOpType::BITWISE_NOT:
+        case UnaryOpType::BITWISE_AND:
         case UnaryOpType::RIGHT_SHIFT:
         case UnaryOpType::LEFT_SHIFT:
         case UnaryOpType::REMAINDER:
@@ -597,6 +599,7 @@ constexpr auto elu = make_eltwise_unary_with_param<UnaryOpType::ELU>{};
 constexpr auto heaviside = make_eltwise_unary_with_param<UnaryOpType::HEAVISIDE>{};
 constexpr auto bitwise_xor = make_eltwise_unary_with_param<UnaryOpType::BITWISE_XOR>{};
 constexpr auto bitwise_not = make_eltwise_unary_with_param<UnaryOpType::BITWISE_NOT>{};
+constexpr auto bitwise_and = make_eltwise_unary_with_param<UnaryOpType::BITWISE_AND>{};
 constexpr auto right_shift = make_eltwise_unary_with_param<UnaryOpType::RIGHT_SHIFT>{};
 constexpr auto left_shift = make_eltwise_unary_with_param<UnaryOpType::LEFT_SHIFT>{};
 constexpr auto unary_remainder = make_eltwise_unary_with_param<UnaryOpType::REMAINDER>{};

--- a/tt_eager/tt_dnn/op_library/eltwise_unary/eltwise_unary_op.hpp
+++ b/tt_eager/tt_dnn/op_library/eltwise_unary/eltwise_unary_op.hpp
@@ -82,6 +82,7 @@ enum class UnaryOpType {
     BITWISE_XOR,
     BITWISE_NOT,
     BITWISE_AND,
+    BITWISE_OR,
     RIGHT_SHIFT,
     FLOOR,
     LEFT_SHIFT,
@@ -117,6 +118,7 @@ bool is_parametrized_type(T val) {
         case UnaryOpType::BITWISE_XOR:
         case UnaryOpType::BITWISE_NOT:
         case UnaryOpType::BITWISE_AND:
+        case UnaryOpType::BITWISE_OR:
         case UnaryOpType::RIGHT_SHIFT:
         case UnaryOpType::LEFT_SHIFT:
         case UnaryOpType::REMAINDER:
@@ -600,6 +602,7 @@ constexpr auto heaviside = make_eltwise_unary_with_param<UnaryOpType::HEAVISIDE>
 constexpr auto bitwise_xor = make_eltwise_unary_with_param<UnaryOpType::BITWISE_XOR>{};
 constexpr auto bitwise_not = make_eltwise_unary_with_param<UnaryOpType::BITWISE_NOT>{};
 constexpr auto bitwise_and = make_eltwise_unary_with_param<UnaryOpType::BITWISE_AND>{};
+constexpr auto bitwise_or = make_eltwise_unary_with_param<UnaryOpType::BITWISE_OR>{};
 constexpr auto right_shift = make_eltwise_unary_with_param<UnaryOpType::RIGHT_SHIFT>{};
 constexpr auto left_shift = make_eltwise_unary_with_param<UnaryOpType::LEFT_SHIFT>{};
 constexpr auto unary_remainder = make_eltwise_unary_with_param<UnaryOpType::REMAINDER>{};

--- a/tt_eager/tt_lib/csrc/tt_lib_bindings_tensor_xary_ops.cpp
+++ b/tt_eager/tt_lib/csrc/tt_lib_bindings_tensor_xary_ops.cpp
@@ -1008,6 +1008,23 @@ namespace tt::tt_metal::detail {
 
         )doc");
 
+        m_tensor.def("bitwise_and",bitwise_and,
+            py::arg("input").noconvert(),py::arg("value"),py::arg("output_mem_config").noconvert() = operation::DEFAULT_OUTPUT_MEMORY_CONFIG,R"doc(
+            Computes bitwise_and of input tensor ``input`` and a scalar ``value``. Input tensor needs to be positive. Support provided only for Wormhole_B0.
+
+            Input tensor must have INT32 data type.
+
+            Output tensor will have INT32 data type.
+
+            .. csv-table::
+                :header: "Argument", "Description", "Data type", "Valid range", "Required"
+
+                "input", "Input Tensor", "Tensor", "Tensor of shape [W, Z, Y, X]", "Yes"
+                "value", "scalar value", "int", "", "Yes"
+                "output_mem_config", "Layout of tensor in TT Accelerator device memory banks", "MemoryConfig", "Default is interleaved in DRAM", "No"
+
+        )doc");
+
         m_tensor.def("right_shift",right_shift,
             py::arg("input").noconvert(),py::arg("shift_amt"),py::arg("output_mem_config").noconvert() = operation::DEFAULT_OUTPUT_MEMORY_CONFIG,R"doc(
             Computes right shift of input tensor ``input`` by ``shift_amt`` bits. ``shift_amt`` range must be [0, 31]. Support provided only for Wormhole_B0.

--- a/tt_eager/tt_lib/csrc/tt_lib_bindings_tensor_xary_ops.cpp
+++ b/tt_eager/tt_lib/csrc/tt_lib_bindings_tensor_xary_ops.cpp
@@ -1010,7 +1010,24 @@ namespace tt::tt_metal::detail {
 
         m_tensor.def("bitwise_and",bitwise_and,
             py::arg("input").noconvert(),py::arg("value"),py::arg("output_mem_config").noconvert() = operation::DEFAULT_OUTPUT_MEMORY_CONFIG,R"doc(
-            Computes bitwise_and of input tensor ``input`` and a scalar ``value``. Input tensor needs to be positive. Support provided only for Wormhole_B0.
+            Computes bitwise_and of input tensor ``input`` by  a scalar ``value``. Input tensor needs to be positive. Support provided only for Wormhole_B0.
+
+            Input tensor must have INT32 data type.
+
+            Output tensor will have INT32 data type.
+
+            .. csv-table::
+                :header: "Argument", "Description", "Data type", "Valid range", "Required"
+
+                "input", "Input Tensor", "Tensor", "Tensor of shape [W, Z, Y, X]", "Yes"
+                "value", "Scalar value", "int", "", "Yes"
+                "output_mem_config", "Layout of tensor in TT Accelerator device memory banks", "MemoryConfig", "Default is interleaved in DRAM", "No"
+
+        )doc");
+        
+        m_tensor.def("bitwise_or",bitwise_or,
+            py::arg("input").noconvert(),py::arg("value"),py::arg("output_mem_config").noconvert() = operation::DEFAULT_OUTPUT_MEMORY_CONFIG,R"doc(
+            Computes bitwise_or of input tensor ``input`` by  a scalar ``value``. Input tensor needs to be positive. Support provided only for Wormhole_B0.
 
             Input tensor must have INT32 data type.
 

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_math_unary_sfpu_api.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_math_unary_sfpu_api.h
@@ -30,5 +30,6 @@
 #include "llk_math_eltwise_unary_sfpu_bitwise_xor.h"
 #include "llk_math_eltwise_unary_sfpu_bitwise_not.h"
 #include "llk_math_eltwise_unary_sfpu_fmod.h"
+#include "llk_math_eltwise_unary_sfpu_bitwise_and.h"
 #include "llk_math_eltwise_unary_sfpu_right_shift.h"
 #include "llk_math_eltwise_unary_sfpu_left_shift.h"

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_math_unary_sfpu_api.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_math_unary_sfpu_api.h
@@ -31,5 +31,6 @@
 #include "llk_math_eltwise_unary_sfpu_bitwise_not.h"
 #include "llk_math_eltwise_unary_sfpu_fmod.h"
 #include "llk_math_eltwise_unary_sfpu_bitwise_and.h"
+#include "llk_math_eltwise_unary_sfpu_bitwise_or.h"
 #include "llk_math_eltwise_unary_sfpu_right_shift.h"
 #include "llk_math_eltwise_unary_sfpu_left_shift.h"

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_bitwise_and.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_bitwise_and.h
@@ -1,0 +1,30 @@
+// SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include "ckernel.h"
+#include "ckernel_defs.h"
+#include "noc_nonblocking_api.h"
+
+using namespace sfpi;
+
+namespace ckernel {
+namespace sfpu {
+
+template <bool APPROXIMATION_MODE, int ITERATIONS = 8>
+inline void calculate_bitwise_and(const uint value) {
+#pragma GCC unroll 0
+    for (int d = 0; d < ITERATIONS; d++) {
+        vInt input = dst_reg[0];
+        vUInt val = reinterpret<vUInt>(input);
+
+        vInt res = reinterpret<vInt>(val & value);
+
+        dst_reg[0] = res;
+        dst_reg++;
+    }
+}
+}  // namespace sfpu
+}  // namespace ckernel

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_bitwise_or.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_bitwise_or.h
@@ -1,24 +1,27 @@
 // SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
-
 #pragma once
-
 #include "ckernel.h"
 #include "ckernel_defs.h"
 #include "noc_nonblocking_api.h"
-
+#include <limits.h>
 using namespace sfpi;
-
 namespace ckernel {
 namespace sfpu {
-
 template <bool APPROXIMATION_MODE, int ITERATIONS = 8>
-inline void calculate_bitwise_and(const uint value) {
+inline void calculate_bitwise_or(const uint value) {
 #pragma GCC unroll 0
     for (int d = 0; d < ITERATIONS; d++) {
         vInt input = dst_reg[0];
-        vInt res = input & value;
+        vInt scalar_value = value;
+        vInt res = input | scalar_value;
+        v_if(res > INT_MIN && res < 0)
+        {
+            res = 0 - res;
+            res = setsgn(res, scalar_value);
+        }
+        v_endif
         dst_reg[0] = res;
         dst_reg++;
     }

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_bitwise_and.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_bitwise_and.h
@@ -1,0 +1,29 @@
+// SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include "ckernel_sfpu_bitwise_and.h"
+#include "llk_math_eltwise_unary_sfpu_params.h"
+#include "llk_math_eltwise_unary_sfpu_init.h"
+
+namespace ckernel {
+
+// New LLK SFPU APIs
+
+template <bool APPROXIMATE>
+inline void llk_math_eltwise_unary_sfpu_bitwise_and_init() {
+    llk_math_eltwise_unary_sfpu_init<SfpuType::bitwise_and, APPROXIMATE>();
+}
+
+template <bool APPROXIMATE>
+inline void llk_math_eltwise_unary_sfpu_bitwise_and(uint dst_index, uint param0, int vector_mode = (int)VectorMode::RC) {
+    llk_math_eltwise_unary_sfpu_params<APPROXIMATE>(
+        ckernel::sfpu::calculate_bitwise_and<APPROXIMATE>,
+        dst_index,
+        vector_mode,
+        param0);
+}
+
+}  // namespace ckernel

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_bitwise_or.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_bitwise_or.h
@@ -1,0 +1,29 @@
+// SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+ //
+ // SPDX-License-Identifier: Apache-2.0
+
+ #pragma once
+
+ #include "ckernel_sfpu_bitwise_or.h"
+ #include "llk_math_eltwise_unary_sfpu_params.h"
+ #include "llk_math_eltwise_unary_sfpu_init.h"
+
+ namespace ckernel {
+
+ // New LLK SFPU APIs
+
+ template <bool APPROXIMATE>
+ inline void llk_math_eltwise_unary_sfpu_bitwise_or_init() {
+     llk_math_eltwise_unary_sfpu_init<SfpuType::bitwise_or, APPROXIMATE>();
+ }
+
+ template <bool APPROXIMATE>
+ inline void llk_math_eltwise_unary_sfpu_bitwise_or(uint dst_index, uint param0, int vector_mode = (int)VectorMode::RC) {
+     llk_math_eltwise_unary_sfpu_params<APPROXIMATE>(
+         ckernel::sfpu::calculate_bitwise_or<APPROXIMATE>,
+         dst_index,
+         vector_mode,
+         param0);
+ }
+
+ }  // namespace ckernel

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu_types.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu_types.h
@@ -78,6 +78,7 @@ enum SfpuType {
     bitwise_xor,
     bitwise_not,
     bitwise_and,
+    bitwise_or,
     right_shift,
     floor,
     left_shift,

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu_types.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu_types.h
@@ -77,6 +77,7 @@ enum SfpuType {
     tiled_prod,
     bitwise_xor,
     bitwise_not,
+    bitwise_and,
     right_shift,
     floor,
     left_shift,

--- a/tt_metal/include/compute_kernel_api/eltwise_unary/bitwise_and.h
+++ b/tt_metal/include/compute_kernel_api/eltwise_unary/bitwise_and.h
@@ -1,0 +1,46 @@
+// SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+
+#include "compute_kernel_api/common_globals.h"
+#ifdef TRISC_MATH
+#include "llk_math_eltwise_unary_sfpu_bitwise_and.h"
+#define MAIN math_main()
+#define MATH(x) x
+#else
+#define MATH(x)
+#endif
+
+
+
+namespace ckernel {
+
+/**
+ * Performs element-wise bitwise_and computation on input x , where x is each element of a tile
+ * in DST register at index tile_index. The value is provided as const param0 The DST register buffer must be in
+ * acquired state via *acquire_dst* call. This call is blocking and is only
+ * available on the compute engine.
+ *
+ * Return value: None
+ *
+ * | Argument        | Description                                                                | Type     | Valid
+ * Range                                           | Required |
+ * |-----------------|----------------------------------------------------------------------------|----------|-------------------------------------------------------|----------|
+ * | idst            | The index of the tile in DST register buffer to perform the computation on | uint32_t | Must be
+ * less than the size of the DST register buffer | True     | | param0          | The value the output is if the input
+ * is greater than 0                     | uint32_t |                                                       | True     |
+ */
+ALWI void bitwise_and_tile(uint32_t idst, uint32_t param0) {
+    MATH((llk_math_eltwise_unary_sfpu_bitwise_and<APPROX>(idst, param0)));
+}
+
+/**
+ * Please refer to documentation for any_init.
+ */
+ALWI void bitwise_and_tile_init() { MATH((llk_math_eltwise_unary_sfpu_bitwise_and_init<APPROX>())); }
+
+
+} // namespace ckernel

--- a/tt_metal/include/compute_kernel_api/eltwise_unary/bitwise_and.h
+++ b/tt_metal/include/compute_kernel_api/eltwise_unary/bitwise_and.h
@@ -19,19 +19,17 @@
 namespace ckernel {
 
 /**
- * Performs element-wise bitwise_and computation on input x , where x is each element of a tile
- * in DST register at index tile_index. The value is provided as const param0 The DST register buffer must be in
+ * Performs element-wise bitwise_and computation on input x by y bits , where x is each element of a tile
+ * in DST register at index tile_index. The input must be of int data type only. The value is provided as const param0 The DST register buffer must be in
  * acquired state via *acquire_dst* call. This call is blocking and is only
  * available on the compute engine.
  *
  * Return value: None
  *
- * | Argument        | Description                                                                | Type     | Valid
- * Range                                           | Required |
+ * | Argument        | Description                                                                | Type     | Valid Range                                           | Required |
  * |-----------------|----------------------------------------------------------------------------|----------|-------------------------------------------------------|----------|
- * | idst            | The index of the tile in DST register buffer to perform the computation on | uint32_t | Must be
- * less than the size of the DST register buffer | True     | | param0          | The value the output is if the input
- * is greater than 0                     | uint32_t |                                                       | True     |
+ * | idst            | The index of the tile in DST register buffer to perform the computation on | uint32_t | Must be less than the size of the DST register buffer | True     |
+ * | param0          | The value the output is if the input is greater than 0                     | uint32_t |                                                       | True     |
  */
 ALWI void bitwise_and_tile(uint32_t idst, uint32_t param0) {
     MATH((llk_math_eltwise_unary_sfpu_bitwise_and<APPROX>(idst, param0)));

--- a/tt_metal/include/compute_kernel_api/eltwise_unary/bitwise_or.h
+++ b/tt_metal/include/compute_kernel_api/eltwise_unary/bitwise_or.h
@@ -1,0 +1,44 @@
+// SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+ //
+ // SPDX-License-Identifier: Apache-2.0
+
+ #pragma once
+
+
+ #include "compute_kernel_api/common_globals.h"
+ #ifdef TRISC_MATH
+ #include "llk_math_eltwise_unary_sfpu_bitwise_or.h"
+ #define MAIN math_main()
+ #define MATH(x) x
+ #else
+ #define MATH(x)
+ #endif
+
+
+
+ namespace ckernel {
+
+ /**
+  * Performs element-wise bitwise_or computation on input x by y bits , where x is each element of a tile
+  * in DST register at index tile_index. The input must be of int data type only. The value is provided as const param0 The DST register buffer must be in
+  * acquired state via *acquire_dst* call. This call is blocking and is only
+  * available on the compute engine.
+  *
+  * Return value: None
+  *
+  * | Argument        | Description                                                                | Type     | Valid Range                                           | Required |
+  * |-----------------|----------------------------------------------------------------------------|----------|-------------------------------------------------------|----------|
+  * | idst            | The index of the tile in DST register buffer to perform the computation on | uint32_t | Must be less than the size of the DST register buffer | True     |
+  * | param0          | The value the output is if the input is greater than 0                     | uint32_t |                                                       | True     |
+  */
+ ALWI void bitwise_or_tile(uint32_t idst, uint32_t param0) {
+     MATH((llk_math_eltwise_unary_sfpu_bitwise_or<APPROX>(idst, param0)));
+ }
+
+ /**
+  * Please refer to documentation for any_init.
+  */
+ ALWI void bitwise_or_tile_init() { MATH((llk_math_eltwise_unary_sfpu_bitwise_or_init<APPROX>())); }
+
+
+ } // namespace ckernel

--- a/tt_metal/include/compute_kernel_api/eltwise_unary/sfpu_split_includes.h
+++ b/tt_metal/include/compute_kernel_api/eltwise_unary/sfpu_split_includes.h
@@ -80,6 +80,10 @@
 #include "compute_kernel_api/eltwise_unary/right_shift.h"
 #endif
 
+#if SFPU_OP_BITWISE_AND_INCLUDE
+#include "compute_kernel_api/eltwise_unary/bitwise_and.h"
+#endif
+
 #if SFPU_OP_FLOOR_INCLUDE
 #include "compute_kernel_api/eltwise_unary/floor.h"
 #endif

--- a/tt_metal/include/compute_kernel_api/eltwise_unary/sfpu_split_includes.h
+++ b/tt_metal/include/compute_kernel_api/eltwise_unary/sfpu_split_includes.h
@@ -84,6 +84,10 @@
 #include "compute_kernel_api/eltwise_unary/bitwise_and.h"
 #endif
 
+#if SFPU_OP_BITWISE_OR_INCLUDE
+#include "compute_kernel_api/eltwise_unary/bitwise_or.h"
+#endif
+
 #if SFPU_OP_FLOOR_INCLUDE
 #include "compute_kernel_api/eltwise_unary/floor.h"
 #endif


### PR DESCRIPTION
Ops added (Skipped for GS): Support provided only for Int data type, bool is not supported.

- Bitwise AND
- Bitwiser OR

Test files :

- Bitwise And - `tests/tt_eager/python_api_testing/sweep_tests/pytests/tt_dnn/test_bitwise_and.py` - PASSED
- Bitwise OR -` tests/tt_eager/python_api_testing/sweep_tests/pytests/tt_dnn/test_bitwise_or.py` -PASSED

- Tested for below ranges

    - Input Tensor range : [ 0, 2147483648] - Int datatype( Input tensor must be positive.)
    - Value : (-100, 100) - Int datatype

Comparison Criteria : comp_equal


**CI:**
- [All post-commit tests](https://github.com/tenstorrent/tt-metal/actions/runs/9759622185) - PASSED
- [[post-commit] Fast Dispatch unit tests](https://github.com/tenstorrent/tt-metal/actions/runs/9759630293) - 
- [[post-commit] Slow Dispatch unit tests](https://github.com/tenstorrent/tt-metal/actions/runs/9759625521) - PASSED

Issues Faced :

- Scalar values can be both positive and negative. Input Tensor needs to be positive only, because negative tensor gives incorrect results.

Implemented concept :

- Bitwise OR
     ```
                 vInt input = dst_reg[0];
                 vInt scalar_value = value;
                 vInt res = input | scalar_value;
                 v_if(res > INT_MIN && res < 0)
                 {
                     res = 0 - res ;
                     res = setsgn(res, scalar_value);
                 }
                 v_endif
                 dst_reg[0] = res;
     ```

    - If condition used : 
         -  For negative scalar value : `v_if(value<0 && value!=0)` 
               -  Eg: For  63 | -4 , expected result is -1 but in TT it is -2147483647 which is negative limit of Int.
               -  Eg: For  38 | -4 , expected result is -2 but in TT it is -2147483646 which is negative limit of Int plus 1.
         -  We've done the calculation to overcome the discrepancy in the result. Hence we've subtracted  the result from zero and used setsgn to set sign of the result.

Test file Result:

- Bitwise AND
  <img width="1183" alt="Screenshot 2024-06-14 at 12 06 35 PM" src="https://github.com/tenstorrent/tt-metal/assets/169127329/1371c94a-3ce8-4845-a8ca-4828469bcff7">
- Bitwise OR
  <img width="1148" alt="Screenshot 2024-06-14 at 12 05 34 PM" src="https://github.com/tenstorrent/tt-metal/assets/169127329/e9d09581-8491-49ff-a42c-3f0fadc7783f">

