### PR TITLE
#10045: use struct for matmul parameter passing and update doc string

### DIFF
--- a/tests/tt_eager/ops/test_bmm_op.cpp
+++ b/tests/tt_eager/ops/test_bmm_op.cpp
@@ -50,7 +50,8 @@ int main(int argc, char **argv) {
         Tensor b = tt::numpy::zeros(shapeb, DataType::BFLOAT16).to(Layout::TILE).to(device);
         Tensor b1 = tt::numpy::zeros(shapeb1, DataType::BFLOAT16).to(Layout::TILE).to(device);
 
-        Tensor mm = tt::operations::primary::matmul(a, b, /*bias=*/std::nullopt, /*program_config=*/std::nullopt, operation::DEFAULT_OUTPUT_MEMORY_CONFIG, /*output_dtype=*/std::nullopt, /*compute_kernel_config=*/std::nullopt, /*untilize_out=*/false, /*user_core_coord=*/std::nullopt, /*user_fused_activation=*/std::nullopt, /*input_b_is_batched=*/true).cpu();
+        Tensor mm = tt::operations::primary::matmul(a, b, /*bias=*/std::nullopt,
+                tt::operations::primary::Matmul{/*program_config=*/std::nullopt, /*bcast_batch=*/std::nullopt,operation::DEFAULT_OUTPUT_MEMORY_CONFIG, /*output_dtype=*/std::nullopt, /*compute_kernel_config=*/std::nullopt, /*untilize_out=*/false, /*user_core_coord=*/std::nullopt, /*user_fused_activation=*/std::nullopt, /*user_run_batched=*/true}).cpu();
         Tensor mm1 = tt::operations::primary::matmul(a, b1).cpu();
 
         ////////////////////////////////////////////////////////////////////////////

--- a/tt_eager/tt_dnn/op_library/composite/composite_ops.cpp
+++ b/tt_eager/tt_dnn/op_library/composite/composite_ops.cpp
@@ -1852,10 +1852,10 @@ Tensor _outer(Tensor& a, Tensor& b, const MemoryConfig& output_mem_config) {
             a_slim,
             b_slim,
             /*bias=*/std::nullopt,
-            /*transpose_a=*/false,
-            /*transpose_b=*/false,
+            tt::operations::primary::Matmul{
             /*program_config=*/std::nullopt,
-            output_mem_config
+            /*bcast_batch=*/std::nullopt,
+            output_mem_config}
             );
 }
 Tensor outer(Tensor& a, Tensor& b, const MemoryConfig& output_mem_config) {

--- a/tt_eager/tt_dnn/op_library/fully_connected/fully_connected_op.cpp
+++ b/tt_eager/tt_dnn/op_library/fully_connected/fully_connected_op.cpp
@@ -8,6 +8,7 @@
 #include "tt_metal/host_api.hpp"
 #include "tt_dnn/op_library/bcast/bcast_op.hpp"
 #include "ttnn/operations/matmul/matmul.hpp"
+#include "ttnn/operations/matmul/device/matmul_op.hpp"
 
 namespace tt {
 namespace tt_metal {
@@ -17,10 +18,7 @@ Tensor fully_connected_(const Tensor& act, const Tensor& weights, std::optional<
             act,
             weights,
             /*bias=*/std::nullopt,
-            /*transpose_a=*/false,
-            /*transpose_b=*/false,
-            /*program_config=*/std::nullopt,
-            output_mem_config
+            tt::operations::primary::Matmul{/*program_config=*/std::nullopt, /*bcast_batch=*/std::nullopt, output_mem_config}
             );
     if (bias) {
         return bcast(mm_output, bias.value(), BcastOpMath::ADD, BcastOpDim::H, output_mem_config);

--- a/ttnn/cpp/ttnn/operations/conv2d.cpp
+++ b/ttnn/cpp/ttnn/operations/conv2d.cpp
@@ -706,13 +706,12 @@ std::tuple<ttnn::Tensor, uint32_t, uint32_t, ttnn::Tensor, std::optional<ttnn::T
             matmul_input,
             weight_tensor_on_device,
             bias_tensor_on_device,
-            /*transpose_a=*/false,
-            /*transpose_b=*/false,
+            tt::operations::primary::Matmul{
             matmul_program_config,
+            /*bcast_batch=*/std::nullopt,
             conv_out_memory_config,
             conv_config.dtype,
-            std::nullopt, // activation fused into matmul. part of the matmul config.
-            compute_kernel_config);
+            compute_kernel_config});
         if (conv_config.deallocate_activation) {
             // matmul_input.deallocate();
             ttnn::operations::core::deallocate(matmul_input);

--- a/ttnn/cpp/ttnn/operations/conv2d.hpp
+++ b/ttnn/cpp/ttnn/operations/conv2d.hpp
@@ -9,6 +9,7 @@
 #include "ttnn/core.hpp"
 #include "ttnn/operations/core.hpp"
 #include "ttnn/cpp/ttnn/operations/matmul/matmul.hpp"
+#include "ttnn/cpp/ttnn/operations/matmul/device/matmul_op.hpp"
 #include "ttnn/types.hpp"
 #include "ttnn/experimental/tensor/tensor_utils.hpp"
 #include "tt_metal/impl/dispatch/command_queue.hpp"

--- a/ttnn/cpp/ttnn/operations/matmul/matmul.hpp
+++ b/ttnn/cpp/ttnn/operations/matmul/matmul.hpp
@@ -27,7 +27,7 @@ namespace matmul {
 
 namespace detail {
 
-inline bool is_input_batched(const ttnn::Shape& shape);
+bool is_input_batched(const ttnn::Shape& shape);
 
 }  // namespace detail
 
@@ -37,15 +37,7 @@ ttnn::Tensor matmul(
     const ttnn::Tensor& input_tensor_a,
     const ttnn::Tensor& input_tensor_b,
     const std::optional<const ttnn::Tensor>& bias,
-    const bool transpose_a = false,
-    const bool transpose_b = false,
-    const std::optional<const MatmulProgramConfig> program_config = std::nullopt,
-    const ttnn::MemoryConfig& memory_config = ttnn::DRAM_MEMORY_CONFIG,
-    std::optional<const DataType> dtype = std::nullopt,
-    const std::optional<const std::string>& activation = std::nullopt,
-    const std::optional<const DeviceComputeKernelConfig> compute_kernel_config = std::nullopt,
-    const std::optional<const ttnn::CoreGrid> core_grid = std::nullopt,
-    const bool propagate_is_b_batched = false);
+    const struct tt::operations::primary::Matmul& parameters);
 
 }  // namespace matmul
 }  // namespace operations

--- a/ttnn/ttnn/operations/matmul.py
+++ b/ttnn/ttnn/operations/matmul.py
@@ -71,17 +71,23 @@ def matmul(
       argument is 1-dimensional, a 1 is prepended to its dimension for the purpose of the
       batched matrix multiply.  If the second argument is 1-dimensional, a
       1 is appended to its dimension for the purpose of the batched matrix multiple.
-      The non-matrix (i.e. batch) dimensions must be broadcastable.  For example, if :attr:`input_tensor_a` is a
-      :math:`(j \\times 1 \\times n_size \\times n_size)` tensor and :attr:`input_tensor_b` is a :math:`(k_size \\times n_size \\times n_size)`
-      tensor, the result will be a :math:`(j \\times k_size \\times n_size \\times n_size)` tensor.
+      The non-matrix (i.e. batch) dimensions must be broadcastable.
+      The behaviour is the same as PyTorch, with the exception of two cases of batch dimensions:
+
+          - The two batch dimensions are swapped. E.g. :math:`(j \\times 1)` and :math:`(1 \\times j)`
+            or :math:`(1 \\times j)` and :math:`(j \\times 1)`
+          - When a batch dimension is implicitly extended then the two patch dimensions are swapped.
+            E.g.  :math:`(j \\times 1)` and :math:`(j)` which is treated as
+            :math:`(j \\times 1)` and :math:`(1 \\times j)`
+
     - In order to leverage sharded matmul implementations we can shard both input_tensor_a and input_tensor_b. The sharding strategy used will be according
       to the sharding stategy on the respective tensor. A sharded 1D matmul can be either HEIGHT or WIDTH sharded, 2D matmuls can be block sharded.
 
       Note that the broadcasting logic only looks at the batch dimensions when determining if the inputs
       are broadcastable, and not the matrix dimensions. For example, if :attr:`input_tensor_a` is a
-      :math:`(j \\times 1 \\times n_size \\times m_size)` tensor and :attr:`input_tensor_b` is a :math:`(k_size \\times m_size \\times p)`
+      :math:`(j \\times 1 \\times n\_size \\times m\_size)` tensor and :attr:`input_tensor_b` is a :math:`(k\_size \\times m\_size \\times p)`
       tensor, these inputs are valid for broadcasting even though the final two dimensions (i.e. the
-      matrix dimensions) are different. The operation will return a :math:`(j \\times k_size \\times n_size \\times p)` tensor.
+      matrix dimensions) are different. The operation will return a :math:`(j \\times k\_size \\times n\_size \\times p)` tensor.
 
 
     .. note::


### PR DESCRIPTION
### Ticket
Link to Github Issue https://github.com/tenstorrent/tt-metal/issues/10045

### Problem description
- matmul has many parameters
- we want to move to passing parameters via structs
- the docs show weird formatting
- the docs don't cover some corner cases

### What's changed
- use a struct to pass parameters for matmul
    - removed some unused methods that called matmul
- update the doc strings to reflect latex syntax properly
- update the doc strings to mention the corner cases

### Checklist
- [x] Post commit CI passes
- [x] Model regression CI testing passes (if applicable)
- [x] New/Existing tests provide coverage for changes

https://github.com/tenstorrent/tt-metal/actions/runs/9892077137 All post commits passes
https://github.com/tenstorrent/tt-metal/actions/runs/9894282721 Model perf passes