### PR TITLE
Restructure ttnn::permute to match the new standard format

### DIFF
--- a/tests/ttnn/unit_tests/operations/test_permute.py
+++ b/tests/ttnn/unit_tests/operations/test_permute.py
@@ -104,3 +104,19 @@ def test_add_after_permute(device):
     output = a + b
     output = ttnn.to_torch(output)
     assert_with_pcc(torch_output, output, 0.9999)
+
+
+@pytest.mark.parametrize("h", [32])
+@pytest.mark.parametrize("w", [64])
+def test_permute_negative_dim(device, h, w):
+    torch_input_tensor = torch.rand((1, 1, h, w), dtype=torch.bfloat16)
+    torch_output_tensor = torch.permute(torch_input_tensor, (0, -3, -1, -2))
+
+    input_tensor = ttnn.from_torch(torch_input_tensor)
+    input_tensor = ttnn.to_device(input_tensor, device)
+    output_tensor = ttnn.permute(input_tensor, (0, -3, -1, -2))
+    output_tensor = ttnn.to_layout(output_tensor, ttnn.ROW_MAJOR_LAYOUT)
+    output_tensor = ttnn.from_device(output_tensor)
+    output_tensor = ttnn.to_torch(output_tensor)
+
+    assert_with_pcc(torch_output_tensor, output_tensor, 0.9999)

--- a/ttnn/cpp/ttnn/operations/data_movement.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement.hpp
@@ -7,7 +7,6 @@
 #include "tt_eager/tensor/types.hpp"
 #include "tt_eager/tt_dnn/op_library/concat/concat_op.hpp"
 #include "tt_eager/tt_dnn/op_library/pad/pad_op.hpp"
-#include "tt_eager/tt_dnn/op_library/permute/permute_op.hpp"
 #include "tt_eager/tt_dnn/op_library/repeat/repeat_op.hpp"
 #include "tt_eager/tt_dnn/op_library/composite/composite_ops.hpp"
 #include "tt_eager/tt_dnn/op_library/upsample/upsample_op.hpp"
