### PR TITLE
#9971: Support time sharding in `ssm_prefix_scan` op

### DIFF
--- a/tests/tt_eager/python_api_testing/unit_testing/misc/test_ssm_prefix_scan.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/misc/test_ssm_prefix_scan.py
@@ -65,10 +65,14 @@ def run_ssm_prefix_scan(L: int, E: int, N: int, num_cores: int, dtype, device):
     assert actual.dtype == dtype
 
     actual = tt2torch_tensor(actual)
-
     passing_pcc, output_pcc = comp_pcc(actual, expected, 0.999)
     logger.debug(f"Out passing={passing_pcc}")
     logger.debug(f"Output pcc={output_pcc}")
+
+    h_prev = tt2torch_tensor(h_prev)
+    passing_pcc, output_pcc = comp_pcc(h_prev, expected[0, 0, -1, :], 0.999)
+    logger.debug(f"Hidden state passing={passing_pcc}")
+    logger.debug(f"Hidden state pcc={output_pcc}")
 
     assert passing_pcc
 

--- a/tt_eager/tt_dnn/op_library/transformer_tms/kernels/compute/ssm_prefix_scan.cpp
+++ b/tt_eager/tt_dnn/op_library/transformer_tms/kernels/compute/ssm_prefix_scan.cpp
@@ -13,20 +13,21 @@ constexpr uint32_t NUM_TILES_IN_TILIZED_CHUNK = 32;
 
 constexpr uint32_t cb_a_in = get_compile_time_arg_val(0);
 constexpr uint32_t cb_bx_in = get_compile_time_arg_val(1);
+constexpr uint32_t cb_h_in = get_compile_time_arg_val(2);
 
-constexpr uint32_t cb_a_tilize_in = get_compile_time_arg_val(2);
-constexpr uint32_t cb_bx_tilize_in = get_compile_time_arg_val(3);
+constexpr uint32_t cb_a_tilize_in = get_compile_time_arg_val(3);
+constexpr uint32_t cb_bx_tilize_in = get_compile_time_arg_val(4);
 
-constexpr uint32_t cb_h_prev = get_compile_time_arg_val(4);
-constexpr uint32_t cb_ah = get_compile_time_arg_val(5);
-constexpr uint32_t cb_h = get_compile_time_arg_val(6);
+constexpr uint32_t cb_h_prev = get_compile_time_arg_val(5);
+constexpr uint32_t cb_ah = get_compile_time_arg_val(6);
+constexpr uint32_t cb_h = get_compile_time_arg_val(7);
 
-constexpr uint32_t cb_tilize_out = get_compile_time_arg_val(7);
-constexpr uint32_t cb_out = get_compile_time_arg_val(8);
+constexpr uint32_t cb_tilize_out = get_compile_time_arg_val(8);
+constexpr uint32_t cb_out = get_compile_time_arg_val(9);
 
-constexpr uint32_t cb_zeros = get_compile_time_arg_val(9);
+constexpr uint32_t cb_zeros = get_compile_time_arg_val(10);
 
