### PR TITLE
#10137: Add structure for composite binary ops in ttnn

### DIFF
--- a/docs/source/ttnn/ttnn/api.rst
+++ b/docs/source/ttnn/ttnn/api.rst
@@ -270,6 +270,8 @@ Pointwise Binary
    :maxdepth: 1
 
    ttnn/add
+   ttnn/addalpha
+   ttnn/subalpha
    ttnn/multiply
    ttnn/subtract
    ttnn/pow

--- a/docs/source/ttnn/ttnn/ttnn/addalpha.rst
+++ b/docs/source/ttnn/ttnn/ttnn/addalpha.rst
@@ -1,0 +1,6 @@
+.. _ttnn.addalpha:
+
+ttnn.addalpha
+#############
+
+.. autofunction:: ttnn.addalpha

--- a/docs/source/ttnn/ttnn/ttnn/subalpha.rst
+++ b/docs/source/ttnn/ttnn/ttnn/subalpha.rst
@@ -1,0 +1,6 @@
+.. _ttnn.subalpha:
+
+ttnn.subalpha
+#############
+
+.. autofunction:: ttnn.subalpha

--- a/tests/ttnn/unit_tests/operations/test_binary_composite.py
+++ b/tests/ttnn/unit_tests/operations/test_binary_composite.py
@@ -1,0 +1,214 @@
+# SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
+
+# SPDX-License-Identifier: Apache-2.0
+
+import torch
+import pytest
+import ttnn
+from tests.ttnn.unit_tests.operations.backward.utility_funcs import data_gen_with_range, compare_pcc
+
+
+@pytest.mark.parametrize(
+    "input_shapes",
+    (
+        (torch.Size([1, 1, 32, 32])),
+        (torch.Size([1, 1, 320, 384])),
+        (torch.Size([1, 3, 320, 384])),
+    ),
+)
+def test_binary_hypot_ttnn(input_shapes, device):
+    in_data1, input_tensor1 = data_gen_with_range(input_shapes, -100, 100, device)
+    in_data2, input_tensor2 = data_gen_with_range(input_shapes, -150, 150, device)
+
+    output_tensor = ttnn.hypot(input_tensor1, input_tensor2)
+    golden_function = ttnn.get_golden_function(ttnn.hypot)
+    golden_tensor = golden_function(in_data1, in_data2)
+
+    comp_pass = compare_pcc([output_tensor], [golden_tensor])
+    assert comp_pass
+
+
+@pytest.mark.parametrize(
+    "input_shapes",
+    (
+        (torch.Size([1, 1, 32, 32])),
+        (torch.Size([1, 1, 320, 384])),
+        (torch.Size([1, 3, 320, 384])),
+    ),
+)
+def test_binary_xlogy_ttnn(input_shapes, device):
+    in_data1, input_tensor1 = data_gen_with_range(input_shapes, -100, 100, device)
+    in_data2, input_tensor2 = data_gen_with_range(input_shapes, -150, 150, device)
+
+    output_tensor = ttnn.xlogy(input_tensor1, input_tensor2)
+    golden_function = ttnn.get_golden_function(ttnn.xlogy)
+    golden_tensor = golden_function(in_data1, in_data2)
+
+    comp_pass = compare_pcc([output_tensor], [golden_tensor])
+    assert comp_pass
+
+
+@pytest.mark.parametrize(
+    "input_shapes",
+    (
+        (torch.Size([1, 1, 32, 32])),
+        (torch.Size([1, 1, 320, 384])),
+        (torch.Size([1, 3, 320, 384])),
+    ),
+)
+def test_binary_nextafter_ttnn(input_shapes, device):
+    in_data1, input_tensor1 = data_gen_with_range(input_shapes, -100, 100, device)
+    in_data2, input_tensor2 = data_gen_with_range(input_shapes, -150, 150, device)
+
+    output_tensor = ttnn.nextafter(input_tensor1, input_tensor2)
+    golden_function = ttnn.get_golden_function(ttnn.nextafter)
+    golden_tensor = golden_function(in_data1, in_data2)
+
+    comp_pass = compare_pcc([output_tensor], [golden_tensor])
+    assert comp_pass
+
+
+@pytest.mark.parametrize(
+    "input_shapes",
+    (
+        (torch.Size([1, 1, 32, 32])),
+        (torch.Size([1, 1, 320, 384])),
+        (torch.Size([1, 3, 320, 384])),
+    ),
+)
+@pytest.mark.parametrize("atol", [1.0, 5.0, 10.0])
+@pytest.mark.parametrize("rtol", [1.0, 5.0, 10.0])
+@pytest.mark.parametrize("equal_nan", [True, False])
+def test_binary_isclose_ttnn(input_shapes, atol, rtol, equal_nan, device):
+    in_data1, input_tensor1 = data_gen_with_range(input_shapes, -100, 100, device)
+    in_data2, input_tensor2 = data_gen_with_range(input_shapes, -150, 150, device)
+
+    output_tensor = ttnn.isclose(input_tensor1, input_tensor2, rtol=rtol, atol=atol, equal_nan=equal_nan)
+
+    golden_function = ttnn.get_golden_function(ttnn.isclose)
+    golden_tensor = golden_function(in_data1, in_data2, rtol=rtol, atol=atol, equal_nan=equal_nan)
+
+    comp_pass = compare_pcc([output_tensor], [golden_tensor])
+    assert comp_pass
+
+
+@pytest.mark.parametrize(
+    "input_shapes",
+    (
+        (torch.Size([1, 1, 32, 32])),
+        (torch.Size([1, 1, 320, 384])),
+        (torch.Size([1, 3, 320, 384])),
+    ),
+)
+def test_binary_minimum_ttnn(input_shapes, device):
+    in_data1, input_tensor1 = data_gen_with_range(input_shapes, -100, 100, device)
+    in_data2, input_tensor2 = data_gen_with_range(input_shapes, -150, 150, device)
+
+    output_tensor = ttnn.minimum(input_tensor1, input_tensor2)
+    golden_function = ttnn.get_golden_function(ttnn.minimum)
+    golden_tensor = golden_function(in_data1, in_data2)
+
+    comp_pass = compare_pcc([output_tensor], [golden_tensor])
+    assert comp_pass
+
+
+@pytest.mark.parametrize(
+    "input_shapes",
+    (
+        (torch.Size([1, 1, 32, 32])),
+        (torch.Size([1, 1, 320, 384])),
+        (torch.Size([1, 3, 320, 384])),
+    ),
+)
+def test_binary_maximum_ttnn(input_shapes, device):
+    in_data1, input_tensor1 = data_gen_with_range(input_shapes, -100, 100, device)
+    in_data2, input_tensor2 = data_gen_with_range(input_shapes, -150, 150, device)
+
+    output_tensor = ttnn.maximum(input_tensor1, input_tensor2)
+    golden_function = ttnn.get_golden_function(ttnn.maximum)
+    golden_tensor = golden_function(in_data1, in_data2)
+
+    comp_pass = compare_pcc([output_tensor], [golden_tensor])
+    assert comp_pass
+
+
+@pytest.mark.parametrize(
+    "input_shapes",
+    (
+        (torch.Size([1, 1, 32, 32])),
+        (torch.Size([1, 1, 320, 384])),
+        (torch.Size([1, 3, 320, 384])),
+    ),
+)
+def test_binary_atan2_ttnn(input_shapes, device):
+    in_data1, input_tensor1 = data_gen_with_range(input_shapes, -100, 100, device)
+    in_data2, input_tensor2 = data_gen_with_range(input_shapes, -150, 150, device)
+
+    output_tensor = ttnn.atan2(input_tensor1, input_tensor2)
+    golden_function = ttnn.get_golden_function(ttnn.atan2)
+    golden_tensor = golden_function(in_data1, in_data2)
+
+    comp_pass = compare_pcc([output_tensor], [golden_tensor])
+    assert comp_pass
+
+
+@pytest.mark.parametrize(
+    "input_shapes",
+    (
+        (torch.Size([1, 1, 32, 32])),
+        (torch.Size([1, 1, 320, 384])),
+        (torch.Size([1, 3, 320, 384])),
+    ),
+)
+def test_binary_logical_xor_ttnn(input_shapes, device):
+    in_data1, input_tensor1 = data_gen_with_range(input_shapes, -100, 100, device)
+    in_data2, input_tensor2 = data_gen_with_range(input_shapes, -150, 150, device)
+
+    output_tensor = ttnn.logical_xor(input_tensor1, input_tensor2)
+    golden_function = ttnn.get_golden_function(ttnn.logical_xor)
+    golden_tensor = golden_function(in_data1, in_data2)
+
+    comp_pass = compare_pcc([output_tensor], [golden_tensor])
+    assert comp_pass
+
+
+@pytest.mark.parametrize(
+    "input_shapes",
+    (
+        (torch.Size([1, 1, 32, 32])),
+        (torch.Size([1, 1, 320, 384])),
+        (torch.Size([1, 3, 320, 384])),
+    ),
+)
+@pytest.mark.parametrize("alpha", [1.0, 5.0, 10.0])
+def test_binary_addalpha_ttnn(input_shapes, alpha, device):
+    in_data1, input_tensor1 = data_gen_with_range(input_shapes, -100, 100, device)
+    in_data2, input_tensor2 = data_gen_with_range(input_shapes, -150, 150, device)
+
+    output_tensor = ttnn.addalpha(input_tensor1, input_tensor2, alpha)
+    golden_function = ttnn.get_golden_function(ttnn.addalpha)
+    golden_tensor = golden_function(in_data1, in_data2, alpha)
+
+    comp_pass = compare_pcc([output_tensor], [golden_tensor])
+    assert comp_pass
+
+
+@pytest.mark.parametrize(
+    "input_shapes",
+    (
+        (torch.Size([1, 1, 32, 32])),
+        (torch.Size([1, 1, 320, 384])),
+        (torch.Size([1, 3, 320, 384])),
+    ),
+)
+@pytest.mark.parametrize("alpha", [1.0, 5.0, 10.0])
+def test_binary_subalpha_ttnn(input_shapes, alpha, device):
+    in_data1, input_tensor1 = data_gen_with_range(input_shapes, -100, 100, device)
+    in_data2, input_tensor2 = data_gen_with_range(input_shapes, -150, 150, device)
+
+    output_tensor = ttnn.subalpha(input_tensor1, input_tensor2, alpha)
+    golden_function = ttnn.get_golden_function(ttnn.subalpha)
+    golden_tensor = golden_function(in_data1, in_data2, alpha)
+
+    comp_pass = compare_pcc([output_tensor], [golden_tensor])
+    assert comp_pass

