### PR TITLE
Migrate binary backward ops

### DIFF
--- a/docs/source/ttnn/ttnn/api.rst
+++ b/docs/source/ttnn/ttnn/api.rst
@@ -211,6 +211,7 @@ Pointwise Binary
    ttnn/binary_ne_bw
    ttnn/binary_ge_bw
    ttnn/min_bw
+   ttnn/max_bw
 
 Pointwise Ternary
 =================

--- a/docs/source/ttnn/ttnn/api.rst
+++ b/docs/source/ttnn/ttnn/api.rst
@@ -210,6 +210,7 @@ Pointwise Binary
    ttnn/binary_gt_bw
    ttnn/binary_ne_bw
    ttnn/binary_ge_bw
+   ttnn/min_bw
 
 Pointwise Ternary
 =================

--- a/docs/source/ttnn/ttnn/api.rst
+++ b/docs/source/ttnn/ttnn/api.rst
@@ -212,6 +212,7 @@ Pointwise Binary
    ttnn/binary_ge_bw
    ttnn/min_bw
    ttnn/max_bw
+   ttnn/div_bw
 
 Pointwise Ternary
 =================

--- a/docs/source/ttnn/ttnn/dependencies/tt_lib.rst
+++ b/docs/source/ttnn/ttnn/dependencies/tt_lib.rst
@@ -848,8 +848,6 @@ Backward Operations
 
 .. autofunction:: tt_lib.tensor.mul_bw
 
-.. autofunction:: tt_lib.tensor.max_bw
-
 .. autofunction:: tt_lib.tensor.tan_bw
 
 .. autofunction:: tt_lib.tensor.exp_bw

--- a/docs/source/ttnn/ttnn/dependencies/tt_lib.rst
+++ b/docs/source/ttnn/ttnn/dependencies/tt_lib.rst
@@ -840,8 +840,6 @@ Backward Operations
 
 .. autofunction:: tt_lib.tensor.unary_div_bw
 
-.. autofunction:: tt_lib.tensor.div_bw
-
 .. autofunction:: tt_lib.tensor.rdiv_bw
 
 .. autofunction:: tt_lib.tensor.sqrt_bw

--- a/docs/source/ttnn/ttnn/dependencies/tt_lib.rst
+++ b/docs/source/ttnn/ttnn/dependencies/tt_lib.rst
@@ -850,8 +850,6 @@ Backward Operations
 
 .. autofunction:: tt_lib.tensor.max_bw
 
-.. autofunction:: tt_lib.tensor.min_bw
-
 .. autofunction:: tt_lib.tensor.tan_bw
 
 .. autofunction:: tt_lib.tensor.exp_bw

--- a/docs/source/ttnn/ttnn/ttnn/div_bw.rst
+++ b/docs/source/ttnn/ttnn/ttnn/div_bw.rst
@@ -1,0 +1,6 @@
+.. _ttnn.div_bw:
+
+ttnn.div_bw
+###############
+
+.. autofunction:: ttnn.div_bw

--- a/docs/source/ttnn/ttnn/ttnn/max_bw.rst
+++ b/docs/source/ttnn/ttnn/ttnn/max_bw.rst
@@ -1,0 +1,6 @@
+.. _ttnn.max_bw:
+
+ttnn.max_bw
+###############
+
+.. autofunction:: ttnn.max_bw

--- a/docs/source/ttnn/ttnn/ttnn/min_bw.rst
+++ b/docs/source/ttnn/ttnn/ttnn/min_bw.rst
@@ -1,0 +1,6 @@
+.. _ttnn.min_bw:
+
+ttnn.min_bw
+###############
+
+.. autofunction:: ttnn.min_bw

--- a/tests/tt_eager/python_api_testing/unit_testing/backward_ops/test_backward_div.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/backward_ops/test_backward_div.py
@@ -4,7 +4,7 @@
 
 import torch
 import pytest
-import tt_lib
+import ttnn
 from tests.tt_eager.python_api_testing.unit_testing.backward_ops.utility_funcs import data_gen_with_range, compare_pcc
 
 
