### PR TITLE
#9467: Bump GS device perf timeout to 75min because of suspected libc++ slowdowns

### DIFF
--- a/.github/workflows/perf-device-models.yaml
+++ b/.github/workflows/perf-device-models.yaml
@@ -14,7 +14,7 @@ jobs:
       fail-fast: false
       matrix:
         test-info: [
-          {name: "GS", arch: grayskull, runs-on: ["perf-no-reset-grayskull", "self-reset"], machine-type: "bare_metal", timeout: 40},
+          {name: "GS", arch: grayskull, runs-on: ["perf-no-reset-grayskull", "self-reset"], machine-type: "bare_metal", timeout: 75},
           {name: "N300 WH B0", arch: wormhole_b0, runs-on: ["perf-wormhole_b0", "self-reset"], machine-type: "bare_metal", timeout: 20},
         ]
     name: "${{ matrix.test-info.name }} device perf"


### PR DESCRIPTION
…

on ReadFromDevice

### Ticket

#9467 

### Problem description

We are seeing much longer read from device times. This is causing the GS device perf tests to run into the 40 min timeout.

### What's changed

Increase timeout.

### Checklist
- [x] Post commit CI passes
- [x] Model regression CI testing passes (if applicable)
- [x] New/Existing tests provide coverage for changes
