### PR TITLE
#9319: Add step to output info of completed workflow run that triggered this produce data event

### DIFF
--- a/.github/workflows/_produce-data.yaml
+++ b/.github/workflows/_produce-data.yaml
@@ -35,3 +35,10 @@ jobs:
           gh api /repos/tenstorrent/tt-metal/actions/runs/${{ github.run_id }}
           echo "[Info] Workflow run attempt"
           gh api /repos/tenstorrent/tt-metal/actions/runs/${{ github.run_id }}/attempts/${{ github.run_attempt }}
+      - name: Output auxiliary values (workflow_run completed)
+        if: ${{ github.event_name == 'workflow_run' }}
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          echo "[Info] Triggering Workflow run"
+          gh api /repos/tenstorrent/tt-metal/actions/runs/${{ github.event.workflow_run.id }}/attempts/${{ github.event.workflow_run.run_attempt }}


### PR DESCRIPTION
…

### Ticket
#9319 

### Problem description

Want to provide data output of triggering workflow run as well. The current impl only produces output of the produce-data event itself, not the pipeline we want.

### What's changed

Filter for workflow trigger based on `github.event_name` and then output the `workflow_run` webhook info.

### Checklist
- [x] Post commit CI passes
- [x] Model regression CI testing passes (if applicable)
- [x] New/Existing tests provide coverage for changes
