### PR TITLE
Update eltwise bcast unary ops to use memory_config and fix PCC issue for interleaved output

### DIFF
--- a/models/demos/ttnn_falcon7b/tests/test_perf_device_falcon.py
+++ b/models/demos/ttnn_falcon7b/tests/test_perf_device_falcon.py
@@ -10,7 +10,7 @@ from models.perf.device_perf_utils import run_device_perf, check_device_perf, pr
 @pytest.mark.parametrize(
     "batch_size, test, expected_perf",
     [
-        [1, "BFLOAT16-L1-falcon_7b-layers_32-prefill_seq256", 3.44],
+        [1, "BFLOAT16-L1-falcon_7b-layers_32-prefill_seq256", 3.666],
         [32, "BFLOAT16-L1-falcon_7b-layers_32-decode_batch32", 139],
     ],
 )

--- a/tests/ttnn/unit_tests/operations/test_add.py
+++ b/tests/ttnn/unit_tests/operations/test_add.py
@@ -156,7 +156,7 @@ def test_add_attention_scores_to_scalar(device, shape, scalar):
     input_tensor = ttnn.from_torch(
         torch_input_tensor, layout=ttnn.TILE_LAYOUT, device=device, memory_config=ttnn.L1_MEMORY_CONFIG
     )
-    output_tensor = ttnn.add(input_tensor, scalar, memory_config=ttnn.L1_MEMORY_CONFIG)
+    output_tensor = ttnn.add(input_tensor, scalar, memory_config=ttnn.DRAM_MEMORY_CONFIG)
     output_tensor = ttnn.to_torch(output_tensor)
 
     assert ttnn.pearson_correlation_coefficient(torch_output_tensor, output_tensor) >= 0.99988

--- a/ttnn/cpp/ttnn/operations/eltwise/binary/binary.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary/binary.hpp
@@ -114,7 +114,7 @@ struct Binary {
             input_tensor_a,
             scalar,
             dtype,
-            operation::DEFAULT_OUTPUT_MEMORY_CONFIG,
+            memory_config,
             optional_output_tensor,
             activations);
     }
@@ -141,7 +141,7 @@ struct Binary {
             input_tensor_a,
             scalar_tensor_device,
             dtype,
-            operation::DEFAULT_OUTPUT_MEMORY_CONFIG,
+            memory_config,
             optional_output_tensor,
             activations);
     }

