### PR TITLE
Add trace and multi cq implementations/tests for WH Resnet

### DIFF
--- a/models/experimental/resnet/tests/test_perf_device_ttnn_resnet.py
+++ b/models/experimental/resnet/tests/test_perf_device_ttnn_resnet.py
@@ -1,0 +1,37 @@
+# SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
+
+# SPDX-License-Identifier: Apache-2.0
+
+import pytest
+from models.perf.device_perf_utils import run_device_perf, check_device_perf, prep_device_perf_report
+from models.utility_functions import skip_for_grayskull
+
+
+@skip_for_grayskull(reason_str="Untested for Grayskull")
+@pytest.mark.models_device_performance_bare_metal
+@pytest.mark.parametrize(
+    "batch_size, test, expected_perf",
+    [
+        [16, "16-act_dtype0-weight_dtype0-math_fidelity0-device_params0", 4750],
+    ],
+)
+def test_perf_device_bare_metal(batch_size, test, expected_perf):
+    subdir = "resnet50"
+    num_iterations = 4
+    margin = 0.03
+    command = (
+        f"pytest models/experimental/resnet/tests/test_ttnn_resnet50_performant.py::test_run_resnet50_inference[{test}]"
+    )
+    cols = ["DEVICE FW", "DEVICE KERNEL", "DEVICE BRISC KERNEL"]
+    inference_time_key = "AVG DEVICE KERNEL SAMPLES/S"
+    expected_perf_cols = {inference_time_key: expected_perf}
+
+    post_processed_results = run_device_perf(command, subdir, num_iterations, cols, batch_size, True)
+    expected_results = check_device_perf(post_processed_results, margin, expected_perf_cols)
+    prep_device_perf_report(
+        model_name=f"ttnn_resnet50_batch_size{batch_size}",
+        batch_size=batch_size,
+        post_processed_results=post_processed_results,
+        expected_results=expected_results,
+        comments=test,
+    )

--- a/models/experimental/resnet/tests/test_perf_ttnn_resnet.py
+++ b/models/experimental/resnet/tests/test_perf_ttnn_resnet.py
@@ -27,7 +27,13 @@ from models.experimental.resnet.tests.test_ttnn_resnet50_performant import (
 )
 from models.experimental.resnet.tt.custom_preprocessing import custom_preprocessor
 from models.experimental.resnet.tt.ttnn_functional_resnet50_new_conv_api import resnet50
-from tracy import signpost
+
+try:
+    from tracy import signpost
+
+    use_signpost = True
+except ModuleNotFoundError:
+    use_signpost = False
 
 # TODO: Create ttnn apis for these
 ttnn.create_event = tt_lib.device.CreateEvent