-constexpr uint32_t cb_h_acc = get_compile_time_arg_val(10);
+constexpr uint32_t cb_h_acc = get_compile_time_arg_val(11);
 
 // This function relies on untilizing NUM_TILES_IN_TILIZED_CHUNK tiles so we pad up to that amount
 FORCE_INLINE void pack_block_rows_into_tiles(uint32_t cb_in, uint32_t cb_out, uint32_t num_tiles) {
@@ -128,8 +129,6 @@ FORCE_INLINE void copy(uint32_t cb_in, uint32_t cb_out) {
     cb_push_back(cb_out, 1);
 }
 
-FORCE_INLINE void fill_tile_zeros(uint32_t cb_id) { copy(cb_zeros, cb_id); }
-
 FORCE_INLINE void compute_ht(uint32_t cb_a, uint32_t cb_bx, uint32_t cb_out, uint32_t num_tiles) {
     for (uint32_t idx = 0; idx < num_tiles; idx++) {
         mul(cb_a, cb_h_prev, cb_ah);
@@ -157,9 +156,10 @@ void MAIN {
     untilize_init(cb_a_in);
     binary_op_init_common(cb_a_in, cb_bx_in);
 
-    // Fill initial hidden states with zeros
+    // Fill initial hidden states
     for (uint32_t tilized_chunk_idx = 0; tilized_chunk_idx < num_tilize_per_row; tilized_chunk_idx++) {
-        fill_tile_zeros(cb_h_acc);
+        copy(cb_h_in, cb_h_acc);
+        cb_pop_front(cb_h_in, 1);
     }
 
     // For each row of tiles we want to tilize chunks of 32 tiles to pack the rows into tiles

--- a/tt_eager/tt_dnn/op_library/transformer_tms/kernels/compute/ssm_prefix_scan.cpp
+++ b/tt_eager/tt_dnn/op_library/transformer_tms/kernels/compute/ssm_prefix_scan.cpp
@@ -25,9 +25,7 @@ constexpr uint32_t cb_h = get_compile_time_arg_val(7);
 constexpr uint32_t cb_tilize_out = get_compile_time_arg_val(8);
 constexpr uint32_t cb_out = get_compile_time_arg_val(9);
 
-constexpr uint32_t cb_zeros = get_compile_time_arg_val(10);
-
-constexpr uint32_t cb_h_acc = get_compile_time_arg_val(11);
+constexpr uint32_t cb_h_acc = get_compile_time_arg_val(10);
 
 // This function relies on untilizing NUM_TILES_IN_TILIZED_CHUNK tiles so we pad up to that amount
 FORCE_INLINE void pack_block_rows_into_tiles(uint32_t cb_in, uint32_t cb_out, uint32_t num_tiles) {

--- a/tt_eager/tt_dnn/op_library/transformer_tms/kernels/compute/ssm_prefix_scan.cpp
+++ b/tt_eager/tt_dnn/op_library/transformer_tms/kernels/compute/ssm_prefix_scan.cpp
@@ -147,22 +147,20 @@ void MAIN {
     const uint32_t total_tiles = get_arg_val<uint32_t>(0);
     const uint32_t total_tiles_per_row = get_arg_val<uint32_t>(1);
     const uint32_t total_tiles_per_col = get_arg_val<uint32_t>(2);
-
-    const uint32_t num_tilize_per_row =
-        (total_tiles_per_row + NUM_TILES_IN_TILIZED_CHUNK - 1) / NUM_TILES_IN_TILIZED_CHUNK;  // ceil(x/y)
+    const uint32_t num_chunks_per_row = get_arg_val<uint32_t>(3);
 
     untilize_init(cb_a_in);
     binary_op_init_common(cb_a_in, cb_bx_in);
 
     // Fill initial hidden states
-    for (uint32_t tilized_chunk_idx = 0; tilized_chunk_idx < num_tilize_per_row; tilized_chunk_idx++) {
+    for (uint32_t tilized_chunk_idx = 0; tilized_chunk_idx < num_chunks_per_row; tilized_chunk_idx++) {
         copy(cb_h_in, cb_h_acc);
         cb_pop_front(cb_h_in, 1);
     }
 
     // For each row of tiles we want to tilize chunks of 32 tiles to pack the rows into tiles
     for (uint32_t row_idx = 0; row_idx < total_tiles_per_col; row_idx++) {
-        for (uint32_t tilized_chunk_idx = 0; tilized_chunk_idx < num_tilize_per_row; tilized_chunk_idx++) {
+        for (uint32_t tilized_chunk_idx = 0; tilized_chunk_idx < num_chunks_per_row; tilized_chunk_idx++) {
             // Load the last row from the hidden state above this row
             copy(cb_h_acc, cb_h_prev);
             cb_pop_front(cb_h_acc, 1);
@@ -170,7 +168,7 @@ void MAIN {
             // If we don't have a full chunk (NUM_TILES_IN_TILIZED_CHUNK tiles) we should figure out how many tiles we
             // have left. This only runs 2-3 tiles per shard so no need to unroll.
             const uint32_t remaining_tiles_in_chunk =
-                tilized_chunk_idx == num_tilize_per_row - 1 && total_tiles_per_row % NUM_TILES_IN_TILIZED_CHUNK != 0
+                tilized_chunk_idx == num_chunks_per_row - 1 && total_tiles_per_row % NUM_TILES_IN_TILIZED_CHUNK != 0
                     ? total_tiles_per_row % NUM_TILES_IN_TILIZED_CHUNK
                     : NUM_TILES_IN_TILIZED_CHUNK;
 

--- a/tt_eager/tt_dnn/op_library/transformer_tms/kernels/dataflow/reader_ssm_prefix_scan.cpp
+++ b/tt_eager/tt_dnn/op_library/transformer_tms/kernels/dataflow/reader_ssm_prefix_scan.cpp
@@ -4,6 +4,8 @@
 
 #include "dataflow_api.h"
 
+constexpr uint32_t NUM_TILES_IN_TILIZED_CHUNK = 32;
+
 void fill_zeros(uint32_t cb_id) {
     constexpr uint32_t num_zeros_reads = 2048 / MEM_ZEROS_SIZE;
     uint64_t zeros_noc_addr = get_noc_addr(MEM_ZEROS_BASE);
@@ -20,13 +22,19 @@ void fill_zeros(uint32_t cb_id) {
 
 void kernel_main() {
     uint32_t num_tiles_per_core = get_arg_val<uint32_t>(0);
+    uint32_t total_tiles_per_row = get_arg_val<uint32_t>(1);
     constexpr uint32_t cb_a_in = get_compile_time_arg_val(0);
     constexpr uint32_t cb_bx_in = get_compile_time_arg_val(1);
-    constexpr uint32_t cb_zeros = get_compile_time_arg_val(2);
+    constexpr uint32_t cb_h_in = get_compile_time_arg_val(2);
+    constexpr uint32_t cb_zeros = get_compile_time_arg_val(3);
+
+    const uint32_t num_chunks_per_row =
+        (total_tiles_per_row + NUM_TILES_IN_TILIZED_CHUNK - 1) / NUM_TILES_IN_TILIZED_CHUNK;  // ceil(x/y)
 
     fill_zeros(cb_zeros);
     cb_push_back(cb_zeros, 1);
 
     cb_push_back(cb_a_in, num_tiles_per_core);
     cb_push_back(cb_bx_in, num_tiles_per_core);
+    cb_push_back(cb_h_in, num_chunks_per_row);
 }

--- a/tt_eager/tt_dnn/op_library/transformer_tms/kernels/dataflow/reader_ssm_prefix_scan.cpp
+++ b/tt_eager/tt_dnn/op_library/transformer_tms/kernels/dataflow/reader_ssm_prefix_scan.cpp
@@ -6,33 +6,16 @@
 
 constexpr uint32_t NUM_TILES_IN_TILIZED_CHUNK = 32;
 
-void fill_zeros(uint32_t cb_id) {
-    constexpr uint32_t num_zeros_reads = 2048 / MEM_ZEROS_SIZE;
-    uint64_t zeros_noc_addr = get_noc_addr(MEM_ZEROS_BASE);
-    uint32_t write_addr = get_write_ptr(cb_id);
-    volatile tt_l1_ptr uint32_t* ptr = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(write_addr);
-
-    // Fill tile with zeros
-    for (uint32_t i = 0; i < num_zeros_reads; ++i) {
-        noc_async_read(zeros_noc_addr, write_addr, MEM_ZEROS_SIZE);
-        write_addr += MEM_ZEROS_SIZE;
-    }
-    noc_async_read_barrier();
-}
-
 void kernel_main() {
     uint32_t num_tiles_per_core = get_arg_val<uint32_t>(0);
     uint32_t total_tiles_per_row = get_arg_val<uint32_t>(1);
+
     constexpr uint32_t cb_a_in = get_compile_time_arg_val(0);
     constexpr uint32_t cb_bx_in = get_compile_time_arg_val(1);
     constexpr uint32_t cb_h_in = get_compile_time_arg_val(2);
-    constexpr uint32_t cb_zeros = get_compile_time_arg_val(3);
 
     const uint32_t num_chunks_per_row =
         (total_tiles_per_row + NUM_TILES_IN_TILIZED_CHUNK - 1) / NUM_TILES_IN_TILIZED_CHUNK;  // ceil(x/y)
-
-    fill_zeros(cb_zeros);
-    cb_push_back(cb_zeros, 1);
 
     cb_push_back(cb_a_in, num_tiles_per_core);
     cb_push_back(cb_bx_in, num_tiles_per_core);

--- a/tt_eager/tt_dnn/op_library/transformer_tms/kernels/dataflow/reader_ssm_prefix_scan.cpp
+++ b/tt_eager/tt_dnn/op_library/transformer_tms/kernels/dataflow/reader_ssm_prefix_scan.cpp
@@ -8,14 +8,11 @@ constexpr uint32_t NUM_TILES_IN_TILIZED_CHUNK = 32;
 
 void kernel_main() {
     uint32_t num_tiles_per_core = get_arg_val<uint32_t>(0);
-    uint32_t total_tiles_per_row = get_arg_val<uint32_t>(1);
+    uint32_t num_chunks_per_row = get_arg_val<uint32_t>(1);
 
     constexpr uint32_t cb_a_in = get_compile_time_arg_val(0);
     constexpr uint32_t cb_bx_in = get_compile_time_arg_val(1);
     constexpr uint32_t cb_h_in = get_compile_time_arg_val(2);
-
-    const uint32_t num_chunks_per_row =
-        (total_tiles_per_row + NUM_TILES_IN_TILIZED_CHUNK - 1) / NUM_TILES_IN_TILIZED_CHUNK;  // ceil(x/y)
 
     cb_push_back(cb_a_in, num_tiles_per_core);
     cb_push_back(cb_bx_in, num_tiles_per_core);

--- a/tt_eager/tt_dnn/op_library/transformer_tms/kernels/dataflow/writer_ssm_prefix_scan.cpp
+++ b/tt_eager/tt_dnn/op_library/transformer_tms/kernels/dataflow/writer_ssm_prefix_scan.cpp
@@ -4,8 +4,29 @@
 
 #include "dataflow_api.h"
 
+constexpr uint32_t NUM_TILES_IN_TILIZED_CHUNK = 32;
+constexpr uint32_t NUM_BYTES_IN_BFLOAT16 = 2;
+constexpr uint32_t TILE_WIDTH = 32;
+constexpr uint32_t NUM_BYTES_IN_TILIZED_CHUNK = NUM_TILES_IN_TILIZED_CHUNK * TILE_WIDTH * NUM_BYTES_IN_BFLOAT16;
+
 void kernel_main() {
     uint32_t num_tiles_per_core = get_arg_val<uint32_t>(0);
+    const uint32_t total_tiles_per_row = get_arg_val<uint32_t>(1);
+
     constexpr uint32_t cb_out = get_compile_time_arg_val(0);
+    constexpr uint32_t cb_h_acc = get_compile_time_arg_val(1);
+    constexpr uint32_t cb_h_out = get_compile_time_arg_val(2);
+
+    const uint32_t num_tilize_per_row =
+        (total_tiles_per_row + NUM_TILES_IN_TILIZED_CHUNK - 1) / NUM_TILES_IN_TILIZED_CHUNK;  // ceil(x/y)
+
+    const uint32_t hidden_state_len_bytes = num_tilize_per_row * NUM_BYTES_IN_TILIZED_CHUNK;
+
     cb_wait_front(cb_out, num_tiles_per_core);
+
+    // This assumes we are updating h input tensor in-place
+    uint32_t src_addr = get_read_ptr(cb_h_acc);
+    uint64_t dst_addr = get_noc_addr(get_write_ptr(cb_h_out));
+    noc_async_write(src_addr, dst_addr, hidden_state_len_bytes);
+    noc_async_write_barrier();
 }

--- a/tt_eager/tt_dnn/op_library/transformer_tms/kernels/dataflow/writer_ssm_prefix_scan.cpp
+++ b/tt_eager/tt_dnn/op_library/transformer_tms/kernels/dataflow/writer_ssm_prefix_scan.cpp
@@ -11,16 +11,13 @@ constexpr uint32_t NUM_BYTES_IN_TILIZED_CHUNK = NUM_TILES_IN_TILIZED_CHUNK * TIL
 
 void kernel_main() {
     uint32_t num_tiles_per_core = get_arg_val<uint32_t>(0);
-    const uint32_t total_tiles_per_row = get_arg_val<uint32_t>(1);
+    const uint32_t num_chunks_per_row = get_arg_val<uint32_t>(1);
 
     constexpr uint32_t cb_out = get_compile_time_arg_val(0);
     constexpr uint32_t cb_h_acc = get_compile_time_arg_val(1);
     constexpr uint32_t cb_h_out = get_compile_time_arg_val(2);
 
-    const uint32_t num_tilize_per_row =
-        (total_tiles_per_row + NUM_TILES_IN_TILIZED_CHUNK - 1) / NUM_TILES_IN_TILIZED_CHUNK;  // ceil(x/y)
-
-    const uint32_t hidden_state_len_bytes = num_tilize_per_row * NUM_BYTES_IN_TILIZED_CHUNK;
+    const uint32_t hidden_state_len_bytes = num_chunks_per_row * NUM_BYTES_IN_TILIZED_CHUNK;
 
     cb_wait_front(cb_out, num_tiles_per_core);
 

--- a/tt_eager/tt_dnn/op_library/transformer_tms/multi_core_ssm_prefix_scan/multi_core_ssm_prefix_scan.cpp
+++ b/tt_eager/tt_dnn/op_library/transformer_tms/multi_core_ssm_prefix_scan/multi_core_ssm_prefix_scan.cpp
@@ -17,6 +17,7 @@ namespace transformers {
 operation::ProgramWithCallbacks multi_core_ssm_prefix_scan(
     const Tensor& a,
     const Tensor& bx,
+    const Tensor& h,
     Tensor& output,
     MathFidelity math_fidelity,
     CoreCoord compute_with_storage_grid_size) {
@@ -24,6 +25,7 @@ operation::ProgramWithCallbacks multi_core_ssm_prefix_scan(
 
     auto* a_buffer = a.buffer();
     auto* bx_buffer = bx.buffer();
+    auto* h_buffer = h.buffer();
     auto* output_buffer = output.buffer();
     TT_ASSERT(output_buffer != nullptr, "Output buffer should be allocated on device");
 
@@ -53,12 +55,17 @@ operation::ProgramWithCallbacks multi_core_ssm_prefix_scan(
     const uint32_t total_tiles_per_row = sharded_hidden_state_length / TILE_HEIGHT;
     const uint32_t total_tiles_per_col = sharded_sequence_length / TILE_HEIGHT;
     const uint32_t total_tiles = total_tiles_per_row * total_tiles_per_col;
+    const uint32_t num_chunks_per_row = ceil(float(total_tiles_per_row) / 32.0f);
 
     const uint32_t cb_a_in_id = tt::CB::c_in0;
     const auto cb_a_in = create_circular_buffer(cb_a_in_id, total_tiles, input_tile_size, input_format, a_buffer);
 
     const uint32_t cb_bx_in_id = tt::CB::c_in1;
     const auto cb_bx_in = create_circular_buffer(cb_bx_in_id, total_tiles, input_tile_size, input_format, bx_buffer);
+
+    // Hidden state is in row-major so must be bfloat16
+    const uint32_t cb_h_in_id = tt::CB::c_in2;
+    const auto cb_h_in = create_circular_buffer(cb_h_in_id, num_chunks_per_row, intermediary_tile_size, intermediary_format, h_buffer);
 
     const uint32_t cb_out_id = tt::CB::c_out0;
     const auto cb_out = create_circular_buffer(cb_out_id, total_tiles, input_tile_size, input_format, output_buffer);
@@ -89,15 +96,15 @@ operation::ProgramWithCallbacks multi_core_ssm_prefix_scan(
     const auto cb_zeros = create_circular_buffer(cb_zeros_id, 1, intermediary_tile_size, intermediary_format);
 
     const uint32_t cb_h_acc_id = tt::CB::c_intermed7;
-    const uint32_t num_chunks_per_row = ceil(float(total_tiles_per_row) / 32.0f);
     const auto cb_h_acc =
         create_circular_buffer(cb_h_acc_id, num_chunks_per_row, intermediary_tile_size, intermediary_format);
 
-    std::vector<uint32_t> reader_compile_time_args = {cb_a_in_id, cb_bx_in_id, cb_zeros_id};
+    std::vector<uint32_t> reader_compile_time_args = {cb_a_in_id, cb_bx_in_id, cb_h_in_id, cb_zeros_id};
     std::vector<uint32_t> writer_compile_time_args = {cb_out_id};
     std::vector<uint32_t> compute_compile_time_args = {
         cb_a_in_id,
         cb_bx_in_id,
+        cb_h_in_id,
         cb_a_tilize_in_id,
         cb_bx_tilize_in_id,
         cb_h_prev_id,
@@ -143,16 +150,17 @@ operation::ProgramWithCallbacks multi_core_ssm_prefix_scan(
                              cores,
                              cb_a_in,
                              cb_bx_in,
-                             cb_out](Program& program, const Tensor& a, const Tensor& bx, const Tensor& output) {
+                             cb_out](Program& program, const Tensor& a, const Tensor& bx, const Tensor &h, const Tensor& output) {
         tt_metal::Buffer* a_buffer = a.buffer();
         tt_metal::Buffer* bx_buffer = bx.buffer();
+        tt_metal::Buffer* h_buffer = h.buffer();
         tt_metal::Buffer* output_buffer = output.buffer();
 
         UpdateDynamicCircularBufferAddress(program, cb_a_in, *a_buffer);
         UpdateDynamicCircularBufferAddress(program, cb_bx_in, *bx_buffer);
         UpdateDynamicCircularBufferAddress(program, cb_out, *output_buffer);
 
-        std::vector<std::vector<uint32_t>> reader_runtime_args = {cores.size(), {0}};  // (num_tiles_per_core)
+        std::vector<std::vector<uint32_t>> reader_runtime_args = {cores.size(), {0, 0}};  // (num_tiles_per_core, total_tiles_per_row)
         std::vector<std::vector<uint32_t>> writer_runtime_args = {cores.size(), {0}};  // (num_tiles_per_core)
         std::vector<std::vector<uint32_t>> compute_runtime_args = {
             cores.size(), {0, 0, 0}};  // (total_tiles, total_tiles_per_row, total_tiles_per_col)
@@ -161,6 +169,7 @@ operation::ProgramWithCallbacks multi_core_ssm_prefix_scan(
             const CoreCoord& core = cores.at(i);
 
             reader_runtime_args[i][0] = total_tiles;
+            reader_runtime_args[i][1] = total_tiles_per_row;
 
             writer_runtime_args[i][0] = total_tiles;
 
@@ -173,7 +182,7 @@ operation::ProgramWithCallbacks multi_core_ssm_prefix_scan(
         SetRuntimeArgs(program, compute_kernel_id, cores, compute_runtime_args);
     };
 
-    set_runtime_args(program, a, bx, output);
+    set_runtime_args(program, a, bx, h, output);
 
     auto override_runtime_arguments_callback = [set_runtime_args](
                                                    const void* operation,
@@ -183,8 +192,9 @@ operation::ProgramWithCallbacks multi_core_ssm_prefix_scan(
                                                    const std::vector<Tensor>& output_tensors) {
         auto& a = input_tensors.at(0);
         auto& bx = input_tensors.at(1);
+        auto& h = input_tensors.at(2);
         auto& out = output_tensors.at(0);
-        set_runtime_args(program, a, bx, out);
+        set_runtime_args(program, a, bx, h, out);
     };
 
     return {.program = std::move(program), .override_runtime_arguments_callback = override_runtime_arguments_callback};

--- a/tt_eager/tt_dnn/op_library/transformer_tms/transformer_tms.cpp
+++ b/tt_eager/tt_dnn/op_library/transformer_tms/transformer_tms.cpp
@@ -670,15 +670,12 @@ tt::stl::reflection::Attributes SSM1DSumReduce::attributes() const {
 }
 
 void SSMPrefixScan::validate(const std::vector<Tensor>& input_tensors) const {
-    TT_FATAL(input_tensors.size() == 2, "Expected 2 input tensors");
+    TT_FATAL(input_tensors.size() == 3, "Expected 3 input tensors (A, Bx, H)");
 
     const auto& a = input_tensors.at(0);
     const auto& bx = input_tensors.at(1);
-
     TT_FATAL(a.dtype() == bx.dtype(), "Expected input tensors to have the same data type");
-
     TT_FATAL(a.layout() == Layout::TILE && bx.layout() == Layout::TILE, "Expected input tensors to be tile layout");
-
     TT_FATAL(a.get_legacy_shape() == bx.get_legacy_shape(), "Expected input tensors to have the same shape");
 
     const auto& shape = a.get_legacy_shape();
@@ -686,14 +683,22 @@ void SSMPrefixScan::validate(const std::vector<Tensor>& input_tensors) const {
     TT_FATAL(shape[0] == 1 && shape[1] == 1, "Dimension 0 and 1 should be size 1");
     TT_FATAL(shape[2] >= TILE_HEIGHT && shape[2] % TILE_HEIGHT == 0, "Sequence length should be a multiple of 32");
 
-    TT_FATAL(a.is_sharded() && bx.is_sharded(), "Expected input tensors to be sharded");
-    TT_FATAL(a.shard_spec().has_value() && bx.shard_spec().has_value(), "Expected input tensors to be sharded");
+    const auto& h = input_tensors.at(2);
+    TT_FATAL(h.dtype() == DataType::BFLOAT16, "Expected initial hidden state to be bfloat16");
+    TT_FATAL(h.layout() == Layout::ROW_MAJOR, "Expected initial hidden state to be row-major");
+    //TT_FATAL(h.get_legacy_shape() == {1, 1, 1, shape[3]}, "Expected initial hidden state to have the same hidden size as A and Bx");
+
+    TT_FATAL(a.is_sharded() && bx.is_sharded() && h.is_sharded(), "Expected input tensors to be sharded");
+    TT_FATAL(a.shard_spec().has_value() && bx.shard_spec().has_value() && h.shard_spec().has_value(), "Expected input tensors to be sharded");
     TT_FATAL(
         a.shard_spec().value().orientation == ShardOrientation::ROW_MAJOR,
         "Expected A tensor to be row major orientation");
     TT_FATAL(
         bx.shard_spec().value().orientation == ShardOrientation::ROW_MAJOR,
         "Expected Bx tensor to be row major orientation");
+    TT_FATAL(
+        h.shard_spec().value().orientation == ShardOrientation::ROW_MAJOR,
+        "Expected h tensor to be row major orientation");
 }
 
 std::vector<Shape> SSMPrefixScan::compute_output_shapes(const std::vector<Tensor>& input_tensors) const {
@@ -710,9 +715,10 @@ operation::ProgramWithCallbacks SSMPrefixScan::create_program(
     const std::vector<Tensor>& input_tensors, std::vector<Tensor>& output_tensors) const {
     const auto& a = input_tensors.at(0);
     const auto& bx = input_tensors.at(1);
+    const auto& h = input_tensors.at(2);
     auto& output = output_tensors.at(0);
     auto device_compute_with_storage_grid_size = a.device()->compute_with_storage_grid_size();
-    return multi_core_ssm_prefix_scan(a, bx, output, math_fidelity, device_compute_with_storage_grid_size);
+    return multi_core_ssm_prefix_scan(a, bx, h, output, math_fidelity, device_compute_with_storage_grid_size);
 }
 
 tt::stl::reflection::Attributes SSMPrefixScan::attributes() const {

--- a/tt_eager/tt_dnn/op_library/transformer_tms/transformer_tms.hpp
+++ b/tt_eager/tt_dnn/op_library/transformer_tms/transformer_tms.hpp
@@ -33,6 +33,7 @@ operation::ProgramWithCallbacks multi_core_ssm_1d_sum_reduce(const Tensor &input
 operation::ProgramWithCallbacks multi_core_ssm_prefix_scan(
     const Tensor& a,
     const Tensor& bx,
+    const Tensor& h,
     Tensor& output,
     MathFidelity math_fidelity,
     CoreCoord compute_with_storage_grid_size);
@@ -240,6 +241,7 @@ struct SSMPrefixScan {
 inline Tensor ssm_prefix_scan(
     const Tensor& a,
     const Tensor& bx,
+    const Tensor& h,
     const MemoryConfig& mem_config,
     std::optional<const DataType> output_dtype = std::nullopt,
     MathFidelity math_fidelity = MathFidelity::HiFi4) {
@@ -251,10 +253,11 @@ inline Tensor ssm_prefix_scan(
             const std::vector<std::optional<Tensor>>& optional_output_tensors) mutable -> std::vector<Tensor> {
             const auto& a = input_tensors.at(0);
             const auto& bx = input_tensors.at(1);
+            const auto& h = input_tensors.at(2);
             return operation::run(
                 SSMPrefixScan{mem_config, output_dtype.value_or(a.get_dtype()), math_fidelity}, input_tensors);
         },
-        {a, bx},
+        {a, bx, h},
         output_tensors);
     return output_tensors.at(0);
 }

--- a/tt_eager/tt_lib/csrc/operations/primary/transformers/module.hpp
+++ b/tt_eager/tt_lib/csrc/operations/primary/transformers/module.hpp
@@ -63,6 +63,7 @@ void py_module(py::module& m_transformers) {
         &ssm_prefix_scan,
         py::arg().noconvert(),
         py::arg().noconvert(),
+        py::arg().noconvert(),
         py::arg("output_mem_config").noconvert() = operation::DEFAULT_OUTPUT_MEMORY_CONFIG,
         py::arg("output_dtype").noconvert() = std::nullopt,
         py::arg("math_fidelity").noconvert() = MathFidelity::HiFi4,


### PR DESCRIPTION
### Problem description
See #9971 

### What's changed
The changes are separated into two commits:
- Allow user to provide an initial hidden state to `ssm_prefix_scan`.
- Update `ssm_prefix_scan` to modify previous hidden states in-place. We use row-major since that reduces the amount of data movement required.

### Checklist
- [X] Post commit CI passes
- [X] Model regression CI testing passes (if applicable)
- [X] New/Existing tests provide coverage for changes
