### PR TITLE
Added prefill mode for mamba modules

### DIFF
--- a/models/demos/mamba/tests/test_full_model.py
+++ b/models/demos/mamba/tests/test_full_model.py
@@ -9,6 +9,8 @@ from transformers import AutoTokenizer
 from typing import Optional
 import ttnn
 from models.demos.mamba.reference.decode_model import MambaDecode, MambaPretrainedModelName
+from models.demos.mamba.reference.prefill_decode_model import Mamba, MambaPretrainedModelName
+from models.demos.mamba.reference.args import ModelMode
 from models.demos.mamba.tt.full_model import MambaTT
 from models.demos.mamba.tt import model_config
 from tests.tt_eager.python_api_testing.sweep_tests.comparison_funcs import (
@@ -44,27 +46,44 @@ def run_inference(
     device: ttnn.Device,
     use_program_cache,
     model_version: MambaPretrainedModelName,
+    mode: ModelMode,
     batch: int,
+    seq_len: int,
     pcc: float,
     num_layers: int,
     iterations: int,
     cache_dir: Optional[str],
 ):
-    torch.manual_seed(10)
+    torch.manual_seed(0)
 
-    reference_model = MambaDecode.from_pretrained(model_version, batch_size=batch)
+    reference_model = Mamba.from_pretrained(model_version, batch_size=batch)
+    reference_model.args.mode = mode
+
+    input_sentence = "Climate change refers to long-term shifts in temperatures and weather patterns. \
+Such shifts can be natural, due to changes in the sun's activity or large volcanic eruptions. \
+But since the 1800s, human activities have been the main driver of climate change, primarily \
+due to the burning of fossil fuels like coal, oil and gas. Burning fossil fuels generates \
+greenhouse gas emissions that act like a blanket wrapped around the Earth, trapping \
+the sun's heat and raising temperatures. The main greenhouse gases that are causing \
+climate change include carbon dioxide and methane. These come from using gasoline \
+for driving a car or coal for heating a building, for example. Clearing land and \
+cutting down forests can also release carbon dioxide. Agriculture, oil and gas \
+operations are major sources of methane emissions. Energy, industry, transport, \
+buildings, agriculture and land use are among the main sectors causing greenhouse gases."
 
     tokenizer = AutoTokenizer.from_pretrained("EleutherAI/gpt-neox-20b")
-    input_ids = tokenizer("Hello", return_tensors="pt")["input_ids"]
+    input_ids = tokenizer(input_sentence, return_tensors="pt")["input_ids"]
+    input_ids = input_ids[:, :seq_len]
     input_ids = input_ids.repeat(batch, 1)
 
     mamba_model_pytorch = MambaPytorch(reference_model, num_layers)
     mamba_model_pytorch.eval()
-    for _ in range(iterations):
+    for idx in range(iterations):
         with torch.no_grad():
             reference_output = mamba_model_pytorch(input_ids)
 
-    config = model_config.create_model_config(batch, reference_model.args.d_model)
+    config = model_config.create_model_config(batch, reference_model.args.d_model, mode=mode, seq_len=seq_len)
+
     mamba_model_tt = MambaTT(reference_model, device, config, tt_cache_path=cache_dir, num_layers=num_layers)
 
     for _ in range(iterations):
@@ -80,16 +99,26 @@ def run_inference(
         assert does_pass, f"PCC value is lower than {pcc}"
 
 
-@skip_for_grayskull("Not supported on Grayskull")
 @pytest.mark.parametrize(
-    "model_version, batch, pcc, num_layers, iterations",
+    "model_version, mode, batch, seq_len, num_layers, iterations, pcc",
     (
         (
             "state-spaces/mamba-2.8b",
-            32,
-            0.94,
+            ModelMode.PREFILL,
+            1,
+            64,
             64,
             1,
+            0.96,
+        ),
+        (
+            "state-spaces/mamba-2.8b",
+            ModelMode.DECODE,
+            32,
+            1,
+            64,
+            1,
+            0.96,
         ),
     ),
 )
@@ -98,16 +127,20 @@ def test_inference(
     use_program_cache,
     get_tt_cache_path,
     model_version: MambaPretrainedModelName,
+    mode: ModelMode,
     batch: int,
-    pcc: float,
+    seq_len: int,
     num_layers: int,
     iterations: int,
+    pcc: float,
 ):
     run_inference(
         device,
         use_program_cache,
         model_version,
+        mode,
         batch,
+        seq_len,
         pcc,
         num_layers,
         iterations,
@@ -134,7 +167,9 @@ def test_device_perf(
         device,
         use_program_cache,
         model_version,
+        ModelMode.DECODE,
         batch,
+        1,
         pcc,
         num_layers,
         iterations,

--- a/models/demos/mamba/tests/test_mamba_perf.py
+++ b/models/demos/mamba/tests/test_mamba_perf.py
@@ -129,7 +129,7 @@ def test_mamba_e2e_perf(
 @pytest.mark.models_device_performance_bare_metal
 @pytest.mark.parametrize(
     "batch, warmup, expected_device_fw_duration_ms",
-    ((32, True, 2.81),),
+    ((32, True, 1.7),),
 )
 def test_mamba_perf_device(batch, warmup, expected_device_fw_duration_ms, reset_seeds):
     subdir = "ttnn_mamba"

--- a/models/demos/mamba/tests/test_mamba_ssm.py
+++ b/models/demos/mamba/tests/test_mamba_ssm.py
@@ -7,7 +7,8 @@ import pytest
 from loguru import logger
 from typing import Optional
 import ttnn
-from models.demos.mamba.reference.decode_model import MambaDecode, MambaPretrainedModelName
+from models.demos.mamba.reference.prefill_decode_model import Mamba, MambaPretrainedModelName
+from models.demos.mamba.reference.args import ModelMode
 from models.demos.mamba.tt.full_model import TtTensorLoader
 from models.demos.mamba.tt.mamba_one_step_ssm import TtMambaSSM
 from models.demos.mamba.tt import model_config
@@ -29,11 +30,20 @@ class PytorchMambaSSM(torch.nn.Module):
 
 
 @pytest.mark.parametrize(
-    "model_version, batch, pcc",
+    "model_version, mode, batch, seq_len, pcc",
     (
         (
             "state-spaces/mamba-2.8b",
+            ModelMode.PREFILL,
+            1,
+            64,
+            0.99,
+        ),
+        (
+            "state-spaces/mamba-2.8b",
+            ModelMode.DECODE,
             32,
+            1,
             0.99,
         ),
     ),
@@ -42,38 +52,38 @@ def test_mamba_ssm_inference(
     device: ttnn.Device,
     use_program_cache,
     model_version: MambaPretrainedModelName,
+    mode: ModelMode,
     batch: int,
+    seq_len: int,
     pcc: float,
 ):
     torch.manual_seed(0)
 
     LAYER_NUM = 0
 
-    reference_model = MambaDecode.from_pretrained(model_version)
-    reference_model.args.batch_size = batch
+    reference_model = Mamba.from_pretrained(model_version, batch_size=batch)
+    reference_model.args.mode = mode
 
-    d_in = reference_model.args.d_model * reference_model.args.expand
-    input = torch.rand(batch, 1, d_in)
+    d_inner = reference_model.args.d_inner
+    input = torch.rand(batch, seq_len, d_inner)
 
     reference_output = PytorchMambaSSM(reference_model, LAYER_NUM)(input)
 
-    residual_block = reference_model.layers[LAYER_NUM]
-    assert not isinstance(residual_block, torch.Tensor), "Expected torch.Module"
-
-    config = model_config.create_model_config(batch, reference_model.args.d_model)
+    config = model_config.create_model_config(batch, reference_model.args.d_model, mode=mode, seq_len=seq_len)
 
     loader = TtTensorLoader(reference_model.state_dict(), device)
 
     model = TtMambaSSM(reference_model.args, device, config, loader.get_tensor_loader(LAYER_NUM))
-    tt_input = input.view(1, 1, batch, d_in)
+
+    tt_input = input.view(1, 1, config["outer_dim"], d_inner)
     tt_input = ttnn.to_device(
-        ttnn.from_torch(tt_input, layout=ttnn.TILE_LAYOUT, dtype=ttnn.bfloat8_b),
+        ttnn.from_torch(tt_input, layout=ttnn.TILE_LAYOUT, dtype=config["dtype"]["activations"]),
         device=device,
         memory_config=ttnn.L1_MEMORY_CONFIG,
     )
     tt_output = model(tt_input)
     tt_output = ttnn.to_torch(tt_output)
-    tt_output = tt_output.view(batch, 1, -1)
+    tt_output = tt_output.view(batch, seq_len, -1)
     logger.info(comp_allclose(reference_output, tt_output))
 
     does_pass, output_pcc = comp_pcc(reference_output, tt_output, pcc)

--- a/models/demos/mamba/tests/test_residual_block.py
+++ b/models/demos/mamba/tests/test_residual_block.py
@@ -8,7 +8,8 @@ from loguru import logger
 from typing import Optional
 import ttnn
 from models.demos.mamba.tt.full_model import TtTensorLoader
-from models.demos.mamba.reference.decode_model import MambaDecode, MambaPretrainedModelName
+from models.demos.mamba.reference.prefill_decode_model import Mamba, MambaPretrainedModelName
+from models.demos.mamba.reference.args import ModelMode
 from models.demos.mamba.tt.residual_block import TtResidualBlock
 from models.demos.mamba.tt import model_config
 from tests.tt_eager.python_api_testing.sweep_tests.comparison_funcs import (
@@ -29,56 +30,65 @@ class PytorchResidualBlock(torch.nn.Module):
 
 
 @pytest.mark.parametrize(
-    "model_version, batch, pcc",
+    "model_version, mode, batch, seq_len, pcc",
     (
         (
             "state-spaces/mamba-2.8b",
+            ModelMode.PREFILL,
+            1,
+            64,
+            0.99,
+        ),
+        (
+            "state-spaces/mamba-2.8b",
+            ModelMode.DECODE,
             32,
+            1,
             0.99,
         ),
     ),
 )
-def test_mamba_residual_block_inference(
+def test_residual_block(
     device: ttnn.Device,
     use_program_cache,
     model_version: MambaPretrainedModelName,
+    mode: ModelMode,
     batch: int,
+    seq_len: int,
     pcc: float,
 ):
     torch.manual_seed(0)
 
     LAYER_NUM = 0
 
-    reference_model = MambaDecode.from_pretrained(model_version, batch_size=batch)
-    reference_model.args.batch_size = batch
+    reference_model = Mamba.from_pretrained(model_version, batch_size=batch)
+    reference_model.args.mode = mode
 
     d_model = reference_model.args.d_model
-    input = torch.rand(batch, 1, d_model)
+    input = torch.rand(batch, seq_len, d_model)
 
     reference_output = PytorchResidualBlock(reference_model, LAYER_NUM)(input)
 
-    residual_block = reference_model.layers[LAYER_NUM]
-    assert not isinstance(residual_block, torch.Tensor), "Expected torch.Module"
-
-    config = model_config.create_model_config(batch, d_model)
+    config = model_config.create_model_config(batch, reference_model.args.d_model, mode=mode, seq_len=seq_len)
 
     loader = TtTensorLoader(reference_model.state_dict(), device)
 
     model = TtResidualBlock(reference_model.args, device, config, loader.get_tensor_loader(LAYER_NUM))
-    tt_input = input.view(1, 1, batch, d_model)
+
+    tt_input = input.view(1, 1, config["outer_dim"], d_model)
     tt_input = ttnn.to_device(
-        ttnn.from_torch(tt_input, layout=ttnn.TILE_LAYOUT, dtype=ttnn.bfloat16),
+        ttnn.from_torch(tt_input, layout=ttnn.TILE_LAYOUT, dtype=config["dtype"]["activations"]),
         device=device,
         memory_config=ttnn.L1_MEMORY_CONFIG,
     )
     tt_output = model(tt_input)
     tt_output = ttnn.to_torch(tt_output)
-    tt_output = tt_output.view(batch, 1, -1)
+    tt_output = tt_output.view(batch, seq_len, -1)
     logger.info(comp_allclose(reference_output, tt_output))
 
     does_pass, output_pcc = comp_pcc(reference_output, tt_output, pcc)
     logger.info(f"PCC value: {output_pcc}")
 
     if not does_pass:
-        logger.warning("Mamba SSM output failed")
+        logger.warning("Mamba Residual Block output failed")
         assert does_pass, f"PCC value is lower than {pcc}"

--- a/models/demos/mamba/tt/mamba_block.py
+++ b/models/demos/mamba/tt/mamba_block.py
@@ -10,6 +10,7 @@ from typing import Callable
 
 from models.demos.mamba.reference.args import ModelArgs
 from models.demos.mamba.tt.mamba_one_step_ssm import TtMambaSSM
+from models.demos.mamba.reference.args import ModelMode
 
 
 class TtMambaBlock(torch.nn.Module):
@@ -20,8 +21,6 @@ class TtMambaBlock(torch.nn.Module):
         self.args = args
         self.batch_size = args.batch_size
         self.configs = configs
-
-        assert self.batch_size == 32, "Batch size must be 32 for now"
 
         in_proj_weight_name = "mixer.in_proj.weight"
 
@@ -63,8 +62,8 @@ class TtMambaBlock(torch.nn.Module):
         conv1d_bias_name = "mixer.conv1d.bias"
         self.conv1d_bias = load_fn(
             conv1d_bias_name,
-            lambda x: x.repeat(self.args.batch_size, 1),
-            postfix=f"{args.batch_size}",
+            lambda x: x.repeat(self.configs["outer_dim"], 1),
+            postfix=f"{self.configs['outer_dim']}",
         )
 
         self.conv_states = []
@@ -77,6 +76,19 @@ class TtMambaBlock(torch.nn.Module):
                 )
             )
 
+        self.use_torch_conv = True
+        if self.use_torch_conv:
+            self.torch_depthwise_conv1d = torch.nn.Conv1d(
+                in_channels=self.args.d_inner,
+                out_channels=self.args.d_inner,
+                kernel_size=4,
+                padding=3,
+                groups=self.args.d_inner,
+                bias=True,
+            )
+            self.torch_depthwise_conv1d.weight.data = load_fn(conv1d_weight_name, return_as_torch=True)
+            self.torch_depthwise_conv1d.bias.data = load_fn(conv1d_bias_name, return_as_torch=True)
+
         self.tt_ssm = TtMambaSSM(self.args, self.device, configs, load_fn)
 
         self.compute_kernel_config = ttl.tensor.WormholeComputeKernelConfig(
@@ -88,7 +100,15 @@ class TtMambaBlock(torch.nn.Module):
     def forward(self, x):
         assert len(x.shape) == 4, "Mamba block expects inputs to be rank 4"
 
-        residual_connection = x  # b, e=d_model
+        residual = ttnn.linear(
+            x,
+            self.mlp_proj_weights,
+            memory_config=ttnn.DRAM_MEMORY_CONFIG,
+            compute_kernel_config=self.compute_kernel_config,
+            use_1d_systolic_array=True,
+            dtype=self.configs["dtype"]["activations"],
+            activation="silu",
+        )
 
         x_ssm = ttnn.linear(
             x,
@@ -96,31 +116,24 @@ class TtMambaBlock(torch.nn.Module):
             memory_config=ttnn.L1_MEMORY_CONFIG,
             compute_kernel_config=self.compute_kernel_config,
             use_1d_systolic_array=True,
-            dtype=self.configs["dtype"]["activations"],
+            dtype=ttnn.bfloat16,  # convolution requires bfloat16
         )
+        ttnn.deallocate(x)
 
-        # shift the states leftward
-        ttnn.deallocate(self.conv_states[0])
-        for i in range(3):
-            self.conv_states[i] = self.conv_states[i + 1]
+        if self.configs["mode"] == ModelMode.DECODE:
+            # shift the states leftward
+            ttnn.deallocate(self.conv_states[0])
+            for i in range(3):
+                self.conv_states[i] = self.conv_states[i + 1]
 
-        # update the last state and move it back to DRAM with all the other states
-        self.conv_states[3] = ttnn.to_memory_config(x_ssm, memory_config=ttnn.DRAM_MEMORY_CONFIG)
-        ttnn.deallocate(x_ssm)
+            # update the last state and move it back to DRAM with all the other states
+            self.conv_states[3] = ttnn.to_memory_config(x_ssm, memory_config=ttnn.DRAM_MEMORY_CONFIG)
+            ttnn.deallocate(x_ssm)
 
-        # do the convolution
-        conv1d_wt = ttnn.to_memory_config(self.conv1d_weights[0], memory_config=self.configs["sharded_d"])
-        conv_state = ttnn.to_memory_config(self.conv_states[0], memory_config=self.configs["sharded_d"])
-        conv_accumulator = ttnn.mul(
-            conv_state, conv1d_wt, memory_config=self.configs["sharded_d"], dtype=self.configs["dtype"]["activations"]
-        )
-        ttnn.deallocate(conv1d_wt)
-        ttnn.deallocate(conv_state)
-
-        for i in range(1, 4):
-            conv1d_wt = ttnn.to_memory_config(self.conv1d_weights[i], memory_config=self.configs["sharded_d"])
-            conv_state = ttnn.to_memory_config(self.conv_states[i], memory_config=self.configs["sharded_d"])
-            prod = ttnn.mul(
+            # do the convolution
+            conv1d_wt = ttnn.to_memory_config(self.conv1d_weights[0], memory_config=self.configs["sharded_d"])
+            conv_state = ttnn.to_memory_config(self.conv_states[0], memory_config=self.configs["sharded_d"])
+            conv_accumulator = ttnn.mul(
                 conv_state,
                 conv1d_wt,
                 memory_config=self.configs["sharded_d"],
@@ -129,39 +142,61 @@ class TtMambaBlock(torch.nn.Module):
             ttnn.deallocate(conv1d_wt)
             ttnn.deallocate(conv_state)
 
-            conv_out = ttnn.add(
-                conv_accumulator,
-                prod,
+            for i in range(1, 4):
+                conv1d_wt = ttnn.to_memory_config(self.conv1d_weights[i], memory_config=self.configs["sharded_d"])
+                conv_state = ttnn.to_memory_config(self.conv_states[i], memory_config=self.configs["sharded_d"])
+                prod = ttnn.mul(
+                    conv_state,
+                    conv1d_wt,
+                    memory_config=self.configs["sharded_d"],
+                    dtype=self.configs["dtype"]["activations"],
+                )
+                ttnn.deallocate(conv1d_wt)
+                ttnn.deallocate(conv_state)
+
+                conv_out = ttnn.add(
+                    conv_accumulator,
+                    prod,
+                    memory_config=self.configs["sharded_d"],
+                    dtype=self.configs["dtype"]["activations"],
+                )
+                ttnn.deallocate(conv_accumulator)
+                ttnn.deallocate(prod)
+                conv_accumulator = conv_out
+
+            conv1d_bias = ttnn.to_memory_config(self.conv1d_bias, memory_config=self.configs["sharded_d"])
+            conv_out_with_bias = ttnn.add(
+                conv_out,
+                conv1d_bias,
                 memory_config=self.configs["sharded_d"],
                 dtype=self.configs["dtype"]["activations"],
             )
-            ttnn.deallocate(conv_accumulator)
-            ttnn.deallocate(prod)
-            conv_accumulator = conv_out
+            ttnn.deallocate(conv_out)
+            ttnn.deallocate(conv1d_bias)
 
-        conv1d_bias = ttnn.to_memory_config(self.conv1d_bias, memory_config=self.configs["sharded_d"])
-        conv_out_with_bias = ttnn.add(
-            conv_out, conv1d_bias, memory_config=self.configs["sharded_d"], dtype=self.configs["dtype"]["activations"]
-        )
-        ttnn.deallocate(conv_out)
-        ttnn.deallocate(conv1d_bias)
+        elif self.configs["mode"] == ModelMode.PREFILL:
+            if self.use_torch_conv:
+                x_ssm_torch = ttnn.to_torch(x_ssm).to(torch.float32)
+                ttnn.deallocate(x_ssm)
+                x_ssm_torch = x_ssm_torch.squeeze(0).squeeze(0).permute(1, 0).unsqueeze(0)
+                conv_out_with_bias = self.torch_depthwise_conv1d(x_ssm_torch)
+                x_ssm_torch.data = torch.tensor([])
+                # omit the padding at the end
+                conv_out_with_bias = conv_out_with_bias[:, :, :-3]
+                conv_out_with_bias = conv_out_with_bias.squeeze(0).permute(1, 0).unsqueeze(0).unsqueeze(0)
+                conv_out_with_bias = ttnn.from_torch(
+                    conv_out_with_bias,
+                    device=self.device,
+                    layout=ttnn.TILE_LAYOUT,
+                    memory_config=ttnn.L1_MEMORY_CONFIG,
+                    dtype=self.configs["dtype"]["activations"],
+                )
 
         conv_out_with_bias_l1 = ttnn.to_memory_config(conv_out_with_bias, memory_config=ttnn.L1_MEMORY_CONFIG)
         conv_out_after_silu = ttnn.silu(conv_out_with_bias_l1, memory_config=ttnn.L1_MEMORY_CONFIG)
         ttnn.deallocate(conv_out_with_bias_l1)
 
         out = self.tt_ssm(conv_out_after_silu)
-
-        residual = ttnn.linear(
-            residual_connection,
-            self.mlp_proj_weights,
-            memory_config=ttnn.L1_MEMORY_CONFIG,
-            compute_kernel_config=self.compute_kernel_config,
-            use_1d_systolic_array=True,
-            dtype=self.configs["dtype"]["activations"],
-            activation="silu",
-        )
-        ttnn.deallocate(residual_connection)
 
         out = ttnn.multiply(
             out,

--- a/models/demos/mamba/tt/model_config.py
+++ b/models/demos/mamba/tt/model_config.py
@@ -4,34 +4,62 @@
 
 import ttnn
 import os
+from models.demos.mamba.reference.args import ModelMode
 
 
-def create_model_config(batch_size, hidden_size):
+def create_model_config(batch_size, hidden_size, mode=ModelMode.DECODE, seq_len=1):
     configs = {}
-    row = 5
-    col = 8
     latent = 32
+    configs["core_grid_row"] = 5
+    configs["core_grid_col"] = 8
     configs["latent_size"] = latent
+    configs["mode"] = mode
+    configs["seq_len"] = seq_len
+
+    if mode == ModelMode.DECODE:
+        outer_dim = batch_size
+        assert batch_size == 32, "Batch size must be 32 for decode model"
+    elif mode == ModelMode.PREFILL:
+        outer_dim = seq_len
+        assert batch_size == 1, "Batch size must be 1 for prefill model"
+        assert seq_len % 32 == 0 and seq_len < 128, "Sequence length must be a multiple of 32 for prefill model"
+    else:
+        raise ValueError(f"Invalid model mode: {mode}")
+
+    configs["outer_dim"] = outer_dim
+
     configs["sharded_h"] = ttnn.create_sharded_memory_config(
-        shape=(1, 1, batch_size, hidden_size),
-        core_grid=ttnn.CoreGrid(y=row, x=col),
+        shape=(1, 1, outer_dim, hidden_size),
+        core_grid=ttnn.CoreGrid(y=get_nearest_core_grid_row(hidden_size), x=configs["core_grid_col"]),
         strategy=ttnn.ShardStrategy.WIDTH,
     )
     configs["sharded_d"] = ttnn.create_sharded_memory_config(
-        shape=(1, 1, batch_size, hidden_size * 2),
-        core_grid=ttnn.CoreGrid(y=row, x=col),
+        shape=(1, 1, outer_dim, hidden_size * 2),
+        core_grid=ttnn.CoreGrid(y=get_nearest_core_grid_row(hidden_size * 2), x=configs["core_grid_col"]),
         strategy=ttnn.ShardStrategy.WIDTH,
     )
     configs["sharded_dn"] = ttnn.create_sharded_memory_config(
-        shape=(1, 1, batch_size, hidden_size * 2 * latent),
-        core_grid=ttnn.CoreGrid(y=row, x=col),
+        shape=(1, 1, outer_dim, hidden_size * 2 * latent),
+        core_grid=ttnn.CoreGrid(y=configs["core_grid_row"], x=configs["core_grid_col"]),
         strategy=ttnn.ShardStrategy.WIDTH,
     )
+    configs["sharded_scan"] = ttnn.create_sharded_memory_config(
+        shape=(1, 1, outer_dim, hidden_size * 2 * latent),
+        core_grid=ttnn.CoreGrid(y=configs["core_grid_row"], x=configs["core_grid_col"]),
+        strategy=ttnn.ShardStrategy.WIDTH,
+        orientation=ttnn.ShardOrientation.ROW_MAJOR,
+    )
+    configs["sharded_prev_hidden"] = ttnn.create_sharded_memory_config(
+        shape=(1, 1, 1, hidden_size * 2 * latent),
+        core_grid=ttnn.CoreGrid(y=configs["core_grid_row"], x=configs["core_grid_col"]),
+        strategy=ttnn.ShardStrategy.WIDTH,
+        orientation=ttnn.ShardOrientation.ROW_MAJOR,
+    )
     configs["SHARDED_NORM_PRGM_CFG"] = ttnn.experimental.operations.primary.LayerNormShardedMultiCoreProgramConfig(
-        compute_with_storage_grid_size=[col, row],
-        subblock_w=(hidden_size // (col * row)) // 32,
-        block_h=1,
-        block_w=(hidden_size // (col * row)) // 32,
+        compute_with_storage_grid_size=[configs["core_grid_col"], get_nearest_core_grid_row(hidden_size)],
+        subblock_w=(hidden_size // (configs["core_grid_col"] * get_nearest_core_grid_row(hidden_size))) // 32,
+        block_h=outer_dim // 32,
+        block_w=(hidden_size // (configs["core_grid_col"] * get_nearest_core_grid_row(hidden_size))) // 32,
         inplace=False,
     )
     configs["dtype"] = {"activations": ttnn.bfloat8_b, "weights": ttnn.bfloat4_b}
@@ -45,3 +73,15 @@ def get_model_config(configs, model_config_str):
 def get_weights_cache_path(model_version, cache_dir="/tmp"):
     cache_path = os.path.join(cache_dir, model_version)
     return cache_path
+
+
+def get_nearest_core_grid_row(tensor_width, core_grid_row=8, core_grid_col=8):
+    core_grid_size = core_grid_row * core_grid_col
+    tile_width = 32
+    num_tiles = tensor_width // tile_width
+    if num_tiles <= core_grid_size:
+        return num_tiles // core_grid_col
+    else:
+        for i in range(core_grid_size, 0, -1):
+            if num_tiles % i == 0:
+                return i // core_grid_col

--- a/models/demos/mamba/tt/residual_block.py
+++ b/models/demos/mamba/tt/residual_block.py
@@ -29,23 +29,30 @@ class TtResidualBlock(torch.nn.Module):
         assert len(x.shape) == 4, "Mamba residual block expects inputs to be rank 4"
 
         residual = x
+        residual = ttnn.to_memory_config(residual, ttnn.DRAM_MEMORY_CONFIG)
+
         rms_norm_weights = ttnn.to_memory_config(self.rms_norm_weights, memory_config=ttnn.L1_MEMORY_CONFIG)
-        x = ttnn.experimental.tensor.interleaved_to_sharded(x, sharded_mem_config=self.configs["sharded_h"])
+        x_sharded = ttnn.experimental.tensor.interleaved_to_sharded(x, sharded_mem_config=self.configs["sharded_h"])
+        ttnn.deallocate(x)
         mamba_x = ttnn.experimental.operations.primary.rmsnorm(
-            x,
+            x_sharded,
             self.args.eps,
             rms_norm_weights,
             program_config=self.configs["SHARDED_NORM_PRGM_CFG"],
             output_mem_config=self.configs["sharded_h"],
         )
-        mamba_x = ttnn.to_memory_config(mamba_x, memory_config=ttnn.L1_MEMORY_CONFIG)
+        ttnn.deallocate(x_sharded)
+        mamba_x_in_l1_int = ttnn.to_memory_config(mamba_x, memory_config=ttnn.L1_MEMORY_CONFIG)
+        ttnn.deallocate(mamba_x)
         ttnn.deallocate(rms_norm_weights)
-        mamba_x = self.tt_mamba_block(mamba_x)
+
+        mamba_block_out = self.tt_mamba_block(mamba_x_in_l1_int)
+        ttnn.deallocate(mamba_x_in_l1_int)
 
         return ttnn.add(
             residual,
-            mamba_x,
+            mamba_block_out,
             dtype=self.configs["dtype"]["activations"],
             memory_config=ttnn.L1_MEMORY_CONFIG,
-            output_tensor=mamba_x,
+            output_tensor=mamba_block_out,
         )


### PR DESCRIPTION
### Problem description
Added prefill mode for seq_len=64 in all the unit tests of mamba modules

### What's changed
1. Shouldn't affect decode graph.
2. Device Perf target got changed for decode as we now pushing residuals on DRAM. Surprisingly, it has improved but not sure if the perf improvements come from rebase.
3. All the prefill tests with seq_len=64 and decode tests are passing with 40 core grid 

### Checklist
- [x] Post commit CI passes
- [x] Model regression CI testing passes (if applicable)
- [x] New/Existing tests provide coverage for changes
