### PR TITLE
Start using `reflect` library

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -96,16 +96,6 @@ if (NOT NUMA_LIBRARY)
     message(FATAL_ERROR "NUMA library not found")
 endif()
 
-
-CPMAddPackage(
-  NAME reflect
-  GITHUB_REPOSITORY boost-ext/reflect
-  GIT_TAG v1.1.1
-)
-add_library(reflect INTERFACE)
-target_include_directories(reflect SYSTEM INTERFACE ${reflect_SOURCE_DIR})
-add_library(reflect::reflect ALIAS reflect)
-
 ############################################################################################################################
 # Constructing interface libs for common compiler flags, header directories, and libraries
 #   These interface libs are linked with PUBLIC scope at lowest common target (tt_metal/common) and at tt_metal_libs level
@@ -142,6 +132,7 @@ endif()
 
 add_library(metal_header_directories INTERFACE)
 target_include_directories(metal_header_directories INTERFACE ${PROJECT_SOURCE_DIR}/tt_metal/hw/inc)
+target_include_directories(metal_header_directories SYSTEM INTERFACE ${reflect_SOURCE_DIR})
 foreach(lib ${BoostPackages})
     target_include_directories(metal_header_directories INTERFACE ${Boost${lib}_SOURCE_DIR}/include)
 endforeach()

--- a/cmake/dependencies.cmake
+++ b/cmake/dependencies.cmake
@@ -48,3 +48,13 @@ if (googletest_ADDED)
     target_link_libraries(gtest PRIVATE c++ c++abi)
     target_link_libraries(gtest_main PRIVATE c++ c++abi)
 endif()
+
+############################################################################################################################
+# boost-ext reflect : https://github.com/boost-ext/reflect
+############################################################################################################################
+
+CPMAddPackage(
+  NAME reflect
+  GITHUB_REPOSITORY boost-ext/reflect
+  GIT_TAG v1.1.1
+)

