### PR TITLE
Add support for single col/row/core output grid for matmul 2D

### DIFF
--- a/tests/ttnn/sweep_tests/sweeps/sweeps/matmul/short/matmul_user_program_config_mcast_1d.py
+++ b/tests/ttnn/sweep_tests/sweeps/sweeps/matmul/short/matmul_user_program_config_mcast_1d.py
@@ -18,6 +18,7 @@ class TensorMemoryConfigs(enum.Enum):
     CUSTOM_MEMORY_CONFIG = enum.auto()
 
 
+IN0_INNER_DIM_PER_CORE = 96
 core_grid = ttnn.CoreCoord(8, 7)
 parameters = {
     "matmul_specs": [
@@ -27,7 +28,7 @@ parameters = {
         # Matmul 1D mcast in0: in0 grid == output grid
         (
             (1,),
-            (64, 32 * 96, 32 * 96),
+            (64, 32 * IN0_INNER_DIM_PER_CORE, 32 * 96),
             ttnn.MatmulMultiCoreReuseMultiCast1DProgramConfig(
                 compute_with_storage_grid_size=(8, 4),
                 in0_block_w=1,
@@ -44,7 +45,7 @@ parameters = {
                 buffer_type=ttnn.BufferType.L1,
                 shard_spec=ttnn.ShardSpec(
                     ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(7, 3))}),
-                    (64, 96),
+                    (64, IN0_INNER_DIM_PER_CORE),
                     ttnn.ShardOrientation.ROW_MAJOR,
                     False,
                 ),
@@ -53,7 +54,7 @@ parameters = {
         # Matmul 1D mcast in0: in0 grid < output grid
         (
             (1,),
-            (64, 28 * 96, 35 * 96),
+            (64, 28 * IN0_INNER_DIM_PER_CORE, 35 * 96),
             ttnn.MatmulMultiCoreReuseMultiCast1DProgramConfig(
                 compute_with_storage_grid_size=(8, 5),
                 in0_block_w=1,
@@ -70,7 +71,7 @@ parameters = {
                 buffer_type=ttnn.BufferType.L1,
                 shard_spec=ttnn.ShardSpec(
                     ttnn.experimental.tensor.num_cores_to_core_range_set(28, core_grid, row_wise=True),
-                    (64, 96),
+                    (64, IN0_INNER_DIM_PER_CORE),
                     ttnn.ShardOrientation.ROW_MAJOR,
                     False,
                 ),
@@ -79,7 +80,7 @@ parameters = {
         # Matmul 1D mcast in0: in0 grid > output grid
         (
             (1,),
-            (64, 35 * 96, 28 * 96),
+            (64, 35 * IN0_INNER_DIM_PER_CORE, 28 * 96),
             ttnn.MatmulMultiCoreReuseMultiCast1DProgramConfig(
                 compute_with_storage_grid_size=(8, 5),
                 in0_block_w=1,
@@ -96,7 +97,7 @@ parameters = {
                 buffer_type=ttnn.BufferType.L1,
                 shard_spec=ttnn.ShardSpec(
                     ttnn.experimental.tensor.num_cores_to_core_range_set(35, core_grid, row_wise=True),
-                    (64, 96),
+                    (64, IN0_INNER_DIM_PER_CORE),
                     ttnn.ShardOrientation.ROW_MAJOR,
                     False,
                 ),
@@ -105,7 +106,7 @@ parameters = {
         # Matmul 1D mcast in0: in0 grid.y == output grid.y but in0 grid.x < output grid.x and output grid.x isn't full row; tests mcast logic for num_active_cores
         (
             (1,),
-            (64, 28 * 96, 30 * 96),
+            (64, 28 * IN0_INNER_DIM_PER_CORE, 30 * 96),
             ttnn.MatmulMultiCoreReuseMultiCast1DProgramConfig(
                 compute_with_storage_grid_size=(8, 4),
                 in0_block_w=1,
@@ -122,7 +123,7 @@ parameters = {
                 buffer_type=ttnn.BufferType.L1,
                 shard_spec=ttnn.ShardSpec(
                     ttnn.experimental.tensor.num_cores_to_core_range_set(28, core_grid, row_wise=True),
-                    (64, 96),
+                    (64, IN0_INNER_DIM_PER_CORE),
                     ttnn.ShardOrientation.ROW_MAJOR,
                     False,
                 ),
@@ -131,7 +132,7 @@ parameters = {
         # Matmul 1D mcast in0: in0 grid.y == output grid.y but in0 grid.x > output grid.x and in0 grid.x isn't full row; tests mcast logic for num_active_cores
         (
             (1,),
-            (64, 30 * 96, 28 * 96),
+            (64, 30 * IN0_INNER_DIM_PER_CORE, 28 * 96),
             ttnn.MatmulMultiCoreReuseMultiCast1DProgramConfig(
                 compute_with_storage_grid_size=(8, 4),
                 in0_block_w=1,
@@ -148,7 +149,7 @@ parameters = {
                 buffer_type=ttnn.BufferType.L1,
                 shard_spec=ttnn.ShardSpec(
                     ttnn.experimental.tensor.num_cores_to_core_range_set(30, core_grid, row_wise=True),
-                    (64, 96),
+                    (64, IN0_INNER_DIM_PER_CORE),
                     ttnn.ShardOrientation.ROW_MAJOR,
                     False,
                 ),
@@ -160,7 +161,7 @@ parameters = {
         # Matmul 1D mcast in0: single-core in0 grid and output grid
         (
             (1,),
-            (64, 96, 128),
+            (64, IN0_INNER_DIM_PER_CORE, 128),
             ttnn.MatmulMultiCoreReuseMultiCast1DProgramConfig(
                 compute_with_storage_grid_size=(1, 1),
                 in0_block_w=1,
@@ -177,7 +178,7 @@ parameters = {
                 buffer_type=ttnn.BufferType.L1,
                 shard_spec=ttnn.ShardSpec(
                     ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(0, 0))}),
-                    (64, 96),
+                    (64, IN0_INNER_DIM_PER_CORE),
                     ttnn.ShardOrientation.ROW_MAJOR,
                     False,
                 ),
@@ -186,7 +187,7 @@ parameters = {
         # Matmul 1D mcast in0: multi-core in0 grid and single-core output grid
         (
             (1,),
-            (64, 5 * 96, 128),
+            (64, 5 * IN0_INNER_DIM_PER_CORE, 128),
             ttnn.MatmulMultiCoreReuseMultiCast1DProgramConfig(
                 compute_with_storage_grid_size=(5, 1),
                 in0_block_w=1,
@@ -203,7 +204,7 @@ parameters = {
                 buffer_type=ttnn.BufferType.L1,
                 shard_spec=ttnn.ShardSpec(
                     ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(4, 0))}),
-                    (64, 96),
+                    (64, IN0_INNER_DIM_PER_CORE),
                     ttnn.ShardOrientation.ROW_MAJOR,
                     False,
                 ),
@@ -212,7 +213,7 @@ parameters = {
         # Matmul 1D mcast in1: single-core in1 grid and output grid
         (
             (1,),
-            (64, 96, 128),
+            (64, IN0_INNER_DIM_PER_CORE, 128),
             ttnn.MatmulMultiCoreReuseMultiCast1DProgramConfig(
                 compute_with_storage_grid_size=(1, 1),
                 in0_block_w=1,
@@ -229,7 +230,7 @@ parameters = {
                 buffer_type=ttnn.BufferType.L1,
                 shard_spec=ttnn.ShardSpec(
                     ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(0, 0))}),
-                    (64, 96),
+                    (64, IN0_INNER_DIM_PER_CORE),
                     ttnn.ShardOrientation.ROW_MAJOR,
                     False,
                 ),
@@ -239,7 +240,7 @@ parameters = {
     "batch_matrix_multiply": [False],
     "in0_block_w": [
         1,
-        3,
+        int(IN0_INNER_DIM_PER_CORE / 32),
     ],  # Used to override in0_block_w in program config (1: loop along in0 shard width; 2: no looping along in0 shard width)
     "input_a_memory_config": [TensorMemoryConfigs.CUSTOM_MEMORY_CONFIG, ttnn.L1_MEMORY_CONFIG],
     "input_b_memory_config": [ttnn.DRAM_MEMORY_CONFIG],

--- a/tests/ttnn/sweep_tests/sweeps/sweeps/matmul/short/matmul_user_program_config_mcast_2d.py
+++ b/tests/ttnn/sweep_tests/sweeps/sweeps/matmul/short/matmul_user_program_config_mcast_2d.py
@@ -18,12 +18,16 @@ class TensorMemoryConfigs(enum.Enum):
     CUSTOM_MEMORY_CONFIG = enum.auto()
 
 
+IN0_INNER_DIM_PER_CORE = 96
 parameters = {
     "matmul_specs": [
-        # Matmul 2D mcast in0: in0 grid == output grid along tensor width
+        ########################################
+        # TESTS: in0 inner dim != output width #
+        ########################################
+        # Matmul 2D mcast: in0 grid == output grid along tensor width
         (
             (1,),
-            (5 * 128, 7 * 64, 7 * 96),
+            (5 * 128, 7 * IN0_INNER_DIM_PER_CORE, 7 * 96),
             ttnn.MatmulMultiCoreReuseMultiCastProgramConfig(
                 compute_with_storage_grid_size=(7, 5),
                 in0_block_w=1,  # Modified by in0_block_w test parameter
@@ -39,7 +43,7 @@ parameters = {
                 buffer_type=ttnn.BufferType.L1,
                 shard_spec=ttnn.ShardSpec(
                     ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(6, 4))}),
-                    (128, 64),
+                    (128, IN0_INNER_DIM_PER_CORE),
                     ttnn.ShardOrientation.ROW_MAJOR,
                     False,
                 ),
@@ -47,7 +51,7 @@ parameters = {
         ),
         (
             (1,),
-            (5 * 128, 7 * 64, 7 * 96),
+            (5 * 128, 7 * IN0_INNER_DIM_PER_CORE, 7 * 96),
             ttnn.MatmulMultiCoreReuseMultiCastProgramConfig(
                 compute_with_storage_grid_size=(5, 7),
                 in0_block_w=1,  # Modified by in0_block_w test parameter
@@ -63,16 +67,16 @@ parameters = {
                 buffer_type=ttnn.BufferType.L1,
                 shard_spec=ttnn.ShardSpec(
                     ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(4, 6))}),
-                    (128, 64),
+                    (128, IN0_INNER_DIM_PER_CORE),
                     ttnn.ShardOrientation.COL_MAJOR,
                     False,
                 ),
             ),
         ),
-        # Matmul 2D mcast in0: in0 grid < output grid along tensor width
+        # Matmul 2D mcast: in0 grid < output grid along tensor width
         (
             (1,),
-            (5 * 128, 4 * 64, 7 * 96),
+            (5 * 128, 4 * IN0_INNER_DIM_PER_CORE, 7 * 96),
             ttnn.MatmulMultiCoreReuseMultiCastProgramConfig(
                 compute_with_storage_grid_size=(7, 5),
                 in0_block_w=1,  # Modified by in0_block_w test parameter
@@ -88,7 +92,7 @@ parameters = {
                 buffer_type=ttnn.BufferType.L1,
                 shard_spec=ttnn.ShardSpec(
                     ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(3, 4))}),
-                    (128, 64),
+                    (128, IN0_INNER_DIM_PER_CORE),
                     ttnn.ShardOrientation.ROW_MAJOR,
                     False,
                 ),
@@ -96,7 +100,7 @@ parameters = {
         ),
         (
             (1,),
-            (5 * 128, 4 * 64, 7 * 96),
+            (5 * 128, 4 * IN0_INNER_DIM_PER_CORE, 7 * 96),
             ttnn.MatmulMultiCoreReuseMultiCastProgramConfig(
                 compute_with_storage_grid_size=(5, 7),
                 in0_block_w=1,  # Modified by in0_block_w test parameter
@@ -112,16 +116,16 @@ parameters = {
                 buffer_type=ttnn.BufferType.L1,
                 shard_spec=ttnn.ShardSpec(
                     ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(4, 3))}),
-                    (128, 64),
+                    (128, IN0_INNER_DIM_PER_CORE),
                     ttnn.ShardOrientation.COL_MAJOR,
                     False,
                 ),
             ),
         ),
-        # Matmul 2D mcast in0: in0 grid > output grid along tensor width
+        # Matmul 2D mcast: in0 grid > output grid along tensor width
         (
             (1,),
-            (5 * 128, 7 * 64, 4 * 96),
+            (5 * 128, 7 * IN0_INNER_DIM_PER_CORE, 4 * 96),
             ttnn.MatmulMultiCoreReuseMultiCastProgramConfig(
                 compute_with_storage_grid_size=(7, 5),
                 in0_block_w=1,  # Modified by in0_block_w test parameter
@@ -137,7 +141,7 @@ parameters = {
                 buffer_type=ttnn.BufferType.L1,
                 shard_spec=ttnn.ShardSpec(
                     ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(6, 4))}),
-                    (128, 64),
+                    (128, IN0_INNER_DIM_PER_CORE),
                     ttnn.ShardOrientation.ROW_MAJOR,
                     False,
                 ),
@@ -145,7 +149,7 @@ parameters = {
         ),
         (
             (1,),
-            (5 * 128, 7 * 64, 4 * 96),
+            (5 * 128, 7 * IN0_INNER_DIM_PER_CORE, 4 * 96),
             ttnn.MatmulMultiCoreReuseMultiCastProgramConfig(
                 compute_with_storage_grid_size=(5, 7),
                 in0_block_w=1,  # Modified by in0_block_w test parameter
@@ -161,7 +165,207 @@ parameters = {
                 buffer_type=ttnn.BufferType.L1,
                 shard_spec=ttnn.ShardSpec(
                     ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(4, 6))}),
-                    (128, 64),
+                    (128, IN0_INNER_DIM_PER_CORE),
+                    ttnn.ShardOrientation.COL_MAJOR,
+                    False,
+                ),
+            ),
+        ),
+        ###############################################################
+        # TESTS: Single row/col or single core output grid edge cases #
+        ###############################################################
+        # Matmul 2D mcast in1 only: output grid along tensor width is 1
+        (
+            (1,),
+            (5 * 128, IN0_INNER_DIM_PER_CORE, 96),
+            ttnn.MatmulMultiCoreReuseMultiCastProgramConfig(
+                compute_with_storage_grid_size=(1, 5),
+                in0_block_w=1,  # Modified by in0_block_w test parameter
+                out_subblock_h=1,
+                out_subblock_w=1,
+                per_core_M=4,
+                per_core_N=3,
+                transpose_mcast=False,
+                fused_activation=None,
+            ),
+            ttnn.MemoryConfig(
+                memory_layout=ttnn.TensorMemoryLayout.BLOCK_SHARDED,
+                buffer_type=ttnn.BufferType.L1,
+                shard_spec=ttnn.ShardSpec(
+                    ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(0, 4))}),
+                    (128, IN0_INNER_DIM_PER_CORE),
+                    ttnn.ShardOrientation.ROW_MAJOR,
+                    False,
+                ),
+            ),
+        ),
+        (
+            (1,),
+            (5 * 128, IN0_INNER_DIM_PER_CORE, 96),
+            ttnn.MatmulMultiCoreReuseMultiCastProgramConfig(
+                compute_with_storage_grid_size=(5, 1),
+                in0_block_w=1,  # Modified by in0_block_w test parameter
+                out_subblock_h=1,
+                out_subblock_w=1,
+                per_core_M=4,
+                per_core_N=3,
+                transpose_mcast=True,
+                fused_activation=None,
+            ),
+            ttnn.MemoryConfig(
+                memory_layout=ttnn.TensorMemoryLayout.BLOCK_SHARDED,
+                buffer_type=ttnn.BufferType.L1,
+                shard_spec=ttnn.ShardSpec(
+                    ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(4, 0))}),
+                    (128, IN0_INNER_DIM_PER_CORE),
+                    ttnn.ShardOrientation.COL_MAJOR,
+                    False,
+                ),
+            ),
+        ),
+        # Matmul 2D mcast in0 only: output grid along tensor height is 1
+        (
+            (1,),
+            (128, 7 * IN0_INNER_DIM_PER_CORE, 4 * 96),
+            ttnn.MatmulMultiCoreReuseMultiCastProgramConfig(
+                compute_with_storage_grid_size=(7, 1),
+                in0_block_w=1,  # Modified by in0_block_w test parameter
+                out_subblock_h=1,
+                out_subblock_w=1,
+                per_core_M=4,
+                per_core_N=3,
+                transpose_mcast=False,
+                fused_activation=None,
+            ),
+            ttnn.MemoryConfig(
+                memory_layout=ttnn.TensorMemoryLayout.BLOCK_SHARDED,
+                buffer_type=ttnn.BufferType.L1,
+                shard_spec=ttnn.ShardSpec(
+                    ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(6, 0))}),
+                    (128, IN0_INNER_DIM_PER_CORE),
+                    ttnn.ShardOrientation.ROW_MAJOR,
+                    False,
+                ),
+            ),
+        ),
+        (
+            (1,),
+            (128, 7 * IN0_INNER_DIM_PER_CORE, 4 * 96),
+            ttnn.MatmulMultiCoreReuseMultiCastProgramConfig(
+                compute_with_storage_grid_size=(1, 7),
+                in0_block_w=1,  # Modified by in0_block_w test parameter
+                out_subblock_h=1,
+                out_subblock_w=1,
+                per_core_M=4,
+                per_core_N=3,
+                transpose_mcast=True,
+                fused_activation=None,
+            ),
+            ttnn.MemoryConfig(
+                memory_layout=ttnn.TensorMemoryLayout.BLOCK_SHARDED,
+                buffer_type=ttnn.BufferType.L1,
+                shard_spec=ttnn.ShardSpec(
+                    ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(0, 6))}),
+                    (128, IN0_INNER_DIM_PER_CORE),
+                    ttnn.ShardOrientation.COL_MAJOR,
+                    False,
+                ),
+            ),
+        ),
+        # Matmul 2D no mcast: output grid along tensor height and width are both 1
+        (
+            (1,),
+            (128, IN0_INNER_DIM_PER_CORE, 96),
+            ttnn.MatmulMultiCoreReuseMultiCastProgramConfig(
+                compute_with_storage_grid_size=(1, 1),
+                in0_block_w=1,  # Modified by in0_block_w test parameter
+                out_subblock_h=1,
+                out_subblock_w=1,
+                per_core_M=4,
+                per_core_N=3,
+                transpose_mcast=False,
+                fused_activation=None,
+            ),
+            ttnn.MemoryConfig(
+                memory_layout=ttnn.TensorMemoryLayout.BLOCK_SHARDED,
+                buffer_type=ttnn.BufferType.L1,
+                shard_spec=ttnn.ShardSpec(
+                    ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(0, 0))}),
+                    (128, IN0_INNER_DIM_PER_CORE),
+                    ttnn.ShardOrientation.ROW_MAJOR,
+                    False,
+                ),
+            ),
+        ),
+        (
+            (1,),
+            (128, IN0_INNER_DIM_PER_CORE, 96),
+            ttnn.MatmulMultiCoreReuseMultiCastProgramConfig(
+                compute_with_storage_grid_size=(1, 1),
+                in0_block_w=1,  # Modified by in0_block_w test parameter
+                out_subblock_h=1,
+                out_subblock_w=1,
+                per_core_M=4,
+                per_core_N=3,
+                transpose_mcast=True,
+                fused_activation=None,
+            ),
+            ttnn.MemoryConfig(
+                memory_layout=ttnn.TensorMemoryLayout.BLOCK_SHARDED,
+                buffer_type=ttnn.BufferType.L1,
+                shard_spec=ttnn.ShardSpec(
+                    ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(0, 0))}),
+                    (128, IN0_INNER_DIM_PER_CORE),
+                    ttnn.ShardOrientation.COL_MAJOR,
+                    False,
+                ),
+            ),
+        ),
+        # Matmul 2D mcast in1 "only" special case: output grid along tensor width is 1 but in0 shard width > 1
+        # in0 interleaved has no mcast but in0 sharded mcasts along tensor width to first core
+        (
+            (1,),
+            (5 * 128, 7 * IN0_INNER_DIM_PER_CORE, 96),
+            ttnn.MatmulMultiCoreReuseMultiCastProgramConfig(
+                compute_with_storage_grid_size=(7, 5),
+                in0_block_w=1,  # Modified by in0_block_w test parameter
+                out_subblock_h=1,
+                out_subblock_w=1,
+                per_core_M=4,
+                per_core_N=3,
+                transpose_mcast=False,
+                fused_activation=None,
+            ),
+            ttnn.MemoryConfig(
+                memory_layout=ttnn.TensorMemoryLayout.BLOCK_SHARDED,
+                buffer_type=ttnn.BufferType.L1,
+                shard_spec=ttnn.ShardSpec(
+                    ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(6, 4))}),
+                    (128, IN0_INNER_DIM_PER_CORE),
+                    ttnn.ShardOrientation.ROW_MAJOR,
+                    False,
+                ),
+            ),
+        ),
+        (
+            (1,),
+            (5 * 128, 7 * IN0_INNER_DIM_PER_CORE, 96),
+            ttnn.MatmulMultiCoreReuseMultiCastProgramConfig(
+                compute_with_storage_grid_size=(5, 7),
+                in0_block_w=1,  # Modified by in0_block_w test parameter
+                out_subblock_h=1,
+                out_subblock_w=1,
+                per_core_M=4,
+                per_core_N=3,
+                transpose_mcast=True,
+                fused_activation=None,
+            ),
+            ttnn.MemoryConfig(
+                memory_layout=ttnn.TensorMemoryLayout.BLOCK_SHARDED,
+                buffer_type=ttnn.BufferType.L1,
+                shard_spec=ttnn.ShardSpec(
+                    ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(4, 6))}),
+                    (128, IN0_INNER_DIM_PER_CORE),
                     ttnn.ShardOrientation.COL_MAJOR,
                     False,
                 ),
