### PR TITLE
#5337: increase t3k frequent test timeout

### DIFF
--- a/tests/scripts/t3000/run_t3000_frequent_tests.sh
+++ b/tests/scripts/t3000/run_t3000_frequent_tests.sh
@@ -50,7 +50,7 @@ run_t3000_mixtral_tests() {
   echo "LOG_METAL: Running run_t3000_mixtral_tests"
 
   # mixtral8x7b 8 chip decode model test (env flags set inside the test)
-  pytest -n auto models/demos/t3000/mixtral8x7b/tests/test_mixtral_model.py ; fail+=$?
+  pytest -n auto models/demos/t3000/mixtral8x7b/tests/test_mixtral_model.py --timeout=600; fail+=$?
 
   # Record the end time
   end_time=$(date +%s)


### PR DESCRIPTION
### Problem description
t3k frequent test pipeline fails on mixtral tests 

### What's changed
increase frequent test mixtral timeout to 600

### Checklist
- [ ] Post commit CI passes
- [ ] Model regression CI testing passes (if applicable)
- [x] New/Existing tests provide coverage for changes
