### PR TITLE
Combined prefill decode for reference model

### DIFF
--- a/models/demos/mamba/reference/args.py
+++ b/models/demos/mamba/reference/args.py
@@ -20,6 +20,12 @@ import math
 
 from dataclasses import dataclass
 from typing import Union
+from enum import Enum
+
+
+class ModelMode(Enum):
+    DECODE = 0
+    PREFILL = 1
 
 
 @dataclass
@@ -36,6 +42,7 @@ class ModelArgs:
     bias: bool = False
     batch_size: int = 1
     eps: float = 1e-5
+    mode: ModelMode = ModelMode.DECODE
 
     def __post_init__(self):
         self.d_inner = int(self.expand * self.d_model)

--- a/models/demos/mamba/reference/prefill_decode_model.py
+++ b/models/demos/mamba/reference/prefill_decode_model.py
@@ -1,0 +1,424 @@
+# SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+
+# SPDX-License-Identifier: Apache-2.0
+
+# Copyright 2023 Tri Dao, Albert Gu
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Simple, minimal implementation of Mamba in one file of PyTorch.
+
+Suggest reading the following before/while reading the code:
+    [1] Mamba: Linear-Time Sequence Modeling with Selective State Spaces (Albert Gu and Tri Dao)
+        https://arxiv.org/abs/2312.00752
+    [2] The Annotated S4 (Sasha Rush and Sidd Karamcheti)
+        https://srush.github.io/annotated-s4
+
+Glossary:
+    b: batch size                       (`B` in Mamba paper [1] Algorithm 2)
+    l: sequence length                  (`L` in [1] Algorithm 2)
+    d or d_model: hidden dim
+    n or d_state: latent state dim      (`N` in [1] Algorithm 2)
+    expand: expansion factor            (`E` in [1] Section 3.4)
+    d_in or d_inner: d * expand         (`D` in [1] Algorithm 2)
+    A, B, C, D: state space parameters  (See any state space representation formula)
+                                        (B, C are input-dependent (aka selective, a key innovation in Mamba); A, D are not)
+    Δ or delta: input-dependent step size
+    dt_rank: rank of Δ                  (See [1] Section 3.6 "Parameterization of ∆")
+
+"""
+
+from __future__ import annotations
+import json
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+from einops import rearrange, repeat, einsum
+
+from models.demos.mamba.reference.args import ModelArgs, ModelMode
+
+from typing import Literal, cast
+
+MambaPretrainedModelName = Literal[
+    "state-spaces/mamba-2.8b-slimpj",
+    "state-spaces/mamba-2.8b",
+    "state-spaces/mamba-1.4b",
+    "state-spaces/mamba-790m",
+    "state-spaces/mamba-370m",
+    "state-spaces/mamba-130m",
+]
+
+
+class Mamba(nn.Module):
+    def __init__(self, args: ModelArgs):
+        """Full Mamba model."""
+        super().__init__()
+        self.args = args
+
+        self.embedding = nn.Embedding(args.vocab_size, args.d_model)
+        self.layers = nn.ModuleList([ResidualBlock(args) for _ in range(args.n_layer)])
+        self.norm_f = RMSNorm(args.d_model)
+
+        self.lm_head = nn.Linear(args.d_model, args.vocab_size, bias=False)
+        self.lm_head.weight = self.embedding.weight  # Tie output projection to embedding weights.
+        # See "Weight Tying" paper
+
+    def forward(self, input_ids):
+        """
+        Args:
+            input_ids (long tensor): shape (b, 1)    (See Glossary at top for definitions of b, l, d_in, n...)
+
+        Returns:
+            logits: shape (b, 1, vocab_size)
+
+        Official Implementation:
+            class MambaLMHeadModel, https://github.com/state-spaces/mamba/blob/main/mamba_ssm/models/mixer_seq_simple.py#L173
+
+        """
+        x = self.embedding(input_ids)
+
+        for i, layer in enumerate(self.layers):
+            x = layer(x)
+
+        x = self.norm_f(x)
+        logits = self.lm_head(x)
+
+        return logits
+
+    def logits_to_token(self, logits: torch.Tensor, sample: bool = False, top_k: Optional[int] = None) -> torch.Tensor:
+        probs = F.softmax(logits, dim=-1)
+
+        if top_k is not None:
+            (values, indices) = torch.topk(probs, k=top_k)
+            probs[probs < values[:, -1, None]] = 0
+            probs = probs / probs.sum(1, keepdim=True)
+
+        if sample:
+            next_token_id = torch.multinomial(probs, num_samples=1)
+        else:
+            next_token_id = torch.argmax(probs, dim=-1)[:, None]
+
+        return next_token_id
+
+    def generate(self, input_ids, n_tokens_to_gen: int = 51, sample: bool = False, top_k: Optional[int] = None):
+        # prefill
+        self.args.mode = ModelMode.PREFILL
+        with torch.no_grad():
+            next_token_logits = self.forward(input_ids)[:, -1]
+        next_token_id = self.logits_to_token(next_token_logits, sample=sample, top_k=top_k)
+        generated_token_ids = next_token_id.clone()
+
+        # decode
+        self.args.mode = ModelMode.DECODE
+        for _ in range(n_tokens_to_gen - 1):
+            with torch.no_grad():
+                next_token_logits = self.forward(next_token_id)  # shape (b, 1, vocab_size)
+                next_token_logits = next_token_logits[:, -1]
+            next_token_id = self.logits_to_token(next_token_logits, sample=sample, top_k=top_k)
+            generated_token_ids = torch.cat([generated_token_ids, next_token_id], dim=1)
+
+        return torch.cat([input_ids, generated_token_ids], dim=1)
+
+    def initialize_states(self):
+        for layer in self.layers:
+            mixer = cast(MambaBlock, layer.mixer)
+            mixer.prev_hidden_states.zero_()
+            mixer.conv_states.zero_()
+
+    @staticmethod
+    def from_pretrained(pretrained_model_name: MambaPretrainedModelName, batch_size: int = 1):
+        """Load pretrained weights from HuggingFace into model.
+
+        Args:
+            pretrained_model_name: One of
+                * 'state-spaces/mamba-2.8b-slimpj'
+                * 'state-spaces/mamba-2.8b'
+                * 'state-spaces/mamba-1.4b'
+                * 'state-spaces/mamba-790m'
+                * 'state-spaces/mamba-370m'
+                * 'state-spaces/mamba-130m'
+
+        Returns:
+            model: Mamba model with weights loaded
+
+        """
+        from transformers.utils import WEIGHTS_NAME, CONFIG_NAME
+        from transformers.utils.hub import cached_file
+
+        def load_config_hf(model_name):
+            resolved_archive_file = cached_file(model_name, CONFIG_NAME, _raise_exceptions_for_missing_entries=False)
+            if not resolved_archive_file:
+                raise RuntimeError("Unable to load Mamba archive file from HF")
+            return json.load(open(resolved_archive_file))
+
+        def load_state_dict_hf(model_name, device=None, dtype=None):
+            resolved_archive_file = cached_file(model_name, WEIGHTS_NAME, _raise_exceptions_for_missing_entries=False)
+            if not resolved_archive_file:
+                raise RuntimeError("Unable to load Mamba weights archive file from HF")
+            return torch.load(resolved_archive_file, weights_only=True, map_location="cpu")
+
+        config_data = load_config_hf(pretrained_model_name)
+        args = ModelArgs(
+            d_model=config_data["d_model"],
+            n_layer=config_data["n_layer"],
+            vocab_size=config_data["vocab_size"],
+            batch_size=batch_size,
+        )
+        model = Mamba(args)
+
+        state_dict = load_state_dict_hf(pretrained_model_name)
+        new_state_dict = {}
+        for key in state_dict:
+            new_key = key.replace("backbone.", "")
+            new_state_dict[new_key] = state_dict[key]
+        model.load_state_dict(new_state_dict)
+
+        return model
+
+
+class ResidualBlock(nn.Module):
+    def __init__(self, args: ModelArgs):
+        """Simple block wrapping Mamba block with normalization and residual connection."""
+        super().__init__()
+        self.args = args
+        self.mixer = MambaBlock(args)
+        self.norm = RMSNorm(args.d_model)
+
+    def forward(self, x):
+        """
+        Args:
+            x: shape (b, l, d)    (See Glossary at top for definitions of b, l, d_in, n...)
+
+        Returns:
+            output: shape (b, l, d)
+
+        Official Implementation:
+            Block.forward(), https://github.com/state-spaces/mamba/blob/main/mamba_ssm/modules/mamba_simple.py#L297
+
+            Note: the official repo chains residual blocks that look like
+                [Add -> Norm -> Mamba] -> [Add -> Norm -> Mamba] -> [Add -> Norm -> Mamba] -> ...
+            where the first Add is a no-op. This is purely for performance reasons as this
+            allows them to fuse the Add->Norm.
+
+            We instead implement our blocks as the more familiar, simpler, and numerically equivalent
+                [Norm -> Mamba -> Add] -> [Norm -> Mamba -> Add] -> [Norm -> Mamba -> Add] -> ....
+
+        """
+        output = self.mixer(self.norm(x)) + x
+
+        return output
+
+
+class MambaBlock(nn.Module):
+    def __init__(self, args: ModelArgs):
+        """A single Mamba block, as described in Figure 3 in Section 3.4 in the Mamba paper [1]."""
+        super().__init__()
+        self.args = args
+
+        self.in_proj = nn.Linear(args.d_model, args.d_inner * 2, bias=args.bias)
+
+        # (b, d_in, l) -> (b, d_in, l)
+        self.conv1d = nn.Conv1d(
+            in_channels=args.d_inner,
+            out_channels=args.d_inner,
+            bias=args.conv_bias,
+            kernel_size=args.d_conv,
+            groups=args.d_inner,
+            padding=args.d_conv - 1,
+        )
+
+        # x_proj takes in `x` and outputs the input-specific Δ, B, C
+        self.x_proj = nn.Linear(args.d_inner, args.dt_rank + args.d_state * 2, bias=False)
+
+        # dt_proj projects Δ from dt_rank to d_in
+        self.dt_proj = nn.Linear(args.dt_rank, args.d_inner, bias=True)
+
+        A = repeat(torch.arange(1, args.d_state + 1), "n -> d n", d=args.d_inner)
+        self.A_log = nn.Parameter(torch.log(A))
+        self.D = nn.Parameter(torch.ones(args.d_inner))
+        self.out_proj = nn.Linear(args.d_inner, args.d_model, bias=args.bias)
+
+        self.prev_hidden_states = torch.zeros((args.batch_size, args.d_inner, args.d_state))
+        self.conv_states = torch.zeros(
+            args.batch_size,
+            args.d_model * args.expand,
+            args.d_conv,
+            device=self.conv1d.weight.device,
+            dtype=self.conv1d.weight.dtype,
+        )  # (b, 4, d_inner)*n_layer
+
+    def forward(self, x):
+        """Mamba block forward. This looks the same as Figure 3 in Section 3.4 in the Mamba paper [1].
+
+        Args:
+            x: shape (b, l, d)    (See Glossary at top for definitions of b, l, d_in, n...)
+
+        Returns:
+            output: shape (b, l, d)
+
+        Official Implementation:
+            class Mamba, https://github.com/state-spaces/mamba/blob/main/mamba_ssm/modules/mamba_simple.py#L119
+            mamba_inner_ref(), https://github.com/state-spaces/mamba/blob/main/mamba_ssm/ops/selective_scan_interface.py#L311
+
+        """
+        (b, l, d) = x.shape
+
+        x_and_res = self.in_proj(x)  # shape (b, l, 2 * d_in)
+        (x, res) = x_and_res.split(split_size=[self.args.d_inner, self.args.d_inner], dim=-1)
+
+        x = rearrange(x, "b l d_in -> b d_in l")
+        if self.args.mode == ModelMode.PREFILL:
+            last_state_idx = -min(self.args.d_conv, l)
+            self.conv_states[:, :, last_state_idx:] = x[:, :, last_state_idx:].clone()
+            x = self.conv1d(x)[:, :, :l]
+
+        elif self.args.mode == ModelMode.DECODE:
+            self.conv_states.copy_(torch.roll(self.conv_states, shifts=-1, dims=-1))  # Update state (B D W)
+            self.conv_states[:, :, -1] = x.squeeze(-1)
+            x = torch.sum(self.conv_states * rearrange(self.conv1d.weight, "d 1 w -> d w"), dim=-1)  # (B D)
+            if self.conv1d.bias is not None:
+                x = x + self.conv1d.bias
+            x = x.unsqueeze(-1)
+
+        x = rearrange(x, "b d_in l -> b l d_in")
+
+        x = F.silu(x)
+
+        y = self.ssm(x)
+
+        y = y * F.silu(res)
+
+        output = self.out_proj(y)
+
+        return output
+
+    def ssm(self, x):
+        """Runs the SSM. See:
+            - Algorithm 2 in Section 3.2 in the Mamba paper [1]
+            - run_SSM(A, B, C, u) in The Annotated S4 [2]
+
+        Args:
+            x: shape (b, l, d_in)    (See Glossary at top for definitions of b, l, d_in, n...)
+
+        Returns:
+            output: shape (b, l, d_in)
+
+        Official Implementation:
+            mamba_inner_ref(), https://github.com/state-spaces/mamba/blob/main/mamba_ssm/ops/selective_scan_interface.py#L311
+
+        """
+        (d_in, n) = self.A_log.shape
+
+        # Compute ∆ A B C D, the state space parameters.
+        #     A, D are input independent (see Mamba paper [1] Section 3.5.2 "Interpretation of A" for why A isn't selective)
+        #     ∆, B, C are input-dependent (this is a key difference between Mamba and the linear time invariant S4,
+        #                                  and is why Mamba is called **selective** state spaces)
+
+        A = -torch.exp(self.A_log.float())  # shape (d_in, n)
+        D = self.D.float()
+
+        x_dbl = self.x_proj(x)  # (b, l, dt_rank + 2*n)
+
+        (delta, B, C) = x_dbl.split(
+            split_size=[self.args.dt_rank, n, n], dim=-1
+        )  # delta: (b, l, dt_rank). B, C: (b, l, n)
+        delta = F.softplus(self.dt_proj(delta))  # (b, l, d_in)
+
+        if self.args.mode == ModelMode.PREFILL:
+            y = self.selective_scan(
+                x, delta, A, B, C, D
+            )  # This is similar to run_SSM(A, B, C, u) in The Annotated S4 [2]
+        elif self.args.mode == ModelMode.DECODE:
+            y = self.one_step_ssm(x, delta, A, B, C, D)
+        return y
+
+    def one_step_ssm(self, u, delta, A, B, C, D):
+        (b, l, d_in) = u.shape
+        n = A.shape[1]
+
+        deltaA = torch.exp(einsum(delta, A, "b l d_in, d_in n -> b l d_in n"))
+        deltaB_u = einsum(delta, B, u, "b l d_in, b l n, b l d_in -> b l d_in n")
+
+        # on step ssm
+        self.prev_hidden_states = deltaA[:, -1] * self.prev_hidden_states + deltaB_u[:, -1]
+        y = einsum(self.prev_hidden_states, C[:, -1], "b d_in n, b n -> b d_in")
+
+        y = y.unsqueeze(1)
+        y = y + u * D
+
+        return y
+
+    def selective_scan(self, u, delta, A, B, C, D):
+        """Does selective scan algorithm. See:
+            - Section 2 State Space Models in the Mamba paper [1]
+            - Algorithm 2 in Section 3.2 in the Mamba paper [1]
+            - run_SSM(A, B, C, u) in The Annotated S4 [2]
+
+        This is the classic discrete state space formula:
+            x(t + 1) = Ax(t) + Bu(t)
+            y(t)     = Cx(t) + Du(t)
+        except B and C (and the step size delta, which is used for discretization) are dependent on the input x(t).
+
+        Args:
+            u: shape (b, l, d_in)    (See Glossary at top for definitions of b, l, d_in, n...)
+            delta: shape (b, l, d_in)
+            A: shape (d_in, n)
+            B: shape (b, l, n)
+            C: shape (b, l, n)
+            D: shape (d_in,)
+
+        Returns:
+            output: shape (b, l, d_in)
+
+        Official Implementation:
+            selective_scan_ref(), https://github.com/state-spaces/mamba/blob/main/mamba_ssm/ops/selective_scan_interface.py#L86
+            Note: I refactored some parts out of `selective_scan_ref` out, so the functionality doesn't match exactly.
+
+        """
+        (b, l, d_in) = u.shape
+        n = A.shape[1]
+
+        # Discretize continuous parameters (A, B)
+        # - A is discretized using zero-order hold (ZOH) discretization (see Section 2 Equation 4 in the Mamba paper [1])
+        # - B is discretized using a simplified Euler discretization instead of ZOH. From a discussion with authors:
+        #   "A is the more important term and the performance doesn't change much with the simplification on B"
+        deltaA = torch.exp(einsum(delta, A, "b l d_in, d_in n -> b l d_in n"))
+        deltaB_u = einsum(delta, B, u, "b l d_in, b l n, b l d_in -> b l d_in n")
+
+        # Perform selective scan (see scan_SSM() in The Annotated S4 [2])
+        # Note that the below is sequential, while the official implementation does a much faster parallel scan that
+        # is additionally hardware-aware (like FlashAttention).
+        x = torch.zeros((b, d_in, n), device=deltaA.device)
+        ys = []
+        for i in range(l):
+            self.prev_hidden_states = deltaA[:, i] * self.prev_hidden_states + deltaB_u[:, i]
+            y = einsum(self.prev_hidden_states, C[:, i, :], "b d_in n, b n -> b d_in")
+            ys.append(y)
+        y = torch.stack(ys, dim=1)  # shape (b, l, d_in)
+
+        y = y + u * D
+
+        return y
+
+
+class RMSNorm(nn.Module):
+    def __init__(self, d_model: int, eps: float = 1e-5):
+        super().__init__()
+        self.eps = eps
+        self.weight = nn.Parameter(torch.ones(d_model))
+
+    def forward(self, x):
+        output = x * torch.rsqrt(x.pow(2).mean(-1, keepdim=True) + self.eps) * self.weight
+
+        return output


### PR DESCRIPTION
### What's changed
* Added a script which combines prefill and decode mode for reference model.
* Default mode : Decode
* To choose Prefill, set the mode in model args before self.forward()

### Checklist
- [ ] Post commit CI passes
- [ ] Model regression CI testing passes (if applicable)
- [ ] New/Existing tests provide coverage for changes
