### PR TITLE
#10076: Migrate Unary bw ops and replace tt_eager ops with ttnn ops

### DIFF
--- a/docs/source/ttnn/ttnn/api.rst
+++ b/docs/source/ttnn/ttnn/api.rst
@@ -177,6 +177,7 @@ Pointwise Unary
    ttnn/lgamma_bw
    ttnn/fill_bw
    ttnn/hardsigmoid_bw
+   ttnn/cos_bw
    ttnn/sub_bw
    ttnn/frac_bw
    ttnn/trunc_bw

--- a/docs/source/ttnn/ttnn/api.rst
+++ b/docs/source/ttnn/ttnn/api.rst
@@ -175,6 +175,7 @@ Pointwise Unary
    ttnn/add_bw
    ttnn/eq_bw
    ttnn/lgamma_bw
+   ttnn/fill_bw
    ttnn/sub_bw
    ttnn/frac_bw
    ttnn/trunc_bw

--- a/docs/source/ttnn/ttnn/api.rst
+++ b/docs/source/ttnn/ttnn/api.rst
@@ -176,6 +176,7 @@ Pointwise Unary
    ttnn/eq_bw
    ttnn/lgamma_bw
    ttnn/fill_bw
+   ttnn/hardsigmoid_bw
    ttnn/sub_bw
    ttnn/frac_bw
    ttnn/trunc_bw

--- a/docs/source/ttnn/ttnn/api.rst
+++ b/docs/source/ttnn/ttnn/api.rst
@@ -181,6 +181,7 @@ Pointwise Unary
    ttnn/acosh_bw
    ttnn/acos_bw
    ttnn/atan_bw
+   ttnn/rad2deg_bw
    ttnn/sub_bw
    ttnn/frac_bw
    ttnn/trunc_bw

--- a/docs/source/ttnn/ttnn/api.rst
+++ b/docs/source/ttnn/ttnn/api.rst
@@ -178,6 +178,7 @@ Pointwise Unary
    ttnn/fill_bw
    ttnn/hardsigmoid_bw
    ttnn/cos_bw
+   ttnn/acosh_bw
    ttnn/sub_bw
    ttnn/frac_bw
    ttnn/trunc_bw

--- a/docs/source/ttnn/ttnn/api.rst
+++ b/docs/source/ttnn/ttnn/api.rst
@@ -180,6 +180,7 @@ Pointwise Unary
    ttnn/cos_bw
    ttnn/acosh_bw
    ttnn/acos_bw
+   ttnn/atan_bw
    ttnn/sub_bw
    ttnn/frac_bw
    ttnn/trunc_bw

--- a/docs/source/ttnn/ttnn/api.rst
+++ b/docs/source/ttnn/ttnn/api.rst
@@ -179,6 +179,7 @@ Pointwise Unary
    ttnn/hardsigmoid_bw
    ttnn/cos_bw
    ttnn/acosh_bw
+   ttnn/acos_bw
    ttnn/sub_bw
    ttnn/frac_bw
    ttnn/trunc_bw

--- a/docs/source/ttnn/ttnn/dependencies/tt_lib.rst
+++ b/docs/source/ttnn/ttnn/dependencies/tt_lib.rst
@@ -812,7 +812,9 @@ Backward Operations
 
 .. autofunction:: tt_lib.tensor.tanh_bw
 
-.. autofunction:: tt_lib.tensor.fill_bw
+.. autofunction:: tt_lib.tensor.log_bw
+
+.. autofunction:: tt_lib.tensor.abs_bw
 
 .. autofunction:: tt_lib.tensor.complex_abs_bw
 

--- a/docs/source/ttnn/ttnn/dependencies/tt_lib.rst
+++ b/docs/source/ttnn/ttnn/dependencies/tt_lib.rst
@@ -838,8 +838,6 @@ Backward Operations
 
 .. autofunction:: tt_lib.tensor.polygamma_bw
 
-.. autofunction:: tt_lib.tensor.atan_bw
-
 .. autofunction:: tt_lib.tensor.atanh_bw
 
 .. autofunction:: tt_lib.tensor.asin_bw

--- a/docs/source/ttnn/ttnn/dependencies/tt_lib.rst
+++ b/docs/source/ttnn/ttnn/dependencies/tt_lib.rst
@@ -848,8 +848,6 @@ Backward Operations
 
 .. autofunction:: tt_lib.tensor.cosh_bw
 
-.. autofunction:: tt_lib.tensor.acosh_bw
-
 .. autofunction:: tt_lib.tensor.acos_bw
 
 .. autofunction:: tt_lib.tensor.erfinv_bw

--- a/docs/source/ttnn/ttnn/dependencies/tt_lib.rst
+++ b/docs/source/ttnn/ttnn/dependencies/tt_lib.rst
@@ -812,10 +812,6 @@ Backward Operations
 
 .. autofunction:: tt_lib.tensor.tanh_bw
 
-.. autofunction:: tt_lib.tensor.log_bw
-
-.. autofunction:: tt_lib.tensor.abs_bw
-
 .. autofunction:: tt_lib.tensor.complex_abs_bw
 
 .. autofunction:: tt_lib.tensor.lt_bw
@@ -827,10 +823,6 @@ Backward Operations
 .. autofunction:: tt_lib.tensor.gelu_bw
 
 .. autofunction:: tt_lib.tensor.bias_gelu_unary_bw
-
-.. autofunction:: tt_lib.tensor.hardshrink_bw
-
-.. autofunction:: tt_lib.tensor.softshrink_bw
 
 .. autofunction:: tt_lib.tensor.hardswish_bw
 
@@ -867,8 +859,6 @@ Backward Operations
 .. autofunction:: tt_lib.tensor.digamma_bw
 
 .. autofunction:: tt_lib.tensor.deg2rad_bw
-
-.. autofunction:: tt_lib.tensor.rad2deg_bw
 
 .. autofunction:: tt_lib.tensor.reciprocal_bw
 

--- a/docs/source/ttnn/ttnn/dependencies/tt_lib.rst
+++ b/docs/source/ttnn/ttnn/dependencies/tt_lib.rst
@@ -828,7 +828,9 @@ Backward Operations
 
 .. autofunction:: tt_lib.tensor.bias_gelu_unary_bw
 
-.. autofunction:: tt_lib.tensor.hardsigmoid_bw
+.. autofunction:: tt_lib.tensor.hardshrink_bw
+
+.. autofunction:: tt_lib.tensor.softshrink_bw
 
 .. autofunction:: tt_lib.tensor.hardswish_bw
 

--- a/docs/source/ttnn/ttnn/dependencies/tt_lib.rst
+++ b/docs/source/ttnn/ttnn/dependencies/tt_lib.rst
@@ -848,8 +848,6 @@ Backward Operations
 
 .. autofunction:: tt_lib.tensor.cosh_bw
 
-.. autofunction:: tt_lib.tensor.cos_bw
-
 .. autofunction:: tt_lib.tensor.acosh_bw
 
 .. autofunction:: tt_lib.tensor.acos_bw

--- a/docs/source/ttnn/ttnn/dependencies/tt_lib.rst
+++ b/docs/source/ttnn/ttnn/dependencies/tt_lib.rst
@@ -848,8 +848,6 @@ Backward Operations
 
 .. autofunction:: tt_lib.tensor.cosh_bw
 
-.. autofunction:: tt_lib.tensor.acos_bw
-
 .. autofunction:: tt_lib.tensor.erfinv_bw
 
 .. autofunction:: tt_lib.tensor.hardtanh_bw

--- a/docs/source/ttnn/ttnn/ttnn/acos_bw.rst
+++ b/docs/source/ttnn/ttnn/ttnn/acos_bw.rst
@@ -1,0 +1,6 @@
+.. _ttnn.acos_bw:
+
+ttnn.acos_bw
+##############
+
+.. autofunction:: ttnn.acos_bw

--- a/docs/source/ttnn/ttnn/ttnn/acosh_bw.rst
+++ b/docs/source/ttnn/ttnn/ttnn/acosh_bw.rst
@@ -1,0 +1,6 @@
+.. _ttnn.acosh_bw:
+
+ttnn.acosh_bw
+###############
+
+.. autofunction:: ttnn.acosh_bw

--- a/docs/source/ttnn/ttnn/ttnn/atan_bw.rst
+++ b/docs/source/ttnn/ttnn/ttnn/atan_bw.rst
@@ -1,0 +1,6 @@
+.. _ttnn.atan_bw:
+
+ttnn.atan_bw
+###############
+
+.. autofunction:: ttnn.atan_bw

--- a/docs/source/ttnn/ttnn/ttnn/cos_bw.rst
+++ b/docs/source/ttnn/ttnn/ttnn/cos_bw.rst
@@ -1,0 +1,6 @@
+.. _ttnn.cos_bw:
+
+ttnn.cos_bw
+############
+
+.. autofunction:: ttnn.cos_bw

--- a/docs/source/ttnn/ttnn/ttnn/fill_bw.rst
+++ b/docs/source/ttnn/ttnn/ttnn/fill_bw.rst
@@ -1,0 +1,6 @@
+.. _ttnn.fill_bw:
+
+ttnn.fill_bw
+#############
+
+.. autofunction:: ttnn.fill_bw

--- a/docs/source/ttnn/ttnn/ttnn/hardsigmoid_bw.rst
+++ b/docs/source/ttnn/ttnn/ttnn/hardsigmoid_bw.rst
@@ -1,0 +1,6 @@
+.. _ttnn.hardsigmoid_bw:
+
+ttnn.hardsigmoid_bw
+####################
+
+.. autofunction:: ttnn.hardsigmoid_bw

--- a/docs/source/ttnn/ttnn/ttnn/rad2deg_bw.rst
+++ b/docs/source/ttnn/ttnn/ttnn/rad2deg_bw.rst
@@ -1,0 +1,6 @@
+.. _ttnn.rad2deg_bw:
+
+ttnn.rad2deg_bw
+################
+
+.. autofunction:: ttnn.rad2deg_bw

