### PR TITLE
#9492: Use to_layout to simplify matmul call in outer

### DIFF
--- a/tt_eager/tt_dnn/op_library/composite/composite_ops.cpp
+++ b/tt_eager/tt_dnn/op_library/composite/composite_ops.cpp
@@ -4,6 +4,7 @@
 
 #include "tt_dnn/op_library/composite/composite_ops.hpp"
 
+#include "tt_dnn/op_library/auto_format.hpp"
 #include "tt_dnn/op_library/bmm/bmm_op.hpp"
 #include "tt_dnn/op_library/concat/concat_op.hpp"
 #include "tt_dnn/op_library/copy/copy_op.hpp"
@@ -1605,6 +1606,15 @@ Tensor _outer(Tensor& a, Tensor& b, const MemoryConfig& output_mem_config) {
     }
     a_slim = ttnn::to_layout(a_slim, ttnn::TILE_LAYOUT, std::nullopt, std::nullopt, (Device*)nullptr);
     b_slim = ttnn::to_layout(b_slim, ttnn::TILE_LAYOUT, std::nullopt, std::nullopt, (Device*)nullptr);
+    Device* device = AutoFormat::GetDefaultDevice();
+    if (device != nullptr) {
+        if (a_slim.storage_type() != tt::tt_metal::StorageType::DEVICE) {
+            a_slim = AutoFormat::move_tensor_to_device(a_slim, device);
+        }
+        if (b_slim.storage_type() != tt::tt_metal::StorageType::DEVICE) {
+            b_slim = AutoFormat::move_tensor_to_device(b_slim, device);
+        }
+    }
 
     return tt::operations::primary::matmul(a_slim, b_slim, std::nullopt, std::nullopt, output_mem_config);
 }

--- a/tt_eager/tt_dnn/op_library/composite/composite_ops.cpp
+++ b/tt_eager/tt_dnn/op_library/composite/composite_ops.cpp
@@ -15,6 +15,7 @@
 #include "tt_dnn/op_library/reduce/reduce_op.hpp"
 #include "tt_dnn/op_library/reshape/reshape_op.hpp"
 #include "tt_dnn/op_library/unpad/unpad_op.hpp"
+#include "tt_eager/tensor/tensor_impl.hpp"
 #include "tt_eager/tensor/tensor_utils.hpp"
 #include "tt_eager/tt_dnn/op_library/pad/pad_op.hpp"
 #include "tt_eager/tt_dnn/op_library/unpad/unpad_op.hpp"
@@ -1602,8 +1603,10 @@ Tensor _outer(Tensor& a, Tensor& b, const MemoryConfig& output_mem_config) {
     if (!skip_reshape_b) {
         b_slim = reshape(b, 1, 1, 1, b.volume(), output_mem_config);
     }
+    a_slim = ttnn::to_layout(a_slim, ttnn::TILE_LAYOUT, std::nullopt, std::nullopt, (Device*)nullptr);
+    b_slim = ttnn::to_layout(b_slim, ttnn::TILE_LAYOUT, std::nullopt, std::nullopt, (Device*)nullptr);
 
-    return tt::operations::primary::matmul(a_slim, b_slim, std::nullopt, std::nullopt, output_mem_config, std::nullopt /*output_dtype*/, std::nullopt /*compute_kernel_config*/, false /*untilize_out*/, std::nullopt /*user_core_coord*/, std::nullopt /*fused_activation*/, std::nullopt /*input_b_is_batched*/, true /*needs_autoformat*/);
+    return tt::operations::primary::matmul(a_slim, b_slim, std::nullopt, std::nullopt, output_mem_config);
 }
 Tensor outer(Tensor& a, Tensor& b, const MemoryConfig& output_mem_config) {
     return operation::decorate_as_composite(__func__, _outer)(a, b, output_mem_config);


### PR DESCRIPTION
### Ticket
- Link to Github Issue. https://github.com/tenstorrent/tt-metal/issues/9492

### Problem description
- outer() has a shape that needs run_with_autoformat to be handled. However, that should not be exposed to ttnn::matmul and should be removed.

### What's changed
- use to_layout to add padding and simplify the call to matmul(). That will allow subsequent movement of the matmul call to ttnn::matmul


### Checklist
- [x] Post commit CI passes
- [x] Model regression CI testing passes (if applicable)
- [x] New/Existing tests provide coverage for changes