@@ -33,7 +33,7 @@ def test_bw_div(input_shapes, round_mode, device):
 
     if round_mode == None:
         round_mode = "None"
-    tt_output_tensor_on_device = tt_lib.tensor.div_bw(grad_tensor, input_tensor, other_tensor, round_mode=round_mode)
+    tt_output_tensor_on_device = ttnn.div_bw(grad_tensor, input_tensor, other_tensor, mode=round_mode)
 
     in_data.retain_grad()
     other_data.retain_grad()

--- a/tests/tt_eager/python_api_testing/unit_testing/backward_ops/test_backward_max.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/backward_ops/test_backward_max.py
@@ -4,7 +4,7 @@
 
 import torch
 import pytest
-import tt_lib
+import ttnn
 from tests.tt_eager.python_api_testing.unit_testing.backward_ops.utility_funcs import data_gen_with_range, compare_pcc
 
 
@@ -21,7 +21,7 @@ def test_bw_max(input_shapes, device):
     other_data, other_tensor = data_gen_with_range(input_shapes, 1, 2, device, True)
     grad_data, grad_tensor = data_gen_with_range(input_shapes, -10, -1, device, True)
 
-    tt_output_tensor_on_device = tt_lib.tensor.max_bw(grad_tensor, input_tensor, other_tensor)
+    tt_output_tensor_on_device = ttnn.max_bw(grad_tensor, input_tensor, other_tensor)
 
     in_data.retain_grad()
     other_data.retain_grad()

--- a/tests/tt_eager/python_api_testing/unit_testing/backward_ops/test_backward_min.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/backward_ops/test_backward_min.py
@@ -4,7 +4,7 @@
 
 import torch
 import pytest
-import tt_lib
+import ttnn
 from tests.tt_eager.python_api_testing.unit_testing.backward_ops.utility_funcs import data_gen_with_range, compare_pcc
 
 
@@ -21,7 +21,7 @@ def test_bw_min(input_shapes, device):
     other_data, other_tensor = data_gen_with_range(input_shapes, 1, 2, device, True)
     grad_data, grad_tensor = data_gen_with_range(input_shapes, -10, -1, device, True)
 
-    tt_output_tensor_on_device = tt_lib.tensor.min_bw(grad_tensor, input_tensor, other_tensor)
+    tt_output_tensor_on_device = ttnn.min_bw(grad_tensor, input_tensor, other_tensor)
 
     in_data.retain_grad()
     other_data.retain_grad()

--- a/tests/ttnn/unit_tests/operations/test_backward.py
+++ b/tests/ttnn/unit_tests/operations/test_backward.py
@@ -157,3 +157,12 @@ def test_logaddexp2(device, h, w, in_val, grad_val, other_val):
 def test_squared_difference(device, h, w, in_val, grad_val, other_val):
     torch_squared_diff = lambda x, y: torch.square(torch.sub(x, y))
     run_backward_binary_test(device, h, w, in_val, grad_val, other_val, ttnn.squared_difference_bw, torch_squared_diff)
+
+
+@pytest.mark.parametrize("h", [64])
+@pytest.mark.parametrize("w", [128])
+@pytest.mark.parametrize("in_val", [-1, 1])
+@pytest.mark.parametrize("grad_val", [-1, 0, 1])
+@pytest.mark.parametrize("other_val", [-1, 1])
+def test_min(device, h, w, in_val, grad_val, other_val):
+    run_backward_binary_test(device, h, w, in_val, grad_val, other_val, ttnn.min_bw, torch.min)

--- a/tests/ttnn/unit_tests/operations/test_backward.py
+++ b/tests/ttnn/unit_tests/operations/test_backward.py
@@ -166,3 +166,12 @@ def test_squared_difference(device, h, w, in_val, grad_val, other_val):
 @pytest.mark.parametrize("other_val", [-1, 1])
 def test_min(device, h, w, in_val, grad_val, other_val):
     run_backward_binary_test(device, h, w, in_val, grad_val, other_val, ttnn.min_bw, torch.min)
