### PR TITLE
#9492: Move matmul program configs to ttnn in tests

### DIFF
--- a/tests/tt_eager/python_api_testing/trace_testing/misc/test_bert_ops.py
+++ b/tests/tt_eager/python_api_testing/trace_testing/misc/test_bert_ops.py
@@ -5,6 +5,7 @@
 import pytest
 import torch
 import math
+import ttnn
 
 import tt_lib as ttl
 
@@ -119,7 +120,7 @@ def test_bert_linear(
         bias, device, tt_memory_config=interleaved_mem_config_L1, tt_dtype=ttl.tensor.DataType.BFLOAT8_B
     )[0]
 
-    program_config = ttl.operations.primary.MatmulMultiCoreReuseMultiCastProgramConfig(
+    program_config = ttnn.MatmulMultiCoreReuseMultiCastProgramConfig(
         compute_with_storage_grid_size=grid_size,
         in0_block_w=in0_block_w,
         out_subblock_h=out_subblock_h,
@@ -148,20 +149,20 @@ def test_bert_linear(
             in0_t = ttl.tensor.clone(in0_t_res, interleaved_mem_config_L1)
 
         if has_bias:
-            output_t = ttl.operations.primary.matmul(
+            output_t = ttnn.linear(
                 in0_t,
                 in1_t,
                 bias=bias_t,
                 program_config=program_config,
-                output_mem_config=output_mem_config,
+                memory_config=output_mem_config,
                 compute_kernel_config=compute_kernel_config,
             )
         else:
-            output_t = ttl.operations.primary.matmul(
+            output_t = ttnn.matmul(
                 in0_t,
                 in1_t,
                 program_config=program_config,
-                output_mem_config=output_mem_config,
+                memory_config=output_mem_config,
                 compute_kernel_config=compute_kernel_config,
             )
         if out_sharded:

--- a/tests/tt_eager/python_api_testing/unit_testing/misc/test_bert_ops.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/misc/test_bert_ops.py
@@ -5,6 +5,7 @@
 import pytest
 import torch
 import math
+import ttnn
 
 import tt_lib as ttl
 from tests.tt_eager.python_api_testing.sweep_tests import (
@@ -167,7 +168,7 @@ def test_bert_linear(
             ttl.tensor.ShardOrientation.COL_MAJOR,
         )
 
-    program_config = ttl.operations.primary.MatmulMultiCoreReuseMultiCastProgramConfig(
+    program_config = ttnn.MatmulMultiCoreReuseMultiCastProgramConfig(
         compute_with_storage_grid_size=grid_size,
         in0_block_w=in0_block_w,
         out_subblock_h=out_subblock_h,
@@ -182,20 +183,20 @@ def test_bert_linear(
     compute_kernel_config = ttl.tensor.GrayskullComputeKernelConfig(math_fidelity=fidelity, math_approx_mode=True)
 
     if has_bias:
-        output_t = ttl.operations.primary.matmul(
+        output_t = ttnn.linear(
             in0_t,
             in1_t,
             bias=bias_t,
             program_config=program_config,
-            output_mem_config=output_mem_config,
+            memory_config=output_mem_config,
             compute_kernel_config=compute_kernel_config,
         )
     else:
-        output_t = ttl.operations.primary.matmul(
+        output_t = ttnn.matmul(
             in0_t,
             in1_t,
             program_config=program_config,
-            output_mem_config=output_mem_config,
+            memory_config=output_mem_config,
             compute_kernel_config=compute_kernel_config,
         )
 
@@ -364,7 +365,7 @@ def test_bert_linear_batch7(
             ttl.tensor.ShardOrientation.ROW_MAJOR,
         )
 
-    program_config = ttl.operations.primary.MatmulMultiCoreReuseMultiCastProgramConfig(
+    program_config = ttnn.MatmulMultiCoreReuseMultiCastProgramConfig(
         compute_with_storage_grid_size=grid_size,
         in0_block_w=in0_block_w,
         out_subblock_h=out_subblock_h,
@@ -383,20 +384,20 @@ def test_bert_linear_batch7(
     )
 
     if has_bias:
-        output_t = ttl.operations.primary.matmul(
+        output_t = ttnn.linear(
             in0_t,
             in1_t,
             bias=bias_t,
             program_config=program_config,
-            output_mem_config=output_mem_config,
+            memory_config=output_mem_config,
             compute_kernel_config=compute_kernel_config,
         )
     else:
-        output_t = ttl.operations.primary.matmul(
+        output_t = ttnn.matmul(
             in0_t,
             in1_t,
             program_config=program_config,
-            output_mem_config=output_mem_config,
+            memory_config=output_mem_config,
             compute_kernel_config=compute_kernel_config,
         )
 
@@ -498,7 +499,7 @@ def run_bert_linear_batch4(
             ttl.tensor.ShardOrientation.ROW_MAJOR,
         )
 
-    program_config = ttl.operations.primary.MatmulMultiCoreReuseMultiCastProgramConfig(
+    program_config = ttnn.MatmulMultiCoreReuseMultiCastProgramConfig(
         compute_with_storage_grid_size=grid_size,
         in0_block_w=in0_block_w,
         out_subblock_h=out_subblock_h,
@@ -517,20 +518,20 @@ def run_bert_linear_batch4(
     )
 
     if has_bias:
-        output_t = ttl.operations.primary.matmul(
+        output_t = ttnn.linear(
             in0_t,
             in1_t,
             bias=bias_t,
             program_config=program_config,
-            output_mem_config=output_mem_config,
+            memory_config=output_mem_config,
             compute_kernel_config=compute_kernel_config,
         )
     else:
-        output_t = ttl.operations.primary.matmul(
+        output_t = ttnn.matmul(
             in0_t,
             in1_t,
             program_config=program_config,
-            output_mem_config=output_mem_config,
+            memory_config=output_mem_config,
             compute_kernel_config=compute_kernel_config,
         )
 
@@ -733,7 +734,7 @@ def test_bert_linear_batch4_fp32_input_output(
         bias, device, tt_memory_config=interleaved_mem_config_DRAM, tt_dtype=ttl.tensor.DataType.FLOAT32
     )[0]
 
-    program_config = ttl.operations.primary.MatmulMultiCoreReuseMultiCastProgramConfig(
+    program_config = ttnn.MatmulMultiCoreReuseMultiCastProgramConfig(
         compute_with_storage_grid_size=grid_size,
         in0_block_w=in0_block_w,
         out_subblock_h=out_subblock_h,
@@ -752,20 +753,20 @@ def test_bert_linear_batch4_fp32_input_output(
     )
 
     if has_bias:
-        output_t = ttl.operations.primary.matmul(
+        output_t = ttnn.linear(
             in0_t,
             in1_t,
             bias=bias_t,
             program_config=program_config,
-            output_mem_config=output_mem_config,
+            memory_config=output_mem_config,
             compute_kernel_config=compute_kernel_config,
         )
     else:
-        output_t = ttl.operations.primary.matmul(
+        output_t = ttnn.matmul(
             in0_t,
             in1_t,
             program_config=program_config,
-            output_mem_config=output_mem_config,
+            memory_config=output_mem_config,
             compute_kernel_config=compute_kernel_config,
         )
 

--- a/tests/tt_eager/python_api_testing/unit_testing/misc/test_matmul.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/misc/test_matmul.py
@@ -8,6 +8,7 @@ import tt_lib as ttl
 from models.utility_functions import is_wormhole_b0, is_grayskull
 from models.utility_functions import torch2tt_tensor, tt2torch_tensor, pad_by_zero, roundup32
 import torch
+import ttnn
 from tests.tt_eager.python_api_testing.sweep_tests.comparison_funcs import (
     comp_equal,
     comp_pcc,
@@ -78,7 +79,7 @@ def test_matmul_1d_in0_batched(
 
         per_core_M = M // 32
 
-        program_config = ttl.operations.primary.MatmulMultiCoreReuseMultiCast1DProgramConfig(
+        program_config = ttnn.MatmulMultiCoreReuseMultiCast1DProgramConfig(
             compute_with_storage_grid_size=grid_size,
             in0_block_w=1,
             out_subblock_h=1,
@@ -89,13 +90,13 @@ def test_matmul_1d_in0_batched(
             fused_activation=None,
             mcast_in0=True,
         )
-        output_t = ttl.operations.primary.matmul_1d(
+        output_t = ttnn.linear(
             in0_t,
             in1_t,
             bias=bias_t,
             program_config=program_config,
-            output_mem_config=output_mem_config,
-            output_dtype=activations_dtype,
+            memory_config=output_mem_config,
+            dtype=activations_dtype,
         )
 
         in0_t.deallocate()
@@ -182,7 +183,7 @@ def test_matmul_1d_fp32_acc_l1(
 
         per_core_M = M // 32
 
-        program_config = ttl.operations.primary.MatmulMultiCoreReuseMultiCast1DProgramConfig(
+        program_config = ttnn.MatmulMultiCoreReuseMultiCast1DProgramConfig(
             compute_with_storage_grid_size=grid_size,
             in0_block_w=1,
             out_subblock_h=1,
@@ -201,13 +202,13 @@ def test_matmul_1d_fp32_acc_l1(
             packer_l1_acc=packer_l1_acc,
         )
 
-        output_t = ttl.operations.primary.matmul_1d(
+        output_t = ttnn.linear(
             in0_t,
             in1_t,
             bias=bias_t,
             program_config=program_config,
-            output_mem_config=output_mem_config,
-            output_dtype=activations_dtype,
+            memory_config=output_mem_config,
+            dtype=activations_dtype,
             compute_kernel_config=compute_kernel_config,
         )
         if out_sharded:
@@ -293,7 +294,7 @@ def test_matmul_no_mcast_fp32_acc_l1(
                 ttl.tensor.ShardOrientation.COL_MAJOR,
             )
 
-        program_config = ttl.operations.primary.MatmulMultiCoreReuseProgramConfig(
+        program_config = ttnn.MatmulMultiCoreReuseProgramConfig(
             compute_with_storage_grid_size=grid_size,
             in0_block_w=K // 32,
             out_subblock_h=out_subblock_h,
@@ -309,12 +310,12 @@ def test_matmul_no_mcast_fp32_acc_l1(
             packer_l1_acc=packer_l1_acc,
         )
 
-        output_t = ttl.operations.primary.matmul(
+        output_t = ttnn.matmul(
             in0_t,
             in1_t,
             program_config=program_config,
-            output_mem_config=output_mem_config,
-            output_dtype=activations_dtype,
+            memory_config=output_mem_config,
+            dtype=activations_dtype,
             compute_kernel_config=compute_kernel_config,
         )
         if out_sharded:
@@ -405,7 +406,7 @@ def test_matmul_1d_fp32_input_output(
 
         per_core_M = M // 32
 
-        program_config = ttl.operations.primary.MatmulMultiCoreReuseMultiCast1DProgramConfig(
+        program_config = ttnn.MatmulMultiCoreReuseMultiCast1DProgramConfig(
             compute_with_storage_grid_size=grid_size,
             in0_block_w=1,
             out_subblock_h=1,
@@ -424,13 +425,13 @@ def test_matmul_1d_fp32_input_output(
             packer_l1_acc=packer_l1_acc,
         )
 
-        output_t = ttl.operations.primary.matmul_1d(
+        output_t = ttnn.linear(
             in0_t,
             in1_t,
             bias=bias_t,
             program_config=program_config,
-            output_mem_config=output_mem_config,
-            output_dtype=activations_dtype,
+            memory_config=output_mem_config,
+            dtype=activations_dtype,
             compute_kernel_config=compute_kernel_config,
         )
         if out_sharded:
@@ -522,7 +523,7 @@ def test_matmul_no_mcast_fp32_input_output(
                 ttl.tensor.ShardOrientation.COL_MAJOR,
             )
 
-        program_config = ttl.operations.primary.MatmulMultiCoreReuseProgramConfig(
+        program_config = ttnn.MatmulMultiCoreReuseProgramConfig(
             compute_with_storage_grid_size=grid_size,
             in0_block_w=K // 32,
             out_subblock_h=out_subblock_h,
@@ -538,12 +539,12 @@ def test_matmul_no_mcast_fp32_input_output(
             packer_l1_acc=packer_l1_acc,
         )
 
-        output_t = ttl.operations.primary.matmul(
+        output_t = ttnn.matmul(
             in0_t,
             in1_t,
             program_config=program_config,
-            output_mem_config=output_mem_config,
-            output_dtype=activations_dtype,
+            memory_config=output_mem_config,
+            dtype=activations_dtype,
             compute_kernel_config=compute_kernel_config,
         )
         if out_sharded:
@@ -640,7 +641,7 @@ def test_matmul_untilize_output(
                 ttl.tensor.ShardOrientation.COL_MAJOR,
             )
 
-        program_config = ttl.operations.primary.MatmulMultiCoreReuseProgramConfig(
+        program_config = ttnn.MatmulMultiCoreReuseProgramConfig(
             compute_with_storage_grid_size=grid_size,
             in0_block_w=K // 32,
             out_subblock_h=out_subblock_h,

--- a/tests/tt_eager/python_api_testing/unit_testing/misc/test_matmul_1d_2d.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/misc/test_matmul_1d_2d.py
@@ -5,6 +5,7 @@
 import pytest
 from loguru import logger
 import tt_lib as ttl
+import ttnn
 from models.utility_functions import is_wormhole_b0, is_grayskull, skip_for_wormhole_b0
 from models.utility_functions import torch2tt_tensor, tt2torch_tensor, pad_by_zero, roundup32
 import torch
@@ -136,7 +137,7 @@ def test_llama2_matmul(
             ttl.tensor.ShardOrientation.ROW_MAJOR,
         )
 
-    program_config = ttl.operations.primary.MatmulMultiCoreReuseMultiCast1DProgramConfig(
+    program_config = ttnn.MatmulMultiCoreReuseMultiCast1DProgramConfig(
         compute_with_storage_grid_size=grid_size,
         in0_block_w=in0_block_w,
         out_subblock_h=out_subblock_h,
@@ -155,12 +156,12 @@ def test_llama2_matmul(
         packer_l1_acc=packer_l1_acc,
     )
 
-    output_t = ttl.operations.primary.matmul_1d(
+    output_t = ttnn.matmul(
         in0_t,
         in1_t,
         program_config=program_config,
-        output_mem_config=output_mem_config,
-        output_dtype=ttl.tensor.DataType.BFLOAT8_B,
+        memory_config=output_mem_config,
+        dtype=ttl.tensor.DataType.BFLOAT8_B,
         compute_kernel_config=compute_kernel_config,
     )
     if out_sharded:
@@ -461,7 +462,7 @@ def test_multi_core_matmul_2d_wh(
             ttl.tensor.ShardOrientation.ROW_MAJOR,
         )
 
-    program_config = ttl.operations.primary.MatmulMultiCoreReuseMultiCastProgramConfig(
+    program_config = ttnn.MatmulMultiCoreReuseMultiCastProgramConfig(
         compute_with_storage_grid_size=grid_size,
         in0_block_w=in0_block_w,
         out_subblock_h=out_subblock_h,
@@ -479,11 +480,11 @@ def test_multi_core_matmul_2d_wh(
         packer_l1_acc=packer_l1_acc,
     )
 
-    output_t = ttl.operations.primary.matmul(
+    output_t = ttnn.matmul(
         in0_t,
         in1_t,
         program_config=program_config,
-        output_mem_config=output_mem_config,
+        memory_config=output_mem_config,
         compute_kernel_config=compute_kernel_config,
     )
 
@@ -788,7 +789,7 @@ def test_multi_core_matmul_1d_wh(
             ttl.tensor.ShardOrientation.ROW_MAJOR,
         )
 
-    program_config = ttl.operations.primary.MatmulMultiCoreReuseMultiCast1DProgramConfig(
+    program_config = ttnn.MatmulMultiCoreReuseMultiCast1DProgramConfig(
         compute_with_storage_grid_size=grid_size,
         in0_block_w=in0_block_w,
         out_subblock_h=out_subblock_h,
@@ -807,12 +808,12 @@ def test_multi_core_matmul_1d_wh(
         packer_l1_acc=packer_l1_acc,
     )
 
-    output_t = ttl.operations.primary.matmul_1d(
+    output_t = ttnn.matmul(
         in0_t,
         in1_t,
         program_config=program_config,
-        output_mem_config=output_mem_config,
-        output_dtype=dtype,
+        memory_config=output_mem_config,
+        dtype=dtype,
         compute_kernel_config=compute_kernel_config,
     )
     if out_sharded:
@@ -1000,7 +1001,7 @@ def test_multi_core_matmul_2d_gs(
             ttl.tensor.ShardOrientation.COL_MAJOR,
         )
 
-    program_config = ttl.operations.primary.MatmulMultiCoreReuseMultiCastProgramConfig(
+    program_config = ttnn.MatmulMultiCoreReuseMultiCastProgramConfig(
         compute_with_storage_grid_size=grid_size,
         in0_block_w=in0_block_w,
         out_subblock_h=out_subblock_h,
@@ -1014,20 +1015,20 @@ def test_multi_core_matmul_2d_gs(
     compute_kernel_config = ttl.tensor.GrayskullComputeKernelConfig(math_fidelity=fidelity, math_approx_mode=True)
 
     if has_bias:
-        output_t = ttl.operations.primary.matmul(
+        output_t = ttnn.linear(
             in0_t,
             in1_t,
             bias=bias_t,
             program_config=program_config,
-            output_mem_config=output_mem_config,
+            memory_config=output_mem_config,
             compute_kernel_config=compute_kernel_config,
         )
     else:
-        output_t = ttl.operations.primary.matmul(
+        output_t = ttnn.matmul(
             in0_t,
             in1_t,
             program_config=program_config,
-            output_mem_config=output_mem_config,
+            memory_config=output_mem_config,
             compute_kernel_config=compute_kernel_config,
         )
 
@@ -1160,7 +1161,7 @@ def test_multi_core_matmul_1d_gs(
             ttl.tensor.ShardOrientation.ROW_MAJOR,
         )
 
-    program_config = ttl.operations.primary.MatmulMultiCoreReuseMultiCast1DProgramConfig(
+    program_config = ttnn.MatmulMultiCoreReuseMultiCast1DProgramConfig(
         compute_with_storage_grid_size=grid_size,
         in0_block_w=in0_block_w,
         out_subblock_h=out_subblock_h,
@@ -1177,12 +1178,12 @@ def test_multi_core_matmul_1d_gs(
         math_approx_mode=True,
     )
 
-    output_t = ttl.operations.primary.matmul_1d(
+    output_t = ttnn.matmul(
         in0_t,
         in1_t,
         program_config=program_config,
-        output_mem_config=output_mem_config,
-        output_dtype=dtype,
+        memory_config=output_mem_config,
+        dtype=dtype,
         compute_kernel_config=compute_kernel_config,
     )
     if out_sharded:

--- a/tests/tt_eager/python_api_testing/unit_testing/misc/test_matmul_dram_sharded.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/misc/test_matmul_dram_sharded.py
@@ -8,6 +8,7 @@ import tt_lib as ttl
 from models.utility_functions import is_wormhole_b0, is_grayskull, skip_for_wormhole_b0
 from models.utility_functions import torch2tt_tensor, tt2torch_tensor, pad_by_zero, roundup32
 import torch
+import ttnn
 from tests.tt_eager.python_api_testing.sweep_tests.comparison_funcs import (
     comp_equal,
     comp_pcc,
@@ -144,7 +145,7 @@ def run_test_matmul_in1_dram_sharded(
         ttl.tensor.ShardOrientation.ROW_MAJOR,
     )
 
-    program_config = ttl.operations.primary.MatmulMultiCoreReuseMultiCastDRAMShardedProgramConfig(
+    program_config = ttnn.MatmulMultiCoreReuseMultiCastDRAMShardedProgramConfig(
         in0_block_w=in0_block_w // 4,
         per_core_M=out_block_h,
         per_core_N=out_block_w,
@@ -165,22 +166,22 @@ def run_test_matmul_in1_dram_sharded(
         )
 
     if has_bias:
-        output_t = ttl.operations.primary.matmul(
+        output_t = ttnn.linear(
             in0_t,
             in1_t,
             bias=bias_t,
             program_config=program_config,
-            output_mem_config=sharded_mem_config,
-            output_dtype=out_dtype,
+            memory_config=sharded_mem_config,
+            dtype=out_dtype,
             compute_kernel_config=compute_kernel_config,
         )
     else:
-        output_t = ttl.operations.primary.matmul(
+        output_t = ttnn.matmul(
             in0_t,
             in1_t,
             program_config=program_config,
-            output_mem_config=sharded_mem_config,
-            output_dtype=out_dtype,
+            memory_config=sharded_mem_config,
+            dtype=out_dtype,
             compute_kernel_config=compute_kernel_config,
         )
     output_t = ttl.tensor.sharded_to_interleaved(output_t, interleaved_mem_config)
@@ -353,7 +354,7 @@ def run_test_matmul_in1_dram_sharded_mm_chain(
     )
     in1_t = torch2tt_tensor(in1, device, tt_memory_config=in1_mem_config, tt_dtype=in1_dtype)
 
-    program_config = ttl.operations.primary.MatmulMultiCoreReuseMultiCastDRAMShardedProgramConfig(
+    program_config = ttnn.MatmulMultiCoreReuseMultiCastDRAMShardedProgramConfig(
         in0_block_w=in0_block_w // 4,
         per_core_M=out_block_h,
         per_core_N=out_block_w,
@@ -374,22 +375,22 @@ def run_test_matmul_in1_dram_sharded_mm_chain(
         )
 
     # 1st mm
-    output_t = ttl.operations.primary.matmul(
+    output_t = ttnn.matmul(
         in0_t,
         in1_t,
         program_config=program_config,
-        output_mem_config=sharded_mem_config,
-        output_dtype=out_dtype,
+        memory_config=sharded_mem_config,
+        dtype=out_dtype,
         compute_kernel_config=compute_kernel_config,
     )
 
     for _ in range(200):
-        output_t = ttl.operations.primary.matmul(
+        output_t = ttnn.matmul(
             in0_t,
             in1_t,
             program_config=program_config,
-            output_mem_config=sharded_mem_config,
-            output_dtype=out_dtype,
+            memory_config=sharded_mem_config,
+            dtype=out_dtype,
             compute_kernel_config=compute_kernel_config,
         )
 
@@ -582,7 +583,7 @@ def test_matmul_2d_in1_dram_sharded(
             bias_padded, device, tt_memory_config=bias_mem_config, tt_dtype=ttl.tensor.DataType.BFLOAT16
         )
 
-    program_config = ttl.operations.primary.MatmulMultiCoreReuseMultiCastProgramConfig(
+    program_config = ttnn.MatmulMultiCoreReuseMultiCastProgramConfig(
         compute_with_storage_grid_size=grid_size,
         in0_block_w=in0_block_w,
         out_subblock_h=out_subblock_h,
@@ -606,20 +607,20 @@ def test_matmul_2d_in1_dram_sharded(
             packer_l1_acc=packer_l1_acc,
         )
     if has_bias:
-        output_t = ttl.operations.primary.matmul(
+        output_t = ttnn.linear(
             in0_t,
             in1_t,
             bias=bias_t,
             program_config=program_config,
-            output_mem_config=sharded_mem_config,
+            memory_config=sharded_mem_config,
             compute_kernel_config=compute_kernel_config,
         )
     else:
-        output_t = ttl.operations.primary.matmul(
+        output_t = ttnn.matmul(
             in0_t,
             in1_t,
             program_config=program_config,
-            output_mem_config=sharded_mem_config,
+            memory_config=sharded_mem_config,
             compute_kernel_config=compute_kernel_config,
         )
 

--- a/tests/tt_eager/python_api_testing/unit_testing/misc/test_resnet50_untilize_with_halo_and_conv.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/misc/test_resnet50_untilize_with_halo_and_conv.py
@@ -7,6 +7,7 @@ from loguru import logger
 import torch
 import pytest
 import tt_lib
+import ttnn
 from tests.tt_eager.python_api_testing.sweep_tests.comparison_funcs import comp_pcc
 from models.demos.resnet.tt.metalResnetBlock50 import (
     compute_conv_output_shape,
@@ -220,7 +221,7 @@ hardcoded_matmul_config_conv = {
             25088,
             64,
             64,
-        ): tt_lib.operations.primary.MatmulMultiCoreReuseMultiCast1DProgramConfig(
+        ): ttnn.MatmulMultiCoreReuseMultiCast1DProgramConfig(
             compute_with_storage_grid_size=(12, 9),
             in0_block_w=2,
             out_subblock_h=4,
@@ -235,7 +236,7 @@ hardcoded_matmul_config_conv = {
             25088,
             64,
             256,
-        ): tt_lib.operations.primary.MatmulMultiCoreReuseMultiCast1DProgramConfig(
+        ): ttnn.MatmulMultiCoreReuseMultiCast1DProgramConfig(
             compute_with_storage_grid_size=(12, 9),
             in0_block_w=2,
             out_subblock_h=1,
@@ -250,7 +251,7 @@ hardcoded_matmul_config_conv = {
             25088,
             256,
             64,
-        ): tt_lib.operations.primary.MatmulMultiCoreReuseMultiCast1DProgramConfig(
+        ): ttnn.MatmulMultiCoreReuseMultiCast1DProgramConfig(
             compute_with_storage_grid_size=(12, 9),
             in0_block_w=8,
             out_subblock_h=4,
@@ -265,7 +266,7 @@ hardcoded_matmul_config_conv = {
             25088,
             256,
             128,
-        ): tt_lib.operations.primary.MatmulMultiCoreReuseMultiCast1DProgramConfig(
+        ): ttnn.MatmulMultiCoreReuseMultiCast1DProgramConfig(
             compute_with_storage_grid_size=(12, 9),
             in0_block_w=8,
             out_subblock_h=2,
@@ -280,7 +281,7 @@ hardcoded_matmul_config_conv = {
             6272,
             128,
             512,
-        ): tt_lib.operations.primary.MatmulMultiCoreReuseMultiCast1DProgramConfig(
+        ): ttnn.MatmulMultiCoreReuseMultiCast1DProgramConfig(
             compute_with_storage_grid_size=(12, 9),
             in0_block_w=4,
             out_subblock_h=1,
@@ -295,7 +296,7 @@ hardcoded_matmul_config_conv = {
             6272,
             512,
             128,
-        ): tt_lib.operations.primary.MatmulMultiCoreReuseMultiCast1DProgramConfig(
+        ): ttnn.MatmulMultiCoreReuseMultiCast1DProgramConfig(
             compute_with_storage_grid_size=(12, 9),
             in0_block_w=16,
             out_subblock_h=2,
@@ -306,7 +307,7 @@ hardcoded_matmul_config_conv = {
             fused_activation=None,
             mcast_in0=False,
         ),
-        (6272, 512, 256): tt_lib.operations.primary.MatmulMultiCoreReuseMultiCastProgramConfig(
+        (6272, 512, 256): ttnn.MatmulMultiCoreReuseMultiCastProgramConfig(
             compute_with_storage_grid_size=(10, 8),
             in0_block_w=2,
             out_subblock_h=5,
@@ -316,7 +317,7 @@ hardcoded_matmul_config_conv = {
             transpose_mcast=True,
             fused_activation=None,
         ),
-        (1568, 256, 1024): tt_lib.operations.primary.MatmulMultiCoreReuseMultiCastProgramConfig(
+        (1568, 256, 1024): ttnn.MatmulMultiCoreReuseMultiCastProgramConfig(
             compute_with_storage_grid_size=(10, 8),
             in0_block_w=4,
             out_subblock_h=5,
@@ -326,7 +327,7 @@ hardcoded_matmul_config_conv = {
             transpose_mcast=True,
             fused_activation=None,
         ),
-        (1568, 1024, 256): tt_lib.operations.primary.MatmulMultiCoreReuseMultiCastProgramConfig(
+        (1568, 1024, 256): ttnn.MatmulMultiCoreReuseMultiCastProgramConfig(
             compute_with_storage_grid_size=(10, 8),
             in0_block_w=16,
             out_subblock_h=5,
@@ -336,7 +337,7 @@ hardcoded_matmul_config_conv = {
             transpose_mcast=True,
             fused_activation=None,
         ),
-        (1568, 1024, 512): tt_lib.operations.primary.MatmulMultiCoreReuseMultiCastProgramConfig(
+        (1568, 1024, 512): ttnn.MatmulMultiCoreReuseMultiCastProgramConfig(
             compute_with_storage_grid_size=(10, 8),
             in0_block_w=16,
             out_subblock_h=5,
@@ -346,7 +347,7 @@ hardcoded_matmul_config_conv = {
             transpose_mcast=True,
             fused_activation=None,
         ),
-        (1568, 1024, 512): tt_lib.operations.primary.MatmulMultiCoreReuseMultiCastProgramConfig(
+        (1568, 1024, 512): ttnn.MatmulMultiCoreReuseMultiCastProgramConfig(
             compute_with_storage_grid_size=(10, 8),
             in0_block_w=16,
             out_subblock_h=5,
@@ -356,7 +357,7 @@ hardcoded_matmul_config_conv = {
             transpose_mcast=True,
             fused_activation=None,
         ),
-        (416, 512, 2048): tt_lib.operations.primary.MatmulMultiCoreReuseMultiCastProgramConfig(
+        (416, 512, 2048): ttnn.MatmulMultiCoreReuseMultiCastProgramConfig(
             compute_with_storage_grid_size=(7, 8),
             in0_block_w=8,
             out_subblock_h=1,
@@ -366,7 +367,7 @@ hardcoded_matmul_config_conv = {
             transpose_mcast=True,
             fused_activation=None,
         ),
-        (416, 2048, 512): tt_lib.operations.primary.MatmulMultiCoreReuseMultiCastProgramConfig(
+        (416, 2048, 512): ttnn.MatmulMultiCoreReuseMultiCastProgramConfig(
             compute_with_storage_grid_size=(7, 8),
             in0_block_w=16,
             out_subblock_h=2,

--- a/tests/tt_eager/python_api_testing/unit_testing/misc/test_resnet50_untilize_with_halo_and_conv_v2.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/misc/test_resnet50_untilize_with_halo_and_conv_v2.py
@@ -7,6 +7,7 @@ from loguru import logger
 import torch
 import pytest
 import tt_lib
+import ttnn
 from tests.tt_eager.python_api_testing.sweep_tests.comparison_funcs import comp_pcc
 from models.demos.resnet.tt.metalResnetBlock50 import (
     compute_conv_output_shape,
@@ -227,7 +228,7 @@ hardcoded_matmul_config_conv = {
             25088,
             64,
             64,
-        ): tt_lib.operations.primary.MatmulMultiCoreReuseMultiCast1DProgramConfig(
+        ): ttnn.MatmulMultiCoreReuseMultiCast1DProgramConfig(
             compute_with_storage_grid_size=(12, 9),
             in0_block_w=2,
             out_subblock_h=4,
@@ -242,7 +243,7 @@ hardcoded_matmul_config_conv = {
             25088,
             64,
             256,
-        ): tt_lib.operations.primary.MatmulMultiCoreReuseMultiCast1DProgramConfig(
+        ): ttnn.MatmulMultiCoreReuseMultiCast1DProgramConfig(
             compute_with_storage_grid_size=(12, 9),
             in0_block_w=2,
             out_subblock_h=1,
@@ -257,7 +258,7 @@ hardcoded_matmul_config_conv = {
             25088,
             256,
             64,
-        ): tt_lib.operations.primary.MatmulMultiCoreReuseMultiCast1DProgramConfig(
+        ): ttnn.MatmulMultiCoreReuseMultiCast1DProgramConfig(
             compute_with_storage_grid_size=(12, 9),
             in0_block_w=8,
             out_subblock_h=4,
@@ -272,7 +273,7 @@ hardcoded_matmul_config_conv = {
             25088,
             256,
             128,
-        ): tt_lib.operations.primary.MatmulMultiCoreReuseMultiCast1DProgramConfig(
+        ): ttnn.MatmulMultiCoreReuseMultiCast1DProgramConfig(
             compute_with_storage_grid_size=(12, 9),
             in0_block_w=8,
             out_subblock_h=2,
@@ -287,7 +288,7 @@ hardcoded_matmul_config_conv = {
             6272,
             128,
             512,
-        ): tt_lib.operations.primary.MatmulMultiCoreReuseMultiCast1DProgramConfig(
+        ): ttnn.MatmulMultiCoreReuseMultiCast1DProgramConfig(
             compute_with_storage_grid_size=(12, 9),
             in0_block_w=4,
             out_subblock_h=1,
@@ -302,7 +303,7 @@ hardcoded_matmul_config_conv = {
             6272,
             512,
             128,
-        ): tt_lib.operations.primary.MatmulMultiCoreReuseMultiCast1DProgramConfig(
+        ): ttnn.MatmulMultiCoreReuseMultiCast1DProgramConfig(
             compute_with_storage_grid_size=(12, 9),
             in0_block_w=16,
             out_subblock_h=2,
@@ -313,7 +314,7 @@ hardcoded_matmul_config_conv = {
             fused_activation=None,
             mcast_in0=False,
         ),
-        (6272, 512, 256): tt_lib.operations.primary.MatmulMultiCoreReuseMultiCastProgramConfig(
+        (6272, 512, 256): ttnn.MatmulMultiCoreReuseMultiCastProgramConfig(
             compute_with_storage_grid_size=(10, 8),
             in0_block_w=2,
             out_subblock_h=5,
@@ -323,7 +324,7 @@ hardcoded_matmul_config_conv = {
             transpose_mcast=True,
             fused_activation=None,
         ),
-        (1568, 256, 1024): tt_lib.operations.primary.MatmulMultiCoreReuseMultiCastProgramConfig(
+        (1568, 256, 1024): ttnn.MatmulMultiCoreReuseMultiCastProgramConfig(
             compute_with_storage_grid_size=(10, 8),
             in0_block_w=4,
             out_subblock_h=5,
@@ -333,7 +334,7 @@ hardcoded_matmul_config_conv = {
             transpose_mcast=True,
             fused_activation=None,
         ),
-        (1568, 1024, 256): tt_lib.operations.primary.MatmulMultiCoreReuseMultiCastProgramConfig(
+        (1568, 1024, 256): ttnn.MatmulMultiCoreReuseMultiCastProgramConfig(
             compute_with_storage_grid_size=(10, 8),
             in0_block_w=16,
             out_subblock_h=5,
@@ -343,7 +344,7 @@ hardcoded_matmul_config_conv = {
             transpose_mcast=True,
             fused_activation=None,
         ),
-        (1568, 1024, 512): tt_lib.operations.primary.MatmulMultiCoreReuseMultiCastProgramConfig(
+        (1568, 1024, 512): ttnn.MatmulMultiCoreReuseMultiCastProgramConfig(
             compute_with_storage_grid_size=(10, 8),
             in0_block_w=16,
             out_subblock_h=5,
@@ -353,7 +354,7 @@ hardcoded_matmul_config_conv = {
             transpose_mcast=True,
             fused_activation=None,
         ),
-        (1568, 1024, 512): tt_lib.operations.primary.MatmulMultiCoreReuseMultiCastProgramConfig(
+        (1568, 1024, 512): ttnn.MatmulMultiCoreReuseMultiCastProgramConfig(
             compute_with_storage_grid_size=(10, 8),
             in0_block_w=16,
             out_subblock_h=5,
@@ -363,7 +364,7 @@ hardcoded_matmul_config_conv = {
             transpose_mcast=True,
             fused_activation=None,
         ),
-        (416, 512, 2048): tt_lib.operations.primary.MatmulMultiCoreReuseMultiCastProgramConfig(
+        (416, 512, 2048): ttnn.MatmulMultiCoreReuseMultiCastProgramConfig(
             compute_with_storage_grid_size=(7, 8),
             in0_block_w=8,
             out_subblock_h=1,
@@ -373,7 +374,7 @@ hardcoded_matmul_config_conv = {
             transpose_mcast=True,
             fused_activation=None,
         ),
-        (416, 2048, 512): tt_lib.operations.primary.MatmulMultiCoreReuseMultiCastProgramConfig(
+        (416, 2048, 512): ttnn.MatmulMultiCoreReuseMultiCastProgramConfig(
             compute_with_storage_grid_size=(7, 8),
             in0_block_w=16,
             out_subblock_h=2,

--- a/tests/tt_eager/python_api_testing/unit_testing/misc/test_sharded.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/misc/test_sharded.py
@@ -358,7 +358,7 @@ def test_height_sharded_matmul_1d_padding(device, M, K, N, num_cores):
         ttl.tensor.ShardOrientation.ROW_MAJOR,
     )
 
-    program_config = ttl.operations.primary.MatmulMultiCoreReuseMultiCast1DProgramConfig(
+    program_config = ttnn.MatmulMultiCoreReuseMultiCast1DProgramConfig(
         compute_with_storage_grid_size=grid_size,
         in0_block_w=K // 32,
         out_subblock_h=1,
@@ -370,13 +370,13 @@ def test_height_sharded_matmul_1d_padding(device, M, K, N, num_cores):
         mcast_in0=False,
     )
 
-    output_t = ttl.operations.primary.matmul_1d(
+    output_t = ttnn.linear(
         in0_t,
         in1_t,
         bias=None,
         program_config=program_config,
-        output_mem_config=sharded_mem_config,
-        output_dtype=ttl.tensor.DataType.BFLOAT16,
+        memory_config=sharded_mem_config,
+        dtype=ttl.tensor.DataType.BFLOAT16,
     )
 
     output_t = ttl.tensor.sharded_to_interleaved(output_t, interleaved_mem_config)
@@ -445,7 +445,7 @@ def test_sharded_matmul_1d_in1(
             ttl.tensor.ShardOrientation.ROW_MAJOR,
         )
 
-    program_config = ttl.operations.primary.MatmulMultiCoreReuseMultiCast1DProgramConfig(
+    program_config = ttnn.MatmulMultiCoreReuseMultiCast1DProgramConfig(
         compute_with_storage_grid_size=(12, 9),
         in0_block_w=K // 32,
         out_subblock_h=8 // (N // 32),
@@ -456,13 +456,13 @@ def test_sharded_matmul_1d_in1(
         fused_activation=None,
         mcast_in0=False,
     )
-    output_t = ttl.operations.primary.matmul_1d(
+    output_t = ttnn.linear(
         in0_t,
         in1_t,
         bias=bias_t,
         program_config=program_config,
-        output_mem_config=output_mem_config,
-        output_dtype=activations_dtype,
+        memory_config=output_mem_config,
+        dtype=activations_dtype,
     )
     if out_sharded:
         output_t = ttl.tensor.sharded_to_interleaved(output_t, interleaved_mem_config)
@@ -1126,7 +1126,7 @@ def test_sharded_matmul_2d(
             ttl.tensor.ShardOrientation.ROW_MAJOR,
         )
 
-    program_config = ttl.operations.primary.MatmulMultiCoreReuseMultiCastProgramConfig(
+    program_config = ttnn.MatmulMultiCoreReuseMultiCastProgramConfig(
         compute_with_storage_grid_size=grid_size,
         in0_block_w=1,
         out_subblock_h=1,
@@ -1136,13 +1136,13 @@ def test_sharded_matmul_2d(
         transpose_mcast=False,
         fused_activation=None,
     )
-    output_t = ttl.operations.primary.matmul(
+    output_t = ttnn.linear(
         in0_t,
         in1_t,
         bias=bias_t,
         program_config=program_config,
-        output_mem_config=output_mem_config,
-        output_dtype=activations_dtype,
+        memory_config=output_mem_config,
+        dtype=activations_dtype,
     )
     if out_sharded:
         output_t = ttl.tensor.sharded_to_interleaved(output_t, interleaved_mem_config)
@@ -1221,7 +1221,7 @@ def test_sharded_matmul_2d_in0_height_sharded_in1_width_sharded(
             ttl.tensor.ShardOrientation.ROW_MAJOR,
         )
 
-    program_config = ttl.operations.primary.MatmulMultiCoreReuseMultiCastProgramConfig(
+    program_config = ttnn.MatmulMultiCoreReuseMultiCastProgramConfig(
         compute_with_storage_grid_size=grid_size,
         in0_block_w=K // 32,
         out_subblock_h=1,
@@ -1232,13 +1232,13 @@ def test_sharded_matmul_2d_in0_height_sharded_in1_width_sharded(
         fused_activation=None,
     )
     output_mem_config = sharded_block_mem_config if out_sharded else interleaved_mem_config
-    output_t = ttl.operations.primary.matmul(
+    output_t = ttnn.linear(
         in0_t,
         in1_t,
         bias=bias_t,
         program_config=program_config,
-        output_mem_config=output_mem_config,
-        output_dtype=output_dtype,
+        memory_config=output_mem_config,
+        dtype=output_dtype,
     )
 
     if out_sharded:
@@ -1309,7 +1309,7 @@ def test_sharded_matmul_2d_transposed(
             ttl.tensor.ShardOrientation.COL_MAJOR,
         )
 
-    program_config = ttl.operations.primary.MatmulMultiCoreReuseMultiCastProgramConfig(
+    program_config = ttnn.MatmulMultiCoreReuseMultiCastProgramConfig(
         compute_with_storage_grid_size=grid_size,
         in0_block_w=1,
         out_subblock_h=1,
@@ -1319,13 +1319,13 @@ def test_sharded_matmul_2d_transposed(
         transpose_mcast=True,
         fused_activation=None,
     )
-    output_t = ttl.operations.primary.matmul(
+    output_t = ttnn.linear(
         in0_t,
         in1_t,
         bias=bias_t,
         program_config=program_config,
-        output_mem_config=output_mem_config,
-        output_dtype=activations_dtype,
+        memory_config=output_mem_config,
+        dtype=activations_dtype,
     )
     if out_sharded:
         output_t = ttl.tensor.sharded_to_interleaved(output_t, interleaved_mem_config)
@@ -1401,7 +1401,7 @@ def test_resharded_binary_to_matmul(device, function_level_defaults):
         ttl.tensor.TensorMemoryLayout.BLOCK_SHARDED,
         ttl.tensor.ShardOrientation.COL_MAJOR,
     )
-    program_config = ttl.operations.primary.MatmulMultiCoreReuseMultiCastProgramConfig(
+    program_config = ttnn.MatmulMultiCoreReuseMultiCastProgramConfig(
         compute_with_storage_grid_size=grid_size_matmul,
         in0_block_w=2,
         out_subblock_h=5,
@@ -1411,12 +1411,12 @@ def test_resharded_binary_to_matmul(device, function_level_defaults):
         transpose_mcast=True,
         fused_activation=None,
     )
-    output_matmul_t = ttl.operations.primary.matmul(
+    output_matmul_t = ttnn.linear(
         output_binary_t,
         weight_t,
         bias=bias_t,
         program_config=program_config,
-        output_mem_config=block_sharded_mem_config,
+        memory_config=block_sharded_mem_config,
     )
     output_matmul_t = ttl.tensor.sharded_to_interleaved(output_matmul_t, interleaved_mem_config)
 
@@ -1968,7 +1968,7 @@ def test_sharded_matmul_1d_in0(
             ttl.tensor.ShardOrientation.ROW_MAJOR,
         )
 
-    program_config = ttl.operations.primary.MatmulMultiCoreReuseMultiCast1DProgramConfig(
+    program_config = ttnn.MatmulMultiCoreReuseMultiCast1DProgramConfig(
         compute_with_storage_grid_size=grid_size,
         in0_block_w=2,
         out_subblock_h=1,
@@ -1979,13 +1979,13 @@ def test_sharded_matmul_1d_in0(
         fused_activation=None,
         mcast_in0=True,
     )
-    output_t = ttl.operations.primary.matmul_1d(
+    output_t = ttnn.linear(
         in0_t,
         in1_t,
         bias=bias_t,
         program_config=program_config,
-        output_mem_config=output_mem_config,
-        output_dtype=activations_dtype,
+        memory_config=output_mem_config,
+        dtype=activations_dtype,
     )
     if out_sharded:
         output_t = ttl.tensor.sharded_to_interleaved(output_t, interleaved_mem_config)
@@ -2042,7 +2042,7 @@ def test_sharded_matmul_1d_in1_wormhole(device, function_level_defaults):
         ttl.tensor.ShardOrientation.ROW_MAJOR,
     )
 
-    program_config = ttl.operations.primary.MatmulMultiCoreReuseMultiCast1DProgramConfig(
+    program_config = ttnn.MatmulMultiCoreReuseMultiCast1DProgramConfig(
         compute_with_storage_grid_size=grid_size,
         in0_block_w=K // 32,
         out_subblock_h=1,
@@ -2053,13 +2053,13 @@ def test_sharded_matmul_1d_in1_wormhole(device, function_level_defaults):
         fused_activation=None,
         mcast_in0=False,
     )
-    output_t = ttl.operations.primary.matmul_1d(
+    output_t = ttnn.linear(
         in0_t,
         in1_t,
         bias=bias_t,
         program_config=program_config,
-        output_mem_config=output_mem_config,
-        output_dtype=dtype,
+        memory_config=output_mem_config,
+        dtype=dtype,
     )
     output_t = ttl.tensor.sharded_to_interleaved(output_t, interleaved_mem_config)
     pt_out = in0 @ in1 + bias
@@ -2136,7 +2136,7 @@ def test_sharded_matmul_no_mcast(
             ttl.tensor.ShardOrientation.COL_MAJOR,
         )
 
-    program_config = ttl.operations.primary.MatmulMultiCoreReuseProgramConfig(
+    program_config = ttnn.MatmulMultiCoreReuseProgramConfig(
         compute_with_storage_grid_size=grid_size,
         in0_block_w=K // 32,
         out_subblock_h=out_subblock_h,
@@ -2145,12 +2145,12 @@ def test_sharded_matmul_no_mcast(
         per_core_N=N // 32,
     )
 
-    output_t = ttl.operations.primary.matmul(
+    output_t = ttnn.matmul(
         in0_t,
         in1_t,
         program_config=program_config,
-        output_mem_config=output_mem_config,
-        output_dtype=activations_dtype,
+        memory_config=output_mem_config,
+        dtype=activations_dtype,
     )
     if out_sharded:
         output_t = ttl.tensor.sharded_to_interleaved(output_t, interleaved_mem_config)

--- a/tests/ttnn/integration_tests/stable_diffusion/test_sharded_attention.py
+++ b/tests/ttnn/integration_tests/stable_diffusion/test_sharded_attention.py
@@ -138,7 +138,7 @@ def test_time_sharded_attnention_hwb(
             ttl.tensor.ShardOrientation.ROW_MAJOR,
         )
 
-        program_config = ttl.operations.primary.MatmulMultiCoreReuseMultiCastProgramConfig(
+        program_config = ttnn.MatmulMultiCoreReuseMultiCastProgramConfig(
             compute_with_storage_grid_size=grid_size,
             in0_block_w=K // 32,
             out_subblock_h=1,
@@ -149,12 +149,12 @@ def test_time_sharded_attnention_hwb(
             fused_activation=None,
         )
 
-        mm_slice = ttl.operations.primary.matmul(
+        mm_slice = ttnn.matmul(
             q_slice,
             k_slice,
             program_config=program_config,
-            output_mem_config=block_sharded_mem_config,
-            output_dtype=data_format,
+            memory_config=block_sharded_mem_config,
+            dtype=data_format,
             compute_kernel_config=compute_kernel_config,
         )
         # mmt = tt2torch_tensor(mm_slice)
@@ -194,7 +194,7 @@ def test_time_sharded_attnention_hwb(
         # print(message)
         # assert passed
 
-        program_config = ttl.operations.primary.MatmulMultiCoreReuseMultiCast1DProgramConfig(
+        program_config = ttnn.MatmulMultiCoreReuseMultiCast1DProgramConfig(
             compute_with_storage_grid_size=grid_size,
             in0_block_w=seq_len // 32,
             per_core_M=tiles_per_shard,
@@ -212,12 +212,12 @@ def test_time_sharded_attnention_hwb(
             output_mem_config=dram_interleaved_memory_config,
         )
 
-        mm_slice = ttl.operations.primary.matmul(
+        mm_slice = ttnn.matmul(
             mm_slice,
             v_slice,
             program_config=program_config,
-            output_mem_config=height_sharded_mem_config,
-            output_dtype=data_format,
+            memory_config=height_sharded_mem_config,
+            dtype=data_format,
             compute_kernel_config=compute_kernel_config,
         )
         v_slice.deallocate()
@@ -336,7 +336,7 @@ def test_time_sharded_attnention(
             ttl.tensor.TensorMemoryLayout.HEIGHT_SHARDED,
             ttl.tensor.ShardOrientation.ROW_MAJOR,
         )
-        program_config = ttl.operations.primary.MatmulMultiCoreReuseMultiCast1DProgramConfig(
+        program_config = ttnn.MatmulMultiCoreReuseMultiCast1DProgramConfig(
             compute_with_storage_grid_size=grid_size,
             in0_block_w=2,
             per_core_M=tiles_per_shard,
@@ -354,12 +354,12 @@ def test_time_sharded_attnention(
             (0, (i * heads_per_slice) + (heads_per_slice - 1), 63, seq_len - 1),
             output_mem_config=l1_interleaved_memory_config,
         )
-        mm_slice = ttl.operations.primary.matmul(
+        mm_slice = ttnn.matmul(
             slice,
             k_slice,
             program_config=program_config,
-            output_mem_config=height_sharded_memory_config,
-            output_dtype=data_format,
+            memory_config=height_sharded_memory_config,
+            dtype=data_format,
             compute_kernel_config=compute_kernel_config,
         )
         k_slice.deallocate()
@@ -374,7 +374,7 @@ def test_time_sharded_attnention(
 
         mm_slice = ttl.operations.primary.softmax_in_place(mm_slice, program_config=softmax_program_config)
 
-        program_config = ttl.operations.primary.MatmulMultiCoreReuseMultiCast1DProgramConfig(
+        program_config = ttnn.MatmulMultiCoreReuseMultiCast1DProgramConfig(
             compute_with_storage_grid_size=grid_size,
             in0_block_w=seq_len // 32,
             per_core_M=tiles_per_shard,
@@ -391,12 +391,12 @@ def test_time_sharded_attnention(
             (0, (i * heads_per_slice) + (heads_per_slice - 1), seq_len - 1, 63),
             output_mem_config=l1_interleaved_memory_config,
         )
-        mm_slice = ttl.operations.primary.matmul(
+        mm_slice = ttnn.matmul(
             mm_slice,
             v_slice,
             program_config=program_config,
-            output_mem_config=height_sharded_memory_config,
-            output_dtype=data_format,
+            memory_config=height_sharded_memory_config,
+            dtype=data_format,
             compute_kernel_config=compute_kernel_config,
         )
         v_slice.deallocate()
@@ -513,7 +513,7 @@ def test_cross_attnention(
         ttl.tensor.ShardOrientation.COL_MAJOR,
     )
 
-    program_config = ttl.operations.primary.MatmulMultiCoreReuseProgramConfig(
+    program_config = ttnn.MatmulMultiCoreReuseProgramConfig(
         compute_with_storage_grid_size=grid_size,
         in0_block_w=2,
         out_subblock_h=1,
@@ -530,12 +530,12 @@ def test_cross_attnention(
         packer_l1_acc=False,
     )
 
-    mm_slice = ttl.operations.primary.matmul(
+    mm_slice = ttnn.matmul(
         q_sharded,
         reference_key_layer_transposed,
         program_config=program_config,
-        output_mem_config=height_sharded_memory_config,
-        output_dtype=data_format,
+        memory_config=height_sharded_memory_config,
+        dtype=data_format,
         compute_kernel_config=compute_kernel_config,
     )
     q_sharded.deallocate()
@@ -597,7 +597,7 @@ def test_cross_attnention(
         fp32_dest_acc_en=False,
         packer_l1_acc=False,
     )
-    program_config = ttl.operations.primary.MatmulMultiCoreReuseProgramConfig(
+    program_config = ttnn.MatmulMultiCoreReuseProgramConfig(
         compute_with_storage_grid_size=grid_size,
         in0_block_w=kv_len // 32,
         out_subblock_h=1,
@@ -605,12 +605,12 @@ def test_cross_attnention(
         per_core_M=num_heads * seq_len // num_cores // 32,
         per_core_N=2,
     )
-    mm_slice = ttl.operations.primary.matmul(
+    mm_slice = ttnn.matmul(
         mm_slice,
         v_sharded,
         program_config=program_config,
-        output_mem_config=height_sharded_memory_config,
-        output_dtype=data_format,
+        memory_config=height_sharded_memory_config,
+        dtype=data_format,
         compute_kernel_config=compute_kernel_config,
     )
     v_sharded.deallocate()
@@ -712,7 +712,7 @@ def test_attention(
     M = num_heads * seq_len
     K = 64
     N = seq_len
-    program_config = ttl.operations.primary.MatmulMultiCoreReuseProgramConfig(
+    program_config = ttnn.MatmulMultiCoreReuseProgramConfig(
         compute_with_storage_grid_size=grid_size,
         in0_block_w=K // 32,
         out_subblock_h=1,
@@ -729,12 +729,12 @@ def test_attention(
         packer_l1_acc=False,
     )
 
-    mm_slice = ttl.operations.primary.matmul(
+    mm_slice = ttnn.matmul(
         q_sharded,
         reference_key_layer_transposed,
         program_config=program_config,
-        output_mem_config=height_sharded_memory_config,
-        output_dtype=data_format,
+        memory_config=height_sharded_memory_config,
+        dtype=data_format,
         compute_kernel_config=compute_kernel_config,
     )
     q_sharded.deallocate()
@@ -812,7 +812,7 @@ def test_attention(
         fp32_dest_acc_en=False,
         packer_l1_acc=False,
     )
-    program_config = ttl.operations.primary.MatmulMultiCoreReuseProgramConfig(
+    program_config = ttnn.MatmulMultiCoreReuseProgramConfig(
         compute_with_storage_grid_size=grid_size,
         in0_block_w=seq_len // 32,
         out_subblock_h=1,
@@ -821,12 +821,12 @@ def test_attention(
         per_core_N=2,
     )
     print(program_config)
-    mm_slice = ttl.operations.primary.matmul(
+    mm_slice = ttnn.matmul(
         mm_slice,
         v_sharded,
         program_config=program_config,
-        output_mem_config=height_sharded_memory_config,
-        output_dtype=data_format,
+        memory_config=height_sharded_memory_config,
+        dtype=data_format,
         compute_kernel_config=compute_kernel_config,
     )
     v_sharded.deallocate()
@@ -940,7 +940,7 @@ def test_q_and_kv(
     in0_block_h, in0_block_w, out_subblock_h, out_subblock_w, out_block_h, out_block_w = determine_blocking(
         M, K, N, grid_size
     )
-    program_config = ttnn.experimental.operations.primary.MatmulMultiCoreReuseMultiCastProgramConfig(
+    program_config = ttnn.MatmulMultiCoreReuseMultiCastProgramConfig(
         compute_with_storage_grid_size=grid_size,
         in0_block_w=in0_block_w,
         out_subblock_h=out_subblock_h,
@@ -957,12 +957,12 @@ def test_q_and_kv(
         fp32_dest_acc_en=False,
         packer_l1_acc=False,
     )
-    mm = ttl.operations.primary.matmul(
+    mm = ttnn.matmul(
         in_0_sharded if size != 4096 else in_0,
         in_1,
         program_config=program_config,
-        output_mem_config=block_sharded_memory_config,
-        output_dtype=ttnn.experimental.tensor.DataType.BFLOAT8_B,
+        memory_config=block_sharded_memory_config,
+        dtype=ttnn.experimental.tensor.DataType.BFLOAT8_B,
         compute_kernel_config=compute_kernel_config,
     )
     in_0_sharded.deallocate()
@@ -973,7 +973,7 @@ def test_q_and_kv(
     out_block_h = math.ceil(M / grid_size[1] / 32)
     out_block_w = math.ceil(N / grid_size[0] / 32)
     out_subblock_h, out_subblock_w = determine_largest_subblock_size(out_block_h, out_block_w)
-    program_config = ttnn.experimental.operations.primary.MatmulMultiCoreReuseMultiCastProgramConfig(
+    program_config = ttnn.MatmulMultiCoreReuseMultiCastProgramConfig(
         compute_with_storage_grid_size=grid_size,
         in0_block_w=in0_block_w,
         out_subblock_h=out_subblock_h,

--- a/tests/ttnn/integration_tests/stable_diffusion/test_sharded_matmuls.py
+++ b/tests/ttnn/integration_tests/stable_diffusion/test_sharded_matmuls.py
@@ -1699,7 +1699,7 @@ def test_matmul(
         assert fused_activation is None
 
     if program_config_type == "MatmulMultiCoreReuseMultiCastProgramConfig":
-        program_config = ttnn.experimental.operations.primary.MatmulMultiCoreReuseMultiCastProgramConfig(
+        program_config = ttnn.MatmulMultiCoreReuseMultiCastProgramConfig(
             compute_with_storage_grid_size=grid_size,
             in0_block_w=in0_block_w,
             out_subblock_h=out_subblock_h,
@@ -1710,7 +1710,7 @@ def test_matmul(
             fused_activation=fused_activation,
         )
     elif program_config_type == "MatmulMultiCoreReuseMultiCast1DProgramConfig":
-        program_config = ttnn.experimental.operations.primary.MatmulMultiCoreReuseMultiCast1DProgramConfig(
+        program_config = ttnn.MatmulMultiCoreReuseMultiCast1DProgramConfig(
             compute_with_storage_grid_size=grid_size,
             in0_block_w=in0_block_w,
             out_subblock_h=out_subblock_h,
@@ -1740,13 +1740,13 @@ def test_matmul(
             kernel_config=compute_kernel_config,
         )
     else:
-        out = ttnn.experimental.operations.primary.matmul(
+        out = ttnn.linear(
             in_0,
             in_1,
             bias=in_2 if bias else None,
             program_config=program_config,
-            output_mem_config=output_mem_config,
-            output_dtype=ttnn.experimental.tensor.DataType.BFLOAT8_B
+            memory_config=output_mem_config,
+            dtype=ttnn.experimental.tensor.DataType.BFLOAT8_B
             if output_dtype == "BFLOAT8_B"
             else ttnn.experimental.tensor.DataType.BFLOAT16,
             compute_kernel_config=compute_kernel_config,

--- a/tests/ttnn/sweep_tests/sweeps/sweeps/matmul/short/matmul_user_program_config.py
+++ b/tests/ttnn/sweep_tests/sweeps/sweeps/matmul/short/matmul_user_program_config.py
@@ -26,7 +26,7 @@ parameters = {
             (16,),
             (128, 128, 1024),
             False,
-            ttnn.experimental.operations.primary.MatmulMultiCoreReuseMultiCast1DProgramConfig(
+            ttnn.MatmulMultiCoreReuseMultiCast1DProgramConfig(
                 compute_with_storage_grid_size=(8, 4),
                 in0_block_w=1,
                 out_subblock_h=1,
@@ -46,7 +46,7 @@ parameters = {
             (2, 16),
             (384, 64, 128),
             True,
-            ttnn.experimental.operations.primary.MatmulMultiCoreReuseProgramConfig(
+            ttnn.MatmulMultiCoreReuseProgramConfig(
                 compute_with_storage_grid_size=(8, 4),
                 in0_block_w=2,  # K // 32
                 out_subblock_h=1,
@@ -81,7 +81,7 @@ parameters = {
             (4, 1),
             (1024, 64, 1024),
             True,
-            ttnn.experimental.operations.primary.MatmulMultiCoreReuseProgramConfig(
+            ttnn.MatmulMultiCoreReuseProgramConfig(
                 compute_with_storage_grid_size=(8, 4),
                 in0_block_w=2,  # K // 32
                 out_subblock_h=1,
@@ -107,7 +107,7 @@ parameters = {
             (1,),
             (63 * 32, 32, 32),
             False,
-            ttnn.experimental.operations.primary.MatmulMultiCoreReuseMultiCast1DProgramConfig(
+            ttnn.MatmulMultiCoreReuseMultiCast1DProgramConfig(
                 compute_with_storage_grid_size=(8, 4),
                 in0_block_w=1,  # K // 32
                 out_subblock_h=1,
@@ -136,7 +136,7 @@ parameters = {
             (1,),
             (8704, 64, 64),
             False,
-            ttnn.experimental.operations.primary.MatmulMultiCoreReuseMultiCast1DProgramConfig(
+            ttnn.MatmulMultiCoreReuseMultiCast1DProgramConfig(
                 compute_with_storage_grid_size=(8, 5),
                 in0_block_w=2,  # K // 32
                 out_subblock_h=4,  # 8 // (N // 32)
@@ -170,7 +170,7 @@ parameters = {
             (1,),
             (64, 2048, 1024),
             False,
-            ttnn.experimental.operations.primary.MatmulMultiCoreReuseMultiCast1DProgramConfig(
+            ttnn.MatmulMultiCoreReuseMultiCast1DProgramConfig(
                 compute_with_storage_grid_size=(8, 4),
                 in0_block_w=2,  # K // 32
                 out_subblock_h=1,
@@ -199,7 +199,7 @@ parameters = {
             (1,),
             (1600, 512, 1024),
             False,
-            ttnn.experimental.operations.primary.MatmulMultiCoreReuseMultiCastProgramConfig(
+            ttnn.MatmulMultiCoreReuseMultiCastProgramConfig(
                 compute_with_storage_grid_size=(8, 5),
                 in0_block_w=1,
                 out_subblock_h=1,
@@ -227,7 +227,7 @@ parameters = {
             (1,),
             (1600, 256, 512),
             False,
-            ttnn.experimental.operations.primary.MatmulMultiCoreReuseMultiCastProgramConfig(
+            ttnn.MatmulMultiCoreReuseMultiCastProgramConfig(
                 compute_with_storage_grid_size=(5, 4),
                 in0_block_w=1,
                 out_subblock_h=1,
@@ -255,7 +255,7 @@ parameters = {
             (1,),
             (192, 64, 384),
             False,
-            ttnn.experimental.operations.primary.MatmulMultiCoreReuseMultiCastProgramConfig(
+            ttnn.MatmulMultiCoreReuseMultiCastProgramConfig(
                 compute_with_storage_grid_size=(6, 6),
                 in0_block_w=2,  # K // 32
                 out_subblock_h=1,

--- a/tests/ttnn/sweep_tests/sweeps/sweeps/matmul/short/matmul_user_program_config_mcast_1d.py
+++ b/tests/ttnn/sweep_tests/sweeps/sweeps/matmul/short/matmul_user_program_config_mcast_1d.py
@@ -28,7 +28,7 @@ parameters = {
         (
             (1,),
             (64, 32 * 96, 32 * 96),
-            ttnn.experimental.operations.primary.MatmulMultiCoreReuseMultiCast1DProgramConfig(
+            ttnn.MatmulMultiCoreReuseMultiCast1DProgramConfig(
                 compute_with_storage_grid_size=(8, 4),
                 in0_block_w=1,
                 out_subblock_h=1,
@@ -54,7 +54,7 @@ parameters = {
         (
             (1,),
             (64, 28 * 96, 35 * 96),
-            ttnn.experimental.operations.primary.MatmulMultiCoreReuseMultiCast1DProgramConfig(
+            ttnn.MatmulMultiCoreReuseMultiCast1DProgramConfig(
                 compute_with_storage_grid_size=(8, 5),
                 in0_block_w=1,
                 out_subblock_h=1,
@@ -80,7 +80,7 @@ parameters = {
         (
             (1,),
             (64, 35 * 96, 28 * 96),
-            ttnn.experimental.operations.primary.MatmulMultiCoreReuseMultiCast1DProgramConfig(
+            ttnn.MatmulMultiCoreReuseMultiCast1DProgramConfig(
                 compute_with_storage_grid_size=(8, 5),
                 in0_block_w=1,
                 out_subblock_h=1,
@@ -106,7 +106,7 @@ parameters = {
         (
             (1,),
             (64, 28 * 96, 30 * 96),
-            ttnn.experimental.operations.primary.MatmulMultiCoreReuseMultiCast1DProgramConfig(
+            ttnn.MatmulMultiCoreReuseMultiCast1DProgramConfig(
                 compute_with_storage_grid_size=(8, 4),
                 in0_block_w=1,
                 out_subblock_h=1,
@@ -132,7 +132,7 @@ parameters = {
         (
             (1,),
             (64, 30 * 96, 28 * 96),
-            ttnn.experimental.operations.primary.MatmulMultiCoreReuseMultiCast1DProgramConfig(
+            ttnn.MatmulMultiCoreReuseMultiCast1DProgramConfig(
                 compute_with_storage_grid_size=(8, 4),
                 in0_block_w=1,
                 out_subblock_h=1,
@@ -161,7 +161,7 @@ parameters = {
         (
             (1,),
             (64, 96, 128),
-            ttnn.experimental.operations.primary.MatmulMultiCoreReuseMultiCast1DProgramConfig(
+            ttnn.MatmulMultiCoreReuseMultiCast1DProgramConfig(
                 compute_with_storage_grid_size=(1, 1),
                 in0_block_w=1,
                 out_subblock_h=1,
@@ -187,7 +187,7 @@ parameters = {
         (
             (1,),
             (64, 5 * 96, 128),
-            ttnn.experimental.operations.primary.MatmulMultiCoreReuseMultiCast1DProgramConfig(
+            ttnn.MatmulMultiCoreReuseMultiCast1DProgramConfig(
                 compute_with_storage_grid_size=(5, 1),
                 in0_block_w=1,
                 out_subblock_h=1,
@@ -213,7 +213,7 @@ parameters = {
         (
             (1,),
             (64, 96, 128),
-            ttnn.experimental.operations.primary.MatmulMultiCoreReuseMultiCast1DProgramConfig(
+            ttnn.MatmulMultiCoreReuseMultiCast1DProgramConfig(
                 compute_with_storage_grid_size=(1, 1),
                 in0_block_w=1,
                 out_subblock_h=1,

--- a/tests/ttnn/sweep_tests/sweeps/sweeps/matmul/short/matmul_user_program_config_mcast_2d.py
+++ b/tests/ttnn/sweep_tests/sweeps/sweeps/matmul/short/matmul_user_program_config_mcast_2d.py
@@ -24,7 +24,7 @@ parameters = {
         (
             (1,),
             (5 * 128, 7 * 64, 7 * 96),
-            ttnn.experimental.operations.primary.MatmulMultiCoreReuseMultiCastProgramConfig(
+            ttnn.MatmulMultiCoreReuseMultiCastProgramConfig(
                 compute_with_storage_grid_size=(7, 5),
                 in0_block_w=1,  # Modified by in0_block_w test parameter
                 out_subblock_h=1,
@@ -48,7 +48,7 @@ parameters = {
         (
             (1,),
             (5 * 128, 7 * 64, 7 * 96),
-            ttnn.experimental.operations.primary.MatmulMultiCoreReuseMultiCastProgramConfig(
+            ttnn.MatmulMultiCoreReuseMultiCastProgramConfig(
                 compute_with_storage_grid_size=(5, 7),
                 in0_block_w=1,  # Modified by in0_block_w test parameter
                 out_subblock_h=1,
@@ -73,7 +73,7 @@ parameters = {
         (
             (1,),
             (5 * 128, 4 * 64, 7 * 96),
-            ttnn.experimental.operations.primary.MatmulMultiCoreReuseMultiCastProgramConfig(
+            ttnn.MatmulMultiCoreReuseMultiCastProgramConfig(
                 compute_with_storage_grid_size=(7, 5),
                 in0_block_w=1,  # Modified by in0_block_w test parameter
                 out_subblock_h=1,
@@ -97,7 +97,7 @@ parameters = {
         (
             (1,),
             (5 * 128, 4 * 64, 7 * 96),
-            ttnn.experimental.operations.primary.MatmulMultiCoreReuseMultiCastProgramConfig(
+            ttnn.MatmulMultiCoreReuseMultiCastProgramConfig(
                 compute_with_storage_grid_size=(5, 7),
                 in0_block_w=1,  # Modified by in0_block_w test parameter
                 out_subblock_h=1,
@@ -122,7 +122,7 @@ parameters = {
         (
             (1,),
             (5 * 128, 7 * 64, 4 * 96),
-            ttnn.experimental.operations.primary.MatmulMultiCoreReuseMultiCastProgramConfig(
+            ttnn.MatmulMultiCoreReuseMultiCastProgramConfig(
                 compute_with_storage_grid_size=(7, 5),
                 in0_block_w=1,  # Modified by in0_block_w test parameter
                 out_subblock_h=1,
@@ -146,7 +146,7 @@ parameters = {
         (
             (1,),
             (5 * 128, 7 * 64, 4 * 96),
-            ttnn.experimental.operations.primary.MatmulMultiCoreReuseMultiCastProgramConfig(
+            ttnn.MatmulMultiCoreReuseMultiCastProgramConfig(
                 compute_with_storage_grid_size=(5, 7),
                 in0_block_w=1,  # Modified by in0_block_w test parameter
                 out_subblock_h=1,

--- a/tests/ttnn/unit_tests/operations/test_experimental.py
+++ b/tests/ttnn/unit_tests/operations/test_experimental.py
@@ -43,7 +43,7 @@ def test_ttnn_experimental_operations_primary_matmul(device, m_size, k_size, n_s
 
     input_tensor_a = ttnn.from_torch(torch_input_tensor_a, device=device, layout=ttnn.TILE_LAYOUT)
     input_tensor_b = ttnn.from_torch(torch_input_tensor_b, device=device, layout=ttnn.TILE_LAYOUT)
-    output_tensor = ttnn.experimental.operations.primary.matmul(input_tensor_a, input_tensor_b)
+    output_tensor = ttnn.matmul(input_tensor_a, input_tensor_b)
 
     output_tensor = ttnn.to_torch(output_tensor)
 
@@ -102,7 +102,7 @@ def test_ttnn_experimental_operations_primary_matmul_1d(
 
     output_memory_config = sharded_memory_config if output_is_sharded else interleaved_memory_config
 
-    program_config = ttnn.experimental.operations.primary.MatmulMultiCoreReuseMultiCast1DProgramConfig(
+    program_config = ttnn.MatmulMultiCoreReuseMultiCast1DProgramConfig(
         compute_with_storage_grid_size=(12, 9),
         in0_block_w=k_size // 32,
         out_subblock_h=8 // (n_size // 32),
@@ -151,7 +151,7 @@ def test_ttnn_experimental_operations_primary_matmul_1d(
                 ttnn.experimental.tensor.ShardOrientation.ROW_MAJOR,
             )
 
-        output_tensor = ttnn.experimental.operations.primary.matmul_1d(
+        output_tensor = ttnn.linear(
             input_tensor_a,
             input_tensor_b,
             bias=bias,
@@ -215,7 +215,7 @@ def test_ttnn_experimental_operations_primary_matmul_dram_sharded(device, m_size
         memory_config=in1_mem_config,
     )
 
-    program_config = ttnn.experimental.operations.primary.MatmulMultiCoreReuseMultiCastDRAMShardedProgramConfig(
+    program_config = ttnn.MatmulMultiCoreReuseMultiCastDRAMShardedProgramConfig(
         in0_block_w=32,
         per_core_M=1,
         per_core_N=4,

--- a/tests/ttnn/unit_tests/operations/test_experimental.py
+++ b/tests/ttnn/unit_tests/operations/test_experimental.py
@@ -156,8 +156,8 @@ def test_ttnn_experimental_operations_primary_matmul_1d(
             input_tensor_b,
             bias=bias,
             program_config=program_config,
-            output_mem_config=output_memory_config,
-            output_dtype=input_a_dtype,
+            memory_config=output_memory_config,
+            dtype=input_a_dtype,
         )
         if output_is_sharded:
             output_tensor = ttnn.experimental.tensor.sharded_to_interleaved(output_tensor, interleaved_memory_config)

--- a/ttnn/cpp/ttnn/operations/matmul.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul.cpp
@@ -35,11 +35,11 @@ bool is_input_batched(const ttnn::Shape& shape) {
 const std::array<ttnn::TensorSchema, 3> input_tensor_schemas() {
     return {
         ttnn::TensorSchema{
-            2, 4, {ttnn::bfloat16, ttnn::bfloat8_b, ttnn::bfloat4_b}, {ttnn::TILE_LAYOUT}, true, false, true, false},
+            2, 4, {ttnn::float32, ttnn::bfloat16, ttnn::bfloat8_b, ttnn::bfloat4_b}, {ttnn::TILE_LAYOUT}, true, false, true, false},
         ttnn::TensorSchema{
-            2, 4, {ttnn::bfloat16, ttnn::bfloat8_b, ttnn::bfloat4_b}, {ttnn::TILE_LAYOUT}, true, false, true, false},
+            2, 4, {ttnn::float32, ttnn::bfloat16, ttnn::bfloat8_b, ttnn::bfloat4_b}, {ttnn::TILE_LAYOUT}, true, false, true, false},
         ttnn::TensorSchema{
-            2, 4, {ttnn::bfloat16, ttnn::bfloat8_b, ttnn::bfloat4_b}, {ttnn::TILE_LAYOUT}, true, false, true, true}};
+            2, 4, {ttnn::float32, ttnn::bfloat16, ttnn::bfloat8_b, ttnn::bfloat4_b}, {ttnn::TILE_LAYOUT}, true, false, true, true}};
 }
 
 std::optional<UnaryWithParam> get_fused_activation(const std::optional<const std::string>& activation) {
@@ -60,9 +60,9 @@ ttnn::Tensor matmul(
     const std::optional<const DeviceComputeKernelConfig> compute_kernel_config,
     const std::optional<const ttnn::CoreGrid> core_grid,
     const bool propagate_is_b_batched) {
-    ttnn::validate_input_tensor("ttnn.linear", input_tensor_a, input_tensor_schemas()[0]);
-    ttnn::validate_input_tensor("ttnn.linear", input_tensor_b, input_tensor_schemas()[1]);
-    ttnn::validate_input_tensor("ttnn.linear", bias, input_tensor_schemas()[2]);
+    ttnn::validate_input_tensor("ttnn.matmul", input_tensor_a, input_tensor_schemas()[0]);
+    ttnn::validate_input_tensor("ttnn.matmul", input_tensor_b, input_tensor_schemas()[1]);
+    ttnn::validate_input_tensor("ttnn.matmul", bias, input_tensor_schemas()[2]);
 
     const auto input_tensor_a_shape = input_tensor_a.get_shape();
     const auto input_tensor_b_shape = input_tensor_b.get_shape();

--- a/ttnn/ttnn/__init__.py
+++ b/ttnn/ttnn/__init__.py
@@ -278,6 +278,10 @@ from ttnn.operations.core import (
 from ttnn.operations.matmul import (
     matmul,
     linear,
+    MatmulMultiCoreReuseProgramConfig,
+    MatmulMultiCoreReuseMultiCastProgramConfig,
+    MatmulMultiCoreReuseMultiCast1DProgramConfig,
+    MatmulMultiCoreReuseMultiCastDRAMShardedProgramConfig,
 )
 
 from ttnn.operations.embedding import (

--- a/ttnn/ttnn/experimental/golden_functions.py
+++ b/ttnn/ttnn/experimental/golden_functions.py
@@ -43,7 +43,7 @@ if not ttnn.CONFIG.enable_fast_runtime_mode:
                 raise RuntimeError(f"{activation} is not supported as activation function")
         return ret
 
-    attach_golden(ttnn.linear, _golden_function_matmul)
+    attach_golden(ttnn.experimental.operations.linear, _golden_function_matmul)
 
     def _golden_function(
         input_tensor,

--- a/ttnn/ttnn/experimental/golden_functions.py
+++ b/ttnn/ttnn/experimental/golden_functions.py
@@ -43,7 +43,7 @@ if not ttnn.CONFIG.enable_fast_runtime_mode:
                 raise RuntimeError(f"{activation} is not supported as activation function")
         return ret
 
-    attach_golden(ttnn.experimental.operations.primary.matmul, _golden_function_matmul)
+    attach_golden(ttnn.linear, _golden_function_matmul)
 
     def _golden_function(
         input_tensor,

--- a/ttnn/ttnn/experimental/golden_functions.py
+++ b/ttnn/ttnn/experimental/golden_functions.py
@@ -43,7 +43,7 @@ if not ttnn.CONFIG.enable_fast_runtime_mode:
                 raise RuntimeError(f"{activation} is not supported as activation function")
         return ret
 
-    attach_golden(ttnn.experimental.operations.linear, _golden_function_matmul)
+    attach_golden(ttnn.experimental.operations.primary.matmul, _golden_function_matmul)
 
     def _golden_function(
         input_tensor,

--- a/ttnn/ttnn/operations/matmul.py
+++ b/ttnn/ttnn/operations/matmul.py
@@ -8,6 +8,16 @@ from typing import Optional, Tuple
 import ttnn
 
 MatmulProgramConfig = ttnn.experimental.operations.primary.MatmulProgramConfig
+MatmulMultiCoreReuseProgramConfig = ttnn.experimental.operations.primary.MatmulMultiCoreReuseProgramConfig
+MatmulMultiCoreReuseMultiCastProgramConfig = (
+    ttnn.experimental.operations.primary.MatmulMultiCoreReuseMultiCastProgramConfig
+)
+MatmulMultiCoreReuseMultiCast1DProgramConfig = (
+    ttnn.experimental.operations.primary.MatmulMultiCoreReuseMultiCast1DProgramConfig
+)
+MatmulMultiCoreReuseMultiCastDRAMShardedProgramConfig = (
+    ttnn.experimental.operations.primary.MatmulMultiCoreReuseMultiCastDRAMShardedProgramConfig
+)
 
 
 def _golden_function(input_tensor_a, input_tensor_b, *args, **kwargs):


### PR DESCRIPTION
### Ticket
- Link to Github Issue. https://github.com/tenstorrent/tt-metal/issues/9492

### Problem description
- ops are moving to ttnn

### What's changed
- point the matmul ops and their program configs in tests to ttnn
- needed to adjust validation
- program configs are now in ttnn proper as placeholders, and the placeholders will be adjusted in the future
- untilize_out is not supported by ttnn.matmul therefore one matmul is not moved. A decision will need to be made later about what to do about this

### Checklist
- [x] Post commit CI passes
- [x] Model regression CI testing passes (if applicable)
- [x] New/Existing tests provide coverage for changes
