### PR TITLE
#9454: add topk to ttnn

### DIFF
--- a/docs/source/ttnn/ttnn/api.rst
+++ b/docs/source/ttnn/ttnn/api.rst
@@ -223,6 +223,7 @@ Reduction
    ttnn/sum
    ttnn/var
    ttnn/argmax
+   ttnn/topk
 
 Data Movement
 =============

--- a/docs/source/ttnn/ttnn/ttnn/topk.rst
+++ b/docs/source/ttnn/ttnn/ttnn/topk.rst
@@ -1,0 +1,6 @@
+.. _ttnn.topk:
+
+ttnn.topk
+###############
+
+.. autofunction:: ttnn.topk

--- a/tests/ttnn/unit_tests/operations/test_topk.py
+++ b/tests/ttnn/unit_tests/operations/test_topk.py
@@ -1,0 +1,77 @@
+# SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
+
+# SPDX-License-Identifier: Apache-2.0
+
+import pytest
+
+import torch
+
+import ttnn
+
+from tests.ttnn.utils_for_testing import assert_with_pcc
+from models.utility_functions import torch_random, skip_for_grayskull
+
+
+def run_topk_test(N, C, H, W, k, dtype, device):
+    torch.manual_seed(2005)
+    shape = [N, C, H, W]
+    torch_dtype = torch.bfloat16
+
+    input = torch.randn(shape, dtype=torch_dtype)
+    pyt_topk_values, pyt_topk_indices = torch.topk(input, k, dim=-1, largest=True, sorted=True)
+
+    ttnn_input = ttnn.from_torch(input, dtype, layout=ttnn.Layout.TILE, device=device)
+    ttnn_topk_values, ttnn_topk_indices = ttnn.topk(ttnn_input, k, dim=-1, largest=True, sorted=True)
+
+    assert list(ttnn_topk_values.get_legacy_shape()) == [N, C, H, k]
+    assert list(ttnn_topk_indices.get_legacy_shape()) == [N, C, H, k]
+
+    ttnn_torch_values = ttnn.to_torch(ttnn_topk_values)
+    ttnn_torch_indices = ttnn.to_torch(ttnn_topk_indices)
+
+    if dtype == ttnn.bfloat8_b:
+        pcc_values = 0.99
+        pcc_index = 0.99
+    else:
+        pcc_index = 1.0
+        pcc_values = 1.0
+
+    # pcc is not a good measure for the raw indices
+    # if index 49 and index 8 are tied, the order of the indices can be different
+    # but the values associated with the indices should be the same
+    # if index 7 and 8 are tied, but swapped, the pcc will be better than if index 49 and 8 are tied but swapped
+    # so we will use pcc for the values and not the indices
+    # to make sure the indices are correct, we gather the relevant values from the original torch tensor and test to see if they are similar
+    # rounding may also cause more ties than expected
+    ttnn_torch_gather_from_indices = torch.gather(input, -1, ttnn_torch_indices.to(torch.int64))
+
+    assert_with_pcc(pyt_topk_values, ttnn_torch_values, pcc_values)
+    assert_with_pcc(pyt_topk_values, ttnn_torch_gather_from_indices, pcc_index)
+
+
+@skip_for_grayskull()
+@pytest.mark.parametrize(
+    "dtype",
+    (
+        ttnn.bfloat16,
+        ttnn.bfloat8_b,
+        # ttnn.float32, top bits in float32 get cut off somewhere, LLK does not work for this
+    ),
+    ids=[
+        "BFLOAT16_B",
+        "BFLOAT8_B",
+        # "FLOAT32",
+    ],
+)
+@pytest.mark.parametrize(
+    "N, C, H, W, k,",
+    (
+        (1, 1, 32, 64, 32),
+        (1, 1, 32, 256, 32),
+        (1, 1, 128, 64, 32),
+        (1, 1, 1024, 64, 32),
+        (1, 1, 2048, 64, 32),
+    ),
+)
+def test_topk(N, C, H, W, k, dtype, device):
+    run_topk_test(N, C, H, W, k, dtype, device)

--- a/ttnn/CMakeLists.txt
+++ b/ttnn/CMakeLists.txt
@@ -6,6 +6,7 @@ set(TTNN_SRCS
     ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/matmul.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/reduction/argmax/device/argmax_op.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/eltwise/binary/device/binary_op.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/reduction/topk/device/topk_op.cpp
 )
 
 add_library(ttnn_lib OBJECT ${TTNN_SRCS})

--- a/ttnn/cpp/ttnn/operations/reduction/reduction_pybind.hpp
+++ b/ttnn/cpp/ttnn/operations/reduction/reduction_pybind.hpp
@@ -12,6 +12,7 @@
 #include "ttnn/operations/reduction/generic/generic_reductions.hpp"
 #include "ttnn/operations/reduction/generic/generic_reductions_pybind.hpp"
 #include "ttnn/operations/reduction/argmax/argmax_pybind.hpp"
+#include "ttnn/operations/reduction/topk/topk_pybind.hpp"
 
 namespace ttnn::operations::reduction {
 
@@ -26,6 +27,7 @@ void py_module(py::module& module) {
 
     // Special reductions
     detail::bind_reduction_argmax_operation(module);
+    detail::bind_reduction_topk_operation(module);
 }
 
 }  // namespace ttnn::operations::reduction

