### PR TITLE
#9747: Implement ttnn::tilize in C++

### DIFF
--- a/tests/tt_eager/ops/test_tilize_op.cpp
+++ b/tests/tt_eager/ops/test_tilize_op.cpp
@@ -11,7 +11,7 @@
 #include "tensor/host_buffer/functions.hpp"
 #include "tensor/host_buffer/types.hpp"
 #include "tensor/tensor.hpp"
-#include "tt_dnn/op_library/tilize/tilize_op.hpp"
+#include "ttnn/operations/data_movement/tilize/tilize.hpp"
 #include "tt_metal/host_api.hpp"
 
 using namespace tt;
@@ -42,7 +42,7 @@ int main(int argc, char **argv) {
         Shape shape = {1, 64, 32, 64};
         // Allocates a DRAM buffer on device populated with values specified by initialize
         Tensor a =  tt::numpy::random::random(shape).to(device);
-        Tensor b = tilize(a);
+        Tensor b = ttnn::tilize(a);
 
         Tensor c = b.cpu();
         ////////////////////////////////////////////////////////////////////////////

--- a/tests/tt_eager/ops/test_tilize_op_channels_last.cpp
+++ b/tests/tt_eager/ops/test_tilize_op_channels_last.cpp
@@ -10,7 +10,7 @@
 #include "tensor/host_buffer/functions.hpp"
 #include "tensor/host_buffer/types.hpp"
 #include "tensor/tensor.hpp"
-#include "tt_dnn/op_library/tilize/tilize_op.hpp"
+#include "ttnn/operations/data_movement/tilize/tilize.hpp"
 #include "tt_metal/host_api.hpp"
 #include "tt_numpy/functions.hpp"
 
@@ -42,7 +42,7 @@ int main(int argc, char **argv) {
         Shape shape = {1, 32, 32, 64};
         // Allocates a DRAM buffer on device populated with values specified by initialize
         Tensor a = tt::numpy::random::random(shape).to(device);
-        Tensor b = tilize(a);
+        Tensor b = ttnn::tilize(a);
         Tensor c = b.cpu();
         ////////////////////////////////////////////////////////////////////////////
         //                      Validation & Teardown

--- a/tests/tt_eager/ops/test_tilize_zero_padding.cpp
+++ b/tests/tt_eager/ops/test_tilize_zero_padding.cpp
@@ -10,7 +10,7 @@
 #include "tensor/host_buffer/functions.hpp"
 #include "tensor/host_buffer/types.hpp"
 #include "tensor/tensor.hpp"
-#include "tt_dnn/op_library/tilize/tilize_op.hpp"
+#include "ttnn/operations/data_movement/tilize/tilize_with_val_padding.hpp"
 #include "tt_metal/host_api.hpp"
 #include "tt_numpy/functions.hpp"
 
@@ -42,7 +42,7 @@ int main(int argc, char **argv) {
         Shape shape = {1, 32, 45, 64};
         // Allocates a DRAM buffer on device populated with values specified by initialize
         Tensor a =  tt::numpy::random::random(shape).to(device);
-        Tensor b = tilize_with_zero_padding(a);
+        Tensor b = ttnn::tilize_with_zero_padding(a);
         Tensor c =  b.cpu();
         ////////////////////////////////////////////////////////////////////////////
         //                      Validation & Teardown

--- a/tests/tt_eager/ops/test_tilize_zero_padding_channels_last.cpp
+++ b/tests/tt_eager/ops/test_tilize_zero_padding_channels_last.cpp
@@ -10,7 +10,7 @@
 #include "tensor/host_buffer/functions.hpp"
 #include "tensor/host_buffer/types.hpp"
 #include "tensor/tensor.hpp"
-#include "tt_dnn/op_library/tilize/tilize_op.hpp"
+#include "ttnn/operations/data_movement/tilize/tilize_with_val_padding.hpp"
 #include "tt_metal/host_api.hpp"
 #include "tt_numpy/functions.hpp"
 
@@ -42,7 +42,7 @@ int main(int argc, char **argv) {
         Shape shape = {1, 32, 61, 32};
         // Allocates a DRAM buffer on device populated with values specified by initialize
         Tensor a = tt::numpy::arange<bfloat16>(0, tt_metal::compute_volume(shape), 1).reshape(shape).to(device);
-        Tensor b = tilize_with_zero_padding(a);
+        Tensor b = ttnn::tilize_with_zero_padding(a);
         Tensor c =  b.cpu();
         ////////////////////////////////////////////////////////////////////////////
         //                      Validation & Teardown

--- a/ttnn/CMakeLists.txt
+++ b/ttnn/CMakeLists.txt
@@ -35,6 +35,8 @@ set(TTNN_SRCS
     ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/normalization/softmax/device/softmax_op.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/normalization/softmax/device/multi_core/softmax_op_multi_core.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/data_movement/pad/device/pad_op.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/data_movement/tilize/device/tilize_op.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/data_movement/tilize/device/tilize_with_val_padding_op.cpp
 )
 
 ### Setup TTNN_LIB as an Object library

--- a/ttnn/cpp/ttnn/operations/data_movement/tilize/device/tilize_op.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/tilize/device/tilize_op.cpp
@@ -1,0 +1,72 @@
+// SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "tilize_op.hpp"
+#include "tilize_program_factory.hpp"
+#include "tt_dnn/op_library/run_operation.hpp"
+
+namespace ttnn::operations::data_movement {
+void Tilize::validate(const std::vector<Tensor>& input_tensors) const {
+    const auto& input_tensor_a = input_tensors.at(0);
+    TT_FATAL(input_tensor_a.storage_type() == StorageType::DEVICE, "Operands to tilize need to be on device!");
+    TT_FATAL(input_tensor_a.buffer() != nullptr, "Operands to tilize need to be allocated in buffers on device!");
+    TT_FATAL(input_tensor_a.get_layout() == Layout::ROW_MAJOR, "Can only tilize row major data");
+
+    TT_FATAL(input_tensor_a.volume() % TILE_HW == 0);
+
+    auto width = input_tensor_a.get_legacy_shape()[-1];
+    uint32_t stick_s = width;
+    uint32_t num_sticks = input_tensor_a.volume() / width;
+    TT_FATAL(input_tensor_a.get_dtype() == DataType::BFLOAT16);
+
+    uint32_t stick_size = stick_s * input_tensor_a.element_size();  // Assuming bfloat16 dataformat
+
+    TT_FATAL((stick_size % 2) == 0, "Stick size must be divisible by 2");
+
+    if (input_tensor_a.memory_config().is_sharded()) {
+        TT_FATAL(input_tensor_a.memory_config().memory_layout == TensorMemoryLayout::HEIGHT_SHARDED);
+        TT_FATAL(this->output_mem_config.memory_layout == input_tensor_a.memory_config().memory_layout);
+        TT_FATAL(this->use_multicore == true);
+        TT_FATAL(input_tensor_a.shard_spec().value().orientation == ShardOrientation::ROW_MAJOR);
+    } else {
+        TT_FATAL(input_tensor_a.memory_config().memory_layout == TensorMemoryLayout::INTERLEAVED);
+        TT_FATAL(this->output_mem_config.memory_layout == TensorMemoryLayout::INTERLEAVED);
+    }
+}
+
+std::vector<tt::tt_metal::Shape> Tilize::compute_output_shapes(const std::vector<Tensor>& input_tensors) const {
+    const auto& input_tensor_a = input_tensors.at(0);
+    auto output_shape = input_tensor_a.get_legacy_shape();
+    return {output_shape};
+}
+
+std::vector<Tensor> Tilize::create_output_tensors(
+    const std::vector<Tensor>& input_tensors, const std::vector<std::optional<Tensor>>& output_tensors) const {
+    const auto& input_tensor = input_tensors.at(0);
+    if (input_tensor.memory_config().is_sharded()) {
+        auto mem_config = this->output_mem_config;
+        mem_config.shard_spec = input_tensor.memory_config().shard_spec;
+        return {create_device_tensor(
+            this->compute_output_shapes(input_tensors).at(0),
+            this->output_dtype,
+            Layout::TILE,
+            input_tensor.device(),
+            mem_config)};
+    } else {
+        return operation::generic_create_output_tensors(
+            *this, input_tensors, this->output_dtype, Layout::TILE, this->output_mem_config);
+    }
+}
+
+operation::ProgramWithCallbacks Tilize::create_program(
+    const std::vector<Tensor>& input_tensors, std::vector<Tensor>& output_tensors) const {
+    const auto& input_tensor_a = input_tensors.at(0);
+    auto& output_tensor = output_tensors.at(0);
+    if (this->use_multicore) {
+        return detail::tilize_multi_core(input_tensor_a, output_tensor);
+    }
+    return detail::tilize_single_core(input_tensor_a, output_tensor);
+}
+
+}  // namespace ttnn::operations::data_movement

--- a/ttnn/cpp/ttnn/operations/data_movement/tilize/device/tilize_op.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/tilize/device/tilize_op.hpp
@@ -1,0 +1,27 @@
+// SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <optional>
+
+#include "tensor/tensor.hpp"
+#include "tt_dnn/op_library/operation.hpp"
+
+namespace ttnn::operations::data_movement {
+
+struct Tilize {
+    const MemoryConfig output_mem_config;
+    const DataType output_dtype;
+    const bool use_multicore;
+
+    void validate(const std::vector<Tensor>& input_tensors) const;
+    std::vector<tt::tt_metal::Shape> compute_output_shapes(const std::vector<Tensor>& input_tensors) const;
+    std::vector<Tensor> create_output_tensors(
+        const std::vector<Tensor>& input_tensors, const std::vector<std::optional<Tensor>>& output_tensors) const;
+    operation::ProgramWithCallbacks create_program(
+        const std::vector<Tensor>& input_tensors, std::vector<Tensor>& output_tensors) const;
+};
+
+}  // namespace ttnn::operations::data_movement

--- a/ttnn/cpp/ttnn/operations/data_movement/tilize/device/tilize_program_factory.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/tilize/device/tilize_program_factory.hpp
@@ -1,0 +1,412 @@
+// SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <math.h>
+
+#include "tt_dnn/op_library/cb_utils.hpp"
+#include "tt_dnn/op_library/math.hpp"
+#include "tt_dnn/op_library/operation.hpp"
+#include "tt_dnn/op_library/work_split_tilize.hpp"
+#include "tt_metal/common/constants.hpp"
+#include "tt_metal/detail/util.hpp"
+#include "tt_metal/host_api.hpp"
+
+using namespace tt::constants;
+
+namespace ttnn::operations::data_movement::detail {
+
+operation::ProgramWithCallbacks tilize_single_core(const Tensor& a, Tensor& output) {
+    tt::tt_metal::Program program{};
+
+    CoreRange core({0, 0}, {0, 0});
+
+    tt::tt_metal::Buffer* src0_buffer = a.buffer();
+
+    // This should allocate a DRAM buffer on the device
+    tt::tt_metal::Device* device = a.device();
+    auto output_shape = output.get_legacy_shape();
+
+    tt::tt_metal::Buffer* dst_buffer = output.buffer();
+    TT_ASSERT(dst_buffer != nullptr, "Output buffer should be allocated on device!");
+
+    tt::DataFormat input_cb_data_format = tt::tt_metal::datatype_to_dataformat_converter(a.get_dtype());
+    uint32_t input_single_tile_size = tt::tt_metal::detail::TileSize(input_cb_data_format);
+
+    tt::DataFormat output_cb_data_format = tt::tt_metal::datatype_to_dataformat_converter(output.get_dtype());
+    uint32_t output_single_tile_size = tt::tt_metal::detail::TileSize(output_cb_data_format);
+
+    uint32_t num_tiles = a.volume() / TILE_HW;
+
+    auto width = a.get_legacy_shape()[-1];
+    uint32_t stick_s = width;
+    uint32_t num_sticks = a.volume() / width;
+    uint32_t stick_size = stick_s * a.element_size();  // Assuming bfloat16 dataformat
+
+    uint32_t num_tiles_in_row = stick_s / TILE_WIDTH;
+    // Ensure we don't intrude into storage space
+    uint32_t max_l1_size = a.device()->l1_size_per_core() / 2 - L1_UNRESERVED_BASE;
+    uint32_t max_tiles = max_l1_size / (input_single_tile_size + output_single_tile_size);  // 2 CBs
+    // Currently need the number of tiles in a row to be divisible by tiles in a block
+    uint32_t num_tiles_per_block = 1;
+    if (num_tiles_in_row <= max_tiles) {
+        num_tiles_per_block = num_tiles_in_row;
+    } else {
+        for (uint32_t n_t = max_tiles; n_t > 0; n_t--) {
+            if (num_tiles_in_row % n_t == 0) {
+                num_tiles_per_block = n_t;
+                break;
+            }
+        }
+    }
+    uint32_t block_width_size = num_tiles_per_block * TILE_WIDTH * a.element_size();
+    uint32_t num_full_blocks_in_row = num_tiles_in_row / num_tiles_per_block;
+    uint32_t num_leftover_tiles = num_tiles_in_row % num_tiles_per_block;
+    uint32_t leftover_width_in_row = num_leftover_tiles * a.element_size();
+
+    uint32_t src0_cb_index = 0;
+    uint32_t num_input_tiles = num_tiles_per_block;
+
+    auto src0_cb_config = tt::tt_metal::CircularBufferConfig(
+                              num_input_tiles * input_single_tile_size, {{src0_cb_index, input_cb_data_format}})
+                              .set_page_size(src0_cb_index, input_single_tile_size);
+    auto cb_src0 = tt::tt_metal::CreateCircularBuffer(program, core, src0_cb_config);
+
+    uint32_t output_cb_index = 16;  // output operands start at index 16
+    uint32_t num_output_tiles = num_tiles_per_block;
+    auto cb_output_config = tt::tt_metal::CircularBufferConfig(
+                                num_output_tiles * output_single_tile_size, {{output_cb_index, output_cb_data_format}})
+                                .set_page_size(output_cb_index, output_single_tile_size);
+    auto cb_output = tt::tt_metal::CreateCircularBuffer(program, core, cb_output_config);
+
+    vector<uint32_t> reader_kernel_args = {
+        src0_buffer->address(),
+        num_sticks,
+        stick_size,
+        num_tiles_per_block,
+        block_width_size,
+        num_full_blocks_in_row,
+        num_leftover_tiles,
+        leftover_width_in_row,
+        0  // row_start_id
+    };
+
+    // Reader compile-time args
+    uint32_t src0_is_dram = src0_buffer->buffer_type() == tt::tt_metal::BufferType::DRAM ? 1 : 0;
+    uint32_t stick_size_is_power_of_two = is_power_of_two_at_least_32(stick_size);
+    uint32_t log2_stick_size = stick_size_is_power_of_two ? (uint32_t)log2(stick_size) : 0;
+    std::vector<uint32_t> reader_compile_time_args = {src0_is_dram, stick_size_is_power_of_two, log2_stick_size};
+
+    uint32_t out_is_dram = dst_buffer->buffer_type() == tt::tt_metal::BufferType::DRAM ? 1 : 0;
+    std::vector<uint32_t> writer_compile_time_args = {output_cb_index, out_is_dram};
+
+    // Tilized reader
+    tt::tt_metal::KernelHandle unary_reader_kernel_id = tt::tt_metal::CreateKernel(
+        program,
+        "tt_eager/tt_dnn/op_library/tilize/kernels/dataflow/reader_unary_stick_layout_split_rows_interleaved.cpp",
+        core,
+        tt::tt_metal::ReaderDataMovementConfig(reader_compile_time_args));
+
+    // Tilized writer
+    tt::tt_metal::KernelHandle unary_writer_kernel_id = tt::tt_metal::CreateKernel(
+        program,
+        "ttnn/cpp/ttnn/operations/eltwise/unary/device/kernels/dataflow/writer_unary_interleaved_start_id.cpp",
+        core,
+        tt::tt_metal::WriterDataMovementConfig(writer_compile_time_args));
+
+    vector<uint32_t> compute_args = {
+        num_tiles / num_tiles_per_block,  // per_core_block_cnt
+        num_tiles_per_block               // per_core_block_tile_cnt
+    };
+
+    auto tilize_kernel_id = tt::tt_metal::CreateKernel(
+        program,
+        "tt_eager/tt_dnn/kernels/compute/tilize.cpp",
+        core,
+        tt::tt_metal::ComputeConfig{.compile_args = compute_args});
+
+    tt::tt_metal::SetRuntimeArgs(program, unary_reader_kernel_id, core, reader_kernel_args);
+
+    tt::tt_metal::SetRuntimeArgs(program, unary_writer_kernel_id, core, {dst_buffer->address(), num_tiles, 0});
+
+    auto override_runtime_args_callback = [reader_kernel_id = unary_reader_kernel_id,
+                                           writer_kernel_id = unary_writer_kernel_id](
+                                              const Program& program,
+                                              const std::vector<Buffer*>& input_buffers,
+                                              const std::vector<Buffer*>& output_buffers) {
+        auto src_buffer = input_buffers.at(0);
+
+        auto dst_buffer = output_buffers.at(0);
+
+        CoreCoord core = {0, 0};
+
+        {
+            auto& runtime_args = GetRuntimeArgs(program, reader_kernel_id, core);
+            runtime_args[0] = src_buffer->address();
+        }
+
+        {
+            auto& runtime_args = GetRuntimeArgs(program, writer_kernel_id, core);
+            runtime_args[0] = dst_buffer->address();
+        }
+    };
+
+    return {std::move(program), override_runtime_args_callback};
+}
+
+operation::ProgramWithCallbacks tilize_multi_core_interleaved(const Tensor& a, Tensor& output) {
+    tt::tt_metal::Program program = tt::tt_metal::CreateProgram();
+
+    tt::DataFormat input_cb_data_format = datatype_to_dataformat_converter(a.get_dtype());
+    uint32_t input_single_tile_size = tt::tt_metal::detail::TileSize(input_cb_data_format);
+    tt::DataFormat output_cb_data_format = datatype_to_dataformat_converter(output.get_dtype());
+    uint32_t output_single_tile_size = tt::tt_metal::detail::TileSize(output_cb_data_format);
+
+    int32_t ntiles = a.volume() / TILE_HW;
+    uint32_t ntiles_per_block = a.get_legacy_shape()[-1] / TILE_WIDTH;
+    uint32_t nblocks = std::ceil((float)ntiles / ntiles_per_block);
+    uint32_t block_size_nbytes = a.get_legacy_shape()[-1] * a.element_size();
+
+    Device* device = a.device();
+    auto grid_size = device->compute_with_storage_grid_size();
+    auto [ncores, all_cores, core_range, core_range_cliff, nblocks_per_core, nblocks_per_core_cliff] =
+        split_blocks_for_tilize(grid_size, nblocks);
+
+    create_cb(tt::CB::c_in0, program, all_cores, input_single_tile_size, ntiles_per_block, input_cb_data_format);
+
+    auto [output_cb_index, _] =
+        create_cb(tt::CB::c_out0, program, all_cores, output_single_tile_size, ntiles_per_block, output_cb_data_format);
+
+    Buffer* src0_buffer = a.buffer();
+    Buffer* dst_buffer = output.buffer();
+    TT_ASSERT(dst_buffer != nullptr, "Output buffer should be allocated on device!");
+
+    /** reader
+     */
+    uint32_t src0_is_dram = src0_buffer->buffer_type() == BufferType::DRAM ? 1 : 0;
+    uint32_t stick_size_is_power_of_two = is_power_of_two_at_least_32(block_size_nbytes);
+    uint32_t log2_stick_size = stick_size_is_power_of_two ? (uint32_t)std::log2(block_size_nbytes) : 0;
+    std::vector<uint32_t> reader_ct_args = {src0_is_dram, stick_size_is_power_of_two, log2_stick_size};
+    KernelHandle unary_reader_kernel_id = CreateKernel(
+        program,
+        "tt_eager/tt_dnn/op_library/tilize/kernels/dataflow/reader_unary_stick_layout_split_rows_interleaved.cpp",
+        all_cores,
+        ReaderDataMovementConfig(reader_ct_args));
+
+    /** writer
+     */
+    uint32_t out_is_dram = dst_buffer->buffer_type() == tt::tt_metal::BufferType::DRAM ? 1 : 0;
+    std::vector<uint32_t> writer_ct_args = {output_cb_index, out_is_dram};
+    KernelHandle unary_writer_kernel_id = CreateKernel(
+        program,
+        "ttnn/cpp/ttnn/operations/eltwise/unary/device/kernels/dataflow/writer_unary_interleaved_start_id.cpp",
+        all_cores,
+        WriterDataMovementConfig(writer_ct_args));
+
+    /** compute
+     */
+    vector<uint32_t> compute_args = {nblocks_per_core, ntiles_per_block};
+    vector<uint32_t> compute_args_cliff = {nblocks_per_core_cliff, ntiles_per_block};
+
+    if (core_range.ranges().size() > 0) {
+        auto tilize_kernel_id = CreateKernel(
+            program,
+            "tt_eager/tt_dnn/kernels/compute/tilize.cpp",
+            core_range,
+            ComputeConfig{.compile_args = compute_args});
+    }
+    if (core_range_cliff.size() > 0) {
+        auto tilize_cliff_kernel_id = CreateKernel(
+            program,
+            "tt_eager/tt_dnn/kernels/compute/tilize.cpp",
+            core_range_cliff,
+            ComputeConfig{.compile_args = compute_args_cliff});
+    }
+
+    // 1D distribution of blocks across cores
+    bool has_cliff = core_range_cliff.size() > 0;
+
+    uint32_t ncores_full = ncores - has_cliff;
+    uint32_t ncores_x = grid_size.x;
+    uint32_t tile_start_id = 0;
+    uint32_t row_start_id = 0;
+    const auto& cores = grid_to_cores(ncores, grid_size.x, grid_size.y, true);
+    for (uint32_t i = 0; i < ncores_full; ++i) {
+        const CoreCoord& core = cores[i];
+
+        // reader runtime args
+        vector<uint32_t> reader_rt_args = {
+            src0_buffer->address(),
+            nblocks_per_core * TILE_HEIGHT,
+            block_size_nbytes,
+            ntiles_per_block,
+            block_size_nbytes,
+            1,  // full blocks in row
+            0,  // num leftover tiles
+            0,  // leftover width in row
+            row_start_id};
+
+        // writer runtime args
+        vector<uint32_t> writer_rt_args = {
+            dst_buffer->address(),
+            ntiles_per_block * nblocks_per_core,  // ntiles per core
+            tile_start_id                         // start id
+        };
+
+        SetRuntimeArgs(program, unary_reader_kernel_id, core, reader_rt_args);
+        SetRuntimeArgs(program, unary_writer_kernel_id, core, writer_rt_args);
+
+        tile_start_id += ntiles_per_block * nblocks_per_core;
+        row_start_id += TILE_HEIGHT * nblocks_per_core;
+    }
+    if (has_cliff) {
+        // the last core is a cliff core with nblocks_per_core_cliff blocks
+        const CoreCoord& core = cores.back();
+
+        // reader runtime args
+        vector<uint32_t> reader_rt_args = {
+            src0_buffer->address(),
+            nblocks_per_core_cliff * TILE_HEIGHT,
+            block_size_nbytes,
+            ntiles_per_block,
+            block_size_nbytes,
+            1,  // full blocks in row
+            0,  // num leftover tiles
+            0,  // leftover width in row
+            row_start_id};
+
+        // writer runtime args
+        vector<uint32_t> writer_rt_args = {
+            dst_buffer->address(),
+            ntiles_per_block * nblocks_per_core_cliff,  // ntiles per core
+            tile_start_id                               // start id
+        };
+
+        SetRuntimeArgs(program, unary_reader_kernel_id, core, reader_rt_args);
+        SetRuntimeArgs(program, unary_writer_kernel_id, core, writer_rt_args);
+    }
+
+    auto override_runtime_args_callback =
+        [reader_kernel_id = unary_reader_kernel_id, writer_kernel_id = unary_writer_kernel_id, cores = cores](
+            const Program& program,
+            const std::vector<Buffer*>& input_buffers,
+            const std::vector<Buffer*>& output_buffers) {
+            auto src_buffer = input_buffers.at(0);
+            auto dst_buffer = output_buffers.at(0);
+
+            auto& reader_runtime_args_by_core = GetRuntimeArgs(program, reader_kernel_id);
+            auto& writer_runtime_args_by_core = GetRuntimeArgs(program, writer_kernel_id);
+            for (const auto& core : cores) {
+                {
+                    auto& runtime_args = reader_runtime_args_by_core[core.x][core.y];
+                    runtime_args[0] = src_buffer->address();
+                }
+                {
+                    auto& runtime_args = writer_runtime_args_by_core[core.x][core.y];
+                    runtime_args[0] = dst_buffer->address();
+                }
+            }
+        };
+
+    return {std::move(program), override_runtime_args_callback};
+}
+
+operation::ProgramWithCallbacks tilize_multi_core_sharded(const Tensor& input, Tensor& output) {
+    tt::tt_metal::Program program{};
+
+    tt::DataFormat input_cb_data_format = tt::tt_metal::datatype_to_dataformat_converter(input.get_dtype());
+    uint32_t input_single_tile_size = tt::tt_metal::detail::TileSize(input_cb_data_format);
+    tt::DataFormat output_cb_data_format = tt::tt_metal::datatype_to_dataformat_converter(output.get_dtype());
+    uint32_t output_single_tile_size = tt::tt_metal::detail::TileSize(output_cb_data_format);
+
+    uint32_t num_tiles = input.volume() / TILE_HW;
+
+    tt::tt_metal::Device* device = input.device();
+
+    auto shard_spec = input.shard_spec().value();
+    uint32_t num_tiles_per_shard = shard_spec.shape[0] * shard_spec.shape[1] / TILE_HW;
+    uint32_t num_tiles_per_row = shard_spec.shape[1] / TILE_WIDTH;
+    auto all_cores = shard_spec.grid;
+    uint32_t num_cores_x = device->compute_with_storage_grid_size().x;
+    uint32_t num_cores = all_cores.num_cores();
+
+    auto [src0_cb_index, cb_src0] = create_cb(
+        tt::CB::c_in0,
+        program,
+        all_cores,
+        input_single_tile_size,
+        num_tiles_per_shard,
+        input_cb_data_format,
+        input.buffer());
+
+    auto [output_cb_index, cb_output] = create_cb(
+        tt::CB::c_out0,
+        program,
+        all_cores,
+        output_single_tile_size,
+        num_tiles_per_shard,
+        output_cb_data_format,
+        output.buffer());
+
+    auto src_buffer = input.buffer();
+
+    auto dst_buffer = output.buffer();
+
+    std::vector<uint32_t> reader_compile_time_args = {(std::uint32_t)src0_cb_index};
+
+    bool dst_is_dram = dst_buffer->buffer_type() == tt::tt_metal::BufferType::DRAM ? 1 : 0;
+    std::vector<uint32_t> writer_compile_time_args = {(std::uint32_t)output_cb_index};
+
+    tt::tt_metal::KernelHandle unary_reader_kernel_id = tt::tt_metal::CreateKernel(
+        program,
+        "ttnn/cpp/ttnn/operations/eltwise/unary/device/kernels/dataflow/reader_unary_sharded.cpp",
+        all_cores,
+        tt::tt_metal::ReaderDataMovementConfig(reader_compile_time_args));
+
+    tt::tt_metal::KernelHandle unary_writer_kernel_id = tt::tt_metal::CreateKernel(
+        program,
+        "tt_eager/tt_dnn/op_library/sharded/kernels/dataflow/writer_unary_sharded.cpp",
+        all_cores,
+        tt::tt_metal::WriterDataMovementConfig(writer_compile_time_args));
+
+    vector<uint32_t> compute_args = {uint32_t(num_tiles_per_shard / num_tiles_per_row), uint32_t(num_tiles_per_row)};
+
+    auto untilize_kernel_id = tt::tt_metal::CreateKernel(
+        program,
+        "tt_eager/tt_dnn/kernels/compute/tilize.cpp",
+        all_cores,
+        tt::tt_metal::ComputeConfig{.compile_args = compute_args});
+
+    tt::tt_metal::SetRuntimeArgs(program, unary_reader_kernel_id, all_cores, {num_tiles_per_shard});
+
+    tt::tt_metal::SetRuntimeArgs(program, unary_writer_kernel_id, all_cores, {num_tiles_per_shard});
+
+    auto override_runtime_arguments_callback =
+        [unary_reader_kernel_id, unary_writer_kernel_id, cb_src0, cb_output](
+            const void* operation,
+            Program& program,
+            const std::vector<Tensor>& input_tensors,
+            const std::vector<std::optional<const Tensor>>& optional_input_tensors,
+            const std::vector<Tensor>& output_tensors) {
+            auto src_buffer = input_tensors.at(0).buffer();
+
+            auto dst_buffer = output_tensors.at(0).buffer();
+
+            UpdateDynamicCircularBufferAddress(program, cb_src0, *src_buffer);
+
+            UpdateDynamicCircularBufferAddress(program, cb_output, *dst_buffer);
+        };
+    return {.program = std::move(program), .override_runtime_arguments_callback = override_runtime_arguments_callback};
+}
+
+operation::ProgramWithCallbacks tilize_multi_core(const Tensor& a, Tensor& output) {
+    if (a.memory_config().is_sharded()) {
+        return tilize_multi_core_sharded(a, output);
+    } else {
+        return tilize_multi_core_interleaved(a, output);
+    }
+}
+
+}  // namespace ttnn::operations::data_movement::detail

--- a/ttnn/cpp/ttnn/operations/data_movement/tilize/device/tilize_with_val_padding_op.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/tilize/device/tilize_with_val_padding_op.cpp
@@ -1,0 +1,82 @@
+// SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "tilize_with_val_padding_op.hpp"
+
+#include "tensor/tensor_utils.hpp"
+#include "tilize_with_val_padding_program_factory.hpp"
+#include "tt_dnn/op_library/run_operation.hpp"
+
+namespace ttnn::operations::data_movement {
+
+void TilizeWithValPadding::validate(const std::vector<Tensor>& input_tensors) const {
+    const auto& input_tensor_a = input_tensors.at(0);
+    TT_FATAL(input_tensor_a.storage_type() == StorageType::DEVICE, "Operands need to be on device!");
+    TT_FATAL(input_tensor_a.buffer() != nullptr, "Operands need to be allocated in buffers on device!");
+    TT_FATAL(input_tensor_a.get_layout() == Layout::ROW_MAJOR, "Can only tilize row major data");
+    TT_FATAL(input_tensor_a.get_dtype() == DataType::BFLOAT16);
+
+    TT_FATAL(input_tensor_a.get_legacy_shape()[0] <= this->output_tensor_shape[0]);
+    TT_FATAL(input_tensor_a.get_legacy_shape()[1] <= this->output_tensor_shape[1]);
+    TT_FATAL(input_tensor_a.get_legacy_shape()[2] <= this->output_tensor_shape[2]);
+    TT_FATAL(input_tensor_a.get_legacy_shape()[3] <= this->output_tensor_shape[3]);
+
+    uint32_t num_rows = this->output_tensor_shape[2];
+    uint32_t inner_dim = this->output_tensor_shape[3];
+    TT_FATAL(num_rows % TILE_HEIGHT == 0, "Output shape must be tilizable");
+    TT_FATAL(inner_dim % TILE_WIDTH == 0, "Output shape must be tilizable");
+
+    if (input_tensor_a.memory_config().is_sharded()) {
+        TT_FATAL(input_tensor_a.memory_config().memory_layout == TensorMemoryLayout::WIDTH_SHARDED);
+        TT_FATAL(this->output_mem_config.memory_layout == input_tensor_a.memory_config().memory_layout);
+        for (uint32_t i = 0; i < input_tensor_a.get_legacy_shape().rank(); i++) {
+            if (i != input_tensor_a.get_legacy_shape().rank() - 2) {
+                TT_FATAL(input_tensor_a.get_legacy_shape()[i] == this->output_tensor_shape[i]);
+            }
+        }
+    }
+}
+
+std::vector<tt::tt_metal::Shape> TilizeWithValPadding::compute_output_shapes(
+    const std::vector<Tensor>& input_tensors) const {
+    auto input_shape = input_tensors.at(0).get_legacy_shape();
+    auto dimensions_pads = std::vector<Padding::PadDimension>();
+    for (auto index = 0; index < input_shape.rank(); index++) {
+        auto back = this->output_tensor_shape[index] - input_shape[index];
+        dimensions_pads.push_back(Padding::PadDimension{.front = 0, .back = back});
+    }
+    const auto padding = Padding(dimensions_pads, Padding::PadValue::Any);
+    return {tt::tt_metal::Shape(this->output_tensor_shape, padding)};
+}
+
+std::vector<Tensor> TilizeWithValPadding::create_output_tensors(
+    const std::vector<Tensor>& input_tensors, const std::vector<std::optional<Tensor>>& output_tensors) const {
+    const auto& input_tensor_a = input_tensors.at(0);
+    if (input_tensor_a.memory_config().is_sharded()) {
+        auto output_shape = this->compute_output_shapes(input_tensors).at(0);
+        auto shard_spec = input_tensor_a.shard_spec().value();
+        shard_spec.shape[0] = tt::tt_metal::compute_volume(output_shape) / output_shape[-1];
+        auto mem_config = this->output_mem_config;
+        mem_config.shard_spec = shard_spec;
+        return {
+            create_device_tensor(output_shape, this->output_dtype, Layout::TILE, input_tensor_a.device(), mem_config)};
+    } else {
+        return operation::generic_create_output_tensors(
+            *this, input_tensors, this->output_dtype, Layout::TILE, this->output_mem_config);
+    }
+}
+
+// TODO: If pad is called on a tile and output is not tile, we could untilize then pad, and output is RM
+// Currently calling pad on a tile requires the output pad shape to be tile
+operation::ProgramWithCallbacks TilizeWithValPadding::create_program(
+    const std::vector<Tensor>& input_tensors, std::vector<Tensor>& output_tensors) const {
+    const auto& input_tensor_a = input_tensors.at(0);
+    auto& output_tensor = output_tensors.at(0);
+    if (this->use_multicore) {
+        return detail::tilize_with_val_padding_multi_core(input_tensor_a, output_tensor, this->pad_value);
+    }
+    return detail::tilize_with_val_padding_single_core(input_tensor_a, output_tensor, this->pad_value);
+}
+
+}  // namespace ttnn::operations::data_movement

--- a/ttnn/cpp/ttnn/operations/data_movement/tilize/device/tilize_with_val_padding_op.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/tilize/device/tilize_with_val_padding_op.hpp
@@ -1,0 +1,29 @@
+// SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <optional>
+
+#include "tensor/tensor.hpp"
+#include "tt_dnn/op_library/operation.hpp"
+
+namespace ttnn::operations::data_movement {
+
+struct TilizeWithValPadding {
+    const tt::tt_metal::Shape output_tensor_shape;
+    const float pad_value;
+    const MemoryConfig output_mem_config;
+    const DataType output_dtype;
+    const bool use_multicore;
+
+    void validate(const std::vector<Tensor>& input_tensors) const;
+    std::vector<tt::tt_metal::Shape> compute_output_shapes(const std::vector<Tensor>& input_tensors) const;
+    std::vector<Tensor> create_output_tensors(
+        const std::vector<Tensor>& input_tensors, const std::vector<std::optional<Tensor>>& output_tensors) const;
+    operation::ProgramWithCallbacks create_program(
+        const std::vector<Tensor>& input_tensors, std::vector<Tensor>& output_tensors) const;
+};
+
+}  // namespace ttnn::operations::data_movement

--- a/ttnn/cpp/ttnn/operations/data_movement/tilize/device/tilize_with_val_padding_program_factory.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/tilize/device/tilize_with_val_padding_program_factory.hpp
@@ -1,0 +1,492 @@
+// SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <math.h>
+
+#include "tt_dnn/op_library/cb_utils.hpp"
+#include "tt_dnn/op_library/math.hpp"
+#include "tt_dnn/op_library/operation.hpp"
+#include "tt_dnn/op_library/work_split_tilize.hpp"
+#include "tt_metal/common/constants.hpp"
+#include "tt_metal/detail/util.hpp"
+#include "tt_metal/host_api.hpp"
+
+using namespace tt::constants;
+
+namespace ttnn::operations::data_movement::detail {
+
+operation::ProgramWithCallbacks tilize_with_val_padding_single_core(
+    const Tensor& a, Tensor& output, const float pad_value) {
+    auto output_shape = output.get_legacy_shape();
+
+    tt::tt_metal::Program program = tt::tt_metal::CreateProgram();
+
+    CoreRange core({0, 0}, {0, 0});
+
+    // This should allocate a DRAM buffer on the device
+    tt::tt_metal::Device* device = a.device();
+
+    tt::tt_metal::Buffer* src0_buffer = a.buffer();
+
+    tt::DataFormat input_cb_data_format = tt::tt_metal::datatype_to_dataformat_converter(a.get_dtype());
+    uint32_t input_single_tile_size = tt::tt_metal::detail::TileSize(input_cb_data_format);
+
+    tt::DataFormat output_cb_data_format = tt::tt_metal::datatype_to_dataformat_converter(output.get_dtype());
+    uint32_t output_single_tile_size = tt::tt_metal::detail::TileSize(output_cb_data_format);
+
+    int32_t num_tiles = output.volume() / TILE_HW;
+
+    auto true_input_shape = a.get_legacy_shape();
+    auto true_output_shape = output.get_legacy_shape();
+
+    auto input_w = true_input_shape.rank() >= 4 ? true_input_shape[-4] : 1;
+    auto input_z = true_input_shape.rank() >= 3 ? true_input_shape[-3] : 1;
+    auto input_y = true_input_shape.rank() >= 2 ? true_input_shape[-2] : 1;
+    auto input_x = true_input_shape[-1];
+
+    auto output_w = true_output_shape.rank() >= 4 ? true_output_shape[-4] : 1;
+    auto output_z = true_output_shape.rank() >= 3 ? true_output_shape[-3] : 1;
+    auto output_y = true_output_shape.rank() >= 2 ? true_output_shape[-2] : 1;
+    auto output_x = true_output_shape[-1];
+
+    uint32_t unpadded_row_size_bytes = input_x * a.element_size();  // Assuming bfloat16 dataformat
+    uint32_t padded_row_size_bytes = output_x * a.element_size();   // Assuming bfloat16 dataformat
+
+    constexpr uint32_t alignment = 32;
+
+    uint32_t num_tiles_in_row = output_x / TILE_WIDTH;
+    // Ensure we don't intrude into storage space
+    uint32_t max_l1_size = a.device()->l1_size_per_core() / 2 - L1_UNRESERVED_BASE;
+    // Memory usage is 2 CBs of width W, plus buffer of size alignment + (W * datum size)
+    uint32_t max_X = (max_l1_size - alignment) / (a.element_size() * TILE_HEIGHT * 2 + a.element_size());
+    uint32_t max_tiles = max_X / TILE_WIDTH;
+
+    // Currently need the number of tiles in a row to be divisible by tiles in a block
+    uint32_t num_tiles_per_block = 1;
+    if (num_tiles_in_row <= max_tiles) {
+        num_tiles_per_block = num_tiles_in_row;
+    } else {
+        for (uint32_t n_t = max_tiles; n_t > 0; n_t--) {
+            if (num_tiles_in_row % n_t == 0) {
+                num_tiles_per_block = n_t;
+                break;
+            }
+        }
+    }
+
+    uint32_t block_width = num_tiles_per_block * TILE_WIDTH;
+    uint32_t block_row_size = block_width * a.element_size();
+    uint32_t num_blocks_w_output = padded_row_size_bytes / block_row_size;
+    uint32_t num_blocks_w_input = unpadded_row_size_bytes / block_row_size;
+
+    // Leftover size if input is not divisible by block size
+    uint32_t block_row_leftover_size = unpadded_row_size_bytes - num_blocks_w_input * block_row_size;
+
+    // Number of blocks that differ between input and output
+    const uint32_t num_blocks_w_diff = num_blocks_w_output - num_blocks_w_input - (block_row_leftover_size > 0 ? 1 : 0);
+
+    const uint32_t padded_Y_diff_blocks = (output_y - input_y) / TILE_HEIGHT * num_blocks_w_output;
+    const uint32_t padded_Z_diff_blocks = (output_z - input_z) * output_y / TILE_HEIGHT * num_blocks_w_output;
+    const uint32_t padded_W_diff_blocks =
+        (output_w - input_w) * output_z * output_y / TILE_HEIGHT * num_blocks_w_output;
+    const uint32_t num_leftover_Y = input_y - input_y / TILE_HEIGHT * TILE_HEIGHT;
+
+    tt::tt_metal::Buffer* dst_buffer = output.buffer();
+    TT_ASSERT(dst_buffer != nullptr, "Output buffer should be allocated on device!");
+
+    uint32_t src0_cb_index = 0;
+    uint32_t num_input_tiles = num_tiles_per_block;
+    assert(num_input_tiles > 0);
+    tt::tt_metal::CircularBufferConfig src0_cb_config =
+        tt::tt_metal::CircularBufferConfig(
+            num_input_tiles * input_single_tile_size, {{src0_cb_index, input_cb_data_format}})
+            .set_page_size(src0_cb_index, input_single_tile_size);
+    auto cb_src0 = tt::tt_metal::CreateCircularBuffer(program, core, src0_cb_config);
+
+    uint32_t output_cb_index = 16;  // output operands start at index 16
+    uint32_t num_output_tiles = num_tiles_per_block;
+    tt::tt_metal::CircularBufferConfig cb_output_config =
+        tt::tt_metal::CircularBufferConfig(
+            num_output_tiles * output_single_tile_size, {{output_cb_index, output_cb_data_format}})
+            .set_page_size(output_cb_index, output_single_tile_size);
+    auto cb_output = tt::tt_metal::CreateCircularBuffer(program, core, cb_output_config);
+
+    bfloat16 bfloat_pad_value = bfloat16(pad_value);
+    uint32_t packed_pad_value = pack_two_bfloat16_into_uint32({bfloat_pad_value, bfloat_pad_value});
+
+    vector<uint32_t> reader_kernel_args = {
+        src0_buffer->address(),
+        input_w,
+        padded_W_diff_blocks,
+        input_z,
+        padded_Z_diff_blocks,
+        input_y,
+        padded_Y_diff_blocks,
+        num_leftover_Y,
+        input_x,
+        unpadded_row_size_bytes,
+        padded_row_size_bytes,
+        packed_pad_value,
+        num_blocks_w_input,
+        num_blocks_w_output,
+        num_blocks_w_diff,
+        block_row_size,
+        block_row_leftover_size};
+
+    // Reader compile-time args
+    uint32_t src0_is_dram = src0_buffer->buffer_type() == tt::tt_metal::BufferType::DRAM ? 1 : 0;
+    uint32_t stick_size = unpadded_row_size_bytes;
+    uint32_t stick_size_is_power_of_two = is_power_of_two_at_least_32(stick_size);
+    uint32_t log2_stick_size = stick_size_is_power_of_two ? (uint32_t)log2(stick_size) : 0;
+    std::vector<uint32_t> reader_compile_time_args = {src0_is_dram, stick_size_is_power_of_two, log2_stick_size};
+
+    // Tilized reader
+    tt::tt_metal::KernelHandle unary_reader_kernel_id = tt::tt_metal::CreateKernel(
+        program,
+        "tt_eager/tt_dnn/op_library/tilize/kernels/dataflow/reader_unary_pad_dims_split_rows.cpp",
+        core,
+        tt::tt_metal::ReaderDataMovementConfig(reader_compile_time_args));
+
+    // Tilized writer
+    uint32_t out_is_dram = dst_buffer->buffer_type() == tt::tt_metal::BufferType::DRAM ? 1 : 0;
+    tt::tt_metal::KernelHandle unary_writer_kernel_id = tt::tt_metal::CreateKernel(
+        program,
+        "ttnn/cpp/ttnn/operations/eltwise/unary/device/kernels/dataflow/writer_unary_interleaved_start_id.cpp",
+        core,
+        tt::tt_metal::WriterDataMovementConfig({output_cb_index, out_is_dram}));
+
+    vector<uint32_t> compute_kernel_args = {uint32_t(num_tiles / num_tiles_per_block), uint32_t(num_tiles_per_block)};
+
+    auto tilize_kernel_id = tt::tt_metal::CreateKernel(
+        program,
+        "tt_eager/tt_dnn/kernels/compute/tilize.cpp",
+        core,
+        tt::tt_metal::ComputeConfig{.compile_args = compute_kernel_args});
+
+    tt::tt_metal::SetRuntimeArgs(program, unary_reader_kernel_id, core, reader_kernel_args);
+
+    tt::tt_metal::SetRuntimeArgs(
+        program, unary_writer_kernel_id, core, {dst_buffer->address(), (uint32_t)num_tiles, 0});
+
+    auto override_runtime_args_callback = [reader_kernel_id = unary_reader_kernel_id,
+                                           writer_kernel_id = unary_writer_kernel_id](
+                                              const Program& program,
+                                              const std::vector<Buffer*>& input_buffers,
+                                              const std::vector<Buffer*>& output_buffers) {
+        auto src_buffer = input_buffers.at(0);
+
+        auto dst_buffer = output_buffers.at(0);
+
+        CoreCoord core = {0, 0};
+
+        {
+            auto& runtime_args = GetRuntimeArgs(program, reader_kernel_id, core);
+            runtime_args[0] = src_buffer->address();
+        }
+
+        {
+            auto& runtime_args = GetRuntimeArgs(program, writer_kernel_id, core);
+            runtime_args[0] = dst_buffer->address();
+        }
+    };
+
+    return {std::move(program), override_runtime_args_callback};
+}
+
+operation::ProgramWithCallbacks tilize_with_val_padding_multi_core_interleaved(
+    const Tensor& a, Tensor& output, const float pad_value) {
+    tt::tt_metal::Program program = tt::tt_metal::CreateProgram();
+
+    tt::DataFormat input_cb_data_format = tt::tt_metal::datatype_to_dataformat_converter(a.get_dtype());
+    uint32_t input_single_tile_size = tt::tt_metal::detail::TileSize(input_cb_data_format);
+    tt::DataFormat output_cb_data_format = tt::tt_metal::datatype_to_dataformat_converter(output.get_dtype());
+    uint32_t output_single_tile_size = tt::tt_metal::detail::TileSize(output_cb_data_format);
+
+    Device* device = a.device();
+    CoreCoord grid_size = device->compute_with_storage_grid_size();
+
+    uint32_t num_blocks = output.volume() / output.get_legacy_shape()[-1] / TILE_HEIGHT;
+    uint32_t num_tiles_per_row = output.get_legacy_shape()[-1] / TILE_WIDTH;
+
+    auto [ncores, all_cores, core_range, core_range_cliff, nblocks_per_core, nblocks_per_core_cliff] =
+        split_blocks_for_tilize(grid_size, num_blocks);
+
+    bool has_cliff = core_range_cliff.size() > 0;
+
+    uint32_t unpadded_row_size_bytes = a.get_legacy_shape()[-1] * a.element_size();     // Assuming bfloat16 dataformat
+    uint32_t padded_row_size_bytes = output.get_legacy_shape()[-1] * a.element_size();  // Assuming bfloat16 dataformat
+
+    auto [src0_cb_index, cb_src0] =
+        create_cb(tt::CB::c_in0, program, all_cores, input_single_tile_size, num_tiles_per_row, input_cb_data_format);
+
+    auto [output_cb_index, cb_output] = create_cb(
+        tt::CB::c_out0, program, all_cores, output_single_tile_size, num_tiles_per_row, output_cb_data_format);
+
+    Buffer* src0_buffer = a.buffer();
+    Buffer* dst_buffer = output.buffer();
+    TT_ASSERT(dst_buffer != nullptr, "Output buffer should be allocated on device!");
+
+    /** reader
+     */
+    uint32_t src0_is_dram = src0_buffer->buffer_type() == BufferType::DRAM ? 1 : 0;
+    uint32_t stick_size = unpadded_row_size_bytes;
+    uint32_t stick_size_is_power_of_two = is_power_of_two_at_least_32(stick_size);
+    uint32_t log2_stick_size = stick_size_is_power_of_two ? (std::uint32_t)std::log2(stick_size) : 0;
+
+    KernelHandle unary_reader_kernel_id = CreateKernel(
+        program,
+        "tt_eager/tt_dnn/op_library/tilize/kernels/dataflow/reader_unary_pad_dims_split_rows_multicore.cpp",
+        all_cores,
+        ReaderDataMovementConfig({src0_is_dram, stick_size_is_power_of_two, log2_stick_size}));
+
+    /** writer
+     */
+    uint32_t out_is_dram = dst_buffer->buffer_type() == tt::tt_metal::BufferType::DRAM ? 1 : 0;
+
+    KernelHandle unary_writer_kernel_id = CreateKernel(
+        program,
+        "ttnn/cpp/ttnn/operations/eltwise/unary/device/kernels/dataflow/writer_unary_interleaved_start_id.cpp",
+        all_cores,
+        WriterDataMovementConfig({output_cb_index, out_is_dram}));
+
+    /** compute
+     */
+    if (core_range.size() > 0) {
+        auto tilize_kernel_id = CreateKernel(
+            program,
+            "tt_eager/tt_dnn/kernels/compute/tilize.cpp",
+            core_range,
+            ComputeConfig{.compile_args = {nblocks_per_core, num_tiles_per_row}});
+    }
+    if (has_cliff) {
+        auto tilize_cliff_kernel_id = CreateKernel(
+            program,
+            "tt_eager/tt_dnn/kernels/compute/tilize.cpp",
+            core_range_cliff,
+            ComputeConfig{.compile_args = {nblocks_per_core_cliff, num_tiles_per_row}});
+    }
+
+    /* RUNTIME ARGS */
+
+    bfloat16 bfloat_pad_value = bfloat16(pad_value);
+    uint32_t packed_pad_value = pack_two_bfloat16_into_uint32({bfloat_pad_value, bfloat_pad_value});
+
+    // 1D distribution of blocks across cores
+    auto core_assignments = distribute_work(
+        output.get_legacy_shape().without_padding(),
+        output.get_legacy_shape().padding(),
+        ncores,
+        nblocks_per_core,
+        has_cliff,
+        nblocks_per_core_cliff);
+
+    uint32_t tile_start_id = 0;
+    uint32_t row_start_id = 0;
+    uint32_t ncores_x = grid_size.x;
+
+    const auto& cores = grid_to_cores(ncores, grid_size.x, grid_size.y, true);
+    for (uint32_t i = 0; i < ncores; ++i) {
+        const auto& core = cores[i];
+        const std::vector<BlockRep>& assignment = core_assignments.at(i);
+
+        // reader runtime args
+        vector<uint32_t> reader_rt_args = {
+            src0_buffer->address(),
+            unpadded_row_size_bytes,
+            padded_row_size_bytes,
+            packed_pad_value,
+            row_start_id,
+            static_cast<unsigned int>(assignment.size()),
+        };
+
+        uint32_t nblocks_per_core = 0;
+
+        for (const auto& el : assignment) {
+            nblocks_per_core += el.block_count();
+            row_start_id += el.data_row_count();
+            reader_rt_args.push_back(el.n_data);
+            reader_rt_args.push_back(el.n_mixed);
+            reader_rt_args.push_back(el.n_pads);
+            reader_rt_args.push_back(el.times);
+        }
+
+        uint32_t num_tiles_per_core = num_tiles_per_row * nblocks_per_core;
+
+        // writer runtime args
+        vector<uint32_t> writer_rt_args = {dst_buffer->address(), num_tiles_per_core, tile_start_id};
+
+        SetRuntimeArgs(program, unary_reader_kernel_id, core, reader_rt_args);
+        SetRuntimeArgs(program, unary_writer_kernel_id, core, writer_rt_args);
+
+        tile_start_id += num_tiles_per_core;
+    }
+
+    auto override_runtime_args_callback =
+        [reader_kernel_id = unary_reader_kernel_id, writer_kernel_id = unary_writer_kernel_id, cores = cores](
+            const Program& program,
+            const std::vector<Buffer*>& input_buffers,
+            const std::vector<Buffer*>& output_buffers) {
+            auto src_buffer = input_buffers.at(0);
+            auto dst_buffer = output_buffers.at(0);
+
+            auto& reader_runtime_args_by_core = GetRuntimeArgs(program, reader_kernel_id);
+            auto& writer_runtime_args_by_core = GetRuntimeArgs(program, writer_kernel_id);
+            for (const auto& core : cores) {
+                {
+                    auto& runtime_args = reader_runtime_args_by_core[core.x][core.y];
+                    runtime_args[0] = src_buffer->address();
+                }
+                {
+                    auto& runtime_args = writer_runtime_args_by_core[core.x][core.y];
+                    runtime_args[0] = dst_buffer->address();
+                }
+            }
+        };
+
+    return {std::move(program), override_runtime_args_callback};
+}
+
+// This purely supports input width shard -> output width shard for now
+operation::ProgramWithCallbacks tilize_with_val_padding_multi_core_sharded(
+    const Tensor& a, Tensor& output, const float pad_value) {
+    tt::tt_metal::Program program = tt::tt_metal::CreateProgram();
+
+    bool src_sharded = a.memory_config().is_sharded();
+    bool out_sharded = output.memory_config().is_sharded();
+
+    tt::DataFormat input_cb_data_format = tt::tt_metal::datatype_to_dataformat_converter(a.get_dtype());
+    uint32_t input_single_tile_size = tt::tt_metal::detail::TileSize(input_cb_data_format);
+    tt::DataFormat output_cb_data_format = tt::tt_metal::datatype_to_dataformat_converter(output.get_dtype());
+    uint32_t output_single_tile_size = tt::tt_metal::detail::TileSize(output_cb_data_format);
+
+    Device* device = a.device();
+
+    auto input_shard_spec = a.shard_spec().value();
+    auto output_shard_spec = output.shard_spec().value();
+
+    auto all_cores = output_shard_spec.grid;
+
+    uint32_t num_batches = output.volume() / (output.get_legacy_shape()[-2] * output.get_legacy_shape()[-1]);
+
+    uint32_t num_input_rows = input_shard_spec.shape[0];
+    uint32_t input_shard_width_bytes = input_shard_spec.shape[1] * a.element_size();
+    uint32_t ntiles_per_core = output_shard_spec.shape[0] * output_shard_spec.shape[1] / TILE_HW;
+    uint32_t ntiles_per_batch = ntiles_per_core / num_batches;
+    uint32_t ntiles_per_block = output_shard_spec.shape[1] / TILE_WIDTH;
+    uint32_t nblocks_per_core = output_shard_spec.shape[0] / TILE_HEIGHT;
+    uint32_t num_padded_rows = output.get_legacy_shape()[-2] - a.get_legacy_shape()[-2];
+
+    auto [src0_cb_index, cb_src0] = create_cb(
+        tt::CB::c_in1,
+        program,
+        all_cores,
+        input_shard_width_bytes,
+        num_input_rows,
+        input_cb_data_format,
+        src_sharded ? a.buffer() : nullptr);
+
+    auto [src1_cb_index, cb_src1] = create_cb(
+        tt::CB::c_in0, program, all_cores, input_single_tile_size, ntiles_per_batch * 2, input_cb_data_format);
+
+    auto [src2_cb_index, cb_src2] =
+        create_cb(tt::CB::c_in2, program, all_cores, input_shard_width_bytes, 1, input_cb_data_format);
+
+    auto [output_cb_index, cb_output] = create_cb(
+        tt::CB::c_out0,
+        program,
+        all_cores,
+        output_single_tile_size,
+        ntiles_per_core,
+        output_cb_data_format,
+        out_sharded ? output.buffer() : nullptr);
+
+    Buffer* src0_buffer = a.buffer();
+    Buffer* dst_buffer = output.buffer();
+    TT_ASSERT(dst_buffer != nullptr, "Output buffer should be allocated on device!");
+
+    /** reader
+     */
+    KernelHandle unary_reader_kernel_id;
+    std::vector<uint32_t> reader_ct_args = {
+        (std::uint32_t)src0_cb_index,
+        (std::uint32_t)src1_cb_index,
+        (std::uint32_t)src2_cb_index,
+    };
+
+    unary_reader_kernel_id = tt::tt_metal::CreateKernel(
+        program,
+        "tt_eager/tt_dnn/op_library/tilize/kernels/dataflow/reader_unary_pad_height_width_sharded.cpp",
+        all_cores,
+        tt::tt_metal::ReaderDataMovementConfig(reader_ct_args));
+
+    /** writer
+     */
+    KernelHandle unary_writer_kernel_id;
+    bool out_is_dram = dst_buffer->buffer_type() == BufferType::DRAM ? 1 : 0;
+    vector<uint32_t> writer_ct_args = {
+        output_cb_index,
+    };
+    unary_writer_kernel_id = CreateKernel(
+        program,
+        "tt_eager/tt_dnn/op_library/sharded/kernels/dataflow/writer_unary_sharded.cpp",
+        all_cores,
+        WriterDataMovementConfig(writer_ct_args));
+
+    /** compute
+     */
+    vector<uint32_t> compute_args = {
+        (uint32_t)nblocks_per_core,  // per_core_block_cnt
+        (uint32_t)ntiles_per_block,  // per_block_ntiles
+    };
+
+    auto tilize_kernel_id = CreateKernel(
+        program, "tt_eager/tt_dnn/kernels/compute/tilize.cpp", all_cores, ComputeConfig{.compile_args = compute_args});
+
+    bfloat16 bfloat_pad_value = bfloat16(pad_value);
+    uint32_t packed_pad_value = pack_two_bfloat16_into_uint32({bfloat_pad_value, bfloat_pad_value});
+
+    vector<uint32_t> reader_rt_args = {
+        num_input_rows,
+        input_shard_width_bytes,
+        (num_input_rows / num_batches) * input_shard_width_bytes,
+        ntiles_per_batch,
+        num_padded_rows,
+        num_batches,
+        packed_pad_value};
+    tt::tt_metal::SetRuntimeArgs(program, unary_reader_kernel_id, all_cores, reader_rt_args);
+
+    vector<uint32_t> writer_rt_args = {ntiles_per_core};
+    tt::tt_metal::SetRuntimeArgs(program, unary_writer_kernel_id, all_cores, writer_rt_args);
+
+    auto override_runtime_arguments_callback = [reader_kernel_id = unary_reader_kernel_id,
+                                                writer_kernel_id = unary_writer_kernel_id,
+                                                cb_src0 = cb_src0,
+                                                cb_output = cb_output](
+                                                   const void* operation,
+                                                   Program& program,
+                                                   const std::vector<Tensor>& input_tensors,
+                                                   const std::vector<std::optional<const Tensor>>&,
+                                                   const std::vector<Tensor>& output_tensors) {
+        auto src_buffer = input_tensors.at(0).buffer();
+        auto dst_buffer = output_tensors.at(0).buffer();
+
+        UpdateDynamicCircularBufferAddress(program, cb_src0, *src_buffer);
+        UpdateDynamicCircularBufferAddress(program, cb_output, *dst_buffer);
+    };
+
+    return {.program = std::move(program), .override_runtime_arguments_callback = override_runtime_arguments_callback};
+}
+
+operation::ProgramWithCallbacks tilize_with_val_padding_multi_core(
+    const Tensor& a, Tensor& output, const float pad_value) {
+    if (a.memory_config().is_sharded()) {
+        return tilize_with_val_padding_multi_core_sharded(a, output, pad_value);
+    } else {
+        return tilize_with_val_padding_multi_core_interleaved(a, output, pad_value);
+    }
+}
+
+}  // namespace ttnn::operations::data_movement::detail

--- a/ttnn/cpp/ttnn/operations/data_movement/tilize/tilize.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/tilize/tilize.hpp
@@ -1,0 +1,47 @@
+// SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include "device/tilize_op.hpp"
+#include "tt_eager/tt_dnn/op_library/run_operation.hpp"
+#include "ttnn/decorators.hpp"
+
+namespace ttnn {
+namespace operations::data_movement {
+
+struct ExecuteTilize {
+    static ttnn::Tensor execute_on_worker_thread(
+        uint8_t queue_id,
+        const ttnn::Tensor &input_tensor,
+        const std::optional<MemoryConfig> &memory_config = std::nullopt,
+        std::optional<const DataType> output_dtype = std::nullopt,
+        bool use_multicore = false) {
+        return operation::run(
+                   Tilize{
+                       memory_config.value_or(input_tensor.memory_config()),
+                       output_dtype.value_or(input_tensor.get_dtype()),
+                       use_multicore},
+                   {input_tensor},
+                   {},
+                   {},
+                   queue_id)
+            .at(0);
+    }
+
+    static ttnn::Tensor execute_on_worker_thread(
+        const ttnn::Tensor &input_tensor,
+        const std::optional<MemoryConfig> &memory_config = std::nullopt,
+        std::optional<const DataType> output_dtype = std::nullopt,
+        bool use_multicore = false) {
+        constexpr uint8_t DefaultQueueId = 0;
+        return execute_on_worker_thread(DefaultQueueId, input_tensor, memory_config, output_dtype, use_multicore);
+    }
+};
+
+}  // namespace operations::data_movement
+
+constexpr auto tilize = ttnn::register_operation<ttnn::operations::data_movement::ExecuteTilize>("ttnn::tilize");
+
+}  // namespace ttnn

--- a/ttnn/cpp/ttnn/operations/data_movement/tilize/tilize_with_val_padding.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/tilize/tilize_with_val_padding.hpp
@@ -1,0 +1,88 @@
+// SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include "device/tilize_with_val_padding_op.hpp"
+#include "tt_eager/tt_dnn/op_library/run_operation.hpp"
+#include "ttnn/decorators.hpp"
+
+namespace ttnn {
+namespace operations::data_movement {
+
+struct ExecuteTilizeWithValPadding {
+    static ttnn::Tensor execute_on_worker_thread(
+        uint8_t queue_id,
+        const ttnn::Tensor &input_tensor,
+        const tt::tt_metal::Shape &output_tensor_shape,
+        float pad_value,
+        const std::optional<MemoryConfig> &memory_config = std::nullopt,
+        std::optional<const DataType> output_dtype = std::nullopt,
+        bool use_multicore = false) {
+        return operation::run(
+                   TilizeWithValPadding{
+                       output_tensor_shape,
+                       pad_value,
+                       memory_config.value_or(input_tensor.memory_config()),
+                       output_dtype.value_or(input_tensor.get_dtype()),
+                       use_multicore},
+                   {input_tensor},
+                   {},
+                   {},
+                   queue_id)
+            .at(0);
+    }
+
+    static ttnn::Tensor execute_on_worker_thread(
+        const ttnn::Tensor &input_tensor,
+        const tt::tt_metal::Shape &output_tensor_shape,
+        float pad_value,
+        const std::optional<MemoryConfig> &memory_config = std::nullopt,
+        std::optional<const DataType> output_dtype = std::nullopt,
+        bool use_multicore = false) {
+        constexpr uint8_t DefaultQueueId = 0;
+        return execute_on_worker_thread(
+            DefaultQueueId, input_tensor, output_tensor_shape, pad_value, memory_config, output_dtype, use_multicore);
+    }
+};
+
+struct ExecuteTilizeWithZeroPadding {
+    static constexpr uint8_t DefaultQueueId = 0;
+
+    static ttnn::Tensor execute_on_worker_thread(
+        uint8_t queue_id,
+        const ttnn::Tensor &input_tensor,
+        const std::optional<MemoryConfig> &memory_config = std::nullopt,
+        std::optional<const DataType> output_dtype = std::nullopt,
+        bool use_multicore = false) {
+        auto shape = input_tensor.get_legacy_shape();
+
+        shape[2] = tt::round_up(shape[2], TILE_HEIGHT);
+        shape[3] = tt::round_up(shape[3], TILE_WIDTH);
+
+        return ExecuteTilizeWithValPadding::execute_on_worker_thread(
+            queue_id, input_tensor, shape, 0, memory_config, output_dtype, use_multicore);
+    }
+
+    static ttnn::Tensor execute_on_worker_thread(
+        const ttnn::Tensor &input_tensor,
+        const std::optional<MemoryConfig> &memory_config = std::nullopt,
+        std::optional<const DataType> output_dtype = std::nullopt,
+        bool use_multicore = false) {
+        constexpr uint8_t DefaultQueueId = 0;
+        return execute_on_worker_thread(DefaultQueueId, input_tensor, memory_config, output_dtype, use_multicore);
+    }
+};
+
+}  // namespace operations::data_movement
+
+constexpr auto tilize_with_val_padding =
+    ttnn::register_operation<ttnn::operations::data_movement::ExecuteTilizeWithValPadding>(
+        "ttnn::tilize_with_val_padding");
+
+constexpr auto tilize_with_zero_padding =
+    ttnn::register_operation<ttnn::operations::data_movement::ExecuteTilizeWithZeroPadding>(
+        "ttnn::tilize_with_zero_padding");
+
+}  // namespace ttnn


### PR DESCRIPTION
### Ticket
#9747 

### Problem description
- Part of the effort to move all ops from tt_eager to ttnn.

### What's changed
- This PR replaces usage of tilize (with padding) ops in C++ with their ttnn analogs

### Checklist
- [x] Post commit CI passes