### PR TITLE
#9486: Replace ttl.tensor.all_gather with ttnn.all_gather

### DIFF
--- a/models/demos/t3000/falcon40b/tt/falcon_attention.py
+++ b/models/demos/t3000/falcon40b/tt/falcon_attention.py
@@ -517,7 +517,7 @@ class TtFalconAttention:
                 output_mem_config=self.model_config["CONCAT_HEADS_OUTPUT_MEMCFG"],
             )
 
-        attn_output = ttnn.experimental.tensor.all_gather(
+        attn_output = ttnn.all_gather(
             attn_output,
             dim=3,
             num_links=self.model_config["ALL_GATHER_NUM_LINKS"],
@@ -807,7 +807,7 @@ class TtFalconAttention:
                 attn_output[i], output_mem_config=self.model_config["DEFAULT_MEMCFG"]
             )
 
-        attn_output = ttnn.experimental.tensor.all_gather(
+        attn_output = ttnn.all_gather(
             attn_output,
             dim=3,
             num_links=self.model_config["ALL_GATHER_NUM_LINKS"],

--- a/models/demos/t3000/falcon40b/tt/falcon_attention.py
+++ b/models/demos/t3000/falcon40b/tt/falcon_attention.py
@@ -521,7 +521,7 @@ class TtFalconAttention:
             attn_output,
             dim=3,
             num_links=self.model_config["ALL_GATHER_NUM_LINKS"],
-            output_mem_config=self.model_config["DEFAULT_MEMCFG"],
+            memory_config=self.model_config["DEFAULT_MEMCFG"],
         )
 
         for i in range(len(attn_output)):
@@ -811,7 +811,7 @@ class TtFalconAttention:
             attn_output,
             dim=3,
             num_links=self.model_config["ALL_GATHER_NUM_LINKS"],
-            output_mem_config=self.model_config["DEFAULT_MEMCFG"],
+            memory_config=self.model_config["DEFAULT_MEMCFG"],
         )
 
         for i in range(len(attn_output)):

--- a/models/demos/t3000/falcon40b/tt/falcon_decoder.py
+++ b/models/demos/t3000/falcon40b/tt/falcon_decoder.py
@@ -243,9 +243,9 @@ class TtFalconDecoderLayer:
 
         replicated_hidden_states = ttnn.all_gather(
             replicated_hidden_states,
-            num_links=self.model_config["ALL_GATHER_NUM_LINKS"],
             dim=3,
-            output_mem_config=self.model_config["DEFAULT_MEMCFG"],
+            num_links=self.model_config["ALL_GATHER_NUM_LINKS"],
+            memory_config=self.model_config["DEFAULT_MEMCFG"],
         )
 
         if self.model_config["LN_INPUT_DTYPE"] != self.model_config["BFP8_DTYPE"]:
@@ -364,9 +364,9 @@ class TtFalconDecoderLayer:
             )
         replicated_hidden_states = ttnn.all_gather(
             replicated_hidden_states,
-            num_links=self.model_config["ALL_GATHER_NUM_LINKS"],
             dim=3,
-            output_mem_config=self.model_config["DEFAULT_MEMCFG"],
+            num_links=self.model_config["ALL_GATHER_NUM_LINKS"],
+            memory_config=self.model_config["DEFAULT_MEMCFG"],
         )
         for i in range(len(replicated_hidden_states)):
             replicated_hidden_states[i] = ttnn.experimental.tensor.interleaved_to_sharded(

--- a/models/demos/t3000/falcon40b/tt/falcon_decoder.py
+++ b/models/demos/t3000/falcon40b/tt/falcon_decoder.py
@@ -241,7 +241,7 @@ class TtFalconDecoderLayer:
                     replicated_hidden_states[i], self.model_config["BFP8_DTYPE"]
                 )
 
