### PR TITLE
bump python 3.8 venv package version

### DIFF
--- a/.github/actions/install-metal-deps/dependencies.json
+++ b/.github/actions/install-metal-deps/dependencies.json
@@ -2,7 +2,7 @@
   "ubuntu-20.04": [
     "software-properties-common=0.99.9.12",
     "build-essential=12.8ubuntu1.1",
-    "python3.8-venv=3.8.10-0ubuntu1~20.04.9",
+    "python3.8-venv=3.8.10-0ubuntu1~20.04.10",
     "libhwloc-dev",
     "graphviz",
     "patchelf"


### PR DESCRIPTION
### Problem description
Eager package failing because [older version of package can't be found](https://github.com/tenstorrent/tt-metal/actions/runs/9946757607/job/27477992827)

### What's changed
bump version of venv package 