--- a/ttnn/CMakeLists.txt
+++ b/ttnn/CMakeLists.txt
@@ -47,6 +47,7 @@ set(TTNN_SRCS
     ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/normalization/groupnorm/device/groupnorm_op.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/normalization/groupnorm/device/multi_core/groupnorm_op_multi_core.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/experimental/transformer/device/transformer_device_operation.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/eltwise/binary/device/binary_composite_op.cpp
 )
 
 ### Setup TTNN as a shared library with optional Python bindings

--- a/ttnn/cpp/ttnn/operations/eltwise/binary/binary_composite.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary/binary_composite.hpp
@@ -1,0 +1,75 @@
+// SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include "ttnn/decorators.hpp"
+#include "ttnn/operations/core.hpp"
+#include "ttnn/cpp/ttnn/operations/eltwise/binary/device/binary_composite_op.hpp"
+
+namespace ttnn {
+
+namespace operations {
+
+namespace binary {
+
+template <BinaryCompositeOpType binary_comp_op_type>
+struct ExecuteBinaryCompositeOps
+{
+    static Tensor execute_on_worker_thread(
+        const Tensor& input_tensor_a,
+        const Tensor& input_tensor_b,
+        const std::optional<MemoryConfig>& memory_config = std::nullopt)
+        {
+            auto op_type = get_function_type0<binary_comp_op_type>();
+            return op_type(input_tensor_a, input_tensor_b, memory_config);
+        }
+};
+
+template <BinaryCompositeOpType binary_comp_op_type>
+struct ExecuteBinaryCompositeOpsFloat
+{
+    static Tensor execute_on_worker_thread(
+        const Tensor& input_tensor_a,
+        const Tensor& input_tensor_b,
+        float alpha,
+        const std::optional<MemoryConfig>& memory_config = std::nullopt)
+        {
+            auto op_type = get_function_type1<binary_comp_op_type>();
+            return op_type(input_tensor_a, input_tensor_b, alpha, memory_config);
+        }
+};
+
+template <BinaryCompositeOpType binary_comp_op_type>
+struct ExecuteBinaryCompositeOpsIsClose
+{
+    static Tensor execute_on_worker_thread(
+        const Tensor& input_tensor_a,
+        const Tensor& input_tensor_b,
+        float rtol,
+        float atol,
+        const bool equal_nan,
+        const std::optional<MemoryConfig>& memory_config = std::nullopt)
+        {
+            auto op_type = get_function_type2<binary_comp_op_type>();
+            return op_type(input_tensor_a, input_tensor_b, rtol, atol, equal_nan, memory_config);
+        }
+};
+
+}  // namespace binary
+}  // namespace operations
+
+// newly imported
+constexpr auto hypot = ttnn::register_operation<operations::binary::ExecuteBinaryCompositeOps<operations::binary::BinaryCompositeOpType::HYPOT>>("ttnn::hypot");
+constexpr auto xlogy = ttnn::register_operation<operations::binary::ExecuteBinaryCompositeOps<operations::binary::BinaryCompositeOpType::XLOGY>>("ttnn::xlogy");
+constexpr auto minimum = ttnn::register_operation<operations::binary::ExecuteBinaryCompositeOps<operations::binary::BinaryCompositeOpType::MINIMUM>>("ttnn::minimum");
+constexpr auto maximum = ttnn::register_operation<operations::binary::ExecuteBinaryCompositeOps<operations::binary::BinaryCompositeOpType::MAXIMUM>>("ttnn::maximum");
+constexpr auto atan2 = ttnn::register_operation<operations::binary::ExecuteBinaryCompositeOps<operations::binary::BinaryCompositeOpType::ATAN2>>("ttnn::atan2");
+constexpr auto logical_xor = ttnn::register_operation<operations::binary::ExecuteBinaryCompositeOps<operations::binary::BinaryCompositeOpType::LOGICAL_XOR>>("ttnn::logical_xor");
+constexpr auto nextafter = ttnn::register_operation<operations::binary::ExecuteBinaryCompositeOps<operations::binary::BinaryCompositeOpType::NEXTAFTER>>("ttnn::nextafter");
+constexpr auto addalpha = ttnn::register_operation<operations::binary::ExecuteBinaryCompositeOpsFloat<operations::binary::BinaryCompositeOpType::ADDALPHA>>("ttnn::addalpha");
+constexpr auto subalpha = ttnn::register_operation<operations::binary::ExecuteBinaryCompositeOpsFloat<operations::binary::BinaryCompositeOpType::SUBALPHA>>("ttnn::subalpha");
+constexpr auto isclose = ttnn::register_operation<operations::binary::ExecuteBinaryCompositeOpsIsClose<operations::binary::BinaryCompositeOpType::ISCLOSE>>("ttnn::isclose");
+
+}  // namespace ttnn