@@ -18,93 +17,6 @@
 namespace ttnn {
 namespace operations {
 namespace data_movement {
-
-inline bool is_on_device(const Tensor& t) {
-    return t.storage_type() == tt::tt_metal::StorageType::DEVICE or
-           t.storage_type() == tt::tt_metal::StorageType::MULTI_DEVICE;
-}
-
-inline bool has_tile_padding(const Tensor& t) {
-    if (t.get_shape().rank() > 1) {
-        auto the_shape = t.get_shape();
-        auto the_shape_with_padding = t.get_shape().with_tile_padding();
-        return the_shape[-1] != the_shape_with_padding[-1] or the_shape[-2] != the_shape_with_padding[-2];
-    }
-    return false;
-}
-
-inline bool has_tile_padding(const Tensor& t, int dim) {
-    int rank = t.get_shape().rank();
-    // Wrap dim
-    dim = dim < 0 ? rank + dim : dim;
-    TT_FATAL(
-        dim >= 0 and dim < rank,
-        "ttnn: Dimension out of range: dim {} cannot be used for tensors of rank {}",
-        dim,
-        rank);
-
-    if (dim < rank) {
-        auto the_shape = t.get_shape();
-        auto the_shape_with_padding = t.get_shape().with_tile_padding();
-        return the_shape[dim] != the_shape_with_padding[dim];
-    }
-    return false;
-}
-
-inline ttnn::Tensor permute(const ttnn::Tensor& input_tensor, const std::vector<int>& order) {
-    const bool initial_input_tensor_on_device = is_on_device(input_tensor);
-    const auto input_layout = input_tensor.get_layout();
-    const auto input_rank = input_tensor.get_shape().rank();
-
-    TT_FATAL(input_rank <= 4);
-    TT_FATAL(
-        input_rank == order.size(),
-        "The number of dimensions in the tensor input does not match the length of the desired ordering");
-
-    auto adjust_order = [](const std::vector<int>& order) {
-        std::vector<std::int64_t> new_order;
-        TT_FATAL(order.size() <= 4);
-        int additional_ranks = 4 - order.size();
-        for (int i = 0; i < additional_ranks; i++) {
-            new_order.push_back(i);
-        }
-        for (int i = 0; i < order.size(); i++) {
-            new_order.push_back(order.at(i) + additional_ranks);
-        }
-        return new_order;
-    };
-    auto itensor = (input_tensor.get_shape().rank() < 4) ? ttnn::unsqueeze_to_4D(input_tensor) : input_tensor;
-    auto iorder = adjust_order(order);
-
-    if (has_tile_padding(itensor)) {
-        itensor = ttnn::to_layout(itensor, ttnn::ROW_MAJOR_LAYOUT, std::nullopt, std::nullopt, (Device*)nullptr);
-    }
-
-    TT_FATAL(is_on_device(itensor) and itensor.get_shape().rank() == 4);
-    auto output_tensor = tt::tt_metal::permute(itensor, iorder, ttnn::DRAM_MEMORY_CONFIG);
-    output_tensor = ttnn::to_layout(output_tensor, input_layout, std::nullopt, std::nullopt, (Device*)nullptr);
-
-    if (input_rank < 4) {
-        const auto shape = output_tensor.get_shape();
-        const auto full_shape = output_tensor.get_shape().with_tile_padding();
-        std::vector<uint32_t> shape_vec{};
-        std::vector<uint32_t> full_shape_vec{};
-        int i = 0;
-        while (i < 3 and shape[i] == 1) i++;
-        for (; i < shape.rank(); i++) {
-            shape_vec.push_back(shape[i]);
-            full_shape_vec.push_back(full_shape[i]);
-        }
-        auto metal_shape = tt::tt_metal::Shape(shape_vec, full_shape_vec);
-        output_tensor = ttnn::reshape(output_tensor, ttnn::Shape(metal_shape));
-    }
-
-    if (initial_input_tensor_on_device and not is_on_device(output_tensor)) {
-        output_tensor = ttnn::to_device(output_tensor, input_tensor.device(), ttnn::DRAM_MEMORY_CONFIG);
-    }
-
-    return output_tensor;
-}
 
 struct UpSample {
     static inline const std::array<TensorSchema, 1> input_tensor_schemas() {

--- a/ttnn/cpp/ttnn/operations/data_movement/data_movement_pybind.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/data_movement_pybind.hpp
@@ -11,37 +11,13 @@
 #include "ttnn/operations/data_movement.hpp"
 #include "ttnn/operations/data_movement/pad/pad_pybind.hpp"
 #include "ttnn/operations/data_movement/concat/concat_pybind.hpp"
+#include "ttnn/operations/data_movement/permute/permute_pybind.hpp"
 
 namespace py = pybind11;
 
 namespace ttnn {
 namespace operations {
 namespace data_movement {
-
-void bind_permute(py::module& module) {
-const auto doc = R"doc(
-Permutes :attr:`input_tensor` using :attr:`order`.
-
-Args:
-    * :attr:`input_tensor`: the input tensor
-    * :attr:`order`: the desired ordering of dimensions.
-
-Example:
-
-    >>> tensor = ttnn.to_device(ttnn.from_torch(torch.zeros((1, 1, 64, 32), dtype=torch.bfloat16)), device)
-    >>> output = ttnn.permute(tensor, (0, 1, 3, 2))
-    >>> print(output.shape)
-    [1, 1, 32, 64]
-
-    )doc";
-
-    module.def(
-        "permute",
-        &permute,
-        py::arg("input_tensor"),
-        py::arg("order"),
-        doc);
-}
 
 void bind_upsample(py::module& module) {
     const auto doc = R"doc(
@@ -141,7 +117,7 @@ Example:
 
 
 void py_module(py::module& module) {
-    bind_permute(module);
+    detail::bind_permute(module);
     detail::bind_concat(module);
     bind_upsample(module);
     detail::bind_pad(module);

--- a/ttnn/cpp/ttnn/operations/data_movement/permute/permute.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/permute/permute.hpp
@@ -1,0 +1,131 @@
+// SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include "ttnn/decorators.hpp"
+#include "ttnn/operations/core.hpp"
+#include "ttnn/validation.hpp"
+#include "tt_eager/tt_dnn/op_library/permute/permute_op.hpp"
+#include "tt_eager/tt_dnn/op_library/run_operation.hpp"
+
+#include "ttnn/cpp/ttnn/types.hpp"
+
+inline bool is_on_device(const Tensor& t) {
+    return t.storage_type() == tt::tt_metal::StorageType::DEVICE or
+           t.storage_type() == tt::tt_metal::StorageType::MULTI_DEVICE;
+}
+
+inline bool has_tile_padding(const Tensor& t) {
+    if (t.get_shape().rank() > 1) {
+        auto the_shape = t.get_shape();
+        auto the_shape_with_padding = t.get_shape().with_tile_padding();
+        return the_shape[-1] != the_shape_with_padding[-1] or the_shape[-2] != the_shape_with_padding[-2];
+    }
+    return false;
+}
+
+
+namespace ttnn {
+namespace operations::data_movement {
+
+constexpr uint8_t DefaultQueueId = 0;
+
+struct Permute {
+    static inline const std::array<TensorSchema, 1> input_tensor_schemas() {
+        return {ttnn::TensorSchema{
+            2,  // min rank
+            4,  // max rank
+            {ttnn::bfloat16, ttnn::bfloat8_b, ttnn::uint16, ttnn::int32, ttnn::uint32, ttnn::float32},
+            {ttnn::TILE_LAYOUT},
+            true,   // can_be_on_device
+            true,  // can_be_on_cpu
+            false,  // can_be_scalar
+            false   // is_optional}
+        }};
+    }
+
+    template <typename... Args>
+    static auto input_tensors_to_validate(uint8_t queue_id, const Tensor& input_tensor, Args&&... args) {
+        return std::forward_as_tuple(input_tensor);
+    }
+
+    static inline ttnn::Tensor execute_on_worker_thread(
+        uint8_t queue_id,
+        const ttnn::Tensor &input_tensor,
+        const std::vector<int>& dims,
+        const std::optional<MemoryConfig>& memory_config) {
+
+        const bool initial_input_tensor_on_device = is_on_device(input_tensor);
+        const auto input_layout = input_tensor.get_layout();
+        const auto input_rank = input_tensor.get_shape().rank();
+
+        TT_FATAL(input_rank <= 4);
+        TT_FATAL(
+            input_rank == dims.size(),
+            "The number of dimensions in the tensor input does not match the length of the desired ordering");
+
+        auto adjust_order = [](const std::vector<int>& dims) {
+            std::vector<std::int64_t> new_order;
+            TT_FATAL(dims.size() <= 4);
+            int additional_ranks = 4 - dims.size();
+            for (int i = 0; i < additional_ranks; i++) {
+                new_order.push_back(i);
+            }
+            for (int i = 0; i < dims.size(); i++) {
+                new_order.push_back(dims.at(i) + additional_ranks);
+            }
+            return new_order;
+        };
+        auto itensor = (input_tensor.get_shape().rank() < 4) ? ttnn::unsqueeze_to_4D(input_tensor) : input_tensor;
+        auto iorder = adjust_order(dims);
+
+        if (has_tile_padding(itensor)) {
+            itensor = ttnn::to_layout(itensor, ttnn::ROW_MAJOR_LAYOUT, std::nullopt, std::nullopt, (Device*)nullptr);
+        }
+
+        TT_FATAL(is_on_device(itensor) and itensor.get_shape().rank() == 4);
+        auto output_tensor = tt::tt_metal::permute(itensor, iorder, memory_config.value_or(ttnn::DRAM_MEMORY_CONFIG));
+        output_tensor = ttnn::to_layout(output_tensor, input_layout, std::nullopt, std::nullopt, (Device*)nullptr);
+
+        if (input_rank < 4) {
+            const auto shape = output_tensor.get_shape();
+            const auto full_shape = output_tensor.get_shape().with_tile_padding();
+            std::vector<uint32_t> shape_vec{};
+            std::vector<uint32_t> full_shape_vec{};
+            int i = 0;
+            while (i < 3 and shape[i] == 1) i++;
+            for (; i < shape.rank(); i++) {
+                shape_vec.push_back(shape[i]);
+                full_shape_vec.push_back(full_shape[i]);
+            }
+            auto metal_shape = tt::tt_metal::Shape(shape_vec, full_shape_vec);
+            output_tensor = ttnn::reshape(output_tensor, ttnn::Shape(metal_shape));
+        }
+
+        if (initial_input_tensor_on_device and not is_on_device(output_tensor)) {
+            output_tensor = ttnn::to_device(output_tensor, input_tensor.device(), memory_config.value_or(ttnn::DRAM_MEMORY_CONFIG));
+        }
+
+        return output_tensor;
+    }
+
+    template <typename... Args>
+    static auto input_tensors_to_validate(const Tensor& input_tensor, Args&&... args) {
+        return std::forward_as_tuple(input_tensor);
+    }
+
+    static inline auto execute_on_worker_thread(
+        const ttnn::Tensor &input_tensor,
+        const std::vector<int>& dims,
+        const std::optional<MemoryConfig>& memory_config) {
+        return execute_on_worker_thread(DefaultQueueId, input_tensor, dims, memory_config);
+    }
+};
+
+}  // namespace operations::data_movement
+
+constexpr auto permute = ttnn::register_operation<ttnn::operations::data_movement::Permute>("ttnn::permute");
+
+}  // namespace ttnn

--- a/ttnn/cpp/ttnn/operations/data_movement/permute/permute.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/permute/permute.hpp
@@ -9,12 +9,18 @@
 #include "ttnn/validation.hpp"
 #include "tt_eager/tt_dnn/op_library/permute/permute_op.hpp"
 #include "tt_eager/tt_dnn/op_library/run_operation.hpp"
+#include "tt_dnn/op_library/transpose/transpose_op.hpp"
 
 #include "ttnn/cpp/ttnn/types.hpp"
 
+
+namespace ttnn {
+namespace operations::data_movement {
+
+namespace permute {
 inline bool is_on_device(const Tensor& t) {
-    return t.storage_type() == tt::tt_metal::StorageType::DEVICE or
-           t.storage_type() == tt::tt_metal::StorageType::MULTI_DEVICE;
+    return ttnn::has_storage_type_of(t, ttnn::StorageType::DEVICE) or
+    ttnn::has_storage_type_of(t, ttnn::StorageType::MULTI_DEVICE);
 }
 
 inline bool has_tile_padding(const Tensor& t) {
@@ -27,10 +33,106 @@ inline bool has_tile_padding(const Tensor& t) {
 }
 
 
-namespace ttnn {
-namespace operations::data_movement {
+inline Tensor permute_impl(const Tensor &a, std::vector<uint32_t> dims, const MemoryConfig& output_mem_config) {
+    Device * device;
 
-constexpr uint8_t DefaultQueueId = 0;
+    // Get the device
+    if (a.storage_type() != StorageType::DEVICE) {
+        device = AutoFormat::GetDefaultDevice();
+        TT_ASSERT(device != nullptr, "Requires setting default device if no inputs to op are on device");
+    } else {
+        device = a.device();
+    }
+
+    TT_FATAL(dims.size() == 4, "Only 4D tensor are supported for permute.");
+    uint32_t N = dims[0], C = dims[1], H = dims[2], W = dims[3];
+
+    bool pad_n = H == 0 || W == 0;
+    bool pad_c = H == 1 || W == 1;
+    // Convert tensor back to original
+    auto a_pad_shape = AutoFormat::pad_to_tile_shape(a.get_legacy_shape(), pad_c, pad_n);
+    auto out_shape = a.get_legacy_shape();
+    out_shape = {out_shape[N], out_shape[C], out_shape[H], out_shape[W]};
+
+    auto formatted_input_tensor = a;
+    if (!AutoFormat::check_input_tensor_format(a, a_pad_shape)) {
+        formatted_input_tensor = AutoFormat::format_input_tensor(a, device, a_pad_shape, 0.0, Layout::TILE);
+    }
+    auto output = formatted_input_tensor;
+    static auto transpose_wh = std::bind(tt::tt_metal::transpose, std::placeholders::_1, -2, -1, output_mem_config); // transpose is a separate action item
+    static auto transpose_hc = std::bind(tt::tt_metal::transpose, std::placeholders::_1, 1, -2, output_mem_config);
+    static auto transpose_cn = std::bind(tt::tt_metal::transpose, std::placeholders::_1, 0, 1, output_mem_config);
+    if (N == 0 && C == 1 && H == 2 && W == 3) {
+        output = formatted_input_tensor;
+    } else if (N == 0 && C == 1 && H == 3 && W == 2) {
+        output = transpose_wh(formatted_input_tensor);
+    } else if (N == 0 && C == 2 && H == 1 && W == 3) {
+        output = transpose_hc(formatted_input_tensor);
+    } else if (N == 0 && C == 2 && H == 3 && W == 1) {
+        output = transpose_wh(transpose_hc(formatted_input_tensor));
+    } else if (N == 0 && C == 3 && H == 1 && W == 2) {
+        output = transpose_hc(transpose_wh(formatted_input_tensor));
+    } else if (N == 0 && C == 3 && H == 2 && W == 1) {
+        output = transpose_wh(transpose_hc(transpose_wh(formatted_input_tensor)));
+    } else if (N == 1 && C == 0 && H == 2 && W == 3) {
+        output = transpose_cn(formatted_input_tensor);
+    } else if (N == 1 && C == 0 && H == 3 && W == 2) {
+        output = transpose_wh(transpose_cn(formatted_input_tensor));
+    } else if (N == 1 && C == 2 && H == 0 && W == 3) {
+        output = transpose_hc(transpose_cn(formatted_input_tensor));
+    } else if (N == 1 && C == 2 && H == 3 && W == 0) {
+        output = transpose_wh(transpose_hc(transpose_cn(formatted_input_tensor)));
+    } else if (N == 1 && C == 3 && H == 0 && W == 2) {
+        output = transpose_hc(transpose_wh(transpose_cn(formatted_input_tensor)));
+    } else if (N == 1 && C == 3 && H == 2 && W == 0) {
+        output = transpose_wh(transpose_hc(transpose_wh(transpose_cn(formatted_input_tensor))));
+    } else if (N == 2 && C == 0 && H == 1 && W == 3) {
+        output = transpose_cn(transpose_hc(formatted_input_tensor));
+    } else if (N == 2 && C == 0 && H == 3 && W == 1) {
+        output = transpose_wh(transpose_cn(transpose_hc(formatted_input_tensor)));
+    } else if (N == 2 && C == 1 && H == 0 && W == 3) {
+        output = transpose_cn(transpose_hc(transpose_cn(formatted_input_tensor)));
+    } else if (N == 2 && C == 1 && H == 3 && W == 0) {
+        output = transpose_wh(transpose_cn(transpose_hc(transpose_cn(formatted_input_tensor))));
+    } else if (N == 2 && C == 3 && H == 0 && W == 1) {
+        output = transpose_hc(transpose_wh(transpose_cn(transpose_hc(formatted_input_tensor))));
+    } else if (N == 2 && C == 3 && H == 1 && W == 0) {
+        output = transpose_wh(transpose_hc(transpose_wh(transpose_cn(transpose_hc(formatted_input_tensor)))));
+    } else if (N == 3 && C == 0 && H == 1 && W == 2) {
+        output = transpose_cn(transpose_hc(transpose_wh(formatted_input_tensor)));
+    } else if (N == 3 && C == 0 && H == 2 && W == 1) {
+        output = transpose_wh(transpose_cn(transpose_hc(transpose_wh(formatted_input_tensor))));
+    } else if (N == 3 && C == 1 && H == 0 && W == 2) {
+        output = transpose_cn(transpose_hc(transpose_cn(transpose_wh(formatted_input_tensor))));
+    } else if (N == 3 && C == 1 && H == 2 && W == 0) {
+        output = transpose_wh(transpose_cn(transpose_hc(transpose_cn(transpose_wh(formatted_input_tensor)))));
+    } else if (N == 3 && C == 2 && H == 0 && W == 1) {
+        output = transpose_hc(transpose_wh(transpose_cn(transpose_hc(transpose_wh(formatted_input_tensor)))));
+    } else if (N == 3 && C == 2 && H == 1 && W == 0) {
+        output = transpose_wh(transpose_hc(transpose_wh(transpose_cn(transpose_hc(transpose_wh(formatted_input_tensor))))));
+    } else {
+        TT_ASSERT(false, "Illegal permute args");
+    }
+    return AutoFormat::format_output_tensor(output, out_shape, device, Layout::TILE);
+}
+
+Tensor permute_launch(const Tensor &a, std::vector<std::int64_t> dims, const MemoryConfig& output_mem_config) {
+    std::vector<Tensor> output_tensors = {Tensor(operation::get_workers_for_op_output({a}))};
+    operation::launch_with_autoformat( // delete the launch_with_autoformat
+        [dims, output_mem_config]  (const std::vector<Tensor>& input_tensors, const std::vector<std::optional<const Tensor>>& optional_input_tensors, const std::vector<std::optional<Tensor>>& optional_output_tensors) mutable -> std::vector<Tensor> {
+            auto& a = input_tensors.at(0);
+            std::vector<uint32_t> normalized_dims(dims.size());
+            std::transform(dims.begin(), dims.end(), normalized_dims.begin(), [a](std::int64_t idx) {return a.get_legacy_shape().get_normalized_index(idx);});
+            std::vector<uint32_t> seq_dims(dims.size());
+            std::iota(seq_dims.begin(), seq_dims.end(), 0);
+            if (normalized_dims == seq_dims) {
+                return {AutoFormat::move_tensor_to_mem_config(a, output_mem_config)};
+            }
+            return {operation::decorate_as_composite(__func__, permute_impl)(a, normalized_dims, output_mem_config)};
+        }, {a}, output_tensors);
+    return output_tensors.at(0);
+}
+}
 
 struct Permute {
     static inline const std::array<TensorSchema, 1> input_tensor_schemas() {
@@ -55,9 +157,10 @@ struct Permute {
         uint8_t queue_id,
         const ttnn::Tensor &input_tensor,
         const std::vector<int>& dims,
-        const std::optional<MemoryConfig>& memory_config) {
-
-        const bool initial_input_tensor_on_device = is_on_device(input_tensor);
+        const std::optional<MemoryConfig>& memory_config,
+        std::optional<ttnn::Tensor> &optional_output_tensor) {
+        TT_FATAL(!optional_output_tensor.has_value(), "Optional output tensor is not supported for permute operation.");
+        const bool initial_input_tensor_on_device = permute::is_on_device(input_tensor);
         const auto input_layout = input_tensor.get_layout();
         const auto input_rank = input_tensor.get_shape().rank();
 
@@ -79,14 +182,14 @@ struct Permute {
             return new_order;
         };
         auto itensor = (input_tensor.get_shape().rank() < 4) ? ttnn::unsqueeze_to_4D(input_tensor) : input_tensor;
-        auto iorder = adjust_order(dims);
+        auto iorder = adjust_order(dims); // internals of permute_impl already adjust negative indices
 
-        if (has_tile_padding(itensor)) {
+        if (permute::has_tile_padding(itensor)) {
             itensor = ttnn::to_layout(itensor, ttnn::ROW_MAJOR_LAYOUT, std::nullopt, std::nullopt, (Device*)nullptr);
         }
 
-        TT_FATAL(is_on_device(itensor) and itensor.get_shape().rank() == 4);
-        auto output_tensor = tt::tt_metal::permute(itensor, iorder, memory_config.value_or(ttnn::DRAM_MEMORY_CONFIG));
+        TT_FATAL(permute::is_on_device(itensor) and itensor.get_shape().rank() == 4);
+        auto output_tensor = permute::permute_launch(itensor, iorder, memory_config.value_or(input_tensor.memory_config()));
         output_tensor = ttnn::to_layout(output_tensor, input_layout, std::nullopt, std::nullopt, (Device*)nullptr);
 
         if (input_rank < 4) {
@@ -100,12 +203,11 @@ struct Permute {
                 shape_vec.push_back(shape[i]);
                 full_shape_vec.push_back(full_shape[i]);
             }
-            auto metal_shape = tt::tt_metal::Shape(shape_vec, full_shape_vec);
-            output_tensor = ttnn::reshape(output_tensor, ttnn::Shape(metal_shape));
+            output_tensor = ttnn::reshape(output_tensor, ttnn::Shape::from_vector(shape_vec, full_shape_vec));
         }
 
-        if (initial_input_tensor_on_device and not is_on_device(output_tensor)) {
-            output_tensor = ttnn::to_device(output_tensor, input_tensor.device(), memory_config.value_or(ttnn::DRAM_MEMORY_CONFIG));
+        if (initial_input_tensor_on_device and not permute::is_on_device(output_tensor)) {
+            output_tensor = ttnn::to_device(output_tensor, input_tensor.device(), memory_config.value_or(input_tensor.memory_config()));
         }
 
         return output_tensor;
@@ -119,8 +221,10 @@ struct Permute {
     static inline auto execute_on_worker_thread(
         const ttnn::Tensor &input_tensor,
         const std::vector<int>& dims,
-        const std::optional<MemoryConfig>& memory_config) {
-        return execute_on_worker_thread(DefaultQueueId, input_tensor, dims, memory_config);
+        const std::optional<MemoryConfig>& memory_config,
+        std::optional<ttnn::Tensor> &optional_output_tensor
+        ) {
+        return execute_on_worker_thread(DefaultQueueId, input_tensor, dims, memory_config, optional_output_tensor);
     }
 };
 

--- a/ttnn/cpp/ttnn/operations/data_movement/permute/permute_pybind.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/permute/permute_pybind.hpp
@@ -1,0 +1,60 @@
+// SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <pybind11/pybind11.h>
+#include <pybind11/stl.h>
+
+#include "ttnn/cpp/pybind11/decorators.hpp"
+
+#include "permute.hpp"
+
+namespace ttnn::operations::data_movement::detail {
+namespace py = pybind11;
+
+void bind_permute(py::module& module) {
+    auto doc =
+        R"doc(permute(input_tensor: ttnn.Tensor, dims: List[int], memory_config: Optional[MemoryConfig] = std::nullopt, queue_id: int = 0) -> ttnn.Tensor
+
+            Permutes the dimensions of the input tensor according to the specified permutation.
+
+            Args:
+                * :attr:`input_tensor`: Input Tensor for permute.
+                * :attr:`dims`: the permutation of the dimensions of the input tensor.
+
+            Keyword Args:
+                * :attr:`memory_config`: Memory Config of the output tensor
+                * :attr:`queue_id`: command queue id
+
+            Example:
+
+                >>> tensor = ttnn.to_device(ttnn.from_torch(torch.zeros((1, 1, 64, 32), dtype=torch.bfloat16)), device)
+                >>> output = ttnn.permute(tensor, (0, 1, 3, 2))
+                >>> print(output.shape)
+                [1, 1, 32, 64])doc";
+
+    using OperationType = decltype(ttnn::permute);
+    ttnn::bind_registered_operation(
+        module,
+        ttnn::permute,
+        doc,
+        ttnn::pybind_overload_t{
+            [] (const OperationType& self,
+                const ttnn::Tensor& input_tensor,
+                const std::vector<int> &dims,
+                std::optional<ttnn::Tensor> optional_output_tensor,
+                const std::optional<ttnn::MemoryConfig>& memory_config,
+                uint8_t queue_id) {
+                    return self(queue_id, input_tensor, dims, memory_config);
+                },
+                py::arg("input_tensor").noconvert(),
+                py::arg("dims"),
+                py::kw_only(),
+                py::arg("out") = std::nullopt,
+                py::arg("memory_config") = std::nullopt,
+                py::arg("queue_id") = 0});
+}
+
+}  // namespace ttnn::operations::data_movement::detail

--- a/ttnn/cpp/ttnn/operations/data_movement/permute/permute_pybind.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/permute/permute_pybind.hpp
@@ -27,6 +27,7 @@ void bind_permute(py::module& module) {
             Keyword Args:
                 * :attr:`memory_config`: Memory Config of the output tensor
                 * :attr:`queue_id`: command queue id
+                * :attr:`output_tensor`: optional output tensor
 
             Example:
 
@@ -44,15 +45,15 @@ void bind_permute(py::module& module) {
             [] (const OperationType& self,
                 const ttnn::Tensor& input_tensor,
                 const std::vector<int> &dims,
-                std::optional<ttnn::Tensor> optional_output_tensor,
+                std::optional<ttnn::Tensor> &optional_output_tensor,
                 const std::optional<ttnn::MemoryConfig>& memory_config,
                 uint8_t queue_id) {
-                    return self(queue_id, input_tensor, dims, memory_config);
+                    return self(queue_id, input_tensor, dims, memory_config, optional_output_tensor);
                 },
                 py::arg("input_tensor").noconvert(),
                 py::arg("dims"),
                 py::kw_only(),
-                py::arg("out") = std::nullopt,
+                py::arg("output_tensor").noconvert() = std::nullopt,
                 py::arg("memory_config") = std::nullopt,
                 py::arg("queue_id") = 0});
 }

--- a/ttnn/ttnn/operations/data_movement.py
+++ b/ttnn/ttnn/operations/data_movement.py
@@ -76,28 +76,13 @@ def _golden_function(input_tensor: ttnn.Tensor, order: Tuple[int, ...], **_):
     return input_tensor.permute(order).contiguous().clone()
 
 
-doc = r"""
-permute(input_tensor: ttnn.Tensor, order: Tuple[int, ...]) -> ttnn.Tensor
+def _golden_function(input_tensor, dims, **_):
+    import torch
 
-Permutes :attr:`input_tensor` using :attr:`order`.
+    return torch.permute(input_tensor, dims)
 
-Args:
-    * :attr:`input_tensor`: the input tensor
-    * :attr:`order`: the desired ordering of dimensions.
 
-Example::
-
-    >>> tensor = ttnn.to_device(ttnn.from_torch(torch.zeros((1, 1, 64, 32), dtype=torch.bfloat16)), device)
-    >>> output = ttnn.permute(tensor, (0, 1, 3, 2))
-    >>> print(output.shape)
-    [1, 1, 32, 64]
-
-"""
-ttnn.register_python_operation(
-    name="ttnn.permute",
-    golden_function=_golden_function,
-    doc=doc,
-)(ttnn._ttnn.operations.data_movement.permute)
+ttnn.attach_golden_function(ttnn._ttnn.operations.data_movement.permute, golden_function=_golden_function)
 
 
 def _golden_function(tensors, dim=0, **_):


### PR DESCRIPTION
### Ticket
#9746 

### Problem description
Permute is already in TTNN but needs to be restructured to the new file structure

### What's changed
Moved the permute pybind and its op calls to its own file
TODO: move all tt_eager logic into the new folder structure
TODO: remove launch_with_autoformat call in that same tt_eager logic
TODO: need the transpose program creation calls moved as well since permute eventually calls those
TODO: create a custom struct for the op creation with its own validate
TODO: delete the tt_eager logic

### Checklist
- [x] Post commit CI passes
- [x] Model regression CI testing passes (if applicable)
- [x] New/Existing tests provide coverage for changes
