### PR TITLE
#10254: Enable preserve_fp32_precision flag in moreh_sum op

### DIFF
--- a/tests/tt_eager/python_api_testing/unit_testing/misc/test_moreh_sum.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/misc/test_moreh_sum.py
@@ -285,11 +285,11 @@ def test_moreh_sum_enable_cache(input_shape, dim, device, use_program_cache):
     "input_shape",
     (
         [10, TILE_HEIGHT * 12, TILE_WIDTH * 12],
-        [10, TILE_HEIGHT * 12 - 1, TILE_WIDTH * 12 - 1],
+        [10, TILE_HEIGHT * 12 - 10, TILE_WIDTH * 12 - 10],
     ),
     ids=[
         "10, TILE_HEIGHT * 12, TILE_WIDTH * 12",
-        "10, TILE_HEIGHT * 12 - 1, TILE_WIDTH * 12 - 1",
+        "10, TILE_HEIGHT * 12 - 10, TILE_WIDTH * 12 - 10",
     ],
 )
 @pytest.mark.parametrize(
@@ -299,7 +299,7 @@ def test_moreh_sum_enable_cache(input_shape, dim, device, use_program_cache):
 )
 @pytest.mark.parametrize("compute_kernel_options", compute_kernel_options, ids=compute_kernel_ids)
 def test_moreh_sum_fp32_dest_acc(input_shape, dim, compute_kernel_options, device):
-    torch.manual_seed(2023)
+    torch.manual_seed(3072)
 
     compute_kernel_config = get_compute_kernel_options(compute_kernel_options)
 

--- a/tt_eager/tt_dnn/op_library/moreh_helper_functions.cpp
+++ b/tt_eager/tt_dnn/op_library/moreh_helper_functions.cpp
@@ -127,12 +127,13 @@ std::tuple<uint32_t, CoreRangeSet, CoreRangeSet, CoreRangeSet, uint32_t, uint32_
     std::map<std::string, std::string> defines,
     MathFidelity math_fidelity,
     bool fp32_dest_acc_en,