--- a/ttnn/cpp/ttnn/operations/eltwise/binary/binary_pybind.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary/binary_pybind.hpp
@@ -9,11 +9,15 @@
 
 #include "ttnn/cpp/pybind11/decorators.hpp"
 #include "ttnn/operations/eltwise/binary/binary.hpp"
+#include "ttnn/operations/eltwise/binary/binary_composite.hpp"
 #include "ttnn/types.hpp"
 
 namespace py = pybind11;
 
-namespace ttnn::operations::binary {
+
+namespace ttnn {
+namespace operations {
+namespace binary {
 
 namespace detail {
 
@@ -92,6 +96,135 @@ void bind_binary_operation(py::module& module, const binary_operation_t& operati
             py::arg("output_tensor") = std::nullopt,
             py::arg("activations") = std::nullopt,
             py::arg("queue_id") = 0});
+}
+
+template <typename binary_operation_t>
+void bind_binary_composite(py::module& module, const binary_operation_t& operation, const std::string& description) {
+    auto doc = fmt::format(
+        R"doc({0}(input_tensor_a: ttnn.Tensor, input_tensor_b: ttnn.Tensor, *, memory_config: Optional[ttnn.MemoryConfig] = None) -> ttnn.Tensor
+
+            Args:
+                * :attr:`input_tensor_a`
+                * :attr:`input_tensor_b` (ttnn.Tensor or Number): the tensor or number to add to :attr:`input_tensor_a`.
+
+            Keyword Args:
+                * :attr:`memory_config` (Optional[ttnn.MemoryConfig]): Memory configuration for the operation.
+
+            Example:
+
+                >>> tensor1 = ttnn.to_device(ttnn.from_torch(torch.tensor((1, 2), dtype=torch.bfloat16)), device)
+                >>> tensor2 = ttnn.to_device(ttnn.from_torch(torch.tensor((0, 1), dtype=torch.bfloat16)), device)
+                >>> output = {1}(tensor1, tensor2)
+        )doc",
+        operation.base_name(),
+        operation.python_fully_qualified_name(),
+        description);
+
+    bind_registered_operation(
+        module,
+        operation,
+        doc,
+        ttnn::pybind_overload_t{
+            [](const binary_operation_t& self,
+               const Tensor& input_tensor_a,
+               const Tensor& input_tensor_b,
+               const std::optional<MemoryConfig>& memory_config) {
+                    return self(input_tensor_a, input_tensor_b, memory_config);
+                },
+            py::arg("input_tensor_a"),
+            py::arg("input_tensor_b"),
+            py::kw_only(),
+            py::arg("memory_config") = std::nullopt});
+}
+
+template <typename binary_operation_t>
+void bind_binary_composite_with_alpha(py::module& module, const binary_operation_t& operation, const std::string& description) {
+    auto doc = fmt::format(
+        R"doc({0}(input_tensor_a: ttnn.Tensor, input_tensor_b: ttnn.Tensor, *, memory_config: Optional[ttnn.MemoryConfig] = None) -> ttnn.Tensor
+
+            Args:
+                * :attr:`input_tensor_a`
+                * :attr:`input_tensor_b` (ttnn.Tensor or Number): the tensor or number to add to :attr:`input_tensor_a`.
+                * :attr:`alpha`
+
+            Keyword Args:
+                * :attr:`memory_config` (Optional[ttnn.MemoryConfig]): Memory configuration for the operation.
+
+            Example:
+
+                >>> tensor1 = ttnn.to_device(ttnn.from_torch(torch.tensor((1, 2), dtype=torch.bfloat16)), device)
+                >>> tensor2 = ttnn.to_device(ttnn.from_torch(torch.tensor((0, 1), dtype=torch.bfloat16)), device)
+                >>> output = {1}(tensor1, tensor2, alpha)
+        )doc",
+        operation.base_name(),
+        operation.python_fully_qualified_name(),
+        description);
+
+    bind_registered_operation(
+        module,
+        operation,
+        doc,
+        ttnn::pybind_overload_t{
+            [](const binary_operation_t& self,
+               const Tensor& input_tensor_a,
+               const Tensor& input_tensor_b,
+               float alpha,
+               const std::optional<MemoryConfig>& memory_config) {
+                    return self(input_tensor_a, input_tensor_b, alpha, memory_config);
+                },
+            py::arg("input_tensor_a"),
+            py::arg("input_tensor_b"),
+            py::arg("alpha") = 1.0f,
+            py::kw_only(),
+            py::arg("memory_config") = std::nullopt});
+}
+
+template <typename binary_operation_t>
+void bind_binary_composite_with_rtol_atol(py::module& module, const binary_operation_t& operation, const std::string& description) {
+    auto doc = fmt::format(
+        R"doc({0}(input_tensor_a: ttnn.Tensor, input_tensor_b: ttnn.Tensor, *, memory_config: Optional[ttnn.MemoryConfig] = None) -> ttnn.Tensor
+
+            Args:
+                * :attr:`input_tensor_a`
+                * :attr:`input_tensor_b` (ttnn.Tensor or Number): the tensor or number to add to :attr:`input_tensor_a`.
+                * :attr:`rtol`
+                * :attr:`atol`
+                * :attr:`equal_nan`
+
+            Keyword Args:
+                * :attr:`memory_config` (Optional[ttnn.MemoryConfig]): Memory configuration for the operation.
+
+            Example:
+
+                >>> tensor1 = ttnn.to_device(ttnn.from_torch(torch.tensor((1, 2), dtype=torch.bfloat16)), device)
+                >>> tensor2 = ttnn.to_device(ttnn.from_torch(torch.tensor((0, 1), dtype=torch.bfloat16)), device)
+                >>> output = {1}(tensor1, tensor2, rtol, atol, equal_nan)
+        )doc",
+        operation.base_name(),
+        operation.python_fully_qualified_name(),
+        description);
+
+    bind_registered_operation(
+        module,
+        operation,
+        doc,
+        ttnn::pybind_overload_t{
+            [](const binary_operation_t& self,
+               const Tensor& input_tensor_a,
+               const Tensor& input_tensor_b,
+               float rtol,
+               float atol,
+               const bool equal_nan,
+               const std::optional<MemoryConfig>& memory_config) {
+                    return self(input_tensor_a, input_tensor_b, rtol, atol, equal_nan, memory_config);
+                },
+            py::arg("input_tensor_a"),
+            py::arg("input_tensor_b"),
+            py::kw_only(),
+            py::arg("rtol") = 1e-05f,
+            py::arg("atol") = 1e-08f,
+            py::arg("equal_nan") = false,
+            py::arg("memory_config") = std::nullopt});
 }
 
 }  // namespace detail
