### PR TITLE
#10101: [Blackhole Bringup] Revert Zeroacc to legacy behaviour

### DIFF
--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_math_common_api.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_math_common_api.h
@@ -21,6 +21,10 @@
 /*************************************************************************
  * LLK MATH COMMON
  *************************************************************************/
+template <bool untilize_en = false>
+inline void llk_math_hw_configure_disaggregated() {
+   _llk_math_hw_configure<untilize_en>();
+}
 
 inline void llk_math_wait_for_dest_available() {
     DEBUG_STATUS("MWDW");

--- a/tt_metal/hw/ckernels/grayskull/metal/llk_api/llk_math_common_api.h
+++ b/tt_metal/hw/ckernels/grayskull/metal/llk_api/llk_math_common_api.h
@@ -18,6 +18,8 @@
 /*************************************************************************
  * LLK MATH COMMON
  *************************************************************************/
+template <bool untilize_en = false>
+inline void llk_math_hw_configure_disaggregated() { /*Unused for GS*/ }
 
 inline void llk_math_wait_for_dest_available() {
     DEBUG_STATUS("MWDW");

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_math_common_api.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_math_common_api.h
@@ -21,6 +21,8 @@
 /*************************************************************************
  * LLK MATH COMMON
  *************************************************************************/
+template <bool untilize_en = false>
+inline void llk_math_hw_configure_disaggregated() { /*Unused for WHB0*/ }
 
 inline void llk_math_wait_for_dest_available() {
     DEBUG_STATUS("MWDW");

--- a/tt_metal/include/compute_kernel_api/bcast.h
+++ b/tt_metal/include/compute_kernel_api/bcast.h
@@ -123,6 +123,7 @@ void init_bcast(uint32_t icb0, uint32_t icb1, uint32_t ocb = 16)
     PACK(( llk_pack_dest_init<false, DST_ACCUM_MODE>() ));
 
     MATH(( llk_math_pack_sync_init<DST_ACCUM_MODE>() ));
+    MATH(( llk_math_hw_configure_disaggregated() ));
 }
 
 

--- a/tt_metal/include/compute_kernel_api/eltwise_binary.h
+++ b/tt_metal/include/compute_kernel_api/eltwise_binary.h
@@ -34,6 +34,7 @@ ALWI void binary_op_init_common(uint32_t icb0, uint32_t icb1, uint32_t ocb=16)
     UNPACK(( llk_unpack_AB_init<BroadcastType::NONE>(icb0, icb1) ));
 
     MATH(( llk_math_pack_sync_init<DST_ACCUM_MODE>() ));
+    MATH(( llk_math_hw_configure_disaggregated() ));
 
     PACK(( llk_pack_hw_configure_disaggregated<false, DST_ACCUM_MODE>(ocb) ));
     PACK(( llk_pack_init(ocb) ));

--- a/tt_metal/include/compute_kernel_api/eltwise_unary/eltwise_unary.h
+++ b/tt_metal/include/compute_kernel_api/eltwise_unary/eltwise_unary.h
@@ -30,6 +30,7 @@ ALWI void unary_op_init_common(uint32_t icb, uint32_t ocb = 16)
 
     MATH(( llk_math_eltwise_unary_datacopy_init<A2D, BroadcastType::NONE, DST_ACCUM_MODE>(false /*transpose of faces*/, false /*transpose within 16x16 face*/, icb) ));
     MATH(( llk_math_pack_sync_init<DST_ACCUM_MODE>() ));
+    MATH(( llk_math_hw_configure_disaggregated() ));
 }
 
 ALWI void init_sfpu(uint32_t icb) {

--- a/tt_metal/include/compute_kernel_api/matmul.h
+++ b/tt_metal/include/compute_kernel_api/matmul.h
@@ -34,6 +34,7 @@ ALWI void mm_init(uint32_t in0_cb_id = 0, uint32_t in1_cb_id = 1, uint32_t out_c
 
     MATH(( llk_math_matmul_init<MATH_FIDELITY>(in0_cb_id, in1_cb_id, transpose) ));
     MATH(( llk_math_pack_sync_init<DST_ACCUM_MODE>()  ));
+    MATH(( llk_math_hw_configure_disaggregated() ));
 
     PACK(( llk_pack_hw_configure_disaggregated<false, DST_ACCUM_MODE>(out_cb_id) ));
     PACK(( llk_pack_init(out_cb_id)  ));

--- a/tt_metal/include/compute_kernel_api/pack_untilize.h
+++ b/tt_metal/include/compute_kernel_api/pack_untilize.h
@@ -23,6 +23,7 @@ ALWI void pack_untilize_init(uint32_t icb, uint32_t ocb)
 {
     MATH(( llk_math_eltwise_unary_datacopy_init<A2D, BroadcastType::NONE, DST_ACCUM_MODE>(false /*transpose of faces*/, false /*transpose within 16x16 face*/, icb) ));
     MATH(( llk_math_pack_sync_init<DST_ACCUM_MODE>() ));
+    MATH(( llk_math_hw_configure_disaggregated() ));
 
     PACK(( llk_pack_hw_configure_disaggregated<false, DST_ACCUM_MODE>(ocb) ));
     PACK(( llk_pack_untilize_init<block_ct_dim>(ocb) ));

--- a/tt_metal/include/compute_kernel_api/reduce.h
+++ b/tt_metal/include/compute_kernel_api/reduce.h
@@ -26,6 +26,7 @@ ALWI void reduce_init(uint32_t icb, uint32_t icb_scaler, uint32_t ocb = 16)
 
     MATH(( llk_math_reduce_init<reduce_type, reduce_dim, MATH_FIDELITY>() ));
     MATH(( llk_math_pack_sync_init<DST_ACCUM_MODE>() ));
+    MATH(( llk_math_hw_configure_disaggregated() ));
 
     PACK(( llk_pack_init() ));
     PACK(( llk_pack_reduce_config_v2<reduce_dim, at_start, false, DST_ACCUM_MODE>(ocb) ));

--- a/tt_metal/include/compute_kernel_api/tilize.h
+++ b/tt_metal/include/compute_kernel_api/tilize.h
@@ -26,6 +26,7 @@ ALWI void tilize_init(uint32_t icb, uint32_t block, uint32_t ocb = 16)
 {
     MATH(( llk_math_eltwise_unary_datacopy_init<A2D, BroadcastType::NONE, DST_ACCUM_MODE, false/*is_int_en*/, true/*tilize en*/>(false /*transpose of faces*/, false /*transpose within 16x16 face*/, icb) ));
     MATH(( llk_math_pack_sync_init<DST_ACCUM_MODE>() ));
+    MATH(( llk_math_hw_configure_disaggregated() ));
 
     PACK(( llk_pack_hw_configure_disaggregated<false, DST_ACCUM_MODE, ReluType::NO_RELU, 0, true/*tilize en*/>(ocb) ));
     PACK(( llk_pack_init<false, false, true/*tilize en*/>(ocb) ));

--- a/tt_metal/include/compute_kernel_api/transpose_wh.h
+++ b/tt_metal/include/compute_kernel_api/transpose_wh.h
@@ -28,6 +28,7 @@ ALWI void transpose_wh_init(uint32_t icb, uint32_t ocb = 16)
 {
     MATH(( llk_math_eltwise_unary_datacopy_init<A2D, BroadcastType::NONE, DST_ACCUM_MODE>(true, true, icb) ));
     MATH(( llk_math_pack_sync_init<DST_ACCUM_MODE>() ));
+    MATH(( llk_math_hw_configure_disaggregated() ));
 
     PACK(( llk_pack_hw_configure_disaggregated<false, DST_ACCUM_MODE>(ocb) ));
     PACK(( llk_pack_init(ocb) ));

--- a/tt_metal/include/compute_kernel_api/untilize.h
+++ b/tt_metal/include/compute_kernel_api/untilize.h
@@ -22,6 +22,7 @@ ALWI void untilize_init(uint32_t icb, uint32_t ocb = 16)
 {
     MATH(( llk_math_eltwise_unary_datacopy_init<A2D, BroadcastType::NONE, DST_ACCUM_MODE>(false /*transpose of faces*/, false /*transpose within 16x16 face*/, icb) ));
     MATH(( llk_math_pack_sync_init<DST_ACCUM_MODE>() ));
+    MATH(( llk_math_hw_configure_disaggregated() ));
 
     PACK(( llk_pack_hw_configure_disaggregated<false, DST_ACCUM_MODE>(ocb) ));
     PACK(( llk_pack_init(ocb) ));


### PR DESCRIPTION
### Ticket
#10101 

### Problem description
ELWMUL + broadcast was mismatching in this test suite:
```
TT_METAL_WATCHER=5 TT_METAL_DPRINT_CORES=0,0 TT_METAL_SLOW_DISPATCH_MODE=1 ./build/test/tt_metal/test_bcast
```

### What's changed
ELWMUL + broadcast uses ZEROACC instructions to clear faces from dest. Mismatches had a pattern of a single 16x16 face being incorrectly zeroed out. That is because ZEROACC had new behaviour with automatically detecting dest bank, and not using indices. reverted zeroacc behaviour.

### Checklist
- [x] Post commit CI passes
- [ ] Model regression CI testing passes (if applicable)
- [ ] New/Existing tests provide coverage for changes
