### PR TITLE
#0: Use CV to wait for cq_reader in production mode. Remove enqueue_record_event for NB calls

### DIFF
--- a/tests/tt_metal/tools/profiler/test_device_profiler.py
+++ b/tests/tt_metal/tools/profiler/test_device_profiler.py
@@ -145,12 +145,12 @@ def test_dispatch_cores():
     ZONE_COUNT = 37
     REF_COUNT_DICT = {
         "grayskull": {
-            "Tensix CQ Dispatch": 33,
-            "Tensix CQ Prefetch": 36,
+            "Tensix CQ Dispatch": 18,
+            "Tensix CQ Prefetch": 21,
         },
         "wormhole_b0": {
-            "Tensix CQ Dispatch": 33,
-            "Tensix CQ Prefetch": 36,
+            "Tensix CQ Dispatch": 18,
+            "Tensix CQ Prefetch": 21,
         },
     }
 

--- a/tests/tt_metal/tt_metal/unit_tests_fast_dispatch/command_queue/test_events.cpp
+++ b/tests/tt_metal/tt_metal/unit_tests_fast_dispatch/command_queue/test_events.cpp
@@ -40,9 +40,9 @@ TEST_F(CommandQueueFixture, TestEventsDataMovementWrittenToCompletionQueueInOrde
             buffers.push_back(std::make_shared<Buffer>(this->device_, page_size, page_size, BufferType::DRAM));
 
             if (data_movement_mode == DataMovementMode::WRITE) {
-                EnqueueWriteBuffer(this->device_->command_queue(), buffers.back(), page, false);
+                EnqueueWriteBuffer(this->device_->command_queue(), buffers.back(), page, true);
             } else if (data_movement_mode == DataMovementMode::READ) {
-                EnqueueReadBuffer(this->device_->command_queue(), buffers.back(), page, false);
+                EnqueueReadBuffer(this->device_->command_queue(), buffers.back(), page, true);
             }
         }
         Finish(this->device_->command_queue());
@@ -280,7 +280,7 @@ TEST_F(CommandQueueFixture, TestEventsMixedWriteBufferRecordWaitSynchronize) {
         EXPECT_EQ(event->event_id, cmds_issued_per_cq);
 
         std::shared_ptr<Buffer> buf = std::make_shared<Buffer>(this->device_, page_size, page_size, BufferType::DRAM);
-        EnqueueWriteBuffer(this->device_->command_queue(), buf, page, false);
+        EnqueueWriteBuffer(this->device_->command_queue(), buf, page, true);
         EnqueueWaitForEvent(this->device_->command_queue(), event);
 
         if (i % 10 == 0) {

--- a/tt_metal/impl/dispatch/command_queue.hpp
+++ b/tt_metal/impl/dispatch/command_queue.hpp
@@ -528,6 +528,8 @@ class HWCommandQueue {
     std::condition_variable reader_thread_cv;
     std::mutex reader_thread_cv_mutex;
 
+    std::condition_variable reads_processed_cv;
+    std::mutex reads_processed_cv_mutex;
     CoreType get_dispatch_core_type();
 
     void copy_into_user_space(


### PR DESCRIPTION
### Ticket
Link to Github Issue

### Problem description
Issuing a `record_event` when making non-blocking calls leads to bad perf in async mode, since the Completion Queue Reader and Worker Threads are bound to the same CPU core. 

Similarly, a while loop in `finish` (polling the Completion Queue Reader status) is bad, due to worker polling CQ reader and CQ reader polling device. 

### What's changed

Remove `record_event` calls, since they're not needed for functionality.

Have CQ reader poll device and send an interrupt to worker thread, using condition vars. No more double polling, and worker thread yields CPU while waiting.

### Checklist
- [x] Post commit CI passes
- [ ] Model regression CI testing passes (if applicable)
- [ ] New/Existing tests provide coverage for changes
