### PR TITLE
#10030: fix moreh_nll_loss hang

### DIFF
--- a/tests/tt_eager/python_api_testing/unit_testing/misc/test_moreh_nll_loss.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/misc/test_moreh_nll_loss.py
@@ -6,38 +6,16 @@ import torch
 
 import tt_lib as ttl
 import pytest
-from models.utility_functions import comp_allclose_and_pcc, is_wormhole_b0
+from models.utility_functions import comp_allclose_and_pcc
 from loguru import logger
 
-
-fp32_dest_acc_en = [
-    False,  # for grayskull
-]
-fp32_dest_acc_en_ids = ["fp32_dest_acc_en=False"]
-if is_wormhole_b0:
-    fp32_dest_acc_en.append(True)
-    fp32_dest_acc_en_ids.append("fp32_dest_acc_en=True")
-
-
-def get_compute_kernel_options(fp32_dest_acc_en):
-    if fp32_dest_acc_en is None:
-        return None
-
-    if is_wormhole_b0():
-        packer_l1_acc = False
-        compute_kernel_config = ttl.tensor.WormholeComputeKernelConfig(
-            math_fidelity=ttl.tensor.MathFidelity.HiFi4,
-            math_approx_mode=False,
-            fp32_dest_acc_en=fp32_dest_acc_en,
-            packer_l1_acc=packer_l1_acc,
-        )
-    else:
-        # Grayskull doesn't support fp32 but test passing a GS config is ok
-        compute_kernel_config = ttl.tensor.GrayskullComputeKernelConfig(
-            math_fidelity=ttl.tensor.MathFidelity.HiFi4,
-            math_approx_mode=True,
-        )
-    return compute_kernel_config
+from tests.tt_eager.python_api_testing.unit_testing.misc.test_utils import (
+    get_compute_kernel_options,
+    compute_kernel_options,
+    compute_kernel_ids,
+    to_cpu,
+    to_npu,
+)
 
 
 def get_torch_tensors(shape):
@@ -59,69 +37,19 @@ def get_torch_tensors(shape):
 def get_tt_tensors(torch_input, torch_target, torch_weight, torch_divisor, torch_output, device):
     C = torch_input.shape[1]
 
-    npu_dtype = ttl.tensor.DataType.BFLOAT16
     npu_index_dtype = ttl.tensor.DataType.INT32
-    npu_layout = ttl.tensor.Layout.TILE
-    npu_weight_layout = ttl.tensor.Layout.TILE
 
-    tt_input = ttl.tensor.Tensor(torch_input, npu_dtype).pad_to_tile(0).to(npu_layout).to(device)
-
-    if len(torch_target.shape) == 1:
-        N = torch_input.shape[0]
-        tt_target = ttl.tensor.Tensor(torch_target.reshape(1, N), npu_index_dtype)
-    else:
-        tt_target = ttl.tensor.Tensor(torch_target, npu_index_dtype)
-
-    tt_target = tt_target.pad_to_tile(0).to(npu_layout).to(device)
-
-    if torch_weight is not None:
-        tt_weight = (
-            ttl.tensor.Tensor(torch_weight.reshape(1, C), npu_dtype).pad_to_tile(0).to(npu_weight_layout).to(device)
-        )
-    else:
-        tt_weight = None
-
-    if torch_divisor is not None:
-        tt_divisor = (
-            ttl.tensor.Tensor(torch_divisor.reshape(1, 1), npu_dtype)
-            .pad_to_tile(float("nan"))
-            .to(npu_layout)
-            .to(device)
-        )
-    else:
-        tt_divisor = None
-
-    if torch_output is not None:
-        if len(torch_output.shape) == 1:
-            tt_output = ttl.tensor.Tensor(torch_output.reshape(1, torch_output.numel()), npu_dtype)
-        else:
-            tt_output = ttl.tensor.Tensor(torch_output, npu_dtype)
-
-        tt_output = tt_output.pad_to_tile(float("nan")).to(npu_layout).to(device)
-    else:
-        tt_output = None
+    tt_input = to_npu(torch_input, device)
+    tt_target = to_npu(torch_target, device, npu_dtype=npu_index_dtype)
+    tt_weight = to_npu(torch_weight, device)
+    tt_divisor = to_npu(torch_divisor, device)
+    tt_output = to_npu(torch_output, device)
 
     return tt_input, tt_target, tt_weight, tt_divisor, tt_output
 
 
