### PR TITLE
#5337: Relaxed Mistral expected compilation time in CI by 1 sec

### DIFF
--- a/models/demos/wormhole/mistral7b/tests/test_mistral_perf.py
+++ b/models/demos/wormhole/mistral7b/tests/test_mistral_perf.py
@@ -49,9 +49,9 @@ class Emb(torch.nn.Module):
 @pytest.mark.parametrize(
     "kv_cache_len, expected_compile_time, expected_inference_time",
     (
-        (32, 5, 0.105),
-        (128, 5, 0.125),
-        (1024, 5, 0.225),
+        (32, 6, 0.105),
+        (128, 6, 0.125),
+        (1024, 6, 0.225),
     ),
 )
 def test_mistral_model_perf(


### PR DESCRIPTION
The expected compile time of Mistral was previously too tight to the actual compile time in CI machines. 
Recent tests were taking 4.9s (expected 5) and recently there was 1 CI run in the pipeline that took 5.1s resulting in a failed pipeline.

Pipeline that failed: https://github.com/tenstorrent/tt-metal/actions/runs/9677596370/job/26699825314

This PR increases the expected compile time to 6, to avoid these small variance pipeline failures.
