### PR TITLE
#9941: update dram/l1 to noc xy header to do the appropriate shift

### DIFF
--- a/tt_metal/hw/inc/blackhole/noc/noc_parameters.h
+++ b/tt_metal/hw/inc/blackhole/noc/noc_parameters.h
@@ -25,6 +25,11 @@
 
 #define NOC_XY_COORD(x, y) ((((uint32_t)(y)) << NOC_ADDR_NODE_ID_BITS) | ((uint32_t)(x)))
 
+// BH has 64 bit address space but pipegen was not updated to support this so WH scheme of encoding addresses is used (36 bits of address followed by coordinates)
+// This means that lo and mid registers need to have the address portion while the coordinates go into hi register
+#define NOC_COORD_REG_OFFSET 0 // offset (from LSB) in register holding x-y coordinate
+
+
 // Alignment restrictions
 #define NOC_L1_READ_ALIGNMENT_BYTES       16
 #define NOC_L1_WRITE_ALIGNMENT_BYTES      16

--- a/tt_metal/hw/inc/dataflow_api.h
+++ b/tt_metal/hw/inc/dataflow_api.h
@@ -434,7 +434,7 @@ std::uint64_t get_noc_addr_helper(std::uint32_t noc_xy, std::uint32_t addr) {
         Get an encoding which contains tensix core and address you want to
         write to via the noc multicast
     */
-    return ((uint64_t)(noc_xy) << 32) | addr;
+    return ((uint64_t)(noc_xy) << NOC_ADDR_COORD_SHIFT) | addr;
 }
 
 

--- a/tt_metal/hw/inc/grayskull/noc/noc_parameters.h
+++ b/tt_metal/hw/inc/grayskull/noc/noc_parameters.h
@@ -20,6 +20,9 @@
 
 #define NOC_XY_ADDR2(xy, addr) ((((uint64_t)(xy)) << NOC_ADDR_LOCAL_BITS) | ((uint64_t)(addr)))
 
+// GS address encoding is 32 bits of address followed by coordinate. First address goes into lo register, coordinates are in the mid register
+#define NOC_COORD_REG_OFFSET 0 // offset (from LSB) in register holding x-y coordinate
+
 // Alignment restrictions
 #define NOC_L1_READ_ALIGNMENT_BYTES       16
 #define NOC_L1_WRITE_ALIGNMENT_BYTES      16

--- a/tt_metal/hw/inc/grayskull/noc_nonblocking_api.h
+++ b/tt_metal/hw/inc/grayskull/noc_nonblocking_api.h
@@ -15,6 +15,7 @@ const uint32_t NCRISC_RD_CMD_BUF = 1;  // for all reads
 const uint32_t NCRISC_WR_REG_CMD_BUF = 2;  // for small writes (e.g., registers, semaphores)
 const uint32_t NCRISC_AT_CMD_BUF = 3; // for atomics
 
+// 32 bits of address followed by coordinate. First address goes into lo register, coordinates are in the mid register
 constexpr uint32_t NOC_ADDR_COORD_SHIFT = 32; // address is lower 36 bits and upper bits are the coordinates, 32 bits in lo reg and rest goes to mid
 const uint32_t NOC_TARG_ADDR_COORDINATE = NOC_TARG_ADDR_MID;
 const uint32_t NOC_RET_ADDR_COORDINATE = NOC_RET_ADDR_MID;

--- a/tt_metal/hw/inc/wormhole/noc/noc_parameters.h
+++ b/tt_metal/hw/inc/wormhole/noc/noc_parameters.h
@@ -32,6 +32,9 @@
    ((((uint64_t)(xy)) << NOC_ADDR_LOCAL_BITS) |                        \
    ((uint64_t)(addr)))
 
+// 36 bits of address followed by coordinate. First 32 bits of address go into lo register, remaining address bits and coordinates are in the mid register
+#define NOC_COORD_REG_OFFSET 4; // offset (from LSB) in register holding x-y coordinate
+
 // Alignment restrictions
 #define NOC_L1_READ_ALIGNMENT_BYTES       16
 #define NOC_L1_WRITE_ALIGNMENT_BYTES      16

