### PR TITLE
#10231: Clean up t3k runs-on tags to minimum

### DIFF
--- a/.github/workflows/t3000-demo-tests.yaml
+++ b/.github/workflows/t3000-demo-tests.yaml
@@ -30,7 +30,7 @@ jobs:
       LOGURU_LEVEL: INFO
       LD_LIBRARY_PATH: ${{ github.workspace }}/build/lib
     environment: dev
-    runs-on: [arch-wormhole_b0, "config-t3000", "in-service", "runner-test", "bare-metal", "pipeline-perf"]
+    runs-on: [arch-wormhole_b0, "config-t3000", "in-service", "pipeline-perf"]
     steps:
       - uses: tenstorrent-metal/metal-workflows/.github/actions/checkout-with-submodule-lfs@v2.0.0
       - name: Enable performance mode

--- a/.github/workflows/t3000-frequent-tests.yaml
+++ b/.github/workflows/t3000-frequent-tests.yaml
@@ -18,15 +18,15 @@ jobs:
       matrix:
         test-group: [
           { name: "t3k tteager tests", arch: wormhole_b0, cmd: run_t3000_tteager_tests, timeout: 60, 
-          runs-on: [arch-wormhole_b0, "config-t3000", "in-service", "runner-test", "bare-metal", "pipeline-functional"], owner_id: ULMEPM2MA}, #Sean Nijjar
+          runs-on: ["config-t3000", "in-service", "pipeline-functional"], owner_id: ULMEPM2MA}, #Sean Nijjar
           { name: "t3k trace stress tests", arch: wormhole_b0, cmd: run_t3000_trace_stress_tests, timeout: 120, 
-          runs-on: [arch-wormhole_b0, "config-t3000", "in-service", "runner-test", "bare-metal", "pipeline-functional", "t3k"], owner_id: U03NG0A5ND7}, #Aditya Saigal
+          runs-on: ["config-t3000", "in-service", "pipeline-functional"], owner_id: U03NG0A5ND7}, #Aditya Saigal
           { name: "t3k falcon40b tests", arch: wormhole_b0, cmd: run_t3000_falcon40b_tests, timeout: 120, 
-          runs-on: [arch-wormhole_b0, "config-t3000", "in-service", "runner-test", "bare-metal", "pipeline-functional"], owner_id: U04S2UV6L8N}, #Sofija Jovic 
+          runs-on: ["config-t3000", "in-service", "pipeline-functional"], owner_id: U04S2UV6L8N}, #Sofija Jovic 
           { name: "t3k llama2_70b tests", arch: wormhole_b0, cmd: run_t3000_llama2_70b_tests, timeout: 60, 
-          runs-on: [arch-wormhole_b0, "config-t3000", "in-service", "runner-test", "bare-metal", "pipeline-functional"], owner_id: U03FJB5TM5Y}, #Colman Glagovich
+          runs-on: ["config-t3000", "in-service", "pipeline-functional"], owner_id: U03FJB5TM5Y}, #Colman Glagovich
           { name: "t3k mixtral tests", arch: wormhole_b0, cmd: run_t3000_mixtral_tests, timeout: 60, 
-          runs-on: [arch-wormhole_b0, "config-t3000", "in-service", "runner-test", "bare-metal", "pipeline-functional"], owner_id: U03PUAKE719}, #Miguel Tairum Cruz
+          runs-on: ["config-t3000", "in-service", "pipeline-functional"], owner_id: U03PUAKE719}, #Miguel Tairum Cruz
         ]
     name: ${{ matrix.test-group.name }}
     env:

