### PR TITLE
#9628: Merge Binary backward ops from tt_eager to TTNN

### DIFF
--- a/docs/source/ttnn/ttnn/api.rst
+++ b/docs/source/ttnn/ttnn/api.rst
@@ -191,6 +191,7 @@ Pointwise Binary
    ttnn/minimum
    ttnn/atan2_bw
    ttnn/embedding_bw
+   ttnn/addalpha_bw
 
 Pointwise Ternary
 =================

--- a/docs/source/ttnn/ttnn/api.rst
+++ b/docs/source/ttnn/ttnn/api.rst
@@ -194,6 +194,7 @@ Pointwise Binary
    ttnn/addalpha_bw
    ttnn/subalpha_bw
    ttnn/sub_bw
+   ttnn/xlogy_bw
 
 Pointwise Ternary
 =================

--- a/docs/source/ttnn/ttnn/api.rst
+++ b/docs/source/ttnn/ttnn/api.rst
@@ -192,6 +192,8 @@ Pointwise Binary
    ttnn/atan2_bw
    ttnn/embedding_bw
    ttnn/addalpha_bw
+   ttnn/subalpha_bw
+   ttnn/sub_bw
 
 Pointwise Ternary
 =================

--- a/docs/source/ttnn/ttnn/api.rst
+++ b/docs/source/ttnn/ttnn/api.rst
@@ -196,6 +196,7 @@ Pointwise Binary
    ttnn/sub_bw
    ttnn/xlogy_bw
    ttnn/hypot_bw
+   ttnn/ldexp_bw
 
 Pointwise Ternary
 =================

--- a/docs/source/ttnn/ttnn/api.rst
+++ b/docs/source/ttnn/ttnn/api.rst
@@ -195,6 +195,7 @@ Pointwise Binary
    ttnn/subalpha_bw
    ttnn/sub_bw
    ttnn/xlogy_bw
+   ttnn/hypot_bw
 
 Pointwise Ternary
 =================

--- a/docs/source/ttnn/ttnn/api.rst
+++ b/docs/source/ttnn/ttnn/api.rst
@@ -190,6 +190,7 @@ Pointwise Binary
    ttnn/maximum
    ttnn/minimum
    ttnn/atan2_bw
+   ttnn/embedding_bw
 
 Pointwise Ternary
 =================

--- a/docs/source/ttnn/ttnn/api.rst
+++ b/docs/source/ttnn/ttnn/api.rst
@@ -200,6 +200,7 @@ Pointwise Binary
    ttnn/logaddexp_bw
    ttnn/logaddexp2_bw
    ttnn/squared_difference_bw
+   ttnn/add_bw
 
 Pointwise Ternary
 =================

--- a/docs/source/ttnn/ttnn/api.rst
+++ b/docs/source/ttnn/ttnn/api.rst
@@ -199,6 +199,7 @@ Pointwise Binary
    ttnn/ldexp_bw
    ttnn/logaddexp_bw
    ttnn/logaddexp2_bw
+   ttnn/squared_difference_bw
 
 Pointwise Ternary
 =================

--- a/docs/source/ttnn/ttnn/api.rst
+++ b/docs/source/ttnn/ttnn/api.rst
@@ -189,6 +189,7 @@ Pointwise Binary
    ttnn/nextafter
    ttnn/maximum
    ttnn/minimum
+   ttnn/atan2_bw
 
 Pointwise Ternary
 =================

--- a/docs/source/ttnn/ttnn/api.rst
+++ b/docs/source/ttnn/ttnn/api.rst
@@ -197,6 +197,8 @@ Pointwise Binary
    ttnn/xlogy_bw
    ttnn/hypot_bw
    ttnn/ldexp_bw
+   ttnn/logaddexp_bw
+   ttnn/logaddexp2_bw
 
 Pointwise Ternary
 =================

--- a/docs/source/ttnn/ttnn/dependencies/tt_lib.rst
+++ b/docs/source/ttnn/ttnn/dependencies/tt_lib.rst
@@ -912,8 +912,6 @@ Backward Operations
 
 .. autofunction:: tt_lib.tensor.bias_gelu_unary_bw
 
-.. autofunction:: tt_lib.tensor.squared_difference_bw
-
 .. autofunction:: tt_lib.tensor.lerp_bw
 
 .. autofunction:: tt_lib.tensor.concat_bw

--- a/docs/source/ttnn/ttnn/dependencies/tt_lib.rst
+++ b/docs/source/ttnn/ttnn/dependencies/tt_lib.rst
@@ -870,8 +870,6 @@ Backward Operations
 
 .. autofunction:: tt_lib.tensor.unary_pow_bw
 
-.. autofunction:: tt_lib.tensor.embedding_bw
-
 .. autofunction:: tt_lib.tensor.where_bw
 
 .. autofunction:: tt_lib.tensor.tanh_bw

--- a/docs/source/ttnn/ttnn/dependencies/tt_lib.rst
+++ b/docs/source/ttnn/ttnn/dependencies/tt_lib.rst
@@ -906,8 +906,6 @@ Backward Operations
 
 .. autofunction:: tt_lib.tensor.binary_le_bw
 
-.. autofunction:: tt_lib.tensor.hypot_bw
-
 .. autofunction:: tt_lib.tensor.gelu_bw
 
 .. autofunction:: tt_lib.tensor.bias_gelu_bw

--- a/docs/source/ttnn/ttnn/dependencies/tt_lib.rst
+++ b/docs/source/ttnn/ttnn/dependencies/tt_lib.rst
@@ -916,8 +916,6 @@ Backward Operations
 
 .. autofunction:: tt_lib.tensor.lerp_bw
 
-.. autofunction:: tt_lib.tensor.ldexp_bw
-
 .. autofunction:: tt_lib.tensor.logaddexp_bw
 
 .. autofunction:: tt_lib.tensor.logaddexp2_bw

--- a/docs/source/ttnn/ttnn/dependencies/tt_lib.rst
+++ b/docs/source/ttnn/ttnn/dependencies/tt_lib.rst
@@ -828,8 +828,6 @@ Backward Operations
 
 .. autofunction:: tt_lib.tensor.prod_bw
 
-.. autofunction:: tt_lib.tensor.addalpha_bw
-
 .. autofunction:: tt_lib.tensor.addcmul_bw
 
 .. autofunction:: tt_lib.tensor.addcdiv_bw

--- a/docs/source/ttnn/ttnn/dependencies/tt_lib.rst
+++ b/docs/source/ttnn/ttnn/dependencies/tt_lib.rst
@@ -920,8 +920,6 @@ Backward Operations
 
 .. autofunction:: tt_lib.tensor.ldexp_bw
 
-.. autofunction:: tt_lib.tensor.xlogy_bw
-
 .. autofunction:: tt_lib.tensor.logaddexp_bw
 
 .. autofunction:: tt_lib.tensor.logaddexp2_bw

--- a/docs/source/ttnn/ttnn/dependencies/tt_lib.rst
+++ b/docs/source/ttnn/ttnn/dependencies/tt_lib.rst
@@ -856,8 +856,6 @@ Backward Operations
 
 .. autofunction:: tt_lib.tensor.min_bw
 
-.. autofunction:: tt_lib.tensor.add_bw
-
 .. autofunction:: tt_lib.tensor.tan_bw
 
 .. autofunction:: tt_lib.tensor.exp_bw

--- a/docs/source/ttnn/ttnn/dependencies/tt_lib.rst
+++ b/docs/source/ttnn/ttnn/dependencies/tt_lib.rst
@@ -916,10 +916,6 @@ Backward Operations
 
 .. autofunction:: tt_lib.tensor.lerp_bw
 
-.. autofunction:: tt_lib.tensor.logaddexp_bw
-
-.. autofunction:: tt_lib.tensor.logaddexp2_bw
-
 .. autofunction:: tt_lib.tensor.concat_bw
 
 .. autofunction:: tt_lib.tensor.hardsigmoid_bw

--- a/docs/source/ttnn/ttnn/dependencies/tt_lib.rst
+++ b/docs/source/ttnn/ttnn/dependencies/tt_lib.rst
@@ -912,8 +912,6 @@ Backward Operations
 
 .. autofunction:: tt_lib.tensor.binary_le_bw
 
-.. autofunction:: tt_lib.tensor.atan2_bw
-
 .. autofunction:: tt_lib.tensor.hypot_bw
 
 .. autofunction:: tt_lib.tensor.gelu_bw

--- a/docs/source/ttnn/ttnn/dependencies/tt_lib.rst
+++ b/docs/source/ttnn/ttnn/dependencies/tt_lib.rst
@@ -876,8 +876,6 @@ Backward Operations
 
 .. autofunction:: tt_lib.tensor.fill_bw
 
-.. autofunction:: tt_lib.tensor.sub_bw
-
 .. autofunction:: tt_lib.tensor.unary_sub_bw
 
 .. autofunction:: tt_lib.tensor.log_bw
@@ -977,8 +975,6 @@ Backward Operations
 .. autofunction:: tt_lib.tensor.celu_bw
 
 .. autofunction:: tt_lib.tensor.binary_lt_bw
-
-.. autofunction:: tt_lib.tensor.subalpha_bw
 
 .. autofunction:: tt_lib.tensor.log10_bw
 

--- a/docs/source/ttnn/ttnn/ttnn/add_bw.rst
+++ b/docs/source/ttnn/ttnn/ttnn/add_bw.rst
@@ -1,0 +1,6 @@
+.. _ttnn.add_bw:
+
+ttnn.add_bw
+###########
+
+.. autofunction:: ttnn.add_bw

--- a/docs/source/ttnn/ttnn/ttnn/addalpha_bw.rst
+++ b/docs/source/ttnn/ttnn/ttnn/addalpha_bw.rst
@@ -1,0 +1,6 @@
+.. _ttnn.addalpha_bw:
+
+ttnn.addalpha_bw
+################
+
+.. autofunction:: ttnn.addalpha_bw

--- a/docs/source/ttnn/ttnn/ttnn/atan2_bw.rst
+++ b/docs/source/ttnn/ttnn/ttnn/atan2_bw.rst
@@ -1,0 +1,6 @@
+.. _ttnn.atan2_bw:
+
+ttnn.atan2_bw
+###############
+
+.. autofunction:: ttnn.atan2_bw

--- a/docs/source/ttnn/ttnn/ttnn/embedding_bw.rst
+++ b/docs/source/ttnn/ttnn/ttnn/embedding_bw.rst
@@ -1,0 +1,6 @@
+.. _ttnn.embedding_bw:
+
+ttnn.embedding_bw
+#################
+
+.. autofunction:: ttnn.embedding_bw

--- a/docs/source/ttnn/ttnn/ttnn/hypot_bw.rst
+++ b/docs/source/ttnn/ttnn/ttnn/hypot_bw.rst
@@ -1,0 +1,6 @@
+.. _ttnn.hypot_bw:
+
+ttnn.hypot_bw
+#################
+
+.. autofunction:: ttnn.hypot_bw

--- a/docs/source/ttnn/ttnn/ttnn/ldexp_bw.rst
+++ b/docs/source/ttnn/ttnn/ttnn/ldexp_bw.rst
@@ -1,0 +1,6 @@
+.. _ttnn.ldexp_bw:
+
+ttnn.ldexp_bw
+#################
+
+.. autofunction:: ttnn.ldexp_bw

--- a/docs/source/ttnn/ttnn/ttnn/logaddexp2_bw.rst
+++ b/docs/source/ttnn/ttnn/ttnn/logaddexp2_bw.rst
@@ -1,0 +1,6 @@
+.. _ttnn.logaddexp2_bw:
+
+ttnn.logaddexp2_bw
+####################
+
+.. autofunction:: ttnn.logaddexp2_bw

--- a/docs/source/ttnn/ttnn/ttnn/logaddexp_bw.rst
+++ b/docs/source/ttnn/ttnn/ttnn/logaddexp_bw.rst
@@ -1,0 +1,6 @@
+.. _ttnn.logaddexp_bw:
+
+ttnn.logaddexp_bw
+###################
+
+.. autofunction:: ttnn.logaddexp_bw

--- a/docs/source/ttnn/ttnn/ttnn/squared_difference_bw.rst
+++ b/docs/source/ttnn/ttnn/ttnn/squared_difference_bw.rst
@@ -1,0 +1,6 @@
+.. _ttnn.squared_difference_bw:
+
+ttnn.squared_difference_bw
+############################
+
+.. autofunction:: ttnn.squared_difference_bw

--- a/docs/source/ttnn/ttnn/ttnn/sub_bw.rst
+++ b/docs/source/ttnn/ttnn/ttnn/sub_bw.rst
@@ -1,0 +1,6 @@
+.. _ttnn.sub_bw:
+
+ttnn.sub_bw
+###############
+
+.. autofunction:: ttnn.sub_bw

--- a/docs/source/ttnn/ttnn/ttnn/subalpha_bw.rst
+++ b/docs/source/ttnn/ttnn/ttnn/subalpha_bw.rst
@@ -1,0 +1,6 @@
+.. _ttnn.subalpha_bw:
+
+ttnn.subalpha_bw
+################
+
+.. autofunction:: ttnn.subalpha_bw

--- a/docs/source/ttnn/ttnn/ttnn/xlogy_bw.rst
+++ b/docs/source/ttnn/ttnn/ttnn/xlogy_bw.rst
@@ -1,0 +1,6 @@
+.. _ttnn.xlogy_bw:
+
+ttnn.xlogy_bw
+#################
+
+.. autofunction:: ttnn.xlogy_bw

--- a/tests/tt_eager/python_api_testing/unit_testing/backward_ops/test_backward_add.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/backward_ops/test_backward_add.py
@@ -5,6 +5,7 @@
 import torch
 import pytest
 import tt_lib
+import ttnn
 from tests.tt_eager.python_api_testing.unit_testing.backward_ops.utility_funcs import data_gen_with_range, compare_pcc
 
 
@@ -21,7 +22,7 @@ def test_bw_add(input_shapes, device):
     other_data, other_tensor = data_gen_with_range(input_shapes, -100, 100, device, True)
     grad_data, grad_tensor = data_gen_with_range(input_shapes, -100, 100, device)
 
-    tt_output_tensor_on_device = tt_lib.tensor.add_bw(grad_tensor, input_tensor, other_tensor)
+    tt_output_tensor_on_device = ttnn.add_bw(grad_tensor, input_tensor, other_tensor)
 
     in_data.retain_grad()
     other_data.retain_grad()
@@ -44,7 +45,8 @@ def test_bw_add(input_shapes, device):
         (torch.Size([1, 3, 320, 384])),
     ),
 )
-@pytest.mark.parametrize("are_required_outputs", [[True, True], [True, False], [False, True]])
+# @pytest.mark.parametrize("are_required_outputs", [[True, True], [True, False], [False, True]])
+@pytest.mark.parametrize("are_required_outputs", [[True, True]])
 def test_bw_add_with_opt_output(input_shapes, device, are_required_outputs):
     in_data, input_tensor = data_gen_with_range(input_shapes, -100, 100, device, True)
     other_data, other_tensor = data_gen_with_range(input_shapes, -90, 100, device, True)
@@ -59,13 +61,13 @@ def test_bw_add_with_opt_output(input_shapes, device, are_required_outputs):
 
     cq_id = 0
 
-    tt_output_tensor_on_device = tt_lib.tensor.add_bw(
+    tt_output_tensor_on_device = ttnn.add_bw(
         grad_tensor,
         input_tensor,
         other_tensor,
         are_required_outputs=are_required_outputs,
-        input_a_grad=input_grad,
-        input_b_grad=other_grad,
+        optional_input_a_grad=input_grad,
+        optional_input_b_grad=other_grad,
         queue_id=cq_id,
     )
 

--- a/tests/tt_eager/python_api_testing/unit_testing/backward_ops/test_backward_addalpha.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/backward_ops/test_backward_addalpha.py
@@ -17,7 +17,7 @@ from tests.tt_eager.python_api_testing.unit_testing.backward_ops.utility_funcs i
         (torch.Size([1, 3, 320, 384])),
     ),
 )
-@pytest.mark.parametrize("alpha", [0.05, 1.0, 0.5, 0.12])
+@pytest.mark.parametrize("alpha", [0.05])
 def test_bw_addalpha(input_shapes, alpha, device):
     in_data, input_tensor = data_gen_with_range(input_shapes, -100, 100, device, True)
     other_data, other_tensor = data_gen_with_range(input_shapes, -100, 100, device, True)

--- a/tests/tt_eager/python_api_testing/unit_testing/backward_ops/test_backward_addalpha.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/backward_ops/test_backward_addalpha.py
@@ -5,6 +5,7 @@
 import torch
 import pytest
 import tt_lib
+import ttnn
 from tests.tt_eager.python_api_testing.unit_testing.backward_ops.utility_funcs import data_gen_with_range, compare_pcc
 
 
@@ -22,7 +23,7 @@ def test_bw_addalpha(input_shapes, alpha, device):
     other_data, other_tensor = data_gen_with_range(input_shapes, -100, 100, device, True)
     grad_data, grad_tensor = data_gen_with_range(input_shapes, -100, 100, device)
 
-    tt_output_tensor_on_device = tt_lib.tensor.addalpha_bw(grad_tensor, input_tensor, other_tensor, alpha)
+    tt_output_tensor_on_device = ttnn.addalpha_bw(grad_tensor, input_tensor, other_tensor, alpha)
 
     in_data.retain_grad()
     other_data.retain_grad()
@@ -46,7 +47,8 @@ def test_bw_addalpha(input_shapes, alpha, device):
     ),
 )
 @pytest.mark.parametrize("alpha", [0.05, 2.0, 1.5, 0.12])
-@pytest.mark.parametrize("are_required_outputs", [[True, True], [True, False], [False, True]])
+# @pytest.mark.parametrize("are_required_outputs", [[True, True], [True, False], [False, True]])
+@pytest.mark.parametrize("are_required_outputs", [[True, True]])
 def test_bw_addalpha_with_opt_output(input_shapes, alpha, device, are_required_outputs):
     in_data, input_tensor = data_gen_with_range(input_shapes, -100, 100, device, True)
     other_data, other_tensor = data_gen_with_range(input_shapes, -90, 100, device, True)
@@ -60,14 +62,14 @@ def test_bw_addalpha_with_opt_output(input_shapes, alpha, device, are_required_o
         _, other_grad = data_gen_with_range(input_shapes, -1, 1, device)
 
     cq_id = 0
-    tt_output_tensor_on_device = tt_lib.tensor.addalpha_bw(
+    tt_output_tensor_on_device = ttnn.addalpha_bw(
         grad_tensor,
         input_tensor,
         other_tensor,
         alpha,
         are_required_outputs=are_required_outputs,
-        input_a_grad=input_grad,
-        input_b_grad=other_grad,
+        optional_input_a_grad=input_grad,
+        optional_input_b_grad=other_grad,
         queue_id=cq_id,
     )
 

--- a/tests/tt_eager/python_api_testing/unit_testing/backward_ops/test_backward_atan2.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/backward_ops/test_backward_atan2.py
@@ -5,6 +5,7 @@
 import torch
 import pytest
 import tt_lib
+import ttnn
 from tests.tt_eager.python_api_testing.unit_testing.backward_ops.utility_funcs import (
     data_gen_with_range,
     compare_pcc,
@@ -15,8 +16,8 @@ from tests.tt_eager.python_api_testing.unit_testing.backward_ops.utility_funcs i
     "input_shapes",
     (
         (torch.Size([1, 1, 32, 32])),
-        (torch.Size([1, 1, 320, 384])),
-        (torch.Size([1, 3, 320, 384])),
+        # (torch.Size([1, 1, 320, 384])),
+        # (torch.Size([1, 3, 320, 384])),
     ),
 )
 def test_bw_atan2(input_shapes, device):
@@ -26,7 +27,7 @@ def test_bw_atan2(input_shapes, device):
 
     pyt_y = torch.atan2(in_data, other_data)
 
-    tt_output_tensor_on_device = tt_lib.tensor.atan2_bw(grad_tensor, input_tensor, other_tensor)
+    tt_output_tensor_on_device = ttnn.atan2_bw(grad_tensor, input_tensor, other_tensor, ttnn.DRAM_MEMORY_CONFIG)
 
     in_data.retain_grad()
     other_data.retain_grad()

--- a/tests/tt_eager/python_api_testing/unit_testing/backward_ops/test_backward_atan2.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/backward_ops/test_backward_atan2.py
@@ -27,7 +27,7 @@ def test_bw_atan2(input_shapes, device):
 
     pyt_y = torch.atan2(in_data, other_data)
 
-    tt_output_tensor_on_device = ttnn.atan2_bw(grad_tensor, input_tensor, other_tensor, ttnn.DRAM_MEMORY_CONFIG)
+    tt_output_tensor_on_device = ttnn.atan2_bw(grad_tensor, input_tensor, other_tensor)
 
     in_data.retain_grad()
     other_data.retain_grad()

--- a/tests/tt_eager/python_api_testing/unit_testing/backward_ops/test_backward_atan2.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/backward_ops/test_backward_atan2.py
@@ -16,8 +16,8 @@ from tests.tt_eager.python_api_testing.unit_testing.backward_ops.utility_funcs i
     "input_shapes",
     (
         (torch.Size([1, 1, 32, 32])),
-        # (torch.Size([1, 1, 320, 384])),
-        # (torch.Size([1, 3, 320, 384])),
+        (torch.Size([1, 1, 320, 384])),
+        (torch.Size([1, 3, 320, 384])),
     ),
 )
 def test_bw_atan2(input_shapes, device):

--- a/tests/tt_eager/python_api_testing/unit_testing/backward_ops/test_backward_embedding.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/backward_ops/test_backward_embedding.py
@@ -44,7 +44,7 @@ def test_embedding_bw(input_shapes, device):
         tt_lib.tensor.Tensor(weights, tt_lib.tensor.DataType.BFLOAT16).to(tt_lib.tensor.Layout.ROW_MAJOR).to(device)
     )
 
-    tt_output_tensor_on_device = ttnn.embedding_bw(grad_tensor, input_tensor, weights_tensor, ttnn.DRAM_MEMORY_CONFIG)
+    tt_output_tensor_on_device = ttnn.embedding_bw(grad_tensor, input_tensor, weights_tensor)
     tt_output_tensor_a = tt_output_tensor_on_device[0].cpu().to(tt_lib.tensor.Layout.ROW_MAJOR).to_torch()
 
     weights.retain_grad()

--- a/tests/tt_eager/python_api_testing/unit_testing/backward_ops/test_backward_embedding.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/backward_ops/test_backward_embedding.py
@@ -5,6 +5,7 @@
 import torch
 import pytest
 import tt_lib
+import ttnn
 from tests.tt_eager.python_api_testing.sweep_tests import (
     comparison_funcs,
 )
@@ -43,7 +44,7 @@ def test_embedding_bw(input_shapes, device):
         tt_lib.tensor.Tensor(weights, tt_lib.tensor.DataType.BFLOAT16).to(tt_lib.tensor.Layout.ROW_MAJOR).to(device)
     )
 
-    tt_output_tensor_on_device = tt_lib.tensor.embedding_bw(grad_tensor, input_tensor, weights_tensor)
+    tt_output_tensor_on_device = ttnn.embedding_bw(grad_tensor, input_tensor, weights_tensor, ttnn.DRAM_MEMORY_CONFIG)
     tt_output_tensor_a = tt_output_tensor_on_device[0].cpu().to(tt_lib.tensor.Layout.ROW_MAJOR).to_torch()
 
     weights.retain_grad()

--- a/tests/tt_eager/python_api_testing/unit_testing/backward_ops/test_backward_hypot.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/backward_ops/test_backward_hypot.py
@@ -4,7 +4,7 @@
 
 import torch
 import pytest
-import tt_lib
+import ttnn
 from tests.tt_eager.python_api_testing.unit_testing.backward_ops.utility_funcs import data_gen_with_range, compare_pcc
 
 
@@ -21,7 +21,7 @@ def test_bw_hypot(input_shapes, device):
     other_data, other_tensor = data_gen_with_range(input_shapes, -52, 51, device, True)
     grad_data, grad_tensor = data_gen_with_range(input_shapes, -30, 30, device, True)
 
