### PR TITLE
Create benchmarking tools for saving run/measurement data (with Falcon7b example) and model-demo utilities for verifying tokens/perf

### DIFF
--- a/docs/source/ttnn/ttnn/demos.rst
+++ b/docs/source/ttnn/ttnn/demos.rst
@@ -30,4 +30,10 @@ What you see below highlights the expectations for all our models that successfu
     - Discuss any external dependencies or services required for the full operation of your model and how they impact the end-to-end performance.
     - Please add your tests to either ``run_perf_models_other()``, ``run_perf_models_llm_javelin()``, or ``run_perf_models_cnn_javelin()`` within ``run_performance.sh``. Only tests marked with ``@pytest.mark.models_performance_bare_metal`` will be included.
 
+5. Does your model have an end-to-end demo test demonstrating working output generation on real inputs and has this been integrated on our CI pipeline?
+    - Include a test that demonstrates the model's functionality and performance on real inputs, such as images or text, to ensure the model is producing the expected output.
+    - This test should be integrated into the CI pipeline to ensure the model's functionality is automatically validated.
+    - Provide instructions on how to run this test locally in the ``README.md``.
+    - Please add your test within ``run_demos_single_card_n150_tests.sh``, ``run_demos_single_card_n300_tests.sh``, and/or ``run_t3000_demo_tests.sh`` depending on the hardware you are targeting.
+
 For the purpose of organizing your tests to be managed for collecting both device and end-to-end performance, please take a look at ``test_ttnn_functional_resnet50.py`` and how the ``ResNet50TestInfra`` class was setup.

--- a/models/demos/falcon7b/demo/demo.py
+++ b/models/demos/falcon7b/demo/demo.py
@@ -6,7 +6,6 @@ import json
 import os
 import time
 from functools import partial
-from pathlib import Path
 
 import torch
 import torch.nn.functional as F
@@ -17,15 +16,15 @@ from models.demos.falcon7b.reference.hf_modeling_falcon import FalconConfig
 from models.demos.falcon7b.tt.falcon_causallm import TtFalconCausalLM
 from models.demos.falcon7b.tt.model_config import get_model_config, model_config_entries
 from models.demos.falcon7b.tests.test_utils import initialize_kv_cache, load_hf_model
+from models.demos.utils.llm_demo_utils import create_benchmark_data, verify_perf, check_tokens_match
 from models.utility_functions import (
     disable_compilation_reports,
     disable_persistent_kernel_cache,
     enable_persistent_kernel_cache,
     nearest_32,
-    profiler,
-    torch2tt_tensor,
     tt_tensors_to_torch_tensors,
 )
+from models.perf.benchmarking_utils import BenchmarkProfiler
 from tqdm import tqdm
 from transformers import AutoTokenizer
 from transformers.generation.utils import top_k_top_p_filtering
@@ -132,18 +131,29 @@ def run_falcon_demo_kv(
     num_layers=32,
     perf_mode=False,  # Option to measure perf using max seq length (with invalid outputs)
     greedy_sampling=False,  # Option to use greedy decoding instead of top-k/p
-    expected_perf_prefill_decode=None,  # Expected perf (t/s) for prefill and decode in perf mode
+    expected_perf_metrics=None,  # Expected perf (t/s) for prefill and decode in perf mode
     expected_greedy_output_path=None,  # Path for expected outputs for greedy decoding
     save_generated_text_path=None,  # If provided, save generated text to this path (e.g. set to expected_greedy_output_path to update expected output)
 ):
-    assert not (expected_perf_prefill_decode and expected_greedy_output_path), "Cannot verify both perf and output!"
+    profiler = BenchmarkProfiler()
+    profiler.start("run")
+
+    assert not (expected_perf_metrics and expected_greedy_output_path), "Cannot verify both perf and output!"
     assert not (perf_mode and save_generated_text_path), "Cannot save generated text in perf mode!"
     if expected_greedy_output_path is not None:
         assert (
             not perf_mode and greedy_sampling
         ), "Output verification only supported for greedy sampling in default mode!"
-    elif expected_perf_prefill_decode is not None:
+    elif expected_perf_metrics is not None:
         assert perf_mode, "Performance verification is only supported for perf mode!"
+
+    # Set up warmup iterations and targets dicts for saving benchmark data
+    if perf_mode:
+        N_warmup_iter = {"inference_prefill": 5, "inference_decode": 10}  # Number of warmup iterations for perf mode
+        targets = expected_perf_metrics if expected_perf_metrics else {}
+    else:
+        N_warmup_iter = {}
+        targets = {"token_verification": 1} if expected_greedy_output_path else {}
 
     disable_persistent_kernel_cache()
     disable_compilation_reports()