+
+
+@pytest.mark.parametrize("h", [64])
+@pytest.mark.parametrize("w", [128])
+@pytest.mark.parametrize("in_val", [-1, 1])
+@pytest.mark.parametrize("grad_val", [-1, 0, 1])
+@pytest.mark.parametrize("other_val", [-1, 1])
+def test_max(device, h, w, in_val, grad_val, other_val):
+    run_backward_binary_test(device, h, w, in_val, grad_val, other_val, ttnn.max_bw, torch.max)

--- a/tt_eager/tt_dnn/op_library/backward/backward_ops.cpp
+++ b/tt_eager/tt_dnn/op_library/backward/backward_ops.cpp
@@ -557,11 +557,6 @@ std::vector<Tensor> max_bw(
     return operation::decorate_as_composite(__func__, _max_bw)(grad, input, other, output_mem_config);
 }
 
-std::vector<Tensor> min_bw(
-    const Tensor& grad, const Tensor& input, const Tensor& other, const MemoryConfig& output_mem_config) {
-    return operation::decorate_as_composite(__func__, _min_bw)(grad, input, other, output_mem_config);
-}
-
 std::vector<Tensor> _fill_zero_bw(const Tensor& grad, const MemoryConfig& output_mem_config) {
     std::vector<Tensor> grad_tensor;
     Tensor result = zeros_like(grad, output_mem_config);

--- a/tt_eager/tt_dnn/op_library/backward/backward_ops.cpp
+++ b/tt_eager/tt_dnn/op_library/backward/backward_ops.cpp
@@ -258,67 +258,6 @@ std::vector<Tensor> unary_div_bw(
         grad, input, scalar, round_mode, output_mem_config);
 }
 
