### PR TITLE
Correctly resolve both tensor dimension and padding when calculating transposed tensor sizes

### DIFF
--- a/tests/tt_eager/CMakeLists.txt
+++ b/tests/tt_eager/CMakeLists.txt
@@ -37,6 +37,7 @@ set(TT_EAGER_TESTS_TENSORS
     tensors/test_raw_host_memory_pointer
     # tensors/test_sharded_loopback           # <- not called in run_tt_eager.py
     tensors/test_async_tensor_apis
+    tensors/test_transpose
 )
 
 set(TT_EAGER_TESTS_INTEGRATION

--- a/tests/tt_eager/tensors/test_transpose.cpp
+++ b/tests/tt_eager/tensors/test_transpose.cpp
@@ -1,0 +1,80 @@
+// SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <algorithm>
+#include <functional>
+#include <random>
+
+#include "common/bfloat16.hpp"
+#include "common/constants.hpp"
+#include "tensor/host_buffer/functions.hpp"
+#include "tensor/host_buffer/types.hpp"
+#include "tensor/tensor.hpp"
+#include "tensor/tensor_impl.hpp"
+#include "tt_metal/host_api.hpp"
+#include "tt_numpy/functions.hpp"
+#include "tt_eager/tt_dnn/op_library/tilize/tilize_op.hpp"
+#include "tt_eager/tt_dnn/op_library/transpose/transpose_op.hpp"
+
+using namespace tt;
+using namespace tt_metal;
+using namespace constants;
+
+bool test_tensor_transpose_non_tile_aligned(Device *device) {
+    bool pass = true;
+
+    const size_t tensor_width = 16;
+    const size_t tensor_height = 256;
+
+    auto buffer = tt::tt_metal::owned_buffer::create(
+        create_random_vector_of_bfloat16_native(
+            tensor_width * tensor_height * 2
+            , 2, 42, -1));
+    auto x = tt::tt_metal::Tensor(
+        OwnedStorage{std::move(buffer)},
+        {1, 1,tensor_width, tensor_height},
+        tt::tt_metal::DataType::BFLOAT16,
+        tt::tt_metal::Layout::ROW_MAJOR);
+    x = tt::tt_metal::tilize_with_zero_padding(x.to(device));
+
+
+    auto y = tt::tt_metal::transpose(x, 2, 3);
+    pass &= (y.shape()[0] == 1 && y.shape()[1] == 1 && y.shape()[2] == tensor_height && y.shape()[3] == tensor_width);
+
+    return pass;
+}
+
+
+int main(int argc, char **argv) {
+    bool pass = true;
+
+    try {
+
+        ////////////////////////////////////////////////////////////////////////////
+        //                      Device Setup
+        ////////////////////////////////////////////////////////////////////////////
+        int device_id = 0;
+        tt_metal::Device *device = tt_metal::CreateDevice(device_id);
+
+        pass &= test_tensor_transpose_non_tile_aligned(device);
+
+
+    } catch (const std::exception &e) {
+        pass = false;
+        // Capture the exception error message
+        log_error(LogTest, "{}", e.what());
+        // Capture system call errors that may have returned from driver/kernel
+        log_error(LogTest, "System error message: {}", std::strerror(errno));
+    }
+
+    if (pass) {
+        log_info(LogTest, "Test Passed");
+    } else {
+        TT_THROW("Test Failed");
+    }
+
+    TT_FATAL(pass);
+
+    return 0;
+}

--- a/tt_eager/tensor/types.cpp
+++ b/tt_eager/tensor/types.cpp
@@ -126,6 +126,10 @@ const Padding& Shape::padding() const {
     return this->padding_;
 }
 
+Padding& Shape::padding() {
+    return this->padding_;
+}
+
 const Shape Shape::without_padding() const {
     auto padding = this->padding_;
     std::vector<std::uint32_t> shape_without_padding;

--- a/tt_eager/tensor/types.hpp
+++ b/tt_eager/tensor/types.hpp
@@ -204,6 +204,7 @@ class Shape {
     const uint32_t *end() const;
 
     const Padding &padding() const;
+    Padding &padding();
     const Shape without_padding() const;
 
     const uint32_t get_normalized_index(std::int64_t index) const;

--- a/tt_eager/tt_dnn/op_library/transpose/transpose_op.cpp
+++ b/tt_eager/tt_dnn/op_library/transpose/transpose_op.cpp
@@ -57,33 +57,35 @@ void Transpose::validate(const std::vector<Tensor> &input_tensors) const {
 
 std::vector<Shape> Transpose::compute_output_shapes(const std::vector<Tensor> &input_tensors) const {
     const auto& input_tensor = input_tensors.at(0);
-    auto out_shape = input_tensor.get_legacy_shape();
+    Shape out_shape = input_tensor.get_legacy_shape();
+    Padding& padding = out_shape.padding();
     switch (this->dim){
         case TransposeOpDim::CN:
-            out_shape[0] = input_tensor.get_legacy_shape()[1];
-            out_shape[1] = input_tensor.get_legacy_shape()[0];
+            std::swap(out_shape[0], out_shape[1]);
+            std::swap(padding[0], padding[1]);
             break;
         case TransposeOpDim::HC:
-            out_shape[1] = input_tensor.get_legacy_shape()[2];
-            out_shape[2] = input_tensor.get_legacy_shape()[1];
+            std::swap(out_shape[1], out_shape[2]);
+            std::swap(padding[1], padding[2]);
             break;
         case TransposeOpDim::WH:
-            out_shape[2] = input_tensor.get_legacy_shape()[3];
-            out_shape[3] = input_tensor.get_legacy_shape()[2];
+            std::swap(out_shape[3], out_shape[2]);
+            std::swap(padding[3], padding[2]);
             break;
         case TransposeOpDim::NH:
-            out_shape[0] = input_tensor.get_legacy_shape()[2];
-            out_shape[2] = input_tensor.get_legacy_shape()[0];
+            std::swap(out_shape[2], out_shape[0]);
+            std::swap(padding[2], padding[0]);
             break;
         case TransposeOpDim::NW:
-            out_shape[3] = input_tensor.get_legacy_shape()[0];
-            out_shape[0] = input_tensor.get_legacy_shape()[3];
+            std::swap(out_shape[0], out_shape[3]);
+            std::swap(padding[0], padding[3]);
             break;
         case TransposeOpDim::CW:
-            out_shape[1] = input_tensor.get_legacy_shape()[3];
-            out_shape[3] = input_tensor.get_legacy_shape()[1];
+            std::swap(out_shape[1], out_shape[3]);
+            std::swap(padding[1], padding[3]);
             break;
     }
+
     return {out_shape};
 }
 


### PR DESCRIPTION
### Ticket
#9708 

### Problem description

During `Transpose::compute_output_shapes` only the tensor dimension size is swapped and the padding is not. This caused the resulting shape to not be correct most of the time less the dimensions happen to be a multiple of 32 or both dimensions had the exact same padding.

This bug has been a show stopper for me even looking into some of the operator support in GGML (not just matmul, I need it for other stuff). I decided to take my shot at it since the issue didn't get any attention.  I think I solved it.. but not familiar with TTNN internals to definitively say this is the correct solution.

Please let me know if I need to change something.

### What's changed

Padding is also swapped along with the dimension size.

### Checklist
- [x] Post commit CI [passes](https://github.com/tenstorrent/tt-metal/actions/runs/9717240585)
- [x] T3K [passes](https://github.com/tenstorrent/tt-metal/actions/runs/9717270337)
- [ ] New/Existing tests provide coverage for changes
