### PR TITLE
OPT convs in RN50 to get better device perf

### DIFF
--- a/models/experimental/resnet/tt/ttnn_functional_resnet50_new_conv_api.py
+++ b/models/experimental/resnet/tt/ttnn_functional_resnet50_new_conv_api.py
@@ -154,7 +154,7 @@ class resnet50Bottleneck:
         height_sharding=None,
         transpose_shards=True,
         packer_l1_accum_enabled=True if is_wormhole_b0() else False,
-        enable_act_doule_buffer=False,
+        enable_act_double_buffer=False,
         enable_split_reader=False,
         enable_subblock_padding=False,
     ):
@@ -183,7 +183,7 @@ class resnet50Bottleneck:
                     reshard_if_not_optimal=reshard_if_not_optimal,
                     transpose_shards=transpose_shards,
                     packer_l1_accum_enabled=packer_l1_accum_enabled,
-                    enable_act_doule_buffer=enable_act_doule_buffer,
+                    enable_act_double_buffer=enable_act_double_buffer,
                     enable_split_reader=enable_split_reader,
                     enable_subblock_padding=enable_subblock_padding,
                 ),
@@ -208,7 +208,7 @@ class resnet50Bottleneck:
         eltwise_binary_out_in_place=True,
         transpose_shards=True,
         packer_l1_acc=True if is_wormhole_b0() else False,
-        enable_act_doule_buffer=False,
+        enable_act_double_buffer=False,
         enable_split_reader=False,
         enable_subblock_padding=False,
     ):
@@ -311,7 +311,7 @@ class resnet50Bottleneck:
                 height_sharding,
                 transpose_shards=transpose_shards,
                 packer_l1_accum_enabled=packer_l1_acc,
-                enable_act_doule_buffer=False,
+                enable_act_double_buffer=False,
                 enable_split_reader=enable_split_reader,
                 enable_subblock_padding=enable_subblock_padding,
             )
@@ -343,7 +343,7 @@ class resnet50Bottleneck:
                 reshard_if_not_optimal=reshard_if_not_optimal,
                 transpose_shards=transpose_shards,
                 packer_l1_accum_enabled=packer_l1_acc,
-                enable_act_doule_buffer=enable_act_doule_buffer,
+                enable_act_double_buffer=enable_act_double_buffer,
                 enable_split_reader=enable_split_reader,
                 enable_subblock_padding=enable_subblock_padding,
             ),
@@ -415,7 +415,7 @@ class resnet50Bottleneck:
                 height_sharding,
                 transpose_shards=transpose_shards,
                 packer_l1_accum_enabled=packer_l1_acc,
-                enable_act_doule_buffer=enable_act_doule_buffer,
+                enable_act_double_buffer=enable_act_double_buffer,
                 enable_split_reader=enable_split_reader,
                 enable_subblock_padding=enable_subblock_padding,
             )
@@ -594,7 +594,7 @@ class resnet50:
             act_block_h_override=act_block_h_override,
             transpose_shards=self.transpose_shards,
             packer_l1_accum_enabled=True if whb0_and_b16 else False,
-            enable_act_doule_buffer=True if whb0_and_b16 else False,
+            enable_act_double_buffer=True if whb0_and_b16 else False,
             enable_split_reader=True if whb0_and_b16 else False,
             enable_subblock_padding=False,
         )
@@ -744,7 +744,7 @@ class resnet50:
             reshard_if_not_optimal=reshard,
             height_sharding=height_shard,
             transpose_shards=self.transpose_shards,
-            enable_act_doule_buffer=True if whb0_and_b16 else False,
+            enable_act_double_buffer=True if whb0_and_b16 else False,
             enable_split_reader=True if whb0_and_b16 else False,
             enable_subblock_padding=True,
         )
@@ -768,7 +768,7 @@ class resnet50:
             x_width,
             conv_op_cache,
             transpose_shards=self.transpose_shards,
-            enable_act_doule_buffer=False,
+            enable_act_double_buffer=False,
             enable_split_reader=True if whb0_and_b16 else False,
             enable_subblock_padding=True,
         )
@@ -782,7 +782,7 @@ class resnet50:
             x_width,
             conv_op_cache,
             transpose_shards=self.transpose_shards,
-            enable_act_doule_buffer=False,
+            enable_act_double_buffer=False,
             enable_split_reader=True if whb0_and_b16 else False,
             enable_subblock_padding=True,
         )
@@ -812,9 +812,9 @@ class resnet50:
             reshard_if_not_optimal=reshard,
             height_sharding=height_shard,
             transpose_shards=self.transpose_shards,
-            enable_act_doule_buffer=True if whb0_and_b16 else False,
-            enable_split_reader=True if whb0_and_b16 else False,
-            enable_subblock_padding=True,
+            enable_act_double_buffer=True if whb0_and_b16 else False,
+            enable_split_reader=False,
+            enable_subblock_padding=False,
         )
 
         if is_first_run:
@@ -836,7 +836,7 @@ class resnet50:
             x_width,
             conv_op_cache,
             transpose_shards=self.transpose_shards,
-            enable_act_doule_buffer=True if whb0_and_b16 else False,
+            enable_act_double_buffer=False,
             enable_split_reader=False,
             enable_subblock_padding=False,
         )
@@ -850,7 +850,7 @@ class resnet50:
             x_width,
             conv_op_cache,
             transpose_shards=self.transpose_shards,
-            enable_act_doule_buffer=True if whb0_and_b16 else False,
+            enable_act_double_buffer=True if whb0_and_b16 else False,
             enable_split_reader=False,
             enable_subblock_padding=False,
         )
@@ -864,7 +864,7 @@ class resnet50:
             x_width,
             conv_op_cache,
             transpose_shards=self.transpose_shards,
-            enable_act_doule_buffer=True if whb0_and_b16 else False,
+            enable_act_double_buffer=True if whb0_and_b16 else False,
             enable_split_reader=False,
             enable_subblock_padding=False,
         )
@@ -890,7 +890,7 @@ class resnet50:
             reshard_if_not_optimal=reshard,
             height_sharding=height_shard,
             transpose_shards=self.transpose_shards,
-            enable_act_doule_buffer=True if whb0_and_b16 else False,
+            enable_act_double_buffer=True if whb0_and_b16 else False,
             enable_split_reader=False,
             enable_subblock_padding=False,
         )
@@ -914,7 +914,7 @@ class resnet50:
             x_width,
             conv_op_cache,
             transpose_shards=self.transpose_shards,
-            enable_act_doule_buffer=True if whb0_and_b16 else False,
+            enable_act_double_buffer=True if whb0_and_b16 else False,
             enable_split_reader=False,
             enable_subblock_padding=False,
         )
@@ -928,7 +928,7 @@ class resnet50:
             x_width,
             conv_op_cache,
             transpose_shards=self.transpose_shards,
-            enable_act_doule_buffer=True if whb0_and_b16 else False,
+            enable_act_double_buffer=True if whb0_and_b16 else False,
             enable_split_reader=False,
             enable_subblock_padding=False,
         )
@@ -942,7 +942,7 @@ class resnet50:
             x_width,
             conv_op_cache,
             transpose_shards=self.transpose_shards,
-            enable_act_doule_buffer=True if whb0_and_b16 else False,
+            enable_act_double_buffer=True if whb0_and_b16 else False,
             enable_split_reader=False,
             enable_subblock_padding=False,
         )
@@ -956,7 +956,7 @@ class resnet50:
             x_width,
             conv_op_cache,
             transpose_shards=self.transpose_shards,
-            enable_act_doule_buffer=True if whb0_and_b16 else False,
+            enable_act_double_buffer=True if whb0_and_b16 else False,
             enable_split_reader=False,
             enable_subblock_padding=False,
         )
@@ -971,7 +971,7 @@ class resnet50:
             conv_op_cache,
             eltwise_binary_out_in_place=True,
             transpose_shards=self.transpose_shards,
-            enable_act_doule_buffer=True if whb0_and_b16 else False,
+            enable_act_double_buffer=True if whb0_and_b16 else False,
             enable_split_reader=False,
             enable_subblock_padding=False,
         )
@@ -1011,7 +1011,7 @@ class resnet50:
             reshard_if_not_optimal=reshard,
             height_sharding=height_shard,
             transpose_shards=self.transpose_shards,
-            enable_act_doule_buffer=True if whb0_and_b16 else False,
+            enable_act_double_buffer=True if whb0_and_b16 else False,
             enable_split_reader=False,
             enable_subblock_padding=False,
         )
@@ -1035,7 +1035,7 @@ class resnet50:
             x_width,
             conv_op_cache,
             transpose_shards=self.transpose_shards,
-            enable_act_doule_buffer=True if whb0_and_b16 else False,
+            enable_act_double_buffer=True if whb0_and_b16 else False,
             enable_split_reader=False,
             enable_subblock_padding=False,
         )
@@ -1049,7 +1049,7 @@ class resnet50:
             x_width,
             conv_op_cache,
             transpose_shards=self.transpose_shards,
-            enable_act_doule_buffer=True if whb0_and_b16 else False,
+            enable_act_double_buffer=True if whb0_and_b16 else False,
             enable_split_reader=False,
             enable_subblock_padding=False,
         )

--- a/models/experimental/resnet/tt/ttnn_functional_resnet50_new_conv_api.py
+++ b/models/experimental/resnet/tt/ttnn_functional_resnet50_new_conv_api.py
@@ -746,7 +746,7 @@ class resnet50:
             transpose_shards=self.transpose_shards,
             enable_act_double_buffer=True if whb0_and_b16 else False,
             enable_split_reader=True if whb0_and_b16 else False,
-            enable_subblock_padding=True,
+            enable_subblock_padding=True if whb0_and_b16 else False,
         )
 
         if is_first_run:
@@ -770,7 +770,7 @@ class resnet50:
             transpose_shards=self.transpose_shards,
             enable_act_double_buffer=False,
             enable_split_reader=True if whb0_and_b16 else False,
-            enable_subblock_padding=True,
+            enable_subblock_padding=True if whb0_and_b16 else False,
         )
 
         logger.debug(f"==== Running layer 1 module 3")
@@ -784,7 +784,7 @@ class resnet50:
             transpose_shards=self.transpose_shards,
             enable_act_double_buffer=False,
             enable_split_reader=True if whb0_and_b16 else False,
-            enable_subblock_padding=True,
+            enable_subblock_padding=True if whb0_and_b16 else False,
         )
 
         if self.batch_size == 20 and is_wormhole_b0():