--- a/ttnn/cpp/ttnn/operations/reduction/topk/device/kernels/compute/topk.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/topk/device/kernels/compute/topk.cpp
@@ -1,0 +1,169 @@
+// SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <cstdint>
+
+#include "compute_kernel_api.h"
+#include "compute_kernel_api/transpose_wh.h"
+#include "compute_kernel_api/tile_move_copy.h"
+#include "compute_kernel_api/unpack.h"
+#include "compute_kernel_api/pack.h"
+
+// topk llk needs a global variable atm
+// this can only be removed once that's fixed
+int32_t topk_replay_init = 0;
+
+namespace NAMESPACE {
+void MAIN {
+    constexpr uint32_t input_cb_index = get_compile_time_arg_val(0);
+    constexpr uint32_t index_cb_index = get_compile_time_arg_val(1);
+    constexpr uint32_t input_transposed_cb_index = get_compile_time_arg_val(2);
+    constexpr uint32_t index_transposed_cb_index = get_compile_time_arg_val(3);
+    constexpr uint32_t values_cb_index = get_compile_time_arg_val(4);
+    constexpr uint32_t output_ind_cb_index = get_compile_time_arg_val(5);
+    constexpr uint32_t Ht = get_compile_time_arg_val(6);
+    constexpr uint32_t Wt = get_compile_time_arg_val(7);
+    constexpr uint32_t K = get_compile_time_arg_val(8);
+    constexpr uint32_t logk = get_compile_time_arg_val(9);
+    constexpr uint32_t logWt = get_compile_time_arg_val(10);
+
+    // dest indices for where to unpack the tiles for the llk
+    // the input goes in index 0,1 and the index goes in index 2,3
+    constexpr uint32_t input_dest_start = 0;
+    constexpr uint32_t index_dest_start = 2;
+    constexpr uint32_t input_dest_end = 1;
+    constexpr uint32_t index_dest_end = 3;
+    // init pack, compute and unpack
+
+    ckernel::topk_tile_init();
+    transpose_wh_init(input_cb_index, input_transposed_cb_index);
+
+    for(uint32_t ht = 0; ht < Ht; ++ht) {
+        bool ascending = false;
+        cb_reserve_back(input_transposed_cb_index, Wt);
+        cb_reserve_back(index_transposed_cb_index, Wt);
+
+        // streaming in input and index tiles to transpose and bitonic local sort them, two tiles at a time
+        for (uint32_t wt = 0; wt < Wt; wt+=2) {
+            acquire_dst(tt::DstMode::Half);
+            // local sort into k groups
+            cb_wait_front(input_cb_index, 2);
+            cb_wait_front(index_cb_index, 2);
+
+            unpack_reconfig_data_format_srca(input_cb_index);
+            transpose_wh_init_short(input_cb_index);
+            transpose_wh_tile(input_cb_index, 0, 0);
+            transpose_wh_tile(input_cb_index, 1, 1);
+
+            unpack_reconfig_data_format_srca(index_cb_index);
+            transpose_wh_init_short(index_cb_index);
+            transpose_wh_tile(index_cb_index, 0, 2);
+            transpose_wh_tile(index_cb_index, 1, 3);
+
+            // llk_topk_sort -> inplace
+            ckernel::topk_local_sort(0, (int) ascending, logk - 1);
+
+            // pack value tiles into cb_intermed0
+            pack_reconfig_data_format(input_transposed_cb_index);
+            pack_tile(0, input_transposed_cb_index);
+            pack_tile(1, input_transposed_cb_index);
+
+            // pack index tiles into cb_intermed1
+            pack_reconfig_data_format(index_transposed_cb_index);
+            pack_tile(2, index_transposed_cb_index);
+            pack_tile(3, index_transposed_cb_index);
+
+            cb_pop_front(input_cb_index, 2);
+            cb_pop_front(index_cb_index, 2);
+            release_dst(tt::DstMode::Half);
+        }
+
+        cb_push_back(input_transposed_cb_index, Wt);
+        cb_push_back(index_transposed_cb_index, Wt);
+
+        // iterative divide and conquer on pairs of tiles (bitonic topk merge and rebuild)
+        // first iteration we compare 0th and 1st tile, then 2nd and 3rd, etc. We get the sorted top 32 values in each pair.
+        // second iteration we compare 0th and 2nd tile, then 4th and 6th, etc.
+        // logWt iteration we compare 0th and Wt/2 tile
+        // single buffer as we can pack tiles back in-place
+        for (uint32_t m_iter = 0; m_iter < logWt; ++m_iter) {
+            bool a = false;
+            cb_wait_front(input_transposed_cb_index, Wt);
+            cb_wait_front(index_transposed_cb_index, Wt);
+
+            for (uint32_t left_ind = 0; left_ind < Wt - (1 << m_iter); left_ind += 2 << m_iter) {
+                uint32_t right_ind = left_ind + (1 << m_iter);
+                acquire_dst(tt::DstMode::Half);
+
+                copy_tile_to_dst_init_short_with_dt(index_transposed_cb_index, input_transposed_cb_index);
+                copy_tile(input_transposed_cb_index, left_ind, input_dest_start);
+                copy_tile(input_transposed_cb_index, right_ind, input_dest_end);
+
+                // unpack indices into dest
+                copy_tile_to_dst_init_short_with_dt(input_transposed_cb_index, index_transposed_cb_index);
+                copy_tile(index_transposed_cb_index, left_ind, index_dest_start);
+                copy_tile(index_transposed_cb_index, right_ind, index_dest_end);
+
+                // merge values - move larger 32 values into 0th dest and lower 32 values into 1st dest
+                ckernel::topk_merge(0, m_iter, K);
+                // sort within the larger 32 values
+                ckernel::topk_rebuild(0, (uint32_t) a, m_iter, K, logk, true);
+
+
+                // pack value tiles in-place in the single-buffered cb_intermed0, we only need the upper 32 values for topk, which was in input_dest_start
+                pack_reconfig_data_format(input_transposed_cb_index);
+                pack_tile<true>(input_dest_start, input_transposed_cb_index, left_ind);
+
+                // pack index tiles in-place in the single-buffered cb_intermed1, we only need the upper 32 values for topk, which was in index_dest_start
+                pack_reconfig_data_format(index_transposed_cb_index);
+                pack_tile<true>(index_dest_start, index_transposed_cb_index, left_ind);
+                release_dst(tt::DstMode::Half);
+                a = !a;
+            }
+            cb_reserve_back(input_transposed_cb_index, Wt);
+            cb_reserve_back(index_transposed_cb_index, Wt);
+
+            cb_pop_front(input_transposed_cb_index, Wt);
+            cb_pop_front(index_transposed_cb_index, Wt);
+
+            cb_push_back(input_transposed_cb_index, Wt);
+            cb_push_back(index_transposed_cb_index, Wt);
+        }
+
+        constexpr uint32_t Kt =  K % TILE_WIDTH == 0 ? K/TILE_WIDTH : K/TILE_WIDTH + 1;
+
+        // transpose value tiles and pack into output buffer
+        unpack_reconfig_data_format_srca(input_transposed_cb_index);
+        transpose_wh_init_short(input_transposed_cb_index);
+        pack_reconfig_data_format(input_transposed_cb_index);
+        cb_wait_front(input_transposed_cb_index, Kt);
+        for (uint32_t i = 0; i < Kt; ++i) {
+            acquire_dst(tt::DstMode::Half);
+            cb_reserve_back(values_cb_index, 1);
+            transpose_wh_tile(input_transposed_cb_index, i, 0);
+            pack_tile(0, values_cb_index);
+            cb_push_back(values_cb_index, 1);
+            release_dst(tt::DstMode::Half);
+        }
+        cb_wait_front(input_transposed_cb_index, Wt);
+        cb_pop_front(input_transposed_cb_index, Wt);
+
+        // transpose index tiles and pack into output buffer
+        unpack_reconfig_data_format_srca(index_transposed_cb_index);
+        transpose_wh_init_short(index_transposed_cb_index);
+        pack_reconfig_data_format(index_transposed_cb_index);
+        cb_wait_front(index_transposed_cb_index, Kt);
+        for (uint32_t i = 0; i < Kt; ++i) {
+            acquire_dst(tt::DstMode::Half);
+            cb_reserve_back(output_ind_cb_index, 1);
+            transpose_wh_tile(index_transposed_cb_index, i, 0);
+            pack_tile(0, output_ind_cb_index);
+            cb_push_back(output_ind_cb_index, 1);
+            release_dst(tt::DstMode::Half);
+        }
+        cb_wait_front(index_transposed_cb_index, Wt);
+        cb_pop_front(index_transposed_cb_index, Wt);
+    }
+}
+}

