### PR TITLE
Mchiou/9792 t3k runner management

### DIFF
--- a/.github/workflows/t3000-frequent-tests.yaml
+++ b/.github/workflows/t3000-frequent-tests.yaml
@@ -17,11 +17,16 @@ jobs:
       fail-fast: false
       matrix:
         test-group: [
-          { name: "t3k tteager tests", arch: wormhole_b0, cmd: run_t3000_tteager_tests, timeout: 120, owner_id: U05RWH3QUPM}, #Sean Nijjar
-          { name: "t3k trace stress tests", arch: wormhole_b0, cmd: run_t3000_trace_stress_tests, timeout: 120, owner_id: U03NG0A5ND7}, #Aditya Saigal
-          { name: "t3k falcon40b tests", arch: wormhole_b0, cmd: run_t3000_falcon40b_tests, timeout: 120, owner_id: S07AJBTLX2L}, #Model Falcon
-          { name: "t3k llama2_70b tests", arch: wormhole_b0, cmd: run_t3000_llama2_70b_tests, timeout: 60, owner_id: U03FJB5TM5Y}, #Colman Glagovich
-          { name: "t3k mixtral tests", arch: wormhole_b0, cmd: run_t3000_mixtral_tests, timeout: 60, owner_id: U03PUAKE719}, #Miguel Tairum Cruz
+          { name: "t3k tteager tests", arch: wormhole_b0, cmd: run_t3000_tteager_tests, timeout: 60, 
+          runs-on: [arch-wormhole_b0, "config-t3000", "in-service", "runner-test", "bare-metal", "pipeline-functional"], owner_id: ULMEPM2MA}, #Sean Nijjar
+          { name: "t3k trace stress tests", arch: wormhole_b0, cmd: run_t3000_trace_stress_tests, timeout: 120, 
+          runs-on: [arch-wormhole_b0, "config-t3000", "in-service", "runner-test", "bare-metal", "pipeline-functional", "t3k"], owner_id: U03NG0A5ND7}, #Aditya Saigal
+          { name: "t3k falcon40b tests", arch: wormhole_b0, cmd: run_t3000_falcon40b_tests, timeout: 120, 
+          runs-on: [arch-wormhole_b0, "config-t3000", "in-service", "runner-test", "bare-metal", "pipeline-functional"], owner_id: S07AJBTLX2L}, #Model Falcon
+          { name: "t3k llama2_70b tests", arch: wormhole_b0, cmd: run_t3000_llama2_70b_tests, timeout: 60, 
+          runs-on: [arch-wormhole_b0, "config-t3000", "in-service", "runner-test", "bare-metal", "pipeline-functional"], owner_id: U03FJB5TM5Y}, #Colman Glagovich
+          { name: "t3k mixtral tests", arch: wormhole_b0, cmd: run_t3000_mixtral_tests, timeout: 60, 
+          runs-on: [arch-wormhole_b0, "config-t3000", "in-service", "runner-test", "bare-metal", "pipeline-functional"], owner_id: U03PUAKE719}, #Miguel Tairum Cruz
         ]
     name: ${{ matrix.test-group.name }}
     env:
@@ -30,7 +35,7 @@ jobs:
       LOGURU_LEVEL: INFO
       LD_LIBRARY_PATH: ${{ github.workspace }}/build/lib
     environment: dev
-    runs-on: [arch-wormhole_b0, "config-t3000", "in-service", "runner-test", "bare-metal", "pipeline-functional"]
+    runs-on: ${{ matrix.test-group.runs-on }}
     steps:
       - uses: tenstorrent-metal/metal-workflows/.github/actions/checkout-with-submodule-lfs@v2.0.0
       - name: Set up dynamic env vars for build

