### PR TITLE
Migration of rsub from tt_eager to ttnn 

### DIFF
--- a/tests/tt_eager/python_api_testing/sweep_tests/op_map.py
+++ b/tests/tt_eager/python_api_testing/sweep_tests/op_map.py
@@ -660,10 +660,6 @@ op_map = {
         "tt_op": tt_lib_ops.eltwise_rdiv,
         "pytorch_op": pytorch_ops.eltwise_rdiv,
     },
-    "eltwise-rsub": {
-        "tt_op": tt_lib_ops.eltwise_rsub,
-        "pytorch_op": pytorch_ops.eltwise_rsub,
-    },
     "eltwise-identity": {
         "tt_op": tt_lib_ops.eltwise_identity,
         "pytorch_op": pytorch_ops.eltwise_identity,

--- a/tests/tt_eager/python_api_testing/sweep_tests/pytests/tt_dnn/test_eltwise_unary.py
+++ b/tests/tt_eager/python_api_testing/sweep_tests/pytests/tt_dnn/test_eltwise_unary.py
@@ -1080,7 +1080,7 @@ class TestEltwiseUnary:
             }
         )
         run_single_pytorch_test(
-            f"ttnn-eltwise-{fn_kind}", input_shapes, datagen_func, comparison_func, device, test_args, ttnn_op=True
+            f"eltwise-{fn_kind}", input_shapes, datagen_func, comparison_func, device, test_args, ttnn_op=True
         )
 
     @pytest.mark.parametrize("fn_kind", ["rsub"])
@@ -1111,7 +1111,7 @@ class TestEltwiseUnary:
             }
         )
         run_single_pytorch_test(
-            f"ttnn-eltwise-{fn_kind}", input_shapes, datagen_func, comparison_func, device, test_args, ttnn_op=True
+            f"eltwise-{fn_kind}", input_shapes, datagen_func, comparison_func, device, test_args, ttnn_op=True
         )
 
     @pytest.mark.parametrize("diag", [-2, -1, 0, 1, 2])

--- a/tests/tt_eager/python_api_testing/sweep_tests/pytests/tt_dnn/test_eltwise_unary.py
+++ b/tests/tt_eager/python_api_testing/sweep_tests/pytests/tt_dnn/test_eltwise_unary.py
@@ -1052,7 +1052,7 @@ class TestEltwiseUnary:
             device,
         )
 
-    @pytest.mark.parametrize("fn_kind", ["rpow", "rsub", "rdiv"])
+    @pytest.mark.parametrize("fn_kind", ["rsub"])
     def test_run_eltwise_reverse_ops(
         self,
         input_shapes,
@@ -1062,7 +1062,7 @@ class TestEltwiseUnary:
         input_mem_config,
         output_mem_config,
     ):
-        values = {"rdiv": (1.0, 100.0), "rsub": (1.0, 50.0), "rpow": (5.0, 10.0)}
+        values = {"rsub": (1.0, 50.0)}
         low_v, high_v = values[fn_kind]
         datagen_func = [
             generation_funcs.gen_func_with_cast(
@@ -1080,15 +1080,10 @@ class TestEltwiseUnary:
             }
         )
         run_single_pytorch_test(
-            f"eltwise-{fn_kind}",
-            input_shapes,
-            datagen_func,
-            comparison_func,
-            device,
-            test_args,
+            f"ttnn-eltwise-{fn_kind}", input_shapes, datagen_func, comparison_func, device, test_args, ttnn_op=True
         )
 
-    @pytest.mark.parametrize("fn_kind", ["rsub", "rdiv"])
+    @pytest.mark.parametrize("fn_kind", ["rsub"])
     def test_run_eltwise_reverse_neg_ops(
         self,
         input_shapes,
@@ -1098,7 +1093,7 @@ class TestEltwiseUnary:
         input_mem_config,
         output_mem_config,
     ):
