### PR TITLE
Migrate unary ops to TTNN

### DIFF
--- a/docs/source/ttnn/ttnn/api.rst
+++ b/docs/source/ttnn/ttnn/api.rst
@@ -224,6 +224,7 @@ Pointwise Unary
    ttnn/logiteps_bw
    ttnn/log2_bw
    ttnn/sign_bw
+   ttnn/fmod_bw
 
 Pointwise Binary
 ================

--- a/docs/source/ttnn/ttnn/api.rst
+++ b/docs/source/ttnn/ttnn/api.rst
@@ -225,6 +225,7 @@ Pointwise Unary
    ttnn/log2_bw
    ttnn/sign_bw
    ttnn/fmod_bw
+   ttnn/remainder_bw
 
 Pointwise Binary
 ================

--- a/docs/source/ttnn/ttnn/api.rst
+++ b/docs/source/ttnn/ttnn/api.rst
@@ -226,6 +226,7 @@ Pointwise Unary
    ttnn/sign_bw
    ttnn/fmod_bw
    ttnn/remainder_bw
+   ttnn/div_no_nan_bw
 
 Pointwise Binary
 ================

--- a/docs/source/ttnn/ttnn/api.rst
+++ b/docs/source/ttnn/ttnn/api.rst
@@ -220,6 +220,7 @@ Pointwise Unary
    ttnn/erfc_bw
    ttnn/ceil_bw
    ttnn/softsign_bw
+   ttnn/cosh_bw
 
 Pointwise Binary
 ================

--- a/docs/source/ttnn/ttnn/api.rst
+++ b/docs/source/ttnn/ttnn/api.rst
@@ -223,6 +223,7 @@ Pointwise Unary
    ttnn/cosh_bw
    ttnn/logiteps_bw
    ttnn/log2_bw
+   ttnn/sign_bw
 
 Pointwise Binary
 ================

--- a/docs/source/ttnn/ttnn/api.rst
+++ b/docs/source/ttnn/ttnn/api.rst
@@ -222,6 +222,7 @@ Pointwise Unary
    ttnn/softsign_bw
    ttnn/cosh_bw
    ttnn/logiteps_bw
+   ttnn/log2_bw
 
 Pointwise Binary
 ================

--- a/docs/source/ttnn/ttnn/api.rst
+++ b/docs/source/ttnn/ttnn/api.rst
@@ -221,6 +221,7 @@ Pointwise Unary
    ttnn/ceil_bw
    ttnn/softsign_bw
    ttnn/cosh_bw
+   ttnn/logiteps_bw
 
 Pointwise Binary
 ================

--- a/docs/source/ttnn/ttnn/dependencies/tt_lib.rst
+++ b/docs/source/ttnn/ttnn/dependencies/tt_lib.rst
@@ -858,8 +858,6 @@ Backward Operations
 
 .. autofunction:: tt_lib.tensor.le_bw
 
-.. autofunction:: tt_lib.tensor.unary_remainder_bw
-
 .. autofunction:: tt_lib.tensor.complex_recip_bw
 
 .. autofunction:: tt_lib.tensor.imag_bw

--- a/docs/source/ttnn/ttnn/dependencies/tt_lib.rst
+++ b/docs/source/ttnn/ttnn/dependencies/tt_lib.rst
@@ -854,8 +854,6 @@ Backward Operations
 
 .. autofunction:: tt_lib.tensor.threshold_bw
 
-.. autofunction:: tt_lib.tensor.sign_bw
-
 .. autofunction:: tt_lib.tensor.ge_bw
 
 .. autofunction:: tt_lib.tensor.le_bw

--- a/docs/source/ttnn/ttnn/dependencies/tt_lib.rst
+++ b/docs/source/ttnn/ttnn/dependencies/tt_lib.rst
@@ -856,8 +856,6 @@ Backward Operations
 
 .. autofunction:: tt_lib.tensor.sign_bw
 
-.. autofunction:: tt_lib.tensor.log2_bw
-
 .. autofunction:: tt_lib.tensor.ge_bw
 
 .. autofunction:: tt_lib.tensor.le_bw

--- a/docs/source/ttnn/ttnn/dependencies/tt_lib.rst
+++ b/docs/source/ttnn/ttnn/dependencies/tt_lib.rst
@@ -876,8 +876,6 @@ Backward Operations
 
 .. autofunction:: tt_lib.tensor.repeat_bw
 
-.. autofunction:: tt_lib.tensor.unary_div_no_nan_bw
-
 Loss Functions
 ==============
 

--- a/docs/source/ttnn/ttnn/dependencies/tt_lib.rst
+++ b/docs/source/ttnn/ttnn/dependencies/tt_lib.rst
@@ -854,8 +854,6 @@ Backward Operations
 
 .. autofunction:: tt_lib.tensor.threshold_bw
 
-.. autofunction:: tt_lib.tensor.logiteps_bw
-
 .. autofunction:: tt_lib.tensor.sign_bw
 
 .. autofunction:: tt_lib.tensor.log2_bw

--- a/docs/source/ttnn/ttnn/dependencies/tt_lib.rst
+++ b/docs/source/ttnn/ttnn/dependencies/tt_lib.rst
@@ -858,8 +858,6 @@ Backward Operations
 
 .. autofunction:: tt_lib.tensor.le_bw
 
-.. autofunction:: tt_lib.tensor.unary_fmod_bw
-
 .. autofunction:: tt_lib.tensor.unary_remainder_bw
 
 .. autofunction:: tt_lib.tensor.complex_recip_bw

--- a/docs/source/ttnn/ttnn/dependencies/tt_lib.rst
+++ b/docs/source/ttnn/ttnn/dependencies/tt_lib.rst
@@ -838,8 +838,6 @@ Backward Operations
 
 .. autofunction:: tt_lib.tensor.polygamma_bw
 
-.. autofunction:: tt_lib.tensor.cosh_bw
-
 .. autofunction:: tt_lib.tensor.erfinv_bw
 
 .. autofunction:: tt_lib.tensor.hardtanh_bw

--- a/docs/source/ttnn/ttnn/ttnn/cosh_bw.rst
+++ b/docs/source/ttnn/ttnn/ttnn/cosh_bw.rst
@@ -1,0 +1,6 @@
+.. _ttnn.cosh_bw:
+
+ttnn.cosh_bw
+###############
+
+.. autofunction:: ttnn.cosh_bw

--- a/docs/source/ttnn/ttnn/ttnn/div_no_nan_bw.rst
+++ b/docs/source/ttnn/ttnn/ttnn/div_no_nan_bw.rst
@@ -1,0 +1,6 @@
+.. _ttnn.div_no_nan_bw:
+
+ttnn.div_no_nan_bw
+####################
+
+.. autofunction:: ttnn.div_no_nan_bw

--- a/docs/source/ttnn/ttnn/ttnn/fmod_bw.rst
+++ b/docs/source/ttnn/ttnn/ttnn/fmod_bw.rst
@@ -1,0 +1,6 @@
+.. _ttnn.fmod_bw:
+
+ttnn.fmod_bw
+##############
+
+.. autofunction:: ttnn.fmod_bw

--- a/docs/source/ttnn/ttnn/ttnn/log2_bw.rst
+++ b/docs/source/ttnn/ttnn/ttnn/log2_bw.rst
@@ -1,0 +1,6 @@
+.. _ttnn.log2_bw:
+
+ttnn.log2_bw
+###############
+
+.. autofunction:: ttnn.log2_bw

--- a/docs/source/ttnn/ttnn/ttnn/logiteps_bw.rst
+++ b/docs/source/ttnn/ttnn/ttnn/logiteps_bw.rst
@@ -1,0 +1,6 @@
+.. _ttnn.logiteps_bw:
+
+ttnn.logiteps_bw
+##################
+
+.. autofunction:: ttnn.logiteps_bw

--- a/docs/source/ttnn/ttnn/ttnn/remainder_bw.rst
+++ b/docs/source/ttnn/ttnn/ttnn/remainder_bw.rst
@@ -1,0 +1,6 @@
+.. _ttnn.remainder_bw:
+
+ttnn.remainder_bw
+##################
+
+.. autofunction:: ttnn.remainder_bw

--- a/docs/source/ttnn/ttnn/ttnn/remainder_bw.rst
+++ b/docs/source/ttnn/ttnn/ttnn/remainder_bw.rst
@@ -3,4 +3,5 @@
 ttnn.remainder_bw
 ##################
 
+
 .. autofunction:: ttnn.remainder_bw

--- a/docs/source/ttnn/ttnn/ttnn/sign_bw.rst
+++ b/docs/source/ttnn/ttnn/ttnn/sign_bw.rst
@@ -1,0 +1,6 @@
+.. _ttnn.sign_bw:
+
+ttnn.sign_bw
+###############
+
+.. autofunction:: ttnn.sign_bw

