### PR TITLE
Fix GCC14 error: control reaches end of non-void during build of latest main branch

### DIFF
--- a/tt_eager/tt_dnn/op_library/composite/composite_ops.cpp
+++ b/tt_eager/tt_dnn/op_library/composite/composite_ops.cpp
@@ -499,8 +499,9 @@ Tensor _sinh(const Tensor& input_a, const MemoryConfig& output_mem_config) {
     e_neg_x.deallocate();
     Tensor scalar =
         ttnn::operations::creation::create_scalar(0.5f, input_a.get_dtype(), Layout::TILE, input_a.device());
-    return ttnn::multiply(nr_term, scalar, std::nullopt, output_mem_config);
+    Tensor res = ttnn::multiply(nr_term, scalar, std::nullopt, output_mem_config);
     scalar.deallocate();
+    return res;
 }
 Tensor sinh(const Tensor& input_a, const MemoryConfig& output_mem_config) {
     return operation::decorate_as_composite(__func__, _sinh)(input_a, output_mem_config);
@@ -515,8 +516,9 @@ Tensor _cosh(const Tensor& input_a, const MemoryConfig& output_mem_config) {
     e_neg_x.deallocate();
     Tensor scalar =
         ttnn::operations::creation::create_scalar(0.5f, input_a.get_dtype(), Layout::TILE, input_a.device());
-    return ttnn::multiply(nr_term, scalar, std::nullopt, output_mem_config);
+    Tensor res ttnn::multiply(nr_term, scalar, std::nullopt, output_mem_config);
     scalar.deallocate();
+    return res;
 }
 Tensor cosh(const Tensor& input_a, const MemoryConfig& output_mem_config) {
     return operation::decorate_as_composite(__func__, _cosh)(input_a, output_mem_config);

--- a/tt_eager/tt_dnn/op_library/composite/composite_ops.cpp
+++ b/tt_eager/tt_dnn/op_library/composite/composite_ops.cpp
@@ -499,9 +499,7 @@ Tensor _sinh(const Tensor& input_a, const MemoryConfig& output_mem_config) {
     e_neg_x.deallocate();
     Tensor scalar =
         ttnn::operations::creation::create_scalar(0.5f, input_a.get_dtype(), Layout::TILE, input_a.device());
-    Tensor res = ttnn::multiply(nr_term, scalar, std::nullopt, output_mem_config);
-    scalar.deallocate();
-    return res;
+    return ttnn::multiply(nr_term, scalar, std::nullopt, output_mem_config);
 }
 Tensor sinh(const Tensor& input_a, const MemoryConfig& output_mem_config) {
     return operation::decorate_as_composite(__func__, _sinh)(input_a, output_mem_config);
@@ -516,9 +514,7 @@ Tensor _cosh(const Tensor& input_a, const MemoryConfig& output_mem_config) {
     e_neg_x.deallocate();
     Tensor scalar =
         ttnn::operations::creation::create_scalar(0.5f, input_a.get_dtype(), Layout::TILE, input_a.device());
-    Tensor res = ttnn::multiply(nr_term, scalar, std::nullopt, output_mem_config);
-    scalar.deallocate();
-    return res;
+    return ttnn::multiply(nr_term, scalar, std::nullopt, output_mem_config);
 }
 Tensor cosh(const Tensor& input_a, const MemoryConfig& output_mem_config) {
     return operation::decorate_as_composite(__func__, _cosh)(input_a, output_mem_config);

--- a/tt_eager/tt_dnn/op_library/composite/composite_ops.cpp
+++ b/tt_eager/tt_dnn/op_library/composite/composite_ops.cpp
@@ -516,7 +516,7 @@ Tensor _cosh(const Tensor& input_a, const MemoryConfig& output_mem_config) {
     e_neg_x.deallocate();
     Tensor scalar =
         ttnn::operations::creation::create_scalar(0.5f, input_a.get_dtype(), Layout::TILE, input_a.device());
-    Tensor res ttnn::multiply(nr_term, scalar, std::nullopt, output_mem_config);
+    Tensor res = ttnn::multiply(nr_term, scalar, std::nullopt, output_mem_config);
     scalar.deallocate();
     return res;
 }


### PR DESCRIPTION
### Problem description

On the latest `main` branch (28f2f01fd9aabf4251aafc59323ee59bc16baf0e), GCC 14 fails to compile tt-metal with the following error message. This PR fixes it (as well as memory leak because the tensors is not freed in the original code).

```
/home/marty/Documents/not-my-projects/tt-metal/tt_eager/tt_dnn/op_library/composite/composite_ops.cpp: In function ‘tt::tt_metal::Tensor tt::tt_metal::_sinh(const Tensor&, const MemoryConfig&)’:
/home/marty/Documents/not-my-projects/tt-metal/tt_eager/tt_dnn/op_library/composite/composite_ops.cpp:504:1: error: control reaches end of non-void function [-Werror=return-type]
  504 | }
      | ^
/home/marty/Documents/not-my-projects/tt-metal/tt_eager/tt_dnn/op_library/composite/composite_ops.cpp: In function ‘tt::tt_metal::Tensor tt::tt_metal::_cosh(const Tensor&, const MemoryConfig&)’:
/home/marty/Documents/not-my-projects/tt-metal/tt_eager/tt_dnn/op_library/composite/composite_ops.cpp:520:1: error: control reaches end of non-void function [-Werror=return-type]
  520 | }
      | ^
cc1plus: all warnings being treated as errors
```

### What's changed

Deallocate temporary tensors before returning.

### Checklist
- [ ] Post commit CI passes
- [ ] Model regression CI testing passes (if applicable)
- [ ] New/Existing tests provide coverage for changes
