### PR TITLE
Support multiple user indices in paged_update_cache

### DIFF
--- a/tests/tt_eager/python_api_testing/unit_testing/misc/test_paged_update_cache.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/misc/test_paged_update_cache.py
@@ -1,0 +1,207 @@
+# SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+
+# SPDX-License-Identifier: Apache-2.0
+
+import torch
+import pytest
+
+import tt_lib as ttl
+from loguru import logger
+from models.utility_functions import nearest_32, pad_by_zero
+from tests.tt_eager.python_api_testing.sweep_tests.comparison_funcs import comp_pcc, comp_equal
+from models.utility_functions import is_grayskull
+
+
+def run_test_update_cache_decode(
+    cache_idx, head_dim, max_seq_len, num_users, num_heads, input_dtype, cache_dtype, device
+):
+    input_shape = [1, num_users, num_heads, head_dim]
+    cache_shape = [num_users, num_heads, max_seq_len, head_dim]
+    cache = torch.randn(cache_shape).bfloat16().float()
+    cachett = ttl.tensor.Tensor(cache, cache_dtype).to(ttl.tensor.Layout.TILE).to(device)
+    x = torch.randn(input_shape).bfloat16().float()
+    x_pad = torch.nn.functional.pad(x, (0, 0, 0, 32 - num_heads), "constant", 0)
+
+    xt = ttl.tensor.Tensor(x_pad, input_dtype).to(ttl.tensor.Layout.TILE)
+    # Input is sharded
+    compute_grid_size = device.compute_with_storage_grid_size()
+    num_cores = num_users
+    shard_grid = ttl.tensor.CoreRangeSet(ttl.tensor.num_cores_to_corerange_set(num_cores, compute_grid_size, True))
+    input_shard_spec = ttl.tensor.ShardSpec(
+        shard_grid,
+        [
+            xt.volume() // xt.get_legacy_shape()[-1] // num_cores,
+            xt.get_legacy_shape()[-1],
+        ],
+        ttl.tensor.ShardOrientation.ROW_MAJOR,
+        False,
+    )
+    input_mem_config = ttl.tensor.MemoryConfig(
+        ttl.tensor.TensorMemoryLayout.HEIGHT_SHARDED, ttl.tensor.BufferType.L1, input_shard_spec
+    )
+    xt = xt.to(device, input_mem_config)
+
+    # Create arbitrary update indices
+    cache_idxs = [cache_idx + i * 17 for i in range(num_users)]
+
+    cachett = ttl.operations.primary.transformers.paged_update_cache(cachett, xt, cache_idxs)
+
+    for i in range(num_users):
+        update_idx = cache_idxs[i]
+        x_view = x.permute(1, 0, 2, 3)[i, ...]
+        cache[i, 0:num_heads, update_idx : update_idx + x.shape[-2], 0 : x.shape[-1]] = x_view
+
+    tt_got_back = cachett.cpu().to(ttl.tensor.Layout.ROW_MAJOR).to_torch()
+
+    tt_updated_slice = []
+    for i in range(num_users):
+        update_idx = cache_idxs[i]
+        tt_slice = tt_got_back[i, 0:num_heads, update_idx : update_idx + x.shape[-2], 0 : x.shape[-1]]
+        tt_updated_slice.append(tt_slice)
+    tt_updated_slice = torch.stack(tt_updated_slice, dim=0).permute(1, 0, 2, 3)
+
+    if input_dtype == ttl.tensor.DataType.BFLOAT16 and cache_dtype == input_dtype:
+        eq_cache, output_cache = comp_equal(cache, tt_got_back)  # checks the entire kv cache
+        eq_update, output_update = comp_equal(x, tt_updated_slice)  # checks the updated parts
+    else:
+        eq_cache, output_cache = comp_pcc(cache, tt_got_back)  # checks the entire kv cache
+        eq_update, output_update = comp_pcc(x, tt_updated_slice)  # checks the updated parts
+    logger.debug(output_cache)
+    logger.debug(output_update)
+    assert eq_cache and eq_update
+
+
+@pytest.mark.parametrize("check_memory", [False])
+@pytest.mark.parametrize("head_dim", [128])
+@pytest.mark.parametrize("max_seq_len", [2048])
+@pytest.mark.parametrize("num_users", [32])
+@pytest.mark.parametrize("num_heads", [1])
+@pytest.mark.parametrize("input_dtype", [ttl.tensor.DataType.BFLOAT16, ttl.tensor.DataType.BFLOAT8_B])
+@pytest.mark.parametrize("cache_idx", [0, 1, 127, 1057])
+@pytest.mark.parametrize("cache_dtype", [ttl.tensor.DataType.BFLOAT16, ttl.tensor.DataType.BFLOAT8_B])
+def test_update_cache_decode(
+    check_memory,
+    cache_idx,
+    head_dim,
+    max_seq_len,
+    num_users,
+    num_heads,
+    input_dtype,
+    cache_dtype,
+    device,
+    use_program_cache,
+):
+    if check_memory:
+        # Create dram tensors to check for overflow
+        cache_shape = [num_users, num_heads, max_seq_len, head_dim]
+        dram_low = ttl.tensor.Tensor(torch.zeros(cache_shape), cache_dtype).to(ttl.tensor.Layout.TILE).to(device)
+        reserved_space = ttl.tensor.Tensor(torch.zeros(cache_shape), cache_dtype).to(ttl.tensor.Layout.TILE).to(device)
+        dram_high = ttl.tensor.Tensor(torch.zeros(cache_shape), cache_dtype).to(ttl.tensor.Layout.TILE).to(device)
+        reserved_space.deallocate(True)
+
+        # Create sharded tensors to check for overflow
+        input_shape = [1, num_users, num_heads, head_dim]
+        x = torch.zeros(input_shape)
+        x_pad = torch.nn.functional.pad(x, (0, 0, 0, 32 - num_heads), "constant", 0)
+
+        xt = ttl.tensor.Tensor(x_pad, input_dtype).to(ttl.tensor.Layout.TILE)
+        # Input is sharded
+        compute_grid_size = device.compute_with_storage_grid_size()
+        num_cores = num_users
+        shard_grid = ttl.tensor.CoreRangeSet(ttl.tensor.num_cores_to_corerange_set(num_cores, compute_grid_size, True))
+        input_shard_spec = ttl.tensor.ShardSpec(
+            shard_grid,
+            [
+                xt.volume() // xt.get_legacy_shape()[-1] // num_cores,
+                xt.get_legacy_shape()[-1],
+            ],
+            ttl.tensor.ShardOrientation.ROW_MAJOR,
+            False,
+        )
+        input_mem_config = ttl.tensor.MemoryConfig(
+            ttl.tensor.TensorMemoryLayout.HEIGHT_SHARDED, ttl.tensor.BufferType.L1, input_shard_spec
+        )
+        sharded_low = xt.to(device, input_mem_config)
+        sharded_reserved = ttl.tensor.Tensor(x_pad, input_dtype).to(ttl.tensor.Layout.TILE).to(device, input_mem_config)
+        sharded_high = ttl.tensor.Tensor(x_pad, input_dtype).to(ttl.tensor.Layout.TILE).to(device, input_mem_config)
+        sharded_reserved.deallocate(True)
+
+    run_test_update_cache_decode(
+        cache_idx, head_dim, max_seq_len, num_users, num_heads, input_dtype, cache_dtype, device
+    )
+
+    if check_memory:
+        # Check for overflow
+        def check_zero(tensor):
+            assert (tensor == 0).all()
+
+        dram_low = dram_low.cpu().to(ttl.tensor.Layout.ROW_MAJOR).to_torch()
+        dram_high = dram_high.cpu().to(ttl.tensor.Layout.ROW_MAJOR).to_torch()
+        sharded_low = sharded_low.cpu().to(ttl.tensor.Layout.ROW_MAJOR).to_torch()
+        sharded_high = sharded_high.cpu().to(ttl.tensor.Layout.ROW_MAJOR).to_torch()
+
+        check_zero(dram_low)
+        check_zero(dram_high)
+        check_zero(sharded_low)
+        check_zero(sharded_high)
+
+
+@pytest.mark.parametrize("head_dim", [128])
+@pytest.mark.parametrize("max_seq_len", [2048])
+@pytest.mark.parametrize("num_users", [32])
+@pytest.mark.parametrize("num_heads", [1])
+@pytest.mark.parametrize("input_dtype", [ttl.tensor.DataType.BFLOAT16, ttl.tensor.DataType.BFLOAT8_B])
+@pytest.mark.parametrize("cache_idx", [127, 1057])
+@pytest.mark.parametrize("cache_dtype", [ttl.tensor.DataType.BFLOAT16, ttl.tensor.DataType.BFLOAT8_B])
+def test_update_cache_decode_program_cache(
+    cache_idx,
+    head_dim,
+    max_seq_len,
+    num_users,
+    num_heads,
+    input_dtype,
+    cache_dtype,
+    device,
+    use_program_cache,
+):
+    dummy_tensors = []
+    for i in range(2):
+        # Create dram tensors to check for overflow
+        cache_shape = [num_users, num_heads, max_seq_len, head_dim]
+        dram_low = ttl.tensor.Tensor(torch.zeros(cache_shape), cache_dtype).to(ttl.tensor.Layout.TILE).to(device)
+        dummy_tensors.append(dram_low)
+
+        # Create sharded tensors to check for overflow
+        input_shape = [1, num_users, num_heads, head_dim]
+        x = torch.zeros(input_shape)
+        x_pad = torch.nn.functional.pad(x, (0, 0, 0, 32 - num_heads), "constant", 0)
+
+        xt = ttl.tensor.Tensor(x_pad, input_dtype).to(ttl.tensor.Layout.TILE)
+        # Input is sharded
+        compute_grid_size = device.compute_with_storage_grid_size()
+        num_cores = num_users
+        shard_grid = ttl.tensor.CoreRangeSet(ttl.tensor.num_cores_to_corerange_set(num_cores, compute_grid_size, True))
+        input_shard_spec = ttl.tensor.ShardSpec(
+            shard_grid,
+            [
+                xt.volume() // xt.get_legacy_shape()[-1] // num_cores,
+                xt.get_legacy_shape()[-1],
+            ],
+            ttl.tensor.ShardOrientation.ROW_MAJOR,
+            False,
+        )
+        input_mem_config = ttl.tensor.MemoryConfig(
+            ttl.tensor.TensorMemoryLayout.HEIGHT_SHARDED, ttl.tensor.BufferType.L1, input_shard_spec
+        )
+        sharded_low = xt.to(device, input_mem_config)
+        dummy_tensors.append(sharded_low)
+
+        run_test_update_cache_decode(
+            cache_idx, head_dim, max_seq_len, num_users, num_heads, input_dtype, cache_dtype, device
+        )
+        # Test that cache_idx is correctly updated between cached runs
+        run_test_update_cache_decode(
+            cache_idx + 1, head_dim, max_seq_len, num_users, num_heads, input_dtype, cache_dtype, device
+        )
+
+    assert device.num_program_cache_entries() == 1

