### PR TITLE
 Support longer sequence lengths in `ssm_prefix_scan`

### DIFF
--- a/tests/tt_eager/python_api_testing/unit_testing/misc/test_ssm_prefix_scan.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/misc/test_ssm_prefix_scan.py
@@ -66,12 +66,15 @@ def run_ssm_prefix_scan(L: int, E: int, N: int, num_cores: int, dtype, device):
     (
         (32, 32, 32, 1),
         (32, 64, 32, 1),
+        (64, 32, 32, 1),
+        (64, 64, 32, 1),
         (32, 2560, 32, 32),
         (32, 5120, 32, 40),
-        # (32, 5120, 32, 64) -> 8x8 grid not supported on CI
+        # (32, 5120, 32, 64), #-> 8x8 grid not supported on CI
+        # (64, 5120, 32, 64) #-> 8x8 grid not supported on CI
     ),
 )
-def test_ssm_reduce(L: int, E: int, N: int, num_cores: int, dtype, device):
+def test_ssm_prefix_scan(L: int, E: int, N: int, num_cores: int, dtype, device):
     run_ssm_prefix_scan(L, E, N, num_cores, dtype, device)
 
 

--- a/tt_eager/tt_dnn/op_library/transformer_tms/kernels/dataflow/reader_ssm_prefix_scan.cpp
+++ b/tt_eager/tt_dnn/op_library/transformer_tms/kernels/dataflow/reader_ssm_prefix_scan.cpp
@@ -4,10 +4,28 @@
 
 #include "dataflow_api.h"
 
+void fill_zeros(uint32_t cb_id) {
+    constexpr uint32_t num_zeros_reads = 2048 / MEM_ZEROS_SIZE;
+    uint64_t zeros_noc_addr = get_noc_addr(MEM_ZEROS_BASE);
+    uint32_t write_addr = get_write_ptr(cb_id);
+    volatile tt_l1_ptr uint32_t* ptr = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(write_addr);
+
+    // Fill tile with zeros
+    for (uint32_t i = 0; i < num_zeros_reads; ++i) {
+        noc_async_read(zeros_noc_addr, write_addr, MEM_ZEROS_SIZE);
+        write_addr += MEM_ZEROS_SIZE;
+    }
+    noc_async_read_barrier();
+}
+
 void kernel_main() {
     uint32_t num_tiles_per_core = get_arg_val<uint32_t>(0);
     constexpr uint32_t cb_a_in = get_compile_time_arg_val(0);
     constexpr uint32_t cb_bx_in = get_compile_time_arg_val(1);
+    constexpr uint32_t cb_zeros = get_compile_time_arg_val(2);
+
+    fill_zeros(cb_zeros);
+    cb_push_back(cb_zeros, 1);
 
     cb_push_back(cb_a_in, num_tiles_per_core);
     cb_push_back(cb_bx_in, num_tiles_per_core);

--- a/tt_eager/tt_dnn/op_library/transformer_tms/multi_core_ssm_prefix_scan/multi_core_ssm_prefix_scan.cpp
+++ b/tt_eager/tt_dnn/op_library/transformer_tms/multi_core_ssm_prefix_scan/multi_core_ssm_prefix_scan.cpp
@@ -88,7 +88,12 @@ operation::ProgramWithCallbacks multi_core_ssm_prefix_scan(
     const uint32_t cb_zeros_id = tt::CB::c_intermed6;
     const auto cb_zeros = create_circular_buffer(cb_zeros_id, 1, intermediary_tile_size, intermediary_format);
 
-    std::vector<uint32_t> reader_compile_time_args = {cb_a_in_id, cb_bx_in_id};
+    const uint32_t cb_h_acc_id = tt::CB::c_intermed7;
+    const uint32_t num_chunks_per_row = ceil(float(total_tiles_per_row) / 32.0f);
+    const auto cb_h_acc =
+        create_circular_buffer(cb_h_acc_id, num_chunks_per_row, intermediary_tile_size, intermediary_format);
+
+    std::vector<uint32_t> reader_compile_time_args = {cb_a_in_id, cb_bx_in_id, cb_zeros_id};
     std::vector<uint32_t> writer_compile_time_args = {cb_out_id};
     std::vector<uint32_t> compute_compile_time_args = {
         cb_a_in_id,
@@ -100,7 +105,8 @@ operation::ProgramWithCallbacks multi_core_ssm_prefix_scan(
         cb_h_id,
         cb_tilize_out_id,
         cb_out_id,
-        cb_zeros_id};
+        cb_zeros_id,
+        cb_h_acc_id};
 
     auto reader_kernel_id = tt_metal::CreateKernel(
         program,


### PR DESCRIPTION
This PR adds support for L > 32 in `ssm_eltwise_mul`. Logically we can handle any value of L but values of L > 128 will run out of L1 in `bfloat8` format. 

This change also addresses issue #9831. 