### PR TITLE
#9479: fix cpu core worker bug

### DIFF
--- a/tt_metal/impl/dispatch/work_executor.hpp
+++ b/tt_metal/impl/dispatch/work_executor.hpp
@@ -102,7 +102,6 @@ class WorkExecutor {
         this->work_executor_mode = default_worker_executor_mode();
         this->worker_queue_mode = default_worker_queue_mode();
         this->worker_state = WorkerState::IDLE;
-        this->cpu_core_for_worker = 0;
         this->worker_queue.parent_thread_id = 0;
         this->worker_queue.worker_thread_id = 0;
         set_process_priority(0);


### PR DESCRIPTION
### Ticket
[Link to Github Issue](https://github.com/tenstorrent/tt-metal/issues/9479)

### Problem description
Perf regression for async mode

### What's changed
Bug causing device to always set its work executor to worker 0.

### Checklist
- [x] Post commit CI passes
- [x] Model regression CI testing passes (if applicable)
- [x] New/Existing tests provide coverage for changes
