### PR TITLE
#9491: Add structure for ternary ops in ttnn

### DIFF
--- a/tests/ttnn/unit_tests/operations/test_ternary_composite.py
+++ b/tests/ttnn/unit_tests/operations/test_ternary_composite.py
@@ -1,0 +1,50 @@
+# SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
+
+# SPDX-License-Identifier: Apache-2.0
+
+import torch
+import pytest
+import ttnn
+from tests.ttnn.unit_tests.operations.backward.utility_funcs import data_gen_with_range, compare_pcc
+
+
+@pytest.mark.parametrize(
+    "input_shapes",
+    (
+        (torch.Size([1, 1, 32, 32])),
+        (torch.Size([1, 1, 320, 384])),
+        (torch.Size([1, 3, 320, 384])),
+    ),
+)
+@pytest.mark.parametrize("value", [1.0, 5.0, 10.0])
+def test_ternary_addcmul_ttnn(input_shapes, value, device):
+    in_data1, input_tensor1 = data_gen_with_range(input_shapes, -100, 100, device)
+    in_data2, input_tensor2 = data_gen_with_range(input_shapes, -100, 100, device)
+    in_data3, input_tensor3 = data_gen_with_range(input_shapes, -100, 100, device)
+
+    output_tensor = ttnn.addcmul(input_tensor1, input_tensor2, input_tensor3, value)
+    golden_tensor = torch.addcmul(in_data1, in_data2, in_data3, value=value)
+
+    comp_pass = compare_pcc([output_tensor], [golden_tensor])
+    assert comp_pass
+
+
+@pytest.mark.parametrize(
+    "input_shapes",
+    (
+        (torch.Size([1, 1, 32, 32])),
+        (torch.Size([1, 1, 320, 384])),
+        (torch.Size([1, 3, 320, 384])),
+    ),
+)
+@pytest.mark.parametrize("value", [1.0, 5.0, 10.0])
+def test_ternary_addcdiv_ttnn(input_shapes, value, device):
+    in_data1, input_tensor1 = data_gen_with_range(input_shapes, -100, 100, device)
+    in_data2, input_tensor2 = data_gen_with_range(input_shapes, -100, 100, device)
+    in_data3, input_tensor3 = data_gen_with_range(input_shapes, -100, 100, device)
+
+    output_tensor = ttnn.addcdiv(input_tensor1, input_tensor2, input_tensor3, value)
+    golden_tensor = torch.addcdiv(in_data1, in_data2, in_data3, value=value)
+
+    comp_pass = compare_pcc([output_tensor], [golden_tensor])
+    assert comp_pass

--- a/ttnn/cpp/ttnn/operations/eltwise/ternary/device/ternary_composite_op.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/ternary/device/ternary_composite_op.cpp
@@ -1,0 +1,62 @@
+// SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+
+#include "third_party/magic_enum/magic_enum.hpp"
+#include "tt_eager/tt_numpy/functions.hpp"
+#include "ttnn/cpp/ttnn/operations/eltwise/unary/unary.hpp"
+#include "ttnn/cpp/ttnn/operations/eltwise/binary/binary.hpp"
+#include "tt_eager/tt_dnn/op_library/composite/composite_ops.hpp"
+#include "ternary_composite_op.hpp"
+#include "tt_eager/tt_dnn/op_library/run_operation.hpp"
+#include "ttnn/cpp/ttnn/types.hpp"
+#include "tt_metal/common/bfloat16.hpp"
+
+namespace ttnn::operations::ternary{
+
+// addcmul(input,tensor1,tensor2,value)=input+value×tensor1×tensor2
+Tensor _addcmul(
+    const Tensor& input_a,
+    const Tensor& input_b,
+    const Tensor& input_c,
+    float value,
+    const MemoryConfig& output_mem_config) {
+    Tensor t_value =
+        ttnn::operations::creation::create_scalar(value, input_a.get_dtype(), Layout::TILE, input_a.device());
+    Tensor t_mul = ttnn::multiply(input_b, input_c, std::nullopt, output_mem_config);
+    Tensor t_factor = ttnn::multiply(t_mul, t_value, std::nullopt, output_mem_config);
+    t_mul.deallocate();
+    t_value.deallocate();
+    Tensor result = ttnn::add(input_a, t_factor, std::nullopt, output_mem_config);
+    return result;
+}
+
+// addcdiv(input,tensor1,tensor2,value)=input+value×tensor1/tensor2
+Tensor _addcdiv(
+    const Tensor& input_a,
+    const Tensor& input_b,
+    const Tensor& input_c,
+    float value,
+    const MemoryConfig& output_mem_config) {
+    Tensor t_value =
+        ttnn::operations::creation::create_scalar(value, input_a.get_dtype(), Layout::TILE, input_a.device());
+    Tensor t_div = ttnn::multiply(input_b, ttnn::reciprocal(input_c, output_mem_config), std::nullopt, output_mem_config);
+    Tensor t_factor = ttnn::multiply(t_div, t_value, std::nullopt, output_mem_config);
+    t_div.deallocate();
+    t_value.deallocate();
+    Tensor result = ttnn::add(input_a, t_factor, std::nullopt, output_mem_config);
+    Tensor t_inf = full_like(input_a, std::numeric_limits<float>::infinity());
+    Tensor t_nan = full_like(input_a, std::nanf(""));
+    return where(
+        ttnn::eqz(input_c, output_mem_config),
+        (value == 0) ? t_nan
+                     : where(
+                           ttnn::eqz(input_b, output_mem_config),
+                           t_nan,
+                           ttnn::multiply(t_inf, ttnn::sign(input_b, output_mem_config), std::nullopt, output_mem_config)),
+        result,
+        output_mem_config);
+}
+
+} // namespace ttnn::operations::binary

