### PR TITLE
#9457: Re-enable PCH

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -148,12 +148,12 @@ else()
 endif()
 
 # Can't use the `REUSE_FROM` option bc tt_lib and ttnn have different build flags :(
-# add_library(pch_pybinds INTERFACE)
-# target_precompile_headers(pch_pybinds INTERFACE
-#     ${PROJECT_SOURCE_DIR}/tt_metal/third_party/pybind11/include/pybind11/operators.h
-#     ${PROJECT_SOURCE_DIR}/tt_metal/third_party/pybind11/include/pybind11/pybind11.h
-#     ${PROJECT_SOURCE_DIR}/tt_metal/third_party/pybind11/include/pybind11/stl.h
-# )
+add_library(pch_pybinds INTERFACE)
+target_precompile_headers(pch_pybinds INTERFACE
+    ${PROJECT_SOURCE_DIR}/tt_metal/third_party/pybind11/include/pybind11/operators.h
+    ${PROJECT_SOURCE_DIR}/tt_metal/third_party/pybind11/include/pybind11/pybind11.h
+    ${PROJECT_SOURCE_DIR}/tt_metal/third_party/pybind11/include/pybind11/stl.h
+)
 
 ############################################################################################################################
 # Build subdirectories

--- a/tt_eager/tt_dnn/op_library/CMakeLists.txt
+++ b/tt_eager/tt_dnn/op_library/CMakeLists.txt
@@ -224,12 +224,12 @@ target_include_directories(tt_dnn PUBLIC
     ${PROJECT_SOURCE_DIR}/tt_metal/third_party/fmt
 )
 
-# target_precompile_headers(tt_dnn PUBLIC
-#     ${PROJECT_SOURCE_DIR}/tt_metal/third_party/magic_enum/magic_enum.hpp
-#     ${PROJECT_SOURCE_DIR}/tt_metal/third_party/tracy/public/tracy/Tracy.hpp
-#     ${CMAKE_CURRENT_SOURCE_DIR}/auto_format.hpp
-#     ${CMAKE_CURRENT_SOURCE_DIR}/compute_kernel_config.hpp
-#     ${CMAKE_CURRENT_SOURCE_DIR}/operation.hpp
-#     ${CMAKE_CURRENT_SOURCE_DIR}/run_operation.hpp
-#     ${CMAKE_CURRENT_SOURCE_DIR}/work_split.hpp
-# )
+target_precompile_headers(tt_dnn PUBLIC
+    ${PROJECT_SOURCE_DIR}/tt_metal/third_party/magic_enum/magic_enum.hpp
+    ${PROJECT_SOURCE_DIR}/tt_metal/third_party/tracy/public/tracy/Tracy.hpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/auto_format.hpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/compute_kernel_config.hpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/operation.hpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/run_operation.hpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/work_split.hpp
+)

--- a/tt_eager/tt_lib/CMakeLists.txt
+++ b/tt_eager/tt_lib/CMakeLists.txt
@@ -13,7 +13,7 @@ set(TT_LIB_SRCS
 # TODO: should be using pybind11_add_module, but right now it introduces many build problems
 # pybinds will always be built as a shared library
 add_library(tt_lib SHARED ${TT_LIB_SRCS})
-target_link_libraries(tt_lib PUBLIC compiler_flags linker_flags tt_eager tt_metal)  # linker_flags = -rdynamic if tracy enabled
+target_link_libraries(tt_lib PUBLIC compiler_flags linker_flags tt_eager tt_metal pch_pybinds)  # linker_flags = -rdynamic if tracy enabled
 target_include_directories(tt_lib PUBLIC
     ${UMD_HOME}
     ${PROJECT_SOURCE_DIR}

--- a/ttnn/CMakeLists.txt
+++ b/ttnn/CMakeLists.txt
@@ -20,16 +20,15 @@ target_include_directories(ttnn_lib PUBLIC
     ${CMAKE_CURRENT_SOURCE_DIR}/cpp
     ${PROJECT_SOURCE_DIR}/tt_metal/third_party/fmt
 )
-# target_precompile_headers(ttnn_lib PRIVATE
-#     ${PROJECT_SOURCE_DIR}/tt_metal/third_party/magic_enum/magic_enum.hpp
-# )
-
+target_precompile_headers(ttnn_lib PRIVATE
+    ${PROJECT_SOURCE_DIR}/tt_metal/third_party/magic_enum/magic_enum.hpp
+)
 
 # TODO: should be using pybind11_add_module, but right now it introduces many build problems
 # pybinds will always be built as a shared library
 add_library(ttnn SHARED ${PROJECT_SOURCE_DIR}/ttnn/cpp/pybind11/__init__.cpp $<TARGET_OBJECTS:ttnn_lib>)
 target_compile_options(ttnn PUBLIC -Wno-int-to-pointer-cast -fno-var-tracking)
-target_link_libraries(ttnn PUBLIC compiler_flags linker_flags tt_eager)     # linker_flags = -rdynamic if tracy enabled
+target_link_libraries(ttnn PUBLIC compiler_flags linker_flags tt_eager pch_pybinds)     # linker_flags = -rdynamic if tracy enabled
 target_include_directories(ttnn PUBLIC
     ${CMAKE_CURRENT_SOURCE_DIR}/cpp
     ${PROJECT_SOURCE_DIR}/tt_metal/third_party/pybind11/include


### PR DESCRIPTION
### Ticket
#9457

### Problem description
During work on https://github.com/tenstorrent/tt-metal/pull/9368 I disable PCH. Even a clean build caused pch invalidation
```
fatal error: file '/home/ubuntu/tt-metal/build/tt_eager/tt_dnn/op_library/CMakeFiles/tt_dnn.dir/cmake_pch.hxx.cxx' has been modified since the precompiled header '/home/ubuntu/tt-metal/build/tt_eager/tt_dnn/op_library/CMakeFiles/tt_dnn.dir/cmake_pch.hxx.pch' was built: mtime changed (was 1717806305, now 1718219529)
note: please rebuild precompiled header '/home/ubuntu/tt-metal/build/tt_eager/tt_dnn/op_library/CMakeFiles/tt_dnn.dir/cmake_pch.hxx.pch'
```

@yan-zaretskiy hinted that it is due to `ccache` conflicting with PCH. Due to my local setup ccache usage is configured on the system level.

### What's changed
I revert the prior change, confident that my changes are not causing an issue. 
If anyone faces a similar problem please call `ccache --clear` or `ccache -C`

We should consider adding `-fno-pch-timestamp` to the build. See [details here](https://discourse.cmake.org/t/ccache-clang-and-fno-pch-timestamp/7253)

### Checklist
- [x] Post commit CI [passes (does not introduce new regressions)](https://github.com/tenstorrent/tt-metal/actions/runs/9525173517)