### PR TITLE
#8729: Pytest multiprocess reset infrastructure

### DIFF
--- a/.github/workflows/fast-dispatch-full-regressions-and-models.yaml
+++ b/.github/workflows/fast-dispatch-full-regressions-and-models.yaml
@@ -26,7 +26,7 @@ jobs:
             { name: "N300 WH-only models", arch: wormhole_b0, cmd: tests/scripts/single_card/nightly/run_wh_b0_only.sh, timeout: 30 },
             { name: "API tests GS", arch: grayskull, cmd: ./tests/scripts/run_tests.sh --tt-arch grayskull --pipeline-type frequent_api --dispatch-mode fast, timeout: 40 },
             { name: "API tests N300 WH B0", arch: wormhole_b0, cmd: ./tests/scripts/run_tests.sh --tt-arch wormhole_b0 --pipeline-type frequent_api --dispatch-mode fast, timeout: 40 },
-            { name: "[Unstable] N300 models", arch: wormhole_b0, cmd: tests/scripts/single_card/nightly/run_wh_b0_unstable.sh, timeout: 35 },
+            { name: "[Unstable] N300 models", arch: wormhole_b0, cmd: tests/scripts/single_card/nightly/run_wh_b0_unstable.sh, timeout: 45 },
           ]
     name: FD ${{ matrix.test-group.name }} ${{ matrix.test-group.arch }}
     env:

--- a/.github/workflows/perf-models.yaml
+++ b/.github/workflows/perf-models.yaml
@@ -52,7 +52,7 @@ jobs:
       - uses: ./.github/actions/install-python-deps
       - name: Run performance regressions
         id: performance_tests
-        timeout-minutes: 30
+        timeout-minutes: 40
         run: |
           source ${{ github.workspace }}/python_env/bin/activate
           ./tests/scripts/run_tests.sh --tt-arch $ARCH_NAME --pipeline-type ${{ matrix.model-type }}_models_performance_${{ matrix.test-info.machine-type }}

