### PR TITLE
#9410: enable fp32 precision unpacking for interm. CBs

### DIFF
--- a/tt_metal/jit_build/genfiles.cpp
+++ b/tt_metal/jit_build/genfiles.cpp
@@ -300,7 +300,7 @@ static void generate_data_format_descriptors(JitBuildOptions& options, const tt:
             (pack_exp_prec == ExpPrecision::A) ? DataFormat::Float16 : DataFormat::Float16_b;
     }
 
-    if (tt::is_all_fp32_formats(desc.input_buf_dataformat_arr) && options.fp32_dest_acc_en){
+    if ((tt::is_all_fp32_formats(desc.input_buf_dataformat_arr) || options.preserve_fp32_precision) && options.fp32_dest_acc_en){
         if (options.preserve_fp32_precision) {
             unpack_conditional_dst_format = DataFormat::Float32;
         } else {


### PR DESCRIPTION
### Ticket
[Link to Github Issue](https://github.com/tenstorrent/tt-metal/issues/9410)

### Problem description
Intermediate CBs need support for fp32 precision unpacking directly to Dest.

### What's changed
Update data format descriptor generation to allow this.

### Checklist
- [x] Post commit CI passes: https://github.com/tenstorrent/tt-metal/actions/runs/9779267101