### PR TITLE
Migrate Pad Host Code, Bindings, C++ Usages from TT Eager to TTNN

### DIFF
--- a/tt_eager/tt_dnn/op_library/auto_format.cpp
+++ b/tt_eager/tt_dnn/op_library/auto_format.cpp
@@ -8,7 +8,7 @@
 #include "tt_dnn/op_library/copy/copy_op.hpp"
 #include "tt_dnn/op_library/data_transfer/data_transfer_op.hpp"
 #include "tt_dnn/op_library/layout_conversion/layout_conversion_op.hpp"
-#include "tt_dnn/op_library/pad/pad_op.hpp"
+#include "ttnn/operations/data_movement/pad/pad.hpp"
 #include "tt_dnn/op_library/tilize/tilize_op.hpp"
 #include "tt_dnn/op_library/transpose/transpose_op.hpp"
 #include "tt_dnn/op_library/unpad/unpad_op.hpp"
@@ -93,14 +93,14 @@ Tensor AutoFormat::format_input_tensor(
             }
         } else if (!convert_layout && pad_input) {
             if (formatted_input.get_layout() == Layout::ROW_MAJOR || formatted_input.get_layout() == Layout::TILE) {
-                return pad(formatted_input, padded_shape, {0, 0, 0, 0}, pad_value, mem_config);
+                return ttnn::pad((const ttnn::Tensor) formatted_input, ttnn::Shape(padded_shape), ttnn::Shape({0, 0, 0, 0}), pad_value, mem_config);
             }
         } else if (convert_layout && pad_input) {
             if (formatted_input.get_layout() == Layout::ROW_MAJOR && target_layout == Layout::TILE) {
                 return tilize_with_val_padding(formatted_input, padded_shape, pad_value, mem_config);
             } else if (formatted_input.get_layout() == Layout::TILE && target_layout == Layout::ROW_MAJOR) {
                 formatted_input = untilize(formatted_input, mem_config);
-                return pad(formatted_input, padded_shape, {0, 0, 0, 0}, pad_value, mem_config);
+                return ttnn::pad((const ttnn::Tensor) formatted_input, ttnn::Shape(padded_shape), ttnn::Shape({0, 0, 0, 0}), pad_value, mem_config);
             }
         }
         // Fall back to host conversions