-    bool math_approx_mode) {
+    bool math_approx_mode,
+    bool preserve_fp32_precision) {
     std::vector<KernelHandle> compute_kernel_ids{};
     KernelHandle compute_kernel_id{};
     for (auto arg : args) {
         compute_kernel_id =
-            CreateComputeKernel(program, file_name, arg, defines, math_fidelity, fp32_dest_acc_en, math_approx_mode);
+            CreateComputeKernel(program, file_name, arg, defines, math_fidelity, fp32_dest_acc_en, math_approx_mode, preserve_fp32_precision);
         compute_kernel_ids.push_back(compute_kernel_id);
     }
     return compute_kernel_ids;
@@ -145,7 +146,8 @@ std::tuple<uint32_t, CoreRangeSet, CoreRangeSet, CoreRangeSet, uint32_t, uint32_
     std::map<std::string, std::string> defines,
     MathFidelity math_fidelity,
     bool fp32_dest_acc_en,
-    bool math_approx_mode) {
+    bool math_approx_mode,
+    bool preserve_fp32_precision) {
     KernelHandle compute_kernel_id{0};
     if (arg.num_tile_per_core_group > 0) {
         compute_kernel_id = CreateKernel(
@@ -155,6 +157,7 @@ std::tuple<uint32_t, CoreRangeSet, CoreRangeSet, CoreRangeSet, uint32_t, uint32_
             tt_metal::ComputeConfig{
                 .math_fidelity = math_fidelity,
                 .fp32_dest_acc_en = fp32_dest_acc_en,
+                .preserve_fp32_precision = preserve_fp32_precision,
                 .math_approx_mode = math_approx_mode,
                 .compile_args = arg.compile_args,
                 .defines = defines});

--- a/tt_eager/tt_dnn/op_library/moreh_helper_functions.hpp
+++ b/tt_eager/tt_dnn/op_library/moreh_helper_functions.hpp
@@ -90,7 +90,8 @@ struct ComputeKernelArg {
     std::map<std::string, std::string> defines = {},
     MathFidelity math_fidelity = MathFidelity::HiFi4,
     bool fp32_dest_acc_en = false,
-    bool math_approx_mode = false);
+    bool math_approx_mode = false,
+    bool preserve_fp32_precision = false);
 
 [[maybe_unused]] KernelHandle CreateComputeKernel(
     Program &program,
@@ -99,7 +100,8 @@ struct ComputeKernelArg {
     std::map<std::string, std::string> defines = {},
     MathFidelity math_fidelity = MathFidelity::HiFi4,
     bool fp32_dest_acc_en = false,
-    bool math_approx_mode = false);
+    bool math_approx_mode = false,
+    bool preserve_fp32_precision = false);
 
 struct CircularBufferArg {
     uint32_t buffer_index;

--- a/tt_eager/tt_dnn/op_library/moreh_sum/moreh_sum_h_impl/moreh_sum_h_impl.cpp
+++ b/tt_eager/tt_dnn/op_library/moreh_sum/moreh_sum_h_impl/moreh_sum_h_impl.cpp
@@ -54,6 +54,7 @@ operation::ProgramWithCallbacks moreh_sum_h_impl(const Tensor &a, const Tensor &
     tt::DataFormat mask_h_cb_data_format = tt::DataFormat::Float16_b;
     uint32_t mask_h_single_tile_size = tt_metal::detail::TileSize(mask_h_cb_data_format);
     tt::DataFormat intermed_cb_data_format = (fp32_dest_acc_en) ? tt::DataFormat::Float32: tt::DataFormat::Float16_b;
+    tt::DataFormat intermed1_cb_data_format = tt::DataFormat::Float16_b;
     uint32_t intermed_single_tile_size= tt_metal::detail::TileSize(intermed_cb_data_format);
     tt::DataFormat dst_cb_data_format = tt_metal::datatype_to_dataformat_converter(output.get_dtype());
     uint32_t dst_single_tile_size = tt_metal::detail::TileSize(dst_cb_data_format);
@@ -98,7 +99,7 @@ operation::ProgramWithCallbacks moreh_sum_h_impl(const Tensor &a, const Tensor &
     auto cb_intermed0 = tt_metal::CreateCircularBuffer(program, all_cores, cb_intermed0_config);
 
     tt_metal::CircularBufferConfig cb_intermed1_config =
-        tt_metal::CircularBufferConfig(intermed_single_tile_size, {{CB::c_intermed1, intermed_cb_data_format}})
+        tt_metal::CircularBufferConfig(intermed_single_tile_size, {{CB::c_intermed1, intermed1_cb_data_format}})
             .set_page_size(CB::c_intermed1, intermed_single_tile_size);
     auto cb_intermed1 = tt_metal::CreateCircularBuffer(program, all_cores, cb_intermed1_config);
 
@@ -150,11 +151,13 @@ operation::ProgramWithCallbacks moreh_sum_h_impl(const Tensor &a, const Tensor &
         origin_H
     };
 
+    // set preserve_fp32_precision to the same value as fp32_dest_acc_en
+    bool preserve_fp32_precision = fp32_dest_acc_en;
     auto reduce_compute_kernel_group_1_id = tt_metal::CreateKernel(
         program,
         compute_kernel_name,
         core_group_1,
-        tt_metal::ComputeConfig{.math_fidelity = math_fidelity, .fp32_dest_acc_en = fp32_dest_acc_en, .math_approx_mode = math_approx_mode, .compile_args = compute_kernel_args_group_1, .defines = reduce_defines});
+        tt_metal::ComputeConfig{.math_fidelity = math_fidelity, .fp32_dest_acc_en = fp32_dest_acc_en, .preserve_fp32_precision = preserve_fp32_precision, .math_approx_mode = math_approx_mode, .compile_args = compute_kernel_args_group_1, .defines = reduce_defines});
 
     if (!core_group_2.ranges().empty()) {
         vector<uint32_t> compute_kernel_args_group_2 = {
@@ -168,7 +171,7 @@ operation::ProgramWithCallbacks moreh_sum_h_impl(const Tensor &a, const Tensor &
             program,
             compute_kernel_name,
             core_group_2,
-            tt_metal::ComputeConfig{.math_fidelity = math_fidelity, .fp32_dest_acc_en = fp32_dest_acc_en, .math_approx_mode = math_approx_mode, .compile_args = compute_kernel_args_group_2, .defines = reduce_defines});
+            tt_metal::ComputeConfig{.math_fidelity = math_fidelity, .fp32_dest_acc_en = fp32_dest_acc_en, .preserve_fp32_precision = preserve_fp32_precision, .math_approx_mode = math_approx_mode, .compile_args = compute_kernel_args_group_2, .defines = reduce_defines});
     }
 
     for (uint32_t i = 0, num_cols_read = 0; i < num_cores; i++) {

--- a/tt_eager/tt_dnn/op_library/moreh_sum/moreh_sum_nc_impl/kernels/moreh_sum_nc.cpp
+++ b/tt_eager/tt_dnn/op_library/moreh_sum/moreh_sum_nc_impl/kernels/moreh_sum_nc.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+// SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -13,50 +13,36 @@ void MAIN {
     constexpr auto cb_in0 = tt::CB::c_in0;
     constexpr auto cb_in1 = tt::CB::c_in1;
     constexpr auto cb_out0 = tt::CB::c_out0;
-    constexpr auto cb_intermed0 = tt::CB::c_intermed0;
     constexpr uint32_t onetile = 1;
     constexpr uint32_t dst0 = 0;
     constexpr uint32_t dst1 = 1;
-    constexpr uint32_t first_tile = 0;
+    constexpr uint32_t idx0 = 0;
+    constexpr bool acc_to_dest = true;
 
     binary_op_init_common(cb_in0, cb_in1, cb_out0);
     cb_wait_front(cb_in1, onetile);
 
     for (uint32_t i = 0; i < num_output_tiles; i++) {
-        bool enable_reload = false;
+        tile_regs_acquire();
+        add_tiles_init(cb_in0, cb_in1, acc_to_dest);
         for (uint32_t j = 0; j < num_input_tiles; ++j) {
-            bool last_out = (j == num_input_tiles - 1);
-            uint32_t cb_add  = (enable_reload) ? (cb_intermed0) : (cb_in1);
-
             cb_wait_front(cb_in0, onetile);
-            if (enable_reload) {
-                cb_wait_front(cb_intermed0, onetile);
-            }
-
-            tile_regs_acquire();
             #if defined FP32_DEST_ACC_EN
-                unpack_reconfig_data_format(cb_in0, cb_add);
+                unpack_reconfig_data_format(cb_in0, cb_in1);
             #endif
-            add_tiles_init(cb_in0, cb_add);
-            add_tiles(cb_in0, cb_add, first_tile, first_tile, dst0);
-            tile_regs_commit();
-
+            add_tiles(cb_in0, cb_in1, idx0, idx0, dst0);
             cb_pop_front(cb_in0, onetile);
-            if (enable_reload) {
-                cb_pop_front(cb_intermed0, onetile);
-            }
-
-            uint32_t cb_out = (last_out) ? (cb_out0) : (cb_intermed0);
-            cb_reserve_back(cb_out, onetile);
-            tile_regs_wait();
-            #if defined FP32_DEST_ACC_EN
-                pack_reconfig_data_format(cb_out);
-            #endif
-            pack_tile(dst0, cb_out);
-            tile_regs_release();
-            cb_push_back(cb_out, onetile);
-            enable_reload = true;
         }
+        tile_regs_commit();
+
+        cb_reserve_back(cb_out0, onetile);
+        tile_regs_wait();
+        #if defined FP32_DEST_ACC_EN
+            pack_reconfig_data_format(cb_out0);
+        #endif
+        pack_tile(dst0, cb_out0);
+        tile_regs_release();
+        cb_push_back(cb_out0, onetile);
     }
 }
 }  // namespace NAMESPACE

--- a/tt_eager/tt_dnn/op_library/moreh_sum/moreh_sum_nc_impl/kernels/moreh_sum_nc_gs.cpp
+++ b/tt_eager/tt_dnn/op_library/moreh_sum/moreh_sum_nc_impl/kernels/moreh_sum_nc_gs.cpp
@@ -1,0 +1,62 @@
+// SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "tt_eager/tt_dnn/kernels/compute/moreh_common.hpp"
+
+namespace NAMESPACE {
+void MAIN {
+    // compile-time args
+    constexpr uint32_t num_output_tiles = get_compile_time_arg_val(0);
+    constexpr uint32_t num_input_tiles = get_compile_time_arg_val(1);
+
+    constexpr auto cb_in0 = tt::CB::c_in0;
+    constexpr auto cb_in1 = tt::CB::c_in1;
+    constexpr auto cb_out0 = tt::CB::c_out0;
+    constexpr auto cb_intermed0 = tt::CB::c_intermed0;
+    constexpr uint32_t onetile = 1;
+    constexpr uint32_t dst0 = 0;
+    constexpr uint32_t dst1 = 1;
+    constexpr uint32_t first_tile = 0;
+
+    binary_op_init_common(cb_in0, cb_in1, cb_out0);
+    cb_wait_front(cb_in1, onetile);
+
+    for (uint32_t i = 0; i < num_output_tiles; i++) {
+        bool enable_reload = false;
+        for (uint32_t j = 0; j < num_input_tiles; ++j) {
+            bool last_out = (j == num_input_tiles - 1);
+            uint32_t cb_add  = (enable_reload) ? (cb_intermed0) : (cb_in1);
+
+            cb_wait_front(cb_in0, onetile);
+            if (enable_reload) {
+                cb_wait_front(cb_intermed0, onetile);
+            }
+
+            tile_regs_acquire();
+            #if defined FP32_DEST_ACC_EN
+                unpack_reconfig_data_format(cb_in0, cb_add);
+            #endif
+            add_tiles_init(cb_in0, cb_add);
+            add_tiles(cb_in0, cb_add, first_tile, first_tile, dst0);
+            tile_regs_commit();
+
+            cb_pop_front(cb_in0, onetile);
+            if (enable_reload) {
+                cb_pop_front(cb_intermed0, onetile);
+            }
+
+            uint32_t cb_out = (last_out) ? (cb_out0) : (cb_intermed0);
+            cb_reserve_back(cb_out, onetile);
+            tile_regs_wait();
+            #if defined FP32_DEST_ACC_EN
+                pack_reconfig_data_format(cb_out);
+            #endif
+            pack_tile(dst0, cb_out);
+            tile_regs_release();
+            cb_push_back(cb_out, onetile);
+            enable_reload = true;
+        }
+    }
+}
+}  // namespace NAMESPACE

--- a/tt_eager/tt_dnn/op_library/moreh_sum/moreh_sum_nc_impl/kernels/reader_moreh_sum_nc.cpp
+++ b/tt_eager/tt_dnn/op_library/moreh_sum/moreh_sum_nc_impl/kernels/reader_moreh_sum_nc.cpp
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "tt_eager/tt_dnn/kernels/dataflow/moreh_common.hpp"
+#include "tt_eager/tt_dnn/kernels/dataflow/generate_reduce_scaler.hpp"
 
 inline uint32_t get_read_tile_id(uint32_t output_tile_id, uint32_t reduce_tile_size, uint32_t inner_tile_size) {
     return ((output_tile_id / inner_tile_size) * reduce_tile_size) + (output_tile_id % inner_tile_size);
@@ -24,15 +25,11 @@ void kernel_main() {
 
     constexpr uint32_t onetile = 1;
     constexpr uint32_t cb_id_in0 = 0;
+
     #ifdef USE_FPU
     constexpr uint32_t cb_id_in1 = 1;
-
-    union {
-        float f;
-        uint32_t u;
-    } scaler;
-    scaler.f = 0.0f;
-    fill_cb_with_value(cb_id_in1, scaler.u);
+    constexpr uint32_t scaler = 0;
+    generate_reduce_scaler(cb_id_in1, scaler);
     #endif
 
     uint32_t l1_write_addr_in0;


### PR DESCRIPTION
### Ticket
[Link to Github Issue](https://github.com/tenstorrent/tt-metal/issues/10254)

### Problem description
To fully support FP32 destination mode in issue https://github.com/tenstorrent/tt-metal/issues/9410 , 
it is necessary to additionally set the preserve_fp32_precision flag.

### What's Changed
- Enabled `preserve_fp32_precision` flag in `moreh_sum` op.
- Refactored `moreh_sum` for batch dimension.

### Additional Context
- Also, verify how much the error is reduced when applying the above changes.
- While MAE (Mean Absolute Error) has decreased for batch-dim and h-dim in FP32 destination mode, it has increased for w-dim. This issue will be raised for further investigation.

### Checklist
[1st all post-commit tests passed](https://github.com/tenstorrent/tt-metal/actions/runs/9952612780)
[2nd all post-commit tests passed](https://github.com/tenstorrent/tt-metal/actions/runs/9972678571)
- [x] Post commit CI passes
- [x] Model regression CI testing passes (if applicable)
- [x] New/Existing tests provide coverage for changes
