### PR TITLE
#0: Multi-CQ support for R-Chip

### DIFF
--- a/tests/scripts/t3000/run_t3000_unit_tests.sh
+++ b/tests/scripts/t3000/run_t3000_unit_tests.sh
@@ -32,6 +32,7 @@ run_t3000_ttnn_tests() {
   start_time=$(date +%s)
 
   echo "LOG_METAL: Running run_t3000_ttnn_tests"
+  WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml ./build/test/ttnn/unit_tests_ttnn
   pytest -n auto tests/ttnn/unit_tests/test_multi_device_trace.py ; fail+=$?
   WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml pytest tests/ttnn/unit_tests/test_multi_device_trace.py ; fail+=$?
   pytest -n auto tests/ttnn/unit_tests/test_multi_device.py ; fail+=$?

--- a/tests/tt_metal/tt_metal/unit_tests/multichip/device_cluster_api.cpp
+++ b/tests/tt_metal/tt_metal/unit_tests/multichip/device_cluster_api.cpp
@@ -33,9 +33,9 @@ TEST_F(N300DeviceFixture, ValidateEthernetConnectivity) {
 
     ASSERT_TRUE(device_0_active_eth_cores.size() == 2);
     ASSERT_TRUE(device_1_active_eth_cores.size() == 2);
-    //mmio device (0) has 4 ports (0, 1, 2 , 3) reserved for umd non-mmio access.
+    //mmio device (0) has 2 ports (8, 9) reserved for umd non-mmio access.
     //mmio device (0) port 15 is reserved for syseng tools.
-    ASSERT_TRUE(device_0->get_inactive_ethernet_cores().size() == 9);
+    ASSERT_TRUE(device_0->get_inactive_ethernet_cores().size() == 13);
     ASSERT_TRUE(device_1->get_inactive_ethernet_cores().size() == 14);
 
     for (const auto& core : device_0_active_eth_cores) {

--- a/tests/tt_metal/tt_metal/unit_tests_fast_dispatch_single_chip_multi_queue/command_queue/test_EnqueueWaitForEvent.cpp
+++ b/tests/tt_metal/tt_metal/unit_tests_fast_dispatch_single_chip_multi_queue/command_queue/test_EnqueueWaitForEvent.cpp
@@ -47,7 +47,7 @@ TEST_F(MultiCommandQueueSingleDeviceFixture, TestEventsEventSynchronizeSanity) {
             EventSynchronize(event);
             // Can check events fields after prev sync w/ async CQ.
             EXPECT_EQ(event->cq_id, cqs[i].get().id());
-            EXPECT_EQ(event->event_id, cmds_issued_per_cq[i]);
+            EXPECT_EQ(event->event_id, cmds_issued_per_cq[i] + 1);
             cmds_issued_per_cq[i] += num_cmds_per_cq;
         }
     }
@@ -68,11 +68,11 @@ TEST_F(MultiCommandQueueSingleDeviceFixture, TestEventsEventSynchronizeSanity) {
 // Simplest test to record and wait-for-events on same CQ.
 TEST_F(MultiCommandQueueSingleDeviceFixture, TestEventsEnqueueWaitForEventSanity) {
     vector<std::reference_wrapper<CommandQueue>> cqs = {this->device_->command_queue(0), this->device_->command_queue(1)};
-    vector<uint32_t> cmds_issued_per_cq = {0, 0};
+    vector<uint32_t> events_issued_per_cq = {0, 0};
     size_t num_events = 10;
 
     TT_ASSERT(cqs.size() == 2);
-    const int num_cmds_per_cq = 2;
+    const int num_events_per_cq = 1;
 
     auto start = std::chrono::system_clock::now();
 
@@ -82,9 +82,9 @@ TEST_F(MultiCommandQueueSingleDeviceFixture, TestEventsEnqueueWaitForEventSanity
             auto event = std::make_shared<Event>();
             EnqueueRecordEvent(cqs[i], event);
             EXPECT_EQ(event->cq_id, cqs[i].get().id());
-            EXPECT_EQ(event->event_id, cmds_issued_per_cq[i]);
+            EXPECT_EQ(event->event_id, events_issued_per_cq[i] + 1);
             EnqueueWaitForEvent(cqs[i], event);
-            cmds_issued_per_cq[i] += num_cmds_per_cq;
+            events_issued_per_cq[i] += num_events_per_cq;
         }
     }
     local_test_functions::FinishAllCqs(cqs);
@@ -123,7 +123,7 @@ TEST_F(MultiCommandQueueSingleDeviceFixture, TestEventsEnqueueWaitForEventCrossC
             log_debug(tt::LogTest, "j : {} Recording event on CQ ID: {} and Device Syncing on CQ ID: {}", j, cqs[cq_idx_record].get().id(), cqs[cq_idx_wait].get().id());
             EnqueueRecordEvent(cqs[cq_idx_record], event);
             EXPECT_EQ(event->cq_id, cqs[cq_idx_record].get().id());
-            EXPECT_EQ(event->event_id, cmds_issued_per_cq[i]);
+            EXPECT_EQ(event->event_id, cmds_issued_per_cq[i] + 1);
             EnqueueWaitForEvent(cqs[cq_idx_wait], event);
 
             // Occasionally do host wait for extra coverage from both CQs.
@@ -131,7 +131,7 @@ TEST_F(MultiCommandQueueSingleDeviceFixture, TestEventsEnqueueWaitForEventCrossC
                 EventSynchronize(event);
             }
             cmds_issued_per_cq[cq_idx_record] += num_cmds_per_cq;
-            cmds_issued_per_cq[cq_idx_wait] += num_cmds_per_cq;
+            // cmds_issued_per_cq[cq_idx_wait] += num_cmds_per_cq; // wait_for_event no longer records an event on host
         }
     }
 
@@ -142,13 +142,13 @@ TEST_F(MultiCommandQueueSingleDeviceFixture, TestEventsEnqueueWaitForEventCrossC
     uint16_t channel = tt::Cluster::instance().get_assigned_channel_for_device(this->device_->id());
     constexpr uint32_t completion_queue_event_alignment = 32;
     uint32_t event;
-
+    // Iterate through all CQs, and verify that the events returned by EnqueueRecordEvent are in order.
     for (uint cq_id = 0; cq_id < cqs.size(); cq_id++) {
-        for (size_t i = 0; i < num_cmds_per_cq * cqs.size() * num_events_per_cq; i++) {
+        for (size_t i = 0; i < num_cmds_per_cq * num_events_per_cq; i++) {
             uint32_t host_addr = completion_queue_base[cq_id] + i * dispatch_constants::TRANSFER_PAGE_SIZE + sizeof(CQDispatchCmd);
             tt::Cluster::instance().read_sysmem(&event, 4, host_addr, mmio_device_id, channel);
             log_debug(tt::LogTest, "Checking completion queue. cq_id: {} i: {} host_addr: {}. Got event_id: {}", cq_id, i, host_addr, event);
-            EXPECT_EQ(event, expected_event_id[cq_id]++);
+            EXPECT_EQ(event, ++expected_event_id[cq_id]);
         }
     }
 

--- a/tests/tt_metal/tt_metal/unit_tests_fast_dispatch_single_chip_multi_queue/common/command_queue_fixture.hpp
+++ b/tests/tt_metal/tt_metal/unit_tests_fast_dispatch_single_chip_multi_queue/common/command_queue_fixture.hpp
@@ -24,6 +24,10 @@ class MultiCommandQueueSingleDeviceFixture : public ::testing::Test {
             GTEST_SKIP();
         }
         arch_ = tt::get_arch_from_string(tt::test_utils::get_env_arch_name());
+        if (arch_ == tt::ARCH::WORMHOLE_B0 and tt::tt_metal::GetNumAvailableDevices() != 1) {
+            tt::log_warning(tt::LogTest, "Ethernet Dispatch not being explicitly used. Set this configuration in Setup()");
+            setenv("WH_ARCH_YAML", "wormhole_b0_80_arch_eth_dispatch.yaml", true);
+        }
         device_ = tt::tt_metal::CreateDevice(0, std::stoi(num_cqs));
     }
 

--- a/tests/ttnn/unit_tests/gtests/CMakeLists.txt
+++ b/tests/ttnn/unit_tests/gtests/CMakeLists.txt
@@ -4,6 +4,7 @@ set(TTNN_UNIT_TESTS_SRC
     ${CMAKE_CURRENT_SOURCE_DIR}/test_repeat_interleave.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/test_async_runtime.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/test_multiprod_queue.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/test_multi_cq_multi_dev.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/test_reflect.cpp
 )
 

--- a/tests/ttnn/unit_tests/gtests/test_multi_cq_multi_dev.cpp
+++ b/tests/ttnn/unit_tests/gtests/test_multi_cq_multi_dev.cpp
@@ -1,0 +1,185 @@
+// SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "tensor/tensor.hpp"
+#include "ttnn_multi_command_queue_fixture.hpp"
+#include "ttnn/operations/eltwise/binary/binary.hpp"
+#include "tt_dnn/op_library/moreh_sum/moreh_sum_op.hpp"
+#include "common/bfloat16.hpp"
+#include "ttnn/cpp/ttnn/async_runtime.hpp"
+#include "tt_numpy/functions.hpp"
+#include <cmath>
+
+using namespace tt;
+using namespace tt_metal;
+using MultiCommandQueueT3KFixture = ttnn::MultiCommandQueueT3KFixture;
+
+Tensor dispatch_ops_to_device(Device* dev, Tensor input_tensor, uint8_t cq_id) {
+    auto op0 = tt::tt_metal::EltwiseUnary{std::vector{tt::tt_metal::UnaryWithParam{tt::tt_metal::UnaryOpType::MUL_UNARY_SFPU, 2}}};
+    auto op1 = tt::tt_metal::EltwiseUnary{std::vector{tt::tt_metal::UnaryWithParam{tt::tt_metal::UnaryOpType::NEG}}};
+    auto op2 = tt::tt_metal::EltwiseUnary{std::vector{tt::tt_metal::UnaryWithParam{tt::tt_metal::UnaryOpType::ADD_UNARY_SFPU, 500}}};
+
+    Tensor output_tensor = ttnn::run_operation(cq_id, op0, {input_tensor}).at(0);
+    for (int i = 0; i < 3; i++) {
+        output_tensor = ttnn::run_operation(cq_id, op1, {output_tensor}).at(0);
+        output_tensor = ttnn::run_operation(cq_id, op1, {output_tensor}).at(0);
+        output_tensor = ttnn::run_operation(cq_id, op0, {output_tensor}).at(0);
+    }
+    output_tensor = ttnn::run_operation(cq_id, op1, {output_tensor}).at(0);
+    output_tensor = ttnn::run_operation(cq_id, op0, {output_tensor}).at(0);
+    output_tensor = ttnn::run_operation(cq_id, op2, {output_tensor}).at(0);
+    return output_tensor;
+}
+
+TEST_F(MultiCommandQueueT3KFixture, Test2CQMultiDeviceProgramsOnCQ1) {
+    // 8 devices with 2 CQs. Enable this test on T3K only.
+    if (tt::tt_metal::GetNumAvailableDevices() < 8 or tt::get_arch_from_string(tt::test_utils::get_env_arch_name()) != tt::ARCH::WORMHOLE_B0) {
+        GTEST_SKIP();
+    }
+
+    MemoryConfig mem_cfg = MemoryConfig{
+        .memory_layout = tt::tt_metal::TensorMemoryLayout::INTERLEAVED,
+        .buffer_type = BufferType::DRAM,
+        .shard_spec = std::nullopt};
+
+    ttnn::Shape shape = ttnn::Shape(Shape({1, 3, 2048, 2048}));
+    uint32_t buf_size_datums = 2048 * 2048 * 3;
+    uint32_t datum_size_bytes = 2;
+    auto host_data = std::shared_ptr<bfloat16 []>(new bfloat16[buf_size_datums]);
+    auto readback_data = std::shared_ptr<bfloat16 []>(new bfloat16[buf_size_datums]);
+    for (int outer_loop = 0; outer_loop < 5; outer_loop++) {
+        log_info(LogTest, "Running outer loop {}", outer_loop);
+        for (int i = 0; i < 30; i++) {
+            for (auto& dev : this->devs) {
+                auto dev_idx = dev.first;
+                auto device = dev.second;
+                if (i == 0 and outer_loop == 0)
+                    device->enable_program_cache();
+                for (int j = 0; j < buf_size_datums; j++) {
+                    host_data[j] = bfloat16(static_cast<float>(i + dev_idx));
+                }
+                auto input_buffer = ttnn::allocate_buffer_on_device(buf_size_datums * datum_size_bytes, device, shape, DataType::BFLOAT16, Layout::TILE, mem_cfg);
+                auto input_storage = tt::tt_metal::DeviceStorage{input_buffer};
+                Tensor input_tensor = Tensor(input_storage, shape, DataType::BFLOAT16, Layout::TILE);
+
+                auto write_event = std::make_shared<Event>();
+                auto workload_event = std::make_shared<Event>();
+                ttnn::write_buffer(0, input_tensor, {host_data, host_data, host_data, host_data, host_data, host_data, host_data, host_data});
+                ttnn::record_event(device->command_queue(0), write_event);
+                ttnn::wait_for_event(device->command_queue(1), write_event);
+                auto output_tensor = dispatch_ops_to_device(device, input_tensor, 1);
+                ttnn::record_event(device->command_queue(1), workload_event);
+                ttnn::wait_for_event(device->command_queue(0), workload_event);
+
+                ttnn::read_buffer(1, output_tensor, {readback_data, readback_data, readback_data, readback_data, readback_data, readback_data, readback_data, readback_data});
+
+                for (int j = 0; j < 3 * 2048 * 2048; j++) {
+                    ASSERT_EQ(readback_data[j].to_float(), -1 * (i + dev_idx) * 32 + 500);
+                }
+            }
+        }
+    }
+}
+
+TEST_F(MultiCommandQueueT3KFixture, Test2CQMultiDeviceProgramsOnCQ0) {
+    // 8 devices with 2 CQs. Enable this test on T3K only.
+    if (tt::tt_metal::GetNumAvailableDevices() < 8 or tt::get_arch_from_string(tt::test_utils::get_env_arch_name()) != tt::ARCH::WORMHOLE_B0) {
+        GTEST_SKIP();
+    }
+
+    MemoryConfig mem_cfg = MemoryConfig{
+        .memory_layout = tt::tt_metal::TensorMemoryLayout::INTERLEAVED,
+        .buffer_type = BufferType::DRAM,
+        .shard_spec = std::nullopt};
+
+    ttnn::Shape shape = ttnn::Shape(Shape({1, 3, 2048, 2048}));
+    uint32_t buf_size_datums = 2048 * 2048 * 3;
+    uint32_t datum_size_bytes = 2;
+    auto host_data = std::shared_ptr<bfloat16 []>(new bfloat16[buf_size_datums]);
+    auto readback_data = std::shared_ptr<bfloat16 []>(new bfloat16[buf_size_datums]);
+
+    for (int outer_loop = 0; outer_loop < 5; outer_loop++) {
+        log_info(LogTest, "Running outer loop {}", outer_loop);
+        for (int i = 0; i < 30; i++) {
+            for (auto& dev : this->devs) {
+                auto dev_idx = dev.first;
+                auto device = dev.second;
+                if (i == 0 and outer_loop == 0)
+                    device->enable_program_cache();
+                for (int j = 0; j < buf_size_datums; j++) {
+                    host_data[j] = bfloat16(static_cast<float>(i + dev_idx));
+                }
+                auto input_buffer = ttnn::allocate_buffer_on_device(buf_size_datums * datum_size_bytes, device, shape, DataType::BFLOAT16, Layout::TILE, mem_cfg);
+                auto input_storage = tt::tt_metal::DeviceStorage{input_buffer};
+                Tensor input_tensor = Tensor(input_storage, shape, DataType::BFLOAT16, Layout::TILE);
+
+                auto write_event = std::make_shared<Event>();
+                auto workload_event = std::make_shared<Event>();
+                ttnn::write_buffer(1, input_tensor, {host_data, host_data, host_data, host_data, host_data, host_data, host_data, host_data});
+                ttnn::record_event(device->command_queue(1), write_event);
+                ttnn::wait_for_event(device->command_queue(0), write_event);
+                auto output_tensor = dispatch_ops_to_device(device, input_tensor, 0);
+                ttnn::record_event(device->command_queue(0), workload_event);
+                ttnn::wait_for_event(device->command_queue(1), workload_event);
+                // std::this_thread::sleep_for(std::chrono::milliseconds(50));
+                ttnn::read_buffer(1, output_tensor, {readback_data, readback_data, readback_data, readback_data, readback_data, readback_data, readback_data, readback_data});
+
+                for (int j = 0; j < 3 * 2048 * 2048; j++) {
+                    ASSERT_EQ(readback_data[j].to_float(), -1 * (i + dev_idx) * 32 + 500);
+                }
+            }
+        }
+    }
+}
+
+TEST_F(MultiCommandQueueT3KFixture, Test2CQMultiDeviceWithCQ1Only) {
+    // 8 devices with 2 CQs. Enable this test on T3K only.
+    if (tt::tt_metal::GetNumAvailableDevices() < 8 or tt::get_arch_from_string(tt::test_utils::get_env_arch_name()) != tt::ARCH::WORMHOLE_B0) {
+        GTEST_SKIP();
+    }
+
+    MemoryConfig mem_cfg = MemoryConfig{
+        .memory_layout = tt::tt_metal::TensorMemoryLayout::INTERLEAVED,
+        .buffer_type = BufferType::DRAM,
+        .shard_spec = std::nullopt};
+
+    ttnn::Shape shape = ttnn::Shape(Shape({1, 3, 2048, 2048}));
+    uint32_t buf_size_datums = 2048 * 2048 * 3;
+    uint32_t datum_size_bytes = 2;
+    auto host_data = std::shared_ptr<bfloat16 []>(new bfloat16[buf_size_datums]);
+    auto readback_data = std::shared_ptr<bfloat16 []>(new bfloat16[buf_size_datums]);
+
+    for (int outer_loop = 0; outer_loop < 5; outer_loop++) {
+        log_info(LogTest, "Running outer loop {}", outer_loop);
+        for (int i = 0; i < 30; i++) {
+            for (auto& dev : this->devs) {
+                auto dev_idx = dev.first;
+                auto device = dev.second;
+                if (i == 0 and outer_loop == 0)
+                    device->enable_program_cache();
+                for (int j = 0; j < buf_size_datums; j++) {
+                    host_data[j] = bfloat16(static_cast<float>(i + dev_idx));
+                }
+                auto input_buffer = ttnn::allocate_buffer_on_device(buf_size_datums * datum_size_bytes, device, shape, DataType::BFLOAT16, Layout::TILE, mem_cfg);
+                auto input_storage = tt::tt_metal::DeviceStorage{input_buffer};
+                Tensor input_tensor = Tensor(input_storage, shape, DataType::BFLOAT16, Layout::TILE);
+
+                auto write_event = std::make_shared<Event>();
+                auto workload_event = std::make_shared<Event>();
+
+                ttnn::write_buffer(1, input_tensor, {host_data, host_data, host_data, host_data, host_data, host_data, host_data, host_data});
+                ttnn::record_event(device->command_queue(1), write_event);
+                ttnn::wait_for_event(device->command_queue(1), write_event);
+                auto output_tensor = dispatch_ops_to_device(device, input_tensor, 1);
+                ttnn::record_event(device->command_queue(1), workload_event);
+                ttnn::wait_for_event(device->command_queue(1), workload_event);
+                ttnn::read_buffer(1, output_tensor, {readback_data, readback_data, readback_data, readback_data, readback_data, readback_data, readback_data, readback_data});
+
+                for (int j = 0; j < 3 * 2048 * 2048; j++) {
+                    ASSERT_EQ(readback_data[j].to_float(), -1 * (i + dev_idx) * 32 + 500);
+                }
+            }
+        }
+    }
+}

--- a/tests/ttnn/unit_tests/gtests/ttnn_multi_command_queue_fixture.hpp
+++ b/tests/ttnn/unit_tests/gtests/ttnn_multi_command_queue_fixture.hpp
@@ -7,6 +7,7 @@
 #include "tt_metal/test_utils/env_vars.hpp"
 #include "tt_metal/impl/dispatch/command_queue.hpp"
 #include "tt_metal/llrt/rtoptions.hpp"
+#include "tt_metal/detail/tt_metal.hpp"
 
 namespace ttnn {
 
@@ -21,8 +22,8 @@ class MultiCommandQueueSingleDeviceFixture : public ::testing::Test {
         }
 
         if (arch_ == tt::ARCH::WORMHOLE_B0 and num_devices_ != 1) {
-            device_ = tt::tt_metal::CreateDevice(0); // Create device here so teardown can gracefully run
-            GTEST_SKIP() << "Skipping for Multi-Chip Wormhole, since not enough dispatch cores.";
+            tt::log_warning(tt::LogTest, "Ethernet Dispatch not being explicitly used. Set this configuration in Setup()");
+            setenv("WH_ARCH_YAML", "wormhole_b0_80_arch_eth_dispatch.yaml", true);
         }
         device_ = tt::tt_metal::CreateDevice(0, 2);
     }
@@ -35,4 +36,33 @@ class MultiCommandQueueSingleDeviceFixture : public ::testing::Test {
     tt::ARCH arch_;
     size_t num_devices_;
 };
+
+class MultiCommandQueueT3KFixture : public ::testing::Test {
+   protected:
+    void SetUp() override {
+        auto slow_dispatch = getenv("TT_METAL_SLOW_DISPATCH_MODE");
+        arch_ = tt::get_arch_from_string(tt::test_utils::get_env_arch_name());
+        num_devices_ = tt::tt_metal::GetNumAvailableDevices();
+        if (slow_dispatch) {
+            GTEST_SKIP() << "Skipping Multi CQ test suite, since it can only be run in Fast Dispatch Mode.";
+        }
+        if (num_devices_ < 8 or arch_ != tt::ARCH::WORMHOLE_B0) {
+            GTEST_SKIP() << "Skipping T3K Multi CQ test suite on non T3K machine.";
+        }
+        // Enable Ethernet Dispatch for Multi-CQ tests.
+        tt::log_warning(tt::LogTest, "Ethernet Dispatch not being explicitly used. Set this configuration in Setup()");
+        setenv("WH_ARCH_YAML", "wormhole_b0_80_arch_eth_dispatch.yaml", true);
+
+        devs = tt::tt_metal::detail::CreateDevices({0, 1, 2, 3, 4, 5, 6, 7}, 2);
+    }
+
+    void TearDown() override {
+        tt::tt_metal::detail::CloseDevices(devs);
+    }
+
+    std::map<chip_id_t, tt::tt_metal::Device*> devs;
+    tt::ARCH arch_;
+    size_t num_devices_;
+};
+
 }

--- a/tt_metal/impl/device/device.cpp
+++ b/tt_metal/impl/device/device.cpp
@@ -46,20 +46,20 @@ void Device::get_associated_dispatch_phys_cores(
     std::unordered_map<chip_id_t,std::unordered_set<CoreCoord>> &other_dispatch_cores) {
     if (this->is_mmio_capable()) {
         for (const chip_id_t &device_id : tt::Cluster::instance().get_devices_controlled_by_mmio_device(this->id_)) {
-            uint8_t curr_num_hw_cqs = device_id == this->id_ ? this->num_hw_cqs() : 1;
+            uint8_t num_hw_cqs = this->num_hw_cqs();
             uint16_t curr_channel = tt::Cluster::instance().get_assigned_channel_for_device(device_id);
-            CoreType dispatch_core_type = dispatch_core_manager::get(curr_num_hw_cqs).get_dispatch_core_type(device_id);
-            for (uint8_t cq_id = 0; cq_id < curr_num_hw_cqs; cq_id++) {
+            CoreType dispatch_core_type = dispatch_core_manager::get(num_hw_cqs).get_dispatch_core_type(device_id);
+            for (uint8_t cq_id = 0; cq_id < num_hw_cqs; cq_id++) {
                 if (device_id == this->id_) {
                     //mmio device.
-                    if (dispatch_core_manager::get(curr_num_hw_cqs).is_dispatcher_core_allocated(device_id, curr_channel, cq_id)) {
-                        tt_cxy_pair dispatch_location = dispatch_core_manager::get(curr_num_hw_cqs).dispatcher_core(device_id, curr_channel, cq_id);
+                    if (dispatch_core_manager::get(num_hw_cqs).is_dispatcher_core_allocated(device_id, curr_channel, cq_id)) {
+                        tt_cxy_pair dispatch_location = dispatch_core_manager::get(num_hw_cqs).dispatcher_core(device_id, curr_channel, cq_id);
                         CoreCoord phys_core = get_physical_core_coordinate(dispatch_location, dispatch_core_type);
                         my_dispatch_cores[this->id_].insert(phys_core);
                         log_debug(tt::LogMetal, "MMIO Device Dispatch core: Logical: {} - Physical: {}", dispatch_location.str(), phys_core.str());
                     }
-                    if (dispatch_core_manager::get(curr_num_hw_cqs).is_prefetcher_core_allocated(device_id, curr_channel, cq_id)) {
-                        tt_cxy_pair prefetch_location = dispatch_core_manager::get(curr_num_hw_cqs).prefetcher_core(device_id, curr_channel, cq_id);
+                    if (dispatch_core_manager::get(num_hw_cqs).is_prefetcher_core_allocated(device_id, curr_channel, cq_id)) {
+                        tt_cxy_pair prefetch_location = dispatch_core_manager::get(num_hw_cqs).prefetcher_core(device_id, curr_channel, cq_id);
                         CoreCoord phys_core = get_physical_core_coordinate(prefetch_location, dispatch_core_type);
                         my_dispatch_cores[this->id_].insert(phys_core);
                         log_debug(tt::LogMetal, "MMIO Device Prefetch core: Logical: {} - Physical: {}", prefetch_location.str(), phys_core.str());
@@ -67,26 +67,26 @@ void Device::get_associated_dispatch_phys_cores(
                 } else if (tt::DevicePool::instance().is_device_active(device_id)) {
                     //non mmio devices serviced by this mmio capable device.
                     //skip remote dispatch cores only if respective remote device is active.
-                    if (dispatch_core_manager::get(curr_num_hw_cqs).is_dispatcher_core_allocated(device_id, curr_channel, cq_id)) {
-                        tt_cxy_pair dispatch_location = dispatch_core_manager::get(curr_num_hw_cqs).dispatcher_core(device_id, curr_channel, cq_id);
+                    if (dispatch_core_manager::get(num_hw_cqs).is_dispatcher_core_allocated(device_id, curr_channel, cq_id)) {
+                        tt_cxy_pair dispatch_location = dispatch_core_manager::get(num_hw_cqs).dispatcher_core(device_id, curr_channel, cq_id);
                         CoreCoord phys_core = get_physical_core_coordinate(dispatch_location, dispatch_core_type);
                         other_dispatch_cores[this->id_].insert(phys_core);
                         log_debug(tt::LogMetal, "Remote Device Dispatch core: Logical: {} - Physical: {} will keep running on MMIO Device.", dispatch_location.str(), phys_core.str());
                     }
-                    if (dispatch_core_manager::get(curr_num_hw_cqs).is_prefetcher_core_allocated(device_id, curr_channel, cq_id)) {
-                        tt_cxy_pair prefetch_location = dispatch_core_manager::get(curr_num_hw_cqs).prefetcher_core(device_id, curr_channel, cq_id);
+                    if (dispatch_core_manager::get(num_hw_cqs).is_prefetcher_core_allocated(device_id, curr_channel, cq_id)) {
+                        tt_cxy_pair prefetch_location = dispatch_core_manager::get(num_hw_cqs).prefetcher_core(device_id, curr_channel, cq_id);
                         CoreCoord phys_core = get_physical_core_coordinate(prefetch_location, dispatch_core_type);
                         other_dispatch_cores[this->id_].insert(phys_core);
                         log_debug(tt::LogMetal, "Remote Device Prefetch core: Logical: {} - Physical: {} will keep running on MMIO Device.", prefetch_location.str(), phys_core.str());
                     }
-                    if (dispatch_core_manager::get(curr_num_hw_cqs).is_mux_core_allocated(device_id, curr_channel, cq_id)) {
-                        tt_cxy_pair mux_location = dispatch_core_manager::get(curr_num_hw_cqs).mux_core(device_id, curr_channel, cq_id);
+                    if (dispatch_core_manager::get(num_hw_cqs).is_mux_core_allocated(device_id, curr_channel, cq_id)) {
+                        tt_cxy_pair mux_location = dispatch_core_manager::get(num_hw_cqs).mux_core(device_id, curr_channel, cq_id);
                         CoreCoord phys_core = get_physical_core_coordinate(mux_location, dispatch_core_type);
                         other_dispatch_cores[this->id_].insert(phys_core);
                         log_debug(tt::LogMetal, "Remote Device Mux core: Logical: {} - Physical: {} will keep running on MMIO Device.", mux_location.str(), phys_core.str());
                     }
-                    if (dispatch_core_manager::get(curr_num_hw_cqs).is_demux_core_allocated(device_id, curr_channel, cq_id)) {
-                        tt_cxy_pair demux_location = dispatch_core_manager::get(curr_num_hw_cqs).demux_core(device_id, curr_channel, cq_id);
+                    if (dispatch_core_manager::get(num_hw_cqs).is_demux_core_allocated(device_id, curr_channel, cq_id)) {
+                        tt_cxy_pair demux_location = dispatch_core_manager::get(num_hw_cqs).demux_core(device_id, curr_channel, cq_id);
                         CoreCoord phys_core = get_physical_core_coordinate(demux_location, dispatch_core_type);
                         other_dispatch_cores[this->id_].insert(phys_core);
                         log_debug(tt::LogMetal, "Remote Device Demux core: Logical: {} - Physical: {} will keep running on MMIO Device.", demux_location.str(), phys_core.str());
@@ -96,46 +96,46 @@ void Device::get_associated_dispatch_phys_cores(
         }
     } else {
         //remote device that is active
-        uint8_t curr_num_hw_cqs = 1;
+        uint8_t num_hw_cqs = this->num_hw_cqs();
         auto device_id = this->id_;
         uint16_t curr_channel = tt::Cluster::instance().get_assigned_channel_for_device(device_id);
-        CoreType dispatch_core_type = dispatch_core_manager::get(curr_num_hw_cqs).get_dispatch_core_type(device_id);
-        for (uint8_t cq_id = 0; cq_id < curr_num_hw_cqs; cq_id++) {
-            if (dispatch_core_manager::get(curr_num_hw_cqs).is_dispatcher_core_allocated(device_id, curr_channel, cq_id)) {
-                tt_cxy_pair dispatch_location = dispatch_core_manager::get(curr_num_hw_cqs).dispatcher_core(device_id, curr_channel, cq_id);
+        CoreType dispatch_core_type = dispatch_core_manager::get(num_hw_cqs).get_dispatch_core_type(device_id);
+        for (uint8_t cq_id = 0; cq_id < num_hw_cqs; cq_id++) {
+            if (dispatch_core_manager::get(num_hw_cqs).is_dispatcher_core_allocated(device_id, curr_channel, cq_id)) {
+                tt_cxy_pair dispatch_location = dispatch_core_manager::get(num_hw_cqs).dispatcher_core(device_id, curr_channel, cq_id);
                 CoreCoord phys_core = get_physical_core_coordinate(dispatch_location, dispatch_core_type);
                 my_dispatch_cores[dispatch_location.chip].insert(phys_core);
                 log_debug(tt::LogMetal, "Remote Device Dispatch core: Logical: {} - Physical: {} will be reset on MMIO Device.", dispatch_location.str(), phys_core.str());
             }
-            if (dispatch_core_manager::get(curr_num_hw_cqs).is_prefetcher_core_allocated(device_id, curr_channel, cq_id)) {
-                tt_cxy_pair prefetch_location = dispatch_core_manager::get(curr_num_hw_cqs).prefetcher_core(device_id, curr_channel, cq_id);
+            if (dispatch_core_manager::get(num_hw_cqs).is_prefetcher_core_allocated(device_id, curr_channel, cq_id)) {
+                tt_cxy_pair prefetch_location = dispatch_core_manager::get(num_hw_cqs).prefetcher_core(device_id, curr_channel, cq_id);
                 CoreCoord phys_core = get_physical_core_coordinate(prefetch_location, dispatch_core_type);
                 my_dispatch_cores[prefetch_location.chip].insert(phys_core);
                 log_debug(tt::LogMetal, "Remote Device Prefetch core: Logical: {} - Physical: {} will be reset on MMIO Device.", prefetch_location.str(), phys_core.str());
             }
-            if (dispatch_core_manager::get(curr_num_hw_cqs).is_mux_core_allocated(device_id, curr_channel, cq_id)) {
-                tt_cxy_pair mux_location = dispatch_core_manager::get(curr_num_hw_cqs).mux_core(device_id, curr_channel, cq_id);
+            if (dispatch_core_manager::get(num_hw_cqs).is_mux_core_allocated(device_id, curr_channel, cq_id)) {
+                tt_cxy_pair mux_location = dispatch_core_manager::get(num_hw_cqs).mux_core(device_id, curr_channel, cq_id);
                 CoreCoord phys_core = get_physical_core_coordinate(mux_location, dispatch_core_type);
                 my_dispatch_cores[mux_location.chip].insert(phys_core);
                 log_debug(tt::LogMetal, "Remote Device Mux core: Logical: {} - Physical: {} will be reset on MMIO Device.", mux_location.str(), phys_core.str());
             }
-            if (dispatch_core_manager::get(curr_num_hw_cqs).is_demux_core_allocated(device_id, curr_channel, cq_id)) {
-                tt_cxy_pair demux_location = dispatch_core_manager::get(curr_num_hw_cqs).demux_core(device_id, curr_channel, cq_id);
+            if (dispatch_core_manager::get(num_hw_cqs).is_demux_core_allocated(device_id, curr_channel, cq_id)) {
+                tt_cxy_pair demux_location = dispatch_core_manager::get(num_hw_cqs).demux_core(device_id, curr_channel, cq_id);
                 CoreCoord phys_core = get_physical_core_coordinate(demux_location, dispatch_core_type);
                 my_dispatch_cores[demux_location.chip].insert(phys_core);
                 log_debug(tt::LogMetal, "Remote Device Demux core: Logical: {} - Physical: {} will be reset on MMIO Device.", demux_location.str(), phys_core.str());
             }
                 CoreCoord phys_core;
-                tt_cxy_pair dispatch_location = dispatch_core_manager::get(curr_num_hw_cqs).dispatcher_d_core(device_id, curr_channel, cq_id);
+                tt_cxy_pair dispatch_location = dispatch_core_manager::get(num_hw_cqs).dispatcher_d_core(device_id, curr_channel, cq_id);
                 phys_core = get_physical_core_coordinate(dispatch_location, dispatch_core_type);
                 my_dispatch_cores[dispatch_location.chip].insert(phys_core);
-                tt_cxy_pair prefetch_location = dispatch_core_manager::get(curr_num_hw_cqs).prefetcher_d_core(device_id, curr_channel, cq_id);
+                tt_cxy_pair prefetch_location = dispatch_core_manager::get(num_hw_cqs).prefetcher_d_core(device_id, curr_channel, cq_id);
                 phys_core = get_physical_core_coordinate(prefetch_location, dispatch_core_type);
                 my_dispatch_cores[dispatch_location.chip].insert(phys_core);
-                tt_cxy_pair mux_location = dispatch_core_manager::get(curr_num_hw_cqs).mux_d_core(device_id, curr_channel, cq_id);
+                tt_cxy_pair mux_location = dispatch_core_manager::get(num_hw_cqs).mux_d_core(device_id, curr_channel, cq_id);
                 phys_core = get_physical_core_coordinate(mux_location, dispatch_core_type);
                 my_dispatch_cores[dispatch_location.chip].insert(phys_core);
-                tt_cxy_pair demux_location = dispatch_core_manager::get(curr_num_hw_cqs).demux_d_core(device_id, curr_channel, cq_id);
+                tt_cxy_pair demux_location = dispatch_core_manager::get(num_hw_cqs).demux_d_core(device_id, curr_channel, cq_id);
                 phys_core = get_physical_core_coordinate(demux_location, dispatch_core_type);
                 my_dispatch_cores[dispatch_location.chip].insert(phys_core);
         }
@@ -195,8 +195,8 @@ void Device::initialize_allocator(size_t l1_small_size, size_t trace_region_size
         const auto noc_coord = this->worker_core_from_logical_core(core);
         config.core_type_from_noc_coord_table[noc_coord] = AllocCoreType::StorageOnly;
     }
+    CoreType dispatch_core_type = tt::get_dispatch_core_type(id_, num_hw_cqs_);
     for (const CoreCoord& core : tt::get_logical_dispatch_cores(id_, num_hw_cqs_)) {
-        CoreType dispatch_core_type = tt::get_dispatch_core_type(id_, num_hw_cqs_);
         const auto noc_coord = this->physical_core_from_logical_core(core, dispatch_core_type);
         config.core_type_from_noc_coord_table[noc_coord] = AllocCoreType::Dispatch;
     }
@@ -543,6 +543,7 @@ void Device::configure_kernel_variant(
 }
 
 void Device::update_workers_build_settings(std::vector<std::vector<std::tuple<tt_cxy_pair, worker_build_settings_t>>> &device_worker_variants) {
+    uint32_t num_hw_cqs = this->num_hw_cqs();
     for (uint32_t dwv = 0; dwv < device_worker_variants.size(); dwv++)
     {
         if (device_worker_variants[dwv].size() == 0) {
@@ -566,7 +567,7 @@ void Device::update_workers_build_settings(std::vector<std::vector<std::tuple<tt
                     auto& compile_args = settings.compile_args;
                     compile_args[0]  = downstream_cb_base;
                     compile_args[1]  = dispatch_constants::PREFETCH_D_BUFFER_LOG_PAGE_SIZE;
-                    compile_args[2]  = dispatch_constants::get(dispatch_core_type).prefetch_d_buffer_pages();
+                    compile_args[2]  = dispatch_constants::get(dispatch_core_type).mux_buffer_pages(num_hw_cqs);
                     compile_args[3]  = settings.producer_semaphore_id;
                     compile_args[4]  = mux_sem++;
                     compile_args[5]  = settings.issue_queue_start_addr;
@@ -671,7 +672,6 @@ void Device::update_workers_build_settings(std::vector<std::vector<std::tuple<tt
                 } else {
                     auto &mux_d_settings = std::get<1>(device_worker_variants[MUX_D][0]);
                     auto &demux_d_settings = std::get<1>(device_worker_variants[DEMUX_D][0]);
-
                     compile_args[5] = packet_switch_4B_pack(mux_d_settings.worker_physical_core.x,
                                         mux_d_settings.worker_physical_core.y,
                                         1,//num_dest_endpoints,
@@ -750,11 +750,12 @@ void Device::update_workers_build_settings(std::vector<std::vector<std::tuple<tt
                 uint32_t num_dispatchers = device_worker_variants[DISPATCH].size();
                 TT_ASSERT(device_worker_variants[DEMUX].size() == 1, "Cannot have more than one Demux.");
                 auto demux_settings = std::get<1>(device_worker_variants[DEMUX][0]);
-                auto prefetch_h_settings = std::get<1>(device_worker_variants[PREFETCH][0]);
-                auto prefetch_physical_core = prefetch_h_settings.worker_physical_core;
                 TT_ASSERT(num_dispatchers == demux_settings.semaphores.size(), "Demux does not have required number of semaphores for Dispatchers. Exptected = {}. Fount = {}", num_dispatchers, demux_settings.semaphores.size());
                 uint32_t demux_sem = demux_settings.producer_semaphore_id;
+                uint32_t dispatch_idx = 0;
                 for (auto&[core, settings] : device_worker_variants[DISPATCH]) {
+                    auto prefetch_h_settings = std::get<1>(device_worker_variants[PREFETCH][dispatch_idx]);
+                    auto prefetch_physical_core = prefetch_h_settings.worker_physical_core;
                     auto dispatch_core_type = settings.dispatch_core_type;
                     settings.upstream_cores.push_back(demux_settings.worker_physical_core);
                     settings.downstream_cores.push_back(tt_cxy_pair(0, 0, 0));
@@ -778,10 +779,11 @@ void Device::update_workers_build_settings(std::vector<std::vector<std::tuple<tt
                     compile_args[15] = true,    // split_prefetcher
                     compile_args[16] = NOC_XY_ENCODING(prefetch_physical_core.x, prefetch_physical_core.y),
                     compile_args[17] = prefetch_h_settings.producer_semaphore_id, // sem_id on prefetch_h that dispatch_d is meant to increment, to resume sending of cmds post exec_buf stall
-                    compile_args[18] = dispatch_constants::get(dispatch_core_type).prefetch_d_buffer_pages(), // XXXX should this be mux pages?
+                    compile_args[18] = dispatch_constants::get(dispatch_core_type).mux_buffer_pages(num_hw_cqs), // XXXX should this be mux pages?
                     compile_args[19] = settings.num_compute_cores;
                     compile_args[20] = false; // is_dram_variant
                     compile_args[21] = true; // is_host_variant
+                    dispatch_idx++;
                 }
                 break;
             }
@@ -802,7 +804,7 @@ void Device::update_workers_build_settings(std::vector<std::vector<std::tuple<tt
 
                 compile_args[4] = packet_switch_4B_pack(demux_d_settings.worker_physical_core.x,
                                     demux_d_settings.worker_physical_core.y,
-                                    is_tunnel_end ? 1 : 2,
+                                    device_worker_variants[PREFETCH_D].size() + device_worker_variants[US_TUNNELER_REMOTE].size(), // input queue id of DEMUX_D
                                     (uint32_t)DispatchRemoteNetworkType::NOC0); // 4: remote_receiver_0_info
 
                 compile_args[5] = packet_switch_4B_pack(tunneler_settings.eth_partner_physical_core.x,
@@ -821,7 +823,7 @@ void Device::update_workers_build_settings(std::vector<std::vector<std::tuple<tt
                                     (uint32_t)DispatchRemoteNetworkType::ETH); // 10: remote_sender_0_info
                 compile_args[11] = packet_switch_4B_pack(mux_d_settings.worker_physical_core.x,
                                     mux_d_settings.worker_physical_core.y,
-                                    is_tunnel_end ? 1 : 2, // mux_d output queue id
+                                    device_worker_variants[DISPATCH_D].size() + device_worker_variants[US_TUNNELER_REMOTE].size(), // mux_d output queue id
                                     (uint32_t)DispatchRemoteNetworkType::NOC0); // 11: remote_sender_1_info
                 compile_args[12] = 0x39000; // 12: test_results_addr
                 compile_args[13] = 0x7000; // 13: test_results_size
@@ -838,11 +840,13 @@ void Device::update_workers_build_settings(std::vector<std::vector<std::tuple<tt
             case DEMUX_D:
             {
                 bool is_tunnel_end = device_worker_variants[US_TUNNELER_REMOTE].size() == 0;
+                if (!is_tunnel_end) {
+                    TT_ASSERT(device_worker_variants[US_TUNNELER_REMOTE].size() == 1, "Unexpected number of ethernet tunnelers.");
+                }
                 TT_ASSERT(device_worker_variants[DEMUX_D].size() == 1, "Unexpected number of device demux.");
 
                 auto &tunneler_settings = std::get<1>(device_worker_variants[US_TUNNELER_LOCAL][0]);
                 auto &demux_d_settings = std::get<1>(device_worker_variants[DEMUX_D][0]);
-                auto &prefetch_d_settings = std::get<1>(device_worker_variants[PREFETCH_D][0]);
 
                 TT_ASSERT(demux_d_settings.tunnel_stop > 0 && demux_d_settings.tunnel_stop <= 4, "Invalid Demux D tunnel stop.");
 
@@ -852,25 +856,29 @@ void Device::update_workers_build_settings(std::vector<std::vector<std::tuple<tt
                 compile_args[0] = 0xB1; // 0: endpoint_id_start_index
                 compile_args[1] = demux_d_settings.cb_start_address >> 4; // 1: rx_queue_start_addr_words
                 compile_args[2] = demux_d_settings.cb_size_bytes >> 4; // 2: rx_queue_size_words
-                compile_args[3] = is_tunnel_end ? 1 : 2; // 3: demux_fan_out
-
-                compile_args[4] = packet_switch_4B_pack(prefetch_d_settings.worker_physical_core.x,
-                                                        prefetch_d_settings.worker_physical_core.y,
-                                                        0,
+                compile_args[3] = device_worker_variants[PREFETCH_D].size() + device_worker_variants[US_TUNNELER_REMOTE].size(); // 3: demux_fan_out
+                uint32_t demux_output_idx = 0;
+                uint32_t demux_output_cb_info_idx = 0;
+                // Tie DEMUX_D outputs to DEMUX_D output queues (prefetch_d and remote tunnel inputs) and set output CB parameters
+                for (const auto& prefetch_d_settings : device_worker_variants[PREFETCH_D]) {
+                    auto prefetch_d_setting = std::get<1>(prefetch_d_settings);
+                    compile_args[4 + demux_output_idx] = packet_switch_4B_pack(prefetch_d_setting.worker_physical_core.x,
+                                                        prefetch_d_setting.worker_physical_core.y,
+                                                        0, // prefetch_d input queue id
                                                         (uint32_t)DispatchRemoteNetworkType::NOC0); // 4: remote_tx_0_info
-
-                compile_args[8] = prefetch_d_settings.cb_start_address >> 4; // 8: remote_tx_queue_start_addr_words 0
-                compile_args[9] = prefetch_d_settings.cb_size_bytes >> 4; // 9: remote_tx_queue_size_words 0
-
-                if(!is_tunnel_end) {
-                    auto &us_tunneler_remote_settings = std::get<1>(device_worker_variants[US_TUNNELER_REMOTE][0]);
-                    compile_args[5] = packet_switch_4B_pack((uint32_t)us_tunneler_remote_settings.worker_physical_core.x,
-                                                                    (uint32_t)us_tunneler_remote_settings.worker_physical_core.y,
-                                                                    0,
-                                                                    (uint32_t)DispatchRemoteNetworkType::NOC0); // 5: remote_tx_1_info
-
-                    compile_args[10] = us_tunneler_remote_settings.cb_start_address >> 4;    // 10: remote_tx_queue_start_addr_words 1
-                    compile_args[11] = us_tunneler_remote_settings.cb_size_bytes >> 4;   // 11: remote_tx_queue_size_words 1
+                    compile_args[8 + demux_output_cb_info_idx] = prefetch_d_setting.cb_start_address >> 4;
+                    compile_args[8 + demux_output_cb_info_idx + 1] = prefetch_d_setting.cb_size_bytes >> 4;
+                    demux_output_idx++;
+                    demux_output_cb_info_idx += 2;
+                }
+                for (const auto& us_tunneler_remote_settings : device_worker_variants[US_TUNNELER_REMOTE]) {
+                    auto us_tunneler_remote_setting =  std::get<1>(us_tunneler_remote_settings);
+                    compile_args[4 + demux_output_idx] = packet_switch_4B_pack((uint32_t)us_tunneler_remote_setting.worker_physical_core.x,
+                                                        (uint32_t)us_tunneler_remote_setting.worker_physical_core.y,
+                                                        0,
+                                                        (uint32_t)DispatchRemoteNetworkType::NOC0); // 5: remote_tx_1_info
+                    compile_args[8 + demux_output_cb_info_idx] = us_tunneler_remote_setting.cb_start_address >> 4;    // 10: remote_tx_queue_start_addr_words 1
+                    compile_args[8 + demux_output_cb_info_idx + 1] = us_tunneler_remote_setting.cb_size_bytes >> 4;   // 11: remote_tx_queue_size_words 1
                 }
 
                 compile_args[16] = tunneler_settings.worker_physical_core.x; // 16: remote_rx_x
@@ -885,11 +893,20 @@ void Device::update_workers_build_settings(std::vector<std::vector<std::tuple<tt
                 compile_args[22] = 0; // 22: test_results_addr (disabled)
                 compile_args[23] = 0; // 23: test_results_size (disabled)
                 compile_args[24] = 0; // 24: timeout_cycles
-                compile_args[25] = 0x1; // 25: output_depacketize_mask
-                compile_args[26] = packet_switch_4B_pack(prefetch_d_settings.cb_log_page_size,
-                                                                        prefetch_d_settings.consumer_semaphore_id, // downstream sem
-                                                                        demux_d_settings.producer_semaphore_id,    // local sem
+                compile_args[25] = 0; // 25: output_depacketize_mask
+                // Update output_depacketize_mask based on num prefetch_d cores (local demux_d outputs)
+                for (int prefetch_d_idx = 0; prefetch_d_idx < device_worker_variants[PREFETCH_D].size(); prefetch_d_idx++) compile_args[25] |= (1 << (prefetch_d_idx));
+                // Set downstream and local sem ids, based on number of demux outputs
+                uint32_t demux_output_sem_idx = 0;
+                uint32_t demux_sem = demux_d_settings.producer_semaphore_id;
+                for (const auto& prefetch_d_settings : device_worker_variants[PREFETCH_D]) {
+                    auto prefetch_d_setting = std::get<1>(prefetch_d_settings);
+                    compile_args[26 + demux_output_sem_idx] = packet_switch_4B_pack(prefetch_d_setting.cb_log_page_size,
+                                                                        prefetch_d_setting.consumer_semaphore_id, // downstream sem
+                                                                        demux_sem++,    // local sem
                                                                         0); // remove header
+                    demux_output_sem_idx++;
+                }
                 break;
             }
             case PREFETCH_D:
@@ -897,45 +914,48 @@ void Device::update_workers_build_settings(std::vector<std::vector<std::tuple<tt
 
                 uint32_t num_prefetchers = device_worker_variants[PREFETCH_D].size();
                 TT_ASSERT(device_worker_variants[DEMUX_D].size() == 1, "Cannot have more than one Demux D.");
-                auto &prefetch_d_settings = std::get<1>(device_worker_variants[PREFETCH_D][0]);
                 auto demux_d_settings = std::get<1>(device_worker_variants[DEMUX_D][0]);
-                auto dispatch_d_settings = std::get<1>(device_worker_variants[DISPATCH_D][0]);
 
                 TT_ASSERT(num_prefetchers == demux_d_settings.semaphores.size(), "Demux D does not have required number of semaphores for Prefetcher D. Exptected = {}. Fount = {}", num_prefetchers, demux_d_settings.semaphores.size());
+                int prefetch_d_idx = 0;
+                uint32_t demux_sem = demux_d_settings.producer_semaphore_id;
+                for (auto&[core, prefetch_d_settings] : device_worker_variants[PREFETCH_D]) {
+                    auto dispatch_d_settings = std::get<1>(device_worker_variants[DISPATCH_D][prefetch_d_idx]); // 1 to 1 mapping bw prefetch_d and dispatch_d
+                    auto dispatch_core_type = prefetch_d_settings.dispatch_core_type;
+                    prefetch_d_settings.upstream_cores.push_back(demux_d_settings.worker_physical_core);
+                    prefetch_d_settings.downstream_cores.push_back(dispatch_d_settings.worker_physical_core);
 
-                auto dispatch_core_type = prefetch_d_settings.dispatch_core_type;
-                prefetch_d_settings.upstream_cores.push_back(demux_d_settings.worker_physical_core);
-                prefetch_d_settings.downstream_cores.push_back(dispatch_d_settings.worker_physical_core);
+                    uint32_t scratch_db_base = (prefetch_d_settings.cb_start_address + prefetch_d_settings.cb_size_bytes + PCIE_ALIGNMENT - 1) & (~(PCIE_ALIGNMENT - 1));
+                    uint32_t scratch_db_size = dispatch_constants::get(dispatch_core_type).scratch_db_size();
+                    const uint32_t l1_size = dispatch_core_type == CoreType::WORKER ? MEM_L1_SIZE : MEM_ETH_SIZE;
+                    TT_ASSERT(scratch_db_base + scratch_db_size <= l1_size);
 
-                uint32_t scratch_db_base = (prefetch_d_settings.cb_start_address + prefetch_d_settings.cb_size_bytes + PCIE_ALIGNMENT - 1) & (~(PCIE_ALIGNMENT - 1));
-                uint32_t scratch_db_size = dispatch_constants::get(dispatch_core_type).scratch_db_size();
-                const uint32_t l1_size = dispatch_core_type == CoreType::WORKER ? MEM_L1_SIZE : MEM_ETH_SIZE;
-                TT_ASSERT(scratch_db_base + scratch_db_size <= l1_size);
-
-                auto& compile_args = prefetch_d_settings.compile_args;
-                compile_args.resize(22);
-                compile_args[0]  = dispatch_d_settings.cb_start_address;
-                compile_args[1]  = dispatch_d_settings.cb_log_page_size;
-                compile_args[2]  = dispatch_d_settings.cb_pages;
-                compile_args[3]  = prefetch_d_settings.producer_semaphore_id;
-                compile_args[4]  = dispatch_d_settings.consumer_semaphore_id;
-                compile_args[5]  = 0;
-                compile_args[6]  = 0;
-                compile_args[7]  = 0;
-                compile_args[8]  = dispatch_constants::get(dispatch_core_type).prefetch_q_size();
-                compile_args[9]  = CQ_PREFETCH_Q_RD_PTR;
-                compile_args[10] = prefetch_d_settings.cb_start_address;
-                compile_args[11] = prefetch_d_settings.cb_size_bytes;
-                compile_args[12] = scratch_db_base;
-                compile_args[13] = scratch_db_size;
-                compile_args[14] = 0; //prefetch_sync_sem
-                compile_args[15] = prefetch_d_settings.cb_pages; // prefetch_d only
-                compile_args[16] = prefetch_d_settings.consumer_semaphore_id; // prefetch_d only
-                compile_args[17] = demux_d_settings.producer_semaphore_id; //prefetch_downstream_cb_sem, // prefetch_d only
-                compile_args[18] = prefetch_d_settings.cb_log_page_size;
-                compile_args[19] = dispatch_constants::PREFETCH_D_BUFFER_BLOCKS; // prefetch_d only
-                compile_args[20] = true;  // is_dram_variant
-                compile_args[21] = false; // is_host_variant
+                    auto& compile_args = prefetch_d_settings.compile_args;
+                    compile_args.resize(22);
+                    compile_args[0]  = dispatch_d_settings.cb_start_address;
+                    compile_args[1]  = dispatch_d_settings.cb_log_page_size;
+                    compile_args[2]  = dispatch_d_settings.cb_pages;
+                    compile_args[3]  = prefetch_d_settings.producer_semaphore_id;
+                    compile_args[4]  = dispatch_d_settings.consumer_semaphore_id;
+                    compile_args[5]  = 0;
+                    compile_args[6]  = 0;
+                    compile_args[7]  = 0;
+                    compile_args[8]  = dispatch_constants::get(dispatch_core_type).prefetch_q_size();
+                    compile_args[9]  = CQ_PREFETCH_Q_RD_PTR;
+                    compile_args[10] = prefetch_d_settings.cb_start_address;
+                    compile_args[11] = prefetch_d_settings.cb_size_bytes;
+                    compile_args[12] = scratch_db_base;
+                    compile_args[13] = scratch_db_size;
+                    compile_args[14] = 0; //prefetch_sync_sem
+                    compile_args[15] = prefetch_d_settings.cb_pages; // prefetch_d only
+                    compile_args[16] = prefetch_d_settings.consumer_semaphore_id; // prefetch_d only
+                    compile_args[17] = demux_sem++; //prefetch_downstream_cb_sem, // prefetch_d only
+                    compile_args[18] = prefetch_d_settings.cb_log_page_size;
+                    compile_args[19] = dispatch_constants::PREFETCH_D_BUFFER_BLOCKS; // prefetch_d only
+                    compile_args[20] = true;  // is_dram_variant
+                    compile_args[21] = false; // is_host_variant
+                    prefetch_d_idx++; // move on to next prefetcher
+                }
                 break;
             }
             case DISPATCH_D:
@@ -945,35 +965,39 @@ void Device::update_workers_build_settings(std::vector<std::vector<std::tuple<tt
                 auto mux_d_settings = std::get<1>(device_worker_variants[MUX_D][0]);
                 TT_ASSERT(num_dispatchers == mux_d_settings.semaphores.size(), "Mux D does not have required number of semaphores for Dispatchers. Exptected = {}. Fount = {}", num_dispatchers, mux_d_settings.semaphores.size());
                 uint32_t sem = 0;
-                auto &dispatch_d_settings = std::get<1>(device_worker_variants[DISPATCH_D][0]);
-                auto prefetch_d_settings = std::get<1>(device_worker_variants[PREFETCH_D][0]);
-                auto dispatch_core_type = dispatch_d_settings.dispatch_core_type;
-                dispatch_d_settings.upstream_cores.push_back(prefetch_d_settings.worker_physical_core);
-                dispatch_d_settings.downstream_cores.push_back(mux_d_settings.worker_physical_core);
-                dispatch_d_settings.compile_args.resize(22);
-                auto& compile_args = dispatch_d_settings.compile_args;
-                compile_args[0] = dispatch_d_settings.cb_start_address;
-                compile_args[1] = dispatch_d_settings.cb_log_page_size;
-                compile_args[2] = dispatch_d_settings.cb_pages;
-                compile_args[3] = dispatch_d_settings.consumer_semaphore_id;
-                compile_args[4] = prefetch_d_settings.producer_semaphore_id;
-                compile_args[5] = dispatch_constants::DISPATCH_BUFFER_SIZE_BLOCKS;
-                compile_args[6] = 0;
-                compile_args[7] = dispatch_d_settings.command_queue_start_addr;
-                compile_args[8] = dispatch_d_settings.completion_queue_start_addr;
-                compile_args[9] = dispatch_d_settings.completion_queue_size;
-                compile_args[10] = mux_d_settings.cb_start_address;
-                compile_args[11] = mux_d_settings.cb_size_bytes;
-                compile_args[12] = dispatch_d_settings.producer_semaphore_id; // unused: local ds semaphore
-                compile_args[13] = mux_d_settings.consumer_semaphore_id; // unused: remote ds semaphore
-                compile_args[14] = sizeof(dispatch_packet_header_t); // preamble size
-                compile_args[15] = true,    // split_prefetcher
-                compile_args[16] = 0;
-                compile_args[17] = 1; //prefetch_downstream_cb_sem,
-                compile_args[18] = dispatch_constants::get(dispatch_core_type).prefetch_d_buffer_pages(), // XXXX should this be mux pages?
-                compile_args[19] = dispatch_d_settings.num_compute_cores;
-                compile_args[20] = true; // is_dram_variant
-                compile_args[21] = false; // is_host_variant
+                int dispatch_d_idx = 0;
+                uint32_t mux_sem = mux_d_settings.consumer_semaphore_id;
+                for (auto&[core, dispatch_d_settings] : device_worker_variants[DISPATCH_D]) {
+                    auto prefetch_d_settings = std::get<1>(device_worker_variants[PREFETCH_D][dispatch_d_idx]); // 1 to 1 mapping bw prefetch_d and dispatch_d
+                    auto dispatch_core_type = dispatch_d_settings.dispatch_core_type;
+                    dispatch_d_settings.upstream_cores.push_back(prefetch_d_settings.worker_physical_core);
+                    dispatch_d_settings.downstream_cores.push_back(mux_d_settings.worker_physical_core);
+                    dispatch_d_settings.compile_args.resize(22);
+                    auto& compile_args = dispatch_d_settings.compile_args;
+                    compile_args[0] = dispatch_d_settings.cb_start_address;
+                    compile_args[1] = dispatch_d_settings.cb_log_page_size;
+                    compile_args[2] = dispatch_d_settings.cb_pages;
+                    compile_args[3] = dispatch_d_settings.consumer_semaphore_id;
+                    compile_args[4] = prefetch_d_settings.producer_semaphore_id;
+                    compile_args[5] = dispatch_constants::DISPATCH_BUFFER_SIZE_BLOCKS;
+                    compile_args[6] = 0;
+                    compile_args[7] = dispatch_d_settings.command_queue_start_addr;
+                    compile_args[8] = dispatch_d_settings.completion_queue_start_addr;
+                    compile_args[9] = dispatch_d_settings.completion_queue_size;
+                    compile_args[10] = mux_d_settings.cb_start_address + mux_d_settings.cb_size_bytes * dispatch_d_idx; // base address for downstream mux CB
+                    compile_args[11] = mux_d_settings.cb_size_bytes;
+                    compile_args[12] = dispatch_d_settings.producer_semaphore_id; // unused: local ds semaphore
+                    compile_args[13] = mux_sem++; // unused: remote ds semaphore
+                    compile_args[14] = sizeof(dispatch_packet_header_t); // preamble size
+                    compile_args[15] = true,    // split_prefetcher
+                    compile_args[16] = 0;
+                    compile_args[17] = 1; //prefetch_downstream_cb_sem,
+                    compile_args[18] = dispatch_constants::get(dispatch_core_type).mux_buffer_pages(num_hw_cqs), // mux buffer size is a function of num_cqs
+                    compile_args[19] = dispatch_d_settings.num_compute_cores;
+                    compile_args[20] = true; // is_dram_variant
+                    compile_args[21] = false; // is_host_variant
+                    dispatch_d_idx++; // move on to next dispatcher
+                }
                 break;
             }
             case MUX_D:
@@ -981,8 +1005,6 @@ void Device::update_workers_build_settings(std::vector<std::vector<std::tuple<tt
                 uint32_t num_dispatchers = device_worker_variants[DISPATCH_D].size();
                 TT_ASSERT(device_worker_variants[MUX_D].size() == 1, "Cannot have more than one Mux D.");
                 auto &mux_d_settings = std::get<1>(device_worker_variants[MUX_D][0]);
-                auto dispatch_d_settings = std::get<1>(device_worker_variants[DISPATCH_D][0]);
-
                 TT_ASSERT(num_dispatchers == mux_d_settings.semaphores.size(), "Mux D does not have required number of semaphores for Dispatchers. Exptected = {}. Fount = {}", num_dispatchers, mux_d_settings.semaphores.size());
                 uint32_t sem = 0;
                 bool is_tunnel_end = device_worker_variants[US_TUNNELER_REMOTE].size() == 0;
@@ -992,21 +1014,27 @@ void Device::update_workers_build_settings(std::vector<std::vector<std::tuple<tt
                 compile_args[0] = 0; // 0: reserved
                 compile_args[1] = mux_d_settings.cb_start_address >> 4; // 1: rx_queue_start_addr_words
                 compile_args[2] = mux_d_settings.cb_size_bytes >> 4; // 2: rx_queue_size_words
-                compile_args[3] = is_tunnel_end ? 1 : 2; // 3: mux_fan_in
-                uint32_t arg_index = 4;
-                compile_args[4] = packet_switch_4B_pack(dispatch_d_settings.worker_physical_core.x,
-                                                        dispatch_d_settings.worker_physical_core.y,
+                compile_args[3] =  device_worker_variants[DISPATCH_D].size() + device_worker_variants[US_TUNNELER_REMOTE].size(); // 3: mux_fan_in
+
+                uint32_t mux_d_input_idx = 0;
+                for (const auto& dispatch_d_settings : device_worker_variants[DISPATCH_D]) {
+                    auto& dispatch_d_setting = std::get<1>(dispatch_d_settings);
+                    compile_args[4 + mux_d_input_idx] = packet_switch_4B_pack(dispatch_d_setting.worker_physical_core.x,
+                                                        dispatch_d_setting.worker_physical_core.y,
                                                         1,
                                                         DispatchRemoteNetworkType::NOC0); // 4,5,6,7: src x info
-
+                    mux_d_input_idx++;
+                }
                 if (!is_tunnel_end) {
                     TT_ASSERT(device_worker_variants[US_TUNNELER_REMOTE].size() == 1, "Unexpected number of ethernet tunnelers.");
-                    auto &us_tunneler_remote_settings = std::get<1>(device_worker_variants[US_TUNNELER_REMOTE][0]);
-                    compile_args[5] = packet_switch_4B_pack(us_tunneler_remote_settings.worker_physical_core.x,
-                                        us_tunneler_remote_settings.worker_physical_core.y,
+                }
+                for (const auto& us_tunneler_remote_settings : device_worker_variants[US_TUNNELER_REMOTE]) {
+                    auto &us_tunneler_remote_setting = std::get<1>(us_tunneler_remote_settings);
+                    compile_args[4 + mux_d_input_idx] = packet_switch_4B_pack(us_tunneler_remote_setting.worker_physical_core.x,
+                                        us_tunneler_remote_setting.worker_physical_core.y,
                                         3,
                                         DispatchRemoteNetworkType::NOC0); // 4,5,6,7: src x info
-
+                    mux_d_input_idx++;
                 }
 
                 TT_ASSERT(device_worker_variants[US_TUNNELER_LOCAL].size() == 1, "Unexpected number of ethernet tunnelers.");
@@ -1023,15 +1051,21 @@ void Device::update_workers_build_settings(std::vector<std::vector<std::tuple<tt
                 compile_args[16] = 0; // 16: timeout_cycles
                 compile_args[17] = 0x0; // 17: output_depacketize
                 compile_args[18] = 0x0; // 18: output_depacketize info
-
-                compile_args[19] = packet_switch_4B_pack(0x1,
-                            dispatch_d_settings.cb_log_page_size,
-                            dispatch_d_settings.producer_semaphore_id,  // upstream sem
-                            mux_d_settings.consumer_semaphore_id); // local sem
+                int mux_d_sem_idx = 0;
+                uint32_t mux_sem = mux_d_settings.consumer_semaphore_id;
+                for (const auto& dispatch_d_settings : device_worker_variants[DISPATCH_D]) {
+                    auto& dispatch_d_setting = std::get<1>(dispatch_d_settings);
+                    compile_args[19 + mux_d_sem_idx] = packet_switch_4B_pack(0x1,
+                            dispatch_d_setting.cb_log_page_size,
+                            dispatch_d_setting.producer_semaphore_id,  // upstream sem
+                            mux_sem++); // local sem
+                    mux_d_sem_idx++;
+                }
                 uint32_t src_id = 0xC1 + mux_d_settings.tunnel_stop - 1;
                 uint32_t dest_id = 0xD1 + mux_d_settings.tunnel_stop - 1;
-                compile_args[23] = packet_switch_4B_pack(src_id, src_id, src_id, src_id); // 23: packetized input src id
-                compile_args[24] = packet_switch_4B_pack(dest_id, dest_id, dest_id, dest_id); // 24: packetized input dest id
+
+                compile_args[23] = packet_switch_4B_pack(src_id, src_id + device_worker_variants[DISPATCH_D].size() - 1, src_id, src_id); // 23: packetized input src id
+                compile_args[24] = packet_switch_4B_pack(dest_id, dest_id + device_worker_variants[DISPATCH_D].size() - 1, dest_id, dest_id); // 24: packetized input dest id
                 break;
             }
         }
@@ -1064,12 +1098,10 @@ void Device::setup_tunnel_for_remote_devices() {
         tunnel_core_allocations.resize(tt::tt_metal::DispatchWorkerType::COUNT);
 
         for (uint32_t tunnel_stop = 1; tunnel_stop < tunnel.size(); tunnel_stop++) {
-            //uint32_t tunnel_stop = tt::Cluster::instance().get_device_tunnel_depth(device_id);
             chip_id_t device_id = tunnel[tunnel_stop];
             // a remote device.
             // tunnel_stop hops away.
-            uint8_t num_hw_cqs = 1;
-            uint32_t cq_id = 0;
+            uint8_t num_hw_cqs = this->num_hw_cqs_;
             uint16_t channel = tt::Cluster::instance().get_assigned_channel_for_device(device_id);
             CoreType dispatch_core_type = dispatch_core_manager::get(num_hw_cqs).get_dispatch_core_type(mmio_device_id);
 
@@ -1077,57 +1109,64 @@ void Device::setup_tunnel_for_remote_devices() {
             //allocations below are on mmio chip.
             settings.tunnel_stop = 0;
             uint32_t cq_size = this->sysmem_manager().get_cq_size();
-            settings.command_queue_start_addr = get_absolute_cq_offset(channel, cq_id, cq_size);
-            settings.issue_queue_start_addr = settings.command_queue_start_addr + CQ_START;
-            settings.issue_queue_size = this->sysmem_manager_->get_issue_queue_size(cq_id);
-            settings.completion_queue_start_addr = settings.issue_queue_start_addr + settings.issue_queue_size;
-            settings.completion_queue_size = this->sysmem_manager_->get_completion_queue_size(cq_id);
-            settings.dispatch_core_type = dispatch_core_type;
+            for (uint32_t cq_id = 0; cq_id < num_hw_cqs; cq_id++) {
+                settings.command_queue_start_addr = get_absolute_cq_offset(channel, cq_id, cq_size);
+                settings.issue_queue_start_addr = settings.command_queue_start_addr + CQ_START;
+                settings.issue_queue_size = this->sysmem_manager_->get_issue_queue_size(cq_id);
+                settings.completion_queue_start_addr = settings.issue_queue_start_addr + settings.issue_queue_size;
+                settings.completion_queue_size = this->sysmem_manager_->get_completion_queue_size(cq_id);
+                settings.dispatch_core_type = dispatch_core_type;
 
-            tt_cxy_pair prefetch_location = dispatch_core_manager::get(num_hw_cqs).prefetcher_core(device_id, channel, cq_id);
-            settings.worker_physical_core = tt_cxy_pair(prefetch_location.chip, get_physical_core_coordinate(prefetch_location, dispatch_core_type));
-            settings.kernel_file = "tt_metal/impl/dispatch/kernels/cq_prefetch.cpp";
-            //prefetch needs three semaphores.
-            settings.semaphores.push_back(0);
-            settings.semaphores.push_back(dispatch_constants::get(dispatch_core_type).prefetch_d_buffer_pages());
-            settings.semaphores.push_back(0);
-            settings.producer_semaphore_id = 1;
-            tunnel_core_allocations[PREFETCH].push_back(std::make_tuple(prefetch_location, settings));
+                tt_cxy_pair prefetch_location = dispatch_core_manager::get(num_hw_cqs).prefetcher_core(device_id, channel, cq_id);
+                settings.worker_physical_core = tt_cxy_pair(prefetch_location.chip, get_physical_core_coordinate(prefetch_location, dispatch_core_type));
+                settings.kernel_file = "tt_metal/impl/dispatch/kernels/cq_prefetch.cpp";
+                //prefetch needs three semaphores.
+                settings.semaphores.push_back(0);
+                settings.semaphores.push_back(dispatch_constants::get(dispatch_core_type).mux_buffer_pages(num_hw_cqs));
+                settings.semaphores.push_back(0);
+                settings.producer_semaphore_id = 1;
+                tunnel_core_allocations[PREFETCH].push_back(std::make_tuple(prefetch_location, settings));
+                settings.semaphores.clear();
+            }
 
-            settings.semaphores.clear();
-            tt_cxy_pair dispatch_location = dispatch_core_manager::get(num_hw_cqs).dispatcher_core(device_id, channel, cq_id);
-            settings.worker_physical_core = tt_cxy_pair(dispatch_location.chip, get_physical_core_coordinate(dispatch_location, dispatch_core_type));
-            settings.kernel_file = "tt_metal/impl/dispatch/kernels/cq_dispatch.cpp";
-            //dispatch needs one semaphore.
-            settings.semaphores.push_back(0);
-            settings.producer_semaphore_id = 0;
-            settings.consumer_semaphore_id = 0;
-            settings.cb_start_address = dispatch_constants::DISPATCH_BUFFER_BASE;
-            settings.cb_log_page_size = dispatch_constants::DISPATCH_BUFFER_LOG_PAGE_SIZE;
-            settings.cb_pages = dispatch_constants::get(dispatch_core_type).dispatch_buffer_pages();
-            settings.cb_size_bytes = (1 << settings.cb_log_page_size) * settings.cb_pages;
-            CoreCoord compute_grid_size = tt::get_compute_grid_size(device_id, num_hw_cqs);
-            settings.num_compute_cores = uint32_t(compute_grid_size.x * compute_grid_size.y);
-            tunnel_core_allocations[DISPATCH].push_back(std::make_tuple(dispatch_location, settings));
-            log_debug(LogMetal, "Device {} Channel {} : Dispatch: Issue Q Start Addr: {} - Completion Q Start Addr: {}",  device_id, channel, settings.issue_queue_start_addr, settings.completion_queue_start_addr);
-
+            for (uint32_t cq_id = 0; cq_id < num_hw_cqs; cq_id++) {
+                tt_cxy_pair dispatch_location = dispatch_core_manager::get(num_hw_cqs).dispatcher_core(device_id, channel, cq_id);
+                settings.worker_physical_core = tt_cxy_pair(dispatch_location.chip, get_physical_core_coordinate(dispatch_location, dispatch_core_type));
+                settings.kernel_file = "tt_metal/impl/dispatch/kernels/cq_dispatch.cpp";
+                //dispatch needs one semaphore.
+                settings.semaphores.push_back(0);
+                settings.producer_semaphore_id = 0;
+                settings.consumer_semaphore_id = 0;
+                settings.command_queue_start_addr = get_absolute_cq_offset(channel, cq_id, cq_size);
+                settings.issue_queue_start_addr = settings.command_queue_start_addr + CQ_START;
+                settings.issue_queue_size = this->sysmem_manager_->get_issue_queue_size(cq_id);
+                settings.completion_queue_start_addr = settings.issue_queue_start_addr + settings.issue_queue_size;
+                settings.cb_start_address = dispatch_constants::DISPATCH_BUFFER_BASE;
+                settings.cb_log_page_size = dispatch_constants::DISPATCH_BUFFER_LOG_PAGE_SIZE;
+                settings.cb_pages = dispatch_constants::get(dispatch_core_type).dispatch_buffer_pages();
+                settings.cb_size_bytes = (1 << settings.cb_log_page_size) * settings.cb_pages;
+                CoreCoord compute_grid_size = tt::get_compute_grid_size(device_id, num_hw_cqs);
+                settings.num_compute_cores = uint32_t(compute_grid_size.x * compute_grid_size.y);
+                tunnel_core_allocations[DISPATCH].push_back(std::make_tuple(dispatch_location, settings));
+                settings.semaphores.clear();
+                log_debug(LogMetal, "Device {} Channel {} : Dispatch: Issue Q Start Addr: {} - Completion Q Start Addr: {}",  device_id, channel, settings.issue_queue_start_addr, settings.completion_queue_start_addr);
+            }
+            uint32_t cq_id = 0;  // 1 mux, demux, local tunneler and remote tunneler per chip. Set cq_id to 0.
             if (tunnel_stop == 1) {
                 //need to allocate mux/demux on mmio chip only once.
                 //all tunnel stops, share the same mux/demux on mmio chip.
-                settings.semaphores.clear();
                 //mux/demux need a semaphore per remote device in the tunnel.
                 //Tunnel includes the mmio device as well, so tunnel.size() - 1 is the number of remote devices.
-                settings.semaphores.resize(tunnel.size()-1);
+                settings.semaphores = std::vector<uint32_t>((tunnel.size() - 1) * num_hw_cqs);
                 settings.producer_semaphore_id = 0;
                 settings.consumer_semaphore_id = 0;
                 tt_cxy_pair mux_location = dispatch_core_manager::get(num_hw_cqs).mux_core(device_id, channel, cq_id);
                 settings.worker_physical_core = tt_cxy_pair(mux_location.chip, get_physical_core_coordinate(mux_location, dispatch_core_type));
                 settings.kernel_file = "tt_metal/impl/dispatch/kernels/packet_mux.cpp";
                 settings.cb_start_address = dispatch_constants::DISPATCH_BUFFER_BASE;
-                settings.cb_size_bytes = dispatch_constants::get(dispatch_core_type).prefetch_d_buffer_size();
+                settings.cb_size_bytes = dispatch_constants::get(dispatch_core_type).mux_buffer_size(num_hw_cqs);
 
                 tunnel_core_allocations[MUX].push_back(std::make_tuple(mux_location, settings));
-
                 tt_cxy_pair demux_location = dispatch_core_manager::get(num_hw_cqs).demux_core(device_id, channel, cq_id);
                 settings.worker_physical_core = tt_cxy_pair(demux_location.chip, get_physical_core_coordinate(demux_location, dispatch_core_type));
                 settings.kernel_file = "tt_metal/impl/dispatch/kernels/packet_demux.cpp";
@@ -1148,7 +1187,6 @@ void Device::setup_tunnel_for_remote_devices() {
             settings.cb_start_address = 0x19000;
             settings.cb_size_bytes = 0x10000;
             tunnel_core_allocations[US_TUNNELER_REMOTE].push_back(std::make_tuple(us_location, settings));
-
             //all allocation below this are on a remote chip.
             settings.tunnel_stop = tunnel_stop;
 
@@ -1158,7 +1196,6 @@ void Device::setup_tunnel_for_remote_devices() {
             settings.eth_partner_physical_core = temp;
             settings.kernel_file = "tt_metal/impl/dispatch/kernels/eth_tunneler.cpp";
             tunnel_core_allocations[US_TUNNELER_LOCAL].push_back(std::make_tuple(local_location, settings));
-
             TT_ASSERT(us_location.chip == us_device,
                 "Upstream Tunneler is on device {} but it is expected to be on device {}", us_location.chip, us_device);
             TT_ASSERT(local_location.chip == device_id,
@@ -1170,14 +1207,13 @@ void Device::setup_tunnel_for_remote_devices() {
             tt_cxy_pair mux_d_location = dispatch_core_manager::get(num_hw_cqs).mux_d_core(device_id, channel, cq_id);
             settings.worker_physical_core = tt_cxy_pair(mux_d_location.chip, get_physical_core_coordinate(mux_d_location, dispatch_core_type));
             settings.kernel_file = "tt_metal/impl/dispatch/kernels/packet_mux.cpp";
-            settings.semaphores.push_back(0);
+            settings.semaphores = std::vector<uint32_t>((tunnel.size() - 1) * num_hw_cqs);
             settings.consumer_semaphore_id = 0;
             settings.cb_start_address = dispatch_constants::DISPATCH_BUFFER_BASE;
             settings.cb_log_page_size = dispatch_constants::DISPATCH_BUFFER_LOG_PAGE_SIZE;
-            settings.cb_pages = dispatch_constants::get(dispatch_core_type).dispatch_buffer_pages();
+            settings.cb_pages = dispatch_constants::get(dispatch_core_type).mux_buffer_pages(num_hw_cqs);
             settings.cb_size_bytes = (1 << settings.cb_log_page_size) * settings.cb_pages;
             tunnel_core_allocations[MUX_D].push_back(std::make_tuple(mux_d_location, settings));
-
             tt_cxy_pair demux_d_location = dispatch_core_manager::get(num_hw_cqs).demux_d_core(device_id, channel, cq_id);
             settings.worker_physical_core = tt_cxy_pair(demux_d_location.chip, get_physical_core_coordinate(demux_d_location, dispatch_core_type));
             settings.kernel_file = "tt_metal/impl/dispatch/kernels/packet_demux.cpp";
@@ -1185,37 +1221,42 @@ void Device::setup_tunnel_for_remote_devices() {
             settings.cb_start_address = L1_UNRESERVED_BASE;
             settings.cb_size_bytes = 0x10000;
             tunnel_core_allocations[DEMUX_D].push_back(std::make_tuple(demux_d_location, settings));
-
             settings.semaphores.clear();
             uint32_t dispatch_buffer_pages = dispatch_constants::get(dispatch_core_type).dispatch_buffer_pages();
-            settings.semaphores.push_back(0);// prefetch_d_sync_sem
-            settings.semaphores.push_back(0);// prefetch_d_upstream_cb_sem
-            settings.semaphores.push_back(dispatch_buffer_pages);// prefetch_d_downstream_cb_sem
-            settings.consumer_semaphore_id = 1;
-            settings.producer_semaphore_id = 2;
+            for (uint32_t cq_id = 0; cq_id < num_hw_cqs; cq_id++) {
+                settings.semaphores.push_back(0);// prefetch_d_sync_sem
+                settings.semaphores.push_back(0);// prefetch_d_upstream_cb_sem
+                settings.semaphores.push_back(dispatch_buffer_pages);// prefetch_d_downstream_cb_sem
+                settings.consumer_semaphore_id = 1;
+                settings.producer_semaphore_id = 2;
 
-            tt_cxy_pair prefetch_d_location = dispatch_core_manager::get(num_hw_cqs).prefetcher_d_core(device_id, channel, cq_id);
-            settings.worker_physical_core = tt_cxy_pair(prefetch_d_location.chip, get_physical_core_coordinate(prefetch_d_location, dispatch_core_type));
-            settings.kernel_file = "tt_metal/impl/dispatch/kernels/cq_prefetch.cpp";
-            settings.cb_start_address = dispatch_constants::DISPATCH_BUFFER_BASE;
-            settings.cb_size_bytes = dispatch_constants::get(dispatch_core_type).prefetch_d_buffer_size();
-            settings.cb_pages = dispatch_constants::get(dispatch_core_type).prefetch_d_buffer_pages();
-            settings.cb_log_page_size = dispatch_constants::PREFETCH_D_BUFFER_LOG_PAGE_SIZE;
-            tunnel_core_allocations[PREFETCH_D].push_back(std::make_tuple(prefetch_d_location, settings));
+                tt_cxy_pair prefetch_d_location = dispatch_core_manager::get(num_hw_cqs).prefetcher_d_core(device_id, channel, cq_id);
+                settings.worker_physical_core = tt_cxy_pair(prefetch_d_location.chip, get_physical_core_coordinate(prefetch_d_location, dispatch_core_type));
+                settings.kernel_file = "tt_metal/impl/dispatch/kernels/cq_prefetch.cpp";
+                settings.cb_start_address = dispatch_constants::DISPATCH_BUFFER_BASE;
+                settings.cb_size_bytes = dispatch_constants::get(dispatch_core_type).prefetch_d_buffer_size();
+                settings.cb_pages = dispatch_constants::get(dispatch_core_type).prefetch_d_buffer_pages();
+                settings.cb_log_page_size = dispatch_constants::PREFETCH_D_BUFFER_LOG_PAGE_SIZE;
+                tunnel_core_allocations[PREFETCH_D].push_back(std::make_tuple(prefetch_d_location, settings));
 
-            settings.semaphores.clear();
-            settings.semaphores.push_back(0);// dispatch_sem
-            settings.semaphores.push_back(dispatch_buffer_pages);// dispatch_downstream_cb_sem
-            settings.consumer_semaphore_id = 0;
-            settings.producer_semaphore_id = 1;
-            settings.cb_start_address = dispatch_constants::DISPATCH_BUFFER_BASE;
-            settings.cb_log_page_size = dispatch_constants::DISPATCH_BUFFER_LOG_PAGE_SIZE;
-            settings.cb_pages = dispatch_constants::get(dispatch_core_type).dispatch_buffer_pages();
-            settings.cb_size_bytes = (1 << settings.cb_log_page_size) * settings.cb_pages;
-            tt_cxy_pair dispatch_d_location = dispatch_core_manager::get(num_hw_cqs).dispatcher_d_core(device_id, channel, cq_id);
-            settings.worker_physical_core = tt_cxy_pair(dispatch_d_location.chip, get_physical_core_coordinate(dispatch_d_location, dispatch_core_type));
-            settings.kernel_file = "tt_metal/impl/dispatch/kernels/cq_dispatch.cpp";
-            tunnel_core_allocations[DISPATCH_D].push_back(std::make_tuple(dispatch_d_location, settings));
+                settings.semaphores.clear();
+            }
+
+            for (uint32_t cq_id = 0; cq_id < num_hw_cqs; cq_id++) {
+                settings.semaphores.push_back(0);// dispatch_sem
+                settings.semaphores.push_back(dispatch_constants::get(dispatch_core_type).mux_buffer_pages(num_hw_cqs));// dispatch_downstream_cb_sem
+                settings.consumer_semaphore_id = 0;
+                settings.producer_semaphore_id = 1;
+                settings.cb_start_address = dispatch_constants::DISPATCH_BUFFER_BASE;
+                settings.cb_log_page_size = dispatch_constants::DISPATCH_BUFFER_LOG_PAGE_SIZE;
+                settings.cb_pages = dispatch_constants::get(dispatch_core_type).dispatch_buffer_pages();
+                settings.cb_size_bytes = (1 << settings.cb_log_page_size) * settings.cb_pages;
+                tt_cxy_pair dispatch_d_location = dispatch_core_manager::get(num_hw_cqs).dispatcher_d_core(device_id, channel, cq_id);
+                settings.worker_physical_core = tt_cxy_pair(dispatch_d_location.chip, get_physical_core_coordinate(dispatch_d_location, dispatch_core_type));
+                settings.kernel_file = "tt_metal/impl/dispatch/kernels/cq_dispatch.cpp";
+                tunnel_core_allocations[DISPATCH_D].push_back(std::make_tuple(dispatch_d_location, settings));
+                settings.semaphores.clear();
+            }
         }
         tunnel_dispatch_core_allocations.insert(std::make_pair(tunnel_id, tunnel_core_allocations));
         tunnel_id++;
@@ -1417,11 +1458,10 @@ void Device::compile_command_queue_programs() {
         this->command_queue_programs.push_back(std::move(command_queue_program_ptr));
         this->setup_tunnel_for_remote_devices();
     } else {
-        uint32_t cq_id = 0;
         chip_id_t device_id = this->id();
         chip_id_t mmio_device_id = tt::Cluster::instance().get_associated_mmio_device(device_id);
+        uint8_t num_hw_cqs = this->num_hw_cqs();
         Device *mmio_device = tt::DevicePool::instance().get_active_device(mmio_device_id);
-        NOC noc_index = this->hw_command_queues_[cq_id]->noc_index;
 
         auto &tunnel_device_dispatch_workers = mmio_device->tunnel_device_dispatch_workers_;
         auto &tunnels_from_mmio = mmio_device->tunnels_from_mmio_;
@@ -1455,8 +1495,9 @@ void Device::compile_command_queue_programs() {
 
         if (first_tunnel_stop) {
             /////////////////Following section is for mmio device serving Remote Device
+            uint32_t cq_id = 0;
             for (auto [prefetch_core, prefetch_settings] : mmio_device_worker_variants[PREFETCH]) {
-                //auto [prefetch_core, prefetch_settings] = mmio_device_worker_variants[PREFETCH][0];
+                NOC noc_index = this->hw_command_queues_[cq_id]->noc_index;
                 for (auto sem : prefetch_settings.semaphores) {
                     //size of semaphores vector is number of needed semaphores on the core.
                     //Value of each vector entry is the initialization value for the semaphore.
@@ -1472,8 +1513,9 @@ void Device::compile_command_queue_programs() {
                     prefetch_settings.upstream_cores[0],
                     prefetch_settings.downstream_cores[0],
                     std::map<string, string> {},
-                    noc_index
+                    this->hw_command_queues_[cq_id]->noc_index
                 );
+                cq_id = (cq_id + 1) % num_hw_cqs;
             }
 
             auto [mux_core, mux_settings] = mmio_device_worker_variants[MUX][0];
@@ -1492,7 +1534,7 @@ void Device::compile_command_queue_programs() {
                 CoreCoord{0, 0},
                 CoreCoord{0, 0},
                 std::map<string, string> {{"SKIP_NOC_LOGGING", "1"}},
-                noc_index
+                this->hw_command_queues_[0]->noc_index // Only one Mux - use NOC for CQ 0
             );
 
             auto [tunneler_core, tunneler_settings] = mmio_device_worker_variants[US_TUNNELER_REMOTE][0];
@@ -1506,7 +1548,7 @@ void Device::compile_command_queue_programs() {
                 CoreCoord{0, 0},
                 CoreCoord{0, 0},
                 std::map<string, string> {{"SKIP_NOC_LOGGING", "1"}},
-                noc_index,
+                this->hw_command_queues_[0]->noc_index, // Only one Remote Tunneler - use NOC for CQ 0
                 true
             );
 
@@ -1526,11 +1568,10 @@ void Device::compile_command_queue_programs() {
                 CoreCoord{0, 0},
                 CoreCoord{0, 0},
                 std::map<string, string> {{"SKIP_NOC_LOGGING", "1"}},
-                noc_index
+                this->hw_command_queues_[0]->noc_index // Only one Demux - use NOC for CQ 0
             );
-
+            cq_id = 0;
             for (auto [dispatch_core, dispatch_settings] : mmio_device_worker_variants[DISPATCH]) {
-                //auto [dispatch_core, dispatch_settings] = mmio_device_worker_variants[DISPATCH][0];
                 for (auto sem : dispatch_settings.semaphores) {
                     //size of semaphores vector is number of needed semaphores on the core.
                     //Value of each vector entry is the initialization value for the semaphore.
@@ -1546,8 +1587,9 @@ void Device::compile_command_queue_programs() {
                     dispatch_settings.upstream_cores[0],
                     CoreCoord{0xffffffff, 0xffffffff},
                     std::map<string, string> {},
-                    noc_index
+                    this->hw_command_queues_[cq_id]->noc_index
                 );
+                cq_id = (cq_id + 1) % num_hw_cqs;
             }
         }
         /////////////////Following section is for Remote Device
@@ -1564,7 +1606,7 @@ void Device::compile_command_queue_programs() {
             CoreCoord{0, 0},
             CoreCoord{0, 0},
             std::map<string, string> {{"SKIP_NOC_LOGGING", "1"}},
-            noc_index,
+            this->hw_command_queues_[0]->noc_index, // Only one Local Tunneler - use NOC for CQ 0
             true
         );
 
@@ -1581,7 +1623,7 @@ void Device::compile_command_queue_programs() {
                 CoreCoord{0, 0},
                 CoreCoord{0, 0},
                 std::map<string, string> {{"SKIP_NOC_LOGGING", "1"}},
-                noc_index,
+                this->hw_command_queues_[0]->noc_index, // Only one Remote Tunneler - use NOC for CQ 0
                 true
             );
         }
@@ -1602,46 +1644,50 @@ void Device::compile_command_queue_programs() {
             CoreCoord{0, 0},
             CoreCoord{0, 0},
             std::map<string, string> {{"SKIP_NOC_LOGGING", "1"}},
-            noc_index
+            this->hw_command_queues_[0]->noc_index // Only one Demux - use NOC for CQ 0
         );
-
-        auto [prefetch_d_core, prefetch_d_settings] = device_worker_variants[PREFETCH_D][0];
-        for (auto sem : prefetch_d_settings.semaphores) {
-            //size of semaphores vector is number of needed semaphores on the core.
-            //Value of each vector entry is the initialization value for the semaphore.
-            tt::tt_metal::CreateSemaphore(*command_queue_program_ptr, prefetch_d_core, sem, prefetch_d_settings.dispatch_core_type);
+        uint32_t cq_id = 0;
+        for (auto [prefetch_d_core, prefetch_d_settings] : device_worker_variants[PREFETCH_D]) {
+            for (auto sem : prefetch_d_settings.semaphores) {
+                //size of semaphores vector is number of needed semaphores on the core.
+                //Value of each vector entry is the initialization value for the semaphore.
+                tt::tt_metal::CreateSemaphore(*command_queue_program_ptr, prefetch_d_core, sem, prefetch_d_settings.dispatch_core_type);
+            }
+            configure_kernel_variant(
+                *command_queue_program_ptr,
+                prefetch_d_settings.kernel_file,
+                prefetch_d_settings.compile_args,
+                prefetch_d_core,
+                prefetch_d_settings.worker_physical_core,
+                prefetch_d_settings.dispatch_core_type,
+                prefetch_d_settings.upstream_cores[0],
+                prefetch_d_settings.downstream_cores[0],
+                std::map<string, string> {},
+                this->hw_command_queues_[cq_id]->noc_index
+            );
+            cq_id = (cq_id + 1) % num_hw_cqs;
         }
-        configure_kernel_variant(
-            *command_queue_program_ptr,
-            prefetch_d_settings.kernel_file,
-            prefetch_d_settings.compile_args,
-            prefetch_d_core,
-            prefetch_d_settings.worker_physical_core,
-            prefetch_d_settings.dispatch_core_type,
-            prefetch_d_settings.upstream_cores[0],
-            prefetch_d_settings.downstream_cores[0],
-            std::map<string, string> {},
-            noc_index
-        );
-
-        auto [dispatch_d_core, dispatch_d_settings] = device_worker_variants[DISPATCH_D][0];
-        for (auto sem : dispatch_d_settings.semaphores) {
-            //size of semaphores vector is number of needed semaphores on the core.
-            //Value of each vector entry is the initialization value for the semaphore.
-            tt::tt_metal::CreateSemaphore(*command_queue_program_ptr, dispatch_d_core, sem, dispatch_d_settings.dispatch_core_type);
+        cq_id = 0;
+        for (auto [dispatch_d_core, dispatch_d_settings] : device_worker_variants[DISPATCH_D]) {
+            for (auto sem : dispatch_d_settings.semaphores) {
+                //size of semaphores vector is number of needed semaphores on the core.
+                //Value of each vector entry is the initialization value for the semaphore.
+                tt::tt_metal::CreateSemaphore(*command_queue_program_ptr, dispatch_d_core, sem, dispatch_d_settings.dispatch_core_type);
+            }
+            configure_kernel_variant(
+                *command_queue_program_ptr,
+                dispatch_d_settings.kernel_file,
+                dispatch_d_settings.compile_args,
+                dispatch_d_core,
+                dispatch_d_settings.worker_physical_core,
+                dispatch_d_settings.dispatch_core_type,
+                dispatch_d_settings.upstream_cores[0],
+                dispatch_d_settings.downstream_cores[0],
+                std::map<string, string> {},
+                this->hw_command_queues_[cq_id]->noc_index
+            );
+            cq_id = (cq_id + 1) % num_hw_cqs;
         }
-        configure_kernel_variant(
-            *command_queue_program_ptr,
-            dispatch_d_settings.kernel_file,
-            dispatch_d_settings.compile_args,
-            dispatch_d_core,
-            dispatch_d_settings.worker_physical_core,
-            dispatch_d_settings.dispatch_core_type,
-            dispatch_d_settings.upstream_cores[0],
-            dispatch_d_settings.downstream_cores[0],
-            std::map<string, string> {},
-            noc_index
-        );
 
 
         auto [mux_d_core, mux_d_settings] = device_worker_variants[MUX_D][0];
@@ -1660,7 +1706,7 @@ void Device::compile_command_queue_programs() {
             CoreCoord{0, 0},
             CoreCoord{0, 0},
             std::map<string, string> {{"SKIP_NOC_LOGGING", "1"}},
-            noc_index
+            this->hw_command_queues_[0]->noc_index // Only one Mux - use NOC for CQ 0
         );
 
         detail::CompileProgram(this, *command_queue_program_ptr);
@@ -1692,8 +1738,9 @@ void Device::configure_command_queue_programs() {
     }
 
     Program& command_queue_program = *this->command_queue_programs[0];
+    uint8_t num_hw_cqs = this->num_hw_cqs();
 
-    for (uint8_t cq_id = 0; cq_id < this->num_hw_cqs(); cq_id++) {
+    for (uint8_t cq_id = 0; cq_id < num_hw_cqs; cq_id++) {
         // Reset the host manager's pointer for this command queue
         this->sysmem_manager_->reset(cq_id);
 
@@ -1703,7 +1750,6 @@ void Device::configure_command_queue_programs() {
         tt::Cluster::instance().write_sysmem(pointers.data(), pointers.size() * sizeof(uint32_t), get_absolute_cq_offset(channel, cq_id, cq_size), mmio_device_id, get_umd_channel(channel));
     }
 
-    uint8_t num_hw_cqs = device_id == mmio_device_id ? this->num_hw_cqs() : 1;
     for (uint8_t cq_id = 0; cq_id < num_hw_cqs; cq_id++) {
         tt_cxy_pair prefetch_location = dispatch_core_manager::get(num_hw_cqs).prefetcher_core(device_id, channel, cq_id);
         tt_cxy_pair completion_q_writer_location = dispatch_core_manager::get(num_hw_cqs).completion_queue_writer_core(device_id, channel, cq_id);
@@ -1720,7 +1766,9 @@ void Device::configure_command_queue_programs() {
         };
         detail::WriteToDeviceL1(mmio_device, prefetch_location, CQ_PREFETCH_Q_RD_PTR, prefetch_q_rd_ptr_addr_data, dispatch_core_type);
         detail::WriteToDeviceL1(mmio_device, prefetch_location, dispatch_constants::PREFETCH_Q_BASE, prefetch_q, dispatch_core_type);
-
+        // Used for prefetch_h, since a wait_for_event on remote chips requires prefetch_h to spin until dispatch_d notfiies completion
+        detail::WriteToDeviceL1(mmio_device, prefetch_location, CQ0_COMPLETION_LAST_EVENT, zero, dispatch_core_type);
+        detail::WriteToDeviceL1(mmio_device, prefetch_location, CQ1_COMPLETION_LAST_EVENT, zero, dispatch_core_type);
         // Initialize completion queue write pointer and read pointer copy
         uint32_t issue_queue_size = this->sysmem_manager_->get_issue_queue_size(cq_id);
         uint32_t completion_queue_start_addr = CQ_START + issue_queue_size + get_absolute_cq_offset(channel, cq_id, cq_size);
@@ -1749,6 +1797,18 @@ void Device::configure_command_queue_programs() {
             Program& mmio_command_queue_program = *this->command_queue_programs[1];
             detail::ConfigureDeviceWithProgram(mmio_device, mmio_command_queue_program, true);
             tt::Cluster::instance().l1_barrier(mmio_device_id);
+        }
+    }
+}
+
+void Device::update_dispatch_cores_for_multi_cq_eth_dispatch() {
+    // When running Multiple CQs using Ethernet Dispatch, we may need more dispatch cores than those allocated in the
+    // core descriptor (ex: 2 CQs on N300 need 10 dispatch cores and the core descriptor only allocates 6).
+    // Infer the remaining dispatch cores from the idle eth core list (this is device dependent).
+    if (dispatch_core_manager::get(this->num_hw_cqs()).get_dispatch_core_type(this->id()) == CoreType::ETH) {
+        auto& dispatch_core_manager = dispatch_core_manager::get(this->num_hw_cqs());
+        for (const auto& idle_eth_core : this->get_inactive_ethernet_cores()) {
+            dispatch_core_manager.add_dispatch_core_to_device(this->id(), idle_eth_core);
         }
     }
 }

--- a/tt_metal/impl/device/device.hpp
+++ b/tt_metal/impl/device/device.hpp
@@ -305,6 +305,7 @@ class Device {
                 or get_worker_mode() == WorkExecutorMode::SYNCHRONOUS;
     }
    uint32_t trace_buffers_size = 0;
+   void update_dispatch_cores_for_multi_cq_eth_dispatch();
    private:
     std::unordered_map<uint32_t, std::shared_ptr<TraceBuffer>> trace_buffer_pool_;
 };

--- a/tt_metal/impl/device/device_pool.cpp
+++ b/tt_metal/impl/device/device_pool.cpp
@@ -146,6 +146,7 @@ void DevicePool::activate_device(chip_id_t id) {
         int core_assigned_to_device = this->device_to_core_map.at(id);
         auto dev =
             new Device(id, this->num_hw_cqs, this->l1_small_size, this->trace_region_size, this->l1_bank_remap, false, core_assigned_to_device);
+            dev->update_dispatch_cores_for_multi_cq_eth_dispatch();
         if (!this->firmware_built_keys.contains(dev->build_key())) {
             dev->build_firmware();
             this->firmware_built_keys.insert(dev->build_key());
@@ -190,10 +191,6 @@ void DevicePool::add_devices_to_pool(std::vector<chip_id_t> device_ids) {
             const auto& mmio_device_id = tt::Cluster::instance().get_associated_mmio_device(device_id);
             for (const auto& mmio_controlled_device_id :
                  tt::Cluster::instance().get_devices_controlled_by_mmio_device(mmio_device_id)) {
-                if (num_hw_cqs > 1 and mmio_device_id != mmio_controlled_device_id) {
-                    // Don't support multi cqs on R chip yet
-                    continue;
-                }
                 if (not this->is_device_active(mmio_controlled_device_id)) {
                     this->activate_device(mmio_controlled_device_id);
                 }

--- a/tt_metal/impl/device/multi_device.cpp
+++ b/tt_metal/impl/device/multi_device.cpp
@@ -13,7 +13,7 @@ namespace ttnn {
 
 namespace multi_device {
 
-DeviceMesh::DeviceMesh(const DeviceGrid& device_grid, const DeviceIds &device_ids, size_t l1_small_size, size_t trace_region_size)
+DeviceMesh::DeviceMesh(const DeviceGrid& device_grid, const DeviceIds &device_ids, size_t l1_small_size, size_t trace_region_size, size_t num_command_queues)
     : device_grid(device_grid)
 {
     auto [num_rows, num_cols] = device_grid;
@@ -48,12 +48,12 @@ DeviceMesh::DeviceMesh(const DeviceGrid& device_grid, const DeviceIds &device_id
                 }
             }
         }
-        managed_devices = tt::tt_metal::detail::CreateDevices(galaxy_device_ids, 1, l1_small_size, trace_region_size);
+        managed_devices = tt::tt_metal::detail::CreateDevices(galaxy_device_ids, num_command_queues, l1_small_size, trace_region_size);
         for (int i = 0; i < num_requested_devices; i++) {
             mesh_devices.emplace_back(device_ids[i], managed_devices.at(galaxy_device_ids[i]));
         }
     } else {
-        managed_devices = tt::tt_metal::detail::CreateDevices(device_ids, 1, l1_small_size, trace_region_size);
+        managed_devices = tt::tt_metal::detail::CreateDevices(device_ids, num_command_queues, l1_small_size, trace_region_size);
         for (int i = 0; i < num_requested_devices; i++) {
             mesh_devices.emplace_back(device_ids[i], managed_devices.at(device_ids[i]));
         }

--- a/tt_metal/impl/device/multi_device.hpp
+++ b/tt_metal/impl/device/multi_device.hpp
@@ -24,7 +24,7 @@ public:
     std::map<chip_id_t, Device *> managed_devices;
     std::vector<std::pair<int, Device *>> mesh_devices;
 
-    DeviceMesh(const DeviceGrid &device_grid, const DeviceIds &device_ids, size_t l1_small_size, size_t trace_region_size);
+    DeviceMesh(const DeviceGrid &device_grid, const DeviceIds &device_ids, size_t l1_small_size, size_t trace_region_size, size_t num_command_queues);
     ~DeviceMesh();
 
     DeviceMesh(const DeviceMesh &) = delete;

--- a/tt_metal/impl/dispatch/command_queue_interface.hpp
+++ b/tt_metal/impl/dispatch/command_queue_interface.hpp
@@ -77,6 +77,10 @@ struct dispatch_constants {
 
     uint32_t prefetch_d_buffer_pages() const { return prefetch_d_buffer_pages_; }
 
+    uint32_t mux_buffer_size(uint8_t num_hw_cqs = 1) const { return prefetch_d_buffer_size_ / num_hw_cqs; }
+
+    uint32_t mux_buffer_pages(uint8_t num_hw_cqs = 1) const { return prefetch_d_buffer_pages_ / num_hw_cqs; }
+
    private:
     dispatch_constants(const CoreType &core_type) {
         TT_ASSERT(core_type == CoreType::WORKER or core_type == CoreType::ETH);
@@ -392,7 +396,7 @@ class SystemMemoryManager {
 
     uint32_t get_next_event(const uint8_t cq_id) {
         cq_to_event_locks[cq_id].lock();
-        uint32_t next_event = this->cq_to_event[cq_id]++;
+        uint32_t next_event = ++this->cq_to_event[cq_id]; // Event ids start at 1
         cq_to_event_locks[cq_id].unlock();
         return next_event;
     }

--- a/tt_metal/impl/dispatch/cq_commands.hpp
+++ b/tt_metal/impl/dispatch/cq_commands.hpp
@@ -27,7 +27,8 @@ enum CQPrefetchCmdId : uint8_t {
     CQ_PREFETCH_CMD_EXEC_BUF_END = 7,         // finish executing commands from a buffer (return), payload like relay_inline
     CQ_PREFETCH_CMD_STALL = 8,                // drain pipe through dispatcher
     CQ_PREFETCH_CMD_DEBUG = 9,                // log waypoint data to watcher, checksum
-    CQ_PREFETCH_CMD_TERMINATE = 10,           // quit
+    CQ_PREFETCH_CMD_WAIT_FOR_EVENT = 10,      // wait_for_event: stall until dispatcher signals event completion
+    CQ_PREFETCH_CMD_TERMINATE = 11,           // quit
 };
 
 // Dispatcher CMD ID enums
@@ -45,7 +46,8 @@ enum CQDispatchCmdId : uint8_t {
     CQ_DISPATCH_CMD_DEBUG = 10,             // log waypoint data to watcher, checksum
     CQ_DISPATCH_CMD_DELAY = 11,             // insert delay (for testing)
     CQ_DISPATCH_CMD_EXEC_BUF_END = 12,      // dispatch_d notify prefetch_h that exec_buf has completed
-    CQ_DISPATCH_CMD_TERMINATE = 13,         // quit
+    CQ_DISPATCH_CMD_REMOTE_WRITE = 13,      // dispatch_d issues write to address on L-Chip through dispatch_h
+    CQ_DISPATCH_CMD_TERMINATE = 14,         // quit
 };
 
 //////////////////////////////////////////////////////////////////////////////
@@ -110,6 +112,13 @@ struct CQPrefetchRelayInlineCmd {
     uint32_t stride;          // explicit stride saves a few insns on device
 } __attribute__((packed));
 
+struct CQPrefetchWaitForEventCmd {
+    uint8_t pad1;
+    uint16_t pad2;
+    uint32_t sync_event;
+    uint32_t sync_event_addr;
+} __attribute__((packed));
+
 struct CQPrefetchExecBufCmd {
     uint8_t pad1;
     uint16_t pad2;
@@ -126,6 +135,7 @@ struct CQPrefetchCmd {
         CQPrefetchRelayPagedPackedCmd relay_paged_packed;
         CQPrefetchRelayInlineCmd relay_inline;
         CQPrefetchExecBufCmd exec_buf;
+        CQPrefetchWaitForEventCmd event_wait;
         CQGenericDebugCmd debug;
     } __attribute__((packed));
 };
@@ -164,6 +174,7 @@ struct CQDispatchWritePagedCmd {
 constexpr uint32_t CQ_DISPATCH_CMD_PACKED_WRITE_FLAG_NONE      = 0x00;
 constexpr uint32_t CQ_DISPATCH_CMD_PACKED_WRITE_FLAG_MCAST     = 0x01;
 constexpr uint32_t CQ_DISPATCH_CMD_PACKED_WRITE_FLAG_NO_STRIDE = 0x02;
+constexpr uint32_t CQ_DISPATCH_CMD_PACKED_WRITE_RELAY = 0x03;
 
 struct CQDispatchWritePackedCmd {
     uint8_t flags;            // see above
@@ -225,6 +236,17 @@ struct CQDispatchDelayCmd {
     uint32_t delay;
 } __attribute__((packed));
 
+// When dispatch_d gets this command, it will be
+// forwarded to dispatch_h, which will write data
+// to local noc_xy_addr at offset addr. The data
+// is currently a uint32_t field, which is inlined in
+// the command.
+struct CQDispatchRemoteWriteCmd {
+    uint32_t data;
+    uint32_t noc_xy_addr;
+    uint32_t addr;
+} __attribute__((packed));
+
 struct CQDispatchCmd {
     CQDispatchBaseCmd base;
 
@@ -234,6 +256,7 @@ struct CQDispatchCmd {
         CQDispatchWritePagedCmd write_paged;
         CQDispatchWritePackedCmd write_packed;
         CQDispatchWritePackedLargeCmd write_packed_large;
+        CQDispatchRemoteWriteCmd write_from_remote;
         CQDispatchWaitCmd wait;
         CQGenericDebugCmd debug;
         CQDispatchDelayCmd delay;

--- a/tt_metal/impl/dispatch/device_command.hpp
+++ b/tt_metal/impl/dispatch/device_command.hpp
@@ -129,6 +129,48 @@ class DeviceCommand {
         }
     }
 
+    void add_prefetch_wait_for_event(uint32_t event_id, uint32_t event_addr) {
+        uint32_t increment_sizeB = align(sizeof(CQPrefetchCmd), PCIE_ALIGNMENT);
+        auto initialize_wait_cmd = [&](CQPrefetchCmd *wait_cmd) {
+            *wait_cmd = {};
+            wait_cmd->base.cmd_id = CQ_PREFETCH_CMD_WAIT_FOR_EVENT;
+            wait_cmd->event_wait.sync_event = event_id;
+            wait_cmd->event_wait.sync_event_addr = event_addr;
+        };
+        CQPrefetchCmd *wait_cmd_dst = this->reserve_space<CQPrefetchCmd *>(increment_sizeB);
+        if constexpr (hugepage_write) {
+            alignas(MEMCPY_ALIGNMENT) CQPrefetchCmd wait_cmd;
+            initialize_wait_cmd(&wait_cmd);
+            this->memcpy(wait_cmd_dst, &wait_cmd, sizeof(CQPrefetchCmd));
+        } else {
+            initialize_wait_cmd(wait_cmd_dst);
+        }
+    }
+
+    void add_dispatch_write_remote(uint32_t data, uint32_t noc_xy_addr, uint32_t addr) {
+        auto initialize_cross_prefetch_write = [&](CQPrefetchCmd *relay_write, CQDispatchCmd *write_cmd) {
+            relay_write->base.cmd_id = CQ_PREFETCH_CMD_RELAY_INLINE;
+            relay_write->relay_inline.length = sizeof(CQDispatchCmd);
+            relay_write->relay_inline.stride = CQ_PREFETCH_CMD_BARE_MIN_SIZE;
+            write_cmd->base.cmd_id = CQ_DISPATCH_CMD_REMOTE_WRITE;
+            write_cmd->write_from_remote.data = data;
+            write_cmd->write_from_remote.noc_xy_addr = noc_xy_addr;
+            write_cmd->write_from_remote.addr = addr;
+        };
+        CQPrefetchCmd *relay_write_dst = this->reserve_space<CQPrefetchCmd *>(sizeof(CQPrefetchCmd));
+        CQDispatchCmd *write_cmd_dst = this->reserve_space<CQDispatchCmd *>(sizeof(CQDispatchCmd));
+
+        if constexpr (hugepage_write) {
+            alignas(MEMCPY_ALIGNMENT) CQPrefetchCmd relay_write;
+            alignas(MEMCPY_ALIGNMENT) CQDispatchCmd write_cmd;
+            initialize_cross_prefetch_write(&relay_write, &write_cmd);
+            this->memcpy(relay_write_dst, &relay_write, sizeof(CQPrefetchCmd));
+            this->memcpy(write_cmd_dst, &write_cmd, sizeof(CQDispatchCmd));
+        } else {
+            initialize_cross_prefetch_write(write_cmd_dst);
+        }
+    }
+
     void add_prefetch_relay_linear(uint32_t noc_xy_addr, uint32_t lengthB, uint32_t addr) {
         uint32_t increment_sizeB = align(sizeof(CQPrefetchCmd), PCIE_ALIGNMENT);
         auto initialize_relay_linear_cmd = [&](CQPrefetchCmd *relay_linear_cmd) {

--- a/tt_metal/impl/dispatch/dispatch_core_manager.hpp
+++ b/tt_metal/impl/dispatch/dispatch_core_manager.hpp
@@ -342,6 +342,13 @@ class dispatch_core_manager {
         return this->dispatch_core_type_by_device[device_id];
     }
 
+    void add_dispatch_core_to_device(chip_id_t device_id, const CoreCoord& core) {
+        auto& dispatch_cores = available_dispatch_cores_by_device.at(device_id);
+        if (std::find(dispatch_cores.begin(), dispatch_cores.end(), core) == dispatch_cores.end()) {
+            dispatch_cores.push_back(core);
+        }
+    }
+
    private:
     /// @brief dispatch_core_manager constructor initializes a list of cores per device that are designated for any dispatch functionality
     ///         This list contains dispatch cores that have not been assigned to a particular dispatch function

--- a/tt_metal/impl/dispatch/kernels/cq_prefetch.cpp
+++ b/tt_metal/impl/dispatch/kernels/cq_prefetch.cpp
@@ -261,7 +261,7 @@ void fetch_q_get_cmds(uint32_t& fence, uint32_t& cmd_ptr, uint32_t& pcie_read_pt
                 if (stall_state == STALL_NEXT) {
                     // If the prefetcher state reached here, it is issuing a read to the same "slot", since for exec_buf commands
                     // we will insert a read barrier. Hence, the exec_buf command will be concatenated to a previous command, and
-                    // should not be offset by pramble size.
+                    // should not be offset by preamble size.
                     pending_read_size = read_from_pcie<0>
                         (prefetch_q_rd_ptr, fence, pcie_read_ptr, cmd_ptr, fetch_size);
                     if (pending_read_size != 0) {
@@ -519,6 +519,14 @@ uint32_t process_relay_paged_cmd_large(uint32_t cmd_ptr,
     downstream_data_ptr = round_up_pow2(downstream_data_ptr, downstream_cb_page_size);
 
     return CQ_PREFETCH_CMD_BARE_MIN_SIZE;
+}
+
+inline uint32_t process_prefetch_h_wait_cmd(uint32_t cmd_ptr) {
+    volatile CQPrefetchCmd tt_l1_ptr *cmd = (volatile CQPrefetchCmd tt_l1_ptr *)(cmd_ptr + sizeof(CQPrefetchHToPrefetchDHeader));
+    volatile tt_l1_ptr uint32_t* event_addr =
+                reinterpret_cast<volatile tt_l1_ptr uint32_t*>(cmd->event_wait.sync_event_addr);
+    while (*event_addr < cmd->event_wait.sync_event);
+    return CQ_PREFETCH_CMD_BARE_MIN_SIZE + sizeof(CQPrefetchHToPrefetchDHeader);
 }
 
 // This fn prefetches data from DRAM memory and writes data to the dispatch core.
@@ -1264,7 +1272,6 @@ void kernel_main_h() {
 
     uint32_t cmd_ptr = cmddat_q_base;
     uint32_t fence = cmddat_q_base;
-
     bool done = false;
     uint32_t heartbeat = 0;
     while (!done) {
@@ -1274,9 +1281,17 @@ void kernel_main_h() {
 
         volatile CQPrefetchCmd tt_l1_ptr *cmd = (volatile CQPrefetchCmd tt_l1_ptr *)(cmd_ptr + sizeof(CQPrefetchHToPrefetchDHeader));
         uint32_t cmd_id = cmd->base.cmd_id;
-        // Infer that an exec_buf command is to be executed based on the stall state.
-        bool is_exec_buf = (stall_state == STALLED);
-        cmd_ptr = process_relay_inline_all(cmd_ptr, fence, is_exec_buf);
+        if (cmd_id == CQ_PREFETCH_CMD_WAIT_FOR_EVENT) {
+            // prefetch_h will stop execution until it recieves an event update from the
+            // dispatch_d core assigned to the other CQ
+            uint32_t stride = process_prefetch_h_wait_cmd(cmd_ptr);
+            cmd_ptr += stride;
+        }
+        else {
+            // Infer that an exec_buf command is to be executed based on the stall state.
+            bool is_exec_buf = (stall_state == STALLED);
+            cmd_ptr = process_relay_inline_all(cmd_ptr, fence, is_exec_buf);
+        }
 
         // Note: one fetch_q entry can contain multiple commands
         // The code below assumes these commands arrive individually, packing them would require parsing all cmds
@@ -1348,7 +1363,6 @@ void kernel_main_d() {
 }
 
 void kernel_main_hd() {
-
     uint32_t cmd_ptr = cmddat_q_base;
     uint32_t fence = cmddat_q_base;
     bool done = false;

--- a/tt_metal/tt_metal.cpp
+++ b/tt_metal/tt_metal.cpp
@@ -168,13 +168,17 @@ std::map<chip_id_t, Device *> CreateDevices(
     const size_t trace_region_size,
     const std::vector<uint32_t> &l1_bank_remap) {
     ZoneScoped;
+    bool is_galaxy = tt::Cluster::instance().is_galaxy_cluster();
+    if (is_galaxy) {
+        TT_FATAL(num_hw_cqs < 2, "Multiple Command Queues are not Currently Supported on Galaxy Systems");
+    }
     tt::DevicePool::initialize(device_ids, num_hw_cqs, l1_small_size, trace_region_size);
     std::vector<Device *> devices = tt::DevicePool::instance().get_all_active_devices();
     std::map<chip_id_t, Device *> ret_devices;
     //Only include the mmio device in the active devices set returned to the caller if we are not running
     //on a Galaxy cluster.
     //On Galaxy, gateway (mmio devices) cannot run compute workloads.
-    bool is_galaxy = tt::Cluster::instance().is_galaxy_cluster();
+
     for (Device * dev: devices) {
         if (is_galaxy and dev->is_mmio_capable()) {
             continue;

--- a/ttnn/cpp/pybind11/multi_device.hpp
+++ b/ttnn/cpp/pybind11/multi_device.hpp
@@ -19,12 +19,13 @@ namespace multi_device {
 void py_module(py::module& module) {
     py::class_<DeviceMesh>(module, "DeviceMesh")
         .def(
-            py::init<DeviceGrid, std::vector<int>, size_t, size_t>(),
+            py::init<DeviceGrid, std::vector<int>, size_t, size_t, size_t>(),
             py::kw_only(),
             py::arg("device_grid"),
             py::arg("device_ids"),
             py::arg("l1_small_size"),
-            py::arg("trace_region_size"))
+            py::arg("trace_region_size"),
+            py::arg("num_command_queues"))
         .def("get_device", &ttnn::multi_device::DeviceMesh::get_device, py::return_value_policy::reference)
         .def("get_num_devices", &ttnn::multi_device::DeviceMesh::num_devices)
         .def("get_device_ids", &ttnn::multi_device::DeviceMesh::get_device_ids)
@@ -42,7 +43,8 @@ void py_module(py::module& module) {
         py::arg("device_grid"),
         py::arg("device_ids"),
         py::arg("l1_small_size"),
-        py::arg("trace_region_size"));
+        py::arg("trace_region_size"),
+        py::arg("num_command_queues"));
 
     module.def("close_device_mesh", &close_device_mesh, py::arg("device_mesh"), py::kw_only());
     module.def(

--- a/ttnn/cpp/ttnn/multi_device.hpp
+++ b/ttnn/cpp/ttnn/multi_device.hpp
@@ -20,8 +20,8 @@ using DeviceGrid = std::pair<int, int>;
 using DeviceIds = std::vector<int>;
 
 
-inline DeviceMesh open_device_mesh(const DeviceGrid& device_grid, const DeviceIds& device_ids, size_t l1_small_size, size_t trace_region_size) {
-    return DeviceMesh(device_grid, device_ids, l1_small_size, trace_region_size);
+inline DeviceMesh open_device_mesh(const DeviceGrid& device_grid, const DeviceIds& device_ids, size_t l1_small_size, size_t trace_region_size, size_t num_command_queues) {
+    return DeviceMesh(device_grid, device_ids, l1_small_size, trace_region_size, num_command_queues);
 }
 
 inline void close_device_mesh(DeviceMesh &multi_device) {

--- a/ttnn/ttnn/multi_device.py
+++ b/ttnn/ttnn/multi_device.py
@@ -38,6 +38,7 @@ def open_device_mesh(
     device_ids: List[int],
     l1_small_size: int = ttl.device.DEFAULT_L1_SMALL_SIZE,
     trace_region_size: int = ttl.device.DEFAULT_TRACE_REGION_SIZE,
+    num_command_queues: int = 1,
 ):
     """
     open_device_mesh(device_grid: ttnn.DeviceGrid, device_ids: int) -> ttnn.DeviceMesh:
@@ -51,6 +52,7 @@ def open_device_mesh(
         device_ids=device_ids,
         l1_small_size=l1_small_size,
         trace_region_size=trace_region_size,
+        num_command_queues=num_command_queues,
     )
 
 
@@ -69,6 +71,7 @@ def create_device_mesh(
     device_ids: List[int],
     l1_small_size: int = ttl.device.DEFAULT_L1_SMALL_SIZE,
     trace_region_size: int = ttl.device.DEFAULT_TRACE_REGION_SIZE,
+    num_command_queues: int = 1,
 ):
     """
     create_device_mesh(device_grid: ttnn.DeviceGrid, device_ids: List[int]) -> ttnn.DeviceMesh
@@ -76,7 +79,11 @@ def create_device_mesh(
     Context manager for opening and closing a device.
     """
     device_mesh = open_device_mesh(
-        device_grid=device_grid, device_ids=device_ids, l1_small_size=l1_small_size, trace_region_size=trace_region_size
+        device_grid=device_grid,
+        device_ids=device_ids,
+        l1_small_size=l1_small_size,
+        trace_region_size=trace_region_size,
+        num_command_queues=num_command_queues,
     )
     try:
         yield device_mesh


### PR DESCRIPTION
### Ticket
Link to Github Issue

### Problem description
Add 2 CQs for remote devices. 

### What's changed
  - Feature Works only with Ethernet Dispatch with 10 Dispatch Cores used on L Chip and 6 Dispatch Cores used on R Chip
  - Make R-Chip dispatch kernel CT args (CB sizes, sem_ids, CB start offsets, etc.) compatible with 2 CQs
  - Ethernet Core Assignment Changes: 
     - On T3K/NBX2, core IDs 0-3 are now considered idle ethernet cores (used for dispatch kernels) 
     - UMD is only given cores 8 and 9 for R-Chip data movement
  - Event Synchronization Changes: 
     - Event IDs now start at 1, instead of 0. This is needed, since event values are zero-initialized, which causes the first wait_for_event to be a nop (incorrect behaviour) 
     - Update event query tests to reflect this change 
     - `wait_for_event` no longer records and event on host 
     - R-Chip Event synchronization requires prefetch_h to wait on an event, instead of dispatch_d stalling. This is needed, since the L-Chip Mux interleaves traffic between the 2 prefetchers, and having dispatch_d wait on an event can cause a deadlock, if it back-pressures and doesn't allow the other dispatch core to get the record_event command
     - Add commands and data-paths for prefetch_h to wait on an event and continue execution after dispatch_d notifies event completion
  - Add T3K tests for traffic (data-movement and programs) on both CQs
  - TTNN Changes: Expose multi-CQ device initialization API to TTNN

### Checklist
- [x] Post commit CI passes
- [ ] Model regression CI testing passes (if applicable)
- [x] New/Existing tests provide coverage for changes
