### PR TITLE
#9123: Add support for optional output tensors to run in the worker t…

### DIFF
--- a/docs/source/ttnn/ttnn/adding_new_ttnn_operation.rst
+++ b/docs/source/ttnn/ttnn/adding_new_ttnn_operation.rst
@@ -29,7 +29,7 @@ C++ Implementation
 ------------------
 
 Step 1: Implement device operation (Optional)
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 In order to add a new device operation, follow the directory structure shown below:
 
@@ -99,6 +99,6 @@ Finally, call the module defined in `examples/example/example_pybind.hpp` wherev
 
 
 Step 2: Register the operation in Python
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 TODO: Add the description of how to register the operation in Python.


### PR DESCRIPTION
### Ticket
#9123 

### Problem description
Add optional output tensors to run within execute_on_worker_thread so that we are not forced to call launch_op explicitly from execute_on_main_thread
 
### What's changed
Just updated the variadic arguments.  

### Checklist
- [x] Post commit CI passes (https://github.com/tenstorrent/tt-metal/actions/runs/9769136148)
- [x] Model regression CI testing passes (https://github.com/tenstorrent/tt-metal/actions/runs/9768815091)
- [ ] New/Existing tests provide coverage for changes
