### PR TITLE
Move Mamba embeddings onto device

### DIFF
--- a/models/demos/mamba/tests/test_full_model.py
+++ b/models/demos/mamba/tests/test_full_model.py
@@ -125,7 +125,7 @@ buildings, agriculture and land use are among the main sectors causing greenhous
             128,
             64,
             1,
-            0.96,
+            0.9575,
         ),
         (
             "state-spaces/mamba-2.8b",


### PR DESCRIPTION
### Summary

This change moves the embedding layer to device. This work is a prerequisite for supporting infinite sequence lengths in prefill.

### Checklist
- [x] Post commit CI passes
- [x] Model regression CI testing passes (if applicable)
- [x] New/Existing tests provide coverage for changes
