### PR TITLE
#9450: change silicon fixtures to session scope

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -430,11 +430,11 @@ def pytest_generate_tests(metafunc):
         )
 
     if uses_silicon_arch:
-        metafunc.parametrize("silicon_arch_name", available_archs)
+        metafunc.parametrize("silicon_arch_name", available_archs, scope="session")
         for test_requested_silicon_arch_fixture in test_requested_silicon_arch_fixtures:
             # The values of these arch-specific fixtures should not be used in
             # the test function, so use any parameters, like [True]
-            metafunc.parametrize(test_requested_silicon_arch_fixture, [True])
+            metafunc.parametrize(test_requested_silicon_arch_fixture, [True], scope="session")
 
     input_method = metafunc.config.getoption("--input-method")
     if input_method == "json":


### PR DESCRIPTION
### Ticket
[Link to Github Issue](https://github.com/tenstorrent/tt-metal/issues/9450)

### Problem description
Scope of some silicon pytest fixtures can be session

### What's changed
change scope of silicon pytest fixtures to session
No impact for now, but will enable extending our fixtures to be session scope

### Checklist
- [ ] Post commit CI passes
- [ ] Model regression CI testing passes (if applicable)
- [ ] New/Existing tests provide coverage for changes
