### PR TITLE
#0: Use new submodule URL

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,6 @@
 [submodule "src/ckernels/sfpi"]
 	path = tt_metal/third_party/sfpi
-	url = https://github.com/tenstorrent-metal/sfpi-rel.git
+	url = https://github.com/tenstorrent/sfpi-rel.git
 [submodule "third_party/pybind11"]
 	path = tt_metal/third_party/pybind11
 	url = https://github.com/pybind/pybind11.git


### PR DESCRIPTION
### Ticket

#9561 9561

### Problem description

GitHub hosted runs not working.

### What's changed

Change SFPI remote in .gitmodules to match what's working

### Checklist
- [x] Post commit CI passes
- [x] Model regression CI testing passes (if applicable)
- [x] New/Existing tests provide coverage for changes