@@ -217,6 +350,69 @@ void py_module(py::module& module) {
         ttnn::divide,
         R"doc(Divides :attr:`input_tensor_a` and :attr:`input_tensor_b` and returns the tensor with the same layout as :attr:`input_tensor_a`
         .. math:: \mathrm{{input\_tensor\_a}}_i || \mathrm{{input\_tensor\_b}}_i)doc");
+
+    // new imported
+    detail::bind_binary_composite(
+        module,
+        ttnn::hypot,
+        R"doc(compute Hypot :attr:`input_tensor_a` and :attr:`input_tensor_b` and returns the tensor with the same layout as :attr:`input_tensor_a`
+        .. math:: \mathrm{{input\_tensor\_a}}_i || \mathrm{{input\_tensor\_b}}_i)doc");
+
+    detail::bind_binary_composite(
+        module,
+        ttnn::xlogy,
+        R"doc(Compute xlogy :attr:`input_tensor_a` and :attr:`input_tensor_b` and returns the tensor with the same layout as :attr:`input_tensor_a`
+        .. math:: \mathrm{{input\_tensor\_a}}_i || \mathrm{{input\_tensor\_b}}_i)doc");
+
+    detail::bind_binary_composite(
+        module,
+        ttnn::nextafter,
+        R"doc(Compute nextafter :attr:`input_tensor_a` and :attr:`input_tensor_b` and returns the tensor with the same layout as :attr:`input_tensor_a`
+        .. math:: \mathrm{{input\_tensor\_a}}_i || \mathrm{{input\_tensor\_b}}_i)doc");
+
+    detail::bind_binary_composite(
+        module,
+        ttnn::minimum,
+        R"doc(Compute minimum :attr:`input_tensor_a` and :attr:`input_tensor_b` and returns the tensor with the same layout as :attr:`input_tensor_a`
+        .. math:: \mathrm{{input\_tensor\_a}}_i || \mathrm{{input\_tensor\_b}}_i)doc");
+
+    detail::bind_binary_composite(
+        module,
+        ttnn::maximum,
+        R"doc(Compute maximum :attr:`input_tensor_a` and :attr:`input_tensor_b` and returns the tensor with the same layout as :attr:`input_tensor_a`
+        .. math:: \mathrm{{input\_tensor\_a}}_i || \mathrm{{input\_tensor\_b}}_i)doc");
+
+    detail::bind_binary_composite(
+        module,
+        ttnn::atan2,
+        R"doc(Compute atan2 :attr:`input_tensor_a` and :attr:`input_tensor_b` and returns the tensor with the same layout as :attr:`input_tensor_a`
+        .. math:: \mathrm{{input\_tensor\_a}}_i || \mathrm{{input\_tensor\_b}}_i)doc");
+
+    detail::bind_binary_composite(
+        module,
+        ttnn::logical_xor,
+        R"doc(Compute logical_xor :attr:`input_tensor_a` and :attr:`input_tensor_b` and returns the tensor with the same layout as :attr:`input_tensor_a`
+        .. math:: \mathrm{{input\_tensor\_a}}_i || \mathrm{{input\_tensor\_b}}_i)doc");
+
+    detail::bind_binary_composite_with_alpha(
+        module,
+        ttnn::addalpha,
+        R"doc(Compute addalpha :attr:`input_tensor_a` and :attr:`input_tensor_b` and returns the tensor with the same layout as :attr:`input_tensor_a`
+        .. math:: \mathrm{{input\_tensor\_a}}_i || \mathrm{{input\_tensor\_b}}_i)doc");
+
+    detail::bind_binary_composite_with_alpha(
+        module,
+        ttnn::subalpha,
+        R"doc(Compute subalpha :attr:`input_tensor_a` and :attr:`input_tensor_b` and returns the tensor with the same layout as :attr:`input_tensor_a`
+        .. math:: \mathrm{{input\_tensor\_a}}_i || \mathrm{{input\_tensor\_b}}_i)doc");
+
+    detail::bind_binary_composite_with_rtol_atol(
+        module,
+        ttnn::isclose,
+        R"doc(Compute isclose :attr:`input_tensor_a` and :attr:`input_tensor_b` and returns the tensor with the same layout as :attr:`input_tensor_a`
+        .. math:: \mathrm{{input\_tensor\_a}}_i || \mathrm{{input\_tensor\_b}}_i)doc");
 }
 
-}
+}  // namespace binary
+}  // namespace operations
+}  // namespace ttnn

