### PR TITLE
#9725: Set release candidate releases on GitHub to pre-release, not draft, to enable downstream users

### DIFF
--- a/.github/workflows/package-and-release.yaml
+++ b/.github/workflows/package-and-release.yaml
@@ -74,9 +74,6 @@ jobs:
       environment: dev
       os: ${{ matrix.os }}
       arch: ${{ matrix.arch }}
-  release-run-frequent-fast-dispatch:
-    uses: ./.github/workflows/fast-dispatch-full-regressions-and-models.yaml
-    secrets: inherit
   # Candidate for breaking up
   create-and-upload-draft-release:
     needs: [

--- a/.github/workflows/package-and-release.yaml
+++ b/.github/workflows/package-and-release.yaml
@@ -113,7 +113,8 @@ jobs:
         with:
           tag_name: ${{ needs.create-tag.outputs.version }}
           name: ${{ needs.create-tag.outputs.version }}
-          draft: true
+          draft: false
+          prerelease: true
           body_path: CHANGELOG.txt
           files: |
             VERSION


### PR DESCRIPTION
### Ticket

#9725 

### Problem description

Use pre-releases so that downstream install workflows can use our wheel artifacts.

### What's changed

We set appropriate `draft` and `prerelease` flags.

### Checklist
- [x] Post commit CI passes
- [x] Model regression CI testing passes (if applicable)
- [x] New/Existing tests provide coverage for changes
