### PR TITLE
#9714: Move SD device perf test to last because it's unstable

### DIFF
--- a/tests/scripts/run_performance.sh
+++ b/tests/scripts/run_performance.sh
@@ -77,16 +77,17 @@ run_device_perf_models() {
         env pytest models/demos/resnet/tests -m $test_marker
     fi
 
+    # Wormhole tests can use timeout because device reset on process failure doesn't affect clocks
     if [ "$tt_arch" == "wormhole_b0" ]; then
-        env pytest models/demos/mamba/tests -m $test_marker
+        env pytest -n auto models/demos/mamba/tests -m $test_marker
 
-        env WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml pytest models/demos/metal_BERT_large_11/tests -m $test_marker
-        #env WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml pytest models/experimental/functional_unet/tests -m $test_marker
+        env WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml pytest -n auto models/demos/metal_BERT_large_11/tests -m $test_marker
+        #env WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml pytest -n auto models/experimental/functional_unet/tests -m $test_marker
 
-        env WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml pytest models/demos/falcon7b/tests -m $test_marker
+        env WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml pytest -n auto models/demos/falcon7b/tests -m $test_marker
     fi
 
-    env pytest tests/device_perf_tests/stable_diffusion -m $test_marker --timeout=600
+    env pytest -n auto tests/device_perf_tests/stable_diffusion -m $test_marker --timeout=600
 
     ## Merge all the generated reports
     env python models/perf/merge_device_perf_results.py

--- a/tests/scripts/run_performance.sh
+++ b/tests/scripts/run_performance.sh
@@ -59,8 +59,6 @@ run_device_perf_models() {
     set -eo pipefail
     local test_marker=$1
 
-    env pytest tests/device_perf_tests/stable_diffusion -m $test_marker --timeout=600
-
     if [ "$tt_arch" == "grayskull" ]; then
         #TODO(MO): Until #6560 is fixed, GS device profiler test are grouped with
         #Model Device perf regression tests to make sure thy run on no-soft-reset BMs
@@ -87,6 +85,8 @@ run_device_perf_models() {
 
         env WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml pytest models/demos/falcon7b/tests -m $test_marker
     fi
+
+    env pytest tests/device_perf_tests/stable_diffusion -m $test_marker --timeout=600
 
     ## Merge all the generated reports
     env python models/perf/merge_device_perf_results.py


### PR DESCRIPTION
Another separate device pipeline for unstable tests right now would take away too many precious cycles from the single WH perf machine we have

### Ticket
#9714 

### Problem description

Stable diffusion errors / hangs frequently, preventing other tests from running.

### What's changed

Moved SD to last test so others can run.

### Checklist
- [x] Post commit CI passes
- [x] Model regression CI testing passes (if applicable)
- [x] New/Existing tests provide coverage for changes
