### PR TITLE
#10112: Drop hard pin for installation instructions for python3.8-venv in dependencies

### DIFF
--- a/INSTALLING.md
+++ b/INSTALLING.md
@@ -26,7 +26,7 @@ Note the current compatability matrix:
 
 ```sh
 sudo apt update
-sudo apt install software-properties-common=0.99.9.12 build-essential=12.8ubuntu1.1 python3.8-venv=3.8.10-0ubuntu1~20.04.9 libhwloc-dev graphviz patchelf
+sudo apt install software-properties-common=0.99.9.12 build-essential=12.8ubuntu1.1 python3.8-venv libhwloc-dev graphviz patchelf
 
 wget https://apt.llvm.org/llvm.sh
 chmod u+x llvm.sh


### PR DESCRIPTION
…

### Ticket

#10112 

### Problem description

`python3.8-venv` doesn't need this pin anymore as it's a pretty stable and soon to-be-deprecated package. Only minor / security changes probably going forward

### What's changed

Dropped pinned version in `INSTALLING.md`, but kept it in dependencies json for github runner builds so our builds are consistent and we get notification of upgrades by failing pipelines.

### Checklist
- [x] Post commit CI passes
- [x] Model regression CI testing passes (if applicable)
- [x] New/Existing tests provide coverage for changes