--- a/tt_metal/hw/inc/wormhole/noc_nonblocking_api.h
+++ b/tt_metal/hw/inc/wormhole/noc_nonblocking_api.h
@@ -15,6 +15,7 @@ const uint32_t NCRISC_RD_CMD_BUF = 1;  // for all reads
 const uint32_t NCRISC_WR_REG_CMD_BUF = 2;  // for small writes (e.g., registers, semaphores)
 const uint32_t NCRISC_AT_CMD_BUF = 3; // for atomics
 
+// 36 bits of address followed by coordinate. First 32 bits of address go into lo register, remaining address bits and coordinates are in the mid register
 constexpr uint32_t NOC_ADDR_COORD_SHIFT = 32; // address is lower 36 bits and upper bits are the coordinates, 32 bits in lo reg and rest goes to mid
 const uint32_t NOC_TARG_ADDR_COORDINATE = NOC_TARG_ADDR_MID;
 const uint32_t NOC_RET_ADDR_COORDINATE = NOC_RET_ADDR_MID;

--- a/tt_metal/jit_build/genfiles.cpp
+++ b/tt_metal/jit_build/genfiles.cpp
@@ -467,7 +467,7 @@ std::string generate_bank_to_noc_coord_descriptor_string(
         for (unsigned int bank_id = 0; bank_id < dram_bank_map.size(); bank_id++) {
             uint16_t noc_x = NOC_0_X(noc, grid_size.x, dram_bank_map[bank_id].x);
             uint16_t noc_y = NOC_0_Y(noc, grid_size.y, dram_bank_map[bank_id].y);
-            uint16_t xy = ((noc_y << NOC_ADDR_NODE_ID_BITS) | noc_x) << (NOC_ADDR_LOCAL_BITS - 32);
+            uint16_t xy = ((noc_y << NOC_ADDR_NODE_ID_BITS) | noc_x) << NOC_COORD_REG_OFFSET;
             ss << "        " << xy << "," << "\t// NOC_X=" << noc_x << " NOC_Y=" << noc_y << endl;
         }
         ss << "    }," << endl;
@@ -524,7 +524,7 @@ std::string generate_bank_to_noc_coord_descriptor_string(
         for (unsigned int bank_id = 0; bank_id < l1_bank_map.size(); bank_id++) {
             uint16_t noc_x = NOC_0_X(noc, grid_size.x, l1_bank_map[bank_id].x);
             uint16_t noc_y = NOC_0_Y(noc, grid_size.y, l1_bank_map[bank_id].y);
-            uint16_t xy = ((noc_y << NOC_ADDR_NODE_ID_BITS) | noc_x) << (NOC_ADDR_LOCAL_BITS - 32);
+            uint16_t xy = ((noc_y << NOC_ADDR_NODE_ID_BITS) | noc_x) << NOC_COORD_REG_OFFSET;
             ss << "        " << xy << "," << "\t// NOC_X=" << noc_x << " NOC_Y=" << noc_y << endl;
         }
         ss << "    }," << endl;


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/9941

### Problem description
The dram/l1 to noc xy mapping in the generated headers was erroneously shifting the xy coordinate  so the incorrect value was being written to the hi register

### What's changed
Added new define for offset of x-y coordinate within the hi register

With this change:
`TT_METAL_SLOW_DISPATCH_MODE=1 ./build/test/tt_eager/ops/test_eltwise_binary_op` is passing 

### Checklist
- [x] [Post commit CI passes](https://github.com/tenstorrent/tt-metal/actions/runs/9787577730) (known [issue](https://github.com/tenstorrent/tt-metal/issues/9888)) passed on [re-run](https://github.com/tenstorrent/tt-metal/actions/runs/9800104057)
- [x] [Model regression CI testing passes](https://github.com/tenstorrent/tt-metal/actions/runs/9787580454)
