### PR TITLE
Extend ssm_1d_reduce for the batch>32

### DIFF
--- a/tests/tt_eager/python_api_testing/unit_testing/misc/test_ssm_1d_sum_reduce.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/misc/test_ssm_1d_sum_reduce.py
@@ -58,6 +58,8 @@ def run_ssm_1d_sum_reduce(H: int, W: int, latent_size: int, dtype, in_mem_config
     (
         (32, 1024, 32),
         (32, 163840, 32),
+        (128, 1024, 32),
+        (64, 163840, 32),
     ),
 )
 def test_ssm_reduce(H, W, latent_size, dtype, out_mem_config, in_mem_config, device):
@@ -70,9 +72,12 @@ def test_ssm_1d_sum_reduce_with_program_cache(device, use_program_cache):
     dtype = ttl.tensor.DataType.BFLOAT16
 
     for _ in range(2):
+        H, W, latent = 32, 163840, 32
+        run_ssm_1d_sum_reduce(H, W, latent, dtype, mem_config, mem_config, device)
+        H, W, latent = 64, 163840, 32
         run_ssm_1d_sum_reduce(H, W, latent, dtype, mem_config, mem_config, device)
         dummy_shape = [1, 1, 32, 32]
         py_dummy_tensor = torch.randn(dummy_shape)
         tt_dummy_tensor = ttl.tensor.Tensor(py_dummy_tensor, dtype).to(ttl.tensor.Layout.TILE).to(device, mem_config)
 
-    assert device.num_program_cache_entries() == 1
+    assert device.num_program_cache_entries() == 2

--- a/tt_eager/tt_dnn/op_library/transformer_tms/kernels/dataflow/reader_ssm_1d_sum_reduce.cpp
+++ b/tt_eager/tt_dnn/op_library/transformer_tms/kernels/dataflow/reader_ssm_1d_sum_reduce.cpp
@@ -1,0 +1,47 @@
+// SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <stdint.h>
+#include "dataflow_api.h"
+#include "tt_eager/tt_dnn/kernels/dataflow/generate_reduce_scaler.hpp"
+
+
+void kernel_main() {
+    uint32_t src_addr  = get_arg_val<uint32_t>(0);
+    uint32_t input_num_blocks_w_per_core = get_arg_val<uint32_t>(1);
+    uint32_t start_id = get_arg_val<uint32_t>(2);
+    uint32_t input_num_blocks_h = get_arg_val<uint32_t>(3);
+    uint32_t input_total_blocks_w = get_arg_val<uint32_t>(4);
+
+    constexpr bool src_is_dram = get_compile_time_arg_val(0) == 1;
+    constexpr uint32_t scaler = get_compile_time_arg_val(1);
+
+    constexpr uint32_t cb_id_in2 = 2;
+    generate_reduce_scaler(cb_id_in2, scaler);
+
+    constexpr uint32_t cb_id_in0 = 0;
+
+    // ublocks size defined in tiles
+    constexpr uint32_t onetile = 1;
+    uint32_t tile_bytes = get_tile_size(cb_id_in0);
+    const DataFormat data_format = get_dataformat(cb_id_in0);
+
+    const InterleavedAddrGenFast<src_is_dram> s = {
+        .bank_base_address = src_addr,
+        .page_size = tile_bytes,
+        .data_format = data_format
+    };
+
+    // read a ublock of tiles from src to CB, and then push the ublock to unpacker
+    for(uint32_t block_h_id = 0; block_h_id < input_num_blocks_h; block_h_id++){
+        uint32_t end_id = start_id + input_num_blocks_w_per_core;
+        for (uint32_t i = start_id; i<end_id; i ++) {
+            cb_reserve_back(cb_id_in0, onetile);
+            uint32_t l1_write_addr = get_write_ptr(cb_id_in0);
+            noc_async_read_tile((block_h_id * input_total_blocks_w) + i, s, l1_write_addr);
+            noc_async_read_barrier();
+            cb_push_back(cb_id_in0, onetile);
+        }
+    }
+}

