### PR TITLE
#10415: add new full-tensor bidirectional mode to all-gather

### DIFF
--- a/tests/ttnn/unit_tests/operations/test_all_gather.py
+++ b/tests/ttnn/unit_tests/operations/test_all_gather.py
@@ -864,6 +864,7 @@ def run_all_gather_sharded(
         else:
             eq, output = comp_pcc(tt_output_tensor, unchunked_input_tensor)
         if not eq:
+            all_eq = False
             logger.error(f"output mismatch for tensor {i}")
     assert all_eq, f"{i} FAILED: {output}"
 

--- a/ttnn/cpp/ttnn/operations/ccl/all_gather/device/kernels/dataflow/worker_interleaved_ring_gather_send_writer.cpp
+++ b/ttnn/cpp/ttnn/operations/ccl/all_gather/device/kernels/dataflow/worker_interleaved_ring_gather_send_writer.cpp
@@ -100,5 +100,4 @@ void kernel_main() {
             pop_filler_pages_from_cb(cb_id_in0, half_cb_n_pages - rem_num_pages);
         }
     }
-
 }

--- a/ttnn/cpp/ttnn/operations/ccl/all_gather/device/multi_core/all_gather_op_multi_core.cpp
+++ b/ttnn/cpp/ttnn/operations/ccl/all_gather/device/multi_core/all_gather_op_multi_core.cpp
@@ -55,6 +55,83 @@ static std::tuple<CoreRangeSet,CoreRangeSet> select_worker_cores(AllGatherConfig
 }
 
 
+std::vector<std::vector<uint32_t>> compute_worker_sender_num_transfers(
+    AllGatherConfig const& all_gather_config, uint32_t num_links, uint32_t ring_size, uint32_t ring_index, all_gather_op::Topology topology, uint32_t direction
+) {
+    std::vector<std::vector<uint32_t>> worker_sender_num_transfers;
+    worker_sender_num_transfers.reserve(num_links);
+    for (uint32_t l = 0; l < num_links; ++l) {
+        worker_sender_num_transfers.emplace_back(all_gather_config.get_num_eth_buffers_per_edm());
+        for(uint32_t b = 0; b < all_gather_config.get_num_eth_buffers_per_edm(); ++b) {
+            uint32_t &worker_num_transfers = worker_sender_num_transfers.at(l).at(b);
+            switch (topology) {
+                case all_gather_op::Topology::Linear:
+                    worker_num_transfers = direction == 0 ? ring_index + 1 : ring_size - ring_index;
+                    break;
+
+                case all_gather_op::Topology::Ring:
+                    switch (all_gather_config.get_bidirectional_mode()) {
+                        case ttnn::AllGatherBidirectionalMode::SPLIT_TENSOR:
+                            worker_num_transfers = ring_size - 1;
+                            break;
+
+                        case ttnn::AllGatherBidirectionalMode::FULL_TENSOR:
+                            worker_num_transfers = direction == 0 /*all_gather_config.is_buffer_in_clockwise_ring(b)*/ ?
+                                ((((ring_size - 1) - 1) / 2) + 1):
+                                (ring_size - 1) / 2;
+                            break;
+
+                        default:
+                            TT_FATAL("Unsupported bidirectional mode");
+                    };
+                    break;
+
+                default:
+                    TT_FATAL("Unsupported topology");
+            };
+        }
+    }
+
+    return worker_sender_num_transfers;
+}
+std::vector<std::vector<uint32_t>> compute_worker_receiver_num_transfers(
+    AllGatherConfig const& all_gather_config, uint32_t num_links, uint32_t ring_size, uint32_t ring_index, all_gather_op::Topology topology, uint32_t direction) {
+    std::vector<std::vector<uint32_t>> worker_sender_num_transfers;
+    worker_sender_num_transfers.reserve(num_links);
+    for (uint32_t l = 0; l < num_links; ++l) {
+        worker_sender_num_transfers.emplace_back(all_gather_config.get_num_eth_buffers_per_edm());
+        for(uint32_t b = 0; b < all_gather_config.get_num_eth_buffers_per_edm(); ++b) {
+            uint32_t &worker_num_transfers = worker_sender_num_transfers.at(l).at(b);
+            switch (topology) {
+                case all_gather_op::Topology::Linear:
+                    worker_num_transfers = (direction == 0 ? ring_index + 1: ring_size - ring_index) - 1;
+                    break;
+
+                case all_gather_op::Topology::Ring:
+                    switch (all_gather_config.get_bidirectional_mode()) {
+                        case ttnn::AllGatherBidirectionalMode::SPLIT_TENSOR:
+                            worker_num_transfers = ring_size - 1;
+                            break;
+
+                        case ttnn::AllGatherBidirectionalMode::FULL_TENSOR:
+                            worker_num_transfers = direction == 0 /*all_gather_config.is_buffer_in_clockwise_ring(b)*/ ?
+                                ((((ring_size - 1) - 1) / 2) + 1):
+                                (ring_size - 1) / 2;
+                            break;
+
+                        default:
+                            TT_FATAL("Unsupported bidirectional mode");
+                    };
+                    break;
+
+                default:
+                    TT_FATAL("Unsupported topology");
+            };
+        }
+    }
+
+    return worker_sender_num_transfers;
+}
 
 
 // For ring all-gather, we can send sub-sections of input tensor in opposite directions
