### PR TITLE
#0: Increase trace region size to account for larger programs. Make trace tests shorter

### DIFF
--- a/tests/scripts/t3000/run_t3000_frequent_tests.sh
+++ b/tests/scripts/t3000/run_t3000_frequent_tests.sh
@@ -91,8 +91,8 @@ run_t3000_trace_stress_tests() {
 
   echo "LOG_METAL: Running run_t3000_trace_stress_tests"
 
-  NUM_TRACE_LOOPS=30 pytest tests/ttnn/unit_tests/test_multi_device_trace.py
-  NUM_TRACE_LOOPS=30 WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml pytest tests/ttnn/unit_tests/test_multi_device_trace.py
+  NUM_TRACE_LOOPS=15 pytest tests/ttnn/unit_tests/test_multi_device_trace.py
+  NUM_TRACE_LOOPS=15 WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml pytest tests/ttnn/unit_tests/test_multi_device_trace.py
 
   # Record the end time
   end_time=$(date +%s)

--- a/tests/ttnn/unit_tests/test_multi_device_trace.py
+++ b/tests/ttnn/unit_tests/test_multi_device_trace.py
@@ -20,7 +20,7 @@ NUM_TRACE_LOOPS = int(os.getenv("NUM_TRACE_LOOPS", 7))
 )
 @pytest.mark.parametrize("use_all_gather", [True, False])
 @pytest.mark.parametrize("enable_async", [True])
-@pytest.mark.parametrize("device_params", [{"trace_region_size": 33792}], indirect=True)
+@pytest.mark.parametrize("device_params", [{"trace_region_size": 60000}], indirect=True)
 def test_multi_device_single_trace(t3k_device_mesh, shape, use_all_gather, enable_async):
     if t3k_device_mesh.get_num_devices() <= 1:
         pytest.skip("This test requires multiple devices")
@@ -112,7 +112,7 @@ def test_multi_device_single_trace(t3k_device_mesh, shape, use_all_gather, enabl
 )
 @pytest.mark.parametrize("use_all_gather", [True, False])
 @pytest.mark.parametrize("enable_async", [True])
-@pytest.mark.parametrize("device_params", [{"trace_region_size": 104448}], indirect=True)
+@pytest.mark.parametrize("device_params", [{"trace_region_size": 200000}], indirect=True)
 def test_multi_device_multi_trace(t3k_device_mesh, shape, use_all_gather, enable_async):
     torch.manual_seed(0)
     if t3k_device_mesh.get_num_devices() <= 1:

--- a/tests/ttnn/unit_tests/test_single_device_trace.py
+++ b/tests/ttnn/unit_tests/test_single_device_trace.py
@@ -14,7 +14,7 @@ from tests.ttnn.utils_for_testing import assert_with_pcc
 @pytest.mark.parametrize("shape", [[1, 3, 1024, 1024], (1, 1, 512, 512), (1, 3, 512, 512), (1, 3, 32, 32)])
 @pytest.mark.parametrize("enable_async", [True, False])
 @pytest.mark.parametrize("blocking", [True, False])
-@pytest.mark.parametrize("device_params", [{"trace_region_size": 106496}], indirect=True)
+@pytest.mark.parametrize("device_params", [{"trace_region_size": 200000}], indirect=True)
 def test_single_device_single_trace(device, shape, enable_async, blocking):
     device.enable_async(enable_async)
     device.enable_program_cache()
@@ -74,7 +74,7 @@ def test_single_device_single_trace(device, shape, enable_async, blocking):
 @pytest.mark.parametrize("shape", [(1, 1, 512, 512), (1, 1, 32, 32), (1, 3, 512, 512), (1, 3, 32, 32)])
 @pytest.mark.parametrize("enable_async", [True, False])
 @pytest.mark.parametrize("blocking", [True, False])
-@pytest.mark.parametrize("device_params", [{"trace_region_size": 133120}], indirect=True)
+@pytest.mark.parametrize("device_params", [{"trace_region_size": 266240}], indirect=True)
 def test_single_device_multi_trace(device, shape, enable_async, blocking):
     device.enable_async(enable_async)
     device.enable_program_cache()


### PR DESCRIPTION
### Ticket
- Link to Github Issue.

### Problem description
- Multi-Device trace tests were failing due to trace region size being too small, after program runtime args updates.

### What's changed
increase trace region size with factor of safety to handle such issues in future.

### Checklist
- [x] Post commit CI passes
- [ ] Model regression CI testing passes