### PR TITLE
Prefill+Decode Demo Functional Implementation 

### DIFF
--- a/models/demos/mamba/demo/demo.py
+++ b/models/demos/mamba/demo/demo.py
@@ -13,6 +13,8 @@ from tqdm import tqdm
 from transformers import AutoTokenizer
 
 from models.demos.mamba.reference.decode_model import MambaPretrainedModelName
+from models.demos.mamba.reference.args import ModelMode
+from models.demos.mamba.tt import model_config
 
 
 def get_cpu_reference_model(version: MambaPretrainedModelName, batch_size: int):
@@ -22,13 +24,18 @@ def get_cpu_reference_model(version: MambaPretrainedModelName, batch_size: int):
 
 
 def get_tt_metal_model(
-    version: MambaPretrainedModelName, device: ttnn.Device, cache_dir: Optional[str] = None, batch_size: int = 32
+    version: MambaPretrainedModelName,
+    device: ttnn.Device,
+    cache_dir: Optional[str] = None,
+    batch_size: int = 32,
+    mode: ModelMode = ModelMode.DECODE,
+    seq_len: int = 1,
 ):
     from models.demos.mamba.tt.full_model import MambaTT
     from models.demos.mamba.tt import model_config
 
     reference_model = get_cpu_reference_model(version, batch_size=batch_size)
-    config = model_config.create_model_config(batch_size, reference_model.args.d_model)
+    config = model_config.create_model_config(batch_size, reference_model.args.d_model, mode=mode, seq_len=seq_len)
     model = MambaTT(reference_model, device, config, tt_cache_path=cache_dir)
 
     return model
@@ -107,6 +114,68 @@ def run_mamba_demo(
         with torch.no_grad():
             start = time.time()
             logits = model(sequences[:, idx].unsqueeze(1))
+            end = time.time()
+
+        logits = apply_repetition_penalty_(logits.squeeze(1), sequences, penalty=1.2)  # Adjust penalty as needed
+        probs = torch.nn.functional.softmax(logits, dim=-1)
+        next_token = torch.argmax(probs, dim=-1)
+
+        sequences = torch.cat([sequences, next_token.unsqueeze(-1)], dim=1)
+        decoded = tokenizer.batch_decode(sequences, skip_special_tokens=False)
+
+        throughput = batch_size / (end - start)
+
+        if display:
+            display_tokens(decoded)
+            print(f"Current total throughput: {throughput:.2f} tok/s")
+            print(f"Current throughput per user: {(throughput/batch_size):.2f} tok/s/u")
+
+
+def run_mamba_prefill_decode_demo(
+    prompts: List[str],
+    device: ttnn.Device,
+    model_version: MambaPretrainedModelName = "state-spaces/mamba-2.8b-slimpj",
+    batch_size: int = 32,
+    generated_sequence_length: int = 50,
+    cache_dir: Optional[str] = None,
+    display: bool = True,
+):
+    if len(prompts) == 1:
+        prompts = prompts * batch_size  # Duplicate the prompt to fill the batch
+
+    assert batch_size == len(prompts), "32 prompts are required"
+
+    tokenizer = get_tokenizer()
+    sequences: torch.Tensor = tokenizer(prompts, return_tensors="pt", padding=True).input_ids
+    prefill_length = sequences.shape[1] - 1
+    logger.info(f"Prefilling the prompt(s) with {prefill_length} tokens...")
+
+    logger.info(f"Running Mamba demo (weights='{model_version}') with batch={batch_size}")
+    logger.info(f"Using tensor cache at '{cache_dir}'")
+    model = get_tt_metal_model(
+        model_version, device, cache_dir, batch_size=1, mode=ModelMode.PREFILL, seq_len=prefill_length
+    )
+    model.eval()
+
+    # Prefill
+    model.to_prefill()
+    num_users = sequences.shape[0]
+    for user_idx in tqdm(range(num_users), desc="Prefilling the prompt(s)..."):
+        with torch.no_grad():
+            model(sequences[user_idx, :-1].unsqueeze(0))  # Omit the last token in the sequence
+
+    # Decode
+    decode_model_config = model_config.create_model_config(
+        batch_size, model.args.d_model, mode=ModelMode.DECODE, seq_len=1
+    )
+    model.to_decode(decode_model_config)
+
+    total_length = prefill_length + generated_sequence_length
+    logger.info("Starting decoding...")
+    for token_idx in range(prefill_length, total_length):
+        with torch.no_grad():
+            start = time.time()
+            logits = model(sequences[:, token_idx].unsqueeze(1))
             end = time.time()
 
         logits = apply_repetition_penalty_(logits.squeeze(1), sequences, penalty=1.2)  # Adjust penalty as needed

--- a/models/demos/mamba/tests/test_mamba_demo.py
+++ b/models/demos/mamba/tests/test_mamba_demo.py
@@ -2,7 +2,7 @@
 
 # SPDX-License-Identifier: Apache-2.0
 
-from models.demos.mamba.demo.demo import run_mamba_demo
+from models.demos.mamba.demo.demo import run_mamba_demo, run_mamba_prefill_decode_demo
 import pytest
 
 
@@ -13,6 +13,30 @@ import pytest
 )
 def test_demo(user_input, model_version, device, use_program_cache, get_tt_cache_path, max_gen_len):
     return run_mamba_demo(
+        prompts=user_input,
+        model_version=model_version,
+        device=device,
+        generated_sequence_length=max_gen_len,
+        display=False,
+        cache_dir=get_tt_cache_path(model_version),
+    )
+
+
+@pytest.mark.timeout(1200)
+@pytest.mark.parametrize(
+    "user_input, model_version, max_gen_len",
+    (
+        (
+            [
+                "Climate change refers to long-term shifts in temperatures and weather patterns. Such shifts can be natural due to changes in the sun's activity or volcanic eruptions."
+            ],
+            "state-spaces/mamba-2.8b-slimpj",
+            2,
+        ),
+    ),
+)
+def test_prefill_decode_demo(user_input, model_version, device, use_program_cache, get_tt_cache_path, max_gen_len):
+    return run_mamba_prefill_decode_demo(
         prompts=user_input,
         model_version=model_version,
         device=device,

--- a/models/demos/mamba/tt/full_model.py
+++ b/models/demos/mamba/tt/full_model.py
@@ -81,6 +81,7 @@ class MambaTT(torch.nn.Module):
         self.device = device
         self.tt_cache_path = tt_cache_path
         self.configs = configs
+        self.return_logits = True
 
         if num_layers is None:
             self.num_layers = len(reference_model.layers)
@@ -112,6 +113,15 @@ class MambaTT(torch.nn.Module):
             fp32_dest_acc_en=True,
         )
 
