### PR TITLE
#9491: Add overload support for lerp op

### DIFF
--- a/tests/ttnn/unit_tests/operations/test_ternary_composite.py
+++ b/tests/ttnn/unit_tests/operations/test_ternary_composite.py
@@ -48,3 +48,43 @@ def test_ternary_addcdiv_ttnn(input_shapes, value, device):
 
     comp_pass = compare_pcc([output_tensor], [golden_tensor])
     assert comp_pass
+
+
+@pytest.mark.parametrize(
+    "input_shapes",
+    (
+        (torch.Size([1, 1, 32, 32])),
+        (torch.Size([1, 1, 320, 384])),
+        (torch.Size([1, 3, 320, 384])),
+    ),
+)
+@pytest.mark.parametrize("value", [1.0, 5.0, 10.0])
+def test_lerp_overload_ttnn(input_shapes, value, device):
+    in_data1, input_tensor1 = data_gen_with_range(input_shapes, -100, 100, device)
+    in_data2, input_tensor2 = data_gen_with_range(input_shapes, -100, 100, device)
+
+    output_tensor = ttnn.lerp(input_tensor1, input_tensor2, value)
+    golden_tensor = torch.lerp(in_data1, in_data2, value)
+
+    comp_pass = compare_pcc([output_tensor], [golden_tensor])
+    assert comp_pass
+
+
+@pytest.mark.parametrize(
+    "input_shapes",
+    (
+        (torch.Size([1, 1, 32, 32])),
+        (torch.Size([1, 1, 320, 384])),
+        (torch.Size([1, 3, 320, 384])),
+    ),
+)
+def test_lerp_ttnn(input_shapes, device):
+    in_data1, input_tensor1 = data_gen_with_range(input_shapes, -100, 100, device)
+    in_data2, input_tensor2 = data_gen_with_range(input_shapes, -100, 100, device)
+    in_data3, input_tensor3 = data_gen_with_range(input_shapes, -100, 100, device)
+
+    output_tensor = ttnn.lerp(input_tensor1, input_tensor2, input_tensor3)
+    golden_tensor = torch.lerp(in_data1, in_data2, in_data3)
+
+    comp_pass = compare_pcc([output_tensor], [golden_tensor])
+    assert comp_pass

--- a/ttnn/cpp/ttnn/operations/eltwise/ternary/device/ternary_composite_op.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/ternary/device/ternary_composite_op.cpp
@@ -15,7 +15,7 @@
 
 namespace ttnn::operations::ternary{
 
-// addcmul(input,tensor1,tensor2,value)=input+value×tensor1×tensor2
+// addcmul(input,tensor1,tensor2,value)=input value×tensor1×tensor2
 Tensor _addcmul(
     const Tensor& input_a,
     const Tensor& input_b,
@@ -32,7 +32,7 @@ Tensor _addcmul(
     return result;
 }
 
-// addcdiv(input,tensor1,tensor2,value)=input+value×tensor1/tensor2
+// addcdiv(input,tensor1,tensor2,value)=input value×tensor1/tensor2
 Tensor _addcdiv(
     const Tensor& input_a,
     const Tensor& input_b,
@@ -59,4 +59,21 @@ Tensor _addcdiv(
         output_mem_config);
 }
 
-} // namespace ttnn::operations::binary
+// lerp(input, end, weight) = start   weight * (end - start)
+Tensor _lerp_overload(const Tensor& input_a, const Tensor& input_b, float value, const MemoryConfig& output_mem_config) {
+    Tensor t_value =
+        ttnn::operations::creation::create_scalar(value, input_a.get_dtype(), Layout::TILE, input_a.device());
+    Tensor t_diff = ttnn::subtract(input_b, input_a, std::nullopt, output_mem_config);
+    Tensor t_mul = ttnn::multiply(t_diff, t_value, std::nullopt, output_mem_config);
+    Tensor result = ttnn::add(input_a, t_mul, std::nullopt, output_mem_config);
+    return result;
+}
+
+Tensor _lerp(const Tensor& input_a, const Tensor& input_b, const Tensor& input_c, const MemoryConfig& output_mem_config) {
+    Tensor t_diff = ttnn::multiply(
+        ttnn::subtract(input_b, input_a, std::nullopt, output_mem_config), input_c, std::nullopt, output_mem_config);
+    Tensor result = ttnn::add(input_a, t_diff, std::nullopt, output_mem_config);
+    return result;
+}
+
+} // namespace ttnn::operations::ternary

