### PR TITLE
#0: Add ttnn/cpp to packages to enable using ttnn kernels in tt_eager ops

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -174,7 +174,7 @@ class CMakeBuild(build_ext):
 # Include tt_metal_C for kernels and src/ and tools
 # And any kernels inside `tt_eager/tt_dnn. We must keep all ops kernels inside
 # tt_dnn
-packages = ["tt_lib", "tt_metal", "tt_lib.models", "tt_eager.tt_dnn", "ttnn"]
+packages = ["tt_lib", "tt_metal", "tt_lib.models", "tt_eager.tt_dnn", "ttnn", "ttnn.cpp"]
 
 # Empty sources in order to force extension executions
 eager_lib_C = Extension("tt_lib._C", sources=[])
@@ -199,6 +199,7 @@ setup(
         "tt_lib.models": "models",
         "tt_eager.tt_dnn": "tt_eager/tt_dnn",
         "ttnn": "ttnn/ttnn",
+        "ttnn.cpp": "ttnn/cpp",
     },
     include_package_data=True,
     long_description_content_type="text/markdown",


### PR DESCRIPTION
### Ticket
[Link to Github Issue](https://github.com/tenstorrent/tt-metal/issues/9322)

### Problem description
To reduce code duplication during port for `tt_eager` ops to `ttnn`, we want to reuse new `ttnn` kernels from `tt_eager` ops.

### What's changed
Add `ttnn/cpp` to packages.

### Checklist
- [x] Post commit CI passes
  - python wheel: https://github.com/tenstorrent/tt-metal/actions/runs/9704371694
  - all post-commit: https://github.com/tenstorrent/tt-metal/actions/runs/9704373357
  - ttnn unit-tests: https://github.com/tenstorrent/tt-metal/actions/runs/9704382532
- [ ] Model regression CI testing passes (if applicable)
- [ ] New/Existing tests provide coverage for changes
