### PR TITLE
#9657: add topk multicore to support larger dimension sizes

### DIFF
--- a/tests/ttnn/unit_tests/operations/test_topk.py
+++ b/tests/ttnn/unit_tests/operations/test_topk.py
@@ -9,7 +9,7 @@ import torch
 import ttnn
 
 from tests.ttnn.utils_for_testing import assert_with_pcc
-from models.utility_functions import torch_random, skip_for_grayskull
+from models.utility_functions import skip_for_grayskull
 
 
 def run_topk_test(N, C, H, W, k, dtype, device):
@@ -27,26 +27,26 @@ def run_topk_test(N, C, H, W, k, dtype, device):
     assert list(ttnn_topk_indices.get_legacy_shape()) == [N, C, H, k]
 
     ttnn_torch_values = ttnn.to_torch(ttnn_topk_values)
-    ttnn_torch_indices = ttnn.to_torch(ttnn_topk_indices)
+    ttnn_torch_indices = ttnn.to_torch(ttnn_topk_indices).to(torch.int64)
 
     if dtype == ttnn.bfloat8_b:
         pcc_values = 0.99
-        pcc_index = 0.99
     else:
-        pcc_index = 1.0
         pcc_values = 1.0
 
     # pcc is not a good measure for the raw indices
     # if index 49 and index 8 are tied, the order of the indices can be different
     # but the values associated with the indices should be the same
     # if index 7 and 8 are tied, but swapped, the pcc will be better than if index 49 and 8 are tied but swapped
-    # so we will use pcc for the values and not the indices
-    # to make sure the indices are correct, we gather the relevant values from the original torch tensor and test to see if they are similar
     # rounding may also cause more ties than expected
+    # the bigger we get, the tighter the distribution of the top 32 elements, so the pcc will be worse as stability/rounding will cause more ties
+    # use cosine similarity on the gathered indices as this will show the top elements are all about the same
     ttnn_torch_gather_from_indices = torch.gather(input, -1, ttnn_torch_indices.to(torch.int64))
+    cosine = torch.nn.CosineSimilarity(dim=-1)
+    ttnn_torch_cosine = torch.mean(cosine(pyt_topk_values, ttnn_torch_gather_from_indices))
 
+    assert ttnn_torch_cosine > 0.99, "Cosine similarity between topk values and gather from indices is less than 0.99"
     assert_with_pcc(pyt_topk_values, ttnn_torch_values, pcc_values)
-    assert_with_pcc(pyt_topk_values, ttnn_torch_gather_from_indices, pcc_index)
 
 
 @skip_for_grayskull()
@@ -67,10 +67,10 @@ def run_topk_test(N, C, H, W, k, dtype, device):
     "N, C, H, W, k,",
     (
         (1, 1, 32, 64, 32),
-        (1, 1, 32, 256, 32),
-        (1, 1, 128, 64, 32),
-        (1, 1, 1024, 64, 32),
+        (1, 1, 32, 8192, 32),
         (1, 1, 2048, 64, 32),
+        (1, 1, 32, 32768, 32),
+        (1, 1, 8192, 64, 32),
     ),
 )
 def test_topk(N, C, H, W, k, dtype, device):

--- a/tt_eager/tt_dnn/op_library/topk/single_core/single_core_topk.cpp
+++ b/tt_eager/tt_dnn/op_library/topk/single_core/single_core_topk.cpp
@@ -93,7 +93,7 @@ operation::ProgramWithCallbacks single_core_topk_interleaved(const Tensor &input
                                                         Wt};
     tt_metal::KernelHandle unary_reader_kernel_id = tt_metal::CreateKernel(
         program,
-        "tt_eager/tt_dnn/op_library/topk/kernels/dataflow/reader_create_index_tensor.cpp",
+        "ttnn/cpp/ttnn/operations/reduction/topk/device/kernels/dataflow/reader_create_index_tensor.cpp",
         core,
         tt_metal::ReaderDataMovementConfig(reader_compile_time_args));
 
@@ -116,7 +116,7 @@ operation::ProgramWithCallbacks single_core_topk_interleaved(const Tensor &input
                                                         k};
     tt_metal::KernelHandle binary_writer_kernel_id = tt_metal::CreateKernel(
         program,
-        "tt_eager/tt_dnn/op_library/topk/kernels/dataflow/writer_binary_interleaved.cpp",
+        "ttnn/cpp/ttnn/operations/reduction/topk/device/kernels/dataflow/writer_binary_interleaved.cpp",
         core,
         tt_metal::WriterDataMovementConfig(writer_compile_time_args));
 
@@ -146,7 +146,7 @@ operation::ProgramWithCallbacks single_core_topk_interleaved(const Tensor &input
                                         };
     tt_metal::KernelHandle topk_compute_kernel_id = tt_metal::CreateKernel(
         program,
-        "tt_eager/tt_dnn/op_library/topk/kernels/compute/topk.cpp",
+        "ttnn/cpp/ttnn/operations/reduction/topk/device/kernels/compute/topk.cpp",
         core,
         tt_metal::ComputeConfig{.compile_args = compute_args}
     );

