### PR TITLE
#9500: Update eth_interface include in tt_cluster to not be hardcoded for WH

### DIFF
--- a/tt_metal/hw/inc/blackhole/eth_interface.h
+++ b/tt_metal/hw/inc/blackhole/eth_interface.h
@@ -1,0 +1,7 @@
+// SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include "tt_metal/third_party/umd/src/firmware/riscv/blackhole/eth_interface.h"

--- a/tt_metal/hw/inc/grayskull/eth_interface.h
+++ b/tt_metal/hw/inc/grayskull/eth_interface.h
@@ -1,0 +1,24 @@
+// SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+const uint32_t ETH_RACK_COORD_WIDTH = 0;
+const uint32_t CMD_BUF_SIZE_MASK = 0;
+const uint32_t MAX_BLOCK_SIZE = 0;
+const uint32_t REQUEST_CMD_QUEUE_BASE = 0;
+const uint32_t RESPONSE_CMD_QUEUE_BASE = 0;
+const uint32_t CMD_COUNTERS_SIZE_BYTES = 0;
+const uint32_t REMOTE_UPDATE_PTR_SIZE_BYTES = 0;
+const uint32_t CMD_DATA_BLOCK = 0;
+const uint32_t CMD_WR_REQ = 0;
+const uint32_t CMD_WR_ACK = 0;
+const uint32_t CMD_RD_REQ = 0;
+const uint32_t CMD_RD_DATA = 0;
+const uint32_t CMD_BUF_SIZE = 0;
+const uint32_t CMD_DATA_BLOCK_DRAM = 0;
+const uint32_t ETH_ROUTING_DATA_BUFFER_ADDR = 0;
+const uint32_t REQUEST_ROUTING_CMD_QUEUE_BASE = 0;
+const uint32_t RESPONSE_ROUTING_CMD_QUEUE_BASE = 0;
+const uint32_t CMD_BUF_PTR_MASK = 0;

--- a/tt_metal/hw/inc/wormhole/eth_interface.h
+++ b/tt_metal/hw/inc/wormhole/eth_interface.h
@@ -1,0 +1,7 @@
+// SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include "tt_metal/third_party/umd/src/firmware/riscv/wormhole/eth_interface.h"

--- a/tt_metal/llrt/tt_cluster.hpp
+++ b/tt_metal/llrt/tt_cluster.hpp
@@ -17,14 +17,10 @@
 #include "tt_metal/third_party/umd/device/tt_cluster_descriptor.h"
 #include "tt_metal/third_party/umd/device/tt_xy_pair.h"
 
-// XXXX
-// TODO(PGK): including wormhole in grayskull build is dangerous
-// Include noc/noc_parameters.h here so that including it from wormhole
-// doesn't pull in the wrong file!
 // clang-format off
 #include "dev_mem_map.h"
 #include "noc/noc_parameters.h"
-#include "tt_metal/third_party/umd/src/firmware/riscv/wormhole/eth_interface.h"
+#include "eth_interface.h"
 #include "dev_msgs.h"
 // clang-format on
 


### PR DESCRIPTION
### Ticket
- https://github.com/tenstorrent/tt-metal/issues/9500

### Problem description
- eth_interface include in tt_cluster was hardcoded to WH eth_interface from UMD

### What's changed
- Add arch specific eth_interface.h headers in `hw/inc/<arch>/` and include arch specific eth_interface from UMD in each
- Set eth interface needed to init UMD for GS to 0 

### Checklist
- [ ] Post commit CI 
- [ ] Model regression CI 
