### PR TITLE
#9751: Restructure ttnn transformers to new folder structure

### DIFF
--- a/ttnn/cpp/pybind11/operations/__init__.hpp
+++ b/ttnn/cpp/pybind11/operations/__init__.hpp
@@ -16,7 +16,6 @@
 #include "pybind11/operations/maxpool2d.hpp"
 #include "pybind11/operations/pool.hpp"
 #include "pybind11/operations/ternary.hpp"
-#include "pybind11/operations/transformer.hpp"
 #include "ttnn/operations/eltwise/binary/binary_pybind.hpp"
 #include "ttnn/operations/eltwise/binary_backward/binary_backward_pybind.hpp"
 #include "ttnn/operations/eltwise/unary/unary_pybind.hpp"
@@ -28,6 +27,7 @@
 #include "ttnn/operations/data_movement/data_movement_pybind.hpp"
 #include "ttnn/operations/embedding/embedding_ops_pybind.hpp"
 #include "ttnn/operations/matmul/matmul_pybind.hpp"
+#include "ttnn/operations/transformer/transformer_pybind.hpp"
 
 
 namespace py = pybind11;

--- a/ttnn/cpp/ttnn/operations/reduction/argmax/argmax_pybind.hpp
+++ b/ttnn/cpp/ttnn/operations/reduction/argmax/argmax_pybind.hpp
@@ -9,7 +9,7 @@
 
 #include "ttnn/cpp/pybind11/decorators.hpp"
 
-#include "argmax.hpp"
+#include "ttnn/operations/reduction/argmax/argmax.hpp"
 
 namespace ttnn::operations::reduction::detail {
 namespace py = pybind11;

--- a/ttnn/cpp/ttnn/operations/transformer/transformer.hpp
+++ b/ttnn/cpp/ttnn/operations/transformer/transformer.hpp
@@ -16,8 +16,7 @@
 #include "ttnn/operations/eltwise/binary/binary.hpp"
 
 namespace ttnn {
-namespace operations {
-namespace transformer {
+namespace operations::transformer {
 
 namespace detail {
 inline std::tuple<Tensor, Tensor, Tensor> reshape_outputs_of_split_query_key_value_and_split_heads(
@@ -300,8 +299,7 @@ struct ExecuteAttentionSoftmax {
     }
 };
 
-}  // namespace transformer
-}  // namespace operations
+}  // namespace operations::transformer
 
 namespace transformer {
 

--- a/ttnn/cpp/ttnn/operations/transformer/transformer_pybind.hpp
+++ b/ttnn/cpp/ttnn/operations/transformer/transformer_pybind.hpp
@@ -8,13 +8,12 @@
 #include <pybind11/stl.h>
 
 #include "ttnn/cpp/pybind11/decorators.hpp"
-#include "ttnn/operations/transformer.hpp"
 
+#include "ttnn/operations/transformer/transformer.hpp"
+
+
+namespace ttnn::operations::transformer {
 namespace py = pybind11;
-
-namespace ttnn {
-namespace operations {
-namespace transformer {
 
 void py_module(py::module& module) {
 
@@ -177,7 +176,7 @@ void py_module(py::module& module) {
             py::arg("num_kv_heads") = std::nullopt,
             py::arg("transpose_key") = true,
             py::arg("memory_config") = std::nullopt});
+
 }
-}  // namespace transformer
-}  // namespace operations
-}  // namespace ttnn
+
+}  // namespace ttnn::operations::transformer


### PR DESCRIPTION
### Ticket
[Link to Github Issue](https://github.com/tenstorrent/tt-metal/issues/9751)

### Problem description
Overall goal is to port over all transformers code in `tt_eager` to `ttnn`. First, I am reordering the structure of existing `ttnn::transformer` code to match the new structure.

### What's changed
Moved `transformer` op and pybinds into same folder. No changes to op usage.

### Checklist
- [x] Post commit CI passes
  - post-commit all: https://github.com/tenstorrent/tt-metal/actions/runs/9960567024 (failures are existing failures)
  - post-commit ttnn unit tests: https://github.com/tenstorrent/tt-metal/actions/runs/9960585308
- [x] Model regression CI testing passes (if applicable)
  - post-commit models: https://github.com/tenstorrent/tt-metal/actions/runs/9960572651
  - T3000 demo: https://github.com/tenstorrent/tt-metal/actions/runs/9960581936
  - T3000 frequent: https://github.com/tenstorrent/tt-metal/actions/runs/9960577880
- [x] New/Existing tests provide coverage for changes
