### PR TITLE
New workflow for custom test dispatch on CI runners

### DIFF
--- a/.github/workflows/test-dispatch.yaml
+++ b/.github/workflows/test-dispatch.yaml
@@ -1,0 +1,47 @@
+name: "Custom test dispatch"
+
+on:
+  workflow_dispatch:
+    inputs:
+      architecture:
+        required: true
+        options:
+          - grayskull
+          - wormhole_b0
+      command:
+        required: true
+        type: string
+      description:
+        type: string
+        required: true
+
+jobs:
+  build-artifact:
+    uses: ./.github/workflows/build-artifact.yaml
+    secrets: inherit
+  test-dispatch:
+    needs: build-artifact
+    timeout-minutes: 1440
+    env:
+      TT_METAL_ENV: ${{ vars.TT_METAL_ENV }}
+      ARCH_NAME: ${{ inputs.architecture }}
+    environment: dev
+    runs-on: ${{ inputs.architecture }}
+    name: Custom test command ${{ inputs.description }}
+    steps:
+      - uses: tenstorrent-metal/metal-workflows/.github/actions/checkout-with-submodule-lfs@v2.0.0
+      - name: Set up dyanmic env vars for build
+        run: |
+          echo "TT_METAL_HOME=$(pwd)" >> $GITHUB_ENV
+      - uses: actions/download-artifact@v4
+        with:
+          name: TTMetal_build_${{ matrix.runner-info.arch }}
+      - name: Extract files
+        run: tar -xvf ttm_${{ matrix.runner-info.arch }}.tar
+      - uses: ./.github/actions/install-python-deps
+      - name: Run pre/post regression tests in a loop
+        run: |
+          source ${{ github.workspace }}/python_env/bin/activate
+          cd $TT_METAL_HOME
+          export PYTHONPATH=$TT_METAL_HOME
+          ${{ inputs.command }}


### PR DESCRIPTION
### Problem description
Reproducing ND issues requires a dev to use their local machine to run, which is a pain. 

### What's changed
This new workflow allows a dev to dispatch a custom run command on our CI runners, which makes it easier to track what was tested and also wouldn't occupy their dev machine for running a potentially very long job.
