### PR TITLE
Mo/9406 profiler build flags

### DIFF
--- a/.github/workflows/metal-run-microbenchmarks.yaml
+++ b/.github/workflows/metal-run-microbenchmarks.yaml
@@ -32,7 +32,9 @@ jobs:
         run: |
           echo "TT_METAL_HOME=$(pwd)" >> $GITHUB_ENV
       - name: Build tt-metal and libs
-        run: ./scripts/build_scripts/build_with_profiler_opt.sh
+        run: |
+          ./scripts/build_scripts/build_with_profiler_opt.sh
+          ./create_venv.sh
       - name: Build tests
         run: cmake --build build --target tests -- -j`nproc`
       - name: Run microbenchmark tests

--- a/.github/workflows/perf-device-models.yaml
+++ b/.github/workflows/perf-device-models.yaml
@@ -38,6 +38,7 @@ jobs:
       - name: Build tt-metal and libs
         run: |
           ./scripts/build_scripts/build_with_profiler_opt.sh
+          ./create_venv.sh
       - name: Run device performance regressions
         timeout-minutes: ${{ matrix.test-info.timeout }}
         run: |

--- a/.github/workflows/run-profiler-regression.yaml
+++ b/.github/workflows/run-profiler-regression.yaml
@@ -34,6 +34,7 @@ jobs:
       - name: Build tt-metal and libs
         run: |
           ./scripts/build_scripts/build_with_profiler_opt.sh
+          ./create_venv.sh
       - name: Run profiler regression tests
         timeout-minutes: 30
         run: |

--- a/.github/workflows/t3000-profiler-tests.yaml
+++ b/.github/workflows/t3000-profiler-tests.yaml
@@ -35,6 +35,7 @@ jobs:
       - name: Build tt-metal and libs
         run: |
           ./scripts/build_scripts/build_with_profiler_opt.sh
+          ./create_venv.sh
       - name: Run profiler regression tests
         timeout-minutes: 30
         run: |

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -65,6 +65,7 @@ message(STATUS "Build Python bindings: ${WITH_PYTHON_BINDINGS}")
 
 option(ENABLE_CODE_TIMERS "Enable code timers" OFF)
 option(TT_METAL_VERSIM_DISABLED "Disable TT_METAL_VERSIM" ON)
+option(ENABLE_TRACY "Enable Tracy Profiling" OFF)
 
 # Default to building everything as a shared lib
 if($ENV{TT_METAL_CREATE_STATIC_LIB})
@@ -134,11 +135,7 @@ endif()
 if(ENABLE_CODE_TIMERS)
     target_compile_options(compiler_flags INTERFACE -DTT_ENABLE_CODE_TIMERS)
 endif()
-if($ENV{ENABLE_PROFILER})
-    message(STATUS "PROFILER ENABLED")
-    target_compile_options(compiler_flags INTERFACE -DPROFILER)
-endif()
-if($ENV{ENABLE_TRACY})
+if(ENABLE_TRACY)
     target_compile_options(compiler_flags INTERFACE -DTRACY_ENABLE -fno-omit-frame-pointer)
     target_link_options(linker_flags INTERFACE -rdynamic)
 endif()
@@ -177,7 +174,7 @@ endif()
 ############################################################################################################################
 # Build subdirectories
 ############################################################################################################################
-if($ENV{ENABLE_TRACY})
+if(ENABLE_TRACY)
     include(${PROJECT_SOURCE_DIR}/cmake/tracy.cmake)
 endif()
 

--- a/build_metal.sh
+++ b/build_metal.sh
@@ -23,11 +23,11 @@ Notes:
     - `cmake --build build --target install` is the EXACT same as running `ninja install -C build`, you would use the cmake command if you want to be
         agnostic of the build system (Ninja or Make)
 
