### PR TITLE
#9861: support check_tensor helper_function

### DIFF
--- a/tt_eager/tt_dnn/op_library/fast_reduce_nc/fast_reduce_nc_op.cpp
+++ b/tt_eager/tt_dnn/op_library/fast_reduce_nc/fast_reduce_nc_op.cpp
@@ -6,6 +6,7 @@
 
 #include <numeric>
 
+#include "tt_eager/tt_dnn/op_library/moreh_helper_functions.hpp"
 #include "tt_dnn/op_library/reduce/reduce_op.hpp"
 #include "tensor/tensor.hpp"
 #include "tt_metal/common/constants.hpp"
@@ -19,28 +20,6 @@ namespace tt_metal {
 //                         FastReduceNC
 ////////////////////////////////////////////////////////////////////////////
 namespace {
-    inline void check_tensor(
-        const Tensor& tensor,
-        const std::string& op_name,
-        Layout layout = Layout::TILE) {
-        TT_FATAL(tensor.get_layout() == layout, "{} only supports tiled layout.", op_name);
-        TT_FATAL(tensor.get_dtype() == DataType::BFLOAT16 || tensor.get_dtype() == DataType::BFLOAT8_B, "{} only supports data type {} and {}.", DataType::BFLOAT16, DataType::BFLOAT8_B);
-        TT_FATAL(
-            tensor.storage_type() == StorageType::DEVICE, "Operands to {} need to be on device!", op_name);
-        TT_FATAL(
-            tensor.buffer() != nullptr, "Operands to {} need to be allocated in buffers on device!", op_name);
-    }
-
-inline void check_tensor(
-    std::optional<Tensor> tensor,
-    const std::string& op_name,
-    tt_metal::DataType data_type = DataType::BFLOAT16,
-    Layout layout = Layout::TILE) {
-    if (!tensor.has_value()) {
-        return;
-    }
-    check_tensor(tensor.value(), op_name, data_type, layout);
-}
 
 Tensor _fast_reduce_nc(
     const Tensor& input,
@@ -79,8 +58,8 @@ void FastReduceNC::validate_with_output_tensors(
     auto& output = output_tensors.at(0);
 
     // validate tensor
-    check_tensor(input, "input");
-    check_tensor(output, "output");
+    tt::operations::primary::check_tensor(input, "FastReduceNC", "input");
+    tt::operations::primary::check_tensor(output, "FastReduceNC", "output");
 
     // validate input dim
     auto input_shape = input.get_legacy_shape();

--- a/tt_eager/tt_dnn/op_library/fast_reduce_nc/fast_reduce_nc_op.cpp
+++ b/tt_eager/tt_dnn/op_library/fast_reduce_nc/fast_reduce_nc_op.cpp
@@ -58,8 +58,8 @@ void FastReduceNC::validate_with_output_tensors(
     auto& output = output_tensors.at(0);
 
     // validate tensor
-    tt::operations::primary::check_tensor(input, "FastReduceNC", "input");
-    tt::operations::primary::check_tensor(output, "FastReduceNC", "output");
+    tt::operations::primary::check_tensor(input, "FastReduceNC", "input", {DataType::BFLOAT16, DataType::BFLOAT8_B});
+    tt::operations::primary::check_tensor(output, "FastReduceNC", "output", {DataType::BFLOAT16, DataType::BFLOAT8_B});
 
     // validate input dim
     auto input_shape = input.get_legacy_shape();

--- a/tt_eager/tt_dnn/op_library/moreh_adam/moreh_adam_op.cpp
+++ b/tt_eager/tt_dnn/op_library/moreh_adam/moreh_adam_op.cpp
@@ -7,6 +7,7 @@
 #include <optional>
 #include <utility>
 
+#include "tt_eager/tt_dnn/op_library/moreh_helper_functions.hpp"
 #include "tt_dnn/op_library/run_operation.hpp"
 #include "tt_eager/tensor/tensor.hpp"
 
@@ -17,19 +18,6 @@ using namespace tt::tt_metal;
 namespace tt {
 namespace operations {
 namespace primary {
-
-namespace {
-
-inline void check_tensor(const Tensor& tensor, const std::string& op_name) {
-    TT_ASSERT(tensor.get_layout() == Layout::TILE, fmt::format("{} only supports tiled layout.", op_name));
-    TT_ASSERT(tensor.get_dtype() == DataType::BFLOAT16, fmt::format("{} only supports bfloat16.", op_name));
-    TT_ASSERT(
-        tensor.storage_type() == StorageType::DEVICE, fmt::format("Operands to {} need to be on device!", op_name));
-    TT_ASSERT(
-        tensor.buffer() != nullptr, fmt::format("Operands to {} need to be allocated in buffers on device!", op_name));
-}
-
-}  // namespace
 
 void MorehAdam::validate_with_output_tensors(
     const std::vector<Tensor>& input_tensors,
@@ -46,13 +34,13 @@ void MorehAdam::validate_with_output_tensors(
 
     const auto& max_exp_avg_sq_in = optional_input_tensors.at(0);
 
-    check_tensor(param_in, "moreh_adam");
-    check_tensor(grad, "moreh_adam");
-    check_tensor(exp_avg_in, "moreh_adam");
-    check_tensor(exp_avg_sq_in, "moreh_adam");
+    check_tensor(param_in, "moreh_adam", "param_in");
+    check_tensor(grad, "moreh_adam", "grad");
+    check_tensor(exp_avg_in, "moreh_adam", "exp_avg_in");
+    check_tensor(exp_avg_sq_in, "moreh_adam", "exp_avg_sq_in");
 
     if (max_exp_avg_sq_in.has_value()) {
-        check_tensor(max_exp_avg_sq_in.value(), "moreh_adam");
+        check_tensor(max_exp_avg_sq_in.value(), "moreh_adam", "max_exp_avg_sq_in");
     }
 
     const auto& param_out = output_tensors.at(0);
@@ -61,16 +49,16 @@ void MorehAdam::validate_with_output_tensors(
     const auto& max_exp_avg_sq_out = output_tensors.at(3);
 
     if (param_out.has_value()) {
-        check_tensor(param_out.value(), "moreh_adam");
+        check_tensor(param_out.value(), "moreh_adam", "param_out");
     }
     if (exp_avg_out.has_value()) {
-        check_tensor(exp_avg_out.value(), "moreh_adam");
+        check_tensor(exp_avg_out.value(), "moreh_adam", "exp_avg_out");
     }
     if (exp_avg_sq_out.has_value()) {
-        check_tensor(exp_avg_sq_out.value(), "moreh_adam");
+        check_tensor(exp_avg_sq_out.value(), "moreh_adam", "exp_avg_sq_out");
     }
     if (max_exp_avg_sq_out.has_value()) {
-        check_tensor(max_exp_avg_sq_out.value(), "moreh_adam");
+        check_tensor(max_exp_avg_sq_out.value(), "moreh_adam", "max_exp_avg_sq_out");
     }
 }
 

--- a/tt_eager/tt_dnn/op_library/moreh_adamw/moreh_adamw_op.cpp
+++ b/tt_eager/tt_dnn/op_library/moreh_adamw/moreh_adamw_op.cpp
@@ -7,6 +7,7 @@
 #include <optional>
 #include <utility>
 
+#include "tt_eager/tt_dnn/op_library/moreh_helper_functions.hpp"
 #include "tt_dnn/op_library/run_operation.hpp"
 #include "tt_eager/tensor/tensor.hpp"
 
@@ -17,19 +18,6 @@ using namespace tt::tt_metal;
 namespace tt {
 namespace operations {
 namespace primary {
-
-namespace {
-
-inline void check_tensor(const Tensor& tensor, const std::string& op_name) {
-    TT_ASSERT(tensor.get_layout() == Layout::TILE, fmt::format("{} only supports tiled layout.", op_name));
-    TT_ASSERT(tensor.get_dtype() == DataType::BFLOAT16, fmt::format("{} only supports bfloat16.", op_name));
-    TT_ASSERT(
-        tensor.storage_type() == StorageType::DEVICE, fmt::format("Operands to {} need to be on device!", op_name));
-    TT_ASSERT(
-        tensor.buffer() != nullptr, fmt::format("Operands to {} need to be allocated in buffers on device!", op_name));
-}
-
-}  // namespace
 
 void MorehAdamW::validate_with_output_tensors(
         const std::vector<Tensor> &input_tensors,
@@ -46,13 +34,13 @@ void MorehAdamW::validate_with_output_tensors(
 
     const auto& max_exp_avg_sq_in = optional_input_tensors.at(0);
 
-    check_tensor(param_in, "moreh_adamw");
-    check_tensor(grad, "moreh_adamw");
-    check_tensor(exp_avg_in, "moreh_adamw");
-    check_tensor(exp_avg_sq_in, "moreh_adamw");
+    check_tensor(param_in, "moreh_adamw", "param_in");
+    check_tensor(grad, "moreh_adamw", "grad");
+    check_tensor(exp_avg_in, "moreh_adamw", "exp_avg_in");
+    check_tensor(exp_avg_sq_in, "moreh_adamw", "exp_avg_sq_in");
 
     if (max_exp_avg_sq_in.has_value()) {
-        check_tensor(max_exp_avg_sq_in.value(), "moreh_adamw");
+        check_tensor(max_exp_avg_sq_in.value(), "moreh_adamw", "max_exp_avg_sq_in");
     }
 
     const auto& param_out = output_tensors.at(0);
@@ -61,16 +49,16 @@ void MorehAdamW::validate_with_output_tensors(
     const auto& max_exp_avg_sq_out = output_tensors.at(3);
 
     if (param_out.has_value()) {
-        check_tensor(param_out.value(), "moreh_adamw");
+        check_tensor(param_out.value(), "moreh_adamw", "param_out");
     }
     if (exp_avg_out.has_value()) {
-        check_tensor(exp_avg_out.value(), "moreh_adamw");
+        check_tensor(exp_avg_out.value(), "moreh_adamw", "exp_avg_out");
     }
     if (exp_avg_sq_out.has_value()) {
-        check_tensor(exp_avg_sq_out.value(), "moreh_adamw");
+        check_tensor(exp_avg_sq_out.value(), "moreh_adamw", "exp_avg_sq_out");
     }
     if (max_exp_avg_sq_out.has_value()) {
-        check_tensor(max_exp_avg_sq_out.value(), "moreh_adamw");
+        check_tensor(max_exp_avg_sq_out.value(), "moreh_adamw", "max_exp_avg_sq_out");
     }
 }
 

--- a/tt_eager/tt_dnn/op_library/moreh_clip_grad_norm/moreh_clip_grad_norm_op.cpp
+++ b/tt_eager/tt_dnn/op_library/moreh_clip_grad_norm/moreh_clip_grad_norm_op.cpp
@@ -9,6 +9,7 @@
 
 #include "tt_eager/tt_dnn/op_library/moreh_clip_grad_norm/moreh_clip_grad_norm_op.hpp"
 #include "ttnn/cpp/ttnn/operations/creation.hpp"
+#include "tt_eager/tt_dnn/op_library/moreh_helper_functions.hpp"
 
 namespace tt {
 
@@ -17,14 +18,6 @@ namespace operations {
 namespace primary {
 
 namespace {
-inline void check_tensor(const Tensor &tensor, const std::string &op_name) {
-    TT_ASSERT(tensor.get_layout() == Layout::TILE, fmt::format("{} only supports tiled layout.", op_name));
-    TT_ASSERT(tensor.get_dtype() == DataType::BFLOAT16, fmt::format("{} only supports bfloat16.", op_name));
-    TT_ASSERT(
-        tensor.storage_type() == StorageType::DEVICE, fmt::format("Operands to {} need to be on device!", op_name));
-    TT_ASSERT(
-        tensor.buffer() != nullptr, fmt::format("Operands to {} need to be allocated in buffers on device!", op_name));
-}
 
 inline uint32_t get_num_device_cores(Device *device) {
     const auto num_cores_x = static_cast<uint32_t>(device->compute_with_storage_grid_size().x);
@@ -47,11 +40,11 @@ void MorehClipGradNormStep1::validate(
     const std::vector<Tensor> &input_tensors,
     const std::vector<std::optional<const Tensor>> &optional_input_tensors) const {
     for (const auto &input : input_tensors) {
-        check_tensor(input, "moreh_clip_grad_norm_step1");
+        check_tensor(input, "moreh_clip_grad_norm_step1", "input");
     }
 
     const auto &tmp_pow_sum = optional_input_tensors.at(0).value();
-    check_tensor(tmp_pow_sum, "moreh_clip_grad_norm_step1");
+    check_tensor(tmp_pow_sum, "moreh_clip_grad_norm_step1", "tmp_pow_sum");
 };
 
 std::vector<Shape> MorehClipGradNormStep1::compute_output_shapes(const std::vector<Tensor> &) const { return {}; }
@@ -105,10 +98,10 @@ void moreh_clip_grad_norm_step1(const std::vector<Tensor> &inputs, float norm_ty
 
 void MorehClipGradNormStep2::validate(const std::vector<Tensor> &input_tensors) const {
     const auto &tmp_pow_sum = input_tensors.at(0);
-    check_tensor(tmp_pow_sum, "moreh_clip_grad_norm_step2");
+    check_tensor(tmp_pow_sum, "moreh_clip_grad_norm_step2", "tmp_pow_sum");
 
     const auto &total_norm = input_tensors.at(1);
-    check_tensor(total_norm, "moreh_clip_grad_norm_step2");
+    check_tensor(total_norm, "moreh_clip_grad_norm_step2", "total_norm");
 }
 
 std::vector<Shape> MorehClipGradNormStep2::compute_output_shapes(const std::vector<Tensor> &) const { return {}; }
@@ -145,11 +138,11 @@ void MorehClipGradNormStep3::validate(
     const std::vector<Tensor> &input_tensors,
     const std::vector<std::optional<const Tensor>> &optional_input_tensors) const {
     for (const auto &input : input_tensors) {
-        check_tensor(input, "moreh_clip_grad_norm_step3");
+        check_tensor(input, "moreh_clip_grad_norm_step3", "input");
     }
 
     const auto &clip_coef_clamped = optional_input_tensors.at(0).value();
-    check_tensor(clip_coef_clamped, "moreh_clip_grad_norm_step3");
+    check_tensor(clip_coef_clamped, "moreh_clip_grad_norm_step3", "clip_coef_clamped");
 }
 
 std::vector<Shape> MorehClipGradNormStep3::compute_output_shapes(const std::vector<Tensor> &) const { return {}; }

--- a/tt_eager/tt_dnn/op_library/moreh_groupnorm/moreh_groupnorm_op.cpp
+++ b/tt_eager/tt_dnn/op_library/moreh_groupnorm/moreh_groupnorm_op.cpp
@@ -8,32 +8,13 @@
 #include <vector>
 
 #include "tt_eager/tt_dnn/op_library/moreh_groupnorm/moreh_groupnorm_op.hpp"
+#include "tt_eager/tt_dnn/op_library/moreh_helper_functions.hpp"
 
 namespace tt {
 
 namespace operations {
 
 namespace primary {
-
-namespace {
-
-inline void check_tensor(const Tensor &tensor, const std::string &op_name) {
-    TT_ASSERT(tensor.get_layout() == Layout::TILE, fmt::format("{} only supports tiled layout.", op_name));
-    TT_ASSERT(tensor.get_dtype() == DataType::BFLOAT16, fmt::format("{} only supports bfloat16.", op_name));
-    TT_ASSERT(
-        tensor.storage_type() == StorageType::DEVICE, fmt::format("Operands to {} need to be on device!", op_name));
-    TT_ASSERT(
-        tensor.buffer() != nullptr, fmt::format("Operands to {} need to be allocated in buffers on device!", op_name));
-}
-
-inline void check_tensor(std::optional<Tensor> tensor, const std::string &op_name) {
-    if (!tensor.has_value()) {
-        return;
-    }
-    check_tensor(tensor.value(), op_name);
-}
-
-}  // namespace
 
 void MorehGroupNorm::validate_with_output_tensors(
     const std::vector<Tensor> &input_tensors,
@@ -48,14 +29,14 @@ void MorehGroupNorm::validate_with_output_tensors(
     auto gamma = optional_input_tensors.at(0);
     auto beta = optional_input_tensors.at(1);
 
-    check_tensor(input, "moreh_groupnorm");
+    check_tensor(input, "moreh_groupnorm", "input");
 
-    check_tensor(output, "moreh_groupnorm");
-    check_tensor(mean, "moreh_groupnorm");
-    check_tensor(rstd, "moreh_groupnorm");
+    check_tensor(output, "moreh_groupnorm", "output");
+    check_tensor(mean, "moreh_groupnorm", "mean");
+    check_tensor(rstd, "moreh_groupnorm", "rstd");
 
-    check_tensor(gamma, "moreh_groupnorm");
-    check_tensor(beta, "moreh_groupnorm");
+    check_tensor(gamma, "moreh_groupnorm", "gamma");
+    check_tensor(beta, "moreh_groupnorm", "beta");
 
     // input (N, C, H, W)
     auto C = input.get_legacy_shape()[1];

--- a/tt_eager/tt_dnn/op_library/moreh_groupnorm_backward/moreh_groupnorm_backward_op.cpp
+++ b/tt_eager/tt_dnn/op_library/moreh_groupnorm_backward/moreh_groupnorm_backward_op.cpp
@@ -8,32 +8,13 @@
 #include <vector>
 
 #include "tt_eager/tt_dnn/op_library/moreh_groupnorm_backward/moreh_groupnorm_backward_op.hpp"
+#include "tt_eager/tt_dnn/op_library/moreh_helper_functions.hpp"
 
 namespace tt {
 
 namespace operations {
 
 namespace primary {
-
-namespace {
-
-inline void check_tensor(const Tensor &tensor, const std::string &op_name) {
-    TT_ASSERT(tensor.get_layout() == Layout::TILE, fmt::format("{} only supports tiled layout.", op_name));
-    TT_ASSERT(tensor.get_dtype() == DataType::BFLOAT16, fmt::format("{} only supports bfloat16.", op_name));
-    TT_ASSERT(
-        tensor.storage_type() == StorageType::DEVICE, fmt::format("Operands to {} need to be on device!", op_name));
-    TT_ASSERT(
-        tensor.buffer() != nullptr, fmt::format("Operands to {} need to be allocated in buffers on device!", op_name));
-}
-
-inline void check_tensor(std::optional<Tensor> tensor, const std::string &op_name) {
-    if (!tensor.has_value()) {
-        return;
-    }
-    check_tensor(tensor.value(), op_name);
-}
-
-}  // namespace
 
 void MorehGroupNormBackwardInputGrad::validate_with_output_tensors(
     const std::vector<Tensor> &input_tensors,
@@ -48,14 +29,14 @@ void MorehGroupNormBackwardInputGrad::validate_with_output_tensors(
 
     auto gamma = optional_input_tensors.at(0);
 
-    check_tensor(output_grad, "moreh_groupnorm_backward_input_grad");
-    check_tensor(input, "moreh_groupnorm_backward_input_grad");
-    check_tensor(mean, "moreh_groupnorm_backward_input_grad");
-    check_tensor(rstd, "moreh_groupnorm_backward_input_grad");
+    check_tensor(output_grad, "moreh_groupnorm_backward_input_grad", "output_grad");
+    check_tensor(input, "moreh_groupnorm_backward_input_grad", "input");
+    check_tensor(mean, "moreh_groupnorm_backward_input_grad", "mean");
+    check_tensor(rstd, "moreh_groupnorm_backward_input_grad", "rstd");
 
-    check_tensor(input_grad, "moreh_groupnorm_backward_input_grad");
+    check_tensor(input_grad, "moreh_groupnorm_backward_input_grad", "input_grad");
 
-    check_tensor(gamma, "moreh_groupnorm_backward_input_grad");
+    check_tensor(gamma, "moreh_groupnorm_backward_input_grad", "gamma");
 
     // output_grad (N, C, H, W)
     auto C = output_grad.get_legacy_shape()[1];
@@ -156,13 +137,13 @@ void MorehGroupNormBackwardGammaBetaGrad::validate_with_output_tensors(
     auto &gamma_grad = output_tensors.at(0);
     auto &beta_grad = output_tensors.at(1);
 
-    check_tensor(output_grad, "moreh_groupnorm_backward_gamma_beta_grad");
-    check_tensor(input, "moreh_groupnorm_backward_gamma_beta_grad");
-    check_tensor(mean, "moreh_groupnorm_backward_gamma_beta_grad");
-    check_tensor(rstd, "moreh_groupnorm_backward_gamma_beta_grad");
+    check_tensor(output_grad, "moreh_groupnorm_backward_gamma_beta_grad", "output_grad");
+    check_tensor(input, "moreh_groupnorm_backward_gamma_beta_grad", "input");
+    check_tensor(mean, "moreh_groupnorm_backward_gamma_beta_grad", "mean");
+    check_tensor(rstd, "moreh_groupnorm_backward_gamma_beta_grad", "rstd");
 
-    check_tensor(gamma_grad, "moreh_groupnorm_backward_gamma_beta_grad");
-    check_tensor(beta_grad, "moreh_groupnorm_backward_gamma_beta_grad");
+    check_tensor(gamma_grad, "moreh_groupnorm_backward_gamma_beta_grad", "gamma_grad");
+    check_tensor(beta_grad, "moreh_groupnorm_backward_gamma_beta_grad", "beta_grad");
 
     // output_grad (N, C, H, W)
     auto C = output_grad.get_legacy_shape()[1];

--- a/tt_eager/tt_dnn/op_library/moreh_helper_functions.hpp
+++ b/tt_eager/tt_dnn/op_library/moreh_helper_functions.hpp
@@ -126,6 +126,22 @@ struct CircularBufferArg {
     tt::DataFormat data_format,
     CircularBufferArg arg);
 
+void check_tensor(
+    const Tensor& tensor,
+    const std::string& op_name,
+    const std::string& tensor_name,
+    const std::initializer_list<DataType> &data_types = {DataType::BFLOAT16},
+    Layout layout = Layout::TILE,
+    bool check_dtype = true,
+    bool check_layout = true);
+
+void check_tensor(std::optional<Tensor> tensor,
+    const std::string& op_name,
+    const std::string& tensor_name,
+    const std::initializer_list<DataType> &data_types = {DataType::BFLOAT16},
+    Layout layout = Layout::TILE,
+    bool check_dtype = true,
+    bool check_layout = true);
 
 struct CallbackArgMap {
     std::map<uint32_t, uint32_t> input;

--- a/tt_eager/tt_dnn/op_library/moreh_matmul/moreh_matmul_op.cpp
+++ b/tt_eager/tt_dnn/op_library/moreh_matmul/moreh_matmul_op.cpp
@@ -31,31 +31,6 @@ inline bool is_dot_forward(const Tensor& input, const Tensor& other, bool transp
     return is_1d_tensor(input) && is_1d_tensor(other) && is_same_shape(input, other);
 }
 
-// TODO: move these check functions to a common header.
-inline void check_tensor(
-    const Tensor& tensor,
-    const std::string& op_name,
-    DataType data_type = DataType::BFLOAT16,
-    Layout layout = Layout::TILE) {
-    TT_FATAL(tensor.get_layout() == layout, "{} only supports tiled layout.", op_name);
-    TT_FATAL(tensor.get_dtype() == data_type, "{} only supports data type {}.", op_name, data_type);
-    TT_FATAL(
-        tensor.storage_type() == StorageType::DEVICE, "Operands to {} need to be on device!", op_name);
-    TT_FATAL(
-        tensor.buffer() != nullptr, "Operands to {} need to be allocated in buffers on device!", op_name);
-}
-
-inline void check_tensor(
-    std::optional<Tensor> tensor,
-    const std::string& op_name,
-    tt_metal::DataType data_type = DataType::BFLOAT16,
-    Layout layout = Layout::TILE) {
-    if (!tensor.has_value()) {
-        return;
-    }
-    check_tensor(tensor.value(), op_name, data_type, layout);
-}
-
 inline Shape compute_output_shape(
     const Shape& input_shape, const Shape& other_shape, bool transpose_input, bool transpose_other) {
     const auto& input_shape_wo_padding = input_shape.without_padding();
@@ -209,10 +184,10 @@ void MorehMatmul::validate_with_output_tensors(
     const auto& output = output_tensors.at(0);
 
     // validate tensor
-    check_tensor(input, "input");
-    check_tensor(other, "other");
-    check_tensor(output, "output");
-    check_tensor(bias, "bias");
+    check_tensor(input, "moreh_matmul", "input");
+    check_tensor(other, "moreh_matmul", "other");
+    check_tensor(output, "moreh_matmul", "output");
+    check_tensor(bias, "moreh_matmul", "bias");
 
     // check matrix dims
     const auto& input_shape = input.get_legacy_shape().without_padding();

--- a/tt_eager/tt_dnn/op_library/moreh_norm/moreh_norm_op.cpp
+++ b/tt_eager/tt_dnn/op_library/moreh_norm/moreh_norm_op.cpp
@@ -28,15 +28,6 @@ namespace primary {
 
 namespace {
 
-inline void check_tensor(const Tensor &tensor, const std::string &op_name) {
-    TT_ASSERT(tensor.get_layout() == Layout::TILE, fmt::format("{} only supports tiled layout.", op_name));
-    TT_ASSERT(tensor.get_dtype() == DataType::BFLOAT16, fmt::format("{} only supports bfloat16.", op_name));
-    TT_ASSERT(
-        tensor.storage_type() == StorageType::DEVICE, fmt::format("Operands to {} need to be on device!", op_name));
-    TT_ASSERT(
-        tensor.buffer() != nullptr, fmt::format("Operands to {} need to be allocated in buffers on device!", op_name));
-}
-
 inline Shape compute_output_shape(const Shape &input_shape, int64_t dim) {
     const auto input_rank = static_cast<decltype(dim)>(input_shape.rank());
     auto output_shape = input_shape;
@@ -78,8 +69,8 @@ void MorehNorm::validate(const std::vector<Tensor> &input_tensors) const {
     const auto &input = input_tensors.at(0);
     const auto &output = input_tensors.at(1);
 
-    check_tensor(input, "moreh_norm");
-    check_tensor(output, "moreh_norm");
+    check_tensor(input, "moreh_norm", "input");
+    check_tensor(output, "moreh_norm", "output");
 }
 
 std::vector<Shape> MorehNorm::compute_output_shapes(const std::vector<Tensor> &) const { return {}; }

--- a/tt_eager/tt_dnn/op_library/moreh_norm_backward/moreh_norm_backward_op.cpp
+++ b/tt_eager/tt_dnn/op_library/moreh_norm_backward/moreh_norm_backward_op.cpp
@@ -24,27 +24,16 @@ namespace operations {
 
 namespace primary {
 
-namespace {
-inline void check_tensor(const Tensor &tensor, const std::string &op_name) {
-    TT_ASSERT(tensor.get_layout() == Layout::TILE, fmt::format("{} only supports tiled layout.", op_name));
-    TT_ASSERT(tensor.get_dtype() == DataType::BFLOAT16, fmt::format("{} only supports bfloat16.", op_name));
-    TT_ASSERT(
-        tensor.storage_type() == StorageType::DEVICE, fmt::format("Operands to {} need to be on device!", op_name));
-    TT_ASSERT(
-        tensor.buffer() != nullptr, fmt::format("Operands to {} need to be allocated in buffers on device!", op_name));
-}
-}  // namespace
-
 void MorehNormBackward::validate(const std::vector<Tensor> &input_tensors) const {
     const auto &input = input_tensors.at(0);
     const auto &output = input_tensors.at(1);
     const auto &output_grad = input_tensors.at(2);
     const auto &input_grad = input_tensors.at(3);
 
-    check_tensor(input, "moreh_norm_backward");
-    check_tensor(output, "moreh_norm_backward");
-    check_tensor(output_grad, "moreh_norm_backward");
-    check_tensor(input_grad, "moreh_norm_backward");
+    check_tensor(input, "moreh_norm_backward", "input");
+    check_tensor(output, "moreh_norm_backward", "output");
+    check_tensor(output_grad, "moreh_norm_backward", "output_grad");
+    check_tensor(input_grad, "moreh_norm_backward", "input_grad");
 }
 
 std::vector<Shape> MorehNormBackward::compute_output_shapes(const std::vector<Tensor> &) const { return {}; }

--- a/tt_eager/tt_dnn/op_library/moreh_sum/moreh_sum_op.cpp
+++ b/tt_eager/tt_dnn/op_library/moreh_sum/moreh_sum_op.cpp
@@ -6,8 +6,8 @@
 
 #include <numeric>
 
-#include "tt_dnn/op_library/reduce/reduce_op.hpp"
 #include "tt_eager/tt_dnn/op_library/moreh_helper_functions.hpp"
+#include "tt_dnn/op_library/reduce/reduce_op.hpp"
 #include "tt_metal/common/constants.hpp"
 #include "tt_metal/host_api.hpp"
 
@@ -20,36 +20,6 @@ namespace primary {
 //                         MorehSum
 ////////////////////////////////////////////////////////////////////////////
 namespace {
-// TODO: move these check functions to a common header.
-inline void check_tensor(
-    const Tensor& tensor,
-    const std::string& op_name,
-    const std::initializer_list<DataType> &data_types = {DataType::BFLOAT16},
-    Layout layout = Layout::TILE) {
-    TT_FATAL(tensor.get_layout() == layout, "{} only supports tiled layout.", op_name);
-    TT_FATAL(tensor.storage_type() == StorageType::DEVICE, "Operands to {} need to be on device!", op_name);
-    TT_FATAL(tensor.buffer() != nullptr, "Operands to {} need to be allocated in buffers on device!", op_name);
-
-    bool dtype_supported = false;
-    for (const auto& data_type : data_types) {
-        if (tensor.get_dtype() == data_type) {
-            dtype_supported = true;
-            break;
-        }
-    }
-    TT_FATAL(dtype_supported, "{} only supports specific data types.", op_name);
-}
-
-inline void check_tensor(
-    std::optional<Tensor> tensor,
-    const std::string& op_name,
-    const std::initializer_list<DataType> &data_types = {DataType::BFLOAT16},
-    Layout layout = Layout::TILE) {
-    if (!tensor.has_value()) {
-        return;
-    }
-    check_tensor(tensor.value(), op_name, data_types, layout);
-}
 
 inline void expand_to_max_dim(std::vector<uint32_t> &dim, const Shape& shape) {
     const auto rank = shape.rank();
@@ -179,8 +149,8 @@ void MorehSum::validate_with_output_tensors(
     const auto& input = input_tensors.at(0);
     auto& output = output_tensors.at(0);
 
-    check_tensor(input, "input", {DataType::BFLOAT16, DataType::INT32});
-    check_tensor(output, "output", {DataType::BFLOAT16, DataType::INT32});
+    check_tensor(input, "moreh_sum", "input", {DataType::BFLOAT16, DataType::INT32});
+    check_tensor(output, "moreh_sum", "output", {DataType::BFLOAT16, DataType::INT32});
 
     validate_input_tensor_with_dim(input, this->dim);
 

--- a/tt_eager/tt_dnn/op_library/moreh_sum_backward/moreh_sum_backward_op.cpp
+++ b/tt_eager/tt_dnn/op_library/moreh_sum_backward/moreh_sum_backward_op.cpp
@@ -4,6 +4,7 @@
 
 #include "tt_dnn/op_library/moreh_sum_backward/moreh_sum_backward_op.hpp"
 #include "tt_dnn/op_library/moreh_sum/moreh_sum_op.hpp"
+#include "tt_eager/tt_dnn/op_library/moreh_helper_functions.hpp"
 
 namespace tt {
 
@@ -11,26 +12,6 @@ using namespace constants;
 
 namespace operations {
 namespace primary {
-
-namespace {
-
-inline void check_tensor(const Tensor &tensor, const std::string &op_name) {
-    TT_FATAL(tensor.get_layout() == Layout::TILE, "{} only supports tiled layout.", op_name);
-    TT_FATAL(tensor.get_dtype() == DataType::BFLOAT16, "{} only supports bfloat16.", op_name);
-    TT_FATAL(
-        tensor.storage_type() == StorageType::DEVICE, "Operands to {} need to be on device!", op_name);
-    TT_FATAL(
-        tensor.buffer() != nullptr, "Operands to {} need to be allocated in buffers on device!", op_name);
-}
-
-inline void check_tensor(std::optional<Tensor> tensor, const std::string &op_name) {
-    if (!tensor.has_value()) {
-        return;
-    }
-    check_tensor(tensor.value(), op_name);
-}
-
-}  // namespace
 
 ////////////////////////////////////////////////////////////////////////////
 //                         MorehSumBackward
@@ -42,9 +23,9 @@ void MorehSumBackward::validate_with_output_tensors(
     auto &input_grad = output_tensors.at(0);
 
     // validate tensor
-    check_tensor(output_grad, "moreh_sum_backward output_grad");
-    check_tensor(input, "moreh_sum_backward input");
-    check_tensor(input_grad, "moreh_sum_backward input_grad");
+    check_tensor(output_grad, "moreh_sum_backward", "output_grad");
+    check_tensor(input, "moreh_sum_backward", "input");
+    check_tensor(input_grad, "moreh_sum_backward", " input_grad");
 
     const auto &input_shape = input.get_legacy_shape();
     auto input_shape_wo_padding = input_shape.without_padding();


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/9861

### Problem description
In most ops, the validate functions check tensors in a similar manner.
However, since there is no common tensor checking function used across ops, the current implementation has several similar functions named `check_tensor`.

### What's changed
Therefore, I create a `check_tensor` function that can be used in most ops.


### Checklist
- [x] Post commit CI passes
- [x] Model regression CI testing passes (if applicable)
- [x] New/Existing tests provide coverage for changes
