### PR TITLE
Optimized MLP with W/H fracturing, sharding and ReduceScatter

### DIFF
--- a/models/demos/t3000/falcon40b/scripts/get_falcon40b_perf_numbers.sh
+++ b/models/demos/t3000/falcon40b/scripts/get_falcon40b_perf_numbers.sh
@@ -8,12 +8,10 @@
 
 seq_lens=(128 2048)
 
-# iterate over config in configs
-
 for seq_len in ${seq_lens[@]}; do
     echo "Running seq length: $seq_len"
     output_folder="generated/profiler/reports/"
-    WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml python3 -m tracy -r -m "pytest models/demos/t3000/falcon40b/tests/test_perf_falcon.py::test_perf_bare_metal[${dtype}-DRAM-falcon_40b-layers_1-prefill_seq${seq_len}-8chips]"
+    WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml python3 -m tracy -r -m "pytest models/demos/t3000/falcon40b/tests/test_perf_falcon.py::test_perf_bare_metal[wormhole_b0-True-falcon_40b-prefill_seq${seq_len}_bfp8_layers1-8chips]"
     # get latest folder in output folder
     latest_created_folder=$(ls -td $output_folder/* | head -n 1)
     # find csv file that starts with "ops_perf_results"

--- a/models/demos/t3000/falcon40b/scripts/perf_summary.py
+++ b/models/demos/t3000/falcon40b/scripts/perf_summary.py
@@ -48,7 +48,7 @@ def analyze_perf_csv(
         # save to intermed file for further analysis
         df.to_csv(out_file.split(".")[0] + ".warmup_removed.csv", index=False, sep=",")
     df = df[df["DEVICE FW DURATION [ns]"] != "-"]
-    df["DEVICE FW DURATION [ns]"] = df["DEVICE FW DURATION [ns]"].astype(int)
+    df["DEVICE FW DURATION [ns]"] = df["DEVICE FW DURATION [ns]"].fillna(0).astype(int)
 
     df = assign_op_id_cross_device(df, num_chips)
     sorted_df = df
@@ -81,7 +81,7 @@ def analyze_perf_csv(
     )
 
     sorted_df.loc[:, "TOTAL_BYTES"] = (
-        (sorted_df["INPUT_0_MEMORY"].str.contains(DRAM_INTERLEAVED, na=False)).astype(int)
+        (sorted_df["INPUT_0_MEMORY"].str.contains(DRAM_INTERLEAVED, na=False)).fillna(0).astype(int)
         * (
             sorted_df["INPUT_0_W"]
             * sorted_df["INPUT_0_Z"]
@@ -89,7 +89,7 @@ def analyze_perf_csv(
             * sorted_df["INPUT_0_X"]
             * sorted_df["INPUT_0_DATATYPE"]
         )
-        + (sorted_df["INPUT_1_MEMORY"].str.contains(DRAM_INTERLEAVED, na=False)).astype(int)
+        + (sorted_df["INPUT_1_MEMORY"].str.contains(DRAM_INTERLEAVED, na=False)).fillna(0).astype(int)
         * (
             sorted_df["INPUT_1_W"]
             * sorted_df["INPUT_1_Z"]
@@ -97,7 +97,7 @@ def analyze_perf_csv(
             * sorted_df["INPUT_1_X"]
             * sorted_df["INPUT_1_DATATYPE"]
         )
-        + (sorted_df["OUTPUT_0_MEMORY"].str.contains(DRAM_INTERLEAVED, na=False)).astype(int)
+        + (sorted_df["OUTPUT_0_MEMORY"].str.contains(DRAM_INTERLEAVED, na=False)).fillna(0).astype(int)
         * (
             sorted_df["OUTPUT_0_W"]
             * sorted_df["OUTPUT_0_Z"]
@@ -157,7 +157,7 @@ def analyze_perf_csv(
         ]
         sorted_df["% TIME"] = 100 * sorted_df["DURATION [ns]"] / sum_duration
         sorted_df["% DEV CB WAIT"] = (
-            100 * sorted_df["DEVICE COMPUTE CB WAIT FRONT [ns]"].astype(int) / sorted_df["DURATION [ns]"]
+            100 * sorted_df["DEVICE COMPUTE CB WAIT FRONT [ns]"].fillna(0).astype(int) / sorted_df["DURATION [ns]"]
         )
 
         # trim all floats to 6 decimal places
@@ -174,7 +174,9 @@ def analyze_perf_csv(
             sum_duration = grouped_df["DURATION [ns]"].sum()
             grouped_df["% TIME"] = 100 * grouped_df["DURATION [ns]"] / sum_duration
             grouped_df["% DEV CB WAIT"] = (
-                100 * grouped_df["DEVICE COMPUTE CB WAIT FRONT [ns]"].astype(int) / grouped_df["DURATION [ns]"]
+                100
+                * grouped_df["DEVICE COMPUTE CB WAIT FRONT [ns]"].fillna(0).astype(int)
+                / grouped_df["DURATION [ns]"]
             )
 
             grouped_matmul_rows = group_by_op_all_devices(matmul_rows)

--- a/models/demos/t3000/falcon40b/tests/ci/test_falcon_end_to_end_60_layer_t3000_prefill_10_loops.py
+++ b/models/demos/t3000/falcon40b/tests/ci/test_falcon_end_to_end_60_layer_t3000_prefill_10_loops.py
@@ -96,35 +96,35 @@ def test_FalconCausalLM_prefill_end_to_end_t3000_ci_loops_10(
 
     if data_type == "BFLOAT8_B":
         if seq_len == 32:
-            out_pcc = 0.984
-            k_cache_pcc = 0.979
-            v_cache_pcc = 0.940
-            token_pcc = 0.99
-        elif seq_len == 128:
-            out_pcc = 0.989
-            k_cache_pcc = 0.989
-            v_cache_pcc = 0.949
-            token_pcc = 0.99
-        elif seq_len == 2048:
-            out_pcc = 0.993
-            k_cache_pcc = 0.991
-            v_cache_pcc = 0.97
-            token_pcc = 0.99
-    elif data_type == "BFLOAT16":
-        if seq_len == 32:
             out_pcc = 0.986
-            k_cache_pcc = 0.993
-            v_cache_pcc = 0.978
+            k_cache_pcc = 0.978
+            v_cache_pcc = 0.934
             token_pcc = 0.99
         elif seq_len == 128:
-            out_pcc = 0.991
-            k_cache_pcc = 0.994
-            v_cache_pcc = 0.982
+            out_pcc = 0.990
+            k_cache_pcc = 0.988
+            v_cache_pcc = 0.940
             token_pcc = 0.99
         elif seq_len == 2048:
             out_pcc = 0.992
-            k_cache_pcc = 0.992
-            v_cache_pcc = 0.980
+            k_cache_pcc = 0.990
+            v_cache_pcc = 0.967
+            token_pcc = 0.99
+    elif data_type == "BFLOAT16":
+        if seq_len == 32:
+            out_pcc = 0.981
+            k_cache_pcc = 0.978
+            v_cache_pcc = 0.929
+            token_pcc = 0.99
+        elif seq_len == 128:
+            out_pcc = 0.991
+            k_cache_pcc = 0.993
+            v_cache_pcc = 0.976
+            token_pcc = 0.99
+        elif seq_len == 2048:
+            out_pcc = 0.992
+            k_cache_pcc = 0.989
+            v_cache_pcc = 0.972
             token_pcc = 0.99
 
     disable_persistent_kernel_cache()

--- a/models/demos/t3000/falcon40b/tests/test_falcon_end_to_end.py
+++ b/models/demos/t3000/falcon40b/tests/test_falcon_end_to_end.py
@@ -401,22 +401,14 @@ def run_test_FalconCausalLM_end_to_end(
     (
         ("prefill", 1, 32, 0),
         ("prefill", 2, 32, 0),
-        # ("prefill", 1, 64, 0),
         ("prefill", 1, 128, 0),
-        # ("prefill", 1, 256, 0),
-        # ("prefill", 1, 512, 0),
-        # ("prefill", 1, 1024, 0),
         ("prefill", 1, 2048, 0),
         ("decode", 32, 1, 128),
     ),
     ids=[
         "prefill_seq32",
         "prefill_seq32_batch2",
-        # "prefill_seq64",
         "prefill_seq128",
-        # "prefill_seq256",
-        # "prefill_seq512",
-        # "prefill_seq1024",
         "prefill_seq2048",
         "decode_batch32",
     ],
@@ -484,41 +476,41 @@ def test_FalconCausalLM_end_to_end_with_program_cache(
         if num_layers == 60:
             if data_type == "BFLOAT8_B":
                 if seq_len == 32:
-                    out_pcc = 0.984
-                    k_cache_pcc = 0.979
-                    v_cache_pcc = 0.940
-                    token_pcc = 0.99
-                elif seq_len == 128:
-                    out_pcc = 0.989
-                    k_cache_pcc = 0.989
-                    v_cache_pcc = 0.949
-                    token_pcc = 0.99
-                elif seq_len == 2048:
-                    out_pcc = 0.993
-                    k_cache_pcc = 0.991
-                    v_cache_pcc = 0.97
-                    token_pcc = 0.99
-            elif data_type == "BFLOAT16":
-                if seq_len == 32:
                     out_pcc = 0.986
-                    k_cache_pcc = 0.993
-                    v_cache_pcc = 0.978
+                    k_cache_pcc = 0.978
+                    v_cache_pcc = 0.934
                     token_pcc = 0.99
                 elif seq_len == 128:
-                    out_pcc = 0.991
-                    k_cache_pcc = 0.994
-                    v_cache_pcc = 0.982
+                    out_pcc = 0.990
+                    k_cache_pcc = 0.988
+                    v_cache_pcc = 0.940
                     token_pcc = 0.99
                 elif seq_len == 2048:
                     out_pcc = 0.992
-                    k_cache_pcc = 0.992
-                    v_cache_pcc = 0.980
+                    k_cache_pcc = 0.990
+                    v_cache_pcc = 0.967
+                    token_pcc = 0.99
+            elif data_type == "BFLOAT16":
+                if seq_len == 32:
+                    out_pcc = 0.981
+                    k_cache_pcc = 0.978
+                    v_cache_pcc = 0.929
+                    token_pcc = 0.99
+                elif seq_len == 128:
+                    out_pcc = 0.991
+                    k_cache_pcc = 0.993
+                    v_cache_pcc = 0.976
+                    token_pcc = 0.99
+                elif seq_len == 2048:
+                    out_pcc = 0.992
+                    k_cache_pcc = 0.989
+                    v_cache_pcc = 0.972
                     token_pcc = 0.99
         elif num_layers == 12:
             out_pcc = 0.99
             k_cache_pcc = 0.98
             v_cache_pcc = 0.98
-    else:
+    else:  # Decode
         if num_layers == 60:
             out_pcc = 0.92
             k_cache_pcc = 0.99

--- a/models/demos/t3000/falcon40b/tests/test_falcon_mlp.py
+++ b/models/demos/t3000/falcon40b/tests/test_falcon_mlp.py
@@ -126,8 +126,8 @@ def run_test_FalconMLP_inference(
 @pytest.mark.parametrize(
     "model_config_str, pcc",
     [
-        ("BFLOAT8_B-SHARDED", 0.9986),
-        ("BFLOAT16-SHARDED", 0.9986),
+        ("BFLOAT8_B-SHARDED", 0.9985),
+        ("BFLOAT16-SHARDED", 0.9985),
         ("BFLOAT8_B-DRAM", 0.9983),
         ("BFLOAT16-DRAM", 0.9986),
     ],

--- a/models/demos/t3000/falcon40b/tests/test_perf_falcon.py
+++ b/models/demos/t3000/falcon40b/tests/test_perf_falcon.py
@@ -337,8 +337,6 @@ def run_test_FalconCausalLM_end_to_end(
         ("prefill", 1, 128, 0, 60, 0.46 + 0.04, 60, "BFLOAT16-DRAM"),
         ("prefill", 1, 2048, 0, 60, 1.18 + 0.1, 60, "BFLOAT16-DRAM"),
         ("decode", 32, 1, 128, 60, 0.21 + 0.02, 60, "BFLOAT8_B-SHARDED"),
-        ("prefill", 1, 128, 0, 60, 0.0099 + 0.002, 1, "BFLOAT8_B-DRAM"),
-        ("prefill", 1, 2048, 0, 60, 0.0393 + 0.02, 1, "BFLOAT8_B-DRAM"),
     ),
     ids=[
         "prefill_seq32_bfp8",
@@ -348,8 +346,6 @@ def run_test_FalconCausalLM_end_to_end(
         "prefill_seq128_fp16",
         "prefill_seq2048_fp16",
         "decode_batch32",
-        "prefill_seq128_bfp8_layers_1",
-        "prefill_seq2048_bfp8_layers_1",
     ],
 )
 @pytest.mark.parametrize(
@@ -410,4 +406,76 @@ def test_perf_bare_metal(
         expected_inference_time,
         warmup_iterations=10,
         is_ci_env=is_ci_env,
+    )
+
+
+@skip_for_grayskull("Requires eth connected devices to run")
+@pytest.mark.parametrize("num_devices", (8,), ids=["8chips"])
+@pytest.mark.parametrize(
+    "llm_mode, batch, seq_len, kv_cache_len, expected_compile_time, expected_inference_time, num_layers, model_config_str",
+    (
+        ("prefill", 1, 128, 0, 60, 0.39 + 0.04, 1, "BFLOAT8_B-DRAM"),
+        ("prefill", 1, 2048, 0, 60, 0.94 + 0.1, 1, "BFLOAT8_B-DRAM"),
+    ),
+    ids=[
+        "prefill_seq128_bfp8_layers1",
+        "prefill_seq2048_bfp8_layers1",
+    ],
+)
+@pytest.mark.parametrize(
+    "model_version",
+    ("tiiuae/falcon-40b-instruct",),
+    ids=["falcon_40b"],
+)
+def test_device_perf_bare_metal(
+    num_devices,
+    model_version,
+    llm_mode,
+    batch,
+    seq_len,
+    kv_cache_len,
+    expected_compile_time,
+    expected_inference_time,
+    num_layers,
+    request,
+    model_config_str,
+    model_location_generator,
+    get_tt_cache_path,
+    t3k_device_mesh,
+    use_program_cache,
+):
+    if llm_mode == "prefill" and (model_config_str not in ["BFLOAT8_B-DRAM", "BFLOAT16-DRAM"] or num_devices != 8):
+        pytest.skip("Prefill is only supported for DRAM memory config and 8 chips!")
+    if llm_mode == "decode" and model_config_str not in ["BFLOAT8_B-SHARDED"]:
+        pytest.skip("Decode is only supported for SHARDED memory config!")
+
+    input_shape = [batch, seq_len]
+    model_config = get_model_config(model_config_str, llm_mode, input_shape, num_devices)
+    devices = t3k_device_mesh.get_devices()
+    compute_grid_size = devices[0].compute_with_storage_grid_size()
+    if compute_grid_size.x < model_config["MAX_GRID_SIZE"][0] or compute_grid_size.y < model_config["MAX_GRID_SIZE"][1]:
+        pytest.skip(f"Requires grid size of at least {model_config['MAX_GRID_SIZE']} to run")
+
+    tt_cache_path = get_tt_cache_path(
+        model_version, model_subdir="Falcon", default_dir=model_config["DEFAULT_CACHE_PATH"]
+    )
+
+    disable_persistent_kernel_cache()
+    disable_compilation_reports()
+
+    run_test_FalconCausalLM_end_to_end(
+        t3k_device_mesh,
+        model_version,
+        llm_mode,
+        batch,
+        seq_len,
+        kv_cache_len,
+        num_layers,
+        model_config,
+        model_config_str,
+        tt_cache_path,
+        model_location_generator,
+        expected_compile_time,
+        expected_inference_time,
+        warmup_iterations=10,
     )

--- a/models/demos/t3000/falcon40b/tt/falcon_mlp.py
+++ b/models/demos/t3000/falcon40b/tt/falcon_mlp.py
@@ -54,13 +54,37 @@ class TtFalconMLP:
             layout=ttnn.TILE_LAYOUT,
             device=self.device_mesh,
             memory_config=self.model_config["DENSE_4H_TO_H_MM_WEIGHTS_MEMCFG"],
-            mesh_mapper=ShardTensorToMesh(self.device_mesh, dim=3),
-            cache_file_name=tt_cache_path / dense_4h_to_h_str,
+            mesh_mapper=ShardTensorToMesh(self.device_mesh, dim=2),
+            cache_file_name=tt_cache_path / f"{dense_4h_to_h_str}_height_fractured",
             preprocess=lambda x: torch.transpose(x.reshape(1, 1, *x.shape), -2, -1),
         )
 
+        self.output = None
+        self._allocate_output_mlp_tensors()
+
     def set_model_config(self, model_config):
         self.model_config = model_config
+
+        self._allocate_output_mlp_tensors()
+
+    def _allocate_output_mlp_tensors(self):
+        if self.model_config["LLM_MODE"] == "prefill":
+            if self.output is not None:
+                self.output.deallocate()
+
+            seq_len = self.model_config["row_height"]
+
+            # prepare output tensor on device
+            out_shape = (1, 1, seq_len, self.dense_4h_to_h_weights.shape[-1])
+            out_tensor = torch.zeros(out_shape).bfloat16()
+
+            self.output = ttnn.from_torch(
+                out_tensor,
+                self.model_config["DENSE_4H_TO_H_MM_OUTPUT_DTYPE"],
+                device=self.device_mesh,
+                layout=ttnn.TILE_LAYOUT,
+                memory_config=self.model_config["DEFAULT_MEMCFG"],
+            )
 
     def __call__(
         self, x: List[ttnn.experimental.tensor.Tensor], llm_mode: str
@@ -83,18 +107,6 @@ class TtFalconMLP:
         )
         x.deallocate(True)
 
-        hidden_states = ttnn.experimental.tensor.sharded_to_interleaved(
-            hidden_states, output_mem_config=self.model_config["DEFAULT_MEMCFG"]
-        )
-        hidden_states = ttnn.all_gather(
-            hidden_states,
-            dim=3,
-            num_links=self.model_config["ALL_GATHER_NUM_LINKS"],
-            memory_config=self.model_config["DEFAULT_MEMCFG"],
-        )
-        hidden_states = ttnn.experimental.tensor.interleaved_to_sharded(
-            hidden_states, sharded_mem_config=self.model_config["MLP_ALL_GATHER_OUTPUT_MEMCFG"]
-        )
         hidden_states = ttnn.matmul(
             hidden_states,
             self.dense_4h_to_h_weights,
@@ -103,6 +115,29 @@ class TtFalconMLP:
             dtype=self.model_config["DENSE_4H_TO_H_MM_OUTPUT_DTYPE"],
             compute_kernel_config=self.model_config["COMPUTE_KERNEL_CONFIG"],
         )
+
+        hidden_states = ttnn.experimental.tensor.sharded_to_interleaved(
+            hidden_states, output_mem_config=self.model_config["DEFAULT_MEMCFG"]
+        )
+
+        hidden_states = ttnn.get_device_tensors(
+            hidden_states
+        )  # Workaround for reduce_scatter only taking a vector of tensors and not device_mesh
+
+        hidden_states = ttnn.experimental.tensor.reduce_scatter(
+            hidden_states,
+            scatter_split_dim=3,
+            reduce_op=ttnn.experimental.tensor.ReduceOpMath.SUM,
+            num_links=1,  # only unidirectional supported for now
+            output_mem_config=self.model_config["DEFAULT_MEMCFG"],
+        )
+
+        hidden_states = ttnn.aggregate_as_tensor(hidden_states)  # Workaround reverse
+
+        hidden_states = ttnn.experimental.tensor.interleaved_to_sharded(
+            hidden_states, sharded_mem_config=self.model_config["MLP_REDUCE_SCATTER_OUTPUT_MEMCFG"]
+        )
+
         # return TT Tensor
         return hidden_states
 
@@ -111,33 +146,67 @@ class TtFalconMLP:
         should_deallocate_ln_tensors = determine_tensor_deallocation(
             self.model_config["layernorm_params"]["slice_size"], x.get_legacy_shape()[2]
         )
-        hidden_states = falcon_prefill_matmul(
-            x,
-            self.dense_h_to_4h_weights,
-            self.model_config["COMPUTE_KERNEL_CONFIG"],
-            output_mem_config=self.model_config["DENSE_H_TO_4H_MM_OUTPUT_MEMCFG"],
-            output_dtype=self.model_config["DENSE_H_TO_4H_MM_OUTPUT_DTYPE"],
-            act=[ttnn.UnaryOpType.GELU, True],
-            overwrite_subblock_w=1,  # Workaround for non deterministic output/hang; issue: 7066
-            overwrite_subblock_h=1,
-        )
-        hidden_states = ttnn.all_gather(
-            hidden_states,
-            dim=3,
-            num_links=self.model_config["ALL_GATHER_NUM_LINKS"],
-            memory_config=self.model_config["DEFAULT_MEMCFG"],
-        )
+
+        mlp_num_slices = self.model_config["MLP_NUM_SLICES"]
+        for slice_idx in range(mlp_num_slices):
+            x_slice = ttnn.experimental.tensor.interleaved_to_sharded_partial(
+                x,
+                self.model_config["MLP_GRID_SIZE"],
+                self.model_config["MLP_INPUT_SHARD_SPEC"],
+                mlp_num_slices,
+                slice_idx,
+                self.model_config["MLP_INPUT_SHARD_LAYOUT"],
+                ttnn.experimental.tensor.ShardOrientation.ROW_MAJOR,
+            )
+
+            hidden_states_slice = falcon_prefill_matmul(
+                x_slice,
+                self.dense_h_to_4h_weights,
+                self.model_config["COMPUTE_KERNEL_CONFIG"],
+                output_mem_config=self.model_config["DENSE_H_TO_4H_MM_OPTIMIZED_OUTPUT_MEMCFG"],
+                output_dtype=self.model_config["DENSE_H_TO_4H_MM_OUTPUT_DTYPE"],
+                act=[ttnn.UnaryOpType.GELU, True],
+                overwrite_subblock_w=1,  # Workaround for non deterministic output/hang; issue: 7066
+                overwrite_subblock_h=1,
+            )
+            x_slice.deallocate(True)
+
+            hidden_states_slice = falcon_prefill_matmul(
+                hidden_states_slice,
+                self.dense_4h_to_h_weights,
+                self.model_config["COMPUTE_KERNEL_CONFIG"],
+                output_mem_config=self.model_config["DENSE_4H_TO_H_MM_OPTIMIZED_OUTPUT_MEMCFG"],
+                output_dtype=self.model_config["DENSE_4H_TO_H_MM_OUTPUT_DTYPE"],
+                overwrite_subblock_w=1,  # Workaround for non deterministic output/hang; issue: 7066
+                overwrite_subblock_h=1,
+            )
+
+            ttnn.experimental.tensor.sharded_to_interleaved_partial(
+                hidden_states_slice,
+                self.output,
+                mlp_num_slices,
+                slice_idx,
+                self.model_config["DEFAULT_MEMCFG"],
+            )
+            hidden_states_slice.deallocate()
+
+        # Deallocate input
         if should_deallocate_ln_tensors:
             x.deallocate(True)
 
-        hidden_states = falcon_prefill_matmul(
+        hidden_states = ttnn.get_device_tensors(
+            self.output
+        )  # Workaround for reduce_scatter only taking a vector of tensors and not device_mesh
+
+        hidden_states = ttnn.experimental.tensor.reduce_scatter(
             hidden_states,
-            self.dense_4h_to_h_weights,
-            self.model_config["COMPUTE_KERNEL_CONFIG"],
-            output_mem_config=self.model_config["DENSE_4H_TO_H_MM_OUTPUT_MEMCFG"],
-            output_dtype=self.model_config["DENSE_4H_TO_H_MM_OUTPUT_DTYPE"],
-            overwrite_subblock_w=1,  # Workaround for non deterministic output/hang; issue: 7066
-            overwrite_subblock_h=1,
+            scatter_split_dim=3,
+            reduce_op=ttnn.experimental.tensor.ReduceOpMath.SUM,
+            num_links=1,  # only one link supported for now
+            output_mem_config=self.model_config["DEFAULT_MEMCFG"],
         )
+
+        hidden_states = ttnn.aggregate_as_tensor(hidden_states)  # Workaround reverse
+
         # return TT Tensor
         return hidden_states

--- a/models/demos/t3000/falcon40b/tt/model_config.py
+++ b/models/demos/t3000/falcon40b/tt/model_config.py
@@ -185,6 +185,7 @@ def get_decode_model_config(model_config_str, input_shape, num_devices):
 
     # Set defaults for dtype and mem_config for all ops
     model_config = {
+        "LLM_MODE": "decode",
         "DEFAULT_DTYPE": dtype,
         "DEFAULT_MEMCFG": mem_config,
         "MOVE_DECODER_OUTPUT_BOOL": False,
@@ -549,14 +550,14 @@ def get_decode_model_config(model_config_str, input_shape, num_devices):
         )
         model_config["SELFOUT_MM_OUTPUT_MEMCFG"] = WIDTH_SHARDED_MEMCFG
         model_config["DENSE_H_TO_4H_MM_OUTPUT_MEMCFG"] = WIDTH_SHARDED_MEMCFG
-        model_config["MLP_ALL_GATHER_OUTPUT_MEMCFG"] = ttnn.experimental.tensor.MemoryConfig(
+        model_config["MLP_REDUCE_SCATTER_OUTPUT_MEMCFG"] = ttnn.experimental.tensor.MemoryConfig(
             ttnn.experimental.tensor.TensorMemoryLayout.WIDTH_SHARDED,
             ttnn.experimental.tensor.BufferType.L1,
             ttnn.experimental.tensor.ShardSpec(
                 shard_spec_32_cores_grid,
                 [
                     row_height,
-                    shard_width_4x_hidden_dim_across_32_cores,
+                    shard_width_hidden_dim_per_device_across_32_cores,
                 ],
                 ttnn.experimental.tensor.ShardOrientation.ROW_MAJOR,
                 False,
@@ -588,11 +589,11 @@ def get_decode_model_config(model_config_str, input_shape, num_devices):
         )
         model_config["DENSE_4H_TO_H_MM_PROGCFG"] = ttnn.MatmulMultiCoreReuseMultiCast1DProgramConfig(
             compute_with_storage_grid_size=(8, 4),
-            in0_block_w=32,  # TODO: Can this be larger
-            out_subblock_h=1,  # TODO: Can this be larger
+            in0_block_w=4,
+            out_subblock_h=1,
             out_subblock_w=1,
             per_core_M=row_height // 32,
-            per_core_N=1,
+            per_core_N=8,
             fuse_batch=True,
             fused_activation=None,
             mcast_in0=True,
@@ -683,6 +684,7 @@ def get_prefill_model_config(model_config_str, input_shape, num_devices):
 
     # Set defaults for dtype and mem_config for all ops
     model_config = {
+        "LLM_MODE": "prefill",
         "DEFAULT_DTYPE": dtype,
         "DEFAULT_MEMCFG": mem_config,
         "MOVE_DECODER_OUTPUT_BOOL": False,
@@ -745,50 +747,76 @@ def get_prefill_model_config(model_config_str, input_shape, num_devices):
     model_config["row_height"] = row_height
     model_config["BATCH_SIZE"] = batch_size
     model_config["SEQ_LEN"] = seq_len
+    model_config["MAX_MM_SEQ_LEN"] = 2048
+    model_config["MM_SEQ_LEN_BATCHED"] = 1024
 
-    # Layernorm is an exception that are sharded also here, because the interleaved OP does not fit in L1 for 40b hidden size
-    layernorm_num_cores_x = 8
-    layernorm_max_num_cores_y = 8
+    def get_grid_size_and_core_range_based_on_num_cores(num_cores):
+        assert num_cores in (16, 32, 64)
+        if num_cores == 16:
+            attention_mm_grid_size = (8, 2)
+            attn_core_range_set = ttnn.experimental.tensor.CoreRangeSet(
+                {
+                    ttnn.experimental.tensor.CoreRange(
+                        ttnn.experimental.tensor.CoreCoord(0, 0),
+                        ttnn.experimental.tensor.CoreCoord(7, 1),
+                    ),
+                }
+            )
+        elif num_cores == 32:
+            attention_mm_grid_size = (8, 4)
+            attn_core_range_set = ttnn.experimental.tensor.CoreRangeSet(
+                {
+                    ttnn.experimental.tensor.CoreRange(
+                        ttnn.experimental.tensor.CoreCoord(0, 0),
+                        ttnn.experimental.tensor.CoreCoord(7, 3),
+                    ),
+                }
+            )
+        else:
+            attention_mm_grid_size = (8, 8)
+            attn_core_range_set = ttnn.experimental.tensor.CoreRangeSet(
+                {
+                    ttnn.experimental.tensor.CoreRange(
+                        ttnn.experimental.tensor.CoreCoord(0, 0),
+                        ttnn.experimental.tensor.CoreCoord(7, 7),
+                    ),
+                }
+            )
+        return attention_mm_grid_size, attn_core_range_set
 
-    layernorm_slice_size = 1024
+    # Attetnion in slices: determine number of cores and shard spec
     attention_max_slice_size = 1024
     attention_slice_size = min(attention_max_slice_size, row_height)
     assert row_height % attention_slice_size == 0
 
     attention_num_slices = row_height // attention_slice_size
     attention_num_cores = min(attention_slice_size * 16 // 32, 64)
-    assert attention_num_cores in (16, 32, 64)
 
-    if attention_num_cores == 16:
-        attention_mm_grid_size = (8, 2)
-        attn_shard_spec = ttnn.experimental.tensor.CoreRangeSet(
-            {
-                ttnn.experimental.tensor.CoreRange(
-                    ttnn.experimental.tensor.CoreCoord(0, 0),
-                    ttnn.experimental.tensor.CoreCoord(7, 1),
-                ),
-            }
-        )
-    elif attention_num_cores == 32:
-        attention_mm_grid_size = (8, 4)
-        attn_shard_spec = ttnn.experimental.tensor.CoreRangeSet(
-            {
-                ttnn.experimental.tensor.CoreRange(
-                    ttnn.experimental.tensor.CoreCoord(0, 0),
-                    ttnn.experimental.tensor.CoreCoord(7, 3),
-                ),
-            }
-        )
-    else:
-        attention_mm_grid_size = (8, 8)
-        attn_shard_spec = ttnn.experimental.tensor.CoreRangeSet(
-            {
-                ttnn.experimental.tensor.CoreRange(
-                    ttnn.experimental.tensor.CoreCoord(0, 0),
-                    ttnn.experimental.tensor.CoreCoord(7, 7),
-                ),
-            }
-        )
+    attention_mm_grid_size, attn_core_range_set = get_grid_size_and_core_range_based_on_num_cores(attention_num_cores)
+
+    # MLP in slices: determine number of cores and shard spec
+    use_mm_2d_start = 512
+    model_config["MM_USE_MM2D_START"] = use_mm_2d_start
+    mlp_max_slice_size = 1024
+    mlp_slice_size = min(mlp_max_slice_size, row_height)
+    assert row_height % mlp_slice_size == 0
+
+    mlp_num_slices = max(row_height // mlp_slice_size, 1)
+    model_config["MLP_NUM_SLICES"] = mlp_num_slices
+
+    if row_height >= use_mm_2d_start:
+        mlp_num_cores = min(mlp_slice_size // 32 * 8, 64)
+    else:  # use 1d matmuls and width sharding
+        mlp_num_cores = 32
+
+    mlpn_mm_grid_size, mlp_core_range_set = get_grid_size_and_core_range_based_on_num_cores(mlp_num_cores)
+    model_config["MLP_GRID_SIZE"] = mlpn_mm_grid_size
+
+    # Layernorm sharding (the interleaved OP does not fit in L1 for 40b hidden size)
+    layernorm_num_cores_x = 8
+    layernorm_max_num_cores_y = 8
+
+    layernorm_slice_size = 1024
 
     (
         layernorm_block_sharded_mem_config,
@@ -803,7 +831,6 @@ def get_prefill_model_config(model_config_str, input_shape, num_devices):
         dtype,
     )
 
-    # partial block sharded layernorm
     model_config["PARTIAL_LN_MEMCFG"] = layernorm_block_sharded_mem_config
     model_config["PARTIAL_LN_PROGCFG"] = layernorm_block_sharded_prg_config
     model_config["PARTIAL_LN_INPLACE_PROGCFG"] = layernorm_block_sharded_prg_config_inplace
@@ -856,7 +883,7 @@ def get_prefill_model_config(model_config_str, input_shape, num_devices):
         ttnn.experimental.tensor.TensorMemoryLayout.HEIGHT_SHARDED,
         ttnn.experimental.tensor.BufferType.L1,
         ttnn.experimental.tensor.ShardSpec(
-            attn_shard_spec,
+            attn_core_range_set,
             [16 * attention_slice_size // attention_num_cores, head_dim],
             ttnn.experimental.tensor.ShardOrientation.ROW_MAJOR,
             False,
@@ -867,7 +894,7 @@ def get_prefill_model_config(model_config_str, input_shape, num_devices):
         ttnn.experimental.tensor.TensorMemoryLayout.HEIGHT_SHARDED,
         ttnn.experimental.tensor.BufferType.L1,
         ttnn.experimental.tensor.ShardSpec(
-            attn_shard_spec,
+            attn_core_range_set,
             [16 * attention_slice_size // attention_num_cores, row_height],
             ttnn.experimental.tensor.ShardOrientation.ROW_MAJOR,
             False,
@@ -878,12 +905,83 @@ def get_prefill_model_config(model_config_str, input_shape, num_devices):
         ttnn.experimental.tensor.TensorMemoryLayout.HEIGHT_SHARDED,
         ttnn.experimental.tensor.BufferType.L1,
         ttnn.experimental.tensor.ShardSpec(
-            attn_shard_spec,
+            attn_core_range_set,
             [16 * attention_slice_size // attention_num_cores, head_dim],
             ttnn.experimental.tensor.ShardOrientation.ROW_MAJOR,
             False,
         ),
     )
+
+    # MLP sharding specs
+
+    if row_height > use_mm_2d_start:
+        model_config["MLP_INPUT_SHARD_SPEC"] = [
+            row_height // mlp_num_slices // mlpn_mm_grid_size[1],
+            hidden_size // mlpn_mm_grid_size[0],
+        ]
+
+        model_config["MLP_INPUT_SHARD_LAYOUT"] = ttnn.experimental.tensor.TensorMemoryLayout.BLOCK_SHARDED
+
+        model_config["DENSE_H_TO_4H_MM_OPTIMIZED_OUTPUT_MEMCFG"] = ttnn.experimental.tensor.MemoryConfig(
+            ttnn.experimental.tensor.TensorMemoryLayout.BLOCK_SHARDED,
+            ttnn.experimental.tensor.BufferType.L1,
+            ttnn.experimental.tensor.ShardSpec(
+                mlp_core_range_set,
+                [
+                    row_height // mlp_num_slices // mlpn_mm_grid_size[1],
+                    hidden_size // 8 // mlpn_mm_grid_size[0],
+                ],
+                ttnn.experimental.tensor.ShardOrientation.ROW_MAJOR,
+                False,
+            ),
+        )
+        model_config["DENSE_4H_TO_H_MM_OPTIMIZED_OUTPUT_MEMCFG"] = ttnn.experimental.tensor.MemoryConfig(
+            ttnn.experimental.tensor.TensorMemoryLayout.BLOCK_SHARDED,
+            ttnn.experimental.tensor.BufferType.L1,
+            ttnn.experimental.tensor.ShardSpec(
+                mlp_core_range_set,
+                [
+                    row_height // mlp_num_slices // mlpn_mm_grid_size[1],
+                    hidden_size // mlpn_mm_grid_size[0],
+                ],
+                ttnn.experimental.tensor.ShardOrientation.ROW_MAJOR,
+                False,
+            ),
+        )
+    else:  # use 1d matmuls and width sharding
+        model_config["MLP_INPUT_SHARD_SPEC"] = [
+            row_height // mlp_num_slices,
+            hidden_size // mlp_num_cores,
+        ]
+
+        model_config["MLP_INPUT_SHARD_LAYOUT"] = ttnn.experimental.tensor.TensorMemoryLayout.WIDTH_SHARDED
+
+        model_config["DENSE_H_TO_4H_MM_OPTIMIZED_OUTPUT_MEMCFG"] = ttnn.experimental.tensor.MemoryConfig(
+            ttnn.experimental.tensor.TensorMemoryLayout.WIDTH_SHARDED,
+            ttnn.experimental.tensor.BufferType.L1,
+            ttnn.experimental.tensor.ShardSpec(
+                mlp_core_range_set,
+                [
+                    row_height // mlp_num_slices,
+                    hidden_size // 8 // mlp_num_cores,
+                ],
+                ttnn.experimental.tensor.ShardOrientation.ROW_MAJOR,
+                False,
+            ),
+        )
+        model_config["DENSE_4H_TO_H_MM_OPTIMIZED_OUTPUT_MEMCFG"] = ttnn.experimental.tensor.MemoryConfig(
+            ttnn.experimental.tensor.TensorMemoryLayout.WIDTH_SHARDED,
+            ttnn.experimental.tensor.BufferType.L1,
+            ttnn.experimental.tensor.ShardSpec(
+                mlp_core_range_set,
+                [
+                    row_height // mlp_num_slices,
+                    hidden_size // mlp_num_cores,
+                ],
+                ttnn.experimental.tensor.ShardOrientation.ROW_MAJOR,
+                False,
+            ),
+        )
 
     # uncomment if need to see all the configs
     # logger.debug(f"Falcon model config: \n{pretty_print_model_config(model_config)}")


### PR DESCRIPTION
Optimized falcon40b MLP
- Use 2D weight stationary fracturing (FF1 in W and FF2 in H)
- MLP in two slices and sharded
- ReduceScatter after FF2 instead of AllGather between FF1 and FF2
- Also added for decode (different sharding scheme, otherwise same concept)

Perf
S=128: 1456 -> 1859 tok/s
S=2048: 2857 -> 3355 tok/s

CI
- [x] Frequent tests: https://github.com/tenstorrent/tt-metal/actions/runs/9991004079
- [x] Unit tests: https://github.com/tenstorrent/tt-metal/actions/runs/9991008499
- [x] Demo tests: https://github.com/tenstorrent/tt-metal/actions/runs/9990971375
- [x] Perf tests: https://github.com/tenstorrent/tt-metal/actions/runs/9991012788