--- a/tests/ttnn/unit_tests/operations/backward/test_backward_acos.py
+++ b/tests/ttnn/unit_tests/operations/backward/test_backward_acos.py
@@ -4,8 +4,8 @@
 
 import torch
 import pytest
-import tt_lib
-from tests.tt_eager.python_api_testing.unit_testing.backward_ops.utility_funcs import data_gen_with_range, compare_pcc
+import ttnn
+from tests.ttnn.unit_tests.operations.backward.utility_funcs import data_gen_with_range, compare_pcc
 
 
 @pytest.mark.parametrize(
@@ -22,7 +22,7 @@ def test_bw_acos(input_shapes, device):
 
     pyt_y = torch.acos(in_data)
 
-    tt_output_tensor_on_device = tt_lib.tensor.acos_bw(grad_tensor, input_tensor)
+    tt_output_tensor_on_device = ttnn.acos_bw(grad_tensor, input_tensor)
 
     in_data.retain_grad()
 

--- a/tests/ttnn/unit_tests/operations/backward/test_backward_acosh.py
+++ b/tests/ttnn/unit_tests/operations/backward/test_backward_acosh.py
@@ -4,8 +4,8 @@
 
 import torch
 import pytest
-import tt_lib
-from tests.tt_eager.python_api_testing.unit_testing.backward_ops.utility_funcs import data_gen_with_range, compare_pcc
+import ttnn
+from tests.ttnn.unit_tests.operations.backward.utility_funcs import data_gen_with_range, compare_pcc
 
 
 @pytest.mark.parametrize(
@@ -22,7 +22,7 @@ def test_bw_acosh(input_shapes, device):
 
     pyt_y = torch.acosh(in_data)
 
-    tt_output_tensor_on_device = tt_lib.tensor.acosh_bw(grad_tensor, input_tensor)
+    tt_output_tensor_on_device = ttnn.acosh_bw(grad_tensor, input_tensor)
 
     in_data.retain_grad()
 

--- a/tests/ttnn/unit_tests/operations/backward/test_backward_atan.py
+++ b/tests/ttnn/unit_tests/operations/backward/test_backward_atan.py
@@ -4,8 +4,8 @@
 
 import torch
 import pytest
-import tt_lib
-from tests.tt_eager.python_api_testing.unit_testing.backward_ops.utility_funcs import (
+import ttnn
+from tests.ttnn.unit_tests.operations.backward.utility_funcs import (
     data_gen_with_range,
     compare_pcc,
 )
@@ -25,7 +25,7 @@ def test_bw_atan(input_shapes, device):
 
     pyt_y = torch.atan(in_data)
 
-    tt_output_tensor_on_device = tt_lib.tensor.atan_bw(grad_tensor, input_tensor)
+    tt_output_tensor_on_device = ttnn.atan_bw(grad_tensor, input_tensor)
 
     in_data.retain_grad()
 

--- a/tests/ttnn/unit_tests/operations/backward/test_backward_cos.py
+++ b/tests/ttnn/unit_tests/operations/backward/test_backward_cos.py
@@ -4,8 +4,8 @@
 
 import torch
 import pytest
-import tt_lib
-from tests.tt_eager.python_api_testing.unit_testing.backward_ops.utility_funcs import data_gen_with_range, compare_pcc
+import ttnn
+from tests.ttnn.unit_tests.operations.backward.utility_funcs import data_gen_with_range, compare_pcc
 from math import pi
 
 
@@ -21,7 +21,7 @@ def test_bw_cos(input_shapes, device):
     in_data, input_tensor = data_gen_with_range(input_shapes, 0, (2 * pi), device, True)
     grad_data, grad_tensor = data_gen_with_range(input_shapes, -10, 10, device, False)
 
-    tt_output_tensor_on_device = tt_lib.tensor.cos_bw(grad_tensor, input_tensor)
+    tt_output_tensor_on_device = ttnn.cos_bw(grad_tensor, input_tensor)
 
     in_data.retain_grad()
 

--- a/tests/ttnn/unit_tests/operations/backward/test_backward_fill.py
+++ b/tests/ttnn/unit_tests/operations/backward/test_backward_fill.py
@@ -4,8 +4,8 @@
 
 import torch
 import pytest
-import tt_lib
-from tests.tt_eager.python_api_testing.unit_testing.backward_ops.utility_funcs import (
+import ttnn
+from tests.ttnn.unit_tests.operations.backward.utility_funcs import (
     data_gen_with_range,
     compare_all_close,
 )
@@ -26,11 +26,12 @@ from tests.tt_eager.python_api_testing.unit_testing.backward_ops.utility_funcs i
 #   result: at::fill(self_t, value_t)
 def test_bw_fill(input_shapes, device):
     grad_data, grad_tensor = data_gen_with_range(input_shapes, -1, 1, device)
+    in_data, input_tensor = data_gen_with_range(input_shapes, -10, 10, device, True)
     pyt_y = torch.zeros_like(grad_data)
     grad_sum = grad_data.sum()
     pyt_y.fill_(grad_sum)
 
-    tt_output_tensor_on_device = tt_lib.tensor.fill_bw(grad_tensor)
+    tt_output_tensor_on_device = ttnn.fill_bw(grad_tensor, input_tensor)
 
     golden_tensor = [pyt_y]
     comp_pass = compare_all_close(tt_output_tensor_on_device, golden_tensor, atol=100, rtol=1e-6)

--- a/tests/ttnn/unit_tests/operations/backward/test_backward_fill.py
+++ b/tests/ttnn/unit_tests/operations/backward/test_backward_fill.py
@@ -5,6 +5,7 @@
 import torch
 import pytest
 import ttnn
+from models.utility_functions import skip_for_wormhole_b0
 from tests.ttnn.unit_tests.operations.backward.utility_funcs import (
     data_gen_with_range,
     compare_all_close,
@@ -24,6 +25,7 @@ from tests.ttnn.unit_tests.operations.backward.utility_funcs import (
 #   self: zeros_like(grad)
 #   value: grad.sum()
 #   result: at::fill(self_t, value_t)
+@skip_for_wormhole_b0()
 def test_bw_fill(input_shapes, device):
     grad_data, grad_tensor = data_gen_with_range(input_shapes, -1, 1, device)
     in_data, input_tensor = data_gen_with_range(input_shapes, -10, 10, device, True)
@@ -34,5 +36,5 @@ def test_bw_fill(input_shapes, device):
     tt_output_tensor_on_device = ttnn.fill_bw(grad_tensor, input_tensor)
 
     golden_tensor = [pyt_y]
-    comp_pass = compare_all_close(tt_output_tensor_on_device, golden_tensor, atol=100, rtol=1e-6)
+    comp_pass = compare_all_close(tt_output_tensor_on_device, golden_tensor, atol=150, rtol=1e-6)
     assert comp_pass

--- a/tests/ttnn/unit_tests/operations/backward/test_backward_hardsigmoid.py
+++ b/tests/ttnn/unit_tests/operations/backward/test_backward_hardsigmoid.py
@@ -5,7 +5,8 @@
 import torch
 import pytest
 import tt_lib
-from tests.tt_eager.python_api_testing.unit_testing.backward_ops.utility_funcs import compare_pcc, data_gen_with_range
+import ttnn
+from tests.ttnn.unit_tests.operations.backward.utility_funcs import compare_pcc, data_gen_with_range
 
 
 @pytest.mark.parametrize(
@@ -26,7 +27,7 @@ def test_bw_hardsigmoid(input_shapes, device):
 
     pyt_y = torch.nn.functional.hardsigmoid(in_data)
 
-    tt_output_tensor_on_device = tt_lib.tensor.hardsigmoid_bw(grad_tensor, input_tensor)
+    tt_output_tensor_on_device = ttnn.hardsigmoid_bw(grad_tensor, input_tensor)
 
     in_data.retain_grad()
 

--- a/tests/ttnn/unit_tests/operations/backward/test_backward_rad2deg.py
+++ b/tests/ttnn/unit_tests/operations/backward/test_backward_rad2deg.py
@@ -4,8 +4,8 @@
 
 import torch
 import pytest
-import tt_lib
-from tests.tt_eager.python_api_testing.unit_testing.backward_ops.utility_funcs import compare_pcc, data_gen_with_range
+import ttnn
+from tests.ttnn.unit_tests.operations.backward.utility_funcs import compare_pcc, data_gen_with_range
 
 
 @pytest.mark.parametrize(
@@ -22,7 +22,7 @@ def test_bw_rad2deg(input_shapes, device):
 
     pyt_y = torch.rad2deg(in_data)
 
-    tt_output_tensor_on_device = tt_lib.tensor.rad2deg_bw(grad_tensor, input_tensor)
+    tt_output_tensor_on_device = ttnn.rad2deg_bw(grad_tensor, input_tensor)
 
     in_data.retain_grad()
 

--- a/tests/ttnn/unit_tests/operations/test_backward.py
+++ b/tests/ttnn/unit_tests/operations/test_backward.py
@@ -41,7 +41,7 @@ def run_backward_unary_test(device, h, w, in_val, grad_val, ttnn_function, torch
 @pytest.mark.parametrize("in_val", [-1, 0, 1])
 @pytest.mark.parametrize("grad_val", [-1, 0, 1])
 def test_atan(device, h, w, in_val, grad_val):
-    run_backward_unary_test(device, h, w, in_val, grad_val, ttnn.experimental.tensor.atan_bw, torch.atan)
+    run_backward_unary_test(device, h, w, in_val, grad_val, ttnn.atan_bw, torch.atan)
 
 
 @pytest.mark.parametrize("h", [64])

--- a/tt_eager/tt_dnn/op_library/backward/backward_ops.cpp
+++ b/tt_eager/tt_dnn/op_library/backward/backward_ops.cpp
@@ -628,19 +628,6 @@ std::vector<Tensor> cosh_bw(const Tensor& grad, const Tensor& input, const Memor
     return operation::decorate_as_composite(__func__, _cosh_bw)(grad, input, output_mem_config);
 }
 
-// name: cos(Tensor self) -> Tensor
-// self: grad * -self.sin()
-std::vector<Tensor> _cos_bw(const Tensor& grad, const Tensor& input_tensor, const MemoryConfig& output_mem_config) {
-    std::vector<Tensor> grad_tensor;
-    Tensor result =
-        ttnn::multiply(grad, (ttnn::neg(ttnn::sin(input_tensor, output_mem_config), output_mem_config)), std::nullopt, output_mem_config);
-    grad_tensor.emplace_back(result);
-    return grad_tensor;
-}
-std::vector<Tensor> cos_bw(const Tensor& grad, const Tensor& input, const MemoryConfig& output_mem_config) {
-    return operation::decorate_as_composite(__func__, _cos_bw)(grad, input, output_mem_config);
-}
-
 std::vector<Tensor> _acosh_bw(const Tensor& grad, const Tensor& input, const MemoryConfig& output_mem_config) {
     std::vector<Tensor> grad_tensor;
     Tensor in_rsqrt = ttnn::square(input, output_mem_config);

--- a/tt_eager/tt_dnn/op_library/backward/backward_ops.cpp
+++ b/tt_eager/tt_dnn/op_library/backward/backward_ops.cpp
@@ -628,36 +628,6 @@ std::vector<Tensor> cosh_bw(const Tensor& grad, const Tensor& input, const Memor
     return operation::decorate_as_composite(__func__, _cosh_bw)(grad, input, output_mem_config);
 }
 
-std::vector<Tensor> _acosh_bw(const Tensor& grad, const Tensor& input, const MemoryConfig& output_mem_config) {
-    std::vector<Tensor> grad_tensor;
-    Tensor in_rsqrt = ttnn::square(input, output_mem_config);
-    in_rsqrt = ttnn::rsqrt(ttnn::subtract(in_rsqrt, 1.0, std::nullopt, output_mem_config), true, output_mem_config);
-    Tensor grad_a = ttnn::multiply(grad, in_rsqrt, std::nullopt, output_mem_config);
-    float t_nan = std::nanf("");
-    float t_inf = std::numeric_limits<float>::infinity();
-    Tensor cond_result = ttnn::logical_or(
-        ttnn::lt(input, full_like(input, -1.0, output_mem_config), std::nullopt, output_mem_config),
-        ttnn::gt(input, full_like(input, 1.0, output_mem_config), std::nullopt, output_mem_config),
-        std::nullopt,
-        output_mem_config);
-    grad_a = where(ttnn::eqz(cond_result, output_mem_config), t_nan, grad_a, output_mem_config);
-    cond_result = ttnn::logical_or(
-        ttnn::eq(input, full_like(input, -1.0, output_mem_config), std::nullopt, output_mem_config),
-        ttnn::eq(input, full_like(input, 1.0, output_mem_config), std::nullopt, output_mem_config),
-        std::nullopt,
-        output_mem_config);
-    grad_a = where(
-        ttnn::eq(cond_result, ones_like(input, output_mem_config), std::nullopt, output_mem_config),
-        t_inf,
-        grad_a,
-        output_mem_config);
-    grad_tensor.emplace_back(grad_a);
-    return grad_tensor;
-}
-std::vector<Tensor> acosh_bw(const Tensor& grad, const Tensor& input, const MemoryConfig& output_mem_config) {
-    return operation::decorate_as_composite(__func__, _acosh_bw)(grad, input, output_mem_config);
-}
-
 // # - name: acos(Tensor self) -> Tensor
 // #   self: grad * -((-self * self + 1).rsqrt())
 std::vector<Tensor> _acos_bw(const Tensor& grad, const Tensor& input, const MemoryConfig& output_mem_config) {

--- a/tt_eager/tt_dnn/op_library/backward/backward_ops.cpp
+++ b/tt_eager/tt_dnn/op_library/backward/backward_ops.cpp
@@ -479,22 +479,6 @@ std::vector<Tensor> polygamma_bw(
     return operation::decorate_as_composite(__func__, _polygamma_bw)(grad, input, n, output_mem_config);
 }
 
-std::vector<Tensor> _atan_bw(const Tensor& grad, const Tensor& input, const MemoryConfig& output_mem_config) {
-    std::vector<Tensor> grad_tensor;
-    using ttnn::operations::unary::UnaryWithParam;
-    using ttnn::operations::unary::UnaryOpType;
-    std::vector<UnaryWithParam> ops_chain = {
-    UnaryWithParam{UnaryOpType::SQUARE},
-    UnaryWithParam{UnaryOpType::ADD_UNARY_SFPU, 1.0f},
-    UnaryWithParam{UnaryOpType::RECIP}};
-    Tensor grad_a = ttnn::multiply(grad, ttnn::unary_chain(input, ops_chain, output_mem_config), std::nullopt, output_mem_config);
-    grad_tensor.emplace_back(grad_a);
-    return grad_tensor;
-}
-std::vector<Tensor> atan_bw(const Tensor& grad, const Tensor& input, const MemoryConfig& output_mem_config) {
-    return operation::decorate_as_composite(__func__, _atan_bw)(grad, input, output_mem_config);
-}
-
 std::vector<Tensor> _atanh_bw(const Tensor& grad, const Tensor& input, const MemoryConfig& output_mem_config) {
     std::vector<Tensor> grad_tensor;
     float t_nan = std::nanf("");

--- a/tt_eager/tt_dnn/op_library/backward/backward_ops.cpp
+++ b/tt_eager/tt_dnn/op_library/backward/backward_ops.cpp
@@ -237,19 +237,6 @@ std::vector<std::optional<Tensor>> tanh_bw(const Tensor& grad, const Tensor& inp
     return operation::decorate_as_composite(__func__, _tanh_bw)(default_queue_id, grad, input, output_mem_config, are_required_outputs, input_grad);
 }
 
-std::vector<Tensor> _fill_bw(const Tensor& grad, const MemoryConfig& output_mem_config) {
-    std::vector<Tensor> grad_tensor;
-    Tensor val = grad;
-    val = global_sum(val, output_mem_config);
-    Tensor result = zeros_like(grad, output_mem_config);
-    result = bcast(result, val, BcastOpMath::ADD, BcastOpDim::HW, output_mem_config);
-    grad_tensor.emplace_back(result);
-    return grad_tensor;
-}
-std::vector<Tensor> fill_bw(const Tensor& grad, const MemoryConfig& output_mem_config) {
-    return operation::decorate_as_composite(__func__, _fill_bw)(grad, output_mem_config);
-}
-
 std::vector<Tensor> _lt_bw(const Tensor& grad, const MemoryConfig& output_mem_config) {
     std::vector<Tensor> grad_tensor;
     Tensor t_zero = zeros_like(grad, output_mem_config);

--- a/tt_eager/tt_dnn/op_library/backward/backward_ops.hpp
+++ b/tt_eager/tt_dnn/op_library/backward/backward_ops.hpp
@@ -175,11 +175,6 @@ std::vector<Tensor> polygamma_bw(
     int n,
     const MemoryConfig& output_mem_config = operation::DEFAULT_OUTPUT_MEMORY_CONFIG);
 
-std::vector<Tensor> atan_bw(
-    const Tensor& grad,
-    const Tensor& input,
-    const MemoryConfig& output_mem_config = operation::DEFAULT_OUTPUT_MEMORY_CONFIG);
-
 std::vector<Tensor> atanh_bw(
     const Tensor& grad,
     const Tensor& input,

--- a/tt_eager/tt_dnn/op_library/backward/backward_ops.hpp
+++ b/tt_eager/tt_dnn/op_library/backward/backward_ops.hpp
@@ -98,9 +98,10 @@ std::vector<std::optional<Tensor>> tanh_bw(
     const std::vector<bool>& are_required_outputs = std::vector<bool>{true},
     std::optional<Tensor> input_grad = std::nullopt);
 
-std::vector<Tensor> fill_bw(
-    const Tensor& grad, const MemoryConfig& output_mem_config = operation::DEFAULT_OUTPUT_MEMORY_CONFIG);
-
+std::vector<Tensor> log_bw(
+    const Tensor& grad,
+    const Tensor& input,
+    const MemoryConfig& output_mem_config = operation::DEFAULT_OUTPUT_MEMORY_CONFIG);
 
 std::vector<Tensor> binary_le_bw(
     const Tensor& grad,

--- a/tt_eager/tt_dnn/op_library/backward/backward_ops.hpp
+++ b/tt_eager/tt_dnn/op_library/backward/backward_ops.hpp
@@ -200,11 +200,6 @@ std::vector<Tensor> cosh_bw(
     const Tensor& input,
     const MemoryConfig& output_mem_config = operation::DEFAULT_OUTPUT_MEMORY_CONFIG);
 
-std::vector<Tensor> acos_bw(
-    const Tensor& grad,
-    const Tensor& input,
-    const MemoryConfig& output_mem_config = operation::DEFAULT_OUTPUT_MEMORY_CONFIG);
-
 std::vector<Tensor> erfinv_bw(
     const Tensor& grad,
     const Tensor& input,

--- a/tt_eager/tt_dnn/op_library/backward/backward_ops.hpp
+++ b/tt_eager/tt_dnn/op_library/backward/backward_ops.hpp
@@ -200,11 +200,6 @@ std::vector<Tensor> cosh_bw(
     const Tensor& input,
     const MemoryConfig& output_mem_config = operation::DEFAULT_OUTPUT_MEMORY_CONFIG);
 
-std::vector<Tensor> acosh_bw(
-    const Tensor& grad,
-    const Tensor& input,
-    const MemoryConfig& output_mem_config = operation::DEFAULT_OUTPUT_MEMORY_CONFIG);
-
 std::vector<Tensor> acos_bw(
     const Tensor& grad,
     const Tensor& input,

--- a/tt_eager/tt_dnn/op_library/backward/backward_ops.hpp
+++ b/tt_eager/tt_dnn/op_library/backward/backward_ops.hpp
@@ -98,11 +98,6 @@ std::vector<std::optional<Tensor>> tanh_bw(
     const std::vector<bool>& are_required_outputs = std::vector<bool>{true},
     std::optional<Tensor> input_grad = std::nullopt);
 
-std::vector<Tensor> log_bw(
-    const Tensor& grad,
-    const Tensor& input,
-    const MemoryConfig& output_mem_config = operation::DEFAULT_OUTPUT_MEMORY_CONFIG);
-
 std::vector<Tensor> binary_le_bw(
     const Tensor& grad,
     const Tensor& input,
@@ -143,18 +138,6 @@ std::vector<Tensor> bias_gelu_unary_bw(
     const Tensor& input,
     float bias,
     string approximate,
-    const MemoryConfig& output_mem_config = operation::DEFAULT_OUTPUT_MEMORY_CONFIG);
-
-std::vector<Tensor> hardshrink_bw(
-    const Tensor& grad,
-    const Tensor& input,
-    float lambd,
-    const MemoryConfig& output_mem_config = operation::DEFAULT_OUTPUT_MEMORY_CONFIG);
-
-std::vector<Tensor> softshrink_bw(
-    const Tensor& grad,
-    const Tensor& input,
-    float lambd,
     const MemoryConfig& output_mem_config = operation::DEFAULT_OUTPUT_MEMORY_CONFIG);
 
 std::vector<Tensor> hardswish_bw(
@@ -249,11 +232,6 @@ std::vector<Tensor> digamma_bw(
     const MemoryConfig& output_mem_config = operation::DEFAULT_OUTPUT_MEMORY_CONFIG);
 
 std::vector<Tensor> deg2rad_bw(
-    const Tensor& grad,
-    const Tensor& input,
-    const MemoryConfig& output_mem_config = operation::DEFAULT_OUTPUT_MEMORY_CONFIG);
-
-std::vector<Tensor> rad2deg_bw(
     const Tensor& grad,
     const Tensor& input,
     const MemoryConfig& output_mem_config = operation::DEFAULT_OUTPUT_MEMORY_CONFIG);

--- a/tt_eager/tt_dnn/op_library/backward/backward_ops.hpp
+++ b/tt_eager/tt_dnn/op_library/backward/backward_ops.hpp
@@ -145,9 +145,16 @@ std::vector<Tensor> bias_gelu_unary_bw(
     string approximate,
     const MemoryConfig& output_mem_config = operation::DEFAULT_OUTPUT_MEMORY_CONFIG);
 
-std::vector<Tensor> hardsigmoid_bw(
+std::vector<Tensor> hardshrink_bw(
     const Tensor& grad,
     const Tensor& input,
+    float lambd,
+    const MemoryConfig& output_mem_config = operation::DEFAULT_OUTPUT_MEMORY_CONFIG);
+
+std::vector<Tensor> softshrink_bw(
+    const Tensor& grad,
+    const Tensor& input,
+    float lambd,
     const MemoryConfig& output_mem_config = operation::DEFAULT_OUTPUT_MEMORY_CONFIG);
 
 std::vector<Tensor> hardswish_bw(

--- a/tt_eager/tt_dnn/op_library/backward/backward_ops.hpp
+++ b/tt_eager/tt_dnn/op_library/backward/backward_ops.hpp
@@ -200,11 +200,6 @@ std::vector<Tensor> cosh_bw(
     const Tensor& input,
     const MemoryConfig& output_mem_config = operation::DEFAULT_OUTPUT_MEMORY_CONFIG);
 
-std::vector<Tensor> cos_bw(
-    const Tensor& grad,
-    const Tensor& input,
-    const MemoryConfig& output_mem_config = operation::DEFAULT_OUTPUT_MEMORY_CONFIG);
-
 std::vector<Tensor> acosh_bw(
     const Tensor& grad,
     const Tensor& input,

--- a/tt_eager/tt_lib/csrc/tt_lib_bindings_tensor_backward_ops.cpp
+++ b/tt_eager/tt_lib/csrc/tt_lib_bindings_tensor_backward_ops.cpp
@@ -663,22 +663,6 @@ namespace tt::tt_metal::detail{
                     "output_mem_config", "Layout of tensor in TT Accelerator device memory banks", "MemoryConfig", "Default is interleaved in DRAM", "No"
             )doc");
 
-    m_tensor.def("rad2deg_bw", &tt::tt_metal::rad2deg_bw,
-            py::arg("grad").noconvert(), py::arg("input").noconvert(), py::arg("output_mem_config").noconvert() = operation::DEFAULT_OUTPUT_MEMORY_CONFIG, R"doc(
-                Performs backward operations for rad2deg for the ``input`` with given ``grad``
-
-                Input tensors must have BFLOAT16 data type.
-
-                Output tensor will have BFLOAT16 data type.
-
-                .. csv-table::
-                    :header: "Argument", "Description", "Data type", "Valid range", "Required"
-
-                    "grad", "Gradient tensor", "Tensor", "Tensor of shape [W, Z, Y, X]", "Yes"
-                    "input", "Input Tensor", "Tensor", "Tensor of shape [W, Z, Y, X]", "Yes"
-                    "output_mem_config", "Layout of tensor in TT Accelerator device memory banks", "MemoryConfig", "Default is interleaved in DRAM", "No"
-            )doc");
-
     m_tensor.def("reciprocal_bw", &tt::tt_metal::reciprocal_bw,
             py::arg("grad").noconvert(), py::arg("input").noconvert(), py::arg("output_mem_config").noconvert() = operation::DEFAULT_OUTPUT_MEMORY_CONFIG, R"doc(
             Performs backward operations for reciprocal for the ``input`` with given ``grad``

--- a/tt_eager/tt_lib/csrc/tt_lib_bindings_tensor_backward_ops.cpp
+++ b/tt_eager/tt_lib/csrc/tt_lib_bindings_tensor_backward_ops.cpp
@@ -249,21 +249,6 @@ namespace tt::tt_metal::detail{
                 "output_mem_config", "Layout of tensor in TT Accelerator device memory banks", "MemoryConfig", "Default is interleaved in DRAM", "No"
         )doc");
 
-    m_tensor.def("fill_bw", &tt::tt_metal::fill_bw,
-            py::arg("grad").noconvert(), py::arg("output_mem_config").noconvert() = operation::DEFAULT_OUTPUT_MEMORY_CONFIG, R"doc(
-            Returns an tensor like ``grad`` tensor with sum of tensor values
-
-            Input tensor must have BFLOAT16 data type.
-
-            Output tensor will have BFLOAT16 data type.
-
-            .. csv-table::
-                :header: "Argument", "Description", "Data type", "Valid range", "Required"
-
-                "grad", "Gradient tensor", "Tensor", "Tensor of shape [W, Z, Y, X]", "Yes"
-                "output_mem_config", "Layout of tensor in TT Accelerator device memory banks", "MemoryConfig", "Default is interleaved in DRAM", "No"
-        )doc");
-
     m_tensor.def("repeat_bw", &tt::tt_metal::repeat_bw,
             py::arg("grad").noconvert(), py::arg("input").noconvert(), py::arg("shape"), py::arg("output_mem_config").noconvert() = operation::DEFAULT_OUTPUT_MEMORY_CONFIG, R"doc(
                     Returns a new tensor filled with repetition of input ``input`` tensor according to number of times specified in ``shape``. The rank of ``shape`` should be same as rank of tensor ``input_a``.

--- a/tt_eager/tt_lib/csrc/tt_lib_bindings_tensor_backward_ops.cpp
+++ b/tt_eager/tt_lib/csrc/tt_lib_bindings_tensor_backward_ops.cpp
@@ -468,22 +468,6 @@ namespace tt::tt_metal::detail{
                 "output_mem_config", "Layout of tensor in TT Accelerator device memory banks", "MemoryConfig", "Default is interleaved in DRAM", "No"
         )doc");
 
-     m_tensor.def("atan_bw", &tt::tt_metal::atan_bw,
-            py::arg("grad").noconvert(), py::arg("input").noconvert(), py::arg("output_mem_config").noconvert() = operation::DEFAULT_OUTPUT_MEMORY_CONFIG, R"doc(
-            Performs backward operations for atan of ``input`` tensors with given ``grad``.
-
-            Input tensors must have BFLOAT16 data type.
-
-            Output tensors will have BFLOAT16 data type.
-
-            .. csv-table::
-                :header: "Argument", "Description", "Data type", "Valid range", "Required"
-
-                "grad", "Gradient tensor", "Tensor", "Tensor of shape [W, Z, Y, X]", "Yes"
-                "input", "Tensor", "Tensor", "Tensor of shape [W, Z, Y, X]", "Yes"
-                "output_mem_config", "Layout of tensor in TT Accelerator device memory banks", "MemoryConfig", "Default is interleaved in DRAM", "No"
-        )doc");
-
     m_tensor.def("atanh_bw", &tt::tt_metal::atanh_bw,
             py::arg("grad").noconvert(), py::arg("input").noconvert(), py::arg("output_mem_config").noconvert() = operation::DEFAULT_OUTPUT_MEMORY_CONFIG, R"doc(
             Performs backward operations for atanh of ``input`` tensors with given ``grad``.

--- a/tt_eager/tt_lib/csrc/tt_lib_bindings_tensor_backward_ops.cpp
+++ b/tt_eager/tt_lib/csrc/tt_lib_bindings_tensor_backward_ops.cpp
@@ -516,23 +516,6 @@ namespace tt::tt_metal::detail{
                 "output_mem_config", "Layout of tensor in TT Accelerator device memory banks", "MemoryConfig", "Default is interleaved in DRAM", "No"
         )doc");
 
-
-    m_tensor.def("acosh_bw", &tt::tt_metal::acosh_bw,
-            py::arg("grad").noconvert(), py::arg("input").noconvert(), py::arg("output_mem_config").noconvert() = operation::DEFAULT_OUTPUT_MEMORY_CONFIG, R"doc(
-            Performs backward operations for acosh of ``input`` and tensor with given ``grad``.
-
-            Input tensors must have BFLOAT16 data type.
-
-            Output tensors will have BFLOAT16 data type.
-
-            .. csv-table::
-                :header: "Argument", "Description", "Data type", "Valid range", "Required"
-
-                "grad", "Gradient tensor", "Tensor", "Tensor of shape [W, Z, Y, X]", "Yes"
-                "input", "Input Tensor", "Tensor", "Tensor of shape [W, Z, Y, X]", "Yes"
-                "output_mem_config", "Layout of tensor in TT Accelerator device memory banks", "MemoryConfig", "Default is interleaved in DRAM", "No"
-        )doc");
-
     m_tensor.def("angle_bw", py::overload_cast<const Tensor&, const Tensor&, bool, const MemoryConfig&>(&angle_bw),
             py::arg("grad").noconvert(), py::arg("input").noconvert(), py::arg("is_complextensor").noconvert() = true, py::arg("output_mem_config").noconvert() = operation::DEFAULT_OUTPUT_MEMORY_CONFIG, R"doc(
                 Performs backward operations for angle for the ``input`` with given ``grad``

--- a/tt_eager/tt_lib/csrc/tt_lib_bindings_tensor_backward_ops.cpp
+++ b/tt_eager/tt_lib/csrc/tt_lib_bindings_tensor_backward_ops.cpp
@@ -533,22 +533,6 @@ namespace tt::tt_metal::detail{
                     "output_mem_config", "Layout of tensor in TT Accelerator device memory banks", "MemoryConfig", "Default is interleaved in DRAM", "No"
             )doc");
 
-    m_tensor.def("acos_bw", &tt::tt_metal::acos_bw,
-            py::arg("grad").noconvert(), py::arg("input").noconvert(), py::arg("output_mem_config").noconvert() = operation::DEFAULT_OUTPUT_MEMORY_CONFIG, R"doc(
-            Performs backward operations for acos for the ``input`` with given ``grad``
-
-            Input tensors must have BFLOAT16 data type.
-
-            Output tensor will have BFLOAT16 data type.
-
-            .. csv-table::
-                :header: "Argument", "Description", "Data type", "Valid range", "Required"
-
-                "grad", "Gradient tensor", "Tensor", "Tensor of shape [W, Z, Y, X]", "Yes"
-                "input", "Tensor", "Tensor", "Tensor of shape [W, Z, Y, X]", "Yes"
-                "output_mem_config", "Layout of tensor in TT Accelerator device memory banks", "MemoryConfig", "Default is interleaved in DRAM", "No"
-            )doc");
-
     m_tensor.def("sin_bw", &tt::tt_metal::sin_bw,
             py::arg("grad").noconvert(), py::arg("input").noconvert(), py::arg("output_mem_config").noconvert() = operation::DEFAULT_OUTPUT_MEMORY_CONFIG, R"doc(
             Performs backward operations for sin of the ``input`` with given ``grad``

--- a/tt_eager/tt_lib/csrc/tt_lib_bindings_tensor_backward_ops.cpp
+++ b/tt_eager/tt_lib/csrc/tt_lib_bindings_tensor_backward_ops.cpp
@@ -418,22 +418,6 @@ namespace tt::tt_metal::detail{
                 "output_mem_config", "Layout of tensor in TT Accelerator device memory banks", "MemoryConfig", "Default is interleaved in DRAM", "No"
         )doc");
 
-    m_tensor.def("hardsigmoid_bw", &tt::tt_metal::hardsigmoid_bw,
-            py::arg("grad").noconvert(), py::arg("input").noconvert(), py::arg("output_mem_config").noconvert() = operation::DEFAULT_OUTPUT_MEMORY_CONFIG, R"doc(
-            Performs backward operations for hardsigmoid of ``input`` tensor with given ``grad``.
-
-            Input tensors must have BFLOAT16 data type.
-
-            Output tensors will have BFLOAT16 data type.
-
-            .. csv-table::
-                :header: "Argument", "Description", "Data type", "Valid range", "Required"
-
-                "grad", "Gradient tensor", "Tensor", "Tensor of shape [W, Z, Y, X]", "Yes"
-                "input", "Tensor hardsigmoid is applied to", "Tensor", "Tensor of shape [W, Z, Y, X]", "Yes"
-                "output_mem_config", "Layout of tensor in TT Accelerator device memory banks", "MemoryConfig", "Default is interleaved in DRAM", "No"
-        )doc");
-
     m_tensor.def("asin_bw", &tt::tt_metal::asin_bw,
             py::arg("grad").noconvert(), py::arg("input").noconvert(), py::arg("output_mem_config").noconvert() = operation::DEFAULT_OUTPUT_MEMORY_CONFIG, R"doc(
             Performs backward operations for asin_bw of ``input`` tensor with given ``grad``.

--- a/tt_eager/tt_lib/csrc/tt_lib_bindings_tensor_backward_ops.cpp
+++ b/tt_eager/tt_lib/csrc/tt_lib_bindings_tensor_backward_ops.cpp
@@ -500,22 +500,6 @@ namespace tt::tt_metal::detail{
                 "output_mem_config", "Layout of tensor in TT Accelerator device memory banks", "MemoryConfig", "Default is interleaved in DRAM", "No"
         )doc");
 
-    m_tensor.def("cos_bw", &tt::tt_metal::cos_bw,
-            py::arg("grad").noconvert(), py::arg("input").noconvert(), py::arg("output_mem_config").noconvert() = operation::DEFAULT_OUTPUT_MEMORY_CONFIG, R"doc(
-                Performs backward operations for cos of the ``input`` with given ``grad``
-
-                Input tensors must have BFLOAT16 data type.
-
-                Output tensor will have BFLOAT16 data type.
-
-                .. csv-table::
-                    :header: "Argument", "Description", "Data type", "Valid range", "Required"
-
-                    "grad", "Gradient tensor", "Tensor", "Tensor of shape [W, Z, Y, X]", "Yes"
-                    "input", "Input Tensor", "Tensor", "Tensor of shape [W, Z, Y, X]", "Yes"
-                    "output_mem_config", "Layout of tensor in TT Accelerator device memory banks", "MemoryConfig", "Default is interleaved in DRAM", "No"
-            )doc");
-
     m_tensor.def("cosh_bw", &tt::tt_metal::cosh_bw,
             py::arg("grad").noconvert(), py::arg("input").noconvert(), py::arg("output_mem_config").noconvert() = operation::DEFAULT_OUTPUT_MEMORY_CONFIG, R"doc(
             Performs backward operations for hyperbolic cos of ``input`` tensors with given ``grad``.

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_backward/device/binary_backward_op.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_backward/device/binary_backward_op.cpp
@@ -499,36 +499,36 @@ std::vector<Tensor> _div_bw(
     const MemoryConfig& output_mem_config) {
     std::vector<Tensor> grad_tensor;
     if (round_mode == "None") {
-        Tensor grad_a = ttnn::multiply(grad, recip(other, output_mem_config), std::nullopt, output_mem_config);
+        Tensor grad_a = ttnn::multiply(grad, ttnn::reciprocal(other, output_mem_config), std::nullopt, output_mem_config);
         Tensor t_inf = ttnn::operations::creation::full_like(input, std::numeric_limits<float>::infinity(), input.get_dtype(), input.get_layout(), std::nullopt, output_mem_config);
         Tensor t_nan = ttnn::operations::creation::full_like(input, std::nanf(""), input.get_dtype(), input.get_layout(), std::nullopt, output_mem_config);
         grad_tensor.emplace_back(where(
-            eqz(other, output_mem_config),
+            ttnn::eqz(other, output_mem_config),
             where(
-                eqz(grad, output_mem_config),
+                ttnn::eqz(grad, output_mem_config),
                 t_nan,
-                ttnn::multiply(t_inf, sign(grad, output_mem_config), std::nullopt, output_mem_config),
+                ttnn::multiply(t_inf, ttnn::sign(grad, output_mem_config), std::nullopt, output_mem_config),
                 output_mem_config),
             grad_a,
             output_mem_config));
         Tensor grad_b = ttnn::multiply(
-            neg(grad, output_mem_config),
-            (ttnn::multiply(input, recip(ttnn::square(other, output_mem_config), output_mem_config), std::nullopt, output_mem_config)),
+            ttnn::neg(grad, output_mem_config),
+            (ttnn::multiply(input, ttnn::reciprocal(ttnn::square(other, output_mem_config), output_mem_config), std::nullopt, output_mem_config)),
             std::nullopt,
             output_mem_config);
         grad_tensor.emplace_back(where(
-            eqz(other, output_mem_config),
+            ttnn::eqz(other, output_mem_config),
             where(
-                eqz(grad, output_mem_config),
+                ttnn::eqz(grad, output_mem_config),
                 t_nan,
                 where(
-                    eqz(input, output_mem_config),
+                    ttnn::eqz(input, output_mem_config),
                     t_nan,
-                    ttnn::multiply(ttnn::multiply(neg(t_inf, output_mem_config),
-                            sign(input, output_mem_config),
+                    ttnn::multiply(ttnn::multiply(ttnn::neg(t_inf, output_mem_config),
+                            ttnn::sign(input, output_mem_config),
                             std::nullopt,
                             output_mem_config),
-                        sign(grad, output_mem_config),
+                        ttnn::sign(grad, output_mem_config),
                         std::nullopt,
                         output_mem_config),
                     output_mem_config),

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_backward/device/binary_backward_op.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_backward/device/binary_backward_op.cpp
@@ -408,9 +408,9 @@ std::vector<Tensor> _concat_bw(
 
 std::vector<Tensor> _binary_comp_bw(const Tensor& grad, const Tensor& input, const Tensor& other, const MemoryConfig& output_mem_config) {
     std::vector<Tensor> grad_tensor;
-    Tensor zero_grad = tt::tt_metal::zeros_like(grad, output_mem_config);
+    Tensor zero_grad = ttnn::operations::creation::zeros_like(grad, grad.get_dtype(), grad.get_layout(), std::nullopt, output_mem_config);
     grad_tensor.emplace_back(zero_grad);
-    Tensor zero_input = tt::tt_metal::zeros_like(input, output_mem_config);
+    Tensor zero_input = ttnn::operations::creation::zeros_like(input, input.get_dtype(), input.get_layout(), std::nullopt, output_mem_config);
     grad_tensor.emplace_back(zero_input);
     return grad_tensor;
 }

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_backward/device/binary_backward_op.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_backward/device/binary_backward_op.cpp
@@ -462,11 +462,11 @@ std::vector<Tensor> _min_or_max_bw(
     const Tensor& grad, const Tensor& input, const Tensor& other, const MemoryConfig& output_mem_config) {
     Tensor zeros_t = ttnn::operations::creation::zeros_like(input, input.get_dtype(), input.get_layout(), std::nullopt, output_mem_config);
     std::vector<Tensor> grad_tensor;
-    Tensor t_scale_grad = mul_unary(grad, 0.5, output_mem_config);
+    Tensor t_scale_grad = ttnn::multiply(grad, 0.5, std::nullopt, output_mem_config);
     Tensor t_sub = ttnn::subtract(other, input, std::nullopt, output_mem_config);
-    Tensor t_sub_gtz = gtz(t_sub, output_mem_config);
-    Tensor t_sub_eqz = eqz(t_sub, output_mem_config);
-    Tensor t_sub_ltz = ltz(t_sub, output_mem_config);
+    Tensor t_sub_gtz = ttnn::gtz(t_sub, output_mem_config);
+    Tensor t_sub_eqz = ttnn::eqz(t_sub, output_mem_config);
+    Tensor t_sub_ltz = ttnn::ltz(t_sub, output_mem_config);
     Tensor grad_other =
         ttnn::add(ttnn::multiply(t_sub_ltz, grad, std::nullopt, output_mem_config),
             ttnn::multiply(t_sub_eqz, t_scale_grad, std::nullopt, output_mem_config),

--- a/ttnn/cpp/ttnn/operations/eltwise/ternary_backward/device/ternary_backward_op.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/ternary_backward/device/ternary_backward_op.cpp
@@ -45,10 +45,10 @@ std::vector<Tensor> _addcdiv_bw(
     grad_tensor.emplace_back(grad);
     Tensor t_inf = ttnn::operations::creation::full_like(input, std::numeric_limits<float>::infinity(), input.get_dtype(), input.get_layout(), std::nullopt, output_mem_config);
     Tensor t_nan = ttnn::operations::creation::full_like(input, std::nanf(""), input.get_dtype(), input.get_layout(), std::nullopt, output_mem_config);
-    Tensor grad_a = ttnn::multiply(ttnn::multiply(grad, value, std::nullopt, output_mem_config), recip(tensor2, output_mem_config));
+    Tensor grad_a = ttnn::multiply(ttnn::multiply(grad, value, std::nullopt, output_mem_config), ttnn::reciprocal(tensor2, output_mem_config));
     grad_tensor.emplace_back(where(
-        eqz(tensor2, output_mem_config),
-        where(eqz(grad, output_mem_config), t_nan, t_inf, output_mem_config),
+        ttnn::eqz(tensor2, output_mem_config),
+        where(ttnn::eqz(grad, output_mem_config), t_nan, t_inf, output_mem_config),
         grad_a,
         output_mem_config));
     Tensor tmp = ttnn::multiply(
@@ -56,8 +56,8 @@ std::vector<Tensor> _addcdiv_bw(
     Tensor grad_b =
         ttnn::multiply(tmp, ttnn::reciprocal(ttnn::square(tensor2, output_mem_config), output_mem_config), std::nullopt, output_mem_config);
     grad_tensor.emplace_back(where(
-        eqz(tensor2, output_mem_config),
-        where(eqz(grad, output_mem_config), t_nan, ttnn::neg(t_inf, output_mem_config), output_mem_config),
+        ttnn::eqz(tensor2, output_mem_config),
+        where(ttnn::eqz(grad, output_mem_config), t_nan, ttnn::neg(t_inf, output_mem_config), output_mem_config),
         grad_b,
         output_mem_config));
     return grad_tensor;

--- a/ttnn/cpp/ttnn/operations/eltwise/unary_backward/device/unary_backward_op.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary_backward/device/unary_backward_op.cpp
@@ -328,6 +328,19 @@ std::vector<Tensor> _acos_bw(const Tensor& grad, const Tensor& input, const Memo
     return grad_tensor;
 }
 
+std::vector<Tensor> _atan_bw(const Tensor& grad, const Tensor& input, const MemoryConfig& output_mem_config) {
+    std::vector<Tensor> grad_tensor;
+    using ttnn::operations::unary::UnaryWithParam;
+    using ttnn::operations::unary::UnaryOpType;
+    std::vector<UnaryWithParam> ops_chain = {
+    UnaryWithParam{UnaryOpType::SQUARE},
+    UnaryWithParam{UnaryOpType::ADD_UNARY_SFPU, 1.0f},
+    UnaryWithParam{UnaryOpType::RECIP}};
+    Tensor grad_a = ttnn::multiply(grad, ttnn::unary_chain(input, ops_chain, output_mem_config), std::nullopt, output_mem_config);
+    grad_tensor.emplace_back(grad_a);
+    return grad_tensor;
+}
+
 std::vector<Tensor> _logit_bw(const Tensor& grad, const Tensor& input, const MemoryConfig& output_mem_config) {
     std::vector<Tensor> grad_tensor;
     Tensor grad_result =
@@ -563,6 +576,8 @@ std::function<std::vector<ttnn::Tensor>(const Tensor&, const Tensor&, const Memo
             return _acosh_bw;
         case UnaryBackwardOpType::ACOS_BW:
             return _acos_bw;
+        case UnaryBackwardOpType::ATAN_BW:
+            return _atan_bw;
         case UnaryBackwardOpType::FRAC_BW:
             return _frac_bw;
         case UnaryBackwardOpType::TRUNC_BW:

--- a/ttnn/cpp/ttnn/operations/eltwise/unary_backward/device/unary_backward_op.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary_backward/device/unary_backward_op.cpp
@@ -341,6 +341,14 @@ std::vector<Tensor> _atan_bw(const Tensor& grad, const Tensor& input, const Memo
     return grad_tensor;
 }
 
+std::vector<Tensor> _rad2deg_bw(const Tensor& grad, const Tensor& input, const MemoryConfig& output_mem_config) {
+    std::vector<Tensor> grad_tensor;
+    float M_180_PI = 180 / M_PI;
+    Tensor grad_result = ttnn::multiply(grad, M_180_PI, std::nullopt, output_mem_config);
+    grad_tensor.emplace_back(grad_result);
+    return grad_tensor;
+}
+
 std::vector<Tensor> _logit_bw(const Tensor& grad, const Tensor& input, const MemoryConfig& output_mem_config) {
     std::vector<Tensor> grad_tensor;
     Tensor grad_result =
@@ -578,6 +586,8 @@ std::function<std::vector<ttnn::Tensor>(const Tensor&, const Tensor&, const Memo
             return _acos_bw;
         case UnaryBackwardOpType::ATAN_BW:
             return _atan_bw;
+        case UnaryBackwardOpType::RAD2DEG_BW:
+            return _rad2deg_bw;
         case UnaryBackwardOpType::FRAC_BW:
             return _frac_bw;
         case UnaryBackwardOpType::TRUNC_BW:

--- a/ttnn/cpp/ttnn/operations/eltwise/unary_backward/device/unary_backward_op.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary_backward/device/unary_backward_op.cpp
@@ -261,6 +261,16 @@ std::vector<Tensor> _hardsigmoid_bw(const Tensor& grad, const Tensor& input, con
     return grad_tensor;
 }
 
+// name: cos(Tensor self) -> Tensor
+// self: grad * -self.sin()
+std::vector<Tensor> _cos_bw(const Tensor& grad, const Tensor& input_tensor, const MemoryConfig& output_mem_config) {
+    std::vector<Tensor> grad_tensor;
+    Tensor result =
+        ttnn::multiply(grad, (ttnn::neg(ttnn::sin(input_tensor, output_mem_config), output_mem_config)), std::nullopt, output_mem_config);
+    grad_tensor.emplace_back(result);
+    return grad_tensor;
+}
+
 std::vector<Tensor> _logit_bw(const Tensor& grad, const Tensor& input, const MemoryConfig& output_mem_config) {
     std::vector<Tensor> grad_tensor;
     Tensor grad_result =
@@ -490,6 +500,8 @@ std::function<std::vector<ttnn::Tensor>(const Tensor&, const Tensor&, const Memo
             return _fill_bw;
         case UnaryBackwardOpType::HARDSIGMOID_BW:
             return _hardsigmoid_bw;
+        case UnaryBackwardOpType::COS_BW:
+            return _cos_bw;
         case UnaryBackwardOpType::FRAC_BW:
             return _frac_bw;
         case UnaryBackwardOpType::TRUNC_BW:

--- a/ttnn/cpp/ttnn/operations/eltwise/unary_backward/device/unary_backward_op.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary_backward/device/unary_backward_op.hpp
@@ -21,6 +21,7 @@ enum class UnaryBackwardOpType {
     ADD_BW,
     EQ_BW,
     LGAMMA_BW,
+    FILL_BW,
     SUB_BW,
     FRAC_BW,
     TRUNC_BW,

--- a/ttnn/cpp/ttnn/operations/eltwise/unary_backward/device/unary_backward_op.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary_backward/device/unary_backward_op.hpp
@@ -25,6 +25,7 @@ enum class UnaryBackwardOpType {
     HARDSIGMOID_BW,
     COS_BW,
     ACOSH_BW,
+    ACOS_BW,
     SUB_BW,
     FRAC_BW,
     TRUNC_BW,

--- a/ttnn/cpp/ttnn/operations/eltwise/unary_backward/device/unary_backward_op.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary_backward/device/unary_backward_op.hpp
@@ -26,6 +26,7 @@ enum class UnaryBackwardOpType {
     COS_BW,
     ACOSH_BW,
     ACOS_BW,
+    ATAN_BW,
     SUB_BW,
     FRAC_BW,
     TRUNC_BW,

--- a/ttnn/cpp/ttnn/operations/eltwise/unary_backward/device/unary_backward_op.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary_backward/device/unary_backward_op.hpp
@@ -22,6 +22,7 @@ enum class UnaryBackwardOpType {
     EQ_BW,
     LGAMMA_BW,
     FILL_BW,
+    HARDSIGMOID_BW,
     SUB_BW,
     FRAC_BW,
     TRUNC_BW,

--- a/ttnn/cpp/ttnn/operations/eltwise/unary_backward/device/unary_backward_op.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary_backward/device/unary_backward_op.hpp
@@ -27,6 +27,7 @@ enum class UnaryBackwardOpType {
     ACOSH_BW,
     ACOS_BW,
     ATAN_BW,
+    RAD2DEG_BW,
     SUB_BW,
     FRAC_BW,
     TRUNC_BW,

--- a/ttnn/cpp/ttnn/operations/eltwise/unary_backward/device/unary_backward_op.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary_backward/device/unary_backward_op.hpp
@@ -24,6 +24,7 @@ enum class UnaryBackwardOpType {
     FILL_BW,
     HARDSIGMOID_BW,
     COS_BW,
+    ACOSH_BW,
     SUB_BW,
     FRAC_BW,
     TRUNC_BW,

--- a/ttnn/cpp/ttnn/operations/eltwise/unary_backward/device/unary_backward_op.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary_backward/device/unary_backward_op.hpp
@@ -23,6 +23,7 @@ enum class UnaryBackwardOpType {
     LGAMMA_BW,
     FILL_BW,
     HARDSIGMOID_BW,
+    COS_BW,
     SUB_BW,
     FRAC_BW,
     TRUNC_BW,

--- a/ttnn/cpp/ttnn/operations/eltwise/unary_backward/unary_backward.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary_backward/unary_backward.hpp
@@ -74,6 +74,7 @@ constexpr auto add_bw = ttnn::register_operation<operations::unary_backward::Exe
 constexpr auto eq_bw = ttnn::register_operation<operations::unary_backward::ExecuteUnaryBackward<operations::unary_backward::UnaryBackwardOpType::EQ_BW>>("ttnn::eq_bw");
 constexpr auto lgamma_bw = ttnn::register_operation<operations::unary_backward::ExecuteUnaryBackward<operations::unary_backward::UnaryBackwardOpType::LGAMMA_BW>>("ttnn::lgamma_bw");
 constexpr auto fill_bw = ttnn::register_operation<operations::unary_backward::ExecuteUnaryBackward<operations::unary_backward::UnaryBackwardOpType::FILL_BW>>("ttnn::fill_bw");
+constexpr auto hardsigmoid_bw = ttnn::register_operation<operations::unary_backward::ExecuteUnaryBackward<operations::unary_backward::UnaryBackwardOpType::HARDSIGMOID_BW>>("ttnn::hardsigmoid_bw");
 constexpr auto sub_bw = ttnn::register_operation<operations::unary_backward::ExecuteUnaryBackward<operations::unary_backward::UnaryBackwardOpType::SUB_BW>>("ttnn::sub_bw");
 constexpr auto frac_bw = ttnn::register_operation<operations::unary_backward::ExecuteUnaryBackward<operations::unary_backward::UnaryBackwardOpType::FRAC_BW>>("ttnn::frac_bw");
 constexpr auto trunc_bw = ttnn::register_operation<operations::unary_backward::ExecuteUnaryBackward<operations::unary_backward::UnaryBackwardOpType::TRUNC_BW>>("ttnn::trunc_bw");

--- a/ttnn/cpp/ttnn/operations/eltwise/unary_backward/unary_backward.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary_backward/unary_backward.hpp
@@ -75,6 +75,7 @@ constexpr auto eq_bw = ttnn::register_operation<operations::unary_backward::Exec
 constexpr auto lgamma_bw = ttnn::register_operation<operations::unary_backward::ExecuteUnaryBackward<operations::unary_backward::UnaryBackwardOpType::LGAMMA_BW>>("ttnn::lgamma_bw");
 constexpr auto fill_bw = ttnn::register_operation<operations::unary_backward::ExecuteUnaryBackward<operations::unary_backward::UnaryBackwardOpType::FILL_BW>>("ttnn::fill_bw");
 constexpr auto hardsigmoid_bw = ttnn::register_operation<operations::unary_backward::ExecuteUnaryBackward<operations::unary_backward::UnaryBackwardOpType::HARDSIGMOID_BW>>("ttnn::hardsigmoid_bw");
+constexpr auto cos_bw = ttnn::register_operation<operations::unary_backward::ExecuteUnaryBackward<operations::unary_backward::UnaryBackwardOpType::COS_BW>>("ttnn::cos_bw");
 constexpr auto sub_bw = ttnn::register_operation<operations::unary_backward::ExecuteUnaryBackward<operations::unary_backward::UnaryBackwardOpType::SUB_BW>>("ttnn::sub_bw");
 constexpr auto frac_bw = ttnn::register_operation<operations::unary_backward::ExecuteUnaryBackward<operations::unary_backward::UnaryBackwardOpType::FRAC_BW>>("ttnn::frac_bw");
 constexpr auto trunc_bw = ttnn::register_operation<operations::unary_backward::ExecuteUnaryBackward<operations::unary_backward::UnaryBackwardOpType::TRUNC_BW>>("ttnn::trunc_bw");

--- a/ttnn/cpp/ttnn/operations/eltwise/unary_backward/unary_backward.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary_backward/unary_backward.hpp
@@ -76,6 +76,7 @@ constexpr auto lgamma_bw = ttnn::register_operation<operations::unary_backward::
 constexpr auto fill_bw = ttnn::register_operation<operations::unary_backward::ExecuteUnaryBackward<operations::unary_backward::UnaryBackwardOpType::FILL_BW>>("ttnn::fill_bw");
 constexpr auto hardsigmoid_bw = ttnn::register_operation<operations::unary_backward::ExecuteUnaryBackward<operations::unary_backward::UnaryBackwardOpType::HARDSIGMOID_BW>>("ttnn::hardsigmoid_bw");
 constexpr auto cos_bw = ttnn::register_operation<operations::unary_backward::ExecuteUnaryBackward<operations::unary_backward::UnaryBackwardOpType::COS_BW>>("ttnn::cos_bw");
+constexpr auto acosh_bw = ttnn::register_operation<operations::unary_backward::ExecuteUnaryBackward<operations::unary_backward::UnaryBackwardOpType::ACOSH_BW>>("ttnn::acosh_bw");
 constexpr auto sub_bw = ttnn::register_operation<operations::unary_backward::ExecuteUnaryBackward<operations::unary_backward::UnaryBackwardOpType::SUB_BW>>("ttnn::sub_bw");
 constexpr auto frac_bw = ttnn::register_operation<operations::unary_backward::ExecuteUnaryBackward<operations::unary_backward::UnaryBackwardOpType::FRAC_BW>>("ttnn::frac_bw");
 constexpr auto trunc_bw = ttnn::register_operation<operations::unary_backward::ExecuteUnaryBackward<operations::unary_backward::UnaryBackwardOpType::TRUNC_BW>>("ttnn::trunc_bw");

--- a/ttnn/cpp/ttnn/operations/eltwise/unary_backward/unary_backward.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary_backward/unary_backward.hpp
@@ -78,6 +78,7 @@ constexpr auto hardsigmoid_bw = ttnn::register_operation<operations::unary_backw
 constexpr auto cos_bw = ttnn::register_operation<operations::unary_backward::ExecuteUnaryBackward<operations::unary_backward::UnaryBackwardOpType::COS_BW>>("ttnn::cos_bw");
 constexpr auto acosh_bw = ttnn::register_operation<operations::unary_backward::ExecuteUnaryBackward<operations::unary_backward::UnaryBackwardOpType::ACOSH_BW>>("ttnn::acosh_bw");
 constexpr auto acos_bw = ttnn::register_operation<operations::unary_backward::ExecuteUnaryBackward<operations::unary_backward::UnaryBackwardOpType::ACOS_BW>>("ttnn::acos_bw");
+constexpr auto atan_bw = ttnn::register_operation<operations::unary_backward::ExecuteUnaryBackward<operations::unary_backward::UnaryBackwardOpType::ATAN_BW>>("ttnn::atan_bw");
 constexpr auto sub_bw = ttnn::register_operation<operations::unary_backward::ExecuteUnaryBackward<operations::unary_backward::UnaryBackwardOpType::SUB_BW>>("ttnn::sub_bw");
 constexpr auto frac_bw = ttnn::register_operation<operations::unary_backward::ExecuteUnaryBackward<operations::unary_backward::UnaryBackwardOpType::FRAC_BW>>("ttnn::frac_bw");
 constexpr auto trunc_bw = ttnn::register_operation<operations::unary_backward::ExecuteUnaryBackward<operations::unary_backward::UnaryBackwardOpType::TRUNC_BW>>("ttnn::trunc_bw");

--- a/ttnn/cpp/ttnn/operations/eltwise/unary_backward/unary_backward.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary_backward/unary_backward.hpp
@@ -73,6 +73,7 @@ constexpr auto multigammaln_bw = ttnn::register_operation<operations::unary_back
 constexpr auto add_bw = ttnn::register_operation<operations::unary_backward::ExecuteUnaryBackward<operations::unary_backward::UnaryBackwardOpType::ADD_BW>>("ttnn::add_bw");
 constexpr auto eq_bw = ttnn::register_operation<operations::unary_backward::ExecuteUnaryBackward<operations::unary_backward::UnaryBackwardOpType::EQ_BW>>("ttnn::eq_bw");
 constexpr auto lgamma_bw = ttnn::register_operation<operations::unary_backward::ExecuteUnaryBackward<operations::unary_backward::UnaryBackwardOpType::LGAMMA_BW>>("ttnn::lgamma_bw");
+constexpr auto fill_bw = ttnn::register_operation<operations::unary_backward::ExecuteUnaryBackward<operations::unary_backward::UnaryBackwardOpType::FILL_BW>>("ttnn::fill_bw");
 constexpr auto sub_bw = ttnn::register_operation<operations::unary_backward::ExecuteUnaryBackward<operations::unary_backward::UnaryBackwardOpType::SUB_BW>>("ttnn::sub_bw");
 constexpr auto frac_bw = ttnn::register_operation<operations::unary_backward::ExecuteUnaryBackward<operations::unary_backward::UnaryBackwardOpType::FRAC_BW>>("ttnn::frac_bw");
 constexpr auto trunc_bw = ttnn::register_operation<operations::unary_backward::ExecuteUnaryBackward<operations::unary_backward::UnaryBackwardOpType::TRUNC_BW>>("ttnn::trunc_bw");

--- a/ttnn/cpp/ttnn/operations/eltwise/unary_backward/unary_backward.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary_backward/unary_backward.hpp
@@ -77,6 +77,7 @@ constexpr auto fill_bw = ttnn::register_operation<operations::unary_backward::Ex
 constexpr auto hardsigmoid_bw = ttnn::register_operation<operations::unary_backward::ExecuteUnaryBackward<operations::unary_backward::UnaryBackwardOpType::HARDSIGMOID_BW>>("ttnn::hardsigmoid_bw");
 constexpr auto cos_bw = ttnn::register_operation<operations::unary_backward::ExecuteUnaryBackward<operations::unary_backward::UnaryBackwardOpType::COS_BW>>("ttnn::cos_bw");
 constexpr auto acosh_bw = ttnn::register_operation<operations::unary_backward::ExecuteUnaryBackward<operations::unary_backward::UnaryBackwardOpType::ACOSH_BW>>("ttnn::acosh_bw");
+constexpr auto acos_bw = ttnn::register_operation<operations::unary_backward::ExecuteUnaryBackward<operations::unary_backward::UnaryBackwardOpType::ACOS_BW>>("ttnn::acos_bw");
 constexpr auto sub_bw = ttnn::register_operation<operations::unary_backward::ExecuteUnaryBackward<operations::unary_backward::UnaryBackwardOpType::SUB_BW>>("ttnn::sub_bw");
 constexpr auto frac_bw = ttnn::register_operation<operations::unary_backward::ExecuteUnaryBackward<operations::unary_backward::UnaryBackwardOpType::FRAC_BW>>("ttnn::frac_bw");
 constexpr auto trunc_bw = ttnn::register_operation<operations::unary_backward::ExecuteUnaryBackward<operations::unary_backward::UnaryBackwardOpType::TRUNC_BW>>("ttnn::trunc_bw");

--- a/ttnn/cpp/ttnn/operations/eltwise/unary_backward/unary_backward.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary_backward/unary_backward.hpp
@@ -79,6 +79,7 @@ constexpr auto cos_bw = ttnn::register_operation<operations::unary_backward::Exe
 constexpr auto acosh_bw = ttnn::register_operation<operations::unary_backward::ExecuteUnaryBackward<operations::unary_backward::UnaryBackwardOpType::ACOSH_BW>>("ttnn::acosh_bw");
 constexpr auto acos_bw = ttnn::register_operation<operations::unary_backward::ExecuteUnaryBackward<operations::unary_backward::UnaryBackwardOpType::ACOS_BW>>("ttnn::acos_bw");
 constexpr auto atan_bw = ttnn::register_operation<operations::unary_backward::ExecuteUnaryBackward<operations::unary_backward::UnaryBackwardOpType::ATAN_BW>>("ttnn::atan_bw");
+constexpr auto rad2deg_bw = ttnn::register_operation<operations::unary_backward::ExecuteUnaryBackward<operations::unary_backward::UnaryBackwardOpType::RAD2DEG_BW>>("ttnn::rad2deg_bw");
 constexpr auto sub_bw = ttnn::register_operation<operations::unary_backward::ExecuteUnaryBackward<operations::unary_backward::UnaryBackwardOpType::SUB_BW>>("ttnn::sub_bw");
 constexpr auto frac_bw = ttnn::register_operation<operations::unary_backward::ExecuteUnaryBackward<operations::unary_backward::UnaryBackwardOpType::FRAC_BW>>("ttnn::frac_bw");
 constexpr auto trunc_bw = ttnn::register_operation<operations::unary_backward::ExecuteUnaryBackward<operations::unary_backward::UnaryBackwardOpType::TRUNC_BW>>("ttnn::trunc_bw");

--- a/ttnn/cpp/ttnn/operations/eltwise/unary_backward/unary_backward_pybind.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary_backward/unary_backward_pybind.hpp
@@ -236,6 +236,11 @@ void py_module(py::module& module) {
 
     detail::bind_unary_backward(
         module,
+        ttnn::rad2deg_bw,
+        R"doc(Performs backward operations for radian to degree conversion (rad2deg) on :attr:`input_tensor` with given :attr:`grad_tensor`.)doc");
+
+    detail::bind_unary_backward(
+        module,
         ttnn::sub_bw,
         R"doc(Performs backward operations for subtraction on :attr:`input_tensor`, :attr:`alpha` or attr:`input_tensor_a`, attr:`input_tensor_b` with given :attr:`grad_tensor`.)doc");
 

--- a/ttnn/cpp/ttnn/operations/eltwise/unary_backward/unary_backward_pybind.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary_backward/unary_backward_pybind.hpp
@@ -211,6 +211,11 @@ void py_module(py::module& module) {
 
     detail::bind_unary_backward(
         module,
+        ttnn::hardsigmoid_bw,
+        R"doc(Performs backward operations for hardsigmoid on :attr:`input_tensor` with given :attr:`grad_tensor`.)doc");
+
+    detail::bind_unary_backward(
+        module,
         ttnn::sub_bw,
         R"doc(Performs backward operations for subtraction on :attr:`input_tensor`, :attr:`alpha` or attr:`input_tensor_a`, attr:`input_tensor_b` with given :attr:`grad_tensor`.)doc");
 

--- a/ttnn/cpp/ttnn/operations/eltwise/unary_backward/unary_backward_pybind.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary_backward/unary_backward_pybind.hpp
@@ -221,6 +221,11 @@ void py_module(py::module& module) {
 
     detail::bind_unary_backward(
         module,
+        ttnn::acosh_bw,
+        R"doc(Performs backward operations for inverse hyperbolic cosine (acosh) on :attr:`input_tensor` with given :attr:`grad_tensor`.)doc");
+
+    detail::bind_unary_backward(
+        module,
         ttnn::sub_bw,
         R"doc(Performs backward operations for subtraction on :attr:`input_tensor`, :attr:`alpha` or attr:`input_tensor_a`, attr:`input_tensor_b` with given :attr:`grad_tensor`.)doc");
 

--- a/ttnn/cpp/ttnn/operations/eltwise/unary_backward/unary_backward_pybind.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary_backward/unary_backward_pybind.hpp
@@ -205,6 +205,12 @@ void py_module(py::module& module) {
 
     detail::bind_unary_backward(
         module,
+        ttnn::fill_bw,
+        R"doc(Performs backward operations for fill on :attr:`input_tensor` with given :attr:`grad_tensor`.
+        Returns an tensor like :attr:`grad_tensor` with sum of tensor values.)doc");
+
+    detail::bind_unary_backward(
+        module,
         ttnn::sub_bw,
         R"doc(Performs backward operations for subtraction on :attr:`input_tensor`, :attr:`alpha` or attr:`input_tensor_a`, attr:`input_tensor_b` with given :attr:`grad_tensor`.)doc");
 

--- a/ttnn/cpp/ttnn/operations/eltwise/unary_backward/unary_backward_pybind.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary_backward/unary_backward_pybind.hpp
@@ -216,6 +216,11 @@ void py_module(py::module& module) {
 
     detail::bind_unary_backward(
         module,
+        ttnn::cos_bw,
+        R"doc(Performs backward operations for cos on :attr:`input_tensor` with given :attr:`grad_tensor`.)doc");
+
+    detail::bind_unary_backward(
+        module,
         ttnn::sub_bw,
         R"doc(Performs backward operations for subtraction on :attr:`input_tensor`, :attr:`alpha` or attr:`input_tensor_a`, attr:`input_tensor_b` with given :attr:`grad_tensor`.)doc");
 

--- a/ttnn/cpp/ttnn/operations/eltwise/unary_backward/unary_backward_pybind.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary_backward/unary_backward_pybind.hpp
@@ -222,6 +222,11 @@ void py_module(py::module& module) {
     detail::bind_unary_backward(
         module,
         ttnn::acosh_bw,
+        R"doc(Performs backward operations for inverse cosine (acos) on :attr:`input_tensor` with given :attr:`grad_tensor`.)doc");
+
+    detail::bind_unary_backward(
+        module,
+        ttnn::acos_bw,
         R"doc(Performs backward operations for inverse hyperbolic cosine (acosh) on :attr:`input_tensor` with given :attr:`grad_tensor`.)doc");
 
     detail::bind_unary_backward(

--- a/ttnn/cpp/ttnn/operations/eltwise/unary_backward/unary_backward_pybind.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary_backward/unary_backward_pybind.hpp
@@ -231,6 +231,11 @@ void py_module(py::module& module) {
 
     detail::bind_unary_backward(
         module,
+        ttnn::atan_bw,
+        R"doc(Performs backward operations for atan on :attr:`input_tensor` with given :attr:`grad_tensor`.)doc");
+
+    detail::bind_unary_backward(
+        module,
         ttnn::sub_bw,
         R"doc(Performs backward operations for subtraction on :attr:`input_tensor`, :attr:`alpha` or attr:`input_tensor_a`, attr:`input_tensor_b` with given :attr:`grad_tensor`.)doc");
 


### PR DESCRIPTION
Issue : #10076 [ Unary Backward Tracking Issue : #9874 , Master issue : #9322 ]

### Work Done:

- Replace tt_eager ops used in 3 binary backward ops with ttnn ops
- Migrate 7 Unary backward ops to TTNN
- Moved test files to TTNN at `tests/ttnn/unit_tests/operations/backward/test_backward_*.py`

**List of ops migrated and their test files :**

- fill_bw
- hardsigmoid_bw
- cos_bw
- acosh_bw
- acos_bw
- atan_bw
- rad2deg_bw
