### PR TITLE
#0: Update dockerfile with c++17-dev and python3-dev, removed venv

### DIFF
--- a/dockerfile/ubuntu-20.04-amd64.Dockerfile
+++ b/dockerfile/ubuntu-20.04-amd64.Dockerfile
@@ -27,8 +27,10 @@ COPY build_metal.sh /scripts/build_metal.sh
 # Setup Env variables to setup Python Virtualenv - Install TT-Metal Python deps
 ENV TT_METAL_INFRA_DIR=/opt/tt_metal_infra
 ENV PYTHON_ENV_DIR=${TT_METAL_INFRA_DIR}/tt-metal/python_env
-RUN python3 -m venv $PYTHON_ENV_DIR
-ENV PATH="$PYTHON_ENV_DIR/bin:$PATH"
+
+# Disable using venv since this is isolated in a docker container
+# RUN python3 -m venv $PYTHON_ENV_DIR
+# ENV PATH="$PYTHON_ENV_DIR/bin:$PATH"
 
 # Copy requirements from tt-metal folders with requirements.txt docs
 COPY /docs/requirements-docs.txt ${TT_METAL_INFRA_DIR}/tt-metal/docs/.
@@ -53,5 +55,12 @@ RUN cd $TT_METAL_INFRA_DIR \
     && ./configure \
     && make -j$(nproc)
 ENV PATH="$TT_METAL_INFRA_DIR/gdb-14.2/gdb:$PATH"
+
+# Can only be installed after Clang-17 installed
+RUN apt-get -y update \
+    && apt-get install -y --no-install-recommends \
+    libc++-17-dev \
+    libc++abi-17-dev \
+    && rm -rf /var/lib/apt/lists/*
 
 CMD ["tail", "-f", "/dev/null"]

--- a/scripts/docker/requirements.txt
+++ b/scripts/docker/requirements.txt
@@ -16,6 +16,7 @@ python3-pip
 libhwloc-dev
 libhdf5-serial-dev
 ruby=1:2.7+1
+python3-dev=3.8.2-0ubuntu2
 python3.8-venv=3.8.10-0ubuntu1~20.04.9
 cargo
 ninja-build


### PR DESCRIPTION
### Problem description
Made a new docker image for tt-metal tagged as ghcr.io/tenstorrent/tt-metal/tt-metalium/ubuntu-20.04-amd64:latest for dev use

### What's changed
- Describe the approach used to solve the problem.
- Added c++17-dev and abi changes for pre-emptive use.
-  removed venv installation so python reqs are baked into docker image. this allows users to use the docker image and still install their own personal python deps as desired
- python3-dev for build compilation

### Checklist
- [ ] Post commit CI passes
- [ ] Model regression CI testing passes (if applicable)
- [ ] New/Existing tests provide coverage for changes

Manually created docker image and tested on IRD