### PR TITLE
Aliu/prevent aho tanking

### DIFF
--- a/tt_metal/core_descriptors/wormhole_b0_80_arch.yaml
+++ b/tt_metal/core_descriptors/wormhole_b0_80_arch.yaml
@@ -63,11 +63,20 @@ nebula_x1:
       start: [0, 0]
       end: [7, 7]
 
+    tg_compute_with_storage_grid_range: # Logical only start and end [x, y]
+      start: [0, 0]
+      end: [7, 3]
+
     storage_cores:
       []
 
     dispatch_cores:
       [[0, -1], [1, -1], [2, -1], [3, -1], [4, -1], [5, -1], [6, -1], [7, -1]]
+
+    tg_dispatch_cores:
+      [[0, -1], [1, -1], [2, -1], [3, -1], [4, -1], [5, -1], [6, -1], [7, -1],
+       [0, -2], [1, -2], [2, -2], [3, -2], [4, -2], [5, -2], [6, -2], [7, -2],
+       [0, -3], [1, -3], [2, -3], [3, -3], [4, -3], [5, -3], [6, -3], [7, -3]]
 
     dispatch_core_type:
       "tensix"

--- a/tt_metal/impl/device/device.cpp
+++ b/tt_metal/impl/device/device.cpp
@@ -1805,16 +1805,9 @@ void Device::update_dispatch_cores_for_multi_cq_eth_dispatch() {
     // When running Multiple CQs using Ethernet Dispatch, we may need more dispatch cores than those allocated in the
     // core descriptor (ex: 2 CQs on N300 need 10 dispatch cores and the core descriptor only allocates 6).
     // Infer the remaining dispatch cores from the idle eth core list (this is device dependent).
-    if (dispatch_core_manager::get(this->num_hw_cqs()).get_dispatch_core_type(this->id()) == CoreType::ETH) {
-        if (!tt::Cluster::instance().is_galaxy_cluster()) {
-            for (uint8_t num_hw_cqs = 1; num_hw_cqs <= Device::max_num_hw_cqs; ++num_hw_cqs) {
-                auto& dispatch_core_manager = dispatch_core_manager::get(num_hw_cqs);
-                for (const auto& idle_eth_core : this->get_inactive_ethernet_cores()) {
-                    dispatch_core_manager.add_dispatch_core_to_device(this->id(), idle_eth_core);
-                }
-            }
-        } else {
-            auto& dispatch_core_manager = dispatch_core_manager::get(this->num_hw_cqs());
+    for (uint8_t num_hw_cqs = 1; num_hw_cqs <= Device::max_num_hw_cqs; ++num_hw_cqs) {
+        if (dispatch_core_manager::get(num_hw_cqs).get_dispatch_core_type(this->id()) == CoreType::ETH) {
+            auto& dispatch_core_manager = dispatch_core_manager::get(num_hw_cqs);
             for (const auto& idle_eth_core : this->get_inactive_ethernet_cores()) {
                 dispatch_core_manager.add_dispatch_core_to_device(this->id(), idle_eth_core);
             }


### PR DESCRIPTION
### Ticket
[Link to Github Issue](https://github.com/tenstorrent/tt-metal/issues/10215)

### Problem description
Galaxy init was broken after multi cq changes. Original fix was to branch off the init for TG cluster.

### What's changed
Revert the fix, and add missing yaml entries for WH core descriptors.

### Checklist
- [x] Post commit CI passes
- [x] Model regression CI testing passes (if applicable)
- [x] New/Existing tests provide coverage for changes
