### PR TITLE
#9715: Use build artifacts for profiler tests

### DIFF
--- a/.github/workflows/all-post-commit-workflows.yaml
+++ b/.github/workflows/all-post-commit-workflows.yaml
@@ -19,6 +19,11 @@ jobs:
   build-artifact:
     uses: ./.github/workflows/build-artifact.yaml
     secrets: inherit
+  build-artifact-profiler:
+    uses: ./.github/workflows/build-artifact.yaml
+    with:
+      profiler-build: true
+    secrets: inherit
   sd-unit-tests:
     needs: build-artifact
     uses: ./.github/workflows/build-and-unit-tests.yaml
@@ -28,6 +33,7 @@ jobs:
     uses: ./.github/workflows/fast-dispatch-build-and-unit-tests.yaml
     secrets: inherit
   profiler-regression:
+    needs: build-artifact-profiler
     uses: ./.github/workflows/run-profiler-regression.yaml
     secrets: inherit
   eager-package-main:

--- a/.github/workflows/build-artifact.yaml
+++ b/.github/workflows/build-artifact.yaml
@@ -7,14 +7,29 @@ on:
         required: false
         type: string
         default: '["grayskull", "wormhole_b0"]'
+      profiler-build:
+        required: false
+        type: boolean
+        default: false
+        description: "Enable tracy and profiler build with _profiler attached to end of artifact"
   workflow_dispatch:
+    inputs:
+      arch:
+        required: false
+        type: string
+        default: '["grayskull", "wormhole_b0"]'
+      profiler-build:
+        required: false
+        type: boolean
+        default: false
+        description: "Enable tracy and profiler build with _profiler attached to end of artifact"
 
 jobs:
   build-artifact:
     strategy:
       matrix:
         arch: ${{ fromJson(inputs.arch || '["grayskull", "wormhole_b0", "blackhole"]') }}
-
+        profiler-build: ${{ fromJson(inputs.profiler-build) || false }}
     env:
       TT_METAL_ENV: ${{ vars.TT_METAL_ENV }}
       ARCH_NAME: ${{ matrix.arch }}
@@ -30,15 +45,19 @@ jobs:
       - name: Update submodules
         run: |
           git submodule update --init --recursive
-      - name: Build tt-metal and libs
+      - name: Build regular tt-metal and libs
+        if: ${{ !matrix.profiler-build }}
         run: |
           cmake -B build -G Ninja
           cmake --build build --target tests
           cmake --build build --target install
