### PR TITLE
#10166: add device mesh apis to query by row and col

### DIFF
--- a/tt_metal/impl/device/multi_device.hpp
+++ b/tt_metal/impl/device/multi_device.hpp
@@ -34,13 +34,20 @@ public:
     DeviceMesh &operator=(DeviceMesh &&) = delete;
 
     std::vector<Device*> get_devices() const;
-    Device* get_device(int queried_device_id);
+    Device *get_device(int logical_device_id) const;
+    Device *get_device(int row_idx, int col_idx) const;
+    std::vector<Device *> get_devices_on_row(int row_idx) const;
+    std::vector<Device *> get_devices_on_column(int col_idx) const;
 
     const DeviceIds get_device_ids() const;
 
     int num_devices() const;
 
     void close_devices();
+
+   private:
+    int num_rows;
+    int num_cols;
 };
 
 

--- a/ttnn/cpp/pybind11/multi_device.hpp
+++ b/ttnn/cpp/pybind11/multi_device.hpp
@@ -26,14 +26,41 @@ void py_module(py::module& module) {
             py::arg("l1_small_size"),
             py::arg("trace_region_size"),
             py::arg("num_command_queues"))
-        .def("get_device", &ttnn::multi_device::DeviceMesh::get_device, py::return_value_policy::reference)
         .def("get_num_devices", &ttnn::multi_device::DeviceMesh::num_devices)
         .def("get_device_ids", &ttnn::multi_device::DeviceMesh::get_device_ids)
+        .def(
+            "get_device",
+            py::overload_cast<int>(&ttnn::multi_device::DeviceMesh::get_device, py::const_),
+            py::return_value_policy::reference)
+        .def(
+            "get_device",
+            py::overload_cast<int, int>(&ttnn::multi_device::DeviceMesh::get_device, py::const_),
+            py::return_value_policy::reference)
         .def("get_devices", &ttnn::multi_device::DeviceMesh::get_devices, py::return_value_policy::reference, R"doc(
             Get the devices in the device mesh.
 
             Returns:
                 List[Device]: The devices in the device mesh.
+        )doc")
+        .def(
+            "get_devices_on_row",
+            &ttnn::multi_device::DeviceMesh::get_devices_on_row,
+            py::return_value_policy::reference,
+            R"doc(
+            Get the devices in a row of the device mesh.
+
+            Returns:
+                List[Device]: The devices on a row in the device mesh.
+        )doc")
+        .def(
+            "get_devices_on_column",
+            &ttnn::multi_device::DeviceMesh::get_devices_on_column,
+            py::return_value_policy::reference,
+            R"doc(
+            Get the devices in a row of the device mesh.
+
+            Returns:
+                List[Device]: The devices on a row in the device mesh.
         )doc");
 
     module.def(


### PR DESCRIPTION
### Ticket
[Link to Github Issue](https://github.com/tenstorrent/tt-metal/issues/10166)

### Problem description
Need some apis to get rows/cols in device mesh.

### What's changed
Add some apis to get rows/cols in device mesh.

### Checklist
- [ ] Post commit CI passes
- [ ] Model regression CI testing passes (if applicable)
- [ ] New/Existing tests provide coverage for changes
