### PR TITLE
[CCL] Making buffer size dynamic to input slice

### DIFF
--- a/tests/tt_eager/python_api_testing/unit_testing/misc/test_reduce_scatter_post_commit.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/misc/test_reduce_scatter_post_commit.py
@@ -122,6 +122,7 @@ def run_reduce_scatter_test(
 @pytest.mark.parametrize(
     "per_chip_output_shape, scatter_dim, layout",
     [
+        ([1, 1, 32, 32 * 8], 3, ttl.tensor.Layout.TILE),
         ([1, 8, 1024, 1024], 3, ttl.tensor.Layout.TILE),
         ([1, 4, 2048, 1024], 3, ttl.tensor.Layout.TILE),
         # # # Has worker slice size warning - defaults to 1x1

--- a/tt_eager/tt_dnn/op_library/ccl/ccl_common.cpp
+++ b/tt_eager/tt_dnn/op_library/ccl/ccl_common.cpp
@@ -224,6 +224,11 @@ RingReduceScatterTensorSlicer::RingReduceScatterTensorSlicer(
     TT_ASSERT(this->worker_slice_offsets.size() == this->worker_slice_shapes.size());
 }
 
+uint32_t RingReduceScatterTensorSlicer::get_worker_slice_size_bytes(int worker_index) {
+    auto worker_slice_shape = this->worker_slice_shapes.at(worker_index);
+    return worker_slice_shape.x * worker_slice_shape.y * this->input_page_size;
+}
+
 std::vector<tt_xy_pair> RingReduceScatterTensorSlicer::compute_worker_slice_offsets(
     std::vector<tt_xy_pair> const& worker_slice_shapes, tt_xy_pair const& tensor_slice_shape) {
     std::vector<tt_xy_pair> worker_slice_offsets;

--- a/tt_eager/tt_dnn/op_library/ccl/ccl_common.hpp
+++ b/tt_eager/tt_dnn/op_library/ccl/ccl_common.hpp
@@ -333,6 +333,8 @@ class RingReduceScatterTensorSlicer : public LegacyCclTensorSlicer {
 
    public:
     std::vector<tt_xy_pair> get_worker_slice_shapes() const { return this->worker_slice_shapes; }
+    uint32_t get_worker_slice_size_bytes(int worker_index);
+
     static std::vector<tt_xy_pair> compute_worker_slice_offsets(
         std::vector<tt_xy_pair> const& worker_slice_shapes, tt_xy_pair const& tensor_slice_shape);
 

--- a/tt_eager/tt_dnn/op_library/ccl/ccl_host_datastructures.hpp
+++ b/tt_eager/tt_dnn/op_library/ccl/ccl_host_datastructures.hpp
@@ -149,7 +149,7 @@ class EriscDatamoverBuilder {
         if (channel.largest_message_size_bytes > 0) {
             args.push_back(std::min<uint32_t>(channel.largest_message_size_bytes, this->eth_buffer_size_bytes));
             if (channel.largest_message_size_bytes < this->eth_buffer_size_bytes) {
-                tt::log_info(tt::LogTest, "Trimming buffer size for channel {} to {}", channel.channel, args.back());
+                log_trace(tt::LogOp, "Trimming buffer size for channel {} to {}", channel.channel, args.back());
             }
         } else {
             args.push_back(this->eth_buffer_size_bytes);

--- a/tt_eager/tt_dnn/op_library/ccl/reduce_scatter/host/reduce_scatter_full_worker_grid.cpp
+++ b/tt_eager/tt_dnn/op_library/ccl/reduce_scatter/host/reduce_scatter_full_worker_grid.cpp
@@ -352,10 +352,7 @@ static void add_worker_config_to_edm_builders(
         }
 
         // Get the expected message size in bytes for this worker
-        auto worker_slice_shape = tensor_slicer.get_worker_slice_shapes().at(global_worker_idx);
-        uint32_t expected_message_size_bytes = worker_slice_shape.x *
-                                                worker_slice_shape.y *
-                                                tensor_slicer.input_page_size;
+        uint32_t expected_message_size_bytes = tensor_slicer.get_worker_slice_size_bytes(global_worker_idx);
 
         bool sender_enabled = true;  // (!is_linear || !is_last_chip_in_chain); // update for linear
         if (sender_enabled) {

--- a/tt_eager/tt_dnn/op_library/ccl/reduce_scatter/host/reduce_scatter_full_worker_grid.cpp
+++ b/tt_eager/tt_dnn/op_library/ccl/reduce_scatter/host/reduce_scatter_full_worker_grid.cpp
@@ -321,6 +321,7 @@ struct EdmInterfaceAddresses {
 // For now - the mapping between workers and EDM channels is 1:1
 static void add_worker_config_to_edm_builders(
     Device* device,
+    RingReduceScatterTensorSlicer& tensor_slicer,  // TODO: Update to Generic ReduceScatterSlicer when it is implemented
     ccl::CCLOpConfig const& op_config,
     std::vector<CoreCoord> const& worker_cores,
     uint32_t num_channels_per_edm,
@@ -350,6 +351,12 @@ static void add_worker_config_to_edm_builders(
                 device->worker_core_from_logical_core(worker_cores.at(w)).y));
         }
 
+        // Get the expected message size in bytes for this worker
+        auto worker_slice_shape = tensor_slicer.get_worker_slice_shapes().at(global_worker_idx);
+        uint32_t expected_message_size_bytes = worker_slice_shape.x *
+                                                worker_slice_shape.y *
+                                                tensor_slicer.input_page_size;
+
         bool sender_enabled = true;  // (!is_linear || !is_last_chip_in_chain); // update for linear
         if (sender_enabled) {
             auto& sender_edm_builder = is_buffer_in_clockwise_direction_fn(c) ? clockwise_edm_builders.at(link)
@@ -359,7 +366,8 @@ static void add_worker_config_to_edm_builders(
                 sender_edm_builder.add_sender_channel(
                     worker_sender_semaphore_address,
                     1,  // cw_edm_channel_num_messages_to_send_per_transfer.at(c) * (ring_size - 1),
-                    sender_worker_coords);
+                    sender_worker_coords,
+                    expected_message_size_bytes);
             edm_interface_addresses.worker_sender_edm_semaphore_addresses.insert(
                 {global_worker_idx, sender_channel_buffer_info.eth_semaphore_l1_address});
             edm_interface_addresses.worker_sender_edm_buffer_addresses.insert(
@@ -378,7 +386,8 @@ static void add_worker_config_to_edm_builders(
                     // Since we are in worker signal EDM termination mode, we don't need to set the actual number of
                     // messages the EDM must forward as it will receive its finish signal from the worker instead
                     1,
-                    receiver_worker_coords);
+                    receiver_worker_coords,
+                    expected_message_size_bytes);
             edm_interface_addresses.worker_receiver_edm_semaphore_addresses.insert(
                 {global_worker_idx, receiver_channel_buffer_info.eth_semaphore_l1_address});
             edm_interface_addresses.worker_receiver_edm_buffer_addresses.insert(
@@ -775,6 +784,7 @@ operation::ProgramWithCallbacks reduce_scatter_with_workers(
     for (std::size_t link = 0; link < num_links; link++) {
         add_worker_config_to_edm_builders(
             device,
+            tensor_slicer,
             op_config,
             worker_cores,
             num_edm_channels,


### PR DESCRIPTION
### Ticket
- #10062 

### Problem description
Currently, if a worker slice has size X and the channel buffer has a size Y, and X < Y, the channel will pad the message to size Y and send it. Therefore, an optimization is to change is to ensure that if X < Y, the sent message is the raw unpadded version with a size of X.

### What's changed
- `add_sender_channel` and `add_reciever_channel` now instantiate the current `largest_message_size_bytes`
- in the EDM builder, where `add_*_channel` is called, pass along the expected message size for that worker

### Checklist
- [ ] Post commit CI passes
- [ ] Model regression CI testing passes (if applicable)