--- a/ttnn/cpp/ttnn/operations/eltwise/binary/device/binary_composite_op.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary/device/binary_composite_op.cpp
@@ -1,0 +1,155 @@
+// SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "binary_composite_op.hpp"
+#include "third_party/magic_enum/magic_enum.hpp"
+#include "ttnn/cpp/ttnn/operations/eltwise/binary/binary.hpp"
+#include "ttnn/cpp/ttnn/operations/eltwise/unary/unary.hpp"
+#include "ttnn/cpp/ttnn/types.hpp"
+#include "tt_metal/common/bfloat16.hpp"
+#include "ttnn/experimental/tt_dnn/op_library/composite/composite_ops.hpp"
+
+namespace ttnn::operations::binary{
+
+
+Tensor _hypot(const Tensor& input_a, const Tensor& input_b, const std::optional<MemoryConfig>& output_mem_config) {
+    Tensor a_sq = ttnn::square(input_a, output_mem_config);
+    Tensor b_sq = ttnn::square(input_b, output_mem_config);
+    Tensor c_sq = ttnn::add(a_sq, b_sq, std::nullopt, output_mem_config);
+    a_sq.deallocate();
+    b_sq.deallocate();
+    return ttnn::sqrt(c_sq, output_mem_config);
+}
+
+// xlogy(x,y)=x*log(y)
+Tensor _xlogy(const Tensor& input_a, const Tensor& input_b, const std::optional<MemoryConfig>& output_mem_config) {
+    Tensor t_nan = ttnn::full_like(input_b, std::nanf(" "));
+    Tensor result = ttnn::multiply(input_a, ttnn::log(input_b, output_mem_config), std::nullopt, output_mem_config);
+    result = where(
+        ttnn::logical_or(
+            ttnn::ltz(input_b, output_mem_config),
+            ttnn::eq(input_b, t_nan, std::nullopt, output_mem_config),
+            std::nullopt,
+            output_mem_config),
+        t_nan,
+        result);
+    return result;
+}
+
+// subalpha(input,other,alpha)=input-alpha*other
+Tensor _subalpha(const Tensor& input_a, const Tensor& input_b, float alpha, const std::optional<MemoryConfig>& output_mem_config) {
+    Tensor result = ttnn::add(
+        ttnn::neg(ttnn::multiply(input_b, alpha, std::nullopt, output_mem_config), output_mem_config), input_a, std::nullopt, output_mem_config);
+    return result;
+}
+
+// addalpha(input, other, alpha) = input + (alpha * other)
+Tensor _addalpha(
+    const Tensor& input_a,
+    const Tensor& input_b,
+    float alpha,
+    const std::optional<MemoryConfig>& output_mem_config) {
+
+    return ttnn::add(ttnn::multiply(input_b, alpha, std::nullopt, output_mem_config), input_a, std::nullopt, output_mem_config);
+}
+
+
+// nextafter
+Tensor _nextafter(const Tensor& input_a, const Tensor& input_b, const std::optional<MemoryConfig>& output_mem_config) {
+    const float eps = input_a.device()->sfpu_eps();
+    Tensor result(input_a);
+    {
+        Tensor eps_gt(input_a);
+        {
+            eps_gt = where(
+                ttnn::gt(input_a, input_b, std::nullopt, output_mem_config),
+                ttnn::add(input_a, eps, std::nullopt, output_mem_config),
+                input_a);
+        }
+        result = where(
+            ttnn::lt(input_a, input_b, std::nullopt, output_mem_config),
+            ttnn::subtract(input_a, eps, std::nullopt, output_mem_config),
+            eps_gt);
+    }
+    return result;
+}
+
+// ∣input−other∣≤ atol+rtol×∣other∣
+Tensor _isclose(
+    const Tensor& input_a,
+    const Tensor& input_b,
+    float rtol,
+    float atol,
+    bool equal_nan,
+    const std::optional<MemoryConfig>& output_mem_config) {
+    Tensor value1 = input_a;
+    Tensor value2 = input_b;
+    if (!equal_nan) {
+        value1 = tt::tt_metal::where(ttnn::isnan(value1, output_mem_config), 1.0f, value1);
+        value2 = tt::tt_metal::where(ttnn::isnan(value2, output_mem_config), 0.0f, value2);
+    }
+    Tensor is_close_lhs = ttnn::abs(ttnn::subtract(value1, value2, std::nullopt, output_mem_config), output_mem_config);
+    Tensor is_close_rhs = input_b;
+    Tensor mul_result = ttnn::multiply(ttnn::abs(value2, output_mem_config), rtol, std::nullopt, output_mem_config);
+    is_close_rhs = ttnn::add(mul_result, atol, std::nullopt, output_mem_config);
+    mul_result.deallocate();
+    Tensor result = tt::tt_metal::where(ttnn::le(is_close_lhs, is_close_rhs, std::nullopt, output_mem_config), 1.0, 0.0);
+    return result;
+}
+
+// minimum(a,b) = a - (a - b > 0 )*(a-b)
+Tensor _minimum(const Tensor& input_a, const Tensor& input_b, const std::optional<MemoryConfig>& output_mem_config) {
+    Tensor t_diff = ttnn::subtract(input_a, input_b, std::nullopt, output_mem_config);
+    Tensor result = where(t_diff, input_b, input_a);
+    return result;
+}
+
+// maximum(a,b) = a + (b - a > 0 )*(b-a)
+Tensor _maximum(const Tensor& input_a, const Tensor& input_b, const std::optional<MemoryConfig>& output_mem_config) {
+    Tensor t_diff = ttnn::subtract(input_b, input_a, std::nullopt, output_mem_config);
+    Tensor result = where(t_diff, input_b, input_a);
+    return result;
+}
+
+Tensor _atan2(const Tensor& input_a, const Tensor& input_b, const std::optional<MemoryConfig>& output_mem_config) {
+    Tensor result(input_a);
+    {
+        Tensor atan_input = ttnn::multiply(
+            ttnn::abs(input_b, output_mem_config),
+            ttnn::reciprocal(ttnn::abs(input_a, output_mem_config), output_mem_config),
+            std::nullopt,
+            output_mem_config);
+        result = ttnn::atan(atan_input, output_mem_config);
+    }
+    Tensor res(result);
+    {
+        Tensor ib_gtz = ttnn::gtz(input_b, output_mem_config);
+        Tensor ib_gt = ttnn::gtz(input_b, output_mem_config);
+        Tensor ib_lt = ttnn::ltz(input_b, output_mem_config);
+        float pi_2 = M_PI_2;
+        Tensor neg_result = ttnn::neg(result, output_mem_config);
+
+        res = where(
+            ttnn::gtz(input_a, output_mem_config),
+            where(ib_gtz, result, neg_result),
+            where(
+                ttnn::ltz(input_a, output_mem_config),
+                where(
+                    ib_gt,
+                    ttnn::add(neg_result, M_PI, std::nullopt, output_mem_config),
+                    where(ib_lt, ttnn::subtract(result, M_PI, std::nullopt, output_mem_config), M_PI)),
+                where(ib_gt, pi_2, where(ib_lt, -pi_2, 0.0f))));
+    }
+    return res;
+}
+
+Tensor _logical_xor(const Tensor& input_a, const Tensor& input_b, const std::optional<MemoryConfig>& output_mem_config) {
+    Tensor in_a_eq_zero = ttnn::eqz(input_a, output_mem_config);
+    Tensor in_b_eq_zero = ttnn::eqz(input_b, output_mem_config);
+    Tensor in_b_neq_zero = ttnn::nez(input_b, output_mem_config);
+    Tensor result = where(in_a_eq_zero, in_b_neq_zero, in_b_eq_zero);
+    return result;
+}
+
+} // namespace ttnn::operations::binary

