### PR TITLE
#9945: Skip SD for nightly FD, device perf tests, and single-card demos as it hangs on di/dt

### DIFF
--- a/.github/workflows/fast-dispatch-full-regressions-and-models.yaml
+++ b/.github/workflows/fast-dispatch-full-regressions-and-models.yaml
@@ -26,7 +26,8 @@ jobs:
             { name: "N300 WH-only models", arch: wormhole_b0, cmd: tests/scripts/single_card/nightly/run_wh_b0_only.sh, timeout: 30 },
             { name: "API tests GS", arch: grayskull, cmd: ./tests/scripts/run_tests.sh --tt-arch grayskull --pipeline-type frequent_api --dispatch-mode fast, timeout: 40 },
             { name: "API tests N300 WH B0", arch: wormhole_b0, cmd: ./tests/scripts/run_tests.sh --tt-arch wormhole_b0 --pipeline-type frequent_api --dispatch-mode fast, timeout: 40 },
-            { name: "[Unstable] N300 models", arch: wormhole_b0, cmd: tests/scripts/single_card/nightly/run_wh_b0_unstable.sh, timeout: 45 },
+            # #9945: Skip SD for now
+            # { name: "[Unstable] N300 models", arch: wormhole_b0, cmd: tests/scripts/single_card/nightly/run_wh_b0_unstable.sh, timeout: 45 },
           ]
     name: FD ${{ matrix.test-group.name }} ${{ matrix.test-group.arch }}
     env:

--- a/models/demos/wormhole/stable_diffusion/demo/demo.py
+++ b/models/demos/wormhole/stable_diffusion/demo/demo.py
@@ -598,6 +598,7 @@ def run_demo_inference_diffusiondb(
         logger.info(f"CLIP Score (TTNN): {clip_score_ttnn}")
 
 
+@pytest.mark.skip(reason="#9945: Skip for now since this breaks on WH because of di/dt")
 @skip_for_grayskull()
 @pytest.mark.parametrize("device_params", [{"l1_small_size": 32768}], indirect=True)
 @pytest.mark.parametrize(

--- a/tests/device_perf_tests/stable_diffusion/test_perf_stable_diffusion.py
+++ b/tests/device_perf_tests/stable_diffusion/test_perf_stable_diffusion.py
@@ -204,6 +204,7 @@ def test_stable_diffusion_perf(device, batch_size, num_inference_steps, expected
 
 
 @skip_for_grayskull()
+@pytest.mark.skip(reason="#9945: Skip for now since this breaks on WH because of di/dt")
 @pytest.mark.models_device_performance_bare_metal
 @pytest.mark.parametrize(
     "expected_perf",
@@ -244,6 +245,7 @@ def test_stable_diffusion_device_perf(expected_perf):
 
 
 @skip_for_grayskull()
+@pytest.mark.skip(reason="#9945: Skip for now since this breaks on WH because of di/dt")
 @pytest.mark.models_device_performance_bare_metal
 @pytest.mark.parametrize(
     "expected_perf",


### PR DESCRIPTION
…

### Ticket

#9945 

### Problem description

SD is hanging / breaking way too often to be in CI right now. We will skipping until the above ticket is resolved.

### What's changed

Skip:

- FD nightly
- demo
- device perf

### Checklist
- [x] Post commit CI passes
- [x] Model regression CI testing passes (if applicable)
- [x] New/Existing tests provide coverage for changes
