### PR TITLE
#9530: Hardcode device aiclk for BH due to lack of arc msg support

### DIFF
--- a/tt_metal/llrt/tt_cluster.cpp
+++ b/tt_metal/llrt/tt_cluster.cpp
@@ -349,8 +349,8 @@ void Cluster::verify_eth_fw() const {
 int Cluster::get_device_aiclk(const chip_id_t &chip_id) const {
     if (this->arch_ == tt::ARCH::BLACKHOLE) {
         // For Blackhole bring up remove AICLK query due to lack of ARC message support
-        log_info(tt::LogDevice, "For Blackhole remove AICLK query due to lack of ARC message support");
-        return 0;
+        log_info(tt::LogDevice, "For Blackhole hardcode AICLK to 800 MHz due to lack of ARC message support");
+        return 800;
     }
     if (this->device_to_mmio_device_.find(chip_id) != this->device_to_mmio_device_.end()) {
         // get_clocks returns MMIO device ID -> clock frequency


### PR DESCRIPTION
### Ticket
- https://github.com/tenstorrent/tt-metal/issues/9530

### Problem description
- ARC msg support hasn't been added to BH but watcher tests require non-zero AICLK value 

### What's changed
- Set AICLK to 800MHz

### Checklist
- [x] [Post commit CI](https://github.com/tenstorrent/tt-metal/actions/runs/9573049234)
