### PR TITLE
Falcon40b prefill for 8k seqlen

### DIFF
--- a/models/demos/t3000/falcon40b/tests/ops/test_falcon_qkv_proj.py
+++ b/models/demos/t3000/falcon40b/tests/ops/test_falcon_qkv_proj.py
@@ -1,0 +1,171 @@
+# SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+
+# SPDX-License-Identifier: Apache-2.0
+
+import torch
+import pytest
+from loguru import logger
+
+import ttnn
+from ttnn import ShardTensorToMesh, ReplicateTensorToMesh, ConcatMeshToTensor
+from tests.tt_eager.python_api_testing.sweep_tests.comparison_funcs import (
+    comp_pcc,
+)
+from models.utility_functions import torch2tt_tensor, tt2torch_tensor
+from models.demos.t3000.falcon40b.tt.model_config import (
+    get_model_config,
+)
+
+from models.demos.t3000.falcon40b.reference.hf_modeling_falcon import (
+    FalconForCausalLM,
+)
+
+from models.demos.t3000.falcon40b.tt.model_utils import falcon_prefill_matmul
+
+
+def run_test_FalconMLP_inference(
+    pcc,
+    device=None,
+    device_mesh=None,
+):
+    # falcon 40b per chip: 8 chip setup
+    if device is not None:
+        num_devices = 1
+    elif device_mesh is not None:
+        num_devices = 8
+    else:
+        assert False
+
+    num_heads = 16
+    num_kv_heads = 1
+    head_dim = 64
+    hidden_size = 8192
+
+    seqlen = 8192
+
+    # Prepare input
+    torch.manual_seed(0)
+    model_input_shape = [1, seqlen]
+
+    model_config = get_model_config("BFLOAT8_B-DRAM", "prefill", model_input_shape, 8)
+
+    input_shape = [
+        1,
+        1,
+        seqlen,
+        hidden_size,
+    ]
+    weight_shape = [
+        1,
+        1,
+        hidden_size,
+        num_devices * (num_heads + num_kv_heads + num_kv_heads) * head_dim,
+    ]
+    input = (torch.rand(input_shape) * 2) - 1
+    weight = (torch.rand(weight_shape) * 2) - 1
+
+    # PyTorch output --------------------------------------------------------------------
+    pytorch_reference = torch.matmul(input, weight)
+
+    # TT hardware execution -------------------------------------------------------------
+    print("Creating input tensor with shape: ", input.shape)
+    if device is not None:
+        input_host = torch2tt_tensor(input, None, tt_dtype=ttnn.experimental.tensor.DataType.BFLOAT8_B)
+        tt_input = input_host.to(
+            device,
+            ttnn.experimental.tensor.MemoryConfig(
+                ttnn.experimental.tensor.TensorMemoryLayout.INTERLEAVED, ttnn.experimental.tensor.BufferType.DRAM
+            ),
+        )
+    elif device_mesh is not None:
+        tt_input = ttnn.as_tensor(
+            tensor=input,
+            dtype=model_config["ATTN_INPUT_DTYPE"],
+            layout=ttnn.TILE_LAYOUT,
+            device=device_mesh,
+            memory_config=model_config["ATTN_INPUT_MEMCFG"],
+            mesh_mapper=ReplicateTensorToMesh(device_mesh),
+        )
+    else:
+        assert False
+
+    print("Creating weight tensor with shape: ", weight.shape)
+    if device is not None:
+        weight_host = torch2tt_tensor(weight, None, tt_dtype=ttnn.experimental.tensor.DataType.BFLOAT8_B)
+        tt_weight = weight_host.to(
+            device,
+            ttnn.experimental.tensor.MemoryConfig(
+                ttnn.experimental.tensor.TensorMemoryLayout.INTERLEAVED, ttnn.experimental.tensor.BufferType.DRAM
+            ),
+        )
+    elif device_mesh is not None:
+        tt_weight = ttnn.as_tensor(
+            tensor=weight,
+            dtype=model_config["FUSED_QKV_MM_WEIGHTS_DTYPE"],
+            layout=ttnn.TILE_LAYOUT,
+            device=device_mesh,
+            memory_config=model_config["FUSED_QKV_MM_WEIGHTS_MEMCFG"],
+            mesh_mapper=ShardTensorToMesh(device_mesh, dim=-1),
+        )
+    else:
+        assert False
+
+    max_mm_seq_len = 1024
+    mm_seq_len_batched = 1024
+    batch_dim = 1 if seqlen < max_mm_seq_len else seqlen // mm_seq_len_batched
+    if batch_dim != 1:
+        tt_input = ttnn.reshape(tt_input, (1, batch_dim, seqlen // batch_dim, -1))
+
+    mm_output = falcon_prefill_matmul(
+        tt_input,
+        tt_weight,
+        model_config["COMPUTE_KERNEL_CONFIG"],
+        output_mem_config=model_config["FUSED_QKV_MM_OUTPUT_MEMCFG"],
+        output_dtype=model_config["FUSED_QKV_MM_OUTPUT_DTYPE"],
+        grid=ttnn.CoreGrid(x=8, y=8) if seqlen >= 512 else ttnn.CoreGrid(x=8, y=min(seqlen // 32, 8)),
+        overwrite_subblock_w=1,  # Workaround for non deterministic output/hang; issue: 7066
+        overwrite_subblock_h=1,
+        fuse_batch_mm2d=False,
+    )
+
+    print("MM output shape: ", mm_output.shape)
+
+    # Reshape to compute long sequence lengths as multiple MM loops (reverse)
+    if batch_dim != 1:
+        mm_output = ttnn.reshape(mm_output, (1, 1, seqlen, -1))
+
+    if device is not None:
+        output = tt2torch_tensor(mm_output)
+    elif device_mesh is not None:
+        output = ttnn.to_torch(mm_output, device=device_mesh, mesh_composer=ConcatMeshToTensor(device_mesh, dim=3))
+    else:
+        assert False
+
+    # check outputs ----------------------------------------------------------------------
+    does_pass, output_pcc = comp_pcc(pytorch_reference, output, pcc)
+    logger.info(f"PCC value: {output_pcc}")
+    assert does_pass, f"PCC value is lower than {pcc}"
+
+
+@pytest.mark.parametrize("pcc", [(0.99)])
+def test_FalconMatmul_inference_t3k(
+    pcc,
+    t3k_device_mesh,
+):
+    run_test_FalconMLP_inference(
+        pcc,
+        device_mesh=t3k_device_mesh,
+    )
+
+
+@pytest.mark.parametrize("pcc", [(0.99)])
+def test_FalconMatmul_inference_wh(
+    pcc,
+    all_devices,
+):
+    device = all_devices[0]
+
+    run_test_FalconMLP_inference(
+        pcc,
+        device=device,
+    )

--- a/models/demos/t3000/falcon40b/tests/test_falcon_attention.py
+++ b/models/demos/t3000/falcon40b/tests/test_falcon_attention.py
@@ -69,7 +69,7 @@ def run_test_FalconAttention_inference(
     torch.manual_seed(0)
     layer_num = 0
     base_url = "transformer.h"
-    max_position_embeddings = 2048
+    max_position_embeddings = max(2048, seq_len)
     head_dim = configuration.hidden_size // configuration.num_attention_heads
 
     # Generate input, attention_mask, and kv_cache --------------------------------------
@@ -309,9 +309,16 @@ def run_test_FalconAttention_inference(
         ("prefill", 1, 32, 0),
         ("prefill", 1, 128, 0),
         ("prefill", 1, 2048, 0),
+        # ("prefill", 1, 8192, 0),
         ("decode", 32, 1, 128),
     ),
-    ids=["prefill_seq32", "prefill_seq128", "prefill_seq2048", "decode_batch32"],
+    ids=[
+        "prefill_seq32",
+        "prefill_seq128",
+        "prefill_seq2048",
+        # "prefill_seq8192",
+        "decode_batch32",
+    ],
 )
 @pytest.mark.parametrize(
     "model_version",

--- a/models/demos/t3000/falcon40b/tests/test_falcon_end_to_end.py
+++ b/models/demos/t3000/falcon40b/tests/test_falcon_end_to_end.py
@@ -404,6 +404,10 @@ def run_test_FalconCausalLM_end_to_end(
         ("prefill", 1, 128, 0),
         ("prefill", 1, 2048, 0),
         # ("prefill", 1, 8192, 0),  # Do not run in CI: takes too long
+        # ("prefill", 1, 16384, 0),
+        # ("prefill", 1, 32768, 0),
+        # ("prefill", 1, 131072, 0),
+        # ("prefill", 1, 262144, 0),
         ("decode", 32, 1, 128),
     ),
     ids=[
@@ -412,6 +416,10 @@ def run_test_FalconCausalLM_end_to_end(
         "prefill_seq128",
         "prefill_seq2048",
         # "prefill_seq8192",
+        # "prefill_seq16k",
+        # "prefill_seq32k",
+        # "prefill_seq120k",
+        # "prefill_seq240k",
         "decode_batch32",
     ],
 )

--- a/models/demos/t3000/falcon40b/tests/test_falcon_end_to_end.py
+++ b/models/demos/t3000/falcon40b/tests/test_falcon_end_to_end.py
@@ -65,7 +65,7 @@ def run_test_FalconCausalLM_end_to_end(
     # Prepare input ------------------------------------------------------------------------
     torch.manual_seed(0)
     base_url = ""
-    max_position_embeddings = 2048
+    max_position_embeddings = max(2048, seq_len)
     head_dim = configuration.hidden_size // configuration.num_attention_heads
     num_attention_heads = configuration.num_attention_heads
     num_kv_heads = configuration.num_kv_heads
@@ -401,23 +401,17 @@ def run_test_FalconCausalLM_end_to_end(
     (
         ("prefill", 1, 32, 0),
         ("prefill", 2, 32, 0),
-        # ("prefill", 1, 64, 0),
         ("prefill", 1, 128, 0),
-        # ("prefill", 1, 256, 0),
-        # ("prefill", 1, 512, 0),
-        # ("prefill", 1, 1024, 0),
         ("prefill", 1, 2048, 0),
+        # ("prefill", 1, 8192, 0),  # Do not run in CI: takes too long
         ("decode", 32, 1, 128),
     ),
     ids=[
         "prefill_seq32",
         "prefill_seq32_batch2",
-        # "prefill_seq64",
         "prefill_seq128",
-        # "prefill_seq256",
-        # "prefill_seq512",
-        # "prefill_seq1024",
         "prefill_seq2048",
+        # "prefill_seq8192",
         "decode_batch32",
     ],
 )

--- a/models/demos/t3000/falcon40b/tests/test_falcon_mlp.py
+++ b/models/demos/t3000/falcon40b/tests/test_falcon_mlp.py
@@ -110,12 +110,14 @@ def run_test_FalconMLP_inference(
         ("prefill", 1, 32),
         ("prefill", 1, 128),
         ("prefill", 1, 2048),
+        # ("prefill", 1, 8192),  # Do not run in CI: takes too long
     ),
     ids=(
         "decode_batch32",
         "prefill_seq32",
         "prefill_seq128",
         "prefill_seq2048",
+        # "prefill_seq8192",
     ),
 )
 @pytest.mark.parametrize(

--- a/models/demos/t3000/falcon40b/tt/falcon_attention.py
+++ b/models/demos/t3000/falcon40b/tt/falcon_attention.py
@@ -337,10 +337,6 @@ class TtFalconAttention:
         q_len = hidden_states.get_legacy_shape()[2]
         assert layer_past is not None
 
-        print("Reshape")
-
-        print(hidden_states.shape)
-
         # Reshape to compute long sequence lengths as multiple MM loops
         _, _, seq_len, _ = hidden_states.shape
         max_mm_seq_len = self.model_config["MAX_MM_SEQ_LEN"]
@@ -348,9 +344,6 @@ class TtFalconAttention:
         batch_dim = 1 if seq_len < max_mm_seq_len else seq_len // mm_seq_len_batched
         if batch_dim != 1:
             hidden_states = ttnn.reshape(hidden_states, (1, batch_dim, seq_len // batch_dim, -1))
-
-        print("qkv proj")
-        print(hidden_states.shape)
 
         # Fused query, key and value projection
         fused_query_key_value = falcon_prefill_matmul(
@@ -365,15 +358,9 @@ class TtFalconAttention:
             fuse_batch_mm2d=False,
         )
 
-        print("Reshape back")
-        print(fused_query_key_value.shape)
-
         # Reshape to compute long sequence lengths as multiple MM loops (reverse)
         if batch_dim != 1:
             fused_query_key_value = ttnn.reshape(fused_query_key_value, (1, 1, seq_len, -1))
-
-        print("nlp_create_qkv_heads")
-        print(fused_query_key_value.shape)
 
         query_layer, key_layer, value_layer = ttnn.experimental.tensor.nlp_create_qkv_heads(
             fused_query_key_value,
@@ -384,13 +371,9 @@ class TtFalconAttention:
         )
         fused_query_key_value.deallocate(True)
 
-        print("rotary_embedding")
-
         # Rotary embeddings
         query_layer = self.rotary_embedding(query_layer)
         key_layer = self.rotary_embedding(key_layer)
-
-        print("fill kvcaches")
 
         # K Cache update
         ttnn.experimental.tensor.fill_cache(
@@ -413,8 +396,6 @@ class TtFalconAttention:
 
         slice_size = self.model_config["attention_params"]["attention_slice_size"]
         num_slices = self.model_config["attention_params"]["attention_num_slices"]
-
-        print("sdpa")
 
         if num_slices > 1:
             for slice_i in range(num_slices):
@@ -468,8 +449,6 @@ class TtFalconAttention:
         query_layer.deallocate(True)
         key_layer_transposed.deallocate(True)
         value_layer.deallocate(True)
-
-        print("out proj")
 
         # Output projection
         attn_output = ttnn.experimental.tensor.nlp_concat_heads(

--- a/models/demos/t3000/falcon40b/tt/model_config.py
+++ b/models/demos/t3000/falcon40b/tt/model_config.py
@@ -747,6 +747,8 @@ def get_prefill_model_config(model_config_str, input_shape, num_devices):
     model_config["row_height"] = row_height
     model_config["BATCH_SIZE"] = batch_size
     model_config["SEQ_LEN"] = seq_len
+    model_config["MAX_MM_SEQ_LEN"] = 2048
+    model_config["MM_SEQ_LEN_BATCHED"] = 1024
 
     # Layernorm is an exception that are sharded also here, because the interleaved OP does not fit in L1 for 40b hidden size
     layernorm_num_cores_x = 8


### PR DESCRIPTION
### Ticket
- Github Issue: https://github.com/tenstorrent/tt-metal/issues/9667

### Problem description
- Currently we only support 2k sequence length

### What's changed
- Enables prefill sequence length of up to 8k
- Reshapes 2d MM inputs into batch dim with a max. slice of 1024 in the H dim; fuse_batch=false

### Checklist
- [ ] Post commit CI passes: not required
- [ ] Model regression CI testing passes
- [ ] New/Existing tests provide coverage for changes

[WAITING] for SDPA op PR to be merged to main