### PR TITLE
#7736: Remove unused reduce dim & type from reduce_init*

### DIFF
--- a/tests/tt_metal/tt_metal/test_kernels/compute/layernorm.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/compute/layernorm.cpp
@@ -104,7 +104,7 @@ void MAIN {
          */
         ACQ();
         cb_reserve_back(cb_ex, 1*onetile);
-        reduce_init_delta<false>(REDUCE_OP, REDUCE_DIM);
+        reduce_init_delta<false>();
         for (uint32_t wt = 0; wt < Wt; wt += blk) {
             cb_wait_front(cb_x, wt+blk);
             for (uint32_t j = 0; j < blk; j++) {
@@ -160,7 +160,7 @@ void MAIN {
          * TODO(AP): can save space here by reusing CB
          */
         cb_reserve_back(cb_ex2, 1);
-        reduce_init_delta<false>(REDUCE_OP, REDUCE_DIM);
+        reduce_init_delta<false>();
         ACQ();
         cb_wait_front(cb_xmm2, Wt);
         //cb_wait_front(cb_xmm, Wt);

--- a/tests/tt_metal/tt_metal/test_kernels/compute/max_pool.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/compute/max_pool.cpp
@@ -71,7 +71,7 @@ inline void reduce_h(uint32_t out_nelems,
                      uint32_t out_cb_id) {
     cb_wait_front(in_cb_id, in_ntiles_hwc * out_nelems);
     cb_reserve_back(out_cb_id, out_ntiles_c * out_nelems);
-    reduce_init_delta<false>(PoolType::MAX, ReduceDim::REDUCE_COL, out_cb_id);
+    reduce_init_delta<false, PoolType::MAX, ReduceDim::REDUCE_COL>(out_cb_id);
     uint32_t base_tile_id = 0;
     for (uint32_t c_i = 0; c_i < in_ntiles_c * out_nelems; ++c_i) {
         // add to accumulator all the in_ntiles_hw in a column of tiles

--- a/tests/tt_metal/tt_metal/test_kernels/compute/max_pool_multi_core.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/compute/max_pool_multi_core.cpp
@@ -71,7 +71,7 @@ inline void reduce_h(uint32_t out_nelems,
                      uint32_t out_cb_id) {
     cb_wait_front(in_cb_id, in_ntiles_hwc * out_nelems);
     cb_reserve_back(out_cb_id, out_ntiles_c * out_nelems);
-    reduce_init_delta<false>(PoolType::MAX, ReduceDim::REDUCE_COL, out_cb_id);
+    reduce_init_delta<false, PoolType::MAX, ReduceDim::REDUCE_COL>(out_cb_id);
     uint32_t base_tile_id = 0;
     for (uint32_t c_i = 0; c_i < in_ntiles_c * out_nelems; ++c_i) {
         // add to accumulator all the in_ntiles_hw in a column of tiles

--- a/tests/tt_metal/tt_metal/test_kernels/compute/reduce_h.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/compute/reduce_h.cpp
@@ -15,7 +15,7 @@ void MAIN {
     constexpr uint32_t Wt = get_compile_time_arg_val(1);
     constexpr uint32_t NC = get_compile_time_arg_val(2);
 
-    reduce_init<true>(REDUCE_OP, REDUCE_DIM, tt::CB::c_in0, tt::CB::c_in2);
+    reduce_init<true>(tt::CB::c_in0, tt::CB::c_in2);
     cb_wait_front(tt::CB::c_in2, 1); // scaler tile from the reader
 
     for (uint32_t nc = 0; nc < NC; nc++) {

--- a/tests/tt_metal/tt_metal/test_kernels/compute/reduce_hw.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/compute/reduce_hw.cpp
@@ -15,7 +15,7 @@ void MAIN {
     constexpr uint32_t Wt = get_compile_time_arg_val(1);
     constexpr uint32_t NC = get_compile_time_arg_val(2);
 
-    reduce_init<true>(REDUCE_OP, REDUCE_DIM, tt::CB::c_in0, tt::CB::c_in2);
+    reduce_init<true>(tt::CB::c_in0, tt::CB::c_in2);
 
     cb_wait_front(tt::CB::c_in2, 1); // scaler tile from the reader
     for (uint32_t nc = 0; nc < NC; nc++) {

--- a/tests/tt_metal/tt_metal/test_kernels/compute/reduce_w.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/compute/reduce_w.cpp
@@ -15,7 +15,7 @@ void MAIN {
     constexpr uint32_t Wt = get_compile_time_arg_val(1);
     constexpr uint32_t NC = get_compile_time_arg_val(2);
 
-    reduce_init<true>(REDUCE_OP, REDUCE_DIM, tt::CB::c_in0, tt::CB::c_in2);
+    reduce_init<true>(tt::CB::c_in0, tt::CB::c_in2);
 
     cb_wait_front(tt::CB::c_in2, 1); // scaler tile from the reader
     for (uint32_t nc = 0; nc < NC; nc++) {

--- a/tests/tt_metal/tt_metal/test_kernels/compute/rmsnorm.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/compute/rmsnorm.cpp
@@ -117,7 +117,7 @@ void MAIN {
          * compute E[(x)^2]
          */
         cb_reserve_back(cb_ex2, 1);
-        reduce_init_delta<false>(REDUCE_OP, REDUCE_DIM);
+        reduce_init_delta<false>();
         ACQ();
         cb_wait_front(cb_x2, Wt);
         //cb_wait_front(cb_xmm, Wt);

--- a/tests/tt_metal/tt_metal/test_kernels/compute/softmax.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/compute/softmax.cpp
@@ -128,7 +128,7 @@ void MAIN {
 
         ACQ();
         cb_reserve_back(cb_recipsumexps, onetile);
-        reduce_init_delta<false>(REDUCE_OP, REDUCE_DIM);
+        reduce_init_delta<false>();
         for (uint32_t wt = 0; wt < Wt; wt++) {
             cb_wait_front(cb_exps, wt+1); // must be a cumulative wait for correctness
             constexpr uint32_t bcast_scaler0 = 0; // 0th index from bcast_scaler CB

--- a/tt_eager/tt_dnn/kernels/compute/moreh_common.hpp
+++ b/tt_eager/tt_dnn/kernels/compute/moreh_common.hpp
@@ -142,7 +142,7 @@ ALWI void reduce_init_delta_with_dt(PoolType reduce_op, ReduceDim dim, uint32_t 
     #if defined FP32_DEST_ACC_EN
         unpack_reconfig_data_format(icb0, icb1);
     #endif
-    reduce_init_delta<at_start, reduce_type, reduce_dim>(reduce_op, dim, ocb, icb0, icb1);
+    reduce_init_delta<at_start, reduce_type, reduce_dim>(ocb, icb0, icb1);
 }
 
 

--- a/tt_eager/tt_dnn/op_library/groupnorm/kernels/compute/groupnorm_sharded.cpp
+++ b/tt_eager/tt_dnn/op_library/groupnorm/kernels/compute/groupnorm_sharded.cpp
@@ -159,7 +159,7 @@ void MAIN {
             }
 
             // Partial-E[x] for each core
-            reduce_init_delta<false>(REDUCE_OP, REDUCE_DIM);
+            reduce_init_delta<false>();
             cb_reserve_back(cb_ex_partial, 1);
             tile_regs_acquire();
             cb_wait_front(cb_scaler, 1);
@@ -183,7 +183,7 @@ void MAIN {
 
             if constexpr(is_mcast_sender and num_cores_per_mcast_group > 1) {
                 index_b_offset = 0;
-                reduce_init_delta<false>(REDUCE_OP, REDUCE_DIM);
+                reduce_init_delta<false>();
                 cb_reserve_back(cb_ex_global, 1);
                 cb_reserve_back(cb_ex, 1);
                 tile_regs_acquire();
@@ -310,7 +310,7 @@ void MAIN {
 
             // Partial-Var(x)
             index_b_offset = 0;
-            reduce_init_delta<false>(REDUCE_OP, REDUCE_DIM);
+            reduce_init_delta<false>();
             cb_reserve_back(cb_ex_partial, 1);
             cb_wait_front(cb_xmm2, block_hw);
             cb_wait_front(cb_scaler, 1);
@@ -333,7 +333,7 @@ void MAIN {
 
             // global reduce
             if constexpr(is_mcast_sender and num_cores_per_mcast_group > 1) {
-                reduce_init_delta<false>(REDUCE_OP, REDUCE_DIM);
+                reduce_init_delta<false>();
                 cb_reserve_back(cb_ex_global, 1);
                 cb_reserve_back(cb_ex, 1);
                 tile_regs_acquire();

--- a/tt_eager/tt_dnn/op_library/groupnorm/kernels/compute/groupnorm_sharded_v2.cpp
+++ b/tt_eager/tt_dnn/op_library/groupnorm/kernels/compute/groupnorm_sharded_v2.cpp
@@ -201,7 +201,7 @@ void MAIN {
 
             // Partial-E[x]
             index_h_offset = 0;
-            reduce_init_delta<false>(REDUCE_OP, REDUCE_DIM);
+            reduce_init_delta<false>();
             cb_reserve_back(cb_ex_partial, 1);
             tile_regs_acquire();
             cb_wait_front(cb_scaler, 1);
@@ -221,7 +221,7 @@ void MAIN {
             reduce_revert_delta();
 
             if constexpr(is_mcast_sender and num_cores_per_mcast_group > 1) {
-                reduce_init_delta<false>(REDUCE_OP, REDUCE_DIM);
+                reduce_init_delta<false>();
                 cb_reserve_back(cb_ex_global, 1);
                 cb_reserve_back(cb_ex, 1);
                 tile_regs_acquire();
@@ -319,7 +319,7 @@ void MAIN {
 
             // Partial-Var(x)
             index_h_offset = 0;
-            reduce_init_delta<false>(REDUCE_OP, REDUCE_DIM);
+            reduce_init_delta<false>();
             cb_reserve_back(cb_ex_partial, 1);
             tile_regs_acquire();
             cb_wait_front(cb_xmm, block_hw);
@@ -340,7 +340,7 @@ void MAIN {
             reduce_revert_delta();
 
             if constexpr(is_mcast_sender and num_cores_per_mcast_group > 1) {
-                reduce_init_delta<false>(REDUCE_OP, REDUCE_DIM);
+                reduce_init_delta<false>();
                 cb_reserve_back(cb_ex_global, 1);
                 cb_reserve_back(cb_ex, 1);
                 tile_regs_acquire();

--- a/tt_eager/tt_dnn/op_library/layernorm/kernels/compute/layernorm.cpp
+++ b/tt_eager/tt_dnn/op_library/layernorm/kernels/compute/layernorm.cpp
@@ -127,7 +127,7 @@ void MAIN {
          */
         ACQ();
         cb_reserve_back(cb_ex, onetile);
-        reduce_init_delta<false>(REDUCE_OP, REDUCE_DIM);
+        reduce_init_delta<false>();
         for (uint32_t wt = 0; wt < Wt; wt += blk) {
             cb_wait_front(cb_x, wt+blk);
             for (uint32_t j = 0; j < blk; j++) {
@@ -198,7 +198,7 @@ void MAIN {
             unpack_reconfig_data_format(cb_xmm2, cb_scaler);
         }
         cb_reserve_back(cb_ex2, 1);
-        reduce_init_delta<false>(REDUCE_OP, REDUCE_DIM);
+        reduce_init_delta<false>();
         ACQ();
         cb_wait_front(cb_xmm2, Wt);
         //cb_wait_front(cb_xmm, Wt);

--- a/tt_eager/tt_dnn/op_library/layernorm/kernels/compute/layernorm_sharded.cpp
+++ b/tt_eager/tt_dnn/op_library/layernorm/kernels/compute/layernorm_sharded.cpp
@@ -141,7 +141,7 @@ void MAIN {
     #ifndef RMSNORM
     // E[x],
     index_h_offset = 0;
-    reduce_init_delta<false>(REDUCE_OP, REDUCE_DIM);
+    reduce_init_delta<false>();
     cb_wait_front(cb_scaler, 1);
     cb_reserve_back(cb_ex_partial, block_h);
     for (uint32_t i = 0; i < block_h; i++) {
@@ -162,7 +162,7 @@ void MAIN {
 
     // global reduce, cb_ex <-- cb_ex_external, cb_ex_partial
     if constexpr(is_allgather_worker) {
-        reduce_init_delta<false>(REDUCE_OP, REDUCE_DIM);
+        reduce_init_delta<false>();
         cb_reserve_back(cb_ex, num_tiles_per_allgather_worker);
 
         for (uint32_t i = 0; i < num_tiles_per_allgather_worker; i++) {
@@ -257,7 +257,7 @@ void MAIN {
     cb_wait_front(cb_scaler, 1);
     #endif
     cb_reserve_back(cb_ex_partial2, block_h);
-    reduce_init_delta<false>(REDUCE_OP, REDUCE_DIM);
+    reduce_init_delta<false>();
     index_h_offset = 0;
     for (uint32_t i = 0; i < block_h; i++) {
         tile_regs_acquire();
@@ -276,7 +276,7 @@ void MAIN {
 
     // global reduce, cb_ex <-- cb_ex_external, cb_ex_partial
     if constexpr(is_allgather_worker) {
-        reduce_init_delta<false>(REDUCE_OP, REDUCE_DIM);
+        reduce_init_delta<false>();
         cb_reserve_back(cb_ex2, num_tiles_per_allgather_worker);
 
         for (uint32_t i = 0; i < num_tiles_per_allgather_worker; i++) {

--- a/tt_eager/tt_dnn/op_library/layernorm_distributed/kernels/compute/layernorm_post_allgather.cpp
+++ b/tt_eager/tt_dnn/op_library/layernorm_distributed/kernels/compute/layernorm_post_allgather.cpp
@@ -92,7 +92,7 @@ void MAIN {
          * cb_stats = [sum(x0**2), sum(x0), sum(x1**2), sum(x1), ...]
          * RMSNorm packs mean(x**2) into cb_var. Layernorm just uses cb_stats_reduced.
          */
-        reduce_init_delta<false>(REDUCE_OP, REDUCE_DIM);
+        reduce_init_delta<false>();
         cb_wait_front(cb_stats, stats_tiles_cols);
         cb_reserve_back(cb_stats_reduced, stats_tile_stride);
         #ifdef RMSNORM

--- a/tt_eager/tt_dnn/op_library/layernorm_distributed/kernels/compute/layernorm_pre_allgather.cpp
+++ b/tt_eager/tt_dnn/op_library/layernorm_distributed/kernels/compute/layernorm_pre_allgather.cpp
@@ -70,7 +70,7 @@ void MAIN {
          */
         unpack_reconfig_data_format(cb_x2, cb_reduce);
         pack_reconfig_data_format(cb_out);
-        reduce_init_delta<false>(REDUCE_OP, REDUCE_DIM);
+        reduce_init_delta<false>();
         cb_wait_front(cb_x2, Wt);
         cb_reserve_back(cb_out, onetile);
         ACQ();
@@ -91,7 +91,7 @@ void MAIN {
          */
         unpack_reconfig_data_format(cb_inp, cb_reduce);
         pack_reconfig_data_format(cb_out);
-        reduce_init_delta<false>(REDUCE_OP, REDUCE_DIM);
+        reduce_init_delta<false>();
         cb_reserve_back(cb_out, onetile);
         ACQ();
         for (uint32_t wtr = 0; wtr<Wt; wtr++) {

--- a/tt_eager/tt_dnn/op_library/moreh_clip_grad_norm/moreh_clip_grad_norm_step1/kernels/moreh_clip_grad_norm_step1_kernel.cpp
+++ b/tt_eager/tt_dnn/op_library/moreh_clip_grad_norm/moreh_clip_grad_norm_step1/kernels/moreh_clip_grad_norm_step1_kernel.cpp
@@ -129,7 +129,7 @@ void MAIN {
     cb_wait_front(cb_xpowadd, onetile);
     cb_reserve_back(cb_y, onetile);
 
-    reduce_init_delta<false>(REDUCE_OP, REDUCE_DIM);
+    reduce_init_delta<false>();
     reduce_tile(cb_xpowadd, cb_one, 0, 0, dst0);
     reduce_revert_delta();
 

--- a/tt_eager/tt_dnn/op_library/moreh_dot/single_core/kernels/moreh_dot.cpp
+++ b/tt_eager/tt_dnn/op_library/moreh_dot/single_core/kernels/moreh_dot.cpp
@@ -47,7 +47,7 @@ void MAIN {
         }
 
         cb_wait_front(tt::CB::c_intermed0, onetile);
-        reduce_init_delta<false>(REDUCE_OP, REDUCE_DIM);
+        reduce_init_delta<false>();
         reduce_tile(tt::CB::c_intermed0, tt::CB::c_in2, 0, 0, 0);
         cb_pop_front(tt::CB::c_intermed0, onetile);
         reduce_revert_delta();

--- a/tt_eager/tt_dnn/op_library/moreh_linear_backward/kernels/moreh_bias_backward_multi_core_h.cpp
+++ b/tt_eager/tt_dnn/op_library/moreh_linear_backward/kernels/moreh_bias_backward_multi_core_h.cpp
@@ -101,7 +101,7 @@ void MAIN {
                 #if defined FP32_DEST_ACC_EN
                     unpack_reconfig_data_format(cb_reduce, cb_scaler);
                 #endif
-                reduce_init_delta<false>(REDUCE_OP, REDUCE_DIM);
+                reduce_init_delta<false>();
                 reduce_tile(cb_reduce, cb_scaler, 0, 0, 0);
                 reduce_revert_delta();
 

--- a/tt_eager/tt_dnn/op_library/moreh_linear_backward/kernels/moreh_bias_backward_single_core_hw.cpp
+++ b/tt_eager/tt_dnn/op_library/moreh_linear_backward/kernels/moreh_bias_backward_single_core_hw.cpp
@@ -100,7 +100,7 @@ void MAIN {
                 #if defined FP32_DEST_ACC_EN
                     unpack_reconfig_data_format(cb_reduce, cb_scaler);
                 #endif
-                reduce_init_delta<false>(REDUCE_OP, REDUCE_DIM);
+                reduce_init_delta<false>();
                 reduce_tile((do_mask) ? (cb_intermed0) : (cb_in0), cb_scaler, 0, 0, 0);
                 reduce_revert_delta();
 

--- a/tt_eager/tt_dnn/op_library/moreh_mean/kernels/moreh_mean_h.cpp
+++ b/tt_eager/tt_dnn/op_library/moreh_mean/kernels/moreh_mean_h.cpp
@@ -55,7 +55,7 @@ void MAIN {
                 for (uint32_t ht = 0; ht < Ht - 1; ++ht) {
                     cb_wait_front(cb_input, onetile);
 
-                    reduce_init_delta<false>(REDUCE_OP, REDUCE_DIM);
+                    reduce_init_delta<false>();
                     reduce_tile(cb_input, cb_scaler, 0, 0, reduce_dst_idx);
                     reduce_revert_delta();
 
@@ -93,7 +93,7 @@ void MAIN {
                 copy_tile(cb_accum_dst, 0, reduce_dst_idx);
             }
 
-            reduce_init_delta<false>(REDUCE_OP, REDUCE_DIM);
+            reduce_init_delta<false>();
             reduce_tile(cb_input, cb_scaler, 0, 0, reduce_dst_idx);
             reduce_revert_delta();
 

--- a/tt_eager/tt_dnn/op_library/moreh_mean/kernels/moreh_mean_w.cpp
+++ b/tt_eager/tt_dnn/op_library/moreh_mean/kernels/moreh_mean_w.cpp
@@ -53,7 +53,7 @@ void MAIN {
                 for (uint32_t wt = 0; wt < Wt - 1; ++wt) {
                     cb_wait_front(cb_input, onetile);
 
-                    reduce_init_delta<false>(REDUCE_OP, REDUCE_DIM);
+                    reduce_init_delta<false>();
                     reduce_tile(cb_input, cb_scaler, 0, 0, reduce_dst_idx);
                     reduce_revert_delta();
 
@@ -91,7 +91,7 @@ void MAIN {
                 copy_tile(cb_accum_dst, 0, reduce_dst_idx);
             }
 
-            reduce_init_delta<false>(REDUCE_OP, REDUCE_DIM);
+            reduce_init_delta<false>();
             reduce_tile(cb_input, cb_scaler, 0, 0, reduce_dst_idx);
             reduce_revert_delta();
 

--- a/tt_eager/tt_dnn/op_library/moreh_norm/moreh_norm_h/kernels/moreh_norm_h_kernel.cpp
+++ b/tt_eager/tt_dnn/op_library/moreh_norm/moreh_norm_h/kernels/moreh_norm_h_kernel.cpp
@@ -125,7 +125,7 @@ void MAIN {
         cb_wait_front(cb_xpowadd, onetile);
         cb_reserve_back(cb_xpowsum, onetile);
 
-        reduce_init_delta<false>(REDUCE_OP, REDUCE_DIM);
+        reduce_init_delta<false>();
         reduce_tile(cb_xpowadd, cb_one, 0, 0, dst0);
         reduce_revert_delta();
 

--- a/tt_eager/tt_dnn/op_library/moreh_norm/moreh_norm_w/kernels/moreh_norm_w_kernel.cpp
+++ b/tt_eager/tt_dnn/op_library/moreh_norm/moreh_norm_w/kernels/moreh_norm_w_kernel.cpp
@@ -125,7 +125,7 @@ void MAIN {
         cb_wait_front(cb_xpowadd, onetile);
         cb_reserve_back(cb_xpowsum, onetile);
 
-        reduce_init_delta<false>(REDUCE_OP, REDUCE_DIM);
+        reduce_init_delta<false>();
         reduce_tile(cb_xpowadd, cb_one, 0, 0, dst0);
         reduce_revert_delta();
 

--- a/tt_eager/tt_dnn/op_library/moreh_sum/moreh_sum_h_impl/kernels/moreh_sum_h.cpp
+++ b/tt_eager/tt_dnn/op_library/moreh_sum/moreh_sum_h_impl/kernels/moreh_sum_h.cpp
@@ -48,7 +48,7 @@ void MAIN {
                     #if defined FP32_DEST_ACC_EN
                         unpack_reconfig_data_format(cb_input, cb_scaler);
                     #endif
-                    reduce_init_delta<false>(REDUCE_OP, REDUCE_DIM);
+                    reduce_init_delta<false>();
                     reduce_tile(cb_input, cb_scaler, 0, 0, reduce_dst_idx);
                     reduce_revert_delta();
 
@@ -105,7 +105,7 @@ void MAIN {
             #if defined FP32_DEST_ACC_EN
                 unpack_reconfig_data_format(cb_input, cb_scaler);
             #endif
-            reduce_init_delta<false>(REDUCE_OP, REDUCE_DIM);
+            reduce_init_delta<false>();
             reduce_tile(cb_input, cb_scaler, 0, 0, reduce_dst_idx);
             reduce_revert_delta();
             tile_regs_commit();

--- a/tt_eager/tt_dnn/op_library/moreh_sum/moreh_sum_w_impl/kernels/moreh_sum_w.cpp
+++ b/tt_eager/tt_dnn/op_library/moreh_sum/moreh_sum_w_impl/kernels/moreh_sum_w.cpp
@@ -48,7 +48,7 @@ void MAIN {
                     #if defined FP32_DEST_ACC_EN
                         unpack_reconfig_data_format(cb_input, cb_scaler);
                     #endif
-                    reduce_init_delta<false>(REDUCE_OP, REDUCE_DIM);
+                    reduce_init_delta<false>();
                     reduce_tile(cb_input, cb_scaler, 0, 0, reduce_dst_idx);
                     reduce_revert_delta();
 
@@ -105,7 +105,7 @@ void MAIN {
             #if defined FP32_DEST_ACC_EN
                 unpack_reconfig_data_format(cb_input, cb_scaler);
             #endif
-            reduce_init_delta<false>(REDUCE_OP, REDUCE_DIM);
+            reduce_init_delta<false>();
             reduce_tile(cb_input, cb_scaler, 0, 0, reduce_dst_idx);
             reduce_revert_delta();
             tile_regs_commit();

--- a/tt_eager/tt_dnn/op_library/pool/kernels/compute/max_pool.cpp
+++ b/tt_eager/tt_dnn/op_library/pool/kernels/compute/max_pool.cpp
@@ -68,7 +68,7 @@ inline void reduce_h_orig(uint32_t out_nelems,
                      uint32_t out_cb_id) {
     cb_wait_front(in_cb_id, in_ntiles_hwc * out_nelems);
     cb_reserve_back(out_cb_id, out_ntiles_c * out_nelems);
-    reduce_init_delta<false>(PoolType::MAX, ReduceDim::REDUCE_COL, out_cb_id);
+    reduce_init_delta<false, PoolType::MAX, ReduceDim::REDUCE_COL>(out_cb_id);
     uint32_t base_tile_id = 0;
     for (uint32_t c_i = 0; c_i < in_ntiles_c * out_nelems; ++c_i) {
         // add to accumulator all the in_ntiles_hw in a column of tiles

--- a/tt_eager/tt_dnn/op_library/reduce/kernels/compute/reduce_h.cpp
+++ b/tt_eager/tt_dnn/op_library/reduce/kernels/compute/reduce_h.cpp
@@ -13,7 +13,7 @@ void MAIN {
     uint32_t Wt = get_compile_time_arg_val(1);
     uint32_t NC = get_compile_time_arg_val(2);
 
-    reduce_init<true>(REDUCE_OP, REDUCE_DIM, tt::CB::c_in0, tt::CB::c_in2);
+    reduce_init<true>(tt::CB::c_in0, tt::CB::c_in2);
     cb_wait_front(tt::CB::c_in2, 1); // scaler tile from the reader
 
     for (uint32_t nc = 0; nc < NC; nc++) {

--- a/tt_eager/tt_dnn/op_library/reduce/kernels/compute/reduce_hw.cpp
+++ b/tt_eager/tt_dnn/op_library/reduce/kernels/compute/reduce_hw.cpp
@@ -13,7 +13,7 @@ void MAIN {
     uint32_t Wt = get_compile_time_arg_val(1);
     uint32_t NC = get_compile_time_arg_val(2);
 
-    reduce_init<true>(REDUCE_OP, REDUCE_DIM, tt::CB::c_in0, tt::CB::c_in2);
+    reduce_init<true>(tt::CB::c_in0, tt::CB::c_in2);
 
     cb_wait_front(tt::CB::c_in2, 1); // scaler tile from the reader
     for (uint32_t nc = 0; nc < NC; nc++) {

--- a/tt_eager/tt_dnn/op_library/reduce/kernels/compute/reduce_w.cpp
+++ b/tt_eager/tt_dnn/op_library/reduce/kernels/compute/reduce_w.cpp
@@ -13,7 +13,7 @@ void MAIN {
     uint32_t Wt = get_compile_time_arg_val(1);
     uint32_t NC = get_compile_time_arg_val(2);
 
-    reduce_init<true>(REDUCE_OP, REDUCE_DIM, tt::CB::c_in0, tt::CB::c_in2);
+    reduce_init<true>(tt::CB::c_in0, tt::CB::c_in2);
 
     cb_wait_front(tt::CB::c_in2, 1); // scaler tile from the reader
     for (uint32_t nc = 0; nc < NC; nc++) {

--- a/tt_eager/tt_dnn/op_library/sdpa/kernels/compute/sdpa.cpp
+++ b/tt_eager/tt_dnn/op_library/sdpa/kernels/compute/sdpa.cpp
@@ -50,7 +50,7 @@ void reduce_c() {
     // Precondition: scale_cb has 1 produced
     // Postcondition: out_cb has rows produced
 
-    reduce_init_delta<false, pool_type, reduce_dim>(pool_type, reduce_dim, in0_cb, scale_cb, out_cb);
+    reduce_init_delta<false, pool_type, reduce_dim>(in0_cb, scale_cb, out_cb);
 
     const uint32_t num_tiles = rows * cols;
     cb_wait_front(scale_cb, 1);

--- a/tt_eager/tt_dnn/op_library/sdpa/kernels/compute/sdpa_flash_decode.cpp
+++ b/tt_eager/tt_dnn/op_library/sdpa/kernels/compute/sdpa_flash_decode.cpp
@@ -76,7 +76,7 @@ void reduce_c() {
     // Precondition: scale_cb has 1 produced
     // Postcondition: out_cb has rows produced
 
-    reduce_init_delta<false, pool_type, reduce_dim>(pool_type, reduce_dim, in0_cb, scale_cb, out_cb);
+    reduce_init_delta<false, pool_type, reduce_dim>(in0_cb, scale_cb, out_cb);
 
     const uint32_t num_tiles = rows * cols;
     cb_wait_front(scale_cb, 1);

--- a/tt_eager/tt_dnn/op_library/sdpa/kernels/compute/sdpa_noncausal.cpp
+++ b/tt_eager/tt_dnn/op_library/sdpa/kernels/compute/sdpa_noncausal.cpp
@@ -50,7 +50,7 @@ void reduce_c() {
     // Precondition: scale_cb has 1 produced
     // Postcondition: out_cb has rows produced
 
-    reduce_init_delta<false, pool_type, reduce_dim>(pool_type, reduce_dim, in0_cb, scale_cb, out_cb);
+    reduce_init_delta<false, pool_type, reduce_dim>(in0_cb, scale_cb, out_cb);
 
     const uint32_t num_tiles = rows * cols;
     cb_wait_front(scale_cb, 1);

--- a/tt_eager/tt_dnn/op_library/transformer_tms/kernels/compute/ssm_1d_sum_reduce.cpp
+++ b/tt_eager/tt_dnn/op_library/transformer_tms/kernels/compute/ssm_1d_sum_reduce.cpp
@@ -37,7 +37,7 @@ FORCE_INLINE void reduce(uint32_t cb_in, uint32_t cb_scalar, uint32_t cb_out) {
     tile_regs_acquire();
     tile_regs_wait();
 
-    reduce_init_delta<false>(REDUCE_OP, REDUCE_DIM, cb_in, cb_scalar, cb_out);
+    reduce_init_delta<false, REDUCE_OP, REDUCE_DIM>(cb_in, cb_scalar, cb_out);
     reduce_tile(cb_in, cb_scalar, 0, 0, 0);
     reduce_revert_delta<REDUCE_DIM>(cb_out);
 
@@ -63,7 +63,7 @@ void MAIN {
     constexpr uint32_t intermed_cb_id2 = get_compile_time_arg_val(4);
     constexpr uint32_t output_cb_id = get_compile_time_arg_val(5);
 
-    reduce_init<true>(REDUCE_OP, REDUCE_DIM, input_cb_id, scalar_cb_id);
+    reduce_init<true>(input_cb_id, scalar_cb_id);
     reduce_revert_delta<REDUCE_DIM>(intermed_cb_id1);  // Required or else the first tile is wrong
 
     for(uint32_t block_h_id = 0; block_h_id < input_num_blocks_h; block_h_id++){

--- a/tt_metal/include/compute_kernel_api/reduce.h
+++ b/tt_metal/include/compute_kernel_api/reduce.h
@@ -18,7 +18,7 @@
 namespace ckernel {
 
 template<bool at_start, PoolType reduce_type = REDUCE_OP, ReduceDim reduce_dim = REDUCE_DIM>
-ALWI void reduce_init(PoolType reduce_op, ReduceDim dim, uint32_t icb, uint32_t icb_scaler, uint32_t ocb = 16)
+ALWI void reduce_init(uint32_t icb, uint32_t icb_scaler, uint32_t ocb = 16)
 {
     UNPACK(( llk_setup_operands() ));
     UNPACK(( llk_unpack_AB_hw_configure_disaggregated<DST_ACCUM_MODE>(icb, icb_scaler) ));
@@ -42,7 +42,7 @@ ALWI void reduce_init_short(uint32_t icb, uint32_t icb_scaler, uint32_t ocb = 16
 }
 
 template<bool at_start, PoolType reduce_type = REDUCE_OP, ReduceDim reduce_dim = REDUCE_DIM>
-ALWI void reduce_init_delta(PoolType reduce_op, ReduceDim dim, uint32_t ocb = 16, uint32_t icb0 = 0, uint32_t icb1 = 1)
+ALWI void reduce_init_delta(uint32_t ocb = 16, uint32_t icb0 = 0, uint32_t icb1 = 1)
 {
     // FIXME: API Update needed in compute kernel?
     UNPACK(( llk_unpack_AB_reduce_init<reduce_dim>(icb0, icb1) ));

--- a/ttnn/cpp/ttnn/operations/normalization/softmax/device/kernels/compute/softmax.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/softmax/device/kernels/compute/softmax.cpp
@@ -182,7 +182,7 @@ void MAIN {
 
         ACQ();
         cb_reserve_back(cb_recipsumexps, onetile);
-        reduce_init_delta<false>(REDUCE_OP, REDUCE_DIM);
+        reduce_init_delta<false>();
         for (uint32_t wt = 0; wt < Wt; wt++) {
             cb_wait_front(cb_exps, wt+1); // must be a cumulative wait for correctness
             constexpr uint32_t bcast_scaler0 = 0; // 0th index from bcast_scaler CB

--- a/ttnn/cpp/ttnn/operations/normalization/softmax/device/kernels/compute/softmax_sharded.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/softmax/device/kernels/compute/softmax_sharded.cpp
@@ -136,7 +136,7 @@ void MAIN {
 
         // sum(exp(x))
         ACQ();
-        reduce_init_delta<false>(REDUCE_OP, REDUCE_DIM);
+        reduce_init_delta<false>();
         cb_wait_front(cb_exps, block_w);
         cb_wait_front(cb_bcast_scaler, 1);
         cb_reserve_back(cb_recipsumexps, 1);


### PR DESCRIPTION
### Ticket
#7736

### Problem description
Reduce dim & type are templated arguments, the runtime function parameters are completely unused, but have never been removed from the function apis. This PR removes all of them

### What's changed
Removed all the unused args because they just cause confusion

### Checklist
- [x] Post commit CI passes
- [ ] Model regression CI testing passes (if applicable)
- [ ] New/Existing tests provide coverage for changes