@@ -224,15 +234,13 @@ def run_falcon_demo_kv(
     )  # only used for compile
     kv_cache = initialize_kv_cache(configuration, num_layers, batch_size, max_seq_len, devices)
     profiler.end(f"initializing_KV_cache")
-    profiler.disable()
 
     ### First prefill run with compile ###
     logger.info("Running 1st run prefill stage with compile...")
     use_cache = True
-    time_prefill_compile = 0
+    profiler.start("compile_prefill")
     N = num_users // num_devices if not perf_mode else 1
     for user_id in tqdm(range(N)):
-        time_prefill_compile_start = time.time()
         (
             tt_prefill_input_ids,
             tt_prefill_attention_mask,
@@ -264,7 +272,7 @@ def run_falcon_demo_kv(
                     raise ValueError("Invalid type for tt_attention_mask")
             tt_logits[i].deallocate()
 
-        time_prefill_compile += time.time() - time_prefill_compile_start
+    profiler.end("compile_prefill")
 
     synchronize_devices(devices)
     logger.info("Finished 1st run prefill stage with compile!")
@@ -277,9 +285,8 @@ def run_falcon_demo_kv(
 
     decode_ids = torch.randint(low=0, high=configuration.vocab_size - 1, size=(global_batch, 1), dtype=torch.int64)
 
-    time_decode_compile = 0
+    profiler.start("compile_decode")
     for kv_cache_len in tqdm(range(num_input_tokens, max_seq_len, 32)):
-        time_decode_compile_start = time.time()
         (
             tt_decode_input_ids,
             tt_decode_attention_mask,
@@ -304,7 +311,7 @@ def run_falcon_demo_kv(
                 tt_decode_attention_mask[i].deallocate()
             tt_logits[i].deallocate()
 
-        time_decode_compile += time.time() - time_decode_compile_start
+    profiler.end("compile_decode")
 
     logger.info("Finished 1st run decode stage with compile!")
     synchronize_devices(devices)
@@ -339,13 +346,14 @@ def run_falcon_demo_kv(
     post_processor = partial(post_process)
     output_ids = torch.zeros(num_users, 1, dtype=torch.int64)
     logger.info("Running inference prefill stage...")
+    profiler.start("inference_prefill")
     time_prefill_inference = 0
     if not perf_mode:
         N = num_users // num_devices
-        N_warmup = 0
+        N_warmup_prefill = 0
     else:
         N = 15
-        N_warmup = 5
+        N_warmup_prefill = N_warmup_iter["inference_prefill"]
     for i in tqdm(range(N)):
         user_id = i if not perf_mode else 0
         time_prefill_inference_start = time.time()
@@ -389,11 +397,12 @@ def run_falcon_demo_kv(
         user_output_ids = post_processor(logits=logits, index=num_input_tokens - 1)
         output_ids[user_id::batch_size] = user_output_ids
 
-        if i >= N_warmup:
+        if i >= N_warmup_prefill:
             time_prefill_inference += time.time() - time_prefill_inference_start
 
+    profiler.end("inference_prefill")
     logger.info("Finished inference prefill stage!")
-    num_users_generated_prefill = num_users if not perf_mode else (N - N_warmup) * num_devices
+    num_users_generated_prefill = num_users if not perf_mode else (N - N_warmup_prefill) * num_devices
 
     if not perf_mode:
         generated_ids = torch.concat((prefill_ids[..., :num_input_tokens], output_ids), dim=1)
@@ -411,13 +420,14 @@ def run_falcon_demo_kv(
     kv_cache_len = num_input_tokens  # This will increment by one after each decode
     prompt_is_done = [False for _ in range(num_users)]
 
+    profiler.start("inference_decode")
     time_decode_inference = 0
     if not perf_mode:
         N = max_seq_len - num_input_tokens
-        N_warmup = 0
+        N_warmup_decode = 0
     else:
         N = 30
-        N_warmup = 10
+        N_warmup_decode = N_warmup_iter["inference_decode"]
     print_per_generated_token = (
         expected_greedy_output_path is None
     )  # print per generated token if not verifying outputs
@@ -454,7 +464,7 @@ def run_falcon_demo_kv(
         else:
             decode_ids = top_pk_logits_efficient(logits.reshape(global_batch, -1)).reshape(global_batch, 1)
 
-        if output_token_index >= N_warmup:
+        if output_token_index >= N_warmup_decode:
             time_decode_inference += time.time() - time_decode_inference_start
 
         if not perf_mode:
@@ -474,14 +484,14 @@ def run_falcon_demo_kv(
                 os.system("clear")
                 print_output_prompts(generated_ids, tokenizer, batch_size)
 
+    profiler.end("inference_decode")
     logger.info("Finished inference decode stage!")
-    num_tokens_generated_decode = global_batch * (output_token_index - N_warmup + 1)
+    num_tokens_generated_decode = global_batch * (output_token_index - N_warmup_decode + 1)
     logger.info(f"Total number of tokens generated in decode: {num_tokens_generated_decode}")
 
     if not perf_mode:
         print_output_prompts(generated_ids, tokenizer, batch_size)
         generated_text = tokenizer.batch_decode(generated_ids.tolist())
-
         if save_generated_text_path is not None:
             with open(save_generated_text_path, "w") as f:
                 json.dump(generated_text, f)
@@ -491,11 +501,13 @@ def run_falcon_demo_kv(
     for device in devices:
         device.disable_and_clear_program_cache()
 
+    time_prefill_compile = profiler.get_duration("compile_prefill")
+    time_decode_compile = profiler.get_duration("compile_decode")
     measurements = {
-        "preprocessing": profiler.get("tokenizing_inputs"),
-        "loading_weights": profiler.get("loading_weights"),
-        "moving_to_device": profiler.get("moving_to_device"),
-        "initializing_KV_cache": profiler.get("initializing_KV_cache"),
+        "preprocessing": profiler.get_duration("tokenizing_inputs"),
+        "loading_weights": profiler.get_duration("loading_weights"),
+        "moving_to_device": profiler.get_duration("moving_to_device"),
+        "initializing_KV_cache": profiler.get_duration("initializing_KV_cache"),
         "compile_prefill": time_prefill_compile,
         "compile_decode": time_decode_compile,
         "compile_total": time_prefill_compile + time_decode_compile,
@@ -503,11 +515,15 @@ def run_falcon_demo_kv(
         "inference_decode": time_decode_inference,
         "inference_total": time_prefill_inference + time_decode_inference,
         "inference_user_throughput_prefill": num_users_generated_prefill / time_prefill_inference,  # users/s
-        "inference_token_throughput_prefill": num_users_generated_prefill
-        / time_prefill_inference
-        * prefill_ids.shape[1],  # tokens/s
-        "inference_token_throughput_decode": num_tokens_generated_decode / time_decode_inference,  # tokens/s
+        "prefill_t/s": num_users_generated_prefill / time_prefill_inference * prefill_ids.shape[1],  # tokens/s
+        "decode_t/s": num_tokens_generated_decode / time_decode_inference,  # tokens/s
+        "decode_t/s/u": num_tokens_generated_decode / time_decode_inference / global_batch,  # tokens/s/user
     }
+
+    # Add token verification measurement (1 for pass or 0 for fail)
+    if expected_greedy_output_path is not None:
+        token_check_does_pass, expected_output = check_tokens_match(generated_text, expected_greedy_output_path)
+        measurements["token_verification"] = float(token_check_does_pass)
 
     logger.info(f"pre processing: {round(measurements['preprocessing'], 5)} s")
     logger.info(f"loading weights (+downloading if not on machine): {round(measurements['loading_weights'], 5)} s")
@@ -523,55 +539,39 @@ def run_falcon_demo_kv(
     logger.info(f"total inference time: {round(measurements['inference_total'], 5)} s")
     logger.info(f"inference throughput prefill: {round(measurements['inference_user_throughput_prefill'], 5)} users/s")
     logger.info(
-        f"inference throughput prefill | seq_len={prefill_ids.shape[1]} : {round(measurements['inference_token_throughput_prefill'], 5)} tok/s"
+        f"inference throughput prefill | seq_len={prefill_ids.shape[1]} : {round(measurements['prefill_t/s'], 5)} tok/s"
     )
-    logger.info(f"inference throughput decode: {round(measurements['inference_token_throughput_decode'], 5)} tok/s")
-    logger.info(
-        f"inference throughput decode (per user): {round(measurements['inference_token_throughput_decode']/global_batch, 5)} tok/s/user"
+    logger.info(f"inference throughput decode: {round(measurements['decode_t/s'], 5)} tok/s")
+    logger.info(f"inference throughput decode (per user): {round(measurements['decode_t/s/u'], 5)} tok/s/user")
+
+    profiler.end("run")
+    logger.info(f"Total demo duration: {(profiler.get_duration('run')):.2f} s")
+
+    # Save benchmark data
+    benchmark_data = create_benchmark_data(profiler, measurements, N_warmup_iter, targets)
+    benchmark_data.prep_csvs(
+        profiler,
+        run_type=f"demo_perf_{num_devices}chip" if perf_mode else f"demo_generate_{num_devices}chip",
+        ml_model_name=model_version,
+        ml_model_type="llm",
+        num_layers=num_layers,
+        batch_size=batch_size,
+        config_params=configuration.to_dict(),
+        precision=f"prefill[{model_config_strs_prefill_decode[0]}]_decode[{model_config_strs_prefill_decode[1]}]",
+        input_sequence_length=num_input_tokens,
+        output_sequence_length=1 if perf_mode else output_token_index + 1,
     )
 
     # Verify output or perf if expected values are provided
-    perf_prefill_decode = [
-        measurements["inference_token_throughput_prefill"],
-        measurements["inference_token_throughput_decode"],
-    ]
-    verify_output_or_perf(
-        generated_text, perf_prefill_decode, expected_greedy_output_path, expected_perf_prefill_decode
-    )
-
-    return generated_text, measurements
-
-
-def verify_output_or_perf(
-    generated_text, perf_prefill_decode, expected_greedy_output_path, expected_perf_prefill_decode
-):
-    assert expected_perf_prefill_decode is None or expected_greedy_output_path is None
-    if expected_perf_prefill_decode is not None:
-        does_pass = True
-        if perf_prefill_decode[0] < expected_perf_prefill_decode[0]:
-            does_pass = False
-            logger.warning(
-                f"Prefill perf {perf_prefill_decode[0]} is lower than expected {expected_perf_prefill_decode[0]}"
-            )
-        if perf_prefill_decode[1] < expected_perf_prefill_decode[1]:
-            does_pass = False
-            logger.warning(
-                f"Decode perf {perf_prefill_decode[1]} is lower than expected {expected_perf_prefill_decode[1]}"
-            )
-        if does_pass:
-            logger.info("Perf Check Passed!")
-        else:
-            logger.warning("Perf Check Failed!")
-            assert (
-                does_pass
-            ), f"Prefill or decode perf is lower than {expected_perf_prefill_decode}. See earlier warnings for more details."
+    assert expected_perf_metrics is None or expected_greedy_output_path is None
+    if expected_perf_metrics is not None:
+        verify_perf(measurements, expected_perf_metrics)
     elif expected_greedy_output_path is not None:
-        with open(expected_greedy_output_path, "r") as f:
-            expected_output = json.load(f)
-        does_pass = generated_text == expected_output
-        if does_pass:
+        if token_check_does_pass:
             logger.info("Output Check Passed!")
         else:
             assert (
-                does_pass
+                token_check_does_pass
             ), f"Generated text does not match expected output! \n\n Generated text:\n {generated_text} \n\n Expected output:\n {expected_output}"
+
+    return generated_text, measurements

--- a/models/demos/t3000/falcon7b/README.md
+++ b/models/demos/t3000/falcon7b/README.md
@@ -8,20 +8,20 @@ Falcon7b prefill uses 8x8 core grid size, so the following environment variable 
 
 To run the demo using prewritten prompts for a batch of 256 users split evenly on 8 devices run (currently only supports same token-length inputs):
 
-`pytest --disable-warnings -q -s --input-method=json --input-path='models/demos/t3000/falcon7b/input_data_t3000.json' models/demos/t3000/falcon7b/demo_t3000.py::test_demo_multichip[user_input0-8-True-default_mode_stochastic]`
+`pytest --disable-warnings -q -s --input-method=json --input-path='models/demos/t3000/falcon7b/input_data_t3000.json' models/demos/t3000/falcon7b/demo_t3000.py::test_demo_multichip[user_input0-8-True-default_mode_1024_stochastic]`
 
 ## Inputs
 
 A sample of input prompts for 256 users is provided in `input_data_t3000.json` in demo directory. If you wish you to run the model using a different set of input prompts you can provide a different path, e.g.:
 
-`pytest --disable-warnings -q -s --input-method=json --input-path='path_to_input_prompts.json' models/demos/t3000/falcon7b/demo_t3000.py::test_demo_multichip[user_input0-8-True-default_mode_stochastic]`
+`pytest --disable-warnings -q -s --input-method=json --input-path='path_to_input_prompts.json' models/demos/t3000/falcon7b/demo_t3000.py::test_demo_multichip[user_input0-8-True-default_mode_1024_stochastic]`
 
 ## Running on a different number of devices
 
 To run the demo on a different number of devices, an input file with the appropriate number of inputs must be prepared (the number of inputs should be (32 x num-devices)). Then, the command above can be modified to replace '8' with
 the desired number of devices. For example, to run with 4 devices:
 
-`pytest --disable-warnings -q -s --input-method=json --input-path='path_to_input_prompts.json' models/demos/t3000/falcon7b/demo_t3000.py::test_demo_multichip[user_input0-4-True-default_mode_stochastic]`
+`pytest --disable-warnings -q -s --input-method=json --input-path='path_to_input_prompts.json' models/demos/t3000/falcon7b/demo_t3000.py::test_demo_multichip[user_input0-4-True-default_mode_1024_stochastic]`
 
 ## Details
 

--- a/models/demos/t3000/falcon7b/demo_t3000.py
+++ b/models/demos/t3000/falcon7b/demo_t3000.py
@@ -8,27 +8,32 @@ from models.utility_functions import is_wormhole_b0, get_devices_for_t3000
 
 
 @pytest.mark.parametrize(
-    "perf_mode, expected_perf_prefill_decode, greedy_sampling, expected_greedy_output_path",
+    "perf_mode, max_seq_len, expected_perf_metrics, greedy_sampling, expected_greedy_output_path",
     (
-        (True, [10000, 1050], False, None),
-        (True, None, False, None),
-        (False, None, True, "models/demos/t3000/falcon7b/expected_greedy_output.json"),
-        (False, None, True, None),
-        (False, None, False, None),
+        (True, 128, {"prefill_t/s": 4350, "decode_t/s": 1000, "decode_t/s/u": 3.9}, False, None),
+        (True, 1024, {"prefill_t/s": 9500, "decode_t/s": 950, "decode_t/s/u": 3.7}, False, None),
+        (True, 2048, {"prefill_t/s": 7800, "decode_t/s": 950, "decode_t/s/u": 3.7}, False, None),
+        (True, 1024, None, False, None),
+        (False, 1024, None, True, "models/demos/t3000/falcon7b/expected_greedy_output.json"),
+        (False, 1024, None, True, None),
+        (False, 1024, None, False, None),
     ),
     ids=[
-        "perf_mode_stochastic_verify",
-        "perf_mode_stochastic",
-        "default_mode_greedy_verify",
-        "default_mode_greedy",
-        "default_mode_stochastic",
+        "perf_mode_128_stochastic_verify",
+        "perf_mode_1024_stochastic_verify",
+        "perf_mode_2048_stochastic_verify",
+        "perf_mode_1024_stochastic",
+        "default_mode_1024_greedy_verify",
+        "default_mode_1024_greedy",
+        "default_mode_1024_stochastic",
     ],
 )
 @pytest.mark.parametrize("async_mode", (True,))  # Option to run Falcon in Async mode
 @pytest.mark.parametrize("num_devices", (1, 2, 3, 4, 5, 6, 7, 8))
 def test_demo_multichip(
     perf_mode,  # Option to measure perf using max seq length (with invalid outputs) and expected perf (t/s)
-    expected_perf_prefill_decode,  # Expected perf (t/s) for prefill and decode in perf mode
+    max_seq_len,
+    expected_perf_metrics,  # Expected perf (t/s) for prefill and decode in perf mode
     greedy_sampling,  # Option to use greedy decoding instead of top-k/p
     expected_greedy_output_path,  # Path for expected outputs for greedy decoding
     num_devices,
@@ -47,13 +52,13 @@ def test_demo_multichip(
     return run_falcon_demo_kv(
         user_input=user_input,
         batch_size=32,
-        max_seq_len=1024,
+        max_seq_len=max_seq_len,
         model_config_strs_prefill_decode=["BFLOAT16-DRAM", "BFLOAT16-L1_SHARDED"],
         model_location_generator=model_location_generator,
         get_tt_cache_path=get_tt_cache_path,
         devices=devices,
         perf_mode=perf_mode,
         greedy_sampling=greedy_sampling,
-        expected_perf_prefill_decode=expected_perf_prefill_decode,
+        expected_perf_metrics=expected_perf_metrics,
         expected_greedy_output_path=expected_greedy_output_path,
     )

--- a/models/demos/utils/llm_demo_utils.py
+++ b/models/demos/utils/llm_demo_utils.py
@@ -1,0 +1,123 @@
+# SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+
+# SPDX-License-Identifier: Apache-2.0
+
+import json
+from loguru import logger
+from models.perf.benchmarking_utils import BenchmarkProfiler, BenchmarkData
+
+
+def create_benchmark_data(profiler: BenchmarkProfiler, measurements: dict, N_warmup_iter: dict, targets: dict):
+    """
+    Create a benchmark data object and populate the object with the given measurements.
+
+    Pre-requisites:
+    - The measurements dictionary should contain the following keys: "compile_prefill", "compile_decode", "prefill_t/s", "decode_t/s", "decode_t/s/u"
+    - The profiler object should contain the start and end times for the steps "compile_prefill", "compile_decode", "inference_prefill", "inference_decode"
+
+    Optional (should be provided if measuring perf, not required for token verification):
+    - The targets dictionary should contain the following keys: "prefill_t/s", "decode_t/s", "decode_t/s/u"
+    - The N_warmup_iter dictionary should contain the following keys: "inference_prefill", "inference_decode"
+
+    Optional (should be provided if doing token verification, not required for perf):
+    - The measurements and targets dictionaries should contain the key "token_verification"
+    """
+
+    assert all(
+        key in measurements
+        for key in [
+            "compile_prefill",
+            "compile_decode",
+            "prefill_t/s",
+            "decode_t/s",
+            "decode_t/s/u",
+        ]
+    )
+
+    benchmark_data = BenchmarkData()
+
+    # Add required measurement data
+    benchmark_data.add_measurement(profiler, 0, "compile_prefill", "time(s)", measurements["compile_prefill"])
+    benchmark_data.add_measurement(profiler, 0, "compile_decode", "time(s)", measurements["compile_decode"])
+    benchmark_data.add_measurement(
+        profiler,
+        0,
+        "inference_prefill",
+        "tokens/s",
+        measurements["prefill_t/s"],
+        step_warm_up_num_iterations=N_warmup_iter["inference_prefill"]
+        if "inference_prefill" in N_warmup_iter
+        else None,
+        target=targets["prefill_t/s"] if "prefill_t/s" in targets else None,
+    )
+    benchmark_data.add_measurement(
+        profiler,
+        0,
+        "inference_decode",
+        "tokens/s",
+        measurements["decode_t/s"],
+        step_warm_up_num_iterations=N_warmup_iter["inference_decode"] if "inference_decode" in N_warmup_iter else None,
+        target=targets["decode_t/s"] if "decode_t/s" in targets else None,
+    )
+    benchmark_data.add_measurement(
+        profiler,
+        0,
+        "inference_decode",
+        "tokens/s/user",
+        measurements["decode_t/s/u"],
+        step_warm_up_num_iterations=N_warmup_iter["inference_decode"] if "inference_decode" in N_warmup_iter else None,
+        target=targets["decode_t/s/u"] if "decode_t/s/u" in targets else None,
+    )
+
+    # Add optional token verification datapoint
+    if "token_verification" in measurements:
+        benchmark_data.add_measurement(
+            profiler,
+            0,
+            "inference_decode",
+            "token_verification",
+            measurements["token_verification"],
+            target=targets["token_verification"] if "token_verification" in targets else None,
+        )
+
+    return benchmark_data
+
+
+def check_tokens_match(generated_text: dict, expected_greedy_output_path: str):
+    with open(expected_greedy_output_path, "r") as f:
+        expected_output = json.load(f)
+    return generated_text == expected_output, expected_output
+
+
+def verify_perf(measurements: dict, expected_perf_metrics: dict):
+    """
+    Verify the performance metrics against the expected values.
+    The metrics that must be provided are specified in expected_measurements below.
+    """
+
+    expected_measurements = {
+        "compile_prefill": False,
+        "compile_decode": False,
+        "prefill_t/s": True,
+        "decode_t/s": True,
+        "decode_t/s/u": True,
+    }
+
+    does_pass = True
+    for key in expected_measurements:
+        if not expected_measurements[key]:
+            continue
+        assert (
+            key in measurements and key in expected_perf_metrics
+        ), f"Metric {key} not found in measurements or expected_perf_metrics"
+        if measurements[key] < expected_perf_metrics[key]:
+            does_pass = False
+            logger.warning(f"{key} ({measurements[key]}) is lower than expected {expected_perf_metrics[key]}")
+
+    if does_pass:
+        logger.info("Perf Check Passed!")
+    else:
+        logger.warning("Perf Check Failed!")
+        assert (
+            does_pass
+        ), f"Prefill or decode perf is lower than {expected_perf_metrics}. See earlier warnings for more details."

--- a/models/perf/benchmarking_utils.py
+++ b/models/perf/benchmarking_utils.py
@@ -1,0 +1,151 @@
+# SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+
+# SPDX-License-Identifier: Apache-2.0
+
+import os
+import csv
+import json
+from datetime import datetime
+import pytz
+from loguru import logger
+from typing import List
+
+
+class BenchmarkProfiler:
+    def __init__(self):
+        self.start_times = dict()
+        self.end_times = dict()
+
+    def start(self, step_name: str, iteration: int = 0):
+        self.start_times[(iteration, step_name)] = datetime.now(tz=pytz.UTC)
+
+    def end(self, step_name: str, iteration: int = 0):
+        self.end_times[(iteration, step_name)] = datetime.now(tz=pytz.UTC)
+
+    def get_duration(self, step_name: str, iteration: int = 0):
+        start_time = self.start_times[(iteration, step_name)]
+        end_time = self.end_times[(iteration, step_name)]
+        return (end_time - start_time).total_seconds()
+
+    def get_str_start(self, step_name: str, iteration: int = 0):
+        return self._get_str_ts(self.start_times[(iteration, step_name)])
+
+    def get_str_end(self, step_name: str, iteration: int = 0):
+        return self._get_str_ts(self.end_times[(iteration, step_name)])
+
+    def contains_step(self, step_name: str, iteration: int = 0):
+        return (iteration, step_name) in self.start_times and (iteration, step_name) in self.end_times
+
+    def _get_str_ts(self, timestamp):
+        return timestamp.strftime("%Y-%m-%dT%H:%M:%S%z")
+
+
+def save_data_csv(data: List[dict], filename: str):
+    assert len(data) > 0, "No data to save"
+
+    parent_dir = os.path.dirname(filename)
+    if parent_dir != "" and not os.path.exists(parent_dir):
+        os.makedirs(parent_dir)
+
+    with open(filename, "w", newline="") as csvfile:
+        writer = csv.DictWriter(csvfile, fieldnames=data[0].keys())
+        writer.writeheader()
+        for row in data:
+            writer.writerow(row)
+
+
+class BenchmarkData:
+    def __init__(self):
+        self.measure_data = []
+        self.output_folder = "generated/benchmark_data/"
+
+    def add_measurement(
+        self,
+        profiler: BenchmarkProfiler,
+        iteration: int,
+        step_name: str,
+        measurement_name: str,
+        value: float,
+        step_warm_up_num_iterations: int = None,
+        target: float = None,
+        device_power: float = None,
+        device_temperature: float = None,
+    ):
+        assert profiler.contains_step(
+            step_name, iteration
+        ), f"Completed step '{step_name}' for iteration {iteration} not found in profiler"
+        self.measure_data.append(
+            {
+                "step_start_ts": profiler.get_str_start(step_name, iteration),
+                "step_end_ts": profiler.get_str_end(step_name, iteration),
+                "iteration": iteration,
+                "step_name": step_name,
+                "measurement_name": measurement_name,
+                "value": value,
+                "step_warm_up_num_iterations": step_warm_up_num_iterations,
+                "target": target,
+                "device_power": device_power,
+                "device_temperature": device_temperature,
+            }
+        )
+
+    def prep_csvs(
+        self,
+        profiler: BenchmarkProfiler,  # must contain a "run" step for the entire run
+        run_type: str,
+        ml_model_name: str,
+        ml_model_type: str = None,
+        num_layers: int = None,
+        batch_size: int = None,
+        config_params: dict = None,
+        precision: str = None,
+        dataset_name: str = None,
+        profiler_name: str = None,
+        input_sequence_length: int = None,
+        output_sequence_length: int = None,
+        image_dimension: int = None,
+    ):
+        assert profiler.contains_step("run"), "Run step not found in profiler"
+        run_start_ts = profiler.get_str_start("run")
+        run_end_ts = profiler.get_str_end("run")
+
+        def prep_run_csv():
+            """
+            Run data contains a single record with attributes for a single benchmark run.
+            """
+
+            run_data = [
+                {
+                    "run_start_ts": run_start_ts,
+                    "run_end_ts": run_end_ts,
+                    "run_type": run_type,
+                    "ml_model_name": ml_model_name,
+                    "ml_model_type": ml_model_type,
+                    "num_layers": num_layers,
+                    "batch_size": batch_size,
+                    "config_params": json.dumps(config_params),
+                    "precision": precision,
+                    "dataset_name": dataset_name,
+                    "profiler_name": profiler_name,
+                    "input_sequence_length": input_sequence_length,
+                    "output_sequence_length": output_sequence_length,
+                    "image_dimension": image_dimension,
+                }
+            ]
+
+            filename = os.path.join(self.output_folder, f"run_{run_start_ts}.csv")
+            save_data_csv(run_data, filename)
+            logger.info(f"Run data saved to {filename}")
+
+        def prep_measurement_csv():
+            """
+            Measurement data contains records and attributes for each measurement performed at each iteration and each step of the benchmark run.
+            The triad of fields (iteration, step_name, name) must be unique.
+            """
+
+            filename = os.path.join(self.output_folder, f"measurement_{run_start_ts}.csv")
+            save_data_csv(self.measure_data, filename)
+            logger.info(f"Measurement data saved to {filename}")
+
+        prep_run_csv()
+        prep_measurement_csv()

--- a/tests/scripts/t3000/run_t3000_demo_tests.sh
+++ b/tests/scripts/t3000/run_t3000_demo_tests.sh
@@ -26,9 +26,11 @@ run_t3000_falcon7b_tests(){
 
   echo "LOG_METAL: Running run_t3000_falcon7b_tests"
 
-  # Falcon7B demo (perf verification and output verification)
-  WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml pytest --disable-warnings -q -s --input-method=json --input-path='models/demos/t3000/falcon7b/input_data_t3000.json' models/demos/t3000/falcon7b/demo_t3000.py::test_demo_multichip[user_input0-8-True-perf_mode_stochastic_verify]
-  WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml pytest --disable-warnings -q -s --input-method=json --input-path='models/demos/t3000/falcon7b/input_data_t3000.json' models/demos/t3000/falcon7b/demo_t3000.py::test_demo_multichip[user_input0-8-True-default_mode_greedy_verify]
+  # Falcon7B demo (perf verification for 128/1024/2048 seq lens and output token verification)
+  WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml pytest --disable-warnings -q -s --input-method=json --input-path='models/demos/t3000/falcon7b/input_data_t3000.json' models/demos/t3000/falcon7b/demo_t3000.py::test_demo_multichip[user_input0-8-True-perf_mode_128_stochastic_verify]
+  WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml pytest --disable-warnings -q -s --input-method=json --input-path='models/demos/t3000/falcon7b/input_data_t3000.json' models/demos/t3000/falcon7b/demo_t3000.py::test_demo_multichip[user_input0-8-True-perf_mode_1024_stochastic_verify]
+  WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml pytest --disable-warnings -q -s --input-method=json --input-path='models/demos/t3000/falcon7b/input_data_t3000.json' models/demos/t3000/falcon7b/demo_t3000.py::test_demo_multichip[user_input0-8-True-perf_mode_2048_stochastic_verify]
+  WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml pytest --disable-warnings -q -s --input-method=json --input-path='models/demos/t3000/falcon7b/input_data_t3000.json' models/demos/t3000/falcon7b/demo_t3000.py::test_demo_multichip[user_input0-8-True-default_mode_1024_greedy_verify]
 
   # Falcon7B perplexity test (prefill and decode)
   WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml pytest models/demos/falcon7b/tests/test_perplexity_falcon.py::test_perplexity[True-prefill_seq1024_dram]


### PR DESCRIPTION
### Ticket
- #9648 
- #5383 

### Problem description
- Currently, model tests (notably the demos, which are our key deliverables) do not have a standardized way of tracking run and measurement data. There are parallel efforts from the dev-ops and data science teams to bring up tools for monitoring such data, however a set of tools for logging and saving the data in the appropriate formats is required for model developers. 

### What's changed
- Created a file `models/perf/benchmarking_utils.py` containing tools for profiling data and saving CSVs in the appropriate formats (the requirements for these CSVs were specified by the data science team). These tools can be used for any type of test, not only demos. Two CSVs are saved for any run, "run_<start_ts>.csv" and "measurement_<start_ts>.csv".
- Created a file `models/demos/utils/llm_demo_utils.py` containing a function which adds demo measurements using the benchmarking tools mentioned above. This is only applicable to model demos and defines certain requirements for data produced by the demos.
- In the same `llm_demo_utils.py` file mentioned above, created functions for doing output token verification and output perf verification. 
- Modified the Falcon7b demo to save run/measurement CSVs using the tools mentioned above.
- Added 128/2k seq len options for the Falcon7b demo (perf-mode)

### Checklist
- [x] Post commit CI passes
- [x] Model regression CI testing passes (if applicable)
- [x] New/Existing tests provide coverage for changes

cc @uaydonat 
