### PR TITLE
#10107: Fix hangs w/ launch_msg size >32bytes

### DIFF
--- a/tests/tt_metal/tt_metal/test_kernels/dataflow/dram_copy.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/dataflow/dram_copy.cpp
@@ -34,7 +34,8 @@ void kernel_main() {
 #else
         tt_l1_ptr mailboxes_t* const mailboxes = (tt_l1_ptr mailboxes_t*)(MEM_MAILBOX_BASE);
 #endif
-        uint64_t dispatch_addr = NOC_XY_ADDR(NOC_X(mailboxes->launch.dispatch_core_x), NOC_Y(mailboxes->launch.dispatch_core_y), DISPATCH_MESSAGE_ADDR);
+        uint64_t dispatch_addr = NOC_XY_ADDR(NOC_X(mailboxes->launch.kernel_config.dispatch_core_x),
+                                             NOC_Y(mailboxes->launch.kernel_config.dispatch_core_y), DISPATCH_MESSAGE_ADDR);
         noc_fast_atomic_increment(noc_index, NCRISC_AT_CMD_BUF, dispatch_addr, NOC_UNICAST_WRITE_VC, 1, 31, false);
 #endif
 

--- a/tests/tt_metal/tt_metal/test_kernels/misc/watcher_asserts.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/misc/watcher_asserts.cpp
@@ -40,7 +40,9 @@ void MAIN {
 #else
         tt_l1_ptr mailboxes_t* const mailboxes = (tt_l1_ptr mailboxes_t*)(MEM_MAILBOX_BASE);
 #endif
-        uint64_t dispatch_addr = NOC_XY_ADDR(NOC_X(mailboxes->launch.dispatch_core_x), NOC_Y(mailboxes->launch.dispatch_core_y), DISPATCH_MESSAGE_ADDR);
+        uint64_t dispatch_addr =
+            NOC_XY_ADDR(NOC_X(mailboxes->launch.kernel_config.dispatch_core_x),
+                        NOC_Y(mailboxes->launch.kernel_config.dispatch_core_y), DISPATCH_MESSAGE_ADDR);
         noc_fast_atomic_increment(noc_index, NCRISC_AT_CMD_BUF, dispatch_addr, NOC_UNICAST_WRITE_VC, 1, 31 /*wrap*/, false /*linked*/);
     }
 #else

--- a/tests/tt_metal/tt_metal/unit_tests_common/watcher/test_assert.cpp
+++ b/tests/tt_metal/tt_metal/unit_tests_common/watcher/test_assert.cpp
@@ -154,7 +154,7 @@ static void RunTest(WatcherFixture *fixture, Device *device, riscv_id_t riscv_ty
     // We should be able to find the expected watcher error in the log as well,
     // expected error message depends on the risc we're running on.
     string kernel = "tests/tt_metal/tt_metal/test_kernels/misc/watcher_asserts.cpp";
-    int line_num = 55;
+    int line_num = 57;
 
     string expected = fmt::format(
         "Device {} {} core(x={:2},y={:2}) phys(x={:2},y={:2}): {} tripped an assert on line {}. Current kernel: {}.",

--- a/tt_metal/hw/firmware/src/erisc.cc
+++ b/tt_metal/hw/firmware/src/erisc.cc
@@ -77,12 +77,14 @@ void __attribute__((section("erisc_l1_code.1"), noinline)) Application(void) {
 
     while (routing_info->routing_enabled) {
         // FD: assume that no more host -> remote writes are pending
-        if (mailboxes->launch.run == RUN_MSG_GO) {
+        if (mailboxes->launch.go.run == RUN_MSG_GO) {
             DeviceZoneScopedMainN("ERISC-FW");
             DEBUG_STATUS("R");
-            uint32_t kernel_config_base = mailboxes->launch.kernel_config_base;
-            rta_l1_base = (uint32_t tt_l1_ptr *)(kernel_config_base + mailboxes->launch.mem_map[DISPATCH_CLASS_ETH_DM0].rta_offset);
-            crta_l1_base = (uint32_t tt_l1_ptr *)(kernel_config_base + mailboxes->launch.mem_map[DISPATCH_CLASS_ETH_DM0].crta_offset);
+            uint32_t kernel_config_base = mailboxes->launch.kernel_config.kernel_config_base;
+            rta_l1_base = (uint32_t tt_l1_ptr *)(kernel_config_base +
+                mailboxes->launch.kernel_config.mem_map[DISPATCH_CLASS_ETH_DM0].rta_offset);
+            crta_l1_base = (uint32_t tt_l1_ptr *)(kernel_config_base +
+                mailboxes->launch.kernel_config.mem_map[DISPATCH_CLASS_ETH_DM0].crta_offset);
 
             kernel_init();
         } else {

--- a/tt_metal/hw/firmware/src/erisck.cc
+++ b/tt_metal/hw/firmware/src/erisck.cc
@@ -32,9 +32,11 @@ void __attribute__((section("erisc_l1_code"))) kernel_launch() {
     rtos_context_switch_ptr = (void (*)())RtosTable[0];
 
     kernel_main();
-    mailboxes->launch.run = RUN_MSG_DONE;
-    uint64_t dispatch_addr = NOC_XY_ADDR(NOC_X(mailboxes->launch.dispatch_core_x), NOC_Y(mailboxes->launch.dispatch_core_y), DISPATCH_MESSAGE_ADDR);
-    if (routing_info->routing_enabled and mailboxes->launch.mode == DISPATCH_MODE_DEV) {
+    mailboxes->launch.go.run = RUN_MSG_DONE;
+    uint64_t dispatch_addr =
+        NOC_XY_ADDR(NOC_X(mailboxes->launch.kernel_config.dispatch_core_x),
+                    NOC_Y(mailboxes->launch.kernel_config.dispatch_core_y), DISPATCH_MESSAGE_ADDR);
+    if (routing_info->routing_enabled and mailboxes->launch.kernel_config.mode == DISPATCH_MODE_DEV) {
         internal_::notify_dispatch_core_done(dispatch_addr);
     }
 }

--- a/tt_metal/hw/firmware/src/ncrisc.cc
+++ b/tt_metal/hw/firmware/src/ncrisc.cc
@@ -94,11 +94,13 @@ int main(int argc, char *argv[]) {
         notify_brisc_and_wait();
         DeviceZoneScopedMainN("NCRISC-FW");
 
-        setup_cb_read_write_interfaces(0, mailboxes->launch.max_cb_index, true, true);
+        setup_cb_read_write_interfaces(0, mailboxes->launch.kernel_config.max_cb_index, true, true);
 
-        uint32_t kernel_config_base = mailboxes->launch.kernel_config_base;
-        rta_l1_base = (uint32_t tt_l1_ptr *)(kernel_config_base + mailboxes->launch.mem_map[DISPATCH_CLASS_TENSIX_DM1].rta_offset);
-        crta_l1_base = (uint32_t tt_l1_ptr *)(kernel_config_base + mailboxes->launch.mem_map[DISPATCH_CLASS_TENSIX_DM1].crta_offset);
+        uint32_t kernel_config_base = mailboxes->launch.kernel_config.kernel_config_base;
+        rta_l1_base = (uint32_t tt_l1_ptr *)(kernel_config_base +
+            mailboxes->launch.kernel_config.mem_map[DISPATCH_CLASS_TENSIX_DM1].rta_offset);
+        crta_l1_base = (uint32_t tt_l1_ptr *)(kernel_config_base +
+            mailboxes->launch.kernel_config.mem_map[DISPATCH_CLASS_TENSIX_DM1].crta_offset);
 
         DEBUG_STATUS("R");
         kernel_init();

--- a/tt_metal/hw/firmware/src/trisc.cc
+++ b/tt_metal/hw/firmware/src/trisc.cc
@@ -106,12 +106,14 @@ int main(int argc, char *argv[]) {
         DeviceZoneScopedMainN("TRISC-FW");
 
 #if !defined(UCK_CHLKC_MATH)
-        setup_cb_read_write_interfaces(0, mailboxes->launch.max_cb_index, cb_init_read, cb_init_write);
+        setup_cb_read_write_interfaces(0, mailboxes->launch.kernel_config.max_cb_index, cb_init_read, cb_init_write);
 #endif
 
-        uint32_t kernel_config_base = mailboxes->launch.kernel_config_base;
-        rta_l1_base = (uint32_t tt_l1_ptr *)(kernel_config_base + mailboxes->launch.mem_map[DISPATCH_CLASS_TENSIX_COMPUTE].rta_offset);
-        crta_l1_base = (uint32_t tt_l1_ptr *)(kernel_config_base + mailboxes->launch.mem_map[DISPATCH_CLASS_TENSIX_COMPUTE].crta_offset);
+        uint32_t kernel_config_base = mailboxes->launch.kernel_config.kernel_config_base;
+        rta_l1_base = (uint32_t tt_l1_ptr *)(kernel_config_base +
+            mailboxes->launch.kernel_config.mem_map[DISPATCH_CLASS_TENSIX_COMPUTE].rta_offset);
+        crta_l1_base = (uint32_t tt_l1_ptr *)(kernel_config_base +
+            mailboxes->launch.kernel_config.mem_map[DISPATCH_CLASS_TENSIX_COMPUTE].crta_offset);
 
         DEBUG_STATUS("R");
         kernel_init();

--- a/tt_metal/hw/inc/debug/assert.h
+++ b/tt_metal/hw/inc/debug/assert.h
@@ -19,7 +19,7 @@ void assert_and_hang(uint32_t line_num) {
 
     // Update launch msg to show that we've exited.
     tt_l1_ptr launch_msg_t *launch_msg = GET_MAILBOX_ADDRESS_DEV(launch);
-    launch_msg->run = RUN_MSG_DONE;
+    launch_msg->go.run = RUN_MSG_DONE;
 
     // Hang, or in the case of erisc, early exit.
 #if defined(COMPILE_FOR_ERISC)

--- a/tt_metal/hw/inc/debug/sanitize_noc.h
+++ b/tt_metal/hw/inc/debug/sanitize_noc.h
@@ -83,7 +83,7 @@ inline void debug_sanitize_post_noc_addr_and_hang(
 
     // Update launch msg to show that we've exited.
     tt_l1_ptr launch_msg_t *launch_msg = GET_MAILBOX_ADDRESS_DEV(launch);
-    launch_msg->run = RUN_MSG_DONE;
+    launch_msg->go.run = RUN_MSG_DONE;
 
 #if defined(COMPILE_FOR_ERISC)
     // For erisc, we can't hang the kernel/fw, because the core doesn't get restarted when a new

--- a/tt_metal/hw/inc/dev_msgs.h
+++ b/tt_metal/hw/inc/dev_msgs.h
@@ -76,7 +76,7 @@ struct dyn_mem_map_t {
     volatile uint16_t crta_offset;
 };
 
-struct launch_msg_t {  // must be cacheline aligned
+struct kernel_config_msg_t {
     volatile uint16_t watcher_kernel_ids[DISPATCH_CLASS_MAX];
     volatile uint16_t ncrisc_kernel_size16;  // size in 16 byte units
 
@@ -91,7 +91,16 @@ struct launch_msg_t {  // must be cacheline aligned
     volatile uint8_t dispatch_core_x;
     volatile uint8_t dispatch_core_y;
     volatile uint8_t exit_erisc_kernel;
-    volatile uint8_t run;  // must be in last cacheline of this msg
+    volatile uint8_t pad1;
+} __attribute__((packed));
+
+struct go_msg_t {
+    volatile uint32_t run;  // must be in last cacheline of this msg
+} __attribute__((packed));
+
+struct launch_msg_t {  // must be cacheline aligned
+    kernel_config_msg_t kernel_config;
+    go_msg_t go;
 } __attribute__((packed));
 
 struct slave_sync_msg_t {
@@ -194,7 +203,7 @@ struct mailboxes_t {
     struct debug_insert_delays_msg_t debug_insert_delays;
 };
 
-static_assert(sizeof(launch_msg_t) % sizeof(uint32_t) == 0);
+static_assert(sizeof(kernel_config_msg_t) % sizeof(uint32_t) == 0);
 
 #ifndef TENSIX_FIRMWARE
 // Validate assumptions on mailbox layout on host compile

--- a/tt_metal/impl/debug/watcher_server.cpp
+++ b/tt_metal/impl/debug/watcher_server.cpp
@@ -126,9 +126,9 @@ void create_kernel_file() {
 
 static void log_running_kernels(const launch_msg_t *launch_msg) {
     log_info("While running kernels:");
-    log_info(" brisc : {}", kernel_names[launch_msg->watcher_kernel_ids[DISPATCH_CLASS_TENSIX_DM0]]);
-    log_info(" ncrisc: {}", kernel_names[launch_msg->watcher_kernel_ids[DISPATCH_CLASS_TENSIX_DM1]]);
-    log_info(" triscs: {}", kernel_names[launch_msg->watcher_kernel_ids[DISPATCH_CLASS_TENSIX_COMPUTE]]);
+    log_info(" brisc : {}", kernel_names[launch_msg->kernel_config.watcher_kernel_ids[DISPATCH_CLASS_TENSIX_DM0]]);
+    log_info(" ncrisc: {}", kernel_names[launch_msg->kernel_config.watcher_kernel_ids[DISPATCH_CLASS_TENSIX_DM1]]);
+    log_info(" triscs: {}", kernel_names[launch_msg->kernel_config.watcher_kernel_ids[DISPATCH_CLASS_TENSIX_COMPUTE]]);
 }
 
 static void dump_l1_status(FILE *f, Device *device, CoreCoord core, const launch_msg_t *launch_msg) {
@@ -158,13 +158,13 @@ static const char *get_riscv_name(CoreCoord core, uint32_t type) {
 
 static string get_kernel_name(CoreCoord core, const launch_msg_t *launch_msg, uint32_t type) {
     switch (type) {
-        case DebugBrisc: return kernel_names[launch_msg->watcher_kernel_ids[DISPATCH_CLASS_TENSIX_DM0]];
+        case DebugBrisc: return kernel_names[launch_msg->kernel_config.watcher_kernel_ids[DISPATCH_CLASS_TENSIX_DM0]];
         case DebugErisc:
-        case DebugIErisc: return kernel_names[launch_msg->watcher_kernel_ids[DISPATCH_CLASS_ETH_DM0]];
-        case DebugNCrisc: return kernel_names[launch_msg->watcher_kernel_ids[DISPATCH_CLASS_TENSIX_DM1]];
+        case DebugIErisc: return kernel_names[launch_msg->kernel_config.watcher_kernel_ids[DISPATCH_CLASS_ETH_DM0]];
+        case DebugNCrisc: return kernel_names[launch_msg->kernel_config.watcher_kernel_ids[DISPATCH_CLASS_TENSIX_DM1]];
         case DebugTrisc0:
         case DebugTrisc1:
-        case DebugTrisc2: return kernel_names[launch_msg->watcher_kernel_ids[DISPATCH_CLASS_TENSIX_COMPUTE]];
+        case DebugTrisc2: return kernel_names[launch_msg->kernel_config.watcher_kernel_ids[DISPATCH_CLASS_TENSIX_COMPUTE]];
         default:
             log_running_kernels(launch_msg);
             TT_THROW("Watcher data corrupted, unexpected riscv type on core {}: {}", core.str(), type);
@@ -460,57 +460,57 @@ static void dump_run_mailboxes(
     FILE *f, CoreCoord core, const launch_msg_t *launch_msg, const slave_sync_msg_t *slave_sync) {
     fprintf(f, "rmsg:");
 
-    if (launch_msg->mode == DISPATCH_MODE_DEV) {
+    if (launch_msg->kernel_config.mode == DISPATCH_MODE_DEV) {
         fprintf(f, "D");
-    } else if (launch_msg->mode == DISPATCH_MODE_HOST) {
+    } else if (launch_msg->kernel_config.mode == DISPATCH_MODE_HOST) {
         fprintf(f, "H");
     } else {
         log_running_kernels(launch_msg);
         TT_THROW(
             "Watcher data corruption, unexpected launch mode on core {}: {} (expected {} or {})",
             core.str(),
-            launch_msg->mode,
+            launch_msg->kernel_config.mode,
             DISPATCH_MODE_DEV,
             DISPATCH_MODE_HOST);
     }
 
-    if (launch_msg->brisc_noc_id == 0 || launch_msg->brisc_noc_id == 1) {
-        fprintf(f, "%d", launch_msg->brisc_noc_id);
+    if (launch_msg->kernel_config.brisc_noc_id == 0 || launch_msg->kernel_config.brisc_noc_id == 1) {
+        fprintf(f, "%d", launch_msg->kernel_config.brisc_noc_id);
     } else {
         log_running_kernels(launch_msg);
         TT_THROW(
             "Watcher data corruption, unexpected brisc noc_id on core {}: {} (expected 0 or 1)",
             core.str(),
-            launch_msg->brisc_noc_id);
+            launch_msg->kernel_config.brisc_noc_id);
     }
 
-    dump_run_state(f, core, launch_msg, launch_msg->run);
+    dump_run_state(f, core, launch_msg, launch_msg->go.run);
 
     fprintf(f, "|");
 
-    if (launch_msg->enables & ~(DISPATCH_CLASS_MASK_TENSIX_ENABLE_DM0 |
-                                DISPATCH_CLASS_MASK_TENSIX_ENABLE_DM1 |
-                                DISPATCH_CLASS_MASK_TENSIX_ENABLE_COMPUTE)) {
+    if (launch_msg->kernel_config.enables & ~(DISPATCH_CLASS_MASK_TENSIX_ENABLE_DM0 |
+                                              DISPATCH_CLASS_MASK_TENSIX_ENABLE_DM1 |
+                                              DISPATCH_CLASS_MASK_TENSIX_ENABLE_COMPUTE)) {
         log_running_kernels(launch_msg);
         TT_THROW(
             "Watcher data corruption, unexpected kernel enable on core {}: {} (expected only low bits set)",
             core.str(),
-            launch_msg->enables);
+            launch_msg->kernel_config.enables);
     }
 
-    if (launch_msg->enables & DISPATCH_CLASS_MASK_TENSIX_ENABLE_DM0) {
+    if (launch_msg->kernel_config.enables & DISPATCH_CLASS_MASK_TENSIX_ENABLE_DM0) {
         fprintf(f, "B");
     } else {
         fprintf(f, "b");
     }
 
-    if (launch_msg->enables & DISPATCH_CLASS_MASK_TENSIX_ENABLE_DM1) {
+    if (launch_msg->kernel_config.enables & DISPATCH_CLASS_MASK_TENSIX_ENABLE_DM1) {
         fprintf(f, "N");
     } else {
         fprintf(f, "n");
     }
 
-    if (launch_msg->enables & DISPATCH_CLASS_MASK_TENSIX_ENABLE_COMPUTE) {
+    if (launch_msg->kernel_config.enables & DISPATCH_CLASS_MASK_TENSIX_ENABLE_COMPUTE) {
         fprintf(f, "T");
     } else {
         fprintf(f, "t");
@@ -557,8 +557,8 @@ static void dump_sync_regs(FILE *f, Device *device, CoreCoord core) {
 
 static void validate_kernel_ids(
     FILE *f, std::map<int, bool> &used_kernel_names, chip_id_t device_id, CoreCoord core, const launch_msg_t *launch) {
-    if (launch->watcher_kernel_ids[DISPATCH_CLASS_TENSIX_DM0] >= kernel_names.size()) {
-        uint16_t watcher_kernel_id = launch->watcher_kernel_ids[DISPATCH_CLASS_TENSIX_DM0];
+    if (launch->kernel_config.watcher_kernel_ids[DISPATCH_CLASS_TENSIX_DM0] >= kernel_names.size()) {
+        uint16_t watcher_kernel_id = launch->kernel_config.watcher_kernel_ids[DISPATCH_CLASS_TENSIX_DM0];
         TT_THROW(
             "Watcher data corruption, unexpected brisc kernel id on Device {} core {}: {} (last valid {})",
             device_id,
@@ -566,10 +566,10 @@ static void validate_kernel_ids(
             watcher_kernel_id,
             kernel_names.size());
     }
-    used_kernel_names[launch->watcher_kernel_ids[DISPATCH_CLASS_TENSIX_DM0]] = true;
+    used_kernel_names[launch->kernel_config.watcher_kernel_ids[DISPATCH_CLASS_TENSIX_DM0]] = true;
 
-    if (launch->watcher_kernel_ids[DISPATCH_CLASS_TENSIX_DM1] >= kernel_names.size()) {
-        uint16_t watcher_kernel_id = launch->watcher_kernel_ids[DISPATCH_CLASS_TENSIX_DM1];
+    if (launch->kernel_config.watcher_kernel_ids[DISPATCH_CLASS_TENSIX_DM1] >= kernel_names.size()) {
+        uint16_t watcher_kernel_id = launch->kernel_config.watcher_kernel_ids[DISPATCH_CLASS_TENSIX_DM1];
         TT_THROW(
             "Watcher data corruption, unexpected ncrisc kernel id on Device {} core {}: {} (last valid {})",
             device_id,
@@ -577,10 +577,10 @@ static void validate_kernel_ids(
             watcher_kernel_id,
             kernel_names.size());
     }
-    used_kernel_names[launch->watcher_kernel_ids[DISPATCH_CLASS_TENSIX_DM1]] = true;
+    used_kernel_names[launch->kernel_config.watcher_kernel_ids[DISPATCH_CLASS_TENSIX_DM1]] = true;
 
-    if (launch->watcher_kernel_ids[DISPATCH_CLASS_TENSIX_COMPUTE] >= kernel_names.size()) {
-        uint16_t watcher_kernel_id = launch->watcher_kernel_ids[DISPATCH_CLASS_TENSIX_COMPUTE];
+    if (launch->kernel_config.watcher_kernel_ids[DISPATCH_CLASS_TENSIX_COMPUTE] >= kernel_names.size()) {
+        uint16_t watcher_kernel_id = launch->kernel_config.watcher_kernel_ids[DISPATCH_CLASS_TENSIX_COMPUTE];
         TT_THROW(
             "Watcher data corruption, unexpected trisc kernel id on Device {} core {}: {} (last valid {})",
             device_id,
@@ -588,7 +588,7 @@ static void validate_kernel_ids(
             watcher_kernel_id,
             kernel_names.size());
     }
-    used_kernel_names[launch->watcher_kernel_ids[DISPATCH_CLASS_TENSIX_COMPUTE]] = true;
+    used_kernel_names[launch->kernel_config.watcher_kernel_ids[DISPATCH_CLASS_TENSIX_COMPUTE]] = true;
 }
 
 static void dump_core(
@@ -672,20 +672,20 @@ static void dump_core(
         }
     } else {
         fprintf(f, "rmsg:");
-        dump_run_state(f, core, &mbox_data->launch, mbox_data->launch.run);
+        dump_run_state(f, core, &mbox_data->launch, mbox_data->launch.go.run);
         fprintf(f, " ");
     }
 
     // Eth core only reports erisc kernel id, uses the brisc field
     if (is_eth_core) {
-        fprintf(f, "k_id:%d", mbox_data->launch.watcher_kernel_ids[DISPATCH_CLASS_ETH_DM0]);
+        fprintf(f, "k_id:%d", mbox_data->launch.kernel_config.watcher_kernel_ids[DISPATCH_CLASS_ETH_DM0]);
     } else {
         fprintf(
             f,
             "k_ids:%d|%d|%d",
-            mbox_data->launch.watcher_kernel_ids[DISPATCH_CLASS_TENSIX_DM0],
-            mbox_data->launch.watcher_kernel_ids[DISPATCH_CLASS_TENSIX_DM1],
-            mbox_data->launch.watcher_kernel_ids[DISPATCH_CLASS_TENSIX_COMPUTE]);
+            mbox_data->launch.kernel_config.watcher_kernel_ids[DISPATCH_CLASS_TENSIX_DM0],
+            mbox_data->launch.kernel_config.watcher_kernel_ids[DISPATCH_CLASS_TENSIX_DM1],
+            mbox_data->launch.kernel_config.watcher_kernel_ids[DISPATCH_CLASS_TENSIX_COMPUTE]);
     }
 
     // Ring buffer at the end because it can print a bunch of data

--- a/tt_metal/impl/dispatch/command_queue.cpp
+++ b/tt_metal/impl/dispatch/command_queue.cpp
@@ -929,9 +929,9 @@ void EnqueueProgramCommand::assemble_device_commands() {
         constexpr uint32_t aligned_go_signal_sizeB = align(go_signal_sizeB, L1_ALIGNMENT);
         constexpr uint32_t go_signal_size_words = aligned_go_signal_sizeB / sizeof(uint32_t);
         for (KernelGroup& kernel_group : program.get_kernel_groups(CoreType::WORKER)) {
-            kernel_group.launch_msg.mode = DISPATCH_MODE_DEV;
-            kernel_group.launch_msg.dispatch_core_x = this->dispatch_core.x;
-            kernel_group.launch_msg.dispatch_core_y = this->dispatch_core.y;
+            kernel_group.launch_msg.kernel_config.mode = DISPATCH_MODE_DEV;
+            kernel_group.launch_msg.kernel_config.dispatch_core_x = this->dispatch_core.x;
+            kernel_group.launch_msg.kernel_config.dispatch_core_y = this->dispatch_core.y;
             const void* launch_message_data = (const void*)(&kernel_group.launch_msg);
             for (const CoreRange& core_range : kernel_group.core_ranges.ranges()) {
                 CoreCoord physical_start =
@@ -956,9 +956,9 @@ void EnqueueProgramCommand::assemble_device_commands() {
         }
 
         for (KernelGroup& kernel_group : program.get_kernel_groups(CoreType::ETH)) {
-            kernel_group.launch_msg.mode = DISPATCH_MODE_DEV;
-            kernel_group.launch_msg.dispatch_core_x = this->dispatch_core.x;
-            kernel_group.launch_msg.dispatch_core_y = this->dispatch_core.y;
+            kernel_group.launch_msg.kernel_config.mode = DISPATCH_MODE_DEV;
+            kernel_group.launch_msg.kernel_config.dispatch_core_x = this->dispatch_core.x;
+            kernel_group.launch_msg.kernel_config.dispatch_core_y = this->dispatch_core.y;
             const void* launch_message_data = (const launch_msg_t*)(&kernel_group.launch_msg);
             for (const CoreRange& core_range : kernel_group.core_ranges.ranges()) {
                 for (auto x = core_range.start.x; x <= core_range.end.x; x++) {
@@ -1145,8 +1145,8 @@ void EnqueueProgramCommand::assemble_device_commands() {
             i++;
         }
         for (auto& go_signal : cached_program_command_sequence.go_signals) {
-            go_signal->dispatch_core_x = this->dispatch_core.x;
-            go_signal->dispatch_core_y = this->dispatch_core.y;
+            go_signal->kernel_config.dispatch_core_x = this->dispatch_core.x;
+            go_signal->kernel_config.dispatch_core_y = this->dispatch_core.y;
         }
     }
 }

--- a/tt_metal/impl/dispatch/kernels/cq_helpers.hpp
+++ b/tt_metal/impl/dispatch/kernels/cq_helpers.hpp
@@ -11,7 +11,7 @@
 // Helper function to determine if the dispatch kernel needs to early exit, only valid for IERISC.
 FORCE_INLINE bool early_exit() {
     tt_l1_ptr mailboxes_t * const mailbox = (tt_l1_ptr mailboxes_t *)(MEM_IERISC_MAILBOX_BASE);
-    return mailbox->launch.exit_erisc_kernel;
+    return mailbox->launch.kernel_config.exit_erisc_kernel;
 }
 
 #define IDLE_ERISC_RETURN(...) \

--- a/tt_metal/impl/dispatch/kernels/eth_tunneler.cpp
+++ b/tt_metal/impl/dispatch/kernels/eth_tunneler.cpp
@@ -153,7 +153,7 @@ void kernel_main() {
         }
 
         tt_l1_ptr launch_msg_t * const launch_msg = GET_MAILBOX_ADDRESS_DEV(launch);
-        if (launch_msg->exit_erisc_kernel) {
+        if (launch_msg->kernel_config.exit_erisc_kernel) {
             return;
         }
         // need to optimize this.

--- a/tt_metal/llrt/llrt.hpp
+++ b/tt_metal/llrt/llrt.hpp
@@ -73,7 +73,7 @@ std::vector<std::uint32_t> read_hex_vec_from_core(chip_id_t chip, const CoreCoor
 
 CoreCoord logical_core_from_ethernet_core(chip_id_t chip_id, CoreCoord &physical_core);
 
-void write_launch_msg_to_core(chip_id_t chip, CoreCoord core, launch_msg_t *msg);
+void write_launch_msg_to_core(chip_id_t chip, CoreCoord core, launch_msg_t *msg, bool send_go = true);
 
 void launch_erisc_app_fw_on_core(chip_id_t chip, CoreCoord core);
 

--- a/tt_metal/llrt/tlb_config.cpp
+++ b/tt_metal/llrt/tlb_config.cpp
@@ -185,7 +185,13 @@ void configure_static_tlbs(tt::ARCH arch, chip_id_t mmio_device_id, const metal_
     // Setup static TLBs for all worker cores
     for (auto &core : statically_mapped_cores) {
         auto tlb_index = get_static_tlb_index(core);
-        device_driver.configure_tlb(mmio_device_id, core, tlb_index, address);
+        // TODO
+        // Note: see issue #10107
+        // Strict is less performant than Posted, however, metal doesn't presently
+        // use this on a perf path and the launch_msg "kernel config" needs to
+        // arrive prior to the "go" message during device init and slow dispatch
+        // Revisit this when we have a more flexible UMD api
+        device_driver.configure_tlb(mmio_device_id, core, tlb_index, address, TLB_DATA::Strict);
     }
 
     // TODO (#9932): Remove workaround for BH

--- a/tt_metal/tt_metal.cpp
+++ b/tt_metal/tt_metal.cpp
@@ -647,7 +647,7 @@ void WriteRuntimeArgsToDevice(Device *device, Program &program) {
                                 }
 
                                 if (rt_args.size() > 0) {
-                                    auto args_base_addr = kernel_config_base + kg.launch_msg.mem_map[dispatch_class].rta_offset;
+                                    auto args_base_addr = kernel_config_base + kg.launch_msg.kernel_config.mem_map[dispatch_class].rta_offset;
                                     log_trace(
                                               tt::LogMetal,
                                               "{} - Writing {} unique rtargs to core {} (physical: {}) addr 0x{:x} => args: {}",
@@ -662,7 +662,7 @@ void WriteRuntimeArgsToDevice(Device *device, Program &program) {
 
                                 const auto &common_rt_args = kernel->common_runtime_args();
                                 if (common_rt_args.size() > 0) {
-                                    auto common_rt_args_addr = kernel_config_base + kg.launch_msg.mem_map[dispatch_class].crta_offset;
+                                    auto common_rt_args_addr = kernel_config_base + kg.launch_msg.kernel_config.mem_map[dispatch_class].crta_offset;
                                     log_trace(
                                               tt::LogMetal,
                                               "{} - Writing {} common rtargs to core {} (physical: {}) addr 0x{:x} => args: {}",


### PR DESCRIPTION
Change default MMIO TLB ordering from posted to strict (will have a negative perf impact)
Split launch message into kernel_config and go
Write these separately from host w/ an sfence between

### Ticket
#10107 

### Problem description
launch message grew to beyond 32 bytes, default TLB settings were relaxed resulting in split transactions and hangs

### What's changed
See above

### Checklist
- [ ] Post commit CI passes
- [ ] Model regression CI testing passes (if applicable)
- [ ] New/Existing tests provide coverage for changes
