### PR TITLE
#9767: updated tt::stl::reflection library to print structs using boost reflect

### DIFF
--- a/tt_eager/tensor/types.hpp
+++ b/tt_eager/tensor/types.hpp
@@ -242,11 +242,6 @@ struct MemoryConfig {
     bool is_sharded() const;
     bool is_l1() const;
     bool is_dram() const;
-
-    static constexpr auto attribute_names = std::forward_as_tuple("memory_layout", "buffer_type", "shard_spec");
-    const auto attribute_values() const {
-        return std::forward_as_tuple(this->memory_layout, this->buffer_type, this->shard_spec);
-    }
 };
 
 bool operator==(const MemoryConfig &config_a, const MemoryConfig &config_b);


### PR DESCRIPTION
### Ticket
[Link to Github Issue](https://github.com/tenstorrent/tt-metal/issues/9767)

### Problem description
`fmt::format` wasn't overloaded for types that can be reflected on using boost reflect. 

### What's changed
- Added support for printing objects that are supported using boost reflect
- Removed manually exported attributes from MemoryConfig

### Checklist
- [ ] Post commit CI passes
- [ ] Model regression CI testing passes (if applicable)
- [ ] New/Existing tests provide coverage for changes
