### PR TITLE
Extend ssm_eltwise_mul for num_users > 32

### DIFF
--- a/tt_eager/tt_dnn/op_library/transformer_tms/kernels/compute/ssm_eltwise_mul.cpp
+++ b/tt_eager/tt_dnn/op_library/transformer_tms/kernels/compute/ssm_eltwise_mul.cpp
@@ -11,6 +11,7 @@
 namespace NAMESPACE {
 void MAIN {
     uint32_t in1_num_blocks = get_arg_val<uint32_t>(0);
+    uint32_t in1_num_blocks_h = get_arg_val<uint32_t>(1);
 
     constexpr uint32_t cb_id_in0 = get_compile_time_arg_val(0);
     constexpr uint32_t cb_id_in1 = get_compile_time_arg_val(1);
@@ -29,29 +30,31 @@ void MAIN {
     binary_op_init_common(cb_id_in0, cb_id_in1);
 #endif
 
+for(uint32_t block_h_id = 0; block_h_id < in1_num_blocks_h; block_h_id++){
+
 #ifdef REPEAT_IN0
     // Transpose in0
     cb_wait_front(cb_id_in0, onetile);
-// No need to transpose in0 if in1 is not repeat_interleaved
-#ifdef REPEAT_INTERLEAVE_IN1
-    tile_regs_acquire();
-    tile_regs_wait();
+    // No need to transpose in0 if in1 is not repeat_interleaved
+    #ifdef REPEAT_INTERLEAVE_IN1
+        tile_regs_acquire();
+        tile_regs_wait();
 
-    transpose_wh_init_short(cb_id_in0);
-    unpack_reconfig_data_format_srca(cb_out_transposed, cb_id_in0);
-    pack_reconfig_data_format(cb_id_out, cb_in0_transposed);
-    transpose_wh_tile(cb_id_in0, 0, 0);
+        transpose_wh_init_short(cb_id_in0);
+        unpack_reconfig_data_format_srca(cb_out_transposed, cb_id_in0);
+        pack_reconfig_data_format(cb_id_out, cb_in0_transposed);
+        transpose_wh_tile(cb_id_in0, 0, 0);
 
-    cb_reserve_back(cb_in0_transposed, onetile);
-    pack_tile(0, cb_in0_transposed);
+        cb_reserve_back(cb_in0_transposed, onetile);
+        pack_tile(0, cb_in0_transposed);
 
-    tile_regs_commit();
-    tile_regs_release();
-    cb_push_back(cb_in0_transposed, onetile);
-    cb_pop_front(cb_id_in0, onetile);
+        tile_regs_commit();
+        tile_regs_release();
+        cb_push_back(cb_in0_transposed, onetile);
+        cb_pop_front(cb_id_in0, onetile);
 
-    cb_wait_front(cb_in0_transposed, onetile);
-#endif
+        cb_wait_front(cb_in0_transposed, onetile);
+    #endif
 #endif
 
     for (uint32_t in1_block = 0; in1_block < in1_num_blocks; in1_block++) {
@@ -180,5 +183,6 @@ void MAIN {
     cb_pop_front(cb_id_in0, onetile);
 #endif
 #endif
+}
 }
 }  // namespace NAMESPACE

--- a/tt_eager/tt_dnn/op_library/transformer_tms/kernels/dataflow/reader_ssm_eltwise_mul.cpp
+++ b/tt_eager/tt_dnn/op_library/transformer_tms/kernels/dataflow/reader_ssm_eltwise_mul.cpp
@@ -10,6 +10,9 @@ void kernel_main() {
     uint32_t src1_addr  = get_arg_val<uint32_t>(1);
     uint32_t in1_num_blocks = get_arg_val<uint32_t>(2);
     uint32_t in1_start_id = get_arg_val<uint32_t>(3);
+    uint32_t in1_num_blocks_h = get_arg_val<uint32_t>(4);
+    uint32_t in1_num_blocks_w = get_arg_val<uint32_t>(5);
+    uint32_t in0_num_blocks_w = get_arg_val<uint32_t>(6);
 
     constexpr uint32_t cb_id_in0 = get_compile_time_arg_val(0);
     constexpr uint32_t cb_id_in1 = get_compile_time_arg_val(1);
@@ -44,74 +47,76 @@ void kernel_main() {
     constexpr uint32_t bfloat16_one_row_in_face_bytes = 32;
     constexpr uint32_t in0_blocks_per_in1_block = 32;
 
-    #ifdef REPEAT_IN0
-        // in0 only has one tile and read in only once
-        cb_reserve_back(cb_id_in0, onetile);
-        l1_write_addr_in0 = get_write_ptr(cb_id_in0);
-        noc_async_read_tile(0, s0, l1_write_addr_in0);
-        noc_async_read_barrier();
-        cb_push_back(cb_id_in0, onetile);
-    #endif
-
-    for (uint32_t i = in1_start_id; i < in1_start_id + in1_num_blocks; i++) {
-        cb_reserve_back(cb_id_in1, onetile);
-        l1_write_addr_in1 = get_write_ptr(cb_id_in1);
-        noc_async_read_tile(i, s1, l1_write_addr_in1);
-
-        noc_async_read_barrier();
-        cb_push_back(cb_id_in1, onetile);
-
-        #ifdef REPEAT_INTERLEAVE_IN1
-            cb_wait_front(cb_in1_transposed, onetile);
-            uint64_t cb_in1_transposed_read_ptr = get_noc_addr(get_read_ptr(cb_in1_transposed));
-
-            // Manually unroll iterating across the tile to eliminate unncessary conditional checking
-            // First + second face
-            for (uint32_t tile_row_id = 0; tile_row_id < num_rows_in_face; tile_row_id++) {
-                cb_reserve_back(cb_in1_bcast_row, onetile);
-                uint32_t cb_in1_bcast_row_write_ptr = get_write_ptr(cb_in1_bcast_row);
-
-                #ifndef REPEAT_IN0
-                    cb_reserve_back(cb_id_in0, onetile);
-                    l1_write_addr_in0 = get_write_ptr(cb_id_in0);
-                    noc_async_read_tile(i * in0_blocks_per_in1_block + tile_row_id, s0, l1_write_addr_in0);
-                #endif
-                noc_async_read(cb_in1_transposed_read_ptr, cb_in1_bcast_row_write_ptr, bfloat16_one_row_in_face_bytes);
-                noc_async_read(cb_in1_transposed_read_ptr + bfloat16_one_face_bytes, cb_in1_bcast_row_write_ptr + bfloat16_one_face_bytes, bfloat16_one_row_in_face_bytes);
-                noc_async_read_barrier();
-
-                #ifndef REPEAT_IN0
-                    cb_push_back(cb_id_in0, onetile);
-                #endif
-                cb_push_back(cb_in1_bcast_row, onetile);
-
-                cb_in1_transposed_read_ptr += bfloat16_one_row_in_face_bytes;
-            }
-
-            cb_in1_transposed_read_ptr += bfloat16_one_face_bytes;
-            // Third + fourth face
-            for (uint32_t tile_row_id = num_rows_in_face; tile_row_id < 2*num_rows_in_face; tile_row_id++) {
-                cb_reserve_back(cb_in1_bcast_row, onetile);
-                uint32_t cb_in1_bcast_row_write_ptr = get_write_ptr(cb_in1_bcast_row);
-
-                #ifndef REPEAT_IN0
-                    cb_reserve_back(cb_id_in0, onetile);
-                    l1_write_addr_in0 = get_write_ptr(cb_id_in0);
-                    noc_async_read_tile(i * in0_blocks_per_in1_block + tile_row_id, s0, l1_write_addr_in0);
-                #endif
-                noc_async_read(cb_in1_transposed_read_ptr, cb_in1_bcast_row_write_ptr, bfloat16_one_row_in_face_bytes);
-                noc_async_read(cb_in1_transposed_read_ptr + bfloat16_one_face_bytes, cb_in1_bcast_row_write_ptr + bfloat16_one_face_bytes, bfloat16_one_row_in_face_bytes);
-                noc_async_read_barrier();
-
-                #ifndef REPEAT_IN0
-                    cb_push_back(cb_id_in0, onetile);
-                #endif
-                cb_push_back(cb_in1_bcast_row, onetile);
-
-                cb_in1_transposed_read_ptr += bfloat16_one_row_in_face_bytes;
-            }
-            cb_pop_front(cb_in1_transposed, onetile);
-
+    for(uint32_t block_h_id = 0; block_h_id < in1_num_blocks_h; block_h_id++){
+        #ifdef REPEAT_IN0
+            // in0 only has one tile and read in only once
+            cb_reserve_back(cb_id_in0, onetile);
+            l1_write_addr_in0 = get_write_ptr(cb_id_in0);
+            noc_async_read_tile(block_h_id, s0, l1_write_addr_in0);
+            noc_async_read_barrier();
+            cb_push_back(cb_id_in0, onetile);
         #endif
+
+        for (uint32_t i = in1_start_id; i < in1_start_id + in1_num_blocks; i++) {
+            cb_reserve_back(cb_id_in1, onetile);
+            l1_write_addr_in1 = get_write_ptr(cb_id_in1);
+            noc_async_read_tile(block_h_id*in1_num_blocks_w + i, s1, l1_write_addr_in1);
+
+            noc_async_read_barrier();
+            cb_push_back(cb_id_in1, onetile);
+
+            #ifdef REPEAT_INTERLEAVE_IN1
+                cb_wait_front(cb_in1_transposed, onetile);
+                uint64_t cb_in1_transposed_read_ptr = get_noc_addr(get_read_ptr(cb_in1_transposed));
+
+                // Manually unroll iterating across the tile to eliminate unncessary conditional checking
+                // First + second face
+                for (uint32_t tile_row_id = 0; tile_row_id < num_rows_in_face; tile_row_id++) {
+                    cb_reserve_back(cb_in1_bcast_row, onetile);
+                    uint32_t cb_in1_bcast_row_write_ptr = get_write_ptr(cb_in1_bcast_row);
+
+                    #ifndef REPEAT_IN0
+                        cb_reserve_back(cb_id_in0, onetile);
+                        l1_write_addr_in0 = get_write_ptr(cb_id_in0);
+                        noc_async_read_tile(block_h_id*in0_num_blocks_w + (i * in0_blocks_per_in1_block + tile_row_id), s0, l1_write_addr_in0);
+                    #endif
+                    noc_async_read(cb_in1_transposed_read_ptr, cb_in1_bcast_row_write_ptr, bfloat16_one_row_in_face_bytes);
+                    noc_async_read(cb_in1_transposed_read_ptr + bfloat16_one_face_bytes, cb_in1_bcast_row_write_ptr + bfloat16_one_face_bytes, bfloat16_one_row_in_face_bytes);
+                    noc_async_read_barrier();
+
+                    #ifndef REPEAT_IN0
+                        cb_push_back(cb_id_in0, onetile);
+                    #endif
+                    cb_push_back(cb_in1_bcast_row, onetile);
+
+                    cb_in1_transposed_read_ptr += bfloat16_one_row_in_face_bytes;
+                }
+
+                cb_in1_transposed_read_ptr += bfloat16_one_face_bytes;
+                // Third + fourth face
+                for (uint32_t tile_row_id = num_rows_in_face; tile_row_id < 2*num_rows_in_face; tile_row_id++) {
+                    cb_reserve_back(cb_in1_bcast_row, onetile);
+                    uint32_t cb_in1_bcast_row_write_ptr = get_write_ptr(cb_in1_bcast_row);
+
+                    #ifndef REPEAT_IN0
+                        cb_reserve_back(cb_id_in0, onetile);
+                        l1_write_addr_in0 = get_write_ptr(cb_id_in0);
+                        noc_async_read_tile(block_h_id*5120 + (i * in0_blocks_per_in1_block + tile_row_id), s0, l1_write_addr_in0);
+                    #endif
+                    noc_async_read(cb_in1_transposed_read_ptr, cb_in1_bcast_row_write_ptr, bfloat16_one_row_in_face_bytes);
+                    noc_async_read(cb_in1_transposed_read_ptr + bfloat16_one_face_bytes, cb_in1_bcast_row_write_ptr + bfloat16_one_face_bytes, bfloat16_one_row_in_face_bytes);
+                    noc_async_read_barrier();
+
+                    #ifndef REPEAT_IN0
+                        cb_push_back(cb_id_in0, onetile);
+                    #endif
+                    cb_push_back(cb_in1_bcast_row, onetile);
+
+                    cb_in1_transposed_read_ptr += bfloat16_one_row_in_face_bytes;
+                }
+                cb_pop_front(cb_in1_transposed, onetile);
+
+            #endif
+        }
     }
 }

--- a/tt_eager/tt_dnn/op_library/transformer_tms/kernels/dataflow/writer_ssm_eltwise_mul.cpp
+++ b/tt_eager/tt_dnn/op_library/transformer_tms/kernels/dataflow/writer_ssm_eltwise_mul.cpp
@@ -1,0 +1,40 @@
+// SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "dataflow_api.h"
+
+void kernel_main() {
+    uint32_t dst_addr  = get_arg_val<uint32_t>(0);
+    uint32_t out_num_blocks_w_per_core = get_arg_val<uint32_t>(1);
+    uint32_t start_id = get_arg_val<uint32_t>(2);
+    uint32_t out_num_blocks_h = get_arg_val<uint32_t>(3);
+    uint32_t out_total_blocks_w = get_arg_val<uint32_t>(4);
+
+
+    constexpr uint32_t cb_id_out = get_compile_time_arg_val(0);
+    constexpr bool dst_is_dram = get_compile_time_arg_val(1) == 1;
+
+
+    // single-tile ublocks
+    constexpr uint32_t onetile = 1;
+    const uint32_t tile_bytes = get_tile_size(cb_id_out);
+    const DataFormat data_format = get_dataformat(cb_id_out);
+
+    const InterleavedAddrGenFast<dst_is_dram> s = {
+        .bank_base_address = dst_addr,
+        .page_size = tile_bytes,
+        .data_format = data_format
+    };
+
+    for(uint32_t block_h_id = 0; block_h_id < out_num_blocks_h; block_h_id++){
+        uint32_t end_id = start_id + out_num_blocks_w_per_core;
+        for (uint32_t i = start_id; i < end_id; ++ i) {
+            cb_wait_front(cb_id_out, onetile);
+            uint32_t l1_read_addr = get_read_ptr(cb_id_out);
+            noc_async_write_tile((block_h_id * out_total_blocks_w) + i, s, l1_read_addr);
+            noc_async_write_barrier();
+            cb_pop_front(cb_id_out, onetile);
+        }
+    }
+}

--- a/tt_eager/tt_dnn/op_library/transformer_tms/transformer_tms.cpp
+++ b/tt_eager/tt_dnn/op_library/transformer_tms/transformer_tms.cpp
@@ -562,8 +562,9 @@ void SSMEltwiseMul::validate(const std::vector<Tensor>& input_tensors) const {
     const auto bshape = input_tensor_b.get_legacy_shape();
     TT_FATAL((ashape[0] == 1 and ashape[1] == 1), "Batch not supported for input a!");
     TT_FATAL((bshape[0] == 1 and bshape[1] == 1), "Batch not supported for input b!");
-    TT_FATAL((ashape[2] == TILE_HEIGHT), "Num of users must be 32 for input a!");
-    TT_FATAL((bshape[2] == TILE_HEIGHT), "Num of users must be 32 for input b!");
+    TT_FATAL((ashape[2] % TILE_HEIGHT == 0), "Num of users must be multiple of 32 for input a!");
+    TT_FATAL((bshape[2] % TILE_HEIGHT == 0), "Num of users must be multiple of 32 for input b!");
+    TT_FATAL((ashape[2] == bshape[2]), "Num of users must match in both of the input!");
     TT_FATAL((ashape[3] != bshape[3]), "Use eltwise mul for same size inputs!");
     TT_FATAL(
         (ashape[3] == TILE_WIDTH || ashape[3] == TILE_WIDTH * HIDDEN_SIZE), "Input a width must be 32 or 32*5120!");


### PR DESCRIPTION
### Ticket
This is a follow-on work upon this [PR](https://github.com/tenstorrent/tt-metal/pull/8108)
### Problem description
In previous implementation of `ssm_eltwise_mul`, we assumed batch_size/users will always be 32 (Tile Height).
However, in prefill model we are utilizing this batch dimension with sequence length and would like have support for seq_len = [32, 64, 128 or larger].
### What's changed
We used to same design of the reader, compute, and writer kernel. Although now since B>32, there is an extra dimension getting added along the input height. We compute this new data by looping along the input/output height blocks.
In future, the design of the kernel can be simplified by sharding the data.

### Checklist
- [x] Post commit CI passes
- [x] Model regression CI testing passes (if applicable)
- [x] New/Existing tests provide coverage for changes
