### PR TITLE
#9642: add pre-in0 activation arg to add sub mul

### DIFF
--- a/ttnn/cpp/ttnn/operations/eltwise/binary/binary.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary/binary.hpp
@@ -110,7 +110,8 @@ struct BinaryOperation {
         const std::optional<const DataType> &output_dtype = std::nullopt,
         const std::optional<MemoryConfig> &memory_config = std::nullopt,
         std::optional<Tensor> optional_output_tensor = std::nullopt,
-        std::optional<FusedActivations> activations = std::nullopt) {
+        std::optional<FusedActivations> activations = std::nullopt,
+        std::optional<unary::UnaryWithParam> input_tensor_a_activation = std::nullopt) {
         if(output_dtype.has_value() && optional_output_tensor.has_value()){
             TT_FATAL(output_dtype.value() == optional_output_tensor.value().get_dtype(), "If both output dtype and output tensor provided dtype should match");
         }
@@ -157,7 +158,7 @@ struct BinaryOperation {
         return ttnn::device_operation::run<BinaryDeviceOperation>(
             queue_id,
             BinaryDeviceOperation::operation_attributes_t{
-                binary_op_type, in_place, activations, output_memory_config, dtype, std::nullopt},
+                binary_op_type, in_place, activations, input_tensor_a_activation, output_memory_config, dtype, std::nullopt},
             BinaryDeviceOperation::tensor_args_t{input_tensor_a, input_tensor_b, optional_output_tensor});
     }
 
@@ -167,7 +168,8 @@ struct BinaryOperation {
         const std::optional<const DataType> &output_dtype = std::nullopt,
         const std::optional<MemoryConfig> &memory_config = std::nullopt,
         std::optional<Tensor> optional_output_tensor = std::nullopt,
-        std::optional<FusedActivations> activations = std::nullopt) {
+        std::optional<FusedActivations> activations = std::nullopt,
+        std::optional<unary::UnaryWithParam> input_tensor_a_activation = std::nullopt) {
         return operator()(
             DefaultQueueId,
             input_tensor_a_arg,
@@ -175,7 +177,8 @@ struct BinaryOperation {
             output_dtype,
             memory_config,
             optional_output_tensor,
-            activations);
+            activations,
+            input_tensor_a_activation);
     }
 
     // TODO: this case should use BinaryWithScalarProgramConfig and there should be a custom kernel to run this
@@ -186,9 +189,10 @@ struct BinaryOperation {
         const std::optional<const DataType> &dtype = std::nullopt,
         const std::optional<ttnn::MemoryConfig> &memory_config = std::nullopt,
         const std::optional<Tensor> &optional_output_tensor = std::nullopt,
-        std::optional<FusedActivations> activations = std::nullopt) {
+        std::optional<FusedActivations> activations = std::nullopt,
+        std::optional<unary::UnaryWithParam> input_tensor_a_activation = std::nullopt) {
         return BinaryOperation::operator()(
-            DefaultQueueId, input_tensor_a, scalar, dtype, memory_config, optional_output_tensor, activations);
+            DefaultQueueId, input_tensor_a, scalar, dtype, memory_config, optional_output_tensor, activations, input_tensor_a_activation);
     }
 
     static Tensor operator()(
@@ -198,7 +202,8 @@ struct BinaryOperation {
         const std::optional<const DataType> &dtype = std::nullopt,
         const std::optional<ttnn::MemoryConfig> &memory_config = std::nullopt,
         const std::optional<Tensor> &optional_output_tensor = std::nullopt,
-        std::optional<FusedActivations> activations = std::nullopt) {
+        std::optional<FusedActivations> activations = std::nullopt,
+        std::optional<unary::UnaryWithParam> input_tensor_a_activation = std::nullopt) {
         // Cast Float Scalar to a device tensor
         auto host_buffer = owned_buffer::create<::bfloat16>(static_cast<std::size_t>(TILE_HEIGHT * TILE_WIDTH));
         host_buffer[0] = scalar;
@@ -210,7 +215,7 @@ struct BinaryOperation {
         Tensor scalar_tensor_device = scalar_tensor_host.to(input_tensor_a.device());
         // TODO(arakhmati): #7637 pass in memory_config instead of operation::DEFAULT_OUTPUT_MEMORY_CONFIG
         return BinaryOperation::operator()(
-            input_tensor_a, scalar_tensor_device, dtype, memory_config, optional_output_tensor, activations);
+            input_tensor_a, scalar_tensor_device, dtype, memory_config, optional_output_tensor, activations, input_tensor_a_activation);
     }
 };
 
