### PR TITLE
#9205: Add __name__ for builtin ops

### DIFF
--- a/ttnn/cpp/pybind11/decorators.hpp
+++ b/ttnn/cpp/pybind11/decorators.hpp
@@ -119,7 +119,7 @@ auto bind_registered_operation(
 
     const auto cpp_fully_qualified_name = std::string{operation.cpp_fully_qualified_name};
 
-    py::class_<registered_operation_t> py_operation(module, operation.class_name().c_str());
+    py::class_<registered_operation_t> py_operation(module, operation.class_name().c_str(), py::dynamic_attr());
 
     py_operation.doc() = append_input_tensor_schemas_to_doc(operation, doc).c_str();
 
@@ -143,6 +143,7 @@ auto bind_registered_operation(
         ...);
 
     module.attr(operation.name().c_str()) = operation;  // Bind an instance of the operation to the module
+    module.attr(operation.name().c_str()).attr("__name__") = operation.name().c_str();
 
     return py_operation;
 }
@@ -157,7 +158,7 @@ auto bind_registered_operation(
 
     const auto cpp_fully_qualified_name = std::string{operation.cpp_fully_qualified_name};
 
-    py::class_<registered_operation_t> py_operation(module, operation.class_name().c_str());
+    py::class_<registered_operation_t> py_operation(module, operation.class_name().c_str(), py::dynamic_attr());
 
     py_operation.doc() = doc;
 
@@ -185,6 +186,7 @@ auto bind_registered_operation(
         ...);
 
     module.attr(operation.name().c_str()) = operation;  // Bind an instance of the operation to the module
+    module.attr(operation.name().c_str()).attr("__name__") = operation.name().c_str();
 
     return py_operation;
 }


### PR DESCRIPTION
Hi I am new to here, I am trying to convert the PyTorch operator into TTNN's operators with torch.dynamo. I am not sure about how to pass checklist. Please let me know if I make any mistakes, thank you all.

In order to add __name__ for the builtin ops, we have to specify the `py::dynamic_attr()` in pybind11 and set the name with

```python
module.attr(operation.name().c_str()).attr("__name__") = operation.name.c_str();
```

### Ticket
#9205 

### Problem description
To integrate the torch.dynamo, the torch.dynamo will try to access the function's name through the `__name__` attribute (by "functions" means ops, just like `torch.add` or `torch.sub`). However the current implementation of the TTNN builtin ops with pybind11 dose not contain `__name__` attribute and does not allowed to set attribute.

### What's changed
To fix the problem, we do two things:
1. We specify the `py::dynamic_attr()` for pybind11 so that those builtin ops can specify attributes.
2. We specify the `__name__` attribute with the operations name.

### Checklist
- [ ] Post commit CI passes
- [ ] Model regression CI testing passes (if applicable)
- [ ] New/Existing tests provide coverage for changes
