### PR TITLE
#9910: Improve Softplus kernel accuracy

### DIFF
--- a/tests/ttnn/unit_tests/operations/test_activation.py
+++ b/tests/ttnn/unit_tests/operations/test_activation.py
@@ -102,27 +102,31 @@ def test_swish(device, h, w):
     run_activation_unary_test(device, h, w, ttnn.swish, F.hardswish)
 
 
-def run_activation_softplus_test(device, h, w, beta, threshold, ttnn_function, torch_function, pcc=0.99):
+def run_activation_softplus_test(device, h, w, beta, threshold, ttnn_function, torch_function, pcc=0.999):
     torch.manual_seed(0)
 
     torch_input_tensor_a = torch.rand((h, w), dtype=torch.bfloat16)
 
     torch_output_tensor = torch_function(torch_input_tensor_a, beta=beta, threshold=threshold)
 
-    input_tensor_a = ttnn.from_torch(torch_input_tensor_a, layout=ttnn.TILE_LAYOUT, device=device)
+    input_tensor_a = ttnn.from_torch(
+        torch_input_tensor_a, layout=ttnn.TILE_LAYOUT, device=device, memory_config=ttnn.L1_MEMORY_CONFIG
+    )
 
     output_tensor = ttnn_function(input_tensor_a, beta=beta, threshold=threshold)
     output_tensor = ttnn.to_layout(output_tensor, ttnn.ROW_MAJOR_LAYOUT)
     output_tensor = ttnn.from_device(output_tensor)
     output_tensor = ttnn.to_torch(output_tensor)
+    print(torch_output_tensor)
+    print(output_tensor)
     assert_with_pcc(torch_output_tensor, output_tensor, pcc)
 
 
 @skip_for_grayskull()
 @pytest.mark.parametrize("h", [64])
 @pytest.mark.parametrize("w", [128])
-@pytest.mark.parametrize("beta", [-1, 1, 2, 0.5, 10])
-@pytest.mark.parametrize("threshold", [20, 40, -5, 10, -20])
+@pytest.mark.parametrize("beta", [-1, 0.5, 1, 2])
+@pytest.mark.parametrize("threshold", [-20, 5, 10, 20, 40])
 def test_softplus(device, h, w, beta, threshold):
     run_activation_softplus_test(device, h, w, beta, threshold, ttnn.softplus, F.softplus)
 


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/9910

### Problem description

Softplus kernel is inaccurate when the input distribution is centered around small values of X. See #9910 for more details.

### What's changed

- The softplus kernel has been reimplemented using a Remez approximation instead of using the existing `log` and `exp` functions. The max error is 0.0006.
- This has improved the overall accuracy without a meaningful drop in device time.

![Figure_1](https://github.com/tenstorrent/tt-metal/assets/159198142/092a3657-df2a-49d1-8ff7-ce1adca47b84)

### Checklist
- [x] Post commit CI passes
- [x] Model regression CI testing passes (if applicable)
- [x] New/Existing tests provide coverage for changes
