### PR TITLE
Reshard RM with Different Stick Widths

### DIFF
--- a/tests/ttnn/unit_tests/operations/test_core.py
+++ b/tests/ttnn/unit_tests/operations/test_core.py
@@ -308,15 +308,73 @@ from enum import Enum
         #            (40, 32),
         #            (64, 32),
         #        ),
+        #        (
+        #            2,
+        #            16,
+        #            ttnn.ROW_MAJOR_LAYOUT,
+        #            dict(
+        #                core_grid=ttnn.experimental.tensor.CoreRangeSet(
+        #                    {
+        #                        ttnn.experimental.tensor.CoreRange(
+        #                            ttnn.experimental.tensor.CoreCoord(0, 0), ttnn.experimental.tensor.CoreCoord(0, 1)
+        #                        ),
+        #                    }
+        #                ),
+        #                strategy=ttnn.ShardStrategy.BLOCK,
+        #                orientation=ttnn.ShardOrientation.COL_MAJOR,
+        #            ),
+        #            dict(
+        #                core_grid=ttnn.experimental.tensor.CoreRangeSet(
+        #                    {
+        #                        ttnn.experimental.tensor.CoreRange(
+        #                            ttnn.experimental.tensor.CoreCoord(0, 0), ttnn.experimental.tensor.CoreCoord(0, 0)
+        #                        ),
+        #                    }
+        #                ),
+        #                strategy=ttnn.ShardStrategy.BLOCK,
+        #                orientation=ttnn.ShardOrientation.COL_MAJOR,
+        #            ),
+        #            (8, 2),
+        #            (16, 2),
+        #        ),
+        #        (
+        #            2,
+        #            16,
+        #            ttnn.ROW_MAJOR_LAYOUT,
+        #            dict(
+        #                core_grid=ttnn.experimental.tensor.CoreRangeSet(
+        #                    {
+        #                        ttnn.experimental.tensor.CoreRange(
+        #                            ttnn.experimental.tensor.CoreCoord(0, 0), ttnn.experimental.tensor.CoreCoord(0, 0)
+        #                        ),
+        #                    }
+        #                ),
+        #                strategy=ttnn.ShardStrategy.BLOCK,
+        #                orientation=ttnn.ShardOrientation.COL_MAJOR,
+        #            ),
+        #            dict(
+        #                core_grid=ttnn.experimental.tensor.CoreRangeSet(
+        #                    {
+        #                        ttnn.experimental.tensor.CoreRange(
+        #                            ttnn.experimental.tensor.CoreCoord(0, 0), ttnn.experimental.tensor.CoreCoord(0, 1)
+        #                        ),
+        #                    }
+        #                ),
+        #                strategy=ttnn.ShardStrategy.BLOCK,
+        #                orientation=ttnn.ShardOrientation.COL_MAJOR,
+        #            ),
+        #            (16, 2),
+        #            (8, 2),
+        #        ),
         (
-            2,
-            16,
+            1,
+            320,
             ttnn.ROW_MAJOR_LAYOUT,
             dict(
                 core_grid=ttnn.experimental.tensor.CoreRangeSet(
                     {
                         ttnn.experimental.tensor.CoreRange(
-                            ttnn.experimental.tensor.CoreCoord(0, 0), ttnn.experimental.tensor.CoreCoord(0, 1)
+                            ttnn.experimental.tensor.CoreCoord(0, 0), ttnn.experimental.tensor.CoreCoord(0, 7)
                         ),
                     }
                 ),
@@ -327,25 +385,25 @@ from enum import Enum
                 core_grid=ttnn.experimental.tensor.CoreRangeSet(
                     {
                         ttnn.experimental.tensor.CoreRange(
-                            ttnn.experimental.tensor.CoreCoord(0, 0), ttnn.experimental.tensor.CoreCoord(0, 0)
+                            ttnn.experimental.tensor.CoreCoord(0, 0), ttnn.experimental.tensor.CoreCoord(0, 4)
                         ),
                     }
                 ),
                 strategy=ttnn.ShardStrategy.BLOCK,
                 orientation=ttnn.ShardOrientation.COL_MAJOR,
             ),
-            (8, 2),
-            (16, 2),
+            (40, 1),
+            (64, 1),
         ),
         (
-            2,
-            16,
+            1,
+            160,
             ttnn.ROW_MAJOR_LAYOUT,
             dict(
                 core_grid=ttnn.experimental.tensor.CoreRangeSet(
                     {
                         ttnn.experimental.tensor.CoreRange(
-                            ttnn.experimental.tensor.CoreCoord(0, 0), ttnn.experimental.tensor.CoreCoord(0, 0)
+                            ttnn.experimental.tensor.CoreCoord(0, 0), ttnn.experimental.tensor.CoreCoord(0, 4)
                         ),
                     }
                 ),
@@ -356,15 +414,15 @@ from enum import Enum
                 core_grid=ttnn.experimental.tensor.CoreRangeSet(
                     {
                         ttnn.experimental.tensor.CoreRange(
-                            ttnn.experimental.tensor.CoreCoord(0, 0), ttnn.experimental.tensor.CoreCoord(0, 1)
+                            ttnn.experimental.tensor.CoreCoord(0, 0), ttnn.experimental.tensor.CoreCoord(0, 3)
                         ),
                     }
                 ),
                 strategy=ttnn.ShardStrategy.BLOCK,
                 orientation=ttnn.ShardOrientation.COL_MAJOR,
             ),
-            (16, 2),
-            (8, 2),
+            (32, 1),
+            (40, 1),
         ),
     ],
 )
@@ -411,7 +469,10 @@ def test_reshard(
     sharded_input_torch = ttnn.to_torch(sharded_input_tensor)
 
     torch.set_printoptions(profile="full")
+    print("Input Tensor without Reshard")
     print(sharded_input_torch)
+    print("Tensor after Reshard")
+    print(output)
     assert_with_pcc(torch_input_tensor, output, 1.0)
 
 

--- a/tests/ttnn/unit_tests/operations/test_core.py
+++ b/tests/ttnn/unit_tests/operations/test_core.py
@@ -163,10 +163,10 @@ from enum import Enum
         ),
         # (1, 1, 32, 1280) (8 to 1 cores width shardrd)
         (
+            1,
             32,
-            1280,
             ttnn.ROW_MAJOR_LAYOUT,
-            dict(core_grid=ttnn.CoreGrid(y=1, x=8), strategy=ttnn.ShardStrategy.WIDTH),
+            dict(core_grid=ttnn.CoreGrid(y=1, x=2), strategy=ttnn.ShardStrategy.WIDTH),
             dict(core_grid=ttnn.CoreGrid(y=1, x=1), strategy=ttnn.ShardStrategy.WIDTH),
             None,
             None,

--- a/tests/ttnn/unit_tests/operations/test_core.py
+++ b/tests/ttnn/unit_tests/operations/test_core.py
@@ -252,42 +252,71 @@ from enum import Enum
         #            (64, 128),
         #            (96, 64),
         #        ),
-        #        (
-        #            96,
-        #            128,
-        #            ttnn.TILE_LAYOUT,
-        #            dict(
-        #                core_grid=ttnn.experimental.tensor.CoreRangeSet(
-        #                    {
-        #                        ttnn.experimental.tensor.CoreRange(
-        #                            ttnn.experimental.tensor.CoreCoord(0, 0), ttnn.experimental.tensor.CoreCoord(0, 2)
+        #                (
+        #                    96,
+        #                    128,
+        #                    ttnn.TILE_LAYOUT,
+        #                    dict(
+        #                        core_grid=ttnn.experimental.tensor.CoreRangeSet(
+        #                            {
+        #                                ttnn.experimental.tensor.CoreRange(
+        #                                    ttnn.experimental.tensor.CoreCoord(0, 0), ttnn.experimental.tensor.CoreCoord(0, 2)
+        #                                ),
+        #                            }
         #                        ),
-        #                    }
+        #                        strategy=ttnn.ShardStrategy.HEIGHT,
+        #                    ),
+        #                    dict(
+        #                        core_grid=ttnn.experimental.tensor.CoreRangeSet(
+        #                            {
+        #                                ttnn.experimental.tensor.CoreRange(
+        #                                    ttnn.experimental.tensor.CoreCoord(0, 0), ttnn.experimental.tensor.CoreCoord(1, 1)
+        #                                ),
+        #                            }
+        #                        ),
+        #                        strategy=ttnn.ShardStrategy.BLOCK,
+        #                    ),
+        #                    (32, 128),
+        #                    (64, 64),
         #                ),
-        #                strategy=ttnn.ShardStrategy.HEIGHT,
-        #            ),
+        #        (
+        #            256,
+        #            320,
+        #            ttnn.ROW_MAJOR_LAYOUT,
         #            dict(
         #                core_grid=ttnn.experimental.tensor.CoreRangeSet(
         #                    {
         #                        ttnn.experimental.tensor.CoreRange(
-        #                            ttnn.experimental.tensor.CoreCoord(0, 0), ttnn.experimental.tensor.CoreCoord(1, 1)
+        #                            ttnn.experimental.tensor.CoreCoord(0, 0), ttnn.experimental.tensor.CoreCoord(7, 7)
         #                        ),
         #                    }
         #                ),
         #                strategy=ttnn.ShardStrategy.BLOCK,
+        #                orientation=ttnn.ShardOrientation.COL_MAJOR,
         #            ),
-        #            (32, 128),
-        #            (64, 64),
+        #            dict(
+        #                core_grid=ttnn.experimental.tensor.CoreRangeSet(
+        #                    {
+        #                        ttnn.experimental.tensor.CoreRange(
+        #                            ttnn.experimental.tensor.CoreCoord(0, 0), ttnn.experimental.tensor.CoreCoord(7, 4)
+        #                        ),
+        #                    }
+        #                ),
+        #                strategy=ttnn.ShardStrategy.BLOCK,
+        #                orientation=ttnn.ShardOrientation.COL_MAJOR,
+        #            ),
+        #            (40, 32),
+        #            (64, 32),
         #        ),
         (
-            256,
-            320,
+            4,
+            16,
             ttnn.ROW_MAJOR_LAYOUT,
             dict(
                 core_grid=ttnn.experimental.tensor.CoreRangeSet(
                     {
                         ttnn.experimental.tensor.CoreRange(
-                            ttnn.experimental.tensor.CoreCoord(0, 0), ttnn.experimental.tensor.CoreCoord(7, 7)
+                            ttnn.experimental.tensor.CoreCoord(0, 0), ttnn.experimental.tensor.CoreCoord(0, 1)
                         ),
                     }
                 ),
@@ -298,15 +327,15 @@ from enum import Enum
                 core_grid=ttnn.experimental.tensor.CoreRangeSet(
                     {
                         ttnn.experimental.tensor.CoreRange(
-                            ttnn.experimental.tensor.CoreCoord(0, 0), ttnn.experimental.tensor.CoreCoord(7, 4)
+                            ttnn.experimental.tensor.CoreCoord(0, 0), ttnn.experimental.tensor.CoreCoord(0, 0)
                         ),
                     }
                 ),
                 strategy=ttnn.ShardStrategy.BLOCK,
                 orientation=ttnn.ShardOrientation.COL_MAJOR,
             ),
-            (40, 32),
-            (64, 32),
+            (8, 4),
+            (16, 4),
         ),
     ],
 )
@@ -342,6 +371,7 @@ def test_reshard(
         )
 
     torch_input_tensor = torch.rand(input_shape, dtype=torch.bfloat16)
+    # torch_input_tensor = torch.randint(0, 100, input_shape)
     sharded_input_tensor = ttnn.from_torch(
         torch_input_tensor, layout=input_memory_layout, device=device, memory_config=input_shard_memory_config
     )
