### PR TITLE
#10045: remove use_1d_systolic_array from ttnn matmul

### DIFF
--- a/models/demos/falcon7b/tt/falcon_attention.py
+++ b/models/demos/falcon7b/tt/falcon_attention.py
@@ -403,7 +403,6 @@ class TtFalconAttentionPrefill(nn.Module):
                     dtype=self.model_config["FUSED_QKV_MM_OUTPUT_DTYPE"],
                     compute_kernel_config=self.model_config["FUSED_QKV_MM_OPTIMIZED_KERNEL_CONFIG"],
                     core_grid=ttnn.CoreGrid(y=7, x=8),
-                    use_1d_systolic_array=True,
                 )
                 for device_id in range(self.num_devices)
             ]
@@ -558,7 +557,6 @@ class TtFalconAttentionPrefill(nn.Module):
                 dtype=self.model_config["SELFOUT_MM_OUTPUT_DTYPE"],
                 compute_kernel_config=self.model_config["SELFOUT_MM_OPTIMIZED_KERNEL_CONFIG"],
                 core_grid=ttnn.CoreGrid(y=7, x=8),
-                use_1d_systolic_array=True,
             )
             for device_id in range(self.num_devices)
         ]

--- a/models/demos/falcon7b/tt/falcon_causallm.py
+++ b/models/demos/falcon7b/tt/falcon_causallm.py
@@ -169,7 +169,6 @@ class TtFalconCausalLM(TtFalconModelShared):
                         memory_config=self.model_config["LM_HEAD_MM_OUTPUT_MEMCFG"],
                         dtype=self.model_config["LM_HEAD_MM_OUTPUT_DTYPE"],
                         core_grid=get_falcon_default_core_grid(hidden_states[device_id].device()),
-                        use_1d_systolic_array=True,
                         compute_kernel_config=self.model_config["LM_HEAD_KERNEL_CONFIG"],
                     )
                     for device_id in range(self.num_devices)

--- a/models/demos/falcon7b/tt/falcon_mlp.py
+++ b/models/demos/falcon7b/tt/falcon_mlp.py
@@ -40,7 +40,6 @@ def falcon_dense_4h_to_h_matmul(
         memory_config=output_mem_config,
         dtype=output_dtype,
         core_grid=core_grid,
-        use_1d_systolic_array=True,
         compute_kernel_config=compute_kernel_config,
     )
 
@@ -272,7 +271,6 @@ class TtFalconMLPPrefill(nn.Module):
                         memory_config=self.model_config["DENSE_H_TO_4H_MM_OUTPUT_MEMCFG"],
                         dtype=self.model_config["DENSE_H_TO_4H_MM_OUTPUT_DTYPE"],
                         core_grid=get_falcon_default_core_grid(x[device_id].device()),
-                        use_1d_systolic_array=True,
                         compute_kernel_config=self.model_config["MLP_KERNEL_CONFIG"],
                         activation="gelu",
                     )
@@ -285,7 +283,6 @@ class TtFalconMLPPrefill(nn.Module):
                     memory_config=self.model_config["DENSE_4H_TO_H_MM_OUTPUT_MEMCFG"],
                     dtype=self.model_config["DENSE_4H_TO_H_MM_OUTPUT_DTYPE"],
                     core_grid=get_falcon_default_core_grid(hidden_states[device_id].device()),
-                    use_1d_systolic_array=True,
                     compute_kernel_config=self.model_config["MLP_KERNEL_CONFIG"],
                 )
 

--- a/models/demos/mamba/tt/full_model.py
+++ b/models/demos/mamba/tt/full_model.py
@@ -145,7 +145,7 @@ class MambaTT(torch.nn.Module):
             x,
             self.lm_head_weights,
             memory_config=ttnn.L1_MEMORY_CONFIG,
-            use_1d_systolic_array=True,
+            core_grid=x.device().core_grid,
             compute_kernel_config=self.compute_kernel_config,
             dtype=self.configs["dtype"]["activations"],
         )

--- a/models/demos/mamba/tt/mamba_block.py
+++ b/models/demos/mamba/tt/mamba_block.py
@@ -115,7 +115,7 @@ class TtMambaBlock(torch.nn.Module):
             self.ssm_in_proj_weights,
             memory_config=ttnn.L1_MEMORY_CONFIG,
             compute_kernel_config=self.compute_kernel_config,
-            use_1d_systolic_array=True,
+            core_grid=x.device().core_grid,
             dtype=ttnn.bfloat16,  # convolution requires bfloat16
         )
         ttnn.deallocate(x)