--- a/ttnn/cpp/ttnn/operations/reduction/topk/device/kernels/dataflow/reader_create_index_tensor.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/topk/device/kernels/dataflow/reader_create_index_tensor.cpp
@@ -1,0 +1,71 @@
+// SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <stdint.h>
+#include "dataflow_api.h"
+
+/**
+ * add a cb full of indices for the tile
+ * each row is identical in the index tensor, so we just need to add an offset based on which row tile it is
+ * first 32 elements are {0,..31}, then next 32 are {32,..64}
+ * wt is which tile it is along the row [0, Wt) so j + 32*wt is the value in the tile at each element
+*/
+FORCE_INLINE void generate_index_tile(const uint32_t cb_id, const uint32_t wt) {
+    // TODO: investigate moving to compile time (binary size is at risk)
+    cb_reserve_back(cb_id, 1);
+    uint32_t write_addr = get_write_ptr(cb_id);
+    volatile tt_l1_ptr uint32_t* ptr = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(write_addr);
+    uint16_t wt_offset = wt << 5;
+
+    uint32_t count = 0;
+    for (uint32_t i = 0; i < 2; ++i) {
+        for (uint32_t j = 0; j < 2; ++j) {
+            for (uint32_t k = 0; k < 16; ++k) {
+                for (uint32_t l = 0; l < 16; l+=2) {
+                    uint16_t value = l + 16*j + wt_offset;
+                    ptr[count] = (value + 1) << 16 | value;
+                    count++;
+                }
+            }
+        }
+    }
+    cb_push_back(cb_id, 1);
+}
+
+
+void kernel_main() {
+    uint32_t src_addr  = get_arg_val<uint32_t>(0);
+
+    constexpr uint32_t cb_id_in0 = get_compile_time_arg_val(0);
+    constexpr uint32_t cb_intermed_index = get_compile_time_arg_val(1);
+    constexpr bool src_is_dram = get_compile_time_arg_val(2) == 1;
+
+    constexpr uint32_t Ht = get_compile_time_arg_val(3);
+    constexpr uint32_t Wt = get_compile_time_arg_val(4);
+
+
+    // ublocks size defined in tiles
+    constexpr uint32_t onetile = 1;
+    constexpr uint32_t tile_bytes = get_tile_size(cb_id_in0);
+    constexpr DataFormat data_format = get_dataformat(cb_id_in0);
+
+    const InterleavedAddrGenFast<src_is_dram> s = {
+        .bank_base_address = src_addr,
+        .page_size = tile_bytes,
+        .data_format = data_format
+    };
+
+    // Stream in input tensor, buffer has four tiles as we double-buffer to continue streaming while waiting for compute and we need two tiles for the bitonic sort llk
+    // We could load in an entire row of tiles at a time but that would require substantially more memory (we would be double buffering four Wt sized CBs)
+    for (uint32_t i = 0; i < Ht; ++i) {
+        for (uint32_t j = 0; j < Wt; ++j) {
+            cb_reserve_back(cb_id_in0, onetile);
+            uint32_t l1_write_addr = get_write_ptr(cb_id_in0);
+            noc_async_read_tile(i*Wt + j, s, l1_write_addr);
+            noc_async_read_barrier();
+            cb_push_back(cb_id_in0, onetile);
+            generate_index_tile(cb_intermed_index, j);
+        }
+    }
+}

