### PR TITLE
#9837: Assign workers after performing ref count cleanup in async mode

### DIFF
--- a/tt_eager/tensor/tensor.hpp
+++ b/tt_eager/tensor/tensor.hpp
@@ -188,10 +188,9 @@ struct Tensor {
     Tensor &operator=(const Tensor &other) {
         // Don't self-assign
         if (this->tensor_attributes != other.tensor_attributes) {
-            // Assign workers before cleanup
-            this->workers = other.workers;
             // Update ref count for curr tensor_attr and deallocate if needed
             perform_cleanup_for_async_mode();
+            this->workers = other.workers;
             this->tensor_id = other.tensor_id;
             this->tensor_attributes = other.tensor_attributes;
             this->deallocate_through_destructor = other.deallocate_through_destructor;
@@ -209,10 +208,9 @@ struct Tensor {
     Tensor &operator=(Tensor &&other) {
         // Don't self assign
         if (this->tensor_attributes != other.tensor_attributes) {
-            // Assign workers before cleanup
-            this->workers = std::move(other.workers);
             // Update ref count for curr tensor_attr and deallocate if needed
             perform_cleanup_for_async_mode();
+            this->workers = std::move(other.workers);
             this->tensor_id = std::move(other.tensor_id);
             this->tensor_attributes = std::move(other.tensor_attributes);
             this->deallocate_through_destructor = std::move(other.deallocate_through_destructor);


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/9837

### Problem description
Segfault seen when generating rotation matrix cache for LLMs. Was never seen on CI, since these runners have the cache already created.

### What's changed
Reference count management for tensors was erroneous. This case was not correctly supported:

`device_tensor = device_tensor.cpu()`

The reference count for the device tensor would not get decremented post assignment.

Assign worker vector after decrementing ref count when calling the tensor copy or move assignment operators.

### Checklist
- [x] Post commit CI passes
- [ ] Model regression CI testing passes (if applicable)
- [ ] New/Existing tests provide coverage for changes
