### PR TITLE
#9479: Update Mixtral perf estimates

### DIFF
--- a/models/demos/t3000/mixtral8x7b/tests/test_mixtral_perf.py
+++ b/models/demos/t3000/mixtral8x7b/tests/test_mixtral_perf.py
@@ -43,10 +43,10 @@ class Emb(torch.nn.Module):
 @pytest.mark.parametrize(
     "generation_start_pos, expected_compile_time, expected_inference_time",
     (
-        (32, 150, 0.058),  # FIXME: Perf regression (issue #9479)
-        (128, 150, 0.058),  # FIXME: Perf regression (issue #9479)
-        (1024, 150, 0.058),  # FIXME: Perf regression (issue #9479)
-        (2048, 150, 0.058),  # FIXME: Perf regression (issue #9479)
+        (32, 150, 0.075),
+        (128, 150, 0.075),
+        (1024, 150, 0.075),
+        (2048, 150, 0.075),
     ),
 )
 def test_mixtral_model_perf(
@@ -61,7 +61,7 @@ def test_mixtral_model_perf(
 
     # Can use dummy_weights=True correctness is not tested, but it is much slower
     model_args = TtModelArgs(t3k_device_mesh.get_device(0), dummy_weights=False)
-    model_args.n_layers = 1
+    model_args.n_layers = 32
 
     # Clear global profiler state before starting measurements
     profiler.clear()

--- a/tests/scripts/t3000/run_t3000_model_perf_tests.sh
+++ b/tests/scripts/t3000/run_t3000_model_perf_tests.sh
@@ -22,7 +22,7 @@ run_t3000_mixtral_tests() {
 
   echo "LOG_METAL: Running run_t3000_mixtral_tests"
 
-  env pytest models/demos/t3000/mixtral8x7b/tests/test_mixtral_perf.py::test_mixtral_model_perf[wormhole_b0-True-2048-150-0.058] -m "model_perf_t3000"
+  env pytest models/demos/t3000/mixtral8x7b/tests/test_mixtral_perf.py -m "model_perf_t3000"
 
   # Record the end time
   end_time=$(date +%s)

--- a/tests/scripts/t3000/run_t3000_unit_tests.sh
+++ b/tests/scripts/t3000/run_t3000_unit_tests.sh
@@ -80,7 +80,6 @@ run_t3000_mixtral_tests() {
   pytest models/demos/t3000/mixtral8x7b/tests/test_mixtral_embedding.py
   pytest models/demos/t3000/mixtral8x7b/tests/test_mixtral_moe.py
   pytest models/demos/t3000/mixtral8x7b/tests/test_mixtral_decoder.py
-  pytest models/demos/t3000/mixtral8x7b/tests/test_mixtral_model.py::test_mixtral_model_inference[wormhole_b0-True-1-1-pcc]
 
   # Record the end time
   end_time=$(date +%s)
@@ -111,7 +110,7 @@ main() {
     echo "Script is being sourced, not executing main function"
     return 0
   fi
-  
+
   if [[ -z "$TT_METAL_HOME" ]]; then
     echo "Must provide TT_METAL_HOME in environment" 1>&2
     exit 1


### PR DESCRIPTION
Since the perf regression issue #9479 has been fixed, we've updated the Mixtral e2e perf estimates.

Additionally, to better detect perf regressions in the future I've changed the perf test to run for the full 32L instead of a single one, and to run all 4 KV-cache sizes.

One other minor change was the removal of the Mixtral model test from the T3k unit test pipeline, since this is already run on the frequent pipeline.

Looking at this [passing pipeline](https://github.com/tenstorrent/tt-metal/actions/runs/9701487113 ), we should expect the Mixtral perf tests to take around 13 min of CI time.


- I've kicked a new T3k Demo pipeline with all the tests included: https://github.com/tenstorrent/tt-metal/actions/runs/9711539065
- Pipeline with just the Mixtral perf test: https://github.com/tenstorrent/tt-metal/actions/runs/9701487113
- All post commit pipeline: https://github.com/tenstorrent/tt-metal/actions/runs/9711540251