### PR TITLE
#9486: ttnn.all_gather allows tensor or a list of tensors

### DIFF
--- a/ttnn/cpp/pybind11/operations/ccl.hpp
+++ b/ttnn/cpp/pybind11/operations/ccl.hpp
@@ -37,7 +37,22 @@ void bind_ccl_operation(py::module& module, const ccl_operation_t& operation, co
             py::arg("dim"),
             py::kw_only(),
             py::arg("num_links") = 1,
-            py::arg("memory_config") = std::nullopt});
+            py::arg("memory_config") = std::nullopt
+        },
+        ttnn::pybind_overload_t{
+            [](const ccl_operation_t& self,
+               const std::vector<ttnn::Tensor>& input_tensors,
+               const uint32_t dim,
+               const uint32_t num_links,
+               const std::optional<ttnn::MemoryConfig>& memory_config) -> ttnn::Tensor {
+                return self(input_tensors, dim, num_links, memory_config);
+            },
+            py::arg("input_tensors"),
+            py::arg("dim"),
+            py::kw_only(),
+            py::arg("num_links") = 1,
+            py::arg("memory_config") = std::nullopt
+        });
 }
 
 }  // namespace detail
@@ -47,12 +62,12 @@ void py_module(py::module& module) {
     detail::bind_ccl_operation(
         module,
         ttnn::all_gather,
-        R"doc(all_gather(input_tensor: ttnn.Tensor, dim: int, *, num_links: int = 1, memory_config: Optional[ttnn.MemoryConfig] = None) -> ttnn.Tensor
+        R"doc(all_gather(input: Union[ttnn.Tensor, List[ttnn.Tensor]], dim: int, *, num_links: int = 1, memory_config: Optional[ttnn.MemoryConfig] = None) -> ttnn.Tensor
 
         Performs an all-gather operation on multi-device :attr:`input_tensor` across all devices.
 
         Args:
-            * :attr:`input_tensor` (ttnn.Tensor): multi-device tensor
+            * :attr:`input` (Union[ttnn.Tensor, List[ttnn.Tensor]]): multi-device tensor or a list of tensors
             * :attr:`dim` (int)
 
         Keyword Args:

--- a/ttnn/cpp/ttnn/operations/ccl.hpp
+++ b/ttnn/cpp/ttnn/operations/ccl.hpp
@@ -25,6 +25,20 @@ struct ExecuteAllGather {
     }
 
     template <typename... Args>
+    static auto input_tensors_to_validate(const std::vector<ttnn::Tensor>& input_tensors, Args&&... args) {
+        return std::forward_as_tuple(input_tensor);
+    }
+
+    static ttnn::Tensor execute_on_main_thread(
+        const std::vector<ttnn::Tensor>& input_tensors,
+        const uint32_t dim,
+        const uint32_t num_links = 1,
+        const std::optional<ttnn::MemoryConfig>& memory_config = std::nullopt) {
+        return tt::operations::ccl::all_gather(input_tensors, dim, num_links, memory_config);
+    }
+
+
+    template <typename... Args>
     static auto input_tensors_to_validate(const ttnn::Tensor& input_tensor, Args&&... args) {
         return std::forward_as_tuple(input_tensor);
     }


### PR DESCRIPTION
### Ticket
#9486 

### Problem description
ttnn version of the op only accepted a single Tensor, but prior tt_lib analog allowed a single tensor or a list.
I did not ran all tests and it looks like broke some models it t3k demo tests pipeline.

### What's changed
Added a version of the op accepting a list of tensors

### Checklist
- [ ] Post commit CI [passes](https://github.com/tenstorrent/tt-metal/actions/runs/9582246004)
- [ ] T3K Demo tests [passes](https://github.com/tenstorrent/tt-metal/actions/runs/9582235136)