--- a/ttnn/cpp/ttnn/operations/reduction/topk/device/kernels/dataflow/writer_binary_interleaved.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/topk/device/kernels/dataflow/writer_binary_interleaved.cpp
@@ -1,0 +1,59 @@
+// SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "dataflow_api.h"
+
+void kernel_main() {
+    uint32_t dst_addr0  = get_arg_val<uint32_t>(0);
+    uint32_t dst_addr1  = get_arg_val<uint32_t>(1);
+
+    constexpr uint32_t values_cb_index = get_compile_time_arg_val(0);
+    constexpr uint32_t output_ind_cb_index = get_compile_time_arg_val(1);
+    constexpr bool values_is_dram = get_compile_time_arg_val(2) == 1;
+    constexpr bool output_ind_is_dram = get_compile_time_arg_val(3) == 1;
+    constexpr uint32_t Ht = get_compile_time_arg_val(4);
+    constexpr uint32_t K = get_compile_time_arg_val(5);
+    constexpr uint32_t Kt =  K % 32 == 0 ? K/32 : K/32 + 1;
+
+    // can amortize the noc reads by doing them side by side for the two tensors
+    constexpr uint32_t onetile = 1;
+    const uint32_t tile_bytes_values = get_tile_size(values_cb_index);
+    const DataFormat data_format_values = get_dataformat(values_cb_index);
+
+    const InterleavedAddrGenFast<values_is_dram> interleaved_accessor0 = {
+        .bank_base_address = dst_addr0,
+        .page_size = tile_bytes_values,
+        .data_format = data_format_values
+    };
+
+    const uint32_t tile_bytes_ind = get_tile_size(output_ind_cb_index);
+    const DataFormat data_format_ind = get_dataformat(output_ind_cb_index);
+
+    const InterleavedAddrGenFast<output_ind_is_dram> interleaved_accessor1 = {
+        .bank_base_address = dst_addr1,
+        .page_size = tile_bytes_ind,
+        .data_format = data_format_ind
+    };
+
+    // Get Kt rows of values and then Kt rows of indices from compute kernel
+    for (uint32_t j = 0; j < Ht; ++j) {
+        // topk values
+        for (uint32_t i = 0; i < Kt; ++i) {
+            cb_wait_front(values_cb_index, onetile);
+            uint32_t l1_read_addr = get_read_ptr(values_cb_index);
+            noc_async_write_tile(j*Kt + i, interleaved_accessor0, l1_read_addr);
+            noc_async_write_barrier();
+            cb_pop_front(values_cb_index, onetile);
+        }
+
+        // topk indices
+        for (uint32_t i = 0; i < Kt; ++i) {
+            cb_wait_front(output_ind_cb_index, onetile);
+            uint32_t l1_read_addr = get_read_ptr(output_ind_cb_index);
+            noc_async_write_tile(j*Kt + i, interleaved_accessor1, l1_read_addr);
+            noc_async_write_barrier();
+            cb_pop_front(output_ind_cb_index, onetile);
+        }
+    }
+}

