### PR TITLE
#10165: Fix build error with g++-12

### DIFF
--- a/tt_metal/impl/debug/watcher_server.cpp
+++ b/tt_metal/impl/debug/watcher_server.cpp
@@ -558,31 +558,34 @@ static void dump_sync_regs(FILE *f, Device *device, CoreCoord core) {
 static void validate_kernel_ids(
     FILE *f, std::map<int, bool> &used_kernel_names, chip_id_t device_id, CoreCoord core, const launch_msg_t *launch) {
     if (launch->watcher_kernel_ids[DISPATCH_CLASS_TENSIX_DM0] >= kernel_names.size()) {
+        uint16_t watcher_kernel_id = launch->watcher_kernel_ids[DISPATCH_CLASS_TENSIX_DM0];
         TT_THROW(
             "Watcher data corruption, unexpected brisc kernel id on Device {} core {}: {} (last valid {})",
             device_id,
             core.str(),
-            launch->watcher_kernel_ids[DISPATCH_CLASS_TENSIX_DM0],
+            watcher_kernel_id,
             kernel_names.size());
     }
     used_kernel_names[launch->watcher_kernel_ids[DISPATCH_CLASS_TENSIX_DM0]] = true;
 
     if (launch->watcher_kernel_ids[DISPATCH_CLASS_TENSIX_DM1] >= kernel_names.size()) {
+        uint16_t watcher_kernel_id = launch->watcher_kernel_ids[DISPATCH_CLASS_TENSIX_DM1];
         TT_THROW(
             "Watcher data corruption, unexpected ncrisc kernel id on Device {} core {}: {} (last valid {})",
             device_id,
             core.str(),
-            launch->watcher_kernel_ids[DISPATCH_CLASS_TENSIX_DM1],
+            watcher_kernel_id,
             kernel_names.size());
     }
     used_kernel_names[launch->watcher_kernel_ids[DISPATCH_CLASS_TENSIX_DM1]] = true;
 
     if (launch->watcher_kernel_ids[DISPATCH_CLASS_TENSIX_COMPUTE] >= kernel_names.size()) {
+        uint16_t watcher_kernel_id = launch->watcher_kernel_ids[DISPATCH_CLASS_TENSIX_COMPUTE];
         TT_THROW(
             "Watcher data corruption, unexpected trisc kernel id on Device {} core {}: {} (last valid {})",
             device_id,
             core.str(),
-            launch->watcher_kernel_ids[DISPATCH_CLASS_TENSIX_COMPUTE],
+            watcher_kernel_id,
             kernel_names.size());
     }
     used_kernel_names[launch->watcher_kernel_ids[DISPATCH_CLASS_TENSIX_COMPUTE]] = true;


### PR DESCRIPTION
### Ticket
[Link to Github Issue](https://github.com/tenstorrent/tt-metal/issues/10165)

### Problem description
- cannot bind packed field ‘launch->watcher_kernel_ids[2]’ to ‘const volatile short unsigned int&’

### What's changed
- Copy the value and pass it to `TT_THROW`

### Checklist
- [x] Post commit CI passes
- [x] Model regression CI testing passes (if applicable)
- [x] New/Existing tests provide coverage for changes
All post-commit tests passed https://github.com/tenstorrent/tt-metal/actions/runs/9894497499
