### PR TITLE
Added user prefill-decode demo test for reference model

### DIFF
--- a/models/demos/mamba/tests/test_mamba_demo.py
+++ b/models/demos/mamba/tests/test_mamba_demo.py
@@ -3,14 +3,21 @@
 # SPDX-License-Identifier: Apache-2.0
 
 from models.demos.mamba.demo.demo import run_mamba_demo
+from models.demos.mamba.tests.test_reference_model import (
+    generate_through_selective_scan,
+    generate_through_prefill_decode,
+)
+from models.demos.mamba.reference.prefill_decode_model import Mamba as MambaPrefillDecode
+from models.demos.mamba.reference.model import Mamba
 import pytest
+from transformers import AutoTokenizer
 
 
 @pytest.mark.parametrize(
     "user_input, model_version, max_gen_len",
     ((["Hello World"], "state-spaces/mamba-2.8b-slimpj", 2),),
 )
-def test_demo(user_input, model_version, device, use_program_cache, get_tt_cache_path, max_gen_len):
+def test_tt_demo(user_input, model_version, device, use_program_cache, get_tt_cache_path, max_gen_len):
     return run_mamba_demo(
         prompts=user_input,
         model_version=model_version,
@@ -19,3 +26,25 @@ def test_demo(user_input, model_version, device, use_program_cache, get_tt_cache
         display=False,
         cache_dir=get_tt_cache_path(model_version),
     )
+
+
+@pytest.mark.parametrize(
+    "user_input, model_version, batch_size, max_gen_len",
+    ((["Hello World"], "state-spaces/mamba-2.8b-slimpj", 32, 2),),
+)
+def test_reference_demo(user_input, model_version, batch_size, max_gen_len):
+    if len(user_input) != batch_size:
+        user_input = [user_input[0]] * batch_size
+
+    tokenizer = AutoTokenizer.from_pretrained("EleutherAI/gpt-neox-20b")
+
+    selective_scan_model = Mamba.from_pretrained(model_version)
+    prefill_decode_model = MambaPrefillDecode.from_pretrained(model_version, batch_size)
+
+    prefill_decode_outputs = generate_through_prefill_decode(prefill_decode_model, tokenizer, user_input, max_gen_len)
+    selective_scan_outputs = generate_through_selective_scan(selective_scan_model, tokenizer, user_input, max_gen_len)
+
+    for user_idx in range(batch_size):
+        assert (
+            selective_scan_outputs[user_idx] == prefill_decode_outputs[user_idx]
+        ), f"Model outputs should match for user {user_idx}"

--- a/models/demos/mamba/tests/test_reference_model.py
+++ b/models/demos/mamba/tests/test_reference_model.py
@@ -20,7 +20,7 @@ def generate_through_selective_scan(
     model.eval()
     with torch.no_grad():
         output = model.generate(input_ids, n_tokens_to_gen)
-    return tokenizer.batch_decode(output)[0]
+    return tokenizer.batch_decode(output)
 
 
 def generate_through_decode(model, tokenizer, prompt: str, n_tokens_to_gen: int = 51):
@@ -28,7 +28,7 @@ def generate_through_decode(model, tokenizer, prompt: str, n_tokens_to_gen: int 
     model.eval()
     with torch.no_grad():
         output = model.generate(input_ids, n_tokens_to_gen)
-    return tokenizer.batch_decode(output)[0]
+    return tokenizer.batch_decode(output)
 
 
 def generate_through_prefill_decode(model, tokenizer, prompt: str, n_tokens_to_gen: int = 51):
@@ -36,7 +36,7 @@ def generate_through_prefill_decode(model, tokenizer, prompt: str, n_tokens_to_g
     model.eval()
     with torch.no_grad():
         output = model.generate(input_ids, n_tokens_to_gen)
-    return tokenizer.batch_decode(output)[0]
+    return tokenizer.batch_decode(output)
 
 
 @pytest.mark.parametrize(
@@ -56,11 +56,11 @@ def test_cpu_reference_model_decode_vs_selective_scan(
     tokenizer = AutoTokenizer.from_pretrained("EleutherAI/gpt-neox-20b")
 
     selective_scan_model = Mamba.from_pretrained(model_version)
-    decode_model = MambaDecode.from_pretrained(model_version)
-    prefill_decode_model = MambaPrefillDecode.from_pretrained(model_version)
+    decode_model = MambaDecode.from_pretrained(model_version, batch_size=batch)
+    prefill_decode_model = MambaPrefillDecode.from_pretrained(model_version, batch_size=batch)
 
-    prefill_decode_output = generate_through_prefill_decode(prefill_decode_model, tokenizer, prompt, genlen)
-    selective_scan_output = generate_through_selective_scan(selective_scan_model, tokenizer, prompt, genlen)
-    decode_output = generate_through_decode(decode_model, tokenizer, prompt, genlen)
+    prefill_decode_output = generate_through_prefill_decode(prefill_decode_model, tokenizer, prompt, genlen)[0]
+    selective_scan_output = generate_through_selective_scan(selective_scan_model, tokenizer, prompt, genlen)[0]
+    decode_output = generate_through_decode(decode_model, tokenizer, prompt, genlen)[0]
 
     assert selective_scan_output == decode_output == prefill_decode_output, "Model outputs should match"


### PR DESCRIPTION
### Problem description
reference model maintains `batch_size `and `seq_len` as separate dimensions of the tensor shape's., making the the prefill-decode in one go
