### PR TITLE
#10079: Move Unary Backward ops to TTNN 

### DIFF
--- a/docs/source/ttnn/ttnn/api.rst
+++ b/docs/source/ttnn/ttnn/api.rst
@@ -214,6 +214,7 @@ Pointwise Unary
    ttnn/asin_bw
    ttnn/asinh_bw
    ttnn/sin_bw
+   ttnn/sinh_bw
 
 Pointwise Binary
 ================

--- a/docs/source/ttnn/ttnn/api.rst
+++ b/docs/source/ttnn/ttnn/api.rst
@@ -213,6 +213,7 @@ Pointwise Unary
    ttnn/atanh_bw
    ttnn/asin_bw
    ttnn/asinh_bw
+   ttnn/sin_bw
 
 Pointwise Binary
 ================

--- a/docs/source/ttnn/ttnn/api.rst
+++ b/docs/source/ttnn/ttnn/api.rst
@@ -218,6 +218,7 @@ Pointwise Unary
    ttnn/log10_bw
    ttnn/log1p_bw
    ttnn/erfc_bw
+   ttnn/ceil_bw
 
 Pointwise Binary
 ================

--- a/docs/source/ttnn/ttnn/api.rst
+++ b/docs/source/ttnn/ttnn/api.rst
@@ -219,6 +219,7 @@ Pointwise Unary
    ttnn/log1p_bw
    ttnn/erfc_bw
    ttnn/ceil_bw
+   ttnn/softsign_bw
 
 Pointwise Binary
 ================

--- a/docs/source/ttnn/ttnn/api.rst
+++ b/docs/source/ttnn/ttnn/api.rst
@@ -215,6 +215,7 @@ Pointwise Unary
    ttnn/asinh_bw
    ttnn/sin_bw
    ttnn/sinh_bw
+   ttnn/log10_bw
 
 Pointwise Binary
 ================

--- a/docs/source/ttnn/ttnn/api.rst
+++ b/docs/source/ttnn/ttnn/api.rst
@@ -217,6 +217,7 @@ Pointwise Unary
    ttnn/sinh_bw
    ttnn/log10_bw
    ttnn/log1p_bw
+   ttnn/erfc_bw
 
 Pointwise Binary
 ================

--- a/docs/source/ttnn/ttnn/api.rst
+++ b/docs/source/ttnn/ttnn/api.rst
@@ -216,6 +216,7 @@ Pointwise Unary
    ttnn/sin_bw
    ttnn/sinh_bw
    ttnn/log10_bw
+   ttnn/log1p_bw
 
 Pointwise Binary
 ================

--- a/docs/source/ttnn/ttnn/dependencies/tt_lib.rst
+++ b/docs/source/ttnn/ttnn/dependencies/tt_lib.rst
@@ -846,8 +846,6 @@ Backward Operations
 
 .. autofunction:: tt_lib.tensor.angle_bw
 
-.. autofunction:: tt_lib.tensor.log1p_bw
-
 .. autofunction:: tt_lib.tensor.erf_bw
 
 .. autofunction:: tt_lib.tensor.erfc_bw

--- a/docs/source/ttnn/ttnn/dependencies/tt_lib.rst
+++ b/docs/source/ttnn/ttnn/dependencies/tt_lib.rst
@@ -862,8 +862,6 @@ Backward Operations
 
 .. autofunction:: tt_lib.tensor.sign_bw
 
-.. autofunction:: tt_lib.tensor.ceil_bw
-
 .. autofunction:: tt_lib.tensor.log2_bw
 
 .. autofunction:: tt_lib.tensor.ge_bw

--- a/docs/source/ttnn/ttnn/dependencies/tt_lib.rst
+++ b/docs/source/ttnn/ttnn/dependencies/tt_lib.rst
@@ -846,8 +846,6 @@ Backward Operations
 
 .. autofunction:: tt_lib.tensor.angle_bw
 
-.. autofunction:: tt_lib.tensor.sinh_bw
-
 .. autofunction:: tt_lib.tensor.log10_bw
 
 .. autofunction:: tt_lib.tensor.log1p_bw

--- a/docs/source/ttnn/ttnn/dependencies/tt_lib.rst
+++ b/docs/source/ttnn/ttnn/dependencies/tt_lib.rst
@@ -846,8 +846,6 @@ Backward Operations
 
 .. autofunction:: tt_lib.tensor.angle_bw
 
-.. autofunction:: tt_lib.tensor.log10_bw
-
 .. autofunction:: tt_lib.tensor.log1p_bw
 
 .. autofunction:: tt_lib.tensor.erf_bw

--- a/docs/source/ttnn/ttnn/dependencies/tt_lib.rst
+++ b/docs/source/ttnn/ttnn/dependencies/tt_lib.rst
@@ -846,8 +846,6 @@ Backward Operations
 
 .. autofunction:: tt_lib.tensor.angle_bw
 
-.. autofunction:: tt_lib.tensor.sin_bw
-
 .. autofunction:: tt_lib.tensor.sinh_bw
 
 .. autofunction:: tt_lib.tensor.log10_bw

--- a/docs/source/ttnn/ttnn/dependencies/tt_lib.rst
+++ b/docs/source/ttnn/ttnn/dependencies/tt_lib.rst
@@ -858,8 +858,6 @@ Backward Operations
 
 .. autofunction:: tt_lib.tensor.logiteps_bw
 
-.. autofunction:: tt_lib.tensor.softsign_bw
-
 .. autofunction:: tt_lib.tensor.sign_bw
 
 .. autofunction:: tt_lib.tensor.log2_bw

--- a/docs/source/ttnn/ttnn/dependencies/tt_lib.rst
+++ b/docs/source/ttnn/ttnn/dependencies/tt_lib.rst
@@ -848,8 +848,6 @@ Backward Operations
 
 .. autofunction:: tt_lib.tensor.erf_bw
 
-.. autofunction:: tt_lib.tensor.erfc_bw
-
 .. autofunction:: tt_lib.tensor.digamma_bw
 
 .. autofunction:: tt_lib.tensor.deg2rad_bw

--- a/docs/source/ttnn/ttnn/ttnn/ceil_bw.rst
+++ b/docs/source/ttnn/ttnn/ttnn/ceil_bw.rst
@@ -1,0 +1,6 @@
+.. _ttnn.ceil_bw:
+
+ttnn.ceil_bw
+#############
+
+  .. autofunction:: ttnn.ceil_bw

--- a/docs/source/ttnn/ttnn/ttnn/erfc_bw.rst
+++ b/docs/source/ttnn/ttnn/ttnn/erfc_bw.rst
@@ -1,0 +1,6 @@
+.. _ttnn.erfc_bw:
+
+ttnn.erfc_bw
+#############
+
+  .. autofunction:: ttnn.erfc_bw

--- a/docs/source/ttnn/ttnn/ttnn/log10_bw.rst
+++ b/docs/source/ttnn/ttnn/ttnn/log10_bw.rst
@@ -1,0 +1,6 @@
+.. _ttnn.log10_bw:
+
+ttnn.log10_bw
+##############
+
+  .. autofunction:: ttnn.log10_bw

--- a/docs/source/ttnn/ttnn/ttnn/log1p_bw.rst
+++ b/docs/source/ttnn/ttnn/ttnn/log1p_bw.rst
@@ -1,0 +1,7 @@
+
+.. _ttnn.log1p_bw:
+
+ttnn.log1p_bw
+##############
+
+  .. autofunction:: ttnn.log1p_bw

--- a/docs/source/ttnn/ttnn/ttnn/sin_bw.rst
+++ b/docs/source/ttnn/ttnn/ttnn/sin_bw.rst
@@ -1,0 +1,6 @@
+.. _ttnn.sin_bw:
+
+ttnn.sin_bw
+############
+
+  .. autofunction:: ttnn.sin_bw

--- a/docs/source/ttnn/ttnn/ttnn/sinh_bw.rst
+++ b/docs/source/ttnn/ttnn/ttnn/sinh_bw.rst
@@ -1,0 +1,6 @@
+.. _ttnn.sinh_bw:
+
+ttnn.sinh_bw
+#############
+
+  .. autofunction:: ttnn.sinh_bw

--- a/docs/source/ttnn/ttnn/ttnn/softsign_bw.rst
+++ b/docs/source/ttnn/ttnn/ttnn/softsign_bw.rst
@@ -1,0 +1,6 @@
+.. _ttnn.softsign_bw:
+
+ttnn.softsign_bw
+#################
+
+  .. autofunction:: ttnn.softsign_bw

--- a/tests/ttnn/unit_tests/operations/backward/test_backward_ceil.py
+++ b/tests/ttnn/unit_tests/operations/backward/test_backward_ceil.py
@@ -4,8 +4,8 @@
 
 import torch
 import pytest
