### PR TITLE
Add native caching for Mamba convolution/hidden states

### DIFF
--- a/models/demos/mamba/demo/demo.py
+++ b/models/demos/mamba/demo/demo.py
@@ -163,6 +163,7 @@ def run_mamba_prefill_decode_demo(
     for user_idx in tqdm(range(num_users), desc="Prefilling the prompt(s)..."):
         with torch.no_grad():
             model(sequences[user_idx, :-1].unsqueeze(0))  # Omit the last token in the sequence
+            model.configs["current_user"] += 1
 
     # Decode
     decode_model_config = model_config.create_model_config(

--- a/models/demos/mamba/tests/test_cache.py
+++ b/models/demos/mamba/tests/test_cache.py
@@ -1,0 +1,48 @@
+# SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
+
+# SPDX-License-Identifier: Apache-2.0
+
+import pytest
+import ttnn
+import torch
+
+from models.demos.mamba.tt.cache import TensorCache
+
+from tests.tt_eager.python_api_testing.sweep_tests.comparison_funcs import (
+    comp_pcc,
+)
+
+
+@pytest.mark.parametrize("on_host", [True, False])
+@pytest.mark.parametrize(
+    "E, num_users, num_entries",
+    (
+        (32, 32, 1),
+        (2560, 32, 1),
+        (5120, 32, 4),
+    ),
+)
+def test_cache(E, num_users, num_entries, on_host, device):
+    values = [[torch.rand((1, 1, 1, E), dtype=torch.bfloat16) for _ in range(num_users)] for _ in range(num_entries)]
+
+    cache = TensorCache(num_users, num_entries, E, device, on_host=on_host)
+    for i in range(num_entries):
+        for user in range(num_users):
+            value = ttnn.from_torch(
+                values[i][user],
+                device=device,
+                layout=ttnn.ROW_MAJOR_LAYOUT,
+                memory_config=ttnn.DRAM_MEMORY_CONFIG,
+                dtype=ttnn.bfloat16,
+            )
+            cache.set(user, i, value)
+            did_pass, output_pcc = comp_pcc(ttnn.to_torch(value), ttnn.to_torch(cache.get(user, i)), 1.0)
+            assert did_pass
+
+    for i in range(num_entries):
+        conv_states = cache.concat_users(i)
+        assert list(conv_states.shape) == [1, 1, num_users, E]
+
+        expected = torch.concat(values[i], dim=2)
+        did_pass, output_pcc = comp_pcc(expected, ttnn.to_torch(conv_states), 1.0)
+        assert did_pass

--- a/models/demos/mamba/tt/cache.py
+++ b/models/demos/mamba/tt/cache.py
@@ -1,0 +1,63 @@
+# SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
+
+# SPDX-License-Identifier: Apache-2.0
+
+import ttnn
+import torch
+import tt_lib as ttl
+
+
+class TensorCache:
+    def __init__(
+        self, num_users: int, entries_per_user: int, entry_size: int, device: ttnn.Device, on_host: bool = True
+    ):
+        self.device = device
+        self.num_users = num_users
+        self.entries_per_user = entries_per_user
+        self.entry_shape = [1, 1, 1, entry_size]
+        self.on_host = on_host
+
+        if self.on_host:
+            device = None
+            self.cache_memory_config = None
+        else:
+            device = device
+            self.cache_memory_config = ttnn.DRAM_MEMORY_CONFIG
+        self.cache = [
+            [
+                ttnn.from_torch(
+                    torch.zeros(self.entry_shape),
+                    device=device,
+                    layout=ttnn.ROW_MAJOR_LAYOUT,
+                    memory_config=self.cache_memory_config,
+                    dtype=ttnn.bfloat16,
+                )
+                for _ in range(self.num_users)
+            ]
+            for _ in range(self.entries_per_user)
+        ]
+
+    def set(self, user_idx: int, entry_idx: int, value: ttnn.Tensor):
+        assert entry_idx < len(self.cache), f"Expected key {entry_idx} to exist in cache"
+        assert value.layout == ttnn.ROW_MAJOR_LAYOUT, f"Expected value tensor to be row-major layout"
+        assert list(value.shape) == self.entry_shape, f"Expected value tensor to be correct shape ({self.entry_shape})"
+        if self.on_host:
+            self.cache[entry_idx][user_idx] = value.cpu()
+        else:
+            ttl.tensor.copy(value, self.cache[entry_idx][user_idx])
+
+    def get(self, user_idx: int, entry_idx: int) -> ttnn.Tensor:
+        assert entry_idx < len(self.cache), f"Expected key {entry_idx} to exist in cache"
+        return ttnn.to_device(
+            self.cache[entry_idx][user_idx], device=self.device, memory_config=self.cache_memory_config
+        )
+
+    def concat_users(self, entry_idx: int, layout=ttnn.TILE_LAYOUT):
+        assert entry_idx < len(self.cache), f"Expected key {entry_idx} to exist in cache"
+        values = self.cache[entry_idx]
+        if self.on_host:
+            values = [
+                ttnn.to_device(values[i], device=self.device, memory_config=self.cache_memory_config)
+                for i in range(self.num_users)
+            ]
+        return ttnn.to_layout(ttnn.concat(values, dim=2), layout)

--- a/models/demos/mamba/tt/full_model.py
+++ b/models/demos/mamba/tt/full_model.py
@@ -139,7 +139,6 @@ class MambaTT(torch.nn.Module):
         )
 
         for i, layer in enumerate(self.layers):
-            # print(f"Running layer {i}")
             x = layer(x)
 
         if self.return_logits or self.configs["mode"] == ModelMode.DECODE:

--- a/models/demos/mamba/tt/mamba_one_step_ssm.py
+++ b/models/demos/mamba/tt/mamba_one_step_ssm.py
@@ -8,8 +8,8 @@ import ttnn
 import tt_lib as ttl
 from typing import Callable
 
-from models.demos.mamba.reference.args import ModelArgs
-from models.demos.mamba.reference.args import ModelMode
+from models.demos.mamba.reference.args import ModelArgs, ModelMode
+from models.demos.mamba.tt.cache import TensorCache
 
 
 class TtMambaSSM(torch.nn.Module):
@@ -116,11 +116,9 @@ class TtMambaSSM(torch.nn.Module):
                 f"tt_hidden_state_{self.batch_size}", torch_tensor=prev_hidden_states, tt_layout=ttnn.TILE_LAYOUT
             )
         else:
-            prev_hidden_states = torch.zeros((1, 1, 1, self.hidden_size * self.n))
-            self.prev_hidden_state = load_fn(
-                f"tt_hidden_state_{1}", torch_tensor=prev_hidden_states, tt_layout=ttnn.ROW_MAJOR_LAYOUT
+            self.hidden_state_cache = TensorCache(
+                self.configs["num_users"], 1, self.hidden_size * self.n, device, on_host=True
             )
-            self.tt_hidden_states = []
 
         self.compute_kernel_config = ttl.tensor.WormholeComputeKernelConfig(
             math_fidelity=ttl.tensor.MathFidelity.HiFi2,
@@ -133,18 +131,17 @@ class TtMambaSSM(torch.nn.Module):
 
     def to_decode(self, decode_config):
         self.configs = decode_config
-        # deallocate prefill A and D, need to reinitialize when back in prefill mode
+
+        # Deallocate prefill A and D, need to reinitialize when back in prefill mode
         ttnn.deallocate(self.A)
         ttnn.deallocate(self.D)
         self.A = self.A_decode
         self.D = self.D_decode
-        self.tt_hidden_states = torch.cat(self.tt_hidden_states, dim=2)
-        self.tt_hidden_states = ttnn.from_torch(
-            self.tt_hidden_states,
-            device=self.device,
-            layout=ttnn.TILE_LAYOUT,
-            memory_config=ttnn.DRAM_MEMORY_CONFIG,
-            dtype=self.configs["dtype"]["activations"],
+
+        # The initial decode hidden state is stored in the cache
+        self.tt_hidden_states = ttnn.typecast(
+            self.hidden_state_cache.concat_users(0),
+            self.configs["dtype"]["activations"],
         )
 
     def forward(self, x):
@@ -263,7 +260,8 @@ class TtMambaSSM(torch.nn.Module):
 
         elif self.configs["mode"] == ModelMode.PREFILL:
             prev_hidden_state = ttnn.to_memory_config(
-                self.prev_hidden_state, memory_config=self.configs["sharded_prev_hidden"]
+                self.hidden_state_cache.get(self.configs["current_user"], 0),
+                memory_config=self.configs["sharded_prev_hidden"],
             )
             abar2_sharded = ttnn.to_memory_config(abar2, self.configs["sharded_scan"])
             ttnn.deallocate(abar2)
@@ -279,14 +277,15 @@ class TtMambaSSM(torch.nn.Module):
             ttnn.deallocate(abar2_sharded)
             ttnn.deallocate(bmulx0_sharded)
 
-            # TODO Need to update when chunkimg is supported, however, this also need to be reset to zeros for next user
-            # self.prev_hidden_state = ttnn.to_memory_config(prev_hidden_state, memory_config=ttnn.DRAM_MEMORY_CONFIG)
+            # We have to move hidden states results to DRAM or else we don't have enough room for the prev_hidden_state copy
+            hidden_state0 = ttnn.to_memory_config(hidden_states_sharded, memory_config=ttnn.DRAM_MEMORY_CONFIG)
+            ttnn.deallocate(hidden_states_sharded)
 
-            self.tt_hidden_states.append(ttnn.to_torch(prev_hidden_state))
+            prev_hidden_state = ttnn.to_memory_config(prev_hidden_state, memory_config=ttnn.DRAM_MEMORY_CONFIG)
+            self.hidden_state_cache.set(self.configs["current_user"], 0, prev_hidden_state)
             ttnn.deallocate(prev_hidden_state)
 
-            hidden_state0 = ttnn.to_memory_config(hidden_states_sharded, memory_config=ttnn.L1_MEMORY_CONFIG)
-            ttnn.deallocate(hidden_states_sharded)
+            hidden_state0 = ttnn.to_memory_config(hidden_state0, memory_config=ttnn.L1_MEMORY_CONFIG)
 
         # compute C
         C0 = ttnn.linear(

--- a/models/demos/mamba/tt/model_config.py
+++ b/models/demos/mamba/tt/model_config.py
@@ -17,6 +17,7 @@ def create_model_config(batch_size, hidden_size, mode=ModelMode.DECODE, seq_len=
     configs["seq_len"] = seq_len
     configs["batch_size"] = batch_size
     configs["num_users"] = 32  # fixing the number of users to 32 throughout the model
+    configs["current_user"] = 0  # fixing the number of users to 32 throughout the model
 
     if mode == ModelMode.DECODE:
         outer_dim = batch_size

--- a/tests/nightly/wh_b0_only_eth/models/demos/mamba/tests/test_cache.py
+++ b/tests/nightly/wh_b0_only_eth/models/demos/mamba/tests/test_cache.py
@@ -1,0 +1,48 @@
+# SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
+
+# SPDX-License-Identifier: Apache-2.0
+
+import pytest
+import ttnn
+import torch
+
+from models.demos.mamba.tt.cache import TensorCache
+
+from tests.tt_eager.python_api_testing.sweep_tests.comparison_funcs import (
+    comp_pcc,
+)
+
+
+@pytest.mark.parametrize("on_host", [True, False])
+@pytest.mark.parametrize(
+    "E, num_users, num_entries",
+    (
+        (32, 32, 1),
+        (2560, 32, 1),
+        (5120, 32, 4),
+    ),
+)
+def test_cache(E, num_users, num_entries, on_host, device):
+    values = [[torch.rand((1, 1, 1, E), dtype=torch.bfloat16) for _ in range(num_users)] for _ in range(num_entries)]
+
+    cache = TensorCache(num_users, num_entries, E, device, on_host=on_host)
+    for i in range(num_entries):
+        for user in range(num_users):
+            value = ttnn.from_torch(
+                values[i][user],
+                device=device,
+                layout=ttnn.ROW_MAJOR_LAYOUT,
+                memory_config=ttnn.DRAM_MEMORY_CONFIG,
+                dtype=ttnn.bfloat16,
+            )
+            cache.set(user, i, value)
+            did_pass, output_pcc = comp_pcc(ttnn.to_torch(value), ttnn.to_torch(cache.get(user, i)), 1.0)
+            assert did_pass
+
+    for i in range(num_entries):
+        conv_states = cache.concat_users(i)
+        assert list(conv_states.shape) == [1, 1, num_users, E]
+
+        expected = torch.concat(values[i], dim=2)
+        did_pass, output_pcc = comp_pcc(expected, ttnn.to_torch(conv_states), 1.0)
+        assert did_pass


### PR DESCRIPTION
### Summary
This change adds a new type `TensorCache` which is used to store the convolution and hidden state values between model invocations. Previously this was a fallback to PyTorch.

### Checklist
- [x] Post commit CI passes
- [x] Model regression CI testing passes (if applicable)
- [x] New/Existing tests provide coverage for changes