-Different configs: to change build type or use profiler/tracy, you have to change the configuration cmake step (step #2)
+Different configs: to change build type or use tracy, you have to change the configuration cmake step (step #2)
     - changing build types: `CONFIG=<type> cmake -B build -G Ninja`
         - valid build_types: `Release`, `Debug`, `RelWithDebInfo`
         - Release is the default if you do not set CONFIG
-    - tracy + profiler: `ENABLE_PROFILER=1 ENABLE_TRACY=1 cmake -B build -G Ninja`
+    - tracy: `cmake -B build -G Ninja -DENABLE_TRACY=ON`
 
 Now you can have multiple build folders with different configs, if you want to switch just run `ninja install -C <your_build_folder` to install different pybinds
     - Caveats:

--- a/docs/source/tt-metalium/tools/device_program_profiler.rst
+++ b/docs/source/tt-metalium/tools/device_program_profiler.rst
@@ -28,7 +28,7 @@ The commands to build and run the ``full_buffer`` example after following :ref:`
 
 The generated csv is ``profile_log_device.csv`` and is saved under ``{$TT_METAL_HOME}/generated/profiler/.logs`` by default.
 
-``build_with_profiler_opt.sh`` also enables tracy for the build by using the ``ENABLE_TRACY=1`` flag. In tracy builds, device-side profiling data is also sent to tracy's GUI.
+``build_with_profiler_opt.sh`` also enables tracy for the build by using the ``ENABLE_TRACY=ON`` cmake option. In tracy builds, device-side profiling data is also sent to tracy's GUI.
 
 
 Example

--- a/docs/source/tt-metalium/tools/tracy_profiler.rst
+++ b/docs/source/tt-metalium/tools/tracy_profiler.rst
@@ -49,7 +49,7 @@ Profiling Host
 C++
 ~~~
 
-Build with the ``ENABLE_TRACY=1`` flag is required for profiling with tracy.
+Build with the profiler option (i.e. ``ENABLE_TRACY=ON`` cmake option) is required for profiling with tracy.
 
 ..  code-block:: sh
 

--- a/models/demos/mamba/README.md
+++ b/models/demos/mamba/README.md
@@ -76,7 +76,7 @@ pytest -svv models/demos/mamba/tests/test_mamba_perf.py -m models_performance_ba
 
 ### Device-Side Performance
 
-Build with profiler support enabled (use flags `ENABLE_PROFILER=1 ENABLE_TRACY=1`) and run the following command to test device-side performance:
+Build with profiler support enabled (use the build script `./scripts/build_scripts/build_with_profiler_opt.sh`) and run the following command to test device-side performance:
 
 ```
 pytest -svv models/demos/mamba/tests/test_mamba_perf.py -m models_device_performance_bare_metal

--- a/scripts/build_scripts/build_with_profiler_opt.sh
+++ b/scripts/build_scripts/build_with_profiler_opt.sh
@@ -11,7 +11,7 @@ if [[ -z "$ARCH_NAME" ]]; then
     exit 1
 fi
 
-ENABLE_TRACY=1 ENABLE_PROFILER=1 cmake -B build -G Ninja
+cmake -B build -G Ninja -DENABLE_TRACY=ON
 
 if [[ $1 == "NO_CLEAN" ]]; then
     cmake --build build
@@ -22,4 +22,3 @@ fi
 
 cmake --build build --target install
 cmake --build build --target programming_examples
-./create_venv.sh

--- a/tests/scripts/run_moreh_microbenchmark.sh
+++ b/tests/scripts/run_moreh_microbenchmark.sh
@@ -18,7 +18,7 @@ run_profiling_test() {
     exit 1
   fi
 
-  echo "Make sure this test runs in a build with ENABLE_PROFILER=1"
+  echo "Make sure this test runs in a build with cmake option ENABLE_TRACY=ON"
 
   source python_env/bin/activate
   export PYTHONPATH=$TT_METAL_HOME

--- a/tests/scripts/run_profiler_regressions.sh
+++ b/tests/scripts/run_profiler_regressions.sh
@@ -53,7 +53,7 @@ run_profiling_test(){
       exit 1
     fi
 
-    echo "Make sure this test runs in a build with ENABLE_PROFILER=1 ENABLE_TRACY=1"
+    echo "Make sure this test runs in a build with cmake option ENABLE_TRACY=ON"
 
     source python_env/bin/activate
     export PYTHONPATH=$TT_METAL_HOME
@@ -83,7 +83,7 @@ run_profiling_no_reset_test(){
       exit 1
     fi
 
-    echo "Make sure this test runs in a build with ENABLE_PROFILER=1 ENABLE_TRACY=1"
+    echo "Make sure this test runs in a build with cmake option ENABLE_TRACY=ON"
 
     source python_env/bin/activate
     export PYTHONPATH=$TT_METAL_HOME

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/1_compute_mm/test_compute_mm.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/1_compute_mm/test_compute_mm.cpp
@@ -52,7 +52,7 @@ using namespace tt;
 //   cores for certain input shapes. In that case, only some cores are used with
 //   a warning message.
 //   - To measure performance in the slow dispatch mode, build tt_metal project
-//   with the profiler build flag (ENABLE_PROFILER=1) first. This benchmark
+//   with the profiler option using scripts/build_scripts/build_with_profiler_opt.sh first. This benchmark
 //   copied device profiler's internal code to get the "t0 to any riscfw end"
 //   cycles. If device profiler is changed, it also should be updated.
 //   Otherwise, it may get inappropriate cycle value.
@@ -287,11 +287,11 @@ int main(int argc, char** argv) {
         else if (fast_dispatch_mode == false) {
             setenv("TT_METAL_SLOW_DISPATCH_MODE", "1", true);
 
-#if !defined(PROFILER)
+#if !defined(TRACY_ENABLE)
             log_error(
                 "In the slow dispatch mode, device profiler is used to measure the "
-                "performance. Build the Metal library and test code with "
-                "'ENABLE_PROFILER=1'");
+                "profiler option using ./scripts/build_scripts/build_with_profiler_opt.sh");
+
             TT_ASSERT(false);
 #endif
 

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/2_noc_adjacent/test_noc_adjacent.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/2_noc_adjacent/test_noc_adjacent.cpp
@@ -115,11 +115,11 @@ int main(int argc, char** argv) {
     }
 
     if (use_device_profiler) {
-#if !defined(PROFILER)
+#if !defined(TRACY_ENABLE)
         log_error(
             LogTest,
             "Metal library and test code should be build with "
-            "'ENABLE_PROFILER=1' to use device profiler");
+            "profiler option using ./scripts/build_scripts/build_with_profiler_opt.sh");
 #endif
         auto device_profiler = getenv("TT_METAL_DEVICE_PROFILER");
         TT_FATAL(

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/2_noc_rtor/test_noc_rtor.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/2_noc_rtor/test_noc_rtor.cpp
@@ -95,11 +95,11 @@ int main(int argc, char** argv) {
     }
 
     if (use_device_profiler) {
-#if !defined(PROFILER)
+#if !defined(TRACY_ENABLE)
         log_error(
             LogTest,
             "Metal library and test code should be build with "
-            "'ENABLE_PROFILER=1' to use device profiler");
+            "profiler option using ./scripts/build_scripts/build_with_profiler_opt.sh");
 #endif
         auto device_profiler = getenv("TT_METAL_DEVICE_PROFILER");
         TT_FATAL(

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/6_dram_offchip/test_dram_offchip.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/6_dram_offchip/test_dram_offchip.cpp
@@ -136,11 +136,11 @@ int main(int argc, char **argv) {
         TT_ASSERT(input_size != 0, "--input-size should not be zero");
 
         if (use_device_profiler) {
-#if !defined(PROFILER)
+#if !defined(TRACY_ENABLE)
             log_error(
                 LogTest,
                 "Metal library and test code should be build with "
-                "'ENABLE_PROFILER=1' to use device profiler");
+                "profiler option using ./scripts/build_scripts/build_with_profiler_opt.sh");
 #endif
             auto device_profiler = getenv("TT_METAL_DEVICE_PROFILER");
             TT_FATAL(

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/8_dram_adjacent_core_read/test_dram_read.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/8_dram_adjacent_core_read/test_dram_read.cpp
@@ -291,11 +291,11 @@ int main(int argc, char **argv) {
         }
 
         if (use_device_profiler) {
-#if !defined(PROFILER)
+#if !defined(TRACY_ENABLE)
             log_error(
                 LogTest,
                 "Metal library and test code should be build with "
-                "'ENABLE_PROFILER=1' to use device profiler");
+                "profiler option using ./scripts/build_scripts/build_with_profiler_opt.sh");
 #endif
             auto device_profiler = getenv("TT_METAL_DEVICE_PROFILER");
             TT_FATAL(

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/common/util.hpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/common/util.hpp
@@ -12,7 +12,7 @@
 #include "tt_metal/host_api.hpp"
 
 inline uint64_t get_t0_to_any_riscfw_end_cycle(tt::tt_metal::Device *device, const tt::tt_metal::Program &program) {
-#if defined(PROFILER)
+#if defined(TRACY_ENABLE)
     // TODO: use enums from profiler_common.h
     enum BufferIndex { BUFFER_END_INDEX, DROPPED_MARKER_COUNTER, MARKER_DATA_START };
     enum TimerDataIndex { TIMER_ID, TIMER_VAL_L, TIMER_VAL_H, TIMER_DATA_UINT32_SIZE };

--- a/tt_metal/CMakeLists.txt
+++ b/tt_metal/CMakeLists.txt
@@ -33,7 +33,7 @@ target_precompile_headers(tt_metal PRIVATE
     <vector>
 )
 
-target_link_libraries(tt_metal PUBLIC compiler_flags linker_flags metal_header_directories $<$<BOOL:$ENV{ENABLE_TRACY}>:TracyClient>)  # linker_flags = -rdynamic if tracy enabled
+target_link_libraries(tt_metal PUBLIC compiler_flags linker_flags metal_header_directories $<$<BOOL:${ENABLE_TRACY}>:TracyClient>)  # linker_flags = -rdynamic if tracy enabled
 target_link_directories(tt_metal PUBLIC ${PROJECT_BINARY_DIR}/lib)    # required so tt_metal can find device library
 target_include_directories(tt_metal PUBLIC
     ${UMD_HOME}

--- a/tt_metal/common/metal_soc_descriptor.cpp
+++ b/tt_metal/common/metal_soc_descriptor.cpp
@@ -334,7 +334,7 @@ void metal_SocDescriptor::generate_logical_eth_coords_mapping() {
 }
 
 void metal_SocDescriptor::generate_physical_routing_to_profiler_flat_id() {
-#if defined(PROFILER)
+#if defined(TRACY_ENABLE)
     for (auto &core : this->physical_workers)
     {
         this->physical_routing_to_profiler_flat_id.emplace((CoreCoord){core.x,core.y}, 0);

--- a/tt_metal/jit_build/genfiles.cpp
+++ b/tt_metal/jit_build/genfiles.cpp
@@ -481,7 +481,7 @@ std::string generate_bank_to_noc_coord_descriptor_string(
     ss << "};" << endl;
     ss << endl;
 
-#if defined(PROFILER)
+#if defined(TRACY_ENABLE)
     /*
      * This part is adding the 2D array for sharing the flat IDs soc descriptor has assigned to every NOC coordinate,
      * and the ceiled number of cores per DRAM banks.

--- a/tt_metal/llrt/rtoptions.cpp
+++ b/tt_metal/llrt/rtoptions.cpp
@@ -49,7 +49,7 @@ RunTimeOptions::RunTimeOptions() {
     profiler_enabled = false;
     profile_dispatch_cores = false;
     profiler_sync_enabled = false;
-#if defined(PROFILER)
+#if defined(TRACY_ENABLE)
     const char *profiler_enabled_str = std::getenv("TT_METAL_DEVICE_PROFILER");
     if (profiler_enabled_str != nullptr && profiler_enabled_str[0] == '1') {
         profiler_enabled = true;

--- a/tt_metal/tools/profiler/profiler.cpp
+++ b/tt_metal/tools/profiler/profiler.cpp
@@ -278,7 +278,7 @@ void DeviceProfiler::dumpResultToFile(
 
 DeviceProfiler::DeviceProfiler(const bool new_logs)
 {
-#if defined(PROFILER)
+#if defined(TRACY_ENABLE)
     ZoneScopedC(tracy::Color::Green);
     new_log = new_logs;
     output_dir = std::filesystem::path(string(PROFILER_RUNTIME_ROOT_DIR) + string(PROFILER_LOGS_DIR_NAME));
@@ -289,7 +289,7 @@ DeviceProfiler::DeviceProfiler(const bool new_logs)
 
 DeviceProfiler::~DeviceProfiler()
 {
-#if defined(PROFILER)
+#if defined(TRACY_ENABLE)
     ZoneScoped;
     pushTracyDeviceResults();
     for (auto tracyCtx : device_tracy_contexts)
@@ -302,7 +302,7 @@ DeviceProfiler::~DeviceProfiler()
 
 void DeviceProfiler::setNewLogFlag(bool new_log_flag)
 {
-#if defined(PROFILER)
+#if defined(TRACY_ENABLE)
     new_log = new_log_flag;
 #endif
 }
@@ -310,7 +310,7 @@ void DeviceProfiler::setNewLogFlag(bool new_log_flag)
 
 void DeviceProfiler::setOutputDir(const std::string& new_output_dir)
 {
-#if defined(PROFILER)
+#if defined(TRACY_ENABLE)
     std::filesystem::create_directories(new_output_dir);
     output_dir = new_output_dir;
 #endif
@@ -319,7 +319,7 @@ void DeviceProfiler::setOutputDir(const std::string& new_output_dir)
 
 void DeviceProfiler::setDeviceArchitecture(tt::ARCH device_arch)
 {
-#if defined(PROFILER)
+#if defined(TRACY_ENABLE)
     device_architecture = device_arch;
 #endif
 }
@@ -361,7 +361,7 @@ void DeviceProfiler::generateZoneSourceLocationsHashes()
 void DeviceProfiler::dumpResults (
         Device *device,
         const vector<CoreCoord> &worker_cores){
-#if defined(PROFILER)
+#if defined(TRACY_ENABLE)
     ZoneScoped;
 
     auto device_id = device->id();
@@ -392,7 +392,7 @@ void DeviceProfiler::dumpResults (
 
 void DeviceProfiler::pushTracyDeviceResults()
 {
-#if defined(PROFILER) && defined(TRACY_ENABLE)
+#if defined(TRACY_ENABLE)
     ZoneScoped;
     std::set<std::pair<uint32_t, CoreCoord>> device_cores_set;
     std::vector<std::pair<uint32_t, CoreCoord>> device_cores;

--- a/tt_metal/tools/profiler/tt_metal_profiler.cpp
+++ b/tt_metal/tools/profiler/tt_metal_profiler.cpp
@@ -212,7 +212,7 @@ void syncDeviceHost(Device *device, CoreCoord logical_core, std::shared_ptr<tt_m
 
 
 void InitDeviceProfiler(Device *device){
-#if defined(PROFILER)
+#if defined(TRACY_ENABLE)
     ZoneScoped;
 
     TracySetCpuTime (TracyGetCpuTime());
@@ -295,7 +295,7 @@ void InitDeviceProfiler(Device *device){
 }
 
 void DumpDeviceProfileResults(Device *device, bool lastDump) {
-#if defined(PROFILER)
+#if defined(TRACY_ENABLE)
     std::vector<CoreCoord> workerCores;
     auto device_id = device->id();
     auto device_num_hw_cqs = device->num_hw_cqs();
@@ -313,7 +313,7 @@ void DumpDeviceProfileResults(Device *device, bool lastDump) {
 
 
 void DumpDeviceProfileResults(Device *device, std::vector<CoreCoord> &worker_cores, bool lastDump){
-#if defined(PROFILER)
+#if defined(TRACY_ENABLE)
     ZoneScoped;
 
     if (tt::llrt::OptionsG.get_profiler_do_dispatch_cores()) {
@@ -428,7 +428,7 @@ void DumpDeviceProfileResults(Device *device, std::vector<CoreCoord> &worker_cor
 }
 
 void SetDeviceProfilerDir(std::string output_dir){
-#if defined(PROFILER)
+#if defined(TRACY_ENABLE)
     for (auto& device_id : tt_metal_device_profiler_map)
     {
         tt_metal_device_profiler_map.at(device_id.first).setOutputDir(output_dir);
@@ -437,7 +437,7 @@ void SetDeviceProfilerDir(std::string output_dir){
 }
 
 void FreshProfilerDeviceLog(){
-#if defined(PROFILER)
+#if defined(TRACY_ENABLE)
     for (auto& device_id : tt_metal_device_profiler_map)
     {
         tt_metal_device_profiler_map.at(device_id.first).setNewLogFlag(true);


### PR DESCRIPTION
### Ticket
#9406 
### Problem description

By bringing device profiling build flag under `ENABLE_TRACY`, `ENABLE_PROFILER` has become redundant. 

### What's changed
- `ENABLE_PROFILER` is removed 
- `ENABLE_TRACY` is turned into a cmake option instead of an env var
- call to create_env was moved to action yaml for CI

### Checklist
- [x] Post commit CI passes : https://github.com/tenstorrent/tt-metal/actions/runs/9669828629
- [x] Device perf reg : https://github.com/tenstorrent/tt-metal/actions/runs/9669174246
- [x] T3K profiler : https://github.com/tenstorrent/tt-metal/actions/runs/9669178441/job/26675057860 (Fails with known issue with all gather. Build is successful)
- [x] uBenchmark : https://github.com/tenstorrent/tt-metal/actions/runs/9669171923
