### PR TITLE
#9555: skip t5 conditional generation

### DIFF
--- a/tests/ttnn/integration_tests/t5/test_ttnn_functional_t5.py
+++ b/tests/ttnn/integration_tests/t5/test_ttnn_functional_t5.py
@@ -329,6 +329,7 @@ def test_t5_stack_decoder(device, model_name, batch_size, sequence_size):
 @pytest.mark.parametrize("batch_size", [1])
 @pytest.mark.parametrize("sequence_size", [128])
 def test_t5_for_conditional_generation(device, model_name, batch_size, sequence_size):
+    pytest.skip("Issue 9555: seeing PCC issues if running this in same process as encoder/decoder")
     torch.manual_seed(0)
 
     config = transformers.T5Config.from_pretrained(model_name)

--- a/tests/ttnn/integration_tests/t5/test_ttnn_optimized_functional_t5.py
+++ b/tests/ttnn/integration_tests/t5/test_ttnn_optimized_functional_t5.py
@@ -342,6 +342,7 @@ def test_t5_stack_decoder(device, model_name, batch_size, sequence_size):
 @pytest.mark.parametrize("batch_size", [8])
 @pytest.mark.parametrize("sequence_size", [128])
 def test_t5_for_conditional_generation(device, model_name, batch_size, sequence_size):
+    pytest.skip("Issue 9555: seeing PCC issues if running this in same process as encoder/decoder")
     torch.manual_seed(0)
 
     config = transformers.T5Config.from_pretrained(model_name)


### PR DESCRIPTION
### Ticket
- https://github.com/tenstorrent/tt-metal/issues/9555

### Problem description
- Two tests in TTNN GS hitting PCC issues, only seen when running as same process as other T5 encoder/decoder test.

### What's changed
- Temp disable the tests to get green CI. Debugging and re-enabling soon...

### Checklist
- [x] Post commit CI passes
- [x] Model regression CI testing passes (if applicable)
- [x] New/Existing tests provide coverage for changes
