### PR TITLE
#9628: Merge third set of binary backward op from tt_eager to TTNN

### DIFF
--- a/docs/source/ttnn/ttnn/api.rst
+++ b/docs/source/ttnn/ttnn/api.rst
@@ -208,6 +208,7 @@ Pointwise Binary
    ttnn/rsub_bw
    ttnn/bias_gelu_bw
    ttnn/binary_gt_bw
+   ttnn/binary_lt_bw
    ttnn/binary_ne_bw
    ttnn/binary_ge_bw
    ttnn/min_bw

--- a/docs/source/ttnn/ttnn/api.rst
+++ b/docs/source/ttnn/ttnn/api.rst
@@ -209,6 +209,7 @@ Pointwise Binary
    ttnn/bias_gelu_bw
    ttnn/binary_gt_bw
    ttnn/binary_ne_bw
+   ttnn/binary_ge_bw
 
 Pointwise Ternary
 =================

--- a/docs/source/ttnn/ttnn/api.rst
+++ b/docs/source/ttnn/ttnn/api.rst
@@ -211,6 +211,7 @@ Pointwise Binary
    ttnn/binary_ne_bw
    ttnn/binary_ge_bw
    ttnn/min_bw
+   ttnn/max_bw
 
 Pointwise Ternary
 =================

--- a/docs/source/ttnn/ttnn/api.rst
+++ b/docs/source/ttnn/ttnn/api.rst
@@ -207,6 +207,7 @@ Pointwise Binary
    ttnn/binary_le_bw
    ttnn/rsub_bw
    ttnn/bias_gelu_bw
+   ttnn/binary_gt_bw
 
 Pointwise Ternary
 =================

--- a/docs/source/ttnn/ttnn/api.rst
+++ b/docs/source/ttnn/ttnn/api.rst
@@ -208,6 +208,7 @@ Pointwise Binary
    ttnn/rsub_bw
    ttnn/bias_gelu_bw
    ttnn/binary_gt_bw
+   ttnn/binary_ne_bw
 
 Pointwise Ternary
 =================

--- a/docs/source/ttnn/ttnn/api.rst
+++ b/docs/source/ttnn/ttnn/api.rst
@@ -210,6 +210,7 @@ Pointwise Binary
    ttnn/binary_gt_bw
    ttnn/binary_ne_bw
    ttnn/binary_ge_bw
+   ttnn/min_bw
 
 Pointwise Ternary
 =================

--- a/docs/source/ttnn/ttnn/api.rst
+++ b/docs/source/ttnn/ttnn/api.rst
@@ -212,6 +212,7 @@ Pointwise Binary
    ttnn/binary_ge_bw
    ttnn/min_bw
    ttnn/max_bw
+   ttnn/div_bw
 
 Pointwise Ternary
 =================

--- a/docs/source/ttnn/ttnn/api.rst
+++ b/docs/source/ttnn/ttnn/api.rst
@@ -215,6 +215,7 @@ Pointwise Binary
    ttnn/max_bw
    ttnn/div_bw
    ttnn/lerp_bw
+   ttnn/mul_bw
 
 Pointwise Ternary
 =================

--- a/docs/source/ttnn/ttnn/api.rst
+++ b/docs/source/ttnn/ttnn/api.rst
@@ -214,6 +214,7 @@ Pointwise Binary
    ttnn/min_bw
    ttnn/max_bw
    ttnn/div_bw
+   ttnn/lerp_bw
 
 Pointwise Ternary
 =================

--- a/docs/source/ttnn/ttnn/dependencies/tt_lib.rst
+++ b/docs/source/ttnn/ttnn/dependencies/tt_lib.rst
@@ -852,8 +852,6 @@ Backward Operations
 
 .. autofunction:: tt_lib.tensor.mul_bw
 
-.. autofunction:: tt_lib.tensor.max_bw
-
 .. autofunction:: tt_lib.tensor.tan_bw
 
 .. autofunction:: tt_lib.tensor.exp_bw

--- a/docs/source/ttnn/ttnn/dependencies/tt_lib.rst
+++ b/docs/source/ttnn/ttnn/dependencies/tt_lib.rst
@@ -946,8 +946,6 @@ Backward Operations
 
 .. autofunction:: tt_lib.tensor.celu_bw
 
-.. autofunction:: tt_lib.tensor.binary_lt_bw
-
 .. autofunction:: tt_lib.tensor.log10_bw
 
 .. autofunction:: tt_lib.tensor.log1p_bw

--- a/docs/source/ttnn/ttnn/dependencies/tt_lib.rst
+++ b/docs/source/ttnn/ttnn/dependencies/tt_lib.rst
@@ -848,8 +848,6 @@ Backward Operations
 
 .. autofunction:: tt_lib.tensor.sqrt_bw
 
-.. autofunction:: tt_lib.tensor.mul_bw
-
 .. autofunction:: tt_lib.tensor.tan_bw
 
 .. autofunction:: tt_lib.tensor.exp_bw

--- a/docs/source/ttnn/ttnn/dependencies/tt_lib.rst
+++ b/docs/source/ttnn/ttnn/dependencies/tt_lib.rst
@@ -898,8 +898,6 @@ Backward Operations
 
 .. autofunction:: tt_lib.tensor.bias_gelu_unary_bw
 
-.. autofunction:: tt_lib.tensor.lerp_bw
-
 .. autofunction:: tt_lib.tensor.hardsigmoid_bw
 
 .. autofunction:: tt_lib.tensor.i0_bw

--- a/docs/source/ttnn/ttnn/dependencies/tt_lib.rst
+++ b/docs/source/ttnn/ttnn/dependencies/tt_lib.rst
@@ -854,8 +854,6 @@ Backward Operations
 
 .. autofunction:: tt_lib.tensor.max_bw
 
-.. autofunction:: tt_lib.tensor.min_bw
-
 .. autofunction:: tt_lib.tensor.tan_bw
 
 .. autofunction:: tt_lib.tensor.exp_bw

--- a/docs/source/ttnn/ttnn/dependencies/tt_lib.rst
+++ b/docs/source/ttnn/ttnn/dependencies/tt_lib.rst
@@ -982,8 +982,6 @@ Backward Operations
 
 .. autofunction:: tt_lib.tensor.binary_ge_bw
 
-.. autofunction:: tt_lib.tensor.binary_gt_bw
-
 .. autofunction:: tt_lib.tensor.square_bw
 
 .. autofunction:: tt_lib.tensor.lgamma_bw

--- a/docs/source/ttnn/ttnn/dependencies/tt_lib.rst
+++ b/docs/source/ttnn/ttnn/dependencies/tt_lib.rst
@@ -978,8 +978,6 @@ Backward Operations
 
 .. autofunction:: tt_lib.tensor.selu_bw
 
-.. autofunction:: tt_lib.tensor.binary_ge_bw
-
 .. autofunction:: tt_lib.tensor.square_bw
 
 .. autofunction:: tt_lib.tensor.lgamma_bw

--- a/docs/source/ttnn/ttnn/dependencies/tt_lib.rst
+++ b/docs/source/ttnn/ttnn/dependencies/tt_lib.rst
@@ -844,8 +844,6 @@ Backward Operations
 
 .. autofunction:: tt_lib.tensor.unary_div_bw
 
-.. autofunction:: tt_lib.tensor.div_bw
-
 .. autofunction:: tt_lib.tensor.rdiv_bw
 
 .. autofunction:: tt_lib.tensor.sqrt_bw

--- a/docs/source/ttnn/ttnn/dependencies/tt_lib.rst
+++ b/docs/source/ttnn/ttnn/dependencies/tt_lib.rst
@@ -958,8 +958,6 @@ Backward Operations
 
 .. autofunction:: tt_lib.tensor.log1p_bw
 
-.. autofunction:: tt_lib.tensor.binary_ne_bw
-
 .. autofunction:: tt_lib.tensor.erf_bw
 
 .. autofunction:: tt_lib.tensor.erfc_bw

--- a/docs/source/ttnn/ttnn/ttnn/binary_ge_bw.rst
+++ b/docs/source/ttnn/ttnn/ttnn/binary_ge_bw.rst
@@ -1,0 +1,6 @@
+.. _ttnn.binary_ge_bw:
+
+ttnn.binary_ge_bw
+#################
+
+.. autofunction:: ttnn.binary_ge_bw

--- a/docs/source/ttnn/ttnn/ttnn/binary_gt_bw.rst
+++ b/docs/source/ttnn/ttnn/ttnn/binary_gt_bw.rst
@@ -1,0 +1,6 @@
+.. _ttnn.binary_gt_bw:
+
+ttnn.binary_gt_bw
+#################
+
+.. autofunction:: ttnn.binary_gt_bw

--- a/docs/source/ttnn/ttnn/ttnn/binary_lt_bw.rst
+++ b/docs/source/ttnn/ttnn/ttnn/binary_lt_bw.rst
@@ -1,0 +1,6 @@
+.. _ttnn.binary_lt_bw:
+
+ttnn.binary_lt_bw
+#################
+
+.. autofunction:: ttnn.binary_lt_bw

--- a/docs/source/ttnn/ttnn/ttnn/binary_ne_bw.rst
+++ b/docs/source/ttnn/ttnn/ttnn/binary_ne_bw.rst
@@ -1,0 +1,6 @@
+.. _ttnn.binary_ne_bw:
+
+ttnn.binary_ne_bw
+#################
+
+.. autofunction:: ttnn.binary_ne_bw

--- a/docs/source/ttnn/ttnn/ttnn/div_bw.rst
+++ b/docs/source/ttnn/ttnn/ttnn/div_bw.rst
@@ -1,0 +1,6 @@
+.. _ttnn.div_bw:
+
+ttnn.div_bw
+###############
+
+.. autofunction:: ttnn.div_bw

--- a/docs/source/ttnn/ttnn/ttnn/lerp_bw.rst
+++ b/docs/source/ttnn/ttnn/ttnn/lerp_bw.rst
@@ -1,0 +1,6 @@
+.. _ttnn.lerp_bw:
+
+ttnn.lerp_bw
+#################
+
+.. autofunction:: ttnn.lerp_bw

--- a/docs/source/ttnn/ttnn/ttnn/max_bw.rst
+++ b/docs/source/ttnn/ttnn/ttnn/max_bw.rst
@@ -1,0 +1,6 @@
+.. _ttnn.max_bw:
+
+ttnn.max_bw
+###############
+
+.. autofunction:: ttnn.max_bw

--- a/docs/source/ttnn/ttnn/ttnn/min_bw.rst
+++ b/docs/source/ttnn/ttnn/ttnn/min_bw.rst
@@ -1,0 +1,6 @@
+.. _ttnn.min_bw:
+
+ttnn.min_bw
+###############
+
+.. autofunction:: ttnn.min_bw

--- a/docs/source/ttnn/ttnn/ttnn/mul_bw.rst
+++ b/docs/source/ttnn/ttnn/ttnn/mul_bw.rst
@@ -1,0 +1,6 @@
+.. _ttnn.mul_bw:
+
+ttnn.mul_bw
+###########
+
+.. autofunction:: ttnn.mul_bw

--- a/tests/tt_eager/python_api_testing/unit_testing/backward_ops/test_backward_add.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/backward_ops/test_backward_add.py
@@ -64,8 +64,8 @@ def test_bw_add_with_opt_output(input_shapes, device, are_required_outputs):
         input_tensor,
         other_tensor,
         are_required_outputs=are_required_outputs,
-        optional_input_a_grad=input_grad,
-        optional_input_b_grad=other_grad,
+        input_a_grad=input_grad,
+        input_b_grad=other_grad,
         queue_id=cq_id,
     )
 

--- a/tests/tt_eager/python_api_testing/unit_testing/backward_ops/test_backward_addalpha.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/backward_ops/test_backward_addalpha.py
@@ -67,8 +67,8 @@ def test_bw_addalpha_with_opt_output(input_shapes, alpha, device, are_required_o
         other_tensor,
         alpha,
         are_required_outputs=are_required_outputs,
-        optional_input_a_grad=input_grad,
-        optional_input_b_grad=other_grad,
+        input_a_grad=input_grad,
+        input_b_grad=other_grad,
         queue_id=cq_id,
     )
 

--- a/tests/tt_eager/python_api_testing/unit_testing/backward_ops/test_backward_binary_eq.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/backward_ops/test_backward_binary_eq.py
@@ -56,8 +56,8 @@ def test_bw_binary_eq_opt_output(input_shapes, device, are_required_outputs):
         input_tensor,
         other_tensor,
         are_required_outputs=are_required_outputs,
-        optional_input_a_grad=input_grad,
-        optional_input_b_grad=other_grad,
+        input_a_grad=input_grad,
+        input_b_grad=other_grad,
     )
 
     in_grad = torch.zeros_like(in_data)
@@ -99,8 +99,8 @@ def test_bw_binary_eq_opt_output_qid(input_shapes, device, are_required_outputs)
         input_tensor,
         other_tensor,
         are_required_outputs=are_required_outputs,
-        optional_input_a_grad=input_grad,
-        optional_input_b_grad=other_grad,
+        input_a_grad=input_grad,
+        input_b_grad=other_grad,
         queue_id=cq_id,
     )
 

--- a/tests/tt_eager/python_api_testing/unit_testing/backward_ops/test_backward_binary_ge.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/backward_ops/test_backward_binary_ge.py
@@ -5,6 +5,7 @@
 import torch
 import pytest
 import tt_lib
+import ttnn
 from tests.tt_eager.python_api_testing.unit_testing.backward_ops.utility_funcs import data_gen_with_range, compare_pcc
 
 
@@ -20,7 +21,7 @@ def test_bw_binary_ge(input_shapes, device):
     in_data, input_tensor = data_gen_with_range(input_shapes, -100, 100, device, True)
     grad_data, grad_tensor = data_gen_with_range(input_shapes, -100, 100, device)
 
-    tt_output_tensor_on_device = tt_lib.tensor.binary_ge_bw(grad_tensor, input_tensor)
+    tt_output_tensor_on_device = ttnn.binary_ge_bw(grad_tensor, input_tensor, input_tensor)
     pt_y = torch.zeros_like(grad_data)
     golden_tensor = [pt_y, pt_y]
     comp_pass = compare_pcc(tt_output_tensor_on_device, golden_tensor)

--- a/tests/tt_eager/python_api_testing/unit_testing/backward_ops/test_backward_binary_gt.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/backward_ops/test_backward_binary_gt.py
@@ -5,6 +5,7 @@
 import torch
 import pytest
 import tt_lib
+import ttnn
 from tests.tt_eager.python_api_testing.unit_testing.backward_ops.utility_funcs import data_gen_with_range, compare_pcc
 
 
@@ -18,9 +19,10 @@ from tests.tt_eager.python_api_testing.unit_testing.backward_ops.utility_funcs i
 )
 def test_bw_binary_gt(input_shapes, device):
     in_data, input_tensor = data_gen_with_range(input_shapes, -100, 100, device, True)
+    other_data, other_tensor = data_gen_with_range(input_shapes, -100, 100, device, True)
     grad_data, grad_tensor = data_gen_with_range(input_shapes, -100, 100, device)
 
-    tt_output_tensor_on_device = tt_lib.tensor.binary_gt_bw(grad_tensor, input_tensor)
+    tt_output_tensor_on_device = ttnn.binary_gt_bw(grad_tensor, input_tensor, other_tensor)
     pt_y = torch.zeros_like(grad_data)
     golden_tensor = [pt_y, pt_y]
     comp_pass = compare_pcc(tt_output_tensor_on_device, golden_tensor)

--- a/tests/tt_eager/python_api_testing/unit_testing/backward_ops/test_backward_binary_lt.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/backward_ops/test_backward_binary_lt.py
@@ -4,7 +4,7 @@
 
 import torch
 import pytest
-import tt_lib
+import ttnn
 from tests.tt_eager.python_api_testing.unit_testing.backward_ops.utility_funcs import data_gen_with_range, compare_pcc
 
 
@@ -18,9 +18,10 @@ from tests.tt_eager.python_api_testing.unit_testing.backward_ops.utility_funcs i
 )
 def test_bw_binary_lt(input_shapes, device):
     in_data, input_tensor = data_gen_with_range(input_shapes, -100, 100, device, True)
+    other_data, other_tensor = data_gen_with_range(input_shapes, -100, 100, device, True)
     grad_data, grad_tensor = data_gen_with_range(input_shapes, -5, 5, device)
 
-    tt_output_tensor_on_device = tt_lib.tensor.binary_lt_bw(grad_tensor, input_tensor)
+    tt_output_tensor_on_device = ttnn.binary_lt_bw(grad_tensor, input_tensor, other_tensor)
     pt_y = torch.zeros_like(grad_data)
     golden_tensor = [pt_y, pt_y]
     comp_pass = compare_pcc(tt_output_tensor_on_device, golden_tensor)