--- a/ttnn/cpp/ttnn/operations/reduction/topk/device/kernels/compute/topk_final.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/topk/device/kernels/compute/topk_final.cpp
@@ -1,0 +1,165 @@
+// SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <cstdint>
+
+#include "compute_kernel_api/eltwise_unary/eltwise_unary.h"
+#include "compute_kernel_api.h"
+#include "compute_kernel_api/transpose_wh.h"
+#include "compute_kernel_api/tile_move_copy.h"
+#include "compute_kernel_api/unpack.h"
+#include "compute_kernel_api/pack.h"
+
+// topk llk needs a global variable atm
+// this can only be removed once that's fixed
+int32_t topk_replay_init = 0;
+
+namespace NAMESPACE {
+void MAIN {
+    constexpr uint32_t input_cb_index = get_compile_time_arg_val(0);
+    constexpr uint32_t index_cb_index = get_compile_time_arg_val(1);
+    constexpr uint32_t input_transposed_cb_index = get_compile_time_arg_val(2);
+    constexpr uint32_t index_transposed_cb_index = get_compile_time_arg_val(3);
+    constexpr uint32_t values_cb_index = get_compile_time_arg_val(4);
+    constexpr uint32_t output_ind_cb_index = get_compile_time_arg_val(5);
+    constexpr uint32_t Ht = get_compile_time_arg_val(6);
+    constexpr uint32_t Wt = get_compile_time_arg_val(7); // Leftover row size after multicore processing
+    constexpr uint32_t K = get_compile_time_arg_val(8);
+    constexpr uint32_t Kt = get_compile_time_arg_val(9);
+    constexpr uint32_t logk = get_compile_time_arg_val(10);
+    constexpr uint32_t logWt = get_compile_time_arg_val(11);
+
+    // dest indices for where to unpack the tiles for the llk
+    // the input goes in index 0,1 and the index goes in index 2,3
+    constexpr uint32_t input_dest_start = 0;
+    constexpr uint32_t index_dest_start = 2;
+    constexpr uint32_t input_dest_end = 1;
+    constexpr uint32_t index_dest_end = 3;
+    // init pack, compute and unpack
+
+
+    init_sfpu(input_cb_index);
+    ckernel::topk_tile_init();
+
+
+    for(uint32_t ht = 0; ht < Ht; ++ht) {
+        cb_wait_front(input_cb_index, Wt);
+        cb_wait_front(index_cb_index, Wt);
+
+        // have to use a different buffer than input_cb_index and index_cb_index as we pop/reserve/wait/push on tiles for all the in-place operations
+        // we will end up racing with reader if both kernels use cb apis on the same buffer (input_cb_index/index_cb_index)
+        pack_reconfig_data_format(input_transposed_cb_index);
+        // streaming in input and index tiles to transpose and bitonic local sort them, two tiles at a time
+        for (uint32_t wt = 0; wt < Wt; wt++) {
+            acquire_dst(tt::DstMode::Half);
+            // copy in inputs from input_cb_index - TODO: figure out how to optimize this out
+            cb_reserve_back(input_transposed_cb_index, 1);
+            copy_tile(input_cb_index, wt, 0);
+            // pack value tiles into cb_intermed2
+            pack_tile(0, input_transposed_cb_index);
+            cb_push_back(input_transposed_cb_index, 1);
+            release_dst(tt::DstMode::Half);
+        }
+        cb_wait_front(input_transposed_cb_index, Wt);
+        cb_pop_front(input_cb_index, Wt);
+
+        copy_tile_to_dst_init_short_with_dt(input_cb_index, index_cb_index);
+        pack_reconfig_data_format(index_transposed_cb_index);
+        for (uint32_t wt = 0; wt < Wt; wt++) {
+            acquire_dst(tt::DstMode::Half);
+            // copy in inputs from index_cb_index
+            cb_reserve_back(index_transposed_cb_index, 1);
+            copy_tile(index_cb_index, wt, 0);
+            // pack value tiles into cb_intermed3
+            pack_tile(0, index_transposed_cb_index);
+            cb_push_back(index_transposed_cb_index, 1);
+            release_dst(tt::DstMode::Half);
+        }
+        cb_wait_front(index_transposed_cb_index, Wt);
+        cb_pop_front(index_cb_index, Wt);
+
+
+        // iterative divide and conquer on pairs of tiles (bitonic topk merge and rebuild)
+        // first iteration we compare 0th and 1st tile, then 2nd and 3rd, etc. We get the sorted top 32 values in each pair.
+        // second iteration we compare 0th and 2nd tile, then 4th and 6th, etc.
+        // logWt iteration we compare 0th and Wt/2 tile
+        // single buffer as we can pack tiles back in-place
+        for (uint32_t m_iter = 0; m_iter < logWt; ++m_iter) {
+            bool direction = false;
+            cb_wait_front(input_transposed_cb_index, Wt);
+            cb_wait_front(index_transposed_cb_index, Wt);
+            uint32_t stride = 1 << m_iter;
+            for (uint32_t left_ind = 0; left_ind < Wt - stride; left_ind += 2 << m_iter) {
+                uint32_t right_ind = left_ind + stride;
+                acquire_dst(tt::DstMode::Half);
+
+                // unpack values into dest
+                copy_tile_to_dst_init_short_with_dt(index_transposed_cb_index, input_transposed_cb_index);
+                copy_tile(input_transposed_cb_index, left_ind, input_dest_start);
+                copy_tile(input_transposed_cb_index, right_ind, input_dest_end);
+
+                // unpack indices into dest
+                copy_tile_to_dst_init_short_with_dt(input_transposed_cb_index, index_transposed_cb_index);
+                copy_tile(index_transposed_cb_index, left_ind, index_dest_start);
+                copy_tile(index_transposed_cb_index, right_ind, index_dest_end);
+
+                // merge values - move larger 32 values into 0th dest and lower 32 values into 1st dest
+                ckernel::topk_merge(0, m_iter, K);
+                // sort within the larger 32 values
+                ckernel::topk_rebuild(0, (uint32_t) direction, m_iter, K, logk, true);
+
+                // pack value tiles in-place in the single-buffered cb_intermed0, we only need the upper 32 values for topk, which was in input_dest_start
+                pack_reconfig_data_format(input_transposed_cb_index);
+                pack_tile<true>(input_dest_start, input_transposed_cb_index, left_ind);
+
+                // pack index tiles in-place in the single-buffered cb_intermed1, we only need the upper 32 values for topk, which was in index_dest_start
+                pack_reconfig_data_format(index_transposed_cb_index);
+                pack_tile<true>(index_dest_start, index_transposed_cb_index, left_ind);
+                release_dst(tt::DstMode::Half);
+                direction = !direction;
+            }
+            cb_reserve_back(input_transposed_cb_index, Wt);
+            cb_reserve_back(index_transposed_cb_index, Wt);
+
+            cb_pop_front(input_transposed_cb_index, Wt);
+            cb_pop_front(index_transposed_cb_index, Wt);
+
+            cb_push_back(input_transposed_cb_index, Wt);
+            cb_push_back(index_transposed_cb_index, Wt);
+        }
+
+        // transpose value tiles and pack into output buffer
+        unpack_reconfig_data_format_srca(input_transposed_cb_index);
+        transpose_wh_init_short(input_transposed_cb_index);
+        pack_reconfig_data_format(input_transposed_cb_index);
+        cb_wait_front(input_transposed_cb_index, Kt);
+        for (uint32_t i = 0; i < Kt; ++i) {
+            acquire_dst(tt::DstMode::Half);
+            cb_reserve_back(values_cb_index, 1);
+            transpose_wh_tile(input_transposed_cb_index, i, 0);
+            pack_tile(0, values_cb_index);
+            cb_push_back(values_cb_index, 1);
+            release_dst(tt::DstMode::Half);
+        }
+        cb_wait_front(input_transposed_cb_index, Wt);
+        cb_pop_front(input_transposed_cb_index, Wt);
+
+        // transpose index tiles and pack into output buffer
+        unpack_reconfig_data_format_srca(index_transposed_cb_index);
+        transpose_wh_init_short(index_transposed_cb_index);
+        pack_reconfig_data_format(index_transposed_cb_index);
+        cb_wait_front(index_transposed_cb_index, Kt);
+        for (uint32_t i = 0; i < Kt; ++i) {
+            acquire_dst(tt::DstMode::Half);
+            cb_reserve_back(output_ind_cb_index, 1);
+            transpose_wh_tile(index_transposed_cb_index, i, 0);
+            pack_tile(0, output_ind_cb_index);
+            cb_push_back(output_ind_cb_index, 1);
+            release_dst(tt::DstMode::Half);
+        }
+        cb_wait_front(index_transposed_cb_index, Wt);
+        cb_pop_front(index_transposed_cb_index, Wt);
+    }
+}
+}

