### PR TITLE
#9082: add slack notification to t3k profiler

### DIFF
--- a/.github/workflows/t3000-profiler-tests.yaml
+++ b/.github/workflows/t3000-profiler-tests.yaml
@@ -39,3 +39,8 @@ jobs:
         timeout-minutes: 30
         run: |
           ./tests/scripts/run_profiler_regressions.sh
+      - uses: ./.github/actions/slack-report
+        if: ${{ failure() }}
+        with:
+          slack_webhook_url: ${{ secrets.SLACK_WEBHOOK_URL }}
+          owner: U03BJ1L3LUQ # Mo Memarian  


### PR DESCRIPTION
### Ticket
[Main issue](https://github.com/tenstorrent/tt-metal/issues/9082)
Subissue as working to identify owners and green pipelines

### Problem description
Pings Mo Memarian via slack if t3k profiler pipeline throws an error

### What's changed

### Checklist
- [x] Post commit CI passes https://github.com/tenstorrent/tt-metal/actions/runs/9573695668
- [ ] Model regression CI testing passes (if applicable)
- [ ] New/Existing tests provide coverage for changes https://github.com/tenstorrent/tt-metal/actions/runs/9573697842
