### PR TITLE
#10181: Disable `test_reduce_h`

### DIFF
--- a/tests/scripts/run_tt_metal.py
+++ b/tests/scripts/run_tt_metal.py
@@ -85,7 +85,8 @@ TT_METAL_SLOW_DISPATCH_TEST_ENTRIES = (
     ),
     TestEntry("tt_metal/tests/test_transpose_hc", "test_transpose_hc"),
     TestEntry("tt_metal/tests/test_transpose_wh", "test_transpose_wh"),
-    TestEntry("tt_metal/tests/test_reduce_h", "test_reduce_h"),
+    # (issue #10181: disabling due to sporadic failures in slow dispatch mode)
+    # TestEntry("tt_metal/tests/test_reduce_h", "test_reduce_h"),
     TestEntry("tt_metal/tests/test_reduce_w", "test_reduce_w"),
     TestEntry("tt_metal/tests/test_reduce_hw", "test_reduce_hw"),
     TestEntry("tt_metal/tests/test_bmm", "test_bmm"),

--- a/tests/tt_metal/tt_metal/CMakeLists.txt
+++ b/tests/tt_metal/tt_metal/CMakeLists.txt
@@ -28,7 +28,7 @@ set (TT_METAL_TESTS
     # test_3x3conv_as_matmul_large_block        <- not tested in run_tt_metal.py
     # test_l1_to_l1_multi_core                    <- test borked
     test_dram_copy_sticks_multi_core
-    # test_reduce_h           <- (issue #10181: disabling due to sporadic failures in slow dispatch mode)
+    test_reduce_h
     test_reduce_w
     test_reduce_hw
     test_untilize_eltwise_binary


### PR DESCRIPTION
### Ticket

#10181 

### Problem description

We disabled the build but not the test invocation.

### What's changed

Still build the test, but disable test invocation

### Checklist
- [x] Post commit CI passes
- [x] Model regression CI testing passes (if applicable)
- [x] New/Existing tests provide coverage for changes