@@ -223,7 +228,8 @@ struct RelationalBinary {
         const std::optional<const DataType> &output_dtype = std::nullopt,
         const std::optional<MemoryConfig> &memory_config = std::nullopt,
         std::optional<Tensor> optional_output_tensor = std::nullopt,
-        std::optional<FusedActivations> activations = std::nullopt) {
+        std::optional<FusedActivations> activations = std::nullopt,
+        std::optional<unary::UnaryWithParam> input_tensor_a_activation = std::nullopt) {
         if (output_dtype.has_value() && optional_output_tensor.has_value()) {
             TT_FATAL(
                 output_dtype.value() == optional_output_tensor.value().get_dtype(),
@@ -269,7 +275,7 @@ struct RelationalBinary {
         return ttnn::device_operation::run<BinaryDeviceOperation>(
             queue_id,
             BinaryDeviceOperation::operation_attributes_t{
-                binary_op_type, in_place, activations, output_memory_config, dtype, std::nullopt},
+                binary_op_type, in_place, activations, input_tensor_a_activation, output_memory_config, dtype, std::nullopt},
             BinaryDeviceOperation::tensor_args_t{input_tensor_a, input_tensor_b, optional_output_tensor});
     }
 
@@ -279,7 +285,8 @@ struct RelationalBinary {
         const std::optional<const DataType> &output_dtype = std::nullopt,
         const std::optional<MemoryConfig> &memory_config = std::nullopt,
         std::optional<Tensor> optional_output_tensor = std::nullopt,
-        std::optional<FusedActivations> activations = std::nullopt) {
+        std::optional<FusedActivations> activations = std::nullopt,
+        std::optional<unary::UnaryWithParam> input_tensor_a_activation = std::nullopt) {
         return operator()(
             DefaultQueueId,
             input_tensor_a_arg,
@@ -287,7 +294,8 @@ struct RelationalBinary {
             output_dtype,
             memory_config,
             optional_output_tensor,
-            activations);
+            activations,
+            input_tensor_a_activation);
     }
 
     static Tensor operator()(
@@ -296,7 +304,8 @@ struct RelationalBinary {
         const std::optional<const DataType> &dtype = std::nullopt,
         const std::optional<ttnn::MemoryConfig> &memory_config = std::nullopt,
         const std::optional<Tensor> &optional_output_tensor = std::nullopt,
-        std::optional<FusedActivations> activations = std::nullopt) {
+        std::optional<FusedActivations> activations = std::nullopt,
+        std::optional<unary::UnaryWithParam> input_tensor_a_activation = std::nullopt) {
         return detail::binary_impl(
             DefaultQueueId, binary_op_type, input_tensor_a, scalar, memory_config, optional_output_tensor);
     }
@@ -308,7 +317,8 @@ struct RelationalBinary {
         const std::optional<const DataType> &dtype = std::nullopt,
         const std::optional<ttnn::MemoryConfig> &memory_config = std::nullopt,
         const std::optional<Tensor> &optional_output_tensor = std::nullopt,
-        std::optional<FusedActivations> activations = std::nullopt) {
+        std::optional<FusedActivations> activations = std::nullopt,
+        std::optional<unary::UnaryWithParam> input_tensor_a_activation = std::nullopt) {
         return detail::binary_impl(
             DefaultQueueId, binary_op_type, input_tensor_a, scalar, memory_config, optional_output_tensor);
     }

--- a/ttnn/cpp/ttnn/operations/eltwise/binary/binary_composite.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary/binary_composite.hpp
@@ -102,10 +102,11 @@ struct ExecuteBiasGelu {
         const std::optional<const DataType> &output_dtype = std::nullopt,
         const std::optional<MemoryConfig> &memory_config = std::nullopt,
         std::optional<Tensor> optional_output_tensor = std::nullopt,
-        std::optional<FusedActivations> activations = std::nullopt) {
+        std::optional<FusedActivations> activations = std::nullopt,
+        std::optional<unary::UnaryWithParam> input_tensor_a_activation = std::nullopt) {
 
             return BinaryOperation<binary_op_type, in_place>::operator()(
-                queue_id, input_tensor_a_arg, input_tensor_b_arg, output_dtype, memory_config, optional_output_tensor, activations);
+                queue_id, input_tensor_a_arg, input_tensor_b_arg, output_dtype, memory_config, optional_output_tensor, activations, input_tensor_a_activation);
     }
 
     static Tensor operator()(
@@ -114,10 +115,11 @@ struct ExecuteBiasGelu {
         const std::optional<const DataType> &output_dtype = std::nullopt,
         const std::optional<MemoryConfig> &memory_config = std::nullopt,
         std::optional<Tensor> optional_output_tensor = std::nullopt,
-        std::optional<FusedActivations> activations = std::nullopt) {
+        std::optional<FusedActivations> activations = std::nullopt,
+        std::optional<unary::UnaryWithParam> input_tensor_a_activation = std::nullopt) {
 
             return BinaryOperation<binary_op_type, in_place>::operator()(
-                DefaultQueueId, input_tensor_a_arg, input_tensor_b_arg, output_dtype, memory_config, optional_output_tensor, activations);
+                DefaultQueueId, input_tensor_a_arg, input_tensor_b_arg, output_dtype, memory_config, optional_output_tensor, activations, input_tensor_a_activation);
     }
 
     static Tensor operator()(
@@ -127,7 +129,8 @@ struct ExecuteBiasGelu {
         const std::optional<const DataType> &dtype = std::nullopt,
         const std::optional<ttnn::MemoryConfig> &memory_config = std::nullopt,
         const std::optional<Tensor> &optional_output_tensor = std::nullopt,
-        std::optional<FusedActivations> activations = std::nullopt) {
+        std::optional<FusedActivations> activations = std::nullopt,
+        std::optional<unary::UnaryWithParam> input_tensor_a_activation = std::nullopt) {
 
             return ttnn::gelu(queue_id, ttnn::add(queue_id, input_tensor_a, bias, std::nullopt, memory_config, optional_output_tensor), true, memory_config, optional_output_tensor);
     }
@@ -138,9 +141,10 @@ struct ExecuteBiasGelu {
         const std::optional<const DataType> &dtype = std::nullopt,
         const std::optional<ttnn::MemoryConfig> &memory_config = std::nullopt,
         const std::optional<Tensor> &optional_output_tensor = std::nullopt,
-        std::optional<FusedActivations> activations = std::nullopt) {
+        std::optional<FusedActivations> activations = std::nullopt,
+        std::optional<unary::UnaryWithParam> input_tensor_a_activation = std::nullopt) {
 
-            return operator()(DefaultQueueId, input_tensor_a, bias, dtype, memory_config, optional_output_tensor, activations);
+            return operator()(DefaultQueueId, input_tensor_a, bias, dtype, memory_config, optional_output_tensor, activations, input_tensor_a_activation);
     }
 };
 

--- a/ttnn/cpp/ttnn/operations/eltwise/binary/binary_pybind.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary/binary_pybind.hpp
@@ -68,8 +68,9 @@ void bind_binary_operation(py::module& module, const binary_operation_t& operati
                const std::optional<ttnn::MemoryConfig>& memory_config,
                const std::optional<ttnn::Tensor>& output_tensor,
                const std::optional<FusedActivations>& activations,
+               const std::optional<UnaryWithParam>& input_tensor_a_activation,
                const uint8_t& queue_id) -> ttnn::Tensor {
-                return self(queue_id, input_tensor_a, scalar, dtype, memory_config, output_tensor, activations);
+                return self(queue_id, input_tensor_a, scalar, dtype, memory_config, output_tensor, activations, input_tensor_a_activation);
             },
             py::arg("input_tensor_a"),
             py::arg("input_tensor_b"),
@@ -78,6 +79,7 @@ void bind_binary_operation(py::module& module, const binary_operation_t& operati
             py::arg("memory_config") = std::nullopt,
             py::arg("output_tensor") = std::nullopt,
             py::arg("activations") = std::nullopt,
+            py::arg("input_tensor_a_activation") = std::nullopt,
             py::arg("queue_id") = 0},
 
         // tensor and tensor
@@ -89,8 +91,9 @@ void bind_binary_operation(py::module& module, const binary_operation_t& operati
                const std::optional<ttnn::MemoryConfig>& memory_config,
                const std::optional<ttnn::Tensor>& output_tensor,
                const std::optional<FusedActivations>& activations,
+               const std::optional<UnaryWithParam>& input_tensor_a_activation,
                const uint8_t& queue_id) -> ttnn::Tensor {
-                return self(queue_id, input_tensor_a, input_tensor_b, dtype, memory_config, output_tensor, activations);
+                return self(queue_id, input_tensor_a, input_tensor_b, dtype, memory_config, output_tensor, activations, input_tensor_a_activation);
             },
             py::arg("input_tensor_a"),
             py::arg("input_tensor_b"),
@@ -99,6 +102,7 @@ void bind_binary_operation(py::module& module, const binary_operation_t& operati
             py::arg("memory_config") = std::nullopt,
             py::arg("output_tensor") = std::nullopt,
             py::arg("activations") = std::nullopt,
+            py::arg("input_tensor_a_activation") = std::nullopt,
             py::arg("queue_id") = 0});
 }
 

