### PR TITLE
Fix N150 product name to nebula_x1 even if its unharvested.

### DIFF
--- a/tt_metal/common/core_descriptor.cpp
+++ b/tt_metal/common/core_descriptor.cpp
@@ -18,6 +18,15 @@ const core_descriptor_t &get_core_descriptor_config(chip_id_t device_id, const u
     uint32_t num_harvested_rows = mask_bitset.count();
 
     std::string product_name = get_product_name(arch, num_harvested_rows);
+    if (tt::Cluster::instance().is_galaxy_cluster()) {
+        if (tt::Cluster::instance().get_board_type(device_id) == BoardType::N150) {
+            //some Galaxy machines are setup with N150s that have 0 harvested rows.
+            //get_product_name ( ) returns those chips as galaxy. Override that to nebula_x1.
+            product_name = "nebula_x1";
+        } else {
+            TT_ASSERT(tt::Cluster::instance().get_board_type(device_id) == BoardType::GALAXY, "Invalid Board Type in Galaxy Cluster. Only GALAXY and N150 are supported.");
+        }
+    }
 
     if (num_harvested_rows > 2) {
         TT_THROW("At most two rows can be harvested, but detected {} harvested rows", num_harvested_rows);

--- a/tt_metal/llrt/tt_cluster.cpp
+++ b/tt_metal/llrt/tt_cluster.cpp
@@ -129,6 +129,10 @@ bool Cluster::is_galaxy_cluster() const {
     return this->is_tg_cluster_;
 }
 
+BoardType Cluster::get_board_type(chip_id_t chip_id) const {
+  return this->cluster_desc_->get_board_type(chip_id);
+}
+
 void Cluster::generate_cluster_descriptor() {
     this->cluster_desc_path_ = (this->target_type_ == TargetDevice::Silicon and this->arch_ == tt::ARCH::WORMHOLE_B0)
                                    ? get_cluster_desc_yaml().string()

--- a/tt_metal/llrt/tt_cluster.hpp
+++ b/tt_metal/llrt/tt_cluster.hpp
@@ -223,7 +223,11 @@ class Cluster {
         return this->tunnels_from_mmio_device.at(mmio_chip_id);
     }
 
+    // Returns whether we are running on Galaxy.
     bool is_galaxy_cluster() const;
+
+    // Returns Wormhole chip board type.
+    BoardType get_board_type(chip_id_t chip_id) const;
 
    private:
     Cluster();


### PR DESCRIPTION
product name is used to look up available dispatch cores from arch yaml file.
Galaxy machines can have gateway WH N150 boards that can have 0 harvested rows. Usually N150 has 1 harvested row.
Due to this, the N150 gets aliased with Galaxy board type and Metal picks up galaxy dispatch core settings for gateway N150.
The fix is to use board type on galaxy cluster and override produce name to nebula_x1 if its N150 board.
