### PR TITLE
#9319: Set ubuntu_version to None if we can't find a host_location for it

### DIFF
--- a/infra/data_collection/github/utils.py
+++ b/infra/data_collection/github/utils.py
@@ -139,10 +139,11 @@ def get_job_row_from_github_job(github_job):
         if ubuntu_version == "ubuntu-latest":
             logger.warning("Found ubuntu-latest, replacing with ubuntu-22.04 but may not be case for long")
             ubuntu_version = "ubuntu-22.04"
-    else:
-        assert host_location == "tt_cloud"
+    elif host_location == "tt_cloud":
         logger.warning("Assuming ubuntu-20.04 for tt cloud, but may not be the case soon")
         ubuntu_version = "ubuntu-20.04"
+    else:
+        ubuntu_version = None
 
     host_os = ubuntu_version
 


### PR DESCRIPTION
…

### Ticket

#9319 

### Problem description

We did not account for `host_location` not existing because a job might have never grabbed a runner.

### What's changed

Account for the above and return a null location.

### Checklist
- [x] Post commit CI passes
- [x] Model regression CI testing passes (if applicable)
- [x] New/Existing tests provide coverage for changes