--- a/ttnn/cpp/ttnn/operations/eltwise/ternary/device/ternary_composite_op.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/ternary/device/ternary_composite_op.hpp
@@ -1,0 +1,46 @@
+// SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+#pragma once
+#include <functional>
+#include <optional>
+#include "tensor/tensor.hpp"
+#include "third_party/magic_enum/magic_enum.hpp"
+
+namespace ttnn::operations::ternary{
+
+enum class TernaryCompositeOpType {
+    ADDCMUL,
+    ADDCDIV,
+
+};
+
+Tensor _addcmul(const Tensor&, const Tensor&, const Tensor&, float, const std::optional<MemoryConfig>&);
+Tensor _addcdiv(const Tensor&, const Tensor&, const Tensor&, float, const std::optional<MemoryConfig>&);
+
+
+template <TernaryCompositeOpType OpType>
+struct OpHandler_Float;
+
+
+template <>
+struct OpHandler_Float<TernaryCompositeOpType::ADDCMUL> {
+    static Tensor handle(const Tensor& t1, const Tensor& t2, const Tensor& t3, float value, const std::optional<MemoryConfig>& mem_cfg) {
+        return _addcmul(t1, t2, t3, alpha, mem_cfg);
+    }
+};
+
+template <>
+struct OpHandler_Float<TernaryCompositeOpType::ADDCDIV> {
+    static Tensor handle(const Tensor& t1, const Tensor& t2, const Tensor& t3, float value, const std::optional<MemoryConfig>& mem_cfg) {
+        return _addcdiv(t1, t2, t3, alpha, mem_cfg);
+    }
+};
+
+template <TernaryCompositeOpType OpType>
+auto get_function_type0() {
+    return &OpHandler_Float<OpType>::handle;
+}
+
+
+}

--- a/ttnn/cpp/ttnn/operations/eltwise/ternary/ternary_composite.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/ternary/ternary_composite.hpp
@@ -1,0 +1,40 @@
+// SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include "ttnn/decorators.hpp"
+#include "ttnn/operations/core.hpp"
+#include "ttnn/cpp/ttnn/operations/eltwise/ternary/device/ternary_composite_op.hpp"
+
+namespace ttnn {
+
+namespace operations {
+
+namespace ternary {
+
+template <TernaryCompositeOpType ternary_comp_op_type>
+struct ExecuteTernaryCompositeOps
+{
+    static Tensor execute_on_worker_thread(
+        const Tensor& input_tensor_a,
+        const Tensor& input_tensor_b,
+        const Tensor& input_tensor_c,
+        float value,
+        const std::optional<MemoryConfig>& memory_config = std::nullopt)
+        {
+            auto op_type = get_function_type0<ternary_comp_op_type>();
+            return op_type(input_tensor_a, input_tensor_b, input_tensor_c, value, memory_config);
+        }
+};
+
+}  // namespace ternary
+}  // namespace operations
+
+// newly imported
+constexpr auto addcmul = ttnn::register_operation<operations::ternary::ExecuteTernaryCompositeOps<operations::ternary::TernaryCompositeOpType::ADDCMUL>>("ttnn::addcmul");
+constexpr auto addcdiv = ttnn::register_operation<operations::ternary::ExecuteTernaryCompositeOps<operations::ternary::TernaryCompositeOpType::ADDCDIV>>("ttnn::addcdiv");
+
+
+}  // namespace ttnn

