### PR TITLE
#9559: clean up unused std::mutex in TensorAttributes

### DIFF
--- a/tt_eager/tensor/tensor.hpp
+++ b/tt_eager/tensor/tensor.hpp
@@ -31,7 +31,6 @@ struct Tensor {
         ttnn::Shape shape;
         DataType dtype;
         Layout layout;
-        std::mutex populated_mutex;
         uint32_t num_shards_to_be_populated = 0;
         uint32_t main_thread_ref_count = 0;
         std::atomic<uint32_t> num_sibling_workers_sharing_tensor = 0;


### PR DESCRIPTION
### Ticket
#9559

### Problem description
- There's some lingering dead state that's completely unused (std::mutex)

### What's changed
- Simple deletion of the variable

### Checklist
- [x] Post commit CI passes
- [x] Model regression CI testing passes (if applicable)
- [x] New/Existing tests provide coverage for changes