--- a/ttnn/cpp/ttnn/operations/eltwise/binary/device/broadcast_height_and_width_multi_core_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary/device/broadcast_height_and_width_multi_core_program_factory.cpp
@@ -82,10 +82,17 @@ BinaryDeviceOperation::BroadcastHeightAndWidthMultiCore::create(
     auto compute_with_storage_grid_size = device->compute_with_storage_grid_size();
     uint32_t num_cores_x = compute_with_storage_grid_size.x;
     uint32_t num_cores_y = compute_with_storage_grid_size.y;
+    uint32_t num_cores_total = num_cores_x * num_cores_y;
     auto all_device_cores = CoreRange({0, 0}, {num_cores_x - 1, num_cores_y - 1});
 
+    bool row_major = false;
+    if (shard_spec.has_value()) {
+        row_major = shard_spec.value().orientation == ShardOrientation::ROW_MAJOR;
+    }
     auto [num_cores, all_cores, core_group_1, core_group_2, num_tiles_per_core_group_1, num_tiles_per_core_group_2] =
-        split_work_to_cores(compute_with_storage_grid_size, num_tensor_tiles);
+        split_work_to_cores(compute_with_storage_grid_size, num_tensor_tiles, row_major);
+
+    auto cores = grid_to_cores(num_cores_total, num_cores_x, num_cores_y, row_major);
 
     auto src0_buffer = a.buffer();
     auto src1_buffer = b.buffer();
@@ -169,8 +176,8 @@ BinaryDeviceOperation::BroadcastHeightAndWidthMultiCore::create(
         all_device_cores,
         tt_metal::ComputeConfig{.compile_args = {}, .defines = bcast_compute_defines});
 
-    for (uint32_t i = 0, num_tiles_read = 0; i < num_cores_y * num_cores_x; i++) {
-        CoreCoord core = {i / num_cores_y, i % num_cores_y};
+    for (uint32_t i = 0, num_tiles_read = 0; i < num_cores_total; i++) {
+        const CoreCoord& core = cores.at(i);
         uint32_t num_tensor_tiles_per_core;
         if (core_group_1.core_coord_in_core_ranges(core)) {
             num_tensor_tiles_per_core = num_tiles_per_core_group_1;
@@ -255,6 +262,7 @@ void BinaryDeviceOperation::BroadcastHeightAndWidthMultiCore::override_runtime_a
     auto& program = cached_program.program;
     uint32_t num_cores_x = compute_with_storage_grid_size.x;
     uint32_t num_cores_y = compute_with_storage_grid_size.y;
+    uint32_t num_cores_total = num_cores_x * num_cores_y;
 
     auto src_buffer_a = input_tensor_a.buffer();
     auto src_dram_buffer_b = input_tensor_b.buffer();
@@ -291,8 +299,14 @@ void BinaryDeviceOperation::BroadcastHeightAndWidthMultiCore::override_runtime_a
 
     uint32_t bnc1 = (bN * bC == 1);
 
+    bool row_major = false;
+    if (shard_spec.has_value()) {
+        row_major = shard_spec.value().orientation == ShardOrientation::ROW_MAJOR;
+    }
     auto [num_cores, all_cores, core_group_1, core_group_2, num_tiles_per_core_group_1, num_tiles_per_core_group_2] =
-        split_work_to_cores(compute_with_storage_grid_size, num_tensor_tiles);
+        split_work_to_cores(compute_with_storage_grid_size, num_tensor_tiles, row_major);
+
+    auto cores = grid_to_cores(num_cores_total, num_cores_x, num_cores_y, row_major);
 
     if (shard_spec.has_value()) {
         uint32_t num_tiles_per_shard = 0;
@@ -304,8 +318,8 @@ void BinaryDeviceOperation::BroadcastHeightAndWidthMultiCore::override_runtime_a
         core_group_2 = CoreRangeSet({});
     }
 
-    for (uint32_t i = 0, num_tiles_read = 0; i < num_cores_y * num_cores_x; i++) {
-        CoreCoord core = {i / num_cores_y, i % num_cores_y};
+    for (uint32_t i = 0, num_tiles_read = 0; i < num_cores_total; i++) {
+        const CoreCoord& core = cores.at(i);
         uint32_t num_tensor_tiles_per_core;
         if (core_group_1.core_coord_in_core_ranges(core)) {
             num_tensor_tiles_per_core = num_tiles_per_core_group_1;

--- a/ttnn/cpp/ttnn/operations/eltwise/binary/device/broadcast_height_multi_core_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary/device/broadcast_height_multi_core_program_factory.cpp
@@ -71,10 +71,14 @@ BinaryDeviceOperation ::BroadcastHeightMultiCore::create(
     auto compute_with_storage_grid_size = device->compute_with_storage_grid_size();
     uint32_t num_cores_x = compute_with_storage_grid_size.x;
     uint32_t num_cores_y = compute_with_storage_grid_size.y;
+    uint32_t num_cores_total = num_cores_x * num_cores_y;
     auto all_device_cores = CoreRange({0, 0}, {num_cores_x - 1, num_cores_y - 1});
 
+    constexpr bool row_major = false;
     auto [num_cores, all_cores, core_group_1, core_group_2, Ht_per_core_group_1, Ht_per_core_group_2] =
-        split_work_to_cores(compute_with_storage_grid_size, Ht);
+        split_work_to_cores(compute_with_storage_grid_size, Ht, row_major);
+
+    auto cores = grid_to_cores(num_cores_total, num_cores_x, num_cores_y, row_major);
 
     auto src0_buffer = a.buffer();
     auto src1_buffer = b.buffer();
@@ -128,8 +132,8 @@ BinaryDeviceOperation ::BroadcastHeightMultiCore::create(
         all_device_cores,
         tt_metal::ComputeConfig{.compile_args = {}, .defines = bcast_defines});
 
-    for (uint32_t i = 0, num_Wtiles_read = 0; i < num_cores_y * num_cores_x; i++) {
-        CoreCoord core = {i / num_cores_y, i % num_cores_y};
+    for (uint32_t i = 0, num_Wtiles_read = 0; i < num_cores_total; i++) {
+        const CoreCoord& core = cores.at(i);
         uint32_t Ht_per_core;
         if (core_group_1.core_coord_in_core_ranges(core)) {
             Ht_per_core = Ht_per_core_group_1;
@@ -220,6 +224,7 @@ void BinaryDeviceOperation ::BroadcastHeightMultiCore::override_runtime_argument
 
     uint32_t num_cores_x = compute_with_storage_grid_size.x;
     uint32_t num_cores_y = compute_with_storage_grid_size.y;
+    uint32_t num_cores_total = num_cores_x * num_cores_y;
 
     auto src_dram_buffer_a = input_tensor_a.buffer();
     auto src_dram_buffer_b = input_tensor_b.buffer();
@@ -247,11 +252,14 @@ void BinaryDeviceOperation ::BroadcastHeightMultiCore::override_runtime_argument
 
     uint32_t bnc1 = (bN * bC == 1) ? 1 : 0;
 
+    constexpr bool row_major = false;
     auto [num_cores, all_cores, core_group_1, core_group_2, Ht_per_core_group_1, Ht_per_core_group_2] =
-        split_work_to_cores(compute_with_storage_grid_size, Ht);
+        split_work_to_cores(compute_with_storage_grid_size, Ht, row_major);
 
-    for (uint32_t i = 0, num_Wtiles_read = 0; i < num_cores_y * num_cores_x; i++) {
-        CoreCoord core = {i / num_cores_y, i % num_cores_y};
+    auto cores = grid_to_cores(num_cores_total, num_cores_x, num_cores_y, row_major);
+
+    for (uint32_t i = 0, num_Wtiles_read = 0; i < num_cores_total; i++) {
+        const CoreCoord& core = cores.at(i);
         uint32_t Ht_per_core;
         if (core_group_1.core_coord_in_core_ranges(core)) {
             Ht_per_core = Ht_per_core_group_1;

--- a/ttnn/cpp/ttnn/operations/eltwise/binary/device/element_wise_multi_core_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary/device/element_wise_multi_core_program_factory.cpp
@@ -104,7 +104,7 @@ inline __attribute__((always_inline)) void set_eltwise_binary_runtime_args(
             split_work_to_cores(compute_with_storage_grid_size, num_tiles, row_major);
         block_cnt_per_core_group_1 = num_tiles_per_core_group_1;
         block_cnt_per_core_group_2 = num_tiles_per_core_group_2;
-        cores = grid_to_cores(num_cores_x * num_cores_y, num_cores_x, num_cores_y, row_major);
+        cores = grid_to_cores(num_cores_total, num_cores_x, num_cores_y, row_major);
     }
 
     uint32_t g1_numcores = core_group_1.num_cores();


### PR DESCRIPTION
### Ticket
This addresses two issues:
- https://github.com/tenstorrent/tt-metal/issues/9773
- https://github.com/tenstorrent/tt-metal/issues/7637

### Problem description
Bcast eltwise unary ops essentially had two problems:
- Sharded input and interleaved output doesn't work because the input shard orientation was not being respected by the output work distribution logic
- Output should be sharded by default if input is sharded as well

### What's changed
There are two separate changes to address each of the issue (this will affect eltwise bcast unary `add`, `sub` as well:
- Infer `row_major` from the input shard orientation and pass to APIs like `split_work_to_cores` and `grid_to_cores` (the latter is newly added since it's a cleaner way to iterate across worker cores)
- Pass in `memory_config` instead of hard-coding it to interleaved. This will change the default behaviour of bcast unary ops and I will update usage where necessary.

### Checklist
- [x] Post commit CI passes
  - all post-commit: https://github.com/tenstorrent/tt-metal/actions/runs/9798322599
  - model post-commit: https://github.com/tenstorrent/tt-metal/actions/runs/9798325609
  - nightly fast dispatch: https://github.com/tenstorrent/tt-metal/actions/runs/9798323483 (with pre-existing failures)
  - 
- [x] Model regression CI testing passes (if applicable)
  - Device perf regression: https://github.com/tenstorrent/tt-metal/actions/runs/9799747874 (only GS ran)
  - Model perf regression: https://github.com/tenstorrent/tt-metal/actions/runs/9798330445 (only GS ran)
  - T3000 frequent tests: https://github.com/tenstorrent/tt-metal/actions/runs/9798332967 (lots of pre-existing failures)
  - T3000 demo tests: https://github.com/tenstorrent/tt-metal/actions/runs/9798335978 (lots of pre-existing failures)
- [x] New/Existing tests provide coverage for changes
