### PR TITLE
#5424: Delegated sqrt api call to thirdparty gs submodule sqrt call

### DIFF
--- a/tt_metal/hw/ckernels/grayskull/metal/llk_api/llk_sfpu/ckernel_sfpu_sqrt.h
+++ b/tt_metal/hw/ckernels/grayskull/metal/llk_api/llk_sfpu/ckernel_sfpu_sqrt.h
@@ -20,54 +20,12 @@ namespace sfpu
 template <bool APPROXIMATION_MODE, int ITERATIONS=4, int RECIPROCAL_ITERATIONS=2>
 inline void calculate_sqrt()
 {
-    for (int d = 0; d < ITERATIONS; d++)
-    {
-        vFloat val = dst_reg[0];
-
-        if constexpr (APPROXIMATION_MODE)
-        {
-            vUInt magic = l_reg[LRegs::LReg2];
-
-            //sqrt initial approximation
-            // adjust bias
-            vUInt val_s = magic + reinterpret<vUInt>(val);
-
-            // approximation of square root
-            val_s >>= 1;
-            dst_reg[0] = reinterpret<vFloat>(val_s);
-
-            l_reg[LRegs::LReg2] = magic;
-        }
-        else
-        {
-            // Recip root method
-            //// Init approx
-            //u.i = SQRT_MAGIC_F - (u.i >> 1);
-            vUInt magic = reinterpret<vUInt>(vFloat(s2vFloat16b(0x5f37)));
-            vFloat approx = reinterpret<vFloat>(magic - (reinterpret<vUInt>(val) >> 1));
-
-            // Re-load to save a MOV
-            val = dst_reg[0];
-
-            //Reciproot iterations
-            for (int r = 0; r < RECIPROCAL_ITERATIONS; r++)
-            {
-                //x*r*(1.5f - xhalf*r*r);
-                approx = (approx * approx * val * vConstNeg0p5 + vConst1 + 0.5F) * approx;
-            }
-
-            dst_reg[0] = approx * val;
-        }
-
-        dst_reg++;
-    }
+    _calculate_sqrt_<APPROXIMATION_MODE, ITERATIONS, RECIPROCAL_ITERATIONS>();
 }
 
 template <bool APPROXIMATION_MODE>
 void sqrt_init() {
-    if (APPROXIMATION_MODE) {
-        TTI_SFPLOADI(2, 0, 127 << 7);
-    }
+    _init_sqrt_<APPROXIMATION_MODE>();
 }
 } // namespace sfpu
 } // namespace ckernel


### PR DESCRIPTION
### Ticket
(https://github.com/tenstorrent/tt-metal/issues/5424)

### Problem description
Cleanup duplication of api & third party submodule code for sqrt for GS

### What's changed
Added unroll parameter to sqrt function in third party submodule and made the api version call the third party version.

### Checklist
- [x] Post commit CI passes
- [ ] Model regression CI testing passes (if applicable)
- [ ] New/Existing tests provide coverage for changes
