### PR TITLE
#8534: Publish tt-metal docs to the central site

### DIFF
--- a/.github/workflows/docs-latest-public-wrapper.yaml
+++ b/.github/workflows/docs-latest-public-wrapper.yaml
@@ -2,16 +2,21 @@ name: "[post-commit] Docs build and deploy to GitHub pages on main"
 
 on:
   workflow_dispatch:
-
 jobs:
-  build-docker-artifact:
-    uses: ./.github/workflows/build-docker-artifact.yaml
-    secrets: inherit
+  # build-docker-artifact:
+  #   uses: ./.github/workflows/build-docker-artifact.yaml
+  #   secrets: inherit
   build-artifact:
-    needs: build-docker-artifact
+  #  needs: build-docker-artifact
     uses: ./.github/workflows/build-artifact.yaml
     secrets: inherit
-  build-docs:
+  # build-docs:
+  #   needs: build-artifact
+  #   uses: ./.github/workflows/docs-latest-public.yaml
+  #   secrets: inherit
+  release-docs:
     needs: build-artifact
-    uses: ./.github/workflows/docs-latest-public.yaml
+    uses: ./.github/workflows/docs-release.yaml
+    with:
+      version: v0.52.0
     secrets: inherit

--- a/.github/workflows/docs-latest-public-wrapper.yaml
+++ b/.github/workflows/docs-latest-public-wrapper.yaml
@@ -2,21 +2,16 @@ name: "[post-commit] Docs build and deploy to GitHub pages on main"
 
 on:
   workflow_dispatch:
+
 jobs:
-  # build-docker-artifact:
-  #   uses: ./.github/workflows/build-docker-artifact.yaml
-  #   secrets: inherit
+  build-docker-artifact:
+    uses: ./.github/workflows/build-docker-artifact.yaml
+    secrets: inherit
   build-artifact:
-  #  needs: build-docker-artifact
+    needs: build-docker-artifact
     uses: ./.github/workflows/build-artifact.yaml
     secrets: inherit
-  # build-docs:
-  #   needs: build-artifact
-  #   uses: ./.github/workflows/docs-latest-public.yaml
-  #   secrets: inherit
-  release-docs:
+  build-docs:
     needs: build-artifact
-    uses: ./.github/workflows/docs-release.yaml
-    with:
-      version: v0.52.0
+    uses: ./.github/workflows/docs-latest-public.yaml
     secrets: inherit

--- a/.github/workflows/docs-release.yaml
+++ b/.github/workflows/docs-release.yaml
@@ -29,8 +29,8 @@ jobs:
       matrix:
         arch: [grayskull]
     env:
-      TT_METAL_ENV: ${{ vars.TT_METAL_ENV }}
       DOCS_VERSION: ${{ inputs.version }}
+      DOCS_REPO: tenstorrent.github.io
       ARCH_NAME: ${{ matrix.arch }}
       LOGURU_LEVEL: INFO
       LD_LIBRARY_PATH: ${{ github.workspace }}/build/lib
@@ -71,8 +71,8 @@ jobs:
           git config --global user.email "${GITHUB_USER}@tenstorrent.com"
           git config --global user.name "${GITHUB_USER}"
           echo "About to clone"
-          git clone https://${GITHUB_USER}:${{ secrets.TTBOT_DOCS_ACCESS }}@github.com/tenstorrent/tenstorrent.github.io.git
-          git remote set-url origin https://${GITHUB_USER}::${{ secrets.TTBOT_DOCS_ACCESS }}@github.com/tenstorrent/tenstorrent.github.io.git
+          git clone https://${GITHUB_USER}:${{ secrets.TTBOT_DOCS_ACCESS }}@github.com/tenstorrent/$DOCS_REPO.git
+          git remote set-url origin https://${GITHUB_USER}::${{ secrets.TTBOT_DOCS_ACCESS }}@github.com/tenstorrent/$DOCS_REPO.git
       - name: Package TT-Metalium Docs
         run: |
           echo "Preparing tt-metalium docs assets"
