### PR TITLE
#10300: get the correct operation id on subsequent run

### DIFF
--- a/ttnn/cpp/pybind11/__init__.cpp
+++ b/ttnn/cpp/pybind11/__init__.cpp
@@ -43,5 +43,6 @@ PYBIND11_MODULE(_ttnn, module) {
     module.attr("CONFIG") = &ttnn::CONFIG;
 
     module.def("get_operation_id", []() { return ttnn::OPERATION_ID; }, "Get operation id");
+    module.def("set_operation_id", [](int operation_id) { ttnn::OPERATION_ID = operation_id; }, "Set operation id");
     module.def("increment_operation_id", []() { ttnn::OPERATION_ID++; }, "Increment operation id");
 }

--- a/ttnn/ttnn/decorators.py
+++ b/ttnn/ttnn/decorators.py
@@ -390,8 +390,8 @@ class Operation:
                     ttnn.CONFIG.report_path / ttnn.database.OPERATION_HISTORY_JSON
                 )
                 output = function(*function_args, **function_kwargs)
-                if hasattr(ttnn._ttnn.deprecated.operations, "dump_operation_history_to_csv"):
-                    ttnn._ttnn.deprecated.operations.dump_operation_history_to_csv()
+                if hasattr(ttnn._ttnn.deprecated.operations, "dump_operation_history_to_json"):
+                    ttnn._ttnn.deprecated.operations.dump_operation_history_to_json()
                 if original_operation_history_json is not None:
                     os.environ["OPERATION_HISTORY_JSON"] = original_operation_history_json
                 else:
@@ -484,6 +484,12 @@ class Operation:
         def runtime_decorator(function):
             @wraps(function)
             def call_wrapper(*function_args, **function_kwargs):
+                if ttnn.CONFIG.report_path is not None:
+                    previous_operation = ttnn.database.query_latest_operation(ttnn.CONFIG.report_path)
+                    if previous_operation is not None:
+                        operation_id = previous_operation.operation_id + 1
+                        ttnn._ttnn.set_operation_id(operation_id)
+
                 operation_id = ttnn._ttnn.get_operation_id()
                 is_top_level_operation = len(OPERATION_CALL_STACK) == 1
 


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/10300

### Problem description
The database was getting corrupted when running multiple times because it wasn't getting the operation id of the last stored operation

### What's changed
Added `set_operation_id` method and added a function for getting the last stored operation. Use both to set the operation id of currently running operation correctly

### Checklist
- [ ] Post commit CI passes
- [ ] Model regression CI testing passes (if applicable)
- [ ] New/Existing tests provide coverage for changes
