### PR TITLE
#9492: Remove bmm/resnet_matmul from models

### DIFF
--- a/models/experimental/bert/fused_ops/linear.py
+++ b/models/experimental/bert/fused_ops/linear.py
@@ -4,6 +4,7 @@
 
 from typing import List, Union, Optional
 from tt_lib import tensor
+from ttnn import matmul
 
 
 def Linear(
@@ -27,7 +28,7 @@ def Linear(
 
     def linear_(activation):
         weight_T = tensor.transpose(weight, -2, -1)
-        output = tensor.matmul(activation, weight_T)
+        output = ttnn.matmul(activation, weight_T)
 
         if bias is not None:
             output_plus_bias = tensor.bcast(output, bias, tensor.BcastOpMath.ADD, tensor.BcastOpDim.H)

--- a/models/experimental/bert_large_perf/fused_ops/linear.py
+++ b/models/experimental/bert_large_perf/fused_ops/linear.py
@@ -4,6 +4,7 @@
 
 from typing import List, Union, Optional
 from tt_lib import tensor
+from ttnn import matmul
 
 
 def Linear(
@@ -41,7 +42,7 @@ def Linear(
 
     def linear_(activation):
         weight_T = tensor.transpose(weight, -2, -1)
-        output = tensor.matmul(activation, weight_T)
+        output = ttnn.matmul(activation, weight_T)
 
         if bias is not None:
             output_plus_bias = tensor.bcast(output, bias, tensor.BcastOpMath.ADD, tensor.BcastOpDim.H)

--- a/models/experimental/bert_large_perf/tt/mha.py
+++ b/models/experimental/bert_large_perf/tt/mha.py
@@ -157,7 +157,7 @@ def mha(qw, qb, kw, kb, vw, vb, hidden_dim, num_heads, device):
 
     def op7_bmm(Q_heads, K_T_heads):
         # profiler.start("___op7_bmm")
-        qkt = ttl.tensor.bmm(Q_heads, K_T_heads)
+        qkt = ttnn.matmul(Q_heads, K_T_heads)
         # profiler.end("___op7_bmm")
 
         return qkt
@@ -187,7 +187,7 @@ def mha(qw, qb, kw, kb, vw, vb, hidden_dim, num_heads, device):
 
     def op9_bmm(attention_scores, V_heads):
         # profiler.start("___op9_bmm")
-        weighted_activation = ttl.tensor.bmm(attention_scores, V_heads)
+        weighted_activation = ttnn.matmul(attention_scores, V_heads)
         # profiler.end("___op9_bmm")
 
         return weighted_activation

--- a/models/experimental/bloom/bloom_utils.py
+++ b/models/experimental/bloom/bloom_utils.py
@@ -5,6 +5,7 @@
 import torch
 import json
 import tt_lib
+import ttnn
 
 from models.generation_utils import get_logits_processor
 
@@ -57,14 +58,14 @@ def tt_matmul(t1, t2, device, on_torch=False):
         res = torch.matmul(t1, t2, output_mem_config=mem_config)
         return torch2tt_tensor(res, device)
     else:
-        return tt_lib.tensor.bmm(t1, t2, mem_config)
+        return ttnn.matmul(t1, t2, mem_config)
 
 
 def tt_bmm(t1, t2, device, on_torch=False):
     if on_torch:
         return tt_matmul(t1, t2, device)
     else:
-        return tt_lib.tensor.bmm(t1, t2, mem_config)
+        return ttnn.matmul(t1, t2, mem_config)
 
 
 def read_model_config(json_file):

--- a/models/experimental/distilbert/tt/distilbert_multihead_self_attention.py
+++ b/models/experimental/distilbert/tt/distilbert_multihead_self_attention.py
@@ -11,6 +11,7 @@ from models.utility_functions import (
     torch_to_tt_tensor_rm,
 )
 import tt_lib
+import ttnn
 import tt_lib.fallback_ops as fallback_ops
 from models.helper_funcs import Linear as TtLinear
 
@@ -104,7 +105,7 @@ class TtMultiHeadSelfAttention(nn.Module):
         dim_per_head_tensor = tt_lib.tensor.recip(dim_per_head_tensor)
 
         q = ttnn.mul(q, dim_per_head_tensor)
-        scores = tt_lib.tensor.bmm(q, tt_lib.tensor.transpose(k, -2, -1))
+        scores = ttnn.matmul(q, tt_lib.tensor.transpose(k, -2, -1))
         score_value = self.get_min(scores)
         scores = tt_to_torch_tensor(scores)
         mask = tt_to_torch_tensor(mask)
@@ -121,7 +122,7 @@ class TtMultiHeadSelfAttention(nn.Module):
         if head_mask is not None:
             weights = tt_lib.temsor.mul(weights, head_mask)
 
-        context = tt_lib.tensor.bmm(weights, v)
+        context = ttnn.matmul(weights, v)
         context = unshape(context)
         context = self.out_linear(context)
 

--- a/models/experimental/llama/tt/llama_attention.py
+++ b/models/experimental/llama/tt/llama_attention.py
@@ -245,7 +245,7 @@ class TtLlamaAttention(nn.Module):
         query_states_tt = torch_to_tt_tensor_rm(query_states, self.device)
 
         key_states_tt_transposed = tt_lib.tensor.transpose(key_states_tt, -2, -1)
-        mul = tt_lib.tensor.bmm(query_states_tt, key_states_tt_transposed)
+        mul = ttnn.matmul(query_states_tt, key_states_tt_transposed)
 
         # TODO: Fuse into softmax
         attn_weights = tt_lib.tensor.bcast(mul, self.scalar, tt_lib.tensor.BcastOpMath.MUL, tt_lib.tensor.BcastOpDim.HW)
@@ -275,7 +275,7 @@ class TtLlamaAttention(nn.Module):
         value_states = torch_to_tt_tensor_rm(value_states, self.device)
 
         attn_weights = tt_lib.operations.primary.softmax_in_place(attn_weights)
-        attn_output = tt_lib.tensor.bmm(attn_weights, value_states)
+        attn_output = ttnn.matmul(attn_weights, value_states)
 
         if attn_output.get_legacy_shape() != [bsz, self.num_heads, q_len, self.head_dim]:
             raise ValueError(

--- a/models/experimental/nanogpt/tt/nanogpt_attention.py
+++ b/models/experimental/nanogpt/tt/nanogpt_attention.py
@@ -4,6 +4,7 @@
 
 import torch.nn as nn
 import tt_lib
+import ttnn
 import math
 from tt_lib.fallback_ops import fallback_ops
 from models.helper_funcs import Linear
@@ -101,7 +102,7 @@ class TtCausalSelfAttention(nn.Module):
 
         # manual implementation of attention
         key_layer_transposed = tt_lib.tensor.transpose(k, -2, -1)
-        att = tt_lib.tensor.bmm(q, key_layer_transposed)
+        att = ttnn.matmul(q, key_layer_transposed)
 
         const_att = self.const_tensor(att.get_legacy_shape(), 1.0 / math.sqrt(k.get_legacy_shape()[-1]))
 
@@ -116,7 +117,7 @@ class TtCausalSelfAttention(nn.Module):
             tt_att
         )  # Using tt_lib.tensor.softmax reduces pcc from 0.99 to 0.98 for whole model
 
-        tt_y = tt_lib.tensor.bmm(tt_att, v)
+        tt_y = ttnn.matmul(tt_att, v)
 
         tt_y = tt_lib.tensor.transpose(tt_y, 1, -2)
         tt_y = tt_lib.tensor.reshape(tt_y, 1, B, T, C)

--- a/models/experimental/resnet/tt/ttnn_functional_resnet50_large_new_conv_api.py
+++ b/models/experimental/resnet/tt/ttnn_functional_resnet50_large_new_conv_api.py
@@ -12,7 +12,7 @@ from models.utility_functions import (
 from typing import List
 
 hardcoded_matmul_config_linear = {
-    1: ttnn.experimental.operations.primary.MatmulMultiCoreReuseMultiCast1DProgramConfig(
+    1: ttnn.MatmulMultiCoreReuseMultiCast1DProgramConfig(
         compute_with_storage_grid_size=(8, 4),
         in0_block_w=2,
         out_subblock_h=1,
@@ -23,7 +23,7 @@ hardcoded_matmul_config_linear = {
         fused_activation=None,
         mcast_in0=True,
     ),
-    8: ttnn.experimental.operations.primary.MatmulMultiCoreReuseMultiCast1DProgramConfig(
+    8: ttnn.MatmulMultiCoreReuseMultiCast1DProgramConfig(
         compute_with_storage_grid_size=(8, 4),
         in0_block_w=2,
         out_subblock_h=1,
@@ -34,7 +34,7 @@ hardcoded_matmul_config_linear = {
         fused_activation=None,
         mcast_in0=True,
     ),
-    16: ttnn.experimental.operations.primary.MatmulMultiCoreReuseMultiCast1DProgramConfig(
+    16: ttnn.MatmulMultiCoreReuseMultiCast1DProgramConfig(
         compute_with_storage_grid_size=(8, 4),
         in0_block_w=2,
         out_subblock_h=1,
@@ -45,7 +45,7 @@ hardcoded_matmul_config_linear = {
         fused_activation=None,
         mcast_in0=True,
     ),
-    20: ttnn.experimental.operations.primary.MatmulMultiCoreReuseMultiCast1DProgramConfig(
+    20: ttnn.MatmulMultiCoreReuseMultiCast1DProgramConfig(
         compute_with_storage_grid_size=(8, 4),
         in0_block_w=2,
         out_subblock_h=1,
@@ -81,13 +81,13 @@ def ResnetLinear(
     bias = bias.reshape(1, 1, bias_shape[-2], bias_shape[-1])
 
     def linear_(act):
-        output = ttnn.experimental.operations.primary.matmul_1d(
+        output = ttnn.linear(
             act,
             weight,
             bias=bias,
             program_config=matmul_config,
-            output_mem_config=output_mem_config,
-            output_dtype=model_config["ACTIVATIONS_DTYPE"],
+            memory_config=output_mem_config,
+            dtype=model_config["ACTIVATIONS_DTYPE"],
             compute_kernel_config=compute_kernel_config,
         )
         return output

--- a/models/experimental/resnet/tt/ttnn_functional_resnet50_xlarge_new_conv_api.py
+++ b/models/experimental/resnet/tt/ttnn_functional_resnet50_xlarge_new_conv_api.py
@@ -12,7 +12,7 @@ from models.utility_functions import (
 from typing import List
 
 hardcoded_matmul_config_linear = {
-    1: ttnn.experimental.operations.primary.MatmulMultiCoreReuseMultiCast1DProgramConfig(
+    1: ttnn.MatmulMultiCoreReuseMultiCast1DProgramConfig(
         compute_with_storage_grid_size=(8, 4),
         in0_block_w=2,
         out_subblock_h=1,
@@ -23,7 +23,7 @@ hardcoded_matmul_config_linear = {
         fused_activation=None,
         mcast_in0=True,
     ),
-    8: ttnn.experimental.operations.primary.MatmulMultiCoreReuseMultiCast1DProgramConfig(
+    8: ttnn.MatmulMultiCoreReuseMultiCast1DProgramConfig(
         compute_with_storage_grid_size=(8, 4),
         in0_block_w=2,
         out_subblock_h=1,
@@ -34,7 +34,7 @@ hardcoded_matmul_config_linear = {
         fused_activation=None,
         mcast_in0=True,
     ),
-    16: ttnn.experimental.operations.primary.MatmulMultiCoreReuseMultiCast1DProgramConfig(
+    16: ttnn.MatmulMultiCoreReuseMultiCast1DProgramConfig(
         compute_with_storage_grid_size=(8, 4),
         in0_block_w=2,
         out_subblock_h=1,
@@ -45,7 +45,7 @@ hardcoded_matmul_config_linear = {
         fused_activation=None,
         mcast_in0=True,
     ),
-    20: ttnn.experimental.operations.primary.MatmulMultiCoreReuseMultiCast1DProgramConfig(
+    20: ttnn.MatmulMultiCoreReuseMultiCast1DProgramConfig(
         compute_with_storage_grid_size=(8, 4),
         in0_block_w=2,
         out_subblock_h=1,
@@ -81,13 +81,13 @@ def ResnetLinear(
     bias = bias.reshape(1, 1, bias_shape[-2], bias_shape[-1])
 
     def linear_(act):
-        output = ttnn.experimental.operations.primary.matmul_1d(
+        output = ttnn.linear(
             act,
             weight,
             bias=bias,
             program_config=matmul_config,
-            output_mem_config=output_mem_config,
-            output_dtype=model_config["ACTIVATIONS_DTYPE"],
+            memory_config=output_mem_config,
+            dtype=model_config["ACTIVATIONS_DTYPE"],
             compute_kernel_config=compute_kernel_config,
         )
         return output

--- a/models/experimental/resnet/tt/ttnn_functional_resnet50_xlarge_new_conv_api_24.py
+++ b/models/experimental/resnet/tt/ttnn_functional_resnet50_xlarge_new_conv_api_24.py
@@ -13,7 +13,7 @@ from typing import List
 from loguru import logger
 
 hardcoded_matmul_config_linear = {
-    1: ttnn.experimental.operations.primary.MatmulMultiCoreReuseMultiCast1DProgramConfig(
+    1: ttnn.MatmulMultiCoreReuseMultiCast1DProgramConfig(
         compute_with_storage_grid_size=(8, 4),
         in0_block_w=2,
         out_subblock_h=1,
@@ -24,7 +24,7 @@ hardcoded_matmul_config_linear = {
         fused_activation=None,
         mcast_in0=True,
     ),
-    8: ttnn.experimental.operations.primary.MatmulMultiCoreReuseMultiCast1DProgramConfig(
+    8: ttnn.MatmulMultiCoreReuseMultiCast1DProgramConfig(
         compute_with_storage_grid_size=(8, 4),
         in0_block_w=2,
         out_subblock_h=1,
@@ -35,7 +35,7 @@ hardcoded_matmul_config_linear = {
         fused_activation=None,
         mcast_in0=True,
     ),
-    16: ttnn.experimental.operations.primary.MatmulMultiCoreReuseMultiCast1DProgramConfig(
+    16: ttnn.MatmulMultiCoreReuseMultiCast1DProgramConfig(
         compute_with_storage_grid_size=(8, 4),
         in0_block_w=2,
         out_subblock_h=1,
@@ -46,7 +46,7 @@ hardcoded_matmul_config_linear = {
         fused_activation=None,
         mcast_in0=True,
     ),
-    20: ttnn.experimental.operations.primary.MatmulMultiCoreReuseMultiCast1DProgramConfig(
+    20: ttnn.MatmulMultiCoreReuseMultiCast1DProgramConfig(
         compute_with_storage_grid_size=(8, 4),
         in0_block_w=2,
         out_subblock_h=1,
@@ -82,13 +82,13 @@ def ResnetLinear(
     bias = bias.reshape(1, 1, bias_shape[-2], bias_shape[-1])
 
     def linear_(act):
-        output = ttnn.experimental.operations.primary.matmul_1d(
+        output = ttnn.linear(
             act,
             weight,
             bias=bias,
             program_config=matmul_config,
-            output_mem_config=output_mem_config,
-            output_dtype=model_config["ACTIVATIONS_DTYPE"],
+            memory_config=output_mem_config,
+            dtype=model_config["ACTIVATIONS_DTYPE"],
             compute_kernel_config=compute_kernel_config,
         )
         return output

--- a/models/experimental/resnet/tt/ttnn_functional_resnet50_xxlarge_new_conv_api.py
+++ b/models/experimental/resnet/tt/ttnn_functional_resnet50_xxlarge_new_conv_api.py
@@ -13,7 +13,7 @@ from typing import List
 from loguru import logger
 
 hardcoded_matmul_config_linear = {
-    1: ttnn.experimental.operations.primary.MatmulMultiCoreReuseMultiCast1DProgramConfig(
+    1: ttnn.MatmulMultiCoreReuseMultiCast1DProgramConfig(
         compute_with_storage_grid_size=(8, 4),
         in0_block_w=2,
         out_subblock_h=1,
@@ -24,7 +24,7 @@ hardcoded_matmul_config_linear = {
         fused_activation=None,
         mcast_in0=True,
     ),
-    8: ttnn.experimental.operations.primary.MatmulMultiCoreReuseMultiCast1DProgramConfig(
+    8: ttnn.MatmulMultiCoreReuseMultiCast1DProgramConfig(
         compute_with_storage_grid_size=(8, 4),
         in0_block_w=2,
         out_subblock_h=1,
@@ -35,7 +35,7 @@ hardcoded_matmul_config_linear = {
         fused_activation=None,
         mcast_in0=True,
     ),
-    16: ttnn.experimental.operations.primary.MatmulMultiCoreReuseMultiCast1DProgramConfig(
+    16: ttnn.MatmulMultiCoreReuseMultiCast1DProgramConfig(
         compute_with_storage_grid_size=(8, 4),
         in0_block_w=2,
         out_subblock_h=1,
@@ -46,7 +46,7 @@ hardcoded_matmul_config_linear = {
         fused_activation=None,
         mcast_in0=True,
     ),
-    20: ttnn.experimental.operations.primary.MatmulMultiCoreReuseMultiCast1DProgramConfig(
+    20: ttnn.MatmulMultiCoreReuseMultiCast1DProgramConfig(
         compute_with_storage_grid_size=(8, 4),
         in0_block_w=2,
         out_subblock_h=1,
@@ -82,13 +82,13 @@ def ResnetLinear(
     bias = bias.reshape(1, 1, bias_shape[-2], bias_shape[-1])
 
     def linear_(act):
-        output = ttnn.experimental.operations.primary.matmul_1d(
+        output = ttnn.linear(
             act,
             weight,
             bias=bias,
             program_config=matmul_config,
-            output_mem_config=output_mem_config,
-            output_dtype=model_config["ACTIVATIONS_DTYPE"],
+            memory_config=output_mem_config,
+            dtype=model_config["ACTIVATIONS_DTYPE"],
             compute_kernel_config=compute_kernel_config,
         )
         return output

--- a/models/experimental/roberta/tt/roberta_self_attention.py
+++ b/models/experimental/roberta/tt/roberta_self_attention.py
@@ -151,7 +151,7 @@ class TtRobertaSelfAttention(nn.Module):
         # Take the dot product between "query" and "key" to get the raw attention scores.
         key_layer_transposed = tt_lib.tensor.transpose(key_layer, -2, -1)
 
-        attention_scores = tt_lib.tensor.bmm(query_layer, key_layer_transposed, output_mem_config=self.mem_config)
+        attention_scores = ttnn.matmul(query_layer, key_layer_transposed, memory_config=self.mem_config)
 
         if self.position_embedding_type == "relative_key" or self.position_embedding_type == "relative_key_query":
             """
@@ -222,7 +222,7 @@ class TtRobertaSelfAttention(nn.Module):
         if head_mask is not None:
             attention_probs = ttnn.mul(attention_probs, head_mask, memory_config=self.mem_config)
 
-        context_layer = tt_lib.tensor.bmm(attention_probs, value_layer, self.mem_config)
+        context_layer = ttnn.matmul(attention_probs, value_layer, memory_config=self.mem_config)
         context_layer = tt_lib.tensor.permute(context_layer, (0, 2, 1, 3))
 
         # TODO left here. Finish porting and re-test everything. See other TODO s

--- a/models/experimental/stable_diffusion/tt/cross_attention.py
+++ b/models/experimental/stable_diffusion/tt/cross_attention.py
@@ -174,7 +174,7 @@ class TtCrossAttention(nn.Module):
     ) -> ttl.tensor.Tensor:
         t_key = ttl.tensor.transpose(key, -2, -1)
 
-        temp = ttl.tensor.bmm(query, t_key)
+        temp = ttnn.matmul(query, t_key)
         # Aaron: TODO: intentionally keeping this here!
         # scale_tensor = ttl.tensor.fill_rm(temp.get_legacy_shape()[0],
         #                                 temp.get_legacy_shape()[1],
@@ -228,7 +228,7 @@ def CrossAttnProcessor(
 
     attention_probs = attn.get_attention_scores(query, key, attention_mask)
 
-    hidden_states = ttl.tensor.bmm(attention_probs, value)
+    hidden_states = ttnn.matmul(attention_probs, value)
 
     hidden_states = attn.batch_to_head_dim(hidden_states)
     hidden_states = attn.to_out(hidden_states)

--- a/models/experimental/swin/tt/swin_self_attention.py
+++ b/models/experimental/swin/tt/swin_self_attention.py
@@ -14,6 +14,7 @@ from models.utility_functions import (
 from models.experimental.swin.swin_helper_funcs import linear as TtLinear
 from models.experimental.swin.swin_utils import meshgrid
 import tt_lib
+import ttnn
 from tt_lib.fallback_ops import fallback_ops
 
 
@@ -100,7 +101,7 @@ class TtSwinSelfAttention(nn.Module):
         # Take the dot product between "query" and "key" to get the raw attention scores.
         key_layer_transposed = tt_lib.tensor.transpose(key_layer, -2, -1)
 
-        attention_scores = tt_lib.tensor.bmm(query_layer, key_layer_transposed)
+        attention_scores = ttnn.matmul(query_layer, key_layer_transposed)
 
         attention_head_size_tt = self.const_tensor(attention_scores.get_legacy_shape(), self.attention_head_size)
         attention_head_size_tt = tt_lib.tensor.sqrt(attention_head_size_tt)
@@ -158,7 +159,7 @@ class TtSwinSelfAttention(nn.Module):
         # Mask heads if we want to
         if head_mask is not None:
             attention_probs = attention_probs * head_mask
-        context_layer = tt_lib.tensor.bmm(attention_probs, value_layer)
+        context_layer = ttnn.matmul(attention_probs, value_layer)
         context_layer = tt_lib.tensor.permute(context_layer, (0, 2, 1, 3))
 
         new_context_layer_shape = tuple(context_layer.get_legacy_shape())[:-2] + (self.all_head_size,)

--- a/models/experimental/t5/tests/test_t5_attention.py
+++ b/models/experimental/t5/tests/test_t5_attention.py
@@ -9,6 +9,7 @@ from transformers import T5Model
 from loguru import logger
 
 import tt_lib
+import ttnn
 import pytest
 
 from models.experimental.t5.tt.t5_attention import (
@@ -107,7 +108,7 @@ def run_test_matmul(device):
     test_input2 = (torch.rand(32, 8, 64, 128) * 2) - 1
 
     pt_out = torch.matmul(test_input1, test_input2)
-    tt_out = tt_lib.tensor.bmm(torch2tt_tensor(test_input1, device), torch2tt_tensor(test_input2, device))
+    tt_out = ttnn.matmul(torch2tt_tensor(test_input1, device), torch2tt_tensor(test_input2, device))
     tt_out = tt2torch_tensor(tt_out)
 
     does_pass, pcc_message = comp_pcc(pt_out, tt_out, 0.99)

--- a/models/experimental/t5/tt/t5_attention.py
+++ b/models/experimental/t5/tt/t5_attention.py
@@ -500,7 +500,7 @@ class TtT5Attention(nn.Module):
         # scores = torch.matmul(query_states, key_states.transpose(3, 2))
         # equivalent of torch.einsum("bnqd,bnkd->bnqk", query_states, key_states), compatible with onnx op>9
         transposed_key_states = tt_lib.tensor.transpose(key_states, -2, -1)
-        scores = tt_lib.tensor.bmm(query_states, transposed_key_states, self.mem_config)
+        scores = ttnn.matmul(query_states, transposed_key_states, memory_config=self.mem_config)
 
         if (
             position_bias is None
@@ -557,7 +557,7 @@ class TtT5Attention(nn.Module):
         if layer_head_mask is not None:
             attn_weights = ttnn.mul(attn_weights, layer_head_mask, self.mem_config)
 
-        attn_output = tt_lib.tensor.bmm(attn_weights, value_states, self.mem_config)
+        attn_output = ttnn.matmul(attn_weights, value_states, memory_config=self.mem_config)
         attn_output = unshape(attn_output)  # (batch_size, seq_length, dim)
         attn_output = ttnn.matmul(attn_output, self.o_weights, memory_config=self.mem_config)
 

--- a/models/experimental/trocr/tt/trocr_attention.py
+++ b/models/experimental/trocr/tt/trocr_attention.py
@@ -157,7 +157,7 @@ class TtTrOCRAttention(nn.Module):
 
         src_len = key_states.get_legacy_shape()[2]
         key_states = tt_lib.tensor.transpose(key_states, -2, -1)
-        attn_weights = tt_lib.tensor.bmm(query_states, key_states)
+        attn_weights = ttnn.matmul(query_states, key_states)
 
         if attn_weights.get_legacy_shape() != [1, bsz * self.num_heads, tgt_len, src_len]:
             raise ValueError(
@@ -201,7 +201,7 @@ class TtTrOCRAttention(nn.Module):
         else:
             attn_weights_reshaped = None
 
-        attn_output = tt_lib.tensor.bmm(attn_weights, value_states)
+        attn_output = ttnn.matmul(attn_weights, value_states)
 
         if attn_output.get_legacy_shape() != [1, bsz * self.num_heads, tgt_len, self.head_dim]:
             raise ValueError(

--- a/models/experimental/vit/tt/modeling_vit.py
+++ b/models/experimental/vit/tt/modeling_vit.py
@@ -140,7 +140,7 @@ class TtViTSelfAttention(nn.Module):
 
         # Take the dot product between "query" and "key" to get the raw attention scores.
         key_layer_T = tt_lib.tensor.transpose(key_layer, -2, -1, self.out_mem_config_l1)
-        attention_scores = tt_lib.tensor.bmm(query_layer, key_layer_T, self.out_mem_config_l1)
+        attention_scores = ttnn.matmul(query_layer, key_layer_T, memory_config=self.out_mem_config_l1)
 
         attention_scores = tt_lib.tensor.bcast(
             attention_scores,
@@ -157,7 +157,7 @@ class TtViTSelfAttention(nn.Module):
         if head_mask is not None:
             attention_probs = ttnn.mul(attention_probs, head_mask, memory_config=self.out_mem_config_l1)
 
-        context_layer = tt_lib.tensor.bmm(attention_probs, value_layer)
+        context_layer = ttnn.matmul(attention_probs, value_layer)
 
         context_layer = tt_lib.tensor.permute(context_layer, (0, 2, 1, 3))
         new_context_layer_shape = (1,) + tuple(context_layer.get_legacy_shape())[:-2] + (self.all_head_size,)

--- a/models/experimental/whisper/tt/whisper_attention.py
+++ b/models/experimental/whisper/tt/whisper_attention.py
@@ -167,7 +167,7 @@ class TtWhisperAttention(nn.Module):
 
         key_states_transposed = tt_lib.tensor.transpose(key_states, -2, -1)
         src_len = key_states.get_legacy_shape()[-2]
-        attn_weights = tt_lib.tensor.bmm(query_states, key_states_transposed)
+        attn_weights = ttnn.matmul(query_states, key_states_transposed)
 
         if attn_weights.get_legacy_shape() != [1, bsz * self.num_heads, tgt_len, src_len]:
             raise ValueError(
@@ -226,7 +226,7 @@ class TtWhisperAttention(nn.Module):
 
         attn_probs = attn_weights
 
-        attn_output = tt_lib.tensor.bmm(attn_probs, value_states)
+        attn_output = ttnn.matmul(attn_probs, value_states)
         value_states.deallocate()
 
         if attn_output.get_legacy_shape() != [1, bsz * self.num_heads, tgt_len, self.head_dim]:

--- a/models/helper_funcs.py
+++ b/models/helper_funcs.py
@@ -35,7 +35,7 @@ def Linear(
 
     def linear_(activation):
         assert activation.get_legacy_shape()[-1] == in_features, "activation tensor do not have the expected shape"
-        output = ttnn.matmul(activation, weight_T, output_mem_config)
+        output = ttnn.matmul(activation, weight_T, memory_config=output_mem_config)
 
         if bias is not None:
             output_plus_bias = tensor.bcast(

--- a/models/helper_funcs.py
+++ b/models/helper_funcs.py
@@ -5,6 +5,7 @@
 from typing import List, Union, Optional
 from tt_lib import tensor
 import tt_lib as ttl
+import ttnn
 from loguru import logger
 import tt_lib
 
@@ -34,7 +35,7 @@ def Linear(
 
     def linear_(activation):
         assert activation.get_legacy_shape()[-1] == in_features, "activation tensor do not have the expected shape"
-        output = tensor.matmul(activation, weight_T, output_mem_config)
+        output = ttnn.matmul(activation, weight_T, output_mem_config)
 
         if bias is not None:
             output_plus_bias = tensor.bcast(


### PR DESCRIPTION
### Ticket
Link to Github Issue https://github.com/tenstorrent/tt-metal/issues/9492

### Problem description
- we are porting ops to ttnn

### What's changed
- move over bmm/resnet_matmul and new configs and matmul_1d in models over to ttnn

### Checklist
- [x] Post commit CI passes
- [x] Model regression CI testing passes (if applicable)
- [x] New/Existing tests provide coverage for changes

https://github.com/tenstorrent/tt-metal/actions/runs/9771092294 All post commits passes
https://github.com/tenstorrent/tt-metal/actions/runs/9769694820 Model perf passes
https://github.com/tenstorrent/tt-metal/actions/runs/9777843813/job/26993710721 Nightly fails in the same way as main

Probably not affected, but checked:
https://github.com/tenstorrent/tt-metal/actions/runs/9769710160 T3k profiler passes