-        replicated_hidden_states = ttnn.experimental.tensor.all_gather(
+        replicated_hidden_states = ttnn.all_gather(
             replicated_hidden_states,
             num_links=self.model_config["ALL_GATHER_NUM_LINKS"],
             dim=3,
@@ -362,7 +362,7 @@ class TtFalconDecoderLayer:
                     hidden_states[i], output_mem_config=self.model_config["DEFAULT_MEMCFG"]
                 )
             )
-        replicated_hidden_states = ttnn.experimental.tensor.all_gather(
+        replicated_hidden_states = ttnn.all_gather(
             replicated_hidden_states,
             num_links=self.model_config["ALL_GATHER_NUM_LINKS"],
             dim=3,

--- a/models/demos/t3000/falcon40b/tt/falcon_mlp.py
+++ b/models/demos/t3000/falcon40b/tt/falcon_mlp.py
@@ -125,7 +125,7 @@ class TtFalconMLP:
             hidden_states[i] = ttnn.experimental.tensor.sharded_to_interleaved(
                 hidden_states[i], output_mem_config=self.model_config["DEFAULT_MEMCFG"]
             )
-        hidden_states = ttnn.experimental.tensor.all_gather(
+        hidden_states = ttnn.all_gather(
             hidden_states,
             dim=3,
             num_links=self.model_config["ALL_GATHER_NUM_LINKS"],
@@ -169,7 +169,7 @@ class TtFalconMLP:
             if should_deallocate_ln_tensors:
                 x[i].deallocate(True)
 
-        hidden_states = ttnn.experimental.tensor.all_gather(
+        hidden_states = ttnn.all_gather(
             hidden_states,
             dim=3,
             num_links=self.model_config["ALL_GATHER_NUM_LINKS"],

--- a/models/demos/t3000/falcon40b/tt/falcon_mlp.py
+++ b/models/demos/t3000/falcon40b/tt/falcon_mlp.py
@@ -129,7 +129,7 @@ class TtFalconMLP:
             hidden_states,
             dim=3,
             num_links=self.model_config["ALL_GATHER_NUM_LINKS"],
-            output_mem_config=self.model_config["DEFAULT_MEMCFG"],
+            memory_config=self.model_config["DEFAULT_MEMCFG"],
         )
         for i in range(len(hidden_states)):
             hidden_states[i] = ttnn.experimental.tensor.interleaved_to_sharded(
@@ -173,7 +173,7 @@ class TtFalconMLP:
             hidden_states,
             dim=3,
             num_links=self.model_config["ALL_GATHER_NUM_LINKS"],
-            output_mem_config=self.model_config["DEFAULT_MEMCFG"],
+            memory_config=self.model_config["DEFAULT_MEMCFG"],
         )
 
         for i in range(len(hidden_states)):

--- a/models/demos/t3000/falcon40b/tt/falcon_model.py
+++ b/models/demos/t3000/falcon40b/tt/falcon_model.py
@@ -343,7 +343,7 @@ class TtFalconModelShared:
             layer_output,
             dim=3,
             num_links=self.model_config["ALL_GATHER_NUM_LINKS"],
-            output_mem_config=self.model_config["DEFAULT_MEMCFG"],
+            memory_config=self.model_config["DEFAULT_MEMCFG"],
         )
 
         if self.model_config["LN_INPUT_DTYPE"] != self.model_config["BFP8_DTYPE"]:
@@ -403,7 +403,7 @@ class TtFalconModelShared:
             layer_output,
             dim=3,
             num_links=self.model_config["ALL_GATHER_NUM_LINKS"],
-            output_mem_config=self.model_config["DEFAULT_MEMCFG"],
+            memory_config=self.model_config["DEFAULT_MEMCFG"],
         )
         for i in range(len(layer_output)):
             layer_output[i] = ttnn.experimental.tensor.interleaved_to_sharded(

--- a/models/demos/t3000/falcon40b/tt/falcon_model.py
+++ b/models/demos/t3000/falcon40b/tt/falcon_model.py
@@ -339,7 +339,7 @@ class TtFalconModelShared:
             for i in range(len(layer_output)):
                 layer_output[i] = ttnn.experimental.tensor.typecast(layer_output[i], self.model_config["BFP8_DTYPE"])
 
-        layer_output = ttnn.experimental.tensor.all_gather(
+        layer_output = ttnn.all_gather(
             layer_output,
             dim=3,
             num_links=self.model_config["ALL_GATHER_NUM_LINKS"],
@@ -399,7 +399,7 @@ class TtFalconModelShared:
             layer_output[i] = ttnn.experimental.tensor.sharded_to_interleaved(
                 layer_output[i], output_mem_config=self.model_config["DEFAULT_MEMCFG"]
             )
-        layer_output = ttnn.experimental.tensor.all_gather(
+        layer_output = ttnn.all_gather(
             layer_output,
             dim=3,
             num_links=self.model_config["ALL_GATHER_NUM_LINKS"],

--- a/models/demos/t3000/llama2_70b/tt/llama_attention_optimized.py
+++ b/models/demos/t3000/llama2_70b/tt/llama_attention_optimized.py
@@ -649,7 +649,7 @@ class TtLlamaAttention_optimized(torch.nn.Module):
         if self.emulated:
             attn_output = tt_all_gather_torch(attn_output, dim=-1)
         else:
-            attn_output = tt_lib.tensor.all_gather(
+            attn_output = ttnn.all_gather(
                 attn_output,
                 dim=3,
                 num_links=self.model_config["ALL_GATHER_NUM_LINKS"],
@@ -911,7 +911,7 @@ class TtLlamaAttention_optimized(torch.nn.Module):
         if self.emulated:
             attn_output = tt_all_gather_torch(attn_output, dim=-1)
         else:
-            attn_output = tt_lib.tensor.all_gather(
+            attn_output = ttnn.all_gather(
                 attn_output,
                 dim=3,
                 num_links=self.model_config["ALL_GATHER_NUM_LINKS"],

--- a/models/demos/t3000/llama2_70b/tt/llama_attention_optimized.py
+++ b/models/demos/t3000/llama2_70b/tt/llama_attention_optimized.py
@@ -653,7 +653,7 @@ class TtLlamaAttention_optimized(torch.nn.Module):
                 attn_output,
                 dim=3,
                 num_links=self.model_config["ALL_GATHER_NUM_LINKS"],
-                output_mem_config=self.model_config["L1_MEMCFG"],
+                memory_config=self.model_config["L1_MEMCFG"],
             )
 
         for i in range(len(attn_output)):
@@ -915,7 +915,7 @@ class TtLlamaAttention_optimized(torch.nn.Module):
                 attn_output,
                 dim=3,
                 num_links=self.model_config["ALL_GATHER_NUM_LINKS"],
-                output_mem_config=self.model_config["DRAM_MEMCFG"],
+                memory_config=self.model_config["DRAM_MEMCFG"],
             )
 
         for i in range(len(attn_output)):

--- a/models/demos/t3000/llama2_70b/tt/llama_decoder_optimized.py
+++ b/models/demos/t3000/llama2_70b/tt/llama_decoder_optimized.py
@@ -305,7 +305,7 @@ class TtLlamaDecoder_optimized:
         if self.emulated:
             xs_replicated = tt_all_gather_torch(xs_replicated, dim=-1)
         else:
-            xs_replicated = tt_lib.tensor.all_gather(
+            xs_replicated = ttnn.all_gather(
                 xs_replicated,
                 dim=3,
                 num_links=self.model_config["ALL_GATHER_NUM_LINKS"],
@@ -360,7 +360,7 @@ class TtLlamaDecoder_optimized:
         if self.emulated:
             attn_resid_replicated = tt_all_gather_torch(attn_resid_replicated, dim=-1)
         else:
-            attn_resid_replicated = tt_lib.tensor.all_gather(
+            attn_resid_replicated = ttnn.all_gather(
                 attn_resid_replicated,
                 dim=3,
                 num_links=self.model_config["ALL_GATHER_NUM_LINKS"],
@@ -480,7 +480,7 @@ class TtLlamaDecoder_optimized:
         if self.emulated:
             xs_replicated = tt_all_gather_torch(xs_replicated, dim=-1)
         else:
-            xs_replicated = tt_lib.tensor.all_gather(
+            xs_replicated = ttnn.all_gather(
                 xs_replicated,
                 dim=3,
                 num_links=self.model_config["ALL_GATHER_NUM_LINKS"],
@@ -515,7 +515,7 @@ class TtLlamaDecoder_optimized:
         if self.emulated:
             attn_resid_replicated = tt_all_gather_torch(attn_resid_replicated, dim=-1)
         else:
-            attn_resid_replicated = tt_lib.tensor.all_gather(
+            attn_resid_replicated = ttnn.all_gather(
                 attn_resid_replicated,
                 dim=3,
                 num_links=self.model_config["ALL_GATHER_NUM_LINKS"],

--- a/models/demos/t3000/llama2_70b/tt/llama_decoder_optimized.py
+++ b/models/demos/t3000/llama2_70b/tt/llama_decoder_optimized.py
@@ -309,7 +309,7 @@ class TtLlamaDecoder_optimized:
                 xs_replicated,
                 dim=3,
                 num_links=self.model_config["ALL_GATHER_NUM_LINKS"],
-                output_mem_config=self.model_config["L1_MEMCFG"],
+                memory_config=self.model_config["L1_MEMCFG"],
             )
 
         for i in range(self.num_devices):
@@ -364,7 +364,7 @@ class TtLlamaDecoder_optimized:
                 attn_resid_replicated,
                 dim=3,
                 num_links=self.model_config["ALL_GATHER_NUM_LINKS"],
-                output_mem_config=self.model_config["L1_MEMCFG"],
+                memory_config=self.model_config["L1_MEMCFG"],
             )
 
         for i in range(self.num_devices):
@@ -484,7 +484,7 @@ class TtLlamaDecoder_optimized:
                 xs_replicated,
                 dim=3,
                 num_links=self.model_config["ALL_GATHER_NUM_LINKS"],
-                output_mem_config=self.model_config["DRAM_MEMCFG"],
+                memory_config=self.model_config["DRAM_MEMCFG"],
             )
 
         attn_norm_interleaved = self.sharded_rmsnorm(xs_replicated, self.norm_eps, self.attn_norm_list)
@@ -519,7 +519,7 @@ class TtLlamaDecoder_optimized:
                 attn_resid_replicated,
                 dim=3,
                 num_links=self.model_config["ALL_GATHER_NUM_LINKS"],
-                output_mem_config=self.model_config["L1_MEMCFG"],
+                memory_config=self.model_config["L1_MEMCFG"],
             )
 
         ffn_norm_interleaved = self.sharded_rmsnorm(attn_resid_replicated, self.norm_eps, self.ffn_norm_list)

--- a/models/demos/t3000/llama2_70b/tt/llama_mlp_optimized.py
+++ b/models/demos/t3000/llama2_70b/tt/llama_mlp_optimized.py
@@ -274,7 +274,7 @@ class TtLlamaMLP_optimized(nn.Module):
                 hidden_states,
                 dim=3,
                 num_links=self.model_config["ALL_GATHER_NUM_LINKS"],
-                output_mem_config=self.model_config["L1_MEMCFG"],
+                memory_config=self.model_config["L1_MEMCFG"],
             )
 
         # Put AllGather results in L1 Sharded

--- a/models/demos/t3000/llama2_70b/tt/llama_mlp_optimized.py
+++ b/models/demos/t3000/llama2_70b/tt/llama_mlp_optimized.py
@@ -210,7 +210,7 @@ class TtLlamaMLP_optimized(nn.Module):
         if self.emulated:
             hidden_states = tt_all_gather_torch(hidden_states, dim=-1)
         else:
-            hidden_states = tt_lib.tensor.all_gather(
+            hidden_states = ttnn.all_gather(
                 hidden_states,
                 dim=3,
                 num_links=self.model_config["ALL_GATHER_NUM_LINKS"],
@@ -270,7 +270,7 @@ class TtLlamaMLP_optimized(nn.Module):
         if self.emulated:
             hidden_states = tt_all_gather_torch(hidden_states, dim=-1)
         else:
-            hidden_states = tt_lib.tensor.all_gather(
+            hidden_states = ttnn.all_gather(
                 hidden_states,
                 dim=3,
                 num_links=self.model_config["ALL_GATHER_NUM_LINKS"],

--- a/models/demos/t3000/llama2_70b/tt/llama_model_optimized.py
+++ b/models/demos/t3000/llama2_70b/tt/llama_model_optimized.py
@@ -368,7 +368,7 @@ class TtLlamaModel_optimized(nn.Module):
         if self.emulated:
             xs = tt_all_gather_torch(xs, dim=-1)
         else:
-            xs = tt_lib.tensor.all_gather(
+            xs = ttnn.all_gather(
                 xs,
                 dim=3,
                 num_links=self.model_config["ALL_GATHER_NUM_LINKS"],
@@ -492,7 +492,7 @@ class TtLlamaModel_optimized(nn.Module):
         if self.emulated:
             xs = tt_all_gather_torch(xs, dim=-1)
         else:
-            xs = tt_lib.tensor.all_gather(
+            xs = ttnn.all_gather(
                 xs,
                 dim=3,
                 num_links=self.model_config["ALL_GATHER_NUM_LINKS"],

--- a/models/demos/t3000/llama2_70b/tt/llama_model_optimized.py
+++ b/models/demos/t3000/llama2_70b/tt/llama_model_optimized.py
@@ -372,7 +372,7 @@ class TtLlamaModel_optimized(nn.Module):
                 xs,
                 dim=3,
                 num_links=self.model_config["ALL_GATHER_NUM_LINKS"],
-                output_mem_config=self.model_config["L1_MEMCFG"],
+                memory_config=self.model_config["L1_MEMCFG"],
             )
 
         ## Duplicate layernorm
@@ -496,7 +496,7 @@ class TtLlamaModel_optimized(nn.Module):
                 xs,
                 dim=3,
                 num_links=self.model_config["ALL_GATHER_NUM_LINKS"],
-                output_mem_config=self.model_config["DRAM_MEMCFG"],
+                memory_config=self.model_config["DRAM_MEMCFG"],
             )
 
         ## Duplicate layernorm

--- a/models/experimental/llama2_70b/tt/llama_decoder_optimized.py
+++ b/models/experimental/llama2_70b/tt/llama_decoder_optimized.py
@@ -298,7 +298,7 @@ class TtLlamaDecoder_optimized:
         # if self.emulated:
         #     xs_replicated = tt_all_gather_torch(xs_replicated, dim=-1)
         # else:
-        #     xs_replicated = tt_lib.tensor.all_gather(
+        #     xs_replicated = ttnn.all_gather(
         #         xs_replicated,
         #         dim=3,
         #         num_links=self.model_config["ALL_GATHER_NUM_LINKS"],
@@ -351,7 +351,7 @@ class TtLlamaDecoder_optimized:
         # if self.emulated:
         #     attn_resid_replicated = tt_all_gather_torch(attn_resid_replicated, dim=-1)
         # else:
-        #     attn_resid_replicated = tt_lib.tensor.all_gather(
+        #     attn_resid_replicated = ttnn.all_gather(
         #         attn_resid_replicated,
         #         dim=3,
         #         num_links=self.model_config["ALL_GATHER_NUM_LINKS"],
@@ -468,7 +468,7 @@ class TtLlamaDecoder_optimized:
         # if self.emulated:
         #     xs_replicated = tt_all_gather_torch(xs_replicated, dim=-1)
         # else:
-        #     xs_replicated = tt_lib.tensor.all_gather(
+        #     xs_replicated = ttnn.all_gather(
         #         xs_replicated,
         #         dim=3,
         #         num_links=self.model_config["ALL_GATHER_NUM_LINKS"],
@@ -497,7 +497,7 @@ class TtLlamaDecoder_optimized:
         # if self.emulated:
         #     attn_resid_replicated = tt_all_gather_torch(attn_resid_replicated, dim=-1)
         # else:
-        #     attn_resid_replicated = tt_lib.tensor.all_gather(
+        #     attn_resid_replicated = ttnn.all_gather(
         #         attn_resid_replicated,
         #         dim=3,
         #         num_links=self.model_config["ALL_GATHER_NUM_LINKS"],

--- a/models/experimental/llama2_70b/tt/llama_model_optimized.py
+++ b/models/experimental/llama2_70b/tt/llama_model_optimized.py
@@ -340,7 +340,7 @@ class TtLlamaModel_optimized:
         # if self.emulated:
         #     xs = tt_all_gather_torch(xs, dim=-1)
         # else:
-        #     xs = tt_lib.tensor.all_gather(
+        #     xs = ttnn.all_gather(
         #         xs,
         #         dim=3,
         #         num_links=self.model_config["ALL_GATHER_NUM_LINKS"],
@@ -456,7 +456,7 @@ class TtLlamaModel_optimized:
         # if self.emulated:
         #     xs = tt_all_gather_torch(xs, dim=-1)
         # else:
-        #     xs = tt_lib.tensor.all_gather(
+        #     xs = ttnn.all_gather(
         #         xs,
         #         dim=3,
         #         num_links=self.model_config["ALL_GATHER_NUM_LINKS"],

--- a/tests/tt_eager/python_api_testing/unit_testing/misc/test_all_gather.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/misc/test_all_gather.py
@@ -6,6 +6,7 @@ import torch
 import pytest
 from loguru import logger
 import tt_lib as ttl
+import ttnn
 from tests.tt_eager.python_api_testing.sweep_tests.comparison_funcs import comp_equal, comp_pcc
 from models.utility_functions import skip_for_grayskull, get_devices_for_t3000
 import itertools
@@ -109,7 +110,7 @@ def run_all_gather_on_t3000_impl(
         tt_input_tensors.append(ttl.tensor.Tensor(t, input_dtype).to(layout).to(devices[i], mem_config))
 
     for i in range(num_iters):
-        tt_out_tensors = ttl.tensor.all_gather(tt_input_tensors, dim, num_links, output_mem_config=mem_config)
+        tt_out_tensors = ttnn.all_gather(tt_input_tensors, dim, num_links, output_mem_config=mem_config)
 
         for d in devices:
             ttl.device.Synchronize(d)
@@ -779,7 +780,7 @@ def test_all_gather_post_commit_sharded(
     for i, t in enumerate(input_tensors):
         tt_input_tensors.append(ttl.tensor.Tensor(t, input_dtype).to(tensor_layout).to(devices[i], input_mem_config))
 
-    tt_out_tensors = ttl.tensor.all_gather(tt_input_tensors, dim, num_links, output_mem_config=output_mem_config)
+    tt_out_tensors = ttnn.all_gather(tt_input_tensors, dim, num_links, output_mem_config=output_mem_config)
     for d in devices:
         ttl.device.Synchronize(d)
     torch.set_printoptions(sci_mode=False)
@@ -833,7 +834,7 @@ def test_all_gather_fp32(
     for i, t in enumerate(input_tensors):
         tt_input_tensors.append(ttl.tensor.Tensor(t, ttl.tensor.DataType.FLOAT32).to(layout).to(devices[i], mem_config))
 
-    tt_out_tensors = ttl.tensor.all_gather(tt_input_tensors, dim, num_links, output_mem_config=mem_config)
+    tt_out_tensors = ttnn.all_gather(tt_input_tensors, dim, num_links, output_mem_config=mem_config)
 
     for i, t in enumerate(tt_out_tensors):
         tt_output_tensor = t.cpu().to(ttl.tensor.Layout.ROW_MAJOR).to_torch()

--- a/tests/tt_eager/python_api_testing/unit_testing/misc/test_all_gather.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/misc/test_all_gather.py
@@ -110,7 +110,7 @@ def run_all_gather_on_t3000_impl(
         tt_input_tensors.append(ttl.tensor.Tensor(t, input_dtype).to(layout).to(devices[i], mem_config))
 
     for i in range(num_iters):
-        tt_out_tensors = ttnn.all_gather(tt_input_tensors, dim, num_links, output_mem_config=mem_config)
+        tt_out_tensors = ttnn.all_gather(tt_input_tensors, dim, num_links=num_links, memory_config=mem_config)
 
         for d in devices:
             ttl.device.Synchronize(d)
@@ -780,7 +780,7 @@ def test_all_gather_post_commit_sharded(
     for i, t in enumerate(input_tensors):
         tt_input_tensors.append(ttl.tensor.Tensor(t, input_dtype).to(tensor_layout).to(devices[i], input_mem_config))
 
-    tt_out_tensors = ttnn.all_gather(tt_input_tensors, dim, num_links, output_mem_config=output_mem_config)
+    tt_out_tensors = ttnn.all_gather(tt_input_tensors, dim, num_links=num_links, memory_config=output_mem_config)
     for d in devices:
         ttl.device.Synchronize(d)
     torch.set_printoptions(sci_mode=False)
@@ -834,7 +834,7 @@ def test_all_gather_fp32(
     for i, t in enumerate(input_tensors):
         tt_input_tensors.append(ttl.tensor.Tensor(t, ttl.tensor.DataType.FLOAT32).to(layout).to(devices[i], mem_config))
 
-    tt_out_tensors = ttnn.all_gather(tt_input_tensors, dim, num_links, output_mem_config=mem_config)
+    tt_out_tensors = ttnn.all_gather(tt_input_tensors, dim, num_links=num_links, memory_config=mem_config)
 
     for i, t in enumerate(tt_out_tensors):
         tt_output_tensor = t.cpu().to(ttl.tensor.Layout.ROW_MAJOR).to_torch()

--- a/ttnn/cpp/pybind11/operations/ccl.hpp
+++ b/ttnn/cpp/pybind11/operations/ccl.hpp
@@ -35,6 +35,7 @@ void bind_ccl_operation(py::module& module, const ccl_operation_t& operation, co
             },
             py::arg("input_tensor"),
             py::arg("dim"),
+            py::kw_only(),
             py::arg("num_links") = 1,
             py::arg("memory_config") = std::nullopt});
 }


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/9486

### Problem description
As a first step of fully migrating ccl ops, we replace ttl all_gather with ttnn

### What's changed
Replace usage in python from `tt_lib` to `ttnn`
Order of params is different between ttnn and tt_lib, so there are some related adjustments

This PR helps to minimize changes before the next PR.
Next step is to remove bindings as they are supposedly not used after this change.

### Checklist
- [x] Post commit CI passes [passes](https://github.com/tenstorrent/tt-metal/actions/runs/9570159651)
- [x] Nightly fast dispatch [passes](https://github.com/tenstorrent/tt-metal/actions/runs/9570153913)
- [x] T3000 model perf [does not introduce new regression](https://github.com/tenstorrent/tt-metal/actions/runs/9570136057)
- [x] T3000 frequent tests [does not introduce new regression](https://github.com/tenstorrent/tt-metal/actions/runs/9570144165)