--- a/.github/workflows/t3000-demo-tests.yaml
+++ b/.github/workflows/t3000-demo-tests.yaml
@@ -17,7 +17,7 @@ jobs:
       fail-fast: false
       matrix:
         test-group: [
-          { name: "t3k falcon40b tests", arch: wormhole_b0, cmd: run_t3000_falcon40b_tests, timeout: 40, owner_id: U044T8U8DEF}, #Johanna Rock
+          { name: "t3k falcon40b tests", arch: wormhole_b0, cmd: run_t3000_falcon40b_tests, timeout: 50, owner_id: U044T8U8DEF}, #Johanna Rock
           { name: "t3k llama3_70b tests", arch: wormhole_b0, cmd: run_t3000_llama3_70b_tests, timeout: 30, owner_id: U03FJB5TM5Y}, #Colman Glagovich
           { name: "t3k falcon7b tests", arch: wormhole_b0, cmd: run_t3000_falcon7b_tests, timeout: 90, owner_id: U05RWH3QUPM}, #Salar Hosseini
           { name: "t3k mixtral tests", arch: wormhole_b0, cmd: run_t3000_mixtral_tests, timeout: 30, owner_id: U03PUAKE719}, # Miguel Tairum
@@ -46,6 +46,7 @@ jobs:
         run: tar -xvf ttm_${{ matrix.test-group.arch }}.tar
       - uses: ./.github/actions/install-python-deps
       - name: Run demo regression tests
+        shell: bash {0}
         timeout-minutes: ${{ matrix.test-group.timeout }}
         run: |
           source ${{ github.workspace }}/python_env/bin/activate

--- a/.github/workflows/t3000-frequent-tests.yaml
+++ b/.github/workflows/t3000-frequent-tests.yaml
@@ -42,6 +42,7 @@ jobs:
         run: tar -xvf ttm_${{ matrix.test-group.arch }}.tar
       - uses: ./.github/actions/install-python-deps
       - name: Run frequent regression tests
+        shell: bash {0}
         timeout-minutes: ${{ matrix.test-group.timeout }}
         run: |
           source ${{ github.workspace }}/python_env/bin/activate

--- a/.github/workflows/t3000-model-perf-tests.yaml
+++ b/.github/workflows/t3000-model-perf-tests.yaml
@@ -17,10 +17,10 @@ jobs:
       fail-fast: false
       matrix:
         test-group: [
-          { name: "t3k LLM falcon7b model perf tests", model: "falcob7b", model-type: "LLM", arch: wormhole_b0, cmd: run_t3000_falcon7b_tests, timeout: 60, owner_id: S07AJBTLX2L}, #Model Falcon
-          { name: "t3k LLM mixtral model perf tests", model: "mixtral", model-type: "LLM", arch: wormhole_b0, cmd: run_t3000_mixtral_tests, timeout: 60, owner_id: U03PUAKE719}, # Miguel Tairum
-          { name: "t3k LLM llama2 model perf tests", model: "llama2", model-type: "LLM", arch: wormhole_b0, cmd: run_t3000_llama2_70b_tests, timeout: 60, owner_id: U03FJB5TM5Y}, #Colman Glagovich
-          { name: "t3k LLM falcon40b model perf tests", model: "falcon40b", model-type: "LLM", arch: wormhole_b0, cmd: run_t3000_falcon40b_tests, timeout: 60, owner_id: S07AJBTLX2L}, # Model Falcon
+          { name: "t3k LLM falcon7b model perf tests", model: "falcob7b", model-type: "LLM", arch: wormhole_b0, cmd: run_t3000_falcon7b_tests, timeout: 75, owner_id: S07AJBTLX2L}, #Model Falcon
+          { name: "t3k LLM mixtral model perf tests", model: "mixtral", model-type: "LLM", arch: wormhole_b0, cmd: run_t3000_mixtral_tests, timeout: 75, owner_id: U03PUAKE719}, # Miguel Tairum
+          { name: "t3k LLM llama2 model perf tests", model: "llama2", model-type: "LLM", arch: wormhole_b0, cmd: run_t3000_llama2_70b_tests, timeout: 75, owner_id: U03FJB5TM5Y}, #Colman Glagovich
+          { name: "t3k LLM falcon40b model perf tests", model: "falcon40b", model-type: "LLM", arch: wormhole_b0, cmd: run_t3000_falcon40b_tests, timeout: 75, owner_id: S07AJBTLX2L}, # Model Falcon
           #{ name: "t3k CNN model perf tests ", model-type: "CNN", arch: wormhole_b0, cmd: run_t3000_cnn_tests, timeout: 120, owner_id: }, #No tests are being run?
         ]
     name: ${{ matrix.test-group.name }}
@@ -52,6 +52,7 @@ jobs:
         run: tar -xvf ttm_${{ matrix.test-group.arch }}.tar
       - uses: ./.github/actions/install-python-deps
       - name: Run model perf regression tests
+        shell: bash {0}
         timeout-minutes: ${{ matrix.test-group.timeout }}
         run: |
           source ${{ github.workspace }}/python_env/bin/activate

--- a/.github/workflows/t3000-unit-tests.yaml
+++ b/.github/workflows/t3000-unit-tests.yaml
@@ -43,6 +43,7 @@ jobs:
         run: tar -xvf ttm_${{ matrix.test-group.arch }}.tar
       - uses: ./.github/actions/install-python-deps
       - name: Run unit regression tests
+        shell: bash {0}
         timeout-minutes: ${{ matrix.test-group.timeout }}
         run: |
           source ${{ github.workspace }}/python_env/bin/activate

--- a/conftest.py
+++ b/conftest.py
@@ -12,6 +12,11 @@ from itertools import chain
 from operator import contains, eq, getitem
 from pathlib import Path
 import json
+import copy
+import multiprocess
+import signal
+import time
+import psutil
 
 from loguru import logger
 
@@ -70,6 +75,224 @@ def get_tt_cache_path():
     return get_tt_cache_path_
 
 
+@pytest.fixture(scope="function")
+def device_params(request):
+    return getattr(request, "param", {})
+
+
+@pytest.fixture(scope="function")
+def device(request, device_params):
+    import tt_lib as ttl
+
+    device_id = request.config.getoption("device_id")
+
+    request.node.device_ids = [device_id]
+    request.node.pci_ids = [ttl.device.GetPCIeDeviceID(device_id)]
+
+    num_devices = ttl.device.GetNumPCIeDevices()
+    assert device_id < num_devices, "CreateDevice not supported for non-mmio device"
+    device = ttl.device.CreateDevice(device_id=device_id, **device_params)
+    ttl.device.SetDefaultDevice(device)
+
+    yield device
+
+    ttl.device.DumpDeviceProfiler(device)
+
+    ttl.device.Synchronize(device)
+    ttl.device.CloseDevice(device)
+
+
+@pytest.fixture(scope="function")
+def pcie_devices(request, device_params):
+    import tt_lib as ttl
+
+    num_devices = ttl.device.GetNumPCIeDevices()
+    device_ids = [i for i in range(num_devices)]
+
+    request.node.device_ids = device_ids
+    request.node.pci_ids = [ttl.device.GetPCIeDeviceID(i) for i in device_ids]
+
+    # Get only physical devices
+    devices = ttl.device.CreateDevices(device_ids, **device_params)
+
+    yield [devices[i] for i in range(num_devices)]
+
+    for device in devices.values():
+        ttl.device.DumpDeviceProfiler(device)
+
+    ttl.device.CloseDevices(devices)
+
+
+@pytest.fixture(scope="function")
+def all_devices(request, device_params):
+    import tt_lib as ttl
+
+    num_devices = ttl.device.GetNumAvailableDevices()
+    device_ids = [i for i in range(num_devices)]
+
+    request.node.device_ids = device_ids
+    request.node.pci_ids = [ttl.device.GetPCIeDeviceID(i) for i in device_ids]
+
+    # Get only physical devices
+    devices = ttl.device.CreateDevices(device_ids, **device_params)
+
+    yield [devices[i] for i in range(num_devices)]
+
+    for device in devices.values():
+        ttl.device.DumpDeviceProfiler(device)
+
+    ttl.device.CloseDevices(devices)
+
+
+@pytest.fixture(scope="function")
+def device_mesh(request, silicon_arch_name, silicon_arch_wormhole_b0, device_params):
+    import ttnn
+    import tt_lib as ttl
+
+    device_ids = ttnn.get_device_ids()
+    try:
+        num_devices_requested = min(request.param, len(device_ids))
+    except (ValueError, AttributeError):
+        num_devices_requested = len(device_ids)
+
+    request.node.device_ids = device_ids[:num_devices_requested]
+    request.node.pci_ids = [ttl.device.GetPCIeDeviceID(i) for i in device_ids[:num_devices_requested]]
+
+    device_mesh = ttnn.open_device_mesh(
+        ttnn.DeviceGrid(1, num_devices_requested), device_ids[:num_devices_requested], **device_params
+    )
+
+    logger.debug(f"multidevice with {device_mesh.get_num_devices()} devices is created")
+    yield device_mesh
+
+    for device in device_mesh.get_devices():
+        ttl.device.DumpDeviceProfiler(device)
+
+    ttnn.close_device_mesh(device_mesh)
+    del device_mesh
+
+
+@pytest.fixture(scope="function")
+def pcie_device_mesh(request, silicon_arch_name, silicon_arch_wormhole_b0, device_params):
+    import ttnn
+    import tt_lib as ttl
+
+    device_ids = ttnn.get_pcie_device_ids()
+    try:
+        num_pcie_devices_requested = min(request.param, len(device_ids))
+    except (ValueError, AttributeError):
+        num_pcie_devices_requested = len(device_ids)
+
+    request.node.device_ids = device_ids[:num_pcie_devices_requested]
+    request.node.pci_ids = [ttl.device.GetPCIeDeviceID(i) for i in device_ids[:num_pcie_devices_requested]]
+
+    device_mesh = ttnn.open_device_mesh(
+        ttnn.DeviceGrid(1, num_pcie_devices_requested), device_ids[:num_pcie_devices_requested], **device_params
+    )
+
+    logger.debug(f"multidevice with {device_mesh.get_num_devices()} devices is created")
+    yield device_mesh
+
+    for device in device_mesh.get_devices():
+        ttl.device.DumpDeviceProfiler(device)
+
+    ttnn.close_device_mesh(device_mesh)
+    del device_mesh
+
+
+@pytest.fixture(scope="function")
+def t3k_device_mesh(request, silicon_arch_name, silicon_arch_wormhole_b0, device_params):
+    import ttnn
+    import tt_lib as ttl
+
+    if ttnn.get_num_devices() < 8:
+        pytest.skip()
+    device_ids = [0, 4, 5, 1, 2, 6, 7, 3]
+    try:
+        num_devices_requested = min(request.param, len(device_ids))
+    except (ValueError, AttributeError):
+        num_devices_requested = len(device_ids)
+
+    request.node.device_ids = device_ids[:num_devices_requested]
+    request.node.pci_ids = [ttl.device.GetPCIeDeviceID(i) for i in device_ids[:num_devices_requested]]
+
+    device_mesh = ttnn.open_device_mesh(
+        ttnn.DeviceGrid(1, num_devices_requested), device_ids[:num_devices_requested], **device_params
+    )
+
+    logger.debug(f"multidevice with {device_mesh.get_num_devices()} devices is created")
+    yield device_mesh
+
+    for device in device_mesh.get_devices():
+        ttl.device.DumpDeviceProfiler(device)
+
+    ttnn.close_device_mesh(device_mesh)
+    del device_mesh
+
+
+@pytest.fixture()
+def clear_compile_cache():
+    yield
+    import tt_lib as ttl
+
+    ttl.device.DisablePersistentKernelCache()
+
+
+@pytest.fixture(autouse=True)
+def reset_default_device():
+    import tt_lib as ttl
+
+    device = ttl.device.GetDefaultDevice()
+    yield
+    ttl.device.SetDefaultDevice(device)
+
+
+@pytest.fixture(scope="function")
+def use_program_cache(request):
+    import tt_lib as ttl
+
+    if "device" in request.fixturenames:
+        dev = request.getfixturevalue("device")
+        dev.enable_program_cache()
+    elif "all_devices" in request.fixturenames:
+        devices = request.getfixturevalue("all_devices")
+        for dev in devices:
+            dev.enable_program_cache()
+    elif "pcie_devices" in request.fixturenames:
+        devices = request.getfixturevalue("pcie_devices")
+        for dev in devices:
+            dev.enable_program_cache()
+    elif "device_mesh" in request.fixturenames:
+        mesh = request.getfixturevalue("device_mesh")
+        for device_id in mesh.get_device_ids():
+            mesh.get_device(device_id).enable_program_cache()
+    elif "t3k_device_mesh" in request.fixturenames:
+        mesh = request.getfixturevalue("t3k_device_mesh")
+        for device_id in mesh.get_device_ids():
+            mesh.get_device(device_id).enable_program_cache()
+    elif "pcie_device_mesh" in request.fixturenames:
+        mesh = request.getfixturevalue("pcie_device_mesh")
+        for device_id in mesh.get_device_ids():
+            mesh.get_device(device_id).enable_program_cache()
+    else:
+        logger.warning("No device fixture found to apply program cache to: PROGRAM CACHE DISABLED")
+    yield
+
+
+@pytest.fixture(scope="function")
+def tracy_profile():
+    from tracy import Profiler
+
+    profiler = Profiler()
+
+    profiler.enable()
+    yield
+    profiler.disable()
+
+
+###############################
+# Modifying pytest hooks
+###############################
 ALL_ARCHS = set(
     [
         "grayskull",
@@ -84,6 +307,11 @@ def pytest_addoption(parser):
         choices=[*ALL_ARCHS],
         default=os.environ.get("ARCH_NAME", "grayskull"),
         help="Target arch, ex. grayskull, wormhole_b0",
+    )
+    parser.addoption(
+        "--pipeline-type",
+        default="",
+        help="Only `models_device_performance_bare_metal` should run `pytest_runtest_teardown`",
     )
     parser.addoption(
         "--device-id",
@@ -105,6 +333,12 @@ def pytest_addoption(parser):
         help="Path to json file with inputs",
     )
     parser.addoption("--cli-input", action="store", default=None, help="Enter prompt if --input-method=cli")
+    parser.addoption(
+        "--metal-cleanup",
+        action="store",
+        default=None,
+        help="Enable process timeout",
+    )
 
 
 def pytest_generate_tests(metafunc):
@@ -200,11 +434,11 @@ def pytest_generate_tests(metafunc):
         )
 
     if uses_silicon_arch:
-        metafunc.parametrize("silicon_arch_name", available_archs, scope="session")
+        metafunc.parametrize("silicon_arch_name", available_archs)
         for test_requested_silicon_arch_fixture in test_requested_silicon_arch_fixtures:
             # The values of these arch-specific fixtures should not be used in
             # the test function, so use any parameters, like [True]
-            metafunc.parametrize(test_requested_silicon_arch_fixture, [True], scope="session")
+            metafunc.parametrize(test_requested_silicon_arch_fixture, [True])
 
     input_method = metafunc.config.getoption("--input-method")
     if input_method == "json":
@@ -236,223 +470,90 @@ def pytest_runtest_makereport(item, call):
     item.stash.setdefault(phase_report_key, {})[rep.when] = rep
 
 
-@pytest.fixture(scope="function")
-def reset_tensix(request, silicon_arch_name):
+@pytest.hookimpl(hookwrapper=True)
+def pytest_runtest_teardown(item, nextitem):
     yield
-
-    report = request.node.stash[phase_report_key]
-
-    test_failed = ("call" not in report) or report["call"].failed
-
-    if test_failed:
-        logger.debug("Test failed - resetting with smi")
-        if silicon_arch_name == "grayskull":
-            result = run_process_and_get_result("tt-smi -tr all")
-        elif silicon_arch_name == "wormhole_b0":
-            result = run_process_and_get_result("tt-smi -wr all")
-        else:
-            raise Exception(f"Unrecognized arch for tensix-reset: {silicon_arch_name}")
-        assert result.returncode == 0, "Tensix reset script raised error"
+    metal_cleanup_enabled = item.config.getoption("--metal-cleanup")
+    if metal_cleanup_enabled is not None:
+        report = item.stash[phase_report_key]
+        test_failed = report.get("call", None) and report["call"].failed
+        if test_failed:
+            logger.info(f"In custom teardown, open device ids: {item.device_ids} {set(item.pci_ids)}")
+            # reset_tensix(set(item.pci_ids))
+            reset_tensix()
 
 
-@pytest.fixture(scope="function")
-def device_params(request):
-    return getattr(request, "param", {})
+# This is overriding the timer setup hook from pytest-timeout
+# If --metal-timeout is passed, we define a new timeout method that spawns a timer process
+# At timeout, the process kills it's parent (the test process) and then itself
+@pytest.hookimpl(tryfirst=True)
+def pytest_timeout_set_timer(item, settings):
+    metal_timeout_enabled = item.config.getoption("--metal-cleanup")
+    if metal_timeout_enabled is not None:
+        parent_pid = os.getpid()
+        logger.info(f"Metal timeout {settings.timeout} seconds")
+
+        def get_parent_status():
+            try:
+                parent = psutil.Process(parent_pid)
+            except:
+                return "already dead"
+            return parent.status()
+
+        def run_timer(settings):
+            dead_status = ["zombie", "dead", "already dead"]
+            timeout = settings.timeout
+            while get_parent_status() not in dead_status and timeout > 0:
+                time.sleep(1)
+                timeout -= 1
+            if get_parent_status() != "already dead":
+                logger.info(f"Timing out test case")
+                os.kill(parent_pid, signal.SIGKILL)
+            logger.info(f"Killing timer")
+            os._exit(1)
+
+        def cancel():
+            logger.info(f"Cancelling timer")
+            metal_timer.terminate()
+
+        metal_timer = multiprocess.Process(target=run_timer, args=(settings,), daemon=True)
+        item.cancel_timeout = cancel
+        metal_timer.start()
+        # logger.info(f"parent and metal timer pid: {parent_pid} {metal_timer.pid}")
+    return True
 
 
-@pytest.fixture(scope="function")
-def device(request, device_params):
-    import tt_lib as ttl
-
-    device_id = request.config.getoption("device_id")
-
-    num_devices = ttl.device.GetNumPCIeDevices()
-    assert device_id < num_devices, "CreateDevice not supported for non-mmio device"
-    device = ttl.device.CreateDevice(device_id=device_id, **device_params)
-    ttl.device.SetDefaultDevice(device)
-
-    yield device
-
-    ttl.device.DumpDeviceProfiler(device)
-
-    ttl.device.Synchronize(device)
-    ttl.device.CloseDevice(device)
+# This is a hook used in pytest-xdist to handle when a worker crashes out
+# In our case, combined with pytest-timeout thread method, the worker will crash out for a hang and
+# then it should get cleaned up by the controller through this fixture :fingers_crossed:
+@pytest.hookimpl(tryfirst=True)
+def pytest_handlecrashitem(crashitem, report, sched):
+    reset_tensix()
 
 
-@pytest.fixture(scope="function")
-def pcie_devices(request, device_params):
-    import tt_lib as ttl
+def reset_tensix(tt_open_devices=None):
+    metal_env = copy.deepcopy(os.environ)
+    arch = metal_env.get("ARCH_NAME")
+    if arch != "grayskull" and arch != "wormhole_b0":
+        raise Exception(f"Unrecognized arch for tensix-reset: {arch}")
 
-    num_devices = ttl.device.GetNumPCIeDevices()
-
-    # Get only physical devices
-    devices = ttl.device.CreateDevices(device_ids=[i for i in range(num_devices)], **device_params)
-
-    yield [devices[i] for i in range(num_devices)]
-
-    for device in devices.values():
-        ttl.device.DumpDeviceProfiler(device)
-
-    ttl.device.CloseDevices(devices)
-
-
-@pytest.fixture(scope="function")
-def all_devices(request, device_params):
-    import tt_lib as ttl
-
-    num_devices = ttl.device.GetNumAvailableDevices()
-
-    # Get only physical devices
-    devices = ttl.device.CreateDevices(device_ids=[i for i in range(num_devices)], **device_params)
-
-    yield [devices[i] for i in range(num_devices)]
-
-    for device in devices.values():
-        ttl.device.DumpDeviceProfiler(device)
-
-    ttl.device.CloseDevices(devices)
-
-
-@pytest.fixture(scope="function")
-def device_mesh(request, silicon_arch_name, silicon_arch_wormhole_b0, device_params):
-    import ttnn
-
-    device_ids = ttnn.get_device_ids()
-    try:
-        num_devices_requested = min(request.param, len(device_ids))
-    except (ValueError, AttributeError):
-        num_devices_requested = len(device_ids)
-
-    device_mesh = ttnn.open_device_mesh(
-        ttnn.DeviceGrid(1, num_devices_requested), device_ids[:num_devices_requested], **device_params
-    )
-
-    logger.debug(f"multidevice with {device_mesh.get_num_devices()} devices is created")
-    yield device_mesh
-
-    import tt_lib as ttl
-
-    for device in device_mesh.get_devices():
-        ttl.device.DumpDeviceProfiler(device)
-
-    ttnn.close_device_mesh(device_mesh)
-    del device_mesh
-
-
-@pytest.fixture(scope="function")
-def pcie_device_mesh(request, silicon_arch_name, silicon_arch_wormhole_b0, device_params):
-    import ttnn
-
-    device_ids = ttnn.get_pcie_device_ids()
-    try:
-        num_pcie_devices_requested = min(request.param, len(device_ids))
-    except (ValueError, AttributeError):
-        num_pcie_devices_requested = len(device_ids)
-
-    device_mesh = ttnn.open_device_mesh(
-        ttnn.DeviceGrid(1, num_pcie_devices_requested), device_ids[:num_pcie_devices_requested], **device_params
-    )
-
-    logger.debug(f"multidevice with {device_mesh.get_num_devices()} devices is created")
-    yield device_mesh
-
-    import tt_lib as ttl
-
-    for device in device_mesh.get_devices():
-        ttl.device.DumpDeviceProfiler(device)
-
-    ttnn.close_device_mesh(device_mesh)
-    del device_mesh
-
-
-@pytest.fixture(scope="function")
-def t3k_device_mesh(request, silicon_arch_name, silicon_arch_wormhole_b0, device_params):
-    import ttnn
-
-    if ttnn.get_num_devices() < 8:
-        pytest.skip()
-    device_ids = [0, 4, 5, 1, 2, 6, 7, 3]
-    try:
-        num_devices_requested = min(request.param, len(device_ids))
-    except (ValueError, AttributeError):
-        num_devices_requested = len(device_ids)
-
-    device_mesh = ttnn.open_device_mesh(
-        ttnn.DeviceGrid(1, num_devices_requested), device_ids[:num_devices_requested], **device_params
-    )
-
-    logger.debug(f"multidevice with {device_mesh.get_num_devices()} devices is created")
-    yield device_mesh
-
-    import tt_lib as ttl
-
-    for device in device_mesh.get_devices():
-        ttl.device.DumpDeviceProfiler(device)
-
-    ttnn.close_device_mesh(device_mesh)
-    del device_mesh
-
-
-@pytest.fixture()
-def clear_compile_cache():
-    yield
-    import tt_lib as ttl
-
-    ttl.device.DisablePersistentKernelCache()
-
-
-@pytest.fixture(autouse=True)
-def reset_default_device():
-    import tt_lib as ttl
-
-    device = ttl.device.GetDefaultDevice()
-    yield
-    ttl.device.SetDefaultDevice(device)
-
-
-@pytest.fixture(scope="function")
-def use_program_cache(request):
-    import tt_lib as ttl
-
-    if "device" in request.fixturenames:
-        dev = request.getfixturevalue("device")
-        dev.enable_program_cache()
-    elif "all_devices" in request.fixturenames:
-        devices = request.getfixturevalue("all_devices")
-        for dev in devices:
-            dev.enable_program_cache()
-    elif "pcie_devices" in request.fixturenames:
-        devices = request.getfixturevalue("pcie_devices")
-        for dev in devices:
-            dev.enable_program_cache()
-    elif "device_mesh" in request.fixturenames:
-        mesh = request.getfixturevalue("device_mesh")
-        for device_id in mesh.get_device_ids():
-            mesh.get_device(device_id).enable_program_cache()
-    elif "t3k_device_mesh" in request.fixturenames:
-        mesh = request.getfixturevalue("t3k_device_mesh")
-        for device_id in mesh.get_device_ids():
-            mesh.get_device(device_id).enable_program_cache()
-    elif "pcie_device_mesh" in request.fixturenames:
-        mesh = request.getfixturevalue("pcie_device_mesh")
-        for device_id in mesh.get_device_ids():
-            mesh.get_device(device_id).enable_program_cache()
+    if tt_open_devices is None:
+        logger.info(f"Running reset with reset script: /opt/tt_metal_infra/scripts/ci/{arch}/reset.sh")
+        smi_reset_result = run_process_and_get_result(f"/opt/tt_metal_infra/scripts/ci/{arch}/reset.sh")
     else:
-        logger.warning("No device fixture found to apply program cache to: PROGRAM CACHE DISABLED")
-    yield
+        tt_open_devices_str = ",".join([str(i) for i in tt_open_devices])
+        check_smi = run_process_and_get_result("tt-smi-metal -h")
+        logger.info(f"Check tt-smi-metal exists: {check_smi.returncode}")
+        logger.info(f"Running reset for pci devices: {tt_open_devices_str}")
+        if check_smi.returncode > 0:
+            logger.info(f"Test failed - resetting {arch} with tt-smi")
+            smi_reset_result = run_process_and_get_result(f"tt-smi -r {tt_open_devices_str}")
+        else:
+            smi_reset_result = run_process_and_get_result(f"tt-smi-metal -r {tt_open_devices_str}")
+    logger.info(f"tt-smi reset status: {smi_reset_result.returncode}")
 
 
-@pytest.fixture(scope="function")
-def tracy_profile():
-    from tracy import Profiler
-
-    profiler = Profiler()
-
-    profiler.enable()
-    yield
-    profiler.disable()
-
-
-@pytest.fixture
-def input_path(request):
-    return request.config.getoption("--input-path")
+@pytest.hookimpl(tryfirst=True)
+def pytest_xdist_auto_num_workers(config):
+    logger.info("getting num of xdist workers")
+    return 1

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,7 +1,7 @@
 [pytest]
 timeout = 300
 minversion = 7.2
-addopts = --import-mode=importlib -vs -rA
+addopts = --import-mode=importlib -vvs -rA --durations=0
 empty_parameter_set_mark = skip
 markers =
     post_commit: mark tests to run on post-commit

--- a/tests/scripts/run_performance.sh
+++ b/tests/scripts/run_performance.sh
@@ -1,6 +1,6 @@
 #/bin/bash
 
-set -eo pipefail
+# set -eo pipefail
 
 if [[ -z "$TT_METAL_HOME" ]]; then
   echo "Must provide TT_METAL_HOME in environment" 1>&2
@@ -11,19 +11,19 @@ run_perf_models_other() {
     local tt_arch=$1
     local test_marker=$2
 
-    env pytest tests/ttnn/integration_tests/resnet/test_performance.py -m $test_marker
+    env pytest -n auto tests/ttnn/integration_tests/resnet/test_performance.py -m $test_marker
 
-    env pytest tests/ttnn/integration_tests/bert/test_performance.py -m $test_marker
+    env pytest -n auto tests/ttnn/integration_tests/bert/test_performance.py -m $test_marker
 
-    env pytest models/demos/ttnn_falcon7b/tests -m $test_marker
+    env pytest -n auto models/demos/ttnn_falcon7b/tests -m $test_marker
 
     # Separate calls since we can't mix switching between number of cqs
-    env pytest models/demos/resnet/tests/test_perf_resnet.py -m $test_marker
-    env pytest models/demos/resnet/tests/test_perf_resnet_2cqs.py -m $test_marker
+    env pytest -n auto models/demos/resnet/tests/test_perf_resnet.py -m $test_marker
+    env pytest -n auto models/demos/resnet/tests/test_perf_resnet_2cqs.py -m $test_marker
 
-    env pytest tests/ttnn/integration_tests/whisper/test_performance.py -m $test_marker
+    env pytest -n auto tests/ttnn/integration_tests/whisper/test_performance.py -m $test_marker
 
-    env pytest models/demos/metal_BERT_large_11/tests -m $test_marker
+    env pytest -n auto models/demos/metal_BERT_large_11/tests -m $test_marker
 
     ## Merge all the generated reports
     env python models/perf/merge_perf_results.py
@@ -33,13 +33,13 @@ run_perf_models_llm_javelin() {
     local tt_arch=$1
     local test_marker=$2
 
-    env WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml pytest models/demos/falcon7b/tests -m $test_marker
+    env WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml pytest -n auto models/demos/falcon7b/tests -m $test_marker
 
     if [ "$tt_arch" == "wormhole_b0" ]; then
-        env pytest models/demos/mamba/tests -m $test_marker --timeout=360
+        env pytest -n auto models/demos/mamba/tests -m $test_marker --timeout=360
     fi
 
-    env  WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml pytest models/demos/wormhole/mistral7b/tests -m $test_marker --timeout=360
+    env  WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml pytest -n auto models/demos/wormhole/mistral7b/tests -m $test_marker --timeout=360
 
     ## Merge all the generated reports
     env python models/perf/merge_perf_results.py
@@ -50,7 +50,7 @@ run_perf_models_cnn_javelin() {
     local test_marker=$2
 
     # Run tests
-    env WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml pytest tests/device_perf_tests/stable_diffusion -m $test_marker --timeout=480
+    env WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml pytest -n auto tests/device_perf_tests/stable_diffusion -m $test_marker --timeout=480
     #env WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml pytest models/experimental/functional_unet/tests -m $test_marker
 
     ## Merge all the generated reports
@@ -58,6 +58,7 @@ run_perf_models_cnn_javelin() {
 }
 
 run_device_perf_models() {
+    set -eo pipefail
     local test_marker=$1
 
     env pytest tests/device_perf_tests/stable_diffusion -m $test_marker --timeout=600

--- a/tests/scripts/run_tests.sh
+++ b/tests/scripts/run_tests.sh
@@ -81,7 +81,7 @@ run_frequent_api_pipeline_tests() {
         ./tests/scripts/run_python_api_unit_tests.sh
     else
         if [[ $tt_arch == "wormhole_b0" ]]; then
-            pytest  tests/tt_eager/python_api_testing/unit_testing/misc/test_all_gather.py -k nightly
+            pytest -n auto tests/tt_eager/python_api_testing/unit_testing/misc/test_all_gather.py -k nightly
         else
             echo "API tests are not available for fast dispatch because they're already covered in post-commit"
         fi

--- a/tests/scripts/single_card/nightly/run_common_models.sh
+++ b/tests/scripts/single_card/nightly/run_common_models.sh
@@ -1,12 +1,17 @@
 #/bin/bash
 
-set -eo pipefail
+# set -eo pipefail
 
 if [[ -z "$TT_METAL_HOME" ]]; then
   echo "Must provide TT_METAL_HOME in environment" 1>&2
   exit 1
 fi
+fail=0
 
 echo "Running common models for archs"
 
-env pytest tests/nightly/common_models/
+env pytest -n auto tests/nightly/common_models/ ; fail+=$?
+
+if [[ $fail -ne 0 ]]; then
+  exit 1
+fi

--- a/tests/scripts/single_card/nightly/run_gs_only.sh
+++ b/tests/scripts/single_card/nightly/run_gs_only.sh
@@ -1,14 +1,19 @@
 #/bin/bash
 
-set -eo pipefail
+# set -eo pipefail
 
 if [[ -z "$TT_METAL_HOME" ]]; then
   echo "Must provide TT_METAL_HOME in environment" 1>&2
   exit 1
 fi
+fail=0
 
 echo "Running model nightly tests for GS only"
 
-env pytest models/demos/resnet/tests/test_metal_resnet50_performant.py
+env pytest -n auto models/demos/resnet/tests/test_metal_resnet50_performant.py ; fail+=$?
 
-env pytest models/demos/resnet/tests/test_metal_resnet50_2cqs_performant.py
+env pytest -n auto models/demos/resnet/tests/test_metal_resnet50_2cqs_performant.py ; fail+=$?
+
+if [[ $fail -ne 0 ]]; then
+  exit 1
+fi

--- a/tests/scripts/single_card/nightly/run_ttnn.sh
+++ b/tests/scripts/single_card/nightly/run_ttnn.sh
@@ -1,12 +1,17 @@
 #/bin/bash
 
-set -eo pipefail
+# set -eo pipefail
 
 if [[ -z "$TT_METAL_HOME" ]]; then
   echo "Must provide TT_METAL_HOME in environment" 1>&2
   exit 1
 fi
+fail=0
 
 echo "Running ttnn nightly tests for GS only"
 
-env pytest tests/ttnn/integration_tests -m "not models_performance_bare_metal and not models_device_performance_bare_metal"
+env pytest -n auto tests/ttnn/integration_tests -m "not models_performance_bare_metal and not models_device_performance_bare_metal" ; fail+=$?
+
+if [[ $fail -ne 0 ]]; then
+  exit 1
+fi

--- a/tests/scripts/single_card/nightly/run_wh_b0_only.sh
+++ b/tests/scripts/single_card/nightly/run_wh_b0_only.sh
@@ -1,12 +1,17 @@
 #/bin/bash
 
-set -eo pipefail
+# set -eo pipefail
 
 if [[ -z "$TT_METAL_HOME" ]]; then
   echo "Must provide TT_METAL_HOME in environment" 1>&2
   exit 1
 fi
+fail=0
 
 echo "Running nightly tests for WH B0 only"
-env WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml pytest tests/nightly/wh_b0_only_eth
-env pytest tests/nightly/wh_b0_only
+env WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml pytest -n auto tests/nightly/wh_b0_only_eth ; fail+=$?
+env pytest -n auto tests/nightly/wh_b0_only ; fail+=$?
+
+if [[ $fail -ne 0 ]]; then
+  exit 1
+fi

--- a/tests/scripts/single_card/nightly/run_wh_b0_unstable.sh
+++ b/tests/scripts/single_card/nightly/run_wh_b0_unstable.sh
@@ -1,12 +1,17 @@
 #/bin/bash
 
-set -eo pipefail
+# set -eo pipefail
 
 if [[ -z "$TT_METAL_HOME" ]]; then
   echo "Must provide TT_METAL_HOME in environment" 1>&2
   exit 1
 fi
+fail=0
 
 echo "Running unstable nightly tests for WH B0 only"
 
-SLOW_MATMULS=1 WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml env pytest tests/ttnn/integration_tests/stable_diffusion
+SLOW_MATMULS=1 WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml env pytest -n auto tests/ttnn/integration_tests/stable_diffusion ; fail+=$?
+
+if [[ $fail -ne 0 ]]; then
+    exit 1
+fi

--- a/tests/scripts/t3000/run_t3000_demo_tests.sh
+++ b/tests/scripts/t3000/run_t3000_demo_tests.sh
@@ -1,23 +1,27 @@
 
 #/bin/bash
-set -eo pipefail
+# set -eo pipefail
 
 run_t3000_falcon40b_tests() {
   # Record the start time
+  fail=0
   start_time=$(date +%s)
 
   echo "LOG_METAL: Running run_t3000_falcon40b_tests"
 
   # Falcon40B prefill 60 layer end to end with 10 loops; we need 8x8 grid size
-  WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml pytest models/demos/t3000/falcon40b/tests/ci/test_falcon_end_to_end_60_layer_t3000_prefill_10_loops.py --timeout=720
+  WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml pytest -n auto models/demos/t3000/falcon40b/tests/ci/test_falcon_end_to_end_60_layer_t3000_prefill_10_loops.py --timeout=720 ; fail+=$?
 
   # Falcon40B end to end demo (prefill + decode)
-  WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml pytest models/demos/t3000/falcon40b/tests/ci/test_falcon_end_to_end_t3000_demo_loops.py
+  WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml pytest -n auto models/demos/t3000/falcon40b/tests/ci/test_falcon_end_to_end_t3000_demo_loops.py ; fail+=$?
 
   # Record the end time
   end_time=$(date +%s)
   duration=$((end_time - start_time))
   echo "LOG_METAL: run_t3000_falcon40b_tests $duration seconds to complete"
+  if [[ $fail -ne 0 ]]; then
+    exit 1
+  fi
 }
 
 run_t3000_llama3_70b_tests() {
@@ -38,39 +42,47 @@ run_t3000_llama3_70b_tests() {
 
 run_t3000_falcon7b_tests(){
   # Record the start time
+  fail=0
   start_time=$(date +%s)
 
   echo "LOG_METAL: Running run_t3000_falcon7b_tests"
 
   # Falcon7B demo (perf verification for 128/1024/2048 seq lens and output token verification)
-  WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml pytest --disable-warnings -q -s --input-method=json --input-path='models/demos/t3000/falcon7b/input_data_t3000.json' models/demos/t3000/falcon7b/demo_t3000.py::test_demo_multichip[user_input0-8-True-perf_mode_128_stochastic_verify]
-  WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml pytest --disable-warnings -q -s --input-method=json --input-path='models/demos/t3000/falcon7b/input_data_t3000.json' models/demos/t3000/falcon7b/demo_t3000.py::test_demo_multichip[user_input0-8-True-perf_mode_1024_stochastic_verify]
-  WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml pytest --disable-warnings -q -s --input-method=json --input-path='models/demos/t3000/falcon7b/input_data_t3000.json' models/demos/t3000/falcon7b/demo_t3000.py::test_demo_multichip[user_input0-8-True-perf_mode_2048_stochastic_verify]
-  WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml pytest --disable-warnings -q -s --input-method=json --input-path='models/demos/t3000/falcon7b/input_data_t3000.json' models/demos/t3000/falcon7b/demo_t3000.py::test_demo_multichip[user_input0-8-True-default_mode_1024_greedy_verify]
+  WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml pytest -n auto --disable-warnings -q -s --input-method=json --input-path='models/demos/t3000/falcon7b/input_data_t3000.json' models/demos/t3000/falcon7b/demo_t3000.py::test_demo_multichip[user_input0-8-True-perf_mode_128_stochastic_verify] ; fail+=$?
+  WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml pytest -n auto --disable-warnings -q -s --input-method=json --input-path='models/demos/t3000/falcon7b/input_data_t3000.json' models/demos/t3000/falcon7b/demo_t3000.py::test_demo_multichip[user_input0-8-True-perf_mode_1024_stochastic_verify] ; fail+=$?
+  WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml pytest -n auto --disable-warnings -q -s --input-method=json --input-path='models/demos/t3000/falcon7b/input_data_t3000.json' models/demos/t3000/falcon7b/demo_t3000.py::test_demo_multichip[user_input0-8-True-perf_mode_2048_stochastic_verify] ; fail+=$?
+  WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml pytest -n auto --disable-warnings -q -s --input-method=json --input-path='models/demos/t3000/falcon7b/input_data_t3000.json' models/demos/t3000/falcon7b/demo_t3000.py::test_demo_multichip[user_input0-8-True-default_mode_1024_greedy_verify] ; fail+=$?
 
   # Falcon7B perplexity test (prefill and decode)
-  WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml pytest models/demos/falcon7b/tests/test_perplexity_falcon.py::test_perplexity[True-prefill_seq1024_dram] --timeout=720
-  WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml pytest models/demos/falcon7b/tests/test_perplexity_falcon.py::test_perplexity[True-decode_1024_l1_sharded] --timeout=720
+  WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml pytest -n auto models/demos/falcon7b/tests/test_perplexity_falcon.py::test_perplexity[True-prefill_seq1024_dram] --timeout=720 ; fail+=$?
+  WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml pytest -n auto models/demos/falcon7b/tests/test_perplexity_falcon.py::test_perplexity[True-decode_1024_l1_sharded] --timeout=720 ; fail+=$?
 
   # Record the end time
   end_time=$(date +%s)
   duration=$((end_time - start_time))
   echo "LOG_METAL: run_t3000_falcon7b_tests $duration seconds to complete"
+  if [[ $fail -ne 0 ]]; then
+    exit 1
+  fi
 }
 
 run_t3000_mixtral_tests() {
   # Record the start time
+  fail=0
   start_time=$(date +%s)
 
   echo "LOG_METAL: Running run_t3000_mixtral8x7b_tests"
 
   # mixtral8x7b 8 chip demo test - 100 token generation with general weights (env flags set inside the test)
-  pytest models/demos/t3000/mixtral8x7b/demo/demo.py::test_mixtral8x7b_demo[wormhole_b0-True-general_weights] --timeout=720
+  pytest -n auto models/demos/t3000/mixtral8x7b/demo/demo.py::test_mixtral8x7b_demo[wormhole_b0-True-general_weights] --timeout=720 ; fail+=$?
 
   # Record the end time
   end_time=$(date +%s)
   duration=$((end_time - start_time))
   echo "LOG_METAL: run_t3000_mixtral_tests $duration seconds to complete"
+  if [[ $fail -ne 0 ]]; then
+    exit 1
+  fi
 }
 
 run_t3000_tests() {
@@ -87,6 +99,7 @@ run_t3000_tests() {
   run_t3000_mixtral_tests
 }
 
+fail=0
 main() {
     # For CI pipeline - source func commands but don't execute tests if not invoked directly
   if [[ "${BASH_SOURCE[0]}" != "${0}" ]]; then
@@ -109,6 +122,10 @@ main() {
   export PYTHONPATH=$TT_METAL_HOME
 
   run_t3000_tests
+
+  if [[ $fail -ne 0 ]]; then
+    exit 1
+  fi
 }
 
 main "$@"

--- a/tests/scripts/t3000/run_t3000_frequent_tests.sh
+++ b/tests/scripts/t3000/run_t3000_frequent_tests.sh
@@ -1,99 +1,122 @@
 
 #/bin/bash
-set -eo pipefail
+# set -eo pipefail
 
 run_t3000_ethernet_tests() {
   # Record the start time
+  fail=0
   start_time=$(date +%s)
 
   echo "LOG_METAL: Running run_t3000_ethernet_tests"
 
-  pytest tests/tt_metal/microbenchmarks/ethernet/test_ethernet_bidirectional_bandwidth_microbenchmark.py
-  pytest tests/tt_metal/microbenchmarks/ethernet/test_ethernet_ring_latency_microbenchmark.py
+  pytest -n auto tests/tt_metal/microbenchmarks/ethernet/test_ethernet_bidirectional_bandwidth_microbenchmark.py ; fail+=$?
+  pytest -n auto tests/tt_metal/microbenchmarks/ethernet/test_ethernet_ring_latency_microbenchmark.py ; fail+=$?
 
   # Record the end time
   end_time=$(date +%s)
   duration=$((end_time - start_time))
   echo "LOG_METAL: run_t3000_ethernet_tests $duration seconds to complete"
+  if [[ $fail -ne 0 ]]; then
+    exit 1
+  fi
 }
 
 run_t3000_llama2_70b_tests() {
   # Record the start time
+  fail=0
   start_time=$(date +%s)
 
   echo "LOG_METAL: Running run_t3000_llama2_70b_tests"
 
-  env WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml pytest models/demos/t3000/llama2_70b/tests/test_llama_mlp_t3000.py
-  env WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml pytest models/demos/t3000/llama2_70b/tests/test_llama_attention_t3000.py
-  env WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml pytest models/demos/t3000/llama2_70b/tests/test_llama_decoder_t3000.py
-  env WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml pytest models/demos/t3000/llama2_70b/tests/test_llama_model_t3000.py --timeout=900
+  env WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml pytest -n auto models/demos/t3000/llama2_70b/tests/test_llama_mlp_t3000.py ; fail+=$?
+  env WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml pytest -n auto models/demos/t3000/llama2_70b/tests/test_llama_attention_t3000.py ; fail+=$?
+  env WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml pytest -n auto models/demos/t3000/llama2_70b/tests/test_llama_decoder_t3000.py ; fail+=$?
+  env WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml pytest -n auto models/demos/t3000/llama2_70b/tests/test_llama_model_t3000.py --timeout=900 ; fail+=$?
 
   # Record the end time
   end_time=$(date +%s)
   duration=$((end_time - start_time))
   echo "LOG_METAL: run_t3000_llama2_70b_tests $duration seconds to complete"
+  if [[ $fail -ne 0 ]]; then
+    exit 1
+  fi
 }
 
 run_t3000_mixtral_tests() {
   # Record the start time
+  fail=0
   start_time=$(date +%s)
 
   echo "LOG_METAL: Running run_t3000_mixtral_tests"
 
   # mixtral8x7b 8 chip decode model test (env flags set inside the test)
-  pytest models/demos/t3000/mixtral8x7b/tests/test_mixtral_model.py::test_mixtral_model_inference[wormhole_b0-True-10-1-pcc]
+  pytest -n auto models/demos/t3000/mixtral8x7b/tests/test_mixtral_model.py::test_mixtral_model_inference[wormhole_b0-True-10-1-pcc] ; fail+=$?
 
   # Record the end time
   end_time=$(date +%s)
   duration=$((end_time - start_time))
   echo "LOG_METAL: run_t3000_mixtral_tests $duration seconds to complete"
+  if [[ $fail -ne 0 ]]; then
+    exit 1
+  fi
 }
 
 run_t3000_tteager_tests() {
   # Record the start time
+  fail=0
   start_time=$(date +%s)
 
   echo "LOG_METAL: Running run_t3000_tteager_tests"
 
-  pytest tests/tt_eager/python_api_testing/unit_testing/misc/test_all_gather.py -k post_commit
-  pytest tests/tt_eager/python_api_testing/unit_testing/misc/test_reduce_scatter_post_commit.py
+  pytest -n auto tests/tt_eager/python_api_testing/unit_testing/misc/test_all_gather.py -k post_commit ; fail+=$?
+  pytest -n auto tests/tt_eager/python_api_testing/unit_testing/misc/test_reduce_scatter_post_commit.py ; fail+=$?
 
   # Record the end time
   end_time=$(date +%s)
   duration=$((end_time - start_time))
   echo "LOG_METAL: run_t3000_tteager_tests $duration seconds to complete"
+  if [[ $fail -ne 0 ]]; then
+    exit 1
+  fi
 }
 
 run_t3000_trace_stress_tests() {
+  fail=0
   start_time=$(date +%s)
 
   echo "LOG_METAL: Running run_t3000_trace_stress_tests"
-
-  NUM_TRACE_LOOPS=15 pytest tests/ttnn/unit_tests/test_multi_device_trace.py
-  NUM_TRACE_LOOPS=15 WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml pytest tests/ttnn/unit_tests/test_multi_device_trace.py
+  NUM_TRACE_LOOPS=15 pytest -n auto tests/ttnn/unit_tests/test_multi_device_trace.py ; fail+=$?
+  NUM_TRACE_LOOPS=15 WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml pytest -n auto tests/ttnn/unit_tests/test_multi_device_trace.py ; fail+=$?
 
   # Record the end time
   end_time=$(date +%s)
   duration=$((end_time - start_time))
   echo "LOG_METAL: run_t3000_trace_stress_tests $duration seconds to complete"
+  if [[ $fail -ne 0 ]]; then
+    exit 1
+  fi
 }
 
 
 run_t3000_falcon40b_tests() {
+  fail=0
   # Record the start time
   start_time=$(date +%s)
 
   echo "LOG_METAL: Running run_t3000_falcon40b_tests"
 
-  WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml pytest models/demos/t3000/falcon40b/tests/test_falcon_mlp.py
-  WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml pytest models/demos/t3000/falcon40b/tests/test_falcon_attention.py --timeout=480
-  WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml pytest models/demos/t3000/falcon40b/tests/test_falcon_decoder.py --timeout=480
-  WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml pytest models/demos/t3000/falcon40b/tests/test_falcon_causallm.py --timeout=600
+  WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml pytest -n auto models/demos/t3000/falcon40b/tests/test_falcon_mlp.py ; fail+=$?
+  WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml pytest -n auto models/demos/t3000/falcon40b/tests/test_falcon_attention.py --timeout=480 ; fail+=$?
+  WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml pytest -n auto models/demos/t3000/falcon40b/tests/test_falcon_decoder.py --timeout=480 ; fail+=$?
+  WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml pytest -n auto models/demos/t3000/falcon40b/tests/test_falcon_causallm.py --timeout=600 ; fail+=$?
 
   # Record the end time
   end_time=$(date +%s)
   duration=$((end_time - start_time))
   echo "LOG_METAL: run_t3000_falcon40b_tests $duration seconds to complete"
+  if [[ $fail -ne 0 ]]; then
+    exit 1
+  fi
 }
 
 run_t3000_tests() {
@@ -102,9 +125,6 @@ run_t3000_tests() {
 
   # Run tteager tests
   run_t3000_tteager_tests
-
-  # Run trace tests
-  run_t3000_trace_stress_tests
 
   # Run falcon40b tests
   run_t3000_falcon40b_tests
@@ -115,8 +135,12 @@ run_t3000_tests() {
   # Run mixtral tests
   run_t3000_mixtral_tests
 
+  # Run trace tests
+  run_t3000_trace_stress_tests
+
 }
 
+fail=0
 main() {
   # For CI pipeline - source func commands but don't execute tests if not invoked directly
   if [[ "${BASH_SOURCE[0]}" != "${0}" ]]; then
@@ -139,6 +163,10 @@ main() {
   export PYTHONPATH=$TT_METAL_HOME
 
   run_t3000_tests
+
+  if [[ $fail -ne 0 ]]; then
+    exit 1
+  fi
 }
 
 main "$@"

--- a/tests/scripts/t3000/run_t3000_model_perf_tests.sh
+++ b/tests/scripts/t3000/run_t3000_model_perf_tests.sh
@@ -1,61 +1,77 @@
 
 #/bin/bash
-set -eo pipefail
+# set -eo pipefail
 
 run_t3000_falcon7b_tests() {
   # Record the start time
+  fail=0
   start_time=$(date +%s)
 
   echo "LOG_METAL: Running run_t3000_falcon7b_tests"
 
-  env WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml pytest models/demos/falcon7b/tests -m "model_perf_t3000"
+  env WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml pytest -n auto models/demos/falcon7b/tests -m "model_perf_t3000" ; fail+=$?
 
   # Record the end time
   end_time=$(date +%s)
   duration=$((end_time - start_time))
   echo "LOG_METAL: run_t3000_falcon7b_tests $duration seconds to complete"
+  if [[ $fail -ne 0 ]]; then
+    exit 1
+  fi
 }
 
 run_t3000_mixtral_tests() {
   # Record the start time
+  fail=0
   start_time=$(date +%s)
 
   echo "LOG_METAL: Running run_t3000_mixtral_tests"
 
-  env pytest models/demos/t3000/mixtral8x7b/tests/test_mixtral_perf.py -m "model_perf_t3000"
+  env pytest -n auto models/demos/t3000/mixtral8x7b/tests/test_mixtral_perf.py -m "model_perf_t3000" ; fail+=$?
 
   # Record the end time
   end_time=$(date +%s)
   duration=$((end_time - start_time))
   echo "LOG_METAL: run_t3000_mixtral_tests $duration seconds to complete"
+  if [[ $fail -ne 0 ]]; then
+    exit 1
+  fi
 }
 
 run_t3000_llama2_70b_tests() {
   # Record the start time
+  fail=0
   start_time=$(date +%s)
 
   echo "LOG_METAL: Running run_t3000_llama2_70b_tests"
 
-  env WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml pytest models/demos/t3000/llama2_70b/tests/test_llama_perf_decode.py -m "model_perf_t3000" --timeout=600
+  env WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml pytest -n auto models/demos/t3000/llama2_70b/tests/test_llama_perf_decode.py -m "model_perf_t3000" --timeout=600 ; fail+=$?
 
   # Record the end time
   end_time=$(date +%s)
   duration=$((end_time - start_time))
   echo "LOG_METAL: run_t3000_llama2_70b_tests $duration seconds to complete"
+  if [[ $fail -ne 0 ]]; then
+    exit 1
+  fi
 }
 
 run_t3000_falcon40b_tests() {
   # Record the start time
+  fail=0
   start_time=$(date +%s)
 
   echo "LOG_METAL: Running run_t3000_falcon40b_tests"
 
-  env WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml pytest models/demos/t3000/falcon40b/tests/test_perf_falcon.py -m "model_perf_t3000" --timeout=600
+  env WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml pytest -n auto models/demos/t3000/falcon40b/tests/test_perf_falcon.py -m "model_perf_t3000" --timeout=600 ; fail+=$?
 
   # Record the end time
   end_time=$(date +%s)
   duration=$((end_time - start_time))
   echo "LOG_METAL: run_t3000_falcon40b_tests $duration seconds to complete"
+  if [[ $fail -ne 0 ]]; then
+    exit 1
+  fi
 }
 
 run_t3000_llm_tests() {
@@ -80,6 +96,7 @@ run_t3000_cnn_tests() {
   env python models/perf/merge_perf_results.py
 }
 
+fail=0
 main() {
   # For CI pipeline - source func commands but don't execute tests if not invoked directly
   if [[ "${BASH_SOURCE[0]}" != "${0}" ]]; then
@@ -127,6 +144,10 @@ main() {
     run_t3000_cnn_tests
   else
     echo "$pipeline_type is invalid (supported: [cnn_model_perf_t3000_device, cnn_model_perf_t3000_device])" 2>&1
+    exit 1
+  fi
+
+  if [[ $fail -ne 0 ]]; then
     exit 1
   fi
 }

--- a/tests/scripts/t3000/run_t3000_unit_tests.sh
+++ b/tests/scripts/t3000/run_t3000_unit_tests.sh
@@ -1,66 +1,79 @@
 
 #/bin/bash
-set -eo pipefail
+# set -eo pipefail
 
 run_t3000_ttmetal_tests() {
   # Record the start time
+  fail=0
   start_time=$(date +%s)
 
   echo "LOG_METAL: Running run_t3000_ttmetal_tests"
 
-  TT_METAL_SLOW_DISPATCH_MODE=1 ./build/test/tt_metal/unit_tests --gtest_filter="DeviceFixture.EthKernelsDirectSendAllConnectedChips"
-  TT_METAL_SLOW_DISPATCH_MODE=1 ./build/test/tt_metal/unit_tests --gtest_filter="DeviceFixture.EthKernelsSendInterleavedBufferAllConnectedChips"
-  TT_METAL_SLOW_DISPATCH_MODE=1 ./build/test/tt_metal/unit_tests --gtest_filter="DeviceFixture.EthKernelsDirectRingGatherAllChips"
-  TT_METAL_SLOW_DISPATCH_MODE=1 ./build/test/tt_metal/unit_tests --gtest_filter="DeviceFixture.EthKernelsInterleavedRingGatherAllChips"
-  TT_METAL_ENABLE_REMOTE_CHIP=1 ./build/test/tt_metal/unit_tests_fast_dispatch --gtest_filter="CommandQueueSingleCardFixture.*"
-  ./build/test/tt_metal/unit_tests_fast_dispatch --gtest_filter="CommandQueueMultiDeviceFixture.*"
-  ./build/test/tt_metal/unit_tests_fast_dispatch --gtest_filter="DPrintFixture.*:WatcherFixture.*"
+  TT_METAL_SLOW_DISPATCH_MODE=1 ./build/test/tt_metal/unit_tests --gtest_filter="DeviceFixture.EthKernelsDirectSendAllConnectedChips" ; fail+=$?
+  TT_METAL_SLOW_DISPATCH_MODE=1 ./build/test/tt_metal/unit_tests --gtest_filter="DeviceFixture.EthKernelsSendInterleavedBufferAllConnectedChips" ; fail+=$?
+  TT_METAL_SLOW_DISPATCH_MODE=1 ./build/test/tt_metal/unit_tests --gtest_filter="DeviceFixture.EthKernelsDirectRingGatherAllChips" ; fail+=$?
+  TT_METAL_SLOW_DISPATCH_MODE=1 ./build/test/tt_metal/unit_tests --gtest_filter="DeviceFixture.EthKernelsInterleavedRingGatherAllChips" ; fail+=$?
+  TT_METAL_ENABLE_REMOTE_CHIP=1 ./build/test/tt_metal/unit_tests_fast_dispatch --gtest_filter="CommandQueueSingleCardFixture.*" ; fail+=$?
+  ./build/test/tt_metal/unit_tests_fast_dispatch --gtest_filter="CommandQueueMultiDeviceFixture.*" ; fail+=$?
+  ./build/test/tt_metal/unit_tests_fast_dispatch --gtest_filter="DPrintFixture.*:WatcherFixture.*" ; fail+=$?
 
   # Record the end time
   end_time=$(date +%s)
   duration=$((end_time - start_time))
   echo "LOG_METAL: run_t3000_ttmetal_tests $duration seconds to complete"
+  if [[ $fail -ne 0 ]]; then
+    exit 1
+  fi
 }
 
 run_t3000_ttnn_tests() {
   # Record the start time
+  fail=0
   start_time=$(date +%s)
 
   echo "LOG_METAL: Running run_t3000_ttnn_tests"
-  pytest tests/ttnn/unit_tests/test_multi_device_trace.py
-  WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml pytest tests/ttnn/unit_tests/test_multi_device_trace.py
-  pytest tests/ttnn/unit_tests/test_multi_device.py
-  pytest tests/ttnn/unit_tests/test_multi_device_async.py
+  pytest -n auto tests/ttnn/unit_tests/test_multi_device_trace.py ; fail+=$?
+  WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml pytest tests/ttnn/unit_tests/test_multi_device_trace.py ; fail+=$?
+  pytest -n auto tests/ttnn/unit_tests/test_multi_device.py ; fail+=$?
+  pytest -n auto tests/ttnn/unit_tests/test_multi_device_async.py ; fail+=$?
   # Record the end time
   end_time=$(date +%s)
   duration=$((end_time - start_time))
   echo "LOG_METAL: run_t3000_ttnn_tests $duration seconds to complete"
+  if [[ $fail -ne 0 ]]; then
+    exit 1
+  fi
 }
 
 run_t3000_falcon7b_tests() {
   # Record the start time
+  fail=0
   start_time=$(date +%s)
 
   echo "LOG_METAL: Running run_t3000_falcon7b_tests"
 
-  pytest models/demos/ttnn_falcon7b/tests/multi_chip/test_falcon_mlp.py
-  pytest models/demos/ttnn_falcon7b/tests/multi_chip/test_falcon_attention.py
-  pytest models/demos/ttnn_falcon7b/tests/multi_chip/test_falcon_decoder.py
+  pytest -n auto models/demos/ttnn_falcon7b/tests/multi_chip/test_falcon_mlp.py ; fail+=$?
+  pytest -n auto models/demos/ttnn_falcon7b/tests/multi_chip/test_falcon_attention.py ; fail+=$?
+  pytest -n auto models/demos/ttnn_falcon7b/tests/multi_chip/test_falcon_decoder.py ; fail+=$?
   #pytest models/demos/ttnn_falcon7b/tests/multi_chip/test_falcon_causallm.py
 
   # Record the end time
   end_time=$(date +%s)
   duration=$((end_time - start_time))
   echo "LOG_METAL: run_t3000_falcon7b_tests $duration seconds to complete"
+  if [[ $fail -ne 0 ]]; then
+    exit 1
+  fi
 }
 
 run_t3000_falcon40b_tests() {
   # Record the start time
+  fail=0
   start_time=$(date +%s)
 
   echo "LOG_METAL: Running run_t3000_falcon40b_tests"
 
-  WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml pytest models/demos/t3000/falcon40b/tests/ci/test_falcon_end_to_end_1_layer_t3000.py
+  WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml pytest -n auto models/demos/t3000/falcon40b/tests/ci/test_falcon_end_to_end_1_layer_t3000.py ; fail+=$?
 
   # Record the end time
   end_time=$(date +%s)
@@ -70,21 +83,25 @@ run_t3000_falcon40b_tests() {
 
 run_t3000_mixtral_tests() {
   # Record the start time
+  fail=0
   start_time=$(date +%s)
 
   echo "LOG_METAL: Running run_t3000_mixtral_tests"
 
-  pytest models/demos/t3000/mixtral8x7b/tests/test_mixtral_attention.py
-  pytest models/demos/t3000/mixtral8x7b/tests/test_mixtral_mlp.py
-  pytest models/demos/t3000/mixtral8x7b/tests/test_mixtral_rms_norm.py
-  pytest models/demos/t3000/mixtral8x7b/tests/test_mixtral_embedding.py
-  pytest models/demos/t3000/mixtral8x7b/tests/test_mixtral_moe.py
-  pytest models/demos/t3000/mixtral8x7b/tests/test_mixtral_decoder.py
+  pytest -n auto models/demos/t3000/mixtral8x7b/tests/test_mixtral_attention.py ; fail+=$?
+  pytest -n auto models/demos/t3000/mixtral8x7b/tests/test_mixtral_mlp.py ; fail+=$?
+  pytest -n auto models/demos/t3000/mixtral8x7b/tests/test_mixtral_rms_norm.py ; fail+=$?
+  pytest -n auto models/demos/t3000/mixtral8x7b/tests/test_mixtral_embedding.py ; fail+=$?
+  pytest -n auto models/demos/t3000/mixtral8x7b/tests/test_mixtral_moe.py ; fail+=$?
+  pytest -n auto models/demos/t3000/mixtral8x7b/tests/test_mixtral_decoder.py ; fail+=$?
 
   # Record the end time
   end_time=$(date +%s)
   duration=$((end_time - start_time))
   echo "LOG_METAL: run_t3000_mixtral_tests $duration seconds to complete"
+  if [[ $fail -ne 0 ]]; then
+    exit 1
+  fi
 }
 
 run_t3000_tests() {
@@ -104,6 +121,7 @@ run_t3000_tests() {
   run_t3000_mixtral_tests
 }
 
+fail=0
 main() {
   # For CI pipeline - source func commands but don't execute tests if not invoked directly
   if [[ "${BASH_SOURCE[0]}" != "${0}" ]]; then
@@ -126,6 +144,10 @@ main() {
   export PYTHONPATH=$TT_METAL_HOME
 
   run_t3000_tests
+
+  if [[ $fail -ne 0 ]]; then
+    exit 1
+  fi
 }
 
 main "$@"

--- a/tt_eager/tt_lib/csrc/tt_lib_bindings.cpp
+++ b/tt_eager/tt_lib/csrc/tt_lib_bindings.cpp
@@ -136,6 +136,10 @@ void DeviceModule(py::module &m_device) {
         Returns number of Tenstorrent devices that are connected to host via PCIe and can be targeted.
     )doc");
 
+    m_device.def("GetPCIeDeviceID", &GetPCIeDeviceID, R"doc(
+        Returns associated mmio device of give device id.
+    )doc");
+
     m_device.def("SetDefaultDevice", &AutoFormat::SetDefaultDevice, R"doc(
         Sets the default device to use for ops when inputs aren't on device.
 

--- a/tt_metal/host_api.hpp
+++ b/tt_metal/host_api.hpp
@@ -55,6 +55,8 @@ size_t GetNumAvailableDevices();
  */
 size_t GetNumPCIeDevices();
 
+chip_id_t GetPCIeDeviceID(chip_id_t device_id);
+
 /**
  * Instantiates a device object.
  *

--- a/tt_metal/python_env/requirements-dev.txt
+++ b/tt_metal/python_env/requirements-dev.txt
@@ -21,6 +21,7 @@ mypy==1.9.0
 pytest==7.2.2
 pytest-timeout==2.2.0
 pytest-split==0.8.2
+pytest-xdist==3.6.1
 jsbeautifier==1.14.7
 datasets==2.9.0
 torch==2.2.1.0+cpu

--- a/tt_metal/tt_metal.cpp
+++ b/tt_metal/tt_metal.cpp
@@ -730,6 +730,10 @@ size_t GetNumPCIeDevices() {
 #endif
 }
 
+chip_id_t GetPCIeDeviceID(chip_id_t device_id){
+    return tt::Cluster::instance().get_associated_mmio_device(device_id);
+}
+
 Device *CreateDevice(
     chip_id_t device_id,
     const uint8_t num_hw_cqs,


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/8729

### Problem description
- Provide a reliable way to time out pytest hangs and cleanup (smi reset) after hangs/fails
- `pytest-timeout` doesn't provide a reliable timeout method due to the python GIL

### What's changed
- Using combo of `xdist` + `pytest-timeout` plugins to provide smi reset infrastructure after hang/fail
- New timeout method, where test process spins up a timer process that monitors the test process and kills when timed out
- when test fails, will run a cleanup teardown fixture that runs tt-smi reset
- expose `tt::Cluster::instance().get_associated_mmio_device` to pybinds in order to reset specific PCI that device that hung/failed
- `pytest -n auto` will use xdist multiprocess where test runs in a different process and enable the timer, allowing for reliable timeouts and cleanups for hangs and failures
- Adding `--metal-timeout=1` will enable timer and tt-smi cleanup after test failures (will not handle hangs)
- Overhead is reasonable, adding a couple mins depending on how many tests + how long they originally run for
- `xdist` does not show C++ logging and will only show python level logging

Will enable `xdist` on all t3k pipelines (except profiler) + fd nightly + model perf for now.

In a separate [PR](https://github.com/tenstorrent/tt-metal/pull/9742) ~that should go out before this~: 
- will change global timeout to 5 mins (most tests should pass within 5 mins)
- add custom timeouts for tests that take longer than 5 mins

### Checklist
- [x] Post commit: https://github.com/tenstorrent/tt-metal/actions/runs/9701663644
- [x] Model perf: https://github.com/tenstorrent/tt-metal/actions/runs/9709636013
- [x] Fd nightly: https://github.com/tenstorrent/tt-metal/actions/runs/9669729598
- [x] t3k frequent: [failing but ran through whole suite](https://github.com/tenstorrent/tt-metal/actions/runs/9670988071)
- [x] t3k unit: [failing but ran through whole suite](https://github.com/tenstorrent/tt-metal/actions/runs/9683794045)
- [x] t3k model perf: [failing but ran through whole suite](https://github.com/tenstorrent/tt-metal/actions/runs/9683782247)
- [x] t3k demo: https://github.com/tenstorrent/tt-metal/actions/runs/9684976908