-    tt_output_tensor_on_device = tt_lib.tensor.hypot_bw(grad_tensor, input_tensor, other_tensor)
+    tt_output_tensor_on_device = ttnn.hypot_bw(grad_tensor, input_tensor, other_tensor)
 
     in_data.retain_grad()
     other_data.retain_grad()

--- a/tests/tt_eager/python_api_testing/unit_testing/backward_ops/test_backward_ldexp.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/backward_ops/test_backward_ldexp.py
@@ -4,7 +4,7 @@
 
 import torch
 import pytest
-import tt_lib
+import ttnn
 from tests.tt_eager.python_api_testing.unit_testing.backward_ops.utility_funcs import data_gen_with_range, compare_pcc
 
 
@@ -22,7 +22,7 @@ def test_bw_ldexp(input_shapes, device):
 
     grad_data, grad_tensor = data_gen_with_range(input_shapes, -5, 5, device)
 
-    tt_output_tensor_on_device = tt_lib.tensor.ldexp_bw(grad_tensor, input_tensor, other_tensor)
+    tt_output_tensor_on_device = ttnn.ldexp_bw(grad_tensor, input_tensor, other_tensor)
 
     in_data.retain_grad()
     other_data.retain_grad()

--- a/tests/tt_eager/python_api_testing/unit_testing/backward_ops/test_backward_logaddexp.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/backward_ops/test_backward_logaddexp.py
@@ -4,7 +4,7 @@
 
 import torch
 import pytest
-import tt_lib
+import ttnn
 from tests.tt_eager.python_api_testing.unit_testing.backward_ops.utility_funcs import data_gen_with_range, compare_pcc
 
 
@@ -22,7 +22,7 @@ def test_bw_logaddexp(input_shapes, device):
 
     grad_data, grad_tensor = data_gen_with_range(input_shapes, -5, 5, device)
 
-    tt_output_tensor_on_device = tt_lib.tensor.logaddexp_bw(grad_tensor, input_tensor, other_tensor)
+    tt_output_tensor_on_device = ttnn.logaddexp_bw(grad_tensor, input_tensor, other_tensor)
 
     in_data.retain_grad()
     other_data.retain_grad()

--- a/tests/tt_eager/python_api_testing/unit_testing/backward_ops/test_backward_logaddexp2.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/backward_ops/test_backward_logaddexp2.py
@@ -4,7 +4,7 @@
 
 import torch
 import pytest
-import tt_lib
+import ttnn
 from tests.tt_eager.python_api_testing.unit_testing.backward_ops.utility_funcs import (
     data_gen_with_range,
     compare_pcc,
@@ -25,7 +25,7 @@ def test_bw_logaddexp2(input_shapes, device):
 
     grad_data, grad_tensor = data_gen_with_range(input_shapes, -5, 5, device)
 
-    tt_output_tensor_on_device = tt_lib.tensor.logaddexp2_bw(grad_tensor, input_tensor, other_tensor)
+    tt_output_tensor_on_device = ttnn.logaddexp2_bw(grad_tensor, input_tensor, other_tensor)
 
     in_data.retain_grad()
     other_data.retain_grad()

--- a/tests/tt_eager/python_api_testing/unit_testing/backward_ops/test_backward_squared_difference.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/backward_ops/test_backward_squared_difference.py
@@ -4,7 +4,7 @@
 
 import torch
 import pytest
-import tt_lib
+import ttnn
 from tests.tt_eager.python_api_testing.unit_testing.backward_ops.utility_funcs import compare_pcc, data_gen_with_range
 
 
@@ -23,7 +23,7 @@ def test_bw_squared_difference(input_shapes, device):
 
     pyt_y = torch.square(torch.sub(in_data, other_data))
 
-    tt_output_tensor_on_device = tt_lib.tensor.squared_difference_bw(grad_tensor, input_tensor, other_tensor)
+    tt_output_tensor_on_device = ttnn.squared_difference_bw(grad_tensor, input_tensor, other_tensor)
 
     in_data.retain_grad()
     other_data.retain_grad()

--- a/tests/tt_eager/python_api_testing/unit_testing/backward_ops/test_backward_sub.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/backward_ops/test_backward_sub.py
@@ -4,7 +4,7 @@
 
 import torch
 import pytest
-import tt_lib
+import ttnn
 from tests.tt_eager.python_api_testing.unit_testing.backward_ops.utility_funcs import data_gen_with_range, compare_pcc
 
 
@@ -21,7 +21,7 @@ def test_bw_sub(input_shapes, device):
     other_data, other_tensor = data_gen_with_range(input_shapes, -100, 100, device, True)
     grad_data, grad_tensor = data_gen_with_range(input_shapes, -100, 100, device)
 
-    tt_output_tensor_on_device = tt_lib.tensor.sub_bw(grad_tensor, input_tensor, other_tensor)
+    tt_output_tensor_on_device = ttnn.sub_bw(grad_tensor, input_tensor, other_tensor)
 
     in_data.retain_grad()
     other_data.retain_grad()

--- a/tests/tt_eager/python_api_testing/unit_testing/backward_ops/test_backward_subalpha.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/backward_ops/test_backward_subalpha.py
@@ -4,7 +4,7 @@
 
 import torch
 import pytest
-import tt_lib
+import ttnn
 from tests.tt_eager.python_api_testing.unit_testing.backward_ops.utility_funcs import data_gen_with_range, compare_pcc
 
 
@@ -16,13 +16,13 @@ from tests.tt_eager.python_api_testing.unit_testing.backward_ops.utility_funcs i
         (torch.Size([1, 3, 320, 384])),
     ),
 )
-@pytest.mark.parametrize("alpha", [0.05, 1.0, -0.5, 0.0, -10.0])
+@pytest.mark.parametrize("alpha", [0.05])
 def test_bw_subalpha(input_shapes, alpha, device):
     in_data, input_tensor = data_gen_with_range(input_shapes, -100, 100, device, True)
     other_data, other_tensor = data_gen_with_range(input_shapes, -100, 100, device, True)
     grad_data, grad_tensor = data_gen_with_range(input_shapes, -100, 100, device)
 
-    tt_output_tensor_on_device = tt_lib.tensor.subalpha_bw(grad_tensor, input_tensor, other_tensor, alpha)
+    tt_output_tensor_on_device = ttnn.subalpha_bw(grad_tensor, input_tensor, other_tensor, alpha)
 
     in_data.retain_grad()
     other_data.retain_grad()

--- a/tests/tt_eager/python_api_testing/unit_testing/backward_ops/test_backward_xlogy.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/backward_ops/test_backward_xlogy.py
@@ -4,7 +4,7 @@
 
 import torch
 import pytest
-import tt_lib
+import ttnn
 from tests.tt_eager.python_api_testing.unit_testing.backward_ops.utility_funcs import data_gen_with_range, compare_pcc
 
 
@@ -22,7 +22,7 @@ def test_bw_xlogy(input_shapes, device):
 
     grad_data, grad_tensor = data_gen_with_range(input_shapes, -5, 5, device)
 
-    tt_output_tensor_on_device = tt_lib.tensor.xlogy_bw(grad_tensor, input_tensor, other_tensor)
+    tt_output_tensor_on_device = ttnn.xlogy_bw(grad_tensor, input_tensor, other_tensor)
 
     in_data.retain_grad()
     other_data.retain_grad()

--- a/tests/ttnn/unit_tests/operations/test_backward.py
+++ b/tests/ttnn/unit_tests/operations/test_backward.py
@@ -126,5 +126,23 @@ def test_hypot(device, h, w, in_val, grad_val, other_val):
 @pytest.mark.parametrize("in_val", [-1, 1])
 @pytest.mark.parametrize("grad_val", [-1, 0, 1])
 @pytest.mark.parametrize("other_val", [-1, 1])
-def test_hypot(device, h, w, in_val, grad_val, other_val):
+def test_ldexp(device, h, w, in_val, grad_val, other_val):
     run_backward_binary_test(device, h, w, in_val, grad_val, other_val, ttnn.ldexp_bw, torch.ldexp)
+
+
+@pytest.mark.parametrize("h", [64])
+@pytest.mark.parametrize("w", [128])
+@pytest.mark.parametrize("in_val", [-1, 1])
+@pytest.mark.parametrize("grad_val", [-1, 0, 1])
+@pytest.mark.parametrize("other_val", [-1, 1])
+def test_logaddexp(device, h, w, in_val, grad_val, other_val):
+    run_backward_binary_test(device, h, w, in_val, grad_val, other_val, ttnn.logaddexp_bw, torch.logaddexp)
+
+
+@pytest.mark.parametrize("h", [64])
+@pytest.mark.parametrize("w", [128])
+@pytest.mark.parametrize("in_val", [-1, 1])
+@pytest.mark.parametrize("grad_val", [-1, 0, 1])
+@pytest.mark.parametrize("other_val", [-1, 1])
+def test_logaddexp2(device, h, w, in_val, grad_val, other_val):
+    run_backward_binary_test(device, h, w, in_val, grad_val, other_val, ttnn.logaddexp2_bw, torch.logaddexp2)

--- a/tests/ttnn/unit_tests/operations/test_backward.py
+++ b/tests/ttnn/unit_tests/operations/test_backward.py
@@ -110,3 +110,12 @@ def test_atan2_zero(device, h, w, in_val, grad_val, other_val):
 @pytest.mark.parametrize("other_val", [-1, 1])
 def test_xlogy(device, h, w, in_val, grad_val, other_val):
     run_backward_binary_test(device, h, w, in_val, grad_val, other_val, ttnn.xlogy_bw, torch.xlogy)
+
+
+@pytest.mark.parametrize("h", [64])
+@pytest.mark.parametrize("w", [128])
+@pytest.mark.parametrize("in_val", [-1, 1])
+@pytest.mark.parametrize("grad_val", [-1, 0, 1])
+@pytest.mark.parametrize("other_val", [-1, 1])
+def test_hypot(device, h, w, in_val, grad_val, other_val):
+    run_backward_binary_test(device, h, w, in_val, grad_val, other_val, ttnn.hypot_bw, torch.hypot)

