### PR TITLE
Migrate bckward ops to TTNN

### DIFF
--- a/docs/source/ttnn/ttnn/api.rst
+++ b/docs/source/ttnn/ttnn/api.rst
@@ -194,6 +194,7 @@ Pointwise Binary
    ttnn/addalpha_bw
    ttnn/subalpha_bw
    ttnn/sub_bw
+   ttnn/xlogy_bw
 
 Pointwise Ternary
 =================

--- a/docs/source/ttnn/ttnn/api.rst
+++ b/docs/source/ttnn/ttnn/api.rst
@@ -196,6 +196,7 @@ Pointwise Binary
    ttnn/sub_bw
    ttnn/xlogy_bw
    ttnn/hypot_bw
+   ttnn/ldexp_bw
 
 Pointwise Ternary
 =================

--- a/docs/source/ttnn/ttnn/api.rst
+++ b/docs/source/ttnn/ttnn/api.rst
@@ -195,6 +195,7 @@ Pointwise Binary
    ttnn/subalpha_bw
    ttnn/sub_bw
    ttnn/xlogy_bw
+   ttnn/hypot_bw
 
 Pointwise Ternary
 =================

--- a/docs/source/ttnn/ttnn/api.rst
+++ b/docs/source/ttnn/ttnn/api.rst
@@ -199,6 +199,7 @@ Pointwise Binary
    ttnn/ldexp_bw
    ttnn/logaddexp_bw
    ttnn/logaddexp2_bw
+   ttnn/squared_difference_bw
 
 Pointwise Ternary
 =================

--- a/docs/source/ttnn/ttnn/api.rst
+++ b/docs/source/ttnn/ttnn/api.rst
@@ -197,6 +197,8 @@ Pointwise Binary
    ttnn/xlogy_bw
    ttnn/hypot_bw
    ttnn/ldexp_bw
+   ttnn/logaddexp_bw
+   ttnn/logaddexp2_bw
 
 Pointwise Ternary
 =================

--- a/docs/source/ttnn/ttnn/dependencies/tt_lib.rst
+++ b/docs/source/ttnn/ttnn/dependencies/tt_lib.rst
@@ -910,8 +910,6 @@ Backward Operations
 
 .. autofunction:: tt_lib.tensor.bias_gelu_unary_bw
 
-.. autofunction:: tt_lib.tensor.squared_difference_bw
-
 .. autofunction:: tt_lib.tensor.lerp_bw
 
 .. autofunction:: tt_lib.tensor.concat_bw

--- a/docs/source/ttnn/ttnn/dependencies/tt_lib.rst
+++ b/docs/source/ttnn/ttnn/dependencies/tt_lib.rst
@@ -918,8 +918,6 @@ Backward Operations
 
 .. autofunction:: tt_lib.tensor.ldexp_bw
 
-.. autofunction:: tt_lib.tensor.xlogy_bw
-
 .. autofunction:: tt_lib.tensor.logaddexp_bw
 
 .. autofunction:: tt_lib.tensor.logaddexp2_bw

--- a/docs/source/ttnn/ttnn/dependencies/tt_lib.rst
+++ b/docs/source/ttnn/ttnn/dependencies/tt_lib.rst
@@ -914,8 +914,6 @@ Backward Operations
 
 .. autofunction:: tt_lib.tensor.lerp_bw
 
-.. autofunction:: tt_lib.tensor.ldexp_bw
-
 .. autofunction:: tt_lib.tensor.logaddexp_bw
 
 .. autofunction:: tt_lib.tensor.logaddexp2_bw

--- a/docs/source/ttnn/ttnn/dependencies/tt_lib.rst
+++ b/docs/source/ttnn/ttnn/dependencies/tt_lib.rst
@@ -904,8 +904,6 @@ Backward Operations
 
 .. autofunction:: tt_lib.tensor.binary_le_bw
 
-.. autofunction:: tt_lib.tensor.hypot_bw
-
 .. autofunction:: tt_lib.tensor.gelu_bw
 
 .. autofunction:: tt_lib.tensor.bias_gelu_bw

--- a/docs/source/ttnn/ttnn/dependencies/tt_lib.rst
+++ b/docs/source/ttnn/ttnn/dependencies/tt_lib.rst
@@ -914,10 +914,6 @@ Backward Operations
 
 .. autofunction:: tt_lib.tensor.lerp_bw
 
-.. autofunction:: tt_lib.tensor.logaddexp_bw
-
-.. autofunction:: tt_lib.tensor.logaddexp2_bw
-
 .. autofunction:: tt_lib.tensor.concat_bw
 
 .. autofunction:: tt_lib.tensor.hardsigmoid_bw

--- a/docs/source/ttnn/ttnn/ttnn/hypot_bw.rst
+++ b/docs/source/ttnn/ttnn/ttnn/hypot_bw.rst
@@ -1,0 +1,6 @@
+.. _ttnn.hypot_bw:
+
+ttnn.hypot_bw
+#################
+
+.. autofunction:: ttnn.hypot_bw

--- a/docs/source/ttnn/ttnn/ttnn/ldexp_bw.rst
+++ b/docs/source/ttnn/ttnn/ttnn/ldexp_bw.rst
@@ -1,0 +1,6 @@
+.. _ttnn.ldexp_bw:
+
+ttnn.ldexp_bw
+#################
+
+.. autofunction:: ttnn.ldexp_bw

--- a/docs/source/ttnn/ttnn/ttnn/logaddexp2_bw.rst
+++ b/docs/source/ttnn/ttnn/ttnn/logaddexp2_bw.rst
@@ -1,0 +1,6 @@
+.. _ttnn.logaddexp2_bw:
+
+ttnn.logaddexp2_bw
+####################
+
+.. autofunction:: ttnn.logaddexp2_bw

--- a/docs/source/ttnn/ttnn/ttnn/logaddexp_bw.rst
+++ b/docs/source/ttnn/ttnn/ttnn/logaddexp_bw.rst
@@ -1,0 +1,6 @@
+.. _ttnn.logaddexp_bw:
+
+ttnn.logaddexp_bw
+###################
+
+.. autofunction:: ttnn.logaddexp_bw

--- a/docs/source/ttnn/ttnn/ttnn/squared_difference_bw.rst
+++ b/docs/source/ttnn/ttnn/ttnn/squared_difference_bw.rst
@@ -1,0 +1,6 @@
+.. _ttnn.squared_difference_bw:
+
+ttnn.squared_difference_bw
+############################
+
+.. autofunction:: ttnn.squared_difference_bw

--- a/docs/source/ttnn/ttnn/ttnn/xlogy_bw.rst
+++ b/docs/source/ttnn/ttnn/ttnn/xlogy_bw.rst
@@ -1,0 +1,6 @@
+.. _ttnn.xlogy_bw:
+
+ttnn.xlogy_bw
+#################
+
+.. autofunction:: ttnn.xlogy_bw

--- a/tests/tt_eager/python_api_testing/unit_testing/backward_ops/test_backward_hypot.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/backward_ops/test_backward_hypot.py
@@ -4,7 +4,7 @@
 
 import torch
 import pytest
-import tt_lib
+import ttnn
 from tests.tt_eager.python_api_testing.unit_testing.backward_ops.utility_funcs import data_gen_with_range, compare_pcc
 
 
@@ -21,7 +21,7 @@ def test_bw_hypot(input_shapes, device):
     other_data, other_tensor = data_gen_with_range(input_shapes, -52, 51, device, True)
     grad_data, grad_tensor = data_gen_with_range(input_shapes, -30, 30, device, True)
 
-    tt_output_tensor_on_device = tt_lib.tensor.hypot_bw(grad_tensor, input_tensor, other_tensor)
+    tt_output_tensor_on_device = ttnn.hypot_bw(grad_tensor, input_tensor, other_tensor)
 
     in_data.retain_grad()
     other_data.retain_grad()

--- a/tests/tt_eager/python_api_testing/unit_testing/backward_ops/test_backward_ldexp.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/backward_ops/test_backward_ldexp.py
@@ -4,7 +4,7 @@
 
 import torch
 import pytest
-import tt_lib
+import ttnn
 from tests.tt_eager.python_api_testing.unit_testing.backward_ops.utility_funcs import data_gen_with_range, compare_pcc
 
 
