### PR TITLE
Add fused layernorm to falcon40b

### DIFF
--- a/models/demos/t3000/falcon40b/scripts/get_falcon40b_perf_numbers.sh
+++ b/models/demos/t3000/falcon40b/scripts/get_falcon40b_perf_numbers.sh
@@ -5,12 +5,13 @@
 # SPDX-License-Identifier: Apache-2.0
 
 # This script runs the performance tests for the falcon40b model with different sequence lengths
+
 seq_lens=(128 2048)
 
-dtype="BFLOAT8_B" #BFLOAT16
+# iterate over config in configs
 
 for seq_len in ${seq_lens[@]}; do
-    echo "Running seq_len: $seq_len"
+    echo "Running seq length: $seq_len"
     output_folder="generated/profiler/reports/"
     WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml python3 -m tracy -r -m "pytest models/demos/t3000/falcon40b/tests/test_perf_falcon.py::test_perf_bare_metal[${dtype}-DRAM-falcon_40b-layers_1-prefill_seq${seq_len}-8chips]"
     # get latest folder in output folder
@@ -18,7 +19,7 @@ for seq_len in ${seq_lens[@]}; do
     # find csv file that starts with "ops_perf_results"
     csv_file=$(find $latest_created_folder -name "ops_perf_results*.csv")
     # create output summary file from csv file
-    output_perf_filename="${csv_file%.*}_seq_len_${seq_len}_summary.csv"
+    output_perf_filename="${csv_file%.*}_seqlen_${seq_len}_summary.csv"
     echo "CSV file: $csv_file"
     echo "Output file: $output_perf_filename"
     python models/demos/t3000/falcon40b/scripts/perf_summary.py --all $csv_file -o $output_perf_filename --remove-warmup -g --num-chips 8 --layers 60 --seq ${seq_len}