@@ -81,7 +81,7 @@ jobs:
           cp -Lr docs/source/tt-metalium/* tt-metalium
           rm tt-metalium/conf.py  # Do not change conf.py
           echo "Copying the docs into the repo"
-          cp -r tt-metalium/* tenstorrent.github.io/tt-metalium
+          cp -r tt-metalium/* $DOCS_REPO/tt-metalium
       - name: Package TT-NN Docs
         run: |
           mkdir ttnn-docs
@@ -98,18 +98,18 @@ jobs:
           sed -i "s/.\/ttnn\/installing/\/installing/g" ttnn-docs/ttnn/get_started.rst
 
           echo "Copying the docs into the repo"
-          cp -r ttnn-docs/* tenstorrent.github.io/ttnn
+          cp -r ttnn-docs/* $DOCS_REPO/ttnn
       - name: Push new versions to the Docs repo for publishing
         run: |
-          cd tenstorrent.github.io
+          cd $DOCS_REPO
           echo "Register new documentation versions"
           python update_tags.py tt-metalium $DOCS_VERSION
           python update_tags.py ttnn $DOCS_VERSION
-          git checkout -b test_v51_deploy
+          git checkout mains
           git add .
           git commit -m "Update ttnn and tt-metalium docs from pipeline ${{ github.run_id }} with tag $DOCS_VERSION"
           echo "Tag commits to identify different versions."
           git tag -a ttnn_$DOCS_VERSION -m "ttnn and tt-metalium documentation version $DOCS_VERSION"
           git tag -a tt-metalium_$DOCS_VERSION -m "ttnn and tt-metalium documentation version $DOCS_VERSION"
           echo "Pushing the new docs"
-          git push -u origin test_v51_deploy && git push --tags
+          git push -u origin main && git push --tags

--- a/.github/workflows/docs-release.yaml
+++ b/.github/workflows/docs-release.yaml
@@ -1,0 +1,106 @@
+name: "Release Docs: package the docs and publish to Docs the repo"
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        required: true
+        type: string
+  workflow_call:
+    inputs:
+      version:
+        required: true
+        type: string
+
+concurrency:
+  # Note that people may spam the post-commit pipeline on their branch, and
+  # we have this docs pipeline in the post-commit pipeline, then people
+  # would have to wait until the previous one fully completes. That may be
+  # ok because each post-commit pipeline definitely takes more than 30 min
+  group: "pages-${{ github.ref }}"
+  cancel-in-progress: false
+
+jobs:
+  package-push-docs:
+    strategy:
+      # Do not fail-fast because we need to ensure all tests go to completion
+      # so we try not to get hanging machines
+      fail-fast: false
+      matrix:
+        arch: [grayskull]
+    env:
+      TT_METAL_ENV: ${{ vars.TT_METAL_ENV }}
+      DOCS_VERSION: ${{ inputs.version }}
+      ARCH_NAME: ${{ matrix.arch }}
+      LOGURU_LEVEL: INFO
+      LD_LIBRARY_PATH: ${{ github.workspace }}/build/lib
+    environment: dev
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive
+          lfs: false
+      - name: Set up dynamic env vars for build
+        run: |
+          echo "TT_METAL_HOME=$(pwd)" >> $GITHUB_ENV
+      - uses: ./.github/actions/install-metal-deps
+        with:
+          os: ubuntu-20.04
+      - uses: ./.github/actions/install-metal-dev-deps
+        with:
+          os: ubuntu-20.04
+      - uses: actions/download-artifact@v4
+        with:
+          name: TTMetal_build_${{ matrix.arch }}
+      - name: Extract files
+        run: tar -xvf ttm_${{ matrix.arch }}.tar
+      - uses: ./.github/actions/install-python-deps
+      - name: Build Doxygen Docs
+        timeout-minutes: 15
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        run: |
+          source ${{ github.workspace }}/python_env/bin/activate
+          cd $TT_METAL_HOME
+          export PYTHONPATH=$TT_METAL_HOME
+          doxygen
+      - name: Clone Shared Docs Repo
+        run: |
+          GITHUB_USER=tenstorrent-github-bot
+          git config --global user.email "${GITHUB_USER}@tenstorrent.com"
+          git config --global user.name "${GITHUB_USER}"
+          echo "About to clone"
+          git clone https://${GITHUB_USER}:${{ secrets.TTBOT_DOCS_ACCESS }}@github.com/tenstorrent/docs-test.git
+          git remote set-url origin https://${GITHUB_USER}::${{ secrets.TTBOT_DOCS_ACCESS }}@github.com/tenstorrent/docs-test.git
+      - name: Package TT-Metalium Docs
+        run: |
+          echo "Preparing tt-metalium docs assets"
+          mkdir tt-metalium
+          cp -Lr docs/doxygen_build tt-metalium
+          cp -Lr docs/source/tt-metalium/* tt-metalium
+          rm tt-metalium/conf.py  # Do not change conf.py
+          echo "Copying the docs into the repo"
+          cp -r tt-metalium/* docs-test/tt-metalium
+      - name: Package TT-NN Docs
+        run: |
+          mkdir ttnn-docs
+          cp -Lr docs/doxygen_build ttnn-docs
+          cp -Lr docs/source/ttnn/* ttnn-docs
+          rm ttnn-docs/conf.py  # Do not change conf.py
+          echo "Copying the docs into the repo"
+          cp -r ttnn-docs/* docs-test/ttnn
+      - name: Push new versions to the Docs repo for publishing
+        run: |
+          cd docs-test
+          echo "Register new documentation versions"
+          python update_tags.py tt-metalium $DOCS_VERSION
+          python update_tags.py ttnn $DOCS_VERSION
+
+          git add .
+          git commit -m "Update ttnn and tt-metalium docs from pipeline ${{ github.run_id }} with tag $DOCS_VERSION"
+          echo "Tag commits to identify different versions."
+          git tag -a ttnn_$DOCS_VERSION -m "ttnn and tt-metalium documentation version $DOCS_VERSION"
+          git tag -a tt-metalium_$DOCS_VERSION -m "ttnn and tt-metalium documentation version $DOCS_VERSION"
+          echo "Pushing the new docs"
+          # git push && git push --tags

--- a/.github/workflows/docs-release.yaml
+++ b/.github/workflows/docs-release.yaml
@@ -105,7 +105,7 @@ jobs:
           echo "Register new documentation versions"
           python update_tags.py tt-metalium $DOCS_VERSION
           python update_tags.py ttnn $DOCS_VERSION
-          git checkout mains
+          git checkout main
           git add .
           git commit -m "Update ttnn and tt-metalium docs from pipeline ${{ github.run_id }} with tag $DOCS_VERSION"
           echo "Tag commits to identify different versions."

--- a/.github/workflows/docs-release.yaml
+++ b/.github/workflows/docs-release.yaml
@@ -71,8 +71,8 @@ jobs:
           git config --global user.email "${GITHUB_USER}@tenstorrent.com"
           git config --global user.name "${GITHUB_USER}"
           echo "About to clone"
-          git clone https://${GITHUB_USER}:${{ secrets.TTBOT_DOCS_ACCESS }}@github.com/tenstorrent/docs-test.git
-          git remote set-url origin https://${GITHUB_USER}::${{ secrets.TTBOT_DOCS_ACCESS }}@github.com/tenstorrent/docs-test.git
+          git clone https://${GITHUB_USER}:${{ secrets.TTBOT_DOCS_ACCESS }}@github.com/tenstorrent/tenstorrent.github.io.git
+          git remote set-url origin https://${GITHUB_USER}::${{ secrets.TTBOT_DOCS_ACCESS }}@github.com/tenstorrent/tenstorrent.github.io.git
       - name: Package TT-Metalium Docs
         run: |
           echo "Preparing tt-metalium docs assets"
@@ -81,26 +81,35 @@ jobs:
           cp -Lr docs/source/tt-metalium/* tt-metalium
           rm tt-metalium/conf.py  # Do not change conf.py
           echo "Copying the docs into the repo"
-          cp -r tt-metalium/* docs-test/tt-metalium
+          cp -r tt-metalium/* tenstorrent.github.io/tt-metalium
       - name: Package TT-NN Docs
         run: |
           mkdir ttnn-docs
           cp -Lr docs/doxygen_build ttnn-docs
           cp -Lr docs/source/ttnn/* ttnn-docs
           rm ttnn-docs/conf.py  # Do not change conf.py
+          echo "Copy tutorials and examples for TTNN from a different repo area."
+          cp -Lr ttnn/examples ttnn-docs/ttnn
+          echo "Make sure the links are updated in ttnn/usage.rst to the correct spot for the tutorials and examples."
+          sed -i "s/..\/..\/..\/..\/ttnn\/examples/examples/g" ttnn-docs/ttnn/usage.rst
+
+          echo "Change tutorial and installation links in TTNN Get Started."
+          sed -i "s/.\/..\/ttnn\/ttnn//g" ttnn-docs/ttnn/get_started.rst
+          sed -i "s/.\/ttnn\/installing/\/installing/g" ttnn-docs/ttnn/get_started.rst
+
           echo "Copying the docs into the repo"
-          cp -r ttnn-docs/* docs-test/ttnn
+          cp -r ttnn-docs/* tenstorrent.github.io/ttnn
       - name: Push new versions to the Docs repo for publishing
         run: |
-          cd docs-test
+          cd tenstorrent.github.io
           echo "Register new documentation versions"
           python update_tags.py tt-metalium $DOCS_VERSION
           python update_tags.py ttnn $DOCS_VERSION
-
+          git checkout -b test_v51_deploy
           git add .
           git commit -m "Update ttnn and tt-metalium docs from pipeline ${{ github.run_id }} with tag $DOCS_VERSION"
           echo "Tag commits to identify different versions."
           git tag -a ttnn_$DOCS_VERSION -m "ttnn and tt-metalium documentation version $DOCS_VERSION"
           git tag -a tt-metalium_$DOCS_VERSION -m "ttnn and tt-metalium documentation version $DOCS_VERSION"
           echo "Pushing the new docs"
-          # git push && git push --tags
+          git push -u origin test_v51_deploy && git push --tags

--- a/.github/workflows/package-and-release.yaml
+++ b/.github/workflows/package-and-release.yaml
@@ -206,3 +206,9 @@ jobs:
           tags: ghcr.io/${{ github.repository }}/tt-metalium/ubuntu-20.04-amd64:${{ needs.create-tag.outputs.version }}-dev
           context: .
           file: dockerfile/ubuntu-20.04-amd64.Dockerfile
+    release-docs:
+      needs: create-and-upload-draft-release
+      uses: ./.github/workflows/docs-release.yaml
+      with:
+        version: ${{ needs.create-tag.outputs.version }}
+      secrets: inherit


### PR DESCRIPTION
### Ticket
[Link to Github Issue
](https://github.com/tenstorrent/tt-metal/issues/8534)

### Problem description
Create and push ttnn and tt-metalium documentation to docs-test repo for the centralized repository.
A particular challenge is to build the doxygen documentation for C++ as well as pick up the documentation from Python libraries of ttnn and tt-metalium that rely on the installation of the tt-metal wheel.

In order to capture Doxygen documentation, we run doxygen and add the resulting .xml files into the docs repo source so we can build documentation as part of the centralized docs repo build.

We also check-in all existing .rst files while not copying `conf.py` file so we can use an adapted conf.py in docs repo.

### What's changed
A new workflow is added that is triggered upon a release workflow.

### Checklist
- [x] Post commit CI passes
- [ ] Model regression CI testing passes (if applicable)
- [ ] New/Existing tests provide coverage for changes