--- a/ttnn/cpp/ttnn/operations/eltwise/ternary/device/ternary_composite_op.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/ternary/device/ternary_composite_op.hpp
@@ -12,21 +12,27 @@ namespace ttnn::operations::ternary{
 enum class TernaryCompositeOpType {
     ADDCMUL,
     ADDCDIV,
+    LERP,
 
 };
 
 Tensor _addcmul(const Tensor&, const Tensor&, const Tensor&, float, const std::optional<MemoryConfig>&);
 Tensor _addcdiv(const Tensor&, const Tensor&, const Tensor&, float, const std::optional<MemoryConfig>&);
+Tensor _lerp(const Tensor&, const Tensor&, const Tensor&, float, const std::optional<MemoryConfig>&);
+Tensor _lerp_overload(const Tensor&, const Tensor&, const Tensor&, float, const std::optional<MemoryConfig>&);
 
 
 template <TernaryCompositeOpType OpType>
 struct OpHandler_Float;
 
+template <TernaryCompositeOpType OpType>
+struct OpHandler_Lerp;
+
 
 template <>
 struct OpHandler_Float<TernaryCompositeOpType::ADDCMUL> {
-    static Tensor handle(const Tensor& t1, const Tensor& t2, const Tensor& t3, float value, const std::optional<MemoryConfig>& mem_cfg) {
-        return _addcmul(t1, t2, t3, alpha, mem_cfg);
+    static Tensor handle(const Tensor& t1, const Tensor& t2, const Tensor& t3, const std::optional<MemoryConfig>& mem_cfg) {
+        return _addcmul(t1, t2, t3, mem_cfg);
     }
 };
 
@@ -37,10 +43,25 @@ struct OpHandler_Float<TernaryCompositeOpType::ADDCDIV> {
     }
 };
 
+template <>
+struct OpHandler_Lerp<TernaryCompositeOpType::LERP> {
+    static Tensor handle(const Tensor& t1, const Tensor& t2, const Tensor& t3, const std::optional<MemoryConfig>& mem_cfg) {
+        return _lerp(t1, t2, t3, mem_cfg);
+    }
+    static Tensor handle(const Tensor& t1, const Tensor& t2, float value, const std::optional<MemoryConfig>& mem_cfg) {
+        return _lerp_overload(t1, t2, value, mem_cfg);
+    }
+};
+
 template <TernaryCompositeOpType OpType>
-auto get_function_type0() {
+auto get_function_type_ternary_with_float() {
     return &OpHandler_Float<OpType>::handle;
 }
 
-
+template <TernaryCompositeOpType OpType>
+auto get_function_type_lerp() {
+    return &OpHandler_Lerp<OpType>::handle;
 }
+
+
+} // namespace ttnn::operations::ternary

--- a/ttnn/cpp/ttnn/operations/eltwise/ternary/ternary_composite.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/ternary/ternary_composite.hpp
@@ -24,10 +24,35 @@ struct ExecuteTernaryCompositeOps
         float value,
         const std::optional<MemoryConfig>& memory_config = std::nullopt)
         {
-            auto op_type = get_function_type0<ternary_comp_op_type>();
+            auto op_type = get_function_type_ternary_with_float<ternary_comp_op_type>();
             return op_type(input_tensor_a, input_tensor_b, input_tensor_c, value, memory_config);
         }
 };
+
+struct ExecuteLerp
+{
+    static Tensor execute_on_worker_thread(
+        const Tensor& input_tensor_a,
+        const Tensor& input_tensor_b,
+        const Tensor& input_tensor_c,
+        const std::optional<MemoryConfig>& memory_config = std::nullopt)
+        {
+            auto op_type = get_function_type_lerp<ternary_comp_op_type>();
+            return op_type(input_tensor_a, input_tensor_b, input_tensor_c, value, memory_config);
+        }
+
+    static Tensor execute_on_worker_thread(
+        const Tensor& input_tensor_a,
+        const Tensor& input_tensor_b,
+        float value,
+        const std::optional<MemoryConfig>& memory_config = std::nullopt)
+        {
+            auto op_type = get_function_type_lerp<ternary_comp_op_type>();
+            return op_type(input_tensor_a, input_tensor_b, value, memory_config);
+        }
+};
+
+
 
 }  // namespace ternary
 }  // namespace operations
@@ -35,6 +60,6 @@ struct ExecuteTernaryCompositeOps
 // newly imported
 constexpr auto addcmul = ttnn::register_operation<operations::ternary::ExecuteTernaryCompositeOps<operations::ternary::TernaryCompositeOpType::ADDCMUL>>("ttnn::addcmul");
 constexpr auto addcdiv = ttnn::register_operation<operations::ternary::ExecuteTernaryCompositeOps<operations::ternary::TernaryCompositeOpType::ADDCDIV>>("ttnn::addcdiv");
