### PR TITLE
Modify rot mat each iteration to avoid allocating 10k tensors upfront

### DIFF
--- a/models/demos/t3000/mixtral8x7b/demo/demo.py
+++ b/models/demos/t3000/mixtral8x7b/demo/demo.py
@@ -227,7 +227,7 @@ def run_mixtral_demo(user_input, batch_size, device_mesh, instruct_mode):
             )
 
         # Run ttnn mixtral model
-        tt_out_11BH = tt_model(decode_input_11BH, start_pos, current_pos, attn_mask, rot_mats)
+        tt_out_11BH = tt_model(decode_input_11BH, start_pos, current_pos, attn_mask)
         # Work around program cache issue https://github.com/tenstorrent/tt-metal/issues/7159
         del decode_input_11BH, attn_mask
         if embed_on_host:

--- a/models/demos/t3000/mixtral8x7b/tests/test_mixtral_attention.py
+++ b/models/demos/t3000/mixtral8x7b/tests/test_mixtral_attention.py
@@ -61,7 +61,7 @@ def test_mixtral_attention_inference(t3k_device_mesh, use_program_cache, reset_s
             # tt_model.hidden_size,
             model_args.dim,
             start_pos,
-            model_args.sliding_window,
+            model_args,
             tt_model.device_mesh,
         )
 

--- a/models/demos/t3000/mixtral8x7b/tests/test_mixtral_decoder.py
+++ b/models/demos/t3000/mixtral8x7b/tests/test_mixtral_decoder.py
@@ -71,7 +71,7 @@ def test_mixtral_decoder_inference(t3k_device_mesh, use_program_cache, reset_see
             pt_decode_input_bsh,
             model_args.dim,
             start_pos,
-            model_args.sliding_window,
+            model_args,
             tt_model.device_mesh,
         )
         # Run TT model

--- a/models/demos/t3000/mixtral8x7b/tests/test_mixtral_model.py
+++ b/models/demos/t3000/mixtral8x7b/tests/test_mixtral_model.py
@@ -106,7 +106,7 @@ def test_mixtral_model_inference(
             tt_decode_input,
             model_args.dim,
             start_pos,
-            model_args.sliding_window,
+            model_args,
             tt_model.device_mesh,
         )
 

--- a/models/demos/t3000/mixtral8x7b/tests/test_mixtral_model.py
+++ b/models/demos/t3000/mixtral8x7b/tests/test_mixtral_model.py
@@ -19,7 +19,7 @@ if os.getenv("CI") == "true":
 import ttnn
 from ttnn import ReplicateTensorToMesh, ConcatMeshToTensor
 
-from models.demos.t3000.mixtral8x7b.tt.mixtral_common import prepare_inputs_ttnn, prepare_rotation_mat_ttnn
+from models.demos.t3000.mixtral8x7b.tt.mixtral_common import prepare_inputs_ttnn
 from models.demos.t3000.mixtral8x7b.tt.mixtral_model import TtTransformer
 from models.demos.t3000.mixtral8x7b.reference.model import Transformer
 from models.demos.t3000.mixtral8x7b.reference.tokenizer import Tokenizer
@@ -81,12 +81,6 @@ def test_mixtral_model_inference(
         dtype=dtype,
     )
 
-    rot_mat = prepare_rotation_mat_ttnn(
-        model_args.head_dim,
-        model_args.max_seq_len,
-        tt_model.device_mesh,
-    )
-
     generation_start_pos = 0
     generation_length = iterations
     all_tests_pass = True
@@ -117,7 +111,7 @@ def test_mixtral_model_inference(
         )
 
         # Run TT model
-        tt_out = tt_model(decode_input, start_pos, current_pos, attn_mask, rot_mat)
+        tt_out = tt_model(decode_input, start_pos, current_pos, attn_mask)
         # Work around program cache issue https://github.com/tenstorrent/tt-metal/issues/7159
         del decode_input, attn_mask
         # Convert ttnn tensor to torch tensor

--- a/models/demos/t3000/mixtral8x7b/tt/mixtral_attention.py
+++ b/models/demos/t3000/mixtral8x7b/tt/mixtral_attention.py
@@ -156,7 +156,7 @@ class TtMixtralAttention(LightweightModule):
         start_pos,
         current_pos,
         attn_masks,
