### PR TITLE
#9486: Remove all_gather binding from tt_lib

### DIFF
--- a/tt_eager/tt_lib/csrc/tt_lib_bindings_tensor_dm_ops.cpp
+++ b/tt_eager/tt_lib/csrc/tt_lib_bindings_tensor_dm_ops.cpp
@@ -553,11 +553,7 @@ namespace tt::tt_metal::detail{
         );
 
         // ---------- Multi-Device ops ----------
-        // All Gather
-        m_tensor.def("all_gather", &all_gather,
-            py::arg("input_tensors"), py::arg("dim"), py::arg("num_links") = 1, py::arg("output_mem_config").noconvert() = operation::DEFAULT_OUTPUT_MEMORY_CONFIG,
-            R"doc(Performs all gather on a list of tensors that form one tensor that is distributed across devices. The output is a list of a tensor which has been duplciated across the input devices.)doc"
-        );
+        // Line All Gather
         m_tensor.def("line_all_gather", &line_all_gather,
             py::arg("input_tensors"), py::arg("dim"), py::arg("num_links") = 1, py::arg("output_mem_config").noconvert() = operation::DEFAULT_OUTPUT_MEMORY_CONFIG,
             R"doc(Performs all gather on a list of tensors that form one tensor that is distributed across devices. The output is a list of a tensor which has been duplciated across the input devices.)doc"


### PR DESCRIPTION
### Ticket
#9486 

### Problem description
After replacing all usage of all_gather with ttnn, we are removing binding from tt_lib

### What's changed
Removing binding.
Next step we are consolidating implementation in ttnn

### Checklist
- [x] Post commit CI passes [passes](https://github.com/tenstorrent/tt-metal/actions/runs/9570979689)
