### PR TITLE
#8602: Make kernel group/launch msg fields indexable

### DIFF
--- a/tests/tt_metal/tt_metal/test_compile_sets_kernel_binaries.cpp
+++ b/tests/tt_metal/tt_metal/test_compile_sets_kernel_binaries.cpp
@@ -136,11 +136,11 @@ int main(int argc, char **argv) {
             // Check that binary memory objects in the kernel match the ones obtained from the persistent cache
             const KernelGroup* kernel_group = program.kernels_on_core(core, CoreType::WORKER);
             TT_FATAL(
-                kernel_group != nullptr && kernel_group->compute_id.has_value() and
-                kernel_group->riscv0_id.has_value() and kernel_group->riscv1_id.has_value());
-            auto compute_kernel = tt_metal::detail::GetKernel(program, kernel_group->compute_id.value());
-            auto riscv0_kernel = tt_metal::detail::GetKernel(program, kernel_group->riscv0_id.value());
-            auto riscv1_kernel = tt_metal::detail::GetKernel(program, kernel_group->riscv1_id.value());
+                kernel_group != nullptr && kernel_group->kernel_ids[DISPATCH_CLASS_TENSIX_COMPUTE].has_value() and
+                kernel_group->kernel_ids[DISPATCH_CLASS_TENSIX_DM0].has_value() and kernel_group->kernel_ids[DISPATCH_CLASS_TENSIX_DM1].has_value());
+            auto compute_kernel = tt_metal::detail::GetKernel(program, kernel_group->kernel_ids[DISPATCH_CLASS_TENSIX_COMPUTE].value());
+            auto riscv0_kernel = tt_metal::detail::GetKernel(program, kernel_group->kernel_ids[DISPATCH_CLASS_TENSIX_DM0].value());
+            auto riscv1_kernel = tt_metal::detail::GetKernel(program, kernel_group->kernel_ids[DISPATCH_CLASS_TENSIX_DM1].value());
 
             // Run iteration to get golden
             uint32_t mask = device->build_key();
