### PR TITLE
Optimize bcast sharded op

### DIFF
--- a/tt_eager/tt_dnn/op_library/CMakeLists.txt
+++ b/tt_eager/tt_dnn/op_library/CMakeLists.txt
@@ -52,6 +52,7 @@ set(TT_DNN_SRCS
     ${CMAKE_CURRENT_SOURCE_DIR}/bcast/bcast_op.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/bcast/multi_core_h/bcast_op_multi_core_h.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/bcast/multi_core_h/bcast_op_sharded_h.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/bcast/multi_core_h/bcast_op_sharded_h_optimised.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/bcast/multi_core_w/bcast_op_multi_core_w.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/bcast/multi_core_hw/bcast_op_multi_core_hw.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/bmm/bmm_op.cpp

--- a/tt_eager/tt_dnn/op_library/bcast/bcast_op.hpp
+++ b/tt_eager/tt_dnn/op_library/bcast/bcast_op.hpp
@@ -19,7 +19,7 @@ enum class BcastOpMath { ADD, SUB, MUL };
 enum class BcastOpDim { H, W, HW };
 
 // TODO: Accept parallelization
-enum class BcastOpParallelizationStrategy { MULTI_CORE_H_SHARDED, MULTI_CORE_H, MULTI_CORE_W, MULTI_CORE_HW, SINGLE_CORE };
+enum class BcastOpParallelizationStrategy { MULTI_CORE_H_SHARDED, MULTI_CORE_H_SHARDED_OPTIMISED, MULTI_CORE_H, MULTI_CORE_W, MULTI_CORE_HW, SINGLE_CORE };
 
 operation::ProgramWithCallbacks bcast_multi_core_h(
     const Tensor &input_tensor_a,
@@ -27,6 +27,11 @@ operation::ProgramWithCallbacks bcast_multi_core_h(
     const Tensor &output_tensor,
     BcastOpMath bcast_op);
 operation::ProgramWithCallbacks bcast_sharded_h(
+    const Tensor &input_tensor_a,
+    const Tensor &input_tensor_b,
+    const Tensor &output_tensor,
+    BcastOpMath bcast_op);
+operation::ProgramWithCallbacks bcast_sharded_h_optimised(
     const Tensor &input_tensor_a,
     const Tensor &input_tensor_b,
     const Tensor &output_tensor,

--- a/tt_eager/tt_dnn/op_library/bcast/kernels/compute/bcast_h_sharded_optimised.cpp
+++ b/tt_eager/tt_dnn/op_library/bcast/kernels/compute/bcast_h_sharded_optimised.cpp
@@ -1,0 +1,43 @@
+// SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <cstdint>
+#include "compute_kernel_api/bcast.h"
+
+
+namespace NAMESPACE {
+void MAIN {
+    constexpr uint32_t onetile = 1;
+    uint32_t NC = get_arg_val<uint32_t>(0);
+    uint32_t Ht = get_arg_val<uint32_t>(1);
+    uint32_t Wt = get_arg_val<uint32_t>(2);
+    uint32_t h_blk = get_arg_val<uint32_t>(3);
+    uint32_t batch_b = get_arg_val<uint32_t>(4);
+    uint32_t Ht_per_batch_b = get_arg_val<uint32_t>(5);
+
+    init_bcast<BCAST_LLKOP, BCAST_DIM>(tt::CB::c_in0, tt::CB::c_in1, tt::CB::c_out0);
+
+    cb_wait_front(tt::CB::c_in0, Wt*Ht);
+    cb_reserve_back(tt::CB::c_out0, Wt*Ht);
+    uint32_t b_offset = 0;
+    for (uint32_t bn = 0; bn < batch_b; bn++) {
+        for (uint32_t wt = 0; wt < Wt; wt++) {
+            cb_wait_front(tt::CB::c_in1, onetile);
+            for (uint32_t ht = 0; ht < Ht_per_batch_b; ht+=h_blk) {
+                acquire_dst(tt::DstMode::Half);
+                for (uint32_t htr = 0; htr<h_blk; htr++) {
+                    uint32_t current_index = b_offset + (ht + htr) * Wt + wt;
+                    BCAST_OP<BroadcastType::ROW>(tt::CB::c_in0, tt::CB::c_in1, current_index, 0, htr);
+                    pack_tile<true>(htr, tt::CB::c_out0, current_index);
+                }
+                release_dst(tt::DstMode::Half);
+            }
+            cb_pop_front(tt::CB::c_in1, onetile);
+        }
+        b_offset += Ht_per_batch_b * Wt;
+    }
+    cb_pop_front(tt::CB::c_in0, Wt*Ht);
+    cb_push_back(tt::CB::c_out0, Wt*Ht);
+}
+} // NAMESPACE

--- a/tt_eager/tt_dnn/op_library/bcast/kernels/dataflow/reader_bcast_h_sharded_optimised.cpp
+++ b/tt_eager/tt_dnn/op_library/bcast/kernels/dataflow/reader_bcast_h_sharded_optimised.cpp
@@ -1,0 +1,53 @@
+// SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <stdint.h>
+#include "dataflow_api.h"
+
+void kernel_main() {
+    uint32_t src1_addr    = get_arg_val<uint32_t>(0);
+    uint32_t Ht           = get_arg_val<uint32_t>(1);
+    uint32_t Wt           = get_arg_val<uint32_t>(2);
+    uint32_t offset       = get_arg_val<uint32_t>(3);
+    uint32_t batch_offset = get_arg_val<uint32_t>(4); //if weight has multiple batches
+    uint32_t w_blk        = get_arg_val<uint32_t>(5);
+    uint32_t batch_b      = get_arg_val<uint32_t>(6);
+
+    //constexpr bool src0_is_dram = get_compile_time_arg_val(0) == 1;
+    constexpr bool src1_is_dram = get_compile_time_arg_val(1) == 1;
+    constexpr uint32_t cb_id_in0 = get_compile_time_arg_val(0);
+
+    //constexpr uint32_t cb_id_in0 = 0;
+    constexpr uint32_t cb_id_in1 = 1;
+    constexpr uint32_t onetile = 1;
+
+    // single-tile ublocks
+    const uint32_t tile_bytes = get_tile_size(cb_id_in1);
+    const DataFormat data_format = get_dataformat(cb_id_in1);
+
+    const InterleavedAddrGenFast<src1_is_dram> s1 = {
+        .bank_base_address = src1_addr,
+        .page_size = tile_bytes,
+        .data_format = data_format
+    };
+
+
+    uint32_t l1_write_addr_in0;
+    uint32_t l1_write_addr_in1;
+
+    cb_push_back(cb_id_in0, Ht * Wt);
+    for (uint32_t b = 0; b < batch_b; b ++) {
+        for (uint32_t wt = 0; wt < Wt; wt += w_blk) {
+            cb_reserve_back(cb_id_in1, w_blk);
+            l1_write_addr_in1 = get_write_ptr(cb_id_in1);
+            for (uint32_t r = 0; r<w_blk; r++) {
+                noc_async_read_tile(offset + wt + r, s1, l1_write_addr_in1);
+                l1_write_addr_in1 += tile_bytes;
+            }
+            noc_async_read_barrier();
+            cb_push_back(cb_id_in1, w_blk);
+        }
+        offset += batch_offset;
+    }
+}


### PR DESCRIPTION
### Ticket
- [Link to Github Issue.](https://github.com/tenstorrent/tt-metal/issues/9472)

### Problem description
- bcast for h dim implementation was not optimal and thus slow

### What's changed
Performance optimization for sharded bcast op in the h dim. It re-uses in1 for all h tiles of in0 per core instead of re-loading in1 for each of them. The interleaved implementation is unchanged.

Speedup depends on the input shape (in0 h tiles per core) and is different for block and width sharding.
Falcon 40b prefill shapes [S, 8192] as an example:

```
block sharded S=256
1.12 x
block sharded S=2048
4.8 x

width sharded S=32
1.3 x
width sharded S=2048
6.7 x
```

### Checklist
- [x] Post commit CI passes: https://github.com/tenstorrent/tt-metal/actions/runs/9715574448 and https://github.com/tenstorrent/tt-metal/actions/runs/9716130882
- [ ] --Model regression CI testing passes (if applicable)--
- [x] New/Existing tests provide coverage for changes

This is an extension/fix for https://github.com/tenstorrent/tt-metal/pull/9478
My commit broke post commit and got reverted, so need to merge again with a fix for multi batch weights. The op now falls back to the old implementation for specific limitations of the newly optimised one (i.e. batch0 = 1 and batch1 > 1). Otherwise the optimised version is used automatically.

Additional changes:
- Fix for in1 dtype (in0 dtype was used to create CBs -> bad PCC when mixing different dt)