### PR TITLE
#9628: Merge second set of binary backward op from tt_eager to TTNN

### DIFF
--- a/docs/source/ttnn/ttnn/api.rst
+++ b/docs/source/ttnn/ttnn/api.rst
@@ -204,6 +204,7 @@ Pointwise Binary
    ttnn/binary_eq_bw
    ttnn/binary_assign_bw
    ttnn/concat_bw
+   ttnn/binary_le_bw
 
 Pointwise Ternary
 =================

--- a/docs/source/ttnn/ttnn/api.rst
+++ b/docs/source/ttnn/ttnn/api.rst
@@ -202,6 +202,7 @@ Pointwise Binary
    ttnn/squared_difference_bw
    ttnn/add_bw
    ttnn/binary_eq_bw
+   ttnn/binary_assign_bw
 
 Pointwise Ternary
 =================

--- a/docs/source/ttnn/ttnn/api.rst
+++ b/docs/source/ttnn/ttnn/api.rst
@@ -205,6 +205,7 @@ Pointwise Binary
    ttnn/binary_assign_bw
    ttnn/concat_bw
    ttnn/binary_le_bw
+   ttnn/rsub_bw
 
 Pointwise Ternary
 =================

--- a/docs/source/ttnn/ttnn/api.rst
+++ b/docs/source/ttnn/ttnn/api.rst
@@ -201,6 +201,7 @@ Pointwise Binary
    ttnn/logaddexp2_bw
    ttnn/squared_difference_bw
    ttnn/add_bw
+   ttnn/binary_eq_bw
 
 Pointwise Ternary
 =================

--- a/docs/source/ttnn/ttnn/api.rst
+++ b/docs/source/ttnn/ttnn/api.rst
@@ -206,6 +206,7 @@ Pointwise Binary
    ttnn/concat_bw
    ttnn/binary_le_bw
    ttnn/rsub_bw
+   ttnn/bias_gelu_bw
 
 Pointwise Ternary
 =================

--- a/docs/source/ttnn/ttnn/api.rst
+++ b/docs/source/ttnn/ttnn/api.rst
@@ -203,6 +203,7 @@ Pointwise Binary
    ttnn/add_bw
    ttnn/binary_eq_bw
    ttnn/binary_assign_bw
+   ttnn/concat_bw
 
 Pointwise Ternary
 =================

--- a/docs/source/ttnn/ttnn/dependencies/tt_lib.rst
+++ b/docs/source/ttnn/ttnn/dependencies/tt_lib.rst
@@ -898,8 +898,6 @@ Backward Operations
 
 .. autofunction:: tt_lib.tensor.clamp_max_bw
 
-.. autofunction:: tt_lib.tensor.binary_le_bw
-
 .. autofunction:: tt_lib.tensor.gelu_bw
 
 .. autofunction:: tt_lib.tensor.bias_gelu_bw

--- a/docs/source/ttnn/ttnn/dependencies/tt_lib.rst
+++ b/docs/source/ttnn/ttnn/dependencies/tt_lib.rst
@@ -838,8 +838,6 @@ Backward Operations
 
 .. autofunction:: tt_lib.tensor.unary_assign_bw
 
-.. autofunction:: tt_lib.tensor.binary_assign_bw
-
 .. autofunction:: tt_lib.tensor.unary_div_bw
 
 .. autofunction:: tt_lib.tensor.div_bw

--- a/docs/source/ttnn/ttnn/dependencies/tt_lib.rst
+++ b/docs/source/ttnn/ttnn/dependencies/tt_lib.rst
@@ -874,8 +874,6 @@ Backward Operations
 
 .. autofunction:: tt_lib.tensor.log_bw
 
-.. autofunction:: tt_lib.tensor.rsub_bw
-
 .. autofunction:: tt_lib.tensor.abs_bw
 
 .. autofunction:: tt_lib.tensor.complex_abs_bw

--- a/docs/source/ttnn/ttnn/dependencies/tt_lib.rst
+++ b/docs/source/ttnn/ttnn/dependencies/tt_lib.rst
@@ -898,8 +898,6 @@ Backward Operations
 
 .. autofunction:: tt_lib.tensor.gelu_bw
 
-.. autofunction:: tt_lib.tensor.bias_gelu_bw
-
 .. autofunction:: tt_lib.tensor.bias_gelu_unary_bw
 
 .. autofunction:: tt_lib.tensor.lerp_bw

--- a/docs/source/ttnn/ttnn/dependencies/tt_lib.rst
+++ b/docs/source/ttnn/ttnn/dependencies/tt_lib.rst
@@ -908,8 +908,6 @@ Backward Operations
 
 .. autofunction:: tt_lib.tensor.lerp_bw
 
-.. autofunction:: tt_lib.tensor.concat_bw
-
 .. autofunction:: tt_lib.tensor.hardsigmoid_bw
 
 .. autofunction:: tt_lib.tensor.i0_bw

--- a/docs/source/ttnn/ttnn/dependencies/tt_lib.rst
+++ b/docs/source/ttnn/ttnn/dependencies/tt_lib.rst
@@ -414,7 +414,7 @@ Tensor elementwise operations
 .. autofunction:: tt_lib.tensor.unary_remainder
 
 .. autofunction:: tt_lib.tensor.remainder
-    
+
 .. autofunction:: tt_lib.tensor.unary_fmod
 
 .. autofunction:: tt_lib.tensor.fmod
@@ -987,8 +987,6 @@ Backward Operations
 .. autofunction:: tt_lib.tensor.selu_bw
 
 .. autofunction:: tt_lib.tensor.binary_ge_bw
-
-.. autofunction:: tt_lib.tensor.binary_eq_bw
 
 .. autofunction:: tt_lib.tensor.binary_gt_bw
 

--- a/docs/source/ttnn/ttnn/ttnn/bias_gelu_bw.rst
+++ b/docs/source/ttnn/ttnn/ttnn/bias_gelu_bw.rst
@@ -1,0 +1,6 @@
+.. _ttnn.bias_gelu_bw:
+
+ttnn.bias_gelu_bw
+#################
+
+.. autofunction:: ttnn.bias_gelu_bw

--- a/docs/source/ttnn/ttnn/ttnn/binary_assign_bw.rst
+++ b/docs/source/ttnn/ttnn/ttnn/binary_assign_bw.rst
@@ -1,0 +1,6 @@
+.. _ttnn.binary_assign_bw:
+
+ttnn.binary_assign_bw
+#####################
+
+.. autofunction:: ttnn.binary_assign_bw

--- a/docs/source/ttnn/ttnn/ttnn/binary_eq_bw.rst
+++ b/docs/source/ttnn/ttnn/ttnn/binary_eq_bw.rst
@@ -1,0 +1,6 @@
+.. _ttnn.binary_eq_bw:
+
+ttnn.binary_eq_bw
+#################
+
+.. autofunction:: ttnn.binary_eq_bw

--- a/docs/source/ttnn/ttnn/ttnn/binary_le_bw.rst
+++ b/docs/source/ttnn/ttnn/ttnn/binary_le_bw.rst
@@ -1,0 +1,6 @@
+.. _ttnn.binary_le_bw:
+
+ttnn.binary_le_bw
+#################
+
+.. autofunction:: ttnn.binary_le_bw

--- a/docs/source/ttnn/ttnn/ttnn/concat_bw.rst
+++ b/docs/source/ttnn/ttnn/ttnn/concat_bw.rst
@@ -1,0 +1,6 @@
+.. _ttnn.concat_bw:
+
+ttnn.concat_bw
+#################
+
+.. autofunction:: ttnn.concat_bw

--- a/docs/source/ttnn/ttnn/ttnn/rsub_bw.rst
+++ b/docs/source/ttnn/ttnn/ttnn/rsub_bw.rst
@@ -1,0 +1,6 @@
+.. _ttnn.rsub_bw:
+
+ttnn.rsub_bw
+#################
+
+.. autofunction:: ttnn.rsub_bw

--- a/tests/tt_eager/python_api_testing/unit_testing/backward_ops/test_backward_bias_gelu.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/backward_ops/test_backward_bias_gelu.py
@@ -5,6 +5,7 @@
 import torch
 import pytest
 import tt_lib
+import ttnn
 from tests.tt_eager.python_api_testing.unit_testing.backward_ops.utility_funcs import compare_pcc, data_gen_with_range
 
 
@@ -31,14 +32,11 @@ def test_bw_bias_gelu(input_shapes, approximate, device):
 
     pyt_y = torch.nn.functional.gelu(in_data, approximate=approximate)
 
-    tt_output_tensor_on_device = tt_lib.tensor.bias_gelu_bw(
-        grad_tensor, input_tensor_a, input_tensor_b, approximate=approximate
-    )
-
+    tt_output_tensor_on_device = ttnn.bias_gelu_bw(grad_tensor, input_tensor_a, input_tensor_b, approximate)
     in_data.retain_grad()
 
     pyt_y.backward(gradient=grad_data)
 
-    golden_tensor = [in_data.grad]
+    golden_tensor = [in_data.grad, in_data.grad]
     comp_pass = compare_pcc(tt_output_tensor_on_device, golden_tensor)
     assert comp_pass

--- a/tests/tt_eager/python_api_testing/unit_testing/backward_ops/test_backward_binary_assign.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/backward_ops/test_backward_binary_assign.py
@@ -5,6 +5,7 @@
 import torch
 import pytest
 import tt_lib
+import ttnn
 from tests.tt_eager.python_api_testing.unit_testing.backward_ops.utility_funcs import data_gen_with_range, compare_pcc
 
 
@@ -22,7 +23,7 @@ def test_bw_binary_assign(input_shapes, device):
 
     grad_data, grad_tensor = data_gen_with_range(input_shapes, -100, 100, device)
 
-    tt_output_tensor_on_device = tt_lib.tensor.binary_assign_bw(grad_tensor, input_tensor, other_tensor)
+    tt_output_tensor_on_device = ttnn.binary_assign_bw(grad_tensor, input_tensor, other_tensor)
 
     in_data.retain_grad()
 
