### PR TITLE
#10211: Fix iterating cores in core range

### DIFF
--- a/tests/tt_metal/tt_metal/perf_microbenchmark/8_dram_adjacent_core_read/test_dram_read.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/8_dram_adjacent_core_read/test_dram_read.cpp
@@ -127,14 +127,14 @@ std::tuple<tt_metal::Program, tt_metal::KernelHandle, uint32_t> create_program(
 
     std::vector<uint32_t> bank_ids;
     for (int i=0; i < all_cores_list.size(); i++) {
-        auto core = all_cores_list[i].start;
+        auto core = all_cores_list[i].start_;
         uint32_t bank_id = i + bank_start_id;
         uint32_t vc = bank_id & 0x3;
 
         bank_ids.push_back(bank_id);
 
         for (int j=0; j<i; ++j) {
-            auto core_ = all_cores_list[j].start;
+            auto core_ = all_cores_list[j].start_;
 
             if (core_.y == core.y and ((bank_id & 0x3) == (bank_ids[j] & 0x3))) { // same vc and same row
                 vc = (vc + 1) & 0x3;
@@ -176,7 +176,7 @@ bool validation(
     for (auto core: all_cores) {
         std::vector<uint32_t> result_vec;
         tt_metal::detail::ReadFromDeviceL1(
-            device, core.start, cb_addr, num_tiles_cb * single_tile_size, result_vec);
+            device, core.start_, cb_addr, num_tiles_cb * single_tile_size, result_vec);
 
         uint32_t num_datum_per_block = block_h * block_w * num_datum_per_slice;
         uint32_t tensor_slice_stride = core_id * num_datum_per_slice;
@@ -597,8 +597,8 @@ int main(int argc, char **argv) {
         uint32_t num_tiles_cb = num_tiles_per_core / num_blocks;
 
         for (auto core: all_cores_list) {
-            auto phys_core = device->worker_core_from_logical_core(core.start);
-            log_info("logical core: {}, physical coer: {}", core.start, phys_core);
+            auto phys_core = device->worker_core_from_logical_core(core.start_);
+            log_info("logical core: {}, physical coer: {}", core.start_, phys_core);
         }
 
         log_info(

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/8_dram_adjacent_core_read/test_dram_read.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/8_dram_adjacent_core_read/test_dram_read.cpp
@@ -127,14 +127,14 @@ std::tuple<tt_metal::Program, tt_metal::KernelHandle, uint32_t> create_program(
 
     std::vector<uint32_t> bank_ids;
     for (int i=0; i < all_cores_list.size(); i++) {
-        auto core = all_cores_list[i].start_;
+        auto core = all_cores_list[i].start_coord;
         uint32_t bank_id = i + bank_start_id;
         uint32_t vc = bank_id & 0x3;
 
         bank_ids.push_back(bank_id);
 
         for (int j=0; j<i; ++j) {
-            auto core_ = all_cores_list[j].start_;
+            auto core_ = all_cores_list[j].start_coord;
 
             if (core_.y == core.y and ((bank_id & 0x3) == (bank_ids[j] & 0x3))) { // same vc and same row
                 vc = (vc + 1) & 0x3;
@@ -176,7 +176,7 @@ bool validation(
     for (auto core: all_cores) {
         std::vector<uint32_t> result_vec;
         tt_metal::detail::ReadFromDeviceL1(
-            device, core.start_, cb_addr, num_tiles_cb * single_tile_size, result_vec);
+            device, core.start_coord, cb_addr, num_tiles_cb * single_tile_size, result_vec);
 
         uint32_t num_datum_per_block = block_h * block_w * num_datum_per_slice;
         uint32_t tensor_slice_stride = core_id * num_datum_per_slice;
@@ -597,8 +597,8 @@ int main(int argc, char **argv) {
         uint32_t num_tiles_cb = num_tiles_per_core / num_blocks;
 
         for (auto core: all_cores_list) {
-            auto phys_core = device->worker_core_from_logical_core(core.start_);
-            log_info("logical core: {}, physical coer: {}", core.start_, phys_core);
+            auto phys_core = device->worker_core_from_logical_core(core.start_coord);
+            log_info("logical core: {}, physical coer: {}", core.start_coord, phys_core);
         }
 
         log_info(

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/common/work_split.hpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/common/work_split.hpp
@@ -120,21 +120,21 @@ inline std::tuple<uint32_t, CoreRangeSet, CoreRangeSet, CoreRangeSet, uint32_t, 
         auto last_block_group_2 = (*core_group_2_set.rbegin());
         auto last_block_all_cores = (*all_cores.ranges().rbegin());
         // Case where only the last column is divided between core group 1 and 2
-        if (last_block_group_2.end.x == last_block_all_cores.end.x &&
-            last_block_group_2.end.y != last_block_all_cores.end.y) {
+        if (last_block_group_2.end_.x == last_block_all_cores.end_.x &&
+            last_block_group_2.end_.y != last_block_all_cores.end_.y) {
             CoreRange leftover_block(
-                {last_block_group_2.end.x, last_block_group_2.end.y + 1}, last_block_all_cores.end);
+                {last_block_group_2.end_.x, last_block_group_2.end_.y + 1}, last_block_all_cores.end_);
             core_group_1_set.insert(leftover_block);
         } else {
             // Case where a middle column is divided between core group 1 and 2
-            if (last_block_group_2.end.y != num_cores_y - 1) {
+            if (last_block_group_2.end_.y != num_cores_y - 1) {
                 CoreRange leftover_stick(
-                    {last_block_group_2.end.x, last_block_group_2.end.y + 1},
-                    {last_block_group_2.end.x, num_cores_y - 1});
+                    {last_block_group_2.end_.x, last_block_group_2.end_.y + 1},
+                    {last_block_group_2.end_.x, num_cores_y - 1});
                 core_group_1_set.insert(leftover_stick);
             }
             // Remaining columns of cores that does less work
-            CoreRange leftover_block({last_block_group_2.end.x + 1, 0}, last_block_all_cores.end);
+            CoreRange leftover_block({last_block_group_2.end_.x + 1, 0}, last_block_all_cores.end_);
             core_group_1_set.insert(leftover_block);
         }
         units_per_core_group_2 = units_per_core_group_1 + 1;

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/common/work_split.hpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/common/work_split.hpp
@@ -120,21 +120,21 @@ inline std::tuple<uint32_t, CoreRangeSet, CoreRangeSet, CoreRangeSet, uint32_t, 
         auto last_block_group_2 = (*core_group_2_set.rbegin());
         auto last_block_all_cores = (*all_cores.ranges().rbegin());
         // Case where only the last column is divided between core group 1 and 2
-        if (last_block_group_2.end_.x == last_block_all_cores.end_.x &&
-            last_block_group_2.end_.y != last_block_all_cores.end_.y) {
+        if (last_block_group_2.end_coord.x == last_block_all_cores.end_coord.x &&
+            last_block_group_2.end_coord.y != last_block_all_cores.end_coord.y) {
             CoreRange leftover_block(
-                {last_block_group_2.end_.x, last_block_group_2.end_.y + 1}, last_block_all_cores.end_);
+                {last_block_group_2.end_coord.x, last_block_group_2.end_coord.y + 1}, last_block_all_cores.end_coord);
             core_group_1_set.insert(leftover_block);
         } else {
             // Case where a middle column is divided between core group 1 and 2
-            if (last_block_group_2.end_.y != num_cores_y - 1) {
+            if (last_block_group_2.end_coord.y != num_cores_y - 1) {
                 CoreRange leftover_stick(
-                    {last_block_group_2.end_.x, last_block_group_2.end_.y + 1},
-                    {last_block_group_2.end_.x, num_cores_y - 1});
+                    {last_block_group_2.end_coord.x, last_block_group_2.end_coord.y + 1},
+                    {last_block_group_2.end_coord.x, num_cores_y - 1});
                 core_group_1_set.insert(leftover_stick);
             }
             // Remaining columns of cores that does less work
-            CoreRange leftover_block({last_block_group_2.end_.x + 1, 0}, last_block_all_cores.end_);
+            CoreRange leftover_block({last_block_group_2.end_coord.x + 1, 0}, last_block_all_cores.end_coord);
             core_group_1_set.insert(leftover_block);
         }
         units_per_core_group_2 = units_per_core_group_1 + 1;

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/common.h
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/common.h
@@ -152,8 +152,8 @@ DeviceData::DeviceData(Device *device,
             this->all_data[core][bank_id].bank_offset = bank_offset;
         }
     } else {
-        for (uint32_t y = workers.start.y; y <= workers.end.y; y++) {
-            for (uint32_t x = workers.start.x; x <= workers.end.x; x++) {
+        for (uint32_t y = workers.start_.y; y <= workers.end_.y; y++) {
+            for (uint32_t x = workers.start_.x; x <= workers.end_.x; x++) {
                 CoreCoord core = {x, y};
                 CoreCoord phys_core = device->worker_core_from_logical_core(core);
                 this->all_data[core][0] = one_core_data_t();
@@ -233,8 +233,8 @@ void DeviceData::push_one(CoreCoord core, uint32_t datum) {
 void DeviceData::push_range(const CoreRange& cores, uint32_t datum, bool is_mcast) {
 
     bool counted = false;
-    for (auto y = cores.start.y; y <= cores.end.y; y++) {
-        for (auto x = cores.start.x; x <= cores.end.x; x++) {
+    for (auto y = cores.start_.y; y <= cores.end_.y; y++) {
+        for (auto x = cores.start_.x; x <= cores.end_.x; x++) {
             CoreCoord core = {x, y};
             if (core_and_bank_present(core, 0)) {
                 if (not counted || not is_mcast) {
@@ -287,8 +287,8 @@ void DeviceData::relevel(CoreRange range) {
     size_t max = 0;
 
     constexpr uint32_t bank = 0;
-    for (uint32_t y = range.start.y; y <= range.end.y; y++) {
-        for (uint32_t x = range.start.x; x <= range.end.x; x++) {
+    for (uint32_t y = range.start_.y; y <= range.end_.y; y++) {
+        for (uint32_t x = range.start_.x; x <= range.end_.x; x++) {
             CoreCoord core = {x, y};
             if (this->all_data[core][bank].data.size() > max) {
                 max = this->all_data[core][bank].data.size();
@@ -296,8 +296,8 @@ void DeviceData::relevel(CoreRange range) {
         }
     }
 
-    for (uint32_t y = range.start.y; y <= range.end.y; y++) {
-        for (uint32_t x = range.start.x; x <= range.end.x; x++) {
+    for (uint32_t y = range.start_.y; y <= range.end_.y; y++) {
+        for (uint32_t x = range.start_.x; x <= range.end_.x; x++) {
             CoreCoord core = {x, y};
             this->all_data[core][bank].data.resize(max);
             this->all_data[core][bank].valid.resize(max);
@@ -648,7 +648,7 @@ inline void generate_random_packed_large_payload(vector<uint32_t>& generated_dat
     const uint32_t bank_id = 0; // No interleaved pages here.
 
     bool first_core = true;
-    CoreCoord first_worker = range.start;
+    CoreCoord first_worker = range.start_;
     uint32_t data_base = generated_data.size();
     for (uint32_t i = 0; i < size_words; i++) {
         uint32_t datum = (use_coherent_data_g) ? ((first_worker.x << 16) | (first_worker.y << 24) | coherent_count++) : std::rand();
@@ -656,8 +656,8 @@ inline void generate_random_packed_large_payload(vector<uint32_t>& generated_dat
     }
     generated_data.resize(padded_size(generated_data.size(), 4)); // XXXXX L1_ALIGNMENT16/sizeof(uint)
 
-    for (uint32_t y = range.start.y; y <= range.end.y; y++) {
-        for (uint32_t x = range.start.x; x <= range.end.x; x++) {
+    for (uint32_t y = range.start_.y; y <= range.end_.y; y++) {
+        for (uint32_t x = range.start_.x; x <= range.end_.x; x++) {
             CoreCoord core = {x, y};
             for (uint32_t i = 0; i < size_words; i++) {
                 data.push_one(core, bank_id, generated_data[data_base + i]);
@@ -845,13 +845,13 @@ inline void gen_dispatcher_multicast_write_cmd(Device *device,
     CQDispatchCmd cmd;
     memset(&cmd, 0, sizeof(CQDispatchCmd));
 
-    CoreCoord physical_start = device->physical_core_from_logical_core(worker_core_range.start, CoreType::WORKER);
-    CoreCoord physical_end = device->physical_core_from_logical_core(worker_core_range.end, CoreType::WORKER);
+    CoreCoord physical_start = device->physical_core_from_logical_core(worker_core_range.start_, CoreType::WORKER);
+    CoreCoord physical_end = device->physical_core_from_logical_core(worker_core_range.end_, CoreType::WORKER);
     const uint32_t bank_id = 0; // No interleaved pages here.
 
     cmd.base.cmd_id = CQ_DISPATCH_CMD_WRITE_LINEAR;
     cmd.write_linear.noc_xy_addr = NOC_MULTICAST_ENCODING(physical_start.x, physical_start.y, physical_end.x, physical_end.y);
-    cmd.write_linear.addr = device_data.get_result_data_addr(worker_core_range.start);
+    cmd.write_linear.addr = device_data.get_result_data_addr(worker_core_range.start_);
     cmd.write_linear.length = length;
     cmd.write_linear.num_mcast_dests = worker_core_range.size();
 
@@ -1020,21 +1020,21 @@ inline bool gen_rnd_dispatcher_packed_write_large_cmd(Device *device,
         CoreRange range = workers;
         if (!perf_test_g) {
             // Not random, but gives some variation
-            uint32_t span = workers.end.x - workers.start.x + 1;
-            range.end.x = std::rand() % span + range.start.x;
-            span = workers.end.y - workers.start.y + 1;
-            range.end.y = std::rand() % span + range.start.y;
+            uint32_t span = workers.end_.x - workers.start_.x + 1;
+            range.end_.x = std::rand() % span + range.start_.x;
+            span = workers.end_.y - workers.start_.y + 1;
+            range.end_.y = std::rand() % span + range.start_.y;
         }
 
         device_data.relevel(range);
 
         CQDispatchWritePackedLargeSubCmd sub_cmd;
-        CoreCoord physical_start = device->physical_core_from_logical_core(range.start, CoreType::WORKER);
-        CoreCoord physical_end = device->physical_core_from_logical_core(range.end, CoreType::WORKER);
+        CoreCoord physical_start = device->physical_core_from_logical_core(range.start_, CoreType::WORKER);
+        CoreCoord physical_end = device->physical_core_from_logical_core(range.end_, CoreType::WORKER);
         sub_cmd.noc_xy_addr = NOC_MULTICAST_ENCODING(physical_start.x, physical_start.y, physical_end.x, physical_end.y);
-        sub_cmd.addr = device_data.get_result_data_addr(range.start);
+        sub_cmd.addr = device_data.get_result_data_addr(range.start_);
         sub_cmd.length = xfer_size_bytes;
-        sub_cmd.num_mcast_dests = (range.end.x - range.start.x + 1) * (range.end.y - range.start.y + 1);
+        sub_cmd.num_mcast_dests = (range.end_.x - range.start_.x + 1) * (range.end_.y - range.start_.y + 1);
 
         for (uint32_t i = 0; i < sizeof(CQDispatchWritePackedLargeSubCmd) / sizeof(uint32_t); i++) {
             cmds.push_back(((uint32_t *)&sub_cmd)[i]);

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/test_bw_and_latency.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/test_bw_and_latency.cpp
@@ -227,12 +227,12 @@ int main(int argc, char **argv) {
         if (page_size_as_runtime_arg_g) {
             vector<uint32_t> args;
             args.push_back(page_size_g);
-            tt_metal::SetRuntimeArgs(program, dm0, worker_g.start_, args);
+            tt_metal::SetRuntimeArgs(program, dm0, worker_g.start_coord, args);
         }
 
         std::shared_ptr<Event> sync_event = std::make_shared<Event>();
 
-        CoreCoord w = device->physical_core_from_logical_core(worker_g.start_, CoreType::WORKER);
+        CoreCoord w = device->physical_core_from_logical_core(worker_g.start_coord, CoreType::WORKER);
         log_info(LogTest, "Master core: {}", w.str());
         if (source_mem_g == 3) {
             log_info(LogTest, "Reading: {}", src_mem);

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/test_bw_and_latency.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/test_bw_and_latency.cpp
@@ -227,12 +227,12 @@ int main(int argc, char **argv) {
         if (page_size_as_runtime_arg_g) {
             vector<uint32_t> args;
             args.push_back(page_size_g);
-            tt_metal::SetRuntimeArgs(program, dm0, worker_g.start, args);
+            tt_metal::SetRuntimeArgs(program, dm0, worker_g.start_, args);
         }
 
         std::shared_ptr<Event> sync_event = std::make_shared<Event>();
 
-        CoreCoord w = device->physical_core_from_logical_core(worker_g.start, CoreType::WORKER);
+        CoreCoord w = device->physical_core_from_logical_core(worker_g.start_, CoreType::WORKER);
         log_info(LogTest, "Master core: {}", w.str());
         if (source_mem_g == 3) {
             log_info(LogTest, "Reading: {}", src_mem);

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/test_dispatcher.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/test_dispatcher.cpp
@@ -81,8 +81,8 @@ void init(int argc, char **argv) {
         log_info(LogTest, "    -t: test type, 0:uni_write 1:mcast_write 2:dram paged_write 3:l1 paged_write 4:packed_write 5:packed_write_large (default {})", 0);
         log_info(LogTest, "    -w: warm-up iterations before starting timer (default {}), ", DEFAULT_WARMUP_ITERATIONS);
         log_info(LogTest, "    -i: host iterations (default {})", DEFAULT_ITERATIONS);
-        log_info(LogTest, "   -wx: right-most worker in grid (default {})", all_workers_g.end.x);
-        log_info(LogTest, "   -wy: bottom-most worker in grid (default {})", all_workers_g.end.y);
+        log_info(LogTest, "   -wx: right-most worker in grid (default {})", all_workers_g.end_.x);
+        log_info(LogTest, "   -wy: bottom-most worker in grid (default {})", all_workers_g.end_.y);
         log_info(LogTest, "    -a: send to all workers (vs random) for 1-to-N cmds (default random)");
         log_info(LogTest, "   -pi: prefetcher iterations (looping on device) (default {})", 1);
         log_info(LogTest, "  -lps: log of page size of prefetch/dispatch buffer (default {})", DEFAULT_DISPATCH_BUFFER_LOG_PAGE_SIZE);
@@ -109,8 +109,8 @@ void init(int argc, char **argv) {
     iterations_g = test_args::get_command_option_uint32(input_args, "-i", DEFAULT_ITERATIONS);
     prefetcher_iterations_g = test_args::get_command_option_uint32(input_args, "-pi", 1);
     test_type_g = test_args::get_command_option_uint32(input_args, "-t", 0);
-    all_workers_g.end.x = test_args::get_command_option_uint32(input_args, "-wx", all_workers_g.end.x);
-    all_workers_g.end.y = test_args::get_command_option_uint32(input_args, "-wy", all_workers_g.end.y);
+    all_workers_g.end_.x = test_args::get_command_option_uint32(input_args, "-wx", all_workers_g.end_.x);
+    all_workers_g.end_.y = test_args::get_command_option_uint32(input_args, "-wy", all_workers_g.end_.y);
 
     log_dispatch_buffer_page_size_g = test_args::get_command_option_uint32(input_args, "-lps", DEFAULT_DISPATCH_BUFFER_LOG_PAGE_SIZE);
     dispatch_buffer_page_size_g = 1 << log_dispatch_buffer_page_size_g;
@@ -211,7 +211,7 @@ void gen_linear_or_packed_write_test(uint32_t& cmd_count,
             if (is_linear_multicast) {
                 gen_dispatcher_multicast_write_cmd(device, dispatch_cmds, worker_cores, device_data, xfer_size_bytes);
             } else {
-                gen_dispatcher_unicast_write_cmd(device, dispatch_cmds, worker_cores.start, device_data, xfer_size_bytes);
+                gen_dispatcher_unicast_write_cmd(device, dispatch_cmds, worker_cores.start_, device_data, xfer_size_bytes);
             }
             break;
         }

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/test_dispatcher.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/test_dispatcher.cpp
@@ -81,8 +81,8 @@ void init(int argc, char **argv) {
         log_info(LogTest, "    -t: test type, 0:uni_write 1:mcast_write 2:dram paged_write 3:l1 paged_write 4:packed_write 5:packed_write_large (default {})", 0);
         log_info(LogTest, "    -w: warm-up iterations before starting timer (default {}), ", DEFAULT_WARMUP_ITERATIONS);
         log_info(LogTest, "    -i: host iterations (default {})", DEFAULT_ITERATIONS);
-        log_info(LogTest, "   -wx: right-most worker in grid (default {})", all_workers_g.end_.x);
-        log_info(LogTest, "   -wy: bottom-most worker in grid (default {})", all_workers_g.end_.y);
+        log_info(LogTest, "   -wx: right-most worker in grid (default {})", all_workers_g.end_coord.x);
+        log_info(LogTest, "   -wy: bottom-most worker in grid (default {})", all_workers_g.end_coord.y);
         log_info(LogTest, "    -a: send to all workers (vs random) for 1-to-N cmds (default random)");
         log_info(LogTest, "   -pi: prefetcher iterations (looping on device) (default {})", 1);
         log_info(LogTest, "  -lps: log of page size of prefetch/dispatch buffer (default {})", DEFAULT_DISPATCH_BUFFER_LOG_PAGE_SIZE);
@@ -109,8 +109,8 @@ void init(int argc, char **argv) {
     iterations_g = test_args::get_command_option_uint32(input_args, "-i", DEFAULT_ITERATIONS);
     prefetcher_iterations_g = test_args::get_command_option_uint32(input_args, "-pi", 1);
     test_type_g = test_args::get_command_option_uint32(input_args, "-t", 0);
-    all_workers_g.end_.x = test_args::get_command_option_uint32(input_args, "-wx", all_workers_g.end_.x);
-    all_workers_g.end_.y = test_args::get_command_option_uint32(input_args, "-wy", all_workers_g.end_.y);
+    all_workers_g.end_coord.x = test_args::get_command_option_uint32(input_args, "-wx", all_workers_g.end_coord.x);
+    all_workers_g.end_coord.y = test_args::get_command_option_uint32(input_args, "-wy", all_workers_g.end_coord.y);
 
     log_dispatch_buffer_page_size_g = test_args::get_command_option_uint32(input_args, "-lps", DEFAULT_DISPATCH_BUFFER_LOG_PAGE_SIZE);
     dispatch_buffer_page_size_g = 1 << log_dispatch_buffer_page_size_g;
@@ -211,7 +211,7 @@ void gen_linear_or_packed_write_test(uint32_t& cmd_count,
             if (is_linear_multicast) {
                 gen_dispatcher_multicast_write_cmd(device, dispatch_cmds, worker_cores, device_data, xfer_size_bytes);
             } else {
-                gen_dispatcher_unicast_write_cmd(device, dispatch_cmds, worker_cores.start_, device_data, xfer_size_bytes);
+                gen_dispatcher_unicast_write_cmd(device, dispatch_cmds, worker_cores.start_coord, device_data, xfer_size_bytes);
             }
             break;
         }

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/test_pgm_dispatch.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/test_pgm_dispatch.cpp
@@ -123,8 +123,8 @@ void init(int argc, char **argv) {
 }
 
 void set_runtime_args(Program& program, tt_metal::KernelHandle kernel_id, vector<uint32_t>& args, CoreRange kg) {
-    for (int core_idx_y = kg.start.y; core_idx_y <= kg.end.y; core_idx_y++) {
-        for (int core_idx_x = kg.start.x; core_idx_x <= kg.end.x; core_idx_x++) {
+    for (int core_idx_y = kg.start_.y; core_idx_y <= kg.end_.y; core_idx_y++) {
+        for (int core_idx_x = kg.start_.x; core_idx_x <= kg.end_.x; core_idx_x++) {
             CoreCoord core = {(std::size_t)core_idx_x, (std::size_t)core_idx_y};
             tt_metal::SetRuntimeArgs(program, kernel_id, core, args);
         }
@@ -158,7 +158,7 @@ void initialize_program(tt_metal::Program& program, uint32_t run_cycles) {
     }
 
     // first kernel group is possibly wide, remaining kernel groups are 1 column each
-    CoreRange kg = { workers_g.start, { workers_g.end.x - n_kgs_g + 1, workers_g.end.y }};
+    CoreRange kg = { workers_g.start_, { workers_g.end_.x - n_kgs_g + 1, workers_g.end_.y }};
     for (uint32_t i = 0; i < n_kgs_g; i++) {
         defines.insert(std::pair<string, string>(string("KG_") + std::to_string(i), ""));
 
@@ -192,8 +192,8 @@ void initialize_program(tt_metal::Program& program, uint32_t run_cycles) {
             tt_metal::SetCommonRuntimeArgs(program, compute, common_args);
         }
 
-        kg.start = { kg.end.x + 1, kg.end.y };
-        kg.end = kg.start;
+        kg.start_ = { kg.end_.x + 1, kg.end_.y };
+        kg.end_ = kg.start_;
     }
 }
 
@@ -241,7 +241,7 @@ int main(int argc, char **argv) {
 
         log_info(LogTest, "Warmup iterations: {}", warmup_iterations_g);
         log_info(LogTest, "Iterations: {}", iterations_g);
-        log_info(LogTest, "Grid: ({}-{}) ({} cores)", workers_g.start.str(), workers_g.end.str(), workers_g.size());
+        log_info(LogTest, "Grid: ({}-{}) ({} cores)", workers_g.start_.str(), workers_g.end_.str(), workers_g.size());
         log_info(LogTest, "Kernel size: {}", kernel_size_g);
         if (nfast_kernels_g != 0) {
             log_info(LogTest, "Fast kernel cycles: {}", fast_kernel_cycles_g);

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/test_pgm_dispatch.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/test_pgm_dispatch.cpp
@@ -123,8 +123,8 @@ void init(int argc, char **argv) {
 }
 
 void set_runtime_args(Program& program, tt_metal::KernelHandle kernel_id, vector<uint32_t>& args, CoreRange kg) {
-    for (int core_idx_y = kg.start_.y; core_idx_y <= kg.end_.y; core_idx_y++) {
-        for (int core_idx_x = kg.start_.x; core_idx_x <= kg.end_.x; core_idx_x++) {
+    for (int core_idx_y = kg.start_coord.y; core_idx_y <= kg.end_coord.y; core_idx_y++) {
+        for (int core_idx_x = kg.start_coord.x; core_idx_x <= kg.end_coord.x; core_idx_x++) {
             CoreCoord core = {(std::size_t)core_idx_x, (std::size_t)core_idx_y};
             tt_metal::SetRuntimeArgs(program, kernel_id, core, args);
         }
@@ -158,7 +158,7 @@ void initialize_program(tt_metal::Program& program, uint32_t run_cycles) {
     }
 
     // first kernel group is possibly wide, remaining kernel groups are 1 column each
-    CoreRange kg = { workers_g.start_, { workers_g.end_.x - n_kgs_g + 1, workers_g.end_.y }};
+    CoreRange kg = { workers_g.start_coord, { workers_g.end_coord.x - n_kgs_g + 1, workers_g.end_coord.y }};
     for (uint32_t i = 0; i < n_kgs_g; i++) {
         defines.insert(std::pair<string, string>(string("KG_") + std::to_string(i), ""));
 
@@ -192,8 +192,8 @@ void initialize_program(tt_metal::Program& program, uint32_t run_cycles) {
             tt_metal::SetCommonRuntimeArgs(program, compute, common_args);
         }
 
-        kg.start_ = { kg.end_.x + 1, kg.end_.y };
-        kg.end_ = kg.start_;
+        kg.start_coord = { kg.end_coord.x + 1, kg.end_coord.y };
+        kg.end_coord = kg.start_coord;
     }
 }
 
@@ -241,7 +241,7 @@ int main(int argc, char **argv) {
 
         log_info(LogTest, "Warmup iterations: {}", warmup_iterations_g);
         log_info(LogTest, "Iterations: {}", iterations_g);
-        log_info(LogTest, "Grid: ({}-{}) ({} cores)", workers_g.start_.str(), workers_g.end_.str(), workers_g.size());
+        log_info(LogTest, "Grid: ({}-{}) ({} cores)", workers_g.start_coord.str(), workers_g.end_coord.str(), workers_g.size());
         log_info(LogTest, "Kernel size: {}", kernel_size_g);
         if (nfast_kernels_g != 0) {
             log_info(LogTest, "Fast kernel cycles: {}", fast_kernel_cycles_g);

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/test_prefetcher.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/test_prefetcher.cpp
@@ -115,8 +115,8 @@ void init(int argc, char **argv) {
         log_info(LogTest, "  -t: test type: 0:Terminate 1:Smoke 2:Random 3:PCIe 4:DRAM-read 5:DRAM-write-read 6:Host 7:Packed-read (default {})", DEFAULT_TEST_TYPE);
         log_info(LogTest, "  -w: warm-up before starting timer (default disabled)");
         log_info(LogTest, "  -i: host iterations (default {})", DEFAULT_ITERATIONS);
-        log_info(LogTest, " -wx: right-most worker in grid (default {})", all_workers_g.end.x);
-        log_info(LogTest, " -wy: bottom-most worker in grid (default {})", all_workers_g.end.y);
+        log_info(LogTest, " -wx: right-most worker in grid (default {})", all_workers_g.end_.x);
+        log_info(LogTest, " -wy: bottom-most worker in grid (default {})", all_workers_g.end_.y);
         log_info(LogTest, "  -b: run a \"big\" test (fills memory w/ fewer transactions) (default false)", DEFAULT_TEST_TYPE);
         log_info(LogTest, " -rb: gen data, readback and test every iteration - disable for perf measurements (default true)");
         log_info(LogTest, "  -c: use coherent data as payload (default false)");
@@ -155,8 +155,8 @@ void init(int argc, char **argv) {
     prefetch_d_buffer_size_g = test_args::get_command_option_uint32(input_args, "-pdcs", dispatch_constants::get(CoreType::WORKER).prefetch_d_buffer_size());
 
     test_type_g = test_args::get_command_option_uint32(input_args, "-t", DEFAULT_TEST_TYPE);
-    all_workers_g.end.x = test_args::get_command_option_uint32(input_args, "-wx", all_workers_g.end.x);
-    all_workers_g.end.y = test_args::get_command_option_uint32(input_args, "-wy", all_workers_g.end.y);
+    all_workers_g.end_.x = test_args::get_command_option_uint32(input_args, "-wx", all_workers_g.end_.x);
+    all_workers_g.end_.y = test_args::get_command_option_uint32(input_args, "-wy", all_workers_g.end_.y);
     split_prefetcher_g = test_args::has_command_option(input_args, "-spre");
     split_dispatcher_g = test_args::has_command_option(input_args, "-sdis");
     use_dram_exec_buf_g = test_args::has_command_option(input_args, "-x");
@@ -911,8 +911,8 @@ void gen_rnd_test(Device *device,
     while (device_data.size() * sizeof(uint32_t) < DEVICE_DATA_SIZE) {
         // Assumes terminate is the last command...
         uint32_t cmd = std::rand() % CQ_PREFETCH_CMD_TERMINATE;
-        uint32_t x = rand() % (all_workers_g.end.x - first_worker_g.x);
-        uint32_t y = rand() % (all_workers_g.end.y - first_worker_g.y);
+        uint32_t x = rand() % (all_workers_g.end_.x - first_worker_g.x);
+        uint32_t y = rand() % (all_workers_g.end_.y - first_worker_g.y);
 
         CoreCoord worker_core(first_worker_g.x + x, first_worker_g.y + y);
 
@@ -1168,8 +1168,8 @@ void gen_smoke_test(Device *device,
 
     dispatch_cmds.resize(0);
     worker_cores.resize(0);
-    for (uint32_t y = all_workers_g.start.y; y <= all_workers_g.end.y; y++) {
-        for (uint32_t x = all_workers_g.start.x; x <= all_workers_g.end.x; x++) {
+    for (uint32_t y = all_workers_g.start_.y; y <= all_workers_g.end_.y; y++) {
+        for (uint32_t x = all_workers_g.start_.x; x <= all_workers_g.end_.x; x++) {
             CoreCoord worker_core(x, y);
             worker_cores.push_back(worker_core);
         }
@@ -1184,7 +1184,7 @@ void gen_smoke_test(Device *device,
     dispatch_cmds.resize(0);
     worker_cores.resize(0);
     worker_cores.push_back(first_worker_g);
-    worker_cores.push_back(all_workers_g.end);
+    worker_cores.push_back(all_workers_g.end_);
     gen_dispatcher_packed_write_cmd(device, dispatch_cmds, worker_cores, device_data, 156);
     add_prefetcher_cmd(prefetch_cmds, cmd_sizes, CQ_PREFETCH_CMD_RELAY_INLINE, dispatch_cmds);
 
@@ -1266,7 +1266,7 @@ void gen_prefetcher_cmds(Device *device,
         // No cmds, tests terminating - true smoke test
         break;
     case 1:
-        gen_smoke_test(device, prefetch_cmds, cmd_sizes, device_data, first_worker_g, all_workers_g.end);
+        gen_smoke_test(device, prefetch_cmds, cmd_sizes, device_data, first_worker_g, all_workers_g.end_);
         break;
     case 2:
         gen_rnd_test(device, prefetch_cmds, cmd_sizes, device_data);

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/test_prefetcher.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/test_prefetcher.cpp
@@ -115,8 +115,8 @@ void init(int argc, char **argv) {
         log_info(LogTest, "  -t: test type: 0:Terminate 1:Smoke 2:Random 3:PCIe 4:DRAM-read 5:DRAM-write-read 6:Host 7:Packed-read (default {})", DEFAULT_TEST_TYPE);
         log_info(LogTest, "  -w: warm-up before starting timer (default disabled)");
         log_info(LogTest, "  -i: host iterations (default {})", DEFAULT_ITERATIONS);
-        log_info(LogTest, " -wx: right-most worker in grid (default {})", all_workers_g.end_.x);
-        log_info(LogTest, " -wy: bottom-most worker in grid (default {})", all_workers_g.end_.y);
+        log_info(LogTest, " -wx: right-most worker in grid (default {})", all_workers_g.end_coord.x);
+        log_info(LogTest, " -wy: bottom-most worker in grid (default {})", all_workers_g.end_coord.y);
         log_info(LogTest, "  -b: run a \"big\" test (fills memory w/ fewer transactions) (default false)", DEFAULT_TEST_TYPE);
         log_info(LogTest, " -rb: gen data, readback and test every iteration - disable for perf measurements (default true)");
         log_info(LogTest, "  -c: use coherent data as payload (default false)");
@@ -155,8 +155,8 @@ void init(int argc, char **argv) {
     prefetch_d_buffer_size_g = test_args::get_command_option_uint32(input_args, "-pdcs", dispatch_constants::get(CoreType::WORKER).prefetch_d_buffer_size());
 
     test_type_g = test_args::get_command_option_uint32(input_args, "-t", DEFAULT_TEST_TYPE);
-    all_workers_g.end_.x = test_args::get_command_option_uint32(input_args, "-wx", all_workers_g.end_.x);
-    all_workers_g.end_.y = test_args::get_command_option_uint32(input_args, "-wy", all_workers_g.end_.y);
+    all_workers_g.end_coord.x = test_args::get_command_option_uint32(input_args, "-wx", all_workers_g.end_coord.x);
+    all_workers_g.end_coord.y = test_args::get_command_option_uint32(input_args, "-wy", all_workers_g.end_coord.y);
     split_prefetcher_g = test_args::has_command_option(input_args, "-spre");
     split_dispatcher_g = test_args::has_command_option(input_args, "-sdis");
     use_dram_exec_buf_g = test_args::has_command_option(input_args, "-x");
@@ -911,8 +911,8 @@ void gen_rnd_test(Device *device,
     while (device_data.size() * sizeof(uint32_t) < DEVICE_DATA_SIZE) {
         // Assumes terminate is the last command...
         uint32_t cmd = std::rand() % CQ_PREFETCH_CMD_TERMINATE;
-        uint32_t x = rand() % (all_workers_g.end_.x - first_worker_g.x);
-        uint32_t y = rand() % (all_workers_g.end_.y - first_worker_g.y);
+        uint32_t x = rand() % (all_workers_g.end_coord.x - first_worker_g.x);
+        uint32_t y = rand() % (all_workers_g.end_coord.y - first_worker_g.y);
 
         CoreCoord worker_core(first_worker_g.x + x, first_worker_g.y + y);
 
@@ -1168,8 +1168,8 @@ void gen_smoke_test(Device *device,
 
     dispatch_cmds.resize(0);
     worker_cores.resize(0);
-    for (uint32_t y = all_workers_g.start_.y; y <= all_workers_g.end_.y; y++) {
-        for (uint32_t x = all_workers_g.start_.x; x <= all_workers_g.end_.x; x++) {
+    for (uint32_t y = all_workers_g.start_coord.y; y <= all_workers_g.end_coord.y; y++) {
+        for (uint32_t x = all_workers_g.start_coord.x; x <= all_workers_g.end_coord.x; x++) {
             CoreCoord worker_core(x, y);
             worker_cores.push_back(worker_core);
         }
@@ -1184,7 +1184,7 @@ void gen_smoke_test(Device *device,
     dispatch_cmds.resize(0);
     worker_cores.resize(0);
     worker_cores.push_back(first_worker_g);
-    worker_cores.push_back(all_workers_g.end_);
+    worker_cores.push_back(all_workers_g.end_coord);
     gen_dispatcher_packed_write_cmd(device, dispatch_cmds, worker_cores, device_data, 156);
     add_prefetcher_cmd(prefetch_cmds, cmd_sizes, CQ_PREFETCH_CMD_RELAY_INLINE, dispatch_cmds);
 
@@ -1266,7 +1266,7 @@ void gen_prefetcher_cmds(Device *device,
         // No cmds, tests terminating - true smoke test
         break;
     case 1:
-        gen_smoke_test(device, prefetch_cmds, cmd_sizes, device_data, first_worker_g, all_workers_g.end_);
+        gen_smoke_test(device, prefetch_cmds, cmd_sizes, device_data, first_worker_g, all_workers_g.end_coord);
         break;
     case 2:
         gen_rnd_test(device, prefetch_cmds, cmd_sizes, device_data);

--- a/tests/tt_metal/tt_metal/test_core_range_set.cpp
+++ b/tests/tt_metal/tt_metal/test_core_range_set.cpp
@@ -22,8 +22,8 @@ using namespace tt;
 void check_program_is_mapped_to_correct_cores(const tt_metal::Program &program, const CoreRangeSet &core_range_set, const std::vector<uint32_t> &compute_kernel_args) {
     // every kernel, semaphore and CB should be mapped to each core in the core ranges of core_range_set
     for (auto core_range : core_range_set.ranges()) {
-        for (auto x = core_range.start.x; x <= core_range.end.x; x++) {
-            for (auto y = core_range.start.y; y <= core_range.end.y; y++) {
+        for (auto x = core_range.start_.x; x <= core_range.end_.x; x++) {
+            for (auto y = core_range.start_.y; y <= core_range.end_.y; y++) {
                 auto logical_core = CoreCoord{x, y};
                 for (size_t kernel_id = 0; kernel_id < program.num_kernels(); kernel_id++) {
                     auto kernel = tt_metal::detail::GetKernel(program, kernel_id);
@@ -47,8 +47,8 @@ void check_program_is_mapped_to_correct_cores(const tt_metal::Program &program, 
 
 void check_semaphores_are_initialized(tt_metal::Device *device, const CoreRangeSet &core_range_set, const std::vector<uint32_t> &golden_sem_values) {
     for (auto core_range : core_range_set.ranges()) {
-        for (auto x = core_range.start.x; x <= core_range.end.x; x++) {
-            for (auto y = core_range.start.y; y <= core_range.end.y; y++) {
+        for (auto x = core_range.start_.x; x <= core_range.end_.x; x++) {
+            for (auto y = core_range.start_.y; y <= core_range.end_.y; y++) {
                 auto logical_core = CoreCoord{x, y};
                 std::vector<uint32_t> res;
                 tt_metal::detail::ReadFromDeviceL1(device, logical_core, SEMAPHORE_BASE, SEMAPHORE_SIZE, res);
@@ -86,8 +86,8 @@ bool test_program_specified_with_core_range_set(tt_metal::Device *device, tt_met
 
     std::map<CoreCoord, std::shared_ptr<tt_metal::Buffer>> core_to_l1_buffer;
     for (auto core_range : core_range_set.ranges()) {
-        auto start = core_range.start;
-        auto end = core_range.end;
+        auto start = core_range.start_;
+        auto end = core_range.end_;
         for (auto x = start.x; x <= end.x; x++) {
             for (auto y = start.y; y <= end.y; y++) {
                 CoreCoord logical_core(x, y);

--- a/tests/tt_metal/tt_metal/test_core_range_set.cpp
+++ b/tests/tt_metal/tt_metal/test_core_range_set.cpp
@@ -22,8 +22,8 @@ using namespace tt;
 void check_program_is_mapped_to_correct_cores(const tt_metal::Program &program, const CoreRangeSet &core_range_set, const std::vector<uint32_t> &compute_kernel_args) {
     // every kernel, semaphore and CB should be mapped to each core in the core ranges of core_range_set
     for (auto core_range : core_range_set.ranges()) {
-        for (auto x = core_range.start_.x; x <= core_range.end_.x; x++) {
-            for (auto y = core_range.start_.y; y <= core_range.end_.y; y++) {
+        for (auto x = core_range.start_coord.x; x <= core_range.end_coord.x; x++) {
+            for (auto y = core_range.start_coord.y; y <= core_range.end_coord.y; y++) {
                 auto logical_core = CoreCoord{x, y};
                 for (size_t kernel_id = 0; kernel_id < program.num_kernels(); kernel_id++) {
                     auto kernel = tt_metal::detail::GetKernel(program, kernel_id);
@@ -47,8 +47,8 @@ void check_program_is_mapped_to_correct_cores(const tt_metal::Program &program, 
 
 void check_semaphores_are_initialized(tt_metal::Device *device, const CoreRangeSet &core_range_set, const std::vector<uint32_t> &golden_sem_values) {
     for (auto core_range : core_range_set.ranges()) {
-        for (auto x = core_range.start_.x; x <= core_range.end_.x; x++) {
-            for (auto y = core_range.start_.y; y <= core_range.end_.y; y++) {
+        for (auto x = core_range.start_coord.x; x <= core_range.end_coord.x; x++) {
+            for (auto y = core_range.start_coord.y; y <= core_range.end_coord.y; y++) {
                 auto logical_core = CoreCoord{x, y};
                 std::vector<uint32_t> res;
                 tt_metal::detail::ReadFromDeviceL1(device, logical_core, SEMAPHORE_BASE, SEMAPHORE_SIZE, res);
@@ -86,8 +86,8 @@ bool test_program_specified_with_core_range_set(tt_metal::Device *device, tt_met
 
     std::map<CoreCoord, std::shared_ptr<tt_metal::Buffer>> core_to_l1_buffer;
     for (auto core_range : core_range_set.ranges()) {
-        auto start = core_range.start_;
-        auto end = core_range.end_;
+        auto start = core_range.start_coord;
+        auto end = core_range.end_coord;
         for (auto x = start.x; x <= end.x; x++) {
             for (auto y = start.y; y <= end.y; y++) {
                 CoreCoord logical_core(x, y);

--- a/tests/tt_metal/tt_metal/test_multi_core_kernel.cpp
+++ b/tests/tt_metal/tt_metal/test_multi_core_kernel.cpp
@@ -25,8 +25,8 @@ std::tuple<tt_metal::Program, tt_metal::KernelHandle, tt_metal::KernelHandle> cr
     const std::vector<uint32_t> &eltwise_unary_args) {
     tt_metal::Program program = tt_metal::CreateProgram();
 
-    CoreCoord start_core = all_cores.start;
-    CoreCoord end_core = all_cores.end;
+    CoreCoord start_core = all_cores.start_;
+    CoreCoord end_core = all_cores.end_;
     // input CB is larger than the output CB, to test the backpressure from the output CB all the way into the input CB
     // CB_out size = 1 forces the serialization of packer and writer kernel, generating backpressure to math kernel, input CB and reader
     for (auto x = start_core.x; x <= end_core.x; x++) {
@@ -88,8 +88,8 @@ void compile_and_configure_program(
 }
 
 void set_rt_args(tt_metal::Program &program, tt_metal::KernelHandle kernel, const CoreRange &core_range, const std::vector<uint32_t> &rt_args) {
-    for (auto x = core_range.start.x; x <= core_range.end.x; x++) {
-        for (auto y = core_range.start.y; y <= core_range.end.y; y++) {
+    for (auto x = core_range.start_.x; x <= core_range.end_.x; x++) {
+        for (auto y = core_range.start_.y; y <= core_range.end_.y; y++) {
             CoreCoord core = CoreCoord(x, y);
             tt_metal::SetRuntimeArgs(program, kernel, core, rt_args);
         }

--- a/tests/tt_metal/tt_metal/test_multi_core_kernel.cpp
+++ b/tests/tt_metal/tt_metal/test_multi_core_kernel.cpp
@@ -25,8 +25,8 @@ std::tuple<tt_metal::Program, tt_metal::KernelHandle, tt_metal::KernelHandle> cr
     const std::vector<uint32_t> &eltwise_unary_args) {
     tt_metal::Program program = tt_metal::CreateProgram();
 
-    CoreCoord start_core = all_cores.start_;
-    CoreCoord end_core = all_cores.end_;
+    CoreCoord start_core = all_cores.start_coord;
+    CoreCoord end_core = all_cores.end_coord;
     // input CB is larger than the output CB, to test the backpressure from the output CB all the way into the input CB
     // CB_out size = 1 forces the serialization of packer and writer kernel, generating backpressure to math kernel, input CB and reader
     for (auto x = start_core.x; x <= end_core.x; x++) {
@@ -88,8 +88,8 @@ void compile_and_configure_program(
 }
 
 void set_rt_args(tt_metal::Program &program, tt_metal::KernelHandle kernel, const CoreRange &core_range, const std::vector<uint32_t> &rt_args) {
-    for (auto x = core_range.start_.x; x <= core_range.end_.x; x++) {
-        for (auto y = core_range.start_.y; y <= core_range.end_.y; y++) {
+    for (auto x = core_range.start_coord.x; x <= core_range.end_coord.x; x++) {
+        for (auto y = core_range.start_coord.y; y <= core_range.end_coord.y; y++) {
             CoreCoord core = CoreCoord(x, y);
             tt_metal::SetRuntimeArgs(program, kernel, core, rt_args);
         }

--- a/tests/tt_metal/tt_metal/unit_tests/CMakeLists.txt
+++ b/tests/tt_metal/tt_metal/unit_tests/CMakeLists.txt
@@ -20,6 +20,7 @@ set(UNIT_TESTS_SRC
     ${CMAKE_CURRENT_SOURCE_DIR}/core_coord/test_CoreRange_adjacent.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/core_coord/test_CoreRange_contains.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/core_coord/test_CoreRange_intersects.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/core_coord/test_CoreRange_iterator.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/core_coord/test_CoreRange_merge.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/core_coord/test_CoreRangeSet_construct.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/core_coord/test_CoreRangeSet_merge.cpp

--- a/tests/tt_metal/tt_metal/unit_tests/basic/initialize_semaphores.cpp
+++ b/tests/tt_metal/tt_metal/unit_tests/basic/initialize_semaphores.cpp
@@ -73,8 +73,8 @@ void create_and_read_max_num_semaphores(
 
     ASSERT_TRUE(tt_metal::detail::ConfigureDeviceWithProgram(device, program));
 
-    for (auto x = core_range.start_.x; x <= core_range.end_.x; x++) {
-        for (auto y = core_range.start_.y; y <= core_range.end_.y; y++) {
+    for (auto x = core_range.start_coord.x; x <= core_range.end_coord.x; x++) {
+        for (auto y = core_range.start_coord.y; y <= core_range.end_coord.y; y++) {
             auto logical_core = CoreCoord{x, y};
             std::vector<uint32_t> res;
             for (uint32_t i = 0; i < NUM_SEMAPHORES; i++) {

--- a/tests/tt_metal/tt_metal/unit_tests/basic/initialize_semaphores.cpp
+++ b/tests/tt_metal/tt_metal/unit_tests/basic/initialize_semaphores.cpp
@@ -73,8 +73,8 @@ void create_and_read_max_num_semaphores(
 
     ASSERT_TRUE(tt_metal::detail::ConfigureDeviceWithProgram(device, program));
 
-    for (auto x = core_range.start.x; x <= core_range.end.x; x++) {
-        for (auto y = core_range.start.y; y <= core_range.end.y; y++) {
+    for (auto x = core_range.start_.x; x <= core_range.end_.x; x++) {
+        for (auto y = core_range.start_.y; y <= core_range.end_.y; y++) {
             auto logical_core = CoreCoord{x, y};
             std::vector<uint32_t> res;
             for (uint32_t i = 0; i < NUM_SEMAPHORES; i++) {

--- a/tests/tt_metal/tt_metal/unit_tests/basic/runtime_args.cpp
+++ b/tests/tt_metal/tt_metal/unit_tests/basic/runtime_args.cpp
@@ -152,8 +152,8 @@ bool verify_results(
             auto common_rt_args_base_addr = get_runtime_arg_addr(kernel->processor(), true);
 
             for (auto &core_range : kernel->logical_coreranges()) {
-                for (auto x = core_range.start.x; x <= core_range.end.x; x++) {
-                    for (auto y = core_range.start.y; y <= core_range.end.y; y++) {
+                for (auto x = core_range.start_.x; x <= core_range.end_.x; x++) {
+                    for (auto y = core_range.start_.y; y <= core_range.end_.y; y++) {
                         CoreCoord logical_core({x, y});
                         auto rt_args = kernel->common_runtime_args();
                         EXPECT_EQ(rt_args, common_rt_args);
@@ -181,8 +181,8 @@ TEST_F(DeviceFixture, LegallyModifyRTArgsDataMovement) {
 
         std::map<CoreCoord, std::vector<uint32_t>> core_to_rt_args;
         for (auto core_range : core_range_set.ranges()) {
-            for (auto x = core_range.start.x; x <= core_range.end.x; x++) {
-                for (auto y = core_range.start.y; y <= core_range.end.y; y++) {
+            for (auto x = core_range.start_.x; x <= core_range.end_.x; x++) {
+                for (auto y = core_range.start_.y; y <= core_range.end_.y; y++) {
                     CoreCoord logical_core(x, y);
                     core_to_rt_args[logical_core] = initial_runtime_args;
                 }
@@ -195,8 +195,8 @@ TEST_F(DeviceFixture, LegallyModifyRTArgsDataMovement) {
         std::vector<uint32_t> second_runtime_args = {202, 505};
         SetRuntimeArgs(program, 0, first_core_range, second_runtime_args);
         detail::WriteRuntimeArgsToDevice(this->devices_.at(id), program);
-        for (auto x = first_core_range.start.x; x <= first_core_range.end.x; x++) {
-            for (auto y = first_core_range.start.y; y <= first_core_range.end.y; y++) {
+        for (auto x = first_core_range.start_.x; x <= first_core_range.end_.x; x++) {
+            for (auto y = first_core_range.start_.y; y <= first_core_range.end_.y; y++) {
                 CoreCoord logical_core(x, y);
                 core_to_rt_args[logical_core] = second_runtime_args;
             }
@@ -227,8 +227,8 @@ TEST_F(DeviceFixture, LegallyModifyRTArgsCompute) {
 
         std::map<CoreCoord, std::vector<uint32_t>> core_to_rt_args;
         for (auto core_range : core_range_set.ranges()) {
-            for (auto x = core_range.start.x; x <= core_range.end.x; x++) {
-                for (auto y = core_range.start.y; y <= core_range.end.y; y++) {
+            for (auto x = core_range.start_.x; x <= core_range.end_.x; x++) {
+                for (auto y = core_range.start_.y; y <= core_range.end_.y; y++) {
                     CoreCoord logical_core(x, y);
                     core_to_rt_args[logical_core] = initial_runtime_args;
                 }
@@ -257,8 +257,8 @@ TEST_F(DeviceFixture, SetRuntimeArgsSubsetOfCoresCompute) {
         SetRuntimeArgs(program, 0, first_core_range, initial_runtime_args); // First core range only.
 
         std::map<CoreCoord, std::vector<uint32_t>> core_to_rt_args;
-        for (auto x = first_core_range.start.x; x <= first_core_range.end.x; x++) {
-            for (auto y = first_core_range.start.y; y <= first_core_range.end.y; y++) {
+        for (auto x = first_core_range.start_.x; x <= first_core_range.end_.x; x++) {
+            for (auto y = first_core_range.start_.y; y <= first_core_range.end_.y; y++) {
                 CoreCoord logical_core(x, y);
                 core_to_rt_args[logical_core] = initial_runtime_args;
             }
@@ -283,8 +283,8 @@ TEST_F(DeviceFixture, SetRuntimeArgsUniqueValuesCompute) {
 
         std::map<CoreCoord, std::vector<uint32_t>> core_to_rt_args;
         for (auto core_range : core_range_set.ranges()) {
-            for (auto x = core_range.start.x; x <= core_range.end.x; x++) {
-                for (auto y = core_range.start.y; y <= core_range.end.y; y++) {
+            for (auto x = core_range.start_.x; x <= core_range.end_.x; x++) {
+                for (auto y = core_range.start_.y; y <= core_range.end_.y; y++) {
                     CoreCoord logical_core(x, y);
                     // Generate an rt arg val based on x and y.
                     uint32_t val_offset = x * 100 + y * 10;
@@ -319,8 +319,8 @@ TEST_F(DeviceFixture, SetRuntimeArgsVaryingLengthPerCore) {
         // with fewer will just increment unused memory, no big deal.
         uint32_t max_unique_rt_args = 0;
         for (auto core_range : core_range_set.ranges()) {
-            for (auto x = core_range.start.x; x <= core_range.end.x; x++) {
-                for (auto y = core_range.start.y; y <= core_range.end.y; y++) {
+            for (auto x = core_range.start_.x; x <= core_range.end_.x; x++) {
+                for (auto y = core_range.start_.y; y <= core_range.end_.y; y++) {
                     uint32_t num_rt_args = 2 + x + y;
                     max_unique_rt_args = std::max(max_unique_rt_args, num_rt_args);
                 }
@@ -331,8 +331,8 @@ TEST_F(DeviceFixture, SetRuntimeArgsVaryingLengthPerCore) {
 
         std::map<CoreCoord, std::vector<uint32_t>> core_to_rt_args;
         for (auto core_range : core_range_set.ranges()) {
-            for (auto x = core_range.start.x; x <= core_range.end.x; x++) {
-                for (auto y = core_range.start.y; y <= core_range.end.y; y++) {
+            for (auto x = core_range.start_.x; x <= core_range.end_.x; x++) {
+                for (auto y = core_range.start_.y; y <= core_range.end_.y; y++) {
                     CoreCoord logical_core(x, y);
                     // Generate rt args length and val based on x,y arbitrarily.
                     uint32_t val_offset = x * 100 + y * 10;
@@ -389,8 +389,8 @@ TEST_F(DeviceFixture, IllegallyModifyRTArgs) {
 
         std::map<CoreCoord, std::vector<uint32_t>> core_to_rt_args;
         for (auto core_range : core_range_set.ranges()) {
-            for (auto x = core_range.start.x; x <= core_range.end.x; x++) {
-                for (auto y = core_range.start.y; y <= core_range.end.y; y++) {
+            for (auto x = core_range.start_.x; x <= core_range.end_.x; x++) {
+                for (auto y = core_range.start_.y; y <= core_range.end_.y; y++) {
                     CoreCoord logical_core(x, y);
                     core_to_rt_args[logical_core] = initial_runtime_args;
                 }

--- a/tests/tt_metal/tt_metal/unit_tests/basic/runtime_args.cpp
+++ b/tests/tt_metal/tt_metal/unit_tests/basic/runtime_args.cpp
@@ -152,8 +152,8 @@ bool verify_results(
             auto common_rt_args_base_addr = get_runtime_arg_addr(kernel->processor(), true);
 
             for (auto &core_range : kernel->logical_coreranges()) {
-                for (auto x = core_range.start_.x; x <= core_range.end_.x; x++) {
-                    for (auto y = core_range.start_.y; y <= core_range.end_.y; y++) {
+                for (auto x = core_range.start_coord.x; x <= core_range.end_coord.x; x++) {
+                    for (auto y = core_range.start_coord.y; y <= core_range.end_coord.y; y++) {
                         CoreCoord logical_core({x, y});
                         auto rt_args = kernel->common_runtime_args();
                         EXPECT_EQ(rt_args, common_rt_args);
@@ -181,8 +181,8 @@ TEST_F(DeviceFixture, LegallyModifyRTArgsDataMovement) {
 
         std::map<CoreCoord, std::vector<uint32_t>> core_to_rt_args;
         for (auto core_range : core_range_set.ranges()) {
-            for (auto x = core_range.start_.x; x <= core_range.end_.x; x++) {
-                for (auto y = core_range.start_.y; y <= core_range.end_.y; y++) {
+            for (auto x = core_range.start_coord.x; x <= core_range.end_coord.x; x++) {
+                for (auto y = core_range.start_coord.y; y <= core_range.end_coord.y; y++) {
                     CoreCoord logical_core(x, y);
                     core_to_rt_args[logical_core] = initial_runtime_args;
                 }
@@ -195,8 +195,8 @@ TEST_F(DeviceFixture, LegallyModifyRTArgsDataMovement) {
         std::vector<uint32_t> second_runtime_args = {202, 505};
         SetRuntimeArgs(program, 0, first_core_range, second_runtime_args);
         detail::WriteRuntimeArgsToDevice(this->devices_.at(id), program);
-        for (auto x = first_core_range.start_.x; x <= first_core_range.end_.x; x++) {
-            for (auto y = first_core_range.start_.y; y <= first_core_range.end_.y; y++) {
+        for (auto x = first_core_range.start_coord.x; x <= first_core_range.end_coord.x; x++) {
+            for (auto y = first_core_range.start_coord.y; y <= first_core_range.end_coord.y; y++) {
                 CoreCoord logical_core(x, y);
                 core_to_rt_args[logical_core] = second_runtime_args;
             }
@@ -227,8 +227,8 @@ TEST_F(DeviceFixture, LegallyModifyRTArgsCompute) {
 
         std::map<CoreCoord, std::vector<uint32_t>> core_to_rt_args;
         for (auto core_range : core_range_set.ranges()) {
-            for (auto x = core_range.start_.x; x <= core_range.end_.x; x++) {
-                for (auto y = core_range.start_.y; y <= core_range.end_.y; y++) {
+            for (auto x = core_range.start_coord.x; x <= core_range.end_coord.x; x++) {
+                for (auto y = core_range.start_coord.y; y <= core_range.end_coord.y; y++) {
                     CoreCoord logical_core(x, y);
                     core_to_rt_args[logical_core] = initial_runtime_args;
                 }
@@ -257,8 +257,8 @@ TEST_F(DeviceFixture, SetRuntimeArgsSubsetOfCoresCompute) {
         SetRuntimeArgs(program, 0, first_core_range, initial_runtime_args); // First core range only.
 
         std::map<CoreCoord, std::vector<uint32_t>> core_to_rt_args;
-        for (auto x = first_core_range.start_.x; x <= first_core_range.end_.x; x++) {
-            for (auto y = first_core_range.start_.y; y <= first_core_range.end_.y; y++) {
+        for (auto x = first_core_range.start_coord.x; x <= first_core_range.end_coord.x; x++) {
+            for (auto y = first_core_range.start_coord.y; y <= first_core_range.end_coord.y; y++) {
                 CoreCoord logical_core(x, y);
                 core_to_rt_args[logical_core] = initial_runtime_args;
             }
@@ -283,8 +283,8 @@ TEST_F(DeviceFixture, SetRuntimeArgsUniqueValuesCompute) {
 
         std::map<CoreCoord, std::vector<uint32_t>> core_to_rt_args;
         for (auto core_range : core_range_set.ranges()) {
-            for (auto x = core_range.start_.x; x <= core_range.end_.x; x++) {
-                for (auto y = core_range.start_.y; y <= core_range.end_.y; y++) {
+            for (auto x = core_range.start_coord.x; x <= core_range.end_coord.x; x++) {
+                for (auto y = core_range.start_coord.y; y <= core_range.end_coord.y; y++) {
                     CoreCoord logical_core(x, y);
                     // Generate an rt arg val based on x and y.
                     uint32_t val_offset = x * 100 + y * 10;
@@ -319,8 +319,8 @@ TEST_F(DeviceFixture, SetRuntimeArgsVaryingLengthPerCore) {
         // with fewer will just increment unused memory, no big deal.
         uint32_t max_unique_rt_args = 0;
         for (auto core_range : core_range_set.ranges()) {
-            for (auto x = core_range.start_.x; x <= core_range.end_.x; x++) {
-                for (auto y = core_range.start_.y; y <= core_range.end_.y; y++) {
+            for (auto x = core_range.start_coord.x; x <= core_range.end_coord.x; x++) {
+                for (auto y = core_range.start_coord.y; y <= core_range.end_coord.y; y++) {
                     uint32_t num_rt_args = 2 + x + y;
                     max_unique_rt_args = std::max(max_unique_rt_args, num_rt_args);
                 }
@@ -331,8 +331,8 @@ TEST_F(DeviceFixture, SetRuntimeArgsVaryingLengthPerCore) {
 
         std::map<CoreCoord, std::vector<uint32_t>> core_to_rt_args;
         for (auto core_range : core_range_set.ranges()) {
-            for (auto x = core_range.start_.x; x <= core_range.end_.x; x++) {
-                for (auto y = core_range.start_.y; y <= core_range.end_.y; y++) {
+            for (auto x = core_range.start_coord.x; x <= core_range.end_coord.x; x++) {
+                for (auto y = core_range.start_coord.y; y <= core_range.end_coord.y; y++) {
                     CoreCoord logical_core(x, y);
                     // Generate rt args length and val based on x,y arbitrarily.
                     uint32_t val_offset = x * 100 + y * 10;
@@ -389,8 +389,8 @@ TEST_F(DeviceFixture, IllegallyModifyRTArgs) {
 
         std::map<CoreCoord, std::vector<uint32_t>> core_to_rt_args;
         for (auto core_range : core_range_set.ranges()) {
-            for (auto x = core_range.start_.x; x <= core_range.end_.x; x++) {
-                for (auto y = core_range.start_.y; y <= core_range.end_.y; y++) {
+            for (auto x = core_range.start_coord.x; x <= core_range.end_coord.x; x++) {
+                for (auto y = core_range.start_coord.y; y <= core_range.end_coord.y; y++) {
                     CoreCoord logical_core(x, y);
                     core_to_rt_args[logical_core] = initial_runtime_args;
                 }

--- a/tests/tt_metal/tt_metal/unit_tests/circular_buffer/test_CircularBuffer_allocation.cpp
+++ b/tests/tt_metal/tt_metal/unit_tests/circular_buffer/test_CircularBuffer_allocation.cpp
@@ -21,8 +21,8 @@ void validate_cb_address(Program &program, Device *device, const CoreRangeSet &c
     uint32_t cb_config_buffer_size = NUM_CIRCULAR_BUFFERS * UINT32_WORDS_PER_CIRCULAR_BUFFER_CONFIG * sizeof(uint32_t);
 
     for (const CoreRange &core_range : cr_set.ranges()) {
-        for (auto x = core_range.start_.x; x <= core_range.end_.x; x++) {
-            for (auto y = core_range.start_.y; y <= core_range.end_.y; y++) {
+        for (auto x = core_range.start_coord.x; x <= core_range.end_coord.x; x++) {
+            for (auto y = core_range.start_coord.y; y <= core_range.end_coord.y; y++) {
                 CoreCoord core_coord(x, y);
                 tt::tt_metal::detail::ReadFromDeviceL1(
                     device, core_coord, CIRCULAR_BUFFER_CONFIG_BASE, cb_config_buffer_size, cb_config_vector);
@@ -133,8 +133,8 @@ TEST_F(DeviceFixture, TestValidCircularBufferAddress) {
 
     std::map<CoreCoord, std::map<uint8_t, uint32_t>> golden_addresses_per_core;
     for (const CoreRange &core_range : cr_set.ranges()) {
-        for (auto x = core_range.start_.x; x <= core_range.end_.x; x++) {
-            for (auto y = core_range.start_.y; y <= core_range.end_.y; y++) {
+        for (auto x = core_range.start_coord.x; x <= core_range.end_coord.x; x++) {
+            for (auto y = core_range.start_coord.y; y <= core_range.end_coord.y; y++) {
                     CoreCoord core_coord(x, y);
                     for (uint8_t buffer_index : buffer_indices) {
                         golden_addresses_per_core[core_coord][buffer_index] = expected_cb_addr;
@@ -312,8 +312,8 @@ TEST_F(DeviceFixture, TestUpdateCircularBufferPageSize) {
     uint32_t cb_config_buffer_size = NUM_CIRCULAR_BUFFERS * UINT32_WORDS_PER_CIRCULAR_BUFFER_CONFIG * sizeof(uint32_t);
 
     for (const CoreRange &core_range : cr_set.ranges()) {
-        for (auto x = core_range.start_.x; x <= core_range.end_.x; x++) {
-            for (auto y = core_range.start_.y; y <= core_range.end_.y; y++) {
+        for (auto x = core_range.start_coord.x; x <= core_range.end_coord.x; x++) {
+            for (auto y = core_range.start_coord.y; y <= core_range.end_coord.y; y++) {
                 CoreCoord core_coord(x, y);
                 tt::tt_metal::detail::ReadFromDeviceL1(
                     this->devices_.at(id), core_coord, CIRCULAR_BUFFER_CONFIG_BASE, cb_config_buffer_size, cb_config_vector);
@@ -337,8 +337,8 @@ TEST_F(DeviceFixture, TestUpdateCircularBufferPageSize) {
 
     // addresses should not be changed
     for (const CoreRange &core_range : cr_set.ranges()) {
-        for (auto x = core_range.start_.x; x <= core_range.end_.x; x++) {
-            for (auto y = core_range.start_.y; y <= core_range.end_.y; y++) {
+        for (auto x = core_range.start_coord.x; x <= core_range.end_coord.x; x++) {
+            for (auto y = core_range.start_coord.y; y <= core_range.end_coord.y; y++) {
                 CoreCoord core_coord(x, y);
                 tt::tt_metal::detail::ReadFromDeviceL1(
                     this->devices_.at(id), core_coord, CIRCULAR_BUFFER_CONFIG_BASE, cb_config_buffer_size, cb_config_vector);

--- a/tests/tt_metal/tt_metal/unit_tests/circular_buffer/test_CircularBuffer_allocation.cpp
+++ b/tests/tt_metal/tt_metal/unit_tests/circular_buffer/test_CircularBuffer_allocation.cpp
@@ -21,8 +21,8 @@ void validate_cb_address(Program &program, Device *device, const CoreRangeSet &c
     uint32_t cb_config_buffer_size = NUM_CIRCULAR_BUFFERS * UINT32_WORDS_PER_CIRCULAR_BUFFER_CONFIG * sizeof(uint32_t);
 
     for (const CoreRange &core_range : cr_set.ranges()) {
-        for (auto x = core_range.start.x; x <= core_range.end.x; x++) {
-            for (auto y = core_range.start.y; y <= core_range.end.y; y++) {
+        for (auto x = core_range.start_.x; x <= core_range.end_.x; x++) {
+            for (auto y = core_range.start_.y; y <= core_range.end_.y; y++) {
                 CoreCoord core_coord(x, y);
                 tt::tt_metal::detail::ReadFromDeviceL1(
                     device, core_coord, CIRCULAR_BUFFER_CONFIG_BASE, cb_config_buffer_size, cb_config_vector);
@@ -133,8 +133,8 @@ TEST_F(DeviceFixture, TestValidCircularBufferAddress) {
 
     std::map<CoreCoord, std::map<uint8_t, uint32_t>> golden_addresses_per_core;
     for (const CoreRange &core_range : cr_set.ranges()) {
-        for (auto x = core_range.start.x; x <= core_range.end.x; x++) {
-            for (auto y = core_range.start.y; y <= core_range.end.y; y++) {
+        for (auto x = core_range.start_.x; x <= core_range.end_.x; x++) {
+            for (auto y = core_range.start_.y; y <= core_range.end_.y; y++) {
                     CoreCoord core_coord(x, y);
                     for (uint8_t buffer_index : buffer_indices) {
                         golden_addresses_per_core[core_coord][buffer_index] = expected_cb_addr;
@@ -312,8 +312,8 @@ TEST_F(DeviceFixture, TestUpdateCircularBufferPageSize) {
     uint32_t cb_config_buffer_size = NUM_CIRCULAR_BUFFERS * UINT32_WORDS_PER_CIRCULAR_BUFFER_CONFIG * sizeof(uint32_t);
 
     for (const CoreRange &core_range : cr_set.ranges()) {
-        for (auto x = core_range.start.x; x <= core_range.end.x; x++) {
-            for (auto y = core_range.start.y; y <= core_range.end.y; y++) {
+        for (auto x = core_range.start_.x; x <= core_range.end_.x; x++) {
+            for (auto y = core_range.start_.y; y <= core_range.end_.y; y++) {
                 CoreCoord core_coord(x, y);
                 tt::tt_metal::detail::ReadFromDeviceL1(
                     this->devices_.at(id), core_coord, CIRCULAR_BUFFER_CONFIG_BASE, cb_config_buffer_size, cb_config_vector);
@@ -337,8 +337,8 @@ TEST_F(DeviceFixture, TestUpdateCircularBufferPageSize) {
 
     // addresses should not be changed
     for (const CoreRange &core_range : cr_set.ranges()) {
-        for (auto x = core_range.start.x; x <= core_range.end.x; x++) {
-            for (auto y = core_range.start.y; y <= core_range.end.y; y++) {
+        for (auto x = core_range.start_.x; x <= core_range.end_.x; x++) {
+            for (auto y = core_range.start_.y; y <= core_range.end_.y; y++) {
                 CoreCoord core_coord(x, y);
                 tt::tt_metal::detail::ReadFromDeviceL1(
                     this->devices_.at(id), core_coord, CIRCULAR_BUFFER_CONFIG_BASE, cb_config_buffer_size, cb_config_vector);

--- a/tests/tt_metal/tt_metal/unit_tests/circular_buffer/test_CircularBuffer_creation.cpp
+++ b/tests/tt_metal/tt_metal/unit_tests/circular_buffer/test_CircularBuffer_creation.cpp
@@ -24,8 +24,8 @@ bool test_cb_config_written_to_core(Program &program, Device *device, const Core
 
     for (const auto cb: program.circular_buffers()) {
         for (const CoreRange &core_range : cb->core_ranges().ranges()) {
-            for (auto x = core_range.start.x; x <= core_range.end.x; x++) {
-                for (auto y = core_range.start.y; y <= core_range.end.y; y++) {
+            for (auto x = core_range.start_.x; x <= core_range.end_.x; x++) {
+                for (auto y = core_range.start_.y; y <= core_range.end_.y; y++) {
                     CoreCoord core_coord(x, y);
                     tt::tt_metal::detail::ReadFromDeviceL1(
                         device, core_coord, CIRCULAR_BUFFER_CONFIG_BASE, cb_config_buffer_size, cb_config_vector);

--- a/tests/tt_metal/tt_metal/unit_tests/circular_buffer/test_CircularBuffer_creation.cpp
+++ b/tests/tt_metal/tt_metal/unit_tests/circular_buffer/test_CircularBuffer_creation.cpp
@@ -24,8 +24,8 @@ bool test_cb_config_written_to_core(Program &program, Device *device, const Core
 
     for (const auto cb: program.circular_buffers()) {
         for (const CoreRange &core_range : cb->core_ranges().ranges()) {
-            for (auto x = core_range.start_.x; x <= core_range.end_.x; x++) {
-                for (auto y = core_range.start_.y; y <= core_range.end_.y; y++) {
+            for (auto x = core_range.start_coord.x; x <= core_range.end_coord.x; x++) {
+                for (auto y = core_range.start_coord.y; y <= core_range.end_coord.y; y++) {
                     CoreCoord core_coord(x, y);
                     tt::tt_metal::detail::ReadFromDeviceL1(
                         device, core_coord, CIRCULAR_BUFFER_CONFIG_BASE, cb_config_buffer_size, cb_config_vector);

--- a/tests/tt_metal/tt_metal/unit_tests/common/core_coord_fixture.hpp
+++ b/tests/tt_metal/tt_metal/unit_tests/common/core_coord_fixture.hpp
@@ -24,9 +24,17 @@ class CoreCoordHarness : public ::testing::Test {
     CoreRange cr14 = CoreRange({0, 1}, {1, 1});
     CoreRange cr15 = CoreRange({0, 1}, {0, 2});
     CoreRange cr16 = CoreRange({0, 0}, {1, 2});
+    CoreRange cr17 = CoreRange({2, 3}, {2, 3});
+    CoreRange cr18 = CoreRange({3, 1}, {3, 3});
 
     CoreRange sc1 = CoreRange({1, 1}, {1, 1});
     CoreRange sc2 = CoreRange({0, 1}, {0, 1});
     CoreRange sc3 = CoreRange({0, 2}, {0, 2});
     CoreRange sc4 = CoreRange({1, 2}, {1, 2});
+
+    // CoreRange cr1_iterator = CoreRange({0, 0}, {0, 1}, {1, 0}, {1, 1});
+    // CoreRange cr2_iterator = CoreRange({3, 3}, {3, 4}, {4, 3}, {4, 4}, {5, 3}, {5, 4});
+    // CoreRange cr3_iterator = CoreRange({1, 2}, {2, 2});
+    // CoreRange cr15_iterator = CoreRange({0, 1}, {0, 2});
+    // CoreRange cr17_iterator = CoreRange({2, 3});
 };

--- a/tests/tt_metal/tt_metal/unit_tests/common/core_coord_fixture.hpp
+++ b/tests/tt_metal/tt_metal/unit_tests/common/core_coord_fixture.hpp
@@ -31,10 +31,4 @@ class CoreCoordHarness : public ::testing::Test {
     CoreRange sc2 = CoreRange({0, 1}, {0, 1});
     CoreRange sc3 = CoreRange({0, 2}, {0, 2});
     CoreRange sc4 = CoreRange({1, 2}, {1, 2});
-
-    // CoreRange cr1_iterator = CoreRange({0, 0}, {0, 1}, {1, 0}, {1, 1});
-    // CoreRange cr2_iterator = CoreRange({3, 3}, {3, 4}, {4, 3}, {4, 4}, {5, 3}, {5, 4});
-    // CoreRange cr3_iterator = CoreRange({1, 2}, {2, 2});
-    // CoreRange cr15_iterator = CoreRange({0, 1}, {0, 2});
-    // CoreRange cr17_iterator = CoreRange({2, 3});
 };

--- a/tests/tt_metal/tt_metal/unit_tests/compute/sfpu/sfpu_compute.cpp
+++ b/tests/tt_metal/tt_metal/unit_tests/compute/sfpu/sfpu_compute.cpp
@@ -208,19 +208,11 @@ bool run_sfpu_all_same_buffer(tt_metal::Device* device, const SfpuConfig& test_c
                 .compile_args = compute_kernel_args,
                 .defines = sfpu_defines});
 
-        int chip_id = 0;
-        CoresInCoreRangeGenerator cores_in_core_range(core_range, device->logical_grid_size());
-
-        bool terminate;
-
-        do {
-            auto [core_coord, terminate_] = cores_in_core_range();
-
-            terminate = terminate_;
-
+        for (const CoreCoord& core_coord : core_range)
+        {
             SetRuntimeArgs(program, writer_kernel, core_coord, writer_rt_args);
             SetRuntimeArgs(program, reader_kernel, core_coord, reader_rt_args);
-        } while (not terminate);
+        }
     }
 
     std::vector<uint32_t> dest_buffer_data;

--- a/tests/tt_metal/tt_metal/unit_tests/core_coord/test_CoreRangeSet_merge.cpp
+++ b/tests/tt_metal/tt_metal/unit_tests/core_coord/test_CoreRangeSet_merge.cpp
@@ -26,8 +26,8 @@ TEST_F(CoreCoordHarness, TestCoreRangeSetMergeCoreCoord)
     EXPECT_EQ ( ::CoreRangeSet({cr1}).merge({sc3}).merge({sc4}).ranges() , std::set<::CoreRange>( {cr16}) );
     CoreRange rect ( {0,0}, {4,2});
     std::set<CoreRange> rect_pts;
-    for (unsigned y = rect.start_.y; y <= rect.end_.y; y++){
-        for (unsigned x = rect.start_.x; x <= rect.end_.x; x++){
+    for (unsigned y = rect.start_coord.y; y <= rect.end_coord.y; y++){
+        for (unsigned x = rect.start_coord.x; x <= rect.end_coord.x; x++){
             rect_pts.insert ( CoreRange( {x, y}, {x, y} ) );
         }
     }

--- a/tests/tt_metal/tt_metal/unit_tests/core_coord/test_CoreRangeSet_merge.cpp
+++ b/tests/tt_metal/tt_metal/unit_tests/core_coord/test_CoreRangeSet_merge.cpp
@@ -26,8 +26,8 @@ TEST_F(CoreCoordHarness, TestCoreRangeSetMergeCoreCoord)
     EXPECT_EQ ( ::CoreRangeSet({cr1}).merge({sc3}).merge({sc4}).ranges() , std::set<::CoreRange>( {cr16}) );
     CoreRange rect ( {0,0}, {4,2});
     std::set<CoreRange> rect_pts;
-    for (unsigned y = rect.start.y; y <= rect.end.y; y++){
-        for (unsigned x = rect.start.x; x <= rect.end.x; x++){
+    for (unsigned y = rect.start_.y; y <= rect.end_.y; y++){
+        for (unsigned x = rect.start_.x; x <= rect.end_.x; x++){
             rect_pts.insert ( CoreRange( {x, y}, {x, y} ) );
         }
     }

--- a/tests/tt_metal/tt_metal/unit_tests/core_coord/test_CoreRange_iterator.cpp
+++ b/tests/tt_metal/tt_metal/unit_tests/core_coord/test_CoreRange_iterator.cpp
@@ -11,53 +11,55 @@ namespace basic_tests::CoreRange {
 
 TEST_F(CoreCoordHarness, TestCoreRangeIterator)
 {
+    vector<CoreCoord> cores_in_core_range;
 
-    uint32_t num_cores_iterated = 0;
+    vector<CoreCoord> cores_iterated;
     for (CoreCoord& core : this->cr1)
     {
-        EXPECT_TRUE(this->cr1.contains(core));
-        num_cores_iterated++;
+        cores_iterated.push_back(core);
     }
-    EXPECT_EQ(num_cores_iterated, this->cr1.size());
+    cores_in_core_range = {CoreCoord(0, 0), CoreCoord(1, 0), CoreCoord(0, 1), CoreCoord(1, 1)};
+    EXPECT_EQ(cores_iterated, cores_in_core_range);
 
-    num_cores_iterated = 0;
+    cores_iterated.clear();
     for (CoreCoord& core : this->cr2)
     {
-        EXPECT_TRUE(this->cr2.contains(core));
-        num_cores_iterated++;
+        cores_iterated.push_back(core);
     }
-    EXPECT_EQ(num_cores_iterated, this->cr2.size());
+    cores_in_core_range = {CoreCoord(3, 3), CoreCoord(4, 3), CoreCoord(5, 3),
+                            CoreCoord(3, 4), CoreCoord(4, 4), CoreCoord(5, 4)};
+    EXPECT_EQ(cores_iterated, cores_in_core_range);
 
-    num_cores_iterated = 0;
+    cores_iterated.clear();
     for (CoreCoord& core : this->cr3)
     {
-        EXPECT_TRUE(this->cr3.contains(core));
-        num_cores_iterated++;
+        cores_iterated.push_back(core);
     }
-    EXPECT_EQ(num_cores_iterated, this->cr3.size());
+    cores_in_core_range = {CoreCoord(1, 2), CoreCoord(2, 2)};
+    EXPECT_EQ(cores_iterated, cores_in_core_range);
 
-    num_cores_iterated = 0;
-    for (CoreCoord& core : this->cr5)
+    cores_iterated.clear();
+    for (CoreCoord& core : this->cr15)
     {
-        EXPECT_TRUE(this->cr5.contains(core));
-        num_cores_iterated++;
+        cores_iterated.push_back(core);
     }
-    EXPECT_EQ(num_cores_iterated, this->cr5.size());
+    cores_in_core_range = {CoreCoord(0, 1), CoreCoord(0, 2)};
+    EXPECT_EQ(cores_iterated, cores_in_core_range);
 
-    num_cores_iterated = 0;
+    cores_iterated.clear();
     for (CoreCoord& core : this->cr17)
     {
-        EXPECT_TRUE(this->cr17.contains(core));
-        num_cores_iterated++;
+        cores_iterated.push_back(core);
     }
-    EXPECT_EQ(num_cores_iterated, this->cr17.size());
+    cores_in_core_range = {CoreCoord(2, 3)};
+    EXPECT_EQ(cores_iterated, cores_in_core_range);
 
-    num_cores_iterated = 0;
+    cores_iterated.clear();
     for (CoreCoord& core : this->cr18)
     {
-        EXPECT_TRUE(this->cr18.contains(core));
-        num_cores_iterated++;
+        cores_iterated.push_back(core);
     }
-    EXPECT_EQ(num_cores_iterated, this->cr18.size());
+    cores_in_core_range = {CoreCoord(3, 1), CoreCoord(3, 2), CoreCoord(3, 3)};
+    EXPECT_EQ(cores_iterated, cores_in_core_range);
 }
 }

--- a/tests/tt_metal/tt_metal/unit_tests/core_coord/test_CoreRange_iterator.cpp
+++ b/tests/tt_metal/tt_metal/unit_tests/core_coord/test_CoreRange_iterator.cpp
@@ -1,0 +1,63 @@
+// SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+
+#include "gtest/gtest.h"
+#include "tt_metal/common/core_coord.h"
+#include "core_coord_fixture.hpp"
+
+namespace basic_tests::CoreRange {
+
+TEST_F(CoreCoordHarness, TestCoreRangeIterator)
+{
+
+    uint32_t num_cores_iterated = 0;
+    for (CoreCoord& core : this->cr1)
+    {
+        EXPECT_TRUE(this->cr1.contains(core));
+        num_cores_iterated++;
+    }
+    EXPECT_EQ(num_cores_iterated, this->cr1.size());
+
+    num_cores_iterated = 0;
+    for (CoreCoord& core : this->cr2)
+    {
+        EXPECT_TRUE(this->cr2.contains(core));
+        num_cores_iterated++;
+    }
+    EXPECT_EQ(num_cores_iterated, this->cr2.size());
+
+    num_cores_iterated = 0;
+    for (CoreCoord& core : this->cr3)
+    {
+        EXPECT_TRUE(this->cr3.contains(core));
+        num_cores_iterated++;
+    }
+    EXPECT_EQ(num_cores_iterated, this->cr3.size());
+
+    num_cores_iterated = 0;
+    for (CoreCoord& core : this->cr5)
+    {
+        EXPECT_TRUE(this->cr5.contains(core));
+        num_cores_iterated++;
+    }
+    EXPECT_EQ(num_cores_iterated, this->cr5.size());
+
+    num_cores_iterated = 0;
+    for (CoreCoord& core : this->cr17)
+    {
+        EXPECT_TRUE(this->cr17.contains(core));
+        num_cores_iterated++;
+    }
+    EXPECT_EQ(num_cores_iterated, this->cr17.size());
+
+    num_cores_iterated = 0;
+    for (CoreCoord& core : this->cr18)
+    {
+        EXPECT_TRUE(this->cr18.contains(core));
+        num_cores_iterated++;
+    }
+    EXPECT_EQ(num_cores_iterated, this->cr18.size());
+}
+}

--- a/tests/tt_metal/tt_metal/unit_tests_fast_dispatch/command_queue/test_EnqueueProgram.cpp
+++ b/tests/tt_metal/tt_metal/unit_tests_fast_dispatch/command_queue/test_EnqueueProgram.cpp
@@ -611,8 +611,8 @@ bool test_increment_runtime_args_sanity(Device* device, const DummyProgramConfig
     constexpr uint32_t unique_arg_incr_val = 10;
     constexpr uint32_t common_arg_incr_val = 100;
     for (auto &core_range : kernel->logical_coreranges()) {
-        for (auto x = core_range.start_.x; x <= core_range.end_.x; x++) {
-            for (auto y = core_range.start_.y; y <= core_range.end_.y; y++) {
+        for (auto x = core_range.start_coord.x; x <= core_range.end_coord.x; x++) {
+            for (auto y = core_range.start_coord.y; y <= core_range.end_coord.y; y++) {
                 CoreCoord core_coord(x, y);
                 pass &= verify_rt_args(true, device, core_coord, riscv, unique_args_addr, unique_runtime_args, unique_arg_incr_val);
                 pass &= verify_rt_args(false, device, core_coord, riscv, common_args_addr, common_runtime_args, common_arg_incr_val);

--- a/tests/tt_metal/tt_metal/unit_tests_fast_dispatch/compute/sfpu/sfpu_compute.cpp
+++ b/tests/tt_metal/tt_metal/unit_tests_fast_dispatch/compute/sfpu/sfpu_compute.cpp
@@ -207,19 +207,13 @@ bool run_sfpu_all_same_buffer(CommandQueue & cq, const SfpuConfig& test_config) 
                 .defines = sfpu_defines});
 
         int chip_id = 0;
-        CoresInCoreRangeGenerator cores_in_core_range(core_range, cq.device()->logical_grid_size());
-
-        bool terminate;
 
         // TODO(agrebenisan): Clean this up to only use the first path once Enqueue apis supported on WH
-        do {
-            auto [core_coord, terminate_] = cores_in_core_range();
-
-            terminate = terminate_;
-
+        for (const CoreCoord& core_coord : core_range)
+        {
             SetRuntimeArgs(program, writer_kernel, core_coord, writer_rt_args);
             SetRuntimeArgs(program, reader_kernel, core_coord, reader_rt_args);
-        } while (not terminate);
+        }
     }
 
     std::vector<uint32_t> dest_buffer_data;

--- a/tests/tt_metal/tt_metal/unit_tests_frequent/tests/run_many_times.cpp
+++ b/tests/tt_metal/tt_metal/unit_tests_frequent/tests/run_many_times.cpp
@@ -51,7 +51,7 @@ void RunTest(Device *device) {
         return (uint32_t) core.y * 100 * multiplier;
     };
     for (auto &core_range : core_ranges) {
-        CoreCoord core = core_range.start;
+        CoreCoord core = core_range.start_;
         std::vector<uint32_t> brisc_rt_args = {
             get_first_arg(device, core, 1),
             get_second_arg(device, core, 1)
@@ -77,7 +77,7 @@ void RunTest(Device *device) {
 
     // Check results
     for (auto &core_range : core_ranges) {
-        CoreCoord core = core_range.start;
+        CoreCoord core = core_range.start_;
         std::vector<uint32_t> brisc_result;
         tt_metal::detail::ReadFromDeviceL1(
             device, core, L1_UNRESERVED_BASE, sizeof(uint32_t), brisc_result

--- a/tests/tt_metal/tt_metal/unit_tests_frequent/tests/run_many_times.cpp
+++ b/tests/tt_metal/tt_metal/unit_tests_frequent/tests/run_many_times.cpp
@@ -51,7 +51,7 @@ void RunTest(Device *device) {
         return (uint32_t) core.y * 100 * multiplier;
     };
     for (auto &core_range : core_ranges) {
-        CoreCoord core = core_range.start_;
+        CoreCoord core = core_range.start_coord;
         std::vector<uint32_t> brisc_rt_args = {
             get_first_arg(device, core, 1),
             get_second_arg(device, core, 1)
@@ -77,7 +77,7 @@ void RunTest(Device *device) {
 
     // Check results
     for (auto &core_range : core_ranges) {
-        CoreCoord core = core_range.start_;
+        CoreCoord core = core_range.start_coord;
         std::vector<uint32_t> brisc_result;
         tt_metal::detail::ReadFromDeviceL1(
             device, core, L1_UNRESERVED_BASE, sizeof(uint32_t), brisc_result

--- a/tt_metal/common/core_coord.h
+++ b/tt_metal/common/core_coord.h
@@ -198,7 +198,8 @@ struct CoreRange {
 
     CoreIterator end() const
     {
-        return CoreIterator(this->end_, *this);
+        const CoreCoord iterator_end(this->start_.x, this->end_.y + 1);
+        return CoreIterator(iterator_end, *this);
     }
 };
 

--- a/tt_metal/common/core_coord.h
+++ b/tt_metal/common/core_coord.h
@@ -578,7 +578,7 @@ struct from_json_t<RelativeCoreCoord> {
 template <>
 struct to_json_t<CoreRange> {
     nlohmann::json operator()(const CoreRange &core_range) noexcept {
-        return {{"start", to_json(core_range.start)}, {"end", to_json(core_range.end)}};
+        return {{"start", to_json(core_range.start_)}, {"end", to_json(core_range.end_)}};
     }
 };
 

--- a/tt_metal/common/core_coord.h
+++ b/tt_metal/common/core_coord.h
@@ -66,19 +66,20 @@ inline CoreCoord get_core_coord_from_relative(const RelativeCoreCoord &in, const
 }
 
 struct CoreRange {
-    CoreCoord start_;
-    CoreCoord end_;
+    CoreCoord start_coord;
+    CoreCoord end_coord;
     CoreRange(const CoreCoord &point) {
-        this->start_ = point;
-        this->end_ = point;
+        this->start_coord = point;
+        this->end_coord = point;
     }
 
-    CoreRange(const CoreCoord &start, const CoreCoord &end) {
+    CoreRange(const CoreCoord &start_coord, const CoreCoord &end_coord) {
         TT_ASSERT(
-            end.x >= start.x and end.y >= start.y, "Invalid core range for start: {}, end: {}", start.str(), end.str());
+            end_coord.x >= start_coord.x and end_coord.y >= start_coord.y,
+            "Invalid core range for start_coord: {}, end_coord: {}", start_coord.str(), end_coord.str());
 
-        this->start_ = start;
-        this->end_ = end;
+        this->start_coord = start_coord;
+        this->end_coord = end_coord;
     }
 
     CoreRange(const CoreRange &other) = default;
@@ -86,16 +87,17 @@ struct CoreRange {
     CoreRange(CoreRange &&other) = default;
     CoreRange &operator=(CoreRange &&other) = default;
 
-    void validate() {
-        TT_FATAL(
-            end_.x >= start_.x and end_.y >= start_.y, "Invalid core range for start: {}, end: {}", start_.str(), end_.str());
-    }
+    // void validate() {
+    //     TT_FATAL(
+    //         end_coord.x >= start_coord.x and end_coord.y >= start_coord.y,
+    //         "Invalid core range for start_coord: {}, end_coord: {}", start_coord.str(), end_coord.str());
+    // }
 
     inline std::optional<CoreRange> intersects(const CoreRange &other) const {
-        std::size_t x1 = std::max(this->start_.x, other.start_.x);
-        std::size_t y1 = std::max(this->start_.y, other.start_.y);
-        std::size_t x2 = std::min(this->end_.x, other.end_.x);
-        std::size_t y2 = std::min(this->end_.y, other.end_.y);
+        std::size_t x1 = std::max(this->start_coord.x, other.start_coord.x);
+        std::size_t y1 = std::max(this->start_coord.y, other.start_coord.y);
+        std::size_t x2 = std::min(this->end_coord.x, other.end_coord.x);
+        std::size_t y2 = std::min(this->end_coord.y, other.end_coord.y);
         if (x1 <= x2 and y1 <= y2)
             return CoreRange({x1, y1}, {x2, y2});
 
@@ -103,44 +105,44 @@ struct CoreRange {
     }
 
     inline bool adjacent(const CoreRange &other) const {
-        std::size_t x1 = std::max(this->start_.x, other.start_.x);
-        std::size_t y1 = std::max(this->start_.y, other.start_.y);
-        std::size_t x2 = std::min(this->end_.x, other.end_.x);
-        std::size_t y2 = std::min(this->end_.y, other.end_.y);
+        std::size_t x1 = std::max(this->start_coord.x, other.start_coord.x);
+        std::size_t y1 = std::max(this->start_coord.y, other.start_coord.y);
+        std::size_t x2 = std::min(this->end_coord.x, other.end_coord.x);
+        std::size_t y2 = std::min(this->end_coord.y, other.end_coord.y);
         return ((x2 + 1 == x1 && y1 <= y2) || (y2 + 1 == y1 && x1 <= x2));
     }
 
     inline bool contains(const CoreRange &other) const {
-        return (other.start_.x >= this->start_.x) && (other.end_.x <= this->end_.x) && (other.start_.y >= this->start_.y) &&
-               (other.end_.y <= this->end_.y);
+        return (other.start_coord.x >= this->start_coord.x) && (other.end_coord.x <= this->end_coord.x) && (other.start_coord.y >= this->start_coord.y) &&
+               (other.end_coord.y <= this->end_coord.y);
     }
 
     inline bool contains(const CoreCoord &other) const {
-        return (other.x >= this->start_.x) && (other.x <= this->end_.x) && (other.y >= this->start_.y) &&
-               (other.y <= this->end_.y);
+        return (other.x >= this->start_coord.x) && (other.x <= this->end_coord.x) && (other.y >= this->start_coord.y) &&
+               (other.y <= this->end_coord.y);
     }
 
     // Merge lined-up (in x or y dimension) intersecting/adjacent rectangles
     std::optional<CoreRange> merge(const CoreRange &cr) const {
         if (this->intersects(cr) || this->adjacent(cr)) {
-            if (this->start_.x == cr.start_.x && this->end_.x == cr.end_.x)
+            if (this->start_coord.x == cr.start_coord.x && this->end_coord.x == cr.end_coord.x)
                 return CoreRange(
-                    {this->start_.x, std::min(this->start_.y, cr.start_.y)},
-                    {this->end_.x, std::max(this->end_.y, cr.end_.y)});
+                    {this->start_coord.x, std::min(this->start_coord.y, cr.start_coord.y)},
+                    {this->end_coord.x, std::max(this->end_coord.y, cr.end_coord.y)});
 
-            else if (this->start_.y == cr.start_.y && this->end_.y == cr.end_.y)
+            else if (this->start_coord.y == cr.start_coord.y && this->end_coord.y == cr.end_coord.y)
                 return CoreRange(
-                    {std::min(this->start_.x, cr.start_.x), this->start_.y},
-                    {std::max(this->end_.x, cr.end_.x), this->end_.y});
+                    {std::min(this->start_coord.x, cr.start_coord.x), this->start_coord.y},
+                    {std::max(this->end_coord.x, cr.end_coord.x), this->end_coord.y});
         }
         return std::nullopt;
     }
 
-    std::string str() const { return "[" + start_.str() + " - " + end_.str() + "]"; }
+    std::string str() const { return "[" + this->start_coord.str() + " - " + this->end_coord.str() + "]"; }
 
-    size_t size() const { return (this->end_.x - this->start_.x + 1) * (this->end_.y - this->start_.y + 1); }
+    size_t size() const { return (this->end_coord.x - this->start_coord.x + 1) * (this->end_coord.y - this->start_coord.y + 1); }
 
-    CoreCoord grid_size() const { return {this->end_.x - this->start_.x + 1, this->end_.y - this->start_.y + 1}; }
+    CoreCoord grid_size() const { return {this->end_coord.x - this->start_coord.x + 1, this->end_coord.y - this->start_coord.y + 1}; }
 
     class CoreIterator
     {
@@ -159,11 +161,11 @@ struct CoreRange {
         {
             CoreCoord next;
 
-            const bool is_curr_core_at_end_of_row = current_.x == range_.end_.x;
+            const bool is_curr_core_at_end_of_row = current_.x == range_.end_coord.x;
             if (is_curr_core_at_end_of_row)
             {
                 // Go to the beginning of the next row
-                next.x = range_.start_.x;
+                next.x = range_.start_coord.x;
                 next.y = current_.y + 1;
             }
             else
@@ -193,24 +195,24 @@ struct CoreRange {
 
     CoreIterator begin() const
     {
-        return CoreIterator(this->start_, *this);
+        return CoreIterator(this->start_coord, *this);
     }
 
     CoreIterator end() const
     {
-        const CoreCoord iterator_end(this->start_.x, this->end_.y + 1);
+        const CoreCoord iterator_end(this->start_coord.x, this->end_coord.y + 1);
         return CoreIterator(iterator_end, *this);
     }
 };
 
 constexpr inline bool operator==(const CoreRange &a, const CoreRange &b) {
-    return a.start_ == b.start_ && a.end_ == b.end_;
+    return a.start_coord == b.start_coord && a.end_coord == b.end_coord;
 }
 
 constexpr inline bool operator!=(const CoreRange &a, const CoreRange &b) { return !(a == b); }
 
 constexpr inline bool operator<(const CoreRange &left, const CoreRange &right) {
-    return (left.start_ < right.start_ || (left.start_ == right.start_ && left.end_ < right.end_));
+    return (left.start_coord < right.start_coord || (left.start_coord == right.start_coord && left.end_coord < right.end_coord));
 }
 
 template <>
@@ -229,8 +231,8 @@ template <>
 struct hash<CoreRange> {
     std::size_t operator()(const CoreRange &core_range) const {
         std::size_t seed = 0;
-        seed = std::hash<CoreCoord>{}(core_range.start_) + 0x9e3779b9 + (seed << 6) + (seed >> 2);
-        seed = std::hash<CoreCoord>{}(core_range.end_) + 0x9e3779b9 + (seed << 6) + (seed >> 2);
+        seed = std::hash<CoreCoord>{}(core_range.start_coord) + 0x9e3779b9 + (seed << 6) + (seed >> 2);
+        seed = std::hash<CoreCoord>{}(core_range.end_coord) + 0x9e3779b9 + (seed << 6) + (seed >> 2);
         return seed;
     }
 };
@@ -247,10 +249,10 @@ class CoreRangeSet {
                 }
                 CoreRange first_core_range = *outer_it;
                 CoreRange second_core_range = *inner_it;
-                bool first_core_left_of_second = first_core_range.end_.x < second_core_range.start_.x;
-                bool first_core_right_of_second = first_core_range.start_.x > second_core_range.end_.x;
-                bool first_core_above_second = first_core_range.end_.y < second_core_range.start_.y;
-                bool first_core_below_second = first_core_range.start_.y > second_core_range.end_.y;
+                bool first_core_left_of_second = first_core_range.end_coord.x < second_core_range.start_coord.x;
+                bool first_core_right_of_second = first_core_range.start_coord.x > second_core_range.end_coord.x;
+                bool first_core_above_second = first_core_range.end_coord.y < second_core_range.start_coord.y;
+                bool first_core_below_second = first_core_range.start_coord.y > second_core_range.end_coord.y;
                 auto no_overlap = first_core_left_of_second or first_core_right_of_second or first_core_above_second or
                                   first_core_below_second;
                 if (not no_overlap) {
@@ -278,10 +280,10 @@ class CoreRangeSet {
 
         for (const auto &cr : crs) {
             // std::cout << "merging " << cr.str() << std::endl;
-            min_x = std::min(min_x, cr.start_.x);
-            max_x = std::max(max_x, cr.end_.x);
-            min_y = std::min(min_y, cr.start_.y);
-            max_y = std::max(max_y, cr.end_.y);
+            min_x = std::min(min_x, cr.start_coord.x);
+            max_x = std::max(max_x, cr.end_coord.x);
+            min_y = std::min(min_y, cr.start_coord.y);
+            max_y = std::max(max_y, cr.end_coord.y);
         }
 
         // By overallocating by one x entry, we can avoid needing to check for
@@ -291,8 +293,8 @@ class CoreRangeSet {
         memset(grid, 0, sizeof(grid));
 
         for (const auto &cr : crs)
-            for (unsigned y = cr.start_.y; y <= cr.end_.y; y++)
-                for (unsigned x = cr.start_.x; x <= cr.end_.x; x++) grid[y][x] = true;
+            for (unsigned y = cr.start_coord.y; y <= cr.end_coord.y; y++)
+                for (unsigned x = cr.start_coord.x; x <= cr.end_coord.x; x++) grid[y][x] = true;
 
         crs.clear();
         for (unsigned y = min_y; y <= max_y; y++) {
@@ -381,10 +383,10 @@ class CoreRangeSet {
         TT_FATAL(this->ranges().size() > 0, "Cannot get bounding_box of an empty CoreRangeSet!");
         size_t min_x = UINT32_MAX, min_y = UINT32_MAX, max_x = 0, max_y = 0;
         for (const auto &cr : this->ranges()) {
-            min_x = std::min(min_x, cr.start_.x);
-            max_x = std::max(max_x, cr.end_.x);
-            min_y = std::min(min_y, cr.start_.y);
-            max_y = std::max(max_y, cr.end_.y);
+            min_x = std::min(min_x, cr.start_coord.x);
+            max_x = std::max(max_x, cr.end_coord.x);
+            min_y = std::min(min_y, cr.start_coord.y);
+            max_y = std::max(max_y, cr.end_coord.y);
         }
         return {{min_x, min_y}, {max_x, max_y}};
     }
@@ -501,8 +503,8 @@ inline std::vector<CoreCoord> corerange_to_cores(
     uint32_t offset = 0;
 
     for (auto core_range : crs.ranges()) {
-        auto start_coord = core_range.start_;
-        auto end_coord = core_range.end_;
+        auto start_coord = core_range.start_coord;
+        auto end_coord = core_range.end_coord;
         auto cores = grid_to_cores(start_coord, end_coord, row_wise);
         if (max_cores.has_value()) {
             if (all_cores.size() + cores.size() > max_cores.value()) {
@@ -578,7 +580,7 @@ struct from_json_t<RelativeCoreCoord> {
 template <>
 struct to_json_t<CoreRange> {
     nlohmann::json operator()(const CoreRange &core_range) noexcept {
-        return {{"start", to_json(core_range.start_)}, {"end", to_json(core_range.end_)}};
+        return {{"start", to_json(core_range.start_coord)}, {"end", to_json(core_range.end_coord)}};
     }
 };
 

--- a/tt_metal/detail/tt_metal.hpp
+++ b/tt_metal/detail/tt_metal.hpp
@@ -433,8 +433,8 @@ namespace tt::tt_metal{
             };
 
             for (const auto &core_range : core_ranges.ranges()) {
-                for (auto x = core_range.start_.x; x <= core_range.end_.x; x++) {
-                    for (auto y = core_range.start_.y; y <= core_range.end_.y; y++) {
+                for (auto x = core_range.start_coord.x; x <= core_range.end_coord.x; x++) {
+                    for (auto y = core_range.start_coord.y; y <= core_range.end_coord.y; y++) {
                         const KernelGroup * kernel_group = program.kernels_on_core(CoreCoord(x, y), CoreType::WORKER);
                         if (kernel_group != nullptr) {
                             bool local_noc0_in_use = false; bool local_noc1_in_use = false;

--- a/tt_metal/detail/tt_metal.hpp
+++ b/tt_metal/detail/tt_metal.hpp
@@ -433,8 +433,8 @@ namespace tt::tt_metal{
             };
 
             for (const auto &core_range : core_ranges.ranges()) {
-                for (auto x = core_range.start.x; x <= core_range.end.x; x++) {
-                    for (auto y = core_range.start.y; y <= core_range.end.y; y++) {
+                for (auto x = core_range.start_.x; x <= core_range.end_.x; x++) {
+                    for (auto y = core_range.start_.y; y <= core_range.end_.y; y++) {
                         const KernelGroup * kernel_group = program.kernels_on_core(CoreCoord(x, y), CoreType::WORKER);
                         if (kernel_group != nullptr) {
                             bool local_noc0_in_use = false; bool local_noc1_in_use = false;

--- a/tt_metal/impl/device/device.cpp
+++ b/tt_metal/impl/device/device.cpp
@@ -2080,17 +2080,17 @@ uint32_t Device::get_noc_multicast_encoding(uint8_t noc_index, const CoreRange& 
     // NOC 1 mcasts from bottom left to top right, so we need to reverse the coords
     if (noc_index == 0) {
         return NOC_MULTICAST_ENCODING(
-            NOC_0_X(noc_index, grid_size.x, physical_cores.start.x),
-            NOC_0_Y(noc_index, grid_size.y, physical_cores.start.y),
-            NOC_0_X(noc_index, grid_size.x, physical_cores.end.x),
-            NOC_0_Y(noc_index, grid_size.y, physical_cores.end.y)
+            NOC_0_X(noc_index, grid_size.x, physical_cores.start_.x),
+            NOC_0_Y(noc_index, grid_size.y, physical_cores.start_.y),
+            NOC_0_X(noc_index, grid_size.x, physical_cores.end_.x),
+            NOC_0_Y(noc_index, grid_size.y, physical_cores.end_.y)
         );
     } else {
         return NOC_MULTICAST_ENCODING(
-            NOC_0_X(noc_index, grid_size.x, physical_cores.end.x),
-            NOC_0_Y(noc_index, grid_size.y, physical_cores.end.y),
-            NOC_0_X(noc_index, grid_size.x, physical_cores.start.x),
-            NOC_0_Y(noc_index, grid_size.y, physical_cores.start.y)
+            NOC_0_X(noc_index, grid_size.x, physical_cores.end_.x),
+            NOC_0_Y(noc_index, grid_size.y, physical_cores.end_.y),
+            NOC_0_X(noc_index, grid_size.x, physical_cores.start_.x),
+            NOC_0_Y(noc_index, grid_size.y, physical_cores.start_.y)
         );
     }
 }

--- a/tt_metal/impl/device/device.cpp
+++ b/tt_metal/impl/device/device.cpp
@@ -2080,17 +2080,17 @@ uint32_t Device::get_noc_multicast_encoding(uint8_t noc_index, const CoreRange& 
     // NOC 1 mcasts from bottom left to top right, so we need to reverse the coords
     if (noc_index == 0) {
         return NOC_MULTICAST_ENCODING(
-            NOC_0_X(noc_index, grid_size.x, physical_cores.start_.x),
-            NOC_0_Y(noc_index, grid_size.y, physical_cores.start_.y),
-            NOC_0_X(noc_index, grid_size.x, physical_cores.end_.x),
-            NOC_0_Y(noc_index, grid_size.y, physical_cores.end_.y)
+            NOC_0_X(noc_index, grid_size.x, physical_cores.start_coord.x),
+            NOC_0_Y(noc_index, grid_size.y, physical_cores.start_coord.y),
+            NOC_0_X(noc_index, grid_size.x, physical_cores.end_coord.x),
+            NOC_0_Y(noc_index, grid_size.y, physical_cores.end_coord.y)
         );
     } else {
         return NOC_MULTICAST_ENCODING(
-            NOC_0_X(noc_index, grid_size.x, physical_cores.end_.x),
-            NOC_0_Y(noc_index, grid_size.y, physical_cores.end_.y),
-            NOC_0_X(noc_index, grid_size.x, physical_cores.start_.x),
-            NOC_0_Y(noc_index, grid_size.y, physical_cores.start_.y)
+            NOC_0_X(noc_index, grid_size.x, physical_cores.end_coord.x),
+            NOC_0_Y(noc_index, grid_size.y, physical_cores.end_coord.y),
+            NOC_0_X(noc_index, grid_size.x, physical_cores.start_coord.x),
+            NOC_0_Y(noc_index, grid_size.y, physical_cores.start_coord.y)
         );
     }
 }

--- a/tt_metal/impl/dispatch/command_queue.cpp
+++ b/tt_metal/impl/dispatch/command_queue.cpp
@@ -505,9 +505,9 @@ void EnqueueProgramCommand::assemble_runtime_args_commands() {
     for (CoreType core_type : core_types) {
         for (auto& kg : program.get_kernel_groups(core_type)) {
             if (kg.total_rta_size != 0) {
-                for (const CoreRange& core_range : kg.core_ranges.ranges()) {
-                    for (auto x = core_range.start.x; x <= core_range.end.x; x++) {
-                        for (auto y = core_range.start.y; y <= core_range.end.y; y++) {
+                for (const CoreRange &core_range : kg.core_ranges.ranges()) {
+                    for (auto x = core_range.start_.x; x <= core_range.end_.x; x++) {
+                        for (auto y = core_range.start_.y; y <= core_range.end_.y; y++) {
                             CoreCoord core_coord(x, y);
 
                             unique_rt_args_data.resize(unique_rt_args_data.size() + 1);
@@ -751,8 +751,8 @@ void EnqueueProgramCommand::assemble_device_commands() {
             uint32_t i = 0;
             uint32_t max_overall_base_index = 0;
             for (const CoreRange& core_range : circular_buffers_unique_coreranges) {
-                const CoreCoord physical_start = device->worker_core_from_logical_core(core_range.start);
-                const CoreCoord physical_end = device->worker_core_from_logical_core(core_range.end);
+                const CoreCoord physical_start = device->worker_core_from_logical_core(core_range.start_);
+                const CoreCoord physical_end = device->worker_core_from_logical_core(core_range.end_);
 
                 const uint32_t num_receivers = core_range.size();
                 auto& cb_config_payload = cb_config_payloads[i];
@@ -935,9 +935,9 @@ void EnqueueProgramCommand::assemble_device_commands() {
             const void* launch_message_data = (const void*)(&kernel_group.launch_msg);
             for (const CoreRange& core_range : kernel_group.core_ranges.ranges()) {
                 CoreCoord physical_start =
-                    device->physical_core_from_logical_core(core_range.start, kernel_group.get_core_type());
+                    device->physical_core_from_logical_core(core_range.start_, kernel_group.get_core_type());
                 CoreCoord physical_end =
-                    device->physical_core_from_logical_core(core_range.end, kernel_group.get_core_type());
+                    device->physical_core_from_logical_core(core_range.end_, kernel_group.get_core_type());
 
                 multicast_go_signal_sub_cmds.emplace_back(CQDispatchWritePackedMulticastSubCmd{
                     .noc_xy_addr = this->device->get_noc_multicast_encoding(
@@ -961,8 +961,8 @@ void EnqueueProgramCommand::assemble_device_commands() {
             kernel_group.launch_msg.kernel_config.dispatch_core_y = this->dispatch_core.y;
             const void* launch_message_data = (const launch_msg_t*)(&kernel_group.launch_msg);
             for (const CoreRange& core_range : kernel_group.core_ranges.ranges()) {
-                for (auto x = core_range.start.x; x <= core_range.end.x; x++) {
-                    for (auto y = core_range.start.y; y <= core_range.end.y; y++) {
+                for (auto x = core_range.start_.x; x <= core_range.end_.x; x++) {
+                    for (auto y = core_range.start_.y; y <= core_range.end_.y; y++) {
                         CoreCoord physical_coord =
                             device->physical_core_from_logical_core(CoreCoord({x, y}), kernel_group.get_core_type());
                         unicast_go_signal_sub_cmds.emplace_back(CQDispatchWritePackedUnicastSubCmd{

--- a/tt_metal/impl/dispatch/command_queue.cpp
+++ b/tt_metal/impl/dispatch/command_queue.cpp
@@ -506,8 +506,8 @@ void EnqueueProgramCommand::assemble_runtime_args_commands() {
         for (auto& kg : program.get_kernel_groups(core_type)) {
             if (kg.total_rta_size != 0) {
                 for (const CoreRange &core_range : kg.core_ranges.ranges()) {
-                    for (auto x = core_range.start_.x; x <= core_range.end_.x; x++) {
-                        for (auto y = core_range.start_.y; y <= core_range.end_.y; y++) {
+                    for (auto x = core_range.start_coord.x; x <= core_range.end_coord.x; x++) {
+                        for (auto y = core_range.start_coord.y; y <= core_range.end_coord.y; y++) {
                             CoreCoord core_coord(x, y);
 
                             unique_rt_args_data.resize(unique_rt_args_data.size() + 1);
@@ -751,8 +751,8 @@ void EnqueueProgramCommand::assemble_device_commands() {
             uint32_t i = 0;
             uint32_t max_overall_base_index = 0;
             for (const CoreRange& core_range : circular_buffers_unique_coreranges) {
-                const CoreCoord physical_start = device->worker_core_from_logical_core(core_range.start_);
-                const CoreCoord physical_end = device->worker_core_from_logical_core(core_range.end_);
+                const CoreCoord physical_start = device->worker_core_from_logical_core(core_range.start_coord);
+                const CoreCoord physical_end = device->worker_core_from_logical_core(core_range.end_coord);
 
                 const uint32_t num_receivers = core_range.size();
                 auto& cb_config_payload = cb_config_payloads[i];
@@ -935,9 +935,9 @@ void EnqueueProgramCommand::assemble_device_commands() {
             const void* launch_message_data = (const void*)(&kernel_group.launch_msg);
             for (const CoreRange& core_range : kernel_group.core_ranges.ranges()) {
                 CoreCoord physical_start =
-                    device->physical_core_from_logical_core(core_range.start_, kernel_group.get_core_type());
+                    device->physical_core_from_logical_core(core_range.start_coord, kernel_group.get_core_type());
                 CoreCoord physical_end =
-                    device->physical_core_from_logical_core(core_range.end_, kernel_group.get_core_type());
+                    device->physical_core_from_logical_core(core_range.end_coord, kernel_group.get_core_type());
 
                 multicast_go_signal_sub_cmds.emplace_back(CQDispatchWritePackedMulticastSubCmd{
                     .noc_xy_addr = this->device->get_noc_multicast_encoding(
@@ -961,8 +961,8 @@ void EnqueueProgramCommand::assemble_device_commands() {
             kernel_group.launch_msg.kernel_config.dispatch_core_y = this->dispatch_core.y;
             const void* launch_message_data = (const launch_msg_t*)(&kernel_group.launch_msg);
             for (const CoreRange& core_range : kernel_group.core_ranges.ranges()) {
-                for (auto x = core_range.start_.x; x <= core_range.end_.x; x++) {
-                    for (auto y = core_range.start_.y; y <= core_range.end_.y; y++) {
+                for (auto x = core_range.start_coord.x; x <= core_range.end_coord.x; x++) {
+                    for (auto y = core_range.start_coord.y; y <= core_range.end_coord.y; y++) {
                         CoreCoord physical_coord =
                             device->physical_core_from_logical_core(CoreCoord({x, y}), kernel_group.get_core_type());
                         unicast_go_signal_sub_cmds.emplace_back(CQDispatchWritePackedUnicastSubCmd{

--- a/tt_metal/impl/kernels/kernel.cpp
+++ b/tt_metal/impl/kernels/kernel.cpp
@@ -36,8 +36,8 @@ Kernel::Kernel(
 
     size_t max_x = 0, max_y = 0;
     for (auto core_range : this->core_range_set_.ranges()) {
-        auto start = core_range.start_;
-        auto end = core_range.end_;
+        auto start = core_range.start_coord;
+        auto end = core_range.end_coord;
         for (auto x = start.x; x <= end.x; x++) {
             for (auto y = start.y; y <= end.y; y++) {
                 CoreCoord logical_core({x, y});
@@ -260,8 +260,8 @@ void Kernel::set_common_runtime_args(const std::vector<uint32_t> &common_runtime
 void Kernel::set_runtime_args_count(CoreRangeSet& core_ranges, uint32_t count) {
 
     for (const CoreRange &core_range : core_ranges.ranges()) {
-        for (auto x = core_range.start_.x; x <= core_range.end_.x; x++) {
-            for (auto y = core_range.start_.y; y <= core_range.end_.y; y++) {
+        for (auto x = core_range.start_coord.x; x <= core_range.end_coord.x; x++) {
+            for (auto y = core_range.start_coord.y; y <= core_range.end_coord.y; y++) {
                 auto &set_rt_args = this->core_to_runtime_args_[x][y];
                 if (set_rt_args.empty()) continue;
 

--- a/tt_metal/impl/kernels/kernel.cpp
+++ b/tt_metal/impl/kernels/kernel.cpp
@@ -36,8 +36,8 @@ Kernel::Kernel(
 
     size_t max_x = 0, max_y = 0;
     for (auto core_range : this->core_range_set_.ranges()) {
-        auto start = core_range.start;
-        auto end = core_range.end;
+        auto start = core_range.start_;
+        auto end = core_range.end_;
         for (auto x = start.x; x <= end.x; x++) {
             for (auto y = start.y; y <= end.y; y++) {
                 CoreCoord logical_core({x, y});
@@ -260,8 +260,8 @@ void Kernel::set_common_runtime_args(const std::vector<uint32_t> &common_runtime
 void Kernel::set_runtime_args_count(CoreRangeSet& core_ranges, uint32_t count) {
 
     for (const CoreRange &core_range : core_ranges.ranges()) {
-        for (auto x = core_range.start.x; x <= core_range.end.x; x++) {
-            for (auto y = core_range.start.y; y <= core_range.end.y; y++) {
+        for (auto x = core_range.start_.x; x <= core_range.end_.x; x++) {
+            for (auto y = core_range.start_.y; y <= core_range.end_.y; y++) {
                 auto &set_rt_args = this->core_to_runtime_args_[x][y];
                 if (set_rt_args.empty()) continue;
 

--- a/tt_metal/impl/program/program.cpp
+++ b/tt_metal/impl/program/program.cpp
@@ -272,8 +272,8 @@ void Program::update_kernel_groups(const CoreType &core_type) {
 
             // Map from core X,Y back to the unique KernelGroup
             for (CoreRange range : kg_to_cores.second) {
-                for (auto y = range.start_.y; y <= range.end_.y; y++) {
-                    for (auto x = range.start_.x; x <= range.end_.x; x++) {
+                for (auto y = range.start_coord.y; y <= range.end_coord.y; y++) {
+                    for (auto x = range.start_coord.x; x <= range.end_coord.x; x++) {
                         core_to_kernel_group_index_table_[core_type][y * grid_extent_[core_type].x + x] = index;
 
                         auto val = per_core_cb_indices_.find(CoreCoord({x, y}));
@@ -330,8 +330,8 @@ CBHandle Program::add_circular_buffer(const CoreRangeSet &core_range_set, const 
     }
     // Mark which buffer indices are being used on each core the circular buffer is used on
     for (const CoreRange &core_range : core_range_set.ranges()) {
-        for (auto x = core_range.start_.x; x <= core_range.end_.x; x++) {
-            for (auto y = core_range.start_.y; y <= core_range.end_.y; y++) {
+        for (auto x = core_range.start_coord.x; x <= core_range.end_coord.x; x++) {
+            for (auto y = core_range.start_coord.y; y <= core_range.end_coord.y; y++) {
                 CoreCoord logical_core(x, y);
                 std::bitset<NUM_CIRCULAR_BUFFERS> &cb_indices = this->per_core_cb_indices_[logical_core];
 
@@ -578,8 +578,8 @@ void Program::populate_dispatch_data(Device *device) {
         // This API extracts all the pairs of noc multicast encodings given a set of core ranges
         vector<pair<transfer_info_cores, uint32_t>> dst_noc_unicast_info;
         for (const CoreRange &core_range : ranges) {
-            for (auto x = core_range.start_.x; x <= core_range.end_.x; x++) {
-                for (auto y = core_range.start_.y; y <= core_range.end_.y; y++) {
+            for (auto x = core_range.start_coord.x; x <= core_range.end_coord.x; x++) {
+                for (auto y = core_range.start_coord.y; y <= core_range.end_coord.y; y++) {
                     CoreCoord physical_coord = device->physical_core_from_logical_core(CoreCoord({x, y}), core_type);
                     dst_noc_unicast_info.push_back(std::make_pair(physical_coord, /*num_mcast_dests=*/0));
                 }
@@ -782,8 +782,8 @@ void Program::finalize_rt_args() {
                 if (optional_id) {
                     auto kernel = detail::GetKernel(*this, optional_id.value());
                     for (const CoreRange &core_range : kg.core_ranges.ranges()) {
-                        for (auto x = core_range.start_.x; x <= core_range.end_.x; x++) {
-                            for (auto y = core_range.start_.y; y <= core_range.end_.y; y++) {
+                        for (auto x = core_range.start_coord.x; x <= core_range.end_coord.x; x++) {
+                            for (auto y = core_range.start_coord.y; y <= core_range.end_coord.y; y++) {
                                 CoreCoord core_coord(x, y);
                                 max_rtas[dispatch_class] =
                                     std::max(max_rtas[dispatch_class], (uint32_t)kernel->runtime_args(core_coord).size());

--- a/tt_metal/impl/program/program.cpp
+++ b/tt_metal/impl/program/program.cpp
@@ -272,8 +272,8 @@ void Program::update_kernel_groups(const CoreType &core_type) {
 
             // Map from core X,Y back to the unique KernelGroup
             for (CoreRange range : kg_to_cores.second) {
-                for (auto y = range.start.y; y <= range.end.y; y++) {
-                    for (auto x = range.start.x; x <= range.end.x; x++) {
+                for (auto y = range.start_.y; y <= range.end_.y; y++) {
+                    for (auto x = range.start_.x; x <= range.end_.x; x++) {
                         core_to_kernel_group_index_table_[core_type][y * grid_extent_[core_type].x + x] = index;
 
                         auto val = per_core_cb_indices_.find(CoreCoord({x, y}));
@@ -330,8 +330,8 @@ CBHandle Program::add_circular_buffer(const CoreRangeSet &core_range_set, const 
     }
     // Mark which buffer indices are being used on each core the circular buffer is used on
     for (const CoreRange &core_range : core_range_set.ranges()) {
-        for (auto x = core_range.start.x; x <= core_range.end.x; x++) {
-            for (auto y = core_range.start.y; y <= core_range.end.y; y++) {
+        for (auto x = core_range.start_.x; x <= core_range.end_.x; x++) {
+            for (auto y = core_range.start_.y; y <= core_range.end_.y; y++) {
                 CoreCoord logical_core(x, y);
                 std::bitset<NUM_CIRCULAR_BUFFERS> &cb_indices = this->per_core_cb_indices_[logical_core];
 
@@ -578,8 +578,8 @@ void Program::populate_dispatch_data(Device *device) {
         // This API extracts all the pairs of noc multicast encodings given a set of core ranges
         vector<pair<transfer_info_cores, uint32_t>> dst_noc_unicast_info;
         for (const CoreRange &core_range : ranges) {
-            for (auto x = core_range.start.x; x <= core_range.end.x; x++) {
-                for (auto y = core_range.start.y; y <= core_range.end.y; y++) {
+            for (auto x = core_range.start_.x; x <= core_range.end_.x; x++) {
+                for (auto y = core_range.start_.y; y <= core_range.end_.y; y++) {
                     CoreCoord physical_coord = device->physical_core_from_logical_core(CoreCoord({x, y}), core_type);
                     dst_noc_unicast_info.push_back(std::make_pair(physical_coord, /*num_mcast_dests=*/0));
                 }
@@ -782,8 +782,8 @@ void Program::finalize_rt_args() {
                 if (optional_id) {
                     auto kernel = detail::GetKernel(*this, optional_id.value());
                     for (const CoreRange &core_range : kg.core_ranges.ranges()) {
-                        for (auto x = core_range.start.x; x <= core_range.end.x; x++) {
-                            for (auto y = core_range.start.y; y <= core_range.end.y; y++) {
+                        for (auto x = core_range.start_.x; x <= core_range.end_.x; x++) {
+                            for (auto y = core_range.start_.y; y <= core_range.end_.y; y++) {
                                 CoreCoord core_coord(x, y);
                                 max_rtas[dispatch_class] =
                                     std::max(max_rtas[dispatch_class], (uint32_t)kernel->runtime_args(core_coord).size());

--- a/tt_metal/impl/program/program.hpp
+++ b/tt_metal/impl/program/program.hpp
@@ -59,8 +59,8 @@ vector<pair<transfer_info_cores, uint32_t>> extract_dst_noc_multicast_info(Devic
     vector<pair<transfer_info_cores, uint32_t>> dst_noc_multicast_info;
     dst_noc_multicast_info.reserve(ranges.size());
     for (const CoreRange& core_range : ranges) {
-        CoreCoord physical_start = device->physical_core_from_logical_core(core_range.start, core_type);
-        CoreCoord physical_end = device->physical_core_from_logical_core(core_range.end, core_type);
+        CoreCoord physical_start = device->physical_core_from_logical_core(core_range.start_, core_type);
+        CoreCoord physical_end = device->physical_core_from_logical_core(core_range.end_, core_type);
 
         uint32_t num_receivers = core_range.size();
         dst_noc_multicast_info.push_back(std::make_pair(CoreRange(physical_start, physical_end), num_receivers));

--- a/tt_metal/impl/program/program.hpp
+++ b/tt_metal/impl/program/program.hpp
@@ -59,8 +59,8 @@ vector<pair<transfer_info_cores, uint32_t>> extract_dst_noc_multicast_info(Devic
     vector<pair<transfer_info_cores, uint32_t>> dst_noc_multicast_info;
     dst_noc_multicast_info.reserve(ranges.size());
     for (const CoreRange& core_range : ranges) {
-        CoreCoord physical_start = device->physical_core_from_logical_core(core_range.start_, core_type);
-        CoreCoord physical_end = device->physical_core_from_logical_core(core_range.end_, core_type);
+        CoreCoord physical_start = device->physical_core_from_logical_core(core_range.start_coord, core_type);
+        CoreCoord physical_end = device->physical_core_from_logical_core(core_range.end_coord, core_type);
 
         uint32_t num_receivers = core_range.size();
         dst_noc_multicast_info.push_back(std::make_pair(CoreRange(physical_start, physical_end), num_receivers));

--- a/tt_metal/programming_examples/matmul_common/work_split.hpp
+++ b/tt_metal/programming_examples/matmul_common/work_split.hpp
@@ -128,38 +128,38 @@ inline std::tuple<uint32_t, CoreRangeSet, CoreRangeSet, CoreRangeSet, uint32_t, 
         auto last_block_all_cores = (*all_cores.ranges().rbegin());
         if (row_wise) {
             // Case where only the last row is divided between core group 1 and 2
-            if (last_block_group_1.end_.y == last_block_all_cores.end_.y && last_block_group_1.end_.x != last_block_all_cores.end_.x) {
+            if (last_block_group_1.end_coord.y == last_block_all_cores.end_coord.y && last_block_group_1.end_coord.x != last_block_all_cores.end_coord.x) {
                 CoreRange leftover_block(
-                    {last_block_group_1.end_.x + 1, last_block_group_1.end_.y}, last_block_all_cores.end_);
+                    {last_block_group_1.end_coord.x + 1, last_block_group_1.end_coord.y}, last_block_all_cores.end_coord);
                 core_group_2_set.insert(leftover_block);
             } else {
                 // Case where a middle row is divided between core group 1 and 2
-                if (last_block_group_1.end_.x != num_cores_x - 1) {
+                if (last_block_group_1.end_coord.x != num_cores_x - 1) {
                     CoreRange leftover_stick(
-                        {last_block_group_1.end_.x + 1, last_block_group_1.end_.y},
-                        {num_cores_x - 1, last_block_group_1.end_.y});
+                        {last_block_group_1.end_coord.x + 1, last_block_group_1.end_coord.y},
+                        {num_cores_x - 1, last_block_group_1.end_coord.y});
                     core_group_2_set.insert(leftover_stick);
                 }
                 // Remaining rows of cores that does less work
-                CoreRange leftover_block({0, last_block_group_1.end_.y + 1}, last_block_all_cores.end_);
+                CoreRange leftover_block({0, last_block_group_1.end_coord.y + 1}, last_block_all_cores.end_coord);
                 core_group_2_set.insert(leftover_block);
             }
         } else {
             // Case where only the last column is divided between core group 1 and 2
-            if (last_block_group_1.end_.x == last_block_all_cores.end_.x && last_block_group_1.end_.y != last_block_all_cores.end_.y) {
+            if (last_block_group_1.end_coord.x == last_block_all_cores.end_coord.x && last_block_group_1.end_coord.y != last_block_all_cores.end_coord.y) {
                 CoreRange leftover_block(
-                    {last_block_group_1.end_.x, last_block_group_1.end_.y + 1}, last_block_all_cores.end_);
+                    {last_block_group_1.end_coord.x, last_block_group_1.end_coord.y + 1}, last_block_all_cores.end_coord);
                 core_group_2_set.insert(leftover_block);
             } else {
                 // Case where a middle column is divided between core group 1 and 2
-                if (last_block_group_1.end_.y != num_cores_y - 1) {
+                if (last_block_group_1.end_coord.y != num_cores_y - 1) {
                     CoreRange leftover_stick(
-                        {last_block_group_1.end_.x, last_block_group_1.end_.y + 1},
-                        {last_block_group_1.end_.x, num_cores_y - 1});
+                        {last_block_group_1.end_coord.x, last_block_group_1.end_coord.y + 1},
+                        {last_block_group_1.end_coord.x, num_cores_y - 1});
                     core_group_2_set.insert(leftover_stick);
                 }
                 // Remaining columns of cores that does less work
-                CoreRange leftover_block({last_block_group_1.end_.x + 1, 0}, last_block_all_cores.end_);
+                CoreRange leftover_block({last_block_group_1.end_coord.x + 1, 0}, last_block_all_cores.end_coord);
                 core_group_2_set.insert(leftover_block);
             }
         }

--- a/tt_metal/programming_examples/matmul_common/work_split.hpp
+++ b/tt_metal/programming_examples/matmul_common/work_split.hpp
@@ -128,38 +128,38 @@ inline std::tuple<uint32_t, CoreRangeSet, CoreRangeSet, CoreRangeSet, uint32_t, 
         auto last_block_all_cores = (*all_cores.ranges().rbegin());
         if (row_wise) {
             // Case where only the last row is divided between core group 1 and 2
-            if (last_block_group_1.end.y == last_block_all_cores.end.y && last_block_group_1.end.x != last_block_all_cores.end.x) {
+            if (last_block_group_1.end_.y == last_block_all_cores.end_.y && last_block_group_1.end_.x != last_block_all_cores.end_.x) {
                 CoreRange leftover_block(
-                    {last_block_group_1.end.x + 1, last_block_group_1.end.y}, last_block_all_cores.end);
+                    {last_block_group_1.end_.x + 1, last_block_group_1.end_.y}, last_block_all_cores.end_);
                 core_group_2_set.insert(leftover_block);
             } else {
                 // Case where a middle row is divided between core group 1 and 2
-                if (last_block_group_1.end.x != num_cores_x - 1) {
+                if (last_block_group_1.end_.x != num_cores_x - 1) {
                     CoreRange leftover_stick(
-                        {last_block_group_1.end.x + 1, last_block_group_1.end.y},
-                        {num_cores_x - 1, last_block_group_1.end.y});
+                        {last_block_group_1.end_.x + 1, last_block_group_1.end_.y},
+                        {num_cores_x - 1, last_block_group_1.end_.y});
                     core_group_2_set.insert(leftover_stick);
                 }
                 // Remaining rows of cores that does less work
-                CoreRange leftover_block({0, last_block_group_1.end.y + 1}, last_block_all_cores.end);
+                CoreRange leftover_block({0, last_block_group_1.end_.y + 1}, last_block_all_cores.end_);
                 core_group_2_set.insert(leftover_block);
             }
         } else {
             // Case where only the last column is divided between core group 1 and 2
-            if (last_block_group_1.end.x == last_block_all_cores.end.x && last_block_group_1.end.y != last_block_all_cores.end.y) {
+            if (last_block_group_1.end_.x == last_block_all_cores.end_.x && last_block_group_1.end_.y != last_block_all_cores.end_.y) {
                 CoreRange leftover_block(
-                    {last_block_group_1.end.x, last_block_group_1.end.y + 1}, last_block_all_cores.end);
+                    {last_block_group_1.end_.x, last_block_group_1.end_.y + 1}, last_block_all_cores.end_);
                 core_group_2_set.insert(leftover_block);
             } else {
                 // Case where a middle column is divided between core group 1 and 2
-                if (last_block_group_1.end.y != num_cores_y - 1) {
+                if (last_block_group_1.end_.y != num_cores_y - 1) {
                     CoreRange leftover_stick(
-                        {last_block_group_1.end.x, last_block_group_1.end.y + 1},
-                        {last_block_group_1.end.x, num_cores_y - 1});
+                        {last_block_group_1.end_.x, last_block_group_1.end_.y + 1},
+                        {last_block_group_1.end_.x, num_cores_y - 1});
                     core_group_2_set.insert(leftover_stick);
                 }
                 // Remaining columns of cores that does less work
-                CoreRange leftover_block({last_block_group_1.end.x + 1, 0}, last_block_all_cores.end);
+                CoreRange leftover_block({last_block_group_1.end_.x + 1, 0}, last_block_all_cores.end_);
                 core_group_2_set.insert(leftover_block);
             }
         }

--- a/tt_metal/tt_metal.cpp
+++ b/tt_metal/tt_metal.cpp
@@ -40,8 +40,8 @@ void ConfigureKernelGroup(
 std::optional<uint32_t> get_semaphore_address(const Program &program, const CoreRange &core_range) {
     std::optional<uint32_t> address = nullopt;
     std::vector<uint32_t> semaphore_histogram(NUM_SEMAPHORES, 0);
-    for (auto x = core_range.start.x; x <= core_range.end.x; x++) {
-        for (auto y = core_range.start.y; y <= core_range.end.y; y++) {
+    for (auto x = core_range.start_.x; x <= core_range.end_.x; x++) {
+        for (auto y = core_range.start_.y; y <= core_range.end_.y; y++) {
             CoreCoord logical_core(x, y);
             auto semaphores = program.semaphores_on_core(logical_core);
             if (semaphores.size() == NUM_SEMAPHORES) {
@@ -87,8 +87,8 @@ inline void SetRuntimeArgs(
     const std::vector<uint32_t> &runtime_args) {
     if (runtime_args.size() != 0) {
         auto kernel = detail::GetKernel(program, kernel_id);
-        for (auto x = core_range.start.x; x <= core_range.end.x; ++x) {
-            for (auto y = core_range.start.y; y <= core_range.end.y; ++y) {
+        for (auto x = core_range.start_.x; x <= core_range.end_.x; ++x) {
+            for (auto y = core_range.start_.y; y <= core_range.end_.y; ++y) {
                 kernel->set_runtime_args(CoreCoord(x, y), runtime_args);
             }
         }
@@ -103,8 +103,8 @@ inline void SetRuntimeArgs(
     if (runtime_args.size() != 0) {
         auto kernel = detail::GetKernel(program, kernel_id);
         for (const auto &core_range : core_range_set.ranges()) {
-            for (auto x = core_range.start.x; x <= core_range.end.x; ++x) {
-                for (auto y = core_range.start.y; y <= core_range.end.y; ++y) {
+            for (auto x = core_range.start_.x; x <= core_range.end_.x; ++x) {
+                for (auto y = core_range.start_.y; y <= core_range.end_.y; ++y) {
                     kernel->set_runtime_args(CoreCoord(x, y), runtime_args);
                 }
             }
@@ -125,15 +125,15 @@ inline void SetRuntimeArgs(
             if constexpr (std::is_same_v<T, CoreCoord>) {
                 EnqueueSetRuntimeArgs(cq, kernel, core_spec, runtime_args, blocking);
             } else if constexpr (std::is_same_v<T, CoreRange>) {
-                for (auto x = core_spec.start.x; x <= core_spec.end.x; x++) {
-                    for (auto y = core_spec.start.y; y <= core_spec.end.y; y++) {
+                for (auto x = core_spec.start_.x; x <= core_spec.end_.x; x++) {
+                    for (auto y = core_spec.start_.y; y <= core_spec.end_.y; y++) {
                         EnqueueSetRuntimeArgs(cq, kernel, CoreCoord(x, y), runtime_args, blocking);
                     }
                 }
             } else if constexpr (std::is_same_v<T, CoreRangeSet>) {
                 for (const auto &core_range : core_spec.ranges()) {
-                    for (auto x = core_range.start.x; x <= core_range.end.x; x++) {
-                        for (auto y = core_range.start.y; y <= core_range.end.y; y++) {
+                    for (auto x = core_range.start_.x; x <= core_range.end_.x; x++) {
+                        for (auto y = core_range.start_.y; y <= core_range.end_.y; y++) {
                             EnqueueSetRuntimeArgs(cq, kernel, CoreCoord(x, y), runtime_args, blocking);
                         }
                     }
@@ -623,8 +623,8 @@ void WriteRuntimeArgsToDevice(Device *device, Program &program) {
     for (CoreType core_type : core_types) {
         for (auto& kg : program.get_kernel_groups(core_type)) {
             for (const CoreRange &core_range : kg.core_ranges.ranges()) {
-                for (auto x = core_range.start.x; x <= core_range.end.x; x++) {
-                    for (auto y = core_range.start.y; y <= core_range.end.y; y++) {
+                for (auto x = core_range.start_.x; x <= core_range.end_.x; x++) {
+                    for (auto y = core_range.start_.y; y <= core_range.end_.y; y++) {
                         CoreCoord logical_core(x, y);
                         auto physical_core = device->physical_core_from_logical_core(logical_core, core_type);
                         for (int dispatch_class = 0; dispatch_class < DISPATCH_CLASS_MAX; dispatch_class++) {
@@ -831,8 +831,8 @@ uint32_t CreateSemaphore(
             std::optional<uint32_t> address;
             TT_FATAL(crs.ranges().size() > 0, "Expecting a non-empty CoreRangeSet!");
             for (const auto &core_range : crs.ranges()) {
-                CoreCoord start_core = core_range.start;
-                CoreCoord end_core = core_range.end;
+                CoreCoord start_core = core_range.start_;
+                CoreCoord end_core = core_range.end_;
                 std::optional<uint32_t> addr_candidate = get_semaphore_address(program, core_range);
                 if (!address.has_value()) {
                     address = addr_candidate;

--- a/tt_metal/tt_metal.cpp
+++ b/tt_metal/tt_metal.cpp
@@ -40,8 +40,8 @@ void ConfigureKernelGroup(
 std::optional<uint32_t> get_semaphore_address(const Program &program, const CoreRange &core_range) {
     std::optional<uint32_t> address = nullopt;
     std::vector<uint32_t> semaphore_histogram(NUM_SEMAPHORES, 0);
-    for (auto x = core_range.start_.x; x <= core_range.end_.x; x++) {
-        for (auto y = core_range.start_.y; y <= core_range.end_.y; y++) {
+    for (auto x = core_range.start_coord.x; x <= core_range.end_coord.x; x++) {
+        for (auto y = core_range.start_coord.y; y <= core_range.end_coord.y; y++) {
             CoreCoord logical_core(x, y);
             auto semaphores = program.semaphores_on_core(logical_core);
             if (semaphores.size() == NUM_SEMAPHORES) {
@@ -87,8 +87,8 @@ inline void SetRuntimeArgs(
     const std::vector<uint32_t> &runtime_args) {
     if (runtime_args.size() != 0) {
         auto kernel = detail::GetKernel(program, kernel_id);
-        for (auto x = core_range.start_.x; x <= core_range.end_.x; ++x) {
-            for (auto y = core_range.start_.y; y <= core_range.end_.y; ++y) {
+        for (auto x = core_range.start_coord.x; x <= core_range.end_coord.x; ++x) {
+            for (auto y = core_range.start_coord.y; y <= core_range.end_coord.y; ++y) {
                 kernel->set_runtime_args(CoreCoord(x, y), runtime_args);
             }
         }
@@ -103,8 +103,8 @@ inline void SetRuntimeArgs(
     if (runtime_args.size() != 0) {
         auto kernel = detail::GetKernel(program, kernel_id);
         for (const auto &core_range : core_range_set.ranges()) {
-            for (auto x = core_range.start_.x; x <= core_range.end_.x; ++x) {
-                for (auto y = core_range.start_.y; y <= core_range.end_.y; ++y) {
+            for (auto x = core_range.start_coord.x; x <= core_range.end_coord.x; ++x) {
+                for (auto y = core_range.start_coord.y; y <= core_range.end_coord.y; ++y) {
                     kernel->set_runtime_args(CoreCoord(x, y), runtime_args);
                 }
             }
@@ -125,15 +125,15 @@ inline void SetRuntimeArgs(
             if constexpr (std::is_same_v<T, CoreCoord>) {
                 EnqueueSetRuntimeArgs(cq, kernel, core_spec, runtime_args, blocking);
             } else if constexpr (std::is_same_v<T, CoreRange>) {
-                for (auto x = core_spec.start_.x; x <= core_spec.end_.x; x++) {
-                    for (auto y = core_spec.start_.y; y <= core_spec.end_.y; y++) {
+                for (auto x = core_spec.start_coord.x; x <= core_spec.end_coord.x; x++) {
+                    for (auto y = core_spec.start_coord.y; y <= core_spec.end_coord.y; y++) {
                         EnqueueSetRuntimeArgs(cq, kernel, CoreCoord(x, y), runtime_args, blocking);
                     }
                 }
             } else if constexpr (std::is_same_v<T, CoreRangeSet>) {
                 for (const auto &core_range : core_spec.ranges()) {
-                    for (auto x = core_range.start_.x; x <= core_range.end_.x; x++) {
-                        for (auto y = core_range.start_.y; y <= core_range.end_.y; y++) {
+                    for (auto x = core_range.start_coord.x; x <= core_range.end_coord.x; x++) {
+                        for (auto y = core_range.start_coord.y; y <= core_range.end_coord.y; y++) {
                             EnqueueSetRuntimeArgs(cq, kernel, CoreCoord(x, y), runtime_args, blocking);
                         }
                     }
@@ -623,8 +623,8 @@ void WriteRuntimeArgsToDevice(Device *device, Program &program) {
     for (CoreType core_type : core_types) {
         for (auto& kg : program.get_kernel_groups(core_type)) {
             for (const CoreRange &core_range : kg.core_ranges.ranges()) {
-                for (auto x = core_range.start_.x; x <= core_range.end_.x; x++) {
-                    for (auto y = core_range.start_.y; y <= core_range.end_.y; y++) {
+                for (auto x = core_range.start_coord.x; x <= core_range.end_coord.x; x++) {
+                    for (auto y = core_range.start_coord.y; y <= core_range.end_coord.y; y++) {
                         CoreCoord logical_core(x, y);
                         auto physical_core = device->physical_core_from_logical_core(logical_core, core_type);
                         for (int dispatch_class = 0; dispatch_class < DISPATCH_CLASS_MAX; dispatch_class++) {
@@ -831,8 +831,8 @@ uint32_t CreateSemaphore(
             std::optional<uint32_t> address;
             TT_FATAL(crs.ranges().size() > 0, "Expecting a non-empty CoreRangeSet!");
             for (const auto &core_range : crs.ranges()) {
-                CoreCoord start_core = core_range.start_;
-                CoreCoord end_core = core_range.end_;
+                CoreCoord start_core = core_range.start_coord;
+                CoreCoord end_core = core_range.end_coord;
                 std::optional<uint32_t> addr_candidate = get_semaphore_address(program, core_range);
                 if (!address.has_value()) {
                     address = addr_candidate;

--- a/ttnn/cpp/ttnn/experimental/tt_dnn/op_library/bcast/multi_core_h/bcast_op_sharded_h.cpp
+++ b/ttnn/cpp/ttnn/experimental/tt_dnn/op_library/bcast/multi_core_h/bcast_op_sharded_h.cpp
@@ -56,7 +56,7 @@ operation::ProgramWithCallbacks bcast_sharded_h(const Tensor &a, const Tensor &b
 
     uint32_t Wt, Ht;
     if(a.memory_config().memory_layout == TensorMemoryLayout::BLOCK_SHARDED){
-        ncores_x = all_cores.ranges().begin()->end.y + 1;
+        ncores_x = all_cores.ranges().begin()->end_.y + 1;
         Wt = shard_spec.shape[1] / TILE_WIDTH;
         Ht = shard_spec.shape[0] / TILE_HEIGHT;
     } else if(a.memory_config().memory_layout == TensorMemoryLayout::WIDTH_SHARDED){

--- a/ttnn/cpp/ttnn/experimental/tt_dnn/op_library/bcast/multi_core_h/bcast_op_sharded_h.cpp
+++ b/ttnn/cpp/ttnn/experimental/tt_dnn/op_library/bcast/multi_core_h/bcast_op_sharded_h.cpp
@@ -56,7 +56,7 @@ operation::ProgramWithCallbacks bcast_sharded_h(const Tensor &a, const Tensor &b
 
     uint32_t Wt, Ht;
     if(a.memory_config().memory_layout == TensorMemoryLayout::BLOCK_SHARDED){
-        ncores_x = all_cores.ranges().begin()->end_.y + 1;
+        ncores_x = all_cores.ranges().begin()->end_coord.y + 1;
         Wt = shard_spec.shape[1] / TILE_WIDTH;
         Ht = shard_spec.shape[0] / TILE_HEIGHT;
     } else if(a.memory_config().memory_layout == TensorMemoryLayout::WIDTH_SHARDED){

--- a/ttnn/cpp/ttnn/experimental/tt_dnn/op_library/bcast/multi_core_h/bcast_op_sharded_h_optimised.cpp
+++ b/ttnn/cpp/ttnn/experimental/tt_dnn/op_library/bcast/multi_core_h/bcast_op_sharded_h_optimised.cpp
@@ -56,7 +56,7 @@ operation::ProgramWithCallbacks bcast_sharded_h_optimised(const Tensor &a, const
 
     uint32_t Wt, Ht;
     if(a.memory_config().memory_layout == TensorMemoryLayout::BLOCK_SHARDED){
-        ncores_x = all_cores.ranges().begin()->end_.y + 1;
+        ncores_x = all_cores.ranges().begin()->end_coord.y + 1;
         Wt = shard_spec.shape[1] / TILE_WIDTH;
         Ht = shard_spec.shape[0] / TILE_HEIGHT;
     } else if(a.memory_config().memory_layout == TensorMemoryLayout::WIDTH_SHARDED){

--- a/ttnn/cpp/ttnn/experimental/tt_dnn/op_library/bcast/multi_core_h/bcast_op_sharded_h_optimised.cpp
+++ b/ttnn/cpp/ttnn/experimental/tt_dnn/op_library/bcast/multi_core_h/bcast_op_sharded_h_optimised.cpp
@@ -56,7 +56,7 @@ operation::ProgramWithCallbacks bcast_sharded_h_optimised(const Tensor &a, const
 
     uint32_t Wt, Ht;
     if(a.memory_config().memory_layout == TensorMemoryLayout::BLOCK_SHARDED){
-        ncores_x = all_cores.ranges().begin()->end.y + 1;
+        ncores_x = all_cores.ranges().begin()->end_.y + 1;
         Wt = shard_spec.shape[1] / TILE_WIDTH;
         Ht = shard_spec.shape[0] / TILE_HEIGHT;
     } else if(a.memory_config().memory_layout == TensorMemoryLayout::WIDTH_SHARDED){

--- a/ttnn/cpp/ttnn/experimental/tt_dnn/op_library/moreh_adamw/moreh_adamw.cpp
+++ b/ttnn/cpp/ttnn/experimental/tt_dnn/op_library/moreh_adamw/moreh_adamw.cpp
@@ -52,8 +52,8 @@ operation::ProgramWithCallbacks moreh_adamw_(
     auto grid = device->compute_with_storage_grid_size();
     const auto num_cores_y = grid.y;
 
-    uint32_t core_w = core_range.end_.x - core_range.start_.x + 1;
-    uint32_t core_h = core_range.end_.y - core_range.start_.y + 1;
+    uint32_t core_w = core_range.end_coord.x - core_range.start_coord.x + 1;
+    uint32_t core_h = core_range.end_coord.y - core_range.start_coord.y + 1;
 
     auto
         [num_cores, all_cores, core_group_1, core_group_2, num_units_per_core_group_1, num_units_per_core_group_2] =

--- a/ttnn/cpp/ttnn/experimental/tt_dnn/op_library/moreh_adamw/moreh_adamw.cpp
+++ b/ttnn/cpp/ttnn/experimental/tt_dnn/op_library/moreh_adamw/moreh_adamw.cpp
@@ -52,8 +52,8 @@ operation::ProgramWithCallbacks moreh_adamw_(
     auto grid = device->compute_with_storage_grid_size();
     const auto num_cores_y = grid.y;
 
-    uint32_t core_w = core_range.end.x - core_range.start.x + 1;
-    uint32_t core_h = core_range.end.y - core_range.start.y + 1;
+    uint32_t core_w = core_range.end_.x - core_range.start_.x + 1;
+    uint32_t core_h = core_range.end_.y - core_range.start_.y + 1;
 
     auto
         [num_cores, all_cores, core_group_1, core_group_2, num_units_per_core_group_1, num_units_per_core_group_2] =

--- a/ttnn/cpp/ttnn/experimental/tt_dnn/op_library/moreh_arange/moreh_arange_op.cpp
+++ b/ttnn/cpp/ttnn/experimental/tt_dnn/op_library/moreh_arange/moreh_arange_op.cpp
@@ -29,8 +29,8 @@ operation::ProgramWithCallbacks moreh_arange_(
     auto Wt = div_up(W, TILE_WIDTH);
 
     uint32_t units_to_divide = Wt;
-    uint32_t core_w = core_range.end_.x - core_range.start_.x + 1;
-    uint32_t core_h = core_range.end_.y - core_range.start_.y + 1;
+    uint32_t core_w = core_range.end_coord.x - core_range.start_coord.x + 1;
+    uint32_t core_h = core_range.end_coord.y - core_range.start_coord.y + 1;
 
     auto [num_cores, all_cores, core_group_1, core_group_2, num_tiles_per_core_group_1, num_tiles_per_core_group_2] =
         split_work_to_cores(core_range, units_to_divide);
@@ -74,8 +74,8 @@ operation::ProgramWithCallbacks moreh_arange_(
         writer_defines);
 
     // Set Runtime Args
-    auto core_x_offset = core_range.start_.x;
-    auto core_y_offset = core_range.start_.y;
+    auto core_x_offset = core_range.start_coord.x;
+    auto core_y_offset = core_range.start_coord.y;
 
     for (uint32_t i = 0, tile_offset = 0; i < num_cores; i++) {
         CoreCoord core = {i / core_h + core_x_offset, i % core_h + core_y_offset};

--- a/ttnn/cpp/ttnn/experimental/tt_dnn/op_library/moreh_arange/moreh_arange_op.cpp
+++ b/ttnn/cpp/ttnn/experimental/tt_dnn/op_library/moreh_arange/moreh_arange_op.cpp
@@ -29,8 +29,8 @@ operation::ProgramWithCallbacks moreh_arange_(
     auto Wt = div_up(W, TILE_WIDTH);
 
     uint32_t units_to_divide = Wt;
-    uint32_t core_w = core_range.end.x - core_range.start.x + 1;
-    uint32_t core_h = core_range.end.y - core_range.start.y + 1;
+    uint32_t core_w = core_range.end_.x - core_range.start_.x + 1;
+    uint32_t core_h = core_range.end_.y - core_range.start_.y + 1;
 
     auto [num_cores, all_cores, core_group_1, core_group_2, num_tiles_per_core_group_1, num_tiles_per_core_group_2] =
         split_work_to_cores(core_range, units_to_divide);
@@ -74,8 +74,8 @@ operation::ProgramWithCallbacks moreh_arange_(
         writer_defines);
 
     // Set Runtime Args
-    auto core_x_offset = core_range.start.x;
-    auto core_y_offset = core_range.start.y;
+    auto core_x_offset = core_range.start_.x;
+    auto core_y_offset = core_range.start_.y;
 
     for (uint32_t i = 0, tile_offset = 0; i < num_cores; i++) {
         CoreCoord core = {i / core_h + core_x_offset, i % core_h + core_y_offset};

--- a/ttnn/cpp/ttnn/experimental/tt_dnn/op_library/moreh_getitem/moreh_getitem_rm/moreh_getitem_rm.cpp
+++ b/ttnn/cpp/ttnn/experimental/tt_dnn/op_library/moreh_getitem/moreh_getitem_rm/moreh_getitem_rm.cpp
@@ -73,8 +73,8 @@ operation::ProgramWithCallbacks moreh_getitem_rm(
     uint32_t num_units = output.volume() / output_shape[-1];
     log_debug(LogTest, "num_units {}", num_units);
 
-    uint32_t core_w = core_range.end_.x - core_range.start_.x + 1;
-    uint32_t core_h = core_range.end_.y - core_range.start_.y + 1;
+    uint32_t core_w = core_range.end_coord.x - core_range.start_coord.x + 1;
+    uint32_t core_h = core_range.end_coord.y - core_range.start_coord.y + 1;
 
     auto [num_cores, all_cores, core_group_1, core_group_2, num_units_per_core_group_1, num_units_per_core_group_2] =
         split_work_to_cores(core_range, num_units);
@@ -142,8 +142,8 @@ operation::ProgramWithCallbacks moreh_getitem_rm(
     uint32_t input_stick_idx_stride_n = input_stick_idx_stride_c * input_4d_shape.without_padding()[1];
 
     // Set Runtime Args
-    auto core_x_offset = core_range.start_.x;
-    auto core_y_offset = core_range.start_.y;
+    auto core_x_offset = core_range.start_coord.x;
+    auto core_y_offset = core_range.start_coord.y;
 
     uint32_t g1_numcores = core_group_1.num_cores();
     uint32_t g2_numcores = core_group_2.num_cores();

--- a/ttnn/cpp/ttnn/experimental/tt_dnn/op_library/moreh_getitem/moreh_getitem_rm/moreh_getitem_rm.cpp
+++ b/ttnn/cpp/ttnn/experimental/tt_dnn/op_library/moreh_getitem/moreh_getitem_rm/moreh_getitem_rm.cpp
@@ -73,8 +73,8 @@ operation::ProgramWithCallbacks moreh_getitem_rm(
     uint32_t num_units = output.volume() / output_shape[-1];
     log_debug(LogTest, "num_units {}", num_units);
 
-    uint32_t core_w = core_range.end.x - core_range.start.x + 1;
-    uint32_t core_h = core_range.end.y - core_range.start.y + 1;
+    uint32_t core_w = core_range.end_.x - core_range.start_.x + 1;
+    uint32_t core_h = core_range.end_.y - core_range.start_.y + 1;
 
     auto [num_cores, all_cores, core_group_1, core_group_2, num_units_per_core_group_1, num_units_per_core_group_2] =
         split_work_to_cores(core_range, num_units);
@@ -142,8 +142,8 @@ operation::ProgramWithCallbacks moreh_getitem_rm(
     uint32_t input_stick_idx_stride_n = input_stick_idx_stride_c * input_4d_shape.without_padding()[1];
 
     // Set Runtime Args
-    auto core_x_offset = core_range.start.x;
-    auto core_y_offset = core_range.start.y;
+    auto core_x_offset = core_range.start_.x;
+    auto core_y_offset = core_range.start_.y;
 
     uint32_t g1_numcores = core_group_1.num_cores();
     uint32_t g2_numcores = core_group_2.num_cores();

--- a/ttnn/cpp/ttnn/experimental/tt_dnn/op_library/moreh_getitem/moreh_getitem_tilized/moreh_getitem_tilized.cpp
+++ b/ttnn/cpp/ttnn/experimental/tt_dnn/op_library/moreh_getitem/moreh_getitem_tilized/moreh_getitem_tilized.cpp
@@ -77,8 +77,8 @@ operation::ProgramWithCallbacks moreh_getitem_tilized(
             ((output_shape_without_padding[3] + num_elements_per_alignment - 1) / num_elements_per_alignment);
         log_debug(LogTest, "num_units {}", num_units);
 
-        uint32_t core_w = core_range.end_.x - core_range.start_.x + 1;
-        uint32_t core_h = core_range.end_.y - core_range.start_.y + 1;
+        uint32_t core_w = core_range.end_coord.x - core_range.start_coord.x + 1;
+        uint32_t core_h = core_range.end_coord.y - core_range.start_coord.y + 1;
 
         auto
             [num_cores, all_cores, core_group_1, core_group_2, num_units_per_core_group_1, num_units_per_core_group_2] =
@@ -182,8 +182,8 @@ operation::ProgramWithCallbacks moreh_getitem_tilized(
         uint32_t input_stick_idx_stride_n = input_stick_idx_stride_c * input_shape.without_padding()[1];
 
         // Set Runtime Args
-        auto core_x_offset = core_range.start_.x;
-        auto core_y_offset = core_range.start_.y;
+        auto core_x_offset = core_range.start_coord.x;
+        auto core_y_offset = core_range.start_coord.y;
 
         uint32_t g1_numcores = core_group_1.num_cores();
         uint32_t g2_numcores = core_group_2.num_cores();
@@ -340,8 +340,8 @@ operation::ProgramWithCallbacks moreh_getitem_tilized(
                              output_shape_without_padding[2] * ((output_shape_without_padding[3] + 15) / 16);
         log_debug(LogTest, "num_units {}", num_units);
 
-        uint32_t core_w = core_range.end_.x - core_range.start_.x + 1;
-        uint32_t core_h = core_range.end_.y - core_range.start_.y + 1;
+        uint32_t core_w = core_range.end_coord.x - core_range.start_coord.x + 1;
+        uint32_t core_h = core_range.end_coord.y - core_range.start_coord.y + 1;
 
         auto
             [num_cores, all_cores, core_group_1, core_group_2, num_units_per_core_group_1, num_units_per_core_group_2] =
@@ -440,8 +440,8 @@ operation::ProgramWithCallbacks moreh_getitem_tilized(
 
 
         // Set Runtime Args
-        auto core_x_offset = core_range.start_.x;
-        auto core_y_offset = core_range.start_.y;
+        auto core_x_offset = core_range.start_coord.x;
+        auto core_y_offset = core_range.start_coord.y;
 
         uint32_t g1_numcores = core_group_1.num_cores();
         uint32_t g2_numcores = core_group_2.num_cores();

--- a/ttnn/cpp/ttnn/experimental/tt_dnn/op_library/moreh_getitem/moreh_getitem_tilized/moreh_getitem_tilized.cpp
+++ b/ttnn/cpp/ttnn/experimental/tt_dnn/op_library/moreh_getitem/moreh_getitem_tilized/moreh_getitem_tilized.cpp
@@ -77,8 +77,8 @@ operation::ProgramWithCallbacks moreh_getitem_tilized(
             ((output_shape_without_padding[3] + num_elements_per_alignment - 1) / num_elements_per_alignment);
         log_debug(LogTest, "num_units {}", num_units);
 
-        uint32_t core_w = core_range.end.x - core_range.start.x + 1;
-        uint32_t core_h = core_range.end.y - core_range.start.y + 1;
+        uint32_t core_w = core_range.end_.x - core_range.start_.x + 1;
+        uint32_t core_h = core_range.end_.y - core_range.start_.y + 1;
 
         auto
             [num_cores, all_cores, core_group_1, core_group_2, num_units_per_core_group_1, num_units_per_core_group_2] =
@@ -182,8 +182,8 @@ operation::ProgramWithCallbacks moreh_getitem_tilized(
         uint32_t input_stick_idx_stride_n = input_stick_idx_stride_c * input_shape.without_padding()[1];
 
         // Set Runtime Args
-        auto core_x_offset = core_range.start.x;
-        auto core_y_offset = core_range.start.y;
+        auto core_x_offset = core_range.start_.x;
+        auto core_y_offset = core_range.start_.y;
 
         uint32_t g1_numcores = core_group_1.num_cores();
         uint32_t g2_numcores = core_group_2.num_cores();
@@ -340,8 +340,8 @@ operation::ProgramWithCallbacks moreh_getitem_tilized(
                              output_shape_without_padding[2] * ((output_shape_without_padding[3] + 15) / 16);
         log_debug(LogTest, "num_units {}", num_units);
 
-        uint32_t core_w = core_range.end.x - core_range.start.x + 1;
-        uint32_t core_h = core_range.end.y - core_range.start.y + 1;
+        uint32_t core_w = core_range.end_.x - core_range.start_.x + 1;
+        uint32_t core_h = core_range.end_.y - core_range.start_.y + 1;
 
         auto
             [num_cores, all_cores, core_group_1, core_group_2, num_units_per_core_group_1, num_units_per_core_group_2] =
@@ -440,8 +440,8 @@ operation::ProgramWithCallbacks moreh_getitem_tilized(
 
 
         // Set Runtime Args
-        auto core_x_offset = core_range.start.x;
-        auto core_y_offset = core_range.start.y;
+        auto core_x_offset = core_range.start_.x;
+        auto core_y_offset = core_range.start_.y;
 
         uint32_t g1_numcores = core_group_1.num_cores();
         uint32_t g2_numcores = core_group_2.num_cores();

--- a/ttnn/cpp/ttnn/experimental/tt_dnn/op_library/moreh_helper_functions.cpp
+++ b/ttnn/cpp/ttnn/experimental/tt_dnn/op_library/moreh_helper_functions.cpp
@@ -26,20 +26,20 @@ std::tuple<CoreRangeSet, CoreRangeSet, CoreRangeSet> add_core_offset(
 
     for (auto core : all_cores.ranges()) {
         new_all_cores_set.insert(CoreRange(
-            {core.start_.x + offset_x, core.start_.y + offset_y},
-            {core.end_.x + offset_x, core.end_.y + offset_y}));
+            {core.start_coord.x + offset_x, core.start_coord.y + offset_y},
+            {core.end_coord.x + offset_x, core.end_coord.y + offset_y}));
     }
 
     for (auto core : core_group_1.ranges()) {
         new_core_group_1_set.insert(CoreRange(
-            {core.start_.x + offset_x, core.start_.y + offset_y},
-            {core.end_.x + offset_x, core.end_.y + offset_y}));
+            {core.start_coord.x + offset_x, core.start_coord.y + offset_y},
+            {core.end_coord.x + offset_x, core.end_coord.y + offset_y}));
     }
 
     for (auto core : core_group_2.ranges()) {
         new_core_group_2_set.insert(CoreRange(
-            {core.start_.x + offset_x, core.start_.y + offset_y},
-            {core.end_.x + offset_x, core.end_.y + offset_y}));
+            {core.start_coord.x + offset_x, core.start_coord.y + offset_y},
+            {core.end_coord.x + offset_x, core.end_coord.y + offset_y}));
     }
 
     CoreRangeSet new_all_cores(new_all_cores_set);
@@ -51,8 +51,8 @@ std::tuple<CoreRangeSet, CoreRangeSet, CoreRangeSet> add_core_offset(
 
 std::tuple<uint32_t, CoreRangeSet, CoreRangeSet, CoreRangeSet, uint32_t, uint32_t> split_work_to_cores(
     CoreRange core_range, uint32_t units_to_divide) {
-    uint32_t core_w = core_range.end_.x - core_range.start_.x + 1;
-    uint32_t core_h = core_range.end_.y - core_range.start_.y + 1;
+    uint32_t core_w = core_range.end_coord.x - core_range.start_coord.x + 1;
+    uint32_t core_h = core_range.end_coord.y - core_range.start_coord.y + 1;
     CoreCoord grid_size = {core_w, core_h};
     auto
         [num_cores,
@@ -62,8 +62,8 @@ std::tuple<uint32_t, CoreRangeSet, CoreRangeSet, CoreRangeSet, uint32_t, uint32_
          num_tiles_per_core_group_1,
          num_tiles_per_core_group_2] = tt::tt_metal::split_work_to_cores(grid_size, units_to_divide);
 
-    auto core_x_offset = core_range.start_.x;
-    auto core_y_offset = core_range.start_.y;
+    auto core_x_offset = core_range.start_coord.x;
+    auto core_y_offset = core_range.start_coord.y;
 
     auto [all_cores, core_group_1, core_group_2] =
         add_core_offset(all_cores_t, core_group_1_t, core_group_2_t, core_x_offset, core_y_offset);

--- a/ttnn/cpp/ttnn/experimental/tt_dnn/op_library/moreh_helper_functions.cpp
+++ b/ttnn/cpp/ttnn/experimental/tt_dnn/op_library/moreh_helper_functions.cpp
@@ -26,20 +26,20 @@ std::tuple<CoreRangeSet, CoreRangeSet, CoreRangeSet> add_core_offset(
 
     for (auto core : all_cores.ranges()) {
         new_all_cores_set.insert(CoreRange(
-            {core.start.x + offset_x, core.start.y + offset_y},
-            {core.end.x + offset_x, core.end.y + offset_y}));
+            {core.start_.x + offset_x, core.start_.y + offset_y},
+            {core.end_.x + offset_x, core.end_.y + offset_y}));
     }
 
     for (auto core : core_group_1.ranges()) {
         new_core_group_1_set.insert(CoreRange(
-            {core.start.x + offset_x, core.start.y + offset_y},
-            {core.end.x + offset_x, core.end.y + offset_y}));
+            {core.start_.x + offset_x, core.start_.y + offset_y},
+            {core.end_.x + offset_x, core.end_.y + offset_y}));
     }
 
     for (auto core : core_group_2.ranges()) {
         new_core_group_2_set.insert(CoreRange(
-            {core.start.x + offset_x, core.start.y + offset_y},
-            {core.end.x + offset_x, core.end.y + offset_y}));
+            {core.start_.x + offset_x, core.start_.y + offset_y},
+            {core.end_.x + offset_x, core.end_.y + offset_y}));
     }
 
     CoreRangeSet new_all_cores(new_all_cores_set);
@@ -51,8 +51,8 @@ std::tuple<CoreRangeSet, CoreRangeSet, CoreRangeSet> add_core_offset(
 
 std::tuple<uint32_t, CoreRangeSet, CoreRangeSet, CoreRangeSet, uint32_t, uint32_t> split_work_to_cores(
     CoreRange core_range, uint32_t units_to_divide) {
-    uint32_t core_w = core_range.end.x - core_range.start.x + 1;
-    uint32_t core_h = core_range.end.y - core_range.start.y + 1;
+    uint32_t core_w = core_range.end_.x - core_range.start_.x + 1;
+    uint32_t core_h = core_range.end_.y - core_range.start_.y + 1;
     CoreCoord grid_size = {core_w, core_h};
     auto
         [num_cores,
@@ -62,8 +62,8 @@ std::tuple<uint32_t, CoreRangeSet, CoreRangeSet, CoreRangeSet, uint32_t, uint32_
          num_tiles_per_core_group_1,
          num_tiles_per_core_group_2] = tt::tt_metal::split_work_to_cores(grid_size, units_to_divide);
 
-    auto core_x_offset = core_range.start.x;
-    auto core_y_offset = core_range.start.y;
+    auto core_x_offset = core_range.start_.x;
+    auto core_y_offset = core_range.start_.y;
 
     auto [all_cores, core_group_1, core_group_2] =
         add_core_offset(all_cores_t, core_group_1_t, core_group_2_t, core_x_offset, core_y_offset);

--- a/ttnn/cpp/ttnn/experimental/tt_dnn/op_library/moreh_nll_loss/moreh_nll_loss_step1/moreh_nll_loss_step1.cpp
+++ b/ttnn/cpp/ttnn/experimental/tt_dnn/op_library/moreh_nll_loss/moreh_nll_loss_step1/moreh_nll_loss_step1.cpp
@@ -42,8 +42,8 @@ operation::ProgramWithCallbacks moreh_nll_loss_step1_impl(
     // copy TILE per core
     uint32_t units_to_divide = target.volume() / H / W * (Ht * Wt);
 
-    uint32_t core_w = core_range.end_.x - core_range.start_.x + 1;
-    uint32_t core_h = core_range.end_.y - core_range.start_.y + 1;
+    uint32_t core_w = core_range.end_coord.x - core_range.start_coord.x + 1;
+    uint32_t core_h = core_range.end_coord.y - core_range.start_coord.y + 1;
 
     auto [num_cores, all_cores, core_group_1, core_group_2, units_per_core_group_1, units_per_core_group_2] =
         split_work_to_cores(core_range, units_to_divide);
@@ -108,8 +108,8 @@ operation::ProgramWithCallbacks moreh_nll_loss_step1_impl(
     const auto output_addr = output.buffer()->address();
 
     // Set Runtime Args
-    auto core_x_offset = core_range.start_.x;
-    auto core_y_offset = core_range.start_.y;
+    auto core_x_offset = core_range.start_coord.x;
+    auto core_y_offset = core_range.start_coord.y;
     for (uint32_t i = 0, tile_offset = 0; i < num_cores; i++) {
         CoreCoord core = {i / core_h + core_x_offset, i % core_h + core_y_offset};
         uint32_t num_units_per_core;

--- a/ttnn/cpp/ttnn/experimental/tt_dnn/op_library/moreh_nll_loss/moreh_nll_loss_step1/moreh_nll_loss_step1.cpp
+++ b/ttnn/cpp/ttnn/experimental/tt_dnn/op_library/moreh_nll_loss/moreh_nll_loss_step1/moreh_nll_loss_step1.cpp
@@ -42,8 +42,8 @@ operation::ProgramWithCallbacks moreh_nll_loss_step1_impl(
     // copy TILE per core
     uint32_t units_to_divide = target.volume() / H / W * (Ht * Wt);
 
-    uint32_t core_w = core_range.end.x - core_range.start.x + 1;
-    uint32_t core_h = core_range.end.y - core_range.start.y + 1;
+    uint32_t core_w = core_range.end_.x - core_range.start_.x + 1;
+    uint32_t core_h = core_range.end_.y - core_range.start_.y + 1;
 
     auto [num_cores, all_cores, core_group_1, core_group_2, units_per_core_group_1, units_per_core_group_2] =
         split_work_to_cores(core_range, units_to_divide);
@@ -108,8 +108,8 @@ operation::ProgramWithCallbacks moreh_nll_loss_step1_impl(
     const auto output_addr = output.buffer()->address();
 
     // Set Runtime Args
-    auto core_x_offset = core_range.start.x;
-    auto core_y_offset = core_range.start.y;
+    auto core_x_offset = core_range.start_.x;
+    auto core_y_offset = core_range.start_.y;
     for (uint32_t i = 0, tile_offset = 0; i < num_cores; i++) {
         CoreCoord core = {i / core_h + core_x_offset, i % core_h + core_y_offset};
         uint32_t num_units_per_core;

--- a/ttnn/cpp/ttnn/experimental/tt_dnn/op_library/moreh_nll_loss/moreh_nll_loss_step2/moreh_nll_loss_step2.cpp
+++ b/ttnn/cpp/ttnn/experimental/tt_dnn/op_library/moreh_nll_loss/moreh_nll_loss_step2/moreh_nll_loss_step2.cpp
@@ -42,8 +42,8 @@ operation::ProgramWithCallbacks moreh_nll_loss_step2_impl_2d(
     const bool weight_has_value = weight.has_value();
     const bool divisor_has_value = divisor.has_value();
 
-    uint32_t core_w = core_range.end_.x - core_range.start_.x + 1;
-    uint32_t core_h = core_range.end_.y - core_range.start_.y + 1;
+    uint32_t core_w = core_range.end_coord.x - core_range.start_coord.x + 1;
+    uint32_t core_h = core_range.end_coord.y - core_range.start_coord.y + 1;
 
     auto [num_cores, all_cores, core_group_1, core_group_2, units_per_core_group_1, units_per_core_group_2] =
         split_work_to_cores(core_range, units_to_divide);
@@ -136,8 +136,8 @@ operation::ProgramWithCallbacks moreh_nll_loss_step2_impl_2d(
     const auto output_addr = output.buffer()->address();
 
     // Set Runtime Args
-    auto core_x_offset = core_range.start_.x;
-    auto core_y_offset = core_range.start_.y;
+    auto core_x_offset = core_range.start_coord.x;
+    auto core_y_offset = core_range.start_coord.y;
     for (uint32_t i = 0, tile_offset = 0; i < num_cores; i++) {
         CoreCoord core = {i / core_h + core_x_offset, i % core_h + core_y_offset};
         uint32_t units_per_core;
@@ -215,8 +215,8 @@ operation::ProgramWithCallbacks moreh_nll_loss_step2_impl_3d(
     const bool weight_has_value = weight.has_value();
     const bool divisor_has_value = divisor.has_value();
 
-    uint32_t core_w = core_range.end_.x - core_range.start_.x + 1;
-    uint32_t core_h = core_range.end_.y - core_range.start_.y + 1;
+    uint32_t core_w = core_range.end_coord.x - core_range.start_coord.x + 1;
+    uint32_t core_h = core_range.end_coord.y - core_range.start_coord.y + 1;
 
     // copy FACE_WIDTH per core
     uint32_t units_to_divide = origin_N * div_up(origin_W, FACE_WIDTH);
@@ -312,8 +312,8 @@ operation::ProgramWithCallbacks moreh_nll_loss_step2_impl_3d(
     const auto output_addr = output.buffer()->address();
 
     // Set Runtime Args
-    auto core_x_offset = core_range.start_.x;
-    auto core_y_offset = core_range.start_.y;
+    auto core_x_offset = core_range.start_coord.x;
+    auto core_y_offset = core_range.start_coord.y;
     for (uint32_t i = 0, tile_offset = 0; i < num_cores; i++) {
         CoreCoord core = {i / core_h + core_x_offset, i % core_h + core_y_offset};
         uint32_t units_per_core;
@@ -400,8 +400,8 @@ operation::ProgramWithCallbacks moreh_nll_loss_step2_impl_4d(
     const bool weight_has_value = weight.has_value();
     const bool divisor_has_value = divisor.has_value();
 
-    uint32_t core_w = core_range.end_.x - core_range.start_.x + 1;
-    uint32_t core_h = core_range.end_.y - core_range.start_.y + 1;
+    uint32_t core_w = core_range.end_coord.x - core_range.start_coord.x + 1;
+    uint32_t core_h = core_range.end_coord.y - core_range.start_coord.y + 1;
 
     // copy TILE per loop
     uint32_t units_to_divide = target.volume() / H / W * Ht * Wt;
@@ -498,8 +498,8 @@ operation::ProgramWithCallbacks moreh_nll_loss_step2_impl_4d(
     const auto output_addr = output.buffer()->address();
 
     // Set Runtime Args
-    auto core_x_offset = core_range.start_.x;
-    auto core_y_offset = core_range.start_.y;
+    auto core_x_offset = core_range.start_coord.x;
+    auto core_y_offset = core_range.start_coord.y;
     for (uint32_t i = 0, tile_offset = 0; i < num_cores; i++) {
         CoreCoord core = {i / core_h + core_x_offset, i % core_h + core_y_offset};
         uint32_t units_per_core;

--- a/ttnn/cpp/ttnn/experimental/tt_dnn/op_library/moreh_nll_loss/moreh_nll_loss_step2/moreh_nll_loss_step2.cpp
+++ b/ttnn/cpp/ttnn/experimental/tt_dnn/op_library/moreh_nll_loss/moreh_nll_loss_step2/moreh_nll_loss_step2.cpp
@@ -42,8 +42,8 @@ operation::ProgramWithCallbacks moreh_nll_loss_step2_impl_2d(
     const bool weight_has_value = weight.has_value();
     const bool divisor_has_value = divisor.has_value();
 
-    uint32_t core_w = core_range.end.x - core_range.start.x + 1;
-    uint32_t core_h = core_range.end.y - core_range.start.y + 1;
+    uint32_t core_w = core_range.end_.x - core_range.start_.x + 1;
+    uint32_t core_h = core_range.end_.y - core_range.start_.y + 1;
 
     auto [num_cores, all_cores, core_group_1, core_group_2, units_per_core_group_1, units_per_core_group_2] =
         split_work_to_cores(core_range, units_to_divide);
@@ -136,8 +136,8 @@ operation::ProgramWithCallbacks moreh_nll_loss_step2_impl_2d(
     const auto output_addr = output.buffer()->address();
 
     // Set Runtime Args
-    auto core_x_offset = core_range.start.x;
-    auto core_y_offset = core_range.start.y;
+    auto core_x_offset = core_range.start_.x;
+    auto core_y_offset = core_range.start_.y;
     for (uint32_t i = 0, tile_offset = 0; i < num_cores; i++) {
         CoreCoord core = {i / core_h + core_x_offset, i % core_h + core_y_offset};
         uint32_t units_per_core;
@@ -215,8 +215,8 @@ operation::ProgramWithCallbacks moreh_nll_loss_step2_impl_3d(
     const bool weight_has_value = weight.has_value();
     const bool divisor_has_value = divisor.has_value();
 
-    uint32_t core_w = core_range.end.x - core_range.start.x + 1;
-    uint32_t core_h = core_range.end.y - core_range.start.y + 1;
+    uint32_t core_w = core_range.end_.x - core_range.start_.x + 1;
+    uint32_t core_h = core_range.end_.y - core_range.start_.y + 1;
 
     // copy FACE_WIDTH per core
     uint32_t units_to_divide = origin_N * div_up(origin_W, FACE_WIDTH);
@@ -312,8 +312,8 @@ operation::ProgramWithCallbacks moreh_nll_loss_step2_impl_3d(
     const auto output_addr = output.buffer()->address();
 
     // Set Runtime Args
-    auto core_x_offset = core_range.start.x;
-    auto core_y_offset = core_range.start.y;
+    auto core_x_offset = core_range.start_.x;
+    auto core_y_offset = core_range.start_.y;
     for (uint32_t i = 0, tile_offset = 0; i < num_cores; i++) {
         CoreCoord core = {i / core_h + core_x_offset, i % core_h + core_y_offset};
         uint32_t units_per_core;
@@ -400,8 +400,8 @@ operation::ProgramWithCallbacks moreh_nll_loss_step2_impl_4d(
     const bool weight_has_value = weight.has_value();
     const bool divisor_has_value = divisor.has_value();
 
-    uint32_t core_w = core_range.end.x - core_range.start.x + 1;
-    uint32_t core_h = core_range.end.y - core_range.start.y + 1;
+    uint32_t core_w = core_range.end_.x - core_range.start_.x + 1;
+    uint32_t core_h = core_range.end_.y - core_range.start_.y + 1;
 
     // copy TILE per loop
     uint32_t units_to_divide = target.volume() / H / W * Ht * Wt;
@@ -498,8 +498,8 @@ operation::ProgramWithCallbacks moreh_nll_loss_step2_impl_4d(
     const auto output_addr = output.buffer()->address();
 
     // Set Runtime Args
-    auto core_x_offset = core_range.start.x;
-    auto core_y_offset = core_range.start.y;
+    auto core_x_offset = core_range.start_.x;
+    auto core_y_offset = core_range.start_.y;
     for (uint32_t i = 0, tile_offset = 0; i < num_cores; i++) {
         CoreCoord core = {i / core_h + core_x_offset, i % core_h + core_y_offset};
         uint32_t units_per_core;

--- a/ttnn/cpp/ttnn/experimental/tt_dnn/op_library/moreh_nll_loss_backward/moreh_nll_loss_backward/moreh_nll_loss_backward.cpp
+++ b/ttnn/cpp/ttnn/experimental/tt_dnn/op_library/moreh_nll_loss_backward/moreh_nll_loss_backward/moreh_nll_loss_backward.cpp
@@ -42,8 +42,8 @@ operation::ProgramWithCallbacks moreh_nll_loss_backward_impl_4d(
     const bool weight_has_value = weight.has_value();
     const bool divisor_has_value = divisor.has_value();
 
-    uint32_t core_w = core_range.end.x - core_range.start.x + 1;
-    uint32_t core_h = core_range.end.y - core_range.start.y + 1;
+    uint32_t core_w = core_range.end_.x - core_range.start_.x + 1;
+    uint32_t core_h = core_range.end_.y - core_range.start_.y + 1;
 
     uint32_t units_to_divide = input_grad.volume() / H / W * Ht * Wt;
 
@@ -141,8 +141,8 @@ operation::ProgramWithCallbacks moreh_nll_loss_backward_impl_4d(
     // Set Runtime Args
     auto element_size = weight_has_value ? weight.value().element_size() : 0;
 
-    auto core_x_offset = core_range.start.x;
-    auto core_y_offset = core_range.start.y;
+    auto core_x_offset = core_range.start_.x;
+    auto core_y_offset = core_range.start_.y;
     for (uint32_t i = 0, tile_offset = 0; i < num_cores; i++) {
         CoreCoord core = {i / core_h + core_x_offset, i % core_h + core_y_offset};
         uint32_t units_per_core;
@@ -220,8 +220,8 @@ operation::ProgramWithCallbacks moreh_nll_loss_backward_impl_3d(
     const bool weight_has_value = weight.has_value();
     const bool divisor_has_value = divisor.has_value();
 
-    uint32_t core_w = core_range.end.x - core_range.start.x + 1;
-    uint32_t core_h = core_range.end.y - core_range.start.y + 1;
+    uint32_t core_w = core_range.end_.x - core_range.start_.x + 1;
+    uint32_t core_h = core_range.end_.y - core_range.start_.y + 1;
 
     uint32_t units_to_divide = input_grad.volume() / TILE_HEIGHT / TILE_WIDTH;
 
@@ -319,8 +319,8 @@ operation::ProgramWithCallbacks moreh_nll_loss_backward_impl_3d(
     // Set Runtime Args
     auto element_size = weight_has_value ? weight.value().element_size() : 0;
 
-    auto core_x_offset = core_range.start.x;
-    auto core_y_offset = core_range.start.y;
+    auto core_x_offset = core_range.start_.x;
+    auto core_y_offset = core_range.start_.y;
     for (uint32_t i = 0, tile_offset = 0; i < num_cores; i++) {
         CoreCoord core = {i / core_h + core_x_offset, i % core_h + core_y_offset};
         uint32_t units_per_core;
@@ -394,8 +394,8 @@ operation::ProgramWithCallbacks moreh_nll_loss_backward_impl_2d(
     const bool weight_has_value = weight.has_value();
     const bool divisor_has_value = divisor.has_value();
 
-    uint32_t core_w = core_range.end.x - core_range.start.x + 1;
-    uint32_t core_h = core_range.end.y - core_range.start.y + 1;
+    uint32_t core_w = core_range.end_.x - core_range.start_.x + 1;
+    uint32_t core_h = core_range.end_.y - core_range.start_.y + 1;
 
     uint32_t units_to_divide = input_grad.volume() / TILE_HEIGHT / TILE_WIDTH;
 
@@ -493,8 +493,8 @@ operation::ProgramWithCallbacks moreh_nll_loss_backward_impl_2d(
     // Set Runtime Args
     auto element_size = weight_has_value ? weight.value().element_size() : 0;
 
-    auto core_x_offset = core_range.start.x;
-    auto core_y_offset = core_range.start.y;
+    auto core_x_offset = core_range.start_.x;
+    auto core_y_offset = core_range.start_.y;
     for (uint32_t i = 0, tile_offset = 0; i < num_cores; i++) {
         CoreCoord core = {i / core_h + core_x_offset, i % core_h + core_y_offset};
         uint32_t units_per_core;

--- a/ttnn/cpp/ttnn/experimental/tt_dnn/op_library/moreh_nll_loss_backward/moreh_nll_loss_backward/moreh_nll_loss_backward.cpp
+++ b/ttnn/cpp/ttnn/experimental/tt_dnn/op_library/moreh_nll_loss_backward/moreh_nll_loss_backward/moreh_nll_loss_backward.cpp
@@ -42,8 +42,8 @@ operation::ProgramWithCallbacks moreh_nll_loss_backward_impl_4d(
     const bool weight_has_value = weight.has_value();
     const bool divisor_has_value = divisor.has_value();
 
-    uint32_t core_w = core_range.end_.x - core_range.start_.x + 1;
-    uint32_t core_h = core_range.end_.y - core_range.start_.y + 1;
+    uint32_t core_w = core_range.end_coord.x - core_range.start_coord.x + 1;
+    uint32_t core_h = core_range.end_coord.y - core_range.start_coord.y + 1;
 
     uint32_t units_to_divide = input_grad.volume() / H / W * Ht * Wt;
 
@@ -141,8 +141,8 @@ operation::ProgramWithCallbacks moreh_nll_loss_backward_impl_4d(
     // Set Runtime Args
     auto element_size = weight_has_value ? weight.value().element_size() : 0;
 
-    auto core_x_offset = core_range.start_.x;
-    auto core_y_offset = core_range.start_.y;
+    auto core_x_offset = core_range.start_coord.x;
+    auto core_y_offset = core_range.start_coord.y;
     for (uint32_t i = 0, tile_offset = 0; i < num_cores; i++) {
         CoreCoord core = {i / core_h + core_x_offset, i % core_h + core_y_offset};
         uint32_t units_per_core;
@@ -220,8 +220,8 @@ operation::ProgramWithCallbacks moreh_nll_loss_backward_impl_3d(
     const bool weight_has_value = weight.has_value();
     const bool divisor_has_value = divisor.has_value();
 
-    uint32_t core_w = core_range.end_.x - core_range.start_.x + 1;
-    uint32_t core_h = core_range.end_.y - core_range.start_.y + 1;
+    uint32_t core_w = core_range.end_coord.x - core_range.start_coord.x + 1;
+    uint32_t core_h = core_range.end_coord.y - core_range.start_coord.y + 1;
 
     uint32_t units_to_divide = input_grad.volume() / TILE_HEIGHT / TILE_WIDTH;
 
@@ -319,8 +319,8 @@ operation::ProgramWithCallbacks moreh_nll_loss_backward_impl_3d(
     // Set Runtime Args
     auto element_size = weight_has_value ? weight.value().element_size() : 0;
 
-    auto core_x_offset = core_range.start_.x;
-    auto core_y_offset = core_range.start_.y;
+    auto core_x_offset = core_range.start_coord.x;
+    auto core_y_offset = core_range.start_coord.y;
     for (uint32_t i = 0, tile_offset = 0; i < num_cores; i++) {
         CoreCoord core = {i / core_h + core_x_offset, i % core_h + core_y_offset};
         uint32_t units_per_core;
@@ -394,8 +394,8 @@ operation::ProgramWithCallbacks moreh_nll_loss_backward_impl_2d(
     const bool weight_has_value = weight.has_value();
     const bool divisor_has_value = divisor.has_value();
 
-    uint32_t core_w = core_range.end_.x - core_range.start_.x + 1;
-    uint32_t core_h = core_range.end_.y - core_range.start_.y + 1;
+    uint32_t core_w = core_range.end_coord.x - core_range.start_coord.x + 1;
+    uint32_t core_h = core_range.end_coord.y - core_range.start_coord.y + 1;
 
     uint32_t units_to_divide = input_grad.volume() / TILE_HEIGHT / TILE_WIDTH;
 
@@ -493,8 +493,8 @@ operation::ProgramWithCallbacks moreh_nll_loss_backward_impl_2d(
     // Set Runtime Args
     auto element_size = weight_has_value ? weight.value().element_size() : 0;
 
-    auto core_x_offset = core_range.start_.x;
-    auto core_y_offset = core_range.start_.y;
+    auto core_x_offset = core_range.start_coord.x;
+    auto core_y_offset = core_range.start_coord.y;
     for (uint32_t i = 0, tile_offset = 0; i < num_cores; i++) {
         CoreCoord core = {i / core_h + core_x_offset, i % core_h + core_y_offset};
         uint32_t units_per_core;

--- a/ttnn/cpp/ttnn/experimental/tt_dnn/op_library/moreh_nll_loss_unreduced_backward/moreh_nll_loss_unreduced_backward.cpp
+++ b/ttnn/cpp/ttnn/experimental/tt_dnn/op_library/moreh_nll_loss_unreduced_backward/moreh_nll_loss_unreduced_backward.cpp
@@ -38,8 +38,8 @@ operation::ProgramWithCallbacks moreh_nll_loss_unreduced_backward_impl_2d(
 
     const bool weight_has_value = weight.has_value();
 
-    uint32_t core_w = core_range.end_.x - core_range.start_.x + 1;
-    uint32_t core_h = core_range.end_.y - core_range.start_.y + 1;
+    uint32_t core_w = core_range.end_coord.x - core_range.start_coord.x + 1;
+    uint32_t core_h = core_range.end_coord.y - core_range.start_coord.y + 1;
 
     uint32_t units_to_divide = input_grad.volume() / TILE_HEIGHT / TILE_WIDTH;
 
@@ -108,8 +108,8 @@ operation::ProgramWithCallbacks moreh_nll_loss_unreduced_backward_impl_2d(
     const auto input_grad_addr = input_grad.buffer()->address();
 
     // Set Runtime Args
-    auto core_x_offset = core_range.start_.x;
-    auto core_y_offset = core_range.start_.y;
+    auto core_x_offset = core_range.start_coord.x;
+    auto core_y_offset = core_range.start_coord.y;
     for (uint32_t i = 0, tile_offset = 0; i < num_cores; i++) {
         CoreCoord core = {i / core_h + core_x_offset, i % core_h + core_y_offset};
         uint32_t units_per_core;
@@ -172,8 +172,8 @@ operation::ProgramWithCallbacks moreh_nll_loss_unreduced_backward_impl_3d(
 
     const bool weight_has_value = weight.has_value();
 
-    uint32_t core_w = core_range.end_.x - core_range.start_.x + 1;
-    uint32_t core_h = core_range.end_.y - core_range.start_.y + 1;
+    uint32_t core_w = core_range.end_coord.x - core_range.start_coord.x + 1;
+    uint32_t core_h = core_range.end_coord.y - core_range.start_coord.y + 1;
 
     uint32_t units_to_divide = input_grad.volume() / TILE_HEIGHT / TILE_WIDTH;
 
@@ -240,8 +240,8 @@ operation::ProgramWithCallbacks moreh_nll_loss_unreduced_backward_impl_3d(
     const auto input_grad_addr = input_grad.buffer()->address();
 
     // Set Runtime Args
-    auto core_x_offset = core_range.start_.x;
-    auto core_y_offset = core_range.start_.y;
+    auto core_x_offset = core_range.start_coord.x;
+    auto core_y_offset = core_range.start_coord.y;
     for (uint32_t i = 0, tile_offset = 0; i < num_cores; i++) {
         CoreCoord core = {i / core_h + core_x_offset, i % core_h + core_y_offset};
         uint32_t units_per_core;
@@ -302,8 +302,8 @@ operation::ProgramWithCallbacks moreh_nll_loss_unreduced_backward_impl_4d(
 
     const bool weight_has_value = weight.has_value();
 
-    uint32_t core_w = core_range.end_.x - core_range.start_.x + 1;
-    uint32_t core_h = core_range.end_.y - core_range.start_.y + 1;
+    uint32_t core_w = core_range.end_coord.x - core_range.start_coord.x + 1;
+    uint32_t core_h = core_range.end_coord.y - core_range.start_coord.y + 1;
 
     uint32_t units_to_divide = input_grad.volume() / H / W * Ht * Wt;
 
@@ -371,8 +371,8 @@ operation::ProgramWithCallbacks moreh_nll_loss_unreduced_backward_impl_4d(
     const auto input_grad_addr = input_grad.buffer()->address();
 
     // Set Runtime Args
-    auto core_x_offset = core_range.start_.x;
-    auto core_y_offset = core_range.start_.y;
+    auto core_x_offset = core_range.start_coord.x;
+    auto core_y_offset = core_range.start_coord.y;
     for (uint32_t i = 0, tile_offset = 0; i < num_cores; i++) {
         CoreCoord core = {i / core_h + core_x_offset, i % core_h + core_y_offset};
         uint32_t units_per_core;

--- a/ttnn/cpp/ttnn/experimental/tt_dnn/op_library/moreh_nll_loss_unreduced_backward/moreh_nll_loss_unreduced_backward.cpp
+++ b/ttnn/cpp/ttnn/experimental/tt_dnn/op_library/moreh_nll_loss_unreduced_backward/moreh_nll_loss_unreduced_backward.cpp
@@ -38,8 +38,8 @@ operation::ProgramWithCallbacks moreh_nll_loss_unreduced_backward_impl_2d(
 
     const bool weight_has_value = weight.has_value();
 
-    uint32_t core_w = core_range.end.x - core_range.start.x + 1;
-    uint32_t core_h = core_range.end.y - core_range.start.y + 1;
+    uint32_t core_w = core_range.end_.x - core_range.start_.x + 1;
+    uint32_t core_h = core_range.end_.y - core_range.start_.y + 1;
 
     uint32_t units_to_divide = input_grad.volume() / TILE_HEIGHT / TILE_WIDTH;
 
@@ -108,8 +108,8 @@ operation::ProgramWithCallbacks moreh_nll_loss_unreduced_backward_impl_2d(
     const auto input_grad_addr = input_grad.buffer()->address();
 
     // Set Runtime Args
-    auto core_x_offset = core_range.start.x;
-    auto core_y_offset = core_range.start.y;
+    auto core_x_offset = core_range.start_.x;
+    auto core_y_offset = core_range.start_.y;
     for (uint32_t i = 0, tile_offset = 0; i < num_cores; i++) {
         CoreCoord core = {i / core_h + core_x_offset, i % core_h + core_y_offset};
         uint32_t units_per_core;
@@ -172,8 +172,8 @@ operation::ProgramWithCallbacks moreh_nll_loss_unreduced_backward_impl_3d(
 
     const bool weight_has_value = weight.has_value();
 
-    uint32_t core_w = core_range.end.x - core_range.start.x + 1;
-    uint32_t core_h = core_range.end.y - core_range.start.y + 1;
+    uint32_t core_w = core_range.end_.x - core_range.start_.x + 1;
+    uint32_t core_h = core_range.end_.y - core_range.start_.y + 1;
 
     uint32_t units_to_divide = input_grad.volume() / TILE_HEIGHT / TILE_WIDTH;
 
@@ -240,8 +240,8 @@ operation::ProgramWithCallbacks moreh_nll_loss_unreduced_backward_impl_3d(
     const auto input_grad_addr = input_grad.buffer()->address();
 
     // Set Runtime Args
-    auto core_x_offset = core_range.start.x;
-    auto core_y_offset = core_range.start.y;
+    auto core_x_offset = core_range.start_.x;
+    auto core_y_offset = core_range.start_.y;
     for (uint32_t i = 0, tile_offset = 0; i < num_cores; i++) {
         CoreCoord core = {i / core_h + core_x_offset, i % core_h + core_y_offset};
         uint32_t units_per_core;
@@ -302,8 +302,8 @@ operation::ProgramWithCallbacks moreh_nll_loss_unreduced_backward_impl_4d(
 
     const bool weight_has_value = weight.has_value();
 
-    uint32_t core_w = core_range.end.x - core_range.start.x + 1;
-    uint32_t core_h = core_range.end.y - core_range.start.y + 1;
+    uint32_t core_w = core_range.end_.x - core_range.start_.x + 1;
+    uint32_t core_h = core_range.end_.y - core_range.start_.y + 1;
 
     uint32_t units_to_divide = input_grad.volume() / H / W * Ht * Wt;
 
@@ -371,8 +371,8 @@ operation::ProgramWithCallbacks moreh_nll_loss_unreduced_backward_impl_4d(
     const auto input_grad_addr = input_grad.buffer()->address();
 
     // Set Runtime Args
-    auto core_x_offset = core_range.start.x;
-    auto core_y_offset = core_range.start.y;
+    auto core_x_offset = core_range.start_.x;
+    auto core_y_offset = core_range.start_.y;
     for (uint32_t i = 0, tile_offset = 0; i < num_cores; i++) {
         CoreCoord core = {i / core_h + core_x_offset, i % core_h + core_y_offset};
         uint32_t units_per_core;

--- a/ttnn/cpp/ttnn/experimental/tt_dnn/op_library/moreh_sgd/moreh_sgd.cpp
+++ b/ttnn/cpp/ttnn/experimental/tt_dnn/op_library/moreh_sgd/moreh_sgd.cpp
@@ -43,8 +43,8 @@ operation::ProgramWithCallbacks moreh_sgd_(
     bool has_momentum_buffer_out = momentum_buffer_out.has_value();
 
     uint32_t units_to_divide = num * Ht * Wt;
-    uint32_t core_w = core_range.end_.x - core_range.start_.x + 1;
-    uint32_t core_h = core_range.end_.y - core_range.start_.y + 1;
+    uint32_t core_w = core_range.end_coord.x - core_range.start_coord.x + 1;
+    uint32_t core_h = core_range.end_coord.y - core_range.start_coord.y + 1;
 
     auto [num_cores, all_cores, core_group_1, core_group_2, num_tiles_per_core_group_1, num_tiles_per_core_group_2] =
         split_work_to_cores(core_range, units_to_divide);
@@ -136,8 +136,8 @@ operation::ProgramWithCallbacks moreh_sgd_(
         math_approx_mode);
 
     // Set Runtime Args
-    auto core_x_offset = core_range.start_.x;
-    auto core_y_offset = core_range.start_.y;
+    auto core_x_offset = core_range.start_coord.x;
+    auto core_y_offset = core_range.start_coord.y;
 
     for (uint32_t i = 0, tile_offset = 0; i < num_cores; i++) {
         CoreCoord core = {i / core_h + core_x_offset, i % core_h + core_y_offset};

--- a/ttnn/cpp/ttnn/experimental/tt_dnn/op_library/moreh_sgd/moreh_sgd.cpp
+++ b/ttnn/cpp/ttnn/experimental/tt_dnn/op_library/moreh_sgd/moreh_sgd.cpp
@@ -43,8 +43,8 @@ operation::ProgramWithCallbacks moreh_sgd_(
     bool has_momentum_buffer_out = momentum_buffer_out.has_value();
 
     uint32_t units_to_divide = num * Ht * Wt;
-    uint32_t core_w = core_range.end.x - core_range.start.x + 1;
-    uint32_t core_h = core_range.end.y - core_range.start.y + 1;
+    uint32_t core_w = core_range.end_.x - core_range.start_.x + 1;
+    uint32_t core_h = core_range.end_.y - core_range.start_.y + 1;
 
     auto [num_cores, all_cores, core_group_1, core_group_2, num_tiles_per_core_group_1, num_tiles_per_core_group_2] =
         split_work_to_cores(core_range, units_to_divide);
@@ -136,8 +136,8 @@ operation::ProgramWithCallbacks moreh_sgd_(
         math_approx_mode);
 
     // Set Runtime Args
-    auto core_x_offset = core_range.start.x;
-    auto core_y_offset = core_range.start.y;
+    auto core_x_offset = core_range.start_.x;
+    auto core_y_offset = core_range.start_.y;
 
     for (uint32_t i = 0, tile_offset = 0; i < num_cores; i++) {
         CoreCoord core = {i / core_h + core_x_offset, i % core_h + core_y_offset};

--- a/ttnn/cpp/ttnn/experimental/tt_dnn/op_library/moreh_softmax/softmax_c_large/softmax_c_large.cpp
+++ b/ttnn/cpp/ttnn/experimental/tt_dnn/op_library/moreh_softmax/softmax_c_large/softmax_c_large.cpp
@@ -29,8 +29,8 @@ operation::ProgramWithCallbacks moreh_softmax_c_large(const Tensor &input, const
 
     uint32_t num_tiles = input.volume() / shape[dim] / H / W * Ht * Wt;
 
-    uint32_t core_w = core_range.end_.x - core_range.start_.x + 1;
-    uint32_t core_h = core_range.end_.y - core_range.start_.y + 1;
+    uint32_t core_w = core_range.end_coord.x - core_range.start_coord.x + 1;
+    uint32_t core_h = core_range.end_coord.y - core_range.start_coord.y + 1;
 
     auto [num_cores, all_cores, core_group_1, core_group_2, num_tiles_per_core_group_1, num_tiles_per_core_group_2] =
         split_work_to_cores(core_range, num_tiles);
@@ -103,8 +103,8 @@ operation::ProgramWithCallbacks moreh_softmax_c_large(const Tensor &input, const
         math_approx_mode);
 
     // Set Runtime Args
-    auto core_x_offset = core_range.start_.x;
-    auto core_y_offset = core_range.start_.y;
+    auto core_x_offset = core_range.start_coord.x;
+    auto core_y_offset = core_range.start_coord.y;
 
     for (uint32_t i = 0, tile_offset = 0; i < num_cores; i++) {
         CoreCoord core = {i / core_h + core_x_offset, i % core_h + core_y_offset};

--- a/ttnn/cpp/ttnn/experimental/tt_dnn/op_library/moreh_softmax/softmax_c_large/softmax_c_large.cpp
+++ b/ttnn/cpp/ttnn/experimental/tt_dnn/op_library/moreh_softmax/softmax_c_large/softmax_c_large.cpp
@@ -29,8 +29,8 @@ operation::ProgramWithCallbacks moreh_softmax_c_large(const Tensor &input, const
 
     uint32_t num_tiles = input.volume() / shape[dim] / H / W * Ht * Wt;
 
-    uint32_t core_w = core_range.end.x - core_range.start.x + 1;
-    uint32_t core_h = core_range.end.y - core_range.start.y + 1;
+    uint32_t core_w = core_range.end_.x - core_range.start_.x + 1;
+    uint32_t core_h = core_range.end_.y - core_range.start_.y + 1;
 
     auto [num_cores, all_cores, core_group_1, core_group_2, num_tiles_per_core_group_1, num_tiles_per_core_group_2] =
         split_work_to_cores(core_range, num_tiles);
@@ -103,8 +103,8 @@ operation::ProgramWithCallbacks moreh_softmax_c_large(const Tensor &input, const
         math_approx_mode);
 
     // Set Runtime Args
-    auto core_x_offset = core_range.start.x;
-    auto core_y_offset = core_range.start.y;
+    auto core_x_offset = core_range.start_.x;
+    auto core_y_offset = core_range.start_.y;
 
     for (uint32_t i = 0, tile_offset = 0; i < num_cores; i++) {
         CoreCoord core = {i / core_h + core_x_offset, i % core_h + core_y_offset};

--- a/ttnn/cpp/ttnn/experimental/tt_dnn/op_library/moreh_softmax/softmax_h_large/softmax_h_large.cpp
+++ b/ttnn/cpp/ttnn/experimental/tt_dnn/op_library/moreh_softmax/softmax_h_large/softmax_h_large.cpp
@@ -29,8 +29,8 @@ operation::ProgramWithCallbacks moreh_softmax_h_large(const Tensor &input, const
 
     auto num = input.volume() / H / W;
     uint32_t num_cols_tiles = num * Wt;
-    uint32_t core_w = core_range.end_.x - core_range.start_.x + 1;
-    uint32_t core_h = core_range.end_.y - core_range.start_.y + 1;
+    uint32_t core_w = core_range.end_coord.x - core_range.start_coord.x + 1;
+    uint32_t core_h = core_range.end_coord.y - core_range.start_coord.y + 1;
 
     auto [num_cores, all_cores, core_group_1, core_group_2, num_tiles_per_core_group_1, num_tiles_per_core_group_2] =
         split_work_to_cores(core_range, num_cols_tiles);
@@ -98,8 +98,8 @@ operation::ProgramWithCallbacks moreh_softmax_h_large(const Tensor &input, const
         math_approx_mode);
 
     // Set Runtime Args
-    auto core_x_offset = core_range.start_.x;
-    auto core_y_offset = core_range.start_.y;
+    auto core_x_offset = core_range.start_coord.x;
+    auto core_y_offset = core_range.start_coord.y;
 
     for (uint32_t i = 0, tile_offset = 0; i < num_cores; i++) {
         CoreCoord core = {i / core_h + core_x_offset, i % core_h + core_y_offset};

--- a/ttnn/cpp/ttnn/experimental/tt_dnn/op_library/moreh_softmax/softmax_h_large/softmax_h_large.cpp
+++ b/ttnn/cpp/ttnn/experimental/tt_dnn/op_library/moreh_softmax/softmax_h_large/softmax_h_large.cpp
@@ -29,8 +29,8 @@ operation::ProgramWithCallbacks moreh_softmax_h_large(const Tensor &input, const
 
     auto num = input.volume() / H / W;
     uint32_t num_cols_tiles = num * Wt;
-    uint32_t core_w = core_range.end.x - core_range.start.x + 1;
-    uint32_t core_h = core_range.end.y - core_range.start.y + 1;
+    uint32_t core_w = core_range.end_.x - core_range.start_.x + 1;
+    uint32_t core_h = core_range.end_.y - core_range.start_.y + 1;
 
     auto [num_cores, all_cores, core_group_1, core_group_2, num_tiles_per_core_group_1, num_tiles_per_core_group_2] =
         split_work_to_cores(core_range, num_cols_tiles);
@@ -98,8 +98,8 @@ operation::ProgramWithCallbacks moreh_softmax_h_large(const Tensor &input, const
         math_approx_mode);
 
     // Set Runtime Args
-    auto core_x_offset = core_range.start.x;
-    auto core_y_offset = core_range.start.y;
+    auto core_x_offset = core_range.start_.x;
+    auto core_y_offset = core_range.start_.y;
 
     for (uint32_t i = 0, tile_offset = 0; i < num_cores; i++) {
         CoreCoord core = {i / core_h + core_x_offset, i % core_h + core_y_offset};

--- a/ttnn/cpp/ttnn/experimental/tt_dnn/op_library/moreh_softmax/softmax_h_small/softmax_h_small.cpp
+++ b/ttnn/cpp/ttnn/experimental/tt_dnn/op_library/moreh_softmax/softmax_h_small/softmax_h_small.cpp
@@ -62,8 +62,8 @@ operation::ProgramWithCallbacks moreh_softmax_h_small(const Tensor &input, const
 
     auto num = input.volume() / H / W;
     uint32_t num_cols_tiles = num * Wt;
-    uint32_t core_w = core_range.end.x - core_range.start.x + 1;
-    uint32_t core_h = core_range.end.y - core_range.start.y + 1;
+    uint32_t core_w = core_range.end_.x - core_range.start_.x + 1;
+    uint32_t core_h = core_range.end_.y - core_range.start_.y + 1;
 
     auto [num_cores, all_cores, core_group_1, core_group_2, num_tiles_per_core_group_1, num_tiles_per_core_group_2] =
         split_work_to_cores(core_range, num_cols_tiles);
@@ -131,8 +131,8 @@ operation::ProgramWithCallbacks moreh_softmax_h_small(const Tensor &input, const
         math_approx_mode);
 
     // Set Runtime Args
-    auto core_x_offset = core_range.start.x;
-    auto core_y_offset = core_range.start.y;
+    auto core_x_offset = core_range.start_.x;
+    auto core_y_offset = core_range.start_.y;
 
     for (uint32_t i = 0, tile_offset = 0; i < num_cores; i++) {
         CoreCoord core = {i / core_h + core_x_offset, i % core_h + core_y_offset};

--- a/ttnn/cpp/ttnn/experimental/tt_dnn/op_library/moreh_softmax/softmax_h_small/softmax_h_small.cpp
+++ b/ttnn/cpp/ttnn/experimental/tt_dnn/op_library/moreh_softmax/softmax_h_small/softmax_h_small.cpp
@@ -62,8 +62,8 @@ operation::ProgramWithCallbacks moreh_softmax_h_small(const Tensor &input, const
 
     auto num = input.volume() / H / W;
     uint32_t num_cols_tiles = num * Wt;
-    uint32_t core_w = core_range.end_.x - core_range.start_.x + 1;
-    uint32_t core_h = core_range.end_.y - core_range.start_.y + 1;
+    uint32_t core_w = core_range.end_coord.x - core_range.start_coord.x + 1;
+    uint32_t core_h = core_range.end_coord.y - core_range.start_coord.y + 1;
 
     auto [num_cores, all_cores, core_group_1, core_group_2, num_tiles_per_core_group_1, num_tiles_per_core_group_2] =
         split_work_to_cores(core_range, num_cols_tiles);
@@ -131,8 +131,8 @@ operation::ProgramWithCallbacks moreh_softmax_h_small(const Tensor &input, const
         math_approx_mode);
 
     // Set Runtime Args
-    auto core_x_offset = core_range.start_.x;
-    auto core_y_offset = core_range.start_.y;
+    auto core_x_offset = core_range.start_coord.x;
+    auto core_y_offset = core_range.start_coord.y;
 
     for (uint32_t i = 0, tile_offset = 0; i < num_cores; i++) {
         CoreCoord core = {i / core_h + core_x_offset, i % core_h + core_y_offset};

--- a/ttnn/cpp/ttnn/experimental/tt_dnn/op_library/moreh_softmax/softmax_w_large/softmax_w_large.cpp
+++ b/ttnn/cpp/ttnn/experimental/tt_dnn/op_library/moreh_softmax/softmax_w_large/softmax_w_large.cpp
@@ -30,8 +30,8 @@ operation::ProgramWithCallbacks moreh_softmax_w_large(const Tensor &input, const
     auto num = input.volume() / H / W;
 
     uint32_t num_kernel_rows = num * Ht;
-    uint32_t core_w = core_range.end_.x - core_range.start_.x + 1;
-    uint32_t core_h = core_range.end_.y - core_range.start_.y + 1;
+    uint32_t core_w = core_range.end_coord.x - core_range.start_coord.x + 1;
+    uint32_t core_h = core_range.end_coord.y - core_range.start_coord.y + 1;
 
     auto [num_cores, all_cores, core_group_1, core_group_2, num_tiles_per_core_group_1, num_tiles_per_core_group_2] =
         split_work_to_cores(core_range, num_kernel_rows);
@@ -99,8 +99,8 @@ operation::ProgramWithCallbacks moreh_softmax_w_large(const Tensor &input, const
         math_approx_mode);
 
     // Set Runtime Args
-    auto core_x_offset = core_range.start_.x;
-    auto core_y_offset = core_range.start_.y;
+    auto core_x_offset = core_range.start_coord.x;
+    auto core_y_offset = core_range.start_coord.y;
 
     for (uint32_t i = 0, tile_offset = 0; i < num_cores; i++) {
         CoreCoord core = {i / core_h + core_x_offset, i % core_h + core_y_offset};

--- a/ttnn/cpp/ttnn/experimental/tt_dnn/op_library/moreh_softmax/softmax_w_large/softmax_w_large.cpp
+++ b/ttnn/cpp/ttnn/experimental/tt_dnn/op_library/moreh_softmax/softmax_w_large/softmax_w_large.cpp
@@ -30,8 +30,8 @@ operation::ProgramWithCallbacks moreh_softmax_w_large(const Tensor &input, const
     auto num = input.volume() / H / W;
 
     uint32_t num_kernel_rows = num * Ht;
-    uint32_t core_w = core_range.end.x - core_range.start.x + 1;
-    uint32_t core_h = core_range.end.y - core_range.start.y + 1;
+    uint32_t core_w = core_range.end_.x - core_range.start_.x + 1;
+    uint32_t core_h = core_range.end_.y - core_range.start_.y + 1;
 
     auto [num_cores, all_cores, core_group_1, core_group_2, num_tiles_per_core_group_1, num_tiles_per_core_group_2] =
         split_work_to_cores(core_range, num_kernel_rows);
@@ -99,8 +99,8 @@ operation::ProgramWithCallbacks moreh_softmax_w_large(const Tensor &input, const
         math_approx_mode);
 
     // Set Runtime Args
-    auto core_x_offset = core_range.start.x;
-    auto core_y_offset = core_range.start.y;
+    auto core_x_offset = core_range.start_.x;
+    auto core_y_offset = core_range.start_.y;
 
     for (uint32_t i = 0, tile_offset = 0; i < num_cores; i++) {
         CoreCoord core = {i / core_h + core_x_offset, i % core_h + core_y_offset};

--- a/ttnn/cpp/ttnn/experimental/tt_dnn/op_library/moreh_softmax/softmax_w_small/softmax_w_small.cpp
+++ b/ttnn/cpp/ttnn/experimental/tt_dnn/op_library/moreh_softmax/softmax_w_small/softmax_w_small.cpp
@@ -62,8 +62,8 @@ operation::ProgramWithCallbacks moreh_softmax_w_small(const Tensor &input, const
     auto num = input.volume() / H / W;
 
     uint32_t num_kernel_rows = num * Ht;
-    uint32_t core_w = core_range.end_.x - core_range.start_.x + 1;
-    uint32_t core_h = core_range.end_.y - core_range.start_.y + 1;
+    uint32_t core_w = core_range.end_coord.x - core_range.start_coord.x + 1;
+    uint32_t core_h = core_range.end_coord.y - core_range.start_coord.y + 1;
 
     auto [num_cores, all_cores, core_group_1, core_group_2, num_tiles_per_core_group_1, num_tiles_per_core_group_2] =
         split_work_to_cores(core_range, num_kernel_rows);
@@ -131,8 +131,8 @@ operation::ProgramWithCallbacks moreh_softmax_w_small(const Tensor &input, const
         math_approx_mode);
 
     // Set Runtime Args
-    auto core_x_offset = core_range.start_.x;
-    auto core_y_offset = core_range.start_.y;
+    auto core_x_offset = core_range.start_coord.x;
+    auto core_y_offset = core_range.start_coord.y;
 
     for (uint32_t i = 0, tile_offset = 0; i < num_cores; i++) {
         CoreCoord core = {i / core_h + core_x_offset, i % core_h + core_y_offset};

--- a/ttnn/cpp/ttnn/experimental/tt_dnn/op_library/moreh_softmax/softmax_w_small/softmax_w_small.cpp
+++ b/ttnn/cpp/ttnn/experimental/tt_dnn/op_library/moreh_softmax/softmax_w_small/softmax_w_small.cpp
@@ -62,8 +62,8 @@ operation::ProgramWithCallbacks moreh_softmax_w_small(const Tensor &input, const
     auto num = input.volume() / H / W;
 
     uint32_t num_kernel_rows = num * Ht;
-    uint32_t core_w = core_range.end.x - core_range.start.x + 1;
-    uint32_t core_h = core_range.end.y - core_range.start.y + 1;
+    uint32_t core_w = core_range.end_.x - core_range.start_.x + 1;
+    uint32_t core_h = core_range.end_.y - core_range.start_.y + 1;
 
     auto [num_cores, all_cores, core_group_1, core_group_2, num_tiles_per_core_group_1, num_tiles_per_core_group_2] =
         split_work_to_cores(core_range, num_kernel_rows);
@@ -131,8 +131,8 @@ operation::ProgramWithCallbacks moreh_softmax_w_small(const Tensor &input, const
         math_approx_mode);
 
     // Set Runtime Args
-    auto core_x_offset = core_range.start.x;
-    auto core_y_offset = core_range.start.y;
+    auto core_x_offset = core_range.start_.x;
+    auto core_y_offset = core_range.start_.y;
 
     for (uint32_t i = 0, tile_offset = 0; i < num_cores; i++) {
         CoreCoord core = {i / core_h + core_x_offset, i % core_h + core_y_offset};

--- a/ttnn/cpp/ttnn/experimental/tt_dnn/op_library/moreh_softmax_backward/softmax_backward_c_large/softmax_backward_c_large.cpp
+++ b/ttnn/cpp/ttnn/experimental/tt_dnn/op_library/moreh_softmax_backward/softmax_backward_c_large/softmax_backward_c_large.cpp
@@ -30,8 +30,8 @@ operation::ProgramWithCallbacks moreh_softmax_backward_c_large(const Tensor &out
 
     uint32_t num_tiles = input_grad.volume() / shape[dim] / H / W * Ht * Wt;
 
-    uint32_t core_w = core_range.end_.x - core_range.start_.x + 1;
-    uint32_t core_h = core_range.end_.y - core_range.start_.y + 1;
+    uint32_t core_w = core_range.end_coord.x - core_range.start_coord.x + 1;
+    uint32_t core_h = core_range.end_coord.y - core_range.start_coord.y + 1;
 
     auto [num_cores, all_cores, core_group_1, core_group_2, num_tiles_per_core_group_1, num_tiles_per_core_group_2] =
         split_work_to_cores(core_range, num_tiles);
@@ -104,8 +104,8 @@ operation::ProgramWithCallbacks moreh_softmax_backward_c_large(const Tensor &out
         math_approx_mode);
 
     // Set Runtime Args
-    auto core_x_offset = core_range.start_.x;
-    auto core_y_offset = core_range.start_.y;
+    auto core_x_offset = core_range.start_coord.x;
+    auto core_y_offset = core_range.start_coord.y;
 
     for (uint32_t i = 0, tile_offset = 0; i < num_cores; i++) {
         CoreCoord core = {i / core_h + core_x_offset, i % core_h + core_y_offset};

--- a/ttnn/cpp/ttnn/experimental/tt_dnn/op_library/moreh_softmax_backward/softmax_backward_c_large/softmax_backward_c_large.cpp
+++ b/ttnn/cpp/ttnn/experimental/tt_dnn/op_library/moreh_softmax_backward/softmax_backward_c_large/softmax_backward_c_large.cpp
@@ -30,8 +30,8 @@ operation::ProgramWithCallbacks moreh_softmax_backward_c_large(const Tensor &out
 
     uint32_t num_tiles = input_grad.volume() / shape[dim] / H / W * Ht * Wt;
 
-    uint32_t core_w = core_range.end.x - core_range.start.x + 1;
-    uint32_t core_h = core_range.end.y - core_range.start.y + 1;
+    uint32_t core_w = core_range.end_.x - core_range.start_.x + 1;
+    uint32_t core_h = core_range.end_.y - core_range.start_.y + 1;
 
     auto [num_cores, all_cores, core_group_1, core_group_2, num_tiles_per_core_group_1, num_tiles_per_core_group_2] =
         split_work_to_cores(core_range, num_tiles);
@@ -104,8 +104,8 @@ operation::ProgramWithCallbacks moreh_softmax_backward_c_large(const Tensor &out
         math_approx_mode);
 
     // Set Runtime Args
-    auto core_x_offset = core_range.start.x;
-    auto core_y_offset = core_range.start.y;
+    auto core_x_offset = core_range.start_.x;
+    auto core_y_offset = core_range.start_.y;
 
     for (uint32_t i = 0, tile_offset = 0; i < num_cores; i++) {
         CoreCoord core = {i / core_h + core_x_offset, i % core_h + core_y_offset};

--- a/ttnn/cpp/ttnn/experimental/tt_dnn/op_library/moreh_softmax_backward/softmax_backward_h_large/softmax_backward_h_large.cpp
+++ b/ttnn/cpp/ttnn/experimental/tt_dnn/op_library/moreh_softmax_backward/softmax_backward_h_large/softmax_backward_h_large.cpp
@@ -31,8 +31,8 @@ operation::ProgramWithCallbacks moreh_softmax_backward_h_large(const Tensor &out
     auto num = input_grad.volume() / H / W;
 
     uint32_t num_cols_tiles = num * Wt;
-    uint32_t core_w = core_range.end.x - core_range.start.x + 1;
-    uint32_t core_h = core_range.end.y - core_range.start.y + 1;
+    uint32_t core_w = core_range.end_.x - core_range.start_.x + 1;
+    uint32_t core_h = core_range.end_.y - core_range.start_.y + 1;
 
     auto [num_cores, all_cores, core_group_1, core_group_2, num_tiles_per_core_group_1, num_tiles_per_core_group_2] =
         split_work_to_cores(core_range, num_cols_tiles);
@@ -100,8 +100,8 @@ operation::ProgramWithCallbacks moreh_softmax_backward_h_large(const Tensor &out
         math_approx_mode);
 
     // Set Runtime Args
-    auto core_x_offset = core_range.start.x;
-    auto core_y_offset = core_range.start.y;
+    auto core_x_offset = core_range.start_.x;
+    auto core_y_offset = core_range.start_.y;
 
     for (uint32_t i = 0, tile_offset = 0; i < num_cores; i++) {
         CoreCoord core = {i / core_h + core_x_offset, i % core_h + core_y_offset};

--- a/ttnn/cpp/ttnn/experimental/tt_dnn/op_library/moreh_softmax_backward/softmax_backward_h_large/softmax_backward_h_large.cpp
+++ b/ttnn/cpp/ttnn/experimental/tt_dnn/op_library/moreh_softmax_backward/softmax_backward_h_large/softmax_backward_h_large.cpp
@@ -31,8 +31,8 @@ operation::ProgramWithCallbacks moreh_softmax_backward_h_large(const Tensor &out
     auto num = input_grad.volume() / H / W;
 
     uint32_t num_cols_tiles = num * Wt;
-    uint32_t core_w = core_range.end_.x - core_range.start_.x + 1;
-    uint32_t core_h = core_range.end_.y - core_range.start_.y + 1;
+    uint32_t core_w = core_range.end_coord.x - core_range.start_coord.x + 1;
+    uint32_t core_h = core_range.end_coord.y - core_range.start_coord.y + 1;
 
     auto [num_cores, all_cores, core_group_1, core_group_2, num_tiles_per_core_group_1, num_tiles_per_core_group_2] =
         split_work_to_cores(core_range, num_cols_tiles);
@@ -100,8 +100,8 @@ operation::ProgramWithCallbacks moreh_softmax_backward_h_large(const Tensor &out
         math_approx_mode);
 
     // Set Runtime Args
-    auto core_x_offset = core_range.start_.x;
-    auto core_y_offset = core_range.start_.y;
+    auto core_x_offset = core_range.start_coord.x;
+    auto core_y_offset = core_range.start_coord.y;
 
     for (uint32_t i = 0, tile_offset = 0; i < num_cores; i++) {
         CoreCoord core = {i / core_h + core_x_offset, i % core_h + core_y_offset};

--- a/ttnn/cpp/ttnn/experimental/tt_dnn/op_library/moreh_softmax_backward/softmax_backward_h_small/softmax_backward_h_small.cpp
+++ b/ttnn/cpp/ttnn/experimental/tt_dnn/op_library/moreh_softmax_backward/softmax_backward_h_small/softmax_backward_h_small.cpp
@@ -54,8 +54,8 @@ operation::ProgramWithCallbacks moreh_softmax_backward_h_small(const Tensor &out
     auto num = input_grad.volume() / H / W;
 
     uint32_t num_cols_tiles = num * Wt;
-    uint32_t core_w = core_range.end_.x - core_range.start_.x + 1;
-    uint32_t core_h = core_range.end_.y - core_range.start_.y + 1;
+    uint32_t core_w = core_range.end_coord.x - core_range.start_coord.x + 1;
+    uint32_t core_h = core_range.end_coord.y - core_range.start_coord.y + 1;
 
     auto [num_cores, all_cores, core_group_1, core_group_2, num_tiles_per_core_group_1, num_tiles_per_core_group_2] =
         split_work_to_cores(core_range, num_cols_tiles);
@@ -122,8 +122,8 @@ operation::ProgramWithCallbacks moreh_softmax_backward_h_small(const Tensor &out
         math_approx_mode);
 
     // Set Runtime Args
-    auto core_x_offset = core_range.start_.x;
-    auto core_y_offset = core_range.start_.y;
+    auto core_x_offset = core_range.start_coord.x;
+    auto core_y_offset = core_range.start_coord.y;
 
     for (uint32_t i = 0, tile_offset = 0; i < num_cores; i++) {
         CoreCoord core = {i / core_h + core_x_offset, i % core_h + core_y_offset};

--- a/ttnn/cpp/ttnn/experimental/tt_dnn/op_library/moreh_softmax_backward/softmax_backward_h_small/softmax_backward_h_small.cpp
+++ b/ttnn/cpp/ttnn/experimental/tt_dnn/op_library/moreh_softmax_backward/softmax_backward_h_small/softmax_backward_h_small.cpp
@@ -54,8 +54,8 @@ operation::ProgramWithCallbacks moreh_softmax_backward_h_small(const Tensor &out
     auto num = input_grad.volume() / H / W;
 
     uint32_t num_cols_tiles = num * Wt;
-    uint32_t core_w = core_range.end.x - core_range.start.x + 1;
-    uint32_t core_h = core_range.end.y - core_range.start.y + 1;
+    uint32_t core_w = core_range.end_.x - core_range.start_.x + 1;
+    uint32_t core_h = core_range.end_.y - core_range.start_.y + 1;
 
     auto [num_cores, all_cores, core_group_1, core_group_2, num_tiles_per_core_group_1, num_tiles_per_core_group_2] =
         split_work_to_cores(core_range, num_cols_tiles);
@@ -122,8 +122,8 @@ operation::ProgramWithCallbacks moreh_softmax_backward_h_small(const Tensor &out
         math_approx_mode);
 
     // Set Runtime Args
-    auto core_x_offset = core_range.start.x;
-    auto core_y_offset = core_range.start.y;
+    auto core_x_offset = core_range.start_.x;
+    auto core_y_offset = core_range.start_.y;
 
     for (uint32_t i = 0, tile_offset = 0; i < num_cores; i++) {
         CoreCoord core = {i / core_h + core_x_offset, i % core_h + core_y_offset};

--- a/ttnn/cpp/ttnn/experimental/tt_dnn/op_library/moreh_softmax_backward/softmax_backward_w_large/softmax_backward_w_large.cpp
+++ b/ttnn/cpp/ttnn/experimental/tt_dnn/op_library/moreh_softmax_backward/softmax_backward_w_large/softmax_backward_w_large.cpp
@@ -30,8 +30,8 @@ operation::ProgramWithCallbacks moreh_softmax_backward_w_large(const Tensor &out
     auto num = input_grad.volume() / H / W;
 
     uint32_t num_kernel_rows = num * Ht;
-    uint32_t core_w = core_range.end.x - core_range.start.x + 1;
-    uint32_t core_h = core_range.end.y - core_range.start.y + 1;
+    uint32_t core_w = core_range.end_.x - core_range.start_.x + 1;
+    uint32_t core_h = core_range.end_.y - core_range.start_.y + 1;
 
     auto [num_cores, all_cores, core_group_1, core_group_2, num_tiles_per_core_group_1, num_tiles_per_core_group_2] =
         split_work_to_cores(core_range, num_kernel_rows);
@@ -100,8 +100,8 @@ operation::ProgramWithCallbacks moreh_softmax_backward_w_large(const Tensor &out
         math_approx_mode);
 
     // Set Runtime Args
-    auto core_x_offset = core_range.start.x;
-    auto core_y_offset = core_range.start.y;
+    auto core_x_offset = core_range.start_.x;
+    auto core_y_offset = core_range.start_.y;
 
     for (uint32_t i = 0, tile_offset = 0; i < num_cores; i++) {
         CoreCoord core = {i / core_h + core_x_offset, i % core_h + core_y_offset};

--- a/ttnn/cpp/ttnn/experimental/tt_dnn/op_library/moreh_softmax_backward/softmax_backward_w_large/softmax_backward_w_large.cpp
+++ b/ttnn/cpp/ttnn/experimental/tt_dnn/op_library/moreh_softmax_backward/softmax_backward_w_large/softmax_backward_w_large.cpp
@@ -30,8 +30,8 @@ operation::ProgramWithCallbacks moreh_softmax_backward_w_large(const Tensor &out
     auto num = input_grad.volume() / H / W;
 
     uint32_t num_kernel_rows = num * Ht;
-    uint32_t core_w = core_range.end_.x - core_range.start_.x + 1;
-    uint32_t core_h = core_range.end_.y - core_range.start_.y + 1;
+    uint32_t core_w = core_range.end_coord.x - core_range.start_coord.x + 1;
+    uint32_t core_h = core_range.end_coord.y - core_range.start_coord.y + 1;
 
     auto [num_cores, all_cores, core_group_1, core_group_2, num_tiles_per_core_group_1, num_tiles_per_core_group_2] =
         split_work_to_cores(core_range, num_kernel_rows);
@@ -100,8 +100,8 @@ operation::ProgramWithCallbacks moreh_softmax_backward_w_large(const Tensor &out
         math_approx_mode);
 
     // Set Runtime Args
-    auto core_x_offset = core_range.start_.x;
-    auto core_y_offset = core_range.start_.y;
+    auto core_x_offset = core_range.start_coord.x;
+    auto core_y_offset = core_range.start_coord.y;
 
     for (uint32_t i = 0, tile_offset = 0; i < num_cores; i++) {
         CoreCoord core = {i / core_h + core_x_offset, i % core_h + core_y_offset};

--- a/ttnn/cpp/ttnn/experimental/tt_dnn/op_library/moreh_softmax_backward/softmax_backward_w_small/softmax_backward_w_small.cpp
+++ b/ttnn/cpp/ttnn/experimental/tt_dnn/op_library/moreh_softmax_backward/softmax_backward_w_small/softmax_backward_w_small.cpp
@@ -55,8 +55,8 @@ operation::ProgramWithCallbacks moreh_softmax_backward_w_small(const Tensor &out
     auto num = input_grad.volume() / H / W;
 
     uint32_t num_kernel_rows = num * Ht;
-    uint32_t core_w = core_range.end.x - core_range.start.x + 1;
-    uint32_t core_h = core_range.end.y - core_range.start.y + 1;
+    uint32_t core_w = core_range.end_.x - core_range.start_.x + 1;
+    uint32_t core_h = core_range.end_.y - core_range.start_.y + 1;
 
     auto [num_cores, all_cores, core_group_1, core_group_2, num_tiles_per_core_group_1, num_tiles_per_core_group_2] =
         split_work_to_cores(core_range, num_kernel_rows);
@@ -123,8 +123,8 @@ operation::ProgramWithCallbacks moreh_softmax_backward_w_small(const Tensor &out
         math_approx_mode);
 
     // Set Runtime Args
-    auto core_x_offset = core_range.start.x;
-    auto core_y_offset = core_range.start.y;
+    auto core_x_offset = core_range.start_.x;
+    auto core_y_offset = core_range.start_.y;
 
     for (uint32_t i = 0, tile_offset = 0; i < num_cores; i++) {
         CoreCoord core = {i / core_h + core_x_offset, i % core_h + core_y_offset};

--- a/ttnn/cpp/ttnn/experimental/tt_dnn/op_library/moreh_softmax_backward/softmax_backward_w_small/softmax_backward_w_small.cpp
+++ b/ttnn/cpp/ttnn/experimental/tt_dnn/op_library/moreh_softmax_backward/softmax_backward_w_small/softmax_backward_w_small.cpp
@@ -55,8 +55,8 @@ operation::ProgramWithCallbacks moreh_softmax_backward_w_small(const Tensor &out
     auto num = input_grad.volume() / H / W;
 
     uint32_t num_kernel_rows = num * Ht;
-    uint32_t core_w = core_range.end_.x - core_range.start_.x + 1;
-    uint32_t core_h = core_range.end_.y - core_range.start_.y + 1;
+    uint32_t core_w = core_range.end_coord.x - core_range.start_coord.x + 1;
+    uint32_t core_h = core_range.end_coord.y - core_range.start_coord.y + 1;
 
     auto [num_cores, all_cores, core_group_1, core_group_2, num_tiles_per_core_group_1, num_tiles_per_core_group_2] =
         split_work_to_cores(core_range, num_kernel_rows);
@@ -123,8 +123,8 @@ operation::ProgramWithCallbacks moreh_softmax_backward_w_small(const Tensor &out
         math_approx_mode);
 
     // Set Runtime Args
-    auto core_x_offset = core_range.start_.x;
-    auto core_y_offset = core_range.start_.y;
+    auto core_x_offset = core_range.start_coord.x;
+    auto core_y_offset = core_range.start_coord.y;
 
     for (uint32_t i = 0, tile_offset = 0; i < num_cores; i++) {
         CoreCoord core = {i / core_h + core_x_offset, i % core_h + core_y_offset};

--- a/ttnn/cpp/ttnn/experimental/tt_dnn/op_library/move/multi_core/move_op_multi_core_overlap.cpp
+++ b/ttnn/cpp/ttnn/experimental/tt_dnn/op_library/move/multi_core/move_op_multi_core_overlap.cpp
@@ -25,11 +25,11 @@ std::vector<CoreRange> get_multicast_regions(const Device *device, const CoreRan
 
     std::vector<CoreRange> logical_core_ranges;
     auto split_core_range_containing_controller = [&](const CoreRange &controller_core_range) {
-        TT_ASSERT(controller_core_range.start == logical_controller);
-        CoreRange right_block(CoreCoord(logical_controller.x + 1, logical_controller.y), controller_core_range.end);
+        TT_ASSERT(controller_core_range.start_ == logical_controller);
+        CoreRange right_block(CoreCoord(logical_controller.x + 1, logical_controller.y), controller_core_range.end_);
         CoreRange remaining_stick = CoreRange(
             CoreCoord(logical_controller.x, logical_controller.y + 1),
-            CoreCoord(logical_controller.x, controller_core_range.end.y)
+            CoreCoord(logical_controller.x, controller_core_range.end_.y)
         );
 
         logical_core_ranges.push_back(right_block);
@@ -41,10 +41,10 @@ std::vector<CoreRange> get_multicast_regions(const Device *device, const CoreRan
         split_core_range_containing_controller(range_0);
     } else {
         CoreRange range_1 = *all_cores.ranges().rbegin();
-        if (range_0.start == logical_controller) {
+        if (range_0.start_ == logical_controller) {
             split_core_range_containing_controller(range_0);
             logical_core_ranges.push_back(range_1);
-        } else if (range_1.start == logical_controller) {
+        } else if (range_1.start_ == logical_controller) {
             split_core_range_containing_controller(range_1);
             logical_core_ranges.push_back(range_0);
         } else {
@@ -113,7 +113,7 @@ operation::ProgramWithCallbacks move_multi_core_with_overlap(const Tensor &input
 
     std::vector<CoreRange> noc_multicast_regions;
     for (const auto &logical_cr : logical_multicast_regions) {
-        CoreRange noc_cr(device->worker_core_from_logical_core(logical_cr.start), device->worker_core_from_logical_core(logical_cr.end));
+        CoreRange noc_cr(device->worker_core_from_logical_core(logical_cr.start_), device->worker_core_from_logical_core(logical_cr.end_));
         noc_multicast_regions.push_back(std::move(noc_cr));
     }
 
@@ -145,20 +145,20 @@ operation::ProgramWithCallbacks move_multi_core_with_overlap(const Tensor &input
             (uint32_t)noc_controller.y,
             /*control_value=*/(num_cores - 1),
             (uint32_t)is_controller,
-            (uint32_t)range_0_noc.start.x,
-            (uint32_t)range_0_noc.start.y,
-            (uint32_t)range_0_noc.end.x,
-            (uint32_t)range_0_noc.end.y,
+            (uint32_t)range_0_noc.start_.x,
+            (uint32_t)range_0_noc.start_.y,
+            (uint32_t)range_0_noc.end_.x,
+            (uint32_t)range_0_noc.end_.y,
             (uint32_t)logical_multicast_regions[0].size(),
-            (uint32_t)range_1_noc.start.x,
-            (uint32_t)range_1_noc.start.y,
-            (uint32_t)range_1_noc.end.x,
-            (uint32_t)range_1_noc.end.y,
+            (uint32_t)range_1_noc.start_.x,
+            (uint32_t)range_1_noc.start_.y,
+            (uint32_t)range_1_noc.end_.x,
+            (uint32_t)range_1_noc.end_.y,
             (uint32_t)logical_multicast_regions[1].size(),
-            (uint32_t)noc_multicast_regions.back().start.x,
-            (uint32_t)noc_multicast_regions.back().start.y,
-            (uint32_t)noc_multicast_regions.back().end.x,
-            (uint32_t)noc_multicast_regions.back().end.y,
+            (uint32_t)noc_multicast_regions.back().start_.x,
+            (uint32_t)noc_multicast_regions.back().start_.y,
+            (uint32_t)noc_multicast_regions.back().end_.x,
+            (uint32_t)noc_multicast_regions.back().end_.y,
             (uint32_t)logical_multicast_regions.back().size(),
             (uint32_t)do_third_multicast
         };

--- a/ttnn/cpp/ttnn/experimental/tt_dnn/op_library/move/multi_core/move_op_multi_core_overlap.cpp
+++ b/ttnn/cpp/ttnn/experimental/tt_dnn/op_library/move/multi_core/move_op_multi_core_overlap.cpp
@@ -25,11 +25,11 @@ std::vector<CoreRange> get_multicast_regions(const Device *device, const CoreRan
 
     std::vector<CoreRange> logical_core_ranges;
     auto split_core_range_containing_controller = [&](const CoreRange &controller_core_range) {
-        TT_ASSERT(controller_core_range.start_ == logical_controller);
-        CoreRange right_block(CoreCoord(logical_controller.x + 1, logical_controller.y), controller_core_range.end_);
+        TT_ASSERT(controller_core_range.start_coord == logical_controller);
+        CoreRange right_block(CoreCoord(logical_controller.x + 1, logical_controller.y), controller_core_range.end_coord);
         CoreRange remaining_stick = CoreRange(
             CoreCoord(logical_controller.x, logical_controller.y + 1),
-            CoreCoord(logical_controller.x, controller_core_range.end_.y)
+            CoreCoord(logical_controller.x, controller_core_range.end_coord.y)
         );
 
         logical_core_ranges.push_back(right_block);
@@ -41,10 +41,10 @@ std::vector<CoreRange> get_multicast_regions(const Device *device, const CoreRan
         split_core_range_containing_controller(range_0);
     } else {
         CoreRange range_1 = *all_cores.ranges().rbegin();
-        if (range_0.start_ == logical_controller) {
+        if (range_0.start_coord == logical_controller) {
             split_core_range_containing_controller(range_0);
             logical_core_ranges.push_back(range_1);
-        } else if (range_1.start_ == logical_controller) {
+        } else if (range_1.start_coord == logical_controller) {
             split_core_range_containing_controller(range_1);
             logical_core_ranges.push_back(range_0);
         } else {
@@ -113,7 +113,7 @@ operation::ProgramWithCallbacks move_multi_core_with_overlap(const Tensor &input
 
     std::vector<CoreRange> noc_multicast_regions;
     for (const auto &logical_cr : logical_multicast_regions) {
-        CoreRange noc_cr(device->worker_core_from_logical_core(logical_cr.start_), device->worker_core_from_logical_core(logical_cr.end_));
+        CoreRange noc_cr(device->worker_core_from_logical_core(logical_cr.start_coord), device->worker_core_from_logical_core(logical_cr.end_coord));
         noc_multicast_regions.push_back(std::move(noc_cr));
     }
 
@@ -145,20 +145,20 @@ operation::ProgramWithCallbacks move_multi_core_with_overlap(const Tensor &input
             (uint32_t)noc_controller.y,
             /*control_value=*/(num_cores - 1),
             (uint32_t)is_controller,
-            (uint32_t)range_0_noc.start_.x,
-            (uint32_t)range_0_noc.start_.y,
-            (uint32_t)range_0_noc.end_.x,
-            (uint32_t)range_0_noc.end_.y,
+            (uint32_t)range_0_noc.start_coord.x,
+            (uint32_t)range_0_noc.start_coord.y,
+            (uint32_t)range_0_noc.end_coord.x,
+            (uint32_t)range_0_noc.end_coord.y,
             (uint32_t)logical_multicast_regions[0].size(),
-            (uint32_t)range_1_noc.start_.x,
-            (uint32_t)range_1_noc.start_.y,
-            (uint32_t)range_1_noc.end_.x,
-            (uint32_t)range_1_noc.end_.y,
+            (uint32_t)range_1_noc.start_coord.x,
+            (uint32_t)range_1_noc.start_coord.y,
+            (uint32_t)range_1_noc.end_coord.x,
+            (uint32_t)range_1_noc.end_coord.y,
             (uint32_t)logical_multicast_regions[1].size(),
-            (uint32_t)noc_multicast_regions.back().start_.x,
-            (uint32_t)noc_multicast_regions.back().start_.y,
-            (uint32_t)noc_multicast_regions.back().end_.x,
-            (uint32_t)noc_multicast_regions.back().end_.y,
+            (uint32_t)noc_multicast_regions.back().start_coord.x,
+            (uint32_t)noc_multicast_regions.back().start_coord.y,
+            (uint32_t)noc_multicast_regions.back().end_coord.x,
+            (uint32_t)noc_multicast_regions.back().end_coord.y,
             (uint32_t)logical_multicast_regions.back().size(),
             (uint32_t)do_third_multicast
         };

--- a/ttnn/cpp/ttnn/experimental/tt_dnn/op_library/nlp_tms/multi_core_create_q_and_kv_heads_separate/multi_core_create_q_and_kv_heads.cpp
+++ b/ttnn/cpp/ttnn/experimental/tt_dnn/op_library/nlp_tms/multi_core_create_q_and_kv_heads_separate/multi_core_create_q_and_kv_heads.cpp
@@ -20,8 +20,8 @@ static inline operation::ProgramWithCallbacks create_qkv_separate(const Tensor &
     auto bbox = all_cores.bounding_box();
     ShardOrientation shard_orientation = shard_spec.orientation;
     bool rm = shard_orientation == ShardOrientation::ROW_MAJOR;
-    uint32_t num_h_cores = rm ? bbox.end_.y + 1 : bbox.end_.x + 1;
-    uint32_t num_w_cores = rm ? bbox.end_.x + 1 : bbox.end_.y + 1;
+    uint32_t num_h_cores = rm ? bbox.end_coord.y + 1 : bbox.end_coord.x + 1;
+    uint32_t num_w_cores = rm ? bbox.end_coord.x + 1 : bbox.end_coord.y + 1;
 
     uint32_t q_shard_wt = (q_shape[3]) / (num_w_cores * TILE_WIDTH); // number of tiles in width dimension  - multiple tiles per head, multiple heads per group, multiple tensors in group, multiple groups per cores
     uint32_t q_shard_ht = (q_shape[0] * q_shape[2])/ (num_h_cores * TILE_HEIGHT);

--- a/ttnn/cpp/ttnn/experimental/tt_dnn/op_library/nlp_tms/multi_core_create_q_and_kv_heads_separate/multi_core_create_q_and_kv_heads.cpp
+++ b/ttnn/cpp/ttnn/experimental/tt_dnn/op_library/nlp_tms/multi_core_create_q_and_kv_heads_separate/multi_core_create_q_and_kv_heads.cpp
@@ -20,8 +20,8 @@ static inline operation::ProgramWithCallbacks create_qkv_separate(const Tensor &
     auto bbox = all_cores.bounding_box();
     ShardOrientation shard_orientation = shard_spec.orientation;
     bool rm = shard_orientation == ShardOrientation::ROW_MAJOR;
-    uint32_t num_h_cores = rm ? bbox.end.y + 1 : bbox.end.x + 1;
-    uint32_t num_w_cores = rm ? bbox.end.x + 1 : bbox.end.y + 1;
+    uint32_t num_h_cores = rm ? bbox.end_.y + 1 : bbox.end_.x + 1;
+    uint32_t num_w_cores = rm ? bbox.end_.x + 1 : bbox.end_.y + 1;
 
     uint32_t q_shard_wt = (q_shape[3]) / (num_w_cores * TILE_WIDTH); // number of tiles in width dimension  - multiple tiles per head, multiple heads per group, multiple tensors in group, multiple groups per cores
     uint32_t q_shard_ht = (q_shape[0] * q_shape[2])/ (num_h_cores * TILE_HEIGHT);

--- a/ttnn/cpp/ttnn/experimental/tt_dnn/op_library/nlp_tms/multi_core_create_qkv_heads/multi_core_create_qkv_heads.cpp
+++ b/ttnn/cpp/ttnn/experimental/tt_dnn/op_library/nlp_tms/multi_core_create_qkv_heads/multi_core_create_qkv_heads.cpp
@@ -32,8 +32,8 @@ static inline operation::ProgramWithCallbacks create_heads_combined_qkv_sharded(
     auto bbox = all_cores.bounding_box();
     ShardOrientation shard_orientation = shard_spec.orientation;
     bool rm = shard_orientation == ShardOrientation::ROW_MAJOR;
-    uint32_t num_h_cores = rm ? bbox.end.y + 1 : bbox.end.x + 1;
-    uint32_t num_w_cores = rm ? bbox.end.x + 1 : bbox.end.y + 1;
+    uint32_t num_h_cores = rm ? bbox.end_.y + 1 : bbox.end_.x + 1;
+    uint32_t num_w_cores = rm ? bbox.end_.x + 1 : bbox.end_.y + 1;
 
     TT_FATAL(input_shape[3] % (num_w_cores * TILE_WIDTH) == 0, fmt::format("Flattened hidden dimensions of QKV {} must be a multiple of width cores {} times tile width {}", input_shape[3], num_w_cores, TILE_WIDTH));
     TT_FATAL(groups % num_w_cores == 0, fmt::format("number of groups {} must be a multiple of the number of width cores {}", groups, num_w_cores));

--- a/ttnn/cpp/ttnn/experimental/tt_dnn/op_library/nlp_tms/multi_core_create_qkv_heads/multi_core_create_qkv_heads.cpp
+++ b/ttnn/cpp/ttnn/experimental/tt_dnn/op_library/nlp_tms/multi_core_create_qkv_heads/multi_core_create_qkv_heads.cpp
@@ -32,8 +32,8 @@ static inline operation::ProgramWithCallbacks create_heads_combined_qkv_sharded(
     auto bbox = all_cores.bounding_box();
     ShardOrientation shard_orientation = shard_spec.orientation;
     bool rm = shard_orientation == ShardOrientation::ROW_MAJOR;
-    uint32_t num_h_cores = rm ? bbox.end_.y + 1 : bbox.end_.x + 1;
-    uint32_t num_w_cores = rm ? bbox.end_.x + 1 : bbox.end_.y + 1;
+    uint32_t num_h_cores = rm ? bbox.end_coord.y + 1 : bbox.end_coord.x + 1;
+    uint32_t num_w_cores = rm ? bbox.end_coord.x + 1 : bbox.end_coord.y + 1;
 
     TT_FATAL(input_shape[3] % (num_w_cores * TILE_WIDTH) == 0, fmt::format("Flattened hidden dimensions of QKV {} must be a multiple of width cores {} times tile width {}", input_shape[3], num_w_cores, TILE_WIDTH));
     TT_FATAL(groups % num_w_cores == 0, fmt::format("number of groups {} must be a multiple of the number of width cores {}", groups, num_w_cores));

--- a/ttnn/cpp/ttnn/experimental/tt_dnn/op_library/nlp_tms/nlp_concat_heads_decode.cpp
+++ b/ttnn/cpp/ttnn/experimental/tt_dnn/op_library/nlp_tms/nlp_concat_heads_decode.cpp
@@ -53,13 +53,13 @@ operation::ProgramWithCallbacks multi_core_nlp_concat_heads_decode(const Tensor 
     // cores to read and write to output
     uint32_t num_cores = q_cores.num_cores(); // number of cores of the output
     auto core_grid = q_cores.bounding_box();
-    uint32_t num_cores_x = core_grid.end.x + 1, num_cores_y = core_grid.end.y + 1;
+    uint32_t num_cores_x = core_grid.end_.x + 1, num_cores_y = core_grid.end_.y + 1;
     const auto &cores = grid_to_cores(num_cores, num_cores_x, num_cores_y, true);
 
     // cores for input
     uint32_t in_num_cores = in_cores.num_cores(); // number of cores of the input
     auto in_core_grid = in_cores.bounding_box();
-    uint32_t in_num_cores_x = in_core_grid.end.x + 1, in_num_cores_y = in_core_grid.end.y + 1;
+    uint32_t in_num_cores_x = in_core_grid.end_.x + 1, in_num_cores_y = in_core_grid.end_.y + 1;
 
     std::vector<uint32_t> noc_x_coords;
     noc_x_coords.reserve(in_num_cores_x);

--- a/ttnn/cpp/ttnn/experimental/tt_dnn/op_library/nlp_tms/nlp_concat_heads_decode.cpp
+++ b/ttnn/cpp/ttnn/experimental/tt_dnn/op_library/nlp_tms/nlp_concat_heads_decode.cpp
@@ -53,13 +53,13 @@ operation::ProgramWithCallbacks multi_core_nlp_concat_heads_decode(const Tensor 
     // cores to read and write to output
     uint32_t num_cores = q_cores.num_cores(); // number of cores of the output
     auto core_grid = q_cores.bounding_box();
-    uint32_t num_cores_x = core_grid.end_.x + 1, num_cores_y = core_grid.end_.y + 1;
+    uint32_t num_cores_x = core_grid.end_coord.x + 1, num_cores_y = core_grid.end_coord.y + 1;
     const auto &cores = grid_to_cores(num_cores, num_cores_x, num_cores_y, true);
 
     // cores for input
     uint32_t in_num_cores = in_cores.num_cores(); // number of cores of the input
     auto in_core_grid = in_cores.bounding_box();
-    uint32_t in_num_cores_x = in_core_grid.end_.x + 1, in_num_cores_y = in_core_grid.end_.y + 1;
+    uint32_t in_num_cores_x = in_core_grid.end_coord.x + 1, in_num_cores_y = in_core_grid.end_coord.y + 1;
 
     std::vector<uint32_t> noc_x_coords;
     noc_x_coords.reserve(in_num_cores_x);

--- a/ttnn/cpp/ttnn/experimental/tt_dnn/op_library/nlp_tms/nlp_create_qkv_heads.cpp
+++ b/ttnn/cpp/ttnn/experimental/tt_dnn/op_library/nlp_tms/nlp_create_qkv_heads.cpp
@@ -364,7 +364,7 @@ operation::ProgramWithCallbacks multi_core_nlp_create_qkv_heads_sharded(const Te
     uint32_t num_cores = std::max(q_cores.num_cores(), k_cores.num_cores());
 
     auto core_grid = q_cores.bounding_box();
-    uint32_t num_cores_x = core_grid.end_.x + 1, num_cores_y = core_grid.end_.y + 1;
+    uint32_t num_cores_x = core_grid.end_coord.x + 1, num_cores_y = core_grid.end_coord.y + 1;
     uint32_t num_kv_cores = k_cores.num_cores();
 
     const auto &cores = grid_to_cores(num_cores, num_cores_x, num_cores_y, true);

--- a/ttnn/cpp/ttnn/experimental/tt_dnn/op_library/nlp_tms/nlp_create_qkv_heads.cpp
+++ b/ttnn/cpp/ttnn/experimental/tt_dnn/op_library/nlp_tms/nlp_create_qkv_heads.cpp
@@ -364,7 +364,7 @@ operation::ProgramWithCallbacks multi_core_nlp_create_qkv_heads_sharded(const Te
     uint32_t num_cores = std::max(q_cores.num_cores(), k_cores.num_cores());
 
     auto core_grid = q_cores.bounding_box();
-    uint32_t num_cores_x = core_grid.end.x + 1, num_cores_y = core_grid.end.y + 1;
+    uint32_t num_cores_x = core_grid.end_.x + 1, num_cores_y = core_grid.end_.y + 1;
     uint32_t num_kv_cores = k_cores.num_cores();
 
     const auto &cores = grid_to_cores(num_cores, num_cores_x, num_cores_y, true);

--- a/ttnn/cpp/ttnn/experimental/tt_dnn/op_library/nlp_tms/nlp_create_qkv_heads_decode.cpp
+++ b/ttnn/cpp/ttnn/experimental/tt_dnn/op_library/nlp_tms/nlp_create_qkv_heads_decode.cpp
@@ -73,13 +73,13 @@ operation::ProgramWithCallbacks multi_core_nlp_create_qkv_heads_decode(const Ten
     // cores to read and write to output
     uint32_t num_cores = q_cores.num_cores(); // number of cores of the output
     auto core_grid = q_cores.bounding_box();
-    uint32_t num_cores_x = core_grid.end.x + 1, num_cores_y = core_grid.end.y + 1;
+    uint32_t num_cores_x = core_grid.end_.x + 1, num_cores_y = core_grid.end_.y + 1;
     const auto &cores = grid_to_cores(num_cores, num_cores_x, num_cores_y, true);
 
     // cores for input
     uint32_t in_num_cores = in_cores.num_cores(); // number of cores of the input
     auto in_core_grid = in_cores.bounding_box();
-    uint32_t in_num_cores_x = in_core_grid.end.x + 1, in_num_cores_y = in_core_grid.end.y + 1;
+    uint32_t in_num_cores_x = in_core_grid.end_.x + 1, in_num_cores_y = in_core_grid.end_.y + 1;
 
     std::vector<uint32_t> noc_x_coords;
     noc_x_coords.reserve(in_num_cores_x);

--- a/ttnn/cpp/ttnn/experimental/tt_dnn/op_library/nlp_tms/nlp_create_qkv_heads_decode.cpp
+++ b/ttnn/cpp/ttnn/experimental/tt_dnn/op_library/nlp_tms/nlp_create_qkv_heads_decode.cpp
@@ -73,13 +73,13 @@ operation::ProgramWithCallbacks multi_core_nlp_create_qkv_heads_decode(const Ten
     // cores to read and write to output
     uint32_t num_cores = q_cores.num_cores(); // number of cores of the output
     auto core_grid = q_cores.bounding_box();
-    uint32_t num_cores_x = core_grid.end_.x + 1, num_cores_y = core_grid.end_.y + 1;
+    uint32_t num_cores_x = core_grid.end_coord.x + 1, num_cores_y = core_grid.end_coord.y + 1;
     const auto &cores = grid_to_cores(num_cores, num_cores_x, num_cores_y, true);
 
     // cores for input
     uint32_t in_num_cores = in_cores.num_cores(); // number of cores of the input
     auto in_core_grid = in_cores.bounding_box();
-    uint32_t in_num_cores_x = in_core_grid.end_.x + 1, in_num_cores_y = in_core_grid.end_.y + 1;
+    uint32_t in_num_cores_x = in_core_grid.end_coord.x + 1, in_num_cores_y = in_core_grid.end_coord.y + 1;
 
     std::vector<uint32_t> noc_x_coords;
     noc_x_coords.reserve(in_num_cores_x);

--- a/ttnn/cpp/ttnn/experimental/tt_dnn/op_library/nlp_tms/nlp_tms.cpp
+++ b/ttnn/cpp/ttnn/experimental/tt_dnn/op_library/nlp_tms/nlp_tms.cpp
@@ -477,12 +477,12 @@ void CreateQKVHeads::validate(const std::vector<Tensor> &input_tensors) const {
     TT_FATAL(input_shape[1] == 1, "Unsupported input shape");
 
     auto bbox = input_tensor.shard_spec().value().grid.bounding_box();
-    TT_FATAL((bbox.end.x < input_tensor.device()->compute_with_storage_grid_size().x && bbox.end.y < input_tensor.device()->compute_with_storage_grid_size().y));
+    TT_FATAL((bbox.end_.x < input_tensor.device()->compute_with_storage_grid_size().x && bbox.end_.y < input_tensor.device()->compute_with_storage_grid_size().y));
     TT_FATAL(input_tensor.memory_config().memory_layout == TensorMemoryLayout::BLOCK_SHARDED);
     ShardOrientation shard_orientation = input_tensor.shard_spec().value().orientation;
     bool rm = shard_orientation == ShardOrientation::ROW_MAJOR;
-    uint32_t num_h_cores = rm ? bbox.end.y + 1 : bbox.end.x + 1;
-    uint32_t num_w_cores = rm ? bbox.end.x + 1 : bbox.end.y + 1;
+    uint32_t num_h_cores = rm ? bbox.end_.y + 1 : bbox.end_.x + 1;
+    uint32_t num_w_cores = rm ? bbox.end_.x + 1 : bbox.end_.y + 1;
 
     TT_FATAL(this->num_q_heads % this->num_kv_heads == 0, fmt::format("Number of q heads {} must fit evenly into number of kv heads {}", this->num_q_heads, this->num_kv_heads));
     TT_FATAL(input_shape[3] % (num_w_cores * TILE_WIDTH) == 0, fmt::format("Flattened hidden dimension {} must be a multiple of width cores {} * tile width {} to ensure that each core gets an even amount of tiles", input_shape[3], num_w_cores, TILE_WIDTH));
@@ -522,8 +522,8 @@ std::vector<Tensor> CreateQKVHeads::create_output_tensors(const std::vector<Tens
     auto bbox = all_cores.bounding_box();
     // TODO: Do we need to know cores along row and col?
     //bool rm = shard_orientation == ShardOrientation::ROW_MAJOR;
-    //uint32_t num_h_cores = rm ? bbox.end.y + 1 : bbox.end.x + 1;
-    //uint32_t num_w_cores = rm ? bbox.end.x + 1 : bbox.end.y + 1;
+    //uint32_t num_h_cores = rm ? bbox.end_.y + 1 : bbox.end_.x + 1;
+    //uint32_t num_w_cores = rm ? bbox.end_.x + 1 : bbox.end_.y + 1;
     uint32_t num_cores = bbox.size();
 
     auto shapes = compute_output_shapes(input_tensors);
@@ -572,15 +572,15 @@ void CreateQKVHeadsSeparateTensors::validate(const std::vector<Tensor> &input_te
 
 
     auto bbox = q_input_tensor.shard_spec().value().grid.bounding_box();
-    TT_FATAL((bbox.end.x < q_input_tensor.device()->compute_with_storage_grid_size().x && bbox.end.y < q_input_tensor.device()->compute_with_storage_grid_size().y));
+    TT_FATAL((bbox.end_.x < q_input_tensor.device()->compute_with_storage_grid_size().x && bbox.end_.y < q_input_tensor.device()->compute_with_storage_grid_size().y));
 
     TT_FATAL(q_input_tensor.memory_config().memory_layout == TensorMemoryLayout::BLOCK_SHARDED);
     TT_FATAL(kv_input_tensor.memory_config().memory_layout == TensorMemoryLayout::BLOCK_SHARDED);
 
     ShardOrientation shard_orientation = q_input_tensor.shard_spec().value().orientation;
     bool rm = shard_orientation == ShardOrientation::ROW_MAJOR;
-    uint32_t num_h_cores = rm ? bbox.end.y + 1 : bbox.end.x + 1;
-    uint32_t num_w_cores = rm ? bbox.end.x + 1 : bbox.end.y + 1;
+    uint32_t num_h_cores = rm ? bbox.end_.y + 1 : bbox.end_.x + 1;
+    uint32_t num_w_cores = rm ? bbox.end_.x + 1 : bbox.end_.y + 1;
 
     TT_FATAL(this->num_q_heads % num_w_cores == 0, fmt::format("Number of q heads {} must fit evenly into cores {}", this->num_q_heads, num_w_cores));
     TT_FATAL(this->num_kv_heads % num_w_cores == 0, fmt::format("Number of kv heads {} must fit evenly into cores {}", this->num_kv_heads, num_w_cores));
@@ -652,8 +652,8 @@ std::vector<Tensor> CreateQKVHeadsSeparateTensors::create_output_tensors(const s
     auto bbox = all_cores.bounding_box();
     // TODO: Do we need to know cores along row and col?
     //bool rm = shard_orientation == ShardOrientation::ROW_MAJOR;
-    //uint32_t num_h_cores = rm ? bbox.end.y + 1 : bbox.end.x + 1;
-    //uint32_t num_w_cores = rm ? bbox.end.x + 1 : bbox.end.y + 1;
+    //uint32_t num_h_cores = rm ? bbox.end_.y + 1 : bbox.end_.x + 1;
+    //uint32_t num_w_cores = rm ? bbox.end_.x + 1 : bbox.end_.y + 1;
     uint32_t num_cores = bbox.size();
 
     auto shapes = compute_output_shapes(input_tensors);

--- a/ttnn/cpp/ttnn/experimental/tt_dnn/op_library/paged_update_cache/multi_core/paged_update_cache_op_multi_core.cpp
+++ b/ttnn/cpp/ttnn/experimental/tt_dnn/op_library/paged_update_cache/multi_core/paged_update_cache_op_multi_core.cpp
@@ -85,8 +85,8 @@ operation::ProgramWithCallbacks paged_update_cache_multi_core(const Tensor& cach
     num_batched_heads_per_core = shard_spec.value().shape[0] / TILE_HEIGHT;
     num_input_tiles = shard_spec.value().shape[0] * shard_spec.value().shape[1] / TILE_HW;
     auto bbox = all_cores.bounding_box();
-    num_cores_x = bbox.end_.x + 1;
-    num_cores_y = bbox.end_.y + 1;
+    num_cores_x = bbox.end_coord.x + 1;
+    num_cores_y = bbox.end_coord.y + 1;
 
     uint32_t src0_cb_index = CB::c_in0;
     uint32_t num_cache_tiles = 2 * Wt; // double buffered

--- a/ttnn/cpp/ttnn/experimental/tt_dnn/op_library/paged_update_cache/multi_core/paged_update_cache_op_multi_core.cpp
+++ b/ttnn/cpp/ttnn/experimental/tt_dnn/op_library/paged_update_cache/multi_core/paged_update_cache_op_multi_core.cpp
@@ -85,8 +85,8 @@ operation::ProgramWithCallbacks paged_update_cache_multi_core(const Tensor& cach
     num_batched_heads_per_core = shard_spec.value().shape[0] / TILE_HEIGHT;
     num_input_tiles = shard_spec.value().shape[0] * shard_spec.value().shape[1] / TILE_HW;
     auto bbox = all_cores.bounding_box();
-    num_cores_x = bbox.end.x + 1;
-    num_cores_y = bbox.end.y + 1;
+    num_cores_x = bbox.end_.x + 1;
+    num_cores_y = bbox.end_.y + 1;
 
     uint32_t src0_cb_index = CB::c_in0;
     uint32_t num_cache_tiles = 2 * Wt; // double buffered

--- a/ttnn/cpp/ttnn/experimental/tt_dnn/op_library/rotary_embedding/multi_core/rotary_embedding_op_multi_core.cpp
+++ b/ttnn/cpp/ttnn/experimental/tt_dnn/op_library/rotary_embedding/multi_core/rotary_embedding_op_multi_core.cpp
@@ -96,8 +96,8 @@ operation::ProgramWithCallbacks rotary_embedding_multi_core(
         num_output_tiles =
             out_sharded ? shard_spec.value().shape[0] * shard_spec.value().shape[1] / TILE_HW : 2 * Wt;
         auto bbox = all_cores.bounding_box();
-        num_cores_x = bbox.end.x + 1;
-        num_cores_y = bbox.end.y + 1;
+        num_cores_x = bbox.end_.x + 1;
+        num_cores_y = bbox.end_.y + 1;
     } else {
         row_major = true;
         std::tie(

--- a/ttnn/cpp/ttnn/experimental/tt_dnn/op_library/rotary_embedding/multi_core/rotary_embedding_op_multi_core.cpp
+++ b/ttnn/cpp/ttnn/experimental/tt_dnn/op_library/rotary_embedding/multi_core/rotary_embedding_op_multi_core.cpp
@@ -96,8 +96,8 @@ operation::ProgramWithCallbacks rotary_embedding_multi_core(
         num_output_tiles =
             out_sharded ? shard_spec.value().shape[0] * shard_spec.value().shape[1] / TILE_HW : 2 * Wt;
         auto bbox = all_cores.bounding_box();
-        num_cores_x = bbox.end_.x + 1;
-        num_cores_y = bbox.end_.y + 1;
+        num_cores_x = bbox.end_coord.x + 1;
+        num_cores_y = bbox.end_coord.y + 1;
     } else {
         row_major = true;
         std::tie(

--- a/ttnn/cpp/ttnn/experimental/tt_dnn/op_library/sharded/multi_core/sharded_op_multi_core.cpp
+++ b/ttnn/cpp/ttnn/experimental/tt_dnn/op_library/sharded/multi_core/sharded_op_multi_core.cpp
@@ -50,7 +50,7 @@ operation::ProgramWithCallbacks interleaved_to_sharded_multi_core(
 
     bool rm_orientation = shard_spec.orientation == ShardOrientation::ROW_MAJOR;
 
-    CoreCoord end_core = (*shard_spec.grid.ranges().rbegin()).end;
+    CoreCoord end_core = (*shard_spec.grid.ranges().rbegin()).end_;
     if (input.get_layout() == Layout::TILE) {
         num_units = input.volume() / TILE_HW;
         input_unit_size = tt_metal::detail::TileSize(input_cb_data_format);
@@ -339,7 +339,7 @@ operation::ProgramWithCallbacks sharded_to_interleaved_multi_core(
     auto shard_strategy = input.memory_config().memory_layout;
 
     bool rm_orientation = shard_spec.orientation == ShardOrientation::ROW_MAJOR;
-    CoreCoord end_core = (*shard_spec.grid.ranges().rbegin()).end;
+    CoreCoord end_core = (*shard_spec.grid.ranges().rbegin()).end_;
     if (output.get_layout() == Layout::TILE) {
         num_units = input.volume() / TILE_HW;
         input_unit_size = tt_metal::detail::TileSize(input_cb_data_format);
@@ -620,7 +620,7 @@ std::unordered_map<CoreCoord, std::vector<PageStride>> get_core_page_ranges(
     auto output_core_host_page_indices = output_buffer_page_mapping.core_host_page_indices_;
     auto device = input_buffer->device();
     auto full_grid = device->compute_with_storage_grid_size();
-    CoreCoord end_core = (*output_buffer->shard_spec().grid().ranges().rbegin()).end;
+    CoreCoord end_core = (*output_buffer->shard_spec().grid().ranges().rbegin()).end_;
     uint32_t output_core_id = 0;
     for (auto output_core : output_cores) {
         ret_map.try_emplace(output_core, std::vector<PageStride>{});

--- a/ttnn/cpp/ttnn/experimental/tt_dnn/op_library/sharded/multi_core/sharded_op_multi_core.cpp
+++ b/ttnn/cpp/ttnn/experimental/tt_dnn/op_library/sharded/multi_core/sharded_op_multi_core.cpp
@@ -50,7 +50,7 @@ operation::ProgramWithCallbacks interleaved_to_sharded_multi_core(
 
     bool rm_orientation = shard_spec.orientation == ShardOrientation::ROW_MAJOR;
 
-    CoreCoord end_core = (*shard_spec.grid.ranges().rbegin()).end_;
+    CoreCoord end_core = (*shard_spec.grid.ranges().rbegin()).end_coord;
     if (input.get_layout() == Layout::TILE) {
         num_units = input.volume() / TILE_HW;
         input_unit_size = tt_metal::detail::TileSize(input_cb_data_format);
@@ -339,7 +339,7 @@ operation::ProgramWithCallbacks sharded_to_interleaved_multi_core(
     auto shard_strategy = input.memory_config().memory_layout;
 
     bool rm_orientation = shard_spec.orientation == ShardOrientation::ROW_MAJOR;
-    CoreCoord end_core = (*shard_spec.grid.ranges().rbegin()).end_;
+    CoreCoord end_core = (*shard_spec.grid.ranges().rbegin()).end_coord;
     if (output.get_layout() == Layout::TILE) {
         num_units = input.volume() / TILE_HW;
         input_unit_size = tt_metal::detail::TileSize(input_cb_data_format);
@@ -620,7 +620,7 @@ std::unordered_map<CoreCoord, std::vector<PageStride>> get_core_page_ranges(
     auto output_core_host_page_indices = output_buffer_page_mapping.core_host_page_indices_;
     auto device = input_buffer->device();
     auto full_grid = device->compute_with_storage_grid_size();
-    CoreCoord end_core = (*output_buffer->shard_spec().grid().ranges().rbegin()).end_;
+    CoreCoord end_core = (*output_buffer->shard_spec().grid().ranges().rbegin()).end_coord;
     uint32_t output_core_id = 0;
     for (auto output_core : output_cores) {
         ret_map.try_emplace(output_core, std::vector<PageStride>{});

--- a/ttnn/cpp/ttnn/experimental/tt_dnn/op_library/sharded/sharded_op.hpp
+++ b/ttnn/cpp/ttnn/experimental/tt_dnn/op_library/sharded/sharded_op.hpp
@@ -81,7 +81,7 @@ inline Tensor interleaved_to_sharded(
                         grid_set = num_cores_to_corerange_set(num_cores, grid_size, row_wise);
                     } else if constexpr (std::is_same_v<GridType, CoreRangeSet>) {
                         auto bbox = grid.bounding_box();
-                        grid_size = CoreCoord{bbox.end.x + 1, bbox.end.y + 1};
+                        grid_size = CoreCoord{bbox.end_.x + 1, bbox.end_.y + 1};
                         grid_set = grid;
                     }
                 },
@@ -110,7 +110,7 @@ inline Tensor interleaved_to_sharded(
             const auto& input_tensor = input_tensors.at(0);
             TT_FATAL(sharded_mem_config.is_sharded());
             auto bbox = sharded_mem_config.shard_spec.value().grid.bounding_box();
-            CoreCoord grid_size(bbox.end.x + 1, bbox.end.y + 1);
+            CoreCoord grid_size(bbox.end_.x + 1, bbox.end_.y + 1);
             return operation::run(
                     Sharded{
                         .grid_size = grid_size,

--- a/ttnn/cpp/ttnn/experimental/tt_dnn/op_library/sharded/sharded_op.hpp
+++ b/ttnn/cpp/ttnn/experimental/tt_dnn/op_library/sharded/sharded_op.hpp
@@ -81,7 +81,7 @@ inline Tensor interleaved_to_sharded(
                         grid_set = num_cores_to_corerange_set(num_cores, grid_size, row_wise);
                     } else if constexpr (std::is_same_v<GridType, CoreRangeSet>) {
                         auto bbox = grid.bounding_box();
-                        grid_size = CoreCoord{bbox.end_.x + 1, bbox.end_.y + 1};
+                        grid_size = CoreCoord{bbox.end_coord.x + 1, bbox.end_coord.y + 1};
                         grid_set = grid;
                     }
                 },
@@ -110,7 +110,7 @@ inline Tensor interleaved_to_sharded(
             const auto& input_tensor = input_tensors.at(0);
             TT_FATAL(sharded_mem_config.is_sharded());
             auto bbox = sharded_mem_config.shard_spec.value().grid.bounding_box();
-            CoreCoord grid_size(bbox.end_.x + 1, bbox.end_.y + 1);
+            CoreCoord grid_size(bbox.end_coord.x + 1, bbox.end_coord.y + 1);
             return operation::run(
                     Sharded{
                         .grid_size = grid_size,

--- a/ttnn/cpp/ttnn/experimental/tt_dnn/op_library/sliding_window_op_infra/halo_op.cpp
+++ b/ttnn/cpp/ttnn/experimental/tt_dnn/op_library/sliding_window_op_infra/halo_op.cpp
@@ -59,8 +59,8 @@ std::vector<Tensor> Halo::create_output_tensors(const std::vector<Tensor> &input
     if (input_tensor.memory_config().memory_layout == TensorMemoryLayout::BLOCK_SHARDED) {
         auto input_core_range = *(input_tensor.memory_config().shard_spec->grid.ranges().begin());
         auto output_core_range = *(output_memory_config_.shard_spec->grid.ranges().begin());
-        auto input_core_w = input_core_range.end_.y - input_core_range.start_.y + 1;
-        auto output_core_w = output_core_range.end_.y - output_core_range.start_.y + 1;
+        auto input_core_w = input_core_range.end_coord.y - input_core_range.start_coord.y + 1;
+        auto output_core_w = output_core_range.end_coord.y - output_core_range.start_coord.y + 1;
         TT_FATAL(input_core_w == output_core_w);
     }
 

--- a/ttnn/cpp/ttnn/experimental/tt_dnn/op_library/sliding_window_op_infra/halo_op.cpp
+++ b/ttnn/cpp/ttnn/experimental/tt_dnn/op_library/sliding_window_op_infra/halo_op.cpp
@@ -59,8 +59,8 @@ std::vector<Tensor> Halo::create_output_tensors(const std::vector<Tensor> &input
     if (input_tensor.memory_config().memory_layout == TensorMemoryLayout::BLOCK_SHARDED) {
         auto input_core_range = *(input_tensor.memory_config().shard_spec->grid.ranges().begin());
         auto output_core_range = *(output_memory_config_.shard_spec->grid.ranges().begin());
-        auto input_core_w = input_core_range.end.y - input_core_range.start.y + 1;
-        auto output_core_w = output_core_range.end.y - output_core_range.start.y + 1;
+        auto input_core_w = input_core_range.end_.y - input_core_range.start_.y + 1;
+        auto output_core_w = output_core_range.end_.y - output_core_range.start_.y + 1;
         TT_FATAL(input_core_w == output_core_w);
     }
 

--- a/ttnn/cpp/ttnn/experimental/tt_dnn/op_library/sliding_window_op_infra/sliding_window.cpp
+++ b/ttnn/cpp/ttnn/experimental/tt_dnn/op_library/sliding_window_op_infra/sliding_window.cpp
@@ -376,8 +376,8 @@ namespace tt::tt_metal::sliding_window {
         } else if (p_config.shard_scheme == TensorMemoryLayout::BLOCK_SHARDED) {
             TT_ASSERT(p_config.grid.ranges().size() == 1, "BLOCK_SHARDED should have just a single core range");
             // NOTE: it is assumed that the range start is always (0, 0)
-            uint32_t ncores_y = p_config.grid.ranges().begin()->end.y + 1;
-            uint32_t ncores_x = p_config.grid.ranges().begin()->end.x + 1;
+            uint32_t ncores_y = p_config.grid.ranges().begin()->end_.y + 1;
+            uint32_t ncores_x = p_config.grid.ranges().begin()->end_.x + 1;
             std::vector<uint16_t> repeat_config;
             uint32_t repeat_factor = 0;
             if (p_config.shard_orientation == ShardOrientation::ROW_MAJOR) {

--- a/ttnn/cpp/ttnn/experimental/tt_dnn/op_library/sliding_window_op_infra/sliding_window.cpp
+++ b/ttnn/cpp/ttnn/experimental/tt_dnn/op_library/sliding_window_op_infra/sliding_window.cpp
@@ -376,8 +376,8 @@ namespace tt::tt_metal::sliding_window {
         } else if (p_config.shard_scheme == TensorMemoryLayout::BLOCK_SHARDED) {
             TT_ASSERT(p_config.grid.ranges().size() == 1, "BLOCK_SHARDED should have just a single core range");
             // NOTE: it is assumed that the range start is always (0, 0)
-            uint32_t ncores_y = p_config.grid.ranges().begin()->end_.y + 1;
-            uint32_t ncores_x = p_config.grid.ranges().begin()->end_.x + 1;
+            uint32_t ncores_y = p_config.grid.ranges().begin()->end_coord.y + 1;
+            uint32_t ncores_x = p_config.grid.ranges().begin()->end_coord.x + 1;
             std::vector<uint16_t> repeat_config;
             uint32_t repeat_factor = 0;
             if (p_config.shard_orientation == ShardOrientation::ROW_MAJOR) {

--- a/ttnn/cpp/ttnn/experimental/tt_dnn/op_library/transformer_tms/multi_core_group_attn_matmul/multi_core_group_attn_matmul.cpp
+++ b/ttnn/cpp/ttnn/experimental/tt_dnn/op_library/transformer_tms/multi_core_group_attn_matmul/multi_core_group_attn_matmul.cpp
@@ -370,8 +370,8 @@ operation::ProgramWithCallbacks multi_core_group_attn_matmul(const Tensor &a, co
         CoreRange mcast_receiver_cores_bounding_box = mcast_receiver_cores.bounding_box();
         uint32_t mcast_num_dests = mcast_receiver_cores.num_cores(); // same as num_active_cores if Q_HEADS >= 32; also, always same as Q_HEADS
         uint32_t mcast_num_cores = mcast_receiver_cores_bounding_box.size();
-        CoreCoord top_left_core = mcast_receiver_cores_bounding_box.start;
-        CoreCoord bottom_right_core = mcast_receiver_cores_bounding_box.end;
+        CoreCoord top_left_core = mcast_receiver_cores_bounding_box.start_;
+        CoreCoord bottom_right_core = mcast_receiver_cores_bounding_box.end_;
         CoreCoord top_left_core_physical = device->worker_core_from_logical_core(top_left_core);
         CoreCoord bottom_right_core_physical = device->worker_core_from_logical_core(bottom_right_core);
 
@@ -464,8 +464,8 @@ operation::ProgramWithCallbacks multi_core_group_attn_matmul(const Tensor &a, co
 
         CoreRange all_cores_bounding_box = all_cores.bounding_box();
         std::vector<CoreCoord> cores = grid_to_cores_with_noop(
-            all_cores_bounding_box.end.x,
-            all_cores_bounding_box.end.y,
+            all_cores_bounding_box.end_.x,
+            all_cores_bounding_box.end_.y,
             device_compute_with_storage_grid.x,
             device_compute_with_storage_grid.y,
             row_major

--- a/ttnn/cpp/ttnn/experimental/tt_dnn/op_library/transformer_tms/multi_core_group_attn_matmul/multi_core_group_attn_matmul.cpp
+++ b/ttnn/cpp/ttnn/experimental/tt_dnn/op_library/transformer_tms/multi_core_group_attn_matmul/multi_core_group_attn_matmul.cpp
@@ -370,8 +370,8 @@ operation::ProgramWithCallbacks multi_core_group_attn_matmul(const Tensor &a, co
         CoreRange mcast_receiver_cores_bounding_box = mcast_receiver_cores.bounding_box();
         uint32_t mcast_num_dests = mcast_receiver_cores.num_cores(); // same as num_active_cores if Q_HEADS >= 32; also, always same as Q_HEADS
         uint32_t mcast_num_cores = mcast_receiver_cores_bounding_box.size();
-        CoreCoord top_left_core = mcast_receiver_cores_bounding_box.start_;
-        CoreCoord bottom_right_core = mcast_receiver_cores_bounding_box.end_;
+        CoreCoord top_left_core = mcast_receiver_cores_bounding_box.start_coord;
+        CoreCoord bottom_right_core = mcast_receiver_cores_bounding_box.end_coord;
         CoreCoord top_left_core_physical = device->worker_core_from_logical_core(top_left_core);
         CoreCoord bottom_right_core_physical = device->worker_core_from_logical_core(bottom_right_core);
 
@@ -464,8 +464,8 @@ operation::ProgramWithCallbacks multi_core_group_attn_matmul(const Tensor &a, co
 
         CoreRange all_cores_bounding_box = all_cores.bounding_box();
         std::vector<CoreCoord> cores = grid_to_cores_with_noop(
-            all_cores_bounding_box.end_.x,
-            all_cores_bounding_box.end_.y,
+            all_cores_bounding_box.end_coord.x,
+            all_cores_bounding_box.end_coord.y,
             device_compute_with_storage_grid.x,
             device_compute_with_storage_grid.y,
             row_major

--- a/ttnn/cpp/ttnn/experimental/tt_dnn/op_library/transformer_tms/multi_core_split_query_key_value_and_split_heads/multi_core_split_query_key_value_and_split_heads.cpp
+++ b/ttnn/cpp/ttnn/experimental/tt_dnn/op_library/transformer_tms/multi_core_split_query_key_value_and_split_heads/multi_core_split_query_key_value_and_split_heads.cpp
@@ -231,8 +231,8 @@ operation::ProgramWithCallbacks multi_core_split_query_key_value_and_split_heads
     auto bbox = all_cores.bounding_box();
     ShardOrientation shard_orientation = a.shard_spec().value().orientation;
     bool rm = shard_orientation == ShardOrientation::ROW_MAJOR;
-    uint32_t num_h_cores = rm ? bbox.end_.y + 1 : bbox.end_.x + 1;
-    uint32_t num_w_cores = rm ? bbox.end_.x + 1 : bbox.end_.y + 1;
+    uint32_t num_h_cores = rm ? bbox.end_coord.y + 1 : bbox.end_coord.x + 1;
+    uint32_t num_w_cores = rm ? bbox.end_coord.x + 1 : bbox.end_coord.y + 1;
     // tensor shape
     const auto shape = a.get_legacy_shape();
     uint32_t M = shape[2] * shape[0]; // 4608

--- a/ttnn/cpp/ttnn/experimental/tt_dnn/op_library/transformer_tms/multi_core_split_query_key_value_and_split_heads/multi_core_split_query_key_value_and_split_heads.cpp
+++ b/ttnn/cpp/ttnn/experimental/tt_dnn/op_library/transformer_tms/multi_core_split_query_key_value_and_split_heads/multi_core_split_query_key_value_and_split_heads.cpp
@@ -231,8 +231,8 @@ operation::ProgramWithCallbacks multi_core_split_query_key_value_and_split_heads
     auto bbox = all_cores.bounding_box();
     ShardOrientation shard_orientation = a.shard_spec().value().orientation;
     bool rm = shard_orientation == ShardOrientation::ROW_MAJOR;
-    uint32_t num_h_cores = rm ? bbox.end.y + 1 : bbox.end.x + 1;
-    uint32_t num_w_cores = rm ? bbox.end.x + 1 : bbox.end.y + 1;
+    uint32_t num_h_cores = rm ? bbox.end_.y + 1 : bbox.end_.x + 1;
+    uint32_t num_w_cores = rm ? bbox.end_.x + 1 : bbox.end_.y + 1;
     // tensor shape
     const auto shape = a.get_legacy_shape();
     uint32_t M = shape[2] * shape[0]; // 4608

--- a/ttnn/cpp/ttnn/experimental/tt_dnn/op_library/transformer_tms/transformer_tms.cpp
+++ b/ttnn/cpp/ttnn/experimental/tt_dnn/op_library/transformer_tms/transformer_tms.cpp
@@ -29,8 +29,8 @@ void SplitFusedQKVAndSplitHeads::validate(const std::vector<Tensor>& input_tenso
     } else {
         auto bbox = input_tensor.shard_spec().value().grid.bounding_box();
         TT_FATAL(
-            (bbox.end.x < this->compute_with_storage_grid_size.x &&
-             bbox.end.y < this->compute_with_storage_grid_size.y));
+            (bbox.end_.x < this->compute_with_storage_grid_size.x &&
+             bbox.end_.y < this->compute_with_storage_grid_size.y));
         TT_FATAL(input_tensor.shard_spec().value().grid.ranges().size() == 1);
         TT_FATAL(input_tensor.memory_config().memory_layout == TensorMemoryLayout::BLOCK_SHARDED);
     }
@@ -63,7 +63,7 @@ std::vector<Tensor> SplitFusedQKVAndSplitHeads::create_output_tensors(const std:
         CoreRangeSet all_cores = input_tensor.shard_spec().value().grid;
         ShardOrientation shard_orientation = input_tensor.shard_spec().value().orientation;
         auto bbox = all_cores.bounding_box();
-        uint32_t num_M_cores = shard_orientation == ShardOrientation::ROW_MAJOR ? bbox.end.x + 1 : bbox.end.y + 1;
+        uint32_t num_M_cores = shard_orientation == ShardOrientation::ROW_MAJOR ? bbox.end_.x + 1 : bbox.end_.y + 1;
         // shard spec
         uint32_t per_core_M_qv = (num_heads / num_M_cores) * M;  // 768
         uint32_t per_core_N_qv = K;                              // 64

--- a/ttnn/cpp/ttnn/experimental/tt_dnn/op_library/transformer_tms/transformer_tms.cpp
+++ b/ttnn/cpp/ttnn/experimental/tt_dnn/op_library/transformer_tms/transformer_tms.cpp
@@ -29,8 +29,8 @@ void SplitFusedQKVAndSplitHeads::validate(const std::vector<Tensor>& input_tenso
     } else {
         auto bbox = input_tensor.shard_spec().value().grid.bounding_box();
         TT_FATAL(
-            (bbox.end_.x < this->compute_with_storage_grid_size.x &&
-             bbox.end_.y < this->compute_with_storage_grid_size.y));
+            (bbox.end_coord.x < this->compute_with_storage_grid_size.x &&
+             bbox.end_coord.y < this->compute_with_storage_grid_size.y));
         TT_FATAL(input_tensor.shard_spec().value().grid.ranges().size() == 1);
         TT_FATAL(input_tensor.memory_config().memory_layout == TensorMemoryLayout::BLOCK_SHARDED);
     }
@@ -63,7 +63,7 @@ std::vector<Tensor> SplitFusedQKVAndSplitHeads::create_output_tensors(const std:
         CoreRangeSet all_cores = input_tensor.shard_spec().value().grid;
         ShardOrientation shard_orientation = input_tensor.shard_spec().value().orientation;
         auto bbox = all_cores.bounding_box();
-        uint32_t num_M_cores = shard_orientation == ShardOrientation::ROW_MAJOR ? bbox.end_.x + 1 : bbox.end_.y + 1;
+        uint32_t num_M_cores = shard_orientation == ShardOrientation::ROW_MAJOR ? bbox.end_coord.x + 1 : bbox.end_coord.y + 1;
         // shard spec
         uint32_t per_core_M_qv = (num_heads / num_M_cores) * M;  // 768
         uint32_t per_core_N_qv = K;                              // 64

--- a/ttnn/cpp/ttnn/experimental/tt_dnn/op_library/transpose/wh_multi_core/transpose_wh_op_multi_core.cpp
+++ b/ttnn/cpp/ttnn/experimental/tt_dnn/op_library/transpose/wh_multi_core/transpose_wh_op_multi_core.cpp
@@ -331,7 +331,7 @@ operation::ProgramWithCallbacks transpose_wh_multi_core_sharded(const Tensor &a,
     uint32_t NHtWt = N * HtWt;
 
     auto bbox = all_cores.bounding_box();
-    vector<CoreCoord> cores = grid_to_cores_with_noop(bbox.end_.x, bbox.end_.y, num_cores_x, num_cores_y, row_major);
+    vector<CoreCoord> cores = grid_to_cores_with_noop(bbox.end_coord.x, bbox.end_coord.y, num_cores_x, num_cores_y, row_major);
 
     std::vector< std::vector<uint32_t> > unary_reader_args = { cores.size(), std::vector<uint32_t>(1) };
     std::vector< std::vector<uint32_t> > unary_compute_args = { cores.size(), std::vector<uint32_t>(5) };
@@ -397,7 +397,7 @@ operation::ProgramWithCallbacks transpose_wh_multi_core_sharded(const Tensor &a,
         bool row_major = shard_spec.orientation == ShardOrientation::ROW_MAJOR;
 
         auto bbox = all_cores.bounding_box();
-        vector<CoreCoord> cores = grid_to_cores_with_noop(bbox.end_.x, bbox.end_.y, num_cores_x, num_cores_y, row_major);
+        vector<CoreCoord> cores = grid_to_cores_with_noop(bbox.end_coord.x, bbox.end_coord.y, num_cores_x, num_cores_y, row_major);
         std::vector< std::vector<uint32_t> > unary_reader_args = { cores.size(), std::vector<uint32_t>(1) };
         std::vector< std::vector<uint32_t> > unary_compute_args = { cores.size(), std::vector<uint32_t>(5) };
         std::vector< std::vector<uint32_t> > unary_writer_args = { cores.size(), std::vector<uint32_t>(1) };

--- a/ttnn/cpp/ttnn/experimental/tt_dnn/op_library/transpose/wh_multi_core/transpose_wh_op_multi_core.cpp
+++ b/ttnn/cpp/ttnn/experimental/tt_dnn/op_library/transpose/wh_multi_core/transpose_wh_op_multi_core.cpp
@@ -331,7 +331,7 @@ operation::ProgramWithCallbacks transpose_wh_multi_core_sharded(const Tensor &a,
     uint32_t NHtWt = N * HtWt;
 
     auto bbox = all_cores.bounding_box();
-    vector<CoreCoord> cores = grid_to_cores_with_noop(bbox.end.x, bbox.end.y, num_cores_x, num_cores_y, row_major);
+    vector<CoreCoord> cores = grid_to_cores_with_noop(bbox.end_.x, bbox.end_.y, num_cores_x, num_cores_y, row_major);
 
     std::vector< std::vector<uint32_t> > unary_reader_args = { cores.size(), std::vector<uint32_t>(1) };
     std::vector< std::vector<uint32_t> > unary_compute_args = { cores.size(), std::vector<uint32_t>(5) };
@@ -397,7 +397,7 @@ operation::ProgramWithCallbacks transpose_wh_multi_core_sharded(const Tensor &a,
         bool row_major = shard_spec.orientation == ShardOrientation::ROW_MAJOR;
 
         auto bbox = all_cores.bounding_box();
-        vector<CoreCoord> cores = grid_to_cores_with_noop(bbox.end.x, bbox.end.y, num_cores_x, num_cores_y, row_major);
+        vector<CoreCoord> cores = grid_to_cores_with_noop(bbox.end_.x, bbox.end_.y, num_cores_x, num_cores_y, row_major);
         std::vector< std::vector<uint32_t> > unary_reader_args = { cores.size(), std::vector<uint32_t>(1) };
         std::vector< std::vector<uint32_t> > unary_compute_args = { cores.size(), std::vector<uint32_t>(5) };
         std::vector< std::vector<uint32_t> > unary_writer_args = { cores.size(), std::vector<uint32_t>(1) };

--- a/ttnn/cpp/ttnn/experimental/tt_dnn/op_library/untilize/multi_core/untilize_op_multi_core.cpp
+++ b/ttnn/cpp/ttnn/experimental/tt_dnn/op_library/untilize/multi_core/untilize_op_multi_core.cpp
@@ -86,7 +86,7 @@ operation::ProgramWithCallbacks untilize_multi_core(
                                                             output.element_size();
         uint32_t num_output_rows = output.volume() / output.get_legacy_shape()[-1];
         num_output_rows_unpadded = num_rows_block - (round_up(num_output_rows, shard_spec.shape[0]) - num_output_rows);
-        end_core = (*shard_spec.grid.ranges().begin()).end;
+        end_core = (*shard_spec.grid.ranges().begin()).end_;
     }
 
     uint32_t num_input_tiles = src_sharded ? ntiles_per_block * nblocks_per_core : ntiles_per_block * 2;
@@ -625,8 +625,8 @@ operation::ProgramWithCallbacks untilize_with_unpadding_multi_core_sharded(
 
     bool row_major = shard_spec.orientation == ShardOrientation::ROW_MAJOR;
     auto grid = *shard_spec.grid.ranges().begin();
-    uint32_t ncores_x = grid.end.x + 1;
-    uint32_t ncores_y = grid.end.y + 1;
+    uint32_t ncores_x = grid.end_.x + 1;
+    uint32_t ncores_y = grid.end_.y + 1;
     auto all_cores = shard_spec.grid;
     uint32_t ncores = all_cores.num_cores();
     uint32_t ntiles_per_block = shard_spec.shape[1] / TILE_WIDTH;

--- a/ttnn/cpp/ttnn/experimental/tt_dnn/op_library/untilize/multi_core/untilize_op_multi_core.cpp
+++ b/ttnn/cpp/ttnn/experimental/tt_dnn/op_library/untilize/multi_core/untilize_op_multi_core.cpp
@@ -86,7 +86,7 @@ operation::ProgramWithCallbacks untilize_multi_core(
                                                             output.element_size();
         uint32_t num_output_rows = output.volume() / output.get_legacy_shape()[-1];
         num_output_rows_unpadded = num_rows_block - (round_up(num_output_rows, shard_spec.shape[0]) - num_output_rows);
-        end_core = (*shard_spec.grid.ranges().begin()).end_;
+        end_core = (*shard_spec.grid.ranges().begin()).end_coord;
     }
 
     uint32_t num_input_tiles = src_sharded ? ntiles_per_block * nblocks_per_core : ntiles_per_block * 2;
@@ -625,8 +625,8 @@ operation::ProgramWithCallbacks untilize_with_unpadding_multi_core_sharded(
 
     bool row_major = shard_spec.orientation == ShardOrientation::ROW_MAJOR;
     auto grid = *shard_spec.grid.ranges().begin();
-    uint32_t ncores_x = grid.end_.x + 1;
-    uint32_t ncores_y = grid.end_.y + 1;
+    uint32_t ncores_x = grid.end_coord.x + 1;
+    uint32_t ncores_y = grid.end_coord.y + 1;
     auto all_cores = shard_spec.grid;
     uint32_t ncores = all_cores.num_cores();
     uint32_t ntiles_per_block = shard_spec.shape[1] / TILE_WIDTH;

--- a/ttnn/cpp/ttnn/experimental/tt_dnn/op_library/untilize/untilize_with_halo_op.cpp
+++ b/ttnn/cpp/ttnn/experimental/tt_dnn/op_library/untilize/untilize_with_halo_op.cpp
@@ -776,8 +776,8 @@ operation::ProgramWithCallbacks untilize_with_halo_multi_core_s1(const Tensor& a
     int32_t ncores_col = 1;
     if (a.memory_config().memory_layout == TensorMemoryLayout::BLOCK_SHARDED) {
         auto core_range = *(all_cores.ranges().begin());
-        ncores = core_range.end.x - core_range.start.x + 1;
-        ncores_col = core_range.end.y - core_range.start.y + 1;
+        ncores = core_range.end_.x - core_range.start_.x + 1;
+        ncores_col = core_range.end_.y - core_range.start_.y + 1;
     }
 
     CoreRangeSet core_range_cliff = CoreRangeSet({});
@@ -795,7 +795,7 @@ operation::ProgramWithCallbacks untilize_with_halo_multi_core_s1(const Tensor& a
         nblocks = ceil((float) ntiles / ntiles_per_block);
         block_size_nbytes = shard_shape[1] * output.element_size();
         auto core_range = *(all_cores.ranges().begin());
-        int32_t ncores_y = core_range.end.y - core_range.start.y + 1;
+        int32_t ncores_y = core_range.end_.y - core_range.start_.y + 1;
         TT_ASSERT(a.shard_spec().value().shape[1] * ncores_y == input_shape[3], "Input shape in W should be same as shard width * num cores along each row!");
     } else {
         TT_ASSERT(a.shard_spec().value().shape[1] == input_shape[3], "Input shape in W should be same as shard width!");
@@ -1318,7 +1318,7 @@ std::vector<Shape> UntilizeWithHalo::compute_output_shapes(const std::vector<Ten
     uint32_t ncores = in_nhw / shard_shape[0];
     if (input.memory_config().memory_layout == TensorMemoryLayout::BLOCK_SHARDED) {
         auto core_range = *(input.shard_spec().value().grid.ranges().begin());
-        ncores = core_range.end.x - core_range.start.x + 1;
+        ncores = core_range.end_.x - core_range.start_.x + 1;
     }
 
     uint32_t total_nsticks = ncores * max_out_nsticks_per_core_;
@@ -1351,7 +1351,7 @@ std::vector<Tensor> UntilizeWithHalo::create_output_tensors(const std::vector<Te
     uint32_t ncores = input_tensor.get_legacy_shape()[0] * input_tensor.get_legacy_shape()[2] / shard_spec.shape[0];
     if (input_tensor.memory_config().memory_layout == TensorMemoryLayout::BLOCK_SHARDED) {
         auto core_range = *(input_tensor.shard_spec().value().grid.ranges().begin());
-        ncores = core_range.end.x - core_range.start.x + 1;
+        ncores = core_range.end_.x - core_range.start_.x + 1;
     }
     shard_spec.shape[0] = output_shape[0] * div_up(output_shape[2], ncores);
     shard_spec.halo = true;
@@ -1400,7 +1400,7 @@ Tensor untilize_with_halo(const Tensor &input_tensor_a, const uint32_t pad_val, 
         TT_ASSERT(input_tensor_a.shard_spec().value().orientation == ShardOrientation::COL_MAJOR);
         TT_ASSERT(all_cores.ranges().size() == 1);
         auto core_range = *(all_cores.ranges().begin());
-        ncores = core_range.end.x - core_range.start.x + 1;
+        ncores = core_range.end_.x - core_range.start_.x + 1;
         in_nsticks_per_core = input_tensor_a.shard_spec().value().shape[0];
     }
 

--- a/ttnn/cpp/ttnn/experimental/tt_dnn/op_library/untilize/untilize_with_halo_op.cpp
+++ b/ttnn/cpp/ttnn/experimental/tt_dnn/op_library/untilize/untilize_with_halo_op.cpp
@@ -776,8 +776,8 @@ operation::ProgramWithCallbacks untilize_with_halo_multi_core_s1(const Tensor& a
     int32_t ncores_col = 1;
     if (a.memory_config().memory_layout == TensorMemoryLayout::BLOCK_SHARDED) {
         auto core_range = *(all_cores.ranges().begin());
-        ncores = core_range.end_.x - core_range.start_.x + 1;
-        ncores_col = core_range.end_.y - core_range.start_.y + 1;
+        ncores = core_range.end_coord.x - core_range.start_coord.x + 1;
+        ncores_col = core_range.end_coord.y - core_range.start_coord.y + 1;
     }
 
     CoreRangeSet core_range_cliff = CoreRangeSet({});
@@ -795,7 +795,7 @@ operation::ProgramWithCallbacks untilize_with_halo_multi_core_s1(const Tensor& a
         nblocks = ceil((float) ntiles / ntiles_per_block);
         block_size_nbytes = shard_shape[1] * output.element_size();
         auto core_range = *(all_cores.ranges().begin());
-        int32_t ncores_y = core_range.end_.y - core_range.start_.y + 1;
+        int32_t ncores_y = core_range.end_coord.y - core_range.start_coord.y + 1;
         TT_ASSERT(a.shard_spec().value().shape[1] * ncores_y == input_shape[3], "Input shape in W should be same as shard width * num cores along each row!");
     } else {
         TT_ASSERT(a.shard_spec().value().shape[1] == input_shape[3], "Input shape in W should be same as shard width!");
@@ -1318,7 +1318,7 @@ std::vector<Shape> UntilizeWithHalo::compute_output_shapes(const std::vector<Ten
     uint32_t ncores = in_nhw / shard_shape[0];
     if (input.memory_config().memory_layout == TensorMemoryLayout::BLOCK_SHARDED) {
         auto core_range = *(input.shard_spec().value().grid.ranges().begin());
-        ncores = core_range.end_.x - core_range.start_.x + 1;
+        ncores = core_range.end_coord.x - core_range.start_coord.x + 1;
     }
 
     uint32_t total_nsticks = ncores * max_out_nsticks_per_core_;
@@ -1351,7 +1351,7 @@ std::vector<Tensor> UntilizeWithHalo::create_output_tensors(const std::vector<Te
     uint32_t ncores = input_tensor.get_legacy_shape()[0] * input_tensor.get_legacy_shape()[2] / shard_spec.shape[0];
     if (input_tensor.memory_config().memory_layout == TensorMemoryLayout::BLOCK_SHARDED) {
         auto core_range = *(input_tensor.shard_spec().value().grid.ranges().begin());
-        ncores = core_range.end_.x - core_range.start_.x + 1;
+        ncores = core_range.end_coord.x - core_range.start_coord.x + 1;
     }
     shard_spec.shape[0] = output_shape[0] * div_up(output_shape[2], ncores);
     shard_spec.halo = true;
@@ -1400,7 +1400,7 @@ Tensor untilize_with_halo(const Tensor &input_tensor_a, const uint32_t pad_val, 
         TT_ASSERT(input_tensor_a.shard_spec().value().orientation == ShardOrientation::COL_MAJOR);
         TT_ASSERT(all_cores.ranges().size() == 1);
         auto core_range = *(all_cores.ranges().begin());
-        ncores = core_range.end_.x - core_range.start_.x + 1;
+        ncores = core_range.end_coord.x - core_range.start_coord.x + 1;
         in_nsticks_per_core = input_tensor_a.shard_spec().value().shape[0];
     }
 

--- a/ttnn/cpp/ttnn/experimental/tt_dnn/op_library/untilize/untilize_with_halo_op_v2.cpp
+++ b/ttnn/cpp/ttnn/experimental/tt_dnn/op_library/untilize/untilize_with_halo_op_v2.cpp
@@ -295,8 +295,8 @@ std::vector<Tensor> UntilizeWithHaloV2::create_output_tensors(const std::vector<
     if (input_tensor.memory_config().memory_layout == TensorMemoryLayout::BLOCK_SHARDED) {
         auto input_core_range = *(input_tensor.memory_config().shard_spec->grid.ranges().begin());
         auto output_core_range = *(out_mem_config_.shard_spec->grid.ranges().begin());
-        auto input_core_w = input_core_range.end.y - input_core_range.start.y + 1;
-        auto output_core_w = output_core_range.end.y - output_core_range.start.y + 1;
+        auto input_core_w = input_core_range.end_.y - input_core_range.start_.y + 1;
+        auto output_core_w = output_core_range.end_.y - output_core_range.start_.y + 1;
         TT_FATAL(input_core_w == output_core_w);
     }
 

--- a/ttnn/cpp/ttnn/experimental/tt_dnn/op_library/untilize/untilize_with_halo_op_v2.cpp
+++ b/ttnn/cpp/ttnn/experimental/tt_dnn/op_library/untilize/untilize_with_halo_op_v2.cpp
@@ -295,8 +295,8 @@ std::vector<Tensor> UntilizeWithHaloV2::create_output_tensors(const std::vector<
     if (input_tensor.memory_config().memory_layout == TensorMemoryLayout::BLOCK_SHARDED) {
         auto input_core_range = *(input_tensor.memory_config().shard_spec->grid.ranges().begin());
         auto output_core_range = *(out_mem_config_.shard_spec->grid.ranges().begin());
-        auto input_core_w = input_core_range.end_.y - input_core_range.start_.y + 1;
-        auto output_core_w = output_core_range.end_.y - output_core_range.start_.y + 1;
+        auto input_core_w = input_core_range.end_coord.y - input_core_range.start_coord.y + 1;
+        auto output_core_w = output_core_range.end_coord.y - output_core_range.start_coord.y + 1;
         TT_FATAL(input_core_w == output_core_w);
     }
 

--- a/ttnn/cpp/ttnn/experimental/tt_dnn/op_library/update_cache/multi_core/update_cache_op_multi_core.cpp
+++ b/ttnn/cpp/ttnn/experimental/tt_dnn/op_library/update_cache/multi_core/update_cache_op_multi_core.cpp
@@ -92,8 +92,8 @@ operation::ProgramWithCallbacks update_cache_multi_core(const Tensor& cache_tens
         num_batched_heads_per_core_group_2 = 0;
         num_input_tiles = shard_spec.value().shape[0] * shard_spec.value().shape[1] / TILE_HW;
         auto bbox = all_cores.bounding_box();
-        num_cores_x = bbox.end_.x + 1;
-        num_cores_y = bbox.end_.y + 1;
+        num_cores_x = bbox.end_coord.x + 1;
+        num_cores_y = bbox.end_coord.y + 1;
     } else {
         row_major = true;
         std::tie(num_cores, all_cores, core_group_1, core_group_2, num_batched_heads_per_core_group_1, num_batched_heads_per_core_group_2) = split_work_to_cores(compute_with_storage_grid_size, num_batched_heads, row_major);
@@ -353,8 +353,8 @@ operation::ProgramWithCallbacks fill_cache_multi_core(const Tensor& cache_tensor
         num_blocks_per_core_group_2 = 0;
         num_input_tiles = shard_spec.value().shape[0] * shard_spec.value().shape[1] / TILE_HW;
         auto bbox = all_cores.bounding_box();
-        num_cores_x = bbox.end_.x + 1;
-        num_cores_y = bbox.end_.y + 1;
+        num_cores_x = bbox.end_coord.x + 1;
+        num_cores_y = bbox.end_coord.y + 1;
     } else {
         row_major = true;
         std::tie(num_cores, all_cores, core_group_1, core_group_2, num_blocks_per_core_group_1, num_blocks_per_core_group_2) = split_work_to_cores(compute_with_storage_grid_size, num_blocks_of_work, row_major);

--- a/ttnn/cpp/ttnn/experimental/tt_dnn/op_library/update_cache/multi_core/update_cache_op_multi_core.cpp
+++ b/ttnn/cpp/ttnn/experimental/tt_dnn/op_library/update_cache/multi_core/update_cache_op_multi_core.cpp
@@ -92,8 +92,8 @@ operation::ProgramWithCallbacks update_cache_multi_core(const Tensor& cache_tens
         num_batched_heads_per_core_group_2 = 0;
         num_input_tiles = shard_spec.value().shape[0] * shard_spec.value().shape[1] / TILE_HW;
         auto bbox = all_cores.bounding_box();
-        num_cores_x = bbox.end.x + 1;
-        num_cores_y = bbox.end.y + 1;
+        num_cores_x = bbox.end_.x + 1;
+        num_cores_y = bbox.end_.y + 1;
     } else {
         row_major = true;
         std::tie(num_cores, all_cores, core_group_1, core_group_2, num_batched_heads_per_core_group_1, num_batched_heads_per_core_group_2) = split_work_to_cores(compute_with_storage_grid_size, num_batched_heads, row_major);
@@ -353,8 +353,8 @@ operation::ProgramWithCallbacks fill_cache_multi_core(const Tensor& cache_tensor
         num_blocks_per_core_group_2 = 0;
         num_input_tiles = shard_spec.value().shape[0] * shard_spec.value().shape[1] / TILE_HW;
         auto bbox = all_cores.bounding_box();
-        num_cores_x = bbox.end.x + 1;
-        num_cores_y = bbox.end.y + 1;
+        num_cores_x = bbox.end_.x + 1;
+        num_cores_y = bbox.end_.y + 1;
     } else {
         row_major = true;
         std::tie(num_cores, all_cores, core_group_1, core_group_2, num_blocks_per_core_group_1, num_blocks_per_core_group_2) = split_work_to_cores(compute_with_storage_grid_size, num_blocks_of_work, row_major);

--- a/ttnn/cpp/ttnn/experimental/tt_dnn/op_library/work_split.hpp
+++ b/ttnn/cpp/ttnn/experimental/tt_dnn/op_library/work_split.hpp
@@ -177,40 +177,40 @@ inline std::tuple<uint32_t, CoreRangeSet, CoreRangeSet, CoreRangeSet, uint32_t, 
         auto last_block_all_cores = (*all_cores.ranges().rbegin());
         if (row_wise) {
             // Case where only the last row is divided between core group 1 and 2
-            if (last_block_group_1.end_.y == last_block_all_cores.end_.y &&
-                last_block_group_1.end_.x != last_block_all_cores.end_.x) {
+            if (last_block_group_1.end_coord.y == last_block_all_cores.end_coord.y &&
+                last_block_group_1.end_coord.x != last_block_all_cores.end_coord.x) {
                 CoreRange leftover_block(
-                    {last_block_group_1.end_.x + 1, last_block_group_1.end_.y}, last_block_all_cores.end_);
+                    {last_block_group_1.end_coord.x + 1, last_block_group_1.end_coord.y}, last_block_all_cores.end_coord);
                 core_group_2_set.insert(leftover_block);
             } else {
                 // Case where a middle row is divided between core group 1 and 2
-                if (last_block_group_1.end_.x != num_cores_x - 1) {
+                if (last_block_group_1.end_coord.x != num_cores_x - 1) {
                     CoreRange leftover_stick(
-                        {last_block_group_1.end_.x + 1, last_block_group_1.end_.y},
-                        {num_cores_x - 1, last_block_group_1.end_.y});
+                        {last_block_group_1.end_coord.x + 1, last_block_group_1.end_coord.y},
+                        {num_cores_x - 1, last_block_group_1.end_coord.y});
                     core_group_2_set.insert(leftover_stick);
                 }
                 // Remaining rows of cores that does less work
-                CoreRange leftover_block({0, last_block_group_1.end_.y + 1}, last_block_all_cores.end_);
+                CoreRange leftover_block({0, last_block_group_1.end_coord.y + 1}, last_block_all_cores.end_coord);
                 core_group_2_set.insert(leftover_block);
             }
         } else {
             // Case where only the last column is divided between core group 1 and 2
-            if (last_block_group_1.end_.x == last_block_all_cores.end_.x &&
-                last_block_group_1.end_.y != last_block_all_cores.end_.y) {
+            if (last_block_group_1.end_coord.x == last_block_all_cores.end_coord.x &&
+                last_block_group_1.end_coord.y != last_block_all_cores.end_coord.y) {
                 CoreRange leftover_block(
-                    {last_block_group_1.end_.x, last_block_group_1.end_.y + 1}, last_block_all_cores.end_);
+                    {last_block_group_1.end_coord.x, last_block_group_1.end_coord.y + 1}, last_block_all_cores.end_coord);
                 core_group_2_set.insert(leftover_block);
             } else {
                 // Case where a middle column is divided between core group 1 and 2
-                if (last_block_group_1.end_.y != num_cores_y - 1) {
+                if (last_block_group_1.end_coord.y != num_cores_y - 1) {
                     CoreRange leftover_stick(
-                        {last_block_group_1.end_.x, last_block_group_1.end_.y + 1},
-                        {last_block_group_1.end_.x, num_cores_y - 1});
+                        {last_block_group_1.end_coord.x, last_block_group_1.end_coord.y + 1},
+                        {last_block_group_1.end_coord.x, num_cores_y - 1});
                     core_group_2_set.insert(leftover_stick);
                 }
                 // Remaining columns of cores that does less work
-                CoreRange leftover_block({last_block_group_1.end_.x + 1, 0}, last_block_all_cores.end_);
+                CoreRange leftover_block({last_block_group_1.end_coord.x + 1, 0}, last_block_all_cores.end_coord);
                 core_group_2_set.insert(leftover_block);
             }
         }

--- a/ttnn/cpp/ttnn/experimental/tt_dnn/op_library/work_split.hpp
+++ b/ttnn/cpp/ttnn/experimental/tt_dnn/op_library/work_split.hpp
@@ -177,40 +177,40 @@ inline std::tuple<uint32_t, CoreRangeSet, CoreRangeSet, CoreRangeSet, uint32_t, 
         auto last_block_all_cores = (*all_cores.ranges().rbegin());
         if (row_wise) {
             // Case where only the last row is divided between core group 1 and 2
-            if (last_block_group_1.end.y == last_block_all_cores.end.y &&
-                last_block_group_1.end.x != last_block_all_cores.end.x) {
+            if (last_block_group_1.end_.y == last_block_all_cores.end_.y &&
+                last_block_group_1.end_.x != last_block_all_cores.end_.x) {
                 CoreRange leftover_block(
-                    {last_block_group_1.end.x + 1, last_block_group_1.end.y}, last_block_all_cores.end);
+                    {last_block_group_1.end_.x + 1, last_block_group_1.end_.y}, last_block_all_cores.end_);
                 core_group_2_set.insert(leftover_block);
             } else {
                 // Case where a middle row is divided between core group 1 and 2
-                if (last_block_group_1.end.x != num_cores_x - 1) {
+                if (last_block_group_1.end_.x != num_cores_x - 1) {
                     CoreRange leftover_stick(
-                        {last_block_group_1.end.x + 1, last_block_group_1.end.y},
-                        {num_cores_x - 1, last_block_group_1.end.y});
+                        {last_block_group_1.end_.x + 1, last_block_group_1.end_.y},
+                        {num_cores_x - 1, last_block_group_1.end_.y});
                     core_group_2_set.insert(leftover_stick);
                 }
                 // Remaining rows of cores that does less work
-                CoreRange leftover_block({0, last_block_group_1.end.y + 1}, last_block_all_cores.end);
+                CoreRange leftover_block({0, last_block_group_1.end_.y + 1}, last_block_all_cores.end_);
                 core_group_2_set.insert(leftover_block);
             }
         } else {
             // Case where only the last column is divided between core group 1 and 2
-            if (last_block_group_1.end.x == last_block_all_cores.end.x &&
-                last_block_group_1.end.y != last_block_all_cores.end.y) {
+            if (last_block_group_1.end_.x == last_block_all_cores.end_.x &&
+                last_block_group_1.end_.y != last_block_all_cores.end_.y) {
                 CoreRange leftover_block(
-                    {last_block_group_1.end.x, last_block_group_1.end.y + 1}, last_block_all_cores.end);
+                    {last_block_group_1.end_.x, last_block_group_1.end_.y + 1}, last_block_all_cores.end_);
                 core_group_2_set.insert(leftover_block);
             } else {
                 // Case where a middle column is divided between core group 1 and 2
-                if (last_block_group_1.end.y != num_cores_y - 1) {
+                if (last_block_group_1.end_.y != num_cores_y - 1) {
                     CoreRange leftover_stick(
-                        {last_block_group_1.end.x, last_block_group_1.end.y + 1},
-                        {last_block_group_1.end.x, num_cores_y - 1});
+                        {last_block_group_1.end_.x, last_block_group_1.end_.y + 1},
+                        {last_block_group_1.end_.x, num_cores_y - 1});
                     core_group_2_set.insert(leftover_stick);
                 }
                 // Remaining columns of cores that does less work
-                CoreRange leftover_block({last_block_group_1.end.x + 1, 0}, last_block_all_cores.end);
+                CoreRange leftover_block({last_block_group_1.end_.x + 1, 0}, last_block_all_cores.end_);
                 core_group_2_set.insert(leftover_block);
             }
         }

--- a/ttnn/cpp/ttnn/experimental/tt_dnn/op_library/work_split_tilize.hpp
+++ b/ttnn/cpp/ttnn/experimental/tt_dnn/op_library/work_split_tilize.hpp
@@ -65,7 +65,7 @@ inline BlockSplit split_blocks_for_tilize(CoreCoord grid_size, uint32_t nblocks)
             // Cliff core is in the same row as the last core range, increment its end
             auto last_range = *all_cores.rbegin();
             auto node = all_cores.extract(last_range);
-            node.value().end = *cliff_core;
+            node.value().end_ = *cliff_core;
             all_cores.insert(std::move(node));
         }
     }

--- a/ttnn/cpp/ttnn/experimental/tt_dnn/op_library/work_split_tilize.hpp
+++ b/ttnn/cpp/ttnn/experimental/tt_dnn/op_library/work_split_tilize.hpp
@@ -65,7 +65,7 @@ inline BlockSplit split_blocks_for_tilize(CoreCoord grid_size, uint32_t nblocks)
             // Cliff core is in the same row as the last core range, increment its end
             auto last_range = *all_cores.rbegin();
             auto node = all_cores.extract(last_range);
-            node.value().end_ = *cliff_core;
+            node.value().end_coord = *cliff_core;
             all_cores.insert(std::move(node));
         }
     }

--- a/ttnn/cpp/ttnn/experimental/tt_lib/csrc/tt_lib_bindings_tensor.cpp
+++ b/ttnn/cpp/ttnn/experimental/tt_lib/csrc/tt_lib_bindings_tensor.cpp
@@ -221,8 +221,8 @@ void TensorModule(py::module& m_tensor) {
         Class defining a range of cores)doc");
     pyCoreRange.def(py::init<>([](const CoreCoord& start, const CoreCoord& end) { return CoreRange{start, end}; }))
         .def("__repr__", [](const CoreRange& core_range) -> std::string { return fmt::format("{}", core_range); })
-        .def_readonly("start", &CoreRange::start)
-        .def_readonly("end", &CoreRange::end)
+        .def_readonly("start", &CoreRange::start_)
+        .def_readonly("end", &CoreRange::end_)
         .def("grid_size", &CoreRange::grid_size);
 
     auto pyCoreRangeSet = py::class_<CoreRangeSet>(m_tensor, "CoreRangeSet", R"doc(

--- a/ttnn/cpp/ttnn/experimental/tt_lib/csrc/tt_lib_bindings_tensor.cpp
+++ b/ttnn/cpp/ttnn/experimental/tt_lib/csrc/tt_lib_bindings_tensor.cpp
@@ -221,8 +221,8 @@ void TensorModule(py::module& m_tensor) {
         Class defining a range of cores)doc");
     pyCoreRange.def(py::init<>([](const CoreCoord& start, const CoreCoord& end) { return CoreRange{start, end}; }))
         .def("__repr__", [](const CoreRange& core_range) -> std::string { return fmt::format("{}", core_range); })
-        .def_readonly("start", &CoreRange::start_)
-        .def_readonly("end", &CoreRange::end_)
+        .def_readonly("start", &CoreRange::start_coord)
+        .def_readonly("end", &CoreRange::end_coord)
         .def("grid_size", &CoreRange::grid_size);
 
     auto pyCoreRangeSet = py::class_<CoreRangeSet>(m_tensor, "CoreRangeSet", R"doc(

--- a/ttnn/cpp/ttnn/op_library/to_memory_config/to_memory_config_op.hpp
+++ b/ttnn/cpp/ttnn/op_library/to_memory_config/to_memory_config_op.hpp
@@ -73,7 +73,7 @@ struct ToMemoryConfig {
                 }
             } else {
                 auto bbox = memory_config.shard_spec.value().grid.bounding_box();
-                CoreCoord grid_size(bbox.end_.x + 1, bbox.end_.y + 1);
+                CoreCoord grid_size(bbox.end_coord.x + 1, bbox.end_coord.y + 1);
                 return operation::run(
                            Sharded{
                                .grid_size = grid_size,

--- a/ttnn/cpp/ttnn/op_library/to_memory_config/to_memory_config_op.hpp
+++ b/ttnn/cpp/ttnn/op_library/to_memory_config/to_memory_config_op.hpp
@@ -73,7 +73,7 @@ struct ToMemoryConfig {
                 }
             } else {
                 auto bbox = memory_config.shard_spec.value().grid.bounding_box();
-                CoreCoord grid_size(bbox.end.x + 1, bbox.end.y + 1);
+                CoreCoord grid_size(bbox.end_.x + 1, bbox.end_.y + 1);
                 return operation::run(
                            Sharded{
                                .grid_size = grid_size,

--- a/ttnn/cpp/ttnn/operations/conv2d/device/multi_core_optimized_conv_sharded/optimized_conv_op_sharded_v2.cpp
+++ b/ttnn/cpp/ttnn/operations/conv2d/device/multi_core_optimized_conv_sharded/optimized_conv_op_sharded_v2.cpp
@@ -1416,7 +1416,7 @@ operation::ProgramWithCallbacks multi_core_optimized_conv_sharded_v2_impl(
 
     }  // for num_cores
 
-    auto mcast_sender_cores_vec = grid_to_cores(mcast_sender_cores.start_, mcast_sender_cores.end_, true);
+    auto mcast_sender_cores_vec = grid_to_cores(mcast_sender_cores.start_coord, mcast_sender_cores.end_coord, true);
     auto mcast_receiver_cores_vec = corerange_to_cores(mcast_receiver_cores, std::nullopt, true);
     auto override_runtime_arguments_callback =
         [reader_kernel_id = reader_id,

--- a/ttnn/cpp/ttnn/operations/conv2d/device/multi_core_optimized_conv_sharded/optimized_conv_op_sharded_v2.cpp
+++ b/ttnn/cpp/ttnn/operations/conv2d/device/multi_core_optimized_conv_sharded/optimized_conv_op_sharded_v2.cpp
@@ -1416,7 +1416,7 @@ operation::ProgramWithCallbacks multi_core_optimized_conv_sharded_v2_impl(
 
     }  // for num_cores
 
-    auto mcast_sender_cores_vec = grid_to_cores(mcast_sender_cores.start, mcast_sender_cores.end, true);
+    auto mcast_sender_cores_vec = grid_to_cores(mcast_sender_cores.start_, mcast_sender_cores.end_, true);
     auto mcast_receiver_cores_vec = corerange_to_cores(mcast_receiver_cores, std::nullopt, true);
     auto override_runtime_arguments_callback =
         [reader_kernel_id = reader_id,

--- a/ttnn/cpp/ttnn/operations/data_movement/downsample/device/downsample_op.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/downsample/device/downsample_op.cpp
@@ -47,10 +47,10 @@ std::pair<uint32_t, uint32_t> get_num_cores_height_width_sliced(
     uint32_t num_cores = all_cores.num_cores();
     auto first_core_range = *all_cores.ranges().begin();
     uint32_t num_cores_height_sliced =
-        memory_layout == TensorMemoryLayout::HEIGHT_SHARDED ? num_cores : first_core_range.end_.x + 1;
+        memory_layout == TensorMemoryLayout::HEIGHT_SHARDED ? num_cores : first_core_range.end_coord.x + 1;
     uint32_t num_cores_width_sliced = memory_layout == TensorMemoryLayout::HEIGHT_SHARDED
                                           ? 1
-                                          : first_core_range.end_.y + 1;  // width is not sliced when height sharded
+                                          : first_core_range.end_coord.y + 1;  // width is not sliced when height sharded
     return {num_cores_height_sliced, num_cores_width_sliced};
 }
 

--- a/ttnn/cpp/ttnn/operations/data_movement/downsample/device/downsample_op.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/downsample/device/downsample_op.cpp
@@ -47,10 +47,10 @@ std::pair<uint32_t, uint32_t> get_num_cores_height_width_sliced(
     uint32_t num_cores = all_cores.num_cores();
     auto first_core_range = *all_cores.ranges().begin();
     uint32_t num_cores_height_sliced =
-        memory_layout == TensorMemoryLayout::HEIGHT_SHARDED ? num_cores : first_core_range.end.x + 1;
+        memory_layout == TensorMemoryLayout::HEIGHT_SHARDED ? num_cores : first_core_range.end_.x + 1;
     uint32_t num_cores_width_sliced = memory_layout == TensorMemoryLayout::HEIGHT_SHARDED
                                           ? 1
-                                          : first_core_range.end.y + 1;  // width is not sliced when height sharded
+                                          : first_core_range.end_.y + 1;  // width is not sliced when height sharded
     return {num_cores_height_sliced, num_cores_width_sliced};
 }
 

--- a/ttnn/cpp/ttnn/operations/eltwise/binary/device/element_wise_multi_core_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary/device/element_wise_multi_core_program_factory.cpp
@@ -91,14 +91,14 @@ inline __attribute__((always_inline)) void set_eltwise_binary_runtime_args(
             block_height = shard_spec.value().shape[0] / TILE_HEIGHT;
             block_width = shard_spec.value().shape[1] / TILE_WIDTH;
             block_size = block_width * block_height;
-            end_core = (*shard_spec.value().grid.ranges().begin()).end_;
+            end_core = (*shard_spec.value().grid.ranges().begin()).end_coord;
             output_width = output.get_legacy_shape()[-1] / TILE_WIDTH;
             uint32_t output_height = output.volume() / output.get_legacy_shape()[-1] / TILE_HEIGHT;
             last_unpadded_block_height = block_height - (round_up(output_height, block_height) - output_height);
             last_unpadded_block_width = block_width - (round_up(output_width, block_width) - output_width);
         }
         auto bbox = core_group_1.bounding_box();
-        cores = grid_to_cores_with_noop(bbox.end_.x, bbox.end_.y, num_cores_x, num_cores_y, row_major);
+        cores = grid_to_cores_with_noop(bbox.end_coord.x, bbox.end_coord.y, num_cores_x, num_cores_y, row_major);
     } else {
         row_major = true;
         std::tie(

--- a/ttnn/cpp/ttnn/operations/eltwise/binary/device/element_wise_multi_core_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary/device/element_wise_multi_core_program_factory.cpp
@@ -91,14 +91,14 @@ inline __attribute__((always_inline)) void set_eltwise_binary_runtime_args(
             block_height = shard_spec.value().shape[0] / TILE_HEIGHT;
             block_width = shard_spec.value().shape[1] / TILE_WIDTH;
             block_size = block_width * block_height;
-            end_core = (*shard_spec.value().grid.ranges().begin()).end;
+            end_core = (*shard_spec.value().grid.ranges().begin()).end_;
             output_width = output.get_legacy_shape()[-1] / TILE_WIDTH;
             uint32_t output_height = output.volume() / output.get_legacy_shape()[-1] / TILE_HEIGHT;
             last_unpadded_block_height = block_height - (round_up(output_height, block_height) - output_height);
             last_unpadded_block_width = block_width - (round_up(output_width, block_width) - output_width);
         }
         auto bbox = core_group_1.bounding_box();
-        cores = grid_to_cores_with_noop(bbox.end.x, bbox.end.y, num_cores_x, num_cores_y, row_major);
+        cores = grid_to_cores_with_noop(bbox.end_.x, bbox.end_.y, num_cores_x, num_cores_y, row_major);
     } else {
         row_major = true;
         std::tie(

--- a/ttnn/cpp/ttnn/operations/matmul/device/matmul_op.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/matmul_op.cpp
@@ -916,8 +916,8 @@ void Matmul::validate(
                         TT_FATAL(K == program_config.in0_block_w);
                         TT_FATAL(program_config.in0_block_w == (shard_shape[1] / TILE_WIDTH));
                         TT_FATAL(
-                            input_tensor_a.shard_spec()->grid.bounding_box().start_.x ==
-                            input_tensor_a.shard_spec()->grid.bounding_box().end_.x);
+                            input_tensor_a.shard_spec()->grid.bounding_box().start_coord.x ==
+                            input_tensor_a.shard_spec()->grid.bounding_box().end_coord.x);
                     }
 
                     TT_FATAL(per_core_M == (shard_shape[0] / TILE_HEIGHT));
@@ -932,8 +932,8 @@ void Matmul::validate(
                         TT_FATAL(program_config.per_core_N == (input_tensor_b.shard_spec().value().shape[1] / TILE_WIDTH));
                     }
                     TT_FATAL(
-                        input_tensor_b.shard_spec()->grid.bounding_box().start_.y ==
-                        input_tensor_b.shard_spec()->grid.bounding_box().end_.y);
+                        input_tensor_b.shard_spec()->grid.bounding_box().start_coord.y ==
+                        input_tensor_b.shard_spec()->grid.bounding_box().end_coord.y);
                 }
 
                 if (this->output_mem_config.is_sharded()) {

--- a/ttnn/cpp/ttnn/operations/matmul/device/matmul_op.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/matmul_op.cpp
@@ -916,8 +916,8 @@ void Matmul::validate(
                         TT_FATAL(K == program_config.in0_block_w);
                         TT_FATAL(program_config.in0_block_w == (shard_shape[1] / TILE_WIDTH));
                         TT_FATAL(
-                            input_tensor_a.shard_spec()->grid.bounding_box().start.x ==
-                            input_tensor_a.shard_spec()->grid.bounding_box().end.x);
+                            input_tensor_a.shard_spec()->grid.bounding_box().start_.x ==
+                            input_tensor_a.shard_spec()->grid.bounding_box().end_.x);
                     }
 
                     TT_FATAL(per_core_M == (shard_shape[0] / TILE_HEIGHT));
@@ -932,8 +932,8 @@ void Matmul::validate(
                         TT_FATAL(program_config.per_core_N == (input_tensor_b.shard_spec().value().shape[1] / TILE_WIDTH));
                     }
                     TT_FATAL(
-                        input_tensor_b.shard_spec()->grid.bounding_box().start.y ==
-                        input_tensor_b.shard_spec()->grid.bounding_box().end.y);
+                        input_tensor_b.shard_spec()->grid.bounding_box().start_.y ==
+                        input_tensor_b.shard_spec()->grid.bounding_box().end_.y);
                 }
 
                 if (this->output_mem_config.is_sharded()) {

--- a/ttnn/cpp/ttnn/operations/matmul/device/multi_core_reuse_mcast_1d_optimized/bmm_op_multi_core_reuse_mcast_1d_optimized.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/multi_core_reuse_mcast_1d_optimized/bmm_op_multi_core_reuse_mcast_1d_optimized.cpp
@@ -195,8 +195,8 @@ operation::ProgramWithCallbacks create_program_mcast_in0(
     auto in0_mcast_sender_semaphore = tt_metal::CreateSemaphore(program, all_cores, INVALID);
     auto in0_mcast_receiver_semaphore = tt_metal::CreateSemaphore(program, all_cores, INVALID);
 
-    CoreCoord top_left_core = in0_mcast_receiver_cores_bounding_box.start_;
-    CoreCoord bottom_right_core = in0_mcast_receiver_cores_bounding_box.end_;
+    CoreCoord top_left_core = in0_mcast_receiver_cores_bounding_box.start_coord;
+    CoreCoord bottom_right_core = in0_mcast_receiver_cores_bounding_box.end_coord;
     auto top_left_core_physical = device->worker_core_from_logical_core(top_left_core);
     auto bottom_right_core_physical = device->worker_core_from_logical_core(bottom_right_core);
 
@@ -915,8 +915,8 @@ operation::ProgramWithCallbacks create_program_mcast_in1(
     uint32_t in3_mcast_sender_semaphore = 0;
     uint32_t in3_mcast_receiver_semaphore = 0;
 
-    CoreCoord top_left_core = in1_mcast_receiver_cores_bounding_box.start_;
-    CoreCoord bottom_right_core = in1_mcast_receiver_cores_bounding_box.end_;
+    CoreCoord top_left_core = in1_mcast_receiver_cores_bounding_box.start_coord;
+    CoreCoord bottom_right_core = in1_mcast_receiver_cores_bounding_box.end_coord;
     auto top_left_core_physical = device->worker_core_from_logical_core(top_left_core);
     auto bottom_right_core_physical = device->worker_core_from_logical_core(bottom_right_core);
 

--- a/ttnn/cpp/ttnn/operations/matmul/device/multi_core_reuse_mcast_1d_optimized/bmm_op_multi_core_reuse_mcast_1d_optimized.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/multi_core_reuse_mcast_1d_optimized/bmm_op_multi_core_reuse_mcast_1d_optimized.cpp
@@ -195,8 +195,8 @@ operation::ProgramWithCallbacks create_program_mcast_in0(
     auto in0_mcast_sender_semaphore = tt_metal::CreateSemaphore(program, all_cores, INVALID);
     auto in0_mcast_receiver_semaphore = tt_metal::CreateSemaphore(program, all_cores, INVALID);
 
-    CoreCoord top_left_core = in0_mcast_receiver_cores_bounding_box.start;
-    CoreCoord bottom_right_core = in0_mcast_receiver_cores_bounding_box.end;
+    CoreCoord top_left_core = in0_mcast_receiver_cores_bounding_box.start_;
+    CoreCoord bottom_right_core = in0_mcast_receiver_cores_bounding_box.end_;
     auto top_left_core_physical = device->worker_core_from_logical_core(top_left_core);
     auto bottom_right_core_physical = device->worker_core_from_logical_core(bottom_right_core);
 
@@ -915,8 +915,8 @@ operation::ProgramWithCallbacks create_program_mcast_in1(
     uint32_t in3_mcast_sender_semaphore = 0;
     uint32_t in3_mcast_receiver_semaphore = 0;
 
-    CoreCoord top_left_core = in1_mcast_receiver_cores_bounding_box.start;
-    CoreCoord bottom_right_core = in1_mcast_receiver_cores_bounding_box.end;
+    CoreCoord top_left_core = in1_mcast_receiver_cores_bounding_box.start_;
+    CoreCoord bottom_right_core = in1_mcast_receiver_cores_bounding_box.end_;
     auto top_left_core_physical = device->worker_core_from_logical_core(top_left_core);
     auto bottom_right_core_physical = device->worker_core_from_logical_core(bottom_right_core);
 

--- a/ttnn/cpp/ttnn/operations/matmul/device/multi_core_reuse_mcast_2d_optimized/bmm_op_multi_core_reuse_mcast_2d_optimized.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/multi_core_reuse_mcast_2d_optimized/bmm_op_multi_core_reuse_mcast_2d_optimized.cpp
@@ -792,16 +792,16 @@ operation::ProgramWithCallbacks create_program_mcast_in0_in1(
 
     uint32_t in0_end_idx = num_blocks_y - 1;
     uint32_t in1_end_idx = num_blocks_x - 1;
-    const auto& cores = grid_to_cores(all_cores.start, all_cores.end, true);
+    const auto& cores = grid_to_cores(all_cores.start_, all_cores.end_, true);
     const auto& in0_sender_interleaved_cores =
-        grid_to_cores(in0_sender_interleaved.start, in0_sender_interleaved.end, true);  // Only used for interleaved in0
-    const auto& in1_sender_cores = grid_to_cores(in1_sender.start, in1_sender.end, true);
+        grid_to_cores(in0_sender_interleaved.start_, in0_sender_interleaved.end_, true);  // Only used for interleaved in0
+    const auto& in1_sender_cores = grid_to_cores(in1_sender.start_, in1_sender.end_, true);
     const auto& in1_receiver_cores = corerange_to_cores(in1_receiver, std::nullopt, true);
     std::vector<CoreCoord> in1_receiver_other_cores;
     if (in0_receiver_in1_receiver_interleaved_other_cores.has_value()) {
         in1_receiver_other_cores = grid_to_cores(
-            in0_receiver_in1_receiver_interleaved_other_cores.value().start,
-            in0_receiver_in1_receiver_interleaved_other_cores.value().end,
+            in0_receiver_in1_receiver_interleaved_other_cores.value().start_,
+            in0_receiver_in1_receiver_interleaved_other_cores.value().end_,
             true);
     }
 

--- a/ttnn/cpp/ttnn/operations/matmul/device/multi_core_reuse_mcast_2d_optimized/bmm_op_multi_core_reuse_mcast_2d_optimized.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/multi_core_reuse_mcast_2d_optimized/bmm_op_multi_core_reuse_mcast_2d_optimized.cpp
@@ -792,16 +792,16 @@ operation::ProgramWithCallbacks create_program_mcast_in0_in1(
 
     uint32_t in0_end_idx = num_blocks_y - 1;
     uint32_t in1_end_idx = num_blocks_x - 1;
-    const auto& cores = grid_to_cores(all_cores.start_, all_cores.end_, true);
+    const auto& cores = grid_to_cores(all_cores.start_coord, all_cores.end_coord, true);
     const auto& in0_sender_interleaved_cores =
-        grid_to_cores(in0_sender_interleaved.start_, in0_sender_interleaved.end_, true);  // Only used for interleaved in0
-    const auto& in1_sender_cores = grid_to_cores(in1_sender.start_, in1_sender.end_, true);
+        grid_to_cores(in0_sender_interleaved.start_coord, in0_sender_interleaved.end_coord, true);  // Only used for interleaved in0
+    const auto& in1_sender_cores = grid_to_cores(in1_sender.start_coord, in1_sender.end_coord, true);
     const auto& in1_receiver_cores = corerange_to_cores(in1_receiver, std::nullopt, true);
     std::vector<CoreCoord> in1_receiver_other_cores;
     if (in0_receiver_in1_receiver_interleaved_other_cores.has_value()) {
         in1_receiver_other_cores = grid_to_cores(
-            in0_receiver_in1_receiver_interleaved_other_cores.value().start_,
-            in0_receiver_in1_receiver_interleaved_other_cores.value().end_,
+            in0_receiver_in1_receiver_interleaved_other_cores.value().start_coord,
+            in0_receiver_in1_receiver_interleaved_other_cores.value().end_coord,
             true);
     }
 

--- a/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/multi_core/groupnorm_op_multi_core.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/multi_core/groupnorm_op_multi_core.cpp
@@ -382,7 +382,7 @@ operation::ProgramWithCallbacks groupnorm_multi_core_sharded(
         }
     }
     for (auto& coord : mcast_sender_core_ranges) {
-        log_debug(tt::LogOp, "mcast sender coord: {} {}", coord.start_.x, coord.start_.y);
+        log_debug(tt::LogOp, "mcast sender coord: {} {}", coord.start_coord.x, coord.start_coord.y);
     }
     for (int i=0; i < num_cores; ++i) {
         // not found in mcast sender
@@ -391,7 +391,7 @@ operation::ProgramWithCallbacks groupnorm_multi_core_sharded(
         }
     }
     for (auto& coord : mcast_receiver_core_ranges) {
-        log_debug(tt::LogOp, "mcast receiver coord: {} {}", coord.start_.x, coord.start_.y);
+        log_debug(tt::LogOp, "mcast receiver coord: {} {}", coord.start_coord.x, coord.start_coord.y);
     }
     CoreRangeSet mcast_sender_cores = CoreRangeSet(mcast_sender_core_ranges);
     CoreRangeSet mcast_receiver_cores = CoreRangeSet(mcast_receiver_core_ranges);

--- a/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/multi_core/groupnorm_op_multi_core.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/multi_core/groupnorm_op_multi_core.cpp
@@ -382,7 +382,7 @@ operation::ProgramWithCallbacks groupnorm_multi_core_sharded(
         }
     }
     for (auto& coord : mcast_sender_core_ranges) {
-        log_debug(tt::LogOp, "mcast sender coord: {} {}", coord.start.x, coord.start.y);
+        log_debug(tt::LogOp, "mcast sender coord: {} {}", coord.start_.x, coord.start_.y);
     }
     for (int i=0; i < num_cores; ++i) {
         // not found in mcast sender
@@ -391,7 +391,7 @@ operation::ProgramWithCallbacks groupnorm_multi_core_sharded(
         }
     }
     for (auto& coord : mcast_receiver_core_ranges) {
-        log_debug(tt::LogOp, "mcast receiver coord: {} {}", coord.start.x, coord.start.y);
+        log_debug(tt::LogOp, "mcast receiver coord: {} {}", coord.start_.x, coord.start_.y);
     }
     CoreRangeSet mcast_sender_cores = CoreRangeSet(mcast_sender_core_ranges);
     CoreRangeSet mcast_receiver_cores = CoreRangeSet(mcast_receiver_core_ranges);

--- a/ttnn/cpp/ttnn/operations/normalization/layernorm/device/layernorm_op.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/layernorm/device/layernorm_op.cpp
@@ -98,7 +98,7 @@ void LayerNorm::validate(const std::vector<Tensor> &input_tensors, const std::ve
                 TT_FATAL(M % TILE_HEIGHT == 0, "M must be divisible by tile height.");
                 TT_FATAL(K % TILE_WIDTH == 0, "K must be divisible by tile width.");
                 const auto bbox = shard_spec.grid.bounding_box();
-                TT_FATAL(bbox.end_.x < program_config.compute_with_storage_grid_size.x && bbox.end_.y < program_config.compute_with_storage_grid_size.y);
+                TT_FATAL(bbox.end_coord.x < program_config.compute_with_storage_grid_size.x && bbox.end_coord.y < program_config.compute_with_storage_grid_size.y);
 
                 bool mcast_1d = M == block_h;
                 bool row_wise = shard_spec.orientation == ShardOrientation::ROW_MAJOR;
@@ -108,11 +108,11 @@ void LayerNorm::validate(const std::vector<Tensor> &input_tensors, const std::ve
                     TT_FATAL(a.memory_config().memory_layout != TensorMemoryLayout::HEIGHT_SHARDED);
                 } else {
                     if (row_wise) {
-                        TT_FATAL(tt::div_up(Kt, (bbox.end_.x + 1)) == program_config.block_w, "block_w must equal to K / num_cores_c.");
-                        TT_FATAL(Mt / (bbox.end_.y + 1) == program_config.block_h, "block_h must equal to M / num_cores_r.");
+                        TT_FATAL(tt::div_up(Kt, (bbox.end_coord.x + 1)) == program_config.block_w, "block_w must equal to K / num_cores_c.");
+                        TT_FATAL(Mt / (bbox.end_coord.y + 1) == program_config.block_h, "block_h must equal to M / num_cores_r.");
                     } else {
-                        TT_FATAL(tt::div_up(Kt, (bbox.end_.y + 1)) == program_config.block_w, "block_w must equal to K / num_cores_r.");
-                        TT_FATAL(Mt / (bbox.end_.x + 1) == program_config.block_h, "block_h must equal to M / num_cores_c.");
+                        TT_FATAL(tt::div_up(Kt, (bbox.end_coord.y + 1)) == program_config.block_w, "block_w must equal to K / num_cores_r.");
+                        TT_FATAL(Mt / (bbox.end_coord.x + 1) == program_config.block_h, "block_h must equal to M / num_cores_c.");
                     }
                 }
                 if (b.has_value()) {

--- a/ttnn/cpp/ttnn/operations/normalization/layernorm/device/layernorm_op.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/layernorm/device/layernorm_op.cpp
@@ -98,7 +98,7 @@ void LayerNorm::validate(const std::vector<Tensor> &input_tensors, const std::ve
                 TT_FATAL(M % TILE_HEIGHT == 0, "M must be divisible by tile height.");
                 TT_FATAL(K % TILE_WIDTH == 0, "K must be divisible by tile width.");
                 const auto bbox = shard_spec.grid.bounding_box();
-                TT_FATAL(bbox.end.x < program_config.compute_with_storage_grid_size.x && bbox.end.y < program_config.compute_with_storage_grid_size.y);
+                TT_FATAL(bbox.end_.x < program_config.compute_with_storage_grid_size.x && bbox.end_.y < program_config.compute_with_storage_grid_size.y);
 
                 bool mcast_1d = M == block_h;
                 bool row_wise = shard_spec.orientation == ShardOrientation::ROW_MAJOR;
@@ -108,11 +108,11 @@ void LayerNorm::validate(const std::vector<Tensor> &input_tensors, const std::ve
                     TT_FATAL(a.memory_config().memory_layout != TensorMemoryLayout::HEIGHT_SHARDED);
                 } else {
                     if (row_wise) {
-                        TT_FATAL(tt::div_up(Kt, (bbox.end.x + 1)) == program_config.block_w, "block_w must equal to K / num_cores_c.");
-                        TT_FATAL(Mt / (bbox.end.y + 1) == program_config.block_h, "block_h must equal to M / num_cores_r.");
+                        TT_FATAL(tt::div_up(Kt, (bbox.end_.x + 1)) == program_config.block_w, "block_w must equal to K / num_cores_c.");
+                        TT_FATAL(Mt / (bbox.end_.y + 1) == program_config.block_h, "block_h must equal to M / num_cores_r.");
                     } else {
-                        TT_FATAL(tt::div_up(Kt, (bbox.end.y + 1)) == program_config.block_w, "block_w must equal to K / num_cores_r.");
-                        TT_FATAL(Mt / (bbox.end.x + 1) == program_config.block_h, "block_h must equal to M / num_cores_c.");
+                        TT_FATAL(tt::div_up(Kt, (bbox.end_.y + 1)) == program_config.block_w, "block_w must equal to K / num_cores_r.");
+                        TT_FATAL(Mt / (bbox.end_.x + 1) == program_config.block_h, "block_h must equal to M / num_cores_c.");
                     }
                 }
                 if (b.has_value()) {

--- a/ttnn/cpp/ttnn/operations/normalization/layernorm/device/multi_core/layernorm_op_multi_core.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/layernorm/device/multi_core/layernorm_op_multi_core.cpp
@@ -496,7 +496,7 @@ operation::ProgramWithCallbacks layernorm_multi_core_sharded(
     bool mcast_1d = M == block_h;
     bool row_wise = shard_spec.orientation == ShardOrientation::ROW_MAJOR;
     auto bbox = shard_spec.grid.bounding_box();
-    CoreCoord grid_size = {bbox.end_.x + 1, bbox.end_.y+1};
+    CoreCoord grid_size = {bbox.end_coord.x + 1, bbox.end_coord.y+1};
     if (mcast_1d) {
         num_blocks = shard_spec.num_cores();
     } else if (row_wise) {
@@ -636,7 +636,7 @@ operation::ProgramWithCallbacks layernorm_multi_core_sharded(
         if (row_wise) {
             if (use_mcast) {
                 CoreCoord all_start_core;
-                CoreCoord end_core = sender_cores.end_;
+                CoreCoord end_core = sender_cores.end_coord;
                 if (use_two_stage_reduce) {
                     if (end_core.x == all_core_grid_size.x - 1) {
                         all_start_core = {0, end_core.y + 1};
@@ -644,7 +644,7 @@ operation::ProgramWithCallbacks layernorm_multi_core_sharded(
                         all_start_core = {end_core.x + 1, end_core.y};
                     }
                 } else {
-                    if (end_core.x == bbox.end_.x) {
+                    if (end_core.x == bbox.end_coord.x) {
                         all_start_core = {0, end_core.y + 1};
                     } else {
                         all_start_core = {end_core.x + 1, end_core.y};
@@ -654,15 +654,15 @@ operation::ProgramWithCallbacks layernorm_multi_core_sharded(
             }
             if (num_none_all_to_all_workers > 0) {
                 if (use_two_stage_reduce) {
-                    CoreCoord none_start_core = {all_core_grid_size.x, sender_cores.end_.y};
+                    CoreCoord none_start_core = {all_core_grid_size.x, sender_cores.end_coord.y};
                     CoreCoord none_end_core = {num_cores_x - 1, num_cores_y - 1};
                     CoreRange none_core_range = CoreRange(none_start_core, none_end_core);
                     std::set<CoreRange> none_core_set; none_core_set.insert(none_core_range);
                     not_all_to_all_workers = CoreRangeSet(none_core_set);
                 } else {
                     CoreCoord none_start_core;
-                    CoreCoord end_core = (*all_to_all_cores.ranges().rbegin()).end_;
-                    if (end_core.x == bbox.end_.x) {
+                    CoreCoord end_core = (*all_to_all_cores.ranges().rbegin()).end_coord;
+                    if (end_core.x == bbox.end_coord.x) {
                         none_start_core = {0, end_core.y + 1};
                     } else {
                         none_start_core = {end_core.x + 1, end_core.y};
@@ -673,7 +673,7 @@ operation::ProgramWithCallbacks layernorm_multi_core_sharded(
         } else {
             if (use_mcast) {
                 CoreCoord all_start_core;
-                CoreCoord end_core = sender_cores.end_;
+                CoreCoord end_core = sender_cores.end_coord;
                 if (use_two_stage_reduce) {
                     if (end_core.y == all_core_grid_size.y - 1) {
                         all_start_core = {end_core.x + 1, 0};
@@ -681,7 +681,7 @@ operation::ProgramWithCallbacks layernorm_multi_core_sharded(
                         all_start_core = {end_core.x, end_core.y + 1};
                     }
                 } else {
-                    if (end_core.y == bbox.end_.y) {
+                    if (end_core.y == bbox.end_coord.y) {
                         all_start_core = {end_core.x + 1, 0};
                     } else {
                         all_start_core = {end_core.x, end_core.y + 1};
@@ -691,15 +691,15 @@ operation::ProgramWithCallbacks layernorm_multi_core_sharded(
             }
             if (num_none_all_to_all_workers > 0) {
                 if (use_two_stage_reduce) {
-                    CoreCoord none_start_core = {sender_cores.end_.x, all_core_grid_size.y};
+                    CoreCoord none_start_core = {sender_cores.end_coord.x, all_core_grid_size.y};
                     CoreCoord none_end_core = {num_cores_x - 1, num_cores_y - 1};
                     CoreRange none_core_range = CoreRange(none_start_core, none_end_core);
                     std::set<CoreRange> none_core_set; none_core_set.insert(none_core_range);
                     not_all_to_all_workers = CoreRangeSet(none_core_set);
                 } else {
                     CoreCoord none_start_core;
-                    CoreCoord end_core = (*all_to_all_cores.ranges().rbegin()).end_;
-                    if (end_core.y == bbox.end_.y) {
+                    CoreCoord end_core = (*all_to_all_cores.ranges().rbegin()).end_coord;
+                    if (end_core.y == bbox.end_coord.y) {
                         none_start_core = {end_core.x + 1, 0};
                     } else {
                         none_start_core = {end_core.x, end_core.y + 1};

--- a/ttnn/cpp/ttnn/operations/normalization/layernorm/device/multi_core/layernorm_op_multi_core.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/layernorm/device/multi_core/layernorm_op_multi_core.cpp
@@ -496,7 +496,7 @@ operation::ProgramWithCallbacks layernorm_multi_core_sharded(
     bool mcast_1d = M == block_h;
     bool row_wise = shard_spec.orientation == ShardOrientation::ROW_MAJOR;
     auto bbox = shard_spec.grid.bounding_box();
-    CoreCoord grid_size = {bbox.end.x + 1, bbox.end.y+1};
+    CoreCoord grid_size = {bbox.end_.x + 1, bbox.end_.y+1};
     if (mcast_1d) {
         num_blocks = shard_spec.num_cores();
     } else if (row_wise) {
@@ -636,7 +636,7 @@ operation::ProgramWithCallbacks layernorm_multi_core_sharded(
         if (row_wise) {
             if (use_mcast) {
                 CoreCoord all_start_core;
-                CoreCoord end_core = sender_cores.end;
+                CoreCoord end_core = sender_cores.end_;
                 if (use_two_stage_reduce) {
                     if (end_core.x == all_core_grid_size.x - 1) {
                         all_start_core = {0, end_core.y + 1};
@@ -644,7 +644,7 @@ operation::ProgramWithCallbacks layernorm_multi_core_sharded(
                         all_start_core = {end_core.x + 1, end_core.y};
                     }
                 } else {
-                    if (end_core.x == bbox.end.x) {
+                    if (end_core.x == bbox.end_.x) {
                         all_start_core = {0, end_core.y + 1};
                     } else {
                         all_start_core = {end_core.x + 1, end_core.y};
@@ -654,15 +654,15 @@ operation::ProgramWithCallbacks layernorm_multi_core_sharded(
             }
             if (num_none_all_to_all_workers > 0) {
                 if (use_two_stage_reduce) {
-                    CoreCoord none_start_core = {all_core_grid_size.x, sender_cores.end.y};
+                    CoreCoord none_start_core = {all_core_grid_size.x, sender_cores.end_.y};
                     CoreCoord none_end_core = {num_cores_x - 1, num_cores_y - 1};
                     CoreRange none_core_range = CoreRange(none_start_core, none_end_core);
                     std::set<CoreRange> none_core_set; none_core_set.insert(none_core_range);
                     not_all_to_all_workers = CoreRangeSet(none_core_set);
                 } else {
                     CoreCoord none_start_core;
-                    CoreCoord end_core = (*all_to_all_cores.ranges().rbegin()).end;
-                    if (end_core.x == bbox.end.x) {
+                    CoreCoord end_core = (*all_to_all_cores.ranges().rbegin()).end_;
+                    if (end_core.x == bbox.end_.x) {
                         none_start_core = {0, end_core.y + 1};
                     } else {
                         none_start_core = {end_core.x + 1, end_core.y};
@@ -673,7 +673,7 @@ operation::ProgramWithCallbacks layernorm_multi_core_sharded(
         } else {
             if (use_mcast) {
                 CoreCoord all_start_core;
-                CoreCoord end_core = sender_cores.end;
+                CoreCoord end_core = sender_cores.end_;
                 if (use_two_stage_reduce) {
                     if (end_core.y == all_core_grid_size.y - 1) {
                         all_start_core = {end_core.x + 1, 0};
@@ -681,7 +681,7 @@ operation::ProgramWithCallbacks layernorm_multi_core_sharded(
                         all_start_core = {end_core.x, end_core.y + 1};
                     }
                 } else {
-                    if (end_core.y == bbox.end.y) {
+                    if (end_core.y == bbox.end_.y) {
                         all_start_core = {end_core.x + 1, 0};
                     } else {
                         all_start_core = {end_core.x, end_core.y + 1};
@@ -691,15 +691,15 @@ operation::ProgramWithCallbacks layernorm_multi_core_sharded(
             }
             if (num_none_all_to_all_workers > 0) {
                 if (use_two_stage_reduce) {
-                    CoreCoord none_start_core = {sender_cores.end.x, all_core_grid_size.y};
+                    CoreCoord none_start_core = {sender_cores.end_.x, all_core_grid_size.y};
                     CoreCoord none_end_core = {num_cores_x - 1, num_cores_y - 1};
                     CoreRange none_core_range = CoreRange(none_start_core, none_end_core);
                     std::set<CoreRange> none_core_set; none_core_set.insert(none_core_range);
                     not_all_to_all_workers = CoreRangeSet(none_core_set);
                 } else {
                     CoreCoord none_start_core;
-                    CoreCoord end_core = (*all_to_all_cores.ranges().rbegin()).end;
-                    if (end_core.y == bbox.end.y) {
+                    CoreCoord end_core = (*all_to_all_cores.ranges().rbegin()).end_;
+                    if (end_core.y == bbox.end_.y) {
                         none_start_core = {end_core.x + 1, 0};
                     } else {
                         none_start_core = {end_core.x, end_core.y + 1};

--- a/ttnn/cpp/ttnn/operations/upsample/device/upsample_op_multi_core.cpp
+++ b/ttnn/cpp/ttnn/operations/upsample/device/upsample_op_multi_core.cpp
@@ -55,8 +55,8 @@ operation::ProgramWithCallbacks upsample_multi_core(const Tensor &input, Tensor&
     if (input.memory_config().memory_layout == TensorMemoryLayout::HEIGHT_SHARDED) {
         TT_FATAL(in_nsticks_per_core % in_w == 0, "Restriction: Input sticks per core {} should be divisible by input width {}. TODO to remove this restriction", in_nsticks_per_core, in_w);
     } else if (input.memory_config().memory_layout == TensorMemoryLayout::BLOCK_SHARDED) {
-        ncores_x = all_cores.ranges().begin()->end.x + 1;
-        ncores_nhw = all_cores.ranges().begin()->end.y + 1;
+        ncores_x = all_cores.ranges().begin()->end_.x + 1;
+        ncores_nhw = all_cores.ranges().begin()->end_.y + 1;
         input_stick_nbytes = input_stick_nbytes / ncores_x;
         output_stick_nbytes = output_stick_nbytes / ncores_x;
     } else {

--- a/ttnn/cpp/ttnn/operations/upsample/device/upsample_op_multi_core.cpp
+++ b/ttnn/cpp/ttnn/operations/upsample/device/upsample_op_multi_core.cpp
@@ -55,8 +55,8 @@ operation::ProgramWithCallbacks upsample_multi_core(const Tensor &input, Tensor&
     if (input.memory_config().memory_layout == TensorMemoryLayout::HEIGHT_SHARDED) {
         TT_FATAL(in_nsticks_per_core % in_w == 0, "Restriction: Input sticks per core {} should be divisible by input width {}. TODO to remove this restriction", in_nsticks_per_core, in_w);
     } else if (input.memory_config().memory_layout == TensorMemoryLayout::BLOCK_SHARDED) {
-        ncores_x = all_cores.ranges().begin()->end_.x + 1;
-        ncores_nhw = all_cores.ranges().begin()->end_.y + 1;
+        ncores_x = all_cores.ranges().begin()->end_coord.x + 1;
+        ncores_nhw = all_cores.ranges().begin()->end_coord.y + 1;
         input_stick_nbytes = input_stick_nbytes / ncores_x;
         output_stick_nbytes = output_stick_nbytes / ncores_x;
     } else {

--- a/ttnn/cpp/ttnn/operations/upsample/upsample_op.cpp
+++ b/ttnn/cpp/ttnn/operations/upsample/upsample_op.cpp
@@ -69,8 +69,8 @@ std::vector<Tensor> UpSample::create_output_tensors(const std::vector<Tensor> &i
                 auto shard_grid = input_shard_spec.grid.ranges();
                 TT_FATAL(shard_grid.size() == 1, "Block sharded input should have only one CoreRange");
                 auto core_range = *shard_grid.begin();
-                uint32_t ncores_w = core_range.end_.x + 1;
-                uint32_t ncores_h = core_range.end_.y + 1;
+                uint32_t ncores_w = core_range.end_coord.x + 1;
+                uint32_t ncores_h = core_range.end_coord.y + 1;
                 // array<uint32_t, 2> output_shard_shape = {output_shape[0] * output_shape[1] * output_shape[2] / ncores_h, output_shape[-1] / ncores_w};
                 // auto output_shard_spec = input_shard_spec;
                 // output_shard_spec.shape = output_shard_shape;

--- a/ttnn/cpp/ttnn/operations/upsample/upsample_op.cpp
+++ b/ttnn/cpp/ttnn/operations/upsample/upsample_op.cpp
@@ -69,8 +69,8 @@ std::vector<Tensor> UpSample::create_output_tensors(const std::vector<Tensor> &i
                 auto shard_grid = input_shard_spec.grid.ranges();
                 TT_FATAL(shard_grid.size() == 1, "Block sharded input should have only one CoreRange");
                 auto core_range = *shard_grid.begin();
-                uint32_t ncores_w = core_range.end.x + 1;
-                uint32_t ncores_h = core_range.end.y + 1;
+                uint32_t ncores_w = core_range.end_.x + 1;
+                uint32_t ncores_h = core_range.end_.y + 1;
                 // array<uint32_t, 2> output_shard_shape = {output_shape[0] * output_shape[1] * output_shape[2] / ncores_h, output_shape[-1] / ncores_w};
                 // auto output_shard_spec = input_shard_spec;
                 // output_shard_spec.shape = output_shard_shape;


### PR DESCRIPTION
### Ticket
[Link to Github Issue](https://github.com/tenstorrent/tt-metal/issues/10211)

### Problem description
Iterating over the cores in a core range sometimes iterates over cores outside the boundaries of the core range. This commit fixes that by only iterating over the cores within the boundaries of the given core range.

### What's changed
Inside the `CoreRange` class, a nested class called `CoreIterator` is responsible for handling the iteration over cores in a core range. The iterator lazily generates the successive core to be traversed after the current core. `CoresInCoreRangeGenerator` is no longer used anywhere and so it has been removed. In order to be able to use `CoreIterator`, the `CoreRange` class has two new methods - `begin()` and `end()` - which are used when the iterator is called. Since `end` was already being used as a member variable, I renamed it to `end_`. I also renamed `start` to `start_` to be consistent. Most of the files that have been modified are because of these member variable names being changed.

### Checklist
- [x] Post commit CI passes
- [ ] Model regression CI testing passes (if applicable)
- [x] New/Existing tests provide coverage for changes
