### PR TITLE
#9484: Add output_tensor queue_id to dependency ops

### DIFF
--- a/tests/tt_eager/python_api_testing/unit_testing/backward_ops/test_backward_exp.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/backward_ops/test_backward_exp.py
@@ -31,3 +31,38 @@ def test_bw_exp(input_shapes, device):
 
     comp_pass = compare_pcc(tt_output_tensor_on_device, golden_tensor)
     assert comp_pass
+
+
+@pytest.mark.parametrize(
+    "input_shapes",
+    (
+        (torch.Size([1, 1, 32, 32])),
+        (torch.Size([1, 1, 320, 384])),
+        (torch.Size([1, 3, 320, 384])),
+    ),
+)
+def test_bw_exp_output(input_shapes, device):
+    grad_data, grad_tensor = data_gen_with_range(input_shapes, -100, 100, device)
+    in_data, input_tensor = data_gen_with_range(input_shapes, -199, 200, device, True)
+    input_grad = None
+
+    _, input_grad = data_gen_with_range(input_shapes, -1, 1, device)
+
+    cq_id = 0
+    tt_output_tensor_on_device = tt_lib.tensor.exp_bw(
+        grad_tensor,
+        input_tensor,
+        are_required_outputs=[True],
+        input_grad=input_grad,
+        queue_id=cq_id,
+    )
+    pyt_y = torch.exp(in_data)
+
+    in_data.retain_grad()
+
+    pyt_y.backward(gradient=grad_data)
+
+    golden_tensor = [in_data.grad]
+
+    comp_pass = compare_pcc(tt_output_tensor_on_device, golden_tensor)
+    assert comp_pass

--- a/tests/tt_eager/python_api_testing/unit_testing/backward_ops/test_backward_sqrt.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/backward_ops/test_backward_sqrt.py
@@ -31,3 +31,37 @@ def test_bw_sqrt(input_shapes, device):
     golden_tensor = [in_data.grad]
     status = compare_pcc(tt_output_tensor_on_device, golden_tensor)
     assert status
+
+
+@pytest.mark.parametrize(
+    "input_shapes",
+    (
+        (torch.Size([1, 1, 32, 32])),
+        (torch.Size([1, 1, 320, 384])),
+        (torch.Size([1, 3, 320, 384])),
+    ),
+)
+def test_bw_sqrt_output(input_shapes, device):
+    in_data, input_tensor = data_gen_with_range(input_shapes, -1e4, 1e4, device, True)
+    grad_data, grad_tensor = data_gen_with_range(input_shapes, -1e4, 1e4, device)
+    input_grad = None
+
+    _, input_grad = data_gen_with_range(input_shapes, -1, 1, device)
+
+    cq_id = 0
+    tt_output_tensor_on_device = tt_lib.tensor.sqrt_bw(
+        grad_tensor,
+        input_tensor,
+        are_required_outputs=[True],
+        input_grad=input_grad,
+        queue_id=cq_id,
+    )
+    pyt_y = torch.sqrt(in_data)
+
+    in_data.retain_grad()
+
+    pyt_y.backward(gradient=grad_data)
+
+    golden_tensor = [in_data.grad]
+    status = compare_pcc(tt_output_tensor_on_device, golden_tensor)
+    assert status

--- a/tests/tt_eager/python_api_testing/unit_testing/backward_ops/test_backward_tanh.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/backward_ops/test_backward_tanh.py
@@ -32,3 +32,40 @@ def test_bw_tanh(input_shapes, device):
 
     status = compare_pcc(tt_output_tensor_on_device, golden_tensor, 0.95)
     assert status
+
+
+@pytest.mark.parametrize(
+    "input_shapes",
+    (
+        (torch.Size([1, 1, 32, 32])),
+        (torch.Size([1, 1, 320, 384])),
+        (torch.Size([1, 3, 320, 384])),
+    ),
+)
+def test_bw_tanh_with_output(input_shapes, device):
+    # tt tan supports input range [-1.45, 1.45]
+    in_data, input_tensor = data_gen_with_range(input_shapes, -1.45, 1.45, device, True)
+    grad_data, grad_tensor = data_gen_with_range(input_shapes, -1e4, 1e4, device)
+    input_grad = None
+
+    _, input_grad = data_gen_with_range(input_shapes, -1, 1, device)
+
+    cq_id = 0
+    tt_output_tensor_on_device = tt_lib.tensor.tanh_bw(
+        grad_tensor,
+        input_tensor,
+        are_required_outputs=[True],
+        input_grad=input_grad,
+        queue_id=cq_id,
+    )
+
+    pyt_y = torch.tanh(in_data)
+
+    in_data.retain_grad()
+
+    pyt_y.backward(gradient=grad_data)
+
+    golden_tensor = [in_data.grad]
+
+    status = compare_pcc(tt_output_tensor_on_device, golden_tensor, 0.95)
+    assert status

--- a/tests/tt_eager/python_api_testing/unit_testing/backward_ops/test_backward_unary_pow.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/backward_ops/test_backward_unary_pow.py
@@ -138,3 +138,53 @@ def test_bw_unary_pow_test_neg_inf(input_shapes, device):
 
     status = compare_pcc(tt_output_tensor_on_device, golden_tensor)
     assert status
+
+
+@pytest.mark.parametrize(
+    "input_shapes",
+    (
+        (torch.Size([1, 1, 32, 32])),
+        (torch.Size([1, 1, 320, 384])),
+        (torch.Size([1, 3, 320, 384])),
+    ),
+)
+@pytest.mark.parametrize(
+    "exponent_and_pcc",
+    [
+        (0.0, 0.99),
+        (1.0, 0.99),
+        (2.0, 0.99),
+        (5.0, 0.99),
+        (0.5, 0.92),
+        (1.5, 0.84),
+        (2.5, 0.57),
+    ],
+)
+def test_bw_unary_pow_output(input_shapes, exponent_and_pcc, device):
+    exponent, pcc = exponent_and_pcc
+    in_data, input_tensor = data_gen_with_range(input_shapes, -100, 100, device, True)
+    grad_data, grad_tensor = data_gen_with_range(input_shapes, -10, 10, device)
+    input_grad = None
+
+    _, input_grad = data_gen_with_range(input_shapes, -1, 1, device)
+
+    cq_id = 0
+    tt_output_tensor_on_device = tt_lib.tensor.unary_pow_bw(
+        grad_tensor,
+        input_tensor,
+        exponent=exponent,
+        are_required_outputs=[True],
+        input_grad=input_grad,
+        queue_id=cq_id,
+    )
+
+    in_data.retain_grad()
+
+    pyt_y = torch.pow(in_data, exponent)
+
+    pyt_y.backward(gradient=grad_data)
+
+    golden_tensor = [in_data.grad]
+
+    status = compare_pcc(tt_output_tensor_on_device, golden_tensor, pcc=pcc)
+    assert status

--- a/tests/tt_eager/python_api_testing/unit_testing/misc/test_eltwise_unary_output.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/misc/test_eltwise_unary_output.py
@@ -207,3 +207,170 @@ def test_unary_add_output_scalar(input_shapes, device, scalar):
 
     comp_pass = compare_pcc([output_tensor], [golden_tensor])
     assert comp_pass
+
+
+@pytest.mark.parametrize(
+    "input_shapes",
+    (
+        (torch.Size([1, 1, 32, 32])),
+        (torch.Size([1, 1, 320, 384])),
+        (torch.Size([1, 3, 320, 384])),
+    ),
+)
+def test_unary_gtz_output(input_shapes, device):
+    in_data, input_tensor = data_gen_with_range(input_shapes, -100, 100, device)
+    _, output_tensor = data_gen_with_range(input_shapes, -1, 1, device)
+
+    cq_id = 0
+    tt_lib.tensor.gtz(input_tensor, output_tensor=output_tensor, queue_id=cq_id)
+    golden_tensor = torch.gt(in_data, 0)
+
+    comp_pass = compare_pcc([output_tensor], [golden_tensor])
+    assert comp_pass
+
+
+@pytest.mark.parametrize(
+    "input_shapes",
+    (
+        (torch.Size([1, 1, 32, 32])),
+        (torch.Size([1, 1, 320, 384])),
+        (torch.Size([1, 3, 320, 384])),
+    ),
+)
+def test_unary_lez_output(input_shapes, device):
+    in_data, input_tensor = data_gen_with_range(input_shapes, -100, 100, device)
+    _, output_tensor = data_gen_with_range(input_shapes, -1, 1, device)
+
+    cq_id = 0
+    tt_lib.tensor.lez(input_tensor, output_tensor=output_tensor, queue_id=cq_id)
+    golden_tensor = torch.le(in_data, 0)
+
+    comp_pass = compare_pcc([output_tensor], [golden_tensor])
+    assert comp_pass
+
+
+@pytest.mark.parametrize(
+    "input_shapes",
+    (
+        (torch.Size([1, 1, 32, 32])),
+        (torch.Size([1, 1, 320, 384])),
+        (torch.Size([1, 3, 320, 384])),
+    ),
+)
+def test_unary_eqz_output(input_shapes, device):
+    in_data, input_tensor = data_gen_with_range(input_shapes, -100, 100, device)
+    _, output_tensor = data_gen_with_range(input_shapes, -1, 1, device)
+
+    cq_id = 0
+    tt_lib.tensor.eqz(input_tensor, output_tensor=output_tensor, queue_id=cq_id)
+    golden_tensor = torch.eq(in_data, 0)
+
+    comp_pass = compare_pcc([output_tensor], [golden_tensor])
+    assert comp_pass
+
+
+@pytest.mark.parametrize(
+    "input_shapes",
+    (
+        (torch.Size([1, 1, 32, 32])),
+        (torch.Size([1, 1, 320, 384])),
+        (torch.Size([1, 3, 320, 384])),
+    ),
+)
+def test_unary_log_output(input_shapes, device):
+    in_data, input_tensor = data_gen_with_range(input_shapes, 1e-6, 100, device)
+    _, output_tensor = data_gen_with_range(input_shapes, 1e-6, 1, device)
+
+    cq_id = 0
+    tt_lib.tensor.log(input_tensor, output_tensor=output_tensor, queue_id=cq_id)
+    golden_tensor = torch.log(in_data)
+
+    comp_pass = compare_pcc([output_tensor], [golden_tensor])
+    assert comp_pass
+
+
+@pytest.mark.parametrize(
+    "input_shapes",
+    (
+        (torch.Size([1, 1, 32, 32])),
+        (torch.Size([1, 1, 320, 384])),
+        (torch.Size([1, 3, 320, 384])),
+    ),
+)
+def test_unary_sqrt_output(input_shapes, device):
+    in_data, input_tensor = data_gen_with_range(input_shapes, 0, 100, device)
+    _, output_tensor = data_gen_with_range(input_shapes, 0, 1, device)
+
+    cq_id = 0
+    tt_lib.tensor.sqrt(input_tensor, output_tensor=output_tensor, queue_id=cq_id)
+    golden_tensor = torch.sqrt(in_data)
+
+    comp_pass = compare_pcc([output_tensor], [golden_tensor])
+    assert comp_pass
+
+
+@pytest.mark.parametrize(
+    "input_shapes",
+    (
+        (torch.Size([1, 1, 32, 32])),
+        (torch.Size([1, 1, 320, 384])),
+        (torch.Size([1, 3, 320, 384])),
+    ),
+)
+@pytest.mark.parametrize(
+    "unary_op_fn", [[tt_lib.tensor.neg, torch.neg], [tt_lib.tensor.sign, torch.sign], [tt_lib.tensor.tanh, torch.tanh]]
+)
+def test_unary_ops_output(input_shapes, device, unary_op_fn):
+    in_data, input_tensor = data_gen_with_range(input_shapes, -100, 100, device)
+    _, output_tensor = data_gen_with_range(input_shapes, -1, 1, device)
+
+    cq_id = 0
+    tt_op = unary_op_fn[0]
+    torch_op = unary_op_fn[1]
+    tt_op(input_tensor, output_tensor=output_tensor, queue_id=cq_id)
+    golden_tensor = torch_op(in_data)
+
+    comp_pass = compare_pcc([output_tensor], [golden_tensor])
+    assert comp_pass
+
+
+@pytest.mark.parametrize(
+    "input_shapes",
+    (
+        (torch.Size([1, 1, 32, 32])),
+        (torch.Size([1, 1, 320, 384])),
+        (torch.Size([1, 3, 320, 384])),
+    ),
+)
+@pytest.mark.parametrize("exponent", (3, 0.5))
+def test_unary_pow(input_shapes, device, exponent):
+    in_data, input_tensor = data_gen_with_range(input_shapes, -5, 5, device)
+    _, output_tensor = data_gen_with_range(input_shapes, -1, 1, device)
+
+    cq_id = 0
+    tt_lib.tensor.pow(input_tensor, exponent, output_tensor=output_tensor, queue_id=cq_id)
+    golden_tensor = torch.pow(in_data, exponent)
+
+    comp_pass = compare_pcc([output_tensor], [golden_tensor])
+    assert comp_pass
+
+
+@pytest.mark.parametrize(
+    "input_shapes",
+    (
+        (torch.Size([1, 1, 32, 32])),
+        (torch.Size([1, 1, 320, 384])),
+        (torch.Size([1, 3, 320, 384])),
+    ),
+)
+@pytest.mark.parametrize("fast_and_approx", (True, False))
+def test_unary_exp(input_shapes, device, fast_and_approx):
+    in_data, input_tensor = data_gen_with_range(input_shapes, -10, 10, device)
+    _, output_tensor = data_gen_with_range(input_shapes, -1, 1, device)
+
+    cq_id = 0
+    tt_lib.tensor.exp(input_tensor, fast_and_approx=fast_and_approx, output_tensor=output_tensor, queue_id=cq_id)
+    golden_tensor = torch.exp(in_data)
+
+    comp_pass = compare_pcc([output_tensor], [golden_tensor])
+    assert comp_pass

--- a/tt_eager/tt_dnn/op_library/backward/backward_ops.hpp
+++ b/tt_eager/tt_dnn/op_library/backward/backward_ops.hpp
@@ -35,11 +35,22 @@ std::vector<Tensor> unary_add_bw(
     float alpha,
     const MemoryConfig& output_mem_config = operation::DEFAULT_OUTPUT_MEMORY_CONFIG);
 
