### PR TITLE
[Falcon7b] Add perplexity tests to new pipeline and restructure pytests to invoke with filenames

### DIFF
--- a/models/demos/falcon7b/tests/perplexity/test_perplexity_falcon.py
+++ b/models/demos/falcon7b/tests/perplexity/test_perplexity_falcon.py
@@ -1,0 +1,62 @@
+# SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+
+# SPDX-License-Identifier: Apache-2.0
+
+import pytest
+from models.demos.falcon7b.tests.perplexity.run_perplexity_falcon import run_test_perplexity
+from models.utility_functions import is_wormhole_b0
+
+
+@pytest.mark.parametrize(
+    "llm_mode, batch_size, max_seq_len, model_config_str, num_samples, expected_ppl, expected_top1, expected_top5",
+    (
+        ("prefill", 1, 128, "BFLOAT16-DRAM", 64, 19.93, 0.41, 0.66),
+        ("prefill", 1, 1024, "BFLOAT16-DRAM", 64, 11.41, 0.49, 0.72),
+        ("prefill", 1, 2048, "BFLOAT16-DRAM", 64, 9.96, 0.50, 0.74),
+        ("decode", 32, 128, "BFLOAT16-L1_SHARDED", 64, 20.25, 0.40, 0.66),
+        ("decode", 32, 1024, "BFLOAT16-L1_SHARDED", 64, 11.63, 0.48, 0.72),
+        ("decode", 32, 2048, "BFLOAT16-L1_SHARDED", 64, 10.18, 0.50, 0.74),
+    ),
+    ids=[
+        "prefill_seq128_dram",
+        "prefill_seq1024_dram",
+        "prefill_seq2048_dram",
+        "decode_128_l1_sharded",
+        "decode_1024_l1_sharded",
+        "decode_2048_l1_sharded",
+    ],
+)
+@pytest.mark.parametrize("async_mode", (True,))  # Option to run Falcon in Async mode
+def test_perplexity(
+    llm_mode,
+    batch_size,
+    max_seq_len,
+    model_config_str,
+    num_samples,  # Total number of prompts to evaluate (all if None)
+    expected_ppl,
+    expected_top1,
+    expected_top5,
+    async_mode,
+    model_location_generator,
+    get_tt_cache_path,
+    device,
+    use_program_cache,
+):
+    if llm_mode == "decode" and max_seq_len == 2048:
+        pytest.skip("Skipping decode-seq2048 due to Issue #10365")
+
+    assert is_wormhole_b0(), "This test is only for Wormhole B0"
+
+    device.enable_async(async_mode)
+
+    run_test_perplexity(
+        llm_mode,
+        batch_size,
+        max_seq_len,
+        model_config_str,
+        model_location_generator,
+        get_tt_cache_path,
+        [device],
+        num_samples,
+        {"ppl": expected_ppl, "top1_acc": expected_top1, "top5_acc": expected_top5},
+    )

--- a/models/demos/falcon7b/tests/perplexity/test_perplexity_falcon_ref.py
+++ b/models/demos/falcon7b/tests/perplexity/test_perplexity_falcon_ref.py
@@ -1,0 +1,49 @@
+# SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+
+# SPDX-License-Identifier: Apache-2.0
+
+import pytest
+from models.demos.falcon7b.tests.perplexity.run_perplexity_falcon import run_test_perplexity
+
+
+@pytest.mark.parametrize(
+    "llm_mode, batch_size, max_seq_len, num_samples, expected_ppl, expected_top1, expected_top5",
+    (
+        ("prefill", 32, 128, 64, 19.67, 0.41, 0.66),
+        ("prefill", 32, 1024, 64, 11.19, 0.48, 0.72),
+        ("prefill", 32, 2048, 64, 9.81, 0.50, 0.74),
+        ("decode", 64, 128, 64, 19.67, 0.41, 0.66),
+        ("decode", 64, 1024, 64, 11.19, 0.48, 0.72),
+        ("decode", 64, 2048, 64, 9.81, 0.50, 0.74),
+    ),
+    ids=[
+        "prefill_seq128",
+        "prefill_seq1024",
+        "prefill_seq2048",
+        "decode_128",
+        "decode_1024",
+        "decode_2048",
+    ],
+)
+def test_perplexity_huggingface(
+    llm_mode,
+    batch_size,
+    max_seq_len,
+    num_samples,  # Total number of prompts to evaluate (all if None)
+    expected_ppl,
+    expected_top1,
+    expected_top5,
+    model_location_generator,
+):
+    run_test_perplexity(
+        llm_mode,
+        batch_size,
+        max_seq_len,
+        None,
+        model_location_generator,
+        None,
+        None,
+        num_samples,
+        {"ppl": expected_ppl, "top1_acc": expected_top1, "top5_acc": expected_top5},
+        use_hf_model=True,
+    )

--- a/tests/scripts/t3000/run_t3000_demo_tests.sh
+++ b/tests/scripts/t3000/run_t3000_demo_tests.sh
@@ -50,10 +50,6 @@ run_t3000_falcon7b_tests(){
   # Falcon7B demo (perf verification for 128/1024/2048 seq lens and output token verification)
   WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml pytest -n auto --disable-warnings -q -s --input-method=json --input-path='models/demos/t3000/falcon7b/input_data_t3000.json' models/demos/t3000/falcon7b/demo_t3000.py ; fail+=$?
 
-  # Falcon7B perplexity test (prefill and decode)
-  WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml pytest -n auto models/demos/falcon7b/tests/test_perplexity_falcon.py::test_perplexity[True-prefill_seq1024_dram] --timeout=1800 ; fail+=$?
-  WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml pytest -n auto models/demos/falcon7b/tests/test_perplexity_falcon.py::test_perplexity[True-decode_1024_l1_sharded] --timeout=1800 ; fail+=$?
-
   # Record the end time
   end_time=$(date +%s)
   duration=$((end_time - start_time))

--- a/tests/scripts/t3000/run_t3000_perplexity_tests.sh
+++ b/tests/scripts/t3000/run_t3000_perplexity_tests.sh
@@ -7,9 +7,9 @@ run_t3000_perplexity_tests() {
   start_time=$(date +%s)
 
   echo "LOG_METAL: Running run_t3000_perplexity_tests"
-  # Insert Tests here
-  
-  echo "Hello World"
+
+  # Falcon7B perplexity tests
+  WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml pytest -n auto models/demos/falcon7b/tests/perplexity/test_perplexity_falcon.py --timeout=1500 ; fail+=$?
 
   # Record the end time
   end_time=$(date +%s)


### PR DESCRIPTION
### Ticket
#5383 

### Problem description
- Falcon7b perplexity tests were included in the t3k demo pipeline since there was no perplexity pipeline and only seq len 1024 was tested
- Perplexity tests were being invoked with `::[...]`, not meeting the requirements of #7586 

### What's changed
- Moved Falcon7b perplexity tests to the new t3k perplexity pipeline, including 128/1024/2048 seq lens for prefill and decode
- Restructured perplexity tests to be invoked with filename only

### Checklist
- [x] Post commit CI passes
- [x] Model regression CI testing passes (if applicable)
- [x] New/Existing tests provide coverage for changes