--- a/.github/workflows/t3000-model-perf-tests.yaml
+++ b/.github/workflows/t3000-model-perf-tests.yaml
@@ -18,13 +18,13 @@ jobs:
       matrix:
         test-group: [
           { name: "t3k LLM falcon7b model perf tests", model: "falcob7b", model-type: "LLM", arch: wormhole_b0, cmd: run_t3000_falcon7b_tests, timeout: 75, 
-            runs-on: ["arch-wormhole_b0", "config-t3000", "in-service", "runner-test", "bare-metal", "pipeline-perf", "runs-llm-falcon"], owner_id: U053W15B6JF}, # Djordje Ivanovic
+            runs-on: ["arch-wormhole_b0", "config-t3000", "in-service", "pipeline-perf"], owner_id: U053W15B6JF}, # Djordje Ivanovic
           { name: "t3k LLM mixtral model perf tests", model: "mixtral", model-type: "LLM", arch: wormhole_b0, cmd: run_t3000_mixtral_tests, timeout: 75, 
-            runs-on: ["arch-wormhole_b0", "config-t3000", "in-service", "runner-test", "bare-metal", "pipeline-perf"  ], owner_id: U03PUAKE719}, # Miguel Tairum
+            runs-on: ["arch-wormhole_b0", "config-t3000", "in-service", "pipeline-perf"], owner_id: U03PUAKE719}, # Miguel Tairum
           { name: "t3k LLM llama2 model perf tests", model: "llama2", model-type: "LLM", arch: wormhole_b0, cmd: run_t3000_llama2_70b_tests, timeout: 75, 
-            runs-on: ["arch-wormhole_b0", "config-t3000", "in-service", "runner-test", "bare-metal", "pipeline-perf"], owner_id: U03FJB5TM5Y}, #Colman Glagovich
+            runs-on: ["arch-wormhole_b0", "config-t3000", "in-service", "pipeline-perf"], owner_id: U03FJB5TM5Y}, #Colman Glagovich
           { name: "t3k LLM falcon40b model perf tests", model: "falcon40b", model-type: "LLM", arch: wormhole_b0, cmd: run_t3000_falcon40b_tests, timeout: 75, 
-            runs-on: ["arch-wormhole_b0", "config-t3000", "in-service", "runner-test", "bare-metal", "pipeline-perf", "runs-llm-falcon"], owner_id: U04JRL8DZHQ}, #Pavle Popovic
+            runs-on: ["arch-wormhole_b0", "config-t3000", "in-service", "pipeline-perf"], owner_id: U04JRL8DZHQ}, #Pavle Popovic
           #{ name: "t3k CNN model perf tests ", model-type: "CNN", arch: wormhole_b0, cmd: run_t3000_cnn_tests, timeout: 120, owner_id: }, #No tests are being run?
         ]
     name: ${{ matrix.test-group.name }}

--- a/.github/workflows/t3000-profiler-tests.yaml
+++ b/.github/workflows/t3000-profiler-tests.yaml
@@ -22,7 +22,7 @@ jobs:
           {
             name: "T3000 profiler tests",
             arch: wormhole_b0,
-            runs-on: [arch-wormhole_b0, "config-t3000", "in-service", "runner-test", "bare-metal", "pipeline-perf"],
+            runs-on: [arch-wormhole_b0, "config-t3000", "in-service", "pipeline-perf"],
             cmd: './tests/scripts/run_profiler_regressions.sh'
           },
         ]

--- a/.github/workflows/t3000-unit-tests.yaml
+++ b/.github/workflows/t3000-unit-tests.yaml
@@ -30,7 +30,7 @@ jobs:
       LOGURU_LEVEL: INFO
       LD_LIBRARY_PATH: ${{ github.workspace }}/build/lib
     environment: dev
-    runs-on: [arch-wormhole_b0, "config-t3000", "in-service", "runner-test", "bare-metal", "pipeline-functional"]
+    runs-on: ["config-t3000", "in-service", "pipeline-functional"]
     steps:
       - uses: tenstorrent-metal/metal-workflows/.github/actions/checkout-with-submodule-lfs@v2.0.0
       - name: Set up dynamic env vars for build


### PR DESCRIPTION
### Ticket
[Link to Github Issue](https://github.com/tenstorrent/tt-metal/issues/10231)

### Problem description
Functionally t3k workflows only require the following tags:
which machine configuration to run on (config-t3000)
which pipeline to run (pipeline-function or pipeline-perf)
active machine in ci (in-service)

Other runner-labels are descriptive in nature and should be kept at a minimum

### What's changed
Reduced t3k runner labels to only functional ones.
removed cosmetic labels

Future Work:
Rename t3k runner into different naming scheme. ie (tt-metal-ci-bm-t3k-{HOSTNAME})
Remove actual labels from t3k runners when this PR is merged

### Checklist
- [ ] Post commit CI passes
- [ ] Model regression CI testing passes (if applicable)
- [ ] New/Existing tests provide coverage for changes

Proof that CI workflows still are able to call on CI runners
t3k unit: https://github.com/tenstorrent/tt-metal/actions/runs/9913648077
t3k model: https://github.com/tenstorrent/tt-metal/actions/runs/9915049991
t3k profiler: https://github.com/tenstorrent/tt-metal/actions/runs/9913646134
t3k demo: https://github.com/tenstorrent/tt-metal/actions/runs/9913645005
t3k freq: https://github.com/tenstorrent/tt-metal/actions/runs/9913641720