-
+constexpr auto lerp = ttnn::register_operation<operations::ternary::ExecuteLerp<operations::ternary::TernaryCompositeOpType::LERP>>("ttnn::lerp");
 
 }  // namespace ttnn

--- a/ttnn/cpp/ttnn/operations/eltwise/ternary/ternary_pybind.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/ternary/ternary_pybind.hpp
@@ -65,6 +65,63 @@ void bind_ternary_composite(py::module& module, const ternary_operation_t& opera
             py::arg("memory_config") = std::nullopt});
 }
 
+template <typename ternary_operation_t>
+void bind_lerp(py::module& module, const ternary_operation_t& operation, const std::string& description) {
+    auto doc = fmt::format(
+        R"doc({0}(input_tensor_a: ttnn.Tensor, input_tensor_b: ttnn.Tensor, input_tensor_c: ttnn.Tensor, *, memory_config: Optional[ttnn.MemoryConfig] = None) -> ttnn.Tensor
+
+            Args:
+                * :attr:`input_tensor_a`
+                * :attr:`input_tensor_b`
+                * :attr:`input_tensor_c` (ttnn.Tensor or Number):
+
+            Keyword Args:
+                * :attr:`memory_config` (Optional[ttnn.MemoryConfig]): Memory configuration for the operation.
+
+            Example:
+
+                >>> tensor1 = ttnn.to_device(ttnn.from_torch(torch.tensor((1, 2), dtype=torch.bfloat16)), device)
+                >>> tensor2 = ttnn.to_device(ttnn.from_torch(torch.tensor((0, 1), dtype=torch.bfloat16)), device)
+                >>> tensor3 = ttnn.to_device(ttnn.from_torch(torch.tensor((0, 1), dtype=torch.bfloat16)), device)
+                >>> output = {1}(tensor1, tensor2, tensor3/scalar)
+        )doc",
+        operation.base_name(),
+        operation.python_fully_qualified_name(),
+        description);
+
+    bind_registered_operation(
+        module,
+        operation,
+        doc,
+        ttnn::pybind_overload_t{
+            [](const ternary_operation_t& self,
+            const Tensor& input_tensor_a,
+            const Tensor& input_tensor_b,
+            const Tensor& input_tensor_c,
+            const std::optional<MemoryConfig>& memory_config) {
+                    return self(input_tensor_a, input_tensor_b, input_tensor_c, memory_config);
+                },
+            py::arg("input_tensor_a"),
+            py::arg("input_tensor_b"),
+            py::arg("input_tensor_c"),
+            py::kw_only(),
+            py::arg("memory_config") = std::nullopt},
+
+        ttnn::pybind_overload_t{
+            [](const ternary_operation_t& self,
+            const Tensor& input_tensor_a,
+            const Tensor& input_tensor_b,
+            float value,
+            const std::optional<MemoryConfig>& memory_config) {
+                    return self(input_tensor_a, input_tensor_b, value, memory_config);
+                },
+            py::arg("input_tensor_a"),
+            py::arg("input_tensor_b"),
+            py::arg("value") = 1.0f,
+            py::kw_only(),
+            py::arg("memory_config") = std::nullopt});
+}
+
 }  // namespace detail
 
 void py_module(py::module& module) {
@@ -80,6 +137,13 @@ void py_module(py::module& module) {
         ttnn::addcdiv,
         R"doc(compute Addcdiv :attr:`input_tensor_a` and :attr:`input_tensor_b` and :attr:`input_tensor_c` and returns the tensor with the same layout as :attr:`input_tensor_a`
         .. math:: \mathrm{{input\_tensor\_a}}_i || \mathrm{{input\_tensor\_b}}_i)doc");
+
+    detail::bind_ternary_composite(
+        module,
+        ttnn::lerp,
+        R"doc(compute Lerp :attr:`input_tensor_a` and :attr:`input_tensor_b` and :attr:`input_tensor_c` and returns the tensor with the same layout as :attr:`input_tensor_a`
+        .. math:: \mathrm{{input\_tensor\_a}}_i || \mathrm{{input\_tensor\_b}}_i)doc");
+
 }
 
 }  // namespace ternary


### PR DESCRIPTION
### Ticket
[Link to Github Issue](https://github.com/tenstorrent/tt-metal/issues/9491)

### Problem description
Move ternary ops to ttnn with overload support

### What's changed

- [x] Lerp
- [x] Mac

### Checklist
- [ ] Post commit CI passes
- [ ] Model regression CI testing passes (if applicable)
- [ ] New/Existing tests provide coverage for changes
