### PR TITLE
Pack runtime arguments across brisc/ncrisc/trisc

### DIFF
--- a/tests/tt_metal/tt_metal/test_kernels/compute/increment_runtime_arg.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/compute/increment_runtime_arg.cpp
@@ -11,11 +11,9 @@ void MAIN {
     constexpr uint32_t num_unique_rt_args = get_compile_time_arg_val(0);
     constexpr uint32_t num_common_rt_args = get_compile_time_arg_val(1);
     constexpr uint32_t rt_args_base = get_compile_time_arg_val(2);
+    constexpr uint32_t common_rt_args_base = get_compile_time_arg_val(3);
     constexpr uint32_t unique_arg_incr_val = 10;
     constexpr uint32_t common_arg_incr_val = 100;
-
-    // DPRINT << "increment_runtime_arg: " << num_unique_rt_args << " " << num_common_rt_args << " " << unique_arg_incr_val << " " << common_arg_incr_val << " ";
-    // DPRINT << rt_args_base << " " << COMMON_RT_ARGS_INDEX << ENDL();
 
     // This verifies get_arg_val and get_common_arg_val APIs
     for (uint32_t i = 0; i < num_unique_rt_args; i++) {
@@ -26,7 +24,7 @@ void MAIN {
 
     for (uint32_t i = 0; i < num_common_rt_args; i++) {
         uint32_t rt_arg = get_common_arg_val<uint32_t>(i);
-        tt_l1_ptr std::uint32_t* arg_ptr = (tt_l1_ptr uint32_t*)(rt_args_base + COMMON_RT_ARGS_INDEX * sizeof(uint32_t) + (i * 4));
+        tt_l1_ptr std::uint32_t* arg_ptr = (tt_l1_ptr uint32_t*)(common_rt_args_base + (i * 4));
         UNPACK(arg_ptr[0] = rt_arg + common_arg_incr_val);
     }
 

--- a/tests/tt_metal/tt_metal/test_kernels/misc/increment_runtime_arg.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/misc/increment_runtime_arg.cpp
@@ -11,11 +11,9 @@ void kernel_main() {
     constexpr uint32_t num_unique_rt_args = get_compile_time_arg_val(0);
     constexpr uint32_t num_common_rt_args = get_compile_time_arg_val(1);
     constexpr uint32_t rt_args_base = get_compile_time_arg_val(2);
+    constexpr uint32_t common_rt_args_base = get_compile_time_arg_val(3);
     constexpr uint32_t unique_arg_incr_val = 10;
     constexpr uint32_t common_arg_incr_val = 100;
-
-    // DPRINT << "increment_runtime_arg: " << num_unique_rt_args << " " << num_common_rt_args << " " << unique_arg_incr_val << " " << common_arg_incr_val << " ";
-    // DPRINT << rt_args_base << " " << COMMON_RT_ARGS_INDEX << ENDL();
 
     // This verifies get_arg_val and get_common_arg_val APIs
     for (uint32_t i = 0; i < num_unique_rt_args; i++) {
@@ -26,7 +24,7 @@ void kernel_main() {
 
     for (uint32_t i = 0; i < num_common_rt_args; i++) {
         uint32_t rt_arg = get_common_arg_val<uint32_t>(i);
-        tt_l1_ptr std::uint32_t* arg_ptr = (tt_l1_ptr uint32_t*)(rt_args_base + COMMON_RT_ARGS_INDEX * sizeof(uint32_t) + (i * 4));
+        tt_l1_ptr std::uint32_t* arg_ptr = (tt_l1_ptr uint32_t*)(common_rt_args_base + (i * 4));
         arg_ptr[0] = rt_arg + common_arg_incr_val;
     }
 

--- a/tests/tt_metal/tt_metal/test_kernels/misc/runtime_args_kernel.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/misc/runtime_args_kernel.cpp
@@ -21,7 +21,11 @@ void MAIN  {
 #endif
     volatile uint32_t tt_l1_ptr *results = (volatile uint32_t tt_l1_ptr *)RESULTS_ADDR;
     for (int i = 0; i < NUM_RUNTIME_ARGS; i++) {
+#ifdef COMMON_RUNTIME_ARGS
+        results[i] = get_common_arg_val<uint32_t>(i);
+#else
         results[i] = get_arg_val<uint32_t>(i);
+#endif
     }
 }
 }

--- a/tests/tt_metal/tt_metal/unit_tests/basic/runtime_args.cpp
+++ b/tests/tt_metal/tt_metal/unit_tests/basic/runtime_args.cpp
@@ -25,21 +25,27 @@ enum class KernelType {
     COMPUTE = 1,
 };
 
-uint32_t get_runtime_arg_addr(tt::RISCV processor) {
+uint32_t get_runtime_arg_addr(tt::RISCV processor, bool is_common) {
     uint32_t result_base = 0;
+
+    // Spread results out a bit, overly generous
+    constexpr uint32_t runtime_args_space = 1024 * sizeof(uint32_t);
+
     switch (processor) {
         case tt::RISCV::BRISC: {
             result_base = L1_UNRESERVED_BASE;
         } break;
         case tt::RISCV::NCRISC: {
-            result_base = L1_UNRESERVED_BASE + 256 * sizeof(uint32_t);
+            result_base = L1_UNRESERVED_BASE + 1 * runtime_args_space;
         } break;
         case tt::RISCV::COMPUTE: {
-            result_base = L1_UNRESERVED_BASE + 2 * 256 * sizeof(uint32_t);
+            result_base = L1_UNRESERVED_BASE + 2 * runtime_args_space;
         } break;
         default: TT_THROW("Unknown processor");
     }
-    return result_base;
+
+    uint32_t offset = is_common ? 3 * runtime_args_space : 0;
+    return result_base + offset;
 };
 
 Program initialize_program_data_movement(Device *device, const CoreRangeSet &core_range_set) {
@@ -56,13 +62,17 @@ Program initialize_program_data_movement(Device *device, const CoreRangeSet &cor
     return std::move(program);
 }
 
-Program initialize_program_data_movement_rta(Device *device, const CoreRangeSet &core_range_set, uint32_t num_unique_rt_args) {
+Program initialize_program_data_movement_rta(Device *device, const CoreRangeSet &core_range_set, uint32_t num_unique_rt_args,
+                                             bool common_rtas = false) {
     Program program = tt_metal::CreateProgram();
 
-    uint32_t rta_base_dm = get_runtime_arg_addr(tt::RISCV::BRISC);
+    uint32_t rta_base_dm = get_runtime_arg_addr(tt::RISCV::BRISC, common_rtas);
     std::map<string, string> dm_defines = {{"DATA_MOVEMENT", "1"},
                                            {"NUM_RUNTIME_ARGS", std::to_string(num_unique_rt_args)},
                                            {"RESULTS_ADDR", std::to_string(rta_base_dm)}};
+    if (common_rtas) {
+        dm_defines["COMMON_RUNTIME_ARGS"] = "1";
+    }
 
     auto kernel = tt_metal::CreateKernel(
         program,
@@ -79,8 +89,9 @@ Program initialize_program_compute(Device *device, const CoreRangeSet &core_rang
     Program program = tt_metal::CreateProgram();
 
     // Tell kernel how many unique and common RT args to expect. Will increment each.
-    uint32_t rta_base_compute = get_runtime_arg_addr(tt::RISCV::COMPUTE);
-    std::vector<uint32_t> compile_args = {num_unique_rt_args, num_common_rt_args, rta_base_compute};
+    uint32_t rta_base_compute = get_runtime_arg_addr(tt::RISCV::COMPUTE, false);
+    uint32_t common_rta_base_compute = get_runtime_arg_addr(tt::RISCV::COMPUTE, true);
+    std::vector<uint32_t> compile_args = {num_unique_rt_args, num_common_rt_args, rta_base_compute, common_rta_base_compute};
     bool fp32_dest_acc_en = false;
     bool math_approx_mode = false;
 
@@ -124,9 +135,7 @@ bool verify_results(
 
     for (size_t kernel_id = 0; kernel_id < program.num_kernels(); kernel_id++) {
         const auto kernel = tt_metal::detail::GetKernel(program, kernel_id);
-        auto rt_args_base_addr = get_runtime_arg_addr(kernel->processor());
-        auto processor = kernel->processor();
-        uint32_t common_rt_args_offset = 0; // Set to max required across all cores.
+        auto rt_args_base_addr = get_runtime_arg_addr(kernel->processor(), false);
 
         // Verify Unique RT Args (per core)
         for (const auto &logical_core : kernel->cores_with_runtime_args()) {
@@ -136,19 +145,19 @@ bool verify_results(
 
             pass &= verify_core_rt_args(device, false, logical_core, rt_args_base_addr, expected_rt_args, unique_arg_incr_val);
             auto rt_args_size_bytes = rt_args.size() * sizeof(uint32_t);
-            common_rt_args_offset = rt_args_size_bytes > common_rt_args_offset ? rt_args_size_bytes : common_rt_args_offset;
         }
 
         // Verify common RT Args (same for all cores) if they exist.
         if (common_rt_args.size() > 0) {
-            const auto common_args_addr = rt_args_base_addr + align(common_rt_args_offset, L1_ALIGNMENT); // Common args are placed after unique args per core. 16B aligned.
+            auto common_rt_args_base_addr = get_runtime_arg_addr(kernel->processor(), true);
+
             for (auto &core_range : kernel->logical_coreranges()) {
                 for (auto x = core_range.start.x; x <= core_range.end.x; x++) {
                     for (auto y = core_range.start.y; y <= core_range.end.y; y++) {
                         CoreCoord logical_core({x, y});
                         auto rt_args = kernel->common_runtime_args();
                         EXPECT_EQ(rt_args, common_rt_args);
-                        pass &= verify_core_rt_args(device, true, logical_core, common_args_addr, common_rt_args, common_arg_incr_val);
+                        pass &= verify_core_rt_args(device, true, logical_core, common_rt_args_base_addr, common_rt_args, common_arg_incr_val);
                     }
                 }
             }
@@ -183,7 +192,7 @@ TEST_F(DeviceFixture, LegallyModifyRTArgsDataMovement) {
         tt_metal::detail::LaunchProgram(this->devices_.at(id), program);
         EXPECT_TRUE(unit_tests::runtime_args::verify_results(false, this->devices_.at(id), program, core_to_rt_args));
 
-        std::vector<uint32_t> second_runtime_args = {303, 606};
+        std::vector<uint32_t> second_runtime_args = {202, 505};
         SetRuntimeArgs(program, 0, first_core_range, second_runtime_args);
         detail::WriteRuntimeArgsToDevice(this->devices_.at(id), program);
         for (auto x = first_core_range.start.x; x <= first_core_range.end.x; x++) {
@@ -195,7 +204,7 @@ TEST_F(DeviceFixture, LegallyModifyRTArgsDataMovement) {
         tt_metal::detail::LaunchProgram(this->devices_.at(id), program);
         EXPECT_TRUE(unit_tests::runtime_args::verify_results(false, this->devices_.at(id), program, core_to_rt_args));
 
-        auto program2 = unit_tests::runtime_args::initialize_program_data_movement_rta(this->devices_.at(id), core_range_set, 4);
+        auto program2 = unit_tests::runtime_args::initialize_program_data_movement_rta(this->devices_.at(id), core_range_set, 4, true);
         // Set common runtime args, automatically sent to all cores used by kernel.
         std::vector<uint32_t> common_runtime_args = {303, 606, 999, 1234};
         SetCommonRuntimeArgs(program2, 0, common_runtime_args);

--- a/tt_metal/common/tt_backend_api_types.hpp
+++ b/tt_metal/common/tt_backend_api_types.hpp
@@ -138,7 +138,7 @@ std::string get_string(ARCH arch);
 std::string get_string_lowercase(ARCH arch);
 ARCH get_arch_from_string(const std::string &arch_str);
 
-enum class RISCV : uint8_t {
+enum RISCV : uint8_t {
     BRISC = 0,
     NCRISC = 1,
     TRISC0 = 2,
@@ -146,6 +146,7 @@ enum class RISCV : uint8_t {
     TRISC2 = 4,
     ERISC = 5,
     COMPUTE = 6,     // Encompasses TRISC0, TRISC1, and TRISC2
+    MAX = 7,
 };
 
 inline std::ostream& operator<<(std::ostream& os, const RISCV& riscv) {

--- a/tt_metal/detail/tt_metal.hpp
+++ b/tt_metal/detail/tt_metal.hpp
@@ -127,7 +127,7 @@ namespace tt::tt_metal{
          * | device       | The device to whcih runtime args will be written                       | Device *                      |                                    | Yes      |
          * | program      | The program holding the runtime args                                   | const Program &               |                                    | Yes      |
          */
-        void WriteRuntimeArgsToDevice(Device *device, const Program &program);
+        void WriteRuntimeArgsToDevice(Device *device, Program &program);
 
         // Configures a given device with a given program.
         // - Loads all kernel binaries into L1s of assigned Tensix cores

--- a/tt_metal/hostdevcommon/common_runtime_address_map.h
+++ b/tt_metal/hostdevcommon/common_runtime_address_map.h
@@ -13,6 +13,8 @@
 * This file contains addresses that are visible to both host and device compiled code.
 */
 
+constexpr static std::uint32_t L1_ALIGNMENT = NOC_L1_READ_ALIGNMENT_BYTES >= NOC_L1_WRITE_ALIGNMENT_BYTES ? NOC_L1_READ_ALIGNMENT_BYTES : NOC_L1_WRITE_ALIGNMENT_BYTES;
+
 // TODO: these could be moved to even lower addresses -- 5 RISC-V hexes combined don't need 100 KB
 constexpr static std::uint32_t PROFILER_L1_MARKER_UINT32_SIZE = 2;
 constexpr static std::uint32_t PROFILER_L1_MARKER_BYTES_SIZE = PROFILER_L1_MARKER_UINT32_SIZE * sizeof(uint32_t);
@@ -42,11 +44,9 @@ constexpr static std::uint32_t PROFILER_RISC_COUNT = 5;
 static_assert (PROFILER_FULL_HOST_BUFFER_SIZE_PER_RISC > PROFILER_L1_BUFFER_SIZE);
 
 constexpr static std::uint32_t L1_KERNEL_CONFIG_BASE = PROFILER_L1_END_ADDRESS;
-constexpr static std::uint32_t L1_KERNEL_CONFIG_SIZE = 3 * 1024;
+constexpr static std::uint32_t L1_KERNEL_CONFIG_SIZE = 3 * 1024 + L1_ALIGNMENT; // alignment between unique&common RTAs
 
 constexpr static std::uint32_t IDLE_ERISC_L1_KERNEL_CONFIG_BASE = 32 * 1024;
-
-constexpr static std::uint32_t L1_ALIGNMENT = NOC_L1_READ_ALIGNMENT_BYTES >= NOC_L1_WRITE_ALIGNMENT_BYTES ? NOC_L1_READ_ALIGNMENT_BYTES : NOC_L1_WRITE_ALIGNMENT_BYTES;
 
 // config for 32 L1 buffers is at addr BUFFER_CONFIG_BASE
 // 12 bytes for each buffer: (addr, size, size_in_tiles)

--- a/tt_metal/hw/firmware/src/brisc.cc
+++ b/tt_metal/hw/firmware/src/brisc.cc
@@ -64,7 +64,8 @@ uint32_t atomic_ret_val __attribute__((section("l1_data"))) __attribute__((used)
 
 CBInterface cb_interface[NUM_CIRCULAR_BUFFERS] __attribute__((used));
 
-uint32_t tt_l1_ptr *l1_arg_base __attribute__((used));
+uint32_t tt_l1_ptr *rta_l1_base __attribute__((used));
+uint32_t tt_l1_ptr *crta_l1_base __attribute__((used));
 
 #define MEM_MOVER_VIEW_IRAM_BASE_ADDR (0x4 << 12)
 
@@ -384,7 +385,9 @@ int main() {
             // Run the BRISC kernel
             DEBUG_STATUS("R");
             uint32_t kernel_config_base = mailboxes->launch.kernel_config_base;
-            l1_arg_base = (uint32_t tt_l1_ptr *)(kernel_config_base + mailboxes->launch.rta_offsets[DISPATCH_CLASS_TENSIX_DM0]);
+            rta_l1_base = (uint32_t tt_l1_ptr *)(kernel_config_base + mailboxes->launch.mem_map[DISPATCH_CLASS_TENSIX_DM0].rta_offset);
+            crta_l1_base = (uint32_t tt_l1_ptr *)(kernel_config_base + mailboxes->launch.mem_map[DISPATCH_CLASS_TENSIX_DM0].crta_offset);
+
             if (enables & DISPATCH_CLASS_MASK_TENSIX_ENABLE_DM0) {
                 setup_cb_read_write_interfaces(num_cbs_to_early_init, mailboxes->launch.max_cb_index, true, true);
                 kernel_init();

--- a/tt_metal/hw/firmware/src/erisc.cc
+++ b/tt_metal/hw/firmware/src/erisc.cc
@@ -45,7 +45,8 @@ uint32_t noc_nonposted_atomics_acked[NUM_NOCS] __attribute__((used));
 uint32_t noc_posted_writes_num_issued[NUM_NOCS] __attribute__((used));
 uint32_t atomic_ret_val __attribute__ ((section ("l1_data"))) __attribute__((used));
 
-uint32_t tt_l1_ptr *l1_arg_base __attribute__((used));
+uint32_t tt_l1_ptr *rta_l1_base __attribute__((used));
+uint32_t tt_l1_ptr *crta_l1_base __attribute__((used));
 
 void __attribute__((section("erisc_l1_code.1"), noinline)) Application(void) {
     DEBUG_STATUS("I");
@@ -80,7 +81,9 @@ void __attribute__((section("erisc_l1_code.1"), noinline)) Application(void) {
             DeviceZoneScopedMainN("ERISC-FW");
             DEBUG_STATUS("R");
             uint32_t kernel_config_base = mailboxes->launch.kernel_config_base;
-            l1_arg_base = (uint32_t tt_l1_ptr *)(kernel_config_base + mailboxes->launch.rta_offsets[DISPATCH_CLASS_ETH_DM0]);
+            rta_l1_base = (uint32_t tt_l1_ptr *)(kernel_config_base + mailboxes->launch.mem_map[DISPATCH_CLASS_ETH_DM0].rta_offset);
+            crta_l1_base = (uint32_t tt_l1_ptr *)(kernel_config_base + mailboxes->launch.mem_map[DISPATCH_CLASS_ETH_DM0].crta_offset);
+
             kernel_init();
         } else {
             internal_::risc_context_switch();

--- a/tt_metal/hw/firmware/src/idle_erisc.cc
+++ b/tt_metal/hw/firmware/src/idle_erisc.cc
@@ -37,7 +37,8 @@ uint32_t noc_nonposted_atomics_acked[NUM_NOCS] __attribute__((used));
 uint32_t noc_posted_writes_num_issued[NUM_NOCS] __attribute__((used));
 uint32_t atomic_ret_val __attribute__ ((section ("l1_data"))) __attribute__((used));
 
-uint32_t tt_l1_ptr *l1_arg_base __attribute__((used));
+uint32_t tt_l1_ptr *rta_l1_base __attribute__((used));
+uint32_t tt_l1_ptr *crta_l1_base __attribute__((used));
 
 uint8_t my_x[NUM_NOCS] __attribute__((used));
 uint8_t my_y[NUM_NOCS] __attribute__((used));
@@ -119,7 +120,9 @@ int main() {
                 //UC FIXME: do i need this?
                 setup_cb_read_write_interfaces(num_cbs_to_early_init, mailboxes->launch.max_cb_index, true, true);
                 uint32_t kernel_config_base = mailboxes->launch.kernel_config_base;
-                l1_arg_base = (uint32_t tt_l1_ptr *)(kernel_config_base + mailboxes->launch.rta_offsets[DISPATCH_CLASS_ETH_DM0]);
+                rta_l1_base = (uint32_t tt_l1_ptr *)(kernel_config_base + mailboxes->launch.mem_map[DISPATCH_CLASS_ETH_DM0].rta_offset);
+                crta_l1_base = (uint32_t tt_l1_ptr *)(kernel_config_base + mailboxes->launch.mem_map[DISPATCH_CLASS_ETH_DM0].crta_offset);
+
                 kernel_init();
             //} else {
                 // This was not initialized in kernel_init

--- a/tt_metal/hw/firmware/src/ncrisc.cc
+++ b/tt_metal/hw/firmware/src/ncrisc.cc
@@ -15,6 +15,7 @@
 #include "circular_buffer.h"
 
 #include "debug/status.h"
+#include "debug/dprint.h"
 // clang-format on
 
 uint32_t halt_stack_ptr_save;
@@ -34,7 +35,8 @@ uint32_t atomic_ret_val __attribute__((section("l1_data"))) __attribute__((used)
 
 CBInterface cb_interface[NUM_CIRCULAR_BUFFERS] __attribute__((used));
 
-uint32_t tt_l1_ptr *l1_arg_base __attribute__((used));
+uint32_t tt_l1_ptr *rta_l1_base __attribute__((used));
+uint32_t tt_l1_ptr *crta_l1_base __attribute__((used));
 
 #if defined(PROFILE_KERNEL)
 namespace kernel_profiler {
@@ -95,7 +97,8 @@ int main(int argc, char *argv[]) {
         setup_cb_read_write_interfaces(0, mailboxes->launch.max_cb_index, true, true);
 
         uint32_t kernel_config_base = mailboxes->launch.kernel_config_base;
-        l1_arg_base = (uint32_t tt_l1_ptr *)(kernel_config_base + mailboxes->launch.rta_offsets[DISPATCH_CLASS_TENSIX_DM1]);
+        rta_l1_base = (uint32_t tt_l1_ptr *)(kernel_config_base + mailboxes->launch.mem_map[DISPATCH_CLASS_TENSIX_DM1].rta_offset);
+        crta_l1_base = (uint32_t tt_l1_ptr *)(kernel_config_base + mailboxes->launch.mem_map[DISPATCH_CLASS_TENSIX_DM1].crta_offset);
 
         DEBUG_STATUS("R");
         kernel_init();

--- a/tt_metal/hw/firmware/src/trisc.cc
+++ b/tt_metal/hw/firmware/src/trisc.cc
@@ -13,6 +13,7 @@
 
 #include "debug/fw_debug.h"
 #include "debug/status.h"
+#include "debug/dprint.h"
 #include "circular_buffer.h"
 // clang-format on
 
@@ -25,7 +26,8 @@ namespace kernel_profiler {
 }
 #endif
 
-tt_l1_ptr uint32_t *l1_arg_base __attribute__((used));
+uint32_t tt_l1_ptr *rta_l1_base __attribute__((used));
+uint32_t tt_l1_ptr *crta_l1_base __attribute__((used));
 
 namespace ckernel {
 
@@ -108,7 +110,8 @@ int main(int argc, char *argv[]) {
 #endif
 
         uint32_t kernel_config_base = mailboxes->launch.kernel_config_base;
-        l1_arg_base = (uint32_t tt_l1_ptr *)(kernel_config_base + mailboxes->launch.rta_offsets[DISPATCH_CLASS_TENSIX_COMPUTE]);
+        rta_l1_base = (uint32_t tt_l1_ptr *)(kernel_config_base + mailboxes->launch.mem_map[DISPATCH_CLASS_TENSIX_COMPUTE].rta_offset);
+        crta_l1_base = (uint32_t tt_l1_ptr *)(kernel_config_base + mailboxes->launch.mem_map[DISPATCH_CLASS_TENSIX_COMPUTE].crta_offset);
 
         DEBUG_STATUS("R");
         kernel_init();

--- a/tt_metal/hw/inc/dataflow_api.h
+++ b/tt_metal/hw/inc/dataflow_api.h
@@ -27,7 +27,8 @@
 #include "dev_msgs.h"
 
 extern uint8_t noc_index;
-extern uint32_t tt_l1_ptr *l1_arg_base;
+extern uint32_t tt_l1_ptr *rta_l1_base;
+extern uint32_t tt_l1_ptr *crta_l1_base;
 
 /** @file */
 
@@ -42,11 +43,6 @@ extern CBInterface cb_interface[NUM_CIRCULAR_BUFFERS];
 #define NOC_DISPATCH_MULTICAST_WRITE_VC 5 // Only to be used by the dispatch cores
 
 
-// JIT Build flow will set this as needed.
-#ifndef COMMON_RT_ARGS_INDEX
-    #define COMMON_RT_ARGS_INDEX 0
-#endif
-
 inline uint32_t align(uint32_t addr, uint32_t alignment) { return ((addr - 1) | (alignment - 1)) + 1; }
 
 /**
@@ -60,7 +56,7 @@ inline uint32_t align(uint32_t addr, uint32_t alignment) { return ((addr - 1) | 
  */
 static FORCE_INLINE
 uint32_t get_arg_addr(int arg_idx) {
-    return (uint32_t)&l1_arg_base[arg_idx];;
+    return (uint32_t)&rta_l1_base[arg_idx];;
 }
 
 /**
@@ -74,7 +70,7 @@ uint32_t get_arg_addr(int arg_idx) {
  */
 static FORCE_INLINE
 uint32_t get_common_arg_addr(int arg_idx) {
-    return (uint32_t)&l1_arg_base[arg_idx + COMMON_RT_ARGS_INDEX];
+    return (uint32_t)&crta_l1_base[arg_idx];
 }
 
 /**

--- a/tt_metal/hw/inc/dev_msgs.h
+++ b/tt_metal/hw/inc/dev_msgs.h
@@ -69,13 +69,20 @@ enum dispatch_core_processor_masks {
     DISPATCH_CLASS_MASK_ETH_DM0 = 1 << DISPATCH_CLASS_ETH_DM0,
 };
 
+// Address offsets to kernel runtime configuration components
+// struct to densely packs values used by each processor
+struct dyn_mem_map_t {
+    volatile uint16_t rta_offset;
+    volatile uint16_t crta_offset;
+};
+
 struct launch_msg_t {  // must be cacheline aligned
     volatile uint16_t watcher_kernel_ids[DISPATCH_CLASS_MAX];
     volatile uint16_t ncrisc_kernel_size16;  // size in 16 byte units
 
     // Ring buffer of kernel configuration data
     volatile uint32_t kernel_config_base;
-    volatile uint16_t rta_offsets[DISPATCH_CLASS_MAX];
+    dyn_mem_map_t mem_map[DISPATCH_CLASS_MAX];
 
     volatile uint8_t mode;                   // dispatch mode host/dev
     volatile uint8_t brisc_noc_id;
@@ -85,7 +92,7 @@ struct launch_msg_t {  // must be cacheline aligned
     volatile uint8_t dispatch_core_y;
     volatile uint8_t exit_erisc_kernel;
     volatile uint8_t run;  // must be in last cacheline of this msg
-};
+} __attribute__((packed));
 
 struct slave_sync_msg_t {
     union {

--- a/tt_metal/hw/inc/dev_msgs.h
+++ b/tt_metal/hw/inc/dev_msgs.h
@@ -194,6 +194,8 @@ struct mailboxes_t {
     struct debug_insert_delays_msg_t debug_insert_delays;
 };
 
+static_assert(sizeof(launch_msg_t) % sizeof(uint32_t) == 0);
+
 #ifndef TENSIX_FIRMWARE
 // Validate assumptions on mailbox layout on host compile
 static_assert((MEM_MAILBOX_BASE + offsetof(mailboxes_t, launch)) % 32 == 0);

--- a/tt_metal/hw/inc/dev_msgs.h
+++ b/tt_metal/hw/inc/dev_msgs.h
@@ -58,20 +58,28 @@ enum dispatch_core_processor_classes {
     // Ethernet processor classes
     DISPATCH_CLASS_ETH_DM0 = 0,
 
-    DISPATCH_CLASS_MAX_PROC = 3,
+    DISPATCH_CLASS_MAX = 3,
+};
+
+enum dispatch_core_processor_masks {
+    DISPATCH_CLASS_MASK_TENSIX_ENABLE_DM0     = 1 << DISPATCH_CLASS_TENSIX_DM0,
+    DISPATCH_CLASS_MASK_TENSIX_ENABLE_DM1     = 1 << DISPATCH_CLASS_TENSIX_DM1,
+    DISPATCH_CLASS_MASK_TENSIX_ENABLE_COMPUTE = 1 << DISPATCH_CLASS_TENSIX_COMPUTE,
+
+    DISPATCH_CLASS_MASK_ETH_DM0 = 1 << DISPATCH_CLASS_ETH_DM0,
 };
 
 struct launch_msg_t {  // must be cacheline aligned
-    volatile uint16_t watcher_kernel_ids[DISPATCH_CLASS_MAX_PROC];
+    volatile uint16_t watcher_kernel_ids[DISPATCH_CLASS_MAX];
     volatile uint16_t ncrisc_kernel_size16;  // size in 16 byte units
 
     // Ring buffer of kernel configuration data
     volatile uint32_t kernel_config_base;
-    volatile uint16_t rta_offsets[DISPATCH_CLASS_MAX_PROC];
+    volatile uint16_t rta_offsets[DISPATCH_CLASS_MAX];
 
     volatile uint8_t mode;                   // dispatch mode host/dev
     volatile uint8_t brisc_noc_id;
-    volatile uint8_t enables[DISPATCH_CLASS_MAX_PROC];
+    volatile uint8_t enables;
     volatile uint8_t max_cb_index;
     volatile uint8_t dispatch_core_x;
     volatile uint8_t dispatch_core_y;

--- a/tt_metal/hw/inc/risc_common.h
+++ b/tt_metal/hw/inc/risc_common.h
@@ -33,7 +33,6 @@ const uint32_t MAX_TILES_PER_PHASE = 2048;
 
 extern uint8_t my_x[NUM_NOCS];
 extern uint8_t my_y[NUM_NOCS];
-extern uint32_t *l1_arg_base;
 
 inline void WRITE_REG(uint32_t addr, uint32_t val) {
     volatile tt_reg_ptr uint32_t* ptr = (volatile tt_reg_ptr uint32_t*)addr;

--- a/tt_metal/impl/debug/watcher_server.cpp
+++ b/tt_metal/impl/debug/watcher_server.cpp
@@ -488,40 +488,32 @@ static void dump_run_mailboxes(
 
     fprintf(f, "|");
 
-    if (launch_msg->enables[DISPATCH_CLASS_TENSIX_DM0] == 1) {
+    if (launch_msg->enables & ~(DISPATCH_CLASS_MASK_TENSIX_ENABLE_DM0 |
+                                DISPATCH_CLASS_MASK_TENSIX_ENABLE_DM1 |
+                                DISPATCH_CLASS_MASK_TENSIX_ENABLE_COMPUTE)) {
+        log_running_kernels(launch_msg);
+        TT_THROW(
+            "Watcher data corruption, unexpected kernel enable on core {}: {} (expected only low bits set)",
+            core.str(),
+            launch_msg->enables);
+    }
+
+    if (launch_msg->enables & DISPATCH_CLASS_MASK_TENSIX_ENABLE_DM0) {
         fprintf(f, "B");
-    } else if (launch_msg->enables[DISPATCH_CLASS_TENSIX_DM0] == 0) {
+    } else {
         fprintf(f, "b");
-    } else {
-        log_running_kernels(launch_msg);
-        TT_THROW(
-            "Watcher data corruption, unexpected brisc enable on core {}: {} (expected 0 or 1)",
-            core.str(),
-            launch_msg->enables[DISPATCH_CLASS_TENSIX_DM0]);
     }
 
-    if (launch_msg->enables[DISPATCH_CLASS_TENSIX_DM1] == 1) {
+    if (launch_msg->enables & DISPATCH_CLASS_MASK_TENSIX_ENABLE_DM1) {
         fprintf(f, "N");
-    } else if (launch_msg->enables[DISPATCH_CLASS_TENSIX_DM1] == 0) {
-        fprintf(f, "n");
     } else {
-        log_running_kernels(launch_msg);
-        TT_THROW(
-            "Watcher data corruption, unexpected ncrisc enable on core {}: {} (expected 0 or 1)",
-            core.str(),
-            launch_msg->enables[DISPATCH_CLASS_TENSIX_DM1]);
+        fprintf(f, "n");
     }
 
-    if (launch_msg->enables[DISPATCH_CLASS_TENSIX_COMPUTE] == 1) {
+    if (launch_msg->enables & DISPATCH_CLASS_MASK_TENSIX_ENABLE_COMPUTE) {
         fprintf(f, "T");
-    } else if (launch_msg->enables[DISPATCH_CLASS_TENSIX_COMPUTE] == 0) {
-        fprintf(f, "t");
     } else {
-        log_running_kernels(launch_msg);
-        TT_THROW(
-            "Watcher data corruption, unexpected trisc enable on core {}: {} (expected 0 or 1)",
-            core.str(),
-            launch_msg->enables[DISPATCH_CLASS_TENSIX_COMPUTE]);
+        fprintf(f, "t");
     }
 
     fprintf(f, " ");

--- a/tt_metal/impl/dispatch/command_queue.cpp
+++ b/tt_metal/impl/dispatch/command_queue.cpp
@@ -496,7 +496,7 @@ void EnqueueProgramCommand::assemble_runtime_args_commands() {
     for (size_t kernel_id = 0; kernel_id < program.num_kernels(); kernel_id++) {
         auto kernel = detail::GetKernel(program, kernel_id);
 
-        uint32_t processor_idx = static_cast<typename std::underlying_type<tt::RISCV>::type>(kernel->processor());
+        uint32_t processor_idx = kernel->processor();
 
         if (!kernel->cores_with_runtime_args().empty()) {
             unique_processors.insert(processor_idx);

--- a/tt_metal/impl/dispatch/command_queue.cpp
+++ b/tt_metal/impl/dispatch/command_queue.cpp
@@ -388,12 +388,11 @@ void generate_runtime_args_cmds(
     std::vector<HostMemDeviceCommand>& runtime_args_command_sequences,
     const uint32_t& l1_arg_base_addr,
     const std::vector<PackedSubCmd>& sub_cmds,
-    const std::vector<std::pair<const void*, uint32_t>>& rt_data_and_sizes,
+    const std::vector<std::vector<std::tuple<const void*, uint32_t, uint32_t>>>& rt_data_and_sizes,
     const uint32_t& max_runtime_args_len,
-    std::vector<std::reference_wrapper<RuntimeArgsData>>& rt_args_data,
+    std::vector<std::vector<std::reference_wrapper<RuntimeArgsData>>>& rt_args_data,
     const uint32_t max_prefetch_command_size,
     const uint32_t packed_write_max_unicast_sub_cmds,
-    const uint32_t id,
     bool no_stride = false) {
     static_assert(
         std::is_same<PackedSubCmd, CQDispatchWritePackedUnicastSubCmd>::value or
@@ -426,6 +425,7 @@ void generate_runtime_args_cmds(
         TT_FATAL(max_packed_cmds >= num_packed_cmds_in_seq);
     }
     while (num_packed_cmds_in_seq != 0) {
+        // Generate the device command
         uint32_t num_packed_cmds = std::min(num_packed_cmds_in_seq, max_packed_cmds);
         uint32_t rt_payload_sizeB =
             get_runtime_payload_sizeB(num_packed_cmds, max_runtime_args_len, unicast, no_stride);
@@ -441,12 +441,19 @@ void generate_runtime_args_cmds(
             packed_write_max_unicast_sub_cmds,
             offset_idx,
             no_stride);
+
+        // Update kernel RTA pointers to point into the generated command
+        // Future RTA updates through the API will update the command sequence directly
         uint32_t data_offset = (uint32_t)get_runtime_args_data_offset(num_packed_cmds, max_runtime_args_len, unicast);
         const uint32_t data_inc = align(max_runtime_args_len * sizeof(uint32_t), L1_ALIGNMENT);
         uint32_t num_data_copies = no_stride ? 1 : num_packed_cmds;
         for (uint32_t i = offset_idx; i < offset_idx + num_data_copies; ++i) {
-            rt_args_data[i].get().rt_args_data =
-                (uint32_t*)((char*)runtime_args_command_sequences.back().data() + data_offset);
+            uint32_t offset = 0;
+            for (auto& data : rt_args_data[i]) {
+                data.get().rt_args_data =
+                    (uint32_t*)((char*)runtime_args_command_sequences.back().data() + data_offset + offset);
+                offset += data.get().rt_args_count * sizeof(uint32_t);
+            }
             data_offset += data_inc;
         }
         num_packed_cmds_in_seq -= num_packed_cmds;
@@ -456,151 +463,185 @@ void generate_runtime_args_cmds(
 
 // Generate command sequence for unique (unicast) and common (multicast) runtime args
 void EnqueueProgramCommand::assemble_runtime_args_commands() {
-    // Maps to enum class RISCV, tt_backend_api_types.h
-    thread_local static const std::vector<uint32_t> unique_processor_to_l1_arg_base_addr = {
-        L1_KERNEL_CONFIG_BASE,
-        L1_KERNEL_CONFIG_BASE + max_runtime_args * sizeof(uint32_t),
-        0,
-        0,
-        0,
-        eth_l1_mem::address_map::ERISC_L1_KERNEL_CONFIG_BASE,
-        L1_KERNEL_CONFIG_BASE + 2 * max_runtime_args * sizeof(uint32_t),
-    };
+
+    // TODO: provide this at a lower level
+    static vector<CoreType>core_types = {CoreType::WORKER, CoreType::ETH };
+
     CoreType dispatch_core_type =
         dispatch_core_manager::get(this->device->num_hw_cqs()).get_dispatch_core_type(this->device->id());
     const uint32_t max_prefetch_command_size = dispatch_constants::get(dispatch_core_type).max_prefetch_command_size();
 
-    uint32_t num_processors = unique_processor_to_l1_arg_base_addr.size();
-    std::vector<std::vector<CQDispatchWritePackedUnicastSubCmd>> unique_sub_cmds(num_processors);
-    std::vector<std::vector<std::pair<const void*, uint32_t>>> unique_rt_data_and_sizes(num_processors);
-    std::vector<std::vector<std::reference_wrapper<RuntimeArgsData>>> unique_rt_args_data(num_processors);
-    std::vector<uint32_t> unique_max_runtime_args_len(num_processors, 0);
+    // Note: each sub_cmd contain data for multiple kernels (DM*, COMPUTE)
+    // the outer vector counts through the kernels, the inner vectors contains the data for each kernel
+    std::vector<CQDispatchWritePackedUnicastSubCmd> unique_sub_cmds;
+    std::vector<std::vector<std::tuple<const void*, uint32_t, uint32_t>>> unique_rt_data_and_sizes;
+    std::vector<std::vector<std::reference_wrapper<RuntimeArgsData>>> unique_rt_args_data;
 
-    uint32_t num_kernels = program.num_kernels();
-    std::vector<std::variant<
-        std::vector<CQDispatchWritePackedMulticastSubCmd>,
-        std::vector<CQDispatchWritePackedUnicastSubCmd>>>
-        common_sub_cmds(num_kernels);
-    std::vector<std::vector<std::pair<const void*, uint32_t>>> common_rt_data_and_sizes(num_kernels);
-    std::vector<std::vector<std::reference_wrapper<RuntimeArgsData>>> common_rt_args_data(num_kernels);
-    std::vector<uint32_t> common_max_runtime_args_len(num_kernels, 0);
-    std::vector<uint32_t> common_processor_to_l1_arg_base_addr(num_kernels);
+    std::variant<std::vector<CQDispatchWritePackedMulticastSubCmd>,
+                 std::vector<CQDispatchWritePackedUnicastSubCmd>> common_sub_cmds;
+    std::vector<std::vector<std::tuple<const void*, uint32_t, uint32_t>>> common_rt_data_and_sizes;
+    std::vector<std::vector<std::reference_wrapper<RuntimeArgsData>>> common_rt_args_data;
 
-    std::set<uint32_t> unique_processors;
-    std::set<uint32_t> common_kernels;
+    this->cached_program_command_sequences[program.id].runtime_args_command_sequences = {};
+
+    uint32_t command_count = 0;
+    for (CoreType core_type : core_types) {
+        for (auto& kg : program.get_kernel_groups(core_type)) {
+            if (kg.total_rta_size != 0) {
+                // Reserve 2x for unique rtas as we pontentially split the cmds due to not fitting in one prefetch cmd
+                command_count += 2;
+            }
+        }
+        for (int dispatch_class = 0; dispatch_class < DISPATCH_CLASS_MAX; dispatch_class++) {
+            uint32_t common_size = program.crta_sizes[core_type == CoreType::WORKER][dispatch_class];
+            if (common_size != 0) {
+                command_count++;
+            }
+        }
+    }
+
+    this->cached_program_command_sequences[program.id].runtime_args_command_sequences.reserve(command_count);
 
     // Unique Runtime Args (Unicast)
-    // TODO: If we need to break apart cmds if they exceed the max prefetch cmd size
-    // would potentially be more optimal to sort the data by size and have a max rt arg size
-    // to pad to per split. Currently we take the max of all rt args before splitting
-    for (size_t kernel_id = 0; kernel_id < program.num_kernels(); kernel_id++) {
-        auto kernel = detail::GetKernel(program, kernel_id);
+    for (CoreType core_type : core_types) {
+        for (auto& kg : program.get_kernel_groups(core_type)) {
+            if (kg.total_rta_size != 0) {
+                for (const CoreRange &core_range : kg.core_ranges.ranges()) {
+                    for (auto x = core_range.start.x; x <= core_range.end.x; x++) {
+                        for (auto y = core_range.start.y; y <= core_range.end.y; y++) {
+                            CoreCoord core_coord(x, y);
 
-        uint32_t processor_idx = kernel->processor();
+                            unique_rt_args_data.resize(unique_rt_args_data.size() + 1);
+                            unique_rt_data_and_sizes.resize(unique_rt_data_and_sizes.size() + 1);
+                            for (int dispatch_class = 0; dispatch_class < DISPATCH_CLASS_MAX; dispatch_class++) {
+                                auto& optional_id = kg.kernel_ids[dispatch_class];
+                                if (optional_id) {
+                                    auto kernel = detail::GetKernel(program, optional_id.value());
+                                    if (!kernel->cores_with_runtime_args().empty()) {
+                                        const auto& runtime_args_data = kernel->runtime_args(core_coord);
+                                        unique_rt_args_data.back().emplace_back(kernel->runtime_args_data(core_coord));
+                                        TT_ASSERT(runtime_args_data.size() * sizeof(uint32_t) <= kg.rta_sizes[dispatch_class]);
+                                        unique_rt_data_and_sizes.back().emplace_back(
+                                            runtime_args_data.data(),
+                                            runtime_args_data.size() * sizeof(uint32_t),
+                                            kg.rta_sizes[dispatch_class]);
+                                    }
+                                }
+                            }
 
-        if (!kernel->cores_with_runtime_args().empty()) {
-            unique_processors.insert(processor_idx);
-            unique_sub_cmds[processor_idx].reserve(kernel->cores_with_runtime_args().size());
-            unique_rt_data_and_sizes[processor_idx].reserve(kernel->cores_with_runtime_args().size());
-            unique_rt_args_data[processor_idx].reserve(kernel->cores_with_runtime_args().size());
-            for (const auto& core_coord : kernel->cores_with_runtime_args()) {
-                // can make a vector of unicast encodings here
-                CoreCoord physical_core =
-                    device->physical_core_from_logical_core(core_coord, kernel->get_kernel_core_type());
-                const auto& runtime_args_data = kernel->runtime_args(core_coord);
-                unique_rt_args_data[processor_idx].emplace_back(kernel->runtime_args_data(core_coord));
-                // 2, 17, could be differnet len here
-
-                unique_sub_cmds[processor_idx].emplace_back(CQDispatchWritePackedUnicastSubCmd{
-                    .noc_xy_addr = this->device->get_noc_unicast_encoding(this->noc_index, physical_core)});
-                unique_rt_data_and_sizes[processor_idx].emplace_back(
-                    runtime_args_data.data(), runtime_args_data.size() * sizeof(uint32_t));
-                unique_max_runtime_args_len[processor_idx] =
-                    std::max(unique_max_runtime_args_len[processor_idx], (uint32_t)runtime_args_data.size());
-            }
-        }
-        // Common Runtime Args (Multicast)
-        const auto& common_rt_args = kernel->common_runtime_args();
-
-        if (common_rt_args.size() > 0) {
-            common_kernels.insert(kernel_id);
-            uint32_t common_args_addr = unique_processor_to_l1_arg_base_addr[processor_idx] +
-                                        kernel->get_common_runtime_args_index() * sizeof(uint32_t);
-            common_processor_to_l1_arg_base_addr[kernel_id] = common_args_addr;
-            common_rt_data_and_sizes[kernel_id].emplace_back(
-                common_rt_args.data(), common_rt_args.size() * sizeof(uint32_t));
-            common_rt_args_data[kernel_id].emplace_back(kernel->common_runtime_args_data());
-            common_max_runtime_args_len[kernel_id] = (uint32_t)common_rt_args.size();
-            if (kernel->get_kernel_core_type() == CoreType::ETH) {
-                common_sub_cmds[kernel_id].emplace<std::vector<CQDispatchWritePackedUnicastSubCmd>>(
-                    std::vector<CQDispatchWritePackedUnicastSubCmd>());
-                auto& unicast_sub_cmd =
-                    std::get<std::vector<CQDispatchWritePackedUnicastSubCmd>>(common_sub_cmds[kernel_id]);
-                unicast_sub_cmd.reserve(kernel->logical_cores().size());
-                for (auto& core_coord : kernel->logical_cores()) {
-                    // can make a vector of unicast encodings here
-                    CoreCoord physical_core = device->ethernet_core_from_logical_core(core_coord);
-                    unicast_sub_cmd.emplace_back(CQDispatchWritePackedUnicastSubCmd{
-                        .noc_xy_addr = this->device->get_noc_unicast_encoding(this->noc_index, physical_core)});
+                            CoreCoord physical_core =
+                                device->physical_core_from_logical_core(core_coord, core_type);
+                            unique_sub_cmds.emplace_back(CQDispatchWritePackedUnicastSubCmd{
+                                    .noc_xy_addr = this->device->get_noc_unicast_encoding(this->noc_index, physical_core)});
+                        }
+                    }
                 }
-            } else {
-                vector<pair<transfer_info_cores, uint32_t>> dst_noc_multicast_info =
-                    extract_dst_noc_multicast_info<std::vector<CoreRange>>(
-                        device, kernel->logical_coreranges(), kernel->get_kernel_core_type());
-                common_sub_cmds[kernel_id].emplace<std::vector<CQDispatchWritePackedMulticastSubCmd>>(
-                    std::vector<CQDispatchWritePackedMulticastSubCmd>());
-                auto& multicast_sub_cmd =
-                    std::get<std::vector<CQDispatchWritePackedMulticastSubCmd>>(common_sub_cmds[kernel_id]);
-                multicast_sub_cmd.reserve(dst_noc_multicast_info.size());
-                for (const auto& mcast_dests : dst_noc_multicast_info) {
-                    multicast_sub_cmd.emplace_back(CQDispatchWritePackedMulticastSubCmd{
-                        .noc_xy_addr = this->device->get_noc_multicast_encoding(
-                            this->noc_index, std::get<CoreRange>(mcast_dests.first)),
-                        .num_mcast_dests = mcast_dests.second});
+
+                // TODO: eventually get this from the dispatch ring buffer
+                uint32_t kernel_config_base;
+                if (core_type == CoreType::WORKER) {
+                    kernel_config_base = L1_KERNEL_CONFIG_BASE;
+                } else {
+                    TT_ASSERT(core_type == CoreType::ETH);
+                    kernel_config_base = eth_l1_mem::address_map::ERISC_L1_KERNEL_CONFIG_BASE;
                 }
-            }
-        }
-    }
-    // Reserve 2x for unique rtas as we pontentially split the cmds due to not fitting in one prefetch cmd
-    // Common rtas are always expected to fit in one prefetch cmd
-    this->cached_program_command_sequences[program.id].runtime_args_command_sequences = {};
-    this->cached_program_command_sequences[program.id].runtime_args_command_sequences.reserve(
-        2 * unique_processors.size() + common_kernels.size());
-    std::vector<std::pair<uint32_t, uint32_t>> runtime_args_data_index;
-    runtime_args_data_index.reserve(2 * (unique_processors.size() + common_kernels.size()));
-    // Array of cmd idx, # sub cmds, rt arg offset, rt arg len
-    // Currently we only really need the base cmd idx since they are sequential, and the rt arg len is currently the
-    // same for all splits
-    for (const uint32_t& processor_idx : unique_processors) {
-        generate_runtime_args_cmds(
-            this->cached_program_command_sequences[program.id].runtime_args_command_sequences,
-            unique_processor_to_l1_arg_base_addr[processor_idx],
-            unique_sub_cmds[processor_idx],
-            unique_rt_data_and_sizes[processor_idx],
-            unique_max_runtime_args_len[processor_idx],
-            unique_rt_args_data[processor_idx],
-            max_prefetch_command_size,
-            packed_write_max_unicast_sub_cmds,
-            processor_idx,
-            false);
-    }
-    for (const uint32_t& kernel_id : common_kernels) {
-        std::visit(
-            [&](auto&& sub_cmds) {
+
                 generate_runtime_args_cmds(
                     this->cached_program_command_sequences[program.id].runtime_args_command_sequences,
-                    common_processor_to_l1_arg_base_addr[kernel_id],
-                    sub_cmds,
-                    common_rt_data_and_sizes[kernel_id],
-                    common_max_runtime_args_len[kernel_id],
-                    common_rt_args_data[kernel_id],
+                    kernel_config_base,
+                    unique_sub_cmds,
+                    unique_rt_data_and_sizes,
+                    kg.total_rta_size / sizeof(uint32_t),
+                    unique_rt_args_data,
                     max_prefetch_command_size,
                     packed_write_max_unicast_sub_cmds,
-                    kernel_id,
-                    true);
-            },
-            common_sub_cmds[kernel_id]);
+                    false);
+                unique_sub_cmds.clear();
+                unique_rt_data_and_sizes.clear();
+                unique_rt_args_data.clear();
+            }
+        }
+
+        for (int dispatch_class = 0; dispatch_class < DISPATCH_CLASS_MAX; dispatch_class++) {
+            uint32_t common_size = program.crta_sizes[core_type == CoreType::WORKER][dispatch_class];
+            for (size_t kernel_id = 0; kernel_id < program.num_kernels(); kernel_id++) {
+                auto kernel = detail::GetKernel(program, kernel_id);
+                if (kernel->get_kernel_core_type() != core_type) continue; // TODO: fixme, need list of kernels by core_typexdispatch_class
+                if (kernel->dispatch_class() != dispatch_class) continue; // TODO: fixme, need list of kernels by core_typexdispatch_class
+
+                const auto& common_rt_args = kernel->common_runtime_args();
+                if (common_rt_args.size() > 0) {
+                    common_rt_args_data.resize(common_rt_args_data.size() + 1);
+                    common_rt_data_and_sizes.resize(common_rt_data_and_sizes.size() + 1);
+
+                    TT_ASSERT(kernel->common_runtime_args_data().size() * sizeof(uint32_t) == common_size);
+                    TT_ASSERT(common_rt_args.size() * sizeof(uint32_t) <= common_size);
+                    common_rt_data_and_sizes.back().emplace_back(
+                        common_rt_args.data(), common_rt_args.size() * sizeof(uint32_t), common_size);
+                    common_rt_args_data.back().emplace_back(kernel->common_runtime_args_data());
+
+                    if (core_type == CoreType::ETH) {
+                        common_sub_cmds.emplace<std::vector<CQDispatchWritePackedUnicastSubCmd>>(
+                            std::vector<CQDispatchWritePackedUnicastSubCmd>());
+                        auto& unicast_sub_cmd =
+                            std::get<std::vector<CQDispatchWritePackedUnicastSubCmd>>(common_sub_cmds);
+                        unicast_sub_cmd.reserve(kernel->logical_cores().size());
+                        for (auto& core_coord : kernel->logical_cores()) {
+                            // can make a vector of unicast encodings here
+                            CoreCoord physical_core = device->ethernet_core_from_logical_core(core_coord);
+                            unicast_sub_cmd.emplace_back(CQDispatchWritePackedUnicastSubCmd{
+                                    .noc_xy_addr = this->device->get_noc_unicast_encoding(this->noc_index, physical_core)});
+                        }
+                    } else {
+                        vector<pair<transfer_info_cores, uint32_t>> dst_noc_multicast_info =
+                            extract_dst_noc_multicast_info<std::vector<CoreRange>>(
+                                device, kernel->logical_coreranges(), core_type);
+                        common_sub_cmds.emplace<std::vector<CQDispatchWritePackedMulticastSubCmd>>(
+                            std::vector<CQDispatchWritePackedMulticastSubCmd>());
+                        auto& multicast_sub_cmd =
+                            std::get<std::vector<CQDispatchWritePackedMulticastSubCmd>>(common_sub_cmds);
+                        multicast_sub_cmd.reserve(dst_noc_multicast_info.size());
+                        for (const auto& mcast_dests : dst_noc_multicast_info) {
+                            multicast_sub_cmd.emplace_back(CQDispatchWritePackedMulticastSubCmd{
+                                .noc_xy_addr = this->device->get_noc_multicast_encoding(
+                                    this->noc_index, std::get<CoreRange>(mcast_dests.first)),
+                                .num_mcast_dests = mcast_dests.second});
+                        }
+                    }
+                }
+            }
+
+            if (common_size != 0) {
+                uint32_t common_offset = program.crta_offsets[core_type == CoreType::WORKER][dispatch_class];
+
+                uint32_t common_args_addr = (core_type == CoreType::ETH) ?
+                    eth_l1_mem::address_map::ERISC_L1_KERNEL_CONFIG_BASE + common_offset :
+                    L1_KERNEL_CONFIG_BASE + common_offset;
+
+                // Common rtas are always expected to fit in one prefetch cmd
+                // TODO: use a linear write instead of a packed-write
+                std::visit(
+                    [&](auto&& sub_cmds) {
+                        generate_runtime_args_cmds(
+                            this->cached_program_command_sequences[program.id].runtime_args_command_sequences,
+                            common_args_addr,
+                            sub_cmds,
+                            common_rt_data_and_sizes,
+                            common_size / sizeof(uint32_t),
+                            common_rt_args_data,
+                            max_prefetch_command_size,
+                            packed_write_max_unicast_sub_cmds,
+                            true);
+                        sub_cmds.clear();
+                    },
+                    common_sub_cmds);
+            }
+
+            common_rt_data_and_sizes.clear();
+            common_rt_args_data.clear();
+        }
     }
+
     uint32_t runtime_args_fetch_size_bytes = 0;
     for (const auto& cmds : this->cached_program_command_sequences[program.id].runtime_args_command_sequences) {
         // BRISC, NCRISC, TRISC...
@@ -611,7 +652,7 @@ void EnqueueProgramCommand::assemble_runtime_args_commands() {
 
 void EnqueueProgramCommand::assemble_device_commands() {
     auto& cached_program_command_sequence = this->cached_program_command_sequences[this->program.id];
-    if (!program.loaded_onto_device) {
+    if (!program.is_finalized()) {
         // Calculate size of command and fill program indices of data to update
         // TODO: Would be nice if we could pull this out of program
         uint32_t cmd_sequence_sizeB = 0;
@@ -1102,7 +1143,10 @@ void EnqueueProgramCommand::process() {
 
     // Preamble, some waits and stalls
     // can be written directly to the issue queue
-    if (not program.loaded_onto_device) {
+    if (not program.is_finalized()) {
+        // TODO: only build kernel groups here, remove on-the-fly state validation and validate here
+        program.finalize_rt_args();
+
         this->assemble_preamble_commands(true);
         // Runtime Args Command Sequence
         this->assemble_runtime_args_commands();
@@ -1185,9 +1229,9 @@ void EnqueueProgramCommand::process() {
     }
 
     // Front load generating and caching preamble without stall during program loading stage
-    if (not program.loaded_onto_device) {
+    if (not program.is_finalized()) {
         this->assemble_preamble_commands(false);
-        program.loaded_onto_device = true;
+        program.set_finalized();
     }
 }
 
@@ -1831,7 +1875,7 @@ void HWCommandQueue::enqueue_write_buffer(const Buffer& buffer, const void* src,
 
 void HWCommandQueue::enqueue_program(Program& program, bool blocking) {
     ZoneScopedN("HWCommandQueue_enqueue_program");
-    if (not program.loaded_onto_device) {
+    if (not program.is_finalized()) {
         TT_FATAL(!this->manager.get_bypass_mode(), "Tracing should only be used when programs have been cached");
         TT_ASSERT(program.program_transfer_info.kernel_bins.size() == program.kg_buffers.size());
         for (int buffer_idx = 0; buffer_idx < program.program_transfer_info.kernel_bins.size(); buffer_idx++) {

--- a/tt_metal/impl/dispatch/kernels/cq_prefetch.cpp
+++ b/tt_metal/impl/dispatch/kernels/cq_prefetch.cpp
@@ -162,7 +162,7 @@ uint32_t read_from_pcie(volatile tt_l1_ptr prefetch_q_entry_type *& prefetch_q_r
     }
 
     uint64_t host_src_addr = pcie_noc_xy | pcie_read_ptr;
-    DPRINT << "read_from_pcie: " << fence + preamble_size << " " << pcie_read_ptr << ENDL();
+    //DPRINT << "read_from_pcie: " << fence + preamble_size << " " << pcie_read_ptr << ENDL();
     noc_async_read(host_src_addr, fence + preamble_size, size);
     pending_read_size = size + preamble_size;
     pcie_read_ptr += size;
@@ -213,7 +213,7 @@ void fetch_q_get_cmds(uint32_t& fence, uint32_t& cmd_ptr, uint32_t& pcie_read_pt
          return;
     }
 
-    DPRINT << "fetch_q_get_cmds: " << cmd_ptr << " " << fence << ENDL();
+    //DPRINT << "fetch_q_get_cmds: " << cmd_ptr << " " << fence << ENDL();
     if (fence < cmd_ptr) {
         cmd_ptr = fence;
     }
@@ -759,7 +759,7 @@ uint32_t process_relay_paged_packed_cmd(uint32_t cmd_ptr,
     uint32_t sub_cmds_length = cmd->relay_paged_packed.count * sizeof(CQPrefetchRelayPagedPackedSubCmd);
     uint32_t stride = cmd->relay_paged_packed.stride;
     ASSERT(total_length > 0);
-    DPRINT << "paged_packed: " << total_length << " " << cmd->relay_paged_packed.stride << ENDL();
+    //DPRINT << "paged_packed: " << total_length << " " << cmd->relay_paged_packed.stride << ENDL();
 
     uint32_t data_ptr = cmd_ptr + sizeof(CQPrefetchCmd);
     uint32_t remaining = cmddat_q_end - data_ptr;
@@ -789,7 +789,7 @@ uint32_t process_relay_linear_cmd(uint32_t cmd_ptr,
     uint32_t read_addr = cmd->relay_linear.addr;
     uint32_t length = cmd->relay_linear.length;
     uint32_t read_length = length;
-    DPRINT << "relay_linear: " << cmd_ptr << " " << length << " " << read_addr << " " << noc_xy_addr << ENDL();
+    //DPRINT << "relay_linear: " << cmd_ptr << " " << length << " " << read_addr << " " << noc_xy_addr << ENDL();
 
     // First step - read into DB0
     uint32_t scratch_read_addr = scratch_db_top[0];
@@ -900,7 +900,7 @@ static uint32_t process_exec_buf_relay_inline_cmd(uint32_t& cmd_ptr,
     uint32_t length = cmd->relay_inline.length;
     uint32_t data_ptr = cmd_ptr + sizeof(CQPrefetchCmd);
 
-    DPRINT << "relay_inline_exec_buf_cmd:" << length << ENDL();
+    //DPRINT << "relay_inline_exec_buf_cmd:" << length << ENDL();
     uint32_t npages = (length + downstream_cb_page_size - 1) >> downstream_cb_log_page_size;
 
     // Assume the downstream buffer is big relative to cmddat command size that we can
@@ -992,7 +992,7 @@ static uint32_t process_exec_buf_relay_paged_packed_cmd(uint32_t& cmd_ptr,
     uint32_t sub_cmds_length = cmd->relay_paged_packed.count * sizeof(CQPrefetchRelayPagedPackedSubCmd);
     uint32_t stride = cmd->relay_paged_packed.stride;
     ASSERT(total_length > 0);
-    DPRINT << "paged_packed: " << total_length << " " << cmd->relay_paged_packed.stride << ENDL();
+    //DPRINT << "paged_packed: " << total_length << " " << cmd->relay_paged_packed.stride << ENDL();
 
     uint32_t remaining_stride = exec_buf_state.length;
     uint32_t remaining = (exec_buf_state.length - sizeof(CQPrefetchCmd));
@@ -1066,12 +1066,12 @@ bool process_cmd(uint32_t& cmd_ptr,
 
     switch (cmd->base.cmd_id) {
     case CQ_PREFETCH_CMD_RELAY_LINEAR:
-        DPRINT << "relay linear: " << cmd_ptr << ENDL();
+        //DPRINT << "relay linear: " << cmd_ptr << ENDL();
         stride = process_relay_linear_cmd(cmd_ptr, downstream_data_ptr);
         break;
 
     case CQ_PREFETCH_CMD_RELAY_PAGED:
-        DPRINT << "relay dram page: " << cmd_ptr << ENDL();
+        //DPRINT << "relay dram page: " << cmd_ptr << ENDL();
         {
             uint32_t packed_page_flags = cmd->relay_paged.packed_page_flags;
             uint32_t is_dram = packed_page_flags & (1 << CQ_PREFETCH_RELAY_PAGED_IS_DRAM_SHIFT);
@@ -1087,7 +1087,7 @@ bool process_cmd(uint32_t& cmd_ptr,
         break;
 
     case CQ_PREFETCH_CMD_RELAY_PAGED_PACKED:
-        DPRINT << "relay paged packed" << ENDL();
+        //DPRINT << "relay paged packed" << ENDL();
         if (exec_buf) {
             stride = process_exec_buf_relay_paged_packed_cmd(cmd_ptr, downstream_data_ptr);
         } else {
@@ -1096,7 +1096,7 @@ bool process_cmd(uint32_t& cmd_ptr,
         break;
 
     case CQ_PREFETCH_CMD_RELAY_INLINE:
-        DPRINT << "relay inline" << ENDL();
+        //DPRINT << "relay inline" << ENDL();
         if (exec_buf) {
             stride = process_exec_buf_relay_inline_cmd(cmd_ptr, downstream_data_ptr);
         } else {
@@ -1105,7 +1105,7 @@ bool process_cmd(uint32_t& cmd_ptr,
         break;
 
     case CQ_PREFETCH_CMD_RELAY_INLINE_NOFLUSH:
-        DPRINT << "inline no flush" << ENDL();
+        //DPRINT << "inline no flush" << ENDL();
         if (exec_buf) {
             stride = process_exec_buf_relay_inline_noflush_cmd(cmd_ptr, downstream_data_ptr);
         } else {
@@ -1114,7 +1114,7 @@ bool process_cmd(uint32_t& cmd_ptr,
         break;
 
     case CQ_PREFETCH_CMD_EXEC_BUF:
-        DPRINT << "exec buf: " << cmd_ptr << ENDL();
+        //DPRINT << "exec buf: " << cmd_ptr << ENDL();
         ASSERT(!exec_buf);
         if (is_h_variant) {
             ASSERT(stall_state == STALLED); // ExecBuf must be preceded by a prefetcher stall
@@ -1124,19 +1124,19 @@ bool process_cmd(uint32_t& cmd_ptr,
         break;
 
     case CQ_PREFETCH_CMD_EXEC_BUF_END:
-        DPRINT << "exec buf end: " << cmd_ptr << ENDL();
+        //DPRINT << "exec buf end: " << cmd_ptr << ENDL();
         ASSERT(exec_buf);
         stride = process_exec_buf_relay_inline_cmd(cmd_ptr, downstream_data_ptr);
         done = true;
         break;
 
     case CQ_PREFETCH_CMD_STALL:
-        DPRINT << "stall" << ENDL();
+        //DPRINT << "stall" << ENDL();
         stride = process_stall(cmd_ptr);
         break;
 
     case CQ_PREFETCH_CMD_DEBUG:
-        DPRINT << "debug" << ENDL();
+        //DPRINT << "debug" << ENDL();
         // Splitting debug cmds not implemented for exec_bufs (yet)
         if (exec_buf) {
             ASSERT(0);
@@ -1145,13 +1145,13 @@ bool process_cmd(uint32_t& cmd_ptr,
         break;
 
     case CQ_PREFETCH_CMD_TERMINATE:
-        DPRINT << "prefetch terminating_" << is_h_variant << is_d_variant << ENDL();;
+        //DPRINT << "prefetch terminating_" << is_h_variant << is_d_variant << ENDL();;
         ASSERT(!exec_buf);
         done = true;
         break;
 
     default:
-        DPRINT << "prefetch invalid command:" << (uint32_t)cmd->base.cmd_id << " " << cmd_ptr << " " << cmddat_q_base << ENDL();
+        //DPRINT << "prefetch invalid command:" << (uint32_t)cmd->base.cmd_id << " " << cmd_ptr << " " << cmddat_q_base << ENDL();
         DPRINT << HEX() << *(uint32_t*)cmd_ptr << ENDL();
         DPRINT << HEX() << *((uint32_t*)cmd_ptr+1) << ENDL();
         DPRINT << HEX() << *((uint32_t*)cmd_ptr+2) << ENDL();

--- a/tt_metal/impl/kernels/kernel.hpp
+++ b/tt_metal/impl/kernels/kernel.hpp
@@ -67,7 +67,7 @@ class Kernel : public JitBuildSettings {
 
     std::string name() const;
 
-    CoreRangeSet core_range_set() const { return core_range_set_; }
+    const CoreRangeSet& core_range_set() const { return core_range_set_; }
 
     const std::set<CoreCoord> &logical_cores() const;
 

--- a/tt_metal/impl/program/program.hpp
+++ b/tt_metal/impl/program/program.hpp
@@ -35,14 +35,14 @@ namespace detail{
 struct KernelGroup {
     CoreType core_type;
     CoreRangeSet core_ranges;
-    std::array<std::optional<KernelHandle>, DISPATCH_CLASS_MAX_PROC> kernel_ids;
+    std::array<std::optional<KernelHandle>, DISPATCH_CLASS_MAX> kernel_ids;
     launch_msg_t launch_msg;
 
     KernelGroup();
     KernelGroup(
         const Program &program,
         CoreType core_type,
-        std::array<std::optional<KernelHandle>, DISPATCH_CLASS_MAX_PROC> kernel_ids,
+        std::array<std::optional<KernelHandle>, DISPATCH_CLASS_MAX> kernel_ids,
         bool erisc_is_idle,
         int last_cb_index,
         const CoreRangeSet &new_ranges);

--- a/tt_metal/impl/program/program.hpp
+++ b/tt_metal/impl/program/program.hpp
@@ -36,6 +36,8 @@ struct KernelGroup {
     CoreType core_type;
     CoreRangeSet core_ranges;
     std::array<std::optional<KernelHandle>, DISPATCH_CLASS_MAX> kernel_ids;
+    uint32_t rta_sizes[DISPATCH_CLASS_MAX];
+    uint32_t total_rta_size;
     launch_msg_t launch_msg;
 
     KernelGroup();
@@ -50,6 +52,7 @@ struct KernelGroup {
     CoreType get_core_type() const;
 };
 
+// TODO: why is this in program.hpp
 template <typename CoreRangeContainer>
 vector<pair<transfer_info_cores, uint32_t>> extract_dst_noc_multicast_info(Device* device, const CoreRangeContainer& ranges, const CoreType core_type) {
     // This API extracts all the pairs of noc multicast encodings given a set of core ranges
@@ -131,6 +134,10 @@ class Program {
 
     void allocate_circular_buffers();
 
+    void finalize_rt_args();
+    bool is_finalized() const { return loaded_onto_device; }
+    void set_finalized() { loaded_onto_device = true; }
+
    private:
     void populate_dispatch_data(Device *device);
 
@@ -192,6 +199,10 @@ class Program {
     std::unordered_map<CoreType, std::vector<uint8_t>> core_to_kernel_group_index_table_;
 
     std::vector<std::shared_ptr<Buffer>> config_buffers_;
+
+    static constexpr uint32_t num_dispatchable_core_types = 2;
+    std::array<std::array<uint32_t, DISPATCH_CLASS_MAX>, num_dispatchable_core_types> crta_offsets;
+    std::array<std::array<uint32_t, DISPATCH_CLASS_MAX>, num_dispatchable_core_types> crta_sizes;
 
     friend CBHandle CreateCircularBuffer(Program &program, const std::variant<CoreCoord, CoreRange, CoreRangeSet> &core_spec, const CircularBufferConfig &config);
     friend std::shared_ptr<CircularBuffer> detail::GetCircularBuffer(const Program &program, CBHandle id);

--- a/tt_metal/include/compute_kernel_api/common.h
+++ b/tt_metal/include/compute_kernel_api/common.h
@@ -11,12 +11,8 @@
 #include "compute_kernel_api/cb_api.h"
 
 
-// JIT Build flow will set this as needed.
-#ifndef COMMON_RT_ARGS_INDEX
-    #define COMMON_RT_ARGS_INDEX 0
-#endif
-
-extern uint32_t *l1_arg_base;
+extern uint32_t *rta_l1_base;
+extern uint32_t *crta_l1_base;
 
 /**
  * Returns the address in L1 for a given runtime argument index for unique (per core) runtime arguments set via SetRuntimeArgs() API.
@@ -29,7 +25,7 @@ extern uint32_t *l1_arg_base;
  */
 static FORCE_INLINE
 uint32_t get_arg_addr(int arg_idx) {
-    return (uint32_t)&l1_arg_base[arg_idx];
+    return (uint32_t)&rta_l1_base[arg_idx];
 }
 
 /**
@@ -43,7 +39,7 @@ uint32_t get_arg_addr(int arg_idx) {
  */
 static FORCE_INLINE
 uint32_t get_common_arg_addr(int arg_idx) {
-    return (uint32_t)&l1_arg_base[arg_idx + COMMON_RT_ARGS_INDEX];
+    return (uint32_t)&crta_l1_base[arg_idx];
 }
 
 /**

--- a/tt_metal/llrt/llrt.cpp
+++ b/tt_metal/llrt/llrt.cpp
@@ -164,7 +164,6 @@ void write_launch_msg_to_core(chip_id_t chip, const CoreCoord core, launch_msg_t
     }
 
     msg->mode = DISPATCH_MODE_HOST;
-    TT_ASSERT(sizeof(launch_msg_t) % sizeof(uint32_t) == 0);
     if (is_active_eth_core) {
         tt::Cluster::instance().write_core(
             (void *)msg, sizeof(launch_msg_t), tt_cxy_pair(chip, core), GET_ETH_MAILBOX_ADDRESS_HOST(launch));

--- a/tt_metal/llrt/llrt.cpp
+++ b/tt_metal/llrt/llrt.cpp
@@ -164,6 +164,7 @@ void write_launch_msg_to_core(chip_id_t chip, const CoreCoord core, launch_msg_t
     }
 
     msg->mode = DISPATCH_MODE_HOST;
+    TT_ASSERT(sizeof(launch_msg_t) % sizeof(uint32_t) == 0);
     if (is_active_eth_core) {
         tt::Cluster::instance().write_core(
             (void *)msg, sizeof(launch_msg_t), tt_cxy_pair(chip, core), GET_ETH_MAILBOX_ADDRESS_HOST(launch));


### PR DESCRIPTION
### Ticket
#8602 
### Problem description
Runtime args are sent w/ many unicast NOC commands.  Packing B/N/T together reduces the number of commands by up to a factor of 3 which improves perf when few RTAs are sent

### What's changed
Track number of RTAs in kernel groups
"Level" (to max) the number of RTAs per dispatch processor type (B/N/T)
Send RTAs w/ single packed write command per core (for unique RTAs)

### Checklist
- [ ] Post commit CI passes
- [ ] Model regression CI testing passes (if applicable)
- [ ] New/Existing tests provide coverage for changes