-@pytest.mark.parametrize(
-    "shape",
-    [
-        (5, 10),
-        (500, 100),
-        (45, 100, 90),
-        (45, 100, 50, 60),
-        (5, 100, 2, 7, 50, 70),
-    ],
-)
-@pytest.mark.parametrize("ignore_index", [1])
-@pytest.mark.parametrize("reduction", ["mean", "sum"])
-@pytest.mark.parametrize("none_weight", [True, False])
-@pytest.mark.parametrize("fp32_dest_acc_en", fp32_dest_acc_en, ids=fp32_dest_acc_en_ids)
-def test_moreh_nll_loss(shape, ignore_index, reduction, none_weight, fp32_dest_acc_en, device, use_program_cache):
-    torch.manual_seed(0)
-
-    compute_kernel_config = get_compute_kernel_options(fp32_dest_acc_en)
+def run_moreh_nll_loss(shape, ignore_index, reduction, none_weight, device, compute_kernel_options=None):
+    compute_kernel_config = get_compute_kernel_options(compute_kernel_options)
 
     (torch_input, torch_target, torch_weight, torch_divisor, torch_output) = get_torch_tensors(shape)
 
@@ -147,85 +75,16 @@ def test_moreh_nll_loss(shape, ignore_index, reduction, none_weight, fp32_dest_a
         compute_kernel_config=compute_kernel_config,
     )
 
-    tt_loss_to_cpu = tt_loss.cpu().to(ttl.tensor.Layout.ROW_MAJOR).unpad_from_tile([1, 1]).to_torch().reshape([1])
+    tt_loss_to_cpu = to_cpu(tt_loss, [1])
     rtol = atol = 0.05
     passing, out = comp_allclose_and_pcc(torch_loss, tt_loss_to_cpu, pcc=0.999, rtol=rtol, atol=atol)
     logger.debug(f"Out passing (param)={passing}")
     logger.debug(f"Output pcc={out}")
-
     assert passing
 
 
-@pytest.mark.parametrize(
-    "shape",
-    [
-        (5, 10),
-        (5, 10, 10),
-        (5, 10, 10, 20),
-    ],
-)
-@pytest.mark.parametrize("reduction", ["mean", "sum"])
-@pytest.mark.parametrize("none_weight", [True, False])
-def test_moreh_nll_loss_callback(shape, reduction, none_weight, device, use_program_cache):
-    torch.manual_seed(0)
-
-    ignore_index = 1
-    reduction_mean = reduction == "mean"
-
-    # run TT
-    for _ in range(2):
-        (torch_input, torch_target, torch_weight, torch_divisor, torch_output) = get_torch_tensors(shape)
-        if none_weight:
-            torch_weight = None
-
-        (tt_input, tt_target, tt_weight, tt_divisor, tt_output) = get_tt_tensors(
-            torch_input, torch_target, torch_weight, torch_divisor, torch_output, device
-        )
-
-        tt_loss = ttl.operations.primary.moreh_nll_loss(
-            tt_input,
-            tt_target,
-            tt_weight,
-            tt_divisor,
-            tt_output,
-            ignore_index,
-            reduction_mean,
-        )
-
-    tt_loss_to_cpu = tt_loss.cpu().to(ttl.tensor.Layout.ROW_MAJOR).unpad_from_tile([1, 1]).to_torch().reshape([1])
-
-    # run torch
-    nll_loss = torch.nn.NLLLoss(weight=torch_weight, ignore_index=ignore_index, reduction=reduction)
-    torch_loss = torch.tensor([nll_loss(torch_input, torch_target)])
-
-    # compare result
-    rtol = atol = 0.05
-    passing, out = comp_allclose_and_pcc(torch_loss, tt_loss_to_cpu, pcc=0.999, rtol=rtol, atol=atol)
-    logger.debug(f"Out passing (param)={passing}")
-    logger.debug(f"Output pcc={out}")
-
-    assert passing
-
-
-@pytest.mark.parametrize(
-    "shape",
-    [
-        (400, 300),
-        (20, 300, 320),
-        (3, 4, 32 * 5, 32 * 6),
-        (5, 2, 5, 40, 70),
-    ],
-)
-@pytest.mark.parametrize("ignore_index", [1])
-@pytest.mark.parametrize("reduction_mean", [True, False])
-@pytest.mark.parametrize("none_weight", [True, False])
-@pytest.mark.parametrize("fp32_dest_acc_en", fp32_dest_acc_en, ids=fp32_dest_acc_en_ids)
-def test_moreh_nll_loss_backward(
-    shape, ignore_index, reduction_mean, none_weight, fp32_dest_acc_en, device, use_program_cache
-):
-    torch.manual_seed(0)
-
-    compute_kernel_config = get_compute_kernel_options(fp32_dest_acc_en)
+def run_moreh_nll_loss_backward(shape, ignore_index, reduction_mean, none_weight, device, compute_kernel_options=None):
+    compute_kernel_config = get_compute_kernel_options(compute_kernel_options)
 
     (torch_input, torch_target, torch_weight, torch_divisor, torch_output) = get_torch_tensors(shape)
     if none_weight:
