### PR TITLE
add tagged docker image with releases

### DIFF
--- a/.github/workflows/package-and-release.yaml
+++ b/.github/workflows/package-and-release.yaml
@@ -119,6 +119,15 @@ jobs:
             infra/machine_setup/scripts/setup_hugepages.py
             metal_libs-*+*.whl
           fail_on_unmatched_files: true
+  create-docker-image:
+    needs: [
+      create-tag,
+      create-and-upload-draft-release
+    ]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
       - name: Login to GitHub Container Registry

--- a/.github/workflows/package-and-release.yaml
+++ b/.github/workflows/package-and-release.yaml
@@ -119,3 +119,21 @@ jobs:
             infra/machine_setup/scripts/setup_hugepages.py
             metal_libs-*+*.whl
           fail_on_unmatched_files: true
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: https://ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Build and push
+        env: 
+          TT_METAL_DOCKER_IMAGE: tt-metalium/ubuntu-20.04-amd64
+        uses: docker/build-push-action@v6
+        with:
+          push: true
+          tags: ghcr.io/${{ github.repository }}/tt-metalium/ubuntu-20.04-amd64:${{ needs.create-tag.outputs.version }}-dev
+          context: .
+          file: dockerfile/ubuntu-20.04-amd64.Dockerfile
+          


### PR DESCRIPTION
### Ticket
[Link to Github Issue](https://github.com/tenstorrent/tt-metal/issues/9687)

### Problem description
Github releases only have a tag, but no docker image is associated
Build and push a docker image for each release

### What's changed
Added step that builds docker image.
Successfully builds a dev docker image 

### Checklist
- [ ] Post commit CI passes Not Required
- [ ] Model regression CI testing passes (if applicable) Not Required
- [ ] New/Existing tests provide coverage for changes https://github.com/tenstorrent/tt-metal/actions/runs/9672004658 (note that this pipeline only has commented out sections of code for the workflow to pass. The section to note is the new 'create-docker-image' step at the end which builds docker images.