-        rot_mats,
+        rot_mat,
     ):
         """
         x: (seq_len, 1, batch, hidden_dim)
@@ -176,7 +176,6 @@ class TtMixtralAttention(LightweightModule):
         x_11BH = xs
         wo = self.wo
         layer_past = self.layer_past
-        rot_mat = rot_mats[start_pos]
         attn_mask_1B4P = attn_masks
         ###
         # QKV matmuls

--- a/models/demos/t3000/mixtral8x7b/tt/mixtral_common.py
+++ b/models/demos/t3000/mixtral8x7b/tt/mixtral_common.py
@@ -88,9 +88,9 @@ def prepare_inputs_ttnn(x_bsh, hidden_size, current_pos, model_args, device_mesh
     attn_mask[:, :, :, current_pos + 1 :] = torch.finfo(attn_mask.dtype).min
 
     if model_args.dummy_weights:
-        cache_name = lambda _: None
+        cache_name = None
     else:
-        cache_name = lambda name: model_args.weight_cache_path(ttnn.bfloat4_b) / (f"attention_mask.{current_pos}")
+        cache_name = model_args.weight_cache_path(ttnn.bfloat4_b) / (f"attention_mask.{current_pos}")
 
     attn_mask = ttnn.as_tensor(
         attn_mask,
@@ -182,9 +182,9 @@ def cache_attention(device_mesh, state_dict, model_args, current_rot_mat, rot_ma
         pos = iter
 
         if model_args.dummy_weights:
-            cache_name = lambda _: None
+            cache_name = None
         else:
-            cache_name = lambda name: model_args.weight_cache_path(ttnn.bfloat4_b) / (f"attention_mask.{pos}")
+            cache_name = model_args.weight_cache_path(ttnn.bfloat4_b) / (f"attention_mask.{pos}")
 
         padded_layer_past_len = min(nearest_32(pos + 1), model_args.sliding_window)
         attn_mask = torch.zeros(1, 32, 32, padded_layer_past_len)  # [SB4P]

--- a/models/demos/t3000/mixtral8x7b/tt/mixtral_decoder.py
+++ b/models/demos/t3000/mixtral8x7b/tt/mixtral_decoder.py
@@ -76,7 +76,7 @@ class TtTransformerBlock(LightweightModule):
         start_pos,
         current_pos,
         attn_masks,
-        rot_mats,
+        rot_mat,
     ) -> ttnn.Tensor:
         """
         Tensors are postfixed with 4 characters that represent their 4-D shape:
@@ -92,7 +92,7 @@ class TtTransformerBlock(LightweightModule):
             start_pos,
             current_pos,
             attn_masks,
-            rot_mats,
+            rot_mat,
         )
         hs_1SBH = ttnn.add(xs_1SBH, attn_1SBH)
         ffn_norm_1SBH = self.ffn_norm(hs_1SBH)

--- a/models/demos/t3000/mixtral8x7b/tt/mixtral_model.py
+++ b/models/demos/t3000/mixtral8x7b/tt/mixtral_model.py
@@ -74,6 +74,7 @@ class TtTransformer(LightweightModule):
         attn_masks,
     ):
         if start_pos > 0:
+            # assigning to a new variable to explictly deallocate since matmul creates a new buffer for the output
             prev_rot_mat = self.current_rot_mat
             self.current_rot_mat = ttnn.linear(self.rot_matrix, prev_rot_mat)
             prev_rot_mat.deallocate(True)

--- a/models/demos/t3000/mixtral8x7b/tt/mixtral_model.py
+++ b/models/demos/t3000/mixtral8x7b/tt/mixtral_model.py
@@ -6,7 +6,7 @@ import ttnn
 from models.demos.t3000.mixtral8x7b.tt.mixtral_decoder import TtTransformerBlock
 from models.demos.t3000.mixtral8x7b.tt.mixtral_rms_norm import TtRMSNormSharded, TtRMSNorm
 from ttnn import ReplicateTensorToMesh
-from models.demos.t3000.mixtral8x7b.tt.mixtral_common import LightweightModule
+from models.demos.t3000.mixtral8x7b.tt.mixtral_common import LightweightModule, get_single_rot_mat
 
 
 class TtTransformer(LightweightModule):
@@ -64,16 +64,21 @@ class TtTransformer(LightweightModule):
 
         self.compute_kernel = self.args.get_compute_kernel_config()
 
+        self.current_rot_mat, self.rot_matrix = get_single_rot_mat(self.args.head_dim, device_mesh)
+
     def forward(
         self,
         x,
         start_pos,
         current_pos,
         attn_masks,
-        rot_mats,
     ):
+        if start_pos > 0:
+            prev_rot_mat = self.current_rot_mat
+            self.current_rot_mat = ttnn.linear(self.rot_matrix, prev_rot_mat)
+            prev_rot_mat.deallocate(True)
         for i, layer in enumerate(self.layers):
-            x = layer(x, start_pos, current_pos, attn_masks, rot_mats)
+            x = layer(x, start_pos, current_pos, attn_masks, self.current_rot_mat)
         attn_masks.deallocate(True)
 
         x_norm = self.norm(x)


### PR DESCRIPTION
### Ticket
#5337 

### Problem description
Modify rot mat each iteration to avoid allocating 10k tensors upfront

### What's changed
Initializing one rot_matrix and a transformation_matrix and then updating rot_matrix = transformation_matrix @ rot_matrix each iteration

### Checklist
- [ ] Post commit CI passes
- [ ] Model regression CI testing passes (if applicable)
- [ ] New/Existing tests provide coverage for changes
