### PR TITLE
#9801: Add cb alignment fix for blackhole that was missed in rebase

### DIFF
--- a/tt_metal/impl/dispatch/command_queue.cpp
+++ b/tt_metal/impl/dispatch/command_queue.cpp
@@ -984,7 +984,7 @@ void EnqueueProgramCommand::assemble_device_commands() {
                     curr_sub_cmd_idx);
                 curr_sub_cmd_idx += num_sub_cmds_in_cmd;
                 uint32_t curr_sub_cmd_data_offset_words =
-                    (write_offset_bytes + CQ_PREFETCH_CMD_BARE_MIN_SIZE +
+                    (write_offset_bytes + (sizeof(CQPrefetchCmd) + sizeof(CQDispatchCmd)) +
                      align(num_sub_cmds_in_cmd * sizeof(CQDispatchWritePackedMulticastSubCmd), L1_ALIGNMENT)) /
                     sizeof(uint32_t);
                 for (uint32_t i = 0; i < num_sub_cmds_in_cmd; ++i) {


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/9801

### Problem description
There were a series of alignment updates but this one was missed on a bad merge conflict rebase

### What's changed
Use `sizeof(CQPrefetchCmd) + sizeof(CQDispatchCmd)` rather than `CQ_PREFETCH_CMD_BARE_MIN_SIZE`


### Checklist
- [x] [Post commit CI passes](https://github.com/tenstorrent/tt-metal/actions/runs/9860924364)
