### PR TITLE
Add PyBind to TTNN Slice (Formerly Referred to Unpad in TT Lib)

### DIFF
--- a/ttnn/cpp/ttnn/operations/data_movement/data_movement_pybind.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/data_movement_pybind.hpp
@@ -10,6 +10,7 @@
 #include "ttnn/cpp/pybind11/decorators.hpp"
 #include "ttnn/operations/data_movement.hpp"
 #include "ttnn/operations/data_movement/pad/pad_pybind.hpp"
+#include "ttnn/operations/data_movement/slice/slice_pybind.hpp"
 #include "ttnn/operations/data_movement/concat/concat_pybind.hpp"
 #include "ttnn/operations/data_movement/permute/permute_pybind.hpp"
 
@@ -121,6 +122,7 @@ void py_module(py::module& module) {
     detail::bind_concat(module);
     bind_upsample(module);
     detail::bind_pad(module);
+    detail::bind_slice(module);
     bind_repeat(module);
     bind_repeat_interleave(module);
 }

--- a/ttnn/cpp/ttnn/operations/data_movement/slice/device/slice_op.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/slice/device/slice_op.hpp
@@ -13,8 +13,8 @@ namespace ttnn::operations::data_movement {
 
 
 struct Slice {
-    const tt::tt_metal::Shape output_tensor_start;
-    const tt::tt_metal::Shape output_tensor_end;
+    const tt::tt_metal::Shape slice_start;
+    const tt::tt_metal::Shape slice_end;
     const MemoryConfig output_mem_config;
 
 
@@ -23,6 +23,9 @@ struct Slice {
     std::vector<Tensor> create_output_tensors(const std::vector<Tensor>& input_tensors, const std::vector<std::optional<Tensor>>& output_tensors) const;
     operation::ProgramWithCallbacks create_program(
         const std::vector<Tensor>& input_tensors, std::vector<Tensor>& output_tensors) const;
+
+    const operation::Hash compute_program_hash(
+        const std::vector<Tensor> &input_tensors) const;
 };
 
 

--- a/ttnn/cpp/ttnn/operations/data_movement/slice/slice.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/slice/slice.hpp
@@ -87,6 +87,36 @@ struct ExecuteSlice {
     }
 
 
+    static ttnn::Tensor execute_on_worker_thread(
+        uint8_t queue_id,
+        const ttnn::Tensor& input_tensor,
+        const ttnn::Shape output_tensor_start,
+        const ttnn::Shape output_tensor_end,
+        const std::optional<MemoryConfig>& memory_config_arg) {
+
+        std::vector<uint32_t> output_tensor_start_vec(output_tensor_start.rank());
+        std::vector<uint32_t> output_tensor_end_vec(output_tensor_end.rank());
+
+        for(uint32_t dim = 0; dim<output_tensor_start.rank(); dim++) {
+            output_tensor_start_vec[dim] = output_tensor_start[dim];
+        }
+        
+        for(uint32_t dim = 0; dim<output_tensor_end.rank(); dim++) {
+            output_tensor_end_vec[dim] = output_tensor_end[dim];
+        }
+
+        return execute_on_worker_thread(
+                queue_id, 
+                input_tensor, 
+                output_tensor_start_vec, 
+                output_tensor_end_vec, 
+                memory_config_arg
+                );
+
+
+    }
+
+
 };
 
 }  // namespace data_movement

--- a/ttnn/cpp/ttnn/operations/data_movement/slice/slice_pybind.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/slice/slice_pybind.hpp
@@ -1,0 +1,63 @@
+// SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <pybind11/pybind11.h>
+#include <pybind11/stl.h>
+
+#include "ttnn/cpp/pybind11/decorators.hpp"
+
+#include "slice.hpp"
+
+namespace ttnn::operations::data_movement::detail {
+namespace py = pybind11;
+
+void bind_slice(py::module& module) {
+    auto doc =
+        R"doc(
+            slice(input_tensor: ttnn.Tensor, slice_start: ttnn.Shape, slice_end: ttnn.Shape,  value: Union[int, float], *, Optional[ttnn.MemoryConfig] = None) -> ttnn.Tensor
+
+            Returns a sliced tensor.
+
+            Equivalent pytorch code:
+
+            .. code-block:: python
+
+                output_tensor = input_tensor[output_start: output_end]
+
+            Args:
+                * :attr:`input_tensor`: Input Tensor.
+                * :attr:`slice_start`: Shape describing where to start slice.
+                * :attr:`slice_end`: Shape describing where to end slice.
+
+            Keyword Args:
+                * :attr:`memory_config`: Memory Config of the output tensor
+                * :attr:`queue_id` (Optional[uint8]): command queue id
+        )doc";
+
+    using OperationType = decltype(ttnn::slice);
+    ttnn::bind_registered_operation(
+        module,
+        ttnn::slice,
+        doc,
+        ttnn::pybind_overload_t{
+            [] (const OperationType& self,
+                const ttnn::Tensor& input_tensor,
+                const ttnn::Shape & slice_start,
+                const ttnn::Shape & slice_end,
+                const std::optional<ttnn::MemoryConfig>& memory_config,
+                uint8_t queue_id) {
+                    return self(queue_id, input_tensor, slice_start, slice_end, memory_config);
+                },
+                py::arg("input_tensor"),
+                py::arg("slice_start"),
+                py::arg("slice_end"),
+                py::kw_only(),
+                py::arg("memory_config") = std::nullopt,
+                py::arg("queue_id") = 0,
+                }
+        );
+}
+}  // namespace ttnn::operations::data_movement::detail


### PR DESCRIPTION
### Ticket
[Link to Github Issu](https://github.com/tenstorrent/tt-metal/issues/9745)e

### Problem description
Migrating Unpad to ttnn

### What's changed
Added TTNN Python binding, moved the unit test reference from tt_lib to ttnn. Will change rest of references in future PR and then delete tt_lib bindings

### Checklist
- [ ] Post commit CI passes (in progress)
- [ ] Model regression CI testing passes (if applicable)
- [ ] New/Existing tests provide coverage for changes