@@ -200,7 +200,7 @@ class TtMambaBlock(torch.nn.Module):
             self.out_proj_weights,
             memory_config=ttnn.L1_MEMORY_CONFIG,
             compute_kernel_config=self.compute_kernel_config,
-            use_1d_systolic_array=True,
+            core_grid=out.device().core_grid,
             dtype=self.configs["dtype"]["activations"],
         )
         ttnn.deallocate(out)

--- a/models/demos/mamba/tt/mamba_one_step_ssm.py
+++ b/models/demos/mamba/tt/mamba_one_step_ssm.py
@@ -125,7 +125,6 @@ class TtMambaSSM(torch.nn.Module):
             self.delta_t_proj_weights,
             memory_config=ttnn.L1_MEMORY_CONFIG,
             compute_kernel_config=self.compute_kernel_config,
-            use_1d_systolic_array=True,
             core_grid=ttnn.CoreGrid(y=self.core_grid_row, x=self.core_grid_col),
             dtype=self.configs["dtype"]["activations"],
         )
@@ -136,7 +135,6 @@ class TtMambaSSM(torch.nn.Module):
             bias=self.dt_proj_bias,
             memory_config=ttnn.L1_MEMORY_CONFIG,
             compute_kernel_config=self.compute_kernel_config,
-            use_1d_systolic_array=True,
             core_grid=ttnn.CoreGrid(y=self.core_grid_row, x=self.core_grid_col),
             dtype=self.configs["dtype"]["activations"],
         )
@@ -176,7 +174,6 @@ class TtMambaSSM(torch.nn.Module):
             self.B_proj_weights,
             memory_config=ttnn.L1_MEMORY_CONFIG,
             compute_kernel_config=self.compute_kernel_config,
-            use_1d_systolic_array=True,
             core_grid=ttnn.CoreGrid(y=self.core_grid_row, x=self.core_grid_col),
             dtype=self.configs["dtype"]["activations"],
         )
@@ -263,7 +260,6 @@ class TtMambaSSM(torch.nn.Module):
             self.C_proj_weights,
             memory_config=ttnn.L1_MEMORY_CONFIG,
             compute_kernel_config=self.compute_kernel_config,
-            use_1d_systolic_array=True,
             core_grid=ttnn.CoreGrid(y=self.core_grid_row, x=self.core_grid_col),
             dtype=self.configs["dtype"]["activations"],
         )  # b,n

--- a/models/demos/ttnn_falcon7b/tt/falcon_attention.py
+++ b/models/demos/ttnn_falcon7b/tt/falcon_attention.py
@@ -96,7 +96,6 @@ class TtFalconAttention:
             input_tensor_b=self.query_key_value_weights,
             memory_config=self.model_config["FUSED_QKV_MM_OUTPUT_MEMCFG"],
             dtype=self.model_config["FUSED_QKV_MM_OUTPUT_DTYPE"],
-            use_1d_systolic_array=True,
             core_grid=self.core_grid,
         )
         batch_size, _, sequence_size, fused_query_key_value_width = fused_query_key_value.shape
@@ -260,7 +259,6 @@ class TtFalconAttention:
             attn_output,
             self.dense_weights,
             memory_config=self.model_config["SELFOUT_MM_OUTPUT_MEMCFG"],
-            use_1d_systolic_array=True,
             core_grid=self.core_grid,
         )
 

--- a/models/demos/ttnn_falcon7b/tt/falcon_causallm.py
+++ b/models/demos/ttnn_falcon7b/tt/falcon_causallm.py
@@ -66,7 +66,6 @@ class TtFalconCausalLM(TtFalconModelShared):
             self.lm_head_weights,
             memory_config=self.model_config["LM_HEAD_MM_OUTPUT_MEMCFG"],
             dtype=self.model_config["LM_HEAD_MM_OUTPUT_DTYPE"],
-            use_1d_systolic_array=True,
             core_grid=self.core_grid,
         )
 

--- a/models/demos/ttnn_falcon7b/tt/falcon_mlp.py
+++ b/models/demos/ttnn_falcon7b/tt/falcon_mlp.py
@@ -27,7 +27,6 @@ class TtFalconMLP:
             self.dense_h_to_4h_weights,
             memory_config=self.model_config["DENSE_H_TO_4H_MM_OUTPUT_MEMCFG"],
             dtype=self.model_config["DENSE_H_TO_4H_MM_OUTPUT_DTYPE"],
