### PR TITLE
#9642: fix matmul2d in1 sharded with batch>1

### DIFF
--- a/tt_eager/tt_dnn/op_library/bmm/kernels/dataflow/reader_bmm_tile_layout_in1_sender_writer_padding.cpp
+++ b/tt_eager/tt_dnn/op_library/bmm/kernels/dataflow/reader_bmm_tile_layout_in1_sender_writer_padding.cpp
@@ -163,11 +163,13 @@ void kernel_main() {
 
     #ifdef IN1_DRAM_SHARDED
     constexpr uint32_t in1_dram_block_size_bytes = in1_dram_block_num_tiles * in1_single_tile_size_bytes;
-    uint32_t l1_read_addr_in1_offset = 0;
     uint32_t in1_block_w_bytes = in1_block_w * in1_single_tile_size_bytes;
     #endif
 
     for (uint32_t b = 0; b < batch; ++b) {
+        #ifdef IN1_DRAM_SHARDED
+        uint32_t l1_read_addr_in1_offset = 0;
+        #endif
         uint32_t in1_tensor_current_block_start_tile_id = in1_tensor_start_tile_id;
         for (uint32_t block = 0; block < num_blocks; ++block) {
 


### PR DESCRIPTION
### Ticket
- [Link to Github Issue.](https://github.com/tenstorrent/tt-metal/issues/9642)

### Problem description
- pcc error when batch>1 for matmul2d in1 sharded in DRAM.

### What's changed
- fix matmul2d in1 sharded, when batch>1, reset the tile index to 0.

### Checklist
- 
