### PR TITLE
#10031: Fix -Werror=return-type error in composite_ops

### DIFF
--- a/tt_eager/tt_dnn/op_library/composite/composite_ops.cpp
+++ b/tt_eager/tt_dnn/op_library/composite/composite_ops.cpp
@@ -499,8 +499,9 @@ Tensor _sinh(const Tensor& input_a, const MemoryConfig& output_mem_config) {
     e_neg_x.deallocate();
     Tensor scalar =
         ttnn::operations::creation::create_scalar(0.5f, input_a.get_dtype(), Layout::TILE, input_a.device());
-    return ttnn::multiply(nr_term, scalar, std::nullopt, output_mem_config);
+    Tensor result = ttnn::multiply(nr_term, scalar, std::nullopt, output_mem_config);
     scalar.deallocate();
+    return result;
 }
 Tensor sinh(const Tensor& input_a, const MemoryConfig& output_mem_config) {
     return operation::decorate_as_composite(__func__, _sinh)(input_a, output_mem_config);
@@ -515,8 +516,9 @@ Tensor _cosh(const Tensor& input_a, const MemoryConfig& output_mem_config) {
     e_neg_x.deallocate();
     Tensor scalar =
         ttnn::operations::creation::create_scalar(0.5f, input_a.get_dtype(), Layout::TILE, input_a.device());
-    return ttnn::multiply(nr_term, scalar, std::nullopt, output_mem_config);
+    Tensor result = ttnn::multiply(nr_term, scalar, std::nullopt, output_mem_config);
     scalar.deallocate();
+    return result;
 }
 Tensor cosh(const Tensor& input_a, const MemoryConfig& output_mem_config) {
     return operation::decorate_as_composite(__func__, _cosh)(input_a, output_mem_config);


### PR DESCRIPTION
### Ticket
[Link to Github Issue](https://github.com/tenstorrent/tt-metal/issues/10031)

### Problem description
When building the tt-metal project using g++-12, a compilation error occurs due to the -Werror=return-type flag.

### What's changed
The scalar.deallocate(); function is called before the return statement.

### Checklist
- [x] Post commit CI passes https://github.com/tenstorrent/tt-metal/actions/runs/9852080419
- [ ] Model regression CI testing passes (if applicable)
- [ ] New/Existing tests provide coverage for changes
