### PR TITLE
#0: extend t3k frequent tests to 2 hours

### DIFF
--- a/.github/workflows/t3000-frequent-tests.yaml
+++ b/.github/workflows/t3000-frequent-tests.yaml
@@ -44,7 +44,7 @@ jobs:
         run: tar -xvf ttm_${{ matrix.test-group.arch }}.tar
       - uses: ./.github/actions/install-python-deps
       - name: Run frequent regression tests
-        timeout-minutes: 60
+        timeout-minutes: 120
         run: |
           source ${{ github.workspace }}/python_env/bin/activate
           cd $TT_METAL_HOME


### PR DESCRIPTION
### Ticket
- Extend timeout for t3k frequent workflow

### Problem description
- too short, 

### What's changed
- Describe the approach used to solve the problem.
- Summarize the changes made and its impact.

### Checklist
- [ ] Post commit CI passes
- [ ] Model regression CI testing passes (if applicable)
- [ ] New/Existing tests provide coverage for changes
