### PR TITLE
Update FD cmds to be PCIe aligned

### DIFF
--- a/tests/scripts/run_cpp_fd2_tests.sh
+++ b/tests/scripts/run_cpp_fd2_tests.sh
@@ -87,8 +87,8 @@ run_test "./build/test/tt_metal/perf_microbenchmark/dispatch/test_prefetcher -t 
 run_test "./build/test/tt_metal/perf_microbenchmark/dispatch/test_prefetcher -t 2 -i 1000 -x -rb -spre -sdis -packetized_en"  # Random Test
 
 
-# Testcase: Paged Write Cmd to DRAM. 256 pages, 224b size.
-./build/test/tt_metal/perf_microbenchmark/dispatch/test_prefetcher -t 4 -i 1 -dpgs 224 -dpgr 256
+# Testcase: Paged Write Cmd to DRAM. 256 pages, 256b size.
+./build/test/tt_metal/perf_microbenchmark/dispatch/test_prefetcher -t 4 -i 1 -dpgs 256 -dpgr 256
 # Testcase: Paged Write Cmd to DRAM. 120 pages, 64b size.
 ./build/test/tt_metal/perf_microbenchmark/dispatch/test_prefetcher -t 4 -i 1 -dpgs 64 -dpgr 120
 

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/test_prefetcher.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/test_prefetcher.cpp
@@ -43,7 +43,7 @@ constexpr uint32_t DEFAULT_PACKETIZED_PATH_TIMEOUT_EN = 0;
 constexpr uint32_t DRAM_DATA_SIZE_BYTES = 16 * 1024 * 1024;
 constexpr uint32_t DRAM_DATA_SIZE_WORDS = DRAM_DATA_SIZE_BYTES / sizeof(uint32_t);
 constexpr uint32_t DRAM_DATA_BASE_ADDR = 1024 * 1024;
-constexpr uint32_t DRAM_DATA_ALIGNMENT = 32;
+constexpr uint32_t DRAM_DATA_ALIGNMENT = DRAM_ALIGNMENT;
 
 constexpr uint32_t PCIE_TRANSFER_SIZE_DEFAULT = 4096;
 
@@ -1097,10 +1097,11 @@ void gen_smoke_test(Device *device,
     gen_dram_packed_read_cmd(device, prefetch_cmds, cmd_sizes, device_data, another_worker_core, packed_read_page_size, lengths);
 
     lengths.resize(0);
-    lengths.push_back(2080);
+    uint32_t length_to_read = align(2080, DRAM_DATA_ALIGNMENT);
+    lengths.push_back(length_to_read);
     gen_dram_packed_read_cmd(device, prefetch_cmds, cmd_sizes, device_data, another_worker_core, packed_read_page_size, lengths);
 
-    lengths.push_back(2080);
+    lengths.push_back(length_to_read);
     gen_dram_packed_read_cmd(device, prefetch_cmds, cmd_sizes, device_data, another_worker_core, packed_read_page_size + 1, lengths);
 
     lengths.resize(0);
@@ -1121,38 +1122,38 @@ void gen_smoke_test(Device *device,
     // Read from dram, write to worker
     // start_page, base addr, page_size, pages
     gen_dram_read_cmd(device, prefetch_cmds, cmd_sizes, device_data, worker_core,
-                      0, 0, 32, num_dram_banks_g, 0);
+                      0, 0, DRAM_ALIGNMENT, num_dram_banks_g, 0);
     gen_dram_read_cmd(device, prefetch_cmds, cmd_sizes, device_data, worker_core,
-                      0, 0, 32, num_dram_banks_g, 0);
+                      0, 0, DRAM_ALIGNMENT, num_dram_banks_g, 0);
     gen_dram_read_cmd(device, prefetch_cmds, cmd_sizes, device_data, worker_core,
-                      4, 32, 64, num_dram_banks_g, 0);
+                      4, DRAM_ALIGNMENT, DRAM_ALIGNMENT * 2, num_dram_banks_g, 0);
 
     gen_dram_read_cmd(device, prefetch_cmds, cmd_sizes, device_data, worker_core,
                       0, 0, 128, 128, 0);
     gen_dram_read_cmd(device, prefetch_cmds, cmd_sizes, device_data, worker_core,
-                      4, 32, 2048, num_dram_banks_g + 4, 0);
+                      4, DRAM_ALIGNMENT, 2048, num_dram_banks_g + 4, 0);
     gen_dram_read_cmd(device, prefetch_cmds, cmd_sizes, device_data, worker_core,
-                      5, 32, 2048, num_dram_banks_g * 3 + 1, 0);
+                      5, DRAM_ALIGNMENT, 2048, num_dram_banks_g * 3 + 1, 0);
     gen_dram_read_cmd(device, prefetch_cmds, cmd_sizes, device_data, worker_core,
-                      3, 128, 6144, num_dram_banks_g - 1, 0);
+                      3, align(128, DRAM_ALIGNMENT), 6144, num_dram_banks_g - 1, 0);
 
     gen_dram_read_cmd(device, prefetch_cmds, cmd_sizes, device_data, worker_core,
                       0, 0, 128, 128, 32);
     gen_dram_read_cmd(device, prefetch_cmds, cmd_sizes, device_data, worker_core,
-                      4, 32, 2048, num_dram_banks_g * 2, 1536);
+                      4, DRAM_ALIGNMENT, 2048, num_dram_banks_g * 2, 1536);
     gen_dram_read_cmd(device, prefetch_cmds, cmd_sizes, device_data, worker_core,
-                      5, 32, 2048, num_dram_banks_g * 2 + 1, 256);
+                      5, DRAM_ALIGNMENT, 2048, num_dram_banks_g * 2 + 1, 256);
     gen_dram_read_cmd(device, prefetch_cmds, cmd_sizes, device_data, worker_core,
-                      3, 128, 6144, num_dram_banks_g - 1, 640);
+                      3, align(128, DRAM_ALIGNMENT), 6144, num_dram_banks_g - 1, 640);
 
     // Large pages
     gen_dram_read_cmd(device, prefetch_cmds, cmd_sizes, device_data, worker_core,
-                      0, 0, scratch_db_size_g / 2 + 32, 2, 128); // just a little larger than the scratch_db, length_adjust backs into prior page
+                      0, 0, scratch_db_size_g / 2 + DRAM_ALIGNMENT, 2, 128); // just a little larger than the scratch_db, length_adjust backs into prior page
     gen_dram_read_cmd(device, prefetch_cmds, cmd_sizes, device_data, worker_core,
                       0, 0, scratch_db_size_g, 2, 0); // exactly the scratch db size
 
     // Forces length_adjust to back into prior read.  Device reads pages, shouldn't be a problem...