--- a/ttnn/cpp/ttnn/operations/eltwise/binary/device/binary_composite_op.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary/device/binary_composite_op.hpp
@@ -1,0 +1,136 @@
+
+// SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+#pragma once
+#include <functional>
+#include <optional>
+#include "tensor/tensor.hpp"
+#include "third_party/magic_enum/magic_enum.hpp"
+
+namespace ttnn::operations::binary{
+
+enum class BinaryCompositeOpType {
+    HYPOT,
+    XLOGY,
+    ADDALPHA,
+    SUBALPHA,
+    NEXTAFTER,
+    ISCLOSE,
+    MINIMUM,
+    MAXIMUM,
+    ATAN2,
+    LOGICAL_XOR,
+
+};
+
+Tensor _hypot(const Tensor&, const Tensor&, const std::optional<MemoryConfig>&);
+Tensor _xlogy(const Tensor&, const Tensor&, const std::optional<MemoryConfig>&);
+Tensor _minimum(const Tensor&, const Tensor&, const std::optional<MemoryConfig>&);
+Tensor _maximum(const Tensor&, const Tensor&, const std::optional<MemoryConfig>&);
+Tensor _atan2(const Tensor&, const Tensor&, const std::optional<MemoryConfig>&);
+Tensor _logical_xor(const Tensor&, const Tensor&, const std::optional<MemoryConfig>&);
+Tensor _nextafter(const Tensor&, const Tensor&, const std::optional<MemoryConfig>&);
+Tensor _addalpha(const Tensor&, const Tensor&, float, const std::optional<MemoryConfig>&);
+Tensor _subalpha(const Tensor&, const Tensor&, float, const std::optional<MemoryConfig>&);
+Tensor _isclose(const Tensor&, const Tensor&, float, float, const bool, const std::optional<MemoryConfig>&);
+
+// OpHandler struct template
+template <BinaryCompositeOpType OpType>
+struct OpHandler;
+
+template <BinaryCompositeOpType OpType>
+struct OpHandler_Float;
+
+template <BinaryCompositeOpType OpType>
+struct OpHandler_IsClose;
+
+
+template <>
+struct OpHandler<BinaryCompositeOpType::HYPOT> {
+    static Tensor handle(const Tensor& t1, const Tensor& t2, const std::optional<MemoryConfig>& mem_cfg) {
+        return _hypot(t1, t2, mem_cfg);
+    }
+};
+
+template <>
+struct OpHandler<BinaryCompositeOpType::XLOGY> {
+    static Tensor handle(const Tensor& t1, const Tensor& t2, const std::optional<MemoryConfig>& mem_cfg) {
+        return _xlogy(t1, t2, mem_cfg);
+    }
+};
+
+template <>
+struct OpHandler<BinaryCompositeOpType::NEXTAFTER> {
+    static Tensor handle(const Tensor& t1, const Tensor& t2, const std::optional<MemoryConfig>& mem_cfg) {
+        return _nextafter(t1, t2, mem_cfg);
+    }
+};
+
+template <>
+struct OpHandler<BinaryCompositeOpType::MINIMUM> {
+    static Tensor handle(const Tensor& t1, const Tensor& t2, const std::optional<MemoryConfig>& mem_cfg) {
+        return _minimum(t1, t2, mem_cfg);
+    }
+};
+
+template <>
+struct OpHandler<BinaryCompositeOpType::MAXIMUM> {
+    static Tensor handle(const Tensor& t1, const Tensor& t2, const std::optional<MemoryConfig>& mem_cfg) {
+        return _maximum(t1, t2, mem_cfg);
+    }
+};
+
+template <>
+struct OpHandler<BinaryCompositeOpType::ATAN2> {
+    static Tensor handle(const Tensor& t1, const Tensor& t2, const std::optional<MemoryConfig>& mem_cfg) {
+        return _atan2(t1, t2, mem_cfg);
+    }
+};
+
+template <>
+struct OpHandler<BinaryCompositeOpType::LOGICAL_XOR> {
+    static Tensor handle(const Tensor& t1, const Tensor& t2, const std::optional<MemoryConfig>& mem_cfg) {
+        return _logical_xor(t1, t2, mem_cfg);
+    }
+};
+
+template <>
+struct OpHandler_Float<BinaryCompositeOpType::ADDALPHA> {
+    static Tensor handle(const Tensor& t1, const Tensor& t2, float alpha, const std::optional<MemoryConfig>& mem_cfg) {
+        return _addalpha(t1, t2, alpha, mem_cfg);
+    }
+};
+
+template <>
+struct OpHandler_Float<BinaryCompositeOpType::SUBALPHA> {
+    static Tensor handle(const Tensor& t1, const Tensor& t2, float alpha, const std::optional<MemoryConfig>& mem_cfg) {
+        return _subalpha(t1, t2, alpha, mem_cfg);
+    }
+};
+
+
+template <>
+struct OpHandler_IsClose<BinaryCompositeOpType::ISCLOSE> {
+    static Tensor handle(const Tensor& t1, const Tensor& t2, float rtol, float atol, const bool equal_nan, const std::optional<MemoryConfig>& mem_cfg) {
+        return _isclose(t1, t2, rtol, atol, equal_nan, mem_cfg);
+    }
+};
+
+// Template functions to get the function pointers
+template <BinaryCompositeOpType OpType>
+auto get_function_type0() {
+    return &OpHandler<OpType>::handle;
+}
+
+template <BinaryCompositeOpType OpType>
+auto get_function_type1() {
+    return &OpHandler_Float<OpType>::handle;
+}
+
+template <BinaryCompositeOpType OpType>
+auto get_function_type2() {
+    return &OpHandler_IsClose<OpType>::handle;
+}
+
+}

--- a/ttnn/cpp/ttnn/operations/eltwise/unary/device/unary_composite_op.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary/device/unary_composite_op.cpp
@@ -129,7 +129,6 @@ Tensor _cosh(const Tensor& input_a, const std::optional<MemoryConfig>& output_me
    Tensor scalar = ttnn::full_like(input_a, 0.5f);
     //    ttnn::operations::creation::create_scalar(0.5f, input_a.get_dtype(), Layout::TILE, input_a.device());
    return ttnn::multiply(nr_term, scalar, std::nullopt);
-   scalar.deallocate();
 }
 
 // TODO: In future will uplift the op once the floor and tan has supported.
@@ -314,7 +313,6 @@ Tensor _sinh(const Tensor& input_a, const std::optional<MemoryConfig>& output_me
     e_neg_x.deallocate();
     Tensor scalar = ttnn::full_like(input_a, 0.5f);
     return ttnn::multiply(nr_term, scalar, std::nullopt, output_mem_config);
-    scalar.deallocate();
 }
 
 // Function: softsign