--- a/tests/tt_eager/python_api_testing/unit_testing/backward_ops/test_backward_binary_ne.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/backward_ops/test_backward_binary_ne.py
@@ -5,6 +5,7 @@
 import torch
 import pytest
 import tt_lib
+import ttnn
 from tests.tt_eager.python_api_testing.unit_testing.backward_ops.utility_funcs import data_gen_with_range, compare_pcc
 
 
@@ -20,7 +21,7 @@ def test_bw_binary_ne(input_shapes, device):
     in_data, input_tensor = data_gen_with_range(input_shapes, -100, 100, device, True)
     grad_data, grad_tensor = data_gen_with_range(input_shapes, -5, 5, device)
 
-    tt_output_tensor_on_device = tt_lib.tensor.binary_ne_bw(grad_tensor, input_tensor)
+    tt_output_tensor_on_device = ttnn.binary_ne_bw(grad_tensor, input_tensor, input_tensor)
     pt_y = torch.zeros_like(grad_data)
     golden_tensor = [pt_y, pt_y]
     comp_pass = compare_pcc(tt_output_tensor_on_device, golden_tensor)

--- a/tests/tt_eager/python_api_testing/unit_testing/backward_ops/test_backward_div.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/backward_ops/test_backward_div.py
@@ -4,7 +4,7 @@
 
 import torch
 import pytest
-import tt_lib
+import ttnn
 from tests.tt_eager.python_api_testing.unit_testing.backward_ops.utility_funcs import data_gen_with_range, compare_pcc
 
 
@@ -33,7 +33,7 @@ def test_bw_div(input_shapes, round_mode, device):
 
     if round_mode == None:
         round_mode = "None"
-    tt_output_tensor_on_device = tt_lib.tensor.div_bw(grad_tensor, input_tensor, other_tensor, round_mode=round_mode)
+    tt_output_tensor_on_device = ttnn.div_bw(grad_tensor, input_tensor, other_tensor, mode=round_mode)
 
     in_data.retain_grad()
     other_data.retain_grad()

--- a/tests/tt_eager/python_api_testing/unit_testing/backward_ops/test_backward_lerp.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/backward_ops/test_backward_lerp.py
@@ -4,10 +4,10 @@
 
 import torch
 import pytest
-import tt_lib
+import ttnn
 from tests.tt_eager.python_api_testing.unit_testing.backward_ops.utility_funcs import compare_pcc, data_gen_with_range
 
-
+"""
 @pytest.mark.parametrize(
     "input_shapes",
     (
@@ -35,6 +35,7 @@ def test_bw_lerp(input_shapes, device):
 
     status = compare_pcc(tt_output_tensor_on_device, golden_tensor)
     assert status
+"""
 
 
 @pytest.mark.parametrize(
@@ -51,7 +52,7 @@ def test_bw_lerp_weight_scalar(input_shapes, weight, device):
     in_data, input_tensor = data_gen_with_range(input_shapes, -200, 201, device, True)
     end_data, end_tensor = data_gen_with_range(input_shapes, -199, 199, device, True)
 
-    tt_output_tensor_on_device = tt_lib.tensor.lerp_bw(grad_tensor, input_tensor, end_tensor, weight)
+    tt_output_tensor_on_device = ttnn.lerp_bw(grad_tensor, input_tensor, end_tensor, weight)
 
     in_data.retain_grad()
     end_data.retain_grad()

--- a/tests/tt_eager/python_api_testing/unit_testing/backward_ops/test_backward_lerp.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/backward_ops/test_backward_lerp.py
@@ -7,7 +7,7 @@ import pytest
 import ttnn
 from tests.tt_eager.python_api_testing.unit_testing.backward_ops.utility_funcs import compare_pcc, data_gen_with_range
 
-"""
+
 @pytest.mark.parametrize(
     "input_shapes",
     (
@@ -22,7 +22,7 @@ def test_bw_lerp(input_shapes, device):
     end_data, end_tensor = data_gen_with_range(input_shapes, -199, 199, device, True)
     weight_data, weight_tensor = data_gen_with_range(input_shapes, -201, 201, device, True)
 
-    tt_output_tensor_on_device = tt_lib.tensor.lerp_bw(grad_tensor, input_tensor, end_tensor, weight_tensor)
+    tt_output_tensor_on_device = ttnn.lerp_bw(grad_tensor, input_tensor, end_tensor, weight_tensor)
 
     in_data.retain_grad()
     end_data.retain_grad()
@@ -35,7 +35,6 @@ def test_bw_lerp(input_shapes, device):
 
     status = compare_pcc(tt_output_tensor_on_device, golden_tensor)
     assert status
-"""
 
 
 @pytest.mark.parametrize(

--- a/tests/tt_eager/python_api_testing/unit_testing/backward_ops/test_backward_max.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/backward_ops/test_backward_max.py
@@ -4,7 +4,7 @@
 
 import torch
 import pytest
-import tt_lib
+import ttnn
 from tests.tt_eager.python_api_testing.unit_testing.backward_ops.utility_funcs import data_gen_with_range, compare_pcc
 
 
@@ -21,7 +21,7 @@ def test_bw_max(input_shapes, device):
     other_data, other_tensor = data_gen_with_range(input_shapes, 1, 2, device, True)
     grad_data, grad_tensor = data_gen_with_range(input_shapes, -10, -1, device, True)
 
-    tt_output_tensor_on_device = tt_lib.tensor.max_bw(grad_tensor, input_tensor, other_tensor)
+    tt_output_tensor_on_device = ttnn.max_bw(grad_tensor, input_tensor, other_tensor)
 
     in_data.retain_grad()
     other_data.retain_grad()

--- a/tests/tt_eager/python_api_testing/unit_testing/backward_ops/test_backward_min.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/backward_ops/test_backward_min.py
@@ -4,7 +4,7 @@
 
 import torch
 import pytest
-import tt_lib
+import ttnn
 from tests.tt_eager.python_api_testing.unit_testing.backward_ops.utility_funcs import data_gen_with_range, compare_pcc
 
 
@@ -21,7 +21,7 @@ def test_bw_min(input_shapes, device):
     other_data, other_tensor = data_gen_with_range(input_shapes, 1, 2, device, True)
     grad_data, grad_tensor = data_gen_with_range(input_shapes, -10, -1, device, True)
 
-    tt_output_tensor_on_device = tt_lib.tensor.min_bw(grad_tensor, input_tensor, other_tensor)
+    tt_output_tensor_on_device = ttnn.min_bw(grad_tensor, input_tensor, other_tensor)
 
     in_data.retain_grad()
     other_data.retain_grad()

--- a/tests/tt_eager/python_api_testing/unit_testing/backward_ops/test_backward_mul.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/backward_ops/test_backward_mul.py
@@ -4,7 +4,7 @@
 
 import torch
 import pytest
-import tt_lib
+import ttnn
 from tests.tt_eager.python_api_testing.unit_testing.backward_ops.utility_funcs import data_gen_with_range, compare_pcc
 
 
@@ -21,7 +21,7 @@ def test_bw_mul(input_shapes, device):
     in_data_b, input_tensor_b = data_gen_with_range(input_shapes, -5, 5, device, True)
     grad_data, grad_tensor = data_gen_with_range(input_shapes, -100, 100, device)
 
-    tt_output_tensor_on_device = tt_lib.tensor.mul_bw(grad_tensor, input_tensor_a, input_tensor_b)
+    tt_output_tensor_on_device = ttnn.mul_bw(grad_tensor, input_tensor_a, input_tensor_b)
 
     in_data_a.retain_grad()
     in_data_b.retain_grad()
@@ -44,7 +44,7 @@ def test_bw_mul(input_shapes, device):
         (torch.Size([1, 3, 320, 384])),
     ),
 )
-@pytest.mark.parametrize("are_required_outputs", [[True, True], [True, False], [False, True]])
+@pytest.mark.parametrize("are_required_outputs", [[True, True], [True, False], [False, True], [False, False]])
 @pytest.mark.parametrize("pass_queue_id", [True, False])
 def test_bw_mul_opt_output(input_shapes, device, are_required_outputs, pass_queue_id):
     in_data_a, input_tensor_a = data_gen_with_range(input_shapes, -90, 80, device, True)
