### PR TITLE
#9681: set __name__ attribute for ttnn operations when fast runtime m…

### DIFF
--- a/ttnn/ttnn/operations/binary.py
+++ b/ttnn/ttnn/operations/binary.py
@@ -49,7 +49,6 @@ def register_ttl_binary_function(name, ttl_binary_function, doc):
         return output_tensor
 
     if isinstance(binary_function, ttnn.decorators.Operation):
-        binary_function.__name__ = f"ttnn.{name}"
         binary_function.decorated_function.__doc__ = doc + (
             binary_function.__doc__ if binary_function.__doc__ is not None else ""
         )
@@ -348,7 +347,6 @@ def register_ttl_elt_binary_function(name, ttl_elt_binary_function, op_name):
         return output_tensor
 
     if isinstance(elt_binary_function, ttnn.decorators.Operation):
-        elt_binary_function.__name__ = f"ttnn.{name}"
         elt_binary_function.decorated_function.__doc__ = f"""{name}(input_tensor_a: ttnn.Tensor, input_tensor_b: ttnn.Tensor, *, memory_config: ttnn.MemoryConfig = ttnn.DRAM_MEMORY_CONFIG) -> ttnn.Tensor
 
             Performs eltwise-binary {op_name} operation on two tensors :attr:`input_a` and :attr:`input_b`.

--- a/ttnn/ttnn/operations/losses.py
+++ b/ttnn/ttnn/operations/losses.py
@@ -79,7 +79,6 @@ def register_ttl_loss_function(name, ttl_loss_function):
         return output_tensor
 
     if isinstance(loss_function, ttnn.decorators.Operation):
-        loss_function.__name__ = f"ttnn.{name}"
         loss_function.decorated_function.__doc__ = f"""{name}(input_tensor_a: ttnn.Tensor, input_tensor_b: ttnn.Tensor, loss_mode: str, *, memory_config: ttnn.MemoryConfig = ttnn.DRAM_MEMORY_CONFIG) -> ttnn.Tensor
 
             Applies {name} to :attr:`input_tensor_a` and :attr:`input_tensor_b` with loss_mode :attr:`loss_mode`.

--- a/ttnn/ttnn/operations/ternary.py
+++ b/ttnn/ttnn/operations/ternary.py
@@ -99,7 +99,6 @@ def register_ttl_ternary_function(name, ttl_ternary_function):
         return output_tensor
 
     if isinstance(ternary_function, ttnn.decorators.Operation):
-        ternary_function.__name__ = f"ttnn.{name}"
         ternary_function.decorated_function.__doc__ = f"""{name}(input_tensor: ttnn.Tensor, input_tensor1: ttnn.Tensor, input_tensor2: ttnn.Tensor, *, memory_config: ttnn.MemoryConfig = ttnn.DRAM_MEMORY_CONFIG) -> ttnn.Tensor
 
             Returns tensor with the {name} of all of elements of the input tensors input, tensor1, tensor2.
@@ -221,7 +220,6 @@ def register_ttl_ternary_function_with_float(name, ttl_ternary_function, op_name
         return output_tensor
 
     if isinstance(ternary_function, ttnn.decorators.Operation):
-        ternary_function.__name__ = f"ttnn.{(name)}"
         ternary_function.decorated_function.__doc__ = f"""{(name)}(input_tensor: ttnn.Tensor, input_tensor1: ttnn.Tensor, input_tensor2: ttnn.Tensor, parameter, *, memory_config: ttnn.MemoryConfig = ttnn.DRAM_MEMORY_CONFIG) -> ttnn.Tensor
 
             Performs the element-wise {op_name} of tensor1 by tensor2, multiplies the result by the scalar value and adds it to input input.

--- a/ttnn/ttnn/operations/unary.py
+++ b/ttnn/ttnn/operations/unary.py
@@ -260,7 +260,6 @@ def register_ttl_unary_function_with_float(name, ttl_unary_function, param):
         return output_tensor
 
     if isinstance(unary_function, ttnn.decorators.Operation):
-        unary_function.__name__ = f"ttnn.{(name)}"
         unary_function.decorated_function.__doc__ = f"""{(name)}(input_tensor: ttnn.Tensor, parameter, *, memory_config: ttnn.MemoryConfig = ttnn.DRAM_MEMORY_CONFIG) -> ttnn.Tensor
 
             Applies the {name} function to the elements of the input tensor :attr:`input_tensor` with :attr:`{param}` parameter.
@@ -346,7 +345,6 @@ def register_ttl_activation_function_with_float(name, ttl_activation_function, p
         return output_tensor
 
     if isinstance(activation_function, ttnn.decorators.Operation):
-        activation_function.__name__ = f"ttnn.{(name)}"
         activation_function.decorated_function.__doc__ = f"""{(name)}(input_tensor: ttnn.Tensor, parameter, *, memory_config: ttnn.MemoryConfig = ttnn.DRAM_MEMORY_CONFIG) -> ttnn.Tensor
 
             Applies the {name} function to the elements of the input tensor :attr:`input_tensor` with :attr:`{param}` parameter.
@@ -430,7 +428,6 @@ def register_ttl_activation_function_with_two_float_params(name, ttl_activation_
         return output_tensor
 
     if isinstance(activation_function, ttnn.decorators.Operation):
-        activation_function.__name__ = f"ttnn.{(name)}"
         activation_function.decorated_function.__doc__ = f"""{(name)}(input_tensor: ttnn.Tensor, parameter, *, memory_config: ttnn.MemoryConfig = ttnn.DRAM_MEMORY_CONFIG) -> ttnn.Tensor
 
             Applies the {name} function to the elements of the input tensor :attr:`input_tensor` with :attr:`{param1_name}` and :attr:`{param2_name}`  parameters.
@@ -550,7 +547,6 @@ def register_ttl_activation_function_glu(name, ttl_activation_function, param):
         return output_tensor
 
     if isinstance(activation_function, ttnn.decorators.Operation):
-        activation_function.__name__ = f"ttnn.{(name)}"
         activation_function.decorated_function.__doc__ = f"""{(name)}(input_tensor: ttnn.Tensor, dim: int = -1, *, memory_config: ttnn.MemoryConfig = ttnn.DRAM_MEMORY_CONFIG) -> ttnn.Tensor
 
             Applies the {name} function to the elements of the input tensor :attr:`input_tensor` split along :attr:`{param}`.


### PR DESCRIPTION
### Ticket
#9681

### Problem description
ttnn operations have no `__name__` attribute. See ticket for more info.

### What's changed
- Assign the `python_fully_qualified_name` to the `__name__` attribute for ttnn operations when fast runtime mode is disabled

### Checklist
- [ ] Post commit CI passes
- [ ] Model regression CI testing passes (if applicable)
- [ ] New/Existing tests provide coverage for changes