+      - name: Build regular tt-metal and libs
+        if: ${{ matrix.profiler-build }}
+        run: ./scripts/build_scripts/build_with_profiler_opt.sh
       - name: 'Tar files'
         run: tar -cvf ttm_${{ matrix.arch }}.tar build/lib ttnn/ttnn/*.so build/programming_examples build/test build/tools runtime
       - name: 'Upload Artifact'
         uses: actions/upload-artifact@v4
         with:
-          name: TTMetal_build_${{ matrix.arch }}
+          name: TTMetal_build_${{ matrix.arch }}${{ matrix.profiler-build && '_profiler' }}
           path: ttm_${{ matrix.arch }}.tar

--- a/.github/workflows/build-artifact.yaml
+++ b/.github/workflows/build-artifact.yaml
@@ -29,7 +29,6 @@ jobs:
     strategy:
       matrix:
         arch: ${{ fromJson(inputs.arch || '["grayskull", "wormhole_b0", "blackhole"]') }}
-        profiler-build: ${{ fromJson([inputs.profiler-build]) || [false] }}
     env:
       TT_METAL_ENV: ${{ vars.TT_METAL_ENV }}
       ARCH_NAME: ${{ matrix.arch }}
@@ -46,18 +45,18 @@ jobs:
         run: |
           git submodule update --init --recursive
       - name: Build regular tt-metal and libs
-        if: ${{ !matrix.profiler-build }}
+        if: ${{ !inputs.profiler-build }}
         run: |
           cmake -B build -G Ninja
           cmake --build build --target tests
           cmake --build build --target install
       - name: Build regular tt-metal and libs
-        if: ${{ matrix.profiler-build }}
+        if: ${{ inputs.profiler-build }}
         run: ./scripts/build_scripts/build_with_profiler_opt.sh
       - name: 'Tar files'
         run: tar -cvf ttm_${{ matrix.arch }}.tar build/lib ttnn/ttnn/*.so build/programming_examples build/test build/tools runtime
       - name: 'Upload Artifact'
         uses: actions/upload-artifact@v4
         with:
-          name: TTMetal_build_${{ matrix.arch }}${{ matrix.profiler-build && '_profiler' }}
+          name: TTMetal_build_${{ matrix.arch }}${{ inputs.profiler-build && '_profiler' }}
           path: ttm_${{ matrix.arch }}.tar

--- a/.github/workflows/build-artifact.yaml
+++ b/.github/workflows/build-artifact.yaml
@@ -58,5 +58,5 @@ jobs:
       - name: 'Upload Artifact'
         uses: actions/upload-artifact@v4
         with:
-          name: TTMetal_build_${{ matrix.arch }}${{ inputs.profiler-build && '_profiler' }}
+          name: TTMetal_build_${{ matrix.arch }}${{ (inputs.profiler-build && '_profiler') || '' }}
           path: ttm_${{ matrix.arch }}.tar

--- a/.github/workflows/build-artifact.yaml
+++ b/.github/workflows/build-artifact.yaml
@@ -29,7 +29,7 @@ jobs:
     strategy:
       matrix:
         arch: ${{ fromJson(inputs.arch || '["grayskull", "wormhole_b0", "blackhole"]') }}
-        profiler-build: ${{ fromJson(inputs.profiler-build) || false }}
+        profiler-build: ${{ fromJson([inputs.profiler-build]) || [false] }}
     env:
       TT_METAL_ENV: ${{ vars.TT_METAL_ENV }}
       ARCH_NAME: ${{ matrix.arch }}

--- a/.github/workflows/build-artifact.yaml
+++ b/.github/workflows/build-artifact.yaml
@@ -50,7 +50,7 @@ jobs:
           cmake -B build -G Ninja
           cmake --build build --target tests
           cmake --build build --target install
-      - name: Build regular tt-metal and libs
+      - name: Build profiler tt-metal and libs
         if: ${{ inputs.profiler-build }}
         run: ./scripts/build_scripts/build_with_profiler_opt.sh
       - name: 'Tar files'

--- a/.github/workflows/perf-device-models.yaml
+++ b/.github/workflows/perf-device-models.yaml
@@ -7,7 +7,13 @@ on:
   workflow_call:
 
 jobs:
+  build-artifact-profiler:
+    uses: ./.github/workflows/build-artifact.yaml
+    with:
+      profiler-build: true
+    secrets: inherit
   device-perf:
+    needs: build-artifact-profiler
     strategy:
       # Do not fail-fast because we need to ensure all tests go to completion
       # so we try not to get hanging machines
@@ -21,7 +27,6 @@ jobs:
     env:
       TT_METAL_ENV: ${{ vars.TT_METAL_ENV }}
       ARCH_NAME: ${{ matrix.test-info.arch }}
-      TTNN_CONFIG_OVERRIDES: '{"enable_fast_runtime_mode": true}'
       LOGURU_LEVEL: INFO
     environment: dev
     runs-on: ${{ matrix.test-info.runs-on }}
@@ -35,10 +40,12 @@ jobs:
       - name: Set up dynamic env vars for build
         run: |
           echo "TT_METAL_HOME=$(pwd)" >> $GITHUB_ENV
-      - name: Build tt-metal and libs
-        run: |
-          ./scripts/build_scripts/build_with_profiler_opt.sh
-          ./create_venv.sh
+      - uses: actions/download-artifact@v4
+        with:
+          name: TTMetal_build_${{ matrix.runner-info.arch }}_profiler
+      - name: Extract files
+        run: tar -xvf ttm_${{ matrix.runner-info.arch }}.tar
+      - uses: ./.github/actions/install-python-deps
       - name: Run device performance regressions
         timeout-minutes: ${{ matrix.test-info.timeout }}
         run: |

--- a/.github/workflows/perf-device-models.yaml
+++ b/.github/workflows/perf-device-models.yaml
@@ -28,6 +28,7 @@ jobs:
       TT_METAL_ENV: ${{ vars.TT_METAL_ENV }}
       ARCH_NAME: ${{ matrix.test-info.arch }}
       LOGURU_LEVEL: INFO
+      LD_LIBRARY_PATH: ${{ github.workspace }}/build/lib
     environment: dev
     runs-on: ${{ matrix.test-info.runs-on }}
     steps:

--- a/.github/workflows/perf-device-models.yaml
+++ b/.github/workflows/perf-device-models.yaml
@@ -43,9 +43,9 @@ jobs:
           echo "TT_METAL_HOME=$(pwd)" >> $GITHUB_ENV
       - uses: actions/download-artifact@v4
         with:
-          name: TTMetal_build_${{ matrix.runner-info.arch }}_profiler
+          name: TTMetal_build_${{ matrix.test-info.arch }}_profiler
       - name: Extract files
-        run: tar -xvf ttm_${{ matrix.runner-info.arch }}.tar
+        run: tar -xvf ttm_${{ matrix.test-info.arch }}.tar
       - uses: ./.github/actions/install-python-deps
       - name: Run device performance regressions
         timeout-minutes: ${{ matrix.test-info.timeout }}

--- a/.github/workflows/perf-models.yaml
+++ b/.github/workflows/perf-models.yaml
@@ -27,7 +27,6 @@ jobs:
       TT_METAL_ENV: ${{ vars.TT_METAL_ENV }}
       ARCH_NAME: ${{ matrix.test-info.arch }}
       LOGURU_LEVEL: INFO
-      TTNN_CONFIG_OVERRIDES: '{"enable_fast_runtime_mode": true}'
     environment: dev
     runs-on: ${{ matrix.test-info.runs-on }}
     steps:

--- a/.github/workflows/run-profiler-regression-wrapper.yaml
+++ b/.github/workflows/run-profiler-regression-wrapper.yaml
@@ -1,0 +1,16 @@
+name: "[post-commit] metal - Run profiler regression"
+
+on:
+  workflow_dispatch:
+  workflow_call:
+
+jobs:
+  build-artifact-profiler:
+    uses: ./.github/workflows/build-artifact.yaml
+    with:
+      profiler-build: true
+    secrets: inherit
+  run-profiler-regression:
+    needs: build-artifact-profiler
+    uses: ./.github/workflows/run-profiler-regression.yaml
+    secrets: inherit

--- a/.github/workflows/run-profiler-regression-wrapper.yaml
+++ b/.github/workflows/run-profiler-regression-wrapper.yaml
@@ -3,6 +3,9 @@ name: "[post-commit] metal - Run profiler regression"
 on:
   workflow_dispatch:
   workflow_call:
+  push:
+    branches:
+      - rkim/9715-profiler-artifact
 
 jobs:
   build-artifact-profiler:

--- a/.github/workflows/run-profiler-regression-wrapper.yaml
+++ b/.github/workflows/run-profiler-regression-wrapper.yaml
@@ -3,9 +3,6 @@ name: "[post-commit] metal - Run profiler regression"
 on:
   workflow_dispatch:
   workflow_call:
-  push:
-    branches:
-      - rkim/9715-profiler-artifact
 
 jobs:
   build-artifact-profiler:

--- a/.github/workflows/run-profiler-regression.yaml
+++ b/.github/workflows/run-profiler-regression.yaml
@@ -22,6 +22,7 @@ jobs:
       TT_METAL_ENV: ${{ vars.TT_METAL_ENV }}
       ARCH_NAME: ${{ matrix.runner-info.arch }}
       LOGURU_LEVEL: INFO
+      LD_LIBRARY_PATH: ${{ github.workspace }}/build/lib
     environment: dev
     runs-on: ${{ matrix.runner-info.runs-on }}
     steps:

--- a/.github/workflows/run-profiler-regression.yaml
+++ b/.github/workflows/run-profiler-regression.yaml
@@ -1,8 +1,6 @@
-name: "[post-commit] metal - Run profiler regression"
+name: "[internal] metal - Run profiler regression impl"
 
 on:
-
-  workflow_dispatch:
   workflow_call:
 
 jobs:
@@ -31,10 +29,12 @@ jobs:
       - name: Set up dynamic env vars for build
         run: |
           echo "TT_METAL_HOME=$(pwd)" >> $GITHUB_ENV
-      - name: Build tt-metal and libs
-        run: |
-          ./scripts/build_scripts/build_with_profiler_opt.sh
-          ./create_venv.sh
+      - uses: actions/download-artifact@v4
+        with:
+          name: TTMetal_build_${{ matrix.runner-info.arch }}_profiler
+      - name: Extract files
+        run: tar -xvf ttm_${{ matrix.runner-info.arch }}.tar
+      - uses: ./.github/actions/install-python-deps
       - name: Run profiler regression tests
         timeout-minutes: 30
         run: |

--- a/.github/workflows/t3000-profiler-tests.yaml
+++ b/.github/workflows/t3000-profiler-tests.yaml
@@ -7,7 +7,14 @@ on:
     - cron: "0 */8 * * *" # This cron schedule runs the workflow every 8 hours
 
 jobs:
+  build-artifact-profiler:
+    uses: ./.github/workflows/build-artifact.yaml
+    with:
+      arch: '["wormhole_b0"]'
+      profiler-build: true
+    secrets: inherit
   t3000-profiler-tests:
+    needs: build-artifact-profiler
     strategy:
       fail-fast: false
       matrix:
@@ -32,10 +39,12 @@ jobs:
       - name: Set up dynamic env vars for build
         run: |
           echo "TT_METAL_HOME=$(pwd)" >> $GITHUB_ENV
-      - name: Build tt-metal and libs
-        run: |
-          ./scripts/build_scripts/build_with_profiler_opt.sh
-          ./create_venv.sh
+      - uses: actions/download-artifact@v4
+        with:
+          name: TTMetal_build_${{ matrix.runner-info.arch }}_profiler
+      - name: Extract files
+        run: tar -xvf ttm_${{ matrix.runner-info.arch }}.tar
+      - uses: ./.github/actions/install-python-deps
       - name: Run profiler regression tests
         timeout-minutes: 30
         run: |
@@ -44,4 +53,4 @@ jobs:
         if: ${{ failure() }}
         with:
           slack_webhook_url: ${{ secrets.SLACK_WEBHOOK_URL }}
-          owner: U03BJ1L3LUQ # Mo Memarian  
+          owner: U03BJ1L3LUQ # Mo Memarian

--- a/.github/workflows/t3000-profiler-tests.yaml
+++ b/.github/workflows/t3000-profiler-tests.yaml
@@ -41,9 +41,9 @@ jobs:
           echo "TT_METAL_HOME=$(pwd)" >> $GITHUB_ENV
       - uses: actions/download-artifact@v4
         with:
-          name: TTMetal_build_${{ matrix.runner-info.arch }}_profiler
+          name: TTMetal_build_${{ matrix.test-group.arch }}_profiler
       - name: Extract files
-        run: tar -xvf ttm_${{ matrix.runner-info.arch }}.tar
+        run: tar -xvf ttm_${{ matrix.test-group.arch }}.tar
       - uses: ./.github/actions/install-python-deps
       - name: Run profiler regression tests
         timeout-minutes: 30


### PR DESCRIPTION
### Ticket

#9715 

### Problem description

We spend a lot of time building on silicon machines for profiler tests because it's a separate build.

Let's not do this anymore.

### What's changed

Extended build artifact job to have a profiler option. Goal is to enable profiler jobs to download artifacts with `_profiler` attached at the end.

### Checklist
- [x] Post commit CI passes
- [x] Model regression CI testing passes (if applicable)
- [x] New/Existing tests provide coverage for changes