--- a/ttnn/cpp/ttnn/operations/eltwise/ternary/ternary_pybind.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/ternary/ternary_pybind.hpp
@@ -1,0 +1,87 @@
+// SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <pybind11/pybind11.h>
+#include <pybind11/stl.h>
+
+#include "ttnn/cpp/pybind11/decorators.hpp"
+#include "ttnn/operations/eltwise/ternary/ternary_composite.hpp"
+#include "ttnn/types.hpp"
+
+namespace py = pybind11;
+
+
+namespace ttnn {
+namespace operations {
+namespace ternary {
+
+namespace detail {
+
+template <typename ternary_operation_t>
+void bind_ternary_composite(py::module& module, const ternary_operation_t& operation, const std::string& description) {
+    auto doc = fmt::format(
+        R"doc({0}(input_tensor_a: ttnn.Tensor, input_tensor_b: ttnn.Tensor, input_tensor_c: ttnn.Tensor, *, memory_config: Optional[ttnn.MemoryConfig] = None) -> ttnn.Tensor
+
+            Args:
+                * :attr:`input_tensor_a`
+                * :attr:`input_tensor_b`
+                * :attr:`input_tensor_c` (ttnn.Tensor or Number):
+
+            Keyword Args:
+                * :attr:`memory_config` (Optional[ttnn.MemoryConfig]): Memory configuration for the operation.
+
+            Example:
+
+                >>> tensor1 = ttnn.to_device(ttnn.from_torch(torch.tensor((1, 2), dtype=torch.bfloat16)), device)
+                >>> tensor2 = ttnn.to_device(ttnn.from_torch(torch.tensor((0, 1), dtype=torch.bfloat16)), device)
+                >>> tensor3 = ttnn.to_device(ttnn.from_torch(torch.tensor((0, 1), dtype=torch.bfloat16)), device)
+                >>> output = {1}(tensor1, tensor2, tensor3)
+        )doc",
+        operation.base_name(),
+        operation.python_fully_qualified_name(),
+        description);
+
+    bind_registered_operation(
+        module,
+        operation,
+        doc,
+        ttnn::pybind_overload_t{
+            [](const ternary_operation_t& self,
+               const Tensor& input_tensor_a,
+               const Tensor& input_tensor_b,
+               const Tensor& input_tensor_c,
+               float value,
+               const std::optional<MemoryConfig>& memory_config) {
+                    return self(input_tensor_a, input_tensor_b, input_tensor_c, value, memory_config);
+                },
+            py::arg("input_tensor_a"),
+            py::arg("input_tensor_b"),
+            py::arg("input_tensor_c"),
+            py::arg("value") = 1.0f,
+            py::kw_only(),
+            py::arg("memory_config") = std::nullopt});
+}
+
+}  // namespace detail
+
+void py_module(py::module& module) {
+    // new imported
+    detail::bind_ternary_composite(
+        module,
+        ttnn::addcmul,
+        R"doc(compute Addcmul :attr:`input_tensor_a` and :attr:`input_tensor_b` and :attr:`input_tensor_c` and returns the tensor with the same layout as :attr:`input_tensor_a`
+        .. math:: \mathrm{{input\_tensor\_a}}_i || \mathrm{{input\_tensor\_b}}_i)doc");
+
+    detail::bind_ternary_composite(
+        module,
+        ttnn::addcdiv,
+        R"doc(compute Addcdiv :attr:`input_tensor_a` and :attr:`input_tensor_b` and :attr:`input_tensor_c` and returns the tensor with the same layout as :attr:`input_tensor_a`
+        .. math:: \mathrm{{input\_tensor\_a}}_i || \mathrm{{input\_tensor\_b}}_i)doc");
+}
+
+}  // namespace ternary
+}  // namespace operations
+}  // namespace ttnn


### PR DESCRIPTION
### Ticket
[Link to Github Issue](https://github.com/tenstorrent/tt-metal/issues/9491)

### Problem description
Move ternary ops to ttnn

### What's changed

- [x] Addcmul
- [x] Addcdiv
- [ ] Mac
- [ ] Where
- [ ] Lerp

### Checklist
- [ ] Post commit CI passes
- [ ] Model regression CI testing passes (if applicable)
- [ ] New/Existing tests provide coverage for changes