@@ -256,18 +115,8 @@ def test_moreh_nll_loss_backward(
     output_grad = torch.randn_like(torch_loss)
     torch_loss.backward(output_grad)
 
-    tt_output_grad = (
-        ttl.tensor.Tensor(output_grad.reshape(1, 1), ttl.tensor.DataType.BFLOAT16)
-        .pad_to_tile(float("nan"))
-        .to(ttl.tensor.Layout.TILE)
-        .to(device)
-    )
-    tt_input_grad = (
-        ttl.tensor.Tensor(torch_input, ttl.tensor.DataType.BFLOAT16)
-        .pad_to_tile(float("nan"))
-        .to(ttl.tensor.Layout.TILE)
-        .to(device)
-    )
+    tt_output_grad = to_npu(output_grad, device)
+    tt_input_grad = to_npu(torch_input, device)
 
     tt_input_grad = ttl.operations.primary.moreh_nll_loss_backward(
         tt_target,
@@ -279,7 +128,7 @@ def test_moreh_nll_loss_backward(
         reduction_mean,
         compute_kernel_config=compute_kernel_config,
     )
-    tt_input_grad_to_cpu = tt_input_grad.cpu().to(ttl.tensor.Layout.ROW_MAJOR).unpad_from_tile(shape).to_torch()
+    tt_input_grad_to_cpu = to_cpu(tt_input_grad, shape)
 
     rtol = atol = 0.05
     passing, out = comp_allclose_and_pcc(torch_input.grad, tt_input_grad_to_cpu, pcc=0.999, rtol=rtol, atol=atol)
@@ -288,6 +137,61 @@ def test_moreh_nll_loss_backward(
     logger.debug(f"Output pcc={out}")
 
     assert passing
+
+
+@pytest.mark.parametrize(
+    "shape",
+    [
+        (5, 10),
+        (3000, 100),
+        (200, 100, 90),
+        (5, 50, 2, 7, 50, 70),
+    ],
+)
+@pytest.mark.parametrize("ignore_index", [1])
+@pytest.mark.parametrize("reduction", ["mean", "sum"])
+@pytest.mark.parametrize("none_weight", [True, False])
+def test_moreh_nll_loss(shape, ignore_index, reduction, none_weight, device):
+    torch.manual_seed(0)
+
+    run_moreh_nll_loss(shape, ignore_index, reduction, none_weight, device)
+
+
+@pytest.mark.parametrize(
+    "shape",
+    [
+        (5, 10),
+        (5, 6, 7),
+        (5, 6, 8, 9),
+    ],
+)
+@pytest.mark.parametrize("reduction", ["mean", "sum"])
+@pytest.mark.parametrize("none_weight", [True, False])
+def test_moreh_nll_loss_callback(shape, reduction, none_weight, device, use_program_cache):
+    torch.manual_seed(0)
+
+    ignore_idx = 0
+
+    for _ in range(2):
+        run_moreh_nll_loss(shape, ignore_idx, reduction, none_weight, device)
+
+
+@pytest.mark.parametrize(
+    "shape",
+    [
+        (400, 300),
+        (20, 300, 320),
+        (3, 4, 32 * 5, 32 * 6),
+        (5, 2, 5, 40, 70),
+    ],
+)
+@pytest.mark.parametrize("ignore_index", [1])
+@pytest.mark.parametrize("reduction_mean", [True, False])
+@pytest.mark.parametrize("none_weight", [True, False])
+def test_moreh_nll_loss_backward(shape, ignore_index, reduction_mean, none_weight, device):
+    torch.manual_seed(0)
+
+    run_moreh_nll_loss_backward(shape, ignore_index, reduction_mean, none_weight, device)
 
 
 @pytest.mark.parametrize(
@@ -305,62 +209,50 @@ def test_moreh_nll_loss_backward_test_callback(shape, reduction_mean, none_weigh
 
     ignore_index = 0
 
-    # run TT
     for _ in range(2):
-        (torch_input, torch_target, torch_weight, torch_divisor, torch_output) = get_torch_tensors(shape)
-        if none_weight:
-            torch_weight = None
+        run_moreh_nll_loss_backward(shape, ignore_index, reduction_mean, none_weight, device)
 
-        (tt_input, tt_target, tt_weight, tt_divisor, tt_output) = get_tt_tensors(
-            torch_input, torch_target, torch_weight, torch_divisor, torch_output, device
-        )
-        if reduction_mean == False:
-            tt_divisor = None
-        tt_loss = ttl.operations.primary.moreh_nll_loss(
-            tt_input, tt_target, tt_weight, tt_divisor, tt_output, ignore_index, reduction_mean
-        )
 
-        output_grad = torch.rand([])
+@pytest.mark.parametrize(
+    "shape",
+    [
+        (5, 10),
+        (10, 20, 30),
+        (10, 20, 30, 40),
+    ],
+)
+@pytest.mark.parametrize("ignore_index", [1])
+@pytest.mark.parametrize("reduction", ["mean", "sum"])
+@pytest.mark.parametrize("none_weight", [True, False])
+@pytest.mark.parametrize("compute_kernel_options", compute_kernel_options, ids=compute_kernel_ids)
+def test_moreh_nll_loss_compute_kernel_options(
+    shape, ignore_index, reduction, none_weight, compute_kernel_options, device
+):
+    torch.manual_seed(0)
 
-        tt_output_grad = (
-            ttl.tensor.Tensor(output_grad.reshape(1, 1), ttl.tensor.DataType.BFLOAT16)
-            .pad_to_tile(float("nan"))
-            .to(ttl.tensor.Layout.TILE)
-            .to(device)
-        )
-
-        tt_input_grad = (
-            ttl.tensor.Tensor(torch_input, ttl.tensor.DataType.BFLOAT16)
-            .pad_to_tile(float("nan"))
-            .to(ttl.tensor.Layout.TILE)
-            .to(device)
-        )
-
-        tt_input_grad = ttl.operations.primary.moreh_nll_loss_backward(
-            tt_target,
-            tt_weight,
-            tt_divisor,
-            tt_output_grad,
-            tt_input_grad,
-            ignore_index,
-            reduction_mean,
-        )
-
-    tt_input_grad_to_cpu = tt_input_grad.cpu().to(ttl.tensor.Layout.ROW_MAJOR).unpad_from_tile(shape).to_torch()
-
-    # run torch
-    nll_loss = torch.nn.NLLLoss(
-        weight=torch_weight, ignore_index=ignore_index, reduction="mean" if reduction_mean else "sum"
+    run_moreh_nll_loss(
+        shape, ignore_index, reduction, none_weight, device, compute_kernel_options=compute_kernel_options
     )
-    torch_loss = nll_loss(torch_input, torch_target)
 
-    torch_loss.backward(output_grad)
 
-    # compare result
-    rtol = atol = 0.05
-    passing, out = comp_allclose_and_pcc(torch_input.grad, tt_input_grad_to_cpu, pcc=0.999, rtol=rtol, atol=atol)
+@pytest.mark.parametrize(
+    "shape",
+    [
+        (5, 10),
+        (10, 20, 30),
+        (10, 20, 30, 40),
+    ],
+)
+@pytest.mark.parametrize("reduction_mean", [True, False])
+@pytest.mark.parametrize("none_weight", [True, False])
+@pytest.mark.parametrize("compute_kernel_options", compute_kernel_options, ids=compute_kernel_ids)
+def test_moreh_nll_loss_backward_compute_kernel_options(
+    shape, reduction_mean, none_weight, compute_kernel_options, device
+):
+    torch.manual_seed(0)
 
-    logger.debug(f"Out passing (param)={passing}")
-    logger.debug(f"Output pcc={out}")
+    ignore_index = 0
 
-    assert passing
+    run_moreh_nll_loss_backward(
+        shape, ignore_index, reduction_mean, none_weight, device, compute_kernel_options=compute_kernel_options
+    )

--- a/tt_eager/tt_dnn/op_library/moreh_nll_loss/moreh_nll_loss_step2/kernels/reader_moreh_nll_loss_step2_2d.cpp
+++ b/tt_eager/tt_dnn/op_library/moreh_nll_loss/moreh_nll_loss_step2/kernels/reader_moreh_nll_loss_step2_2d.cpp
@@ -57,20 +57,13 @@ void kernel_main() {
         .page_size = weight_tile_bytes,
     };
 
-    const InterleavedAddrGenFast<divisor_is_dram> addrg_divisor = {
-        .bank_base_address = divisor_addr, .page_size = divisor_tile_bytes, .data_format = divisor_data_format};
-
     constexpr uint32_t onetile = 1;
 
 #if defined(DIVISOR)
-    cb_reserve_back(cb_divisor, onetile);
-    uint32_t l1_write_addr_divisor = get_write_ptr(cb_divisor);
-    volatile tt_l1_ptr uint16_t* target_l1_ptr = reinterpret_cast<volatile tt_l1_ptr uint16_t*>(l1_write_addr_divisor);
+    const InterleavedAddrGenFast<divisor_is_dram> addrg_divisor = {
+        .bank_base_address = divisor_addr, .page_size = divisor_tile_bytes, .data_format = divisor_data_format};
 
-    noc_async_read_tile(0, addrg_divisor, l1_write_addr_divisor);
-    noc_async_read_barrier();
-
-    cb_push_back(cb_divisor, onetile);
+    read_tile(cb_divisor, addrg_divisor, 0);
 #endif
 
     uint32_t Ct = (C + TILE_HEIGHT - 1) / TILE_HEIGHT;
@@ -83,36 +76,20 @@ void kernel_main() {
         uint32_t nt = i;
 
         // target: (1, N)
-        // noc_id: nt = i
-        cb_reserve_back(cb_target, onetile);
-        uint32_t l1_write_addr_target = get_write_ptr(cb_target);
-        volatile tt_l1_ptr int32_t* target_l1_ptr = reinterpret_cast<volatile tt_l1_ptr int32_t*>(l1_write_addr_target);
-        uint32_t noc_id = nt;
-        uint64_t target_noc_addr = get_noc_addr(noc_id, addrg_target);
-        noc_async_read(target_noc_addr, l1_write_addr_target, target_tile_bytes);
-        noc_async_read_barrier();
-        cb_push_back(cb_target, onetile);
+        auto target_noc_id = nt;
+        read_tile(cb_target, addrg_target, target_noc_id);
 
 #if defined(WEIGHT)
-        cb_reserve_back(cb_weight, onetile);
         cb_reserve_back(cb_tmp_weight, onetile);
 
-        uint32_t l1_write_addr_tmp_weight = get_write_ptr(cb_tmp_weight);
-        volatile tt_l1_ptr FP32_DEST_ACC_FTYPE* tmp_weight_l1_ptr =
-            reinterpret_cast<volatile tt_l1_ptr FP32_DEST_ACC_FTYPE*>(l1_write_addr_tmp_weight);
+        auto tmp_weight_l1_ptr = get_write_ptr<FP32_DEST_ACC_FTYPE>(cb_tmp_weight);
 #endif
 
-        cb_reserve_back(cb_input, onetile);
         cb_reserve_back(cb_tmp_input, onetile);
-#if defined(FP32_DEST_ACC_EN)
-        uint32_t l1_write_addr_tmp_input = get_write_ptr(cb_tmp_input);
-        volatile tt_l1_ptr float* tmp_input_l1_ptr =
-            reinterpret_cast<volatile tt_l1_ptr float*>(l1_write_addr_tmp_input);
-#else
-        uint32_t l1_write_addr_tmp_input = get_write_ptr(cb_tmp_input);
-        volatile tt_l1_ptr uint16_t* tmp_input_l1_ptr =
-            reinterpret_cast<volatile tt_l1_ptr uint16_t*>(l1_write_addr_tmp_input);
-#endif
+        cb_wait_front(cb_target, onetile);
+
+        auto tmp_input_l1_ptr = get_write_ptr<FP32_DEST_ACC_FTYPE>(cb_tmp_input);
+        auto target_l1_ptr = get_read_ptr<int32_t>(cb_target);
 
         uint32_t w = 0;
         for (uint32_t n = n_start; n < n_end; n++, w++) {
@@ -122,21 +99,15 @@ void kernel_main() {
             if (target_val != ignore_index && (0 <= target_val && target_val < static_cast<int32_t>(C))) {
                 // input: (N, C)
                 // noc_id: nt * Ct + ct
-                uint32_t l1_write_addr_input = get_write_ptr(cb_input);
-                volatile tt_l1_ptr uint16_t* input_l1_ptr =
-                    reinterpret_cast<volatile tt_l1_ptr uint16_t*>(l1_write_addr_input);
-
-                uint32_t noc_offset;
-                get_noc_offset(n, target_val, element_size, noc_offset);
-
                 uint32_t noc_id = (nt * Ct) + (target_val / TILE_WIDTH);
-                uint64_t src_noc_addr = get_noc_addr(noc_id, addrg_input, noc_offset);
-                noc_async_read(src_noc_addr, l1_write_addr_input, NOC_MINIMUM_READ_SIZE);
-                noc_async_read_barrier();
+                uint32_t input_tilized_idx = get_tilized_idx(n, target_val);
+                read_value(cb_input, addrg_input, noc_id, input_tilized_idx);
 
-                uint32_t buffer_idx = target_val % 16;
+                cb_wait_front(cb_input, onetile);
+                auto input_l1_ptr = get_read_ptr<uint16_t>(cb_input);
+                tmp_input_l1_ptr[tilized_idx] = fp32_dest_acc_cast(input_l1_ptr[input_tilized_idx]);
 
-                tmp_input_l1_ptr[tilized_idx] = fp32_dest_acc_cast(input_l1_ptr[buffer_idx]);
+                cb_pop_front(cb_input, onetile);
             } else {
                 tmp_input_l1_ptr[tilized_idx] = fp32_dest_acc_cast(0.0f);
             }
@@ -145,26 +116,20 @@ void kernel_main() {
             // read weight
             // weight: (1, C)
             // noc_id: target_val / TILE_WIDTH
-            uint32_t l1_write_addr_weight = get_write_ptr(cb_weight);
-            volatile tt_l1_ptr uint16_t* weight_l1_ptr =
-                reinterpret_cast<volatile tt_l1_ptr uint16_t*>(l1_write_addr_weight);
-
-            uint32_t noc_offset;
-            get_noc_offset(0, target_val, element_size, noc_offset);
-
             uint32_t noc_id = target_val / TILE_WIDTH;
-            uint64_t src_noc_addr = get_noc_addr(noc_id, addrg_weight, noc_offset);
-            noc_async_read(src_noc_addr, l1_write_addr_weight, NOC_MINIMUM_READ_SIZE);
-            noc_async_read_barrier();
+            uint32_t weight_tilized_idx = get_tilized_idx(0, target_val);
+            read_value(cb_weight, addrg_weight, noc_id, weight_tilized_idx);
 
-            uint32_t buffer_idx = target_val % 16;
-
-            tmp_weight_l1_ptr[tilized_idx] = fp32_dest_acc_cast(weight_l1_ptr[buffer_idx]);
+            cb_wait_front(cb_weight, onetile);
+            auto weight_l1_ptr = get_read_ptr<uint16_t>(cb_weight);
+            tmp_weight_l1_ptr[tilized_idx] = fp32_dest_acc_cast(weight_l1_ptr[weight_tilized_idx]);
+            cb_pop_front(cb_weight, onetile);
 #endif
         }
         cb_push_back(cb_tmp_input, onetile);
 #if defined(WEIGHT)
         cb_push_back(cb_tmp_weight, onetile);
 #endif
+        cb_pop_front(cb_target, onetile);
     }
 }

--- a/tt_eager/tt_dnn/op_library/moreh_nll_loss_backward/moreh_nll_loss_backward/kernels/reader_moreh_nll_loss_backward_2d.cpp
+++ b/tt_eager/tt_dnn/op_library/moreh_nll_loss_backward/moreh_nll_loss_backward/kernels/reader_moreh_nll_loss_backward_2d.cpp
@@ -56,39 +56,21 @@ void kernel_main() {
         .page_size = weight_tile_bytes,
     };
 
-    cb_reserve_back(cb_weight, weight_num_tile);
-    uint32_t l1_write_addr_weight = get_write_ptr(cb_weight);
-    volatile tt_l1_ptr uint16_t* weight_l1_ptr = reinterpret_cast<volatile tt_l1_ptr uint16_t*>(l1_write_addr_weight);
+    // weight: (1, C)
+    read_line(cb_weight, addrg_weight, weight_num_tile);
 
-    for (uint32_t i = 0; i < weight_num_tile * 2; ++i) {
-        uint32_t noc_id = i / 2;
-        uint32_t noc_offset = 0;
-        if (noc_id * 2 != i) {
-            noc_offset += 256 * element_size;
-        }
-        uint64_t src_noc_addr = get_noc_addr(noc_id, addrg_weight, noc_offset);
-        noc_async_read(src_noc_addr, l1_write_addr_weight, NOC_MINIMUM_READ_SIZE);
-        noc_async_read_barrier();
-        l1_write_addr_weight += NOC_MINIMUM_READ_SIZE;
-    }
+    cb_wait_front(cb_weight, weight_num_tile);
+    auto weight_l1_ptr = get_read_ptr<uint16_t>(cb_weight);
 #endif
 
 #if defined(DIVISOR)
     const InterleavedAddrGenFast<divisor_is_dram> addrg_divisor = {
         .bank_base_address = divisor_addr, .page_size = divisor_tile_bytes, .data_format = divisor_data_format};
 
-    cb_reserve_back(cb_divisor, onetile);
-    uint32_t l1_write_addr_divisor = get_write_ptr(cb_divisor);
-    noc_async_read_tile(0, addrg_divisor, l1_write_addr_divisor);
-    noc_async_read_barrier();
-    cb_push_back(cb_divisor, onetile);
+    read_tile(cb_divisor, addrg_divisor, 0);
 #endif
 
-    cb_reserve_back(cb_output_grad, onetile);
-    uint32_t l1_write_addr_output_grad = get_write_ptr(cb_output_grad);
-    noc_async_read_tile(0, addrg_output_grad, l1_write_addr_output_grad);
-    noc_async_read_barrier();
-    cb_push_back(cb_output_grad, onetile);
+    read_tile(cb_output_grad, addrg_output_grad, 0);
 
 
     uint32_t Ct = (C + TILE_HEIGHT - 1) / TILE_HEIGHT;
@@ -100,22 +82,14 @@ void kernel_main() {
 
         // target: (1, N)
         // noc_id: nt
-        cb_reserve_back(cb_target, onetile);
-        uint32_t l1_write_addr_target = get_write_ptr(cb_target);
-        volatile tt_l1_ptr uint32_t* target_l1_ptr =
-            reinterpret_cast<volatile tt_l1_ptr uint32_t*>(l1_write_addr_target);
         uint32_t target_noc_id = nt;
-        uint64_t target_noc_addr = get_noc_addr(target_noc_id, addrg_target);
-        noc_async_read(target_noc_addr, l1_write_addr_target, target_tile_bytes);
-        noc_async_read_barrier();
-        cb_push_back(cb_target, onetile);
+        read_tile(cb_target, addrg_target, target_noc_id);
 
         cb_reserve_back(cb_tmp_weight, onetile);
-        uint32_t l1_write_addr_tmp_weight = get_write_ptr(cb_tmp_weight);
+        cb_wait_front(cb_target, onetile);
 
-
-        volatile tt_l1_ptr FP32_DEST_ACC_FTYPE* tmp_weight_l1_ptr =
-            reinterpret_cast<volatile tt_l1_ptr FP32_DEST_ACC_FTYPE*>(l1_write_addr_tmp_weight);
+        auto tmp_weight_l1_ptr = get_write_ptr<FP32_DEST_ACC_FTYPE>(cb_tmp_weight);
+        auto target_l1_ptr = get_read_ptr<int32_t>(cb_target);
 
         for (uint32_t h = 0; h < TILE_HEIGHT; h++) {
             for (uint32_t w = 0; w < TILE_WIDTH; w++) {
@@ -141,7 +115,6 @@ void kernel_main() {
 
         cb_push_back(cb_tmp_weight, onetile);
 
-        cb_wait_front(cb_target, onetile);
         cb_pop_front(cb_target, onetile);
     }
 }

--- a/tt_eager/tt_dnn/op_library/moreh_nll_loss_backward/moreh_nll_loss_backward/kernels/reader_moreh_nll_loss_backward_4d.cpp
+++ b/tt_eager/tt_dnn/op_library/moreh_nll_loss_backward/moreh_nll_loss_backward/kernels/reader_moreh_nll_loss_backward_4d.cpp
@@ -57,39 +57,21 @@ void kernel_main() {
         .page_size = weight_tile_bytes,
     };
 
-    cb_reserve_back(cb_weight, weight_num_tile);
-    uint32_t l1_write_addr_weight = get_write_ptr(cb_weight);
-    volatile tt_l1_ptr uint16_t* weight_l1_ptr = reinterpret_cast<volatile tt_l1_ptr uint16_t*>(l1_write_addr_weight);
+    // weight: (1, C)
+    read_line(cb_weight, addrg_weight, weight_num_tile);
 
-    for (uint32_t i = 0; i < weight_num_tile * 2; ++i) {
-        uint32_t noc_id = i / 2;
-        uint32_t noc_offset = 0;
-        if (noc_id * 2 != i) {
-            noc_offset += 256 * element_size;
-        }
-        uint64_t src_noc_addr = get_noc_addr(noc_id, addrg_weight, noc_offset);
-        noc_async_read(src_noc_addr, l1_write_addr_weight, NOC_MINIMUM_READ_SIZE);
-        noc_async_read_barrier();
-        l1_write_addr_weight += NOC_MINIMUM_READ_SIZE;
-    }
+    cb_wait_front(cb_weight, weight_num_tile);
+    auto weight_l1_ptr = get_read_ptr<uint16_t>(cb_weight);
 #endif
 
 #if defined(DIVISOR)
     const InterleavedAddrGenFast<divisor_is_dram> addrg_divisor = {
         .bank_base_address = divisor_addr, .page_size = divisor_tile_bytes, .data_format = divisor_data_format};
 
-    cb_reserve_back(cb_divisor, onetile);
-    uint32_t l1_write_addr_divisor = get_write_ptr(cb_divisor);
-    noc_async_read_tile(0, addrg_divisor, l1_write_addr_divisor);
-    noc_async_read_barrier();
-    cb_push_back(cb_divisor, onetile);
+    read_tile(cb_divisor, addrg_divisor, 0);
 #endif
 
-    cb_reserve_back(cb_output_grad, onetile);
-    uint32_t l1_write_addr_output_grad = get_write_ptr(cb_output_grad);
-    noc_async_read_tile(0, addrg_output_grad, l1_write_addr_output_grad);
-    noc_async_read_barrier();
-    cb_push_back(cb_output_grad, onetile);
+    read_tile(cb_output_grad, addrg_output_grad, 0);
 
     uint32_t end_id = start_id + num_tiles_per_core;
     for (uint32_t i = start_id; i < end_id; ++i) {
@@ -98,21 +80,14 @@ void kernel_main() {
         uint32_t n = nc / C;
         uint32_t c = nc % C;
 
-        cb_reserve_back(cb_target, onetile);
-        uint32_t l1_write_addr_target = get_write_ptr(cb_target);
-        volatile tt_l1_ptr uint32_t* target_l1_ptr =
-            reinterpret_cast<volatile tt_l1_ptr uint32_t*>(l1_write_addr_target);
         uint32_t target_noc_id = n * num_inner_tile + inner;
-        uint64_t target_noc_addr = get_noc_addr(target_noc_id, addrg_target);
-        noc_async_read(target_noc_addr, l1_write_addr_target, target_tile_bytes);
-        noc_async_read_barrier();
-        cb_push_back(cb_target, onetile);
+        read_tile(cb_target, addrg_target, target_noc_id);
 
         cb_reserve_back(cb_tmp_weight, onetile);
-        uint32_t l1_write_addr_tmp_weight = get_write_ptr(cb_tmp_weight);
+        cb_wait_front(cb_target, onetile);
 
-        volatile tt_l1_ptr FP32_DEST_ACC_FTYPE* tmp_weight_l1_ptr =
-            reinterpret_cast<volatile tt_l1_ptr FP32_DEST_ACC_FTYPE*>(l1_write_addr_tmp_weight);
+        auto tmp_weight_l1_ptr = get_write_ptr<FP32_DEST_ACC_FTYPE>(cb_tmp_weight);
+        auto target_l1_ptr = get_read_ptr<int32_t>(cb_target);
 
         for (uint32_t h = 0; h < TILE_HEIGHT; h++) {
             for (uint32_t w = 0; w < TILE_WIDTH; w++) {
@@ -136,7 +111,6 @@ void kernel_main() {
 
         cb_push_back(cb_tmp_weight, onetile);
 
-        cb_wait_front(cb_target, onetile);
         cb_pop_front(cb_target, onetile);
     }
 }


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/10030

### Problem description
I discovered that in the moreh_nll_loss implementation, a hang occurs when N becomes large.
The issue appears to be caused by a missing pop in the target cb.

### What's changed
- fix moreh nll loss compute kernel code.

### Checklist
- [x] Post commit CI passes
- [x] Model regression CI testing passes (if applicable)
- [x] New/Existing tests provide coverage for changes