--- a/tt_eager/tt_dnn/op_library/backward/backward_ops.cpp
+++ b/tt_eager/tt_dnn/op_library/backward/backward_ops.cpp
@@ -1607,17 +1607,11 @@ std::vector<Tensor> _prod_bw(
     // dim 0
     Tensor tensor_1_temp = reciprocal_input;
     if (reciprocal_input.get_legacy_shape()[0] % 32 != 0) {
-        const Shape start_index = {0, 0, 0, 0};
-        const Shape required_shape = {
-            reciprocal_input.get_legacy_shape()[0] + (32 - (reciprocal_input.get_legacy_shape()[0] % 32)),
-            reciprocal_input.get_legacy_shape()[1],
-            reciprocal_input.get_legacy_shape()[2],
-            reciprocal_input.get_legacy_shape()[3]};
         std::vector<std::pair<uint32_t, uint32_t>> padding = {{0, 0},
                       {0, 32 - (reciprocal_input.get_legacy_shape()[0] % 32)},
                       {0, 0},
                       {0, 0}};
-        tensor_1_temp = ttnn::pad(reciprocal_input, padding, 0, std::nullopt);
+        tensor_1_temp = ttnn::pad(reciprocal_input, padding, 0,  std::nullopt);
     }
     std::vector<int64_t> after_permute_dims = {3, 1, 2, 0};
     Tensor tensor_1 = permute(tensor_1_temp, after_permute_dims, output_mem_config);

--- a/tt_eager/tt_dnn/op_library/backward/backward_ops.cpp
+++ b/tt_eager/tt_dnn/op_library/backward/backward_ops.cpp
@@ -1607,8 +1607,8 @@ std::vector<Tensor> _prod_bw(
     // dim 0
     Tensor tensor_1_temp = reciprocal_input;
     if (reciprocal_input.get_legacy_shape()[0] % 32 != 0) {
-        std::vector<std::pair<uint32_t, uint32_t>> padding = {{0, 0},
-                      {0, 32 - (reciprocal_input.get_legacy_shape()[0] % 32)},
+        std::vector<std::pair<uint32_t, uint32_t>> padding = {{0, (32 - (reciprocal_input.get_legacy_shape()[0] % 32))},
+                      {0, 0},
                       {0, 0},
                       {0, 0}};
         tensor_1_temp = ttnn::pad(reciprocal_input, padding, 0,  std::nullopt);

--- a/tt_eager/tt_dnn/op_library/backward/backward_ops.cpp
+++ b/tt_eager/tt_dnn/op_library/backward/backward_ops.cpp
@@ -14,7 +14,7 @@
 #include "tt_dnn/op_library/reshape/reshape_op.hpp"
 #include "tt_dnn/op_library/unpad/unpad_op.hpp"
 #include "tt_eager/tensor/tensor_utils.hpp"
-#include "ttnn/operations/data_movement/pad.hpp"
+#include "ttnn/operations/data_movement/pad/pad.hpp"
 #include "tt_numpy/functions.hpp"
 #include "tt_dnn/op_library/copy/copy_op.hpp"
 

--- a/tt_eager/tt_dnn/op_library/composite/composite_ops.cpp
+++ b/tt_eager/tt_dnn/op_library/composite/composite_ops.cpp
@@ -1393,17 +1393,10 @@ Tensor hypot(const Tensor& input_a, const Tensor& input_b, const MemoryConfig& o
 
 Tensor _scatter(const Tensor& input_a, const Tensor& input_b, const MemoryConfig& output_mem_config) {
     const Shape start_index = {0, 0, 0, 0};
-    ttnn::Tensor input_tensor_4D = ttnn::unsqueeze_to_4D(input_a);        
-    auto input_shape_with_tile_padding = input_tensor_4D.get_shape().with_tile_padding();
-    auto output_padded_shape = input_b.legacy_shape();
-    std::vector<std::pair<uint32_t, uint32_t>> padding(4); 
-    for(size_t i = 0; i < padding.size(); i++) {
-        padding[i] = {0, output_padded_shape[i] - input_shape_with_tile_padding[i]};
-    }
+    ttnn::Tensor input_tensor_4D = ttnn::unsqueeze_to_4D(input_a);
 
-
-    Tensor index = ttnn::pad(ones_like(input_a, output_mem_config), padding, 0, std::nullopt);
-    Tensor temp_a = ttnn::pad(input_a, padding, 0, std::nullopt);
+    Tensor index = ttnn::pad(ones_like(input_tensor_4D, output_mem_config), input_b.shape(), ttnn::Shape(start_index), 0, std::nullopt);
+    Tensor temp_a = ttnn::pad(input_tensor_4D,input_b.shape(), ttnn::Shape(start_index), 0, std::nullopt);
     return where(index, temp_a, input_b, output_mem_config);
 }
 Tensor scatter(const Tensor& input_a, const Tensor& input_b, const MemoryConfig& output_mem_config) {

--- a/tt_eager/tt_dnn/op_library/composite/composite_ops.hpp
+++ b/tt_eager/tt_dnn/op_library/composite/composite_ops.hpp
@@ -15,7 +15,7 @@
 
 
 #include "ttnn/operations/eltwise/binary/device/binary_op.hpp"
-#include "ttnn/operations/data_movement/pad.hpp"
+#include "ttnn/operations/data_movement/pad/pad.hpp"
 
 namespace tt {
 

--- a/tt_eager/tt_dnn/op_library/composite/composite_ops.hpp
+++ b/tt_eager/tt_dnn/op_library/composite/composite_ops.hpp
@@ -15,6 +15,7 @@
 
 
 #include "ttnn/operations/eltwise/binary/device/binary_op.hpp"
+#include "ttnn/operations/data_movement/pad.hpp"
 
 namespace tt {
 

--- a/ttnn/cpp/pybind11/operations/__init__.hpp
+++ b/ttnn/cpp/pybind11/operations/__init__.hpp
@@ -11,7 +11,6 @@
 #include "pybind11/operations/conv2d.hpp"
 #include "pybind11/operations/core.hpp"
 #include "pybind11/operations/creation.hpp"
-#include "pybind11/operations/data_movement.hpp"
 #include "pybind11/operations/embedding.hpp"
 #include "pybind11/operations/kv_cache.hpp"
 #include "pybind11/operations/matmul.hpp"
@@ -26,6 +25,7 @@
 #include "ttnn/operations/eltwise/unary/unary_pybind.hpp"
 #include "ttnn/operations/reduction/reduction_pybind.hpp"
 #include "ttnn/operations/eltwise/binary_backward/binary_backward_pybind.hpp"
+#include "ttnn/operations/data_movement/data_movement_pybind.hpp"
 
 
 namespace py = pybind11;

--- a/ttnn/cpp/ttnn/operations/data_movement.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement.hpp
@@ -319,110 +319,11 @@ struct RepeatInterleave {
     }
 };
 
-struct Pad {
-    static inline const std::array<TensorSchema, 1> input_tensor_schemas() {
-        return {ttnn::TensorSchema{
-            2,  // min rank
-            4,  // max rank
-            {ttnn::bfloat16, ttnn::bfloat8_b, ttnn::uint16, ttnn::int32, ttnn::uint32},
-            {ttnn::TILE_LAYOUT},
-            true,   // can_be_on_device
-            false,  // can_be_on_cpu
-            false,  // can_be_scalar
-            false   // is_optional}
-        }};
-    }
 
-    template <typename... Args>
-    static auto input_tensors_to_validate(const ttnn::Tensor& input_tensor, Args&&... args) {
-        return std::make_tuple(input_tensor);
-    }
-
-    static ttnn::Tensor execute_on_worker_thread(
-        const ttnn::Tensor& input_tensor,
-        std::vector<std::pair<uint32_t, uint32_t>> padding, //intentionally not const&
-        const float value,
-        const std::optional<MemoryConfig>& memory_config_arg) {
-
-        const int original_rank = input_tensor.get_shape().rank();
-        if(int diff = original_rank - padding.size(); diff != 0) {
-            TT_FATAL(diff > 0, "ttnn.pad: padding len can't be larger than input tensor rank");
-
-            padding.insert(padding.begin(), diff, {0, 0});
-        }
-
-        TT_FATAL(
-            padding.size() == original_rank,
-            "ttnn.pad: padding must be the same length as the input tensor rank");
-        TT_FATAL(
-            input_tensor.get_layout() != ttnn::ROW_MAJOR_LAYOUT,
-            "ttnn.pad: row-major tensors have to use fallback because the kernel currently causes a PCC error");
-
-        // Unsqueeze Tensor to 4D if it is not already
-        ttnn::Tensor input_tensor_4D = ttnn::unsqueeze_to_4D(input_tensor);        
-        padding.insert(padding.begin(), 4 - original_rank, {0, 0});
-        auto input_shape_with_tile_padding = input_tensor_4D.get_shape().with_tile_padding();
-        std::vector<uint32_t> output_padded_shape(padding.size());
-        for(size_t i = 0; i < padding.size(); i++) {
-            output_padded_shape[i] = input_shape_with_tile_padding[i] + padding[i].second;
-        }
-
-        // Due to the strangeness of tt::tt_metal::pad, we need to split front and back pad
-        // Front will be passed separately. And pad_back is retrieved -> output_padded_shape - pad_front
-        auto memory_config = memory_config_arg.value_or(input_tensor.memory_config());
-        auto pad_front = padding | std::views::transform([](const auto& p) { return p.first; });
-        auto pad_back = padding | std::views::transform([](const auto& p) { return p.second; });
-
-        const bool front_padding_is_zero = std::accumulate(pad_front.begin(), pad_front.end(), 0) == 0;
-        TT_FATAL(
-            front_padding_is_zero,
-            "ttnn.pad: on device padding does not support front padding");
-
-        const int target_height = output_padded_shape[output_padded_shape.size() - 2];
-        const int target_width = output_padded_shape[output_padded_shape.size() - 1];
-        TT_FATAL(
-            target_height % ttnn::TILE_SIZE == 0 || target_width % ttnn::TILE_SIZE == 0,
-            "ttnn.pad: for tiled tensors padding end must be a multiple of the tile size on height and width for a "
-            "tensor in tile layout");
-
-        // Performing actual padding        
-        std::vector<uint32_t> pad_front_vec(pad_front.begin(), pad_front.end());
-        auto output_tensor = operation::run(
-            tt::tt_metal::Pad{
-                .output_tensor_shape=tt::tt_metal::Shape(output_padded_shape),
-                .input_tensor_start=tt::tt_metal::Shape(pad_front_vec),
-                .pad_value=value,
-                .output_mem_config=memory_config,
-                .use_multicore=true
-            },
-            {input_tensor_4D}).front();
-
-
-        // output_tensor is currently 4D. We have to squeeze back to the original rank
-        auto to_vec = [](const auto& arr) {return std::vector<uint32_t>(arr.begin(), arr.end());};
-        auto shape = to_vec(output_tensor.get_shape().value());
-        auto padded_shape = to_vec(output_tensor.get_shape().with_tile_padding().value());
-        if (auto rank_diff = shape.size() - original_rank; rank_diff) {
-            auto remove_first_elements = [](auto& source, size_t n) {
-                source.erase(source.begin(), source.begin() + n);
-            };
-            remove_first_elements(shape, rank_diff);
-            remove_first_elements(padded_shape, rank_diff);
-            auto squeezedShape = ttnn::Shape(tt::tt_metal::Shape(shape, padded_shape));
-            output_tensor = ttnn::reshape(output_tensor, squeezedShape);
-        }
-
-        // Padding always turns the intended shape to the shape with tile padding. For simplicity of the operation
-        output_tensor = ttnn::reshape(output_tensor, ttnn::Shape(padded_shape));
-
-        return output_tensor;
-    }
-};
 
 }  // namespace data_movement
 }  // namespace operations
 
-constexpr auto pad = ttnn::register_operation<ttnn::operations::data_movement::Pad>("ttnn::pad");
 constexpr auto upsample = ttnn::register_operation<ttnn::operations::data_movement::UpSample>("ttnn::upsample");
 constexpr auto repeat = ttnn::register_operation<ttnn::operations::data_movement::Repeat>("ttnn::repeat");
 constexpr auto repeat_interleave = ttnn::register_operation<ttnn::operations::data_movement::RepeatInterleave>("ttnn::repeat_interleave");

--- a/ttnn/cpp/ttnn/operations/data_movement/data_movement_pybind.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/data_movement_pybind.hpp
@@ -7,7 +7,9 @@
 #include <pybind11/pybind11.h>
 #include <pybind11/stl.h>
 
+#include "ttnn/cpp/pybind11/decorators.hpp"
 #include "ttnn/operations/data_movement.hpp"
+#include "ttnn/operations/data_movement/pad/pad_pybind.hpp"
 
 namespace py = pybind11;
 
@@ -94,30 +96,7 @@ void bind_upsample(py::module& module) {
             py::arg("memory_config") = std::nullopt});
 }
 
-void bind_pad(py::module& module) {
-    auto doc =
-        R"doc(pad(input_tensor: ttnn.Tensor, padding: Tuple[Tuple[int, int], ...], value: Union[int, float], *, Optional[ttnn.MemoryConfig] = None) -> ttnn.Tensor
-Pad tensor with constant value. Padded shape is accumulated if ttnn.pad is called on a tensor with padding.
 
-Args:
-    * :attr:`input_tensor`: input tensor
-    * :attr:`padding`: padding to apply. Each element of padding should be a tuple of 2 integers, with the first integer specifying the number of values to add before the tensor and the second integer specifying the number of values to add after the tensor.
-    * :attr:`value`: value to pad with
-
-Keyword Args:
-    * :attr:`memory_config`: the memory configuration to use for the operation)doc";
-
-    ttnn::bind_registered_operation(
-        module,
-        ttnn::pad,
-        doc,
-        ttnn::pybind_arguments_t{
-            py::arg("input_tensor"),
-            py::arg("padding"),
-            py::arg("value"),
-            py::kw_only(),
-            py::arg("memory_config") = nullopt});
-}
 
 void bind_repeat_interleave(py::module& module) {
     auto doc = R"doc(
@@ -196,7 +175,7 @@ void py_module(py::module& module) {
     bind_permute(module);
     bind_concat(module);
     bind_upsample(module);
-    bind_pad(module);
+    detail::bind_pad(module);
     bind_repeat(module);
     bind_repeat_interleave(module);
 }

--- a/ttnn/cpp/ttnn/operations/data_movement/pad.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/pad.hpp
@@ -1,0 +1,128 @@
+// SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include "tt_eager/tensor/types.hpp"
+#include "tt_eager/tt_dnn/op_library/concat/concat_op.hpp"
+#include "tt_eager/tt_dnn/op_library/pad/pad_op.hpp"
+#include "tt_eager/tt_dnn/op_library/permute/permute_op.hpp"
+#include "tt_eager/tt_dnn/op_library/repeat/repeat_op.hpp"
+#include "tt_eager/tt_dnn/op_library/composite/composite_ops.hpp"
+#include "tt_eager/tt_dnn/op_library/upsample/upsample_op.hpp"
+#include "ttnn/cpp/ttnn/operations/core.hpp"
+
+#include <ranges>
+
+namespace ttnn {
+namespace operations {
+namespace data_movement {
+
+
+struct Pad {
+    static inline const std::array<TensorSchema, 1> input_tensor_schemas() {
+        return {ttnn::TensorSchema{
+            2,  // min rank
+            4,  // max rank
+            {ttnn::bfloat16, ttnn::bfloat8_b, ttnn::uint16, ttnn::int32, ttnn::uint32},
+            {ttnn::TILE_LAYOUT},
+            true,   // can_be_on_device
+            false,  // can_be_on_cpu
+            false,  // can_be_scalar
+            false   // is_optional}
+        }};
+    }
+
+    template <typename... Args>
+    static auto input_tensors_to_validate(const ttnn::Tensor& input_tensor, Args&&... args) {
+        return std::make_tuple(input_tensor);
+    }
+
+    static ttnn::Tensor execute_on_worker_thread(
+        const ttnn::Tensor& input_tensor,
+        std::vector<std::pair<uint32_t, uint32_t>> padding, //intentionally not const&
+        const float value,
+        const std::optional<MemoryConfig>& memory_config_arg) {
+
+        const int original_rank = input_tensor.get_shape().rank();
+        if(int diff = original_rank - padding.size(); diff != 0) {
+            TT_FATAL(diff > 0, "ttnn.pad: padding len can't be larger than input tensor rank");
+
+            padding.insert(padding.begin(), diff, {0, 0});
+        }
+
+        TT_FATAL(
+            padding.size() == original_rank,
+            "ttnn.pad: padding must be the same length as the input tensor rank");
+        TT_FATAL(
+            input_tensor.get_layout() != ttnn::ROW_MAJOR_LAYOUT,
+            "ttnn.pad: row-major tensors have to use fallback because the kernel currently causes a PCC error");
+
+        // Unsqueeze Tensor to 4D if it is not already
+        ttnn::Tensor input_tensor_4D = ttnn::unsqueeze_to_4D(input_tensor);        
+        padding.insert(padding.begin(), 4 - original_rank, {0, 0});
+        auto input_shape_with_tile_padding = input_tensor_4D.get_shape().with_tile_padding();
+        std::vector<uint32_t> output_padded_shape(padding.size());
+        for(size_t i = 0; i < padding.size(); i++) {
+            output_padded_shape[i] = input_shape_with_tile_padding[i] + padding[i].second;
+        }
+
+        // Due to the strangeness of tt::tt_metal::pad, we need to split front and back pad
+        // Front will be passed separately. And pad_back is retrieved -> output_padded_shape - pad_front
+        auto memory_config = memory_config_arg.value_or(input_tensor.memory_config());
+        auto pad_front = padding | std::views::transform([](const auto& p) { return p.first; });
+        auto pad_back = padding | std::views::transform([](const auto& p) { return p.second; });
+
+        const bool front_padding_is_zero = std::accumulate(pad_front.begin(), pad_front.end(), 0) == 0;
+        TT_FATAL(
+            front_padding_is_zero,
+            "ttnn.pad: on device padding does not support front padding");
+
+        const int target_height = output_padded_shape[output_padded_shape.size() - 2];
+        const int target_width = output_padded_shape[output_padded_shape.size() - 1];
+        TT_FATAL(
+            target_height % ttnn::TILE_SIZE == 0 || target_width % ttnn::TILE_SIZE == 0,
+            "ttnn.pad: for tiled tensors padding end must be a multiple of the tile size on height and width for a "
+            "tensor in tile layout");
+
+        // Performing actual padding        
+        std::vector<uint32_t> pad_front_vec(pad_front.begin(), pad_front.end());
+        auto output_tensor = operation::run(
+            tt::tt_metal::Pad{
+                .output_tensor_shape=tt::tt_metal::Shape(output_padded_shape),
+                .input_tensor_start=tt::tt_metal::Shape(pad_front_vec),
+                .pad_value=value,
+                .output_mem_config=memory_config,
+                .use_multicore=true
+            },
+            {input_tensor_4D}).front();
+
+
+        // output_tensor is currently 4D. We have to squeeze back to the original rank
+        auto to_vec = [](const auto& arr) {return std::vector<uint32_t>(arr.begin(), arr.end());};
+        auto shape = to_vec(output_tensor.get_shape().value());
+        auto padded_shape = to_vec(output_tensor.get_shape().with_tile_padding().value());
+        if (auto rank_diff = shape.size() - original_rank; rank_diff) {
+            auto remove_first_elements = [](auto& source, size_t n) {
+                source.erase(source.begin(), source.begin() + n);
+            };
+            remove_first_elements(shape, rank_diff);
+            remove_first_elements(padded_shape, rank_diff);
+            auto squeezedShape = ttnn::Shape(tt::tt_metal::Shape(shape, padded_shape));
+            output_tensor = ttnn::reshape(output_tensor, squeezedShape);
+        }
+
+        // Padding always turns the intended shape to the shape with tile padding. For simplicity of the operation
+        output_tensor = ttnn::reshape(output_tensor, ttnn::Shape(padded_shape));
+
+        return output_tensor;
+    }
+};
+
+}  // namespace data_movement
+}  // namespace operations
+
+constexpr auto pad = ttnn::register_operation<ttnn::operations::data_movement::Pad>("ttnn::pad");
+
+}  // namespace ttnn

--- a/ttnn/cpp/ttnn/operations/data_movement/pad/pad.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/pad/pad.hpp
@@ -15,9 +15,12 @@
 
 #include <ranges>
 
+
 namespace ttnn {
 namespace operations {
 namespace data_movement {
+
+constexpr uint8_t DefaultQueueId = 0;
 
 
 struct Pad {
@@ -40,6 +43,7 @@ struct Pad {
     }
 
     static ttnn::Tensor execute_on_worker_thread(
+        uint8_t queue_id,
         const ttnn::Tensor& input_tensor,
         std::vector<std::pair<uint32_t, uint32_t>> padding, //intentionally not const&
         const float value,
@@ -117,6 +121,16 @@ struct Pad {
         output_tensor = ttnn::reshape(output_tensor, ttnn::Shape(padded_shape));
 
         return output_tensor;
+    }
+
+    static ttnn::Tensor execute_on_worker_thread(
+      const ttnn::Tensor& input_tensor,
+      std::vector<std::pair<uint32_t, uint32_t>> padding, //intentionally not const&
+      const float value,
+      const std::optional<MemoryConfig>& memory_config_arg) {
+
+        return execute_on_worker_thread(DefaultQueueId, input_tensor, padding, value, memory_config_arg);
+
     }
 };
 

--- a/ttnn/cpp/ttnn/operations/data_movement/pad/pad_pybind.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/pad/pad_pybind.hpp
@@ -23,10 +23,12 @@ Args:
     * :attr:`input_tensor`: input tensor
     * :attr:`padding`: padding to apply. Each element of padding should be a tuple of 2 integers, with the first integer specifying the number of values to add before the tensor and the second integer specifying the number of values to add after the tensor.
     * :attr:`value`: value to pad with
-    * :attr:`queue_id` (Optional[uint8]): command queue id
 
 Keyword Args:
-    * :attr:`memory_config`: the memory configuration to use for the operation)doc";
+    * :attr:`memory_config`: the memory configuration to use for the operation
+    * :attr:`queue_id` (Optional[uint8]): command queue id
+    * :attr:`use_multicore` (Optional[bool]): whether or not we should use multicore. Defaults to true
+    )doc";
 
     using OperationType = decltype(ttnn::pad);
     ttnn::bind_registered_operation(
@@ -47,7 +49,8 @@ Keyword Args:
                 py::arg("value"),
                 py::kw_only(),
                 py::arg("memory_config") = std::nullopt,
-                py::arg("queue_id") = 0});
+                py::arg("queue_id") = 0,
+                });
 }
 
 }  // namespace ttnn::operations::data_movement::detail