--- a/tests/ttnn/unit_tests/operations/backward/test_backward_cosh.py
+++ b/tests/ttnn/unit_tests/operations/backward/test_backward_cosh.py
@@ -4,8 +4,8 @@
 
 import torch
 import pytest
-import tt_lib
-from tests.tt_eager.python_api_testing.unit_testing.backward_ops.utility_funcs import (
+import ttnn
+from tests.ttnn.unit_tests.operations.backward.utility_funcs import (
     data_gen_with_range,
     compare_pcc,
 )
@@ -26,7 +26,7 @@ def test_bw_cosh(input_shapes, device):
     in_data, input_tensor = data_gen_with_range(input_shapes, -9, 9, device, True)
     grad_data, grad_tensor = data_gen_with_range(input_shapes, -20, 20, device)
 
-    tt_output_tensor_on_device = tt_lib.tensor.cosh_bw(grad_tensor, input_tensor)
+    tt_output_tensor_on_device = ttnn.cosh_bw(grad_tensor, input_tensor)
 
     in_data.retain_grad()
 
@@ -52,7 +52,7 @@ def test_bw_cosh_inf(input_shapes, device):
     in_data, input_tensor = data_gen_with_range(input_shapes, 90, 95, device, True)
     grad_data, grad_tensor = data_gen_with_range(input_shapes, -7, 7, device)
 
-    tt_output_tensor_on_device = tt_lib.tensor.cosh_bw(grad_tensor, input_tensor)
+    tt_output_tensor_on_device = ttnn.cosh_bw(grad_tensor, input_tensor)
 
     in_data.retain_grad()
 
@@ -78,7 +78,7 @@ def test_bw_cosh_neg_inf(input_shapes, device):
     in_data, input_tensor = data_gen_with_range(input_shapes, -95, -89, device, True)
     grad_data, grad_tensor = data_gen_with_range(input_shapes, -7, 7, device)
 
-    tt_output_tensor_on_device = tt_lib.tensor.cosh_bw(grad_tensor, input_tensor)
+    tt_output_tensor_on_device = ttnn.cosh_bw(grad_tensor, input_tensor)
 
     in_data.retain_grad()
 
@@ -101,7 +101,7 @@ def test_bw_cosh_nan_test1(input_shapes, device):
     in_data, input_tensor = data_gen_with_range(input_shapes, 86, 89, device, True)
     grad_data, grad_tensor = data_gen_with_range(input_shapes, 35, 50, device)
 
-    tt_output_tensor_on_device = tt_lib.tensor.cosh_bw(grad_tensor, input_tensor)
+    tt_output_tensor_on_device = ttnn.cosh_bw(grad_tensor, input_tensor)
 
     in_data.retain_grad()
 
@@ -124,7 +124,7 @@ def test_bw_cosh_nan_test2(input_shapes, device):
     in_data, input_tensor = data_gen_with_range(input_shapes, 86, 89, device, True)
     grad_data, grad_tensor = data_gen_with_range(input_shapes, -50, -35, device)
 
-    tt_output_tensor_on_device = tt_lib.tensor.cosh_bw(grad_tensor, input_tensor)
+    tt_output_tensor_on_device = ttnn.cosh_bw(grad_tensor, input_tensor)
 
     in_data.retain_grad()
 

--- a/tests/ttnn/unit_tests/operations/backward/test_backward_div_no_nan.py
+++ b/tests/ttnn/unit_tests/operations/backward/test_backward_div_no_nan.py
@@ -4,8 +4,8 @@
 
 import torch
 import pytest
-import tt_lib
-from tests.tt_eager.python_api_testing.unit_testing.backward_ops.utility_funcs import compare_pcc, data_gen_with_range
+import ttnn
+from tests.ttnn.unit_tests.operations.backward.utility_funcs import compare_pcc, data_gen_with_range
 
 
 def torch_div_no_nan(input, scalar):
@@ -25,7 +25,7 @@ def test_bw_unary_div_no_nan(input_shapes, scalar, device):
     grad_data, grad_tensor = data_gen_with_range(input_shapes, -100, 199, device)
     in_data, input_tensor = data_gen_with_range(input_shapes, -200, 201, device, required_grad=True)
 
-    tt_output_tensor_on_device = tt_lib.tensor.unary_div_no_nan_bw(grad_tensor, input_tensor, scalar=scalar)
+    tt_output_tensor_on_device = ttnn.div_no_nan_bw(grad_tensor, input_tensor, scalar)
 
     in_data.retain_grad()
 

--- a/tests/ttnn/unit_tests/operations/backward/test_backward_fmod.py
+++ b/tests/ttnn/unit_tests/operations/backward/test_backward_fmod.py
@@ -4,8 +4,8 @@
 
 import torch
 import pytest
-import tt_lib
-from tests.tt_eager.python_api_testing.unit_testing.backward_ops.utility_funcs import compare_pcc, data_gen_with_range
+import ttnn
+from tests.ttnn.unit_tests.operations.backward.utility_funcs import compare_pcc, data_gen_with_range
 
 
 @pytest.mark.parametrize(
@@ -30,7 +30,7 @@ def test_bw_unary_fmod(input_shapes, scalar, device):
 
     pyt_y = torch.fmod(in_data, scalar)
 
-    tt_output_tensor_on_device = tt_lib.tensor.unary_fmod_bw(grad_tensor, input_tensor, scalar)
+    tt_output_tensor_on_device = ttnn.fmod_bw(grad_tensor, input_tensor, scalar)
 
     in_data.retain_grad()
 

--- a/tests/ttnn/unit_tests/operations/backward/test_backward_log2.py
+++ b/tests/ttnn/unit_tests/operations/backward/test_backward_log2.py
@@ -4,8 +4,8 @@
 
 import torch
 import pytest
-import tt_lib
-from tests.tt_eager.python_api_testing.unit_testing.backward_ops.utility_funcs import (
+import ttnn
+from tests.ttnn.unit_tests.operations.backward.utility_funcs import (
     compare_pcc,
     data_gen_with_range,
 )
@@ -23,7 +23,7 @@ def test_bw_log2(input_shapes, device):
     in_data, input_tensor = data_gen_with_range(input_shapes, -100, 100, device, True)
     grad_data, grad_tensor = data_gen_with_range(input_shapes, -10, 10, device)
 
-    tt_output_tensor_on_device = tt_lib.tensor.log2_bw(grad_tensor, input_tensor)
+    tt_output_tensor_on_device = ttnn.log2_bw(grad_tensor, input_tensor)
 
     in_data.retain_grad()
 

--- a/tests/ttnn/unit_tests/operations/backward/test_backward_logiteps.py
+++ b/tests/ttnn/unit_tests/operations/backward/test_backward_logiteps.py
@@ -4,8 +4,8 @@
 
 import torch
 import pytest
-import tt_lib
-from tests.tt_eager.python_api_testing.unit_testing.backward_ops.utility_funcs import (
+import ttnn
+from tests.ttnn.unit_tests.operations.backward.utility_funcs import (
     data_gen_with_range,
     data_gen_with_val,
     compare_pcc,
@@ -27,7 +27,7 @@ from tests.tt_eager.python_api_testing.unit_testing.backward_ops.utility_funcs i
 def test_bw_logiteps(input_shapes, eps, device):
     in_data, input_tensor = data_gen_with_range(input_shapes, -2, 2, device, True)
     grad_data, grad_tensor = data_gen_with_range(input_shapes, -5, 5, device)
-    tt_output_tensor_on_device = tt_lib.tensor.logiteps_bw(grad_tensor, input_tensor, eps=eps)
+    tt_output_tensor_on_device = ttnn.logiteps_bw(grad_tensor, input_tensor, eps)
     in_data.retain_grad()
 
     pyt_y = torch.logit(in_data, eps=eps)

--- a/tests/ttnn/unit_tests/operations/backward/test_backward_remainder.py
+++ b/tests/ttnn/unit_tests/operations/backward/test_backward_remainder.py
@@ -4,8 +4,8 @@
 
 import torch
 import pytest
-import tt_lib
-from tests.tt_eager.python_api_testing.unit_testing.backward_ops.utility_funcs import compare_pcc, data_gen_with_range
+import ttnn
+from tests.ttnn.unit_tests.operations.backward.utility_funcs import compare_pcc, data_gen_with_range
 
 
 @pytest.mark.parametrize(
@@ -31,7 +31,7 @@ def test_bw_unary_remainder(input_shapes, scalar, device):
 
     pyt_y = torch.remainder(in_data, scalar)
 
-    tt_output_tensor_on_device = tt_lib.tensor.unary_remainder_bw(grad_tensor, input_tensor, scalar)
+    tt_output_tensor_on_device = ttnn.remainder_bw(grad_tensor, input_tensor, scalar)
 
     in_data.retain_grad()
 

--- a/tests/ttnn/unit_tests/operations/backward/test_backward_sign.py
+++ b/tests/ttnn/unit_tests/operations/backward/test_backward_sign.py
@@ -4,7 +4,7 @@
 
 import torch
 import pytest
-import tt_lib
+import ttnn
 from tests.ttnn.unit_tests.operations.backward.utility_funcs import compare_pcc, data_gen_with_range
 
 

--- a/tests/ttnn/unit_tests/operations/backward/test_backward_sign.py
+++ b/tests/ttnn/unit_tests/operations/backward/test_backward_sign.py
@@ -5,7 +5,7 @@
 import torch
 import pytest
 import tt_lib
-from tests.tt_eager.python_api_testing.unit_testing.backward_ops.utility_funcs import compare_pcc, data_gen_with_range
+from tests.ttnn.unit_tests.operations.backward.utility_funcs import compare_pcc, data_gen_with_range
 
 
 @pytest.mark.parametrize(
@@ -21,7 +21,7 @@ def test_bw_sign(input_shapes, device):
     in_data, input_tensor = data_gen_with_range(input_shapes, -100, 100, device, True)
 
     pyt_y = torch.sign(in_data)
-    tt_output_tensor_on_device = tt_lib.tensor.sign_bw(grad_tensor, input_tensor)
+    tt_output_tensor_on_device = ttnn.sign_bw(grad_tensor, input_tensor)
 
     in_data.retain_grad()
 

--- a/tt_eager/tt_dnn/op_library/backward/backward_ops.cpp
+++ b/tt_eager/tt_dnn/op_library/backward/backward_ops.cpp
@@ -421,39 +421,6 @@ std::vector<Tensor> polygamma_bw(
     return operation::decorate_as_composite(__func__, _polygamma_bw)(grad, input, n, output_mem_config);
 }
 
-// name: cosh(Tensor self) -> Tensor
-// self: grad * self.sinh()
-std::vector<Tensor> _cosh_bw(const Tensor& grad, const Tensor& input, const MemoryConfig& output_mem_config) {
-    std::vector<Tensor> grad_tensor;
-    Tensor t_inf = ttnn::multiply(ttnn::sign(grad, output_mem_config), std::numeric_limits<float>::infinity(), std::nullopt, output_mem_config);
-    Tensor t_neg_inf =
-        ttnn::multiply(ttnn::sign(grad, output_mem_config), -std::numeric_limits<float>::infinity(), std::nullopt, output_mem_config);
-    Tensor grad_a = where(
-        ttnn::gt(input, full_like(input, 88.50, output_mem_config), std::nullopt, output_mem_config),
-        t_inf,
-        where(
-            ttnn::lt(input, full_like(input, -88.50, output_mem_config), std::nullopt, output_mem_config),
-            t_neg_inf,
-            ttnn::multiply(grad, sinh(input, output_mem_config), std::nullopt, output_mem_config),
-            output_mem_config),
-        output_mem_config);
-    t_neg_inf.deallocate();
-    t_inf.deallocate();
-    grad_a = where(
-        ttnn::ge(grad_a, 3.4e+38, std::nullopt, output_mem_config),
-        std::numeric_limits<float>::infinity(),
-        where(
-            ttnn::le(grad_a, -3.4e+38, std::nullopt, output_mem_config),
-            -std::numeric_limits<float>::infinity(),
-            grad_a,
-            output_mem_config),
-        output_mem_config);
-    grad_tensor.emplace_back(grad_a);
-    return grad_tensor;
-}
-std::vector<Tensor> cosh_bw(const Tensor& grad, const Tensor& input, const MemoryConfig& output_mem_config) {
-    return operation::decorate_as_composite(__func__, _cosh_bw)(grad, input, output_mem_config);
-}
 
 // Hardtanh
 // result: torch.where((input <= min) | (input >= max), 0.0, grad)

--- a/tt_eager/tt_dnn/op_library/backward/backward_ops.cpp
+++ b/tt_eager/tt_dnn/op_library/backward/backward_ops.cpp
@@ -729,17 +729,6 @@ std::vector<Tensor> threshold_bw(
 }
 
 
-std::vector<Tensor> _sign_bw(const Tensor& grad, const Tensor& input, const MemoryConfig& output_mem_config) {
-    std::vector<Tensor> grad_tensor;
-    Tensor zero_grad = zeros_like(grad, output_mem_config);
-    grad_tensor.emplace_back(zero_grad);
-    return grad_tensor;
-}
-std::vector<Tensor> sign_bw(const Tensor& grad, const Tensor& input, const MemoryConfig& output_mem_config) {
-    return operation::decorate_as_composite(__func__, _sign_bw)(grad, input, output_mem_config);
-}
-
-
 std::vector<Tensor> _ge_bw(const Tensor& grad, const MemoryConfig& output_mem_config) {
     std::vector<Tensor> grad_tensor;
     Tensor t_zero = zeros_like(grad, output_mem_config);

--- a/tt_eager/tt_dnn/op_library/backward/backward_ops.cpp
+++ b/tt_eager/tt_dnn/op_library/backward/backward_ops.cpp
@@ -750,17 +750,6 @@ std::vector<Tensor> le_bw(const Tensor& grad, const MemoryConfig& output_mem_con
 }
 
 
-std::vector<Tensor> _unary_remainder_bw(
-    const Tensor& grad, const Tensor& input, float scalar, const MemoryConfig& output_mem_config) {
-    std::vector<Tensor> grad_tensor;
-    grad_tensor.emplace_back(grad);
-    return grad_tensor;
-}
-std::vector<Tensor> unary_remainder_bw(
-    const Tensor& grad, const Tensor& input, float scalar, const MemoryConfig& output_mem_config) {
-    return operation::decorate_as_composite(__func__, _unary_remainder_bw)(grad, input, scalar, output_mem_config);
-}
-
 #define CHECK_FOR_COMPLEX(input)                                                     \
     do {                                                                             \
         TT_ASSERT(utility::is_complex_shape(input), "works for complex shape only"); \

--- a/tt_eager/tt_dnn/op_library/backward/backward_ops.cpp
+++ b/tt_eager/tt_dnn/op_library/backward/backward_ops.cpp
@@ -1088,21 +1088,6 @@ std::vector<Tensor> repeat_bw(
     return operation::decorate_as_composite(__func__, _repeat_bw)(grad, input, shape, output_mem_config);
 }
 
-std::vector<Tensor> _unary_div_no_nan_bw(
-    const Tensor& grad, const Tensor& input, float scalar, const MemoryConfig& output_mem_config) {
-    std::vector<Tensor> grad_tensor;
-    Tensor zeros = zeros_like(grad, output_mem_config);
-    Tensor val = full_like(input, scalar, output_mem_config);
-    Tensor result = where(
-        ttnn::eq(val, 0, std::nullopt, output_mem_config), zeros, ttnn::multiply(grad, 1 / scalar, std::nullopt, output_mem_config), output_mem_config);
-    grad_tensor.emplace_back(result);
-    return grad_tensor;
-}
-std::vector<Tensor> unary_div_no_nan_bw(
-    const Tensor& grad, const Tensor& input, float scalar, const MemoryConfig& output_mem_config) {
-    return operation::decorate_as_composite(__func__, _unary_div_no_nan_bw)(grad, input, scalar, output_mem_config);
-}
-
 }  // namespace tt_metal
 
 }  // namespace tt

--- a/tt_eager/tt_dnn/op_library/backward/backward_ops.cpp
+++ b/tt_eager/tt_dnn/op_library/backward/backward_ops.cpp
@@ -749,16 +749,6 @@ std::vector<Tensor> le_bw(const Tensor& grad, const MemoryConfig& output_mem_con
     return operation::decorate_as_composite(__func__, _le_bw)(grad, output_mem_config);
 }
 
-std::vector<Tensor> _unary_fmod_bw(
-    const Tensor& grad, const Tensor& input, float scalar, const MemoryConfig& output_mem_config) {
-    std::vector<Tensor> grad_tensor;
-    grad_tensor.emplace_back(grad);
-    return grad_tensor;
-}
-std::vector<Tensor> unary_fmod_bw(
-    const Tensor& grad, const Tensor& input, float scalar, const MemoryConfig& output_mem_config) {
-    return operation::decorate_as_composite(__func__, _unary_fmod_bw)(grad, input, scalar, output_mem_config);
-}
 
 std::vector<Tensor> _unary_remainder_bw(
     const Tensor& grad, const Tensor& input, float scalar, const MemoryConfig& output_mem_config) {

--- a/tt_eager/tt_dnn/op_library/backward/backward_ops.cpp
+++ b/tt_eager/tt_dnn/op_library/backward/backward_ops.cpp
@@ -739,27 +739,7 @@ std::vector<Tensor> sign_bw(const Tensor& grad, const Tensor& input, const Memor
     return operation::decorate_as_composite(__func__, _sign_bw)(grad, input, output_mem_config);
 }
 
-// bw(log2(in)) = grad/(in * 0.69314718055994530942)
-std::vector<Tensor> _log2_bw(const Tensor& grad, const Tensor& input, const MemoryConfig& output_mem_config) {
-    std::vector<Tensor> grad_tensor;
-    Tensor t_inf = where(
-        ttnn::ltz(grad, output_mem_config),
-        -std::numeric_limits<float>::infinity(),
-        std::numeric_limits<float>::infinity(),
-        output_mem_config);
-    Tensor grad_a = ttnn::multiply(
-        grad, ttnn::reciprocal(ttnn::multiply(input, M_LN2, std::nullopt, output_mem_config), output_mem_config), std::nullopt, output_mem_config);
-    grad_a = where(
-        ttnn::logical_and(ttnn::eqz(input, output_mem_config), ttnn::eqz(grad, output_mem_config), std::nullopt, output_mem_config),
-        std::nanf(" "),
-        where(ttnn::eqz(input, output_mem_config), t_inf, grad_a, output_mem_config),
-        output_mem_config);
-    grad_tensor.emplace_back(grad_a);
-    return grad_tensor;
-}
-std::vector<Tensor> log2_bw(const Tensor& grad, const Tensor& input, const MemoryConfig& output_mem_config) {
-    return operation::decorate_as_composite(__func__, _log2_bw)(grad, input, output_mem_config);
-}
+
 std::vector<Tensor> _ge_bw(const Tensor& grad, const MemoryConfig& output_mem_config) {
     std::vector<Tensor> grad_tensor;
     Tensor t_zero = zeros_like(grad, output_mem_config);

--- a/tt_eager/tt_dnn/op_library/backward/backward_ops.hpp
+++ b/tt_eager/tt_dnn/op_library/backward/backward_ops.hpp
@@ -205,10 +205,16 @@ std::vector<Tensor> threshold_bw(
     float value,
     const MemoryConfig& output_mem_config = operation::DEFAULT_OUTPUT_MEMORY_CONFIG);
 
+<<<<<<< HEAD
 std::vector<Tensor> logiteps_bw(
     const Tensor& grad,
     const Tensor& input,
     float eps = 0.0f,
+=======
+std::vector<Tensor> softsign_bw(
+    const Tensor& grad,
+    const Tensor& input,
+>>>>>>> #10070: Move logit eps bw to TTNN
     const MemoryConfig& output_mem_config = operation::DEFAULT_OUTPUT_MEMORY_CONFIG);
 
 std::vector<Tensor> sign_bw(

--- a/tt_eager/tt_dnn/op_library/backward/backward_ops.hpp
+++ b/tt_eager/tt_dnn/op_library/backward/backward_ops.hpp
@@ -153,11 +153,6 @@ std::vector<Tensor> polygamma_bw(
     int n,
     const MemoryConfig& output_mem_config = operation::DEFAULT_OUTPUT_MEMORY_CONFIG);
 
-std::vector<Tensor> cosh_bw(
-    const Tensor& grad,
-    const Tensor& input,
-    const MemoryConfig& output_mem_config = operation::DEFAULT_OUTPUT_MEMORY_CONFIG);
-
 std::vector<Tensor> erfinv_bw(
     const Tensor& grad,
     const Tensor& input,

--- a/tt_eager/tt_dnn/op_library/backward/backward_ops.hpp
+++ b/tt_eager/tt_dnn/op_library/backward/backward_ops.hpp
@@ -222,11 +222,6 @@ std::vector<Tensor> sign_bw(
     const Tensor& input,
     const MemoryConfig& output_mem_config = operation::DEFAULT_OUTPUT_MEMORY_CONFIG);
 
-std::vector<Tensor> log2_bw(
-    const Tensor& grad,
-    const Tensor& input,
-    const MemoryConfig& output_mem_config = operation::DEFAULT_OUTPUT_MEMORY_CONFIG);
-
 std::vector<Tensor> ge_bw(
     const Tensor& grad, const MemoryConfig& output_mem_config = operation::DEFAULT_OUTPUT_MEMORY_CONFIG);
 

--- a/tt_eager/tt_dnn/op_library/backward/backward_ops.hpp
+++ b/tt_eager/tt_dnn/op_library/backward/backward_ops.hpp
@@ -205,23 +205,6 @@ std::vector<Tensor> threshold_bw(
     float value,
     const MemoryConfig& output_mem_config = operation::DEFAULT_OUTPUT_MEMORY_CONFIG);
 
-<<<<<<< HEAD
-std::vector<Tensor> logiteps_bw(
-    const Tensor& grad,
-    const Tensor& input,
-    float eps = 0.0f,
-=======
-std::vector<Tensor> softsign_bw(
-    const Tensor& grad,
-    const Tensor& input,
->>>>>>> #10070: Move logit eps bw to TTNN
-    const MemoryConfig& output_mem_config = operation::DEFAULT_OUTPUT_MEMORY_CONFIG);
-
-std::vector<Tensor> sign_bw(
-    const Tensor& grad,
-    const Tensor& input,
-    const MemoryConfig& output_mem_config = operation::DEFAULT_OUTPUT_MEMORY_CONFIG);
-
 std::vector<Tensor> ge_bw(
     const Tensor& grad, const MemoryConfig& output_mem_config = operation::DEFAULT_OUTPUT_MEMORY_CONFIG);
 

--- a/tt_eager/tt_dnn/op_library/backward/backward_ops.hpp
+++ b/tt_eager/tt_dnn/op_library/backward/backward_ops.hpp
@@ -212,12 +212,6 @@ std::vector<Tensor> le_bw(
     const Tensor& grad, const MemoryConfig& output_mem_config = operation::DEFAULT_OUTPUT_MEMORY_CONFIG);
 
 
-std::vector<Tensor> unary_remainder_bw(
-    const Tensor& grad,
-    const Tensor& input,
-    float eps = 0.0f,
-    const MemoryConfig& output_mem_config = operation::DEFAULT_OUTPUT_MEMORY_CONFIG);
-
 std::vector<Tensor> conj_bw(
     const Tensor& grad,
     const Tensor& input,

--- a/tt_eager/tt_dnn/op_library/backward/backward_ops.hpp
+++ b/tt_eager/tt_dnn/op_library/backward/backward_ops.hpp
@@ -211,11 +211,6 @@ std::vector<Tensor> ge_bw(
 std::vector<Tensor> le_bw(
     const Tensor& grad, const MemoryConfig& output_mem_config = operation::DEFAULT_OUTPUT_MEMORY_CONFIG);
 
-std::vector<Tensor> unary_fmod_bw(
-    const Tensor& grad,
-    const Tensor& input,
-    float eps = 0.0f,
-    const MemoryConfig& output_mem_config = operation::DEFAULT_OUTPUT_MEMORY_CONFIG);
 
 std::vector<Tensor> unary_remainder_bw(
     const Tensor& grad,

--- a/tt_eager/tt_dnn/op_library/backward/backward_ops.hpp
+++ b/tt_eager/tt_dnn/op_library/backward/backward_ops.hpp
@@ -267,12 +267,6 @@ std::vector<Tensor> complex_sub_bw(
 std::vector<Tensor> repeat_bw(
     const Tensor& grad, const Tensor& input, const Shape& shape, const MemoryConfig& output_mem_config);
 
-std::vector<Tensor> unary_div_no_nan_bw(
-    const Tensor& grad,
-    const Tensor& input,
-    float scalar = 1.0f,
-    const MemoryConfig& output_mem_config = operation::DEFAULT_OUTPUT_MEMORY_CONFIG);
-
 Tensor change_layout_to_tile(const Tensor& temp, const MemoryConfig& output_mem_config);
 }  // namespace tt_metal
 

--- a/tt_eager/tt_lib/csrc/tt_lib_bindings_tensor_backward_ops.cpp
+++ b/tt_eager/tt_lib/csrc/tt_lib_bindings_tensor_backward_ops.cpp
@@ -418,21 +418,6 @@ namespace tt::tt_metal::detail{
                 "output_mem_config", "Layout of tensor in TT Accelerator device memory banks", "MemoryConfig", "Default is interleaved in DRAM", "No"
         )doc");
 
-    m_tensor.def("cosh_bw", &tt::tt_metal::cosh_bw,
-            py::arg("grad").noconvert(), py::arg("input").noconvert(), py::arg("output_mem_config").noconvert() = operation::DEFAULT_OUTPUT_MEMORY_CONFIG, R"doc(
-            Performs backward operations for hyperbolic cos of ``input`` tensors with given ``grad``.
-
-            Input tensors must have BFLOAT16 data type.
-
-            Output tensors will have BFLOAT16 data type.
-
-            .. csv-table::
-                :header: "Argument", "Description", "Data type", "Valid range", "Required"
-
-                "grad", "Gradient tensor", "Tensor", "Tensor of shape [W, Z, Y, X]", "Yes"
-                "input", "Input Tensor", "Tensor", "Tensor of shape [W, Z, Y, X]", "Yes"
-                "output_mem_config", "Layout of tensor in TT Accelerator device memory banks", "MemoryConfig", "Default is interleaved in DRAM", "No"
-        )doc");
 
     m_tensor.def("angle_bw", py::overload_cast<const Tensor&, const Tensor&, bool, const MemoryConfig&>(&angle_bw),
             py::arg("grad").noconvert(), py::arg("input").noconvert(), py::arg("is_complextensor").noconvert() = true, py::arg("output_mem_config").noconvert() = operation::DEFAULT_OUTPUT_MEMORY_CONFIG, R"doc(

--- a/tt_eager/tt_lib/csrc/tt_lib_bindings_tensor_backward_ops.cpp
+++ b/tt_eager/tt_lib/csrc/tt_lib_bindings_tensor_backward_ops.cpp
@@ -553,22 +553,6 @@ namespace tt::tt_metal::detail{
                 "output_mem_config", "Layout of tensor in TT Accelerator device memory banks", "MemoryConfig", "Default is interleaved in DRAM", "No"
         )doc");
 
-   m_tensor.def("logiteps_bw", &tt::tt_metal::logiteps_bw,
-            py::arg("grad").noconvert(), py::arg("input").noconvert(), py::arg("eps") = 0.0f, py::arg("output_mem_config").noconvert() = operation::DEFAULT_OUTPUT_MEMORY_CONFIG, R"doc(
-            Performs backward operations for logit of ``input`` tensors with `eps` for the given ``grad``.
-
-            Input tensors must have BFLOAT16 data type.
-
-            Output tensors will have BFLOAT16 data type.
-
-            .. csv-table::
-                :header: "Argument", "Description", "Data type", "Valid range", "Required"
-
-                "grad", "Gradient tensor", "Tensor", "Tensor of shape [W, Z, Y, X]", "Yes"
-                "input", "Input Tensor", "Tensor", "Tensor of shape [W, Z, Y, X]", "Yes"
-                "eps", "eps value", "float", "default to 0.0f", "No"
-                "output_mem_config", "Layout of tensor in TT Accelerator device memory banks", "MemoryConfig", "Default is interleaved in DRAM", "No"
-        )doc");
 
     m_tensor.def("sign_bw", &tt::tt_metal::sign_bw,
             py::arg("grad").noconvert(), py::arg("input").noconvert(), py::arg("output_mem_config").noconvert() = operation::DEFAULT_OUTPUT_MEMORY_CONFIG, R"doc(

--- a/tt_eager/tt_lib/csrc/tt_lib_bindings_tensor_backward_ops.cpp
+++ b/tt_eager/tt_lib/csrc/tt_lib_bindings_tensor_backward_ops.cpp
@@ -554,23 +554,6 @@ namespace tt::tt_metal::detail{
         )doc");
 
 
-    m_tensor.def("sign_bw", &tt::tt_metal::sign_bw,
-            py::arg("grad").noconvert(), py::arg("input").noconvert(), py::arg("output_mem_config").noconvert() = operation::DEFAULT_OUTPUT_MEMORY_CONFIG, R"doc(
-            Performs backward sign operations on ``input`` tensors with given ``grad``.
-
-            Input tensors must have BFLOAT16 data type.
-
-            Output tensors will have BFLOAT16 data type.
-
-            .. csv-table::
-                :header: "Argument", "Description", "Data type", "Valid range", "Required"
-
-                "grad", "Gradient tensor", "Tensor", "Tensor of shape [W, Z, Y, X]", "Yes"
-                "input", "Tensor sign_bw is applied to", "Tensor", "Tensor of shape [W, Z, Y, X]", "Yes"
-                "output_mem_config", "Layout of tensor in TT Accelerator device memory banks", "MemoryConfig", "Default is interleaved in DRAM", "No"
-        )doc");
-
-
     m_tensor.def("ge_bw", &tt::tt_metal::ge_bw,
             py::arg("grad").noconvert(), py::arg("output_mem_config").noconvert() = operation::DEFAULT_OUTPUT_MEMORY_CONFIG, R"doc(
             Returns an tensor of zeros like ``grad`` tensor

--- a/tt_eager/tt_lib/csrc/tt_lib_bindings_tensor_backward_ops.cpp
+++ b/tt_eager/tt_lib/csrc/tt_lib_bindings_tensor_backward_ops.cpp
@@ -584,22 +584,6 @@ namespace tt::tt_metal::detail{
                 "output_mem_config", "Layout of tensor in TT Accelerator device memory banks", "MemoryConfig", "Default is interleaved in DRAM", "No"
         )doc");
 
-   m_tensor.def("unary_fmod_bw", &tt::tt_metal::unary_fmod_bw,
-            py::arg("grad").noconvert(), py::arg("input").noconvert(), py::arg("scalar"), py::arg("output_mem_config").noconvert() = operation::DEFAULT_OUTPUT_MEMORY_CONFIG, R"doc(
-            Performs backward operations for fmod of ``input`` tensors with `scalar` for the given ``grad``.
-
-            Input tensors must have BFLOAT16 data type.
-
-            Output tensors will have BFLOAT16 data type.
-
-            .. csv-table::
-                :header: "Argument", "Description", "Data type", "Valid range", "Required"
-
-                "grad", "Gradient tensor", "Tensor", "Tensor of shape [W, Z, Y, X]", "Yes"
-                "input", "Input Tensor", "Tensor", "Tensor of shape [W, Z, Y, X]", "Yes"
-                "scalar", "scalar value", "float", "float", "Yes"
-                "output_mem_config", "Layout of tensor in TT Accelerator device memory banks", "MemoryConfig", "Default is interleaved in DRAM", "No"
-        )doc");
 
    m_tensor.def("unary_remainder_bw", &tt::tt_metal::unary_remainder_bw,
             py::arg("grad").noconvert(), py::arg("input").noconvert(), py::arg("scalar"), py::arg("output_mem_config").noconvert() = operation::DEFAULT_OUTPUT_MEMORY_CONFIG, R"doc(

--- a/tt_eager/tt_lib/csrc/tt_lib_bindings_tensor_backward_ops.cpp
+++ b/tt_eager/tt_lib/csrc/tt_lib_bindings_tensor_backward_ops.cpp
@@ -585,23 +585,6 @@ namespace tt::tt_metal::detail{
         )doc");
 
 
-   m_tensor.def("unary_remainder_bw", &tt::tt_metal::unary_remainder_bw,
-            py::arg("grad").noconvert(), py::arg("input").noconvert(), py::arg("scalar"), py::arg("output_mem_config").noconvert() = operation::DEFAULT_OUTPUT_MEMORY_CONFIG, R"doc(
-            Performs backward operations for ramainder of ``input`` tensors with `scalar` for the given ``grad``.
-
-            Input tensors must have BFLOAT16 data type.
-
-            Output tensors will have BFLOAT16 data type.
-
-            .. csv-table::
-                :header: "Argument", "Description", "Data type", "Valid range", "Required"
-
-                "grad", "Gradient tensor", "Tensor", "Tensor of shape [W, Z, Y, X]", "Yes"
-                "input", "Input Tensor", "Tensor", "Tensor of shape [W, Z, Y, X]", "Yes"
-                "scalar", "scalar value", "float", "float", "Yes"
-                "output_mem_config", "Layout of tensor in TT Accelerator device memory banks", "MemoryConfig", "Default is interleaved in DRAM", "No"
-        )doc");
-
     m_tensor.def("imag_bw", py::overload_cast<const Tensor&, const Tensor&, const MemoryConfig&>(&imag_bw),
             py::arg("grad").noconvert(), py::arg("input").noconvert(), py::arg("output_mem_config").noconvert() = operation::DEFAULT_OUTPUT_MEMORY_CONFIG, R"doc(
             Performs backward operations for imaginary part of complex tensor ``input`` with given ``grad``

--- a/tt_eager/tt_lib/csrc/tt_lib_bindings_tensor_backward_ops.cpp
+++ b/tt_eager/tt_lib/csrc/tt_lib_bindings_tensor_backward_ops.cpp
@@ -570,21 +570,6 @@ namespace tt::tt_metal::detail{
                 "output_mem_config", "Layout of tensor in TT Accelerator device memory banks", "MemoryConfig", "Default is interleaved in DRAM", "No"
         )doc");
 
-    m_tensor.def("log2_bw", &tt::tt_metal::log2_bw,
-            py::arg("grad").noconvert(), py::arg("input").noconvert(), py::arg("output_mem_config").noconvert() = operation::DEFAULT_OUTPUT_MEMORY_CONFIG, R"doc(
-            Performs backward operations for log2 of ``input`` tensors with given ``grad``.
-
-            Input tensors must have BFLOAT16 data type.
-
-            Output tensors will have BFLOAT16 data type.
-
-            .. csv-table::
-                :header: "Argument", "Description", "Data type", "Valid range", "Required"
-
-                "grad", "Gradient tensor", "Tensor", "Tensor of shape [W, Z, Y, X]", "Yes"
-                "input", "Input Tensor", "Tensor", "Tensor of shape [W, Z, Y, X]", "Yes"
-                "output_mem_config", "Layout of tensor in TT Accelerator device memory banks", "MemoryConfig", "Default is interleaved in DRAM", "No"
-        )doc");
 
     m_tensor.def("ge_bw", &tt::tt_metal::ge_bw,
             py::arg("grad").noconvert(), py::arg("output_mem_config").noconvert() = operation::DEFAULT_OUTPUT_MEMORY_CONFIG, R"doc(

--- a/tt_eager/tt_lib/csrc/tt_lib_bindings_tensor_backward_ops.cpp
+++ b/tt_eager/tt_lib/csrc/tt_lib_bindings_tensor_backward_ops.cpp
@@ -651,23 +651,6 @@ namespace tt::tt_metal::detail{
                 "output_mem_config", "Layout of tensor in TT Accelerator device memory banks", "MemoryConfig", "Default is interleaved in DRAM", "No"
         )doc");
 
-    m_tensor.def("unary_div_no_nan_bw", &tt::tt_metal::unary_div_no_nan_bw,
-            py::arg("grad").noconvert(), py::arg("input").noconvert(), py::arg("scalar") = 1.0f, py::arg("output_mem_config").noconvert() = operation::DEFAULT_OUTPUT_MEMORY_CONFIG, R"doc(
-            Performs backward operations for division with given ``grad`` and ``scalar`` with no nan.
-
-            Input tensors must have BFLOAT16 data type.
-
-            Output tensor will have BFLOAT16 data type.
-
-            .. csv-table::
-                :header: "Argument", "Description", "Data type", "Valid range", "Required"
-
-                "grad", "Gradient tensor", "Tensor", "Tensor of shape [W, Z, Y, X]", "Yes"
-                "input", "Tensor", "Tensor", "Tensor of shape [W, Z, Y, X]", "Yes"
-                "scalar", "Scalar value", "float", "default to 1.0f", "No"
-                "output_mem_config", "Layout of tensor in TT Accelerator device memory banks", "MemoryConfig", "Default is interleaved in DRAM", "No"
-        )doc");
-
     m_tensor.def("complex_mul_bw", py::overload_cast<const Tensor&, const Tensor&, const Tensor&, const MemoryConfig&>(&complex_mul_bw),
             py::arg("grad").noconvert(), py::arg("input").noconvert(), py::arg("other").noconvert(), py::arg("output_mem_config").noconvert() = operation::DEFAULT_OUTPUT_MEMORY_CONFIG, R"doc(
             Performs backward operations for multiplication of complex tensors``input`` and ``other`` with given ``grad``.

--- a/ttnn/cpp/ttnn/operations/eltwise/unary_backward/device/unary_backward_op.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary_backward/device/unary_backward_op.cpp
@@ -935,6 +935,14 @@ std::vector<Tensor> _fmod_bw(
 }
 
 
+std::vector<Tensor> _unary_remainder_bw(
+    const Tensor& grad, const Tensor& input, float scalar, const MemoryConfig& output_mem_config) {
+    std::vector<Tensor> grad_tensor;
+    grad_tensor.emplace_back(grad);
+    return grad_tensor;
+}
+
+
 std::function<std::vector<ttnn::Tensor>(const Tensor&, const Tensor&, const MemoryConfig&)> UnaryBackwardFunction::get_function_type1(UnaryBackwardOpType OpType){
     switch (OpType) {
         case UnaryBackwardOpType::ASSIGN_BW:
@@ -1061,6 +1069,8 @@ std::function<std::vector<ttnn::Tensor>(const Tensor&, const Tensor&, float, con
             return _logiteps_bw;
         case UnaryBackwardOpType::FMOD_BW:
             return _fmod_bw;
+        case UnaryBackwardOpType::REMAINDER_BW:
+            return _remainder_bw;
         default:
             TT_ASSERT(false && "Undefined op type");
             return 0;

--- a/ttnn/cpp/ttnn/operations/eltwise/unary_backward/device/unary_backward_op.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary_backward/device/unary_backward_op.cpp
@@ -919,6 +919,14 @@ std::vector<Tensor> _log2_bw(const Tensor& grad, const Tensor& input, const Memo
 }
 
 
+std::vector<Tensor> _sign_bw(const Tensor& grad, const Tensor& input, const MemoryConfig& output_mem_config) {
+    std::vector<Tensor> grad_tensor;
+    Tensor zero_grad = ttnn::operations::creation::zeros_like(grad, grad.get_dtype(), grad.get_layout(), std::nullopt, output_mem_config);
+    grad_tensor.emplace_back(zero_grad);
+    return grad_tensor;
+}
+
+
 std::function<std::vector<ttnn::Tensor>(const Tensor&, const Tensor&, const MemoryConfig&)> UnaryBackwardFunction::get_function_type1(UnaryBackwardOpType OpType){
     switch (OpType) {
         case UnaryBackwardOpType::ASSIGN_BW:
@@ -1007,6 +1015,8 @@ std::function<std::vector<ttnn::Tensor>(const Tensor&, const Tensor&, const Memo
             return _cosh_bw;
         case UnaryBackwardOpType::LOG2_BW:
             return _log2_bw;
+        case UnaryBackwardOpType::SIGN_BW:
+            return _sign_bw;
         default:
             TT_ASSERT(false && "Undefined op type");
             return 0;

--- a/ttnn/cpp/ttnn/operations/eltwise/unary_backward/device/unary_backward_op.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary_backward/device/unary_backward_op.cpp
@@ -927,6 +927,14 @@ std::vector<Tensor> _sign_bw(const Tensor& grad, const Tensor& input, const Memo
 }
 
 
+std::vector<Tensor> _fmod_bw(
+    const Tensor& grad, const Tensor& input, float scalar, const MemoryConfig& output_mem_config) {
+    std::vector<Tensor> grad_tensor;
+    grad_tensor.emplace_back(grad);
+    return grad_tensor;
+}
+
+
 std::function<std::vector<ttnn::Tensor>(const Tensor&, const Tensor&, const MemoryConfig&)> UnaryBackwardFunction::get_function_type1(UnaryBackwardOpType OpType){
     switch (OpType) {
         case UnaryBackwardOpType::ASSIGN_BW:
@@ -1051,6 +1059,8 @@ std::function<std::vector<ttnn::Tensor>(const Tensor&, const Tensor&, float, con
             return _rpow_bw;
         case UnaryBackwardOpType::LOGITEPS_BW:
             return _logiteps_bw;
+        case UnaryBackwardOpType::FMOD_BW:
+            return _fmod_bw;
         default:
             TT_ASSERT(false && "Undefined op type");
             return 0;

--- a/ttnn/cpp/ttnn/operations/eltwise/unary_backward/device/unary_backward_op.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary_backward/device/unary_backward_op.cpp
@@ -935,13 +935,24 @@ std::vector<Tensor> _fmod_bw(
 }
 
 
-std::vector<Tensor> _unary_remainder_bw(
+std::vector<Tensor> _remainder_bw(
     const Tensor& grad, const Tensor& input, float scalar, const MemoryConfig& output_mem_config) {
     std::vector<Tensor> grad_tensor;
     grad_tensor.emplace_back(grad);
     return grad_tensor;
 }
 
+
+std::vector<Tensor> _div_no_nan_bw(
+    const Tensor& grad, const Tensor& input, float scalar, const MemoryConfig& output_mem_config) {
+    std::vector<Tensor> grad_tensor;
+    Tensor zeros = ttnn::operations::creation::zeros_like(grad, grad.get_dtype(), grad.get_layout(), std::nullopt, output_mem_config);
+    Tensor val = ttnn::operations::creation::full_like(input, scalar, input.get_dtype(), input.get_layout(), std::nullopt, output_mem_config);
+    Tensor result = where(
+        ttnn::eq(val, 0, std::nullopt, output_mem_config), zeros, ttnn::multiply(grad, 1 / scalar, std::nullopt, output_mem_config), output_mem_config);
+    grad_tensor.emplace_back(result);
+    return grad_tensor;
+}
 
 std::function<std::vector<ttnn::Tensor>(const Tensor&, const Tensor&, const MemoryConfig&)> UnaryBackwardFunction::get_function_type1(UnaryBackwardOpType OpType){
     switch (OpType) {
@@ -1071,6 +1082,8 @@ std::function<std::vector<ttnn::Tensor>(const Tensor&, const Tensor&, float, con
             return _fmod_bw;
         case UnaryBackwardOpType::REMAINDER_BW:
             return _remainder_bw;
+        case UnaryBackwardOpType::DIV_NO_NAN_BW:
+            return _div_no_nan_bw;
         default:
             TT_ASSERT(false && "Undefined op type");
             return 0;

--- a/ttnn/cpp/ttnn/operations/eltwise/unary_backward/device/unary_backward_op.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary_backward/device/unary_backward_op.hpp
@@ -68,6 +68,7 @@ enum class UnaryBackwardOpType {
     CEIL_BW,
     SOFTSIGN_BW,
     COSH_BW,
+    LOGITEPS_BW,
 };
 
 struct UnaryBackwardFunction{

--- a/ttnn/cpp/ttnn/operations/eltwise/unary_backward/device/unary_backward_op.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary_backward/device/unary_backward_op.hpp
@@ -71,6 +71,7 @@ enum class UnaryBackwardOpType {
     LOGITEPS_BW,
     LOG2_BW,
     SIGN_BW,
+    FMOD_BW,
 };
 
 struct UnaryBackwardFunction{

--- a/ttnn/cpp/ttnn/operations/eltwise/unary_backward/device/unary_backward_op.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary_backward/device/unary_backward_op.hpp
@@ -72,6 +72,7 @@ enum class UnaryBackwardOpType {
     LOG2_BW,
     SIGN_BW,
     FMOD_BW,
+    REMAINDER_BW,
 };
 
 struct UnaryBackwardFunction{

--- a/ttnn/cpp/ttnn/operations/eltwise/unary_backward/device/unary_backward_op.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary_backward/device/unary_backward_op.hpp
@@ -70,6 +70,7 @@ enum class UnaryBackwardOpType {
     COSH_BW,
     LOGITEPS_BW,
     LOG2_BW,
+    SIGN_BW,
 };
 
 struct UnaryBackwardFunction{

--- a/ttnn/cpp/ttnn/operations/eltwise/unary_backward/device/unary_backward_op.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary_backward/device/unary_backward_op.hpp
@@ -69,6 +69,7 @@ enum class UnaryBackwardOpType {
     SOFTSIGN_BW,
     COSH_BW,
     LOGITEPS_BW,
+    LOG2_BW,
 };
 
 struct UnaryBackwardFunction{

--- a/ttnn/cpp/ttnn/operations/eltwise/unary_backward/device/unary_backward_op.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary_backward/device/unary_backward_op.hpp
@@ -67,6 +67,7 @@ enum class UnaryBackwardOpType {
     ERFC_BW,
     CEIL_BW,
     SOFTSIGN_BW,
+    COSH_BW,
 };
 
 struct UnaryBackwardFunction{

--- a/ttnn/cpp/ttnn/operations/eltwise/unary_backward/device/unary_backward_op.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary_backward/device/unary_backward_op.hpp
@@ -73,6 +73,7 @@ enum class UnaryBackwardOpType {
     SIGN_BW,
     FMOD_BW,
     REMAINDER_BW,
+    DIV_NO_NAN_BW,
 };
 
 struct UnaryBackwardFunction{

--- a/ttnn/cpp/ttnn/operations/eltwise/unary_backward/unary_backward.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary_backward/unary_backward.hpp
@@ -122,6 +122,7 @@ constexpr auto softsign_bw = ttnn::register_operation<operations::unary_backward
 constexpr auto cosh_bw = ttnn::register_operation<operations::unary_backward::ExecuteUnaryBackward<operations::unary_backward::UnaryBackwardOpType::COSH_BW>>("ttnn::cosh_bw");
 constexpr auto logiteps_bw = ttnn::register_operation<operations::unary_backward::ExecuteUnaryBackward<operations::unary_backward::UnaryBackwardOpType::LOGITEPS_BW>>("ttnn::logiteps_bw");
 constexpr auto log2_bw = ttnn::register_operation<operations::unary_backward::ExecuteUnaryBackward<operations::unary_backward::UnaryBackwardOpType::LOG2_BW>>("ttnn::log2_bw");
+constexpr auto sign_bw = ttnn::register_operation<operations::unary_backward::ExecuteUnaryBackward<operations::unary_backward::UnaryBackwardOpType::SIGN_BW>>("ttnn::sign_bw");
 
 
 }  // namespace ttnn

--- a/ttnn/cpp/ttnn/operations/eltwise/unary_backward/unary_backward.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary_backward/unary_backward.hpp
@@ -123,6 +123,6 @@ constexpr auto cosh_bw = ttnn::register_operation<operations::unary_backward::Ex
 constexpr auto logiteps_bw = ttnn::register_operation<operations::unary_backward::ExecuteUnaryBackward<operations::unary_backward::UnaryBackwardOpType::LOGITEPS_BW>>("ttnn::logiteps_bw");
 constexpr auto log2_bw = ttnn::register_operation<operations::unary_backward::ExecuteUnaryBackward<operations::unary_backward::UnaryBackwardOpType::LOG2_BW>>("ttnn::log2_bw");
 constexpr auto sign_bw = ttnn::register_operation<operations::unary_backward::ExecuteUnaryBackward<operations::unary_backward::UnaryBackwardOpType::SIGN_BW>>("ttnn::sign_bw");
-
+constexpr auto fmod_bw = ttnn::register_operation<operations::unary_backward::ExecuteUnaryBackward<operations::unary_backward::UnaryBackwardOpType::FMOD_BW>>("ttnn::fmod_bw");
 
 }  // namespace ttnn

--- a/ttnn/cpp/ttnn/operations/eltwise/unary_backward/unary_backward.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary_backward/unary_backward.hpp
@@ -125,5 +125,7 @@ constexpr auto log2_bw = ttnn::register_operation<operations::unary_backward::Ex
 constexpr auto sign_bw = ttnn::register_operation<operations::unary_backward::ExecuteUnaryBackward<operations::unary_backward::UnaryBackwardOpType::SIGN_BW>>("ttnn::sign_bw");
 constexpr auto fmod_bw = ttnn::register_operation<operations::unary_backward::ExecuteUnaryBackward<operations::unary_backward::UnaryBackwardOpType::FMOD_BW>>("ttnn::fmod_bw");
 constexpr auto remainder_bw = ttnn::register_operation<operations::unary_backward::ExecuteUnaryBackward<operations::unary_backward::UnaryBackwardOpType::REMAINDER_BW>>("ttnn::remainder_bw");
+constexpr auto div_no_nan_bw = ttnn::register_operation<operations::unary_backward::ExecuteUnaryBackward<operations::unary_backward::UnaryBackwardOpType::DIV_NO_NAN_BW>>("ttnn::div_no_nan_bw");
+
 
 }  // namespace ttnn

--- a/ttnn/cpp/ttnn/operations/eltwise/unary_backward/unary_backward.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary_backward/unary_backward.hpp
@@ -124,5 +124,6 @@ constexpr auto logiteps_bw = ttnn::register_operation<operations::unary_backward
 constexpr auto log2_bw = ttnn::register_operation<operations::unary_backward::ExecuteUnaryBackward<operations::unary_backward::UnaryBackwardOpType::LOG2_BW>>("ttnn::log2_bw");
 constexpr auto sign_bw = ttnn::register_operation<operations::unary_backward::ExecuteUnaryBackward<operations::unary_backward::UnaryBackwardOpType::SIGN_BW>>("ttnn::sign_bw");
 constexpr auto fmod_bw = ttnn::register_operation<operations::unary_backward::ExecuteUnaryBackward<operations::unary_backward::UnaryBackwardOpType::FMOD_BW>>("ttnn::fmod_bw");
+constexpr auto remainder_bw = ttnn::register_operation<operations::unary_backward::ExecuteUnaryBackward<operations::unary_backward::UnaryBackwardOpType::REMAINDER_BW>>("ttnn::remainder_bw");
 
 }  // namespace ttnn

--- a/ttnn/cpp/ttnn/operations/eltwise/unary_backward/unary_backward.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary_backward/unary_backward.hpp
@@ -121,6 +121,7 @@ constexpr auto ceil_bw = ttnn::register_operation<operations::unary_backward::Ex
 constexpr auto softsign_bw = ttnn::register_operation<operations::unary_backward::ExecuteUnaryBackward<operations::unary_backward::UnaryBackwardOpType::SOFTSIGN_BW>>("ttnn::softsign_bw");
 constexpr auto cosh_bw = ttnn::register_operation<operations::unary_backward::ExecuteUnaryBackward<operations::unary_backward::UnaryBackwardOpType::COSH_BW>>("ttnn::cosh_bw");
 constexpr auto logiteps_bw = ttnn::register_operation<operations::unary_backward::ExecuteUnaryBackward<operations::unary_backward::UnaryBackwardOpType::LOGITEPS_BW>>("ttnn::logiteps_bw");
+constexpr auto log2_bw = ttnn::register_operation<operations::unary_backward::ExecuteUnaryBackward<operations::unary_backward::UnaryBackwardOpType::LOG2_BW>>("ttnn::log2_bw");
 
 
 }  // namespace ttnn

--- a/ttnn/cpp/ttnn/operations/eltwise/unary_backward/unary_backward.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary_backward/unary_backward.hpp
@@ -119,5 +119,7 @@ constexpr auto log1p_bw = ttnn::register_operation<operations::unary_backward::E
 constexpr auto erfc_bw = ttnn::register_operation<operations::unary_backward::ExecuteUnaryBackward<operations::unary_backward::UnaryBackwardOpType::ERFC_BW>>("ttnn::erfc_bw");
 constexpr auto ceil_bw = ttnn::register_operation<operations::unary_backward::ExecuteUnaryBackward<operations::unary_backward::UnaryBackwardOpType::CEIL_BW>>("ttnn::ceil_bw");
 constexpr auto softsign_bw = ttnn::register_operation<operations::unary_backward::ExecuteUnaryBackward<operations::unary_backward::UnaryBackwardOpType::SOFTSIGN_BW>>("ttnn::softsign_bw");
+constexpr auto cosh_bw = ttnn::register_operation<operations::unary_backward::ExecuteUnaryBackward<operations::unary_backward::UnaryBackwardOpType::COSH_BW>>("ttnn::cosh_bw");
+
 
 }  // namespace ttnn

--- a/ttnn/cpp/ttnn/operations/eltwise/unary_backward/unary_backward.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary_backward/unary_backward.hpp
@@ -120,6 +120,7 @@ constexpr auto erfc_bw = ttnn::register_operation<operations::unary_backward::Ex
 constexpr auto ceil_bw = ttnn::register_operation<operations::unary_backward::ExecuteUnaryBackward<operations::unary_backward::UnaryBackwardOpType::CEIL_BW>>("ttnn::ceil_bw");
 constexpr auto softsign_bw = ttnn::register_operation<operations::unary_backward::ExecuteUnaryBackward<operations::unary_backward::UnaryBackwardOpType::SOFTSIGN_BW>>("ttnn::softsign_bw");
 constexpr auto cosh_bw = ttnn::register_operation<operations::unary_backward::ExecuteUnaryBackward<operations::unary_backward::UnaryBackwardOpType::COSH_BW>>("ttnn::cosh_bw");
+constexpr auto logiteps_bw = ttnn::register_operation<operations::unary_backward::ExecuteUnaryBackward<operations::unary_backward::UnaryBackwardOpType::LOGITEPS_BW>>("ttnn::logiteps_bw");
 
 
 }  // namespace ttnn

--- a/ttnn/cpp/ttnn/operations/eltwise/unary_backward/unary_backward_pybind.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary_backward/unary_backward_pybind.hpp
@@ -459,6 +459,12 @@ void py_module(py::module& module) {
         module,
         ttnn::fmod_bw,
         R"doc(Performs backward operations for fmod on :attr:`input_tensor`, :attr:`eps` with given :attr:`grad_tensor`.)doc");
+
+    detail::bind_unary_backward(
+        module,
+        ttnn::remainder_bw,
+        R"doc(Performs backward operations for remainder on :attr:`input_tensor`, :attr:`scalar` with given :attr:`grad_tensor`.)doc");
+
 }
 
 }  // namespace binary_backward

--- a/ttnn/cpp/ttnn/operations/eltwise/unary_backward/unary_backward_pybind.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary_backward/unary_backward_pybind.hpp
@@ -455,6 +455,10 @@ void py_module(py::module& module) {
         ttnn::sign_bw,
         R"doc(Performs backward operations for sign on :attr:`input_tensor` with given :attr:`grad_tensor`.)doc");
 
+    detail::bind_unary_backward(
+        module,
+        ttnn::fmod_bw,
+        R"doc(Performs backward operations for fmod on :attr:`input_tensor`, :attr:`eps` with given :attr:`grad_tensor`.)doc");
 }
 
 }  // namespace binary_backward

--- a/ttnn/cpp/ttnn/operations/eltwise/unary_backward/unary_backward_pybind.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary_backward/unary_backward_pybind.hpp
@@ -444,6 +444,11 @@ void py_module(py::module& module) {
         module,
         ttnn::logiteps_bw,
         R"doc(Performs backward operations for logiteps on :attr:`input_tensor`, :attr:`eps` with given :attr:`grad_tensor`.)doc");
+
+    detail::bind_unary_backward(
+        module,
+        ttnn::log2_bw,
+        R"doc(Performs backward operations for log2 on :attr:`input_tensor` with given :attr:`grad_tensor`.)doc");
 }
 
 }  // namespace binary_backward

--- a/ttnn/cpp/ttnn/operations/eltwise/unary_backward/unary_backward_pybind.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary_backward/unary_backward_pybind.hpp
@@ -308,7 +308,7 @@ void py_module(py::module& module) {
         module,
         ttnn::clamp_max_bw,
         R"doc(Performs backward operations for clamp max value on :attr:`input_tensor`, :attr:`max` with given :attr:`grad_tensor`.)doc");
-    
+
     detail::bind_unary_backward(
         module,
         ttnn::hardshrink_bw,
@@ -434,6 +434,11 @@ void py_module(py::module& module) {
         ttnn::softsign_bw,
         R"doc(Performs backward operations for softsign on :attr:`input_tensor` with given :attr:`grad_tensor`)doc");
 
+
+    detail::bind_unary_backward(
+        module,
+        ttnn::cosh_bw,
+        R"doc(Performs backward operations for cosh on :attr:`input_tensor` with given :attr:`grad_tensor`.)doc");
 }
 
 }  // namespace binary_backward

--- a/ttnn/cpp/ttnn/operations/eltwise/unary_backward/unary_backward_pybind.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary_backward/unary_backward_pybind.hpp
@@ -465,6 +465,11 @@ void py_module(py::module& module) {
         ttnn::remainder_bw,
         R"doc(Performs backward operations for remainder on :attr:`input_tensor`, :attr:`scalar` with given :attr:`grad_tensor`.)doc");
 
+    detail::bind_unary_backward(
+        module,
+        ttnn::div_no_nan_bw,
+        R"doc(Performs backward operations for div_no_nan on :attr:`input_tensor`, :attr:`scalar` with given :attr:`grad_tensor`.)doc");
+
 }
 
 }  // namespace binary_backward

--- a/ttnn/cpp/ttnn/operations/eltwise/unary_backward/unary_backward_pybind.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary_backward/unary_backward_pybind.hpp
@@ -449,6 +449,12 @@ void py_module(py::module& module) {
         module,
         ttnn::log2_bw,
         R"doc(Performs backward operations for log2 on :attr:`input_tensor` with given :attr:`grad_tensor`.)doc");
+
+    detail::bind_unary_backward(
+        module,
+        ttnn::sign_bw,
+        R"doc(Performs backward operations for sign on :attr:`input_tensor` with given :attr:`grad_tensor`.)doc");
+
 }
 
 }  // namespace binary_backward

--- a/ttnn/cpp/ttnn/operations/eltwise/unary_backward/unary_backward_pybind.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary_backward/unary_backward_pybind.hpp
@@ -439,6 +439,11 @@ void py_module(py::module& module) {
         module,
         ttnn::cosh_bw,
         R"doc(Performs backward operations for cosh on :attr:`input_tensor` with given :attr:`grad_tensor`.)doc");
+
+    detail::bind_unary_backward(
+        module,
+        ttnn::logiteps_bw,
+        R"doc(Performs backward operations for logiteps on :attr:`input_tensor`, :attr:`eps` with given :attr:`grad_tensor`.)doc");
 }
 
 }  // namespace binary_backward


### PR DESCRIPTION
### Ticket
#10070 

### Problem description
Migrate following ops to TTNN

- cosh_bw
- logiteps_bw
- sign_bw
- fmod_bw
- remainder_bw
- div_no_nan_bw
- log2_bw


### Checklist
- [x] [Post commit CI passes](https://github.com/tenstorrent/tt-metal/actions/runs/9894440588)