--- a/.github/workflows/t3000-frequent-tests.yaml
+++ b/.github/workflows/t3000-frequent-tests.yaml
@@ -17,6 +17,7 @@ jobs:
       fail-fast: false
       matrix:
         test-group: [
+          { name: "t3k tteager tests", arch: wormhole_b0, cmd: run_t3000_tteager_tests, timeout: 120, owner_id: U05RWH3QUPM}, #Sean Nijjar
           { name: "t3k trace stress tests", arch: wormhole_b0, cmd: run_t3000_trace_stress_tests, timeout: 120, owner_id: U03NG0A5ND7}, #Aditya Saigal
           { name: "t3k falcon40b tests", arch: wormhole_b0, cmd: run_t3000_falcon40b_tests, timeout: 120, owner_id: S07AJBTLX2L}, #Model Falcon
           { name: "t3k llama2_70b tests", arch: wormhole_b0, cmd: run_t3000_llama2_70b_tests, timeout: 60, owner_id: U03FJB5TM5Y}, #Colman Glagovich

--- a/.github/workflows/t3000-model-perf-tests.yaml
+++ b/.github/workflows/t3000-model-perf-tests.yaml
@@ -17,10 +17,14 @@ jobs:
       fail-fast: false
       matrix:
         test-group: [
-          { name: "t3k LLM falcon7b model perf tests", model: "falcob7b", model-type: "LLM", arch: wormhole_b0, cmd: run_t3000_falcon7b_tests, timeout: 75, owner_id: S07AJBTLX2L}, #Model Falcon
-          { name: "t3k LLM mixtral model perf tests", model: "mixtral", model-type: "LLM", arch: wormhole_b0, cmd: run_t3000_mixtral_tests, timeout: 75, owner_id: U03PUAKE719}, # Miguel Tairum
-          { name: "t3k LLM llama2 model perf tests", model: "llama2", model-type: "LLM", arch: wormhole_b0, cmd: run_t3000_llama2_70b_tests, timeout: 75, owner_id: U03FJB5TM5Y}, #Colman Glagovich
-          { name: "t3k LLM falcon40b model perf tests", model: "falcon40b", model-type: "LLM", arch: wormhole_b0, cmd: run_t3000_falcon40b_tests, timeout: 75, owner_id: S07AJBTLX2L}, # Model Falcon
+          { name: "t3k LLM falcon7b model perf tests", model: "falcob7b", model-type: "LLM", arch: wormhole_b0, cmd: run_t3000_falcon7b_tests, timeout: 75, 
+            runs-on: ["arch-wormhole_b0", "config-t3000", "in-service", "runner-test", "bare-metal", "pipeline-perf", "runs-llm-falcon"], owner_id: S07AJBTLX2L}, #Model Falcon
+          { name: "t3k LLM mixtral model perf tests", model: "mixtral", model-type: "LLM", arch: wormhole_b0, cmd: run_t3000_mixtral_tests, timeout: 75, 
+            runs-on: ["arch-wormhole_b0", "config-t3000", "in-service", "runner-test", "bare-metal", "pipeline-perf"  ], owner_id: U03PUAKE719}, # Miguel Tairum
+          { name: "t3k LLM llama2 model perf tests", model: "llama2", model-type: "LLM", arch: wormhole_b0, cmd: run_t3000_llama2_70b_tests, timeout: 75, 
+            runs-on: ["arch-wormhole_b0", "config-t3000", "in-service", "runner-test", "bare-metal", "pipeline-perf"], owner_id: U03FJB5TM5Y}, #Colman Glagovich
+          { name: "t3k LLM falcon40b model perf tests", model: "falcon40b", model-type: "LLM", arch: wormhole_b0, cmd: run_t3000_falcon40b_tests, timeout: 75, 
+            runs-on: ["arch-wormhole_b0", "config-t3000", "in-service", "runner-test", "bare-metal", "pipeline-perf", "runs-llm-falcon"], owner_id: S07AJBTLX2L}, # Model Falcon
           #{ name: "t3k CNN model perf tests ", model-type: "CNN", arch: wormhole_b0, cmd: run_t3000_cnn_tests, timeout: 120, owner_id: }, #No tests are being run?
         ]
     name: ${{ matrix.test-group.name }}
@@ -30,7 +34,7 @@ jobs:
       LOGURU_LEVEL: INFO
       LD_LIBRARY_PATH: ${{ github.workspace }}/build/lib
     environment: dev
-    runs-on: [arch-wormhole_b0, "config-t3000", "in-service", "runner-test", "bare-metal", "pipeline-perf"]
+    runs-on: ${{ matrix.test-group.runs-on }}
     steps:
       - uses: tenstorrent-metal/metal-workflows/.github/actions/checkout-with-submodule-lfs@v2.0.0
       - name: Enable performance mode


### PR DESCRIPTION
### Ticket
Link to Github Issue
https://github.com/tenstorrent/tt-metal/issues/9792

### Problem description
Currently t3k pipelines are broken due to either broken tests or some ci runner quirks. 
Examples include a runner which can sometimes hang when running falcon model tests but works for other models.
(see linked github issue for relevant issues)

### What's changed
Since there are very few runners. This PR rebalanced which ci runners run which tests so that ci runners with quirks (such as f10cs08 crashing on falcon tests) do not run for those tests which can potentially cause ND hangs but run for others.
introduced new ci runner labels such as 't3k', 'runs-llm-falcon', 't7k' to assist with identifying which pipelines.

Tests which are currently broken across all tests are left unchanged.
These changes act as a stop-gap measure to let development progress while devs work on fixing tests or we can work on diagnosing ci runners at a later time.

PRs seem to get t3k model perf and freq tests passing

### Checklist
- [ ] Post commit CI passes
- [ ] Model regression CI testing passes (if applicable)
- [ ] New/Existing tests provide coverage for changes

https://github.com/tenstorrent/tt-metal/actions/runs/9705754827
https://github.com/tenstorrent/tt-metal/actions/runs/9719905737
