### PR TITLE
#0: bump python3.8 venv versioning since apt repos updated

### DIFF
--- a/scripts/docker/requirements.txt
+++ b/scripts/docker/requirements.txt
@@ -16,6 +16,6 @@ libhwloc-dev
 libhdf5-serial-dev
 ruby=1:2.7+1
 python3-dev=3.8.2-0ubuntu2
-python3.8-venv=3.8.10-0ubuntu1~20.04.9
+python3.8-venv=3.8.10-0ubuntu1~20.04.10
 cargo
 ninja-build


### PR DESCRIPTION
### Ticket
[failed package and release](https://github.com/tenstorrent/tt-metal/actions/runs/9866677762/job/27246561809)

package and release build fails for docker

Checked by manually installing python3.8-venv=3.8.10-0ubuntu1~20.04.10
```
mchiou@e04cs06:~$ sudo apt install python3.8-venv=3.8.10-0ubuntu1~20.04.10
Reading package lists... Done
Building dependency tree
Reading state information... Done
The following additional packages will be installed:
  libpython3.8 libpython3.8-dev libpython3.8-minimal libpython3.8-stdlib python3.8 python3.8-dev python3.8-minimal
Suggested packages:
  python3.8-doc
The following packages will be upgraded:
  libpython3.8 libpython3.8-dev libpython3.8-minimal libpython3.8-stdlib python3.8 python3.8-dev python3.8-minimal python3.8-venv
8 upgraded, 0 newly installed, 0 to remove and 94 not upgraded.
Need to get 0 B/10.8 MB of archives.
After this operation, 27.6 kB of additional disk space will be used.
Do you want to continue? [Y/n] ^C
```

### Problem description
Python3.8 venv got updated. Older versions on apt are deleted.

### What's changed
Updated python3.8 venv to new updated version

### Checklist
- [ ] Post commit CI passes
- [ ] Model regression CI testing passes (if applicable)
- [ ] New/Existing tests provide coverage for changes
