### PR TITLE
#0: Fix bug with var name in single-chip falcon7b demo tests

### DIFF
--- a/models/demos/grayskull/falcon7b/demo_grayskull.py
+++ b/models/demos/grayskull/falcon7b/demo_grayskull.py
@@ -7,7 +7,7 @@ from models.demos.falcon7b.demo.demo import run_falcon_demo_kv
 
 
 @pytest.mark.parametrize(
-    "perf_mode, expected_perf_prefill_decode, greedy_sampling, expected_greedy_output_path",
+    "perf_mode, expected_perf_metrics, greedy_sampling, expected_greedy_output_path",
     (
         (False, None, True, "models/demos/grayskull/falcon7b/expected_greedy_output.json"),
         (False, None, True, None),
@@ -21,7 +21,7 @@ from models.demos.falcon7b.demo.demo import run_falcon_demo_kv
 )
 def test_demo(
     perf_mode,  # Option to measure perf using max seq length (with invalid outputs) and expected perf (t/s)
-    expected_perf_prefill_decode,  # Expected perf (t/s) for prefill and decode in perf mode
+    expected_perf_metrics,  # Expected perf (t/s) for prefill and decode in perf mode
     greedy_sampling,  # Option to use greedy decoding instead of top-k/p
     expected_greedy_output_path,  # Path for expected outputs for greedy decoding
     user_input,
@@ -40,6 +40,6 @@ def test_demo(
         devices=[device],
         perf_mode=perf_mode,
         greedy_sampling=greedy_sampling,
-        expected_perf_prefill_decode=expected_perf_prefill_decode,
+        expected_perf_metrics=expected_perf_metrics,
         expected_greedy_output_path=expected_greedy_output_path,
     )

--- a/models/demos/wormhole/falcon7b/demo_wormhole.py
+++ b/models/demos/wormhole/falcon7b/demo_wormhole.py
@@ -7,9 +7,9 @@ from models.demos.falcon7b.demo.demo import run_falcon_demo_kv
 
 
 @pytest.mark.parametrize(
-    "perf_mode, expected_perf_prefill_decode, greedy_sampling, expected_greedy_output_path",
+    "perf_mode, expected_perf_metrics, greedy_sampling, expected_greedy_output_path",
     (
-        (True, [1100, 335], False, None),
+        (True, {"prefill_t/s": 1100, "decode_t/s": 335, "decode_t/s/u": 10.4}, False, None),
         (True, None, False, None),
         (False, None, True, "models/demos/wormhole/falcon7b/expected_greedy_output.json"),
         (False, None, True, None),
@@ -25,7 +25,7 @@ from models.demos.falcon7b.demo.demo import run_falcon_demo_kv
 )
 def test_demo(
     perf_mode,  # Option to measure perf using max seq length (with invalid outputs) and expected perf (t/s)
-    expected_perf_prefill_decode,  # Expected perf (t/s) for prefill and decode in perf mode
+    expected_perf_metrics,  # Expected perf (t/s) for prefill and decode in perf mode
     greedy_sampling,  # Option to use greedy decoding instead of top-k/p
     expected_greedy_output_path,  # Path for expected outputs for greedy decoding
     user_input,
@@ -44,6 +44,6 @@ def test_demo(
         devices=[device],
         perf_mode=perf_mode,
         greedy_sampling=greedy_sampling,
-        expected_perf_prefill_decode=expected_perf_prefill_decode,
+        expected_perf_metrics=expected_perf_metrics,
         expected_greedy_output_path=expected_greedy_output_path,
     )


### PR DESCRIPTION
### Ticket
None

### Problem description
A variable name was not updated for the single-chip falcon7b demo tests in d02fd3f

### What's changed
Fixed minor variable name bug in wormhole and grayskull falcon7b demos.

### Checklist
- [x] Post commit CI passes
- [x] Model regression CI testing passes (if applicable)
- [x] New/Existing tests provide coverage for changes
