### PR TITLE
#0: New sfpi remote to use temp one on metal org

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,6 @@
 [submodule "src/ckernels/sfpi"]
 	path = tt_metal/third_party/sfpi
-	url = https://github.com/tenstorrent/sfpi-rel.git
+	url = https://github.com/tenstorrent-metal/sfpi-rel-temp.git
 [submodule "third_party/pybind11"]
 	path = tt_metal/third_party/pybind11
 	url = https://github.com/pybind/pybind11.git


### PR DESCRIPTION
### Ticket

#9561 

### Problem description

Still broken, need to use temp SFPI remote

### What's changed

Use mirrored master on tenstorrent-metal

### Checklist
- [ ] Post commit CI passes
- [ ] Model regression CI testing passes (if applicable)
- [ ] New/Existing tests provide coverage for changes