-    uint32_t page_size = 256 + 32;
+    uint32_t page_size = 256 + DRAM_ALIGNMENT;
     uint32_t length = scratch_db_size_g / 2 / page_size * page_size + page_size;
     gen_dram_read_cmd(device, prefetch_cmds, cmd_sizes, device_data, worker_core,
                       3, 128, page_size, length / page_size, 160);

--- a/tt_metal/impl/dispatch/command_queue.cpp
+++ b/tt_metal/impl/dispatch/command_queue.cpp
@@ -188,7 +188,7 @@ void EnqueueWriteInterleavedBufferCommand::add_buffer_data(HugepageDeviceCommand
             this->buffer.page_size();
         if (this->buffer.page_size() % this->buffer.alignment() != 0 and
             this->buffer.page_size() != this->buffer.size()) {
-            // If page size is not 32B-aligned, we cannot do a contiguous write
+            // If page size is not aligned, we cannot do a contiguous write
             uint32_t src_address_offset = unpadded_src_offset;
             for (uint32_t sysmem_address_offset = 0; sysmem_address_offset < data_size_bytes;
                  sysmem_address_offset += this->padded_page_size) {
@@ -826,7 +826,7 @@ void EnqueueProgramCommand::assemble_device_commands() {
         }
         for (uint32_t i = 0; i < kernel_bins_dispatch_subcmds.size(); ++i) {
             cmd_sequence_sizeB += align(
-                CQ_PREFETCH_CMD_BARE_MIN_SIZE +
+                ((sizeof(CQPrefetchCmd) + sizeof(CQDispatchCmd))) +
                     kernel_bins_dispatch_subcmds[i].size() * sizeof(CQDispatchWritePackedLargeSubCmd),
                 PCIE_ALIGNMENT);
             cmd_sequence_sizeB += align(
@@ -1222,7 +1222,7 @@ void EnqueueRecordEventCommand::process() {
         packed_write_sizeB +  // CQ_PREFETCH_CMD_RELAY_INLINE + CQ_DISPATCH_CMD_WRITE_PACKED + unicast subcmds + event
                               // payload
         align(
-            CQ_PREFETCH_CMD_BARE_MIN_SIZE + dispatch_constants::EVENT_PADDED_SIZE,
+            sizeof(CQPrefetchCmd) + sizeof(CQDispatchCmd) + dispatch_constants::EVENT_PADDED_SIZE,
             PCIE_ALIGNMENT);  // CQ_PREFETCH_CMD_RELAY_INLINE + CQ_DISPATCH_CMD_WRITE_LINEAR_HOST + event ID
 
     void* cmd_region = this->manager.issue_queue_reserve(cmd_sequence_sizeB, this->command_queue_id);

--- a/tt_metal/impl/dispatch/device_command.hpp
+++ b/tt_metal/impl/dispatch/device_command.hpp
@@ -107,6 +107,7 @@ class DeviceCommand {
         } else {
             initialize_wait_cmds(relay_wait_dst, wait_cmd_dst);
         }
+        this->cmd_write_offsetB = align(this->cmd_write_offsetB, PCIE_ALIGNMENT);
     }
 
     void add_dispatch_wait_with_prefetch_stall(
@@ -301,6 +302,8 @@ class DeviceCommand {
             TT_ASSERT(data != nullptr);  // compiled out?
             uint32_t increment_sizeB = align(data_sizeB, PCIE_ALIGNMENT);
             this->add_data(data, data_sizeB, increment_sizeB);
+        } else {
+            this->cmd_write_offsetB = align(this->cmd_write_offsetB, PCIE_ALIGNMENT);
         }
     }
 
@@ -338,6 +341,7 @@ class DeviceCommand {
         } else {
             initialize_terminate_cmd(terminate_cmd_dst);
         }
+        this->cmd_write_offsetB = align(this->cmd_write_offsetB, PCIE_ALIGNMENT);
     }
 
     void add_prefetch_terminate() {
@@ -362,7 +366,7 @@ class DeviceCommand {
             // prefetch exec_buf_end behaves as a relay_inline
             exec_buf_end_cmd->base.cmd_id = CQ_PREFETCH_CMD_EXEC_BUF_END;
             exec_buf_end_cmd->relay_inline.length = sizeof(CQDispatchCmd);
-            exec_buf_end_cmd->relay_inline.stride = sizeof(CQDispatchCmd) + sizeof(CQPrefetchCmd);
+            exec_buf_end_cmd->relay_inline.stride = align(sizeof(CQDispatchCmd) + sizeof(CQPrefetchCmd), PCIE_ALIGNMENT);
         };
         auto initialize_dispatch_exec_buf_end_cmd = [&](CQDispatchCmd *exec_buf_end_cmd) {
             exec_buf_end_cmd->base.cmd_id = CQ_DISPATCH_CMD_EXEC_BUF_END;
@@ -382,6 +386,7 @@ class DeviceCommand {
             initialize_prefetch_exec_buf_end_cmd(prefetch_exec_buf_end_cmd_dst);
             initialize_dispatch_exec_buf_end_cmd(dispatch_exec_buf_end_cmd_dst);
         }
+        this->cmd_write_offsetB = align(this->cmd_write_offsetB, PCIE_ALIGNMENT);
     }
 
     void update_cmd_sequence(uint32_t cmd_offsetB, const void *new_data, uint32_t data_sizeB) {
@@ -493,6 +498,7 @@ class DeviceCommand {
         }
 
         this->memcpy(write_packed_large_sub_cmds_dst, &sub_cmds[offset_idx], sub_cmds_sizeB);
+        this->cmd_write_offsetB = align(this->cmd_write_offsetB, PCIE_ALIGNMENT);
     }
 
     template <typename CommandPtr, bool data = false>


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/9703
https://github.com/tenstorrent/tt-metal/issues/9801

### Problem description
Test prefetcher was hardcoding 32B for dram alignment and some cmd sequences were not abiding PCIe alignment constraints. Exposed by BH bring up because `sizeof(CQPrefetchCmd) + sizeof(CQDispatchCmd) != PCIe alignment`

### What's changed
swap some cmd sizes to use sizeof(CQPrefetchCmd) + sizeof(CQDispatchCmd)` rather than `CQ_PREFETCH_CMD_BARE_MIN_SIZE` and align cmds being written to issue queue to pcie alignment where necessary

### Checklist
- [x] [Post commit CI](https://github.com/tenstorrent/tt-metal/actions/runs/9783406488)
- [x] [Model regression CI testing](https://github.com/tenstorrent/tt-metal/actions/runs/9784414666)
