### PR TITLE
#10224: Update offsets for GO signal commands to use sizeof prefetch/dispatch cmd rather than pcie aligned size

### DIFF
--- a/tt_metal/impl/dispatch/command_queue.cpp
+++ b/tt_metal/impl/dispatch/command_queue.cpp
@@ -1088,7 +1088,7 @@ void EnqueueProgramCommand::assemble_device_commands() {
                     curr_sub_cmd_idx);
                 curr_sub_cmd_idx += num_sub_cmds_in_cmd;
                 uint32_t curr_sub_cmd_data_offset_words =
-                    (write_offset_bytes + CQ_PREFETCH_CMD_BARE_MIN_SIZE +
+                    (write_offset_bytes + (sizeof(CQPrefetchCmd) + sizeof(CQDispatchCmd)) +
                      align(num_sub_cmds_in_cmd * sizeof(CQDispatchWritePackedMulticastSubCmd), L1_ALIGNMENT)) /
                     sizeof(uint32_t);
                 for (uint32_t i = 0; i < num_sub_cmds_in_cmd; ++i) {
@@ -1114,7 +1114,7 @@ void EnqueueProgramCommand::assemble_device_commands() {
                     curr_sub_cmd_idx);
                 curr_sub_cmd_idx += num_sub_cmds_in_cmd;
                 uint32_t curr_sub_cmd_data_offset_words =
-                    (write_offset_bytes + CQ_PREFETCH_CMD_BARE_MIN_SIZE +
+                    (write_offset_bytes + (sizeof(CQPrefetchCmd) + sizeof(CQDispatchCmd)) +
                      align(num_sub_cmds_in_cmd * sizeof(CQDispatchWritePackedUnicastSubCmd), L1_ALIGNMENT)) /
                     sizeof(uint32_t);
                 for (uint32_t i = 0; i < num_sub_cmds_in_cmd; ++i) {


### PR DESCRIPTION
### Ticket
[Link to Github Issue](https://github.com/tenstorrent/tt-metal/issues/10224)

### Problem description
Using CQ_PREFETCH_CMD_BARE_MIN_SIZE rather than sizeof(CQPrefetchCmd) and sizeof(CQDispatchCmd) to calculate offsets for writing go signal data. This was leading to writing/reading to incorrect locations

### What's changed
CQ_PREFETCH_CMD_BARE_MIN_SIZE -> (sizeof(CQPrefetchCmd) + sizeof(CQDispatchCmd))

### Checklist
- [x] [Post commit CI passes](https://github.com/tenstorrent/tt-metal/actions/runs/9961549036)
- [x] [Model regression CI testing passes](https://github.com/tenstorrent/tt-metal/actions/runs/9961554476)
