### PR TITLE
#0: Add back record_event for enqueue_trace, since its breaking all-gather

### DIFF
--- a/tt_metal/impl/dispatch/command_queue.cpp
+++ b/tt_metal/impl/dispatch/command_queue.cpp
@@ -1917,6 +1917,9 @@ void HWCommandQueue::enqueue_trace(const uint32_t trace_id, bool blocking) {
 
     if (blocking) {
         this->finish();
+    } else {
+        std::shared_ptr<Event> event = std::make_shared<Event>();
+        this->enqueue_record_event(event);
     }
 }
 


### PR DESCRIPTION


### Ticket
Link to Github Issue

### Problem description
Recent optimizations to cq txns (specifically removing record_event for trace) broke trace tests using all-gather. The issue seems to be an issue/potential race with ethernet core handshakes/initialization at the start of the `erisc_data_mover` kernel.

Until the issue is debugged, removing this optmization.

### What's changed
Describe the approach used to solve the problem.
Summarize the changes made and its impact.

### Checklist
- [ ] Post commit CI passes
- [ ] Model regression CI testing passes (if applicable)
- [ ] New/Existing tests provide coverage for changes