--- a/tests/ttnn/unit_tests/gtests/CMakeLists.txt
+++ b/tests/ttnn/unit_tests/gtests/CMakeLists.txt
@@ -9,7 +9,7 @@ set(TTNN_UNIT_TESTS_SRC
 
 add_executable(unit_tests_ttnn ${TTNN_UNIT_TESTS_SRC})
 
-target_link_libraries(unit_tests_ttnn PUBLIC test_common_libs ttnn_lib tt_metal tt_eager reflect::reflect)
+target_link_libraries(unit_tests_ttnn PUBLIC test_common_libs ttnn_lib tt_metal tt_eager)
 target_include_directories(unit_tests_ttnn PRIVATE
     ${UMD_HOME}
     ${PROJECT_SOURCE_DIR}

--- a/tt_eager/tt_dnn/op_library/CMakeLists.txt
+++ b/tt_eager/tt_dnn/op_library/CMakeLists.txt
@@ -220,7 +220,7 @@ set(TT_DNN_SRCS
 
 add_library(tt_dnn OBJECT ${TT_DNN_SRCS})
 
-target_link_libraries(tt_dnn PUBLIC metal_header_directories compiler_flags umd_device reflect::reflect)
+target_link_libraries(tt_dnn PUBLIC metal_header_directories compiler_flags umd_device)
 target_include_directories(tt_dnn PUBLIC
     ${UMD_HOME}
     ${PROJECT_SOURCE_DIR}

--- a/tt_metal/tt_stl/reflection.hpp
+++ b/tt_metal/tt_stl/reflection.hpp
@@ -9,6 +9,7 @@
 #include <experimental/type_traits>
 #include <optional>
 #include <ostream>
+#include <reflect>
 #include <set>
 #include <string>
 #include <tuple>
@@ -16,7 +17,6 @@
 #include <vector>
 
 #include "third_party/magic_enum/magic_enum.hpp"
-
 #include "type_name.hpp"
 
 namespace tt {
@@ -37,9 +37,7 @@ concept IsVariant = requires { typename std::variant_size<T>::type; };
 
 template <IsVariant Variant>
 constexpr auto get_active_type_name_in_variant(const Variant& v) {
-    return std::visit([](auto&& arg) -> std::string_view {
-        return short_type_name<std::decay_t<decltype(arg)>>;
-    }, v);
+    return std::visit([](auto&& arg) -> std::string_view { return short_type_name<std::decay_t<decltype(arg)>>; }, v);
 }
 
 // Forward Declare hash_object
@@ -397,46 +395,100 @@ std::ostream& operator<<(std::ostream& os, const std::set<T>& set) {
     return os;
 }
 
-template <typename to_visit_t, typename T>
-    requires std::same_as<std::decay_t<T>, to_visit_t>
+template <typename object_t, typename T>
+    requires std::same_as<std::decay_t<T>, object_t>
 constexpr auto visit_object_of_type(auto callback, T&& value) {
     callback(value);
 }
 
-template <typename to_visit_t, typename T>
+template <typename object_t, typename T>
 constexpr auto visit_object_of_type(auto callback, const std::optional<T>& value) {
     if (value.has_value()) {
-        visit_object_of_type<to_visit_t>(callback, value.value());
+        visit_object_of_type<object_t>(callback, value.value());
     }
 }
 
-template <typename to_visit_t, typename T>
+template <typename object_t, typename T>
 constexpr auto visit_object_of_type(auto callback, const std::vector<T>& value) {
     for (auto& tensor : value) {
-        visit_object_of_type<to_visit_t>(callback, tensor);
+        visit_object_of_type<object_t>(callback, tensor);
     }
 }
 
-template <typename to_visit_t, typename T, auto N>
+template <typename object_t, typename T, auto N>
 constexpr auto visit_object_of_type(auto callback, const std::array<T, N>& value) {
     for (auto& tensor : value) {
-        visit_object_of_type<to_visit_t>(callback, tensor);
+        visit_object_of_type<object_t>(callback, tensor);
     }
 }
 
-template <typename to_visit_t, typename... Ts>
+template <typename object_t, typename... Ts>
 constexpr auto visit_object_of_type(auto callback, const std::tuple<Ts...>& value) {
     constexpr auto num_attributes = sizeof...(Ts);
     [&callback, &value]<size_t... Ns>(std::index_sequence<Ns...>) {
-        (visit_object_of_type<to_visit_t>(callback, std::get<Ns>(value)), ...);
+        (visit_object_of_type<object_t>(callback, std::get<Ns>(value)), ...);
     }(std::make_index_sequence<num_attributes>{});
 }
 
-template <typename to_visit_t, typename T>
-    requires(not std::same_as<std::decay_t<T>, to_visit_t>) and requires { std::decay_t<T>::attribute_names; }
+template <typename object_t, typename T>
+    requires(not std::same_as<std::decay_t<T>, object_t>) and requires { std::decay_t<T>::attribute_names; }
 constexpr auto visit_object_of_type(auto callback, T&& object) {
     constexpr auto num_attributes = std::tuple_size_v<decltype(std::decay_t<T>::attribute_names)>;
-    visit_object_of_type<to_visit_t>(callback, object.attribute_values());
+    visit_object_of_type<object_t>(callback, object.attribute_values());
+}
+
+template <typename object_t, typename T>
+    requires(not std::same_as<std::decay_t<T>, object_t>) and requires { std::is_aggregate_v<std::decay_t<T>>; }
+constexpr auto visit_object_of_type(auto callback, T&& object) {
+    reflect::for_each(
+        [&callback, &object](auto I) { visit_object_of_type<object_t>(callback, reflect::get<I>(object)); }, object);
+}
+
+template <typename object_t, typename T>
+    requires std::same_as<std::decay_t<T>, object_t>
+constexpr auto get_first_object_of_type(T&& value) {
+    return std::cref(value);
+}
+
+template <typename object_t, typename T>
+constexpr auto get_first_object_of_type(const std::optional<T>& value) {
+    if (value.has_value()) {
+        const auto& tensor = value.value();
+        return get_first_object_of_type<object_t>(tensor);
+    }
+}
+
+template <typename object_t, typename T>
+constexpr auto get_first_object_of_type(const std::vector<T>& value) {
+    for (auto& tensor : value) {
+        return get_first_object_of_type<object_t>(tensor);
+    }
+}
+
+template <typename object_t, typename T, auto N>
+constexpr auto get_first_object_of_type(const std::array<T, N>& value) {
+    for (auto& tensor : value) {
+        return get_first_object_of_type<object_t>(tensor);
+    }
+}
+
+template <typename object_t, typename... Ts>
+constexpr auto get_first_object_of_type(const std::tuple<Ts...>& value) {
+    constexpr auto num_attributes = sizeof...(Ts);
+    return get_first_object_of_type<object_t>(std::get<0>(value));
+}
+
+template <typename object_t, typename T>
+    requires (not std::same_as<std::decay_t<T>, object_t>) and requires { std::decay_t<T>::attribute_names; }
+constexpr auto get_first_object_of_type(T&& object) {
+    constexpr auto num_attributes = std::tuple_size_v<decltype(std::decay_t<T>::attribute_names)>;
+    return get_first_object_of_type<object_t>(object.attribute_values());
+}
+
+template <typename object_t, typename T>
+    requires (not std::same_as<std::decay_t<T>, object_t>) and requires { std::is_aggregate_v<std::decay_t<T>>; }
+constexpr auto get_first_object_of_type(T&& object) {
+    return get_first_object_of_type<object_t>(reflect::get<0>(object));
 }
 
 }  // namespace reflection
@@ -694,6 +746,13 @@ inline hash_t hash_object(const T& object) noexcept {
         } else {
             return 0;
         }
+    } else if constexpr (std::is_aggregate_v<T>) {
+        if constexpr (DEBUG_HASH_OBJECT_FUNCTION) {
+            fmt::print("Hashing struct {} using reflect library: {}\n", get_type_name<T>(), object);
+        }
+        std::size_t hash = 0;
+        reflect::for_each([&hash, &object](auto I) { hash = hash_objects(hash, reflect::get<I>(object)); }, object);
+        return hash;
     } else {
         static_assert(tt::stl::concepts::always_false_v<T>, "Type doesn't support std::hash");
     }

--- a/ttnn/CMakeLists.txt
+++ b/ttnn/CMakeLists.txt
@@ -17,7 +17,7 @@ set(TTNN_SRCS
 add_library(ttnn_lib OBJECT ${TTNN_SRCS})
 target_compile_options(ttnn_lib PUBLIC -MP -Wno-int-to-pointer-cast -fno-var-tracking)
 target_link_libraries(ttnn_lib
-    PUBLIC compiler_flags metal_header_directories metal_common_libs reflect::reflect
+    PUBLIC compiler_flags metal_header_directories metal_common_libs
 )
 target_include_directories(ttnn_lib PUBLIC
     ${UMD_HOME}

--- a/ttnn/cpp/ttnn/operations/eltwise/binary/device/binary_op.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary/device/binary_op.hpp
@@ -65,29 +65,11 @@ struct Binary {
         const MemoryConfig memory_config;
         const DataType dtype;
         std::optional<DeviceComputeKernelConfig> compute_kernel_config;
-
-        static constexpr auto attribute_names = std::forward_as_tuple(
-            "binary_op_type", "in_place", "activations", "memory_config", "dtype", "compute_kernel_config");
-        const auto attribute_values() const {
-            return std::forward_as_tuple(
-                this->binary_op_type,
-                this->in_place,
-                this->activations,
-                this->memory_config,
-                this->dtype,
-                this->compute_kernel_config);
-        }
     };
     struct tensor_args_t {
         const Tensor& input_tensor_a;
         const Tensor& input_tensor_b;
         std::optional<Tensor> output_tensor;
-
-        static constexpr auto attribute_names =
-            std::forward_as_tuple("input_tensor_a", "input_tensor_b", "output_tensor");
-        const auto attribute_values() const {
-            return std::forward_as_tuple(this->input_tensor_a, this->input_tensor_b, this->output_tensor);
-        }
     };
     using shape_return_value_t = ttnn::Shape;
     using tensor_return_value_t = Tensor;


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/9767

### Problem description
`boost-ext/reflect` was recently added and it can improve the speed of development and get rid of bugs caused by omitted attributes

### What's changed
This PR adds support for using `reflect` library for hashing structs in binary op

### Checklist
- [ ] Post commit CI passes
- [ ] Model regression CI testing passes (if applicable)
- [ ] New/Existing tests provide coverage for changes
