### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,11 +42,11 @@
 >
 > All model demos in this table function on both N150 and N300 Wormhole cards, unless otherwise stated.
 
-| Model                                                                                | Gen. Token [3]     |  Batch               | End-to-end throughput [1]    | Device throughput [2]       | Target         |
+| Model                                                                                | Gen. Token [3]     |  Batch               | End-to-end decode throughput [1]    | Device decode throughput [2]       | Target         |
 |--------------------------------------------------------------------------------------|--------------------|----------------------|------------------------------|-----------------------------|----------------|
-| [Falcon7B-decode](./models/demos/wormhole/falcon7b)                                  | 129th              | 32                   | 13.3 t/s/u - 425 t/s         | 15.4 t/s/u - 493 t/s        | 26             |
-| [Mistral-7B-decode](./models/demos/wormhole/mistral7b)                               | 129th              | 32                   | 9.9 t/s/u - 317 t/s          | 11.0 t/s/u - 352 t/s        | 25             |
-| [Mamba-2.8B-decode](./models/demos/mamba)                                            | any                | 32                   | 11.6 t/s/u - 370 t/s         | 16.5 t/s/u - 528 t/s        | 41             |
+| [Falcon7B](./models/demos/wormhole/falcon7b)                                  | 129th              | 32                   | 13.3 t/s/u - 425 t/s         | 15.4 t/s/u - 493 t/s        | 26             |
+| [Mistral-7B](./models/demos/wormhole/mistral7b)                               | 129th              | 32                   | 9.9 t/s/u - 317 t/s          | 11.0 t/s/u - 352 t/s        | 25             |
+| [Mamba-2.8B](./models/demos/mamba)                                            | any                | 32                   | 11.6 t/s/u - 370 t/s         | 16.5 t/s/u - 528 t/s        | 41             |
 | [BERT-Large](./models/demos/metal_BERT_large_11/) (sen/s) [4]                        |                    | 8                    | 270                          | 340                         | 400            |
 | [Stable Diffusion 1.4](./models/demos/wormhole/stable_diffusion) 512x512  (sec/img)  |                    | 1                    | 6                            | 5                           |                |
 | [ResNet-50](./models/demos/ttnn_resnet) (fps)                                        |                    | 16                   | 4,300                        | 5,550                       | 7,000          |
@@ -61,13 +61,13 @@
 
 ## T3000 (2x4 mesh of WHs) Models
 
-| Model                                                     |   Technique        | Gen. Token [3]      |  Batch                | End-to-end throughput [1]    | Device throughput [2]        | Target          |
+| Model                                                     |   Technique        | Gen. Token [3]      |  Batch                | End-to-end decode throughput [1]    | Device decode throughput [2]        | Target          |
 |-----------------------------------------------------------|--------------------|---------------------|-----------------------|------------------------------|------------------------------|-----------------|
-| [Falcon7B-decode](./models/demos/t3000/falcon7b)          | Data Parallel      | 129th               |  256                  |  7.4 t/s/u - 1901 t/s        |  15.5 t/s/u - 3968 t/s       |   26 t/s/u      |
-| [LLaMA-2-70B-decode](./models/demos/t3000/llama2_70b)     | Tensor Parallel    | 129th               |  32                   | 10.4 t/s/u - 333 t/s         |  16.6 t/s/u - 532 t/s        |   20 t/s/u      |
-| [LLaMA-3-70B-decode](./models/demos/t3000/llama3_70b)     | Tensor Parallel    | 129th               |  32                   | 10.4 t/s/u - 333 t/s         |  15.8 t/s/u - 506 t/s        |   20 t/s/u      |
-| [Falcon40B-decode](./models/demos/t3000/falcon40b)        | Tensor Parallel    | 129th               |  32                   | work-in-progress             |  10.0 t/s/u - 320 t/s        |   36 t/s/u      |
-| [Mixtral7Bx8-decode](./models/demos/t3000/mixtral8x7b)    | Tensor Parallel    | 129th               |  32                   | 15.1 t/s/u - 483 t/s         |  27.1 t/s/u - 868 t/s        |   33 t/s/u      |
+| [Falcon7B](./models/demos/t3000/falcon7b)          | Data Parallel      | 129th               |  256                  |  7.4 t/s/u - 1901 t/s        |  15.5 t/s/u - 3968 t/s       |   26 t/s/u      |
+| [LLaMA-2-70B](./models/demos/t3000/llama2_70b)     | Tensor Parallel    | 129th               |  32                   | 10.4 t/s/u - 333 t/s         |  16.6 t/s/u - 532 t/s        |   20 t/s/u      |
+| [LLaMA-3-70B](./models/demos/t3000/llama3_70b)     | Tensor Parallel    | 129th               |  32                   | 10.4 t/s/u - 333 t/s         |  15.8 t/s/u - 506 t/s        |   20 t/s/u      |
+| [Falcon40B](./models/demos/t3000/falcon40b)        | Tensor Parallel    | 129th               |  32                   | work-in-progress             |  10.0 t/s/u - 320 t/s        |   36 t/s/u      |
+| [Mixtral7Bx8](./models/demos/t3000/mixtral8x7b)    | Tensor Parallel    | 129th               |  32                   | 15.1 t/s/u - 483 t/s         |  27.1 t/s/u - 868 t/s        |   33 t/s/u      |
 | ResNet50                                                  | Data Parallel      | coming soon         |                       |                              |                              |                 |
 
 ## Using TT-NN ops and tensors


### PR DESCRIPTION
Remove "decode" from the model names, but specify measured throughput is "decode throughput"