--- a/tests/ttnn/integration_tests/resnet/test_ttnn_functional_resnet50_new.py
+++ b/tests/ttnn/integration_tests/resnet/test_ttnn_functional_resnet50_new.py
@@ -257,16 +257,16 @@ def create_test_infra(
 @pytest.mark.parametrize(
     "batch_size, act_dtype, weight_dtype, math_fidelity",
     (
-        (
-            8,
-            ttnn.bfloat8_b,
-            ttnn.bfloat8_b,
-            ttnn.MathFidelity.LoFi,
-        ),  ## memory config issue due to l4m1 downsample reshard
-        (16, ttnn.bfloat8_b, ttnn.bfloat8_b, ttnn.MathFidelity.HiFi2),
+        # (
+        #     8,
+        #     ttnn.bfloat8_b,
+        #     ttnn.bfloat8_b,
+        #     ttnn.MathFidelity.LoFi,
+        # ),  ## memory config issue due to l4m1 downsample reshard
+        # (16, ttnn.bfloat8_b, ttnn.bfloat8_b, ttnn.MathFidelity.HiFi2),
         (16, ttnn.bfloat8_b, ttnn.bfloat8_b, ttnn.MathFidelity.LoFi),
-        (20, ttnn.bfloat8_b, ttnn.bfloat8_b, ttnn.MathFidelity.HiFi2),
-        (20, ttnn.bfloat8_b, ttnn.bfloat8_b, ttnn.MathFidelity.LoFi),
+        # (20, ttnn.bfloat8_b, ttnn.bfloat8_b, ttnn.MathFidelity.HiFi2),
+        # (20, ttnn.bfloat8_b, ttnn.bfloat8_b, ttnn.MathFidelity.LoFi),
     ),
 )
 @pytest.mark.parametrize(

--- a/tests/ttnn/integration_tests/resnet/test_ttnn_functional_resnet50_new.py
+++ b/tests/ttnn/integration_tests/resnet/test_ttnn_functional_resnet50_new.py
@@ -257,16 +257,16 @@ def create_test_infra(
 @pytest.mark.parametrize(
     "batch_size, act_dtype, weight_dtype, math_fidelity",
     (
-        # (
-        #     8,
-        #     ttnn.bfloat8_b,
-        #     ttnn.bfloat8_b,
-        #     ttnn.MathFidelity.LoFi,
-        # ),  ## memory config issue due to l4m1 downsample reshard
-        # (16, ttnn.bfloat8_b, ttnn.bfloat8_b, ttnn.MathFidelity.HiFi2),
+        (
+            8,
+            ttnn.bfloat8_b,
+            ttnn.bfloat8_b,
+            ttnn.MathFidelity.LoFi,
+        ),  ## memory config issue due to l4m1 downsample reshard
+        (16, ttnn.bfloat8_b, ttnn.bfloat8_b, ttnn.MathFidelity.HiFi2),
         (16, ttnn.bfloat8_b, ttnn.bfloat8_b, ttnn.MathFidelity.LoFi),
-        # (20, ttnn.bfloat8_b, ttnn.bfloat8_b, ttnn.MathFidelity.HiFi2),
-        # (20, ttnn.bfloat8_b, ttnn.bfloat8_b, ttnn.MathFidelity.LoFi),
+        (20, ttnn.bfloat8_b, ttnn.bfloat8_b, ttnn.MathFidelity.HiFi2),
+        (20, ttnn.bfloat8_b, ttnn.bfloat8_b, ttnn.MathFidelity.LoFi),
     ),
 )
 @pytest.mark.parametrize(

--- a/tests/ttnn/unit_tests/operations/test_new_conv2d.py
+++ b/tests/ttnn/unit_tests/operations/test_new_conv2d.py
@@ -115,7 +115,7 @@ def run_conv(
         deallocate_activation=deallocate_activation,
         fp32_dest_acc_enabled=fp32_accum,
         packer_l1_accum_enabled=packer_l1_acc,
-        enable_act_doule_buffer=False if (batch_size == 20 and output_channels == 64) else True,
+        enable_act_double_buffer=False if (batch_size == 20 and output_channels == 64) else True,
         enable_split_reader=False,
         enable_subblock_padding=False,
     )
@@ -459,24 +459,14 @@ def test_resnet50_conv_gs(
 )
 @pytest.mark.parametrize(
     "weights_dtype",
-    # [ttnn.bfloat16, ttnn.bfloat8_b],
-    [ttnn.bfloat8_b],
+    [ttnn.bfloat16, ttnn.bfloat8_b],
 )
 @pytest.mark.parametrize(
     "activations_dtype",
-    # [ttnn.bfloat16, ttnn.bfloat8_b],
-    [ttnn.bfloat8_b],
+    [ttnn.bfloat16, ttnn.bfloat8_b],
 )
 @pytest.mark.parametrize("math_fidelity", [ttnn.MathFidelity.LoFi])
-@pytest.mark.parametrize(
-    "packer_l1_acc",
-    [
-        True,
-    ],
-    ids=[
-        "pack_l1",
-    ],
-)
+@pytest.mark.parametrize("packer_l1_acc", [True, False], ids=["pack_l1", "no_pack_l1"])
 def test_resnet50_conv_wh(
     device,
     use_program_cache,

--- a/tests/ttnn/unit_tests/operations/test_new_conv2d.py
+++ b/tests/ttnn/unit_tests/operations/test_new_conv2d.py
@@ -116,6 +116,8 @@ def run_conv(
         fp32_dest_acc_enabled=fp32_accum,
         packer_l1_accum_enabled=packer_l1_acc,
         enable_act_doule_buffer=False if (batch_size == 20 and output_channels == 64) else True,
+        enable_split_reader=False,
+        enable_subblock_padding=False,
     )
     if config_override and "act_block_h" in config_override:
         conv_config.act_block_h_override = config_override["act_block_h"]

--- a/tests/ttnn/unit_tests/operations/test_new_conv2d.py
+++ b/tests/ttnn/unit_tests/operations/test_new_conv2d.py
@@ -115,7 +115,7 @@ def run_conv(
         deallocate_activation=deallocate_activation,
         fp32_dest_acc_enabled=fp32_accum,
         packer_l1_accum_enabled=packer_l1_acc,
-        enable_act_double_buffer=False if (batch_size == 20 and output_channels == 64) else True,
+        enable_act_double_buffer=False,
         enable_split_reader=False,
         enable_subblock_padding=False,
     )

--- a/tests/ttnn/unit_tests/operations/test_new_conv2d.py
+++ b/tests/ttnn/unit_tests/operations/test_new_conv2d.py
@@ -101,15 +101,15 @@ def run_conv(
         )
 
     tt_input_tensor = ttnn.from_torch(torch_input_tensor, ttnn.bfloat16)
-    print(tt_input_tensor)
     # breakpoint()
     conv_config = ttnn.Conv2dConfig(
         dtype=activations_dtype,
         weights_dtype=weights_dtype,
         math_fidelity=math_fidelity,
         height_sharding=use_1d_systolic_array,
-        # input_channels_alignment=(16 if use_shallow_conv_variant else 32),
-        input_channels_alignment=16,
+        input_channels_alignment=(
+            16 if use_shallow_conv_variant or (input_channels == 16 and input_height == 115) else 32
+        ),
         deallocate_activation=deallocate_activation,
         fp32_dest_acc_enabled=fp32_accum,
         packer_l1_accum_enabled=packer_l1_acc,
@@ -141,8 +141,6 @@ def run_conv(
         debug=debug,
         groups=groups,
     )
-
-    print(tt_output_tensor_on_device.shape)
 
     tt_output_tensor = ttnn.from_device(tt_output_tensor_on_device)
     torch_output_tensor = ttnn.to_torch(tt_output_tensor)
@@ -410,67 +408,59 @@ def test_resnet50_conv_gs(
         # first conv post folding and input_channels padding to tile width
         # (8, 64, 16, 115, 115, 4, 4, 1, 1, 0, 0, True, None), HANGS!!
         (16, 64, 16, 115, 115, 4, 4, 1, 1, 0, 0, True, {"act_block_h": 256}),
-        # (20, 64, 16, 115, 115, 4, 4, 1, 1, 0, 0, True, {"act_block_h": 64}),
-        # # rn50 layer1
-        # (8, 64, 64, 56, 56, 3, 3, 1, 1, 1, 1, True, None),
-        # (16, 64, 64, 56, 56, 3, 3, 1, 1, 1, 1, True, None),
-        # (20, 64, 64, 56, 56, 3, 3, 1, 1, 1, 1, True, None),
-        # # rn50 layer2
-        # (8, 128, 128, 56, 56, 3, 3, 2, 2, 1, 1, True, None),
-        # (16, 128, 128, 56, 56, 3, 3, 2, 2, 1, 1, True, None),
-        # (20, 128, 128, 56, 56, 3, 3, 2, 2, 1, 1, True, {"act_block_h": 32}),
-        # (8, 128, 128, 28, 28, 3, 3, 1, 1, 1, 1, True, None),
-        # (16, 128, 128, 28, 28, 3, 3, 1, 1, 1, 1, True, None),
-        # (20, 128, 128, 28, 28, 3, 3, 1, 1, 1, 1, True, None),
-        # # rn50 layer3
-        # (8, 256, 256, 28, 28, 3, 3, 2, 2, 1, 1, False, None),
-        # (16, 256, 256, 28, 28, 3, 3, 2, 2, 1, 1, False, None),
-        # (20, 256, 256, 28, 28, 3, 3, 2, 2, 1, 1, False, None),
-        # (8, 256, 256, 14, 14, 3, 3, 1, 1, 1, 1, False, None),
-        # (16, 256, 256, 14, 14, 3, 3, 1, 1, 1, 1, False, None),
-        # (20, 256, 256, 14, 14, 3, 3, 1, 1, 1, 1, False, None),
-        # # rn50 layer4
-        # (8, 512, 512, 14, 14, 3, 3, 2, 2, 1, 1, False, None),
-        # (16, 512, 512, 14, 14, 3, 3, 2, 2, 1, 1, False, None),
-        # (20, 512, 512, 14, 14, 3, 3, 2, 2, 1, 1, False, None),
-        # (8, 512, 512, 7, 7, 3, 3, 1, 1, 1, 1, False, None),
-        # (16, 512, 512, 7, 7, 3, 3, 1, 1, 1, 1, False, None),
-        # (20, 512, 512, 7, 7, 3, 3, 1, 1, 1, 1, False, None),
-        # ## small test
-        # (1, 64, 64, 8, 8, 3, 3, 1, 1, 1, 1, False, {"num_cores_nhw": 2, "grid_size": (2, 2)}),
-        # (1, 64, 64, 16, 16, 3, 3, 1, 1, 1, 1, False, {"num_cores_nhw": 4, "grid_size": (2, 4)}),
-        # # (1, 160, 160, 7, 7, 3, 3, 1, 1, 1, 1, False, None), sliding_window_op_infra/sliding_window.cpp:341: indices_length_last_core <= indices_length_per_core
-        # (8, 256, 256, 7, 7, 3, 3, 1, 1, 1, 1, False, None),
-        # # r50 1x1s2 shapes
-        # # Fails with packer_l1_acc = True (20, 256, 64, 56, 56, 1, 1, 2, 2, 0, 0, False, None),  # r50 first bottleneck downsample shape
-        # (20, 256, 64, 56, 56, 1, 1, 2, 2, 0, 0, True, None),  # r50 first bottleneck downsample shape
-        # # Fails with packer_l1_acc = True (20, 512, 256, 56, 56, 1, 1, 2, 2, 0, 0, False, None),  # r50 second bottleneck downsample shape
-        # # (20, 512, 256, 56, 56, 1, 1, 2, 2, 0, 0, True, None), - doesnt fit
-        # (20, 1024, 512, 28, 28, 1, 1, 2, 2, 0, 0, False, None),  # r50 third bottleneck downsample shape
-        # # (20, 1024, 512, 28, 28, 1, 1, 2, 2, 0, 0, True, None), - doesnt fit
-        # (20, 2048, 1024, 14, 14, 1, 1, 2, 2, 0, 0, False, None),  # r50 fourth bottleneck downsample shape
-        # # (20, 2048, 1024, 14, 14, 1, 1, 2, 2, 0, 0, True, None), - doesnt fit
-        # # (20, 128, 256, 56, 56, 1, 1, 2, 2, 0, 0, True, None),  ## L2M1 DS: doesn't fit
+        # (20, 64, 16, 115, 115, 4, 4, 1, 1, 0, 0, True, {"act_block_h": 32}),  Out of Memory!!
+        # rn50 layer1
+        (8, 64, 64, 56, 56, 3, 3, 1, 1, 1, 1, True, None),
+        (16, 64, 64, 56, 56, 3, 3, 1, 1, 1, 1, True, None),
+        (20, 64, 64, 56, 56, 3, 3, 1, 1, 1, 1, True, None),
+        # rn50 layer2
+        (8, 128, 128, 56, 56, 3, 3, 2, 2, 1, 1, True, None),
+        (16, 128, 128, 56, 56, 3, 3, 2, 2, 1, 1, True, None),
+        (20, 128, 128, 56, 56, 3, 3, 2, 2, 1, 1, True, {"act_block_h": 32}),
+        (8, 128, 128, 28, 28, 3, 3, 1, 1, 1, 1, True, None),
+        (16, 128, 128, 28, 28, 3, 3, 1, 1, 1, 1, True, None),
+        (20, 128, 128, 28, 28, 3, 3, 1, 1, 1, 1, True, None),
+        # rn50 layer3
+        (8, 256, 256, 28, 28, 3, 3, 2, 2, 1, 1, False, None),
+        (16, 256, 256, 28, 28, 3, 3, 2, 2, 1, 1, False, None),
+        (20, 256, 256, 28, 28, 3, 3, 2, 2, 1, 1, False, None),
+        (8, 256, 256, 14, 14, 3, 3, 1, 1, 1, 1, False, None),
+        (16, 256, 256, 14, 14, 3, 3, 1, 1, 1, 1, False, None),
+        (20, 256, 256, 14, 14, 3, 3, 1, 1, 1, 1, False, None),
+        # rn50 layer4
+        (8, 512, 512, 14, 14, 3, 3, 2, 2, 1, 1, False, None),
+        (16, 512, 512, 14, 14, 3, 3, 2, 2, 1, 1, False, None),
+        (20, 512, 512, 14, 14, 3, 3, 2, 2, 1, 1, False, None),
+        (8, 512, 512, 7, 7, 3, 3, 1, 1, 1, 1, False, None),
+        (16, 512, 512, 7, 7, 3, 3, 1, 1, 1, 1, False, None),
+        (20, 512, 512, 7, 7, 3, 3, 1, 1, 1, 1, False, None),
+        ## small test
+        (1, 64, 64, 8, 8, 3, 3, 1, 1, 1, 1, False, {"num_cores_nhw": 2, "grid_size": (2, 2)}),
+        (1, 64, 64, 16, 16, 3, 3, 1, 1, 1, 1, False, {"num_cores_nhw": 4, "grid_size": (2, 4)}),
+        # (1, 160, 160, 7, 7, 3, 3, 1, 1, 1, 1, False, None), sliding_window_op_infra/sliding_window.cpp:341: indices_length_last_core <= indices_length_per_core
+        (8, 256, 256, 7, 7, 3, 3, 1, 1, 1, 1, False, None),
+        # r50 1x1s2 shapes
+        # Fails with packer_l1_acc = True (20, 256, 64, 56, 56, 1, 1, 2, 2, 0, 0, False, None),  # r50 first bottleneck downsample shape
+        (20, 256, 64, 56, 56, 1, 1, 2, 2, 0, 0, True, None),  # r50 first bottleneck downsample shape
+        # Fails with packer_l1_acc = True (20, 512, 256, 56, 56, 1, 1, 2, 2, 0, 0, False, None),  # r50 second bottleneck downsample shape
+        # (20, 512, 256, 56, 56, 1, 1, 2, 2, 0, 0, True, None), - doesnt fit
+        (20, 1024, 512, 28, 28, 1, 1, 2, 2, 0, 0, False, None),  # r50 third bottleneck downsample shape
+        # (20, 1024, 512, 28, 28, 1, 1, 2, 2, 0, 0, True, None), - doesnt fit
+        (20, 2048, 1024, 14, 14, 1, 1, 2, 2, 0, 0, False, None),  # r50 fourth bottleneck downsample shape
+        # (20, 2048, 1024, 14, 14, 1, 1, 2, 2, 0, 0, True, None), - doesnt fit
+        # (20, 128, 256, 56, 56, 1, 1, 2, 2, 0, 0, True, None),  ## L2M1 DS: doesn't fit
     ),
 )
 @pytest.mark.parametrize(
     "weights_dtype",
-    # [ttnn.bfloat16, ttnn.bfloat8_b],
-    [ttnn.bfloat8_b],
+    [ttnn.bfloat16, ttnn.bfloat8_b],
 )
 @pytest.mark.parametrize(
     "activations_dtype",
-    # [ttnn.bfloat16, ttnn.bfloat8_b],
-    [ttnn.bfloat8_b],
+    [ttnn.bfloat16, ttnn.bfloat8_b],
 )
 @pytest.mark.parametrize("math_fidelity", [ttnn.MathFidelity.LoFi])
-@pytest.mark.parametrize(
-    "packer_l1_acc",
-    [
-        True,
-    ],
-    ids=["pack_l1"],
-)
+@pytest.mark.parametrize("packer_l1_acc", [True, False], ids=["pack_l1", "no_pack_l1"])
 def test_resnet50_conv_wh(
     device,
     use_program_cache,

--- a/tt_eager/tt_dnn/op_library/conv/kernels/conv_bmm_tilize_col_major_out_blocks.cpp
+++ b/tt_eager/tt_dnn/op_library/conv/kernels/conv_bmm_tilize_col_major_out_blocks.cpp
@@ -9,7 +9,7 @@
 #include "compute_kernel_api/pack_untilize.h"
 #include "compute_kernel_api/tile_move_copy.h"
 #include "compute_kernel_api/matmul.h"
-//#include "debug/dprint.h"
+// #include "debug/dprint.h"
 
 #ifdef FUSE_BIAS
 #include "compute_kernel_api/bcast.h"

--- a/tt_eager/tt_dnn/op_library/conv/kernels/conv_bmm_tilize_col_major_out_blocks.cpp
+++ b/tt_eager/tt_dnn/op_library/conv/kernels/conv_bmm_tilize_col_major_out_blocks.cpp
@@ -9,7 +9,7 @@
 #include "compute_kernel_api/pack_untilize.h"
 #include "compute_kernel_api/tile_move_copy.h"
 #include "compute_kernel_api/matmul.h"
-#include "debug/dprint.h"
+// #include "debug/dprint.h"
 
 #ifdef FUSE_BIAS
 #include "compute_kernel_api/bcast.h"
@@ -136,8 +136,6 @@ void MAIN {
     constexpr uint32_t in0_num_subblocks_read = in0_num_subblocks;
     #endif
 
-    // DPRINT << "in0_num_subblocks_read " << in0_num_subblocks_read << ENDL();
-    // DPRINT << "in0_num_subblocks_read_last " <<in0_num_subblocks_read_last << ENDL();
 
     mm_block_init(mm_in0_cb_id, in1_cb_id, out_cb_id, false, out_subblock_w, out_subblock_h, in0_block_w);
     #ifdef SFPU_OP_INIT_ACTIVATION
@@ -185,12 +183,6 @@ void MAIN {
                     #ifdef SPLIT_READER
                     tilize_in(in0_cb_second_reader_id, in0_subblock_h, in0_block_w, in0_num_subblocks_read_last, tilized_in0_cb_id);
                     #endif
-
-                    // cb_wait_front(tilized_in0_cb_id, in0_block_num_tiles);
-                    // for (uint32_t a=0;a<in0_block_num_tiles;++a){
-                    //     UNPACK(( DPRINT << TSLICE(tilized_in0_cb_id, 0, SliceRange::h0_w0_32()) << ENDL() ));
-                    // }
-                    // UNPACK(( DPRINT << TSLICE(tilized_in0_cb_id, 0, SliceRange::h0_w0_32()) << ENDL() ));
 
                     mm_block_init_short_with_dt(mm_in0_cb_id, in1_cb_id, /*srca_old_operand=*/in0_cb_id, false, out_subblock_w, out_subblock_h, in0_block_w);
                 }

--- a/tt_eager/tt_dnn/op_library/conv/kernels/conv_bmm_tilize_col_major_out_blocks.cpp
+++ b/tt_eager/tt_dnn/op_library/conv/kernels/conv_bmm_tilize_col_major_out_blocks.cpp
@@ -9,7 +9,7 @@
 #include "compute_kernel_api/pack_untilize.h"
 #include "compute_kernel_api/tile_move_copy.h"
 #include "compute_kernel_api/matmul.h"
-// #include "debug/dprint.h"
+#include "debug/dprint.h"
 
 #ifdef FUSE_BIAS
 #include "compute_kernel_api/bcast.h"
@@ -130,10 +130,14 @@ void MAIN {
     constexpr uint32_t mm_in0_cb_id = tilize_in0 ? tilized_in0_cb_id : in0_cb_id;
 
     #ifdef SPLIT_READER
-    constexpr uint32_t in0_num_subblocks_read = in0_num_subblocks / 2;
+    constexpr uint32_t in0_num_subblocks_read_last = in0_num_subblocks / 2;
+    constexpr uint32_t in0_num_subblocks_read = in0_num_subblocks - in0_num_subblocks_read_last;
     #else
     constexpr uint32_t in0_num_subblocks_read = in0_num_subblocks;
     #endif
+
+    // DPRINT << "in0_num_subblocks_read " << in0_num_subblocks_read << ENDL();
+    // DPRINT << "in0_num_subblocks_read_last " <<in0_num_subblocks_read_last << ENDL();
 
     mm_block_init(mm_in0_cb_id, in1_cb_id, out_cb_id, false, out_subblock_w, out_subblock_h, in0_block_w);
     #ifdef SFPU_OP_INIT_ACTIVATION
@@ -179,8 +183,14 @@ void MAIN {
 
                     tilize_in(in0_cb_id, in0_subblock_h, in0_block_w, in0_num_subblocks_read, tilized_in0_cb_id);
                     #ifdef SPLIT_READER
-                    tilize_in(in0_cb_second_reader_id, in0_subblock_h, in0_block_w, in0_num_subblocks_read, tilized_in0_cb_id);
+                    tilize_in(in0_cb_second_reader_id, in0_subblock_h, in0_block_w, in0_num_subblocks_read_last, tilized_in0_cb_id);
                     #endif
+
+                    // cb_wait_front(tilized_in0_cb_id, in0_block_num_tiles);
+                    // for (uint32_t a=0;a<in0_block_num_tiles;++a){
+                    //     UNPACK(( DPRINT << TSLICE(tilized_in0_cb_id, 0, SliceRange::h0_w0_32()) << ENDL() ));
+                    // }
+                    // UNPACK(( DPRINT << TSLICE(tilized_in0_cb_id, 0, SliceRange::h0_w0_32()) << ENDL() ));
 
                     mm_block_init_short_with_dt(mm_in0_cb_id, in1_cb_id, /*srca_old_operand=*/in0_cb_id, false, out_subblock_w, out_subblock_h, in0_block_w);
                 }

--- a/tt_eager/tt_dnn/op_library/conv/kernels/reader_conv_activations_padded_with_halo_3x3_weights_v2.cpp
+++ b/tt_eager/tt_dnn/op_library/conv/kernels/reader_conv_activations_padded_with_halo_3x3_weights_v2.cpp
@@ -6,7 +6,6 @@
 #include "dataflow_api.h"
 #include "firmware_common.h"
 
-#include "debug/dprint.h"
 
 void kernel_main() {
     constexpr uint32_t LOCAL_PACKED_READER_INDICES_MAX_SIZE = 128;
@@ -59,8 +58,6 @@ void kernel_main() {
     }
 
     #ifdef SPLIT_READER
-    // constexpr uint32_t act_block_h_datums_read = act_block_h_datums / 4; // Extra /2 because of packed uint16 reads
-    // constexpr uint32_t act_block_num_tiles_read = act_block_num_tiles / 2;
     constexpr uint32_t act_block_h_datums_read = act_block_h_datums / 2; // Extra /2 because of packed uint16 reads
     constexpr uint32_t act_block_num_tiles_read = act_block_num_tiles;
     #else

--- a/tt_eager/tt_dnn/op_library/conv/kernels/reader_conv_activations_padded_with_halo_3x3_weights_v2.cpp
+++ b/tt_eager/tt_dnn/op_library/conv/kernels/reader_conv_activations_padded_with_halo_3x3_weights_v2.cpp
@@ -6,7 +6,7 @@
 #include "dataflow_api.h"
 #include "firmware_common.h"
 
-// #include "debug/dprint.h"
+#include "debug/dprint.h"
 
 void kernel_main() {
     constexpr uint32_t LOCAL_PACKED_READER_INDICES_MAX_SIZE = 128;
@@ -59,12 +59,15 @@ void kernel_main() {
     }
 
     #ifdef SPLIT_READER
-    constexpr uint32_t act_block_h_datums_read = act_block_h_datums / 4; // Extra /2 because of packed uint16 reads
-    constexpr uint32_t act_block_num_tiles_read = act_block_num_tiles / 2;
+    // constexpr uint32_t act_block_h_datums_read = act_block_h_datums / 4; // Extra /2 because of packed uint16 reads
+    // constexpr uint32_t act_block_num_tiles_read = act_block_num_tiles / 2;
+    constexpr uint32_t act_block_h_datums_read = act_block_h_datums / 2; // Extra /2 because of packed uint16 reads
+    constexpr uint32_t act_block_num_tiles_read = act_block_num_tiles;
     #else
     constexpr uint32_t act_block_h_datums_read = act_block_h_datums / 2; // packed uint16 reads
     constexpr uint32_t act_block_num_tiles_read = act_block_num_tiles;
     #endif
+
 
     // LOOP TO FILL READER INDICES
     constexpr uint32_t cb_reader_indices = tt::CB::c_in4;
@@ -89,6 +92,7 @@ void kernel_main() {
     reader_offset_idx = 0;
     uint32_t act_l1_offset = 0;
     uint32_t act_l1_read_addr = get_read_ptr(cb_id_sharded_act);
+
 
     static_assert(coalesced_read_bytes <= NOC_MAX_BURST_SIZE);
     // set_state uses just x/y from the get_noc_addr, addr is ignored
@@ -131,6 +135,7 @@ void kernel_main() {
                 reader_idx++;
             }
             noc_async_read_barrier();
+
             cb_push_back(cb_id_act, act_block_num_tiles_read);
 
             reader_offset_idx += window_inner;

--- a/tt_eager/tt_dnn/op_library/conv/kernels/reader_conv_activations_padded_with_halo_3x3_weights_v2.cpp
+++ b/tt_eager/tt_dnn/op_library/conv/kernels/reader_conv_activations_padded_with_halo_3x3_weights_v2.cpp
@@ -6,6 +6,7 @@
 #include "dataflow_api.h"
 #include "firmware_common.h"
 
+// #include "debug/dprint.h"
 
 void kernel_main() {
     constexpr uint32_t LOCAL_PACKED_READER_INDICES_MAX_SIZE = 128;

--- a/tt_eager/tt_dnn/op_library/conv/kernels/reader_writer_tiled_out_1d_mcast_receiver_conv_weights_tiled_col_to_rm_blocks.cpp
+++ b/tt_eager/tt_dnn/op_library/conv/kernels/reader_writer_tiled_out_1d_mcast_receiver_conv_weights_tiled_col_to_rm_blocks.cpp
@@ -53,6 +53,7 @@ void kernel_main() {
     constexpr uint32_t coalesced_read_bytes = get_compile_time_arg_val(35);
     constexpr uint32_t window_outer_offset = get_compile_time_arg_val(36);
     constexpr uint32_t act_block_w_extra_align_bytes = get_compile_time_arg_val(37);
+    constexpr uint32_t act_block_h_datums_first_reader = get_compile_time_arg_val(38);
 
     constexpr uint32_t total_weight_num_tiles = weight_block_height_num_outer * num_blocks_weight_h * weight_block_num_tiles;
 
@@ -82,8 +83,10 @@ void kernel_main() {
 
     constexpr uint32_t cb_id_act_second_reader = 7;
     constexpr uint32_t cb_id_sharded_act = 3;
-    constexpr uint32_t act_block_h_datums_read = act_block_h_datums / 4; // Extra /2 because of packed uint16 reads
-    constexpr uint32_t act_block_num_tiles_read = act_block_num_tiles / 2;
+    // constexpr uint32_t act_block_h_datums_read = act_block_h_datums / 4; // Extra /2 because of packed uint16 reads
+    // constexpr uint32_t act_block_num_tiles_read = act_block_num_tiles / 2;
+    constexpr uint32_t act_block_h_datums_read = act_block_h_datums / 2; // Extra /2 because of packed uint16 reads
+    constexpr uint32_t act_block_num_tiles_read = act_block_num_tiles;
 
     constexpr uint32_t cb_reader_indices = tt::CB::c_in4;
     volatile tt_l1_ptr uint32_t* packed_reader_indices_ptr = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(get_write_ptr(cb_reader_indices));
@@ -119,7 +122,7 @@ void kernel_main() {
         // coalesce reads along weight_size_w
         uint32_t act_l1_offset = 0;
         uint32_t act_l1_read_addr = get_read_ptr(cb_id_sharded_act);
-        uint32_t start_reader_idx = act_block_h_datums_read;
+        uint32_t start_reader_idx = act_block_h_datums_first_reader / 2;
 
         bool read_weights = true;
         for(uint32_t bh = 0; bh < out_num_blocks_h; bh++) {

--- a/tt_eager/tt_dnn/op_library/conv/kernels/reader_writer_tiled_out_1d_mcast_receiver_conv_weights_tiled_col_to_rm_blocks.cpp
+++ b/tt_eager/tt_dnn/op_library/conv/kernels/reader_writer_tiled_out_1d_mcast_receiver_conv_weights_tiled_col_to_rm_blocks.cpp
@@ -83,8 +83,6 @@ void kernel_main() {
 
     constexpr uint32_t cb_id_act_second_reader = 7;
     constexpr uint32_t cb_id_sharded_act = 3;
-    // constexpr uint32_t act_block_h_datums_read = act_block_h_datums / 4; // Extra /2 because of packed uint16 reads
-    // constexpr uint32_t act_block_num_tiles_read = act_block_num_tiles / 2;
     constexpr uint32_t act_block_h_datums_read = act_block_h_datums / 2; // Extra /2 because of packed uint16 reads
     constexpr uint32_t act_block_num_tiles_read = act_block_num_tiles;
 

--- a/tt_eager/tt_dnn/op_library/conv/kernels/reader_writer_tiled_out_1d_mcast_sender_conv_weights_tiled_col_to_rm_blocks.cpp
+++ b/tt_eager/tt_dnn/op_library/conv/kernels/reader_writer_tiled_out_1d_mcast_sender_conv_weights_tiled_col_to_rm_blocks.cpp
@@ -5,7 +5,6 @@
 #include "dataflow_api.h"
 #include "firmware_common.h"
 
-#include "debug/dprint.h"
 
 void kernel_main() {
     constexpr uint32_t LOCAL_PACKED_READER_INDICES_MAX_SIZE = 128;
@@ -87,8 +86,6 @@ void kernel_main() {
 
     constexpr uint32_t cb_id_act_second_reader = 7;
     constexpr uint32_t cb_id_sharded_act = 3;
-    // constexpr uint32_t act_block_h_datums_read = act_block_h_datums / 4; // Extra /2 because of packed uint16 reads
-    // constexpr uint32_t act_block_num_tiles_read = act_block_num_tiles / 2;
     constexpr uint32_t act_block_h_datums_read = act_block_h_datums / 2; // Extra /2 because of packed uint16 reads
     constexpr uint32_t act_block_num_tiles_read = act_block_num_tiles;
 

--- a/tt_eager/tt_dnn/op_library/conv/multi_core_optimized_conv_sharded/optimized_conv_op_sharded_v2.cpp
+++ b/tt_eager/tt_dnn/op_library/conv/multi_core_optimized_conv_sharded/optimized_conv_op_sharded_v2.cpp
@@ -40,6 +40,7 @@ tuple<CBHandle, CBHandle> create_CBs_for_sharded_input_v2(
     const Tensor& input,
     CoreRange core,
     uint32_t num_cb0_tiles,
+    uint32_t num_cb0_second_reader_tiles,
     uint32_t num_cb1_tiles,
     uint32_t num_cb0_tilized_tiles,
     uint32_t num_output_tiles,
@@ -108,13 +109,19 @@ tuple<CBHandle, CBHandle> create_CBs_for_sharded_input_v2(
             // Extra cb for second reader if we split act reads across two RISCs
             // In this case, the regular reader only does first half of reads along output block h
             if (split_reader) {
-                num_cb0_tiles /= 2;
+                // num_cb0_tiles /= 2;
+
+                // CircularBufferConfig cb_act_config =
+                //     CircularBufferConfig(num_cb0_tiles * act_tile_size, {{act_cb_second_reader, act_df}})
+                //         .set_page_size(act_cb_second_reader, act_tile_size);
+                // auto cb_act = tt_metal::CreateCircularBuffer(program, core, cb_act_config);
+                // log_debug(LogOp, "Act CB Second Reader: {}, npages: {}, pagesize: {}", act_cb_second_reader, num_cb0_tiles, act_tile_size);
 
                 CircularBufferConfig cb_act_config =
-                    CircularBufferConfig(num_cb0_tiles * act_tile_size, {{act_cb_second_reader, act_df}})
+                    CircularBufferConfig(num_cb0_second_reader_tiles * act_tile_size, {{act_cb_second_reader, act_df}})
                         .set_page_size(act_cb_second_reader, act_tile_size);
                 auto cb_act = tt_metal::CreateCircularBuffer(program, core, cb_act_config);
-                log_debug(LogOp, "Act CB Second Reader: {}, npages: {}, pagesize: {}", act_cb_second_reader, num_cb0_tiles, act_tile_size);
+                log_debug(LogOp, "Act CB Second Reader: {}, npages: {}, pagesize: {}", act_cb_second_reader, num_cb0_second_reader_tiles, act_tile_size);
             }
 
             CircularBufferConfig cb_act_config = CircularBufferConfig(num_cb0_tiles * act_tile_size, {{act_cb, act_df}})
@@ -242,6 +249,8 @@ operation::ProgramWithCallbacks multi_core_optimized_conv_sharded_v2_impl(
     uint32_t out_subblock_h_ntiles = block_config.out_subblock_h_ntiles;
     uint32_t out_subblock_w_ntiles = block_config.out_subblock_w_ntiles;
 
+    // out_subblock_h_ntiles = 8;
+
     DataFormat act_df = tt_metal::datatype_to_dataformat_converter(a.get_dtype());
     DataFormat weight_df = tt_metal::datatype_to_dataformat_converter(b.get_dtype());
     DataFormat out_df = tt_metal::datatype_to_dataformat_converter(output.get_dtype());
@@ -293,10 +302,11 @@ operation::ProgramWithCallbacks multi_core_optimized_conv_sharded_v2_impl(
         }
     }
     // it is bad for compute, pad act_block_h_ntiles
+    uint32_t max_num_subblock = fp32_dest_acc_en ? 4 : 8;
     uint32_t max_subblock_h = fp32_dest_acc_en ? 4 : 8;
     uint32_t act_block_h_ntiles_padded = act_block_h_ntiles;
     uint32_t out_subblock_h_ntiles_padded = out_subblock_h_ntiles;
-    if (out_subblock_w_ntiles == 1 and out_subblock_h_ntiles < max_subblock_h and (act_block_h_ntiles == out_block_h_ntiles)) {
+    if ((out_subblock_w_ntiles * out_subblock_h_ntiles <= max_num_subblock / 2) and (out_subblock_w_ntiles == weight_block_w_ntiles) and (act_block_h_ntiles == out_block_h_ntiles)) {
         uint32_t num_subblock_h = act_block_h_ntiles / out_subblock_h_ntiles;
         uint32_t num_iter = max_subblock_h - out_subblock_h_ntiles;
         uint32_t new_out_subblock_h = out_subblock_h_ntiles;
@@ -306,7 +316,7 @@ operation::ProgramWithCallbacks multi_core_optimized_conv_sharded_v2_impl(
             new_out_subblock_h += 1;
             uint32_t new_num_subblock_h = (act_block_h_ntiles + new_out_subblock_h - 1) / new_out_subblock_h;
 
-            if (new_num_subblock_h < num_subblock_h) {
+            if (new_num_subblock_h < num_subblock_h and (out_subblock_w_ntiles * new_out_subblock_h <= max_num_subblock)) {
                 num_subblock_h = new_num_subblock_h;
                 preferred_out_subblock_h = new_out_subblock_h;
             }
@@ -374,14 +384,15 @@ operation::ProgramWithCallbacks multi_core_optimized_conv_sharded_v2_impl(
                                                                               // by 8 not 16.
     // Always use split reader for first conv in resnet which has input channels = 16
     // TODO: Expose option to split readers for 1D convs to python?
-    bool split_reader = use_shallow_conv_variant;
+    // bool split_reader = use_shallow_conv_variant;
+    bool split_reader = use_shallow_conv_variant or (not weight_width_sliced and (act_block_h_ntiles / block_config.out_subblock_h_ntiles) >= 2);
     if (split_reader) {
         TT_FATAL(
             block_config.act_block_h_ntiles % block_config.out_subblock_h_ntiles == 0,
             "Out_block_h must be divisible by out_subblock_h!");
-        TT_FATAL(
-            (block_config.act_block_h_ntiles / block_config.out_subblock_h_ntiles) % 2 == 0,
-            "Number of out_subblock_h must be divisible by 2 for split reader!");
+        // TT_FATAL(
+        //     (block_config.act_block_h_ntiles / block_config.out_subblock_h_ntiles) % 2 == 0,
+        //     "Number of out_subblock_h must be divisible by 2 for split reader!");
     }
     Shape ashape_with_channels_padded = {ashape[0], ashape[1], ashape[2], input_channels_padded};
     uint32_t conv_act_size_h = ashape_with_channels_padded[1];
@@ -453,6 +464,27 @@ operation::ProgramWithCallbacks multi_core_optimized_conv_sharded_v2_impl(
     // act block info
     uint32_t act_block_w_datums = act_matrix_width / num_blocks_act_w;
     uint32_t act_block_h_datums = act_matrix_height / num_blocks_act_h;
+
+    uint32_t act_block_h_nsubblocks = block_config.act_block_h_ntiles / block_config.out_subblock_h_ntiles;
+    uint32_t act_block_h_nsubblocks_split = act_block_h_nsubblocks;
+    uint32_t act_block_h_nsubblocks_split_last = 0;
+    if (split_reader) {
+        act_block_h_nsubblocks_split_last = act_block_h_nsubblocks / 2;
+        act_block_h_nsubblocks_split = act_block_h_nsubblocks - act_block_h_nsubblocks_split_last;
+    }
+    uint32_t act_block_h_datums_split = act_block_h_nsubblocks_split * out_subblock_h_ntiles * TILE_HEIGHT;
+    uint32_t act_block_h_datums_split_last = act_block_h_nsubblocks_split_last * out_subblock_h_ntiles * TILE_HEIGHT;
+
+    uint32_t act_block_num_tiles_split = act_block_h_nsubblocks_split * out_subblock_h_ntiles * act_block_w_ntiles;
+    uint32_t act_block_num_tiles_split_last = act_block_h_nsubblocks_split_last * out_subblock_h_ntiles * act_block_w_ntiles;
+
+    log_debug(LogOp, "act_block_h_nsubblocks_split: {}", act_block_h_nsubblocks_split);
+    log_debug(LogOp, "act_block_h_nsubblocks_split_last: {}", act_block_h_nsubblocks_split_last);
+    log_debug(LogOp, "act_block_h_datums_split: {}", act_block_h_datums_split);
+    log_debug(LogOp, "act_block_h_datums_split_last: {}", act_block_h_datums_split_last);
+    log_debug(LogOp, "act_block_num_tiles_split: {}", act_block_num_tiles_split);
+    log_debug(LogOp, "act_block_num_tiles_split_last: {}", act_block_num_tiles_split_last);
+
     TT_ASSERT(
         (act_block_w_datums == round_up(conv_act_size_c * weight_size_w, TILE_WIDTH)) ||
         ((act_block_w_datums <= conv_act_size_c) && (conv_act_size_c % act_block_w_datums == 0)));
@@ -502,6 +534,7 @@ operation::ProgramWithCallbacks multi_core_optimized_conv_sharded_v2_impl(
     assert(act_matrix_width_ntiles % act_block_w_ntiles == 0);
     assert(act_block_h_ntiles % out_subblock_h_ntiles == 0);
     // assert(out_block_h_ntiles % out_subblock_h_ntiles == 0);
+    // uint32_t act_num_subblocks = (act_block_h_ntiles + out_subblock_h_ntiles - 1) / out_subblock_h_ntiles;
     uint32_t act_num_subblocks = act_block_h_ntiles / out_subblock_h_ntiles;
     uint32_t act_block_num_tiles = act_block_h_ntiles * act_block_w_ntiles;
     uint32_t act_subblock_h_ntiles = out_subblock_h_ntiles;
@@ -572,6 +605,7 @@ operation::ProgramWithCallbacks multi_core_optimized_conv_sharded_v2_impl(
     // For debug
     {
         log_debug(LogOp, "multi_core_optimized_conv_sharded_v2_");
+        log_debug(LogOp, "split readers: {}", split_reader);
         log_debug(LogOp, "conv_act_size_h: {}", conv_act_size_h);
         log_debug(LogOp, "conv_act_size_w: {}", conv_act_size_w);
         log_debug(LogOp, "act_matrix_height: {}", act_matrix_height);
@@ -771,6 +805,7 @@ operation::ProgramWithCallbacks multi_core_optimized_conv_sharded_v2_impl(
     uint32_t num_weight_cb_tiles = weight_block_h_ntiles * weight_block_w_ntiles / conv_act_c_blocks;
     bool fully_buffer_weights = false;
     uint32_t num_act_cb_tiles = act_block_h_ntiles * act_block_w_ntiles / conv_act_c_blocks;
+    uint32_t num_act_cb_second_reader_tiles = 0;
     // TODO: This flag should be set in kernel logic but need this for create_CB
     if (a.memory_config().is_sharded() and ((weight_size_h == 3 and weight_size_w == 3 and
         (stride_h == 1 or stride_h == 2)) or (weight_size_h == 1 and weight_size_w == 1 and stride_h == 2)) and weight_width_sliced) {
@@ -792,12 +827,25 @@ operation::ProgramWithCallbacks multi_core_optimized_conv_sharded_v2_impl(
         num_weight_cb_tiles = num_weight_cb_tiles * 2;
     }
 
-    if (enable_act_doule_buffer) {
-        num_act_cb_tiles = num_act_cb_tiles * 2;
-    } else if (conv_act_size_c / conv_act_c_blocks < 160 &&
-        per_core_out_matrix_height_ntiles < 22) {  // Q: where are these numbers from?
-        num_act_cb_tiles = num_act_cb_tiles * 2;   // double buffered
+    if (split_reader) {
+        if (enable_act_doule_buffer) {
+            num_act_cb_tiles = act_block_num_tiles_split;
+            num_act_cb_second_reader_tiles = act_block_num_tiles_split_last;
+            num_act_cb_tiles = num_act_cb_tiles * 2; // double buffered
+            num_act_cb_second_reader_tiles = num_act_cb_second_reader_tiles * 2; // double buffered
+        } else {
+            num_act_cb_tiles = act_block_num_tiles_split;
+            num_act_cb_second_reader_tiles = act_block_num_tiles_split_last;
+        }
+    } else {
+        if (enable_act_doule_buffer) {
+            num_act_cb_tiles = num_act_cb_tiles * 2;
+        } else if (conv_act_size_c / conv_act_c_blocks < 160 &&
+            per_core_out_matrix_height_ntiles < 22) {  // Q: where are these numbers from?
+            num_act_cb_tiles = num_act_cb_tiles * 2;   // double buffered
+        }
     }
+
 
     uint32_t out_block_h_ntiles_padded = num_blocks_act_h_per_core * act_block_h_ntiles;
     uint32_t writer_output_block_num_tiles = out_block_h_ntiles_padded * weight_block_w_ntiles;
@@ -835,6 +883,7 @@ operation::ProgramWithCallbacks multi_core_optimized_conv_sharded_v2_impl(
         a,
         all_cores,
         num_act_cb_tiles,               // row major act cb
+        num_act_cb_second_reader_tiles, // row major act cb second reader
         num_weight_cb_tiles,            // tiled weight cb
         num_cb0_tilized_tiles,          // tiled act cb
         output_block_num_tiles,  // math output cb
@@ -952,8 +1001,8 @@ operation::ProgramWithCallbacks multi_core_optimized_conv_sharded_v2_impl(
         (uint32_t)conv_act_c_read_bytes,
         (uint32_t)window_outer,
         (uint32_t)window_inner,
-        (uint32_t)act_block_h_datums,
-        (uint32_t)act_block_num_tiles / conv_act_c_blocks,
+        (uint32_t)(split_reader ? act_block_h_datums_split : act_block_h_datums),
+        (uint32_t)(split_reader ? act_block_num_tiles_split / conv_act_c_blocks : act_block_num_tiles / conv_act_c_blocks),
         (uint32_t)weight_size_w,
         (uint32_t)conv_act_size_w + (2 * pad_w),
         (uint32_t)act_block_w_extra_align_bytes,  // only used for 1d systolic variant
@@ -1044,12 +1093,15 @@ operation::ProgramWithCallbacks multi_core_optimized_conv_sharded_v2_impl(
     };
     if (split_reader) {
         std::vector<uint32_t> split_reader_args = {
-            (uint32_t)act_block_h_datums,
-            (uint32_t)act_block_num_tiles / conv_act_c_blocks,
+            // (uint32_t)act_block_h_datums,
+            (uint32_t)act_block_h_datums_split_last,
+            // (uint32_t)act_block_num_tiles / conv_act_c_blocks,
+            (uint32_t)act_block_num_tiles_split_last / conv_act_c_blocks,
             (uint32_t)conv_act_c_read_bytes,
             (uint32_t)weight_size_w * conv_act_c_read_bytes,                  // coalesced_read_bytes
             (uint32_t)(conv_act_size_w + 2 * pad_w) * conv_act_c_read_bytes,  // window_outer_offset
             (uint32_t)act_block_w_extra_align_bytes,                          // only used for 1d systolic variant
+            (uint32_t)act_block_h_datums_split,                          // only used for 1d systolic variant
         };
         writer_compile_time_args.insert(
             writer_compile_time_args.end(), split_reader_args.begin(), split_reader_args.end());

--- a/tt_eager/tt_dnn/op_library/conv/optimized_conv_op.cpp
+++ b/tt_eager/tt_dnn/op_library/conv/optimized_conv_op.cpp
@@ -71,13 +71,13 @@ Tensor optimized_conv(const Tensor& a,
             bool use_shallow_conv_variant,
             bool transpose_mcast,
             std::optional<const DeviceComputeKernelConfig> compute_kernel_config,
-            bool enable_act_doule_buffer,
+            bool enable_act_double_buffer,
             bool enable_split_reader,
             bool enable_subblock_padding
 ) {
     std::vector<Tensor> output_tensors = {Tensor(operation::get_workers_for_op_output({a, b}))};
     operation::launch_op(
-        [conv_params, output_channels, untilize_out, has_bias, fuse_relu, math_fidelity, parallelization_config, block_config, extra_padding_for_32B_alignment, output_mem_config, output_dtype, input_tensor_shape, use_shallow_conv_variant, transpose_mcast, compute_kernel_config, enable_act_doule_buffer, enable_split_reader, enable_subblock_padding]
+        [conv_params, output_channels, untilize_out, has_bias, fuse_relu, math_fidelity, parallelization_config, block_config, extra_padding_for_32B_alignment, output_mem_config, output_dtype, input_tensor_shape, use_shallow_conv_variant, transpose_mcast, compute_kernel_config, enable_act_double_buffer, enable_split_reader, enable_subblock_padding]
             (const std::vector<Tensor>& input_tensors, const std::vector<std::optional<const Tensor>>& optional_input_tensors, const std::vector<std::optional<Tensor>>& optional_output_tensors) mutable -> std::vector<Tensor> {
                 auto& a = input_tensors.at(0);
                 auto& b = input_tensors.at(1);
@@ -100,7 +100,7 @@ Tensor optimized_conv(const Tensor& a,
                 bool fp32_accum = a.device()->arch() == ARCH::WORMHOLE_B0;  // && compute_kernel_config.has_value()) ? compute_kernel_config.value().fp32_dest_acc_en : false;
                 auto kernel_config_val = init_device_compute_kernel_config(arch, compute_kernel_config, MathFidelity::LoFi, true, fp32_accum, false);
                 return operation::run_without_autoformat(
-                    OptimizedConv(conv_params, output_channels, untilize_out, has_bias, fuse_relu, math_fidelity, parallelization_config, block_config, extra_padding_for_32B_alignment, output_mem_config.value_or(a.memory_config()), output_dtype.value_or(a.get_dtype()), ashape, use_shallow_conv_variant, transpose_mcast, kernel_config_val, enable_act_doule_buffer, enable_split_reader, enable_subblock_padding
+                    OptimizedConv(conv_params, output_channels, untilize_out, has_bias, fuse_relu, math_fidelity, parallelization_config, block_config, extra_padding_for_32B_alignment, output_mem_config.value_or(a.memory_config()), output_dtype.value_or(a.get_dtype()), ashape, use_shallow_conv_variant, transpose_mcast, kernel_config_val, enable_act_double_buffer, enable_split_reader, enable_subblock_padding
                     ),
                     input_tensors,
                     optional_input_tensors);
@@ -211,7 +211,7 @@ operation::ProgramWithCallbacks OptimizedConv::create_program(const std::vector<
     if (input_tensor_a.memory_config().is_sharded()) {
         // If conv_reader_indices is passed in, use v2 where we don't generate indices locally
         if (conv_reader_indices.has_value()) {
-            return multi_core_optimized_conv_sharded_v2_(input_tensor_a, input_tensor_b, this->input_tensor_shape, input_tensor_bias, conv_reader_indices, conv_params, output_channels, untilize_out, has_bias, fuse_relu, parallelization_config, block_config, extra_padding_for_32B_alignment, this->use_shallow_conv_variant, transpose_mcast, output_tensor, this->compute_kernel_config, this->enable_act_doule_buffer, this->enable_split_reader, this->enable_subblock_padding);
+            return multi_core_optimized_conv_sharded_v2_(input_tensor_a, input_tensor_b, this->input_tensor_shape, input_tensor_bias, conv_reader_indices, conv_params, output_channels, untilize_out, has_bias, fuse_relu, parallelization_config, block_config, extra_padding_for_32B_alignment, this->use_shallow_conv_variant, transpose_mcast, output_tensor, this->compute_kernel_config, this->enable_act_double_buffer, this->enable_split_reader, this->enable_subblock_padding);
         } else {
             return multi_core_optimized_conv_sharded_(input_tensor_a, input_tensor_b, this->input_tensor_shape, input_tensor_bias, conv_params, output_channels, untilize_out, has_bias, fuse_relu, math_fidelity, parallelization_config, block_config, extra_padding_for_32B_alignment, output_tensor);
         }
@@ -281,7 +281,7 @@ Tensor optimized_conv_new(const Tensor& a, const Tensor &b, std::optional<const 
     std::array<std::uint32_t, 4> input_tensor_shape,
     bool use_shallow_conv_variant,
     std::optional<const DeviceComputeKernelConfig> compute_kernel_config,
-    bool enable_act_doule_buffer,
+    bool enable_act_double_buffer,
     bool enable_split_reader,
     bool enable_subblock_padding
 ) {
@@ -300,7 +300,7 @@ Tensor optimized_conv_new(const Tensor& a, const Tensor &b, std::optional<const 
     bool fp32_accum = a.device()->arch() == ARCH::WORMHOLE_B0;  // && compute_kernel_config.has_value()) ? compute_kernel_config.value().fp32_dest_acc_en : false;
     auto kernel_config_val = init_device_compute_kernel_config(arch, compute_kernel_config, MathFidelity::LoFi, true, fp32_accum, false);
     return operation::run_without_autoformat(
-        OptimizedConvNew(conv_params, output_channels, untilize_out, bias.has_value(), fuse_relu, math_fidelity, parallelization_config, block_config, extra_padding_for_32B_alignment, output_mem_config, output_dtype, input_tensor_shape, use_shallow_conv_variant, kernel_config_val, enable_act_doule_buffer, enable_split_reader, enable_subblock_padding
+        OptimizedConvNew(conv_params, output_channels, untilize_out, bias.has_value(), fuse_relu, math_fidelity, parallelization_config, block_config, extra_padding_for_32B_alignment, output_mem_config, output_dtype, input_tensor_shape, use_shallow_conv_variant, kernel_config_val, enable_act_double_buffer, enable_split_reader, enable_subblock_padding
         ),
         {a, b},
         {bias}).at(0);
@@ -424,7 +424,7 @@ operation::ProgramWithCallbacks OptimizedConvNew::create_program(const std::vect
         use_shallow_conv_variant,
         compute_kernel_config,
         output_tensor,
-        enable_act_doule_buffer,
+        enable_act_double_buffer,
         enable_split_reader,
         enable_subblock_padding);
 }

--- a/tt_eager/tt_dnn/op_library/conv/optimized_conv_op.cpp
+++ b/tt_eager/tt_dnn/op_library/conv/optimized_conv_op.cpp
@@ -70,11 +70,12 @@ Tensor optimized_conv(const Tensor& a,
             std::optional<std::array<std::uint32_t, 4>> input_tensor_shape,
             bool use_shallow_conv_variant,
             bool transpose_mcast,
-            std::optional<const DeviceComputeKernelConfig> compute_kernel_config
+            std::optional<const DeviceComputeKernelConfig> compute_kernel_config,
+            bool enable_act_doule_buffer
 ) {
     std::vector<Tensor> output_tensors = {Tensor(operation::get_workers_for_op_output({a, b}))};
     operation::launch_op(
-        [conv_params, output_channels, untilize_out, has_bias, fuse_relu, math_fidelity, parallelization_config, block_config, extra_padding_for_32B_alignment, output_mem_config, output_dtype, input_tensor_shape, use_shallow_conv_variant, transpose_mcast, compute_kernel_config]
+        [conv_params, output_channels, untilize_out, has_bias, fuse_relu, math_fidelity, parallelization_config, block_config, extra_padding_for_32B_alignment, output_mem_config, output_dtype, input_tensor_shape, use_shallow_conv_variant, transpose_mcast, compute_kernel_config, enable_act_doule_buffer]
             (const std::vector<Tensor>& input_tensors, const std::vector<std::optional<const Tensor>>& optional_input_tensors, const std::vector<std::optional<Tensor>>& optional_output_tensors) mutable -> std::vector<Tensor> {
                 auto& a = input_tensors.at(0);
                 auto& b = input_tensors.at(1);
@@ -97,7 +98,7 @@ Tensor optimized_conv(const Tensor& a,
                 bool fp32_accum = a.device()->arch() == ARCH::WORMHOLE_B0;  // && compute_kernel_config.has_value()) ? compute_kernel_config.value().fp32_dest_acc_en : false;
                 auto kernel_config_val = init_device_compute_kernel_config(arch, compute_kernel_config, MathFidelity::LoFi, true, fp32_accum, false);
                 return operation::run_without_autoformat(
-                    OptimizedConv(conv_params, output_channels, untilize_out, has_bias, fuse_relu, math_fidelity, parallelization_config, block_config, extra_padding_for_32B_alignment, output_mem_config.value_or(a.memory_config()), output_dtype.value_or(a.get_dtype()), ashape, use_shallow_conv_variant, transpose_mcast, kernel_config_val
+                    OptimizedConv(conv_params, output_channels, untilize_out, has_bias, fuse_relu, math_fidelity, parallelization_config, block_config, extra_padding_for_32B_alignment, output_mem_config.value_or(a.memory_config()), output_dtype.value_or(a.get_dtype()), ashape, use_shallow_conv_variant, transpose_mcast, kernel_config_val, enable_act_doule_buffer
                     ),
                     input_tensors,
                     optional_input_tensors);
@@ -208,7 +209,7 @@ operation::ProgramWithCallbacks OptimizedConv::create_program(const std::vector<
     if (input_tensor_a.memory_config().is_sharded()) {
         // If conv_reader_indices is passed in, use v2 where we don't generate indices locally
         if (conv_reader_indices.has_value()) {
-            return multi_core_optimized_conv_sharded_v2_(input_tensor_a, input_tensor_b, this->input_tensor_shape, input_tensor_bias, conv_reader_indices, conv_params, output_channels, untilize_out, has_bias, fuse_relu, parallelization_config, block_config, extra_padding_for_32B_alignment, this->use_shallow_conv_variant, transpose_mcast, output_tensor, this->compute_kernel_config);
+            return multi_core_optimized_conv_sharded_v2_(input_tensor_a, input_tensor_b, this->input_tensor_shape, input_tensor_bias, conv_reader_indices, conv_params, output_channels, untilize_out, has_bias, fuse_relu, parallelization_config, block_config, extra_padding_for_32B_alignment, this->use_shallow_conv_variant, transpose_mcast, output_tensor, this->compute_kernel_config, this->enable_act_doule_buffer);
         } else {
             return multi_core_optimized_conv_sharded_(input_tensor_a, input_tensor_b, this->input_tensor_shape, input_tensor_bias, conv_params, output_channels, untilize_out, has_bias, fuse_relu, math_fidelity, parallelization_config, block_config, extra_padding_for_32B_alignment, output_tensor);
         }
@@ -277,7 +278,8 @@ Tensor optimized_conv_new(const Tensor& a, const Tensor &b, std::optional<const 
     DataType output_dtype,
     std::array<std::uint32_t, 4> input_tensor_shape,
     bool use_shallow_conv_variant,
-    std::optional<const DeviceComputeKernelConfig> compute_kernel_config
+    std::optional<const DeviceComputeKernelConfig> compute_kernel_config,
+    bool enable_act_doule_buffer
 ) {
     //TT_ASSERT(!untilize_out, "Optimized conv only supports tiled out");
     TT_ASSERT(b.get_layout() == Layout::TILE); // Weights should already be formatted
@@ -294,7 +296,7 @@ Tensor optimized_conv_new(const Tensor& a, const Tensor &b, std::optional<const 
     bool fp32_accum = a.device()->arch() == ARCH::WORMHOLE_B0;  // && compute_kernel_config.has_value()) ? compute_kernel_config.value().fp32_dest_acc_en : false;
     auto kernel_config_val = init_device_compute_kernel_config(arch, compute_kernel_config, MathFidelity::LoFi, true, fp32_accum, false);
     return operation::run_without_autoformat(
-        OptimizedConvNew(conv_params, output_channels, untilize_out, bias.has_value(), fuse_relu, math_fidelity, parallelization_config, block_config, extra_padding_for_32B_alignment, output_mem_config, output_dtype, input_tensor_shape, use_shallow_conv_variant, kernel_config_val
+        OptimizedConvNew(conv_params, output_channels, untilize_out, bias.has_value(), fuse_relu, math_fidelity, parallelization_config, block_config, extra_padding_for_32B_alignment, output_mem_config, output_dtype, input_tensor_shape, use_shallow_conv_variant, kernel_config_val, enable_act_doule_buffer
         ),
         {a, b},
         {bias}).at(0);
@@ -417,7 +419,8 @@ operation::ProgramWithCallbacks OptimizedConvNew::create_program(const std::vect
         input_tensor_shape,
         use_shallow_conv_variant,
         compute_kernel_config,
-        output_tensor);
+        output_tensor,
+        enable_act_doule_buffer);
 }
 
 operation::OpPerformanceModel OptimizedConvNew::create_op_performance_model(const std::vector<Tensor>& input_tensors, const std::vector<std::optional<const Tensor>>& optional_input_tensors, const std::vector<Tensor> &output_tensors) const {

--- a/tt_eager/tt_dnn/op_library/conv/optimized_conv_op.hpp
+++ b/tt_eager/tt_dnn/op_library/conv/optimized_conv_op.hpp
@@ -42,7 +42,7 @@ struct OptimizedConvBlockConfig {
 
 operation::ProgramWithCallbacks multi_core_optimized_conv_(const Tensor& a, const Tensor &b, const Shape& ashape, std::optional<const Tensor> bias, vector<int> conv_params, uint32_t output_channels, bool untilize_out, bool has_bias, bool fuse_relu, const MathFidelity math_fidelity, const OptimizedConvParallelizationConfig& parallelization_config, const OptimizedConvBlockConfig& block_config, uint32_t extra_padding_for_32B_alignment, Tensor &output);
 operation::ProgramWithCallbacks multi_core_optimized_conv_sharded_(const Tensor& a, const Tensor &b, const Shape& ashape, std::optional<const Tensor> bias, vector<int> conv_params, uint32_t output_channels, bool untilize_out, bool has_bias, bool fuse_relu, const MathFidelity math_fidelity, const OptimizedConvParallelizationConfig& parallelization_config, const OptimizedConvBlockConfig& block_config, uint32_t extra_padding_for_32B_alignment, Tensor &output);
-operation::ProgramWithCallbacks multi_core_optimized_conv_sharded_v2_(const Tensor& a, const Tensor &b, const Shape& ashape, std::optional<const Tensor> bias, const std::optional<const Tensor> conv_reader_indices, vector<int> conv_params, uint32_t output_channels, bool untilize_out, bool has_bias, bool fuse_relu, const OptimizedConvParallelizationConfig& parallelization_config, const OptimizedConvBlockConfig& block_config, uint32_t extra_padding_for_32B_alignment, bool use_shallow_conv_variant, bool transpose_mcast, Tensor &output, DeviceComputeKernelConfig compute_kernel_config);
+operation::ProgramWithCallbacks multi_core_optimized_conv_sharded_v2_(const Tensor& a, const Tensor &b, const Shape& ashape, std::optional<const Tensor> bias, const std::optional<const Tensor> conv_reader_indices, vector<int> conv_params, uint32_t output_channels, bool untilize_out, bool has_bias, bool fuse_relu, const OptimizedConvParallelizationConfig& parallelization_config, const OptimizedConvBlockConfig& block_config, uint32_t extra_padding_for_32B_alignment, bool use_shallow_conv_variant, bool transpose_mcast, Tensor &output, DeviceComputeKernelConfig compute_kernel_config, bool enable_act_doule_buffer);
 operation::ProgramWithCallbacks multi_core_optimized_conv_sharded_v2_new(const Tensor& a, const Tensor &b, std::optional<const Tensor> bias,
     vector<int> conv_params,
     uint32_t output_channels,
@@ -53,7 +53,8 @@ operation::ProgramWithCallbacks multi_core_optimized_conv_sharded_v2_new(const T
     std::array<std::uint32_t, 4> input_tensor_shape,
     bool use_shallow_conv_variant,
     std::optional<const DeviceComputeKernelConfig> compute_kernel_config,
-    Tensor& output);
+    Tensor& output,
+    bool enable_act_doule_buffer);
 
 struct OptimizedConv {
     OptimizedConvParallelizationConfig parallelization_config;
@@ -70,13 +71,14 @@ struct OptimizedConv {
     bool use_shallow_conv_variant;
     bool transpose_mcast;   // default for GS = true, WH = false
     const DeviceComputeKernelConfig compute_kernel_config;
+    bool enable_act_doule_buffer;
     OptimizedConv(const std::vector<int>&c_params,
         uint32_t output_channels, bool untile_out,
         bool has_bias, bool fuse_relu,
         MathFidelity mfidelity, const OptimizedConvParallelizationConfig& p_config,
         const OptimizedConvBlockConfig& b_config,
         uint32_t e_padding_for_32B_alignment,
-        MemoryConfig output_mem_config, DataType output_dtype, Shape input_tensor_shape, bool use_shallow_conv_variant, bool transpose_mcast, const DeviceComputeKernelConfig compute_kernel_config) :
+        MemoryConfig output_mem_config, DataType output_dtype, Shape input_tensor_shape, bool use_shallow_conv_variant, bool transpose_mcast, const DeviceComputeKernelConfig compute_kernel_config, bool enable_act_doule_buffer) :
             output_channels(output_channels),
             conv_params(c_params),
             untilize_out(untile_out),
@@ -89,7 +91,8 @@ struct OptimizedConv {
             output_mem_config(output_mem_config), output_dtype(output_dtype), input_tensor_shape(input_tensor_shape),
             use_shallow_conv_variant(use_shallow_conv_variant),
             transpose_mcast(transpose_mcast),
-            compute_kernel_config(compute_kernel_config) {}
+            compute_kernel_config(compute_kernel_config),
+            enable_act_doule_buffer(enable_act_doule_buffer) {}
 
     void validate(const std::vector<Tensor>& input_tensors, const std::vector<std::optional<const Tensor>>& optional_input_tensors) const;
     std::vector<Shape> compute_output_shapes(const std::vector<Tensor>& input_tensors) const;
@@ -140,7 +143,8 @@ Tensor optimized_conv(const Tensor& a, const Tensor &b, std::optional<const Tens
     std::optional<std::array<std::uint32_t, 4>> input_tensor_shape = std::nullopt,
     bool use_shallow_conv_variant = false,
     bool tranpose_mcast = true,
-    std::optional<const DeviceComputeKernelConfig> compute_kernel_config = std::nullopt
+    std::optional<const DeviceComputeKernelConfig> compute_kernel_config = std::nullopt,
+    bool enable_act_doule_buffer = false
 );
 
 // new micro op
@@ -157,6 +161,7 @@ struct OptimizedConvNew {
     std::array<std::uint32_t, 4> input_tensor_shape; // For sharded input, input tensor shape is nonsense
     bool use_shallow_conv_variant;
     const DeviceComputeKernelConfig compute_kernel_config;
+    bool enable_act_doule_buffer;
     OptimizedConvNew(const vector<int>& c_params,
         uint32_t output_channels, bool untile_out,
         bool has_bias, bool fuse_relu,
@@ -165,7 +170,7 @@ struct OptimizedConvNew {
         uint32_t e_padding_for_32B_alignment, MemoryConfig out_mem_config,
         DataType output_dtype,
         std::array<std::uint32_t, 4> input_tensor_shape, bool use_shallow_conv_variant,
-        const DeviceComputeKernelConfig compute_kernel_config) :
+        const DeviceComputeKernelConfig compute_kernel_config, bool enable_act_doule_buffer) :
             output_channels(output_channels),
             conv_params(c_params),
             untilize_out(untile_out),
@@ -178,7 +183,8 @@ struct OptimizedConvNew {
             output_mem_config(out_mem_config),
             output_dtype(output_dtype), input_tensor_shape(input_tensor_shape),
             use_shallow_conv_variant(use_shallow_conv_variant),
-            compute_kernel_config(compute_kernel_config) {}
+            compute_kernel_config(compute_kernel_config),
+            enable_act_doule_buffer(enable_act_doule_buffer) {}
 
     void validate(const std::vector<Tensor>& input_tensors, const std::vector<std::optional<const Tensor>>& optional_input_tensors) const;
     std::vector<Shape> compute_output_shapes(const std::vector<Tensor>& input_tensors) const;
@@ -227,7 +233,8 @@ Tensor optimized_conv_new(const Tensor& a, const Tensor &b, std::optional<const 
     DataType output_dtype,
     std::array<std::uint32_t, 4> input_tensor_shape,
     bool use_shallow_conv_variant,
-    std::optional<const DeviceComputeKernelConfig> compute_kernel_config = std::nullopt
+    std::optional<const DeviceComputeKernelConfig> compute_kernel_config = std::nullopt,
+    bool enable_act_doule_buffer = false
 );
 
 }  // namespace tt_metal

--- a/tt_eager/tt_dnn/op_library/conv/optimized_conv_op.hpp
+++ b/tt_eager/tt_dnn/op_library/conv/optimized_conv_op.hpp
@@ -42,7 +42,7 @@ struct OptimizedConvBlockConfig {
 
 operation::ProgramWithCallbacks multi_core_optimized_conv_(const Tensor& a, const Tensor &b, const Shape& ashape, std::optional<const Tensor> bias, vector<int> conv_params, uint32_t output_channels, bool untilize_out, bool has_bias, bool fuse_relu, const MathFidelity math_fidelity, const OptimizedConvParallelizationConfig& parallelization_config, const OptimizedConvBlockConfig& block_config, uint32_t extra_padding_for_32B_alignment, Tensor &output);
 operation::ProgramWithCallbacks multi_core_optimized_conv_sharded_(const Tensor& a, const Tensor &b, const Shape& ashape, std::optional<const Tensor> bias, vector<int> conv_params, uint32_t output_channels, bool untilize_out, bool has_bias, bool fuse_relu, const MathFidelity math_fidelity, const OptimizedConvParallelizationConfig& parallelization_config, const OptimizedConvBlockConfig& block_config, uint32_t extra_padding_for_32B_alignment, Tensor &output);
-operation::ProgramWithCallbacks multi_core_optimized_conv_sharded_v2_(const Tensor& a, const Tensor &b, const Shape& ashape, std::optional<const Tensor> bias, const std::optional<const Tensor> conv_reader_indices, vector<int> conv_params, uint32_t output_channels, bool untilize_out, bool has_bias, bool fuse_relu, const OptimizedConvParallelizationConfig& parallelization_config, const OptimizedConvBlockConfig& block_config, uint32_t extra_padding_for_32B_alignment, bool use_shallow_conv_variant, bool transpose_mcast, Tensor &output, DeviceComputeKernelConfig compute_kernel_config, bool enable_act_doule_buffer, bool enable_split_reader, bool enable_subblock_padding);
+operation::ProgramWithCallbacks multi_core_optimized_conv_sharded_v2_(const Tensor& a, const Tensor &b, const Shape& ashape, std::optional<const Tensor> bias, const std::optional<const Tensor> conv_reader_indices, vector<int> conv_params, uint32_t output_channels, bool untilize_out, bool has_bias, bool fuse_relu, const OptimizedConvParallelizationConfig& parallelization_config, const OptimizedConvBlockConfig& block_config, uint32_t extra_padding_for_32B_alignment, bool use_shallow_conv_variant, bool transpose_mcast, Tensor &output, DeviceComputeKernelConfig compute_kernel_config, bool enable_act_double_buffer, bool enable_split_reader, bool enable_subblock_padding);
 operation::ProgramWithCallbacks multi_core_optimized_conv_sharded_v2_new(const Tensor& a, const Tensor &b, std::optional<const Tensor> bias,
     vector<int> conv_params,
     uint32_t output_channels,
@@ -54,7 +54,7 @@ operation::ProgramWithCallbacks multi_core_optimized_conv_sharded_v2_new(const T
     bool use_shallow_conv_variant,
     std::optional<const DeviceComputeKernelConfig> compute_kernel_config,
     Tensor& output,
-    bool enable_act_doule_buffer,
+    bool enable_act_double_buffer,
     bool enable_split_reader,
     bool enable_subblock_padding);
 
@@ -73,7 +73,7 @@ struct OptimizedConv {
     bool use_shallow_conv_variant;
     bool transpose_mcast;   // default for GS = true, WH = false
     const DeviceComputeKernelConfig compute_kernel_config;
-    bool enable_act_doule_buffer;
+    bool enable_act_double_buffer;
     bool enable_split_reader;
     bool enable_subblock_padding;
     OptimizedConv(const std::vector<int>&c_params,
@@ -82,7 +82,7 @@ struct OptimizedConv {
         MathFidelity mfidelity, const OptimizedConvParallelizationConfig& p_config,
         const OptimizedConvBlockConfig& b_config,
         uint32_t e_padding_for_32B_alignment,
-        MemoryConfig output_mem_config, DataType output_dtype, Shape input_tensor_shape, bool use_shallow_conv_variant, bool transpose_mcast, const DeviceComputeKernelConfig compute_kernel_config, bool enable_act_doule_buffer, bool enable_split_reader, bool enable_subblock_padding) :
+        MemoryConfig output_mem_config, DataType output_dtype, Shape input_tensor_shape, bool use_shallow_conv_variant, bool transpose_mcast, const DeviceComputeKernelConfig compute_kernel_config, bool enable_act_double_buffer, bool enable_split_reader, bool enable_subblock_padding) :
             output_channels(output_channels),
             conv_params(c_params),
             untilize_out(untile_out),
@@ -96,7 +96,7 @@ struct OptimizedConv {
             use_shallow_conv_variant(use_shallow_conv_variant),
             transpose_mcast(transpose_mcast),
             compute_kernel_config(compute_kernel_config),
-            enable_act_doule_buffer(enable_act_doule_buffer),
+            enable_act_double_buffer(enable_act_double_buffer),
             enable_split_reader(enable_split_reader),
             enable_subblock_padding(enable_subblock_padding) {}
 
@@ -121,7 +121,7 @@ struct OptimizedConv {
         "output_dtype",
         "input_tensor_shape",
         "use_shallow_conv_variant",
-        "enable_act_doule_buffer",
+        "enable_act_double_buffer",
         "enable_split_reader",
         "enable_subblock_padding");
     const auto attribute_values() const {
@@ -139,7 +139,7 @@ struct OptimizedConv {
             std::cref(this->output_dtype),
             std::cref(this->input_tensor_shape),
             std::cref(this->use_shallow_conv_variant),
-            std::cref(this->enable_act_doule_buffer),
+            std::cref(this->enable_act_double_buffer),
             std::cref(this->enable_split_reader),
             std::cref(this->enable_subblock_padding));
     }
@@ -156,7 +156,7 @@ Tensor optimized_conv(const Tensor& a, const Tensor &b, std::optional<const Tens
     bool use_shallow_conv_variant = false,
     bool tranpose_mcast = true,
     std::optional<const DeviceComputeKernelConfig> compute_kernel_config = std::nullopt,
-    bool enable_act_doule_buffer = false,
+    bool enable_act_double_buffer = false,
     bool enable_split_reader = false,
     bool enable_subblock_padding = false
 );
@@ -175,7 +175,7 @@ struct OptimizedConvNew {
     std::array<std::uint32_t, 4> input_tensor_shape; // For sharded input, input tensor shape is nonsense
     bool use_shallow_conv_variant;
     const DeviceComputeKernelConfig compute_kernel_config;
-    bool enable_act_doule_buffer;
+    bool enable_act_double_buffer;
     bool enable_split_reader;
     bool enable_subblock_padding;
     OptimizedConvNew(const vector<int>& c_params,
@@ -186,7 +186,7 @@ struct OptimizedConvNew {
         uint32_t e_padding_for_32B_alignment, MemoryConfig out_mem_config,
         DataType output_dtype,
         std::array<std::uint32_t, 4> input_tensor_shape, bool use_shallow_conv_variant,
-        const DeviceComputeKernelConfig compute_kernel_config, bool enable_act_doule_buffer, bool enable_split_reader, bool enable_subblock_padding) :
+        const DeviceComputeKernelConfig compute_kernel_config, bool enable_act_double_buffer, bool enable_split_reader, bool enable_subblock_padding) :
             output_channels(output_channels),
             conv_params(c_params),
             untilize_out(untile_out),
@@ -200,7 +200,7 @@ struct OptimizedConvNew {
             output_dtype(output_dtype), input_tensor_shape(input_tensor_shape),
             use_shallow_conv_variant(use_shallow_conv_variant),
             compute_kernel_config(compute_kernel_config),
-            enable_act_doule_buffer(enable_act_doule_buffer),
+            enable_act_double_buffer(enable_act_double_buffer),
             enable_split_reader(enable_split_reader),
             enable_subblock_padding(enable_subblock_padding) {}
 
@@ -224,7 +224,7 @@ struct OptimizedConvNew {
         "output_dtype",
         "input_tensor_shape",
         "use_shallow_conv_variant",
-        "enable_act_doule_buffer",
+        "enable_act_double_buffer",
         "enable_split_reader",
         "enable_subblock_padding");
     const auto attribute_values() const {
@@ -241,7 +241,7 @@ struct OptimizedConvNew {
             std::cref(this->output_dtype),
             std::cref(this->input_tensor_shape),
             std::cref(this->use_shallow_conv_variant),
-            std::cref(this->enable_act_doule_buffer),
+            std::cref(this->enable_act_double_buffer),
             std::cref(this->enable_split_reader),
             std::cref(this->enable_subblock_padding));
     }
@@ -258,7 +258,7 @@ Tensor optimized_conv_new(const Tensor& a, const Tensor &b, std::optional<const 
     std::array<std::uint32_t, 4> input_tensor_shape,
     bool use_shallow_conv_variant,
     std::optional<const DeviceComputeKernelConfig> compute_kernel_config = std::nullopt,
-    bool enable_act_doule_buffer = false,
+    bool enable_act_double_buffer = false,
     bool enable_split_reader = false,
     bool enable_subblock_padding = false
 );

--- a/tt_eager/tt_dnn/op_library/conv/optimized_conv_op.hpp
+++ b/tt_eager/tt_dnn/op_library/conv/optimized_conv_op.hpp
@@ -114,7 +114,8 @@ struct OptimizedConv {
         "output_mem_config",
         "output_dtype",
         "input_tensor_shape",
-        "use_shallow_conv_variant");
+        "use_shallow_conv_variant",
+        "enable_act_doule_buffer");
     const auto attribute_values() const {
         return std::make_tuple(
             std::cref(this->parallelization_config),
@@ -129,7 +130,8 @@ struct OptimizedConv {
             std::cref(this->output_mem_config),
             std::cref(this->output_dtype),
             std::cref(this->input_tensor_shape),
-            std::cref(this->use_shallow_conv_variant));
+            std::cref(this->use_shallow_conv_variant),
+            std::cref(this->enable_act_doule_buffer));
     }
 };
 
@@ -205,7 +207,8 @@ struct OptimizedConvNew {
         "extra_padding_for_32B_alignment",
         "output_dtype",
         "input_tensor_shape",
-        "use_shallow_conv_variant");
+        "use_shallow_conv_variant",
+        "enable_act_doule_buffer");
     const auto attribute_values() const {
         return std::make_tuple(
             std::cref(this->parallelization_config),
@@ -219,7 +222,8 @@ struct OptimizedConvNew {
             std::cref(this->extra_padding_for_32B_alignment),
             std::cref(this->output_dtype),
             std::cref(this->input_tensor_shape),
-            std::cref(this->use_shallow_conv_variant));
+            std::cref(this->use_shallow_conv_variant),
+            std::cref(this->enable_act_doule_buffer));
     }
 };
 

--- a/tt_eager/tt_lib/csrc/tt_lib_bindings_tensor.cpp
+++ b/tt_eager/tt_lib/csrc/tt_lib_bindings_tensor.cpp
@@ -499,6 +499,7 @@ void TensorModule(py::module& m_tensor) {
         py::arg("use_shallow_conv_variant").noconvert() = false,
         py::arg("transpose_mcast").noconvert() = true,
         py::arg("compute_kernel_config").noconvert() = std::nullopt,
+        py::arg("enable_act_doule_buffer").noconvert() = false,
         R"doc(
         Perform a conv ``A x B`` with two tensors
         This op tilizes tensor A and untilizes the output

--- a/tt_eager/tt_lib/csrc/tt_lib_bindings_tensor.cpp
+++ b/tt_eager/tt_lib/csrc/tt_lib_bindings_tensor.cpp
@@ -499,7 +499,7 @@ void TensorModule(py::module& m_tensor) {
         py::arg("use_shallow_conv_variant").noconvert() = false,
         py::arg("transpose_mcast").noconvert() = true,
         py::arg("compute_kernel_config").noconvert() = std::nullopt,
-        py::arg("enable_act_doule_buffer").noconvert() = false,
+        py::arg("enable_act_double_buffer").noconvert() = false,
         py::arg("enable_split_reader").noconvert() = false,
         py::arg("enable_subblock_padding").noconvert() = false,
         R"doc(

--- a/tt_eager/tt_lib/csrc/tt_lib_bindings_tensor.cpp
+++ b/tt_eager/tt_lib/csrc/tt_lib_bindings_tensor.cpp
@@ -500,6 +500,8 @@ void TensorModule(py::module& m_tensor) {
         py::arg("transpose_mcast").noconvert() = true,
         py::arg("compute_kernel_config").noconvert() = std::nullopt,
         py::arg("enable_act_doule_buffer").noconvert() = false,
+        py::arg("enable_split_reader").noconvert() = false,
+        py::arg("enable_subblock_padding").noconvert() = false,
         R"doc(
         Perform a conv ``A x B`` with two tensors
         This op tilizes tensor A and untilizes the output

--- a/ttnn/cpp/pybind11/operations/conv2d.hpp
+++ b/ttnn/cpp/pybind11/operations/conv2d.hpp
@@ -76,7 +76,7 @@ void py_module(py::module& module) {
             py::arg("core_grid") = std::nullopt,
             py::arg("transpose_shards") = true,
             py::arg("output_layout") = Layout::TILE,
-            py::arg("enable_act_doule_buffer") = false,
+            py::arg("enable_act_double_buffer") = false,
             py::arg("enable_split_reader") = false,
             py::arg("enable_subblock_padding") = false
         );
@@ -97,7 +97,7 @@ void py_module(py::module& module) {
         py_conv_config.def_readwrite("core_grid", &Conv2dConfig::core_grid);
         py_conv_config.def_readwrite("transpose_shards", &Conv2dConfig::transpose_shards);
         py_conv_config.def_readwrite("output_layout", &Conv2dConfig::output_layout);
-        py_conv_config.def_readwrite("enable_act_doule_buffer", &Conv2dConfig::enable_act_doule_buffer);
+        py_conv_config.def_readwrite("enable_act_double_buffer", &Conv2dConfig::enable_act_double_buffer);
         py_conv_config.def_readwrite("enable_split_reader", &Conv2dConfig::enable_split_reader);
         py_conv_config.def_readwrite("enable_subblock_padding", &Conv2dConfig::enable_subblock_padding);
 

--- a/ttnn/cpp/pybind11/operations/conv2d.hpp
+++ b/ttnn/cpp/pybind11/operations/conv2d.hpp
@@ -57,7 +57,7 @@ void py_module(py::module& module) {
 
     auto py_conv_config = py::class_<Conv2dConfig>(module, "Conv2dConfig");
     py_conv_config.def(
-            py::init<MathFidelity, DataType, DataType, bool, bool, bool, string, uint32_t, bool, bool, uint32_t, bool, bool, bool, std::optional<CoreRangeSet>, bool, Layout, bool>(),
+            py::init<MathFidelity, DataType, DataType, bool, bool, bool, string, uint32_t, bool, bool, uint32_t, bool, bool, bool, std::optional<CoreRangeSet>, bool, Layout, bool, bool, bool>(),
             py::kw_only(),
             py::arg("math_fidelity") = MathFidelity::HiFi4,
             py::arg("dtype") = DataType::BFLOAT16,
@@ -76,7 +76,9 @@ void py_module(py::module& module) {
             py::arg("core_grid") = std::nullopt,
             py::arg("transpose_shards") = true,
             py::arg("output_layout") = Layout::TILE,
-            py::arg("enable_act_doule_buffer") = false
+            py::arg("enable_act_doule_buffer") = false,
+            py::arg("enable_split_reader") = false,
+            py::arg("enable_subblock_padding") = false
         );
         py_conv_config.def_readwrite("math_fidelity", &Conv2dConfig::math_fidelity);
         py_conv_config.def_readwrite("dtype", &Conv2dConfig::dtype);
@@ -96,6 +98,8 @@ void py_module(py::module& module) {
         py_conv_config.def_readwrite("transpose_shards", &Conv2dConfig::transpose_shards);
         py_conv_config.def_readwrite("output_layout", &Conv2dConfig::output_layout);
         py_conv_config.def_readwrite("enable_act_doule_buffer", &Conv2dConfig::enable_act_doule_buffer);
+        py_conv_config.def_readwrite("enable_split_reader", &Conv2dConfig::enable_split_reader);
+        py_conv_config.def_readwrite("enable_subblock_padding", &Conv2dConfig::enable_subblock_padding);
 
     module.def(
         "get_conv_padded_input_shape_and_mem_config",

--- a/ttnn/cpp/pybind11/operations/conv2d.hpp
+++ b/ttnn/cpp/pybind11/operations/conv2d.hpp
@@ -57,7 +57,7 @@ void py_module(py::module& module) {
 
     auto py_conv_config = py::class_<Conv2dConfig>(module, "Conv2dConfig");
     py_conv_config.def(
-            py::init<MathFidelity, DataType, DataType, bool, bool, bool, string, uint32_t, bool, bool, uint32_t, bool, bool, bool, std::optional<CoreRangeSet>, bool, Layout>(),
+            py::init<MathFidelity, DataType, DataType, bool, bool, bool, string, uint32_t, bool, bool, uint32_t, bool, bool, bool, std::optional<CoreRangeSet>, bool, Layout, bool>(),
             py::kw_only(),
             py::arg("math_fidelity") = MathFidelity::HiFi4,
             py::arg("dtype") = DataType::BFLOAT16,
@@ -75,7 +75,8 @@ void py_module(py::module& module) {
             py::arg("height_sharding") = true,
             py::arg("core_grid") = std::nullopt,
             py::arg("transpose_shards") = true,
-            py::arg("output_layout") = Layout::TILE
+            py::arg("output_layout") = Layout::TILE,
+            py::arg("enable_act_doule_buffer") = false
         );
         py_conv_config.def_readwrite("math_fidelity", &Conv2dConfig::math_fidelity);
         py_conv_config.def_readwrite("dtype", &Conv2dConfig::dtype);
@@ -94,6 +95,7 @@ void py_module(py::module& module) {
         py_conv_config.def_readwrite("core_grid", &Conv2dConfig::core_grid);
         py_conv_config.def_readwrite("transpose_shards", &Conv2dConfig::transpose_shards);
         py_conv_config.def_readwrite("output_layout", &Conv2dConfig::output_layout);
+        py_conv_config.def_readwrite("enable_act_doule_buffer", &Conv2dConfig::enable_act_doule_buffer);
 
     module.def(
         "get_conv_padded_input_shape_and_mem_config",

--- a/ttnn/cpp/ttnn/operations/conv2d.cpp
+++ b/ttnn/cpp/ttnn/operations/conv2d.cpp
@@ -679,7 +679,9 @@ std::tuple<ttnn::Tensor, uint32_t, uint32_t, ttnn::Tensor, std::optional<ttnn::T
             {batch_size, input_height, input_width, in_channels},
             conv_config.input_channels_alignment == 16,
             compute_kernel_config,
-            conv_config.enable_act_doule_buffer);
+            conv_config.enable_act_doule_buffer,
+            conv_config.enable_split_reader,
+            conv_config.enable_subblock_padding);
         // halo_output.deallocate();
         ttnn::operations::core::deallocate(halo_output);
         return {conv_output, output_height, output_width, weight_tensor_on_device, bias_tensor_on_device};

--- a/ttnn/cpp/ttnn/operations/conv2d.cpp
+++ b/ttnn/cpp/ttnn/operations/conv2d.cpp
@@ -679,7 +679,7 @@ std::tuple<ttnn::Tensor, uint32_t, uint32_t, ttnn::Tensor, std::optional<ttnn::T
             {batch_size, input_height, input_width, in_channels},
             conv_config.input_channels_alignment == 16,
             compute_kernel_config,
-            conv_config.enable_act_doule_buffer,
+            conv_config.enable_act_double_buffer,
             conv_config.enable_split_reader,
             conv_config.enable_subblock_padding);
         // halo_output.deallocate();

--- a/ttnn/cpp/ttnn/operations/conv2d.cpp
+++ b/ttnn/cpp/ttnn/operations/conv2d.cpp
@@ -678,7 +678,8 @@ std::tuple<ttnn::Tensor, uint32_t, uint32_t, ttnn::Tensor, std::optional<ttnn::T
             conv_config.dtype,
             {batch_size, input_height, input_width, in_channels},
             conv_config.input_channels_alignment == 16,
-            compute_kernel_config);
+            compute_kernel_config,
+            conv_config.enable_act_doule_buffer);
         // halo_output.deallocate();
         ttnn::operations::core::deallocate(halo_output);
         return {conv_output, output_height, output_width, weight_tensor_on_device, bias_tensor_on_device};

--- a/ttnn/cpp/ttnn/operations/conv2d.hpp
+++ b/ttnn/cpp/ttnn/operations/conv2d.hpp
@@ -43,7 +43,7 @@ struct Conv2dConfig {
     std::optional<CoreRangeSet> core_grid = std::nullopt; // used only if override_sharding_config is true
     bool transpose_shards = true; // used only if override_sharding_config is true and if height sharding is false
     Layout output_layout = Layout::TILE;
-    bool enable_act_doule_buffer = false;
+    bool enable_act_double_buffer = false;
     bool enable_split_reader = false;
     bool enable_subblock_padding = false;
     static constexpr auto attribute_names = std::make_tuple(
@@ -64,7 +64,7 @@ struct Conv2dConfig {
         "core_grid",
         "transpose_shards",
         "output_layout",
-        "enable_act_doule_buffer",
+        "enable_act_double_buffer",
         "enable_split_reader",
         "enable_subblock_padding");
     const auto attribute_values() const {
@@ -86,7 +86,7 @@ struct Conv2dConfig {
             std::cref(this->core_grid),
             std::cref(this->transpose_shards),
             std::cref(this->output_layout),
-            std::cref(this->enable_act_doule_buffer),
+            std::cref(this->enable_act_double_buffer),
             std::cref(this->enable_split_reader),
             std::cref(this->enable_subblock_padding));
     }

--- a/ttnn/cpp/ttnn/operations/conv2d.hpp
+++ b/ttnn/cpp/ttnn/operations/conv2d.hpp
@@ -43,6 +43,7 @@ struct Conv2dConfig {
     std::optional<CoreRangeSet> core_grid = std::nullopt; // used only if override_sharding_config is true
     bool transpose_shards = true; // used only if override_sharding_config is true and if height sharding is false
     Layout output_layout = Layout::TILE;
+    bool enable_act_doule_buffer = false;
     static constexpr auto attribute_names = std::make_tuple(
         "math_fidelity",
         "dtype",
@@ -60,7 +61,8 @@ struct Conv2dConfig {
         "height_sharding",
         "core_grid",
         "transpose_shards",
-        "output_layout");
+        "output_layout",
+        "enable_act_doule_buffer");
     const auto attribute_values() const {
         return std::make_tuple(
             std::cref(this->math_fidelity),
@@ -79,7 +81,8 @@ struct Conv2dConfig {
             std::cref(this->height_sharding),
             std::cref(this->core_grid),
             std::cref(this->transpose_shards),
-            std::cref(this->output_layout));
+            std::cref(this->output_layout),
+            std::cref(this->enable_act_doule_buffer));
     }
 };
 

--- a/ttnn/cpp/ttnn/operations/conv2d.hpp
+++ b/ttnn/cpp/ttnn/operations/conv2d.hpp
@@ -44,6 +44,8 @@ struct Conv2dConfig {
     bool transpose_shards = true; // used only if override_sharding_config is true and if height sharding is false
     Layout output_layout = Layout::TILE;
     bool enable_act_doule_buffer = false;
+    bool enable_split_reader = false;
+    bool enable_subblock_padding = false;
     static constexpr auto attribute_names = std::make_tuple(
         "math_fidelity",
         "dtype",
@@ -62,7 +64,9 @@ struct Conv2dConfig {
         "core_grid",
         "transpose_shards",
         "output_layout",
-        "enable_act_doule_buffer");
+        "enable_act_doule_buffer",
+        "enable_split_reader",
+        "enable_subblock_padding");
     const auto attribute_values() const {
         return std::make_tuple(
             std::cref(this->math_fidelity),
@@ -82,7 +86,9 @@ struct Conv2dConfig {
             std::cref(this->core_grid),
             std::cref(this->transpose_shards),
             std::cref(this->output_layout),
-            std::cref(this->enable_act_doule_buffer));
+            std::cref(this->enable_act_doule_buffer),
+            std::cref(this->enable_split_reader),
+            std::cref(this->enable_subblock_padding));
     }
 };
 


### PR DESCRIPTION
### Ticket
[Link to Github Issue](https://github.com/tenstorrent/tt-metal/issues/10277)

### Problem description
WH device perf is low, especially on first layer. new perf at 5500fps (main is 4700)

### What's changed
three OPTs: padding on subblock size, uneven split reader for in0, double buffer in0

### Checklist
- [x] Post commit CI pass https://github.com/tenstorrent/tt-metal/actions/runs/9944145069/job/27471478816