+    def to_prefill(self):
+        self.return_logits = False
+
+    def to_decode(self, decode_config):
+        self.configs = decode_config
+        self.return_logits = True
+        for i in range(self.num_layers):
+            self.layers[i].to_decode(decode_config)
+
     def forward(self, x):
         assert len(x.shape) == 2, f"Mamba expects inputs to be rank 2 (was {len(x.shape)})"
 
@@ -132,26 +142,25 @@ class MambaTT(torch.nn.Module):
             # print(f"Running layer {i}")
             x = layer(x)
 
-        x = ttnn.experimental.tensor.interleaved_to_sharded(x, sharded_mem_config=self.configs["sharded_h"])
-        x = ttnn.rms_norm(
-            x,
-            epsilon=self.args.eps,
-            weight=self.norm_f_weights,
-            program_config=self.configs["SHARDED_NORM_PRGM_CFG"],
-            memory_config=self.configs["sharded_h"],
-        )
-        x = ttnn.experimental.tensor.sharded_to_interleaved(x)
-        x = ttnn.linear(
-            x,
-            self.lm_head_weights,
-            memory_config=ttnn.L1_MEMORY_CONFIG,
-            core_grid=x.device().core_grid,
-            compute_kernel_config=self.compute_kernel_config,
-            dtype=self.configs["dtype"]["activations"],
-        )
+        if self.return_logits or self.configs["mode"] == ModelMode.DECODE:
+            x = ttnn.experimental.tensor.interleaved_to_sharded(x, sharded_mem_config=self.configs["sharded_h"])
+            x = ttnn.rms_norm(
+                x,
+                epsilon=self.args.eps,
+                weight=self.norm_f_weights,
+                program_config=self.configs["SHARDED_NORM_PRGM_CFG"],
+                memory_config=self.configs["sharded_h"],
+            )
+            x = ttnn.experimental.tensor.sharded_to_interleaved(x)
+            x = ttnn.linear(
+                x,
+                self.lm_head_weights,
+                memory_config=ttnn.L1_MEMORY_CONFIG,
+                core_grid=x.device().core_grid,
+                compute_kernel_config=self.compute_kernel_config,
+                dtype=self.configs["dtype"]["activations"],
+            )
+            x = ttnn.to_torch(x).to(torch.float32)  # (1, 1, B, E)
+            x = x.view((self.configs["batch_size"], self.configs["seq_len"], -1))
 
-        x = ttnn.to_torch(x).to(torch.float32)  # (1, 1, B, E)
-
-        x = x.view((self.args.batch_size, self.configs["seq_len"], -1))
-
-        return x
+            return x

--- a/models/demos/mamba/tt/model_config.py
+++ b/models/demos/mamba/tt/model_config.py
@@ -15,6 +15,8 @@ def create_model_config(batch_size, hidden_size, mode=ModelMode.DECODE, seq_len=
     configs["latent_size"] = latent
     configs["mode"] = mode
     configs["seq_len"] = seq_len
+    configs["batch_size"] = batch_size
+    configs["num_users"] = 32  # fixing the number of users to 32 throughout the model
 
     if mode == ModelMode.DECODE:
         outer_dim = batch_size

--- a/models/demos/mamba/tt/residual_block.py
+++ b/models/demos/mamba/tt/residual_block.py
@@ -25,6 +25,10 @@ class TtResidualBlock(torch.nn.Module):
 
         self.tt_mamba_block = TtMambaBlock(self.args, self.device, configs, load_fn)
 
+    def to_decode(self, decode_config):
+        self.configs = decode_config
+        self.tt_mamba_block.to_decode(decode_config)
+
     def forward(self, x):
         assert len(x.shape) == 4, "Mamba residual block expects inputs to be rank 4"
 


### PR DESCRIPTION
### Problem description
Connects prefill and decode mode for the demo. 
It runs prefill in single user mode and collect hidden_states and conv_states caches for all the users on host. Then switch to decode mode and run in batch mode.

### What's changed
1. Added prefill-decode transition helper functions
2. User internal states are cached on host and moved to device before decode.
2. Added prefill-decode demo test
3. Shouldnot affect prefill only or decode only modes
3. Demo functionally working and giving good outputs.

### Next
1. Need to add functionality for running multiple iterations of the demo

### Checklist
- [ ] Post commit CI passes
- [ ] Model regression CI testing passes (if applicable)
- [ ] New/Existing tests provide coverage for changes