--- a/tt_eager/tt_dnn/op_library/CMakeLists.txt
+++ b/tt_eager/tt_dnn/op_library/CMakeLists.txt
@@ -200,6 +200,8 @@ set(TT_DNN_SRCS
     ${CMAKE_CURRENT_SOURCE_DIR}/embeddings/embeddings_op.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/update_cache/multi_core/update_cache_op_multi_core.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/update_cache/update_cache_op.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/paged_update_cache/multi_core/paged_update_cache_op_multi_core.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/paged_update_cache/paged_update_cache_op.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/fold/fold_op.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/fold/single_core/fold_op_single_core.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/fold/multi_core/fold_op_multi_core.cpp

--- a/tt_eager/tt_dnn/op_library/paged_update_cache/kernels/compute/update_cache.cpp
+++ b/tt_eager/tt_dnn/op_library/paged_update_cache/kernels/compute/update_cache.cpp
@@ -1,0 +1,58 @@
+// SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <cstdint>
+
+#include "compute_kernel_api/common.h"
+#include "compute_kernel_api/pack_untilize.h"
+#include "compute_kernel_api/tilize.h"
+
+namespace NAMESPACE {
+void MAIN {
+    constexpr uint32_t cache_cb = get_compile_time_arg_val(0);
+    constexpr uint32_t in_cb = get_compile_time_arg_val(1);
+    constexpr uint32_t untilized_cache_cb = get_compile_time_arg_val(2);
+    constexpr uint32_t untilized_cache2_cb = get_compile_time_arg_val(3);
+    constexpr uint32_t untilized_in_cb = get_compile_time_arg_val(4);
+    constexpr uint32_t out_cb = get_compile_time_arg_val(5);
+    constexpr uint32_t Wt = get_compile_time_arg_val(6);
+
+    pack_untilize_init<Wt>(in_cb, untilized_in_cb);
+
+
+    cb_wait_front(in_cb, Wt);
+    cb_reserve_back(untilized_in_cb, Wt);
+    pack_untilize_block<Wt>(in_cb, 1, untilized_in_cb);
+    cb_push_back(untilized_in_cb, Wt);
+    cb_pop_front(in_cb, Wt);
+
+    unpack_reconfig_data_format_srca(in_cb, cache_cb);
+
+    pack_untilize_init_short<Wt>(cache_cb, untilized_cache_cb);
+
+
+    // Untilize a block from the cache
+    cb_wait_front(cache_cb, Wt);
+    cb_reserve_back(untilized_cache_cb, Wt);
+    pack_untilize_block<Wt>(cache_cb, 1, untilized_cache_cb);
+    cb_push_back(untilized_cache_cb, Wt);
+    cb_pop_front(cache_cb, Wt);
+
+    pack_untilize_uninit(untilized_cache_cb);
+
+    unpack_reconfig_data_format_srca(cache_cb, untilized_cache2_cb);
+    pack_reconfig_data_format(untilized_cache_cb, out_cb);
+
+    tilize_init_short(untilized_cache2_cb, Wt);
+
+
+    // Wait on writer to update block. Tilize.
+    cb_wait_front(untilized_cache2_cb, Wt);
+    cb_reserve_back(out_cb, Wt);
+    tilize_block(untilized_cache2_cb, Wt, out_cb);
+    cb_push_back(out_cb, Wt);
+    cb_pop_front(untilized_cache2_cb, Wt);
+
+}
+} // NAMESPACE

--- a/tt_eager/tt_dnn/op_library/paged_update_cache/kernels/dataflow/reader_update_cache_interleaved_start_id.cpp
+++ b/tt_eager/tt_dnn/op_library/paged_update_cache/kernels/dataflow/reader_update_cache_interleaved_start_id.cpp
@@ -1,0 +1,40 @@
+// SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <stdint.h>
+#include "dataflow_api.h"
+
+void kernel_main() {
+    const uint32_t cache_addr  = get_arg_val<uint32_t>(0);
+    const uint32_t Wt          = get_arg_val<uint32_t>(1);
+    const uint32_t cache_start_id = get_arg_val<uint32_t>(2);
+
+    constexpr bool cache_is_dram = get_compile_time_arg_val(0) == 1;
+    constexpr uint32_t cache_cb_id = get_compile_time_arg_val(1);
+    constexpr uint32_t input_cb_id = get_compile_time_arg_val(2);
+
+    const uint32_t cache_tile_bytes = get_tile_size(cache_cb_id);
+    const DataFormat cache_data_format = get_dataformat(cache_cb_id);
+
+    const InterleavedAddrGenFast<cache_is_dram> s0 = {
+        .bank_base_address = cache_addr,
+        .page_size = cache_tile_bytes,
+        .data_format = cache_data_format
+    };
+
+    cb_reserve_back(input_cb_id, Wt);
+    cb_push_back(input_cb_id, Wt);
+
+    uint32_t cache_id = cache_start_id;
+
+    cb_reserve_back(cache_cb_id, Wt);
+    uint32_t cache_l1_write_addr = get_write_ptr(cache_cb_id);
+    for (uint32_t curr_cache_id = cache_id; curr_cache_id < cache_id + Wt; ++curr_cache_id) {
+        noc_async_read_tile(curr_cache_id, s0, cache_l1_write_addr);
+        cache_l1_write_addr += cache_tile_bytes;
+    }
+
+    noc_async_read_barrier();
+    cb_push_back(cache_cb_id, Wt );
+}

--- a/tt_eager/tt_dnn/op_library/paged_update_cache/kernels/dataflow/writer_update_cache_interleaved_start_id.cpp
+++ b/tt_eager/tt_dnn/op_library/paged_update_cache/kernels/dataflow/writer_update_cache_interleaved_start_id.cpp
@@ -1,0 +1,60 @@
+// SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <stdint.h>
+#include "dataflow_api.h"
+// #include "dprint.h"
+
+void kernel_main() {
+    const uint32_t cache_addr  = get_arg_val<uint32_t>(0);
+    const uint32_t Wt          = get_arg_val<uint32_t>(1);
+    const uint32_t cache_start_id = get_arg_val<uint32_t>(2);
+    const uint32_t Wbytes      = get_arg_val<uint32_t>(3);
+    const uint32_t cache_tile_offset_B = get_arg_val<uint32_t>(4);
+
+    constexpr bool cache_is_dram = get_compile_time_arg_val(0) == 1;
+    constexpr uint32_t cache_cb_id = get_compile_time_arg_val(1);
+    constexpr uint32_t untilized_cache_cb_id = get_compile_time_arg_val(2);
+    constexpr uint32_t untilized_cache2_cb_id = get_compile_time_arg_val(3);
+    constexpr uint32_t untilized_input_cb_id = get_compile_time_arg_val(4);
+
+    const uint32_t cache_tile_bytes = get_tile_size(cache_cb_id);
+    const DataFormat cache_data_format = get_dataformat(cache_cb_id);
+
+    const InterleavedAddrGenFast<cache_is_dram> s0 = {
+        .bank_base_address = cache_addr,
+        .page_size = cache_tile_bytes,
+        .data_format = cache_data_format
+    };
+
+    uint32_t cache_id = cache_start_id;
+
+    cb_wait_front(untilized_input_cb_id, Wt);
+    uint64_t input_l1_read_addr = get_noc_addr(get_read_ptr(untilized_input_cb_id));
+
+    // Wait on compute to untilize a block. Update that block in L1.
+    cb_wait_front(untilized_cache_cb_id, Wt);
+    cb_reserve_back(untilized_cache2_cb_id, Wt);
+    uint32_t cache_l1_write_addr = get_read_ptr(untilized_cache_cb_id) + cache_tile_offset_B;
+    noc_async_read(input_l1_read_addr, cache_l1_write_addr, Wbytes);
+    noc_async_read_barrier();
+    cb_push_back(untilized_cache2_cb_id, Wt);
+    cb_pop_front(untilized_cache_cb_id, Wt); // NEW
+
+    // Wait on compute to tilize an updated block. Write that block to DRAM
+    cb_wait_front(cache_cb_id, Wt);
+    uint32_t out_l1_read_addr = get_read_ptr(cache_cb_id);
+    for(uint32_t curr_cache_id = cache_id; curr_cache_id < cache_id + Wt; ++curr_cache_id) {
+        noc_async_write_tile(curr_cache_id, s0, out_l1_read_addr);
+        out_l1_read_addr += cache_tile_bytes;
+    }
+
+    noc_async_writes_flushed();
+    cb_pop_front(cache_cb_id, Wt);
+
+    cb_pop_front(untilized_input_cb_id, Wt);
+
+    // Delay syncing the writes to maximize perf.
+    noc_async_write_barrier();
+}

--- a/tt_eager/tt_dnn/op_library/paged_update_cache/multi_core/paged_update_cache_op_multi_core.cpp
+++ b/tt_eager/tt_dnn/op_library/paged_update_cache/multi_core/paged_update_cache_op_multi_core.cpp
@@ -1,0 +1,273 @@
+// SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "tt_dnn/op_library/paged_update_cache/paged_update_cache_op.hpp"
+#include "tt_dnn/op_library/work_split.hpp"
+
+#include "tt_metal/host_api.hpp"
+#include "tt_metal/common/constants.hpp"
+#include "tt_metal/detail/util.hpp"
+#include <stdint.h>
+
+using namespace tt::constants;
+
+namespace tt {
+namespace operations {
+namespace primary {
+
+operation::ProgramWithCallbacks paged_update_cache_multi_core(const Tensor& cache_tensor, const Tensor &input_tensor, const std::vector<uint32_t> update_idxs, const uint32_t batch_offset, DeviceComputeKernelConfig compute_kernel_config) {
+    Program program{};
+
+    tt::DataFormat cache_cb_data_format = tt_metal::datatype_to_dataformat_converter(cache_tensor.get_dtype());
+    uint32_t cache_single_tile_size = tt_metal::detail::TileSize(cache_cb_data_format);
+
+    tt::DataFormat input_cb_data_format = tt_metal::datatype_to_dataformat_converter(input_tensor.get_dtype());
+    uint32_t input_single_tile_size = tt_metal::detail::TileSize(input_cb_data_format);
+
+    tt_metal::Device *device = input_tensor.device();
+
+    bool fp32_dest_acc_en;
+    std::visit([&](auto&& compute_kernel_config) {
+        using T = std::decay_t<decltype(compute_kernel_config)>;
+        if constexpr (std::is_same_v<T, GrayskullComputeKernelConfig>) {
+            TT_ASSERT(device->arch() == ARCH::GRAYSKULL, "kernel config is not for graykull");
+            fp32_dest_acc_en = false;
+        } else if constexpr (std::is_same_v<T, WormholeComputeKernelConfig>) {
+            TT_ASSERT(device->arch() == ARCH::WORMHOLE_B0, "kernel config is not for wormhole_b0");
+            fp32_dest_acc_en = input_cb_data_format == tt::DataFormat::Float32 ? true : compute_kernel_config.fp32_dest_acc_en;
+        } else {
+            TT_FATAL("arch not supported");
+        }
+
+    }, compute_kernel_config);
+
+    tt::DataFormat interm_cb_data_format = fp32_dest_acc_en ? tt::DataFormat::Float32 : tt::DataFormat::Float16_b;
+    uint32_t interm_single_tile_size = tt_metal::detail::TileSize(interm_cb_data_format);
+
+    uint32_t Wt = cache_tensor.get_legacy_shape()[-1] / TILE_WIDTH;
+
+    // Width size after untilize
+    uint32_t Wbytes = fp32_dest_acc_en ? cache_tensor.get_legacy_shape()[-1] * sizeof(float) : cache_tensor.get_legacy_shape()[-1] * sizeof(bfloat16);
+
+    log_debug("cache_cb_data_format: {}", cache_cb_data_format);
+    log_debug("input_cb_data_format: {}", input_cb_data_format);
+    log_debug("interm_cb_data_format: {}", interm_cb_data_format);
+    log_debug("Wbytes: {}", Wbytes);
+    log_debug("Wt: {}", Wt);
+
+
+    uint32_t cache_total_num_tiles = cache_tensor.volume() / TILE_HW;
+    uint32_t cache_batch_num_tiles = cache_total_num_tiles / cache_tensor.get_legacy_shape()[0];
+    // uint32_t cache_head_num_tiles = cache_batch_num_tiles / cache_tensor.get_legacy_shape()[1];
+
+    uint32_t num_tiles = input_tensor.volume() / TILE_HW;
+
+    uint32_t B = input_tensor.get_legacy_shape()[1];
+    uint32_t num_heads = cache_tensor.get_legacy_shape()[1];
+
+    auto compute_with_storage_grid_size = device->compute_with_storage_grid_size();
+    uint32_t num_cores_x = compute_with_storage_grid_size.x;
+    uint32_t num_cores_y = compute_with_storage_grid_size.y;
+
+    bool row_major;
+    uint32_t num_cores, num_batched_heads_per_core;
+
+    CoreRangeSet all_cores({});
+
+    std::optional<ShardSpec> shard_spec = input_tensor.shard_spec();
+
+    uint32_t num_input_tiles;
+
+    row_major = shard_spec.value().orientation == ShardOrientation::ROW_MAJOR;
+    all_cores = shard_spec.value().grid;
+    num_cores = all_cores.num_cores();
+    num_batched_heads_per_core = shard_spec.value().shape[0] / TILE_HEIGHT;
+    num_input_tiles = shard_spec.value().shape[0] * shard_spec.value().shape[1] / TILE_HW;
+    auto bbox = all_cores.bounding_box();
+    num_cores_x = bbox.end.x + 1;
+    num_cores_y = bbox.end.y + 1;
+
+    uint32_t src0_cb_index = CB::c_in0;
+    uint32_t num_cache_tiles = 2 * Wt; // double buffered
+    tt_metal::CircularBufferConfig cb_src0_config = tt_metal::CircularBufferConfig(num_cache_tiles * cache_single_tile_size, {{src0_cb_index, cache_cb_data_format}})
+		.set_page_size(src0_cb_index, cache_single_tile_size);
+    auto cb_src0 = tt_metal::CreateCircularBuffer(program, all_cores, cb_src0_config);
+
+    uint32_t src1_cb_index = CB::c_in1;
+    tt_metal::CircularBufferConfig cb_src1_config = tt_metal::CircularBufferConfig(num_input_tiles * input_single_tile_size, {{src1_cb_index, input_cb_data_format}})
+		.set_page_size(src1_cb_index, input_single_tile_size);
+    if (shard_spec.has_value()) {
+        cb_src1_config = cb_src1_config.set_globally_allocated_address(*input_tensor.buffer());
+    }
+    auto cb_src1 = tt_metal::CreateCircularBuffer(program, all_cores, cb_src1_config);
+    uint32_t interm0_cb_index = CB::c_intermed0;
+    uint32_t interm1_cb_index = CB::c_intermed1;
+
+    uint32_t num_interm_tiles = 2 * Wt; // double buffered
+    std::map<uint8_t, tt::DataFormat> interim_data_format_spec = {
+        {interm0_cb_index, interm_cb_data_format},
+        {interm1_cb_index, interm_cb_data_format}
+    };
+    tt_metal::CircularBufferConfig cb_interm0_config = tt_metal::CircularBufferConfig(num_interm_tiles * interm_single_tile_size, interim_data_format_spec)
+		.set_page_size(interm0_cb_index, interm_single_tile_size)
+        .set_page_size(interm1_cb_index, interm_single_tile_size);
+    auto cb_interm0 = tt_metal::CreateCircularBuffer(program, all_cores, cb_interm0_config);
+
+    uint32_t interm2_cb_index = CB::c_intermed2;
+    tt_metal::CircularBufferConfig cb_interm2_config = tt_metal::CircularBufferConfig(num_interm_tiles * interm_single_tile_size, {{interm2_cb_index, interm_cb_data_format}})
+		.set_page_size(interm2_cb_index, interm_single_tile_size);
+    auto cb_interm2 = tt_metal::CreateCircularBuffer(program, all_cores, cb_interm2_config);
+
+    // Output is same tensor as cache input, so cb/tile size is same
+    uint32_t output_cb_index = CB::c_out0;
+
+    // Must buffer all tiles for a single head
+    uint32_t num_output_tiles = B * Wt;
+    tt_metal::CircularBufferConfig cb_output_config = tt_metal::CircularBufferConfig(num_output_tiles * cache_single_tile_size, {{output_cb_index, cache_cb_data_format}})
+		.set_page_size(output_cb_index, cache_single_tile_size);
+    auto cb_output = tt_metal::CreateCircularBuffer(program, all_cores, cb_output_config);
+
+    auto src_buffer = input_tensor.buffer();
+    auto dst_buffer = cache_tensor.buffer();
+
+    bool src_is_dram = src_buffer->buffer_type() == tt_metal::BufferType::DRAM ? 1 : 0;
+    bool dst_is_dram = dst_buffer->buffer_type() == tt_metal::BufferType::DRAM ? 1 : 0;
+
+    std::vector<uint32_t> reader_compile_time_args = {
+        (std::uint32_t) dst_is_dram,
+        (std::uint32_t) src0_cb_index,
+        (std::uint32_t) src1_cb_index,
+    };
+
+    std::vector<uint32_t> writer_compile_time_args = {
+        (std::uint32_t) dst_is_dram,
+        (std::uint32_t) output_cb_index,
+        (std::uint32_t) interm0_cb_index,
+        (std::uint32_t) interm1_cb_index,
+        (std::uint32_t) interm2_cb_index,
+    };
+
+
+    tt_metal::KernelHandle unary_reader_kernel_id = tt_metal::CreateKernel(
+        program,
+        "tt_eager/tt_dnn/op_library/paged_update_cache/kernels/dataflow/reader_update_cache_interleaved_start_id.cpp",
+        all_cores,
+        tt_metal::ReaderDataMovementConfig(reader_compile_time_args));
+
+    tt_metal::KernelHandle unary_writer_kernel_id = tt_metal::CreateKernel(
+        program,
+        "tt_eager/tt_dnn/op_library/paged_update_cache/kernels/dataflow/writer_update_cache_interleaved_start_id.cpp",
+        all_cores,
+        tt_metal::WriterDataMovementConfig(writer_compile_time_args));
+
+    vector<uint32_t> compute_kernel_args = {
+        src0_cb_index,
+        src1_cb_index,
+        interm0_cb_index,
+        interm1_cb_index,
+        interm2_cb_index,
+        output_cb_index,
+        Wt,
+    };
+
+    auto compute_kernel_id = tt_metal::CreateKernel(
+        program,
+        "tt_eager/tt_dnn/op_library/paged_update_cache/kernels/compute/update_cache.cpp",
+        all_cores,
+        tt_metal::ComputeConfig{.fp32_dest_acc_en=fp32_dest_acc_en, .compile_args = compute_kernel_args}
+    );
+
+    const auto& cores = grid_to_cores(num_cores, num_cores_x, num_cores_y, row_major);
+
+    for (uint32_t i = 0, num_tiles_read = 0; i < num_cores; ++i) {
+        const CoreCoord &core = cores.at(i);
+        const uint32_t update_idx = update_idxs.at(i);
+        // Cache tile info
+        const uint32_t cache_batch_tile_offset = i * cache_batch_num_tiles;
+        const uint32_t cache_start_id = cache_batch_tile_offset + (update_idx / TILE_HEIGHT) * Wt;
+        // Offset to write into untilized cache
+        uint32_t tile_update_offset_B = update_idx % TILE_HEIGHT * Wbytes;
+
+        SetRuntimeArgs(
+            program,
+            unary_reader_kernel_id,
+            core,
+            {
+                dst_buffer->address(),
+                Wt, cache_start_id
+            }
+        );
+
+        SetRuntimeArgs(
+            program,
+            unary_writer_kernel_id,
+            core,
+            {
+                dst_buffer->address(),
+                Wt, cache_start_id, Wbytes, tile_update_offset_B
+            }
+        );
+    }
+
+    auto override_runtime_arguments_callback = [
+        unary_reader_kernel_id,
+        unary_writer_kernel_id,
+        cores,
+        Wbytes,
+        Wt,
+        cb_src1,
+        cache_batch_num_tiles
+    ](
+        const void* operation,
+        Program& program,
+        const std::vector<Tensor>& input_tensors,
+        const std::vector<std::optional<const Tensor>>&,
+        const std::vector<Tensor>& output_tensors
+    ) {
+        const std::vector<uint32_t> update_idxs = static_cast<const PagedUpdateCache*>(operation)->update_idxs;
+
+
+
+        auto src_buffer = input_tensors.at(1).buffer();
+
+        auto dst_buffer = input_tensors.at(0).buffer();
+
+        if (input_tensors.at(1).is_sharded()) {
+            UpdateDynamicCircularBufferAddress(program, cb_src1, *src_buffer);
+        }
+
+        auto& reader_args_by_core = GetRuntimeArgs(program, unary_reader_kernel_id);
+        auto& writer_args_by_core = GetRuntimeArgs(program, unary_writer_kernel_id);
+
+        for (uint32_t i = 0, num_tiles_read = 0; i < cores.size(); ++i){
+            const uint32_t update_idx = update_idxs.at(i);
+            // Cache tile info
+            const uint32_t cache_batch_tile_offset = i * cache_batch_num_tiles;
+            const uint32_t cache_start_id = cache_batch_tile_offset + (update_idx / TILE_HEIGHT) * Wt;
+            // Offset to write into untilized cache
+            uint32_t tile_update_offset_B = update_idx % TILE_HEIGHT * Wbytes;
+
+            const CoreCoord &core = cores.at(i);
+
+            {
+                auto &runtime_args = reader_args_by_core.at(core.x).at(core.y);
+                runtime_args[0] = dst_buffer->address();
+                runtime_args[2] = cache_start_id;
+            }
+
+            {
+                auto &runtime_args = writer_args_by_core.at(core.x).at(core.y);
+                runtime_args[0] = dst_buffer->address();
+                runtime_args[2] = cache_start_id;
+                runtime_args[4] = tile_update_offset_B;
+            }
+        }
+    };
+
+    return {.program=std::move(program), .override_runtime_arguments_callback=override_runtime_arguments_callback};
+}
+
+}   // namespace primary
+}   // namespace operations
+}   // namespace tt

--- a/tt_eager/tt_dnn/op_library/paged_update_cache/paged_update_cache_op.cpp
+++ b/tt_eager/tt_dnn/op_library/paged_update_cache/paged_update_cache_op.cpp
@@ -1,0 +1,88 @@
+// SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "tt_dnn/op_library/paged_update_cache/paged_update_cache_op.hpp"
+
+#include "tt_metal/common/constants.hpp"
+#include "tt_metal/host_api.hpp"
+
+using namespace tt::constants;
+
+namespace tt {
+namespace operations {
+namespace primary {
+
+
+void PagedUpdateCache::validate(const std::vector<Tensor>& input_tensors) const {
+    const auto& cache_tensor = input_tensors.at(0);
+    const auto& input_tensor = input_tensors.at(1);
+    TT_FATAL(input_tensor.storage_type() == StorageType::DEVICE and cache_tensor.storage_type() == StorageType::DEVICE, "Operands to update_cache need to be on device!");
+    TT_FATAL(input_tensor.device() == cache_tensor.device(), "Operands to update_cache need to be on the same device!");
+    TT_FATAL(input_tensor.buffer() != nullptr and cache_tensor.buffer() != nullptr, "Operands to update_cache need to be allocated in buffers on device!");
+    TT_FATAL((input_tensor.get_layout() == Layout::TILE && cache_tensor.get_layout() == Layout::TILE), "Inputs to update_cache must be tilized");
+    TT_FATAL(input_tensor.get_dtype() == DataType::FLOAT32 || input_tensor.get_dtype() == DataType::BFLOAT16 || input_tensor.get_dtype() == DataType::BFLOAT8_B);
+    TT_FATAL(cache_tensor.get_dtype() == DataType::FLOAT32 || cache_tensor.get_dtype() == DataType::BFLOAT16 || cache_tensor.get_dtype() == DataType::BFLOAT8_B);
+
+    // input_tensor: [1, b, padded_heads, head_dim]
+    // cache_tensor: [b, 1, kv_len, head_dim]
+    TT_FATAL(input_tensor.get_legacy_shape()[-1] == cache_tensor.get_legacy_shape()[-1]);
+    TT_FATAL(input_tensor.get_legacy_shape()[0] == 1);
+    TT_FATAL(cache_tensor.get_legacy_shape()[1] == 1, "Only supports 1 head now.");
+    TT_FATAL(input_tensor.get_legacy_shape()[1] == cache_tensor.get_legacy_shape()[0]);
+    TT_FATAL(cache_tensor.memory_config().memory_layout == TensorMemoryLayout::INTERLEAVED);
+
+    TT_FATAL(this->op_type == PagedUpdateCacheOpType::UPDATE, "Only UPDATE operation is supported for PagedUpdateCache");
+
+    if (this->op_type == PagedUpdateCacheOpType::UPDATE) {
+        TT_FATAL(input_tensor.get_legacy_shape()[1] == this->update_idxs.size(), "Number of update_idxs should match batch size");
+        TT_FATAL(input_tensor.is_sharded());
+        if (input_tensor.is_sharded()) {
+            TT_FATAL(input_tensor.memory_config().memory_layout != TensorMemoryLayout::WIDTH_SHARDED);
+            TT_FATAL(input_tensor.shard_spec().value().shape[1] == input_tensor.get_legacy_shape()[-1]);
+            // Require even work division for now
+            TT_FATAL(input_tensor.shard_spec().value().grid.num_cores() == cache_tensor.get_legacy_shape()[0], "Input must be sharded on batch num cores");
+            TT_FATAL((input_tensor.volume() / input_tensor.get_legacy_shape()[-1]) % input_tensor.shard_spec().value().shape[0] == 0);
+            TT_FATAL(input_tensor.shard_spec().value().orientation == ShardOrientation::ROW_MAJOR, "Only ROW_MAJOR sharding is supported");
+        }
+        TT_FATAL(cache_tensor.get_legacy_shape()[0] <= input_tensor.get_legacy_shape()[-1]);
+        // batch offset is only valid if num_user less than 32 and batch_offset + num_user <= 32
+        if (cache_tensor.get_legacy_shape()[0] < 32) TT_FATAL(this->batch_offset + cache_tensor.get_legacy_shape()[0] <= 32);
+        else TT_FATAL(this->batch_offset == 0);
+    }
+}
+
+std::vector<Shape> PagedUpdateCache::compute_output_shapes(const std::vector<Tensor>& input_tensors) const {
+    // Do nothing because it's an in-place operation
+    return {};
+}
+
+std::vector<Tensor> PagedUpdateCache::create_output_tensors(const std::vector<Tensor>& input_tensors) const {
+    // Do nothing because it's an in-place operation
+    return {};
+}
+
+operation::ProgramWithCallbacks PagedUpdateCache::create_program(const std::vector<Tensor>& input_tensors, std::vector<Tensor> &output_tensors) const {
+    const auto& cache_tensor = input_tensors.at(0);
+    const auto& input_tensor = input_tensors.at(1);
+
+    switch(this->get_parallelization_strategy(input_tensors)) {
+        case PagedUpdateCacheOpParallelizationStrategy::MULTI_CORE:
+        default:
+            return paged_update_cache_multi_core(cache_tensor, input_tensor, this->update_idxs, this->batch_offset, this->compute_kernel_config);
+    };
+}
+
+
+PagedUpdateCacheOpParallelizationStrategy PagedUpdateCache::get_parallelization_strategy(const std::vector<Tensor> &input_tensors) const {
+    return PagedUpdateCacheOpParallelizationStrategy::MULTI_CORE;
+}
+
+const operation::Hash PagedUpdateCache::compute_program_hash(
+    const std::vector<Tensor> &input_tensors) const {
+    return operation::hash_operation<PagedUpdateCache>(this->op_type, input_tensors);
+}
+
+}   // namespace primary
+}   // namespace operations
+}   // namespace tt

--- a/tt_eager/tt_dnn/op_library/paged_update_cache/paged_update_cache_op.hpp
+++ b/tt_eager/tt_dnn/op_library/paged_update_cache/paged_update_cache_op.hpp
@@ -1,0 +1,75 @@
+// SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include "tensor/tensor.hpp"
+#include "tt_dnn/op_library/run_operation.hpp"
+#include "tt_metal/host_api.hpp"
+#include "tt_dnn/op_library/compute_kernel_config.hpp"
+
+namespace tt {
+namespace operations {
+namespace primary {
+using namespace tt_metal;
+
+enum class PagedUpdateCacheOpParallelizationStrategy {
+    MULTI_CORE
+};
+
+enum class PagedUpdateCacheOpType {
+    UPDATE
+};
+
+operation::ProgramWithCallbacks paged_update_cache_multi_core(const Tensor& cache_tensor, const Tensor &input_tensor, const std::vector<uint32_t> update_idxs, const uint32_t batch_offset, DeviceComputeKernelConfig compute_kernel_config);
+
+struct PagedUpdateCache {
+    const uint32_t batch_idx;
+    const std::vector<uint32_t> update_idxs;
+    const uint32_t batch_offset;
+    const PagedUpdateCacheOpType op_type;
+    const DeviceComputeKernelConfig compute_kernel_config;
+
+    PagedUpdateCacheOpParallelizationStrategy get_parallelization_strategy(const std::vector<Tensor> &input_tensors) const;
+
+    void validate(const std::vector<Tensor> &input_tensors) const;
+    std::vector<Shape> compute_output_shapes(
+        const std::vector<Tensor> &input_tensors) const;
+    std::vector<Tensor> create_output_tensors(
+        const std::vector<Tensor> &input_tensors) const;
+
+
+    operation::ProgramWithCallbacks create_program(
+        const std::vector<Tensor> &input_tensors,
+        std::vector<Tensor> &output_tensors) const;
+
+    static constexpr auto attribute_names =
+        std::forward_as_tuple("batch_idx", "update_idxs", "batch_offset", "op_type", "compute_kernel_config");
+
+    const auto attribute_values() const {
+        return std::forward_as_tuple(batch_idx, update_idxs, batch_offset, op_type, compute_kernel_config);
+    }
+
+    const operation::Hash compute_program_hash(
+        const std::vector<Tensor> &input_tensors) const;
+};
+
+namespace transformers {
+inline Tensor paged_update_cache(const Tensor& cache_tensor, const Tensor& input_tensor, const std::vector<uint32_t> update_idxs, const uint32_t batch_offset, std::optional<const DeviceComputeKernelConfig> compute_kernel_config = std::nullopt) {
+    std::vector<Tensor> dummy_output_tensors = {Tensor(operation::get_workers_for_op_output({cache_tensor, input_tensor}))};
+    operation::launch_op(
+        [update_idxs, batch_offset, compute_kernel_config] (const std::vector<Tensor>& input_tensors, const std::vector<std::optional<const Tensor>>& optional_input_tensors, const std::vector<std::optional<Tensor>>& optional_output_tensors) mutable -> std::vector<Tensor> {
+            auto& cache_tensor = input_tensors.at(0);
+            auto& input_tensor = input_tensors.at(1);
+            auto kernel_config_val = init_device_compute_kernel_config(input_tensor.device()->arch(), compute_kernel_config);
+            return operation::run(PagedUpdateCache{0, update_idxs, batch_offset, PagedUpdateCacheOpType::UPDATE, kernel_config_val}, {cache_tensor, input_tensor});
+        }, {cache_tensor, input_tensor}, dummy_output_tensors);
+    return cache_tensor;
+}
+} // namespace transformers
+
+
+}   // namespace primary
+}   // namespace operations
+}   // namespace tt

--- a/tt_eager/tt_lib/csrc/operations/primary/transformers/module.hpp
+++ b/tt_eager/tt_lib/csrc/operations/primary/transformers/module.hpp
@@ -6,6 +6,7 @@
 
 #include "tt_dnn/op_library/transformer_tms/transformer_tms.hpp"
 #include "tt_dnn/op_library/sdpa/sdpa_op.hpp"
+#include "tt_dnn/op_library/paged_update_cache/paged_update_cache_op.hpp"
 
 #include <pybind11/pybind11.h>
 #include <pybind11/stl.h>
@@ -129,6 +130,20 @@ void py_module(py::module& m_transformers) {
 
         "Accepts a `SDPAMultiCoreProgramConfig` which specifies the grid size and chunk tiles in the K/V/Mask sequence lengths (Q chunk tiles is not used). The op parallelizes over `b` and K/V/Mask's `s` dimension."
         );
+
+    m_transformers.def(
+        "paged_update_cache",
+        &paged_update_cache,
+        py::arg("cache_tensor").noconvert(),
+        py::arg("input_tensor").noconvert(),
+        py::arg("update_idxs").noconvert(),
+        py::arg("batch_offset") = 0,
+        py::arg("compute_kernel_config").noconvert() = std::nullopt,
+        R"doc(
+        Paged update cache operation. This operation expects the following inputs: cache_tensor of shape [B, 1, kv_len, head_dim] and input_tensor of shape [1, B, 1[32], head_dim] where input_tensor is height sharded on B cores. update_idxs will specify for each batch element which token to update in the cache.
+        )doc"
+    );
+
 
 }
 


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/6733

### Problem description
For continuous batching, we need to support a decode batch of users which are on different token indices. `update_cache` is one of these ops which today assumes that all users are on the same index, so it must be changed to accept a list of indices.

### What's changed
Instead of changing the existing `update_cache` op to add this support, we decided to create a new op called `paged_update_cache`. This is because
1. The way we used `update_cache` was abusing the parallelization logic. We provided inputs of shape `[1, b, num_heads, head_dim]` instead of the expected `[1, num_heads, b, head_dim]` in order to get free parallelization over dim 1. Changing `update_cache` to become aware of this input format so it could also make use of a vector of token indices would be fairly complicated.
2. We have an upcoming change to `update_cache`, `fill_cache`, and `FlashDecode` planned to implement a paged KV cache. All of these kernels will have to change their readers/writers to take a `page_table` tensor to indirectly index into another tensor. By creating this `paged_update_cache` op which we can extend soon to use a `page_table`, we can separate this concern from the standard `update_cache` op.

### Checklist
- [x] Post commit CI passes (https://github.com/tenstorrent/tt-metal/actions/runs/9861076101)
- [ ] Model regression CI testing passes (if applicable)
- [x] New/Existing tests provide coverage for changes