-        values = {"rdiv": (1.0, 100.0), "rsub": (1.0, 50.0), "rpow": (5.0, 10.0)}
+        values = {"rsub": (1.0, 50.0)}
         low_v, high_v = values[fn_kind]
         datagen_func = [
             generation_funcs.gen_func_with_cast(
@@ -1116,12 +1111,7 @@ class TestEltwiseUnary:
             }
         )
         run_single_pytorch_test(
-            f"eltwise-{fn_kind}",
-            input_shapes,
-            datagen_func,
-            comparison_func,
-            device,
-            test_args,
+            f"ttnn-eltwise-{fn_kind}", input_shapes, datagen_func, comparison_func, device, test_args, ttnn_op=True
         )
 
     @pytest.mark.parametrize("diag", [-2, -1, 0, 1, 2])

--- a/tests/tt_eager/python_api_testing/sweep_tests/tt_lib_ops.py
+++ b/tests/tt_eager/python_api_testing/sweep_tests/tt_lib_ops.py
@@ -2453,24 +2453,6 @@ def eltwise_rdiv(
 
 
 @setup_host_and_device
-def eltwise_rsub(
-    x,
-    *args,
-    device,
-    dtype,
-    layout,
-    input_mem_config,
-    output_mem_config,
-    **kwargs,
-):
-    factor = kwargs["factor"]
-    t0 = setup_tt_tensor(x, device, layout[0], input_mem_config[0], dtype[0])
-    t1 = ttnn.rsub(t0, factor, memory_config=output_mem_config)
-
-    return tt2torch_tensor(t1)
-
-
-@setup_host_and_device
 def eltwise_identity(
     x,
     *args,

--- a/tests/ttnn/python_api_testing/sweep_tests/op_map.py
+++ b/tests/ttnn/python_api_testing/sweep_tests/op_map.py
@@ -80,6 +80,10 @@ op_map = {
         "tt_op": ttnn_ops.eltwise_rsqrt,
         "pytorch_op": pytorch_ops.rsqrt,
     },
+    "ttnn-eltwise-rsub": {
+        "tt_op": ttnn_ops.eltwise_rsub,
+        "pytorch_op": pytorch_ops.eltwise_rsub,
+    },
     "ttnn-eltwise-lerp_binary": {
         "tt_op": ttnn_ops.eltwise_lerp_binary,
         "pytorch_op": pytorch_ops.lerp_binary,

--- a/tests/ttnn/python_api_testing/sweep_tests/op_map.py
+++ b/tests/ttnn/python_api_testing/sweep_tests/op_map.py
@@ -80,7 +80,7 @@ op_map = {
         "tt_op": ttnn_ops.eltwise_rsqrt,
         "pytorch_op": pytorch_ops.rsqrt,
     },
-    "ttnn-eltwise-rsub": {
+    "eltwise-rsub": {
         "tt_op": ttnn_ops.eltwise_rsub,
         "pytorch_op": pytorch_ops.eltwise_rsub,
     },

--- a/tests/ttnn/python_api_testing/sweep_tests/test_configs/ci_sweep_tests_working/grayskull/ttnn_eltwise_rsub_test.yaml
+++ b/tests/ttnn/python_api_testing/sweep_tests/test_configs/ci_sweep_tests_working/grayskull/ttnn_eltwise_rsub_test.yaml
@@ -1,6 +1,6 @@
 ---
 test-list:
-  - ttnn-eltwise-rsub:
+  - eltwise-rsub:
       shape:
         start-shape: [1, 1, 32, 32]
         end-shape: [12, 24, 512, 512]

--- a/tests/ttnn/python_api_testing/sweep_tests/test_configs/ci_sweep_tests_working/grayskull/ttnn_eltwise_rsub_test.yaml
+++ b/tests/ttnn/python_api_testing/sweep_tests/test_configs/ci_sweep_tests_working/grayskull/ttnn_eltwise_rsub_test.yaml
@@ -1,6 +1,6 @@
 ---
 test-list:
-  - eltwise-rsub:
+  - ttnn-eltwise-rsub:
       shape:
         start-shape: [1, 1, 32, 32]
         end-shape: [12, 24, 512, 512]
@@ -21,11 +21,11 @@ test-list:
           - input-1:
             data-layout: ["TILE"]
             data-type: ["BFLOAT16"]
-            buffer-type: ["DRAM", "L1", "SYSTEM_MEMORY"]
+            buffer-type: ["DRAM", "L1"]
           - input-2:
             data-layout: ["TILE"]
             data-type: ["BFLOAT16"]
-            buffer-type: ["DRAM", "L1", "SYSTEM_MEMORY"]
+            buffer-type: ["DRAM", "L1"]
         out-buffer-type: ["DRAM"]
       output-file: eltwise_rsub_sweep.csv
       env:

--- a/tests/ttnn/python_api_testing/sweep_tests/test_configs/ci_sweep_tests_working/grayskull/ttnn_eltwise_rsub_test.yaml
+++ b/tests/ttnn/python_api_testing/sweep_tests/test_configs/ci_sweep_tests_working/grayskull/ttnn_eltwise_rsub_test.yaml
@@ -5,8 +5,8 @@ test-list:
         start-shape: [1, 1, 32, 32]
         end-shape: [12, 24, 512, 512]
         interval: [1, 1, 32, 32]
-        num-shapes: 2
-        num-samples: 64
+        num-shapes: 1
+        num-samples: 128
         args-sampling-strategy: "all"
       datagen:
         function: gen_rand
@@ -17,16 +17,10 @@ test-list:
         function: comp_pcc
       args-gen: gen_rop_args
       args:
-        inputs:
-          - input-1:
-            data-layout: ["TILE"]
-            data-type: ["BFLOAT16"]
-            buffer-type: ["DRAM", "L1"]
-          - input-2:
-            data-layout: ["TILE"]
-            data-type: ["BFLOAT16"]
-            buffer-type: ["DRAM", "L1"]
-        out-buffer-type: ["DRAM"]
+        data-layout: ["TILE"]
+        data-type: ["BFLOAT16", "BFLOAT8_B"]
+        buffer-type: ["DRAM", "L1"]
+        out-buffer-type: ["DRAM", "L1", "SYSTEM_MEMORY"]
       output-file: eltwise_rsub_sweep.csv
       env:
         # TT_PCI_DMA_BUF_SIZE: "1048576"

--- a/tests/ttnn/python_api_testing/sweep_tests/test_configs/ci_sweep_tests_working/wormhole/ttnn_eltwise_rsub_test.yaml
+++ b/tests/ttnn/python_api_testing/sweep_tests/test_configs/ci_sweep_tests_working/wormhole/ttnn_eltwise_rsub_test.yaml
@@ -1,6 +1,6 @@
 ---
 test-list:
-  - ttnn-eltwise-rsub:
+  - eltwise-rsub:
       shape:
         start-shape: [1, 1, 32, 32]
         end-shape: [12, 24, 512, 512]

--- a/tests/ttnn/python_api_testing/sweep_tests/test_configs/ci_sweep_tests_working/wormhole/ttnn_eltwise_rsub_test.yaml
+++ b/tests/ttnn/python_api_testing/sweep_tests/test_configs/ci_sweep_tests_working/wormhole/ttnn_eltwise_rsub_test.yaml
@@ -5,8 +5,8 @@ test-list:
         start-shape: [1, 1, 32, 32]
         end-shape: [12, 24, 512, 512]
         interval: [1, 1, 32, 32]
-        num-shapes: 2
-        num-samples: 64
+        num-shapes: 1
+        num-samples: 128
         args-sampling-strategy: "all"
       datagen:
         function: gen_rand
@@ -17,16 +17,10 @@ test-list:
         function: comp_pcc
       args-gen: gen_rop_args
       args:
-        inputs:
-          - input-1:
-            data-layout: ["TILE"]
-            data-type: ["BFLOAT16", "BFLOAT8_B"]
-            buffer-type: ["DRAM", "L1"]
-          - input-2:
-            data-layout: ["TILE"]
-            data-type: ["BFLOAT16", "BFLOAT8_B"]
-            buffer-type: ["DRAM", "L1"]
-        out-buffer-type: ["DRAM"]
+        data-layout: ["TILE"]
+        data-type: ["BFLOAT16", "BFLOAT8_B"]
+        buffer-type: ["DRAM", "L1"]
+        out-buffer-type: ["DRAM", "L1", "SYSTEM_MEMORY"]
       output-file: eltwise_rsub_sweep.csv
       env:
         # TT_PCI_DMA_BUF_SIZE: "1048576"

--- a/tests/ttnn/python_api_testing/sweep_tests/test_configs/ci_sweep_tests_working/wormhole/ttnn_eltwise_rsub_test.yaml
+++ b/tests/ttnn/python_api_testing/sweep_tests/test_configs/ci_sweep_tests_working/wormhole/ttnn_eltwise_rsub_test.yaml
@@ -1,6 +1,6 @@
 ---
 test-list:
-  - eltwise-rsub:
+  - ttnn-eltwise-rsub:
       shape:
         start-shape: [1, 1, 32, 32]
         end-shape: [12, 24, 512, 512]
@@ -20,12 +20,12 @@ test-list:
         inputs:
           - input-1:
             data-layout: ["TILE"]
-            data-type: ["BFLOAT16"]
-            buffer-type: ["DRAM", "L1", "SYSTEM_MEMORY"]
+            data-type: ["BFLOAT16", "BFLOAT8_B"]
+            buffer-type: ["DRAM", "L1"]
           - input-2:
             data-layout: ["TILE"]
-            data-type: ["BFLOAT16"]
-            buffer-type: ["DRAM", "L1", "SYSTEM_MEMORY"]
+            data-type: ["BFLOAT16", "BFLOAT8_B"]
+            buffer-type: ["DRAM", "L1"]
         out-buffer-type: ["DRAM"]
       output-file: eltwise_rsub_sweep.csv
       env:

--- a/tests/ttnn/python_api_testing/sweep_tests/ttnn_ops.py
+++ b/tests/ttnn/python_api_testing/sweep_tests/ttnn_ops.py
@@ -1210,6 +1210,23 @@ def eltwise_relu6(
     return ttnn_tensor_to_torch(t1)
 
 
+def eltwise_rsub(
+    x,
+    *args,
+    device,
+    dtype,
+    layout,
+    input_mem_config,
+    output_mem_config,
+    **kwargs,
+):
+    factor = kwargs["factor"]
+    t0 = setup_ttnn_tensor(x, device, layout[0], input_mem_config[0], dtype[0])
+    t1 = ttnn.rsub(t0, factor, memory_config=output_mem_config)
+
+    return ttnn_tensor_to_torch(t1)
+
+
 def eltwise_rsqrt(
     x,
     *args,
@@ -1220,10 +1237,10 @@ def eltwise_rsqrt(
     output_mem_config,
     **kwargs,
 ):
-    t0 = setup_ttnn_tensor(x, device, layout[0], input_mem_config[0], dtype[0])
+    t0 = setup_tt_tensor(x, device, layout[0], input_mem_config[0], dtype[0])
     t1 = ttnn.rsqrt(t0, memory_config=memory_config_to_ttnn(output_mem_config))
 
-    return ttnn_tensor_to_torch(t1)
+    return tt2torch_tensor(t1)
 
 
 def eltwise_sigmoid(


### PR DESCRIPTION
### Ticket
[Link to Github Issue](https://github.com/tenstorrent/tt-metal/issues/10147)

### Problem description
MIgrating eltwise_rsub from tt_eager to ttnn

### What's changed
1. Created new YAML files for ttnn_eltwise_rsub_min for both GS and WH
2. Removed YAML files for pytorch_eltwise_rsub_min for both GS and WH
3. Added corresponding API calls in ttnn_ops and ttnn/op_map 
4. Removed corresponding API calls in tt_lib_ops and tt_eager/op_map 
5. Modifed test_eltwise_unary.py so that it passes for ttnn rsub