@@ -349,7 +379,10 @@ def test_reshard(
     sharded_output_tensor = ttnn.to_memory_config(sharded_input_tensor, output_shard_memory_config)
 
     output = ttnn.to_torch(sharded_output_tensor)
+    sharded_input_torch = ttnn.to_torch(sharded_input_tensor)
 
+    torch.set_printoptions(profile="full")
+    print(sharded_input_torch)
     assert_with_pcc(torch_input_tensor, output, 1.0)
 
 

--- a/tests/ttnn/unit_tests/operations/test_core.py
+++ b/tests/ttnn/unit_tests/operations/test_core.py
@@ -15,366 +15,279 @@ from enum import Enum
 @pytest.mark.parametrize(
     "input_height, input_width, input_memory_layout, input_sharded_memory_config_args, output_sharded_memory_config_args, input_override, output_override",
     [
-        #        (
-        #            128,
-        #            128,
-        #            ttnn.TILE_LAYOUT,
-        #            dict(core_grid=ttnn.CoreGrid(y=2, x=1), strategy=ttnn.ShardStrategy.HEIGHT),
-        #            dict(core_grid=ttnn.CoreGrid(y=1, x=2), strategy=ttnn.ShardStrategy.WIDTH),
-        #            None,
-        #            None,
-        #        ),
-        #        (
-        #            128,
-        #            128,
-        #            ttnn.TILE_LAYOUT,
-        #            dict(core_grid=ttnn.CoreGrid(y=1, x=2), strategy=ttnn.ShardStrategy.WIDTH),
-        #            dict(core_grid=ttnn.CoreGrid(y=2, x=1), strategy=ttnn.ShardStrategy.HEIGHT),
-        #            None,
-        #            None,
-        #        ),
-        #        (
-        #            128,
-        #            64,
-        #            ttnn.TILE_LAYOUT,
-        #            dict(core_grid=ttnn.CoreGrid(y=2, x=1), strategy=ttnn.ShardStrategy.HEIGHT),
-        #            dict(core_grid=ttnn.CoreGrid(y=4, x=2), strategy=ttnn.ShardStrategy.BLOCK),
-        #            None,
-        #            None,
-        #        ),
-        #        (
-        #            128,
-        #            64,
-        #            ttnn.TILE_LAYOUT,
-        #            dict(core_grid=ttnn.CoreGrid(y=2, x=1), strategy=ttnn.ShardStrategy.HEIGHT),
-        #            dict(core_grid=ttnn.CoreGrid(y=4, x=1), strategy=ttnn.ShardStrategy.HEIGHT),
-        #            None,
-        #            None,
-        #        ),
-        #        (
-        #            128,
-        #            64,
-        #            ttnn.TILE_LAYOUT,
-        #            dict(core_grid=ttnn.CoreGrid(y=1, x=2), strategy=ttnn.ShardStrategy.WIDTH),
-        #            dict(core_grid=ttnn.CoreGrid(y=4, x=1), strategy=ttnn.ShardStrategy.HEIGHT),
-        #            None,
-        #            None,
-        #        ),
-        #        (
-        #            128,
-        #            64,
-        #            ttnn.TILE_LAYOUT,
-        #            dict(core_grid=ttnn.CoreGrid(y=2, x=1), strategy=ttnn.ShardStrategy.BLOCK),
-        #            dict(core_grid=ttnn.CoreGrid(y=4, x=2), strategy=ttnn.ShardStrategy.BLOCK),
-        #            None,
-        #            None,
-        #        ),
-        #        (
-        #            32,
-        #            128,
-        #            ttnn.TILE_LAYOUT,
-        #            dict(core_grid=ttnn.CoreGrid(y=1, x=4), strategy=ttnn.ShardStrategy.BLOCK),
-        #            dict(core_grid=ttnn.CoreGrid(y=1, x=2), strategy=ttnn.ShardStrategy.BLOCK),
-        #            None,
-        #            None,
-        #        ),
-        #        (
-        #            32,
-        #            128,
-        #            ttnn.TILE_LAYOUT,
-        #            dict(core_grid=ttnn.CoreGrid(y=1, x=4), strategy=ttnn.ShardStrategy.WIDTH),
-        #            dict(core_grid=ttnn.CoreGrid(y=1, x=2), strategy=ttnn.ShardStrategy.BLOCK),
-        #            None,
-        #            None,
-        #        ),
-        #        (
-        #            32,
-        #            16,
-        #            ttnn.ROW_MAJOR_LAYOUT,
-        #            dict(core_grid=ttnn.CoreGrid(y=1, x=1), strategy=ttnn.ShardStrategy.BLOCK),
-        #            dict(core_grid=ttnn.CoreGrid(y=2, x=1), strategy=ttnn.ShardStrategy.BLOCK),
-        #            None,
-        #            None,
-        #        ),
-        #        (
-        #            32,
-        #            2304,
-        #            ttnn.TILE_LAYOUT,
-        #            dict(core_grid=ttnn.CoreGrid(y=1, x=8), strategy=ttnn.ShardStrategy.WIDTH),
-        #            dict(core_grid=ttnn.CoreGrid(y=1, x=2), strategy=ttnn.ShardStrategy.WIDTH),
-        #            None,
-        #            None,
-        #        ),
-        #        (
-        #            32,
-        #            1792,
-        #            ttnn.TILE_LAYOUT,
-        #            dict(core_grid=ttnn.CoreGrid(y=7, x=8), strategy=ttnn.ShardStrategy.WIDTH),
-        #            dict(core_grid=ttnn.CoreGrid(y=1, x=8), strategy=ttnn.ShardStrategy.BLOCK),
-        #            [32, 32],
-        #            None,
-        #        ),
-        #        (
-        #            32,
-        #            7168,
-        #            ttnn.TILE_LAYOUT,
-        #            dict(core_grid=ttnn.CoreGrid(y=7, x=8), strategy=ttnn.ShardStrategy.WIDTH),
-        #            dict(core_grid=ttnn.CoreGrid(y=1, x=8), strategy=ttnn.ShardStrategy.BLOCK),
-        #            [32, 128],
-        #            None,
-        #        ),
-        #        (
-        #            32,
-        #            320,
-        #            ttnn.TILE_LAYOUT,
-        #            dict(core_grid=ttnn.CoreGrid(y=1, x=2), strategy=ttnn.ShardStrategy.BLOCK),
-        #            dict(core_grid=ttnn.CoreGrid(y=1, x=5), strategy=ttnn.ShardStrategy.BLOCK),
-        #            None,
-        #            None,
-        #        ),
-        #        (
-        #            8192,
-        #            320,
-        #            ttnn.TILE_LAYOUT,
-        #            dict(core_grid=ttnn.CoreGrid(y=8, x=2), strategy=ttnn.ShardStrategy.BLOCK),
-        #            dict(core_grid=ttnn.CoreGrid(y=8, x=5), strategy=ttnn.ShardStrategy.BLOCK),
-        #            None,
-        #            None,
-        #        ),
-        #        # (1, 1, 32, 8192) (32 to 8 cores width shardrd)
-        #        (
-        #            32,
-        #            8192,
-        #            ttnn.TILE_LAYOUT,
-        #            dict(core_grid=ttnn.CoreGrid(y=4, x=8), strategy=ttnn.ShardStrategy.WIDTH),
-        #            dict(core_grid=ttnn.CoreGrid(y=1, x=8), strategy=ttnn.ShardStrategy.WIDTH),
-        #            (32, 256),
-        #            None,
-        #        ),
-        #        # (1, 1, 32, 8192) (64 to 8 cores width shardrd)
-        #        (
-        #            32,
-        #            8192,
-        #            ttnn.TILE_LAYOUT,
-        #            dict(core_grid=ttnn.CoreGrid(y=8, x=8), strategy=ttnn.ShardStrategy.WIDTH),
-        #            dict(core_grid=ttnn.CoreGrid(y=1, x=8), strategy=ttnn.ShardStrategy.WIDTH),
-        #            (32, 128),
-        #            None,
-        #        ),
-        #        # (1, 1, 32, 1280) (8 to 1 cores width shardrd)
-        #        (
-        #            32,
-        #            1280,
-        #            ttnn.ROW_MAJOR_LAYOUT,
-        #            dict(core_grid=ttnn.CoreGrid(y=1, x=8), strategy=ttnn.ShardStrategy.WIDTH),
-        #            dict(core_grid=ttnn.CoreGrid(y=1, x=1), strategy=ttnn.ShardStrategy.WIDTH),
-        #            None,
-        #            None,
-        #        ),
-        #        # (1, 1, 128, 1280) (32 cores block sharded to 4 cores height sharded)
-        #        (
-        #            128,
-        #            1280,
-        #            ttnn.TILE_LAYOUT,
-        #            dict(core_grid=ttnn.CoreGrid(y=4, x=8), strategy=ttnn.ShardStrategy.BLOCK),
-        #            dict(core_grid=ttnn.CoreGrid(y=4, x=1), strategy=ttnn.ShardStrategy.HEIGHT),
-        #            None,
-        #            None,
-        #        ),
-        #        (
-        #            160,
-        #            64,
-        #            ttnn.TILE_LAYOUT,
-        #            dict(
-        #                core_grid=ttnn.CoreGrid(y=5, x=1),
-        #                strategy=ttnn.ShardStrategy.HEIGHT,
-        #                orientation=ttnn.ShardOrientation.ROW_MAJOR,
-        #            ),
-        #            dict(
-        #                core_grid=ttnn.CoreGrid(y=2, x=2),
-        #                strategy=ttnn.ShardStrategy.BLOCK,
-        #                orientation=ttnn.ShardOrientation.COL_MAJOR,
-        #            ),
-        #            (32, 64),
-        #            (32, 96),
-        #        ),
-        #        (
-        #            192,
-        #            128,
-        #            ttnn.TILE_LAYOUT,
-        #            dict(
-        #                core_grid=ttnn.experimental.tensor.CoreRangeSet(
-        #                    {
-        #                        ttnn.experimental.tensor.CoreRange(
-        #                            ttnn.experimental.tensor.CoreCoord(0, 0), ttnn.experimental.tensor.CoreCoord(0, 1)
-        #                        ),
-        #                    }
-        #                ),
-        #                strategy=ttnn.ShardStrategy.HEIGHT,
-        #            ),
-        #            dict(
-        #                core_grid=ttnn.experimental.tensor.CoreRangeSet(
-        #                    {
-        #                        ttnn.experimental.tensor.CoreRange(
-        #                            ttnn.experimental.tensor.CoreCoord(0, 0), ttnn.experimental.tensor.CoreCoord(1, 1)
-        #                        ),
-        #                    }
-        #                ),
-        #                strategy=ttnn.ShardStrategy.BLOCK,
-        #            ),
-        #            (96, 128),
-        #            (128, 64),
-        #        ),
-        #        (
-        #            128,
-        #            128,
-        #            ttnn.TILE_LAYOUT,
-        #            dict(
-        #                core_grid=ttnn.experimental.tensor.CoreRangeSet(
-        #                    {
-        #                        ttnn.experimental.tensor.CoreRange(
-        #                            ttnn.experimental.tensor.CoreCoord(0, 0), ttnn.experimental.tensor.CoreCoord(0, 1)
-        #                        ),
-        #                    }
-        #                ),
-        #                strategy=ttnn.ShardStrategy.HEIGHT,
-        #            ),
-        #            dict(
-        #                core_grid=ttnn.experimental.tensor.CoreRangeSet(
-        #                    {
-        #                        ttnn.experimental.tensor.CoreRange(
-        #                            ttnn.experimental.tensor.CoreCoord(0, 0), ttnn.experimental.tensor.CoreCoord(1, 1)
-        #                        ),
-        #                    }
-        #                ),
-        #                strategy=ttnn.ShardStrategy.BLOCK,
-        #            ),
-        #            (64, 128),
-        #            (96, 64),
-        #        ),
-        #                (
-        #                    96,
-        #                    128,
-        #                    ttnn.TILE_LAYOUT,
-        #                    dict(
-        #                        core_grid=ttnn.experimental.tensor.CoreRangeSet(
-        #                            {
-        #                                ttnn.experimental.tensor.CoreRange(
-        #                                    ttnn.experimental.tensor.CoreCoord(0, 0), ttnn.experimental.tensor.CoreCoord(0, 2)
-        #                                ),
-        #                            }
-        #                        ),
-        #                        strategy=ttnn.ShardStrategy.HEIGHT,
-        #                    ),
-        #                    dict(
-        #                        core_grid=ttnn.experimental.tensor.CoreRangeSet(
-        #                            {
-        #                                ttnn.experimental.tensor.CoreRange(
-        #                                    ttnn.experimental.tensor.CoreCoord(0, 0), ttnn.experimental.tensor.CoreCoord(1, 1)
-        #                                ),
-        #                            }
-        #                        ),
-        #                        strategy=ttnn.ShardStrategy.BLOCK,
-        #                    ),
-        #                    (32, 128),
-        #                    (64, 64),
-        #                ),
-        #        (
-        #            256,
-        #            320,
-        #            ttnn.ROW_MAJOR_LAYOUT,
-        #            dict(
-        #                core_grid=ttnn.experimental.tensor.CoreRangeSet(
-        #                    {
-        #                        ttnn.experimental.tensor.CoreRange(
-        #                            ttnn.experimental.tensor.CoreCoord(0, 0), ttnn.experimental.tensor.CoreCoord(7, 7)
-        #                        ),
-        #                    }
-        #                ),
-        #                strategy=ttnn.ShardStrategy.BLOCK,
-        #                orientation=ttnn.ShardOrientation.COL_MAJOR,
-        #            ),
-        #            dict(
-        #                core_grid=ttnn.experimental.tensor.CoreRangeSet(
-        #                    {
-        #                        ttnn.experimental.tensor.CoreRange(
-        #                            ttnn.experimental.tensor.CoreCoord(0, 0), ttnn.experimental.tensor.CoreCoord(7, 4)
-        #                        ),
-        #                    }
-        #                ),
-        #                strategy=ttnn.ShardStrategy.BLOCK,
-        #                orientation=ttnn.ShardOrientation.COL_MAJOR,
-        #            ),
-        #            (40, 32),
-        #            (64, 32),
-        #        ),
-        #        (
-        #            2,
-        #            16,
-        #            ttnn.ROW_MAJOR_LAYOUT,
-        #            dict(
-        #                core_grid=ttnn.experimental.tensor.CoreRangeSet(
-        #                    {
-        #                        ttnn.experimental.tensor.CoreRange(
-        #                            ttnn.experimental.tensor.CoreCoord(0, 0), ttnn.experimental.tensor.CoreCoord(0, 1)
-        #                        ),
-        #                    }
-        #                ),
-        #                strategy=ttnn.ShardStrategy.BLOCK,
-        #                orientation=ttnn.ShardOrientation.COL_MAJOR,
-        #            ),
-        #            dict(
-        #                core_grid=ttnn.experimental.tensor.CoreRangeSet(
-        #                    {
-        #                        ttnn.experimental.tensor.CoreRange(
-        #                            ttnn.experimental.tensor.CoreCoord(0, 0), ttnn.experimental.tensor.CoreCoord(0, 0)
-        #                        ),
-        #                    }
-        #                ),
-        #                strategy=ttnn.ShardStrategy.BLOCK,
-        #                orientation=ttnn.ShardOrientation.COL_MAJOR,
-        #            ),
-        #            (8, 2),
-        #            (16, 2),
-        #        ),
-        #        (
-        #            2,
-        #            16,
-        #            ttnn.ROW_MAJOR_LAYOUT,
-        #            dict(
-        #                core_grid=ttnn.experimental.tensor.CoreRangeSet(
-        #                    {
-        #                        ttnn.experimental.tensor.CoreRange(
-        #                            ttnn.experimental.tensor.CoreCoord(0, 0), ttnn.experimental.tensor.CoreCoord(0, 0)
-        #                        ),
-        #                    }
-        #                ),
-        #                strategy=ttnn.ShardStrategy.BLOCK,
-        #                orientation=ttnn.ShardOrientation.COL_MAJOR,
-        #            ),
-        #            dict(
-        #                core_grid=ttnn.experimental.tensor.CoreRangeSet(
-        #                    {
-        #                        ttnn.experimental.tensor.CoreRange(
-        #                            ttnn.experimental.tensor.CoreCoord(0, 0), ttnn.experimental.tensor.CoreCoord(0, 1)
-        #                        ),
-        #                    }
-        #                ),
-        #                strategy=ttnn.ShardStrategy.BLOCK,
-        #                orientation=ttnn.ShardOrientation.COL_MAJOR,
-        #            ),
-        #            (16, 2),
-        #            (8, 2),
-        #        ),
         (
-            1,
+            128,
+            128,
+            ttnn.TILE_LAYOUT,
+            dict(core_grid=ttnn.CoreGrid(y=2, x=1), strategy=ttnn.ShardStrategy.HEIGHT),
+            dict(core_grid=ttnn.CoreGrid(y=1, x=2), strategy=ttnn.ShardStrategy.WIDTH),
+            None,
+            None,
+        ),
+        (
+            128,
+            128,
+            ttnn.TILE_LAYOUT,
+            dict(core_grid=ttnn.CoreGrid(y=1, x=2), strategy=ttnn.ShardStrategy.WIDTH),
+            dict(core_grid=ttnn.CoreGrid(y=2, x=1), strategy=ttnn.ShardStrategy.HEIGHT),
+            None,
+            None,
+        ),
+        (
+            128,
+            64,
+            ttnn.TILE_LAYOUT,
+            dict(core_grid=ttnn.CoreGrid(y=2, x=1), strategy=ttnn.ShardStrategy.HEIGHT),
+            dict(core_grid=ttnn.CoreGrid(y=4, x=2), strategy=ttnn.ShardStrategy.BLOCK),
+            None,
+            None,
+        ),
+        (
+            128,
+            64,
+            ttnn.TILE_LAYOUT,
+            dict(core_grid=ttnn.CoreGrid(y=2, x=1), strategy=ttnn.ShardStrategy.HEIGHT),
+            dict(core_grid=ttnn.CoreGrid(y=4, x=1), strategy=ttnn.ShardStrategy.HEIGHT),
+            None,
+            None,
+        ),
+        (
+            128,
+            64,
+            ttnn.TILE_LAYOUT,
+            dict(core_grid=ttnn.CoreGrid(y=1, x=2), strategy=ttnn.ShardStrategy.WIDTH),
+            dict(core_grid=ttnn.CoreGrid(y=4, x=1), strategy=ttnn.ShardStrategy.HEIGHT),
+            None,
+            None,
+        ),
+        (
+            128,
+            64,
+            ttnn.TILE_LAYOUT,
+            dict(core_grid=ttnn.CoreGrid(y=2, x=1), strategy=ttnn.ShardStrategy.BLOCK),
+            dict(core_grid=ttnn.CoreGrid(y=4, x=2), strategy=ttnn.ShardStrategy.BLOCK),
+            None,
+            None,
+        ),
+        (
+            32,
+            128,
+            ttnn.TILE_LAYOUT,
+            dict(core_grid=ttnn.CoreGrid(y=1, x=4), strategy=ttnn.ShardStrategy.BLOCK),
+            dict(core_grid=ttnn.CoreGrid(y=1, x=2), strategy=ttnn.ShardStrategy.BLOCK),
+            None,
+            None,
+        ),
+        (
+            32,
+            128,
+            ttnn.TILE_LAYOUT,
+            dict(core_grid=ttnn.CoreGrid(y=1, x=4), strategy=ttnn.ShardStrategy.WIDTH),
+            dict(core_grid=ttnn.CoreGrid(y=1, x=2), strategy=ttnn.ShardStrategy.BLOCK),
+            None,
+            None,
+        ),
+        (
+            32,
+            16,
+            ttnn.ROW_MAJOR_LAYOUT,
+            dict(core_grid=ttnn.CoreGrid(y=1, x=1), strategy=ttnn.ShardStrategy.BLOCK),
+            dict(core_grid=ttnn.CoreGrid(y=2, x=1), strategy=ttnn.ShardStrategy.BLOCK),
+            None,
+            None,
+        ),
+        (
+            32,
+            2304,
+            ttnn.TILE_LAYOUT,
+            dict(core_grid=ttnn.CoreGrid(y=1, x=8), strategy=ttnn.ShardStrategy.WIDTH),
+            dict(core_grid=ttnn.CoreGrid(y=1, x=2), strategy=ttnn.ShardStrategy.WIDTH),
+            None,
+            None,
+        ),
+        (
+            32,
+            1792,
+            ttnn.TILE_LAYOUT,
+            dict(core_grid=ttnn.CoreGrid(y=7, x=8), strategy=ttnn.ShardStrategy.WIDTH),
+            dict(core_grid=ttnn.CoreGrid(y=1, x=8), strategy=ttnn.ShardStrategy.BLOCK),
+            [32, 32],
+            None,
+        ),
+        (
+            32,
+            7168,
+            ttnn.TILE_LAYOUT,
+            dict(core_grid=ttnn.CoreGrid(y=7, x=8), strategy=ttnn.ShardStrategy.WIDTH),
+            dict(core_grid=ttnn.CoreGrid(y=1, x=8), strategy=ttnn.ShardStrategy.BLOCK),
+            [32, 128],
+            None,
+        ),
+        (
+            32,
+            320,
+            ttnn.TILE_LAYOUT,
+            dict(core_grid=ttnn.CoreGrid(y=1, x=2), strategy=ttnn.ShardStrategy.BLOCK),
+            dict(core_grid=ttnn.CoreGrid(y=1, x=5), strategy=ttnn.ShardStrategy.BLOCK),
+            None,
+            None,
+        ),
+        (
+            8192,
+            320,
+            ttnn.TILE_LAYOUT,
+            dict(core_grid=ttnn.CoreGrid(y=8, x=2), strategy=ttnn.ShardStrategy.BLOCK),
+            dict(core_grid=ttnn.CoreGrid(y=8, x=5), strategy=ttnn.ShardStrategy.BLOCK),
+            None,
+            None,
+        ),
+        # (1, 1, 32, 8192) (32 to 8 cores width shardrd)
+        (
+            32,
+            8192,
+            ttnn.TILE_LAYOUT,
+            dict(core_grid=ttnn.CoreGrid(y=4, x=8), strategy=ttnn.ShardStrategy.WIDTH),
+            dict(core_grid=ttnn.CoreGrid(y=1, x=8), strategy=ttnn.ShardStrategy.WIDTH),
+            (32, 256),
+            None,
+        ),
+        # (1, 1, 32, 8192) (64 to 8 cores width shardrd)
+        (
+            32,
+            8192,
+            ttnn.TILE_LAYOUT,
+            dict(core_grid=ttnn.CoreGrid(y=8, x=8), strategy=ttnn.ShardStrategy.WIDTH),
+            dict(core_grid=ttnn.CoreGrid(y=1, x=8), strategy=ttnn.ShardStrategy.WIDTH),
+            (32, 128),
+            None,
+        ),
+        # (1, 1, 32, 1280) (8 to 1 cores width shardrd)
+        (
+            32,
+            1280,
+            ttnn.ROW_MAJOR_LAYOUT,
+            dict(core_grid=ttnn.CoreGrid(y=1, x=8), strategy=ttnn.ShardStrategy.WIDTH),
+            dict(core_grid=ttnn.CoreGrid(y=1, x=1), strategy=ttnn.ShardStrategy.WIDTH),
+            None,
+            None,
+        ),
+        # (1, 1, 128, 1280) (32 cores block sharded to 4 cores height sharded)
+        (
+            128,
+            1280,
+            ttnn.TILE_LAYOUT,
+            dict(core_grid=ttnn.CoreGrid(y=4, x=8), strategy=ttnn.ShardStrategy.BLOCK),
+            dict(core_grid=ttnn.CoreGrid(y=4, x=1), strategy=ttnn.ShardStrategy.HEIGHT),
+            None,
+            None,
+        ),
+        (
+            160,
+            64,
+            ttnn.TILE_LAYOUT,
+            dict(
+                core_grid=ttnn.CoreGrid(y=5, x=1),
+                strategy=ttnn.ShardStrategy.HEIGHT,
+                orientation=ttnn.ShardOrientation.ROW_MAJOR,
+            ),
+            dict(
+                core_grid=ttnn.CoreGrid(y=2, x=2),
+                strategy=ttnn.ShardStrategy.BLOCK,
+                orientation=ttnn.ShardOrientation.COL_MAJOR,
+            ),
+            (32, 64),
+            (32, 96),
+        ),
+        (
+            192,
+            128,
+            ttnn.TILE_LAYOUT,
+            dict(
+                core_grid=ttnn.experimental.tensor.CoreRangeSet(
+                    {
+                        ttnn.experimental.tensor.CoreRange(
+                            ttnn.experimental.tensor.CoreCoord(0, 0), ttnn.experimental.tensor.CoreCoord(0, 1)
+                        ),
+                    }
+                ),
+                strategy=ttnn.ShardStrategy.HEIGHT,
+            ),
+            dict(
+                core_grid=ttnn.experimental.tensor.CoreRangeSet(
+                    {
+                        ttnn.experimental.tensor.CoreRange(
+                            ttnn.experimental.tensor.CoreCoord(0, 0), ttnn.experimental.tensor.CoreCoord(1, 1)
+                        ),
+                    }
+                ),
+                strategy=ttnn.ShardStrategy.BLOCK,
+            ),
+            (96, 128),
+            (128, 64),
+        ),
+        (
+            128,
+            128,
+            ttnn.TILE_LAYOUT,
+            dict(
+                core_grid=ttnn.experimental.tensor.CoreRangeSet(
+                    {
+                        ttnn.experimental.tensor.CoreRange(
+                            ttnn.experimental.tensor.CoreCoord(0, 0), ttnn.experimental.tensor.CoreCoord(0, 1)
+                        ),
+                    }
+                ),
+                strategy=ttnn.ShardStrategy.HEIGHT,
+            ),
+            dict(
+                core_grid=ttnn.experimental.tensor.CoreRangeSet(
+                    {
+                        ttnn.experimental.tensor.CoreRange(
+                            ttnn.experimental.tensor.CoreCoord(0, 0), ttnn.experimental.tensor.CoreCoord(1, 1)
+                        ),
+                    }
+                ),
+                strategy=ttnn.ShardStrategy.BLOCK,
+            ),
+            (64, 128),
+            (96, 64),
+        ),
+        (
+            96,
+            128,
+            ttnn.TILE_LAYOUT,
+            dict(
+                core_grid=ttnn.experimental.tensor.CoreRangeSet(
+                    {
+                        ttnn.experimental.tensor.CoreRange(
+                            ttnn.experimental.tensor.CoreCoord(0, 0), ttnn.experimental.tensor.CoreCoord(0, 2)
+                        ),
+                    }
+                ),
+                strategy=ttnn.ShardStrategy.HEIGHT,
+            ),
+            dict(
+                core_grid=ttnn.experimental.tensor.CoreRangeSet(
+                    {
+                        ttnn.experimental.tensor.CoreRange(
+                            ttnn.experimental.tensor.CoreCoord(0, 0), ttnn.experimental.tensor.CoreCoord(1, 1)
+                        ),
+                    }
+                ),
+                strategy=ttnn.ShardStrategy.BLOCK,
+            ),
+            (32, 128),
+            (64, 64),
+        ),
+        (
+            256,
             320,
             ttnn.ROW_MAJOR_LAYOUT,
             dict(
                 core_grid=ttnn.experimental.tensor.CoreRangeSet(
                     {
                         ttnn.experimental.tensor.CoreRange(
-                            ttnn.experimental.tensor.CoreCoord(0, 0), ttnn.experimental.tensor.CoreCoord(0, 7)
+                            ttnn.experimental.tensor.CoreCoord(0, 0), ttnn.experimental.tensor.CoreCoord(7, 7)
                         ),
                     }
                 ),
@@ -385,44 +298,15 @@ from enum import Enum
                 core_grid=ttnn.experimental.tensor.CoreRangeSet(
                     {
                         ttnn.experimental.tensor.CoreRange(
-                            ttnn.experimental.tensor.CoreCoord(0, 0), ttnn.experimental.tensor.CoreCoord(0, 4)
+                            ttnn.experimental.tensor.CoreCoord(0, 0), ttnn.experimental.tensor.CoreCoord(7, 4)
                         ),
                     }
                 ),
                 strategy=ttnn.ShardStrategy.BLOCK,
                 orientation=ttnn.ShardOrientation.COL_MAJOR,
             ),
-            (40, 1),
-            (64, 1),
-        ),
-        (
-            1,
-            160,
-            ttnn.ROW_MAJOR_LAYOUT,
-            dict(
-                core_grid=ttnn.experimental.tensor.CoreRangeSet(
-                    {
-                        ttnn.experimental.tensor.CoreRange(
-                            ttnn.experimental.tensor.CoreCoord(0, 0), ttnn.experimental.tensor.CoreCoord(0, 4)
-                        ),
-                    }
-                ),
-                strategy=ttnn.ShardStrategy.BLOCK,
-                orientation=ttnn.ShardOrientation.COL_MAJOR,
-            ),
-            dict(
-                core_grid=ttnn.experimental.tensor.CoreRangeSet(
-                    {
-                        ttnn.experimental.tensor.CoreRange(
-                            ttnn.experimental.tensor.CoreCoord(0, 0), ttnn.experimental.tensor.CoreCoord(0, 3)
-                        ),
-                    }
-                ),
-                strategy=ttnn.ShardStrategy.BLOCK,
-                orientation=ttnn.ShardOrientation.COL_MAJOR,
-            ),
-            (32, 1),
-            (40, 1),
+            (40, 32),
+            (64, 32),
         ),
     ],
 )
@@ -436,6 +320,7 @@ def test_reshard(
     input_override,
     output_override,
 ):
+    torch.manual_seed(420)
     if isinstance(input_sharded_memory_config_args["core_grid"], (ttnn.CoreGrid)):
         if device.core_grid.y < input_sharded_memory_config_args["core_grid"].y:
             pytest.skip()
@@ -466,13 +351,13 @@ def test_reshard(
     sharded_output_tensor = ttnn.to_memory_config(sharded_input_tensor, output_shard_memory_config)
 
     output = ttnn.to_torch(sharded_output_tensor)
-    sharded_input_torch = ttnn.to_torch(sharded_input_tensor)
 
-    torch.set_printoptions(profile="full")
-    print("Input Tensor without Reshard")
-    print(sharded_input_torch)
-    print("Tensor after Reshard")
-    print(output)
+    # sharded_input_torch = ttnn.to_torch(sharded_input_tensor)
+    # torch.set_printoptions(profile="full")
+    # print("Input Tensor without Reshard")
+    # print(sharded_input_torch)
+    # print("Tensor after Reshard")
+    # print(output)
     assert_with_pcc(torch_input_tensor, output, 1.0)
 
 

--- a/tests/ttnn/unit_tests/operations/test_core.py
+++ b/tests/ttnn/unit_tests/operations/test_core.py
@@ -309,7 +309,7 @@ from enum import Enum
         #            (64, 32),
         #        ),
         (
-            4,
+            2,
             16,
             ttnn.ROW_MAJOR_LAYOUT,
             dict(
@@ -334,8 +334,37 @@ from enum import Enum
                 strategy=ttnn.ShardStrategy.BLOCK,
                 orientation=ttnn.ShardOrientation.COL_MAJOR,
             ),
-            (8, 4),
-            (16, 4),
+            (8, 2),
+            (16, 2),
+        ),
+        (
+            2,
+            16,
+            ttnn.ROW_MAJOR_LAYOUT,
+            dict(
+                core_grid=ttnn.experimental.tensor.CoreRangeSet(
+                    {
+                        ttnn.experimental.tensor.CoreRange(
+                            ttnn.experimental.tensor.CoreCoord(0, 0), ttnn.experimental.tensor.CoreCoord(0, 0)
+                        ),
+                    }
+                ),
+                strategy=ttnn.ShardStrategy.BLOCK,
+                orientation=ttnn.ShardOrientation.COL_MAJOR,
+            ),
+            dict(
+                core_grid=ttnn.experimental.tensor.CoreRangeSet(
+                    {
+                        ttnn.experimental.tensor.CoreRange(
+                            ttnn.experimental.tensor.CoreCoord(0, 0), ttnn.experimental.tensor.CoreCoord(0, 1)
+                        ),
+                    }
+                ),
+                strategy=ttnn.ShardStrategy.BLOCK,
+                orientation=ttnn.ShardOrientation.COL_MAJOR,
+            ),
+            (16, 2),
+            (8, 2),
         ),
     ],
 )