--- a/ttnn/cpp/ttnn/operations/reduction/topk/device/topk_op.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/topk/device/topk_op.cpp
@@ -1,0 +1,50 @@
+// SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "topk_op.hpp"
+#include "topk_program_factory.hpp"
+
+namespace ttnn::operations::reduction {
+
+void TopK::validate_with_output_tensors(
+    const std::vector<Tensor> &input_tensors, const std::vector<std::optional<Tensor>> &output_tensors) const {
+    auto input_shape = input_tensors.at(0).get_legacy_shape();
+    TT_FATAL(input_shape.rank() == 4, fmt::format("Input shape must be 4D, got {}", input_shape.rank()));
+    TT_FATAL(this->k == 32, fmt::format("K must be equal to 32, pad with -infinity if necessary to get 32, got {}", this->k));
+    TT_FATAL(this->dim == -1 || this->dim == 3, fmt::format("Only the last dim is supported right now, got {}", this->dim));
+
+    TT_FATAL(input_shape[-1] >= 64, fmt::format("Input shape inner dim {} must be a multiple of 64, pad with -infinity if necessary", input_shape[-1]));
+    TT_FATAL((input_shape[-1] & (input_shape[-1] - 1)) == 0, fmt::format("Input shape inner dim {} must be a power of 2, pad with -infinity if necessary", input_shape[-1]));
+    TT_FATAL((input_shape[0] * input_shape[1] * input_shape[2]) % 32 == 0, fmt::format("Input height (combined input_shape[0-3]) {} must be a multiple of 32", input_shape[0] * input_shape[1] * input_shape[2]));
+
+    TT_FATAL(this->output_mem_config.is_sharded() == false, "Sharded implementation not supported yet");
+    TT_FATAL(input_tensors.at(0).get_layout() == Layout::TILE, "The input must be in tiled format");
+}
+
+std::vector<tt::tt_metal::Shape> TopK::compute_output_shapes(const std::vector<Tensor>& input_tensors) const {
+    const auto& input_tensor = input_tensors.at(0);
+    const auto input_shape = input_tensor.get_legacy_shape();
+    return {{input_shape[0], input_shape[1], input_shape[2], this->k}, {input_shape[0], input_shape[1], input_shape[2], this->k}};
+}
+
+std::vector<Tensor> TopK::create_output_tensors(
+    const std::vector<Tensor> &input_tensors, const std::vector<std::optional<Tensor>> &output_tensors) const {
+    if (output_tensors.size() == 2) {
+        if (output_tensors.at(0).has_value() && output_tensors.at(1).has_value()) {
+            return {output_tensors[0].value(), output_tensors[1].value()};
+        }
+    }
+    const auto& input_tensor = input_tensors.at(0);
+    const auto shapes = compute_output_shapes(input_tensors);
+    auto values_tensor = create_device_tensor(shapes[0], input_tensor.get_dtype(), Layout::TILE, input_tensor.device(), this->output_mem_config);
+    auto index_tensor = create_device_tensor(shapes[1], DataType::UINT16, Layout::TILE, input_tensor.device(), this->output_mem_config);
+    return {values_tensor, index_tensor};
+}
+
+operation::ProgramWithCallbacks TopK::create_program(const std::vector<Tensor>& input_tensors, std::vector<Tensor> &output_tensors) const {
+    const auto& input_tensor = input_tensors.at(0);
+    return detail::topk_single_core_interleaved(input_tensor, this->k, this->dim, output_tensors.at(0), output_tensors.at(1));
+}
+
+}  // namespace ttnn::operations::reduction

--- a/ttnn/cpp/ttnn/operations/reduction/topk/device/topk_op.hpp
+++ b/ttnn/cpp/ttnn/operations/reduction/topk/device/topk_op.hpp
@@ -1,0 +1,32 @@
+// SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <optional>
+
+#include "tensor/tensor.hpp"
+#include "tt_dnn/op_library/run_operation.hpp"
+
+namespace ttnn::operations::reduction {
+
+struct TopK {
+    const uint16_t k;
+    const int8_t dim;
+    const bool largest;
+    const bool sorted;
+    const MemoryConfig output_mem_config;
+
+    void validate_with_output_tensors(const std::vector<Tensor>& input_tensors, const std::vector<std::optional<Tensor>>& output_tensors) const;
+    std::vector<tt::tt_metal::Shape> compute_output_shapes(const std::vector<Tensor>& input_tensors) const;
+    std::vector<Tensor> create_output_tensors(const std::vector<Tensor>& input_tensors, const std::vector<std::optional<Tensor>>& output_tensors) const;
+    operation::ProgramWithCallbacks create_program(
+        const std::vector<Tensor>& input_tensors, std::vector<Tensor>& output_tensors) const;
+    static constexpr auto attribute_names = std::forward_as_tuple("k", "dim", "largest", "sorted", "output_mem_config");
+    const auto attribute_values() const {
+        return std::forward_as_tuple(this->k, this->dim, this->largest, this->sorted, this->output_mem_config);
+    }
+};
+
+} // namespace ttnn::operations::reduction