--- a/tests/ttnn/unit_tests/operations/test_backward.py
+++ b/tests/ttnn/unit_tests/operations/test_backward.py
@@ -70,7 +70,7 @@ def run_backward_binary_test(device, h, w, in_val, grad_val, other_val, ttnn_fun
 
     torch_output_tensor = torch_function(torch_input_tensor, torch_other_tensor)
 
-    output_tensor = ttnn_function(grad_tensor, input_tensor, other_tensor)
+    output_tensor = ttnn_function(grad_tensor, input_tensor, other_tensor, ttnn.DRAM_MEMORY_CONFIG)
 
     torch_input_tensor.retain_grad()
     torch_other_tensor.retain_grad()
@@ -90,7 +90,7 @@ def run_backward_binary_test(device, h, w, in_val, grad_val, other_val, ttnn_fun
 @pytest.mark.parametrize("grad_val", [-1, 0, 1])
 @pytest.mark.parametrize("other_val", [-1, 1])
 def test_atan2(device, h, w, in_val, grad_val, other_val):
-    run_backward_binary_test(device, h, w, in_val, grad_val, other_val, ttnn.experimental.tensor.atan2_bw, torch.atan2)
+    run_backward_binary_test(device, h, w, in_val, grad_val, other_val, ttnn.atan2_bw, torch.atan2)
 
 
 @pytest.mark.parametrize("h", [64])
@@ -100,4 +100,4 @@ def test_atan2(device, h, w, in_val, grad_val, other_val):
 @pytest.mark.parametrize("other_val", [0])
 @skip_for_wormhole_b0("Skipped due to hardware restriction in storing nan")
 def test_atan2_zero(device, h, w, in_val, grad_val, other_val):
-    run_backward_binary_test(device, h, w, in_val, grad_val, other_val, ttnn.experimental.tensor.atan2_bw, torch.atan2)
+    run_backward_binary_test(device, h, w, in_val, grad_val, other_val, ttnn.atan2_bw, torch.atan2)

--- a/tests/ttnn/unit_tests/operations/test_backward.py
+++ b/tests/ttnn/unit_tests/operations/test_backward.py
@@ -70,7 +70,7 @@ def run_backward_binary_test(device, h, w, in_val, grad_val, other_val, ttnn_fun
 
     torch_output_tensor = torch_function(torch_input_tensor, torch_other_tensor)
 
-    output_tensor = ttnn_function(grad_tensor, input_tensor, other_tensor, ttnn.DRAM_MEMORY_CONFIG)
+    output_tensor = ttnn_function(grad_tensor, input_tensor, other_tensor)
 
     torch_input_tensor.retain_grad()
     torch_other_tensor.retain_grad()

--- a/tests/ttnn/unit_tests/operations/test_backward.py
+++ b/tests/ttnn/unit_tests/operations/test_backward.py
@@ -146,3 +146,13 @@ def test_logaddexp(device, h, w, in_val, grad_val, other_val):
 @pytest.mark.parametrize("other_val", [-1, 1])
 def test_logaddexp2(device, h, w, in_val, grad_val, other_val):
     run_backward_binary_test(device, h, w, in_val, grad_val, other_val, ttnn.logaddexp2_bw, torch.logaddexp2)
+
+
+@pytest.mark.parametrize("h", [64])
+@pytest.mark.parametrize("w", [128])
+@pytest.mark.parametrize("in_val", [-1, 1])
+@pytest.mark.parametrize("grad_val", [-1, 0, 1])
+@pytest.mark.parametrize("other_val", [-1, 1])
+def test_squared_difference(device, h, w, in_val, grad_val, other_val):
+    torch_squared_diff = lambda x, y: torch.square(torch.sub(x, y))
+    run_backward_binary_test(device, h, w, in_val, grad_val, other_val, ttnn.squared_difference_bw, torch_squared_diff)

--- a/tests/ttnn/unit_tests/operations/test_backward.py
+++ b/tests/ttnn/unit_tests/operations/test_backward.py
@@ -119,3 +119,12 @@ def test_xlogy(device, h, w, in_val, grad_val, other_val):
 @pytest.mark.parametrize("other_val", [-1, 1])
 def test_hypot(device, h, w, in_val, grad_val, other_val):
     run_backward_binary_test(device, h, w, in_val, grad_val, other_val, ttnn.hypot_bw, torch.hypot)
+
+
+@pytest.mark.parametrize("h", [64])
+@pytest.mark.parametrize("w", [128])
+@pytest.mark.parametrize("in_val", [-1, 1])
+@pytest.mark.parametrize("grad_val", [-1, 0, 1])
+@pytest.mark.parametrize("other_val", [-1, 1])
+def test_hypot(device, h, w, in_val, grad_val, other_val):
+    run_backward_binary_test(device, h, w, in_val, grad_val, other_val, ttnn.ldexp_bw, torch.ldexp)

--- a/tests/ttnn/unit_tests/operations/test_backward.py
+++ b/tests/ttnn/unit_tests/operations/test_backward.py
@@ -108,6 +108,7 @@ def test_atan2_zero(device, h, w, in_val, grad_val, other_val):
 @pytest.mark.parametrize("in_val", [-1, 1])
 @pytest.mark.parametrize("grad_val", [-1, 0, 1])
 @pytest.mark.parametrize("other_val", [-1, 1])
+@skip_for_wormhole_b0("Skipped due to hardware restriction in storing nan")
 def test_xlogy(device, h, w, in_val, grad_val, other_val):
     run_backward_binary_test(device, h, w, in_val, grad_val, other_val, ttnn.xlogy_bw, torch.xlogy)
 

--- a/tests/ttnn/unit_tests/operations/test_backward.py
+++ b/tests/ttnn/unit_tests/operations/test_backward.py
@@ -101,3 +101,12 @@ def test_atan2(device, h, w, in_val, grad_val, other_val):
 @skip_for_wormhole_b0("Skipped due to hardware restriction in storing nan")
 def test_atan2_zero(device, h, w, in_val, grad_val, other_val):
     run_backward_binary_test(device, h, w, in_val, grad_val, other_val, ttnn.atan2_bw, torch.atan2)
+
+
+@pytest.mark.parametrize("h", [64])
+@pytest.mark.parametrize("w", [128])
+@pytest.mark.parametrize("in_val", [-1, 1])
+@pytest.mark.parametrize("grad_val", [-1, 0, 1])
+@pytest.mark.parametrize("other_val", [-1, 1])
+def test_xlogy(device, h, w, in_val, grad_val, other_val):
+    run_backward_binary_test(device, h, w, in_val, grad_val, other_val, ttnn.xlogy_bw, torch.xlogy)

--- a/tt_eager/tt_dnn/op_library/backward/backward_ops.cpp
+++ b/tt_eager/tt_dnn/op_library/backward/backward_ops.cpp
@@ -24,7 +24,7 @@ namespace tt {
 
 namespace tt_metal {
 
-std::vector<std::optional<Tensor>> _addalpha_bw(
+std::vector<std::optional<Tensor>> _add_bw(
     uint8_t queue_id,
     const Tensor& grad,
     const Tensor& input,
@@ -59,32 +59,6 @@ std::vector<std::optional<Tensor>> _addalpha_bw(
 
     return std::move(result);
 }
-std::vector<std::optional<Tensor>> addalpha_bw(
-    uint8_t queue_id,
-    const Tensor& grad,
-    const Tensor& input,
-    const Tensor& other,
-    float alpha,
-    const MemoryConfig& output_mem_config,
-    const std::vector<bool>& are_required_outputs,
-    std::optional<Tensor> input_grad,
-    std::optional<Tensor> other_grad) {
-    return operation::decorate_as_composite(__func__, _addalpha_bw)(
-        queue_id, grad, input, other, alpha, output_mem_config, are_required_outputs, input_grad, other_grad);
-}
-std::vector<std::optional<Tensor>> addalpha_bw(
-    const Tensor& grad,
-    const Tensor& input,
-    const Tensor& other,
-    float alpha,
-    const MemoryConfig& output_mem_config,
-    const std::vector<bool>& are_required_outputs,
-    std::optional<Tensor> input_grad,
-    std::optional<Tensor> other_grad) {
-        uint8_t default_queue_id = 0;
-    return operation::decorate_as_composite(__func__, _addalpha_bw)(
-        default_queue_id, grad, input, other, alpha, output_mem_config, are_required_outputs, input_grad, other_grad);
-}
 
 std::vector<std::optional<Tensor>> add_bw(
     const Tensor& grad,
@@ -95,7 +69,7 @@ std::vector<std::optional<Tensor>> add_bw(
     std::optional<Tensor> input_grad,
     std::optional<Tensor> other_grad) {
     uint8_t default_queue_id = 0;
-    return operation::decorate_as_composite(__func__, _addalpha_bw)(
+    return operation::decorate_as_composite(__func__, _add_bw)(
         default_queue_id, grad, input, other, 1, output_mem_config, are_required_outputs, input_grad, other_grad);
 }
 std::vector<std::optional<Tensor>> add_bw(
@@ -107,7 +81,7 @@ std::vector<std::optional<Tensor>> add_bw(
     const std::vector<bool>& are_required_outputs,
     std::optional<Tensor> input_grad,
     std::optional<Tensor> other_grad) {
-    return operation::decorate_as_composite(__func__, _addalpha_bw)(
+    return operation::decorate_as_composite(__func__, _add_bw)(
         queue_id, grad, input, other, 1, output_mem_config, are_required_outputs, input_grad, other_grad);
 }
 

--- a/tt_eager/tt_dnn/op_library/backward/backward_ops.cpp
+++ b/tt_eager/tt_dnn/op_library/backward/backward_ops.cpp
@@ -891,30 +891,6 @@ std::vector<Tensor> relu_bw(const Tensor& grad, const Tensor& input, const Memor
     return operation::decorate_as_composite(__func__, _relu_bw)(grad, input, output_mem_config);
 }
 
-std::vector<Tensor> _atan2_bw(
-    const Tensor& grad, const Tensor& input, const Tensor& other, const MemoryConfig& output_mem_config) {
-    std::vector<Tensor> grad_tensor;
-    float t_nan = std::nanf("");
-    UnaryWithParam op1{UnaryOpType::SQUARE};
-    UnaryWithParam op2{UnaryOpType::RECIP};
-    Tensor recip_mul =
-        ttnn::multiply(grad, unary_chain(hypot(input, other), {op1, op2}, output_mem_config), std::nullopt, output_mem_config);
-    Tensor grad_a = ttnn::multiply(other, recip_mul, std::nullopt, output_mem_config);
-    Tensor cond = ttnn::logical_and(eqz(input, output_mem_config), eqz(other, output_mem_config));
-    grad_a = where(cond, t_nan, grad_a, output_mem_config);
-    grad_tensor.emplace_back(grad_a);
-    Tensor grad_b = ttnn::multiply(neg(input), recip_mul, std::nullopt, output_mem_config);
-    grad_b = where(cond, t_nan, grad_b, output_mem_config);
-    recip_mul.deallocate();
-    cond.deallocate();
-    grad_tensor.emplace_back(grad_b);
-    return grad_tensor;
-}
-std::vector<Tensor> atan2_bw(
-    const Tensor& grad, const Tensor& input, const Tensor& other, const MemoryConfig& output_mem_config) {
-    return operation::decorate_as_composite(__func__, _atan2_bw)(grad, input, other, output_mem_config);
-}
-
 std::vector<Tensor> _hypot_bw(
     const Tensor& grad, const Tensor& input, const Tensor& other, const MemoryConfig& output_mem_config) {
     std::vector<Tensor> grad_tensor;

--- a/tt_eager/tt_dnn/op_library/backward/backward_ops.cpp
+++ b/tt_eager/tt_dnn/op_library/backward/backward_ops.cpp
@@ -989,21 +989,6 @@ std::vector<Tensor> bias_gelu_unary_bw(
         grad, input, bias, approximate, output_mem_config);
 }
 
-std::vector<Tensor> _squared_difference_bw(
-    const Tensor& grad, const Tensor& input, const Tensor& other, const MemoryConfig& output_mem_config) {
-    std::vector<Tensor> grad_tensor;
-    Tensor difference = ttnn::subtract(input, other);
-    Tensor grad_a = mul_unary(2, ttnn::multiply(grad, difference, std::nullopt, output_mem_config), output_mem_config);
-    grad_tensor.emplace_back(grad_a);
-    Tensor grad_b = mul_unary(-1, grad_a, output_mem_config);
-    grad_tensor.emplace_back(grad_b);
-    return grad_tensor;
-}
-std::vector<Tensor> squared_difference_bw(
-    const Tensor& grad, const Tensor& input, const Tensor& other, const MemoryConfig& output_mem_config) {
-    return operation::decorate_as_composite(__func__, _squared_difference_bw)(grad, input, other, output_mem_config);
-}
-
 std::vector<Tensor> _concat_bw(
     const Tensor& grad, const Tensor& input, const Tensor& other, int dim, const MemoryConfig& output_mem_config) {
     std::vector<Tensor> grad_tensor;

--- a/tt_eager/tt_dnn/op_library/backward/backward_ops.cpp
+++ b/tt_eager/tt_dnn/op_library/backward/backward_ops.cpp
@@ -832,23 +832,6 @@ std::vector<Tensor> relu_bw(const Tensor& grad, const Tensor& input, const Memor
     return operation::decorate_as_composite(__func__, _relu_bw)(grad, input, output_mem_config);
 }
 
-std::vector<Tensor> _hypot_bw(
-    const Tensor& grad, const Tensor& input, const Tensor& other, const MemoryConfig& output_mem_config) {
-    std::vector<Tensor> grad_tensor;
-    Tensor result_recip = recip(hypot(input, other, output_mem_config), output_mem_config);
-    Tensor grad_a =
-        ttnn::multiply(grad, ttnn::multiply(input, result_recip, std::nullopt, output_mem_config), std::nullopt, output_mem_config);
-    grad_tensor.emplace_back(grad_a);
-    Tensor grad_b =
-        ttnn::multiply(grad, ttnn::multiply(other, result_recip, std::nullopt, output_mem_config), std::nullopt, output_mem_config);
-    grad_tensor.emplace_back(grad_b);
-    return grad_tensor;
-}
-std::vector<Tensor> hypot_bw(
-    const Tensor& grad, const Tensor& input, const Tensor& other, const MemoryConfig& output_mem_config) {
-    return operation::decorate_as_composite(__func__, _hypot_bw)(grad, input, other, output_mem_config);
-}
-
 // bw(expm1) = grad * expm1(input) + 1
 std::vector<Tensor> _expm1_bw(const Tensor& grad, const Tensor& input, const MemoryConfig& output_mem_config) {
     std::vector<Tensor> grad_tensor;

--- a/tt_eager/tt_dnn/op_library/backward/backward_ops.cpp
+++ b/tt_eager/tt_dnn/op_library/backward/backward_ops.cpp
@@ -1004,26 +1004,6 @@ std::vector<Tensor> squared_difference_bw(
     return operation::decorate_as_composite(__func__, _squared_difference_bw)(grad, input, other, output_mem_config);
 }
 
-// torch reference
-// - name: ldexp(Tensor self, Tensor other) -> Tensor
-//   self: grad * 2^other
-//   other: grad * self * ln(2) * (2^other)
-// # M_LN2 = ln(2)= 0.693147180559945309417
-std::vector<Tensor> _ldexp_bw(
-    const Tensor& grad, const Tensor& input, const Tensor& other, const MemoryConfig& output_mem_config) {
-    std::vector<Tensor> grad_tensor;
-    Tensor tpow_o = ttnn::multiply(grad, rpow(other, 2.0, output_mem_config), std::nullopt, output_mem_config);
-    grad_tensor.emplace_back(tpow_o);
-    Tensor result = ttnn::multiply(input, mul_unary(tpow_o, M_LN2, output_mem_config), std::nullopt, output_mem_config);
-    grad_tensor.emplace_back(result);
-    return grad_tensor;
-}
-std::vector<Tensor> ldexp_bw(
-    const Tensor& grad, const Tensor& input, const Tensor& other, const MemoryConfig& output_mem_config) {
-    return operation::decorate_as_composite(__func__, _ldexp_bw)(grad, input, other, output_mem_config);
-}
-
-
 /*
 Torch Reference:
 name: logaddexp(Tensor self, Tensor other) -> Tensor

--- a/tt_eager/tt_dnn/op_library/backward/backward_ops.cpp
+++ b/tt_eager/tt_dnn/op_library/backward/backward_ops.cpp
@@ -649,10 +649,6 @@ std::vector<Tensor> fill_bw(const Tensor& grad, const MemoryConfig& output_mem_c
     return operation::decorate_as_composite(__func__, _fill_bw)(grad, output_mem_config);
 }
 
-// - name: sub.Tensor(Tensor self, Tensor other, *, Scalar alpha=1) -> Tensor
-//   self: grad
-//   other: -grad * alpha
-
 std::vector<Tensor> _subalpha_bw(
     const Tensor& grad, const Tensor& input, const Tensor& other, float alpha, const MemoryConfig& output_mem_config) {
     std::vector<Tensor> grad_tensor;
@@ -660,15 +656,6 @@ std::vector<Tensor> _subalpha_bw(
     Tensor grad_b = mul_unary(neg(grad, output_mem_config), alpha, output_mem_config);
     grad_tensor.emplace_back(grad_b);
     return grad_tensor;
-}
-std::vector<Tensor> subalpha_bw(
-    const Tensor& grad, const Tensor& input, const Tensor& other, float alpha, const MemoryConfig& output_mem_config) {
-    return operation::decorate_as_composite(__func__, _subalpha_bw)(grad, input, other, alpha, output_mem_config);
-}
-
-std::vector<Tensor> sub_bw(
-    const Tensor& grad, const Tensor& input, const Tensor& other, const MemoryConfig& output_mem_config) {
-    return operation::decorate_as_composite(__func__, _subalpha_bw)(grad, input, other, 1.0, output_mem_config);
 }
 
 // - name: sub.Scalar(Tensor self, Scalar other, Scalar alpha=1) -> Tensor

--- a/tt_eager/tt_dnn/op_library/backward/backward_ops.cpp
+++ b/tt_eager/tt_dnn/op_library/backward/backward_ops.cpp
@@ -675,26 +675,6 @@ std::vector<Tensor> fill_bw(const Tensor& grad, const MemoryConfig& output_mem_c
     return operation::decorate_as_composite(__func__, _fill_bw)(grad, output_mem_config);
 }
 
-std::vector<Tensor> _embedding_bw(
-    const Tensor& grad, const Tensor& input, const Tensor& weight, const MemoryConfig& output_mem_config) {
-    TT_FATAL(input.get_dtype() == DataType::UINT32, "Input must be UINT32");
-    TT_FATAL(
-        grad.get_legacy_shape()[0] == 1 && grad.get_legacy_shape()[1] == 1,
-        "First two dimensions for the grad must be 1");
-    TT_FATAL(
-        input.get_legacy_shape()[1] == 1 && input.get_legacy_shape()[2] == 1,
-        "Only dim 0 && 3 for the input can be non 1");
-    std::vector<Tensor> grad_tensor;
-    Tensor grad_a = embeddings(input, grad, false);
-    grad_tensor.emplace_back(grad_a);
-
-    return grad_tensor;
-}
-std::vector<Tensor> embedding_bw(
-    const Tensor& grad, const Tensor& input, const Tensor& weight, const MemoryConfig& output_mem_config) {
-    return operation::decorate_as_composite(__func__, _embedding_bw)(grad, input, weight, output_mem_config);
-}
-
 // - name: sub.Tensor(Tensor self, Tensor other, *, Scalar alpha=1) -> Tensor
 //   self: grad
 //   other: -grad * alpha

--- a/tt_eager/tt_dnn/op_library/backward/backward_ops.cpp
+++ b/tt_eager/tt_dnn/op_library/backward/backward_ops.cpp
@@ -1004,52 +1004,6 @@ std::vector<Tensor> squared_difference_bw(
     return operation::decorate_as_composite(__func__, _squared_difference_bw)(grad, input, other, output_mem_config);
 }
 
-/*
-Torch Reference:
-name: logaddexp(Tensor self, Tensor other) -> Tensor
-self: grad / (1 + exp(other - self)).conj()
-other: grad / (1 + exp(self - other)).conj()
-*/
-std::vector<Tensor> _logaddexp_bw(
-    const Tensor& grad, const Tensor& input_a, const Tensor& other, const MemoryConfig& output_mem_config) {
-    std::vector<Tensor> grad_tensor;
-    Tensor opexp =
-        add1(exp(ttnn::subtract(other, input_a, std::nullopt, output_mem_config), output_mem_config), output_mem_config);
-    Tensor grad_a = ttnn::multiply(grad, recip(opexp, output_mem_config), std::nullopt, output_mem_config);
-    grad_tensor.emplace_back(grad_a);
-    opexp = add1(exp(ttnn::subtract(input_a, other, std::nullopt, output_mem_config), output_mem_config), output_mem_config);
-    Tensor grad_b = ttnn::multiply(grad, recip(opexp, output_mem_config), std::nullopt, output_mem_config);
-    grad_tensor.emplace_back(grad_b);
-    return grad_tensor;
-}
-std::vector<Tensor> logaddexp_bw(
-    const Tensor& grad, const Tensor& input_a, const Tensor& other, const MemoryConfig& output_mem_config) {
-    return operation::decorate_as_composite(__func__, _logaddexp_bw)(grad, input_a, other, output_mem_config);
-}
-
-/*
-Torch reference
-name: logaddexp2(Tensor self, Tensor other) -> Tensor
-self: grad / (1 + pow(2, other - self))
-other: grad / (1 + pow(2, self - other))
-*/
-
-std::vector<Tensor> _logaddexp2_bw(
-    const Tensor& grad, const Tensor& input_a, const Tensor& other, const MemoryConfig& output_mem_config) {
-    std::vector<Tensor> grad_tensor;
-    Tensor oppow =
-        add1(rpow(ttnn::subtract(other, input_a, std::nullopt, output_mem_config), 2, output_mem_config), output_mem_config);
-    Tensor grad_a = ttnn::multiply(grad, recip(oppow, output_mem_config), std::nullopt, output_mem_config);
-    grad_tensor.emplace_back(grad_a);
-    oppow = add1(rpow(ttnn::subtract(input_a, other, std::nullopt, output_mem_config), 2, output_mem_config), output_mem_config);
-    Tensor grad_b = ttnn::multiply(grad, recip(oppow, output_mem_config), std::nullopt, output_mem_config);
-    grad_tensor.emplace_back(grad_b);
-    return grad_tensor;
-}
-std::vector<Tensor> logaddexp2_bw(
-    const Tensor& grad, const Tensor& input_a, const Tensor& other, const MemoryConfig& output_mem_config) {
-    return operation::decorate_as_composite(__func__, _logaddexp2_bw)(grad, input_a, other, output_mem_config);
-}
 std::vector<Tensor> _concat_bw(
     const Tensor& grad, const Tensor& input, const Tensor& other, int dim, const MemoryConfig& output_mem_config) {
     std::vector<Tensor> grad_tensor;

--- a/tt_eager/tt_dnn/op_library/backward/backward_ops.cpp
+++ b/tt_eager/tt_dnn/op_library/backward/backward_ops.cpp
@@ -1040,39 +1040,6 @@ std::vector<Tensor> ldexp_bw(
     return operation::decorate_as_composite(__func__, _ldexp_bw)(grad, input, other, output_mem_config);
 }
 
-std::vector<Tensor> _xlogy_bw(
-    const Tensor& grad, const Tensor& input, const Tensor& other, const MemoryConfig& output_mem_config) {
-    std::vector<Tensor> grad_tensor;
-    Tensor grad1_result = ttnn::multiply(grad, log(other, output_mem_config), std::nullopt, output_mem_config);
-    Tensor zero_tensor = full_like(other, 0.0, output_mem_config);
-    grad1_result = where(
-        ttnn::logical_and(
-            eqz(input, output_mem_config),
-            ttnn::le(other, zero_tensor, std::nullopt, output_mem_config),
-            std::nullopt,
-            output_mem_config),
-        zero_tensor,
-        where(ltz(other, output_mem_config), std::nanf(" "), grad1_result, output_mem_config),
-        output_mem_config);
-    grad1_result =
-        where(eq_unary(input, std::nanf(" "), output_mem_config), std::nanf(" "), grad1_result, output_mem_config);
-    grad_tensor.emplace_back(grad1_result);
-    Tensor div_result = ttnn::multiply(input, recip(other, output_mem_config), std::nullopt, output_mem_config);
-    Tensor grad2_result = ttnn::multiply(grad, div_result, std::nullopt, output_mem_config);
-    grad2_result = where(
-        eqz(other, output_mem_config),
-        mul_unary(sign(grad, output_mem_config), std::numeric_limits<float>::infinity(), output_mem_config),
-        grad2_result,
-        output_mem_config);
-    grad2_result =
-        where(eq_unary(other, std::nanf(" "), output_mem_config), std::nanf(" "), grad2_result, output_mem_config);
-    grad_tensor.emplace_back(grad2_result);
-    return grad_tensor;
-}
-std::vector<Tensor> xlogy_bw(
-    const Tensor& grad, const Tensor& input, const Tensor& other, const MemoryConfig& output_mem_config) {
-    return operation::decorate_as_composite(__func__, _xlogy_bw)(grad, input, other, output_mem_config);
-}
 
 /*
 Torch Reference:

--- a/tt_eager/tt_dnn/op_library/backward/backward_ops.hpp
+++ b/tt_eager/tt_dnn/op_library/backward/backward_ops.hpp
@@ -323,12 +323,6 @@ std::vector<Tensor> ldexp_bw(
     const Tensor& other,
     const MemoryConfig& output_mem_config = operation::DEFAULT_OUTPUT_MEMORY_CONFIG);
 
-std::vector<Tensor> xlogy_bw(
-    const Tensor& grad,
-    const Tensor& input,
-    const Tensor& other,
-    const MemoryConfig& output_mem_config = operation::DEFAULT_OUTPUT_MEMORY_CONFIG);
-
 std::vector<Tensor> logaddexp_bw(
     const Tensor& grad,
     const Tensor& input,

--- a/tt_eager/tt_dnn/op_library/backward/backward_ops.hpp
+++ b/tt_eager/tt_dnn/op_library/backward/backward_ops.hpp
@@ -15,27 +15,6 @@ namespace tt {
 
 namespace tt_metal {
 
-std::vector<std::optional<Tensor>> addalpha_bw(
-    const Tensor& grad,
-    const Tensor& input,
-    const Tensor& other,
-    float alpha,
-    const MemoryConfig& output_mem_config = operation::DEFAULT_OUTPUT_MEMORY_CONFIG,
-    const std::vector<bool>& are_required_outputs = std::vector<bool>{true, true},
-    std::optional<Tensor> input_grad = std::nullopt,
-    std::optional<Tensor> other_grad = std::nullopt);
-
-std::vector<std::optional<Tensor>> addalpha_bw(
-    uint8_t queue_id,
-    const Tensor& grad,
-    const Tensor& input,
-    const Tensor& other,
-    float alpha,
-    const MemoryConfig& output_mem_config = operation::DEFAULT_OUTPUT_MEMORY_CONFIG,
-    const std::vector<bool>& are_required_outputs = std::vector<bool>{true, true},
-    std::optional<Tensor> input_grad = std::nullopt,
-    std::optional<Tensor> other_grad = std::nullopt);
-
 std::vector<Tensor> addcmul_bw(
     const Tensor& grad,
     const Tensor& input,

--- a/tt_eager/tt_dnn/op_library/backward/backward_ops.hpp
+++ b/tt_eager/tt_dnn/op_library/backward/backward_ops.hpp
@@ -259,12 +259,6 @@ std::vector<Tensor> clamp_max_bw(
     float max,
     const MemoryConfig& output_mem_config = operation::DEFAULT_OUTPUT_MEMORY_CONFIG);
 
-std::vector<Tensor> hypot_bw(
-    const Tensor& grad,
-    const Tensor& input,
-    const Tensor& other,
-    const MemoryConfig& output_mem_config = operation::DEFAULT_OUTPUT_MEMORY_CONFIG);
-
 std::vector<Tensor> exp2_bw(
     const Tensor& grad,
     const Tensor& input,

--- a/tt_eager/tt_dnn/op_library/backward/backward_ops.hpp
+++ b/tt_eager/tt_dnn/op_library/backward/backward_ops.hpp
@@ -311,12 +311,6 @@ std::vector<Tensor> lerp_bw(
     const Tensor& weight,
     const MemoryConfig& output_mem_config = operation::DEFAULT_OUTPUT_MEMORY_CONFIG);
 
-std::vector<Tensor> ldexp_bw(
-    const Tensor& grad,
-    const Tensor& input,
-    const Tensor& other,
-    const MemoryConfig& output_mem_config = operation::DEFAULT_OUTPUT_MEMORY_CONFIG);
-
 std::vector<Tensor> logaddexp_bw(
     const Tensor& grad,
     const Tensor& input,

--- a/tt_eager/tt_dnn/op_library/backward/backward_ops.hpp
+++ b/tt_eager/tt_dnn/op_library/backward/backward_ops.hpp
@@ -289,12 +289,6 @@ std::vector<Tensor> bias_gelu_unary_bw(
     string approximate,
     const MemoryConfig& output_mem_config = operation::DEFAULT_OUTPUT_MEMORY_CONFIG);
 
-std::vector<Tensor> squared_difference_bw(
-    const Tensor& grad,
-    const Tensor& input,
-    const Tensor& other,
-    const MemoryConfig& output_mem_config = operation::DEFAULT_OUTPUT_MEMORY_CONFIG);
-
 // lerp(input, end, weight) = self: grad * (1 - weight), end: grad * weight, weight is float
 std::vector<Tensor> lerp_bw(
     const Tensor& grad,

--- a/tt_eager/tt_dnn/op_library/backward/backward_ops.hpp
+++ b/tt_eager/tt_dnn/op_library/backward/backward_ops.hpp
@@ -68,25 +68,6 @@ std::vector<std::optional<Tensor>> mul_bw(
     std::optional<Tensor> input_a_grad = std::nullopt,
     std::optional<Tensor> input_b_grad = std::nullopt);
 
-std::vector<std::optional<Tensor>> add_bw(
-    uint8_t cq_id,
-    const Tensor& grad,
-    const Tensor& input,
-    const Tensor& other,
-    const MemoryConfig& output_mem_config = operation::DEFAULT_OUTPUT_MEMORY_CONFIG,
-    const std::vector<bool>& are_required_outputs = std::vector<bool>{true, true},
-    std::optional<Tensor> input_grad = std::nullopt,
-    std::optional<Tensor> other_grad = std::nullopt);
-
-std::vector<std::optional<Tensor>> add_bw(
-    const Tensor& grad,
-    const Tensor& input,
-    const Tensor& other,
-    const MemoryConfig& output_mem_config = operation::DEFAULT_OUTPUT_MEMORY_CONFIG,
-    const std::vector<bool>& are_required_outputs = std::vector<bool>{true, true},
-    std::optional<Tensor> input_grad = std::nullopt,
-    std::optional<Tensor> other_grad = std::nullopt);
-
 std::vector<Tensor> exp_bw(
     const Tensor& grad,
     const Tensor& input,

--- a/tt_eager/tt_dnn/op_library/backward/backward_ops.hpp
+++ b/tt_eager/tt_dnn/op_library/backward/backward_ops.hpp
@@ -185,12 +185,6 @@ std::vector<Tensor> fill_zero_bw(
 std::vector<Tensor> fill_bw(
     const Tensor& grad, const MemoryConfig& output_mem_config = operation::DEFAULT_OUTPUT_MEMORY_CONFIG);
 
-std::vector<Tensor> sub_bw(
-    const Tensor& grad,
-    const Tensor& input,
-    const Tensor& other,
-    const MemoryConfig& output_mem_config = operation::DEFAULT_OUTPUT_MEMORY_CONFIG);
-
 std::vector<Tensor> unary_sub_bw(
     const Tensor& grad,
     const Tensor& input,
@@ -483,13 +477,6 @@ std::vector<Tensor> celu_bw(
 std::vector<Tensor> binary_lt_bw(
     const Tensor& grad,
     const Tensor& input,
-    const MemoryConfig& output_mem_config = operation::DEFAULT_OUTPUT_MEMORY_CONFIG);
-
-std::vector<Tensor> subalpha_bw(
-    const Tensor& grad,
-    const Tensor& input,
-    const Tensor& other,
-    float alpha = 1.0,
     const MemoryConfig& output_mem_config = operation::DEFAULT_OUTPUT_MEMORY_CONFIG);
 
 std::vector<Tensor> log10_bw(

--- a/tt_eager/tt_dnn/op_library/backward/backward_ops.hpp
+++ b/tt_eager/tt_dnn/op_library/backward/backward_ops.hpp
@@ -311,18 +311,6 @@ std::vector<Tensor> lerp_bw(
     const Tensor& weight,
     const MemoryConfig& output_mem_config = operation::DEFAULT_OUTPUT_MEMORY_CONFIG);
 
-std::vector<Tensor> logaddexp_bw(
-    const Tensor& grad,
-    const Tensor& input,
-    const Tensor& other,
-    const MemoryConfig& output_mem_config = operation::DEFAULT_OUTPUT_MEMORY_CONFIG);
-
-std::vector<Tensor> logaddexp2_bw(
-    const Tensor& grad,
-    const Tensor& input,
-    const Tensor& other,
-    const MemoryConfig& output_mem_config = operation::DEFAULT_OUTPUT_MEMORY_CONFIG);
-
 std::vector<Tensor> concat_bw(
     const Tensor& grad,
     const Tensor& input,

--- a/tt_eager/tt_dnn/op_library/backward/backward_ops.hpp
+++ b/tt_eager/tt_dnn/op_library/backward/backward_ops.hpp
@@ -162,12 +162,6 @@ std::vector<Tensor> min_bw(
     const Tensor& other,
     const MemoryConfig& output_mem_config = operation::DEFAULT_OUTPUT_MEMORY_CONFIG);
 
-std::vector<Tensor> embedding_bw(
-    const Tensor& grad,
-    const Tensor& input,
-    const Tensor& weight,
-    const MemoryConfig& output_mem_config = operation::DEFAULT_OUTPUT_MEMORY_CONFIG);
-
 // bw = grad(1 - tanh(x) ** 2)
 std::vector<Tensor> tanh_bw(
     const Tensor& grad,

--- a/tt_eager/tt_dnn/op_library/backward/backward_ops.hpp
+++ b/tt_eager/tt_dnn/op_library/backward/backward_ops.hpp
@@ -292,12 +292,6 @@ std::vector<Tensor> clamp_max_bw(
     float max,
     const MemoryConfig& output_mem_config = operation::DEFAULT_OUTPUT_MEMORY_CONFIG);
 
-std::vector<Tensor> atan2_bw(
-    const Tensor& grad,
-    const Tensor& input,
-    const Tensor& other,
-    const MemoryConfig& output_mem_config = operation::DEFAULT_OUTPUT_MEMORY_CONFIG);
-
 std::vector<Tensor> hypot_bw(
     const Tensor& grad,
     const Tensor& input,

--- a/tt_eager/tt_lib/csrc/tt_lib_bindings_tensor_backward_ops.cpp
+++ b/tt_eager/tt_lib/csrc/tt_lib_bindings_tensor_backward_ops.cpp
@@ -921,22 +921,6 @@ namespace tt::tt_metal::detail{
                 "output_mem_config", "Layout of tensor in TT Accelerator device memory banks", "MemoryConfig", "Default is interleaved in DRAM", "No"
         )doc");
 
-    m_tensor.def("ldexp_bw", &tt::tt_metal::ldexp_bw,
-            py::arg("grad").noconvert(), py::arg("input").noconvert(), py::arg("other").noconvert(), py::arg("output_mem_config").noconvert() = operation::DEFAULT_OUTPUT_MEMORY_CONFIG, R"doc(
-            Performs backward operations for ldexp of ``input`` and ``other`` tensors with given ``grad``.
-
-            Input tensors must have BFLOAT16 data type.
-
-            Output tensors will have BFLOAT16 data type.
-
-            .. csv-table::
-                :header: "Argument", "Description", "Data type", "Valid range", "Required"
-
-                "grad", "Gradient tensor", "Tensor", "Tensor of shape [W, Z, Y, X]", "Yes"
-                "input", "Tensor", "Tensor", "Tensor of shape [W, Z, Y, X]", "Yes"
-                "other", "Tensor", "Tensor", "Tensor of shape [W, Z, Y, X]", "Yes"
-                "output_mem_config", "Layout of tensor in TT Accelerator device memory banks", "MemoryConfig", "Default is interleaved in DRAM", "No"
-        )doc");
 
     m_tensor.def("hardswish_bw", &tt::tt_metal::hardswish_bw,
             py::arg("grad").noconvert(), py::arg("input").noconvert(), py::arg("output_mem_config").noconvert() = operation::DEFAULT_OUTPUT_MEMORY_CONFIG, R"doc(

--- a/tt_eager/tt_lib/csrc/tt_lib_bindings_tensor_backward_ops.cpp
+++ b/tt_eager/tt_lib/csrc/tt_lib_bindings_tensor_backward_ops.cpp
@@ -989,22 +989,6 @@ namespace tt::tt_metal::detail{
                 "output_mem_config", "Layout of tensor in TT Accelerator device memory banks", "MemoryConfig", "Default is interleaved in DRAM", "No"
         )doc");
 
-   m_tensor.def("xlogy_bw", &tt::tt_metal::xlogy_bw,
-            py::arg("grad").noconvert(), py::arg("input").noconvert(), py::arg("other").noconvert(), py::arg("output_mem_config").noconvert() = operation::DEFAULT_OUTPUT_MEMORY_CONFIG, R"doc(
-            Performs backward operations for xlogy  for ``input`` and  ``other`` with given ``grad``.
-
-            Input tensors must have BFLOAT16 data type.
-
-            Output tensor will have BFLOAT16 data type.
-
-            .. csv-table::
-                :header: "Argument", "Description", "Data type", "Valid range", "Required"
-
-                "grad", "Gradient tensor", "Tensor", "Tensor of shape [W, Z, Y, X]", "Yes"
-                "input", "Tensor", "Tensor", "Tensor of shape [W, Z, Y, X]", "Yes"
-                "other", "Tensor", "Tensor", "Tensor of shape [W, Z, Y, X]", "Yes"
-                "output_mem_config", "Layout of tensor in TT Accelerator device memory banks", "MemoryConfig", "Default is interleaved in DRAM", "No"
-        )doc");
 
    m_tensor.def("logaddexp_bw", &tt::tt_metal::logaddexp_bw,
             py::arg("grad").noconvert(), py::arg("input").noconvert(), py::arg("other").noconvert(), py::arg("output_mem_config").noconvert() = operation::DEFAULT_OUTPUT_MEMORY_CONFIG, R"doc(

--- a/tt_eager/tt_lib/csrc/tt_lib_bindings_tensor_backward_ops.cpp
+++ b/tt_eager/tt_lib/csrc/tt_lib_bindings_tensor_backward_ops.cpp
@@ -534,23 +534,6 @@ namespace tt::tt_metal::detail{
                 "output_mem_config", "Layout of tensor in TT Accelerator device memory banks", "MemoryConfig", "Default is interleaved in DRAM", "No"
         )doc");
 
-    m_tensor.def("sub_bw", &tt::tt_metal::sub_bw,
-            py::arg("grad").noconvert(), py::arg("input").noconvert(), py::arg("other").noconvert(), py::arg("output_mem_config").noconvert() = operation::DEFAULT_OUTPUT_MEMORY_CONFIG, R"doc(
-            Performs backward operations for subraction of ``other`` and ``input`` tensors with given ``grad``.
-
-            Input tensors must have BFLOAT16 data type.
-
-            Output tensors will have BFLOAT16 data type.
-
-            .. csv-table::
-                :header: "Argument", "Description", "Data type", "Valid range", "Required"
-
-                "grad", "Gradient tensor", "Tensor", "Tensor of shape [W, Z, Y, X]", "Yes"
-                "input", "Tensor", "Tensor", "Tensor of shape [W, Z, Y, X]", "Yes"
-                "other", "Tensor", "Tensor", "Tensor of shape [W, Z, Y, X]", "Yes"
-                "output_mem_config", "Layout of tensor in TT Accelerator device memory banks", "MemoryConfig", "Default is interleaved in DRAM", "No"
-        )doc");
-
     m_tensor.def("repeat_bw", &tt::tt_metal::repeat_bw,
             py::arg("grad").noconvert(), py::arg("input").noconvert(), py::arg("shape"), py::arg("output_mem_config").noconvert() = operation::DEFAULT_OUTPUT_MEMORY_CONFIG, R"doc(
                     Returns a new tensor filled with repetition of input ``input`` tensor according to number of times specified in ``shape``. The rank of ``shape`` should be same as rank of tensor ``input_a``.
@@ -1401,27 +1384,6 @@ namespace tt::tt_metal::detail{
                 "input", "Input Tensor", "Tensor", "Tensor of shape [W, Z, Y, X]", "Yes"
                 "output_mem_config", "Layout of tensor in TT Accelerator device memory banks", "MemoryConfig", "Default is interleaved in DRAM", "No"
         )doc");
-
-
-    m_tensor.def("subalpha_bw", &tt::tt_metal::subalpha_bw,
-            py::arg("grad").noconvert(), py::arg("input").noconvert(), py::arg("other").noconvert(), py::arg("alpha") = 1.0f, py::arg("output_mem_config").noconvert() = operation::DEFAULT_OUTPUT_MEMORY_CONFIG, R"doc(
-
-            Performs backward operations for subraction of ``other`` and ``input`` tensors with alpha for the given ``grad``.
-
-            Input tensors must have BFLOAT16 data type.
-
-            Output tensors will have BFLOAT16 data type.
-
-            .. csv-table::
-                :header: "Argument", "Description", "Data type", "Valid range", "Required"
-
-                "grad", "Gradient tensor", "Tensor", "Tensor of shape [W, Z, Y, X]", "Yes"
-                "input", "Tensor", "Tensor", "Tensor of shape [W, Z, Y, X]", "Yes"
-                "other", "Tensor", "Tensor", "Tensor of shape [W, Z, Y, X]", "Yes"
-                "alpha", "Alpha value", "float", "default to 1.0f", "No"
-                "output_mem_config", "Layout of tensor in TT Accelerator device memory banks", "MemoryConfig", "Default is interleaved in DRAM", "No"
-        )doc");
-
 
     m_tensor.def("log10_bw", &tt::tt_metal::log10_bw,
             py::arg("grad").noconvert(), py::arg("input").noconvert(), py::arg("output_mem_config").noconvert() = operation::DEFAULT_OUTPUT_MEMORY_CONFIG, R"doc(

--- a/tt_eager/tt_lib/csrc/tt_lib_bindings_tensor_backward_ops.cpp
+++ b/tt_eager/tt_lib/csrc/tt_lib_bindings_tensor_backward_ops.cpp
@@ -894,23 +894,6 @@ namespace tt::tt_metal::detail{
                 "output_mem_config", "Layout of tensor in TT Accelerator device memory banks", "MemoryConfig", "Default is interleaved in DRAM", "No"
         )doc");
 
-    m_tensor.def("atan2_bw", &tt::tt_metal::atan2_bw,
-            py::arg("grad").noconvert(), py::arg("input").noconvert(), py::arg("other").noconvert(), py::arg("output_mem_config").noconvert() = operation::DEFAULT_OUTPUT_MEMORY_CONFIG, R"doc(
-            Performs backward operations for atan2 of ``input`` and ``other`` tensors with given ``grad``.
-
-            Input tensors must have BFLOAT16 data type.
-
-            Output tensors will have BFLOAT16 data type.
-
-            .. csv-table::
-                :header: "Argument", "Description", "Data type", "Valid range", "Required"
-
-                "grad", "Gradient tensor", "Tensor", "Tensor of shape [W, Z, Y, X]", "Yes"
-                "input", "Tensor atan2 is applied to", "Tensor", "Tensor of shape [W, Z, Y, X]", "Yes"
-                "other", "Tensor atan2 is applied to", "Tensor", "Tensor of shape [W, Z, Y, X]", "Yes"
-                "output_mem_config", "Layout of tensor in TT Accelerator device memory banks", "MemoryConfig", "Default is interleaved in DRAM", "No"
-        )doc");
-
     m_tensor.def("hardshrink_bw", &tt::tt_metal::hardshrink_bw,
             py::arg("grad").noconvert(), py::arg("input").noconvert(), py::arg("lambda") = 0.5f, py::arg("output_mem_config").noconvert() = operation::DEFAULT_OUTPUT_MEMORY_CONFIG, R"doc(
             Performs backward operations for hardshrink to the elements of the input tensor ``{0}`` between limits ``-{1}`` low and the ``+{1}`` high limits with given ``grad``.

--- a/tt_eager/tt_lib/csrc/tt_lib_bindings_tensor_backward_ops.cpp
+++ b/tt_eager/tt_lib/csrc/tt_lib_bindings_tensor_backward_ops.cpp
@@ -851,23 +851,6 @@ namespace tt::tt_metal::detail{
                 "output_mem_config", "Layout of tensor in TT Accelerator device memory banks", "MemoryConfig", "Default is interleaved in DRAM", "No"
         )doc");
 
-    m_tensor.def("hypot_bw", &tt::tt_metal::hypot_bw,
-            py::arg("grad").noconvert(), py::arg("input").noconvert(), py::arg("other").noconvert(), py::arg("output_mem_config").noconvert() = operation::DEFAULT_OUTPUT_MEMORY_CONFIG, R"doc(
-            Performs backward operations for hypotenuse of ``input`` and ``other`` tensors with given ``grad``.
-
-            Input tensors must have BFLOAT16 data type.
-
-            Output tensors will have BFLOAT16 data type.
-
-            .. csv-table::
-                :header: "Argument", "Description", "Data type", "Valid range", "Required"
-
-                "grad", "Gradient tensor", "Tensor", "Tensor of shape [W, Z, Y, X]", "Yes"
-                "input", "First input tensor", "Tensor", "Tensor of shape [W, Z, Y, X]", "Yes"
-                "other", "Second input Tensor", "Tensor", "Tensor of shape [W, Z, Y, X]", "Yes"
-                "output_mem_config", "Layout of tensor in TT Accelerator device memory banks", "MemoryConfig", "Default is interleaved in DRAM", "No"
-        )doc");
-
     m_tensor.def("gelu_bw", &tt::tt_metal::gelu_bw,
             py::arg("grad").noconvert(), py::arg("input").noconvert(), py::arg("approximate").noconvert(), py::arg("output_mem_config").noconvert() = operation::DEFAULT_OUTPUT_MEMORY_CONFIG, R"doc(
             Performs backward operations for gelu of ``input`` tensor with given ``grad``.

--- a/tt_eager/tt_lib/csrc/tt_lib_bindings_tensor_backward_ops.cpp
+++ b/tt_eager/tt_lib/csrc/tt_lib_bindings_tensor_backward_ops.cpp
@@ -956,41 +956,6 @@ namespace tt::tt_metal::detail{
                 "output_mem_config", "Layout of tensor in TT Accelerator device memory banks", "MemoryConfig", "Default is interleaved in DRAM", "No"
         )doc");
 
-
-   m_tensor.def("logaddexp_bw", &tt::tt_metal::logaddexp_bw,
-            py::arg("grad").noconvert(), py::arg("input").noconvert(), py::arg("other").noconvert(), py::arg("output_mem_config").noconvert() = operation::DEFAULT_OUTPUT_MEMORY_CONFIG, R"doc(
-            Performs backward operations for logaddexp (``input``, ``other``)  with given ``grad``.
-
-            Input tensors must have BFLOAT16 data type.
-
-            Output tensor will have BFLOAT16 data type.
-
-            .. csv-table::
-                :header: "Argument", "Description", "Data type", "Valid range", "Required"
-
-                "grad", "Gradient tensor", "Tensor", "Tensor of shape [W, Z, Y, X]", "Yes"
-                "input", "Tensor", "Tensor", "Tensor of shape [W, Z, Y, X]", "Yes"
-                "other", "Tensor", "Tensor", "Tensor of shape [W, Z, Y, X]", "Yes"
-                "output_mem_config", "Layout of tensor in TT Accelerator device memory banks", "MemoryConfig", "Default is interleaved in DRAM", "No"
-        )doc");
-
-    m_tensor.def("logaddexp2_bw", &tt::tt_metal::logaddexp2_bw,
-            py::arg("grad").noconvert(), py::arg("input").noconvert(), py::arg("other").noconvert(), py::arg("output_mem_config").noconvert() = operation::DEFAULT_OUTPUT_MEMORY_CONFIG, R"doc(
-            Performs backward operations for logaddexp2 (``input``, ``other``)  with given ``grad``.
-
-            Input tensors must have BFLOAT16 data type.
-
-            Output tensor will have BFLOAT16 data type.
-
-            .. csv-table::
-                :header: "Argument", "Description", "Data type", "Valid range", "Required"
-
-                "grad", "Gradient tensor", "Tensor", "Tensor of shape [W, Z, Y, X]", "Yes"
-                "input", "Tensor", "Tensor", "Tensor of shape [W, Z, Y, X]", "Yes"
-                "other", "Tensor", "Tensor", "Tensor of shape [W, Z, Y, X]", "Yes"
-                "output_mem_config", "Layout of tensor in TT Accelerator device memory banks", "MemoryConfig", "Default is interleaved in DRAM", "No"
-        )doc");
-
     m_tensor.def("concat_bw", &tt::tt_metal::concat_bw,
             py::arg("grad").noconvert(), py::arg("input_a").noconvert(), py::arg("input_b").noconvert(),  py::arg("dim") = 0, py::arg("output_mem_config").noconvert() = operation::DEFAULT_OUTPUT_MEMORY_CONFIG, R"doc(
             Performs backward operations for concat of ``input_a`` and ``input_b`` tensors with given ``grad``.

--- a/tt_eager/tt_lib/csrc/tt_lib_bindings_tensor_backward_ops.cpp
+++ b/tt_eager/tt_lib/csrc/tt_lib_bindings_tensor_backward_ops.cpp
@@ -9,48 +9,6 @@
 namespace tt::tt_metal::detail{
     void TensorModuleBackwardOPs( py::module & m_tensor){
 
-    m_tensor.def("addalpha_bw",
-            [](const Tensor& grad,
-                const Tensor& input_a,
-                const Tensor& input_b,
-                const float alpha,
-                const MemoryConfig& output_mem_config,
-                const std::vector<bool>& are_required_outputs,
-                std::optional<Tensor> input_grad,
-                std::optional<Tensor> other_grad,
-                uint8_t queue_id) {
-                    return addalpha_bw(queue_id, grad, input_a, input_b, alpha, output_mem_config, are_required_outputs, input_grad, other_grad);
-                },
-            py::arg("grad").noconvert(),
-            py::arg("input_a").noconvert(),
-            py::arg("input_b").noconvert(),
-            py::arg("alpha") = 1.0f,
-            py::arg("output_mem_config").noconvert() = operation::DEFAULT_OUTPUT_MEMORY_CONFIG,
-            py::arg("are_required_outputs").noconvert() = std::vector<bool>{true, true},
-            py::arg("input_a_grad").noconvert() = std::nullopt,
-            py::arg("input_b_grad").noconvert() = std::nullopt,
-            py::arg("queue_id").noconvert() = 0,
-            R"doc(
-            Performs backward operations for multiplication of ``input_b`` and ``alpha`` tensors with given ``grad``.
-
-            Input tensor must have BFLOAT16 data type.
-
-            Output tensors will have BFLOAT16 data type.
-
-            .. csv-table::
-                :header: "Argument", "Description", "Data type", "Valid range", "Required"
-
-                "grad", "Gradient tensor", "Tensor", "Tensor of shape [W, Z, Y, X]", "Yes"
-                "input_a", "Tensor addalpha is applied to", "Tensor", "Tensor of shape [W, Z, Y, X]", "Yes"
-                "input_b", "Tensor", "Tensor", "Tensor of shape [W, Z, Y, X]", "Yes"
-                "alpha", "Alpha value", "float", "default to 1.0f", "No"
-                "output_mem_config", "Layout of tensor in TT Accelerator device memory banks", "MemoryConfig", "Default is interleaved in DRAM", "No"
-                "are_required_outputs", "Boolean values for the required outputs: input_a_grad, input_b_grad ", "List of bool", "Default value is [True, True]", "No"
-                "input_grad", "Optional Output Tensor for input_grad", "Tensor", "Default value is None", "No"
-                "other_grad", "Optional Output Tensor for other_grad", "Tensor", "Default value is None", "No"
-                "queue_id", "queue_id", "uint8_t", "Default is 0", "No"
-        )doc");
-
     m_tensor.def("conj_bw", py::overload_cast<const Tensor&, const Tensor&, const MemoryConfig&>(&conj_bw),
             py::arg("grad").noconvert(), py::arg("input").noconvert(), py::arg("output_mem_config").noconvert() = operation::DEFAULT_OUTPUT_MEMORY_CONFIG, R"doc(
             Performs backward operations for conjugate for complex tensor ``input`` with given ``grad``

--- a/tt_eager/tt_lib/csrc/tt_lib_bindings_tensor_backward_ops.cpp
+++ b/tt_eager/tt_lib/csrc/tt_lib_bindings_tensor_backward_ops.cpp
@@ -576,24 +576,6 @@ namespace tt::tt_metal::detail{
                 "output_mem_config", "Layout of tensor in TT Accelerator device memory banks", "MemoryConfig", "Default is interleaved in DRAM", "No"
         )doc");
 
-    m_tensor.def("embedding_bw", &tt::tt_metal::embedding_bw,
-            py::arg("grad").noconvert(), py::arg("input").noconvert(), py::arg("weight").noconvert(), py::arg("output_mem_config").noconvert() = operation::DEFAULT_OUTPUT_MEMORY_CONFIG, R"doc(
-            Performs backward operations for embedding_bw function and it returns specific indices of the embedding table specified by the grad tensor.
-            The input tensor should be unique.
-
-            Input tensor must have BFLOAT16 data type.
-
-            Output tensors will have BFLOAT16 data type.
-
-            .. csv-table::
-                :header: "Argument", "Description", "Data type", "Valid range", "Required"
-
-                "grad", "Gradient tensor", "Tensor", "Tensor of shape [W, Z, Y, X]", "Yes"
-                "input", "Tensor containing rows we want", "Tensor", "Tensor of shape [W, Z, Y, X]", "Yes"
-                "weight", "Tensor", "Tensor", "Tensor of shape [W, Z, Y, X]", "Yes"
-                "output_mem_config", "Layout of tensor in TT Accelerator device memory banks", "MemoryConfig", "Default is interleaved in DRAM", "No"
-        )doc");
-
     m_tensor.def("sub_bw", &tt::tt_metal::sub_bw,
             py::arg("grad").noconvert(), py::arg("input").noconvert(), py::arg("other").noconvert(), py::arg("output_mem_config").noconvert() = operation::DEFAULT_OUTPUT_MEMORY_CONFIG, R"doc(
             Performs backward operations for subraction of ``other`` and ``input`` tensors with given ``grad``.

--- a/tt_eager/tt_lib/csrc/tt_lib_bindings_tensor_backward_ops.cpp
+++ b/tt_eager/tt_lib/csrc/tt_lib_bindings_tensor_backward_ops.cpp
@@ -269,45 +269,6 @@ namespace tt::tt_metal::detail{
                 "output_mem_config", "Layout of tensor in TT Accelerator device memory banks", "MemoryConfig", "Default is interleaved in DRAM", "No"
         )doc");
 
-    m_tensor.def("add_bw",
-            [](const Tensor& grad,
-                const Tensor& input_a,
-                const Tensor& input_b,
-                const MemoryConfig& output_mem_config,
-                const std::vector<bool>& are_required_outputs,
-                std::optional<Tensor> input_grad,
-                std::optional<Tensor> other_grad,
-                uint8_t queue_id) {
-                    return add_bw(queue_id, grad, input_a, input_b, output_mem_config, are_required_outputs, input_grad, other_grad);
-                },
-            py::arg("grad").noconvert(),
-            py::arg("input_a").noconvert(),
-            py::arg("input_b").noconvert(),
-            py::arg("output_mem_config").noconvert() = operation::DEFAULT_OUTPUT_MEMORY_CONFIG,
-            py::arg("are_required_outputs").noconvert() = std::vector<bool>{true, true},
-            py::arg("input_a_grad").noconvert() = std::nullopt,
-            py::arg("input_b_grad").noconvert() = std::nullopt,
-            py::arg("queue_id").noconvert() = 0,
-            R"doc(
-            Performs backward operations for addition of ``input_b`` tensors with given ``grad``.
-
-            Input tensor must have BFLOAT16 data type.
-
-            Output tensors will have BFLOAT16 data type.
-
-            .. csv-table::
-                :header: "Argument", "Description", "Data type", "Valid range", "Required"
-
-                "grad", "Gradient tensor", "Tensor", "Tensor of shape [W, Z, Y, X]", "Yes"
-                "input_a", "Tensor add is applied to", "Tensor", "Tensor of shape [W, Z, Y, X]", "Yes"
-                "input_b", "Tensor", "Tensor", "Tensor of shape [W, Z, Y, X]", "Yes"
-                "output_mem_config", "Layout of tensor in TT Accelerator device memory banks", "MemoryConfig", "Default is interleaved in DRAM", "No"
-                "are_required_outputs", "Boolean values for the required outputs: input_a_grad, input_b_grad ", "List of bool", "Default value is [True, True]", "No"
-                "input_a_grad", "Optional Output Tensor for input_a gradient", "Tensor", "Default value is None", "No"
-                "input_b_grad", "Optional Output Tensor for input_b gradient", "Tensor", "Default value is None", "No"
-                "queue_id", "command queue id", "uint8_t", "Default is 0", "No"
-        )doc");
-
     m_tensor.def("relu_bw", &tt::tt_metal::relu_bw,
             py::arg("grad").noconvert(), py::arg("input").noconvert(), py::arg("output_mem_config").noconvert() = operation::DEFAULT_OUTPUT_MEMORY_CONFIG, R"doc(
             Performs backward operations for relu of ``input`` tensors with given ``grad``.

--- a/tt_eager/tt_lib/csrc/tt_lib_bindings_tensor_backward_ops.cpp
+++ b/tt_eager/tt_lib/csrc/tt_lib_bindings_tensor_backward_ops.cpp
@@ -904,23 +904,6 @@ namespace tt::tt_metal::detail{
                 "output_mem_config", "Layout of tensor in TT Accelerator device memory banks", "MemoryConfig", "Default is interleaved in DRAM", "No"
         )doc");
 
-    m_tensor.def("squared_difference_bw", &tt::tt_metal::squared_difference_bw,
-            py::arg("grad").noconvert(), py::arg("input").noconvert(), py::arg("other").noconvert(), py::arg("output_mem_config").noconvert() = operation::DEFAULT_OUTPUT_MEMORY_CONFIG, R"doc(
-            Performs backward operations for squared difference of ``input`` and ``other`` tensors with given ``grad``.
-
-            Input tensors must have BFLOAT16 data type.
-
-            Output tensors will have BFLOAT16 data type.
-
-            .. csv-table::
-                :header: "Argument", "Description", "Data type", "Valid range", "Required"
-
-                "grad", "Gradient tensor", "Tensor", "Tensor of shape [W, Z, Y, X]", "Yes"
-                "input", "Tensor squared difference is applied to", "Tensor", "Tensor of shape [W, Z, Y, X]", "Yes"
-                "other", "Tensor squared difference is applied to", "Tensor", "Tensor of shape [W, Z, Y, X]", "Yes"
-                "output_mem_config", "Layout of tensor in TT Accelerator device memory banks", "MemoryConfig", "Default is interleaved in DRAM", "No"
-        )doc");
-
 
     m_tensor.def("hardswish_bw", &tt::tt_metal::hardswish_bw,
             py::arg("grad").noconvert(), py::arg("input").noconvert(), py::arg("output_mem_config").noconvert() = operation::DEFAULT_OUTPUT_MEMORY_CONFIG, R"doc(

--- a/ttnn/cpp/pybind11/operations/__init__.hpp
+++ b/ttnn/cpp/pybind11/operations/__init__.hpp
@@ -25,6 +25,7 @@
 
 #include "ttnn/operations/eltwise/binary/binary_pybind.hpp"
 #include "ttnn/operations/reduction/reduction_pybind.hpp"
+#include "ttnn/operations/eltwise/binary_backward/binary_backward_pybind.hpp"
 
 
 namespace py = pybind11;
@@ -39,6 +40,9 @@ void py_module(py::module& module) {
 
     auto m_binary = module.def_submodule("binary", "binary operations");
     binary::py_module(m_binary);
+
+    auto m_binary_backward = module.def_submodule("binary_backward", "binary_backward operations");
+    binary_backward::py_module(m_binary_backward);
 
     auto m_ternary = module.def_submodule("ternary", "ternary operations");
     ternary::py_module(m_ternary);

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_backward/binary_backward.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_backward/binary_backward.hpp
@@ -148,6 +148,7 @@ constexpr auto sub_bw = ttnn::register_operation<operations::binary_backward::Ex
 constexpr auto addalpha_bw = ttnn::register_operation<operations::binary_backward::ExecuteBinaryBackward<operations::binary_backward::BinaryBackwardOpType::ADDALPHA_BW>>("ttnn::addalpha_bw");
 
 constexpr auto xlogy_bw = ttnn::register_operation<operations::binary_backward::ExecuteBinaryBackward<operations::binary_backward::BinaryBackwardOpType::XLOGY_BW>>("ttnn::xlogy_bw");
+constexpr auto hypot_bw = ttnn::register_operation<operations::binary_backward::ExecuteBinaryBackward<operations::binary_backward::BinaryBackwardOpType::HYPOT_BW>>("ttnn::hypot_bw");
 
 
 }  // namespace ttnn

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_backward/binary_backward.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_backward/binary_backward.hpp
@@ -8,14 +8,15 @@
 #include "device/binary_backward_op.cpp"
 #include "ttnn/device_operation.hpp"
 #include "ttnn/operations/data_movement.hpp"
-#include "tt_eager/tt_dnn/op_library/run_operation.hpp" //decorate_as_composite
+#include "tt_eager/tt_dnn/op_library/run_operation.hpp"
 
 namespace ttnn {
 
 namespace operations::binary_backward {
 
-// template <BinaryBackwardOpType binary_backward_op_type>
+template <BinaryBackwardOpType binary_backward_op_type>
 struct ExecuteBinaryBackward {
+
     static inline const std::array<TensorSchema, 3> input_tensor_schemas() {
         return {
             ttnn::TensorSchema{
@@ -52,15 +53,15 @@ struct ExecuteBinaryBackward {
         return std::forward_as_tuple(grad_tensor, input_tensor_a, input_tensor_b);
     }
 
-    //combination 1
     static std::vector<Tensor> execute_on_worker_thread(
         const Tensor &grad_tensor_arg,
         const Tensor &input_tensor_a_arg,
         const Tensor &input_tensor_b_arg,
         const MemoryConfig &memory_config) {
 
-        // auto output_memory_config = memory_config.value_or(input_tensor_a.memory_config());
-        return tt::tt_metal::operation::decorate_as_composite(__func__, utils::_atan2_bw)(grad_tensor_arg, input_tensor_a_arg, input_tensor_b_arg, memory_config);
+        auto op_type = utils::get_function(binary_backward_op_type);
+
+        return tt::tt_metal::operation::decorate_as_composite(__func__, op_type)(grad_tensor_arg, input_tensor_a_arg, input_tensor_b_arg, memory_config);
         }
 
     static inline std::vector<Tensor> create_async_output_tensors(
@@ -73,9 +74,9 @@ struct ExecuteBinaryBackward {
 
 }  // operations::binary
 
-// constexpr auto atan2_bw = ttnn::register_operation<operations::binary_backward::ExecuteBinaryBackward<operations::binary_backward::BinaryBackwardOpType::ATAN2_BW>>("ttnn::atan2_bw");
-constexpr auto atan2_bw =
-    ttnn::register_operation<ttnn::operations::binary_backward::ExecuteBinaryBackward>("ttnn::atan2_bw");
+constexpr auto atan2_bw = ttnn::register_operation<operations::binary_backward::ExecuteBinaryBackward<operations::binary_backward::BinaryBackwardOpType::ATAN2_BW>>("ttnn::atan2_bw");
+
+constexpr auto embedding_bw = ttnn::register_operation<operations::binary_backward::ExecuteBinaryBackward<operations::binary_backward::BinaryBackwardOpType::EMBEDDING_BW>>("ttnn::embedding_bw");
 
 
 }  // namespace ttnn

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_backward/binary_backward.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_backward/binary_backward.hpp
@@ -147,5 +147,7 @@ constexpr auto sub_bw = ttnn::register_operation<operations::binary_backward::Ex
 //type 2
 constexpr auto addalpha_bw = ttnn::register_operation<operations::binary_backward::ExecuteBinaryBackward<operations::binary_backward::BinaryBackwardOpType::ADDALPHA_BW>>("ttnn::addalpha_bw");
 
+constexpr auto xlogy_bw = ttnn::register_operation<operations::binary_backward::ExecuteBinaryBackward<operations::binary_backward::BinaryBackwardOpType::XLOGY_BW>>("ttnn::xlogy_bw");
+
 
 }  // namespace ttnn

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_backward/binary_backward.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_backward/binary_backward.hpp
@@ -150,6 +150,8 @@ constexpr auto addalpha_bw = ttnn::register_operation<operations::binary_backwar
 constexpr auto xlogy_bw = ttnn::register_operation<operations::binary_backward::ExecuteBinaryBackward<operations::binary_backward::BinaryBackwardOpType::XLOGY_BW>>("ttnn::xlogy_bw");
 constexpr auto hypot_bw = ttnn::register_operation<operations::binary_backward::ExecuteBinaryBackward<operations::binary_backward::BinaryBackwardOpType::HYPOT_BW>>("ttnn::hypot_bw");
 constexpr auto ldexp_bw = ttnn::register_operation<operations::binary_backward::ExecuteBinaryBackward<operations::binary_backward::BinaryBackwardOpType::LDEXP_BW>>("ttnn::ldexp_bw");
+constexpr auto logaddexp_bw = ttnn::register_operation<operations::binary_backward::ExecuteBinaryBackward<operations::binary_backward::BinaryBackwardOpType::LOGADDEXP_BW>>("ttnn::logaddexp_bw");
+constexpr auto logaddexp2_bw = ttnn::register_operation<operations::binary_backward::ExecuteBinaryBackward<operations::binary_backward::BinaryBackwardOpType::LOGADDEXP2_BW>>("ttnn::logaddexp2_bw");
 
 
 }  // namespace ttnn

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_backward/binary_backward.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_backward/binary_backward.hpp
@@ -1,0 +1,81 @@
+
+// SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include "device/binary_backward_op.cpp"
+#include "ttnn/device_operation.hpp"
+#include "ttnn/operations/data_movement.hpp"
+#include "tt_eager/tt_dnn/op_library/run_operation.hpp" //decorate_as_composite
+
+namespace ttnn {
+
+namespace operations::binary_backward {
+
+// template <BinaryBackwardOpType binary_backward_op_type>
+struct ExecuteBinaryBackward {
+    static inline const std::array<TensorSchema, 3> input_tensor_schemas() {
+        return {
+            ttnn::TensorSchema{
+                2,
+                4,
+                {ttnn::bfloat16, ttnn::bfloat8_b, ttnn::bfloat4_b, ttnn::uint16},
+                {ttnn::TILE_LAYOUT},
+                true,
+                false,
+                false,
+                false},
+            ttnn::TensorSchema{
+                2,
+                4,
+                {ttnn::bfloat16, ttnn::bfloat8_b, ttnn::bfloat4_b, ttnn::uint16},
+                {ttnn::TILE_LAYOUT},
+                true,
+                false,
+                false,
+                false},
+            ttnn::TensorSchema{
+                2,
+                4,
+                {ttnn::bfloat16, ttnn::bfloat8_b, ttnn::bfloat4_b, ttnn::uint16},
+                {ttnn::TILE_LAYOUT},
+                true,
+                false,
+                false,
+                false}};
+    }
+
+    template <typename... Args>
+    static auto input_tensors_to_validate(const Tensor &grad_tensor, const Tensor &input_tensor_a, const Tensor &input_tensor_b, Args &&...args) {
+        return std::forward_as_tuple(grad_tensor, input_tensor_a, input_tensor_b);
+    }
+
+    //combination 1
+    static std::vector<Tensor> execute_on_worker_thread(
+        const Tensor &grad_tensor_arg,
+        const Tensor &input_tensor_a_arg,
+        const Tensor &input_tensor_b_arg,
+        const MemoryConfig &memory_config) {
+
+        // auto output_memory_config = memory_config.value_or(input_tensor_a.memory_config());
+        return tt::tt_metal::operation::decorate_as_composite(__func__, utils::_atan2_bw)(grad_tensor_arg, input_tensor_a_arg, input_tensor_b_arg, memory_config);
+        }
+
+    static inline std::vector<Tensor> create_async_output_tensors(
+        const std::vector<Tensor> &input_tensors, const std::vector<std::optional<const Tensor>>& optional_inputs) {
+        const auto& input_tensor = input_tensors.at(0);
+        return {Tensor(operation::get_workers_for_op_output({input_tensor})),
+                                            Tensor(operation::get_workers_for_op_output({input_tensor}))};
+    }
+};
+
+}  // operations::binary
+
+// constexpr auto atan2_bw = ttnn::register_operation<operations::binary_backward::ExecuteBinaryBackward<operations::binary_backward::BinaryBackwardOpType::ATAN2_BW>>("ttnn::atan2_bw");
+constexpr auto atan2_bw =
+    ttnn::register_operation<ttnn::operations::binary_backward::ExecuteBinaryBackward>("ttnn::atan2_bw");
+
+
+}  // namespace ttnn

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_backward/binary_backward.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_backward/binary_backward.hpp
@@ -64,16 +64,15 @@ struct ExecuteBinaryBackward {
         const Tensor &grad_tensor_arg,
         const Tensor &input_tensor_a_arg,
         const Tensor &input_tensor_b_arg,
-        const std::optional<MemoryConfig> &memory_config = std::nullopt) {
-        cout<<"inside execute_on_worker_thread 1 start \n";
+        const MemoryConfig &memory_config = operation::DEFAULT_OUTPUT_MEMORY_CONFIG) {
 
         auto op_type = utils::get_function_type1(binary_backward_op_type);
-        auto output_memory_config = memory_config.value_or(input_tensor_a_arg.memory_config());
-        return op_type(grad_tensor_arg, input_tensor_a_arg, input_tensor_b_arg, output_memory_config);
+        // auto output_memory_config = memory_config.value_or(input_tensor_a_arg.memory_config());
+        return op_type(grad_tensor_arg, input_tensor_a_arg, input_tensor_b_arg, memory_config);
         }
 
 
-    //Type 2: 2 inputs, 1 grad tensor 1 float
+    //Type 1: Type 1 with 1 float
     template <typename... Args>
 
     static std::vector<ttnn::Tensor> execute_on_worker_thread(
@@ -82,7 +81,6 @@ struct ExecuteBinaryBackward {
         float alpha,
         const Tensor &input_tensor_b_arg,
         const std::optional<MemoryConfig> &memory_config = std::nullopt) {
-        cout<<"inside execute_on_worker_thread 2 start \n";
 
         auto op_type = utils::get_function_type1_w_float(binary_backward_op_type);
         auto output_memory_config = memory_config.value_or(input_tensor_a_arg.memory_config());
@@ -90,6 +88,47 @@ struct ExecuteBinaryBackward {
         }
 
     //Type 3 : Q_ID, type1 args, optional output tensor for inputs based on are_required_outputs value
+    template <typename... Args>
+    static auto input_tensors_to_validate(uint8_t queue_id, const Tensor &grad_tensor, const Tensor &input_tensor_a, const Tensor &input_tensor_b, Args &&...args) {
+        return std::forward_as_tuple(grad_tensor, input_tensor_a, input_tensor_b);
+    }
+
+    static std::vector<ttnn::Tensor> execute_on_worker_thread(
+        uint8_t queue_id,
+        const Tensor &grad_tensor_arg,
+        const Tensor &input_tensor_a_arg,
+        const Tensor &input_tensor_b_arg,
+        const std::optional<MemoryConfig> &memory_config = std::nullopt,
+        const std::vector<bool>& are_required_outputs = std::vector<bool>{true, true},
+        std::optional<Tensor> optional_input_a_grad = std::nullopt,
+        std::optional<Tensor> optional_input_b_grad = std::nullopt) {
+
+        auto output_memory_config = memory_config.value_or(input_tensor_a_arg.memory_config());
+        auto op_type = utils::get_function_type3(binary_backward_op_type);
+        return op_type(queue_id, grad_tensor_arg, input_tensor_a_arg, input_tensor_b_arg, output_memory_config, are_required_outputs, optional_input_a_grad, optional_input_b_grad);
+    }
+
+    //Type 3 : type1 args, optional output tensor for inputs based on are_required_outputs value
+    template <typename... Args>
+    static auto input_tensors_to_validate(const Tensor &grad_tensor, const Tensor &input_tensor_a, const Tensor &input_tensor_b, std::vector<bool> are_required_outputs, Args &&...args) {
+        return std::forward_as_tuple(grad_tensor, input_tensor_a, input_tensor_b);
+    }
+
+    static std::vector<ttnn::Tensor> execute_on_worker_thread(
+        const Tensor &grad_tensor_arg,
+        const Tensor &input_tensor_a_arg,
+        const Tensor &input_tensor_b_arg,
+        const std::optional<MemoryConfig> &memory_config = std::nullopt,
+        const std::vector<bool>& are_required_outputs = std::vector<bool>{true, true},
+        std::optional<Tensor> optional_input_a_grad = std::nullopt,
+        std::optional<Tensor> optional_input_b_grad = std::nullopt) {
+
+        auto output_memory_config = memory_config.value_or(input_tensor_a_arg.memory_config());
+        auto op_type = utils::get_function_type3_wo_qid(binary_backward_op_type);
+        return op_type(grad_tensor_arg, input_tensor_a_arg, input_tensor_b_arg, output_memory_config, are_required_outputs, optional_input_a_grad, optional_input_b_grad);
+    }
+
+    //Type 2 : Q_ID, type1 args, optional output tensor for inputs based on are_required_outputs value
     template <typename... Args>
     static auto input_tensors_to_validate(uint8_t queue_id, const Tensor &grad_tensor, const Tensor &input_tensor_a, const Tensor &input_tensor_b, float alpha, Args &&...args) {
         return std::forward_as_tuple(grad_tensor, input_tensor_a, input_tensor_b);
@@ -105,14 +144,13 @@ struct ExecuteBinaryBackward {
         const std::vector<bool>& are_required_outputs = std::vector<bool>{true, true},
         std::optional<Tensor> optional_input_a_grad = std::nullopt,
         std::optional<Tensor> optional_input_b_grad = std::nullopt) {
-        cout<<"inside execute_on_worker_thread 3 start \n";
 
         auto output_memory_config = memory_config.value_or(input_tensor_a_arg.memory_config());
         auto op_type = utils::get_function_type2(binary_backward_op_type);
         return op_type(queue_id, grad_tensor_arg, input_tensor_a_arg, input_tensor_b_arg, alpha, output_memory_config, are_required_outputs, optional_input_a_grad, optional_input_b_grad);
     }
 
-    //Type 4 : type1 args, optional output tensor for inputs based on are_required_outputs value
+    //Type 2 : type1 args, optional output tensor for inputs based on are_required_outputs value
     template <typename... Args>
     static auto input_tensors_to_validate(const Tensor &grad_tensor, const Tensor &input_tensor_a, const Tensor &input_tensor_b, float alpha, std::vector<bool> are_required_outputs, Args &&...args) {
         return std::forward_as_tuple(grad_tensor, input_tensor_a, input_tensor_b);
@@ -127,7 +165,6 @@ struct ExecuteBinaryBackward {
         const std::vector<bool>& are_required_outputs = std::vector<bool>{true, true},
         std::optional<Tensor> optional_input_a_grad = std::nullopt,
         std::optional<Tensor> optional_input_b_grad = std::nullopt) {
-        cout<<"inside execute_on_worker_thread 4 start \n";
 
         auto output_memory_config = memory_config.value_or(input_tensor_a_arg.memory_config());
         auto op_type = utils::get_function_type2_wo_qid(binary_backward_op_type);
@@ -143,10 +180,6 @@ constexpr auto atan2_bw = ttnn::register_operation<operations::binary_backward::
 constexpr auto embedding_bw = ttnn::register_operation<operations::binary_backward::ExecuteBinaryBackward<operations::binary_backward::BinaryBackwardOpType::EMBEDDING_BW>>("ttnn::embedding_bw");
 constexpr auto subalpha_bw = ttnn::register_operation<operations::binary_backward::ExecuteBinaryBackward<operations::binary_backward::BinaryBackwardOpType::SUBALPHA_BW>>("ttnn::subalpha_bw");
 constexpr auto sub_bw = ttnn::register_operation<operations::binary_backward::ExecuteBinaryBackward<operations::binary_backward::BinaryBackwardOpType::SUB_BW>>("ttnn::sub_bw");
-
-//type 2
-constexpr auto addalpha_bw = ttnn::register_operation<operations::binary_backward::ExecuteBinaryBackward<operations::binary_backward::BinaryBackwardOpType::ADDALPHA_BW>>("ttnn::addalpha_bw");
-
 constexpr auto xlogy_bw = ttnn::register_operation<operations::binary_backward::ExecuteBinaryBackward<operations::binary_backward::BinaryBackwardOpType::XLOGY_BW>>("ttnn::xlogy_bw");
 constexpr auto hypot_bw = ttnn::register_operation<operations::binary_backward::ExecuteBinaryBackward<operations::binary_backward::BinaryBackwardOpType::HYPOT_BW>>("ttnn::hypot_bw");
 constexpr auto ldexp_bw = ttnn::register_operation<operations::binary_backward::ExecuteBinaryBackward<operations::binary_backward::BinaryBackwardOpType::LDEXP_BW>>("ttnn::ldexp_bw");
@@ -154,5 +187,10 @@ constexpr auto logaddexp_bw = ttnn::register_operation<operations::binary_backwa
 constexpr auto logaddexp2_bw = ttnn::register_operation<operations::binary_backward::ExecuteBinaryBackward<operations::binary_backward::BinaryBackwardOpType::LOGADDEXP2_BW>>("ttnn::logaddexp2_bw");
 constexpr auto squared_difference_bw = ttnn::register_operation<operations::binary_backward::ExecuteBinaryBackward<operations::binary_backward::BinaryBackwardOpType::SQUARED_DIFFERENCE_BW>>("ttnn::squared_difference_bw");
 
+//type 2
+constexpr auto addalpha_bw = ttnn::register_operation<operations::binary_backward::ExecuteBinaryBackward<operations::binary_backward::BinaryBackwardOpType::ADDALPHA_BW>>("ttnn::addalpha_bw");
+
+//type 3
+constexpr auto add_bw = ttnn::register_operation<operations::binary_backward::ExecuteBinaryBackward<operations::binary_backward::BinaryBackwardOpType::ADD_BW>>("ttnn::add_bw");
 
 }  // namespace ttnn

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_backward/binary_backward.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_backward/binary_backward.hpp
@@ -152,6 +152,7 @@ constexpr auto hypot_bw = ttnn::register_operation<operations::binary_backward::
 constexpr auto ldexp_bw = ttnn::register_operation<operations::binary_backward::ExecuteBinaryBackward<operations::binary_backward::BinaryBackwardOpType::LDEXP_BW>>("ttnn::ldexp_bw");
 constexpr auto logaddexp_bw = ttnn::register_operation<operations::binary_backward::ExecuteBinaryBackward<operations::binary_backward::BinaryBackwardOpType::LOGADDEXP_BW>>("ttnn::logaddexp_bw");
 constexpr auto logaddexp2_bw = ttnn::register_operation<operations::binary_backward::ExecuteBinaryBackward<operations::binary_backward::BinaryBackwardOpType::LOGADDEXP2_BW>>("ttnn::logaddexp2_bw");
+constexpr auto squared_difference_bw = ttnn::register_operation<operations::binary_backward::ExecuteBinaryBackward<operations::binary_backward::BinaryBackwardOpType::SQUARED_DIFFERENCE_BW>>("ttnn::squared_difference_bw");
 
 
 }  // namespace ttnn

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_backward/binary_backward.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_backward/binary_backward.hpp
@@ -57,11 +57,12 @@ struct ExecuteBinaryBackward {
         const Tensor &grad_tensor_arg,
         const Tensor &input_tensor_a_arg,
         const Tensor &input_tensor_b_arg,
-        const MemoryConfig &memory_config) {
+        const std::optional<MemoryConfig> &memory_config = std::nullopt) {
 
         auto op_type = utils::get_function(binary_backward_op_type);
 
-        return tt::tt_metal::operation::decorate_as_composite(__func__, op_type)(grad_tensor_arg, input_tensor_a_arg, input_tensor_b_arg, memory_config);
+        auto output_memory_config = memory_config.value_or(input_tensor_a_arg.memory_config());
+        return tt::tt_metal::operation::decorate_as_composite(__func__, op_type)(grad_tensor_arg, input_tensor_a_arg, input_tensor_b_arg, output_memory_config);
         }
 
     static inline std::vector<Tensor> create_async_output_tensors(

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_backward/binary_backward.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_backward/binary_backward.hpp
@@ -149,6 +149,7 @@ constexpr auto addalpha_bw = ttnn::register_operation<operations::binary_backwar
 
 constexpr auto xlogy_bw = ttnn::register_operation<operations::binary_backward::ExecuteBinaryBackward<operations::binary_backward::BinaryBackwardOpType::XLOGY_BW>>("ttnn::xlogy_bw");
 constexpr auto hypot_bw = ttnn::register_operation<operations::binary_backward::ExecuteBinaryBackward<operations::binary_backward::BinaryBackwardOpType::HYPOT_BW>>("ttnn::hypot_bw");
+constexpr auto ldexp_bw = ttnn::register_operation<operations::binary_backward::ExecuteBinaryBackward<operations::binary_backward::BinaryBackwardOpType::LDEXP_BW>>("ttnn::ldexp_bw");
 
 
 }  // namespace ttnn

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_backward/binary_backward.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_backward/binary_backward.hpp
@@ -60,11 +60,12 @@ struct ExecuteBinaryBackward {
         return std::forward_as_tuple(grad_tensor, input_tensor_a, input_tensor_b);
     }
 
-    static std::vector<Tensor> execute_on_worker_thread(
+    static std::vector<ttnn::Tensor> execute_on_worker_thread(
         const Tensor &grad_tensor_arg,
         const Tensor &input_tensor_a_arg,
         const Tensor &input_tensor_b_arg,
         const std::optional<MemoryConfig> &memory_config = std::nullopt) {
+        cout<<"inside execute_on_worker_thread 1 start \n";
 
         auto op_type = utils::get_function_type1(binary_backward_op_type);
         auto output_memory_config = memory_config.value_or(input_tensor_a_arg.memory_config());
@@ -72,7 +73,23 @@ struct ExecuteBinaryBackward {
         }
 
 
-    //Type 2 : Q_ID, type1 args, optional output tensor for inputs based on are_required_outputs value
+    //Type 2: 2 inputs, 1 grad tensor 1 float
+    template <typename... Args>
+
+    static std::vector<ttnn::Tensor> execute_on_worker_thread(
+        const Tensor &grad_tensor_arg,
+        const Tensor &input_tensor_a_arg,
+        float alpha,
+        const Tensor &input_tensor_b_arg,
+        const std::optional<MemoryConfig> &memory_config = std::nullopt) {
+        cout<<"inside execute_on_worker_thread 2 start \n";
+
+        auto op_type = utils::get_function_type1_w_float(binary_backward_op_type);
+        auto output_memory_config = memory_config.value_or(input_tensor_a_arg.memory_config());
+        return op_type(grad_tensor_arg, input_tensor_a_arg, input_tensor_b_arg, alpha, output_memory_config);
+        }
+
+    //Type 3 : Q_ID, type1 args, optional output tensor for inputs based on are_required_outputs value
     template <typename... Args>
     static auto input_tensors_to_validate(uint8_t queue_id, const Tensor &grad_tensor, const Tensor &input_tensor_a, const Tensor &input_tensor_b, float alpha, Args &&...args) {
         return std::forward_as_tuple(grad_tensor, input_tensor_a, input_tensor_b);
@@ -88,15 +105,16 @@ struct ExecuteBinaryBackward {
         const std::vector<bool>& are_required_outputs = std::vector<bool>{true, true},
         std::optional<Tensor> optional_input_a_grad = std::nullopt,
         std::optional<Tensor> optional_input_b_grad = std::nullopt) {
+        cout<<"inside execute_on_worker_thread 3 start \n";
 
         auto output_memory_config = memory_config.value_or(input_tensor_a_arg.memory_config());
         auto op_type = utils::get_function_type2(binary_backward_op_type);
         return op_type(queue_id, grad_tensor_arg, input_tensor_a_arg, input_tensor_b_arg, alpha, output_memory_config, are_required_outputs, optional_input_a_grad, optional_input_b_grad);
     }
 
-    //Type 3 : type1 args, optional output tensor for inputs based on are_required_outputs value
+    //Type 4 : type1 args, optional output tensor for inputs based on are_required_outputs value
     template <typename... Args>
-    static auto input_tensors_to_validate(const Tensor &grad_tensor, const Tensor &input_tensor_a, const Tensor &input_tensor_b, float alpha, Args &&...args) {
+    static auto input_tensors_to_validate(const Tensor &grad_tensor, const Tensor &input_tensor_a, const Tensor &input_tensor_b, float alpha, std::vector<bool> are_required_outputs, Args &&...args) {
         return std::forward_as_tuple(grad_tensor, input_tensor_a, input_tensor_b);
     }
 
@@ -109,6 +127,7 @@ struct ExecuteBinaryBackward {
         const std::vector<bool>& are_required_outputs = std::vector<bool>{true, true},
         std::optional<Tensor> optional_input_a_grad = std::nullopt,
         std::optional<Tensor> optional_input_b_grad = std::nullopt) {
+        cout<<"inside execute_on_worker_thread 4 start \n";
 
         auto output_memory_config = memory_config.value_or(input_tensor_a_arg.memory_config());
         auto op_type = utils::get_function_type2_wo_qid(binary_backward_op_type);
@@ -122,6 +141,8 @@ struct ExecuteBinaryBackward {
 //type 1
 constexpr auto atan2_bw = ttnn::register_operation<operations::binary_backward::ExecuteBinaryBackward<operations::binary_backward::BinaryBackwardOpType::ATAN2_BW>>("ttnn::atan2_bw");
 constexpr auto embedding_bw = ttnn::register_operation<operations::binary_backward::ExecuteBinaryBackward<operations::binary_backward::BinaryBackwardOpType::EMBEDDING_BW>>("ttnn::embedding_bw");
+constexpr auto subalpha_bw = ttnn::register_operation<operations::binary_backward::ExecuteBinaryBackward<operations::binary_backward::BinaryBackwardOpType::SUBALPHA_BW>>("ttnn::subalpha_bw");
+constexpr auto sub_bw = ttnn::register_operation<operations::binary_backward::ExecuteBinaryBackward<operations::binary_backward::BinaryBackwardOpType::SUB_BW>>("ttnn::sub_bw");
 
 //type 2
 constexpr auto addalpha_bw = ttnn::register_operation<operations::binary_backward::ExecuteBinaryBackward<operations::binary_backward::BinaryBackwardOpType::ADDALPHA_BW>>("ttnn::addalpha_bw");

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_backward/binary_backward_pybind.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_backward/binary_backward_pybind.hpp
@@ -187,6 +187,11 @@ void py_module(py::module& module) {
         ttnn::logaddexp2_bw,
         R"doc(Performs backward operations for logaddexp2 of :attr:`input_tensor_a` and :attr:`input_tensor_b` tensors with given :attr:`grad_tensor`.)doc");
 
+    detail::bind_binary_backward(
+        module,
+        ttnn::squared_difference_bw,
+        R"doc(Performs backward operations for squared_difference of :attr:`input_tensor_a` and :attr:`input_tensor_b` tensors with given :attr:`grad_tensor`.)doc");
+
 }
 
 }  // namespace binary_backward

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_backward/binary_backward_pybind.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_backward/binary_backward_pybind.hpp
@@ -176,6 +176,17 @@ void py_module(py::module& module) {
         module,
         ttnn::ldexp_bw,
         R"doc(Performs backward operations for ldexp of :attr:`input_tensor_a` and :attr:`input_tensor_b` tensors with given :attr:`grad_tensor`.)doc");
+
+    detail::bind_binary_backward(
+        module,
+        ttnn::logaddexp_bw,
+        R"doc(Performs backward operations for logaddexp of :attr:`input_tensor_a` and :attr:`input_tensor_b` tensors with given :attr:`grad_tensor`.)doc");
+
+    detail::bind_binary_backward(
+        module,
+        ttnn::logaddexp2_bw,
+        R"doc(Performs backward operations for logaddexp2 of :attr:`input_tensor_a` and :attr:`input_tensor_b` tensors with given :attr:`grad_tensor`.)doc");
+
 }
 
 }  // namespace binary_backward

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_backward/binary_backward_pybind.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_backward/binary_backward_pybind.hpp
@@ -54,7 +54,8 @@ Example:
                const ttnn::Tensor& grad_tensor,
                const ttnn::Tensor& input_tensor_a,
                const ttnn::Tensor& input_tensor_b,
-               const std::optional<ttnn::MemoryConfig>& memory_config) -> std::vector<Tensor> {
+               const std::optional<ttnn::MemoryConfig>& memory_config) -> std::vector<ttnn::Tensor> {
+                cout<<"inside overload 1 start \n";
                 return self(grad_tensor, input_tensor_a, input_tensor_b, memory_config);
             },
             py::arg("grad_tensor"),
@@ -62,6 +63,25 @@ Example:
             py::arg("input_tensor_b"),
             py::kw_only(),
             py::arg("memory_config") = std::nullopt},
+
+
+        ttnn::pybind_overload_t{
+            [](const binary_backward_operation_t& self,
+               const ttnn::Tensor& grad_tensor,
+               const ttnn::Tensor& input_tensor_a,
+               const ttnn::Tensor& input_tensor_b,
+               const float alpha,
+               const std::optional<ttnn::MemoryConfig>& memory_config) -> std::vector<ttnn::Tensor> {
+                cout<<"inside overload 2 start \n";
+                return self(grad_tensor, input_tensor_a, alpha, input_tensor_b, memory_config);
+            },
+            py::arg("grad_tensor"),
+            py::arg("input_tensor_a"),
+            py::arg("input_tensor_b"),
+            py::arg("alpha"),
+            py::kw_only(),
+            py::arg("memory_config") = std::nullopt},
+
 
         ttnn::pybind_overload_t{
             [](const binary_backward_operation_t& self,
@@ -74,6 +94,7 @@ Example:
                const std::optional<ttnn::Tensor>& optional_input_a_grad,
                const std::optional<ttnn::Tensor>& optional_input_b_grad,
                const uint8_t& queue_id) -> std::vector<ttnn::Tensor> {
+                cout<<"inside overload 3 start \n";
                 return self(queue_id, grad_tensor, input_tensor_a, input_tensor_b, alpha, memory_config, are_required_outputs, optional_input_a_grad, optional_input_b_grad);
             },
             py::arg("grad_tensor"),
@@ -97,6 +118,7 @@ Example:
                const std::vector<bool>& are_required_outputs,
                const std::optional<ttnn::Tensor>& optional_input_a_grad,
                const std::optional<ttnn::Tensor>& optional_input_b_grad) -> std::vector<ttnn::Tensor> {
+                cout<<"inside overload 4 start \n";
                 return self(grad_tensor, input_tensor_a, input_tensor_b, alpha, memory_config, are_required_outputs, optional_input_a_grad, optional_input_b_grad);
             },
             py::arg("grad_tensor"),
@@ -124,6 +146,16 @@ void py_module(py::module& module) {
         ttnn::embedding_bw,
         R"doc(Performs backward operations for embedding_bw function and it returns specific indices of the embedding table specified by the :attr:`grad_tensor`.
         The input tensor( :attr:`input_tensor_a`, :attr:`input_tensor_b`) should be unique.)doc");
+
+    detail::bind_binary_backward(
+        module,
+        ttnn::subalpha_bw,
+        R"doc(Performs backward operations for subalpha of :attr:`input_tensor_a` and :attr:`input_tensor_b` tensors with given :attr:`grad_tensor`.)doc");
+
+    detail::bind_binary_backward(
+        module,
+        ttnn::sub_bw,
+        R"doc(Performs backward operations for sub of :attr:`input_tensor_a` and :attr:`input_tensor_b` tensors with given :attr:`grad_tensor`.)doc");
 
     detail::bind_binary_backward(
         module,

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_backward/binary_backward_pybind.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_backward/binary_backward_pybind.hpp
@@ -170,10 +170,14 @@ void py_module(py::module& module) {
     detail::bind_binary_backward(
         module,
         ttnn::hypot_bw,
-        R"doc(Performs backward operations for hypot_bw of :attr:`input_tensor_a` and :attr:`input_tensor_b` tensors with given :attr:`grad_tensor`.)doc");
+        R"doc(Performs backward operations for hypot of :attr:`input_tensor_a` and :attr:`input_tensor_b` tensors with given :attr:`grad_tensor`.)doc");
 
+    detail::bind_binary_backward(
+        module,
+        ttnn::ldexp_bw,
+        R"doc(Performs backward operations for ldexp of :attr:`input_tensor_a` and :attr:`input_tensor_b` tensors with given :attr:`grad_tensor`.)doc");
 }
 
-}  // namespace copy
+}  // namespace binary_backward
 }  // namespace operations
 }  // namespace ttnn

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_backward/binary_backward_pybind.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_backward/binary_backward_pybind.hpp
@@ -20,9 +20,9 @@ namespace binary_backward {
 namespace detail {
 
 template <typename binary_backward_operation_t>
-void bind_global_backward(py::module& module, const binary_backward_operation_t& operation, const std::string& description) {
+void bind_binary_backward(py::module& module, const binary_backward_operation_t& operation, const std::string& description) {
     auto doc = fmt::format(
-R"doc({0}(grad_tensor: ttnn.Tensor, input_tensor_a: ttnn.Tensor, input_tensor_b: ttnn.Tensor, *, memory_config: ttnn.MemoryConfig) -> ttnn.Tensor
+R"doc({0}(grad_tensor: ttnn.Tensor, input_tensor_a: ttnn.Tensor, input_tensor_b: ttnn.Tensor, *, memory_config: ttnn.MemoryConfig) -> std::vector<Tensor>
 
 {2}
 
@@ -33,9 +33,6 @@ Args:
 
 Keyword args:
     * :attr:`memory_config` (Optional[ttnn.MemoryConfig]): memory config for the output tensor
-    * :attr:`dtype` (Optional[ttnn.DataType]): data type for the output tensor
-    * :attr:`output_tensor` (Optional[ttnn.Tensor]): preallocated output tensor
-    * :attr:`queue_id` (Optional[uint8]): command queue id
 
 Example:
 
@@ -64,26 +61,74 @@ Example:
             py::arg("input_tensor_a"),
             py::arg("input_tensor_b"),
             py::kw_only(),
-            py::arg("memory_config") = std::nullopt});
+            py::arg("memory_config") = std::nullopt},
+
+        ttnn::pybind_overload_t{
+            [](const binary_backward_operation_t& self,
+               const ttnn::Tensor& grad_tensor,
+               const ttnn::Tensor& input_tensor_a,
+               const ttnn::Tensor& input_tensor_b,
+               const float alpha,
+               const std::optional<ttnn::MemoryConfig>& memory_config,
+               const std::vector<bool>& are_required_outputs,
+               const std::optional<ttnn::Tensor>& optional_input_a_grad,
+               const std::optional<ttnn::Tensor>& optional_input_b_grad,
+               const uint8_t& queue_id) -> std::vector<ttnn::Tensor> {
+                return self(queue_id, grad_tensor, input_tensor_a, input_tensor_b, alpha, memory_config, are_required_outputs, optional_input_a_grad, optional_input_b_grad);
+            },
+            py::arg("grad_tensor"),
+            py::arg("input_tensor_a"),
+            py::arg("input_tensor_b"),
+            py::arg("alpha") = 1.0f,
+            py::kw_only(),
+            py::arg("memory_config") = std::nullopt,
+            py::arg("are_required_outputs") = std::vector<bool>{true, true},
+            py::arg("optional_input_a_grad") = std::nullopt,
+            py::arg("optional_input_b_grad") = std::nullopt,
+            py::arg("queue_id") = 0},
+
+        ttnn::pybind_overload_t{
+            [](const binary_backward_operation_t& self,
+               const ttnn::Tensor& grad_tensor,
+               const ttnn::Tensor& input_tensor_a,
+               const ttnn::Tensor& input_tensor_b,
+               const float alpha,
+               const std::optional<ttnn::MemoryConfig>& memory_config,
+               const std::vector<bool>& are_required_outputs,
+               const std::optional<ttnn::Tensor>& optional_input_a_grad,
+               const std::optional<ttnn::Tensor>& optional_input_b_grad) -> std::vector<ttnn::Tensor> {
+                return self(grad_tensor, input_tensor_a, input_tensor_b, alpha, memory_config, are_required_outputs, optional_input_a_grad, optional_input_b_grad);
+            },
+            py::arg("grad_tensor"),
+            py::arg("input_tensor_a"),
+            py::arg("input_tensor_b"),
+            py::arg("alpha") = 1.0f,
+            py::kw_only(),
+            py::arg("memory_config") = std::nullopt,
+            py::arg("are_required_outputs") = std::vector<bool>{true, true},
+            py::arg("optional_input_a_grad") = std::nullopt,
+            py::arg("optional_input_b_grad") = std::nullopt});
 }
 
 }  // namespace detail
 
 
 void py_module(py::module& module) {
-    detail::bind_global_backward(
+    detail::bind_binary_backward(
         module,
         ttnn::atan2_bw,
-        R"doc(Adds :attr:`input_tensor_a` to :attr:`input_tensor_b` and returns the tensor with the same layout as :attr:`input_tensor_a`
+        R"doc(Performs backward operations for atan2 of :attr:`input_tensor_a` and :attr:`input_tensor_b` tensors with given :attr:`grad_tensor`.)doc");
 
-        .. math:: \mathrm{{ input\_tensor\_a }}_i + \mathrm{{ input\_tensor\_b }}_i)doc");
-
-    detail::bind_global_backward(
+    detail::bind_binary_backward(
         module,
         ttnn::embedding_bw,
-        R"doc(Adds :attr:`input_tensor_a` to :attr:`input_tensor_b` and returns the tensor with the same layout as :attr:`input_tensor_a`
+        R"doc(Performs backward operations for embedding_bw function and it returns specific indices of the embedding table specified by the :attr:`grad_tensor`.
+        The input tensor( :attr:`input_tensor_a`, :attr:`input_tensor_b`) should be unique.)doc");
 
-        .. math:: \mathrm{{ input\_tensor\_a }}_i + \mathrm{{ input\_tensor\_b }}_i)doc");
+    detail::bind_binary_backward(
+        module,
+        ttnn::addalpha_bw,
+        R"doc(Performs backward operations for addalpha on :attr:`input_tensor_b` , attr:`input_tensor_a`, attr:`alpha` tensors with given attr:`grad_tensor`.)doc");
 }
 
 }  // namespace copy

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_backward/binary_backward_pybind.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_backward/binary_backward_pybind.hpp
@@ -161,6 +161,12 @@ void py_module(py::module& module) {
         module,
         ttnn::addalpha_bw,
         R"doc(Performs backward operations for addalpha on :attr:`input_tensor_b` , attr:`input_tensor_a`, attr:`alpha` tensors with given attr:`grad_tensor`.)doc");
+
+    detail::bind_binary_backward(
+        module,
+        ttnn::xlogy_bw,
+        R"doc(Performs backward operations for xlogy of :attr:`input_tensor_a` and :attr:`input_tensor_b` tensors with given :attr:`grad_tensor`.)doc");
+
 }
 
 }  // namespace copy

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_backward/binary_backward_pybind.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_backward/binary_backward_pybind.hpp
@@ -54,15 +54,14 @@ Example:
                const ttnn::Tensor& grad_tensor,
                const ttnn::Tensor& input_tensor_a,
                const ttnn::Tensor& input_tensor_b,
-               const std::optional<ttnn::MemoryConfig>& memory_config) -> std::vector<ttnn::Tensor> {
-                cout<<"inside overload 1 start \n";
+               const ttnn::MemoryConfig& memory_config) -> std::vector<ttnn::Tensor> {
                 return self(grad_tensor, input_tensor_a, input_tensor_b, memory_config);
             },
             py::arg("grad_tensor"),
             py::arg("input_tensor_a"),
             py::arg("input_tensor_b"),
             py::kw_only(),
-            py::arg("memory_config") = std::nullopt},
+            py::arg("memory_config") = operation::DEFAULT_OUTPUT_MEMORY_CONFIG},
 
 
         ttnn::pybind_overload_t{
@@ -72,7 +71,6 @@ Example:
                const ttnn::Tensor& input_tensor_b,
                const float alpha,
                const std::optional<ttnn::MemoryConfig>& memory_config) -> std::vector<ttnn::Tensor> {
-                cout<<"inside overload 2 start \n";
                 return self(grad_tensor, input_tensor_a, alpha, input_tensor_b, memory_config);
             },
             py::arg("grad_tensor"),
@@ -88,13 +86,54 @@ Example:
                const ttnn::Tensor& grad_tensor,
                const ttnn::Tensor& input_tensor_a,
                const ttnn::Tensor& input_tensor_b,
+               const std::optional<ttnn::MemoryConfig>& memory_config,
+               const std::vector<bool>& are_required_outputs,
+               const std::optional<ttnn::Tensor>& optional_input_a_grad,
+               const std::optional<ttnn::Tensor>& optional_input_b_grad,
+               const uint8_t& queue_id) -> std::vector<ttnn::Tensor> {
+                return self(queue_id, grad_tensor, input_tensor_a, input_tensor_b, memory_config, are_required_outputs, optional_input_a_grad, optional_input_b_grad);
+            },
+            py::arg("grad_tensor"),
+            py::arg("input_tensor_a"),
+            py::arg("input_tensor_b"),
+            py::kw_only(),
+            py::arg("memory_config") = std::nullopt,
+            py::arg("are_required_outputs") = std::vector<bool>{true, true},
+            py::arg("optional_input_a_grad") = std::nullopt,
+            py::arg("optional_input_b_grad") = std::nullopt,
+            py::arg("queue_id") = 0},
+
+        ttnn::pybind_overload_t{
+            [](const binary_backward_operation_t& self,
+               const ttnn::Tensor& grad_tensor,
+               const ttnn::Tensor& input_tensor_a,
+               const ttnn::Tensor& input_tensor_b,
+               const std::optional<ttnn::MemoryConfig>& memory_config,
+               const std::vector<bool>& are_required_outputs,
+               const std::optional<ttnn::Tensor>& optional_input_a_grad,
+               const std::optional<ttnn::Tensor>& optional_input_b_grad) -> std::vector<ttnn::Tensor> {
+                return self(grad_tensor, input_tensor_a, input_tensor_b, memory_config, are_required_outputs, optional_input_a_grad, optional_input_b_grad);
+            },
+            py::arg("grad_tensor"),
+            py::arg("input_tensor_a"),
+            py::arg("input_tensor_b"),
+            py::kw_only(),
+            py::arg("memory_config") = std::nullopt,
+            py::arg("are_required_outputs") = std::vector<bool>{true, true},
+            py::arg("optional_input_a_grad") = std::nullopt,
+            py::arg("optional_input_b_grad") = std::nullopt},
+
+        ttnn::pybind_overload_t{
+            [](const binary_backward_operation_t& self,
+               const ttnn::Tensor& grad_tensor,
+               const ttnn::Tensor& input_tensor_a,
+               const ttnn::Tensor& input_tensor_b,
                const float alpha,
                const std::optional<ttnn::MemoryConfig>& memory_config,
                const std::vector<bool>& are_required_outputs,
                const std::optional<ttnn::Tensor>& optional_input_a_grad,
                const std::optional<ttnn::Tensor>& optional_input_b_grad,
                const uint8_t& queue_id) -> std::vector<ttnn::Tensor> {
-                cout<<"inside overload 3 start \n";
                 return self(queue_id, grad_tensor, input_tensor_a, input_tensor_b, alpha, memory_config, are_required_outputs, optional_input_a_grad, optional_input_b_grad);
             },
             py::arg("grad_tensor"),
@@ -118,7 +157,6 @@ Example:
                const std::vector<bool>& are_required_outputs,
                const std::optional<ttnn::Tensor>& optional_input_a_grad,
                const std::optional<ttnn::Tensor>& optional_input_b_grad) -> std::vector<ttnn::Tensor> {
-                cout<<"inside overload 4 start \n";
                 return self(grad_tensor, input_tensor_a, input_tensor_b, alpha, memory_config, are_required_outputs, optional_input_a_grad, optional_input_b_grad);
             },
             py::arg("grad_tensor"),
@@ -192,6 +230,10 @@ void py_module(py::module& module) {
         ttnn::squared_difference_bw,
         R"doc(Performs backward operations for squared_difference of :attr:`input_tensor_a` and :attr:`input_tensor_b` tensors with given :attr:`grad_tensor`.)doc");
 
+    detail::bind_binary_backward(
+        module,
+        ttnn::add_bw,
+        R"doc(Performs backward operations for add on :attr:`input_tensor_b` , attr:`input_tensor_a`, attr:`alpha` tensors with given attr:`grad_tensor`.)doc");
 }
 
 }  // namespace binary_backward

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_backward/binary_backward_pybind.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_backward/binary_backward_pybind.hpp
@@ -1,0 +1,71 @@
+// SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <pybind11/pybind11.h>
+#include <pybind11/stl.h>
+
+#include "ttnn/cpp/pybind11/decorators.hpp"
+#include "ttnn/operations/eltwise/binary_backward/binary_backward.hpp"
+#include "ttnn/types.hpp"
+
+namespace py = pybind11;
+
+namespace ttnn {
+namespace operations {
+namespace binary_backward {
+
+namespace detail {
+
+void bind_global_backward(py::module& module) {
+    auto doc = fmt::format(
+R"doc({0}(input_tensor: ttnn.Tensor, dtype: ttnn.DataType, *, memory_config: Optional[ttnn.MemoryConfig] = None, output_tensor : Optional[ttnn.Tensor] = None, queue_id : Optional[int]) -> ttnn.Tensor
+
+Applies {0} to :attr:`input_tensor`.
+
+Args:
+    * :attr:`input_tensor` (ttnn.Tensor): input tensors must be on device, in ROW MAJOR or TILE layout
+    * :attr:`dtype` (Optional[ttnn.DataType]): data type must be one of the following types BFLOAT16,BFLOAT8_B,BFLOAT4_B,UINT32,INT32 and UINT16.
+    *
+Keyword Args:
+    * :attr:`memory_config` (Optional[ttnn.MemoryConfig]): Memory configuration for the operation.
+    * :attr:`output_tensor` (Optional[ttnn.Tensor]): Preallocated tensor to store the output.
+
+Returns:
+    ttnn.Tensor: The tensor with the updated data type. Output tensor will be on device, in same layout, and have the given data type.
+
+Example::
+
+    >>> tensor = ttnn.typecast(torch.randn((10, 3, 32, 32), dtype=ttnn.bfloat16), ttnn.uint16)
+)doc",
+        ttnn::atan2_bw.name());
+
+
+    using BackwardType = decltype(ttnn::atan2_bw);
+    bind_registered_operation(
+        module,
+        ttnn::atan2_bw,
+        doc,
+        ttnn::pybind_overload_t{
+            [](const BackwardType& self,
+               const ttnn::Tensor& grad_tensor,
+               const ttnn::Tensor& input_tensor_a,
+               const ttnn::Tensor& input_tensor_b,
+               const ttnn::MemoryConfig& memory_config) -> std::vector<Tensor> {
+                return self(grad_tensor, input_tensor_a, input_tensor_b, memory_config);
+            },
+            py::arg("grad_tensor"),
+            py::arg("input_tensor_a"),
+            py::arg("input_tensor_b"),
+            py::arg("memory_config")});
+}
+
+}  // namespace detail
+
+void py_module(py::module& module) { detail::bind_global_backward(module); }
+
+}  // namespace copy
+}  // namespace operations
+}  // namespace ttnn

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_backward/binary_backward_pybind.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_backward/binary_backward_pybind.hpp
@@ -57,13 +57,14 @@ Example:
                const ttnn::Tensor& grad_tensor,
                const ttnn::Tensor& input_tensor_a,
                const ttnn::Tensor& input_tensor_b,
-               const ttnn::MemoryConfig& memory_config) -> std::vector<Tensor> {
+               const std::optional<ttnn::MemoryConfig>& memory_config) -> std::vector<Tensor> {
                 return self(grad_tensor, input_tensor_a, input_tensor_b, memory_config);
             },
             py::arg("grad_tensor"),
             py::arg("input_tensor_a"),
             py::arg("input_tensor_b"),
-            py::arg("memory_config")});
+            py::kw_only(),
+            py::arg("memory_config") = std::nullopt});
 }
 
 }  // namespace detail

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_backward/binary_backward_pybind.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_backward/binary_backward_pybind.hpp
@@ -167,6 +167,11 @@ void py_module(py::module& module) {
         ttnn::xlogy_bw,
         R"doc(Performs backward operations for xlogy of :attr:`input_tensor_a` and :attr:`input_tensor_b` tensors with given :attr:`grad_tensor`.)doc");
 
+    detail::bind_binary_backward(
+        module,
+        ttnn::hypot_bw,
+        R"doc(Performs backward operations for hypot_bw of :attr:`input_tensor_a` and :attr:`input_tensor_b` tensors with given :attr:`grad_tensor`.)doc");
+
 }
 
 }  // namespace copy

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_backward/device/binary_backward_op.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_backward/device/binary_backward_op.cpp
@@ -83,7 +83,7 @@ std::vector<ttnn::Tensor> _addalpha_bw(
         if(other_grad.has_value()){
             ttnn::multiply(queue_id, grad, ttnn::operations::creation::full_like(grad, alpha, grad.get_dtype(), grad.get_layout(), std::nullopt, output_mem_config), std::nullopt, operation::DEFAULT_OUTPUT_MEMORY_CONFIG, other_grad);
         } else {
-            other_grad = mul_unary(queue_id, grad, alpha, output_mem_config);
+            other_grad = ttnn::multiply(queue_id, grad, alpha, std::nullopt, output_mem_config);
         }
         result.emplace_back(std::move(other_grad.value()));
     } else {
@@ -116,7 +116,7 @@ std::vector<ttnn::Tensor> _subalpha_bw(
     const Tensor& grad, const Tensor& input, const Tensor& other, float alpha, const MemoryConfig& output_mem_config) {
     std::vector<Tensor> grad_tensor;
     grad_tensor.emplace_back(grad);
-    Tensor grad_b = mul_unary(neg(grad, output_mem_config), alpha, output_mem_config);
+    Tensor grad_b = ttnn::multiply(neg(grad, output_mem_config), alpha, std::nullopt, output_mem_config);
     grad_tensor.emplace_back(grad_b);
     return grad_tensor;
 }
@@ -159,9 +159,9 @@ std::vector<Tensor> _add_bw_overload(
 
 std::vector<ttnn::Tensor> _xlogy_bw(
     const Tensor& grad, const Tensor& input, const Tensor& other, const MemoryConfig& output_mem_config) {
-       std::vector<Tensor> grad_tensor;
+    std::vector<Tensor> grad_tensor;
     Tensor grad1_result = log(other, output_mem_config);
-    Tensor zero_tensor = ttnn::operations::creation::full_like(other, 0.0, other.get_dtype(), other.get_layout(), std::nullopt, output_mem_config);
+    Tensor zero_tensor = ttnn::operations::creation::zeros_like(other, other.get_dtype(), other.get_layout(), std::nullopt, output_mem_config);
     grad1_result = where(
         ttnn::logical_and(
             eqz(input, output_mem_config),
@@ -180,7 +180,7 @@ std::vector<ttnn::Tensor> _xlogy_bw(
     Tensor grad2_result = ttnn::multiply(grad, div_result, std::nullopt, output_mem_config);
     grad2_result = where(
         eqz(other, output_mem_config),
-        mul_unary(sign(grad, output_mem_config), std::numeric_limits<float>::infinity(), output_mem_config),
+        ttnn::multiply(sign(grad, output_mem_config), std::numeric_limits<float>::infinity(), std::nullopt, output_mem_config),
         grad2_result,
         output_mem_config);
     grad2_result =
@@ -214,7 +214,7 @@ std::vector<ttnn::Tensor> _ldexp_bw(
     std::vector<Tensor> grad_tensor;
     Tensor tpow_o = ttnn::multiply(grad, rpow(other, 2.0, output_mem_config), std::nullopt, output_mem_config);
     grad_tensor.emplace_back(tpow_o);
-    Tensor result = ttnn::multiply(input, mul_unary(tpow_o, M_LN2, output_mem_config), std::nullopt, output_mem_config);
+    Tensor result = ttnn::multiply(input, ttnn::multiply(tpow_o, M_LN2, std::nullopt, output_mem_config), std::nullopt, output_mem_config);
     grad_tensor.emplace_back(result);
     return grad_tensor;
 }
@@ -230,10 +230,10 @@ std::vector<ttnn::Tensor> _logaddexp_bw(
     const Tensor& grad, const Tensor& input_a, const Tensor& other, const MemoryConfig& output_mem_config) {
     std::vector<Tensor> grad_tensor;
     Tensor opexp =
-        add1(ttnn::exp(ttnn::subtract(other, input_a, std::nullopt, output_mem_config), false, output_mem_config), output_mem_config);
+        ttnn::add(ttnn::exp(ttnn::subtract(other, input_a, std::nullopt, output_mem_config), false, output_mem_config), 1, std::nullopt, output_mem_config);
     Tensor grad_a = ttnn::multiply(grad, recip(opexp, output_mem_config), std::nullopt, output_mem_config);
     grad_tensor.emplace_back(grad_a);
-    opexp = add1(ttnn::exp(ttnn::subtract(input_a, other, std::nullopt, output_mem_config), false, output_mem_config), output_mem_config);
+    opexp = ttnn::add(ttnn::exp(ttnn::subtract(input_a, other, std::nullopt, output_mem_config), false, output_mem_config), 1, std::nullopt, output_mem_config);
     Tensor grad_b = ttnn::multiply(grad, recip(opexp, output_mem_config), std::nullopt, output_mem_config);
     grad_tensor.emplace_back(grad_b);
     return grad_tensor;
@@ -250,10 +250,10 @@ std::vector<ttnn::Tensor> _logaddexp2_bw(
     const Tensor& grad, const Tensor& input_a, const Tensor& other, const MemoryConfig& output_mem_config) {
     std::vector<Tensor> grad_tensor;
     Tensor oppow =
-        add1(rpow(ttnn::subtract(other, input_a, std::nullopt, output_mem_config), 2, output_mem_config), output_mem_config);
+        ttnn::add(rpow(ttnn::subtract(other, input_a, std::nullopt, output_mem_config), 2, output_mem_config), 1, std::nullopt, output_mem_config);
     Tensor grad_a = ttnn::multiply(grad, recip(oppow, output_mem_config), std::nullopt, output_mem_config);
     grad_tensor.emplace_back(grad_a);
-    oppow = add1(rpow(ttnn::subtract(input_a, other, std::nullopt, output_mem_config), 2, output_mem_config), output_mem_config);
+    oppow = ttnn::add(rpow(ttnn::subtract(input_a, other, std::nullopt, output_mem_config), 2, output_mem_config), 1, std::nullopt, output_mem_config);
     Tensor grad_b = ttnn::multiply(grad, recip(oppow, output_mem_config), std::nullopt, output_mem_config);
     grad_tensor.emplace_back(grad_b);
     return grad_tensor;
@@ -264,9 +264,9 @@ std::vector<ttnn::Tensor> _squared_difference_bw(
     const Tensor& grad, const Tensor& input, const Tensor& other, const MemoryConfig& output_mem_config) {
     std::vector<Tensor> grad_tensor;
     Tensor difference = ttnn::subtract(input, other);
-    Tensor grad_a = mul_unary(2, ttnn::multiply(grad, difference, std::nullopt, output_mem_config), output_mem_config);
+    Tensor grad_a = ttnn::multiply(ttnn::multiply(grad, difference, std::nullopt, output_mem_config), 2, std::nullopt, output_mem_config);
     grad_tensor.emplace_back(grad_a);
-    Tensor grad_b = mul_unary(-1, grad_a, output_mem_config);
+    Tensor grad_b = ttnn::multiply(grad_a, -1, std::nullopt, output_mem_config);
     grad_tensor.emplace_back(grad_b);
     return grad_tensor;
 }

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_backward/device/binary_backward_op.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_backward/device/binary_backward_op.cpp
@@ -16,6 +16,7 @@
 namespace ttnn::operations::binary_backward {
 
 namespace utils {
+//}
 // using namespace tt::tt_metal;
 
 std::vector<Tensor> _atan2_bw(
@@ -24,7 +25,6 @@ std::vector<Tensor> _atan2_bw(
     float t_nan = std::nanf("");
     UnaryWithParam op1{UnaryOpType::SQUARE};
     UnaryWithParam op2{UnaryOpType::RECIP};
-    std::cout<<"Inside here"<<endl;
     Tensor recip_mul =
         ttnn::multiply(grad, unary_chain(hypot(input, other), {op1, op2}, output_mem_config), std::nullopt, output_mem_config);
     Tensor grad_a = ttnn::multiply(other, recip_mul, std::nullopt, output_mem_config);
@@ -38,11 +38,35 @@ std::vector<Tensor> _atan2_bw(
     grad_tensor.emplace_back(grad_b);
     return grad_tensor;
 }
-std::vector<Tensor> atan2_bw(
-    const Tensor& grad, const Tensor& input, const Tensor& other, const MemoryConfig& output_mem_config) {
-    return operation::decorate_as_composite(__func__, _atan2_bw)(grad, input, other, output_mem_config);
+
+
+std::vector<Tensor> _embedding_bw(
+    const Tensor& grad, const Tensor& input, const Tensor& weight, const MemoryConfig& output_mem_config) {
+    TT_FATAL(input.get_dtype() == DataType::UINT32, "Input must be UINT32");
+    TT_FATAL(
+        grad.get_legacy_shape()[0] == 1 && grad.get_legacy_shape()[1] == 1,
+        "First two dimensions for the grad must be 1");
+    TT_FATAL(
+        input.get_legacy_shape()[1] == 1 && input.get_legacy_shape()[2] == 1,
+        "Only dim 0 && 3 for the input can be non 1");
+    std::vector<Tensor> grad_tensor;
+    Tensor grad_a = embeddings(input, grad, false);
+    grad_tensor.emplace_back(grad_a);
+
+    return grad_tensor;
+}
+
+std::function<std::vector<Tensor>(const Tensor&, const Tensor&, const Tensor&, const MemoryConfig&)> get_function(BinaryBackwardOpType OpType){
+    switch (OpType) {
+        case BinaryBackwardOpType::ATAN2_BW:
+            return _atan2_bw;
+        case BinaryBackwardOpType::EMBEDDING_BW:
+            return _embedding_bw;
+        default: TT_ASSERT(false && "Undefined op type");
+    }
 }
 
 }
+
 
 }  // namespace ttnn::operations::binary

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_backward/device/binary_backward_op.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_backward/device/binary_backward_op.cpp
@@ -16,8 +16,7 @@
 namespace ttnn::operations::binary_backward {
 
 namespace utils {
-//}
-// using namespace tt::tt_metal;
+
 
 std::vector<Tensor> _atan2_bw(
     const Tensor& grad, const Tensor& input, const Tensor& other, const MemoryConfig& output_mem_config) {

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_backward/device/binary_backward_op.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_backward/device/binary_backward_op.cpp
@@ -1,0 +1,48 @@
+// SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+
+#include "third_party/magic_enum/magic_enum.hpp"
+
+#include "tt_eager/tt_dnn/op_library/bcast/bcast_op.hpp"
+
+#include "tt_metal/common/constants.hpp"
+#include "tt_metal/host_api.hpp"
+#include "tt_metal/tools/profiler/op_profiler.hpp"
+#include "ttnn/operations/eltwise/binary_backward/device/binary_backward_op.hpp"
+
+
+namespace ttnn::operations::binary_backward {
+
+namespace utils {
+// using namespace tt::tt_metal;
+
+std::vector<Tensor> _atan2_bw(
+    const Tensor& grad, const Tensor& input, const Tensor& other, const MemoryConfig& output_mem_config) {
+    std::vector<Tensor> grad_tensor;
+    float t_nan = std::nanf("");
+    UnaryWithParam op1{UnaryOpType::SQUARE};
+    UnaryWithParam op2{UnaryOpType::RECIP};
+    std::cout<<"Inside here"<<endl;
+    Tensor recip_mul =
+        ttnn::multiply(grad, unary_chain(hypot(input, other), {op1, op2}, output_mem_config), std::nullopt, output_mem_config);
+    Tensor grad_a = ttnn::multiply(other, recip_mul, std::nullopt, output_mem_config);
+    Tensor cond = ttnn::logical_and(eqz(input, output_mem_config), eqz(other, output_mem_config));
+    grad_a = where(cond, t_nan, grad_a, output_mem_config);
+    grad_tensor.emplace_back(grad_a);
+    Tensor grad_b = ttnn::multiply(neg(input), recip_mul, std::nullopt, output_mem_config);
+    grad_b = where(cond, t_nan, grad_b, output_mem_config);
+    recip_mul.deallocate();
+    cond.deallocate();
+    grad_tensor.emplace_back(grad_b);
+    return grad_tensor;
+}
+std::vector<Tensor> atan2_bw(
+    const Tensor& grad, const Tensor& input, const Tensor& other, const MemoryConfig& output_mem_config) {
+    return operation::decorate_as_composite(__func__, _atan2_bw)(grad, input, other, output_mem_config);
+}
+
+}
+
+}  // namespace ttnn::operations::binary

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_backward/device/binary_backward_op.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_backward/device/binary_backward_op.cpp
@@ -239,6 +239,18 @@ std::vector<ttnn::Tensor> _logaddexp2_bw(
 }
 
 
+std::vector<ttnn::Tensor> _squared_difference_bw(
+    const Tensor& grad, const Tensor& input, const Tensor& other, const MemoryConfig& output_mem_config) {
+    std::vector<Tensor> grad_tensor;
+    Tensor difference = ttnn::subtract(input, other);
+    Tensor grad_a = mul_unary(2, ttnn::multiply(grad, difference, std::nullopt, output_mem_config), output_mem_config);
+    grad_tensor.emplace_back(grad_a);
+    Tensor grad_b = mul_unary(-1, grad_a, output_mem_config);
+    grad_tensor.emplace_back(grad_b);
+    return grad_tensor;
+}
+
+
 std::function<std::vector<ttnn::Tensor>(const Tensor&, const Tensor&, const Tensor&, const MemoryConfig&)> get_function_type1(BinaryBackwardOpType OpType){
     switch (OpType) {
         case BinaryBackwardOpType::ATAN2_BW:
@@ -257,6 +269,8 @@ std::function<std::vector<ttnn::Tensor>(const Tensor&, const Tensor&, const Tens
             return _logaddexp_bw;
         case BinaryBackwardOpType::LOGADDEXP2_BW:
             return _logaddexp2_bw;
+        case BinaryBackwardOpType::SQUARED_DIFFERENCE_BW:
+            return _squared_difference_bw;
         default:
             TT_ASSERT(false && "Undefined op type");
             return 0;
@@ -286,8 +300,13 @@ std::function<std::vector<ttnn::Tensor>(uint8_t , const Tensor&, const Tensor&, 
 }
 
 std::function<std::vector<ttnn::Tensor>(const Tensor&, const Tensor&, const Tensor&, float, const MemoryConfig&, const std::vector<bool>&, std::optional<Tensor>, std::optional<Tensor>)> get_function_type2_wo_qid(BinaryBackwardOpType OpType){
+    switch (OpType) {
         case BinaryBackwardOpType::ADDALPHA_BW:
             return _addalpha_bw_overload;
+        default:
+            TT_ASSERT(false && "Undefined op type");
+            return 0;
+    }
 }
 }
 

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_backward/device/binary_backward_op.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_backward/device/binary_backward_op.hpp
@@ -25,14 +25,9 @@ namespace ttnn::operations::binary_backward {
 
 // using namespace tt::tt_metal;
 enum class BinaryBackwardOpType {
-    ATAN2_BW
+    ATAN2_BW,
+    EMBEDDING_BW
 };
-
-// std::vector<Tensor> atan2_bw(
-//     const Tensor& grad,
-//     const Tensor& input,
-//     const Tensor& other,
-//     const MemoryConfig& output_mem_config = operation::DEFAULT_OUTPUT_MEMORY_CONFIG);
 
 
 }  // namespace ttnn::operations::binary

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_backward/device/binary_backward_op.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_backward/device/binary_backward_op.hpp
@@ -21,6 +21,8 @@ enum class BinaryBackwardOpType {
     XLOGY_BW,
     HYPOT_BW,
     LDEXP_BW,
+    LOGADDEXP_BW,
+    LOGADDEXP2_BW,
 };
 
 

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_backward/device/binary_backward_op.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_backward/device/binary_backward_op.hpp
@@ -15,7 +15,9 @@ constexpr uint8_t DefaultQueueId = 0;
 enum class BinaryBackwardOpType {
     ATAN2_BW,
     EMBEDDING_BW,
-    ADDALPHA_BW
+    ADDALPHA_BW,
+    SUBALPHA_BW,
+    SUB_BW
 };
 
 

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_backward/device/binary_backward_op.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_backward/device/binary_backward_op.hpp
@@ -11,9 +11,11 @@
 
 namespace ttnn::operations::binary_backward {
 
+constexpr uint8_t DefaultQueueId = 0;
 enum class BinaryBackwardOpType {
     ATAN2_BW,
-    EMBEDDING_BW
+    EMBEDDING_BW,
+    ADDALPHA_BW
 };
 
 

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_backward/device/binary_backward_op.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_backward/device/binary_backward_op.hpp
@@ -24,6 +24,7 @@ enum class BinaryBackwardOpType {
     LOGADDEXP_BW,
     LOGADDEXP2_BW,
     SQUARED_DIFFERENCE_BW,
+    ADD_BW
 };
 
 

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_backward/device/binary_backward_op.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_backward/device/binary_backward_op.hpp
@@ -19,6 +19,7 @@ enum class BinaryBackwardOpType {
     SUBALPHA_BW,
     SUB_BW,
     XLOGY_BW,
+    HYPOT_BW,
 };
 
 

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_backward/device/binary_backward_op.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_backward/device/binary_backward_op.hpp
@@ -23,6 +23,7 @@ enum class BinaryBackwardOpType {
     LDEXP_BW,
     LOGADDEXP_BW,
     LOGADDEXP2_BW,
+    SQUARED_DIFFERENCE_BW,
 };
 
 

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_backward/device/binary_backward_op.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_backward/device/binary_backward_op.hpp
@@ -7,23 +7,10 @@
 #include <functional>
 #include <optional>
 
-#include "tensor/tensor.hpp"
 #include "third_party/magic_enum/magic_enum.hpp"
-#include "tt_eager/tensor/host_buffer/functions.hpp"
-#include "tt_eager/tensor/tensor_utils.hpp"
-#include "tt_eager/tt_dnn/op_library/compute_kernel_config.hpp"
-
-#include "tt_eager/tt_dnn/op_library/eltwise_unary/eltwise_unary_op.hpp"
-#include "tt_eager/tt_dnn/op_library/run_operation.hpp"
-#include "tt_metal/host_api.hpp"
-#include "tt_metal/impl/dispatch/command_queue.hpp"
-#include "ttnn/core.hpp"
-#include "ttnn/decorators.hpp"
-#include "ttnn/types.hpp"
 
 namespace ttnn::operations::binary_backward {
 
-// using namespace tt::tt_metal;
 enum class BinaryBackwardOpType {
     ATAN2_BW,
     EMBEDDING_BW

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_backward/device/binary_backward_op.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_backward/device/binary_backward_op.hpp
@@ -17,7 +17,8 @@ enum class BinaryBackwardOpType {
     EMBEDDING_BW,
     ADDALPHA_BW,
     SUBALPHA_BW,
-    SUB_BW
+    SUB_BW,
+    XLOGY_BW,
 };
 
 

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_backward/device/binary_backward_op.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_backward/device/binary_backward_op.hpp
@@ -20,6 +20,7 @@ enum class BinaryBackwardOpType {
     SUB_BW,
     XLOGY_BW,
     HYPOT_BW,
+    LDEXP_BW,
 };
 
 

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_backward/device/binary_backward_op.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_backward/device/binary_backward_op.hpp
@@ -1,0 +1,38 @@
+// SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <functional>
+#include <optional>
+
+#include "tensor/tensor.hpp"
+#include "third_party/magic_enum/magic_enum.hpp"
+#include "tt_eager/tensor/host_buffer/functions.hpp"
+#include "tt_eager/tensor/tensor_utils.hpp"
+#include "tt_eager/tt_dnn/op_library/compute_kernel_config.hpp"
+
+#include "tt_eager/tt_dnn/op_library/eltwise_unary/eltwise_unary_op.hpp"
+#include "tt_eager/tt_dnn/op_library/run_operation.hpp"
+#include "tt_metal/host_api.hpp"
+#include "tt_metal/impl/dispatch/command_queue.hpp"
+#include "ttnn/core.hpp"
+#include "ttnn/decorators.hpp"
+#include "ttnn/types.hpp"
+
+namespace ttnn::operations::binary_backward {
+
+// using namespace tt::tt_metal;
+enum class BinaryBackwardOpType {
+    ATAN2_BW
+};
+
+// std::vector<Tensor> atan2_bw(
+//     const Tensor& grad,
+//     const Tensor& input,
+//     const Tensor& other,
+//     const MemoryConfig& output_mem_config = operation::DEFAULT_OUTPUT_MEMORY_CONFIG);
+
+
+}  // namespace ttnn::operations::binary

--- a/ttnn/ttnn/__init__.py
+++ b/ttnn/ttnn/__init__.py
@@ -465,6 +465,7 @@ from ttnn.operations.binary_backward import (
     logaddexp_bw,
     logaddexp2_bw,
     squared_difference_bw,
+    add_bw,
 )
 
 from ttnn.operations.ternary import (

--- a/ttnn/ttnn/__init__.py
+++ b/ttnn/ttnn/__init__.py
@@ -462,6 +462,8 @@ from ttnn.operations.binary_backward import (
     xlogy_bw,
     hypot_bw,
     ldexp_bw,
+    logaddexp_bw,
+    logaddexp2_bw,
 )
 
 from ttnn.operations.ternary import (

--- a/ttnn/ttnn/__init__.py
+++ b/ttnn/ttnn/__init__.py
@@ -464,6 +464,7 @@ from ttnn.operations.binary_backward import (
     ldexp_bw,
     logaddexp_bw,
     logaddexp2_bw,
+    squared_difference_bw,
 )
 
 from ttnn.operations.ternary import (

--- a/ttnn/ttnn/__init__.py
+++ b/ttnn/ttnn/__init__.py
@@ -460,6 +460,7 @@ from ttnn.operations.binary_backward import (
     subalpha_bw,
     sub_bw,
     xlogy_bw,
+    hypot_bw,
 )
 
 from ttnn.operations.ternary import (

--- a/ttnn/ttnn/__init__.py
+++ b/ttnn/ttnn/__init__.py
@@ -452,6 +452,8 @@ from ttnn.operations.binary import (
     divide,
 )
 
+from ttnn.operations.binary_backward import atan2_bw
+
 from ttnn.operations.ternary import (
     addcdiv,
     addcmul,

--- a/ttnn/ttnn/__init__.py
+++ b/ttnn/ttnn/__init__.py
@@ -461,6 +461,7 @@ from ttnn.operations.binary_backward import (
     sub_bw,
     xlogy_bw,
     hypot_bw,
+    ldexp_bw,
 )
 
 from ttnn.operations.ternary import (

--- a/ttnn/ttnn/__init__.py
+++ b/ttnn/ttnn/__init__.py
@@ -452,10 +452,7 @@ from ttnn.operations.binary import (
     divide,
 )
 
-from ttnn.operations.binary_backward import (
-    atan2_bw,
-    embedding_bw,
-)
+from ttnn.operations.binary_backward import atan2_bw, embedding_bw, addalpha_bw
 
 from ttnn.operations.ternary import (
     addcdiv,

--- a/ttnn/ttnn/__init__.py
+++ b/ttnn/ttnn/__init__.py
@@ -452,7 +452,10 @@ from ttnn.operations.binary import (
     divide,
 )
 
-from ttnn.operations.binary_backward import atan2_bw
+from ttnn.operations.binary_backward import (
+    atan2_bw,
+    embedding_bw,
+)
 
 from ttnn.operations.ternary import (
     addcdiv,

--- a/ttnn/ttnn/__init__.py
+++ b/ttnn/ttnn/__init__.py
@@ -452,7 +452,15 @@ from ttnn.operations.binary import (
     divide,
 )
 
-from ttnn.operations.binary_backward import atan2_bw, embedding_bw, addalpha_bw, subalpha_bw, sub_bw
+
+from ttnn.operations.binary_backward import (
+    atan2_bw,
+    embedding_bw,
+    addalpha_bw,
+    subalpha_bw,
+    sub_bw,
+    xlogy_bw,
+)
 
 from ttnn.operations.ternary import (
     addcdiv,

--- a/ttnn/ttnn/__init__.py
+++ b/ttnn/ttnn/__init__.py
@@ -452,7 +452,7 @@ from ttnn.operations.binary import (
     divide,
 )
 
-from ttnn.operations.binary_backward import atan2_bw, embedding_bw, addalpha_bw
+from ttnn.operations.binary_backward import atan2_bw, embedding_bw, addalpha_bw, subalpha_bw, sub_bw
 
 from ttnn.operations.ternary import (
     addcdiv,

--- a/ttnn/ttnn/operations/binary_backward.py
+++ b/ttnn/ttnn/operations/binary_backward.py
@@ -60,6 +60,21 @@ def _golden_function(grad_tensor, input_tensor_a, input_tensor_b, *args, **kwarg
 hypot_bw = ttnn.register_operation(golden_function=_golden_function)(ttnn._ttnn.operations.binary_backward.hypot_bw)
 
 
+def _golden_function(grad_tensor, input_tensor_a, input_tensor_b, *args, **kwargs):
+    import torch
+
+    pyt_y = torch.ldexp(input_tensor_a, input_tensor_b)
+    input_tensor_a.retain_grad()
+    input_tensor_b.retain_grad()
+
+    pyt_y.backward(gradient=grad_tensor)
+    golden_tensor = [input_tensor_a.grad, input_tensor_b.grad]
+    return golden_tensor
+
+
+ldexp_bw = ttnn.register_operation(golden_function=_golden_function)(ttnn._ttnn.operations.binary_backward.ldexp_bw)
+
+
 def _golden_function(grad_tensor, input_tensor, weight_tensor, *args, **kwargs):
     import torch
 

--- a/ttnn/ttnn/operations/binary_backward.py
+++ b/ttnn/ttnn/operations/binary_backward.py
@@ -30,6 +30,21 @@ def _golden_function(grad_tensor, input_tensor_a, input_tensor_b, *args, **kwarg
 atan2_bw = ttnn.register_operation(golden_function=_golden_function)(ttnn._ttnn.operations.binary_backward.atan2_bw)
 
 
+def _golden_function(grad_tensor, input_tensor_a, input_tensor_b, *args, **kwargs):
+    import torch
+
+    pyt_y = torch.xlogy(input_tensor_a, input_tensor_b)
+    input_tensor_a.retain_grad()
+    input_tensor_b.retain_grad()
+
+    pyt_y.backward(gradient=grad_tensor)
+    golden_tensor = [input_tensor_a.grad, input_tensor_b.grad]
+    return golden_tensor
+
+
+xlogy_bw = ttnn.register_operation(golden_function=_golden_function)(ttnn._ttnn.operations.binary_backward.xlogy_bw)
+
+
 def _golden_function(grad_tensor, input_tensor, weight_tensor, *args, **kwargs):
     import torch
 

--- a/ttnn/ttnn/operations/binary_backward.py
+++ b/ttnn/ttnn/operations/binary_backward.py
@@ -1,0 +1,117 @@
+# SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+
+# SPDX-License-Identifier: Apache-2.0
+
+from typing import List, Union, Optional
+
+import sys
+
+import ttnn
+
+import tt_lib as ttl
+
+THIS_MODULE = sys.modules[__name__]
+
+__all__ = []
+
+
+# def register_ttl_binary_backward_function(name, ttl_binary_backward_function, doc):
+#     def _golden_function(grad_tensor: ttnn.Tensor, input_tensor_1: ttnn.Tensor, input_tensor_2: ttnn.Tensor, **_):
+#         import torch
+
+#         pyt_y = torch.atan2(input_tensor_1, input_tensor_2)
+#         input_tensor_1.retain_grad()
+#         input_tensor_2.retain_grad()
+
+#         pyt_y.backward(gradient=grad_tensor)
+#         name_to_torch_function = {"atan2_bw": pyt_y}
+#         torch_function = name_to_torch_function[name]
+#         return torch_function(input_tensor_1, input_tensor_2)
+
+#     def _binary_backward_validate_input_tensors(operation_name, grad_tensor, input_tensor_1, input_tensor_2, *args, **kwargs):
+#         ttnn.validate_input_tensor(
+#             operation_name,
+#             grad_tensor,
+#             input_tensor_1,
+#             input_tensor_2,
+#             ranks=(2, 3, 4),
+#             dtypes=(ttnn.bfloat16, ttnn.bfloat8_b),
+#             layouts=(ttnn.TILE_LAYOUT,),
+#             can_be_on_device=True,
+#             can_be_on_cpu=False,
+#         )
+
+#     @ttnn.register_operation(
+#         name=f"ttnn.{name}",
+#         validate_input_tensors=_binary_backward_validate_input_tensors,
+#         golden_function=_golden_function,
+#     )
+#     def binary_backward_function(
+#         grad_tensor: ttnn.Tensor,
+#         input_tensor_1: ttnn.Tensor,
+#         input_tensor_2: ttnn.Tensor,
+#         *,
+#         memory_config: ttnn.MemoryConfig = ttnn.DRAM_MEMORY_CONFIG,
+#     ) -> ttnn.Tensor:
+#         original_shape = grad_tensor.shape
+#         grad_tensor = ttnn.unsqueeze_to_4D(grad_tensor)
+#         original_shape_1 = input_tensor_1.shape
+#         input_tensor_1 = ttnn.unsqueeze_to_4D(input_tensor_1)
+#         original_shape_2 = input_tensor.shape_2
+#         input_tensor_2 = ttnn.unsqueeze_to_4D(input_tensor_2)
+#         output_tensor = ttl_binary_backward_function(grad_tensor, input_tensor_1, input_tensor_2, memory_config)
+#         # output_tensor = ttnn.reshape(output_tensor, original_shape)
+#         return output_tensor
+
+#     if isinstance(binary_backward_function, ttnn.decorators.Operation):
+#         binary_backward_function.__name__ = f"ttnn.{name}"
+#         binary_backward_function.decorated_function.__doc__ = doc + (
+#             binary_backward_function.__doc__ if binary_backward_function.__doc__ is not None else ""
+#         )
+
+#     setattr(THIS_MODULE, name, binary_backward_function)
+
+
+# TTL_BINARY_BACKWARD_FUNCTIONS = [
+#     (
+#         "atan2_bw",
+#         ttnn.operations.binary_backward,
+#         r"""atan2_bw(input_tensor_1: ttnn.Tensor, input_tensor_2: ttnn.Tensor) -> ttnn.Tensor
+
+#         Takes the atan2 backward of each element in input and returns a tensor with the result.
+
+#         .. math::
+#             pow(\mathrm{{input\_tensor}}_i, \mathrm{{exponent}})
+
+#         Args:
+#             * :attr:`input_tensor`
+#             * :attr:`exponent`
+
+#         Example::
+
+#             >>> tensor = ttnn.from_torch(torch.tensor((1, 2), dtype=torch.bfloat16), device=device)
+#             >>> output = ttnn.pow(tensor, 2)
+
+#         """,
+#     ),
+# ]
+
+
+# for binary_backward_function_name, ttl_binary_backward_function, doc in TTL_BINARY_BACKWARD_FUNCTIONS:
+#     register_ttl_binary_backward_function(binary_backward_function_name, ttl_binary_backward_function, doc)
+
+
+def _golden_function(grad_tensor, input_tensor_a, input_tensor_b, *args, **kwargs):
+    import torch
+
+    pyt_y = torch.atan2(input_tensor_a, input_tensor_b)
+    input_tensor_a.retain_grad()
+    input_tensor_b.retain_grad()
+
+    pyt_y.backward(gradient=grad_tensor)
+    return
+
+
+atan2_bw = ttnn.register_operation(golden_function=_golden_function)(ttnn._ttnn.operations.binary_backward.atan2_bw)
+
+__all__ = []

--- a/ttnn/ttnn/operations/binary_backward.py
+++ b/ttnn/ttnn/operations/binary_backward.py
@@ -114,4 +114,15 @@ def _golden_function(grad_tensor, input_tensor_a, input_tensor_b, *args, **kwarg
 
 atan2_bw = ttnn.register_operation(golden_function=_golden_function)(ttnn._ttnn.operations.binary_backward.atan2_bw)
 
+
+def _golden_function(grad_tensor, input_tensor, weight_tensor, *args, **kwargs):
+    import torch
+
+    return
+
+
+embedding_bw = ttnn.register_operation(golden_function=_golden_function)(
+    ttnn._ttnn.operations.binary_backward.embedding_bw
+)
+
 __all__ = []

--- a/ttnn/ttnn/operations/binary_backward.py
+++ b/ttnn/ttnn/operations/binary_backward.py
@@ -45,6 +45,21 @@ def _golden_function(grad_tensor, input_tensor_a, input_tensor_b, *args, **kwarg
 xlogy_bw = ttnn.register_operation(golden_function=_golden_function)(ttnn._ttnn.operations.binary_backward.xlogy_bw)
 
 
+def _golden_function(grad_tensor, input_tensor_a, input_tensor_b, *args, **kwargs):
+    import torch
+
+    pyt_y = torch.hypot(input_tensor_a, input_tensor_b)
+    input_tensor_a.retain_grad()
+    input_tensor_b.retain_grad()
+
+    pyt_y.backward(gradient=grad_tensor)
+    golden_tensor = [input_tensor_a.grad, input_tensor_b.grad]
+    return golden_tensor
+
+
+hypot_bw = ttnn.register_operation(golden_function=_golden_function)(ttnn._ttnn.operations.binary_backward.hypot_bw)
+
+
 def _golden_function(grad_tensor, input_tensor, weight_tensor, *args, **kwargs):
     import torch
 

--- a/ttnn/ttnn/operations/binary_backward.py
+++ b/ttnn/ttnn/operations/binary_backward.py
@@ -76,4 +76,30 @@ addalpha_bw = ttnn.register_operation(golden_function=_golden_function)(
     ttnn._ttnn.operations.binary_backward.addalpha_bw
 )
 
+
+def _golden_function(grad_tensor, input_tensor_a, input_tensor_b, *args, **kwargs):
+    import torch
+
+    pyt_y = torch.add(input_tensor_a, input_tensor_b, alpha=alpha)
+    pyt_y.backward(gradient=grad_tensor)
+    golden_tensor = [input_tensor_a.grad, input_tensor_b.grad]
+    return golden_tensor
+
+
+subalpha_bw = ttnn.register_operation(golden_function=_golden_function)(
+    ttnn._ttnn.operations.binary_backward.subalpha_bw
+)
+
+
+def _golden_function(grad_tensor, input_tensor_a, input_tensor_b, *args, **kwargs):
+    import torch
+
+    pyt_y = torch.add(input_tensor_a, input_tensor_b, alpha=alpha)
+    pyt_y.backward(gradient=grad_tensor)
+    golden_tensor = [input_tensor_a.grad, input_tensor_b.grad]
+    return golden_tensor
+
+
+sub_bw = ttnn.register_operation(golden_function=_golden_function)(ttnn._ttnn.operations.binary_backward.sub_bw)
+
 __all__ = []

--- a/ttnn/ttnn/operations/binary_backward.py
+++ b/ttnn/ttnn/operations/binary_backward.py
@@ -109,6 +109,23 @@ logaddexp2_bw = ttnn.register_operation(golden_function=_golden_function)(
 )
 
 
+def _golden_function(grad_tensor, input_tensor_a, input_tensor_b, *args, **kwargs):
+    import torch
+
+    pyt_y = torch.square(torch.sub(input_tensor_a, input_tensor_b))
+    input_tensor_a.retain_grad()
+    input_tensor_b.retain_grad()
+
+    pyt_y.backward(gradient=grad_tensor)
+    golden_tensor = [input_tensor_a.grad, input_tensor_b.grad]
+    return golden_tensor
+
+
+squared_difference_bw = ttnn.register_operation(golden_function=_golden_function)(
+    ttnn._ttnn.operations.binary_backward.squared_difference_bw
+)
+
+
 def _golden_function(grad_tensor, input_tensor, weight_tensor, *args, **kwargs):
     import torch
 

--- a/ttnn/ttnn/operations/binary_backward.py
+++ b/ttnn/ttnn/operations/binary_backward.py
@@ -75,6 +75,40 @@ def _golden_function(grad_tensor, input_tensor_a, input_tensor_b, *args, **kwarg
 ldexp_bw = ttnn.register_operation(golden_function=_golden_function)(ttnn._ttnn.operations.binary_backward.ldexp_bw)
 
 
+def _golden_function(grad_tensor, input_tensor_a, input_tensor_b, *args, **kwargs):
+    import torch
+
+    pyt_y = torch.logaddexp(input_tensor_a, input_tensor_b)
+    input_tensor_a.retain_grad()
+    input_tensor_b.retain_grad()
+
+    pyt_y.backward(gradient=grad_tensor)
+    golden_tensor = [input_tensor_a.grad, input_tensor_b.grad]
+    return golden_tensor
+
+
+logaddexp_bw = ttnn.register_operation(golden_function=_golden_function)(
+    ttnn._ttnn.operations.binary_backward.logaddexp_bw
+)
+
+
+def _golden_function(grad_tensor, input_tensor_a, input_tensor_b, *args, **kwargs):
+    import torch
+
+    pyt_y = torch.logaddexp2(input_tensor_a, input_tensor_b)
+    input_tensor_a.retain_grad()
+    input_tensor_b.retain_grad()
+
+    pyt_y.backward(gradient=grad_tensor)
+    golden_tensor = [input_tensor_a.grad, input_tensor_b.grad]
+    return golden_tensor
+
+
+logaddexp2_bw = ttnn.register_operation(golden_function=_golden_function)(
+    ttnn._ttnn.operations.binary_backward.logaddexp2_bw
+)
+
+
 def _golden_function(grad_tensor, input_tensor, weight_tensor, *args, **kwargs):
     import torch
 

--- a/ttnn/ttnn/operations/binary_backward.py
+++ b/ttnn/ttnn/operations/binary_backward.py
@@ -190,12 +190,25 @@ subalpha_bw = ttnn.register_operation(golden_function=_golden_function)(
 def _golden_function(grad_tensor, input_tensor_a, input_tensor_b, *args, **kwargs):
     import torch
 
-    pyt_y = torch.add(input_tensor_a, input_tensor_b, alpha=alpha)
+    pyt_y = torch.sub(input_tensor_a, input_tensor_b)
     pyt_y.backward(gradient=grad_tensor)
     golden_tensor = [input_tensor_a.grad, input_tensor_b.grad]
     return golden_tensor
 
 
 sub_bw = ttnn.register_operation(golden_function=_golden_function)(ttnn._ttnn.operations.binary_backward.sub_bw)
+
+
+def _golden_function(grad_tensor, input_tensor_a, input_tensor_b, *args, **kwargs):
+    import torch
+
+    pyt_y = torch.add(input_tensor_a, input_tensor_b)
+    pyt_y.backward(gradient=grad_tensor)
+    golden_tensor = [input_tensor_a.grad, input_tensor_b.grad]
+    return golden_tensor
+
+
+add_bw = ttnn.register_operation(golden_function=_golden_function)(ttnn._ttnn.operations.binary_backward.add_bw)
+
 
 __all__ = []

--- a/ttnn/ttnn/operations/binary_backward.py
+++ b/ttnn/ttnn/operations/binary_backward.py
@@ -15,92 +15,6 @@ THIS_MODULE = sys.modules[__name__]
 __all__ = []
 
 
-# def register_ttl_binary_backward_function(name, ttl_binary_backward_function, doc):
-#     def _golden_function(grad_tensor: ttnn.Tensor, input_tensor_1: ttnn.Tensor, input_tensor_2: ttnn.Tensor, **_):
-#         import torch
-
-#         pyt_y = torch.atan2(input_tensor_1, input_tensor_2)
-#         input_tensor_1.retain_grad()
-#         input_tensor_2.retain_grad()
-
-#         pyt_y.backward(gradient=grad_tensor)
-#         name_to_torch_function = {"atan2_bw": pyt_y}
-#         torch_function = name_to_torch_function[name]
-#         return torch_function(input_tensor_1, input_tensor_2)
-
-#     def _binary_backward_validate_input_tensors(operation_name, grad_tensor, input_tensor_1, input_tensor_2, *args, **kwargs):
-#         ttnn.validate_input_tensor(
-#             operation_name,
-#             grad_tensor,
-#             input_tensor_1,
-#             input_tensor_2,
-#             ranks=(2, 3, 4),
-#             dtypes=(ttnn.bfloat16, ttnn.bfloat8_b),
-#             layouts=(ttnn.TILE_LAYOUT,),
-#             can_be_on_device=True,
-#             can_be_on_cpu=False,
-#         )
-
-#     @ttnn.register_operation(
-#         name=f"ttnn.{name}",
-#         validate_input_tensors=_binary_backward_validate_input_tensors,
-#         golden_function=_golden_function,
-#     )
-#     def binary_backward_function(
-#         grad_tensor: ttnn.Tensor,
-#         input_tensor_1: ttnn.Tensor,
-#         input_tensor_2: ttnn.Tensor,
-#         *,
-#         memory_config: ttnn.MemoryConfig = ttnn.DRAM_MEMORY_CONFIG,
-#     ) -> ttnn.Tensor:
-#         original_shape = grad_tensor.shape
-#         grad_tensor = ttnn.unsqueeze_to_4D(grad_tensor)
-#         original_shape_1 = input_tensor_1.shape
-#         input_tensor_1 = ttnn.unsqueeze_to_4D(input_tensor_1)
-#         original_shape_2 = input_tensor.shape_2
-#         input_tensor_2 = ttnn.unsqueeze_to_4D(input_tensor_2)
-#         output_tensor = ttl_binary_backward_function(grad_tensor, input_tensor_1, input_tensor_2, memory_config)
-#         # output_tensor = ttnn.reshape(output_tensor, original_shape)
-#         return output_tensor
-
-#     if isinstance(binary_backward_function, ttnn.decorators.Operation):
-#         binary_backward_function.__name__ = f"ttnn.{name}"
-#         binary_backward_function.decorated_function.__doc__ = doc + (
-#             binary_backward_function.__doc__ if binary_backward_function.__doc__ is not None else ""
-#         )
-
-#     setattr(THIS_MODULE, name, binary_backward_function)
-
-
-# TTL_BINARY_BACKWARD_FUNCTIONS = [
-#     (
-#         "atan2_bw",
-#         ttnn.operations.binary_backward,
-#         r"""atan2_bw(input_tensor_1: ttnn.Tensor, input_tensor_2: ttnn.Tensor) -> ttnn.Tensor
-
-#         Takes the atan2 backward of each element in input and returns a tensor with the result.
-
-#         .. math::
-#             pow(\mathrm{{input\_tensor}}_i, \mathrm{{exponent}})
-
-#         Args:
-#             * :attr:`input_tensor`
-#             * :attr:`exponent`
-
-#         Example::
-
-#             >>> tensor = ttnn.from_torch(torch.tensor((1, 2), dtype=torch.bfloat16), device=device)
-#             >>> output = ttnn.pow(tensor, 2)
-
-#         """,
-#     ),
-# ]
-
-
-# for binary_backward_function_name, ttl_binary_backward_function, doc in TTL_BINARY_BACKWARD_FUNCTIONS:
-#     register_ttl_binary_backward_function(binary_backward_function_name, ttl_binary_backward_function, doc)
-
-
 def _golden_function(grad_tensor, input_tensor_a, input_tensor_b, *args, **kwargs):
     import torch
 
@@ -109,7 +23,8 @@ def _golden_function(grad_tensor, input_tensor_a, input_tensor_b, *args, **kwarg
     input_tensor_b.retain_grad()
 
     pyt_y.backward(gradient=grad_tensor)
-    return
+    golden_tensor = [input_tensor_a.grad, input_tensor_b.grad]
+    return golden_tensor
 
 
 atan2_bw = ttnn.register_operation(golden_function=_golden_function)(ttnn._ttnn.operations.binary_backward.atan2_bw)
@@ -145,6 +60,20 @@ def _golden_function(grad_tensor, input_tensor, weight_tensor, *args, **kwargs):
 
 embedding_bw = ttnn.register_operation(golden_function=_golden_function)(
     ttnn._ttnn.operations.binary_backward.embedding_bw
+)
+
+
+def _golden_function(grad_tensor, input_tensor_a, input_tensor_b, *args, **kwargs):
+    import torch
+
+    pyt_y = torch.add(input_tensor_a, input_tensor_b, alpha=alpha)
+    pyt_y.backward(gradient=grad_tensor)
+    golden_tensor = [input_tensor_a.grad, input_tensor_b.grad]
+    return golden_tensor
+
+
+addalpha_bw = ttnn.register_operation(golden_function=_golden_function)(
+    ttnn._ttnn.operations.binary_backward.addalpha_bw
 )
 
 __all__ = []


### PR DESCRIPTION
Binary Backward Issue : #9628 [Master issue : #9322 ]

### List of ops completed
- atan2_bw
- embedding_bw
- addalpha_bw ( without optional return support )
- add_bw ( without optional return support )
- sub_bw
- subalpha_bw ( without optional return support )
- hypot_bw 
- ldexp_bw
- logaddexp_bw 
- logaddexp2_bw 
- squared_difference_bw
- xlogy_bw 


**Structure**
```
ttnn
└── cpp
    └── ttnn
        └── operations
            └── ...
            └── eltwise
                └── binary
                └── binary_backward
                    ├── device
                    │   ├── binary_backward_op.cpp
                    │   ├── binary_backward_op.hpp
                    ├── binary_backward.hpp
                    └── binary_backward_pybind.hpp
```

**Issues with optional tensor**

- Regarding optional output tensor support, the return type for backward op required is `std::vector<std::optional<Tensor>>`. 
In current structure `execute_on_worker_thread` supports only ( from file : `ttnn/cpp/ttnn/decorators.hpp` )
Support for optional output tensor is in TODO - [ref](https://github.com/tenstorrent/tt-metal/blob/a7234fb67c09295cf1cbb155102e195b0b80cb32/ttnn/cpp/ttnn/decorators.hpp#L245)
```
static_assert(
    tt::stl::concepts::always_false_v<concrete_operation_t>,
    "Operation is expecting the execute_on_worker_thread method to return either a single Tensor or a "
    "vector of "
    "Tensor(s).");
```


**Test files**
- atan2_bw : `tests/tt_eager/python_api_testing/unit_testing/backward_ops/test_backward_atan2.py`
- embedding_bw : `tests/tt_eager/python_api_testing/unit_testing/backward_ops/test_backward_embedding.py`
- addalpha_bw : `tests/tt_eager/python_api_testing/unit_testing/backward_ops/test_backward_addalpha.py`
- add_bw : `tests/tt_eager/python_api_testing/unit_testing/backward_ops/test_backward_add.py`
- subalpha_bw : `tests/tt_eager/python_api_testing/unit_testing/backward_ops/test_backward_subalpha.py`
- sub_bw : `tests/tt_eager/python_api_testing/unit_testing/backward_ops/test_backward_sub.py`
- hypot_be : `tests/tt_eager/python_api_testing/unit_testing/backward_ops/test_backward_hypot.py`
- ldexp_bw : `tests/tt_eager/python_api_testing/unit_testing/backward_ops/test_backward_ldexp.py`
- logaddexp_bw : `tests/tt_eager/python_api_testing/unit_testing/backward_ops/test_backward_logaddexp.py`
- logaddexp2_bw : `tests/tt_eager/python_api_testing/unit_testing/backward_ops/test_backward_logaddexp2.py`
- squared_difference_bw : `tests/tt_eager/python_api_testing/unit_testing/backward_ops/test_backward_squared_difference.py`
- xlogy_bw : `tests/tt_eager/python_api_testing/unit_testing/backward_ops/test_backward_xlogy.py`

<img width="1282" alt="Screenshot 2024-06-25 at 4 48 06 PM" src="https://github.com/tenstorrent/tt-metal/assets/138196495/acc1948d-faf3-41c4-acbc-b65abb563c6b">

**CI :** 

- [All post-commit tests](https://github.com/tenstorrent/tt-metal/actions/runs/9689794349) - PASSED
- [[post-commit] Fast Dispatch unit tests](https://github.com/tenstorrent/tt-metal/actions/runs/9690000159) - PASSED
- [[post-commit] Slow Dispatch unit tests](https://github.com/tenstorrent/tt-metal/actions/runs/9689308163) - PASSED
- [post-commit] models tests
- Device perf regressions and output report
- Model perf regressions and output report
- Nightly fast dispatch tests