### PR TITLE
Fix branching bug in softplus kernel

### DIFF
--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_softplus.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_softplus.h
@@ -30,7 +30,7 @@ inline vFloat softplus(vFloat x) {
     v_elseif(x < -5.0f) {
         // Coefficients for [-20, -5]
         result =
-            (((((vConstFloatPrgm0 * x + vConstFloatPrgm1) * x + vConstFloatPrgm2) * x + 5.25169871e-03) * x +
+            (((((2.01778601e-07 * x + 1.41959790e-05) * x + 3.90682149e-04) * x + 5.25169871e-03) * x +
               3.44602422e-02) *
                  x +
              8.83130932e-02);
@@ -87,11 +87,7 @@ inline void calculate_softplus(uint param0, uint param1, uint param2) {
 }
 
 template <bool APPROXIMATION_MODE>
-void softplus_init() {
-    vConstFloatPrgm0 = 2.01778601e-07;
-    vConstFloatPrgm1 = 1.41959790e-05;
-    vConstFloatPrgm2 = 3.90682149e-04;
-}
+void softplus_init() {}
 
 }  // namespace sfpu
 }  // namespace ckernel


### PR DESCRIPTION
Fixes broken pipeline from commit https://github.com/tenstorrent/tt-metal/commit/52956355ac6910302c599fe79c051d9fc791b6d2

@rtawfik01 Not sure why the constants work in the `ttnn` tests but not the `ttl` sweep tests. Maybe you know what the issue is?
