### PR TITLE
#10074: Move Unary backward ops to TTNN

### DIFF
--- a/docs/source/ttnn/ttnn/api.rst
+++ b/docs/source/ttnn/ttnn/api.rst
@@ -238,6 +238,7 @@ Pointwise Unary
    ttnn/digamma_bw
    ttnn/erfinv_bw
    ttnn/erf_bw
+   ttnn/deg2rad_bw
 
 Pointwise Binary
 ================

--- a/docs/source/ttnn/ttnn/api.rst
+++ b/docs/source/ttnn/ttnn/api.rst
@@ -236,6 +236,7 @@ Pointwise Unary
    ttnn/expm1_bw
    ttnn/reciprocal_bw
    ttnn/digamma_bw
+   ttnn/erfinv_bw
 
 Pointwise Binary
 ================

--- a/docs/source/ttnn/ttnn/api.rst
+++ b/docs/source/ttnn/ttnn/api.rst
@@ -234,6 +234,7 @@ Pointwise Unary
    ttnn/div_no_nan_bw
    ttnn/exp2_bw
    ttnn/expm1_bw
+   ttnn/reciprocal_bw
 
 Pointwise Binary
 ================

--- a/docs/source/ttnn/ttnn/api.rst
+++ b/docs/source/ttnn/ttnn/api.rst
@@ -237,6 +237,7 @@ Pointwise Unary
    ttnn/reciprocal_bw
    ttnn/digamma_bw
    ttnn/erfinv_bw
+   ttnn/erf_bw
 
 Pointwise Binary
 ================

--- a/docs/source/ttnn/ttnn/api.rst
+++ b/docs/source/ttnn/ttnn/api.rst
@@ -232,6 +232,7 @@ Pointwise Unary
    ttnn/fmod_bw
    ttnn/remainder_bw
    ttnn/div_no_nan_bw
+   ttnn/exp2_bw
 
 Pointwise Binary
 ================

--- a/docs/source/ttnn/ttnn/api.rst
+++ b/docs/source/ttnn/ttnn/api.rst
@@ -233,6 +233,7 @@ Pointwise Unary
    ttnn/remainder_bw
    ttnn/div_no_nan_bw
    ttnn/exp2_bw
+   ttnn/expm1_bw
 
 Pointwise Binary
 ================

--- a/docs/source/ttnn/ttnn/api.rst
+++ b/docs/source/ttnn/ttnn/api.rst
@@ -235,6 +235,7 @@ Pointwise Unary
    ttnn/exp2_bw
    ttnn/expm1_bw
    ttnn/reciprocal_bw
+   ttnn/digamma_bw
 
 Pointwise Binary
 ================

--- a/docs/source/ttnn/ttnn/dependencies/tt_lib.rst
+++ b/docs/source/ttnn/ttnn/dependencies/tt_lib.rst
@@ -832,8 +832,6 @@ Backward Operations
 
 .. autofunction:: tt_lib.tensor.angle_bw
 
-.. autofunction:: tt_lib.tensor.deg2rad_bw
-
 .. autofunction:: tt_lib.tensor.threshold_bw
 
 .. autofunction:: tt_lib.tensor.complex_recip_bw

--- a/docs/source/ttnn/ttnn/dependencies/tt_lib.rst
+++ b/docs/source/ttnn/ttnn/dependencies/tt_lib.rst
@@ -814,8 +814,6 @@ Backward Operations
 
 .. autofunction:: tt_lib.tensor.exp_bw
 
-.. autofunction:: tt_lib.tensor.exp2_bw
-
 .. autofunction:: tt_lib.tensor.expm1_bw
 
 .. autofunction:: tt_lib.tensor.unary_pow_bw

--- a/docs/source/ttnn/ttnn/dependencies/tt_lib.rst
+++ b/docs/source/ttnn/ttnn/dependencies/tt_lib.rst
@@ -814,8 +814,6 @@ Backward Operations
 
 .. autofunction:: tt_lib.tensor.exp_bw
 
-.. autofunction:: tt_lib.tensor.expm1_bw
-
 .. autofunction:: tt_lib.tensor.unary_pow_bw
 
 .. autofunction:: tt_lib.tensor.tanh_bw

--- a/docs/source/ttnn/ttnn/dependencies/tt_lib.rst
+++ b/docs/source/ttnn/ttnn/dependencies/tt_lib.rst
@@ -832,8 +832,6 @@ Backward Operations
 
 .. autofunction:: tt_lib.tensor.angle_bw
 
-.. autofunction:: tt_lib.tensor.erf_bw
-
 .. autofunction:: tt_lib.tensor.deg2rad_bw
 
 .. autofunction:: tt_lib.tensor.threshold_bw

--- a/docs/source/ttnn/ttnn/dependencies/tt_lib.rst
+++ b/docs/source/ttnn/ttnn/dependencies/tt_lib.rst
@@ -828,8 +828,6 @@ Backward Operations
 
 .. autofunction:: tt_lib.tensor.polygamma_bw
 
-.. autofunction:: tt_lib.tensor.erfinv_bw
-
 .. autofunction:: tt_lib.tensor.hardtanh_bw
 
 .. autofunction:: tt_lib.tensor.angle_bw

--- a/docs/source/ttnn/ttnn/dependencies/tt_lib.rst
+++ b/docs/source/ttnn/ttnn/dependencies/tt_lib.rst
@@ -840,8 +840,6 @@ Backward Operations
 
 .. autofunction:: tt_lib.tensor.deg2rad_bw
 
-.. autofunction:: tt_lib.tensor.reciprocal_bw
-
 .. autofunction:: tt_lib.tensor.threshold_bw
 
 .. autofunction:: tt_lib.tensor.complex_recip_bw

--- a/docs/source/ttnn/ttnn/dependencies/tt_lib.rst
+++ b/docs/source/ttnn/ttnn/dependencies/tt_lib.rst
@@ -836,8 +836,6 @@ Backward Operations
 
 .. autofunction:: tt_lib.tensor.erf_bw
 
-.. autofunction:: tt_lib.tensor.digamma_bw
-
 .. autofunction:: tt_lib.tensor.deg2rad_bw
 
 .. autofunction:: tt_lib.tensor.threshold_bw

--- a/docs/source/ttnn/ttnn/ttnn/deg2rad_bw.rst
+++ b/docs/source/ttnn/ttnn/ttnn/deg2rad_bw.rst
@@ -1,0 +1,6 @@
+.. _ttnn.deg2rad_bw:
+
+ttnn.deg2rad_bw
+###############
+
+.. autofunction:: ttnn.deg2rad_bw

--- a/docs/source/ttnn/ttnn/ttnn/digamma_bw.rst
+++ b/docs/source/ttnn/ttnn/ttnn/digamma_bw.rst
@@ -1,0 +1,6 @@
+.. _ttnn.digamma_bw:
+
+ttnn.digamma_bw
+###############
+
+.. autofunction:: ttnn.digamma_bw

--- a/docs/source/ttnn/ttnn/ttnn/erf_bw.rst
+++ b/docs/source/ttnn/ttnn/ttnn/erf_bw.rst
@@ -1,0 +1,6 @@
+.. _ttnn.erf_bw:
+
+ttnn.erf_bw
+###############
+
+.. autofunction:: ttnn.erf_bw

--- a/docs/source/ttnn/ttnn/ttnn/erfinv_bw.rst
+++ b/docs/source/ttnn/ttnn/ttnn/erfinv_bw.rst
@@ -1,0 +1,6 @@
+.. _ttnn.erfinv_bw:
+
+ttnn.erfinv_bw
+###############
+
+.. autofunction:: ttnn.erfinv_bw

--- a/docs/source/ttnn/ttnn/ttnn/exp2_bw.rst
+++ b/docs/source/ttnn/ttnn/ttnn/exp2_bw.rst
@@ -1,0 +1,6 @@
+.. _ttnn.exp2_bw:
+
+ttnn.exp2_bw
+###############
+
+.. autofunction:: ttnn.exp2_bw

--- a/docs/source/ttnn/ttnn/ttnn/expm1_bw.rst
+++ b/docs/source/ttnn/ttnn/ttnn/expm1_bw.rst
@@ -1,0 +1,6 @@
+.. _ttnn.expm1_bw:
+
+ttnn.expm1_bw
+###############
+
+.. autofunction:: ttnn.expm1_bw

--- a/docs/source/ttnn/ttnn/ttnn/reciprocal_bw.rst
+++ b/docs/source/ttnn/ttnn/ttnn/reciprocal_bw.rst
@@ -1,6 +1,6 @@
 .. _ttnn.reciprocal_bw:
 
 ttnn.reciprocal_bw
-###############
+##################
 
 .. autofunction:: ttnn.reciprocal_bw

--- a/docs/source/ttnn/ttnn/ttnn/reciprocal_bw.rst
+++ b/docs/source/ttnn/ttnn/ttnn/reciprocal_bw.rst
@@ -1,0 +1,6 @@
+.. _ttnn.reciprocal_bw:
+
+ttnn.reciprocal_bw
+###############
+
+.. autofunction:: ttnn.reciprocal_bw