--- a/ttnn/cpp/ttnn/operations/eltwise/binary/device/binary_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary/device/binary_device_operation.cpp
@@ -20,7 +20,8 @@ std::map<string, string> get_defines(
     BinaryOpType op_type,
     const std::optional<DataType> input_dtype,
     const std::optional<DataType> output_dtype,
-    const std::optional<std::vector<UnaryWithParam>> fused_activations) {
+    const std::optional<std::vector<UnaryWithParam>> fused_activations,
+    const std::optional<UnaryWithParam> input_tensor_a_activation) {
     std::map<string, string> defines;
     string op_name = "sub_tiles";
     string op_binary_type = "EltwiseBinaryType::ELWSUB";
@@ -150,6 +151,10 @@ std::map<string, string> get_defines(
         } else {
             defines.merge(ttnn::operations::unary::utils::get_block_defines(fused_activations.value(), "0", idst));
         }
+    }
+
+    if (input_tensor_a_activation.has_value() ) {
+        defines.merge(ttnn::operations::unary::utils::get_defines(input_tensor_a_activation.value().op_type, std::nullopt, "PRE_IN0_0"));
     }
 
     return defines;

--- a/ttnn/cpp/ttnn/operations/eltwise/binary/device/binary_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary/device/binary_device_operation.hpp
@@ -53,7 +53,8 @@ std::map<string, string> get_defines(
     BinaryOpType op_type,
     const std::optional<DataType> in_dtype = std::nullopt,
     const std::optional<DataType> out_dtype = std::nullopt,
-    const std::optional<FusedActivations> fused_activations = std::nullopt);
+    const std::optional<FusedActivations> fused_activations = std::nullopt,
+    const std::optional<unary::UnaryWithParam> input_tensor_a_activation = std::nullopt);
 
 }  // namespace utils
 
