### PR TITLE
#9319: Use printf to safely print everything in github context to a JSON file and use the offending workflow to test it

### DIFF
--- a/.github/workflows/_produce-data.yaml
+++ b/.github/workflows/_produce-data.yaml
@@ -52,7 +52,6 @@ jobs:
       - name: Output github context values to file
         run: |
           printf "%s\n" "${{ toJSON(github) }}" > github_context.json
-          cat github_context.json
       - name: Create CSVs and show
         env:
           PYTHONPATH: ${{ github.workspace }}
@@ -61,3 +60,20 @@ jobs:
         run: ls -hal
       - name: Show CSVs output
         run: cat *.csv
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: cicd-data
+          path: |
+            *.csv
+      - name: Upload context data, even on failure
+        if: ${{ !cancelled() }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: context-data
+          path: |
+            if-no-files-found: warn
+            path: |
+              workflow.json
+              workflow_jobs.json
+              github_context.json

--- a/.github/workflows/_produce-data.yaml
+++ b/.github/workflows/_produce-data.yaml
@@ -11,6 +11,10 @@ on:
   workflow_run:
     workflows:
       - "All post-commit tests"
+      - "(T3K) T3000 demo tests"
+      - "(T3K) T3000 model perf tests"
+      - "(Single-card) Model perf tests"
+      - "(Single-card) Device perf tests"
     types:
       - completed
 

--- a/.github/workflows/_produce-data.yaml
+++ b/.github/workflows/_produce-data.yaml
@@ -3,6 +3,11 @@ name: "[internal] Produce data for external analysis"
 on:
   workflow_call:
   workflow_dispatch:
+    inputs:
+      test_workflow_run_id:
+        description: "Unique GitHub workflow run ID to use for data"
+        default: 9605916313
+        type: number
   workflow_run:
     workflows:
       - "All post-commit tests"
@@ -32,14 +37,13 @@ jobs:
         if: ${{ github.event_name == 'workflow_dispatch' }}
         env:
           GH_TOKEN: ${{ github.token }}
-          ALL_PC_TEST_ID: 9605916313
         run: |
           echo "[Info] Workflow run attempt"
-          gh api /repos/tenstorrent/tt-metal/actions/runs/$ALL_PC_TEST_ID/attempts/1
-          gh api /repos/tenstorrent/tt-metal/actions/runs/$ALL_PC_TEST_ID/attempts/1 > workflow.json
+          gh api /repos/tenstorrent/tt-metal/actions/runs/${{ inputs.test_workflow_run_id }}/attempts/1
+          gh api /repos/tenstorrent/tt-metal/actions/runs/${{ inputs.test_workflow_run_id }}/attempts/1 > workflow.json
           echo "[Info] Workflow run attempt jobs"
-          gh api --paginate /repos/tenstorrent/tt-metal/actions/runs/$ALL_PC_TEST_ID/attempts/1/jobs
-          gh api --paginate /repos/tenstorrent/tt-metal/actions/runs/$ALL_PC_TEST_ID/attempts/1/jobs > workflow_jobs.json
+          gh api --paginate /repos/tenstorrent/tt-metal/actions/runs/${{ inputs.test_workflow_run_id }}/attempts/1/jobs
+          gh api --paginate /repos/tenstorrent/tt-metal/actions/runs/${{ inputs.test_workflow_run_id }}/attempts/1/jobs > workflow_jobs.json
       - name: Output auxiliary values (workflow_run completed)
         if: ${{ github.event_name == 'workflow_run' }}
         env:

--- a/.github/workflows/_produce-data.yaml
+++ b/.github/workflows/_produce-data.yaml
@@ -32,7 +32,7 @@ jobs:
         if: ${{ github.event_name == 'workflow_dispatch' }}
         env:
           GH_TOKEN: ${{ github.token }}
-          ALL_PC_TEST_ID: 9470068019
+          ALL_PC_TEST_ID: 9605916313
         run: |
           echo "[Info] Workflow run attempt"
           gh api /repos/tenstorrent/tt-metal/actions/runs/$ALL_PC_TEST_ID/attempts/1
@@ -51,7 +51,7 @@ jobs:
           gh api --paginate /repos/tenstorrent/tt-metal/actions/runs/${{ github.event.workflow_run.id }}/attempts/${{ github.event.workflow_run.run_attempt }}/jobs > workflow_jobs.json
       - name: Output github context values to file
         run: |
-          echo '${{ toJSON(github) }}' > github_context.json
+          printf "%s\n" "${{ toJSON(github) }}" > github_context.json
           cat github_context.json
       - name: Create CSVs and show
         env:

--- a/.github/workflows/_produce-data.yaml
+++ b/.github/workflows/_produce-data.yaml
@@ -60,12 +60,6 @@ jobs:
         run: ls -hal
       - name: Show CSVs output
         run: cat *.csv
-      - name: Upload artifacts
-        uses: actions/upload-artifact@v4
-        with:
-          name: cicd-data
-          path: |
-            *.csv
       - name: Upload context data, even on failure
         if: ${{ !cancelled() }}
         uses: actions/upload-artifact@v4

--- a/.github/workflows/_produce-data.yaml
+++ b/.github/workflows/_produce-data.yaml
@@ -51,7 +51,7 @@ jobs:
           gh api --paginate /repos/tenstorrent/tt-metal/actions/runs/${{ github.event.workflow_run.id }}/attempts/${{ github.event.workflow_run.run_attempt }}/jobs > workflow_jobs.json
       - name: Output github context values to file
         run: |
-          printf "%s\n" "${{ toJSON(github) }}" > github_context.json
+          echo '${{ toJSON(github) }}' > github_context.json
       - name: Create CSVs and show
         env:
           PYTHONPATH: ${{ github.workspace }}

--- a/.github/workflows/t3000-demo-tests.yaml
+++ b/.github/workflows/t3000-demo-tests.yaml
@@ -1,4 +1,4 @@
-name: "[T3K] T3000 demo tests"
+name: "(T3K) T3000 demo tests"
 
 on:
   workflow_dispatch:

--- a/.github/workflows/t3000-model-perf-tests.yaml
+++ b/.github/workflows/t3000-model-perf-tests.yaml
@@ -1,4 +1,4 @@
-name: "[T3K] T3000 model perf tests"
+name: "(T3K) T3000 model perf tests"
 
 on:
   workflow_dispatch:
@@ -18,16 +18,16 @@ jobs:
       matrix:
         test-group: [
           {
-            name: "T3000 LLM model perf tests", 
+            name: "T3000 LLM model perf tests",
             model-type: "LLM",
-            arch: wormhole_b0, 
+            arch: wormhole_b0,
             runs-on: [arch-wormhole_b0, "config-t3000", "in-service", "runner-test", "bare-metal", "pipeline-perf"],
             cmd: './tests/scripts/run_tests.sh --tt-arch wormhole_b0 --pipeline-type llm_model_perf_t3000_device --dispatch-mode ""'
           },
           {
-            name: "T3000 CNN model perf tests", 
+            name: "T3000 CNN model perf tests",
             model-type: "CNN",
-            arch: wormhole_b0, 
+            arch: wormhole_b0,
             runs-on: [arch-wormhole_b0, "config-t3000", "in-service", "runner-test", "bare-metal", "pipeline-perf"],
             cmd: './tests/scripts/run_tests.sh --tt-arch wormhole_b0 --pipeline-type cnn_model_perf_t3000_device --dispatch-mode ""'
           },

--- a/infra/data_collection/github/utils.py
+++ b/infra/data_collection/github/utils.py
@@ -115,11 +115,16 @@ def return_first_string_starts_with(starting_string, strings):
 def get_job_row_from_github_job(github_job):
     github_job_id = github_job["id"]
 
+    logger.info(f"Processing github job with ID {github_job_id}")
+
     host_name = github_job["runner_name"]
 
     labels = github_job["labels"]
 
-    if "GitHub Actions " in host_name:
+    if not host_name:
+        logger.debug("Detected null host_name, so will return null host_location")
+        host_location = None
+    elif "GitHub Actions " in host_name:
         host_location = "github"
     else:
         host_location = "tt_cloud"


### PR DESCRIPTION
…

### Ticket

#9319 

### Problem description

Certain commit message broke the data generation pipeline.

### What's changed

We use printf instead because it more reliable prints characters via terminal.

### Checklist
- [ ] Post commit CI passes
- [ ] Model regression CI testing passes (if applicable)
- [ ] New/Existing tests provide coverage for changes
