### PR TITLE
#9319: Add escape characters to ensure workflow name is parsed correctly

### DIFF
--- a/.github/workflows/_produce-data.yaml
+++ b/.github/workflows/_produce-data.yaml
@@ -4,7 +4,7 @@ on:
   workflow_call:
   workflow_dispatch:
   workflow_run:
-    workflows: ["[post-commit] all - Static checks, linters etc."]
+    workflows: ["All post-commit tests", "[post-commit] all - Static checks, linters etc."]
     types:
       - completed
 

--- a/.github/workflows/_produce-data.yaml
+++ b/.github/workflows/_produce-data.yaml
@@ -4,8 +4,7 @@ on:
   workflow_call:
   workflow_dispatch:
   workflow_run:
-    workflows:
-      - "All post-commit tests"
+    workflows: ["[post-commit] all - Static checks, linters etc."]
     types:
       - completed
 


### PR DESCRIPTION
according to https://github.com/github/docs/issues/12572

### Ticket

#9319 

### Problem description

Special characters in workflow names seem to not be supported with `workflow_run:`. This happens when you specify a workflow with special characters in the name under `workflow_run: workflows:`. Actions says it can't parse anything.

### What's changed

We added special characters to the string to parse for, per https://github.com/github/docs/issues/12572

### Checklist
- [ ] Post commit CI passes
- [ ] Model regression CI testing passes (if applicable)
- [ ] New/Existing tests provide coverage for changes