--- a/ttnn/cpp/ttnn/operations/data_movement/pad/pad_pybind.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/pad/pad_pybind.hpp
@@ -1,0 +1,53 @@
+// SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <pybind11/pybind11.h>
+#include <pybind11/stl.h>
+
+#include "ttnn/cpp/pybind11/decorators.hpp"
+
+#include "pad.hpp"
+
+namespace ttnn::operations::data_movement::detail {
+namespace py = pybind11;
+
+void bind_pad(py::module& module) {
+    auto doc =
+        R"doc(pad(input_tensor: ttnn.Tensor, padding: Tuple[Tuple[int, int], ...], value: Union[int, float], *, Optional[ttnn.MemoryConfig] = None) -> ttnn.Tensor
+Pad tensor with constant value. Padded shape is accumulated if ttnn.pad is called on a tensor with padding.
+
+Args:
+    * :attr:`input_tensor`: input tensor
+    * :attr:`padding`: padding to apply. Each element of padding should be a tuple of 2 integers, with the first integer specifying the number of values to add before the tensor and the second integer specifying the number of values to add after the tensor.
+    * :attr:`value`: value to pad with
+    * :attr:`queue_id` (Optional[uint8]): command queue id
+
+Keyword Args:
+    * :attr:`memory_config`: the memory configuration to use for the operation)doc";
+
+    using OperationType = decltype(ttnn::pad);
+    ttnn::bind_registered_operation(
+        module,
+        ttnn::pad,
+        doc,
+        ttnn::pybind_overload_t{
+            [] (const OperationType& self,
+                const ttnn::Tensor& input_tensor,
+                std::vector<std::pair<uint32_t, uint32_t>> padding,
+                const float value,
+                const std::optional<ttnn::MemoryConfig>& memory_config,
+                uint8_t queue_id) {
+                    return self(queue_id, input_tensor, padding, value, memory_config);
+                },
+                py::arg("input_tensor").noconvert(),
+                py::arg("padding"),
+                py::arg("value"),
+                py::kw_only(),
+                py::arg("memory_config") = std::nullopt,
+                py::arg("queue_id") = 0});
+}
+
+}  // namespace ttnn::operations::data_movement::detail

--- a/ttnn/cpp/ttnn/operations/data_movement/pad/pad_pybind.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/pad/pad_pybind.hpp
@@ -44,7 +44,7 @@ Keyword Args:
                 uint8_t queue_id) {
                     return self(queue_id, input_tensor, padding, value, memory_config);
                 },
-                py::arg("input_tensor").noconvert(),
+                py::arg("input_tensor"),
                 py::arg("padding"),
                 py::arg("value"),
                 py::kw_only(),


### PR DESCRIPTION
### Ticket
[Link to Github Issue](https://github.com/tenstorrent/tt-metal/issues/9744)

### Problem description
Moving pad from tt_lib to ttnn

### What's changed
Pybindings, host side migration of tt_eager to ttnn, C++ usages, topk python usage.

### What Remains with Respect to Pad
Device side code to be migrated (currently migrated host side code still calls tt_eager device code), kernels to be moved, and the rest of python usages.

### Checklist
- [x] Post commit CI passes (https://github.com/tenstorrent/tt-metal/actions/runs/9764263765)
- [ ] Model regression CI testing passes (if applicable)
- [x] Tested with TopK and Scatter test_compostte