--- a/models/demos/t3000/falcon40b/tests/ci/test_falcon_end_to_end_60_layer_t3000_prefill_10_loops.py
+++ b/models/demos/t3000/falcon40b/tests/ci/test_falcon_end_to_end_60_layer_t3000_prefill_10_loops.py
@@ -96,19 +96,19 @@ def test_FalconCausalLM_prefill_end_to_end_t3000_ci_loops_10(
 
     if data_type == "BFLOAT8_B":
         if seq_len == 32:
-            out_pcc = 0.983
-            k_cache_pcc = 0.982
-            v_cache_pcc = 0.949
+            out_pcc = 0.984
+            k_cache_pcc = 0.979
+            v_cache_pcc = 0.940
             token_pcc = 0.99
         elif seq_len == 128:
-            out_pcc = 0.990
+            out_pcc = 0.989
             k_cache_pcc = 0.989
-            v_cache_pcc = 0.950
+            v_cache_pcc = 0.949
             token_pcc = 0.99
         elif seq_len == 2048:
             out_pcc = 0.993
             k_cache_pcc = 0.991
-            v_cache_pcc = 0.972
+            v_cache_pcc = 0.97
             token_pcc = 0.99
     elif data_type == "BFLOAT16":
         if seq_len == 32:

--- a/models/demos/t3000/falcon40b/tests/ops/test_fused_falcon_layernorm.py
+++ b/models/demos/t3000/falcon40b/tests/ops/test_fused_falcon_layernorm.py
@@ -1,0 +1,168 @@
+# SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+
+# SPDX-License-Identifier: Apache-2.0
+
+import torch
+import pytest
+import math
+from loguru import logger
+
+import tt_lib as ttl
+import ttnn
+from models.demos.t3000.falcon40b.tt.ops.fused_layernorm import TtFusedFalconLayernorm
+from tests.tt_eager.python_api_testing.sweep_tests.comparison_funcs import (
+    comp_pcc,
+)
+from models.utility_functions import torch2tt_tensor, tt2torch_tensor, skip_for_grayskull, get_devices_for_t3000
+from models.demos.t3000.falcon40b.tt.model_config import (
+    get_model_config,
+)
+
+from models.demos.t3000.falcon40b.reference.hf_modeling_falcon import (
+    FalconForCausalLM,
+)
+
+from models.demos.t3000.falcon40b.tt.model_utils import (
+    convert_to_layout,
+)
+
+
+class PytorchFusedLayernorm(torch.nn.Module):
+    def __init__(self, hf_reference_model, layer_num=0):
+        super().__init__()
+        self.ln_attn = hf_reference_model.transformer.h[layer_num].ln_attn
+        self.ln_mlp = hf_reference_model.transformer.h[layer_num].ln_mlp
+
+        self.ln_attn.eval()
+        self.ln_mlp.eval()
+
+    def forward(self, x):
+        result1 = self.ln_attn(x)
+        # result1 = x * self.ln_attn.weight
+        result2 = self.ln_mlp(x)
+        # result2 = x
+        return result1, result2
+
+
+def run_test_FalconLayernorm_inference(pcc, devices, model_location_generator, get_tt_cache_path):
+    seqlen = 1024
+    num_chips = 8
+
+    # Prepare input
+    torch.manual_seed(0)
+    model_input_shape = [1, seqlen]
+
+    model_version = "tiiuae/falcon-40b-instruct"
+
+    model_config = get_model_config(
+        "BFLOAT8_B-DRAM", "prefill", model_input_shape, num_chips
+    )  # Block sharding for layernorm to work around PCC issue
+
+    tt_cache_path = get_tt_cache_path(
+        model_version, model_subdir="Falcon", default_dir=model_config["DEFAULT_CACHE_PATH"]
+    )
+
+    model_name = model_location_generator(model_version, model_subdir="Falcon")
+
+    hugging_face_reference_model = FalconForCausalLM.from_pretrained(
+        model_name, low_cpu_mem_usage=True, num_hidden_layers=1
+    )
+    hugging_face_reference_model.eval()
+    config = hugging_face_reference_model.config
+    gamma1 = hugging_face_reference_model.transformer.h[0].ln_attn.weight
+    beta1 = hugging_face_reference_model.transformer.h[0].ln_attn.bias
+    gamma2 = hugging_face_reference_model.transformer.h[0].ln_mlp.weight
+    beta2 = hugging_face_reference_model.transformer.h[0].ln_mlp.bias
+
+    H = config.hidden_size  # H = 8192
+
+    input_shape = [1, 1, seqlen, H]
+
+    input_torch = (torch.rand(input_shape) * 2) - 1
+    input = torch2tt_tensor(
+        input_torch, None, tt_dtype=ttl.tensor.DataType.BFLOAT16
+    )  # tt_dtype=ttl.tensor.DataType.BFLOAT16  # ttl.tensor.DataType.BFLOAT8_B
+    input = input.to(devices[0], model_config["DEFAULT_MEMCFG"])
+
+    # block sharded hardcoded for S=128 and 8x4 grid of cores
+    shard_spec_cores_grid = ttl.tensor.CoreRangeSet(
+        {
+            ttl.tensor.CoreRange(
+                ttl.tensor.CoreCoord(0, 0),
+                ttl.tensor.CoreCoord(7, 7),
+            ),
+        }
+    )
+    block_sharded_memconfig = ttl.tensor.MemoryConfig(
+        ttl.tensor.TensorMemoryLayout.BLOCK_SHARDED,
+        ttl.tensor.BufferType.L1,
+        ttl.tensor.ShardSpec(
+            shard_spec_cores_grid,
+            [
+                seqlen // 8,
+                H // 8,
+            ],
+            ttl.tensor.ShardOrientation.ROW_MAJOR,
+            False,
+        ),
+    )
+    # width_sharded_memconfig = ttl.tensor.MemoryConfig(
+    #     ttl.tensor.TensorMemoryLayout.WIDTH_SHARDED,
+    #     ttl.tensor.BufferType.L1,
+    #     ttl.tensor.ShardSpec(
+    #         shard_spec_cores_grid,
+    #         [
+    #             seqlen,
+    #             H // 64,
+    #         ],
+    #         ttl.tensor.ShardOrientation.ROW_MAJOR,
+    #         False,
+    #     ),
+    # )
+    input = ttl.tensor.interleaved_to_sharded(input, sharded_mem_config=block_sharded_memconfig)
+
+    # PyTorch output --------------------------------------------------------------------
+    pytorch_FalconLayernorm_model = PytorchFusedLayernorm(hugging_face_reference_model)
+    torch_out1, torch_out2 = pytorch_FalconLayernorm_model(input_torch)
+
+    # TT hardware execution -------------------------------------------------------------
+
+    tt_Falcon_layernorm_model = TtFusedFalconLayernorm(
+        devices[0], gamma1, beta1, gamma2, beta2, model_config, config, tt_cache_path
+    )
+    tt_out1, tt_out2 = tt_Falcon_layernorm_model(input)
+
+    tt_out1 = tt2torch_tensor(tt_out1)
+    tt_out2 = tt2torch_tensor(tt_out2)
+
+    # check outputs ----------------------------------------------------------------------
+    does_pass, output_pcc1 = comp_pcc(torch_out1, tt_out1, pcc)
+    logger.info(f"PCC value: {output_pcc1}")
+
+    if does_pass:
+        logger.info("Layernorm output 1 Passed!")
+    else:
+        logger.warning("Layernorm output 1 Failed!")
+        assert does_pass, f"PCC value is lower than {pcc}"
+
+    does_pass, output_pcc2 = comp_pcc(torch_out2, tt_out2, pcc)
+    logger.info(f"PCC value: {output_pcc2}")
+
+    if does_pass:
+        logger.info("Layernorm output 2 Passed!")
+    else:
+        logger.warning("Layernorm output 2 Failed!")
+        assert does_pass, f"PCC value is lower than {pcc}"
+
+
+@skip_for_grayskull("Requires eth connected devices to run")
+@pytest.mark.parametrize("pcc", [(0.99)])
+def test_FalconLayernorm_inference(
+    pcc,
+    all_devices,
+    model_location_generator,
+    get_tt_cache_path,
+):
+    devices = all_devices
+
+    run_test_FalconLayernorm_inference(pcc, devices, model_location_generator, get_tt_cache_path)

--- a/models/demos/t3000/falcon40b/tests/test_falcon_end_to_end.py
+++ b/models/demos/t3000/falcon40b/tests/test_falcon_end_to_end.py
@@ -425,10 +425,11 @@ def run_test_FalconCausalLM_end_to_end(
     "num_layers",
     (
         1,
+        4,
         12,
         60,
     ),
-    ids=["layers_1", "layers_12", "layers_60"],
+    ids=["layers_1", "layers_4", "layers_12", "layers_60"],
 )
 @pytest.mark.parametrize(
     "model_version",
@@ -483,19 +484,19 @@ def test_FalconCausalLM_end_to_end_with_program_cache(
         if num_layers == 60:
             if data_type == "BFLOAT8_B":
                 if seq_len == 32:
-                    out_pcc = 0.983
-                    k_cache_pcc = 0.982
-                    v_cache_pcc = 0.949
+                    out_pcc = 0.984
+                    k_cache_pcc = 0.979
+                    v_cache_pcc = 0.940
                     token_pcc = 0.99
                 elif seq_len == 128:
-                    out_pcc = 0.990
+                    out_pcc = 0.989
                     k_cache_pcc = 0.989
-                    v_cache_pcc = 0.950
+                    v_cache_pcc = 0.949
                     token_pcc = 0.99
                 elif seq_len == 2048:
                     out_pcc = 0.993
                     k_cache_pcc = 0.991
-                    v_cache_pcc = 0.972
+                    v_cache_pcc = 0.97
                     token_pcc = 0.99
             elif data_type == "BFLOAT16":
                 if seq_len == 32:

--- a/models/demos/t3000/falcon40b/tests/test_perf_falcon.py
+++ b/models/demos/t3000/falcon40b/tests/test_perf_falcon.py
@@ -235,6 +235,8 @@ def run_test_FalconCausalLM_end_to_end(
         ttnn.device.synchronize_device(device)
 
     # Run for perf iteration - profiler enabled
+    for device in devices:
+        tt_lib.device.DumpDeviceProfiler(device)
     profiler.enable()
     enable_persistent_kernel_cache()
     logger.info(f"Enable profiler and enable binary and compile cache")
@@ -334,6 +336,8 @@ def run_test_FalconCausalLM_end_to_end(
         ("prefill", 1, 128, 0, 60, 0.46 + 0.04, 60, "BFLOAT16-DRAM"),
         ("prefill", 1, 2048, 0, 60, 1.18 + 0.1, 60, "BFLOAT16-DRAM"),
         ("decode", 32, 1, 128, 60, 0.21 + 0.02, 60, "BFLOAT8_B-SHARDED"),
+        ("prefill", 1, 128, 0, 60, 0.0099 + 0.002, 1, "BFLOAT8_B-DRAM"),
+        ("prefill", 1, 2048, 0, 60, 0.0393 + 0.02, 1, "BFLOAT8_B-DRAM"),
     ),
     ids=[
         "prefill_seq32_bfp8",
@@ -343,6 +347,8 @@ def run_test_FalconCausalLM_end_to_end(
         "prefill_seq128_fp16",
         "prefill_seq2048_fp16",
         "decode_batch32",
+        "prefill_seq128_bfp8_layers_1",
+        "prefill_seq2048_bfp8_layers_1",
     ],
 )
 @pytest.mark.parametrize(

--- a/models/demos/t3000/falcon40b/tt/model_config.py
+++ b/models/demos/t3000/falcon40b/tt/model_config.py
@@ -750,7 +750,7 @@ def get_prefill_model_config(model_config_str, input_shape, num_devices):
     layernorm_num_cores_x = 8
     layernorm_max_num_cores_y = 8
 
-    layernorm_slice_size = 512
+    layernorm_slice_size = 1024
     attention_max_slice_size = 1024
     attention_slice_size = min(attention_max_slice_size, row_height)
     assert row_height % attention_slice_size == 0

--- a/models/demos/t3000/falcon40b/tt/ops/falcon_layernorm.py
+++ b/models/demos/t3000/falcon40b/tt/ops/falcon_layernorm.py
@@ -170,7 +170,7 @@ class TtFalconLayernorm:
             #     self.layernorm_eps,
             #     self.ln_attn_gamma[0],
             #     self.ln_attn_beta[0],
-            #     program_config=ttnn.experimental.operations.primary.LayerNormInterleavedMultiCoreProgramConfig(
+            #     program_config=ttnn.LayerNormInterleavedMultiCoreProgramConfig(
             #         math_fidelity=ttnn.experimental.tensor.MathFidelity.HiFi4,
             #         im_data_format=ttnn.experimental.tensor.DataType.BFLOAT16,
             #         out_data_format=ttnn.experimental.tensor.DataType.BFLOAT8_B,

--- a/models/demos/t3000/falcon40b/tt/ops/fused_layernorm.py
+++ b/models/demos/t3000/falcon40b/tt/ops/fused_layernorm.py
@@ -1,0 +1,306 @@
+# SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+
+# SPDX-License-Identifier: Apache-2.0
+
+import torch
+import math
+from torch import nn
+import tt_lib
+import ttnn
+
+from typing import List
+from models.utility_functions import torch2tt_tensor
+
+
+class TtFusedFalconLayernorm:
+    def __init__(self, device, gamma1, beta1, gamma2, beta2, model_config, config, tt_cache_path):
+        super().__init__()
+
+        gamma_beta_rm = False
+
+        self.model_config = model_config
+
+        layer_name = f"transformer.h.0"
+
+        ln_attn_weights_str = f"{layer_name}.ln_attn.weight"
+        ln_attn_bias_str = f"{layer_name}.ln_attn.bias"
+
+        ln_mlp_weights_str = f"{layer_name}.ln_mlp.weight"
+        ln_mlp_bias_str = f"{layer_name}.ln_mlp.bias"
+
+        if gamma_beta_rm:
+            ln_attn_weights_path = (
+                tt_cache_path
+                / f"{ln_attn_weights_str}_rm_fusedln_{self.model_config['LN_ATTN_WEIGHTS_DTYPE'].name}.bin"
+            )
+            if (ln_attn_weights_path).exists():
+                ln_attn_gamma_host = tt_lib.tensor.load_tensor(str(ln_attn_weights_path))
+                self.ln_attn_gamma = ln_attn_gamma_host.to(device, self.model_config["LN_ATTN_WEIGHTS_MEMCFG"])
+            else:
+                ln_attn_gamma_host = tt_lib.tensor.Tensor(
+                    gamma1.reshape([1, 1, 1, -1]),
+                    self.model_config["LN_ATTN_WEIGHTS_DTYPE"],
+                )
+                self.ln_attn_gamma = ln_attn_gamma_host.to(device, self.model_config["LN_ATTN_WEIGHTS_MEMCFG"])
+                tt_lib.tensor.dump_tensor(
+                    str(ln_attn_weights_path),
+                    ln_attn_gamma_host,
+                )
+
+            ln_attn_bias_path = (
+                tt_cache_path / f"{ln_attn_bias_str}_rm_fusedln_{self.model_config['LN_ATTN_BIAS_DTYPE'].name}.bin"
+            )
+            if (ln_attn_bias_path).exists():
+                ln_attn_beta_host = tt_lib.tensor.load_tensor(str(ln_attn_bias_path))
+                self.ln_attn_beta = ln_attn_beta_host.to(device, self.model_config["LN_ATTN_BIAS_MEMCFG"])
+            else:
+                ln_attn_beta_host = tt_lib.tensor.Tensor(
+                    beta1.reshape([1, 1, 1, -1]),
+                    self.model_config["LN_ATTN_BIAS_DTYPE"],
+                )
+                self.ln_attn_beta = ln_attn_beta_host.to(device, self.model_config["LN_ATTN_BIAS_MEMCFG"])
+                tt_lib.tensor.dump_tensor(
+                    str(ln_attn_bias_path),
+                    ln_attn_beta_host,
+                )
+
+            ln_mlp_weights_path = (
+                tt_cache_path / f"{ln_mlp_weights_str}_rm_fusedln_{self.model_config['LN_MLP_WEIGHTS_DTYPE'].name}.bin"
+            )
+            if (ln_mlp_weights_path).exists():
+                ln_mlp_gamma_host = tt_lib.tensor.load_tensor(str(ln_mlp_weights_path))
+                self.ln_mlp_gamma = ln_mlp_gamma_host.to(device, self.model_config["LN_MLP_WEIGHTS_MEMCFG"])
+            else:
+                ln_mlp_gamma_host = tt_lib.tensor.Tensor(
+                    gamma2.reshape([1, 1, 1, -1]),
+                    self.model_config["LN_MLP_WEIGHTS_DTYPE"],
+                )
+                self.ln_mlp_gamma = ln_mlp_gamma_host.to(device, self.model_config["LN_MLP_WEIGHTS_MEMCFG"])
+                tt_lib.tensor.dump_tensor(
+                    str(ln_mlp_weights_path),
+                    ln_mlp_gamma_host,
+                )
+
+            ln_mlp_bias_path = (
+                tt_cache_path / f"{ln_mlp_bias_str}_rm_fusedln_{self.model_config['LN_MLP_BIAS_DTYPE'].name}.bin"
+            )
+            if (ln_mlp_bias_path).exists():
+                ln_mlp_beta_host = tt_lib.tensor.load_tensor(str(ln_mlp_bias_path))
+                self.ln_mlp_beta = ln_mlp_beta_host.to(device, self.model_config["LN_MLP_BIAS_MEMCFG"])
+            else:
+                ln_mlp_beta_host = tt_lib.tensor.Tensor(
+                    beta2.reshape([1, 1, 1, -1]),
+                    self.model_config["LN_MLP_BIAS_DTYPE"],
+                )
+                self.ln_mlp_beta = ln_mlp_beta_host.to(device, self.model_config["LN_MLP_BIAS_MEMCFG"])
+                tt_lib.tensor.dump_tensor(
+                    str(ln_mlp_bias_path),
+                    ln_mlp_beta_host,
+                )
+        else:
+            ln_attn_weights_path = (
+                tt_cache_path
+                / f"{ln_attn_weights_str}_tilized_fusedln_{self.model_config['LN_ATTN_WEIGHTS_DTYPE'].name}.bin"
+            )
+            if (ln_attn_weights_path).exists():
+                ln_attn_gamma_host = ttnn.experimental.tensor.load_tensor(str(ln_attn_weights_path))
+                self.ln_attn_gamma = ln_attn_gamma_host.to(device, self.model_config["LN_ATTN_WEIGHTS_MEMCFG"])
+            else:
+                ln_attn_gamma_torch = gamma1.reshape(1, 1, 1, -1)
+                ln_attn_gamma_torch_padded = torch.cat(
+                    [ln_attn_gamma_torch, torch.zeros(1, 1, 31, ln_attn_gamma_torch.shape[-1])], dim=2
+                )
+                ln_attn_gamma_host = torch2tt_tensor(
+                    ln_attn_gamma_torch_padded,
+                    None,
+                    tt_layout=ttnn.experimental.tensor.Layout.TILE,
+                    tt_memory_config=self.model_config["LN_ATTN_WEIGHTS_MEMCFG"],
+                    tt_dtype=self.model_config["LN_ATTN_WEIGHTS_DTYPE"],
+                )
+                self.ln_attn_gamma = ln_attn_gamma_host.to(device, self.model_config["LN_ATTN_WEIGHTS_MEMCFG"])
+                ttnn.experimental.tensor.dump_tensor(
+                    str(ln_attn_weights_path),
+                    ln_attn_gamma_host,
+                )
+
+            ln_attn_bias_path = (
+                tt_cache_path / f"{ln_attn_bias_str}_tilized_fusedln_{self.model_config['LN_ATTN_BIAS_DTYPE'].name}.bin"
+            )
+            if (ln_attn_bias_path).exists():
+                ln_attn_beta_host = ttnn.experimental.tensor.load_tensor(str(ln_attn_bias_path))
+                self.ln_attn_beta = ln_attn_beta_host.to(device, self.model_config["LN_ATTN_BIAS_MEMCFG"])
+            else:
+                ln_attn_beta_torch = beta1.reshape(1, 1, 1, -1)
+                ln_attn_beta_torch_padded = torch.cat(
+                    [ln_attn_beta_torch, torch.zeros(1, 1, 31, ln_attn_beta_torch.shape[-1])], dim=2
+                )
+                ln_attn_beta_host = torch2tt_tensor(
+                    ln_attn_beta_torch_padded,
+                    None,
+                    tt_layout=ttnn.experimental.tensor.Layout.TILE,
+                    tt_memory_config=self.model_config["LN_ATTN_BIAS_MEMCFG"],
+                    tt_dtype=self.model_config["LN_ATTN_BIAS_DTYPE"],
+                )
+                self.ln_attn_beta = ln_attn_beta_host.to(device, self.model_config["LN_ATTN_BIAS_MEMCFG"])
+                ttnn.experimental.tensor.dump_tensor(
+                    str(ln_attn_bias_path),
+                    ln_attn_beta_host,
+                )
+
+            ln_mlp_weights_path = (
+                tt_cache_path
+                / f"{ln_mlp_weights_str}_tilized_fusedln_{self.model_config['LN_MLP_WEIGHTS_DTYPE'].name}.bin"
+            )
+            if (ln_mlp_weights_path).exists():
+                ln_mlp_gamma_host = ttnn.experimental.tensor.load_tensor(str(ln_mlp_weights_path))
+                self.ln_mlp_gamma = ln_mlp_gamma_host.to(device, self.model_config["LN_MLP_WEIGHTS_MEMCFG"])
+            else:
+                ln_mlp_gamma_torch = gamma2.reshape(1, 1, 1, -1)
+                ln_mlp_gamma_torch_padded = torch.cat(
+                    [ln_mlp_gamma_torch, torch.zeros(1, 1, 31, ln_mlp_gamma_torch.shape[-1])], dim=2
+                )
+                ln_mlp_gamma_host = torch2tt_tensor(
+                    ln_mlp_gamma_torch_padded,
+                    None,
+                    tt_layout=ttnn.experimental.tensor.Layout.TILE,
+                    tt_memory_config=self.model_config["LN_MLP_WEIGHTS_MEMCFG"],
+                    tt_dtype=self.model_config["LN_MLP_WEIGHTS_DTYPE"],
+                )
+                self.ln_mlp_gamma = ln_mlp_gamma_host.to(device, self.model_config["LN_MLP_WEIGHTS_MEMCFG"])
+                ttnn.experimental.tensor.dump_tensor(
+                    str(ln_mlp_weights_path),
+                    ln_mlp_gamma_host,
+                )
+
+            ln_mlp_bias_path = (
+                tt_cache_path / f"{ln_mlp_bias_str}_tilized_fusedln_{self.model_config['LN_MLP_BIAS_DTYPE'].name}.bin"
+            )
+            if (ln_mlp_bias_path).exists():
+                ln_mlp_beta_host = ttnn.experimental.tensor.load_tensor(str(ln_mlp_bias_path))
+                self.ln_mlp_beta = ln_mlp_beta_host.to(device, self.model_config["LN_MLP_BIAS_MEMCFG"])
+            else:
+                ln_mlp_beta_torch = beta2.reshape(1, 1, 1, -1)
+                ln_mlp_beta_torch_padded = torch.cat(
+                    [ln_mlp_beta_torch, torch.zeros(1, 1, 31, ln_mlp_beta_torch.shape[-1])], dim=2
+                )
+                ln_mlp_beta_host = torch2tt_tensor(
+                    ln_mlp_beta_torch_padded,
+                    None,
+                    tt_layout=ttnn.experimental.tensor.Layout.TILE,
+                    tt_memory_config=self.model_config["LN_MLP_BIAS_MEMCFG"],
+                    tt_dtype=self.model_config["LN_MLP_BIAS_DTYPE"],
+                )
+                self.ln_mlp_beta = ln_mlp_beta_host.to(device, self.model_config["LN_MLP_BIAS_MEMCFG"])
+                ttnn.experimental.tensor.dump_tensor(
+                    str(ln_mlp_bias_path),
+                    ln_mlp_beta_host,
+                )
+
+        self.layernorm_eps = config.layer_norm_epsilon
+
+        shard_spec_cores_grid = ttnn.experimental.tensor.CoreRangeSet(
+            {
+                ttnn.experimental.tensor.CoreRange(
+                    ttnn.experimental.tensor.CoreCoord(0, 0),
+                    ttnn.experimental.tensor.CoreCoord(7, 7),
+                ),
+            }
+        )
+        H = config.hidden_size  # 8192
+        self.sharded_memconfig = ttnn.experimental.tensor.MemoryConfig(
+            ttnn.experimental.tensor.TensorMemoryLayout.BLOCK_SHARDED,
+            ttnn.experimental.tensor.BufferType.L1,
+            ttnn.experimental.tensor.ShardSpec(
+                shard_spec_cores_grid,
+                [self.model_config["SEQ_LEN"] // 8, H // 8],  # 1024
+                ttnn.experimental.tensor.ShardOrientation.ROW_MAJOR,
+                False,
+            ),
+        )
+        self.width_sharded_memconfig = ttnn.experimental.tensor.MemoryConfig(
+            ttnn.experimental.tensor.TensorMemoryLayout.WIDTH_SHARDED,
+            ttnn.experimental.tensor.BufferType.L1,
+            ttnn.experimental.tensor.ShardSpec(
+                shard_spec_cores_grid,
+                [
+                    self.model_config["SEQ_LEN"],
+                    H // 64,
+                ],
+                ttnn.experimental.tensor.ShardOrientation.ROW_MAJOR,
+                False,
+            ),
+        )
+
+        self.prg_config = ttnn.LayerNormShardedMultiCoreProgramConfig(
+            compute_with_storage_grid_size=[8, 8],
+            subblock_w=min(8, H // 8),
+            block_h=self.model_config["SEQ_LEN"] // 32 // 8,
+            block_w=H // 32 // 8,
+            inplace=False,
+        )
+
+        self.interleaved_memconfig = ttnn.experimental.tensor.MemoryConfig(
+            ttnn.experimental.tensor.TensorMemoryLayout.INTERLEAVED,
+            ttnn.experimental.tensor.BufferType.L1,
+        )
+
+    def __call__(self, x: ttnn.experimental.tensor.Tensor) -> ttnn.experimental.tensor.Tensor:
+        # # OG layernorm
+        # out1 = ttnn.layer_norm(
+        #     x, epsilon=self.layernorm_eps, weight=self.ln_attn_gamma, bias=self.ln_attn_beta, memory_config=self.sharded_memconfig, program_config=self.prg_config
+        # )
+        # out2 = ttnn.layer_norm(
+        #     x, epsilon=self.layernorm_eps, weight=self.ln_mlp_gamma, bias=self.ln_mlp_beta, memory_config=self.sharded_memconfig, program_config=self.prg_config
+        # )
+
+        # all block sharded
+        out2 = ttnn.layer_norm(
+            x,
+            epsilon=self.layernorm_eps,
+            weight=None,
+            bias=None,
+            memory_config=self.sharded_memconfig,
+            program_config=self.prg_config,
+        )
+
+        out1 = ttnn.experimental.tensor.bcast(
+            out2,
+            self.ln_attn_gamma,
+            math_op=ttnn.experimental.tensor.BcastOpMath.MUL,
+            dim=ttnn.experimental.tensor.BcastOpDim.H,
+            output_mem_config=self.sharded_memconfig,
+        )
+        out1 = ttnn.experimental.tensor.bcast(
+            out1,
+            self.ln_attn_beta,
+            math_op=ttnn.experimental.tensor.BcastOpMath.ADD,
+            dim=ttnn.experimental.tensor.BcastOpDim.H,
+            output_mem_config=self.sharded_memconfig,
+        )
+
+        out2 = ttnn.experimental.tensor.bcast(
+            out2,
+            self.ln_mlp_gamma,
+            math_op=ttnn.experimental.tensor.BcastOpMath.MUL,
+            dim=ttnn.experimental.tensor.BcastOpDim.H,
+            output_mem_config=self.sharded_memconfig,
+        )
+        out2 = ttnn.experimental.tensor.bcast(
+            out2,
+            self.ln_mlp_beta,
+            math_op=ttnn.experimental.tensor.BcastOpMath.ADD,
+            dim=ttnn.experimental.tensor.BcastOpDim.H,
+            output_mem_config=self.sharded_memconfig,
+        )
+
+        # # Testing bcast only
+        # out1 = ttnn.experimental.tensor.bcast(
+        #     x,
+        #     self.ln_attn_gamma,
+        #     math_op=ttnn.experimental.tensor.BcastOpMath.MUL,
+        #     dim=ttnn.experimental.tensor.BcastOpDim.H,
+        #     output_mem_config=self.sharded_memconfig,
+        # )
+        # out2 = x
+
+        return out1, out2


### PR DESCRIPTION
- Add fused partial layernorm to model_utils
- Use for decoder layernorms in falcon40b
- Add op test for fused layernorm

Pipelines
- [x] Unit tests: https://github.com/tenstorrent/tt-metal/actions/runs/9969851706/job/27548213214
- [x] Frequent tests: https://github.com/tenstorrent/tt-metal/actions/runs/9970385387
- [x] Demo tests: https://github.com/tenstorrent/tt-metal/actions/runs/9970378130

Perf
S=128
device: 1456 -> 1491 tok/sec
e2e: 308 -> 310 tok/sec

S=2048
device: 2857 -> 2936  tok/sec
e2e: 2415 -> 2562 tok/sec