--- a/ttnn/cpp/ttnn/operations/reduction/topk/device/kernels/dataflow/reader_final_topk.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/topk/device/kernels/dataflow/reader_final_topk.cpp
@@ -1,0 +1,53 @@
+// SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <stdint.h>
+#include "dataflow_api.h"
+
+
+void kernel_main() {
+    constexpr uint32_t receiver_semaphore = get_compile_time_arg_val(0);
+    constexpr uint32_t sender_semaphore = get_compile_time_arg_val(1);
+
+    constexpr uint32_t noc_start_x = get_compile_time_arg_val(2);
+    constexpr uint32_t noc_start_y = get_compile_time_arg_val(3);
+    constexpr uint32_t noc_end_x = get_compile_time_arg_val(4);
+    constexpr uint32_t noc_end_y = get_compile_time_arg_val(5);
+
+    constexpr uint32_t Ht = get_compile_time_arg_val(6);
+    constexpr uint32_t Wt_final = get_compile_time_arg_val(7);
+    constexpr uint32_t num_dests = get_compile_time_arg_val(8);
+
+    constexpr uint32_t final_values_cb_index = tt::CB::c_intermed2;
+    constexpr uint32_t final_indices_cb_index = tt::CB::c_intermed3;
+
+    volatile tt_l1_ptr uint32_t* receiver_semaphore_addr = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(receiver_semaphore);
+    volatile tt_l1_ptr uint32_t* sender_semaphore_addr = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(sender_semaphore);
+
+    uint64_t mcast_receiver_semaphore_noc_addr = get_noc_multicast_addr(
+    noc_start_x,
+    noc_start_y,
+    noc_end_x,
+    noc_end_y,
+    receiver_semaphore);
+
+    for (uint32_t i = 0; i < Ht; ++i) {
+        // Look for space in buffer
+        cb_reserve_back(final_values_cb_index, Wt_final);
+        cb_reserve_back(final_indices_cb_index, Wt_final);
+
+        // Data is unsent so label the sender semaphore as INVALID
+        noc_semaphore_set(sender_semaphore_addr, INVALID);
+
+        // Set the receiver semaphore to VALID to allow the sender to write
+        noc_semaphore_set(receiver_semaphore_addr, VALID);
+
+        // Update the multicast address for the receiver semaphore, to allow the senders to write
+        noc_semaphore_set_multicast(receiver_semaphore, mcast_receiver_semaphore_noc_addr, num_dests);
+        noc_semaphore_wait(sender_semaphore_addr, Wt_final);
+
+        cb_push_back(final_values_cb_index, Wt_final);
+        cb_push_back(final_indices_cb_index, Wt_final);
+    }
+}

