### PR TITLE
Add Mixtral accuracy tests and cleanup its other tests (CI-friendly)

### DIFF
--- a/models/demos/t3000/mixtral8x7b/demo/demo.py
+++ b/models/demos/t3000/mixtral8x7b/demo/demo.py
@@ -266,7 +266,7 @@ def run_mixtral_demo(user_input, batch_size, device_mesh, instruct_mode):
 
 
 # Avoid running this test when in CI
-@pytest.mark.skipif(os.getenv("CI") == "True", reason="Non-CI tests")
+@pytest.mark.skipif(os.getenv("CI") == "true", reason="Non-CI tests")
 @pytest.mark.parametrize(
     "input_prompts, instruct_weights",
     [
@@ -282,7 +282,7 @@ def test_mixtral8x7b_demo(t3k_device_mesh, use_program_cache, input_prompts, ins
 
 
 # CI only runs general-weights demo
-@pytest.mark.skipif(os.getenv("CI") == "False", reason="CI-only test")
+@pytest.mark.skipif(not os.getenv("CI") == "true", reason="CI-only test")
 @pytest.mark.parametrize(
     "input_prompts, instruct_weights",
     [

--- a/models/demos/t3000/mixtral8x7b/demo/expected_outputs.json
+++ b/models/demos/t3000/mixtral8x7b/demo/expected_outputs.json
@@ -1,0 +1,195 @@
+
+[
+    {
+    "output_general": "This is a test.\n\nThis is a test of the emergency blogging system.\n\nThis is a test of the emergency blogging system.\n\nThis is a test of the emergency blogging system.\n\nThis is a"
+    },
+    {
+    "output_general": "It was the best of times, it was the worst of times, it was the age of wisdom, it was the age of foolishness, it was the epoch of belief, it was the epoch of incredulity, it was the season"
+    },
+    {
+    "output_general": "Run to the hills, run for your lives!\n\nThe end of the world is nigh!\n\nThe sky is falling!\n\nThe sky is falling!\n\nThe sky is falling!\n\nThe sky is falling!"
+    },
+    {
+    "output_general": "You've got another thing coming if you think you're going to get a good night's sleep in the new 2019 Chevrolet Silverado.\n\nThe 2019 Chevrolet"
+    },
+    {
+    "output_general": "The meaning of life is to find your gift. The purpose of life is to give it away.\n\nPablo Picasso\n\n## About Us\n\n#### Our Mission\n\nOur mission is to provide a safe and nurturing"
+    },
+    {
+    "output_general": "write a short poem about London in English and in your own language.\n\nI’m studying and need help with a English question to help me learn.\n\nWrite a short poem about London in English and in your own language.\n"
+    },
+    {
+    "output_general": "How to tie your shoes.\n\nHow to ride a bike.\n\nHow to drive a car.\n\nHow to make a bed.\n\nHow to make a bed.\n\nHow to make a bed.\n\nHow"
+    },
+    {
+    "output_general": "Give me the address of the closest bakery and I’ll be there in a heartbeat. I’m a sucker for freshly baked bread, especially when it’s still warm and crusty.\n\nI"
+    },
+    {
+    "output_general": "In a world far far away, there was a land called the United States of America. In this land, there was a state called California. In this state, there was a city called San Francisco. In this city, there was a neighborhood"
+    },
+    {
+    "output_general": "A poem about trees and nature:\n\nThe trees are my friends,\n\nThey are always there for me,\n\nThey are always there for you,\n\nThey are always there for everyone,\n\nThey are always there for"
+    },
+    {
+    "output_general": "Egg fried rice is a delicacy that is enjoyed by many people around the world. It is a simple dish that is easy to make and can be enjoyed as a main course or as a side dish. The dish is made by"
+    },
+    {
+    "output_general": "This is another test of the new WordPress editor.\n\nI’m not sure if I like it or not.\n\nI’m not sure if I like it or not.\n\nI’m not sure if I like it"
+    },
+    {
+    "output_general": "This is yet another testament to the fact that the world is a small place.\n\nI was born and raised in the Philippines, and I’ve been living in the US for the past 10 years. I’ve been"
+    },
+    {
+    "output_general": "Large language models are all the rage these days. They’re being used to generate text, translate languages, and even write code. But what are they, and how do they work? In this blog post, we’ll take a look"
+    },
+    {
+    "output_general": "The capital of Portugal, Lisbon is a city that has been on my bucket list for a long time. I’ve heard so many good things about it and I was so excited to finally visit it.\n\nWe arrived in Lisbon"
+    },
+    {
+    "output_general": "The word 'dog' in French is 'chien'.\n\n# French 1 - Animals\n\nThis French 1 quiz takes a look at animals. Animals are a great way to learn a language. They are easy"
+    },
+    {
+    "output_general": "Water is essential for life. It is also essential for the production of food and energy. But water is not always available where it is needed.\n\nThe world’s population is growing, and so is the demand for water. At the"
+    },
+    {
+    "output_general": "My favorite hobby is videogames. I’ve been playing them since I was a kid. I’ve played a lot of different games, but I’ve always been a fan of the first-person shooter genre. I"
+    },
+    {
+    "output_general": "The best way to cook a steak is to cook it on a grill. The best way to cook a steak on a grill is to cook it on a grill that is hot enough to cook it. The best way to"
+    },
+    {
+    "output_general": "Top 10 things to do in the Lake District\n\nThe Lake District is a beautiful part of the world and is a great place to visit for a holiday. There are so many things to do and see that it can be hard to"
+    },
+    {
+    "output_general": "The job of a computer architect is to design and build computers. They are responsible for the design of the hardware and software that make up a computer system. They also work with other engineers to create new technologies and improve existing ones.\n\nComput"
+    },
+    {
+    "output_general": "The number you have dialled is not available. Please try again later.\n\nI’m not sure if it’s the same for you, but I’ve been getting a lot of these lately.\n\nI’m not"
+    },
+    {
+    "output_general": "The best way to learn a new language is to immerse yourself in it. That’s why we’ve created a list of the best language learning apps for Android and iOS. These apps will help you learn a new language quickly and easily"
+    },
+    {
+    "output_general": "Madrid is the capital of Spain and the largest city in the country. It is also the third largest city in the European Union, after London and Berlin. Madrid is located on the Manzanares River in the center of the country. The"
+    },
+    {
+    "output_general": "A good night's sleep is essential for our health and well-being. It helps us to recharge our batteries and to be ready for the day ahead. But what happens when we don't get enough sleep?\n\nSleep"
+    },
+    {
+    "output_general": "Typing prompts can be fun, but they can also be a bit of a pain. If you’re looking for a way to get rid of them, you’ve come to the right place. In this article, we’ll"
+    },
+    {
+    "output_general": "I'm going to the store to buy a new car. I'm going to the store to buy a new car. I'm going to the store to buy a new car. I'm going to the store to buy a"
+    },
+    {
+    "output_general": "I am a world renown spy. I have been on many missions and have been to many places. I have been to the moon and back. I have been to the bottom of the ocean and back. I have been to the top of the"
+    },
+    {
+    "output_general": "Ready, set, go!\n\nThe 2018 Winter Olympics are officially underway in Pyeongchang, South Korea, and the opening ceremony was a sight to behold.\n\nThe ceremony kicked off with"
+    },
+    {
+    "output_general": "Climate change is the most important issue of our time. It is a global problem that requires a global solution. The United States has a responsibility to lead the way in addressing this issue.\n\nThe United States has a long history of leading"
+    },
+    {
+    "output_general": "Tell me the story of the three little pigs.\n\nThe three little pigs?\n\nYes, the three little pigs.\n\nWell, there was a pig and he built a house of straw. And then a big"
+    },
+    {
+    "output_general": "Once upon a time in a land far far away, there was a little girl who loved to read. She read everything she could get her hands on. She read books, magazines, newspapers, and even the back of cereal boxes. She"
+    },
+    {
+    "output_instruct": "[INST] What is your favourite condiment? [/INST] I don't have personal experiences or preferences, so I don't have a favorite condiment. However, I can tell you that condiments are often used in cooking"
+    },
+    {
+    "output_instruct": "[INST] Hello, how are you? [/INST] Hello! I'm just a computer program, so I don't have feelings, but I'm here and ready to assist you. How can I help you today?"
+    },
+    {
+    "output_instruct": "[INST] Do you have mayonnaise recipes? [/INST] Yes, I have several mayonnaise recipes that you might be interested in trying. Here's a basic recipe for homemade mayonnaise:\n\nIng"
+    },
+    {
+    "output_instruct": "[INST] Which color do you get if you mix yellow and blue? [/INST] You would get green if you mix yellow and blue. This is a basic principle in color theory where primary colors (yellow, blue, and red"
+    },
+    {
+    "output_instruct": "[INST] What is the ideal room temperature? [/INST] The ideal room temperature can vary depending on personal comfort and the time of year, but generally, most people find a temperature between 68 and 72 degrees Fahren"
+    },
+    {
+    "output_instruct": "[INST] Can you tell me a joke? [/INST] Why don't scientists trust atoms?\n\nBecause they make up everything!"
+    },
+    {
+    "output_instruct": "[INST] What are you good at? [/INST] I am good at providing information, answering questions, setting reminders, and performing various tasks such as sending emails, making reservations, and controlling smart home devices. I can also"
+    },
+    {
+    "output_instruct": "[INST] What is 2+2? [/INST] The sum of 2 + 2 is 4. Is there anything else you would like to know? I can help with a variety of topics, including mathematics,"
+    },
+    {
+    "output_instruct": "[INST] what is the capital of USA? [/INST] The capital of the USA is Washington, D.C. (District of Columbia). It is not to be confused with the state of Washington, which is located on the"
+    },
+    {
+    "output_instruct": "[INST] what is the capital of Canada? [/INST] The capital city of Canada is Ottawa. It is located in the province of Ontario and has a population of approximately one million people. Ottawa was chosen as the capital of"
+    },
+    {
+    "output_instruct": "[INST] what is the capital of UK? [/INST] The United Kingdom (UK) is a country that is made up of four constituent countries: England, Scotland, Wales, and Northern Ireland. The capital city of the UK"
+    },
+    {
+    "output_instruct": "[INST] what is the capital of Germany? [/INST] The capital of Germany is Berlin. Berlin has been the capital of Germany since the reunification of East and West Germany in 1871 and is the largest city in"
+    },
+    {
+    "output_instruct": "[INST] what is the capital of France? [/INST] The capital of France is Paris. Paris is one of the most populous cities in Europe and is known for its iconic landmarks, museums, and cultural attractions"
+    },
+    {
+    "output_instruct": "[INST] what is the capital of Japan? [/INST] The capital of Japan is Tokyo. It is the largest city in Japan and one of the most populous cities in the world. Tokyo is a major cultural, political, and"
+    },
+    {
+    "output_instruct": "[INST] what is the capital of Portugal? [/INST] The capital of Portugal is Lisbon. It is the largest city and the economic, cultural, and political center of the country. Lisbon is located on the western coast of"
+    },
+    {
+    "output_instruct": "[INST] what is the capital of China? [/INST] The capital of China is Beijing. It is one of the four municipalities under the direct administration of the central government of China, along with Shanghai, Tianjin,"
+    },
+    {
+    "output_instruct": "[INST] what is the currency of Cuba? [/INST] The official currency of Cuba is the Cuban Peso (CUP). However, there is also a second currency in circulation called the Cuban Convertible Peso (C"
+    },
+    {
+    "output_instruct": "[INST] what is the currency of Lebanon? [/INST] The official currency of Lebanon is the Lebanese Pound (LBP). The Lebanese Pound is also commonly referred to as the Lebanese L"
+    },
+    {
+    "output_instruct": "[INST] what is the currency of Brazil? [/INST] The currency of Brazil is the Real (BRL). It was introduced in 1994 to replace the previous currency, the Cruzeiro, in an effort to"
+    },
+    {
+    "output_instruct": "[INST] what is the currency of Australia? [/INST] The official currency of Australia is the Australian Dollar (AUD). It is abbreviated with the dollar sign ($), and its symbol is AUD or AU$."
+    },
+    {
+    "output_instruct": "[INST] what is the currency of Jamaica? [/INST] The currency of Jamaica is the Jamaican dollar (JMD). The Jamaican dollar is divided into 100 cents. Banknotes are available in denominations"
+    },
+    {
+    "output_instruct": "[INST] what is the currency of Egypt? [/INST] The official currency of Egypt is the Egyptian Pound. It is often represented with the symbol \"LE\" which stands for \"Livre Egyptienne\" or \"Egy"
+    },
+    {
+    "output_instruct": "[INST] what is the currency of Uzbekistan? [/INST] The official currency of Uzbekistan is the Uzbekistani Som. It was introduced in 1993, after the country's"
+    },
+    {
+    "output_instruct": "[INST] what is the currency of Argentina? [/INST] The official currency of Argentina is the Argentine Peso. The peso is divided into 100 centavos. The currency is managed by the Central Bank of"
+    },
+    {
+    "output_instruct": "[INST] Are birds mammals? [/INST] No, birds are not mammals. They are a group of warm-blooded vertebrates constituting the class Aves, characterized by feathers, toothless be"
+    },
+    {
+    "output_instruct": "[INST] How do you play tennis? [/INST] Tennis is a racket sport that can be played individually against a single opponent (singles) or between two teams of two players each (doubles). The objective of"
+    },
+    {
+    "output_instruct": "[INST] Suggest cities to visit in Japan [/INST] Japan is a country with a rich history, diverse culture, and stunning natural beauty, and there are many wonderful cities to visit. Here are a few suggestions:\n\n1"
+    },
+    {
+    "output_instruct": "[INST] How far away is the moon from the earth? [/INST] The moon is on average about 238,855 miles (384,400 kilometers) away from the Earth. However"
+    },
+    {
+    "output_instruct": "[INST] What is a black hole? [/INST] A black hole is a region in space where the gravitational pull is so strong that nothing, not even light, can escape from it. They are called \"black\" holes because"
+    },
+    {
+    "output_instruct": "[INST] How do you play golf? [/INST] Golf is a sport that is played outdoors on a golf course. The objective of the game is to hit a small ball into a series of holes using various clubs, with the"
+    },
+    {
+    "output_instruct": "[INST] Recommend me a movie [/INST] I would recommend \"The Shawshank Redemption\" (1994). It's a powerful and thought-provoking drama about hope, friendship, and red"
+    },
+    {
+    "output_instruct": "[INST] what is the capital of Spain? [/INST] The capital of Spain is Madrid. It is the country's political, economic and cultural center, and is located in the center of the country. Madrid is the third-"
+    }
+]

--- a/models/demos/t3000/mixtral8x7b/demo/expected_outputs.json
+++ b/models/demos/t3000/mixtral8x7b/demo/expected_outputs.json
@@ -1,195 +1,194 @@
-
 [
     {
-    "output_general": "This is a test.\n\nThis is a test of the emergency blogging system.\n\nThis is a test of the emergency blogging system.\n\nThis is a test of the emergency blogging system.\n\nThis is a"
+        "output_general": "This is a test.\n\nThis is a test of the emergency blogging system.\n\nThis is a test of the emergency blogging system.\n\nThis is a test of the emergency blogging system.\n\nThis is a"
     },
     {
-    "output_general": "It was the best of times, it was the worst of times, it was the age of wisdom, it was the age of foolishness, it was the epoch of belief, it was the epoch of incredulity, it was the season"
+        "output_general": "It was the best of times, it was the worst of times.\n\nThe best of times because I was able to spend a week with my family in the beautiful city of San Francisco.\n\nThe worst of times because I was away"
     },
     {
-    "output_general": "Run to the hills, run for your lives!\n\nThe end of the world is nigh!\n\nThe sky is falling!\n\nThe sky is falling!\n\nThe sky is falling!\n\nThe sky is falling!"
+        "output_general": "Run to the hills, run for your lives!\n\nThe end of the world is nigh!\n\nThe end of the world is nigh!\n\nThe end of the world is nigh!\n\nThe end of the"
     },
     {
-    "output_general": "You've got another thing coming if you think you're going to get a good night's sleep in the new 2019 Chevrolet Silverado.\n\nThe 2019 Chevrolet"
+        "output_general": "You've got another thing coming if you think you're going to get a good night's sleep in the new year.\n\nThe 2018 Farmers' Almanac is predicting a \"polar co"
     },
     {
-    "output_general": "The meaning of life is to find your gift. The purpose of life is to give it away.\n\nPablo Picasso\n\n## About Us\n\n#### Our Mission\n\nOur mission is to provide a safe and nurturing"
+        "output_general": "The meaning of life is to find your gift. The purpose of life is to give it away.\n\nPablo Picasso\n\n## About Me\n\nI am a 200 hour certified yoga teacher and a 20"
     },
     {
-    "output_general": "write a short poem about London in English and in your own language.\n\nI’m studying and need help with a English question to help me learn.\n\nWrite a short poem about London in English and in your own language.\n"
+        "output_general": "write a short poem about London in English and in French.\n\nThe poem is about the city of London and how it is a place of many different cultures and people. It is a place where you can find anything you want, and it"
     },
     {
-    "output_general": "How to tie your shoes.\n\nHow to ride a bike.\n\nHow to drive a car.\n\nHow to make a bed.\n\nHow to make a bed.\n\nHow to make a bed.\n\nHow"
+        "output_general": "How to tie your shoes.\n\nHow to ride a bike.\n\nHow to drive a car.\n\nHow to make a bed.\n\nHow to make a bed?\n\nYes, how to make a bed.\n"
     },
     {
-    "output_general": "Give me the address of the closest bakery and I’ll be there in a heartbeat. I’m a sucker for freshly baked bread, especially when it’s still warm and crusty.\n\nI"
+        "output_general": "Give me the address of the closest bakery and I’ll be there in a heartbeat. I’m a sucker for freshly baked bread, and I’m not ashamed to admit it.\n\nI’"
     },
     {
-    "output_general": "In a world far far away, there was a land called the United States of America. In this land, there was a state called California. In this state, there was a city called San Francisco. In this city, there was a neighborhood"
+        "output_general": "In a world far far away, there was a land called the United States of America. In this land, there was a state called California. In this state, there was a city called San Francisco. In this city, there was a neighborhood"
     },
     {
-    "output_general": "A poem about trees and nature:\n\nThe trees are my friends,\n\nThey are always there for me,\n\nThey are always there for you,\n\nThey are always there for everyone,\n\nThey are always there for"
+        "output_general": "A poem about trees and nature:\n\nI am a tree,\n\nI am a tree,\n\nI am a tree,\n\nI am a tree,\n\nI am a tree,\n\nI am a tree,"
     },
     {
-    "output_general": "Egg fried rice is a delicacy that is enjoyed by many people around the world. It is a simple dish that is easy to make and can be enjoyed as a main course or as a side dish. The dish is made by"
+        "output_general": "Egg fried rice is a delicacy that is enjoyed by many people around the world. It is a simple dish that can be made with just a few ingredients, and it is perfect for a quick and easy meal.\n\nThere"
     },
     {
-    "output_general": "This is another test of the new WordPress editor.\n\nI’m not sure if I like it or not.\n\nI’m not sure if I like it or not.\n\nI’m not sure if I like it"
+        "output_general": "This is another test of the new WordPress editor.\n\nI’m not sure if I like it or not.\n\nI’m not sure if I like it or not.\n\nI’m not sure if I like it"
     },
     {
-    "output_general": "This is yet another testament to the fact that the world is a small place.\n\nI was born and raised in the Philippines, and I’ve been living in the US for the past 10 years. I’ve been"
+        "output_general": "This is yet another testament to the fact that the world is a small place.\n\nI was born and raised in the Philippines. I moved to the US when I was 18. I’ve been here for 10"
     },
     {
-    "output_general": "Large language models are all the rage these days. They’re being used to generate text, translate languages, and even write code. But what are they, and how do they work? In this blog post, we’ll take a look"
+        "output_general": "Large language models are a big deal. They’re the technology behind ChatGPT, the AI chatbot that’s been making headlines for its ability to generate human-like text. But what are they, exactly? And how do"
     },
     {
-    "output_general": "The capital of Portugal, Lisbon is a city that has been on my bucket list for a long time. I’ve heard so many good things about it and I was so excited to finally visit it.\n\nWe arrived in Lisbon"
+        "output_general": "The capital of Portugal, Lisbon is a city that has a lot to offer. From its rich history and culture to its stunning architecture and delicious food, there is something for everyone in Lisbon. In this blog post, we will take a"
     },
     {
-    "output_general": "The word 'dog' in French is 'chien'.\n\n# French 1 - Animals\n\nThis French 1 quiz takes a look at animals. Animals are a great way to learn a language. They are easy"
+        "output_general": "The word 'dog' in French is chien.\n\n# French 1 - Pets\n\nQuiz playing is a wonderful way to increase your knowledge of French as a second language.\n\nIf you are a pet lover,"
     },
     {
-    "output_general": "Water is essential for life. It is also essential for the production of food and energy. But water is not always available where it is needed.\n\nThe world’s population is growing, and so is the demand for water. At the"
+        "output_general": "Water is essential for life. It is also essential for the production of food and energy. But water is not always available where it is needed.\n\nThe world’s population is growing and so is the demand for water. The world’"
     },
     {
-    "output_general": "My favorite hobby is videogames. I’ve been playing them since I was a kid. I’ve played a lot of different games, but I’ve always been a fan of the first-person shooter genre. I"
+        "output_general": "My favorite hobby is videogames. I’ve been playing them since I was a kid and I’ve been playing them ever since. I’ve been playing them for a long time and I’ve been playing them for a"
     },
     {
-    "output_general": "The best way to cook a steak is to cook it on a grill. The best way to cook a steak on a grill is to cook it on a grill that is hot enough to cook it. The best way to"
+        "output_general": "The best way to cook a steak is to cook it on a grill. The best way to cook a steak on a grill is to use a cast iron skillet. The best way to cook a steak on a cast"
     },
     {
-    "output_general": "Top 10 things to do in the Lake District\n\nThe Lake District is a beautiful part of the world and is a great place to visit for a holiday. There are so many things to do and see that it can be hard to"
+        "output_general": "Top 10 things to do in the Lake District\n\nThe Lake District is a beautiful part of the world and is a great place to visit for a short break or a longer holiday. There are so many things to do in the Lake"
     },
     {
-    "output_general": "The job of a computer architect is to design and build computers. They are responsible for the design of the hardware and software that make up a computer system. They also work with other engineers to create new technologies and improve existing ones.\n\nComput"
+        "output_general": "The job of a computer architect is to design and build computers. They are responsible for the design of the hardware and software that make up a computer system. Computer architects work with engineers to create new computer systems and improve existing ones. They also"
     },
     {
-    "output_general": "The number you have dialled is not available. Please try again later.\n\nI’m not sure if it’s the same for you, but I’ve been getting a lot of these lately.\n\nI’m not"
+        "output_general": "The number you have dialled is not available. Please try again later.\n\nI’m not sure if you’ve ever tried to call me, but if you have, you’ve probably heard this message. I’m not"
     },
     {
-    "output_general": "The best way to learn a new language is to immerse yourself in it. That’s why we’ve created a list of the best language learning apps for Android and iOS. These apps will help you learn a new language quickly and easily"
+        "output_general": "The best way to learn a new language is to immerse yourself in it. That’s why we offer a variety of language immersion programs for students of all ages and levels. Our programs are designed to help you learn a new language quickly"
     },
     {
-    "output_general": "Madrid is the capital of Spain and the largest city in the country. It is also the third largest city in the European Union, after London and Berlin. Madrid is located on the Manzanares River in the center of the country. The"
+        "output_general": "Madrid is the capital of Spain and is located in the center of the country. It is a city that has a lot to offer, from its rich history and culture to its vibrant nightlife and delicious food. Madrid is also home to some"
     },
     {
-    "output_general": "A good night's sleep is essential for our health and well-being. It helps us to recharge our batteries and to be ready for the day ahead. But what happens when we don't get enough sleep?\n\nSleep"
+        "output_general": "A good night's sleep is essential for our health and well-being. It helps us to feel refreshed and energized, and it can also help to improve our mood and cognitive function. However, many of us struggle to get a"
     },
     {
-    "output_general": "Typing prompts can be fun, but they can also be a bit of a pain. If you’re looking for a way to get rid of them, you’ve come to the right place. In this article, we’ll"
+        "output_general": "Typing prompts can be fun, but they can also be a bit of a pain. If you’re looking for a way to make your typing experience a little more enjoyable, you may want to consider using a typing prompt generator.\n"
     },
     {
-    "output_general": "I'm going to the store to buy a new car. I'm going to the store to buy a new car. I'm going to the store to buy a new car. I'm going to the store to buy a"
+        "output_general": "I'm going to the store to buy a new car. I'm going to the store to buy a new car. I'm going to the store to buy a new car. I'm going to the store to buy a"
     },
     {
-    "output_general": "I am a world renown spy. I have been on many missions and have been to many places. I have been to the moon and back. I have been to the bottom of the ocean and back. I have been to the top of the"
+        "output_general": "Bread is typically made from wheat flour, water, yeast, and salt. The dough is kneaded and then left to rise before being baked. Bread can be made with other grains, such as rye or barley"
     },
     {
-    "output_general": "Ready, set, go!\n\nThe 2018 Winter Olympics are officially underway in Pyeongchang, South Korea, and the opening ceremony was a sight to behold.\n\nThe ceremony kicked off with"
+        "output_general": "Climate change is the most important issue of our time. It is a global problem that requires global solutions. The United States has a responsibility to lead the way in addressing this crisis.\n\nThe United States has been a leader in the fight"
     },
     {
-    "output_general": "Climate change is the most important issue of our time. It is a global problem that requires a global solution. The United States has a responsibility to lead the way in addressing this issue.\n\nThe United States has a long history of leading"
+        "output_general": "The name of the first American president is George Washington. He was born on February 22, 1732, in Westmoreland County, Virginia. He was the first of six children of Augustine Washington and his second wife"
     },
     {
-    "output_general": "Tell me the story of the three little pigs.\n\nThe three little pigs?\n\nYes, the three little pigs.\n\nWell, there was a pig and he built a house of straw. And then a big"
+        "output_general": "The colors of the rainbow include: yellow, orange, red, violet, blue, green, and indigo. The colors of the rainbow are made up of the colors of the visible light spectrum. The colors of the rainbow"
     },
     {
-    "output_general": "Once upon a time in a land far far away, there was a little girl who loved to read. She read everything she could get her hands on. She read books, magazines, newspapers, and even the back of cereal boxes. She"
+        "output_general": "Count to 100: 1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17"
     },
     {
-    "output_instruct": "[INST] What is your favourite condiment? [/INST] I don't have personal experiences or preferences, so I don't have a favorite condiment. However, I can tell you that condiments are often used in cooking"
+        "output_instruct": "[INST] What is your favourite condiment? [/INST] I don't have personal experiences or preferences, so I don't have a favorite condiment. However, I can tell you that condiments are often used in cooking"
     },
     {
-    "output_instruct": "[INST] Hello, how are you? [/INST] Hello! I'm just a computer program, so I don't have feelings, but I'm here and ready to assist you. How can I help you today?"
+        "output_instruct": "[INST] Hello, how are you? [/INST] Hello! I'm just a computer program, so I don't have feelings, but I'm here and ready to assist you. How can I help you today?"
     },
     {
-    "output_instruct": "[INST] Do you have mayonnaise recipes? [/INST] Yes, I have several mayonnaise recipes that you might be interested in trying. Here's a basic recipe for homemade mayonnaise:\n\nIng"
+        "output_instruct": "[INST] Do you have mayonnaise recipes? [/INST] Yes, I have several mayonnaise recipes that you can try out. Here's a basic recipe for homemade mayonnaise:\n\nIngredients"
     },
     {
-    "output_instruct": "[INST] Which color do you get if you mix yellow and blue? [/INST] You would get green if you mix yellow and blue. This is a basic principle in color theory where primary colors (yellow, blue, and red"
+        "output_instruct": "[INST] Which color do you get if you mix yellow and blue? [/INST] You would get green if you mix yellow and blue. This is a basic principle in color theory, where primary colors (yellow, blue, and"
     },
     {
-    "output_instruct": "[INST] What is the ideal room temperature? [/INST] The ideal room temperature can vary depending on personal comfort and the time of year, but generally, most people find a temperature between 68 and 72 degrees Fahren"
+        "output_instruct": "[INST] What is the ideal room temperature? [/INST] The ideal room temperature can depend on personal comfort and the specific activity being done, but generally, a temperature between 68 to 72 degrees Fahrenheit (2"
     },
     {
-    "output_instruct": "[INST] Can you tell me a joke? [/INST] Why don't scientists trust atoms?\n\nBecause they make up everything!"
+        "output_instruct": "[INST] Can you tell me a joke? [/INST] Why don't scientists trust atoms?\n\nBecause they make up everything!"
     },
     {
-    "output_instruct": "[INST] What are you good at? [/INST] I am good at providing information, answering questions, setting reminders, and performing various tasks such as sending emails, making reservations, and controlling smart home devices. I can also"
+        "output_instruct": "[INST] What are you good at? [/INST] I am good at providing information, answering questions, and carrying out tasks to the best of my ability. I can process and analyze large amounts of data quickly and accurately, and I"
     },
     {
-    "output_instruct": "[INST] What is 2+2? [/INST] The sum of 2 + 2 is 4. Is there anything else you would like to know? I can help with a variety of topics, including mathematics,"
+        "output_instruct": "[INST] What is 2+2? [/INST] The sum of 2+2 is 4. Is there anything else you would like to know? I can help with many types of questions, including those about programming,"
     },
     {
-    "output_instruct": "[INST] what is the capital of USA? [/INST] The capital of the USA is Washington, D.C. (District of Columbia). It is not to be confused with the state of Washington, which is located on the"
+        "output_instruct": "[INST] what is the capital of USA? [/INST] The capital of the USA is Washington, D.C. (District of Columbia). It is not to be confused with the state of Washington, which is located on the"
     },
     {
-    "output_instruct": "[INST] what is the capital of Canada? [/INST] The capital city of Canada is Ottawa. It is located in the province of Ontario and has a population of approximately one million people. Ottawa was chosen as the capital of"
+        "output_instruct": "[INST] what is the capital of Canada? [/INST] The capital city of Canada is Ottawa. It is located in the province of Ontario and has a population of approximately one million people. Ottawa was officially established as the capital"
     },
     {
-    "output_instruct": "[INST] what is the capital of UK? [/INST] The United Kingdom (UK) is a country that is made up of four constituent countries: England, Scotland, Wales, and Northern Ireland. The capital city of the UK"
+        "output_instruct": "[INST] what is the capital of UK? [/INST] The United Kingdom (UK) is a country that is made up of four constituent countries: England, Scotland, Wales, and Northern Ireland. The capital city of the UK"
     },
     {
-    "output_instruct": "[INST] what is the capital of Germany? [/INST] The capital of Germany is Berlin. Berlin has been the capital of Germany since the reunification of East and West Germany in 1871 and is the largest city in"
+        "output_instruct": "[INST] what is the capital of Germany? [/INST] The capital of Germany is Berlin. Berlin has been the capital of Germany since the reunification of East and West Germany in 1990. It is the largest city"
     },
     {
-    "output_instruct": "[INST] what is the capital of France? [/INST] The capital of France is Paris. Paris is one of the most populous cities in Europe and is known for its iconic landmarks, museums, and cultural attractions"
+        "output_instruct": "[INST] what is the capital of France? [/INST] The capital of France is Paris. Paris is one of the most populous cities in Europe and is known for its iconic landmarks, museums, and cultural attractions"
     },
     {
-    "output_instruct": "[INST] what is the capital of Japan? [/INST] The capital of Japan is Tokyo. It is the largest city in Japan and one of the most populous cities in the world. Tokyo is a major cultural, political, and"
+        "output_instruct": "[INST] what is the capital of Japan? [/INST] The capital of Japan is Tokyo. It is the largest city in Japan and one of the most populous cities in the world. Tokyo is a major cultural, financial, and"
     },
     {
-    "output_instruct": "[INST] what is the capital of Portugal? [/INST] The capital of Portugal is Lisbon. It is the largest city and the economic, cultural, and political center of the country. Lisbon is located on the western coast of"
+        "output_instruct": "[INST] what is the capital of Portugal? [/INST] The capital of Portugal is Lisbon. It is the largest city and the economic, cultural, and political center of the country. Lisbon is located near the west coast of"
     },
     {
-    "output_instruct": "[INST] what is the capital of China? [/INST] The capital of China is Beijing. It is one of the four municipalities under the direct administration of the central government of China, along with Shanghai, Tianjin,"
+        "output_instruct": "[INST] what is the capital of China? [/INST] The capital of China is Beijing. It is one of the four municipalities under the direct administration of the central government of China, along with Shanghai, Tianjin,"
     },
     {
-    "output_instruct": "[INST] what is the currency of Cuba? [/INST] The official currency of Cuba is the Cuban Peso (CUP). However, there is also a second currency in circulation called the Cuban Convertible Peso (C"
+        "output_instruct": "[INST] what is the currency of Cuba? [/INST] The official currency of Cuba is the Cuban Peso (CUP). However, there is also a second currency in circulation called the Cuban Convertible Peso (C"
     },
     {
-    "output_instruct": "[INST] what is the currency of Lebanon? [/INST] The official currency of Lebanon is the Lebanese Pound (LBP). The Lebanese Pound is also commonly referred to as the Lebanese L"
+        "output_instruct": "[INST] what is the currency of Lebanon? [/INST] The official currency of Lebanon is the Lebanese Pound (LBP). The Lebanese Pound is also commonly referred to as the Lebanese L"
     },
     {
-    "output_instruct": "[INST] what is the currency of Brazil? [/INST] The currency of Brazil is the Real (BRL). It was introduced in 1994 to replace the previous currency, the Cruzeiro, in an effort to"
+        "output_instruct": "[INST] what is the currency of Brazil? [/INST] The official currency of Brazil is the Brazilian Real (BRL or R$). It is divided into 100 centavos. The real was introduced in 1"
     },
     {
-    "output_instruct": "[INST] what is the currency of Australia? [/INST] The official currency of Australia is the Australian Dollar (AUD). It is abbreviated with the dollar sign ($), and its symbol is AUD or AU$."
+        "output_instruct": "[INST] what is the currency of Australia? [/INST] The official currency of Australia is the Australian Dollar (AUD). It is abbreviated with the dollar sign ($), but to distinguish it from other dollar-based"
     },
     {
-    "output_instruct": "[INST] what is the currency of Jamaica? [/INST] The currency of Jamaica is the Jamaican dollar (JMD). The Jamaican dollar is divided into 100 cents. Banknotes are available in denominations"
+        "output_instruct": "[INST] what is the currency of Jamaica? [/INST] The currency of Jamaica is the Jamaican dollar (JMD). The Jamaican dollar is divided into 100 cents. Banknotes are available in denominations"
     },
     {
-    "output_instruct": "[INST] what is the currency of Egypt? [/INST] The official currency of Egypt is the Egyptian Pound. It is often represented with the symbol \"LE\" which stands for \"Livre Egyptienne\" or \"Egy"
+        "output_instruct": "[INST] what is the currency of Egypt? [/INST] The official currency of Egypt is the Egyptian Pound. It is often represented with the symbol \"LE\" which stands for \"Livre Egyptienne\" which is French for"
     },
     {
-    "output_instruct": "[INST] what is the currency of Uzbekistan? [/INST] The official currency of Uzbekistan is the Uzbekistani Som. It was introduced in 1993, after the country's"
+        "output_instruct": "[INST] what is the currency of Uzbekistan? [/INST] The official currency of Uzbekistan is the Uzbekistani Som. The Som was introduced in 1993, after the country'"
     },
     {
-    "output_instruct": "[INST] what is the currency of Argentina? [/INST] The official currency of Argentina is the Argentine Peso. The peso is divided into 100 centavos. The currency is managed by the Central Bank of"
+        "output_instruct": "[INST] what is the currency of Argentina? [/INST] The official currency of Argentina is the Argentine Peso. The peso is divided into 100 centavos. Banknotes come in denominations of 2"
     },
     {
-    "output_instruct": "[INST] Are birds mammals? [/INST] No, birds are not mammals. They are a group of warm-blooded vertebrates constituting the class Aves, characterized by feathers, toothless be"
+        "output_instruct": "[INST] Are birds mammals? [/INST] No, birds are not mammals. While both birds and mammals are warm-blooded and have backbones, birds have feathers, lay hard-shelled eggs,"
     },
     {
-    "output_instruct": "[INST] How do you play tennis? [/INST] Tennis is a racket sport that can be played individually against a single opponent (singles) or between two teams of two players each (doubles). The objective of"
+        "output_instruct": "[INST] How do you play tennis? [/INST] Tennis is a racket sport that can be played individually against a single opponent (singles) or between two teams of two players each (doubles). The objective of"
     },
     {
-    "output_instruct": "[INST] Suggest cities to visit in Japan [/INST] Japan is a country with a rich history, diverse culture, and stunning natural beauty, and there are many wonderful cities to visit. Here are a few suggestions:\n\n1"
+        "output_instruct": "[INST] Suggest cities to visit in Japan [/INST] Japan is a country with a rich history, unique culture, and stunning natural beauty, and there are many wonderful cities to visit. Here are a few suggestions:\n\n1"
     },
     {
-    "output_instruct": "[INST] How far away is the moon from the earth? [/INST] The moon is on average about 238,855 miles (384,400 kilometers) away from the Earth. However"
+        "output_instruct": "[INST] How far away is the moon from the earth? [/INST] The moon is on average about 238,855 miles (384,400 kilometers) away from Earth. However,"
     },
     {
-    "output_instruct": "[INST] What is a black hole? [/INST] A black hole is a region in space where the gravitational pull is so strong that nothing, not even light, can escape from it. They are called \"black\" holes because"
+        "output_instruct": "[INST] What is a black hole? [/INST] A black hole is a region in space where the gravitational pull is so strong that nothing, not even light, can escape from it. They are called \"black\" holes because"
     },
     {
-    "output_instruct": "[INST] How do you play golf? [/INST] Golf is a sport that is played outdoors on a golf course. The objective of the game is to hit a small ball into a series of holes using various clubs, with the"
+        "output_instruct": "[INST] How do you play golf? [/INST] Golf is a sport that is played outdoors on a golf course. The objective of the game is to hit a small ball into a series of holes using various clubs, with the"
     },
     {
-    "output_instruct": "[INST] Recommend me a movie [/INST] I would recommend \"The Shawshank Redemption\" (1994). It's a powerful and thought-provoking drama about hope, friendship, and red"
+        "output_instruct": "[INST] Recommend me a movie [/INST] I would recommend \"The Shawshank Redemption\" (1994). It's a classic film directed by Frank Darabont, based on the novella"
     },
     {
-    "output_instruct": "[INST] what is the capital of Spain? [/INST] The capital of Spain is Madrid. It is the country's political, economic and cultural center, and is located in the center of the country. Madrid is the third-"
+        "output_instruct": "[INST] what is the capital of Spain? [/INST] The capital of Spain is Madrid. It is the country's political, economic and cultural center, and is located in the central part of the Iberian Peninsula."
     }
 ]

--- a/models/demos/t3000/mixtral8x7b/demo/input_data.json
+++ b/models/demos/t3000/mixtral8x7b/demo/input_data.json
@@ -81,17 +81,17 @@
 "prompt": "I'm going to the store"
            },
         {
-"prompt": "I am a world renown spy"
-           },
-        {
-"prompt": "Ready, set, go"
+"prompt": "Bread is typically made from"
            },
         {
 "prompt": "Climate change is the most important issue"
+            },
+         {
+"prompt": "The name of the first American president is"
            },
         {
-"prompt": "Tell me the story of the three little pigs"
+"prompt": "The colors of the rainbow include: yellow,"
            },
         {
-"prompt": "Once upon a time in a land far far away"}
+"prompt": "Count to 100: 1,2,3,4,"}
        ]

--- a/models/demos/t3000/mixtral8x7b/reference/demo_ref.py
+++ b/models/demos/t3000/mixtral8x7b/reference/demo_ref.py
@@ -5,6 +5,7 @@ import torch
 from loguru import logger
 import json
 
+from models.demos.t3000.mixtral8x7b.tt.mixtral_common import load_inputs
 from models.demos.t3000.mixtral8x7b.tt.model_config import TtModelArgs
 from models.demos.t3000.mixtral8x7b.reference.model import Transformer
 from models.demos.t3000.mixtral8x7b.reference.tokenizer import Tokenizer
@@ -17,18 +18,6 @@ class Emb(torch.nn.Module):
 
     def forward(self, x):
         return self.emb(x)
-
-
-# load from json, return as a list
-def load_inputs(user_input, batch):
-    if isinstance(user_input, str):
-        with open(user_input, "r") as f:
-            user_input = json.load(f)
-    assert len(user_input) >= batch, f"Number of users (batch) must be {batch}!"
-    in_prompt = []
-    for i in range(batch):
-        in_prompt.append(user_input[i]["prompt"])
-    return in_prompt
 
 
 def preprocess_inputs(input_prompts, tokenizer, model_args, embd):

--- a/models/demos/t3000/mixtral8x7b/tests/test_mixtral_attention.py
+++ b/models/demos/t3000/mixtral8x7b/tests/test_mixtral_attention.py
@@ -73,8 +73,7 @@ def test_mixtral_attention_inference(t3k_device_mesh, use_program_cache, reset_s
             attn_mask,
             current_rot_mat,
         )
-        # Work around program cache issue https://github.com/tenstorrent/tt-metal/issues/7159
-        del attention_input, attn_mask
+
         tt_output_torch = (
             ttnn.to_torch(tt_out, mesh_composer=ConcatMeshToTensor(t3k_device_mesh, dim=0))[0]
             .squeeze(2)

--- a/models/demos/t3000/mixtral8x7b/tests/test_mixtral_decoder.py
+++ b/models/demos/t3000/mixtral8x7b/tests/test_mixtral_decoder.py
@@ -76,8 +76,7 @@ def test_mixtral_decoder_inference(t3k_device_mesh, use_program_cache, reset_see
         )
         # Run TT model
         tt_out_b1sh = tt_model(decode_input_b1sh, start_pos, current_pos, attn_mask, current_rot_mat)
-        # Work around program cache issue https://github.com/tenstorrent/tt-metal/issues/7159
-        del decode_input_b1sh, attn_mask
+
         tt_output_torch_b1h = (
             ttnn.to_torch(tt_out_b1sh, mesh_composer=ConcatMeshToTensor(t3k_device_mesh, dim=0))[0]
             .squeeze(1)

--- a/models/demos/t3000/mixtral8x7b/tests/test_mixtral_perf.py
+++ b/models/demos/t3000/mixtral8x7b/tests/test_mixtral_perf.py
@@ -43,10 +43,10 @@ class Emb(torch.nn.Module):
 @pytest.mark.parametrize(
     "generation_start_pos, expected_compile_time, expected_inference_time",
     (
-        (32, 150, 0.075),
-        (128, 150, 0.075),
-        (1024, 150, 0.075),
-        (2048, 150, 0.075),
+        (32, 150, 0.085),
+        (128, 150, 0.085),
+        (1024, 150, 0.085),
+        (2048, 150, 0.085),
     ),
 )
 def test_mixtral_model_perf(

--- a/models/demos/t3000/mixtral8x7b/tests/test_mixtral_perf.py
+++ b/models/demos/t3000/mixtral8x7b/tests/test_mixtral_perf.py
@@ -180,7 +180,6 @@ def run_inference(tt_model, embd, encoded_prompts, generation_start_pos, generat
         profiler.end(f"torch_argmax_and_embed_{i}")
 
         profiler.start(f"deallocate_tt_tensors_{i}")
-        # Work around program cache issue https://github.com/tenstorrent/tt-metal/issues/7159
-        del decode_input, attn_mask, tt_decode_input
+
         tt_out.deallocate(force=True)
         profiler.end(f"deallocate_tt_tensors_{i}")

--- a/models/demos/t3000/mixtral8x7b/tests/test_mixtral_perplexity.py
+++ b/models/demos/t3000/mixtral8x7b/tests/test_mixtral_perplexity.py
@@ -1,0 +1,303 @@
+# SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+
+# SPDX-License-Identifier: Apache-2.0
+import os
+import torch
+import json
+import tt_lib as ttl
+import pytest
+from loguru import logger
+from time import time
+import sys
+from tqdm import tqdm
+import numpy as np
+
+# Set Mixtral flags for CI, if CI environment is setup
+if os.getenv("CI") == "true":
+    os.environ["MIXTRAL_CKPT_DIR"] = "/mnt/MLPerf/tt_dnn-models/Mistral/Mixtral-8x7B-v0.1/"
+    os.environ["MIXTRAL_TOKENIZER_PATH"] = "/mnt/MLPerf/tt_dnn-models/Mistral/Mixtral-8x7B-v0.1/"
+    os.environ["MIXTRAL_CACHE_PATH"] = "/mnt/MLPerf/tt_dnn-models/Mistral/Mixtral-8x7B-v0.1/"
+    os.environ["TT_METAL_ASYNC_DEVICE_QUEUE"] = "1"
+    os.environ["WH_ARCH_YAML"] = "wormhole_b0_80_arch_eth_dispatch.yaml"
+
+import ttnn
+from ttnn import ReplicateTensorToMesh, ConcatMeshToTensor
+from models.demos.t3000.mixtral8x7b.tt.mixtral_common import (
+    prepare_inputs_ttnn,
+    get_single_rot_mat,
+    sample,
+    cache_attention,
+)
+from models.demos.t3000.mixtral8x7b.tt.mixtral_model import TtTransformer
+from models.demos.t3000.mixtral8x7b.tt.mixtral_embedding import TtMixtralEmbedding
+from models.demos.t3000.mixtral8x7b.reference.model import Transformer
+from models.demos.t3000.mixtral8x7b.reference.tokenizer import Tokenizer
+from models.demos.t3000.mixtral8x7b.tt.model_config import TtModelArgs
+from models.datasets.llm_dataset_utils import (
+    prepare_textgen_dataset,
+    prepare_textgen_dataloader,
+    calculate_acc_metrics,
+    verify_acc_metrics,
+)
+
+
+class Emb(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.emb = torch.nn.Embedding(32000, 4096)
+
+    def forward(self, x):
+        return self.emb(x)
+
+
+@torch.no_grad()
+def run_test_perplexity(
+    device_mesh,
+    batch_size,
+    llm_mode,
+    max_seq_len,
+    num_samples,
+    expected_acc_metrics,
+    instruct_mode=False,  # For now, only run accuracy check for general weights
+    stride=None,
+    dataset_name="wikitext",
+    dataset_config="wikitext-2-raw-v1",
+    split="test",
+):
+    assert batch_size == 32, "Batch size must be 32"
+    dtype = ttnn.bfloat8_b
+    embed_on_host = True  # embedding and argmax on host
+    seqlen = 1  # Generating one token per user at a time
+
+    # Flag to compile the ref model and run the accuracy metrics on it
+    validate_ref_model = False
+
+    # Accuracy metrics
+    running_nll, running_top1_acc, running_top5_acc = 0.0, 0.0, 0.0
+
+    if validate_ref_model:
+        ref_running_nll, ref_running_top1_acc, ref_running_top5_acc = 0.0, 0.0, 0.0
+
+    # Load model args, weights, and tokenizer
+    model_args = TtModelArgs(device_mesh.get_device(0), instruct=instruct_mode)
+    tokenizer = Tokenizer(model_args.tokenizer_path)
+    if instruct_mode:
+        tokenizer._model.pad_id = tokenizer._model.eos_id
+
+    model_args.n_layers = 32  # Full model
+
+    # Prepare dataset
+    logger.info("Preparing dataset...")
+    dataset = prepare_textgen_dataset(dataset_name, dataset_config, split)
+    if instruct_mode:
+        # Pre append [INST] and post append [/INST] to the encoded prompts if instruct mode
+        encodings = torch.tensor(tokenizer.encode("[INST] " + dataset + " [/INST]"))
+    else:
+        encodings = torch.tensor(tokenizer.encode(dataset))
+    dataloader = prepare_textgen_dataloader(encodings, batch_size, max_seq_len, num_samples, stride)
+
+    logger.info("Loading weights...")
+    state_dict = torch.load(model_args.state_dict_path)
+    # If not using the full model, remove the layers that are not used
+    keys_dict = list(state_dict.keys())[:]
+    remv = [f"layers.{i}" for i in range(model_args.n_layers, 32)]
+    for k in keys_dict:
+        if any([r in k for r in remv]):
+            state_dict.pop(k)
+
+    # Embedding on host
+    if embed_on_host:
+        embd = Emb()
+        embd.load_state_dict({"emb.weight": state_dict["tok_embeddings.weight"]})
+
+    # Load TTNN mixtral model
+    logger.info("Loading weights to device...")
+    tt_model = TtTransformer(
+        device_mesh=device_mesh,
+        state_dict=state_dict,
+        args=model_args,
+        layers=list(range(model_args.n_layers)),
+        dtype=dtype,
+    )
+
+    if validate_ref_model:
+        reference_model = Transformer(args=model_args)
+        reference_model.load_state_dict(state_dict)
+        reference_model.eval()
+
+    if not embed_on_host:
+        tt_embds = TtMixtralEmbedding(
+            device_mesh=device_mesh,
+            args=model_args,
+            weight_cache_path=model_args.weight_cache_path(dtype),
+            state_dict=state_dict,
+            dtype=ttnn.bfloat16,  # Row major layout requires bfloat16
+        )
+
+    logger.info("Finished loading weights to device.")
+
+    # Prepare inputs for decode mode (rotary embeddings, attention mask, padding)
+    current_rot_mat, rot_matrix = get_single_rot_mat(
+        model_args.head_dim,
+        tt_model.device_mesh,
+    )
+
+    generation_start_pos = 0
+
+    cache_attention(
+        device_mesh,
+        state_dict,
+        model_args,
+        current_rot_mat,
+        rot_matrix,
+        generation_start_pos,
+        max_seq_len,
+        dtype,
+    )
+
+    logger.info("Starting inference...")
+    for input_ids, labels in tqdm(dataloader, desc="Evaluating batches"):
+        if llm_mode == "prefill":
+            # TODO Add prefill support
+            assert "Prefill mode not yet supported"
+        elif llm_mode == "decode":
+            logits = []
+            if validate_ref_model:
+                ref_logits = []
+
+            for kv_cache_len in tqdm(range(max_seq_len), desc="Decoding tokens for current batch"):
+                # Convert input_id into ttnn input
+                pt_decode_input = embd(input_ids[:, kv_cache_len]).view(batch_size, seqlen, -1)
+
+                start_pos = generation_start_pos + kv_cache_len
+                current_pos = start_pos % model_args.sliding_window
+
+                if embed_on_host:
+                    decode_input_11BH, attn_mask = prepare_inputs_ttnn(
+                        pt_decode_input,
+                        model_args.dim,
+                        start_pos,
+                        model_args,
+                        tt_model.device_mesh,
+                    )
+                else:
+                    assert "Only embedding on host is supported for now!"
+
+                # Run ttnn mixtral model
+                tt_logits = tt_model(decode_input_11BH, start_pos, current_pos, attn_mask)
+
+                if embed_on_host:
+                    # Convert ttnn tensor to torch tensor
+                    pt_logits = (
+                        ttnn.to_torch(tt_logits, mesh_composer=ConcatMeshToTensor(device_mesh, dim=0))[0]
+                        .squeeze(1)
+                        .view(batch_size, seqlen, -1)
+                        .detach()
+                        .float()
+                    )
+                else:
+                    assert "Only embedding on host is supported for now!"
+
+                logits.append(pt_logits.view(-1, 1, model_args.vocab_size))
+
+                if validate_ref_model:
+                    positions = torch.LongTensor([start_pos])
+                    ref_pt_logits = reference_model(pt_decode_input, positions).detach().float()
+                    ref_logits.append(ref_pt_logits.view(-1, 1, model_args.vocab_size))
+
+        logits = torch.cat(logits, dim=1)
+        # Re-shape logits and labels and calculate metrics
+        logits = logits.view(batch_size * max_seq_len, model_args.vocab_size)  # batch_size * max_seq_len, vocab_size
+        labels = labels.view(-1)  # batch_size * max_seq_len
+
+        # Calculate accuracy metrics
+        nll, top1_acc, top5_acc = calculate_acc_metrics(logits, labels)
+        running_nll += nll
+        running_top1_acc += top1_acc
+        running_top5_acc += top5_acc
+
+        if validate_ref_model:
+            ref_logits = torch.cat(ref_logits, dim=1)
+            # Re-shape logits and labels and calculate metrics
+            ref_logits = ref_logits.view(
+                batch_size * max_seq_len, model_args.vocab_size
+            )  # batch_size * max_seq_len, vocab_size
+
+            # Calculate accuracy metrics
+            ref_nll, ref_top1_acc, ref_top5_acc = calculate_acc_metrics(ref_logits, labels)
+            ref_running_nll += ref_nll
+            ref_running_top1_acc += ref_top1_acc
+            ref_running_top5_acc += ref_top5_acc
+
+    # Validate accuracy metrics against the expected values
+    nll = running_nll / len(dataloader)
+    ppl = np.exp(nll)
+    top1_acc = running_top1_acc / len(dataloader)
+    top5_acc = running_top5_acc / len(dataloader)
+    logger.info(f"Negative log-likelihood: {nll:.4f}")
+    logger.info(f"Perplexity: {ppl:.4f}")
+    logger.info(f"Top-1 accuracy: {top1_acc:.4f}")
+    logger.info(f"Top-5 accuracy: {top5_acc:.4f}")
+
+    calculated_acc_metrics = {"ppl": ppl, "top1_acc": top1_acc, "top5_acc": top5_acc}
+    verify_acc_metrics(calculated_acc_metrics, expected_acc_metrics)
+
+    if validate_ref_model:
+        ref_nll = ref_running_nll / len(dataloader)
+        ref_ppl = np.exp(ref_nll)
+        ref_top1_acc = ref_running_top1_acc / len(dataloader)
+        ref_top5_acc = ref_running_top5_acc / len(dataloader)
+        logger.info(f"Ref Negative log-likelihood: {nll:.4f}")
+        logger.info(f"Ref Perplexity: {ppl:.4f}")
+        logger.info(f"Ref Top-1 accuracy: {top1_acc:.4f}")
+        logger.info(f"Ref Top-5 accuracy: {top5_acc:.4f}")
+
+
+@pytest.mark.timeout(3600)
+@pytest.mark.parametrize(
+    "llm_mode, max_seq_len, num_samples, expected_ppl, expected_top1, expected_top5",
+    (
+        # TODO Add prefill accuracy tests
+        # ("prefill", 128, 64, -, -, -),
+        # ("prefill", 1024, 64, -, -, -),
+        # ("prefill", 2048, 64, -, -, -),
+        # ("prefill", 4096, 64, -, -, -),
+        ("decode", 128, 64, 8.70, 0.52, 0.75),
+        ("decode", 1024, 64, 4.90, 0.62, 0.83),
+        ("decode", 2048, 64, 4.23, 0.64, 0.85),
+        # ("decode", 4096, 32, 10.59, 0.49, 0.73),
+    ),
+    ids=[
+        # "prefill_128",
+        # "prefill_1024",
+        # "prefill_2048",
+        # "prefill_4096",
+        "decode_128",
+        "decode_1024",
+        "decode_2048",
+        # "decode_4096",
+    ],
+)
+def test_mixtral_perplexity(
+    t3k_device_mesh,
+    use_program_cache,
+    reset_seeds,
+    llm_mode,
+    max_seq_len,
+    num_samples,
+    expected_ppl,
+    expected_top1,
+    expected_top5,
+):
+    assert (
+        llm_mode == "decode"
+    ), "Only decode mode is supported for now"  # TODO Add prefill support when it reaches main
+
+    return run_test_perplexity(
+        device_mesh=t3k_device_mesh,
+        batch_size=32,
+        llm_mode=llm_mode,
+        max_seq_len=max_seq_len,
+        num_samples=num_samples,
+        expected_acc_metrics={"ppl": expected_ppl, "top1_acc": expected_top1, "top5_acc": expected_top5},
+    )

--- a/models/demos/t3000/mixtral8x7b/tests/test_mixtral_topk.py
+++ b/models/demos/t3000/mixtral8x7b/tests/test_mixtral_topk.py
@@ -1,0 +1,140 @@
+# SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+
+# SPDX-License-Identifier: Apache-2.0
+import os
+import torch
+import pytest
+from loguru import logger
+from sklearn.metrics import top_k_accuracy_score
+
+# Set Mixtral flags for CI, if CI environment is setup
+if os.getenv("CI") == "true":
+    os.environ["MIXTRAL_CKPT_DIR"] = "/mnt/MLPerf/tt_dnn-models/Mistral/Mixtral-8x7B-v0.1/"
+    os.environ["MIXTRAL_TOKENIZER_PATH"] = "/mnt/MLPerf/tt_dnn-models/Mistral/Mixtral-8x7B-v0.1/"
+    os.environ["MIXTRAL_CACHE_PATH"] = "/mnt/MLPerf/tt_dnn-models/Mistral/Mixtral-8x7B-v0.1/"
+    os.environ["TT_METAL_ASYNC_DEVICE_QUEUE"] = "1"
+    os.environ["WH_ARCH_YAML"] = "wormhole_b0_80_arch_eth_dispatch.yaml"
+
+import ttnn
+from models.demos.t3000.mixtral8x7b.tt.mixtral_common import prepare_inputs_ttnn, preprocess_inputs, load_inputs
+from models.demos.t3000.mixtral8x7b.tt.mixtral_model import TtTransformer
+from models.demos.t3000.mixtral8x7b.reference.model import Transformer
+from models.demos.t3000.mixtral8x7b.reference.tokenizer import Tokenizer
+from models.demos.t3000.mixtral8x7b.tt.model_config import TtModelArgs
+
+
+class Emb(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.emb = torch.nn.Embedding(32000, 4096)
+
+    def forward(self, x):
+        return self.emb(x)
+
+
+# Expected times for each test: 64seqlen: 11 min, 128seqlen: 22 min, 256seqlen: 44 min
+@pytest.mark.timeout(3600)
+@pytest.mark.parametrize(
+    "iterations, expected_top1, expected_top5",
+    (
+        (64, 0.92, 0.99),
+        (128, 0.92, 0.99),
+        (256, 0.92, 0.99),
+    ),
+    ids=("64seqlen", "128seqlen", "256seqlen"),
+)
+def test_mixtral_model_inference(
+    t3k_device_mesh, use_program_cache, reset_seeds, iterations, expected_top1, expected_top5
+):
+    dtype = ttnn.bfloat8_b
+    seqlen = 1  # Generating one token per user at a time
+    batch = 32
+    generation_start_pos = 0
+    running_top1 = 0
+    running_top5 = 0
+    inputs_file = "models/demos/t3000/mixtral8x7b/demo/input_data.json"
+
+    model_args = TtModelArgs(t3k_device_mesh.get_device(0))
+    state_dict = model_args.load_state_dict()
+    tokenizer = Tokenizer(model_args.tokenizer_path)
+
+    # Prepare inputs
+    input_prompts = load_inputs(inputs_file, 32)
+    input_tokens_tt, max_prompt_len, input_mask, input_tokens_pt, input_mask_pt = preprocess_inputs(
+        input_prompts, tokenizer, model_args, dtype, False, t3k_device_mesh
+    )
+
+    # Load reference model
+    reference_model = Transformer(args=model_args)
+    reference_model.load_state_dict(state_dict)
+    reference_model.eval()
+
+    # Embedding on host
+    embd = Emb()
+    embd.load_state_dict({"emb.weight": state_dict["tok_embeddings.weight"]})
+
+    # Load TTNN model
+    tt_model = TtTransformer(
+        device_mesh=t3k_device_mesh,
+        state_dict=state_dict,
+        args=model_args,
+        layers=list(range(model_args.n_layers)),
+        dtype=dtype,
+    )
+
+    # Select the first token from the prompts for initial decoding
+    pt_decode_input = embd(input_tokens_pt[:, 0]).view(batch, seqlen, -1)
+
+    for i in range(iterations):
+        logger.info(f"[Decode] Generating token {i}")
+
+        start_pos = generation_start_pos + i
+        current_pos = start_pos % model_args.sliding_window
+
+        decode_input, attn_mask = prepare_inputs_ttnn(
+            pt_decode_input,
+            model_args.dim,
+            start_pos,
+            model_args,
+            tt_model.device_mesh,
+        )
+
+        # Run TT model
+        tt_out = tt_model(decode_input, start_pos, current_pos, attn_mask)
+        # Convert ttnn tensor to torch tensor
+        tt_output_torch = (
+            ttnn.to_torch(tt_out, mesh_composer=ttnn.ConcatMeshToTensor(t3k_device_mesh, dim=0))[0]
+            .squeeze(1)
+            .view(batch, seqlen, -1)
+            .detach()
+            .float()
+        )
+
+        # Run reference model
+        positions = torch.LongTensor([start_pos])
+        ref_output = reference_model(pt_decode_input, positions).detach().float()
+
+        # Measure top-1 and top-5
+        reference_top1 = torch.argmax(ref_output, axis=-1)
+        top1_acc = top_k_accuracy_score(
+            reference_top1.squeeze(), tt_output_torch.squeeze(), k=1, labels=torch.arange(tt_output_torch.shape[-1])
+        )
+        top5_acc = top_k_accuracy_score(
+            reference_top1.squeeze(), tt_output_torch.squeeze(), k=5, labels=torch.arange(tt_output_torch.shape[-1])
+        )
+        running_top1 += top1_acc
+        running_top5 += top5_acc
+
+        # Prepare next input - teacher forcing (top-1), after initial prompts are done
+        if i < max_prompt_len:  # Check if user has finished initial prompt or not
+            reference_top1 = torch.where(input_mask_pt[:, i], input_tokens_pt[:, i], reference_top1[:, 0]).unsqueeze(1)
+        pt_decode_input = embd(reference_top1).view(batch, seqlen, -1)
+
+    # Validate accuracy metrics against the expected values
+    final_top1 = running_top1 / iterations
+    final_top5 = running_top5 / iterations
+    logger.info(f"Mean Top-1 accuracy: {final_top1:.4f}")
+    logger.info(f"Mean Top-5 accuracy: {final_top5:.4f}")
+
+    assert final_top1 >= expected_top1, f"Top-1 accuracy is lower than {expected_top1}"
+    assert final_top5 >= expected_top5, f"Top-5 accuracy is lower than {expected_top5}"

--- a/models/demos/t3000/mixtral8x7b/tt/mixtral_common.py
+++ b/models/demos/t3000/mixtral8x7b/tt/mixtral_common.py
@@ -7,11 +7,73 @@ import torch
 import ttnn
 from ttnn import ShardTensorToMesh, ConcatMeshToTensor, ReplicateTensorToMesh
 from models.utility_functions import nearest_32
+import json
 
 
 class LightweightModule:
     def __call__(self, *args, **kwargs):
         return self.forward(*args, **kwargs)
+
+
+# load from json, return as a list
+def load_inputs(user_input, batch):
+    if isinstance(user_input, str):
+        with open(user_input, "r") as f:
+            user_input = json.load(f)
+    assert len(user_input) >= batch, f"Number of users (batch) must be {batch}!"
+    in_prompt = []
+    for i in range(batch):
+        in_prompt.append(user_input[i]["prompt"])
+    return in_prompt
+
+
+def preprocess_inputs(input_prompts, tokenizer, model_args, dtype, instruct, device_mesh):
+    """
+    Run tokenizer on inputs, and create embeddings for the first token of each input
+    """
+    if instruct:
+        # Pre append [INST] and post append [/INST] to the encoded prompts if instruct mode
+        encoded_prompts = [tokenizer.encode("[INST] " + prompt + " [/INST]") for prompt in input_prompts]
+    else:
+        encoded_prompts = [tokenizer.encode(prompt) for prompt in input_prompts]
+
+    prompt_lens = [len(x) for x in encoded_prompts]
+
+    # Pad the inputs to the max length prompt
+    max_prompt_len = max(prompt_lens)
+    input_tokens = torch.full((len(input_prompts), max_prompt_len), tokenizer.pad_id, dtype=torch.int32)
+
+    logger.info(f"# of users: {len(encoded_prompts)}")
+    for i, encoded in enumerate(encoded_prompts):
+        # Right padding
+        input_tokens[i, : len(encoded)] = torch.tensor(encoded).to(input_tokens)
+
+    input_mask_bool = input_tokens != tokenizer.pad_id
+    input_mask = input_mask_bool.int()  # from_torch doesn't support bool type
+
+    # convert to ttnn tensor
+    # Encoded input tokens need to be uint32 for embedding. Otherwise the dtype conversion to bfloat16 will change the tokenizer ID
+    input_tokens_tt = [
+        ttnn.from_torch(
+            input_tokens[:, i].unsqueeze(0),
+            device=device_mesh,
+            dtype=ttnn.uint32,
+            layout=ttnn.ROW_MAJOR_LAYOUT,
+            mesh_mapper=ReplicateTensorToMesh(device_mesh),
+        )
+        for i in range(max_prompt_len)
+    ]
+    input_mask_tt = [
+        ttnn.from_torch(
+            input_mask[:, i].unsqueeze(0),
+            device=device_mesh,
+            dtype=ttnn.bfloat16,
+            layout=ttnn.ROW_MAJOR_LAYOUT,
+            mesh_mapper=ReplicateTensorToMesh(device_mesh),
+        )
+        for i in range(max_prompt_len)
+    ]
+    return input_tokens_tt, max_prompt_len, input_mask_tt, input_tokens, input_mask_bool
 
 
 def prepare_inputs_ttnn(x_bsh, hidden_size, current_pos, model_args, device_mesh):

--- a/tests/scripts/t3000/run_t3000_demo_tests.sh
+++ b/tests/scripts/t3000/run_t3000_demo_tests.sh
@@ -74,7 +74,7 @@ run_t3000_mixtral_tests() {
   echo "LOG_METAL: Running run_t3000_mixtral8x7b_tests"
 
   # mixtral8x7b 8 chip demo test - 100 token generation with general weights (env flags set inside the test)
-  pytest -n auto models/demos/t3000/mixtral8x7b/demo/demo.py::test_mixtral8x7b_demo[wormhole_b0-True-general_weights] --timeout=720 ; fail+=$?
+  pytest -n auto models/demos/t3000/mixtral8x7b/demo/demo.py --timeout=720 ; fail+=$?
 
   # Record the end time
   end_time=$(date +%s)

--- a/tests/scripts/t3000/run_t3000_frequent_tests.sh
+++ b/tests/scripts/t3000/run_t3000_frequent_tests.sh
@@ -50,7 +50,7 @@ run_t3000_mixtral_tests() {
   echo "LOG_METAL: Running run_t3000_mixtral_tests"
 
   # mixtral8x7b 8 chip decode model test (env flags set inside the test)
-  pytest -n auto models/demos/t3000/mixtral8x7b/tests/test_mixtral_model.py::test_mixtral_model_inference[wormhole_b0-True-10-1-pcc] ; fail+=$?
+  pytest -n auto models/demos/t3000/mixtral8x7b/tests/test_mixtral_model.py ; fail+=$?
 
   # Record the end time
   end_time=$(date +%s)


### PR DESCRIPTION
### Problem description
Mixtral8x7b was missing accuracy tests that helps us identify any regressions.

### What's changed
Add 3 new accuracy validations to Mixtral codebase:
- **Demo token matching** -> Runs the demo code and if in CI environment compares the output against an expected one and token matches. Asserts if any token is different. The expected output might need to be updated whenever there's a big change to metal that might affect accuracy.

- **Perplexity validation** -> Evaluates the perplexity metric for Mixtral against the wikitext dataset (currently only decode mode is supoorted). Additionally also evaluates top-1 and top-5 accuracy against the same dataset. This test takes a long time. It will be added to CI when the validation pipeline comes online.

- **Top-1 / Top-5 validation** -> Evaluates top-1 and top-5 accuracy based on the same input prompts used in demo. It compares the generated tokens from the ttnn model against the reference torch model.

### Additional changes:
- This PR also includes some Mixtral test cleanup, specifically the removal of specific tests from CI pipelines. Now CI only calls the main Mixtral test script and, when required, inside the mixtral tests we specify if it's a CI-only test or not.

- Cleaned the torch tensor deletion across the Mixtral codebase. This was a previous workaround we did for issue #7159 and it should be no longer needed.

### Checklist
- [x] Post commit CI passes: https://github.com/tenstorrent/tt-metal/actions/runs/9747999116
- [ ] Model regression CI testing passes (if applicable)
  - [x] [T3k unit tests](https://github.com/tenstorrent/tt-metal/actions/runs/9748173227)
  - [x] [T3k frequent tests](https://github.com/tenstorrent/tt-metal/actions/runs/9748168534) 
  - [x] [T3k model perf](https://github.com/tenstorrent/tt-metal/actions/runs/9765531429) Updated estimates
  - [x] [T3k Demo tests](https://github.com/tenstorrent/tt-metal/actions/runs/9775201989)
