### PR TITLE
Add pytest xdist multiprocess to single-chip demo tests

### DIFF
--- a/tests/scripts/single_card/run_demos_single_card_n150_tests.sh
+++ b/tests/scripts/single_card/run_demos_single_card_n150_tests.sh
@@ -10,13 +10,13 @@ fi
 export WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml
 
 # working on both
-pytest --disable-warnings -q -s --input-method=cli --cli-input="YOUR PROMPT GOES HERE!"  models/demos/wormhole/falcon7b/demo_wormhole.py::test_demo[user_input0-default_mode_stochastic]
+pytest -n auto --disable-warnings -q -s --input-method=cli --cli-input="YOUR PROMPT GOES HERE!"  models/demos/wormhole/falcon7b/demo_wormhole.py::test_demo[user_input0-default_mode_stochastic]
 
 # working on both
-pytest models/demos/wormhole/mistral7b/demo/demo.py::test_demo[instruct_weights]
+pytest -n auto models/demos/wormhole/mistral7b/demo/demo.py::test_demo[instruct_weights] --timeout 420
 
 # working on both
-pytest --disable-warnings -q -s --input-method=cli --cli-input="YOUR PROMPT GOES HERE!"  models/demos/mamba/demo/demo.py
+pytest -n auto --disable-warnings -q -s --input-method=cli --cli-input="YOUR PROMPT GOES HERE!"  models/demos/mamba/demo/demo.py --timeout 420
 
 # working on both
-pytest --disable-warnings --input-path="models/demos/wormhole/stable_diffusion/demo/input_data.json" models/demos/wormhole/stable_diffusion/demo/demo.py::test_demo
+pytest -n auto --disable-warnings --input-path="models/demos/wormhole/stable_diffusion/demo/input_data.json" models/demos/wormhole/stable_diffusion/demo/demo.py::test_demo --timeout 900

--- a/tests/scripts/single_card/run_demos_single_card_n300_tests.sh
+++ b/tests/scripts/single_card/run_demos_single_card_n300_tests.sh
@@ -14,4 +14,4 @@ source tests/scripts/single_card/run_demos_single_card_n150_tests.sh
 # Not working on N150, working on N300
 unset WH_ARCH_YAML
 rm -rf built
-pytest --disable-warnings models/demos/metal_BERT_large_11/demo/demo.py -k batch_7
+pytest -n auto --disable-warnings models/demos/metal_BERT_large_11/demo/demo.py -k batch_7


### PR DESCRIPTION
### Ticket
N/A

### Problem description
The pytests in the single-chip demo pipeline were not using the xdist plugin with `-n auto`, so hangs in c++ would not be caught with `pytest-timeout`

### What's changed
- Enabled xdist for the tests in the single-chip demo pipeline to catch c++ hangs 
- Updated test timeout values

### Checklist
- [x] Post commit CI passes
- [x] Model regression CI testing passes (if applicable)
- [x] New/Existing tests provide coverage for changes
