### PR TITLE
[Mixtral] Reverted output dtype of ttnn.eq()

### DIFF
--- a/models/demos/t3000/mixtral8x7b/tt/mixtral_moe.py
+++ b/models/demos/t3000/mixtral8x7b/tt/mixtral_moe.py
@@ -99,7 +99,7 @@ class TtMoeLayer(LightweightModule):
         gate_logits_1SB8 = ttnn.add(gate_logits_1SB8, self.top8_mask_11B_64)
         ttl_topk_values, ttl_topk_indices = ttnn.experimental.operations.primary.topk(gate_logits_1SB8, 32)
         ttl_topk_values = ttnn.add(ttl_topk_values, self.top2_mask_11BB)
-        mask_B2 = ttnn.eq(self.expert_mask_11BB, ttl_topk_indices, dtype=ttnn.bfloat16)
+        mask_B2 = ttnn.eq(self.expert_mask_11BB, ttl_topk_indices)
         weights_1SB1 = ttnn.sum(ttnn.softmax(ttl_topk_values, dim=-1) * mask_B2, dim=3)
 
         # MLP and masking


### PR DESCRIPTION
This fixes issue https://github.com/tenstorrent/tt-metal/issues/9480

The change of output dtype on the `ttnn.eq` op used in the MoE layer came due to a regression during the continuous work on typecast. 

With a recent commit https://github.com/tenstorrent/tt-metal/commit/e12b6001dfa2b29118f5c2517075384829ffeb43 we have to revert the change we made to restore accuracy to Mixtral.

The accuracy of the Mixtral decoder test dropped to a PCC of 0.37. With this PR it goes back to 0.99+