@@ -171,7 +375,7 @@ parameters = {
     "batch_matrix_multiply": [False],
     "in0_block_w": [
         1,
-        2,
+        int(IN0_INNER_DIM_PER_CORE / 32),
     ],  # Used to override in0_block_w in program config (1: loop along in0 shard width; 2: no looping along in0 shard width)
     "input_a_memory_config": [TensorMemoryConfigs.CUSTOM_MEMORY_CONFIG, ttnn.L1_MEMORY_CONFIG],
     "input_b_memory_config": [ttnn.DRAM_MEMORY_CONFIG],

--- a/tests/ttnn/unit_tests/operations/test_linear.py
+++ b/tests/ttnn/unit_tests/operations/test_linear.py
@@ -122,26 +122,16 @@ def test_linear_with_core_grid(
     else:
         bias = None
 
-    if batch_size == 1:
-        with pytest.raises(RuntimeError) as exception:
-            output_tensor = ttnn.linear(
-                input_tensor_a,
-                input_tensor_b,
-                bias=bias,
-                core_grid=ttnn.CoreGrid(y=batch_size, x=6),
-            )
-        assert "1D mcast for in0 or in1 is not implemented yet" in str(exception.value)
-    else:
-        output_tensor = ttnn.linear(
-            input_tensor_a,
-            input_tensor_b,
-            bias=bias,
-            core_grid=ttnn.CoreGrid(y=batch_size, x=6),
-        )
+    output_tensor = ttnn.linear(
+        input_tensor_a,
+        input_tensor_b,
+        bias=bias,
+        core_grid=ttnn.CoreGrid(y=batch_size, x=6),
+    )
 
-        output_tensor = ttnn.to_torch(output_tensor)
+    output_tensor = ttnn.to_torch(output_tensor)
 
-        assert_with_pcc(torch_output_tensor, output_tensor, 0.999)
+    assert_with_pcc(torch_output_tensor, output_tensor, 0.999)
 
 
 @pytest.mark.parametrize("batch_size", [1, 8])

--- a/tests/ttnn/unit_tests/operations/test_matmul.py
+++ b/tests/ttnn/unit_tests/operations/test_matmul.py
@@ -398,23 +398,14 @@ def test_matmul_with_core_grid(device, batch_size):
     input_tensor_a = ttnn.from_torch(torch_input_tensor_a, layout=ttnn.TILE_LAYOUT, device=device)
     input_tensor_b = ttnn.from_torch(torch_input_tensor_b, layout=ttnn.TILE_LAYOUT, device=device)
 
-    if batch_size == 1:
-        with pytest.raises(RuntimeError) as exception:
-            output_tensor = ttnn.matmul(
-                input_tensor_a,
-                input_tensor_b,
-                core_grid=ttnn.CoreGrid(y=batch_size, x=8),
-            )
-        assert "1D mcast for in0 or in1 is not implemented yet" in str(exception.value)
-    else:
-        output_tensor = ttnn.matmul(
-            input_tensor_a,
-            input_tensor_b,
-            core_grid=ttnn.CoreGrid(y=batch_size, x=8),
-        )
+    output_tensor = ttnn.matmul(
+        input_tensor_a,
+        input_tensor_b,
+        core_grid=ttnn.CoreGrid(y=batch_size, x=8),
+    )
 
-        output_tensor = ttnn.to_torch(output_tensor)
-        assert_with_pcc(torch_output_tensor, output_tensor, 0.999)
+    output_tensor = ttnn.to_torch(output_tensor)
+    assert_with_pcc(torch_output_tensor, output_tensor, 0.999)
 
 
 @skip_for_wormhole_b0()

--- a/tt_eager/tt_dnn/op_library/bmm/multi_core_reuse_mcast_2d_optimized/bmm_op_multi_core_reuse_mcast_2d_optimized.cpp
+++ b/tt_eager/tt_dnn/op_library/bmm/multi_core_reuse_mcast_2d_optimized/bmm_op_multi_core_reuse_mcast_2d_optimized.cpp
@@ -125,45 +125,6 @@ operation::ProgramWithCallbacks create_program_mcast_in0_in1(
         {(std::size_t)start_core_x, (std::size_t)start_core_y},
         {(std::size_t)start_core_x + num_cores_with_work_c - 1, (std::size_t)start_core_y + num_cores_with_work_r - 1});
 
-    CoreRange top_left_corner(
-        {(std::size_t)start_core_x, (std::size_t)start_core_y}, {(std::size_t)start_core_x, (std::size_t)start_core_y});
-
-    CoreRange left_column(
-        {(std::size_t)start_core_x, (std::size_t)start_core_y},
-        {(std::size_t)start_core_x, (std::size_t)start_core_y + num_cores_with_work_r - 1});
-
-    CoreRange top_row(
-        {(std::size_t)start_core_x, (std::size_t)start_core_y},
-        {(std::size_t)start_core_x + num_cores_with_work_c - 1, (std::size_t)start_core_y});
-
-    CoreRange all_except_left_column(
-        {(std::size_t)start_core_x + 1, (std::size_t)start_core_y},
-        {(std::size_t)start_core_x + num_cores_with_work_c - 1, (std::size_t)start_core_y + num_cores_with_work_r - 1});
-
-    CoreRange all_except_top_row(
-        {(std::size_t)start_core_x, (std::size_t)start_core_y + 1},
-        {(std::size_t)start_core_x + num_cores_with_work_c - 1, (std::size_t)start_core_y + num_cores_with_work_r - 1});
-
-    CoreRange left_column_except_corner(
-        {(std::size_t)start_core_x, (std::size_t)start_core_y + 1},
-        {(std::size_t)start_core_x, (std::size_t)start_core_y + num_cores_with_work_r - 1});
-
-    CoreRange top_row_except_corner(
-        {(std::size_t)start_core_x + 1, (std::size_t)start_core_y},
-        {(std::size_t)start_core_x + num_cores_with_work_c - 1, (std::size_t)start_core_y});
-
-    ////////////////////////////////////////////////////////////////////////////
-    //                      INTERLEAVED SENDER/RECEIVER
-    ////////////////////////////////////////////////////////////////////////////
-    CoreRange in0_sender = left_column;
-    CoreRange in0_sender_in1_receiver = left_column_except_corner;
-    CoreRange in1_sender = top_row;
-    CoreRange in0_receiver_in1_sender = top_row_except_corner;
-    if (transpose_mcast) {
-        std::swap(in0_sender, in1_sender);
-        std::swap(in0_sender_in1_receiver, in0_receiver_in1_sender);
-    }
-
     ////////////////////////////////////////////////////////////////////////////
     //                      IN0 SHARDED SENDER/RECEIVER
     ////////////////////////////////////////////////////////////////////////////
@@ -176,15 +137,8 @@ operation::ProgramWithCallbacks create_program_mcast_in0_in1(
     uint32_t in0_sender_num_cores_along_width;
 
     // Only used for in0 block sharded
-    CoreRange in0_mcast_cores_with_work_and_in_receiver_grid(
-        {(std::size_t)start_core_x, (std::size_t)start_core_y},
-        {(std::size_t)start_core_x, (std::size_t)start_core_y});  // Placeholder
-    CoreRange in0_mcast_cores_without_work_and_not_in_receiver_grid(
-        {(std::size_t)start_core_x, (std::size_t)start_core_y},
-        {(std::size_t)start_core_x, (std::size_t)start_core_y});  // Placeholder
+    std::optional<CoreRange> in0_mcast_cores_without_work_and_not_in_receiver_grid;
     if (in0_block_sharded) {
-        in0_mcast_cores_with_work_and_in_receiver_grid = all_cores_with_work;
-
         CoreCoord in0_shard_grid = in0_buffer->shard_spec().grid().bounding_box().grid_size();
         // in0 shard grid already accounts for transpose_mcast
         // ie. If transpose_mcast, in0 width is along y
@@ -192,11 +146,11 @@ operation::ProgramWithCallbacks create_program_mcast_in0_in1(
         if (in0_sender_num_cores_along_width > num_blocks_x) {
             in0_mcast_cores_without_work_and_not_in_receiver_grid =
                 transpose_mcast ? CoreRange(
-                                      {(std::size_t)start_core_x, (std::size_t)start_core_y + num_blocks_x - 1},
+                                      {(std::size_t)start_core_x, (std::size_t)start_core_y + num_blocks_x},
                                       {(std::size_t)start_core_x + num_blocks_y - 1,
                                        (std::size_t)start_core_y + in0_sender_num_cores_along_width - 1})
                                 : CoreRange(
-                                      {(std::size_t)start_core_x + num_blocks_x - 1, (std::size_t)start_core_y},
+                                      {(std::size_t)start_core_x + num_blocks_x, (std::size_t)start_core_y},
                                       {(std::size_t)start_core_x + in0_sender_num_cores_along_width - 1,
                                        (std::size_t)start_core_y + num_blocks_y - 1});
         }
@@ -232,22 +186,73 @@ operation::ProgramWithCallbacks create_program_mcast_in0_in1(
         {(std::size_t)start_core_x, (std::size_t)start_core_y},
         {(std::size_t)start_core_x + num_cores_c - 1, (std::size_t)start_core_y + num_cores_r - 1});
 
-    ////////////////////////////////////////////////////////////////////////////
-    //       RECEIVER-RECEIVER USED BY BOTH IN0 INTERLEAVED OR SHARDED
-    ////////////////////////////////////////////////////////////////////////////
+    //////////////////////////////////////////////////////////////////////////////////////////
+    //       IN0 SENDER (interleaved only) and IN1 SENDER (both interleaved and sharded)
+    //////////////////////////////////////////////////////////////////////////////////////////
+    // Left column
+    CoreRange in0_sender_interleaved(
+        {(std::size_t)start_core_x, (std::size_t)start_core_y},
+        {(std::size_t)start_core_x, (std::size_t)start_core_y + num_cores_with_work_r - 1});
+
+    // Top row
+    CoreRange in1_sender(
+        {(std::size_t)start_core_x, (std::size_t)start_core_y},
+        {(std::size_t)start_core_x + num_cores_with_work_c - 1, (std::size_t)start_core_y});
+
+    // Left column except corner
+    std::optional<CoreRange> in0_sender_in1_receiver;
+    if (num_cores_with_work_r > 1) {
+        in0_sender_in1_receiver = {
+            {(std::size_t)start_core_x, (std::size_t)start_core_y + 1},
+            {(std::size_t)start_core_x, (std::size_t)start_core_y + num_cores_with_work_r - 1}};
+    }
+
+    // Top row except corner
+    std::optional<CoreRange> in0_receiver_in1_sender;
+    if (num_cores_with_work_c > 1) {
+        in0_receiver_in1_sender = {
+            {(std::size_t)start_core_x + 1, (std::size_t)start_core_y},
+            {(std::size_t)start_core_x + num_cores_with_work_c - 1, (std::size_t)start_core_y}};
+    }
+
+    if (transpose_mcast) {
+        std::swap(in0_sender_interleaved, in1_sender);
+        std::swap(in0_sender_in1_receiver, in0_receiver_in1_sender);
+    }
+
+    /////////////////////////////////////////////////////////////////////////////////////////////////
+    //       IN0 RECEIVER (interleaved only) and IN1 RECEIVER (both interleaved and sharded)
+    /////////////////////////////////////////////////////////////////////////////////////////////////
     // Not exactly half-half; this seems to get slightly better perf for fused qkv and selfout
     // TODO: Experiment with different splits?
-    bool split_half = num_cores_with_work_c > 2 && !in0_is_sharded;
+    bool split_half = num_cores_with_work_c > 2 && num_cores_with_work_r > 1 && !in0_is_sharded;
     uint32_t half_core = split_half ? (num_cores_with_work_c) / 2 : num_cores_with_work_c - 1;
 
-    CoreRange in0_receiver_in1_receiver_left_half(
-        {(std::size_t)start_core_x + 1, (std::size_t)start_core_y + 1},
-        {(std::size_t)start_core_x + half_core, (std::size_t)start_core_y + num_cores_with_work_r - 1});
+    std::optional<CoreRange> in0_receiver_in1_receiver_left_half;
+    if (num_cores_with_work_c > 1 and num_cores_with_work_r > 1) {
+        in0_receiver_in1_receiver_left_half = {
+            {(std::size_t)start_core_x + 1, (std::size_t)start_core_y + 1},
+            {(std::size_t)start_core_x + half_core, (std::size_t)start_core_y + num_cores_with_work_r - 1}};
+    }
 
-    CoreRange in0_receiver_in1_receiver_right_half({0, 0}, {0, 0});
+    std::set<CoreRange> in0_receiver_interleaved_set;
+    std::set<CoreRange> in1_receiver_set;
+    if (in0_receiver_in1_sender.has_value()) {
+        in0_receiver_interleaved_set.insert(in0_receiver_in1_sender.value());
+    }
+    if (in0_sender_in1_receiver.has_value()) {
+        in1_receiver_set.insert(in0_sender_in1_receiver.value());
+    }
+    if (in0_receiver_in1_receiver_left_half.has_value()) {
+        in0_receiver_interleaved_set.insert(in0_receiver_in1_receiver_left_half.value());
+        in1_receiver_set.insert(in0_receiver_in1_receiver_left_half.value());
+    }
+    CoreRangeSet in0_receiver_interleaved(in0_receiver_interleaved_set);
+    CoreRangeSet in1_receiver(in1_receiver_set);
 
+    std::optional<CoreRange> in0_receiver_in1_receiver_interleaved_other_cores;
     if (split_half) {
-        in0_receiver_in1_receiver_right_half = {
+        in0_receiver_in1_receiver_interleaved_other_cores = {
             {(std::size_t)start_core_x + half_core + 1, (std::size_t)start_core_y + 1},
             {(std::size_t)start_core_x + num_cores_with_work_c - 1,
              (std::size_t)start_core_y + num_cores_with_work_r - 1}};
@@ -430,7 +435,8 @@ operation::ProgramWithCallbacks create_program_mcast_in0_in1(
     }
 
     std::map<string, string> mm_kernel_defines;
-    std::map<string, string> mm_kernel_in0_sender_defines;
+    std::map<string, string> mm_kernel_in0_sender_sharded_defines;
+    std::map<string, string> mm_kernel_in0_sender_interleaved_defines;
     std::map<string, string> mm_kernel_in1_sender_writer_defines;
     std::map<string, string> mm_kernel_in1_receiver_writer_defines;
     std::map<string, string> mm_kernel_in1_receiver_writer_other_noc_setup_defines;
@@ -455,8 +461,15 @@ operation::ProgramWithCallbacks create_program_mcast_in0_in1(
         mm_kernel_defines["FP32_DEST_ACC_EN"] = "1";
     }
 
+    if (in0_receiver_interleaved.num_cores() == 0) {
+        mm_kernel_in0_sender_interleaved_defines["SKIP_MCAST"] = "1";
+    }
     if (in0_height_sharded) {
-        mm_kernel_in0_sender_defines["IN0_SHARDED"] = "1";
+        mm_kernel_in0_sender_interleaved_defines["IN0_SHARDED"] = "1";
+    }
+
+    if (in1_receiver.num_cores() == 0) {
+        mm_kernel_in1_sender_writer_defines["SKIP_MCAST"] = "1";
     }
     if (in1_is_sharded) {
         if (in1_is_dram) {
@@ -485,36 +498,36 @@ operation::ProgramWithCallbacks create_program_mcast_in0_in1(
             program,
             "tt_eager/tt_dnn/op_library/bmm/kernels/dataflow/"
             "reader_bmm_tile_layout_in0_sender_receiver_padding_block_sharded.cpp",
-            in0_mcast_cores_with_work_and_in_receiver_grid,
+            all_cores_with_work,  // in0_mcast_cores_with_work_and_in_receiver_grid
             tt_metal::DataMovementConfig{
                 .processor = tt_metal::DataMovementProcessor::RISCV_1,
                 .noc = in0_noc,
                 .compile_args = in0_sender_compile_time_args,
-                .defines = mm_kernel_in0_sender_defines});
-        if (in0_mcast_cores_without_work_and_not_in_receiver_grid.size() > 0) {
+                .defines = mm_kernel_in0_sender_sharded_defines});
+        if (in0_mcast_cores_without_work_and_not_in_receiver_grid.has_value()) {
             in0_sender_compile_time_args[0] = 0;  // core_has_output_block_work
             in0_sender_compile_time_args[1] = 0;  // core_in_in0_receiver_mcast_grid
             mm_kernel_in0_mcast_cores_without_work_and_not_in_receiver_grid_id = tt_metal::CreateKernel(
                 program,
                 "tt_eager/tt_dnn/op_library/bmm/kernels/dataflow/"
                 "reader_bmm_tile_layout_in0_sender_receiver_padding_block_sharded.cpp",
-                in0_mcast_cores_without_work_and_not_in_receiver_grid,
+                in0_mcast_cores_without_work_and_not_in_receiver_grid.value(),
                 tt_metal::DataMovementConfig{
                     .processor = tt_metal::DataMovementProcessor::RISCV_1,
                     .noc = in0_noc,
                     .compile_args = in0_sender_compile_time_args,
-                    .defines = mm_kernel_in0_sender_defines});
+                    .defines = mm_kernel_in0_sender_sharded_defines});
         }
     } else {
         mm_kernel_in0_sender_id = tt_metal::CreateKernel(
             program,
             "tt_eager/tt_dnn/op_library/bmm/kernels/dataflow/reader_bmm_tile_layout_in0_sender_padding.cpp",
-            in0_sender,
+            in0_sender_interleaved,
             tt_metal::DataMovementConfig{
                 .processor = tt_metal::DataMovementProcessor::RISCV_1,
                 .noc = in0_noc,
                 .compile_args = in0_sender_compile_time_args,
-                .defines = mm_kernel_in0_sender_defines});
+                .defines = mm_kernel_in0_sender_interleaved_defines});
     }
 
     auto mm_kernel_in1_sender_writer_id = tt_metal::CreateKernel(
@@ -527,26 +540,27 @@ operation::ProgramWithCallbacks create_program_mcast_in0_in1(
             .compile_args = in1_sender_writer_compile_time_args,
             .defines = mm_kernel_in1_sender_writer_defines});
 
-    auto in1_receiver =
-        (CoreRangeSet)(std::set<CoreRange>){in0_sender_in1_receiver, in0_receiver_in1_receiver_left_half};
-    auto mm_kernel_in1_receiver_writer_id = tt_metal::CreateKernel(
-        program,
-        "tt_eager/tt_dnn/op_library/bmm/kernels/dataflow/reader_bmm_tile_layout_in1_receiver_writer_padding.cpp",
-        /* in0_sender_in1_receiver, // If not using half-half noc setup */
-        in1_receiver,
-        tt_metal::DataMovementConfig{
-            .processor = tt_metal::DataMovementProcessor::RISCV_0,
-            .noc = in1_noc,
-            .compile_args = in1_receiver_writer_compile_time_args,
-            .defines = mm_kernel_in1_receiver_writer_defines});
+    KernelHandle mm_kernel_in1_receiver_writer_id = 0;
+    if (in1_receiver.num_cores() > 0) {
+        mm_kernel_in1_receiver_writer_id = tt_metal::CreateKernel(
+            program,
+            "tt_eager/tt_dnn/op_library/bmm/kernels/dataflow/reader_bmm_tile_layout_in1_receiver_writer_padding.cpp",
+            /* in0_sender_in1_receiver, // If not using half-half noc setup */
+            in1_receiver,
+            tt_metal::DataMovementConfig{
+                .processor = tt_metal::DataMovementProcessor::RISCV_0,
+                .noc = in1_noc,
+                .compile_args = in1_receiver_writer_compile_time_args,
+                .defines = mm_kernel_in1_receiver_writer_defines});
+    }
 
     KernelHandle mm_kernel_in0_receiver_id = 0;
-    if (!in0_block_sharded) {
+    if (!in0_block_sharded and in0_receiver_interleaved.num_cores() > 0) {
         mm_kernel_in0_receiver_id = tt_metal::CreateKernel(
             program,
             "tt_eager/tt_dnn/op_library/bmm/kernels/dataflow/reader_bmm_tile_layout_in0_receiver.cpp",
             /* in0_receiver_in1_sender, // If not using half-half noc setup */
-            (CoreRangeSet)(std::set<CoreRange>){in0_receiver_in1_sender, in0_receiver_in1_receiver_left_half},
+            in0_receiver_interleaved,
             tt_metal::DataMovementConfig{
                 .processor = tt_metal::DataMovementProcessor::RISCV_1,
                 .noc = in0_noc,
@@ -556,11 +570,11 @@ operation::ProgramWithCallbacks create_program_mcast_in0_in1(
     KernelHandle mm_kernel_in1_receiver_writer_other_noc_setup_id = mm_kernel_in1_receiver_writer_id;
     KernelHandle mm_kernel_in0_receiver_other_noc_setup_id = mm_kernel_in0_receiver_id;
 
-    if (split_half) {
+    if (in0_receiver_in1_receiver_interleaved_other_cores.has_value()) {
         mm_kernel_in1_receiver_writer_other_noc_setup_id = tt_metal::CreateKernel(
             program,
             "tt_eager/tt_dnn/op_library/bmm/kernels/dataflow/reader_bmm_tile_layout_in1_receiver_writer_padding.cpp",
-            in0_receiver_in1_receiver_right_half,
+            in0_receiver_in1_receiver_interleaved_other_cores.value(),
             tt_metal::DataMovementConfig{
                 .processor = tt_metal::DataMovementProcessor::RISCV_0,
                 .noc = in1_split_noc,
@@ -570,7 +584,7 @@ operation::ProgramWithCallbacks create_program_mcast_in0_in1(
         mm_kernel_in0_receiver_other_noc_setup_id = tt_metal::CreateKernel(
             program,
             "tt_eager/tt_dnn/op_library/bmm/kernels/dataflow/reader_bmm_tile_layout_in0_receiver.cpp",
-            in0_receiver_in1_receiver_right_half,
+            in0_receiver_in1_receiver_interleaved_other_cores.value(),
             tt_metal::DataMovementConfig{
                 .processor = tt_metal::DataMovementProcessor::RISCV_1,
                 .noc = in0_split_noc,
@@ -776,12 +790,18 @@ operation::ProgramWithCallbacks create_program_mcast_in0_in1(
     uint32_t in0_end_idx = num_blocks_y - 1;
     uint32_t in1_end_idx = num_blocks_x - 1;
     const auto& cores = grid_to_cores(all_cores.start, all_cores.end, true);
-    const auto& in0_sender_cores =
-        grid_to_cores(in0_sender.start, in0_sender.end, true);  // Only used for interleaved in0
+    const auto& in0_sender_interleaved_cores =
+        grid_to_cores(in0_sender_interleaved.start, in0_sender_interleaved.end, true);  // Only used for interleaved in0
     const auto& in1_sender_cores = grid_to_cores(in1_sender.start, in1_sender.end, true);
     const auto& in1_receiver_cores = corerange_to_cores(in1_receiver, std::nullopt, true);
-    const auto& in1_receiver_other_cores =
-        grid_to_cores(in0_receiver_in1_receiver_right_half.start, in0_receiver_in1_receiver_right_half.end, true);
+    std::vector<CoreCoord> in1_receiver_other_cores;
+    if (in0_receiver_in1_receiver_interleaved_other_cores.has_value()) {
+        in1_receiver_other_cores = grid_to_cores(
+            in0_receiver_in1_receiver_interleaved_other_cores.value().start,
+            in0_receiver_in1_receiver_interleaved_other_cores.value().end,
+            true);
+    }
+
     for (const auto& core : cores) {
         CoreCoord left_core = {(std::size_t)start_core_x, (std::size_t)core.y};
         CoreCoord left_core_plus_one = {(std::size_t)start_core_x + 1, (std::size_t)core.y};
@@ -1081,7 +1101,7 @@ operation::ProgramWithCallbacks create_program_mcast_in0_in1(
 
     auto override_runtime_arguments_callback =
         [mm_kernel_in0_sender_id,
-         in0_sender_cores,
+         in0_sender_interleaved_cores,
          mm_kernel_in1_sender_writer_id,
          in1_sender_cores,
          mm_kernel_in1_receiver_writer_id,
@@ -1123,7 +1143,7 @@ operation::ProgramWithCallbacks create_program_mcast_in0_in1(
                 UpdateDynamicCircularBufferAddress(program, cb_src2, *src_buffer_a);
             } else {
                 auto& reader_sender_runtime_args_by_core = GetRuntimeArgs(program, mm_kernel_in0_sender_id);
-                for (const auto& core : in0_sender_cores) {
+                for (const auto& core : in0_sender_interleaved_cores) {
                     auto& reader_runtime_args = reader_sender_runtime_args_by_core[core.x][core.y];
                     reader_runtime_args[0] = src_buffer_a->address();
                 }
@@ -1299,9 +1319,14 @@ operation::ProgramWithCallbacks matmul_multi_core_reuse_mcast_2d_optimized_(
     // TODO: Move these validates to op validate and properly check for this
     TT_FATAL(
         num_blocks_x <= num_cores_x,
-        "Num output blocks along x {} must be smaller than or equal to the number of columns in compute grid {}!", num_blocks_x, num_cores_x);
+        "Num output blocks along x {} must be smaller than or equal to the number of columns in compute grid {}!",
+        num_blocks_x,
+        num_cores_x);
     TT_FATAL(
-        num_blocks_y <= num_cores_y, "Num output blocks along y {} must be smaller than or equal to the number of rows in compute grid {}!", num_blocks_y, num_cores_y);
+        num_blocks_y <= num_cores_y,
+        "Num output blocks along y {} must be smaller than or equal to the number of rows in compute grid {}!",
+        num_blocks_y,
+        num_cores_y);
 
     ////////////////////////////////////////////////////////////////////////////
     //                      Grayskull Device Setup
@@ -1312,43 +1337,33 @@ operation::ProgramWithCallbacks matmul_multi_core_reuse_mcast_2d_optimized_(
     ////////////////////////////////////////////////////////////////////////////
     //                      Application Setup
     ////////////////////////////////////////////////////////////////////////////
-
-    if (num_blocks_x > 1 and num_blocks_y > 1) {
-        return reuse_mcast_optimized_helpers::create_program_mcast_in0_in1(
-            device,
-            math_fidelity,
-            fp32_dest_acc_en,
-            math_approx_mode,
-            packer_l1_acc,
-            B,
-            Mt,
-            Nt,
-            Kt,
-            bcast_batch,
-            in0_block_w,
-            out_subblock_h,
-            out_subblock_w,
-            per_core_M,
-            per_core_N,
-            transpose_mcast,
-            fused_activation,
-            in0_buffer,
-            in1_buffer,
-            bias_buffer,
-            out_buffer,
-            in0_data_format,
-            in1_data_format,
-            bias_data_format,
-            output_data_format,
-            untilize_out);
-    } else if (num_blocks_x > 1 or num_blocks_y > 1) {
-        // Refer to bmm_op_multi_core_reuse_mcast_padding_generalized.cpp
-        TT_FATAL(false, "1D mcast for in0 or in1 is not implemented yet.");
-    } else {
-        TT_FATAL(false, "Grid is invalid for mcast matmul!");
-    }
-
-    return {};
+    return reuse_mcast_optimized_helpers::create_program_mcast_in0_in1(
+        device,
+        math_fidelity,
+        fp32_dest_acc_en,
+        math_approx_mode,
+        packer_l1_acc,
+        B,
+        Mt,
+        Nt,
+        Kt,
+        bcast_batch,
+        in0_block_w,
+        out_subblock_h,
+        out_subblock_w,
+        per_core_M,
+        per_core_N,
+        transpose_mcast,
+        fused_activation,
+        in0_buffer,
+        in1_buffer,
+        bias_buffer,
+        out_buffer,
+        in0_data_format,
+        in1_data_format,
+        bias_data_format,
+        output_data_format,
+        untilize_out);
 }
 
 operation::ProgramWithCallbacks matmul_multi_core_reuse_mcast_2d_optimized(

--- a/tt_metal/common/core_coord.h
+++ b/tt_metal/common/core_coord.h
@@ -364,6 +364,7 @@ class CoreRangeSet {
     }
 
     CoreRange bounding_box() const {
+        TT_FATAL(this->ranges().size() > 0, "Cannot get bounding_box of an empty CoreRangeSet!");
         size_t min_x = UINT32_MAX, min_y = UINT32_MAX, max_x = 0, max_y = 0;
         for (const auto &cr : this->ranges()) {
             min_x = std::min(min_x, cr.start.x);


### PR DESCRIPTION
### Ticket
#9449

### Problem description
There are corner cases of matmul 2D for single col/row or single core output grids that aren't supported currently. To support this, we need to properly turn off mcasting along corresponding dims. Simlar to work done for mcast 1D, this will help generalize our matmul further.

### What's changed
Changes:
- Remove restriction on output block sizes for matmul 2D
- Turn off mcasting for single col or row cases
  - in1 sender is always turned off depending on input shapes
  - in0 sender is turned off for interleaved depending on input shapes
  - in0 sender sharded works internally in kernels
  - Single core case is a special case of when both in0 and in1 are turned off
- Fix bug for start coord of `in0_mcast_cores_without_work_and_not_in_receiver_grid`
- Cleanup CoreRange device grid descriptors for clarity in matmul 2D

Test changes to `tests/ttnn/sweep_tests/sweeps/sweeps/matmul/short/matmul_user_program_config_mcast_2d.py`:
- Refactor hard-coded inner dims for matmul 1D and 2D tests to top-level variable
- Switch K per core to 3 tiles for better testing (same as 1D matmul)
- Add test cases for single col/row or single core output grids

### Checklist
- [x] Post commit CI passes
  - All post-commit: https://github.com/tenstorrent/tt-metal/actions/runs/9681940174
  - ttnn post-commit: https://github.com/tenstorrent/tt-metal/actions/runs/9681827725
  - Nightly fast dispatch: https://github.com/tenstorrent/tt-metal/actions/runs/9670534304
- [x] Model regression CI testing passes (if applicable): 
  - Models unit tests: https://github.com/tenstorrent/tt-metal/actions/runs/9670535215
- [x] New/Existing tests provide coverage for changes