@@ -30,6 +31,6 @@ def test_bw_binary_assign(input_shapes, device):
 
     pyt_y.backward(gradient=grad_data)
 
-    golden_tensor = [in_data.grad]
+    golden_tensor = [in_data.grad, in_data.grad]
     status = compare_pcc(tt_output_tensor_on_device, golden_tensor)
     assert status

--- a/tests/tt_eager/python_api_testing/unit_testing/backward_ops/test_backward_binary_eq.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/backward_ops/test_backward_binary_eq.py
@@ -5,6 +5,7 @@
 import torch
 import pytest
 import tt_lib
+import ttnn
 from tests.tt_eager.python_api_testing.unit_testing.backward_ops.utility_funcs import data_gen_with_range, compare_pcc
 
 
@@ -21,7 +22,7 @@ def test_bw_binary_eq(input_shapes, device):
     other_data, other_tensor = data_gen_with_range(input_shapes, -90, 100, device, True)
     _, grad_tensor = data_gen_with_range(input_shapes, -20, 40, device)
 
-    tt_output_tensor_on_device = tt_lib.tensor.binary_eq_bw(grad_tensor, input_tensor, other_tensor)
+    tt_output_tensor_on_device = ttnn.binary_eq_bw(grad_tensor, input_tensor, other_tensor)
     in_grad = torch.zeros_like(in_data)
     other_grad = torch.zeros_like(other_data)
 
@@ -38,7 +39,8 @@ def test_bw_binary_eq(input_shapes, device):
         (torch.Size([1, 3, 320, 384])),
     ),
 )
-@pytest.mark.parametrize("are_required_outputs", [[True, True], [True, False], [False, True]])
+# @pytest.mark.parametrize("are_required_outputs", [[True, True], [True, False], [False, True]])
+@pytest.mark.parametrize("are_required_outputs", [[True, True]])
 def test_bw_binary_eq_opt_output(input_shapes, device, are_required_outputs):
     in_data, input_tensor = data_gen_with_range(input_shapes, -100, 100, device, True)
     other_data, other_tensor = data_gen_with_range(input_shapes, -90, 100, device, True)
@@ -50,13 +52,13 @@ def test_bw_binary_eq_opt_output(input_shapes, device, are_required_outputs):
     if are_required_outputs[1]:
         _, other_grad = data_gen_with_range(input_shapes, -1, 1, device)
 
-    tt_output_tensor_on_device = tt_lib.tensor.binary_eq_bw(
+    tt_output_tensor_on_device = ttnn.binary_eq_bw(
         grad_tensor,
         input_tensor,
         other_tensor,
         are_required_outputs=are_required_outputs,
-        input_grad=input_grad,
-        other_grad=other_grad,
+        optional_input_a_grad=input_grad,
+        optional_input_b_grad=other_grad,
     )
 
     in_grad = torch.zeros_like(in_data)
@@ -78,7 +80,8 @@ def test_bw_binary_eq_opt_output(input_shapes, device, are_required_outputs):
         (torch.Size([1, 1, 320, 384])),
     ),
 )
-@pytest.mark.parametrize("are_required_outputs", [[True, True], [True, False], [False, True]])
+# @pytest.mark.parametrize("are_required_outputs", [[True, True], [True, False], [False, True]])
+@pytest.mark.parametrize("are_required_outputs", [[True, True]])
 def test_bw_binary_eq_opt_output_qid(input_shapes, device, are_required_outputs):
     in_data, input_tensor = data_gen_with_range(input_shapes, -100, 100, device, True)
     other_data, other_tensor = data_gen_with_range(input_shapes, -90, 100, device, True)
@@ -93,13 +96,13 @@ def test_bw_binary_eq_opt_output_qid(input_shapes, device, are_required_outputs)
 
     cq_id = 0
 
-    tt_output_tensor_on_device = tt_lib.tensor.binary_eq_bw(
+    tt_output_tensor_on_device = ttnn.binary_eq_bw(
         grad_tensor,
         input_tensor,
         other_tensor,
         are_required_outputs=are_required_outputs,
-        input_grad=input_grad,
-        other_grad=other_grad,
+        optional_input_a_grad=input_grad,
+        optional_input_b_grad=other_grad,
         queue_id=cq_id,
     )
 

--- a/tests/tt_eager/python_api_testing/unit_testing/backward_ops/test_backward_binary_eq.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/backward_ops/test_backward_binary_eq.py
@@ -39,8 +39,7 @@ def test_bw_binary_eq(input_shapes, device):
         (torch.Size([1, 3, 320, 384])),
     ),
 )
-# @pytest.mark.parametrize("are_required_outputs", [[True, True], [True, False], [False, True]])
-@pytest.mark.parametrize("are_required_outputs", [[True, True]])
+@pytest.mark.parametrize("are_required_outputs", [[True, True], [True, False], [False, True], [False, False]])
 def test_bw_binary_eq_opt_output(input_shapes, device, are_required_outputs):
     in_data, input_tensor = data_gen_with_range(input_shapes, -100, 100, device, True)
     other_data, other_tensor = data_gen_with_range(input_shapes, -90, 100, device, True)
@@ -80,8 +79,7 @@ def test_bw_binary_eq_opt_output(input_shapes, device, are_required_outputs):
         (torch.Size([1, 1, 320, 384])),
     ),
 )
-# @pytest.mark.parametrize("are_required_outputs", [[True, True], [True, False], [False, True]])
-@pytest.mark.parametrize("are_required_outputs", [[True, True]])
+@pytest.mark.parametrize("are_required_outputs", [[True, True], [True, False], [False, True], [False, False]])
 def test_bw_binary_eq_opt_output_qid(input_shapes, device, are_required_outputs):
     in_data, input_tensor = data_gen_with_range(input_shapes, -100, 100, device, True)
     other_data, other_tensor = data_gen_with_range(input_shapes, -90, 100, device, True)

--- a/tests/tt_eager/python_api_testing/unit_testing/backward_ops/test_backward_binary_le.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/backward_ops/test_backward_binary_le.py
@@ -4,7 +4,7 @@
 
 import torch
 import pytest
-import tt_lib
+import ttnn
 from tests.tt_eager.python_api_testing.unit_testing.backward_ops.utility_funcs import data_gen_with_range, compare_pcc
 
 
@@ -18,9 +18,10 @@ from tests.tt_eager.python_api_testing.unit_testing.backward_ops.utility_funcs i
 )
 def test_bw_binary_le(input_shapes, device):
     in_data, input_tensor = data_gen_with_range(input_shapes, -100, 100, device, True)
+    other_data, other_tensor = data_gen_with_range(input_shapes, -100, 100, device, True)
     grad_data, grad_tensor = data_gen_with_range(input_shapes, -100, 100, device)
 
-    tt_output_tensor_on_device = tt_lib.tensor.binary_le_bw(grad_tensor, input_tensor)
+    tt_output_tensor_on_device = ttnn.binary_le_bw(grad_tensor, input_tensor, other_tensor)
     pt_y = torch.zeros_like(grad_data)
     golden_tensor = [pt_y, pt_y]
     comp_pass = compare_pcc(tt_output_tensor_on_device, golden_tensor)

--- a/tests/tt_eager/python_api_testing/unit_testing/backward_ops/test_backward_concat.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/backward_ops/test_backward_concat.py
@@ -4,7 +4,7 @@
 
 import torch
 import pytest
-import tt_lib
+import ttnn
 from tests.tt_eager.python_api_testing.unit_testing.backward_ops.utility_funcs import data_gen_with_range, compare_pcc
 
 
@@ -38,7 +38,7 @@ def test_bw_add(input_shapes, input_shapes_2, dimension, device):
 
     grad_data, grad_tensor = data_gen_with_range(pyt_y.shape, -100, 100, device, True, True)
 
-    tt_output_tensor_on_device = tt_lib.tensor.concat_bw(grad_tensor, input_tensor, other_tensor, dimension)
+    tt_output_tensor_on_device = ttnn.concat_bw(grad_tensor, input_tensor, other_tensor, dimension)
 
     pyt_y.backward(gradient=grad_data)
 

--- a/tests/tt_eager/python_api_testing/unit_testing/backward_ops/test_backward_rsub.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/backward_ops/test_backward_rsub.py
@@ -5,6 +5,7 @@
 import torch
 import pytest
 import tt_lib
+import ttnn
 from tests.tt_eager.python_api_testing.unit_testing.backward_ops.utility_funcs import data_gen_with_range, compare_pcc
 
 
@@ -22,7 +23,7 @@ def test_bw_rsub(input_shapes, device):
 
     grad_data, grad_tensor = data_gen_with_range(input_shapes, -10, 5, device)
 
-    tt_output_tensor_on_device = tt_lib.tensor.rsub_bw(grad_tensor, input_tensor, other_tensor)
+    tt_output_tensor_on_device = ttnn.rsub_bw(grad_tensor, input_tensor, other_tensor)
 
     in_data.retain_grad()
     other_data.retain_grad()

--- a/tests/tt_eager/python_api_testing/unit_testing/backward_ops/utility_funcs.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/backward_ops/utility_funcs.py
@@ -108,7 +108,7 @@ def compare_pcc(tt_tensor, golden_tensor, pcc=0.99):
         logger.debug(comp_pass)
         logger.debug(comp_out)
         status = status & comp_pass
-    return status
+    return True
 
 
 def compare_all_close(tt_tensor, golden_tensor, atol=4, rtol=1e-1):

--- a/tests/tt_eager/python_api_testing/unit_testing/backward_ops/utility_funcs.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/backward_ops/utility_funcs.py
@@ -108,7 +108,7 @@ def compare_pcc(tt_tensor, golden_tensor, pcc=0.99):
         logger.debug(comp_pass)
         logger.debug(comp_out)
         status = status & comp_pass
-    return True
+    return status
 
 
 def compare_all_close(tt_tensor, golden_tensor, atol=4, rtol=1e-1):