@@ -62,7 +68,8 @@ def run_model(device, tt_inputs, tt_resnet50, num_warmup_iterations, num_measure
         _ = ttnn.from_device(tt_resnet50(tt_inputs, device, ops_parallel_config), blocking=True)
         ttnn.dump_device_profiler(device)
 
-    signpost(header="start")
+    if use_signpost:
+        signpost(header="start")
     outputs = []
     profiler.start(f"run")
     for iter in range(0, num_measurement_iterations):
@@ -70,7 +77,8 @@ def run_model(device, tt_inputs, tt_resnet50, num_warmup_iterations, num_measure
         outputs.append(ttnn.from_device(tt_resnet50(tt_inputs, device, ops_parallel_config), blocking=False))
     ttnn.device.synchronize_device(device)
     profiler.end(f"run")
-    signpost(header="stop")
+    if use_signpost:
+        signpost(header="stop")
     ttnn.dump_device_profiler(device)
 
 
@@ -115,7 +123,8 @@ def run_2cq_model(device, tt_inputs, tt_resnet50, num_warmup_iterations, num_mea
         _ = ttnn.from_device(tt_resnet50(reshard_out, device, ops_parallel_config), blocking=True)
         ttnn.dump_device_profiler(device)
 
-    signpost(header="start")
+    if use_signpost:
+        signpost(header="start")
     outputs = []
     profiler.start(f"run")
     for iter in range(0, num_measurement_iterations):
@@ -128,7 +137,8 @@ def run_2cq_model(device, tt_inputs, tt_resnet50, num_warmup_iterations, num_mea
         outputs.append(ttnn.from_device(tt_resnet50(reshard_out, device, ops_parallel_config), blocking=False))
     ttnn.device.synchronize_device(device)
     profiler.end(f"run")
-    signpost(header="stop")
+    if use_signpost:
+        signpost(header="stop")
     ttnn.dump_device_profiler(device)
 
 
@@ -165,7 +175,8 @@ def run_trace_model(device, tt_inputs, tt_resnet50, num_warmup_iterations, num_m
         _ = ttnn.from_device(tt_output_res, blocking=True)
         ttnn.dump_device_profiler(device)
 
-    signpost(header="start")
+    if use_signpost:
+        signpost(header="start")
     outputs = []
     profiler.start(f"run")
     for iter in range(0, num_measurement_iterations):
@@ -174,7 +185,8 @@ def run_trace_model(device, tt_inputs, tt_resnet50, num_warmup_iterations, num_m
         outputs.append(ttnn.from_device(tt_output_res, blocking=False))
     ttnn.device.synchronize_device(device)
     profiler.end(f"run")
-    signpost(header="stop")
+    if use_signpost:
+        signpost(header="stop")
     ttnn.dump_device_profiler(device)
 
 
@@ -239,7 +251,8 @@ def run_trace_2cq_model(device, tt_inputs, tt_resnet50, num_warmup_iterations, n
         ttnn.execute_trace(device, tid, cq_id=0, blocking=True)
         ttnn.dump_device_profiler(device)
 
-    signpost(header="start")
+    if use_signpost:
+        signpost(header="start")
     outputs = []
     profiler.start(f"run")
     for iter in range(0, num_measurement_iterations):
@@ -254,7 +267,8 @@ def run_trace_2cq_model(device, tt_inputs, tt_resnet50, num_warmup_iterations, n
         outputs.append(tt_output_res.cpu(blocking=False))
     ttnn.device.synchronize_device(device)
     profiler.end(f"run")
-    signpost(header="stop")
+    if use_signpost:
+        signpost(header="stop")
     ttnn.dump_device_profiler(device)
 
 

--- a/models/experimental/resnet/tests/test_perf_ttnn_resnet.py
+++ b/models/experimental/resnet/tests/test_perf_ttnn_resnet.py
@@ -1,0 +1,445 @@
+# SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
+
+# SPDX-License-Identifier: Apache-2.0
+
+import torch
+from loguru import logger
+import torchvision
+from transformers import AutoImageProcessor
+import pytest
+import ttnn
+import tt_lib
+from ttnn.model_preprocessing import (
+    preprocess_model_parameters,
+)
+
+from models.utility_functions import (
+    profiler,
+    disable_persistent_kernel_cache,
+    skip_for_grayskull,
+)
+
+from models.perf.perf_utils import prep_perf_report
+
+from models.experimental.resnet.tests.test_ttnn_resnet50_performant import (
+    setup_l1_sharded_input,
+    setup_dram_sharded_input,
+)
+from models.experimental.resnet.tt.custom_preprocessing import custom_preprocessor
+from models.experimental.resnet.tt.ttnn_functional_resnet50_new_conv_api import resnet50
+from tracy import signpost
+
+# TODO: Create ttnn apis for these
+ttnn.create_event = tt_lib.device.CreateEvent
+ttnn.wait_for_event = tt_lib.device.WaitForEvent
+ttnn.record_event = tt_lib.device.RecordEvent
+ttnn.dump_device_profiler = tt_lib.device.DumpDeviceProfiler
+
+model_config = {
+    "MATH_FIDELITY": ttnn.MathFidelity.LoFi,
+    "WEIGHTS_DTYPE": ttnn.bfloat8_b,
+    "ACTIVATIONS_DTYPE": ttnn.bfloat8_b,
+}
+
+
+def run_model(device, tt_inputs, tt_resnet50, num_warmup_iterations, num_measurement_iterations):
+    ops_parallel_config = {}
+    tt_inputs_host, input_mem_config = setup_l1_sharded_input(device, tt_inputs, tt_resnet50)
+    profiler.start("compile")
+    tt_inputs = tt_inputs_host.to(device, input_mem_config)
+    _ = ttnn.from_device(tt_resnet50(tt_inputs, device, ops_parallel_config), blocking=True)
+    profiler.end("compile")
+    ttnn.dump_device_profiler(device)
+
+    profiler.start("cache")
+    tt_inputs = tt_inputs_host.to(device, input_mem_config)
+    _ = ttnn.from_device(tt_resnet50(tt_inputs, device, ops_parallel_config), blocking=True)
+    profiler.end("cache")
+    ttnn.dump_device_profiler(device)
+
+    for iter in range(0, num_warmup_iterations):
+        tt_inputs = tt_inputs_host.to(device, input_mem_config)
+        _ = ttnn.from_device(tt_resnet50(tt_inputs, device, ops_parallel_config), blocking=True)
+        ttnn.dump_device_profiler(device)
+
+    signpost(header="start")
+    outputs = []
+    profiler.start(f"run")
+    for iter in range(0, num_measurement_iterations):
+        tt_inputs = tt_inputs_host.to(device, input_mem_config)
+        outputs.append(ttnn.from_device(tt_resnet50(tt_inputs, device, ops_parallel_config), blocking=False))
+    ttnn.device.synchronize_device(device)
+    profiler.end(f"run")
+    signpost(header="stop")
+    ttnn.dump_device_profiler(device)
+
+
+def run_2cq_model(device, tt_inputs, tt_resnet50, num_warmup_iterations, num_measurement_iterations):
+    ops_parallel_config = {}
+    tt_inputs_host, sharded_mem_config_DRAM, input_mem_config = setup_dram_sharded_input(device, tt_inputs, tt_resnet50)
+    tt_image_res = tt_inputs_host.to(device, sharded_mem_config_DRAM)
+    op_event = ttnn.create_event()
+    write_event = ttnn.create_event()
+    # Initialize the op event so we can write
+    ttnn.record_event(device, 0, op_event)
+
+    profiler.start("compile")
+    ttnn.wait_for_event(device, 1, op_event)
+    ttnn.copy_host_to_device_tensor(tt_inputs_host, tt_image_res, 1)
+    ttnn.record_event(device, 1, write_event)
+    ttnn.wait_for_event(device, 0, write_event)
+    reshard_out = ttnn.to_memory_config(tt_image_res, input_mem_config)
+    ttnn.record_event(device, 0, op_event)
+    _ = ttnn.from_device(tt_resnet50(reshard_out, device, ops_parallel_config), blocking=True)
+    profiler.end("compile")
+    ttnn.dump_device_profiler(device)
+
+    profiler.start("cache")
+    ttnn.wait_for_event(device, 1, op_event)
+    ttnn.copy_host_to_device_tensor(tt_inputs_host, tt_image_res, 1)
+    ttnn.record_event(device, 1, write_event)
+    ttnn.wait_for_event(device, 0, write_event)
+    reshard_out = ttnn.to_memory_config(tt_image_res, input_mem_config)
+    ttnn.record_event(device, 0, op_event)
+    _ = ttnn.from_device(tt_resnet50(reshard_out, device, ops_parallel_config), blocking=True)
+    profiler.end("cache")
+    ttnn.dump_device_profiler(device)
+
+    for iter in range(0, num_warmup_iterations):
+        ttnn.wait_for_event(device, 1, op_event)
+        ttnn.copy_host_to_device_tensor(tt_inputs_host, tt_image_res, 1)
+        ttnn.record_event(device, 1, write_event)
+        ttnn.wait_for_event(device, 0, write_event)
+        reshard_out = ttnn.to_memory_config(tt_image_res, input_mem_config)
+        ttnn.record_event(device, 0, op_event)
+        _ = ttnn.from_device(tt_resnet50(reshard_out, device, ops_parallel_config), blocking=True)
+        ttnn.dump_device_profiler(device)
+
+    signpost(header="start")
+    outputs = []
+    profiler.start(f"run")
+    for iter in range(0, num_measurement_iterations):
+        ttnn.wait_for_event(device, 1, op_event)
+        ttnn.copy_host_to_device_tensor(tt_inputs_host, tt_image_res, 1)
+        ttnn.record_event(device, 1, write_event)
+        ttnn.wait_for_event(device, 0, write_event)
+        reshard_out = ttnn.to_memory_config(tt_image_res, input_mem_config)
+        ttnn.record_event(device, 0, op_event)
+        outputs.append(ttnn.from_device(tt_resnet50(reshard_out, device, ops_parallel_config), blocking=False))
+    ttnn.device.synchronize_device(device)
+    profiler.end(f"run")
+    signpost(header="stop")
+    ttnn.dump_device_profiler(device)
+
+
+def run_trace_model(device, tt_inputs, tt_resnet50, num_warmup_iterations, num_measurement_iterations):
+    ops_parallel_config = {}
+    tt_inputs_host, sharded_mem_config_DRAM, input_mem_config = setup_dram_sharded_input(device, tt_inputs, tt_resnet50)
+    tt_image_res = tt_inputs_host.to(device, sharded_mem_config_DRAM)
+    # Compile
+    profiler.start("compile")
+    ttnn.copy_host_to_device_tensor(tt_inputs_host, tt_image_res)
+    reshard_out = ttnn.to_memory_config(tt_image_res, input_mem_config)
+    _ = ttnn.from_device(tt_resnet50(reshard_out, device, ops_parallel_config), blocking=True)
+    profiler.end("compile")
+    ttnn.dump_device_profiler(device)
+
+    profiler.start("cache")
+    ttnn.copy_host_to_device_tensor(tt_inputs_host, tt_image_res)
+    reshard_out = ttnn.to_memory_config(tt_image_res, input_mem_config)
+    _ = ttnn.from_device(tt_resnet50(reshard_out, device, ops_parallel_config), blocking=True)
+    profiler.end("cache")
+    ttnn.dump_device_profiler(device)
+
+    # Capture
+    ttnn.copy_host_to_device_tensor(tt_inputs_host, tt_image_res)
+    tid = ttnn.begin_trace_capture(device, cq_id=0)
+    reshard_out = ttnn.to_memory_config(tt_image_res, input_mem_config)
+    tt_output_res = tt_resnet50(reshard_out, device, ops_parallel_config)
+    ttnn.end_trace_capture(device, tid, cq_id=0)
+    ttnn.dump_device_profiler(device)
+
+    for iter in range(0, num_warmup_iterations):
+        ttnn.copy_host_to_device_tensor(tt_inputs_host, tt_image_res)
+        ttnn.execute_trace(device, tid, cq_id=0, blocking=False)
+        _ = ttnn.from_device(tt_output_res, blocking=True)
+        ttnn.dump_device_profiler(device)
+
+    signpost(header="start")
+    outputs = []
+    profiler.start(f"run")
+    for iter in range(0, num_measurement_iterations):
+        ttnn.copy_host_to_device_tensor(tt_inputs_host, tt_image_res)
+        ttnn.execute_trace(device, tid, cq_id=0, blocking=False)
+        outputs.append(ttnn.from_device(tt_output_res, blocking=False))
+    ttnn.device.synchronize_device(device)
+    profiler.end(f"run")
+    signpost(header="stop")
+    ttnn.dump_device_profiler(device)
+
+
+def run_trace_2cq_model(device, tt_inputs, tt_resnet50, num_warmup_iterations, num_measurement_iterations):
+    ops_parallel_config = {}
+    tt_inputs_host, sharded_mem_config_DRAM, input_mem_config = setup_dram_sharded_input(device, tt_inputs, tt_resnet50)
+    tt_image_res = tt_inputs_host.to(device, sharded_mem_config_DRAM)
+
+    op_event = ttnn.create_event()
+    write_event = ttnn.create_event()
+    # Initialize the op event so we can write
+    ttnn.record_event(device, 0, op_event)
+
+    profiler.start("compile")
+    ttnn.wait_for_event(device, 1, op_event)
+    ttnn.copy_host_to_device_tensor(tt_inputs_host, tt_image_res, 1)
+    ttnn.record_event(device, 1, write_event)
+    ttnn.wait_for_event(device, 0, write_event)
+    reshard_out = ttnn.to_memory_config(tt_image_res, input_mem_config)
+    ttnn.record_event(device, 0, op_event)
+    _ = ttnn.from_device(tt_resnet50(reshard_out, device, ops_parallel_config), blocking=True)
+    profiler.end("compile")
+    ttnn.dump_device_profiler(device)
+
+    profiler.start("cache")
+    ttnn.wait_for_event(device, 1, op_event)
+    ttnn.copy_host_to_device_tensor(tt_inputs_host, tt_image_res, 1)
+    ttnn.record_event(device, 1, write_event)
+    ttnn.wait_for_event(device, 0, write_event)
+    reshard_out = ttnn.to_memory_config(tt_image_res, input_mem_config)
+    first_out_addr = reshard_out.buffer_address()
+    ttnn.record_event(device, 0, op_event)
+    _ = ttnn.from_device(tt_resnet50(reshard_out, device, ops_parallel_config), blocking=True)
+    profiler.end("cache")
+    ttnn.dump_device_profiler(device)
+
+    # Capture
+    ttnn.wait_for_event(device, 1, op_event)
+    ttnn.copy_host_to_device_tensor(tt_inputs_host, tt_image_res, 1)
+    ttnn.record_event(device, 1, write_event)
+
+    ttnn.wait_for_event(device, 0, write_event)
+    reshard_out = ttnn.to_memory_config(tt_image_res, input_mem_config)
+    ttnn.record_event(device, 0, op_event)
+
+    tid = ttnn.begin_trace_capture(device, cq_id=0)
+    tt_output_res = tt_resnet50(reshard_out, device, ops_parallel_config)
+    reshard_out = ttnn.allocate_tensor_on_device(
+        reshard_out.shape, reshard_out.dtype, reshard_out.layout, device, input_mem_config
+    )
+    ttnn.end_trace_capture(device, tid, cq_id=0)
+    assert first_out_addr == reshard_out.buffer_address()
+    ttnn.dump_device_profiler(device)
+
+    for iter in range(0, num_warmup_iterations):
+        ttnn.wait_for_event(device, 1, op_event)
+        ttnn.copy_host_to_device_tensor(tt_inputs_host, tt_image_res, 1)
+        ttnn.record_event(device, 1, write_event)
+        ttnn.wait_for_event(device, 0, write_event)
+        reshard_out = ttnn.experimental.tensor.reshard(tt_image_res, input_mem_config, reshard_out)
+        ttnn.record_event(device, 0, op_event)
+        ttnn.execute_trace(device, tid, cq_id=0, blocking=True)
+        ttnn.dump_device_profiler(device)
+
+    signpost(header="start")
+    outputs = []
+    profiler.start(f"run")
+    for iter in range(0, num_measurement_iterations):
+        ttnn.wait_for_event(device, 1, op_event)
+        ttnn.copy_host_to_device_tensor(tt_inputs_host, tt_image_res, 1)
+        ttnn.record_event(device, 1, write_event)
+        ttnn.wait_for_event(device, 0, write_event)
+        # TODO: Add in place support to ttnn to_memory_config
+        reshard_out = ttnn.experimental.tensor.reshard(tt_image_res, input_mem_config, reshard_out)
+        ttnn.record_event(device, 0, op_event)
+        ttnn.execute_trace(device, tid, cq_id=0, blocking=False)
+        outputs.append(tt_output_res.cpu(blocking=False))
+    ttnn.device.synchronize_device(device)
+    profiler.end(f"run")
+    signpost(header="stop")
+    ttnn.dump_device_profiler(device)
+
+
+def run_perf_resnet(
+    batch_size,
+    expected_inference_time,
+    expected_compile_time,
+    hf_cat_image_sample_input,
+    device,
+    model_version,
+):
+    profiler.clear()
+    disable_persistent_kernel_cache()
+    if batch_size <= 2:
+        pytest.skip("Batch size 1 and 2 are not supported with sharded data")
+    first_key = f"first_iter_batchsize{batch_size}"
+    second_key = f"second_iter_batchsize{batch_size}"
+    cpu_key = f"ref_key_batchsize{batch_size}"
+    model_name = "microsoft/resnet-50"
+
+    image = hf_cat_image_sample_input
+    image_processor = AutoImageProcessor.from_pretrained(model_name)
+    inputs = image_processor(image, return_tensors="pt")
+
+    inputs = inputs["pixel_values"].bfloat16()
+    comments = f"{list(inputs.shape)[-2]}x{list(inputs.shape)[-1]}_batchsize{batch_size}"
+
+    inputs1 = inputs
+    for i in range(batch_size - 1):
+        inputs = torch.cat((inputs, inputs1), dim=0)
+
+    torch_resnet50 = torchvision.models.resnet50(weights=torchvision.models.ResNet50_Weights.IMAGENET1K_V1)
+    torch_resnet50.eval()
+
+    parameters = preprocess_model_parameters(
+        initialize_model=lambda: torch_resnet50, custom_preprocessor=custom_preprocessor, device=None
+    )
+    torch_resnet50.to(torch.bfloat16)
+
+    tt_resnet50 = resnet50(
+        device=device,
+        parameters=parameters,
+        batch_size=batch_size,
+        model_config=model_config,
+        dealloc_input=True,
+        final_output_mem_config=ttnn.DRAM_MEMORY_CONFIG if "trace" in model_version else ttnn.L1_MEMORY_CONFIG,
+    )
+    ttnn.device.synchronize_device(device)
+
+    num_warmup_iterations = 5
+    num_measurement_iterations = 15
+
+    with torch.no_grad():
+        profiler.start(cpu_key)
+        logits = torch_resnet50(inputs)
+        profiler.end(cpu_key)
+
+        tt_inputs = tt_resnet50.preprocessing(inputs)
+        if "resnet50_trace_2cqs" in model_version:
+            run_trace_2cq_model(device, tt_inputs, tt_resnet50, num_warmup_iterations, num_measurement_iterations)
+        elif "resnet50_2cqs" in model_version:
+            run_2cq_model(device, tt_inputs, tt_resnet50, num_warmup_iterations, num_measurement_iterations)
+        elif "resnet50_trace" in model_version:
+            run_trace_model(device, tt_inputs, tt_resnet50, num_warmup_iterations, num_measurement_iterations)
+        elif "resnet50" in model_version:
+            run_model(device, tt_inputs, tt_resnet50, num_warmup_iterations, num_measurement_iterations)
+        else:
+            assert False, f"Model version to run {model_version} not found"
+
+    first_iter_time = profiler.get(f"compile") + profiler.get(f"cache")
+
+    # ensuring inference time fluctuations is not noise
+    inference_time_avg = profiler.get("run") / num_measurement_iterations
+
+    cpu_time = profiler.get(cpu_key)
+    compile_time = first_iter_time - 2 * inference_time_avg
+    prep_perf_report(
+        model_name=f"ttnn_{model_version}_batch_size{batch_size}",
+        batch_size=batch_size,
+        inference_and_compile_time=first_iter_time,
+        inference_time=inference_time_avg,
+        expected_compile_time=expected_compile_time,
+        expected_inference_time=expected_inference_time,
+        comments=comments,
+        inference_time_cpu=cpu_time,
+    )
+
+    logger.info(f"{model_name} {comments} inference time (avg): {inference_time_avg}")
+    logger.info(f"{model_name} compile time: {compile_time}")
+
+
+@skip_for_grayskull(reason_str="Untested for Grayskull")
+@pytest.mark.parametrize("device_params", [{"l1_small_size": 24576}], indirect=True)
+@pytest.mark.models_performance_bare_metal
+@pytest.mark.parametrize(
+    "batch_size, expected_inference_time, expected_compile_time",
+    ((16, 4, 25),),  # E2E perf without trace currently unstable
+)
+def test_perf_bare_metal(
+    device,
+    use_program_cache,
+    batch_size,
+    expected_inference_time,
+    expected_compile_time,
+    hf_cat_image_sample_input,
+):
+    run_perf_resnet(
+        batch_size, expected_inference_time, expected_compile_time, hf_cat_image_sample_input, device, "resnet50"
+    )
+
+
+@skip_for_grayskull(reason_str="Untested for Grayskull")
+@pytest.mark.parametrize("device_params", [{"l1_small_size": 32768, "trace_region_size": 1500000}], indirect=True)
+@pytest.mark.models_performance_bare_metal
+@pytest.mark.parametrize(
+    "batch_size, enable_async, expected_inference_time, expected_compile_time",
+    (
+        # (16, True, 0.009, 25),
+        (16, False, 0.009, 25),
+    ),
+)
+def test_perf_trace_bare_metal(
+    device,
+    use_program_cache,
+    batch_size,
+    expected_inference_time,
+    expected_compile_time,
+    hf_cat_image_sample_input,
+    enable_async,
+):
+    device.enable_async(enable_async)
+    mode = "async" if enable_async else "sync"
+    run_perf_resnet(
+        batch_size,
+        expected_inference_time,
+        expected_compile_time,
+        hf_cat_image_sample_input,
+        device,
+        f"resnet50_trace_{mode}",
+    )
+    device.enable_async(False)
+
+
+@skip_for_grayskull(reason_str="Untested for Grayskull")
+@pytest.mark.parametrize("device_params", [{"l1_small_size": 32768, "num_hw_cqs": 2}], indirect=True)
+@pytest.mark.models_performance_bare_metal
+@pytest.mark.parametrize(
+    "batch_size, expected_inference_time, expected_compile_time",
+    ((16, 4, 25),),  # E2E perf without trace currently unstable
+)
+def test_perf_2cqs_bare_metal(
+    device,
+    use_program_cache,
+    batch_size,
+    expected_inference_time,
+    expected_compile_time,
+    hf_cat_image_sample_input,
+):
+    run_perf_resnet(
+        batch_size, expected_inference_time, expected_compile_time, hf_cat_image_sample_input, device, "resnet50_2cqs"
+    )
+
+
+@skip_for_grayskull(reason_str="Untested for Grayskull")
+@pytest.mark.parametrize(
+    "device_params", [{"l1_small_size": 32768, "num_hw_cqs": 2, "trace_region_size": 1332224}], indirect=True
+)
+@pytest.mark.models_performance_bare_metal
+@pytest.mark.parametrize(
+    "batch_size, expected_inference_time, expected_compile_time",
+    ((16, 0.008, 25),),
+)
+def test_perf_trace_2cqs_bare_metal(
+    device,
+    use_program_cache,
+    batch_size,
+    expected_inference_time,
+    expected_compile_time,
+    hf_cat_image_sample_input,
+):
+    run_perf_resnet(
+        batch_size,
+        expected_inference_time,
+        expected_compile_time,
+        hf_cat_image_sample_input,
+        device,
+        "resnet50_trace_2cqs",
+    )

--- a/models/experimental/resnet/tests/test_ttnn_resnet50_performant.py
+++ b/models/experimental/resnet/tests/test_ttnn_resnet50_performant.py
@@ -1,0 +1,309 @@
+# SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
+
+# SPDX-License-Identifier: Apache-2.0
+
+import pytest
+import torch
+import tt_lib
+import ttnn
+from models.utility_functions import (
+    is_wormhole_b0,
+    divup,
+    skip_for_grayskull,
+)
+from tests.ttnn.integration_tests.resnet.test_ttnn_functional_resnet50_new import create_test_infra
+
+try:
+    from tracy import signpost
+
+    use_signpost = True
+except ModuleNotFoundError:
+    use_signpost = False
+
+
+# TODO: Create ttnn apis for these
+ttnn.create_event = tt_lib.device.CreateEvent
+ttnn.wait_for_event = tt_lib.device.WaitForEvent
+ttnn.record_event = tt_lib.device.RecordEvent
+ttnn.dump_device_profiler = tt_lib.device.DumpDeviceProfiler
+
+
+# TODO: Move these into Resnet model preprocessing/member functions
+def setup_l1_sharded_input(device, tt_inputs, tt_resnet50):
+    padded_input_shape, input_mem_config, _ = ttnn.get_conv_padded_input_shape_and_mem_config(
+        device=device,
+        input_tensor=tt_inputs,
+        conv_config=tt_resnet50.conv1_config,
+        batch_size=tt_resnet50.batch_size,
+        height=tt_resnet50.conv1_output_height,
+        width=tt_resnet50.conv1_output_width,
+        in_channels=tt_resnet50.conv1_input_channels,
+        out_channels=tt_resnet50.conv1_output_channels,
+    )
+    inputs_padded = tt_inputs.to_torch()
+    inputs_padded = inputs_padded.reshape(1, 1, -1, inputs_padded.shape[-1])
+    inputs_padded = torch.nn.functional.pad(
+        inputs_padded,
+        (0, padded_input_shape[-1] - inputs_padded.shape[-1], 0, padded_input_shape[-2] - inputs_padded.shape[-2]),
+    )
+    tt_inputs_host = ttnn.from_torch(inputs_padded, dtype=ttnn.bfloat16, layout=ttnn.ROW_MAJOR_LAYOUT)
+    return tt_inputs_host, input_mem_config
+
+
+def setup_dram_sharded_input(device, tt_inputs, tt_resnet50):
+    tt_inputs_host, input_mem_config = setup_l1_sharded_input(device, tt_inputs, tt_resnet50)
+    dram_grid_size = device.dram_grid_size()
+    dram_shard_spec = ttnn.ShardSpec(
+        ttnn.CoreRangeSet(
+            {ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(dram_grid_size.x - 1, dram_grid_size.y - 1))}
+        ),
+        [
+            divup(tt_inputs_host.volume() // tt_inputs_host.shape[-1], dram_grid_size.x),
+            tt_inputs_host.shape[-1],
+        ],
+        ttnn.ShardOrientation.ROW_MAJOR,
+        False,
+    )
+    sharded_mem_config_DRAM = ttnn.MemoryConfig(
+        ttnn.TensorMemoryLayout.HEIGHT_SHARDED, ttnn.BufferType.DRAM, dram_shard_spec
+    )
+
+    return tt_inputs_host, sharded_mem_config_DRAM, input_mem_config
+
+
+@skip_for_grayskull(reason_str="Untested for Grayskull")
+@pytest.mark.parametrize("device_params", [{"l1_small_size": 24576}], indirect=True)
+@pytest.mark.parametrize(
+    "batch_size, act_dtype, weight_dtype, math_fidelity",
+    ((16, ttnn.bfloat8_b, ttnn.bfloat8_b, ttnn.MathFidelity.LoFi),),
+)
+def test_run_resnet50_inference(device, use_program_cache, batch_size, act_dtype, weight_dtype, math_fidelity):
+    if batch_size == 8:
+        pytest.skip("Skipping batch size 8 due to memory config issue")
+    if is_wormhole_b0() and batch_size == 20:
+        pytest.skip("Skipping batch size 20 for Wormhole B0 due to fitting issue")
+    test_infra = create_test_infra(
+        device, batch_size, act_dtype, weight_dtype, math_fidelity, True, ttnn.L1_MEMORY_CONFIG
+    )
+    test_infra.preprocess_torch_input()
+    tt_inputs_host, input_mem_config = setup_l1_sharded_input(
+        device, test_infra.input_tensor, test_infra.ttnn_resnet50_model
+    )
+
+    # First run configures convs JIT
+    test_infra.input_tensor = tt_inputs_host.to(device, input_mem_config)
+    test_infra.run()
+    # Optimized run
+    test_infra.input_tensor = tt_inputs_host.to(device, input_mem_config)
+    test_infra.run()
+    # More optimized run with caching
+    if use_signpost:
+        signpost(header="start")
+    test_infra.input_tensor = tt_inputs_host.to(device, input_mem_config)
+    test_infra.run()
+    if use_signpost:
+        signpost(header="stop")
+    test_infra.validate()
+
+
+@skip_for_grayskull(reason_str="Untested for Grayskull")
+@pytest.mark.parametrize("device_params", [{"l1_small_size": 24576, "trace_region_size": 800768}], indirect=True)
+@pytest.mark.parametrize(
+    "batch_size, act_dtype, weight_dtype, math_fidelity",
+    ((16, ttnn.bfloat8_b, ttnn.bfloat8_b, ttnn.MathFidelity.LoFi),),
+)
+def test_run_resnet50_trace_inference(device, use_program_cache, batch_size, act_dtype, weight_dtype, math_fidelity):
+    if batch_size == 8:
+        pytest.skip("Skipping batch size 8 due to memory config issue")
+    if is_wormhole_b0() and batch_size == 20:
+        pytest.skip("Skipping batch size 20 for Wormhole B0 due to fitting issue")
+    test_infra = create_test_infra(
+        device, batch_size, act_dtype, weight_dtype, math_fidelity, True, ttnn.DRAM_MEMORY_CONFIG
+    )
+    test_infra.preprocess_torch_input()
+    tt_inputs_host, sharded_mem_config_DRAM, input_mem_config = setup_dram_sharded_input(
+        device, test_infra.input_tensor, test_infra.ttnn_resnet50_model
+    )
+    tt_image_res = tt_inputs_host.to(device, sharded_mem_config_DRAM)
+
+    # First run configures convs JIT
+    ttnn.copy_host_to_device_tensor(tt_inputs_host, tt_image_res, 0)
+    test_infra.input_tensor = ttnn.to_memory_config(tt_image_res, input_mem_config)
+    test_infra.run()
+
+    # Optimized run
+    ttnn.copy_host_to_device_tensor(tt_inputs_host, tt_image_res, 0)
+    test_infra.input_tensor = ttnn.to_memory_config(tt_image_res, input_mem_config)
+    test_infra.run()
+
+    # Capture
+    ttnn.copy_host_to_device_tensor(tt_inputs_host, tt_image_res, 0)
+    tid = ttnn.begin_trace_capture(device, cq_id=0)
+    test_infra.input_tensor = ttnn.to_memory_config(tt_image_res, input_mem_config)
+    test_infra.run()
+    ttnn.end_trace_capture(device, tid, cq_id=0)
+
+    # More optimized run with caching
+    if use_signpost:
+        signpost(header="start")
+    ttnn.copy_host_to_device_tensor(tt_inputs_host, tt_image_res, 0)
+    ttnn.execute_trace(device, tid, cq_id=0, blocking=True)
+    if use_signpost:
+        signpost(header="stop")
+    test_infra.validate()
+
+
+@skip_for_grayskull(reason_str="Untested for Grayskull")
+@pytest.mark.parametrize("device_params", [{"l1_small_size": 24576, "num_hw_cqs": 2}], indirect=True)
+@pytest.mark.parametrize(
+    "batch_size, act_dtype, weight_dtype, math_fidelity",
+    ((16, ttnn.bfloat8_b, ttnn.bfloat8_b, ttnn.MathFidelity.LoFi),),
+)
+def test_run_resnet50_2cqs_inference(device, use_program_cache, batch_size, act_dtype, weight_dtype, math_fidelity):
+    if batch_size == 8:
+        pytest.skip("Skipping batch size 8 due to memory config issue")
+    if is_wormhole_b0() and batch_size == 20:
+        pytest.skip("Skipping batch size 20 for Wormhole B0 due to fitting issue")
+    test_infra = create_test_infra(
+        device, batch_size, act_dtype, weight_dtype, math_fidelity, True, ttnn.L1_MEMORY_CONFIG
+    )
+    test_infra.preprocess_torch_input()
+    tt_inputs_host, sharded_mem_config_DRAM, input_mem_config = setup_dram_sharded_input(
+        device, test_infra.input_tensor, test_infra.ttnn_resnet50_model
+    )
+    tt_image_res = tt_inputs_host.to(device, sharded_mem_config_DRAM)
+    op_event = ttnn.create_event()
+    write_event = ttnn.create_event()
+    # Initialize the op event so we can write
+    ttnn.record_event(device, 0, op_event)
+
+    # First run configures convs JIT
+    ttnn.wait_for_event(device, 1, op_event)
+    ttnn.copy_host_to_device_tensor(tt_inputs_host, tt_image_res, 1)
+    ttnn.record_event(device, 1, write_event)
+    ttnn.wait_for_event(device, 0, write_event)
+    test_infra.input_tensor = ttnn.to_memory_config(tt_image_res, input_mem_config)
+    ttnn.record_event(device, 0, op_event)
+    test_infra.run()
+    test_infra.validate()
+
+    # Optimized run
+    ttnn.wait_for_event(device, 1, op_event)
+    ttnn.copy_host_to_device_tensor(tt_inputs_host, tt_image_res, 1)
+    ttnn.record_event(device, 1, write_event)
+    ttnn.wait_for_event(device, 0, write_event)
+    test_infra.input_tensor = ttnn.to_memory_config(tt_image_res, input_mem_config)
+    ttnn.record_event(device, 0, op_event)
+    test_infra.run()
+    test_infra.validate()
+
+    # More optimized run with caching
+    if use_signpost:
+        signpost(header="start")
+    outputs = []
+    for iter in range(0, 2):
+        ttnn.wait_for_event(device, 1, op_event)
+        ttnn.copy_host_to_device_tensor(tt_inputs_host, tt_image_res, 1)
+        ttnn.record_event(device, 1, write_event)
+        ttnn.wait_for_event(device, 0, write_event)
+        test_infra.input_tensor = ttnn.to_memory_config(tt_image_res, input_mem_config)
+        ttnn.record_event(device, 0, op_event)
+        outputs.append(ttnn.from_device(test_infra.run(), blocking=False))
+    ttnn.device.synchronize_device(device)
+    if use_signpost:
+        signpost(header="stop")
+    for output in outputs:
+        test_infra.validate(output)
+
+
+@skip_for_grayskull(reason_str="Untested for Grayskull")
+@pytest.mark.parametrize(
+    "device_params", [{"l1_small_size": 24576, "trace_region_size": 800768, "num_hw_cqs": 2}], indirect=True
+)
+@pytest.mark.parametrize(
+    "batch_size, act_dtype, weight_dtype, math_fidelity",
+    ((16, ttnn.bfloat8_b, ttnn.bfloat8_b, ttnn.MathFidelity.LoFi),),
+)
+def test_run_resnet50_trace_2cqs_inference(
+    device, use_program_cache, batch_size, act_dtype, weight_dtype, math_fidelity
+):
+    if batch_size == 8:
+        pytest.skip("Skipping batch size 8 due to memory config issue")
+    if is_wormhole_b0() and batch_size == 20:
+        pytest.skip("Skipping batch size 20 for Wormhole B0 due to fitting issue")
+    test_infra = create_test_infra(
+        device, batch_size, act_dtype, weight_dtype, math_fidelity, True, ttnn.DRAM_MEMORY_CONFIG
+    )
+    test_infra.preprocess_torch_input()
+    tt_inputs_host, sharded_mem_config_DRAM, input_mem_config = setup_dram_sharded_input(
+        device, test_infra.input_tensor, test_infra.ttnn_resnet50_model
+    )
+    tt_image_res = tt_inputs_host.to(device, sharded_mem_config_DRAM)
+    op_event = ttnn.create_event()
+    write_event = ttnn.create_event()
+    # Initialize the op event so we can write
+    ttnn.record_event(device, 0, op_event)
+
+    # First run configures convs JIT
+    ttnn.wait_for_event(device, 1, op_event)
+    ttnn.copy_host_to_device_tensor(tt_inputs_host, tt_image_res, 1)
+    ttnn.record_event(device, 1, write_event)
+    ttnn.wait_for_event(device, 0, write_event)
+    test_infra.input_tensor = ttnn.to_memory_config(tt_image_res, input_mem_config)
+    ttnn.record_event(device, 0, op_event)
+    test_infra.run()
+    test_infra.validate()
+
+    # Optimized run
+    ttnn.wait_for_event(device, 1, op_event)
+    ttnn.copy_host_to_device_tensor(tt_inputs_host, tt_image_res, 1)
+    ttnn.record_event(device, 1, write_event)
+    ttnn.wait_for_event(device, 0, write_event)
+    test_infra.input_tensor = ttnn.to_memory_config(tt_image_res, input_mem_config)
+    first_out_addr = test_infra.input_tensor.buffer_address()
+    ttnn.record_event(device, 0, op_event)
+    test_infra.run()
+    test_infra.validate()
+
+    # Capture
+    ttnn.wait_for_event(device, 1, op_event)
+    ttnn.copy_host_to_device_tensor(tt_inputs_host, tt_image_res, 1)
+    ttnn.record_event(device, 1, write_event)
+    ttnn.wait_for_event(device, 0, write_event)
+    test_infra.input_tensor = ttnn.to_memory_config(tt_image_res, input_mem_config)
+    ttnn.record_event(device, 0, op_event)
+    tid = ttnn.begin_trace_capture(device, cq_id=0)
+    test_infra.run()
+    test_infra.input_tensor = ttnn.allocate_tensor_on_device(
+        test_infra.input_tensor.shape,
+        test_infra.input_tensor.dtype,
+        test_infra.input_tensor.layout,
+        device,
+        input_mem_config,
+    )
+    ttnn.end_trace_capture(device, tid, cq_id=0)
+    assert first_out_addr == test_infra.input_tensor.buffer_address()
+    test_infra.validate()
+
+    # More optimized run with caching
+    if use_signpost:
+        signpost(header="start")
+    outputs = []
+    for iter in range(0, 1):
+        ttnn.wait_for_event(device, 1, op_event)
+        ttnn.copy_host_to_device_tensor(tt_inputs_host, tt_image_res, 1)
+        ttnn.record_event(device, 1, write_event)
+        ttnn.wait_for_event(device, 0, write_event)
+        # TODO: Add in place support to ttnn to_memory_config
+        test_infra.input_tensor = ttnn.experimental.tensor.reshard(
+            tt_image_res, input_mem_config, test_infra.input_tensor
+        )
+        ttnn.record_event(device, 0, op_event)
+        ttnn.execute_trace(device, tid, cq_id=0, blocking=False)
+        outputs.append(ttnn.from_device(test_infra.output_tensor, blocking=False))
+
+    ttnn.device.synchronize_device(device)
+    if use_signpost:
+        signpost(header="stop")
+    for output in outputs:
+        test_infra.validate(output)

--- a/models/experimental/resnet/tt/custom_preprocessing.py
+++ b/models/experimental/resnet/tt/custom_preprocessing.py
@@ -1,0 +1,58 @@
+# SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
+
+# SPDX-License-Identifier: Apache-2.0
+
+import torch
+import torchvision
+
+import ttnn
+from ttnn.model_preprocessing import (
+    fold_batch_norm2d_into_conv2d,
+    convert_torch_model_to_ttnn_model,
+)
+from models.utility_functions import pad_and_fold_conv_filters_for_unity_stride
+
+
+def preprocess_conv_parameter(parameter, *, dtype):
+    parameter = ttnn.from_torch(parameter, dtype=dtype, layout=ttnn.TILE_LAYOUT)
+    return parameter
+
+
+def custom_preprocessor(model, name, ttnn_module_args, convert_to_ttnn):
+    parameters = {}
+    if isinstance(model, torchvision.models.resnet.Bottleneck):
+        conv1_weight, conv1_bias = fold_batch_norm2d_into_conv2d(model.conv1, model.bn1)
+        conv2_weight, conv2_bias = fold_batch_norm2d_into_conv2d(model.conv2, model.bn2)
+        conv3_weight, conv3_bias = fold_batch_norm2d_into_conv2d(model.conv3, model.bn3)
+        parameters["conv1"] = {}
+        parameters["conv2"] = {}
+        parameters["conv3"] = {}
+        parameters["conv1"]["weight"] = ttnn.from_torch(conv1_weight)
+        parameters["conv2"]["weight"] = ttnn.from_torch(conv2_weight)
+        parameters["conv3"]["weight"] = ttnn.from_torch(conv3_weight)
+        parameters["conv1"]["bias"] = ttnn.from_torch(torch.reshape(conv1_bias, (1, 1, 1, -1)))
+        parameters["conv2"]["bias"] = ttnn.from_torch(torch.reshape(conv2_bias, (1, 1, 1, -1)))
+        parameters["conv3"]["bias"] = ttnn.from_torch(torch.reshape(conv3_bias, (1, 1, 1, -1)))
+        if model.downsample is not None:
+            downsample_weight, downsample_bias = fold_batch_norm2d_into_conv2d(model.downsample[0], model.downsample[1])
+            parameters["downsample"] = {}
+            parameters["downsample"]["weight"] = ttnn.from_torch(downsample_weight)
+            parameters["downsample"]["bias"] = ttnn.from_torch(torch.reshape(downsample_bias, (1, 1, 1, -1)))
+    elif isinstance(model, torchvision.models.resnet.ResNet):
+        conv1_weight, conv1_bias = fold_batch_norm2d_into_conv2d(model.conv1, model.bn1)
+        conv1_weight = pad_and_fold_conv_filters_for_unity_stride(conv1_weight, 2, 2)
+        parameters["conv1"] = {}
+        parameters["conv1"]["weight"] = ttnn.from_torch(conv1_weight)
+        parameters["conv1"]["bias"] = ttnn.from_torch(torch.reshape(conv1_bias, (1, 1, 1, -1)))
+        named_parameters = tuple((name, parameter) for name, parameter in model.named_parameters() if "." not in name)
+        for child_name, child in tuple(model.named_children()) + named_parameters:
+            if child_name in {"conv1", "bn1"}:
+                continue
+            parameters[child_name] = convert_torch_model_to_ttnn_model(
+                child,
+                name=name,
+                custom_preprocessor=custom_preprocessor,
+                convert_to_ttnn=convert_to_ttnn,
+                ttnn_module_args=ttnn_module_args,
+            )
+    return parameters

--- a/models/experimental/resnet/tt/ttnn_functional_resnet50_new_conv_api.py
+++ b/models/experimental/resnet/tt/ttnn_functional_resnet50_new_conv_api.py
@@ -329,7 +329,9 @@ class resnet50Bottleneck:
             conv_op_cache=conv_op_cache,
         )
 
-        logger.info(f"{batch_size} and {input_height} and {self.conv1_input_channels} and {self.conv1_output_channels}")
+        logger.debug(
+            f"{batch_size} and {input_height} and {self.conv1_input_channels} and {self.conv1_output_channels}"
+        )
 
         if (
             is_wormhole_b0()
@@ -424,6 +426,8 @@ class resnet50:
         parameters,
         batch_size,
         model_config,
+        dealloc_input=True,
+        final_output_mem_config=ttnn.L1_MEMORY_CONFIG,
     ) -> None:
         super().__init__()
         layers = [3, 4, 6, 3]
@@ -435,6 +439,7 @@ class resnet50:
         self.model_config = model_config
         self.conv_op_cache = {}
         self.inplanes = 64
+        self.final_output_mem_config = final_output_mem_config
         if is_grayskull():
             compute_kernel_config = ttnn.GrayskullComputeKernelConfig(
                 math_fidelity=model_config["MATH_FIDELITY"],
@@ -536,6 +541,39 @@ class resnet50:
             compute_kernel_config=compute_kernel_config,
         )  # num_classes = 1000
 
+        self.transpose_shards = True
+        if is_wormhole_b0():
+            self.transpose_shards = False
+            if batch_size == 16:
+                act_block_h_override = 1568
+            elif batch_size == 20:
+                act_block_h_override = 640
+        else:
+            act_block_h_override = 0
+        input_channels_alignment = 16 if not is_wormhole_b0() else 32
+        self.conv1_config = ttnn.Conv2dConfig(
+            dtype=self.model_config["ACTIVATIONS_DTYPE"],
+            weights_dtype=self.model_config["WEIGHTS_DTYPE"],
+            math_fidelity=self.model_config["MATH_FIDELITY"],
+            activation="relu",
+            deallocate_activation=dealloc_input,
+            input_channels_alignment=input_channels_alignment,
+            act_block_h_override=act_block_h_override,
+            transpose_shards=self.transpose_shards,
+        )
+
+        self.conv1_kernel_size = (4, 4)
+        self.conv1_stride = (1, 1)
+        self.conv1_padding = (0, 0)
+        self.conv1_input_height = 115
+        self.conv1_input_width = 115
+        self.conv1_output_height = (
+            (self.conv1_input_height - self.conv1_kernel_size[0] + 2 * self.conv1_padding[0]) // self.conv1_stride[0]
+        ) + 1
+        self.conv1_output_width = (
+            (self.conv1_input_width - self.conv1_kernel_size[1] + 2 * self.conv1_padding[1]) // self.conv1_stride[1]
+        ) + 1
+
     def __del__(self):
         # Need to clear global configs for each Resnet run
         self.conv_op_cache.clear()
@@ -584,31 +622,19 @@ class resnet50:
         input_tensor = ttnn.from_torch(input_tensor, dtype=ttnn.bfloat16)
         return input_tensor
 
-    def __call__(self, input_tensor, device, batch_size, ops_parallel_config) -> ttnn.Tensor:
+    def __call__(self, input_tensor, device, ops_parallel_config) -> ttnn.Tensor:
         return self.run(
-            input_tensor, device, batch_size, ops_parallel_config, {} if not ops_parallel_config else self.conv_op_cache
+            input_tensor, device, ops_parallel_config, {} if not ops_parallel_config else self.conv_op_cache
         )
 
     ## merged runs (first and optimized)
-    def run(self, input_tensor, device, batch_size, ops_parallel_config, conv_op_cache={}) -> ttnn.Tensor:
+    def run(self, input_tensor, device, ops_parallel_config, conv_op_cache={}) -> ttnn.Tensor:
         is_first_run = False
         if not ops_parallel_config:
             is_first_run = True
             logger.debug(f"==== First run")
         else:
             logger.debug(f"==== Optimized run")
-
-        transpose_shards = True
-        if is_wormhole_b0():
-            transpose_shards = False
-
-        if is_wormhole_b0():
-            if batch_size == 16:
-                act_block_h_override = 1568
-            elif batch_size == 20:
-                act_block_h_override = 640
-        else:
-            act_block_h_override = 0
 
         x, x_height, x_width, self.conv1_weight_tensor, self.conv1_bias_tensor = ttnn.conv2d(
             input_tensor=input_tensor,
@@ -617,22 +643,13 @@ class resnet50:
             out_channels=self.conv1_output_channels,
             device=device,
             bias_tensor=self.conv1_bias_tensor,
-            kernel_size=(4, 4),
-            stride=(1, 1),
-            padding=(0, 0),
+            kernel_size=self.conv1_kernel_size,
+            stride=self.conv1_stride,
+            padding=self.conv1_padding,
             batch_size=self.batch_size,
-            input_height=115,
-            input_width=115,
-            conv_config=ttnn.Conv2dConfig(
-                dtype=self.model_config["ACTIVATIONS_DTYPE"],
-                weights_dtype=self.model_config["WEIGHTS_DTYPE"],
-                math_fidelity=self.model_config["MATH_FIDELITY"],
-                activation="relu",
-                deallocate_activation=True,
-                input_channels_alignment=16 if not is_wormhole_b0() else 32,
-                act_block_h_override=act_block_h_override,
-                transpose_shards=transpose_shards,
-            ),
+            input_height=self.conv1_input_height,
+            input_width=self.conv1_input_width,
+            conv_config=self.conv1_config,
             conv_op_cache=conv_op_cache,
         )
         # Relu is fused with conv1
@@ -680,13 +697,13 @@ class resnet50:
         x, x_height, x_width = self.layer1_module1(
             x,
             device,
-            batch_size,
+            self.batch_size,
             x_height,
             x_width,
             conv_op_cache,
             reshard_if_not_optimal=reshard,
             height_sharding=height_shard,
-            transpose_shards=transpose_shards,
+            transpose_shards=self.transpose_shards,
         )
 
         if is_first_run:
@@ -701,12 +718,12 @@ class resnet50:
 
         logger.debug(f"==== Running layer 1 module 2")
         x, x_height, x_width = self.layer1_module2(
-            x, device, batch_size, x_height, x_width, conv_op_cache, transpose_shards=transpose_shards
+            x, device, self.batch_size, x_height, x_width, conv_op_cache, transpose_shards=self.transpose_shards
         )
 
         logger.debug(f"==== Running layer 1 module 3")
         x, x_height, x_width = self.layer1_module3(
-            x, device, batch_size, x_height, x_width, conv_op_cache, transpose_shards=transpose_shards
+            x, device, self.batch_size, x_height, x_width, conv_op_cache, transpose_shards=self.transpose_shards
         )
 
         if self.batch_size == 20 and is_wormhole_b0():
@@ -727,13 +744,13 @@ class resnet50:
         x, x_height, x_width = self.layer2_module1(
             x,
             device,
-            batch_size,
+            self.batch_size,
             x_height,
             x_width,
             conv_op_cache,
             reshard_if_not_optimal=reshard,
             height_sharding=height_shard,
-            transpose_shards=transpose_shards,
+            transpose_shards=self.transpose_shards,
         )
 
         if is_first_run:
@@ -748,17 +765,17 @@ class resnet50:
 
         logger.debug(f"==== Running layer 2 module 2")
         x, x_height, x_width = self.layer2_module2(
-            x, device, batch_size, x_height, x_width, conv_op_cache, transpose_shards=transpose_shards
+            x, device, self.batch_size, x_height, x_width, conv_op_cache, transpose_shards=self.transpose_shards
         )
 
         logger.debug(f"==== Running layer 2 module 3")
         x, x_height, x_width = self.layer2_module3(
-            x, device, batch_size, x_height, x_width, conv_op_cache, transpose_shards=transpose_shards
+            x, device, self.batch_size, x_height, x_width, conv_op_cache, transpose_shards=self.transpose_shards
         )
 
         logger.debug(f"==== Running layer 2 module 4")
         x, x_height, x_width = self.layer2_module4(
-            x, device, batch_size, x_height, x_width, conv_op_cache, transpose_shards=transpose_shards
+            x, device, self.batch_size, x_height, x_width, conv_op_cache, transpose_shards=self.transpose_shards
         )
 
         layer3_module1_input_shape = ttnn.Shape(x.get_legacy_shape())
@@ -775,13 +792,13 @@ class resnet50:
         x, x_height, x_width = self.layer3_module1(
             x,
             device,
-            batch_size,
+            self.batch_size,
             x_height,
             x_width,
             conv_op_cache,
             reshard_if_not_optimal=reshard,
             height_sharding=height_shard,
-            transpose_shards=transpose_shards,
+            transpose_shards=self.transpose_shards,
         )
 
         if is_first_run:
@@ -796,37 +813,37 @@ class resnet50:
 
         logger.debug(f"==== Running layer 3 module 2")
         x, x_height, x_width = self.layer3_module2(
-            x, device, batch_size, x_height, x_width, conv_op_cache, transpose_shards=transpose_shards
+            x, device, self.batch_size, x_height, x_width, conv_op_cache, transpose_shards=self.transpose_shards
         )
 
         logger.debug(f"==== Running layer 3 module 3")
         x, x_height, x_width = self.layer3_module3(
-            x, device, batch_size, x_height, x_width, conv_op_cache, transpose_shards=transpose_shards
+            x, device, self.batch_size, x_height, x_width, conv_op_cache, transpose_shards=self.transpose_shards
         )
 
         logger.debug(f"==== Running layer 3 module 4")
         x, x_height, x_width = self.layer3_module4(
-            x, device, batch_size, x_height, x_width, conv_op_cache, transpose_shards=transpose_shards
+            x, device, self.batch_size, x_height, x_width, conv_op_cache, transpose_shards=self.transpose_shards
         )
 
         logger.debug(f"==== Running layer 3 module 5")
         x, x_height, x_width = self.layer3_module5(
-            x, device, batch_size, x_height, x_width, conv_op_cache, transpose_shards=transpose_shards
+            x, device, self.batch_size, x_height, x_width, conv_op_cache, transpose_shards=self.transpose_shards
         )
 
         logger.debug(f"==== Running layer 3 module 6")
         x, x_height, x_width = self.layer3_module6(
             x,
             device,
-            batch_size,
+            self.batch_size,
             x_height,
             x_width,
             conv_op_cache,
             eltwise_binary_out_in_place=False,
-            transpose_shards=transpose_shards,
+            transpose_shards=self.transpose_shards,
         )
 
-        if is_wormhole_b0() and batch_size == 16:
+        if is_wormhole_b0() and self.batch_size == 16:
             xshape = x.shape_without_padding()
             ## NOTE: using multicore untilize_with_unpadding results in PCC error
             x = ttnn.experimental.tensor.untilize_with_unpadding(
@@ -867,13 +884,13 @@ class resnet50:
         x, x_height, x_width = self.layer4_module1(
             x,
             device,
-            batch_size,
+            self.batch_size,
             x_height,
             x_width,
             conv_op_cache,
             reshard_if_not_optimal=reshard,
             height_sharding=height_shard,
-            transpose_shards=transpose_shards,
+            transpose_shards=self.transpose_shards,
         )
 
         if is_first_run:
@@ -888,12 +905,12 @@ class resnet50:
 
         logger.debug(f"==== Running layer 4 module 2")
         x, x_height, x_width = self.layer4_module2(
-            x, device, batch_size, x_height, x_width, conv_op_cache, transpose_shards=transpose_shards
+            x, device, self.batch_size, x_height, x_width, conv_op_cache, transpose_shards=self.transpose_shards
         )
 
         logger.debug(f"==== Running layer 4 module 3")
         x, x_height, x_width = self.layer4_module3(
-            x, device, batch_size, x_height, x_width, conv_op_cache, transpose_shards=transpose_shards
+            x, device, self.batch_size, x_height, x_width, conv_op_cache, transpose_shards=self.transpose_shards
         )
 
         unpadded_shape = x.shape_without_padding()
@@ -985,7 +1002,7 @@ class resnet50:
         x = ttnn.experimental.tensor.untilize_with_unpadding(
             x,
             (desired_shape[0] - 1, desired_shape[1] - 1, desired_shape[2] - 1, desired_shape[3] - 1),
-            ttnn.L1_MEMORY_CONFIG,
+            self.final_output_mem_config,
         )
         x = ttnn.reshape(
             x,

--- a/tests/nightly/wh_b0_only_eth/models/experimental/resnet/tests/test_ttnn_resnet50_performant.py
+++ b/tests/nightly/wh_b0_only_eth/models/experimental/resnet/tests/test_ttnn_resnet50_performant.py
@@ -1,0 +1,1 @@
+../../../../../../../models/experimental/resnet/tests/test_ttnn_resnet50_performant.py

--- a/tests/scripts/run_performance.sh
+++ b/tests/scripts/run_performance.sh
@@ -11,7 +11,7 @@ run_perf_models_other() {
     local tt_arch=$1
     local test_marker=$2
 
-    env pytest -n auto tests/ttnn/integration_tests/resnet/test_performance.py -m $test_marker
+    env WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml pytest models/experimental/resnet/tests -m $test_marker
 
     env pytest -n auto tests/ttnn/integration_tests/bert/test_performance.py -m $test_marker
 
@@ -59,6 +59,8 @@ run_device_perf_models() {
     set -eo pipefail
     local test_marker=$1
 
+    env WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml pytest models/experimental/resnet/tests -m $test_marker
+
     env pytest tests/device_perf_tests/stable_diffusion -m $test_marker --timeout=600
 
     if [ "$tt_arch" == "grayskull" ]; then
@@ -73,8 +75,6 @@ run_device_perf_models() {
         env pytest models/demos/bert/tests -m $test_marker
 
         env pytest models/demos/wormhole/mistral7b/tests -m $test_marker
-
-        env pytest "tests/ttnn/integration_tests/resnet/test_performance.py" -m $test_marker
 
         env pytest models/demos/resnet/tests -m $test_marker
     fi

--- a/tt_eager/tensor/types.cpp
+++ b/tt_eager/tensor/types.cpp
@@ -56,11 +56,27 @@ Padding::Padding(const std::vector<PadDimension>& pad_dimensions, PadValue pad_v
     std::copy(std::begin(pad_dimensions), std::end(pad_dimensions), std::begin(this->pad_dimensions_));
 }
 
-Padding::PadDimension& Padding::operator[](const std::int64_t index) {
-    return this->pad_dimensions_[index];
+const uint32_t Padding::get_normalized_index(std::int64_t index) const {
+    std::int64_t rank = static_cast<std::int64_t>(this->rank_);
+    std::uint64_t normalized_index = index >= 0 ? index : rank + index;
+    TT_ASSERT(
+        normalized_index >= 0 and normalized_index < rank,
+        fmt::format(
+            "Index is out of bounds for the rank, should be between 0 and {} however is {}",
+            rank - 1,
+            normalized_index));
+    return normalized_index;
 }
 
-const Padding::PadDimension Padding::operator[](const std::int64_t index) const { return this->pad_dimensions_[index]; }
+Padding::PadDimension& Padding::operator[](const std::int64_t index) {
+    auto normalized_index = this->get_normalized_index(index);
+    return this->pad_dimensions_[normalized_index];
+}
+
+const Padding::PadDimension Padding::operator[](const std::int64_t index) const {
+    auto normalized_index = this->get_normalized_index(index);
+    return this->pad_dimensions_[normalized_index];
+}
 
 Padding::PadValue Padding::pad_value() const { return this->pad_value_; }
 

--- a/tt_eager/tensor/types.hpp
+++ b/tt_eager/tensor/types.hpp
@@ -107,6 +107,8 @@ struct Padding {
         }
     }
 
+    const uint32_t get_normalized_index(std::int64_t index) const;
+
     PadDimension &operator[](const std::int64_t index);
     const PadDimension operator[](const std::int64_t index) const;
 

--- a/tt_metal/impl/device/device.cpp
+++ b/tt_metal/impl/device/device.cpp
@@ -1805,10 +1805,12 @@ void Device::update_dispatch_cores_for_multi_cq_eth_dispatch() {
     // When running Multiple CQs using Ethernet Dispatch, we may need more dispatch cores than those allocated in the
     // core descriptor (ex: 2 CQs on N300 need 10 dispatch cores and the core descriptor only allocates 6).
     // Infer the remaining dispatch cores from the idle eth core list (this is device dependent).
-    if (dispatch_core_manager::get(this->num_hw_cqs()).get_dispatch_core_type(this->id()) == CoreType::ETH) {
-        auto& dispatch_core_manager = dispatch_core_manager::get(this->num_hw_cqs());
-        for (const auto& idle_eth_core : this->get_inactive_ethernet_cores()) {
-            dispatch_core_manager.add_dispatch_core_to_device(this->id(), idle_eth_core);
+    for (uint8_t num_hw_cqs = 1; num_hw_cqs <= Device::max_num_hw_cqs; ++num_hw_cqs) {
+        if (dispatch_core_manager::get(num_hw_cqs).get_dispatch_core_type(this->id()) == CoreType::ETH) {
+            auto& dispatch_core_manager = dispatch_core_manager::get(num_hw_cqs);
+            for (const auto& idle_eth_core : this->get_inactive_ethernet_cores()) {
+                dispatch_core_manager.add_dispatch_core_to_device(this->id(), idle_eth_core);
+            }
         }
     }
 }

--- a/ttnn/cpp/pybind11/operations/conv2d.hpp
+++ b/ttnn/cpp/pybind11/operations/conv2d.hpp
@@ -94,6 +94,29 @@ void py_module(py::module& module) {
         py_conv_config.def_readwrite("core_grid", &Conv2dConfig::core_grid);
         py_conv_config.def_readwrite("transpose_shards", &Conv2dConfig::transpose_shards);
         py_conv_config.def_readwrite("output_layout", &Conv2dConfig::output_layout);
+
+    module.def(
+        "get_conv_padded_input_shape_and_mem_config",
+        [](ttnn::Device& device,
+            const ttnn::Tensor& input_tensor,
+            const Conv2dConfig& conv_config,
+            uint32_t batch_size,
+            uint32_t height,
+            uint32_t width,
+            uint32_t in_channels,
+            uint32_t out_channels) -> std::tuple<ttnn::Shape, ttnn::MemoryConfig, bool> {
+            return ttnn::operations::conv2d::get_conv_padded_input_shape_and_mem_config(
+                device, input_tensor, conv_config, batch_size, height, width, in_channels, out_channels);
+        },
+        py::kw_only(),
+        py::arg("device"),
+        py::arg("input_tensor"),
+        py::arg("conv_config"),
+        py::arg("batch_size"),
+        py::arg("height"),
+        py::arg("width"),
+        py::arg("in_channels"),
+        py::arg("out_channels"));
 }
 
 }  // namespace conv2d

--- a/ttnn/cpp/ttnn/operations/conv2d.hpp
+++ b/ttnn/cpp/ttnn/operations/conv2d.hpp
@@ -111,6 +111,8 @@ std::pair<uint32_t, uint32_t> determine_largest_subblock_size(uint32_t block_hei
 
 tt::tt_metal::OptimizedConvBlockConfig determine_per_core_conv_block_config(const ParallelConfig& parallel_config, const tt::tt_metal::OptimizedConvParallelizationConfig& conv_op_parallel_config, uint32_t padded_in_channels, uint32_t act_block_h_override, uint32_t window_w, bool fp32_accum, bool use_shallow_conv_variant);
 
+std::tuple<ttnn::Shape, ttnn::MemoryConfig, bool> get_conv_padded_input_shape_and_mem_config(Device& device, const ttnn::Tensor& input_tensor_, const Conv2dConfig& conv_config, uint32_t batch_size, uint32_t height, uint32_t width, uint32_t in_channels, uint32_t out_channels);
+
 std::tuple<ttnn::Tensor, ParallelConfig, bool>  shard_or_reshard_tensor_if_required(Device& device, const ttnn::Tensor& input_tensor_, const Conv2dConfig& conv_config, uint32_t batch_size, uint32_t height, uint32_t width, uint32_t in_channels, uint32_t out_channels);
 
 void validate_weight_and_bias_tensors(const ttnn::Tensor& weight_tensor, std::optional<const ttnn::Tensor>& bias_tensor);

--- a/ttnn/cpp/ttnn/operations/data_movement/slice/device/slice_op.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/slice/device/slice_op.cpp
@@ -70,7 +70,7 @@ void Slice::validate_with_output_tensors(
     TT_FATAL(input_tensor_a.storage_type() == StorageType::DEVICE, "Operands to unpad need to be on device!");
     TT_FATAL(input_tensor_a.buffer() != nullptr, "Operands to unpad need to be allocated in buffers on device!");
     TT_FATAL(input_tensor_a.get_layout() == Layout::TILE || input_tensor_a.get_layout() == Layout::ROW_MAJOR);
-
+    TT_FATAL(input_tensor_a.get_legacy_shape().rank() == this->slice_start.rank() && this->slice_start.rank() == this->slice_end.rank());
     for (uint32_t i = 0; i < input_tensor_a.get_legacy_shape().rank(); i++) {
         TT_FATAL(this->slice_start[i] < input_tensor_a.get_legacy_shape()[i]);
         TT_FATAL(this->slice_end[i] < input_tensor_a.get_legacy_shape()[i]);

--- a/ttnn/cpp/ttnn/operations/data_movement/slice/slice.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/slice/slice.hpp
@@ -4,56 +4,65 @@
 
 #pragma once
 
-#include "ttnn/decorators.hpp"
-#include "ttnn/cpp/ttnn/operations/core.hpp"
-
-
-#include "tt_eager/tt_dnn/op_library/run_operation.hpp"
 #include "device/slice_op.hpp"
+#include "tt_eager/tt_dnn/op_library/run_operation.hpp"
+#include "ttnn/cpp/ttnn/operations/core.hpp"
+#include "ttnn/decorators.hpp"
 
 namespace ttnn {
 namespace operations {
 namespace data_movement {
 
-
-
 struct ExecuteSlice {
-
     static ttnn::Tensor execute_on_worker_thread(
         uint8_t queue_id,
         const ttnn::Tensor& input_tensor,
         tt::tt_metal::Shape output_tensor_start,
         tt::tt_metal::Shape output_tensor_end,
         const std::optional<MemoryConfig>& memory_config_arg) {
-
         auto memory_config = memory_config_arg.value_or(input_tensor.memory_config());
 
+        // TODO: Generalize this early exit of slice for other cases
+        auto& input_tensor_shape = input_tensor.get_legacy_shape();
+        if (input_tensor.is_sharded() && input_tensor.memory_config() == memory_config &&
+            input_tensor_shape.rank() > 1 && input_tensor_shape.rank() == output_tensor_start.rank() &&
+            output_tensor_start.rank() == output_tensor_end.rank()) {
+            uint32_t i;
+            // Require all leading dims to be 1 (TODO: This can be relaxed to support outermost non-1 dim unpadding)
+            bool in_place_unpad = true;
+            for (i = 0; i < input_tensor.get_legacy_shape().rank() - 2; ++i) {
+                in_place_unpad &=
+                    output_tensor_start[i] == 0 && output_tensor_end[i] == 0 && input_tensor_shape[i] == 1;
+            }
+            in_place_unpad &= output_tensor_start[i] == 0 &&
+                              tt::div_up(output_tensor_end[i] + 1, input_tensor.shard_spec().value().shape[0]) ==
+                                  tt::div_up(input_tensor_shape[i], input_tensor.shard_spec().value().shape[0]);
+            i++;
+            in_place_unpad &= output_tensor_start[i] == 0 && output_tensor_end[i] == input_tensor_shape[i] - 1;
+            if (in_place_unpad) {
+                auto new_shape = input_tensor.get_legacy_shape();
+                auto new_pad = new_shape.padding();
+
+                std::size_t unpad_val = input_tensor_shape[-2] - output_tensor_end[-2] - 1;
+                new_shape[-2] -= unpad_val;
+                new_pad[-2].back -= std::min(unpad_val, new_pad[-2].back);
+                auto padded_shape = ttnn::Shape(tt::tt_metal::Shape(new_shape, new_pad));
+                return Tensor(input_tensor.storage(), padded_shape, input_tensor.dtype(), input_tensor.layout());
+            }
+        }
+
         return operation::run(
-                   Slice{output_tensor_start, output_tensor_end, memory_config},
-                   {input_tensor}, {}, {}, queue_id)
+                   Slice{output_tensor_start, output_tensor_end, memory_config}, {input_tensor}, {}, {}, queue_id)
             .at(0);
-
     }
-
 
     static ttnn::Tensor execute_on_worker_thread(
         const ttnn::Tensor& input_tensor,
         tt::tt_metal::Shape output_tensor_start,
         tt::tt_metal::Shape output_tensor_end,
-        const std::optional<MemoryConfig>& memory_config_arg
-        ) {
-
-        
-        return execute_on_worker_thread(
-                0, 
-                input_tensor, 
-                output_tensor_start, 
-                output_tensor_end, 
-                memory_config_arg
-                );
-        
+        const std::optional<MemoryConfig>& memory_config_arg) {
+        return execute_on_worker_thread(0, input_tensor, output_tensor_start, output_tensor_end, memory_config_arg);
     }
-
 
     static ttnn::Tensor execute_on_worker_thread(
         uint8_t queue_id,
@@ -61,14 +70,12 @@ struct ExecuteSlice {
         std::vector<uint32_t> output_tensor_start,
         std::vector<uint32_t> output_tensor_end,
         const std::optional<MemoryConfig>& memory_config_arg) {
-
-        return execute_on_worker_thread(queue_id, 
-                input_tensor, 
-                tt::tt_metal::Shape(output_tensor_start), 
-                tt::tt_metal::Shape(output_tensor_end), 
-                memory_config_arg
-                );
-
+        return execute_on_worker_thread(
+            queue_id,
+            input_tensor,
+            tt::tt_metal::Shape(output_tensor_start),
+            tt::tt_metal::Shape(output_tensor_end),
+            memory_config_arg);
     }
 
     static ttnn::Tensor execute_on_worker_thread(
@@ -76,16 +83,8 @@ struct ExecuteSlice {
         std::vector<uint32_t> output_tensor_start,
         std::vector<uint32_t> output_tensor_end,
         const std::optional<MemoryConfig>& memory_config_arg) {
-
-        return execute_on_worker_thread(
-                0, 
-                input_tensor, 
-                output_tensor_start, 
-                output_tensor_end, 
-                memory_config_arg
-                );
+        return execute_on_worker_thread(0, input_tensor, output_tensor_start, output_tensor_end, memory_config_arg);
     }
-
 
     static ttnn::Tensor execute_on_worker_thread(
         uint8_t queue_id,
@@ -93,30 +92,20 @@ struct ExecuteSlice {
         const ttnn::Shape output_tensor_start,
         const ttnn::Shape output_tensor_end,
         const std::optional<MemoryConfig>& memory_config_arg) {
-
         std::vector<uint32_t> output_tensor_start_vec(output_tensor_start.rank());
         std::vector<uint32_t> output_tensor_end_vec(output_tensor_end.rank());
 
-        for(uint32_t dim = 0; dim<output_tensor_start.rank(); dim++) {
+        for (uint32_t dim = 0; dim < output_tensor_start.rank(); dim++) {
             output_tensor_start_vec[dim] = output_tensor_start[dim];
         }
-        
-        for(uint32_t dim = 0; dim<output_tensor_end.rank(); dim++) {
+
+        for (uint32_t dim = 0; dim < output_tensor_end.rank(); dim++) {
             output_tensor_end_vec[dim] = output_tensor_end[dim];
         }
 
         return execute_on_worker_thread(
-                queue_id, 
-                input_tensor, 
-                output_tensor_start_vec, 
-                output_tensor_end_vec, 
-                memory_config_arg
-                );
-
-
+            queue_id, input_tensor, output_tensor_start_vec, output_tensor_end_vec, memory_config_arg);
     }
-
-
 };
 
 }  // namespace data_movement

--- a/ttnn/ttnn/__init__.py
+++ b/ttnn/ttnn/__init__.py
@@ -310,5 +310,5 @@ from ttnn.operations.normalization import (
     create_group_norm_input_mask,
     determine_expected_group_norm_sharded_config_and_grid_size,
 )
-from ttnn.operations.conv2d import Conv2d, Conv2dConfig, get_conv_output_dim
+from ttnn.operations.conv2d import Conv2d, Conv2dConfig, get_conv_output_dim, get_conv_padded_input_shape_and_mem_config
 from ttnn.operations.pool import MaxPool2d

--- a/ttnn/ttnn/operations/conv2d.py
+++ b/ttnn/ttnn/operations/conv2d.py
@@ -31,6 +31,8 @@ def _nearest_32(x):
 
 Conv2dConfig = ttnn._ttnn.operations.conv2d.Conv2dConfig
 
+get_conv_padded_input_shape_and_mem_config = ttnn._ttnn.operations.conv2d.get_conv_padded_input_shape_and_mem_config
+
 
 class Conv2d:
     def __init__(


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/10020

### Problem description
Adding trace and multi cq versions of Resnet for WH

### What's changed
Refactored out logic for padding/sharding for first conv to allow for preprocessing needed for trace/multi cq

### Checklist
- [x] Post commit CI passes https://github.com/tenstorrent/tt-metal/actions/runs/9845333911
- [x] Model regression CI testing passes (if applicable)
- [x] New/Existing tests provide coverage for changes
