### PR TITLE
Mchiou/9082 slack notification owners

### DIFF
--- a/.github/workflows/t3000-frequent-tests.yaml
+++ b/.github/workflows/t3000-frequent-tests.yaml
@@ -1,4 +1,4 @@
-name: "[T3K] T3000 frequent tests"
+name: "(T3K) T3000 frequent tests"
 
 on:
   workflow_dispatch:

--- a/.github/workflows/t3000-frequent-tests.yaml
+++ b/.github/workflows/t3000-frequent-tests.yaml
@@ -17,12 +17,11 @@ jobs:
       fail-fast: false
       matrix:
         test-group: [
-          {
-            name: "T3000 frequent tests",
-            arch: wormhole_b0,
-            runs-on: [arch-wormhole_b0, "config-t3000", "in-service", "runner-test", "bare-metal", "pipeline-functional"],
-            cmd: './tests/scripts/run_tests.sh --tt-arch wormhole_b0 --pipeline-type frequent_t3000_device --dispatch-mode ""'
-          },
+          { name: "t3k trace stress tests", arch: wormhole_b0, cmd: run_t3000_trace_stress_tests, timeout: 120, owner_id: U03NG0A5ND7}, #Aditya Saigal
+          { name: "t3k llama2_70b experimental tests", arch: wormhole_b0, cmd: run_t3000_llama2_70b_experimental_tests, timeout: 120, owner_id: U03FJB5TM5Y}, #Colman Glagovich
+          { name: "t3k falcon40b tests", arch: wormhole_b0, cmd: run_t3000_falcon40b_tests, timeout: 120, owner_id: U05RWH3QUPM}, #Salar Hosseini Khorasgani
+          { name: "t3k llama2_70b tests", arch: wormhole_b0, cmd: run_t3000_llama2_70b_tests, timeout: 120, owner_id: U03FJB5TM5Y}, #Colman Glagovich
+          { name: "t3k mixtral tests", arch: wormhole_b0, cmd: run_t3000_mixtral_tests, timeout: 120, owner_id: U03PUAKE719}, #Miguel Tairum Cruz
         ]
     name: ${{ matrix.test-group.name }}
     env:
@@ -31,7 +30,7 @@ jobs:
       LOGURU_LEVEL: INFO
       LD_LIBRARY_PATH: ${{ github.workspace }}/build/lib
     environment: dev
-    runs-on: ${{ matrix.test-group.runs-on }}
+    runs-on: [arch-wormhole_b0, "config-t3000", "in-service", "runner-test", "bare-metal", "pipeline-functional"]
     steps:
       - uses: tenstorrent-metal/metal-workflows/.github/actions/checkout-with-submodule-lfs@v2.0.0
       - name: Set up dynamic env vars for build
@@ -49,4 +48,10 @@ jobs:
           source ${{ github.workspace }}/python_env/bin/activate
           cd $TT_METAL_HOME
           export PYTHONPATH=$TT_METAL_HOME
+          source ${{ github.workspace }}/tests/scripts/t3000/run_t3000_frequent_tests.sh 
           ${{ matrix.test-group.cmd }}
+      - uses: ./.github/actions/slack-report
+        if: ${{ failure() }}
+        with:
+          slack_webhook_url: ${{ secrets.SLACK_WEBHOOK_URL }}
+          owner: ${{ matrix.test-group.owner_id }}

--- a/.github/workflows/t3000-profiler-tests.yaml
+++ b/.github/workflows/t3000-profiler-tests.yaml
@@ -1,4 +1,4 @@
-name: "[T3K] T3000 profiler tests"
+name: "(T3K) T3000 profiler tests"
 
 on:
   workflow_dispatch:

--- a/.github/workflows/t3000-unit-tests.yaml
+++ b/.github/workflows/t3000-unit-tests.yaml
@@ -1,4 +1,4 @@
-name: "[T3K] T3000 unit tests"
+name: "(T3K) T3000 unit tests"
 
 on:
   workflow_dispatch:

