### PR TITLE
#10181: Disable test_reduce_h due to sporadic failures in slow dispatch

### DIFF
--- a/tests/tt_metal/tt_metal/CMakeLists.txt
+++ b/tests/tt_metal/tt_metal/CMakeLists.txt
@@ -28,7 +28,7 @@ set (TT_METAL_TESTS
     # test_3x3conv_as_matmul_large_block        <- not tested in run_tt_metal.py
     # test_l1_to_l1_multi_core                    <- test borked
     test_dram_copy_sticks_multi_core
-    test_reduce_h
+    # test_reduce_h           <- (issue #10181: disabling due to sporadic failures in slow dispatch mode)
     test_reduce_w
     test_reduce_hw
     test_untilize_eltwise_binary


### PR DESCRIPTION
### Ticket
[Link to Github Issue](https://github.com/tenstorrent/tt-metal/issues/10181)

### Problem description
Seeing sporadic failures with this specific test in CI (eg. https://github.com/tenstorrent/tt-metal/actions/runs/9960567024/job/27520464740)

### What's changed
Disabling the test for now so post-commit CI is more reliable.

### Checklist
- [ ] Post commit CI passes
- [ ] Model regression CI testing passes (if applicable)
- [ ] New/Existing tests provide coverage for changes