-std::vector<Tensor> _div_bw(
-    const Tensor& grad,
-    const Tensor& input,
-    const Tensor& other,
-    string round_mode,
-    const MemoryConfig& output_mem_config) {
-    std::vector<Tensor> grad_tensor;
-    if (round_mode == "None") {
-        Tensor grad_a = ttnn::multiply(grad, recip(other, output_mem_config), std::nullopt, output_mem_config);
-        Tensor t_inf = full_like(input, std::numeric_limits<float>::infinity(), output_mem_config);
-        Tensor t_nan = full_like(input, std::nanf(""), output_mem_config);
-        grad_tensor.emplace_back(where(
-            eqz(other, output_mem_config),
-            where(
-                eqz(grad, output_mem_config),
-                t_nan,
-                ttnn::multiply(t_inf, sign(grad, output_mem_config), std::nullopt, output_mem_config),
-                output_mem_config),
-            grad_a,
-            output_mem_config));
-        Tensor grad_b = ttnn::multiply(
-            neg(grad, output_mem_config),
-            (ttnn::multiply(input, recip(ttnn::square(other, output_mem_config), output_mem_config), std::nullopt, output_mem_config)),
-            std::nullopt,
-            output_mem_config);
-        grad_tensor.emplace_back(where(
-            eqz(other, output_mem_config),
-            where(
-                eqz(grad, output_mem_config),
-                t_nan,
-                where(
-                    eqz(input, output_mem_config),
-                    t_nan,
-                    ttnn::multiply(ttnn::multiply(neg(t_inf, output_mem_config),
-                            sign(input, output_mem_config),
-                            std::nullopt,
-                            output_mem_config),
-                        sign(grad, output_mem_config),
-                        std::nullopt,
-                        output_mem_config),
-                    output_mem_config),
-                output_mem_config),
-            grad_b,
-            output_mem_config));
-    } else {
-        Tensor grad_a = zeros_like(grad, output_mem_config);
-        grad_tensor.emplace_back(grad_a);
-        Tensor grad_b = zeros_like(grad, output_mem_config);
-        grad_tensor.emplace_back(grad_b);
-    }
-
-    return grad_tensor;
-}
-std::vector<Tensor> div_bw(
-    const Tensor& grad,
-    const Tensor& input,
-    const Tensor& other,
-    string round_mode,
-    const MemoryConfig& output_mem_config) {
-    return operation::decorate_as_composite(__func__, _div_bw)(grad, input, other, round_mode, output_mem_config);
-}
 
 std::vector<Tensor> _rdiv_bw(
     const Tensor& grad, const Tensor& input, float scalar, string round_mode, const MemoryConfig& output_mem_config) {

--- a/tt_eager/tt_dnn/op_library/backward/backward_ops.hpp
+++ b/tt_eager/tt_dnn/op_library/backward/backward_ops.hpp
@@ -110,12 +110,6 @@ std::vector<Tensor> max_bw(
     const Tensor& other,
     const MemoryConfig& output_mem_config = operation::DEFAULT_OUTPUT_MEMORY_CONFIG);
 
-std::vector<Tensor> min_bw(
-    const Tensor& grad,
-    const Tensor& input,
-    const Tensor& other,
-    const MemoryConfig& output_mem_config = operation::DEFAULT_OUTPUT_MEMORY_CONFIG);
-
 // bw = grad(1 - tanh(x) ** 2)
 std::vector<Tensor> tanh_bw(
     const Tensor& grad,

--- a/tt_eager/tt_dnn/op_library/backward/backward_ops.hpp
+++ b/tt_eager/tt_dnn/op_library/backward/backward_ops.hpp
@@ -90,13 +90,6 @@ std::vector<Tensor> unary_div_bw(
     string round_mode,
     const MemoryConfig& output_mem_config = operation::DEFAULT_OUTPUT_MEMORY_CONFIG);
 
-std::vector<Tensor> div_bw(
-    const Tensor& grad,
-    const Tensor& input,
-    const Tensor& other,
-    string round_mode,
-    const MemoryConfig& output_mem_config = operation::DEFAULT_OUTPUT_MEMORY_CONFIG);
-
 std::vector<Tensor> rdiv_bw(
     const Tensor& grad,
     const Tensor& input,

--- a/tt_eager/tt_dnn/op_library/backward/backward_ops.hpp
+++ b/tt_eager/tt_dnn/op_library/backward/backward_ops.hpp
@@ -104,12 +104,6 @@ std::vector<Tensor> rdiv_bw(
     string round_mode,
     const MemoryConfig& output_mem_config = operation::DEFAULT_OUTPUT_MEMORY_CONFIG);
 
-std::vector<Tensor> max_bw(
-    const Tensor& grad,
-    const Tensor& input,
-    const Tensor& other,
-    const MemoryConfig& output_mem_config = operation::DEFAULT_OUTPUT_MEMORY_CONFIG);
-
 // bw = grad(1 - tanh(x) ** 2)
 std::vector<Tensor> tanh_bw(
     const Tensor& grad,

--- a/tt_eager/tt_lib/csrc/tt_lib_bindings_tensor_backward_ops.cpp
+++ b/tt_eager/tt_lib/csrc/tt_lib_bindings_tensor_backward_ops.cpp
@@ -370,23 +370,6 @@ namespace tt::tt_metal::detail{
         )doc");
 
 
-    m_tensor.def("max_bw", &tt::tt_metal::max_bw,
-            py::arg("grad").noconvert(), py::arg("input_a").noconvert(), py::arg("input_b").noconvert(), py::arg("output_mem_config").noconvert() = operation::DEFAULT_OUTPUT_MEMORY_CONFIG, R"doc(
-            Performs backward operations for maximum of ``input_b`` with given ``grad``.
-
-            Input tensor must have BFLOAT16 data type.
-
-            Output tensors will have BFLOAT16 data type.
-
-            .. csv-table::
-                :header: "Argument", "Description", "Data type", "Valid range", "Required"
-
-                "grad", "Gradient tensor", "Tensor", "Tensor of shape [W, Z, Y, X]", "Yes"
-                "input_a", "Tensor max is applied to", "Tensor", "Tensor of shape [W, Z, Y, X]", "Yes"
-                "input_b", "Tensor", "Tensor", "Tensor of shape [W, Z, Y, X]", "Yes"
-                "output_mem_config", "Layout of tensor in TT Accelerator device memory banks", "MemoryConfig", "Default is interleaved in DRAM", "No"
-        )doc");
-
     m_tensor.def("where_bw",
         [](const Tensor& grad,
            const Tensor& condition,

--- a/tt_eager/tt_lib/csrc/tt_lib_bindings_tensor_backward_ops.cpp
+++ b/tt_eager/tt_lib/csrc/tt_lib_bindings_tensor_backward_ops.cpp
@@ -369,22 +369,6 @@ namespace tt::tt_metal::detail{
                 "output_mem_config", "Layout of tensor in TT Accelerator device memory banks", "MemoryConfig", "Default is interleaved in DRAM", "No"
         )doc");
 
-    m_tensor.def("min_bw", &tt::tt_metal::min_bw,
-            py::arg("grad").noconvert(), py::arg("input_a").noconvert(), py::arg("input_b").noconvert(), py::arg("output_mem_config").noconvert() = operation::DEFAULT_OUTPUT_MEMORY_CONFIG, R"doc(
-            Performs backward operations for minimum of ``input_b`` with given ``grad``.
-
-            Input tensor must have BFLOAT16 data type.
-
-            Output tensors will have BFLOAT16 data type.
-
-            .. csv-table::
-                :header: "Argument", "Description", "Data type", "Valid range", "Required"
-
-                "grad", "Gradient tensor", "Tensor", "Tensor of shape [W, Z, Y, X]", "Yes"
-                "input_a", "Tensor min is applied to", "Tensor", "Tensor of shape [W, Z, Y, X]", "Yes"
-                "input_b", "Tensor", "Tensor", "Tensor of shape [W, Z, Y, X]", "Yes"
-                "output_mem_config", "Layout of tensor in TT Accelerator device memory banks", "MemoryConfig", "Default is interleaved in DRAM", "No"
-        )doc");
 
     m_tensor.def("max_bw", &tt::tt_metal::max_bw,
             py::arg("grad").noconvert(), py::arg("input_a").noconvert(), py::arg("input_b").noconvert(), py::arg("output_mem_config").noconvert() = operation::DEFAULT_OUTPUT_MEMORY_CONFIG, R"doc(

--- a/tt_eager/tt_lib/csrc/tt_lib_bindings_tensor_backward_ops.cpp
+++ b/tt_eager/tt_lib/csrc/tt_lib_bindings_tensor_backward_ops.cpp
@@ -335,22 +335,6 @@ namespace tt::tt_metal::detail{
                 "output_mem_config", "Layout of tensor in TT Accelerator device memory banks", "MemoryConfig", "Default is interleaved in DRAM", "No"
         )doc");
 
-    m_tensor.def("div_bw", &tt::tt_metal::div_bw,
-            py::arg("grad").noconvert(), py::arg("input_a").noconvert(), py::arg("input_b").noconvert(), py::arg("round_mode") = "None", py::arg("output_mem_config").noconvert() = operation::DEFAULT_OUTPUT_MEMORY_CONFIG, R"doc(
-            Performs backward operations for division of ``input_b`` with given ``grad``.
-
-            Input tensor must have BFLOAT16 data type.
-
-            Output tensors will have BFLOAT16 data type.
-
-            .. csv-table::
-                :header: "Argument", "Description", "Data type", "Valid range", "Required"
-
-                "grad", "Gradient tensor", "Tensor", "Tensor of shape [W, Z, Y, X]", "Yes"
-                "input_a", "Tensor div is applied to", "Tensor", "Tensor of shape [W, Z, Y, X]", "Yes"
-                "input_b", "Tensor", "Tensor", "Tensor of shape [W, Z, Y, X]", "Yes"
-                "output_mem_config", "Layout of tensor in TT Accelerator device memory banks", "MemoryConfig", "Default is interleaved in DRAM", "No"
-        )doc");
 
     m_tensor.def("rdiv_bw", &tt::tt_metal::rdiv_bw,
             py::arg("grad").noconvert(), py::arg("input").noconvert(), py::arg("scalar") = 1.0f, py::arg("round_mode") = "None", py::arg("output_mem_config").noconvert() = operation::DEFAULT_OUTPUT_MEMORY_CONFIG, R"doc(

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_backward/binary_backward.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_backward/binary_backward.hpp
@@ -208,6 +208,7 @@ constexpr auto bias_gelu_bw = ttnn::register_operation<operations::binary_backwa
 constexpr auto binary_gt_bw = ttnn::register_operation<operations::binary_backward::ExecuteBinaryBackward<operations::binary_backward::BinaryBackwardOpType::BINARY_GT_BW>>("ttnn::binary_gt_bw");
 constexpr auto binary_ne_bw = ttnn::register_operation<operations::binary_backward::ExecuteBinaryBackward<operations::binary_backward::BinaryBackwardOpType::BINARY_NE_BW>>("ttnn::binary_ne_bw");
 constexpr auto binary_ge_bw = ttnn::register_operation<operations::binary_backward::ExecuteBinaryBackward<operations::binary_backward::BinaryBackwardOpType::BINARY_GE_BW>>("ttnn::binary_ge_bw");
+constexpr auto min_bw = ttnn::register_operation<operations::binary_backward::ExecuteBinaryBackward<operations::binary_backward::BinaryBackwardOpType::MIN_BW>>("ttnn::min_bw");
 
 //type 2
 constexpr auto addalpha_bw = ttnn::register_operation<operations::binary_backward::ExecuteBinaryBackward<operations::binary_backward::BinaryBackwardOpType::ADDALPHA_BW>>("ttnn::addalpha_bw");

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_backward/binary_backward.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_backward/binary_backward.hpp
@@ -210,6 +210,7 @@ constexpr auto binary_ne_bw = ttnn::register_operation<operations::binary_backwa
 constexpr auto binary_ge_bw = ttnn::register_operation<operations::binary_backward::ExecuteBinaryBackward<operations::binary_backward::BinaryBackwardOpType::BINARY_GE_BW>>("ttnn::binary_ge_bw");
 constexpr auto min_bw = ttnn::register_operation<operations::binary_backward::ExecuteBinaryBackward<operations::binary_backward::BinaryBackwardOpType::MIN_BW>>("ttnn::min_bw");
 constexpr auto max_bw = ttnn::register_operation<operations::binary_backward::ExecuteBinaryBackward<operations::binary_backward::BinaryBackwardOpType::MAX_BW>>("ttnn::max_bw");
+constexpr auto div_bw = ttnn::register_operation<operations::binary_backward::ExecuteBinaryBackward<operations::binary_backward::BinaryBackwardOpType::DIV_BW>>("ttnn::div_bw");
 
 //type 2
 constexpr auto addalpha_bw = ttnn::register_operation<operations::binary_backward::ExecuteBinaryBackward<operations::binary_backward::BinaryBackwardOpType::ADDALPHA_BW>>("ttnn::addalpha_bw");

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_backward/binary_backward.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_backward/binary_backward.hpp
@@ -209,6 +209,7 @@ constexpr auto binary_gt_bw = ttnn::register_operation<operations::binary_backwa
 constexpr auto binary_ne_bw = ttnn::register_operation<operations::binary_backward::ExecuteBinaryBackward<operations::binary_backward::BinaryBackwardOpType::BINARY_NE_BW>>("ttnn::binary_ne_bw");
 constexpr auto binary_ge_bw = ttnn::register_operation<operations::binary_backward::ExecuteBinaryBackward<operations::binary_backward::BinaryBackwardOpType::BINARY_GE_BW>>("ttnn::binary_ge_bw");
 constexpr auto min_bw = ttnn::register_operation<operations::binary_backward::ExecuteBinaryBackward<operations::binary_backward::BinaryBackwardOpType::MIN_BW>>("ttnn::min_bw");
+constexpr auto max_bw = ttnn::register_operation<operations::binary_backward::ExecuteBinaryBackward<operations::binary_backward::BinaryBackwardOpType::MAX_BW>>("ttnn::max_bw");
 
 //type 2
 constexpr auto addalpha_bw = ttnn::register_operation<operations::binary_backward::ExecuteBinaryBackward<operations::binary_backward::BinaryBackwardOpType::ADDALPHA_BW>>("ttnn::addalpha_bw");

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_backward/binary_backward_pybind.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_backward/binary_backward_pybind.hpp
@@ -87,14 +87,14 @@ Example:
                const ttnn::Tensor& grad_tensor,
                const ttnn::Tensor& input_tensor_a,
                const ttnn::Tensor& input_tensor_b,
-               const string value,
+               const string mode,
                const std::optional<ttnn::MemoryConfig>& memory_config) -> std::vector<ttnn::Tensor> {
-                return self(grad_tensor, input_tensor_a, value, input_tensor_b, memory_config);
+                return self(grad_tensor, input_tensor_a, mode, input_tensor_b, memory_config);
             },
             py::arg("grad_tensor"),
             py::arg("input_tensor_a"),
             py::arg("input_tensor_b"),
-            py::arg("value"),
+            py::arg("mode"),
             py::kw_only(),
             py::arg("memory_config") = std::nullopt},
 
@@ -311,6 +311,11 @@ void py_module(py::module& module) {
         module,
         ttnn::max_bw,
         R"doc(Performs backward operations for maximum of :attr:`input_tensor_a` and :attr:`input_tensor_b` with given :attr:`grad_tensor`.)doc");
+
+    detail::bind_binary_backward(
+        module,
+        ttnn::div_bw,
+        R"doc(Performs backward operations for divide of :attr:`input_tensor_a` and :attr:`input_tensor_b` with given :attr:`grad_tensor`.)doc");
 
 }
 

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_backward/binary_backward_pybind.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_backward/binary_backward_pybind.hpp
@@ -307,6 +307,11 @@ void py_module(py::module& module) {
         ttnn::min_bw,
         R"doc(Performs backward operations for minimum of :attr:`input_tensor_a` and :attr:`input_tensor_b` with given :attr:`grad_tensor`.)doc");
 
+    detail::bind_binary_backward(
+        module,
+        ttnn::max_bw,
+        R"doc(Performs backward operations for maximum of :attr:`input_tensor_a` and :attr:`input_tensor_b` with given :attr:`grad_tensor`.)doc");
+
 }
 
 }  // namespace binary_backward

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_backward/binary_backward_pybind.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_backward/binary_backward_pybind.hpp
@@ -302,6 +302,11 @@ void py_module(py::module& module) {
         R"doc(Performs backward operations for greater than or equal to comparison on :attr:`input_tensor_a` , attr:`input_tensor_b` with given attr:`grad_tensor`.
         Returns an tensor of zeros like :attr:`input_tensor_a` and :attr:`input_tensor_b` tensor.)doc");
 
+    detail::bind_binary_backward(
+        module,
+        ttnn::min_bw,
+        R"doc(Performs backward operations for minimum of :attr:`input_tensor_a` and :attr:`input_tensor_b` with given :attr:`grad_tensor`.)doc");
+
 }
 
 }  // namespace binary_backward

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_backward/device/binary_backward_op.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_backward/device/binary_backward_op.cpp
@@ -514,6 +514,8 @@ std::function<std::vector<ttnn::Tensor>(const Tensor&, const Tensor&, const Tens
             return _binary_ge_bw;
         case BinaryBackwardOpType::MIN_BW:
             return _min_or_max_bw<false>;
+        case BinaryBackwardOpType::MAX_BW:
+            return _min_or_max_bw<true>;
         default:
             TT_ASSERT(false && "Undefined op type");
             return 0;

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_backward/device/binary_backward_op.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_backward/device/binary_backward_op.hpp
@@ -33,7 +33,8 @@ enum class BinaryBackwardOpType {
     BIAS_GELU_BW,
     BINARY_GT_BW,
     BINARY_NE_BW,
-    BINARY_GE_BW
+    BINARY_GE_BW,
+    MIN_BW,
 };
 
 

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_backward/device/binary_backward_op.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_backward/device/binary_backward_op.hpp
@@ -36,6 +36,7 @@ enum class BinaryBackwardOpType {
     BINARY_GE_BW,
     MIN_BW,
     MAX_BW,
+    DIV_BW,
 };
 
 

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_backward/device/binary_backward_op.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_backward/device/binary_backward_op.hpp
@@ -35,6 +35,7 @@ enum class BinaryBackwardOpType {
     BINARY_NE_BW,
     BINARY_GE_BW,
     MIN_BW,
+    MAX_BW,
 };
 
 

--- a/ttnn/ttnn/__init__.py
+++ b/ttnn/ttnn/__init__.py
@@ -476,6 +476,7 @@ from ttnn.operations.binary_backward import (
     binary_ne_bw,
     binary_ge_bw,
     min_bw,
+    max_bw,
 )
 
 from ttnn.operations.ternary import (

--- a/ttnn/ttnn/__init__.py
+++ b/ttnn/ttnn/__init__.py
@@ -475,6 +475,7 @@ from ttnn.operations.binary_backward import (
     binary_gt_bw,
     binary_ne_bw,
     binary_ge_bw,
+    min_bw,
 )
 
 from ttnn.operations.ternary import (

--- a/ttnn/ttnn/__init__.py
+++ b/ttnn/ttnn/__init__.py
@@ -477,6 +477,7 @@ from ttnn.operations.binary_backward import (
     binary_ge_bw,
     min_bw,
     max_bw,
+    div_bw,
 )
 
 from ttnn.operations.ternary import (

--- a/ttnn/ttnn/operations/binary_backward.py
+++ b/ttnn/ttnn/operations/binary_backward.py
@@ -218,4 +218,10 @@ binary_ge_bw = ttnn.register_operation(
     )
 )(ttnn._ttnn.operations.binary_backward.binary_ge_bw)
 
+min_bw = ttnn.register_operation(
+    golden_function=lambda grad, a, b, *args, **kwargs: _golden_function_backward(
+        torch.min, grad, a, b, *args, **kwargs
+    )
+)(ttnn._ttnn.operations.binary_backward.min_bw)
+
 __all__ = []

--- a/ttnn/ttnn/operations/binary_backward.py
+++ b/ttnn/ttnn/operations/binary_backward.py
@@ -85,7 +85,11 @@ def _golden_function_backward_with_string(
         pyt_y.backward(gradient=grad_tensor)
         golden_tensor = [sum_result.grad, sum_result.grad]
         return golden_tensor
-    pyt_y = torch_op(input_tensor_a, input_tensor_b, value=value)
+
+    if torch_op == torch.div:
+        pyt_y = torch_op(input_tensor_a, input_tensor_b, rounding_mode=value)
+    else:
+        pyt_y = torch_op(input_tensor_a, input_tensor_b, value=value)
     input_tensor_a.retain_grad()
     input_tensor_b.retain_grad()
     pyt_y.backward(gradient=grad_tensor)
@@ -229,5 +233,11 @@ max_bw = ttnn.register_operation(
         torch.max, grad, a, b, *args, **kwargs
     )
 )(ttnn._ttnn.operations.binary_backward.max_bw)
+
+div_bw = ttnn.register_operation(
+    golden_function=lambda grad, a, b, *args, **kwargs: _golden_function_backward_with_string(
+        torch.div, grad, a, b, *args, **kwargs
+    )
+)(ttnn._ttnn.operations.binary_backward.div_bw)
 
 __all__ = []

--- a/ttnn/ttnn/operations/binary_backward.py
+++ b/ttnn/ttnn/operations/binary_backward.py
@@ -224,4 +224,10 @@ min_bw = ttnn.register_operation(
     )
 )(ttnn._ttnn.operations.binary_backward.min_bw)
 
+max_bw = ttnn.register_operation(
+    golden_function=lambda grad, a, b, *args, **kwargs: _golden_function_backward(
+        torch.max, grad, a, b, *args, **kwargs
+    )
+)(ttnn._ttnn.operations.binary_backward.max_bw)
+
 __all__ = []


### PR DESCRIPTION
### Ticket
#9628 
### Problem description
Move binary backward ops to ttnn folder, updated following ops
- min
- max
- div

### What's changed
```
ttnn
└── cpp
    └── ttnn
        └── operations
            └── ...
            └── eltwise
                └── binary
                └── binary_backward
                    ├── device
                    │   ├── binary_backward_op.cpp
                    │   ├── binary_backward_op.hpp
                    ├── binary_backward.hpp
                    └── binary_backward_pybind.hpp
```

### Checklist
- [ ] Post commit CI passes
- [ ] Model regression CI testing passes (if applicable)
- [ ] New/Existing tests provide coverage for changes
