### PR TITLE
#10045: fix up missed parameter change in mamba block model

### DIFF
--- a/models/demos/mamba/tt/mamba_block.py
+++ b/models/demos/mamba/tt/mamba_block.py
@@ -105,7 +105,7 @@ class TtMambaBlock(torch.nn.Module):
             self.mlp_proj_weights,
             memory_config=ttnn.DRAM_MEMORY_CONFIG,
             compute_kernel_config=self.compute_kernel_config,
-            use_1d_systolic_array=True,
+            core_grid=x.device().core_grid,
             dtype=self.configs["dtype"]["activations"],
             activation="silu",
         )


### PR DESCRIPTION
### Ticket
Link to Github Issue https://github.com/tenstorrent/tt-metal/issues/10045

### Problem description
- missed a line in the original PR to remove use_1d_systolic_array parameter for matmul/linear

### What's changed
- fix up the line

### Checklist
- [x] Post commit CI passes
- [ ] Model regression CI testing passes (if applicable) N/A
- [x] New/Existing tests provide coverage for changes

https://github.com/tenstorrent/tt-metal/actions/runs/9912279162 All post commits passes
https://github.com/tenstorrent/tt-metal/actions/runs/9912283603/ Single card demo test passes