### PR TITLE
Support 8k decode in Llama3

### DIFF
--- a/models/experimental/llama2_70b/tt/llama_attention_optimized.py
+++ b/models/experimental/llama2_70b/tt/llama_attention_optimized.py
@@ -12,6 +12,8 @@ from models.utility_functions import nearest_32
 from models.experimental.llama2_70b.tt.llama_common import (
     MAX_SEQ_LEN,
     MAX_SEQ_LEN_LLAMA3,
+    get_padded_layer_len,
+    get_flash_decode_chunk_size,
 )
 
 
@@ -26,7 +28,6 @@ class TtLlamaAttention_optimized:
         configuration,
         transformation_mats,
         cache_path=None,
-        batch_size=None,
         read_cache=False,
     ):
         self.state_dict = state_dict
@@ -39,7 +40,7 @@ class TtLlamaAttention_optimized:
         self.n_heads = configuration.n_heads
         self.n_kv_heads = configuration.n_kv_heads
         self.head_dim = self.hidden_size // self.n_heads
-        self.max_seq_len = configuration.max_seq_len
+        self.max_kv_context_len = model_config["MAX_CONTEXT_LEN"]
         self.max_batch_size = model_config["MAX_BATCH_SIZE"]
         self.llama3 = configuration.vocab_size == 128256
         self.scale = 1 / math.sqrt(self.head_dim)
@@ -70,8 +71,7 @@ class TtLlamaAttention_optimized:
             (
                 self.n_kv_heads,
                 self.max_batch_size,
-                # self.max_seq_len,
-                self.model_config["MAX_CONTEXT_LEN"],
+                self.max_kv_context_len,
                 self.head_dim,
             )
         )
@@ -79,8 +79,7 @@ class TtLlamaAttention_optimized:
             (
                 self.n_kv_heads,
                 self.max_batch_size,
-                # self.max_seq_len,
-                self.model_config["MAX_CONTEXT_LEN"],
+                self.max_kv_context_len,
                 self.head_dim,
             )
         )
@@ -220,6 +219,11 @@ class TtLlamaAttention_optimized:
         )
         xs.deallocate(True)
 
+        # Reshape such that true unpadded batch is tracked in shape
+        fqkv_shape = fused_query_key_value.shape
+        fused_query_key_value = ttnn.reshape(
+            fused_query_key_value, ttnn.Shape((1, 1, self.max_batch_size, fqkv_shape[3]), (1, 1, 32, fqkv_shape[3]))
+        )
         # Split QKV
         (
             query_layer,  # [seqlen, n_local_heads, bsz, head_dim]
@@ -241,7 +245,7 @@ class TtLlamaAttention_optimized:
             rot_mats,
             program_config=self.model_config["ROT_MAT_MM_PROGCFG"],
             output_mem_config=self.model_config["HEIGHT_SHARDED_MEMCFG"],
-            compute_kernel_config=self.model_config["ROT_MAT_COMPUTE_KERNEL_CONFIG"]
+            compute_kernel_config=self.model_config["ROT_MAT_COMPUTE_KERNEL_CONFIG"],
             # [seqlen, n_heads, bsz, head_dim]  # [1, 1, head_dim, head_dim]  => [seqlen, n_heads, bsz, head_dim]
         )
 
@@ -264,82 +268,36 @@ class TtLlamaAttention_optimized:
         attn_masks,
         batch_offset: int = 0,
     ):
-        padded_layer_past_len = nearest_32(start_pos + 1)
-
-        # K Cache Update
-        kv_cache_memcfg = self.model_config["KV_CACHE_SLICE_OUTPUT_MEMCFG"]
-        if kv_cache_memcfg.is_sharded():
-            kv_cache_shard_shape = kv_cache_memcfg.shard_spec.shape
-            kv_cache_shard_shape[0] = self.layer_past[0].shape[0] * padded_layer_past_len
-            kv_cache_memcfg.shard_spec.shape = kv_cache_shard_shape
-
         keys = self.layer_past[0]
         tt_lib.tensor.update_cache(keys, key_layer, start_pos, batch_offset=batch_offset)
         key_layer.deallocate(True)
