### PR TITLE
#9815: Update host to pass packed write max unicast sub cmds to cq dispatch

### DIFF
--- a/tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/test_dispatcher.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/test_dispatcher.cpp
@@ -382,6 +382,8 @@ int main(int argc, char **argv) {
         CoreCoord phys_spoof_prefetch_core = device->worker_core_from_logical_core(spoof_prefetch_core);
         CoreCoord phys_dispatch_core = device->worker_core_from_logical_core(dispatch_core);
 
+        uint32_t num_compute_cores = device->compute_with_storage_grid_size().x * device->compute_with_storage_grid_size().y;
+
         // Want different buffers on each core, instead use big buffer and self-manage it
         uint32_t l1_buf_base = align(DISPATCH_L1_UNRESERVED_BASE, dispatch_buffer_page_size_g);
         TT_ASSERT((l1_buf_base & (dispatch_buffer_page_size_g - 1)) == 0);
@@ -466,8 +468,9 @@ int main(int argc, char **argv) {
              0,    // prefetch noc_xy
              0,    // prefetch_local_downstream_sem_addr
              0,    // prefetch_downstream_buffer_pages
+             num_compute_cores, // max_write_packed_cores
              true, // is_dram_variant
-             true, // is_host_variant
+             true // is_host_variant
             };
         std::vector<uint32_t> spoof_prefetch_compile_args =
             {l1_buf_base,

--- a/tt_metal/impl/dispatch/command_queue.cpp
+++ b/tt_metal/impl/dispatch/command_queue.cpp
@@ -281,6 +281,10 @@ void EnqueueWriteBufferCommand::process() {
     this->manager.fetch_queue_write(cmd_sequence_sizeB, this->command_queue_id);
 }
 
+inline uint32_t get_packed_write_max_unicast_sub_cmds(Device *device) {
+    return uint32_t(device->compute_with_storage_grid_size().x * device->compute_with_storage_grid_size().y);
+}
+
 // EnqueueProgramCommand Section
 
 EnqueueProgramCommand::EnqueueProgramCommand(
@@ -299,6 +303,7 @@ EnqueueProgramCommand::EnqueueProgramCommand(
     dispatch_core(dispatch_core) {
     this->device = device;
     this->dispatch_core_type = dispatch_core_manager::get(device->num_hw_cqs()).get_dispatch_core_type(device->id());
+    this->packed_write_max_unicast_sub_cmds = get_packed_write_max_unicast_sub_cmds(this->device);
 }
 
 void EnqueueProgramCommand::assemble_preamble_commands(bool prefetch_stall) {
@@ -333,7 +338,7 @@ void EnqueueProgramCommand::assemble_preamble_commands(bool prefetch_stall) {
 }
 
 template <typename PackedSubCmd>
-uint32_t get_max_write_packed_sub_cmds(uint32_t data_size, uint32_t max_prefetch_cmd_size, bool no_stride) {
+uint32_t get_max_write_packed_sub_cmds(uint32_t data_size, uint32_t max_prefetch_cmd_size, uint32_t packed_write_max_unicast_sub_cmds, bool no_stride) {
     static_assert(
         std::is_same<PackedSubCmd, CQDispatchWritePackedUnicastSubCmd>::value or
         std::is_same<PackedSubCmd, CQDispatchWritePackedMulticastSubCmd>::value);
@@ -346,10 +351,11 @@ uint32_t get_max_write_packed_sub_cmds(uint32_t data_size, uint32_t max_prefetch
     uint32_t max_prefetch_num_packed_cmds =
         no_stride ? (max_prefetch_size - align(data_size * sizeof(uint32_t), L1_ALIGNMENT)) / sub_cmd_sizeB
                   : max_prefetch_size / (align(data_size * sizeof(uint32_t), L1_ALIGNMENT) + sub_cmd_sizeB);
+
+    uint32_t packed_write_max_multicast_sub_cmds = get_packed_write_max_multicast_sub_cmds(packed_write_max_unicast_sub_cmds);
     return min(
         max_prefetch_num_packed_cmds,
-        is_unicast ? CQ_DISPATCH_CMD_PACKED_WRITE_MAX_UNICAST_SUB_CMDS
-                   : CQ_DISPATCH_CMD_PACKED_WRITE_MAX_MULTICAST_SUB_CMDS);
+        is_unicast ? packed_write_max_unicast_sub_cmds : packed_write_max_multicast_sub_cmds);
 };
 
 template <typename PackedSubCmd>
@@ -357,10 +363,11 @@ uint32_t insert_write_packed_payloads(
     const uint32_t num_sub_cmds,
     const uint32_t sub_cmd_sizeB,
     const uint32_t max_prefetch_command_size,
+    const uint32_t packed_write_max_unicast_sub_cmds,
     std::vector<std::pair<uint32_t, uint32_t>>& packed_cmd_payloads) {
     const uint32_t aligned_sub_cmd_sizeB = align(sub_cmd_sizeB, L1_ALIGNMENT);
     const uint32_t max_packed_sub_cmds_per_cmd =
-        get_max_write_packed_sub_cmds<PackedSubCmd>(aligned_sub_cmd_sizeB, max_prefetch_command_size, false);
+        get_max_write_packed_sub_cmds<PackedSubCmd>(aligned_sub_cmd_sizeB, max_prefetch_command_size, packed_write_max_unicast_sub_cmds, false);
     uint32_t rem_num_sub_cmds = num_sub_cmds;
     uint32_t cmd_payload_sizeB = 0;
     while (rem_num_sub_cmds != 0) {
@@ -384,6 +391,7 @@ void generate_runtime_args_cmds(
     const uint32_t& max_runtime_args_len,
     std::vector<std::reference_wrapper<RuntimeArgsData>>& rt_args_data,
     const uint32_t max_prefetch_command_size,
+    const uint32_t packed_write_max_unicast_sub_cmds,
     const uint32_t id,
     bool no_stride = false) {
     static_assert(
@@ -411,7 +419,7 @@ void generate_runtime_args_cmds(
 
     uint32_t num_packed_cmds_in_seq = sub_cmds.size();
     uint32_t max_packed_cmds =
-        get_max_write_packed_sub_cmds<PackedSubCmd>(max_runtime_args_len, max_prefetch_command_size, no_stride);
+        get_max_write_packed_sub_cmds<PackedSubCmd>(max_runtime_args_len, max_prefetch_command_size, packed_write_max_unicast_sub_cmds, no_stride);
     uint32_t offset_idx = 0;
     if (no_stride) {
         TT_FATAL(max_packed_cmds >= num_packed_cmds_in_seq);
@@ -429,6 +437,7 @@ void generate_runtime_args_cmds(
             rt_payload_sizeB,
             sub_cmds,
             rt_data_and_sizes,
+            packed_write_max_unicast_sub_cmds,
             offset_idx,
             no_stride);
         uint32_t data_offset = (uint32_t)get_runtime_args_data_offset(num_packed_cmds, max_runtime_args_len, unicast);
@@ -570,6 +579,7 @@ void EnqueueProgramCommand::assemble_runtime_args_commands() {
             unique_max_runtime_args_len[processor_idx],
             unique_rt_args_data[processor_idx],
             max_prefetch_command_size,
+            packed_write_max_unicast_sub_cmds,
             processor_idx,
             false);
     }
@@ -584,6 +594,7 @@ void EnqueueProgramCommand::assemble_runtime_args_commands() {
                     common_max_runtime_args_len[kernel_id],
                     common_rt_args_data[kernel_id],
                     max_prefetch_command_size,
+                    packed_write_max_unicast_sub_cmds,
                     kernel_id,
                     true);
             },
@@ -704,7 +715,7 @@ void EnqueueProgramCommand::assemble_device_commands() {
                 (max_overall_base_index + UINT32_WORDS_PER_CIRCULAR_BUFFER_CONFIG) * sizeof(uint32_t);
             aligned_cb_config_size_bytes = align(cb_config_size_bytes, L1_ALIGNMENT);
             cmd_sequence_sizeB += insert_write_packed_payloads<CQDispatchWritePackedMulticastSubCmd>(
-                num_multicast_cb_sub_cmds, cb_config_size_bytes, max_prefetch_command_size, mcast_cb_payload);
+                num_multicast_cb_sub_cmds, cb_config_size_bytes, max_prefetch_command_size, this->packed_write_max_unicast_sub_cmds, mcast_cb_payload);
         }
 
         // Program Binaries and Go Signals
@@ -861,6 +872,7 @@ void EnqueueProgramCommand::assemble_device_commands() {
                 multicast_go_signal_sub_cmds.size(),
                 go_signal_sizeB,
                 max_prefetch_command_size,
+                this->packed_write_max_unicast_sub_cmds,
                 multicast_go_signals_payload);
         }
 
@@ -886,6 +898,7 @@ void EnqueueProgramCommand::assemble_device_commands() {
                 unicast_go_signal_sub_cmds.size(),
                 go_signal_sizeB,
                 max_prefetch_command_size,
+                this->packed_write_max_unicast_sub_cmds,
                 unicast_go_signals_payload);
         }
 
@@ -920,7 +933,7 @@ void EnqueueProgramCommand::assemble_device_commands() {
             uint32_t payload_sizeB = dispatch_cmd_sizeB + aligned_semaphore_data_sizeB;
 
             program_command_sequence.add_dispatch_write_packed<CQDispatchWritePackedMulticastSubCmd>(
-                num_packed_cmds, dst, write_packed_len * sizeof(uint32_t), payload_sizeB, multicast_sub_cmds, sem_data);
+                num_packed_cmds, dst, write_packed_len * sizeof(uint32_t), payload_sizeB, multicast_sub_cmds, sem_data, this->packed_write_max_unicast_sub_cmds);
         }
 
         // Unicast Semaphore Cmd
@@ -949,7 +962,7 @@ void EnqueueProgramCommand::assemble_device_commands() {
             uint32_t payload_sizeB = dispatch_cmd_sizeB + aligned_semaphore_data_sizeB;
 
             program_command_sequence.add_dispatch_write_packed<CQDispatchWritePackedUnicastSubCmd>(
-                num_packed_cmds, dst, write_packed_len * sizeof(uint32_t), payload_sizeB, unicast_sub_cmds, sem_data);
+                num_packed_cmds, dst, write_packed_len * sizeof(uint32_t), payload_sizeB, unicast_sub_cmds, sem_data, this->packed_write_max_unicast_sub_cmds);
         }
 
         // CB Configs commands
@@ -966,6 +979,7 @@ void EnqueueProgramCommand::assemble_device_commands() {
                     mcast_cb_payload_sizeB,
                     multicast_cb_config_sub_cmds,
                     multicast_cb_config_data,
+                    this->packed_write_max_unicast_sub_cmds,
                     curr_sub_cmd_idx);
                 curr_sub_cmd_idx += num_sub_cmds_in_cmd;
                 uint32_t curr_sub_cmd_data_offset_words =
@@ -1015,6 +1029,7 @@ void EnqueueProgramCommand::assemble_device_commands() {
                     multicast_go_signal_payload_sizeB,
                     multicast_go_signal_sub_cmds,
                     multicast_go_signal_data,
+                    this->packed_write_max_unicast_sub_cmds,
                     curr_sub_cmd_idx);
                 curr_sub_cmd_idx += num_sub_cmds_in_cmd;
                 uint32_t curr_sub_cmd_data_offset_words =
@@ -1040,6 +1055,7 @@ void EnqueueProgramCommand::assemble_device_commands() {
                     unicast_go_signal_payload_sizeB,
                     unicast_go_signal_sub_cmds,
                     unicast_go_signal_data,
+                    this->packed_write_max_unicast_sub_cmds,
                     curr_sub_cmd_idx);
                 curr_sub_cmd_idx += num_sub_cmds_in_cmd;
                 uint32_t curr_sub_cmd_data_offset_words =
@@ -1238,13 +1254,15 @@ void EnqueueRecordEventCommand::process() {
     }
 
     uint32_t address = this->command_queue_id == 0 ? CQ0_COMPLETION_LAST_EVENT : CQ1_COMPLETION_LAST_EVENT;
+    const uint32_t packed_write_max_unicast_sub_cmds = get_packed_write_max_unicast_sub_cmds(this->device);
     command_sequence.add_dispatch_write_packed<CQDispatchWritePackedUnicastSubCmd>(
         num_hw_cqs,
         address,
         dispatch_constants::EVENT_PADDED_SIZE,
         packed_event_payload_sizeB,
         unicast_sub_cmds,
-        event_payloads);
+        event_payloads,
+        packed_write_max_unicast_sub_cmds);
 
     bool flush_prefetch = true;
     command_sequence.add_dispatch_write_host<true>(

--- a/tt_metal/impl/dispatch/command_queue.hpp
+++ b/tt_metal/impl/dispatch/command_queue.hpp
@@ -297,6 +297,7 @@ class EnqueueProgramCommand : public Command {
     CoreCoord dispatch_core;
     CoreType dispatch_core_type;
     uint32_t expected_num_workers_completed;
+    uint32_t packed_write_max_unicast_sub_cmds;
 
    public:
     struct CachedProgramCommandSequence {

--- a/tt_metal/impl/dispatch/cq_commands.hpp
+++ b/tt_metal/impl/dispatch/cq_commands.hpp
@@ -181,15 +181,17 @@ struct CQDispatchWritePackedMulticastSubCmd {
     uint32_t num_mcast_dests;
 } __attribute__((packed));
 
-constexpr uint32_t CQ_DISPATCH_CMD_PACKED_WRITE_MAX_UNICAST_SUB_CMDS = 108;  // GS 120 - 1 row TODO: this should be a compile time arg passed in from host
-constexpr uint32_t CQ_DISPATCH_CMD_PACKED_WRITE_MAX_MULTICAST_SUB_CMDS = CQ_DISPATCH_CMD_PACKED_WRITE_MAX_UNICAST_SUB_CMDS * sizeof(CQDispatchWritePackedUnicastSubCmd) / sizeof(CQDispatchWritePackedMulticastSubCmd);
-
 struct CQDispatchWritePackedLargeSubCmd {
     uint32_t noc_xy_addr;
     uint32_t addr;
     uint16_t length;          // multiples of L1 cache line alignment
     uint16_t num_mcast_dests;
 } __attribute__((packed));
+
+inline __attribute__((always_inline)) uint32_t get_packed_write_max_multicast_sub_cmds(uint32_t packed_write_max_unicast_sub_cmds) {
+    uint32_t packed_write_max_multicast_sub_cmds = packed_write_max_unicast_sub_cmds * sizeof(CQDispatchWritePackedUnicastSubCmd) / sizeof(CQDispatchWritePackedMulticastSubCmd);
+    return packed_write_max_multicast_sub_cmds;
+}
 
 // Current implementation limit is based on size of the l1_cache which stores the sub_cmds
 constexpr uint32_t CQ_DISPATCH_CMD_PACKED_WRITE_LARGE_MAX_SUB_CMDS = 35;

--- a/tt_metal/impl/dispatch/device_command.hpp
+++ b/tt_metal/impl/dispatch/device_command.hpp
@@ -402,6 +402,7 @@ class DeviceCommand {
         uint32_t payload_sizeB,
         const std::vector<PackedSubCmd> &sub_cmds,
         const std::vector<std::pair<const void *, uint32_t>> &data_collection,
+        uint32_t packed_write_max_unicast_sub_cmds,
         const uint32_t offset_idx = 0,
         const bool no_stride = false) {
         static_assert(
@@ -409,7 +410,8 @@ class DeviceCommand {
             std::is_same<PackedSubCmd, CQDispatchWritePackedMulticastSubCmd>::value);
         bool multicast = std::is_same<PackedSubCmd, CQDispatchWritePackedMulticastSubCmd>::value;
 
-        constexpr uint32_t max_num_packed_sub_cmds = std::is_same<PackedSubCmd, CQDispatchWritePackedUnicastSubCmd>::value ? CQ_DISPATCH_CMD_PACKED_WRITE_MAX_UNICAST_SUB_CMDS : CQ_DISPATCH_CMD_PACKED_WRITE_MAX_MULTICAST_SUB_CMDS;
+        uint32_t packed_write_max_multicast_sub_cmds = get_packed_write_max_multicast_sub_cmds(packed_write_max_unicast_sub_cmds);
+        uint32_t max_num_packed_sub_cmds = std::is_same<PackedSubCmd, CQDispatchWritePackedUnicastSubCmd>::value ? packed_write_max_unicast_sub_cmds : packed_write_max_multicast_sub_cmds;
         TT_FATAL(
             num_sub_cmds <= max_num_packed_sub_cmds,
             "Max number of packed sub commands are {} but requesting {}",

--- a/tt_metal/impl/dispatch/dispatch_core_manager.hpp
+++ b/tt_metal/impl/dispatch/dispatch_core_manager.hpp
@@ -56,6 +56,7 @@ struct worker_build_settings_t{
     uint32_t cb_log_page_size;
     uint32_t cb_pages;
     uint32_t tunnel_stop;
+    uint32_t num_compute_cores;
 };
 
 // std::optional is used to determine whether core has been assigned


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/9815

### Problem description
`CQ_DISPATCH_CMD_PACKED_WRITE_MAX_UNICAST_SUB_CMDS` was hardcoded to 108 

### What's changed
Pass `CQ_DISPATCH_CMD_PACKED_WRITE_MAX_UNICAST_SUB_CMDS` as compile time arg to cq_dispatch and set it to num compute cores

### Checklist
- [x] [Post commit CI](https://github.com/tenstorrent/tt-metal/actions/runs/9754688545) first run failed but [re-running](https://github.com/tenstorrent/tt-metal/actions/runs/9762277266) passes
       - failure is seen on main (https://github.com/tenstorrent/tt-metal/actions/runs/9779145192/job/26998035540)
- [x] [Model regression CI testing passes](https://github.com/tenstorrent/tt-metal/actions/runs/9754689934)