@@ -116,8 +193,14 @@ operation::ProgramWithCallbacks all_gather_multi_core_with_workers(const Tensor&
         worker_defines["TILE_INTERLEAVED"] = "1";
     }
 
+    bool full_send_both_directions =
+        (topology == all_gather_op::Topology::Linear ||
+         (topology == all_gather_op::Topology::Ring &&
+          all_gather_config.get_bidirectional_mode() == ttnn::AllGatherBidirectionalMode::FULL_TENSOR));
+    const uint32_t num_full_send_directions = full_send_both_directions ? 2 : 1;
+    constexpr uint32_t max_num_full_send_directions = 2;
     // number of worker cores is 2x this since there is 1 worker for the sender buffer and 1 worker for the receiver buffer
-    uint32_t total_worker_core_pairs_used = num_links * all_gather_config.get_num_eth_buffers_per_edm();
+    uint32_t total_worker_core_pairs_used = num_links * all_gather_config.get_num_eth_buffers_per_edm() * num_full_send_directions;
 
     std::vector<KernelHandle> worker_reader_sender_kernels;
     worker_reader_sender_kernels.reserve(total_worker_core_pairs_used);
@@ -134,14 +217,9 @@ operation::ProgramWithCallbacks all_gather_multi_core_with_workers(const Tensor&
     std::vector<CoreCoord> all_worker_receiver_cores;
     all_worker_receiver_cores.reserve(total_worker_core_pairs_used);
 
-
     uint32_t num_input_pages = input_tensor.buffer()->size() / input_page_size;
     uint32_t min_pages_per_link = num_input_pages / num_links;
 
-
-
-    const uint32_t num_full_send_directions = topology == all_gather_op::Topology::Linear ? 2 : 1;
-    constexpr uint32_t max_num_full_send_directions = 2;
 
     std::vector<EriscDatamoverBuilder> clockwise_edm_builders;
     std::vector<EriscDatamoverBuilder> counter_clockwise_edm_builders;
@@ -151,8 +229,8 @@ operation::ProgramWithCallbacks all_gather_multi_core_with_workers(const Tensor&
     auto edm_sem_addrs_per_link = std::vector<std::vector<uint32_t>>(num_links);
     auto edm_buffer_addrs_per_link = std::vector<std::vector<uint32_t>>(num_links);
     for (uint32_t link = 0; link < num_links; link++) {
-        edm_sem_addrs_per_link.at(link).reserve(all_gather_config.get_num_eth_buffers_per_edm());
-        edm_buffer_addrs_per_link.at(link).reserve(all_gather_config.get_num_eth_buffers_per_edm());
+        edm_sem_addrs_per_link.at(link).reserve(all_gather_config.get_num_eth_buffers_per_edm() * num_full_send_directions);
+        edm_buffer_addrs_per_link.at(link).reserve(all_gather_config.get_num_eth_buffers_per_edm() * num_full_send_directions);
 
         uint32_t edm_sem_addr = all_gather_config.get_eth_sems_l1_base_byte_address();
         uint32_t edm_buffer_addr = all_gather_config.get_eth_buffers_l1_base_byte_address();
@@ -178,22 +256,21 @@ operation::ProgramWithCallbacks all_gather_multi_core_with_workers(const Tensor&
         // but if we are implementing a line topology, the number of transfers will depend on whether we
         // are setting up the forward/clockwise direction or the backward/counter-clockwise direction and also
         // how far we are from the first/last chip, depending on whether we are in forward or  direction
-        const uint32_t sender_num_transfers = topology == all_gather_op::Topology::Linear ?
-            (direction == 0 ? ring_index + 1: ring_size - ring_index):
-            ring_size - 1;
-        const uint32_t receiver_num_transfers = topology == all_gather_op::Topology::Linear ?
-            sender_num_transfers - 1:
-            ring_size - 1;
+
+        auto const& sender_worker_num_transfers = compute_worker_sender_num_transfers(
+            all_gather_config, num_links, ring_size, ring_index, topology, direction);
+        auto const& receiver_worker_num_transfers = compute_worker_receiver_num_transfers(
+            all_gather_config, num_links, ring_size, ring_index, topology, direction);
         std::vector<CoreCoord> eth_sender_cores;
         eth_sender_cores.reserve(num_links);
         std::vector<CoreCoord> eth_receiver_cores;
         eth_receiver_cores.reserve(num_links);
         // If linear topology, the first chip in the chain will not have a "receiver" eth core (or more correctly,
         // it doesn't have an input clockwise our output counter-clockwise connection)
-        bool is_first_chip_in_chain = direction == 0 ? ring_index == 0 : ring_index == ring_size - 1;
+        bool is_first_chip_in_chain = is_linear && (direction == 0 ? ring_index == 0 : ring_index == ring_size - 1);
         // If linear topology, the last chip in the chain will not have a "sender" eth core (or more correctly,
         // it doesn't have an output clockwise our input counter-clockwise connection)
-        bool is_last_chip_in_chain = direction == 0 ? ring_index == ring_size - 1 : ring_index == 0;
+        bool is_last_chip_in_chain = is_linear && (direction == 0 ? ring_index == ring_size - 1 : ring_index == 0);
 
         uint32_t sender_socket_idx = 0;
         uint32_t receiver_socket_idx = 0;
@@ -220,10 +297,14 @@ operation::ProgramWithCallbacks all_gather_multi_core_with_workers(const Tensor&
             }
         }
 
-        auto is_buffer_in_clockwise_direction = [&all_gather_config,&direction](uint32_t b) {
+        auto is_buffer_in_clockwise_direction = [&all_gather_config,&direction,&topology_config](uint32_t b) {
             TT_ASSERT(direction < max_num_full_send_directions);
-            bool in_clockwise_direction = all_gather_config.is_buffer_in_clockwise_ring(b);
-            return (direction == 0) ? in_clockwise_direction : !in_clockwise_direction;
+            if (!topology_config.is_linear && all_gather_config.get_bidirectional_mode() == ttnn::AllGatherBidirectionalMode::FULL_TENSOR) {
+                return direction == 0;
+            } else {
+                bool in_clockwise_direction = all_gather_config.is_buffer_in_clockwise_ring(b);
+                return (direction == 0) ? in_clockwise_direction : !in_clockwise_direction;
+            }
         };
 
         std::vector<uint32_t> pages_per_link(num_links, min_pages_per_link);
@@ -315,20 +396,10 @@ operation::ProgramWithCallbacks all_gather_multi_core_with_workers(const Tensor&
 
             TT_ASSERT(rem_pages < pages_per_chunk || num_full_chunks == 0);
             TT_ASSERT(rem_pages <= max_pages_per_chunk);
-            std::vector<uint32_t> num_full_chunks_per_worker(all_gather_config.get_num_eth_buffers_per_edm(), num_full_chunks / all_gather_config.get_num_eth_buffers_per_edm());
+            std::vector<uint32_t> num_full_chunks_per_worker(all_gather_config.get_num_eth_buffers_per_edm(),0);
+            std::vector<uint32_t> rem_pages_per_worker(all_gather_config.get_num_eth_buffers_per_edm(), 0);
             std::vector<bool> is_channel_shrinkable(all_gather_config.get_num_eth_buffers_per_edm(), false);
             std::vector<uint32_t> largest_packets_per_channel(all_gather_config.get_num_eth_buffers_per_edm(), 0);
-            std::vector<uint32_t> rem_pages_per_worker(all_gather_config.get_num_eth_buffers_per_edm(), 0);
-            {
-                uint32_t worker_idx = 0;
-                for (worker_idx = 0; worker_idx < num_full_chunks % all_gather_config.get_num_eth_buffers_per_edm(); ++worker_idx) {
-                    num_full_chunks_per_worker.at(worker_idx)++;
-                }
-                if (rem_pages != 0) {
-                    rem_pages_per_worker.at(worker_idx % all_gather_config.get_num_eth_buffers_per_edm()) = rem_pages;
-                    TT_ASSERT(rem_pages_per_worker.at(worker_idx % all_gather_config.get_num_eth_buffers_per_edm()) * 2 <= cb_num_pages);
-                }
-            }
 
             std::vector<uint32_t> clockwise_link_buffer_num_messages_to_send;
             std::vector<uint32_t> counter_clockwise_link_buffer_num_messages_to_send;
@@ -338,6 +409,34 @@ operation::ProgramWithCallbacks all_gather_multi_core_with_workers(const Tensor&
             counter_clockwise_link_buffer_num_messages_to_send.reserve(all_gather_config.get_num_eth_buffers_per_edm());
             edm_semaphores_base_address.reserve(all_gather_config.get_num_eth_buffers_per_edm());
             link_buffer_sender_addresses.reserve(all_gather_config.get_num_eth_buffers_per_edm());
+
+            {
+                for (std::size_t b = 0; b < all_gather_config.get_num_eth_buffers_per_edm(); b++) {
+                    num_full_chunks_per_worker.at(b) = num_full_chunks / all_gather_config.get_num_eth_buffers_per_edm();
+                }
+                uint32_t worker_idx = 0;
+                for (worker_idx = 0; worker_idx < num_full_chunks % all_gather_config.get_num_eth_buffers_per_edm(); ++worker_idx) {
+                    num_full_chunks_per_worker.at(worker_idx)++;
+                }
+                if (rem_pages != 0) {
+                    rem_pages_per_worker.at(worker_idx % all_gather_config.get_num_eth_buffers_per_edm()) = rem_pages;
+                    TT_ASSERT(rem_pages_per_worker.at(worker_idx % all_gather_config.get_num_eth_buffers_per_edm()) * 2 <= cb_num_pages);
+                }
+                { // Logging
+                    log_trace(tt::LogOp, "num_full_chunks, remaining pages per worker (clockwise):");
+                    for (std::size_t b = 0; b < all_gather_config.get_num_eth_buffers_per_edm(); b++) {
+                        if (is_buffer_in_clockwise_direction(b)) {
+                            log_trace(tt::LogOp, "\tworker {}: {}, {}", b, num_full_chunks_per_worker.at(b), rem_pages_per_worker.at(b));
+                        }
+                    }
+                    log_trace(tt::LogOp, "num_full_chunks, remaining pages per worker (counter-clockwise):");
+                    for (std::size_t b = 0; b < all_gather_config.get_num_eth_buffers_per_edm(); b++) {
+                        if (!is_buffer_in_clockwise_direction(b)) {
+                            log_trace(tt::LogOp, "\tworker {}: {}, {}", b, num_full_chunks_per_worker.at(b), rem_pages_per_worker.at(b));
+                        }
+                    }
+                }
+            }
             if (is_sharded) {
                 for(uint32_t b = 0; b < all_gather_config.get_num_eth_buffers_per_edm(); ++b) {
                     auto input_tensor_shard_arg_generator = InputTensorShardAddrGenArgGenerator(
@@ -376,10 +475,10 @@ operation::ProgramWithCallbacks all_gather_multi_core_with_workers(const Tensor&
                 // link num messages
                 clockwise_link_buffer_num_messages_to_send.push_back(
                     (num_full_chunks_per_worker.at(b) + (rem_pages_per_worker.at(b) > 0 ? 1 : 0)) *
-                    sender_num_transfers);
+                    sender_worker_num_transfers.at(i).at(b));
                 counter_clockwise_link_buffer_num_messages_to_send.push_back(
                     (num_full_chunks_per_worker.at(b) + (rem_pages_per_worker.at(b) > 0 ? 1 : 0)) *
-                    receiver_num_transfers);
+                    receiver_worker_num_transfers.at(i).at(b));
             }
             for(uint32_t b = 0; b < all_gather_config.get_num_eth_buffers_per_edm(); ++b) {
                 log_trace(tt::LogOp, "rem_pages_per_worker[{}]: {}", b, rem_pages_per_worker.at(b));
@@ -470,18 +569,18 @@ operation::ProgramWithCallbacks all_gather_multi_core_with_workers(const Tensor&
                             // 2) num_transfers
                             std::vector<uint32_t> worker_reader_sender_ct_args = {
                                 static_cast<uint32_t>(sharding_info.get_shard_type()),
-                                static_cast<uint32_t>(sender_num_transfers)
+                                static_cast<uint32_t>(sender_worker_num_transfers.at(i).at(b))
                             };
                             log_trace(tt::LogOp, "----worker_reader_sender_ct_args size={}", worker_reader_sender_ct_args.size());
                             log_trace(tt::LogOp, "\tsharding_info.get_shard_type(): {}", sharding_info.get_shard_type());
-                            log_trace(tt::LogOp, "\tnum_transfers: {}", sender_num_transfers);
+                            log_trace(tt::LogOp, "\tnum_transfers: {}", sender_worker_num_transfers.at(i).at(b));
 
                             return worker_reader_sender_ct_args;
                         } else {
                             std::vector<uint32_t> worker_reader_sender_ct_args = {
                                 static_cast<uint32_t>(all_gather_config.is_input_dram()),
                                 static_cast<uint32_t>(all_gather_config.is_output_dram()),
-                                static_cast<uint32_t>(sender_num_transfers),
+                                static_cast<uint32_t>(sender_worker_num_transfers.at(i).at(b)),
                                 static_cast<uint32_t>(num_full_chunks_per_worker.at(b)),
                                 static_cast<uint32_t>(input_page_size),
                                 static_cast<uint32_t>(output_page_size),
@@ -510,7 +609,7 @@ operation::ProgramWithCallbacks all_gather_multi_core_with_workers(const Tensor&
                             log_trace(tt::LogOp, "Worker {} SR args", b);
                             log_trace(tt::LogOp, "\tall_gather_config.is_input_dram(): {}", all_gather_config.is_input_dram());
                             log_trace(tt::LogOp, "\tall_gather_config.is_output_dram(): {}", all_gather_config.is_output_dram());
-                            log_trace(tt::LogOp, "\tsender_num_transfers: {}", sender_num_transfers);
+                            log_trace(tt::LogOp, "\tsender_num_transfers: {}", sender_worker_num_transfers.at(i).at(b));
                             log_trace(tt::LogOp, "\tnum_full_chunks_per_worker.at(b): {}", num_full_chunks_per_worker.at(b));
                             log_trace(tt::LogOp, "\tinput_page_size: {}", input_page_size);
                             log_trace(tt::LogOp, "\toutput_page_size: {}", output_page_size);
@@ -647,7 +746,7 @@ operation::ProgramWithCallbacks all_gather_multi_core_with_workers(const Tensor&
                             CoreCoord const& worker_eth_sender_core = is_clockwise_direction ? eth_sender_cores.at(i) : eth_receiver_cores.at(i);
                             std::vector<uint32_t> worker_writer_sender_ct_args = {
                                 static_cast<uint32_t>(all_gather_config.is_output_dram()),
-                                static_cast<uint32_t>(sender_num_transfers),
+                                static_cast<uint32_t>(sender_worker_num_transfers.at(i).at(b)),
                                 static_cast<uint32_t>(num_full_chunks_per_worker.at(b)),
                                 static_cast<uint32_t>(input_page_size),
                                 static_cast<uint32_t>(output_page_size),
@@ -672,7 +771,7 @@ operation::ProgramWithCallbacks all_gather_multi_core_with_workers(const Tensor&
                             };
                             log_trace(tt::LogOp, "Worker {} SW CT args", b);
                             log_trace(tt::LogOp, "\tall_gather_config.is_output_dram(): {}", all_gather_config.is_output_dram());
-                            log_trace(tt::LogOp, "\tsender_num_transfers: {}", sender_num_transfers);
+                            log_trace(tt::LogOp, "\tsender_num_transfers: {}", sender_worker_num_transfers.at(i).at(b));
                             log_trace(tt::LogOp, "\tnum_full_chunks_per_worker: {}", num_full_chunks_per_worker.at(b));
                             log_trace(tt::LogOp, "\tinput_page_size: {}", input_page_size);
                             log_trace(tt::LogOp, "\toutput_page_size: {}", output_page_size);
@@ -755,7 +854,7 @@ operation::ProgramWithCallbacks all_gather_multi_core_with_workers(const Tensor&
                                 static_cast<uint32_t>(device->ethernet_core_from_logical_core(worker_eth_sender_core).y), // eth_sender_noc_y
                                 static_cast<uint32_t>(pages_per_eth_l1_buffer.at(b)), //output_tensor_shard_arg_generator.args_struct.num_dest_cores),//pages_per_eth_l1_buffer.at(b)),
                                 static_cast<uint32_t>(sender_worker_writer_semaphore_addr), // writer_send_sem_addr
-                                static_cast<uint32_t>(sender_num_transfers),
+                                static_cast<uint32_t>(sender_worker_num_transfers.at(i).at(b)),
                                 static_cast<uint32_t>(input_tensor_shard_arg_generator.args_struct.num_dest_cores),
                                 static_cast<uint32_t>(cb_num_pages / 2),
                             };
@@ -771,7 +870,7 @@ operation::ProgramWithCallbacks all_gather_multi_core_with_workers(const Tensor&
                             log_trace(tt::LogOp, "\teth_sender_noc_y: {}", device->ethernet_core_from_logical_core(worker_eth_sender_core).y);
                             log_trace(tt::LogOp, "\tpages_per_eth_l1_buffer: {}", pages_per_eth_l1_buffer.at(b));
                             log_trace(tt::LogOp, "\twriter_send_sem_addr: {}", sender_worker_writer_semaphore_addr);
-                            log_trace(tt::LogOp, "\tnum_transfers: {}", sender_num_transfers);
+                            log_trace(tt::LogOp, "\tnum_transfers: {}", sender_worker_num_transfers.at(i).at(b));
                             output_tensor_shard_arg_generator.dump_to_log();
 
                             return worker_writer_sender_rt_args;
@@ -817,7 +916,6 @@ operation::ProgramWithCallbacks all_gather_multi_core_with_workers(const Tensor&
                     TT_ASSERT(!is_linear ||
                         ((is_clockwise_direction && (ring_index != 0)) || (!is_clockwise_direction && ring_index != ring_size - 1))
                     );
-                    // TODO(snijjar): squash before merge
                     uint32_t receiver_ring_index = is_linear?
                         (is_clockwise_direction ? ring_index - 1 : ring_index + 1):
                         (is_clockwise_direction ?
@@ -869,7 +967,7 @@ operation::ProgramWithCallbacks all_gather_multi_core_with_workers(const Tensor&
                         } else {
                             CoreCoord const& worker_eth_receiver_core = is_clockwise_direction ? eth_receiver_cores.at(i) : eth_sender_cores.at(i);
                             std::vector<uint32_t> worker_receiver_reader_ct_args = {
-                                static_cast<uint32_t>(receiver_num_transfers),
+                                static_cast<uint32_t>(receiver_worker_num_transfers.at(i).at(b)),
                                 static_cast<uint32_t>(num_full_chunks_per_worker.at(b)),
                                 static_cast<uint32_t>(input_page_size),
                                 static_cast<uint32_t>(pages_per_chunk),
@@ -882,7 +980,7 @@ operation::ProgramWithCallbacks all_gather_multi_core_with_workers(const Tensor&
                             };
 
                             log_trace(tt::LogOp, "Worker {} RR ct args", b);
-                            log_trace(tt::LogOp, "\treceiver_num_transfers: {}", receiver_num_transfers);
+                            log_trace(tt::LogOp, "\treceiver_num_transfers: {}", receiver_worker_num_transfers.at(i).at(b));
                             log_trace(tt::LogOp, "\tnum_full_chunks_per_worker: {}", num_full_chunks_per_worker.at(b));
                             log_trace(tt::LogOp, "\tinput_page_size: {}", input_page_size);
                             log_trace(tt::LogOp, "\tpages_per_chunk: {}", pages_per_chunk);
@@ -940,7 +1038,7 @@ operation::ProgramWithCallbacks all_gather_multi_core_with_workers(const Tensor&
                             worker_reader_receiver_rt_args.push_back(static_cast<uint32_t>(receiver_eth_sem_addrs.at(b))); // eth_receiver_l1_semaphore_addr
                             worker_reader_receiver_rt_args.push_back(receiver_worker_semaphore_addr); // local_receiver_read_sem_addr
                             worker_reader_receiver_rt_args.push_back(pages_per_eth_l1_buffer.at(b)), //output_tensor_shard_arg_generator.args_struct.num_dest_cores), //pages_per_eth_l1_buffer.at(b)); // num_shards_per_eth_buf
-                            worker_reader_receiver_rt_args.push_back(receiver_num_transfers); // local_receiver_read_sem_addr
+                            worker_reader_receiver_rt_args.push_back(receiver_worker_num_transfers.at(i).at(b)); // local_receiver_read_sem_addr
                             worker_reader_receiver_rt_args.push_back(static_cast<uint32_t>(cb_num_pages / 2)); // local_receiver_read_sem_addr
                             std::copy(output_tensor_shard_addr_gen_args.begin(), output_tensor_shard_addr_gen_args.end(), std::back_inserter(worker_reader_receiver_rt_args));
 
@@ -999,7 +1097,7 @@ operation::ProgramWithCallbacks all_gather_multi_core_with_workers(const Tensor&
                         } else {
                             std::vector<uint32_t> worker_writer_receiver_ct_args = {
                                 static_cast<uint32_t>(all_gather_config.is_output_dram()),
-                                static_cast<uint32_t>(receiver_num_transfers),
+                                static_cast<uint32_t>(receiver_worker_num_transfers.at(i).at(b)),
                                 static_cast<uint32_t>(num_full_chunks_per_worker.at(b)),
                                 static_cast<uint32_t>(input_page_size),
                                 static_cast<uint32_t>(output_page_size),
@@ -1026,7 +1124,7 @@ operation::ProgramWithCallbacks all_gather_multi_core_with_workers(const Tensor&
 
                             log_trace(tt::LogOp, "Worker {} RW ct args", b);
                             log_trace(tt::LogOp, "\tall_gather_config.is_output_dram(): {}", all_gather_config.is_output_dram());
-                            log_trace(tt::LogOp, "\treceiver_num_transfers: {}", receiver_num_transfers);
+                            log_trace(tt::LogOp, "\treceiver_num_transfers: {}", receiver_worker_num_transfers.at(i).at(b));
                             log_trace(tt::LogOp, "\tnum_full_chunks_per_worker.at(b): {}", num_full_chunks_per_worker.at(b));
                             log_trace(tt::LogOp, "\tinput_page_size: {}", input_page_size);
                             log_trace(tt::LogOp, "\toutput_page_size: {}", output_page_size);
@@ -1091,7 +1189,7 @@ operation::ProgramWithCallbacks all_gather_multi_core_with_workers(const Tensor&
                             worker_receive_writer_rt_args.push_back(sender_worker_reader_semaphore_addr);
 
                             worker_receive_writer_rt_args.push_back(output_tensor_shard_arg_generator.args_struct.num_dest_cores), //pages_per_eth_l1_buffer.at(b));
-                            worker_receive_writer_rt_args.push_back(receiver_num_transfers);
+                            worker_receive_writer_rt_args.push_back(receiver_worker_num_transfers.at(i).at(b));
                             worker_receive_writer_rt_args.push_back(pages_per_buffer.at(b));
                             worker_receive_writer_rt_args.push_back(static_cast<uint32_t>(cb_num_pages / 2));
 

--- a/ttnn/cpp/ttnn/operations/ccl/ccl_common.cpp
+++ b/ttnn/cpp/ttnn/operations/ccl/ccl_common.cpp
@@ -78,12 +78,12 @@ KernelHandle generate_edm_kernel(
     ccl::EriscDatamoverBuilder const& edm_builder,
     CoreCoord const& eth_core,
     NOC noc_id) {
-    log_trace(tt::LogOp, "EDM CLOCKWISE KERNEL RT ARGS: ");
     edm_builder.dump_to_log();
 
     std::vector<uint32_t> const& edm_clockwise_kernel_rt_args = edm_builder.emit_runtime_args();
     // Ethernet Kernels
     std::vector<uint32_t> eth_sender_ct_args = edm_builder.emit_compile_time_args();
+    log_trace(tt::LogOp, "EDM core (x={},y={}):", eth_core.x, eth_core.y);
     log_trace(tt::LogOp, "CT ARGS:");
     for (auto const& s : eth_sender_ct_args) {
         log_trace(tt::LogOp, "\t{}", s);

--- a/ttnn/cpp/ttnn/operations/ccl/kernels/edm/erisc_datamover.cpp
+++ b/ttnn/cpp/ttnn/operations/ccl/kernels/edm/erisc_datamover.cpp
@@ -107,6 +107,7 @@ struct sender_receiver_index_t {
     }
 };
 
+
 void kernel_main() {
     // COMPILE TIME ARGS
     // If true, will enable this erisc's sender functionality
@@ -124,9 +125,9 @@ void kernel_main() {
     constexpr ttnn::ccl::EriscDataMoverTerminationMode terminate_on_worker_signal =
         static_cast<ttnn::ccl::EriscDataMoverTerminationMode>(get_compile_time_arg_val(5));
 
-    constexpr auto EDM_CONFIG = erisc::datamover::EriscDatamoverConfig<edm_buffer_sharing_mode, terminate_on_worker_signal>();
-    using EDM_CONFIG_T = decltype(EDM_CONFIG);
+    using EDM_CONFIG_T = erisc::datamover::EriscDatamoverConfig<edm_buffer_sharing_mode, terminate_on_worker_signal>;
     using ChannelBufferT = erisc::datamover::ChannelBuffer<EDM_CONFIG_T>;
+
     std::array<ChannelBufferT, eth_l1_mem::address_map::MAX_NUM_CONCURRENT_TRANSACTIONS> buffer_channels;
 
     //


### PR DESCRIPTION
The new bidirectional all-gather mode is being added as a prerequisite to all-gather + matmul fusion. In addition, this change also leads to performance improvements, particularly for smaller all-gathers because fewer end-to-end latencies add up for what tensor to be single packet per channel/per ring index. Larger tensors see a performance degradation with this mode but this mode is only enabled for small tensors at the moment, otherwise it can be opted into.

The new mode sends the full input tensor for a given tensor both directions around the ring, but only halfway around the ring in each direction. This is in contrast to the prior default mode (SPLIT_TENSOR) which would send half of the input tensor each direction, but the full way around the ring.

This new mode is not enabled yet for sharded all-gather.

### Ticket
[Link to Github Issue](https://github.com/tenstorrent/tt-metal/issues/10415)

### Problem description
When fusing all-gather matmul, the current bidirectional all-gather data movement scheme would require **extremely** tight coupling between matmul and all-gather. This alternative bidirectional approach removes that because full chunks can be passed to each matmul instead of weird slice shapes that depend on CCL worker schedule.

### What's changed
Setup work for enabling all_gather + matmul fusion

### Checklist
- [x] Post commit CI passes
  - [x] https://github.com/tenstorrent/tt-metal/actions/runs/10030701080
- [x] t3000 frequent
  - [x] https://github.com/tenstorrent/tt-metal/actions/runs/10014049625
- [x] t3000 model regression
  - [x] https://github.com/tenstorrent/tt-metal/actions/runs/10014059851
- [x] New/Existing tests provide coverage for changes
  - Not a new feature - so running against existing tests
