### PR TITLE
#9275: Fix Falcon7b demo failing to run by default on an Grayskull e75

### DIFF
--- a/models/demos/ttnn_falcon7b/tt/falcon_attention.py
+++ b/models/demos/ttnn_falcon7b/tt/falcon_attention.py
@@ -172,7 +172,9 @@ class TtFalconAttention:
                 attn_weights = ttnn.experimental.operations.primary.transformers.group_attn_matmul(
                     query_layer,
                     key_layer_transposed,
-                    compute_with_storage_grid_size=ttnn.experimental.tensor.CoreCoord(12, 9),
+                    compute_with_storage_grid_size=ttnn.experimental.tensor.CoreCoord(
+                        self.core_grid.x, self.core_grid.y
+                    ),
                     output_mem_config=self.model_config["PRE_SOFTMAX_MM_OUTPUT_MEMCFG"],
                     output_dtype=self.model_config["PRE_SOFTMAX_MM_OUTPUT_DTYPE"],  # Must be BFLOAT16
                 )
@@ -237,7 +239,9 @@ class TtFalconAttention:
                 attn_output = ttnn.experimental.operations.primary.transformers.group_attn_matmul(
                     attn_weights,
                     value_layer,
-                    compute_with_storage_grid_size=ttnn.experimental.tensor.CoreCoord(12, 9),
+                    compute_with_storage_grid_size=ttnn.experimental.tensor.CoreCoord(
+                        self.core_grid.x, self.core_grid.y
+                    ),
                     output_mem_config=self.model_config["POST_SOFTMAX_MM_OUTPUT_MEMCFG"],
                     output_dtype=self.model_config["POST_SOFTMAX_MM_OUTPUT_DTYPE"],  # Must be BFLOAT16
                 )


### PR DESCRIPTION
### Ticket
#9275 

### Problem description

I was revisiting the Falcon7b example as I noticed tt-firmware 80.9. I was trying against benchmarks I tried in the past. And decided to upstream the falcon change needed to get it running on an e75, since I'm already at it.

I am not sure if it runs on an e150. Let me know if it doesn't an I'll fix it.

### What's changed

Use the device's core grid size instead of the hard coded 12x9 on Grayskull.

### Checklist
- [x] Post commit CI passes
