### PR TITLE
#9849: Move checks on batch dims for matmul to validate

### DIFF
--- a/tt_eager/tt_dnn/op_library/bmm/multi_core_reuse_mcast_1d_optimized/bmm_op_multi_core_reuse_mcast_1d_optimized.cpp
+++ b/tt_eager/tt_dnn/op_library/bmm/multi_core_reuse_mcast_1d_optimized/bmm_op_multi_core_reuse_mcast_1d_optimized.cpp
@@ -1509,19 +1509,6 @@ operation::ProgramWithCallbacks matmul_multi_core_reuse_mcast_1d_optimized_(
     uint32_t in1_single_tile_size = tt_metal::detail::TileSize(in1_data_format);
     tt_metal::Buffer* in0_buffer = a.buffer();
     tt_metal::Buffer* in1_buffer = b.buffer();
-    if (bcast_batch)
-        TT_FATAL(
-            get_batch_size(bshape) == 1 &&
-            "matmul (batch bcast variant) expects input tensors of shapes BCMK*11KN=BCMN or equivalent");
-    else {
-        // same condition as above, different message
-        TT_FATAL(ashape.rank() == bshape.rank() && "bmm (non-bcast matmul) expects input tensors of the same rank");
-        for (auto i = 0; i < ashape.rank() - 2; i++) {
-            TT_FATAL(
-                ashape[i] == bshape[i] &&
-                "bmm (non-bcast matmul) expects input tensors of shapes BCMK*BCKN=BCMN or equivalent");
-        }
-    }
     TT_FATAL(in0_buffer->size() % in0_single_tile_size == 0);
     TT_FATAL(in1_buffer->size() % in1_single_tile_size == 0);
 

--- a/tt_eager/tt_dnn/op_library/bmm/multi_core_reuse_mcast_2d_optimized/bmm_op_multi_core_reuse_mcast_2d_optimized.cpp
+++ b/tt_eager/tt_dnn/op_library/bmm/multi_core_reuse_mcast_2d_optimized/bmm_op_multi_core_reuse_mcast_2d_optimized.cpp
@@ -1232,19 +1232,6 @@ operation::ProgramWithCallbacks matmul_multi_core_reuse_mcast_2d_optimized_(
     uint32_t in1_single_tile_size = tt_metal::detail::TileSize(in1_data_format);
     tt_metal::Buffer* in0_buffer = a.buffer();
     tt_metal::Buffer* in1_buffer = b.buffer();
-    if (bcast_batch)
-        TT_FATAL(
-            get_batch_size(bshape) == 1 &&
-            "matmul (batch bcast variant) expects input tensors of shapes BCMK*11KN=BCMN or equivalent");
-    else {
-        // same condition as above, different message
-        TT_FATAL(ashape.rank() == bshape.rank() && "bmm (non-bcast matmul) expects input tensors of the same rank");
-        for (auto i = 0; i < ashape.rank() - 2; i++) {
-            TT_FATAL(
-                ashape[i] == bshape[i] &&
-                "bmm (non-bcast matmul) expects input tensors of shapes BCMK*BCKN=BCMN or equivalent");
-        }
-    }
     TT_FATAL(in0_buffer->size() % in0_single_tile_size == 0);
     TT_FATAL(in1_buffer->size() % in1_single_tile_size == 0);
 

--- a/tt_eager/tt_dnn/op_library/bmm/multi_core_reuse_mcast_dram_sharded_optimized/bmm_op_multi_core_reuse_dram_sharded_optimized.cpp
+++ b/tt_eager/tt_dnn/op_library/bmm/multi_core_reuse_mcast_dram_sharded_optimized/bmm_op_multi_core_reuse_dram_sharded_optimized.cpp
@@ -1152,12 +1152,6 @@ operation::ProgramWithCallbacks matmul_multi_core_reuse_dram_sharded_optimized_(
     uint32_t in1_single_tile_size = tt_metal::detail::TileSize(in1_data_format);
     tt_metal::Buffer* in0_buffer = a.buffer();
     tt_metal::Buffer* in1_buffer = b.buffer();
-    TT_FATAL(ashape.rank() == bshape.rank() && ashape.rank() >= 2 && "bmm (non-bcast matmul) expects input tensors of the same rank and must have rank >= 2");
-    for (auto i = 0; i < ashape.rank() - 2; i++) {
-        TT_FATAL(
-            ashape[i] == bshape[i] &&
-            "bmm (non-bcast matmul) expects input tensors of shapes BCMK*BCKN=BCMN or equivalent");
-    }
     TT_FATAL(in0_buffer->size() % in0_single_tile_size == 0);
     TT_FATAL(in1_buffer->size() % in1_single_tile_size == 0);
 

--- a/tt_eager/tt_dnn/op_library/bmm/multi_core_reuse_optimized/bmm_op_multi_core_reuse_optimized.cpp
+++ b/tt_eager/tt_dnn/op_library/bmm/multi_core_reuse_optimized/bmm_op_multi_core_reuse_optimized.cpp
@@ -463,19 +463,6 @@ operation::ProgramWithCallbacks matmul_multi_core_reuse_optimized_(const Tensor 
     uint32_t in1_single_tile_size = tt_metal::detail::TileSize(in1_data_format);
     tt_metal::Buffer *in0_buffer = a.buffer();
     tt_metal::Buffer *in1_buffer = b.buffer();
-    if (bcast_batch)
-        TT_FATAL(
-            get_batch_size(bshape) == 1 &&
-            "matmul (batch bcast variant) expects input tensors of shapes BCMK*11KN=BCMN or equivalent");
-    else {
-        // same condition as above, different message
-        TT_FATAL(ashape.rank() == bshape.rank() && "bmm (non-bcast matmul) expects input tensors of the same rank");
-        for (auto i = 0; i < ashape.rank() - 2; i++) {
-            TT_FATAL(
-                ashape[i] == bshape[i] &&
-                "bmm (non-bcast matmul) expects input tensors of shapes BCMK*BCKN=BCMN or equivalent");
-        }
-    }
 
     MathFidelity math_fidelity;
     bool math_approx_mode;


### PR DESCRIPTION
### Ticket
[Link to Github Issue](https://github.com/tenstorrent/tt-metal/issues/9849)

### Problem description
[Provide context for the problem.](https://github.com/tenstorrent/tt-metal/issues/9849#issuecomment-2211432336)
TLDR, corrupted values were seen in matmul output because we were missing check on batch dims for batched matmuls in some of our matmul variants.

### What's changed
I moved the checks for batches for matmul to the same place in `validate` which applies to all matmul variants. This does two things:
- Reduce code duplication for these checks across all the matmul variants
- Adds the missing checks to `matmul_multicore` and `matmul_multicore_reuse` as an intended side effect

### Checklist
- [x] Post commit CI passes:
  - Post-commit all: https://github.com/tenstorrent/tt-metal/actions/runs/9842643920
  - Post-commit ttnn unit tests: https://github.com/tenstorrent/tt-metal/actions/runs/9842650730
  - Post-commit models: https://github.com/tenstorrent/tt-metal/actions/runs/9842647477
- [ ] Model regression CI testing passes (if applicable)
- [x] New/Existing tests provide coverage for changes
   - Test in original issue now properly errors out without running matmul