--- a/tests/ttnn/unit_tests/operations/test_core.py
+++ b/tests/ttnn/unit_tests/operations/test_core.py
@@ -15,269 +15,298 @@ from enum import Enum
 @pytest.mark.parametrize(
     "input_height, input_width, input_memory_layout, input_sharded_memory_config_args, output_sharded_memory_config_args, input_override, output_override",
     [
+        #        (
+        #            128,
+        #            128,
+        #            ttnn.TILE_LAYOUT,
+        #            dict(core_grid=ttnn.CoreGrid(y=2, x=1), strategy=ttnn.ShardStrategy.HEIGHT),
+        #            dict(core_grid=ttnn.CoreGrid(y=1, x=2), strategy=ttnn.ShardStrategy.WIDTH),
+        #            None,
+        #            None,
+        #        ),
+        #        (
+        #            128,
+        #            128,
+        #            ttnn.TILE_LAYOUT,
+        #            dict(core_grid=ttnn.CoreGrid(y=1, x=2), strategy=ttnn.ShardStrategy.WIDTH),
+        #            dict(core_grid=ttnn.CoreGrid(y=2, x=1), strategy=ttnn.ShardStrategy.HEIGHT),
+        #            None,
+        #            None,
+        #        ),
+        #        (
+        #            128,
+        #            64,
+        #            ttnn.TILE_LAYOUT,
+        #            dict(core_grid=ttnn.CoreGrid(y=2, x=1), strategy=ttnn.ShardStrategy.HEIGHT),
+        #            dict(core_grid=ttnn.CoreGrid(y=4, x=2), strategy=ttnn.ShardStrategy.BLOCK),
+        #            None,
+        #            None,
+        #        ),
+        #        (
+        #            128,
+        #            64,
+        #            ttnn.TILE_LAYOUT,
+        #            dict(core_grid=ttnn.CoreGrid(y=2, x=1), strategy=ttnn.ShardStrategy.HEIGHT),
+        #            dict(core_grid=ttnn.CoreGrid(y=4, x=1), strategy=ttnn.ShardStrategy.HEIGHT),
+        #            None,
+        #            None,
+        #        ),
+        #        (
+        #            128,
+        #            64,
+        #            ttnn.TILE_LAYOUT,
+        #            dict(core_grid=ttnn.CoreGrid(y=1, x=2), strategy=ttnn.ShardStrategy.WIDTH),
+        #            dict(core_grid=ttnn.CoreGrid(y=4, x=1), strategy=ttnn.ShardStrategy.HEIGHT),
+        #            None,
+        #            None,
+        #        ),
+        #        (
+        #            128,
+        #            64,
+        #            ttnn.TILE_LAYOUT,
+        #            dict(core_grid=ttnn.CoreGrid(y=2, x=1), strategy=ttnn.ShardStrategy.BLOCK),
+        #            dict(core_grid=ttnn.CoreGrid(y=4, x=2), strategy=ttnn.ShardStrategy.BLOCK),
+        #            None,
+        #            None,
+        #        ),
+        #        (
+        #            32,
+        #            128,
+        #            ttnn.TILE_LAYOUT,
+        #            dict(core_grid=ttnn.CoreGrid(y=1, x=4), strategy=ttnn.ShardStrategy.BLOCK),
+        #            dict(core_grid=ttnn.CoreGrid(y=1, x=2), strategy=ttnn.ShardStrategy.BLOCK),
+        #            None,
+        #            None,
+        #        ),
+        #        (
+        #            32,
+        #            128,
+        #            ttnn.TILE_LAYOUT,
+        #            dict(core_grid=ttnn.CoreGrid(y=1, x=4), strategy=ttnn.ShardStrategy.WIDTH),
+        #            dict(core_grid=ttnn.CoreGrid(y=1, x=2), strategy=ttnn.ShardStrategy.BLOCK),
+        #            None,
+        #            None,
+        #        ),
+        #        (
+        #            32,
+        #            16,
+        #            ttnn.ROW_MAJOR_LAYOUT,
+        #            dict(core_grid=ttnn.CoreGrid(y=1, x=1), strategy=ttnn.ShardStrategy.BLOCK),
+        #            dict(core_grid=ttnn.CoreGrid(y=2, x=1), strategy=ttnn.ShardStrategy.BLOCK),
+        #            None,
+        #            None,
+        #        ),
+        #        (
+        #            32,
+        #            2304,
+        #            ttnn.TILE_LAYOUT,
+        #            dict(core_grid=ttnn.CoreGrid(y=1, x=8), strategy=ttnn.ShardStrategy.WIDTH),
+        #            dict(core_grid=ttnn.CoreGrid(y=1, x=2), strategy=ttnn.ShardStrategy.WIDTH),
+        #            None,
+        #            None,
+        #        ),
+        #        (
+        #            32,
+        #            1792,
+        #            ttnn.TILE_LAYOUT,
+        #            dict(core_grid=ttnn.CoreGrid(y=7, x=8), strategy=ttnn.ShardStrategy.WIDTH),
+        #            dict(core_grid=ttnn.CoreGrid(y=1, x=8), strategy=ttnn.ShardStrategy.BLOCK),
+        #            [32, 32],
+        #            None,
+        #        ),
+        #        (
+        #            32,
+        #            7168,
+        #            ttnn.TILE_LAYOUT,
+        #            dict(core_grid=ttnn.CoreGrid(y=7, x=8), strategy=ttnn.ShardStrategy.WIDTH),
+        #            dict(core_grid=ttnn.CoreGrid(y=1, x=8), strategy=ttnn.ShardStrategy.BLOCK),
+        #            [32, 128],
+        #            None,
+        #        ),
+        #        (
+        #            32,
+        #            320,
+        #            ttnn.TILE_LAYOUT,
+        #            dict(core_grid=ttnn.CoreGrid(y=1, x=2), strategy=ttnn.ShardStrategy.BLOCK),
+        #            dict(core_grid=ttnn.CoreGrid(y=1, x=5), strategy=ttnn.ShardStrategy.BLOCK),
+        #            None,
+        #            None,
+        #        ),
+        #        (
+        #            8192,
+        #            320,
+        #            ttnn.TILE_LAYOUT,
+        #            dict(core_grid=ttnn.CoreGrid(y=8, x=2), strategy=ttnn.ShardStrategy.BLOCK),
+        #            dict(core_grid=ttnn.CoreGrid(y=8, x=5), strategy=ttnn.ShardStrategy.BLOCK),
+        #            None,
+        #            None,
+        #        ),
+        #        # (1, 1, 32, 8192) (32 to 8 cores width shardrd)
+        #        (
+        #            32,
+        #            8192,
+        #            ttnn.TILE_LAYOUT,
+        #            dict(core_grid=ttnn.CoreGrid(y=4, x=8), strategy=ttnn.ShardStrategy.WIDTH),
+        #            dict(core_grid=ttnn.CoreGrid(y=1, x=8), strategy=ttnn.ShardStrategy.WIDTH),
+        #            (32, 256),
+        #            None,
+        #        ),
+        #        # (1, 1, 32, 8192) (64 to 8 cores width shardrd)
+        #        (
+        #            32,
+        #            8192,
+        #            ttnn.TILE_LAYOUT,
+        #            dict(core_grid=ttnn.CoreGrid(y=8, x=8), strategy=ttnn.ShardStrategy.WIDTH),
+        #            dict(core_grid=ttnn.CoreGrid(y=1, x=8), strategy=ttnn.ShardStrategy.WIDTH),
+        #            (32, 128),
+        #            None,
+        #        ),
+        #        # (1, 1, 32, 1280) (8 to 1 cores width shardrd)
+        #        (
+        #            32,
+        #            1280,
+        #            ttnn.ROW_MAJOR_LAYOUT,
+        #            dict(core_grid=ttnn.CoreGrid(y=1, x=8), strategy=ttnn.ShardStrategy.WIDTH),
+        #            dict(core_grid=ttnn.CoreGrid(y=1, x=1), strategy=ttnn.ShardStrategy.WIDTH),
+        #            None,
+        #            None,
+        #        ),
+        #        # (1, 1, 128, 1280) (32 cores block sharded to 4 cores height sharded)
+        #        (
+        #            128,
+        #            1280,
+        #            ttnn.TILE_LAYOUT,
+        #            dict(core_grid=ttnn.CoreGrid(y=4, x=8), strategy=ttnn.ShardStrategy.BLOCK),
+        #            dict(core_grid=ttnn.CoreGrid(y=4, x=1), strategy=ttnn.ShardStrategy.HEIGHT),
+        #            None,
+        #            None,
+        #        ),
+        #        (
+        #            160,
+        #            64,
+        #            ttnn.TILE_LAYOUT,
+        #            dict(
+        #                core_grid=ttnn.CoreGrid(y=5, x=1),
+        #                strategy=ttnn.ShardStrategy.HEIGHT,
+        #                orientation=ttnn.ShardOrientation.ROW_MAJOR,
+        #            ),
+        #            dict(
+        #                core_grid=ttnn.CoreGrid(y=2, x=2),
+        #                strategy=ttnn.ShardStrategy.BLOCK,
+        #                orientation=ttnn.ShardOrientation.COL_MAJOR,
+        #            ),
+        #            (32, 64),
+        #            (32, 96),
+        #        ),
+        #        (
+        #            192,
+        #            128,
+        #            ttnn.TILE_LAYOUT,
+        #            dict(
+        #                core_grid=ttnn.experimental.tensor.CoreRangeSet(
+        #                    {
+        #                        ttnn.experimental.tensor.CoreRange(
+        #                            ttnn.experimental.tensor.CoreCoord(0, 0), ttnn.experimental.tensor.CoreCoord(0, 1)
+        #                        ),
+        #                    }
+        #                ),
+        #                strategy=ttnn.ShardStrategy.HEIGHT,
+        #            ),
+        #            dict(
+        #                core_grid=ttnn.experimental.tensor.CoreRangeSet(
+        #                    {
+        #                        ttnn.experimental.tensor.CoreRange(
+        #                            ttnn.experimental.tensor.CoreCoord(0, 0), ttnn.experimental.tensor.CoreCoord(1, 1)
+        #                        ),
+        #                    }
+        #                ),
+        #                strategy=ttnn.ShardStrategy.BLOCK,
+        #            ),
+        #            (96, 128),
+        #            (128, 64),
+        #        ),
+        #        (
+        #            128,
+        #            128,
+        #            ttnn.TILE_LAYOUT,
+        #            dict(
+        #                core_grid=ttnn.experimental.tensor.CoreRangeSet(
+        #                    {
+        #                        ttnn.experimental.tensor.CoreRange(
+        #                            ttnn.experimental.tensor.CoreCoord(0, 0), ttnn.experimental.tensor.CoreCoord(0, 1)
+        #                        ),
+        #                    }
+        #                ),
+        #                strategy=ttnn.ShardStrategy.HEIGHT,
+        #            ),
+        #            dict(
+        #                core_grid=ttnn.experimental.tensor.CoreRangeSet(
+        #                    {
+        #                        ttnn.experimental.tensor.CoreRange(
+        #                            ttnn.experimental.tensor.CoreCoord(0, 0), ttnn.experimental.tensor.CoreCoord(1, 1)
+        #                        ),
+        #                    }
+        #                ),
+        #                strategy=ttnn.ShardStrategy.BLOCK,
+        #            ),
+        #            (64, 128),
+        #            (96, 64),
+        #        ),
+        #        (
+        #            96,
+        #            128,
+        #            ttnn.TILE_LAYOUT,
+        #            dict(
+        #                core_grid=ttnn.experimental.tensor.CoreRangeSet(
+        #                    {
+        #                        ttnn.experimental.tensor.CoreRange(
+        #                            ttnn.experimental.tensor.CoreCoord(0, 0), ttnn.experimental.tensor.CoreCoord(0, 2)
+        #                        ),
+        #                    }
+        #                ),
+        #                strategy=ttnn.ShardStrategy.HEIGHT,
+        #            ),
+        #            dict(
+        #                core_grid=ttnn.experimental.tensor.CoreRangeSet(
+        #                    {
+        #                        ttnn.experimental.tensor.CoreRange(
+        #                            ttnn.experimental.tensor.CoreCoord(0, 0), ttnn.experimental.tensor.CoreCoord(1, 1)
+        #                        ),
+        #                    }
+        #                ),
+        #                strategy=ttnn.ShardStrategy.BLOCK,
+        #            ),
+        #            (32, 128),
+        #            (64, 64),
+        #        ),
         (
-            128,
-            128,
-            ttnn.TILE_LAYOUT,
-            dict(core_grid=ttnn.CoreGrid(y=2, x=1), strategy=ttnn.ShardStrategy.HEIGHT),
-            dict(core_grid=ttnn.CoreGrid(y=1, x=2), strategy=ttnn.ShardStrategy.WIDTH),
-            None,
-            None,
-        ),
-        (
-            128,
-            128,
-            ttnn.TILE_LAYOUT,
-            dict(core_grid=ttnn.CoreGrid(y=1, x=2), strategy=ttnn.ShardStrategy.WIDTH),
-            dict(core_grid=ttnn.CoreGrid(y=2, x=1), strategy=ttnn.ShardStrategy.HEIGHT),
-            None,
-            None,
-        ),
-        (
-            128,
-            64,
-            ttnn.TILE_LAYOUT,
-            dict(core_grid=ttnn.CoreGrid(y=2, x=1), strategy=ttnn.ShardStrategy.HEIGHT),
-            dict(core_grid=ttnn.CoreGrid(y=4, x=2), strategy=ttnn.ShardStrategy.BLOCK),
-            None,
-            None,
-        ),
-        (
-            128,
-            64,
-            ttnn.TILE_LAYOUT,
-            dict(core_grid=ttnn.CoreGrid(y=2, x=1), strategy=ttnn.ShardStrategy.HEIGHT),
-            dict(core_grid=ttnn.CoreGrid(y=4, x=1), strategy=ttnn.ShardStrategy.HEIGHT),
-            None,
-            None,
-        ),
-        (
-            128,
-            64,
-            ttnn.TILE_LAYOUT,
-            dict(core_grid=ttnn.CoreGrid(y=1, x=2), strategy=ttnn.ShardStrategy.WIDTH),
-            dict(core_grid=ttnn.CoreGrid(y=4, x=1), strategy=ttnn.ShardStrategy.HEIGHT),
-            None,
-            None,
-        ),
-        (
-            128,
-            64,
-            ttnn.TILE_LAYOUT,
-            dict(core_grid=ttnn.CoreGrid(y=2, x=1), strategy=ttnn.ShardStrategy.BLOCK),
-            dict(core_grid=ttnn.CoreGrid(y=4, x=2), strategy=ttnn.ShardStrategy.BLOCK),
-            None,
-            None,
-        ),
-        (
-            32,
-            128,
-            ttnn.TILE_LAYOUT,
-            dict(core_grid=ttnn.CoreGrid(y=1, x=4), strategy=ttnn.ShardStrategy.BLOCK),
-            dict(core_grid=ttnn.CoreGrid(y=1, x=2), strategy=ttnn.ShardStrategy.BLOCK),
-            None,
-            None,
-        ),
-        (
-            32,
-            128,
-            ttnn.TILE_LAYOUT,
-            dict(core_grid=ttnn.CoreGrid(y=1, x=4), strategy=ttnn.ShardStrategy.WIDTH),
-            dict(core_grid=ttnn.CoreGrid(y=1, x=2), strategy=ttnn.ShardStrategy.BLOCK),
-            None,
-            None,
-        ),
-        (
-            32,
-            16,
-            ttnn.ROW_MAJOR_LAYOUT,
-            dict(core_grid=ttnn.CoreGrid(y=1, x=1), strategy=ttnn.ShardStrategy.BLOCK),
-            dict(core_grid=ttnn.CoreGrid(y=2, x=1), strategy=ttnn.ShardStrategy.BLOCK),
-            None,
-            None,
-        ),
-        (
-            32,
-            2304,
-            ttnn.TILE_LAYOUT,
-            dict(core_grid=ttnn.CoreGrid(y=1, x=8), strategy=ttnn.ShardStrategy.WIDTH),
-            dict(core_grid=ttnn.CoreGrid(y=1, x=2), strategy=ttnn.ShardStrategy.WIDTH),
-            None,
-            None,
-        ),
-        (
-            32,
-            1792,
-            ttnn.TILE_LAYOUT,
-            dict(core_grid=ttnn.CoreGrid(y=7, x=8), strategy=ttnn.ShardStrategy.WIDTH),
-            dict(core_grid=ttnn.CoreGrid(y=1, x=8), strategy=ttnn.ShardStrategy.BLOCK),
-            [32, 32],
-            None,
-        ),
-        (
-            32,
-            7168,
-            ttnn.TILE_LAYOUT,
-            dict(core_grid=ttnn.CoreGrid(y=7, x=8), strategy=ttnn.ShardStrategy.WIDTH),
-            dict(core_grid=ttnn.CoreGrid(y=1, x=8), strategy=ttnn.ShardStrategy.BLOCK),
-            [32, 128],
-            None,
-        ),
-        (
-            32,
+            256,
             320,
-            ttnn.TILE_LAYOUT,
-            dict(core_grid=ttnn.CoreGrid(y=1, x=2), strategy=ttnn.ShardStrategy.BLOCK),
-            dict(core_grid=ttnn.CoreGrid(y=1, x=5), strategy=ttnn.ShardStrategy.BLOCK),
-            None,
-            None,
-        ),
-        (
-            8192,
-            320,
-            ttnn.TILE_LAYOUT,
-            dict(core_grid=ttnn.CoreGrid(y=8, x=2), strategy=ttnn.ShardStrategy.BLOCK),
-            dict(core_grid=ttnn.CoreGrid(y=8, x=5), strategy=ttnn.ShardStrategy.BLOCK),
-            None,
-            None,
-        ),
-        # (1, 1, 32, 8192) (32 to 8 cores width shardrd)
-        (
-            32,
-            8192,
-            ttnn.TILE_LAYOUT,
-            dict(core_grid=ttnn.CoreGrid(y=4, x=8), strategy=ttnn.ShardStrategy.WIDTH),
-            dict(core_grid=ttnn.CoreGrid(y=1, x=8), strategy=ttnn.ShardStrategy.WIDTH),
-            (32, 256),
-            None,
-        ),
-        # (1, 1, 32, 8192) (64 to 8 cores width shardrd)
-        (
-            32,
-            8192,
-            ttnn.TILE_LAYOUT,
-            dict(core_grid=ttnn.CoreGrid(y=8, x=8), strategy=ttnn.ShardStrategy.WIDTH),
-            dict(core_grid=ttnn.CoreGrid(y=1, x=8), strategy=ttnn.ShardStrategy.WIDTH),
-            (32, 128),
-            None,
-        ),
-        # (1, 1, 32, 1280) (8 to 1 cores width shardrd)
-        (
-            32,
-            1280,
             ttnn.ROW_MAJOR_LAYOUT,
-            dict(core_grid=ttnn.CoreGrid(y=1, x=8), strategy=ttnn.ShardStrategy.WIDTH),
-            dict(core_grid=ttnn.CoreGrid(y=1, x=1), strategy=ttnn.ShardStrategy.WIDTH),
-            None,
-            None,
-        ),
-        # (1, 1, 128, 1280) (32 cores block sharded to 4 cores height sharded)
-        (
-            128,
-            1280,
-            ttnn.TILE_LAYOUT,
-            dict(core_grid=ttnn.CoreGrid(y=4, x=8), strategy=ttnn.ShardStrategy.BLOCK),
-            dict(core_grid=ttnn.CoreGrid(y=4, x=1), strategy=ttnn.ShardStrategy.HEIGHT),
-            None,
-            None,
-        ),
-        (
-            160,
-            64,
-            ttnn.TILE_LAYOUT,
             dict(
-                core_grid=ttnn.CoreGrid(y=5, x=1),
-                strategy=ttnn.ShardStrategy.HEIGHT,
-                orientation=ttnn.ShardOrientation.ROW_MAJOR,
-            ),
-            dict(
-                core_grid=ttnn.CoreGrid(y=2, x=2),
+                core_grid=ttnn.experimental.tensor.CoreRangeSet(
+                    {
+                        ttnn.experimental.tensor.CoreRange(
+                            ttnn.experimental.tensor.CoreCoord(0, 0), ttnn.experimental.tensor.CoreCoord(7, 7)
+                        ),
+                    }
+                ),
                 strategy=ttnn.ShardStrategy.BLOCK,
                 orientation=ttnn.ShardOrientation.COL_MAJOR,
             ),
-            (32, 64),
-            (32, 96),
-        ),
-        (
-            192,
-            128,
-            ttnn.TILE_LAYOUT,
             dict(
                 core_grid=ttnn.experimental.tensor.CoreRangeSet(
                     {
                         ttnn.experimental.tensor.CoreRange(
-                            ttnn.experimental.tensor.CoreCoord(0, 0), ttnn.experimental.tensor.CoreCoord(0, 1)
-                        ),
-                    }
-                ),
-                strategy=ttnn.ShardStrategy.HEIGHT,
-            ),
-            dict(
-                core_grid=ttnn.experimental.tensor.CoreRangeSet(
-                    {
-                        ttnn.experimental.tensor.CoreRange(
-                            ttnn.experimental.tensor.CoreCoord(0, 0), ttnn.experimental.tensor.CoreCoord(1, 1)
+                            ttnn.experimental.tensor.CoreCoord(0, 0), ttnn.experimental.tensor.CoreCoord(7, 4)
                         ),
                     }
                 ),
                 strategy=ttnn.ShardStrategy.BLOCK,
+                orientation=ttnn.ShardOrientation.COL_MAJOR,
             ),
-            (96, 128),
-            (128, 64),
-        ),
-        (
-            128,
-            128,
-            ttnn.TILE_LAYOUT,
-            dict(
-                core_grid=ttnn.experimental.tensor.CoreRangeSet(
-                    {
-                        ttnn.experimental.tensor.CoreRange(
-                            ttnn.experimental.tensor.CoreCoord(0, 0), ttnn.experimental.tensor.CoreCoord(0, 1)
-                        ),
-                    }
-                ),
-                strategy=ttnn.ShardStrategy.HEIGHT,
-            ),
-            dict(
-                core_grid=ttnn.experimental.tensor.CoreRangeSet(
-                    {
-                        ttnn.experimental.tensor.CoreRange(
-                            ttnn.experimental.tensor.CoreCoord(0, 0), ttnn.experimental.tensor.CoreCoord(1, 1)
-                        ),
-                    }
-                ),
-                strategy=ttnn.ShardStrategy.BLOCK,
-            ),
-            (64, 128),
-            (96, 64),
-        ),
-        (
-            96,
-            128,
-            ttnn.TILE_LAYOUT,
-            dict(
-                core_grid=ttnn.experimental.tensor.CoreRangeSet(
-                    {
-                        ttnn.experimental.tensor.CoreRange(
-                            ttnn.experimental.tensor.CoreCoord(0, 0), ttnn.experimental.tensor.CoreCoord(0, 2)
-                        ),
-                    }
-                ),
-                strategy=ttnn.ShardStrategy.HEIGHT,
-            ),
-            dict(
-                core_grid=ttnn.experimental.tensor.CoreRangeSet(
-                    {
-                        ttnn.experimental.tensor.CoreRange(
-                            ttnn.experimental.tensor.CoreCoord(0, 0), ttnn.experimental.tensor.CoreCoord(1, 1)
-                        ),
-                    }
-                ),
-                strategy=ttnn.ShardStrategy.BLOCK,
-            ),
-            (32, 128),
-            (64, 64),
+            (40, 32),
+            (64, 32),
         ),
     ],
 )