@@ -61,7 +61,7 @@ def test_bw_mul_opt_output(input_shapes, device, are_required_outputs, pass_queu
 
     cq_id = 0
     if pass_queue_id:
-        tt_output_tensor_on_device = tt_lib.tensor.mul_bw(
+        tt_output_tensor_on_device = ttnn.mul_bw(
             grad_tensor,
             input_tensor_a,
             input_tensor_b,
@@ -71,7 +71,7 @@ def test_bw_mul_opt_output(input_shapes, device, are_required_outputs, pass_queu
             queue_id=cq_id,
         )
     else:
-        tt_output_tensor_on_device = tt_lib.tensor.mul_bw(
+        tt_output_tensor_on_device = ttnn.mul_bw(
             grad_tensor,
             input_tensor_a,
             input_tensor_b,

--- a/tests/ttnn/unit_tests/operations/test_backward.py
+++ b/tests/ttnn/unit_tests/operations/test_backward.py
@@ -157,3 +157,12 @@ def test_logaddexp2(device, h, w, in_val, grad_val, other_val):
 def test_squared_difference(device, h, w, in_val, grad_val, other_val):
     torch_squared_diff = lambda x, y: torch.square(torch.sub(x, y))
     run_backward_binary_test(device, h, w, in_val, grad_val, other_val, ttnn.squared_difference_bw, torch_squared_diff)
+
+
+@pytest.mark.parametrize("h", [64])
+@pytest.mark.parametrize("w", [128])
+@pytest.mark.parametrize("in_val", [-1, 1])
+@pytest.mark.parametrize("grad_val", [-1, 0, 1])
+@pytest.mark.parametrize("other_val", [-1, 1])
+def test_min(device, h, w, in_val, grad_val, other_val):
+    run_backward_binary_test(device, h, w, in_val, grad_val, other_val, ttnn.min_bw, torch.min)

--- a/tests/ttnn/unit_tests/operations/test_backward.py
+++ b/tests/ttnn/unit_tests/operations/test_backward.py
@@ -166,3 +166,12 @@ def test_squared_difference(device, h, w, in_val, grad_val, other_val):
 @pytest.mark.parametrize("other_val", [-1, 1])
 def test_min(device, h, w, in_val, grad_val, other_val):
     run_backward_binary_test(device, h, w, in_val, grad_val, other_val, ttnn.min_bw, torch.min)
+
+
+@pytest.mark.parametrize("h", [64])
+@pytest.mark.parametrize("w", [128])
+@pytest.mark.parametrize("in_val", [-1, 1])
+@pytest.mark.parametrize("grad_val", [-1, 0, 1])
+@pytest.mark.parametrize("other_val", [-1, 1])
+def test_max(device, h, w, in_val, grad_val, other_val):
+    run_backward_binary_test(device, h, w, in_val, grad_val, other_val, ttnn.max_bw, torch.max)

--- a/tt_eager/tt_dnn/op_library/backward/backward_ops.cpp
+++ b/tt_eager/tt_dnn/op_library/backward/backward_ops.cpp
@@ -1501,18 +1501,6 @@ std::vector<Tensor> log1p_bw(const Tensor& grad, const Tensor& input, const Memo
     return operation::decorate_as_composite(__func__, _log1p_bw)(grad, input, output_mem_config);
 }
 
-std::vector<Tensor> _binary_ne_bw(const Tensor& grad, const Tensor& input, const MemoryConfig& output_mem_config) {
-    std::vector<Tensor> grad_tensor;
-    Tensor zero_grad = zeros_like(grad, output_mem_config);
-    grad_tensor.emplace_back(zero_grad);
-    Tensor zero_input = zeros_like(input, output_mem_config);
-    grad_tensor.emplace_back(zero_input);
-    return grad_tensor;
-}
-std::vector<Tensor> binary_ne_bw(const Tensor& grad, const Tensor& input, const MemoryConfig& output_mem_config) {
-    return operation::decorate_as_composite(__func__, _binary_ne_bw)(grad, input, output_mem_config);
-}
-
 std::vector<Tensor> _erf_bw(const Tensor& grad, const Tensor& input, const MemoryConfig& output_mem_config) {
     std::vector<Tensor> grad_tensor;
     Tensor result = mul_unary(

--- a/tt_eager/tt_dnn/op_library/backward/backward_ops.cpp
+++ b/tt_eager/tt_dnn/op_library/backward/backward_ops.cpp
@@ -689,22 +689,6 @@ std::vector<Tensor> exp2_bw(const Tensor& grad, const Tensor& input, const Memor
 }
 
 // lerp(input, end, weight) = self: grad * (1 - weight), end: grad * weight
-std::vector<Tensor> _lerp(
-    const Tensor& grad, const Tensor& input, const Tensor& end, float weight, const MemoryConfig& output_mem_config) {
-    std::vector<Tensor> grad_tensor;
-    float sub_scalar = 1.0f - weight;
-    Tensor result_1 = mul_unary(grad, sub_scalar, output_mem_config);
-    grad_tensor.emplace_back(result_1);
-    Tensor result_2 = mul_unary(grad, weight, output_mem_config);
-    grad_tensor.emplace_back(result_2);
-    return grad_tensor;
-}
-std::vector<Tensor> lerp_bw(
-    const Tensor& grad, const Tensor& input, const Tensor& end, float weight, const MemoryConfig& output_mem_config) {
-    return operation::decorate_as_composite(__func__, _lerp)(grad, input, end, weight, output_mem_config);
-}
-
-// lerp(input, end, weight) = self: grad * (1 - weight), end: grad * weight
 std::vector<Tensor> _lerp_overload(
     const Tensor& grad,
     const Tensor& input,

--- a/tt_eager/tt_dnn/op_library/backward/backward_ops.cpp
+++ b/tt_eager/tt_dnn/op_library/backward/backward_ops.cpp
@@ -1691,18 +1691,6 @@ std::vector<Tensor> selu_bw(const Tensor& grad, const Tensor& input, const Memor
     return operation::decorate_as_composite(__func__, _selu_bw)(grad, input, output_mem_config);
 }
 
-std::vector<Tensor> _binary_ge_bw(const Tensor& grad, const Tensor& input, const MemoryConfig& output_mem_config) {
-    std::vector<Tensor> grad_tensor;
-    Tensor zero_grad = zeros_like(grad, output_mem_config);
-    grad_tensor.emplace_back(zero_grad);
-    Tensor zero_input = zeros_like(input, output_mem_config);
-    grad_tensor.emplace_back(zero_input);
-    return grad_tensor;
-}
-std::vector<Tensor> binary_ge_bw(const Tensor& grad, const Tensor& input, const MemoryConfig& output_mem_config) {
-    return operation::decorate_as_composite(__func__, _binary_ge_bw)(grad, input, output_mem_config);
-}
-
 
 // Autoformat support
 Tensor change_layout_to_tile(const Tensor& temp, const MemoryConfig& output_mem_config) {

--- a/tt_eager/tt_dnn/op_library/backward/backward_ops.cpp
+++ b/tt_eager/tt_dnn/op_library/backward/backward_ops.cpp
@@ -547,46 +547,6 @@ std::vector<std::optional<Tensor>> where_bw(
     return operation::decorate_as_composite(__func__, _where_bw)(default_queue_id, grad, condition, input, other, output_mem_config, are_required_outputs, input_grad, other_grad);
 }
 
-// template parameter min_or_max = TRUE for MAX, FALSE for MIN
-template <bool min_or_max>
-std::vector<Tensor> _min_or_max_bw(
-    const Tensor& grad, const Tensor& input, const Tensor& other, const MemoryConfig& output_mem_config) {
-    Tensor zeros_t = zeros_like(input, output_mem_config);
-    std::vector<Tensor> grad_tensor;
-    Tensor t_scale_grad = mul_unary(grad, 0.5, output_mem_config);
-    Tensor t_sub = ttnn::subtract(other, input, std::nullopt, output_mem_config);
-    Tensor t_sub_gtz = gtz(t_sub, output_mem_config);
-    Tensor t_sub_eqz = eqz(t_sub, output_mem_config);
-    Tensor t_sub_ltz = ltz(t_sub, output_mem_config);
-    Tensor grad_other =
-        ttnn::add(ttnn::multiply(t_sub_ltz, grad, std::nullopt, output_mem_config),
-            ttnn::multiply(t_sub_eqz, t_scale_grad, std::nullopt, output_mem_config),
-            std::nullopt,
-            output_mem_config);
-    Tensor grad_input =
-        ttnn::add(ttnn::multiply(t_sub_gtz, grad, std::nullopt, output_mem_config),
-            ttnn::multiply(t_sub_eqz, t_scale_grad, std::nullopt, output_mem_config),
-            std::nullopt,
-            output_mem_config);
-
-    if (min_or_max) {
-        // MAX
-        grad_tensor.emplace_back(grad_other);
-        grad_tensor.emplace_back(grad_input);
-    } else {
-        // MIN
-        grad_tensor.emplace_back(grad_input);
-        grad_tensor.emplace_back(grad_other);
-    }
-    return grad_tensor;
-}
-auto _max_bw = _min_or_max_bw<true>;
-auto _min_bw = _min_or_max_bw<false>;
-
-std::vector<Tensor> max_bw(
-    const Tensor& grad, const Tensor& input, const Tensor& other, const MemoryConfig& output_mem_config) {
-    return operation::decorate_as_composite(__func__, _max_bw)(grad, input, other, output_mem_config);
-}
 
 std::vector<Tensor> _fill_zero_bw(const Tensor& grad, const MemoryConfig& output_mem_config) {
     std::vector<Tensor> grad_tensor;

--- a/tt_eager/tt_dnn/op_library/backward/backward_ops.cpp
+++ b/tt_eager/tt_dnn/op_library/backward/backward_ops.cpp
@@ -588,11 +588,6 @@ std::vector<Tensor> max_bw(
     return operation::decorate_as_composite(__func__, _max_bw)(grad, input, other, output_mem_config);
 }
 
-std::vector<Tensor> min_bw(
-    const Tensor& grad, const Tensor& input, const Tensor& other, const MemoryConfig& output_mem_config) {
-    return operation::decorate_as_composite(__func__, _min_bw)(grad, input, other, output_mem_config);
-}
-
 std::vector<Tensor> _fill_zero_bw(const Tensor& grad, const MemoryConfig& output_mem_config) {
     std::vector<Tensor> grad_tensor;
     Tensor result = zeros_like(grad, output_mem_config);

--- a/tt_eager/tt_dnn/op_library/backward/backward_ops.cpp
+++ b/tt_eager/tt_dnn/op_library/backward/backward_ops.cpp
@@ -92,65 +92,6 @@ std::vector<Tensor> unary_add_bw(
     return operation::decorate_as_composite(__func__, _unary_add_bw)(grad, input, alpha, output_mem_config);
 }
 
-std::vector<std::optional<Tensor>> _mul_bw(
-    uint8_t cq_id,
-    const Tensor& grad,
-    const Tensor& input_a,
-    const Tensor& input_b,
-    const MemoryConfig& output_mem_config,
-    const std::vector<bool>& are_required_outputs,
-    std::optional<Tensor> input_a_grad,
-    std::optional<Tensor> input_b_grad) {
-    std::vector<std::optional<Tensor>> result;
-
-    if (are_required_outputs.at(0)) {
-        if(input_a_grad.has_value()) {
-            ttnn::multiply(cq_id, grad, input_b, std::nullopt, std::nullopt, input_a_grad, std::nullopt);
-        } else {
-            input_a_grad = ttnn::multiply(cq_id, grad, input_b, std::nullopt, output_mem_config);
-        }
-        result.emplace_back(input_a_grad);
-    } else {
-        result.emplace_back(std::nullopt);
-    }
-    if (are_required_outputs.at(1)) {
-        if(input_b_grad.has_value()) {
-            ttnn::multiply(cq_id, grad, input_a, std::nullopt, std::nullopt, input_b_grad, std::nullopt);
-        } else {
-            input_b_grad = ttnn::multiply(cq_id, grad, input_a, std::nullopt, output_mem_config);
-        }
-        result.emplace_back(input_b_grad);
-    } else {
-        result.emplace_back(std::nullopt);
-    }
-
-    return std::move(result);
-}
-std::vector<std::optional<Tensor>> mul_bw(
-    uint8_t cq_id,
-    const Tensor& grad,
-    const Tensor& input_a,
-    const Tensor& input_b,
-    const MemoryConfig& output_mem_config,
-    const std::vector<bool>& are_required_outputs,
-    std::optional<Tensor> input_a_grad,
-    std::optional<Tensor> input_b_grad) {
-    return operation::decorate_as_composite(__func__, _mul_bw)(
-        cq_id, grad, input_a, input_b, output_mem_config, are_required_outputs, input_a_grad, input_b_grad);
-}
-std::vector<std::optional<Tensor>> mul_bw(
-    const Tensor& grad,
-    const Tensor& input_a,
-    const Tensor& input_b,
-    const MemoryConfig& output_mem_config,
-    const std::vector<bool>& are_required_outputs,
-    std::optional<Tensor> input_a_grad,
-    std::optional<Tensor> input_b_grad) {
-        uint8_t default_queue_id = 0;
-    return operation::decorate_as_composite(__func__, _mul_bw)(
-        default_queue_id, grad, input_a, input_b, output_mem_config, are_required_outputs, input_a_grad, input_b_grad);
-}
-
 std::vector<std::optional<Tensor>> _exp_bw(uint8_t queue_id, const Tensor& grad, const Tensor& input, const MemoryConfig& output_mem_config, const std::vector<bool>& are_required_outputs, std::optional<Tensor> input_grad) {
     std::vector<std::optional<Tensor>> grad_tensor;
     TT_FATAL(are_required_outputs.at(0), "input_grad derivative is a required output");

--- a/tt_eager/tt_dnn/op_library/backward/backward_ops.cpp
+++ b/tt_eager/tt_dnn/op_library/backward/backward_ops.cpp
@@ -1294,17 +1294,6 @@ std::vector<Tensor> celu_bw(
     return operation::decorate_as_composite(__func__, _celu_bw)(grad, input, alpha, output_mem_config);
 }
 
-std::vector<Tensor> _binary_lt_bw(const Tensor& grad, const Tensor& input, const MemoryConfig& output_mem_config) {
-    std::vector<Tensor> grad_tensor;
-    Tensor zero_grad = zeros_like(grad, output_mem_config);
-    grad_tensor.emplace_back(zero_grad);
-    Tensor zero_input = zeros_like(input, output_mem_config);
-    grad_tensor.emplace_back(zero_input);
-    return grad_tensor;
-}
-std::vector<Tensor> binary_lt_bw(const Tensor& grad, const Tensor& input, const MemoryConfig& output_mem_config) {
-    return operation::decorate_as_composite(__func__, _binary_lt_bw)(grad, input, output_mem_config);
-}
 
 // erfinv
 // self: 0.5 * sqrt(M_PI) * exp(self.erfinv().pow(2)) * grad

--- a/tt_eager/tt_dnn/op_library/backward/backward_ops.cpp
+++ b/tt_eager/tt_dnn/op_library/backward/backward_ops.cpp
@@ -702,14 +702,6 @@ std::vector<Tensor> _lerp_overload(
     grad_tensor.emplace_back(result_2);
     return grad_tensor;
 }
-std::vector<Tensor> lerp_bw(
-    const Tensor& grad,
-    const Tensor& input,
-    const Tensor& end,
-    const Tensor& weight,
-    const MemoryConfig& output_mem_config) {
-    return operation::decorate_as_composite(__func__, _lerp_overload)(grad, input, end, weight, output_mem_config);
-}
 
 std::vector<Tensor> _gelu_bw(
     const Tensor& grad, const Tensor& input, string approximate, const MemoryConfig& output_mem_config) {

--- a/tt_eager/tt_dnn/op_library/backward/backward_ops.cpp
+++ b/tt_eager/tt_dnn/op_library/backward/backward_ops.cpp
@@ -1715,17 +1715,6 @@ std::vector<Tensor> binary_ge_bw(const Tensor& grad, const Tensor& input, const 
     return operation::decorate_as_composite(__func__, _binary_ge_bw)(grad, input, output_mem_config);
 }
 
-std::vector<Tensor> _binary_gt_bw(const Tensor& grad, const Tensor& input, const MemoryConfig& output_mem_config) {
-    std::vector<Tensor> grad_tensor;
-    Tensor zero_grad = zeros_like(grad, output_mem_config);
-    grad_tensor.emplace_back(zero_grad);
-    Tensor zero_input = zeros_like(input, output_mem_config);
-    grad_tensor.emplace_back(zero_input);
-    return grad_tensor;
-}
-std::vector<Tensor> binary_gt_bw(const Tensor& grad, const Tensor& input, const MemoryConfig& output_mem_config) {
-    return operation::decorate_as_composite(__func__, _binary_gt_bw)(grad, input, output_mem_config);
-}
 
 // Autoformat support
 Tensor change_layout_to_tile(const Tensor& temp, const MemoryConfig& output_mem_config) {

--- a/tt_eager/tt_dnn/op_library/backward/backward_ops.hpp
+++ b/tt_eager/tt_dnn/op_library/backward/backward_ops.hpp
@@ -500,11 +500,6 @@ std::vector<Tensor> selu_bw(
     const Tensor& input,
     const MemoryConfig& output_mem_config = operation::DEFAULT_OUTPUT_MEMORY_CONFIG);
 
-std::vector<Tensor> binary_ge_bw(
-    const Tensor& grad,
-    const Tensor& input,
-    const MemoryConfig& output_mem_config = operation::DEFAULT_OUTPUT_MEMORY_CONFIG);
-
 std::vector<Tensor> square_bw(
     const Tensor& grad,
     const Tensor& input,

--- a/tt_eager/tt_dnn/op_library/backward/backward_ops.hpp
+++ b/tt_eager/tt_dnn/op_library/backward/backward_ops.hpp
@@ -415,11 +415,6 @@ std::vector<Tensor> celu_bw(
     float alpha,
     const MemoryConfig& output_mem_config = operation::DEFAULT_OUTPUT_MEMORY_CONFIG);
 
-std::vector<Tensor> binary_lt_bw(
-    const Tensor& grad,
-    const Tensor& input,
-    const MemoryConfig& output_mem_config = operation::DEFAULT_OUTPUT_MEMORY_CONFIG);
-
 std::vector<Tensor> log10_bw(
     const Tensor& grad,
     const Tensor& input,

--- a/tt_eager/tt_dnn/op_library/backward/backward_ops.hpp
+++ b/tt_eager/tt_dnn/op_library/backward/backward_ops.hpp
@@ -273,14 +273,6 @@ std::vector<Tensor> bias_gelu_unary_bw(
     string approximate,
     const MemoryConfig& output_mem_config = operation::DEFAULT_OUTPUT_MEMORY_CONFIG);
 
-// lerp(input, end, weight) = self: grad * (1 - weight), end: grad * weight, weight is float
-std::vector<Tensor> lerp_bw(
-    const Tensor& grad,
-    const Tensor& input,
-    const Tensor& end,
-    float weight,
-    const MemoryConfig& output_mem_config = operation::DEFAULT_OUTPUT_MEMORY_CONFIG);
-
 // lerp(input, end, weight) = self: grad * (1 - weight), end: grad * weight, weight is tensor
 std::vector<Tensor> lerp_bw(
     const Tensor& grad,

--- a/tt_eager/tt_dnn/op_library/backward/backward_ops.hpp
+++ b/tt_eager/tt_dnn/op_library/backward/backward_ops.hpp
@@ -60,25 +60,6 @@ std::vector<Tensor> addcdiv_bw(
     float value,
     const MemoryConfig& output_mem_config = operation::DEFAULT_OUTPUT_MEMORY_CONFIG);
 
-std::vector<std::optional<Tensor>> mul_bw(
-    const Tensor& grad,
-    const Tensor& input_a,
-    const Tensor& input_b,
-    const MemoryConfig& output_mem_config = operation::DEFAULT_OUTPUT_MEMORY_CONFIG,
-    const std::vector<bool>& are_required_outputs = std::vector<bool>{true, true},
-    std::optional<Tensor> input_a_grad = std::nullopt,
-    std::optional<Tensor> input_b_grad = std::nullopt);
-
-std::vector<std::optional<Tensor>> mul_bw(
-    uint8_t cq_id,
-    const Tensor& grad,
-    const Tensor& input_a,
-    const Tensor& input_b,
-    const MemoryConfig& output_mem_config = operation::DEFAULT_OUTPUT_MEMORY_CONFIG,
-    const std::vector<bool>& are_required_outputs = std::vector<bool>{true, true},
-    std::optional<Tensor> input_a_grad = std::nullopt,
-    std::optional<Tensor> input_b_grad = std::nullopt);
-
 std::vector<std::optional<Tensor>> exp_bw(
     uint8_t cq_id,
     const Tensor& grad,

--- a/tt_eager/tt_dnn/op_library/backward/backward_ops.hpp
+++ b/tt_eager/tt_dnn/op_library/backward/backward_ops.hpp
@@ -141,12 +141,6 @@ std::vector<Tensor> max_bw(
     const Tensor& other,
     const MemoryConfig& output_mem_config = operation::DEFAULT_OUTPUT_MEMORY_CONFIG);
 
-std::vector<Tensor> min_bw(
-    const Tensor& grad,
-    const Tensor& input,
-    const Tensor& other,
-    const MemoryConfig& output_mem_config = operation::DEFAULT_OUTPUT_MEMORY_CONFIG);
-
 // bw = grad(1 - tanh(x) ** 2)
 std::vector<std::optional<Tensor>> tanh_bw(
     uint8_t cq_id,

--- a/tt_eager/tt_dnn/op_library/backward/backward_ops.hpp
+++ b/tt_eager/tt_dnn/op_library/backward/backward_ops.hpp
@@ -135,12 +135,6 @@ std::vector<Tensor> rdiv_bw(
     string round_mode,
     const MemoryConfig& output_mem_config = operation::DEFAULT_OUTPUT_MEMORY_CONFIG);
 
-std::vector<Tensor> max_bw(
-    const Tensor& grad,
-    const Tensor& input,
-    const Tensor& other,
-    const MemoryConfig& output_mem_config = operation::DEFAULT_OUTPUT_MEMORY_CONFIG);
-
 // bw = grad(1 - tanh(x) ** 2)
 std::vector<std::optional<Tensor>> tanh_bw(
     uint8_t cq_id,

--- a/tt_eager/tt_dnn/op_library/backward/backward_ops.hpp
+++ b/tt_eager/tt_dnn/op_library/backward/backward_ops.hpp
@@ -510,11 +510,6 @@ std::vector<Tensor> binary_ge_bw(
     const Tensor& input,
     const MemoryConfig& output_mem_config = operation::DEFAULT_OUTPUT_MEMORY_CONFIG);
 
-std::vector<Tensor> binary_gt_bw(
-    const Tensor& grad,
-    const Tensor& input,
-    const MemoryConfig& output_mem_config = operation::DEFAULT_OUTPUT_MEMORY_CONFIG);
-
 std::vector<Tensor> square_bw(
     const Tensor& grad,
     const Tensor& input,

--- a/tt_eager/tt_dnn/op_library/backward/backward_ops.hpp
+++ b/tt_eager/tt_dnn/op_library/backward/backward_ops.hpp
@@ -121,13 +121,6 @@ std::vector<Tensor> unary_div_bw(
     string round_mode,
     const MemoryConfig& output_mem_config = operation::DEFAULT_OUTPUT_MEMORY_CONFIG);
 
-std::vector<Tensor> div_bw(
-    const Tensor& grad,
-    const Tensor& input,
-    const Tensor& other,
-    string round_mode,
-    const MemoryConfig& output_mem_config = operation::DEFAULT_OUTPUT_MEMORY_CONFIG);
-
 std::vector<Tensor> rdiv_bw(
     const Tensor& grad,
     const Tensor& input,

--- a/tt_eager/tt_dnn/op_library/backward/backward_ops.hpp
+++ b/tt_eager/tt_dnn/op_library/backward/backward_ops.hpp
@@ -449,11 +449,6 @@ std::vector<Tensor> log1p_bw(
     const Tensor& input,
     const MemoryConfig& output_mem_config = operation::DEFAULT_OUTPUT_MEMORY_CONFIG);
 
-std::vector<Tensor> binary_ne_bw(
-    const Tensor& grad,
-    const Tensor& input,
-    const MemoryConfig& output_mem_config = operation::DEFAULT_OUTPUT_MEMORY_CONFIG);
-
 std::vector<Tensor> erf_bw(
     const Tensor& grad,
     const Tensor& input,

--- a/tt_eager/tt_lib/csrc/tt_lib_bindings_tensor_backward_ops.cpp
+++ b/tt_eager/tt_lib/csrc/tt_lib_bindings_tensor_backward_ops.cpp
@@ -58,44 +58,6 @@ namespace tt::tt_metal::detail{
                     "output_mem_config", "Layout of tensor in TT Accelerator device memory banks", "MemoryConfig", "Default is interleaved in DRAM", "No"
             )doc");
 
-    m_tensor.def("mul_bw",
-        [](const Tensor& grad,
-           const Tensor& input_a,
-           const Tensor& input_b,
-           const MemoryConfig& output_mem_config,
-           const std::vector<bool>& are_required_outputs,
-           std::optional<Tensor> input_a_grad,
-           std::optional<Tensor> input_b_grad,
-           uint8_t queue_id) {
-            return mul_bw(queue_id, grad, input_a, input_b, output_mem_config, are_required_outputs, input_a_grad, input_b_grad);
-        },
-            py::arg("grad").noconvert(),
-            py::arg("input_a").noconvert(),
-            py::arg("input_b").noconvert(),
-            py::arg("output_mem_config").noconvert() = operation::DEFAULT_OUTPUT_MEMORY_CONFIG,
-            py::arg("are_required_outputs").noconvert() = std::vector<bool>{true, true},
-            py::arg("input_a_grad").noconvert() = std::nullopt,
-            py::arg("input_b_grad").noconvert() = std::nullopt,
-            py::arg("queue_id").noconvert() = 0,
-            R"doc(
-                Performs backward operations for multiplication of two input tensors with given ``grad``
-
-                Input tensors must have BFLOAT16 data type.
-
-                Output tensors will have BFLOAT16 data type.
-
-                .. csv-table::
-                    :header: "Argument", "Description", "Data type", "Valid range", "Required"
-
-                    "grad", "Gradient tensor", "Tensor", "Tensor of shape [W, Z, Y, X]", "Yes"
-                    "input_a", "Tensor", "Tensor", "Tensor of shape [W, Z, Y, X]", "Yes"
-                    "input_b", "Tensor", "Tensor", "Tensor of shape [W, Z, Y, X]", "Yes"
-                    "output_mem_config", "Layout of tensor in TT Accelerator device memory banks", "MemoryConfig", "Default is interleaved in DRAM", "No"
-                    "are_required_outputs", "Boolean values for the required outputs: input_a_grad, input_b_grad ", "List of bool", "Default value is [True, True]", "No"
-                    "input_a_grad", "Optional Output Tensor for input_a gradient", "Tensor", "Default value is None", "No"
-                    "input_b_grad", "Optional Output Tensor for input_b gradient", "Tensor", "Default value is None", "No"
-                    "queue_id", "command queue id", "uint8_t", "Default is 0", "No"
-            )doc");
 
         m_tensor.def("exp_bw",
             [](const Tensor& grad,

--- a/tt_eager/tt_lib/csrc/tt_lib_bindings_tensor_backward_ops.cpp
+++ b/tt_eager/tt_lib/csrc/tt_lib_bindings_tensor_backward_ops.cpp
@@ -713,44 +713,6 @@ namespace tt::tt_metal::detail{
                 "output_mem_config", "Layout of tensor in TT Accelerator device memory banks", "MemoryConfig", "Default is interleaved in DRAM", "No"
         )doc");
 
-    m_tensor.def("lerp_bw", py::overload_cast<const Tensor&, const Tensor&, const Tensor&, float, const MemoryConfig&>(&lerp_bw),
-            py::arg("grad").noconvert(), py::arg("input").noconvert(), py::arg("end").noconvert(), py::arg("weight"), py::arg("output_mem_config").noconvert() = operation::DEFAULT_OUTPUT_MEMORY_CONFIG,R"doc(
-            Applies the linear interpolation of two tensors ``arg0`` (given by input) and ``arg1`` based on a
-            scalar ``arg2``  with given ``grad``.
-
-            Input tensor must have BFLOAT16 data type.
-
-            Output tensor will have BFLOAT16 data type.
-
-            .. csv-table::
-                :header: "Argument", "Description", "Data type", "Valid range", "Required"
-
-                "grad", "Gradient tensor", "Tensor", "Tensor of shape [W, Z, Y, X]", "Yes"
-                "input", "Tensor lerp is applied to", "Tensor", "Tensor of shape [W, Z, Y, X]", "Yes"
-                "end", "End value", "Tensor", "Tensor of shape [W, Z, Y, X]", "Yes"
-                "weight", "Weight value", "float", "", "Yes"
-                "output_mem_config", "Layout of tensor in TT Accelerator device memory banks", "MemoryConfig", "Default is interleaved in DRAM", "No"
-        )doc");
-
-    m_tensor.def("lerp_bw", py::overload_cast<const Tensor&, const Tensor&, const Tensor&, const Tensor&, const MemoryConfig&>(&lerp_bw),
-            py::arg("grad").noconvert(), py::arg("input").noconvert(), py::arg("end").noconvert(), py::arg("weight").noconvert(), py::arg("output_mem_config").noconvert() = operation::DEFAULT_OUTPUT_MEMORY_CONFIG, R"doc(
-            Applies the linear interpolation of two tensors ``arg0`` (given by input) and ``arg1`` based on a
-            tensor ``arg2`` with given ``grad``.
-
-            Input tensor must have BFLOAT16 data type.
-
-            Output tensor will have BFLOAT16 data type.
-
-            .. csv-table::
-                :header: "Argument", "Description", "Data type", "Valid range", "Required"
-
-                "grad", "Gradient tensor", "Tensor", "Tensor of shape [W, Z, Y, X]", "Yes"
-                "input", "Tensor lerp is applied to", "Tensor", "Tensor of shape [W, Z, Y, X]", "Yes"
-                "end", "End value", "Tensor", "Tensor of shape [W, Z, Y, X]", "Yes"
-                "weight", "Weight value", "Tensor", "Tensor of shape [W, Z, Y, X]", "Yes"
-                "output_mem_config", "Layout of tensor in TT Accelerator device memory banks", "MemoryConfig", "Default is interleaved in DRAM", "No"
-        )doc");
-
     m_tensor.def("hardshrink_bw", &tt::tt_metal::hardshrink_bw,
             py::arg("grad").noconvert(), py::arg("input").noconvert(), py::arg("lambda") = 0.5f, py::arg("output_mem_config").noconvert() = operation::DEFAULT_OUTPUT_MEMORY_CONFIG, R"doc(
             Performs backward operations for hardshrink to the elements of the input tensor ``{0}`` between limits ``-{1}`` low and the ``+{1}`` high limits with given ``grad``.

--- a/tt_eager/tt_lib/csrc/tt_lib_bindings_tensor_backward_ops.cpp
+++ b/tt_eager/tt_lib/csrc/tt_lib_bindings_tensor_backward_ops.cpp
@@ -407,22 +407,6 @@ namespace tt::tt_metal::detail{
                 "output_mem_config", "Layout of tensor in TT Accelerator device memory banks", "MemoryConfig", "Default is interleaved in DRAM", "No"
         )doc");
 
-    m_tensor.def("div_bw", &tt::tt_metal::div_bw,
-            py::arg("grad").noconvert(), py::arg("input_a").noconvert(), py::arg("input_b").noconvert(), py::arg("round_mode") = "None", py::arg("output_mem_config").noconvert() = operation::DEFAULT_OUTPUT_MEMORY_CONFIG, R"doc(
-            Performs backward operations for division of ``input_b`` with given ``grad``.
-
-            Input tensor must have BFLOAT16 data type.
-
-            Output tensors will have BFLOAT16 data type.
-
-            .. csv-table::
-                :header: "Argument", "Description", "Data type", "Valid range", "Required"
-
-                "grad", "Gradient tensor", "Tensor", "Tensor of shape [W, Z, Y, X]", "Yes"
-                "input_a", "Tensor div is applied to", "Tensor", "Tensor of shape [W, Z, Y, X]", "Yes"
-                "input_b", "Tensor", "Tensor", "Tensor of shape [W, Z, Y, X]", "Yes"
-                "output_mem_config", "Layout of tensor in TT Accelerator device memory banks", "MemoryConfig", "Default is interleaved in DRAM", "No"
-        )doc");
 
     m_tensor.def("rdiv_bw", &tt::tt_metal::rdiv_bw,
             py::arg("grad").noconvert(), py::arg("input").noconvert(), py::arg("scalar") = 1.0f, py::arg("round_mode") = "None", py::arg("output_mem_config").noconvert() = operation::DEFAULT_OUTPUT_MEMORY_CONFIG, R"doc(

--- a/tt_eager/tt_lib/csrc/tt_lib_bindings_tensor_backward_ops.cpp
+++ b/tt_eager/tt_lib/csrc/tt_lib_bindings_tensor_backward_ops.cpp
@@ -1426,22 +1426,6 @@ namespace tt::tt_metal::detail{
                 "output_mem_config", "Layout of tensor in TT Accelerator device memory banks", "MemoryConfig", "Default is interleaved in DRAM", "No"
         )doc");
 
-    m_tensor.def("binary_ge_bw", &tt::tt_metal::binary_ge_bw,
-            py::arg("grad").noconvert(), py::arg("input").noconvert(), py::arg("output_mem_config").noconvert() = operation::DEFAULT_OUTPUT_MEMORY_CONFIG, R"doc(
-            Returns an tensor of zeros like ``grad`` tensor and ``input`` tensor.
-
-            Input tensors must have BFLOAT16 data type.
-
-            Output tensors will have BFLOAT16 data type.
-
-            .. csv-table::
-                :header: "Argument", "Description", "Data type", "Valid range", "Required"
-
-                "grad", "Gradient tensor", "Tensor", "Tensor of shape [W, Z, Y, X]", "Yes"
-                "input", "Input Tensor", "Tensor", "Tensor of shape [W, Z, Y, X]", "Yes"
-                "output_mem_config", "Layout of tensor in TT Accelerator device memory banks", "MemoryConfig", "Default is interleaved in DRAM", "No"
-        )doc");
-
     m_tensor.def("square_bw", &tt::tt_metal::square_bw,
             py::arg("grad").noconvert(), py::arg("input").noconvert(), py::arg("output_mem_config").noconvert() = operation::DEFAULT_OUTPUT_MEMORY_CONFIG, R"doc(
             Performs backward square operations on ``input`` tensors with given ``grad``.

--- a/tt_eager/tt_lib/csrc/tt_lib_bindings_tensor_backward_ops.cpp
+++ b/tt_eager/tt_lib/csrc/tt_lib_bindings_tensor_backward_ops.cpp
@@ -441,22 +441,6 @@ namespace tt::tt_metal::detail{
                 "output_mem_config", "Layout of tensor in TT Accelerator device memory banks", "MemoryConfig", "Default is interleaved in DRAM", "No"
         )doc");
 
-    m_tensor.def("min_bw", &tt::tt_metal::min_bw,
-            py::arg("grad").noconvert(), py::arg("input_a").noconvert(), py::arg("input_b").noconvert(), py::arg("output_mem_config").noconvert() = operation::DEFAULT_OUTPUT_MEMORY_CONFIG, R"doc(
-            Performs backward operations for minimum of ``input_b`` with given ``grad``.
-
-            Input tensor must have BFLOAT16 data type.
-
-            Output tensors will have BFLOAT16 data type.
-
-            .. csv-table::
-                :header: "Argument", "Description", "Data type", "Valid range", "Required"
-
-                "grad", "Gradient tensor", "Tensor", "Tensor of shape [W, Z, Y, X]", "Yes"
-                "input_a", "Tensor min is applied to", "Tensor", "Tensor of shape [W, Z, Y, X]", "Yes"
-                "input_b", "Tensor", "Tensor", "Tensor of shape [W, Z, Y, X]", "Yes"
-                "output_mem_config", "Layout of tensor in TT Accelerator device memory banks", "MemoryConfig", "Default is interleaved in DRAM", "No"
-        )doc");
 
     m_tensor.def("max_bw", &tt::tt_metal::max_bw,
             py::arg("grad").noconvert(), py::arg("input_a").noconvert(), py::arg("input_b").noconvert(), py::arg("output_mem_config").noconvert() = operation::DEFAULT_OUTPUT_MEMORY_CONFIG, R"doc(

--- a/tt_eager/tt_lib/csrc/tt_lib_bindings_tensor_backward_ops.cpp
+++ b/tt_eager/tt_lib/csrc/tt_lib_bindings_tensor_backward_ops.cpp
@@ -1133,22 +1133,6 @@ namespace tt::tt_metal::detail{
                 "output_mem_config", "Layout of tensor in TT Accelerator device memory banks", "MemoryConfig", "Default is interleaved in DRAM", "No"
         )doc");
 
-     m_tensor.def("binary_lt_bw", &tt::tt_metal::binary_lt_bw,
-            py::arg("grad").noconvert(), py::arg("input").noconvert(), py::arg("output_mem_config").noconvert() = operation::DEFAULT_OUTPUT_MEMORY_CONFIG, R"doc(
-            Returns an tensor of zeros like ``grad`` tensor and ``input`` tensor.
-
-            Input tensors must have BFLOAT16 data type.
-
-            Output tensors will have BFLOAT16 data type.
-
-            .. csv-table::
-                :header: "Argument", "Description", "Data type", "Valid range", "Required"
-
-                "grad", "Gradient tensor", "Tensor", "Tensor of shape [W, Z, Y, X]", "Yes"
-                "input", "Tensor LT is applied to", "Tensor", "Tensor of shape [W, Z, Y, X]", "Yes"
-                "output_mem_config", "Layout of tensor in TT Accelerator device memory banks", "MemoryConfig", "Default is interleaved in DRAM", "No"
-        )doc");
-
     m_tensor.def("elu_bw", &tt::tt_metal::elu_bw,
             py::arg("grad").noconvert(), py::arg("input").noconvert(), py::arg("alpha").noconvert(), py::arg("output_mem_config").noconvert() = operation::DEFAULT_OUTPUT_MEMORY_CONFIG, R"doc(
             Performs backward operations for elu for the ``input`` with given ``grad``

--- a/tt_eager/tt_lib/csrc/tt_lib_bindings_tensor_backward_ops.cpp
+++ b/tt_eager/tt_lib/csrc/tt_lib_bindings_tensor_backward_ops.cpp
@@ -1458,22 +1458,6 @@ namespace tt::tt_metal::detail{
                 "output_mem_config", "Layout of tensor in TT Accelerator device memory banks", "MemoryConfig", "Default is interleaved in DRAM", "No"
         )doc");
 
-    m_tensor.def("binary_gt_bw", &tt::tt_metal::binary_gt_bw,
-            py::arg("grad").noconvert(), py::arg("input").noconvert(), py::arg("output_mem_config").noconvert() = operation::DEFAULT_OUTPUT_MEMORY_CONFIG, R"doc(
-            Returns an tensor of zeros like ``grad`` tensor and ``input`` tensor.
-
-            Input tensors must have BFLOAT16 data type.
-
-            Output tensors will have BFLOAT16 data type.
-
-            .. csv-table::
-                :header: "Argument", "Description", "Data type", "Valid range", "Required"
-
-                "grad", "Gradient tensor", "Tensor", "Tensor of shape [W, Z, Y, X]", "Yes"
-                "input", "Input Tensor", "Tensor", "Tensor of shape [W, Z, Y, X]", "Yes"
-                "output_mem_config", "Layout of tensor in TT Accelerator device memory banks", "MemoryConfig", "Default is interleaved in DRAM", "No"
-        )doc");
-
     m_tensor.def("square_bw", &tt::tt_metal::square_bw,
             py::arg("grad").noconvert(), py::arg("input").noconvert(), py::arg("output_mem_config").noconvert() = operation::DEFAULT_OUTPUT_MEMORY_CONFIG, R"doc(
             Performs backward square operations on ``input`` tensors with given ``grad``.

--- a/tt_eager/tt_lib/csrc/tt_lib_bindings_tensor_backward_ops.cpp
+++ b/tt_eager/tt_lib/csrc/tt_lib_bindings_tensor_backward_ops.cpp
@@ -442,23 +442,6 @@ namespace tt::tt_metal::detail{
         )doc");
 
 
-    m_tensor.def("max_bw", &tt::tt_metal::max_bw,
-            py::arg("grad").noconvert(), py::arg("input_a").noconvert(), py::arg("input_b").noconvert(), py::arg("output_mem_config").noconvert() = operation::DEFAULT_OUTPUT_MEMORY_CONFIG, R"doc(
-            Performs backward operations for maximum of ``input_b`` with given ``grad``.
-
-            Input tensor must have BFLOAT16 data type.
-
-            Output tensors will have BFLOAT16 data type.
-
-            .. csv-table::
-                :header: "Argument", "Description", "Data type", "Valid range", "Required"
-
-                "grad", "Gradient tensor", "Tensor", "Tensor of shape [W, Z, Y, X]", "Yes"
-                "input_a", "Tensor max is applied to", "Tensor", "Tensor of shape [W, Z, Y, X]", "Yes"
-                "input_b", "Tensor", "Tensor", "Tensor of shape [W, Z, Y, X]", "Yes"
-                "output_mem_config", "Layout of tensor in TT Accelerator device memory banks", "MemoryConfig", "Default is interleaved in DRAM", "No"
-        )doc");
-
     m_tensor.def("where_bw",
         [](const Tensor& grad,
            const Tensor& condition,

--- a/tt_eager/tt_lib/csrc/tt_lib_bindings_tensor_backward_ops.cpp
+++ b/tt_eager/tt_lib/csrc/tt_lib_bindings_tensor_backward_ops.cpp
@@ -1264,22 +1264,6 @@ namespace tt::tt_metal::detail{
                 "output_mem_config", "Layout of tensor in TT Accelerator device memory banks", "MemoryConfig", "Default is interleaved in DRAM", "No"
         )doc");
 
-    m_tensor.def("binary_ne_bw", &tt::tt_metal::binary_ne_bw,
-            py::arg("grad").noconvert(), py::arg("input").noconvert(), py::arg("output_mem_config").noconvert() = operation::DEFAULT_OUTPUT_MEMORY_CONFIG, R"doc(
-            Returns an tensor of zeros like ``grad`` tensor and ``input`` tensor.
-
-            Input tensors must have BFLOAT16 data type.
-
-            Output tensors will have BFLOAT16 data type.
-
-            .. csv-table::
-                :header: "Argument", "Description", "Data type", "Valid range", "Required"
-
-                "grad", "Gradient tensor", "Tensor", "Tensor of shape [W, Z, Y, X]", "Yes"
-                "input", "Input Tensor", "Tensor", "Tensor of shape [W, Z, Y, X]", "Yes"
-                "output_mem_config", "Layout of tensor in TT Accelerator device memory banks", "MemoryConfig", "Default is interleaved in DRAM", "No"
-        )doc");
-
      m_tensor.def("erf_bw", &tt::tt_metal::erf_bw,
             py::arg("grad").noconvert(), py::arg("input").noconvert(), py::arg("output_mem_config").noconvert() = operation::DEFAULT_OUTPUT_MEMORY_CONFIG, R"doc(
             Performs backward operations for erf of ``input`` tensor with given ``grad``.

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_backward/binary_backward.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_backward/binary_backward.hpp
@@ -70,6 +70,21 @@ struct ExecuteBinaryBackward {
         return op_type(grad_tensor_arg, input_tensor_a_arg, input_tensor_b_arg, memory_config);
         }
 
+    template <typename... Args>
+    static auto input_tensors_to_validate(const Tensor &grad_tensor, const Tensor &input_tensor_a, const Tensor &input_tensor_b, const Tensor &input_tensor_c, Args &&...args) {
+        return std::forward_as_tuple(grad_tensor, input_tensor_a, input_tensor_b, input_tensor_c);
+    }
+
+    static std::vector<ttnn::Tensor> execute_on_worker_thread(
+        const Tensor &grad_tensor_arg,
+        const Tensor &input_tensor_a_arg,
+        const Tensor &input_tensor_b_arg,
+        const Tensor &input_tensor_c_arg,
+        const MemoryConfig &memory_config) {
+
+        auto op_type = utils::get_overload_function(binary_backward_op_type);
+        return op_type(grad_tensor_arg, input_tensor_a_arg, input_tensor_b_arg, input_tensor_c_arg, memory_config);
+        }
 
     //Type 1: Type 1 with 1 float
     template <typename... Args>

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_backward/binary_backward.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_backward/binary_backward.hpp
@@ -129,12 +129,12 @@ struct ExecuteBinaryBackward {
         const Tensor &input_tensor_b_arg,
         const std::optional<MemoryConfig> &memory_config = std::nullopt,
         const std::vector<bool>& are_required_outputs = std::vector<bool>{true, true},
-        std::optional<Tensor> optional_input_a_grad = std::nullopt,
-        std::optional<Tensor> optional_input_b_grad = std::nullopt) {
+        std::optional<Tensor> input_a_grad = std::nullopt,
+        std::optional<Tensor> input_b_grad = std::nullopt) {
 
         auto output_memory_config = memory_config.value_or(input_tensor_a_arg.memory_config());
         auto op_type = utils::get_function_type3(binary_backward_op_type);
-        return op_type(queue_id, grad_tensor_arg, input_tensor_a_arg, input_tensor_b_arg, output_memory_config, are_required_outputs, optional_input_a_grad, optional_input_b_grad);
+        return op_type(queue_id, grad_tensor_arg, input_tensor_a_arg, input_tensor_b_arg, output_memory_config, are_required_outputs, input_a_grad, input_b_grad);
     }
 
     //Type 3 : type1 args, optional output tensor for inputs based on are_required_outputs value
@@ -149,12 +149,12 @@ struct ExecuteBinaryBackward {
         const Tensor &input_tensor_b_arg,
         const std::optional<MemoryConfig> &memory_config = std::nullopt,
         const std::vector<bool>& are_required_outputs = std::vector<bool>{true, true},
-        std::optional<Tensor> optional_input_a_grad = std::nullopt,
-        std::optional<Tensor> optional_input_b_grad = std::nullopt) {
+        std::optional<Tensor> input_a_grad = std::nullopt,
+        std::optional<Tensor> input_b_grad = std::nullopt) {
 
         auto output_memory_config = memory_config.value_or(input_tensor_a_arg.memory_config());
         auto op_type = utils::get_function_type3_wo_qid(binary_backward_op_type);
-        return op_type(grad_tensor_arg, input_tensor_a_arg, input_tensor_b_arg, output_memory_config, are_required_outputs, optional_input_a_grad, optional_input_b_grad);
+        return op_type(grad_tensor_arg, input_tensor_a_arg, input_tensor_b_arg, output_memory_config, are_required_outputs, input_a_grad, input_b_grad);
     }
 
     //Type 2 : Q_ID, type1 args, optional output tensor for inputs based on are_required_outputs value
@@ -171,12 +171,12 @@ struct ExecuteBinaryBackward {
         float alpha,
         const std::optional<MemoryConfig> &memory_config = std::nullopt,
         const std::vector<bool>& are_required_outputs = std::vector<bool>{true, true},
-        std::optional<Tensor> optional_input_a_grad = std::nullopt,
-        std::optional<Tensor> optional_input_b_grad = std::nullopt) {
+        std::optional<Tensor> input_a_grad = std::nullopt,
+        std::optional<Tensor> input_b_grad = std::nullopt) {
 
         auto output_memory_config = memory_config.value_or(input_tensor_a_arg.memory_config());
         auto op_type = utils::get_function_type2(binary_backward_op_type);
-        return op_type(queue_id, grad_tensor_arg, input_tensor_a_arg, input_tensor_b_arg, alpha, output_memory_config, are_required_outputs, optional_input_a_grad, optional_input_b_grad);
+        return op_type(queue_id, grad_tensor_arg, input_tensor_a_arg, input_tensor_b_arg, alpha, output_memory_config, are_required_outputs, input_a_grad, input_b_grad);
     }
 
     //Type 2 : type1 args, optional output tensor for inputs based on are_required_outputs value
@@ -192,12 +192,12 @@ struct ExecuteBinaryBackward {
         float alpha,
         const std::optional<MemoryConfig> &memory_config = std::nullopt,
         const std::vector<bool>& are_required_outputs = std::vector<bool>{true, true},
-        std::optional<Tensor> optional_input_a_grad = std::nullopt,
-        std::optional<Tensor> optional_input_b_grad = std::nullopt) {
+        std::optional<Tensor> input_a_grad = std::nullopt,
+        std::optional<Tensor> input_b_grad = std::nullopt) {
 
         auto output_memory_config = memory_config.value_or(input_tensor_a_arg.memory_config());
         auto op_type = utils::get_function_type2_wo_qid(binary_backward_op_type);
-        return op_type(grad_tensor_arg, input_tensor_a_arg, input_tensor_b_arg, alpha, output_memory_config, are_required_outputs, optional_input_a_grad, optional_input_b_grad);
+        return op_type(grad_tensor_arg, input_tensor_a_arg, input_tensor_b_arg, alpha, output_memory_config, are_required_outputs, input_a_grad, input_b_grad);
     }
 
 };
@@ -235,5 +235,6 @@ constexpr auto addalpha_bw = ttnn::register_operation<operations::binary_backwar
 //type 3
 constexpr auto add_bw = ttnn::register_operation<operations::binary_backward::ExecuteBinaryBackward<operations::binary_backward::BinaryBackwardOpType::ADD_BW>>("ttnn::add_bw");
 constexpr auto binary_eq_bw = ttnn::register_operation<operations::binary_backward::ExecuteBinaryBackward<operations::binary_backward::BinaryBackwardOpType::BINARY_EQ_BW>>("ttnn::binary_eq_bw");
+constexpr auto mul_bw = ttnn::register_operation<operations::binary_backward::ExecuteBinaryBackward<operations::binary_backward::BinaryBackwardOpType::MUL_BW>>("ttnn::mul_bw");
 
 }  // namespace ttnn

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_backward/binary_backward.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_backward/binary_backward.hpp
@@ -212,6 +212,7 @@ constexpr auto binary_ge_bw = ttnn::register_operation<operations::binary_backwa
 constexpr auto min_bw = ttnn::register_operation<operations::binary_backward::ExecuteBinaryBackward<operations::binary_backward::BinaryBackwardOpType::MIN_BW>>("ttnn::min_bw");
 constexpr auto max_bw = ttnn::register_operation<operations::binary_backward::ExecuteBinaryBackward<operations::binary_backward::BinaryBackwardOpType::MAX_BW>>("ttnn::max_bw");
 constexpr auto div_bw = ttnn::register_operation<operations::binary_backward::ExecuteBinaryBackward<operations::binary_backward::BinaryBackwardOpType::DIV_BW>>("ttnn::div_bw");
+constexpr auto lerp_bw = ttnn::register_operation<operations::binary_backward::ExecuteBinaryBackward<operations::binary_backward::BinaryBackwardOpType::LERP_BW>>("ttnn::lerp_bw");
 
 //type 2
 constexpr auto addalpha_bw = ttnn::register_operation<operations::binary_backward::ExecuteBinaryBackward<operations::binary_backward::BinaryBackwardOpType::ADDALPHA_BW>>("ttnn::addalpha_bw");

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_backward/binary_backward.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_backward/binary_backward.hpp
@@ -207,6 +207,7 @@ constexpr auto rsub_bw = ttnn::register_operation<operations::binary_backward::E
 constexpr auto bias_gelu_bw = ttnn::register_operation<operations::binary_backward::ExecuteBinaryBackward<operations::binary_backward::BinaryBackwardOpType::BIAS_GELU_BW>>("ttnn::bias_gelu_bw");
 constexpr auto binary_gt_bw = ttnn::register_operation<operations::binary_backward::ExecuteBinaryBackward<operations::binary_backward::BinaryBackwardOpType::BINARY_GT_BW>>("ttnn::binary_gt_bw");
 constexpr auto binary_ne_bw = ttnn::register_operation<operations::binary_backward::ExecuteBinaryBackward<operations::binary_backward::BinaryBackwardOpType::BINARY_NE_BW>>("ttnn::binary_ne_bw");
+constexpr auto binary_ge_bw = ttnn::register_operation<operations::binary_backward::ExecuteBinaryBackward<operations::binary_backward::BinaryBackwardOpType::BINARY_GE_BW>>("ttnn::binary_ge_bw");
 
 //type 2
 constexpr auto addalpha_bw = ttnn::register_operation<operations::binary_backward::ExecuteBinaryBackward<operations::binary_backward::BinaryBackwardOpType::ADDALPHA_BW>>("ttnn::addalpha_bw");

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_backward/binary_backward.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_backward/binary_backward.hpp
@@ -208,6 +208,7 @@ constexpr auto bias_gelu_bw = ttnn::register_operation<operations::binary_backwa
 constexpr auto binary_gt_bw = ttnn::register_operation<operations::binary_backward::ExecuteBinaryBackward<operations::binary_backward::BinaryBackwardOpType::BINARY_GT_BW>>("ttnn::binary_gt_bw");
 constexpr auto binary_ne_bw = ttnn::register_operation<operations::binary_backward::ExecuteBinaryBackward<operations::binary_backward::BinaryBackwardOpType::BINARY_NE_BW>>("ttnn::binary_ne_bw");
 constexpr auto binary_ge_bw = ttnn::register_operation<operations::binary_backward::ExecuteBinaryBackward<operations::binary_backward::BinaryBackwardOpType::BINARY_GE_BW>>("ttnn::binary_ge_bw");
+constexpr auto min_bw = ttnn::register_operation<operations::binary_backward::ExecuteBinaryBackward<operations::binary_backward::BinaryBackwardOpType::MIN_BW>>("ttnn::min_bw");
 
 //type 2
 constexpr auto addalpha_bw = ttnn::register_operation<operations::binary_backward::ExecuteBinaryBackward<operations::binary_backward::BinaryBackwardOpType::ADDALPHA_BW>>("ttnn::addalpha_bw");

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_backward/binary_backward.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_backward/binary_backward.hpp
@@ -205,6 +205,7 @@ constexpr auto concat_bw = ttnn::register_operation<operations::binary_backward:
 constexpr auto binary_le_bw = ttnn::register_operation<operations::binary_backward::ExecuteBinaryBackward<operations::binary_backward::BinaryBackwardOpType::BINARY_LE_BW>>("ttnn::binary_le_bw");
 constexpr auto rsub_bw = ttnn::register_operation<operations::binary_backward::ExecuteBinaryBackward<operations::binary_backward::BinaryBackwardOpType::RSUB_BW>>("ttnn::rsub_bw");
 constexpr auto bias_gelu_bw = ttnn::register_operation<operations::binary_backward::ExecuteBinaryBackward<operations::binary_backward::BinaryBackwardOpType::BIAS_GELU_BW>>("ttnn::bias_gelu_bw");
+constexpr auto binary_gt_bw = ttnn::register_operation<operations::binary_backward::ExecuteBinaryBackward<operations::binary_backward::BinaryBackwardOpType::BINARY_GT_BW>>("ttnn::binary_gt_bw");
 
 //type 2
 constexpr auto addalpha_bw = ttnn::register_operation<operations::binary_backward::ExecuteBinaryBackward<operations::binary_backward::BinaryBackwardOpType::ADDALPHA_BW>>("ttnn::addalpha_bw");

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_backward/binary_backward.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_backward/binary_backward.hpp
@@ -206,6 +206,7 @@ constexpr auto binary_le_bw = ttnn::register_operation<operations::binary_backwa
 constexpr auto rsub_bw = ttnn::register_operation<operations::binary_backward::ExecuteBinaryBackward<operations::binary_backward::BinaryBackwardOpType::RSUB_BW>>("ttnn::rsub_bw");
 constexpr auto bias_gelu_bw = ttnn::register_operation<operations::binary_backward::ExecuteBinaryBackward<operations::binary_backward::BinaryBackwardOpType::BIAS_GELU_BW>>("ttnn::bias_gelu_bw");
 constexpr auto binary_gt_bw = ttnn::register_operation<operations::binary_backward::ExecuteBinaryBackward<operations::binary_backward::BinaryBackwardOpType::BINARY_GT_BW>>("ttnn::binary_gt_bw");
+constexpr auto binary_ne_bw = ttnn::register_operation<operations::binary_backward::ExecuteBinaryBackward<operations::binary_backward::BinaryBackwardOpType::BINARY_NE_BW>>("ttnn::binary_ne_bw");
 
 //type 2
 constexpr auto addalpha_bw = ttnn::register_operation<operations::binary_backward::ExecuteBinaryBackward<operations::binary_backward::BinaryBackwardOpType::ADDALPHA_BW>>("ttnn::addalpha_bw");

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_backward/binary_backward.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_backward/binary_backward.hpp
@@ -210,6 +210,7 @@ constexpr auto binary_ne_bw = ttnn::register_operation<operations::binary_backwa
 constexpr auto binary_ge_bw = ttnn::register_operation<operations::binary_backward::ExecuteBinaryBackward<operations::binary_backward::BinaryBackwardOpType::BINARY_GE_BW>>("ttnn::binary_ge_bw");
 constexpr auto min_bw = ttnn::register_operation<operations::binary_backward::ExecuteBinaryBackward<operations::binary_backward::BinaryBackwardOpType::MIN_BW>>("ttnn::min_bw");
 constexpr auto max_bw = ttnn::register_operation<operations::binary_backward::ExecuteBinaryBackward<operations::binary_backward::BinaryBackwardOpType::MAX_BW>>("ttnn::max_bw");
+constexpr auto div_bw = ttnn::register_operation<operations::binary_backward::ExecuteBinaryBackward<operations::binary_backward::BinaryBackwardOpType::DIV_BW>>("ttnn::div_bw");
 
 //type 2
 constexpr auto addalpha_bw = ttnn::register_operation<operations::binary_backward::ExecuteBinaryBackward<operations::binary_backward::BinaryBackwardOpType::ADDALPHA_BW>>("ttnn::addalpha_bw");

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_backward/binary_backward.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_backward/binary_backward.hpp
@@ -206,6 +206,7 @@ constexpr auto binary_le_bw = ttnn::register_operation<operations::binary_backwa
 constexpr auto rsub_bw = ttnn::register_operation<operations::binary_backward::ExecuteBinaryBackward<operations::binary_backward::BinaryBackwardOpType::RSUB_BW>>("ttnn::rsub_bw");
 constexpr auto bias_gelu_bw = ttnn::register_operation<operations::binary_backward::ExecuteBinaryBackward<operations::binary_backward::BinaryBackwardOpType::BIAS_GELU_BW>>("ttnn::bias_gelu_bw");
 constexpr auto binary_gt_bw = ttnn::register_operation<operations::binary_backward::ExecuteBinaryBackward<operations::binary_backward::BinaryBackwardOpType::BINARY_GT_BW>>("ttnn::binary_gt_bw");
+constexpr auto binary_lt_bw = ttnn::register_operation<operations::binary_backward::ExecuteBinaryBackward<operations::binary_backward::BinaryBackwardOpType::BINARY_LT_BW>>("ttnn::binary_lt_bw");
 constexpr auto binary_ne_bw = ttnn::register_operation<operations::binary_backward::ExecuteBinaryBackward<operations::binary_backward::BinaryBackwardOpType::BINARY_NE_BW>>("ttnn::binary_ne_bw");
 constexpr auto binary_ge_bw = ttnn::register_operation<operations::binary_backward::ExecuteBinaryBackward<operations::binary_backward::BinaryBackwardOpType::BINARY_GE_BW>>("ttnn::binary_ge_bw");
 constexpr auto min_bw = ttnn::register_operation<operations::binary_backward::ExecuteBinaryBackward<operations::binary_backward::BinaryBackwardOpType::MIN_BW>>("ttnn::min_bw");

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_backward/binary_backward.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_backward/binary_backward.hpp
@@ -209,6 +209,7 @@ constexpr auto binary_gt_bw = ttnn::register_operation<operations::binary_backwa
 constexpr auto binary_ne_bw = ttnn::register_operation<operations::binary_backward::ExecuteBinaryBackward<operations::binary_backward::BinaryBackwardOpType::BINARY_NE_BW>>("ttnn::binary_ne_bw");
 constexpr auto binary_ge_bw = ttnn::register_operation<operations::binary_backward::ExecuteBinaryBackward<operations::binary_backward::BinaryBackwardOpType::BINARY_GE_BW>>("ttnn::binary_ge_bw");
 constexpr auto min_bw = ttnn::register_operation<operations::binary_backward::ExecuteBinaryBackward<operations::binary_backward::BinaryBackwardOpType::MIN_BW>>("ttnn::min_bw");
+constexpr auto max_bw = ttnn::register_operation<operations::binary_backward::ExecuteBinaryBackward<operations::binary_backward::BinaryBackwardOpType::MAX_BW>>("ttnn::max_bw");
 
 //type 2
 constexpr auto addalpha_bw = ttnn::register_operation<operations::binary_backward::ExecuteBinaryBackward<operations::binary_backward::BinaryBackwardOpType::ADDALPHA_BW>>("ttnn::addalpha_bw");

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_backward/binary_backward_pybind.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_backward/binary_backward_pybind.hpp
@@ -87,14 +87,14 @@ Example:
                const ttnn::Tensor& grad_tensor,
                const ttnn::Tensor& input_tensor_a,
                const ttnn::Tensor& input_tensor_b,
-               const string value,
+               const string mode,
                const std::optional<ttnn::MemoryConfig>& memory_config) -> std::vector<ttnn::Tensor> {
-                return self(grad_tensor, input_tensor_a, value, input_tensor_b, memory_config);
+                return self(grad_tensor, input_tensor_a, mode, input_tensor_b, memory_config);
             },
             py::arg("grad_tensor"),
             py::arg("input_tensor_a"),
             py::arg("input_tensor_b"),
-            py::arg("value"),
+            py::arg("mode"),
             py::kw_only(),
             py::arg("memory_config") = std::nullopt},
 
@@ -311,6 +311,11 @@ void py_module(py::module& module) {
         module,
         ttnn::max_bw,
         R"doc(Performs backward operations for maximum of :attr:`input_tensor_a` and :attr:`input_tensor_b` with given :attr:`grad_tensor`.)doc");
+
+    detail::bind_binary_backward(
+        module,
+        ttnn::div_bw,
+        R"doc(Performs backward operations for divide of :attr:`input_tensor_a` and :attr:`input_tensor_b` with given :attr:`grad_tensor`.)doc");
 
 }
 

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_backward/binary_backward_pybind.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_backward/binary_backward_pybind.hpp
@@ -70,6 +70,24 @@ Example:
                const ttnn::Tensor& grad_tensor,
                const ttnn::Tensor& input_tensor_a,
                const ttnn::Tensor& input_tensor_b,
+               const ttnn::Tensor& input_tensor_c,
+               const std::optional<ttnn::MemoryConfig>& memory_config) -> std::vector<ttnn::Tensor> {
+                auto output_memory_config = memory_config.value_or(input_tensor_a.memory_config());
+                return self(grad_tensor, input_tensor_a, input_tensor_b, input_tensor_c, output_memory_config);
+            },
+            py::arg("grad_tensor"),
+            py::arg("input_tensor_a"),
+            py::arg("input_tensor_b"),
+            py::arg("input_tensor_c"),
+            py::kw_only(),
+            py::arg("memory_config") = std::nullopt},
+
+
+        ttnn::pybind_overload_t{
+            [](const binary_backward_operation_t& self,
+               const ttnn::Tensor& grad_tensor,
+               const ttnn::Tensor& input_tensor_a,
+               const ttnn::Tensor& input_tensor_b,
                const float alpha,
                const std::optional<ttnn::MemoryConfig>& memory_config) -> std::vector<ttnn::Tensor> {
                 return self(grad_tensor, input_tensor_a, alpha, input_tensor_b, memory_config);

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_backward/binary_backward_pybind.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_backward/binary_backward_pybind.hpp
@@ -307,6 +307,11 @@ void py_module(py::module& module) {
         ttnn::min_bw,
         R"doc(Performs backward operations for minimum of :attr:`input_tensor_a` and :attr:`input_tensor_b` with given :attr:`grad_tensor`.)doc");
 
+    detail::bind_binary_backward(
+        module,
+        ttnn::max_bw,
+        R"doc(Performs backward operations for maximum of :attr:`input_tensor_a` and :attr:`input_tensor_b` with given :attr:`grad_tensor`.)doc");
+
 }
 
 }  // namespace binary_backward

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_backward/binary_backward_pybind.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_backward/binary_backward_pybind.hpp
@@ -220,6 +220,11 @@ void py_module(py::module& module) {
 
     detail::bind_binary_backward(
         module,
+        ttnn::lerp_bw,
+        R"doc(Performs backward operations for lerp on :attr:`input_tensor_a` , attr:`input_tensor_b`, attr:`weight` with given attr:`grad_tensor`.)doc");
+
+    detail::bind_binary_backward(
+        module,
         ttnn::xlogy_bw,
         R"doc(Performs backward operations for xlogy of :attr:`input_tensor_a` and :attr:`input_tensor_b` with given :attr:`grad_tensor`.)doc");
 

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_backward/binary_backward_pybind.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_backward/binary_backward_pybind.hpp
@@ -290,10 +290,16 @@ void py_module(py::module& module) {
         R"doc(Performs backward operations for greater than comparison on :attr:`input_tensor_a` , attr:`input_tensor_b` with given attr:`grad_tensor`.
         Returns an tensor of zeros like :attr:`input_tensor_a` and :attr:`input_tensor_b` tensor.)doc");
 
-detail::bind_binary_backward(
+    detail::bind_binary_backward(
         module,
         ttnn::binary_ne_bw,
         R"doc(Performs backward operations for not equal comparison on :attr:`input_tensor_a` , attr:`input_tensor_b` with given attr:`grad_tensor`.
+        Returns an tensor of zeros like :attr:`input_tensor_a` and :attr:`input_tensor_b` tensor.)doc");
+
+    detail::bind_binary_backward(
+        module,
+        ttnn::binary_ge_bw,
+        R"doc(Performs backward operations for greater than or equal to comparison on :attr:`input_tensor_a` , attr:`input_tensor_b` with given attr:`grad_tensor`.
         Returns an tensor of zeros like :attr:`input_tensor_a` and :attr:`input_tensor_b` tensor.)doc");
 
 }

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_backward/binary_backward_pybind.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_backward/binary_backward_pybind.hpp
@@ -195,7 +195,7 @@ void py_module(py::module& module) {
     detail::bind_binary_backward(
         module,
         ttnn::atan2_bw,
-        R"doc(Performs backward operations for atan2 of :attr:`input_tensor_a` and :attr:`input_tensor_b` tensors with given :attr:`grad_tensor`.)doc");
+        R"doc(Performs backward operations for atan2 of :attr:`input_tensor_a` and :attr:`input_tensor_b` with given :attr:`grad_tensor`.)doc");
 
     detail::bind_binary_backward(
         module,
@@ -206,57 +206,57 @@ void py_module(py::module& module) {
     detail::bind_binary_backward(
         module,
         ttnn::subalpha_bw,
-        R"doc(Performs backward operations for subalpha of :attr:`input_tensor_a` and :attr:`input_tensor_b` tensors with given :attr:`grad_tensor`.)doc");
+        R"doc(Performs backward operations for subalpha of :attr:`input_tensor_a` and :attr:`input_tensor_b` with given :attr:`grad_tensor`.)doc");
 
     detail::bind_binary_backward(
         module,
         ttnn::sub_bw,
-        R"doc(Performs backward operations for sub of :attr:`input_tensor_a` and :attr:`input_tensor_b` tensors with given :attr:`grad_tensor`.)doc");
+        R"doc(Performs backward operations for sub of :attr:`input_tensor_a` and :attr:`input_tensor_b` with given :attr:`grad_tensor`.)doc");
 
     detail::bind_binary_backward(
         module,
         ttnn::addalpha_bw,
-        R"doc(Performs backward operations for addalpha on :attr:`input_tensor_b` , attr:`input_tensor_a`, attr:`alpha` tensors with given attr:`grad_tensor`.)doc");
+        R"doc(Performs backward operations for addalpha on :attr:`input_tensor_b` , attr:`input_tensor_a`, attr:`alpha` with given attr:`grad_tensor`.)doc");
 
     detail::bind_binary_backward(
         module,
         ttnn::xlogy_bw,
-        R"doc(Performs backward operations for xlogy of :attr:`input_tensor_a` and :attr:`input_tensor_b` tensors with given :attr:`grad_tensor`.)doc");
+        R"doc(Performs backward operations for xlogy of :attr:`input_tensor_a` and :attr:`input_tensor_b` with given :attr:`grad_tensor`.)doc");
 
     detail::bind_binary_backward(
         module,
         ttnn::hypot_bw,
-        R"doc(Performs backward operations for hypot of :attr:`input_tensor_a` and :attr:`input_tensor_b` tensors with given :attr:`grad_tensor`.)doc");
+        R"doc(Performs backward operations for hypot of :attr:`input_tensor_a` and :attr:`input_tensor_b` with given :attr:`grad_tensor`.)doc");
 
     detail::bind_binary_backward(
         module,
         ttnn::ldexp_bw,
-        R"doc(Performs backward operations for ldexp of :attr:`input_tensor_a` and :attr:`input_tensor_b` tensors with given :attr:`grad_tensor`.)doc");
+        R"doc(Performs backward operations for ldexp of :attr:`input_tensor_a` and :attr:`input_tensor_b` with given :attr:`grad_tensor`.)doc");
 
     detail::bind_binary_backward(
         module,
         ttnn::logaddexp_bw,
-        R"doc(Performs backward operations for logaddexp of :attr:`input_tensor_a` and :attr:`input_tensor_b` tensors with given :attr:`grad_tensor`.)doc");
+        R"doc(Performs backward operations for logaddexp of :attr:`input_tensor_a` and :attr:`input_tensor_b` with given :attr:`grad_tensor`.)doc");
 
     detail::bind_binary_backward(
         module,
         ttnn::logaddexp2_bw,
-        R"doc(Performs backward operations for logaddexp2 of :attr:`input_tensor_a` and :attr:`input_tensor_b` tensors with given :attr:`grad_tensor`.)doc");
+        R"doc(Performs backward operations for logaddexp2 of :attr:`input_tensor_a` and :attr:`input_tensor_b` with given :attr:`grad_tensor`.)doc");
 
     detail::bind_binary_backward(
         module,
         ttnn::squared_difference_bw,
-        R"doc(Performs backward operations for squared_difference of :attr:`input_tensor_a` and :attr:`input_tensor_b` tensors with given :attr:`grad_tensor`.)doc");
+        R"doc(Performs backward operations for squared_difference of :attr:`input_tensor_a` and :attr:`input_tensor_b` with given :attr:`grad_tensor`.)doc");
 
     detail::bind_binary_backward(
         module,
         ttnn::add_bw,
-        R"doc(Performs backward operations for add on :attr:`input_tensor_b` , attr:`input_tensor_a` tensors with given attr:`grad_tensor`.)doc");
+        R"doc(Performs backward operations for add on :attr:`input_tensor_b` , attr:`input_tensor_a` with given attr:`grad_tensor`.)doc");
 
     detail::bind_binary_backward(
         module,
         ttnn::binary_eq_bw,
-        R"doc(Performs backward operations for equal to comparison on :attr:`input_tensor_b` , attr:`input_tensor_a` tensors with given attr:`grad_tensor`.
+        R"doc(Performs backward operations for equal to comparison on :attr:`input_tensor_a` , attr:`input_tensor_b` with given attr:`grad_tensor`.
         Returns an tensor of zeros like :attr:`input_tensor_a` and :attr:`input_tensor_b` tensor.)doc");
 
     detail::bind_binary_backward(
@@ -277,12 +277,19 @@ void py_module(py::module& module) {
     detail::bind_binary_backward(
         module,
         ttnn::rsub_bw,
-        R"doc(Performs backward operations for subraction of :attr:`input_tensor_a` from :attr:`input_tensor_b` tensors with given attr:`grad_tensor` (reversed order of subtraction operator).)doc");
+        R"doc(Performs backward operations for subraction of :attr:`input_tensor_a` from :attr:`input_tensor_b` with given attr:`grad_tensor` (reversed order of subtraction operator).)doc");
 
     detail::bind_binary_backward(
         module,
         ttnn::bias_gelu_bw,
-        R"doc(Performs backward operations for binary gelu of :attr:`input_tensor_a` and :attr:`input_tensor_b` tensors with given attr:`grad_tensor`.)doc");
+        R"doc(Performs backward operations for binary gelu of :attr:`input_tensor_a` and :attr:`input_tensor_b` with given attr:`grad_tensor`.)doc");
+
+    detail::bind_binary_backward(
+        module,
+        ttnn::binary_gt_bw,
+        R"doc(Performs backward operations for greater than comparison on :attr:`input_tensor_a` , attr:`input_tensor_b` with given attr:`grad_tensor`.
+        Returns an tensor of zeros like :attr:`input_tensor_a` and :attr:`input_tensor_b` tensor.)doc");
+
 
 }
 

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_backward/binary_backward_pybind.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_backward/binary_backward_pybind.hpp
@@ -290,6 +290,11 @@ void py_module(py::module& module) {
         R"doc(Performs backward operations for greater than comparison on :attr:`input_tensor_a` , attr:`input_tensor_b` with given attr:`grad_tensor`.
         Returns an tensor of zeros like :attr:`input_tensor_a` and :attr:`input_tensor_b` tensor.)doc");
 
+detail::bind_binary_backward(
+        module,
+        ttnn::binary_ne_bw,
+        R"doc(Performs backward operations for not equal comparison on :attr:`input_tensor_a` , attr:`input_tensor_b` with given attr:`grad_tensor`.
+        Returns an tensor of zeros like :attr:`input_tensor_a` and :attr:`input_tensor_b` tensor.)doc");
 
 }
 

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_backward/binary_backward_pybind.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_backward/binary_backward_pybind.hpp
@@ -124,10 +124,10 @@ Example:
                const ttnn::Tensor& input_tensor_b,
                const std::optional<ttnn::MemoryConfig>& memory_config,
                const std::vector<bool>& are_required_outputs,
-               const std::optional<ttnn::Tensor>& optional_input_a_grad,
-               const std::optional<ttnn::Tensor>& optional_input_b_grad,
+               const std::optional<ttnn::Tensor>& input_a_grad,
+               const std::optional<ttnn::Tensor>& input_b_grad,
                const uint8_t& queue_id) -> std::vector<optional<ttnn::Tensor>> {
-                return self(queue_id, grad_tensor, input_tensor_a, input_tensor_b, memory_config, are_required_outputs, optional_input_a_grad, optional_input_b_grad);
+                return self(queue_id, grad_tensor, input_tensor_a, input_tensor_b, memory_config, are_required_outputs, input_a_grad, input_b_grad);
             },
             py::arg("grad_tensor"),
             py::arg("input_tensor_a"),
@@ -135,8 +135,8 @@ Example:
             py::kw_only(),
             py::arg("memory_config") = std::nullopt,
             py::arg("are_required_outputs") = std::vector<bool>{true, true},
-            py::arg("optional_input_a_grad") = std::nullopt,
-            py::arg("optional_input_b_grad") = std::nullopt,
+            py::arg("input_a_grad") = std::nullopt,
+            py::arg("input_b_grad") = std::nullopt,
             py::arg("queue_id") = 0},
 
         ttnn::pybind_overload_t{
@@ -146,9 +146,9 @@ Example:
                const ttnn::Tensor& input_tensor_b,
                const std::optional<ttnn::MemoryConfig>& memory_config,
                const std::vector<bool>& are_required_outputs,
-               const std::optional<ttnn::Tensor>& optional_input_a_grad,
-               const std::optional<ttnn::Tensor>& optional_input_b_grad) -> std::vector<optional<ttnn::Tensor>> {
-                return self(grad_tensor, input_tensor_a, input_tensor_b, memory_config, are_required_outputs, optional_input_a_grad, optional_input_b_grad);
+               const std::optional<ttnn::Tensor>& input_a_grad,
+               const std::optional<ttnn::Tensor>& input_b_grad) -> std::vector<optional<ttnn::Tensor>> {
+                return self(grad_tensor, input_tensor_a, input_tensor_b, memory_config, are_required_outputs, input_a_grad, input_b_grad);
             },
             py::arg("grad_tensor"),
             py::arg("input_tensor_a"),
@@ -156,8 +156,8 @@ Example:
             py::kw_only(),
             py::arg("memory_config") = std::nullopt,
             py::arg("are_required_outputs") = std::vector<bool>{true, true},
-            py::arg("optional_input_a_grad") = std::nullopt,
-            py::arg("optional_input_b_grad") = std::nullopt},
+            py::arg("input_a_grad") = std::nullopt,
+            py::arg("input_b_grad") = std::nullopt},
 
         ttnn::pybind_overload_t{
             [](const binary_backward_operation_t& self,
@@ -167,10 +167,10 @@ Example:
                const float alpha,
                const std::optional<ttnn::MemoryConfig>& memory_config,
                const std::vector<bool>& are_required_outputs,
-               const std::optional<ttnn::Tensor>& optional_input_a_grad,
-               const std::optional<ttnn::Tensor>& optional_input_b_grad,
+               const std::optional<ttnn::Tensor>& input_a_grad,
+               const std::optional<ttnn::Tensor>& input_b_grad,
                const uint8_t& queue_id) -> std::vector<optional<ttnn::Tensor>> {
-                return self(queue_id, grad_tensor, input_tensor_a, input_tensor_b, alpha, memory_config, are_required_outputs, optional_input_a_grad, optional_input_b_grad);
+                return self(queue_id, grad_tensor, input_tensor_a, input_tensor_b, alpha, memory_config, are_required_outputs, input_a_grad, input_b_grad);
             },
             py::arg("grad_tensor"),
             py::arg("input_tensor_a"),
@@ -179,8 +179,8 @@ Example:
             py::kw_only(),
             py::arg("memory_config") = std::nullopt,
             py::arg("are_required_outputs") = std::vector<bool>{true, true},
-            py::arg("optional_input_a_grad") = std::nullopt,
-            py::arg("optional_input_b_grad") = std::nullopt,
+            py::arg("input_a_grad") = std::nullopt,
+            py::arg("input_b_grad") = std::nullopt,
             py::arg("queue_id") = 0},
 
         ttnn::pybind_overload_t{
@@ -191,9 +191,9 @@ Example:
                const float alpha,
                const std::optional<ttnn::MemoryConfig>& memory_config,
                const std::vector<bool>& are_required_outputs,
-               const std::optional<ttnn::Tensor>& optional_input_a_grad,
-               const std::optional<ttnn::Tensor>& optional_input_b_grad) -> std::vector<optional<ttnn::Tensor>> {
-                return self(grad_tensor, input_tensor_a, input_tensor_b, alpha, memory_config, are_required_outputs, optional_input_a_grad, optional_input_b_grad);
+               const std::optional<ttnn::Tensor>& input_a_grad,
+               const std::optional<ttnn::Tensor>& input_b_grad) -> std::vector<optional<ttnn::Tensor>> {
+                return self(grad_tensor, input_tensor_a, input_tensor_b, alpha, memory_config, are_required_outputs, input_a_grad, input_b_grad);
             },
             py::arg("grad_tensor"),
             py::arg("input_tensor_a"),
@@ -202,8 +202,8 @@ Example:
             py::kw_only(),
             py::arg("memory_config") = std::nullopt,
             py::arg("are_required_outputs") = std::vector<bool>{true, true},
-            py::arg("optional_input_a_grad") = std::nullopt,
-            py::arg("optional_input_b_grad") = std::nullopt});
+            py::arg("input_a_grad") = std::nullopt,
+            py::arg("input_b_grad") = std::nullopt});
 }
 
 }  // namespace detail
@@ -345,6 +345,11 @@ void py_module(py::module& module) {
         module,
         ttnn::div_bw,
         R"doc(Performs backward operations for divide of :attr:`input_tensor_a` and :attr:`input_tensor_b` with given :attr:`grad_tensor`.)doc");
+
+    detail::bind_binary_backward(
+        module,
+        ttnn::mul_bw,
+        R"doc(Performs backward operations for multiply on :attr:`input_tensor_b` , attr:`input_tensor_a` with given attr:`grad_tensor`.)doc");
 
 }
 

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_backward/binary_backward_pybind.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_backward/binary_backward_pybind.hpp
@@ -292,6 +292,12 @@ void py_module(py::module& module) {
 
     detail::bind_binary_backward(
         module,
+        ttnn::binary_lt_bw,
+        R"doc(Performs backward operations for less than comparison on :attr:`input_tensor_a` , attr:`input_tensor_b` with given attr:`grad_tensor`.
+        Returns an tensor of zeros like :attr:`input_tensor_a` and :attr:`input_tensor_b` tensor.)doc");
+
+    detail::bind_binary_backward(
+        module,
         ttnn::binary_ne_bw,
         R"doc(Performs backward operations for not equal comparison on :attr:`input_tensor_a` , attr:`input_tensor_b` with given attr:`grad_tensor`.
         Returns an tensor of zeros like :attr:`input_tensor_a` and :attr:`input_tensor_b` tensor.)doc");

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_backward/binary_backward_pybind.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_backward/binary_backward_pybind.hpp
@@ -302,6 +302,11 @@ void py_module(py::module& module) {
         R"doc(Performs backward operations for greater than or equal to comparison on :attr:`input_tensor_a` , attr:`input_tensor_b` with given attr:`grad_tensor`.
         Returns an tensor of zeros like :attr:`input_tensor_a` and :attr:`input_tensor_b` tensor.)doc");
 
+    detail::bind_binary_backward(
+        module,
+        ttnn::min_bw,
+        R"doc(Performs backward operations for minimum of :attr:`input_tensor_a` and :attr:`input_tensor_b` with given :attr:`grad_tensor`.)doc");
+
 }
 
 }  // namespace binary_backward

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_backward/device/binary_backward_op.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_backward/device/binary_backward_op.cpp
@@ -514,6 +514,8 @@ std::function<std::vector<ttnn::Tensor>(const Tensor&, const Tensor&, const Tens
             return _binary_ge_bw;
         case BinaryBackwardOpType::MIN_BW:
             return _min_or_max_bw<false>;
+        case BinaryBackwardOpType::MAX_BW:
+            return _min_or_max_bw<true>;
         default:
             TT_ASSERT(false && "Undefined op type");
             return 0;

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_backward/device/binary_backward_op.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_backward/device/binary_backward_op.cpp
@@ -539,6 +539,18 @@ std::vector<Tensor> _div_bw(
     return grad_tensor;
 }
 
+// lerp(input, end, weight) = self: grad * (1 - weight), end: grad * weight
+std::vector<Tensor> _lerp_bw(
+    const Tensor& grad, const Tensor& input, const Tensor& end, float weight, const MemoryConfig& output_mem_config) {
+    std::vector<Tensor> grad_tensor;
+    float sub_scalar = 1.0f - weight;
+    Tensor result_1 = ttnn::multiply(grad, sub_scalar, std::nullopt, output_mem_config);
+    grad_tensor.emplace_back(result_1);
+    Tensor result_2 = ttnn::multiply(grad, weight, std::nullopt, output_mem_config);
+    grad_tensor.emplace_back(result_2);
+    return grad_tensor;
+}
+
 
 std::function<std::vector<ttnn::Tensor>(const Tensor&, const Tensor&, const Tensor&, const MemoryConfig&)> get_function_type1(BinaryBackwardOpType OpType){
     switch (OpType) {
@@ -596,6 +608,8 @@ std::function<std::vector<ttnn::Tensor>(const Tensor&, const Tensor&, const Tens
             return _addalpha_bw_inter;
         case BinaryBackwardOpType::CONCAT_BW:
             return _concat_bw;
+        case BinaryBackwardOpType::LERP_BW:
+            return _lerp_bw;
         default:
             TT_ASSERT(false && "Undefined op type");
             return 0;

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_backward/device/binary_backward_op.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_backward/device/binary_backward_op.cpp
@@ -431,12 +431,11 @@ std::vector<Tensor> _bias_gelu_bw(
 
 
 std::vector<Tensor> _binary_gt_bw(const Tensor& grad, const Tensor& input, const Tensor& other, const MemoryConfig& output_mem_config) {
-    std::vector<Tensor> grad_tensor;
-    Tensor zero_grad = tt::tt_metal::zeros_like(grad, output_mem_config);
-    grad_tensor.emplace_back(zero_grad);
-    Tensor zero_input =  tt::tt_metal::zeros_like(input, output_mem_config);
-    grad_tensor.emplace_back(zero_input);
-    return grad_tensor;
+    return _binary_le_bw(grad, input, other, output_mem_config);
+}
+
+std::vector<Tensor> _binary_ne_bw(const Tensor& grad, const Tensor& input, const Tensor& other, const MemoryConfig& output_mem_config) {
+    return _binary_le_bw(grad, input, other, output_mem_config);
 }
 
 
@@ -472,6 +471,8 @@ std::function<std::vector<ttnn::Tensor>(const Tensor&, const Tensor&, const Tens
             return _rsub_bw;
         case BinaryBackwardOpType::BINARY_GT_BW:
             return _binary_gt_bw;
+        case BinaryBackwardOpType::BINARY_NE_BW:
+            return _binary_ne_bw;
         default:
             TT_ASSERT(false && "Undefined op type");
             return 0;

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_backward/device/binary_backward_op.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_backward/device/binary_backward_op.cpp
@@ -430,6 +430,16 @@ std::vector<Tensor> _bias_gelu_bw(
 }
 
 
+std::vector<Tensor> _binary_gt_bw(const Tensor& grad, const Tensor& input, const Tensor& other, const MemoryConfig& output_mem_config) {
+    std::vector<Tensor> grad_tensor;
+    Tensor zero_grad = tt::tt_metal::zeros_like(grad, output_mem_config);
+    grad_tensor.emplace_back(zero_grad);
+    Tensor zero_input =  tt::tt_metal::zeros_like(input, output_mem_config);
+    grad_tensor.emplace_back(zero_input);
+    return grad_tensor;
+}
+
+
 std::function<std::vector<ttnn::Tensor>(const Tensor&, const Tensor&, const Tensor&, const MemoryConfig&)> get_function_type1(BinaryBackwardOpType OpType){
     switch (OpType) {
         case BinaryBackwardOpType::ATAN2_BW:
@@ -460,6 +470,8 @@ std::function<std::vector<ttnn::Tensor>(const Tensor&, const Tensor&, const Tens
             return _binary_le_bw;
         case BinaryBackwardOpType::RSUB_BW:
             return _rsub_bw;
+        case BinaryBackwardOpType::BINARY_GT_BW:
+            return _binary_gt_bw;
         default:
             TT_ASSERT(false && "Undefined op type");
             return 0;

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_backward/device/binary_backward_op.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_backward/device/binary_backward_op.cpp
@@ -400,7 +400,7 @@ std::vector<Tensor> _concat_bw(
     return grad_tensor;
 }
 
-std::vector<Tensor> _binary_le_bw(const Tensor& grad, const Tensor& input, const Tensor& other, const MemoryConfig& output_mem_config) {
+std::vector<Tensor> _binary_comp_bw(const Tensor& grad, const Tensor& input, const Tensor& other, const MemoryConfig& output_mem_config) {
     std::vector<Tensor> grad_tensor;
     Tensor zero_grad = tt::tt_metal::zeros_like(grad, output_mem_config);
     grad_tensor.emplace_back(zero_grad);
@@ -431,15 +431,23 @@ std::vector<Tensor> _bias_gelu_bw(
 
 
 std::vector<Tensor> _binary_gt_bw(const Tensor& grad, const Tensor& input, const Tensor& other, const MemoryConfig& output_mem_config) {
-    return _binary_le_bw(grad, input, other, output_mem_config);
+    return _binary_comp_bw(grad, input, other, output_mem_config);
 }
 
 std::vector<Tensor> _binary_ne_bw(const Tensor& grad, const Tensor& input, const Tensor& other, const MemoryConfig& output_mem_config) {
-    return _binary_le_bw(grad, input, other, output_mem_config);
+    return _binary_comp_bw(grad, input, other, output_mem_config);
 }
 
 std::vector<Tensor> _binary_ge_bw(const Tensor& grad, const Tensor& input, const Tensor& other, const MemoryConfig& output_mem_config) {
-    return _binary_le_bw(grad, input, other, output_mem_config);
+    return _binary_comp_bw(grad, input, other, output_mem_config);
+}
+
+std::vector<Tensor> _binary_le_bw(const Tensor& grad, const Tensor& input, const Tensor& other, const MemoryConfig& output_mem_config) {
+    return _binary_comp_bw(grad, input, other, output_mem_config);
+}
+
+std::vector<Tensor> _binary_lt_bw(const Tensor& grad, const Tensor& input, const Tensor& other, const MemoryConfig& output_mem_config) {
+    return _binary_comp_bw(grad, input, other, output_mem_config);
 }
 
 // template parameter min_or_max = TRUE for MAX, FALSE for MIN
@@ -564,6 +572,8 @@ std::function<std::vector<ttnn::Tensor>(const Tensor&, const Tensor&, const Tens
             return _rsub_bw;
         case BinaryBackwardOpType::BINARY_GT_BW:
             return _binary_gt_bw;
+        case BinaryBackwardOpType::BINARY_LT_BW:
+            return _binary_lt_bw;
         case BinaryBackwardOpType::BINARY_NE_BW:
             return _binary_ne_bw;
         case BinaryBackwardOpType::BINARY_GE_BW:

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_backward/device/binary_backward_op.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_backward/device/binary_backward_op.cpp
@@ -671,6 +671,17 @@ std::function<std::vector<std::optional<ttnn::Tensor>>(const Tensor&, const Tens
             return 0;
     }
 }
+
+std::function<std::vector<ttnn::Tensor>(const Tensor&, const Tensor&, const Tensor&, const Tensor&, const MemoryConfig&)> get_overload_function(BinaryBackwardOpType OpType){
+    switch (OpType) {
+        case BinaryBackwardOpType::LERP_BW:
+            return tt::tt_metal::_lerp_overload;
+        default:
+            TT_ASSERT(false && "Undefined op type");
+            return 0;
+    }
+}
+
 }
 
 

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_backward/device/binary_backward_op.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_backward/device/binary_backward_op.cpp
@@ -438,6 +438,10 @@ std::vector<Tensor> _binary_ne_bw(const Tensor& grad, const Tensor& input, const
     return _binary_le_bw(grad, input, other, output_mem_config);
 }
 
+std::vector<Tensor> _binary_ge_bw(const Tensor& grad, const Tensor& input, const Tensor& other, const MemoryConfig& output_mem_config) {
+    return _binary_le_bw(grad, input, other, output_mem_config);
+}
+
 
 std::function<std::vector<ttnn::Tensor>(const Tensor&, const Tensor&, const Tensor&, const MemoryConfig&)> get_function_type1(BinaryBackwardOpType OpType){
     switch (OpType) {
@@ -473,6 +477,8 @@ std::function<std::vector<ttnn::Tensor>(const Tensor&, const Tensor&, const Tens
             return _binary_gt_bw;
         case BinaryBackwardOpType::BINARY_NE_BW:
             return _binary_ne_bw;
+        case BinaryBackwardOpType::BINARY_GE_BW:
+            return _binary_ge_bw;
         default:
             TT_ASSERT(false && "Undefined op type");
             return 0;

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_backward/device/binary_backward_op.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_backward/device/binary_backward_op.hpp
@@ -30,7 +30,8 @@ enum class BinaryBackwardOpType {
     CONCAT_BW,
     BINARY_LE_BW,
     RSUB_BW,
-    BIAS_GELU_BW
+    BIAS_GELU_BW,
+    BINARY_GT_BW
 };
 
 

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_backward/device/binary_backward_op.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_backward/device/binary_backward_op.hpp
@@ -39,6 +39,7 @@ enum class BinaryBackwardOpType {
     MAX_BW,
     DIV_BW,
     LERP_BW,
+    MUL_BW,
 };
 
 

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_backward/device/binary_backward_op.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_backward/device/binary_backward_op.hpp
@@ -33,7 +33,8 @@ enum class BinaryBackwardOpType {
     BIAS_GELU_BW,
     BINARY_GT_BW,
     BINARY_NE_BW,
-    BINARY_GE_BW
+    BINARY_GE_BW,
+    MIN_BW,
 };
 
 

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_backward/device/binary_backward_op.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_backward/device/binary_backward_op.hpp
@@ -38,6 +38,7 @@ enum class BinaryBackwardOpType {
     MIN_BW,
     MAX_BW,
     DIV_BW,
+    LERP_BW,
 };
 
 

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_backward/device/binary_backward_op.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_backward/device/binary_backward_op.hpp
@@ -32,7 +32,8 @@ enum class BinaryBackwardOpType {
     RSUB_BW,
     BIAS_GELU_BW,
     BINARY_GT_BW,
-    BINARY_NE_BW
+    BINARY_NE_BW,
+    BINARY_GE_BW
 };
 
 

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_backward/device/binary_backward_op.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_backward/device/binary_backward_op.hpp
@@ -36,6 +36,7 @@ enum class BinaryBackwardOpType {
     BINARY_GE_BW,
     MIN_BW,
     MAX_BW,
+    DIV_BW,
 };
 
 

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_backward/device/binary_backward_op.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_backward/device/binary_backward_op.hpp
@@ -35,6 +35,7 @@ enum class BinaryBackwardOpType {
     BINARY_NE_BW,
     BINARY_GE_BW,
     MIN_BW,
+    MAX_BW,
 };
 
 

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_backward/device/binary_backward_op.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_backward/device/binary_backward_op.hpp
@@ -31,7 +31,8 @@ enum class BinaryBackwardOpType {
     BINARY_LE_BW,
     RSUB_BW,
     BIAS_GELU_BW,
-    BINARY_GT_BW
+    BINARY_GT_BW,
+    BINARY_NE_BW
 };
 
 

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_backward/device/binary_backward_op.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_backward/device/binary_backward_op.hpp
@@ -32,6 +32,7 @@ enum class BinaryBackwardOpType {
     RSUB_BW,
     BIAS_GELU_BW,
     BINARY_GT_BW,
+    BINARY_LT_BW,
     BINARY_NE_BW,
     BINARY_GE_BW,
     MIN_BW,

--- a/ttnn/ttnn/__init__.py
+++ b/ttnn/ttnn/__init__.py
@@ -476,6 +476,7 @@ from ttnn.operations.binary_backward import (
     binary_ne_bw,
     binary_ge_bw,
     min_bw,
+    max_bw,
 )
 
 from ttnn.operations.ternary import (

--- a/ttnn/ttnn/__init__.py
+++ b/ttnn/ttnn/__init__.py
@@ -475,6 +475,7 @@ from ttnn.operations.binary_backward import (
     binary_gt_bw,
     binary_ne_bw,
     binary_ge_bw,
+    min_bw,
 )
 
 from ttnn.operations.ternary import (

--- a/ttnn/ttnn/__init__.py
+++ b/ttnn/ttnn/__init__.py
@@ -479,6 +479,7 @@ from ttnn.operations.binary_backward import (
     min_bw,
     max_bw,
     div_bw,
+    lerp_bw,
 )
 
 from ttnn.operations.ternary import (

--- a/ttnn/ttnn/__init__.py
+++ b/ttnn/ttnn/__init__.py
@@ -473,6 +473,7 @@ from ttnn.operations.binary_backward import (
     rsub_bw,
     bias_gelu_bw,
     binary_gt_bw,
+    binary_lt_bw,
     binary_ne_bw,
     binary_ge_bw,
     min_bw,

--- a/ttnn/ttnn/__init__.py
+++ b/ttnn/ttnn/__init__.py
@@ -473,6 +473,7 @@ from ttnn.operations.binary_backward import (
     rsub_bw,
     bias_gelu_bw,
     binary_gt_bw,
+    binary_ne_bw,
 )
 
 from ttnn.operations.ternary import (

--- a/ttnn/ttnn/__init__.py
+++ b/ttnn/ttnn/__init__.py
@@ -474,6 +474,7 @@ from ttnn.operations.binary_backward import (
     bias_gelu_bw,
     binary_gt_bw,
     binary_ne_bw,
+    binary_ge_bw,
 )
 
 from ttnn.operations.ternary import (

--- a/ttnn/ttnn/__init__.py
+++ b/ttnn/ttnn/__init__.py
@@ -480,6 +480,7 @@ from ttnn.operations.binary_backward import (
     max_bw,
     div_bw,
     lerp_bw,
+    mul_bw,
 )
 
 from ttnn.operations.ternary import (

--- a/ttnn/ttnn/__init__.py
+++ b/ttnn/ttnn/__init__.py
@@ -472,6 +472,7 @@ from ttnn.operations.binary_backward import (
     binary_le_bw,
     rsub_bw,
     bias_gelu_bw,
+    binary_gt_bw,
 )
 
 from ttnn.operations.ternary import (

--- a/ttnn/ttnn/__init__.py
+++ b/ttnn/ttnn/__init__.py
@@ -477,6 +477,7 @@ from ttnn.operations.binary_backward import (
     binary_ge_bw,
     min_bw,
     max_bw,
+    div_bw,
 )
 
 from ttnn.operations.ternary import (

--- a/ttnn/ttnn/operations/binary_backward.py
+++ b/ttnn/ttnn/operations/binary_backward.py
@@ -183,8 +183,8 @@ concat_bw = ttnn.register_operation(
 )(ttnn._ttnn.operations.binary_backward.concat_bw)
 
 binary_le_bw = ttnn.register_operation(
-    golden_function=lambda grad, a, b, *args, **kwargs: _golden_function_backward(
-        torch.clone, grad, a, b, *args, **kwargs
+    golden_function=lambda grad, a, b, *args, **kwargs: _golden_function_comparison_ops(
+        torch.le, grad, a, b, *args, **kwargs
     )
 )(ttnn._ttnn.operations.binary_backward.binary_le_bw)
 
@@ -202,14 +202,20 @@ bias_gelu_bw = ttnn.register_operation(
 
 binary_gt_bw = ttnn.register_operation(
     golden_function=lambda grad, a, b, *args, **kwargs: _golden_function_comparison_ops(
-        torch.eq, grad, a, b, *args, **kwargs
+        torch.gt, grad, a, b, *args, **kwargs
     )
 )(ttnn._ttnn.operations.binary_backward.binary_gt_bw)
 
 binary_ne_bw = ttnn.register_operation(
     golden_function=lambda grad, a, b, *args, **kwargs: _golden_function_comparison_ops(
-        torch.eq, grad, a, b, *args, **kwargs
+        torch.ne, grad, a, b, *args, **kwargs
     )
 )(ttnn._ttnn.operations.binary_backward.binary_ne_bw)
+
+binary_ge_bw = ttnn.register_operation(
+    golden_function=lambda grad, a, b, *args, **kwargs: _golden_function_comparison_ops(
+        torch.ge, grad, a, b, *args, **kwargs
+    )
+)(ttnn._ttnn.operations.binary_backward.binary_ge_bw)
 
 __all__ = []

--- a/ttnn/ttnn/operations/binary_backward.py
+++ b/ttnn/ttnn/operations/binary_backward.py
@@ -200,4 +200,10 @@ bias_gelu_bw = ttnn.register_operation(
     )
 )(ttnn._ttnn.operations.binary_backward.bias_gelu_bw)
 
+binary_gt_bw = ttnn.register_operation(
+    golden_function=lambda grad, a, b, *args, **kwargs: _golden_function_comparison_ops(
+        torch.eq, grad, a, b, *args, **kwargs
+    )
+)(ttnn._ttnn.operations.binary_backward.binary_gt_bw)
+
 __all__ = []

--- a/ttnn/ttnn/operations/binary_backward.py
+++ b/ttnn/ttnn/operations/binary_backward.py
@@ -210,6 +210,12 @@ binary_gt_bw = ttnn.register_operation(
     )
 )(ttnn._ttnn.operations.binary_backward.binary_gt_bw)
 
+binary_lt_bw = ttnn.register_operation(
+    golden_function=lambda grad, a, b, *args, **kwargs: _golden_function_comparison_ops(
+        torch.gt, grad, a, b, *args, **kwargs
+    )
+)(ttnn._ttnn.operations.binary_backward.binary_lt_bw)
+
 binary_ne_bw = ttnn.register_operation(
     golden_function=lambda grad, a, b, *args, **kwargs: _golden_function_comparison_ops(
         torch.ne, grad, a, b, *args, **kwargs

--- a/ttnn/ttnn/operations/binary_backward.py
+++ b/ttnn/ttnn/operations/binary_backward.py
@@ -252,4 +252,10 @@ lerp_bw = ttnn.register_operation(
     )
 )(ttnn._ttnn.operations.binary_backward.lerp_bw)
 
+mul_bw = ttnn.register_operation(
+    golden_function=lambda grad, a, b, *args, **kwargs: _golden_function_backward(
+        torch.mul, grad, a, b, *args, **kwargs
+    )
+)(ttnn._ttnn.operations.binary_backward.mul_bw)
+
 __all__ = []

--- a/ttnn/ttnn/operations/binary_backward.py
+++ b/ttnn/ttnn/operations/binary_backward.py
@@ -218,4 +218,10 @@ binary_ge_bw = ttnn.register_operation(
     )
 )(ttnn._ttnn.operations.binary_backward.binary_ge_bw)
 
+min_bw = ttnn.register_operation(
+    golden_function=lambda grad, a, b, *args, **kwargs: _golden_function_backward(
+        torch.min, grad, a, b, *args, **kwargs
+    )
+)(ttnn._ttnn.operations.binary_backward.min_bw)
+
 __all__ = []

--- a/ttnn/ttnn/operations/binary_backward.py
+++ b/ttnn/ttnn/operations/binary_backward.py
@@ -85,7 +85,11 @@ def _golden_function_backward_with_string(
         pyt_y.backward(gradient=grad_tensor)
         golden_tensor = [sum_result.grad, sum_result.grad]
         return golden_tensor
-    pyt_y = torch_op(input_tensor_a, input_tensor_b, value=value)
+
+    if torch_op == torch.div:
+        pyt_y = torch_op(input_tensor_a, input_tensor_b, rounding_mode=value)
+    else:
+        pyt_y = torch_op(input_tensor_a, input_tensor_b, value=value)
     input_tensor_a.retain_grad()
     input_tensor_b.retain_grad()
     pyt_y.backward(gradient=grad_tensor)
@@ -229,5 +233,11 @@ max_bw = ttnn.register_operation(
         torch.max, grad, a, b, *args, **kwargs
     )
 )(ttnn._ttnn.operations.binary_backward.max_bw)
+
+div_bw = ttnn.register_operation(
+    golden_function=lambda grad, a, b, *args, **kwargs: _golden_function_backward_with_string(
+        torch.div, grad, a, b, *args, **kwargs
+    )
+)(ttnn._ttnn.operations.binary_backward.div_bw)
 
 __all__ = []

--- a/ttnn/ttnn/operations/binary_backward.py
+++ b/ttnn/ttnn/operations/binary_backward.py
@@ -224,4 +224,10 @@ min_bw = ttnn.register_operation(
     )
 )(ttnn._ttnn.operations.binary_backward.min_bw)
 
+max_bw = ttnn.register_operation(
+    golden_function=lambda grad, a, b, *args, **kwargs: _golden_function_backward(
+        torch.max, grad, a, b, *args, **kwargs
+    )
+)(ttnn._ttnn.operations.binary_backward.max_bw)
+
 __all__ = []

--- a/ttnn/ttnn/operations/binary_backward.py
+++ b/ttnn/ttnn/operations/binary_backward.py
@@ -206,4 +206,10 @@ binary_gt_bw = ttnn.register_operation(
     )
 )(ttnn._ttnn.operations.binary_backward.binary_gt_bw)
 
+binary_ne_bw = ttnn.register_operation(
+    golden_function=lambda grad, a, b, *args, **kwargs: _golden_function_comparison_ops(
+        torch.eq, grad, a, b, *args, **kwargs
+    )
+)(ttnn._ttnn.operations.binary_backward.binary_ne_bw)
+
 __all__ = []

--- a/ttnn/ttnn/operations/binary_backward.py
+++ b/ttnn/ttnn/operations/binary_backward.py
@@ -246,4 +246,10 @@ div_bw = ttnn.register_operation(
     )
 )(ttnn._ttnn.operations.binary_backward.div_bw)
 
+lerp_bw = ttnn.register_operation(
+    golden_function=lambda grad, a, b, weight, *args, **kwargs: _golden_function_backward_with_float(
+        torch.add, grad, a, b, weight, *args, **kwargs
+    )
+)(ttnn._ttnn.operations.binary_backward.lerp_bw)
+
 __all__ = []


### PR DESCRIPTION
Binary Backward Issue : #9628 [Master issue : #9322 ]

### List of ops completed
- binary_ne_bw
- binary_gt_bw
- binary_ge_bw
- binary_lt_bw
- min_bw
- max_bw
- div_bw
- mul_bw
- lerp_bw

**Structure**
```
ttnn
└── cpp
    └── ttnn
        └── operations
            └── ...
            └── eltwise
                └── binary
                └── binary_backward
                    ├── device
                    │   ├── binary_backward_op.cpp
                    │   ├── binary_backward_op.hpp
                    ├── binary_backward.hpp
                    └── binary_backward_pybind.hpp
```

**Test files**
- binary_gt_bw : `tests/tt_eager/python_api_testing/unit_testing/backward_ops/test_backward_binary_gt.py`
- binary_ne_bw : `tests/tt_eager/python_api_testing/unit_testing/backward_ops/test_backward_binary_ne.py`
- binary_ge_bw : `tests/tt_eager/python_api_testing/unit_testing/backward_ops/test_backward_binary_ge.py`
- binary_lt_bw : `tests/tt_eager/python_api_testing/unit_testing/backward_ops/test_backward_binary_lt.py`
- min_bw : `tests/tt_eager/python_api_testing/unit_testing/backward_ops/test_backward_min.py`
- max_bw : `tests/tt_eager/python_api_testing/unit_testing/backward_ops/test_backward_max.py`
- div_bw : `tests/tt_eager/python_api_testing/unit_testing/backward_ops/test_backward_div.py`
- mul_bw : `tests/tt_eager/python_api_testing/unit_testing/backward_ops/test_backward_mul.py`
- lerp_bw : `tests/tt_eager/python_api_testing/unit_testing/backward_ops/test_backward_lerp.py`

**CI :** 

- [All post-commit tests](https://github.com/tenstorrent/tt-metal/actions/runs/9722419832) - PASSED
- [[post-commit] Fast Dispatch unit tests](https://github.com/tenstorrent/tt-metal/actions/runs/9722437819) - PASSED
- [[post-commit] Slow Dispatch unit tests](https://github.com/tenstorrent/tt-metal/actions/runs/9722438194) - PASSED
- [post-commit] models tests
- Device perf regressions and output report
- Model perf regressions and output report
- Nightly fast dispatch tests