### PR TITLE
#9492: Move matmul[_1d] calls to ttnn

### DIFF
--- a/models/demos/falcon7b/tests/unit_tests/test_falcon_matmuls_and_bmms_with_mixed_precision.py
+++ b/models/demos/falcon7b/tests/unit_tests/test_falcon_matmuls_and_bmms_with_mixed_precision.py
@@ -356,7 +356,7 @@ def test_falcon7b_attnention_sliced(
             mcast_in0=False,
         )
 
-        mm_slice = ttnn.experimental.operations.primary.matmul(
+        mm_slice = ttnn.matmul(
             slice,
             reference_key_layer_transposed,
             program_config=program_config,
@@ -427,7 +427,7 @@ def test_falcon7b_attnention_sliced(
             mcast_in0=False,
         )
 
-        attn_out_slice = ttnn.experimental.operations.primary.matmul(
+        attn_out_slice = ttnn.matmul(
             mm_slice,
             reference_value_layer,
             program_config=program_config,
@@ -450,7 +450,7 @@ def test_falcon7b_attnention_sliced(
 
     attention_output_concatenated_torch = tt2torch_tensor(attention_output_concatenated)
 
-    attn_weights = ttnn.experimental.tensor.matmul(
+    attn_weights = ttnn.matmul(
         reference_query_layer, reference_key_layer_transposed, output_mem_config=dram_interleaved_memory_config
     )
 
@@ -465,7 +465,7 @@ def test_falcon7b_attnention_sliced(
     attn_weights = ttnn.experimental.operations.primary.softmax_in_place(
         attn_weights, compute_kernel_config=compute_kernel_config
     )
-    attn_output = ttnn.experimental.tensor.matmul(attn_weights, reference_value_layer)
+    attn_output = ttnn.matmul(attn_weights, reference_value_layer)
     attn_output_torch = tt2torch_tensor(attn_output)
     passing = True
 
@@ -653,7 +653,7 @@ def test_falcon7b_attention_softmax_sequence(
             mcast_in0=False,
         )
 
-        mm_slice = ttnn.experimental.operations.primary.matmul(
+        mm_slice = ttnn.matmul(
             slice,
             reference_key_layer_transposed,
             program_config=program_config,
@@ -698,7 +698,7 @@ def test_falcon7b_attention_softmax_sequence(
             mcast_in0=False,
         )
 
-        attn_out_slice = ttnn.experimental.operations.primary.matmul(
+        attn_out_slice = ttnn.matmul(
             mm_slice,
             reference_value_layer,
             program_config=program_config,
@@ -721,7 +721,7 @@ def test_falcon7b_attention_softmax_sequence(
 
     attention_output_concatenated_torch = tt2torch_tensor(attention_output_concatenated)
 
-    attn_weights = ttnn.experimental.tensor.matmul(
+    attn_weights = ttnn.matmul(
         reference_query_layer, reference_key_layer_transposed, output_mem_config=dram_interleaved_memory_config
     )
 
@@ -734,7 +734,7 @@ def test_falcon7b_attention_softmax_sequence(
         compute_kernel_config=compute_kernel_config,
     )
 
-    attn_output = ttnn.experimental.tensor.matmul(attn_weights, reference_value_layer)
+    attn_output = ttnn.matmul(attn_weights, reference_value_layer)
     attn_output_torch = tt2torch_tensor(attn_output)
     passing = True
 

--- a/models/demos/falcon7b/tests/unit_tests/test_falcon_matmuls_and_bmms_with_mixed_precision.py
+++ b/models/demos/falcon7b/tests/unit_tests/test_falcon_matmuls_and_bmms_with_mixed_precision.py
@@ -360,8 +360,8 @@ def test_falcon7b_attnention_sliced(
             slice,
             reference_key_layer_transposed,
             program_config=program_config,
-            output_mem_config=height_sharded_memory_config,
-            output_dtype=ttnn.experimental.tensor.DataType.BFLOAT16,
+            memory_config=height_sharded_memory_config,
+            dtype=ttnn.experimental.tensor.DataType.BFLOAT16,
             compute_kernel_config=compute_kernel_config,
         )
 
@@ -431,8 +431,8 @@ def test_falcon7b_attnention_sliced(
             mm_slice,
             reference_value_layer,
             program_config=program_config,
-            output_mem_config=height_sharded_memory_config,
-            output_dtype=ttnn.experimental.tensor.DataType.BFLOAT16,
+            memory_config=height_sharded_memory_config,
+            dtype=ttnn.experimental.tensor.DataType.BFLOAT16,
             compute_kernel_config=compute_kernel_config,
         )
 
@@ -451,7 +451,7 @@ def test_falcon7b_attnention_sliced(
     attention_output_concatenated_torch = tt2torch_tensor(attention_output_concatenated)
 
     attn_weights = ttnn.matmul(
-        reference_query_layer, reference_key_layer_transposed, output_mem_config=dram_interleaved_memory_config
+        reference_query_layer, reference_key_layer_transposed, memory_config=dram_interleaved_memory_config
     )
 
     attn_weights = ttnn.experimental.operations.primary.bcast(
@@ -657,8 +657,8 @@ def test_falcon7b_attention_softmax_sequence(
             slice,
             reference_key_layer_transposed,
             program_config=program_config,
-            output_mem_config=height_sharded_memory_config,
-            output_dtype=ttnn.experimental.tensor.DataType.BFLOAT16,
+            memory_config=height_sharded_memory_config,
+            dtype=ttnn.experimental.tensor.DataType.BFLOAT16,
             compute_kernel_config=compute_kernel_config,
         )
 
@@ -702,8 +702,8 @@ def test_falcon7b_attention_softmax_sequence(
             mm_slice,
             reference_value_layer,
             program_config=program_config,
-            output_mem_config=height_sharded_memory_config,
-            output_dtype=ttnn.experimental.tensor.DataType.BFLOAT16,
+            memory_config=height_sharded_memory_config,
+            dtype=ttnn.experimental.tensor.DataType.BFLOAT16,
             compute_kernel_config=compute_kernel_config,
         )
 
@@ -722,7 +722,7 @@ def test_falcon7b_attention_softmax_sequence(
     attention_output_concatenated_torch = tt2torch_tensor(attention_output_concatenated)
 
     attn_weights = ttnn.matmul(
-        reference_query_layer, reference_key_layer_transposed, output_mem_config=dram_interleaved_memory_config
+        reference_query_layer, reference_key_layer_transposed, memory_config=dram_interleaved_memory_config
     )
 
     attn_weights = ttnn.experimental.operations.primary.transformers.scale_mask_softmax_in_place(

--- a/models/demos/falcon7b/tt/falcon_attention.py
+++ b/models/demos/falcon7b/tt/falcon_attention.py
@@ -296,7 +296,7 @@ class TtFalconAttentionPrefill(nn.Module):
                 ttnn.matmul(
                     query_layer[i],
                     key_layer_transposed[i],
-                    output_mem_config=self.model_config["PRE_SOFTMAX_MM_OUTPUT_MEMCFG"],
+                    memory_config=self.model_config["PRE_SOFTMAX_MM_OUTPUT_MEMCFG"],
                 )
             )
             query_layer[i].deallocate()
@@ -343,7 +343,7 @@ class TtFalconAttentionPrefill(nn.Module):
                 ttnn.matmul(
                     attn_weights[i],
                     value_layer[i],
-                    output_mem_config=self.model_config["POST_SOFTMAX_MM_OUTPUT_MEMCFG"],
+                    memory_config=self.model_config["POST_SOFTMAX_MM_OUTPUT_MEMCFG"],
                 )
             )
             attn_weights[i].deallocate()
@@ -387,8 +387,8 @@ class TtFalconAttentionPrefill(nn.Module):
                     hidden_states[device_id],
                     self.query_key_value_weights[device_id],
                     program_config=self.model_config["FUSED_QKV_MM_OPTIMIZED_PROGCFG"],
-                    output_mem_config=self.model_config["FUSED_QKV_MM_OPTIMIZED_MEMCFG"],
-                    output_dtype=ttnn.experimental.tensor.DataType.BFLOAT16,
+                    memory_config=self.model_config["FUSED_QKV_MM_OPTIMIZED_MEMCFG"],
+                    dtype=ttnn.experimental.tensor.DataType.BFLOAT16,
                     compute_kernel_config=self.model_config["FUSED_QKV_MM_OPTIMIZED_KERNEL_CONFIG"],
                 )
                 for device_id in range(self.num_devices)
@@ -487,8 +487,8 @@ class TtFalconAttentionPrefill(nn.Module):
                     slices[device_id],
                     key_layer_transposed[device_id],
                     program_config=qkt_prg_cfg,
-                    output_mem_config=self.model_config["QKTV_MM_OPTIMIZED_MEMCFG"],
-                    output_dtype=ttnn.experimental.tensor.DataType.BFLOAT16,
+                    memory_config=self.model_config["QKTV_MM_OPTIMIZED_MEMCFG"],
+                    dtype=ttnn.experimental.tensor.DataType.BFLOAT16,
                     compute_kernel_config=self.model_config["QKTV_AND_SOFTMAX_OPTIMIZED_KERNEL_CONFIG"],
                 )
                 for device_id in range(self.num_devices)
@@ -516,8 +516,8 @@ class TtFalconAttentionPrefill(nn.Module):
                     mm_slices[device_id],
                     value_layer[device_id],
                     program_config=qktv_prg_cfg,
-                    output_mem_config=self.model_config["QKTV_MM_OPTIMIZED_MEMCFG"],
-                    output_dtype=ttnn.experimental.tensor.DataType.BFLOAT16,
+                    memory_config=self.model_config["QKTV_MM_OPTIMIZED_MEMCFG"],
+                    dtype=ttnn.experimental.tensor.DataType.BFLOAT16,
                     compute_kernel_config=self.model_config["QKTV_AND_SOFTMAX_OPTIMIZED_KERNEL_CONFIG"],
                 )
                 for device_id in range(self.num_devices)
@@ -785,10 +785,10 @@ class TtFalconAttentionDecode(nn.Module):
                         program_config=self.model_config["ATTN_BATCHED_MM_PROGCFG"](
                             self.head_dim // 32, self.padded_local_heads // 32, padded_layer_past_len // 32
                         ),
-                        output_mem_config=self.model_config["ATTN_BATCH_SHARDED_MEMCFG"](
+                        memory_config=self.model_config["ATTN_BATCH_SHARDED_MEMCFG"](
                             self.padded_local_heads, padded_layer_past_len
                         ),
-                        output_dtype=self.model_config["PRE_SOFTMAX_MM_OUTPUT_DTYPE"],  # Must be BFLOAT16
+                        dtype=self.model_config["PRE_SOFTMAX_MM_OUTPUT_DTYPE"],  # Must be BFLOAT16
                         compute_kernel_config=self.model_config["PRE_SOFTMAX_MM_COMPUTE_KERNEL_CONFIG"],
                     )
                 )
@@ -902,11 +902,11 @@ class TtFalconAttentionDecode(nn.Module):
                             self.padded_local_heads // 32,
                             self.head_dim // 32,
                         ),
-                        output_mem_config=self.model_config["ATTN_BATCH_SHARDED_MEMCFG"](
+                        memory_config=self.model_config["ATTN_BATCH_SHARDED_MEMCFG"](
                             self.padded_local_heads,
                             self.head_dim,
                         ),
-                        output_dtype=self.model_config["POST_SOFTMAX_MM_OUTPUT_DTYPE"],
+                        dtype=self.model_config["POST_SOFTMAX_MM_OUTPUT_DTYPE"],
                         compute_kernel_config=self.model_config["POST_SOFTMAX_MM_COMPUTE_KERNEL_CONFIG"],
                     )
                 )

--- a/models/demos/falcon7b/tt/falcon_lm_head.py
+++ b/models/demos/falcon7b/tt/falcon_lm_head.py
@@ -79,8 +79,8 @@ def falcon_lm_head_matmul_2d(
                 hidden_states,
                 weights[i],
                 program_config=program_config,
-                output_mem_config=out_mem_config,
-                output_dtype=out_dtype,
+                memory_config=out_mem_config,
+                dtype=out_dtype,
                 compute_kernel_config=compute_kernel_config,
             )
         )

--- a/models/demos/falcon7b/tt/falcon_lm_head.py
+++ b/models/demos/falcon7b/tt/falcon_lm_head.py
@@ -75,7 +75,7 @@ def falcon_lm_head_matmul_2d(
     out_slices = []
     for i in range(num_slices):
         out_slices.append(
-            ttnn.experimental.operations.primary.matmul(
+            ttnn.matmul(
                 hidden_states,
                 weights[i],
                 program_config=program_config,

--- a/models/demos/t3000/falcon40b/tests/test_falcon_model_single_chip.py
+++ b/models/demos/t3000/falcon40b/tests/test_falcon_model_single_chip.py
@@ -173,7 +173,7 @@ def test_sharded_matmul_1d_in0(
         fused_activation=None,
         mcast_in0=True,
     )
-    output_t = ttnn.experimental.operations.primary.matmul_1d(
+    output_t = ttnn.linear(
         in0_t,
         in1_t,
         bias=bias_t,
@@ -291,7 +291,7 @@ def test_sharded_matmul_1d_in0_multi_chip(
     for i in range(num_devices):
         logger.info(f"Running matmul on device: {i}")
         output_t.append(
-            ttnn.experimental.operations.primary.matmul_1d(
+            ttnn.matmul(
                 in0_t[i],
                 in1_t[i],
                 program_config=program_config,
@@ -404,7 +404,7 @@ def test_sharded_matmul_1d_in0_multi_chip(
     for i in range(num_devices):
         logger.info(f"Running matmul on device: {i}")
         output_t.append(
-            ttnn.experimental.operations.primary.matmul_1d(
+            ttnn.matmul(
                 in0_t[i],
                 in1_t[i],
                 program_config=program_config,

--- a/models/demos/t3000/falcon40b/tests/test_falcon_model_single_chip.py
+++ b/models/demos/t3000/falcon40b/tests/test_falcon_model_single_chip.py
@@ -178,8 +178,8 @@ def test_sharded_matmul_1d_in0(
         in1_t,
         bias=bias_t,
         program_config=program_config,
-        output_mem_config=output_mem_config,
-        output_dtype=activations_dtype,
+        memory_config=output_mem_config,
+        dtype=activations_dtype,
     )
     if out_sharded:
         output_t = ttnn.experimental.tensor.sharded_to_interleaved(output_t, interleaved_mem_config)
@@ -295,8 +295,8 @@ def test_sharded_matmul_1d_in0_multi_chip(
                 in0_t[i],
                 in1_t[i],
                 program_config=program_config,
-                output_mem_config=output_mem_config,
-                output_dtype=activations_dtype,
+                memory_config=output_mem_config,
+                dtype=activations_dtype,
             )
         )
 
@@ -408,8 +408,8 @@ def test_sharded_matmul_1d_in0_multi_chip(
                 in0_t[i],
                 in1_t[i],
                 program_config=program_config,
-                output_mem_config=output_mem_config,
-                output_dtype=activations_dtype,
+                memory_config=output_mem_config,
+                dtype=activations_dtype,
             )
         )
 

--- a/models/demos/t3000/falcon40b/tt/falcon_causallm.py
+++ b/models/demos/t3000/falcon40b/tt/falcon_causallm.py
@@ -162,12 +162,12 @@ class TtFalconCausalLM(TtFalconModelShared):
         )
 
         # LM Head
-        lm_logits = ttnn.experimental.operations.primary.matmul_1d(
+        lm_logits = ttnn.matmul(
             hidden_states,
             self.lm_head_weights,
             program_config=self.model_config["LM_HEAD_MM_PROGCFG"],
-            output_mem_config=self.model_config["LM_HEAD_MM_OUTPUT_MEMCFG"],
-            output_dtype=self.model_config["LM_HEAD_MM_OUTPUT_DTYPE"],
+            memory_config=self.model_config["LM_HEAD_MM_OUTPUT_MEMCFG"],
+            dtype=self.model_config["LM_HEAD_MM_OUTPUT_DTYPE"],
             compute_kernel_config=self.model_config["COMPUTE_KERNEL_CONFIG"],
         )
         hidden_states.deallocate(True)

--- a/models/demos/t3000/falcon40b/tt/falcon_mlp.py
+++ b/models/demos/t3000/falcon40b/tt/falcon_mlp.py
@@ -73,12 +73,12 @@ class TtFalconMLP:
             assert False
 
     def fwd_decode(self, x: List[ttnn.experimental.tensor.Tensor]) -> List[ttnn.experimental.tensor.Tensor]:
-        hidden_states = ttnn.experimental.operations.primary.matmul_1d(
+        hidden_states = ttnn.matmul(
             x,
             self.dense_h_to_4h_weights,
             program_config=self.model_config["DENSE_H_TO_4H_MM_PROGCFG"],
-            output_mem_config=self.model_config["DENSE_H_TO_4H_MM_OUTPUT_MEMCFG"],
-            output_dtype=self.model_config["DENSE_H_TO_4H_MM_OUTPUT_DTYPE"],
+            memory_config=self.model_config["DENSE_H_TO_4H_MM_OUTPUT_MEMCFG"],
+            dtype=self.model_config["DENSE_H_TO_4H_MM_OUTPUT_DTYPE"],
             compute_kernel_config=self.model_config["COMPUTE_KERNEL_CONFIG"],
         )
         x.deallocate(True)
@@ -95,12 +95,12 @@ class TtFalconMLP:
         hidden_states = ttnn.experimental.tensor.interleaved_to_sharded(
             hidden_states, sharded_mem_config=self.model_config["MLP_ALL_GATHER_OUTPUT_MEMCFG"]
         )
-        hidden_states = ttnn.experimental.operations.primary.matmul_1d(
+        hidden_states = ttnn.matmul(
             hidden_states,
             self.dense_4h_to_h_weights,
             program_config=self.model_config["DENSE_4H_TO_H_MM_PROGCFG"],
-            output_mem_config=self.model_config["DENSE_4H_TO_H_MM_OUTPUT_MEMCFG"],
-            output_dtype=self.model_config["DENSE_4H_TO_H_MM_OUTPUT_DTYPE"],
+            memory_config=self.model_config["DENSE_4H_TO_H_MM_OUTPUT_MEMCFG"],
+            dtype=self.model_config["DENSE_4H_TO_H_MM_OUTPUT_DTYPE"],
             compute_kernel_config=self.model_config["COMPUTE_KERNEL_CONFIG"],
         )
         # return TT Tensor

--- a/models/demos/t3000/falcon40b/tt/model_utils.py
+++ b/models/demos/t3000/falcon40b/tt/model_utils.py
@@ -268,7 +268,7 @@ def falcon_prefill_matmul(
             overwrite_subblock_h=overwrite_subblock_h,
         )
         # print(f"Program config: {matmul_pgmcfg}")
-        return ttnn.experimental.operations.primary.matmul(
+        return ttnn.matmul(
             in0,
             in1,
             program_config=matmul_pgmcfg,
@@ -290,7 +290,7 @@ def falcon_prefill_matmul(
             overwrite_subblock_h=overwrite_subblock_h,
         )
         # print(f"Program config: {matmul_pgmcfg}")
-        return ttnn.experimental.operations.primary.matmul_1d(
+        return ttnn.matmul(
             in0,
             in1,
             program_config=matmul_pgmcfg,

--- a/models/demos/t3000/falcon40b/tt/model_utils.py
+++ b/models/demos/t3000/falcon40b/tt/model_utils.py
@@ -272,8 +272,8 @@ def falcon_prefill_matmul(
             in0,
             in1,
             program_config=matmul_pgmcfg,
-            output_mem_config=output_mem_config,
-            output_dtype=output_dtype,
+            memory_config=output_mem_config,
+            dtype=output_dtype,
             compute_kernel_config=compute_kernel_config,
         )
     else:
@@ -294,8 +294,8 @@ def falcon_prefill_matmul(
             in0,
             in1,
             program_config=matmul_pgmcfg,
-            output_mem_config=output_mem_config,
-            output_dtype=output_dtype,
+            memory_config=output_mem_config,
+            dtype=output_dtype,
             compute_kernel_config=compute_kernel_config,
         )
 

--- a/models/demos/t3000/mixtral8x7b/tt/mixtral_mlp.py
+++ b/models/demos/t3000/mixtral8x7b/tt/mixtral_mlp.py
@@ -53,7 +53,7 @@ class TtMixtralMLP(LightweightModule):
         w3 -> up_proj
         HF reference: self.down_proj(self.act_fn(self.gate_proj(x)) * self.up_proj(x))
         """
-        w1_out = ttnn.experimental.operations.primary.matmul_1d(
+        w1_out = ttnn.matmul(
             x,
             self.w1,
             program_config=self.model_config["FF1_OUTPUT_PROGCFG"],  # SILu activation fused in the op
@@ -61,7 +61,7 @@ class TtMixtralMLP(LightweightModule):
             compute_kernel_config=self.model_args.get_compute_kernel_config(),
             output_dtype=ttnn.bfloat8_b,
         )
-        w3_out = ttnn.experimental.operations.primary.matmul_1d(
+        w3_out = ttnn.matmul(
             x,
             self.w3,
             program_config=self.model_config["FF3_OUTPUT_PROGCFG"],
@@ -71,7 +71,7 @@ class TtMixtralMLP(LightweightModule):
         )
         w2_in = ttnn.mul(w1_out, w3_out)
 
-        w2_out = ttnn.experimental.operations.primary.matmul_1d(
+        w2_out = ttnn.matmul(
             w2_in,
             self.w2,
             program_config=self.model_config["FF2_OUTPUT_PROGCFG"],

--- a/models/demos/t3000/mixtral8x7b/tt/mixtral_mlp.py
+++ b/models/demos/t3000/mixtral8x7b/tt/mixtral_mlp.py
@@ -57,17 +57,17 @@ class TtMixtralMLP(LightweightModule):
             x,
             self.w1,
             program_config=self.model_config["FF1_OUTPUT_PROGCFG"],  # SILu activation fused in the op
-            output_mem_config=self.model_config["FF1_OUTPUT_MEMCFG"],
+            memory_config=self.model_config["FF1_OUTPUT_MEMCFG"],
             compute_kernel_config=self.model_args.get_compute_kernel_config(),
-            output_dtype=ttnn.bfloat8_b,
+            dtype=ttnn.bfloat8_b,
         )
         w3_out = ttnn.matmul(
             x,
             self.w3,
             program_config=self.model_config["FF3_OUTPUT_PROGCFG"],
-            output_mem_config=self.model_config["FF3_OUTPUT_MEMCFG"],
+            memory_config=self.model_config["FF3_OUTPUT_MEMCFG"],
             compute_kernel_config=self.model_args.get_compute_kernel_config(),
-            output_dtype=ttnn.bfloat8_b,
+            dtype=ttnn.bfloat8_b,
         )
         w2_in = ttnn.mul(w1_out, w3_out)
 
@@ -75,9 +75,9 @@ class TtMixtralMLP(LightweightModule):
             w2_in,
             self.w2,
             program_config=self.model_config["FF2_OUTPUT_PROGCFG"],
-            output_mem_config=self.model_config["FF2_OUTPUT_MEMCFG"],
+            memory_config=self.model_config["FF2_OUTPUT_MEMCFG"],
             compute_kernel_config=self.model_args.get_compute_kernel_config(),
-            output_dtype=ttnn.bfloat8_b,
+            dtype=ttnn.bfloat8_b,
         )
 
         return w2_out

--- a/models/demos/t3000/mixtral8x7b/tt/mixtral_model.py
+++ b/models/demos/t3000/mixtral8x7b/tt/mixtral_model.py
@@ -82,7 +82,7 @@ class TtTransformer(LightweightModule):
             self.output_weight,
             # compute_with_storage_grid_size=(8, 8),
             program_config=self.model_config["OUTPUT_MM_PROGCFG"],
-            output_mem_config=self.model_config["OUTPUT_MM_MEMCFG"],
+            memory_config=self.model_config["OUTPUT_MM_MEMCFG"],
             compute_kernel_config=self.compute_kernel,
         )
 

--- a/models/demos/t3000/mixtral8x7b/tt/mixtral_model.py
+++ b/models/demos/t3000/mixtral8x7b/tt/mixtral_model.py
@@ -77,7 +77,7 @@ class TtTransformer(LightweightModule):
         attn_masks.deallocate(True)
 
         x_norm = self.norm(x)
-        outputs = ttnn.experimental.operations.primary.matmul(
+        outputs = ttnn.matmul(
             x_norm,
             self.output_weight,
             # compute_with_storage_grid_size=(8, 8),

--- a/models/demos/t3000/mixtral8x7b/tt/mixtral_moe.py
+++ b/models/demos/t3000/mixtral8x7b/tt/mixtral_moe.py
@@ -87,7 +87,7 @@ class TtMoeLayer(LightweightModule):
         input_i_1SBH = inputs
         expert_i_HH = self.experts
         # get logits for the experts
-        gate_logits_1SB8 = ttnn.experimental.operations.primary.matmul(
+        gate_logits_1SB8 = ttnn.matmul(
             input_i_1SBH,
             self.gates_H8,
             program_config=self.model_config["GATE_MM_OUTPUT_PROGCFG"],
@@ -109,5 +109,5 @@ class TtMoeLayer(LightweightModule):
         # all gather
         output_11BH_gathered = ttnn.all_gather(results_11BH, dim=2, num_links=1)
         # sum on each device
-        output_11BH_gathered = ttnn.experimental.operations.primary.matmul(self.reduce_mask, output_11BH_gathered)
+        output_11BH_gathered = ttnn.matmul(self.reduce_mask, output_11BH_gathered)
         return output_11BH_gathered

--- a/models/demos/t3000/mixtral8x7b/tt/mixtral_moe.py
+++ b/models/demos/t3000/mixtral8x7b/tt/mixtral_moe.py
@@ -91,9 +91,9 @@ class TtMoeLayer(LightweightModule):
             input_i_1SBH,
             self.gates_H8,
             program_config=self.model_config["GATE_MM_OUTPUT_PROGCFG"],
-            output_mem_config=self.model_config["GATE_MM_OUTPUT_MEMCFG"],
+            memory_config=self.model_config["GATE_MM_OUTPUT_MEMCFG"],
             compute_kernel_config=self.compute_kernel,
-            output_dtype=ttnn.bfloat16,
+            dtype=ttnn.bfloat16,
         )
         # get weights for top-2 experts
         gate_logits_1SB8 = ttnn.add(gate_logits_1SB8, self.top8_mask_11B_64)

--- a/models/demos/wormhole/stable_diffusion/tt2/ttnn_functional_cross_attention.py
+++ b/models/demos/wormhole/stable_diffusion/tt2/ttnn_functional_cross_attention.py
@@ -392,8 +392,8 @@ class cross_attention:
                     slice,
                     k_slice,
                     program_config=self.program_configs["tsa_qkt"],
-                    output_mem_config=self.height_sharded_memory_config,
-                    output_dtype=ttnn.experimental.tensor.DataType.BFLOAT8_B,
+                    memory_config=self.height_sharded_memory_config,
+                    dtype=ttnn.experimental.tensor.DataType.BFLOAT8_B,
                     compute_kernel_config=self.compute_kernel_config,
                 )
                 k_slice.deallocate()
@@ -432,8 +432,8 @@ class cross_attention:
                     mm_slice,
                     v_slice,
                     program_config=self.program_configs["tsa_v"],
-                    output_mem_config=self.height_sharded_memory_config,
-                    output_dtype=ttnn.experimental.tensor.DataType.BFLOAT8_B,
+                    memory_config=self.height_sharded_memory_config,
+                    dtype=ttnn.experimental.tensor.DataType.BFLOAT8_B,
                     compute_kernel_config=self.compute_kernel_config,
                 )
                 v_slice.deallocate()
@@ -492,8 +492,8 @@ class cross_attention:
             q_sharded,
             key,
             program_config=program_config,
-            output_mem_config=self.height_sharded_memory_config,
-            output_dtype=ttnn.experimental.tensor.DataType.BFLOAT8_B,
+            memory_config=self.height_sharded_memory_config,
+            dtype=ttnn.experimental.tensor.DataType.BFLOAT8_B,
             compute_kernel_config=self.compute_kernel_config,
         )
 
@@ -585,8 +585,8 @@ class cross_attention:
             attention_scores,
             v_sharded,
             program_config=program_config,
-            output_mem_config=self.height_sharded_memory_config,
-            output_dtype=ttnn.experimental.tensor.DataType.BFLOAT8_B,
+            memory_config=self.height_sharded_memory_config,
+            dtype=ttnn.experimental.tensor.DataType.BFLOAT8_B,
             compute_kernel_config=self.compute_kernel_config,
         )
         attention_scores = reshard_to(
@@ -660,8 +660,8 @@ class cross_attention:
             self.parameters.to_out[0].weight,
             bias=self.parameters.to_out[0].bias,
             program_config=program_config,
-            output_mem_config=output_mem_config,
-            output_dtype=ttnn.experimental.tensor.DataType.BFLOAT8_B,
+            memory_config=output_mem_config,
+            dtype=ttnn.experimental.tensor.DataType.BFLOAT8_B,
             compute_kernel_config=self.compute_kernel_config,
         )
 
@@ -706,10 +706,10 @@ class cross_attention:
                 hidden_states,
                 self.parameters.qkv.weight,
                 program_config=program_config,
-                output_mem_config=self.l1_interleaved_memory_config
+                memory_config=self.l1_interleaved_memory_config
                 if interleaved_out
                 else self.block_sharded_memory_config,
-                output_dtype=ttnn.experimental.tensor.DataType.BFLOAT8_B,
+                dtype=ttnn.experimental.tensor.DataType.BFLOAT8_B,
                 compute_kernel_config=self.compute_kernel_config,
             )
             ttnn.deallocate(hidden_states)
@@ -740,8 +740,8 @@ class cross_attention:
                 hidden_states,
                 self.parameters.to_q.weight,
                 program_config=program_config,
-                output_mem_config=self.block_sharded_memory_config,
-                output_dtype=ttnn.experimental.tensor.DataType.BFLOAT8_B,
+                memory_config=self.block_sharded_memory_config,
+                dtype=ttnn.experimental.tensor.DataType.BFLOAT8_B,
                 compute_kernel_config=self.compute_kernel_config,
             )
             ttnn.deallocate(hidden_states)
@@ -751,8 +751,8 @@ class cross_attention:
                 encoder_hidden_states,
                 self.parameters.kv.weight,
                 program_config=program_config,
-                output_mem_config=self.block_sharded_memory_config,
-                output_dtype=ttnn.experimental.tensor.DataType.BFLOAT8_B,
+                memory_config=self.block_sharded_memory_config,
+                dtype=ttnn.experimental.tensor.DataType.BFLOAT8_B,
                 compute_kernel_config=self.compute_kernel_config,
             )
             end_core = (

--- a/models/demos/wormhole/stable_diffusion/tt2/ttnn_functional_cross_attention.py
+++ b/models/demos/wormhole/stable_diffusion/tt2/ttnn_functional_cross_attention.py
@@ -388,7 +388,7 @@ class cross_attention:
                     output_mem_config=self.l1_interleaved_memory_config,
                 )
 
-                mm_slice = ttnn.experimental.operations.primary.matmul(
+                mm_slice = ttnn.matmul(
                     slice,
                     k_slice,
                     program_config=self.program_configs["tsa_qkt"],
@@ -428,7 +428,7 @@ class cross_attention:
                     (j, i, self.seq_len - 1, self.key_len - 1),
                     output_mem_config=self.l1_interleaved_memory_config,
                 )
-                mm_slice = ttnn.experimental.operations.primary.matmul(
+                mm_slice = ttnn.matmul(
                     mm_slice,
                     v_slice,
                     program_config=self.program_configs["tsa_v"],
@@ -488,7 +488,7 @@ class cross_attention:
             per_core_N=key_len // 32,
         )
         attention_scores = dealloc_input(
-            ttnn.experimental.operations.primary.matmul,
+            ttnn.matmul,
             q_sharded,
             key,
             program_config=program_config,
@@ -581,7 +581,7 @@ class cross_attention:
             per_core_M=num_heads * seq_len // num_cores // 32,
             per_core_N=inner // 32,
         )
-        attention_scores = ttnn.experimental.operations.primary.matmul(
+        attention_scores = ttnn.matmul(
             attention_scores,
             v_sharded,
             program_config=program_config,
@@ -655,7 +655,7 @@ class cross_attention:
                 fused_activation=None,
             )
 
-        hidden_states = ttnn.experimental.operations.primary.matmul(
+        hidden_states = ttnn.matmul(
             hidden_states,
             self.parameters.to_out[0].weight,
             bias=self.parameters.to_out[0].bias,
@@ -702,7 +702,7 @@ class cross_attention:
             program_config = self.program_configs["qkv"]
             # TODO: Output sharded once https://github.com/tenstorrent/tt-metal/issues/6775 is fixed
             interleaved_out = self.seq_len == 4096 or self.seq_len == 1024
-            qkv_out = ttnn.experimental.operations.primary.matmul(
+            qkv_out = ttnn.matmul(
                 hidden_states,
                 self.parameters.qkv.weight,
                 program_config=program_config,
@@ -736,7 +736,7 @@ class cross_attention:
                 hidden_states = ttnn.to_memory_config(hidden_states, ttnn.L1_MEMORY_CONFIG)
 
             program_config = self.program_configs["q"]
-            q_proj = ttnn.experimental.operations.primary.matmul(
+            q_proj = ttnn.matmul(
                 hidden_states,
                 self.parameters.to_q.weight,
                 program_config=program_config,
@@ -747,7 +747,7 @@ class cross_attention:
             ttnn.deallocate(hidden_states)
 
             program_config = self.program_configs["kv"]
-            kv_proj = ttnn.experimental.operations.primary.matmul(
+            kv_proj = ttnn.matmul(
                 encoder_hidden_states,
                 self.parameters.kv.weight,
                 program_config=program_config,

--- a/models/demos/wormhole/stable_diffusion/tt2/ttnn_functional_cross_attention.py
+++ b/models/demos/wormhole/stable_diffusion/tt2/ttnn_functional_cross_attention.py
@@ -655,7 +655,7 @@ class cross_attention:
                 fused_activation=None,
             )
 
-        hidden_states = ttnn.matmul(
+        hidden_states = ttnn.linear(
             hidden_states,
             self.parameters.to_out[0].weight,
             bias=self.parameters.to_out[0].bias,

--- a/models/demos/wormhole/stable_diffusion/tt2/ttnn_functional_feedforward.py
+++ b/models/demos/wormhole/stable_diffusion/tt2/ttnn_functional_feedforward.py
@@ -88,10 +88,8 @@ class feedforward:
             self.parameters.net[2].weight,
             bias=self.parameters.net[2].bias,
             program_config=program_config,
-            output_mem_config=self.l1_interleaved_memory_config
-            if interleaved_output
-            else self.block_sharded_memory_config,
-            output_dtype=ttnn.experimental.tensor.DataType.BFLOAT8_B,
+            memory_config=self.l1_interleaved_memory_config if interleaved_output else self.block_sharded_memory_config,
+            dtype=ttnn.experimental.tensor.DataType.BFLOAT8_B,
             compute_kernel_config=self.compute_kernel_config,
         )
         if interleaved_output:

--- a/models/demos/wormhole/stable_diffusion/tt2/ttnn_functional_feedforward.py
+++ b/models/demos/wormhole/stable_diffusion/tt2/ttnn_functional_feedforward.py
@@ -83,7 +83,7 @@ class feedforward:
         )
         if hidden_states.shape[-2] == 8192:
             hidden_states = ttnn.reallocate(hidden_states)
-        hidden_states = ttnn.experimental.operations.primary.matmul(
+        hidden_states = ttnn.matmul(
             hidden_states,
             self.parameters.net[2].weight,
             bias=self.parameters.net[2].bias,

--- a/models/demos/wormhole/stable_diffusion/tt2/ttnn_functional_feedforward.py
+++ b/models/demos/wormhole/stable_diffusion/tt2/ttnn_functional_feedforward.py
@@ -83,7 +83,7 @@ class feedforward:
         )
         if hidden_states.shape[-2] == 8192:
             hidden_states = ttnn.reallocate(hidden_states)
-        hidden_states = ttnn.matmul(
+        hidden_states = ttnn.linear(
             hidden_states,
             self.parameters.net[2].weight,
             bias=self.parameters.net[2].bias,

--- a/models/demos/wormhole/stable_diffusion/tt2/ttnn_functional_geglu.py
+++ b/models/demos/wormhole/stable_diffusion/tt2/ttnn_functional_geglu.py
@@ -113,7 +113,7 @@ class geglu:
             transpose_mcast=False,
             fused_activation=None,
         )
-        proj = ttnn.experimental.operations.primary.matmul(
+        proj = ttnn.matmul(
             hidden_states,
             self.parameters.proj.proj_weight,
             bias=self.parameters.proj.proj_bias,
@@ -145,7 +145,7 @@ class geglu:
             transpose_mcast=False,
             fused_activation=[ttnn.experimental.tensor.FusibleActivation.GELU, True],
         )
-        gate = ttnn.experimental.operations.primary.matmul(
+        gate = ttnn.matmul(
             hidden_states,
             self.parameters.proj.gate_weight,
             bias=self.parameters.proj.gate_bias,

--- a/models/demos/wormhole/stable_diffusion/tt2/ttnn_functional_geglu.py
+++ b/models/demos/wormhole/stable_diffusion/tt2/ttnn_functional_geglu.py
@@ -118,10 +118,8 @@ class geglu:
             self.parameters.proj.proj_weight,
             bias=self.parameters.proj.proj_bias,
             program_config=program_config,
-            output_mem_config=self.l1_interleaved_memory_config
-            if interleaved_output
-            else self.block_sharded_memory_config,
-            output_dtype=ttnn.experimental.tensor.DataType.BFLOAT8_B,
+            memory_config=self.l1_interleaved_memory_config if interleaved_output else self.block_sharded_memory_config,
+            dtype=ttnn.experimental.tensor.DataType.BFLOAT8_B,
             compute_kernel_config=self.compute_kernel_config,
         )
         if interleaved_output:
@@ -150,10 +148,8 @@ class geglu:
             self.parameters.proj.gate_weight,
             bias=self.parameters.proj.gate_bias,
             program_config=program_config,
-            output_mem_config=self.l1_interleaved_memory_config
-            if interleaved_output
-            else self.block_sharded_memory_config,
-            output_dtype=ttnn.experimental.tensor.DataType.BFLOAT8_B,
+            memory_config=self.l1_interleaved_memory_config if interleaved_output else self.block_sharded_memory_config,
+            dtype=ttnn.experimental.tensor.DataType.BFLOAT8_B,
             compute_kernel_config=self.compute_kernel_config,
         )
         if interleaved_output:

--- a/models/demos/wormhole/stable_diffusion/tt2/ttnn_functional_geglu.py
+++ b/models/demos/wormhole/stable_diffusion/tt2/ttnn_functional_geglu.py
@@ -113,7 +113,7 @@ class geglu:
             transpose_mcast=False,
             fused_activation=None,
         )
-        proj = ttnn.matmul(
+        proj = ttnn.linear(
             hidden_states,
             self.parameters.proj.proj_weight,
             bias=self.parameters.proj.proj_bias,
@@ -143,7 +143,7 @@ class geglu:
             transpose_mcast=False,
             fused_activation=[ttnn.experimental.tensor.FusibleActivation.GELU, True],
         )
-        gate = ttnn.matmul(
+        gate = ttnn.linear(
             hidden_states,
             self.parameters.proj.gate_weight,
             bias=self.parameters.proj.gate_bias,

--- a/models/demos/wormhole/stable_diffusion/tt2/ttnn_functional_resnetblock2d.py
+++ b/models/demos/wormhole/stable_diffusion/tt2/ttnn_functional_resnetblock2d.py
@@ -527,7 +527,7 @@ class resnetBlock2D:
                     memory_layout=ttnn.experimental.tensor.TensorMemoryLayout.INTERLEAVED,
                     buffer_type=ttnn.experimental.tensor.BufferType.L1,
                 )
-                temb = ttnn.experimental.operations.primary.matmul(
+                temb = ttnn.matmul(
                     temb,
                     self.parameters.time_emb_proj.weight,
                     bias=self.parameters.time_emb_proj.bias,

--- a/models/demos/wormhole/stable_diffusion/tt2/ttnn_functional_resnetblock2d.py
+++ b/models/demos/wormhole/stable_diffusion/tt2/ttnn_functional_resnetblock2d.py
@@ -532,8 +532,8 @@ class resnetBlock2D:
                     self.parameters.time_emb_proj.weight,
                     bias=self.parameters.time_emb_proj.bias,
                     program_config=program_config,
-                    output_mem_config=l1_memory_config,
-                    output_dtype=ttnn.experimental.tensor.DataType.BFLOAT8_B,
+                    memory_config=l1_memory_config,
+                    dtype=ttnn.experimental.tensor.DataType.BFLOAT8_B,
                     compute_kernel_config=compute_kernel_config,
                 )
 

--- a/models/demos/wormhole/stable_diffusion/tt2/ttnn_functional_resnetblock2d.py
+++ b/models/demos/wormhole/stable_diffusion/tt2/ttnn_functional_resnetblock2d.py
@@ -527,7 +527,7 @@ class resnetBlock2D:
                     memory_layout=ttnn.experimental.tensor.TensorMemoryLayout.INTERLEAVED,
                     buffer_type=ttnn.experimental.tensor.BufferType.L1,
                 )
-                temb = ttnn.matmul(
+                temb = ttnn.linear(
                     temb,
                     self.parameters.time_emb_proj.weight,
                     bias=self.parameters.time_emb_proj.bias,

--- a/models/demos/wormhole/stable_diffusion/tt2/ttnn_functional_resnetblock2d_new_conv.py
+++ b/models/demos/wormhole/stable_diffusion/tt2/ttnn_functional_resnetblock2d_new_conv.py
@@ -561,7 +561,7 @@ class resnetBlock2D:
                     memory_layout=ttnn.experimental.tensor.TensorMemoryLayout.INTERLEAVED,
                     buffer_type=ttnn.experimental.tensor.BufferType.L1,
                 )
-                temb = ttnn.experimental.operations.primary.matmul(
+                temb = ttnn.matmul(
                     temb,
                     self.parameters.time_emb_proj.weight,
                     bias=self.parameters.time_emb_proj.bias,

--- a/models/demos/wormhole/stable_diffusion/tt2/ttnn_functional_resnetblock2d_new_conv.py
+++ b/models/demos/wormhole/stable_diffusion/tt2/ttnn_functional_resnetblock2d_new_conv.py
@@ -561,7 +561,7 @@ class resnetBlock2D:
                     memory_layout=ttnn.experimental.tensor.TensorMemoryLayout.INTERLEAVED,
                     buffer_type=ttnn.experimental.tensor.BufferType.L1,
                 )
-                temb = ttnn.matmul(
+                temb = ttnn.linear(
                     temb,
                     self.parameters.time_emb_proj.weight,
                     bias=self.parameters.time_emb_proj.bias,

--- a/models/demos/wormhole/stable_diffusion/tt2/ttnn_functional_resnetblock2d_new_conv.py
+++ b/models/demos/wormhole/stable_diffusion/tt2/ttnn_functional_resnetblock2d_new_conv.py
@@ -566,8 +566,8 @@ class resnetBlock2D:
                     self.parameters.time_emb_proj.weight,
                     bias=self.parameters.time_emb_proj.bias,
                     program_config=program_config,
-                    output_mem_config=l1_memory_config,
-                    output_dtype=ttnn.experimental.tensor.DataType.BFLOAT8_B,
+                    memory_config=l1_memory_config,
+                    dtype=ttnn.experimental.tensor.DataType.BFLOAT8_B,
                     compute_kernel_config=compute_kernel_config,
                 )
 

--- a/models/experimental/resnet/tt/ttnn_functional_resnet50.py
+++ b/models/experimental/resnet/tt/ttnn_functional_resnet50.py
@@ -74,8 +74,8 @@ def ResnetLinear(
             weight,
             bias=bias,
             program_config=matmul_config,
-            output_mem_config=output_mem_config,
-            output_dtype=model_config["ACTIVATIONS_DTYPE"],
+            memory_config=output_mem_config,
+            dtype=model_config["ACTIVATIONS_DTYPE"],
             compute_kernel_config=compute_kernel_config,
         )
         return output

--- a/models/experimental/resnet/tt/ttnn_functional_resnet50.py
+++ b/models/experimental/resnet/tt/ttnn_functional_resnet50.py
@@ -69,7 +69,7 @@ def ResnetLinear(
     bias = bias.reshape(1, 1, bias_shape[-2], bias_shape[-1])
 
     def linear_(act):
-        output = ttnn.experimental.operations.primary.matmul_1d(
+        output = ttnn.linear(
             act,
             weight,
             bias=bias,

--- a/models/experimental/resnet/tt/ttnn_functional_resnet50_new_conv_api.py
+++ b/models/experimental/resnet/tt/ttnn_functional_resnet50_new_conv_api.py
@@ -70,7 +70,7 @@ def ResnetLinear(
     bias = bias.reshape(1, 1, bias_shape[-2], bias_shape[-1])
 
     def linear_(act):
-        output = ttnn.experimental.operations.primary.matmul_1d(
+        output = ttnn.linear(
             act,
             weight,
             bias=bias,

--- a/models/experimental/resnet/tt/ttnn_functional_resnet50_new_conv_api.py
+++ b/models/experimental/resnet/tt/ttnn_functional_resnet50_new_conv_api.py
@@ -75,8 +75,8 @@ def ResnetLinear(
             weight,
             bias=bias,
             program_config=matmul_config,
-            output_mem_config=output_mem_config,
-            output_dtype=model_config["ACTIVATIONS_DTYPE"],
+            memory_config=output_mem_config,
+            dtype=model_config["ACTIVATIONS_DTYPE"],
             compute_kernel_config=compute_kernel_config,
         )
         return output


### PR DESCRIPTION
### Ticket
- Link to Github Issue. https://github.com/tenstorrent/tt-metal/issues/9492

### Problem description
- We're removing experimental / tt_lib

### What's changed
- Move calls of experimental/tt_lib matmul/matmul_1d to ttnn matmul/linear in the models python files

### Checklist
- [x] Post commit CI passes
- [x] Model regression CI testing passes (if applicable)
- [x] New/Existing tests provide coverage for changes

### Tests

https://github.com/tenstorrent/tt-metal/actions/runs/9587583184 Model perf regressions and output report passes
https://github.com/tenstorrent/tt-metal/actions/runs/9596914396 [T3K] T3000 model perf tests - CNN portion passes (the other one fails on main)
https://github.com/tenstorrent/tt-metal/actions/runs/9597008828 All post-commit tests passes