@@ -175,9 +175,9 @@ int main(int argc, char **argv) {
                         uint32_t mask = device->build_key();
                         tt_metal::detail::CompileProgram(device, program);
                         const KernelGroup* kernel_group = program.kernels_on_core(core, CoreType::WORKER);
-                        auto compute_kernel = tt_metal::detail::GetKernel(program, kernel_group->compute_id.value());
-                        auto riscv0_kernel = tt_metal::detail::GetKernel(program, kernel_group->riscv0_id.value());
-                        auto riscv1_kernel = tt_metal::detail::GetKernel(program, kernel_group->riscv1_id.value());
+                        auto compute_kernel = tt_metal::detail::GetKernel(program, kernel_group->kernel_ids[DISPATCH_CLASS_TENSIX_COMPUTE].value());
+                        auto riscv0_kernel = tt_metal::detail::GetKernel(program, kernel_group->kernel_ids[DISPATCH_CLASS_TENSIX_DM0].value());
+                        auto riscv1_kernel = tt_metal::detail::GetKernel(program, kernel_group->kernel_ids[DISPATCH_CLASS_TENSIX_DM1].value());
                         TT_FATAL(compute_kernel->binaries(mask) == compute_binaries.at(mask));
                         TT_FATAL(riscv0_kernel->binaries(mask) == brisc_binaries.at(mask));
                         TT_FATAL(riscv1_kernel->binaries(mask) == ncrisc_binaries.at(mask));

--- a/tt_metal/detail/tt_metal.hpp
+++ b/tt_metal/detail/tt_metal.hpp
@@ -445,15 +445,16 @@ namespace tt::tt_metal{
                         const KernelGroup * kernel_group = program.kernels_on_core(CoreCoord(x, y), CoreType::WORKER);
                         if (kernel_group != nullptr) {
                             bool local_noc0_in_use = false; bool local_noc1_in_use = false;
-                            if (kernel_group->riscv0_id.has_value()) {
+                            if (kernel_group->kernel_ids[DISPATCH_CLASS_TENSIX_DM0].has_value()) {
                                 riscv0_in_use = true;
-                                set_global_and_local_noc_usage(kernel_group->riscv0_id.value(), local_noc0_in_use, local_noc1_in_use);
+                                set_global_and_local_noc_usage(kernel_group->kernel_ids[DISPATCH_CLASS_TENSIX_DM0].value(), local_noc0_in_use, local_noc1_in_use);
                             }
-                            if (kernel_group->riscv1_id.has_value()) {
+                            if (kernel_group->kernel_ids[DISPATCH_CLASS_TENSIX_DM1].has_value()) {
                                 riscv1_in_use = true;
-                                set_global_and_local_noc_usage(kernel_group->riscv1_id.value(), local_noc0_in_use, local_noc1_in_use);
+                                set_global_and_local_noc_usage(kernel_group->kernel_ids[DISPATCH_CLASS_TENSIX_DM1].value(), local_noc0_in_use, local_noc1_in_use);
                             }
-                            if (kernel_group->riscv0_id.has_value() and kernel_group->riscv1_id.has_value()) {
+                            if (kernel_group->kernel_ids[DISPATCH_CLASS_TENSIX_DM0].has_value() and
+                                kernel_group->kernel_ids[DISPATCH_CLASS_TENSIX_DM1].has_value()) {
                                 TT_FATAL(local_noc0_in_use and local_noc1_in_use, "Illegal NOC usage: data movement kernels on logical core {} cannot use the same NOC, doing so results in hangs!", CoreCoord(x, y).str());
                             }
                         }

--- a/tt_metal/hw/firmware/src/brisc.cc
+++ b/tt_metal/hw/firmware/src/brisc.cc
@@ -308,13 +308,13 @@ inline void set_ncrisc_kernel_resume_deassert_address() {
 }
 
 inline void run_triscs() {
-    if (mailboxes->launch.enable_triscs) {
+    if (mailboxes->launch.enables[DISPATCH_CLASS_TENSIX_COMPUTE]) {
         mailboxes->slave_sync.all = RUN_SYNC_MSG_ALL_TRISCS_GO;
     }
 }
 
 inline void finish_ncrisc_copy_and_run() {
-    if (mailboxes->launch.enable_ncrisc) {
+    if (mailboxes->launch.enables[DISPATCH_CLASS_TENSIX_DM1]) {
         mailboxes->slave_sync.ncrisc = RUN_SYNC_MSG_GO;
 
         l1_to_ncrisc_iram_copy_wait();
@@ -383,8 +383,8 @@ int main() {
             // Run the BRISC kernel
             DEBUG_STATUS("R");
             uint32_t kernel_config_base = mailboxes->launch.kernel_config_base;
-            l1_arg_base = (uint32_t tt_l1_ptr *)(kernel_config_base + mailboxes->launch.rta_offset_brisc);
-            if (mailboxes->launch.enable_brisc) {
+            l1_arg_base = (uint32_t tt_l1_ptr *)(kernel_config_base + mailboxes->launch.rta_offsets[DISPATCH_CLASS_TENSIX_DM0]);
+            if (mailboxes->launch.enables[DISPATCH_CLASS_TENSIX_DM0]) {
                 setup_cb_read_write_interfaces(num_cbs_to_early_init, mailboxes->launch.max_cb_index, true, true);
                 kernel_init();
             } else {

--- a/tt_metal/hw/firmware/src/erisc.cc
+++ b/tt_metal/hw/firmware/src/erisc.cc
@@ -80,7 +80,7 @@ void __attribute__((section("erisc_l1_code.1"), noinline)) Application(void) {
             DeviceZoneScopedMainN("ERISC-FW");
             DEBUG_STATUS("R");
             uint32_t kernel_config_base = mailboxes->launch.kernel_config_base;
-            l1_arg_base = (uint32_t tt_l1_ptr *)(kernel_config_base + mailboxes->launch.rta_offset_brisc); // overloaded
+            l1_arg_base = (uint32_t tt_l1_ptr *)(kernel_config_base + mailboxes->launch.rta_offsets[DISPATCH_CLASS_ETH_DM0]);
             kernel_init();
         } else {
             internal_::risc_context_switch();

--- a/tt_metal/hw/firmware/src/idle_erisc.cc
+++ b/tt_metal/hw/firmware/src/idle_erisc.cc
@@ -119,7 +119,7 @@ int main() {
                 //UC FIXME: do i need this?
                 setup_cb_read_write_interfaces(num_cbs_to_early_init, mailboxes->launch.max_cb_index, true, true);
                 uint32_t kernel_config_base = mailboxes->launch.kernel_config_base;
-                l1_arg_base = (uint32_t tt_l1_ptr *)(kernel_config_base + mailboxes->launch.rta_offset_brisc); // overloaded
+                l1_arg_base = (uint32_t tt_l1_ptr *)(kernel_config_base + mailboxes->launch.rta_offsets[DISPATCH_CLASS_ETH_DM0]);
                 kernel_init();
             //} else {
                 // This was not initialized in kernel_init

--- a/tt_metal/hw/firmware/src/ncrisc.cc
+++ b/tt_metal/hw/firmware/src/ncrisc.cc
@@ -95,7 +95,7 @@ int main(int argc, char *argv[]) {
         setup_cb_read_write_interfaces(0, mailboxes->launch.max_cb_index, true, true);
 
         uint32_t kernel_config_base = mailboxes->launch.kernel_config_base;
-        l1_arg_base = (uint32_t tt_l1_ptr *)(kernel_config_base + mailboxes->launch.rta_offset_ncrisc);
+        l1_arg_base = (uint32_t tt_l1_ptr *)(kernel_config_base + mailboxes->launch.rta_offsets[DISPATCH_CLASS_TENSIX_DM1]);
 
         DEBUG_STATUS("R");
         kernel_init();

--- a/tt_metal/hw/firmware/src/trisc.cc
+++ b/tt_metal/hw/firmware/src/trisc.cc
@@ -108,7 +108,7 @@ int main(int argc, char *argv[]) {
 #endif
 
         uint32_t kernel_config_base = mailboxes->launch.kernel_config_base;
-        l1_arg_base = (uint32_t tt_l1_ptr *)(kernel_config_base + mailboxes->launch.rta_offset_trisc);
+        l1_arg_base = (uint32_t tt_l1_ptr *)(kernel_config_base + mailboxes->launch.rta_offsets[DISPATCH_CLASS_TENSIX_COMPUTE]);
 
         DEBUG_STATUS("R");
         kernel_init();

--- a/tt_metal/hw/inc/dev_msgs.h
+++ b/tt_metal/hw/inc/dev_msgs.h
@@ -49,25 +49,30 @@ enum dispatch_mode {
     DISPATCH_MODE_HOST,
 };
 
+enum dispatch_core_processor_classes {
+    // Tensix processor classes
+    DISPATCH_CLASS_TENSIX_DM0 = 0,
+    DISPATCH_CLASS_TENSIX_DM1 = 1,
+    DISPATCH_CLASS_TENSIX_COMPUTE = 2,
+
+    // Ethernet processor classes
+    DISPATCH_CLASS_ETH_DM0 = 0,
+
+    DISPATCH_CLASS_MAX_PROC = 3,
+};
+
 struct launch_msg_t {  // must be cacheline aligned
-    volatile uint16_t brisc_watcher_kernel_id;
-    volatile uint16_t ncrisc_watcher_kernel_id;
-    volatile uint16_t triscs_watcher_kernel_id;
+    volatile uint16_t watcher_kernel_ids[DISPATCH_CLASS_MAX_PROC];
     volatile uint16_t ncrisc_kernel_size16;  // size in 16 byte units
 
     // Ring buffer of kernel configuration data
     volatile uint32_t kernel_config_base;
-    volatile uint16_t rta_offset_brisc;
-    volatile uint16_t rta_offset_ncrisc;
-    volatile uint16_t rta_offset_trisc;
+    volatile uint16_t rta_offsets[DISPATCH_CLASS_MAX_PROC];
 
     volatile uint8_t mode;                   // dispatch mode host/dev
     volatile uint8_t brisc_noc_id;
-    volatile uint8_t enable_brisc;
-    volatile uint8_t enable_ncrisc;
-    volatile uint8_t enable_triscs;
+    volatile uint8_t enables[DISPATCH_CLASS_MAX_PROC];
     volatile uint8_t max_cb_index;
-    volatile uint8_t enable_erisc;
     volatile uint8_t run;  // must be in last cacheline of this msg
 };
 

--- a/tt_metal/impl/device/device.cpp
+++ b/tt_metal/impl/device/device.cpp
@@ -201,19 +201,10 @@ void Device::initialize_firmware(CoreCoord phys_core, launch_msg_t *launch_msg) 
 void Device::initialize_and_launch_firmware() {
     ZoneScoped;
 
-    launch_msg_t launch_msg = {
-        .brisc_watcher_kernel_id = 0,
-        .ncrisc_watcher_kernel_id = 0,
-        .triscs_watcher_kernel_id = 0,
-        .ncrisc_kernel_size16 = 0,
-        .mode = DISPATCH_MODE_HOST,
-        .brisc_noc_id = 0,
-        .enable_brisc = 0,
-        .enable_ncrisc = 0,
-        .enable_triscs = 0,
-        .enable_erisc = 0,
-        .run = RUN_MSG_INIT,
-    };
+    launch_msg_t launch_msg;
+    std::memset(&launch_msg, 0, sizeof(launch_msg_t));
+    launch_msg.mode = DISPATCH_MODE_HOST,
+    launch_msg.run = RUN_MSG_INIT,
 
     // Download to worker cores
     log_debug("Initializing firmware");

--- a/tt_metal/impl/kernels/kernel.hpp
+++ b/tt_metal/impl/kernels/kernel.hpp
@@ -91,6 +91,7 @@ class Kernel : public JitBuildSettings {
     std::map<std::string, std::string> defines() const { return defines_; }
 
     virtual RISCV processor() const = 0;
+    dispatch_core_processor_classes dispatch_class() { return this->dispatch_class_; }
 
     virtual bool configure(Device *device, const CoreCoord &logical_core) const = 0;
 
@@ -131,6 +132,7 @@ class Kernel : public JitBuildSettings {
     // TODO: break this dependency by https://github.com/tenstorrent/tt-metal/issues/3381
     std::unordered_map<chip_id_t, std::vector<ll_api::memory>> binaries_;
     uint16_t binary_size16_;
+    dispatch_core_processor_classes dispatch_class_;
     std::vector<uint32_t> compile_time_args_;
     std::vector< std::vector< std::vector<uint32_t>> > core_to_runtime_args_;
     std::vector< std::vector< RuntimeArgsData> > core_to_runtime_args_data_;
@@ -149,7 +151,7 @@ class Kernel : public JitBuildSettings {
 
 class DataMovementKernel : public Kernel {
    public:
-    DataMovementKernel(const std::string &kernel_path, const CoreRangeSet &cr_set, const DataMovementConfig &config) : Kernel(kernel_path, cr_set, config.compile_args, config.defines), config_(config) {}
+    DataMovementKernel(const std::string &kernel_path, const CoreRangeSet &cr_set, const DataMovementConfig &config) : Kernel(kernel_path, cr_set, config.compile_args, config.defines), config_(config) { this->dispatch_class_ = (config.processor == DataMovementProcessor::RISCV_0) ? DISPATCH_CLASS_TENSIX_DM0 : DISPATCH_CLASS_TENSIX_DM1; }
 
     ~DataMovementKernel() {}
 
@@ -176,7 +178,7 @@ class DataMovementKernel : public Kernel {
 class EthernetKernel : public Kernel {
    public:
     EthernetKernel(const std::string &kernel_path, const CoreRangeSet &cr_set, const EthernetConfig &config) :
-        Kernel(kernel_path, cr_set, config.compile_args, config.defines), config_(config) {}
+        Kernel(kernel_path, cr_set, config.compile_args, config.defines), config_(config) { this->dispatch_class_ = DISPATCH_CLASS_ETH_DM0; }
 
     ~EthernetKernel() {}
 
@@ -202,7 +204,7 @@ class EthernetKernel : public Kernel {
 
 class ComputeKernel : public Kernel {
    public:
-    ComputeKernel(const std::string &kernel_path, const CoreRangeSet &cr_set, const ComputeConfig &config) : Kernel(kernel_path, cr_set, config.compile_args, config.defines), config_(config) {}
+    ComputeKernel(const std::string &kernel_path, const CoreRangeSet &cr_set, const ComputeConfig &config) : Kernel(kernel_path, cr_set, config.compile_args, config.defines), config_(config) { this->dispatch_class_ = DISPATCH_CLASS_TENSIX_COMPUTE; }
 
     ~ComputeKernel() {}
 

--- a/tt_metal/impl/program/program.hpp
+++ b/tt_metal/impl/program/program.hpp
@@ -33,20 +33,16 @@ namespace detail{
 }
 
 struct KernelGroup {
+    CoreType core_type;
     CoreRangeSet core_ranges;
-    std::optional<KernelHandle> compute_id = std::nullopt;
-    std::optional<KernelHandle> riscv0_id = std::nullopt;
-    std::optional<KernelHandle> riscv1_id = std::nullopt;
-    std::optional<KernelHandle> erisc_id = std::nullopt;
+    std::array<std::optional<KernelHandle>, DISPATCH_CLASS_MAX_PROC> kernel_ids;
     launch_msg_t launch_msg;
 
     KernelGroup();
     KernelGroup(
         const Program &program,
-        std::optional<KernelHandle> brisc_id,
-        std::optional<KernelHandle> ncrisc_id,
-        std::optional<KernelHandle> trisc_id,
-        std::optional<KernelHandle> erisc_id,
+        CoreType core_type,
+        std::array<std::optional<KernelHandle>, DISPATCH_CLASS_MAX_PROC> kernel_ids,
         bool erisc_is_idle,
         int last_cb_index,
         const CoreRangeSet &new_ranges);

--- a/tt_metal/tt_metal.cpp
+++ b/tt_metal/tt_metal.cpp
@@ -29,17 +29,11 @@ namespace {
 
 void ConfigureKernelGroup(
     const Program &program, const KernelGroup *kernel_group, Device *device, const CoreCoord &logical_core) {
-    if (kernel_group->compute_id.has_value()) {
-        detail::GetKernel(program, kernel_group->compute_id.value())->configure(device, logical_core);
-    }
-    if (kernel_group->riscv1_id.has_value()) {
-        detail::GetKernel(program, kernel_group->riscv1_id.value())->configure(device, logical_core);
-    }
-    if (kernel_group->riscv0_id.has_value()) {
-        detail::GetKernel(program, kernel_group->riscv0_id.value())->configure(device, logical_core);
-    }
-    if (kernel_group->erisc_id.has_value()) {
-        detail::GetKernel(program, kernel_group->erisc_id.value())->configure(device, logical_core);
+
+    for (auto& optional_id : kernel_group->kernel_ids) {
+        if (optional_id) {
+            detail::GetKernel(program, optional_id.value())->configure(device, logical_core);
+        }
     }
 }
 


### PR DESCRIPTION
create a dispatch processor class enum, change named fields into arrays

### Ticket
-#8602

### Problem description
- Moving to dynamic run map not having indexable by processor class arrays was not scalable

### What's changed
- Moved from ncrisc, brisc, compute to array_name[type]

### Checklist
- [x] Post commit CI passes
- [ ] Model regression CI testing passes (if applicable)
- [ ] New/Existing tests provide coverage for changes
