### PR TITLE
#0: Fixed module loader for python3.12

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -110,8 +110,6 @@ src/firmware/riscv/targets/erisc/src/eth_routing_v2.cpp
 .ipynb_checkpoints/
 ttnn/tutorials/DiT/
 
-ttnn/ttnn/.rpath_checked__ttnn
-
 .envrc
 
 # tt_lib and _ttnn stubs
@@ -126,4 +124,4 @@ ttnn/ttnn/.rpath_checked*
 .cpmcache
 
 ClangBuildAnalyzer.ini
-ttnn/ttnn/.rpath_checked*
+ttnn/ttnn/.rpath_checked__ttnn

--- a/.gitignore
+++ b/.gitignore
@@ -126,4 +126,4 @@ ttnn/ttnn/.rpath_checked*
 .cpmcache
 
 ClangBuildAnalyzer.ini
-ttnn/ttnn/.rpath_checked__ttnn
+ttnn/ttnn/.rpath_checked*

--- a/.gitignore
+++ b/.gitignore
@@ -110,6 +110,8 @@ src/firmware/riscv/targets/erisc/src/eth_routing_v2.cpp
 .ipynb_checkpoints/
 ttnn/tutorials/DiT/
 
+ttnn/ttnn/.rpath_checked__ttnn
+
 .envrc
 
 # tt_lib and _ttnn stubs

--- a/ttnn/ttnn/operations/__init__.py
+++ b/ttnn/ttnn/operations/__init__.py
@@ -6,7 +6,7 @@ import pkgutil
 
 __all__ = []
 
-for loader, module_name, is_pkg in pkgutil.iter_modules(__path__):
+for loader, module_name, is_pkg in pkgutil.walk_packages(__path__):
     __all__.append(module_name)
     _module = loader.find_spec(module_name).loader.load_module(module_name)
     globals()[module_name] = _module

--- a/ttnn/ttnn/operations/__init__.py
+++ b/ttnn/ttnn/operations/__init__.py
@@ -6,7 +6,7 @@ import pkgutil
 
 __all__ = []
 
-for loader, module_name, is_pkg in pkgutil.walk_packages(__path__):
+for loader, module_name, is_pkg in pkgutil.iter_modules(__path__):
     __all__.append(module_name)
-    _module = loader.find_module(module_name).load_module(module_name)
+    _module = loader.find_spec(module_name).loader.load_module(module_name)
     globals()[module_name] = _module


### PR DESCRIPTION
### Problem description
find_module has been removed in [Python 3.12](https://docs.python.org/3/reference/import.html#the-meta-path)

### What's changed
find_module has been replaced with find_spec().loader

### Checklist
- [x] Post commit CI passes - https://github.com/tenstorrent/tt-metal/actions/runs/9987289159

