### PR TITLE
#9059: Get matmul per core factor based on L1 usage

### DIFF
--- a/tt_eager/tt_dnn/op_library/bmm/multi_core_reuse_mcast_2d_optimized/bmm_op_multi_core_reuse_mcast_2d_optimized.cpp
+++ b/tt_eager/tt_dnn/op_library/bmm/multi_core_reuse_mcast_2d_optimized/bmm_op_multi_core_reuse_mcast_2d_optimized.cpp
@@ -1296,9 +1296,9 @@ operation::ProgramWithCallbacks matmul_multi_core_reuse_mcast_2d_optimized_(
     // TODO: Move these validates to op validate and properly check for this
     TT_FATAL(
         num_blocks_x <= num_cores_x,
-        "Num output blocks along x must be smaller than number of columns in compute grid!");
+        "Num output blocks along x {} must be smaller than or equal to the number of columns in compute grid {}!", num_blocks_x, num_cores_x);
     TT_FATAL(
-        num_blocks_y <= num_cores_y, "Num output blocks along y must be smaller than number of rows in compute grid!");
+        num_blocks_y <= num_cores_y, "Num output blocks along y {} must be smaller than or equal to the number of rows in compute grid {}!", num_blocks_y, num_cores_y);
 
     ////////////////////////////////////////////////////////////////////////////
     //                      Grayskull Device Setup


### PR DESCRIPTION
### Ticket
- Link to Github Issue. https://github.com/tenstorrent/tt-metal/issues/9059

### Problem description
- For some tensor inputs, one of the chosen matmul program configs that uses per_core_M/N of 16 was running out of L1 space.

### What's changed
Therefore this change reduces the per_core_M/N based on available L1 space. Based on other parameters may change to other program config.

Also removed redundant check on Kt when there's one already higher up.

### Checklist
- [x] Post commit CI passes
- [x] Model regression CI testing passes (if applicable)
- [x] New/Existing tests provide coverage for changes