--- a/ttnn/cpp/ttnn/operations/reduction/topk/device/kernels/dataflow/writer_local_topk.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/topk/device/kernels/dataflow/writer_local_topk.cpp
@@ -1,0 +1,73 @@
+// SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "dataflow_api.h"
+
+void kernel_main() {
+
+    constexpr uint32_t receiver_semaphore = get_compile_time_arg_val(0);
+    constexpr uint32_t sender_semaphore = get_compile_time_arg_val(1);
+    constexpr uint32_t noc_final_x = get_compile_time_arg_val(2);
+    constexpr uint32_t noc_final_y = get_compile_time_arg_val(3);
+    constexpr uint32_t Ht = get_compile_time_arg_val(4);
+    constexpr uint32_t K =  get_compile_time_arg_val(5);
+    constexpr uint32_t Kt = get_compile_time_arg_val(6);
+
+    uint32_t start_ht = get_arg_val<uint32_t>(0);
+    uint32_t start_wt = get_arg_val<uint32_t>(1);
+
+    constexpr uint32_t values_cb_index = tt::CB::c_out0;
+    constexpr uint32_t output_ind_cb_index = tt::CB::c_out1;
+
+
+    constexpr uint32_t topk_local_values_cb_index = tt::CB::c_intermed0;
+    constexpr uint32_t topk_local_indices_cb_index = tt::CB::c_intermed1;
+
+
+    constexpr uint32_t final_values_cb_index = tt::CB::c_intermed2;
+    constexpr uint32_t final_indices_cb_index = tt::CB::c_intermed3;
+
+    // can amortize the noc reads by doing them side by side for the two tensors
+    constexpr uint32_t onetile = 1;
+    const uint32_t tile_bytes_values = get_tile_size(values_cb_index);
+    const uint32_t tile_bytes_ind = get_tile_size(output_ind_cb_index);
+
+    uint32_t final_values_cb_addr = get_write_ptr(final_values_cb_index);
+    uint32_t final_indices_cb_addr = get_write_ptr(final_indices_cb_index);
+
+    uint64_t noc_final_addr_values = get_noc_addr(noc_final_x, noc_final_y, final_values_cb_addr) + start_wt * tile_bytes_values;
+    uint64_t noc_value_addr_values = get_noc_addr(noc_final_x, noc_final_y, final_indices_cb_addr) + start_wt * tile_bytes_ind;
+
+    volatile tt_l1_ptr uint32_t* receiver_semaphore_addr = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(receiver_semaphore);
+    volatile tt_l1_ptr uint32_t* sender_semaphore_addr = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(sender_semaphore);
+
+    uint64_t noc_remote_sender_semaphore_addr = get_noc_addr(noc_final_x, noc_final_y, (uint32_t)sender_semaphore_addr);
+
+    // Get Kt rows of values and then Kt rows of indices from compute kernel
+    for (uint32_t j = 0; j < Ht; ++j) {
+        // wait until we can write to the cb of the final topk core
+        noc_semaphore_wait(receiver_semaphore_addr, VALID);
+        // write out topk values of the local chunk
+        for (uint32_t i = 0; i < Kt; ++i) {
+            cb_wait_front(values_cb_index, onetile);
+            uint32_t l1_read_addr_val = get_read_ptr(values_cb_index);
+            noc_async_write(l1_read_addr_val, noc_final_addr_values + i * tile_bytes_values, tile_bytes_values);
+            cb_pop_front(values_cb_index, onetile);
+        }
+
+        // write out topk indices of the local chunk
+        for (uint32_t i = 0; i < Kt; ++i) {
+            cb_wait_front(output_ind_cb_index, onetile);
+            uint32_t l1_read_addr_ind = get_read_ptr(output_ind_cb_index);
+            noc_async_write(l1_read_addr_ind, noc_value_addr_values + i * tile_bytes_ind, tile_bytes_ind);
+            cb_pop_front(output_ind_cb_index, onetile);
+        }
+        // since we're writing to a precise location we don't need the barrier until later
+        noc_async_write_barrier();
+        // signal the receiver that this local chunk has sent its Kt tiles
+        noc_semaphore_inc(noc_remote_sender_semaphore_addr, Kt);
+        // set the receiver ready semaphore to invalid until the receiver is ready to receive data
+        noc_semaphore_set(receiver_semaphore_addr, INVALID);
+    }
+}

--- a/ttnn/cpp/ttnn/operations/reduction/topk/device/topk_op.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/topk/device/topk_op.cpp
@@ -5,6 +5,24 @@
 #include "topk_op.hpp"
 #include "topk_program_factory.hpp"
 