-
-        # key and value layers will have kv_seq_len padded to nearest 32
-        keys = self.layer_past[0]
-        key_layer = tt_lib.tensor.nlp_kv_cache_load_slice(keys, 0, padded_layer_past_len)
-
-        # PRE-SOFTMAX MM
-        key_layer_transposed = tt_lib.tensor.transpose(
-            key_layer,
-            -2,
-            -1,
-            output_mem_config=self.model_config["HEIGHT_SHARDED_MEMCFG"],
-        )
-
-        key_layer.deallocate(True)
-
-        attn_prog_config = self.model_config["ATTN_BATCHED_MM_PROGCFG_LAMBDA"](padded_layer_past_len // 32)
-        attn_output_memcfg = self.model_config["ATTN_BATCHED_MM_OUTPUT_MEMCFG"]
-        attn_output_memcfg.shard_spec.shape[1] = padded_layer_past_len
-
-        attn_weights = tt_lib.operations.primary.matmul(
-            query_layer,
-            key_layer_transposed,
-            program_config=attn_prog_config,
-            output_mem_config=attn_output_memcfg,
-            output_dtype=ttnn.bfloat16,
-            compute_kernel_config=self.model_config["COMPUTE_KERNEL_CONFIG"],
-        )
-
-        query_layer.deallocate(True)
-        key_layer_transposed.deallocate(True)
-
-        # SOFTMAX
-        softmax_progcfg = self.model_config["BATCHED_SOFTMAX_PROGCFG"]
-        softmax_progcfg.block_w = padded_layer_past_len // 32
-
-        attn_weights = tt_lib.operations.primary.transformers.scale_mask_softmax_in_place(
-            attn_weights,
-            self.scale,
-            attn_masks,
-            program_config=self.model_config["BATCHED_SOFTMAX_PROGCFG"],
-            is_causal_mask=True,
-        )
 
         # V CACHE UPDATE
         values = self.layer_past[1]
         tt_lib.tensor.update_cache(values, value_layer, start_pos, batch_offset=batch_offset)
         value_layer.deallocate(True)
 
-        values = self.layer_past[1]
-        value_layer = tt_lib.tensor.nlp_kv_cache_load_slice(values, 0, padded_layer_past_len)
+        k_chunk_size = get_flash_decode_chunk_size(start_pos + 1)
+        padded_layer_past_len = get_padded_layer_len(start_pos + 1, k_chunk_size)
 
-        # POST-SOFTMAX MM
-        scores_prog_config = self.model_config["SCORES_BATCHED_MM_PROGCFG_LAMBDA"](padded_layer_past_len // 32)
-
-        attn_output = tt_lib.operations.primary.matmul(
-            attn_weights,
-            value_layer,
-            program_config=scores_prog_config,
-            output_mem_config=self.model_config["SCORES_BATCHED_MM_OUTPUT_MEMCFG"],
-            output_dtype=ttnn.bfloat16,
-            compute_kernel_config=self.model_config["COMPUTE_KERNEL_CONFIG"],
+        program_config = tt_lib.operations.primary.transformers.SDPAMultiCoreProgramConfig(
+            compute_with_storage_grid_size=[8, 7],
+            q_chunk_size=self.padded_local_heads,
+            k_chunk_size=k_chunk_size,
         )
-        attn_weights.deallocate(True)
-        value_layer.deallocate(True)
+
+        attn_output = tt_lib.operations.primary.transformers.scaled_dot_product_attention(
+            query_layer,
+            keys,
+            values,
+            attn_masks,
+            is_causal=False,
+            scale=self.scale,
+            program_config=program_config,
+            valid_seq_len=padded_layer_past_len,
+            compute_kernel_config=self.model_config["SDPA_DECODE_COMPUTE_KERNEL_CONFIG"],
+            output_mem_config=self.model_config["SDPA_DECODE_OUTPUT_MEMCFG"],
+        )
 
         return attn_output
 
@@ -357,7 +315,6 @@ class TtLlamaAttention_optimized:
             attn_output,
             dim=3,
             num_links=self.model_config["ALL_GATHER_NUM_LINKS"],
-            # memory_config=self.model_config["L1_MEMCFG"],
             memory_config=self.model_config["ATTN_ALL_GATHER_OUTPUT_MEMCFG"],
         )
 
@@ -452,13 +409,17 @@ class TtLlamaAttention_optimized:
         # FILL K CACHE
         keys = self.layer_past[0]
         # Fill cache expects batch in dim0
-        keys_reshaped = ttnn.reshape(keys, [self.max_batch_size, self.n_local_kv_heads, -1, self.head_dim])
+        keys_reshaped = ttnn.reshape(
+            keys, [self.max_batch_size, self.n_local_kv_heads, self.max_kv_context_len, self.head_dim]
+        )
         tt_lib.tensor.fill_cache(keys_reshaped, tt_lib.tensor.typecast(key_layer, ttnn.bfloat8_b), user_id)
 
         # FILL V CACHE
         values = self.layer_past[1]
         # Fill cache expects batch in dim0
-        values_reshaped = ttnn.reshape(values, [self.max_batch_size, self.n_local_kv_heads, -1, self.head_dim])
+        values_reshaped = ttnn.reshape(
+            values, [self.max_batch_size, self.n_local_kv_heads, self.max_kv_context_len, self.head_dim]
+        )
         tt_lib.tensor.fill_cache(values_reshaped, tt_lib.tensor.typecast(value_layer, ttnn.bfloat8_b), user_id)
 
         # SPDA

--- a/models/experimental/llama2_70b/tt/llama_common.py
+++ b/models/experimental/llama2_70b/tt/llama_common.py
@@ -400,3 +400,22 @@ def check_kv_cache(pt_cache_all, tt_cache_all, generation_start_pos, generation_
             logger.warning(f"KV Cache Failed! PCC value is lower than {pcc}")
             test_passed = False
     return test_passed
+
+
+def get_flash_decode_chunk_size(token_idx):
+    # Not sure if optimal
+    if token_idx <= 32:
+        return 32
+    if token_idx <= 64:
+        return 64
+    if token_idx <= 128:
+        return 128
+    if token_idx <= 256:
+        return 256
+    if token_idx <= 2048:
+        return 512
+    return 1024
+
+
+def get_padded_layer_len(token_idx, chunk_size):
+    return ((token_idx + chunk_size - 1) // chunk_size) * chunk_size

--- a/models/experimental/llama2_70b/tt/llama_decoder_optimized.py
+++ b/models/experimental/llama2_70b/tt/llama_decoder_optimized.py
@@ -25,7 +25,6 @@ class TtLlamaDecoder_optimized:
         layer_num,
         model_config,
         configuration,
-        batch,
         transformation_mats,
         cache_path=None,
         read_cache=False,

--- a/models/experimental/llama2_70b/tt/llama_model_optimized.py
+++ b/models/experimental/llama2_70b/tt/llama_model_optimized.py
@@ -8,7 +8,7 @@ from tqdm import tqdm
 import torch
 import ttnn.experimental as tt_lib
 import ttnn
-from ttnn import ShardTensorToMesh, ReplicateTensorToMesh
+from ttnn import ShardTensorToMesh, ReplicateTensorToMesh, ConcatMeshToTensor
 
 
 from models.utility_functions import nearest_32, profiler
@@ -20,6 +20,8 @@ from models.experimental.llama2_70b.tt.llama_common import (
     precompute_freqs,
     gather_cos_sin,
     get_rot_transformation_mat,
+    get_flash_decode_chunk_size,
+    get_padded_layer_len,
 )
 
 
@@ -32,7 +34,6 @@ class TtLlamaModel_optimized:
         n_layers,
         model_config,
         configuration,
-        batch,
         cache_path=None,
         read_cache=False,
     ):
@@ -75,7 +76,6 @@ class TtLlamaModel_optimized:
                 layer_num,
                 model_config,
                 configuration,
-                batch,
                 transformation_mats,
                 cache_path=cache_path,
                 read_cache=read_cache,
@@ -163,6 +163,9 @@ class TtLlamaModel_optimized:
 
         if self.model_config["LLM_MODE"] == "decode":
             inp_ids = inp_ids.reshape(seq_len, 1, 1, batch)
+            # Pad small batches to 32
+            inp_ids = torch.nn.functional.pad(inp_ids, (0, 32 - batch))
+
         else:
             inp_ids = inp_ids.reshape(batch, 1, 1, seq_len)
 
@@ -174,7 +177,6 @@ class TtLlamaModel_optimized:
             memory_config=self.model_config["DRAM_MEMCFG"],
             mesh_mapper=ReplicateTensorToMesh(self.device_mesh),
         )
-        x = ttnn.to_device(x, self.device_mesh)
 
         xs = self.tt_embd(x)
 
@@ -237,7 +239,7 @@ class TtLlamaModel_optimized:
 
         elif self.model_config["LLM_MODE"] == "decode":
             assert seq_len == 1, "Decode mode only supports seq_len=1"
-            assert xs.shape == (seq_len, 1, batch, self.hidden_size // self.num_devices)
+            assert xs.shape == (seq_len, 1, 32, self.hidden_size // self.num_devices)
 
             xs = tt_lib.tensor.interleaved_to_sharded(
                 xs, sharded_mem_config=self.model_config["WORD_EMBEDDING_OUTPUT_MEMCFG"]
@@ -251,7 +253,7 @@ class TtLlamaModel_optimized:
                 dtype=ttnn.bfloat16,
                 layout=ttnn.TILE_LAYOUT,
                 device=self.device_mesh,
-                cache_file_name=cache_name(f"rot_mat_decode_{start_pos}"),
+                cache_file_name=cache_name(f"rot_mat_decode_b{batch}_{start_pos}"),
                 memory_config=self.model_config["DRAM_MEMCFG"],
                 mesh_mapper=ReplicateTensorToMesh(self.device_mesh),
             )
@@ -261,16 +263,15 @@ class TtLlamaModel_optimized:
                 rot_mats, sharded_mem_config=self.model_config["ROT_MAT_MM_IN1_MEMCFG"]
             )
 
-            padded_layer_past_len = nearest_32(start_pos + 1)
-
-            padded_layer_past_len = nearest_32(start_pos + 1)
+            k_chunk_size = get_flash_decode_chunk_size(start_pos + 1)
+            padded_layer_past_len = get_padded_layer_len(start_pos + 1, k_chunk_size)
             attn_mask_shape = (seq_len, 1, self.padded_local_heads, padded_layer_past_len)
             attn_mask = torch.zeros(*attn_mask_shape)
             attn_mask[:, :, :, start_pos + 1 :] = torch.finfo(attn_mask.dtype).min
 
             attn_masks = ttnn.as_tensor(
                 attn_mask,
-                dtype=ttnn.bfloat16,
+                dtype=ttnn.bfloat8_b,
                 layout=ttnn.TILE_LAYOUT,
                 cache_file_name=cache_name(f"attn_masks_decode_{start_pos}"),
                 memory_config=self.model_config["DRAM_MEMCFG"],
@@ -283,16 +284,6 @@ class TtLlamaModel_optimized:
             attn_masks = tt_lib.tensor.repeat(
                 attn_masks, repeat_shape, output_mem_config=self.model_config["DRAM_MEMCFG"]
             )
-            # Put attn_mask on the device with the sharded config
-            attention_mask_memconfig = self.model_config["ATTN_MASK_MEMCFG"]
-            if attention_mask_memconfig.is_sharded():
-                attn_mask_shard_shape = attention_mask_memconfig.shard_spec.shape
-                attn_mask_shard_shape[-1] = padded_layer_past_len
-                attention_mask_memconfig.shard_spec.shape = attn_mask_shard_shape
-
-                attn_masks = tt_lib.tensor.interleaved_to_sharded(
-                    attn_masks, sharded_mem_config=attention_mask_memconfig
-                )
 
         return (
             xs,

--- a/models/experimental/llama2_70b/tt/model_config.py
+++ b/models/experimental/llama2_70b/tt/model_config.py
@@ -97,6 +97,12 @@ def get_model_config(
             fp32_dest_acc_en=True,
             packer_l1_acc=True,
         ),
+        "SDPA_DECODE_COMPUTE_KERNEL_CONFIG": ttl.tensor.WormholeComputeKernelConfig(
+            math_fidelity=ttl.tensor.MathFidelity.HiFi2,  # Highest fidelity
+            math_approx_mode=False,
+            fp32_dest_acc_en=True,
+            packer_l1_acc=False,
+        ),
         "L1_MEMCFG": L1_MEMCFG,
         "DRAM_MEMCFG": DRAM_MEMCFG,
         "BFLOAT16_DTYPE": BFLOAT16_DTYPE,
@@ -105,6 +111,8 @@ def get_model_config(
         "HEIGHT_SHARDED_MEMCFG": HEIGHT_SHARDED_MEMCFG,
         "BLOCK_SHARDED_MEMCFG": BLOCK_SHARDED_MEMCFG,
         "MAX_MM_SEQ_LEN": 1024,  # Used to support seq len greater than 2k
+        "MAX_BATCH_SIZE": max_batch_size,
+        "MAX_CONTEXT_LEN": max_context_len,
     }
     hidden_size = model_config_entries["hidden_size"]
     head_dim = model_config_entries["head_dim"]
@@ -112,7 +120,7 @@ def get_model_config(
     n_kv_heads = model_config_entries["num_kv_heads"]
 
     if llm_mode == "decode":
-        shard_height = batch
+        shard_height = 32  # batch
     else:
         shard_height = seq_len
 
@@ -164,6 +172,15 @@ def get_model_config(
             ),
         }
     )
+    if llm_mode == "decode":
+        if batch == 16:
+            batch_size_corerange = shard_spec_16_cores_grid
+            batch_size_coregrid = [8, 2]
+        elif batch == 32:
+            batch_size_corerange = shard_spec_32_cores_grid
+            batch_size_coregrid = [8, 4]
+        else:
+            raise NotImplementedError(f"Unsupported batch size: {batch}")
 
     # Constants based on hidden_dim
     shard_width_hidden_dim_across_32_cores = hidden_size // 32
@@ -442,41 +459,42 @@ def get_model_config(
             False,
         ),
     )
-    model_config["ROT_MAT_MM_PROGCFG"] = ttl.operations.primary.MatmulMultiCoreReuseProgramConfig(
-        compute_with_storage_grid_size=[8, 4],
-        in0_block_w=4,  # 128 // TILE_SIZE (dynamic)
-        out_subblock_h=1,
-        out_subblock_w=4,
-        per_core_M=1,
-        per_core_N=4,
-    )
-    model_config["ROT_MAT_MM_IN1_MEMCFG"] = ttl.tensor.MemoryConfig(
-        ttl.tensor.TensorMemoryLayout.HEIGHT_SHARDED,
-        ttl.tensor.BufferType.L1,
-        ttl.tensor.ShardSpec(
-            shard_spec_32_cores_grid,
-            [
-                head_dim,
-                head_dim,  # head dim
-            ],
-            ttl.tensor.ShardOrientation.ROW_MAJOR,
-            False,
-        ),
-    )
-    model_config["KV_CACHE_SLICE_OUTPUT_MEMCFG"] = ttl.tensor.MemoryConfig(
-        ttl.tensor.TensorMemoryLayout.HEIGHT_SHARDED,
-        ttl.tensor.BufferType.L1,
-        ttl.tensor.ShardSpec(
-            shard_spec_32_cores_grid if num_devices == 8 else shard_spec_8_cores_grid,
-            [
-                1,  # Dynamic
-                head_dim,
-            ],
-            ttl.tensor.ShardOrientation.ROW_MAJOR,
-            False,
-        ),
-    )
+
     if llm_mode == "decode":
+        model_config["ROT_MAT_MM_PROGCFG"] = ttl.operations.primary.MatmulMultiCoreReuseProgramConfig(
+            compute_with_storage_grid_size=batch_size_coregrid,
+            in0_block_w=4,  # 128 // TILE_SIZE (dynamic)
+            out_subblock_h=1,
+            out_subblock_w=4,
+            per_core_M=1,
+            per_core_N=4,
+        )
+        model_config["ROT_MAT_MM_IN1_MEMCFG"] = ttl.tensor.MemoryConfig(
+            ttl.tensor.TensorMemoryLayout.HEIGHT_SHARDED,
+            ttl.tensor.BufferType.L1,
+            ttl.tensor.ShardSpec(
+                batch_size_corerange,
+                [
+                    head_dim,
+                    head_dim,  # head dim
+                ],
+                ttl.tensor.ShardOrientation.ROW_MAJOR,
+                False,
+            ),
+        )
+        model_config["KV_CACHE_SLICE_OUTPUT_MEMCFG"] = ttl.tensor.MemoryConfig(
+            ttl.tensor.TensorMemoryLayout.HEIGHT_SHARDED,
+            ttl.tensor.BufferType.L1,
+            ttl.tensor.ShardSpec(
+                shard_spec_32_cores_grid if num_devices == 8 else shard_spec_8_cores_grid,
+                [
+                    1,  # Dynamic
+                    head_dim,
+                ],
+                ttl.tensor.ShardOrientation.ROW_MAJOR,
+                False,
+            ),
+        )
         model_config[
             "ATTN_BATCHED_MM_PROGCFG_LAMBDA"
         ] = lambda seq_tiles: ttl.operations.primary.MatmulMultiCoreReuseProgramConfig(
@@ -500,6 +518,21 @@ def get_model_config(
                 False,
             ),
         )
+
+        model_config["SDPA_DECODE_OUTPUT_MEMCFG"] = ttl.tensor.MemoryConfig(
+            ttl.tensor.TensorMemoryLayout.HEIGHT_SHARDED,
+            ttl.tensor.BufferType.L1,
+            ttl.tensor.ShardSpec(
+                batch_size_corerange,
+                [
+                    shard_height,  # Each core has 32 users
+                    head_dim,  # Dynamic (padded seqlen)
+                ],
+                ttl.tensor.ShardOrientation.ROW_MAJOR,
+                False,
+            ),
+        )
+
         model_config[
             "SCORES_BATCHED_MM_PROGCFG_LAMBDA"
         ] = lambda seq_tiles: ttl.operations.primary.MatmulMultiCoreReuseProgramConfig(

--- a/tt_eager/tt_dnn/op_library/sdpa/sdpa_op.cpp
+++ b/tt_eager/tt_dnn/op_library/sdpa/sdpa_op.cpp
@@ -56,14 +56,12 @@ void ScaledDotProductAttention::validate(
     const auto v_shape = input_tensors.at(2).get_legacy_shape();
     const auto mask_shape = mask.get_legacy_shape();
 
-    // assert all dataformats are the same
-    TT_FATAL(
-        input_tensors.at(0).get_dtype() == input_tensors.at(1).get_dtype() &&
-        input_tensors.at(0).get_dtype() == input_tensors.at(2).get_dtype() &&
-        input_tensors.at(0).get_dtype() == mask.get_dtype());
-
-
     if (this->is_causal) {
+        // assert all dataformats are the same
+        TT_FATAL(
+            input_tensors.at(0).get_dtype() == input_tensors.at(1).get_dtype() &&
+            input_tensors.at(0).get_dtype() == input_tensors.at(2).get_dtype() &&
+            input_tensors.at(0).get_dtype() == mask.get_dtype());
         // All inputs must be in DRAM
         for (auto& input_tensor : input_tensors) {
             TT_FATAL(input_tensor.buffer()->buffer_type() == tt_metal::BufferType::DRAM);


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/9159

### Problem description
We need to make changes to the model to support batch=16, max_kv_context_len=8192 for decode mode.

### What's changed
- Use SDPA in flash-decode mode
- Use padding to tell NLP TMs the true batch size

### Checklist
- [ ] Post commit CI passes
- [ ] Model regression CI testing passes (if applicable)
- [ ] New/Existing tests provide coverage for changes
