### PR TITLE
#10322: Re-enable Mixtral CI tests due to corrupted cache in CI machine

### DIFF
--- a/models/demos/t3000/mixtral8x7b/tests/test_mixtral_attention.py
+++ b/models/demos/t3000/mixtral8x7b/tests/test_mixtral_attention.py
@@ -27,7 +27,6 @@ from models.utility_functions import (
 )
 
 
-@skip_for_wormhole_b0("See GH Issue #10322")
 def test_mixtral_attention_inference(t3k_device_mesh, use_program_cache, reset_seeds):
     pcc = 0.99
     dtype = ttnn.bfloat8_b

--- a/models/demos/t3000/mixtral8x7b/tests/test_mixtral_mlp.py
+++ b/models/demos/t3000/mixtral8x7b/tests/test_mixtral_mlp.py
@@ -26,7 +26,6 @@ from models.utility_functions import (
 )
 
 
-@skip_for_wormhole_b0("See GH Issue #10322")
 def test_mixtral_mlp_inference(t3k_device_mesh, use_program_cache, reset_seeds):
     # Specify different dtypes for each feedForward weights
     dtypes = {

--- a/models/demos/t3000/mixtral8x7b/tests/test_mixtral_rms_norm.py
+++ b/models/demos/t3000/mixtral8x7b/tests/test_mixtral_rms_norm.py
@@ -27,7 +27,6 @@ from models.utility_functions import (
 )
 
 
-# @skip_for_wormhole_b0("See GH Issue #10322")
 def test_mixtral_rms_norm_inference(t3k_device_mesh, use_program_cache, reset_seeds):
     dtype = ttnn.bfloat8_b
 


### PR DESCRIPTION
### Ticket
[Issue](https://github.com/tenstorrent/tt-metal/issues/10322)

### Problem description
There was a corrupt cache file in the CI machine, leading to Mixtral test failing. I've re-generated the file and tests are now passing.

Affected cache file was the rms norm weight. This would affect rms, attn, decoder and model tests.

### Checklist
- [ ] [Post commit CI passes](https://github.com/tenstorrent/tt-metal/actions/runs/9989342747)
- [ ] [T3k Mixtral unit tests](https://github.com/tenstorrent/tt-metal/actions/runs/9989190776)
- [ ] [T3k Mixtral frequent tests](https://github.com/tenstorrent/tt-metal/actions/runs/9989181058)