--- a/ttnn/cpp/ttnn/operations/reduction/topk/device/topk_program_factory.hpp
+++ b/ttnn/cpp/ttnn/operations/reduction/topk/device/topk_program_factory.hpp
@@ -1,0 +1,180 @@
+// SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "tt_metal/host_api.hpp"
+#include "tt_metal/common/constants.hpp"
+#include "tt_metal/detail/util.hpp"
+#include "tt_metal/host_api.hpp"
+#include "tt_log.h"
+
+namespace ttnn::operations::reduction::detail {
+
+operation::ProgramWithCallbacks topk_single_core_interleaved(const Tensor &input_tensor, const uint16_t k, const int8_t dim, Tensor &value_tensor, Tensor &index_tensor) {
+    tt::tt_metal::Program program{};
+    CoreRange core({0, 0}, {0, 0});
+    tt::DataFormat input_cb_data_format = tt::tt_metal::datatype_to_dataformat_converter(input_tensor.get_dtype());
+    tt::DataFormat value_cb_data_format = tt::tt_metal::datatype_to_dataformat_converter(value_tensor.get_dtype());
+    tt::DataFormat index_cb_data_format = tt::tt_metal::datatype_to_dataformat_converter(index_tensor.get_dtype());
+
+    uint32_t input_tile_size = tile_size(input_cb_data_format);
+    uint32_t value_tile_size = tile_size(value_cb_data_format);
+    uint32_t index_tile_size = tile_size(index_cb_data_format);
+
+    auto input_buffer = input_tensor.buffer();
+    auto values_buffer = value_tensor.buffer();
+    auto index_buffer = index_tensor.buffer();
+
+    bool input_is_dram = input_buffer->buffer_type() == tt::tt_metal::BufferType::DRAM;
+    bool values_is_dram = values_buffer->buffer_type() == tt::tt_metal::BufferType::DRAM;
+    bool index_is_dram = index_buffer->buffer_type() == tt::tt_metal::BufferType::DRAM;
+
+    uint32_t num_input_tiles = input_tensor.volume()/TILE_HW;
+    uint32_t num_value_tiles = value_tensor.volume()/TILE_HW;
+
+    auto input_shape = input_tensor.get_legacy_shape();
+    uint32_t Ht = (input_shape[0]*input_shape[1]*input_shape[2])/TILE_HEIGHT;
+    uint32_t Wt = input_shape[3]/TILE_WIDTH;
+    // for streaming in input
+    uint32_t num_cb_unit = 2;
+    uint32_t cb_in_units = 2 * num_cb_unit;
+
+    // Two tiles are loaded in for topk_local_sort at a time, and we double buffer to avoid stalls, so allocate four tiles of space
+    // TODO: In theory if we have enough memory we could allocate 2*Wt tiles to reduce stalls
+    uint32_t input_cb_index = tt::CB::c_in0;
+    tt::tt_metal::CircularBufferConfig input_cb_config = tt::tt_metal::CircularBufferConfig(
+        cb_in_units  * value_tile_size, {{input_cb_index, input_cb_data_format}})
+		.set_page_size(input_cb_index, input_tile_size);
+    auto cb_input_tensor = tt::tt_metal::CreateCircularBuffer(program, core, input_cb_config);
+
+    // Two tiles are loaded in for topk_local_sort at a time, and we double buffer to avoid stalls, so allocate four tiles of space
+    // This CB carries the indices that are created in the reader kernel
+    uint32_t index_cb_index = tt::CB::c_in1;
+    tt::tt_metal::CircularBufferConfig index_input_intermed0_config = tt::tt_metal::CircularBufferConfig(
+        cb_in_units * index_tile_size, {{index_cb_index, index_cb_data_format}})
+		.set_page_size(index_cb_index, index_tile_size);
+    auto cb_index_tensor = tt::tt_metal::CreateCircularBuffer(program, core, index_input_intermed0_config);
+
+    // Single buffered circular buffer that holds the transposed input tiles
+    uint32_t input_transposed_cb_index = tt::CB::c_intermed0;
+    tt::tt_metal::CircularBufferConfig input_transposed_cb_config = tt::tt_metal::CircularBufferConfig(
+         Wt * value_tile_size, {{input_transposed_cb_index, input_cb_data_format}})
+		.set_page_size(input_transposed_cb_index, input_tile_size);
+    auto cb_input_transposed_tiles = tt::tt_metal::CreateCircularBuffer(program, core, input_transposed_cb_config);
+
+    // Single buffered circular buffer that holds the transposed index tiles
+    uint32_t index_transposed_cb_index = tt::CB::c_intermed1;
+    tt::tt_metal::CircularBufferConfig index_transposed_cb_config = tt::tt_metal::CircularBufferConfig(
+         Wt * index_tile_size, {{index_transposed_cb_index, index_cb_data_format}})
+		.set_page_size(index_transposed_cb_index, index_tile_size);
+    auto cb_index_transposed_tiles = tt::tt_metal::CreateCircularBuffer(program, core, index_transposed_cb_config);
+
+    // Output topk values
+    uint32_t values_cb_index = tt::CB::c_out0;
+    tt::tt_metal::CircularBufferConfig values_cb_config = tt::tt_metal::CircularBufferConfig(
+        num_cb_unit * value_tile_size, {{values_cb_index, value_cb_data_format}})
+        .set_page_size(values_cb_index, value_tile_size);
+    auto cb_values_tensor = tt::tt_metal::CreateCircularBuffer(program, core, values_cb_config);
+
+
+    // Output topk indices
+    uint32_t output_ind_cb_index = tt::CB::c_out1;
+    tt::tt_metal::CircularBufferConfig output_ind_cb_config = tt::tt_metal::CircularBufferConfig(
+        num_cb_unit * index_tile_size, {{output_ind_cb_index, index_cb_data_format}})
+        .set_page_size(output_ind_cb_index, index_tile_size);
+    auto cb_output_ind_tensor = tt::tt_metal::CreateCircularBuffer(program, core, output_ind_cb_config);
+
+    std::vector<uint32_t> reader_compile_time_args = {
+                                                        input_cb_index,
+                                                        index_cb_index,
+                                                        (uint32_t)input_is_dram,
+                                                        Ht,
+                                                        Wt};
+    tt::tt_metal::KernelHandle unary_reader_kernel_id = tt::tt_metal::CreateKernel(
+        program,
+        "ttnn/cpp/ttnn/operations/reduction/topk/device/kernels/dataflow/reader_create_index_tensor.cpp",
+        core,
+        tt::tt_metal::ReaderDataMovementConfig(reader_compile_time_args));
+
+
+    SetRuntimeArgs(
+        program,
+        unary_reader_kernel_id,
+        core,
+        {
+            input_buffer->address(),
+        }
+    );
+
+    std::vector<uint32_t> writer_compile_time_args = {
+                                                        values_cb_index,
+                                                        output_ind_cb_index,
+                                                        (std::uint32_t) values_is_dram,
+                                                        (std::uint32_t) index_is_dram,
+                                                        Ht,
+                                                        k};
+    tt::tt_metal::KernelHandle binary_writer_kernel_id = tt::tt_metal::CreateKernel(
+        program,
+        "ttnn/cpp/ttnn/operations/reduction/topk/device/kernels/dataflow/writer_binary_interleaved.cpp",
+        core,
+        tt::tt_metal::WriterDataMovementConfig(writer_compile_time_args));
+
+    SetRuntimeArgs(
+        program,
+        binary_writer_kernel_id,
+        core,
+        {
+            values_buffer->address(),
+            index_buffer->address(),
+
+        }
+    );
+
+    std::vector<uint32_t> compute_args = {
+                                        input_cb_index,
+                                        index_cb_index,
+                                        input_transposed_cb_index,
+                                        index_transposed_cb_index,
+                                        values_cb_index,
+                                        output_ind_cb_index,
+                                        Ht,
+                                        Wt,
+                                        k,
+                                        (std::uint32_t) std::log2(k),
+                                        (std::uint32_t) std::log2(Wt),
+                                        };
+    tt::tt_metal::KernelHandle topk_compute_kernel_id = tt::tt_metal::CreateKernel(
+        program,
+        "ttnn/cpp/ttnn/operations/reduction/topk/device/kernels/compute/topk.cpp",
+        core,
+        tt::tt_metal::ComputeConfig{.compile_args = compute_args}
+    );
+
+
+    auto override_runtime_args_callback = [unary_reader_kernel_id, binary_writer_kernel_id](
+        const Program &program,
+        const std::vector<Buffer*>& input_buffers,
+        const std::vector<Buffer*>& output_buffers
+    ) {
+
+        auto input_buffer = input_buffers.at(0);
+        auto values_buffer = output_buffers.at(0);
+        auto index_buffer = output_buffers.at(1);
+
+        CoreCoord core = {0, 0};
+
+        {
+            auto &reader_runtime_args = GetRuntimeArgs(program, unary_reader_kernel_id, core);
+            reader_runtime_args[0] = input_buffer->address();
+
+            auto &writer_runtime_args = GetRuntimeArgs(program, binary_writer_kernel_id, core);
+            writer_runtime_args[0] = values_buffer->address();
+            writer_runtime_args[1] = index_buffer->address();
+        }
+
+    };
+
+    return {std::move(program), override_runtime_args_callback};
+}
+
+} // namespace ttnn::operations::reduction::detail

