### PR TITLE
#10320: Enable falcon40b tests again

### DIFF
--- a/models/demos/t3000/falcon40b/tests/ci/test_falcon_end_to_end_1_layer_t3000.py
+++ b/models/demos/t3000/falcon40b/tests/ci/test_falcon_end_to_end_1_layer_t3000.py
@@ -12,12 +12,10 @@ from models.utility_functions import (
     disable_persistent_kernel_cache,
     disable_compilation_reports,
     skip_for_grayskull,
-    skip_for_wormhole_b0,
 )
 
 
 @skip_for_grayskull("Requires eth connected devices to run")
-@skip_for_wormhole_b0("See GH Issue #10321")
 @pytest.mark.parametrize("num_devices", (8,), ids=["8chips"])
 @pytest.mark.parametrize(
     "llm_mode, batch, seq_len, kv_cache_len",

--- a/models/demos/t3000/falcon40b/tests/ci/test_falcon_end_to_end_60_layer_t3000_prefill_10_loops.py
+++ b/models/demos/t3000/falcon40b/tests/ci/test_falcon_end_to_end_60_layer_t3000_prefill_10_loops.py
@@ -12,12 +12,10 @@ from models.utility_functions import (
     disable_persistent_kernel_cache,
     disable_compilation_reports,
     skip_for_grayskull,
-    skip_for_wormhole_b0,
 )
 
 
 @skip_for_grayskull("Requires eth connected devices to run")
-@skip_for_wormhole_b0("See GH Issue #10320")
 @pytest.mark.parametrize(
     "num_loops",
     (10,),

--- a/models/demos/t3000/falcon40b/tests/ci/test_falcon_end_to_end_t3000_demo_loops.py
+++ b/models/demos/t3000/falcon40b/tests/ci/test_falcon_end_to_end_t3000_demo_loops.py
@@ -9,12 +9,10 @@ from models.demos.t3000.falcon40b.tt.model_config import get_model_config, model
 from models.utility_functions import (
     disable_compilation_reports,
     skip_for_grayskull,
-    skip_for_wormhole_b0,
 )
 
 
 @skip_for_grayskull("Requires eth connected devices to run")
-@skip_for_wormhole_b0("See GH Issue #10320")
 @pytest.mark.timeout(3600)
 @pytest.mark.parametrize(
     "num_loops",

--- a/models/demos/t3000/falcon40b/tests/test_falcon_causallm.py
+++ b/models/demos/t3000/falcon40b/tests/test_falcon_causallm.py
@@ -20,7 +20,7 @@ from models.demos.t3000.falcon40b.tt.model_config import (
 from tests.tt_eager.python_api_testing.sweep_tests.comparison_funcs import (
     comp_pcc,
 )
-from models.utility_functions import skip_for_grayskull, skip_for_wormhole_b0
+from models.utility_functions import skip_for_grayskull
 
 
 class PytorchFalconCausalLM(torch.nn.Module):
@@ -285,7 +285,6 @@ def run_test_FalconCausalLM_inference(
 
 
 @skip_for_grayskull("Requires eth connected devices to run")
-@skip_for_wormhole_b0("See GH Issue #10304")
 @pytest.mark.parametrize("num_devices", (8,), ids=["8chips"])
 @pytest.mark.parametrize(
     "llm_mode, batch, seq_len, kv_cache_len",

--- a/models/demos/t3000/falcon40b/tests/test_perf_falcon.py
+++ b/models/demos/t3000/falcon40b/tests/test_perf_falcon.py
@@ -29,7 +29,6 @@ from models.utility_functions import (
     disable_persistent_kernel_cache,
     disable_compilation_reports,
     skip_for_grayskull,
-    skip_for_wormhole_b0,
 )
 from models.perf.perf_utils import prep_perf_report
 
@@ -323,7 +322,6 @@ def run_test_FalconCausalLM_end_to_end(
 
 
 @skip_for_grayskull("Requires eth connected devices to run")
-@skip_for_wormhole_b0(" See GH Issue #10324")
 @pytest.mark.model_perf_t3000
 @pytest.mark.parametrize("num_devices", (8,), ids=["8chips"])
 @pytest.mark.parametrize(


### PR DESCRIPTION
The issue was not the model but the cached weights stored on the CI weka. Removing and re-generating the cached files solved the issue.

Pipelines now all green:
- [x] Unit tests: https://github.com/tenstorrent/tt-metal/actions/runs/9963912937
- [x] Frequent tests: https://github.com/tenstorrent/tt-metal/actions/runs/9963906808
- [x] Demo tests: https://github.com/tenstorrent/tt-metal/actions/runs/9962954056
- [x] Perf tests: https://github.com/tenstorrent/tt-metal/actions/runs/9963910733/job/27531315002
