### PR TITLE
#0: Fix compilation errors when using g++-11 and fmt v10

### DIFF
--- a/tests/tt_metal/tt_metal/perf_microbenchmark/1_compute_mm/test_compute_mm.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/1_compute_mm/test_compute_mm.cpp
@@ -233,9 +233,9 @@ int main(int argc, char** argv) {
         //                      Initial Runtime Args Parse
         ////////////////////////////////////////////////////////////////////////////
         std::vector<std::string> input_args(argv, argv + argc);
-        uint32_t M;
-        uint32_t N;
-        uint32_t K;
+        uint32_t M = 0;
+        uint32_t N = 0;
+        uint32_t K = 0;
         uint32_t dtype = 0; // bfp8
         uint32_t fidel = 0; // lofi
         uint32_t num_tests = 10;

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/2_noc_adjacent/test_noc_adjacent.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/2_noc_adjacent/test_noc_adjacent.cpp
@@ -57,7 +57,7 @@ int main(int argc, char** argv) {
     uint32_t noc_index = 0;
     uint32_t noc_direction = 0;
     uint32_t access_type = 0;
-    uint32_t tiles_per_transfer;
+    uint32_t tiles_per_transfer = 0;
     uint32_t num_tests = 10;
     bool use_device_profiler = false;
     bool bypass_check = false;

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/3_pcie_transfer/test_rw_buffer.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/3_pcie_transfer/test_rw_buffer.cpp
@@ -42,8 +42,8 @@ int main(int argc, char** argv) {
     std::vector<double> h2d_bandwidth;
     std::vector<double> d2h_bandwidth;
     int32_t buffer_type = 0;
-    uint32_t transfer_size;
-    uint32_t page_size;
+    uint32_t transfer_size = 0;
+    uint32_t page_size = 0;
 
     try {
         // Input arguments parsing

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/6_dram_offchip/test_dram_offchip.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/6_dram_offchip/test_dram_offchip.cpp
@@ -99,11 +99,11 @@ int main(int argc, char **argv) {
     }
 
     bool pass = true;
-    bool use_device_profiler;
+    bool use_device_profiler = false;
     bool bypass_check = false;
     std::vector<double> dram_bandwidth;
     uint32_t num_tests = 10;
-    uint64_t input_size;
+    uint64_t input_size = 0;
     uint32_t access_type;
     uint32_t dram_bandwidth_spec = 0;
 

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/7_kernel_launch/test_kernel_launch.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/7_kernel_launch/test_kernel_launch.cpp
@@ -46,7 +46,7 @@ int main(int argc, char** argv) {
     std::vector<std::string> input_args(argv, argv + argc);
     uint32_t num_cores_r = 0;
     uint32_t num_cores_c = 0;
-    uint32_t num_core_groups;
+    uint32_t num_core_groups = 0;
     uint32_t num_tests = 10;
     bool bypass_check = false;
     try {

--- a/tests/ttnn/unit_tests/gtests/test_reflect.cpp
+++ b/tests/ttnn/unit_tests/gtests/test_reflect.cpp
@@ -2,6 +2,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
+#if defined(__clang__) || (defined(__GNUC__) && __GNUC__ >=12)
 #include <string_view>
 #include <reflect>
 
@@ -29,3 +30,4 @@ static_assert(B == reflect::get<"b">(f), "Reflect get<\"b\"> check failed");
 constexpr auto t = reflect::to<std::tuple>(f);
 static_assert(42 == std::get<0>(t), "Reflect to<std::tuple> get<0> check failed");
 static_assert(B == std::get<1>(t), "Reflect to<std::tuple> get<1> check failed");
+#endif

--- a/tt_eager/tt_dnn/op_library/bmm/multi_core_reuse_mcast_2d_optimized/bmm_op_multi_core_reuse_mcast_2d_optimized.cpp
+++ b/tt_eager/tt_dnn/op_library/bmm/multi_core_reuse_mcast_2d_optimized/bmm_op_multi_core_reuse_mcast_2d_optimized.cpp
@@ -134,7 +134,7 @@ operation::ProgramWithCallbacks create_program_mcast_in0_in1(
     uint32_t in0_mcast_receiver_grid_diff_coord_end;
     std::vector<uint32_t> in0_mcast_noc_x;
     std::vector<uint32_t> in0_mcast_noc_y;
-    uint32_t in0_sender_num_cores_along_width;
+    uint32_t in0_sender_num_cores_along_width = 0;
 
     // Only used for in0 block sharded
     std::optional<CoreRange> in0_mcast_cores_without_work_and_not_in_receiver_grid;

--- a/tt_eager/tt_dnn/op_library/moreh_sum_backward/moreh_sum_backward_impl/moreh_sum_backward_impl.cpp
+++ b/tt_eager/tt_dnn/op_library/moreh_sum_backward/moreh_sum_backward_impl/moreh_sum_backward_impl.cpp
@@ -148,7 +148,8 @@ operation::ProgramWithCallbacks moreh_sum_backward_impl(const Tensor &output_gra
     //                      DataMovementKernel SetUp
     ////////////////////////////////////////////////////////////////////////////
     std::vector<uint32_t> reader_compile_time_args =
-    { static_cast<uint32_t>(is_dram(output_grad)), input_grad_rank };
+    { static_cast<uint32_t>(is_dram(output_grad)),
+      static_cast<uint32_t>(input_grad_rank) };
     std::vector<uint32_t> writer_compile_time_args =
     { static_cast<uint32_t>(is_dram(input_grad)) };
     const auto reader_kernel_file = "tt_eager/tt_dnn/op_library/moreh_sum_backward/moreh_sum_backward_impl/kernels/reader_moreh_sum_backward.cpp";

--- a/tt_metal/common/logger.hpp
+++ b/tt_metal/common/logger.hpp
@@ -120,7 +120,11 @@ class Logger {
                 level_names[static_cast<std::underlying_type_t<Level>>(level)]);
             std::string type_str = fmt::format(fmt::fg(fmt::color::green), "{:>23}", type_names[type]);
             fmt::print(*fd, "{} | {} | ", type_str, level_str);
+#if FMT_VERSION < 100000
             fmt::print(*fd, fmt, std::forward<Args>(args)...);
+#else
+            fmt::print(*fd, fmt::runtime(fmt), std::forward<Args>(args)...);
+#endif
             *fd << std::endl;
         }
     }

--- a/tt_metal/common/utils.hpp
+++ b/tt_metal/common/utils.hpp
@@ -7,6 +7,8 @@
 #include <string>
 #include <thread>
 #include <mutex>
+#include <vector>
+#include <sstream>
 
 using std::string;
 

--- a/ttnn/cpp/ttnn/device_operation.hpp
+++ b/ttnn/cpp/ttnn/device_operation.hpp
@@ -90,9 +90,9 @@ concept DeviceOperationWithCustomProgramCacheConcept = DeviceOperationConcept<de
 };
 
 template <typename... Ts>
-[[nodiscard]] std::variant<Ts...> constexpr map_index_to_variant(std::size_t i, std::variant<Ts...>) {
+[[nodiscard]] std::variant<Ts...> map_index_to_variant(std::size_t i, std::variant<Ts...>) {
     assert(i < sizeof...(Ts));
-    static constexpr std::variant<Ts...> table[] = { Ts{ }... };
+    static std::variant<Ts...> table[] = { Ts{ }... };
     return table[i];
 }
 

--- a/ttnn/cpp/ttnn/operations/reduction/argmax/device/argmax_program_factory.hpp
+++ b/ttnn/cpp/ttnn/operations/reduction/argmax/device/argmax_program_factory.hpp
@@ -82,8 +82,8 @@ operation::ProgramWithCallbacks argmax_multi_core(
         C,
         H,
         W,
-        dim.value_or(0),
-        (uint32_t)(not dim.has_value()),
+        (uint32_t) dim.value_or(0),
+        (uint32_t) (not dim.has_value()),
     };
 
     std::map<string, string> kernel_defines;


### PR DESCRIPTION
I tried building tt-metal project with g++-11 (with C++20 standard) and encountered some compilation errors (initially warnings but turned into errors because of -Werror flag).

This PR fixes some compilation errors when using g++-11 and fmt v10 (it is v8 in the current metal repo but I guess we will move to higher version someday 😄).

The compilation errors this PR solves:
- Maybe uninitialized
- Narrowing conversion
- Missing header inclusion
- Static variable not permitted in a constexpr function
- Bypass boost-ext/reflect (C++20 minimal static reflection library) unittest for g++-11 (it requires g++-12 or higher)
- Check format string at runtime instead of compile-time ([more info](https://fmt.dev/latest/api.html#compile-time-format-string-checks))

The main reason I am trying with g++-11 is that I am building an external project that links metal libraries ([libtt_metal.so](http://libtt_metal.so/) and [libtt_eager.so](http://libtt_eager.so/)). The external project is built upon g++-11.

Post commit test: https://github.com/tenstorrent/tt-metal/actions/runs/9646947558