--- a/ttnn/ttnn/operations/binary.py
+++ b/ttnn/ttnn/operations/binary.py
@@ -173,136 +173,109 @@ def _golden_function(input_tensor_a, input_tensor_b, *args, **kwargs):
 ttnn.attach_golden_function(ttnn.bias_gelu, golden_function=_golden_function)
 
 
-def _golden_function(input_tensor_a, input_tensor_b, *args, **kwargs):
+def _golden_function_squared_difference(input_tensor_a, input_tensor_b, *args, **kwargs):
     import torch
 
-    return torch.squared_difference(input_tensor_a, input_tensor_b)
+    return torch_squared_difference(input_tensor_a, input_tensor_b)
 
 
-ttnn.attach_golden_function(ttnn.squared_difference, golden_function=_golden_function)
+ttnn.attach_golden_function(ttnn.squared_difference, golden_function=_golden_function_squared_difference)
+
+
+def _golden_function_addalpha(input_tensor_a, input_tensor_b, alpha, *args, **kwargs):
+    import torch
+
+    return torch.add(input_tensor_a, input_tensor_b, alpha=alpha)
+
+
+ttnn.attach_golden_function(ttnn._ttnn.operations.binary.addalpha, golden_function=_golden_function_addalpha)
+
+
+def _golden_function_subalpha(input_tensor_a, input_tensor_b, alpha, *args, **kwargs):
+    import torch
+
+    return torch.sub(input_tensor_a, input_tensor_b, alpha=alpha)
+
+
+ttnn.attach_golden_function(ttnn._ttnn.operations.binary.subalpha, golden_function=_golden_function_subalpha)
+
+
+def _golden_function_xlogy(input_tensor_a, input_tensor_b, *args, **kwargs):
+    import torch
+
+    return torch.xlogy(input_tensor_a, input_tensor_b)
+
+
+ttnn.attach_golden_function(ttnn._ttnn.operations.binary.xlogy, golden_function=_golden_function_xlogy)
+
+
+def _golden_function_hypot(input_tensor_a, input_tensor_b, *args, **kwargs):
+    import torch
+
+    return torch.hypot(input_tensor_a, input_tensor_b)
+
+
+ttnn.attach_golden_function(ttnn._ttnn.operations.binary.hypot, golden_function=_golden_function_hypot)
+
+
+def _golden_function_maximum(input_tensor_a, input_tensor_b, *args, **kwargs):
+    import torch
+
+    return torch.maximum(input_tensor_a, input_tensor_b)
+
+
+ttnn.attach_golden_function(ttnn._ttnn.operations.binary.maximum, golden_function=_golden_function_maximum)
+
+
+def _golden_function_minimum(input_tensor_a, input_tensor_b, *args, **kwargs):
+    import torch
+
+    return torch.minimum(input_tensor_a, input_tensor_b)
+
+
+ttnn.attach_golden_function(ttnn._ttnn.operations.binary.minimum, golden_function=_golden_function_minimum)
+
+
+def _golden_function_logical_xor(input_tensor_a, input_tensor_b, *args, **kwargs):
+    import torch
+
+    return torch.logical_xor(input_tensor_a, input_tensor_b)
+
+
+ttnn.attach_golden_function(ttnn._ttnn.operations.binary.logical_xor, golden_function=_golden_function_logical_xor)
+
+
+def _golden_function_atan2(input_tensor_a, input_tensor_b, *args, **kwargs):
+    import torch
+
+    return torch.atan2(input_tensor_a, input_tensor_b)
+
+
+ttnn.attach_golden_function(ttnn._ttnn.operations.binary.atan2, golden_function=_golden_function_atan2)
+
+
+def _golden_function_nextafter(input_tensor_a, input_tensor_b, *args, **kwargs):
+    import torch
+
+    return torch.nextafter(input_tensor_a, input_tensor_b)
+
+
+ttnn.attach_golden_function(ttnn._ttnn.operations.binary.nextafter, golden_function=_golden_function_nextafter)
+
+
+def _golden_function_isclose(input_tensor_a, input_tensor_b, *args, rtol=1e-05, atol=1e-08, equal_nan=False, **kwargs):
+    import torch
+
+    return torch.isclose(input_tensor_a, input_tensor_b, rtol=rtol, atol=atol, equal_nan=equal_nan)
+
+
+ttnn.attach_golden_function(ttnn._ttnn.operations.binary.isclose, golden_function=_golden_function_isclose)
 
 
 def torch_squared_difference(x, y, *args, **kwargs):
     import torch
 
     return torch.square(torch.sub(x, y))
