### PR TITLE
#9628: Support optional return tensor

### DIFF
--- a/tests/tt_eager/python_api_testing/unit_testing/backward_ops/test_backward_add.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/backward_ops/test_backward_add.py
@@ -4,7 +4,6 @@
 
 import torch
 import pytest
-import tt_lib
 import ttnn
 from tests.tt_eager.python_api_testing.unit_testing.backward_ops.utility_funcs import data_gen_with_range, compare_pcc
 
@@ -45,8 +44,7 @@ def test_bw_add(input_shapes, device):
         (torch.Size([1, 3, 320, 384])),
     ),
 )
-# @pytest.mark.parametrize("are_required_outputs", [[True, True], [True, False], [False, True]])
-@pytest.mark.parametrize("are_required_outputs", [[True, True]])
+@pytest.mark.parametrize("are_required_outputs", [[True, True], [True, False], [False, True], [False, False]])
 def test_bw_add_with_opt_output(input_shapes, device, are_required_outputs):
     in_data, input_tensor = data_gen_with_range(input_shapes, -100, 100, device, True)
     other_data, other_tensor = data_gen_with_range(input_shapes, -90, 100, device, True)

--- a/tests/tt_eager/python_api_testing/unit_testing/backward_ops/test_backward_addalpha.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/backward_ops/test_backward_addalpha.py
@@ -17,7 +17,7 @@ from tests.tt_eager.python_api_testing.unit_testing.backward_ops.utility_funcs i
         (torch.Size([1, 3, 320, 384])),
     ),
 )
-@pytest.mark.parametrize("alpha", [0.05])
+@pytest.mark.parametrize("alpha", [0.05, 2.0, 1.5, 0.12])
 def test_bw_addalpha(input_shapes, alpha, device):
     in_data, input_tensor = data_gen_with_range(input_shapes, -100, 100, device, True)
     other_data, other_tensor = data_gen_with_range(input_shapes, -100, 100, device, True)
@@ -47,8 +47,7 @@ def test_bw_addalpha(input_shapes, alpha, device):
     ),
 )
 @pytest.mark.parametrize("alpha", [0.05, 2.0, 1.5, 0.12])
-# @pytest.mark.parametrize("are_required_outputs", [[True, True], [True, False], [False, True]])
-@pytest.mark.parametrize("are_required_outputs", [[True, True]])
+@pytest.mark.parametrize("are_required_outputs", [[True, True], [True, False], [False, True], [False, False]])
 def test_bw_addalpha_with_opt_output(input_shapes, alpha, device, are_required_outputs):
     in_data, input_tensor = data_gen_with_range(input_shapes, -100, 100, device, True)
     other_data, other_tensor = data_gen_with_range(input_shapes, -90, 100, device, True)

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_backward/binary_backward.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_backward/binary_backward.hpp
@@ -47,7 +47,7 @@ struct ExecuteBinaryBackward {
                 false}};
     }
 