--- a/tests/ttnn/unit_tests/operations/backward/test_backward_deg2rad.py
+++ b/tests/ttnn/unit_tests/operations/backward/test_backward_deg2rad.py
@@ -4,8 +4,8 @@
 
 import torch
 import pytest
-import tt_lib
-from tests.tt_eager.python_api_testing.unit_testing.backward_ops.utility_funcs import compare_pcc, data_gen_with_range
+import ttnn
+from tests.ttnn.unit_tests.operations.backward.utility_funcs import compare_pcc, data_gen_with_range
 
 
 @pytest.mark.parametrize(
@@ -22,7 +22,7 @@ def test_bw_deg2rad(input_shapes, device):
 
     pyt_y = torch.deg2rad(in_data)
 
-    tt_output_tensor_on_device = tt_lib.tensor.deg2rad_bw(grad_tensor, input_tensor)
+    tt_output_tensor_on_device = ttnn.deg2rad_bw(grad_tensor, input_tensor)
 
     in_data.retain_grad()
 

--- a/tests/ttnn/unit_tests/operations/backward/test_backward_digamma.py
+++ b/tests/ttnn/unit_tests/operations/backward/test_backward_digamma.py
@@ -4,8 +4,8 @@
 
 import torch
 import pytest
-import tt_lib
-from tests.tt_eager.python_api_testing.unit_testing.backward_ops.utility_funcs import compare_pcc, data_gen_with_range
+import ttnn
+from tests.ttnn.unit_tests.operations.backward.utility_funcs import compare_pcc, data_gen_with_range
 
 
 @pytest.mark.parametrize(
@@ -22,7 +22,7 @@ def test_bw_digamma(input_shapes, device):
 
     pyt_y = torch.digamma(in_data)
 
-    tt_output_tensor_on_device = tt_lib.tensor.digamma_bw(grad_tensor, input_tensor)
+    tt_output_tensor_on_device = ttnn.digamma_bw(grad_tensor, input_tensor)
 
     in_data.retain_grad()
 

--- a/tests/ttnn/unit_tests/operations/backward/test_backward_erf.py
+++ b/tests/ttnn/unit_tests/operations/backward/test_backward_erf.py
@@ -4,8 +4,8 @@
 
 import torch
 import pytest
-import tt_lib
-from tests.tt_eager.python_api_testing.unit_testing.backward_ops.utility_funcs import compare_pcc, data_gen_with_range
+import ttnn
+from tests.ttnn.unit_tests.operations.backward.utility_funcs import compare_pcc, data_gen_with_range
 
 
 @pytest.mark.parametrize(
@@ -22,7 +22,7 @@ def test_bw_erf(input_shapes, device):
 
     pyt_y = torch.erf(in_data)
 
-    tt_output_tensor_on_device = tt_lib.tensor.erf_bw(grad_tensor, input_tensor)
+    tt_output_tensor_on_device = ttnn.erf_bw(grad_tensor, input_tensor)
 
     in_data.retain_grad()
 

--- a/tests/ttnn/unit_tests/operations/backward/test_backward_erfinv.py
+++ b/tests/ttnn/unit_tests/operations/backward/test_backward_erfinv.py
@@ -4,8 +4,8 @@
 
 import torch
 import pytest
-import tt_lib
-from tests.tt_eager.python_api_testing.unit_testing.backward_ops.utility_funcs import data_gen_with_range, compare_pcc
+import ttnn
+from tests.ttnn.unit_tests.operations.backward.utility_funcs import data_gen_with_range, compare_pcc
 
 
 @pytest.mark.parametrize(
@@ -21,7 +21,7 @@ def test_bw_erfinv(input_shapes, device):
     grad_data, grad_tensor = data_gen_with_range(input_shapes, -20, 20, device, True)
     in_data.retain_grad()
 
-    tt_output_tensor_on_device = tt_lib.tensor.erfinv_bw(grad_tensor, input_tensor)
+    tt_output_tensor_on_device = ttnn.erfinv_bw(grad_tensor, input_tensor)
 
     pyt_y = torch.erfinv(in_data)
 

--- a/tests/ttnn/unit_tests/operations/backward/test_backward_exp2.py
+++ b/tests/ttnn/unit_tests/operations/backward/test_backward_exp2.py
@@ -4,8 +4,8 @@
 
 import torch
 import pytest
-import tt_lib
-from tests.tt_eager.python_api_testing.unit_testing.backward_ops.utility_funcs import data_gen_with_range, compare_pcc
+import ttnn
+from tests.ttnn.unit_tests.operations.backward.utility_funcs import data_gen_with_range, compare_pcc
 
 
 @pytest.mark.parametrize(
@@ -22,7 +22,7 @@ def test_bw_exp2(input_shapes, device):
 
     pyt_y = torch.exp2(in_data)
 
-    tt_output_tensor_on_device = tt_lib.tensor.exp2_bw(grad_tensor, input_tensor)
+    tt_output_tensor_on_device = ttnn.exp2_bw(grad_tensor, input_tensor)
 
     in_data.retain_grad()
 

--- a/tests/ttnn/unit_tests/operations/backward/test_backward_expm1.py
+++ b/tests/ttnn/unit_tests/operations/backward/test_backward_expm1.py
@@ -4,8 +4,8 @@
 
 import torch
 import pytest
-import tt_lib
-from tests.tt_eager.python_api_testing.unit_testing.backward_ops.utility_funcs import data_gen_with_range, compare_pcc
+import ttnn
+from tests.ttnn.unit_tests.operations.backward.utility_funcs import data_gen_with_range, compare_pcc
 
 
 @pytest.mark.parametrize(
@@ -22,7 +22,7 @@ def test_bw_expm1(input_shapes, device):
 
     pyt_y = torch.expm1(in_data)
 
-    tt_output_tensor_on_device = tt_lib.tensor.expm1_bw(grad_tensor, input_tensor)
+    tt_output_tensor_on_device = ttnn.expm1_bw(grad_tensor, input_tensor)
 
     in_data.retain_grad()
 

--- a/tests/ttnn/unit_tests/operations/backward/test_backward_reciprocal.py
+++ b/tests/ttnn/unit_tests/operations/backward/test_backward_reciprocal.py
@@ -4,8 +4,8 @@
 
 import torch
 import pytest
-import tt_lib
-from tests.tt_eager.python_api_testing.unit_testing.backward_ops.utility_funcs import (
+import ttnn
+from tests.ttnn.unit_tests.operations.backward.utility_funcs import (
     compare_pcc,
     data_gen_with_range,
     data_gen_with_val,
@@ -26,7 +26,7 @@ def test_bw_reciprocal_0(input_shapes, device):
 
     pyt_y = torch.reciprocal(in_data)
 
-    tt_output_tensor_on_device = tt_lib.tensor.reciprocal_bw(grad_tensor, input_tensor)
+    tt_output_tensor_on_device = ttnn.reciprocal_bw(grad_tensor, input_tensor)
 
     in_data.retain_grad()
 
@@ -51,7 +51,7 @@ def test_bw_reciprocal(input_shapes, device):
 
     pyt_y = torch.reciprocal(in_data)
 
-    tt_output_tensor_on_device = tt_lib.tensor.reciprocal_bw(grad_tensor, input_tensor)
+    tt_output_tensor_on_device = ttnn.reciprocal_bw(grad_tensor, input_tensor)
 
     in_data.retain_grad()
 

--- a/tt_eager/tt_dnn/op_library/backward/backward_ops.cpp
+++ b/tt_eager/tt_dnn/op_library/backward/backward_ops.cpp
@@ -479,29 +479,6 @@ std::vector<Tensor> deg2rad_bw(const Tensor& grad, const Tensor& input, const Me
     return operation::decorate_as_composite(__func__, _deg2rad_bw)(grad, input, output_mem_config);
 }
 
-
-std::vector<Tensor> _reciprocal_bw(const Tensor& grad, const Tensor& input, const MemoryConfig& output_mem_config) {
-    std::vector<Tensor> grad_tensor;
-    Tensor t_inf = full_like(input, std::numeric_limits<float>::infinity(), output_mem_config);
-    Tensor t_nan = full_like(input, std::nanf(""), output_mem_config);
-    grad_tensor.emplace_back(where(
-        ttnn::eqz(input, output_mem_config),
-        where(
-            ttnn::eqz(grad, output_mem_config),
-            t_nan,
-            ttnn::multiply(t_inf, ttnn::neg(ttnn::sign(grad, output_mem_config), output_mem_config), std::nullopt, output_mem_config),
-            output_mem_config),
-        ttnn::multiply(ttnn::neg(grad, output_mem_config),
-            ttnn::reciprocal(ttnn::square(input, output_mem_config), output_mem_config),
-            std::nullopt,
-            output_mem_config),
-        output_mem_config));
-    return grad_tensor;
-}
-std::vector<Tensor> reciprocal_bw(const Tensor& grad, const Tensor& input, const MemoryConfig& output_mem_config) {
-    return operation::decorate_as_composite(__func__, _reciprocal_bw)(grad, input, output_mem_config);
-}
-
 // Autoformat support
 Tensor change_layout_to_tile(const Tensor& temp, const MemoryConfig& output_mem_config) {
     auto formatted_input_tensor = temp;

--- a/tt_eager/tt_dnn/op_library/backward/backward_ops.cpp
+++ b/tt_eager/tt_dnn/op_library/backward/backward_ops.cpp
@@ -250,20 +250,6 @@ std::vector<Tensor> expm1_bw(const Tensor& grad, const Tensor& input, const Memo
     return operation::decorate_as_composite(__func__, _expm1_bw)(grad, input, output_mem_config);
 }
 
-// #  bw (exp2) = grad * exp2(input) * M_LN2
-// # M_LN2 = 0.693147180559945309417
-std::vector<Tensor> _exp2_bw(const Tensor& grad, const Tensor& input, const MemoryConfig& output_mem_config) {
-    std::vector<Tensor> grad_tensor;
-    Tensor exp_result = ttnn::exp2(input, output_mem_config);
-    exp_result = ttnn::multiply(exp_result, M_LN2, std::nullopt, output_mem_config);
-    Tensor result = ttnn::multiply(grad, exp_result, std::nullopt, output_mem_config);
-    grad_tensor.emplace_back(result);
-    return grad_tensor;
-}
-std::vector<Tensor> exp2_bw(const Tensor& grad, const Tensor& input, const MemoryConfig& output_mem_config) {
-    return operation::decorate_as_composite(__func__, _exp2_bw)(grad, input, output_mem_config);
-}
-
 std::vector<Tensor> _gelu_bw(
     const Tensor& grad, const Tensor& input, string approximate, const MemoryConfig& output_mem_config) {
     std::vector<Tensor> grad_tensor;

--- a/tt_eager/tt_dnn/op_library/backward/backward_ops.cpp
+++ b/tt_eager/tt_dnn/op_library/backward/backward_ops.cpp
@@ -441,33 +441,6 @@ std::vector<Tensor> erf_bw(const Tensor& grad, const Tensor& input, const Memory
     return operation::decorate_as_composite(__func__, _erf_bw)(grad, input, output_mem_config);
 }
 
-std::vector<Tensor> _digamma_bw(const Tensor& grad, const Tensor& input, const MemoryConfig& output_mem_config) {
-    std::vector<Tensor> grad_tensor;
-    float t_inf = std::numeric_limits<float>::infinity();
-    float t_nan = std::nanf("");
-    Tensor grad_a = ttnn::multiply(grad, polygamma(input, 1, output_mem_config), std::nullopt, output_mem_config);
-    grad_a = where(
-        ttnn::logical_and(ttnn::eqz(input, output_mem_config), ttnn::eqz(grad, output_mem_config), std::nullopt, output_mem_config),
-        t_nan,
-        grad_a,
-        output_mem_config);
-    grad_a = where(
-        ttnn::logical_and(ttnn::eqz(input, output_mem_config), ttnn::ltz(grad, output_mem_config), std::nullopt, output_mem_config),
-        -t_inf,
-        grad_a,
-        output_mem_config);
-    grad_a = where(
-        ttnn::logical_and(ttnn::eqz(input, output_mem_config), ttnn::gtz(grad, output_mem_config), std::nullopt, output_mem_config),
-        t_inf,
-        grad_a,
-        output_mem_config);
-    grad_tensor.emplace_back(grad_a);
-    return grad_tensor;
-}
-std::vector<Tensor> digamma_bw(const Tensor& grad, const Tensor& input, const MemoryConfig& output_mem_config) {
-    return operation::decorate_as_composite(__func__, _digamma_bw)(grad, input, output_mem_config);
-}
-
 std::vector<Tensor> _deg2rad_bw(const Tensor& grad, const Tensor& input, const MemoryConfig& output_mem_config) {
     std::vector<Tensor> grad_tensor;
     float M_PI_180 = M_PI / 180;

--- a/tt_eager/tt_dnn/op_library/backward/backward_ops.cpp
+++ b/tt_eager/tt_dnn/op_library/backward/backward_ops.cpp
@@ -384,17 +384,6 @@ std::vector<Tensor> hardtanh_bw(
     return operation::decorate_as_composite(__func__, _hardtanh_bw)(grad, input, min, max, output_mem_config);
 }
 
-std::vector<Tensor> _deg2rad_bw(const Tensor& grad, const Tensor& input, const MemoryConfig& output_mem_config) {
-    std::vector<Tensor> grad_tensor;
-    float M_PI_180 = M_PI / 180;
-    Tensor grad_result = ttnn::multiply(grad, M_PI_180, std::nullopt, output_mem_config);
-    grad_tensor.emplace_back(grad_result);
-    return grad_tensor;
-}
-std::vector<Tensor> deg2rad_bw(const Tensor& grad, const Tensor& input, const MemoryConfig& output_mem_config) {
-    return operation::decorate_as_composite(__func__, _deg2rad_bw)(grad, input, output_mem_config);
-}
-
 // Autoformat support
 Tensor change_layout_to_tile(const Tensor& temp, const MemoryConfig& output_mem_config) {
     auto formatted_input_tensor = temp;

--- a/tt_eager/tt_dnn/op_library/backward/backward_ops.cpp
+++ b/tt_eager/tt_dnn/op_library/backward/backward_ops.cpp
@@ -384,46 +384,6 @@ std::vector<Tensor> hardtanh_bw(
     return operation::decorate_as_composite(__func__, _hardtanh_bw)(grad, input, min, max, output_mem_config);
 }
 
-// erfinv
-// self: 0.5 * sqrt(M_PI) * exp(self.erfinv().pow(2)) * grad
-// for input -1 and 1: grad.sign() * inf, for input > 1 or < -1 : nan
-std::vector<Tensor> _erfinv_bw(const Tensor& grad, const Tensor& input, const MemoryConfig& output_mem_config) {
-    std::vector<Tensor> grad_tensor;
-    Tensor result = ttnn::multiply(
-        ttnn::multiply(ttnn::sqrt(full_like(input, M_PI, output_mem_config), output_mem_config),
-            ttnn::multiply(ttnn::exp(ttnn::square(ttnn::erfinv(input, output_mem_config), output_mem_config), false, output_mem_config),
-                grad,
-                std::nullopt,
-                output_mem_config),
-            std::nullopt,
-            output_mem_config),
-        0.5,
-        std::nullopt,
-        output_mem_config);
-    Tensor neg_one = full_like(input, -1.0, output_mem_config);
-    Tensor pos_one = full_like(input, 1.0, output_mem_config);
-    Tensor t_inf = ttnn::multiply(ttnn::sign(grad, output_mem_config), std::numeric_limits<float>::infinity(), std::nullopt, output_mem_config);
-    result = where(
-        ttnn::logical_or(
-            ttnn::lt(input, neg_one, std::nullopt, output_mem_config),
-            ttnn::gt(input, pos_one, std::nullopt, output_mem_config),
-            std::nullopt,
-            output_mem_config),
-        std::nanf(" "),
-        result,
-        output_mem_config);
-    result = where(
-        ttnn::eq(input, neg_one, std::nullopt, output_mem_config),
-        t_inf,
-        where(ttnn::eq(input, pos_one, std::nullopt, output_mem_config), t_inf, result, output_mem_config),
-        output_mem_config);
-    grad_tensor.emplace_back(result);
-    return grad_tensor;
-}
-std::vector<Tensor> erfinv_bw(const Tensor& grad, const Tensor& input, const MemoryConfig& output_mem_config) {
-    return operation::decorate_as_composite(__func__, _erfinv_bw)(grad, input, output_mem_config);
-}
-
 std::vector<Tensor> _erf_bw(const Tensor& grad, const Tensor& input, const MemoryConfig& output_mem_config) {
     std::vector<Tensor> grad_tensor;
     Tensor result = ttnn::multiply(

--- a/tt_eager/tt_dnn/op_library/backward/backward_ops.cpp
+++ b/tt_eager/tt_dnn/op_library/backward/backward_ops.cpp
@@ -237,19 +237,6 @@ std::vector<std::optional<Tensor>> tanh_bw(const Tensor& grad, const Tensor& inp
     return operation::decorate_as_composite(__func__, _tanh_bw)(default_queue_id, grad, input, output_mem_config, are_required_outputs, input_grad);
 }
 
-// bw(expm1) = grad * expm1(input) + 1
-std::vector<Tensor> _expm1_bw(const Tensor& grad, const Tensor& input, const MemoryConfig& output_mem_config) {
-    std::vector<Tensor> grad_tensor;
-    Tensor eresult = ttnn::expm1(input, output_mem_config);
-    Tensor rp1 = ttnn::add(eresult, 1.0f, std::nullopt, output_mem_config);
-    Tensor result = ttnn::multiply(grad, rp1, std::nullopt, output_mem_config);
-    grad_tensor.emplace_back(result);
-    return grad_tensor;
-}
-std::vector<Tensor> expm1_bw(const Tensor& grad, const Tensor& input, const MemoryConfig& output_mem_config) {
-    return operation::decorate_as_composite(__func__, _expm1_bw)(grad, input, output_mem_config);
-}
-
 std::vector<Tensor> _gelu_bw(
     const Tensor& grad, const Tensor& input, string approximate, const MemoryConfig& output_mem_config) {
     std::vector<Tensor> grad_tensor;

--- a/tt_eager/tt_dnn/op_library/backward/backward_ops.cpp
+++ b/tt_eager/tt_dnn/op_library/backward/backward_ops.cpp
@@ -384,23 +384,6 @@ std::vector<Tensor> hardtanh_bw(
     return operation::decorate_as_composite(__func__, _hardtanh_bw)(grad, input, min, max, output_mem_config);
 }
 
-std::vector<Tensor> _erf_bw(const Tensor& grad, const Tensor& input, const MemoryConfig& output_mem_config) {
-    std::vector<Tensor> grad_tensor;
-    Tensor result = ttnn::multiply(
-        ttnn::multiply(ttnn::exp(ttnn::neg(ttnn::square(input, output_mem_config), output_mem_config), false, output_mem_config),
-            grad,
-            std::nullopt,
-            output_mem_config),
-        M_2_SQRTPI,
-        std::nullopt,
-        output_mem_config);
-    grad_tensor.emplace_back(result);
-    return grad_tensor;
-}
-std::vector<Tensor> erf_bw(const Tensor& grad, const Tensor& input, const MemoryConfig& output_mem_config) {
-    return operation::decorate_as_composite(__func__, _erf_bw)(grad, input, output_mem_config);
-}
-
 std::vector<Tensor> _deg2rad_bw(const Tensor& grad, const Tensor& input, const MemoryConfig& output_mem_config) {
     std::vector<Tensor> grad_tensor;
     float M_PI_180 = M_PI / 180;

--- a/tt_eager/tt_dnn/op_library/backward/backward_ops.hpp
+++ b/tt_eager/tt_dnn/op_library/backward/backward_ops.hpp
@@ -147,11 +147,6 @@ std::vector<Tensor> angle_bw(
     bool is_complextensor = true,
     const MemoryConfig& output_mem_config = operation::DEFAULT_OUTPUT_MEMORY_CONFIG);
 
-std::vector<Tensor> deg2rad_bw(
-    const Tensor& grad,
-    const Tensor& input,
-    const MemoryConfig& output_mem_config = operation::DEFAULT_OUTPUT_MEMORY_CONFIG);
-
 std::vector<Tensor> prod_bw(
     const Tensor& grad,
     const Tensor& input,

--- a/tt_eager/tt_dnn/op_library/backward/backward_ops.hpp
+++ b/tt_eager/tt_dnn/op_library/backward/backward_ops.hpp
@@ -133,7 +133,7 @@ std::vector<Tensor> polygamma_bw(
     const Tensor& input,
     int n,
     const MemoryConfig& output_mem_config = operation::DEFAULT_OUTPUT_MEMORY_CONFIG);
-    
+
 std::vector<Tensor> hardtanh_bw(
     const Tensor& grad,
     const Tensor& input,
@@ -145,11 +145,6 @@ std::vector<Tensor> angle_bw(
     const Tensor& grad,
     const Tensor& input,
     bool is_complextensor = true,
-    const MemoryConfig& output_mem_config = operation::DEFAULT_OUTPUT_MEMORY_CONFIG);
-
-std::vector<Tensor> erf_bw(
-    const Tensor& grad,
-    const Tensor& input,
     const MemoryConfig& output_mem_config = operation::DEFAULT_OUTPUT_MEMORY_CONFIG);
 
 std::vector<Tensor> deg2rad_bw(

--- a/tt_eager/tt_dnn/op_library/backward/backward_ops.hpp
+++ b/tt_eager/tt_dnn/op_library/backward/backward_ops.hpp
@@ -108,11 +108,6 @@ std::vector<Tensor> complex_abs_bw(
     const Tensor& input,
     const MemoryConfig& output_mem_config = operation::DEFAULT_OUTPUT_MEMORY_CONFIG);
 
-std::vector<Tensor> exp2_bw(
-    const Tensor& grad,
-    const Tensor& input,
-    const MemoryConfig& output_mem_config = operation::DEFAULT_OUTPUT_MEMORY_CONFIG);
-
 std::vector<Tensor> expm1_bw(
     const Tensor& grad,
     const Tensor& input,

--- a/tt_eager/tt_dnn/op_library/backward/backward_ops.hpp
+++ b/tt_eager/tt_dnn/op_library/backward/backward_ops.hpp
@@ -133,12 +133,7 @@ std::vector<Tensor> polygamma_bw(
     const Tensor& input,
     int n,
     const MemoryConfig& output_mem_config = operation::DEFAULT_OUTPUT_MEMORY_CONFIG);
-
-std::vector<Tensor> erfinv_bw(
-    const Tensor& grad,
-    const Tensor& input,
-    const MemoryConfig& output_mem_config = operation::DEFAULT_OUTPUT_MEMORY_CONFIG);
-
+    
 std::vector<Tensor> hardtanh_bw(
     const Tensor& grad,
     const Tensor& input,

--- a/tt_eager/tt_dnn/op_library/backward/backward_ops.hpp
+++ b/tt_eager/tt_dnn/op_library/backward/backward_ops.hpp
@@ -108,11 +108,6 @@ std::vector<Tensor> complex_abs_bw(
     const Tensor& input,
     const MemoryConfig& output_mem_config = operation::DEFAULT_OUTPUT_MEMORY_CONFIG);
 
-std::vector<Tensor> expm1_bw(
-    const Tensor& grad,
-    const Tensor& input,
-    const MemoryConfig& output_mem_config = operation::DEFAULT_OUTPUT_MEMORY_CONFIG);
-
 std::vector<Tensor> gelu_bw(
     const Tensor& grad,
     const Tensor& input,

--- a/tt_eager/tt_dnn/op_library/backward/backward_ops.hpp
+++ b/tt_eager/tt_dnn/op_library/backward/backward_ops.hpp
@@ -167,11 +167,6 @@ std::vector<Tensor> deg2rad_bw(
     const Tensor& input,
     const MemoryConfig& output_mem_config = operation::DEFAULT_OUTPUT_MEMORY_CONFIG);
 
-std::vector<Tensor> reciprocal_bw(
-    const Tensor& grad,
-    const Tensor& input,
-    const MemoryConfig& output_mem_config = operation::DEFAULT_OUTPUT_MEMORY_CONFIG);
-
 std::vector<Tensor> prod_bw(
     const Tensor& grad,
     const Tensor& input,

--- a/tt_eager/tt_dnn/op_library/backward/backward_ops.hpp
+++ b/tt_eager/tt_dnn/op_library/backward/backward_ops.hpp
@@ -157,11 +157,6 @@ std::vector<Tensor> erf_bw(
     const Tensor& input,
     const MemoryConfig& output_mem_config = operation::DEFAULT_OUTPUT_MEMORY_CONFIG);
 
-std::vector<Tensor> digamma_bw(
-    const Tensor& grad,
-    const Tensor& input,
-    const MemoryConfig& output_mem_config = operation::DEFAULT_OUTPUT_MEMORY_CONFIG);
-
 std::vector<Tensor> deg2rad_bw(
     const Tensor& grad,
     const Tensor& input,

--- a/tt_eager/tt_lib/csrc/tt_lib_bindings_tensor_backward_ops.cpp
+++ b/tt_eager/tt_lib/csrc/tt_lib_bindings_tensor_backward_ops.cpp
@@ -353,22 +353,6 @@ namespace tt::tt_metal::detail{
                     "output_mem_config", "Layout of tensor in TT Accelerator device memory banks", "MemoryConfig", "Default is interleaved in DRAM", "No"
             )doc");
 
-     m_tensor.def("erfinv_bw", &tt::tt_metal::erfinv_bw,
-            py::arg("grad").noconvert(), py::arg("input").noconvert(), py::arg("output_mem_config").noconvert() = operation::DEFAULT_OUTPUT_MEMORY_CONFIG, R"doc(
-            Performs backward operations for erfinv of ``input`` tensor with given ``grad``.
-
-            Input tensors must have BFLOAT16 data type.
-
-            Output tensors will have BFLOAT16 data type.
-
-            .. csv-table::
-                :header: "Argument", "Description", "Data type", "Valid range", "Required"
-
-                "grad", "Gradient tensor", "Tensor", "Tensor of shape [W, Z, Y, X]", "Yes"
-                "input", "Input Tensor", "Tensor", "Tensor of shape [W, Z, Y, X]", "Yes"
-                "output_mem_config", "Layout of tensor in TT Accelerator device memory banks", "MemoryConfig", "Default is interleaved in DRAM", "No"
-        )doc");
-
      m_tensor.def("erf_bw", &tt::tt_metal::erf_bw,
             py::arg("grad").noconvert(), py::arg("input").noconvert(), py::arg("output_mem_config").noconvert() = operation::DEFAULT_OUTPUT_MEMORY_CONFIG, R"doc(
             Performs backward operations for erf of ``input`` tensor with given ``grad``.

--- a/tt_eager/tt_lib/csrc/tt_lib_bindings_tensor_backward_ops.cpp
+++ b/tt_eager/tt_lib/csrc/tt_lib_bindings_tensor_backward_ops.cpp
@@ -75,23 +75,6 @@ namespace tt::tt_metal::detail{
                 "queue_id", "queue_id", "uint8_t", "Default is 0", "No"
         )doc");
 
-    m_tensor.def("expm1_bw", &tt::tt_metal::expm1_bw,
-            py::arg("grad").noconvert(), py::arg("input").noconvert(), py::arg("output_mem_config").noconvert() = operation::DEFAULT_OUTPUT_MEMORY_CONFIG, R"doc(
-                Performs backward operations for expm1 with given ``grad``
-
-                Input tensors must have BFLOAT16 data type.
-
-                Output tensor will have BFLOAT16 data type.
-
-                .. csv-table::
-                    :header: "Argument", "Description", "Data type", "Valid range", "Required"
-
-
-                    "grad", "Gradient tensor", "Tensor", "Tensor of shape [W, Z, Y, X]", "Yes"
-                    "input", "Tensor", "Tensor", "Tensor of shape [W, Z, Y, X]", "Yes"
-                    "output_mem_config", "Layout of tensor in TT Accelerator device memory banks", "MemoryConfig", "Default is interleaved in DRAM", "No"
-            )doc");
-
     m_tensor.def("tanh_bw",
             [](const Tensor& grad,
                 const Tensor& input,

--- a/tt_eager/tt_lib/csrc/tt_lib_bindings_tensor_backward_ops.cpp
+++ b/tt_eager/tt_lib/csrc/tt_lib_bindings_tensor_backward_ops.cpp
@@ -385,22 +385,6 @@ namespace tt::tt_metal::detail{
                 "output_mem_config", "Layout of tensor in TT Accelerator device memory banks", "MemoryConfig", "Default is interleaved in DRAM", "No"
         )doc");
 
-    m_tensor.def("digamma_bw", &tt::tt_metal::digamma_bw,
-            py::arg("grad").noconvert(), py::arg("input").noconvert(), py::arg("output_mem_config").noconvert() = operation::DEFAULT_OUTPUT_MEMORY_CONFIG, R"doc(
-            Performs backward operations for digamma for the ``input`` with given ``grad``
-
-            Input tensors must have BFLOAT16 data type.
-
-            Output tensor will have BFLOAT16 data type.
-
-            .. csv-table::
-                :header: "Argument", "Description", "Data type", "Valid range", "Required"
-
-                "grad", "Gradient tensor", "Tensor", "Tensor of shape [W, Z, Y, X]", "Yes"
-                "input", "Tensor", "Tensor", "Tensor of shape [W, Z, Y, X]", "Yes"
-                "output_mem_config", "Layout of tensor in TT Accelerator device memory banks", "MemoryConfig", "Default is interleaved in DRAM", "No"
-        )doc");
-
     m_tensor.def("deg2rad_bw", &tt::tt_metal::deg2rad_bw,
             py::arg("grad").noconvert(), py::arg("input").noconvert(), py::arg("output_mem_config").noconvert() = operation::DEFAULT_OUTPUT_MEMORY_CONFIG, R"doc(
                 Performs backward operations for deg2rad for the ``input`` with given ``grad``

--- a/tt_eager/tt_lib/csrc/tt_lib_bindings_tensor_backward_ops.cpp
+++ b/tt_eager/tt_lib/csrc/tt_lib_bindings_tensor_backward_ops.cpp
@@ -75,24 +75,6 @@ namespace tt::tt_metal::detail{
                 "queue_id", "queue_id", "uint8_t", "Default is 0", "No"
         )doc");
 
-
-    m_tensor.def("exp2_bw", &tt::tt_metal::exp2_bw,
-            py::arg("grad").noconvert(), py::arg("input").noconvert(), py::arg("output_mem_config").noconvert() = operation::DEFAULT_OUTPUT_MEMORY_CONFIG, R"doc(
-                Performs backward operations for exp2 with given ``grad``
-
-                Input tensors must have BFLOAT16 data type.
-
-                Output tensor will have BFLOAT16 data type.
-
-                .. csv-table::
-                    :header: "Argument", "Description", "Data type", "Valid range", "Required"
-
-
-                    "grad", "Gradient tensor", "Tensor", "Tensor of shape [W, Z, Y, X]", "Yes"
-                    "input", "Tensor", "Tensor", "Tensor of shape [W, Z, Y, X]", "Yes"
-                    "output_mem_config", "Layout of tensor in TT Accelerator device memory banks", "MemoryConfig", "Default is interleaved in DRAM", "No"
-            )doc");
-
     m_tensor.def("expm1_bw", &tt::tt_metal::expm1_bw,
             py::arg("grad").noconvert(), py::arg("input").noconvert(), py::arg("output_mem_config").noconvert() = operation::DEFAULT_OUTPUT_MEMORY_CONFIG, R"doc(
                 Performs backward operations for expm1 with given ``grad``

--- a/tt_eager/tt_lib/csrc/tt_lib_bindings_tensor_backward_ops.cpp
+++ b/tt_eager/tt_lib/csrc/tt_lib_bindings_tensor_backward_ops.cpp
@@ -353,22 +353,6 @@ namespace tt::tt_metal::detail{
                     "output_mem_config", "Layout of tensor in TT Accelerator device memory banks", "MemoryConfig", "Default is interleaved in DRAM", "No"
             )doc");
 
-     m_tensor.def("erf_bw", &tt::tt_metal::erf_bw,
-            py::arg("grad").noconvert(), py::arg("input").noconvert(), py::arg("output_mem_config").noconvert() = operation::DEFAULT_OUTPUT_MEMORY_CONFIG, R"doc(
-            Performs backward operations for erf of ``input`` tensor with given ``grad``.
-
-            Input tensors must have BFLOAT16 data type.
-
-            Output tensors will have BFLOAT16 data type.
-
-            .. csv-table::
-                :header: "Argument", "Description", "Data type", "Valid range", "Required"
-
-                "grad", "Gradient tensor", "Tensor", "Tensor of shape [W, Z, Y, X]", "Yes"
-                "input", "Tensor", "Tensor", "Tensor of shape [W, Z, Y, X]", "Yes"
-                "output_mem_config", "Layout of tensor in TT Accelerator device memory banks", "MemoryConfig", "Default is interleaved in DRAM", "No"
-        )doc");
-
     m_tensor.def("deg2rad_bw", &tt::tt_metal::deg2rad_bw,
             py::arg("grad").noconvert(), py::arg("input").noconvert(), py::arg("output_mem_config").noconvert() = operation::DEFAULT_OUTPUT_MEMORY_CONFIG, R"doc(
                 Performs backward operations for deg2rad for the ``input`` with given ``grad``

--- a/tt_eager/tt_lib/csrc/tt_lib_bindings_tensor_backward_ops.cpp
+++ b/tt_eager/tt_lib/csrc/tt_lib_bindings_tensor_backward_ops.cpp
@@ -417,22 +417,6 @@ namespace tt::tt_metal::detail{
                     "output_mem_config", "Layout of tensor in TT Accelerator device memory banks", "MemoryConfig", "Default is interleaved in DRAM", "No"
             )doc");
 
-    m_tensor.def("reciprocal_bw", &tt::tt_metal::reciprocal_bw,
-            py::arg("grad").noconvert(), py::arg("input").noconvert(), py::arg("output_mem_config").noconvert() = operation::DEFAULT_OUTPUT_MEMORY_CONFIG, R"doc(
-            Performs backward operations for reciprocal for the ``input`` with given ``grad``
-
-            Input tensors must have BFLOAT16 data type.
-
-            Output tensor will have BFLOAT16 data type.
-
-            .. csv-table::
-                :header: "Argument", "Description", "Data type", "Valid range", "Required"
-
-                "grad", "Gradient tensor", "Tensor", "Tensor of shape [W, Z, Y, X]", "Yes"
-                "input", "Tensor", "Tensor", "Tensor of shape [W, Z, Y, X]", "Yes"
-                "output_mem_config", "Layout of tensor in TT Accelerator device memory banks", "MemoryConfig", "Default is interleaved in DRAM", "No"
-            )doc");
-
     m_tensor.def("prod_bw", &tt::tt_metal::prod_bw,
             py::arg("grad").noconvert(), py::arg("input").noconvert(), py::arg("all_dimensions") , py::arg("dim") , py::arg("output_mem_config").noconvert() = operation::DEFAULT_OUTPUT_MEMORY_CONFIG, R"doc(
             Performs backward operations for prod on ``input_a`` along ``all_dimensions`` or a particular ``dim``.

--- a/tt_eager/tt_lib/csrc/tt_lib_bindings_tensor_backward_ops.cpp
+++ b/tt_eager/tt_lib/csrc/tt_lib_bindings_tensor_backward_ops.cpp
@@ -353,22 +353,6 @@ namespace tt::tt_metal::detail{
                     "output_mem_config", "Layout of tensor in TT Accelerator device memory banks", "MemoryConfig", "Default is interleaved in DRAM", "No"
             )doc");
 
-    m_tensor.def("deg2rad_bw", &tt::tt_metal::deg2rad_bw,
-            py::arg("grad").noconvert(), py::arg("input").noconvert(), py::arg("output_mem_config").noconvert() = operation::DEFAULT_OUTPUT_MEMORY_CONFIG, R"doc(
-                Performs backward operations for deg2rad for the ``input`` with given ``grad``
-
-                Input tensors must have BFLOAT16 data type.
-
-                Output tensor will have BFLOAT16 data type.
-
-                .. csv-table::
-                    :header: "Argument", "Description", "Data type", "Valid range", "Required"
-
-                    "grad", "Gradient tensor", "Tensor", "Tensor of shape [W, Z, Y, X]", "Yes"
-                    "input", "Input Tensor", "Tensor", "Tensor of shape [W, Z, Y, X]", "Yes"
-                    "output_mem_config", "Layout of tensor in TT Accelerator device memory banks", "MemoryConfig", "Default is interleaved in DRAM", "No"
-            )doc");
-
     m_tensor.def("prod_bw", &tt::tt_metal::prod_bw,
             py::arg("grad").noconvert(), py::arg("input").noconvert(), py::arg("all_dimensions") , py::arg("dim") , py::arg("output_mem_config").noconvert() = operation::DEFAULT_OUTPUT_MEMORY_CONFIG, R"doc(
             Performs backward operations for prod on ``input_a`` along ``all_dimensions`` or a particular ``dim``.

--- a/ttnn/cpp/ttnn/operations/eltwise/unary_backward/device/unary_backward_op.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary_backward/device/unary_backward_op.cpp
@@ -1080,6 +1080,20 @@ std::vector<Tensor> _erfinv_bw(const Tensor& grad, const Tensor& input, const Me
     return grad_tensor;
 }
 
+std::vector<Tensor> _erf_bw(const Tensor& grad, const Tensor& input, const MemoryConfig& output_mem_config) {
+    std::vector<Tensor> grad_tensor;
+    Tensor result = ttnn::multiply(
+        ttnn::multiply(ttnn::exp(ttnn::neg(ttnn::square(input, output_mem_config), output_mem_config), false, output_mem_config),
+            grad,
+            std::nullopt,
+            output_mem_config),
+        M_2_SQRTPI,
+        std::nullopt,
+        output_mem_config);
+    grad_tensor.emplace_back(result);
+    return grad_tensor;
+}
+
 std::function<std::vector<ttnn::Tensor>(const Tensor&, const Tensor&, const MemoryConfig&)> UnaryBackwardFunction::get_function_type1(UnaryBackwardOpType OpType){
     switch (OpType) {
         case UnaryBackwardOpType::ASSIGN_BW:
@@ -1180,6 +1194,8 @@ std::function<std::vector<ttnn::Tensor>(const Tensor&, const Tensor&, const Memo
             return _digamma_bw;
         case UnaryBackwardOpType::ERFINV_BW:
             return _erfinv_bw;
+        case UnaryBackwardOpType::ERF_BW:
+            return _erf_bw;
         default:
             TT_ASSERT(false && "Undefined op type");
             return 0;

--- a/ttnn/cpp/ttnn/operations/eltwise/unary_backward/device/unary_backward_op.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary_backward/device/unary_backward_op.cpp
@@ -1094,6 +1094,14 @@ std::vector<Tensor> _erf_bw(const Tensor& grad, const Tensor& input, const Memor
     return grad_tensor;
 }
 
+std::vector<Tensor> _deg2rad_bw(const Tensor& grad, const Tensor& input, const MemoryConfig& output_mem_config) {
+    std::vector<Tensor> grad_tensor;
+    float M_PI_180 = M_PI / 180;
+    Tensor grad_result = ttnn::multiply(grad, M_PI_180, std::nullopt, output_mem_config);
+    grad_tensor.emplace_back(grad_result);
+    return grad_tensor;
+}
+
 std::function<std::vector<ttnn::Tensor>(const Tensor&, const Tensor&, const MemoryConfig&)> UnaryBackwardFunction::get_function_type1(UnaryBackwardOpType OpType){
     switch (OpType) {
         case UnaryBackwardOpType::ASSIGN_BW:
@@ -1196,6 +1204,8 @@ std::function<std::vector<ttnn::Tensor>(const Tensor&, const Tensor&, const Memo
             return _erfinv_bw;
         case UnaryBackwardOpType::ERF_BW:
             return _erf_bw;
+        case UnaryBackwardOpType::DEG2RAD_BW:
+            return _deg2rad_bw;
         default:
             TT_ASSERT(false && "Undefined op type");
             return 0;

--- a/ttnn/cpp/ttnn/operations/eltwise/unary_backward/device/unary_backward_op.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary_backward/device/unary_backward_op.cpp
@@ -990,6 +990,16 @@ std::vector<Tensor> _exp2_bw(const Tensor& grad, const Tensor& input, const Memo
     return grad_tensor;
 }
 
+// bw(expm1) = grad * expm1(input) + 1
+std::vector<Tensor> _expm1_bw(const Tensor& grad, const Tensor& input, const MemoryConfig& output_mem_config) {
+    std::vector<Tensor> grad_tensor;
+    Tensor eresult = ttnn::expm1(input, output_mem_config);
+    Tensor rp1 = ttnn::add(eresult, 1.0f, std::nullopt, output_mem_config);
+    Tensor result = ttnn::multiply(grad, rp1, std::nullopt, output_mem_config);
+    grad_tensor.emplace_back(result);
+    return grad_tensor;
+}
+
 std::function<std::vector<ttnn::Tensor>(const Tensor&, const Tensor&, const MemoryConfig&)> UnaryBackwardFunction::get_function_type1(UnaryBackwardOpType OpType){
     switch (OpType) {
         case UnaryBackwardOpType::ASSIGN_BW:
@@ -1048,7 +1058,6 @@ std::function<std::vector<ttnn::Tensor>(const Tensor&, const Tensor&, const Memo
             return _silu_bw;
         case UnaryBackwardOpType::SELU_BW:
             return _selu_bw;
-<<<<<<< HEAD
         case UnaryBackwardOpType::SQUARE_BW:
             return _square_bw;
         case UnaryBackwardOpType::HARDSWISH_BW:
@@ -1081,10 +1090,10 @@ std::function<std::vector<ttnn::Tensor>(const Tensor&, const Tensor&, const Memo
             return _log2_bw;
         case UnaryBackwardOpType::SIGN_BW:
             return _sign_bw;
-=======
         case UnaryBackwardOpType::EXP2_BW:
             return _exp2_bw;
->>>>>>> 792040fd61... #10074: Move exp2_bw to TTNN
+        case UnaryBackwardOpType::EXPM1_BW:
+            return _expm1_bw;
         default:
             TT_ASSERT(false && "Undefined op type");
             return 0;

--- a/ttnn/cpp/ttnn/operations/eltwise/unary_backward/device/unary_backward_op.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary_backward/device/unary_backward_op.cpp
@@ -979,6 +979,17 @@ std::vector<Tensor> _div_no_nan_bw(
     return grad_tensor;
 }
 
+// #  bw (exp2) = grad * exp2(input) * M_LN2
+// # M_LN2 = 0.693147180559945309417
+std::vector<Tensor> _exp2_bw(const Tensor& grad, const Tensor& input, const MemoryConfig& output_mem_config) {
+    std::vector<Tensor> grad_tensor;
+    Tensor exp_result = ttnn::exp2(input, output_mem_config);
+    exp_result = ttnn::multiply(exp_result, M_LN2, std::nullopt, output_mem_config);
+    Tensor result = ttnn::multiply(grad, exp_result, std::nullopt, output_mem_config);
+    grad_tensor.emplace_back(result);
+    return grad_tensor;
+}
+
 std::function<std::vector<ttnn::Tensor>(const Tensor&, const Tensor&, const MemoryConfig&)> UnaryBackwardFunction::get_function_type1(UnaryBackwardOpType OpType){
     switch (OpType) {
         case UnaryBackwardOpType::ASSIGN_BW:
@@ -1037,6 +1048,7 @@ std::function<std::vector<ttnn::Tensor>(const Tensor&, const Tensor&, const Memo
             return _silu_bw;
         case UnaryBackwardOpType::SELU_BW:
             return _selu_bw;
+<<<<<<< HEAD
         case UnaryBackwardOpType::SQUARE_BW:
             return _square_bw;
         case UnaryBackwardOpType::HARDSWISH_BW:
@@ -1069,6 +1081,10 @@ std::function<std::vector<ttnn::Tensor>(const Tensor&, const Tensor&, const Memo
             return _log2_bw;
         case UnaryBackwardOpType::SIGN_BW:
             return _sign_bw;
+=======
+        case UnaryBackwardOpType::EXP2_BW:
+            return _exp2_bw;
+>>>>>>> 792040fd61... #10074: Move exp2_bw to TTNN
         default:
             TT_ASSERT(false && "Undefined op type");
             return 0;

--- a/ttnn/cpp/ttnn/operations/eltwise/unary_backward/device/unary_backward_op.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary_backward/device/unary_backward_op.hpp
@@ -82,6 +82,7 @@ enum class UnaryBackwardOpType {
     EXP2_BW,
     EXPM1_BW,
     RECIPROCAL_BW,
+    DIGAMMA_BW,
 };
 
 struct UnaryBackwardFunction{

--- a/ttnn/cpp/ttnn/operations/eltwise/unary_backward/device/unary_backward_op.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary_backward/device/unary_backward_op.hpp
@@ -80,6 +80,7 @@ enum class UnaryBackwardOpType {
     REMAINDER_BW,
     DIV_NO_NAN_BW,
     EXP2_BW,
+    EXPM1_BW,
 };
 
 struct UnaryBackwardFunction{

--- a/ttnn/cpp/ttnn/operations/eltwise/unary_backward/device/unary_backward_op.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary_backward/device/unary_backward_op.hpp
@@ -85,6 +85,7 @@ enum class UnaryBackwardOpType {
     DIGAMMA_BW,
     ERFINV_BW,
     ERF_BW,
+    DEG2RAD_BW,
 };
 
 struct UnaryBackwardFunction{

--- a/ttnn/cpp/ttnn/operations/eltwise/unary_backward/device/unary_backward_op.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary_backward/device/unary_backward_op.hpp
@@ -81,6 +81,7 @@ enum class UnaryBackwardOpType {
     DIV_NO_NAN_BW,
     EXP2_BW,
     EXPM1_BW,
+    RECIPROCAL_BW,
 };
 
 struct UnaryBackwardFunction{

--- a/ttnn/cpp/ttnn/operations/eltwise/unary_backward/device/unary_backward_op.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary_backward/device/unary_backward_op.hpp
@@ -83,6 +83,7 @@ enum class UnaryBackwardOpType {
     EXPM1_BW,
     RECIPROCAL_BW,
     DIGAMMA_BW,
+    ERFINV_BW,
 };
 
 struct UnaryBackwardFunction{

--- a/ttnn/cpp/ttnn/operations/eltwise/unary_backward/device/unary_backward_op.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary_backward/device/unary_backward_op.hpp
@@ -79,6 +79,7 @@ enum class UnaryBackwardOpType {
     FMOD_BW,
     REMAINDER_BW,
     DIV_NO_NAN_BW,
+    EXP2_BW,
 };
 
 struct UnaryBackwardFunction{

--- a/ttnn/cpp/ttnn/operations/eltwise/unary_backward/device/unary_backward_op.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary_backward/device/unary_backward_op.hpp
@@ -84,6 +84,7 @@ enum class UnaryBackwardOpType {
     RECIPROCAL_BW,
     DIGAMMA_BW,
     ERFINV_BW,
+    ERF_BW,
 };
 
 struct UnaryBackwardFunction{

--- a/ttnn/cpp/ttnn/operations/eltwise/unary_backward/unary_backward.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary_backward/unary_backward.hpp
@@ -132,5 +132,6 @@ constexpr auto fmod_bw = ttnn::register_operation<operations::unary_backward::Ex
 constexpr auto remainder_bw = ttnn::register_operation<operations::unary_backward::ExecuteUnaryBackward<operations::unary_backward::UnaryBackwardOpType::REMAINDER_BW>>("ttnn::remainder_bw");
 constexpr auto div_no_nan_bw = ttnn::register_operation<operations::unary_backward::ExecuteUnaryBackward<operations::unary_backward::UnaryBackwardOpType::DIV_NO_NAN_BW>>("ttnn::div_no_nan_bw");
 constexpr auto exp2_bw = ttnn::register_operation<operations::unary_backward::ExecuteUnaryBackward<operations::unary_backward::UnaryBackwardOpType::EXP2_BW>>("ttnn::exp2_bw");
+constexpr auto expm1_bw = ttnn::register_operation<operations::unary_backward::ExecuteUnaryBackward<operations::unary_backward::UnaryBackwardOpType::EXPM1_BW>>("ttnn::expm1_bw");
 
 }  // namespace ttnn

--- a/ttnn/cpp/ttnn/operations/eltwise/unary_backward/unary_backward.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary_backward/unary_backward.hpp
@@ -137,5 +137,6 @@ constexpr auto reciprocal_bw = ttnn::register_operation<operations::unary_backwa
 constexpr auto digamma_bw = ttnn::register_operation<operations::unary_backward::ExecuteUnaryBackward<operations::unary_backward::UnaryBackwardOpType::DIGAMMA_BW>>("ttnn::digamma_bw");
 constexpr auto erfinv_bw = ttnn::register_operation<operations::unary_backward::ExecuteUnaryBackward<operations::unary_backward::UnaryBackwardOpType::ERFINV_BW>>("ttnn::erfinv_bw");
 constexpr auto erf_bw = ttnn::register_operation<operations::unary_backward::ExecuteUnaryBackward<operations::unary_backward::UnaryBackwardOpType::ERF_BW>>("ttnn::erf_bw");
+constexpr auto deg2rad_bw = ttnn::register_operation<operations::unary_backward::ExecuteUnaryBackward<operations::unary_backward::UnaryBackwardOpType::DEG2RAD_BW>>("ttnn::deg2rad_bw");
 
 }  // namespace ttnn

--- a/ttnn/cpp/ttnn/operations/eltwise/unary_backward/unary_backward.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary_backward/unary_backward.hpp
@@ -136,5 +136,6 @@ constexpr auto expm1_bw = ttnn::register_operation<operations::unary_backward::E
 constexpr auto reciprocal_bw = ttnn::register_operation<operations::unary_backward::ExecuteUnaryBackward<operations::unary_backward::UnaryBackwardOpType::RECIPROCAL_BW>>("ttnn::reciprocal_bw");
 constexpr auto digamma_bw = ttnn::register_operation<operations::unary_backward::ExecuteUnaryBackward<operations::unary_backward::UnaryBackwardOpType::DIGAMMA_BW>>("ttnn::digamma_bw");
 constexpr auto erfinv_bw = ttnn::register_operation<operations::unary_backward::ExecuteUnaryBackward<operations::unary_backward::UnaryBackwardOpType::ERFINV_BW>>("ttnn::erfinv_bw");
+constexpr auto erf_bw = ttnn::register_operation<operations::unary_backward::ExecuteUnaryBackward<operations::unary_backward::UnaryBackwardOpType::ERF_BW>>("ttnn::erf_bw");
 
 }  // namespace ttnn

--- a/ttnn/cpp/ttnn/operations/eltwise/unary_backward/unary_backward.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary_backward/unary_backward.hpp
@@ -133,5 +133,6 @@ constexpr auto remainder_bw = ttnn::register_operation<operations::unary_backwar
 constexpr auto div_no_nan_bw = ttnn::register_operation<operations::unary_backward::ExecuteUnaryBackward<operations::unary_backward::UnaryBackwardOpType::DIV_NO_NAN_BW>>("ttnn::div_no_nan_bw");
 constexpr auto exp2_bw = ttnn::register_operation<operations::unary_backward::ExecuteUnaryBackward<operations::unary_backward::UnaryBackwardOpType::EXP2_BW>>("ttnn::exp2_bw");
 constexpr auto expm1_bw = ttnn::register_operation<operations::unary_backward::ExecuteUnaryBackward<operations::unary_backward::UnaryBackwardOpType::EXPM1_BW>>("ttnn::expm1_bw");
+constexpr auto reciprocal_bw = ttnn::register_operation<operations::unary_backward::ExecuteUnaryBackward<operations::unary_backward::UnaryBackwardOpType::RECIPROCAL_BW>>("ttnn::reciprocal_bw");
 
 }  // namespace ttnn

--- a/ttnn/cpp/ttnn/operations/eltwise/unary_backward/unary_backward.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary_backward/unary_backward.hpp
@@ -131,6 +131,6 @@ constexpr auto sign_bw = ttnn::register_operation<operations::unary_backward::Ex
 constexpr auto fmod_bw = ttnn::register_operation<operations::unary_backward::ExecuteUnaryBackward<operations::unary_backward::UnaryBackwardOpType::FMOD_BW>>("ttnn::fmod_bw");
 constexpr auto remainder_bw = ttnn::register_operation<operations::unary_backward::ExecuteUnaryBackward<operations::unary_backward::UnaryBackwardOpType::REMAINDER_BW>>("ttnn::remainder_bw");
 constexpr auto div_no_nan_bw = ttnn::register_operation<operations::unary_backward::ExecuteUnaryBackward<operations::unary_backward::UnaryBackwardOpType::DIV_NO_NAN_BW>>("ttnn::div_no_nan_bw");
-
+constexpr auto exp2_bw = ttnn::register_operation<operations::unary_backward::ExecuteUnaryBackward<operations::unary_backward::UnaryBackwardOpType::EXP2_BW>>("ttnn::exp2_bw");
 
 }  // namespace ttnn

--- a/ttnn/cpp/ttnn/operations/eltwise/unary_backward/unary_backward.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary_backward/unary_backward.hpp
@@ -134,5 +134,6 @@ constexpr auto div_no_nan_bw = ttnn::register_operation<operations::unary_backwa
 constexpr auto exp2_bw = ttnn::register_operation<operations::unary_backward::ExecuteUnaryBackward<operations::unary_backward::UnaryBackwardOpType::EXP2_BW>>("ttnn::exp2_bw");
 constexpr auto expm1_bw = ttnn::register_operation<operations::unary_backward::ExecuteUnaryBackward<operations::unary_backward::UnaryBackwardOpType::EXPM1_BW>>("ttnn::expm1_bw");
 constexpr auto reciprocal_bw = ttnn::register_operation<operations::unary_backward::ExecuteUnaryBackward<operations::unary_backward::UnaryBackwardOpType::RECIPROCAL_BW>>("ttnn::reciprocal_bw");
+constexpr auto digamma_bw = ttnn::register_operation<operations::unary_backward::ExecuteUnaryBackward<operations::unary_backward::UnaryBackwardOpType::DIGAMMA_BW>>("ttnn::digamma_bw");
 
 }  // namespace ttnn

--- a/ttnn/cpp/ttnn/operations/eltwise/unary_backward/unary_backward.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary_backward/unary_backward.hpp
@@ -135,5 +135,6 @@ constexpr auto exp2_bw = ttnn::register_operation<operations::unary_backward::Ex
 constexpr auto expm1_bw = ttnn::register_operation<operations::unary_backward::ExecuteUnaryBackward<operations::unary_backward::UnaryBackwardOpType::EXPM1_BW>>("ttnn::expm1_bw");
 constexpr auto reciprocal_bw = ttnn::register_operation<operations::unary_backward::ExecuteUnaryBackward<operations::unary_backward::UnaryBackwardOpType::RECIPROCAL_BW>>("ttnn::reciprocal_bw");
 constexpr auto digamma_bw = ttnn::register_operation<operations::unary_backward::ExecuteUnaryBackward<operations::unary_backward::UnaryBackwardOpType::DIGAMMA_BW>>("ttnn::digamma_bw");
+constexpr auto erfinv_bw = ttnn::register_operation<operations::unary_backward::ExecuteUnaryBackward<operations::unary_backward::UnaryBackwardOpType::ERFINV_BW>>("ttnn::erfinv_bw");
 
 }  // namespace ttnn

--- a/ttnn/cpp/ttnn/operations/eltwise/unary_backward/unary_backward_pybind.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary_backward/unary_backward_pybind.hpp
@@ -538,12 +538,17 @@ void py_module(py::module& module) {
     detail::bind_unary_backward(
         module,
         ttnn::erfinv_bw,
-        R"doc(Performs backward operations for digamma on :attr:`input_tensor` with given :attr:`grad_tensor`)doc");
+        R"doc(Performs backward operations for erfinv on :attr:`input_tensor` with given :attr:`grad_tensor`)doc");
 
     detail::bind_unary_backward(
         module,
         ttnn::erf_bw,
-        R"doc(Performs backward operations for digamma on :attr:`input_tensor` with given :attr:`grad_tensor`)doc");
+        R"doc(Performs backward operations for erf on :attr:`input_tensor` with given :attr:`grad_tensor`)doc");
+
+    detail::bind_unary_backward(
+        module,
+        ttnn::deg2rad_bw,
+        R"doc(Performs backward operations for deg2rad on :attr:`input_tensor` with given :attr:`grad_tensor`)doc");
 
 }
 

--- a/ttnn/cpp/ttnn/operations/eltwise/unary_backward/unary_backward_pybind.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary_backward/unary_backward_pybind.hpp
@@ -540,6 +540,11 @@ void py_module(py::module& module) {
         ttnn::erfinv_bw,
         R"doc(Performs backward operations for digamma on :attr:`input_tensor` with given :attr:`grad_tensor`)doc");
 
+    detail::bind_unary_backward(
+        module,
+        ttnn::erf_bw,
+        R"doc(Performs backward operations for digamma on :attr:`input_tensor` with given :attr:`grad_tensor`)doc");
+
 }
 
 }  // namespace binary_backward

--- a/ttnn/cpp/ttnn/operations/eltwise/unary_backward/unary_backward_pybind.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary_backward/unary_backward_pybind.hpp
@@ -530,6 +530,11 @@ void py_module(py::module& module) {
         ttnn::reciprocal_bw,
         R"doc(Performs backward operations for exp2 on :attr:`input_tensor` with given :attr:`grad_tensor`)doc");
 
+    detail::bind_unary_backward(
+        module,
+        ttnn::digamma_bw,
+        R"doc(Performs backward operations for digamma on :attr:`input_tensor` with given :attr:`grad_tensor`)doc");
+
 }
 
 }  // namespace binary_backward

--- a/ttnn/cpp/ttnn/operations/eltwise/unary_backward/unary_backward_pybind.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary_backward/unary_backward_pybind.hpp
@@ -535,6 +535,11 @@ void py_module(py::module& module) {
         ttnn::digamma_bw,
         R"doc(Performs backward operations for digamma on :attr:`input_tensor` with given :attr:`grad_tensor`)doc");
 
+    detail::bind_unary_backward(
+        module,
+        ttnn::erfinv_bw,
+        R"doc(Performs backward operations for digamma on :attr:`input_tensor` with given :attr:`grad_tensor`)doc");
+
 }
 
 }  // namespace binary_backward

--- a/ttnn/cpp/ttnn/operations/eltwise/unary_backward/unary_backward_pybind.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary_backward/unary_backward_pybind.hpp
@@ -520,6 +520,11 @@ void py_module(py::module& module) {
         ttnn::exp2_bw,
         R"doc(Performs backward operations for exp2 on :attr:`input_tensor` with given :attr:`grad_tensor`)doc");
 
+    detail::bind_unary_backward(
+        module,
+        ttnn::expm1_bw,
+        R"doc(Performs backward operations for exp2 on :attr:`input_tensor` with given :attr:`grad_tensor`)doc");
+
 }
 
 }  // namespace binary_backward

--- a/ttnn/cpp/ttnn/operations/eltwise/unary_backward/unary_backward_pybind.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary_backward/unary_backward_pybind.hpp
@@ -525,6 +525,11 @@ void py_module(py::module& module) {
         ttnn::expm1_bw,
         R"doc(Performs backward operations for exp2 on :attr:`input_tensor` with given :attr:`grad_tensor`)doc");
 
+    detail::bind_unary_backward(
+        module,
+        ttnn::reciprocal_bw,
+        R"doc(Performs backward operations for exp2 on :attr:`input_tensor` with given :attr:`grad_tensor`)doc");
+
 }
 
 }  // namespace binary_backward

--- a/ttnn/cpp/ttnn/operations/eltwise/unary_backward/unary_backward_pybind.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary_backward/unary_backward_pybind.hpp
@@ -514,6 +514,11 @@ void py_module(py::module& module) {
         module,
         ttnn::div_no_nan_bw,
         R"doc(Performs backward operations for div_no_nan on :attr:`input_tensor`, :attr:`scalar` with given :attr:`grad_tensor`.)doc");
+     
+    detail::bind_unary_backward(
+        module,
+        ttnn::exp2_bw,
+        R"doc(Performs backward operations for exp2 on :attr:`input_tensor` with given :attr:`grad_tensor`)doc");
 
 }
 


### PR DESCRIPTION
Issue : #10074 [ Unary Backward Tracking Issue : #9874 , Master issue : #9322 ]

Ops Migrated:

- exp2_bw
- expm1_bw
- reciprocal_bw
- digamma_bw
- erfinv_bw
- erf_bw
- deg2rad_bw

### Checklist
- [ ] Post commit CI passes
- [ ] Model regression CI testing passes (if applicable)
- [ ] New/Existing tests provide coverage for changes