--- a/.github/workflows/t3000-unit-tests.yaml
+++ b/.github/workflows/t3000-unit-tests.yaml
@@ -17,12 +17,11 @@ jobs:
       fail-fast: false
       matrix:
         test-group: [
-          {
-            name: "T3000 unit tests",
-            arch: wormhole_b0,
-            runs-on: [arch-wormhole_b0, "config-t3000", "in-service", "runner-test", "bare-metal", "pipeline-functional"],
-            cmd: './tests/scripts/run_tests.sh --tt-arch wormhole_b0 --pipeline-type unit_t3000_device --dispatch-mode ""'
-          },
+          { name: "t3k ttmetal tests", arch: wormhole_b0, cmd: run_t3000_ttmetal_tests, timeout: 120, owner_id: ULMEPM2MA}, #Sean Nijjar
+          { name: "t3k ttnn tests", arch: wormhole_b0, cmd: run_t3000_ttnn_tests, timeout: 120, owner_id: UAFM0F6FM}, #Akhmed Rakhmati
+          { name: "t3k falcon7b tests", arch: wormhole_b0, cmd: run_t3000_falcon7b_tests, timeout: 120, owner_id: UBHPP2NDP}, #Joseph Chu
+          { name: "t3k falcon40b tests", arch: wormhole_b0, cmd: run_t3000_falcon40b_tests, timeout: 120, owner_id: U044T8U8DEF}, #Johanna Rock
+          { name: "t3k mixtral tests", arch: wormhole_b0, cmd: run_t3000_mixtral_tests, timeout: 120, owner_id: U03PUAKE719}, #Miguel Tairum Cruz
         ]
     name: ${{ matrix.test-group.name }}
     env:
@@ -31,7 +30,7 @@ jobs:
       LOGURU_LEVEL: INFO
       LD_LIBRARY_PATH: ${{ github.workspace }}/build/lib
     environment: dev
-    runs-on: ${{ matrix.test-group.runs-on }}
+    runs-on: [arch-wormhole_b0, "config-t3000", "in-service", "runner-test", "bare-metal", "pipeline-functional"]
     steps:
       - uses: tenstorrent-metal/metal-workflows/.github/actions/checkout-with-submodule-lfs@v2.0.0
       - name: Set up dynamic env vars for build
@@ -49,4 +48,10 @@ jobs:
           source ${{ github.workspace }}/python_env/bin/activate
           cd $TT_METAL_HOME
           export PYTHONPATH=$TT_METAL_HOME
+          source ${{ github.workspace }}/tests/scripts/t3000/run_t3000_unit_tests.sh
           ${{ matrix.test-group.cmd }}
+      - uses: ./.github/actions/slack-report
+        if: ${{ failure() }}
+        with:
+          slack_webhook_url: ${{ secrets.SLACK_WEBHOOK_URL }}
+          owner: ${{ matrix.test-group.owner_id }}

--- a/tests/scripts/t3000/run_t3000_demo_tests.sh
+++ b/tests/scripts/t3000/run_t3000_demo_tests.sh
@@ -69,6 +69,7 @@ run_t3000_tests() {
 }
 
 main() {
+    # For CI pipeline - source func commands but don't execute tests if not invoked directly
   if [[ "${BASH_SOURCE[0]}" != "${0}" ]]; then
     echo "Script is being sourced, not executing main function"
     return 0

--- a/tests/scripts/t3000/run_t3000_frequent_tests.sh
+++ b/tests/scripts/t3000/run_t3000_frequent_tests.sh
@@ -144,6 +144,12 @@ run_t3000_tests() {
 }
 
 main() {
+  # For CI pipeline - source func commands but don't execute tests if not invoked directly
+  if [[ "${BASH_SOURCE[0]}" != "${0}" ]]; then
+    echo "Script is being sourced, not executing main function"
+    return 0
+  fi
+
   if [[ -z "$TT_METAL_HOME" ]]; then
     echo "Must provide TT_METAL_HOME in environment" 1>&2
     exit 1

--- a/tests/scripts/t3000/run_t3000_unit_tests.sh
+++ b/tests/scripts/t3000/run_t3000_unit_tests.sh
@@ -106,6 +106,12 @@ run_t3000_tests() {
 }
 
 main() {
+  # For CI pipeline - source func commands but don't execute tests if not invoked directly
+  if [[ "${BASH_SOURCE[0]}" != "${0}" ]]; then
+    echo "Script is being sourced, not executing main function"
+    return 0
+  fi
+  
   if [[ -z "$TT_METAL_HOME" ]]; then
     echo "Must provide TT_METAL_HOME in environment" 1>&2
     exit 1


### PR DESCRIPTION
### Ticket
- [Link to Github Issue.](https://github.com/tenstorrent/tt-metal/issues/9082)

### Problem description
- Split tests into its own job for t3k unit/freq  workflows and notify one owner of each job in tests.
- 
### What's changed
- Split tests into separate jobs.
- Easier to identify what causes failures.

### Checklist
- [ ] Post commit CI passes (not required)
- [ ] Model regression CI testing passes (if applicable) 
- [ ] New/Existing tests provide coverage for changes 
t3k unit tests: https://github.com/tenstorrent/tt-metal/actions/runs/9670187585
t3k freq: https://github.com/tenstorrent/tt-metal/actions/runs/9669044861/job/26675197394
