### PR TITLE
#4970: Fix compute kernel absolute/rel-to-CWD paths

### DIFF
--- a/tests/tt_metal/tt_metal/unit_tests_common/dprint/test_print_all_harts.cpp
+++ b/tests/tt_metal/tt_metal/unit_tests_common/dprint/test_print_all_harts.cpp
@@ -148,19 +148,19 @@ static void RunTest(DPrintFixture* fixture, Device* device) {
     // failing test cases, although all three kernels simply print.
     KernelHandle brisc_print_kernel_id = CreateKernel(
         program,
-        "tests/tt_metal/tt_metal/test_kernels/misc/brisc_print.cpp",
+        llrt::OptionsG.get_root_dir() + "tests/tt_metal/tt_metal/test_kernels/misc/brisc_print.cpp",
         core,
         DataMovementConfig{.processor = DataMovementProcessor::RISCV_0, .noc = NOC::RISCV_0_default}
     );
     KernelHandle ncrisc_print_kernel_id = CreateKernel(
         program,
-        "tests/tt_metal/tt_metal/test_kernels/misc/ncrisc_print.cpp",
+        llrt::OptionsG.get_root_dir() + "tests/tt_metal/tt_metal/test_kernels/misc/ncrisc_print.cpp",
         core,
         DataMovementConfig{.processor = DataMovementProcessor::RISCV_1, .noc = NOC::RISCV_1_default}
     );
     KernelHandle trisc_print_kernel_id = CreateKernel(
         program,
-        "tests/tt_metal/tt_metal/test_kernels/misc/trisc_print.cpp",
+        llrt::OptionsG.get_root_dir() + "tests/tt_metal/tt_metal/test_kernels/misc/trisc_print.cpp",
         core,
         ComputeConfig{}
     );

--- a/tt_metal/host_api.hpp
+++ b/tt_metal/host_api.hpp
@@ -113,7 +113,7 @@ Program CreateProgram();
  * | Argument     | Description                                                                                                                          | Type                                                     | Valid Range | Required |
  * |--------------|--------------------------------------------------------------------------------------------------------------------------------------|----------------------------------------------------------|-------------|----------|
  * | program      | The program to which this kernel will be added to                                                                                    | Program &                                                |             | Yes      |
- * | file_name    | Path to kernel src. Assumed to be absolute path, but will fall back to relative path from TT_METAL_HOME if file doesn't exist.       | const std::string &                                      |             | Yes      |
+ * | file_name    | Path to kernel src. Assumed to be absolute/relative to CWD, but will fall back to relative path from TT_METAL_HOME.                  | const std::string &                                      |             | Yes      |
  * | core_spec    | Either a single logical core, a range of logical cores or a set of logical core ranges that indicate which cores kernel is placed on | const std::variant<CoreCoord, CoreRange, CoreRangeSet> & |             | Yes      |
  * | config       | Config for data movement or compute kernel                                                                                           | const std::variant<DataMovementConfig,ComputeConfig,EthernetConfig> &   |             | No       |
  */

--- a/tt_metal/hw/firmware/src/brisck.cc
+++ b/tt_metal/hw/firmware/src/brisck.cc
@@ -20,7 +20,7 @@
 #include "dataflow_api.h"
 #include "noc_addr_ranges_gen.h"
 
-#include <kernel.cpp>
+#include <kernel_includes.hpp>
 
 uint8_t noc_index = NOC_INDEX;
 

--- a/tt_metal/hw/firmware/src/erisck.cc
+++ b/tt_metal/hw/firmware/src/erisck.cc
@@ -20,7 +20,7 @@
 #include "noc_addr_ranges_gen.h"
 #include "tools/profiler/kernel_profiler.hpp"
 #include "tt_metal/impl/dispatch/dispatch_address_map.hpp"
-#include <kernel.cpp>
+#include <kernel_includes.hpp>
 
 
 uint8_t noc_index = NOC_INDEX;

--- a/tt_metal/hw/firmware/src/idle_erisck.cc
+++ b/tt_metal/hw/firmware/src/idle_erisck.cc
@@ -20,7 +20,7 @@
 #include "dataflow_api.h"
 #include "noc_addr_ranges_gen.h"
 
-#include <kernel.cpp>
+#include <kernel_includes.hpp>
 
 uint8_t noc_index = NOC_INDEX;
 //inline void RISC_POST_STATUS(uint32_t status) {

--- a/tt_metal/hw/firmware/src/ncrisck.cc
+++ b/tt_metal/hw/firmware/src/ncrisck.cc
@@ -18,7 +18,7 @@
 #include "tensix_functions.h"
 #include "c_tensix_core.h"
 
-#include "kernel.cpp"
+#include "kernel_includes.hpp"
 
 uint8_t noc_index = NOC_INDEX;
 

--- a/tt_metal/impl/kernels/kernel.cpp
+++ b/tt_metal/impl/kernels/kernel.cpp
@@ -319,6 +319,7 @@ void ComputeKernel::set_build_options(JitBuildOptions &build_options) const {
 }
 
 void DataMovementKernel::generate_binaries(Device *device, JitBuildOptions &build_options) const {
+    jit_build_genfiles_kernel_include(device->build_env(), *this, this->kernel_path_file_name_);
     detail::GenerateDeviceHeaders(device, build_options.path);
     int riscv_id = static_cast<std::underlying_type<DataMovementProcessor>::type>(this->config_.processor);
     jit_build(
@@ -326,6 +327,7 @@ void DataMovementKernel::generate_binaries(Device *device, JitBuildOptions &buil
 }
 
 void EthernetKernel::generate_binaries(Device *device, JitBuildOptions &build_options) const {
+    jit_build_genfiles_kernel_include(device->build_env(), *this, this->kernel_path_file_name_);
     detail::GenerateDeviceHeaders(device, build_options.path);
     int erisc_id = this->config_.eth_mode == Eth::IDLE ? 1 : 0;
     jit_build(

--- a/tt_metal/jit_build/build.cpp
+++ b/tt_metal/jit_build/build.cpp
@@ -398,24 +398,6 @@ static void build_failure(const string& target_name, const string& op, const str
 
 void JitBuildState::pre_compile(const string& kernel_in_path, const string& op_out_path) const {}
 
-void JitBuildState::copy_kernel(const string& kernel_in_path, const string& op_out_path) const {
-    // TODO(pgk): get rid of this copy, compile kernel file in place as its own .o
-    const string out_dir = this->out_path_ + op_out_path + this->target_name_;
-    const string dst = out_dir + "/kernel.cpp";
-    // Assume kernel_in_path is absolute and test if it exists, if it doesn't exist then assume
-    // it's relative to TT_METAL_HOME.
-    const string src = fs::exists(kernel_in_path) ? kernel_in_path : env_.get_root_path() + kernel_in_path;
-    fs::copy(src, dst, fs::copy_options::overwrite_existing);
-}
-
-void JitBuildDataMovement::pre_compile(const string& kernel_in_path, const string& op_out_path) const {
-    copy_kernel(kernel_in_path, op_out_path);
-}
-
-void JitBuildEthernet::pre_compile(const string& kernel_in_path, const string& op_out_path) const {
-    copy_kernel(kernel_in_path, op_out_path);
-}
-
 void JitBuildState::compile_one(
     const string& log_file,
     const string& out_dir,

--- a/tt_metal/jit_build/build.hpp
+++ b/tt_metal/jit_build/build.hpp
@@ -133,7 +133,6 @@ class JitBuildDataMovement : public JitBuildState {
 
   public:
     JitBuildDataMovement(const JitBuildEnv& env, int which, bool is_fw = false);
-    void pre_compile(const string& kernel_in_path, const string& op_out_path) const;
 };
 
 class JitBuildCompute : public JitBuildState {
@@ -146,7 +145,6 @@ class JitBuildEthernet : public JitBuildState {
   private:
   public:
     JitBuildEthernet(const JitBuildEnv& env, int which, bool is_fw = false);
-    void pre_compile(const string& kernel_in_path, const string& op_out_path) const;
 };
 
 // Abstract base class for kernel specialization

--- a/tt_metal/jit_build/genfiles.hpp
+++ b/tt_metal/jit_build/genfiles.hpp
@@ -15,6 +15,8 @@ class JitBuildEnv;
 class JitBuildSettings;
 class JitBuildOptions;
 
+void jit_build_genfiles_kernel_include(
+    const JitBuildEnv& env, const JitBuildSettings& settings, const string& input_hlk_file_path);
 void jit_build_genfiles_triscs_src(const JitBuildEnv& env,
                                    const JitBuildSettings& settings,
                                    const std::string& kernel_in_path);


### PR DESCRIPTION
Quick fix for absolute/relative-to-cwd paths not working for compute kernels. Previous implementation added this for data movement/eth kernels, but compute kernels had a different code path.

CI running: https://github.com/tenstorrent/tt-metal/actions/runs/9553695616
