### PR TITLE
#0: Update buffer asserts to account for trace buffers

### DIFF
--- a/tt_metal/impl/buffers/buffer.cpp
+++ b/tt_metal/impl/buffers/buffer.cpp
@@ -255,7 +255,7 @@ void Buffer::allocate() {
 }
 
 uint32_t Buffer::dram_channel_from_bank_id(uint32_t bank_id) const {
-    TT_ASSERT(this->buffer_type_ == BufferType::DRAM, "Expected DRAM buffer!");
+    TT_ASSERT(this->is_dram(), "Expected DRAM buffer!");
     return this->device_->dram_channel_from_bank_id(bank_id);
 }
 

--- a/tt_metal/impl/dispatch/command_queue.cpp
+++ b/tt_metal/impl/dispatch/command_queue.cpp
@@ -64,7 +64,7 @@ EnqueueReadBufferCommand::EnqueueReadBufferCommand(
     src_page_index(src_page_index),
     pages_to_read(pages_to_read.has_value() ? pages_to_read.value() : buffer.num_pages()) {
     TT_ASSERT(
-        buffer.buffer_type() == BufferType::DRAM or buffer.buffer_type() == BufferType::L1,
+        buffer.is_dram() or buffer.is_l1(),
         "Trying to read an invalid buffer");
 
     this->device = device;


### PR DESCRIPTION
### Ticket

### Problem description
@pgkeller pointed out asserts being hit with `InstantiateTraceSanity` in debug mode. Turns out some of the paths for backdoor trace access were not accounting for trace buffer type.

### What's changed
Modify assert `TT_ASSERT(this->buffer_type_ == BufferType::DRAM)` to more generic `TT_ASSERT(this->is_dram())`, which accounts for all different buffer types that live in DRAM, including trace.

### Checklist
- [ ] Post commit CI passes
- [ ] Model regression CI testing passes (if applicable)
- [ ] New/Existing tests provide coverage for changes
