### PR TITLE
#9389: Add support for integer type in sum operation

### DIFF
--- a/tt_eager/tt_dnn/kernels/compute/moreh_common.hpp
+++ b/tt_eager/tt_dnn/kernels/compute/moreh_common.hpp
@@ -19,6 +19,7 @@
 #include "compute_kernel_api.h"
 #include "compute_kernel_api/bcast.h"
 #include "compute_kernel_api/eltwise_binary.h"
+#include "compute_kernel_api/eltwise_unary/eltwise_unary.h"
 #include "compute_kernel_api/eltwise_unary/negative.h"
 #include "compute_kernel_api/eltwise_unary/exp.h"
 #include "compute_kernel_api/eltwise_unary/recip.h"
@@ -997,6 +998,27 @@ ALWI void power_and_recip_tile_to_cb(
     cb_pop_front(cb_exp_lxmd, onetile);
     cb_push_back(cb_recip_xpow, onetile);
     REL();
+}
+
+ALWI void copy_tile_to_dst(uint32_t icb, uint32_t itile = 0, uint32_t dst = 0, bool cb_wait_and_pop = true) {
+    constexpr uint32_t onetile = 1;
+    if (cb_wait_and_pop) {
+        cb_wait_front(icb, onetile);
+    }
+    unpack_reconfig_data_format_srca(icb);
+    copy_tile_to_dst_init_short(icb);
+    copy_tile(icb, itile, dst);
+    if (cb_wait_and_pop) {
+        cb_pop_front(icb, onetile);
+    }
+}
+
+ALWI void pack_tile_from_dst(uint32_t ocb, uint32_t dst = 0) {
+    constexpr uint32_t onetile = 1;
+    cb_reserve_back(ocb, onetile);
+    pack_reconfig_data_format(ocb);
+    pack_tile(dst, ocb);
+    cb_push_back(ocb, onetile);
 }
 
 }  // namespace ckernel

--- a/tt_eager/tt_dnn/kernels/dataflow/moreh_common.hpp
+++ b/tt_eager/tt_dnn/kernels/dataflow/moreh_common.hpp
@@ -307,6 +307,141 @@ FORCE_INLINE void generate_mask_w(uint32_t cb_mask, uint32_t mask_w) {
     cb_push_back(cb_mask, 1);
 }
 
