### PR TITLE
Uplift UMD to grab support for configuring static TLBs and Hugepage for BH 

### DIFF
--- a/tests/tt_metal/tt_metal/perf_microbenchmark/3_pcie_transfer/kernels/pull_from_pcie.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/3_pcie_transfer/kernels/pull_from_pcie.cpp
@@ -16,8 +16,9 @@ void kernel_main() {
 
     volatile tt_l1_ptr uint32_t* done_address = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(L1_UNRESERVED_BASE);
 
+    uint64_t pcie_noc_xy_encoding = (uint64_t)NOC_XY_PCIE_ENCODING(PCIE_NOC_X, PCIE_NOC_Y, NOC_INDEX);
     while (done_address[0] == 0) {
-        uint64_t host_src_addr = get_noc_addr_helper(NOC_XY_PCIE_ENCODING(PCIE_NOC_X, PCIE_NOC_Y, NOC_INDEX), pcie_read_ptr);
+        uint64_t host_src_addr = pcie_noc_xy_encoding | pcie_read_ptr;
         noc_async_read(host_src_addr, L1_UNRESERVED_BASE, read_sizeB);
         pcie_read_ptr += read_sizeB;
         if (pcie_read_ptr > pcie_base + pcie_sizeB) {

--- a/tests/tt_metal/tt_metal/test_kernels/dataflow/unit_tests/command_queue/pcie_write_16b.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/dataflow/unit_tests/command_queue/pcie_write_16b.cpp
@@ -11,7 +11,7 @@ void kernel_main() {
     constexpr uint32_t base_pcie_dst_address = get_compile_time_arg_val(1);
     constexpr uint32_t num_16b_writes = get_compile_time_arg_val(2);
 
-    uint64_t pcie_core_noc_encoding = uint64_t(NOC_XY_PCIE_ENCODING(PCIE_NOC_X, PCIE_NOC_Y, NOC_INDEX)) << 32;
+    uint64_t pcie_core_noc_encoding = uint64_t(NOC_XY_PCIE_ENCODING(PCIE_NOC_X, PCIE_NOC_Y, NOC_INDEX));
 
     uint32_t l1_src_address = base_l1_src_address;
     uint32_t pcie_dst_address = base_pcie_dst_address;

--- a/tt_metal/hw/inc/blackhole/noc/noc_parameters.h
+++ b/tt_metal/hw/inc/blackhole/noc/noc_parameters.h
@@ -9,26 +9,31 @@
 #define PCIE_NOC_X 11
 #define PCIE_NOC_Y 0
 
-// Addres formats
-
-#define NOC_XY_ENCODING(x, y) \
-    ((((uint64_t)(y)) << (NOC_ADDR_LOCAL_BITS + NOC_ADDR_NODE_ID_BITS)) | (((uint64_t)(x)) << NOC_ADDR_LOCAL_BITS))
-
-#define NOC_XY_PCIE_ENCODING(x, y, noc_index) \
-    NOC_XY_ENCODING(x, y)
-
-#define NOC_MULTICAST_ENCODING(x_start, y_start, x_end, y_end)                      \
-    ((((uint64_t)(x_start)) << (NOC_ADDR_LOCAL_BITS + 2 * NOC_ADDR_NODE_ID_BITS)) | \
-     (((uint64_t)(y_start)) << (NOC_ADDR_LOCAL_BITS + 3 * NOC_ADDR_NODE_ID_BITS)) | \
-     (((uint64_t)(x_end)) << NOC_ADDR_LOCAL_BITS) |                                 \
-     (((uint64_t)(y_end)) << (NOC_ADDR_LOCAL_BITS + NOC_ADDR_NODE_ID_BITS)))
-
-#define NOC_XY_COORD(x, y) ((((uint32_t)(y)) << NOC_ADDR_NODE_ID_BITS) | ((uint32_t)(x)))
+#define PCIE_NOC1_X 5
+#define PCIE_NOC1_Y 11
 
 // BH has 64 bit address space but pipegen was not updated to support this so WH scheme of encoding addresses is used (36 bits of address followed by coordinates)
 // This means that lo and mid registers need to have the address portion while the coordinates go into hi register
 #define NOC_COORD_REG_OFFSET 0 // offset (from LSB) in register holding x-y coordinate
 
+// Addres formats
+
+#define NOC_XY_ENCODING(x, y) ((((uint32_t)(y)) << (NOC_ADDR_NODE_ID_BITS)) | (((uint32_t)(x))))
+
+// Base address pulled from tt_SiliconDevice::get_pcie_base_addr_from_device
+#define NOC_XY_PCIE_ENCODING(x, y, noc_index)                                        \
+   ((uint64_t(NOC_XY_ENCODING(x, y)) << (NOC_ADDR_LOCAL_BITS - NOC_COORD_REG_OFFSET))) |  \
+   ((noc_index ? (x == PCIE_NOC1_X and y == PCIE_NOC1_Y) : (x == PCIE_NOC_X and y == PCIE_NOC_Y)) * 0x1000000000000000) \
+
+#define NOC_MULTICAST_ENCODING(x_start, y_start, x_end, y_end)                      \
+    ((((uint32_t)(x_start)) << (2 * NOC_ADDR_NODE_ID_BITS)) | \
+     (((uint32_t)(y_start)) << (3 * NOC_ADDR_NODE_ID_BITS)) | \
+     (((uint32_t)(x_end))) |                                 \
+     (((uint32_t)(y_end)) << (NOC_ADDR_NODE_ID_BITS)))
+
+// Because BH uses WH style address encoding (36 bits followed by coordinates) but PCIe transactions require bit 60 to be set, we need to mask out the xy-coordinate
+// When NOC_ADDR_LOCAL_BITS is 64 then NOC_LOCAL_ADDR_OFFSET can be used and the below define can be deprecated
+#define NOC_LOCAL_ADDR(addr) ((addr) & 0x1000000FFFFFFFFF)
 
 // Alignment restrictions
 #define NOC_L1_READ_ALIGNMENT_BYTES       16

--- a/tt_metal/hw/inc/dataflow_internal.h
+++ b/tt_metal/hw/inc/dataflow_internal.h
@@ -17,7 +17,10 @@ void noc_fast_read_wait_ready() {
 
 FORCE_INLINE
 void noc_fast_read_set_src_xy(uint64_t src_addr) {
-    NOC_CMD_BUF_WRITE_REG(noc_index, NCRISC_RD_CMD_BUF, NOC_TARG_ADDR_COORDINATE, uint32_t(src_addr >> NOC_ADDR_COORD_SHIFT));
+#ifdef ARCH_BLACKHOLE
+    NOC_CMD_BUF_WRITE_REG(noc_index, NCRISC_RD_CMD_BUF, NOC_TARG_ADDR_MID, (uint32_t)(src_addr >> 32) & 0x1000000F);
+#endif
+    NOC_CMD_BUF_WRITE_REG(noc_index, NCRISC_RD_CMD_BUF, NOC_TARG_ADDR_COORDINATE, uint32_t(src_addr >> NOC_ADDR_COORD_SHIFT) & NOC_COORDINATE_MASK);
 }
 
 FORCE_INLINE
@@ -63,7 +66,10 @@ void noc_fast_write_set_cmd_field(uint32_t vc, bool mcast, bool linked) {
 
 FORCE_INLINE
 void noc_fast_write_set_dst_xy(uint64_t dest_addr) {
-    NOC_CMD_BUF_WRITE_REG(noc_index, NCRISC_WR_CMD_BUF, NOC_RET_ADDR_COORDINATE, (uint32_t)(dest_addr >> NOC_ADDR_COORD_SHIFT));
+#ifdef ARCH_BLACKHOLE
+    NOC_CMD_BUF_WRITE_REG(noc_index, NCRISC_WR_CMD_BUF, NOC_RET_ADDR_MID, (uint32_t)(dest_addr >> 32) & 0x1000000F);
+#endif
+    NOC_CMD_BUF_WRITE_REG(noc_index, NCRISC_WR_CMD_BUF, NOC_RET_ADDR_COORDINATE, (uint32_t)(dest_addr >> NOC_ADDR_COORD_SHIFT) & NOC_COORDINATE_MASK);
 }
 
 FORCE_INLINE

--- a/tt_metal/hw/inc/debug/sanitize_noc.h
+++ b/tt_metal/hw/inc/debug/sanitize_noc.h
@@ -114,7 +114,7 @@ uint32_t debug_sanitize_noc_addr(
         x = NOC_UNICAST_ADDR_X(noc_addr);
         y = NOC_UNICAST_ADDR_Y(noc_addr);
     }
-    uint64_t noc_local_addr = NOC_LOCAL_ADDR_OFFSET(noc_addr);
+    uint64_t noc_local_addr = NOC_LOCAL_ADDR(noc_addr);
 
     // Extra check for multicast
     if (multicast) {
@@ -193,6 +193,7 @@ void debug_sanitize_noc_and_worker_addr(
 #define DEBUG_SANITIZE_NOC_READ_TRANSACTION_FROM_STATE(noc_id)                                   \
     DEBUG_SANITIZE_NOC_READ_TRANSACTION(                                                         \
         ((uint64_t)NOC_CMD_BUF_READ_REG(noc_id, NCRISC_RD_CMD_BUF, NOC_TARG_ADDR_COORDINATE) << NOC_ADDR_COORD_SHIFT) |   \
+            ((uint64_t)NOC_CMD_BUF_READ_REG(noc_id, NCRISC_RD_CMD_BUF, NOC_TARG_ADDR_MID) << 32) | \
             ((uint64_t)NOC_CMD_BUF_READ_REG(noc_id, NCRISC_RD_CMD_BUF, NOC_TARG_ADDR_LO)), \
         NOC_CMD_BUF_READ_REG(noc_id, NCRISC_RD_CMD_BUF, NOC_RET_ADDR_LO),                        \
         NOC_CMD_BUF_READ_REG(noc_index, NCRISC_RD_CMD_BUF, NOC_AT_LEN_BE));                      \
@@ -201,6 +202,7 @@ void debug_sanitize_noc_and_worker_addr(
 #define DEBUG_SANITIZE_NOC_WRITE_TRANSACTION_FROM_STATE(noc_id)                               \
     DEBUG_SANITIZE_NOC_WRITE_TRANSACTION(                                                     \
         ((uint64_t)NOC_CMD_BUF_READ_REG(noc_id, NCRISC_WR_CMD_BUF, NOC_RET_ADDR_COORDINATE) << NOC_ADDR_COORD_SHIFT) | \
+            ((uint64_t)NOC_CMD_BUF_READ_REG(noc_id, NCRISC_WR_CMD_BUF, NOC_RET_ADDR_MID) << 32) | \
             ((uint64_t)NOC_CMD_BUF_READ_REG(noc_id, NCRISC_WR_CMD_BUF, NOC_RET_ADDR_LO)),     \
         NOC_CMD_BUF_READ_REG(noc_id, NCRISC_WR_CMD_BUF, NOC_TARG_ADDR_LO),                    \
         NOC_CMD_BUF_READ_REG(noc_id, NCRISC_WR_CMD_BUF, NOC_AT_LEN_BE));                      \
@@ -230,17 +232,23 @@ void debug_sanitize_noc_and_worker_addr(
 
 #define DEBUG_SANITIZE_NOC_READ_TRANSACTION_WITH_ADDR_AND_SIZE_STATE(noc_id, noc_a_lower, worker_a)         \
     DEBUG_SANITIZE_NOC_READ_TRANSACTION(                                                                    \
-        ((uint64_t)NOC_CMD_BUF_READ_REG(noc_id, NCRISC_RD_CMD_BUF, NOC_TARG_ADDR_COORDINATE) << NOC_ADDR_COORD_SHIFT) | noc_a_lower, \
+        ((uint64_t)NOC_CMD_BUF_READ_REG(noc_id, NCRISC_RD_CMD_BUF, NOC_TARG_ADDR_COORDINATE) << NOC_ADDR_COORD_SHIFT) | \
+            ((uint64_t)NOC_CMD_BUF_READ_REG(noc_id, NCRISC_RD_CMD_BUF, NOC_TARG_ADDR_MID) << 32) | \
+            noc_a_lower, \
         worker_a,                                                                                           \
         NOC_CMD_BUF_READ_REG(noc_index, NCRISC_RD_CMD_BUF, NOC_AT_LEN_BE));
 #define DEBUG_SANITIZE_NOC_READ_TRANSACTION_WITH_ADDR_STATE(noc_id, noc_a_lower, worker_a, l)               \
     DEBUG_SANITIZE_NOC_READ_TRANSACTION(                                                                    \
-        ((uint64_t)NOC_CMD_BUF_READ_REG(noc_id, NCRISC_RD_CMD_BUF, NOC_TARG_ADDR_COORDINATE) << NOC_ADDR_COORD_SHIFT) | noc_a_lower, \
+        ((uint64_t)NOC_CMD_BUF_READ_REG(noc_id, NCRISC_RD_CMD_BUF, NOC_TARG_ADDR_COORDINATE) << NOC_ADDR_COORD_SHIFT) | \
+            ((uint64_t)NOC_CMD_BUF_READ_REG(noc_id, NCRISC_RD_CMD_BUF, NOC_TARG_ADDR_MID) << 32) | \
+            noc_a_lower, \
         worker_a,                                                                                           \
         l);
 #define DEBUG_SANITIZE_NOC_WRITE_TRANSACTION_WITH_ADDR_AND_SIZE_STATE(noc_id, noc_a_lower, worker_a)           \
     DEBUG_SANITIZE_NOC_WRITE_TRANSACTION(                                                                      \
-        ((uint64_t)NOC_CMD_BUF_READ_REG(noc_index, NCRISC_WR_CMD_BUF, NOC_TARG_ADDR_COORDINATE) << NOC_ADDR_COORD_SHIFT) | noc_a_lower, \
+        ((uint64_t)NOC_CMD_BUF_READ_REG(noc_id, NCRISC_WR_CMD_BUF, NOC_TARG_ADDR_COORDINATE) << NOC_ADDR_COORD_SHIFT) | \
+            ((uint64_t)NOC_CMD_BUF_READ_REG(noc_id, NCRISC_WR_CMD_BUF, NOC_TARG_ADDR_MID) << 32) | \
+            noc_a_lower, \
         worker_a,                                                                                              \
         NOC_CMD_BUF_READ_REG(noc_index, NCRISC_WR_CMD_BUF, NOC_AT_LEN_BE));
 #define DEBUG_INSERT_DELAY(transaction_type) debug_insert_delay(transaction_type)

--- a/tt_metal/hw/inc/grayskull/noc/noc_parameters.h
+++ b/tt_metal/hw/inc/grayskull/noc/noc_parameters.h
@@ -9,10 +9,13 @@
 #define PCIE_NOC_X 0
 #define PCIE_NOC_Y 4
 
+// GS address encoding is 32 bits of address followed by coordinate. First address goes into lo register, coordinates are in the mid register
+#define NOC_COORD_REG_OFFSET 0 // offset (from LSB) in register holding x-y coordinate
+
 // Address formats
 #define NOC_XY_ENCODING(x, y) ((((uint32_t)(y)) << (NOC_ADDR_NODE_ID_BITS)) | (((uint32_t)(x))))
 
-#define NOC_XY_PCIE_ENCODING(x, y, noc_index) NOC_XY_ENCODING(x, y)
+#define NOC_XY_PCIE_ENCODING(x, y, noc_index) ((uint64_t(NOC_XY_ENCODING(x, y)) << (NOC_ADDR_LOCAL_BITS - NOC_COORD_REG_OFFSET)))
 
 #define NOC_MULTICAST_ENCODING(x_start, y_start, x_end, y_end)                                          \
     ((x_start) << (2 * NOC_ADDR_NODE_ID_BITS)) | ((y_start) << (3 * NOC_ADDR_NODE_ID_BITS)) | (x_end) | \
@@ -20,8 +23,8 @@
 
 #define NOC_XY_ADDR2(xy, addr) ((((uint64_t)(xy)) << NOC_ADDR_LOCAL_BITS) | ((uint64_t)(addr)))
 
-// GS address encoding is 32 bits of address followed by coordinate. First address goes into lo register, coordinates are in the mid register
-#define NOC_COORD_REG_OFFSET 0 // offset (from LSB) in register holding x-y coordinate
+// Pass-through for WH and GS, special cased for BH
+#define NOC_LOCAL_ADDR(addr) NOC_LOCAL_ADDR_OFFSET(addr)
 
 // Alignment restrictions
 #define NOC_L1_READ_ALIGNMENT_BYTES       16

--- a/tt_metal/hw/inc/grayskull/noc_nonblocking_api.h
+++ b/tt_metal/hw/inc/grayskull/noc_nonblocking_api.h
@@ -19,6 +19,7 @@ const uint32_t NCRISC_AT_CMD_BUF = 3; // for atomics
 constexpr uint32_t NOC_ADDR_COORD_SHIFT = 32; // address is lower 36 bits and upper bits are the coordinates, 32 bits in lo reg and rest goes to mid
 const uint32_t NOC_TARG_ADDR_COORDINATE = NOC_TARG_ADDR_MID;
 const uint32_t NOC_RET_ADDR_COORDINATE = NOC_RET_ADDR_MID;
+const uint32_t NOC_COORDINATE_MASK = 0xFFFFFFFF;
 
 extern uint32_t noc_reads_num_issued[NUM_NOCS];
 extern uint32_t noc_nonposted_writes_num_issued[NUM_NOCS];

--- a/tt_metal/hw/inc/wormhole/noc/noc_parameters.h
+++ b/tt_metal/hw/inc/wormhole/noc/noc_parameters.h
@@ -12,6 +12,9 @@
 #define PCIE_NOC1_X 9
 #define PCIE_NOC1_Y 8
 
+// 36 bits of address followed by coordinate. First 32 bits of address go into lo register, remaining address bits and coordinates are in the mid register
+#define NOC_COORD_REG_OFFSET 4 // offset (from LSB) in register holding x-y coordinate
+
 // Address formats
 #define NOC_XY_ENCODING(x, y)                                        \
    (((uint32_t)(y)) << ((NOC_ADDR_LOCAL_BITS % 32)+NOC_ADDR_NODE_ID_BITS)) |  \
@@ -19,8 +22,8 @@
 
 // Address formats
 #define NOC_XY_PCIE_ENCODING(x, y, noc_index)                                        \
-   NOC_XY_ENCODING(x, y) |  \
-   ((noc_index ? (x == PCIE_NOC1_X and y == PCIE_NOC1_Y) : (x == PCIE_NOC_X and y == PCIE_NOC_Y)) * 0x8) \
+   ((uint64_t(NOC_XY_ENCODING(x, y)) << (NOC_ADDR_LOCAL_BITS - NOC_COORD_REG_OFFSET))) |  \
+   ((noc_index ? (x == PCIE_NOC1_X and y == PCIE_NOC1_Y) : (x == PCIE_NOC_X and y == PCIE_NOC_Y)) * 0x800000000) \
 
 #define NOC_MULTICAST_ENCODING(x_start, y_start, x_end, y_end)                \
    (((uint32_t)(x_start)) << ((NOC_ADDR_LOCAL_BITS % 32)+2*NOC_ADDR_NODE_ID_BITS)) |   \
@@ -32,8 +35,8 @@
    ((((uint64_t)(xy)) << NOC_ADDR_LOCAL_BITS) |                        \
    ((uint64_t)(addr)))
 
-// 36 bits of address followed by coordinate. First 32 bits of address go into lo register, remaining address bits and coordinates are in the mid register
-#define NOC_COORD_REG_OFFSET 4; // offset (from LSB) in register holding x-y coordinate
+// Pass-through for WH and GS, special cased for BH
+#define NOC_LOCAL_ADDR(addr) NOC_LOCAL_ADDR_OFFSET(addr)
 
 // Alignment restrictions
 #define NOC_L1_READ_ALIGNMENT_BYTES       16

--- a/tt_metal/hw/inc/wormhole/noc_nonblocking_api.h
+++ b/tt_metal/hw/inc/wormhole/noc_nonblocking_api.h
@@ -19,6 +19,7 @@ const uint32_t NCRISC_AT_CMD_BUF = 3; // for atomics
 constexpr uint32_t NOC_ADDR_COORD_SHIFT = 32; // address is lower 36 bits and upper bits are the coordinates, 32 bits in lo reg and rest goes to mid
 const uint32_t NOC_TARG_ADDR_COORDINATE = NOC_TARG_ADDR_MID;
 const uint32_t NOC_RET_ADDR_COORDINATE = NOC_RET_ADDR_MID;
+const uint32_t NOC_COORDINATE_MASK = 0xFFFFFFFF;
 
 extern uint32_t noc_reads_num_issued[NUM_NOCS];
 extern uint32_t noc_nonposted_writes_num_issued[NUM_NOCS];

--- a/tt_metal/impl/debug/watcher_server.cpp
+++ b/tt_metal/impl/debug/watcher_server.cpp
@@ -294,7 +294,7 @@ static string get_noc_target_str(Device *device, CoreCoord &core, int noc, const
             "{} core w/ physical coords {} {}", type_and_mem.first, target_phys_noc_core.str(), type_and_mem.second);
     }
 
-    out += fmt::format("[addr=0x{:08x},len={}]", NOC_LOCAL_ADDR_OFFSET(san->noc_addr), san->len);
+    out += fmt::format("[addr=0x{:08x},len={}]", NOC_LOCAL_ADDR(san->noc_addr), san->len);
     return out;
 }
 

--- a/tt_metal/impl/dispatch/kernels/cq_common.hpp
+++ b/tt_metal/impl/dispatch/kernels/cq_common.hpp
@@ -94,7 +94,11 @@ void cq_noc_async_write_with_state(uint32_t src_addr, uint64_t dst_addr, uint32_
         NOC_CMD_BUF_WRITE_REG(noc_index, NCRISC_WR_CMD_BUF, NOC_RET_ADDR_LO, (uint32_t)dst_addr);
     }
     if constexpr (flags & CQ_NOC_FLAG_NOC) {
-        NOC_CMD_BUF_WRITE_REG(noc_index, NCRISC_WR_CMD_BUF, NOC_RET_ADDR_COORDINATE, (uint32_t)(dst_addr >> NOC_ADDR_COORD_SHIFT));
+#ifdef ARCH_BLACKHOLE
+        // Handles writing to PCIe
+        NOC_CMD_BUF_WRITE_REG(noc_index, NCRISC_WR_CMD_BUF, NOC_RET_ADDR_MID, (uint32_t)(dst_addr >> 32) & 0x1000000F);
+#endif
+        NOC_CMD_BUF_WRITE_REG(noc_index, NCRISC_WR_CMD_BUF, NOC_RET_ADDR_COORDINATE, (uint32_t)(dst_addr >> NOC_ADDR_COORD_SHIFT) & NOC_COORDINATE_MASK);
     }
     if constexpr (flags & CQ_NOC_FLAG_LEN) {
         ASSERT(size <= NOC_MAX_BURST_SIZE);

--- a/tt_metal/impl/dispatch/kernels/cq_prefetch.cpp
+++ b/tt_metal/impl/dispatch/kernels/cq_prefetch.cpp
@@ -50,7 +50,7 @@ constexpr uint32_t is_h_variant = get_compile_time_arg_val(21);
 constexpr uint32_t my_noc_xy = uint32_t(NOC_XY_ENCODING(MY_NOC_X, MY_NOC_Y));
 constexpr uint32_t upstream_noc_xy = uint32_t(NOC_XY_ENCODING(UPSTREAM_NOC_X, UPSTREAM_NOC_Y));
 constexpr uint32_t downstream_noc_xy = uint32_t(NOC_XY_ENCODING(DOWNSTREAM_NOC_X, DOWNSTREAM_NOC_Y));
-constexpr uint32_t pcie_noc_xy = uint32_t(NOC_XY_PCIE_ENCODING(NOC_0_X(static_cast<uint8_t>(NOC_INDEX), noc_size_x, PCIE_NOC_X), NOC_0_Y(static_cast<uint8_t>(NOC_INDEX), noc_size_y, PCIE_NOC_Y), NOC_INDEX));
+constexpr uint64_t pcie_noc_xy = uint64_t(NOC_XY_PCIE_ENCODING(NOC_0_X(static_cast<uint8_t>(NOC_INDEX), noc_size_x, PCIE_NOC_X), NOC_0_Y(static_cast<uint8_t>(NOC_INDEX), noc_size_y, PCIE_NOC_Y), NOC_INDEX));
 constexpr uint32_t downstream_cb_page_size = 1 << downstream_cb_log_page_size;
 constexpr uint32_t downstream_cb_end = downstream_cb_base + (1 << downstream_cb_log_page_size) * downstream_cb_pages;
 constexpr uint32_t prefetch_q_end = prefetch_q_base + prefetch_q_size;
@@ -161,7 +161,7 @@ uint32_t read_from_pcie(volatile tt_l1_ptr prefetch_q_entry_type *& prefetch_q_r
         pcie_read_ptr = pcie_base;
     }
 
-    uint64_t host_src_addr = get_noc_addr_helper(pcie_noc_xy, pcie_read_ptr);
+    uint64_t host_src_addr = pcie_noc_xy | pcie_read_ptr;
     DPRINT << "read_from_pcie: " << fence + preamble_size << " " << pcie_read_ptr << ENDL();
     noc_async_read(host_src_addr, fence + preamble_size, size);
     pending_read_size = size + preamble_size;

--- a/tt_metal/llrt/tt_cluster.cpp
+++ b/tt_metal/llrt/tt_cluster.cpp
@@ -294,9 +294,7 @@ void Cluster::start_driver(chip_id_t mmio_device_id, tt_device_params &device_pa
 
     TT_FATAL(this->sdesc_per_chip_.size(), "Descriptor must be loaded. Try open_driver()");
 
-    // static TLBs avoided for Blackhole bring up
-    if (this->target_type_ == TargetDevice::Silicon && device_params.init_device &&
-        this->arch_ != tt::ARCH::BLACKHOLE) {
+    if (this->target_type_ == TargetDevice::Silicon && device_params.init_device) {
         ll_api::configure_static_tlbs(
             this->arch_, mmio_device_id, this->get_soc_desc(mmio_device_id), this->get_driver(mmio_device_id));
     }

--- a/tt_metal/llrt/tt_cluster.cpp
+++ b/tt_metal/llrt/tt_cluster.cpp
@@ -250,8 +250,7 @@ void Cluster::open_driver(
         // This is the target/desired number of mem channels per arch/device.
         // Silicon driver will attempt to open this many hugepages as channels, and assert if workload uses more than
         // available. Metal currently uses assigns 1 channel per device
-        uint32_t num_host_mem_ch_per_mmio_device =
-            this->arch_ == tt::ARCH::BLACKHOLE ? 0 : controlled_device_ids.size();
+        uint32_t num_host_mem_ch_per_mmio_device = controlled_device_ids.size();
         if (is_tg_cluster_) {
             num_host_mem_ch_per_mmio_device = HOST_MEM_CHANNELS;
         }

--- a/tt_metal/soc_descriptors/blackhole_140_arch.yaml
+++ b/tt_metal/soc_descriptors/blackhole_140_arch.yaml
@@ -65,7 +65,8 @@ worker_l1_size:
   1499136
 
 dram_bank_size:
-  4294967296
+  # 4278190080 TODO (abhullar): upper 2GB of DRAM is untested on some BH machines. Test this limitation
+  2147483648
 
 eth_l1_size:
   262144


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/9813
https://github.com/tenstorrent/tt-metal/issues/9814

### What's changed
- Grabbed latest UMD changes to enable static TLBs and Hugepages on BH
- Remove skipping over configuring static TLBs for BH (only Tensix cores are configured)
- `get_static_tlb_index` logic taken from BBE 
- Program the `MID` registers when issuing NoC transactions because PCIe base addr from device requires bit 60 of 64 bit address to be set
- Add new `NOC_LOCAL_ADDR` define in `noc_parameters.h` because existing `NOC_LOCAL_ADDR_OFFSET` in UMD masks out the pcie base addr since we are currently using WH style addr encoding (36 bits followed by x-y coordinates)

### Checklist
- [x] [Post commit CI](https://github.com/tenstorrent/tt-metal/actions/runs/9784369317)
- [x] [Model regression CI](https://github.com/tenstorrent/tt-metal/actions/runs/9785757235)
- [x] [Nightly fast dispatch](https://github.com/tenstorrent/tt-metal/actions/runs/9785760733) - same as main
- [x] [T3000 frequent tests](https://github.com/tenstorrent/tt-metal/actions/runs/9785763354)
- [x] [T3000 model perf tests](https://github.com/tenstorrent/tt-metal/actions/runs/9785765459)
- [x] [Device perf regressions](https://github.com/tenstorrent/tt-metal/actions/runs/9785768133)
- [x] [TGG frequent tests](https://github.com/tenstorrent/tt-metal/actions/runs/9785770848)
- [x] [TGG model perf tests](https://github.com/tenstorrent/tt-metal/actions/runs/9785773644)
