### PR TITLE
#9492: Change models matmul usage to ttnn

### DIFF
--- a/models/demos/metal_BERT_large_11/tt/bert_encoder.py
+++ b/models/demos/metal_BERT_large_11/tt/bert_encoder.py
@@ -8,6 +8,7 @@ from typing import Optional
 from functools import partial
 
 import tt_lib
+import ttnn
 from models.demos.metal_BERT_large_11.tt.mha import TtMultiHeadAttentionModel
 from models.demos.metal_BERT_large_11.tt.ffn import TtFeedForwardModel
 from models.demos.metal_BERT_large_11.tt import custom_matmuls
@@ -142,13 +143,13 @@ class TtBertEncoder:
         if "OP7_SELFOUT_CONFIG" in model_config:
 
             def op7_mm_plus_bias(mha_res, attention_output_weight, attention_output_bias):
-                mha_out = tt_lib.operations.primary.matmul(
+                mha_out = ttnn.linear(
                     mha_res,
                     attention_output_weight,
                     bias=attention_output_bias,
                     program_config=model_config["OP7_SELFOUT_CONFIG"],
-                    output_mem_config=model_config["OP7_SELFOUT_OUTPUT_MEMCFG"],
-                    output_dtype=model_config["OP7_SELFOUT_OUTPUT_DTYPE"],
+                    memory_config=model_config["OP7_SELFOUT_OUTPUT_MEMCFG"],
+                    dtype=model_config["OP7_SELFOUT_OUTPUT_DTYPE"],
                 )
                 return mha_out
 

--- a/models/demos/metal_BERT_large_11/tt/bert_model.py
+++ b/models/demos/metal_BERT_large_11/tt/bert_model.py
@@ -8,6 +8,7 @@ import torch
 from loguru import logger
 
 import tt_lib
+import ttnn
 
 from models.demos.metal_BERT_large_11.tt.embeddings import TtEmbeddings
 from models.demos.metal_BERT_large_11.tt.bert_encoder import TtBertEncoder
@@ -77,7 +78,7 @@ class TtBertBatchDram:
         # QA linear
         # TODO: Replace with custom op with fused bias?
         def qa_linear_(activation):
-            output = tt_lib.tensor.matmul(activation, weight, model_config["QA_LINEAR_OUTPUT_MEMCFG"])
+            output = ttnn.matmul(activation, weight, memory_config=model_config["QA_LINEAR_OUTPUT_MEMCFG"])
             output_plus_bias = tt_lib.tensor.bcast(
                 output,
                 bias,

--- a/models/demos/metal_BERT_large_11/tt/ffn.py
+++ b/models/demos/metal_BERT_large_11/tt/ffn.py
@@ -6,6 +6,7 @@
 import torch
 
 import tt_lib
+import ttnn
 from tt_lib.utils import pad_weight
 from models.demos.metal_BERT_large_11.tt import custom_matmuls
 
@@ -27,13 +28,13 @@ def feed_forward(
     if "OP9_FF1_MM_CONFIG" in model_config:
 
         def op9_MM_bias_gelu(activation, ff1_weighta, ff1_biasa):
-            output_plus_bias_act = tt_lib.operations.primary.matmul(
+            output_plus_bias_act = tt.linear(
                 activation,
                 ff1_weighta,
                 bias=ff1_biasa,
                 program_config=model_config["OP9_FF1_MM_CONFIG"],
-                output_mem_config=model_config["OP9_FF1_MM_OUTPUT_MEMCFG"],
-                output_dtype=model_config["OP9_FF1_MM_OUTPUT_DTYPE"],
+                memory_config=model_config["OP9_FF1_MM_OUTPUT_MEMCFG"],
+                dtype=model_config["OP9_FF1_MM_OUTPUT_DTYPE"],
             )
             return output_plus_bias_act
 
@@ -53,13 +54,13 @@ def feed_forward(
     if "OP10_FF2_MM_CONFIG" in model_config:
 
         def op10_MM_bias(activation, ff2_weighta, ff2_biasa):
-            output_plus_bias = tt_lib.operations.primary.matmul(
+            output_plus_bias = ttnn.linear(
                 activation,
                 ff2_weighta,
                 bias=ff2_biasa,
                 program_config=model_config["OP10_FF2_MM_CONFIG"],
-                output_mem_config=model_config["OP10_FF2_MM_OUTPUT_MEMCFG"],
-                output_dtype=model_config["OP10_FF2_MM_OUTPUT_DTYPE"],
+                memory_config=model_config["OP10_FF2_MM_OUTPUT_MEMCFG"],
+                dtype=model_config["OP10_FF2_MM_OUTPUT_DTYPE"],
             )
             return output_plus_bias
 

--- a/models/demos/metal_BERT_large_11/tt/ffn.py
+++ b/models/demos/metal_BERT_large_11/tt/ffn.py
@@ -28,7 +28,7 @@ def feed_forward(
     if "OP9_FF1_MM_CONFIG" in model_config:
 
         def op9_MM_bias_gelu(activation, ff1_weighta, ff1_biasa):
-            output_plus_bias_act = tt.linear(
+            output_plus_bias_act = ttnn.linear(
                 activation,
                 ff1_weighta,
                 bias=ff1_biasa,

--- a/models/demos/resnet/tt/metalResnetBlock50.py
+++ b/models/demos/resnet/tt/metalResnetBlock50.py
@@ -123,18 +123,18 @@ def ResnetLinear(
     if matmul_config is None:
 
         def linear_(act):
-            return tt_lib.tensor.resnet_matmul(act, weight_T, bias, output_mem_config)
+            return ttnn.linear(act, weight_T, bias=bias, memory_config=output_mem_config)
 
     else:
 
         def linear_(act):
-            return tt_lib.operations.primary.matmul_1d(
+            return ttnn.linear(
                 act,
                 weight_T,
                 bias=bias,
                 program_config=matmul_config,
-                output_mem_config=output_mem_config,
-                output_dtype=model_config["ACTIVATIONS_DTYPE"],
+                memory_config=output_mem_config,
+                dtype=model_config["ACTIVATIONS_DTYPE"],
                 compute_kernel_config=compute_kernel_config,
             )
 

--- a/models/demos/t3000/llama2_70b/tests/perf/ivan_ff.py
+++ b/models/demos/t3000/llama2_70b/tests/perf/ivan_ff.py
@@ -31,14 +31,12 @@ class TtFF1:
 
     def __call__(self, x, prog_config):
         # Assume interleaved input
-        ff_out = tt_lib.operations.primary.matmul_1d(
+        ff_out = ttnn.matmul(
             x,
             self.weight,
-            fp32_dest_acc_en=USE_ACC,
-            packer_l1_acc=USE_ACC,
             program_config=prog_config,
-            output_mem_config=WIDTH_SHARDED_MEMCFG,
-            output_dtype=BFP8_DTYPE,
+            memory_config=WIDTH_SHARDED_MEMCFG,
+            dtype=BFP8_DTYPE,
         )
         x.deallocate()
 

--- a/models/demos/t3000/llama2_70b/tests/perf/test_bmm.py
+++ b/models/demos/t3000/llama2_70b/tests/perf/test_bmm.py
@@ -75,12 +75,12 @@ class TT_bmm:
             sharded_mem_config=q_mem_config,
         )
 
-        out = tt_lib.operations.primary.matmul(
+        out = ttnn.matmul(
             q,
             k,
             program_config=prog_config,
-            output_mem_config=output_config,
-            output_dtype=ttl.tensor.DataType.BFLOAT16,
+            memory_config=output_config,
+            dtype=ttl.tensor.DataType.BFLOAT16,
         )
 
         return out

--- a/models/demos/t3000/llama2_70b/tests/perf/test_ff1.py
+++ b/models/demos/t3000/llama2_70b/tests/perf/test_ff1.py
@@ -36,14 +36,12 @@ class TtFF1:
 
     def __call__(self, x, prog_config, output_config):
         # Assume interleaved input
-        ff_out = tt_lib.operations.primary.matmul_1d(
+        ff_out = ttnn.matmul(
             x,
             self.weight,
-            fp32_dest_acc_en=USE_ACC,
-            packer_l1_acc=USE_ACC,
             program_config=prog_config,
-            output_mem_config=output_config,
-            output_dtype=self.model_config["FF1_MM_OUTPUT_DTYPE"],
+            memory_config=output_config,
+            dtype=self.model_config["FF1_MM_OUTPUT_DTYPE"],
         )
         x.deallocate()
 

--- a/models/demos/t3000/llama2_70b/tests/perf/test_llama_matmul_perf.py
+++ b/models/demos/t3000/llama2_70b/tests/perf/test_llama_matmul_perf.py
@@ -56,12 +56,12 @@ class Decode_FF1:
         )
 
     def __call__(self, x):
-        ff_out = tt_lib.operations.primary.matmul_1d(
+        ff_out = ttnn.matmul(
             x,
             self.weight,
             program_config=self.prog_config,
-            output_mem_config=WIDTH_SHARDED_MEMCFG,
-            output_dtype=BFP8_DTYPE,
+            memory_config=WIDTH_SHARDED_MEMCFG,
+            dtype=BFP8_DTYPE,
             compute_kernel_config=COMPUTE_KERNEL_CONFIG,
         )
 
@@ -91,12 +91,12 @@ class Decode_FF2:
 
     def __call__(self, x):
         # Assume interleaved input
-        ff_out = tt_lib.operations.primary.matmul_1d(
+        ff_out = ttnn.matmul(
             x,
             self.weight,
             program_config=self.prog_config,
-            output_mem_config=WIDTH_SHARDED_MEMCFG,
-            output_dtype=BFP8_DTYPE,
+            memory_config=WIDTH_SHARDED_MEMCFG,
+            dtype=BFP8_DTYPE,
             compute_kernel_config=COMPUTE_KERNEL_CONFIG,
         )
 
@@ -162,20 +162,20 @@ class Prefill_MLP_128:
 
     def __call__(self, x, x_allgather):
         # Assume interleaved input
-        ff1_out = tt_lib.operations.primary.matmul(
+        ff1_out = ttnn.matmul(
             x,
             self.w1,
             program_config=self.prog_config1,
-            output_dtype=BFP8_DTYPE,
-            output_mem_config=WIDTH_SHARDED_MEMCFG,
+            dtype=BFP8_DTYPE,
+            memory_config=WIDTH_SHARDED_MEMCFG,
             compute_kernel_config=COMPUTE_KERNEL_FP16_CONFIG,
         )
-        ff3_out = tt_lib.operations.primary.matmul(
+        ff3_out = ttnn.matmul(
             x,
             self.w3,
             program_config=self.prog_config3,
-            output_dtype=BFP8_DTYPE,
-            output_mem_config=WIDTH_SHARDED_MEMCFG,
+            dtype=BFP8_DTYPE,
+            memory_config=WIDTH_SHARDED_MEMCFG,
             compute_kernel_config=COMPUTE_KERNEL_FP16_CONFIG,
         )
 
@@ -187,12 +187,12 @@ class Prefill_MLP_128:
 
         out.deallocate()
         x.deallocate()
-        ff2_out = tt_lib.operations.primary.matmul(
+        ff2_out = ttnn.matmul(
             x_allgather,
             self.w2,
             program_config=self.prog_config2,
-            output_dtype=BFP8_DTYPE,
-            output_mem_config=WIDTH_SHARDED_MEMCFG,
+            dtype=BFP8_DTYPE,
+            memory_config=WIDTH_SHARDED_MEMCFG,
             compute_kernel_config=COMPUTE_KERNEL_FP16_CONFIG,
         )
         return out
@@ -341,18 +341,18 @@ class Prefill_MLP_2k:
 
     def __call__(self, x, x_allgather):
         # Assume interleaved input
-        ff1_out = tt_lib.operations.primary.matmul(
+        ff1_out = ttnn.matmul(
             x,
             self.w1,
             program_config=self.prog_config1,
-            output_mem_config=self.block_sharded,
+            memory_config=self.block_sharded,
             compute_kernel_config=COMPUTE_KERNEL_FP16_CONFIG,
         )
-        ff3_out = tt_lib.operations.primary.matmul(
+        ff3_out = ttnn.matmul(
             x,
             self.w3,
             program_config=self.prog_config3,
-            output_mem_config=self.block_sharded,
+            memory_config=self.block_sharded,
             compute_kernel_config=COMPUTE_KERNEL_FP16_CONFIG,
         )
 
@@ -361,7 +361,7 @@ class Prefill_MLP_2k:
         ff3_out.deallocate()
         out.deallocate()
 
-        ff2_out = tt_lib.operations.primary.matmul(
+        ff2_out = ttnn.matmul(
             x_allgather,
             self.w2,
             program_config=self.prog_config2,

--- a/models/demos/t3000/llama2_70b/tests/unit_tests/test_attn_sdpa.py
+++ b/models/demos/t3000/llama2_70b/tests/unit_tests/test_attn_sdpa.py
@@ -118,7 +118,7 @@ class TtLlamaSDPA(torch.nn.Module):
             # output_mem_config=self.model_config["CONCAT_HEADS_OUTPUT_MEMCFG"],
         )  # seqlen, 1, batch, hidden_size
 
-        attb_output = tt_lib.tensor.matmul(
+        attb_output = ttnn.matmul(
             attn_output,
             self.wo,
         )  # seqlen, 1, batch, hidden_size

--- a/models/demos/t3000/llama2_70b/tests/unit_tests/test_qkv_matmul.py
+++ b/models/demos/t3000/llama2_70b/tests/unit_tests/test_qkv_matmul.py
@@ -79,12 +79,10 @@ class TtLlamaQKV(torch.nn.Module):
         fused_query_key_value = []
         for i in range(len(xs)):
             fused_query_key_value.append(
-                tt_lib.operations.primary.matmul(
+                ttnn.matmul(
                     xs[i],
                     self.qkv_list[i],
                     program_config=self.model_config["FUSED_QKV_MM_PROGCFG"],
-                    # output_mem_config=self.model_config["FUSED_QKV_MM_OUTPUT_MEMCFG"],
-                    # output_dtype=self.model_config["FUSED_QKV_MM_OUTPUT_DTYPE"],
                     compute_kernel_config=self.model_config["COMPUTE_KERNEL_CONFIG"],
                 )
             )

--- a/models/demos/t3000/llama2_70b/tests/unit_tests/test_reshape_rotary.py
+++ b/models/demos/t3000/llama2_70b/tests/unit_tests/test_reshape_rotary.py
@@ -87,7 +87,7 @@ class TtLlamaRotary(torch.nn.Module):
         xq = tt_lib.tensor.pad(xq, [1, 32, 128, self.head_dim], [0, 0, 0, 0], 0.0)
         xq = tt_lib.tensor.transpose(xq, 1, 2)
 
-        xq = tt_lib.operations.primary.matmul(
+        xq = ttnn.matmul(
             xq,
             rot_mat,
             # compute_kernel_config=self.model_config["ROT_MAT_COMPUTE_KERNEL_CONFIG"]
@@ -104,7 +104,7 @@ class TtLlamaRotary(torch.nn.Module):
 
         xk = tt_lib.tensor.transpose(xk, 1, 2)
 
-        xk = tt_lib.operations.primary.matmul(
+        xk = ttnn.matmul(
             xk,
             rot_mat,
             # compute_kernel_config=self.model_config["ROT_MAT_COMPUTE_KERNEL_CONFIG"],

--- a/models/demos/t3000/llama2_70b/tests/unit_tests/test_rotary_matmul.py
+++ b/models/demos/t3000/llama2_70b/tests/unit_tests/test_rotary_matmul.py
@@ -101,18 +101,18 @@ def run_test_rotary_matmul1(
     rotary_mat_tt = torch2tt_tensor(rotary_mat, devices[0])
 
     # tt operation
-    query_tt = ttl.operations.primary.matmul(
+    query_tt = ttnn.matmul(
         query_tt,
         rotary_mat_tt,
         program_config=ROT_MAT_Q_MM_PROGCFG,
-        output_mem_config=ROT_MAT_Q_MM_OUTPUT_MEMCFG,
+        memory_config=ROT_MAT_Q_MM_OUTPUT_MEMCFG,
         compute_kernel_config=ROT_MAT_COMPUTE_KERNEL_CONFIG
         # [seqlen, n_heads, bsz, head_dim]  # [1, 1, head_dim, head_dim]  => [seqlen, n_heads, bsz, head_dim]
     )
-    key_tt = ttl.operations.primary.matmul(
+    key_tt = ttnn.matmul(
         key_tt,
         rotary_mat_tt,
-        output_mem_config=L1_MEMCFG,
+        memory_config=L1_MEMCFG,
         compute_kernel_config=ROT_MAT_COMPUTE_KERNEL_CONFIG
         # [seqlen, 1, bsz, head_dim]  # [1, 1, head_dim, head_dim]  => [seqlen, 1, bsz, head_dim]
     )
@@ -214,19 +214,19 @@ def run_test_rotary_matmul2(
     rotary_mat_tt = torch2tt_tensor(rotary_mat, devices[0])
 
     # tt operation
-    query_tt = ttl.operations.primary.matmul(
+    query_tt = ttnn.matmul(
         query_tt,
         rotary_mat_tt,
         program_config=ROT_MAT_MM_PROGCFG,
-        output_mem_config=ROT_MAT_MM_OUTPUT_MEMCFG,
+        memory_config=ROT_MAT_MM_OUTPUT_MEMCFG,
         compute_kernel_config=ROT_MAT_COMPUTE_KERNEL_CONFIG
         # [seqlen, n_heads, bsz, head_dim]  # [1, 1, head_dim, head_dim]  => [seqlen, n_heads, bsz, head_dim]
     )
-    key_tt = ttl.operations.primary.matmul(
+    key_tt = ttnn.matmul(
         key_tt,
         rotary_mat_tt,
         program_config=ROT_MAT_MM_PROGCFG,
-        output_mem_config=ROT_MAT_MM_OUTPUT_MEMCFG,
+        memory_config=ROT_MAT_MM_OUTPUT_MEMCFG,
         compute_kernel_config=ROT_MAT_COMPUTE_KERNEL_CONFIG
         # [seqlen, 1, bsz, head_dim]  # [1, 1, head_dim, head_dim]  => [seqlen, 1, bsz, head_dim]
     )
@@ -325,19 +325,19 @@ def run_test_rotary_matmul3(
     rotary_mat_tt = torch2tt_tensor(rotary_mat, devices[0])
 
     # tt operation
-    query_tt = ttl.operations.primary.matmul(
+    query_tt = ttnn.matmul(
         query_tt,
         rotary_mat_tt,
         program_config=ROT_MAT_MM_PROGCFG,
-        output_mem_config=ROT_MAT_MM_OUTPUT_MEMCFG,
+        memory_config=ROT_MAT_MM_OUTPUT_MEMCFG,
         compute_kernel_config=ROT_MAT_COMPUTE_KERNEL_CONFIG
         # [seqlen, n_heads, bsz, head_dim]  # [1, 1, head_dim, head_dim]  => [seqlen, n_heads, bsz, head_dim]
     )
-    key_tt = ttl.operations.primary.matmul(
+    key_tt = ttnn.matmul(
         key_tt,
         rotary_mat_tt,
         program_config=ROT_MAT_MM_PROGCFG,
-        output_mem_config=ROT_MAT_MM_OUTPUT_MEMCFG,
+        memory_config=ROT_MAT_MM_OUTPUT_MEMCFG,
         compute_kernel_config=ROT_MAT_COMPUTE_KERNEL_CONFIG
         # [seqlen, 1, bsz, head_dim]  # [1, 1, head_dim, head_dim]  => [seqlen, 1, bsz, head_dim]
     )
@@ -447,19 +447,19 @@ def run_test_rotary_matmul4(
     rotary_mat_tt = torch2tt_tensor(rotary_mat, tt_device=None).to(device=devices[0], mem_config=ROT_MAT_MM_IN1_MEMCFG)
 
     # tt operation
-    query_tt = ttl.operations.primary.matmul(
+    query_tt = ttnn.matmul(
         query_tt,
         rotary_mat_tt,
         program_config=ROT_MAT_MM_PROGCFG,
-        output_mem_config=ROT_MAT_MM_OUTPUT_MEMCFG,
+        memory_config=ROT_MAT_MM_OUTPUT_MEMCFG,
         compute_kernel_config=ROT_MAT_COMPUTE_KERNEL_CONFIG
         # [seqlen, n_heads, bsz, head_dim]  # [1, 1, head_dim, head_dim]  => [seqlen, n_heads, bsz, head_dim]
     )
-    key_tt = ttl.operations.primary.matmul(
+    key_tt = ttnn.matmul(
         key_tt,
         rotary_mat_tt,
         program_config=ROT_MAT_MM_PROGCFG,
-        output_mem_config=ROT_MAT_MM_OUTPUT_MEMCFG,
+        memory_config=ROT_MAT_MM_OUTPUT_MEMCFG,
         compute_kernel_config=ROT_MAT_COMPUTE_KERNEL_CONFIG
         # [seqlen, 1, bsz, head_dim]  # [1, 1, head_dim, head_dim]  => [seqlen, 1, bsz, head_dim]
     )

--- a/models/demos/t3000/llama2_70b/tt/llama_mlp_galaxy.py
+++ b/models/demos/t3000/llama2_70b/tt/llama_mlp_galaxy.py
@@ -237,12 +237,12 @@ class TtLlamaMLP_galaxy(nn.Module):
             for device_id in FF1_group:
                 # logger.info(f"FF1 matmul on device {device_id} for chips {FF1_group}")
                 w1_4chips.append(
-                    tt_lib.operations.primary.matmul(
+                    ttnn.matmul(
                         x[device_id],
                         self.w1_list[device_id],
                         program_config=self.model_config["PADDED_FF1_MM_PROGCFG"],
-                        output_mem_config=self.model_config["WIDTH_SHARDED_MEMCFG"],
-                        output_dtype=self.model_config["PADDED_FF1_MM_OUTPUT_DTYPE"],
+                        memory_config=self.model_config["WIDTH_SHARDED_MEMCFG"],
+                        dtype=self.model_config["PADDED_FF1_MM_OUTPUT_DTYPE"],
                         compute_kernel_config=self.model_config["COMPUTE_KERNEL_CONFIG"],
                     )
                 )
@@ -269,12 +269,12 @@ class TtLlamaMLP_galaxy(nn.Module):
             w3_4chips = []
             for device_id in FF3_group:
                 w3_4chips.append(
-                    tt_lib.operations.primary.matmul(
+                    ttnn.matmul(
                         x[device_id],
                         self.w3_list[device_id],
                         program_config=self.model_config["PADDED_FF3_MM_PROGCFG"],
-                        output_mem_config=self.model_config["WIDTH_SHARDED_MEMCFG"],
-                        output_dtype=self.model_config["PADDED_FF3_MM_OUTPUT_DTYPE"],
+                        memory_config=self.model_config["WIDTH_SHARDED_MEMCFG"],
+                        dtype=self.model_config["PADDED_FF3_MM_OUTPUT_DTYPE"],
                         compute_kernel_config=self.model_config["COMPUTE_KERNEL_CONFIG"],
                     )
                 )
@@ -334,12 +334,12 @@ class TtLlamaMLP_galaxy(nn.Module):
             for j in range(len(hidden_states_32chips[i])):
                 device_id = self.FF2_groups[i][j]
                 # logger.info(f"FF2 matmul on device {device_id} for chips {self.FF2_groups[i]}")
-                hidden_states_32chips[i][j] = tt_lib.operations.primary.matmul(
+                hidden_states_32chips[i][j] = ttnn.matmul(
                     hidden_states_32chips[i][j],
                     self.w2_list[device_id],
                     program_config=self.model_config["PADDED_FF2_MM_PROGCFG"],
-                    output_mem_config=self.model_config["WIDTH_SHARDED_MEMCFG"],
-                    output_dtype=self.model_config["PADDED_FF2_MM_OUTPUT_DTYPE"],
+                    memory_config=self.model_config["WIDTH_SHARDED_MEMCFG"],
+                    dtype=self.model_config["PADDED_FF2_MM_OUTPUT_DTYPE"],
                     compute_kernel_config=self.model_config["COMPUTE_KERNEL_CONFIG"],
                 )
 

--- a/models/demos/t3000/llama2_70b/tt/llama_mlp_optimized.py
+++ b/models/demos/t3000/llama2_70b/tt/llama_mlp_optimized.py
@@ -143,12 +143,12 @@ class TtLlamaMLP_optimized:
             num_links=self.model_config["ALL_GATHER_NUM_LINKS"],
         )
 
-        hidden_states = tt_lib.operations.primary.matmul(
+        hidden_states = ttnn.matmul(
             hidden_states,
             self.w2,
             program_config=self.model_config["PADDED_FF2_MM_PROGCFG"],
             compute_kernel_config=self.model_config["COMPUTE_KERNEL_FP16_ACC_CONFIG"],
-            output_dtype=self.model_config["BFLOAT16_DTYPE"],
+            dtype=self.model_config["BFLOAT16_DTYPE"],
         )
 
         # Prefill Reshape fix (reverse)

--- a/models/demos/t3000/llama2_70b/tt/llama_mlp_optimized.py
+++ b/models/demos/t3000/llama2_70b/tt/llama_mlp_optimized.py
@@ -116,22 +116,20 @@ class TtLlamaMLP_optimized:
         batch_dim = 1 if seq_len < max_mm_seq_len else seq_len // max_mm_seq_len  # Find the division factor
         x = ttnn.reshape(x, (1, batch_dim, seq_len // batch_dim, self.hidden_size))
 
-        w1_out = tt_lib.operations.primary.matmul(
+        w1_out = ttnn.matmul(
             x,
             self.w1,
             program_config=self.model_config["PADDED_FF1_MM_PROGCFG"],
-            # output_mem_config=self.model_config["MLP_BLOCK_SHARDED_MEMCFG"],
             compute_kernel_config=self.model_config["COMPUTE_KERNEL_CONFIG_LOFI"],
-            output_dtype=self.model_config["BFLOAT16_DTYPE"],
+            dtype=self.model_config["BFLOAT16_DTYPE"],
         )
 
-        w3_out = tt_lib.operations.primary.matmul(
+        w3_out = ttnn.matmul(
             x,
             self.w3,
             program_config=self.model_config["PADDED_FF3_MM_PROGCFG"],
-            # output_mem_config=self.model_config["MLP_BLOCK_SHARDED_MEMCFG"],
             compute_kernel_config=self.model_config["COMPUTE_KERNEL_CONFIG_LOFI"],
-            output_dtype=self.model_config["BFLOAT16_DTYPE"],
+            dtype=self.model_config["BFLOAT16_DTYPE"],
         )
         x.deallocate(True)
 
@@ -161,19 +159,19 @@ class TtLlamaMLP_optimized:
     def decode_forward(self, x: List[tt_lib.tensor.Tensor]) -> List[tt_lib.tensor.Tensor]:
         hidden_states = []
 
-        w1_out = tt_lib.operations.primary.matmul_1d(
+        w1_out = ttnn.matmul(
             x,
             self.w1,
             program_config=self.model_config["PADDED_FF1_MM_PROGCFG"],
-            output_mem_config=self.model_config["WIDTH_SHARDED_MEMCFG"],
+            memory_config=self.model_config["WIDTH_SHARDED_MEMCFG"],
             compute_kernel_config=self.model_config["COMPUTE_KERNEL_CONFIG_LOFI"],
         )
 
-        w3_out = tt_lib.operations.primary.matmul_1d(
+        w3_out = ttnn.matmul(
             x,
             self.w3,
             program_config=self.model_config["PADDED_FF3_MM_PROGCFG"],
-            output_mem_config=self.model_config["WIDTH_SHARDED_MEMCFG"],
+            memory_config=self.model_config["WIDTH_SHARDED_MEMCFG"],
             compute_kernel_config=self.model_config["COMPUTE_KERNEL_CONFIG_LOFI"],
         )
         x.deallocate(True)
@@ -195,12 +193,11 @@ class TtLlamaMLP_optimized:
             memory_config=self.model_config["PADDED_MLP_ALL_GATHER_OUTPUT_MEMCFG"],
         )
 
-        hidden_states = tt_lib.operations.primary.matmul_1d(
+        hidden_states = ttnn.matmul(
             hidden_states,
             self.w2,
             program_config=self.model_config["PADDED_FF2_MM_PROGCFG"],
-            output_mem_config=self.model_config["WIDTH_SHARDED_MEMCFG"],
-            # output_dtype=self.model_config["BFP8_DTYPE"],
+            memory_config=self.model_config["WIDTH_SHARDED_MEMCFG"],
             compute_kernel_config=self.model_config["COMPUTE_KERNEL_CONFIG"],
         )
         return hidden_states

--- a/models/demos/t3000/llama2_70b/tt/llama_model_optimized.py
+++ b/models/demos/t3000/llama2_70b/tt/llama_model_optimized.py
@@ -343,7 +343,7 @@ class TtLlamaModel_optimized:
         )
 
         ### Each device does an LM head fracture
-        lm_head_out = tt.matmul(
+        lm_head_out = ttnn.matmul(
             norm_out_replicated,
             self.lm_head,
             program_config=self.model_config["LLAMA3_LM_HEAD_MM_PROGCFG"]

--- a/models/demos/t3000/llama2_70b/tt/llama_model_optimized.py
+++ b/models/demos/t3000/llama2_70b/tt/llama_model_optimized.py
@@ -343,14 +343,14 @@ class TtLlamaModel_optimized:
         )
 
         ### Each device does an LM head fracture
-        lm_head_out = tt_lib.operations.primary.matmul_1d(
+        lm_head_out = tt.matmul(
             norm_out_replicated,
             self.lm_head,
             program_config=self.model_config["LLAMA3_LM_HEAD_MM_PROGCFG"]
             if self.llama3
             else self.model_config["LM_HEAD_MM_PROGCFG"],
-            output_mem_config=self.model_config["DRAM_MEMCFG"],
-            output_dtype=ttnn.bfloat16,
+            memory_config=self.model_config["DRAM_MEMCFG"],
+            dtype=ttnn.bfloat16,
             compute_kernel_config=self.model_config["COMPUTE_KERNEL_CONFIG"],
         )
         norm_out_replicated.deallocate(True)
@@ -447,11 +447,11 @@ class TtLlamaModel_optimized:
         batch_dim = 1 if seq_len < max_mm_seq_len else seq_len // max_mm_seq_len  # Find the division factor
         norm_out_replicated = ttnn.reshape(norm_out_replicated, (1, batch_dim, seq_len // batch_dim, -1))
 
-        lm_head_out = tt_lib.operations.primary.matmul(
+        lm_head_out = ttnn.matmul(
             norm_out_replicated,
             self.lm_head,
             program_config=self.model_config["LM_HEAD_MM_PROGCFG"],
-            output_mem_config=self.model_config["DRAM_MEMCFG"],
+            memory_config=self.model_config["DRAM_MEMCFG"],
             compute_kernel_config=self.model_config["COMPUTE_KERNEL_FP16_ACC_CONFIG"],
         )
         norm_out_replicated.deallocate(True)

--- a/models/demos/t3000/llama2_70b/tt/model_config.py
+++ b/models/demos/t3000/llama2_70b/tt/model_config.py
@@ -440,7 +440,7 @@ def get_model_config(
             False,
         ),
     )
-    model_config["ROT_MAT_MM_PROGCFG"] = ttl.operations.primary.MatmulMultiCoreReuseProgramConfig(
+    model_config["ROT_MAT_MM_PROGCFG"] = ttnn.MatmulMultiCoreReuseProgramConfig(
         compute_with_storage_grid_size=[8, 4],
         in0_block_w=4,  # 128 // TILE_SIZE (dynamic)
         out_subblock_h=1,

--- a/models/experimental/bert_large_perf/tt/ffn.py
+++ b/models/experimental/bert_large_perf/tt/ffn.py
@@ -8,6 +8,7 @@ from loguru import logger
 import torch
 from transformers import BertForQuestionAnswering
 import tt_lib as ttl
+import ttnn
 from tt_lib.utils import pad_activation, pad_weight, print_diff_argmax
 from models.utility_functions import comp_pcc, comp_allclose
 
@@ -22,7 +23,7 @@ def feed_forward(ffn_dim, hidden_dim, ff1_weighta, ff1_biasa, ff2_weighta, ff2_b
     # output = [1, 9, 384, 4096]
     def op13_MM_bias_gelu(activation, ff1_weighta, ff1_biasa):
         # profiler.start("___op13_MM_bias_gelu")
-        output = ttl.tensor.matmul(activation, ff1_weighta)
+        output = ttnn.matmul(activation, ff1_weighta)
         output_plus_bias = ttl.tensor.bcast(output, ff1_biasa, ttl.tensor.BcastOpMath.ADD, ttl.tensor.BcastOpDim.H)
         output_plus_bias_act = ttl.tensor.gelu(output_plus_bias)
         # profiler.end("___op13_MM_bias_gelu")
@@ -34,7 +35,7 @@ def feed_forward(ffn_dim, hidden_dim, ff1_weighta, ff1_biasa, ff2_weighta, ff2_b
     # output = [1, 9, 384, 1024]
     def op14_MM_bias(activation, ff2_weighta, ff2_biasa):
         # profiler.start("___op14_MM_bias")
-        output = ttl.tensor.matmul(activation, ff2_weighta)
+        output = ttnn.matmul(activation, ff2_weighta)
         output_plus_bias = ttl.tensor.bcast(output, ff2_biasa, ttl.tensor.BcastOpMath.ADD, ttl.tensor.BcastOpDim.H)
         # profiler.end("___op14_MM_bias")
 

--- a/models/experimental/bert_large_perf/tt/mha.py
+++ b/models/experimental/bert_large_perf/tt/mha.py
@@ -11,6 +11,7 @@ from transformers import BertForQuestionAnswering
 import numpy as np
 
 import tt_lib as ttl
+import ttnn
 from tt_lib.utils import pad_activation, pad_weight, print_diff_argmax
 from tt_lib.fused_ops.softmax import softmax
 from models.utility_functions import (
@@ -106,7 +107,7 @@ def mha(qw, qb, kw, kb, vw, vb, hidden_dim, num_heads, device):
 
     def op1_qkv_fused(activation, qkv_weight, qkv_bias):
         # profiler.start("___op1_qkv_fused")
-        qkv = ttl.tensor.matmul(activation, qkv_weight)
+        qkv = ttnn.matmul(activation, qkv_weight)
         qkv = ttl.tensor.bcast(qkv, qkv_bias, ttl.tensor.BcastOpMath.ADD, ttl.tensor.BcastOpDim.H)
         # profiler.end("___op1_qkv_fused")
 

--- a/models/experimental/bloom/tt/bloom_qa.py
+++ b/models/experimental/bloom/tt/bloom_qa.py
@@ -4,6 +4,7 @@
 
 import torch
 import tt_lib
+import ttnn
 import models.experimental.bloom.bloom_utils as bloom_utils
 import models.experimental.bloom.tt.bloom_model as bloom_model
 from typing import Optional
@@ -62,7 +63,7 @@ class TtBloomForQuestionAnswering:
 
         sequence_output = outputs[0]
 
-        logits = tt_lib.tensor.matmul(sequence_output, self.qa_outputs_weight, output_mem_config=self.mem_config)
+        logits = ttnn.matmul(sequence_output, self.qa_outputs_weight, output_mem_config=self.mem_config)
         logits = tt_lib.tensor.bcast(
             logits,
             self.qa_outputs_bias,

--- a/models/experimental/convnet_mnist/tt/convnet_mnist.py
+++ b/models/experimental/convnet_mnist/tt/convnet_mnist.py
@@ -4,6 +4,7 @@
 
 import torch
 import tt_lib
+import ttnn
 
 from models.experimental.convnet_mnist.reference.convnet import ConvNet
 from tt_lib.fallback_ops import fallback_ops
@@ -52,7 +53,7 @@ class TtConvNet(torch.nn.Module):
         last_dim_size = out.get_legacy_shape()[-1] * out.get_legacy_shape()[-2] * out.get_legacy_shape()[-3]
         out = fallback_ops.reshape(out, out.get_legacy_shape()[0], 1, 1, last_dim_size)
 
-        out = tt_lib.tensor.matmul(out, self.linear1_weights)
+        out = ttnn.matmul(out, self.linear1_weights)
         out = tt_lib.tensor.bcast(
             out,
             self.linear1_bias,
@@ -60,7 +61,7 @@ class TtConvNet(torch.nn.Module):
             tt_lib.tensor.BcastOpDim.H,
         )
         out = tt_lib.tensor.relu(out)
-        out = tt_lib.tensor.matmul(out, self.linear2_weights)
+        out = ttnn.matmul(out, self.linear2_weights)
         out = tt_lib.tensor.bcast(
             out,
             self.linear2_bias,

--- a/models/experimental/efficientnet/tt/efficientnet_model.py
+++ b/models/experimental/efficientnet/tt/efficientnet_model.py
@@ -175,7 +175,7 @@ class TtEfficientNet(torch.nn.Module):
         # tt_lib.tensor.reshape won't work here since input tensor is of shape [1, n, 1, 1]
         x = tt_lib.fallback_ops.reshape(x, x.get_legacy_shape()[0], 1, 1, last_shape)
 
-        x = tt_lib.tensor.matmul(x, self.classifier_weight)
+        x = ttnn.matmul(x, self.classifier_weight)
 
         if self.classifier_bias is not None:
             x = ttnn.add(x, self.classifier_bias)

--- a/models/experimental/falcon_40b/tests/test_reproduce_nd_matmul.py
+++ b/models/experimental/falcon_40b/tests/test_reproduce_nd_matmul.py
@@ -73,12 +73,12 @@ def test_reproduce_matmul_1d(
     )
 
     # First run for a reference output
-    out = ttl.operations.primary.matmul_1d(
+    out = ttnn.matmul(
         a_t,
         b_t,
         program_config=program_config,
-        output_mem_config=out_mem_config,
-        output_dtype=out_dtype,
+        memory_config=out_mem_config,
+        dtype=out_dtype,
         compute_kernel_config=compute_config,
     )
     ref_out = tt2torch_tensor(out)
@@ -89,12 +89,12 @@ def test_reproduce_matmul_1d(
     for _ in range(loop_count):
         out.deallocate(True)
 
-        out = ttl.operations.primary.matmul_1d(
+        out = ttnn.matmul(
             a_t,
             b_t,
             program_config=program_config,
-            output_mem_config=out_mem_config,
-            output_dtype=out_dtype,
+            memory_config=out_mem_config,
+            dtype=out_dtype,
             compute_kernel_config=compute_config,
         )
 
@@ -174,12 +174,12 @@ def test_reproduce_matmul_2d(
     )
 
     # First run for a reference output
-    out = ttl.operations.primary.matmul(
+    out = ttnn.matmul(
         a_t,
         b_t,
         program_config=program_config,
-        output_mem_config=out_mem_config,
-        output_dtype=out_dtype,
+        memory_config=out_mem_config,
+        dtype=out_dtype,
         compute_kernel_config=compute_config,
     )
     ref_out = tt2torch_tensor(out)
@@ -190,12 +190,12 @@ def test_reproduce_matmul_2d(
     for _ in range(loop_count):
         out.deallocate(True)
 
-        out = ttl.operations.primary.matmul(
+        out = ttnn.matmul(
             a_t,
             b_t,
             program_config=program_config,
-            output_mem_config=out_mem_config,
-            output_dtype=out_dtype,
+            memory_config=out_mem_config,
+            dtype=out_dtype,
             compute_kernel_config=compute_config,
         )
 

--- a/models/experimental/lenet/tt/lenet.py
+++ b/models/experimental/lenet/tt/lenet.py
@@ -3,6 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import tt_lib
+import ttnn
 import torch
 import torch.nn as nn
 
@@ -133,7 +134,7 @@ class TtLeNet5(nn.Module):
 
         # fc
         weight_T = tt_lib.tensor.transpose(self.fc_weights, -2, -1)
-        output = tt_lib.tensor.matmul(out, weight_T)
+        output = ttnn.matmul(out, weight_T)
         out = tt_lib.tensor.bcast(
             output,
             self.fc_bias,
@@ -145,7 +146,7 @@ class TtLeNet5(nn.Module):
 
         # fc1
         weight_T = tt_lib.tensor.transpose(self.fc1_weights, -2, -1)
-        output = tt_lib.tensor.matmul(out, weight_T)
+        output = ttnn.matmul(out, weight_T)
         out = tt_lib.tensor.bcast(
             output,
             self.fc1_bias,
@@ -158,7 +159,7 @@ class TtLeNet5(nn.Module):
 
         # fc2
         weight_T = tt_lib.tensor.transpose(self.fc2_weights, -2, -1)
-        output = tt_lib.tensor.matmul(out, weight_T)
+        output = ttnn.matmul(out, weight_T)
         out = tt_lib.tensor.bcast(
             output,
             self.fc2_bias,

--- a/models/experimental/llama2_70b/tests/perf/ivan_ff.py
+++ b/models/experimental/llama2_70b/tests/perf/ivan_ff.py
@@ -31,11 +31,10 @@ class TtFF1:
 
     def __call__(self, x, prog_config):
         # Assume interleaved input
-        ff_out = tt_lib.operations.primary.matmul_1d(
+        ff_out = ttnn.matmul(
             x,
             self.weight,
             fp32_dest_acc_en=USE_ACC,
-            packer_l1_acc=USE_ACC,
             program_config=prog_config,
             output_mem_config=WIDTH_SHARDED_MEMCFG,
             output_dtype=BFP8_DTYPE,

--- a/models/experimental/llama2_70b/tests/perf/test_bmm.py
+++ b/models/experimental/llama2_70b/tests/perf/test_bmm.py
@@ -75,12 +75,12 @@ class TT_bmm:
             sharded_mem_config=q_mem_config,
         )
 
-        out = tt_lib.operations.primary.matmul(
+        out = ttnn.matmul(
             q,
             k,
             program_config=prog_config,
-            output_mem_config=output_config,
-            output_dtype=ttl.tensor.DataType.BFLOAT16,
+            memory_config=output_config,
+            dtype=ttl.tensor.DataType.BFLOAT16,
         )
 
         return out

--- a/models/experimental/llama2_70b/tests/perf/test_ff1.py
+++ b/models/experimental/llama2_70b/tests/perf/test_ff1.py
@@ -36,14 +36,12 @@ class TtFF1:
 
     def __call__(self, x, prog_config, output_config):
         # Assume interleaved input
-        ff_out = tt_lib.operations.primary.matmul_1d(
+        ff_out = ttnn.matmul(
             x,
             self.weight,
-            fp32_dest_acc_en=USE_ACC,
-            packer_l1_acc=USE_ACC,
             program_config=prog_config,
-            output_mem_config=output_config,
-            output_dtype=self.model_config["FF1_MM_OUTPUT_DTYPE"],
+            memory_config=output_config,
+            dtype=self.model_config["FF1_MM_OUTPUT_DTYPE"],
         )
         x.deallocate()
 

--- a/models/experimental/llama2_70b/tests/perf/test_llama_matmul_perf.py
+++ b/models/experimental/llama2_70b/tests/perf/test_llama_matmul_perf.py
@@ -56,12 +56,12 @@ class Decode_FF1:
         )
 
     def __call__(self, x):
-        ff_out = tt_lib.operations.primary.matmul_1d(
+        ff_out = ttnn.matmul(
             x,
             self.weight,
             program_config=self.prog_config,
-            output_mem_config=WIDTH_SHARDED_MEMCFG,
-            output_dtype=BFP8_DTYPE,
+            memory_config=WIDTH_SHARDED_MEMCFG,
+            dtype=BFP8_DTYPE,
             compute_kernel_config=COMPUTE_KERNEL_CONFIG,
         )
 
@@ -91,12 +91,12 @@ class Decode_FF2:
 
     def __call__(self, x):
         # Assume interleaved input
-        ff_out = tt_lib.operations.primary.matmul_1d(
+        ff_out = ttnn.matmul(
             x,
             self.weight,
             program_config=self.prog_config,
-            output_mem_config=WIDTH_SHARDED_MEMCFG,
-            output_dtype=BFP8_DTYPE,
+            memory_config=WIDTH_SHARDED_MEMCFG,
+            dtype=BFP8_DTYPE,
             compute_kernel_config=COMPUTE_KERNEL_CONFIG,
         )
 
@@ -162,20 +162,20 @@ class Prefill_MLP_128:
 
     def __call__(self, x, x_allgather):
         # Assume interleaved input
-        ff1_out = tt_lib.operations.primary.matmul(
+        ff1_out = ttnn.matmul(
             x,
             self.w1,
             program_config=self.prog_config1,
-            output_dtype=BFP8_DTYPE,
-            output_mem_config=WIDTH_SHARDED_MEMCFG,
+            dtype=BFP8_DTYPE,
+            memory_config=WIDTH_SHARDED_MEMCFG,
             compute_kernel_config=COMPUTE_KERNEL_FP16_CONFIG,
         )
-        ff3_out = tt_lib.operations.primary.matmul(
+        ff3_out = ttnn.matmul(
             x,
             self.w3,
             program_config=self.prog_config3,
-            output_dtype=BFP8_DTYPE,
-            output_mem_config=WIDTH_SHARDED_MEMCFG,
+            dtype=BFP8_DTYPE,
+            memory_config=WIDTH_SHARDED_MEMCFG,
             compute_kernel_config=COMPUTE_KERNEL_FP16_CONFIG,
         )
 
@@ -187,12 +187,12 @@ class Prefill_MLP_128:
 
         out.deallocate()
         x.deallocate()
-        ff2_out = tt_lib.operations.primary.matmul(
+        ff2_out = ttnn.matmul(
             x_allgather,
             self.w2,
             program_config=self.prog_config2,
-            output_dtype=BFP8_DTYPE,
-            output_mem_config=WIDTH_SHARDED_MEMCFG,
+            dtype=BFP8_DTYPE,
+            memory_config=WIDTH_SHARDED_MEMCFG,
             compute_kernel_config=COMPUTE_KERNEL_FP16_CONFIG,
         )
         return out
@@ -341,18 +341,18 @@ class Prefill_MLP_2k:
 
     def __call__(self, x, x_allgather):
         # Assume interleaved input
-        ff1_out = tt_lib.operations.primary.matmul(
+        ff1_out = ttnn.matmul(
             x,
             self.w1,
             program_config=self.prog_config1,
-            output_mem_config=self.block_sharded,
+            memory_config=self.block_sharded,
             compute_kernel_config=COMPUTE_KERNEL_FP16_CONFIG,
         )
-        ff3_out = tt_lib.operations.primary.matmul(
+        ff3_out = ttnn.matmul(
             x,
             self.w3,
             program_config=self.prog_config3,
-            output_mem_config=self.block_sharded,
+            memory_config=self.block_sharded,
             compute_kernel_config=COMPUTE_KERNEL_FP16_CONFIG,
         )
 
@@ -361,7 +361,7 @@ class Prefill_MLP_2k:
         ff3_out.deallocate()
         out.deallocate()
 
-        ff2_out = tt_lib.operations.primary.matmul(
+        ff2_out = ttnn.matmul(
             x_allgather,
             self.w2,
             program_config=self.prog_config2,

--- a/models/experimental/llama2_70b/tests/unit_tests/test_attn_sdpa.py
+++ b/models/experimental/llama2_70b/tests/unit_tests/test_attn_sdpa.py
@@ -118,7 +118,7 @@ class TtLlamaSDPA(torch.nn.Module):
             # output_mem_config=self.model_config["CONCAT_HEADS_OUTPUT_MEMCFG"],
         )  # seqlen, 1, batch, hidden_size
 
-        attb_output = tt_lib.tensor.matmul(
+        attb_output = ttnn.matmul(
             attn_output,
             self.wo,
         )  # seqlen, 1, batch, hidden_size

--- a/models/experimental/llama2_70b/tests/unit_tests/test_qkv_matmul.py
+++ b/models/experimental/llama2_70b/tests/unit_tests/test_qkv_matmul.py
@@ -83,8 +83,6 @@ class TtLlamaQKV(torch.nn.Module):
                     xs[i],
                     self.qkv_list[i],
                     program_config=self.model_config["FUSED_QKV_MM_PROGCFG"],
-                    # memory_config=self.model_config["FUSED_QKV_MM_OUTPUT_MEMCFG"],
-                    # dtype=self.model_config["FUSED_QKV_MM_OUTPUT_DTYPE"],
                     compute_kernel_config=self.model_config["COMPUTE_KERNEL_CONFIG"],
                 )
             )

--- a/models/experimental/llama2_70b/tests/unit_tests/test_qkv_matmul.py
+++ b/models/experimental/llama2_70b/tests/unit_tests/test_qkv_matmul.py
@@ -79,12 +79,12 @@ class TtLlamaQKV(torch.nn.Module):
         fused_query_key_value = []
         for i in range(len(xs)):
             fused_query_key_value.append(
-                tt_lib.operations.primary.matmul(
+                ttnn.matmul(
                     xs[i],
                     self.qkv_list[i],
                     program_config=self.model_config["FUSED_QKV_MM_PROGCFG"],
-                    # output_mem_config=self.model_config["FUSED_QKV_MM_OUTPUT_MEMCFG"],
-                    # output_dtype=self.model_config["FUSED_QKV_MM_OUTPUT_DTYPE"],
+                    # memory_config=self.model_config["FUSED_QKV_MM_OUTPUT_MEMCFG"],
+                    # dtype=self.model_config["FUSED_QKV_MM_OUTPUT_DTYPE"],
                     compute_kernel_config=self.model_config["COMPUTE_KERNEL_CONFIG"],
                 )
             )

--- a/models/experimental/llama2_70b/tests/unit_tests/test_reshape_rotary.py
+++ b/models/experimental/llama2_70b/tests/unit_tests/test_reshape_rotary.py
@@ -87,7 +87,7 @@ class TtLlamaRotary(torch.nn.Module):
         xq = tt_lib.tensor.pad(xq, [1, 32, 128, self.head_dim], [0, 0, 0, 0], 0.0)
         xq = tt_lib.tensor.transpose(xq, 1, 2)
 
-        xq = tt_lib.operations.primary.matmul(
+        xq = ttnn.matmul(
             xq,
             rot_mat,
             # compute_kernel_config=self.model_config["ROT_MAT_COMPUTE_KERNEL_CONFIG"]
@@ -104,7 +104,7 @@ class TtLlamaRotary(torch.nn.Module):
 
         xk = tt_lib.tensor.transpose(xk, 1, 2)
 
-        xk = tt_lib.operations.primary.matmul(
+        xk = ttnn.matmul(
             xk,
             rot_mat,
             # compute_kernel_config=self.model_config["ROT_MAT_COMPUTE_KERNEL_CONFIG"],

--- a/models/experimental/llama2_70b/tests/unit_tests/test_rotary_matmul.py
+++ b/models/experimental/llama2_70b/tests/unit_tests/test_rotary_matmul.py
@@ -101,18 +101,18 @@ def run_test_rotary_matmul1(
     rotary_mat_tt = torch2tt_tensor(rotary_mat, devices[0])
 
     # tt operation
-    query_tt = ttl.operations.primary.matmul(
+    query_tt = ttnn.matmul(
         query_tt,
         rotary_mat_tt,
         program_config=ROT_MAT_Q_MM_PROGCFG,
-        output_mem_config=ROT_MAT_Q_MM_OUTPUT_MEMCFG,
+        memory_config=ROT_MAT_Q_MM_OUTPUT_MEMCFG,
         compute_kernel_config=ROT_MAT_COMPUTE_KERNEL_CONFIG
         # [seqlen, n_heads, bsz, head_dim]  # [1, 1, head_dim, head_dim]  => [seqlen, n_heads, bsz, head_dim]
     )
-    key_tt = ttl.operations.primary.matmul(
+    key_tt = ttnn.matmul(
         key_tt,
         rotary_mat_tt,
-        output_mem_config=L1_MEMCFG,
+        memory_config=L1_MEMCFG,
         compute_kernel_config=ROT_MAT_COMPUTE_KERNEL_CONFIG
         # [seqlen, 1, bsz, head_dim]  # [1, 1, head_dim, head_dim]  => [seqlen, 1, bsz, head_dim]
     )
@@ -214,19 +214,19 @@ def run_test_rotary_matmul2(
     rotary_mat_tt = torch2tt_tensor(rotary_mat, devices[0])
 
     # tt operation
-    query_tt = ttl.operations.primary.matmul(
+    query_tt = ttnn.matmul(
         query_tt,
         rotary_mat_tt,
         program_config=ROT_MAT_MM_PROGCFG,
-        output_mem_config=ROT_MAT_MM_OUTPUT_MEMCFG,
+        memory_config=ROT_MAT_MM_OUTPUT_MEMCFG,
         compute_kernel_config=ROT_MAT_COMPUTE_KERNEL_CONFIG
         # [seqlen, n_heads, bsz, head_dim]  # [1, 1, head_dim, head_dim]  => [seqlen, n_heads, bsz, head_dim]
     )
-    key_tt = ttl.operations.primary.matmul(
+    key_tt = ttnn.matmul(
         key_tt,
         rotary_mat_tt,
         program_config=ROT_MAT_MM_PROGCFG,
-        output_mem_config=ROT_MAT_MM_OUTPUT_MEMCFG,
+        memory_config=ROT_MAT_MM_OUTPUT_MEMCFG,
         compute_kernel_config=ROT_MAT_COMPUTE_KERNEL_CONFIG
         # [seqlen, 1, bsz, head_dim]  # [1, 1, head_dim, head_dim]  => [seqlen, 1, bsz, head_dim]
     )
@@ -325,19 +325,19 @@ def run_test_rotary_matmul3(
     rotary_mat_tt = torch2tt_tensor(rotary_mat, devices[0])
 
     # tt operation
-    query_tt = ttl.operations.primary.matmul(
+    query_tt = ttnn.matmul(
         query_tt,
         rotary_mat_tt,
         program_config=ROT_MAT_MM_PROGCFG,
-        output_mem_config=ROT_MAT_MM_OUTPUT_MEMCFG,
+        memory_config=ROT_MAT_MM_OUTPUT_MEMCFG,
         compute_kernel_config=ROT_MAT_COMPUTE_KERNEL_CONFIG
         # [seqlen, n_heads, bsz, head_dim]  # [1, 1, head_dim, head_dim]  => [seqlen, n_heads, bsz, head_dim]
     )
-    key_tt = ttl.operations.primary.matmul(
+    key_tt = ttnn.matmul(
         key_tt,
         rotary_mat_tt,
         program_config=ROT_MAT_MM_PROGCFG,
-        output_mem_config=ROT_MAT_MM_OUTPUT_MEMCFG,
+        memory_config=ROT_MAT_MM_OUTPUT_MEMCFG,
         compute_kernel_config=ROT_MAT_COMPUTE_KERNEL_CONFIG
         # [seqlen, 1, bsz, head_dim]  # [1, 1, head_dim, head_dim]  => [seqlen, 1, bsz, head_dim]
     )
@@ -447,19 +447,19 @@ def run_test_rotary_matmul4(
     rotary_mat_tt = torch2tt_tensor(rotary_mat, tt_device=None).to(device=devices[0], mem_config=ROT_MAT_MM_IN1_MEMCFG)
 
     # tt operation
-    query_tt = ttl.operations.primary.matmul(
+    query_tt = ttnn.matmul(
         query_tt,
         rotary_mat_tt,
         program_config=ROT_MAT_MM_PROGCFG,
-        output_mem_config=ROT_MAT_MM_OUTPUT_MEMCFG,
+        memory_config=ROT_MAT_MM_OUTPUT_MEMCFG,
         compute_kernel_config=ROT_MAT_COMPUTE_KERNEL_CONFIG
         # [seqlen, n_heads, bsz, head_dim]  # [1, 1, head_dim, head_dim]  => [seqlen, n_heads, bsz, head_dim]
     )
-    key_tt = ttl.operations.primary.matmul(
+    key_tt = ttnn.matmul(
         key_tt,
         rotary_mat_tt,
         program_config=ROT_MAT_MM_PROGCFG,
-        output_mem_config=ROT_MAT_MM_OUTPUT_MEMCFG,
+        memory_config=ROT_MAT_MM_OUTPUT_MEMCFG,
         compute_kernel_config=ROT_MAT_COMPUTE_KERNEL_CONFIG
         # [seqlen, 1, bsz, head_dim]  # [1, 1, head_dim, head_dim]  => [seqlen, 1, bsz, head_dim]
     )

--- a/models/experimental/llama2_70b/tt/llama_mlp_galaxy.py
+++ b/models/experimental/llama2_70b/tt/llama_mlp_galaxy.py
@@ -269,7 +269,7 @@ class TtLlamaMLP_galaxy(nn.Module):
             w3_4chips = []
             for device_id in FF3_group:
                 w3_4chips.append(
-                    tt.matmul(
+                    ttnn.matmul(
                         x[device_id],
                         self.w3_list[device_id],
                         program_config=self.model_config["PADDED_FF3_MM_PROGCFG"],

--- a/models/experimental/llama2_70b/tt/llama_mlp_galaxy.py
+++ b/models/experimental/llama2_70b/tt/llama_mlp_galaxy.py
@@ -237,12 +237,12 @@ class TtLlamaMLP_galaxy(nn.Module):
             for device_id in FF1_group:
                 # logger.info(f"FF1 matmul on device {device_id} for chips {FF1_group}")
                 w1_4chips.append(
-                    tt_lib.operations.primary.matmul(
+                    ttnn.matmul(
                         x[device_id],
                         self.w1_list[device_id],
                         program_config=self.model_config["PADDED_FF1_MM_PROGCFG"],
-                        output_mem_config=self.model_config["WIDTH_SHARDED_MEMCFG"],
-                        output_dtype=self.model_config["PADDED_FF1_MM_OUTPUT_DTYPE"],
+                        memory_config=self.model_config["WIDTH_SHARDED_MEMCFG"],
+                        dtype=self.model_config["PADDED_FF1_MM_OUTPUT_DTYPE"],
                         compute_kernel_config=self.model_config["COMPUTE_KERNEL_CONFIG"],
                     )
                 )
@@ -269,12 +269,12 @@ class TtLlamaMLP_galaxy(nn.Module):
             w3_4chips = []
             for device_id in FF3_group:
                 w3_4chips.append(
-                    tt_lib.operations.primary.matmul(
+                    tt.matmul(
                         x[device_id],
                         self.w3_list[device_id],
                         program_config=self.model_config["PADDED_FF3_MM_PROGCFG"],
-                        output_mem_config=self.model_config["WIDTH_SHARDED_MEMCFG"],
-                        output_dtype=self.model_config["PADDED_FF3_MM_OUTPUT_DTYPE"],
+                        memory_config=self.model_config["WIDTH_SHARDED_MEMCFG"],
+                        dtype=self.model_config["PADDED_FF3_MM_OUTPUT_DTYPE"],
                         compute_kernel_config=self.model_config["COMPUTE_KERNEL_CONFIG"],
                     )
                 )
@@ -334,12 +334,12 @@ class TtLlamaMLP_galaxy(nn.Module):
             for j in range(len(hidden_states_32chips[i])):
                 device_id = self.FF2_groups[i][j]
                 # logger.info(f"FF2 matmul on device {device_id} for chips {self.FF2_groups[i]}")
-                hidden_states_32chips[i][j] = tt_lib.operations.primary.matmul(
+                hidden_states_32chips[i][j] = ttnn.matmul(
                     hidden_states_32chips[i][j],
                     self.w2_list[device_id],
                     program_config=self.model_config["PADDED_FF2_MM_PROGCFG"],
-                    output_mem_config=self.model_config["WIDTH_SHARDED_MEMCFG"],
-                    output_dtype=self.model_config["PADDED_FF2_MM_OUTPUT_DTYPE"],
+                    memory_config=self.model_config["WIDTH_SHARDED_MEMCFG"],
+                    dtype=self.model_config["PADDED_FF2_MM_OUTPUT_DTYPE"],
                     compute_kernel_config=self.model_config["COMPUTE_KERNEL_CONFIG"],
                 )
 

--- a/models/experimental/llama2_70b/tt/llama_mlp_optimized.py
+++ b/models/experimental/llama2_70b/tt/llama_mlp_optimized.py
@@ -117,22 +117,22 @@ class TtLlamaMLP_optimized:
         batch_dim = 1 if seq_len < max_mm_seq_len else seq_len // max_mm_seq_len  # Find the division factor
         x = ttnn.reshape(x, (1, batch_dim, seq_len // batch_dim, self.hidden_size))
 
-        w1_out = tt_lib.operations.primary.matmul(
+        w1_out = ttnn.matmul(
             x,
             self.w1,
             program_config=self.model_config["PADDED_FF1_MM_PROGCFG"],
-            # output_mem_config=self.model_config["MLP_BLOCK_SHARDED_MEMCFG"],
+            # memory_config=self.model_config["MLP_BLOCK_SHARDED_MEMCFG"],
             compute_kernel_config=self.model_config["COMPUTE_KERNEL_CONFIG_LOFI"],
-            output_dtype=self.model_config["BFLOAT16_DTYPE"],
+            dtype=self.model_config["BFLOAT16_DTYPE"],
         )
 
-        w3_out = tt_lib.operations.primary.matmul(
+        w3_out = ttnn.matmul(
             x,
             self.w3,
             program_config=self.model_config["PADDED_FF3_MM_PROGCFG"],
-            # output_mem_config=self.model_config["MLP_BLOCK_SHARDED_MEMCFG"],
+            # memory_config=self.model_config["MLP_BLOCK_SHARDED_MEMCFG"],
             compute_kernel_config=self.model_config["COMPUTE_KERNEL_CONFIG_LOFI"],
-            output_dtype=self.model_config["BFLOAT16_DTYPE"],
+            dtype=self.model_config["BFLOAT16_DTYPE"],
         )
         x.deallocate(True)
 
@@ -146,12 +146,12 @@ class TtLlamaMLP_optimized:
             num_links=self.model_config["ALL_GATHER_NUM_LINKS"],
         )
 
-        hidden_states = tt_lib.operations.primary.matmul(
+        hidden_states = ttnn.matmul(
             hidden_states,
             self.w2,
             program_config=self.model_config["PADDED_FF2_MM_PROGCFG"],
             compute_kernel_config=self.model_config["COMPUTE_KERNEL_FP16_ACC_CONFIG"],
-            output_dtype=self.model_config["BFLOAT16_DTYPE"],
+            dtype=self.model_config["BFLOAT16_DTYPE"],
         )
 
         # Prefill Reshape fix (reverse)
@@ -162,19 +162,19 @@ class TtLlamaMLP_optimized:
     def decode_forward(self, x: List[tt_lib.tensor.Tensor]) -> List[tt_lib.tensor.Tensor]:
         hidden_states = []
 
-        w1_out = tt_lib.operations.primary.matmul_1d(
+        w1_out = ttnn.matmul(
             x,
             self.w1,
             program_config=self.model_config["PADDED_FF1_MM_PROGCFG"],
-            output_mem_config=self.model_config["WIDTH_SHARDED_MEMCFG"],
+            memory_config=self.model_config["WIDTH_SHARDED_MEMCFG"],
             compute_kernel_config=self.model_config["COMPUTE_KERNEL_CONFIG_LOFI"],
         )
 
-        w3_out = tt_lib.operations.primary.matmul_1d(
+        w3_out = ttnn.matmul(
             x,
             self.w3,
             program_config=self.model_config["PADDED_FF3_MM_PROGCFG"],
-            output_mem_config=self.model_config["WIDTH_SHARDED_MEMCFG"],
+            memory_config=self.model_config["WIDTH_SHARDED_MEMCFG"],
             compute_kernel_config=self.model_config["COMPUTE_KERNEL_CONFIG_LOFI"],
         )
         x.deallocate(True)
@@ -196,12 +196,12 @@ class TtLlamaMLP_optimized:
             memory_config=self.model_config["PADDED_MLP_ALL_GATHER_OUTPUT_MEMCFG"],
         )
 
-        hidden_states = tt_lib.operations.primary.matmul_1d(
+        hidden_states = ttnn.matmul(
             hidden_states,
             self.w2,
             program_config=self.model_config["PADDED_FF2_MM_PROGCFG"],
-            output_mem_config=self.model_config["WIDTH_SHARDED_MEMCFG"],
-            # output_dtype=self.model_config["BFP8_DTYPE"],
+            mem_config=self.model_config["WIDTH_SHARDED_MEMCFG"],
+            # dtype=self.model_config["BFP8_DTYPE"],
             compute_kernel_config=self.model_config["COMPUTE_KERNEL_CONFIG"],
         )
         return hidden_states

--- a/models/experimental/llama2_70b/tt/llama_mlp_optimized.py
+++ b/models/experimental/llama2_70b/tt/llama_mlp_optimized.py
@@ -121,7 +121,6 @@ class TtLlamaMLP_optimized:
             x,
             self.w1,
             program_config=self.model_config["PADDED_FF1_MM_PROGCFG"],
-            # memory_config=self.model_config["MLP_BLOCK_SHARDED_MEMCFG"],
             compute_kernel_config=self.model_config["COMPUTE_KERNEL_CONFIG_LOFI"],
             dtype=self.model_config["BFLOAT16_DTYPE"],
         )
@@ -130,7 +129,6 @@ class TtLlamaMLP_optimized:
             x,
             self.w3,
             program_config=self.model_config["PADDED_FF3_MM_PROGCFG"],
-            # memory_config=self.model_config["MLP_BLOCK_SHARDED_MEMCFG"],
             compute_kernel_config=self.model_config["COMPUTE_KERNEL_CONFIG_LOFI"],
             dtype=self.model_config["BFLOAT16_DTYPE"],
         )
@@ -192,7 +190,6 @@ class TtLlamaMLP_optimized:
             hidden_states,
             dim=3,
             num_links=self.model_config["ALL_GATHER_NUM_LINKS"],
-            # memory_config=self.model_config["L1_MEMCFG"],
             memory_config=self.model_config["PADDED_MLP_ALL_GATHER_OUTPUT_MEMCFG"],
         )
 
@@ -201,7 +198,6 @@ class TtLlamaMLP_optimized:
             self.w2,
             program_config=self.model_config["PADDED_FF2_MM_PROGCFG"],
             memory_config=self.model_config["WIDTH_SHARDED_MEMCFG"],
-            # dtype=self.model_config["BFP8_DTYPE"],
             compute_kernel_config=self.model_config["COMPUTE_KERNEL_CONFIG"],
         )
         return hidden_states

--- a/models/experimental/llama2_70b/tt/llama_mlp_optimized.py
+++ b/models/experimental/llama2_70b/tt/llama_mlp_optimized.py
@@ -200,7 +200,7 @@ class TtLlamaMLP_optimized:
             hidden_states,
             self.w2,
             program_config=self.model_config["PADDED_FF2_MM_PROGCFG"],
-            mem_config=self.model_config["WIDTH_SHARDED_MEMCFG"],
+            memory_config=self.model_config["WIDTH_SHARDED_MEMCFG"],
             # dtype=self.model_config["BFP8_DTYPE"],
             compute_kernel_config=self.model_config["COMPUTE_KERNEL_CONFIG"],
         )

--- a/models/experimental/llama2_70b/tt/llama_model_optimized.py
+++ b/models/experimental/llama2_70b/tt/llama_model_optimized.py
@@ -343,14 +343,13 @@ class TtLlamaModel_optimized:
         )
 
         ### Each device does an LM head fracture
-        lm_head_out = tt_lib.operations.primary.matmul_1d(
-            norm_out_replicated,
+        lm_head_out = ttnn.matmul(
             self.lm_head,
             program_config=self.model_config["LLAMA3_LM_HEAD_MM_PROGCFG"]
             if self.llama3
             else self.model_config["LM_HEAD_MM_PROGCFG"],
-            output_mem_config=self.model_config["DRAM_MEMCFG"],
-            output_dtype=ttnn.bfloat16,
+            memory_config=self.model_config["DRAM_MEMCFG"],
+            dtype=ttnn.bfloat16,
             compute_kernel_config=self.model_config["COMPUTE_KERNEL_CONFIG"],
         )
         norm_out_replicated.deallocate(True)
@@ -447,11 +446,11 @@ class TtLlamaModel_optimized:
         batch_dim = 1 if seq_len < max_mm_seq_len else seq_len // max_mm_seq_len  # Find the division factor
         norm_out_replicated = ttnn.reshape(norm_out_replicated, (1, batch_dim, seq_len // batch_dim, -1))
 
-        lm_head_out = tt_lib.operations.primary.matmul(
+        lm_head_out = ttnn.matmul(
             norm_out_replicated,
             self.lm_head,
             program_config=self.model_config["LM_HEAD_MM_PROGCFG"],
-            output_mem_config=self.model_config["DRAM_MEMCFG"],
+            memory_config=self.model_config["DRAM_MEMCFG"],
             compute_kernel_config=self.model_config["COMPUTE_KERNEL_FP16_ACC_CONFIG"],
         )
         norm_out_replicated.deallocate(True)

--- a/models/experimental/llama2_70b/tt/model_config.py
+++ b/models/experimental/llama2_70b/tt/model_config.py
@@ -442,7 +442,7 @@ def get_model_config(
             False,
         ),
     )
-    model_config["ROT_MAT_MM_PROGCFG"] = ttl.operations.primary.MatmulMultiCoreReuseProgramConfig(
+    model_config["ROT_MAT_MM_PROGCFG"] = ttnn.MatmulMultiCoreReuseProgramConfig(
         compute_with_storage_grid_size=[8, 4],
         in0_block_w=4,  # 128 // TILE_SIZE (dynamic)
         out_subblock_h=1,

--- a/models/experimental/mistral/mistral_helper_funcs.py
+++ b/models/experimental/mistral/mistral_helper_funcs.py
@@ -5,6 +5,7 @@ import tt_lib
 from typing import Optional
 from models.utility_functions import tt_to_torch_tensor, torch_to_tt_tensor_rm, tt2torch_tensor
 import torch
+import ttnn
 
 
 def Linear(
@@ -35,7 +36,7 @@ def Linear(
 
     def linear_(activation):
         assert activation.get_legacy_shape()[-1] == in_features, "activation tensor do not have the expected shape"
-        output = tt_lib.tensor.matmul(activation, weight_T, output_mem_config)
+        output = ttnn.matmul(activation, weight_T, output_mem_config)
 
         if bias is not None:
             output_plus_bias = tt_lib.tensor.bcast(

--- a/models/experimental/mnist/tt/mnist_model.py
+++ b/models/experimental/mnist/tt/mnist_model.py
@@ -5,6 +5,7 @@
 from pathlib import Path
 import torch
 import tt_lib
+import ttnn
 
 from tt_lib.fallback_ops import fallback_ops
 from tt_lib.fused_ops.softmax import softmax as tt_softmax
@@ -36,15 +37,15 @@ class TtMnistModel(torch.nn.Module):
         # Operand/target width must be a multiple of 32. So using fallback_ops.reshape.
         x = tt_lib.fallback_ops.reshape(x, x.get_legacy_shape()[0], 1, 1, 784)
 
-        x = tt_lib.tensor.matmul(x, self.fc1_weight)
+        x = ttnn.matmul(x, self.fc1_weight)
         x = tt_lib.tensor.bcast(x, self.fc1_bias, tt_lib.tensor.BcastOpMath.ADD, tt_lib.tensor.BcastOpDim.H)
         x = tt_lib.tensor.relu(x)
 
-        x = tt_lib.tensor.matmul(x, self.fc2_weight)
+        x = ttnn.matmul(x, self.fc2_weight)
         x = tt_lib.tensor.bcast(x, self.fc2_bias, tt_lib.tensor.BcastOpMath.ADD, tt_lib.tensor.BcastOpDim.H)
         x = tt_lib.tensor.relu(x)
 
-        x = tt_lib.tensor.matmul(x, self.fc3_weight)
+        x = ttnn.matmul(x, self.fc3_weight)
         x = tt_lib.tensor.bcast(x, self.fc3_bias, tt_lib.tensor.BcastOpMath.ADD, tt_lib.tensor.BcastOpDim.H)
         x = tt_lib.tensor.relu(x)
 

--- a/models/experimental/roberta/tt/roberta_classification_head.py
+++ b/models/experimental/roberta/tt/roberta_classification_head.py
@@ -6,6 +6,7 @@ import torch
 import torch.nn as nn
 
 import tt_lib
+import ttnn
 
 from models.helper_funcs import Linear as TTLinear
 from models.utility_functions import tt2torch_tensor, pad_by_zero
@@ -48,7 +49,7 @@ class TtRobertaClassificationHead(nn.Module):
 
     def linear(self, x, weight, bias):
         weight = tt_lib.tensor.transpose(weight, -2, -1)
-        x = tt_lib.tensor.matmul(x, weight, output_mem_config=self.mem_config)
+        x = ttnn.matmul(x, weight, memory_config=self.mem_config)
         x = tt_lib.tensor.bcast(
             x,
             bias,

--- a/models/experimental/roberta/tt/roberta_for_multiple_choice.py
+++ b/models/experimental/roberta/tt/roberta_for_multiple_choice.py
@@ -9,6 +9,7 @@ from typing import Optional, Tuple, Union
 from dataclasses import dataclass
 
 import tt_lib
+import ttnn
 
 from models.experimental.roberta.tt.roberta_model import TtRobertaModel
 from tt_lib.fallback_ops import fallback_ops
@@ -54,7 +55,7 @@ class TtRobertaForMultipleChoice(nn.Module):
 
     def linear(self, x, weight, bias):
         weight = tt_lib.tensor.transpose(weight, -2, -1)
-        x = tt_lib.tensor.matmul(x, weight, output_mem_config=self.mem_config)
+        x = ttnn.matmul(x, weight, memory_config=self.mem_config)
         if bias is not None:
             x = tt_lib.tensor.bcast(
                 x,

--- a/models/experimental/roberta/tt/roberta_for_question_answering.py
+++ b/models/experimental/roberta/tt/roberta_for_question_answering.py
@@ -9,6 +9,7 @@ from typing import Optional, Tuple, Union
 from dataclasses import dataclass
 
 import tt_lib
+import ttnn
 
 from models.experimental.roberta.tt.roberta_model import TtRobertaModel
 from models.utility_functions import (
@@ -58,7 +59,7 @@ class TtRobertaForQuestionAnswering(nn.Module):
 
     def linear(self, x, weight, bias):
         weight = tt_lib.tensor.transpose(weight, -2, -1)
-        x = tt_lib.tensor.matmul(x, weight, output_mem_config=self.mem_config)
+        x = ttnn.matmul(x, weight, memory_config=self.mem_config)
         x = tt_lib.tensor.bcast(
             x,
             bias,

--- a/models/experimental/roberta/tt/roberta_for_token_classification.py
+++ b/models/experimental/roberta/tt/roberta_for_token_classification.py
@@ -9,6 +9,7 @@ from typing import Optional, Tuple, Union
 from dataclasses import dataclass
 
 import tt_lib
+import ttnn
 
 from models.experimental.roberta.tt.roberta_model import TtRobertaModel
 from models.experimental.roberta.roberta_common import torch2tt_tensor
@@ -52,7 +53,7 @@ class TtRobertaForTokenClassification(nn.Module):
 
     def linear(self, x, weight, bias):
         weight = tt_lib.tensor.transpose(weight, -2, -1)
-        x = tt_lib.tensor.matmul(x, weight, self.mem_config)
+        x = ttnn.matmul(x, weight, memory_config=self.mem_config)
         if bias is not None:
             x = tt_lib.tensor.bcast(
                 x,

--- a/models/experimental/roberta/tt/roberta_intermediate.py
+++ b/models/experimental/roberta/tt/roberta_intermediate.py
@@ -6,6 +6,7 @@ import torch
 import torch.nn as nn
 
 import tt_lib
+import ttnn
 
 from models.helper_funcs import Linear as TTLinear
 from models.utility_functions import (
@@ -37,7 +38,7 @@ class TtRobertaIntermediate(nn.Module):
 
     def linear(self, x, weight, bias):
         weight = tt_lib.tensor.transpose(weight, -2, -1)
-        x = tt_lib.tensor.matmul(x, weight, output_mem_config=self.mem_config)
+        x = ttnn.matmul(x, weight, memory_config=self.mem_config)
         x = tt_lib.tensor.bcast(
             x,
             bias,

--- a/models/experimental/roberta/tt/roberta_lm_head.py
+++ b/models/experimental/roberta/tt/roberta_lm_head.py
@@ -7,6 +7,7 @@ import torch
 import torch.nn as nn
 
 import tt_lib
+import ttnn
 
 from tt_lib.fallback_ops import fallback_ops
 from models.utility_functions import (
@@ -58,7 +59,7 @@ class TtRobertaLMHead(nn.Module):
 
     def linear(self, x, weight, bias):
         weight = tt_lib.tensor.transpose(weight, -2, -1)
-        x = tt_lib.tensor.matmul(x, weight, output_mem_config=mem_config)
+        x = ttnn.matmul(x, weight, memory_config=mem_config)
         x = tt_lib.tensor.bcast(
             x,
             bias,

--- a/models/experimental/roberta/tt/roberta_output.py
+++ b/models/experimental/roberta/tt/roberta_output.py
@@ -53,7 +53,7 @@ class TtRobertaOutput(nn.Module):
 
     def linear(self, x, weight, bias):
         weight = tt_lib.tensor.transpose(weight, -2, -1)
-        x = tt_lib.tensor.matmul(x, weight, output_mem_config=self.mem_config)
+        x = ttnn.matmul(x, weight, memory_config=self.mem_config)
         x = tt_lib.tensor.bcast(
             x,
             bias,

--- a/models/experimental/roberta/tt/roberta_pooler.py
+++ b/models/experimental/roberta/tt/roberta_pooler.py
@@ -6,6 +6,7 @@ import torch
 import torch.nn as nn
 
 import tt_lib
+import ttnn
 
 from models.helper_funcs import Linear as TTLinear
 from models.utility_functions import (
@@ -41,7 +42,7 @@ class TtRobertaPooler(nn.Module):
 
     def linear(self, x, weight, bias):
         weight = tt_lib.tensor.transpose(weight, -2, -1)
-        x = tt_lib.tensor.matmul(x, weight, self.mem_config)
+        x = ttnn.matmul(x, weight, memory_config=self.mem_config)
         x = tt_lib.tensor.bcast(
             x,
             bias,

--- a/models/experimental/roberta/tt/roberta_self_attention.py
+++ b/models/experimental/roberta/tt/roberta_self_attention.py
@@ -9,6 +9,7 @@ import torch.nn as nn
 from typing import Optional, Tuple
 
 import tt_lib
+import ttnn
 
 from tt_lib.fallback_ops import fallback_ops
 from models.helper_funcs import Linear as TTLinear
@@ -88,7 +89,7 @@ class TtRobertaSelfAttention(nn.Module):
 
     def linear(self, x, weight, bias):
         weight = tt_lib.tensor.transpose(weight, -2, -1)
-        x = tt_lib.tensor.matmul(x, weight, output_mem_config=self.mem_config)
+        x = ttnn.matmul(x, weight, memory_config=self.mem_config)
         x = tt_lib.tensor.bcast(
             x,
             bias,

--- a/models/experimental/roberta/tt/roberta_self_output.py
+++ b/models/experimental/roberta/tt/roberta_self_output.py
@@ -41,7 +41,7 @@ class TtRobertaSelfOutput(nn.Module):
 
     def linear(self, x, weight, bias):
         weight = tt_lib.tensor.transpose(weight, -2, -1)
-        x = tt_lib.tensor.matmul(x, weight, output_mem_config=self.mem_config)
+        x = ttnn.matmul(x, weight, memory_config=self.mem_config)
         x = tt_lib.tensor.bcast(
             x,
             bias,

--- a/models/experimental/swin/swin_helper_funcs.py
+++ b/models/experimental/swin/swin_helper_funcs.py
@@ -3,6 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import tt_lib
+import ttnn
 
 
 def linear(
@@ -11,7 +12,7 @@ def linear(
     bias: tt_lib.tensor.Tensor = None,
 ) -> tt_lib.tensor.Tensor:
     weight = tt_lib.tensor.transpose(weight, -2, -1)
-    x = tt_lib.tensor.matmul(x, weight)
+    x = ttnn.matmul(x, weight)
 
     if bias is not None:
         x = tt_lib.tensor.bcast(x, bias, tt_lib.tensor.BcastOpMath.ADD, tt_lib.tensor.BcastOpDim.H)

--- a/models/experimental/synthetic_gradients/tests/test_block.py
+++ b/models/experimental/synthetic_gradients/tests/test_block.py
@@ -16,7 +16,7 @@ epsilon = 1e-5
 def ttLinear(weight, bias):
     def linear_(activation):
         weight_T = tt_lib.tensor.transpose(weight, -2, -1)
-        output = tt_lib.tensor.matmul(activation, weight_T)
+        output = ttnn.matmul(activation, weight_T)
         output_plus_bias = ttnn.add(output, bias)
         return output_plus_bias
 

--- a/models/experimental/synthetic_gradients/tests/test_full_inference.py
+++ b/models/experimental/synthetic_gradients/tests/test_full_inference.py
@@ -18,7 +18,7 @@ epsilon2 = 1e-5
 def ttLinear(weight, bias):
     def linear_(activation):
         weight_T = tt_lib.tensor.transpose(weight, -2, -1)
-        output = tt_lib.tensor.matmul(activation, weight_T)
+        output = ttnn.matmul(activation, weight_T)
         output_plus_bias = ttnn.add(output, bias)
         return output_plus_bias
 

--- a/models/experimental/synthetic_gradients/tests/test_linear.py
+++ b/models/experimental/synthetic_gradients/tests/test_linear.py
@@ -14,7 +14,7 @@ from models.utility_functions import tilize_to_list, untilize, comp_allclose_and
 def ttLinear(weight, bias):
     def linear_(activation):
         weight_T = tt_lib.tensor.transpose(weight, -2, -1)
-        output = tt_lib.tensor.matmul(activation, weight_T)
+        output = ttnn.matmul(activation, weight_T)
         output_plus_bias = ttnn.add(output, bias)
         return output_plus_bias
 

--- a/models/experimental/t5/tt/t5_attention.py
+++ b/models/experimental/t5/tt/t5_attention.py
@@ -452,11 +452,11 @@ class TtT5Attention(nn.Module):
             if key_value_states is None:
                 # self-attn
                 # (batch_size, n_heads, seq_length, dim_per_head)
-                hidden_states = shape(tt_lib.tensor.matmul(hidden_states, proj_weights, self.mem_config))
+                hidden_states = shape(ttnn.matmul(hidden_states, proj_weights, memory_config=self.mem_config))
             elif past_key_value is None:
                 # cross-attn
                 # (batch_size, n_heads, seq_length, dim_per_head)
-                hidden_states = shape(tt_lib.tensor.matmul(key_value_states, proj_weights, self.mem_config))
+                hidden_states = shape(ttnn.matmul(key_value_states, proj_weights, memory_config=self.mem_config))
 
             if past_key_value is not None:
                 if key_value_states is None:
@@ -470,7 +470,7 @@ class TtT5Attention(nn.Module):
                     # the provided `key_value_states` to support prefix tuning
                     # cross-attn
                     # (batch_size, n_heads, seq_length, dim_per_head)
-                    hidden_states = shape(tt_lib.tensor.matmul(key_value_states, proj_weights, self.mem_config))
+                    hidden_states = shape(ttnn.matmul(key_value_states, proj_weights, memory_config=self.mem_config))
                 else:
                     # cross-attn
                     hidden_states = past_key_value
@@ -478,7 +478,7 @@ class TtT5Attention(nn.Module):
 
         # get query states
         query_states = shape(
-            tt_lib.tensor.matmul(hidden_states, self.q_weights, self.mem_config)
+            ttnn.matmul(hidden_states, self.q_weights, memory_config=self.mem_config)
             # self.q(hidden_states)
         )  # (batch_size, n_heads, seq_length, dim_per_head)
 
@@ -559,7 +559,7 @@ class TtT5Attention(nn.Module):
 
         attn_output = tt_lib.tensor.bmm(attn_weights, value_states, self.mem_config)
         attn_output = unshape(attn_output)  # (batch_size, seq_length, dim)
-        attn_output = tt_lib.tensor.matmul(attn_output, self.o_weights, self.mem_config)
+        attn_output = ttnn.matmul(attn_output, self.o_weights, memory_config=self.mem_config)
 
         present_key_value_state = (key_states, value_states) if (self.is_decoder and use_cache) else None
         outputs = (attn_output,) + (present_key_value_state,) + (position_bias,)

--- a/models/experimental/t5/tt/t5_dense_act_dense.py
+++ b/models/experimental/t5/tt/t5_dense_act_dense.py
@@ -4,6 +4,7 @@
 
 from torch import nn
 import tt_lib
+import ttnn
 from models.utility_functions import torch2tt_tensor
 
 
@@ -31,8 +32,8 @@ class TtT5DenseActDense(nn.Module):
         self.act = tt_lib.tensor.relu
 
     def forward(self, hidden_states):
-        hidden_states = tt_lib.tensor.matmul(hidden_states, self.out_proj_wi)
+        hidden_states = ttnn.matmul(hidden_states, self.out_proj_wi)
         hidden_states = self.act(hidden_states, output_mem_config=self.mem_config)
         # hidden_states = self.dropout(hidden_states)
-        hidden_states = tt_lib.tensor.matmul(hidden_states, self.out_proj_w0, self.mem_config)
+        hidden_states = ttnn.matmul(hidden_states, self.out_proj_w0, memory_config=self.mem_config)
         return hidden_states

--- a/models/experimental/t5/tt/t5_dense_gated_act_dense.py
+++ b/models/experimental/t5/tt/t5_dense_gated_act_dense.py
@@ -4,6 +4,7 @@
 
 import torch
 import tt_lib
+import ttnn
 from loguru import logger
 import math
 
@@ -45,8 +46,8 @@ class TtT5DenseGatedActDense(torch.nn.Module):
         self.act = gelu_new
 
     def forward(self, hidden_states):
-        hidden_gelu = self.act(tt_lib.tensor.matmul(hidden_states, self.wi_0_weights), self.device)
-        hidden_linear = tt_lib.tensor.matmul(hidden_states, self.wi_1_weights, output_mem_config=self.mem_config)
+        hidden_gelu = self.act(ttnn.matmul(hidden_states, self.wi_0_weights), self.device)
+        hidden_linear = ttnn.matmul(hidden_states, self.wi_1_weights, memory_config=self.mem_config)
         hidden_states = ttnn.mul(hidden_gelu, hidden_linear, memory_config=self.mem_config)
         # hidden_states = self.dropout(hidden_states)
 
@@ -60,5 +61,5 @@ class TtT5DenseGatedActDense(torch.nn.Module):
         # ):
         #    hidden_states = hidden_states.to(self.wo.weight.dtype)
 
-        hidden_states = tt_lib.tensor.matmul(hidden_states, self.wo_weights, output_mem_config=self.mem_config)
+        hidden_states = ttnn.matmul(hidden_states, self.wo_weights, memory_config=self.mem_config)
         return hidden_states

--- a/models/experimental/t5/tt/t5_for_conditional_generation.py
+++ b/models/experimental/t5/tt/t5_for_conditional_generation.py
@@ -7,6 +7,7 @@ import torch
 import warnings
 from torch import nn
 import tt_lib
+import ttnn
 import json
 from typing import Optional, Tuple
 
@@ -260,7 +261,7 @@ class TtT5ForConditionalGeneration(nn.Module):
             sequence_output = sequence_output * (self.model_dim**-0.5)
             sequence_output = torch2tt_tensor(sequence_output, self.device)
 
-        lm_logits = tt_lib.tensor.matmul(sequence_output, self.lm_head_weights)
+        lm_logits = ttnn.matmul(sequence_output, self.lm_head_weights)
         loss = None
 
         # Back to torch

--- a/models/experimental/whisper/tt/whisper_common.py
+++ b/models/experimental/whisper/tt/whisper_common.py
@@ -4,6 +4,7 @@
 
 import torch
 import tt_lib
+import ttnn
 
 
 def linear(x, weight, bias=None):
@@ -12,7 +13,7 @@ def linear(x, weight, bias=None):
     )
 
     weight = tt_lib.tensor.transpose(weight, -2, -1)
-    x = tt_lib.tensor.matmul(x, weight)
+    x = ttnn.matmul(x, weight)
     if bias is not None:
         x = tt_lib.tensor.bcast(x, bias, tt_lib.tensor.BcastOpMath.ADD, tt_lib.tensor.BcastOpDim.H)
     return x


### PR DESCRIPTION
### Ticket
Link to Github Issue https://github.com/tenstorrent/tt-metal/issues/9492

### Problem description
We're moving ops to ttnn

### What's changed
Make matmul ops in models point to ttnn matmul/linear

### Checklist
- [x] Post commit CI passes
- [x] Model regression CI testing passes (if applicable)
- [x] New/Existing tests provide coverage for changes

https://github.com/tenstorrent/tt-metal/actions/runs/9681343061 All post-commits tests pass
https://github.com/tenstorrent/tt-metal/actions/runs/9682871493 Nightly fast dispatch tests fails with the same error as main
https://github.com/tenstorrent/tt-metal/actions/runs/9682879735/job/26717273487 (T3K) T3000 demo tests pass
https://github.com/tenstorrent/tt-metal/actions/runs/9683243284/job/26718212659 Device perf regressions and output report GS Device perf passes (the other one fails on main)
https://github.com/tenstorrent/tt-metal/actions/runs/9682876668 Model perf regressions and output report GS ones pass (WH is backed up)

2nd test run:

https://github.com/tenstorrent/tt-metal/actions/runs/9705332123 All post-commits tests pass
https://github.com/tenstorrent/tt-metal/actions/runs/9705034806 (T3K) T3000 model perf tests pass
https://github.com/tenstorrent/tt-metal/actions/runs/9704005481 (T3K) T3000 frequent tests pass
https://github.com/tenstorrent/tt-metal/actions/runs/9704008719 (T3K) T3000 demo tests pass except for mistral which this change doesn't touch and passed in an earlier attempt https://github.com/tenstorrent/tt-metal/actions/runs/9686832542