### PR TITLE
#10323: Reenable Llama perf test in CI

### DIFF
--- a/models/demos/t3000/llama2_70b/tests/test_llama_perf_decode.py
+++ b/models/demos/t3000/llama2_70b/tests/test_llama_perf_decode.py
@@ -233,8 +233,7 @@ def run_test_LlamaModel_end_to_end(
 
 
 @skip_for_grayskull("Requires eth connected devices to run")
-@skip_for_wormhole_b0("See GH Issue #10323")
-@pytest.mark.timeout(240000)
+@pytest.mark.timeout(4500)
 @pytest.mark.model_perf_t3000
 @pytest.mark.parametrize(
     "llama_version",


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/10323

### Problem description
Weight cache issue in CI required me to regenerate cache. Problem is fixed so I'm reenabling the test.

### Checklist
https://github.com/tenstorrent/tt-metal/actions/runs/9978307425