-std::vector<Tensor> unary_pow_bw(
+std::vector<std::optional<Tensor>> unary_pow_bw(
+    uint8_t cq_id,
     const Tensor& grad,
     const Tensor& input,
     float exponent,
-    const MemoryConfig& output_mem_config = operation::DEFAULT_OUTPUT_MEMORY_CONFIG);
+    const MemoryConfig& output_mem_config = operation::DEFAULT_OUTPUT_MEMORY_CONFIG,
+    const std::vector<bool>& are_required_outputs = std::vector<bool>{true},
+    std::optional<Tensor> input_grad = std::nullopt);
+
+std::vector<std::optional<Tensor>> unary_pow_bw(
+    const Tensor& grad,
+    const Tensor& input,
+    float exponent,
+    const MemoryConfig& output_mem_config = operation::DEFAULT_OUTPUT_MEMORY_CONFIG,
+    const std::vector<bool>& are_required_outputs = std::vector<bool>{true},
+    std::optional<Tensor> input_grad = std::nullopt);
 
 std::vector<Tensor> addcdiv_bw(
     const Tensor& grad,
@@ -68,15 +79,35 @@ std::vector<std::optional<Tensor>> mul_bw(
     std::optional<Tensor> input_a_grad = std::nullopt,
     std::optional<Tensor> input_b_grad = std::nullopt);
 
-std::vector<Tensor> exp_bw(
+std::vector<std::optional<Tensor>> exp_bw(
+    uint8_t cq_id,
     const Tensor& grad,
     const Tensor& input,
-    const MemoryConfig& output_mem_config = operation::DEFAULT_OUTPUT_MEMORY_CONFIG);
+    const MemoryConfig& output_mem_config = operation::DEFAULT_OUTPUT_MEMORY_CONFIG,
+    const std::vector<bool>& are_required_outputs = std::vector<bool>{true},
+    std::optional<Tensor> input_grad = std::nullopt);
 
-std::vector<Tensor> sqrt_bw(
+std::vector<std::optional<Tensor>> exp_bw(
     const Tensor& grad,
     const Tensor& input,
-    const MemoryConfig& output_mem_config = operation::DEFAULT_OUTPUT_MEMORY_CONFIG);
+    const MemoryConfig& output_mem_config = operation::DEFAULT_OUTPUT_MEMORY_CONFIG,
+    const std::vector<bool>& are_required_outputs = std::vector<bool>{true},
+    std::optional<Tensor> input_grad = std::nullopt);
+
+std::vector<std::optional<Tensor>> sqrt_bw(
+    uint8_t cq_id,
+    const Tensor& grad,
+    const Tensor& input,
+    const MemoryConfig& output_mem_config = operation::DEFAULT_OUTPUT_MEMORY_CONFIG,
+    const std::vector<bool>& are_required_outputs = std::vector<bool>{true},
+    std::optional<Tensor> input_grad = std::nullopt);
+
+std::vector<std::optional<Tensor>> sqrt_bw(
+    const Tensor& grad,
+    const Tensor& input,
+    const MemoryConfig& output_mem_config = operation::DEFAULT_OUTPUT_MEMORY_CONFIG,
+    const std::vector<bool>& are_required_outputs = std::vector<bool>{true},
+    std::optional<Tensor> input_grad = std::nullopt);
 
 std::vector<Tensor> unary_assign_bw(
     const Tensor& grad,
@@ -117,10 +148,20 @@ std::vector<Tensor> min_bw(
     const MemoryConfig& output_mem_config = operation::DEFAULT_OUTPUT_MEMORY_CONFIG);
 
 // bw = grad(1 - tanh(x) ** 2)
-std::vector<Tensor> tanh_bw(
+std::vector<std::optional<Tensor>> tanh_bw(
+    uint8_t cq_id,
     const Tensor& grad,
     const Tensor& input,
-    const MemoryConfig& output_mem_config = operation::DEFAULT_OUTPUT_MEMORY_CONFIG);
+    const MemoryConfig& output_mem_config = operation::DEFAULT_OUTPUT_MEMORY_CONFIG,
+    const std::vector<bool>& are_required_outputs = std::vector<bool>{true},
+    std::optional<Tensor> input_grad = std::nullopt);
+
+std::vector<std::optional<Tensor>> tanh_bw(
+    const Tensor& grad,
+    const Tensor& input,
+    const MemoryConfig& output_mem_config = operation::DEFAULT_OUTPUT_MEMORY_CONFIG,
+    const std::vector<bool>& are_required_outputs = std::vector<bool>{true},
+    std::optional<Tensor> input_grad = std::nullopt);
 
 // grad(sigmoid) = grad*(1 - sigmoid(x))*sigmoid(x)
 std::vector<Tensor> sigmoid_bw(

--- a/tt_eager/tt_dnn/op_library/composite/composite_ops.hpp
+++ b/tt_eager/tt_dnn/op_library/composite/composite_ops.hpp
@@ -576,19 +576,37 @@ Tensor triu(
 
 // power_fp : power with floating point exponent
 Tensor power_fp(
+    uint8_t queue_id,
     const Tensor& input_a,
     float exponent,
-    const MemoryConfig& output_mem_config = operation::DEFAULT_OUTPUT_MEMORY_CONFIG);
+    const MemoryConfig& output_mem_config = operation::DEFAULT_OUTPUT_MEMORY_CONFIG,
+    std::optional<Tensor> output_tensor = std::nullopt);
 
 Tensor pow(
     const Tensor& input_a,
     float exponent,
-    const MemoryConfig& output_mem_config = operation::DEFAULT_OUTPUT_MEMORY_CONFIG);
+    const MemoryConfig& output_mem_config = operation::DEFAULT_OUTPUT_MEMORY_CONFIG,
+    std::optional<Tensor> output_tensor = std::nullopt);
 
 Tensor pow(
     const Tensor& input_a,
     int exponent,
-    const MemoryConfig& output_mem_config = operation::DEFAULT_OUTPUT_MEMORY_CONFIG);
+    const MemoryConfig& output_mem_config = operation::DEFAULT_OUTPUT_MEMORY_CONFIG,
+    std::optional<Tensor> output_tensor = std::nullopt);
+
+Tensor pow(
+    uint8_t queue_id,
+    const Tensor& input_a,
+    float exponent,
+    const MemoryConfig& output_mem_config = operation::DEFAULT_OUTPUT_MEMORY_CONFIG,
+    std::optional<Tensor> output_tensor = std::nullopt);
+
+Tensor pow(
+    uint8_t queue_id,
+    const Tensor& input_a,
+    int exponent,
+    const MemoryConfig& output_mem_config = operation::DEFAULT_OUTPUT_MEMORY_CONFIG,
+    std::optional<Tensor> output_tensor = std::nullopt);
 
 Tensor argmax(
     const Tensor& input_a,

--- a/tt_eager/tt_dnn/op_library/eltwise_unary/eltwise_unary_op.cpp
+++ b/tt_eager/tt_dnn/op_library/eltwise_unary/eltwise_unary_op.cpp
@@ -493,17 +493,33 @@ Tensor tie_binop_to_unary(
     return bcast(queue_id, input_tensor, t_value, OP, BcastOpDim::HW, operation::DEFAULT_OUTPUT_MEMORY_CONFIG, output_tensor);
 }
 
-Tensor lte_unary(const Tensor& input_tensor, float value, const MemoryConfig& output_mem_config) {
-    return lez(sub_unary_sfpu(input_tensor, value, output_mem_config), output_mem_config);
+Tensor lte_unary(uint8_t queue_id, const Tensor& input_tensor, float value, const MemoryConfig& output_mem_config, std::optional<Tensor> output_tensor) {
+    return lez(queue_id, sub_unary_sfpu(input_tensor, value, output_mem_config), output_mem_config, output_tensor);
 }
-Tensor lte_unary(float value, const Tensor& input_tensor, const MemoryConfig& output_mem_config) {
-    return lez(sub_unary_sfpu(value, input_tensor, output_mem_config), output_mem_config);
+Tensor lte_unary(uint8_t queue_id, float value, const Tensor& input_tensor, const MemoryConfig& output_mem_config, std::optional<Tensor> output_tensor) {
+    return lez(queue_id, sub_unary_sfpu(value, input_tensor, output_mem_config), output_mem_config, output_tensor);
 }
-Tensor gte_unary(const Tensor& input_tensor, float value, const MemoryConfig& output_mem_config) {
-    return gez(sub_unary_sfpu(input_tensor, value, output_mem_config), output_mem_config);
+Tensor gte_unary(uint8_t queue_id, const Tensor& input_tensor, float value, const MemoryConfig& output_mem_config, std::optional<Tensor> output_tensor) {
+    return gez(queue_id, sub_unary_sfpu(input_tensor, value, output_mem_config), output_mem_config, output_tensor);
 }
-Tensor gte_unary(float value, const Tensor& input_tensor, const MemoryConfig& output_mem_config) {
-    return gez(sub_unary_sfpu(value, input_tensor, output_mem_config), output_mem_config);
+Tensor gte_unary(uint8_t queue_id, float value, const Tensor& input_tensor, const MemoryConfig& output_mem_config, std::optional<Tensor> output_tensor) {
+    return gez(queue_id, sub_unary_sfpu(value, input_tensor, output_mem_config), output_mem_config, output_tensor);
+}
+Tensor lte_unary(const Tensor& input_tensor, float value, const MemoryConfig& output_mem_config, std::optional<Tensor> output_tensor) {
+    uint8_t default_queue_id = 0;
+    return lez(default_queue_id, sub_unary_sfpu(input_tensor, value, output_mem_config), output_mem_config, output_tensor);
+}
+Tensor lte_unary(float value, const Tensor& input_tensor, const MemoryConfig& output_mem_config, std::optional<Tensor> output_tensor) {
+    uint8_t default_queue_id = 0;
+    return lez(default_queue_id, sub_unary_sfpu(value, input_tensor, output_mem_config), output_mem_config, output_tensor);
+}
+Tensor gte_unary(const Tensor& input_tensor, float value, const MemoryConfig& output_mem_config, std::optional<Tensor> output_tensor) {
+    uint8_t default_queue_id = 0;
+    return gez(default_queue_id, sub_unary_sfpu(input_tensor, value, output_mem_config), output_mem_config, output_tensor);
+}
+Tensor gte_unary(float value, const Tensor& input_tensor, const MemoryConfig& output_mem_config, std::optional<Tensor> output_tensor) {
+    uint8_t default_queue_id = 0;
+    return gez(default_queue_id, sub_unary_sfpu(value, input_tensor, output_mem_config), output_mem_config, output_tensor);
 }
 Tensor eq_unary(const Tensor& input_tensor, float value, const MemoryConfig& output_mem_config) {
     return eqz(sub_unary_sfpu(input_tensor, value, output_mem_config), output_mem_config);

--- a/tt_eager/tt_dnn/op_library/eltwise_unary/eltwise_unary_op.hpp
+++ b/tt_eager/tt_dnn/op_library/eltwise_unary/eltwise_unary_op.hpp
@@ -269,7 +269,8 @@ inline Tensor run_eltwise_unary(
     uint8_t cq_id,
     const Tensor& input_tensor,
     const std::vector<UnaryWithParam>& ops_chain,
-    const MemoryConfig& output_mem_config = operation::DEFAULT_OUTPUT_MEMORY_CONFIG) {
+    const MemoryConfig& output_mem_config = operation::DEFAULT_OUTPUT_MEMORY_CONFIG,
+    std::optional<Tensor> output_tensor = std::nullopt) {
     TT_FATAL(ops_chain.size() > 0, "At least 1 unary op must be specified");
     DataType output_dtype = (ops_chain[0].op_type == UnaryOpType::TYPECAST) ? static_cast<DataType>(ops_chain[0].params[1]) : input_tensor.get_dtype();
     bool preserve_fp32_precision = (ops_chain[0].op_type == UnaryOpType::TYPECAST) and (input_tensor.get_dtype() == DataType::FLOAT32);
@@ -283,7 +284,7 @@ inline Tensor run_eltwise_unary(
             DataType::INT32;  // MT: Currently only uint32/int32 is moved to DST directly, fp32 is converted to fp16b
     return operation::run(
                EltwiseUnary{ops_chain, output_mem_config, fp32_dest_acc_en, preserve_fp32_precision, output_dtype},
-               {input_tensor}, {}, {}, cq_id)
+               {input_tensor}, {}, {output_tensor}, cq_id)
         .at(0);
 }
 
@@ -366,6 +367,188 @@ inline Tensor recip(
         return run_eltwise_unary_with_output_tensor(queue_id, input_tensor, {UnaryWithParam(UnaryOpType::RECIP)}, output_mem_config, output_tensor);
 }
 
+inline Tensor gtz(
+    const Tensor& input_tensor,
+    const MemoryConfig& output_mem_config = operation::DEFAULT_OUTPUT_MEMORY_CONFIG,
+    std::optional<Tensor> output_tensor = std::nullopt) {
+    uint8_t default_queue_id = 0;
+    return run_eltwise_unary_with_output_tensor(
+        default_queue_id, input_tensor, {UnaryWithParam(UnaryOpType::GTZ)}, output_mem_config, output_tensor);
+}
+inline Tensor gtz(
+    uint8_t queue_id,
+    const Tensor& input_tensor,
+    const MemoryConfig& output_mem_config = operation::DEFAULT_OUTPUT_MEMORY_CONFIG,
+    std::optional<Tensor> output_tensor = std::nullopt) {
+        return run_eltwise_unary_with_output_tensor(queue_id, input_tensor, {UnaryWithParam(UnaryOpType::GTZ)}, output_mem_config, output_tensor);
+}
+
+inline Tensor gez(
+    const Tensor& input_tensor,
+    const MemoryConfig& output_mem_config = operation::DEFAULT_OUTPUT_MEMORY_CONFIG,
+    std::optional<Tensor> output_tensor = std::nullopt) {
+    uint8_t default_queue_id = 0;
+    return run_eltwise_unary_with_output_tensor(
+        default_queue_id, input_tensor, {UnaryWithParam(UnaryOpType::GEZ)}, output_mem_config, output_tensor);
+}
+inline Tensor gez(
+    uint8_t queue_id,
+    const Tensor& input_tensor,
+    const MemoryConfig& output_mem_config = operation::DEFAULT_OUTPUT_MEMORY_CONFIG,
+    std::optional<Tensor> output_tensor = std::nullopt) {
+        return run_eltwise_unary_with_output_tensor(queue_id, input_tensor, {UnaryWithParam(UnaryOpType::GEZ)}, output_mem_config, output_tensor);
+}
+
+inline Tensor lez(
+    const Tensor& input_tensor,
+    const MemoryConfig& output_mem_config = operation::DEFAULT_OUTPUT_MEMORY_CONFIG,
+    std::optional<Tensor> output_tensor = std::nullopt) {
+    uint8_t default_queue_id = 0;
+    return run_eltwise_unary_with_output_tensor(
+        default_queue_id, input_tensor, {UnaryWithParam(UnaryOpType::LEZ)}, output_mem_config, output_tensor);
+}
+inline Tensor lez(
+    uint8_t queue_id,
+    const Tensor& input_tensor,
+    const MemoryConfig& output_mem_config = operation::DEFAULT_OUTPUT_MEMORY_CONFIG,
+    std::optional<Tensor> output_tensor = std::nullopt) {
+        return run_eltwise_unary_with_output_tensor(queue_id, input_tensor, {UnaryWithParam(UnaryOpType::LEZ)}, output_mem_config, output_tensor);
+}
+
+inline Tensor ltz(
+    const Tensor& input_tensor,
+    const MemoryConfig& output_mem_config = operation::DEFAULT_OUTPUT_MEMORY_CONFIG,
+    std::optional<Tensor> output_tensor = std::nullopt) {
+    uint8_t default_queue_id = 0;
+    return run_eltwise_unary_with_output_tensor(
+        default_queue_id, input_tensor, {UnaryWithParam(UnaryOpType::LTZ)}, output_mem_config, output_tensor);
+}
+inline Tensor ltz(
+    uint8_t queue_id,
+    const Tensor& input_tensor,
+    const MemoryConfig& output_mem_config = operation::DEFAULT_OUTPUT_MEMORY_CONFIG,
+    std::optional<Tensor> output_tensor = std::nullopt) {
+        return run_eltwise_unary_with_output_tensor(queue_id, input_tensor, {UnaryWithParam(UnaryOpType::LTZ)}, output_mem_config, output_tensor);
+}
+
+inline Tensor eqz(
+    const Tensor& input_tensor,
+    const MemoryConfig& output_mem_config = operation::DEFAULT_OUTPUT_MEMORY_CONFIG,
+    std::optional<Tensor> output_tensor = std::nullopt) {
+    uint8_t default_queue_id = 0;
+    return run_eltwise_unary_with_output_tensor(
+        default_queue_id, input_tensor, {UnaryWithParam(UnaryOpType::EQZ)}, output_mem_config, output_tensor);
+}
+
+inline Tensor eqz(
+    uint8_t queue_id,
+    const Tensor& input_tensor,
+    const MemoryConfig& output_mem_config = operation::DEFAULT_OUTPUT_MEMORY_CONFIG,
+    std::optional<Tensor> output_tensor = std::nullopt) {
+        return run_eltwise_unary_with_output_tensor(queue_id, input_tensor, {UnaryWithParam(UnaryOpType::EQZ)}, output_mem_config, output_tensor);
+}
+inline Tensor sign(
+    const Tensor& input_tensor,
+    const MemoryConfig& output_mem_config = operation::DEFAULT_OUTPUT_MEMORY_CONFIG,
+    std::optional<Tensor> output_tensor = std::nullopt) {
+    uint8_t default_queue_id = 0;
+    return run_eltwise_unary_with_output_tensor(
+        default_queue_id, input_tensor, {UnaryWithParam(UnaryOpType::SIGN)}, output_mem_config, output_tensor);
+}
+
+inline Tensor sign(
+    uint8_t queue_id,
+    const Tensor& input_tensor,
+    const MemoryConfig& output_mem_config = operation::DEFAULT_OUTPUT_MEMORY_CONFIG,
+    std::optional<Tensor> output_tensor = std::nullopt) {
+        return run_eltwise_unary_with_output_tensor(queue_id, input_tensor, {UnaryWithParam(UnaryOpType::SIGN)}, output_mem_config, output_tensor);
+}
+
+inline Tensor neg(
+    const Tensor& input_tensor,
+    const MemoryConfig& output_mem_config = operation::DEFAULT_OUTPUT_MEMORY_CONFIG,
+    std::optional<Tensor> output_tensor = std::nullopt) {
+    uint8_t default_queue_id = 0;
+    return run_eltwise_unary_with_output_tensor(
+        default_queue_id, input_tensor, {UnaryWithParam(UnaryOpType::NEG)}, output_mem_config, output_tensor);
+}
+
+inline Tensor neg(
+    uint8_t queue_id,
+    const Tensor& input_tensor,
+    const MemoryConfig& output_mem_config = operation::DEFAULT_OUTPUT_MEMORY_CONFIG,
+    std::optional<Tensor> output_tensor = std::nullopt) {
+        return run_eltwise_unary_with_output_tensor(queue_id, input_tensor, {UnaryWithParam(UnaryOpType::NEG)}, output_mem_config, output_tensor);
+}
+
+inline Tensor tanh(
+    const Tensor& input_tensor,
+    const MemoryConfig& output_mem_config = operation::DEFAULT_OUTPUT_MEMORY_CONFIG,
+    std::optional<Tensor> output_tensor = std::nullopt) {
+    uint8_t default_queue_id = 0;
+    return run_eltwise_unary_with_output_tensor(
+        default_queue_id, input_tensor, {UnaryWithParam(UnaryOpType::TANH)}, output_mem_config, output_tensor);
+}
+
+inline Tensor tanh(
+    uint8_t queue_id,
+    const Tensor& input_tensor,
+    const MemoryConfig& output_mem_config = operation::DEFAULT_OUTPUT_MEMORY_CONFIG,
+    std::optional<Tensor> output_tensor = std::nullopt) {
+        return run_eltwise_unary_with_output_tensor(queue_id, input_tensor, {UnaryWithParam(UnaryOpType::TANH)}, output_mem_config, output_tensor);
+}
+
+inline Tensor log(
+    const Tensor& input_tensor,
+    const MemoryConfig& output_mem_config = operation::DEFAULT_OUTPUT_MEMORY_CONFIG,
+    std::optional<Tensor> output_tensor = std::nullopt) {
+    uint8_t default_queue_id = 0;
+    return run_eltwise_unary_with_output_tensor(
+        default_queue_id, input_tensor, {UnaryWithParam(UnaryOpType::LOG)}, output_mem_config, output_tensor);
+}
+
+inline Tensor log(
+    uint8_t queue_id,
+    const Tensor& input_tensor,
+    const MemoryConfig& output_mem_config = operation::DEFAULT_OUTPUT_MEMORY_CONFIG,
+    std::optional<Tensor> output_tensor = std::nullopt) {
+        return run_eltwise_unary_with_output_tensor(queue_id, input_tensor, {UnaryWithParam(UnaryOpType::LOG)}, output_mem_config, output_tensor);
+}
+
+inline Tensor abs(
+    const Tensor& input_tensor,
+    const MemoryConfig& output_mem_config = operation::DEFAULT_OUTPUT_MEMORY_CONFIG,
+    std::optional<Tensor> output_tensor = std::nullopt) {
+    uint8_t default_queue_id = 0;
+    return run_eltwise_unary_with_output_tensor(
+        default_queue_id, input_tensor, {UnaryWithParam(UnaryOpType::ABS)}, output_mem_config, output_tensor);
+}
+
+inline Tensor abs(
+    uint8_t queue_id,
+    const Tensor& input_tensor,
+    const MemoryConfig& output_mem_config = operation::DEFAULT_OUTPUT_MEMORY_CONFIG,
+    std::optional<Tensor> output_tensor = std::nullopt) {
+        return run_eltwise_unary_with_output_tensor(queue_id, input_tensor, {UnaryWithParam(UnaryOpType::ABS)}, output_mem_config, output_tensor);
+}
+
+inline Tensor square(
+    const Tensor& input_tensor,
+    const MemoryConfig& output_mem_config = operation::DEFAULT_OUTPUT_MEMORY_CONFIG,
+    std::optional<Tensor> output_tensor = std::nullopt) {
+    uint8_t default_queue_id = 0;
+    return run_eltwise_unary_with_output_tensor(
+        default_queue_id, input_tensor, {UnaryWithParam(UnaryOpType::SQUARE)}, output_mem_config, output_tensor);
+}
+
+inline Tensor square(
+    uint8_t queue_id,
+    const Tensor& input_tensor,
+    const MemoryConfig& output_mem_config = operation::DEFAULT_OUTPUT_MEMORY_CONFIG,
+    std::optional<Tensor> output_tensor = std::nullopt) {
+        return run_eltwise_unary_with_output_tensor(queue_id, input_tensor, {UnaryWithParam(UnaryOpType::SQUARE)}, output_mem_config, output_tensor);
+}
+
 inline Tensor sqrt(
     const Tensor& input_tensor, const MemoryConfig& output_mem_config = operation::DEFAULT_OUTPUT_MEMORY_CONFIG) {
     uint8_t default_queue_id = 0;
@@ -376,16 +559,15 @@ inline Tensor sqrt(
 inline Tensor sqrt(
     uint8_t cq_id,
     const Tensor& input_tensor,
-    const MemoryConfig& output_mem_config = operation::DEFAULT_OUTPUT_MEMORY_CONFIG) {
-    return run_eltwise_unary(cq_id, input_tensor, {UnaryWithParam(UnaryOpType::SQRT)}, output_mem_config);
+    const MemoryConfig& output_mem_config = operation::DEFAULT_OUTPUT_MEMORY_CONFIG,
+    std::optional<Tensor> output_tensor = std::nullopt) {
+    return run_eltwise_unary(cq_id, input_tensor, {UnaryWithParam(UnaryOpType::SQRT)}, output_mem_config, output_tensor);
 }
 
 constexpr auto relu = make_eltwise_unary<UnaryOpType::RELU>{};
 constexpr auto relu6 = make_eltwise_unary<UnaryOpType::RELU6>{};
 constexpr auto sigmoid = make_eltwise_unary<UnaryOpType::SIGMOID>{};
 constexpr auto tiled_prod = make_eltwise_unary<UnaryOpType::TILED_PROD>{};
-constexpr auto log = make_eltwise_unary<UnaryOpType::LOG>{};
-constexpr auto tanh = make_eltwise_unary<UnaryOpType::TANH>{};
 constexpr auto log2 = make_eltwise_unary<UnaryOpType::LOG2>{};
 constexpr auto log10 = make_eltwise_unary<UnaryOpType::LOG10>{};
 constexpr auto exp2 = make_eltwise_unary<UnaryOpType::EXP2>{};
@@ -394,30 +576,21 @@ constexpr auto sin = make_eltwise_unary<UnaryOpType::SIN>{};
 constexpr auto cos = make_eltwise_unary<UnaryOpType::COS>{};
 constexpr auto asin = make_eltwise_unary<UnaryOpType::ASIN>{};
 constexpr auto acos = make_eltwise_unary<UnaryOpType::ACOS>{};
-constexpr auto abs = make_eltwise_unary<UnaryOpType::ABS>{};
 constexpr auto isfinite = make_eltwise_unary<UnaryOpType::ISFINITE>{};
 constexpr auto isinf = make_eltwise_unary<UnaryOpType::ISINF>{};
 constexpr auto isposinf = make_eltwise_unary<UnaryOpType::ISPOSINF>{};
 constexpr auto isneginf = make_eltwise_unary<UnaryOpType::ISNEGINF>{};
 constexpr auto isnan = make_eltwise_unary<UnaryOpType::ISNAN>{};
-constexpr auto sign = make_eltwise_unary<UnaryOpType::SIGN>{};
 constexpr auto signbit = make_eltwise_unary<UnaryOpType::SIGNBIT>{};
 constexpr auto floor = make_eltwise_unary<UnaryOpType::FLOOR>{};
 constexpr auto atan = make_eltwise_unary<UnaryOpType::ATAN>{};
-constexpr auto eqz = make_eltwise_unary<UnaryOpType::EQZ>{};
 constexpr auto nez = make_eltwise_unary<UnaryOpType::NEZ>{};
-constexpr auto gez = make_eltwise_unary<UnaryOpType::GEZ>{};
-constexpr auto lez = make_eltwise_unary<UnaryOpType::LEZ>{};
-constexpr auto gtz = make_eltwise_unary<UnaryOpType::GTZ>{};
-constexpr auto ltz = make_eltwise_unary<UnaryOpType::LTZ>{};
 constexpr auto logical_not_unary = make_eltwise_unary<UnaryOpType::LOGICAL_NOT_UNARY>{};
 constexpr auto i0 = make_eltwise_unary<UnaryOpType::I0>{};
 constexpr auto erfinv = make_eltwise_unary<UnaryOpType::ERFINV>{};
 constexpr auto tan = make_eltwise_unary<UnaryOpType::TAN>{};
-constexpr auto neg = make_eltwise_unary<UnaryOpType::NEG>{};
 constexpr auto relu_max = make_eltwise_unary_with_param<UnaryOpType::RELU_MAX>{};
 constexpr auto relu_min = make_eltwise_unary_with_param<UnaryOpType::RELU_MIN>{};
-constexpr auto power = make_eltwise_unary_with_param<UnaryOpType::POWER, uint32_t>{};
 constexpr auto leaky_relu = make_eltwise_unary_with_param<UnaryOpType::LEAKY_RELU>{};
 constexpr auto prelu = leaky_relu;
 constexpr auto elu = make_eltwise_unary_with_param<UnaryOpType::ELU>{};
@@ -429,7 +602,6 @@ constexpr auto left_shift = make_eltwise_unary_with_param<UnaryOpType::LEFT_SHIF
 constexpr auto unary_remainder = make_eltwise_unary_with_param<UnaryOpType::REMAINDER>{};
 constexpr auto unary_fmod = make_eltwise_unary_with_param<UnaryOpType::FMOD>{};
 constexpr auto unary_ne = make_eltwise_unary_with_param<UnaryOpType::UNARY_NE>{};
-constexpr auto rsub = make_eltwise_unary_with_param<UnaryOpType::RSUB>{};
 constexpr auto silu = make_eltwise_unary<UnaryOpType::SILU>{};
 constexpr auto identity = make_eltwise_unary<UnaryOpType::IDENTITY>{};
 constexpr auto identity_uint32 = make_eltwise_unary<UnaryOpType::IDENTITY_UINT32>{};
@@ -442,15 +614,72 @@ constexpr auto sub_unary_sfpu =
 constexpr auto div_unary_sfpu =
     make_eltwise_asymmetric_binop_unary_with_param<UnaryOpType::DIV_UNARY_SFPU, UnaryOpType::RDIV>{};
 
+inline Tensor power(
+    uint8_t cq_id,
+    const Tensor& input_tensor,
+    uint32_t exponent,
+    const MemoryConfig& output_mem_config = operation::DEFAULT_OUTPUT_MEMORY_CONFIG,
+    std::optional<Tensor> output_tensor = std::nullopt) {
+
+    return run_eltwise_unary_with_output_tensor(cq_id, input_tensor, {UnaryWithParam(UnaryOpType::POWER, static_cast<float>(exponent))}, output_mem_config, output_tensor);
+}
+inline Tensor power(
+    const Tensor& input_tensor,
+    uint32_t exponent,
+    const MemoryConfig& output_mem_config = operation::DEFAULT_OUTPUT_MEMORY_CONFIG,
+    std::optional<Tensor> output_tensor = std::nullopt) {
+        uint8_t default_queue_id = 0;
+        return run_eltwise_unary_with_output_tensor(default_queue_id, input_tensor, {UnaryWithParam(UnaryOpType::POWER, static_cast<float>(exponent))}, output_mem_config, output_tensor);
+}
+
+inline Tensor rsub(
+    uint8_t cq_id,
+    const Tensor& input_tensor,
+    float value,
+    const MemoryConfig& output_mem_config = operation::DEFAULT_OUTPUT_MEMORY_CONFIG,
+    std::optional<Tensor> output_tensor = std::nullopt) {
+
+    return run_eltwise_unary_with_output_tensor(cq_id, input_tensor, {UnaryWithParam(UnaryOpType::RSUB, static_cast<float>(value))}, output_mem_config, output_tensor);
+}
+inline Tensor rsub(
+    const Tensor& input_tensor,
+    float value,
+    const MemoryConfig& output_mem_config = operation::DEFAULT_OUTPUT_MEMORY_CONFIG,
+    std::optional<Tensor> output_tensor = std::nullopt) {
+        uint8_t default_queue_id = 0;
+        return run_eltwise_unary_with_output_tensor(default_queue_id, input_tensor, {UnaryWithParam(UnaryOpType::RSUB, static_cast<float>(value))}, output_mem_config, output_tensor);
+}
+
+inline Tensor exp(
+    uint8_t cq_id,
+    const Tensor& input_tensor,
+    bool fast_and_approx,
+    const MemoryConfig& output_mem_config = operation::DEFAULT_OUTPUT_MEMORY_CONFIG,
+    std::optional<Tensor> output_tensor = std::nullopt) {
+    return run_eltwise_unary_with_output_tensor(cq_id, input_tensor, {UnaryWithParam(UnaryOpType::EXP, static_cast<float>(fast_and_approx))}, output_mem_config, output_tensor);
+}
+inline Tensor exp(
+    uint8_t cq_id,
+    const Tensor& input_tensor,
+    const MemoryConfig& output_mem_config = operation::DEFAULT_OUTPUT_MEMORY_CONFIG,
+    std::optional<Tensor> output_tensor = std::nullopt) {
+    return run_eltwise_unary_with_output_tensor(cq_id, input_tensor, {UnaryWithParam(UnaryOpType::EXP, static_cast<float>(false))}, output_mem_config, output_tensor);
+}
+
 inline Tensor exp(
     const Tensor& input_tensor,
     bool fast_and_approx,
-    const MemoryConfig& output_mem_config = operation::DEFAULT_OUTPUT_MEMORY_CONFIG) {
-    return make_eltwise_unary_with_param<UnaryOpType::EXP>{}(input_tensor, fast_and_approx, output_mem_config);
+    const MemoryConfig& output_mem_config = operation::DEFAULT_OUTPUT_MEMORY_CONFIG,
+    std::optional<Tensor> output_tensor = std::nullopt) {
+    uint8_t default_queue_id = 0;
+    return exp(default_queue_id, input_tensor, fast_and_approx, output_mem_config, output_tensor);
 }
+
 inline Tensor exp(
-    const Tensor& input_tensor, const MemoryConfig& output_mem_config = operation::DEFAULT_OUTPUT_MEMORY_CONFIG) {
-    return exp(input_tensor, false, output_mem_config);
+    const Tensor& input_tensor, const MemoryConfig& output_mem_config = operation::DEFAULT_OUTPUT_MEMORY_CONFIG,
+    std::optional<Tensor> output_tensor = std::nullopt) {
+    uint8_t default_queue_id = 0;
+    return exp(default_queue_id, input_tensor, output_mem_config, output_tensor);
 }
 
 inline Tensor erf(
@@ -611,21 +840,49 @@ Tensor div_unary(
     std::optional<Tensor> output_tensor = std::nullopt);
 // relops with unary argument
 Tensor lte_unary(
+    uint8_t queue_id,
     const Tensor& input_tensor,
     float value,
-    const MemoryConfig& output_mem_config = operation::DEFAULT_OUTPUT_MEMORY_CONFIG);
+    const MemoryConfig& output_mem_config = operation::DEFAULT_OUTPUT_MEMORY_CONFIG,
+    std::optional<Tensor> output_tensor = std::nullopt);
+Tensor lte_unary(
+    uint8_t queue_id,
+    float value,
+    const Tensor& input_tensor,
+    const MemoryConfig& output_mem_config = operation::DEFAULT_OUTPUT_MEMORY_CONFIG,
+    std::optional<Tensor> output_tensor = std::nullopt);
+Tensor lte_unary(
+    const Tensor& input_tensor,
+    float value,
+    const MemoryConfig& output_mem_config = operation::DEFAULT_OUTPUT_MEMORY_CONFIG,
+    std::optional<Tensor> output_tensor = std::nullopt);
 Tensor lte_unary(
     float value,
     const Tensor& input_tensor,
-    const MemoryConfig& output_mem_config = operation::DEFAULT_OUTPUT_MEMORY_CONFIG);
+    const MemoryConfig& output_mem_config = operation::DEFAULT_OUTPUT_MEMORY_CONFIG,
+    std::optional<Tensor> output_tensor = std::nullopt);
+Tensor gte_unary(
+    uint8_t queue_id,
+    const Tensor& input_tensor,
+    float value,
+    const MemoryConfig& output_mem_config = operation::DEFAULT_OUTPUT_MEMORY_CONFIG,
+    std::optional<Tensor> output_tensor = std::nullopt);
+Tensor gte_unary(
+    uint8_t queue_id,
+    float value,
+    const Tensor& input_tensor,
+    const MemoryConfig& output_mem_config = operation::DEFAULT_OUTPUT_MEMORY_CONFIG,
+    std::optional<Tensor> output_tensor = std::nullopt);
 Tensor gte_unary(
     const Tensor& input_tensor,
     float value,
-    const MemoryConfig& output_mem_config = operation::DEFAULT_OUTPUT_MEMORY_CONFIG);
+    const MemoryConfig& output_mem_config = operation::DEFAULT_OUTPUT_MEMORY_CONFIG,
+    std::optional<Tensor> output_tensor = std::nullopt);
 Tensor gte_unary(
     float value,
     const Tensor& input_tensor,
-    const MemoryConfig& output_mem_config = operation::DEFAULT_OUTPUT_MEMORY_CONFIG);
+    const MemoryConfig& output_mem_config = operation::DEFAULT_OUTPUT_MEMORY_CONFIG,
+    std::optional<Tensor> output_tensor = std::nullopt);
 Tensor eq_unary(
     const Tensor& input_tensor,
     float value,

--- a/tt_eager/tt_lib/csrc/tt_lib_bindings_tensor_backward_ops.cpp
+++ b/tt_eager/tt_lib/csrc/tt_lib_bindings_tensor_backward_ops.cpp
@@ -97,22 +97,38 @@ namespace tt::tt_metal::detail{
                     "queue_id", "command queue id", "uint8_t", "Default is 0", "No"
             )doc");
 
-    m_tensor.def("exp_bw", &tt::tt_metal::exp_bw,
-            py::arg("grad").noconvert(), py::arg("input").noconvert(), py::arg("output_mem_config").noconvert() = operation::DEFAULT_OUTPUT_MEMORY_CONFIG, R"doc(
-                Performs backward operations for exponential with given ``grad``
+        m_tensor.def("exp_bw",
+            [](const Tensor& grad,
+                const Tensor& input,
+                const MemoryConfig& output_mem_config,
+                const std::vector<bool>& are_required_outputs,
+                std::optional<Tensor> input_grad,
+                uint8_t queue_id) {
+                    return exp_bw(queue_id, grad, input, output_mem_config, are_required_outputs, input_grad);
+                },
+            py::arg("grad").noconvert(),
+            py::arg("input").noconvert(),
+            py::arg("output_mem_config").noconvert() = operation::DEFAULT_OUTPUT_MEMORY_CONFIG,
+            py::arg("are_required_outputs").noconvert() = std::vector<bool>{true},
+            py::arg("input_grad").noconvert() = std::nullopt,
+            py::arg("queue_id").noconvert() = 0,
+            R"doc(
+            Performs backward operations for exp with given ``grad``.
 
-                Input tensors must have BFLOAT16 data type.
+            Input tensor must have BFLOAT16 data type.
 
-                Output tensor will have BFLOAT16 data type.
+            Output tensors will have BFLOAT16 data type.
 
-                .. csv-table::
-                    :header: "Argument", "Description", "Data type", "Valid range", "Required"
+            .. csv-table::
+                :header: "Argument", "Description", "Data type", "Valid range", "Required"
 
-
-                    "grad", "Gradient tensor", "Tensor", "Tensor of shape [W, Z, Y, X]", "Yes"
-                    "input", "Tensor", "Tensor", "Tensor of shape [W, Z, Y, X]", "Yes"
-                    "output_mem_config", "Layout of tensor in TT Accelerator device memory banks", "MemoryConfig", "Default is interleaved in DRAM", "No"
-            )doc");
+                "grad", "Gradient tensor", "Tensor", "Tensor of shape [W, Z, Y, X]", "Yes"
+                "input", "Input Tensor ", "Tensor", "Tensor of shape [W, Z, Y, X]", "Yes"
+                "output_mem_config", "Layout of tensor in TT Accelerator device memory banks", "MemoryConfig", "Default is interleaved in DRAM", "No"
+                "are_required_outputs", "input_grad is always required output", "List of bool", "Default value is [True]", "No"
+                "input_grad", "Optional Output Tensor for input_grad", "Tensor", "Default value is None", "No"
+                "queue_id", "queue_id", "uint8_t", "Default is 0", "No"
+        )doc");
 
 
     m_tensor.def("exp2_bw", &tt::tt_metal::exp2_bw,
@@ -201,23 +217,41 @@ namespace tt::tt_metal::detail{
                     "output_mem_config", "Layout of tensor in TT Accelerator device memory banks", "MemoryConfig", "Default is interleaved in DRAM", "No"
             )doc");
 
-    m_tensor.def("tanh_bw", &tt::tt_metal::tanh_bw,
-            py::arg("grad").noconvert(), py::arg("input").noconvert(), py::arg("output_mem_config").noconvert() = operation::DEFAULT_OUTPUT_MEMORY_CONFIG, R"doc(
+    m_tensor.def("tanh_bw",
+            [](const Tensor& grad,
+                const Tensor& input,
+                const MemoryConfig& output_mem_config,
+                const std::vector<bool>& are_required_outputs,
+                std::optional<Tensor> input_grad,
+                uint8_t queue_id) {
+                    return tanh_bw(queue_id, grad, input, output_mem_config, are_required_outputs, input_grad);
+                },
+            py::arg("grad").noconvert(),
+            py::arg("input").noconvert(),
+            py::arg("output_mem_config").noconvert() = operation::DEFAULT_OUTPUT_MEMORY_CONFIG,
+            py::arg("are_required_outputs").noconvert() = std::vector<bool>{true},
+            py::arg("input_grad").noconvert() = std::nullopt,
+            py::arg("queue_id").noconvert() = 0,
+            R"doc(
             Performs backward operations for tanh with given ``grad``.
 
-            Input tensors must have BFLOAT16 data type.
+            Input tensor must have BFLOAT16 data type.
 
-            Output tensor will have BFLOAT16 data type.
+            Output tensors will have BFLOAT16 data type.
 
             .. csv-table::
                 :header: "Argument", "Description", "Data type", "Valid range", "Required"
 
                 "grad", "Gradient tensor", "Tensor", "Tensor of shape [W, Z, Y, X]", "Yes"
-                "input", "Tensor", "Tensor", "Tensor of shape [W, Z, Y, X]", "Yes"
+                "input", "Input Tensor ", "Tensor", "Tensor of shape [W, Z, Y, X]", "Yes"
                 "output_mem_config", "Layout of tensor in TT Accelerator device memory banks", "MemoryConfig", "Default is interleaved in DRAM", "No"
+                "are_required_outputs", "input_grad is always required output", "List of bool", "Default value is [True]", "No"
+                "input_grad", "Optional Output Tensor for input_grad", "Tensor", "Default value is None", "No"
+                "queue_id", "queue_id", "uint8_t", "Default is 0", "No"
         )doc");
 
-        m_tensor.def("sigmoid_bw", &tt::tt_metal::tanh_bw,
+
+        m_tensor.def("sigmoid_bw", &tt::tt_metal::sigmoid_bw,
             py::arg("grad").noconvert(), py::arg("input").noconvert(), py::arg("output_mem_config").noconvert() = operation::DEFAULT_OUTPUT_MEMORY_CONFIG, R"doc(
             Performs backward operations for sigmoid with given ``grad``.
 
@@ -285,38 +319,76 @@ namespace tt::tt_metal::detail{
                     "output_mem_config", "Layout of tensor in TT Accelerator device memory banks", "MemoryConfig", "Default is interleaved in DRAM", "No"
             )doc");
 
-    m_tensor.def("unary_pow_bw", &tt::tt_metal::unary_pow_bw,
-        py::arg("grad").noconvert(), py::arg("input").noconvert(), py::arg("exponent") = 1.0f, py::arg("output_mem_config").noconvert() = operation::DEFAULT_OUTPUT_MEMORY_CONFIG, R"doc(
-            Performs backward operations for power with given ``grad`` and ``exponent`` where exponent value is greater than 1.
+    m_tensor.def("unary_pow_bw",
+            [](const Tensor& grad,
+                const Tensor& input,
+                float exponent,
+                const MemoryConfig& output_mem_config,
+                const std::vector<bool>& are_required_outputs,
+                std::optional<Tensor> input_grad,
+                uint8_t queue_id) {
+                    return unary_pow_bw(queue_id, grad, input, exponent, output_mem_config, are_required_outputs, input_grad);
+                },
+            py::arg("grad").noconvert(),
+            py::arg("input").noconvert(),
+            py::arg("exponent") = 1.0f,
+            py::arg("output_mem_config").noconvert() = operation::DEFAULT_OUTPUT_MEMORY_CONFIG,
+            py::arg("are_required_outputs").noconvert() = std::vector<bool>{true},
+            py::arg("input_grad").noconvert() = std::nullopt,
+            py::arg("queue_id").noconvert() = 0,
+            R"doc(
+            Performs backward operations for pow with given ``grad``.
 
-            Input tensors must have BFLOAT16 data type.
+            Input tensor must have BFLOAT16 data type.
 
-            Output tensor will have BFLOAT16 data type.
+            Output tensors will have BFLOAT16 data type.
 
             .. csv-table::
                 :header: "Argument", "Description", "Data type", "Valid range", "Required"
 
                 "grad", "Gradient tensor", "Tensor", "Tensor of shape [W, Z, Y, X]", "Yes"
-                "input", "Tensor", "Tensor", "Tensor of shape [W, Z, Y, X]", "Yes"
-                "exponent", "Exponent value", "integer", "default to 1", "Yes"
+                "input", "Input Tensor ", "Tensor", "Tensor of shape [W, Z, Y, X]", "Yes"
+                "exponent", "Exponent value", "float", "default to 1.0", "Yes"
                 "output_mem_config", "Layout of tensor in TT Accelerator device memory banks", "MemoryConfig", "Default is interleaved in DRAM", "No"
-            )doc");
+                "are_required_outputs", "input_grad is always required output", "List of bool", "Default value is [True]", "No"
+                "input_grad", "Optional Output Tensor for input_grad", "Tensor", "Default value is None", "No"
+                "queue_id", "queue_id", "uint8_t", "Default is 0", "No"
+        )doc");
 
-    m_tensor.def("sqrt_bw", &tt::tt_metal::sqrt_bw,
-            py::arg("grad").noconvert(), py::arg("input").noconvert(), py::arg("output_mem_config").noconvert() = operation::DEFAULT_OUTPUT_MEMORY_CONFIG, R"doc(
-                Performs backward operations for sqrt with given ``grad``.
 
-                Input tensors must have BFLOAT16 data type.
+    m_tensor.def("sqrt_bw",
+            [](const Tensor& grad,
+                const Tensor& input,
+                const MemoryConfig& output_mem_config,
+                const std::vector<bool>& are_required_outputs,
+                std::optional<Tensor> input_grad,
+                uint8_t queue_id) {
+                    return sqrt_bw(queue_id, grad, input, output_mem_config, are_required_outputs, input_grad);
+                },
+            py::arg("grad").noconvert(),
+            py::arg("input").noconvert(),
+            py::arg("output_mem_config").noconvert() = operation::DEFAULT_OUTPUT_MEMORY_CONFIG,
+            py::arg("are_required_outputs").noconvert() = std::vector<bool>{true},
+            py::arg("input_grad").noconvert() = std::nullopt,
+            py::arg("queue_id").noconvert() = 0,
+            R"doc(
+            Performs backward operations for sqrt with given ``grad``.
 
-                Output tensor will have BFLOAT16 data type.
+            Input tensor must have BFLOAT16 data type.
 
-                .. csv-table::
-                    :header: "Argument", "Description", "Data type", "Valid range", "Required"
+            Output tensors will have BFLOAT16 data type.
 
-                    "grad", "Gradient tensor", "Tensor", "Tensor of shape [W, Z, Y, X]", "Yes"
-                    "input", "Tensor", "Tensor", "Tensor of shape [W, Z, Y, X]", "Yes"
-                    "output_mem_config", "Layout of tensor in TT Accelerator device memory banks", "MemoryConfig", "Default is interleaved in DRAM", "No"
-            )doc");
+            .. csv-table::
+                :header: "Argument", "Description", "Data type", "Valid range", "Required"
+
+                "grad", "Gradient tensor", "Tensor", "Tensor of shape [W, Z, Y, X]", "Yes"
+                "input", "Input Tensor ", "Tensor", "Tensor of shape [W, Z, Y, X]", "Yes"
+                "output_mem_config", "Layout of tensor in TT Accelerator device memory banks", "MemoryConfig", "Default is interleaved in DRAM", "No"
+                "are_required_outputs", "input_grad is always required output", "List of bool", "Default value is [True]", "No"
+                "input_grad", "Optional Output Tensor for input_grad", "Tensor", "Default value is None", "No"
+                "queue_id", "queue_id", "uint8_t", "Default is 0", "No"
+        )doc");
+
 
     m_tensor.def("unary_div_bw", &tt::tt_metal::unary_div_bw,
             py::arg("grad").noconvert(), py::arg("input").noconvert(), py::arg("scalar") = 1.0f, py::arg("round_mode") = "None", py::arg("output_mem_config").noconvert() = operation::DEFAULT_OUTPUT_MEMORY_CONFIG, R"doc(

--- a/tt_eager/tt_lib/csrc/tt_lib_bindings_tensor_composite_ops.cpp
+++ b/tt_eager/tt_lib/csrc/tt_lib_bindings_tensor_composite_ops.cpp
@@ -13,40 +13,65 @@ namespace tt::tt_metal::detail {
 void TensorModuleCompositeOPs(py::module& m_tensor) {
     m_tensor.def(
         "pow",
-        py::overload_cast<const Tensor&, float, const MemoryConfig&>(&tt::tt_metal::pow),
+        [](const Tensor& input,
+           const float exponent,
+           const MemoryConfig& output_mem_config,
+           std::optional<Tensor> output_tensor,
+           uint8_t queue_id) {
+            return pow(queue_id, input, exponent, output_mem_config, output_tensor);
+        },
         py::arg("input"),
         py::arg("exponent"),
         py::arg("output_mem_config").noconvert() = operation::DEFAULT_OUTPUT_MEMORY_CONFIG,
+        py::arg("output_tensor").noconvert() = std::nullopt,
+        py::arg("queue_id").noconvert() = 0,
         R"doc(
-                    Returns a new tensor filled with power of input ``input`` raised to value of ``exponent``.
+            Returns a tensor filled with power of input ``input`` raised to value of ``exponent``.
 
-                    Output tensor will have BFLOAT16 data type.
+            Input tensor must have BFLOAT16 data type.
 
-                    .. csv-table::
-                        :header: "Argument", "Description", "Data type", "Valid range", "Required"
+            Output tensor will have BFLOAT16 data type.
 
-                        "input", "Input tensor for which power is computed", "Tensor", "Tensor of any shape", "Yes"
-                        "exponent", "exponent value", "float", "positive floating point value", "Yes"
-                        "output_mem_config", "Layout of tensor in TT Accelerator device memory banks", "MemoryConfig", "Default is interleaved in DRAM", "No"
-                )doc");
+            .. csv-table::
+                :header: "Argument", "Description", "Data type", "Valid range", "Required"
+
+                "input", "Input tensor for which power is computed", "Tensor", "Tensor of any shape", "Yes"
+                "exponent", "exponent value", "float", "positive floating point value", "Yes"
+                "output_mem_config", "Layout of tensor in TT Accelerator device memory banks", "MemoryConfig", "Default is interleaved in DRAM", "No"
+                "output_tensor", "optional output tensor", "Tensor", "default is None", "No"
+                "queue_id", "Command queue id", "integer", "default to 0", "No"
+        )doc");
     m_tensor.def(
         "pow",
-        py::overload_cast<const Tensor&, int, const MemoryConfig&>(&tt::tt_metal::pow),
+        [](const Tensor& input,
+           const int exponent,
+           const MemoryConfig& output_mem_config,
+           std::optional<Tensor> output_tensor,
+           uint8_t queue_id) {
+            return pow(queue_id, input, exponent, output_mem_config, output_tensor);
+        },
         py::arg("input"),
         py::arg("exponent"),
         py::arg("output_mem_config").noconvert() = operation::DEFAULT_OUTPUT_MEMORY_CONFIG,
+        py::arg("output_tensor").noconvert() = std::nullopt,
+        py::arg("queue_id").noconvert() = 0,
         R"doc(
-                    Returns a new tensor filled with power of input ``input`` raised to value of ``exponent``.
+            Returns a tensor filled with power of input ``input`` raised to value of ``exponent``.
 
-                    Output tensor will have BFLOAT16 data type.
+            Input tensor must have BFLOAT16 data type.
 
-                    .. csv-table::
-                        :header: "Argument", "Description", "Data type", "Valid range", "Required"
+            Output tensor will have BFLOAT16 data type.
 
-                        "input", "Input tensor for which power is computed", "Tensor", "Tensor of any shape", "Yes"
-                        "exponent", "exponent value", "integer", "positive integer value", "Yes"
-                        "output_mem_config", "Layout of tensor in TT Accelerator device memory banks", "MemoryConfig", "Default is interleaved in DRAM", "No"
-                )doc");
+            .. csv-table::
+                :header: "Argument", "Description", "Data type", "Valid range", "Required"
+
+                "input", "Input tensor for which power is computed", "Tensor", "Tensor of any shape", "Yes"
+                "exponent", "exponent value", "integer", "positive integer value", "Yes"
+                "output_mem_config", "Layout of tensor in TT Accelerator device memory banks", "MemoryConfig", "Default is interleaved in DRAM", "No"
+                "output_tensor", "optional output tensor", "Tensor", "default is None", "No"
+                "queue_id", "Command queue id", "integer", "default to 0", "No"
+        )doc");
+
     m_tensor.def(
         "sfpu_eps",
         &tt::tt_metal::sfpu_eps,

--- a/tt_eager/tt_lib/csrc/tt_lib_bindings_tensor_xary_ops.cpp
+++ b/tt_eager/tt_lib/csrc/tt_lib_bindings_tensor_xary_ops.cpp
@@ -23,34 +23,20 @@ namespace tt::tt_metal::detail {
         )doc");
         detail::bind_unary_op(m_tensor, "relu", relu, R"doc(Applies the rectified linear unit (ReLU) function to the elements of the input tensor ``{0}``.)doc");
         detail::bind_unary_op(m_tensor, "relu6", relu6, R"doc(Returns tensor with the relu6 activation on elements of the input tensor ``{0}``.)doc");
-        detail::bind_unary_op(
-            m_tensor,
-            "sqrt",
-            py::overload_cast<const Tensor &, const MemoryConfig &>(sqrt),
-            R"doc(Returns tensor with the square-root of elements of the input tensor ``{0}``.)doc");
         detail::bind_unary_op(m_tensor, "sigmoid", sigmoid, R"doc(Applies the sigmoid function to the elements of the input tensor ``{0}``.)doc");
         detail::bind_unary_op(m_tensor, "sigmoid_accurate", sigmoid_accurate, R"doc(Applies the sigmoid_accurate function to the elements of the input tensor ``{0}``.)doc");
-        detail::bind_unary_op(m_tensor, "log", log, R"doc(Returns tensor with the natural logarithm of elements of the input tensor ``{0}``.)doc");
-        detail::bind_unary_op(m_tensor, "tanh", tanh, R"doc(Returns tensor with the hyperbolic tangent of elements of the input tensor ``{0}``.)doc");
         detail::bind_unary_op(m_tensor, "log2", log2, R"doc(Returns tensor with the base 2 logarithm of elements of the input tensor ``{0}``.)doc");
         detail::bind_unary_op(m_tensor, "log10", log10, R"doc(Returns tensor with the base 10 logarithm of elements of the input tensor ``{0}``.)doc");
         detail::bind_unary_op(m_tensor, "sin", tt::tt_metal::sin, R"doc(Returns tensor with the sine of elements of the input tensor ``{0}``.)doc");
         detail::bind_unary_op(m_tensor, "cos", tt::tt_metal::cos, R"doc(Returns tensor with the cosine of elements of the input tensor ``{0}``.)doc");
         detail::bind_unary_op(m_tensor, "tan", tan, R"doc(Returns a new tensor with the tangent of the elements of the input tensor ``{0}`` for the range [-1.45, 1.45].)doc");
-        detail::bind_unary_op(m_tensor, "abs", abs, R"doc(Returns tensor with elementwise absolute value of the input tensor ``{0}``.)doc");
         detail::bind_unary_op(m_tensor, "isfinite", isfinite, R"doc(Returns boolean tensor that is True where input tensor ``{0}``, is finite and False elsewhere.)doc");
         detail::bind_unary_op(m_tensor, "isinf", isinf, R"doc(Returns boolean tensor that is True where input tensor ``{0}``, is infinite and False elsewhere.)doc");
         detail::bind_unary_op(m_tensor, "isposinf", isposinf, R"doc(Returns each element of input tensor ``{0}``, is positive infinity or not.)doc");
         detail::bind_unary_op(m_tensor, "tiled_prod", tiled_prod, R"doc(Performs tile-wise multiplication on input tensor ``{0}`` and store the result in the last tile of the input tensor.)doc");
         detail::bind_unary_op(m_tensor, "isneginf", isneginf, R"doc(Returns each element of input tensor ``{0}``, is negative infinity or not.)doc");
         detail::bind_unary_op(m_tensor, "isnan", isnan, R"doc(Returns boolean tensor that is True where tensor ``{0}``, is NaN and False elsewhere.)doc");
-        detail::bind_unary_op(m_tensor, "sign", sign, R"doc(Returns tensor with the elementwise signum of the input tensor ``{0}``.)doc");
-        detail::bind_unary_op(m_tensor, "eqz", eqz, R"doc(Returns tensor with the result of equal to zero of all of the elements of the input tensor ``{0}``.)doc");
         detail::bind_unary_op(m_tensor, "nez", nez, R"doc(Returns tensor with the not equal zero of all of the elements of the input tensor ``{0}``.)doc");
-        detail::bind_unary_op(m_tensor, "gtz", gtz, R"doc(Returns tensor with the greater than zero of all of the elements of the input tensor ``{0}``.)doc");
-        detail::bind_unary_op(m_tensor, "ltz", ltz, R"doc(Returns tensor with the less than zero of all of the elements of the input tensor ``{0}``.)doc");
-        detail::bind_unary_op(m_tensor, "gez", gez, R"doc(Returns tensor with the greater than equal zero of all of the elements of the input tensor ``{0}``.)doc");
-        detail::bind_unary_op(m_tensor, "lez", lez, R"doc(Returns tensor with the less than equal zero of all of the elements of the input tensor ``{0}``.)doc");
         detail::bind_unary_op(m_tensor, "exp2", exp2, R"doc(Returns a new tensor with the exp2 (2 power) of the elements of the input tensor ``{0}``.)doc");
         detail::bind_unary_op(m_tensor, "expm1", expm1,
             R"doc(Returns a new tensor with the expm1 of the elements of the input tensor ``{0}``.
@@ -66,7 +52,6 @@ namespace tt::tt_metal::detail {
         detail::bind_unary_op(m_tensor, "erfinv", erfinv, R"doc(Computes inverse error function for all elements of the input tensor ``{0}`` in the range (-1,1) .)doc");
         detail::bind_unary_op(m_tensor, "i0", i0, R"doc(Computes the zeroth order modified Bessel function of the first kind applied on the elements of the input tensor ``{0}``, for the input range -10 to 10.)doc");
         detail::bind_unary_op(m_tensor, "silu", silu, R"doc(Returns tensor with the silu all of elements of the input tensor ``{0}``.)doc");
-        detail::bind_unary_op(m_tensor, "neg", neg, R"doc(Returns tensor with the negate all of elements of the input tensor ``{0}``.)doc");
 
         m_tensor.def("eltwise_typecast", &eltwise_typecast,
             py::arg("input").noconvert(), py::arg("tt_input_dtype"), py::arg("tt_output_dtype"), py::arg("output_mem_config").noconvert() = operation::DEFAULT_OUTPUT_MEMORY_CONFIG, R"doc(
@@ -103,12 +88,6 @@ namespace tt::tt_metal::detail {
                 "output_mem_config", "Layout of tensor in TT Accelerator device memory banks", "MemoryConfig", "Default is interleaved in DRAM", "No"
         )doc");
 
-        detail::bind_unary_op_with_param(
-            m_tensor, "exp", py::overload_cast<const Tensor&, bool, const MemoryConfig&>(&exp),
-            py::arg("fast_and_approx") = false,
-            R"doc(Returns a new tensor with the exponential of the elements of the input tensor ``{0}``.)doc",
-            R"doc("Indicate true for approx and fast mode; false for accurate and slow mode", "bool", "default of false")doc"
-        );
 
         detail::bind_unary_op_with_param(
             m_tensor, "gelu", &gelu,
@@ -195,13 +174,13 @@ namespace tt::tt_metal::detail {
             .. csv-table::
                 :header: "Argument", "Description", "Data type", "Valid range", "Required"
 
-                "input", "Tensor recip is applied to", "Tensor", "Tensor of shape [W, Z, Y, X]", "Yes"
+                "input", "Tensor reciprocal is applied to", "Tensor", "Tensor of shape [W, Z, Y, X]", "Yes"
                 "output_mem_config", "Layout of tensor in TT Accelerator device memory banks", "MemoryConfig", "Default is interleaved in DRAM", "No"
                 "output_tensor", "Optional Output Tensor", "Tensor", "Default value is None", "No"
                 "queue_id", "command queue id", "uint8_t", "Default is 0", "No"
 
         )doc");
-
+    
         m_tensor.def("bitwise_xor",bitwise_xor,
             py::arg("input").noconvert(),py::arg("value"),py::arg("output_mem_config").noconvert() = operation::DEFAULT_OUTPUT_MEMORY_CONFIG,R"doc(
             Computes bitwise_xor of input tensor ``input`` by a scalar ``value``. Input tensor needs to be positive. Support provided only for Wormhole_B0.
@@ -232,6 +211,800 @@ namespace tt::tt_metal::detail {
 
                 "input", "Input Tensor", "Tensor", "Tensor of shape [W, Z, Y, X]", "Yes"
                 "output_mem_config", "Layout of tensor in TT Accelerator device memory banks", "MemoryConfig", "Default is interleaved in DRAM", "No"
+
+        )doc");
+
+        m_tensor.def("sqrt",
+        [](const Tensor& input,
+            const MemoryConfig& output_mem_config,
+            std::optional<Tensor> output_tensor,
+            uint8_t queue_id){
+                return sqrt(queue_id, input, output_mem_config, output_tensor);
+            },
+            py::arg("input"),
+            py::arg("output_mem_config").noconvert() = operation::DEFAULT_OUTPUT_MEMORY_CONFIG,
+            py::arg("output_tensor").noconvert() = std::nullopt,
+            py::arg("queue_id").noconvert() = 0,
+            R"doc(
+            Returns a new tensor with the reciprocal of the elements of the input tensor ``recip``.
+
+            Input tensor must have BFLOAT16 data type.
+
+            Output tensor will have BFLOAT16 data type.
+
+            .. csv-table::
+                :header: "Argument", "Description", "Data type", "Valid range", "Required"
+
+                "input", "Tensor sqrt is applied to", "Tensor", "Tensor of shape [W, Z, Y, X]", "Yes"
+                "output_mem_config", "Layout of tensor in TT Accelerator device memory banks", "MemoryConfig", "Default is interleaved in DRAM", "No"
+                "output_tensor", "Optional Output Tensor", "Tensor", "Default value is None", "No"
+                "queue_id", "command queue id", "uint8_t", "Default is 0", "No"
+
+        )doc");
+
+        m_tensor.def("exp",
+        [](const Tensor& input,
+            bool fast_and_approx,
+            const MemoryConfig& output_mem_config,
+            std::optional<Tensor> output_tensor,
+            uint8_t queue_id){
+                return exp(queue_id, input, fast_and_approx, output_mem_config, output_tensor);
+            },
+            py::arg("input"),
+            py::arg("fast_and_approx") = false,
+            py::arg("output_mem_config").noconvert() = operation::DEFAULT_OUTPUT_MEMORY_CONFIG,
+            py::arg("output_tensor").noconvert() = std::nullopt,
+            py::arg("queue_id").noconvert() = 0,
+            R"doc(
+            Returns a new tensor with the exponential of the elements of the input tensor ``exp``.
+
+            Input tensor must have BFLOAT16 data type.
+
+            Output tensor will have BFLOAT16 data type.
+
+            .. csv-table::
+                :header: "Argument", "Description", "Data type", "Valid range", "Required"
+
+                "input", "Tensor exp is applied to", "Tensor", "Tensor of shape [W, Z, Y, X]", "Yes"
+                "fast_and_approx", "Indicate true for approx and fast mode; false for accurate and slow mode",  "bool", "default of false", "No"
+                "output_mem_config", "Layout of tensor in TT Accelerator device memory banks", "MemoryConfig", "Default is interleaved in DRAM", "No"
+                "output_tensor", "Optional Output Tensor", "Tensor", "Default value is None", "No"
+                "queue_id", "command queue id", "uint8_t", "Default is 0", "No"
+
+        )doc");
+
+        m_tensor.def("gtz",
+        [](const Tensor& input,
+            const MemoryConfig& output_mem_config,
+            std::optional<Tensor> output_tensor,
+            uint8_t queue_id){
+                return gtz(queue_id, input, output_mem_config, output_tensor);
+            },
+            py::arg("input"),
+            py::arg("output_mem_config").noconvert() = operation::DEFAULT_OUTPUT_MEMORY_CONFIG,
+            py::arg("output_tensor").noconvert() = std::nullopt,
+            py::arg("queue_id").noconvert() = 0,
+            R"doc(
+            Returns tensor with the greater than zero of all of the elements of the input tensor (``input`` > ``0``)`.
+
+            Input tensor must have BFLOAT16 data type.
+
+            Output tensor will have BFLOAT16 data type.
+
+            .. csv-table::
+                :header: "Argument", "Description", "Data type", "Valid range", "Required"
+
+                "input", "Tensor gtz is applied to", "Tensor", "Tensor of shape [W, Z, Y, X]", "Yes"
+                "output_mem_config", "Layout of tensor in TT Accelerator device memory banks", "MemoryConfig", "Default is interleaved in DRAM", "No"
+                "output_tensor", "Optional Output Tensor", "Tensor", "Default value is None", "No"
+                "queue_id", "command queue id", "uint8_t", "Default is 0", "No"
+
+        )doc");
+
+        m_tensor.def("gez",
+        [](const Tensor& input,
+            const MemoryConfig& output_mem_config,
+            std::optional<Tensor> output_tensor,
+            uint8_t queue_id){
+                return gez(queue_id, input, output_mem_config, output_tensor);
+            },
+            py::arg("input"),
+            py::arg("output_mem_config").noconvert() = operation::DEFAULT_OUTPUT_MEMORY_CONFIG,
+            py::arg("output_tensor").noconvert() = std::nullopt,
+            py::arg("queue_id").noconvert() = 0,
+            R"doc(
+            Returns tensor with the greater than zero of all of the elements of the input tensor (``input`` > ``0``)`.
+
+            Input tensor must have BFLOAT16 data type.
+
+            Output tensor will have BFLOAT16 data type.
+
+            .. csv-table::
+                :header: "Argument", "Description", "Data type", "Valid range", "Required"
+
+                "input", "Tensor gez is applied to", "Tensor", "Tensor of shape [W, Z, Y, X]", "Yes"
+                "output_mem_config", "Layout of tensor in TT Accelerator device memory banks", "MemoryConfig", "Default is interleaved in DRAM", "No"
+                "output_tensor", "Optional Output Tensor", "Tensor", "Default value is None", "No"
+                "queue_id", "command queue id", "uint8_t", "Default is 0", "No"
+
+        )doc");
+
+        m_tensor.def("lez",
+        [](const Tensor& input,
+            const MemoryConfig& output_mem_config,
+            std::optional<Tensor> output_tensor,
+            uint8_t queue_id){
+                return lez(queue_id, input, output_mem_config, output_tensor);
+            },
+            py::arg("input"),
+            py::arg("output_mem_config").noconvert() = operation::DEFAULT_OUTPUT_MEMORY_CONFIG,
+            py::arg("output_tensor").noconvert() = std::nullopt,
+            py::arg("queue_id").noconvert() = 0,
+            R"doc(
+            Returns tensor with the less than equal zero of all of the elements of the input tensor (``input`` <= ``0``).
+
+            Input tensor must have BFLOAT16 data type.
+
+            Output tensor will have BFLOAT16 data type.
+
+            .. csv-table::
+                :header: "Argument", "Description", "Data type", "Valid range", "Required"
+
+                "input", "Tensor lez is applied to", "Tensor", "Tensor of shape [W, Z, Y, X]", "Yes"
+                "output_mem_config", "Layout of tensor in TT Accelerator device memory banks", "MemoryConfig", "Default is interleaved in DRAM", "No"
+                "output_tensor", "Optional Output Tensor", "Tensor", "Default value is None", "No"
+                "queue_id", "command queue id", "uint8_t", "Default is 0", "No"
+
+        )doc");
+
+        m_tensor.def("ltz",
+        [](const Tensor& input,
+            const MemoryConfig& output_mem_config,
+            std::optional<Tensor> output_tensor,
+            uint8_t queue_id){
+                return ltz(queue_id, input, output_mem_config, output_tensor);
+            },
+            py::arg("input"),
+            py::arg("output_mem_config").noconvert() = operation::DEFAULT_OUTPUT_MEMORY_CONFIG,
+            py::arg("output_tensor").noconvert() = std::nullopt,
+            py::arg("queue_id").noconvert() = 0,
+            R"doc(
+            Returns tensor with the less than zero of all of the elements of the input tensor (``input`` < ``0``).
+
+            Input tensor must have BFLOAT16 data type.
+
+            Output tensor will have BFLOAT16 data type.
+
+            .. csv-table::
+                :header: "Argument", "Description", "Data type", "Valid range", "Required"
+
+                "input", "Tensor ltz is applied to", "Tensor", "Tensor of shape [W, Z, Y, X]", "Yes"
+                "output_mem_config", "Layout of tensor in TT Accelerator device memory banks", "MemoryConfig", "Default is interleaved in DRAM", "No"
+                "output_tensor", "Optional Output Tensor", "Tensor", "Default value is None", "No"
+                "queue_id", "command queue id", "uint8_t", "Default is 0", "No"
+
+        )doc");
+
+        m_tensor.def("eqz",
+        [](const Tensor& input,
+            const MemoryConfig& output_mem_config,
+            std::optional<Tensor> output_tensor,
+            uint8_t queue_id){
+                return eqz(queue_id, input, output_mem_config, output_tensor);
+            },
+            py::arg("input"),
+            py::arg("output_mem_config").noconvert() = operation::DEFAULT_OUTPUT_MEMORY_CONFIG,
+            py::arg("output_tensor").noconvert() = std::nullopt,
+            py::arg("queue_id").noconvert() = 0,
+            R"doc(
+            Returns tensor with the result of equal to zero of all of the elements of the input tensor (``input`` == ``0``).
+
+            Input tensor must have BFLOAT16 data type.
+
+            Output tensor will have BFLOAT16 data type.
+
+            .. csv-table::
+                :header: "Argument", "Description", "Data type", "Valid range", "Required"
+
+                "input", "Tensor eqz is applied to", "Tensor", "Tensor of shape [W, Z, Y, X]", "Yes"
+                "output_mem_config", "Layout of tensor in TT Accelerator device memory banks", "MemoryConfig", "Default is interleaved in DRAM", "No"
+                "output_tensor", "Optional Output Tensor", "Tensor", "Default value is None", "No"
+                "queue_id", "command queue id", "uint8_t", "Default is 0", "No"
+
+        )doc");
+
+        m_tensor.def("sign",
+        [](const Tensor& input,
+            const MemoryConfig& output_mem_config,
+            std::optional<Tensor> output_tensor,
+            uint8_t queue_id){
+                return sign(queue_id, input, output_mem_config, output_tensor);
+            },
+            py::arg("input"),
+            py::arg("output_mem_config").noconvert() = operation::DEFAULT_OUTPUT_MEMORY_CONFIG,
+            py::arg("output_tensor").noconvert() = std::nullopt,
+            py::arg("queue_id").noconvert() = 0,
+            R"doc(
+            Returns tensor with the elementwise signum of the input tensor ``input`` .
+
+            Input tensor must have BFLOAT16 data type.
+
+            Output tensor will have BFLOAT16 data type.
+
+            .. csv-table::
+                :header: "Argument", "Description", "Data type", "Valid range", "Required"
+
+                "input", "Tensor sign operation is applied to", "Tensor", "Tensor of shape [W, Z, Y, X]", "Yes"
+                "output_mem_config", "Layout of tensor in TT Accelerator device memory banks", "MemoryConfig", "Default is interleaved in DRAM", "No"
+                "output_tensor", "Optional Output Tensor", "Tensor", "Default value is None", "No"
+                "queue_id", "command queue id", "uint8_t", "Default is 0", "No"
+
+        )doc");
+
+        m_tensor.def("neg",
+        [](const Tensor& input,
+            const MemoryConfig& output_mem_config,
+            std::optional<Tensor> output_tensor,
+            uint8_t queue_id){
+                return neg(queue_id, input, output_mem_config, output_tensor);
+            },
+            py::arg("input"),
+            py::arg("output_mem_config").noconvert() = operation::DEFAULT_OUTPUT_MEMORY_CONFIG,
+            py::arg("output_tensor").noconvert() = std::nullopt,
+            py::arg("queue_id").noconvert() = 0,
+            R"doc(
+            Returns tensor with the negate all of elements of the input tensor ``input`` .
+
+            Input tensor must have BFLOAT16 data type.
+
+            Output tensor will have BFLOAT16 data type.
+
+            .. csv-table::
+                :header: "Argument", "Description", "Data type", "Valid range", "Required"
+
+                "input", "Tensor neg operation is applied to", "Tensor", "Tensor of shape [W, Z, Y, X]", "Yes"
+                "output_mem_config", "Layout of tensor in TT Accelerator device memory banks", "MemoryConfig", "Default is interleaved in DRAM", "No"
+                "output_tensor", "Optional Output Tensor", "Tensor", "Default value is None", "No"
+                "queue_id", "command queue id", "uint8_t", "Default is 0", "No"
+
+        )doc");
+
+        m_tensor.def("tanh",
+        [](const Tensor& input,
+            const MemoryConfig& output_mem_config,
+            std::optional<Tensor> output_tensor,
+            uint8_t queue_id){
+                return tanh(queue_id, input, output_mem_config, output_tensor);
+            },
+            py::arg("input"),
+            py::arg("output_mem_config").noconvert() = operation::DEFAULT_OUTPUT_MEMORY_CONFIG,
+            py::arg("output_tensor").noconvert() = std::nullopt,
+            py::arg("queue_id").noconvert() = 0,
+            R"doc(
+            Returns tensor with the hyperbolic tangent of elements of the input tensor ``input`` .
+
+            Input tensor must have BFLOAT16 data type.
+
+            Output tensor will have BFLOAT16 data type.
+
+            .. csv-table::
+                :header: "Argument", "Description", "Data type", "Valid range", "Required"
+
+                "input", "Tensor tanh operation is applied to", "Tensor", "Tensor of shape [W, Z, Y, X]", "Yes"
+                "output_mem_config", "Layout of tensor in TT Accelerator device memory banks", "MemoryConfig", "Default is interleaved in DRAM", "No"
+                "output_tensor", "Optional Output Tensor", "Tensor", "Default value is None", "No"
+                "queue_id", "command queue id", "uint8_t", "Default is 0", "No"
+
+        )doc");
+
+        m_tensor.def("log",
+        [](const Tensor& input,
+            const MemoryConfig& output_mem_config,
+            std::optional<Tensor> output_tensor,
+            uint8_t queue_id){
+                return log(queue_id, input, output_mem_config, output_tensor);
+            },
+            py::arg("input"),
+            py::arg("output_mem_config").noconvert() = operation::DEFAULT_OUTPUT_MEMORY_CONFIG,
+            py::arg("output_tensor").noconvert() = std::nullopt,
+            py::arg("queue_id").noconvert() = 0,
+            R"doc(
+            Returns tensor with the natural logarithm of elements of the input tensor ``input`` .
+
+            Input tensor must have BFLOAT16 data type.
+
+            Output tensor will have BFLOAT16 data type.
+
+            .. csv-table::
+                :header: "Argument", "Description", "Data type", "Valid range", "Required"
+
+                "input", "Tensor log operation is applied to", "Tensor", "Tensor of shape [W, Z, Y, X]", "Yes"
+                "output_mem_config", "Layout of tensor in TT Accelerator device memory banks", "MemoryConfig", "Default is interleaved in DRAM", "No"
+                "output_tensor", "Optional Output Tensor", "Tensor", "Default value is None", "No"
+                "queue_id", "command queue id", "uint8_t", "Default is 0", "No"
+
+        )doc");
+
+        m_tensor.def("abs",
+        [](const Tensor& input,
+            const MemoryConfig& output_mem_config,
+            std::optional<Tensor> output_tensor,
+            uint8_t queue_id){
+                return abs(queue_id, input, output_mem_config, output_tensor);
+            },
+            py::arg("input"),
+            py::arg("output_mem_config").noconvert() = operation::DEFAULT_OUTPUT_MEMORY_CONFIG,
+            py::arg("output_tensor").noconvert() = std::nullopt,
+            py::arg("queue_id").noconvert() = 0,
+            R"doc(
+            Returns tensor with elementwise absolute value of the input tensor ``input`` .
+
+            Input tensor must have BFLOAT16 data type.
+
+            Output tensor will have BFLOAT16 data type.
+
+            .. csv-table::
+                :header: "Argument", "Description", "Data type", "Valid range", "Required"
+
+                "input", "Tensor abs operation is applied to", "Tensor", "Tensor of shape [W, Z, Y, X]", "Yes"
+                "output_mem_config", "Layout of tensor in TT Accelerator device memory banks", "MemoryConfig", "Default is interleaved in DRAM", "No"
+                "output_tensor", "Optional Output Tensor", "Tensor", "Default value is None", "No"
+                "queue_id", "command queue id", "uint8_t", "Default is 0", "No"
+
+        )doc");
+
+        m_tensor.def("square",
+        [](const Tensor& input,
+            const MemoryConfig& output_mem_config,
+            std::optional<Tensor> output_tensor,
+            uint8_t queue_id){
+                return square(queue_id, input, output_mem_config, output_tensor);
+            },
+            py::arg("input"),
+            py::arg("output_mem_config").noconvert() = operation::DEFAULT_OUTPUT_MEMORY_CONFIG,
+            py::arg("output_tensor").noconvert() = std::nullopt,
+            py::arg("queue_id").noconvert() = 0,
+            R"doc(
+            Returns tensor with the square of elements of the input tensor ``input`` .
+
+            Input tensor must have BFLOAT16 data type.
+
+            Output tensor will have BFLOAT16 data type.
+
+            .. csv-table::
+                :header: "Argument", "Description", "Data type", "Valid range", "Required"
+
+                "input", "Tensor square operation is applied to", "Tensor", "Tensor of shape [W, Z, Y, X]", "Yes"
+                "output_mem_config", "Layout of tensor in TT Accelerator device memory banks", "MemoryConfig", "Default is interleaved in DRAM", "No"
+                "output_tensor", "Optional Output Tensor", "Tensor", "Default value is None", "No"
+                "queue_id", "command queue id", "uint8_t", "Default is 0", "No"
+
+        )doc");
+
+        m_tensor.def("rsub",
+        [](const Tensor& input,
+            float value,
+            const MemoryConfig& output_mem_config,
+            std::optional<Tensor> output_tensor,
+            uint8_t queue_id){
+                return rsub(queue_id, input, value, output_mem_config, output_tensor);
+            },
+            py::arg("input"),
+            py::arg("value"),
+            py::arg("output_mem_config").noconvert() = operation::DEFAULT_OUTPUT_MEMORY_CONFIG,
+            py::arg("output_tensor").noconvert() = std::nullopt,
+            py::arg("queue_id").noconvert() = 0,
+            R"doc(
+            Returns tensor  with respective elements of the input tensor ``input`` subtracted from the ``value``.
+
+            Input tensor must have BFLOAT16 data type.
+
+            Output tensor will have BFLOAT16 data type.
+
+            .. csv-table::
+                :header: "Argument", "Description", "Data type", "Valid range", "Required"
+
+                "input", "Tensor square operation is applied to", "Tensor", "Tensor of shape [W, Z, Y, X]", "Yes"
+                "output_mem_config", "Layout of tensor in TT Accelerator device memory banks", "MemoryConfig", "Default is interleaved in DRAM", "No"
+                "output_tensor", "Optional Output Tensor", "Tensor", "Default value is None", "No"
+                "queue_id", "command queue id", "uint8_t", "Default is 0", "No"
+
+        )doc");
+
+        m_tensor.def("sqrt",
+        [](const Tensor& input,
+            const MemoryConfig& output_mem_config,
+            std::optional<Tensor> output_tensor,
+            uint8_t queue_id){
+                return sqrt(queue_id, input, output_mem_config, output_tensor);
+            },
+            py::arg("input"),
+            py::arg("output_mem_config").noconvert() = operation::DEFAULT_OUTPUT_MEMORY_CONFIG,
+            py::arg("output_tensor").noconvert() = std::nullopt,
+            py::arg("queue_id").noconvert() = 0,
+            R"doc(
+            Returns a new tensor with the reciprocal of the elements of the input tensor ``recip``.
+
+            Input tensor must have BFLOAT16 data type.
+
+            Output tensor will have BFLOAT16 data type.
+
+            .. csv-table::
+                :header: "Argument", "Description", "Data type", "Valid range", "Required"
+
+                "input", "Tensor sqrt is applied to", "Tensor", "Tensor of shape [W, Z, Y, X]", "Yes"
+                "output_mem_config", "Layout of tensor in TT Accelerator device memory banks", "MemoryConfig", "Default is interleaved in DRAM", "No"
+                "output_tensor", "Optional Output Tensor", "Tensor", "Default value is None", "No"
+                "queue_id", "command queue id", "uint8_t", "Default is 0", "No"
+
+        )doc");
+
+        m_tensor.def("exp",
+        [](const Tensor& input,
+            bool fast_and_approx,
+            const MemoryConfig& output_mem_config,
+            std::optional<Tensor> output_tensor,
+            uint8_t queue_id){
+                return exp(queue_id, input, fast_and_approx, output_mem_config, output_tensor);
+            },
+            py::arg("input"),
+            py::arg("fast_and_approx") = false,
+            py::arg("output_mem_config").noconvert() = operation::DEFAULT_OUTPUT_MEMORY_CONFIG,
+            py::arg("output_tensor").noconvert() = std::nullopt,
+            py::arg("queue_id").noconvert() = 0,
+            R"doc(
+            Returns a new tensor with the exponential of the elements of the input tensor ``exp``.
+
+            Input tensor must have BFLOAT16 data type.
+
+            Output tensor will have BFLOAT16 data type.
+
+            .. csv-table::
+                :header: "Argument", "Description", "Data type", "Valid range", "Required"
+
+                "input", "Tensor exp is applied to", "Tensor", "Tensor of shape [W, Z, Y, X]", "Yes"
+                "fast_and_approx", "Indicate true for approx and fast mode; false for accurate and slow mode",  "bool", "default of false", "No"
+                "output_mem_config", "Layout of tensor in TT Accelerator device memory banks", "MemoryConfig", "Default is interleaved in DRAM", "No"
+                "output_tensor", "Optional Output Tensor", "Tensor", "Default value is None", "No"
+                "queue_id", "command queue id", "uint8_t", "Default is 0", "No"
+
+        )doc");
+
+        m_tensor.def("gtz",
+        [](const Tensor& input,
+            const MemoryConfig& output_mem_config,
+            std::optional<Tensor> output_tensor,
+            uint8_t queue_id){
+                return gtz(queue_id, input, output_mem_config, output_tensor);
+            },
+            py::arg("input"),
+            py::arg("output_mem_config").noconvert() = operation::DEFAULT_OUTPUT_MEMORY_CONFIG,
+            py::arg("output_tensor").noconvert() = std::nullopt,
+            py::arg("queue_id").noconvert() = 0,
+            R"doc(
+            Returns tensor with the greater than zero of all of the elements of the input tensor (``input`` > ``0``)`.
+
+            Input tensor must have BFLOAT16 data type.
+
+            Output tensor will have BFLOAT16 data type.
+
+            .. csv-table::
+                :header: "Argument", "Description", "Data type", "Valid range", "Required"
+
+                "input", "Tensor gtz is applied to", "Tensor", "Tensor of shape [W, Z, Y, X]", "Yes"
+                "output_mem_config", "Layout of tensor in TT Accelerator device memory banks", "MemoryConfig", "Default is interleaved in DRAM", "No"
+                "output_tensor", "Optional Output Tensor", "Tensor", "Default value is None", "No"
+                "queue_id", "command queue id", "uint8_t", "Default is 0", "No"
+
+        )doc");
+
+        m_tensor.def("gez",
+        [](const Tensor& input,
+            const MemoryConfig& output_mem_config,
+            std::optional<Tensor> output_tensor,
+            uint8_t queue_id){
+                return gez(queue_id, input, output_mem_config, output_tensor);
+            },
+            py::arg("input"),
+            py::arg("output_mem_config").noconvert() = operation::DEFAULT_OUTPUT_MEMORY_CONFIG,
+            py::arg("output_tensor").noconvert() = std::nullopt,
+            py::arg("queue_id").noconvert() = 0,
+            R"doc(
+            Returns tensor with the greater than zero of all of the elements of the input tensor (``input`` > ``0``)`.
+
+            Input tensor must have BFLOAT16 data type.
+
+            Output tensor will have BFLOAT16 data type.
+
+            .. csv-table::
+                :header: "Argument", "Description", "Data type", "Valid range", "Required"
+
+                "input", "Tensor gez is applied to", "Tensor", "Tensor of shape [W, Z, Y, X]", "Yes"
+                "output_mem_config", "Layout of tensor in TT Accelerator device memory banks", "MemoryConfig", "Default is interleaved in DRAM", "No"
+                "output_tensor", "Optional Output Tensor", "Tensor", "Default value is None", "No"
+                "queue_id", "command queue id", "uint8_t", "Default is 0", "No"
+
+        )doc");
+
+        m_tensor.def("lez",
+        [](const Tensor& input,
+            const MemoryConfig& output_mem_config,
+            std::optional<Tensor> output_tensor,
+            uint8_t queue_id){
+                return lez(queue_id, input, output_mem_config, output_tensor);
+            },
+            py::arg("input"),
+            py::arg("output_mem_config").noconvert() = operation::DEFAULT_OUTPUT_MEMORY_CONFIG,
+            py::arg("output_tensor").noconvert() = std::nullopt,
+            py::arg("queue_id").noconvert() = 0,
+            R"doc(
+            Returns tensor with the less than equal zero of all of the elements of the input tensor (``input`` <= ``0``).
+
+            Input tensor must have BFLOAT16 data type.
+
+            Output tensor will have BFLOAT16 data type.
+
+            .. csv-table::
+                :header: "Argument", "Description", "Data type", "Valid range", "Required"
+
+                "input", "Tensor lez is applied to", "Tensor", "Tensor of shape [W, Z, Y, X]", "Yes"
+                "output_mem_config", "Layout of tensor in TT Accelerator device memory banks", "MemoryConfig", "Default is interleaved in DRAM", "No"
+                "output_tensor", "Optional Output Tensor", "Tensor", "Default value is None", "No"
+                "queue_id", "command queue id", "uint8_t", "Default is 0", "No"
+
+        )doc");
+
+        m_tensor.def("ltz",
+        [](const Tensor& input,
+            const MemoryConfig& output_mem_config,
+            std::optional<Tensor> output_tensor,
+            uint8_t queue_id){
+                return ltz(queue_id, input, output_mem_config, output_tensor);
+            },
+            py::arg("input"),
+            py::arg("output_mem_config").noconvert() = operation::DEFAULT_OUTPUT_MEMORY_CONFIG,
+            py::arg("output_tensor").noconvert() = std::nullopt,
+            py::arg("queue_id").noconvert() = 0,
+            R"doc(
+            Returns tensor with the less than zero of all of the elements of the input tensor (``input`` < ``0``).
+
+            Input tensor must have BFLOAT16 data type.
+
+            Output tensor will have BFLOAT16 data type.
+
+            .. csv-table::
+                :header: "Argument", "Description", "Data type", "Valid range", "Required"
+
+                "input", "Tensor ltz is applied to", "Tensor", "Tensor of shape [W, Z, Y, X]", "Yes"
+                "output_mem_config", "Layout of tensor in TT Accelerator device memory banks", "MemoryConfig", "Default is interleaved in DRAM", "No"
+                "output_tensor", "Optional Output Tensor", "Tensor", "Default value is None", "No"
+                "queue_id", "command queue id", "uint8_t", "Default is 0", "No"
+
+        )doc");
+
+        m_tensor.def("eqz",
+        [](const Tensor& input,
+            const MemoryConfig& output_mem_config,
+            std::optional<Tensor> output_tensor,
+            uint8_t queue_id){
+                return eqz(queue_id, input, output_mem_config, output_tensor);
+            },
+            py::arg("input"),
+            py::arg("output_mem_config").noconvert() = operation::DEFAULT_OUTPUT_MEMORY_CONFIG,
+            py::arg("output_tensor").noconvert() = std::nullopt,
+            py::arg("queue_id").noconvert() = 0,
+            R"doc(
+            Returns tensor with the result of equal to zero of all of the elements of the input tensor (``input`` == ``0``).
+
+            Input tensor must have BFLOAT16 data type.
+
+            Output tensor will have BFLOAT16 data type.
+
+            .. csv-table::
+                :header: "Argument", "Description", "Data type", "Valid range", "Required"
+
+                "input", "Tensor eqz is applied to", "Tensor", "Tensor of shape [W, Z, Y, X]", "Yes"
+                "output_mem_config", "Layout of tensor in TT Accelerator device memory banks", "MemoryConfig", "Default is interleaved in DRAM", "No"
+                "output_tensor", "Optional Output Tensor", "Tensor", "Default value is None", "No"
+                "queue_id", "command queue id", "uint8_t", "Default is 0", "No"
+
+        )doc");
+
+        m_tensor.def("sign",
+        [](const Tensor& input,
+            const MemoryConfig& output_mem_config,
+            std::optional<Tensor> output_tensor,
+            uint8_t queue_id){
+                return sign(queue_id, input, output_mem_config, output_tensor);
+            },
+            py::arg("input"),
+            py::arg("output_mem_config").noconvert() = operation::DEFAULT_OUTPUT_MEMORY_CONFIG,
+            py::arg("output_tensor").noconvert() = std::nullopt,
+            py::arg("queue_id").noconvert() = 0,
+            R"doc(
+            Returns tensor with the elementwise signum of the input tensor ``input`` .
+
+            Input tensor must have BFLOAT16 data type.
+
+            Output tensor will have BFLOAT16 data type.
+
+            .. csv-table::
+                :header: "Argument", "Description", "Data type", "Valid range", "Required"
+
+                "input", "Tensor sign operation is applied to", "Tensor", "Tensor of shape [W, Z, Y, X]", "Yes"
+                "output_mem_config", "Layout of tensor in TT Accelerator device memory banks", "MemoryConfig", "Default is interleaved in DRAM", "No"
+                "output_tensor", "Optional Output Tensor", "Tensor", "Default value is None", "No"
+                "queue_id", "command queue id", "uint8_t", "Default is 0", "No"
+
+        )doc");
+
+        m_tensor.def("neg",
+        [](const Tensor& input,
+            const MemoryConfig& output_mem_config,
+            std::optional<Tensor> output_tensor,
+            uint8_t queue_id){
+                return neg(queue_id, input, output_mem_config, output_tensor);
+            },
+            py::arg("input"),
+            py::arg("output_mem_config").noconvert() = operation::DEFAULT_OUTPUT_MEMORY_CONFIG,
+            py::arg("output_tensor").noconvert() = std::nullopt,
+            py::arg("queue_id").noconvert() = 0,
+            R"doc(
+            Returns tensor with the negate all of elements of the input tensor ``input`` .
+
+            Input tensor must have BFLOAT16 data type.
+
+            Output tensor will have BFLOAT16 data type.
+
+            .. csv-table::
+                :header: "Argument", "Description", "Data type", "Valid range", "Required"
+
+                "input", "Tensor neg operation is applied to", "Tensor", "Tensor of shape [W, Z, Y, X]", "Yes"
+                "output_mem_config", "Layout of tensor in TT Accelerator device memory banks", "MemoryConfig", "Default is interleaved in DRAM", "No"
+                "output_tensor", "Optional Output Tensor", "Tensor", "Default value is None", "No"
+                "queue_id", "command queue id", "uint8_t", "Default is 0", "No"
+
+        )doc");
+
+        m_tensor.def("tanh",
+        [](const Tensor& input,
+            const MemoryConfig& output_mem_config,
+            std::optional<Tensor> output_tensor,
+            uint8_t queue_id){
+                return tanh(queue_id, input, output_mem_config, output_tensor);
+            },
+            py::arg("input"),
+            py::arg("output_mem_config").noconvert() = operation::DEFAULT_OUTPUT_MEMORY_CONFIG,
+            py::arg("output_tensor").noconvert() = std::nullopt,
+            py::arg("queue_id").noconvert() = 0,
+            R"doc(
+            Returns tensor with the hyperbolic tangent of elements of the input tensor ``input`` .
+
+            Input tensor must have BFLOAT16 data type.
+
+            Output tensor will have BFLOAT16 data type.
+
+            .. csv-table::
+                :header: "Argument", "Description", "Data type", "Valid range", "Required"
+
+                "input", "Tensor tanh operation is applied to", "Tensor", "Tensor of shape [W, Z, Y, X]", "Yes"
+                "output_mem_config", "Layout of tensor in TT Accelerator device memory banks", "MemoryConfig", "Default is interleaved in DRAM", "No"
+                "output_tensor", "Optional Output Tensor", "Tensor", "Default value is None", "No"
+                "queue_id", "command queue id", "uint8_t", "Default is 0", "No"
+
+        )doc");
+
+        m_tensor.def("log",
+        [](const Tensor& input,
+            const MemoryConfig& output_mem_config,
+            std::optional<Tensor> output_tensor,
+            uint8_t queue_id){
+                return log(queue_id, input, output_mem_config, output_tensor);
+            },
+            py::arg("input"),
+            py::arg("output_mem_config").noconvert() = operation::DEFAULT_OUTPUT_MEMORY_CONFIG,
+            py::arg("output_tensor").noconvert() = std::nullopt,
+            py::arg("queue_id").noconvert() = 0,
+            R"doc(
+            Returns tensor with the natural logarithm of elements of the input tensor ``input`` .
+
+            Input tensor must have BFLOAT16 data type.
+
+            Output tensor will have BFLOAT16 data type.
+
+            .. csv-table::
+                :header: "Argument", "Description", "Data type", "Valid range", "Required"
+
+                "input", "Tensor log operation is applied to", "Tensor", "Tensor of shape [W, Z, Y, X]", "Yes"
+                "output_mem_config", "Layout of tensor in TT Accelerator device memory banks", "MemoryConfig", "Default is interleaved in DRAM", "No"
+                "output_tensor", "Optional Output Tensor", "Tensor", "Default value is None", "No"
+                "queue_id", "command queue id", "uint8_t", "Default is 0", "No"
+
+        )doc");
+
+        m_tensor.def("abs",
+        [](const Tensor& input,
+            const MemoryConfig& output_mem_config,
+            std::optional<Tensor> output_tensor,
+            uint8_t queue_id){
+                return abs(queue_id, input, output_mem_config, output_tensor);
+            },
+            py::arg("input"),
+            py::arg("output_mem_config").noconvert() = operation::DEFAULT_OUTPUT_MEMORY_CONFIG,
+            py::arg("output_tensor").noconvert() = std::nullopt,
+            py::arg("queue_id").noconvert() = 0,
+            R"doc(
+            Returns tensor with elementwise absolute value of the input tensor ``input`` .
+
+            Input tensor must have BFLOAT16 data type.
+
+            Output tensor will have BFLOAT16 data type.
+
+            .. csv-table::
+                :header: "Argument", "Description", "Data type", "Valid range", "Required"
+
+                "input", "Tensor abs operation is applied to", "Tensor", "Tensor of shape [W, Z, Y, X]", "Yes"
+                "output_mem_config", "Layout of tensor in TT Accelerator device memory banks", "MemoryConfig", "Default is interleaved in DRAM", "No"
+                "output_tensor", "Optional Output Tensor", "Tensor", "Default value is None", "No"
+                "queue_id", "command queue id", "uint8_t", "Default is 0", "No"
+
+        )doc");
+
+        m_tensor.def("square",
+        [](const Tensor& input,
+            const MemoryConfig& output_mem_config,
+            std::optional<Tensor> output_tensor,
+            uint8_t queue_id){
+                return square(queue_id, input, output_mem_config, output_tensor);
+            },
+            py::arg("input"),
+            py::arg("output_mem_config").noconvert() = operation::DEFAULT_OUTPUT_MEMORY_CONFIG,
+            py::arg("output_tensor").noconvert() = std::nullopt,
+            py::arg("queue_id").noconvert() = 0,
+            R"doc(
+            Returns tensor with the square of elements of the input tensor ``input`` .
+
+            Input tensor must have BFLOAT16 data type.
+
+            Output tensor will have BFLOAT16 data type.
+
+            .. csv-table::
+                :header: "Argument", "Description", "Data type", "Valid range", "Required"
+
+                "input", "Tensor square operation is applied to", "Tensor", "Tensor of shape [W, Z, Y, X]", "Yes"
+                "output_mem_config", "Layout of tensor in TT Accelerator device memory banks", "MemoryConfig", "Default is interleaved in DRAM", "No"
+                "output_tensor", "Optional Output Tensor", "Tensor", "Default value is None", "No"
+                "queue_id", "command queue id", "uint8_t", "Default is 0", "No"
+
+        )doc");
+
+        m_tensor.def("rsub",
+        [](const Tensor& input,
+            float value,
+            const MemoryConfig& output_mem_config,
+            std::optional<Tensor> output_tensor,
+            uint8_t queue_id){
+                return rsub(queue_id, input, value, output_mem_config, output_tensor);
+            },
+            py::arg("input"),
+            py::arg("value"),
+            py::arg("output_mem_config").noconvert() = operation::DEFAULT_OUTPUT_MEMORY_CONFIG,
+            py::arg("output_tensor").noconvert() = std::nullopt,
+            py::arg("queue_id").noconvert() = 0,
+            R"doc(
+            Returns tensor  with respective elements of the input tensor ``input`` subtracted from the ``value``.
+
+            Input tensor must have BFLOAT16 data type.
+
+            Output tensor will have BFLOAT16 data type.
+
+            .. csv-table::
+                :header: "Argument", "Description", "Data type", "Valid range", "Required"
+
+                "input", "Tensor square operation is applied to", "Tensor", "Tensor of shape [W, Z, Y, X]", "Yes"
+                "output_mem_config", "Layout of tensor in TT Accelerator device memory banks", "MemoryConfig", "Default is interleaved in DRAM", "No"
+                "output_tensor", "Optional Output Tensor", "Tensor", "Default value is None", "No"
+                "queue_id", "command queue id", "uint8_t", "Default is 0", "No"
 
         )doc");
 
@@ -294,12 +1067,6 @@ namespace tt::tt_metal::detail {
             py::arg("denominator"),
             R"doc(Returns tensor  with value ``{1}`` divided by each of respective elements of the input tensor ``{0}``.)doc",
             R"doc("denominator value which is actually calculated as numerator", "float", ">=0.0")doc"
-        );
-        detail::bind_unary_op_with_param(
-            m_tensor, "rsub", rsub,
-            py::arg("value"),
-            R"doc(Returns tensor  with respective elements of the input tensor ``{0}`` subtracted from the ``{1}``.)doc",
-            R"doc("subtrahent value which is actually calculated as minuend", "float")doc"
         );
         detail::bind_unary_op_with_param(
             m_tensor, "leaky_relu", leaky_relu,


### PR DESCRIPTION
### Ticket
- [Link to Github Issue.](https://github.com/tenstorrent/tt-metal/issues/9484)

### Problem description
- To add `output_tensor` and `queue_id` to composite ops in #9123, there are a few ops in intermediate level which should also support `output_tensor` and `queue_id`

### What's changed
- Added output_tensor and queue_id to dependent unary ops.
- These ops[ gtz, lez, eqz, sign, neg] now have `output_tensor` and `queue_id` arguments .
- And updated `output_mem_config` in binary ops (ttnn::multiply, ttnn::add) used within some composite ops to pass `std::nullopt` instead of default value   when `output_tensor` is provided.

### Checklist
- [x] Post commit CI - [passes](https://github.com/tenstorrent/tt-metal/actions/runs/9743457306) https://github.com/tenstorrent/tt-metal/actions/runs/9743457306
- [x] Posi commit model tests passes https://github.com/tenstorrent/tt-metal/actions/runs/9741058145
- [x] Nightly fast dispatch tests passes https://github.com/tenstorrent/tt-metal/actions/runs/9741060911
- [x] New/Existing tests provide coverage for changes added