-import tt_lib
-from tests.tt_eager.python_api_testing.unit_testing.backward_ops.utility_funcs import compare_pcc, data_gen_with_range
+import ttnn
+from tests.ttnn.unit_tests.operations.backward.utility_funcs import data_gen_with_range, compare_pcc
 
 
 @pytest.mark.parametrize(
@@ -21,7 +21,7 @@ def test_bw_ceil(input_shapes, device):
     in_data, input_tensor = data_gen_with_range(input_shapes, -100, 100, device, True)
 
     pyt_y = torch.ceil(in_data)
-    tt_output_tensor_on_device = tt_lib.tensor.ceil_bw(grad_tensor, input_tensor)
+    tt_output_tensor_on_device = ttnn.ceil_bw(grad_tensor, input_tensor)
 
     in_data.retain_grad()
 

--- a/tests/ttnn/unit_tests/operations/backward/test_backward_erfc.py
+++ b/tests/ttnn/unit_tests/operations/backward/test_backward_erfc.py
@@ -4,8 +4,8 @@
 
 import torch
 import pytest
-import tt_lib
-from tests.tt_eager.python_api_testing.unit_testing.backward_ops.utility_funcs import compare_pcc, data_gen_with_range
+import ttnn
+from tests.ttnn.unit_tests.operations.backward.utility_funcs import data_gen_with_range, compare_pcc
 
 
 @pytest.mark.parametrize(
@@ -21,7 +21,7 @@ def test_bw_erfc(input_shapes, device):
     in_data, input_tensor = data_gen_with_range(input_shapes, -200, 199, device, required_grad=True)
     pyt_y = torch.erfc(in_data)
 
-    tt_output_tensor_on_device = tt_lib.tensor.erfc_bw(grad_tensor, input_tensor)
+    tt_output_tensor_on_device = ttnn.erfc_bw(grad_tensor, input_tensor)
 
     in_data.retain_grad()
 

--- a/tests/ttnn/unit_tests/operations/backward/test_backward_log10.py
+++ b/tests/ttnn/unit_tests/operations/backward/test_backward_log10.py
@@ -4,11 +4,8 @@
 
 import torch
 import pytest
-import tt_lib
-from tests.tt_eager.python_api_testing.unit_testing.backward_ops.utility_funcs import (
-    compare_pcc,
-    data_gen_with_range,
-)
+import ttnn
+from tests.ttnn.unit_tests.operations.backward.utility_funcs import data_gen_with_range, compare_pcc
 
 
 @pytest.mark.parametrize(
@@ -23,7 +20,7 @@ def test_bw_log10(input_shapes, device):
     in_data, input_tensor = data_gen_with_range(input_shapes, -100, 100, device, True)
     grad_data, grad_tensor = data_gen_with_range(input_shapes, -10, 10, device)
 
-    tt_output_tensor_on_device = tt_lib.tensor.log10_bw(grad_tensor, input_tensor)
+    tt_output_tensor_on_device = ttnn.log10_bw(grad_tensor, input_tensor)
 
     in_data.retain_grad()
 

--- a/tests/ttnn/unit_tests/operations/backward/test_backward_log1p.py
+++ b/tests/ttnn/unit_tests/operations/backward/test_backward_log1p.py
@@ -4,11 +4,8 @@
 
 import torch
 import pytest
-import tt_lib
-from tests.tt_eager.python_api_testing.unit_testing.backward_ops.utility_funcs import (
-    compare_pcc,
-    data_gen_with_range,
-)
+import ttnn
+from tests.ttnn.unit_tests.operations.backward.utility_funcs import data_gen_with_range, compare_pcc
 
 
 @pytest.mark.parametrize(
@@ -23,7 +20,7 @@ def test_bw_log1p(input_shapes, device):
     in_data, input_tensor = data_gen_with_range(input_shapes, -100, 100, device, True)
     grad_data, grad_tensor = data_gen_with_range(input_shapes, -10, 10, device)
 
-    tt_output_tensor_on_device = tt_lib.tensor.log1p_bw(grad_tensor, input_tensor)
+    tt_output_tensor_on_device = ttnn.log1p_bw(grad_tensor, input_tensor)
 
     in_data.retain_grad()
 

--- a/tests/ttnn/unit_tests/operations/backward/test_backward_sin.py
+++ b/tests/ttnn/unit_tests/operations/backward/test_backward_sin.py
@@ -4,8 +4,8 @@
 
 import torch
 import pytest
-import tt_lib
-from tests.tt_eager.python_api_testing.unit_testing.backward_ops.utility_funcs import data_gen_with_range, compare_pcc
+import ttnn
+from tests.ttnn.unit_tests.operations.backward.utility_funcs import data_gen_with_range, compare_pcc
 from math import pi
 
 
@@ -21,7 +21,7 @@ def test_bw_sin(input_shapes, device):
     in_data, input_tensor = data_gen_with_range(input_shapes, 0, 2 * pi, device, True)
     grad_data, grad_tensor = data_gen_with_range(input_shapes, -10, 10, device, False)
 
-    tt_output_tensor_on_device = tt_lib.tensor.sin_bw(grad_tensor, input_tensor)
+    tt_output_tensor_on_device = ttnn.sin_bw(grad_tensor, input_tensor)
 
     in_data.retain_grad()
 

--- a/tests/ttnn/unit_tests/operations/backward/test_backward_sinh.py
+++ b/tests/ttnn/unit_tests/operations/backward/test_backward_sinh.py
@@ -4,11 +4,9 @@
 
 import torch
 import pytest
-import tt_lib
-from tests.tt_eager.python_api_testing.unit_testing.backward_ops.utility_funcs import (
-    data_gen_with_range,
-    compare_pcc,
-)
+import ttnn
+from tests.ttnn.unit_tests.operations.backward.utility_funcs import data_gen_with_range, compare_pcc
+
 from models.utility_functions import (
     skip_for_wormhole_b0,
 )
@@ -26,7 +24,7 @@ def test_bw_sinh(input_shapes, device):
     in_data, input_tensor = data_gen_with_range(input_shapes, -9, 9, device, True)
     grad_data, grad_tensor = data_gen_with_range(input_shapes, -20, 20, device)
 
-    tt_output_tensor_on_device = tt_lib.tensor.sinh_bw(grad_tensor, input_tensor)
+    tt_output_tensor_on_device = ttnn.sinh_bw(grad_tensor, input_tensor)
 
     in_data.retain_grad()
 
@@ -52,7 +50,7 @@ def test_bw_sinh_inf(input_shapes, device):
     in_data, input_tensor = data_gen_with_range(input_shapes, 89, 96, device, True)
     grad_data, grad_tensor = data_gen_with_range(input_shapes, -10, 10, device)
 
-    tt_output_tensor_on_device = tt_lib.tensor.sinh_bw(grad_tensor, input_tensor)
+    tt_output_tensor_on_device = ttnn.sinh_bw(grad_tensor, input_tensor)
 
     in_data.retain_grad()
 
@@ -78,7 +76,7 @@ def test_bw_sinh_neg_inf(input_shapes, device):
     in_data, input_tensor = data_gen_with_range(input_shapes, -97, -89, device, True)
     grad_data, grad_tensor = data_gen_with_range(input_shapes, -10, 10, device)
 
-    tt_output_tensor_on_device = tt_lib.tensor.sinh_bw(grad_tensor, input_tensor)
+    tt_output_tensor_on_device = ttnn.sinh_bw(grad_tensor, input_tensor)
 
     in_data.retain_grad()
 
@@ -101,7 +99,7 @@ def test_bw_sinh_nan_test1(input_shapes, device):
     in_data, input_tensor = data_gen_with_range(input_shapes, 86, 89, device, True)
     grad_data, grad_tensor = data_gen_with_range(input_shapes, 35, 50, device)
 
-    tt_output_tensor_on_device = tt_lib.tensor.sinh_bw(grad_tensor, input_tensor)
+    tt_output_tensor_on_device = ttnn.sinh_bw(grad_tensor, input_tensor)
 
     in_data.retain_grad()
 
@@ -124,7 +122,7 @@ def test_bw_sinh_nan_test2(input_shapes, device):
     in_data, input_tensor = data_gen_with_range(input_shapes, 86, 89, device, True)
     grad_data, grad_tensor = data_gen_with_range(input_shapes, -50, -35, device)
 
-    tt_output_tensor_on_device = tt_lib.tensor.sinh_bw(grad_tensor, input_tensor)
+    tt_output_tensor_on_device = ttnn.sinh_bw(grad_tensor, input_tensor)
 
     in_data.retain_grad()
 

--- a/tests/ttnn/unit_tests/operations/backward/test_backward_softsign.py
+++ b/tests/ttnn/unit_tests/operations/backward/test_backward_softsign.py
@@ -4,8 +4,8 @@
 
 import torch
 import pytest
-import tt_lib
-from tests.tt_eager.python_api_testing.unit_testing.backward_ops.utility_funcs import compare_pcc, data_gen_with_range
+import ttnn
+from tests.ttnn.unit_tests.operations.backward.utility_funcs import data_gen_with_range, compare_pcc
 
 
 @pytest.mark.parametrize(
@@ -21,7 +21,7 @@ def test_bw_softsign(input_shapes, device):
     in_data, input_tensor = data_gen_with_range(input_shapes, -100, 100, device, True)
 
     pyt_y = torch.nn.functional.softsign(in_data)
-    tt_output_tensor_on_device = tt_lib.tensor.softsign_bw(grad_tensor, input_tensor)
+    tt_output_tensor_on_device = ttnn.softsign_bw(grad_tensor, input_tensor)
 
     in_data.retain_grad()
 

--- a/tt_eager/tt_dnn/op_library/backward/backward_ops.cpp
+++ b/tt_eager/tt_dnn/op_library/backward/backward_ops.cpp
@@ -587,6 +587,7 @@ std::vector<Tensor> erf_bw(const Tensor& grad, const Tensor& input, const Memory
     return operation::decorate_as_composite(__func__, _erf_bw)(grad, input, output_mem_config);
 }
 
+<<<<<<< HEAD
 std::vector<Tensor> _erfc_bw(const Tensor& grad, const Tensor& input, const MemoryConfig& output_mem_config) {
     std::vector<Tensor> grad_tensor;
     Tensor result = ttnn::multiply(
@@ -604,6 +605,8 @@ std::vector<Tensor> erfc_bw(const Tensor& grad, const Tensor& input, const Memor
     return operation::decorate_as_composite(__func__, _erfc_bw)(grad, input, output_mem_config);
 }
 
+=======
+>>>>>>> #10079: Merge erfc_bw to TTNN
 std::vector<Tensor> _digamma_bw(const Tensor& grad, const Tensor& input, const MemoryConfig& output_mem_config) {
     std::vector<Tensor> grad_tensor;
     float t_inf = std::numeric_limits<float>::infinity();

--- a/tt_eager/tt_dnn/op_library/backward/backward_ops.cpp
+++ b/tt_eager/tt_dnn/op_library/backward/backward_ops.cpp
@@ -921,16 +921,6 @@ std::vector<Tensor> sign_bw(const Tensor& grad, const Tensor& input, const Memor
     return operation::decorate_as_composite(__func__, _sign_bw)(grad, input, output_mem_config);
 }
 
-std::vector<Tensor> _ceil_bw(const Tensor& grad, const Tensor& input, const MemoryConfig& output_mem_config) {
-    std::vector<Tensor> grad_tensor;
-    Tensor zero_grad = zeros_like(grad, output_mem_config);
-    grad_tensor.emplace_back(zero_grad);
-    return grad_tensor;
-}
-std::vector<Tensor> ceil_bw(const Tensor& grad, const Tensor& input, const MemoryConfig& output_mem_config) {
-    return operation::decorate_as_composite(__func__, _ceil_bw)(grad, input, output_mem_config);
-}
-
 // bw(log2(in)) = grad/(in * 0.69314718055994530942)
 std::vector<Tensor> _log2_bw(const Tensor& grad, const Tensor& input, const MemoryConfig& output_mem_config) {
     std::vector<Tensor> grad_tensor;

--- a/tt_eager/tt_dnn/op_library/backward/backward_ops.cpp
+++ b/tt_eager/tt_dnn/op_library/backward/backward_ops.cpp
@@ -514,62 +514,6 @@ std::vector<Tensor> erfinv_bw(const Tensor& grad, const Tensor& input, const Mem
     return operation::decorate_as_composite(__func__, _erfinv_bw)(grad, input, output_mem_config);
 }
 
-<<<<<<< HEAD
-<<<<<<< HEAD
-// bw(log10(in)) = grad/(in * 2.30258509299404568402)
-std::vector<Tensor> _log10_bw(const Tensor& grad, const Tensor& input, const MemoryConfig& output_mem_config) {
-    std::vector<Tensor> grad_tensor;
-    Tensor t_inf = where(
-        ttnn::ltz(grad, output_mem_config),
-        -std::numeric_limits<float>::infinity(),
-        std::numeric_limits<float>::infinity(),
-        output_mem_config);
-    Tensor grad_a = ttnn::multiply(
-        grad, ttnn::reciprocal(ttnn::multiply(input, M_LN10, std::nullopt, output_mem_config), output_mem_config), std::nullopt, output_mem_config);
-    grad_a = where(
-        ttnn::logical_and(ttnn::eqz(input, output_mem_config), ttnn::eqz(grad, output_mem_config), std::nullopt, output_mem_config),
-        std::nanf(" "),
-        where(ttnn::eqz(input, output_mem_config), t_inf, grad_a, output_mem_config),
-        output_mem_config);
-    grad_tensor.emplace_back(grad_a);
-    return grad_tensor;
-}
-std::vector<Tensor> log10_bw(const Tensor& grad, const Tensor& input, const MemoryConfig& output_mem_config) {
-    return operation::decorate_as_composite(__func__, _log10_bw)(grad, input, output_mem_config);
-}
-
-=======
->>>>>>> #10079: Merge log10_bw to TTNN
-// bw(log1p(in)) = grad/(in + 1)
-// for -1 = inf
-std::vector<Tensor> _log1p_bw(const Tensor& grad, const Tensor& input, const MemoryConfig& output_mem_config) {
-    std::vector<Tensor> grad_tensor;
-    Tensor t_inf = where(
-        ttnn::ltz(grad, output_mem_config),
-        -std::numeric_limits<float>::infinity(),
-        std::numeric_limits<float>::infinity(),
-        output_mem_config);
-    Tensor t_inp1 = ttnn::add(input, 1.0f, std::nullopt, output_mem_config);
-    Tensor grad_a = ttnn::multiply(grad, ttnn::reciprocal(t_inp1, output_mem_config), std::nullopt, output_mem_config);
-    grad_a = where(
-        ttnn::eq(input, full_like(input, -1.0, output_mem_config), std::nullopt, output_mem_config),
-        t_inf,
-        grad_a,
-        output_mem_config);
-    grad_a = where(
-        ttnn::logical_and(ttnn::eqz(t_inp1, output_mem_config), ttnn::eqz(grad, output_mem_config)),
-        std::nanf(" "),
-        grad_a,
-        output_mem_config);
-    grad_tensor.emplace_back(grad_a);
-    return grad_tensor;
-}
-std::vector<Tensor> log1p_bw(const Tensor& grad, const Tensor& input, const MemoryConfig& output_mem_config) {
-    return operation::decorate_as_composite(__func__, _log1p_bw)(grad, input, output_mem_config);
-}
-
-=======
->>>>>>> #10079: Merge log1p_bw to TTNN
 std::vector<Tensor> _erf_bw(const Tensor& grad, const Tensor& input, const MemoryConfig& output_mem_config) {
     std::vector<Tensor> grad_tensor;
     Tensor result = ttnn::multiply(
@@ -587,26 +531,6 @@ std::vector<Tensor> erf_bw(const Tensor& grad, const Tensor& input, const Memory
     return operation::decorate_as_composite(__func__, _erf_bw)(grad, input, output_mem_config);
 }
 
-<<<<<<< HEAD
-std::vector<Tensor> _erfc_bw(const Tensor& grad, const Tensor& input, const MemoryConfig& output_mem_config) {
-    std::vector<Tensor> grad_tensor;
-    Tensor result = ttnn::multiply(
-        ttnn::multiply(ttnn::exp(ttnn::neg(ttnn::square(input, output_mem_config), output_mem_config), false, output_mem_config),
-            grad,
-            std::nullopt,
-            output_mem_config),
-        -M_2_SQRTPI,
-        std::nullopt,
-        output_mem_config);
-    grad_tensor.emplace_back(result);
-    return grad_tensor;
-}
-std::vector<Tensor> erfc_bw(const Tensor& grad, const Tensor& input, const MemoryConfig& output_mem_config) {
-    return operation::decorate_as_composite(__func__, _erfc_bw)(grad, input, output_mem_config);
-}
-
-=======
->>>>>>> #10079: Merge erfc_bw to TTNN
 std::vector<Tensor> _digamma_bw(const Tensor& grad, const Tensor& input, const MemoryConfig& output_mem_config) {
     std::vector<Tensor> grad_tensor;
     float t_inf = std::numeric_limits<float>::infinity();
@@ -890,56 +814,6 @@ std::vector<Tensor> _logiteps_bw(
 std::vector<Tensor> logiteps_bw(
     const Tensor& grad, const Tensor& input, float eps, const MemoryConfig& output_mem_config) {
     return operation::decorate_as_composite(__func__, _logiteps_bw)(grad, input, eps, output_mem_config);
-}
-
-<<<<<<< HEAD
-// softsign
-// result = grad_data / torch.square(1 + torch.abs(input))
-std::vector<Tensor> _softsign_bw(const Tensor& grad, const Tensor& input, const MemoryConfig& output_mem_config) {
-    std::vector<Tensor> grad_tensor;
-    using ttnn::operations::unary::UnaryWithParam;
-    using ttnn::operations::unary::UnaryOpType;
-    std::vector<UnaryWithParam> ops_chain = {
-    UnaryWithParam{UnaryOpType::ABS},
-    UnaryWithParam{UnaryOpType::ADD_UNARY_SFPU, 1.0f},
-    UnaryWithParam{UnaryOpType::SQUARE},
-    UnaryWithParam{UnaryOpType::RECIP}};
-    grad_tensor.emplace_back(
-        ttnn::multiply(grad, ttnn::unary_chain(input, ops_chain, output_mem_config), std::nullopt, output_mem_config));
-    return grad_tensor;
-}
-std::vector<Tensor> softsign_bw(const Tensor& grad, const Tensor& input, const MemoryConfig& output_mem_config) {
-    return operation::decorate_as_composite(__func__, _softsign_bw)(grad, input, output_mem_config);
-=======
-std::vector<Tensor> _logit_bw(const Tensor& grad, const Tensor& input, const MemoryConfig& output_mem_config) {
-    std::vector<Tensor> grad_tensor;
-    Tensor grad_result =
-        ttnn::multiply(grad,
-            recip(ttnn::multiply(input, rsub(input, 1.0f, output_mem_config), std::nullopt, output_mem_config)),
-            std::nullopt,
-            output_mem_config);
-    Tensor status = ttnn::logical_and(
-        gte_unary(input, 0.0f, output_mem_config),
-        lte_unary(input, 1.0f, output_mem_config),
-        std::nullopt,
-        output_mem_config);
-    grad_result = where(
-        ttnn::eq(status, ones_like(input, output_mem_config), std::nullopt, output_mem_config), grad_result, std::nanf(""));
-    grad_result = where(
-        ttnn::logical_or(
-            eq_unary(input, 0.0, output_mem_config),
-            eq_unary(input, 1.0, output_mem_config),
-            std::nullopt,
-            output_mem_config),
-        mul_unary(sign(grad, output_mem_config), std::numeric_limits<float>::infinity(), output_mem_config),
-        grad_result,
-        output_mem_config);
-    grad_tensor.emplace_back(grad_result);
-    return grad_tensor;
-}
-std::vector<Tensor> logit_bw(const Tensor& grad, const Tensor& input, const MemoryConfig& output_mem_config) {
-    return operation::decorate_as_composite(__func__, _logit_bw)(grad, input, output_mem_config);
->>>>>>> #10079: Merge softsign_bw to TTNN
 }
 
 std::vector<Tensor> _sign_bw(const Tensor& grad, const Tensor& input, const MemoryConfig& output_mem_config) {

--- a/tt_eager/tt_dnn/op_library/backward/backward_ops.cpp
+++ b/tt_eager/tt_dnn/op_library/backward/backward_ops.cpp
@@ -514,6 +514,7 @@ std::vector<Tensor> erfinv_bw(const Tensor& grad, const Tensor& input, const Mem
     return operation::decorate_as_composite(__func__, _erfinv_bw)(grad, input, output_mem_config);
 }
 
+<<<<<<< HEAD
 // bw(log10(in)) = grad/(in * 2.30258509299404568402)
 std::vector<Tensor> _log10_bw(const Tensor& grad, const Tensor& input, const MemoryConfig& output_mem_config) {
     std::vector<Tensor> grad_tensor;
@@ -536,6 +537,8 @@ std::vector<Tensor> log10_bw(const Tensor& grad, const Tensor& input, const Memo
     return operation::decorate_as_composite(__func__, _log10_bw)(grad, input, output_mem_config);
 }
 
+=======
+>>>>>>> #10079: Merge log10_bw to TTNN
 // bw(log1p(in)) = grad/(in + 1)
 // for -1 = inf
 std::vector<Tensor> _log1p_bw(const Tensor& grad, const Tensor& input, const MemoryConfig& output_mem_config) {

--- a/tt_eager/tt_dnn/op_library/backward/backward_ops.cpp
+++ b/tt_eager/tt_dnn/op_library/backward/backward_ops.cpp
@@ -474,52 +474,6 @@ std::vector<Tensor> hardtanh_bw(
     return operation::decorate_as_composite(__func__, _hardtanh_bw)(grad, input, min, max, output_mem_config);
 }
 
-<<<<<<< HEAD
-// name: sin(Tensor self) -> Tensor
-// self: grad * self.cos()
-std::vector<Tensor> _sin_bw(const Tensor& grad, const Tensor& input_tensor, const MemoryConfig& output_mem_config) {
-    std::vector<Tensor> grad_tensor;
-    Tensor grad_input = ttnn::multiply(grad, ttnn::cos(input_tensor, output_mem_config), std::nullopt, output_mem_config);
-    grad_tensor.emplace_back(grad_input);
-    return grad_tensor;
-}
-std::vector<Tensor> sin_bw(const Tensor& grad, const Tensor& input, const MemoryConfig& output_mem_config) {
-    return operation::decorate_as_composite(__func__, _sin_bw)(grad, input, output_mem_config);
-}
-
-=======
->>>>>>> #10079: Merge sin_bw to TTNN
-// name: sinh(Tensor self) -> Tensor
-// self: grad * self.cosh()
-std::vector<Tensor> _sinh_bw(const Tensor& grad, const Tensor& input, const MemoryConfig& output_mem_config) {
-    std::vector<Tensor> grad_tensor;
-    Tensor t_inf = ttnn::multiply(ttnn::sign(grad, output_mem_config), std::numeric_limits<float>::infinity(), std::nullopt, output_mem_config);
-    Tensor grad_a = where(
-        ttnn::gt(input, full_like(input, 88.5, output_mem_config), std::nullopt, output_mem_config),
-        t_inf,
-        where(
-            ttnn::lt(input, full_like(input, -88.5, output_mem_config), std::nullopt, output_mem_config),
-            t_inf,
-            ttnn::multiply(grad, cosh(input, output_mem_config), std::nullopt, output_mem_config),
-            output_mem_config),
-        output_mem_config);
-    t_inf.deallocate();
-    grad_a = where(
-        ttnn::ge(grad_a, 3.4e+38, std::nullopt, output_mem_config),
-        std::numeric_limits<float>::infinity(),
-        where(
-            ttnn::le(grad_a, -3.4e+38, std::nullopt, output_mem_config),
-            -std::numeric_limits<float>::infinity(),
-            grad_a,
-            output_mem_config),
-        output_mem_config);
-    grad_tensor.emplace_back(grad_a);
-    return grad_tensor;
-}
-std::vector<Tensor> sinh_bw(const Tensor& grad, const Tensor& input, const MemoryConfig& output_mem_config) {
-    return operation::decorate_as_composite(__func__, _sinh_bw)(grad, input, output_mem_config);
-}
-
 // erfinv
 // self: 0.5 * sqrt(M_PI) * exp(self.erfinv().pow(2)) * grad
 // for input -1 and 1: grad.sign() * inf, for input > 1 or < -1 : nan

--- a/tt_eager/tt_dnn/op_library/backward/backward_ops.cpp
+++ b/tt_eager/tt_dnn/op_library/backward/backward_ops.cpp
@@ -474,6 +474,7 @@ std::vector<Tensor> hardtanh_bw(
     return operation::decorate_as_composite(__func__, _hardtanh_bw)(grad, input, min, max, output_mem_config);
 }
 
+<<<<<<< HEAD
 // name: sin(Tensor self) -> Tensor
 // self: grad * self.cos()
 std::vector<Tensor> _sin_bw(const Tensor& grad, const Tensor& input_tensor, const MemoryConfig& output_mem_config) {
@@ -486,6 +487,8 @@ std::vector<Tensor> sin_bw(const Tensor& grad, const Tensor& input, const Memory
     return operation::decorate_as_composite(__func__, _sin_bw)(grad, input, output_mem_config);
 }
 
+=======
+>>>>>>> #10079: Merge sin_bw to TTNN
 // name: sinh(Tensor self) -> Tensor
 // self: grad * self.cosh()
 std::vector<Tensor> _sinh_bw(const Tensor& grad, const Tensor& input, const MemoryConfig& output_mem_config) {

--- a/tt_eager/tt_dnn/op_library/backward/backward_ops.cpp
+++ b/tt_eager/tt_dnn/op_library/backward/backward_ops.cpp
@@ -515,6 +515,7 @@ std::vector<Tensor> erfinv_bw(const Tensor& grad, const Tensor& input, const Mem
 }
 
 <<<<<<< HEAD
+<<<<<<< HEAD
 // bw(log10(in)) = grad/(in * 2.30258509299404568402)
 std::vector<Tensor> _log10_bw(const Tensor& grad, const Tensor& input, const MemoryConfig& output_mem_config) {
     std::vector<Tensor> grad_tensor;
@@ -567,6 +568,8 @@ std::vector<Tensor> log1p_bw(const Tensor& grad, const Tensor& input, const Memo
     return operation::decorate_as_composite(__func__, _log1p_bw)(grad, input, output_mem_config);
 }
 
+=======
+>>>>>>> #10079: Merge log1p_bw to TTNN
 std::vector<Tensor> _erf_bw(const Tensor& grad, const Tensor& input, const MemoryConfig& output_mem_config) {
     std::vector<Tensor> grad_tensor;
     Tensor result = ttnn::multiply(

--- a/tt_eager/tt_dnn/op_library/backward/backward_ops.hpp
+++ b/tt_eager/tt_dnn/op_library/backward/backward_ops.hpp
@@ -176,11 +176,6 @@ std::vector<Tensor> angle_bw(
     bool is_complextensor = true,
     const MemoryConfig& output_mem_config = operation::DEFAULT_OUTPUT_MEMORY_CONFIG);
 
-std::vector<Tensor> log1p_bw(
-    const Tensor& grad,
-    const Tensor& input,
-    const MemoryConfig& output_mem_config = operation::DEFAULT_OUTPUT_MEMORY_CONFIG);
-
 std::vector<Tensor> erf_bw(
     const Tensor& grad,
     const Tensor& input,

--- a/tt_eager/tt_dnn/op_library/backward/backward_ops.hpp
+++ b/tt_eager/tt_dnn/op_library/backward/backward_ops.hpp
@@ -176,11 +176,6 @@ std::vector<Tensor> angle_bw(
     bool is_complextensor = true,
     const MemoryConfig& output_mem_config = operation::DEFAULT_OUTPUT_MEMORY_CONFIG);
 
-std::vector<Tensor> sinh_bw(
-    const Tensor& grad,
-    const Tensor& input,
-    const MemoryConfig& output_mem_config = operation::DEFAULT_OUTPUT_MEMORY_CONFIG);
-
 std::vector<Tensor> log10_bw(
     const Tensor& grad,
     const Tensor& input,

--- a/tt_eager/tt_dnn/op_library/backward/backward_ops.hpp
+++ b/tt_eager/tt_dnn/op_library/backward/backward_ops.hpp
@@ -226,11 +226,6 @@ std::vector<Tensor> sign_bw(
     const Tensor& input,
     const MemoryConfig& output_mem_config = operation::DEFAULT_OUTPUT_MEMORY_CONFIG);
 
-std::vector<Tensor> ceil_bw(
-    const Tensor& grad,
-    const Tensor& input,
-    const MemoryConfig& output_mem_config = operation::DEFAULT_OUTPUT_MEMORY_CONFIG);
-
 std::vector<Tensor> log2_bw(
     const Tensor& grad,
     const Tensor& input,

--- a/tt_eager/tt_dnn/op_library/backward/backward_ops.hpp
+++ b/tt_eager/tt_dnn/op_library/backward/backward_ops.hpp
@@ -181,11 +181,6 @@ std::vector<Tensor> erf_bw(
     const Tensor& input,
     const MemoryConfig& output_mem_config = operation::DEFAULT_OUTPUT_MEMORY_CONFIG);
 
-std::vector<Tensor> erfc_bw(
-    const Tensor& grad,
-    const Tensor& input,
-    const MemoryConfig& output_mem_config = operation::DEFAULT_OUTPUT_MEMORY_CONFIG);
-
 std::vector<Tensor> digamma_bw(
     const Tensor& grad,
     const Tensor& input,

--- a/tt_eager/tt_dnn/op_library/backward/backward_ops.hpp
+++ b/tt_eager/tt_dnn/op_library/backward/backward_ops.hpp
@@ -216,11 +216,6 @@ std::vector<Tensor> logiteps_bw(
     float eps = 0.0f,
     const MemoryConfig& output_mem_config = operation::DEFAULT_OUTPUT_MEMORY_CONFIG);
 
-std::vector<Tensor> softsign_bw(
-    const Tensor& grad,
-    const Tensor& input,
-    const MemoryConfig& output_mem_config = operation::DEFAULT_OUTPUT_MEMORY_CONFIG);
-
 std::vector<Tensor> sign_bw(
     const Tensor& grad,
     const Tensor& input,

--- a/tt_eager/tt_dnn/op_library/backward/backward_ops.hpp
+++ b/tt_eager/tt_dnn/op_library/backward/backward_ops.hpp
@@ -176,11 +176,6 @@ std::vector<Tensor> angle_bw(
     bool is_complextensor = true,
     const MemoryConfig& output_mem_config = operation::DEFAULT_OUTPUT_MEMORY_CONFIG);
 
-std::vector<Tensor> sin_bw(
-    const Tensor& grad,
-    const Tensor& input,
-    const MemoryConfig& output_mem_config = operation::DEFAULT_OUTPUT_MEMORY_CONFIG);
-
 std::vector<Tensor> sinh_bw(
     const Tensor& grad,
     const Tensor& input,

--- a/tt_eager/tt_dnn/op_library/backward/backward_ops.hpp
+++ b/tt_eager/tt_dnn/op_library/backward/backward_ops.hpp
@@ -176,11 +176,6 @@ std::vector<Tensor> angle_bw(
     bool is_complextensor = true,
     const MemoryConfig& output_mem_config = operation::DEFAULT_OUTPUT_MEMORY_CONFIG);
 
-std::vector<Tensor> log10_bw(
-    const Tensor& grad,
-    const Tensor& input,
-    const MemoryConfig& output_mem_config = operation::DEFAULT_OUTPUT_MEMORY_CONFIG);
-
 std::vector<Tensor> log1p_bw(
     const Tensor& grad,
     const Tensor& input,

--- a/tt_eager/tt_lib/csrc/tt_lib_bindings_tensor_backward_ops.cpp
+++ b/tt_eager/tt_lib/csrc/tt_lib_bindings_tensor_backward_ops.cpp
@@ -451,22 +451,6 @@ namespace tt::tt_metal::detail{
                     "output_mem_config", "Layout of tensor in TT Accelerator device memory banks", "MemoryConfig", "Default is interleaved in DRAM", "No"
             )doc");
 
-    m_tensor.def("sin_bw", &tt::tt_metal::sin_bw,
-            py::arg("grad").noconvert(), py::arg("input").noconvert(), py::arg("output_mem_config").noconvert() = operation::DEFAULT_OUTPUT_MEMORY_CONFIG, R"doc(
-            Performs backward operations for sin of the ``input`` with given ``grad``
-
-            Input tensors must have BFLOAT16 data type.
-
-            Output tensor will have BFLOAT16 data type.
-
-            .. csv-table::
-                :header: "Argument", "Description", "Data type", "Valid range", "Required"
-
-                "grad", "Gradient tensor", "Tensor", "Tensor of shape [W, Z, Y, X]", "Yes"
-                "input", "Input Tensor", "Tensor", "Tensor of shape [W, Z, Y, X]", "Yes"
-                "output_mem_config", "Layout of tensor in TT Accelerator device memory banks", "MemoryConfig", "Default is interleaved in DRAM", "No"
-            )doc");
-
     m_tensor.def("sinh_bw", &tt::tt_metal::sinh_bw,
             py::arg("grad").noconvert(), py::arg("input").noconvert(), py::arg("output_mem_config").noconvert() = operation::DEFAULT_OUTPUT_MEMORY_CONFIG, R"doc(
             Performs backward operations for hyperbolic sin of ``input`` tensors with given ``grad``.

--- a/tt_eager/tt_lib/csrc/tt_lib_bindings_tensor_backward_ops.cpp
+++ b/tt_eager/tt_lib/csrc/tt_lib_bindings_tensor_backward_ops.cpp
@@ -585,22 +585,6 @@ namespace tt::tt_metal::detail{
                 "output_mem_config", "Layout of tensor in TT Accelerator device memory banks", "MemoryConfig", "Default is interleaved in DRAM", "No"
         )doc");
 
-    m_tensor.def("softsign_bw", &tt::tt_metal::softsign_bw,
-            py::arg("grad").noconvert(), py::arg("input").noconvert(), py::arg("output_mem_config").noconvert() = operation::DEFAULT_OUTPUT_MEMORY_CONFIG, R"doc(
-            Performs backward softsign operations on ``input`` tensors with given ``grad``.
-
-            Input tensors must have BFLOAT16 data type.
-
-            Output tensors will have BFLOAT16 data type.
-
-            .. csv-table::
-                :header: "Argument", "Description", "Data type", "Valid range", "Required"
-
-                "grad", "Gradient tensor", "Tensor", "Tensor of shape [W, Z, Y, X]", "Yes"
-                "input", "Tensor softsign_bw is applied to", "Tensor", "Tensor of shape [W, Z, Y, X]", "Yes"
-                "output_mem_config", "Layout of tensor in TT Accelerator device memory banks", "MemoryConfig", "Default is interleaved in DRAM", "No"
-        )doc");
-
     m_tensor.def("sign_bw", &tt::tt_metal::sign_bw,
             py::arg("grad").noconvert(), py::arg("input").noconvert(), py::arg("output_mem_config").noconvert() = operation::DEFAULT_OUTPUT_MEMORY_CONFIG, R"doc(
             Performs backward sign operations on ``input`` tensors with given ``grad``.

--- a/tt_eager/tt_lib/csrc/tt_lib_bindings_tensor_backward_ops.cpp
+++ b/tt_eager/tt_lib/csrc/tt_lib_bindings_tensor_backward_ops.cpp
@@ -451,23 +451,6 @@ namespace tt::tt_metal::detail{
                     "output_mem_config", "Layout of tensor in TT Accelerator device memory banks", "MemoryConfig", "Default is interleaved in DRAM", "No"
             )doc");
 
-    m_tensor.def("sinh_bw", &tt::tt_metal::sinh_bw,
-            py::arg("grad").noconvert(), py::arg("input").noconvert(), py::arg("output_mem_config").noconvert() = operation::DEFAULT_OUTPUT_MEMORY_CONFIG, R"doc(
-            Performs backward operations for hyperbolic sin of ``input`` tensors with given ``grad``.
-
-            Input tensors must have BFLOAT16 data type.
-
-            Output tensors will have BFLOAT16 data type.
-
-            .. csv-table::
-                :header: "Argument", "Description", "Data type", "Valid range", "Required"
-
-                "grad", "Gradient tensor", "Tensor", "Tensor of shape [W, Z, Y, X]", "Yes"
-                "input", "Input Tensor", "Tensor", "Tensor of shape [W, Z, Y, X]", "Yes"
-                "output_mem_config", "Layout of tensor in TT Accelerator device memory banks", "MemoryConfig", "Default is interleaved in DRAM", "No"
-        )doc");
-
-
      m_tensor.def("erfinv_bw", &tt::tt_metal::erfinv_bw,
             py::arg("grad").noconvert(), py::arg("input").noconvert(), py::arg("output_mem_config").noconvert() = operation::DEFAULT_OUTPUT_MEMORY_CONFIG, R"doc(
             Performs backward operations for erfinv of ``input`` tensor with given ``grad``.

--- a/tt_eager/tt_lib/csrc/tt_lib_bindings_tensor_backward_ops.cpp
+++ b/tt_eager/tt_lib/csrc/tt_lib_bindings_tensor_backward_ops.cpp
@@ -483,22 +483,6 @@ namespace tt::tt_metal::detail{
                 "output_mem_config", "Layout of tensor in TT Accelerator device memory banks", "MemoryConfig", "Default is interleaved in DRAM", "No"
         )doc");
 
-     m_tensor.def("erfc_bw", &tt::tt_metal::erfc_bw,
-            py::arg("grad").noconvert(), py::arg("input").noconvert(), py::arg("output_mem_config").noconvert() = operation::DEFAULT_OUTPUT_MEMORY_CONFIG, R"doc(
-            Performs backward operations for erfc of ``input`` tensor with given ``grad``.
-
-            Input tensors must have BFLOAT16 data type.
-
-            Output tensors will have BFLOAT16 data type.
-
-            .. csv-table::
-                :header: "Argument", "Description", "Data type", "Valid range", "Required"
-
-                "grad", "Gradient tensor", "Tensor", "Tensor of shape [W, Z, Y, X]", "Yes"
-                "input", "Input Tensor", "Tensor", "Tensor of shape [W, Z, Y, X]", "Yes"
-                "output_mem_config", "Layout of tensor in TT Accelerator device memory banks", "MemoryConfig", "Default is interleaved in DRAM", "No"
-        )doc");
-
     m_tensor.def("digamma_bw", &tt::tt_metal::digamma_bw,
             py::arg("grad").noconvert(), py::arg("input").noconvert(), py::arg("output_mem_config").noconvert() = operation::DEFAULT_OUTPUT_MEMORY_CONFIG, R"doc(
             Performs backward operations for digamma for the ``input`` with given ``grad``

--- a/tt_eager/tt_lib/csrc/tt_lib_bindings_tensor_backward_ops.cpp
+++ b/tt_eager/tt_lib/csrc/tt_lib_bindings_tensor_backward_ops.cpp
@@ -467,23 +467,6 @@ namespace tt::tt_metal::detail{
                 "output_mem_config", "Layout of tensor in TT Accelerator device memory banks", "MemoryConfig", "Default is interleaved in DRAM", "No"
         )doc");
 
-    m_tensor.def("log10_bw", &tt::tt_metal::log10_bw,
-            py::arg("grad").noconvert(), py::arg("input").noconvert(), py::arg("output_mem_config").noconvert() = operation::DEFAULT_OUTPUT_MEMORY_CONFIG, R"doc(
-            Performs backward operations for log10 of ``input`` tensors with given ``grad``.
-
-            Input tensors must have BFLOAT16 data type.
-
-            Output tensors will have BFLOAT16 data type.
-
-            .. csv-table::
-                :header: "Argument", "Description", "Data type", "Valid range", "Required"
-
-                "grad", "Gradient tensor", "Tensor", "Tensor of shape [W, Z, Y, X]", "Yes"
-                "input", "Input Tensor", "Tensor", "Tensor of shape [W, Z, Y, X]", "Yes"
-                "output_mem_config", "Layout of tensor in TT Accelerator device memory banks", "MemoryConfig", "Default is interleaved in DRAM", "No"
-        )doc");
-
-
     m_tensor.def("log1p_bw", &tt::tt_metal::log1p_bw,
             py::arg("grad").noconvert(), py::arg("input").noconvert(), py::arg("output_mem_config").noconvert() = operation::DEFAULT_OUTPUT_MEMORY_CONFIG, R"doc(
             Performs backward operations for log1p of ``input`` tensors with given ``grad``.

--- a/tt_eager/tt_lib/csrc/tt_lib_bindings_tensor_backward_ops.cpp
+++ b/tt_eager/tt_lib/csrc/tt_lib_bindings_tensor_backward_ops.cpp
@@ -617,22 +617,6 @@ namespace tt::tt_metal::detail{
                 "output_mem_config", "Layout of tensor in TT Accelerator device memory banks", "MemoryConfig", "Default is interleaved in DRAM", "No"
         )doc");
 
-    m_tensor.def("ceil_bw", &tt::tt_metal::ceil_bw,
-            py::arg("grad").noconvert(), py::arg("input").noconvert(), py::arg("output_mem_config").noconvert() = operation::DEFAULT_OUTPUT_MEMORY_CONFIG, R"doc(
-            Performs backward ceil operations on ``input`` tensors with given ``grad``.
-
-            Input tensors must have BFLOAT16 data type.
-
-            Output tensors will have BFLOAT16 data type.
-
-            .. csv-table::
-                :header: "Argument", "Description", "Data type", "Valid range", "Required"
-
-                "grad", "Gradient tensor", "Tensor", "Tensor of shape [W, Z, Y, X]", "Yes"
-                "input", "Tensor ceil_bw is applied to", "Tensor", "Tensor of shape [W, Z, Y, X]", "Yes"
-                "output_mem_config", "Layout of tensor in TT Accelerator device memory banks", "MemoryConfig", "Default is interleaved in DRAM", "No"
-        )doc");
-
     m_tensor.def("log2_bw", &tt::tt_metal::log2_bw,
             py::arg("grad").noconvert(), py::arg("input").noconvert(), py::arg("output_mem_config").noconvert() = operation::DEFAULT_OUTPUT_MEMORY_CONFIG, R"doc(
             Performs backward operations for log2 of ``input`` tensors with given ``grad``.

--- a/tt_eager/tt_lib/csrc/tt_lib_bindings_tensor_backward_ops.cpp
+++ b/tt_eager/tt_lib/csrc/tt_lib_bindings_tensor_backward_ops.cpp
@@ -467,22 +467,6 @@ namespace tt::tt_metal::detail{
                 "output_mem_config", "Layout of tensor in TT Accelerator device memory banks", "MemoryConfig", "Default is interleaved in DRAM", "No"
         )doc");
 
-    m_tensor.def("log1p_bw", &tt::tt_metal::log1p_bw,
-            py::arg("grad").noconvert(), py::arg("input").noconvert(), py::arg("output_mem_config").noconvert() = operation::DEFAULT_OUTPUT_MEMORY_CONFIG, R"doc(
-            Performs backward operations for log1p of ``input`` tensors with given ``grad``.
-
-            Input tensors must have BFLOAT16 data type.
-
-            Output tensors will have BFLOAT16 data type.
-
-            .. csv-table::
-                :header: "Argument", "Description", "Data type", "Valid range", "Required"
-
-                "grad", "Gradient tensor", "Tensor", "Tensor of shape [W, Z, Y, X]", "Yes"
-                "input", "Input Tensor", "Tensor", "Tensor of shape [W, Z, Y, X]", "Yes"
-                "output_mem_config", "Layout of tensor in TT Accelerator device memory banks", "MemoryConfig", "Default is interleaved in DRAM", "No"
-        )doc");
-
      m_tensor.def("erf_bw", &tt::tt_metal::erf_bw,
             py::arg("grad").noconvert(), py::arg("input").noconvert(), py::arg("output_mem_config").noconvert() = operation::DEFAULT_OUTPUT_MEMORY_CONFIG, R"doc(
             Performs backward operations for erf of ``input`` tensor with given ``grad``.

--- a/ttnn/cpp/ttnn/operations/eltwise/unary_backward/device/unary_backward_op.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary_backward/device/unary_backward_op.cpp
@@ -732,6 +732,25 @@ std::vector<Tensor> _sinh_bw(const Tensor& grad, const Tensor& input, const Memo
     return grad_tensor;
 }
 
+// bw(log10(in)) = grad/(in * 2.30258509299404568402)
+std::vector<Tensor> _log10_bw(const Tensor& grad, const Tensor& input, const MemoryConfig& output_mem_config) {
+    std::vector<Tensor> grad_tensor;
+    Tensor t_inf = where(
+        ttnn::ltz(grad, output_mem_config),
+        -std::numeric_limits<float>::infinity(),
+        std::numeric_limits<float>::infinity(),
+        output_mem_config);
+    Tensor grad_a = ttnn::multiply(
+        grad, ttnn::reciprocal(ttnn::multiply(input, M_LN10, std::nullopt, output_mem_config), output_mem_config), std::nullopt, output_mem_config);
+    grad_a = where(
+        ttnn::logical_and(eqz(input, output_mem_config), ttnn::eqz(grad, output_mem_config), std::nullopt, output_mem_config),
+        std::nanf(" "),
+        where(ttnn::eqz(input, output_mem_config), t_inf, grad_a, output_mem_config),
+        output_mem_config);
+    grad_tensor.emplace_back(grad_a);
+    return grad_tensor;
+}
+
 std::function<std::vector<ttnn::Tensor>(const Tensor&, const Tensor&, const MemoryConfig&)> UnaryBackwardFunction::get_function_type1(UnaryBackwardOpType OpType){
     switch (OpType) {
         case UnaryBackwardOpType::ASSIGN_BW:
@@ -806,6 +825,8 @@ std::function<std::vector<ttnn::Tensor>(const Tensor&, const Tensor&, const Memo
             return _sin_bw;
         case UnaryBackwardOpType::SINH_BW:
             return _sinh_bw;
+        case UnaryBackwardOpType::LOG10_BW:
+            return _log10_bw;
         default:
             TT_ASSERT(false && "Undefined op type");
             return 0;

--- a/ttnn/cpp/ttnn/operations/eltwise/unary_backward/device/unary_backward_op.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary_backward/device/unary_backward_op.cpp
@@ -790,6 +790,13 @@ std::vector<Tensor> _erfc_bw(const Tensor& grad, const Tensor& input, const Memo
     return grad_tensor;
 }
 
+std::vector<Tensor> _ceil_bw(const Tensor& grad, const Tensor& input, const MemoryConfig& output_mem_config) {
+    std::vector<Tensor> grad_tensor;
+    Tensor zero_grad = tt::tt_metal::zeros_like(grad, output_mem_config);
+    grad_tensor.emplace_back(zero_grad);
+    return grad_tensor;
+}
+
 std::function<std::vector<ttnn::Tensor>(const Tensor&, const Tensor&, const MemoryConfig&)> UnaryBackwardFunction::get_function_type1(UnaryBackwardOpType OpType){
     switch (OpType) {
         case UnaryBackwardOpType::ASSIGN_BW:
@@ -870,6 +877,8 @@ std::function<std::vector<ttnn::Tensor>(const Tensor&, const Tensor&, const Memo
             return _log1p_bw;
         case UnaryBackwardOpType::ERFC_BW:
             return _erfc_bw;
+        case UnaryBackwardOpType::CEIL_BW:
+            return _ceil_bw;
         default:
             TT_ASSERT(false && "Undefined op type");
             return 0;

--- a/ttnn/cpp/ttnn/operations/eltwise/unary_backward/device/unary_backward_op.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary_backward/device/unary_backward_op.cpp
@@ -704,6 +704,34 @@ std::vector<Tensor> _sin_bw(const Tensor& grad, const Tensor& input_tensor, cons
     return grad_tensor;
 }
 
+// name: sinh(Tensor self) -> Tensor
+// self: grad * self.cosh()
+std::vector<Tensor> _sinh_bw(const Tensor& grad, const Tensor& input, const MemoryConfig& output_mem_config) {
+    std::vector<Tensor> grad_tensor;
+    Tensor t_inf = ttnn::multiply(ttnn::sign(grad, output_mem_config), std::numeric_limits<float>::infinity(), std::nullopt, output_mem_config);
+    Tensor grad_a = where(
+        ttnn::gt(input, tt::tt_metal::full_like(input, 88.5, output_mem_config), std::nullopt, output_mem_config),
+        t_inf,
+        where(
+            ttnn::lt(input, tt::tt_metal::full_like(input, -88.5, output_mem_config), std::nullopt, output_mem_config),
+            t_inf,
+            ttnn::multiply(grad, cosh(input, output_mem_config), std::nullopt, output_mem_config),
+            output_mem_config),
+        output_mem_config);
+    t_inf.deallocate();
+    grad_a = where(
+        ttnn::ge(grad_a, 3.4e+38, std::nullopt, output_mem_config),
+        std::numeric_limits<float>::infinity(),
+        where(
+            ttnn::le(grad_a, -3.4e+38, std::nullopt, output_mem_config),
+            -std::numeric_limits<float>::infinity(),
+            grad_a,
+            output_mem_config),
+        output_mem_config);
+    grad_tensor.emplace_back(grad_a);
+    return grad_tensor;
+}
+
 std::function<std::vector<ttnn::Tensor>(const Tensor&, const Tensor&, const MemoryConfig&)> UnaryBackwardFunction::get_function_type1(UnaryBackwardOpType OpType){
     switch (OpType) {
         case UnaryBackwardOpType::ASSIGN_BW:
@@ -776,6 +804,8 @@ std::function<std::vector<ttnn::Tensor>(const Tensor&, const Tensor&, const Memo
             return _asinh_bw;
         case UnaryBackwardOpType::SIN_BW:
             return _sin_bw;
+        case UnaryBackwardOpType::SINH_BW:
+            return _sinh_bw;
         default:
             TT_ASSERT(false && "Undefined op type");
             return 0;

--- a/ttnn/cpp/ttnn/operations/eltwise/unary_backward/device/unary_backward_op.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary_backward/device/unary_backward_op.cpp
@@ -776,6 +776,20 @@ std::vector<Tensor> _log1p_bw(const Tensor& grad, const Tensor& input, const Mem
     return grad_tensor;
 }
 
+std::vector<Tensor> _erfc_bw(const Tensor& grad, const Tensor& input, const MemoryConfig& output_mem_config) {
+    std::vector<Tensor> grad_tensor;
+    Tensor result = ttnn::multiply(
+        ttnn::multiply(ttnn::exp(ttnn::neg(ttnn::square(input, output_mem_config), output_mem_config), false, output_mem_config),
+            grad,
+            std::nullopt,
+            output_mem_config),
+        -M_2_SQRTPI,
+        std::nullopt,
+        output_mem_config);
+    grad_tensor.emplace_back(result);
+    return grad_tensor;
+}
+
 std::function<std::vector<ttnn::Tensor>(const Tensor&, const Tensor&, const MemoryConfig&)> UnaryBackwardFunction::get_function_type1(UnaryBackwardOpType OpType){
     switch (OpType) {
         case UnaryBackwardOpType::ASSIGN_BW:
@@ -854,6 +868,8 @@ std::function<std::vector<ttnn::Tensor>(const Tensor&, const Tensor&, const Memo
             return _log10_bw;
         case UnaryBackwardOpType::LOG1P_BW:
             return _log1p_bw;
+        case UnaryBackwardOpType::ERFC_BW:
+            return _erfc_bw;
         default:
             TT_ASSERT(false && "Undefined op type");
             return 0;

--- a/ttnn/cpp/ttnn/operations/eltwise/unary_backward/device/unary_backward_op.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary_backward/device/unary_backward_op.cpp
@@ -695,6 +695,15 @@ std::vector<Tensor> _asinh_bw(const Tensor& grad, const Tensor& input, const Mem
     return grad_tensor;
 }
 
+// name: sin(Tensor self) -> Tensor
+// self: grad * self.cos()
+std::vector<Tensor> _sin_bw(const Tensor& grad, const Tensor& input_tensor, const MemoryConfig& output_mem_config) {
+    std::vector<Tensor> grad_tensor;
+    Tensor grad_input = ttnn::multiply(grad, ttnn::cos(input_tensor, output_mem_config), std::nullopt, output_mem_config);
+    grad_tensor.emplace_back(grad_input);
+    return grad_tensor;
+}
+
 std::function<std::vector<ttnn::Tensor>(const Tensor&, const Tensor&, const MemoryConfig&)> UnaryBackwardFunction::get_function_type1(UnaryBackwardOpType OpType){
     switch (OpType) {
         case UnaryBackwardOpType::ASSIGN_BW:
@@ -765,6 +774,8 @@ std::function<std::vector<ttnn::Tensor>(const Tensor&, const Tensor&, const Memo
             return _asin_bw;
         case UnaryBackwardOpType::ASINH_BW:
             return _asinh_bw;
+        case UnaryBackwardOpType::SIN_BW:
+            return _sin_bw;
         default:
             TT_ASSERT(false && "Undefined op type");
             return 0;

--- a/ttnn/cpp/ttnn/operations/eltwise/unary_backward/device/unary_backward_op.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary_backward/device/unary_backward_op.cpp
@@ -710,10 +710,10 @@ std::vector<Tensor> _sinh_bw(const Tensor& grad, const Tensor& input, const Memo
     std::vector<Tensor> grad_tensor;
     Tensor t_inf = ttnn::multiply(ttnn::sign(grad, output_mem_config), std::numeric_limits<float>::infinity(), std::nullopt, output_mem_config);
     Tensor grad_a = where(
-        ttnn::gt(input, tt::tt_metal::full_like(input, 88.5, output_mem_config), std::nullopt, output_mem_config),
+        ttnn::gt(input, ttnn::operations::creation::full_like(input, 88.5), std::nullopt, output_mem_config),
         t_inf,
         where(
-            ttnn::lt(input, tt::tt_metal::full_like(input, -88.5, output_mem_config), std::nullopt, output_mem_config),
+            ttnn::lt(input, ttnn::operations::creation::full_like(input, -88.5), std::nullopt, output_mem_config),
             t_inf,
             ttnn::multiply(grad, cosh(input, output_mem_config), std::nullopt, output_mem_config),
             output_mem_config),
@@ -743,7 +743,7 @@ std::vector<Tensor> _log10_bw(const Tensor& grad, const Tensor& input, const Mem
     Tensor grad_a = ttnn::multiply(
         grad, ttnn::reciprocal(ttnn::multiply(input, M_LN10, std::nullopt, output_mem_config), output_mem_config), std::nullopt, output_mem_config);
     grad_a = where(
-        ttnn::logical_and(eqz(input, output_mem_config), ttnn::eqz(grad, output_mem_config), std::nullopt, output_mem_config),
+        ttnn::logical_and(ttnn::eqz(input, output_mem_config), ttnn::eqz(grad, output_mem_config), std::nullopt, output_mem_config),
         std::nanf(" "),
         where(ttnn::eqz(input, output_mem_config), t_inf, grad_a, output_mem_config),
         output_mem_config);
@@ -763,7 +763,7 @@ std::vector<Tensor> _log1p_bw(const Tensor& grad, const Tensor& input, const Mem
     Tensor t_inp1 = ttnn::add(input, 1.0f, std::nullopt, output_mem_config);
     Tensor grad_a = ttnn::multiply(grad, ttnn::reciprocal(t_inp1, output_mem_config), std::nullopt, output_mem_config);
     grad_a = where(
-        ttnn::eq(input, tt::tt_metal::full_like(input, -1.0, output_mem_config), std::nullopt, output_mem_config),
+        ttnn::eq(input, ttnn::operations::creation::full_like(input, -1.0), std::nullopt, output_mem_config),
         t_inf,
         grad_a,
         output_mem_config);
@@ -792,7 +792,7 @@ std::vector<Tensor> _erfc_bw(const Tensor& grad, const Tensor& input, const Memo
 
 std::vector<Tensor> _ceil_bw(const Tensor& grad, const Tensor& input, const MemoryConfig& output_mem_config) {
     std::vector<Tensor> grad_tensor;
-    Tensor zero_grad = tt::tt_metal::zeros_like(grad, output_mem_config);
+    Tensor zero_grad = ttnn::operations::creation::zeros_like(grad);
     grad_tensor.emplace_back(zero_grad);
     return grad_tensor;
 }

--- a/ttnn/cpp/ttnn/operations/eltwise/unary_backward/device/unary_backward_op.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary_backward/device/unary_backward_op.hpp
@@ -63,6 +63,7 @@ enum class UnaryBackwardOpType {
     SIN_BW,
     SINH_BW,
     LOG10_BW,
+    LOG1P_BW,
 };
 
 struct UnaryBackwardFunction{

--- a/ttnn/cpp/ttnn/operations/eltwise/unary_backward/device/unary_backward_op.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary_backward/device/unary_backward_op.hpp
@@ -61,6 +61,7 @@ enum class UnaryBackwardOpType {
     ASIN_BW,
     ASINH_BW
     SIN_BW,
+    SINH_BW,
 };
 
 struct UnaryBackwardFunction{

--- a/ttnn/cpp/ttnn/operations/eltwise/unary_backward/device/unary_backward_op.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary_backward/device/unary_backward_op.hpp
@@ -62,6 +62,7 @@ enum class UnaryBackwardOpType {
     ASINH_BW
     SIN_BW,
     SINH_BW,
+    LOG10_BW,
 };
 
 struct UnaryBackwardFunction{

--- a/ttnn/cpp/ttnn/operations/eltwise/unary_backward/device/unary_backward_op.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary_backward/device/unary_backward_op.hpp
@@ -59,7 +59,7 @@ enum class UnaryBackwardOpType {
     TANHSHRINK_BW,
     ATANH_BW,
     ASIN_BW,
-    ASINH_BW
+    ASINH_BW,
     SIN_BW,
     SINH_BW,
     LOG10_BW,

--- a/ttnn/cpp/ttnn/operations/eltwise/unary_backward/device/unary_backward_op.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary_backward/device/unary_backward_op.hpp
@@ -65,6 +65,7 @@ enum class UnaryBackwardOpType {
     LOG10_BW,
     LOG1P_BW,
     ERFC_BW,
+    CEIL_BW,
 };
 
 struct UnaryBackwardFunction{

--- a/ttnn/cpp/ttnn/operations/eltwise/unary_backward/device/unary_backward_op.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary_backward/device/unary_backward_op.hpp
@@ -60,6 +60,7 @@ enum class UnaryBackwardOpType {
     ATANH_BW,
     ASIN_BW,
     ASINH_BW
+    SIN_BW,
 };
 
 struct UnaryBackwardFunction{

--- a/ttnn/cpp/ttnn/operations/eltwise/unary_backward/device/unary_backward_op.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary_backward/device/unary_backward_op.hpp
@@ -66,6 +66,7 @@ enum class UnaryBackwardOpType {
     LOG1P_BW,
     ERFC_BW,
     CEIL_BW,
+    SOFTSIGN_BW,
 };
 
 struct UnaryBackwardFunction{

--- a/ttnn/cpp/ttnn/operations/eltwise/unary_backward/device/unary_backward_op.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary_backward/device/unary_backward_op.hpp
@@ -64,6 +64,7 @@ enum class UnaryBackwardOpType {
     SINH_BW,
     LOG10_BW,
     LOG1P_BW,
+    ERFC_BW,
 };
 
 struct UnaryBackwardFunction{

--- a/ttnn/cpp/ttnn/operations/eltwise/unary_backward/unary_backward.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary_backward/unary_backward.hpp
@@ -116,5 +116,6 @@ constexpr auto sin_bw = ttnn::register_operation<operations::unary_backward::Exe
 constexpr auto sinh_bw = ttnn::register_operation<operations::unary_backward::ExecuteUnaryBackward<operations::unary_backward::UnaryBackwardOpType::SINH_BW>>("ttnn::sinh_bw");
 constexpr auto log10_bw = ttnn::register_operation<operations::unary_backward::ExecuteUnaryBackward<operations::unary_backward::UnaryBackwardOpType::LOG10_BW>>("ttnn::log10_bw");
 constexpr auto log1p_bw = ttnn::register_operation<operations::unary_backward::ExecuteUnaryBackward<operations::unary_backward::UnaryBackwardOpType::LOG1P_BW>>("ttnn::log1p_bw");
+constexpr auto erfc_bw = ttnn::register_operation<operations::unary_backward::ExecuteUnaryBackward<operations::unary_backward::UnaryBackwardOpType::ERFC_BW>>("ttnn::erfc_bw");
 
 }  // namespace ttnn

--- a/ttnn/cpp/ttnn/operations/eltwise/unary_backward/unary_backward.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary_backward/unary_backward.hpp
@@ -118,5 +118,6 @@ constexpr auto log10_bw = ttnn::register_operation<operations::unary_backward::E
 constexpr auto log1p_bw = ttnn::register_operation<operations::unary_backward::ExecuteUnaryBackward<operations::unary_backward::UnaryBackwardOpType::LOG1P_BW>>("ttnn::log1p_bw");
 constexpr auto erfc_bw = ttnn::register_operation<operations::unary_backward::ExecuteUnaryBackward<operations::unary_backward::UnaryBackwardOpType::ERFC_BW>>("ttnn::erfc_bw");
 constexpr auto ceil_bw = ttnn::register_operation<operations::unary_backward::ExecuteUnaryBackward<operations::unary_backward::UnaryBackwardOpType::CEIL_BW>>("ttnn::ceil_bw");
+constexpr auto softsign_bw = ttnn::register_operation<operations::unary_backward::ExecuteUnaryBackward<operations::unary_backward::UnaryBackwardOpType::SOFTSIGN_BW>>("ttnn::softsign_bw");
 
 }  // namespace ttnn

--- a/ttnn/cpp/ttnn/operations/eltwise/unary_backward/unary_backward.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary_backward/unary_backward.hpp
@@ -114,5 +114,6 @@ constexpr auto asin_bw = ttnn::register_operation<operations::unary_backward::Ex
 constexpr auto asinh_bw = ttnn::register_operation<operations::unary_backward::ExecuteUnaryBackward<operations::unary_backward::UnaryBackwardOpType::ASINH_BW>>("ttnn::asinh_bw");
 constexpr auto sin_bw = ttnn::register_operation<operations::unary_backward::ExecuteUnaryBackward<operations::unary_backward::UnaryBackwardOpType::SIN_BW>>("ttnn::sin_bw");
 constexpr auto sinh_bw = ttnn::register_operation<operations::unary_backward::ExecuteUnaryBackward<operations::unary_backward::UnaryBackwardOpType::SINH_BW>>("ttnn::sinh_bw");
+constexpr auto log10_bw = ttnn::register_operation<operations::unary_backward::ExecuteUnaryBackward<operations::unary_backward::UnaryBackwardOpType::LOG10_BW>>("ttnn::log10_bw");
 
 }  // namespace ttnn

--- a/ttnn/cpp/ttnn/operations/eltwise/unary_backward/unary_backward.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary_backward/unary_backward.hpp
@@ -115,5 +115,6 @@ constexpr auto asinh_bw = ttnn::register_operation<operations::unary_backward::E
 constexpr auto sin_bw = ttnn::register_operation<operations::unary_backward::ExecuteUnaryBackward<operations::unary_backward::UnaryBackwardOpType::SIN_BW>>("ttnn::sin_bw");
 constexpr auto sinh_bw = ttnn::register_operation<operations::unary_backward::ExecuteUnaryBackward<operations::unary_backward::UnaryBackwardOpType::SINH_BW>>("ttnn::sinh_bw");
 constexpr auto log10_bw = ttnn::register_operation<operations::unary_backward::ExecuteUnaryBackward<operations::unary_backward::UnaryBackwardOpType::LOG10_BW>>("ttnn::log10_bw");
+constexpr auto log1p_bw = ttnn::register_operation<operations::unary_backward::ExecuteUnaryBackward<operations::unary_backward::UnaryBackwardOpType::LOG1P_BW>>("ttnn::log1p_bw");
 
 }  // namespace ttnn

--- a/ttnn/cpp/ttnn/operations/eltwise/unary_backward/unary_backward.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary_backward/unary_backward.hpp
@@ -113,5 +113,6 @@ constexpr auto atanh_bw = ttnn::register_operation<operations::unary_backward::E
 constexpr auto asin_bw = ttnn::register_operation<operations::unary_backward::ExecuteUnaryBackward<operations::unary_backward::UnaryBackwardOpType::ASIN_BW>>("ttnn::asin_bw");
 constexpr auto asinh_bw = ttnn::register_operation<operations::unary_backward::ExecuteUnaryBackward<operations::unary_backward::UnaryBackwardOpType::ASINH_BW>>("ttnn::asinh_bw");
 constexpr auto sin_bw = ttnn::register_operation<operations::unary_backward::ExecuteUnaryBackward<operations::unary_backward::UnaryBackwardOpType::SIN_BW>>("ttnn::sin_bw");
+constexpr auto sinh_bw = ttnn::register_operation<operations::unary_backward::ExecuteUnaryBackward<operations::unary_backward::UnaryBackwardOpType::SINH_BW>>("ttnn::sinh_bw");
 
 }  // namespace ttnn

--- a/ttnn/cpp/ttnn/operations/eltwise/unary_backward/unary_backward.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary_backward/unary_backward.hpp
@@ -112,5 +112,6 @@ constexpr auto tanhshrink_bw = ttnn::register_operation<operations::unary_backwa
 constexpr auto atanh_bw = ttnn::register_operation<operations::unary_backward::ExecuteUnaryBackward<operations::unary_backward::UnaryBackwardOpType::ATANH_BW>>("ttnn::atanh_bw");
 constexpr auto asin_bw = ttnn::register_operation<operations::unary_backward::ExecuteUnaryBackward<operations::unary_backward::UnaryBackwardOpType::ASIN_BW>>("ttnn::asin_bw");
 constexpr auto asinh_bw = ttnn::register_operation<operations::unary_backward::ExecuteUnaryBackward<operations::unary_backward::UnaryBackwardOpType::ASINH_BW>>("ttnn::asinh_bw");
+constexpr auto sin_bw = ttnn::register_operation<operations::unary_backward::ExecuteUnaryBackward<operations::unary_backward::UnaryBackwardOpType::SIN_BW>>("ttnn::sin_bw");
 
 }  // namespace ttnn

--- a/ttnn/cpp/ttnn/operations/eltwise/unary_backward/unary_backward.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary_backward/unary_backward.hpp
@@ -117,5 +117,6 @@ constexpr auto sinh_bw = ttnn::register_operation<operations::unary_backward::Ex
 constexpr auto log10_bw = ttnn::register_operation<operations::unary_backward::ExecuteUnaryBackward<operations::unary_backward::UnaryBackwardOpType::LOG10_BW>>("ttnn::log10_bw");
 constexpr auto log1p_bw = ttnn::register_operation<operations::unary_backward::ExecuteUnaryBackward<operations::unary_backward::UnaryBackwardOpType::LOG1P_BW>>("ttnn::log1p_bw");
 constexpr auto erfc_bw = ttnn::register_operation<operations::unary_backward::ExecuteUnaryBackward<operations::unary_backward::UnaryBackwardOpType::ERFC_BW>>("ttnn::erfc_bw");
+constexpr auto ceil_bw = ttnn::register_operation<operations::unary_backward::ExecuteUnaryBackward<operations::unary_backward::UnaryBackwardOpType::CEIL_BW>>("ttnn::ceil_bw");
 
 }  // namespace ttnn

--- a/ttnn/cpp/ttnn/operations/eltwise/unary_backward/unary_backward_pybind.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary_backward/unary_backward_pybind.hpp
@@ -414,6 +414,12 @@ void py_module(py::module& module) {
          ttnn::log10_bw,
          R"doc(Performs backward operations for log10 on :attr:`input_tensor` with given :attr:`grad_tensor`)doc");
 
+    detail::bind_unary_backward(
+         module,
+         ttnn::log1p_bw,
+         R"doc(Performs backward operations for log1p on :attr:`input_tensor` with given :attr:`grad_tensor`)doc");
+
+
 
 }
 

--- a/ttnn/cpp/ttnn/operations/eltwise/unary_backward/unary_backward_pybind.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary_backward/unary_backward_pybind.hpp
@@ -405,30 +405,34 @@ void py_module(py::module& module) {
         R"doc(Performs backward operations for sin on :attr:`input_tensor` with given :attr:`grad_tensor`)doc");
 
     detail::bind_unary_backward(
-         module,
-         ttnn::sinh_bw,
-         R"doc(Performs backward operations for sinh on :attr:`input_tensor` with given :attr:`grad_tensor`)doc");
+        module,
+        ttnn::sinh_bw,
+        R"doc(Performs backward operations for sinh on :attr:`input_tensor` with given :attr:`grad_tensor`)doc");
 
     detail::bind_unary_backward(
-         module,
-         ttnn::log10_bw,
-         R"doc(Performs backward operations for log10 on :attr:`input_tensor` with given :attr:`grad_tensor`)doc");
+        module,
+        ttnn::log10_bw,
+        R"doc(Performs backward operations for log10 on :attr:`input_tensor` with given :attr:`grad_tensor`)doc");
 
     detail::bind_unary_backward(
-         module,
-         ttnn::log1p_bw,
-         R"doc(Performs backward operations for log1p on :attr:`input_tensor` with given :attr:`grad_tensor`)doc");
+        module,
+        ttnn::log1p_bw,
+        R"doc(Performs backward operations for log1p on :attr:`input_tensor` with given :attr:`grad_tensor`)doc");
 
     detail::bind_unary_backward(
-         module,
-         ttnn::erfc_bw,
-         R"doc(Performs backward operations for erfc on :attr:`input_tensor` with given :attr:`grad_tensor`)doc");
+        module,
+        ttnn::erfc_bw,
+        R"doc(Performs backward operations for erfc on :attr:`input_tensor` with given :attr:`grad_tensor`)doc");
 
     detail::bind_unary_backward(
-         module,
-         ttnn::ceil_bw,
-         R"doc(Performs backward operations for ceil on :attr:`input_tensor` with given :attr:`grad_tensor`)doc");
+        module,
+        ttnn::ceil_bw,
+        R"doc(Performs backward operations for ceil on :attr:`input_tensor` with given :attr:`grad_tensor`)doc");
 
+    detail::bind_unary_backward(
+        module,
+        ttnn::softsign_bw,
+        R"doc(Performs backward operations for softsign on :attr:`input_tensor` with given :attr:`grad_tensor`)doc");
 
 }
 

--- a/ttnn/cpp/ttnn/operations/eltwise/unary_backward/unary_backward_pybind.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary_backward/unary_backward_pybind.hpp
@@ -424,6 +424,10 @@ void py_module(py::module& module) {
          ttnn::erfc_bw,
          R"doc(Performs backward operations for erfc on :attr:`input_tensor` with given :attr:`grad_tensor`)doc");
 
+    detail::bind_unary_backward(
+         module,
+         ttnn::ceil_bw,
+         R"doc(Performs backward operations for ceil on :attr:`input_tensor` with given :attr:`grad_tensor`)doc");
 
 
 }

--- a/ttnn/cpp/ttnn/operations/eltwise/unary_backward/unary_backward_pybind.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary_backward/unary_backward_pybind.hpp
@@ -419,6 +419,11 @@ void py_module(py::module& module) {
          ttnn::log1p_bw,
          R"doc(Performs backward operations for log1p on :attr:`input_tensor` with given :attr:`grad_tensor`)doc");
 
+    detail::bind_unary_backward(
+         module,
+         ttnn::erfc_bw,
+         R"doc(Performs backward operations for erfc on :attr:`input_tensor` with given :attr:`grad_tensor`)doc");
+
 
 
 }

--- a/ttnn/cpp/ttnn/operations/eltwise/unary_backward/unary_backward_pybind.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary_backward/unary_backward_pybind.hpp
@@ -398,6 +398,11 @@ void py_module(py::module& module) {
         module,
         ttnn::asinh_bw,
         R"doc(Performs backward operations for  asinh on :attr:`input_tensor` with given :attr:`grad_tensor`)doc");
+         
+    detail::bind_unary_backward(
+        module,
+        ttnn::sin_bw,
+        R"doc(Performs backward operations for sin on :attr:`input_tensor` with given :attr:`grad_tensor`)doc");
 
 }
 

--- a/ttnn/cpp/ttnn/operations/eltwise/unary_backward/unary_backward_pybind.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary_backward/unary_backward_pybind.hpp
@@ -409,6 +409,12 @@ void py_module(py::module& module) {
          ttnn::sinh_bw,
          R"doc(Performs backward operations for sinh on :attr:`input_tensor` with given :attr:`grad_tensor`)doc");
 
+    detail::bind_unary_backward(
+         module,
+         ttnn::log10_bw,
+         R"doc(Performs backward operations for log10 on :attr:`input_tensor` with given :attr:`grad_tensor`)doc");
+
+
 }
 
 }  // namespace binary_backward

--- a/ttnn/cpp/ttnn/operations/eltwise/unary_backward/unary_backward_pybind.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary_backward/unary_backward_pybind.hpp
@@ -404,6 +404,11 @@ void py_module(py::module& module) {
         ttnn::sin_bw,
         R"doc(Performs backward operations for sin on :attr:`input_tensor` with given :attr:`grad_tensor`)doc");
 
+    detail::bind_unary_backward(
+         module,
+         ttnn::sinh_bw,
+         R"doc(Performs backward operations for sinh on :attr:`input_tensor` with given :attr:`grad_tensor`)doc");
+
 }
 
 }  // namespace binary_backward


### PR DESCRIPTION
Issue : #10079 [ Unary Backward Tracking Issue : #9874 , Master issue : #9322 ]

### Work Done : 

- Migrated 7 unary backward ops to TTNN
- Moved test files to TTNN at `tests/ttnn/unit_tests/operations/backward/test_backward_*.py`

### List of ops completed
- [x] sin_bw
- [x] sinh_bw
- [x] log10_bw
- [x] log1p_bw
- [x] erfc_bw
- [x] ceil_bw
- [x] softsign_bw

**Test files**
- sin_bw : `tests/ttnn/unit_tests/operations/backward/test_backward_sin.py`
- sinh_bw : `tests/ttnn/unit_tests/operations/backward/test_backward_sinh.py`
- log10_bw : `tests/ttnn/unit_tests/operations/backward/test_backward_log10.py`
- log1p_bw : `tests/ttnn/unit_tests/operations/backward/test_backward_log1p.py`
- erfc_bw : `tests/ttnn/unit_tests/operations/backward/test_backward_erfc.py`
- ceil_bw: `tests/ttnn/unit_tests/operations/backward/test_backward_ceil.py`
- softsign_bw: `tests/ttnn/unit_tests/operations/backward/test_backward_softsign.py`

**CI :** 

- [All post-commit tests](https://github.com/tenstorrent/tt-metal/actions/runs/9905691418)
- [[post-commit] Fast Dispatch unit tests](https://github.com/tenstorrent/tt-metal/actions/runs/9905698415)
- [[post-commit] Slow Dispatch unit tests](https://github.com/tenstorrent/tt-metal/actions/runs/9905701414)
