### PR TITLE
#0: Resolve trace issues exposed by using eth dispatch

### DIFF
--- a/tests/scripts/t3000/run_t3000_frequent_tests.sh
+++ b/tests/scripts/t3000/run_t3000_frequent_tests.sh
@@ -92,6 +92,7 @@ run_t3000_trace_stress_tests() {
   echo "LOG_METAL: Running run_t3000_trace_stress_tests"
 
   NUM_TRACE_LOOPS=30 pytest tests/ttnn/unit_tests/test_multi_device_trace.py
+  NUM_TRACE_LOOPS=30 WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml pytest tests/ttnn/unit_tests/test_multi_device_trace.py
 
   # Record the end time
   end_time=$(date +%s)

--- a/tests/scripts/t3000/run_t3000_unit_tests.sh
+++ b/tests/scripts/t3000/run_t3000_unit_tests.sh
@@ -28,6 +28,7 @@ run_t3000_ttnn_tests() {
 
   echo "LOG_METAL: Running run_t3000_ttnn_tests"
   pytest tests/ttnn/unit_tests/test_multi_device_trace.py
+  WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml pytest tests/ttnn/unit_tests/test_multi_device_trace.py
   pytest tests/ttnn/unit_tests/test_multi_device.py
   pytest tests/ttnn/unit_tests/test_multi_device_async.py
   # Record the end time

--- a/tests/ttnn/unit_tests/test_multi_device_trace.py
+++ b/tests/ttnn/unit_tests/test_multi_device_trace.py
@@ -108,11 +108,11 @@ def test_multi_device_single_trace(t3k_device_mesh, shape, use_all_gather, enabl
 
 @pytest.mark.parametrize(
     "shape",
-    [(1, 3, 1024, 1024), (1, 1, 512, 512), (1, 1, 32, 32), (1, 3, 512, 512), (1, 3, 32, 32)],
+    [(1, 1, 256, 256), (1, 3, 1024, 1024), (1, 1, 512, 512), (1, 1, 32, 32), (1, 3, 512, 512), (1, 3, 32, 32)],
 )
 @pytest.mark.parametrize("use_all_gather", [True, False])
 @pytest.mark.parametrize("enable_async", [True])
-@pytest.mark.parametrize("device_params", [{"trace_region_size": 99328}], indirect=True)
+@pytest.mark.parametrize("device_params", [{"trace_region_size": 104448}], indirect=True)
 def test_multi_device_multi_trace(t3k_device_mesh, shape, use_all_gather, enable_async):
     torch.manual_seed(0)
     if t3k_device_mesh.get_num_devices() <= 1:
@@ -245,16 +245,19 @@ def test_multi_device_multi_trace(t3k_device_mesh, shape, use_all_gather, enable
                 assert_with_pcc(device_tensor_torch, torch_output_golden_2, pcc=0.96)
         else:
             # Perform host All-Gather
+            logger.info("Read Back Trace 0 Outputs")
             ttnn_torch_output_tensor = ttnn.to_torch(
                 output_tensor, mesh_composer=ConcatMeshToTensor(t3k_device_mesh, dim=0), device=t3k_device_mesh
             )
             assert_with_pcc(ttnn_torch_output_tensor, torch_output_golden, pcc=0.96)
 
+            logger.info("Read Back Trace 1 Outputs")
             ttnn_torch_output_tensor = ttnn.to_torch(
                 output_tensor_1, mesh_composer=ConcatMeshToTensor(t3k_device_mesh, dim=0), device=t3k_device_mesh
             )
             assert_with_pcc(ttnn_torch_output_tensor, torch_output_golden_1, pcc=0.96)
 
+            logger.info("Read Back Trace 1 Outputs")
             ttnn_torch_output_tensor = ttnn.to_torch(
                 output_tensor_2, mesh_composer=ConcatMeshToTensor(t3k_device_mesh, dim=0), device=t3k_device_mesh
             )


### PR DESCRIPTION


### Ticket
- Link to Github Issue.

### Problem description
- Trace was hanging with certain configurations when using ethernet dispatch. Exposed due to smaller buffers, due to limited memory on erisc cores.
- Main Issue was in CQ Prefetch: stall_state was set to STALLED, even if exec_buf command wrapped around in the cmddat_q, causing read_from_pcie to not be called until exec_buf was run ... except exec_buf was never run, as it was never fetched.

### What's changed
 - Resolve this by only setting the STALLED flag, if there are no pending reads over PCIe -> all entries in the exec_buf fetch_q entry have been read
 - Add multi_device trace tests using ethernet dispatch

### Checklist
- [x] Post commit CI passes
- [ ] Model regression CI testing passes (if applicable)
- [x] New/Existing tests provide coverage for changes