-            use_1d_systolic_array=True,
             activation="gelu",
             compute_kernel_config=self.compute_kernel_config,
             core_grid=self.core_grid,
@@ -37,7 +36,6 @@ class TtFalconMLP:
             self.dense_4h_to_h_weights,
             memory_config=self.model_config["DENSE_4H_TO_H_MM_OUTPUT_MEMCFG"],
             dtype=self.model_config["DENSE_4H_TO_H_MM_OUTPUT_DTYPE"],
-            use_1d_systolic_array=True,
             compute_kernel_config=self.compute_kernel_config,
             core_grid=self.core_grid,
         )

--- a/tests/ttnn/sweep_tests/sweeps/sweeps/matmul/short/matmul_create_program_config.py
+++ b/tests/ttnn/sweep_tests/sweeps/sweeps/matmul/short/matmul_create_program_config.py
@@ -125,8 +125,7 @@ def run(
         input_tensor_b,
         memory_config=output_memory_config,
         dtype=output_dtype,
-        core_grid=core_grid,
-        use_1d_systolic_array=use_1d_systolic_array,
+        core_grid=core_grid or device.core_grid,
         compute_kernel_config=compute_kernel_config,
     )
     output_tensor = ttnn.to_torch(output_tensor)

--- a/tests/ttnn/unit_tests/operations/test_linear.py
+++ b/tests/ttnn/unit_tests/operations/test_linear.py
@@ -139,7 +139,7 @@ def test_linear_with_core_grid(
 @pytest.mark.parametrize("k_size", [1024, 2048])
 @pytest.mark.parametrize("n_size", [1024, 2048])
 @pytest.mark.parametrize("activation", [None, "relu", "silu"])
-def test_wide_linear_with_argument_for_using_1D_systolic_array_set_to_true(
+def test_wide_linear_with_argument_for_core_grid_set_to_device_grid(
     device, batch_size, m_size, k_size, n_size, activation
 ):
     torch.manual_seed(0)
@@ -155,7 +155,7 @@ def test_wide_linear_with_argument_for_using_1D_systolic_array_set_to_true(
     input_tensor_a = ttnn.from_torch(torch_input_tensor_a, layout=ttnn.TILE_LAYOUT, device=device)
     input_tensor_b = ttnn.from_torch(torch_input_tensor_b, layout=ttnn.TILE_LAYOUT, device=device)
 
-    output_tensor = ttnn.linear(input_tensor_a, input_tensor_b, use_1d_systolic_array=True, activation=activation)
+    output_tensor = ttnn.linear(input_tensor_a, input_tensor_b, core_grid=device.core_grid, activation=activation)
 
     output_tensor = ttnn.to_torch(output_tensor)
     assert_with_pcc(torch_output_tensor, output_tensor, 0.997)

--- a/tests/ttnn/unit_tests/operations/test_matmul.py
+++ b/tests/ttnn/unit_tests/operations/test_matmul.py
@@ -413,7 +413,7 @@ def test_matmul_with_core_grid(device, batch_size):
 @pytest.mark.parametrize("m_size", [30, 61])
 @pytest.mark.parametrize("k_size", [1023, 2048])
 @pytest.mark.parametrize("n_size", [1021, 2048])
-def test_wide_matmul_with_argument_for_using_1D_systolic_array_set_to_true(device, batch_size, m_size, k_size, n_size):
+def test_wide_matmul_with_argument_for_core_grid_set_to_device_grid(device, batch_size, m_size, k_size, n_size):
     torch.manual_seed(0)
 
     torch_input_tensor_a = torch.randn((batch_size, m_size, k_size), dtype=torch.bfloat16)
@@ -426,7 +426,7 @@ def test_wide_matmul_with_argument_for_using_1D_systolic_array_set_to_true(devic
     output_tensor = ttnn.matmul(
         input_tensor_a,
         input_tensor_b,
-        use_1d_systolic_array=True,
+        core_grid=device.core_grid,
     )
 
     output_tensor = ttnn.to_torch(output_tensor)
@@ -438,7 +438,7 @@ def test_wide_matmul_with_argument_for_using_1D_systolic_array_set_to_true(devic
 @pytest.mark.parametrize("m_size", [1024, 2048])
 @pytest.mark.parametrize("k_size", [1023, 2048])
 @pytest.mark.parametrize("n_size", [32, 61])
-def test_tall_matmul_with_argument_for_using_1D_systolic_array_set_to_true(device, batch_size, m_size, k_size, n_size):
+def test_tall_matmul_with_argument_for_core_grid_set_to_device_grid(device, batch_size, m_size, k_size, n_size):
     torch.manual_seed(0)
 
     torch_input_tensor_a = torch.randn((batch_size, m_size, k_size), dtype=torch.bfloat16)
@@ -451,7 +451,7 @@ def test_tall_matmul_with_argument_for_using_1D_systolic_array_set_to_true(devic
     output_tensor = ttnn.matmul(
         input_tensor_a,
         input_tensor_b,
-        use_1d_systolic_array=True,
+        core_grid=device.core_grid,
     )
 
     output_tensor = ttnn.to_torch(output_tensor)
@@ -476,7 +476,7 @@ def test_matmul_by_passing_in_1D_systolic_array_program_config(device, batch_siz
     output_tensor = ttnn.matmul(
         input_tensor_a,
         input_tensor_b,
-        core_grid=input_tensor_a.device().core_grid,
+        core_grid=device.core_grid,
     )
 
     output_tensor = ttnn.to_torch(output_tensor)
@@ -536,7 +536,6 @@ def test_falcon_query_key_value_matmul(device, batch_size, m_size, k_size, n_siz
     output_tensor = ttnn.matmul(
         input_tensor_a,
         input_tensor_b,
-        use_1d_systolic_array=True,
         core_grid=core_grid,
     )
 
@@ -639,14 +638,12 @@ def test_sd_matmul(device, batch_size, channel_a, channel_b, m_size, k_size, n_s
             input_tensor_a,
             input_tensor_b,
             bias=input_tensor_c,
-            # use_1d_systolic_array=True,
             core_grid=core_grid,
         )
     else:
         output_tensor = ttnn.matmul(
             input_tensor_a,
             input_tensor_b,
-            # use_1d_systolic_array=True,
             core_grid=core_grid,
         )
 

--- a/tests/ttnn/unit_tests/test_multi_device.py
+++ b/tests/ttnn/unit_tests/test_multi_device.py
@@ -499,7 +499,6 @@ def test_4b_tensor(device_mesh):
         compute_kernel_config=ttnn.WormholeComputeKernelConfig(
             math_fidelity=ttnn.MathFidelity.LoFi, fp32_dest_acc_en=True, packer_l1_acc=True
         ),
-        use_1d_systolic_array=True,
     )
 
 

--- a/ttnn/ttnn/operations/matmul.py
+++ b/ttnn/ttnn/operations/matmul.py
@@ -50,11 +50,10 @@ def matmul(
     core_grid: Optional[ttnn.CoreGrid] = None,
     program_config: Optional[MatmulProgramConfig] = None,
     activation: Optional[str] = None,
-    use_1d_systolic_array: Optional[bool] = None,
     compute_kernel_config: Optional[ttnn.DeviceComputeKernelConfig] = None,
 ) -> ttnn.Tensor:
     """
-    matmul(input_tensor_a: ttnn.Tensor, input_tensor_b: ttnn.Tensor, *, memory_config: ttnn.MemoryConfig=ttnn.DRAM_MEMORY_CONFIG, dtype: Optional[ttnn.DataType] = None, core_grid: Optional[ttnn.CoreGrid] = None, program_config: Optional[MatmulProgramConfig] = None, activation: Optional[str] = None, use_1d_systolic_array: Optional[bool] = None, compute_kernel_config: Optional[ttnn.DeviceComputeKernelConfig] = None) -> ttnn.Tensor
+    matmul(input_tensor_a: ttnn.Tensor, input_tensor_b: ttnn.Tensor, *, memory_config: ttnn.MemoryConfig=ttnn.DRAM_MEMORY_CONFIG, dtype: Optional[ttnn.DataType] = None, core_grid: Optional[ttnn.CoreGrid] = None, program_config: Optional[MatmulProgramConfig] = None, activation: Optional[str] = None, compute_kernel_config: Optional[ttnn.DeviceComputeKernelConfig] = None) -> ttnn.Tensor
 
     Returns the matrix product of two tensors.
 
@@ -104,7 +103,6 @@ def matmul(
         * :attr:`core_grid` (ttnn.CoreGrid): the grid on which to distribute the sharded tensor on (writes to the cores L1s). Defaults to None
         * :attr:`program_config` (ttnn.MatmulProgramConfig): the program configuration for the matmul operation. Defaults to None
         * :attr:`activation` (Optional[str]): the activation function to be applied. Defaults to None
-        * :attr:`use_1d_systolic_array` (bool): whether to use a 1D systolic array. Defaults to None which means it will be determined automatically
         * :attr:`compute_kernel_config` (ttnn.DeviceComputeKernelConfig): the compute kernel configuration for the matmul operation. Defaults to None
 
     Example::
@@ -140,11 +138,6 @@ def matmul(
         >>> print(output.shape)
         [10, 64, 128]
     """
-    if use_1d_systolic_array is not None or core_grid is not None:
-        if program_config is not None:
-            raise RuntimeError(f"Cannot use program_config with use_1d_systolic_array or core_grid")
-        core_grid = core_grid or input_tensor_a.device().core_grid
-
     return ttnn._ttnn.operations.matmul.matmul(
         input_tensor_a,
         input_tensor_b,
@@ -200,11 +193,10 @@ def linear(
     core_grid: Optional[ttnn.CoreGrid] = None,
     program_config: Optional[MatmulProgramConfig] = None,
     activation: Optional[str] = None,
-    use_1d_systolic_array: Optional[bool] = None,
     compute_kernel_config: Optional[ttnn.DeviceComputeKernelConfig] = None,
 ) -> ttnn.Tensor:
     """
-    linear(input_tensor_a: ttnn.Tensor, input_tensor_b: ttnn.Tensor, *, bias: Optional[ttnn.Tensor] = None, memory_config: ttnn.MemoryConfig=ttnn.DRAM_MEMORY_CONFIG, dtype: Optional[ttnn.DataType] = None, core_grid: Optional[ttnn.CoreGrid] = None, program_config: Optional[MatmulProgramConfig] = None, activation: Optional[str] = None, use_1d_systolic_array: Optional[bool] = None, compute_kernel_config: Optional[ttnn.DeviceComputeKernelConfig] = None) -> ttnn.Tensor
+    linear(input_tensor_a: ttnn.Tensor, input_tensor_b: ttnn.Tensor, *, bias: Optional[ttnn.Tensor] = None, memory_config: ttnn.MemoryConfig=ttnn.DRAM_MEMORY_CONFIG, dtype: Optional[ttnn.DataType] = None, core_grid: Optional[ttnn.CoreGrid] = None, program_config: Optional[MatmulProgramConfig] = None, activation: Optional[str] = None, compute_kernel_config: Optional[ttnn.DeviceComputeKernelConfig] = None) -> ttnn.Tensor
 
     Returns the linear transformation of the inputs
 
@@ -219,7 +211,6 @@ def linear(
         * :attr:`core_grid` (Optional[ttnn.CoreGrid]): the grid on which to distribute the sharded tensor on (writes to the cores L1s). Defaults to None
         * :attr:`program_config` (Optional[MatmulProgramConfig]): the program configuration for the matmul operation. Defaults to None
         * :attr:`activation` (Optional[str]): the activation function to be applied. Defaults to None
-        * :attr:`use_1d_systolic_array` (Optional[bool]): whether to use 1D systolic array. Defaults to None which means it will be determined automatically
         * :attr:`compute_kernel_config` (Optional[ttnn.DeviceComputeKernelConfig]): the compute kernel configuration for the matmul operation. Defaults to None
 
     Example::
@@ -231,11 +222,6 @@ def linear(
         >>> print(output.shape)
         [10, 64, 128]
     """
-    if use_1d_systolic_array is not None or core_grid is not None:
-        if program_config is not None:
-            raise RuntimeError(f"Cannot use program_config with use_1d_systolic_array or core_grid")
-        core_grid = core_grid or input_tensor_a.device().core_grid
-
     # FIXME: passing an fp32 compute_kernel_config will cause the underlying C++ function to fail
     return ttnn._ttnn.operations.matmul.linear(
         input_tensor_a,


### PR DESCRIPTION
### Ticket
Link to Github Issue https://github.com/tenstorrent/tt-metal/issues/10045

### Problem description
- the functionality for use_1d_systolic_array has been reduced in previous refactors, if it is set and core grid isn't, the device core grid is used as the core grid
- the parameter is no longer useful

### What's changed
- the parameter is removed while the existing functionality is retained
- to maintain parity change models/tests to function as before, set core grid instead of use_1d_systolic_array where it wasn't already

### Checklist
- [x] Post commit CI passes
- [x] Model regression CI testing passes (if applicable)
- [x] New/Existing tests provide coverage for changes

https://github.com/tenstorrent/tt-metal/actions/runs/9894174092 All post commits passes
https://github.com/tenstorrent/tt-metal/actions/runs/9894181793 Model perf passes
