### PR TITLE
#9082: ping individual falcon member since slack user group is not wo…

### DIFF
--- a/.github/workflows/t3000-frequent-tests.yaml
+++ b/.github/workflows/t3000-frequent-tests.yaml
@@ -22,7 +22,7 @@ jobs:
           { name: "t3k trace stress tests", arch: wormhole_b0, cmd: run_t3000_trace_stress_tests, timeout: 120, 
           runs-on: [arch-wormhole_b0, "config-t3000", "in-service", "runner-test", "bare-metal", "pipeline-functional", "t3k"], owner_id: U03NG0A5ND7}, #Aditya Saigal
           { name: "t3k falcon40b tests", arch: wormhole_b0, cmd: run_t3000_falcon40b_tests, timeout: 120, 
-          runs-on: [arch-wormhole_b0, "config-t3000", "in-service", "runner-test", "bare-metal", "pipeline-functional"], owner_id: S07AJBTLX2L}, #Model Falcon
+          runs-on: [arch-wormhole_b0, "config-t3000", "in-service", "runner-test", "bare-metal", "pipeline-functional"], owner_id: U04S2UV6L8N}, #Sofija Jovic 
           { name: "t3k llama2_70b tests", arch: wormhole_b0, cmd: run_t3000_llama2_70b_tests, timeout: 60, 
           runs-on: [arch-wormhole_b0, "config-t3000", "in-service", "runner-test", "bare-metal", "pipeline-functional"], owner_id: U03FJB5TM5Y}, #Colman Glagovich
           { name: "t3k mixtral tests", arch: wormhole_b0, cmd: run_t3000_mixtral_tests, timeout: 60, 

--- a/.github/workflows/t3000-model-perf-tests.yaml
+++ b/.github/workflows/t3000-model-perf-tests.yaml
@@ -18,13 +18,13 @@ jobs:
       matrix:
         test-group: [
           { name: "t3k LLM falcon7b model perf tests", model: "falcob7b", model-type: "LLM", arch: wormhole_b0, cmd: run_t3000_falcon7b_tests, timeout: 75, 
-            runs-on: ["arch-wormhole_b0", "config-t3000", "in-service", "runner-test", "bare-metal", "pipeline-perf", "runs-llm-falcon"], owner_id: S07AJBTLX2L}, #Model Falcon
+            runs-on: ["arch-wormhole_b0", "config-t3000", "in-service", "runner-test", "bare-metal", "pipeline-perf", "runs-llm-falcon"], owner_id: U053W15B6JF}, # Djordje Ivanovic
           { name: "t3k LLM mixtral model perf tests", model: "mixtral", model-type: "LLM", arch: wormhole_b0, cmd: run_t3000_mixtral_tests, timeout: 75, 
             runs-on: ["arch-wormhole_b0", "config-t3000", "in-service", "runner-test", "bare-metal", "pipeline-perf"  ], owner_id: U03PUAKE719}, # Miguel Tairum
           { name: "t3k LLM llama2 model perf tests", model: "llama2", model-type: "LLM", arch: wormhole_b0, cmd: run_t3000_llama2_70b_tests, timeout: 75, 
             runs-on: ["arch-wormhole_b0", "config-t3000", "in-service", "runner-test", "bare-metal", "pipeline-perf"], owner_id: U03FJB5TM5Y}, #Colman Glagovich
           { name: "t3k LLM falcon40b model perf tests", model: "falcon40b", model-type: "LLM", arch: wormhole_b0, cmd: run_t3000_falcon40b_tests, timeout: 75, 
-            runs-on: ["arch-wormhole_b0", "config-t3000", "in-service", "runner-test", "bare-metal", "pipeline-perf", "runs-llm-falcon"], owner_id: S07AJBTLX2L}, # Model Falcon
+            runs-on: ["arch-wormhole_b0", "config-t3000", "in-service", "runner-test", "bare-metal", "pipeline-perf", "runs-llm-falcon"], owner_id: U04JRL8DZHQ}, #Pavle Popovic
           #{ name: "t3k CNN model perf tests ", model-type: "CNN", arch: wormhole_b0, cmd: run_t3000_cnn_tests, timeout: 120, owner_id: }, #No tests are being run?
         ]
     name: ${{ matrix.test-group.name }}


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/9082
### Problem description
Attempted to use slack user groups but web url does not support using slack user groups. therefore must resort back to individual slack IDs

### What's changed
Change slack owners one of falcon model team members

### Checklist
- [ ] Post commit CI passes
- [ ] Model regression CI testing passes (if applicable)
- [ ] New/Existing tests provide coverage for changes
