### PR TITLE
#0: fix corerangeset for semaphore and CB to use good ranges

### DIFF
--- a/tt_eager/tt_dnn/op_library/bmm/multi_core_reuse_mcast_dram_sharded_optimized/bmm_op_multi_core_reuse_dram_sharded_optimized.cpp
+++ b/tt_eager/tt_dnn/op_library/bmm/multi_core_reuse_mcast_dram_sharded_optimized/bmm_op_multi_core_reuse_dram_sharded_optimized.cpp
@@ -521,9 +521,9 @@ operation::ProgramWithCallbacks create_program_dram_sharded(
     log_debug("bounding_box: {}", bounding_box);
 
     // Mcast args
-    auto in0_mcast_sender_semaphore = tt_metal::CreateSemaphore(program, all_cores, INVALID);
-    auto in0_mcast_receiver_semaphore = tt_metal::CreateSemaphore(program, all_cores, INVALID);
-    auto in0_mcast_sender_valid_semaphore = tt_metal::CreateSemaphore(program, all_cores, VALID);
+    auto in0_mcast_sender_semaphore = tt_metal::CreateSemaphore(program, all_cores_in_rect_grid, INVALID);
+    auto in0_mcast_receiver_semaphore = tt_metal::CreateSemaphore(program, all_cores_in_rect_grid, INVALID);
+    auto in0_mcast_sender_valid_semaphore = tt_metal::CreateSemaphore(program, all_cores_in_rect_grid, VALID);
 
     uint32_t start_core_x = 0;
     uint32_t start_core_y = 0;
@@ -702,7 +702,7 @@ operation::ProgramWithCallbacks create_program_dram_sharded(
     tt_metal::CircularBufferConfig src0_cb_config =
         tt_metal::CircularBufferConfig(in0_CB_size, {{src0_cb_index, in0_data_format}})
             .set_page_size(src0_cb_index, in0_single_tile_size);
-    auto cb_src0 = tt_metal::CreateCircularBuffer(program, all_cores, src0_cb_config);
+    auto cb_src0 = tt_metal::CreateCircularBuffer(program, all_cores_in_rect_grid, src0_cb_config);
     log_debug(
         LogOp,
         "CB {} :: PS = {}, NP = {}, TOTAL = {}",
@@ -715,7 +715,7 @@ operation::ProgramWithCallbacks create_program_dram_sharded(
     tt_metal::CircularBufferConfig src1_cb_config =
         tt_metal::CircularBufferConfig(in1_CB_size, {{src1_cb_index, in1_data_format}})
             .set_page_size(src1_cb_index, in1_single_tile_size);
-    auto cb_src1 = tt_metal::CreateCircularBuffer(program, all_cores, src1_cb_config);
+    auto cb_src1 = tt_metal::CreateCircularBuffer(program, all_cores_in_rect_grid, src1_cb_config);
     log_debug(
         LogOp,
         "CB {} :: PS = {}, NP = {}, TOTAL = {}",
@@ -729,7 +729,7 @@ operation::ProgramWithCallbacks create_program_dram_sharded(
         tt_metal::CircularBufferConfig(in2_CB_size, {{src2_cb_index, in0_data_format}})
             .set_page_size(src2_cb_index, in0_single_tile_size)
             .set_globally_allocated_address(*in0_buffer);
-    auto cb_src2 = tt_metal::CreateCircularBuffer(program, all_cores, src2_cb_config);
+    auto cb_src2 = tt_metal::CreateCircularBuffer(program, all_cores_in_rect_grid, src2_cb_config);
     log_debug(
         LogOp,
         "CB {} :: PS = {}, NP = {}, TOTAL = {}",
@@ -759,7 +759,7 @@ operation::ProgramWithCallbacks create_program_dram_sharded(
         interm0_cb_config = tt_metal::CircularBufferConfig(interm0_CB_size, interm0_cb_data_format_spec)
                                 .set_page_size(interm0_cb_index, interm0_single_tile_size);
 
-        auto cb_interm0 = tt_metal::CreateCircularBuffer(program, all_cores, interm0_cb_config);
+        auto cb_interm0 = tt_metal::CreateCircularBuffer(program, all_cores_in_rect_grid, interm0_cb_config);
         log_debug(
             LogOp,
             "CB {} :: PS = {}, NP = {}, TOTAL = {}",
@@ -776,7 +776,7 @@ operation::ProgramWithCallbacks create_program_dram_sharded(
                                .set_page_size(output_cb_index, output_single_tile_size)
                                .set_page_size(interm0_cb_index, interm0_single_tile_size);
     }
-    auto cb_output = tt_metal::CreateCircularBuffer(program, all_cores, output_cb_config);
+    auto cb_output = tt_metal::CreateCircularBuffer(program, all_cores_in_rect_grid, output_cb_config);
     log_debug(
         LogOp,
         "CB {} :: PS = {}, NP = {}, TOTAL = {}",
@@ -794,14 +794,14 @@ operation::ProgramWithCallbacks create_program_dram_sharded(
         tt_metal::CircularBufferConfig(out_reshard_CB_size, output_reshard_cb_data_format_spec)
             .set_page_size(output_reshard_cb_index, output_single_tile_size);
     output_reshard_cb_config = output_reshard_cb_config.set_globally_allocated_address(*out_buffer);
-    auto cb_output_reshard = tt_metal::CreateCircularBuffer(program, all_cores, output_reshard_cb_config);
+    auto cb_output_reshard = tt_metal::CreateCircularBuffer(program, all_cores_in_rect_grid, output_reshard_cb_config);
 
     if (bias_buffer != nullptr) {
         uint32_t src3_cb_index = 3;
         tt_metal::CircularBufferConfig cb_src3_config =
             tt_metal::CircularBufferConfig(in3_CB_size, {{src3_cb_index, bias_data_format}})
                 .set_page_size(src3_cb_index, bias_single_tile_size);
-        auto cb_src3 = tt_metal::CreateCircularBuffer(program, all_cores, cb_src3_config);
+        auto cb_src3 = tt_metal::CreateCircularBuffer(program, all_cores_in_rect_grid, cb_src3_config);
         log_debug(
             LogOp,
             "CB {} :: PS = {}, NP = {}, TOTAL = {}",


### PR DESCRIPTION
### Ticket


### Problem description
semaphore and CB configs use a core range set that is core by core

### What's changed
need to change it to a set that is a range so won't hit number_of_arg limit

### Checklist
- 