@@ -22,7 +22,7 @@ def test_bw_ldexp(input_shapes, device):
 
     grad_data, grad_tensor = data_gen_with_range(input_shapes, -5, 5, device)
 
-    tt_output_tensor_on_device = tt_lib.tensor.ldexp_bw(grad_tensor, input_tensor, other_tensor)
+    tt_output_tensor_on_device = ttnn.ldexp_bw(grad_tensor, input_tensor, other_tensor)
 
     in_data.retain_grad()
     other_data.retain_grad()

--- a/tests/tt_eager/python_api_testing/unit_testing/backward_ops/test_backward_logaddexp.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/backward_ops/test_backward_logaddexp.py
@@ -4,7 +4,7 @@
 
 import torch
 import pytest
-import tt_lib
+import ttnn
 from tests.tt_eager.python_api_testing.unit_testing.backward_ops.utility_funcs import data_gen_with_range, compare_pcc
 
 
@@ -22,7 +22,7 @@ def test_bw_logaddexp(input_shapes, device):
 
     grad_data, grad_tensor = data_gen_with_range(input_shapes, -5, 5, device)
 
-    tt_output_tensor_on_device = tt_lib.tensor.logaddexp_bw(grad_tensor, input_tensor, other_tensor)
+    tt_output_tensor_on_device = ttnn.logaddexp_bw(grad_tensor, input_tensor, other_tensor)
 
     in_data.retain_grad()
     other_data.retain_grad()

--- a/tests/tt_eager/python_api_testing/unit_testing/backward_ops/test_backward_logaddexp2.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/backward_ops/test_backward_logaddexp2.py
@@ -4,7 +4,7 @@
 
 import torch
 import pytest
-import tt_lib
+import ttnn
 from tests.tt_eager.python_api_testing.unit_testing.backward_ops.utility_funcs import (
     data_gen_with_range,
     compare_pcc,
@@ -25,7 +25,7 @@ def test_bw_logaddexp2(input_shapes, device):
 
     grad_data, grad_tensor = data_gen_with_range(input_shapes, -5, 5, device)
 
-    tt_output_tensor_on_device = tt_lib.tensor.logaddexp2_bw(grad_tensor, input_tensor, other_tensor)
+    tt_output_tensor_on_device = ttnn.logaddexp2_bw(grad_tensor, input_tensor, other_tensor)
 
     in_data.retain_grad()
     other_data.retain_grad()

--- a/tests/tt_eager/python_api_testing/unit_testing/backward_ops/test_backward_squared_difference.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/backward_ops/test_backward_squared_difference.py
@@ -4,7 +4,7 @@
 
 import torch
 import pytest
-import tt_lib
+import ttnn
 from tests.tt_eager.python_api_testing.unit_testing.backward_ops.utility_funcs import compare_pcc, data_gen_with_range
 
 
@@ -23,7 +23,7 @@ def test_bw_squared_difference(input_shapes, device):
 
     pyt_y = torch.square(torch.sub(in_data, other_data))
 
-    tt_output_tensor_on_device = tt_lib.tensor.squared_difference_bw(grad_tensor, input_tensor, other_tensor)
+    tt_output_tensor_on_device = ttnn.squared_difference_bw(grad_tensor, input_tensor, other_tensor)
 
     in_data.retain_grad()
     other_data.retain_grad()

--- a/tests/tt_eager/python_api_testing/unit_testing/backward_ops/test_backward_xlogy.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/backward_ops/test_backward_xlogy.py
@@ -4,7 +4,7 @@
 
 import torch
 import pytest
-import tt_lib
+import ttnn
 from tests.tt_eager.python_api_testing.unit_testing.backward_ops.utility_funcs import data_gen_with_range, compare_pcc
 
 
@@ -22,7 +22,7 @@ def test_bw_xlogy(input_shapes, device):
 
     grad_data, grad_tensor = data_gen_with_range(input_shapes, -5, 5, device)
 
-    tt_output_tensor_on_device = tt_lib.tensor.xlogy_bw(grad_tensor, input_tensor, other_tensor)
+    tt_output_tensor_on_device = ttnn.xlogy_bw(grad_tensor, input_tensor, other_tensor)
 
     in_data.retain_grad()
     other_data.retain_grad()

--- a/tests/ttnn/unit_tests/operations/test_backward.py
+++ b/tests/ttnn/unit_tests/operations/test_backward.py
@@ -126,5 +126,23 @@ def test_hypot(device, h, w, in_val, grad_val, other_val):
 @pytest.mark.parametrize("in_val", [-1, 1])
 @pytest.mark.parametrize("grad_val", [-1, 0, 1])
 @pytest.mark.parametrize("other_val", [-1, 1])
-def test_hypot(device, h, w, in_val, grad_val, other_val):
+def test_ldexp(device, h, w, in_val, grad_val, other_val):
     run_backward_binary_test(device, h, w, in_val, grad_val, other_val, ttnn.ldexp_bw, torch.ldexp)
+
+
+@pytest.mark.parametrize("h", [64])
+@pytest.mark.parametrize("w", [128])
+@pytest.mark.parametrize("in_val", [-1, 1])
+@pytest.mark.parametrize("grad_val", [-1, 0, 1])
+@pytest.mark.parametrize("other_val", [-1, 1])
+def test_logaddexp(device, h, w, in_val, grad_val, other_val):
+    run_backward_binary_test(device, h, w, in_val, grad_val, other_val, ttnn.logaddexp_bw, torch.logaddexp)
+
+
+@pytest.mark.parametrize("h", [64])
+@pytest.mark.parametrize("w", [128])
+@pytest.mark.parametrize("in_val", [-1, 1])
+@pytest.mark.parametrize("grad_val", [-1, 0, 1])
+@pytest.mark.parametrize("other_val", [-1, 1])
+def test_logaddexp2(device, h, w, in_val, grad_val, other_val):
+    run_backward_binary_test(device, h, w, in_val, grad_val, other_val, ttnn.logaddexp2_bw, torch.logaddexp2)

--- a/tests/ttnn/unit_tests/operations/test_backward.py
+++ b/tests/ttnn/unit_tests/operations/test_backward.py
@@ -110,3 +110,12 @@ def test_atan2_zero(device, h, w, in_val, grad_val, other_val):
 @pytest.mark.parametrize("other_val", [-1, 1])
 def test_xlogy(device, h, w, in_val, grad_val, other_val):
     run_backward_binary_test(device, h, w, in_val, grad_val, other_val, ttnn.xlogy_bw, torch.xlogy)
+
+
+@pytest.mark.parametrize("h", [64])
+@pytest.mark.parametrize("w", [128])
+@pytest.mark.parametrize("in_val", [-1, 1])
+@pytest.mark.parametrize("grad_val", [-1, 0, 1])
+@pytest.mark.parametrize("other_val", [-1, 1])
+def test_hypot(device, h, w, in_val, grad_val, other_val):
+    run_backward_binary_test(device, h, w, in_val, grad_val, other_val, ttnn.hypot_bw, torch.hypot)

--- a/tests/ttnn/unit_tests/operations/test_backward.py
+++ b/tests/ttnn/unit_tests/operations/test_backward.py
@@ -146,3 +146,13 @@ def test_logaddexp(device, h, w, in_val, grad_val, other_val):
 @pytest.mark.parametrize("other_val", [-1, 1])
 def test_logaddexp2(device, h, w, in_val, grad_val, other_val):
     run_backward_binary_test(device, h, w, in_val, grad_val, other_val, ttnn.logaddexp2_bw, torch.logaddexp2)
+
+
+@pytest.mark.parametrize("h", [64])
+@pytest.mark.parametrize("w", [128])
+@pytest.mark.parametrize("in_val", [-1, 1])
+@pytest.mark.parametrize("grad_val", [-1, 0, 1])
+@pytest.mark.parametrize("other_val", [-1, 1])
+def test_squared_difference(device, h, w, in_val, grad_val, other_val):
+    torch_squared_diff = lambda x, y: torch.square(torch.sub(x, y))
+    run_backward_binary_test(device, h, w, in_val, grad_val, other_val, ttnn.squared_difference_bw, torch_squared_diff)

--- a/tests/ttnn/unit_tests/operations/test_backward.py
+++ b/tests/ttnn/unit_tests/operations/test_backward.py
@@ -119,3 +119,12 @@ def test_xlogy(device, h, w, in_val, grad_val, other_val):
 @pytest.mark.parametrize("other_val", [-1, 1])
 def test_hypot(device, h, w, in_val, grad_val, other_val):
     run_backward_binary_test(device, h, w, in_val, grad_val, other_val, ttnn.hypot_bw, torch.hypot)
+
+
+@pytest.mark.parametrize("h", [64])
+@pytest.mark.parametrize("w", [128])
+@pytest.mark.parametrize("in_val", [-1, 1])
+@pytest.mark.parametrize("grad_val", [-1, 0, 1])
+@pytest.mark.parametrize("other_val", [-1, 1])
+def test_hypot(device, h, w, in_val, grad_val, other_val):
+    run_backward_binary_test(device, h, w, in_val, grad_val, other_val, ttnn.ldexp_bw, torch.ldexp)

--- a/tests/ttnn/unit_tests/operations/test_backward.py
+++ b/tests/ttnn/unit_tests/operations/test_backward.py
@@ -101,3 +101,12 @@ def test_atan2(device, h, w, in_val, grad_val, other_val):
 @skip_for_wormhole_b0("Skipped due to hardware restriction in storing nan")
 def test_atan2_zero(device, h, w, in_val, grad_val, other_val):
     run_backward_binary_test(device, h, w, in_val, grad_val, other_val, ttnn.atan2_bw, torch.atan2)
+
+
+@pytest.mark.parametrize("h", [64])
+@pytest.mark.parametrize("w", [128])
+@pytest.mark.parametrize("in_val", [-1, 1])
+@pytest.mark.parametrize("grad_val", [-1, 0, 1])
+@pytest.mark.parametrize("other_val", [-1, 1])
+def test_xlogy(device, h, w, in_val, grad_val, other_val):
+    run_backward_binary_test(device, h, w, in_val, grad_val, other_val, ttnn.xlogy_bw, torch.xlogy)

--- a/tt_eager/tt_dnn/op_library/backward/backward_ops.cpp
+++ b/tt_eager/tt_dnn/op_library/backward/backward_ops.cpp
@@ -989,21 +989,6 @@ std::vector<Tensor> bias_gelu_unary_bw(
         grad, input, bias, approximate, output_mem_config);
 }
 
