### PR TITLE
#0: Get rid of extra 3 dash line for YAML file in eager package main workflow and apply Boris to only top level models folder

### DIFF
--- a/.github/workflows/eager-package-main.yaml
+++ b/.github/workflows/eager-package-main.yaml
@@ -1,4 +1,3 @@
----
 name: "[post-commit] Python wheel build and test"
 
 on:

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -135,7 +135,7 @@ ttnn/CMakeLists.txt @tt-rkim
 tests/ttnn/ @eyonland @arakhmati @cfjchu @xanderchin @TT-BrianLiu
 
 # models
-models/ @boris-drazic
+/models/ @boris-drazic
 models/conv_on_device_utils*.py @tt-nshanker
 models/bert_large_performant @tt-aho @TT-BrianLiu
 models/metal_BERT_large_11 @tt-aho @TT-BrianLiu


### PR DESCRIPTION
…
### Ticket

Small workflow changes and cleaning up CODEOWNERS so that it doesn't unnecessarily match test files.

### Problem description

1) We're doing some workflow naming cleanup in order to enable data forwarding to our data team. This will allow us to trigger off workflow runs.
2) @boris-drazic needs to review too many files. We may reduce his load further.

### What's changed

- Got rid of `---` in eager package main
- Specify root-level `/models/` folder so CODEOWNERS only targets top-level folder

### Checklist
- [x] Post commit CI passes
- [x] Model regression CI testing passes (if applicable)
- [x] New/Existing tests provide coverage for changes