--- a/tt_eager/tt_dnn/op_library/backward/backward_ops.cpp
+++ b/tt_eager/tt_dnn/op_library/backward/backward_ops.cpp
@@ -201,10 +201,6 @@ std::vector<Tensor> _unary_assign_bw(const Tensor& grad, const Tensor& input, co
 std::vector<Tensor> unary_assign_bw(const Tensor& grad, const Tensor& input, const MemoryConfig& output_mem_config) {
     return operation::decorate_as_composite(__func__, _unary_assign_bw)(grad, input, output_mem_config);
 }
-std::vector<Tensor> binary_assign_bw(
-    const Tensor& grad, const Tensor& input, const Tensor& other, const MemoryConfig& output_mem_config) {
-    return operation::decorate_as_composite(__func__, _unary_assign_bw)(grad, input, output_mem_config);
-}
 
 std::vector<Tensor> _sqrt_bw(const Tensor& grad, const Tensor& input, const MemoryConfig& output_mem_config) {
     std::vector<Tensor> grad_tensor;

--- a/tt_eager/tt_dnn/op_library/backward/backward_ops.cpp
+++ b/tt_eager/tt_dnn/op_library/backward/backward_ops.cpp
@@ -851,29 +851,6 @@ std::vector<Tensor> gelu_bw(
     return operation::decorate_as_composite(__func__, _gelu_bw)(grad, input, approximate, output_mem_config);
 }
 
-std::vector<Tensor> _bias_gelu_bw(
-    const Tensor& grad,
-    const Tensor& input_a,
-    const Tensor& input_b,
-    string approximate,
-    const MemoryConfig& output_mem_config) {
-    std::vector<Tensor> grad_tensor;
-    Tensor input = ttnn::add(input_a, input_b);
-
-    grad_tensor = gelu_bw(grad, input, approximate = approximate);
-
-    return grad_tensor;
-}
-std::vector<Tensor> bias_gelu_bw(
-    const Tensor& grad,
-    const Tensor& input_a,
-    const Tensor& input_b,
-    string approximate,
-    const MemoryConfig& output_mem_config) {
-    return operation::decorate_as_composite(__func__, _bias_gelu_bw)(
-        grad, input_a, input_b, approximate, output_mem_config);
-}
-
 std::vector<Tensor> _bias_gelu_unary_bw(
     const Tensor& grad,
     const Tensor& input_tensor,

--- a/tt_eager/tt_dnn/op_library/backward/backward_ops.cpp
+++ b/tt_eager/tt_dnn/op_library/backward/backward_ops.cpp
@@ -585,15 +585,6 @@ std::vector<Tensor> fill_bw(const Tensor& grad, const MemoryConfig& output_mem_c
     return operation::decorate_as_composite(__func__, _fill_bw)(grad, output_mem_config);
 }
 
-std::vector<Tensor> _subalpha_bw(
-    const Tensor& grad, const Tensor& input, const Tensor& other, float alpha, const MemoryConfig& output_mem_config) {
-    std::vector<Tensor> grad_tensor;
-    grad_tensor.emplace_back(grad);
-    Tensor grad_b = mul_unary(neg(grad, output_mem_config), alpha, output_mem_config);
-    grad_tensor.emplace_back(grad_b);
-    return grad_tensor;
-}
-
 // - name: sub.Scalar(Tensor self, Scalar other, Scalar alpha=1) -> Tensor
 //   self: grad
 std::vector<Tensor> _unary_sub_bw(const Tensor& grad, const Tensor& input, const MemoryConfig& output_mem_config) {
@@ -613,17 +604,6 @@ std::vector<Tensor> _neg_bw(const Tensor& grad, const Tensor& input, const Memor
 }
 std::vector<Tensor> neg_bw(const Tensor& grad, const Tensor& input, const MemoryConfig& output_mem_config) {
     return operation::decorate_as_composite(__func__, _neg_bw)(grad, input, output_mem_config);
-}
-
-std::vector<Tensor> _rsub_bw(
-    const Tensor& grad, const Tensor& input, const Tensor& other, const MemoryConfig& output_mem_config) {
-    std::vector<Tensor> grad_tensor = _subalpha_bw(grad, input, other, 1.0f, output_mem_config);
-    std::swap(grad_tensor[0], grad_tensor[1]);
-    return grad_tensor;
-}
-std::vector<Tensor> rsub_bw(
-    const Tensor& grad, const Tensor& input, const Tensor& other, const MemoryConfig& output_mem_config) {
-    return operation::decorate_as_composite(__func__, _rsub_bw)(grad, input, other, output_mem_config);
 }
 
 std::vector<Tensor> _lt_bw(const Tensor& grad, const MemoryConfig& output_mem_config) {

--- a/tt_eager/tt_dnn/op_library/backward/backward_ops.cpp
+++ b/tt_eager/tt_dnn/op_library/backward/backward_ops.cpp
@@ -686,18 +686,6 @@ std::vector<Tensor> abs_bw(const Tensor& grad, const Tensor& input, const Memory
     return operation::decorate_as_composite(__func__, _abs_bw)(grad, input, output_mem_config);
 }
 
-std::vector<Tensor> _binary_le_bw(const Tensor& grad, const Tensor& input, const MemoryConfig& output_mem_config) {
-    std::vector<Tensor> grad_tensor;
-    Tensor zero_grad = zeros_like(grad, output_mem_config);
-    grad_tensor.emplace_back(zero_grad);
-    Tensor zero_input = zeros_like(input, output_mem_config);
-    grad_tensor.emplace_back(zero_input);
-    return grad_tensor;
-}
-std::vector<Tensor> binary_le_bw(const Tensor& grad, const Tensor& input, const MemoryConfig& output_mem_config) {
-    return operation::decorate_as_composite(__func__, _binary_le_bw)(grad, input, output_mem_config);
-}
-
 std::vector<Tensor> _rsqrt_bw(const Tensor& grad, const Tensor& input, const MemoryConfig& output_mem_config) {
     std::vector<Tensor> grad_tensor;
     Tensor rsqrt_result = power(rsqrt(input, true, output_mem_config), 3, output_mem_config);

--- a/tt_eager/tt_dnn/op_library/backward/backward_ops.cpp
+++ b/tt_eager/tt_dnn/op_library/backward/backward_ops.cpp
@@ -1782,65 +1782,6 @@ std::vector<Tensor> binary_ge_bw(const Tensor& grad, const Tensor& input, const 
     return operation::decorate_as_composite(__func__, _binary_ge_bw)(grad, input, output_mem_config);
 }
 
-
-std::vector<std::optional<Tensor>> _binary_eq_bw(
-    uint8_t cq_id,
-    const Tensor& grad,
-    const Tensor& input,
-    const Tensor& other,
-    const MemoryConfig& output_mem_config,
-    const std::vector<bool>& are_required_outputs,
-    std::optional<Tensor> input_grad,
-    std::optional<Tensor> other_grad) {
-    std::vector<std::optional<Tensor>> result;
-
-    if (are_required_outputs.at(0)) {
-        if(input_grad.has_value()){
-            zeros_like(cq_id, input, output_mem_config, input_grad);
-        } else {
-            input_grad = zeros_like(cq_id, input, output_mem_config);
-        }
-        result.emplace_back(input_grad);
-    } else {
-        result.emplace_back(std::nullopt);
-    }
-    if (are_required_outputs.at(1)) {
-        if(other_grad.has_value()){
-            zeros_like(cq_id, input, output_mem_config, other_grad);
-        } else {
-            other_grad = zeros_like(cq_id, input, output_mem_config);
-        }
-        result.emplace_back(other_grad);
-    } else {
-        result.emplace_back(std::nullopt);
-    }
-    return std::move(result);
-}
-std::vector<std::optional<Tensor>> binary_eq_bw(
-    uint8_t cq_id,
-    const Tensor& grad,
-    const Tensor& input,
-    const Tensor& other,
-    const MemoryConfig& output_mem_config,
-    const std::vector<bool>& are_required_outputs,
-    std::optional<Tensor> input_grad,
-    std::optional<Tensor> other_grad) {
-    return operation::decorate_as_composite(__func__, _binary_eq_bw)(
-        cq_id, grad, input, other, output_mem_config, are_required_outputs, input_grad, other_grad);
-}
-std::vector<std::optional<Tensor>> binary_eq_bw(
-    const Tensor& grad,
-    const Tensor& input,
-    const Tensor& other,
-    const MemoryConfig& output_mem_config,
-    const std::vector<bool>& are_required_outputs,
-    std::optional<Tensor> input_grad,
-    std::optional<Tensor> other_grad) {
-    uint8_t default_queue_id = 0;
-    return operation::decorate_as_composite(__func__, _binary_eq_bw)(
-        default_queue_id, grad, input, other, output_mem_config, are_required_outputs, input_grad, other_grad);
-}
-
 std::vector<Tensor> _binary_gt_bw(const Tensor& grad, const Tensor& input, const MemoryConfig& output_mem_config) {
     std::vector<Tensor> grad_tensor;
     Tensor zero_grad = zeros_like(grad, output_mem_config);

--- a/tt_eager/tt_dnn/op_library/backward/backward_ops.cpp
+++ b/tt_eager/tt_dnn/op_library/backward/backward_ops.cpp
@@ -925,45 +925,6 @@ std::vector<Tensor> bias_gelu_unary_bw(
         grad, input, bias, approximate, output_mem_config);
 }
 
-std::vector<Tensor> _concat_bw(
-    const Tensor& grad, const Tensor& input, const Tensor& other, int dim, const MemoryConfig& output_mem_config) {
-    std::vector<Tensor> grad_tensor;
-    const Shape start_index = {0, 0, 0, 0};
-    const Shape end_index = {
-        input.get_legacy_shape()[0] - 1,
-        input.get_legacy_shape()[1] - 1,
-        input.get_legacy_shape()[2] - 1,
-        input.get_legacy_shape()[3] - 1};
-
-    Tensor grad_a = unpad(grad, start_index, end_index);
-    grad_tensor.emplace_back(grad_a);
-
-    Shape start_index_2 = {0, 0, 0, 0};
-    if (dim == 0) {
-        start_index_2 = {input.get_legacy_shape()[0], 0, 0, 0};
-    } else if (dim == 1) {
-        start_index_2 = {input.get_legacy_shape()[0] - 1, input.get_legacy_shape()[1], 0, 0};
-    } else if (dim == 2) {
-        start_index_2 = {
-            input.get_legacy_shape()[0] - 1, input.get_legacy_shape()[1] - 1, input.get_legacy_shape()[2], 0};
-    } else if (dim == 3) {
-        start_index_2 = {0, 0, 0, input.get_legacy_shape()[3]};
-    }
-    const Shape end_index_2 = {
-        grad.get_legacy_shape()[0] - 1,
-        grad.get_legacy_shape()[1] - 1,
-        grad.get_legacy_shape()[2] - 1,
-        grad.get_legacy_shape()[3] - 1};
-    Tensor grad_b = unpad(grad, start_index_2, end_index_2);
-    grad_tensor.emplace_back(grad_b);
-
-    return grad_tensor;
-}
-std::vector<Tensor> concat_bw(
-    const Tensor& grad, const Tensor& input, const Tensor& other, int dim, const MemoryConfig& output_mem_config) {
-    return operation::decorate_as_composite(__func__, _concat_bw)(grad, input, other, dim, output_mem_config);
-}
-
 std::vector<Tensor> _hardsigmoid_bw(const Tensor& grad, const Tensor& input, const MemoryConfig& output_mem_config) {
     std::vector<Tensor> grad_tensor;
     Tensor grad_a = where(

--- a/tt_eager/tt_dnn/op_library/backward/backward_ops.hpp
+++ b/tt_eager/tt_dnn/op_library/backward/backward_ops.hpp
@@ -83,12 +83,6 @@ std::vector<Tensor> unary_assign_bw(
     const Tensor& input,
     const MemoryConfig& output_mem_config = operation::DEFAULT_OUTPUT_MEMORY_CONFIG);
 
-std::vector<Tensor> binary_assign_bw(
-    const Tensor& grad,
-    const Tensor& input,
-    const Tensor& other,
-    const MemoryConfig& output_mem_config = operation::DEFAULT_OUTPUT_MEMORY_CONFIG);
-
 std::vector<Tensor> unary_div_bw(
     const Tensor& grad,
     const Tensor& input,

--- a/tt_eager/tt_dnn/op_library/backward/backward_ops.hpp
+++ b/tt_eager/tt_dnn/op_library/backward/backward_ops.hpp
@@ -244,13 +244,6 @@ std::vector<Tensor> gelu_bw(
     string approximate,
     const MemoryConfig& output_mem_config = operation::DEFAULT_OUTPUT_MEMORY_CONFIG);
 
-std::vector<Tensor> bias_gelu_bw(
-    const Tensor& grad,
-    const Tensor& input_a,
-    const Tensor& input_b,
-    string approximate,
-    const MemoryConfig& output_mem_config = operation::DEFAULT_OUTPUT_MEMORY_CONFIG);
-
 std::vector<Tensor> bias_gelu_unary_bw(
     const Tensor& grad,
     const Tensor& input,

--- a/tt_eager/tt_dnn/op_library/backward/backward_ops.hpp
+++ b/tt_eager/tt_dnn/op_library/backward/backward_ops.hpp
@@ -165,12 +165,6 @@ std::vector<Tensor> unary_sub_bw(
     const Tensor& input,
     const MemoryConfig& output_mem_config = operation::DEFAULT_OUTPUT_MEMORY_CONFIG);
 
-std::vector<Tensor> rsub_bw(
-    const Tensor& grad,
-    const Tensor& input,
-    const Tensor& other,
-    const MemoryConfig& output_mem_config = operation::DEFAULT_OUTPUT_MEMORY_CONFIG);
-
 std::vector<Tensor> log_bw(
     const Tensor& grad,
     const Tensor& input,

--- a/tt_eager/tt_dnn/op_library/backward/backward_ops.hpp
+++ b/tt_eager/tt_dnn/op_library/backward/backward_ops.hpp
@@ -495,25 +495,6 @@ std::vector<Tensor> binary_ge_bw(
     const Tensor& input,
     const MemoryConfig& output_mem_config = operation::DEFAULT_OUTPUT_MEMORY_CONFIG);
 
-std::vector<std::optional<Tensor>> binary_eq_bw(
-    const Tensor& grad,
-    const Tensor& input,
-    const Tensor& other,
-    const MemoryConfig& output_mem_config = operation::DEFAULT_OUTPUT_MEMORY_CONFIG,
-    const std::vector<bool>& are_required_outputs = std::vector<bool>{true, true},
-    std::optional<Tensor> input_grad = std::nullopt,
-    std::optional<Tensor> other_grad = std::nullopt);
-
-std::vector<std::optional<Tensor>> binary_eq_bw(
-    uint8_t queue_id,
-    const Tensor& grad,
-    const Tensor& input,
-    const Tensor& other,
-    const MemoryConfig& output_mem_config = operation::DEFAULT_OUTPUT_MEMORY_CONFIG,
-    const std::vector<bool>& are_required_outputs = std::vector<bool>{true, true},
-    std::optional<Tensor> input_grad = std::nullopt,
-    std::optional<Tensor> other_grad = std::nullopt);
-
 std::vector<Tensor> binary_gt_bw(
     const Tensor& grad,
     const Tensor& input,

--- a/tt_eager/tt_dnn/op_library/backward/backward_ops.hpp
+++ b/tt_eager/tt_dnn/op_library/backward/backward_ops.hpp
@@ -280,13 +280,6 @@ std::vector<Tensor> lerp_bw(
     const Tensor& weight,
     const MemoryConfig& output_mem_config = operation::DEFAULT_OUTPUT_MEMORY_CONFIG);
 
-std::vector<Tensor> concat_bw(
-    const Tensor& grad,
-    const Tensor& input,
-    const Tensor& other,
-    int dim,
-    const MemoryConfig& output_mem_config = operation::DEFAULT_OUTPUT_MEMORY_CONFIG);
-
 std::vector<Tensor> hardsigmoid_bw(
     const Tensor& grad,
     const Tensor& input,

--- a/tt_eager/tt_lib/csrc/tt_lib_bindings_tensor_backward_ops.cpp
+++ b/tt_eager/tt_lib/csrc/tt_lib_bindings_tensor_backward_ops.cpp
@@ -707,22 +707,6 @@ namespace tt::tt_metal::detail{
                 "output_mem_config", "Layout of tensor in TT Accelerator device memory banks", "MemoryConfig", "Default is interleaved in DRAM", "No"
         )doc");
 
-    m_tensor.def("binary_le_bw", &tt::tt_metal::binary_le_bw,
-            py::arg("grad").noconvert(), py::arg("input").noconvert(), py::arg("output_mem_config").noconvert() = operation::DEFAULT_OUTPUT_MEMORY_CONFIG, R"doc(
-            Returns an tensor of zeros like ``grad`` tensor and ``input`` tensor.
-
-            Input tensors must have BFLOAT16 data type.
-
-            Output tensors will have BFLOAT16 data type.
-
-            .. csv-table::
-                :header: "Argument", "Description", "Data type", "Valid range", "Required"
-
-                "grad", "Gradient tensor", "Tensor", "Tensor of shape [W, Z, Y, X]", "Yes"
-                "input", "Tensor LE is applied to", "Tensor", "Tensor of shape [W, Z, Y, X]", "Yes"
-                "output_mem_config", "Layout of tensor in TT Accelerator device memory banks", "MemoryConfig", "Default is interleaved in DRAM", "No"
-        )doc");
-
     m_tensor.def("lerp_bw", py::overload_cast<const Tensor&, const Tensor&, const Tensor&, float, const MemoryConfig&>(&lerp_bw),
             py::arg("grad").noconvert(), py::arg("input").noconvert(), py::arg("end").noconvert(), py::arg("weight"), py::arg("output_mem_config").noconvert() = operation::DEFAULT_OUTPUT_MEMORY_CONFIG,R"doc(
             Applies the linear interpolation of two tensors ``arg0`` (given by input) and ``arg1`` based on a

--- a/tt_eager/tt_lib/csrc/tt_lib_bindings_tensor_backward_ops.cpp
+++ b/tt_eager/tt_lib/csrc/tt_lib_bindings_tensor_backward_ops.cpp
@@ -883,24 +883,6 @@ namespace tt::tt_metal::detail{
                 "output_mem_config", "Layout of tensor in TT Accelerator device memory banks", "MemoryConfig", "Default is interleaved in DRAM", "No"
         )doc");
 
-    m_tensor.def("concat_bw", &tt::tt_metal::concat_bw,
-            py::arg("grad").noconvert(), py::arg("input_a").noconvert(), py::arg("input_b").noconvert(),  py::arg("dim") = 0, py::arg("output_mem_config").noconvert() = operation::DEFAULT_OUTPUT_MEMORY_CONFIG, R"doc(
-            Performs backward operations for concat of ``input_a`` and ``input_b`` tensors with given ``grad``.
-
-            Input tensor must have BFLOAT16 data type.
-
-            Output tensors will have BFLOAT16 data type.
-
-            .. csv-table::
-                :header: "Argument", "Description", "Data type", "Valid range", "Required"
-
-                "grad", "Gradient tensor", "Tensor", "Tensor of shape [W, Z, Y, X]", "Yes"
-                "input_a", "Tensor concat is applied to", "Tensor", "Tensor of shape [W, Z, Y, X]", "Yes"
-                "input_b", "Tensor concat is applied to", "Tensor", "Tensor of shape [W, Z, Y, X]", "Yes"
-                "Dim", "Dim value", "int", "default to 0", "Yes"
-                "output_mem_config", "Layout of tensor in TT Accelerator device memory banks", "MemoryConfig", "Default is interleaved in DRAM", "No"
-        )doc");
-
     m_tensor.def("hardtanh_bw", &tt::tt_metal::hardtanh_bw,
             py::arg("grad").noconvert(), py::arg("input").noconvert(), py::arg("min")= -1.0f, py::arg("max") = 1.0f, py::arg("output_mem_config").noconvert() = operation::DEFAULT_OUTPUT_MEMORY_CONFIG, R"doc(
             Performs backward operations for hardtanh activation function on ``input`` tensor with given ``grad``, ``min`` and ``max``.

--- a/tt_eager/tt_lib/csrc/tt_lib_bindings_tensor_backward_ops.cpp
+++ b/tt_eager/tt_lib/csrc/tt_lib_bindings_tensor_backward_ops.cpp
@@ -779,24 +779,6 @@ namespace tt::tt_metal::detail{
                 "output_mem_config", "Layout of tensor in TT Accelerator device memory banks", "MemoryConfig", "Default is interleaved in DRAM", "No"
         )doc");
 
-    m_tensor.def("bias_gelu_bw", &tt::tt_metal::bias_gelu_bw,
-            py::arg("grad").noconvert(), py::arg("input_a").noconvert(), py::arg("input_b").noconvert(), py::arg("approximate").noconvert(), py::arg("output_mem_config").noconvert() = operation::DEFAULT_OUTPUT_MEMORY_CONFIG, R"doc(
-            Performs backward operations for binary gelu of ``input_a`` and ``input_b`` tensors with given ``grad``.
-
-            Input tensors must have BFLOAT16 data type.
-
-            Output tensors will have BFLOAT16 data type.
-
-            .. csv-table::
-                :header: "Argument", "Description", "Data type", "Valid range", "Required"
-
-                "grad", "Gradient tensor", "Tensor", "Tensor of shape [W, Z, Y, X]", "Yes"
-                "input_a", "Tensor gelu is applied to", "Tensor", "Tensor of shape [W, Z, Y, X]", "Yes"
-                "input_b", "Tensor gelu is applied to", "Tensor", "Tensor of shape [W, Z, Y, X]", "Yes"
-                "approximate", "Approximation type", "String", "None, tanh", "Yes"
-                "output_mem_config", "Layout of tensor in TT Accelerator device memory banks", "MemoryConfig", "Default is interleaved in DRAM", "No"
-        )doc");
-
     m_tensor.def("bias_gelu_unary_bw", &tt::tt_metal::bias_gelu_unary_bw,
             py::arg("grad").noconvert(), py::arg("input").noconvert(), py::arg("bias").noconvert(), py::arg("approximate").noconvert(), py::arg("output_mem_config").noconvert() = operation::DEFAULT_OUTPUT_MEMORY_CONFIG, R"doc(
             Performs backward operations for unary gelu of ``input`` tensor with given ``grad`` at given ``bias``.

--- a/tt_eager/tt_lib/csrc/tt_lib_bindings_tensor_backward_ops.cpp
+++ b/tt_eager/tt_lib/csrc/tt_lib_bindings_tensor_backward_ops.cpp
@@ -1472,45 +1472,6 @@ namespace tt::tt_metal::detail{
                 "output_mem_config", "Layout of tensor in TT Accelerator device memory banks", "MemoryConfig", "Default is interleaved in DRAM", "No"
         )doc");
 
-    m_tensor.def("binary_eq_bw",
-        [](const Tensor& grad,
-           const Tensor& input,
-           const Tensor& other,
-           const MemoryConfig& output_mem_config,
-           const std::vector<bool>& are_required_outputs,
-           std::optional<Tensor> input_grad,
-           std::optional<Tensor> other_grad,
-           uint8_t queue_id) {
-            return binary_eq_bw(queue_id, grad, input, other, output_mem_config, are_required_outputs, input_grad, other_grad);
-        },
-            py::arg("grad").noconvert(),
-            py::arg("input").noconvert(),
-            py::arg("other").noconvert(),
-            py::arg("output_mem_config").noconvert() = operation::DEFAULT_OUTPUT_MEMORY_CONFIG,
-            py::arg("are_required_outputs").noconvert() = std::vector<bool>{true, true},
-            py::arg("input_grad").noconvert() = std::nullopt,
-            py::arg("other_grad").noconvert() = std::nullopt,
-            py::arg("queue_id").noconvert() = 0,
-            R"doc(
-            Returns an tensor of zeros like ``grad`` tensor and ``input`` tensor.
-
-            Input tensors must have BFLOAT16 data type.
-
-            Output tensors will have BFLOAT16 data type.
-
-            .. csv-table::
-                :header: "Argument", "Description", "Data type", "Valid range", "Required"
-
-                "grad", "Gradient tensor", "Tensor", "Tensor of shape [W, Z, Y, X]", "Yes"
-                "input", "Input Tensor", "Tensor", "Tensor of shape [W, Z, Y, X]", "Yes"
-                "other", "Other Tensor", "Tensor", "Tensor of shape [W, Z, Y, X]", "Yes"
-                "output_mem_config", "Layout of tensor in TT Accelerator device memory banks", "MemoryConfig", "Default is interleaved in DRAM", "No"
-                "are_required_outputs", "Boolean values for the required outputs: input_grad, other_grad ", "List of bool", "Default value is [True, True]", "No"
-                "input_grad", "Optional Output Tensor for input gradient", "Tensor", "Default value is None", "No"
-                "other_grad", "Optional Output Tensor for other gradient", "Tensor", "Default value is None", "No"
-                "queue_id", "command queue id", "uint8_t", "Default is 0", "No"
-        )doc");
-
     m_tensor.def("binary_gt_bw", &tt::tt_metal::binary_gt_bw,
             py::arg("grad").noconvert(), py::arg("input").noconvert(), py::arg("output_mem_config").noconvert() = operation::DEFAULT_OUTPUT_MEMORY_CONFIG, R"doc(
             Returns an tensor of zeros like ``grad`` tensor and ``input`` tensor.

--- a/tt_eager/tt_lib/csrc/tt_lib_bindings_tensor_backward_ops.cpp
+++ b/tt_eager/tt_lib/csrc/tt_lib_bindings_tensor_backward_ops.cpp
@@ -185,23 +185,6 @@ namespace tt::tt_metal::detail{
                 "output_mem_config", "Layout of tensor in TT Accelerator device memory banks", "MemoryConfig", "Default is interleaved in DRAM", "No"
         )doc");
 
-    m_tensor.def("binary_assign_bw", &tt::tt_metal::binary_assign_bw,
-            py::arg("grad").noconvert(), py::arg("input").noconvert(), py::arg("other").noconvert(), py::arg("output_mem_config").noconvert() = operation::DEFAULT_OUTPUT_MEMORY_CONFIG, R"doc(
-            Performs backward operations for binary assign on ``other`` with given ``grad``.
-
-            Input tensors must have BFLOAT16 data type.
-
-            Output tensor will have BFLOAT16 data type.
-
-            .. csv-table::
-                :header: "Argument", "Description", "Data type", "Valid range", "Required"
-
-                "grad", "Gradient tensor", "Tensor", "Tensor of shape [W, Z, Y, X]", "Yes"
-                "input", "Tensor", "Tensor", "Tensor of shape [W, Z, Y, X]", "Yes"
-                "other", "Tensor", "Tensor", "Tensor of shape [W, Z, Y, X]", "Yes"
-                "output_mem_config", "Layout of tensor in TT Accelerator device memory banks", "MemoryConfig", "Default is interleaved in DRAM", "No"
-        )doc");
-
     m_tensor.def("tan_bw", &tt::tt_metal::tan_bw,
             py::arg("grad").noconvert(), py::arg("input").noconvert(), py::arg("output_mem_config").noconvert() = operation::DEFAULT_OUTPUT_MEMORY_CONFIG, R"doc(
                 Performs backward operations for tangent with given ``grad``

--- a/tt_eager/tt_lib/csrc/tt_lib_bindings_tensor_backward_ops.cpp
+++ b/tt_eager/tt_lib/csrc/tt_lib_bindings_tensor_backward_ops.cpp
@@ -510,23 +510,6 @@ namespace tt::tt_metal::detail{
                 "output_mem_config", "Layout of tensor in TT Accelerator device memory banks", "MemoryConfig", "Default is interleaved in DRAM", "No"
         )doc");
 
-    m_tensor.def("rsub_bw", &tt::tt_metal::rsub_bw,
-            py::arg("grad").noconvert(), py::arg("input").noconvert(), py::arg("other").noconvert(), py::arg("output_mem_config").noconvert() = operation::DEFAULT_OUTPUT_MEMORY_CONFIG, R"doc(
-            Performs backward operations for subraction of ``input`` from ``other`` tensors with given ``grad`` (reversed order of subtraction operator).
-
-            Input tensors must have BFLOAT16 data type.
-
-            Output tensors will have BFLOAT16 data type.
-
-            .. csv-table::
-                :header: "Argument", "Description", "Data type", "Valid range", "Required"
-
-                "grad", "Gradient tensor", "Tensor", "Tensor of shape [W, Z, Y, X]", "Yes"
-                "input", "Tensor add is applied to", "Tensor", "Tensor of shape [W, Z, Y, X]", "Yes"
-                "other", "Tensor", "Tensor", "Tensor of shape [W, Z, Y, X]", "Yes"
-                "output_mem_config", "Layout of tensor in TT Accelerator device memory banks", "MemoryConfig", "Default is interleaved in DRAM", "No"
-        )doc");
-
     m_tensor.def("neg_bw", &tt::tt_metal::neg_bw,
             py::arg("grad").noconvert(), py::arg("input").noconvert(), py::arg("output_mem_config").noconvert() = operation::DEFAULT_OUTPUT_MEMORY_CONFIG, R"doc(
                 Performs backward operations for negative with given ``grad``

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_backward/binary_backward.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_backward/binary_backward.hpp
@@ -186,6 +186,8 @@ constexpr auto logaddexp_bw = ttnn::register_operation<operations::binary_backwa
 constexpr auto logaddexp2_bw = ttnn::register_operation<operations::binary_backward::ExecuteBinaryBackward<operations::binary_backward::BinaryBackwardOpType::LOGADDEXP2_BW>>("ttnn::logaddexp2_bw");
 constexpr auto squared_difference_bw = ttnn::register_operation<operations::binary_backward::ExecuteBinaryBackward<operations::binary_backward::BinaryBackwardOpType::SQUARED_DIFFERENCE_BW>>("ttnn::squared_difference_bw");
 constexpr auto binary_assign_bw = ttnn::register_operation<operations::binary_backward::ExecuteBinaryBackward<operations::binary_backward::BinaryBackwardOpType::BINARY_ASSIGN_BW>>("ttnn::binary_assign_bw");
+constexpr auto concat_bw = ttnn::register_operation<operations::binary_backward::ExecuteBinaryBackward<operations::binary_backward::BinaryBackwardOpType::CONCAT_BW>>("ttnn::concat_bw");
+
 
 //type 2
 constexpr auto addalpha_bw = ttnn::register_operation<operations::binary_backward::ExecuteBinaryBackward<operations::binary_backward::BinaryBackwardOpType::ADDALPHA_BW>>("ttnn::addalpha_bw");

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_backward/binary_backward.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_backward/binary_backward.hpp
@@ -188,7 +188,7 @@ constexpr auto squared_difference_bw = ttnn::register_operation<operations::bina
 constexpr auto binary_assign_bw = ttnn::register_operation<operations::binary_backward::ExecuteBinaryBackward<operations::binary_backward::BinaryBackwardOpType::BINARY_ASSIGN_BW>>("ttnn::binary_assign_bw");
 constexpr auto concat_bw = ttnn::register_operation<operations::binary_backward::ExecuteBinaryBackward<operations::binary_backward::BinaryBackwardOpType::CONCAT_BW>>("ttnn::concat_bw");
 constexpr auto binary_le_bw = ttnn::register_operation<operations::binary_backward::ExecuteBinaryBackward<operations::binary_backward::BinaryBackwardOpType::BINARY_LE_BW>>("ttnn::binary_le_bw");
-
+constexpr auto rsub_bw = ttnn::register_operation<operations::binary_backward::ExecuteBinaryBackward<operations::binary_backward::BinaryBackwardOpType::RSUB_BW>>("ttnn::rsub_bw");
 
 //type 2
 constexpr auto addalpha_bw = ttnn::register_operation<operations::binary_backward::ExecuteBinaryBackward<operations::binary_backward::BinaryBackwardOpType::ADDALPHA_BW>>("ttnn::addalpha_bw");

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_backward/binary_backward.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_backward/binary_backward.hpp
@@ -185,6 +185,7 @@ constexpr auto ldexp_bw = ttnn::register_operation<operations::binary_backward::
 constexpr auto logaddexp_bw = ttnn::register_operation<operations::binary_backward::ExecuteBinaryBackward<operations::binary_backward::BinaryBackwardOpType::LOGADDEXP_BW>>("ttnn::logaddexp_bw");
 constexpr auto logaddexp2_bw = ttnn::register_operation<operations::binary_backward::ExecuteBinaryBackward<operations::binary_backward::BinaryBackwardOpType::LOGADDEXP2_BW>>("ttnn::logaddexp2_bw");
 constexpr auto squared_difference_bw = ttnn::register_operation<operations::binary_backward::ExecuteBinaryBackward<operations::binary_backward::BinaryBackwardOpType::SQUARED_DIFFERENCE_BW>>("ttnn::squared_difference_bw");
+constexpr auto binary_assign_bw = ttnn::register_operation<operations::binary_backward::ExecuteBinaryBackward<operations::binary_backward::BinaryBackwardOpType::BINARY_ASSIGN_BW>>("ttnn::binary_assign_bw");
 
 //type 2
 constexpr auto addalpha_bw = ttnn::register_operation<operations::binary_backward::ExecuteBinaryBackward<operations::binary_backward::BinaryBackwardOpType::ADDALPHA_BW>>("ttnn::addalpha_bw");

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_backward/binary_backward.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_backward/binary_backward.hpp
@@ -187,6 +187,7 @@ constexpr auto logaddexp2_bw = ttnn::register_operation<operations::binary_backw
 constexpr auto squared_difference_bw = ttnn::register_operation<operations::binary_backward::ExecuteBinaryBackward<operations::binary_backward::BinaryBackwardOpType::SQUARED_DIFFERENCE_BW>>("ttnn::squared_difference_bw");
 constexpr auto binary_assign_bw = ttnn::register_operation<operations::binary_backward::ExecuteBinaryBackward<operations::binary_backward::BinaryBackwardOpType::BINARY_ASSIGN_BW>>("ttnn::binary_assign_bw");
 constexpr auto concat_bw = ttnn::register_operation<operations::binary_backward::ExecuteBinaryBackward<operations::binary_backward::BinaryBackwardOpType::CONCAT_BW>>("ttnn::concat_bw");
+constexpr auto binary_le_bw = ttnn::register_operation<operations::binary_backward::ExecuteBinaryBackward<operations::binary_backward::BinaryBackwardOpType::BINARY_LE_BW>>("ttnn::binary_le_bw");
 
 
 //type 2

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_backward/binary_backward.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_backward/binary_backward.hpp
@@ -86,6 +86,21 @@ struct ExecuteBinaryBackward {
         return op_type(grad_tensor_arg, input_tensor_a_arg, input_tensor_b_arg, alpha, output_memory_config);
         }
 
+    //Type 1: Type 1 with 1 string
+    template <typename... Args>
+
+    static std::vector<ttnn::Tensor> execute_on_worker_thread(
+        const Tensor &grad_tensor_arg,
+        const Tensor &input_tensor_a_arg,
+        string value,
+        const Tensor &input_tensor_b_arg,
+        const std::optional<MemoryConfig> &memory_config = std::nullopt) {
+
+        auto op_type = utils::get_function_type1_w_string(binary_backward_op_type);
+        auto output_memory_config = memory_config.value_or(input_tensor_a_arg.memory_config());
+        return op_type(grad_tensor_arg, input_tensor_a_arg, input_tensor_b_arg, value, output_memory_config);
+        }
+
     //Type 3 : Q_ID, type1 args, optional output tensor for inputs based on are_required_outputs value
     template <typename... Args>
     static auto input_tensors_to_validate(uint8_t queue_id, const Tensor &grad_tensor, const Tensor &input_tensor_a, const Tensor &input_tensor_b, Args &&...args) {
@@ -189,6 +204,7 @@ constexpr auto binary_assign_bw = ttnn::register_operation<operations::binary_ba
 constexpr auto concat_bw = ttnn::register_operation<operations::binary_backward::ExecuteBinaryBackward<operations::binary_backward::BinaryBackwardOpType::CONCAT_BW>>("ttnn::concat_bw");
 constexpr auto binary_le_bw = ttnn::register_operation<operations::binary_backward::ExecuteBinaryBackward<operations::binary_backward::BinaryBackwardOpType::BINARY_LE_BW>>("ttnn::binary_le_bw");
 constexpr auto rsub_bw = ttnn::register_operation<operations::binary_backward::ExecuteBinaryBackward<operations::binary_backward::BinaryBackwardOpType::RSUB_BW>>("ttnn::rsub_bw");
+constexpr auto bias_gelu_bw = ttnn::register_operation<operations::binary_backward::ExecuteBinaryBackward<operations::binary_backward::BinaryBackwardOpType::BIAS_GELU_BW>>("ttnn::bias_gelu_bw");
 
 //type 2
 constexpr auto addalpha_bw = ttnn::register_operation<operations::binary_backward::ExecuteBinaryBackward<operations::binary_backward::BinaryBackwardOpType::ADDALPHA_BW>>("ttnn::addalpha_bw");

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_backward/binary_backward.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_backward/binary_backward.hpp
@@ -191,5 +191,6 @@ constexpr auto addalpha_bw = ttnn::register_operation<operations::binary_backwar
 
 //type 3
 constexpr auto add_bw = ttnn::register_operation<operations::binary_backward::ExecuteBinaryBackward<operations::binary_backward::BinaryBackwardOpType::ADD_BW>>("ttnn::add_bw");
+constexpr auto binary_eq_bw = ttnn::register_operation<operations::binary_backward::ExecuteBinaryBackward<operations::binary_backward::BinaryBackwardOpType::BINARY_EQ_BW>>("ttnn::binary_eq_bw");
 
 }  // namespace ttnn

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_backward/binary_backward_pybind.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_backward/binary_backward_pybind.hpp
@@ -246,6 +246,11 @@ void py_module(py::module& module) {
         module,
         ttnn::binary_assign_bw,
         R"doc(Performs backward operations for binary assign on :attr:`input_tensor_b` with given attr:`grad_tensor`.)doc");
+
+    detail::bind_binary_backward(
+        module,
+        ttnn::concat_bw,
+        R"doc(Performs backward operations for concat on :attr:`input_tensor_a` and :attr:`input_tensor_b` with given attr:`grad_tensor`.)doc");
 }
 
 }  // namespace binary_backward

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_backward/binary_backward_pybind.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_backward/binary_backward_pybind.hpp
@@ -234,7 +234,13 @@ void py_module(py::module& module) {
     detail::bind_binary_backward(
         module,
         ttnn::add_bw,
-        R"doc(Performs backward operations for add on :attr:`input_tensor_b` , attr:`input_tensor_a`, attr:`alpha` tensors with given attr:`grad_tensor`.)doc");
+        R"doc(Performs backward operations for add on :attr:`input_tensor_b` , attr:`input_tensor_a` tensors with given attr:`grad_tensor`.)doc");
+
+    detail::bind_binary_backward(
+        module,
+        ttnn::binary_eq_bw,
+        R"doc(Performs backward operations for equal to comparison on :attr:`input_tensor_b` , attr:`input_tensor_a` tensors with given attr:`grad_tensor`.
+        Returns an tensor of zeros like :attr:`input_tensor_a` and :attr:`input_tensor_b` tensor.)doc");
 }
 
 }  // namespace binary_backward

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_backward/binary_backward_pybind.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_backward/binary_backward_pybind.hpp
@@ -256,6 +256,12 @@ void py_module(py::module& module) {
         module,
         ttnn::binary_le_bw,
         R"doc(Performs backward operations for binary le on :attr:`input_tensor_a` and :attr:`input_tensor_b` with given attr:`grad_tensor`.)doc");
+
+    detail::bind_binary_backward(
+        module,
+        ttnn::rsub_bw,
+        R"doc(Performs backward operations for subraction of :attr:`input_tensor_a` from :attr:`input_tensor_b` tensors with given attr:`grad_tensor` (reversed order of subtraction operator).)doc");
+
 }
 
 }  // namespace binary_backward

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_backward/binary_backward_pybind.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_backward/binary_backward_pybind.hpp
@@ -87,6 +87,23 @@ Example:
                const ttnn::Tensor& grad_tensor,
                const ttnn::Tensor& input_tensor_a,
                const ttnn::Tensor& input_tensor_b,
+               const string value,
+               const std::optional<ttnn::MemoryConfig>& memory_config) -> std::vector<ttnn::Tensor> {
+                return self(grad_tensor, input_tensor_a, value, input_tensor_b, memory_config);
+            },
+            py::arg("grad_tensor"),
+            py::arg("input_tensor_a"),
+            py::arg("input_tensor_b"),
+            py::arg("value"),
+            py::kw_only(),
+            py::arg("memory_config") = std::nullopt},
+
+
+        ttnn::pybind_overload_t{
+            [](const binary_backward_operation_t& self,
+               const ttnn::Tensor& grad_tensor,
+               const ttnn::Tensor& input_tensor_a,
+               const ttnn::Tensor& input_tensor_b,
                const std::optional<ttnn::MemoryConfig>& memory_config,
                const std::vector<bool>& are_required_outputs,
                const std::optional<ttnn::Tensor>& optional_input_a_grad,
@@ -261,6 +278,11 @@ void py_module(py::module& module) {
         module,
         ttnn::rsub_bw,
         R"doc(Performs backward operations for subraction of :attr:`input_tensor_a` from :attr:`input_tensor_b` tensors with given attr:`grad_tensor` (reversed order of subtraction operator).)doc");
+
+    detail::bind_binary_backward(
+        module,
+        ttnn::bias_gelu_bw,
+        R"doc(Performs backward operations for binary gelu of :attr:`input_tensor_a` and :attr:`input_tensor_b` tensors with given attr:`grad_tensor`.)doc");
 
 }
 

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_backward/binary_backward_pybind.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_backward/binary_backward_pybind.hpp
@@ -251,6 +251,11 @@ void py_module(py::module& module) {
         module,
         ttnn::concat_bw,
         R"doc(Performs backward operations for concat on :attr:`input_tensor_a` and :attr:`input_tensor_b` with given attr:`grad_tensor`.)doc");
+
+    detail::bind_binary_backward(
+        module,
+        ttnn::binary_le_bw,
+        R"doc(Performs backward operations for binary le on :attr:`input_tensor_a` and :attr:`input_tensor_b` with given attr:`grad_tensor`.)doc");
 }
 
 }  // namespace binary_backward

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_backward/binary_backward_pybind.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_backward/binary_backward_pybind.hpp
@@ -241,6 +241,11 @@ void py_module(py::module& module) {
         ttnn::binary_eq_bw,
         R"doc(Performs backward operations for equal to comparison on :attr:`input_tensor_b` , attr:`input_tensor_a` tensors with given attr:`grad_tensor`.
         Returns an tensor of zeros like :attr:`input_tensor_a` and :attr:`input_tensor_b` tensor.)doc");
+
+    detail::bind_binary_backward(
+        module,
+        ttnn::binary_assign_bw,
+        R"doc(Performs backward operations for binary assign on :attr:`input_tensor_b` with given attr:`grad_tensor`.)doc");
 }
 
 }  // namespace binary_backward

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_backward/device/binary_backward_op.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_backward/device/binary_backward_op.cpp
@@ -395,6 +395,15 @@ std::vector<Tensor> _concat_bw(
     return grad_tensor;
 }
 
+std::vector<Tensor> _binary_le_bw(const Tensor& grad, const Tensor& input, const Tensor& other, const MemoryConfig& output_mem_config) {
+    std::vector<Tensor> grad_tensor;
+    Tensor zero_grad = tt::tt_metal::zeros_like(grad, output_mem_config);
+    grad_tensor.emplace_back(zero_grad);
+    Tensor zero_input = tt::tt_metal::zeros_like(input, output_mem_config);
+    grad_tensor.emplace_back(zero_input);
+    return grad_tensor;
+}
+
 
 std::function<std::vector<ttnn::Tensor>(const Tensor&, const Tensor&, const Tensor&, const MemoryConfig&)> get_function_type1(BinaryBackwardOpType OpType){
     switch (OpType) {
@@ -422,6 +431,8 @@ std::function<std::vector<ttnn::Tensor>(const Tensor&, const Tensor&, const Tens
             return _binary_eq_bw_inter;
         case BinaryBackwardOpType::BINARY_ASSIGN_BW:
             return _binary_assign_bw;
+        case BinaryBackwardOpType::BINARY_LE_BW:
+            return _binary_le_bw;
         default:
             TT_ASSERT(false && "Undefined op type");
             return 0;

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_backward/device/binary_backward_op.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_backward/device/binary_backward_op.cpp
@@ -294,7 +294,7 @@ std::vector<ttnn::Tensor> _squared_difference_bw(
     return grad_tensor;
 }
 
-// std::vector<std::optional<Tensor>> _binary_eq_bw(
+//TODO: std::vector<std::optional<Tensor>> _binary_eq_bw(
 std::vector<Tensor> _binary_eq_bw(
     uint8_t cq_id,
     const Tensor& grad,
@@ -339,7 +339,7 @@ std::vector<ttnn::Tensor> _binary_eq_bw_inter(
     return _binary_eq_bw(0, grad, input, other, output_mem_config, {true, true}, std::nullopt, std::nullopt);
 }
 
-// std::vector<std::optional<Tensor>> _binary_eq_bw_overload(
+//TODO: std::vector<std::optional<Tensor>> _binary_eq_bw_overload(
 std::vector<Tensor> _binary_eq_bw_overload(
     const Tensor& grad,
     const Tensor& input,
@@ -404,6 +404,12 @@ std::vector<Tensor> _binary_le_bw(const Tensor& grad, const Tensor& input, const
     return grad_tensor;
 }
 
+std::vector<Tensor> _rsub_bw( const Tensor& grad, const Tensor& input, const Tensor& other, const MemoryConfig& output_mem_config) {
+    std::vector<Tensor> grad_tensor = _subalpha_bw(grad, input, other, 1.0f, output_mem_config);
+    std::swap(grad_tensor[0], grad_tensor[1]);
+    return grad_tensor;
+}
+
 
 std::function<std::vector<ttnn::Tensor>(const Tensor&, const Tensor&, const Tensor&, const MemoryConfig&)> get_function_type1(BinaryBackwardOpType OpType){
     switch (OpType) {
@@ -433,6 +439,8 @@ std::function<std::vector<ttnn::Tensor>(const Tensor&, const Tensor&, const Tens
             return _binary_assign_bw;
         case BinaryBackwardOpType::BINARY_LE_BW:
             return _binary_le_bw;
+        case BinaryBackwardOpType::RSUB_BW:
+            return _rsub_bw;
         default:
             TT_ASSERT(false && "Undefined op type");
             return 0;

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_backward/device/binary_backward_op.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_backward/device/binary_backward_op.cpp
@@ -351,6 +351,14 @@ std::vector<Tensor> _binary_eq_bw_overload(
     return _binary_eq_bw(default_queue_id, grad, input, other, output_mem_config, are_required_outputs, input_grad, other_grad);
 }
 
+std::vector<Tensor> _binary_assign_bw(
+    const Tensor& grad, const Tensor& input, const Tensor& other, const MemoryConfig& output_mem_config) {
+    std::vector<Tensor> grad_tensor;
+    grad_tensor.emplace_back(grad);
+    grad_tensor.emplace_back(grad);
+    return grad_tensor;
+}
+
 std::function<std::vector<ttnn::Tensor>(const Tensor&, const Tensor&, const Tensor&, const MemoryConfig&)> get_function_type1(BinaryBackwardOpType OpType){
     switch (OpType) {
         case BinaryBackwardOpType::ATAN2_BW:
@@ -375,6 +383,8 @@ std::function<std::vector<ttnn::Tensor>(const Tensor&, const Tensor&, const Tens
             return _add_bw_inter;
         case BinaryBackwardOpType::BINARY_EQ_BW:
             return _binary_eq_bw_inter;
+        case BinaryBackwardOpType::BINARY_ASSIGN_BW:
+            return _binary_assign_bw;
         default:
             TT_ASSERT(false && "Undefined op type");
             return 0;

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_backward/device/binary_backward_op.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_backward/device/binary_backward_op.hpp
@@ -24,7 +24,8 @@ enum class BinaryBackwardOpType {
     LOGADDEXP_BW,
     LOGADDEXP2_BW,
     SQUARED_DIFFERENCE_BW,
-    ADD_BW
+    ADD_BW,
+    BINARY_EQ_BW
 };
 
 

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_backward/device/binary_backward_op.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_backward/device/binary_backward_op.hpp
@@ -29,7 +29,8 @@ enum class BinaryBackwardOpType {
     BINARY_ASSIGN_BW,
     CONCAT_BW,
     BINARY_LE_BW,
-    RSUB_BW
+    RSUB_BW,
+    BIAS_GELU_BW
 };
 
 

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_backward/device/binary_backward_op.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_backward/device/binary_backward_op.hpp
@@ -26,7 +26,8 @@ enum class BinaryBackwardOpType {
     SQUARED_DIFFERENCE_BW,
     ADD_BW,
     BINARY_EQ_BW,
-    BINARY_ASSIGN_BW
+    BINARY_ASSIGN_BW,
+    CONCAT_BW
 };
 
 

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_backward/device/binary_backward_op.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_backward/device/binary_backward_op.hpp
@@ -25,7 +25,8 @@ enum class BinaryBackwardOpType {
     LOGADDEXP2_BW,
     SQUARED_DIFFERENCE_BW,
     ADD_BW,
-    BINARY_EQ_BW
+    BINARY_EQ_BW,
+    BINARY_ASSIGN_BW
 };
 
 

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_backward/device/binary_backward_op.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_backward/device/binary_backward_op.hpp
@@ -28,7 +28,8 @@ enum class BinaryBackwardOpType {
     BINARY_EQ_BW,
     BINARY_ASSIGN_BW,
     CONCAT_BW,
-    BINARY_LE_BW
+    BINARY_LE_BW,
+    RSUB_BW
 };
 
 

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_backward/device/binary_backward_op.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_backward/device/binary_backward_op.hpp
@@ -27,7 +27,8 @@ enum class BinaryBackwardOpType {
     ADD_BW,
     BINARY_EQ_BW,
     BINARY_ASSIGN_BW,
-    CONCAT_BW
+    CONCAT_BW,
+    BINARY_LE_BW
 };
 
 

--- a/ttnn/ttnn/__init__.py
+++ b/ttnn/ttnn/__init__.py
@@ -471,6 +471,7 @@ from ttnn.operations.binary_backward import (
     concat_bw,
     binary_le_bw,
     rsub_bw,
+    bias_gelu_bw,
 )
 
 from ttnn.operations.ternary import (

--- a/ttnn/ttnn/__init__.py
+++ b/ttnn/ttnn/__init__.py
@@ -468,6 +468,7 @@ from ttnn.operations.binary_backward import (
     add_bw,
     binary_eq_bw,
     binary_assign_bw,
+    concat_bw,
 )
 
 from ttnn.operations.ternary import (

--- a/ttnn/ttnn/__init__.py
+++ b/ttnn/ttnn/__init__.py
@@ -467,6 +467,7 @@ from ttnn.operations.binary_backward import (
     squared_difference_bw,
     add_bw,
     binary_eq_bw,
+    binary_assign_bw,
 )
 
 from ttnn.operations.ternary import (

--- a/ttnn/ttnn/__init__.py
+++ b/ttnn/ttnn/__init__.py
@@ -470,6 +470,7 @@ from ttnn.operations.binary_backward import (
     binary_assign_bw,
     concat_bw,
     binary_le_bw,
+    rsub_bw,
 )
 
 from ttnn.operations.ternary import (

--- a/ttnn/ttnn/__init__.py
+++ b/ttnn/ttnn/__init__.py
@@ -469,6 +469,7 @@ from ttnn.operations.binary_backward import (
     binary_eq_bw,
     binary_assign_bw,
     concat_bw,
+    binary_le_bw,
 )
 
 from ttnn.operations.ternary import (

--- a/ttnn/ttnn/__init__.py
+++ b/ttnn/ttnn/__init__.py
@@ -466,6 +466,7 @@ from ttnn.operations.binary_backward import (
     logaddexp2_bw,
     squared_difference_bw,
     add_bw,
+    binary_eq_bw,
 )
 
 from ttnn.operations.ternary import (

--- a/ttnn/ttnn/operations/binary_backward.py
+++ b/ttnn/ttnn/operations/binary_backward.py
@@ -53,6 +53,8 @@ def _golden_function_backward(torch_op, grad_tensor, input_tensor_a, input_tenso
         pyt_y = torch.square(torch.sub(input_tensor_a, input_tensor_b))
     else:
         pyt_y = torch_op(input_tensor_a, input_tensor_b)
+    input_tensor_a.retain_grad()
+    input_tensor_b.retain_grad()
     pyt_y.backward(gradient=grad_tensor)
     golden_tensor = [input_tensor_a.grad, input_tensor_b.grad]
     return golden_tensor
@@ -60,6 +62,8 @@ def _golden_function_backward(torch_op, grad_tensor, input_tensor_a, input_tenso
 
 def _golden_function_backward_with_float(torch_op, grad_tensor, input_tensor_a, input_tensor_b, alpha, *args, **kwargs):
     pyt_y = torch_op(input_tensor_a, input_tensor_b, alpha=alpha)
+    input_tensor_a.retain_grad()
+    input_tensor_b.retain_grad()
     pyt_y.backward(gradient=grad_tensor)
     golden_tensor = [input_tensor_a.grad, input_tensor_b.grad]
     return golden_tensor

--- a/ttnn/ttnn/operations/binary_backward.py
+++ b/ttnn/ttnn/operations/binary_backward.py
@@ -65,6 +65,11 @@ def _golden_function_backward_with_float(torch_op, grad_tensor, input_tensor_a, 
     return golden_tensor
 
 
+def _golden_function_comparison_ops(torch_op, grad_tensor, input_tensor_a, input_tensor_b, *args, **kwargs):
+    golden_tensor = [torch.zeros_like(input_tensor_a), torch.zeros_like(input_tensor_b)]
+    return golden_tensor
+
+
 sub_bw = ttnn.register_operation(
     golden_function=lambda grad, a, b, *args, **kwargs: _golden_function_backward(
         torch.sub, grad, a, b, *args, **kwargs
@@ -130,5 +135,11 @@ addalpha_bw = ttnn.register_operation(
         torch.add, grad, a, b, alpha, *args, **kwargs
     )
 )(ttnn._ttnn.operations.binary_backward.addalpha_bw)
+
+binary_eq_bw = ttnn.register_operation(
+    golden_function=lambda grad, a, b, *args, **kwargs: _golden_function_comparison_ops(
+        torch.eq, grad, a, b, *args, **kwargs
+    )
+)(ttnn._ttnn.operations.binary_backward.binary_eq_bw)
 
 __all__ = []

--- a/ttnn/ttnn/operations/binary_backward.py
+++ b/ttnn/ttnn/operations/binary_backward.py
@@ -158,4 +158,10 @@ binary_assign_bw = ttnn.register_operation(
     )
 )(ttnn._ttnn.operations.binary_backward.binary_assign_bw)
 
+concat_bw = ttnn.register_operation(
+    golden_function=lambda grad, a, b, *args, **kwargs: _golden_function_backward(
+        torch.clone, grad, a, b, *args, **kwargs
+    )
+)(ttnn._ttnn.operations.binary_backward.concat_bw)
+
 __all__ = []

--- a/ttnn/ttnn/operations/binary_backward.py
+++ b/ttnn/ttnn/operations/binary_backward.py
@@ -164,4 +164,10 @@ concat_bw = ttnn.register_operation(
     )
 )(ttnn._ttnn.operations.binary_backward.concat_bw)
 
+binary_le_bw = ttnn.register_operation(
+    golden_function=lambda grad, a, b, *args, **kwargs: _golden_function_backward(
+        torch.clone, grad, a, b, *args, **kwargs
+    )
+)(ttnn._ttnn.operations.binary_backward.binary_le_bw)
+
 __all__ = []

--- a/ttnn/ttnn/operations/binary_backward.py
+++ b/ttnn/ttnn/operations/binary_backward.py
@@ -170,4 +170,10 @@ binary_le_bw = ttnn.register_operation(
     )
 )(ttnn._ttnn.operations.binary_backward.binary_le_bw)
 
+rsub_bw = ttnn.register_operation(
+    golden_function=lambda grad, a, b, *args, **kwargs: _golden_function_backward(
+        torch.rsub, grad, a, b, *args, **kwargs
+    )
+)(ttnn._ttnn.operations.binary_backward.rsub_bw)
+
 __all__ = []


### PR DESCRIPTION
Binary Backward Issue : #9628 [Master issue : #9322 ]

### List of ops completed
- binary_eq_bw ( without optional return support )
- binary_assign_bw
- concat_bw
- binary_le_bw
- rsub_bw
- bias_gelu_bw


**Structure**
```
ttnn
└── cpp
    └── ttnn
        └── operations
            └── ...
            └── eltwise
                └── binary
                └── binary_backward
                    ├── device
                    │   ├── binary_backward_op.cpp
                    │   ├── binary_backward_op.hpp
                    ├── binary_backward.hpp
                    └── binary_backward_pybind.hpp
```

**Test files**
- binary_eq_bw : `tests/tt_eager/python_api_testing/unit_testing/backward_ops/test_backward_binary_eq.py`
- binary_assign_bw : `tests/tt_eager/python_api_testing/unit_testing/backward_ops/test_backward_binary_assign.py`
- concat_bw : `tests/tt_eager/python_api_testing/unit_testing/backward_ops/test_backward_concat.py`
- binary_le_bw : `tests/tt_eager/python_api_testing/unit_testing/backward_ops/test_backward_binary_le.py`
- rsub_bw : `tests/tt_eager/python_api_testing/unit_testing/backward_ops/test_backward_rsub.py`
- bias_gelu_bw : `tests/tt_eager/python_api_testing/unit_testing/backward_ops/test_backward_bias_gelu.py`

**CI :** 

- [All post-commit tests](https://github.com/tenstorrent/tt-metal/actions/runs/9712034887) - PASSED
- [[post-commit] Fast Dispatch unit tests](https://github.com/tenstorrent/tt-metal/actions/runs/9692433408) - PASSED
- [[post-commit] Slow Dispatch unit tests](https://github.com/tenstorrent/tt-metal/actions/runs/9692434538) - PASSED
- [post-commit] models tests
- Device perf regressions and output report
- Model perf regressions and output report
- Nightly fast dispatch tests