--- a/tt_eager/tt_dnn/op_library/transformer_tms/kernels/dataflow/writer_ssm_1d_sum_reduce.cpp
+++ b/tt_eager/tt_dnn/op_library/transformer_tms/kernels/dataflow/writer_ssm_1d_sum_reduce.cpp
@@ -12,8 +12,10 @@ void kernel_main() {
     constexpr uint32_t FACE_SIZE_BYTES = FACE_SIZE * DATA_FORMAT_BYTES;
 
     uint32_t dst_addr = get_arg_val<uint32_t>(0);
-    uint32_t num_output_tiles = get_arg_val<uint32_t>(1);
+    uint32_t num_output_blocks_w_per_core = get_arg_val<uint32_t>(1);
     uint32_t start_id = get_arg_val<uint32_t>(2);
+    uint32_t out_num_blocks_h = get_arg_val<uint32_t>(3);
+    uint32_t out_num_blocks_w = get_arg_val<uint32_t>(4);
 
     constexpr uint32_t intermed_cb_id1 = get_compile_time_arg_val(0);
     constexpr uint32_t intermed_cb_id2 = get_compile_time_arg_val(1);
@@ -27,45 +29,48 @@ void kernel_main() {
     const InterleavedAddrGenFast<output_is_dram> s = {
         .bank_base_address = dst_addr, .page_size = tile_bytes, .data_format = data_format};
 
-    const uint32_t end_id = start_id + num_output_tiles;
-    for (uint32_t i = start_id; i < end_id; ++i) {
-        cb_reserve_back(intermed_cb_id2, onetile);
-        uint32_t dst = get_write_ptr(intermed_cb_id2);
+    const uint32_t end_id = start_id + num_output_blocks_w_per_core;
 
-        // Manually unroll copying into destination face 1+2 and 3+4 to avoid conditional inside loop
-        for (uint32_t j = 0; j < FACE_WIDTH; ++j) {
-            cb_wait_front(intermed_cb_id1, onetile);
-            uint64_t src = get_noc_addr(get_read_ptr(intermed_cb_id1));
+    for(uint32_t block_h_id = 0; block_h_id < out_num_blocks_h; block_h_id++){
+        for (uint32_t i = start_id; i < end_id; ++i) {
+            cb_reserve_back(intermed_cb_id2, onetile);
+            uint32_t dst = get_write_ptr(intermed_cb_id2);
 
-            noc_async_read(src, dst, FACE_WIDTH_BYTES);
-            noc_async_read(src + FACE_SIZE_BYTES, dst + FACE_SIZE_BYTES, FACE_WIDTH_BYTES);
-            noc_async_read_barrier();
+            // Manually unroll copying into destination face 1+2 and 3+4 to avoid conditional inside loop
+            for (uint32_t j = 0; j < FACE_WIDTH; ++j) {
+                cb_wait_front(intermed_cb_id1, onetile);
+                uint64_t src = get_noc_addr(get_read_ptr(intermed_cb_id1));
 
-            cb_pop_front(intermed_cb_id1, onetile);
+                noc_async_read(src, dst, FACE_WIDTH_BYTES);
+                noc_async_read(src + FACE_SIZE_BYTES, dst + FACE_SIZE_BYTES, FACE_WIDTH_BYTES);
+                noc_async_read_barrier();
 
-            dst += FACE_WIDTH_BYTES;
+                cb_pop_front(intermed_cb_id1, onetile);
+
+                dst += FACE_WIDTH_BYTES;
+            }
+            dst += FACE_SIZE_BYTES;
+
+            // Copy face 3/4 into the destination
+            for (uint32_t j = 0; j < FACE_WIDTH; ++j) {
+                cb_wait_front(intermed_cb_id1, onetile);
+                uint64_t src = get_noc_addr(get_read_ptr(intermed_cb_id1));
+
+                noc_async_read(src, dst, FACE_WIDTH_BYTES);
+                noc_async_read(src + FACE_SIZE_BYTES, dst + FACE_SIZE_BYTES, FACE_WIDTH_BYTES);
+                noc_async_read_barrier();
+
+                cb_pop_front(intermed_cb_id1, onetile);
+
+                dst += FACE_WIDTH_BYTES;
+            }
+            cb_push_back(intermed_cb_id2, onetile);
+
+            cb_wait_front(output_cb_id, onetile);
+            uint32_t l1_read_addr = get_read_ptr(output_cb_id);
+            noc_async_write_tile((block_h_id*out_num_blocks_w) + i, s, l1_read_addr);
+            noc_async_write_barrier();
+            cb_pop_front(output_cb_id, onetile);
         }
-        dst += FACE_SIZE_BYTES;
-
-        // Copy face 3/4 into the destination
-        for (uint32_t j = 0; j < FACE_WIDTH; ++j) {
-            cb_wait_front(intermed_cb_id1, onetile);
-            uint64_t src = get_noc_addr(get_read_ptr(intermed_cb_id1));
-
-            noc_async_read(src, dst, FACE_WIDTH_BYTES);
-            noc_async_read(src + FACE_SIZE_BYTES, dst + FACE_SIZE_BYTES, FACE_WIDTH_BYTES);
-            noc_async_read_barrier();
-
-            cb_pop_front(intermed_cb_id1, onetile);
-
-            dst += FACE_WIDTH_BYTES;
-        }
-        cb_push_back(intermed_cb_id2, onetile);
-
-        cb_wait_front(output_cb_id, onetile);
-        uint32_t l1_read_addr = get_read_ptr(output_cb_id);
-        noc_async_write_tile(i, s, l1_read_addr);
-        noc_async_write_barrier();
-        cb_pop_front(output_cb_id, onetile);
     }
 }

--- a/tt_eager/tt_dnn/op_library/transformer_tms/transformer_tms.cpp
+++ b/tt_eager/tt_dnn/op_library/transformer_tms/transformer_tms.cpp
@@ -637,7 +637,7 @@ void SSM1DSumReduce::validate(const std::vector<Tensor>& input_tensors) const {
     constexpr uint32_t latent = 32;
     const auto ashape = input_tensor_a.get_legacy_shape();
     TT_FATAL((ashape[0] == 1 and ashape[1] == 1), "Dim 1 and 2 are expected to be 1 in input a!");
-    TT_FATAL((ashape[2] == TILE_HEIGHT), "Batch size must be 32 for input a!");
+    TT_FATAL((ashape[2] % TILE_HEIGHT == 0), "Batch size must be divisible by 32 for input a!");
     TT_FATAL((ashape[3] % TILE_WIDTH == 0), "Final dim must be a multiple of 32!");
     TT_FATAL(((ashape[3] / TILE_WIDTH) % latent == 0), "Final dim/TILE_SIZE must be a multiple of latent size!");
 }


### PR DESCRIPTION
### Ticket
This is a follow-on work upon this [PR](https://github.com/tenstorrent/tt-metal/pull/7804)
### Problem description
In previous implementation of `ssm_1d_sum_reduce`, we assumed batch_size/users will always be 32 (Tile Height).
However, in prefill model we are utilizing this batch dimension with sequence length and would like have support for seq_len = [32, 64, 128 or larger].
### What's changed
We used to same design of the reader, compute, and writer kernel. Although now since B>32, there is an extra dimension getting added along the input height. We compute this new data by looping along the input/output height blocks.
In future, the design of the kernel can be simplified by sharding the data.

### Checklist
- [X] Post commit CI passes
- [x] Model regression CI testing passes (if applicable)
- [x] New/Existing tests provide coverage for changes
