### PR TITLE
 #9735: fix issues with including reflect library

### DIFF
--- a/tt_eager/tt_dnn/op_library/CMakeLists.txt
+++ b/tt_eager/tt_dnn/op_library/CMakeLists.txt
@@ -215,7 +215,7 @@ set(TT_DNN_SRCS
 
 add_library(tt_dnn OBJECT ${TT_DNN_SRCS})
 
-target_link_libraries(tt_dnn PUBLIC metal_header_directories compiler_flags umd_device)
+target_link_libraries(tt_dnn PUBLIC metal_header_directories compiler_flags umd_device reflect::reflect)
 target_include_directories(tt_dnn PUBLIC
     ${UMD_HOME}
     ${PROJECT_SOURCE_DIR}

--- a/ttnn/CMakeLists.txt
+++ b/ttnn/CMakeLists.txt
@@ -16,8 +16,7 @@ set(TTNN_SRCS
 add_library(ttnn_lib OBJECT ${TTNN_SRCS})
 target_compile_options(ttnn_lib PUBLIC -MP -Wno-int-to-pointer-cast -fno-var-tracking)
 target_link_libraries(ttnn_lib
-    PUBLIC compiler_flags metal_header_directories metal_common_libs
-    PRIVATE reflect::reflect
+    PUBLIC compiler_flags metal_header_directories metal_common_libs reflect::reflect
 )
 target_include_directories(ttnn_lib PUBLIC
     ${UMD_HOME}

--- a/ttnn/cpp/ttnn/device_operation.hpp
+++ b/ttnn/cpp/ttnn/device_operation.hpp
@@ -15,6 +15,7 @@
 #include "tt_stl/concepts.hpp"
 #include "tt_stl/reflection.hpp"
 #include "tt_stl/unique_any.hpp"
+#include <reflect>
 
 namespace ttnn {
 


### PR DESCRIPTION
### Ticket
#9735 

### Problem description
When users include `<reflect>` library with files that are used in both `ttnn_lib` and `tt_eager` targets, there were compilation errors complaining that it wasn't found.

### What's changed
- Since we currently cross-link `tt_eager` target with `ttnn_lib` target, we needed to make the `reflect::reflect` library by changing the link dependency to `PUBLIC`
- We also needed to update link dependency for `tt_dnn` target

### Checklist
- [x] Post commit CI passes
- [x] Model regression CI testing passes (if applicable)
- [x] New/Existing tests provide coverage for changes
