### PR TITLE
removed weight copies from DRAM to L1

### DIFF
--- a/models/demos/mamba/tests/test_mamba_perf.py
+++ b/models/demos/mamba/tests/test_mamba_perf.py
@@ -129,7 +129,7 @@ def test_mamba_e2e_perf(
 @pytest.mark.models_device_performance_bare_metal
 @pytest.mark.parametrize(
     "batch, warmup, expected_device_fw_duration_ms",
-    ((32, True, 1.7),),
+    ((32, True, 1.6),),
 )
 def test_mamba_perf_device(batch, warmup, expected_device_fw_duration_ms, reset_seeds):
     subdir = "ttnn_mamba"


### PR DESCRIPTION
### Problem description
1. Removed DRAM_to_L1_MEMORY explicit conversions calls for weights before eltwise_ops
2. Replaced sharded ops with interleaved in mamba block

### What's changed
Helped to improve decode perf by 0.1ms per layer

### Checklist
- [ ] Post commit CI passes
- [ ] Model regression CI testing passes (if applicable)
- [ ] New/Existing tests provide coverage for changes
