### PR TITLE
#9587: Update CB and worker Go signals to respect max sub cmd limit introduced by dispatch packed write local copy change

### DIFF
--- a/tt_metal/impl/dispatch/command_queue.hpp
+++ b/tt_metal/impl/dispatch/command_queue.hpp
@@ -303,8 +303,7 @@ class EnqueueProgramCommand : public Command {
         std::vector<HostMemDeviceCommand> runtime_args_command_sequences;
         uint32_t runtime_args_fetch_size_bytes;
         HostMemDeviceCommand program_command_sequence;
-        uint32_t cb_configs_payload_start;
-        uint32_t aligned_cb_config_size_bytes;
+        std::vector<uint32_t *> cb_configs_payloads;
         std::vector<std::vector<std::shared_ptr<CircularBuffer>>> circular_buffers_on_core_ranges;
     };
     thread_local static std::unordered_map<uint64_t, CachedProgramCommandSequence> cached_program_command_sequences;

--- a/tt_metal/impl/dispatch/cq_commands.hpp
+++ b/tt_metal/impl/dispatch/cq_commands.hpp
@@ -162,6 +162,7 @@ struct CQDispatchWritePagedCmd {
 constexpr uint32_t CQ_DISPATCH_CMD_PACKED_WRITE_FLAG_NONE      = 0x00;
 constexpr uint32_t CQ_DISPATCH_CMD_PACKED_WRITE_FLAG_MCAST     = 0x01;
 constexpr uint32_t CQ_DISPATCH_CMD_PACKED_WRITE_FLAG_NO_STRIDE = 0x02;
+
 struct CQDispatchWritePackedCmd {
     uint8_t flags;            // see above
     uint16_t count;           // number of sub-cmds (max 1020 unicast, 510 mcast). Max num sub-cmds = (dispatch_constants::TRANSFER_PAGE_SIZE - sizeof(CQDispatchCmd)) / sizeof(CQDispatchWritePacked*castSubCmd)
@@ -177,6 +178,9 @@ struct CQDispatchWritePackedMulticastSubCmd {
     uint32_t noc_xy_addr;     // unique XY address for each SubCmd
     uint32_t num_mcast_dests;
 } __attribute__((packed));
+
+constexpr uint32_t CQ_DISPATCH_CMD_PACKED_WRITE_MAX_UNICAST_SUB_CMDS = 108;  // GS 120 - 1 row TODO: this should be a compile time arg passed in from host
+constexpr uint32_t CQ_DISPATCH_CMD_PACKED_WRITE_MAX_MULTICAST_SUB_CMDS = CQ_DISPATCH_CMD_PACKED_WRITE_MAX_UNICAST_SUB_CMDS * sizeof(CQDispatchWritePackedUnicastSubCmd) / sizeof(CQDispatchWritePackedMulticastSubCmd);
 
 struct CQDispatchWritePackedLargeSubCmd {
     uint32_t noc_xy_addr;

--- a/tt_metal/impl/dispatch/device_command.hpp
+++ b/tt_metal/impl/dispatch/device_command.hpp
@@ -76,6 +76,8 @@ class DeviceCommand {
 
     void *data() const { return this->cmd_region; }
 
+    uint32_t write_offset_bytes() const { return this->cmd_write_offsetB; }
+
     vector_memcpy_aligned<uint32_t> cmd_vector() const { return this->cmd_region_vector; }
 
     void add_dispatch_wait(
@@ -407,9 +409,8 @@ class DeviceCommand {
             std::is_same<PackedSubCmd, CQDispatchWritePackedMulticastSubCmd>::value);
         bool multicast = std::is_same<PackedSubCmd, CQDispatchWritePackedMulticastSubCmd>::value;
 
-        static constexpr uint32_t max_num_packed_sub_cmds =
-            (dispatch_constants::TRANSFER_PAGE_SIZE - sizeof(CQDispatchCmd)) / sizeof(PackedSubCmd);
-        TT_ASSERT(
+        constexpr uint32_t max_num_packed_sub_cmds = std::is_same<PackedSubCmd, CQDispatchWritePackedUnicastSubCmd>::value ? CQ_DISPATCH_CMD_PACKED_WRITE_MAX_UNICAST_SUB_CMDS : CQ_DISPATCH_CMD_PACKED_WRITE_MAX_MULTICAST_SUB_CMDS;
+        TT_FATAL(
             num_sub_cmds <= max_num_packed_sub_cmds,
             "Max number of packed sub commands are {} but requesting {}",
             max_num_packed_sub_cmds,


### PR DESCRIPTION
### Ticket
- https://github.com/tenstorrent/tt-metal/issues/9587

### Problem description
- Dispatch write packed recently introduced a size limit to number of sub cmds, but host code wasn't updated to respect that. The specific test from the issue hits this case because cbs/kernels were created core by core, so we had a lot more subcmds when compared to it being a range.

### What's changed
- Updated CB and worker Go signals host code to break into separate cmds when the number of subcmds exceeds the max. Probably need to add this for the mcast semaphores as well I think. Didn't update unicast the unicast transactions (eth) since those should be well under the limit.

### Checklist
- [x] Post commit CI passes
- [x] Model regression CI testing passes (if applicable)
- [x] New/Existing tests provide coverage for changes

TODO:

- Update sempahore mcast (wasn't hit for this issue)
- Potentially update unicast write packed to also handle this? Currently they should be well under since they're just used for eth cores, but I think we should also add the logic for this to be safe. Will also be easy to do after I refactor some code to make this a generic function api