@@ -296,13 +325,8 @@ def test_reshard(
             pytest.skip()
         if device.core_grid.y < output_sharded_memory_config_args["core_grid"].y:
             pytest.skip()
+
     input_shape = [1, 1, input_height, input_width]
-
-    torch_input_tensor = torch.rand(input_shape, dtype=torch.bfloat16)
-    interleaved_input_tensor = ttnn.from_torch(
-        torch_input_tensor, layout=input_memory_layout, device=device, memory_config=ttnn.DRAM_MEMORY_CONFIG
-    )
-
     if input_override == None:
         input_shard_memory_config = ttnn.create_sharded_memory_config(input_shape, **input_sharded_memory_config_args)
     else:
@@ -316,146 +340,146 @@ def test_reshard(
         output_shard_memory_config = ttnn.create_sharded_memory_config(
             output_override, **output_sharded_memory_config_args, use_height_and_width_as_shard_shape=True
         )
-    # interleaved_to_sharded
-    sharded_input_tensor = ttnn.to_memory_config(interleaved_input_tensor, input_shard_memory_config)
 
+    torch_input_tensor = torch.rand(input_shape, dtype=torch.bfloat16)
+    sharded_input_tensor = ttnn.from_torch(
+        torch_input_tensor, layout=input_memory_layout, device=device, memory_config=input_shard_memory_config
+    )
     # reshard
     sharded_output_tensor = ttnn.to_memory_config(sharded_input_tensor, output_shard_memory_config)
 
-    # sharded_to_interleaved
-    interleaved_output_tensor = ttnn.to_memory_config(sharded_output_tensor, ttnn.DRAM_MEMORY_CONFIG)
-
-    output = ttnn.to_torch(interleaved_output_tensor)
+    output = ttnn.to_torch(sharded_output_tensor)
 
     assert_with_pcc(torch_input_tensor, output, 1.0)
 
 
-class DirectReadWriteType(Enum):
-    READ_ONLY = 0
-    WRITE_ONLY = 1
-    READ_WRITE = 2
-    NONE = 3
-
-
-@pytest.mark.parametrize(
-    "data_transfer_strategy",
-    [
-        (DirectReadWriteType.READ_ONLY),
-        (DirectReadWriteType.WRITE_ONLY),
-        (DirectReadWriteType.NONE),
-        (DirectReadWriteType.READ_WRITE),
-    ],
-)
-@pytest.mark.parametrize(
-    "input_shape, input_shard_shape,  input_sharded_memory_config_args",
-    [
-        (
-            [1, 1, 32, 1024],
-            [32, 256],
-            dict(
-                core_grid=ttnn.experimental.tensor.CoreRangeSet(
-                    {
-                        ttnn.experimental.tensor.CoreRange(
-                            ttnn.experimental.tensor.CoreCoord(0, 0), ttnn.experimental.tensor.CoreCoord(0, 3)
-                        ),
-                    }
-                ),
-                strategy=ttnn.ShardStrategy.WIDTH,
-            ),
-        ),
-        (
-            [1, 1, 32, 1024],
-            [32, 128],
-            dict(
-                core_grid=ttnn.experimental.tensor.CoreRangeSet(
-                    {
-                        ttnn.experimental.tensor.CoreRange(
-                            ttnn.experimental.tensor.CoreCoord(0, 0), ttnn.experimental.tensor.CoreCoord(0, 1)
-                        ),
-                        ttnn.experimental.tensor.CoreRange(
-                            ttnn.experimental.tensor.CoreCoord(0, 2), ttnn.experimental.tensor.CoreCoord(0, 3)
-                        ),
-                        ttnn.experimental.tensor.CoreRange(
-                            ttnn.experimental.tensor.CoreCoord(0, 4), ttnn.experimental.tensor.CoreCoord(0, 7)
-                        ),
-                    }
-                ),
-                strategy=ttnn.ShardStrategy.WIDTH,
-            ),
-        ),
-    ],
-)
-def test_shard_with_corerangeset(
-    device, input_shape, input_shard_shape, input_sharded_memory_config_args, data_transfer_strategy
-):
-    if device.core_grid.y == 7 and input_shard_shape == [32, 128]:
-        pytest.skip()
-    if (
-        ((not (input_shape[2] % input_shard_shape[0] == 0)) or (not (input_shape[3] % input_shard_shape[1] == 0)))
-        and (not (data_transfer_strategy == DirectReadWriteType.READ_WRITE))
-        and (not (input_sharded_memory_config_args["strategy"] == ttnn.ShardStrategy.HEIGHT))
-    ):
-        pytest.skip()
-
-    torch_input_tensor = torch.rand(input_shape, dtype=torch.bfloat16)
-    input_shard_memory_config = ttnn.create_sharded_memory_config(
-        input_shard_shape, **input_sharded_memory_config_args, use_height_and_width_as_shard_shape=True
-    )
-
-    if data_transfer_strategy == DirectReadWriteType.READ_ONLY or data_transfer_strategy == DirectReadWriteType.NONE:
-        interleaved_input_tensor = ttnn.from_torch(
-            torch_input_tensor, layout=ttnn.TILE_LAYOUT, device=device, memory_config=ttnn.DRAM_MEMORY_CONFIG
-        )
-        # interleaved_to_sharded
-        sharded_input_tensor = ttnn.to_memory_config(interleaved_input_tensor, input_shard_memory_config)
-    else:
-        sharded_input_tensor = ttnn.from_torch(
-            torch_input_tensor, layout=ttnn.TILE_LAYOUT, device=device, memory_config=input_shard_memory_config
-        )
-
-    if data_transfer_strategy == DirectReadWriteType.WRITE_ONLY or data_transfer_strategy == DirectReadWriteType.NONE:
-        # sharded_to_interleaved
-        interleaved_output_tensor = ttnn.to_memory_config(sharded_input_tensor, ttnn.DRAM_MEMORY_CONFIG)
-        output = ttnn.to_torch(interleaved_output_tensor)
-    else:
-        output = ttnn.to_torch(sharded_input_tensor)
-
-    assert_with_pcc(torch_input_tensor, output, 1.0)
-
-
-@pytest.mark.parametrize(
-    "shape, strategy, orientation, core_grid",
-    [
-        ([1, 1, 1024, 1024], ttnn.ShardStrategy.WIDTH, ttnn.ShardOrientation.ROW_MAJOR, ttnn.CoreGrid(y=2, x=2)),
-        ([1, 1, 1024, 1024], ttnn.ShardStrategy.HEIGHT, ttnn.ShardOrientation.ROW_MAJOR, ttnn.CoreGrid(y=2, x=2)),
-        ([1, 1, 1024, 1024], ttnn.ShardStrategy.BLOCK, ttnn.ShardOrientation.ROW_MAJOR, ttnn.CoreGrid(y=2, x=2)),
-        ([1, 1, 1024, 1024], ttnn.ShardStrategy.WIDTH, ttnn.ShardOrientation.COL_MAJOR, ttnn.CoreGrid(y=2, x=2)),
-        ([1, 1, 1024, 1024], ttnn.ShardStrategy.HEIGHT, ttnn.ShardOrientation.COL_MAJOR, ttnn.CoreGrid(y=2, x=2)),
-        ([1, 1, 1024, 1024], ttnn.ShardStrategy.BLOCK, ttnn.ShardOrientation.COL_MAJOR, ttnn.CoreGrid(y=2, x=2)),
-        ([1, 1, 128, 1024], ttnn.ShardStrategy.BLOCK, ttnn.ShardOrientation.ROW_MAJOR, ttnn.CoreGrid(y=2, x=4)),
-        ([1, 1, 1024, 128], ttnn.ShardStrategy.BLOCK, ttnn.ShardOrientation.COL_MAJOR, ttnn.CoreGrid(y=4, x=2)),
-    ],
-)
-def test_create_sharded_memory_config(device, shape, strategy, orientation, core_grid):
-    input_data = torch.randn(shape, dtype=torch.bfloat16)
-    x = ttnn.from_torch(
-        input_data,
-        device=device,
-        layout=ttnn.TILE_LAYOUT,
-        memory_config=ttnn.L1_MEMORY_CONFIG,
-        dtype=ttnn.bfloat16,
-    )
-    shard_config = ttnn.create_sharded_memory_config(
-        shape=shape,
-        core_grid=core_grid,
-        strategy=strategy,
-        orientation=orientation,
-        use_height_and_width_as_shard_shape=False,
-    )
-
-    x_t = ttnn.to_memory_config(x, memory_config=shard_config, dtype=ttnn.bfloat16)
-    output_data = ttnn.from_device(x_t)
-    output_data = ttnn.to_torch(output_data)
-
-    passing = torch.equal(input_data, output_data)
-    assert passing
+# class DirectReadWriteType(Enum):
+#    READ_ONLY = 0
+#    WRITE_ONLY = 1
+#    READ_WRITE = 2
+#    NONE = 3
+#
+#
+# @pytest.mark.parametrize(
+#    "data_transfer_strategy",
+#    [
+#        (DirectReadWriteType.READ_ONLY),
+#        (DirectReadWriteType.WRITE_ONLY),
+#        (DirectReadWriteType.NONE),
+#        (DirectReadWriteType.READ_WRITE),
+#    ],
+# )
+# @pytest.mark.parametrize(
+#    "input_shape, input_shard_shape,  input_sharded_memory_config_args",
+#    [
+#        (
+#            [1, 1, 32, 1024],
+#            [32, 256],
+#            dict(
+#                core_grid=ttnn.experimental.tensor.CoreRangeSet(
+#                    {
+#                        ttnn.experimental.tensor.CoreRange(
+#                            ttnn.experimental.tensor.CoreCoord(0, 0), ttnn.experimental.tensor.CoreCoord(0, 3)
+#                        ),
+#                    }
+#                ),
+#                strategy=ttnn.ShardStrategy.WIDTH,
+#            ),
+#        ),
+#        (
+#            [1, 1, 32, 1024],
+#            [32, 128],
+#            dict(
+#                core_grid=ttnn.experimental.tensor.CoreRangeSet(
+#                    {
+#                        ttnn.experimental.tensor.CoreRange(
+#                            ttnn.experimental.tensor.CoreCoord(0, 0), ttnn.experimental.tensor.CoreCoord(0, 1)
+#                        ),
+#                        ttnn.experimental.tensor.CoreRange(
+#                            ttnn.experimental.tensor.CoreCoord(0, 2), ttnn.experimental.tensor.CoreCoord(0, 3)
+#                        ),
+#                        ttnn.experimental.tensor.CoreRange(
+#                            ttnn.experimental.tensor.CoreCoord(0, 4), ttnn.experimental.tensor.CoreCoord(0, 7)
+#                        ),
+#                    }
+#                ),
+#                strategy=ttnn.ShardStrategy.WIDTH,
+#            ),
+#        ),
+#    ],
+# )
+# def test_shard_with_corerangeset(
+#    device, input_shape, input_shard_shape, input_sharded_memory_config_args, data_transfer_strategy
+# ):
+#    if device.core_grid.y == 7 and input_shard_shape == [32, 128]:
+#        pytest.skip()
+#    if (
+#        ((not (input_shape[2] % input_shard_shape[0] == 0)) or (not (input_shape[3] % input_shard_shape[1] == 0)))
+#        and (not (data_transfer_strategy == DirectReadWriteType.READ_WRITE))
+#        and (not (input_sharded_memory_config_args["strategy"] == ttnn.ShardStrategy.HEIGHT))
+#    ):
+#        pytest.skip()
+#
+#    torch_input_tensor = torch.rand(input_shape, dtype=torch.bfloat16)
+#    input_shard_memory_config = ttnn.create_sharded_memory_config(
+#        input_shard_shape, **input_sharded_memory_config_args, use_height_and_width_as_shard_shape=True
+#    )
+#
+#    if data_transfer_strategy == DirectReadWriteType.READ_ONLY or data_transfer_strategy == DirectReadWriteType.NONE:
+#        interleaved_input_tensor = ttnn.from_torch(
+#            torch_input_tensor, layout=ttnn.TILE_LAYOUT, device=device, memory_config=ttnn.DRAM_MEMORY_CONFIG
+#        )
+#        # interleaved_to_sharded
+#        sharded_input_tensor = ttnn.to_memory_config(interleaved_input_tensor, input_shard_memory_config)
+#    else:
+#        sharded_input_tensor = ttnn.from_torch(
+#            torch_input_tensor, layout=ttnn.TILE_LAYOUT, device=device, memory_config=input_shard_memory_config
+#        )
+#
+#    if data_transfer_strategy == DirectReadWriteType.WRITE_ONLY or data_transfer_strategy == DirectReadWriteType.NONE:
+#        # sharded_to_interleaved
+#        interleaved_output_tensor = ttnn.to_memory_config(sharded_input_tensor, ttnn.DRAM_MEMORY_CONFIG)
+#        output = ttnn.to_torch(interleaved_output_tensor)
+#    else:
+#        output = ttnn.to_torch(sharded_input_tensor)
+#
+#    assert_with_pcc(torch_input_tensor, output, 1.0)
+#
+#
+# @pytest.mark.parametrize(
+#    "shape, strategy, orientation, core_grid",
+#    [
+#        ([1, 1, 1024, 1024], ttnn.ShardStrategy.WIDTH, ttnn.ShardOrientation.ROW_MAJOR, ttnn.CoreGrid(y=2, x=2)),
+#        ([1, 1, 1024, 1024], ttnn.ShardStrategy.HEIGHT, ttnn.ShardOrientation.ROW_MAJOR, ttnn.CoreGrid(y=2, x=2)),
+#        ([1, 1, 1024, 1024], ttnn.ShardStrategy.BLOCK, ttnn.ShardOrientation.ROW_MAJOR, ttnn.CoreGrid(y=2, x=2)),
+#        ([1, 1, 1024, 1024], ttnn.ShardStrategy.WIDTH, ttnn.ShardOrientation.COL_MAJOR, ttnn.CoreGrid(y=2, x=2)),
+#        ([1, 1, 1024, 1024], ttnn.ShardStrategy.HEIGHT, ttnn.ShardOrientation.COL_MAJOR, ttnn.CoreGrid(y=2, x=2)),
+#        ([1, 1, 1024, 1024], ttnn.ShardStrategy.BLOCK, ttnn.ShardOrientation.COL_MAJOR, ttnn.CoreGrid(y=2, x=2)),
+#        ([1, 1, 128, 1024], ttnn.ShardStrategy.BLOCK, ttnn.ShardOrientation.ROW_MAJOR, ttnn.CoreGrid(y=2, x=4)),
+#        ([1, 1, 1024, 128], ttnn.ShardStrategy.BLOCK, ttnn.ShardOrientation.COL_MAJOR, ttnn.CoreGrid(y=4, x=2)),
+#    ],
+# )
+# def test_create_sharded_memory_config(device, shape, strategy, orientation, core_grid):
+#    input_data = torch.randn(shape, dtype=torch.bfloat16)
+#    x = ttnn.from_torch(
+#        input_data,
+#        device=device,
+#        layout=ttnn.TILE_LAYOUT,
+#        memory_config=ttnn.L1_MEMORY_CONFIG,
+#        dtype=ttnn.bfloat16,
+#    )
+#    shard_config = ttnn.create_sharded_memory_config(
+#        shape=shape,
+#        core_grid=core_grid,
+#        strategy=strategy,
+#        orientation=orientation,
+#        use_height_and_width_as_shard_shape=False,
+#    )
+#
+#    x_t = ttnn.to_memory_config(x, memory_config=shard_config, dtype=ttnn.bfloat16)
+#    output_data = ttnn.from_device(x_t)
+#    output_data = ttnn.to_torch(output_data)
+#
+#    passing = torch.equal(input_data, output_data)
+#    assert passing
+#

--- a/tt_eager/tensor/tensor.cpp
+++ b/tt_eager/tensor/tensor.cpp
@@ -828,7 +828,7 @@ Tensor create_device_tensor(
         }
 
         auto element_size = tensor_impl::element_size_bytes(data_type);
-        auto page_shape = tensor_impl::get_sharded_page_shape(layout, data_type, shard_spec.shape);
+        auto page_shape = tensor_impl::get_sharded_page_shape(layout, data_type, shard_spec.shape[1]);
         std::array<uint32_t, 2> tensor2d_size = {other_dims / page_shape[0], width / page_shape[1]};
         ShardSpecBuffer shard_spec_buffer(shard_spec, page_shape, tensor2d_size);
         uint32_t packed_size_in_bytes =

--- a/tt_eager/tensor/tensor_impl.cpp
+++ b/tt_eager/tensor/tensor_impl.cpp
@@ -86,12 +86,12 @@ uint32_t get_page_size(DataType dtype, Layout layout, uint32_t total_size_bytes,
     return page_size;
 }
 
-std::array<uint32_t, 2> get_sharded_page_shape(Layout layout, DataType dtype, std::array<uint32_t, 2> shard_shape) {
+std::array<uint32_t, 2> get_sharded_page_shape(Layout layout, DataType dtype, uint32_t width) {
     // Physical limitation in FD for now
     switch (layout) {
         case Layout::ROW_MAJOR:
             // TODO: Explore valid page shapes other than 1,W
-            return {1, shard_shape[1]};
+            return {1, width};
         case Layout::TILE: return {constants::TILE_HEIGHT, constants::TILE_WIDTH};
         default: TT_THROW("Unsupported layout to write to device");
     }
@@ -875,7 +875,7 @@ Tensor to_device(
 
     std::optional<ShardSpecBuffer> shard_spec_buffer_opt = std::nullopt;
     if (memory_config.is_sharded()) {
-        auto page_shape = get_sharded_page_shape(layout, data_type, memory_config.shard_spec.value().shape);
+        auto page_shape = get_sharded_page_shape(layout, data_type, memory_config.shard_spec.value().shape[1]);
 
         auto width = shape[-1];
         auto other_dims = 1;

--- a/tt_eager/tensor/tensor_impl.hpp
+++ b/tt_eager/tensor/tensor_impl.hpp
@@ -24,7 +24,7 @@ namespace tt_metal {
 
 namespace tensor_impl {
 
-std::array<uint32_t, 2> get_sharded_page_shape(Layout layout, DataType dtype, std::array<uint32_t, 2> shard_shape);
+std::array<uint32_t, 2> get_sharded_page_shape(Layout layout, DataType dtype, uint32_t width=32);
 
 // -----------------------------------------------------------------------------------------------------------------------------------------------
 // ===============================================================================================================================================

--- a/tt_eager/tt_dnn/op_library/sharded/kernels/dataflow/reshard_reader.cpp
+++ b/tt_eager/tt_dnn/op_library/sharded/kernels/dataflow/reshard_reader.cpp
@@ -4,7 +4,6 @@
 
 #include <stdint.h>
 #include "dataflow_api.h"
-#include "debug/dprint.h"
 
 void kernel_main() {
 	constexpr uint32_t shard_cb = get_compile_time_arg_val(0);
@@ -21,8 +20,7 @@ void kernel_main() {
 	const uint32_t output_page_offset = get_arg_val<uint32_t>(arg_index++);
 
 
-	uint32_t l1_write_base_addr = get_write_ptr(shard_cb) + output_page_offset * page_size;
-	uint32_t l1_write_addr = l1_write_base_addr + output_page_offset * page_size;
+	uint32_t l1_write_addr = get_write_ptr(shard_cb) + output_page_offset * page_size;
 
 	uint32_t mask_byte = 0x0ff; //8 bits
 	uint32_t mask_short = 0x0ffff; //16 bits
@@ -51,23 +49,12 @@ void kernel_main() {
 		uint32_t core_id_x_index = start_x_index;
 		uint32_t core_id_y_index = start_y_index;
 
-		DPRINT << "STRIDE SIZE " << stride_size << ENDL();
-		DPRINT << "BASE INPUT SHARD ADDR " << HEX() << input_shard_addr << DEC() << ENDL();
-		DPRINT << "PAGE SIZE " << page_size << ENDL();
-		DPRINT << "SHARD CB " << shard_cb << ENDL();
-		DPRINT << "WRITE BASE ADDR " << HEX() << l1_write_base_addr << DEC() << ENDL();
-		DPRINT << "WRITE OFFSET " << HEX() << output_page_offset * page_size << DEC() << ENDL();
 		for(uint32_t stride_idx = 0; stride_idx < num_strides; stride_idx++) {
 			if(!skip) {
 				uint32_t core_id_x = get_arg_val<uint32_t>(core_id_x_index);
 				uint32_t core_id_y = get_arg_val<uint32_t>(y_offset + core_id_y_index);
 				uint64_t noc_address = get_noc_addr(core_id_x, core_id_y,
 						input_shard_addr + addr_offset);
-				DPRINT << "READING STRIDE " << stride_idx << ENDL();
-				DPRINT << "CORE_ID_X_INDEX " << core_id_x_index << " CORE_ID_Y_INDEX " << core_id_y_index << ENDL();
-				DPRINT << "CORE_ID_X " << core_id_x << " CORE_ID_Y " << core_id_y << ENDL();
-				DPRINT << "ADDR OFFSET " << HEX() << addr_offset << DEC() << ENDL();
-				DPRINT << "L1 WRITE ADDR " << HEX() << l1_write_addr << ENDL();
 				noc_async_read(noc_address, l1_write_addr, stride_size);
 				l1_write_addr+=stride_size;
 			}

--- a/tt_eager/tt_dnn/op_library/sharded/kernels/dataflow/reshard_reader.cpp
+++ b/tt_eager/tt_dnn/op_library/sharded/kernels/dataflow/reshard_reader.cpp
@@ -4,6 +4,7 @@
 
 #include <stdint.h>
 #include "dataflow_api.h"
+#include "debug/dprint.h"
 
 void kernel_main() {
 	constexpr uint32_t shard_cb = get_compile_time_arg_val(0);
@@ -20,7 +21,8 @@ void kernel_main() {
 	const uint32_t output_page_offset = get_arg_val<uint32_t>(arg_index++);
 
 
-	uint32_t l1_write_addr = get_write_ptr(shard_cb) + output_page_offset * page_size;
+	uint32_t l1_write_base_addr = get_write_ptr(shard_cb) + output_page_offset * page_size;
+	uint32_t l1_write_addr = l1_write_base_addr + output_page_offset * page_size;
 
 	uint32_t mask_byte = 0x0ff; //8 bits
 	uint32_t mask_short = 0x0ffff; //16 bits
@@ -49,12 +51,23 @@ void kernel_main() {
 		uint32_t core_id_x_index = start_x_index;
 		uint32_t core_id_y_index = start_y_index;
 
+		DPRINT << "STRIDE SIZE " << stride_size << ENDL();
+		DPRINT << "BASE INPUT SHARD ADDR " << HEX() << input_shard_addr << DEC() << ENDL();
+		DPRINT << "PAGE SIZE " << page_size << ENDL();
+		DPRINT << "SHARD CB " << shard_cb << ENDL();
+		DPRINT << "WRITE BASE ADDR " << HEX() << l1_write_base_addr << DEC() << ENDL();
+		DPRINT << "WRITE OFFSET " << HEX() << output_page_offset * page_size << DEC() << ENDL();
 		for(uint32_t stride_idx = 0; stride_idx < num_strides; stride_idx++) {
 			if(!skip) {
 				uint32_t core_id_x = get_arg_val<uint32_t>(core_id_x_index);
 				uint32_t core_id_y = get_arg_val<uint32_t>(y_offset + core_id_y_index);
 				uint64_t noc_address = get_noc_addr(core_id_x, core_id_y,
 						input_shard_addr + addr_offset);
+				DPRINT << "READING STRIDE " << stride_idx << ENDL();
+				DPRINT << "CORE_ID_X_INDEX " << core_id_x_index << " CORE_ID_Y_INDEX " << core_id_y_index << ENDL();
+				DPRINT << "CORE_ID_X " << core_id_x << " CORE_ID_Y " << core_id_y << ENDL();
+				DPRINT << "ADDR OFFSET " << HEX() << addr_offset << DEC() << ENDL();
+				DPRINT << "L1 WRITE ADDR " << HEX() << l1_write_addr << ENDL();
 				noc_async_read(noc_address, l1_write_addr, stride_size);
 				l1_write_addr+=stride_size;
 			}

--- a/tt_eager/tt_dnn/op_library/sharded/kernels/dataflow/reshard_reader_stick_diff_width.cpp
+++ b/tt_eager/tt_dnn/op_library/sharded/kernels/dataflow/reshard_reader_stick_diff_width.cpp
@@ -7,6 +7,38 @@
 #include "debug/dprint.h"
 
 
+inline void print_stride(
+					uint32_t local_addr,
+					uint32_t stride_size) {
+
+  	volatile tt_l1_ptr uint16_t* ptr = reinterpret_cast<volatile tt_l1_ptr uint16_t*>(local_addr);
+	for(uint32_t i=0; i< stride_size/2; i++) {
+		uint32_t num = (uint32_t)ptr[0];
+		num = num << 16;
+ 				float * f_ptr = reinterpret_cast<float *>(&num);
+		DPRINT << f_ptr[0] << " ";
+		ptr++;
+	}
+	DPRINT << ENDL();
+}
+
+inline void read_print_stride(uint32_t input_shard_addr,
+					uint32_t scratch_pad_addr,
+					uint32_t core_x,
+					uint32_t core_y,
+					uint32_t addr_offset,
+					uint32_t stride_size) {
+	uint64_t noc_address = get_noc_addr(core_x, core_y,
+						input_shard_addr + addr_offset);
+	noc_async_read(noc_address, scratch_pad_addr, stride_size);
+	noc_async_read_barrier();
+	print_stride(scratch_pad_addr, stride_size);
+
+
+}
+
+
+
 void kernel_main() {
 	constexpr uint32_t shard_cb = get_compile_time_arg_val(0);
 	constexpr uint32_t num_x_cores = get_compile_time_arg_val(1);
@@ -27,7 +59,7 @@ void kernel_main() {
 	const uint32_t output_page_offset = get_arg_val<uint32_t>(arg_index++);
 
 	uint32_t l1_write_base_addr = get_write_ptr(shard_cb);
-	uint32_t l1_write_addr = l1_write_base_addr + output_page_offset * (page_size + output_page_allignment);
+	uint32_t l1_write_addr = l1_write_base_addr + output_page_offset * (page_size);
 
 	uint32_t mask_byte = 0x0ff; //8 bits
 	uint32_t mask_short = 0x0ffff; //16 bits
@@ -35,6 +67,17 @@ void kernel_main() {
 	uint32_t scratch_pad_base_addr = get_write_ptr(temp_cb);
 
 
+	//DPRINT << "PRINTING SHARD ON CORE (0,0)" << ENDL();
+	//read_print_stride(input_shard_addr, scratch_pad_base_addr, 1, 4, 0, 16);
+
+
+	DPRINT << "PAGE SIZE " << page_size << ENDL();
+	DPRINT << "INPUT PAGE SIZE " << input_page_size << ENDL();
+	DPRINT << "OUTPUT PAGE SIZE " << output_page_size << ENDL();
+	DPRINT << "INPUT PAGE ALLIGNMENT " << input_page_allignment << ENDL();
+	DPRINT << "OUTPUT PAGE ALLIGNMENT " << output_page_allignment << ENDL();
+	DPRINT << "NUM RANGES " << num_ranges << ENDL();
+	DPRINT << "OUTPUT PAGE OFFSET " << output_page_offset << ENDL();
 	for(uint32_t range_id = 0; range_id <num_ranges; range_id++) {
 		const uint32_t core_start_stride = get_arg_val<uint32_t>(arg_index++);
 		const uint32_t start_x_index = (core_start_stride >> 24);
@@ -52,9 +95,10 @@ void kernel_main() {
 
 		const uint32_t stride_data = ((stride_data_offset >> 16)) * page_size;
 
-		uint32_t input_addr_offset = ((stride_data_offset) & mask_short) * (page_size + input_page_allignment);
+		uint32_t input_addr_offset = ((stride_data_offset) & mask_short) * (page_size);
 		const uint32_t num_pages_per_stride = (stride_size_num_strides_skip >> 16);
 		const uint32_t stride_size = num_pages_per_stride * page_size;
+		DPRINT << "NUM PAGES PER STRIDE " << num_pages_per_stride << ENDL();
 
 		uint32_t core_id_x_index = start_x_index;
 		uint32_t core_id_y_index = start_y_index;
@@ -64,18 +108,23 @@ void kernel_main() {
 			uint32_t num_input_iterations = num_strides;
 			uint32_t total_data_read = 0;
 
+			DPRINT << "TOTAL INPUT ITERATIONS " << num_input_iterations << ENDL();
 			//Reads input stride at a time into scratchpad
 			for(uint32_t stride_idx = 0; stride_idx < num_input_iterations ; stride_idx++) {
 				uint32_t core_id_x = get_arg_val<uint32_t>(core_id_x_index);
 				uint32_t core_id_y = get_arg_val<uint32_t>(y_offset + core_id_y_index);
 				uint64_t noc_address = get_noc_addr(core_id_x, core_id_y,
 						input_shard_addr + input_addr_offset);
+				DPRINT << "ADDR OFFSET " << HEX() << input_addr_offset << DEC() << ENDL();
+				DPRINT << "STRIDE SIZE " << stride_size << ENDL();
+				DPRINT << "CORE_ID_X " << core_id_x << ENDL();
+				DPRINT << "CORE_ID_Y " << core_id_x << ENDL();
 				noc_async_read(noc_address, scratch_pad_addr, stride_size);
 				noc_async_read_barrier();
 				scratch_pad_addr += stride_size;
 
 				if(stride_x == 0 and stride_y == 0) {
-					input_addr_offset += (stride_data + stride_size + input_page_allignment);
+					input_addr_offset += (stride_data + stride_size);
 				}
 				else {
 					input_addr_offset += (stride_data);
@@ -87,18 +136,33 @@ void kernel_main() {
 			noc_async_read_barrier();
 
 
+			DPRINT << "TOTAL DATA READ " << total_data_read << ENDL();
+			DPRINT << "FLOATS IN SCRATCH PAD INPUT ROW ";
+			print_stride(scratch_pad_base_addr, total_data_read);
+
+
 			//At this point entire shard is in scratchpad
-			uint32_t num_output_pages_in_range = total_data_read/output_page_size;
-			scratch_pad_addr = scratch_pad_base_addr;
-			uint32_t num_output_iterations = num_output_pages_in_range;
-			//writes output from scratchpad , output row at a time
-			for(uint32_t stride_idx = 0; stride_idx < num_output_iterations; stride_idx++) {
-				//local copy from scratchpad to output shard
-				noc_async_read(get_noc_addr(scratch_pad_addr), l1_write_addr, output_page_size);
-				l1_write_addr += (output_page_size + output_page_allignment);
-				scratch_pad_addr += output_page_size;
+
+			if(output_page_size < page_size){
+				uint32_t num_output_pages_in_range = total_data_read/output_page_size;
+				scratch_pad_addr = scratch_pad_base_addr;
+				uint32_t num_output_iterations = num_output_pages_in_range;
+				//writes output from scratchpad , output row at a time
+				for(uint32_t stride_idx = 0; stride_idx < num_output_iterations; stride_idx++) {
+					//local copy from scratchpad to output shard
+					noc_async_read(get_noc_addr(scratch_pad_addr), l1_write_addr, output_page_size);
+					l1_write_addr += (output_page_size);
+					scratch_pad_addr += output_page_size;
+					DPRINT << "FLOATS IN OUTPUT ROW " << ENDL();
+					print_stride(l1_write_addr, output_page_size);
+				}
+				noc_async_read_barrier();
 			}
-			noc_async_read_barrier();
+			else {
+				noc_async_read(get_noc_addr(scratch_pad_base_addr), l1_write_addr, total_data_read);
+				DPRINT << "FLOATS IN OUTPUT ROW " << ENDL();
+				print_stride(l1_write_addr, total_data_read);
+			}
 		}
 
 	}

--- a/tt_eager/tt_dnn/op_library/sharded/kernels/dataflow/reshard_reader_stick_diff_width.cpp
+++ b/tt_eager/tt_dnn/op_library/sharded/kernels/dataflow/reshard_reader_stick_diff_width.cpp
@@ -6,6 +6,7 @@
 #include "dataflow_api.h"
 #include "debug/dprint.h"
 
+
 void kernel_main() {
 	constexpr uint32_t shard_cb = get_compile_time_arg_val(0);
 	constexpr uint32_t num_x_cores = get_compile_time_arg_val(1);
@@ -13,7 +14,9 @@ void kernel_main() {
 	constexpr uint32_t page_size = get_compile_time_arg_val(3);
 	constexpr uint32_t input_page_size = get_compile_time_arg_val(4);
 	constexpr uint32_t output_page_size = get_compile_time_arg_val(5);
-	constexpr uint32_t temp_cb = get_compile_time_arg_val(6);
+	constexpr uint32_t input_page_allignment = get_compile_time_arg_val(6);
+	constexpr uint32_t output_page_allignment = get_compile_time_arg_val(7);
+	constexpr uint32_t temp_cb = get_compile_time_arg_val(8);
 
 	uint32_t y_offset = num_x_cores;
 
@@ -23,23 +26,14 @@ void kernel_main() {
 	const uint32_t num_ranges = get_arg_val<uint32_t>(arg_index++);
 	const uint32_t output_page_offset = get_arg_val<uint32_t>(arg_index++);
 
-	uint32_t input_stride_allignment = 16;
-
 	uint32_t l1_write_base_addr = get_write_ptr(shard_cb);
-	uint32_t l1_write_addr = l1_write_base_addr + output_page_offset * page_size;
+	uint32_t l1_write_addr = l1_write_base_addr + output_page_offset * (page_size + output_page_allignment);
 
 	uint32_t mask_byte = 0x0ff; //8 bits
 	uint32_t mask_short = 0x0ffff; //16 bits
 
-	DPRINT << "IN RESHARD READER STICK DIFF WIDTH with  " <<  num_ranges << " ranges " << ENDL();
-	DPRINT << "Num x cores  " <<  num_x_cores << ENDL();
-	DPRINT << "Num y cores  " <<  num_x_cores << ENDL();
-	DPRINT << "Input shard addr  " << HEX() <<  input_shard_addr << DEC() << ENDL();
-	DPRINT << "num output pages " <<  num_output_pages << ENDL();
-	DPRINT << "INPUT PAGE SIZE " << input_page_size << ENDL();
-	DPRINT << "OUTPUT PAGE SIZE " << output_page_size << ENDL();
-	DPRINT << "NUM RANGES " << num_ranges << ENDL();
 	uint32_t scratch_pad_base_addr = get_write_ptr(temp_cb);
+
 
 	for(uint32_t range_id = 0; range_id <num_ranges; range_id++) {
 		const uint32_t core_start_stride = get_arg_val<uint32_t>(arg_index++);
@@ -57,102 +51,54 @@ void kernel_main() {
 
 
 		const uint32_t stride_data = ((stride_data_offset >> 16)) * page_size;
-		const uint32_t offset = ((stride_data_offset) & mask_short) * (page_size + input_stride_allignment);
+
+		uint32_t input_addr_offset = ((stride_data_offset) & mask_short) * (page_size + input_page_allignment);
 		const uint32_t num_pages_per_stride = (stride_size_num_strides_skip >> 16);
 		const uint32_t stride_size = num_pages_per_stride * page_size;
 
-		uint32_t addr_offset = offset;
 		uint32_t core_id_x_index = start_x_index;
 		uint32_t core_id_y_index = start_y_index;
 
-		DPRINT << "STRIDE SIZE " << stride_size << ENDL();
-		DPRINT << "BASE INPUT SHARD ADDR " << HEX() << input_shard_addr << DEC() << ENDL();
-		DPRINT << "PAGE SIZE " << page_size << ENDL();
-		DPRINT << "SHARD CB " << shard_cb << ENDL();
-		DPRINT << "WRITE BASE ADDR " << HEX() << l1_write_base_addr << DEC() << ENDL();
-		DPRINT << "WRITE OFFSET " << HEX() << output_page_offset * page_size << DEC() << ENDL();
-		DPRINT << "STRIDE DATA " << stride_data << ENDL();
-		DPRINT << "STRIDE X " << stride_x << ENDL();
-		DPRINT << "STRIDE Y " << stride_y << ENDL();
 		uint32_t scratch_pad_addr = scratch_pad_base_addr;
 		if(!skip) {
-			DPRINT << "FIRST CASE " << ENDL();
-			//uint32_t num_input_iterations = num_strides * num_output_pages;
 			uint32_t num_input_iterations = num_strides;
-			DPRINT << "NUM INPUT ITERATIONS " << num_input_iterations << ENDL();
 			uint32_t total_data_read = 0;
+
+			//Reads input stride at a time into scratchpad
 			for(uint32_t stride_idx = 0; stride_idx < num_input_iterations ; stride_idx++) {
 				uint32_t core_id_x = get_arg_val<uint32_t>(core_id_x_index);
 				uint32_t core_id_y = get_arg_val<uint32_t>(y_offset + core_id_y_index);
 				uint64_t noc_address = get_noc_addr(core_id_x, core_id_y,
-						input_shard_addr + addr_offset);
-				DPRINT << "READING STRIDE " << stride_idx << ENDL();
-				DPRINT << "CORE_ID_X_INDEX " << core_id_x_index << " CORE_ID_Y_INDEX " << core_id_y_index << ENDL();
-				DPRINT << "CORE_ID_X " << core_id_x << " CORE_ID_Y " << core_id_y << ENDL();
-				DPRINT << "ADDR OFFSET " << HEX() << addr_offset << DEC() << ENDL();
-				//need to do this if the input or output page width is diff and has diff alignment
-				DPRINT << "READING ADDR " << HEX() << (noc_address) << DEC() << ENDL();
-				DPRINT << "SCRATCH ADDR " << HEX() << scratch_pad_addr << DEC() << ENDL();
-				noc_async_read(noc_address, scratch_pad_addr, input_page_size);
+						input_shard_addr + input_addr_offset);
+				noc_async_read(noc_address, scratch_pad_addr, stride_size);
 				noc_async_read_barrier();
-   				volatile tt_l1_ptr uint16_t* ptr = reinterpret_cast<volatile tt_l1_ptr uint16_t*>(scratch_pad_addr);
-				DPRINT << "FLOATS IN SCRATCH PAD INPUT ROW ";
-				for(uint32_t i=0; i< input_page_size/2; i++) {
-					uint32_t num = (uint32_t)ptr[0];
-					num = num << 16;
-   					float * f_ptr = reinterpret_cast<float *>(&num);
-					DPRINT << f_ptr[0] << " ";
-					ptr++;
-				}
-				DPRINT << ENDL();
-
-
-				scratch_pad_addr += input_page_size;
+				scratch_pad_addr += stride_size;
 
 				if(stride_x == 0 and stride_y == 0) {
-					addr_offset += (stride_data + stride_size + input_stride_allignment);
+					input_addr_offset += (stride_data + stride_size + input_page_allignment);
 				}
 				else {
-					addr_offset += (stride_data);
+					input_addr_offset += (stride_data);
 				}
 				core_id_x_index += stride_x;
 				core_id_y_index += stride_y;
 				total_data_read+=stride_size;
 			}
 			noc_async_read_barrier();
+
+
+			//At this point entire shard is in scratchpad
 			uint32_t num_output_pages_in_range = total_data_read/output_page_size;
 			scratch_pad_addr = scratch_pad_base_addr;
 			uint32_t num_output_iterations = num_output_pages_in_range;
+			//writes output from scratchpad , output row at a time
 			for(uint32_t stride_idx = 0; stride_idx < num_output_iterations; stride_idx++) {
 				//local copy from scratchpad to output shard
-				DPRINT << "WRITING ADDR " << HEX() << (l1_write_addr) << DEC() << ENDL();
-				DPRINT << "SCRATCH ADDR " << HEX() << scratch_pad_addr << DEC() << ENDL();
 				noc_async_read(get_noc_addr(scratch_pad_addr), l1_write_addr, output_page_size);
-				DPRINT << "FLOATS IN SCRATCH PAD OUTPUT ROW ";
-   				volatile tt_l1_ptr uint16_t* ptr = reinterpret_cast<volatile tt_l1_ptr uint16_t*>(scratch_pad_addr);
-				for(uint32_t i=0; i< output_page_size/2; i++) {
-					uint32_t num = (uint32_t)ptr[0];
-					num = num << 16;
-   					float * f_ptr = reinterpret_cast<float *>(&num);
-					DPRINT << f_ptr[0] << " ";
-					ptr++;
-
-				}
-				DPRINT << ENDL();
-				noc_async_read_barrier();
-				DPRINT << "FLOATS IN  OUTPUT ROW ";
-   				volatile tt_l1_ptr uint16_t* ptr2= reinterpret_cast<volatile tt_l1_ptr uint16_t*>(l1_write_addr);
-				for(uint32_t i=0; i< output_page_size/2; i++) {
-					uint32_t num = (uint32_t)ptr2[0];
-					num = num << 16;
-   					float * f_ptr = reinterpret_cast<float *>(&num);
-					DPRINT << f_ptr[0] << " ";
-					ptr++;
-
-				}
-				l1_write_addr += output_page_size;
+				l1_write_addr += (output_page_size + output_page_allignment);
 				scratch_pad_addr += output_page_size;
 			}
+			noc_async_read_barrier();
 		}
 
 	}

--- a/tt_eager/tt_dnn/op_library/sharded/kernels/dataflow/reshard_reader_stick_diff_width.cpp
+++ b/tt_eager/tt_dnn/op_library/sharded/kernels/dataflow/reshard_reader_stick_diff_width.cpp
@@ -1,0 +1,161 @@
+// SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <stdint.h>
+#include "dataflow_api.h"
+#include "debug/dprint.h"
+
+void kernel_main() {
+	constexpr uint32_t shard_cb = get_compile_time_arg_val(0);
+	constexpr uint32_t num_x_cores = get_compile_time_arg_val(1);
+	constexpr uint32_t num_y_cores = get_compile_time_arg_val(2);
+	constexpr uint32_t page_size = get_compile_time_arg_val(3);
+	constexpr uint32_t input_page_size = get_compile_time_arg_val(4);
+	constexpr uint32_t output_page_size = get_compile_time_arg_val(5);
+	constexpr uint32_t temp_cb = get_compile_time_arg_val(6);
+
+	uint32_t y_offset = num_x_cores;
+
+	uint32_t arg_index = num_x_cores + num_y_cores;
+	const uint32_t input_shard_addr  = get_arg_val<uint32_t>(arg_index++);
+	const uint32_t num_output_pages = get_arg_val<uint32_t>(arg_index++);
+	const uint32_t num_ranges = get_arg_val<uint32_t>(arg_index++);
+	const uint32_t output_page_offset = get_arg_val<uint32_t>(arg_index++);
+
+	uint32_t input_stride_allignment = 16;
+
+	uint32_t l1_write_base_addr = get_write_ptr(shard_cb);
+	uint32_t l1_write_addr = l1_write_base_addr + output_page_offset * page_size;
+
+	uint32_t mask_byte = 0x0ff; //8 bits
+	uint32_t mask_short = 0x0ffff; //16 bits
+
+	DPRINT << "IN RESHARD READER STICK DIFF WIDTH with  " <<  num_ranges << " ranges " << ENDL();
+	DPRINT << "Num x cores  " <<  num_x_cores << ENDL();
+	DPRINT << "Num y cores  " <<  num_x_cores << ENDL();
+	DPRINT << "Input shard addr  " << HEX() <<  input_shard_addr << DEC() << ENDL();
+	DPRINT << "num output pages " <<  num_output_pages << ENDL();
+	DPRINT << "INPUT PAGE SIZE " << input_page_size << ENDL();
+	DPRINT << "OUTPUT PAGE SIZE " << output_page_size << ENDL();
+	DPRINT << "NUM RANGES " << num_ranges << ENDL();
+	uint32_t scratch_pad_base_addr = get_write_ptr(temp_cb);
+
+	for(uint32_t range_id = 0; range_id <num_ranges; range_id++) {
+		const uint32_t core_start_stride = get_arg_val<uint32_t>(arg_index++);
+		const uint32_t start_x_index = (core_start_stride >> 24);
+		const uint32_t start_y_index = (core_start_stride >> 16) & mask_byte;
+		const uint32_t stride_x = (core_start_stride >> 8) & mask_byte;
+		const uint32_t stride_y = (core_start_stride) & mask_byte;
+		const uint32_t start_x = get_arg_val<uint32_t>(start_x_index);
+		const uint32_t start_y = get_arg_val<uint32_t>(y_offset + start_y_index);
+
+		const uint32_t stride_data_offset = get_arg_val<uint32_t>(arg_index++);
+		const uint32_t stride_size_num_strides_skip = get_arg_val<uint32_t>(arg_index++);
+		const uint32_t num_strides = ((stride_size_num_strides_skip) & mask_short) >> 8;
+		const bool skip = (((stride_size_num_strides_skip) & mask_byte)  == 1);
+
+
+		const uint32_t stride_data = ((stride_data_offset >> 16)) * page_size;
+		const uint32_t offset = ((stride_data_offset) & mask_short) * (page_size + input_stride_allignment);
+		const uint32_t num_pages_per_stride = (stride_size_num_strides_skip >> 16);
+		const uint32_t stride_size = num_pages_per_stride * page_size;
+
+		uint32_t addr_offset = offset;
+		uint32_t core_id_x_index = start_x_index;
+		uint32_t core_id_y_index = start_y_index;
+
+		DPRINT << "STRIDE SIZE " << stride_size << ENDL();
+		DPRINT << "BASE INPUT SHARD ADDR " << HEX() << input_shard_addr << DEC() << ENDL();
+		DPRINT << "PAGE SIZE " << page_size << ENDL();
+		DPRINT << "SHARD CB " << shard_cb << ENDL();
+		DPRINT << "WRITE BASE ADDR " << HEX() << l1_write_base_addr << DEC() << ENDL();
+		DPRINT << "WRITE OFFSET " << HEX() << output_page_offset * page_size << DEC() << ENDL();
+		DPRINT << "STRIDE DATA " << stride_data << ENDL();
+		DPRINT << "STRIDE X " << stride_x << ENDL();
+		DPRINT << "STRIDE Y " << stride_y << ENDL();
+		uint32_t scratch_pad_addr = scratch_pad_base_addr;
+		if(!skip) {
+			DPRINT << "FIRST CASE " << ENDL();
+			//uint32_t num_input_iterations = num_strides * num_output_pages;
+			uint32_t num_input_iterations = num_strides;
+			DPRINT << "NUM INPUT ITERATIONS " << num_input_iterations << ENDL();
+			uint32_t total_data_read = 0;
+			for(uint32_t stride_idx = 0; stride_idx < num_input_iterations ; stride_idx++) {
+				uint32_t core_id_x = get_arg_val<uint32_t>(core_id_x_index);
+				uint32_t core_id_y = get_arg_val<uint32_t>(y_offset + core_id_y_index);
+				uint64_t noc_address = get_noc_addr(core_id_x, core_id_y,
+						input_shard_addr + addr_offset);
+				DPRINT << "READING STRIDE " << stride_idx << ENDL();
+				DPRINT << "CORE_ID_X_INDEX " << core_id_x_index << " CORE_ID_Y_INDEX " << core_id_y_index << ENDL();
+				DPRINT << "CORE_ID_X " << core_id_x << " CORE_ID_Y " << core_id_y << ENDL();
+				DPRINT << "ADDR OFFSET " << HEX() << addr_offset << DEC() << ENDL();
+				//need to do this if the input or output page width is diff and has diff alignment
+				DPRINT << "READING ADDR " << HEX() << (noc_address) << DEC() << ENDL();
+				DPRINT << "SCRATCH ADDR " << HEX() << scratch_pad_addr << DEC() << ENDL();
+				noc_async_read(noc_address, scratch_pad_addr, input_page_size);
+				noc_async_read_barrier();
+   				volatile tt_l1_ptr uint16_t* ptr = reinterpret_cast<volatile tt_l1_ptr uint16_t*>(scratch_pad_addr);
+				DPRINT << "FLOATS IN SCRATCH PAD INPUT ROW ";
+				for(uint32_t i=0; i< input_page_size/2; i++) {
+					uint32_t num = (uint32_t)ptr[0];
+					num = num << 16;
+   					float * f_ptr = reinterpret_cast<float *>(&num);
+					DPRINT << f_ptr[0] << " ";
+					ptr++;
+				}
+				DPRINT << ENDL();
+
+
+				scratch_pad_addr += input_page_size;
+
+				if(stride_x == 0 and stride_y == 0) {
+					addr_offset += (stride_data + stride_size + input_stride_allignment);
+				}
+				else {
+					addr_offset += (stride_data);
+				}
+				core_id_x_index += stride_x;
+				core_id_y_index += stride_y;
+				total_data_read+=stride_size;
+			}
+			noc_async_read_barrier();
+			uint32_t num_output_pages_in_range = total_data_read/output_page_size;
+			scratch_pad_addr = scratch_pad_base_addr;
+			uint32_t num_output_iterations = num_output_pages_in_range;
+			for(uint32_t stride_idx = 0; stride_idx < num_output_iterations; stride_idx++) {
+				//local copy from scratchpad to output shard
+				DPRINT << "WRITING ADDR " << HEX() << (l1_write_addr) << DEC() << ENDL();
+				DPRINT << "SCRATCH ADDR " << HEX() << scratch_pad_addr << DEC() << ENDL();
+				noc_async_read(get_noc_addr(scratch_pad_addr), l1_write_addr, output_page_size);
+				DPRINT << "FLOATS IN SCRATCH PAD OUTPUT ROW ";
+   				volatile tt_l1_ptr uint16_t* ptr = reinterpret_cast<volatile tt_l1_ptr uint16_t*>(scratch_pad_addr);
+				for(uint32_t i=0; i< output_page_size/2; i++) {
+					uint32_t num = (uint32_t)ptr[0];
+					num = num << 16;
+   					float * f_ptr = reinterpret_cast<float *>(&num);
+					DPRINT << f_ptr[0] << " ";
+					ptr++;
+
+				}
+				DPRINT << ENDL();
+				noc_async_read_barrier();
+				DPRINT << "FLOATS IN  OUTPUT ROW ";
+   				volatile tt_l1_ptr uint16_t* ptr2= reinterpret_cast<volatile tt_l1_ptr uint16_t*>(l1_write_addr);
+				for(uint32_t i=0; i< output_page_size/2; i++) {
+					uint32_t num = (uint32_t)ptr2[0];
+					num = num << 16;
+   					float * f_ptr = reinterpret_cast<float *>(&num);
+					DPRINT << f_ptr[0] << " ";
+					ptr++;
+
+				}
+				l1_write_addr += output_page_size;
+				scratch_pad_addr += output_page_size;
+			}
+		}
+
+	}
+	noc_async_read_barrier();
+
+}

--- a/tt_eager/tt_dnn/op_library/sharded/multi_core/sharded_op_multi_core.cpp
+++ b/tt_eager/tt_dnn/op_library/sharded/multi_core/sharded_op_multi_core.cpp
@@ -613,9 +613,7 @@ inline std::tuple<uint32_t, uint32_t, std::unordered_map<CoreCoord, std::vector<
     uint32_t total_size =  output_shard_spec.tensor_shard_spec.numel() / TILE_HW * page_width;
     if(input.get_layout() == Layout::ROW_MAJOR and (input_buffer->shard_spec().page_shape[1] != output_buffer->shard_spec().page_shape[1])) {
 
-        std::cout << "In Diff width section with widths of input: " << input_buffer->shard_spec().page_shape[1]  << " and output: " << output_buffer->shard_spec().page_shape[1] << std::endl;
         page_width = get_greatest_common_factor(input_buffer->shard_spec().page_shape[1], output_buffer->shard_spec().page_shape[1]);
-        std::cout << "Page width returned is " << page_width << std::endl;
         std::array<uint32_t, 2> page_shape = {1, page_width};
 
         auto shape = input.get_legacy_shape();
@@ -625,12 +623,10 @@ inline std::tuple<uint32_t, uint32_t, std::unordered_map<CoreCoord, std::vector<
             other_dims *= shape[i];
         }
         std::array<uint32_t,2> tensor2d_size = {other_dims/page_shape[0], width/page_shape[1]};
-        std::cout << "Tensor2D size is: " << tensor2d_size[0] << ", " << tensor2d_size[1] << std::endl;
         tensor2d_shape_page_shape_override = {tensor2d_size, page_shape};
         input_shard_spec = ShardSpecBuffer(input_shard_spec.tensor_shard_spec, tensor2d_shape_page_shape_override.value()[1], tensor2d_shape_page_shape_override.value()[0]);
         output_shard_spec = ShardSpecBuffer(output_shard_spec.tensor_shard_spec, tensor2d_shape_page_shape_override.value()[1], tensor2d_shape_page_shape_override.value()[0]);
         input_num_host_pages_multiplier = input_buffer->shard_spec().page_shape[1] / page_width;
-        std::cout << "Input num host pages multiplier is " << input_num_host_pages_multiplier << std::endl;
         total_size = output_shard_shape[0] * output_shard_shape[1];
     }
     else if (input.get_layout() == Layout::ROW_MAJOR){
@@ -643,38 +639,38 @@ inline std::tuple<uint32_t, uint32_t, std::unordered_map<CoreCoord, std::vector<
     auto output_buffer_page_mapping = generate_buffer_page_mapping(*output_buffer, tensor2d_shape_page_shape_override);
     auto input_buffer_page_mapping = generate_buffer_page_mapping(*input_buffer, tensor2d_shape_page_shape_override);
 
-    std::cout << "Input Mapping " << std::endl;
-    uint32_t dev_page_idx = 0;
-    for(auto _host_page : input_buffer_page_mapping.dev_page_to_host_page_mapping_) {
-        if(_host_page.has_value()) {
-            std::cout << "dev_page [" << dev_page_idx  << "]=" << _host_page.value() << std::endl;;
-        }
-        else {
-            std::cout << "dev_page [" << dev_page_idx  << "] = NULL " << std::endl;
-        }
-        dev_page_idx++;
-    }
-    uint32_t host_page_idx = 0;
-    for(auto _dev_page : input_buffer_page_mapping.host_page_to_dev_page_mapping_) {
-        std::cout << "host_page [" << host_page_idx  << "]=" << _dev_page << std::endl;
-        host_page_idx++;
-    }
-    std::cout << "Output Mapping " << std::endl;
-    dev_page_idx = 0;
-    for(auto _host_page : output_buffer_page_mapping.dev_page_to_host_page_mapping_) {
-        if(_host_page.has_value()) {
-            std::cout << "dev_page [" << dev_page_idx  << "]=" << _host_page.value() << std::endl;;
-        }
-        else {
-            std::cout << "dev_page [" << dev_page_idx  << "] = NULL " << std::endl;
-        }
-        dev_page_idx++;
-    }
-    host_page_idx = 0;
-    for(auto _dev_page : output_buffer_page_mapping.host_page_to_dev_page_mapping_) {
-        std::cout << "host_page [" << host_page_idx  << "]=" << _dev_page << std::endl;;
-        host_page_idx++;
-    }
+//    std::cout << "Input Mapping " << std::endl;
+//    uint32_t dev_page_idx = 0;
+//    for(auto _host_page : input_buffer_page_mapping.dev_page_to_host_page_mapping_) {
+//        if(_host_page.has_value()) {
+//            std::cout << "dev_page [" << dev_page_idx  << "]=" << _host_page.value() << std::endl;;
+//        }
+//        else {
+//            std::cout << "dev_page [" << dev_page_idx  << "] = NULL " << std::endl;
+//        }
+//        dev_page_idx++;
+//    }
+//    uint32_t host_page_idx = 0;
+//    for(auto _dev_page : input_buffer_page_mapping.host_page_to_dev_page_mapping_) {
+//        std::cout << "host_page [" << host_page_idx  << "]=" << _dev_page << std::endl;
+//        host_page_idx++;
+//    }
+//    std::cout << "Output Mapping " << std::endl;
+//    dev_page_idx = 0;
+//    for(auto _host_page : output_buffer_page_mapping.dev_page_to_host_page_mapping_) {
+//        if(_host_page.has_value()) {
+//            std::cout << "dev_page [" << dev_page_idx  << "]=" << _host_page.value() << std::endl;;
+//        }
+//        else {
+//            std::cout << "dev_page [" << dev_page_idx  << "] = NULL " << std::endl;
+//        }
+//        dev_page_idx++;
+//    }
+//    host_page_idx = 0;
+//    for(auto _dev_page : output_buffer_page_mapping.host_page_to_dev_page_mapping_) {
+//        std::cout << "host_page [" << host_page_idx  << "]=" << _dev_page << std::endl;;
+//        host_page_idx++;
+//    }
 
     const auto& output_shard_to_host_mapping = output_buffer_page_mapping.dev_page_to_host_page_mapping_;
     const auto& input_page_to_local_page_mapping = input_buffer_page_mapping.host_page_to_local_shard_page_mapping_;
@@ -719,13 +715,13 @@ inline std::tuple<uint32_t, uint32_t, std::unordered_map<CoreCoord, std::vector<
         const auto end = input_cores_with_pages.end();
 
         uint32_t index = 0;
-        std::cout << "Printing Mappings for core " << output_core.str() << std::endl;
-        for (auto it: input_cores_with_pages) {
-            std::cout << "Output page " << index
-            << " maps to Core: " << it->first.str()
-            << " and page: " << it->second << std::endl;
-            index++;
-        }
+//        std::cout << "Printing Mappings for core " << output_core.str() << std::endl;
+//        for (auto it: input_cores_with_pages) {
+//            std::cout << "Output page " << index
+//            << " maps to Core: " << it->first.str()
+//            << " and page: " << it->second << std::endl;
+//            index++;
+//        }
 
         while (it != end) {
             // hit padding, will see how many consecutive pages has padding to make a padded range
@@ -902,21 +898,21 @@ inline std::tuple<uint32_t, uint32_t, std::unordered_map<CoreCoord, std::vector<
             }
         }
         output_core_id++;
-        std::cout << "CORE " << output_core.str() << " has " << ret_map[output_core].size() << " ranges " << std::endl;
-        uint32_t range_idx = 0;
-        for(auto range : ret_map.at(output_core)) {
-            std::cout << "RANGE " << range_idx
-                << " start_core_x: " << range.start_core.x
-                << " start_core_y: " << range.start_core.y
-                << " start_data: " << range.start_data
-                << " stride_size(pages): " << range.stride_size
-                << " num_reps: " << range.num_strides
-                << " stride_core_x:  " << range.stride.core.x
-                << " stride_core_y: " << range.stride.core.y
-                << " stride_data: " << range.stride.data
-                << std::endl;
-            range_idx++;
-        }
+        //std::cout << "CORE " << output_core.str() << " has " << ret_map[output_core].size() << " ranges " << std::endl;
+        //uint32_t range_idx = 0;
+        //for(auto range : ret_map.at(output_core)) {
+        //    std::cout << "RANGE " << range_idx
+        //        << " start_core_x: " << range.start_core.x
+        //        << " start_core_y: " << range.start_core.y
+        //        << " start_data: " << range.start_data
+        //        << " stride_size(pages): " << range.stride_size
+        //        << " num_reps: " << range.num_strides
+        //        << " stride_core_x:  " << range.stride.core.x
+        //        << " stride_core_y: " << range.stride.core.y
+        //        << " stride_data: " << range.stride.data
+        //        << std::endl;
+        //    range_idx++;
+        //}
     }
 
     return {total_size, page_width, ret_map};
@@ -1122,22 +1118,22 @@ operation::ProgramWithCallbacks reshard_multi_core_generic(const Tensor& input, 
     uint32_t max_page_size = page_size;
 
     auto input_buffer_page_mapping = generate_buffer_page_mapping(*input.buffer());
-    std::cout << " Input Buffer Addr " << std::hex << input.buffer()->address() << std::endl;
-    std::cout << " Input Buffer Page Size " << std::dec << input.buffer()->page_size() << std::endl;
-    std::cout << " Input Buffer Total Size " << std::dec << input.buffer()->size() << std::endl;
-    std::cout << " Input Buffer Num Dev Pages " << std::dec << input.buffer()->num_dev_pages() << std::endl;
-    std::cout << " Input Buffer Num Cores " << std::dec << input.buffer()->num_cores() << std::endl;
-    std::cout << "Input Buffer Cores: " << std::endl;
-    for(auto core: input_buffer_page_mapping.all_cores_) {
-        std::cout << core.str() << std::endl;
-    }
-    for (uint32_t dev_page_idx = 0; dev_page_idx < input.buffer()->num_dev_pages() ; dev_page_idx++)  {
-        auto core_idx = input_buffer_page_mapping.dev_page_to_core_mapping_[dev_page_idx];
-        std::cout << "Input Buffer Dev_page[" << dev_page_idx
-            << "] on Core " << input_buffer_page_mapping.all_cores_[core_idx].str()
-            <<  " with local page " << input_buffer_page_mapping.dev_page_to_local_shard_page_mapping_[dev_page_idx]
-            << std::endl;
-    }
+//    std::cout << " Input Buffer Addr " << std::hex << input.buffer()->address() << std::endl;
+//    std::cout << " Input Buffer Page Size " << std::dec << input.buffer()->page_size() << std::endl;
+//    std::cout << " Input Buffer Num Dev Pages " << std::dec << input.buffer()->num_dev_pages() << std::endl;
+//    std::cout << " Input Buffer Total Size " << std::dec << input.buffer()->size() << std::endl;
+//    std::cout << " Input Buffer Num Cores " << std::dec << input.buffer()->num_cores() << std::endl;
+//    std::cout << "Input Buffer Cores: " << std::endl;
+//    for(auto core: input_buffer_page_mapping.all_cores_) {
+//        std::cout << core.str() << std::endl;
+//    }
+//    for (uint32_t dev_page_idx = 0; dev_page_idx < input.buffer()->num_dev_pages() ; dev_page_idx++)  {
+//        auto core_idx = input_buffer_page_mapping.dev_page_to_core_mapping_[dev_page_idx];
+//        std::cout << "Input Buffer Dev_page[" << dev_page_idx
+//            << "] on Core " << input_buffer_page_mapping.all_cores_[core_idx].str()
+//            <<  " with local page " << input_buffer_page_mapping.dev_page_to_local_shard_page_mapping_[dev_page_idx]
+//            << std::endl;
+//    }
     uint32_t input_page_size = input_shard_spec.shape[1] * input.element_size();
     uint32_t output_page_size = output_shard_spec.shape[1] * output.element_size();
 
@@ -1172,7 +1168,7 @@ operation::ProgramWithCallbacks reshard_multi_core_generic(const Tensor& input, 
                                             output_page_size, /*5*/
                                             input_page_allignment, /*6*/
                                             output_page_allignment, /*7*/
-                                            tmp_cb_index_0 /*8*/
+                                            tmp_cb_index_0, /*8*/
                                             }));
 
         kernel_id_1 = tt_metal::CreateKernel(
@@ -1188,10 +1184,8 @@ operation::ProgramWithCallbacks reshard_multi_core_generic(const Tensor& input, 
                                             output_page_size,
                                             input_page_allignment, /*6*/
                                             output_page_allignment, /*7*/
-                                            tmp_cb_index_1
+                                            tmp_cb_index_1,
                                             }));
-        std::cout << "output shard size " << output_shard_size << " output page size " << output_page_size << " output rows per shard " << output_rows_per_shard << std::endl;
-        std::cout << "Making CBs with total size " << total_size << " and page size " << page_size << std::endl;
         tt_metal::CircularBufferConfig cb_tmp_config_0 =
         tt_metal::CircularBufferConfig(total_size, {{tmp_cb_index_0, data_format}})
             .set_page_size(tmp_cb_index_0, page_size);

--- a/tt_eager/tt_dnn/op_library/sharded/multi_core/sharded_op_multi_core.cpp
+++ b/tt_eager/tt_dnn/op_library/sharded/multi_core/sharded_op_multi_core.cpp
@@ -778,14 +778,14 @@ inline std::tuple<uint32_t, uint32_t, std::unordered_map<CoreCoord, std::vector<
                             break;
                         }
                         // next page is padding
-                        consecutive_it = consecutive_it + 1;
                         last_it_consec = consecutive_it;
+                        consecutive_it = consecutive_it + 1;
                     }
-                    uint32_t stride_size = std::distance(it, last_it_consec);
-                    if (last_it_consec == it) {
-                        stride_size = 1;
-                    }
-                    auto stride_it = it + stride_size;
+                    uint32_t stride_size = std::distance(it, last_it_consec) + 1;
+                    //if (last_it_consec == it) {
+                    //    stride_size = 1;
+                    //}
+                    auto stride_it = it + (stride_size);
                     auto last_it_stride = it;
 
                     // TT_ASSERT((stride_it == end) or stride_it->has_value());
@@ -803,7 +803,7 @@ inline std::tuple<uint32_t, uint32_t, std::unordered_map<CoreCoord, std::vector<
                             auto prev_input_page = *(last_it_stride);
                             TT_ASSERT(prev_input_page.has_value());
                             TT_ASSERT(next_input_page.has_value());
-                            data_stride = next_input_page.value().second - prev_input_page.value().second - stride_size;
+                            data_stride = next_input_page.value().second - prev_input_page.value().second;
                             stride = Stride{.core = {0, 0}, .data = data_stride};
                         }
                         // strided core but same data

--- a/tt_eager/tt_dnn/op_library/sharded/sharded_op.cpp
+++ b/tt_eager/tt_dnn/op_library/sharded/sharded_op.cpp
@@ -86,10 +86,7 @@ void Reshard::validate_with_output_tensors(const std::vector<Tensor>& input_tens
     const auto& out_mem_config = has_output_tensor ? output_tensors[0].value().memory_config() : this->output_mem_config;
     TT_FATAL(out_mem_config.is_sharded(), "output must be sharded");
     TT_FATAL(out_mem_config.buffer_type == BufferType::L1);
-    if(input_tensor.get_layout() == Layout::ROW_MAJOR) {
-        bool same_row_size = input_tensor.memory_config().shard_spec.value().shape[1] == out_mem_config.shard_spec.value().shape[1];
-        TT_FATAL(same_row_size, "row major must have shard_spec[1] be the same on both input and output");
-    }
+
 }
 
 std::vector<Shape> Reshard::compute_output_shapes(const std::vector<Tensor>& input_tensors) const {

--- a/tt_metal/impl/buffers/buffer.cpp
+++ b/tt_metal/impl/buffers/buffer.cpp
@@ -142,16 +142,9 @@ BufferPageMapping generate_buffer_page_mapping(const Buffer &buffer, std::option
         auto tensor2d_shape = tensor2d_shape_page_shape_override.value()[0];
         shard_spec = ShardSpecBuffer(shard_spec.tensor_shard_spec, page_shape, tensor2d_shape);
         num_pages_multiplier = buffer.shard_spec().page_shape[1] / shard_spec.page_shape[1];
-        std::cout << "TENSOR OVERRIDE HAS VALUE " << std::endl;
     }
-    else {
-        std::cout << "No override " << std::endl;
-    }
+
     auto row_major = shard_spec.orientation() == ShardOrientation::ROW_MAJOR;
-    std::cout << "Generate Buffer_page mapping " << std::endl;
-    std::cout << "num_pages_multiplier " << num_pages_multiplier << std::endl;
-    std::cout << "shard_spec.page_shape " << shard_spec.page_shape[0] << " , " << shard_spec.page_shape[1] << std::endl;
-    std::cout << "shard_spec.tensor2d_shape " << shard_spec.tensor2d_shape[0] << " , " << shard_spec.tensor2d_shape[1] << std::endl;
 
     BufferPageMapping buffer_page_mapping;
     uint32_t num_cores = buffer.num_cores();
@@ -206,8 +199,6 @@ BufferPageMapping generate_buffer_page_mapping(const Buffer &buffer, std::option
             }
         }
     }
-    std::cout << "Num host pages seen: " << num_host_pages_seen << std::endl;
-    std::cout << "Num host pages: " << num_host_pages << std::endl;
     TT_ASSERT(num_host_pages_seen == num_host_pages);
     return buffer_page_mapping;
 }

--- a/tt_metal/impl/buffers/buffer.hpp
+++ b/tt_metal/impl/buffers/buffer.hpp
@@ -267,7 +267,7 @@ class Buffer {
     std::optional<ShardSpecBuffer> shard_parameters_;
 };
 
-BufferPageMapping generate_buffer_page_mapping(const Buffer &buffer);
+BufferPageMapping generate_buffer_page_mapping(const Buffer &buffer, std::optional<std::array <std::array<uint32_t, 2>, 2> > tensor2d_shape_page_shape_override = std::nullopt);
 
 namespace detail {
 using PageAddress = uint32_t;

--- a/tt_metal/impl/buffers/buffer.hpp
+++ b/tt_metal/impl/buffers/buffer.hpp
@@ -147,6 +147,7 @@ struct BufferPageMapping {
     std::unordered_map<CoreCoord, uint32_t> core_to_core_id_;
     std::vector<uint32_t> host_page_to_local_shard_page_mapping_;
     std::vector<std::array<uint32_t, 2>> core_shard_shape_;
+    std::vector<uint32_t> dev_page_to_local_shard_page_mapping_;
 };
 
 class Buffer {

--- a/ttnn/cpp/ttnn/op_library/to_memory_config/to_memory_config_op.hpp
+++ b/ttnn/cpp/ttnn/op_library/to_memory_config/to_memory_config_op.hpp
@@ -54,9 +54,9 @@ struct ToMemoryConfig {
                 const auto input_memory_config = ttnn::get_memory_config(tensor);
                 const auto input_shard_spec = input_memory_config.value().shard_spec.value();
                 const auto output_shard_spec = memory_config.shard_spec.value();
-<<<<<<< HEAD
-                if (tensor.get_layout() == ttnn::TILE_LAYOUT ||
-                    input_shard_spec.shape[1] == output_shard_spec.shape[1]) {
+                if (tensor.get_layout() == ttnn::TILE_LAYOUT or
+                    (input_shard_spec.shape[0] <= 32 and output_shard_spec.shape[0] <=32)
+                    ) {
                     if (dtype.has_value()) {
                         throw runtime_error(
                             "dtype cannot be specified when converting sharded tensor to sharded tensor");
@@ -68,8 +68,7 @@ struct ToMemoryConfig {
                                {tensor}, {}, {std::nullopt})
                         .at(0);
                 } else {
-                    // for row-major tensors where shard-spec[1] is different for input shard and output shard
-
+                    // tall row-major tensors generate a lot of runtime args, can be condensed in future PR
                     TT_FATAL(memory_config.is_sharded());
                     Tensor temp = operation::run(
                                       Sharded{
@@ -87,18 +86,7 @@ struct ToMemoryConfig {
                                    .output_dtype = dtype.value_or(temp.get_dtype())},
                                {temp})
                         .at(0);
-=======
-                if (dtype.has_value()) {
-                    throw runtime_error(
-                        "dtype cannot be specified when converting sharded tensor to sharded tensor");
->>>>>>> #0: WIP diff stick lengths
                 }
-                return operation::run(
-                           Reshard{
-                               .output_mem_config = memory_config,
-                           },
-                           {tensor})
-                    .at(0);
             } else {
                 auto bbox = memory_config.shard_spec.value().grid.bounding_box();
                 CoreCoord grid_size(bbox.end.x + 1, bbox.end.y + 1);

--- a/ttnn/cpp/ttnn/op_library/to_memory_config/to_memory_config_op.hpp
+++ b/ttnn/cpp/ttnn/op_library/to_memory_config/to_memory_config_op.hpp
@@ -54,6 +54,7 @@ struct ToMemoryConfig {
                 const auto input_memory_config = ttnn::get_memory_config(tensor);
                 const auto input_shard_spec = input_memory_config.value().shard_spec.value();
                 const auto output_shard_spec = memory_config.shard_spec.value();
+<<<<<<< HEAD
                 if (tensor.get_layout() == ttnn::TILE_LAYOUT ||
                     input_shard_spec.shape[1] == output_shard_spec.shape[1]) {
                     if (dtype.has_value()) {
@@ -86,7 +87,18 @@ struct ToMemoryConfig {
                                    .output_dtype = dtype.value_or(temp.get_dtype())},
                                {temp})
                         .at(0);
+=======
+                if (dtype.has_value()) {
+                    throw runtime_error(
+                        "dtype cannot be specified when converting sharded tensor to sharded tensor");
+>>>>>>> #0: WIP diff stick lengths
                 }
+                return operation::run(
+                           Reshard{
+                               .output_mem_config = memory_config,
+                           },
+                           {tensor})
+                    .at(0);
             } else {
                 auto bbox = memory_config.shard_spec.value().grid.bounding_box();
                 CoreCoord grid_size(bbox.end.x + 1, bbox.end.y + 1);


### PR DESCRIPTION
### Ticket
[Link to Github Issue](https://github.com/tenstorrent/tt-metal/issues/7071)

### Problem description
Reshard row major with different widths previously not supported. This is because the page width of the buffer is determined using the shard width, and then pages from input and output were not easily mapped. 

### What's changed
Used Greatest common factor to get common page width. That page-width needs to be 16B aligned to match L1 alignment. Then with common page size can map input and output pages. Also need extra logic to add padding for page-widths that are not 32B aligned. 

### Checklist
- [ ] Post commit CI passes (in progress)
- [ ] Model regression CI testing passes (if applicable)
- [x] New/Existing tests provide coverage for changes
