### PR TITLE
#3764: Device side opID support

### DIFF
--- a/tests/tt_metal/tt_metal/test_kernels/dataflow/dram_copy.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/dataflow/dram_copy.cpp
@@ -34,7 +34,8 @@ void kernel_main() {
 #else
         tt_l1_ptr mailboxes_t* const mailboxes = (tt_l1_ptr mailboxes_t*)(MEM_MAILBOX_BASE);
 #endif
-        uint64_t dispatch_addr = NOC_XY_ADDR(NOC_X(mailboxes->launch.dispatch_core_x), NOC_Y(mailboxes->launch.dispatch_core_y), DISPATCH_MESSAGE_ADDR);
+        uint64_t dispatch_addr = NOC_XY_ADDR(NOC_X(mailboxes->launch.kernel_config.dispatch_core_x),
+                                             NOC_Y(mailboxes->launch.kernel_config.dispatch_core_y), DISPATCH_MESSAGE_ADDR);
         noc_fast_atomic_increment(noc_index, NCRISC_AT_CMD_BUF, dispatch_addr, NOC_UNICAST_WRITE_VC, 1, 31, false);
 #endif
 

--- a/tests/tt_metal/tt_metal/test_kernels/misc/watcher_asserts.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/misc/watcher_asserts.cpp
@@ -40,7 +40,9 @@ void MAIN {
 #else
         tt_l1_ptr mailboxes_t* const mailboxes = (tt_l1_ptr mailboxes_t*)(MEM_MAILBOX_BASE);
 #endif
-        uint64_t dispatch_addr = NOC_XY_ADDR(NOC_X(mailboxes->launch.dispatch_core_x), NOC_Y(mailboxes->launch.dispatch_core_y), DISPATCH_MESSAGE_ADDR);
+        uint64_t dispatch_addr =
+            NOC_XY_ADDR(NOC_X(mailboxes->launch.kernel_config.dispatch_core_x),
+                        NOC_Y(mailboxes->launch.kernel_config.dispatch_core_y), DISPATCH_MESSAGE_ADDR);
         noc_fast_atomic_increment(noc_index, NCRISC_AT_CMD_BUF, dispatch_addr, NOC_UNICAST_WRITE_VC, 1, 31 /*wrap*/, false /*linked*/);
     }
 #else

--- a/tests/tt_metal/tt_metal/unit_tests_common/watcher/test_assert.cpp
+++ b/tests/tt_metal/tt_metal/unit_tests_common/watcher/test_assert.cpp
@@ -154,7 +154,7 @@ static void RunTest(WatcherFixture *fixture, Device *device, riscv_id_t riscv_ty
     // We should be able to find the expected watcher error in the log as well,
     // expected error message depends on the risc we're running on.
     string kernel = "tests/tt_metal/tt_metal/test_kernels/misc/watcher_asserts.cpp";
-    int line_num = 55;
+    int line_num = 57;
 
     string expected = fmt::format(
         "Device {} {} core(x={:2},y={:2}) phys(x={:2},y={:2}): {} tripped an assert on line {}. Current kernel: {}.",

--- a/tt_eager/tt_dnn/op_library/run_operation.cpp
+++ b/tt_eager/tt_dnn/op_library/run_operation.cpp
@@ -224,6 +224,15 @@ OutputTensors run_device_operation(
         operation, input_tensors, optional_input_tensors, output_tensors, optional_output_tensors);
     uint32_t device_id = detail::get_device(input_tensors, optional_input_tensors)->id();
 
+    if (std::holds_alternative<std::reference_wrapper<Program>>(program))
+    {
+        std::get<std::reference_wrapper<Program>>(program).get().set_global_id(op_id);
+    }
+    else
+    {
+        std::get<std::shared_ptr<Program>>(program)->set_global_id(op_id);
+    }
+
     // Enqueue or Launch Program
     std::visit(
         [&operation, &input_tensors, &optional_input_tensors, &output_tensors, queue](auto&& program) {

--- a/tt_metal/hw/firmware/src/brisc.cc
+++ b/tt_metal/hw/firmware/src/brisc.cc
@@ -366,6 +366,7 @@ int main() {
 
         {
             DeviceZoneScopedMainN("BRISC-FW");
+            DeviceZoneSetCounter(mailboxes->launch.kernel_config.host_assigned_op_id);
 
             // Copies from L1 to IRAM on chips where NCRISC has IRAM
             l1_to_ncrisc_iram_copy(mailboxes->launch.kernel_config.ncrisc_kernel_size16, ncrisc_kernel_start_offset16);

--- a/tt_metal/hw/firmware/src/erisc.cc
+++ b/tt_metal/hw/firmware/src/erisc.cc
@@ -77,12 +77,14 @@ void __attribute__((section("erisc_l1_code.1"), noinline)) Application(void) {
 
     while (routing_info->routing_enabled) {
         // FD: assume that no more host -> remote writes are pending
-        if (mailboxes->launch.run == RUN_MSG_GO) {
+        if (mailboxes->launch.go.run == RUN_MSG_GO) {
             DeviceZoneScopedMainN("ERISC-FW");
             DEBUG_STATUS("R");
-            uint32_t kernel_config_base = mailboxes->launch.kernel_config_base;
-            rta_l1_base = (uint32_t tt_l1_ptr *)(kernel_config_base + mailboxes->launch.mem_map[DISPATCH_CLASS_ETH_DM0].rta_offset);
-            crta_l1_base = (uint32_t tt_l1_ptr *)(kernel_config_base + mailboxes->launch.mem_map[DISPATCH_CLASS_ETH_DM0].crta_offset);
+            uint32_t kernel_config_base = mailboxes->launch.kernel_config.kernel_config_base;
+            rta_l1_base = (uint32_t tt_l1_ptr *)(kernel_config_base +
+                mailboxes->launch.kernel_config.mem_map[DISPATCH_CLASS_ETH_DM0].rta_offset);
+            crta_l1_base = (uint32_t tt_l1_ptr *)(kernel_config_base +
+                mailboxes->launch.kernel_config.mem_map[DISPATCH_CLASS_ETH_DM0].crta_offset);
 
             kernel_init();
         } else {

--- a/tt_metal/hw/firmware/src/erisc.cc
+++ b/tt_metal/hw/firmware/src/erisc.cc
@@ -79,6 +79,7 @@ void __attribute__((section("erisc_l1_code.1"), noinline)) Application(void) {
         // FD: assume that no more host -> remote writes are pending
         if (mailboxes->launch.go.run == RUN_MSG_GO) {
             DeviceZoneScopedMainN("ERISC-FW");
+            DeviceZoneSetCounter(mailboxes->launch.kernel_config.host_assigned_op_id);
             DEBUG_STATUS("R");
             uint32_t kernel_config_base = mailboxes->launch.kernel_config.kernel_config_base;
             rta_l1_base = (uint32_t tt_l1_ptr *)(kernel_config_base +

--- a/tt_metal/hw/firmware/src/erisck.cc
+++ b/tt_metal/hw/firmware/src/erisck.cc
@@ -32,9 +32,11 @@ void __attribute__((section("erisc_l1_code"))) kernel_launch() {
     rtos_context_switch_ptr = (void (*)())RtosTable[0];
 
     kernel_main();
-    mailboxes->launch.run = RUN_MSG_DONE;
-    uint64_t dispatch_addr = NOC_XY_ADDR(NOC_X(mailboxes->launch.dispatch_core_x), NOC_Y(mailboxes->launch.dispatch_core_y), DISPATCH_MESSAGE_ADDR);
-    if (routing_info->routing_enabled and mailboxes->launch.mode == DISPATCH_MODE_DEV) {
+    mailboxes->launch.go.run = RUN_MSG_DONE;
+    uint64_t dispatch_addr =
+        NOC_XY_ADDR(NOC_X(mailboxes->launch.kernel_config.dispatch_core_x),
+                    NOC_Y(mailboxes->launch.kernel_config.dispatch_core_y), DISPATCH_MESSAGE_ADDR);
+    if (routing_info->routing_enabled and mailboxes->launch.kernel_config.mode == DISPATCH_MODE_DEV) {
         internal_::notify_dispatch_core_done(dispatch_addr);
     }
 }

--- a/tt_metal/hw/firmware/src/idle_erisc.cc
+++ b/tt_metal/hw/firmware/src/idle_erisc.cc
@@ -108,6 +108,7 @@ int main() {
 
         {
             DeviceZoneScopedMainN("ERISC-IDLE-FW");
+            DeviceZoneSetCounter(mailboxes->launch.kernel_config.host_assigned_op_id);
 
             noc_index = mailboxes->launch.kernel_config.brisc_noc_id;
 

--- a/tt_metal/hw/firmware/src/ncrisc.cc
+++ b/tt_metal/hw/firmware/src/ncrisc.cc
@@ -94,11 +94,13 @@ int main(int argc, char *argv[]) {
         notify_brisc_and_wait();
         DeviceZoneScopedMainN("NCRISC-FW");
 
-        setup_cb_read_write_interfaces(0, mailboxes->launch.max_cb_index, true, true);
+        setup_cb_read_write_interfaces(0, mailboxes->launch.kernel_config.max_cb_index, true, true);
 
-        uint32_t kernel_config_base = mailboxes->launch.kernel_config_base;
-        rta_l1_base = (uint32_t tt_l1_ptr *)(kernel_config_base + mailboxes->launch.mem_map[DISPATCH_CLASS_TENSIX_DM1].rta_offset);
-        crta_l1_base = (uint32_t tt_l1_ptr *)(kernel_config_base + mailboxes->launch.mem_map[DISPATCH_CLASS_TENSIX_DM1].crta_offset);
+        uint32_t kernel_config_base = mailboxes->launch.kernel_config.kernel_config_base;
+        rta_l1_base = (uint32_t tt_l1_ptr *)(kernel_config_base +
+            mailboxes->launch.kernel_config.mem_map[DISPATCH_CLASS_TENSIX_DM1].rta_offset);
+        crta_l1_base = (uint32_t tt_l1_ptr *)(kernel_config_base +
+            mailboxes->launch.kernel_config.mem_map[DISPATCH_CLASS_TENSIX_DM1].crta_offset);
 
         DEBUG_STATUS("R");
         kernel_init();

--- a/tt_metal/hw/firmware/src/trisc.cc
+++ b/tt_metal/hw/firmware/src/trisc.cc
@@ -106,12 +106,14 @@ int main(int argc, char *argv[]) {
         DeviceZoneScopedMainN("TRISC-FW");
 
 #if !defined(UCK_CHLKC_MATH)
-        setup_cb_read_write_interfaces(0, mailboxes->launch.max_cb_index, cb_init_read, cb_init_write);
+        setup_cb_read_write_interfaces(0, mailboxes->launch.kernel_config.max_cb_index, cb_init_read, cb_init_write);
 #endif
 
-        uint32_t kernel_config_base = mailboxes->launch.kernel_config_base;
-        rta_l1_base = (uint32_t tt_l1_ptr *)(kernel_config_base + mailboxes->launch.mem_map[DISPATCH_CLASS_TENSIX_COMPUTE].rta_offset);
-        crta_l1_base = (uint32_t tt_l1_ptr *)(kernel_config_base + mailboxes->launch.mem_map[DISPATCH_CLASS_TENSIX_COMPUTE].crta_offset);
+        uint32_t kernel_config_base = mailboxes->launch.kernel_config.kernel_config_base;
+        rta_l1_base = (uint32_t tt_l1_ptr *)(kernel_config_base +
+            mailboxes->launch.kernel_config.mem_map[DISPATCH_CLASS_TENSIX_COMPUTE].rta_offset);
+        crta_l1_base = (uint32_t tt_l1_ptr *)(kernel_config_base +
+            mailboxes->launch.kernel_config.mem_map[DISPATCH_CLASS_TENSIX_COMPUTE].crta_offset);
 
         DEBUG_STATUS("R");
         kernel_init();

--- a/tt_metal/hw/inc/debug/assert.h
+++ b/tt_metal/hw/inc/debug/assert.h
@@ -19,7 +19,7 @@ void assert_and_hang(uint32_t line_num) {
 
     // Update launch msg to show that we've exited.
     tt_l1_ptr launch_msg_t *launch_msg = GET_MAILBOX_ADDRESS_DEV(launch);
-    launch_msg->run = RUN_MSG_DONE;
+    launch_msg->go.run = RUN_MSG_DONE;
 
     // Hang, or in the case of erisc, early exit.
 #if defined(COMPILE_FOR_ERISC)

--- a/tt_metal/hw/inc/debug/sanitize_noc.h
+++ b/tt_metal/hw/inc/debug/sanitize_noc.h
@@ -83,7 +83,7 @@ inline void debug_sanitize_post_noc_addr_and_hang(
 
     // Update launch msg to show that we've exited.
     tt_l1_ptr launch_msg_t *launch_msg = GET_MAILBOX_ADDRESS_DEV(launch);
-    launch_msg->run = RUN_MSG_DONE;
+    launch_msg->go.run = RUN_MSG_DONE;
 
 #if defined(COMPILE_FOR_ERISC)
     // For erisc, we can't hang the kernel/fw, because the core doesn't get restarted when a new

--- a/tt_metal/hw/inc/dev_msgs.h
+++ b/tt_metal/hw/inc/dev_msgs.h
@@ -76,7 +76,7 @@ struct dyn_mem_map_t {
     volatile uint16_t crta_offset;
 };
 
-struct launch_msg_t {  // must be cacheline aligned
+struct kernel_config_msg_t {
     volatile uint16_t watcher_kernel_ids[DISPATCH_CLASS_MAX];
     volatile uint16_t ncrisc_kernel_size16;  // size in 16 byte units
 
@@ -91,7 +91,16 @@ struct launch_msg_t {  // must be cacheline aligned
     volatile uint8_t dispatch_core_x;
     volatile uint8_t dispatch_core_y;
     volatile uint8_t exit_erisc_kernel;
-    volatile uint8_t run;  // must be in last cacheline of this msg
+    volatile uint8_t pad1;
+} __attribute__((packed));
+
+struct go_msg_t {
+    volatile uint32_t run;  // must be in last cacheline of this msg
+} __attribute__((packed));
+
+struct launch_msg_t {  // must be cacheline aligned
+    kernel_config_msg_t kernel_config;
+    go_msg_t go;
 } __attribute__((packed));
 
 struct slave_sync_msg_t {
@@ -194,7 +203,7 @@ struct mailboxes_t {
     struct debug_insert_delays_msg_t debug_insert_delays;
 };
 
-static_assert(sizeof(launch_msg_t) % sizeof(uint32_t) == 0);
+static_assert(sizeof(kernel_config_msg_t) % sizeof(uint32_t) == 0);
 
 #ifndef TENSIX_FIRMWARE
 // Validate assumptions on mailbox layout on host compile

--- a/tt_metal/hw/inc/dev_msgs.h
+++ b/tt_metal/hw/inc/dev_msgs.h
@@ -80,6 +80,8 @@ struct kernel_config_msg_t {
     volatile uint16_t watcher_kernel_ids[DISPATCH_CLASS_MAX];
     volatile uint16_t ncrisc_kernel_size16;  // size in 16 byte units
 
+    volatile uint16_t host_assigned_op_id;
+
     // Ring buffer of kernel configuration data
     volatile uint32_t kernel_config_base;
     dyn_mem_map_t mem_map[DISPATCH_CLASS_MAX];
@@ -92,6 +94,7 @@ struct kernel_config_msg_t {
     volatile uint8_t dispatch_core_y;
     volatile uint8_t exit_erisc_kernel;
     volatile uint8_t pad1;
+    volatile uint16_t pad2;
 } __attribute__((packed));
 
 struct go_msg_t {

--- a/tt_metal/impl/device/device.cpp
+++ b/tt_metal/impl/device/device.cpp
@@ -285,7 +285,7 @@ void Device::initialize_firmware(CoreCoord phys_core, launch_msg_t *launch_msg) 
                 llrt::get_risc_binary(firmware_build_states_[riscv_id]->get_target_out_path(""));
             uint32_t kernel_size16 = llrt::get_binary_code_size16(binary_mem, riscv_id);
             if (riscv_id == 1) {
-                launch_msg->ncrisc_kernel_size16 = kernel_size16;
+                launch_msg->kernel_config.ncrisc_kernel_size16 = kernel_size16;
             }
             log_debug(LogDevice, "RISC {} fw binary size: {} in bytes", riscv_id, kernel_size16 * 16);
             llrt::test_load_write_read_risc_binary(binary_mem, this->id(), phys_core, riscv_id);
@@ -301,7 +301,7 @@ void Device::reset_cores() {
     ZoneScoped;
 
     auto kernel_still_running = [](launch_msg_t *launch_msg) {
-        return launch_msg->run == RUN_MSG_GO && launch_msg->exit_erisc_kernel == 0;
+        return launch_msg->go.run == RUN_MSG_GO && launch_msg->kernel_config.exit_erisc_kernel == 0;
     };
 
     auto mmio_device_id = tt::Cluster::instance().get_associated_mmio_device(this->id_);
@@ -320,7 +320,7 @@ void Device::reset_cores() {
                 this->id(),
                 physical_core.str(),
                 this->id());
-            launch_msg->exit_erisc_kernel = 1;
+            launch_msg->kernel_config.exit_erisc_kernel = 1;
             llrt::write_launch_msg_to_core(this->id(), physical_core, launch_msg);
             device_to_early_exit_cores[this->id()].insert(physical_core);
         }
@@ -345,7 +345,7 @@ void Device::reset_cores() {
                         this->id(),
                         phys_core.str(),
                         id_and_cores.first);
-                    launch_msg->exit_erisc_kernel = 1;
+                    launch_msg->kernel_config.exit_erisc_kernel = 1;
                     llrt::write_launch_msg_to_core(id_and_cores.first, phys_core, launch_msg);
                     device_to_early_exit_cores[id_and_cores.first].insert(phys_core);
                 }
@@ -387,8 +387,8 @@ void Device::initialize_and_launch_firmware() {
 
     launch_msg_t launch_msg;
     std::memset(&launch_msg, 0, sizeof(launch_msg_t));
-    launch_msg.mode = DISPATCH_MODE_HOST,
-    launch_msg.run = RUN_MSG_INIT,
+    launch_msg.kernel_config.mode = DISPATCH_MODE_HOST,
+    launch_msg.go.run = RUN_MSG_INIT,
 
     // Download to worker cores
     log_debug("Initializing firmware");

--- a/tt_metal/impl/dispatch/command_queue.cpp
+++ b/tt_metal/impl/dispatch/command_queue.cpp
@@ -892,9 +892,9 @@ void EnqueueProgramCommand::assemble_device_commands() {
         constexpr uint32_t aligned_go_signal_sizeB = align(go_signal_sizeB, L1_ALIGNMENT);
         constexpr uint32_t go_signal_size_words = aligned_go_signal_sizeB / sizeof(uint32_t);
         for (KernelGroup& kernel_group : program.get_kernel_groups(CoreType::WORKER)) {
-            kernel_group.launch_msg.mode = DISPATCH_MODE_DEV;
-            kernel_group.launch_msg.dispatch_core_x = this->dispatch_core.x;
-            kernel_group.launch_msg.dispatch_core_y = this->dispatch_core.y;
+            kernel_group.launch_msg.kernel_config.mode = DISPATCH_MODE_DEV;
+            kernel_group.launch_msg.kernel_config.dispatch_core_x = this->dispatch_core.x;
+            kernel_group.launch_msg.kernel_config.dispatch_core_y = this->dispatch_core.y;
             const void* launch_message_data = (const void*)(&kernel_group.launch_msg);
             for (const CoreRange& core_range : kernel_group.core_ranges.ranges()) {
                 CoreCoord physical_start =
@@ -919,9 +919,9 @@ void EnqueueProgramCommand::assemble_device_commands() {
         }
 
         for (KernelGroup& kernel_group : program.get_kernel_groups(CoreType::ETH)) {
-            kernel_group.launch_msg.mode = DISPATCH_MODE_DEV;
-            kernel_group.launch_msg.dispatch_core_x = this->dispatch_core.x;
-            kernel_group.launch_msg.dispatch_core_y = this->dispatch_core.y;
+            kernel_group.launch_msg.kernel_config.mode = DISPATCH_MODE_DEV;
+            kernel_group.launch_msg.kernel_config.dispatch_core_x = this->dispatch_core.x;
+            kernel_group.launch_msg.kernel_config.dispatch_core_y = this->dispatch_core.y;
             const void* launch_message_data = (const launch_msg_t*)(&kernel_group.launch_msg);
             for (const CoreRange& core_range : kernel_group.core_ranges.ranges()) {
                 for (auto x = core_range.start.x; x <= core_range.end.x; x++) {
@@ -1132,8 +1132,8 @@ void EnqueueProgramCommand::assemble_device_commands() {
             i++;
         }
         for (auto& go_signal : cached_program_command_sequence.go_signals) {
-            go_signal->dispatch_core_x = this->dispatch_core.x;
-            go_signal->dispatch_core_y = this->dispatch_core.y;
+            go_signal->kernel_config.dispatch_core_x = this->dispatch_core.x;
+            go_signal->kernel_config.dispatch_core_y = this->dispatch_core.y;
         }
     }
 }

--- a/tt_metal/impl/dispatch/kernels/cq_helpers.hpp
+++ b/tt_metal/impl/dispatch/kernels/cq_helpers.hpp
@@ -11,7 +11,7 @@
 // Helper function to determine if the dispatch kernel needs to early exit, only valid for IERISC.
 FORCE_INLINE bool early_exit() {
     tt_l1_ptr mailboxes_t * const mailbox = (tt_l1_ptr mailboxes_t *)(MEM_IERISC_MAILBOX_BASE);
-    return mailbox->launch.exit_erisc_kernel;
+    return mailbox->launch.kernel_config.exit_erisc_kernel;
 }
 
 #define IDLE_ERISC_RETURN(...) \

--- a/tt_metal/impl/dispatch/kernels/eth_tunneler.cpp
+++ b/tt_metal/impl/dispatch/kernels/eth_tunneler.cpp
@@ -153,7 +153,7 @@ void kernel_main() {
         }
 
         tt_l1_ptr launch_msg_t * const launch_msg = GET_MAILBOX_ADDRESS_DEV(launch);
-        if (launch_msg->exit_erisc_kernel) {
+        if (launch_msg->kernel_config.exit_erisc_kernel) {
             return;
         }
         // need to optimize this.

--- a/tt_metal/impl/program/program.cpp
+++ b/tt_metal/impl/program/program.cpp
@@ -81,7 +81,7 @@ void DisablePersistentKernelCache() { enable_persistent_kernel_cache = false; }
 std::atomic<uint64_t> Program::program_counter = 0;
 
 Program::Program() :
-    id(program_counter++), worker_crs_({}), local_circular_buffer_allocation_needed_(false), loaded_onto_device(false) {
+    id(program_counter++), global_id(0), worker_crs_({}), local_circular_buffer_allocation_needed_(false), loaded_onto_device(false) {
     std::set<CoreType> supported_core_types = {CoreType::WORKER, CoreType::ETH};
     for (const auto &core_type : supported_core_types) {
         kernels_.insert({core_type, {}});
@@ -933,6 +933,8 @@ void Program::compile(Device *device) {
     compile_needed_[device->id()] = false;
     this->loaded_onto_device = false;
 }
+
+void Program::set_global_id(uint64_t id) { this->global_id = id; }
 
 Program::~Program() {}
 }  // namespace tt::tt_metal

--- a/tt_metal/impl/program/program.hpp
+++ b/tt_metal/impl/program/program.hpp
@@ -80,11 +80,13 @@ class Program {
     Program(Program &&other) = default;
     Program& operator=(Program &&other) = default;
 
+    void set_global_id(uint64_t id);
     ~Program();
 
     void construct_core_range_set_for_worker_cores();
 
     const uint64_t get_id() const { return this->id; }
+    const uint64_t get_global_id() const { return this->global_id; }
 
     size_t num_kernels() const {
       size_t count = 0;
@@ -177,6 +179,7 @@ class Program {
     };
 
     uint64_t id; // Need to make non-const due to move constructor
+    uint64_t global_id; // Need to make non-const due to move constructor
     static std::atomic<uint64_t> program_counter;
     std::unordered_map<CoreType, std::unordered_map<KernelHandle, std::shared_ptr<Kernel> >> kernels_;
     std::unordered_map<CoreType, CoreCoord> grid_extent_;

--- a/tt_metal/llrt/tlb_config.cpp
+++ b/tt_metal/llrt/tlb_config.cpp
@@ -185,7 +185,13 @@ void configure_static_tlbs(tt::ARCH arch, chip_id_t mmio_device_id, const metal_
     // Setup static TLBs for all worker cores
     for (auto &core : statically_mapped_cores) {
         auto tlb_index = get_static_tlb_index(core);
-        device_driver.configure_tlb(mmio_device_id, core, tlb_index, address);
+        // TODO
+        // Note: see issue #10107
+        // Strict is less performant than Posted, however, metal doesn't presently
+        // use this on a perf path and the launch_msg "kernel config" needs to
+        // arrive prior to the "go" message during device init and slow dispatch
+        // Revisit this when we have a more flexible UMD api
+        device_driver.configure_tlb(mmio_device_id, core, tlb_index, address, TLB_DATA::Strict);
     }
 
     // TODO (#9932): Remove workaround for BH

--- a/tt_metal/tools/profiler/kernel_profiler.hpp
+++ b/tt_metal/tools/profiler/kernel_profiler.hpp
@@ -111,7 +111,6 @@ namespace kernel_profiler{
         {
             core_flat_id = noc_xy_to_profiler_flat_id[my_x[0]][my_y[0]];
 
-#pragma GCC unroll 65534
             for (int i = ID_HH; i < GUARANTEED_MARKER_1_H; i ++)
             {
                 eriscBuffer[i] = 0;
@@ -124,14 +123,13 @@ namespace kernel_profiler{
             profiler_control_buffer[FLAT_ID] = core_flat_id;
         }
 
-#pragma GCC unroll 65534
         for (int i = GUARANTEED_MARKER_1_H; i < CUSTOM_MARKERS; i ++)
         {
         //TODO(MO): Clean up magic numbers
             eriscBuffer[i] = 0x80000000;
         }
 
-        eriscBuffer [ID_LL] = runCounter;
+        eriscBuffer [ID_LL] = (runCounter & 0xFFFF) | (eriscBuffer [ID_LL] & 0xFFFF0000);
 
 #endif //ERISC_INIT
 #if  defined(COMPILE_FOR_BRISC)
@@ -146,7 +144,6 @@ namespace kernel_profiler{
         {
             core_flat_id = noc_xy_to_profiler_flat_id[my_x[0]][my_y[0]];
 
-#pragma GCC unroll 65534
             for (int i = ID_HH; i < GUARANTEED_MARKER_1_H; i ++)
             {
                 briscBuffer[i] = 0;
@@ -167,10 +164,9 @@ namespace kernel_profiler{
             profiler_control_buffer[FLAT_ID] = core_flat_id;
         }
 
-#pragma GCC unroll 65534
         for (int i = GUARANTEED_MARKER_1_H; i < CUSTOM_MARKERS; i ++)
         {
-        //TODO(MO): Clean up magic numbers
+            //TODO(MO): Clean up magic numbers
             briscBuffer[i] = 0x80000000;
             ncriscBuffer[i] = 0x80000000;
             trisc0Buffer[i] = 0x80000000;
@@ -178,12 +174,11 @@ namespace kernel_profiler{
             trisc2Buffer[i] = 0x80000000;
         }
 
-        //TODO(MO): Clean up magic numbers
-        briscBuffer [ID_LL] = runCounter;
-        ncriscBuffer[ID_LL] = runCounter;
-        trisc0Buffer[ID_LL] = runCounter;
-        trisc1Buffer[ID_LL] = runCounter;
-        trisc2Buffer[ID_LL] = runCounter;
+        briscBuffer [ID_LL] = (runCounter & 0xFFFF) | (briscBuffer [ID_LL] & 0xFFFF0000);
+        ncriscBuffer[ID_LL] = (runCounter & 0xFFFF) | (ncriscBuffer[ID_LL] & 0xFFFF0000);
+        trisc0Buffer[ID_LL] = (runCounter & 0xFFFF) | (trisc0Buffer[ID_LL] & 0xFFFF0000);
+        trisc1Buffer[ID_LL] = (runCounter & 0xFFFF) | (trisc1Buffer[ID_LL] & 0xFFFF0000);
+        trisc2Buffer[ID_LL] = (runCounter & 0xFFFF) | (trisc2Buffer[ID_LL] & 0xFFFF0000);
 
 
 #endif //BRISC_INIT
@@ -208,14 +203,6 @@ namespace kernel_profiler{
         buffer[index+1] = p_reg[WALL_CLOCK_LOW_INDEX];
     }
 
-    inline __attribute__((always_inline)) void mark_end_at_index_inlined(uint32_t index, uint32_t timer_id_s, uint32_t timer_id)
-    {
-        volatile tt_l1_ptr uint32_t *buffer = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(kernel_profiler::profilerBuffer);
-        volatile tt_reg_ptr uint32_t *p_reg = reinterpret_cast<volatile tt_reg_ptr uint32_t *> (RISCV_DEBUG_REG_WALL_CLOCK_L);
-        buffer[index+2] = 0x80000000 | ((timer_id & 0x7FFFF) << 12) | (p_reg[WALL_CLOCK_HIGH_INDEX] & 0xFFF);
-        buffer[index+3] = p_reg[WALL_CLOCK_LOW_INDEX];
-    }
-
     inline __attribute__((always_inline)) void mark_padding()
     {
         if (wIndex < PROFILER_L1_VECTOR_SIZE)
@@ -233,6 +220,28 @@ namespace kernel_profiler{
         profiler_control_buffer[DROPPED_ZONES] = (1 << index) | curr;
     }
 
+    inline __attribute__((always_inline)) void set_host_counter(uint32_t counterValue)
+    {
+#if defined(COMPILE_FOR_ERISC)
+        volatile tt_l1_ptr uint32_t *eriscBuffer = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(eth_l1_mem::address_map::PROFILER_L1_BUFFER_ER);
+
+        eriscBuffer[ID_LL] = (counterValue << 16) | (eriscBuffer[ID_LL] & 0xFFFF);
+#endif //ERISC_INIT
+
+#if  defined(COMPILE_FOR_BRISC)
+        volatile tt_l1_ptr uint32_t *briscBuffer = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(PROFILER_L1_BUFFER_BR);
+        volatile tt_l1_ptr uint32_t *ncriscBuffer = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(PROFILER_L1_BUFFER_NC);
+        volatile tt_l1_ptr uint32_t *trisc0Buffer = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(PROFILER_L1_BUFFER_T0);
+        volatile tt_l1_ptr uint32_t *trisc1Buffer = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(PROFILER_L1_BUFFER_T1);
+        volatile tt_l1_ptr uint32_t *trisc2Buffer = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(PROFILER_L1_BUFFER_T2);
+
+        briscBuffer[ID_LL] = (counterValue << 16) | (briscBuffer[ID_LL] & 0xFFFF);
+        ncriscBuffer[ID_LL] = (counterValue << 16) | (ncriscBuffer[ID_LL] & 0xFFFF);
+        trisc0Buffer[ID_LL] = (counterValue << 16) | (trisc0Buffer[ID_LL] & 0xFFFF);
+        trisc1Buffer[ID_LL] = (counterValue << 16) | (trisc1Buffer[ID_LL] & 0xFFFF);
+        trisc2Buffer[ID_LL] = (counterValue << 16) | (trisc2Buffer[ID_LL] & 0xFFFF);
+#endif //ERISC_INIT
+    }
 
     inline __attribute__((always_inline)) void risc_finished_profiling()
     {
@@ -374,6 +383,7 @@ namespace kernel_profiler{
 #if defined(DISPATCH_KERNEL) && defined(COMPILE_FOR_NCRISC) && (PROFILE_KERNEL == PROFILER_OPT_DO_DISPATCH_CORES)
         SrcLocNameToHash("PROFILER-NOC-QUICK-SEND");
         mark_time_at_index_inlined(wIndex, hash);
+        wIndex += PROFILER_L1_MARKER_UINT32_SIZE;
         core_flat_id = noc_xy_to_profiler_flat_id[my_x[0]][my_y[0]];
 
         uint32_t dram_offset =
@@ -389,8 +399,8 @@ namespace kernel_profiler{
 
         uint64_t dram_bank_dst_noc_addr = s.get_noc_addr(core_flat_id / profiler_core_count_per_dram, dram_offset);
 
-        mark_end_at_index_inlined(wIndex, hash, get_end_timer_id(hash));
-        wIndex += QUICK_PUSH_MARKER_COUNT * PROFILER_L1_MARKER_UINT32_SIZE;
+        mark_time_at_index_inlined(wIndex, get_end_timer_id(hash));
+        wIndex += PROFILER_L1_MARKER_UINT32_SIZE;
 
         uint32_t currEndIndex = profiler_control_buffer[HOST_BUFFER_END_INDEX_NC] + wIndex;
 
@@ -523,6 +533,8 @@ namespace kernel_profiler{
 
 #define DeviceZoneScopedSumN2( name ) DO_PRAGMA(message(PROFILER_MSG_NAME(name))); auto constexpr hash = kernel_profiler::Hash16_CT(PROFILER_MSG_NAME(name)); kernel_profiler::profileScopeAccumulate<hash, 1> zone = kernel_profiler::profileScopeAccumulate<hash, 1>();
 
+#define DeviceZoneSetCounter( counter ) kernel_profiler::set_host_counter(counter);
+
 #else
 
 #define DeviceZoneScopedMainN( name )
@@ -536,5 +548,7 @@ namespace kernel_profiler{
 #define DeviceZoneScopedSumN2( name )
 
 #define DeviceZoneScopedND( name , nocBuffer, nocIndex )
+
+#define DeviceZoneSetCounter( counter )
 
 #endif

--- a/tt_metal/tools/profiler/process_device_log.py
+++ b/tt_metal/tools/profiler/process_device_log.py
@@ -209,7 +209,15 @@ def import_device_profile_log(logPath):
                 timerID = {"id": int(row[4].strip()), "zone_name": "", "zone_phase": "", "src_line": "", "src_file": ""}
                 timeData = int(row[5].strip())
                 statData = 0
-                if len(row) > 6:
+                if len(row) == 13:
+                    statData = int(row[6].strip())
+                    timerID["run_id"] = int(row[7].strip())
+                    timerID["op_id"] = int(row[8].strip())
+                    timerID["zone_name"] = row[9].strip()
+                    timerID["zone_phase"] = row[10].strip()
+                    timerID["src_line"] = int(row[11].strip())
+                    timerID["src_file"] = row[12].strip()
+                elif len(row) == 12:
                     statData = int(row[6].strip())
                     timerID["run_id"] = int(row[7].strip())
                     timerID["zone_name"] = row[8].strip()

--- a/tt_metal/tools/profiler/process_ops_logs.py
+++ b/tt_metal/tools/profiler/process_ops_logs.py
@@ -197,6 +197,10 @@ def append_device_data(ops, deviceLogFolder):
                 cores = set()
                 for timeID, ts, statData, risc, core in deviceOpTime["timeseries"]:
                     if "zone_name" in timeID.keys() and "FW" in timeID["zone_name"]:
+                        if "op_id" in timeID.keys():
+                            assert (
+                                timeID["op_id"] == deviceOp["global_call_count"]
+                            ), f"op id {timeID['op_id']} reproted by device is not matching assigned op id {deviceOp['global_call_count']}"
                         if core not in cores:
                             cores.add(core)
                 deviceOp["core_usage"] = {"count": len(cores), "cores": [str(core) for core in cores]}

--- a/tt_metal/tools/profiler/profiler.hpp
+++ b/tt_metal/tools/profiler/profiler.hpp
@@ -72,6 +72,7 @@ class DeviceProfiler {
         // Dumping profile result to file
         void dumpResultToFile(
                 uint32_t runID,
+                uint32_t runHostID,
                 int device_id,
                 CoreCoord core,
                 int core_flat,

--- a/tt_metal/tt_metal.cpp
+++ b/tt_metal/tt_metal.cpp
@@ -647,7 +647,7 @@ void WriteRuntimeArgsToDevice(Device *device, Program &program) {
                                 }
 
                                 if (rt_args.size() > 0) {
-                                    auto args_base_addr = kernel_config_base + kg.launch_msg.mem_map[dispatch_class].rta_offset;
+                                    auto args_base_addr = kernel_config_base + kg.launch_msg.kernel_config.mem_map[dispatch_class].rta_offset;
                                     log_trace(
                                               tt::LogMetal,
                                               "{} - Writing {} unique rtargs to core {} (physical: {}) addr 0x{:x} => args: {}",
@@ -662,7 +662,7 @@ void WriteRuntimeArgsToDevice(Device *device, Program &program) {
 
                                 const auto &common_rt_args = kernel->common_runtime_args();
                                 if (common_rt_args.size() > 0) {
-                                    auto common_rt_args_addr = kernel_config_base + kg.launch_msg.mem_map[dispatch_class].crta_offset;
+                                    auto common_rt_args_addr = kernel_config_base + kg.launch_msg.kernel_config.mem_map[dispatch_class].crta_offset;
                                     log_trace(
                                               tt::LogMetal,
                                               "{} - Writing {} common rtargs to core {} (physical: {}) addr 0x{:x} => args: {}",

--- a/tt_metal/tt_metal.cpp
+++ b/tt_metal/tt_metal.cpp
@@ -532,7 +532,7 @@ void LaunchProgram(Device *device, Program &program, bool wait_until_cores_done)
         for (const auto &[core_type, logical_cores] : logical_cores_used_in_program) {
             for (const auto &logical_core : logical_cores) {
                 launch_msg_t *msg = &program.kernels_on_core(logical_core, core_type)->launch_msg;
-
+                msg->kernel_config.host_assigned_op_id = program.get_global_id();
                 auto physical_core = device->physical_core_from_logical_core(logical_core, core_type);
                 not_done_cores.insert(physical_core);
                 tt::llrt::write_launch_msg_to_core(device->id(), physical_core, msg);

--- a/ttnn/cpp/ttnn/device_operation.hpp
+++ b/ttnn/cpp/ttnn/device_operation.hpp
@@ -293,6 +293,8 @@ typename device_operation_t::tensor_return_value_t run(
     auto& program = create_or_get_program_from_cache<device_operation_t>(
         program_cache, program_cache_hit, program_hash, operation_attributes, tensor_args, tensor_return_value);
 
+    program.set_global_id(operation_id);
+
     if (USE_FAST_DISPATCH) {
         ZoneScopedN("EnqueueProgram");
         auto& queue = device->command_queue(cq_id);


### PR DESCRIPTION
### Ticket
[3764](https://github.com/tenstorrent/tt-metal/issues/3764)

### Problem description
Device profiler data did not know which op the running kernels belonged to.

### What's changed

- opID is now updated for cached and uncached FD enqueue programs and for SD LaunchProgram. 
- BRISC FW sets the ID for all riscs ops

With this:

- Device side opID is verified against the expected ID extracted by host
- Tracy device zones include opID
<img width="888" alt="Screenshot 2024-06-28 at 3 11 12 PM" src="https://github.com/tenstorrent/tt-metal/assets/109363418/faa51ca0-68a6-4e1c-8e5c-877f91af0eab">


### Checklist
- [ ] Post commit CI passes
- [ ] uBenchmark
- [ ] Device Perf
- [ ] T3K profiler
