### PR TITLE
#0: add a second codeowner for conv

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -136,7 +136,7 @@ tests/ttnn/ @eyonland @arakhmati @cfjchu @xanderchin @TT-BrianLiu @ayerofieiev-t
 
 # models
 /models/ @boris-drazic
-models/conv_on_device_utils*.py @mywoodstock
+models/conv_on_device_utils*.py @mywoodstock @sankarmanoj-tt
 functional_*/ @eyonland @arakhmati @cfjchu @xanderchin
 models/demos @eyonland @arakhmati @cfjchu @xanderchin
 models/demos/metal_BERT_large_11 @tt-aho @TT-BrianLiu
@@ -164,10 +164,10 @@ docs/source/ttnn/ @eyonland @arakhmati @cfjchu @xanderchin @ayerofieiev-tt
 # docs/source/apis/kernel_apis.rst @davorchap @pgkeller @tt-rkim
 
 # misc
-tests/**/dtx/ @mywoodstock
-tests/**/*test*conv*.py @mywoodstock
+tests/**/dtx/ @mywoodstock @sankarmanoj-tt
+tests/**/*test*conv*.py @mywoodstock @sankarmanoj-tt
 # tests/**/module.mk @tenstorrent-metal/developers
-tests/python_api_testing/conv/ @mywoodstock
+tests/python_api_testing/conv/ @mywoodstock @sankarmanoj-tt
 tests/python_api_testing/unit_testing/fallback_ops @tt-aho
 scripts/profiler/ @mo-tenstorrent
 scripts/docker @ttmchiou @TT-billteng @tt-rkim


### PR DESCRIPTION
### Ticket
Link to Github Issue: N/A

### Problem description
- Only one owner for some paths

### What's changed
- add a second owner

### Checklist
- [ ] Post commit CI passes - N/A
- [ ] Model regression CI testing passes (if applicable) - N/A
- [ ] New/Existing tests provide coverage for changes - N/A
