### PR TITLE
#9319: Revert "#9319: Add escape characters to ensure workflow name is parsed correctly (#9466)"

### DIFF
--- a/.github/workflows/_produce-data.yaml
+++ b/.github/workflows/_produce-data.yaml
@@ -4,7 +4,8 @@ on:
   workflow_call:
   workflow_dispatch:
   workflow_run:
-    workflows: ["All post-commit tests", "[post-commit] all - Static checks, linters etc."]
+    workflows:
+      - "All post-commit tests"
     types:
       - completed
 


### PR DESCRIPTION
This reverts commit ec403bf52bba3d96b9960f17190a37d70d386341.

### Ticket

#9319

### Problem description

Providing complex workflow names as full quoted strings doesn't work still: https://github.com/tenstorrent/tt-metal/actions/runs/9552756704

### What's changed

Reverting for now

### Checklist
- [x] Post commit CI passes
- [x] Model regression CI testing passes (if applicable)
- [x] New/Existing tests provide coverage for changes
