### PR TITLE
fix syntax issue with bisect script

### DIFF
--- a/tests/scripts/tt_bisect.sh
+++ b/tests/scripts/tt_bisect.sh
@@ -18,7 +18,7 @@ source python_env/bin/activate
 export PYTHONPATH=$TT_METAL_HOME
 
 timeout_duration=2m
-while getopts "f:sg:b:t:" opt; do
+while getopts "f:g:b:t:" opt; do
     case $opt in
          f | file)
             test=$OPTARG


### PR DESCRIPTION
### Problem description
There's a problem with parsing of command line options.

### What's changed
Parse command line options properly