-    static inline std::vector<Tensor> create_async_output_tensors(
+    static inline std::vector<ttnn::Tensor> create_async_output_tensors(
         const std::vector<Tensor> &input_tensors, const std::vector<std::optional<const Tensor>>& optional_inputs) {
         const auto& input_tensor = input_tensors.at(0);
         return {Tensor(operation::get_workers_for_op_output({input_tensor})),
@@ -63,11 +63,10 @@ struct ExecuteBinaryBackward {
     static std::vector<ttnn::Tensor> execute_on_worker_thread(
         const Tensor &grad_tensor_arg,
         const Tensor &input_tensor_a_arg,
-        const Tensor &input_tensor_b_arg,
-        const MemoryConfig &memory_config = operation::DEFAULT_OUTPUT_MEMORY_CONFIG) {
+        const MemoryConfig &memory_config,
+        const Tensor &input_tensor_b_arg) {
 
         auto op_type = utils::get_function_type1(binary_backward_op_type);
-        // auto output_memory_config = memory_config.value_or(input_tensor_a_arg.memory_config());
         return op_type(grad_tensor_arg, input_tensor_a_arg, input_tensor_b_arg, memory_config);
         }
 
@@ -93,7 +92,7 @@ struct ExecuteBinaryBackward {
         return std::forward_as_tuple(grad_tensor, input_tensor_a, input_tensor_b);
     }
 
-    static std::vector<ttnn::Tensor> execute_on_worker_thread(
+    static std::vector<std::optional<ttnn::Tensor>> execute_on_main_thread(
         uint8_t queue_id,
         const Tensor &grad_tensor_arg,
         const Tensor &input_tensor_a_arg,
@@ -114,7 +113,7 @@ struct ExecuteBinaryBackward {
         return std::forward_as_tuple(grad_tensor, input_tensor_a, input_tensor_b);
     }
 
-    static std::vector<ttnn::Tensor> execute_on_worker_thread(
+    static std::vector<std::optional<ttnn::Tensor>> execute_on_main_thread(
         const Tensor &grad_tensor_arg,
         const Tensor &input_tensor_a_arg,
         const Tensor &input_tensor_b_arg,
@@ -134,7 +133,7 @@ struct ExecuteBinaryBackward {
         return std::forward_as_tuple(grad_tensor, input_tensor_a, input_tensor_b);
     }
 
-    static std::vector<ttnn::Tensor> execute_on_worker_thread(
+    static std::vector<std::optional<ttnn::Tensor>> execute_on_main_thread(
         uint8_t queue_id,
         const Tensor &grad_tensor_arg,
         const Tensor &input_tensor_a_arg,
@@ -156,7 +155,7 @@ struct ExecuteBinaryBackward {
         return std::forward_as_tuple(grad_tensor, input_tensor_a, input_tensor_b);
     }
 
-    static std::vector<ttnn::Tensor> execute_on_worker_thread(
+    static std::vector<std::optional<ttnn::Tensor>> execute_on_main_thread(
         const Tensor &grad_tensor_arg,
         const Tensor &input_tensor_a_arg,
         const Tensor &input_tensor_b_arg,

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_backward/binary_backward_pybind.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_backward/binary_backward_pybind.hpp
@@ -54,14 +54,15 @@ Example:
                const ttnn::Tensor& grad_tensor,
                const ttnn::Tensor& input_tensor_a,
                const ttnn::Tensor& input_tensor_b,
-               const ttnn::MemoryConfig& memory_config) -> std::vector<ttnn::Tensor> {
-                return self(grad_tensor, input_tensor_a, input_tensor_b, memory_config);
+               const std::optional<ttnn::MemoryConfig>& memory_config) -> std::vector<ttnn::Tensor> {
+                auto output_memory_config = memory_config.value_or(input_tensor_a.memory_config());
+                return self(grad_tensor, input_tensor_a, output_memory_config, input_tensor_b);
             },
             py::arg("grad_tensor"),
             py::arg("input_tensor_a"),
             py::arg("input_tensor_b"),
             py::kw_only(),
-            py::arg("memory_config") = operation::DEFAULT_OUTPUT_MEMORY_CONFIG},
+            py::arg("memory_config") = std::nullopt},
 
 
         ttnn::pybind_overload_t{
@@ -90,7 +91,7 @@ Example:
                const std::vector<bool>& are_required_outputs,
                const std::optional<ttnn::Tensor>& optional_input_a_grad,
                const std::optional<ttnn::Tensor>& optional_input_b_grad,
-               const uint8_t& queue_id) -> std::vector<ttnn::Tensor> {
+               const uint8_t& queue_id) -> std::vector<optional<ttnn::Tensor>> {
                 return self(queue_id, grad_tensor, input_tensor_a, input_tensor_b, memory_config, are_required_outputs, optional_input_a_grad, optional_input_b_grad);
             },
             py::arg("grad_tensor"),
@@ -111,7 +112,7 @@ Example:
                const std::optional<ttnn::MemoryConfig>& memory_config,
                const std::vector<bool>& are_required_outputs,
                const std::optional<ttnn::Tensor>& optional_input_a_grad,
-               const std::optional<ttnn::Tensor>& optional_input_b_grad) -> std::vector<ttnn::Tensor> {
+               const std::optional<ttnn::Tensor>& optional_input_b_grad) -> std::vector<optional<ttnn::Tensor>> {
                 return self(grad_tensor, input_tensor_a, input_tensor_b, memory_config, are_required_outputs, optional_input_a_grad, optional_input_b_grad);
             },
             py::arg("grad_tensor"),
@@ -133,7 +134,7 @@ Example:
                const std::vector<bool>& are_required_outputs,
                const std::optional<ttnn::Tensor>& optional_input_a_grad,
                const std::optional<ttnn::Tensor>& optional_input_b_grad,
-               const uint8_t& queue_id) -> std::vector<ttnn::Tensor> {
+               const uint8_t& queue_id) -> std::vector<optional<ttnn::Tensor>> {
                 return self(queue_id, grad_tensor, input_tensor_a, input_tensor_b, alpha, memory_config, are_required_outputs, optional_input_a_grad, optional_input_b_grad);
             },
             py::arg("grad_tensor"),
@@ -156,7 +157,7 @@ Example:
                const std::optional<ttnn::MemoryConfig>& memory_config,
                const std::vector<bool>& are_required_outputs,
                const std::optional<ttnn::Tensor>& optional_input_a_grad,
-               const std::optional<ttnn::Tensor>& optional_input_b_grad) -> std::vector<ttnn::Tensor> {
+               const std::optional<ttnn::Tensor>& optional_input_b_grad) -> std::vector<optional<ttnn::Tensor>> {
                 return self(grad_tensor, input_tensor_a, input_tensor_b, alpha, memory_config, are_required_outputs, optional_input_a_grad, optional_input_b_grad);
             },
             py::arg("grad_tensor"),


### PR DESCRIPTION
#9570 

### Issue : 
Binary backward migration process required optional tensor support  (`std::vector<std::optional<Tensor>>`) in `ttnn/cpp/ttnn/decorators.hpp`. The current structure `execute_on_worker_thread` supports only tensor or vector of tensor as return type [ref](https://github.com/tenstorrent/tt-metal/blob/a7234fb67c09295cf1cbb155102e195b0b80cb32/ttnn/cpp/ttnn/decorators.hpp#L245)
```
static_assert(
    tt::stl::concepts::always_false_v<concrete_operation_t>,
    "Operation is expecting the execute_on_worker_thread method to return either a single Tensor or a "
    "vector of "
    "Tensor(s).");
```

### Fix Provided: 
As suggested by @arakhmati , used `execute_on_main_thread`  method