--- a/ttnn/cpp/ttnn/operations/reduction/topk/topk.hpp
+++ b/ttnn/cpp/ttnn/operations/reduction/topk/topk.hpp
@@ -1,0 +1,86 @@
+// SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include "ttnn/decorators.hpp"
+#include "ttnn/operations/core.hpp"
+#include "ttnn/validation.hpp"
+
+#include "tt_eager/tt_dnn/op_library/run_operation.hpp"
+
+#include "device/topk_op.hpp"
+#include "ttnn/cpp/ttnn/types.hpp"
+
+constexpr uint8_t DefaultQueueId = 0;
+
+template <class Tuple,
+   class T = std::decay_t<std::tuple_element_t<0, std::decay_t<Tuple>>>>
+std::vector<std::optional<T>> tuple_to_vector_optional(Tuple&& tuple)
+{
+    return std::apply([](auto&&... elems){
+        return std::vector<std::optional<T>>{std::forward<decltype(elems)>(elems)...};
+    }, std::forward<Tuple>(tuple));
+}
+
+
+namespace ttnn {
+namespace operations::reduction {
+
+struct ExecuteTopK {
+    static inline const std::array<TensorSchema, 1> input_tensor_schemas() {
+        return {ttnn::TensorSchema{4, 4, {ttnn::bfloat8_b, ttnn::bfloat16}, {ttnn::TILE_LAYOUT}, true, false, false, false}};
+    }
+
+    template <typename... Args>
+    static auto input_tensors_to_validate(uint8_t queue_id, const Tensor& input_tensor, Args&&... args) {
+        return std::forward_as_tuple(input_tensor);
+    }
+
+    static inline std::vector<Tensor> execute_on_worker_thread(
+        uint8_t queue_id,
+        const Tensor &input_tensor,
+        const uint16_t k,
+        const int8_t dim,
+        const bool largest,
+        const bool sorted,
+        const std::optional<MemoryConfig>& memory_config,
+        std::optional<std::tuple<Tensor, Tensor>> optional_output_tensors = std::nullopt) {
+        return operation::run(TopK{k, dim, largest, sorted, memory_config.value_or(input_tensor.memory_config())},
+        {input_tensor},
+        {},
+        optional_output_tensors.has_value() ? tuple_to_vector_optional(optional_output_tensors.value()) : std::vector<std::optional<Tensor>>{},
+        queue_id);
+    }
+
+    template <typename... Args>
+    static auto input_tensors_to_validate(const Tensor& input_tensor, Args&&... args) {
+        return std::forward_as_tuple(input_tensor);
+    }
+
+    static inline auto execute_on_worker_thread(
+        const Tensor &input_tensor,
+        const uint16_t k,
+        const int8_t dim,
+        const bool largest,
+        const bool sorted,
+        const std::optional<MemoryConfig>& memory_config,
+        std::optional<std::tuple<Tensor, Tensor>> optional_output_tensors) {
+        return execute_on_worker_thread(DefaultQueueId, input_tensor, k, dim, largest, sorted, memory_config, optional_output_tensors);
+    }
+
+
+    static inline std::vector<Tensor> create_async_output_tensors(
+        const std::vector<Tensor> &input_tensors, const std::vector<std::optional<const Tensor>>& optional_inputs) {
+        const auto& input_tensor = input_tensors.at(0);
+        return {Tensor(operation::get_workers_for_op_output({input_tensor})),
+                                            Tensor(operation::get_workers_for_op_output({input_tensor}))};
+    }
+};
+
+}  // namespace operations::reduction
+
+constexpr auto topk = ttnn::register_operation<ttnn::operations::reduction::ExecuteTopK>("ttnn::topk");
+
+}  // namespace ttnn

