### PR TITLE
#0: Make event_synchronize API safer

### DIFF
--- a/ttnn/cpp/ttnn/async_runtime.cpp
+++ b/ttnn/cpp/ttnn/async_runtime.cpp
@@ -114,7 +114,12 @@ void queue_synchronize(CommandQueue& cq) {
     Finish(cq);
 }
 
-void event_synchronize(std::shared_ptr<Event> event) { EventSynchronize(event); }
+void event_synchronize(Device* device, std::shared_ptr<Event> event) {
+    device->push_work([event] () {
+        EventSynchronize(event);
+    });
+    device->synchronize();
+}
 
 bool event_query(std::shared_ptr<Event> event) { return EventQuery(event); }
 

--- a/ttnn/cpp/ttnn/async_runtime.hpp
+++ b/ttnn/cpp/ttnn/async_runtime.hpp
@@ -20,7 +20,7 @@ namespace ttnn {
 
     void queue_synchronize(CommandQueue& cq);
 
-    void event_synchronize(std::shared_ptr<Event> event);
+    void event_synchronize(Device* device, std::shared_ptr<Event> event);
 
     bool event_query(std::shared_ptr<Event> event);
 


### PR DESCRIPTION
### Ticket
Link to Github Issue

### Problem description
Async runtime test is ND failing on post commit CI.

### What's changed
Use `wait_for_event` API for command queue synchronization and make `event_synchronize` API safer, by running the actual event synchronization in the worker thread.

### Checklist
- [x] Post commit CI passes
- [ ] Model regression CI testing passes (if applicable)
- [ ] New/Existing tests provide coverage for changes