+// TODO: Template the generate_mask function to support different data types
+FORCE_INLINE void generate_int_mask_h(uint32_t cb_mask, uint32_t mask_h) {
+    Scalar one;
+    Scalar zero;
+
+    one.u = 1;
+    zero.u = 0;
+
+    cb_reserve_back(cb_mask, 1);
+    auto ptr = reinterpret_cast<int32_t *>(get_write_ptr(cb_mask));
+
+    for (uint32_t w = 0; w < 16; w++) {
+        // sub tile 0
+        {
+            uint32_t mask_h_0 = mask_h;
+            if (mask_h_0 >= 16)
+                mask_h_0 = 16;
+            uint32_t h = 0;
+            for (; h < mask_h_0; h++) {
+                ptr[h * 16 + w] = one.u;
+            }
+            for (; h < 16; h++) {
+                ptr[h * 16 + w] = zero.u;
+            }
+        }
+
+        // sub tile 1
+        {
+            uint32_t mask_h_0 = mask_h;
+            if (mask_h_0 >= 16)
+                mask_h_0 = 16;
+            uint32_t h = 0;
+            for (; h < mask_h_0; h++) {
+                ptr[h * 16 + w + 256] = one.u;
+            }
+            for (; h < 16; h++) {
+                ptr[h * 16 + w + 256] = zero.u;
+            }
+        }
+
+        // sub tile 2
+        {
+            uint32_t mask_h_1 = (mask_h < 16) ? 0 : mask_h - 16;
+            uint32_t h = 0;
+            for (; h < mask_h_1; h++) {
+                ptr[h * 16 + w + 512] = one.u;
+            }
+            for (; h < 16; h++) {
+                ptr[h * 16 + w + 512] = zero.u;
+            }
+        }
+
+        // sub tile 3
+        {
+            uint32_t mask_h_1 = (mask_h < 16) ? 0 : mask_h - 16;
+            uint32_t h = 0;
+            for (; h < mask_h_1; h++) {
+                ptr[h * 16 + w + 768] = one.u;
+            }
+            for (; h < 16; h++) {
+                ptr[h * 16 + w + 768] = zero.u;
+            }
+        }
+    }
+
+    cb_push_back(cb_mask, 1);
+}
+
+FORCE_INLINE void generate_int_mask_w(uint32_t cb_mask, uint32_t mask_w) {
+    Scalar one;
+    Scalar zero;
+
+    one.u = 1;
+    zero.u = 0;
+
+    cb_reserve_back(cb_mask, 1);
+    auto ptr = reinterpret_cast<int32_t*>(get_write_ptr(cb_mask));
+
+    for (uint32_t h = 0; h < 16; h++) {
+        // sub tile 0
+        {
+            uint32_t mask_w_0 = mask_w;
+            if (mask_w_0 >= 16)
+                mask_w_0 = 16;
+            uint32_t w = 0;
+            for (; w < mask_w_0; w++) {
+                ptr[h * 16 + w] = one.u;
+            }
+            for (; w < 16; w++) {
+                ptr[h * 16 + w] = zero.u;
+            }
+        }
+
+        // sub tile 1
+        {
+            uint32_t mask_w_1 = (mask_w < 16) ? 0 : mask_w - 16;
+            uint32_t w = 0;
+            for (; w < mask_w_1; w++) {
+                ptr[h * 16 + w + 256] = one.u;
+            }
+            for (; w < 16; w++) {
+                ptr[h * 16 + w + 256] = zero.u;
+            }
+        }
+
+        // sub tile 2
+        {
+            uint32_t mask_w_0 = mask_w;
+            if (mask_w_0 >= 16)
+                mask_w_0 = 16;
+            uint32_t w = 0;
+            for (; w < mask_w_0; w++) {
+                ptr[h * 16 + w + 512] = one.u;
+            }
+            for (; w < 16; w++) {
+                ptr[h * 16 + w + 512] = zero.u;
+            }
+        }
+
+        // sub tile 3
+        {
+            uint32_t mask_w_1 = (mask_w < 16) ? 0 : mask_w - 16;
+            uint32_t w = 0;
+            for (; w < mask_w_1; w++) {
+                ptr[h * 16 + w + 768] = one.u;
+            }
+            for (; w < 16; w++) {
+                ptr[h * 16 + w + 768] = zero.u;
+            }
+        }
+    }
+
+    cb_push_back(cb_mask, 1);
+}
+
 FORCE_INLINE void generate_mask_h_w(
     uint32_t cb_mask_h_w, uint32_t mask_h, uint32_t mask_w, uint32_t single_tile_size = 2048) {
     Scalar one;

--- a/tt_eager/tt_dnn/op_library/CMakeLists.txt
+++ b/tt_eager/tt_dnn/op_library/CMakeLists.txt
@@ -109,8 +109,11 @@ set(TT_DNN_SRCS
     ${CMAKE_CURRENT_SOURCE_DIR}/moreh_softmax_backward/softmax_backward_h_large/softmax_backward_h_large.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/moreh_softmax_backward/softmax_backward_c_large/softmax_backward_c_large.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/moreh_sum/moreh_sum_h_impl/moreh_sum_h_impl.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/moreh_sum/moreh_sum_h_impl/moreh_int_sum_h_impl.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/moreh_sum/moreh_sum_w_impl/moreh_sum_w_impl.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/moreh_sum/moreh_sum_w_impl/moreh_int_sum_w_impl.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/moreh_sum/moreh_sum_nc_impl/moreh_sum_nc_impl.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/moreh_sum/moreh_sum_nc_impl/moreh_int_sum_nc_impl.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/moreh_sum/moreh_sum_op.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/moreh_sum_backward/moreh_sum_backward_impl/moreh_sum_backward_impl.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/prod/prod_nc/prod_nc.cpp

--- a/tt_eager/tt_dnn/op_library/moreh_sum/moreh_sum_h_impl/kernels/moreh_int_sum_h.cpp
+++ b/tt_eager/tt_dnn/op_library/moreh_sum/moreh_sum_h_impl/kernels/moreh_int_sum_h.cpp
@@ -1,0 +1,94 @@
+// SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "compute_kernel_api/eltwise_unary/sfpu_int_sum.h"
+#include "tt_eager/tt_dnn/kernels/compute/moreh_common.hpp"
+
+namespace NAMESPACE {
+void MAIN {
+    constexpr uint32_t num_cols = get_compile_time_arg_val(0);
+    constexpr uint32_t Ht = get_compile_time_arg_val(1);
+    constexpr uint32_t origin_H = get_compile_time_arg_val(2);
+
+    auto cb_in0 = tt::CB::c_in0;
+    constexpr auto cb_mask_h = tt::CB::c_in1;
+    constexpr auto cb_out0 = tt::CB::c_out0;
+    constexpr auto cb_intermed0 = tt::CB::c_intermed0;
+    constexpr uint32_t TILE_H = 32;
+    constexpr bool do_mask_h = (origin_H % TILE_H) != 0;
+
+    unary_op_init_common(cb_in0, cb_out0);
+
+    constexpr int onetile = 1;
+    constexpr int idx0 = 0;
+    constexpr int dst0 = 0;
+    constexpr int dst1 = 1;
+
+    if (do_mask_h) {
+        cb_wait_front(cb_mask_h, onetile);
+    }
+
+    for (uint32_t col = 0; col < num_cols; ++col) {
+        constexpr bool is_single_ht = (Ht == 1);
+        if (is_single_ht) {
+            tile_regs_acquire();
+            copy_tile_to_dst(cb_in0, idx0, dst0);
+
+            if (do_mask_h) {
+                copy_tile_to_dst(cb_mask_h, idx0, dst1, false);
+                mask_tile_init();
+                int_mask_tile(dst0, dst1);
+            }
+
+            sfpu_sum_int_init();
+            sfpu_sum_int_col(dst0);
+            tile_regs_commit();
+
+            tile_regs_wait();
+            pack_tile_from_dst(cb_out0, dst0);
+            tile_regs_release();
+        } else {
+            for (uint32_t ht = 0; ht < Ht; ++ht) {
+                if (ht == 0) {
+                    tile_regs_acquire();
+                    copy_tile_to_dst(cb_in0, idx0, dst0);
+                    tile_regs_commit();
+
+                    tile_regs_wait();
+                    pack_tile_from_dst(cb_intermed0, dst0);
+                    tile_regs_release();
+                } else {
+                    tile_regs_acquire();
+                    copy_tile_to_dst(cb_in0, idx0, dst0);
+
+                    if (ht == Ht - 1 && do_mask_h) {
+                        copy_tile_to_dst(cb_mask_h, idx0, dst1, false);
+                        mask_tile_init();
+                        int_mask_tile(dst0, dst1);
+                    }
+
+                    copy_tile_to_dst(cb_intermed0, idx0, dst1);
+                    sfpu_sum_int_init();
+                    sfpu_add_int(dst0, dst1);
+                    tile_regs_commit();
+
+                    tile_regs_wait();
+                    pack_tile_from_dst(cb_intermed0, dst0);
+                    tile_regs_release();
+                }
+            }
+
+            tile_regs_acquire();
+            copy_tile_to_dst(cb_intermed0, idx0, dst0);
+            sfpu_sum_int_init();
+            sfpu_sum_int_col(dst0);
+            tile_regs_commit();
+
+            tile_regs_wait();
+            pack_tile_from_dst(cb_out0, dst0);
+            tile_regs_release();
+        }
+    }
+}
+}  // namespace NAMESPACE

--- a/tt_eager/tt_dnn/op_library/moreh_sum/moreh_sum_h_impl/kernels/moreh_int_sum_h.cpp
+++ b/tt_eager/tt_dnn/op_library/moreh_sum/moreh_sum_h_impl/kernels/moreh_int_sum_h.cpp
@@ -38,7 +38,7 @@ void MAIN {
             if (do_mask_h) {
                 copy_tile_to_dst(cb_mask_h, idx0, dst1, false);
                 mask_tile_init();
-                int_mask_tile(dst0, dst1);
+                mask_tile(dst0, dst1, DataFormat::Int32);
             }
 
             sfpu_sum_int_init();
@@ -65,7 +65,7 @@ void MAIN {
                     if (ht == Ht - 1 && do_mask_h) {
                         copy_tile_to_dst(cb_mask_h, idx0, dst1, false);
                         mask_tile_init();
-                        int_mask_tile(dst0, dst1);
+                        mask_tile(dst0, dst1, DataFormat::Int32);
                     }
 
                     copy_tile_to_dst(cb_intermed0, idx0, dst1);

--- a/tt_eager/tt_dnn/op_library/moreh_sum/moreh_sum_h_impl/kernels/reader_moreh_int_sum_h.cpp
+++ b/tt_eager/tt_dnn/op_library/moreh_sum/moreh_sum_h_impl/kernels/reader_moreh_int_sum_h.cpp
@@ -1,0 +1,58 @@
+// SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "tt_eager/tt_dnn/kernels/dataflow/moreh_common.hpp"
+
+void kernel_main() {
+    constexpr bool src_is_dram = get_compile_time_arg_val(0) == 1;
+    constexpr uint32_t Ht  = get_compile_time_arg_val(1);
+    constexpr uint32_t Wt  = get_compile_time_arg_val(2);
+
+    uint32_t src_addr  = get_arg_val<uint32_t>(0);
+    uint32_t col_start_tile_id = get_arg_val<uint32_t>(1); // Start id in column major order. This should be the start of a column
+    uint32_t curr_col_in_batch = get_arg_val<uint32_t>(2);
+    uint32_t num_cols = get_arg_val<uint32_t>(3); // number of cols to read
+    uint32_t mask_h = get_arg_val<uint32_t>(4);
+
+
+    constexpr uint32_t cb_id_in0 = 0;
+
+    // ublocks size defined in tiles
+    constexpr uint32_t onetile = 1;
+    const uint32_t tile_bytes = get_tile_size(cb_id_in0);
+    const DataFormat data_format = get_dataformat(cb_id_in0);
+
+#ifdef DO_MASK_H
+    constexpr uint32_t cb_id_mask_h = 1;
+    generate_int_mask_h(cb_id_mask_h, mask_h);
+#endif
+
+    const InterleavedAddrGenFast<src_is_dram> s = {
+        .bank_base_address = src_addr,
+        .page_size = tile_bytes,
+        .data_format = data_format
+    };
+
+    uint32_t w = curr_col_in_batch;
+
+    // this reader will read a NHW tensor in NWH order
+    for (uint32_t i = 0; i < num_cols; i++) {
+        uint32_t curr_id = col_start_tile_id;
+        for (uint32_t j = 0; j < Ht; j++) {
+            cb_reserve_back(cb_id_in0, onetile);
+            uint32_t l1_write_addr = get_write_ptr(cb_id_in0);
+            noc_async_read_tile(curr_id, s, l1_write_addr);
+            noc_async_read_barrier();
+            cb_push_back(cb_id_in0, onetile);
+            curr_id += Wt; // stride in H
+        }
+        w++;
+        if (w == Wt) {
+            col_start_tile_id = curr_id - Wt + 1;
+            w = 0;
+        } else {
+            col_start_tile_id++;
+        }
+    }
+}

--- a/tt_eager/tt_dnn/op_library/moreh_sum/moreh_sum_h_impl/kernels/writer_moreh_int_sum_h.cpp
+++ b/tt_eager/tt_dnn/op_library/moreh_sum/moreh_sum_h_impl/kernels/writer_moreh_int_sum_h.cpp
@@ -1,0 +1,45 @@
+// SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "dataflow_api.h"
+
+void kernel_main() {
+    constexpr bool dst_is_dram = get_compile_time_arg_val(0) == 1;
+
+    uint32_t dst_addr  = get_arg_val<uint32_t>(0);
+    uint32_t num_tiles = get_arg_val<uint32_t>(1);
+    uint32_t start_id = get_arg_val<uint32_t>(2);
+
+    constexpr uint32_t cb_id_out = 16;
+
+    // single-tile ublocks
+    constexpr uint32_t onetile = 1;
+    const uint32_t tile_bytes = get_tile_size(cb_id_out);
+    const DataFormat data_format = get_dataformat(cb_id_out);
+
+    const InterleavedAddrGenFast<dst_is_dram> s = {
+        .bank_base_address = dst_addr,
+        .page_size = tile_bytes,
+        .data_format = data_format
+    };
+
+    uint32_t end_id = start_id + num_tiles;
+    for (uint32_t i = start_id; i < end_id; ++ i) {
+        cb_wait_front(cb_id_out, onetile);
+
+        uint32_t l1_read_addr = get_read_ptr(cb_id_out);
+        volatile tt_l1_ptr int32_t* out_l1_ptr = reinterpret_cast<volatile tt_l1_ptr int32_t*>(l1_read_addr);
+
+        for (uint32_t w = 0; w < 16; w++) {
+            for (uint32_t subh = 1; subh < 4; ++subh) {
+                out_l1_ptr[w] += out_l1_ptr[w + (16 * subh)];
+                out_l1_ptr[w + 256] += out_l1_ptr[w + 256 + (16 * subh)];
+            }
+        }
+
+        noc_async_write_tile(i, s, l1_read_addr);
+        noc_async_write_barrier();
+        cb_pop_front(cb_id_out, onetile);
+    }
+}

--- a/tt_eager/tt_dnn/op_library/moreh_sum/moreh_sum_h_impl/moreh_int_sum_h_impl.cpp
+++ b/tt_eager/tt_dnn/op_library/moreh_sum/moreh_sum_h_impl/moreh_int_sum_h_impl.cpp
@@ -1,0 +1,416 @@
+// SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <algorithm>
+
+#include "tt_dnn/op_library/moreh_sum/moreh_sum_op.hpp"
+#include "tt_eager/tt_dnn/op_library/moreh_helper_functions.hpp"
+#include "tt_dnn/op_library/work_split.hpp"
+#include "tt_metal/common/constants.hpp"
+#include "tt_metal/detail/util.hpp"
+#include "tt_metal/host_api.hpp"
+
+namespace tt {
+using namespace constants;
+namespace operations {
+
+namespace primary {
+
+
+operation::ProgramWithCallbacks moreh_sum_int_h_impl(const Tensor &input, const Tensor &output, const DeviceComputeKernelConfig &compute_kernel_config) {
+    ////////////////////////////////////////////////////////////////////////////
+    //                      Device Setup
+    ////////////////////////////////////////////////////////////////////////////
+    tt_metal::Device *device{input.device()};
+    tt_metal::Program program{tt_metal::CreateProgram()};
+
+    ////////////////////////////////////////////////////////////////////////////
+    //                         Parameters Setup
+    ////////////////////////////////////////////////////////////////////////////
+    const auto cb_data_format{datatype_to_dataformat_converter(output.get_dtype())};
+    const auto shape{input.get_legacy_shape()};
+
+    const auto [W, H, other_dims_product] = extract_spatial_dims(shape);
+    uint32_t Wt{W / TILE_WIDTH};
+    uint32_t Ht{H / TILE_HEIGHT};
+    uint32_t HtWt{Ht * Wt};
+    uint32_t num_tiles = input.volume() / TILE_HW;
+    auto num_cols{other_dims_product * Wt};
+
+
+    // check mask for h-dim
+    const auto input_shape_without_padding {shape.without_padding()};
+    const auto origin_H {input_shape_without_padding[-2]};
+    const bool do_mask_h {(origin_H % TILE_HEIGHT) != 0};
+    const auto mask_h {do_mask_h ? origin_H % TILE_HEIGHT: TILE_HEIGHT};
+
+    auto [math_fidelity, math_approx_mode, fp32_dest_acc_en, packer_l1_acc] = get_compute_kernel_config_args(input.device()->arch(), compute_kernel_config);
+    log_debug(
+        LogOp,
+        "math_fidelity {} math_approx_mode {} fp32_dest_acc_en {} packer_l1_acc {}",
+        math_fidelity,
+        math_approx_mode,
+        fp32_dest_acc_en,
+        packer_l1_acc);
+
+    if (!fp32_dest_acc_en) {
+        log_warning(LogOp, "fp32_dest_acc_en should be set for integer sum");
+        fp32_dest_acc_en = true;
+    }
+    log_debug(LogOp, "do_mask_h {} mask_h {}", do_mask_h, mask_h);
+
+    ////////////////////////////////////////////////////////////////////////////
+    //                         Core Setup
+    ////////////////////////////////////////////////////////////////////////////
+    auto grid{device->compute_with_storage_grid_size()};
+    const auto num_cores_y{grid.y};
+
+    const uint32_t in0_t{2};        // input
+    const uint32_t in1_t{1};        // mask
+    const uint32_t intermed0_t{1};  // accumalated sum
+    const uint32_t out0_t{2};       // output
+    const auto
+        [num_cores,
+         all_cores,
+         core_group_1,
+         core_group_2,
+         num_cols_per_core_group_1,
+         num_cols_per_core_group_2] = tt_metal::split_work_to_cores(grid, num_cols);
+
+    log_debug(LogOp, "num_tiles {}, num_cols {}, num_cols_per_core_group_1 {}, num_cols_per_core_group_2 {}", num_tiles, num_cols, num_cols_per_core_group_1, num_cols_per_core_group_2);
+
+    ////////////////////////////////////////////////////////////////////////////
+    //                         CircularBuffer Setup
+    ////////////////////////////////////////////////////////////////////////////
+    CreateCircularBuffer(
+        program,
+        all_cores,
+        cb_data_format,
+        {
+            {CB::c_in0, in0_t},              // input
+            {CB::c_in1, in1_t},              // mask
+            {CB::c_intermed0, intermed0_t},  // accumalated sum
+            {CB::c_out0, out0_t},            // output
+        });
+    ////////////////////////////////////////////////////////////////////////////
+    //                      DataMovementKernel SetUp
+    ////////////////////////////////////////////////////////////////////////////
+    std::vector<uint32_t> reader_compile_time_args = {static_cast<uint32_t>(is_dram(input)), Ht, Wt};
+    std::map<string, string> reader_defines{};
+    if (do_mask_h) {
+        reader_defines["DO_MASK_H"] = "1";
+    }
+    std::vector<uint32_t> writer_compile_time_args = {static_cast<uint32_t>(is_dram(output))};
+    const auto reader_kernel_file{
+        "tt_eager/tt_dnn/op_library/moreh_sum/moreh_sum_h_impl/kernels/reader_moreh_int_sum_h.cpp"};
+    const auto writer_kernel_file{
+        "tt_eager/tt_dnn/op_library/moreh_sum/moreh_sum_h_impl/kernels/writer_moreh_int_sum_h.cpp"};
+    const auto reader_kernel_id{
+        CreateReadKernel(program, reader_kernel_file, all_cores, reader_compile_time_args, reader_defines)};
+    const auto writer_kernel_id{CreateWriteKernel(program, writer_kernel_file, all_cores, writer_compile_time_args)};
+
+    ////////////////////////////////////////////////////////////////////////////
+    //                      ComputeKernel SetUp
+    ////////////////////////////////////////////////////////////////////////////
+    const std::vector<uint32_t> compute_args_group_1{
+        num_cols_per_core_group_1,  // num_cols
+        Ht,                         // Ht
+        origin_H};
+
+    std::map<string, string> compute_defines;
+    if (fp32_dest_acc_en) {
+        compute_defines["FP32_DEST_ACC_EN"] = "1";
+    }
+    const auto compute_kernel_file{"tt_eager/tt_dnn/op_library/moreh_sum/moreh_sum_h_impl/kernels/moreh_int_sum_h.cpp"};
+    const auto compute_kernel_1_id = CreateComputeKernel(
+        program, compute_kernel_file, {core_group_1, num_cols_per_core_group_1, compute_args_group_1}, compute_defines,
+        math_fidelity,
+        fp32_dest_acc_en,
+        math_approx_mode);
+
+    std::optional<KernelHandle> compute_kernel_2_id{std::nullopt};
+    if (!core_group_2.ranges().empty()) {
+        const std::vector<uint32_t> compute_args_group_2{
+            num_cols_per_core_group_2,  // num_cols
+            Ht,                         // Ht
+            origin_H};
+        compute_kernel_2_id = CreateComputeKernel(
+            program,
+            compute_kernel_file,
+            {core_group_2, num_cols_per_core_group_2, compute_args_group_2},
+            compute_defines,
+            math_fidelity,
+            fp32_dest_acc_en,
+            math_approx_mode);
+    }
+
+    ////////////////////////////////////////////////////////////////////////////
+    //                      RuntimeArgs SetUp
+    ////////////////////////////////////////////////////////////////////////////
+    uint32_t out_dim_divider{Wt};
+    for (uint32_t i = 0, num_cols_read = 0; i < num_cores; ++i) {
+        CoreCoord core = {i / num_cores_y, i % num_cores_y};
+
+        uint32_t num_cols_per_core{0};
+        if (core_group_1.core_coord_in_core_ranges(core)) {
+            num_cols_per_core = num_cols_per_core_group_1;
+        } else if (core_group_2.core_coord_in_core_ranges(core)) {
+            num_cols_per_core = num_cols_per_core_group_2;
+        } else {
+            TT_THROW("Core not in specified core ranges.");
+        }
+
+        SetRuntimeArgs(
+            program,
+            reader_kernel_id,
+            core,
+            {input.buffer()->address(),
+             num_cols_read / Wt * HtWt + num_cols_read % Wt,
+             num_cols_read % Wt,
+             num_cols_per_core,
+             mask_h});
+
+        SetRuntimeArgs(
+            program,
+            writer_kernel_id,
+            core,
+            {
+                output.buffer()->address(),
+                num_cols_per_core,  // number of tiles to write
+                num_cols_read       // output tile start index
+            });
+
+        num_cols_read += num_cols_per_core;
+    }
+
+     auto override_runtime_args_callback = [reader_kernel_id, writer_kernel_id, num_cores, num_cores_y](
+                                              const Program &program,
+                                              const std::vector<Buffer *> &input_buffers,
+                                              const std::vector<Buffer *> &output_buffers) {
+        log_debug(LogOp, "{}:{} args_callback ", __func__, __LINE__);
+        auto src_dram_buffer{input_buffers.at(0)};
+        auto dst_dram_buffer{output_buffers.at(0)};
+
+        for (uint32_t i = 0, num_tiles_read = 0; i < num_cores; i++) {
+            CoreCoord core = {i / num_cores_y, i % num_cores_y};
+
+            {
+                auto &runtime_args = GetRuntimeArgs(program, reader_kernel_id, core);
+                runtime_args[0] = src_dram_buffer->address();
+            }
+
+            {
+                auto &runtime_args = GetRuntimeArgs(program, writer_kernel_id, core);
+                runtime_args[0] = dst_dram_buffer->address();
+            }
+        }
+    };
+
+    return {std::move(program), override_runtime_args_callback};
+
+
+
+    // const Shape shape { input.get_legacy_shape() };
+    // const auto [W, H, other_dims_product] = extract_spatial_dims(shape);
+
+    // uint32_t Wt{W / TILE_WIDTH};
+    // uint32_t Ht{H / TILE_HEIGHT};
+    // uint32_t HtWt{Ht * Wt};
+
+    // // check mask for h-dim
+    // const auto input_shape_without_padding = shape.without_padding();
+    // const auto origin_H = input_shape_without_padding[-2];
+    // const bool do_mask_h = (origin_H % TILE_HEIGHT) != 0;
+    // const auto mask_h = do_mask_h ? origin_H % TILE_HEIGHT : TILE_HEIGHT;
+
+    // auto [math_fidelity, math_approx_mode, fp32_dest_acc_en, packer_l1_acc] = get_compute_kernel_config_args(input.device()->arch(), compute_kernel_config);
+    // log_debug(
+    //     LogOp,
+    //     "math_fidelity {} math_approx_mode {} fp32_dest_acc_en {} packer_l1_acc {}",
+    //     math_fidelity,
+    //     math_approx_mode,
+    //     fp32_dest_acc_en,
+    //     packer_l1_acc);
+
+    // if (!fp32_dest_acc_en) {
+    //     log_warning(LogOp, "fp32_dest_acc_en should be set for integer sum");
+    //     fp32_dest_acc_en = true;
+    // }
+
+    // tt_metal::Program program = tt_metal::CreateProgram();
+
+    // tt::DataFormat src0_cb_data_format = tt_metal::datatype_to_dataformat_converter(input.get_dtype());
+    // uint32_t src0_single_tile_size = tt_metal::detail::TileSize(src0_cb_data_format);
+    // tt::DataFormat mask_h_cb_data_format = src0_cb_data_format;
+    // uint32_t mask_h_single_tile_size = tt_metal::detail::TileSize(mask_h_cb_data_format);
+    // tt::DataFormat intermed_cb_data_format = src0_cb_data_format;
+    // uint32_t intermed_single_tile_size = tt_metal::detail::TileSize(intermed_cb_data_format);
+    // tt::DataFormat dst_cb_data_format = tt_metal::datatype_to_dataformat_converter(output.get_dtype());
+    // uint32_t dst_single_tile_size = tt_metal::detail::TileSize(dst_cb_data_format);
+    // uint32_t num_tiles = input.volume() / TILE_HW;
+
+    // log_debug(LogOp, "do_mask_h {} mask_h {}", do_mask_h, mask_h);
+    // log_debug(LogOp, "num_tiles {}", num_tiles);
+
+    // tt_metal::Device *device = input.device();
+
+    // auto compute_with_storage_grid_size = device->compute_with_storage_grid_size();
+    // uint32_t num_cores_x = compute_with_storage_grid_size.x;
+    // uint32_t num_cores_y = compute_with_storage_grid_size.y;
+    // auto num_cols = other_dims_product * Wt;
+    // auto [num_cores, all_cores, core_group_1, core_group_2, num_cols_per_core_group_1, num_cols_per_core_group_2] =
+    //     split_work_to_cores(compute_with_storage_grid_size, num_cols);
+
+    // string compute_kernel_name = "tt_eager/tt_dnn/op_library/moreh_sum/moreh_sum_h_impl/kernels/moreh_sum_h_int.cpp";
+
+    // uint32_t src0_cb_index = CB::c_in0;
+    // uint32_t num_input_tiles = 2;
+    // tt_metal::CircularBufferConfig cb_src0_config =
+    //     tt_metal::CircularBufferConfig(num_input_tiles * src0_single_tile_size, {{src0_cb_index, src0_cb_data_format}})
+    //         .set_page_size(src0_cb_index, src0_single_tile_size);
+    // tt_metal::CreateCircularBuffer(program, all_cores, cb_src0_config);
+
+    // tt_metal::CircularBufferConfig cb_mask_h_config =
+    //     tt_metal::CircularBufferConfig(mask_h_single_tile_size, {{CB::c_in1, mask_h_cb_data_format}})
+    //         .set_page_size(CB::c_in1, mask_h_single_tile_size);
+    // auto cb_mask_h = tt_metal::CreateCircularBuffer(program, all_cores, cb_mask_h_config);
+
+    // tt_metal::CircularBufferConfig cb_intermed0_config =
+    //     tt_metal::CircularBufferConfig(intermed_single_tile_size, {{CB::c_intermed0, intermed_cb_data_format}})
+    //         .set_page_size(CB::c_intermed0, intermed_single_tile_size);
+    // auto cb_intermed0 = tt_metal::CreateCircularBuffer(program, all_cores, cb_intermed0_config);
+
+    // uint32_t output_cb_index = CB::c_out0;  // output operands start at index 16
+    // uint32_t num_output_tiles = 2;
+    // tt_metal::CircularBufferConfig cb_output_config =
+    //     tt_metal::CircularBufferConfig(num_output_tiles * dst_single_tile_size, {{output_cb_index, dst_cb_data_format}})
+    //         .set_page_size(output_cb_index, dst_single_tile_size);
+    // tt_metal::CreateCircularBuffer(program, all_cores, cb_output_config);
+
+    // tt_metal::Buffer *src0_buffer = input.buffer();
+    // tt_metal::KernelHandle reader_kernel_id;
+    // bool src0_is_dram = src0_buffer->buffer_type() == tt_metal::BufferType::DRAM ? 1 : 0;
+    // std::vector<uint32_t> reader_compile_time_args = {(std::uint32_t)src0_is_dram, Ht, Wt, HtWt};
+
+    // std::map<string, string> reader_defines;
+    // if (do_mask_h) {
+    //     reader_defines["DO_MASK_H"] = "1";
+    // }
+    // reader_kernel_id = tt_metal::CreateKernel(
+    //     program,
+    //     "tt_eager/tt_dnn/op_library/moreh_sum/moreh_sum_h_impl/kernels/reader_moreh_sum_h_int.cpp",
+    //     all_cores,
+    //     tt_metal::ReaderDataMovementConfig(reader_compile_time_args, reader_defines));
+
+    // tt_metal::Buffer *dst_buffer = output.buffer();
+    // tt_metal::KernelHandle writer_kernel_id;
+
+    // bool dst_is_dram = dst_buffer->buffer_type() == tt_metal::BufferType::DRAM ? 1 : 0;
+    // std::vector<uint32_t> writer_compile_time_args = {(std::uint32_t)output_cb_index, (std::uint32_t)dst_is_dram};
+
+    // writer_kernel_id = tt_metal::CreateKernel(
+    //     program,
+    //     "tt_eager/tt_dnn/op_library/moreh_sum/moreh_sum_h_impl/kernels/writer_moreh_sum_h_int.cpp",
+    //     all_cores,
+    //     tt_metal::WriterDataMovementConfig(writer_compile_time_args));
+    // std::map<string, string> reduce_defines;
+    // if (fp32_dest_acc_en) {
+    //     reduce_defines["FP32_DEST_ACC_EN"] = "1";
+    // }
+
+    // vector<uint32_t> compute_kernel_args_group_1 = {
+    //     Ht,                         // Ht
+    //     num_cols_per_core_group_1,  // Wt
+    //     1,                          // NC
+    //     origin_H
+    // };
+
+    // auto reduce_compute_kernel_group_1_id = tt_metal::CreateKernel(
+    //     program,
+    //     compute_kernel_name,
+    //     core_group_1,
+    //     tt_metal::ComputeConfig{.math_fidelity = math_fidelity, .fp32_dest_acc_en = fp32_dest_acc_en, .math_approx_mode = math_approx_mode, .compile_args = compute_kernel_args_group_1, .defines = reduce_defines});
+
+    // if (!core_group_2.ranges().empty()) {
+    //     vector<uint32_t> compute_kernel_args_group_2 = {
+    //         Ht,                         // Ht
+    //         num_cols_per_core_group_2,  // Wt
+    //         1,                          // NC
+    //         origin_H
+    //     };
+
+    //     auto reduce_compute_kernel_group_2_id = tt_metal::CreateKernel(
+    //         program,
+    //         compute_kernel_name,
+    //         core_group_2,
+    //         tt_metal::ComputeConfig{.math_fidelity = math_fidelity, .fp32_dest_acc_en = fp32_dest_acc_en, .math_approx_mode = math_approx_mode, .compile_args = compute_kernel_args_group_2, .defines = reduce_defines});
+    // }
+
+    // for (uint32_t i = 0, num_cols_read = 0; i < num_cores; i++) {
+    //     CoreCoord core = {i / num_cores_y, i % num_cores_y};
+    //     uint32_t num_cols_per_core = 0;
+    //     if (core_group_1.core_coord_in_core_ranges(core)) {
+    //         num_cols_per_core = num_cols_per_core_group_1;
+    //     } else if (core_group_2.core_coord_in_core_ranges(core)) {
+    //         num_cols_per_core = num_cols_per_core_group_2;
+    //     } else {
+    //         TT_ASSERT(false, "Core not in specified core ranges");
+    //     }
+    //     tt_metal::SetRuntimeArgs(
+    //         program,
+    //         reader_kernel_id,
+    //         core,
+    //         {input.buffer()->address(),
+    //          num_cols_read / Wt * HtWt + num_cols_read % Wt,
+    //          num_cols_read % Wt,
+    //          num_cols_per_core,
+    //          mask_h
+    //          });
+
+    //     tt_metal::SetRuntimeArgs(
+    //         program,
+    //         writer_kernel_id,
+    //         core,
+    //         {
+    //             output.buffer()->address(),
+    //             num_cols_per_core,  // number of tiles to write
+    //             num_cols_read       // output tile start index
+    //         });
+    //     num_cols_read += num_cols_per_core;
+    // }
+
+    // auto override_runtime_arguments_callback = [reader_kernel_id = reader_kernel_id,
+    //                                             writer_kernel_id = writer_kernel_id,
+    //                                             num_cores = num_cores,
+    //                                             num_cores_y = num_cores_y](
+    //                                                const void *operation,
+    //                                                Program &program,
+    //                                                const std::vector<Tensor> &input_tensors,
+    //                                                const std::vector<std::optional<const Tensor>> &,
+    //                                                const std::vector<Tensor> &output_tensors) {
+    //     log_debug(LogOp, "{}:{} args_callback ", __func__, __LINE__);
+    //     auto src_buffer = input_tensors.at(0).buffer();
+    //     auto dst_buffer = output_tensors.at(0).buffer();
+
+    //     for (uint32_t i = 0, num_tiles_read = 0; i < num_cores; i++) {
+    //         CoreCoord core = {i / num_cores_y, i % num_cores_y};
+
+    //         {
+    //             auto &runtime_args = GetRuntimeArgs(program, reader_kernel_id, core);
+    //             runtime_args[0] = src_buffer->address();
+    //         }
+
+    //         {
+    //             auto &runtime_args = GetRuntimeArgs(program, writer_kernel_id, core);
+    //             runtime_args[0] = dst_buffer->address();
+    //         }
+    //     }
+    // };
+
+    // return {.program = std::move(program), .override_runtime_arguments_callback = override_runtime_arguments_callback};
+}
+
+}  // namespace primary
+}  // namespace operations
+}  // namespace tt

--- a/tt_eager/tt_dnn/op_library/moreh_sum/moreh_sum_nc_impl/kernels/moreh_int_sum_nc.cpp
+++ b/tt_eager/tt_dnn/op_library/moreh_sum/moreh_sum_nc_impl/kernels/moreh_int_sum_nc.cpp
@@ -1,0 +1,44 @@
+// SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "compute_kernel_api/eltwise_unary/sfpu_int_sum.h"
+#include "tt_eager/tt_dnn/kernels/compute/moreh_common.hpp"
+
+namespace NAMESPACE {
+void MAIN {
+    // compile-time args
+    constexpr uint32_t num_output_tiles = get_compile_time_arg_val(0);
+    constexpr uint32_t num_input_tiles = get_compile_time_arg_val(1);
+
+    constexpr auto cb_in0 = tt::CB::c_in0;
+    constexpr auto cb_out0 = tt::CB::c_out0;
+    constexpr auto cb_intermed0 = tt::CB::c_intermed0;
+    constexpr int onetile = 1;
+    constexpr int idx0 = 0;
+    constexpr int dst0 = 0;
+    constexpr int dst1 = 1;
+
+    unary_op_init_common(cb_in0, cb_out0);
+    for (uint32_t i = 0; i < num_output_tiles; i++) {
+        bool enable_reload = false;
+        for (uint32_t j = 0; j < num_input_tiles; ++j) {
+            bool last_out = (j == num_input_tiles - 1);
+            tile_regs_acquire();
+            copy_tile_to_dst(cb_in0, idx0, dst0);
+            if (enable_reload) {
+                copy_tile_to_dst(cb_intermed0, idx0, dst1);
+                sfpu_sum_int_init();
+                sfpu_add_int(dst0, dst1);
+            }
+            tile_regs_commit();
+
+            tile_regs_wait();
+            uint32_t cb_out = (last_out) ? (cb_out0) : (cb_intermed0);
+            pack_tile_from_dst(cb_out, dst0);
+            tile_regs_release();
+            enable_reload = true;
+        }
+    }
+}
+}  // namespace NAMESPACE

--- a/tt_eager/tt_dnn/op_library/moreh_sum/moreh_sum_nc_impl/kernels/reader_moreh_sum_nc.cpp
+++ b/tt_eager/tt_dnn/op_library/moreh_sum/moreh_sum_nc_impl/kernels/reader_moreh_sum_nc.cpp
@@ -24,6 +24,7 @@ void kernel_main() {
 
     constexpr uint32_t onetile = 1;
     constexpr uint32_t cb_id_in0 = 0;
+    #ifdef USE_FPU
     constexpr uint32_t cb_id_in1 = 1;
 
     union {
@@ -32,6 +33,7 @@ void kernel_main() {
     } scaler;
     scaler.f = 0.0f;
     fill_cb_with_value(cb_id_in1, scaler.u);
+    #endif
 
     uint32_t l1_write_addr_in0;
     uint32_t input_tile_bytes = get_tile_size(cb_id_in0);

--- a/tt_eager/tt_dnn/op_library/moreh_sum/moreh_sum_w_impl/kernels/moreh_int_sum_w.cpp
+++ b/tt_eager/tt_dnn/op_library/moreh_sum/moreh_sum_w_impl/kernels/moreh_int_sum_w.cpp
@@ -1,0 +1,93 @@
+// SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "compute_kernel_api/eltwise_unary/sfpu_int_sum.h"
+#include "tt_eager/tt_dnn/kernels/compute/moreh_common.hpp"
+
+namespace NAMESPACE {
+
+void MAIN {
+    constexpr uint32_t num_rows = get_compile_time_arg_val(0);
+    constexpr uint32_t Wt = get_compile_time_arg_val(1);
+    constexpr uint32_t origin_W = get_compile_time_arg_val(2);
+
+    constexpr auto cb_in0 = tt::CB::c_in0;
+    constexpr auto cb_mask_w = tt::CB::c_in1;
+    constexpr auto cb_intermed0 = tt::CB::c_intermed0;
+    constexpr auto cb_out0 = tt::CB::c_out0;
+    constexpr uint32_t TILE_W = 32;
+    constexpr bool do_mask_w = (origin_W % TILE_W) != 0;
+    constexpr int onetile = 1;
+    constexpr int idx0 = 0;
+    constexpr int dst0 = 0;
+    constexpr int dst1 = 1;
+
+    unary_op_init_common(cb_in0, cb_out0);
+
+    if (do_mask_w) {
+        cb_wait_front(cb_mask_w, onetile);
+    }
+
+    for (uint32_t row = 0; row < num_rows; ++row) {
+        constexpr bool is_single_wt = (Wt == 1);
+        if (is_single_wt) {
+            tile_regs_acquire();
+            copy_tile_to_dst(cb_in0, idx0, dst0);
+
+            if (do_mask_w) {
+                copy_tile_to_dst(cb_mask_w, idx0, dst1, false);
+                mask_tile_init();
+                int_mask_tile(dst0, dst1);
+            }
+
+            sfpu_sum_int_init();
+            sfpu_sum_int_row(dst0);
+            tile_regs_commit();
+
+            tile_regs_wait();
+            pack_tile_from_dst(cb_out0, dst0);
+            tile_regs_release();
+        } else {
+            for (uint32_t wt = 0; wt < Wt; ++wt) {
+                if (wt == 0) {
+                    tile_regs_acquire();
+                    copy_tile_to_dst(cb_in0, idx0, dst0);
+                    tile_regs_commit();
+
+                    tile_regs_wait();
+                    pack_tile_from_dst(cb_intermed0, dst0);
+                    tile_regs_release();
+                } else {
+                    tile_regs_acquire();
+                    copy_tile_to_dst(cb_in0, idx0, dst0);
+                    if (wt == Wt - 1 && do_mask_w) {
+                        copy_tile_to_dst(cb_mask_w, idx0, dst1, false);
+                        mask_tile_init();
+                        int_mask_tile(dst0, dst1);
+                    }
+
+                    copy_tile_to_dst(cb_intermed0, idx0, dst1);
+                    sfpu_sum_int_init();
+                    sfpu_add_int(dst0, dst1);
+                    tile_regs_commit();
+
+                    tile_regs_wait();
+                    pack_tile_from_dst(cb_intermed0, dst0);
+                    tile_regs_release();
+                }
+            }
+
+            tile_regs_acquire();
+            copy_tile_to_dst(cb_intermed0, idx0, dst0);
+            sfpu_sum_int_init();
+            sfpu_sum_int_row(dst0);
+            tile_regs_commit();
+
+            tile_regs_wait();
+            pack_tile_from_dst(cb_out0, dst0);
+            tile_regs_release();
+        }
+    }
+}
+}  // namespace NAMESPACE

--- a/tt_eager/tt_dnn/op_library/moreh_sum/moreh_sum_w_impl/kernels/moreh_int_sum_w.cpp
+++ b/tt_eager/tt_dnn/op_library/moreh_sum/moreh_sum_w_impl/kernels/moreh_int_sum_w.cpp
@@ -38,7 +38,7 @@ void MAIN {
             if (do_mask_w) {
                 copy_tile_to_dst(cb_mask_w, idx0, dst1, false);
                 mask_tile_init();
-                int_mask_tile(dst0, dst1);
+                mask_tile(dst0, dst1, DataFormat::Int32);
             }
 
             sfpu_sum_int_init();
@@ -64,7 +64,7 @@ void MAIN {
                     if (wt == Wt - 1 && do_mask_w) {
                         copy_tile_to_dst(cb_mask_w, idx0, dst1, false);
                         mask_tile_init();
-                        int_mask_tile(dst0, dst1);
+                        mask_tile(dst0, dst1, DataFormat::Int32);
                     }
 
                     copy_tile_to_dst(cb_intermed0, idx0, dst1);

--- a/tt_eager/tt_dnn/op_library/moreh_sum/moreh_sum_w_impl/kernels/reader_moreh_int_sum_w.cpp
+++ b/tt_eager/tt_dnn/op_library/moreh_sum/moreh_sum_w_impl/kernels/reader_moreh_int_sum_w.cpp
@@ -1,0 +1,36 @@
+// SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "tt_eager/tt_dnn/kernels/dataflow/moreh_common.hpp"
+
+void kernel_main() {
+    constexpr bool src_is_dram = get_compile_time_arg_val(0) == 1;
+
+    uint32_t src_addr = get_arg_val<uint32_t>(0);
+    uint32_t num_tiles = get_arg_val<uint32_t>(1);
+    uint32_t start_id = get_arg_val<uint32_t>(2);
+    uint32_t mask_w = get_arg_val<uint32_t>(3);
+
+    constexpr uint32_t cb_id_in0 = 0;
+    constexpr uint32_t cb_id_mask_w = 1;
+#ifdef DO_MASK_W
+    generate_int_mask_w(cb_id_mask_w, mask_w);
+#endif
+
+    // ublocks size defined in tiles
+    constexpr uint32_t onetile = 1;
+    uint32_t tile_bytes = get_tile_size(cb_id_in0);
+    const DataFormat data_format = get_dataformat(cb_id_in0);
+    const InterleavedAddrGenFast<src_is_dram> s = {
+        .bank_base_address = src_addr, .page_size = tile_bytes, .data_format = data_format};
+
+    // read a ublock of tiles from src to CB, and then push the ublock to unpacker
+    for (uint32_t i = start_id; i < start_id + num_tiles; i++) {
+        cb_reserve_back(cb_id_in0, onetile);
+        uint32_t l1_write_addr = get_write_ptr(cb_id_in0);
+        noc_async_read_tile(i, s, l1_write_addr);
+        noc_async_read_barrier();
+        cb_push_back(cb_id_in0, onetile);
+    }
+}

--- a/tt_eager/tt_dnn/op_library/moreh_sum/moreh_sum_w_impl/kernels/writer_moreh_int_sum_w.cpp
+++ b/tt_eager/tt_dnn/op_library/moreh_sum/moreh_sum_w_impl/kernels/writer_moreh_int_sum_w.cpp
@@ -1,0 +1,44 @@
+// SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "dataflow_api.h"
+
+void kernel_main() {
+    constexpr bool dst_is_dram = get_compile_time_arg_val(0) == 1;
+
+    uint32_t dst_addr  = get_arg_val<uint32_t>(0);
+    uint32_t num_tiles = get_arg_val<uint32_t>(1);
+    uint32_t start_id = get_arg_val<uint32_t>(2);
+
+    constexpr uint32_t cb_id_out = 16;
+
+    // single-tile ublocks
+    constexpr uint32_t onetile = 1;
+    const uint32_t tile_bytes = get_tile_size(cb_id_out);
+    const DataFormat data_format = get_dataformat(cb_id_out);
+
+    const InterleavedAddrGenFast<dst_is_dram> s = {
+        .bank_base_address = dst_addr,
+        .page_size = tile_bytes,
+        .data_format = data_format
+    };
+
+    uint32_t end_id = start_id + num_tiles;
+    for (uint32_t i = start_id; i < end_id; ++ i) {
+        cb_wait_front(cb_id_out, onetile);
+        uint32_t l1_read_addr = get_read_ptr(cb_id_out);
+
+        volatile tt_l1_ptr int32_t* out_l1_ptr = reinterpret_cast<volatile tt_l1_ptr int32_t*>(l1_read_addr);
+        for (uint32_t h = 0; h < 16; h++) {
+            for (uint32_t subw = 1; subw < 8; ++subw) {
+                out_l1_ptr[h * 16] += out_l1_ptr[h * 16 + (2 * subw)];
+                out_l1_ptr[(h * 16) + 512] += out_l1_ptr[(h * 16) + 512 + (2 * subw)];
+            }
+        }
+
+        noc_async_write_tile(i, s, l1_read_addr);
+        noc_async_write_barrier();
+        cb_pop_front(cb_id_out, onetile);
+    }
+}

--- a/tt_eager/tt_dnn/op_library/moreh_sum/moreh_sum_w_impl/moreh_int_sum_w_impl.cpp
+++ b/tt_eager/tt_dnn/op_library/moreh_sum/moreh_sum_w_impl/moreh_int_sum_w_impl.cpp
@@ -1,0 +1,217 @@
+// SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+// based on reduce_op_multi_core_w.cpp in reduce op
+
+#include <algorithm>
+
+#include "tt_dnn/op_library/moreh_sum/moreh_sum_op.hpp"
+#include "tt_eager/tt_dnn/op_library/moreh_helper_functions.hpp"
+#include "tt_dnn/op_library/work_split.hpp"
+#include "tt_metal/common/constants.hpp"
+#include "tt_metal/detail/util.hpp"
+#include "tt_metal/host_api.hpp"
+
+namespace tt {
+using namespace constants;
+namespace operations {
+
+namespace primary {
+
+operation::ProgramWithCallbacks moreh_sum_int_w_impl(const Tensor &input, const Tensor &output, const DeviceComputeKernelConfig &compute_kernel_config) {
+    ////////////////////////////////////////////////////////////////////////////
+    //                      Device Setup
+    ////////////////////////////////////////////////////////////////////////////
+    tt_metal::Device *device{input.device()};
+    tt_metal::Program program{tt_metal::CreateProgram()};
+
+    ////////////////////////////////////////////////////////////////////////////
+    //                         Parameters Setup
+    ////////////////////////////////////////////////////////////////////////////
+    const auto cb_data_format{datatype_to_dataformat_converter(output.get_dtype())};
+    const auto shape{input.get_legacy_shape()};
+
+    const auto [W, H, other_dims_product] = extract_spatial_dims(shape);
+    uint32_t Wt{W / TILE_WIDTH};
+    uint32_t Ht{H / TILE_HEIGHT};
+    uint32_t num_tiles = input.volume() / TILE_HW;
+    auto num_rows{other_dims_product * Ht};
+
+
+    // check mask for w-dim
+    const auto input_shape_without_padding {shape.without_padding()};
+    const auto origin_W {input_shape_without_padding[-1]};
+    const bool do_mask_w {(origin_W % TILE_WIDTH) != 0};
+    const auto mask_w {do_mask_w ? origin_W % TILE_WIDTH : TILE_WIDTH};
+
+    auto [math_fidelity, math_approx_mode, fp32_dest_acc_en, packer_l1_acc] = get_compute_kernel_config_args(input.device()->arch(), compute_kernel_config);
+    log_debug(
+        LogOp,
+        "math_fidelity {} math_approx_mode {} fp32_dest_acc_en {} packer_l1_acc {}",
+        math_fidelity,
+        math_approx_mode,
+        fp32_dest_acc_en,
+        packer_l1_acc);
+
+    if (!fp32_dest_acc_en) {
+        log_warning(LogOp, "fp32_dest_acc_en should be set for integer sum");
+        fp32_dest_acc_en = true;
+    }
+    log_debug(LogOp, "do_mask_w {} mask_w {}", do_mask_w, mask_w);
+
+    ////////////////////////////////////////////////////////////////////////////
+    //                         Core Setup
+    ////////////////////////////////////////////////////////////////////////////
+    auto grid{device->compute_with_storage_grid_size()};
+    const auto num_cores_y{grid.y};
+
+    const uint32_t in0_t{2};        // input
+    const uint32_t in1_t{1};        // mask
+    const uint32_t intermed0_t{1};  // accumalated sum
+    const uint32_t out0_t{2};       // output
+    const auto
+        [num_cores,
+         all_cores,
+         core_group_1,
+         core_group_2,
+         num_rows_per_core_group_1,
+         num_rows_per_core_group_2] = tt_metal::split_work_to_cores(grid, num_rows);
+
+    log_debug(LogOp, "num_tiles {}, num_rows {}, num_rows_per_core_group_1 {}, num_rows_per_core_group_2 {}", num_tiles, num_rows, num_rows_per_core_group_1, num_rows_per_core_group_2);
+
+    ////////////////////////////////////////////////////////////////////////////
+    //                         CircularBuffer Setup
+    ////////////////////////////////////////////////////////////////////////////
+    CreateCircularBuffer(
+        program,
+        all_cores,
+        cb_data_format,
+        {
+            {CB::c_in0, in0_t},              // input
+            {CB::c_in1, in1_t},              // mask
+            {CB::c_intermed0, intermed0_t},  // accumalated sum
+            {CB::c_out0, out0_t},            // output
+        });
+    ////////////////////////////////////////////////////////////////////////////
+    //                      DataMovementKernel SetUp
+    ////////////////////////////////////////////////////////////////////////////
+    std::vector<uint32_t> reader_compile_time_args =
+             {static_cast<uint32_t>(is_dram(input))} ;
+    std::map<string, string> reader_defines{};
+    if (do_mask_w) {
+        reader_defines["DO_MASK_W"] = "1";
+    }
+    std::vector<uint32_t> writer_compile_time_args = {static_cast<uint32_t>(is_dram(output))};
+    const auto reader_kernel_file{
+        "tt_eager/tt_dnn/op_library/moreh_sum/moreh_sum_w_impl/kernels/reader_moreh_int_sum_w.cpp"};
+    const auto writer_kernel_file{
+        "tt_eager/tt_dnn/op_library/moreh_sum/moreh_sum_w_impl/kernels/writer_moreh_int_sum_w.cpp"};
+    const auto reader_kernel_id{
+        CreateReadKernel(program, reader_kernel_file, all_cores, reader_compile_time_args, reader_defines)};
+    const auto writer_kernel_id{CreateWriteKernel(program, writer_kernel_file, all_cores, writer_compile_time_args)};
+
+    ////////////////////////////////////////////////////////////////////////////
+    //                      ComputeKernel SetUp
+    ////////////////////////////////////////////////////////////////////////////
+    const std::vector<uint32_t> compute_args_group_1{
+        num_rows_per_core_group_1,  // num_rows
+        Wt,                         // Wt
+        origin_W};
+
+    std::map<string, string> compute_defines;
+    if (fp32_dest_acc_en) {
+        compute_defines["FP32_DEST_ACC_EN"] = "1";
+    }
+    const auto compute_kernel_file{"tt_eager/tt_dnn/op_library/moreh_sum/moreh_sum_w_impl/kernels/moreh_int_sum_w.cpp"};
+    const auto compute_kernel_1_id = CreateComputeKernel(
+        program, compute_kernel_file, {core_group_1, num_rows_per_core_group_1, compute_args_group_1}, compute_defines,
+        math_fidelity,
+        fp32_dest_acc_en,
+        math_approx_mode);
+
+    std::optional<KernelHandle> compute_kernel_2_id{std::nullopt};
+    if (!core_group_2.ranges().empty()) {
+        const std::vector<uint32_t> compute_args_group_2{
+            num_rows_per_core_group_2,  // num_rows
+            Wt,                         // Wt
+            origin_W};
+        compute_kernel_2_id = CreateComputeKernel(
+            program,
+            compute_kernel_file,
+            {core_group_2, num_rows_per_core_group_2, compute_args_group_2},
+            compute_defines,
+            math_fidelity,
+            fp32_dest_acc_en,
+            math_approx_mode);
+    }
+
+    ////////////////////////////////////////////////////////////////////////////
+    //                      RuntimeArgs SetUp
+    ////////////////////////////////////////////////////////////////////////////
+    uint32_t out_dim_divider{Wt};
+    for (uint32_t i = 0, tile_offset = 0; i < num_cores; ++i) {
+        CoreCoord core = {i / num_cores_y, i % num_cores_y};
+
+        uint32_t num_rows_per_core{0};
+        if (core_group_1.core_coord_in_core_ranges(core)) {
+            num_rows_per_core = num_rows_per_core_group_1;
+        } else if (core_group_2.core_coord_in_core_ranges(core)) {
+            num_rows_per_core = num_rows_per_core_group_2;
+        } else {
+            TT_THROW("Core not in specified core ranges.");
+        }
+
+        uint32_t num_tensor_tiles_per_core {num_rows_per_core * Wt};
+        SetRuntimeArgs(
+            program,
+            reader_kernel_id,
+            core,
+            {
+                input.buffer()->address(),
+                num_tensor_tiles_per_core,
+                tile_offset,  // tile index of row to start reading from
+                mask_w
+             });
+
+        SetRuntimeArgs(
+            program,
+            writer_kernel_id,
+            core,
+            {
+                output.buffer()->address(),
+                num_tensor_tiles_per_core / out_dim_divider,  // number of tiles to write
+                tile_offset / out_dim_divider                 // output tile start index
+            });
+
+        tile_offset += num_tensor_tiles_per_core;
+    }
+
+     auto override_runtime_args_callback = [reader_kernel_id, writer_kernel_id, num_cores, num_cores_y](
+                                              const Program &program,
+                                              const std::vector<Buffer *> &input_buffers,
+                                              const std::vector<Buffer *> &output_buffers) {
+        log_debug(LogOp, "{}:{} args_callback ", __func__, __LINE__);
+        auto src_dram_buffer{input_buffers.at(0)};
+        auto dst_dram_buffer{output_buffers.at(0)};
+
+        for (uint32_t i = 0, num_tiles_read = 0; i < num_cores; i++) {
+            CoreCoord core = {i / num_cores_y, i % num_cores_y};
+
+            {
+                auto &runtime_args = GetRuntimeArgs(program, reader_kernel_id, core);
+                runtime_args[0] = src_dram_buffer->address();
+            }
+
+            {
+                auto &runtime_args = GetRuntimeArgs(program, writer_kernel_id, core);
+                runtime_args[0] = dst_dram_buffer->address();
+            }
+        }
+    };
+
+    return {std::move(program), override_runtime_args_callback};
+}
+
+}  // namespace primary
+}  // namespace operations
+}  // namespace tt

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_mask.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_mask.h
@@ -18,11 +18,11 @@ inline void llk_math_eltwise_unary_sfpu_mask_init() {
 }
 
 template <bool APPROXIMATE>
-inline void llk_math_eltwise_unary_sfpu_mask(uint dst_index, int vector_mode = (int)VectorMode::RC) {
-    llk_math_eltwise_unary_sfpu_params<APPROXIMATE>(
-        ckernel::sfpu::calculate_mask<APPROXIMATE>,
-        dst_index,
-        vector_mode);
+inline void llk_math_eltwise_unary_sfpu_mask(uint dst_index, DataFormat data_format, int vector_mode = (int)VectorMode::RC) {
+    if (data_format == DataFormat::Float16_b || data_format == DataFormat::Float16) {
+        llk_math_eltwise_unary_sfpu_params<APPROXIMATE>(
+            ckernel::sfpu::calculate_mask<APPROXIMATE>, dst_index, vector_mode);
+    }
 }
 
 }

--- a/tt_metal/hw/ckernels/grayskull/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_mask.h
+++ b/tt_metal/hw/ckernels/grayskull/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_mask.h
@@ -18,11 +18,11 @@ inline void llk_math_eltwise_unary_sfpu_mask_init() {
 }
 
 template <bool APPROXIMATE>
-inline void llk_math_eltwise_unary_sfpu_mask(uint dst_index, int vector_mode = (int)VectorMode::RC) {
-    llk_math_eltwise_unary_sfpu_params<APPROXIMATE>(
-        ckernel::sfpu::calculate_mask<APPROXIMATE>,
-        dst_index,
-        vector_mode);
+inline void llk_math_eltwise_unary_sfpu_mask(uint dst_index, DataFormat data_format, int vector_mode = (int)VectorMode::RC) {
+    if (data_format == DataFormat::Float16_b || data_format == DataFormat::Float16) {
+        llk_math_eltwise_unary_sfpu_params<APPROXIMATE>(
+            ckernel::sfpu::calculate_mask<APPROXIMATE>, dst_index, vector_mode);
+    }
 }
 
 }

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_int_sum.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_int_sum.h
@@ -1,0 +1,105 @@
+// SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include "ckernel.h"
+#include "ckernel_defs.h"
+
+#include "noc_nonblocking_api.h"
+
+#include "sfpi.h"
+
+using namespace sfpi;
+
+namespace ckernel {
+namespace sfpu {
+
+#define BIT_MASK_32 0xFFFFFFFF
+#define SIGN 0x80000000
+#define MAGNITUDE 0x7FFFFFFF
+
+
+sfpi_inline vInt sfpu_twos_comp_to_sign_mag(vInt value) {
+    v_if(value & SIGN) {
+        vInt magnitude = (~value + 1) & MAGNITUDE;
+        value = SIGN | magnitude;
+    }
+    v_endif;
+    return value;
+}
+
+sfpi_inline vInt sfpu_sign_mag_to_twos_comp(vInt value) {
+    v_if(value & SIGN) {
+        vInt magnitude = value & MAGNITUDE;
+        value = (~magnitude + 1) & BIT_MASK_32;
+    }
+    v_endif;
+    return value;
+}
+
+template <bool APPROXIMATION_MODE>
+inline void calculate_sum_int_col() {
+    for (size_t i = 0; i < 2; ++i) {
+        vInt a = dst_reg[i];
+        a = sfpu_twos_comp_to_sign_mag(a);
+
+        for (size_t j = 2; j < 8; j += 2) {
+            vInt b = dst_reg[i + j];
+            b = sfpu_twos_comp_to_sign_mag(b);
+            a += b;
+        }
+
+        for (size_t j = 16; j < 24; j += 2) {
+            vInt b = dst_reg[i + j];
+            b = sfpu_twos_comp_to_sign_mag(b);
+            a += b;
+        }
+
+        a = sfpu_sign_mag_to_twos_comp(a);
+        dst_reg[i] = a;
+    }
+}
+
+template <bool APPROXIMATION_MODE>
+inline void calculate_sum_int_row() {
+  for (size_t i = 0; i < 8; i += 2) {
+        vInt a = dst_reg[i];
+        a = sfpu_twos_comp_to_sign_mag(a);
+
+        int arr[] = {1, 8, 9};
+        for (size_t j = 0; j < sizeof(arr)/sizeof(arr[0]); ++j) {
+            vInt b = dst_reg[i + arr[j]];
+            b = sfpu_twos_comp_to_sign_mag(b);
+            a += b;
+        }
+
+        a = sfpu_sign_mag_to_twos_comp(a);
+        dst_reg[i] = a;
+    }
+}
+
+template <bool APPROXIMATION_MODE>
+inline void sum_int_init() {
+}
+
+template <bool APPROXIMATION_MODE, int ITERATIONS>
+inline void add_int(const uint dst_offset) {
+    #pragma GCC unroll 8
+    for (int d = 0; d < ITERATIONS; d++) {
+        vInt a = dst_reg[0];
+        vInt b = dst_reg[32];
+        a = sfpu_twos_comp_to_sign_mag(a);
+        b = sfpu_sign_mag_to_twos_comp(b);
+
+        vInt r = a + b;
+        r = sfpu_sign_mag_to_twos_comp(r);
+
+        dst_reg[0] = r;
+        dst_reg++;
+    }
+}
+
+}  // namespace sfpu
+}  // namespace ckernel

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_mask.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_mask.h
@@ -33,5 +33,21 @@ inline void calculate_mask()
     }
 }
 
+template <bool APPROXIMATION_MODE, int ITERATIONS=8>
+inline void calculate_int_mask(uint mask_index)
+{
+    const int mask_idx = mask_index * 32;
+    #pragma GCC unroll 8
+    for (int d = 0; d < ITERATIONS; d++)
+    {
+        vInt mask = dst_reg[mask_idx];
+        v_if (mask == 0) {
+            dst_reg[0] = vConst0;
+        }
+        v_endif;
+        dst_reg++;
+    }
+}
+
 }  // namespace sfpu
 }  // namespace ckernel

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_mask.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_mask.h
@@ -34,9 +34,9 @@ inline void calculate_mask()
 }
 
 template <bool APPROXIMATION_MODE, int ITERATIONS=8>
-inline void calculate_int_mask(uint mask_index)
+inline void calculate_int_mask()
 {
-    const int mask_idx = mask_index * 32;
+    const int mask_idx = 32;
     #pragma GCC unroll 8
     for (int d = 0; d < ITERATIONS; d++)
     {

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_int_sum.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_int_sum.h
@@ -1,0 +1,46 @@
+// SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include "llk_math_eltwise_unary_sfpu_init.h"
+#include "llk_math_eltwise_unary_sfpu_params.h"
+#include "ckernel_sfpu_int_sum.h"
+
+namespace ckernel {
+
+enum SumIntDim{
+    SUM_COL = 0,
+    SUM_ROW
+};
+
+// New LLK SFPU APIs
+
+template <bool APPROXIMATE>
+inline void llk_math_eltwise_unary_sfpu_sum_int_init() {
+    llk_math_eltwise_unary_sfpu_init<SfpuType::unused, APPROXIMATE>(sfpu::sum_int_init<APPROXIMATE>);
+}
+
+template <bool APPROXIMATE>
+inline void llk_math_eltwise_unary_sfpu_sum_int(uint dst_index, SumIntDim sum_int_dim) {
+    if (sum_int_dim == SumIntDim::SUM_COL) {
+        llk_math_eltwise_unary_sfpu_params<APPROXIMATE>(
+            ckernel::sfpu::calculate_sum_int_col<APPROXIMATE>, dst_index, (int)VectorMode::R);
+    } else if (sum_int_dim == SumIntDim::SUM_ROW) {
+        llk_math_eltwise_unary_sfpu_params<APPROXIMATE>(
+            ckernel::sfpu::calculate_sum_int_row<APPROXIMATE>, dst_index, (int)VectorMode::C);
+    }
+}
+
+template <bool APPROXIMATE>
+inline void llk_math_eltwise_unary_sfpu_add_int(uint dst_index, uint dst_offset, int iterations, int vector_mode = (int)VectorMode::RC) {
+    llk_math_eltwise_unary_sfpu_params<APPROXIMATE>(
+        ckernel::sfpu::add_int<APPROXIMATE, 8>,
+        dst_index,
+        vector_mode,
+        dst_offset
+        );
+}
+
+}

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_mask.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_mask.h
@@ -25,4 +25,13 @@ inline void llk_math_eltwise_unary_sfpu_mask(uint dst_index, int vector_mode = (
         vector_mode);
 }
 
+template <bool APPROXIMATE>
+inline void llk_math_eltwise_unary_sfpu_int_mask(uint dst_index, uint mask_index = 1, int vector_mode = (int)VectorMode::RC) {
+    llk_math_eltwise_unary_sfpu_params<APPROXIMATE>(
+        ckernel::sfpu::calculate_int_mask<APPROXIMATE>,
+        dst_index,
+        vector_mode,
+        mask_index);
+}
+
 }

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_mask.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_mask.h
@@ -18,20 +18,14 @@ inline void llk_math_eltwise_unary_sfpu_mask_init() {
 }
 
 template <bool APPROXIMATE>
-inline void llk_math_eltwise_unary_sfpu_mask(uint dst_index, int vector_mode = (int)VectorMode::RC) {
-    llk_math_eltwise_unary_sfpu_params<APPROXIMATE>(
-        ckernel::sfpu::calculate_mask<APPROXIMATE>,
-        dst_index,
-        vector_mode);
-}
-
-template <bool APPROXIMATE>
-inline void llk_math_eltwise_unary_sfpu_int_mask(uint dst_index, uint mask_index = 1, int vector_mode = (int)VectorMode::RC) {
-    llk_math_eltwise_unary_sfpu_params<APPROXIMATE>(
-        ckernel::sfpu::calculate_int_mask<APPROXIMATE>,
-        dst_index,
-        vector_mode,
-        mask_index);
+inline void llk_math_eltwise_unary_sfpu_mask(uint dst_index, DataFormat data_format, int vector_mode = (int)VectorMode::RC) {
+    if (data_format == DataFormat::Float16_b || data_format == DataFormat::Float16) {
+        llk_math_eltwise_unary_sfpu_params<APPROXIMATE>(
+            ckernel::sfpu::calculate_mask<APPROXIMATE>, dst_index, vector_mode);
+    } else if (data_format == DataFormat::Int32) {
+        llk_math_eltwise_unary_sfpu_params<APPROXIMATE>(
+            ckernel::sfpu::calculate_int_mask<APPROXIMATE>, dst_index, vector_mode);
+    }
 }
 
 }

--- a/tt_metal/include/compute_kernel_api/eltwise_unary/sfpu_int_sum.h
+++ b/tt_metal/include/compute_kernel_api/eltwise_unary/sfpu_int_sum.h
@@ -1,0 +1,38 @@
+// SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+
+#include "compute_kernel_api/common_globals.h"
+#ifdef TRISC_MATH
+#include "llk_math_eltwise_unary_sfpu_int_sum.h"
+#define MAIN math_main()
+#define MATH(x) x
+#else
+#define MATH(x)
+#endif
+
+
+
+namespace ckernel {
+
+ALWI void sfpu_sum_int_init() {
+    MATH(( llk_math_eltwise_unary_sfpu_sum_int_init<APPROX>() ));
+}
+
+ALWI void sfpu_sum_int_col(uint32_t idst) {
+    MATH((llk_math_eltwise_unary_sfpu_sum_int<APPROX>(idst, SumIntDim::SUM_COL)));
+}
+
+ALWI void sfpu_sum_int_row(uint32_t idst) {
+    MATH((llk_math_eltwise_unary_sfpu_sum_int<APPROX>(idst, SumIntDim::SUM_ROW)));
+}
+
+ALWI void sfpu_add_int(uint32_t idst, uint32_t dst_offset = 2, int32_t iterations = 8) {
+    MATH(( llk_math_eltwise_unary_sfpu_add_int<APPROX>(idst, dst_offset, iterations) ));
+}
+
+
+} // namespace ckerne

--- a/tt_metal/include/compute_kernel_api/mask.h
+++ b/tt_metal/include/compute_kernel_api/mask.h
@@ -41,7 +41,7 @@ ALWI void mask_tile_init() {
  * |----------------|----------------------------------------------------------------------------|----------|-------------------------------------------------------|----------|
  * | dst_data_index | The index of the tile in DST REG for the data and result                   | uint32_t | Must be less than the acquired size of DST REG        | True     |
  * | dst_mask_index | The index of the tile in DST REG for the mask                              | uint32_t | Must be less than the acquired size of DST REG        | True     |
- * | data_format    | The format of the data and mask                                            | DataFormat | Must be a valid data format                         | False    |
+ * | data_format    | The format of the data and mask (supports Float16, Float16_b, and Int32)   | DataFormat | Must be a valid data format                         | False    |
  */
 ALWI void mask_tile(uint32_t idst_data, uint32_t idst2_mask, DataFormat data_format = DataFormat::Float16_b) {
     MATH(( llk_math_eltwise_unary_sfpu_mask<true>(idst_data, data_format) ));

--- a/tt_metal/include/compute_kernel_api/mask.h
+++ b/tt_metal/include/compute_kernel_api/mask.h
@@ -46,4 +46,21 @@ ALWI void mask_tile(uint32_t idst_data, uint32_t idst2_mask) {
     MATH(( llk_math_eltwise_unary_sfpu_mask<true>(idst_data) ));
 }
 
+/**
+ * Performs element-wise computation of the mask (int type) on each element of a tile (int type)
+ * in the data and mask DST register. The DST register buffer must be in
+ * acquired state via *acquire_dst* call. This call is blocking and is only
+ * available on the compute engine.
+ *
+ * Return value: None
+ *
+ * | Argument       | Description                                                                | Type     | Valid Range                                           | Required |
+ * |----------------|----------------------------------------------------------------------------|----------|-------------------------------------------------------|----------|
+ * | dst_data_index | The index of the tile in DST REG for the data and result                   | uint32_t | Must be less than the acquired size of DST REG        | True     |
+ * | dst_mask_index | The index of the tile in DST REG for the mask                              | uint32_t | Must be less than the acquired size of DST REG        | True     |
+ */
+ALWI void int_mask_tile(uint32_t idst_data, uint32_t idst2_mask = 1) {
+    MATH(( llk_math_eltwise_unary_sfpu_int_mask<true>(idst_data, idst2_mask) ));
+}
+
 } // namespace ckernel

--- a/tt_metal/include/compute_kernel_api/mask.h
+++ b/tt_metal/include/compute_kernel_api/mask.h
@@ -41,26 +41,10 @@ ALWI void mask_tile_init() {
  * |----------------|----------------------------------------------------------------------------|----------|-------------------------------------------------------|----------|
  * | dst_data_index | The index of the tile in DST REG for the data and result                   | uint32_t | Must be less than the acquired size of DST REG        | True     |
  * | dst_mask_index | The index of the tile in DST REG for the mask                              | uint32_t | Must be less than the acquired size of DST REG        | True     |
+ * | data_format    | The format of the data and mask                                            | DataFormat | Must be a valid data format                         | False    |
  */
-ALWI void mask_tile(uint32_t idst_data, uint32_t idst2_mask) {
-    MATH(( llk_math_eltwise_unary_sfpu_mask<true>(idst_data) ));
-}
-
-/**
- * Performs element-wise computation of the mask (int type) on each element of a tile (int type)
- * in the data and mask DST register. The DST register buffer must be in
- * acquired state via *acquire_dst* call. This call is blocking and is only
- * available on the compute engine.
- *
- * Return value: None
- *
- * | Argument       | Description                                                                | Type     | Valid Range                                           | Required |
- * |----------------|----------------------------------------------------------------------------|----------|-------------------------------------------------------|----------|
- * | dst_data_index | The index of the tile in DST REG for the data and result                   | uint32_t | Must be less than the acquired size of DST REG        | True     |
- * | dst_mask_index | The index of the tile in DST REG for the mask                              | uint32_t | Must be less than the acquired size of DST REG        | True     |
- */
-ALWI void int_mask_tile(uint32_t idst_data, uint32_t idst2_mask = 1) {
-    MATH(( llk_math_eltwise_unary_sfpu_int_mask<true>(idst_data, idst2_mask) ));
+ALWI void mask_tile(uint32_t idst_data, uint32_t idst2_mask, DataFormat data_format = DataFormat::Float16_b) {
+    MATH(( llk_math_eltwise_unary_sfpu_mask<true>(idst_data, data_format) ));
 }
 
 } // namespace ckernel


### PR DESCRIPTION
### Ticket
- [Link to Github Issue.](https://github.com/tenstorrent/tt-metal/issues/9389)

### Problem description
- Currently, the moreh_sum operation only supports the bfl16 data type. 
- It needs to support the integer type for moreh_sum forward.

### What's changed
- moreh_sum op forward supports integer type.

### Checklist
- [x] Post commit CI passes (https://github.com/tenstorrent/tt-metal/actions/runs/9583101717)
- [ ] Model regression CI testing passes (if applicable)
- [x] New/Existing tests provide coverage for changes (test_moreh_sum_integer)