-
-
-def register_ttl_elt_binary_function(name, ttl_elt_binary_function, op_name):
-    def _golden_function(input_tensor_a: ttnn.Tensor, input_tensor_b: ttnn.Tensor, **_):
-        import torch
-
-        name_to_torch_function = {
-            "logical_xor": torch.logical_xor,
-            "xlogy": torch.xlogy,
-            "maximum": torch.maximum,
-            "minimum": torch.minimum,
-            "atan2": torch.atan2,
-            "hypot": torch.hypot,
-        }
-        torch_function = name_to_torch_function[name]
-        return torch_function(input_tensor_a, input_tensor_b)
-
-    doc = f"""{name}(input_tensor_a: ttnn.Tensor, input_tensor_b: ttnn.Tensor, *, memory_config: ttnn.MemoryConfig = ttnn.DRAM_MEMORY_CONFIG) -> ttnn.Tensor
-
-            Performs eltwise-binary {op_name} operation on two tensors :attr:`input_a` and :attr:`input_b`.
-
-            .. math::
-                {name.replace('_',' ')}(\\mathrm{{input\\_tensor\\_a}}_i \\; , \\; \\mathrm{{input\\_tensor\\_b}}_i )
-
-            Args:
-                * :attr:`input_tensor_a`
-                * :attr:`input_tensor_b`
-
-            Example::
-                >>> tensor1 = ttnn.to_device(ttnn.from_torch(torch.tensor(([[1, 2], [3, 4]]), dtype=torch.bfloat16)), device)
-                >>> tensor2 = ttnn.to_device(ttnn.from_torch(torch.tensor(([[1, 1], [4, 4]]), dtype=torch.bfloat16)), device)
-                >>> output = ttnn.{name}(tensor1, tensor2)
-            """
-
-    @ttnn.register_python_operation(name=f"ttnn.{name}", golden_function=_golden_function, doc=doc)
-    def elt_binary_function(
-        input_tensor_a: ttnn.Tensor,
-        input_tensor_b: Union[ttnn.Tensor, int, float],
-        *,
-        memory_config: ttnn.MemoryConfig = ttnn.DRAM_MEMORY_CONFIG,
-    ) -> ttnn.Tensor:
-        if not (input_tensor_a.shape == input_tensor_b.shape):
-            raise RuntimeError("input_tensors must be of same size!")
-
-        if not isinstance(input_tensor_a, ttnn.Tensor) or not isinstance(input_tensor_b, ttnn.Tensor):
-            raise TypeError("Expected both arguments to be a ttnn.Tensor")
-
-        if not ttnn.is_tensor_storage_on_device(input_tensor_a) or not ttnn.is_tensor_storage_on_device(input_tensor_b):
-            raise RuntimeError("input_tensors must be on device!")
-
-        original_shape = input_tensor_a.shape
-
-        input_tensor_a = ttnn.unsqueeze_to_4D(input_tensor_a)
-        input_tensor_b = ttnn.unsqueeze_to_4D(input_tensor_b)
-
-        output_tensor = ttl_elt_binary_function(input_tensor_a, input_tensor_b, output_mem_config=memory_config)
-
-        output_tensor = ttnn.reshape(output_tensor, original_shape)
-        return output_tensor
-
-
-TTL_BINARY_ELTWISE_FUNCTIONS = [
-    ("logical_xor", ttl.tensor.logical_xor, "logical XOR (input_a ^ input_b) "),
-    ("xlogy", ttl.tensor.xlogy, "xlogy (input_a * log( input_b ))"),
-    ("maximum", ttl.tensor.max, "maximum "),
-    ("minimum", ttl.tensor.min, "minimum "),
-    ("atan2", ttl.tensor.atan2, "atan2"),
-    ("hypot", ttl.tensor.hypot, "hypotenuse"),
-]
-
-
-for elt_binary_function_name, ttl_elt_binary_function, op_name in TTL_BINARY_ELTWISE_FUNCTIONS:
-    register_ttl_elt_binary_function(elt_binary_function_name, ttl_elt_binary_function, op_name)
-
-
-def _golden_function(input_tensor_a: ttnn.Tensor, input_tensor_b: ttnn.Tensor, **_):
-    import torch
-
-    return torch.nextafter(input_tensor_a, input_tensor_b)
-
-
-@ttnn.register_python_operation(
-    name="ttnn.nextafter",
-    golden_function=_golden_function,
-)
-def nextafter(
-    input_tensor_a: ttnn.Tensor,
-    input_tensor_b: ttnn.Tensor,
-    *,
-    memory_config: ttnn.MemoryConfig = ttnn.DRAM_MEMORY_CONFIG,
-    dtype: Optional[ttnn.DataType] = None,
-) -> ttnn.Tensor:
-    r"""
-    nextafter(input_tensor_a: ttnn.Tensor, input_tensor_b: ttnn.Tensor, *, memory_config: ttnn.MemoryConfig = ttnn.DRAM_MEMORY_CONFIG, dtype: Optional[ttnn.DataType] = None) -> ttnn.Tensor
-
-    Returns the next floating-point value after input_a towards input_b of the input tensors input_a and input_b.
-
-    .. math::
-        \mathrm{{input\_tensor\_a}}_i , \mathrm{{input\_tensor\_b}}_i
-
-    Args:
-        * :attr:`input_tensor_a`
-        * :attr:`input_tensor_b`
-
-    Keyword args:
-        :attr:`memory_config` (ttnn.MemoryConfig): memory config for the output tensor
-        :attr:`dtype` (Optional[ttnn.DataType]): data type for the output tensor
-
-
-    """
-
-    output = ttnn.experimental.tensor.nextafter(
-        input_tensor_a,
-        input_tensor_b,
-        output_mem_config=memory_config,
-    )
-    return output
 
 
 def torch_polyval(input_tensor, coeff):
@@ -352,55 +325,6 @@ def polyval(
         output_mem_config=memory_config,
     )
     return output
-
-
-def _golden_function(
-    input_tensor_a: ttnn.Tensor,
-    input_tensor_b: ttnn.Tensor,
-    param1: float = 1e-05,
-    param2: float = 1e-08,
-    equal_nan: bool = False,
-    **_,
-):
-    import torch
-
-    return torch.isclose(input_tensor_a, input_tensor_b, rtol=param1, atol=param2, equal_nan=equal_nan)
-
-
-@ttnn.register_python_operation(
-    name=f"ttnn.isclose",
-    golden_function=_golden_function,
-)
-def isclose(
-    input_tensor_a: ttnn.Tensor,
-    input_tensor_b: ttnn.Tensor,
-    *,
-    rtol: float = 1e-05,
-    atol: float = 1e-08,
-    equal_nan: bool = False,
-    memory_config: ttnn.MemoryConfig = ttnn.DRAM_MEMORY_CONFIG,
-) -> ttnn.Tensor:
-    """isclose(input_tensor_a: ttnn.Tensor, input_tensor_b: ttnn.Tensor, *, rtol: float = 1e-05, atol: float = 1e-08, equal_nan: bool = False, memory_config: ttnn.MemoryConfig = ttnn.DRAM_MEMORY_CONFIG) -> ttnn.Tensor
-
-    Applies the isclose function to the elements of the input tensor :attr:`input_a` and :attr:`input_b`.
-
-    isclose(input_a, input_b, rtol, atol) = ∣input_a−input_B∣ ≤ atol+rtol×∣input_b∣.
-
-    .. math::
-        ttnn.isclose(\\mathrm{{input\\_tensor\\_a}}_i \\; , \\; \\mathrm{{input\\_tensor\\_b}}_i  \\; , \\; \\mathrm{{atol}}\\; , \\; \\mathrm{{rtol}})
-
-    Args:
-        * :attr:`input_tensor_a`
-        * :attr:`input_tensor_b`
-
-
-
-    Example::
-        >>> tensor1 = ttnn.to_device(ttnn.from_torch(torch.tensor(([[1, 2], [3, 4]]), dtype=torch.bfloat16)), device)
-        >>> tensor2 = ttnn.to_device(ttnn.from_torch(torch.tensor(([[1 + 1e-10, 1], [4, 4 + 1e-10]]), dtype=torch.bfloat16)), device)
-        >>> output = ttnn.isclose(tensor1, tensor2, rtol, atol)
-    """
-    return ttl.tensor.isclose(input_tensor_a, input_tensor_b, rtol, atol, equal_nan, output_mem_config=memory_config)
 
 
 __all__ = []


### PR DESCRIPTION
### Ticket
[Link to Github Issue](https://github.com/tenstorrent/tt-metal/issues/10137)

### Problem description

Migrate composite Binary op into ttnn

### What's changed

- [x] minimum
- [x] maximum
- [x] hypot
- [x] xlogy
- [x] atan2
- [x] subalpha
- [x] addalpha
- [x] logical_xor
- [x] isclose
- [x] nextafter
- [ ] scatter
- [ ] div
- [ ] div_no_nan
- [ ] remainder
- [ ] fmod
- [ ] floor_div
- [ ] outer



### Checklist
- [x] Post commit CI passes
- [ ] Model regression CI testing passes (if applicable)
- [ ] New/Existing tests provide coverage for changes
