### PR TITLE
#9492: Update static check ttnn count for moving away from tt_eager

### DIFF
--- a/.github/workflows/all-static-checks.yaml
+++ b/.github/workflows/all-static-checks.yaml
@@ -49,5 +49,3 @@ jobs:
         run: |
           if (( $(grep -Rnw 'tests/tt_metal' -e 'tt_lib' | wc -l ) > 0 )); then exit 1; fi
           if (( $(grep -Rnw 'tests/tt_metal' -e 'tt_eager' | wc -l ) > 10 )); then exit 1; fi
-      - name: Check ttnn is not used in tt_eager tests more than allowed count
-        run: if (( $(grep -Rnw 'tests/tt_eager' -e 'ttnn' | wc -l ) > 400 )); then exit 1; fi

--- a/.github/workflows/all-static-checks.yaml
+++ b/.github/workflows/all-static-checks.yaml
@@ -50,4 +50,4 @@ jobs:
           if (( $(grep -Rnw 'tests/tt_metal' -e 'tt_lib' | wc -l ) > 0 )); then exit 1; fi
           if (( $(grep -Rnw 'tests/tt_metal' -e 'tt_eager' | wc -l ) > 10 )); then exit 1; fi
       - name: Check ttnn is not used in tt_eager tests more than allowed count
-        run: if (( $(grep -Rnw 'tests/tt_eager' -e 'ttnn' | wc -l ) > 300 )); then exit 1; fi
+        run: if (( $(grep -Rnw 'tests/tt_eager' -e 'ttnn' | wc -l ) > 400 )); then exit 1; fi


### PR DESCRIPTION
### Ticket
- Link to Github Issue. https://github.com/tenstorrent/tt-metal/issues/9492

### Problem description
- While moving matmul from tt_eager to ttnn, but before moving over all the files, the number of references increased above the threshold

### What's changed
- Increase the threshold
### Checklist
- [ ] Post commit CI passes - not applicable
- [ ] Model regression CI testing passes (if applicable) - not applicable
- [ ] New/Existing tests provide coverage for changes - not applicable