--- a/ttnn/cpp/ttnn/operations/reduction/topk/topk_pybind.hpp
+++ b/ttnn/cpp/ttnn/operations/reduction/topk/topk_pybind.hpp
@@ -1,0 +1,83 @@
+// SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <pybind11/pybind11.h>
+#include <pybind11/stl.h>
+
+#include "ttnn/cpp/pybind11/decorators.hpp"
+
+#include "topk.hpp"
+#include <optional>
+
+namespace ttnn::operations::reduction::detail {
+namespace py = pybind11;
+
+void bind_reduction_topk_operation(py::module& module) {
+    auto doc =
+        R"doc(topk(input_tensor: ttnn.Tensor, k: int, dim: int, largest: bool, sorted: bool, out : Optional[ttnn.Tensor] = std::nullopt, memory_config: MemoryConfig = std::nullopt, queue_id : [int] = 0) -> Tuple[ttnn.Tensor, ttnn.Tensor]
+
+            Returns the ``k`` largest or ``k`` smallest elements of the given input tensor along a given dimension.
+
+            If ``dim`` is not provided, the last dimension of the input tensor is used.
+
+            If ``largest`` is True, the k largest elements are returned. Otherwise, the k smallest elements are returned.
+
+            The boolean option ``sorted`` if True, will make sure that the returned k elements are sorted.
+
+            Input tensor must have BFLOAT8 or BFLOAT16 data type and TILE_LAYOUT layout.
+
+            Output value tensor will have the same data type as input tensor and output index tensor will have UINT16 data type.
+
+            Equivalent pytorch code:
+
+            .. code-block:: python
+
+                return torch.topk(input_tensor, k, dim=dim, largest=largest, sorted=sorted, *, out=None)
+
+            Args:
+                * :attr:`input_tensor`: Input Tensor for topk.
+                * :attr:`k`: the number of top elements to look for
+                * :attr:`dim`: the dimension to reduce
+                * :attr:`largest`: whether to return the largest or the smallest elements
+                * :attr:`sorted`: whether to return the elements in sorted order
+
+            Keyword Args:
+                * :attr:`memory_config`: Memory Config of the output tensors
+                * :attr:`output_tensor` (Optional[ttnn.Tensor]): preallocated output tensors
+                * :attr:`queue_id` (Optional[uint8]): command queue id
+        )doc";
+
+    using OperationType = decltype(ttnn::topk);
+    bind_registered_operation(
+        module,
+        ttnn::topk,
+        doc,
+        ttnn::pybind_overload_t{
+            [] (const OperationType& self,
+                const ttnn::Tensor& input_tensor,
+                const uint16_t k,
+                const int8_t dim,
+                const bool largest,
+                const bool sorted,
+                std::optional<std::tuple<ttnn::Tensor, ttnn::Tensor>> optional_output_tensors,
+                const std::optional<ttnn::MemoryConfig>& memory_config,
+                uint8_t queue_id) {
+                    return self(queue_id, input_tensor, k, dim, largest, sorted,
+                    memory_config, optional_output_tensors);
+                },
+                py::arg("input_tensor").noconvert(),
+                py::arg("k") = 32,
+                py::arg("dim") = -1,
+                py::arg("largest") = true,
+                py::arg("sorted") = true,
+                py::kw_only(),
+                py::arg("out") = std::nullopt,
+                py::arg("memory_config") = std::nullopt,
+                py::arg("queue_id") = 0});
+}
+
+
+}  // namespace ttnn::operations::reduction::detail

--- a/ttnn/ttnn/__init__.py
+++ b/ttnn/ttnn/__init__.py
@@ -308,6 +308,7 @@ from ttnn.operations.reduction import (
     sum,
     mean,
     argmax,
+    topk,
 )
 
 from ttnn.operations.losses import (


### PR DESCRIPTION
- also support vector<Tensor> outputs for ttnn ops on the C++ side
- add support for a user-defined create_async_output_tensors to enable vector<Tensor> support
- allows for runtime-determined tensor count when the number of tensors can be derived from the input tensors and output tensors

TODO: There are a lot of spaces/structs that require tuple and others that require vector. Allowing both is ideal.
TODO: create_async_output_tensors should also be dependent on the actual input parameters - for some torch ops the output tensors depend on parameters (torch.split)
TODO: if performance is good on ttnn.topk then delete ttl.topk

### Ticket
- #9454 : Add TopK to TTNN

### Problem description
- Currently the implementation is only linked to tt_lib, which is being deprecated

### What's changed
- Add to ttnn
- Use new op format
- Add support for vector of outputs in TTNN OPs

### Checklist
- [x] Post commit CI passes
- [ ] Model regression CI testing passes (if applicable)
- [ ] New/Existing tests provide coverage for changes
