### PR TITLE
#9473: Add rounding_mode support for forward div op

### DIFF
--- a/tests/tt_eager/python_api_testing/sweep_tests/op_map.py
+++ b/tests/tt_eager/python_api_testing/sweep_tests/op_map.py
@@ -144,6 +144,10 @@ op_map = {
         "tt_op": tt_lib_ops.eltwise_div_unary,
         "pytorch_op": pytorch_ops.div_unary,
     },
+    "eltwise-unary_div": {
+        "tt_op": tt_lib_ops.eltwise_unary_div,
+        "pytorch_op": pytorch_ops.unary_div,
+    },
     "eltwise-mul_unary": {
         "tt_op": tt_lib_ops.eltwise_mul_unary,
         "pytorch_op": pytorch_ops.mul_unary,

--- a/tests/tt_eager/python_api_testing/sweep_tests/pytests/tt_dnn/test_div_unary.py
+++ b/tests/tt_eager/python_api_testing/sweep_tests/pytests/tt_dnn/test_div_unary.py
@@ -24,7 +24,7 @@ mem_configs = [
 ]
 
 
-@pytest.mark.parametrize("accurate_mode", [False, True])
+@pytest.mark.parametrize("accurate_mode", [True])
 @pytest.mark.parametrize("round_mode", ["None", "trunc", "floor"])
 @pytest.mark.parametrize(
     "input_shapes",
@@ -35,47 +35,40 @@ mem_configs = [
     ],
 )
 @pytest.mark.parametrize(
+    "scalar",
+    {random.uniform(-100, 100) for _ in range(3)},
+)
+@pytest.mark.parametrize(
     "dst_mem_config",
     mem_configs,
 )
 @skip_for_grayskull("#ToDo: GS implementation needs to be done for floor and trunc")
-class TestDiv:
-    def test_run_div(
+class TestUnary_Div:
+    def test_run_unary_div(
         self,
         accurate_mode,
         round_mode,
         input_shapes,
+        scalar,
         dst_mem_config,
         device,
     ):
-        if accurate_mode == False:  # If input_b is non-zero tensor
-            datagen_func = [
-                generation_funcs.gen_func_with_cast(
-                    partial(generation_funcs.gen_rand, low=-1e6, high=1e6), torch.bfloat16
-                )
-            ] + [
-                generation_funcs.gen_func_with_cast(
-                    partial(generation_funcs.gen_rand, low=-1e6, high=-1), torch.bfloat16
-                )
-            ]
-        else:
-            datagen_func = [
-                generation_funcs.gen_func_with_cast(
-                    partial(generation_funcs.gen_rand, low=-1e6, high=1e6), torch.bfloat16
-                )
-            ] * 2
+        datagen_func = [
+            generation_funcs.gen_func_with_cast(partial(generation_funcs.gen_rand, low=-1e6, high=1e6), torch.bfloat16)
+        ] * 2
         test_args = generation_funcs.gen_default_dtype_layout_device(input_shapes)[0]
         test_args.update(
             {
                 "accurate_mode": accurate_mode,
                 "round_mode": round_mode,
+                "scalar": scalar,
             }
         )
         test_args.update({"output_mem_config": dst_mem_config})
         comparison_func = comparison_funcs.comp_pcc
 
         run_single_pytorch_test(
-            "eltwise-div",
+            "eltwise-unary_div",
             input_shapes,
             datagen_func,
             comparison_func,

--- a/tests/tt_eager/python_api_testing/sweep_tests/pytorch_ops.py
+++ b/tests/tt_eager/python_api_testing/sweep_tests/pytorch_ops.py
@@ -713,9 +713,10 @@ def silu(x, *args, **kwargs):
     return torch.nn.functional.silu(x)
 
 
-def div(x, y, *args, accurate_mode, **kwargs):
-    result = torch.div(x, y)
-    return result
+def div(x, y, *args, accurate_mode, round_mode, **kwargs):
+    if round_mode == "None":
+        return torch.div(x, y)
+    return torch.div(x, y, rounding_mode=round_mode)
 
 
 def div_no_nan(x, y, *args, **kwargs):
@@ -735,6 +736,12 @@ def unary_div_no_nan(x, *args, **kwargs):
 def div_unary(x, *args, scalar, **kwargs):
     result = torch.div(x, scalar)
     return result
+
+
+def unary_div(x, *args, scalar, accurate_mode, round_mode, **kwargs):
+    if round_mode == "None":
+        return torch.div(x, scalar)
+    return torch.div(x, scalar, rounding_mode=round_mode)
 
 
 def mul_unary(x, *args, scalar, **kwargs):

--- a/tests/tt_eager/python_api_testing/sweep_tests/tt_lib_ops.py
+++ b/tests/tt_eager/python_api_testing/sweep_tests/tt_lib_ops.py
@@ -1060,6 +1060,7 @@ def eltwise_div(
     y,
     *args,
     accurate_mode,
+    round_mode,
     device,
     dtype,
     layout,
@@ -1069,7 +1070,7 @@ def eltwise_div(
 ):
     t0 = setup_tt_tensor(x, device, layout[0], input_mem_config[0], dtype[0])
     t1 = setup_tt_tensor(y, device, layout[1], input_mem_config[1], dtype[1])
-    t2 = ttl.tensor.div(t0, t1, accurate_mode, output_mem_config=output_mem_config)
+    t2 = ttl.tensor.div(t0, t1, accurate_mode, round_mode, output_mem_config=output_mem_config)
 
     return tt2torch_tensor(t2)
 
@@ -1693,6 +1694,26 @@ def eltwise_div_unary(
 ):
     t0 = setup_tt_tensor(x, device, layout[0], input_mem_config[0], dtype[0])
     t1 = ttl.tensor.div_unary(t0, scalar, output_mem_config=output_mem_config)
+
+    return tt2torch_tensor(t1)
+
+
+@setup_host_and_device
+def eltwise_unary_div(
+    x,
+    *args,
+    scalar,
+    accurate_mode,
+    round_mode,
+    device,
+    dtype,
+    layout,
+    input_mem_config,
+    output_mem_config,
+    **kwargs,
+):
+    t0 = setup_tt_tensor(x, device, layout[0], input_mem_config[0], dtype[0])
+    t1 = ttl.tensor.div(t0, scalar, accurate_mode, round_mode, output_mem_config=output_mem_config)
 
     return tt2torch_tensor(t1)
 

--- a/tt_eager/tt_dnn/op_library/composite/composite_ops.hpp
+++ b/tt_eager/tt_dnn/op_library/composite/composite_ops.hpp
@@ -183,6 +183,14 @@ Tensor div(
     const Tensor& input_a,
     const Tensor& input_b,
     bool accurate_mode = false,
+    string round_mode = "None",
+    const MemoryConfig& output_mem_config = operation::DEFAULT_OUTPUT_MEMORY_CONFIG);
+
+Tensor div(
+    const Tensor& input_a,
+    float scalar,
+    bool accurate_mode = false,
+    string round_mode = "None",
     const MemoryConfig& output_mem_config = operation::DEFAULT_OUTPUT_MEMORY_CONFIG);
 
 Tensor div_no_nan(

--- a/tt_eager/tt_lib/csrc/tt_lib_bindings_tensor_composite_ops.cpp
+++ b/tt_eager/tt_lib/csrc/tt_lib_bindings_tensor_composite_ops.cpp
@@ -1109,10 +1109,11 @@ void TensorModuleCompositeOPs(py::module& m_tensor) {
 
     m_tensor.def(
         "div",
-        &div,
+        py::overload_cast<const Tensor&, const Tensor&, bool, string, const MemoryConfig&>(&div),
         py::arg("input_a").noconvert(),
         py::arg("input_b").noconvert(),
         py::arg("accurate_mode") = false,
+        py::arg("round_mode") = "None",
         py::arg("output_mem_config").noconvert() = operation::DEFAULT_OUTPUT_MEMORY_CONFIG,
         R"doc(
             Performs the element-wise division of ``input_a`` by ``input_b``.
@@ -1128,6 +1129,33 @@ void TensorModuleCompositeOPs(py::module& m_tensor) {
                 "input_a", "Numerator Tensor", "Tensor", "Tensor of shape [W, Z, Y, X]", "Yes"
                 "input_b", "Denominator Tensor", "Tensor", "Tensor of shape [W, Z, Y, X]", "Yes"
                 "accurate_mode", "Mode of Implementation", "bool", "default to false", "No"
+                "round_mode", "Mode of Rounding", "String", "default to None", "No"
+                "output_mem_config", "Layout of tensor in TT Accelerator device memory banks", "MemoryConfig", "Default is interleaved in DRAM", "No"
+        )doc");
+
+    m_tensor.def(
+        "div",
+        py::overload_cast<const Tensor&, float, bool, string, const MemoryConfig&>(&div),
+        py::arg("input_a").noconvert(),
+        py::arg("scalar").noconvert(),
+        py::arg("accurate_mode") = false,
+        py::arg("round_mode") = "None",
+        py::arg("output_mem_config").noconvert() = operation::DEFAULT_OUTPUT_MEMORY_CONFIG,
+        R"doc(
+            Performs the element-wise division of  tensor ``input_a`` by ``scalar`` value.
+            If scalar value is non-zero, then ``accurate_mode`` can be ``false``,else set ``accurate_mode`` to ``true``
+
+            Input tensor must have BFLOAT16 data type.
+
+            Output tensor will have BFLOAT16 data type.
+
+            .. csv-table::
+                :header: "Argument", "Description", "Data type", "Valid range", "Required"
+
+                "input_a", "Numerator Tensor", "Tensor", "Tensor of shape [W, Z, Y, X]", "Yes"
+                "scalar", "Denominator value", "float", "", "Yes"
+                "accurate_mode", "Mode of Implementation", "bool", "default to false", "No"
+                "round_mode", "Mode of Rounding", "String", "default to None", "No"
                 "output_mem_config", "Layout of tensor in TT Accelerator device memory banks", "MemoryConfig", "Default is interleaved in DRAM", "No"
         )doc");
 


### PR DESCRIPTION
Issue #9473

**Work Done:**

- Provided rounding mode support for the div op (trunc, floor).
- Overloaded unary div op.

**Test files:** 

- Unary div: `tests/tt_eager/python_api_testing/sweep_tests/pytests/tt_dnn/test_div.py` - PASSED
- Binary div:  `tests/tt_eager/python_api_testing/sweep_tests/pytests/tt_dnn/test_div_unary.py` - PASSED
- Tested for below ranges using `comp_pcc`
    - Unary div : Numerator Range [ -1e6, 1e6], Denominator Range [ -1e6, 1e6]
    - Binary div : Numerator Range [ -1e6, 1e6], Denominator Range [ -1e6, 1e6]

**CI Test** : 

- [All Post-commit-tests](https://github.com/tenstorrent/tt-metal/actions/runs/9640001441) - PASSED.
-  [[post-commit] Fast Dispatch unit tests](https://github.com/tenstorrent/tt-metal/actions/runs/9640006588) - PASSED.
-  [[post-commit] Slow Dispatch unit tests](https://github.com/tenstorrent/tt-metal/actions/runs/9640012665) - PASSED.


**Test file results**
- Unary div: 
![Screenshot 2024-06-17 at 6 13 08 PM](https://github.com/tenstorrent/tt-metal/assets/169127329/1aba2617-ef1e-4f0c-b02a-5d43d47004fd)

- Binary div:  
![Screenshot 2024-06-17 at 5 29 11 PM](https://github.com/tenstorrent/tt-metal/assets/169127329/238715ee-0b77-4cab-a20b-bf946bf57251)

**Documentation** : 
<img width="1150" alt="Screenshot 2024-06-20 at 5 10 24 PM" src="https://github.com/tenstorrent/tt-metal/assets/169127329/d84b96ec-425a-4796-9f30-602cfedc5b48">