-std::vector<Tensor> _squared_difference_bw(
-    const Tensor& grad, const Tensor& input, const Tensor& other, const MemoryConfig& output_mem_config) {
-    std::vector<Tensor> grad_tensor;
-    Tensor difference = ttnn::subtract(input, other);
-    Tensor grad_a = mul_unary(2, ttnn::multiply(grad, difference, std::nullopt, output_mem_config), output_mem_config);
-    grad_tensor.emplace_back(grad_a);
-    Tensor grad_b = mul_unary(-1, grad_a, output_mem_config);
-    grad_tensor.emplace_back(grad_b);
-    return grad_tensor;
-}
-std::vector<Tensor> squared_difference_bw(
-    const Tensor& grad, const Tensor& input, const Tensor& other, const MemoryConfig& output_mem_config) {
-    return operation::decorate_as_composite(__func__, _squared_difference_bw)(grad, input, other, output_mem_config);
-}
-
 std::vector<Tensor> _concat_bw(
     const Tensor& grad, const Tensor& input, const Tensor& other, int dim, const MemoryConfig& output_mem_config) {
     std::vector<Tensor> grad_tensor;

--- a/tt_eager/tt_dnn/op_library/backward/backward_ops.cpp
+++ b/tt_eager/tt_dnn/op_library/backward/backward_ops.cpp
@@ -832,23 +832,6 @@ std::vector<Tensor> relu_bw(const Tensor& grad, const Tensor& input, const Memor
     return operation::decorate_as_composite(__func__, _relu_bw)(grad, input, output_mem_config);
 }
 
-std::vector<Tensor> _hypot_bw(
-    const Tensor& grad, const Tensor& input, const Tensor& other, const MemoryConfig& output_mem_config) {
-    std::vector<Tensor> grad_tensor;
-    Tensor result_recip = recip(hypot(input, other, output_mem_config), output_mem_config);
-    Tensor grad_a =
-        ttnn::multiply(grad, ttnn::multiply(input, result_recip, std::nullopt, output_mem_config), std::nullopt, output_mem_config);
-    grad_tensor.emplace_back(grad_a);
-    Tensor grad_b =
-        ttnn::multiply(grad, ttnn::multiply(other, result_recip, std::nullopt, output_mem_config), std::nullopt, output_mem_config);
-    grad_tensor.emplace_back(grad_b);
-    return grad_tensor;
-}
-std::vector<Tensor> hypot_bw(
-    const Tensor& grad, const Tensor& input, const Tensor& other, const MemoryConfig& output_mem_config) {
-    return operation::decorate_as_composite(__func__, _hypot_bw)(grad, input, other, output_mem_config);
-}
-
 // bw(expm1) = grad * expm1(input) + 1
 std::vector<Tensor> _expm1_bw(const Tensor& grad, const Tensor& input, const MemoryConfig& output_mem_config) {
     std::vector<Tensor> grad_tensor;

--- a/tt_eager/tt_dnn/op_library/backward/backward_ops.cpp
+++ b/tt_eager/tt_dnn/op_library/backward/backward_ops.cpp
@@ -1004,26 +1004,6 @@ std::vector<Tensor> squared_difference_bw(
     return operation::decorate_as_composite(__func__, _squared_difference_bw)(grad, input, other, output_mem_config);
 }
 
-// torch reference
-// - name: ldexp(Tensor self, Tensor other) -> Tensor
-//   self: grad * 2^other
-//   other: grad * self * ln(2) * (2^other)
-// # M_LN2 = ln(2)= 0.693147180559945309417
-std::vector<Tensor> _ldexp_bw(
-    const Tensor& grad, const Tensor& input, const Tensor& other, const MemoryConfig& output_mem_config) {
-    std::vector<Tensor> grad_tensor;
-    Tensor tpow_o = ttnn::multiply(grad, rpow(other, 2.0, output_mem_config), std::nullopt, output_mem_config);
-    grad_tensor.emplace_back(tpow_o);
-    Tensor result = ttnn::multiply(input, mul_unary(tpow_o, M_LN2, output_mem_config), std::nullopt, output_mem_config);
-    grad_tensor.emplace_back(result);
-    return grad_tensor;
-}
-std::vector<Tensor> ldexp_bw(
-    const Tensor& grad, const Tensor& input, const Tensor& other, const MemoryConfig& output_mem_config) {
-    return operation::decorate_as_composite(__func__, _ldexp_bw)(grad, input, other, output_mem_config);
-}
-
-
 /*
 Torch Reference:
 name: logaddexp(Tensor self, Tensor other) -> Tensor

--- a/tt_eager/tt_dnn/op_library/backward/backward_ops.cpp
+++ b/tt_eager/tt_dnn/op_library/backward/backward_ops.cpp
@@ -1004,52 +1004,6 @@ std::vector<Tensor> squared_difference_bw(
     return operation::decorate_as_composite(__func__, _squared_difference_bw)(grad, input, other, output_mem_config);
 }
 
-/*
-Torch Reference:
-name: logaddexp(Tensor self, Tensor other) -> Tensor
-self: grad / (1 + exp(other - self)).conj()
-other: grad / (1 + exp(self - other)).conj()
-*/
-std::vector<Tensor> _logaddexp_bw(
-    const Tensor& grad, const Tensor& input_a, const Tensor& other, const MemoryConfig& output_mem_config) {
-    std::vector<Tensor> grad_tensor;
-    Tensor opexp =
-        add1(exp(ttnn::subtract(other, input_a, std::nullopt, output_mem_config), output_mem_config), output_mem_config);
-    Tensor grad_a = ttnn::multiply(grad, recip(opexp, output_mem_config), std::nullopt, output_mem_config);
-    grad_tensor.emplace_back(grad_a);
-    opexp = add1(exp(ttnn::subtract(input_a, other, std::nullopt, output_mem_config), output_mem_config), output_mem_config);
-    Tensor grad_b = ttnn::multiply(grad, recip(opexp, output_mem_config), std::nullopt, output_mem_config);
-    grad_tensor.emplace_back(grad_b);
-    return grad_tensor;
-}
-std::vector<Tensor> logaddexp_bw(
-    const Tensor& grad, const Tensor& input_a, const Tensor& other, const MemoryConfig& output_mem_config) {
-    return operation::decorate_as_composite(__func__, _logaddexp_bw)(grad, input_a, other, output_mem_config);
-}
-
-/*
-Torch reference
-name: logaddexp2(Tensor self, Tensor other) -> Tensor
-self: grad / (1 + pow(2, other - self))
-other: grad / (1 + pow(2, self - other))
-*/
-
-std::vector<Tensor> _logaddexp2_bw(
-    const Tensor& grad, const Tensor& input_a, const Tensor& other, const MemoryConfig& output_mem_config) {
-    std::vector<Tensor> grad_tensor;
-    Tensor oppow =
-        add1(rpow(ttnn::subtract(other, input_a, std::nullopt, output_mem_config), 2, output_mem_config), output_mem_config);
-    Tensor grad_a = ttnn::multiply(grad, recip(oppow, output_mem_config), std::nullopt, output_mem_config);
-    grad_tensor.emplace_back(grad_a);
-    oppow = add1(rpow(ttnn::subtract(input_a, other, std::nullopt, output_mem_config), 2, output_mem_config), output_mem_config);
-    Tensor grad_b = ttnn::multiply(grad, recip(oppow, output_mem_config), std::nullopt, output_mem_config);
-    grad_tensor.emplace_back(grad_b);
-    return grad_tensor;
-}
-std::vector<Tensor> logaddexp2_bw(
-    const Tensor& grad, const Tensor& input_a, const Tensor& other, const MemoryConfig& output_mem_config) {
-    return operation::decorate_as_composite(__func__, _logaddexp2_bw)(grad, input_a, other, output_mem_config);
-}
 std::vector<Tensor> _concat_bw(
     const Tensor& grad, const Tensor& input, const Tensor& other, int dim, const MemoryConfig& output_mem_config) {
     std::vector<Tensor> grad_tensor;

--- a/tt_eager/tt_dnn/op_library/backward/backward_ops.cpp
+++ b/tt_eager/tt_dnn/op_library/backward/backward_ops.cpp
@@ -1040,39 +1040,6 @@ std::vector<Tensor> ldexp_bw(
     return operation::decorate_as_composite(__func__, _ldexp_bw)(grad, input, other, output_mem_config);
 }
 
-std::vector<Tensor> _xlogy_bw(
-    const Tensor& grad, const Tensor& input, const Tensor& other, const MemoryConfig& output_mem_config) {
-    std::vector<Tensor> grad_tensor;
-    Tensor grad1_result = ttnn::multiply(grad, log(other, output_mem_config), std::nullopt, output_mem_config);
-    Tensor zero_tensor = full_like(other, 0.0, output_mem_config);
-    grad1_result = where(
-        ttnn::logical_and(
-            eqz(input, output_mem_config),
-            ttnn::le(other, zero_tensor, std::nullopt, output_mem_config),
-            std::nullopt,
-            output_mem_config),
-        zero_tensor,
-        where(ltz(other, output_mem_config), std::nanf(" "), grad1_result, output_mem_config),
-        output_mem_config);
-    grad1_result =
-        where(eq_unary(input, std::nanf(" "), output_mem_config), std::nanf(" "), grad1_result, output_mem_config);
-    grad_tensor.emplace_back(grad1_result);
-    Tensor div_result = ttnn::multiply(input, recip(other, output_mem_config), std::nullopt, output_mem_config);
-    Tensor grad2_result = ttnn::multiply(grad, div_result, std::nullopt, output_mem_config);
-    grad2_result = where(
-        eqz(other, output_mem_config),
-        mul_unary(sign(grad, output_mem_config), std::numeric_limits<float>::infinity(), output_mem_config),
-        grad2_result,
-        output_mem_config);
-    grad2_result =
-        where(eq_unary(other, std::nanf(" "), output_mem_config), std::nanf(" "), grad2_result, output_mem_config);
-    grad_tensor.emplace_back(grad2_result);
-    return grad_tensor;
-}
-std::vector<Tensor> xlogy_bw(
-    const Tensor& grad, const Tensor& input, const Tensor& other, const MemoryConfig& output_mem_config) {
-    return operation::decorate_as_composite(__func__, _xlogy_bw)(grad, input, other, output_mem_config);
-}
 
 /*
 Torch Reference:

--- a/tt_eager/tt_dnn/op_library/backward/backward_ops.hpp
+++ b/tt_eager/tt_dnn/op_library/backward/backward_ops.hpp
@@ -323,12 +323,6 @@ std::vector<Tensor> ldexp_bw(
     const Tensor& other,
     const MemoryConfig& output_mem_config = operation::DEFAULT_OUTPUT_MEMORY_CONFIG);
 
-std::vector<Tensor> xlogy_bw(
-    const Tensor& grad,
-    const Tensor& input,
-    const Tensor& other,
-    const MemoryConfig& output_mem_config = operation::DEFAULT_OUTPUT_MEMORY_CONFIG);
-
 std::vector<Tensor> logaddexp_bw(
     const Tensor& grad,
     const Tensor& input,

--- a/tt_eager/tt_dnn/op_library/backward/backward_ops.hpp
+++ b/tt_eager/tt_dnn/op_library/backward/backward_ops.hpp
@@ -259,12 +259,6 @@ std::vector<Tensor> clamp_max_bw(
     float max,
     const MemoryConfig& output_mem_config = operation::DEFAULT_OUTPUT_MEMORY_CONFIG);
 
-std::vector<Tensor> hypot_bw(
-    const Tensor& grad,
-    const Tensor& input,
-    const Tensor& other,
-    const MemoryConfig& output_mem_config = operation::DEFAULT_OUTPUT_MEMORY_CONFIG);
-
 std::vector<Tensor> exp2_bw(
     const Tensor& grad,
     const Tensor& input,

--- a/tt_eager/tt_dnn/op_library/backward/backward_ops.hpp
+++ b/tt_eager/tt_dnn/op_library/backward/backward_ops.hpp
@@ -311,12 +311,6 @@ std::vector<Tensor> lerp_bw(
     const Tensor& weight,
     const MemoryConfig& output_mem_config = operation::DEFAULT_OUTPUT_MEMORY_CONFIG);
 
-std::vector<Tensor> ldexp_bw(
-    const Tensor& grad,
-    const Tensor& input,
-    const Tensor& other,
-    const MemoryConfig& output_mem_config = operation::DEFAULT_OUTPUT_MEMORY_CONFIG);
-
 std::vector<Tensor> logaddexp_bw(
     const Tensor& grad,
     const Tensor& input,

--- a/tt_eager/tt_dnn/op_library/backward/backward_ops.hpp
+++ b/tt_eager/tt_dnn/op_library/backward/backward_ops.hpp
@@ -289,12 +289,6 @@ std::vector<Tensor> bias_gelu_unary_bw(
     string approximate,
     const MemoryConfig& output_mem_config = operation::DEFAULT_OUTPUT_MEMORY_CONFIG);
 
-std::vector<Tensor> squared_difference_bw(
-    const Tensor& grad,
-    const Tensor& input,
-    const Tensor& other,
-    const MemoryConfig& output_mem_config = operation::DEFAULT_OUTPUT_MEMORY_CONFIG);
-
 // lerp(input, end, weight) = self: grad * (1 - weight), end: grad * weight, weight is float
 std::vector<Tensor> lerp_bw(
     const Tensor& grad,

--- a/tt_eager/tt_dnn/op_library/backward/backward_ops.hpp
+++ b/tt_eager/tt_dnn/op_library/backward/backward_ops.hpp
@@ -311,18 +311,6 @@ std::vector<Tensor> lerp_bw(
     const Tensor& weight,
     const MemoryConfig& output_mem_config = operation::DEFAULT_OUTPUT_MEMORY_CONFIG);
 
-std::vector<Tensor> logaddexp_bw(
-    const Tensor& grad,
-    const Tensor& input,
-    const Tensor& other,
-    const MemoryConfig& output_mem_config = operation::DEFAULT_OUTPUT_MEMORY_CONFIG);
-
-std::vector<Tensor> logaddexp2_bw(
-    const Tensor& grad,
-    const Tensor& input,
-    const Tensor& other,
-    const MemoryConfig& output_mem_config = operation::DEFAULT_OUTPUT_MEMORY_CONFIG);
-
 std::vector<Tensor> concat_bw(
     const Tensor& grad,
     const Tensor& input,

--- a/tt_eager/tt_lib/csrc/tt_lib_bindings_tensor_backward_ops.cpp
+++ b/tt_eager/tt_lib/csrc/tt_lib_bindings_tensor_backward_ops.cpp
@@ -921,22 +921,6 @@ namespace tt::tt_metal::detail{
                 "output_mem_config", "Layout of tensor in TT Accelerator device memory banks", "MemoryConfig", "Default is interleaved in DRAM", "No"
         )doc");
 
-    m_tensor.def("ldexp_bw", &tt::tt_metal::ldexp_bw,
-            py::arg("grad").noconvert(), py::arg("input").noconvert(), py::arg("other").noconvert(), py::arg("output_mem_config").noconvert() = operation::DEFAULT_OUTPUT_MEMORY_CONFIG, R"doc(
-            Performs backward operations for ldexp of ``input`` and ``other`` tensors with given ``grad``.
-
-            Input tensors must have BFLOAT16 data type.
-
-            Output tensors will have BFLOAT16 data type.
-
-            .. csv-table::
-                :header: "Argument", "Description", "Data type", "Valid range", "Required"
-
-                "grad", "Gradient tensor", "Tensor", "Tensor of shape [W, Z, Y, X]", "Yes"
-                "input", "Tensor", "Tensor", "Tensor of shape [W, Z, Y, X]", "Yes"
-                "other", "Tensor", "Tensor", "Tensor of shape [W, Z, Y, X]", "Yes"
-                "output_mem_config", "Layout of tensor in TT Accelerator device memory banks", "MemoryConfig", "Default is interleaved in DRAM", "No"
-        )doc");
 
     m_tensor.def("hardswish_bw", &tt::tt_metal::hardswish_bw,
             py::arg("grad").noconvert(), py::arg("input").noconvert(), py::arg("output_mem_config").noconvert() = operation::DEFAULT_OUTPUT_MEMORY_CONFIG, R"doc(

--- a/tt_eager/tt_lib/csrc/tt_lib_bindings_tensor_backward_ops.cpp
+++ b/tt_eager/tt_lib/csrc/tt_lib_bindings_tensor_backward_ops.cpp
@@ -989,22 +989,6 @@ namespace tt::tt_metal::detail{
                 "output_mem_config", "Layout of tensor in TT Accelerator device memory banks", "MemoryConfig", "Default is interleaved in DRAM", "No"
         )doc");
 
-   m_tensor.def("xlogy_bw", &tt::tt_metal::xlogy_bw,
-            py::arg("grad").noconvert(), py::arg("input").noconvert(), py::arg("other").noconvert(), py::arg("output_mem_config").noconvert() = operation::DEFAULT_OUTPUT_MEMORY_CONFIG, R"doc(
-            Performs backward operations for xlogy  for ``input`` and  ``other`` with given ``grad``.
-
-            Input tensors must have BFLOAT16 data type.
-
-            Output tensor will have BFLOAT16 data type.
-
-            .. csv-table::
-                :header: "Argument", "Description", "Data type", "Valid range", "Required"
-
-                "grad", "Gradient tensor", "Tensor", "Tensor of shape [W, Z, Y, X]", "Yes"
-                "input", "Tensor", "Tensor", "Tensor of shape [W, Z, Y, X]", "Yes"
-                "other", "Tensor", "Tensor", "Tensor of shape [W, Z, Y, X]", "Yes"
-                "output_mem_config", "Layout of tensor in TT Accelerator device memory banks", "MemoryConfig", "Default is interleaved in DRAM", "No"
-        )doc");
 
    m_tensor.def("logaddexp_bw", &tt::tt_metal::logaddexp_bw,
             py::arg("grad").noconvert(), py::arg("input").noconvert(), py::arg("other").noconvert(), py::arg("output_mem_config").noconvert() = operation::DEFAULT_OUTPUT_MEMORY_CONFIG, R"doc(

--- a/tt_eager/tt_lib/csrc/tt_lib_bindings_tensor_backward_ops.cpp
+++ b/tt_eager/tt_lib/csrc/tt_lib_bindings_tensor_backward_ops.cpp
@@ -851,23 +851,6 @@ namespace tt::tt_metal::detail{
                 "output_mem_config", "Layout of tensor in TT Accelerator device memory banks", "MemoryConfig", "Default is interleaved in DRAM", "No"
         )doc");
 
-    m_tensor.def("hypot_bw", &tt::tt_metal::hypot_bw,
-            py::arg("grad").noconvert(), py::arg("input").noconvert(), py::arg("other").noconvert(), py::arg("output_mem_config").noconvert() = operation::DEFAULT_OUTPUT_MEMORY_CONFIG, R"doc(
-            Performs backward operations for hypotenuse of ``input`` and ``other`` tensors with given ``grad``.
-
-            Input tensors must have BFLOAT16 data type.
-
-            Output tensors will have BFLOAT16 data type.
-
-            .. csv-table::
-                :header: "Argument", "Description", "Data type", "Valid range", "Required"
-
-                "grad", "Gradient tensor", "Tensor", "Tensor of shape [W, Z, Y, X]", "Yes"
-                "input", "First input tensor", "Tensor", "Tensor of shape [W, Z, Y, X]", "Yes"
-                "other", "Second input Tensor", "Tensor", "Tensor of shape [W, Z, Y, X]", "Yes"
-                "output_mem_config", "Layout of tensor in TT Accelerator device memory banks", "MemoryConfig", "Default is interleaved in DRAM", "No"
-        )doc");
-
     m_tensor.def("gelu_bw", &tt::tt_metal::gelu_bw,
             py::arg("grad").noconvert(), py::arg("input").noconvert(), py::arg("approximate").noconvert(), py::arg("output_mem_config").noconvert() = operation::DEFAULT_OUTPUT_MEMORY_CONFIG, R"doc(
             Performs backward operations for gelu of ``input`` tensor with given ``grad``.

--- a/tt_eager/tt_lib/csrc/tt_lib_bindings_tensor_backward_ops.cpp
+++ b/tt_eager/tt_lib/csrc/tt_lib_bindings_tensor_backward_ops.cpp
@@ -956,41 +956,6 @@ namespace tt::tt_metal::detail{
                 "output_mem_config", "Layout of tensor in TT Accelerator device memory banks", "MemoryConfig", "Default is interleaved in DRAM", "No"
         )doc");
 
-
-   m_tensor.def("logaddexp_bw", &tt::tt_metal::logaddexp_bw,
-            py::arg("grad").noconvert(), py::arg("input").noconvert(), py::arg("other").noconvert(), py::arg("output_mem_config").noconvert() = operation::DEFAULT_OUTPUT_MEMORY_CONFIG, R"doc(
-            Performs backward operations for logaddexp (``input``, ``other``)  with given ``grad``.
-
-            Input tensors must have BFLOAT16 data type.
-
-            Output tensor will have BFLOAT16 data type.
-
-            .. csv-table::
-                :header: "Argument", "Description", "Data type", "Valid range", "Required"
-
-                "grad", "Gradient tensor", "Tensor", "Tensor of shape [W, Z, Y, X]", "Yes"
-                "input", "Tensor", "Tensor", "Tensor of shape [W, Z, Y, X]", "Yes"
-                "other", "Tensor", "Tensor", "Tensor of shape [W, Z, Y, X]", "Yes"
-                "output_mem_config", "Layout of tensor in TT Accelerator device memory banks", "MemoryConfig", "Default is interleaved in DRAM", "No"
-        )doc");
-
-    m_tensor.def("logaddexp2_bw", &tt::tt_metal::logaddexp2_bw,
-            py::arg("grad").noconvert(), py::arg("input").noconvert(), py::arg("other").noconvert(), py::arg("output_mem_config").noconvert() = operation::DEFAULT_OUTPUT_MEMORY_CONFIG, R"doc(
-            Performs backward operations for logaddexp2 (``input``, ``other``)  with given ``grad``.
-
-            Input tensors must have BFLOAT16 data type.
-
-            Output tensor will have BFLOAT16 data type.
-
-            .. csv-table::
-                :header: "Argument", "Description", "Data type", "Valid range", "Required"
-
-                "grad", "Gradient tensor", "Tensor", "Tensor of shape [W, Z, Y, X]", "Yes"
-                "input", "Tensor", "Tensor", "Tensor of shape [W, Z, Y, X]", "Yes"
-                "other", "Tensor", "Tensor", "Tensor of shape [W, Z, Y, X]", "Yes"
-                "output_mem_config", "Layout of tensor in TT Accelerator device memory banks", "MemoryConfig", "Default is interleaved in DRAM", "No"
-        )doc");
-
     m_tensor.def("concat_bw", &tt::tt_metal::concat_bw,
             py::arg("grad").noconvert(), py::arg("input_a").noconvert(), py::arg("input_b").noconvert(),  py::arg("dim") = 0, py::arg("output_mem_config").noconvert() = operation::DEFAULT_OUTPUT_MEMORY_CONFIG, R"doc(
             Performs backward operations for concat of ``input_a`` and ``input_b`` tensors with given ``grad``.

--- a/tt_eager/tt_lib/csrc/tt_lib_bindings_tensor_backward_ops.cpp
+++ b/tt_eager/tt_lib/csrc/tt_lib_bindings_tensor_backward_ops.cpp
@@ -904,23 +904,6 @@ namespace tt::tt_metal::detail{
                 "output_mem_config", "Layout of tensor in TT Accelerator device memory banks", "MemoryConfig", "Default is interleaved in DRAM", "No"
         )doc");
 
-    m_tensor.def("squared_difference_bw", &tt::tt_metal::squared_difference_bw,
-            py::arg("grad").noconvert(), py::arg("input").noconvert(), py::arg("other").noconvert(), py::arg("output_mem_config").noconvert() = operation::DEFAULT_OUTPUT_MEMORY_CONFIG, R"doc(
-            Performs backward operations for squared difference of ``input`` and ``other`` tensors with given ``grad``.
-
-            Input tensors must have BFLOAT16 data type.
-
-            Output tensors will have BFLOAT16 data type.
-
-            .. csv-table::
-                :header: "Argument", "Description", "Data type", "Valid range", "Required"
-
-                "grad", "Gradient tensor", "Tensor", "Tensor of shape [W, Z, Y, X]", "Yes"
-                "input", "Tensor squared difference is applied to", "Tensor", "Tensor of shape [W, Z, Y, X]", "Yes"
-                "other", "Tensor squared difference is applied to", "Tensor", "Tensor of shape [W, Z, Y, X]", "Yes"
-                "output_mem_config", "Layout of tensor in TT Accelerator device memory banks", "MemoryConfig", "Default is interleaved in DRAM", "No"
-        )doc");
-
 
     m_tensor.def("hardswish_bw", &tt::tt_metal::hardswish_bw,
             py::arg("grad").noconvert(), py::arg("input").noconvert(), py::arg("output_mem_config").noconvert() = operation::DEFAULT_OUTPUT_MEMORY_CONFIG, R"doc(

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_backward/binary_backward.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_backward/binary_backward.hpp
@@ -148,6 +148,7 @@ constexpr auto sub_bw = ttnn::register_operation<operations::binary_backward::Ex
 constexpr auto addalpha_bw = ttnn::register_operation<operations::binary_backward::ExecuteBinaryBackward<operations::binary_backward::BinaryBackwardOpType::ADDALPHA_BW>>("ttnn::addalpha_bw");
 
 constexpr auto xlogy_bw = ttnn::register_operation<operations::binary_backward::ExecuteBinaryBackward<operations::binary_backward::BinaryBackwardOpType::XLOGY_BW>>("ttnn::xlogy_bw");
+constexpr auto hypot_bw = ttnn::register_operation<operations::binary_backward::ExecuteBinaryBackward<operations::binary_backward::BinaryBackwardOpType::HYPOT_BW>>("ttnn::hypot_bw");
 
 
 }  // namespace ttnn

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_backward/binary_backward.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_backward/binary_backward.hpp
@@ -147,5 +147,7 @@ constexpr auto sub_bw = ttnn::register_operation<operations::binary_backward::Ex
 //type 2
 constexpr auto addalpha_bw = ttnn::register_operation<operations::binary_backward::ExecuteBinaryBackward<operations::binary_backward::BinaryBackwardOpType::ADDALPHA_BW>>("ttnn::addalpha_bw");
 
+constexpr auto xlogy_bw = ttnn::register_operation<operations::binary_backward::ExecuteBinaryBackward<operations::binary_backward::BinaryBackwardOpType::XLOGY_BW>>("ttnn::xlogy_bw");
+
 
 }  // namespace ttnn

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_backward/binary_backward.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_backward/binary_backward.hpp
@@ -150,6 +150,8 @@ constexpr auto addalpha_bw = ttnn::register_operation<operations::binary_backwar
 constexpr auto xlogy_bw = ttnn::register_operation<operations::binary_backward::ExecuteBinaryBackward<operations::binary_backward::BinaryBackwardOpType::XLOGY_BW>>("ttnn::xlogy_bw");
 constexpr auto hypot_bw = ttnn::register_operation<operations::binary_backward::ExecuteBinaryBackward<operations::binary_backward::BinaryBackwardOpType::HYPOT_BW>>("ttnn::hypot_bw");
 constexpr auto ldexp_bw = ttnn::register_operation<operations::binary_backward::ExecuteBinaryBackward<operations::binary_backward::BinaryBackwardOpType::LDEXP_BW>>("ttnn::ldexp_bw");
+constexpr auto logaddexp_bw = ttnn::register_operation<operations::binary_backward::ExecuteBinaryBackward<operations::binary_backward::BinaryBackwardOpType::LOGADDEXP_BW>>("ttnn::logaddexp_bw");
+constexpr auto logaddexp2_bw = ttnn::register_operation<operations::binary_backward::ExecuteBinaryBackward<operations::binary_backward::BinaryBackwardOpType::LOGADDEXP2_BW>>("ttnn::logaddexp2_bw");
 
 
 }  // namespace ttnn

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_backward/binary_backward.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_backward/binary_backward.hpp
@@ -152,6 +152,7 @@ constexpr auto hypot_bw = ttnn::register_operation<operations::binary_backward::
 constexpr auto ldexp_bw = ttnn::register_operation<operations::binary_backward::ExecuteBinaryBackward<operations::binary_backward::BinaryBackwardOpType::LDEXP_BW>>("ttnn::ldexp_bw");
 constexpr auto logaddexp_bw = ttnn::register_operation<operations::binary_backward::ExecuteBinaryBackward<operations::binary_backward::BinaryBackwardOpType::LOGADDEXP_BW>>("ttnn::logaddexp_bw");
 constexpr auto logaddexp2_bw = ttnn::register_operation<operations::binary_backward::ExecuteBinaryBackward<operations::binary_backward::BinaryBackwardOpType::LOGADDEXP2_BW>>("ttnn::logaddexp2_bw");
+constexpr auto squared_difference_bw = ttnn::register_operation<operations::binary_backward::ExecuteBinaryBackward<operations::binary_backward::BinaryBackwardOpType::SQUARED_DIFFERENCE_BW>>("ttnn::squared_difference_bw");
 
 
 }  // namespace ttnn

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_backward/binary_backward.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_backward/binary_backward.hpp
@@ -149,6 +149,7 @@ constexpr auto addalpha_bw = ttnn::register_operation<operations::binary_backwar
 
 constexpr auto xlogy_bw = ttnn::register_operation<operations::binary_backward::ExecuteBinaryBackward<operations::binary_backward::BinaryBackwardOpType::XLOGY_BW>>("ttnn::xlogy_bw");
 constexpr auto hypot_bw = ttnn::register_operation<operations::binary_backward::ExecuteBinaryBackward<operations::binary_backward::BinaryBackwardOpType::HYPOT_BW>>("ttnn::hypot_bw");
+constexpr auto ldexp_bw = ttnn::register_operation<operations::binary_backward::ExecuteBinaryBackward<operations::binary_backward::BinaryBackwardOpType::LDEXP_BW>>("ttnn::ldexp_bw");
 
 
 }  // namespace ttnn

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_backward/binary_backward_pybind.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_backward/binary_backward_pybind.hpp
@@ -187,6 +187,11 @@ void py_module(py::module& module) {
         ttnn::logaddexp2_bw,
         R"doc(Performs backward operations for logaddexp2 of :attr:`input_tensor_a` and :attr:`input_tensor_b` tensors with given :attr:`grad_tensor`.)doc");
 
+    detail::bind_binary_backward(
+        module,
+        ttnn::squared_difference_bw,
+        R"doc(Performs backward operations for squared_difference of :attr:`input_tensor_a` and :attr:`input_tensor_b` tensors with given :attr:`grad_tensor`.)doc");
+
 }
 
 }  // namespace binary_backward

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_backward/binary_backward_pybind.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_backward/binary_backward_pybind.hpp
@@ -176,6 +176,17 @@ void py_module(py::module& module) {
         module,
         ttnn::ldexp_bw,
         R"doc(Performs backward operations for ldexp of :attr:`input_tensor_a` and :attr:`input_tensor_b` tensors with given :attr:`grad_tensor`.)doc");
+
+    detail::bind_binary_backward(
+        module,
+        ttnn::logaddexp_bw,
+        R"doc(Performs backward operations for logaddexp of :attr:`input_tensor_a` and :attr:`input_tensor_b` tensors with given :attr:`grad_tensor`.)doc");
+
+    detail::bind_binary_backward(
+        module,
+        ttnn::logaddexp2_bw,
+        R"doc(Performs backward operations for logaddexp2 of :attr:`input_tensor_a` and :attr:`input_tensor_b` tensors with given :attr:`grad_tensor`.)doc");
+
 }
 
 }  // namespace binary_backward

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_backward/binary_backward_pybind.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_backward/binary_backward_pybind.hpp
@@ -170,10 +170,14 @@ void py_module(py::module& module) {
     detail::bind_binary_backward(
         module,
         ttnn::hypot_bw,
-        R"doc(Performs backward operations for hypot_bw of :attr:`input_tensor_a` and :attr:`input_tensor_b` tensors with given :attr:`grad_tensor`.)doc");
+        R"doc(Performs backward operations for hypot of :attr:`input_tensor_a` and :attr:`input_tensor_b` tensors with given :attr:`grad_tensor`.)doc");
 
+    detail::bind_binary_backward(
+        module,
+        ttnn::ldexp_bw,
+        R"doc(Performs backward operations for ldexp of :attr:`input_tensor_a` and :attr:`input_tensor_b` tensors with given :attr:`grad_tensor`.)doc");
 }
 
-}  // namespace copy
+}  // namespace binary_backward
 }  // namespace operations
 }  // namespace ttnn

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_backward/binary_backward_pybind.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_backward/binary_backward_pybind.hpp
@@ -161,6 +161,12 @@ void py_module(py::module& module) {
         module,
         ttnn::addalpha_bw,
         R"doc(Performs backward operations for addalpha on :attr:`input_tensor_b` , attr:`input_tensor_a`, attr:`alpha` tensors with given attr:`grad_tensor`.)doc");
+
+    detail::bind_binary_backward(
+        module,
+        ttnn::xlogy_bw,
+        R"doc(Performs backward operations for xlogy of :attr:`input_tensor_a` and :attr:`input_tensor_b` tensors with given :attr:`grad_tensor`.)doc");
+
 }
 
 }  // namespace copy

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_backward/binary_backward_pybind.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_backward/binary_backward_pybind.hpp
@@ -167,6 +167,11 @@ void py_module(py::module& module) {
         ttnn::xlogy_bw,
         R"doc(Performs backward operations for xlogy of :attr:`input_tensor_a` and :attr:`input_tensor_b` tensors with given :attr:`grad_tensor`.)doc");
 
+    detail::bind_binary_backward(
+        module,
+        ttnn::hypot_bw,
+        R"doc(Performs backward operations for hypot_bw of :attr:`input_tensor_a` and :attr:`input_tensor_b` tensors with given :attr:`grad_tensor`.)doc");
+
 }
 
 }  // namespace copy

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_backward/device/binary_backward_op.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_backward/device/binary_backward_op.cpp
@@ -239,6 +239,18 @@ std::vector<ttnn::Tensor> _logaddexp2_bw(
 }
 
 
+std::vector<ttnn::Tensor> _squared_difference_bw(
+    const Tensor& grad, const Tensor& input, const Tensor& other, const MemoryConfig& output_mem_config) {
+    std::vector<Tensor> grad_tensor;
+    Tensor difference = ttnn::subtract(input, other);
+    Tensor grad_a = mul_unary(2, ttnn::multiply(grad, difference, std::nullopt, output_mem_config), output_mem_config);
+    grad_tensor.emplace_back(grad_a);
+    Tensor grad_b = mul_unary(-1, grad_a, output_mem_config);
+    grad_tensor.emplace_back(grad_b);
+    return grad_tensor;
+}
+
+
 std::function<std::vector<ttnn::Tensor>(const Tensor&, const Tensor&, const Tensor&, const MemoryConfig&)> get_function_type1(BinaryBackwardOpType OpType){
     switch (OpType) {
         case BinaryBackwardOpType::ATAN2_BW:
@@ -257,6 +269,8 @@ std::function<std::vector<ttnn::Tensor>(const Tensor&, const Tensor&, const Tens
             return _logaddexp_bw;
         case BinaryBackwardOpType::LOGADDEXP2_BW:
             return _logaddexp2_bw;
+        case BinaryBackwardOpType::SQUARED_DIFFERENCE_BW:
+            return _squared_difference_bw;
         default:
             TT_ASSERT(false && "Undefined op type");
             return 0;
@@ -286,8 +300,13 @@ std::function<std::vector<ttnn::Tensor>(uint8_t , const Tensor&, const Tensor&, 
 }
 
 std::function<std::vector<ttnn::Tensor>(const Tensor&, const Tensor&, const Tensor&, float, const MemoryConfig&, const std::vector<bool>&, std::optional<Tensor>, std::optional<Tensor>)> get_function_type2_wo_qid(BinaryBackwardOpType OpType){
+    switch (OpType) {
         case BinaryBackwardOpType::ADDALPHA_BW:
             return _addalpha_bw_overload;
+        default:
+            TT_ASSERT(false && "Undefined op type");
+            return 0;
+    }
 }
 }
 

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_backward/device/binary_backward_op.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_backward/device/binary_backward_op.hpp
@@ -21,6 +21,8 @@ enum class BinaryBackwardOpType {
     XLOGY_BW,
     HYPOT_BW,
     LDEXP_BW,
+    LOGADDEXP_BW,
+    LOGADDEXP2_BW,
 };
 
 

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_backward/device/binary_backward_op.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_backward/device/binary_backward_op.hpp
@@ -19,6 +19,7 @@ enum class BinaryBackwardOpType {
     SUBALPHA_BW,
     SUB_BW,
     XLOGY_BW,
+    HYPOT_BW,
 };
 
 

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_backward/device/binary_backward_op.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_backward/device/binary_backward_op.hpp
@@ -23,6 +23,7 @@ enum class BinaryBackwardOpType {
     LDEXP_BW,
     LOGADDEXP_BW,
     LOGADDEXP2_BW,
+    SQUARED_DIFFERENCE_BW,
 };
 
 

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_backward/device/binary_backward_op.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_backward/device/binary_backward_op.hpp
@@ -17,7 +17,8 @@ enum class BinaryBackwardOpType {
     EMBEDDING_BW,
     ADDALPHA_BW,
     SUBALPHA_BW,
-    SUB_BW
+    SUB_BW,
+    XLOGY_BW,
 };
 
 

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_backward/device/binary_backward_op.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_backward/device/binary_backward_op.hpp
@@ -20,6 +20,7 @@ enum class BinaryBackwardOpType {
     SUB_BW,
     XLOGY_BW,
     HYPOT_BW,
+    LDEXP_BW,
 };
 
 

--- a/ttnn/ttnn/__init__.py
+++ b/ttnn/ttnn/__init__.py
@@ -462,6 +462,8 @@ from ttnn.operations.binary_backward import (
     xlogy_bw,
     hypot_bw,
     ldexp_bw,
+    logaddexp_bw,
+    logaddexp2_bw,
 )
 
 from ttnn.operations.ternary import (

--- a/ttnn/ttnn/__init__.py
+++ b/ttnn/ttnn/__init__.py
@@ -464,6 +464,7 @@ from ttnn.operations.binary_backward import (
     ldexp_bw,
     logaddexp_bw,
     logaddexp2_bw,
+    squared_difference_bw,
 )
 
 from ttnn.operations.ternary import (

--- a/ttnn/ttnn/__init__.py
+++ b/ttnn/ttnn/__init__.py
@@ -460,6 +460,7 @@ from ttnn.operations.binary_backward import (
     subalpha_bw,
     sub_bw,
     xlogy_bw,
+    hypot_bw,
 )
 
 from ttnn.operations.ternary import (

--- a/ttnn/ttnn/__init__.py
+++ b/ttnn/ttnn/__init__.py
@@ -461,6 +461,7 @@ from ttnn.operations.binary_backward import (
     sub_bw,
     xlogy_bw,
     hypot_bw,
+    ldexp_bw,
 )
 
 from ttnn.operations.ternary import (

--- a/ttnn/ttnn/__init__.py
+++ b/ttnn/ttnn/__init__.py
@@ -452,7 +452,15 @@ from ttnn.operations.binary import (
     divide,
 )
 
-from ttnn.operations.binary_backward import atan2_bw, embedding_bw, addalpha_bw, subalpha_bw, sub_bw
+
+from ttnn.operations.binary_backward import (
+    atan2_bw,
+    embedding_bw,
+    addalpha_bw,
+    subalpha_bw,
+    sub_bw,
+    xlogy_bw,
+)
 
 from ttnn.operations.ternary import (
     addcdiv,

--- a/ttnn/ttnn/operations/binary_backward.py
+++ b/ttnn/ttnn/operations/binary_backward.py
@@ -60,6 +60,21 @@ def _golden_function(grad_tensor, input_tensor_a, input_tensor_b, *args, **kwarg
 hypot_bw = ttnn.register_operation(golden_function=_golden_function)(ttnn._ttnn.operations.binary_backward.hypot_bw)
 
 
+def _golden_function(grad_tensor, input_tensor_a, input_tensor_b, *args, **kwargs):
+    import torch
+
+    pyt_y = torch.ldexp(input_tensor_a, input_tensor_b)
+    input_tensor_a.retain_grad()
+    input_tensor_b.retain_grad()
+
+    pyt_y.backward(gradient=grad_tensor)
+    golden_tensor = [input_tensor_a.grad, input_tensor_b.grad]
+    return golden_tensor
+
+
+ldexp_bw = ttnn.register_operation(golden_function=_golden_function)(ttnn._ttnn.operations.binary_backward.ldexp_bw)
+
+
 def _golden_function(grad_tensor, input_tensor, weight_tensor, *args, **kwargs):
     import torch
 

--- a/ttnn/ttnn/operations/binary_backward.py
+++ b/ttnn/ttnn/operations/binary_backward.py
@@ -30,6 +30,21 @@ def _golden_function(grad_tensor, input_tensor_a, input_tensor_b, *args, **kwarg
 atan2_bw = ttnn.register_operation(golden_function=_golden_function)(ttnn._ttnn.operations.binary_backward.atan2_bw)
 
 
+def _golden_function(grad_tensor, input_tensor_a, input_tensor_b, *args, **kwargs):
+    import torch
+
+    pyt_y = torch.xlogy(input_tensor_a, input_tensor_b)
+    input_tensor_a.retain_grad()
+    input_tensor_b.retain_grad()
+
+    pyt_y.backward(gradient=grad_tensor)
+    golden_tensor = [input_tensor_a.grad, input_tensor_b.grad]
+    return golden_tensor
+
+
+xlogy_bw = ttnn.register_operation(golden_function=_golden_function)(ttnn._ttnn.operations.binary_backward.xlogy_bw)
+
+
 def _golden_function(grad_tensor, input_tensor, weight_tensor, *args, **kwargs):
     import torch
 

--- a/ttnn/ttnn/operations/binary_backward.py
+++ b/ttnn/ttnn/operations/binary_backward.py
@@ -45,6 +45,21 @@ def _golden_function(grad_tensor, input_tensor_a, input_tensor_b, *args, **kwarg
 xlogy_bw = ttnn.register_operation(golden_function=_golden_function)(ttnn._ttnn.operations.binary_backward.xlogy_bw)
 
 
+def _golden_function(grad_tensor, input_tensor_a, input_tensor_b, *args, **kwargs):
+    import torch
+
+    pyt_y = torch.hypot(input_tensor_a, input_tensor_b)
+    input_tensor_a.retain_grad()
+    input_tensor_b.retain_grad()
+
+    pyt_y.backward(gradient=grad_tensor)
+    golden_tensor = [input_tensor_a.grad, input_tensor_b.grad]
+    return golden_tensor
+
+
+hypot_bw = ttnn.register_operation(golden_function=_golden_function)(ttnn._ttnn.operations.binary_backward.hypot_bw)
+
+
 def _golden_function(grad_tensor, input_tensor, weight_tensor, *args, **kwargs):
     import torch
 

--- a/ttnn/ttnn/operations/binary_backward.py
+++ b/ttnn/ttnn/operations/binary_backward.py
@@ -109,6 +109,23 @@ logaddexp2_bw = ttnn.register_operation(golden_function=_golden_function)(
 )
 
 
+def _golden_function(grad_tensor, input_tensor_a, input_tensor_b, *args, **kwargs):
+    import torch
+
+    pyt_y = torch.square(torch.sub(input_tensor_a, input_tensor_b))
+    input_tensor_a.retain_grad()
+    input_tensor_b.retain_grad()
+
+    pyt_y.backward(gradient=grad_tensor)
+    golden_tensor = [input_tensor_a.grad, input_tensor_b.grad]
+    return golden_tensor
+
+
+squared_difference_bw = ttnn.register_operation(golden_function=_golden_function)(
+    ttnn._ttnn.operations.binary_backward.squared_difference_bw
+)
+
+
 def _golden_function(grad_tensor, input_tensor, weight_tensor, *args, **kwargs):
     import torch
 

--- a/ttnn/ttnn/operations/binary_backward.py
+++ b/ttnn/ttnn/operations/binary_backward.py
@@ -75,6 +75,40 @@ def _golden_function(grad_tensor, input_tensor_a, input_tensor_b, *args, **kwarg
 ldexp_bw = ttnn.register_operation(golden_function=_golden_function)(ttnn._ttnn.operations.binary_backward.ldexp_bw)
 
 
+def _golden_function(grad_tensor, input_tensor_a, input_tensor_b, *args, **kwargs):
+    import torch
+
+    pyt_y = torch.logaddexp(input_tensor_a, input_tensor_b)
+    input_tensor_a.retain_grad()
+    input_tensor_b.retain_grad()
+
+    pyt_y.backward(gradient=grad_tensor)
+    golden_tensor = [input_tensor_a.grad, input_tensor_b.grad]
+    return golden_tensor
+
+
+logaddexp_bw = ttnn.register_operation(golden_function=_golden_function)(
+    ttnn._ttnn.operations.binary_backward.logaddexp_bw
+)
+
+
+def _golden_function(grad_tensor, input_tensor_a, input_tensor_b, *args, **kwargs):
+    import torch
+
+    pyt_y = torch.logaddexp2(input_tensor_a, input_tensor_b)
+    input_tensor_a.retain_grad()
+    input_tensor_b.retain_grad()
+
+    pyt_y.backward(gradient=grad_tensor)
+    golden_tensor = [input_tensor_a.grad, input_tensor_b.grad]
+    return golden_tensor
+
+
+logaddexp2_bw = ttnn.register_operation(golden_function=_golden_function)(
+    ttnn._ttnn.operations.binary_backward.logaddexp2_bw
+)
+
+
 def _golden_function(grad_tensor, input_tensor, weight_tensor, *args, **kwargs):
     import torch
 


### PR DESCRIPTION
### Ticket
- #9628 

Added support for 
- hybot_bw
- xlogy_bw
- ldexp
- logaddexp
- logaddexp2
- squared_difference

### Problem description
- Move binary backward ops to TTNN folder

### What's changed

```
ttnn
└── cpp
    └── ttnn
        └── operations
            └── ...
            └── eltwise
                └── binary
                └── binary_backward
                    ├── device
                    │   ├── binary_backward_op.cpp
                    │   ├── binary_backward_op.hpp
                    ├── binary_backward.hpp
                    └── binary_backward_pybind.hpp
```

### Checklist
- [ ] Post commit CI passes
- [ ] Model regression CI testing passes (if applicable)
- [ ] New/Existing tests provide coverage for changes