@@ -62,6 +63,7 @@ struct BinaryDeviceOperation {
         BinaryOpType binary_op_type;
         bool in_place;
         const std::optional<FusedActivations> activations;
+        const std::optional<unary::UnaryWithParam> input_tensor_a_activation;
         const MemoryConfig memory_config;
         const DataType dtype;
         std::optional<DeviceComputeKernelConfig> compute_kernel_config;

--- a/ttnn/cpp/ttnn/operations/eltwise/binary/device/element_wise_multi_core_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary/device/element_wise_multi_core_program_factory.cpp
@@ -331,7 +331,7 @@ BinaryDeviceOperation::ElementWiseMultiCore::cached_program_t BinaryDeviceOperat
     auto cb_src1 = tt_metal::CreateCircularBuffer(program, all_device_cores, cb_src1_config);
 
     std::map<string, string> eltwise_defines =
-        utils::get_defines(op_type, a.get_dtype(), output.get_dtype(), fused_activations);
+        utils::get_defines(op_type, a.get_dtype(), output.get_dtype(), fused_activations, operation_attributes.input_tensor_a_activation);
 
     if (eltwise_defines.find("SFPU_OP_INIT_PRE_IN0_0") != eltwise_defines.end()) {
         tt_metal::CircularBufferConfig cb_interm_config =


### PR DESCRIPTION
### Ticket
#9642

### Problem description
Currently, eltwise_mul does not take any pre-in0 activations, and Llama requires the support to make matmul faster

### What's changed
Add support for add, sub,mul with pre-in0 SiLU activations

### Checklist
- post commit pass https://github.com/tenstorrent/tt-metal/actions/runs/10149326039