### PR TITLE
#9449: Add tests for matmul 1D single-core cases

### DIFF
--- a/tests/ttnn/sweep_tests/sweeps/sweeps/matmul/short/matmul_user_program_config.py
+++ b/tests/ttnn/sweep_tests/sweeps/sweeps/matmul/short/matmul_user_program_config.py
@@ -194,64 +194,6 @@ parameters = {
             ttnn.L1_MEMORY_CONFIG,
             ttnn.L1_WIDTH_SHARDED_MEMORY_CONFIG,
         ),
-        # Matmul 1D mcast in0 (single core)
-        (
-            (1,),
-            (64, 64, 128),
-            False,
-            ttnn.experimental.operations.primary.MatmulMultiCoreReuseMultiCast1DProgramConfig(
-                compute_with_storage_grid_size=(1, 1),
-                in0_block_w=2,
-                out_subblock_h=1,
-                out_subblock_w=1,
-                per_core_M=2,
-                per_core_N=4,
-                fuse_batch=True,
-                fused_activation=None,
-                mcast_in0=True,
-            ),
-            ttnn.MemoryConfig(
-                memory_layout=ttnn.TensorMemoryLayout.WIDTH_SHARDED,
-                buffer_type=ttnn.BufferType.L1,
-                shard_spec=ttnn.ShardSpec(
-                    ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(0, 0))}),
-                    (64, 64),
-                    ttnn.ShardOrientation.ROW_MAJOR,
-                    False,
-                ),
-            ),
-            ttnn.L1_MEMORY_CONFIG,
-            ttnn.L1_WIDTH_SHARDED_MEMORY_CONFIG,
-        ),
-        # Matmul 1D mcast in1 (single core)
-        (
-            (1,),
-            (64, 64, 128),
-            False,
-            ttnn.experimental.operations.primary.MatmulMultiCoreReuseMultiCast1DProgramConfig(
-                compute_with_storage_grid_size=(1, 1),
-                in0_block_w=2,
-                out_subblock_h=1,
-                out_subblock_w=1,
-                per_core_M=2,
-                per_core_N=4,
-                fuse_batch=True,
-                fused_activation=None,
-                mcast_in0=False,
-            ),
-            ttnn.MemoryConfig(
-                memory_layout=ttnn.TensorMemoryLayout.HEIGHT_SHARDED,
-                buffer_type=ttnn.BufferType.L1,
-                shard_spec=ttnn.ShardSpec(
-                    ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(0, 0))}),
-                    (64, 64),
-                    ttnn.ShardOrientation.ROW_MAJOR,
-                    False,
-                ),
-            ),
-            ttnn.L1_MEMORY_CONFIG,
-            ttnn.L1_HEIGHT_SHARDED_MEMORY_CONFIG,
-        ),
         # Matmul 2D mcast
         (
             (1,),

--- a/tt_eager/tt_dnn/op_library/bmm/kernels/dataflow/reader_bmm_tile_layout_in0_sender_padding.cpp
+++ b/tt_eager/tt_dnn/op_library/bmm/kernels/dataflow/reader_bmm_tile_layout_in0_sender_padding.cpp
@@ -31,16 +31,19 @@ void kernel_main() {
     constexpr uint32_t in0_block_w                        = get_compile_time_arg_val(4);
     constexpr uint32_t in0_block_h                        = get_compile_time_arg_val(5);
     constexpr uint32_t in0_block_num_tiles                = get_compile_time_arg_val(6);
+    constexpr bool extract_shard_sub_blocks               = (bool)get_compile_time_arg_val(7);
+    constexpr uint32_t shard_width_in_tiles               = get_compile_time_arg_val(8);
+    constexpr uint32_t shard_height_in_tiles              = get_compile_time_arg_val(9);
     // in0/in1 common args
-    constexpr uint32_t num_blocks                         = get_compile_time_arg_val(7);
+    constexpr uint32_t num_blocks                         = get_compile_time_arg_val(10);
     // in0 mcast args
-    constexpr uint32_t in0_mcast_sender_semaphore_addr    = get_compile_time_arg_val(8);
-    constexpr uint32_t in0_mcast_receiver_semaphore_addr  = get_compile_time_arg_val(9);
-    constexpr uint32_t in0_mcast_num_dests                = get_compile_time_arg_val(10);
-    constexpr uint32_t in0_mcast_num_cores                = get_compile_time_arg_val(11);
+    constexpr uint32_t in0_mcast_sender_semaphore_addr    = get_compile_time_arg_val(11);
+    constexpr uint32_t in0_mcast_receiver_semaphore_addr  = get_compile_time_arg_val(12);
+    constexpr uint32_t in0_mcast_num_dests                = get_compile_time_arg_val(13);
+    constexpr uint32_t in0_mcast_num_cores                = get_compile_time_arg_val(14);
     // batch args
-    constexpr uint32_t MtKt                               = get_compile_time_arg_val(12); // if 0
-    constexpr uint32_t batch                              = get_compile_time_arg_val(13);
+    constexpr uint32_t MtKt                               = get_compile_time_arg_val(15); // if 0
+    constexpr uint32_t batch                              = get_compile_time_arg_val(16);
 
 
     constexpr uint32_t cb_id_in0 = 0;
@@ -48,11 +51,20 @@ void kernel_main() {
     constexpr uint32_t in0_block_size_bytes = in0_block_num_tiles * in0_single_tile_size_bytes;
 
     #ifdef IN0_SHARDED
-    cb_reserve_back(cb_id_in0, in0_block_num_tiles);
-    cb_push_back(cb_id_in0, in0_block_num_tiles);
+    // In case we need to send multiple blocks per shard, in0 sharded cb is cb2 and we extract the sub-blocks to cb0
+    constexpr uint32_t shard_read_stride = shard_width_in_tiles * in0_single_tile_size_bytes;
+    constexpr uint32_t shard_read_width = in0_single_tile_size_bytes * in0_block_w;
+
+    uint64_t noc_shard_read_start_addr = 0;
+    if constexpr (extract_shard_sub_blocks) {
+        constexpr uint32_t cb_id_in2 = 2;  // in0 sharded cb if extract_shard_sub_blocks
+        noc_shard_read_start_addr = get_noc_addr(get_read_ptr(cb_id_in2));
+    } else {
+        cb_reserve_back(cb_id_in0, in0_block_num_tiles);
+        cb_push_back(cb_id_in0, in0_block_num_tiles);
+    }
     #else
     constexpr DataFormat in0_data_format = get_dataformat(cb_id_in0);
-    uint32_t l1_write_addr_in0;
 
     const InterleavedAddrGenFast<in0_is_dram> s0 = {
         .bank_base_address = in0_tensor_addr,
@@ -84,7 +96,7 @@ void kernel_main() {
         0);
 
     #ifdef IN0_SHARDED
-    uint64_t in0_start_address = get_write_ptr(cb_id_in0);
+    uint32_t in0_start_address = get_write_ptr(cb_id_in0);
     #endif
     #endif
 
@@ -94,9 +106,11 @@ void kernel_main() {
             #ifndef IN0_SHARDED
             // Operand 0
             cb_reserve_back(cb_id_in0, in0_block_num_tiles);
-            l1_write_addr_in0 = get_write_ptr(cb_id_in0);
+            uint32_t l1_write_addr_in0 = get_write_ptr(cb_id_in0);
 
-            uint64_t in0_start_address = l1_write_addr_in0; // copy start address of block, to be used for mcasting
+            #ifndef SKIP_MCAST
+            uint32_t in0_start_address = l1_write_addr_in0; // copy start address of block, to be used for mcasting
+            #endif
 
             // Copy in0 block into CB, as the default kernel
             uint32_t in0_tensor_row_start_tile_id = in0_tensor_current_block_start_tile_id;
@@ -115,6 +129,28 @@ void kernel_main() {
 
             // Barrier! make sure the reads are done
             noc_async_read_barrier();
+            #else
+            if constexpr (extract_shard_sub_blocks) {
+                // Operand 0
+                cb_reserve_back(cb_id_in0, in0_block_num_tiles);
+                uint32_t l1_write_addr_in0 = get_write_ptr(cb_id_in0);
+
+                #ifndef SKIP_MCAST
+                in0_start_address = l1_write_addr_in0; // copy start address of block, to be used for mcasting
+                #endif
+
+                uint64_t noc_shard_read_addr = noc_shard_read_start_addr;
+                noc_shard_read_start_addr += shard_read_width;
+
+                for (uint32_t i = 0; i < shard_height_in_tiles; i++) {
+                    noc_async_read(noc_shard_read_addr, l1_write_addr_in0, shard_read_width);
+
+                    l1_write_addr_in0 += shard_read_width;
+                    noc_shard_read_addr += shard_read_stride;
+                }
+
+                noc_async_read_barrier();
+            }
             #endif
 
             #ifndef SKIP_MCAST
@@ -139,6 +175,10 @@ void kernel_main() {
 
             #ifndef IN0_SHARDED
             cb_push_back(cb_id_in0, in0_block_num_tiles);
+            #else
+            if constexpr (extract_shard_sub_blocks) {
+                cb_push_back(cb_id_in0, in0_block_num_tiles);
+            }
             #endif
         }
         in0_tensor_start_tile_id += MtKt;

--- a/tt_eager/tt_dnn/op_library/bmm/multi_core_reuse_mcast_2d_optimized/bmm_op_multi_core_reuse_mcast_2d_optimized.cpp
+++ b/tt_eager/tt_dnn/op_library/bmm/multi_core_reuse_mcast_2d_optimized/bmm_op_multi_core_reuse_mcast_2d_optimized.cpp
@@ -321,6 +321,9 @@ operation::ProgramWithCallbacks create_program_mcast_in0_in1(
             (std::uint32_t)in0_block_w,          // in0_block_w
             (std::uint32_t)per_core_M,           // in0_block_h
             (std::uint32_t)in0_block_num_tiles,  // in0_block_num_tiles
+            (std::uint32_t) false,               // extract_shard_sub_blocks (not used for interleaved)
+            (std::uint32_t)0,                    // shard_width_in_tiles (not used for interleaved)
+            (std::uint32_t)0,                    // shard_height_in_tiles (not used for interleaved)
             // in0/in1 common args
             (std::uint32_t)num_blocks,  // num_blocks
             // in0 mcast args


### PR DESCRIPTION
- Cleanup mcast 1D in0 single-core
  - Move single-core tests from matmul_user_program_config.py to matmul_user_program_config_mcast_1d.py
  - Add single-core output and multi-core in0 test for mcast in0 1D matmul 
- Add support for reading in0 shard width in chunks for mcast in1 1D matmul
  - Remove K == program_config.in0_block_w restriction for mcast in1 1D matmul
  - Add single-core test for mcast in1 1D matmul 
  - TODO: This also affects in0 HEIGHT sharded case for matmul 2D; need to add cb2 and enable
- Switch K per core to 3 tiles (96) for matmul_user_program_config_mcast_1d.py tests
  - CBs are double buffered and issues may be hidden with only 2 tiles for certain mcast patterns

### Ticket
- https://github.com/tenstorrent/tt-metal/issues/9449

### Problem description
- Cleaning up and generalizing edge cases for in0 sharded matmuls. The specialied reader kernel for in0 width sharded (1D matmul) and block sharded (2D matmul) supports reading along shard width in chunks (ie. no restriction that K == in0_block_w). This PR adds this support for in0 HEIGHT sharded case. Thist affects both mcast in1 1D matmul and a special case of 2D matmul where in0 can be HEIGHT sharded.

### What's changed
- Add support for "extracting" out slices of K in `tt_eager/tt_dnn/op_library/bmm/kernels/dataflow/reader_bmm_tile_layout_in0_sender_padding.cpp`
- Add new testing for this feature

### Checklist
- [x] Post commit CI passes
- [x] Model regression CI testing passes (if applicable)
- [x] New/Existing tests provide coverage for changes
