### PR TITLE
#9492: update matmul path in CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -111,7 +111,7 @@ tests/scripts/run_performance.sh @tt-rkim
 # **/tensor/**/module.mk @tt-rkim @TT-BrianLiu @tt-aho @arakhmati
 
 # eager - ops (dnn)
-tt_eager/tt_dnn/op_library/bmm/ @TT-BrianLiu @bbradelTT @yugaoTT
+ttnn/cpp/ttnn/operations/matmul/ @TT-BrianLiu @bbradelTT @yugaoTT
 
 # eager - tensor and op infra
 tt_eager/tt_dnn/op_library/ccl/ @SeanNijjar

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -110,9 +110,6 @@ tests/scripts/run_performance.sh @tt-rkim
 # **/tensor/ @TT-BrianLiu @tt-aho @arakhmati
 # **/tensor/**/module.mk @tt-rkim @TT-BrianLiu @tt-aho @arakhmati
 
-# eager - ops (dnn)
-ttnn/cpp/ttnn/operations/matmul/ @TT-BrianLiu @bbradelTT @yugaoTT
-
 # eager - tensor and op infra
 tt_eager/tt_dnn/op_library/ccl/ @SeanNijjar
 tt_eager/tt_dnn/op_library/operation_history.*pp @arakhmati @eyonland @cfjchu @xanderchin
@@ -132,6 +129,7 @@ ttnn/ @eyonland @arakhmati @cfjchu @xanderchin @TT-BrianLiu @ayerofieiev-tt
 ttnn/setup.py @tt-rkim
 ttnn/module.mk @tt-rkim
 ttnn/CMakeLists.txt @tt-rkim @ayerofieiev-tt
+ttnn/cpp/ttnn/operations/matmul/ @TT-BrianLiu @bbradelTT @yugaoTT
 tests/ttnn/ @eyonland @arakhmati @cfjchu @xanderchin @TT-BrianLiu @ayerofieiev-tt
 
 # models


### PR DESCRIPTION
### Ticket
Link to Github Issue https://github.com/tenstorrent/tt-metal/issues/9492

### Problem description
- We're moving ops to ttnn

### What's changed
- The path for matmul has changed. Need to update CODEOWNERS to reflect the change.

### Checklist
- [ ] Post commit CI passes N/A
- [ ] Model regression CI testing passes (if applicable) N/A
- [ ] New/Existing tests provide coverage for changes N/A
