### PR TITLE
#0: Fix T3K profiler test logging

### DIFF
--- a/tests/scripts/run_profiler_regressions.sh
+++ b/tests/scripts/run_profiler_regressions.sh
@@ -10,6 +10,8 @@ run_additional_T3000_test(){
 
     ./tt_metal/tools/profiler/profile_this.py -c "pytest tests/tt_eager/python_api_testing/unit_testing/misc/test_all_gather.py::test_all_gather_on_t3000_post_commit[mem_config0-input_dtype0-8-1-input_shape1-0-layout1]" > $PROFILER_ARTIFACTS_DIR/test_out.log
 
+    cat $PROFILER_ARTIFACTS_DIR/test_out.log
+
     if cat $PROFILER_ARTIFACTS_DIR/test_out.log | grep "SKIPPED"
     then
         echo "No verification as test was skipped"
@@ -20,7 +22,6 @@ run_additional_T3000_test(){
         res=$(verify_perf_line_count "$PROFILER_OUTPUT_DIR/$runDate/ops_perf_results_$runDate.csv" "$LINE_COUNT")
         echo $res
     fi
-    cat $PROFILER_ARTIFACTS_DIR/test_out.log
 }
 
 run_async_mode_T3000_test(){


### PR DESCRIPTION
### Ticket
- Quick Fix

### Problem description
- Logging stderr and stdout properly when T3K tests fail

### What's changed
- Test output is dumped before any check on the output

### Checklist
- [x] Post commit CI passes : https://github.com/tenstorrent/tt-metal/actions/runs/9665395391