+namespace topk_utils {
+
+static inline bool verify_available_cores(uint16_t width, uint16_t min_dim, uint16_t max_dim, CoreCoord grid, uint16_t k, const uint32_t value_tile_size, const uint32_t index_tile_size) {
+    const auto max_cores = grid.y - 1; // reserve one core for the gather - switch to grid.x as it allows for more cores and allow spillover to next row
+    for (uint16_t split_size = max_dim; split_size >= min_dim; split_size/=2) {
+        uint16_t rem = width % split_size;
+        uint16_t num_cores = width / split_size + (rem > 0);
+        uint32_t memory_cost_gather = 2*num_cores * (value_tile_size + index_tile_size); // gathering one index and one value tile from each local core, allocating two CBs for each
+        uint32_t memory_cost_local = (split_size / TILE_WIDTH) * (value_tile_size + index_tile_size); // we divide the width into split_size chunks and each chunk, as well as a matching set of indices, is processed by a core
+        if (num_cores <= max_cores && (memory_cost_gather + memory_cost_local) < L1_SIZE && num_cores > 1) {
+            return true;
+        }
+    }
+    return false;
+}
+
+constexpr uint32_t multi_core_min_width = 8192;
+}
 namespace ttnn::operations::reduction {
 
 void TopK::validate_with_output_tensors(
@@ -20,6 +38,17 @@ void TopK::validate_with_output_tensors(
 
     TT_FATAL(this->output_mem_config.is_sharded() == false, "Sharded implementation not supported yet");
     TT_FATAL(input_tensors.at(0).get_layout() == Layout::TILE, "The input must be in tiled format");
+    if (input_shape[dim] >=  topk_utils::multi_core_min_width) { // multicore implementation
+        auto device = input_tensors.at(0).device();
+
+        tt::DataFormat value_cb_data_format = tt::tt_metal::datatype_to_dataformat_converter(input_tensors.at(0).get_dtype());
+        tt::DataFormat index_cb_data_format = tt::DataFormat::UInt16;
+
+        uint32_t value_tile_size = tile_size(value_cb_data_format);
+        uint32_t index_tile_size = tile_size(index_cb_data_format);
+        TT_FATAL(topk_utils::verify_available_cores(input_shape[this->dim], 64, input_shape[this->dim]/2, device->compute_with_storage_grid_size(),
+                            this->k, value_tile_size, index_tile_size), "Not enough cores available to run topk operation");
+    }
 }
 
 std::vector<tt::tt_metal::Shape> TopK::compute_output_shapes(const std::vector<Tensor>& input_tensors) const {
@@ -44,7 +73,11 @@ std::vector<Tensor> TopK::create_output_tensors(
 
 operation::ProgramWithCallbacks TopK::create_program(const std::vector<Tensor>& input_tensors, std::vector<Tensor> &output_tensors) const {
     const auto& input_tensor = input_tensors.at(0);
-    return detail::topk_single_core_interleaved(input_tensor, this->k, this->dim, output_tensors.at(0), output_tensors.at(1));
+    if (input_tensor.get_legacy_shape()[dim] < topk_utils::multi_core_min_width) {
+        return detail::topk_single_core_interleaved(input_tensor, this->k, this->dim, output_tensors.at(0), output_tensors.at(1));
+    } else {
+        return detail::topk_multicore_interleaved(input_tensor, this->k, this->dim, output_tensors.at(0), output_tensors.at(1));
+    }
 }
 
 }  // namespace ttnn::operations::reduction

--- a/ttnn/cpp/ttnn/operations/reduction/topk/device/topk_program_factory.hpp
+++ b/ttnn/cpp/ttnn/operations/reduction/topk/device/topk_program_factory.hpp
@@ -177,4 +177,340 @@ operation::ProgramWithCallbacks topk_single_core_interleaved(const Tensor &input
     return {std::move(program), override_runtime_args_callback};
 }
 
+/**
+ * Split the work along the width such that the width is divisible by min_dim and the number of cores used is less than or equal to max_cores.
+ * Each core must have a minimum of two tiles - min_dim = 64 as that's the minimum size for the llk.
+ * Return the number of cores utilized for the split, the size of the split along the width, the width on the remainder core if any, and the remaining elements that the gather core has to process
+ * If less than the max number of cores are used, then we can try splitting on height as well.
+ * Eg) if only 2 cores are used for the split and then 1 for the gather, we only need 3 cores per row.
+ * Then take cores_per_row = 3 and try to split the height such that the number of cores used is less than or equal to max_cores.
+*/
+static inline std::tuple<uint16_t, uint16_t, uint16_t, uint16_t> cores_utilized(uint16_t width, uint16_t min_dim, uint16_t max_dim, CoreCoord grid, uint16_t k, const uint32_t value_tile_size, const uint32_t index_tile_size) {
+    const auto max_cores = grid.y - 1; // reserve one core for the gather - switch to grid.x as it allows for more cores and allow spillover to next row
+    for (uint16_t split_size = max_dim; split_size >= min_dim; split_size/=2) {
+        uint16_t rem = width % split_size;
+        uint16_t num_cores = width / split_size + (rem > 0);
+        uint32_t memory_cost_gather = 2*num_cores * (value_tile_size + index_tile_size); // gathering one index and one value tile from each local core, allocating two CBs for each
+        uint32_t memory_cost_local = (split_size / TILE_WIDTH) * (value_tile_size + index_tile_size); // we divide the width into split_size chunks and each chunk, as well as a matching set of indices, is processed by a core
+        if (num_cores <= max_cores && (memory_cost_gather + memory_cost_local) < L1_SIZE && num_cores > 1) {
+            return {num_cores + 1, split_size, rem, num_cores * k};
+        }
+    }
+    return {max_cores + 1, width, 0, width * k};
+}
+/**
+ * Split work along width dimension and compute topk values and indices for each split in parallel, on different cores.
+ * Then gather the results of each split onto a single core, where the final topk values and indices are computed.
+ *
+*/
+operation::ProgramWithCallbacks topk_multicore_interleaved(const Tensor &input_tensor, const uint16_t k, const int8_t dim, Tensor &value_tensor, Tensor &index_tensor) {
+    tt::tt_metal::Program program{};
+
+
+    tt::DataFormat input_cb_data_format = tt::tt_metal::datatype_to_dataformat_converter(input_tensor.get_dtype());
+    tt::DataFormat value_cb_data_format = tt::tt_metal::datatype_to_dataformat_converter(value_tensor.get_dtype());
+    tt::DataFormat index_cb_data_format = tt::tt_metal::datatype_to_dataformat_converter(index_tensor.get_dtype());
+
+    uint32_t input_tile_size = tile_size(input_cb_data_format);
+    uint32_t value_tile_size = tile_size(value_cb_data_format);
+    uint32_t index_tile_size = tile_size(index_cb_data_format);
+
+    auto input_buffer = input_tensor.buffer();
+    auto values_buffer = value_tensor.buffer();
+    auto index_buffer = index_tensor.buffer();
+
+    bool input_is_dram = input_buffer->buffer_type() == tt::tt_metal::BufferType::DRAM;
+    bool values_is_dram = values_buffer->buffer_type() == tt::tt_metal::BufferType::DRAM;
+    bool index_is_dram = index_buffer->buffer_type() == tt::tt_metal::BufferType::DRAM;
+
+    uint32_t num_input_tiles = input_tensor.volume()/TILE_HW;
+    uint32_t num_value_tiles = value_tensor.volume()/TILE_HW;
+    auto device = input_tensor.device();
+
+    auto input_shape = input_tensor.get_legacy_shape();
+    uint32_t Ht = (input_shape[0]*input_shape[1]*input_shape[2])/TILE_HEIGHT;
+    const auto & [num_cores, local_topk_input_size, rem, final_topk_input_size] =
+    cores_utilized(input_shape[dim], 64, input_shape[dim]/2, device->compute_with_storage_grid_size(), k, value_tile_size, index_tile_size);
+
+    CoreRange core(
+        {0, 0},
+        {0, num_cores - 1}
+    );
+
+    CoreRange local_cores(
+        {0, 0},
+        {0, num_cores - 2}
+    );
+
+    CoreRange final_cores(
+        {0, num_cores - 1},
+        {0, num_cores - 1}
+    );
+
+    uint32_t Wt_local = local_topk_input_size / TILE_WIDTH;
+    uint32_t Wt_final = final_topk_input_size / TILE_WIDTH;
+    uint32_t Kt = k % TILE_WIDTH == 0 ? k/TILE_WIDTH : k/TILE_WIDTH + 1;
+
+    // for streaming in input
+    uint32_t num_cb_unit = 2;
+    uint32_t cb_in_units = 2 * num_cb_unit;
+
+    // Two tiles are loaded in for topk_local_sort at a time, and we double buffer to avoid stalls, so allocate four tiles of space
+    // TODO: In theory if we have enough memory we could allocate 2*Wt tiles to reduce stalls
+    uint32_t input_cb_index = tt::CB::c_in0;
+    tt::tt_metal::CircularBufferConfig input_cb_config = tt::tt_metal::CircularBufferConfig(
+        cb_in_units  * value_tile_size, {{input_cb_index, input_cb_data_format}})
+		.set_page_size(input_cb_index, input_tile_size);
+    auto cb_input_tensor = tt::tt_metal::CreateCircularBuffer(program, core, input_cb_config);
+
+    // Two tiles are loaded in for topk_local_sort at a time, and we double buffer to avoid stalls, so allocate four tiles of space
+    // This CB carries the indices that are created in the reader kernel
+    uint32_t index_cb_index = tt::CB::c_in1;
+    tt::tt_metal::CircularBufferConfig index_input_intermed0_config = tt::tt_metal::CircularBufferConfig(
+        cb_in_units * index_tile_size, {{index_cb_index, index_cb_data_format}})
+		.set_page_size(index_cb_index, index_tile_size);
+    auto cb_index_tensor = tt::tt_metal::CreateCircularBuffer(program, core, index_input_intermed0_config);
+
+    // Single buffered circular buffer that holds the transposed input tiles
+    uint32_t input_transposed_cb_index = tt::CB::c_intermed0;
+    tt::tt_metal::CircularBufferConfig input_transposed_cb_config = tt::tt_metal::CircularBufferConfig(
+         Wt_local * value_tile_size, {{input_transposed_cb_index, input_cb_data_format}})
+		.set_page_size(input_transposed_cb_index, input_tile_size);
+    auto cb_input_transposed_tiles = tt::tt_metal::CreateCircularBuffer(program, core, input_transposed_cb_config);
+
+    // Single buffered circular buffer that holds the transposed index tiles
+    uint32_t index_transposed_cb_index = tt::CB::c_intermed1;
+    tt::tt_metal::CircularBufferConfig index_transposed_cb_config = tt::tt_metal::CircularBufferConfig(
+         Wt_local * index_tile_size, {{index_transposed_cb_index, index_cb_data_format}})
+		.set_page_size(index_transposed_cb_index, index_tile_size);
+    auto cb_index_transposed_tiles = tt::tt_metal::CreateCircularBuffer(program, core, index_transposed_cb_config);
+
+    uint32_t gathered_values_cb_index = tt::CB::c_intermed2;
+    tt::tt_metal::CircularBufferConfig gathered_values_cb_config = tt::tt_metal::CircularBufferConfig(
+        Wt_final * value_tile_size, {{gathered_values_cb_index, value_cb_data_format}})
+        .set_page_size(gathered_values_cb_index, value_tile_size);
+    auto cb_gathered_topk_values_tensor = tt::tt_metal::CreateCircularBuffer(program, core, gathered_values_cb_config);
+
+    uint32_t gathered_indices_cb_index = tt::CB::c_intermed3;
+    tt::tt_metal::CircularBufferConfig gathered_indices_cb_config = tt::tt_metal::CircularBufferConfig(
+        Wt_final * index_tile_size, {{gathered_indices_cb_index, index_cb_data_format}})
+        .set_page_size(gathered_indices_cb_index, index_tile_size);
+    auto cb_gathered_topk_indices_tensor = tt::tt_metal::CreateCircularBuffer(program, core, gathered_indices_cb_config);
+
+    uint32_t final_values_cb_index = tt::CB::c_intermed4;
+    tt::tt_metal::CircularBufferConfig final_values_cb_config = tt::tt_metal::CircularBufferConfig(
+        Wt_final * value_tile_size, {{final_values_cb_index, value_cb_data_format}})
+        .set_page_size(final_values_cb_index, value_tile_size);
+    auto cb_final_topk_values_tensor = tt::tt_metal::CreateCircularBuffer(program, core, final_values_cb_config);
+
+    uint32_t final_indices_cb_index = tt::CB::c_intermed5;
+    tt::tt_metal::CircularBufferConfig final_indices_cb_config = tt::tt_metal::CircularBufferConfig(
+        Wt_final * index_tile_size, {{final_indices_cb_index, index_cb_data_format}})
+        .set_page_size(final_indices_cb_index, index_tile_size);
+    auto cb_final_topk_index_tensor = tt::tt_metal::CreateCircularBuffer(program, core, final_indices_cb_config);
+
+    // Output topk values
+    uint32_t values_cb_index = tt::CB::c_out0;
+    tt::tt_metal::CircularBufferConfig values_cb_config = tt::tt_metal::CircularBufferConfig(
+        num_cb_unit * value_tile_size, {{values_cb_index, value_cb_data_format}})
+        .set_page_size(values_cb_index, value_tile_size);
+    auto cb_values_tensor = tt::tt_metal::CreateCircularBuffer(program, core, values_cb_config);
+
+
+    // Output topk indices
+    uint32_t output_ind_cb_index = tt::CB::c_out1;
+    tt::tt_metal::CircularBufferConfig output_ind_cb_config = tt::tt_metal::CircularBufferConfig(
+        num_cb_unit * index_tile_size, {{output_ind_cb_index, index_cb_data_format}})
+        .set_page_size(output_ind_cb_index, index_tile_size);
+    auto cb_output_ind_tensor = tt::tt_metal::CreateCircularBuffer(program, core, output_ind_cb_config);
+
+
+    // Create semaphores
+    auto sender_semaphore = tt::tt_metal::CreateSemaphore(program, core, INVALID);
+    auto receiver_semaphore = tt::tt_metal::CreateSemaphore(program, core, INVALID);
+    std::vector<uint32_t> reader_local_compile_time_args = {
+                                                        input_cb_index,
+                                                        index_cb_index,
+                                                        (uint32_t)input_is_dram,
+                                                        Ht,
+                                                        Wt_local,
+                                                        input_shape[-1]/TILE_WIDTH, // Wt
+                                                        };
+    tt::tt_metal::KernelHandle unary_reader_kernel_id = tt::tt_metal::CreateKernel(
+        program,
+        "ttnn/cpp/ttnn/operations/reduction/topk/device/kernels/dataflow/reader_create_index_local_topk.cpp",
+        local_cores,
+        tt::tt_metal::ReaderDataMovementConfig(reader_local_compile_time_args));
+
+
+
+    CoreCoord local_cores_physical_start = device->worker_core_from_logical_core({0, 0});
+    CoreCoord local_cores_physical_end = device->worker_core_from_logical_core({0, num_cores - 2});
+    std::vector<uint32_t> reader_compile_time_args =             {
+                (std::uint32_t) receiver_semaphore,
+                (std::uint32_t) sender_semaphore,
+                (std::uint32_t) local_cores_physical_start.x,
+                (std::uint32_t) local_cores_physical_start.y,
+                (std::uint32_t) local_cores_physical_end.x,
+                (std::uint32_t) local_cores_physical_end.y,
+                (std::uint32_t) Ht,
+                (std::uint32_t) Wt_final,
+                (std::uint32_t) num_cores - 1,
+            };
+
+    tt::tt_metal::KernelHandle unary_reader_final_kernel_id = tt::tt_metal::CreateKernel(
+        program,
+        "ttnn/cpp/ttnn/operations/reduction/topk/device/kernels/dataflow/reader_final_topk.cpp",
+        final_cores,
+        tt::tt_metal::ReaderDataMovementConfig(reader_compile_time_args));
+
+    CoreCoord final_cores_physical = device->worker_core_from_logical_core({0, num_cores - 1});
+    std::vector<uint32_t> writer_compile_time_args = {
+        (std::uint32_t) receiver_semaphore,
+        (std::uint32_t) sender_semaphore,
+        (std::uint32_t) final_cores_physical.x,
+        (std::uint32_t) final_cores_physical.y,
+        Ht,
+        k,
+        Kt,
+    };
+    tt::tt_metal::KernelHandle binary_writer_kernel_id = tt::tt_metal::CreateKernel(
+        program,
+        "ttnn/cpp/ttnn/operations/reduction/topk/device/kernels/dataflow/writer_local_topk.cpp",
+        local_cores,
+        tt::tt_metal::WriterDataMovementConfig(writer_compile_time_args));
+
+
+    std::vector<uint32_t> writer_compile_time_args_final = {
+                                                        values_cb_index,
+                                                        output_ind_cb_index,
+                                                        (std::uint32_t) values_is_dram,
+                                                        (std::uint32_t) index_is_dram,
+                                                        Ht,
+                                                        Kt};
+    tt::tt_metal::KernelHandle binary_writer_final_kernel_id = tt::tt_metal::CreateKernel(
+        program,
+        "ttnn/cpp/ttnn/operations/reduction/topk/device/kernels/dataflow/writer_final_topk.cpp",
+        final_cores,
+        tt::tt_metal::WriterDataMovementConfig(writer_compile_time_args_final));
+
+    std::vector<uint32_t> compute_args = {
+                                        input_cb_index,
+                                        index_cb_index,
+                                        input_transposed_cb_index,
+                                        index_transposed_cb_index,
+                                        values_cb_index,
+                                        output_ind_cb_index,
+                                        Ht,
+                                        Wt_local,
+                                        k,
+                                        Kt,
+                                        (std::uint32_t) std::log2(k),
+                                        (std::uint32_t) std::log2(Wt_local),
+                                        };
+    tt::tt_metal::KernelHandle topk_compute_kernel_id = tt::tt_metal::CreateKernel(
+        program,
+        "ttnn/cpp/ttnn/operations/reduction/topk/device/kernels/compute/topk_local.cpp",
+        local_cores,
+        tt::tt_metal::ComputeConfig{.compile_args = compute_args}
+    );
+
+    std::vector<uint32_t> compute_args_final = {
+                                        gathered_values_cb_index,
+                                        gathered_indices_cb_index,
+                                        final_values_cb_index,
+                                        final_indices_cb_index,
+                                        values_cb_index,
+                                        output_ind_cb_index,
+                                        Ht,
+                                        Wt_final,
+                                        k,
+                                        Kt,
+                                        (std::uint32_t) std::log2(k),
+                                        (std::uint32_t) std::log2(Wt_final),
+                                        };
+
+    tt::tt_metal::KernelHandle topk_final_compute_kernel_id = tt::tt_metal::CreateKernel(
+        program,
+        "ttnn/cpp/ttnn/operations/reduction/topk/device/kernels/compute/topk_final.cpp",
+        final_cores,
+        tt::tt_metal::ComputeConfig{.compile_args = compute_args_final}
+    );
+
+
+
+    for (uint32_t core_h = 0; core_h < 1; core_h++) {
+        bool ascending = false;
+        for (uint32_t core_w = 0; core_w < num_cores - 1; core_w++) {
+            CoreCoord core = {core_h, core_w};
+            SetRuntimeArgs(
+                program,
+                unary_reader_kernel_id,
+                core,
+                {
+                    input_buffer->address(),
+                    0, // no height parallelism for now
+                    core_w * Wt_local,
+                }
+            );
+
+            SetRuntimeArgs(
+                program,
+                binary_writer_kernel_id,
+                core,
+                {
+                    core_h,
+                    core_w,
+                }
+            );
+
+            SetRuntimeArgs(
+                program,
+                topk_compute_kernel_id,
+                core,
+                {
+                    ascending,
+                }
+            );
+
+            ascending = !ascending;
+        }
+        CoreCoord core = {core_h, num_cores - 1};
+        SetRuntimeArgs(
+            program,
+            binary_writer_final_kernel_id,
+            core,
+            {
+                values_buffer->address(),
+                index_buffer->address(),
+            }
+        );
+    }
+
+    auto override_runtime_args_callback = [unary_reader_kernel_id, binary_writer_final_kernel_id, num_cores](
+        const Program &program,
+        const std::vector<Buffer*>& input_buffers,
+        const std::vector<Buffer*>& output_buffers
+    ) {
+
+        auto input_buffer = input_buffers.at(0);
+        auto values_buffer = output_buffers.at(0);
+        auto index_buffer = output_buffers.at(1);
+
+        for (uint32_t core_h = 0; core_h < 1; core_h++) {
+            for (uint32_t core_w = 0; core_w < num_cores - 1; core_w++) {
+                CoreCoord core = {core_h, core_w};
+                auto &reader_runtime_args = GetRuntimeArgs(program, unary_reader_kernel_id, core);
+                reader_runtime_args[0] = input_buffer->address();
+
+                auto &writer_runtime_args = GetRuntimeArgs(program, binary_writer_final_kernel_id, core);
+                writer_runtime_args[0] = values_buffer->address();
+                writer_runtime_args[1] = index_buffer->address();
+            }
+        }
+    };
+
+    return {std::move(program), override_runtime_args_callback};
+}
+
 } // namespace ttnn::operations::reduction::detail


### PR DESCRIPTION

### Ticket
- #9657

### Problem description
- Want to get TopK working on larger inputs to do token selection on device
- Also want to improve performance of larger inputs with larger widths

### What's changed
- Support Mx32768 input (powers of 2 from 2^6 - 2^15 are now supported, though the larger ones may need to be interleaved in DRAM)
- parallelize by splitting width into local chunks of size 2^x, running topk and then pushing to a a gather core
- the gather core then runs topk one last time and pushes it to the interleaved output
- arbitrary height supported
- TODO: use remaining cores to parallelize height
- TODO: gather into one of the local cores instead of a separate core to minimize noc transactions and cores used, combine kernels to do so
- TODO: support k != 32
- TODO: optimize out a potentially unnecessary width sized CB in the gather core which limits the width
- TODO: parallelize width along columns rather than rows as we have more cores
- TODO: allow parallelization to spillover to next row/col of cores as it will allow for greater widths

### Checklist
- [x] Post commit CI passes
- [x] Model regression CI testing passes (if applicable)
- [x] New/Existing tests provide coverage for changes
