### PR TITLE
#9319: Get rid of static checks because that's giving GitHub trouble parsing

### DIFF
--- a/.github/workflows/_produce-data.yaml
+++ b/.github/workflows/_produce-data.yaml
@@ -4,7 +4,8 @@ on:
   workflow_call:
   workflow_dispatch:
   workflow_run:
-    workflows: ["All post-commit tests", "[post-commit] all - Static checks, linters etc."]
+    workflows:
+      - "All post-commit tests"
     types:
       - completed
 


### PR DESCRIPTION
…. Clearly something on their backend

### Ticket
#9319 

### Problem description

Still seeing reds on the action triggers for this workflow.

### What's changed

Trouble parsing static checks, so got rid of that trigger for now.

### Checklist
- [x] Post commit CI passes
- [x] Model regression CI testing passes (if applicable)
- [x] New/Existing tests provide coverage for changes
