### PR TITLE
Dump tool to read out CQ data from hugepages

### DIFF
--- a/tests/scripts/run_cpp_unit_tests.sh
+++ b/tests/scripts/run_cpp_unit_tests.sh
@@ -13,7 +13,7 @@ if [[ ! -z "$TT_METAL_SLOW_DISPATCH_MODE" ]]; then
     env python tests/scripts/run_tt_eager.py --dispatch-mode slow
 else
     ./build/test/tt_metal/unit_tests_fast_dispatch
-    TT_METAL_NUM_HW_CQS=2 ./build/test/tt_metal/unit_tests_fast_dispatch_single_chip_multi_queue --gtest_filter=MultiCommandQueueSingleDeviceFixture.*
+    TT_METAL_GTEST_NUM_HW_CQS=2 ./build/test/tt_metal/unit_tests_fast_dispatch_single_chip_multi_queue --gtest_filter=MultiCommandQueueSingleDeviceFixture.*
     if [[ "$ARCH_NAME" == "wormhole_b0" ]]; then
         WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml ./build/test/tt_metal/unit_tests_fast_dispatch
     fi

--- a/tests/scripts/run_tools_tests.sh
+++ b/tests/scripts/run_tools_tests.sh
@@ -15,7 +15,7 @@ if [[ -z "$TT_METAL_SLOW_DISPATCH_MODE" ]] ; then
     ./build/test/tt_metal/unit_tests_fast_dispatch --gtest_filter=*PrintHanging
 
     # Run dump tool w/ minimum data - no error expected.
-    ./build/tools/watcher_dump -d=0
+    ./build/tools/watcher_dump -d=0 -w -c
 
     # Verify the kernel we ran shows up in the log.
     grep "tests/tt_metal/tt_metal/test_kernels/misc/print_hang.cpp" generated/watcher/watcher.log > /dev/null || { echo "Error: couldn't find expected string in watcher log after dump." ; exit 1; }
@@ -23,7 +23,7 @@ if [[ -z "$TT_METAL_SLOW_DISPATCH_MODE" ]] ; then
 
     # Now run with all watcher features, expect it to throw.
     ./build/test/tt_metal/unit_tests_fast_dispatch --gtest_filter=*WatcherAssertBrisc
-    ./build/tools/watcher_dump -d=0 &> tmp.log || { echo "Above failure is expected."; }
+    ./build/tools/watcher_dump -d=0 -w &> tmp.log || { echo "Above failure is expected."; }
 
     # Verify the error we expect showed up in the program output.
     grep "brisc tripped an assert" tmp.log > /dev/null || { echo "Error: couldn't find expected string in command output:" ; cat tmp.log; exit 1; }
@@ -32,6 +32,7 @@ if [[ -z "$TT_METAL_SLOW_DISPATCH_MODE" ]] ; then
     # Remove created files.
     rm tmp.log
     rm generated/watcher/watcher.log
+    rm generated/watcher/command_queue_dump/*
     echo "Watcher dump tool tests finished..."
 
 

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/test_prefetcher.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/test_prefetcher.cpp
@@ -1614,6 +1614,7 @@ void configure_for_single_chip(Device *device,
         prefetch_q_base,
         prefetch_q_entries_g * (uint32_t)sizeof(dispatch_constants::prefetch_q_entry_type),
         prefetch_q_rd_ptr_addr,
+        prefetch_q_rd_ptr_addr + sizeof(uint32_t),
         cmddat_q_base, // overridden for split below
         cmddat_q_size_g, // overridden for split below
         0, // scratch_db_base filled in below if used
@@ -1636,9 +1637,9 @@ void configure_for_single_chip(Device *device,
         TT_ASSERT(scratch_db_base < 1024 * 1024); // L1 size
 
         prefetch_compile_args[3] = prefetch_d_downstream_cb_sem;
-        prefetch_compile_args[10] = prefetch_d_buffer_base;
-        prefetch_compile_args[11] = prefetch_d_buffer_pages * (1 << dispatch_constants::PREFETCH_D_BUFFER_LOG_PAGE_SIZE);
-        prefetch_compile_args[12] = scratch_db_base;
+        prefetch_compile_args[11] = prefetch_d_buffer_base;
+        prefetch_compile_args[12] = prefetch_d_buffer_pages * (1 << dispatch_constants::PREFETCH_D_BUFFER_LOG_PAGE_SIZE);
+        prefetch_compile_args[13] = scratch_db_base;
 
         CoreCoord phys_prefetch_d_upstream_core =
             packetized_path_en_g ? phys_prefetch_relay_demux_core : phys_prefetch_core_g;
@@ -1656,9 +1657,9 @@ void configure_for_single_chip(Device *device,
         prefetch_compile_args[2] = prefetch_d_buffer_pages;
         prefetch_compile_args[3] = prefetch_downstream_cb_sem;
         prefetch_compile_args[4] = prefetch_d_upstream_cb_sem;
-        prefetch_compile_args[10] = cmddat_q_base;
-        prefetch_compile_args[11] = cmddat_q_size_g;
-        prefetch_compile_args[12] = 0;
+        prefetch_compile_args[11] = cmddat_q_base;
+        prefetch_compile_args[12] = cmddat_q_size_g;
+        prefetch_compile_args[13] = 0;
 
         CoreCoord phys_prefetch_h_downstream_core =
             packetized_path_en_g ? phys_prefetch_relay_mux_core : phys_prefetch_d_core;
@@ -1821,7 +1822,7 @@ void configure_for_single_chip(Device *device,
     } else {
         uint32_t scratch_db_base = cmddat_q_base + ((cmddat_q_size_g + noc_read_alignment - 1) / noc_read_alignment * noc_read_alignment);
         TT_ASSERT(scratch_db_base < 1024 * 1024); // L1 size
-        prefetch_compile_args[12] = scratch_db_base;
+        prefetch_compile_args[13] = scratch_db_base;
 
         configure_kernel_variant<true, true>(
             program,
@@ -2200,6 +2201,7 @@ void configure_for_multi_chip(Device *device,
         prefetch_q_base,
         prefetch_q_entries_g * (uint32_t)sizeof(dispatch_constants::prefetch_q_entry_type),
         prefetch_q_rd_ptr_addr,
+        prefetch_q_rd_ptr_addr + sizeof(uint32_t),
         cmddat_q_base, // overridden for split below
         cmddat_q_size_g, // overridden for split below
         0, // scratch_db_base filled in below if used
@@ -2222,9 +2224,9 @@ void configure_for_multi_chip(Device *device,
         TT_ASSERT(scratch_db_base < 1024 * 1024); // L1 size
 
         prefetch_compile_args[3] = prefetch_d_downstream_cb_sem;
-        prefetch_compile_args[10] = prefetch_d_buffer_base;
-        prefetch_compile_args[11] = prefetch_d_buffer_pages * (1 << dispatch_constants::PREFETCH_D_BUFFER_LOG_PAGE_SIZE);
-        prefetch_compile_args[12] = scratch_db_base;
+        prefetch_compile_args[11] = prefetch_d_buffer_base;
+        prefetch_compile_args[12] = prefetch_d_buffer_pages * (1 << dispatch_constants::PREFETCH_D_BUFFER_LOG_PAGE_SIZE);
+        prefetch_compile_args[13] = scratch_db_base;
 
         CoreCoord phys_prefetch_d_upstream_core =
             packetized_path_en_g ? phys_prefetch_relay_demux_core : phys_prefetch_core_g;
@@ -2242,9 +2244,9 @@ void configure_for_multi_chip(Device *device,
         prefetch_compile_args[2] = prefetch_d_buffer_pages;
         prefetch_compile_args[3] = prefetch_downstream_cb_sem;
         prefetch_compile_args[4] = prefetch_d_upstream_cb_sem;
-        prefetch_compile_args[10] = cmddat_q_base;
-        prefetch_compile_args[11] = cmddat_q_size_g;
-        prefetch_compile_args[12] = 0;
+        prefetch_compile_args[11] = cmddat_q_base;
+        prefetch_compile_args[12] = cmddat_q_size_g;
+        prefetch_compile_args[13] = 0;
 
         CoreCoord phys_prefetch_h_downstream_core =
             packetized_path_en_g ? phys_prefetch_relay_mux_core : phys_prefetch_d_core;
@@ -2492,7 +2494,7 @@ void configure_for_multi_chip(Device *device,
     } else {
         uint32_t scratch_db_base = cmddat_q_base + ((cmddat_q_size_g + noc_read_alignment - 1) / noc_read_alignment * noc_read_alignment);
         TT_ASSERT(scratch_db_base < 1024 * 1024); // L1 size
-        prefetch_compile_args[12] = scratch_db_base;
+        prefetch_compile_args[13] = scratch_db_base;
 
         configure_kernel_variant<true, true>(
             program,

--- a/tests/tt_metal/tt_metal/unit_tests_common/common/common_fixture.hpp
+++ b/tests/tt_metal/tt_metal/unit_tests_common/common/common_fixture.hpp
@@ -74,7 +74,7 @@ protected:
                 continue;
             ids.push_back(id);
         }
-        tt::DevicePool::initialize(ids, 1, DEFAULT_L1_SMALL_SIZE);
+        tt::DevicePool::initialize(ids, tt::llrt::OptionsG.get_num_hw_cqs(), DEFAULT_L1_SMALL_SIZE);
         devices_ = tt::DevicePool::instance().get_all_active_devices();
     }
 

--- a/tests/tt_metal/tt_metal/unit_tests_common/common/dprint_fixture.hpp
+++ b/tests/tt_metal/tt_metal/unit_tests_common/common/dprint_fixture.hpp
@@ -38,8 +38,7 @@ protected:
         tt::llrt::OptionsG.set_watcher_enabled(false);
 
         // By default, exclude dispatch cores from printing
-        auto num_cqs_str = getenv("TT_METAL_NUM_HW_CQS");
-        int num_cqs = (num_cqs_str != nullptr)? std::stoi(num_cqs_str) : 1;
+        unsigned num_cqs = tt::llrt::OptionsG.get_num_hw_cqs();
         std::map<CoreType, std::unordered_set<CoreCoord>> disabled;
         for (unsigned int id = 0; id < tt::tt_metal::GetNumAvailableDevices(); id++) {
             // TODO: Better way to get this info once we've solidified how it will be set.

--- a/tests/tt_metal/tt_metal/unit_tests_fast_dispatch/common/command_queue_fixture.hpp
+++ b/tests/tt_metal/tt_metal/unit_tests_fast_dispatch/common/command_queue_fixture.hpp
@@ -113,9 +113,9 @@ protected:
         }
         if (num_hw_cqs > 1) {
             // Running multi-CQ test. User must set this explicitly.
-            auto num_cqs = getenv("TT_METAL_NUM_HW_CQS");
+            auto num_cqs = getenv("TT_METAL_GTEST_NUM_HW_CQS");
             if (num_cqs == nullptr or strcmp(num_cqs, "2")) {
-                TT_THROW("This suite must be run with TT_METAL_NUM_HW_CQS=2");
+                TT_THROW("This suite must be run with TT_METAL_GTEST_NUM_HW_CQS=2");
                 GTEST_SKIP();
             }
         }

--- a/tests/tt_metal/tt_metal/unit_tests_fast_dispatch_single_chip_multi_queue/common/command_queue_fixture.hpp
+++ b/tests/tt_metal/tt_metal/unit_tests_fast_dispatch_single_chip_multi_queue/common/command_queue_fixture.hpp
@@ -18,9 +18,9 @@ class MultiCommandQueueSingleDeviceFixture : public ::testing::Test {
             TT_THROW("This suite can only be run with fast dispatch or TT_METAL_SLOW_DISPATCH_MODE unset");
             GTEST_SKIP();
         }
-        auto num_cqs = getenv("TT_METAL_NUM_HW_CQS");
-        if (num_cqs == nullptr or strcmp(num_cqs, "2")) {
-            TT_THROW("This suite must be run with TT_METAL_NUM_HW_CQS=2");
+        auto num_cqs = tt::llrt::OptionsG.get_num_hw_cqs();
+        if (num_cqs != 2) {
+            TT_THROW("This suite must be run with TT_METAL_GTEST_NUM_HW_CQS=2");
             GTEST_SKIP();
         }
         arch_ = tt::get_arch_from_string(tt::test_utils::get_env_arch_name());
@@ -28,7 +28,7 @@ class MultiCommandQueueSingleDeviceFixture : public ::testing::Test {
             tt::log_warning(tt::LogTest, "Ethernet Dispatch not being explicitly used. Set this configuration in Setup()");
             setenv("WH_ARCH_YAML", "wormhole_b0_80_arch_eth_dispatch.yaml", true);
         }
-        device_ = tt::tt_metal::CreateDevice(0, std::stoi(num_cqs));
+        device_ = tt::tt_metal::CreateDevice(0, num_cqs);
     }
 
     void TearDown() override {
@@ -52,9 +52,9 @@ protected:
         }
         if (num_hw_cqs > 1) {
             // Running multi-CQ test. User must set this explicitly.
-            auto num_cqs = getenv("TT_METAL_NUM_HW_CQS");
+            auto num_cqs = getenv("TT_METAL_GTEST_NUM_HW_CQS");
             if (num_cqs == nullptr or strcmp(num_cqs, "2")) {
-                TT_THROW("This suite must be run with TT_METAL_NUM_HW_CQS=2");
+                TT_THROW("This suite must be run with TT_METAL_GTEST_NUM_HW_CQS=2");
                 GTEST_SKIP();
             }
         }

--- a/tt_metal/host_api.hpp
+++ b/tt_metal/host_api.hpp
@@ -83,7 +83,8 @@ Device *CreateDevice(
  * | device_id  | ID of the device to target| chip_id_t (int) | 0 to (GetNumAvailableDevices - 1) | Yes      |
  * */
 Device *CreateDeviceMinimal(
-    chip_id_t device_id);
+    chip_id_t device_id,
+    const uint8_t num_hw_cqs = 1);
 
 /**
  * Resets device and closes device

--- a/tt_metal/impl/device/device.cpp
+++ b/tt_metal/impl/device/device.cpp
@@ -556,7 +556,7 @@ void Device::update_workers_build_settings(std::vector<std::vector<std::tuple<tt
                     uint32_t downstream_cb_base = mux_settings.cb_start_address + mux_settings.cb_size_bytes * mux_sem;
                     settings.upstream_cores.push_back(tt_cxy_pair(0, 0, 0));
                     settings.downstream_cores.push_back(mux_settings.worker_physical_core);
-                    settings.compile_args.resize(22);
+                    settings.compile_args.resize(23);
                     auto& compile_args = settings.compile_args;
                     compile_args[0]  = downstream_cb_base;
                     compile_args[1]  = dispatch_constants::PREFETCH_D_BUFFER_LOG_PAGE_SIZE;
@@ -568,18 +568,19 @@ void Device::update_workers_build_settings(std::vector<std::vector<std::tuple<tt
                     compile_args[7]  = dispatch_constants::PREFETCH_Q_BASE;
                     compile_args[8]  = dispatch_constants::get(dispatch_core_type).prefetch_q_size();
                     compile_args[9]  = CQ_PREFETCH_Q_RD_PTR;
-                    compile_args[10] = dispatch_constants::get(dispatch_core_type).cmddat_q_base();
-                    compile_args[11] = dispatch_constants::get(dispatch_core_type).cmddat_q_size();
-                    compile_args[12] = dispatch_constants::get(dispatch_core_type).scratch_db_base(); // unused for prefetch_h
-                    compile_args[13] = dispatch_constants::get(dispatch_core_type).scratch_db_size(); // unused for prefetch_h
-                    compile_args[14] = 0; //prefetch_sync_sem unused for prefetch_h
-                    compile_args[15] = dispatch_constants::get(dispatch_core_type).prefetch_d_buffer_pages(); // prefetch_d only
-                    compile_args[16] = 0; // prefetch_d only
-                    compile_args[17] = 0; //prefetch_downstream_cb_sem, // prefetch_d only
-                    compile_args[18] = dispatch_constants::PREFETCH_D_BUFFER_LOG_PAGE_SIZE;
-                    compile_args[19] = dispatch_constants::PREFETCH_D_BUFFER_BLOCKS; // prefetch_d only
-                    compile_args[20] = false;  // is_dram_variant
-                    compile_args[21] = true;    // is_host_variant
+                    compile_args[10] = CQ_PREFETCH_Q_PCIE_RD_PTR;
+                    compile_args[11] = dispatch_constants::get(dispatch_core_type).cmddat_q_base();
+                    compile_args[12] = dispatch_constants::get(dispatch_core_type).cmddat_q_size();
+                    compile_args[13] = dispatch_constants::get(dispatch_core_type).scratch_db_base(); // unused for prefetch_h
+                    compile_args[14] = dispatch_constants::get(dispatch_core_type).scratch_db_size(); // unused for prefetch_h
+                    compile_args[15] = 0; //prefetch_sync_sem unused for prefetch_h
+                    compile_args[16] = dispatch_constants::get(dispatch_core_type).prefetch_d_buffer_pages(); // prefetch_d only
+                    compile_args[17] = 0; // prefetch_d only
+                    compile_args[18] = 0; //prefetch_downstream_cb_sem, // prefetch_d only
+                    compile_args[19] = dispatch_constants::PREFETCH_D_BUFFER_LOG_PAGE_SIZE;
+                    compile_args[20] = dispatch_constants::PREFETCH_D_BUFFER_BLOCKS; // prefetch_d only
+                    compile_args[21] = false;  // is_dram_variant
+                    compile_args[22] = true;    // is_host_variant
                 }
                 break;
             }
@@ -924,7 +925,7 @@ void Device::update_workers_build_settings(std::vector<std::vector<std::tuple<tt
                     TT_ASSERT(scratch_db_base + scratch_db_size <= l1_size);
 
                     auto& compile_args = prefetch_d_settings.compile_args;
-                    compile_args.resize(22);
+                    compile_args.resize(23);
                     compile_args[0]  = dispatch_d_settings.cb_start_address;
                     compile_args[1]  = dispatch_d_settings.cb_log_page_size;
                     compile_args[2]  = dispatch_d_settings.cb_pages;
@@ -935,18 +936,19 @@ void Device::update_workers_build_settings(std::vector<std::vector<std::tuple<tt
                     compile_args[7]  = 0;
                     compile_args[8]  = dispatch_constants::get(dispatch_core_type).prefetch_q_size();
                     compile_args[9]  = CQ_PREFETCH_Q_RD_PTR;
-                    compile_args[10] = prefetch_d_settings.cb_start_address;
-                    compile_args[11] = prefetch_d_settings.cb_size_bytes;
-                    compile_args[12] = scratch_db_base;
-                    compile_args[13] = scratch_db_size;
-                    compile_args[14] = 0; //prefetch_sync_sem
-                    compile_args[15] = prefetch_d_settings.cb_pages; // prefetch_d only
-                    compile_args[16] = prefetch_d_settings.consumer_semaphore_id; // prefetch_d only
-                    compile_args[17] = demux_sem++; //prefetch_downstream_cb_sem, // prefetch_d only
-                    compile_args[18] = prefetch_d_settings.cb_log_page_size;
-                    compile_args[19] = dispatch_constants::PREFETCH_D_BUFFER_BLOCKS; // prefetch_d only
-                    compile_args[20] = true;  // is_dram_variant
-                    compile_args[21] = false; // is_host_variant
+                    compile_args[10] = CQ_PREFETCH_Q_PCIE_RD_PTR;
+                    compile_args[11] = prefetch_d_settings.cb_start_address;
+                    compile_args[12] = prefetch_d_settings.cb_size_bytes;
+                    compile_args[13] = scratch_db_base;
+                    compile_args[14] = scratch_db_size;
+                    compile_args[15] = 0; //prefetch_sync_sem
+                    compile_args[16] = prefetch_d_settings.cb_pages; // prefetch_d only
+                    compile_args[17] = prefetch_d_settings.consumer_semaphore_id; // prefetch_d only
+                    compile_args[18] = demux_sem++; //prefetch_downstream_cb_sem, // prefetch_d only
+                    compile_args[19] = prefetch_d_settings.cb_log_page_size;
+                    compile_args[20] = dispatch_constants::PREFETCH_D_BUFFER_BLOCKS; // prefetch_d only
+                    compile_args[21] = true;  // is_dram_variant
+                    compile_args[22] = false; // is_host_variant
                     prefetch_d_idx++; // move on to next prefetcher
                 }
                 break;
@@ -1377,6 +1379,7 @@ void Device::compile_command_queue_programs() {
                 dispatch_constants::PREFETCH_Q_BASE,
                 dispatch_constants::get(dispatch_core_type).prefetch_q_size(),
                 CQ_PREFETCH_Q_RD_PTR,
+                CQ_PREFETCH_Q_PCIE_RD_PTR,
                 dispatch_constants::get(dispatch_core_type).cmddat_q_base(),
                 dispatch_constants::get(dispatch_core_type).cmddat_q_size(),
                 dispatch_constants::get(dispatch_core_type).scratch_db_base(),
@@ -1738,7 +1741,9 @@ void Device::configure_command_queue_programs() {
         this->sysmem_manager_->reset(cq_id);
 
         pointers[HOST_CQ_ISSUE_READ_PTR / sizeof(uint32_t)] = (CQ_START + get_absolute_cq_offset(channel, cq_id, cq_size)) >> 4;
+        pointers[HOST_CQ_ISSUE_WRITE_PTR / sizeof(uint32_t)] = (CQ_START + get_absolute_cq_offset(channel, cq_id, cq_size)) >> 4;
         pointers[HOST_CQ_COMPLETION_WRITE_PTR / sizeof(uint32_t)] = (CQ_START + this->sysmem_manager_->get_issue_queue_size(cq_id) + get_absolute_cq_offset(channel, cq_id, cq_size)) >> 4;
+        pointers[HOST_CQ_COMPLETION_READ_PTR / sizeof(uint32_t)] = (CQ_START + this->sysmem_manager_->get_issue_queue_size(cq_id) + get_absolute_cq_offset(channel, cq_id, cq_size)) >> 4;
 
         tt::Cluster::instance().write_sysmem(pointers.data(), pointers.size() * sizeof(uint32_t), get_absolute_cq_offset(channel, cq_id, cq_size), mmio_device_id, get_umd_channel(channel));
     }
@@ -1757,7 +1762,9 @@ void Device::configure_command_queue_programs() {
         std::vector<uint32_t> prefetch_q_rd_ptr_addr_data = {
             (uint32_t)(dispatch_constants::PREFETCH_Q_BASE + dispatch_constants::get(dispatch_core_type).prefetch_q_size())
         };
+        std::vector<uint32_t> prefetch_q_pcie_rd_ptr_addr_data = {get_absolute_cq_offset(channel, cq_id, cq_size) + CQ_START};
         detail::WriteToDeviceL1(mmio_device, prefetch_location, CQ_PREFETCH_Q_RD_PTR, prefetch_q_rd_ptr_addr_data, dispatch_core_type);
+        detail::WriteToDeviceL1(mmio_device, prefetch_location, CQ_PREFETCH_Q_PCIE_RD_PTR, prefetch_q_pcie_rd_ptr_addr_data, dispatch_core_type);
         detail::WriteToDeviceL1(mmio_device, prefetch_location, dispatch_constants::PREFETCH_Q_BASE, prefetch_q, dispatch_core_type);
         // Used for prefetch_h, since a wait_for_event on remote chips requires prefetch_h to spin until dispatch_d notfiies completion
         detail::WriteToDeviceL1(mmio_device, prefetch_location, CQ0_COMPLETION_LAST_EVENT, zero, dispatch_core_type);

--- a/tt_metal/impl/dispatch/command_queue.cpp
+++ b/tt_metal/impl/dispatch/command_queue.cpp
@@ -103,7 +103,7 @@ void EnqueueReadBufferCommand::process() {
 
     uint32_t padded_page_size = this->buffer.aligned_page_size();
     bool flush_prefetch = false;
-    command_sequence.add_dispatch_write_host(flush_prefetch, this->pages_to_read * padded_page_size);
+    command_sequence.add_dispatch_write_host(flush_prefetch, this->pages_to_read * padded_page_size, false);
 
     this->add_prefetch_relay(command_sequence);
 
@@ -1342,7 +1342,7 @@ void EnqueueRecordEventCommand::process() {
 
     bool flush_prefetch = true;
     command_sequence.add_dispatch_write_host<true>(
-        flush_prefetch, dispatch_constants::EVENT_PADDED_SIZE, event_payload.data());
+        flush_prefetch, dispatch_constants::EVENT_PADDED_SIZE, true, event_payload.data());
 
     this->manager.issue_queue_push_back(cmd_sequence_sizeB, this->command_queue_id);
 
@@ -2251,6 +2251,7 @@ void HWCommandQueue::read_completion_queue() {
                                 channel);
                             uint32_t event_completed =
                                 dispatch_cmd_and_event.at(sizeof(CQDispatchCmd) / sizeof(uint32_t));
+
                             TT_ASSERT(
                                 event_completed == read_descriptor.event_id,
                                 "Event Order Issue: expected to read back completion signal for event {} but got {}!",

--- a/tt_metal/impl/dispatch/cq_commands.hpp
+++ b/tt_metal/impl/dispatch/cq_commands.hpp
@@ -29,6 +29,7 @@ enum CQPrefetchCmdId : uint8_t {
     CQ_PREFETCH_CMD_DEBUG = 9,                // log waypoint data to watcher, checksum
     CQ_PREFETCH_CMD_WAIT_FOR_EVENT = 10,      // wait_for_event: stall until dispatcher signals event completion
     CQ_PREFETCH_CMD_TERMINATE = 11,           // quit
+    CQ_PREFETCH_CMD_MAX_COUNT,                // for checking legal IDs
 };
 
 // Dispatcher CMD ID enums
@@ -48,6 +49,7 @@ enum CQDispatchCmdId : uint8_t {
     CQ_DISPATCH_CMD_EXEC_BUF_END = 12,      // dispatch_d notify prefetch_h that exec_buf has completed
     CQ_DISPATCH_CMD_REMOTE_WRITE = 13,      // dispatch_d issues write to address on L-Chip through dispatch_h
     CQ_DISPATCH_CMD_TERMINATE = 14,         // quit
+    CQ_DISPATCH_CMD_MAX_COUNT,              // for checking legal IDs
 };
 
 //////////////////////////////////////////////////////////////////////////////
@@ -156,10 +158,10 @@ struct CQDispatchWriteCmd {
 } __attribute__((packed));
 
 struct CQDispatchWriteHostCmd {
-    uint8_t pad1;
-    uint16_t pad2;
+    uint8_t is_event; // one flag, false=read buffer
+    uint16_t pad1;
+    uint32_t pad2;
     uint32_t pad3;
-    uint32_t pad4;
     uint32_t length;
 } __attribute__((packed));
 

--- a/tt_metal/impl/dispatch/debug_tools.cpp
+++ b/tt_metal/impl/dispatch/debug_tools.cpp
@@ -101,4 +101,505 @@ void wait_for_program_vector_to_arrive_and_compare_to_host_program_vector(
     }
 }
 
+// Returns the number of bytes taken up by this dispatch command (including header).
+uint32_t dump_dispatch_cmd(CQDispatchCmd *cmd, uint32_t cmd_addr, std::ofstream &cq_file) {
+    uint32_t stride = sizeof(CQDispatchCmd);  // Default stride is just the command
+    CQDispatchCmdId cmd_id = cmd->base.cmd_id;
+
+    if (cmd_id < CQ_DISPATCH_CMD_MAX_COUNT) {
+        cq_file << fmt::format("{:#010x}: {}", cmd_addr, cmd_id);
+        switch (cmd_id) {
+            case CQ_DISPATCH_CMD_WRITE_LINEAR:
+            case CQ_DISPATCH_CMD_WRITE_LINEAR_H:
+                cq_file << fmt::format(
+                    " (num_mcast_dests={}, noc_xy_addr={:#010x}, addr={:#010x}, length={:#010x})",
+                    cmd->write_linear.num_mcast_dests,
+                    cmd->write_linear.noc_xy_addr,
+                    cmd->write_linear.addr,
+                    cmd->write_linear.length);
+                stride += cmd->write_linear.length;
+                break;
+            case CQ_DISPATCH_CMD_WRITE_LINEAR_H_HOST:
+                if (cmd->write_linear_host.is_event) {
+                    uint32_t *event_ptr = (uint32_t *)(cmd + 1);
+                    cq_file << fmt::format(" (completed_event_id={})", *event_ptr);
+                } else {
+                    cq_file << fmt::format(" (length={:#010x})", cmd->write_linear_host.length);
+                }
+                stride += cmd->write_linear_host.length;
+                break;
+            case CQ_DISPATCH_CMD_WRITE_PAGED:
+                cq_file << fmt::format(
+                    " (is_dram={}, start_page={}, base_addr={:#010x}, page_size={:#010x}, pages={})",
+                    cmd->write_paged.is_dram,
+                    cmd->write_paged.start_page,
+                    cmd->write_paged.base_addr,
+                    cmd->write_paged.page_size,
+                    cmd->write_paged.pages);
+                stride += cmd->write_paged.pages * cmd->write_paged.page_size;
+                break;
+            case CQ_DISPATCH_CMD_WRITE_PACKED:
+                cq_file << fmt::format(
+                    " (flags={:#02x}, count={}, addr={:#010x}, size={:04x})",
+                    cmd->write_packed.flags,
+                    cmd->write_packed.count,
+                    cmd->write_packed.addr,
+                    cmd->write_packed.size);
+                // TODO: How does the page count for for packed writes?
+                break;
+            case CQ_DISPATCH_CMD_WRITE_PACKED_LARGE:
+                cq_file << fmt::format(
+                    " (count={}, alignment={})", cmd->write_packed_large.count, cmd->write_packed_large.alignment);
+                break;
+            case CQ_DISPATCH_CMD_WAIT:
+                cq_file << fmt::format(
+                    " (barrier={}, notify_prefetch={}, clear_count=(), wait={}, addr={:#010x}, "
+                    "count = {})",
+                    cmd->wait.barrier,
+                    cmd->wait.notify_prefetch,
+                    cmd->wait.clear_count,
+                    cmd->wait.wait,
+                    cmd->wait.addr,
+                    cmd->wait.count);
+                break;
+            case CQ_DISPATCH_CMD_DEBUG:
+                cq_file << fmt::format(
+                    " (pad={}, key={}, checksum={:#010x}, size={}, stride={})",
+                    cmd->debug.pad,
+                    cmd->debug.key,
+                    cmd->debug.checksum,
+                    cmd->debug.size,
+                    cmd->debug.stride);
+                break;
+            case CQ_DISPATCH_CMD_DELAY: cq_file << fmt::format(" (delay={})", cmd->delay.delay); break;
+            // These commands don't have any additional data to dump.
+            case CQ_DISPATCH_CMD_ILLEGAL: break;
+            case CQ_DISPATCH_CMD_GO: break;
+            case CQ_DISPATCH_CMD_SINK: break;
+            case CQ_DISPATCH_CMD_EXEC_BUF_END: break;
+            case CQ_DISPATCH_CMD_REMOTE_WRITE: break;
+            case CQ_DISPATCH_CMD_TERMINATE: break;
+            default: TT_FATAL("Unrecognized dispatch command: {}", cmd_id); break;
+        }
+    }
+    return stride;
+}
+
+// Returns the number of bytes taken up by this prefetch command (including header).
+uint32_t dump_prefetch_cmd(CQPrefetchCmd *cmd, uint32_t cmd_addr, std::ofstream &iq_file) {
+    uint32_t stride = dispatch_constants::ISSUE_Q_ALIGNMENT;  // Default stride matches alignment.
+    CQPrefetchCmdId cmd_id = cmd->base.cmd_id;
+
+    if (cmd_id < CQ_PREFETCH_CMD_MAX_COUNT) {
+        iq_file << fmt::format("{:#010x}: {}", cmd_addr, cmd_id);
+        switch (cmd_id) {
+            case CQ_PREFETCH_CMD_RELAY_LINEAR:
+                iq_file << fmt::format(
+                    " (noc_xy_addr={:#010x}, addr={:#010x}, length={:#010x})",
+                    cmd->relay_linear.noc_xy_addr,
+                    cmd->relay_linear.addr,
+                    cmd->relay_linear.length);
+                break;
+            case CQ_PREFETCH_CMD_RELAY_PAGED:
+                iq_file << fmt::format(
+                    " (packed_page_flags={:#02x}, length_adjust={:#x}, base_addr={:#010x}, page_size={:#010x}, "
+                    "pages={:#010x})",
+                    cmd->relay_paged.packed_page_flags,
+                    cmd->relay_paged.length_adjust,
+                    cmd->relay_paged.base_addr,
+                    cmd->relay_paged.page_size,
+                    cmd->relay_paged.pages);
+                break;
+            case CQ_PREFETCH_CMD_RELAY_PAGED_PACKED:
+                iq_file << fmt::format(
+                    " (count={}, total_length={:#010x}, stride={:#010x})",
+                    cmd->relay_paged_packed.count,
+                    cmd->relay_paged_packed.total_length,
+                    cmd->relay_paged_packed.stride);
+                stride = cmd->relay_paged_packed.stride;
+                break;
+            case CQ_PREFETCH_CMD_RELAY_INLINE:
+            case CQ_PREFETCH_CMD_RELAY_INLINE_NOFLUSH:
+            case CQ_PREFETCH_CMD_EXEC_BUF_END:
+                iq_file << fmt::format(
+                    " (length={:#010x}, stride={:#010x})", cmd->relay_inline.length, cmd->relay_inline.stride);
+                stride = cmd->relay_inline.stride;
+                break;
+            case CQ_PREFETCH_CMD_EXEC_BUF:
+                iq_file << fmt::format(
+                    " (base_addr={:#010x}, log_page_size={}, pages={})",
+                    cmd->exec_buf.base_addr,
+                    cmd->exec_buf.log_page_size,
+                    cmd->exec_buf.pages);
+                break;
+            case CQ_PREFETCH_CMD_DEBUG:
+                iq_file << fmt::format(
+                    " (pad={}, key={}, checksum={:#010x}, size={}, stride={})",
+                    cmd->debug.pad,
+                    cmd->debug.key,
+                    cmd->debug.checksum,
+                    cmd->debug.size,
+                    cmd->debug.stride);
+                stride = cmd->debug.stride;
+                break;
+            case CQ_PREFETCH_CMD_WAIT_FOR_EVENT:
+                iq_file << fmt::format(
+                    " (sync_event={:#08x}, sync_event_addr={:#08x})",
+                    cmd->event_wait.sync_event,
+                    cmd->event_wait.sync_event_addr);
+                stride = CQ_PREFETCH_CMD_BARE_MIN_SIZE + sizeof(CQPrefetchHToPrefetchDHeader);
+                break;
+            // These commands don't have any additional data to dump.
+            case CQ_PREFETCH_CMD_ILLEGAL: break;
+            case CQ_PREFETCH_CMD_STALL: break;
+            case CQ_PREFETCH_CMD_TERMINATE: break;
+            default: break;
+        }
+    }
+    return stride;
+}
+
+void print_progress_bar(float progress, bool init = false) {
+    if (progress > 1.0)
+        progress = 1.0;
+    static int prev_bar_position = -1;
+    if (init)
+        prev_bar_position = -1;
+    int progress_bar_width = 80;
+    int bar_position = static_cast<int>(progress * progress_bar_width);
+    if (bar_position > prev_bar_position) {
+        std::cout << "[";
+        std::cout << string(bar_position, '=') << string(progress_bar_width - bar_position, ' ');
+        std::cout << "]" << int(progress * 100.0) << " %\r" << std::flush;
+        prev_bar_position = bar_position;
+    }
+}
+
+void dump_completion_queue_entries(
+    std::ofstream &cq_file, SystemMemoryManager &sysmem_manager, SystemMemoryCQInterface &cq_interface) {
+    chip_id_t mmio_device_id = tt::Cluster::instance().get_associated_mmio_device(sysmem_manager.get_device_id());
+    uint16_t channel = tt::Cluster::instance().get_assigned_channel_for_device(sysmem_manager.get_device_id());
+    uint32_t completion_write_ptr =
+        get_cq_completion_wr_ptr<true>(sysmem_manager.get_device_id(), cq_interface.id, sysmem_manager.get_cq_size())
+        << 4;
+    uint32_t completion_read_ptr =
+        get_cq_completion_rd_ptr<true>(sysmem_manager.get_device_id(), cq_interface.id, sysmem_manager.get_cq_size())
+        << 4;
+    uint32_t completion_q_bytes = cq_interface.completion_fifo_size << 4;
+    TT_ASSERT(completion_q_bytes % dispatch_constants::TRANSFER_PAGE_SIZE == 0);
+    uint32_t base_addr = (cq_interface.issue_fifo_limit << 4);
+
+    // Read out in pages, this is fine since all completion Q entries are page aligned.
+    vector<uint8_t> read_data;
+    read_data.resize(dispatch_constants::TRANSFER_PAGE_SIZE);
+    tt::log_info("Reading Device {} CQ {}, Completion Queue...", sysmem_manager.get_device_id(), cq_interface.id);
+    cq_file << fmt::format(
+        "Device {}, CQ {}, Completion Queue: write_ptr={:#010x}, read_ptr={:#010x}\n",
+        sysmem_manager.get_device_id(),
+        cq_interface.id,
+        completion_write_ptr,
+        completion_read_ptr);
+    uint32_t last_span_start;
+    bool last_span_invalid = false;
+    print_progress_bar(0.0, true);
+    for (uint32_t page_offset = 0; page_offset < completion_q_bytes;) {  // page_offset increment at end of loop
+        uint32_t page_addr = base_addr + page_offset;
+        tt::Cluster::instance().read_sysmem(read_data.data(), read_data.size(), page_addr, mmio_device_id, channel);
+
+        // Check if this page starts with a valid command id
+        CQDispatchCmd *cmd = (CQDispatchCmd *)read_data.data();
+        if (cmd->base.cmd_id < CQ_DISPATCH_CMD_MAX_COUNT && cmd->base.cmd_id > CQ_DISPATCH_CMD_ILLEGAL) {
+            if (last_span_invalid) {
+                if (page_addr == last_span_start + dispatch_constants::TRANSFER_PAGE_SIZE) {
+                    cq_file << fmt::format("{:#010x}: No valid dispatch commands detected.", last_span_start);
+                } else {
+                    cq_file << fmt::format(
+                        "{:#010x}-{:#010x}: No valid dispatch commands detected.",
+                        last_span_start,
+                        page_addr - dispatch_constants::TRANSFER_PAGE_SIZE);
+                }
+                last_span_invalid = false;
+                if (last_span_start <= (completion_write_ptr) &&
+                    page_addr - dispatch_constants::TRANSFER_PAGE_SIZE >= (completion_write_ptr)) {
+                    cq_file << fmt::format(" << write_ptr (0x{:08x})", completion_write_ptr);
+                }
+                if (last_span_start <= (completion_read_ptr) &&
+                    page_addr - dispatch_constants::TRANSFER_PAGE_SIZE >= (completion_read_ptr)) {
+                    cq_file << fmt::format(" << read_ptr (0x{:08x})", completion_read_ptr);
+                }
+                cq_file << std::endl;
+            }
+            uint32_t stride = dump_dispatch_cmd(cmd, page_addr, cq_file);
+            // Completion Q is page-aligned
+            uint32_t cmd_pages =
+                (stride + dispatch_constants::TRANSFER_PAGE_SIZE - 1) / dispatch_constants::TRANSFER_PAGE_SIZE;
+            page_offset += cmd_pages * dispatch_constants::TRANSFER_PAGE_SIZE;
+            if (page_addr == completion_write_ptr)
+                cq_file << fmt::format(" << write_ptr (0x{:08x})", completion_write_ptr);
+            if (page_addr == completion_read_ptr)
+                cq_file << fmt::format(" << read_ptr (0x{:08x})", completion_read_ptr);
+            cq_file << std::endl;
+
+            // Show which pages have data if present.
+            if (cmd_pages > 2) {
+                cq_file << fmt::format(
+                    "{:#010x}-{:#010x}: Data pages\n",
+                    page_addr + dispatch_constants::TRANSFER_PAGE_SIZE,
+                    page_addr + (cmd_pages - 1) * dispatch_constants::TRANSFER_PAGE_SIZE);
+            } else if (cmd_pages == 2) {
+                cq_file << fmt::format("{:#010x}: Data page\n", page_addr + dispatch_constants::TRANSFER_PAGE_SIZE);
+            }
+        } else {
+            // If no valid command, just move on and try the next page
+            // cq_file << fmt::format("{:#010x}: No valid dispatch command", page_addr) << std::endl;
+            if (!last_span_invalid)
+                last_span_start = page_addr;
+            last_span_invalid = true;
+            page_offset += dispatch_constants::TRANSFER_PAGE_SIZE;
+        }
+
+        print_progress_bar((float)page_offset / completion_q_bytes + 0.005);
+    }
+    if (last_span_invalid) {
+        cq_file << fmt::format(
+            "{:#010x}-{:#010x}: No valid dispatch commands detected.", last_span_start, base_addr + completion_q_bytes);
+    }
+    std::cout << std::endl;
+}
+
+void dump_issue_queue_entries(
+    std::ofstream &iq_file, SystemMemoryManager &sysmem_manager, SystemMemoryCQInterface &cq_interface) {
+    chip_id_t mmio_device_id = tt::Cluster::instance().get_associated_mmio_device(sysmem_manager.get_device_id());
+    uint16_t channel = tt::Cluster::instance().get_assigned_channel_for_device(sysmem_manager.get_device_id());
+    // TODO: Issue Q read ptr is not prefetcly updated 0 try to read it out from chip on dump?
+    uint32_t issue_read_ptr =
+        get_cq_issue_rd_ptr<true>(sysmem_manager.get_device_id(), cq_interface.id, sysmem_manager.get_cq_size()) << 4;
+    uint32_t issue_write_ptr =
+        get_cq_issue_wr_ptr<true>(sysmem_manager.get_device_id(), cq_interface.id, sysmem_manager.get_cq_size()) << 4;
+    uint32_t issue_q_bytes = cq_interface.issue_fifo_size << 4;
+    uint32_t issue_q_base_addr = cq_interface.offset + CQ_START;
+
+    // Read out in 4K pages, could do ISSUE_Q_ALIGNMENT chunks to match the entries but this is ~2x faster.
+    vector<uint8_t> read_data;
+    read_data.resize(dispatch_constants::TRANSFER_PAGE_SIZE);
+    tt::log_info("Reading Device {} CQ {}, Issue Queue...", sysmem_manager.get_device_id(), cq_interface.id);
+    iq_file << fmt::format(
+        "Device {}, CQ {}, Issue Queue: write_ptr={:#010x}, read_ptr={:#010x} (read_ptr not currently implemented)\n",
+        sysmem_manager.get_device_id(),
+        cq_interface.id,
+        issue_write_ptr,
+        issue_read_ptr);
+    uint32_t last_span_start;
+    bool last_span_invalid = false;
+    print_progress_bar(0.0, true);
+    uint32_t first_page_addr = issue_q_base_addr - (issue_q_base_addr % dispatch_constants::TRANSFER_PAGE_SIZE);
+    uint32_t end_of_curr_page =
+        first_page_addr + dispatch_constants::TRANSFER_PAGE_SIZE - 1;  // To track offset of latest page read out
+    tt::Cluster::instance().read_sysmem(read_data.data(), read_data.size(), first_page_addr, mmio_device_id, channel);
+    for (uint32_t offset = 0; offset < issue_q_bytes;) {  // offset increments at end of loop
+        uint32_t curr_addr = issue_q_base_addr + offset;
+        uint32_t page_offset = curr_addr % dispatch_constants::TRANSFER_PAGE_SIZE;
+
+        // Check if we need to read a new page
+        if (curr_addr > end_of_curr_page) {
+            uint32_t page_base = curr_addr - (curr_addr % dispatch_constants::TRANSFER_PAGE_SIZE);
+            tt::Cluster::instance().read_sysmem(read_data.data(), read_data.size(), page_base, mmio_device_id, channel);
+            end_of_curr_page = page_base + dispatch_constants::TRANSFER_PAGE_SIZE - 1;
+        }
+
+        // Check for a valid command id
+        CQPrefetchCmd *cmd = (CQPrefetchCmd *)(read_data.data() + page_offset);
+        if (cmd->base.cmd_id < CQ_PREFETCH_CMD_MAX_COUNT && cmd->base.cmd_id != CQ_PREFETCH_CMD_ILLEGAL) {
+            if (last_span_invalid) {
+                if (curr_addr == last_span_start + dispatch_constants::ISSUE_Q_ALIGNMENT) {
+                    iq_file << fmt::format("{:#010x}: No valid prefetch command detected.", last_span_start);
+                } else {
+                    iq_file << fmt::format(
+                        "{:#010x}-{:#010x}: No valid prefetch commands detected.",
+                        last_span_start,
+                        curr_addr - dispatch_constants::ISSUE_Q_ALIGNMENT);
+                }
+                last_span_invalid = false;
+                if (last_span_start <= (issue_write_ptr) &&
+                    curr_addr - dispatch_constants::ISSUE_Q_ALIGNMENT >= (issue_write_ptr)) {
+                    iq_file << fmt::format(" << write_ptr (0x{:08x})", issue_write_ptr);
+                }
+                if (last_span_start <= (issue_read_ptr) &&
+                    curr_addr - dispatch_constants::ISSUE_Q_ALIGNMENT >= (issue_read_ptr)) {
+                    iq_file << fmt::format(" << read_ptr (0x{:08x})", issue_read_ptr);
+                }
+                iq_file << std::endl;
+            }
+
+            uint32_t cmd_stride = dump_prefetch_cmd(cmd, curr_addr, iq_file);
+
+            // Check for a bad stride (happen to have a valid cmd_id, overwritten values, etc.)
+            if (cmd_stride + offset >= issue_q_bytes || cmd_stride == 0 ||
+                cmd_stride % dispatch_constants::ISSUE_Q_ALIGNMENT != 0) {
+                cmd_stride = dispatch_constants::ISSUE_Q_ALIGNMENT;
+                iq_file << " (bad stride)";
+            }
+
+            if (curr_addr == issue_write_ptr)
+                iq_file << fmt::format(" << write_ptr (0x{:08x})", issue_write_ptr);
+            if (curr_addr == issue_read_ptr)
+                iq_file << fmt::format(" << read_ptr (0x{:08x})", issue_read_ptr);
+            iq_file << std::endl;
+
+            // If it's a RELAY_INLINE command, then the data inside is dispatch commands, show them.
+            if ((cmd->base.cmd_id == CQ_PREFETCH_CMD_RELAY_INLINE ||
+                 cmd->base.cmd_id == CQ_PREFETCH_CMD_RELAY_INLINE_NOFLUSH) &&
+                cmd_stride > dispatch_constants::ISSUE_Q_ALIGNMENT) {
+                uint32_t dispatch_offset = offset + sizeof(CQPrefetchCmd);
+                uint32_t dispatch_curr_addr = issue_q_base_addr + dispatch_offset;
+                while (dispatch_offset < offset + cmd_stride) {
+                    // Check if we need to read a new page
+                    if (dispatch_curr_addr > end_of_curr_page) {
+                        uint32_t page_base =
+                            dispatch_curr_addr - (dispatch_curr_addr % dispatch_constants::TRANSFER_PAGE_SIZE);
+                        tt::Cluster::instance().read_sysmem(
+                            read_data.data(), read_data.size(), page_base, mmio_device_id, channel);
+                        end_of_curr_page = page_base + dispatch_constants::TRANSFER_PAGE_SIZE - 1;
+                    }
+
+                    // Read the dispatch command
+                    uint32_t dispatch_page_offset = dispatch_curr_addr % dispatch_constants::TRANSFER_PAGE_SIZE;
+                    CQDispatchCmd *dispatch_cmd = (CQDispatchCmd *)(read_data.data() + dispatch_page_offset);
+                    if (dispatch_cmd->base.cmd_id < CQ_DISPATCH_CMD_MAX_COUNT) {
+                        iq_file << "  ";
+                        uint32_t dispatch_cmd_stride =
+                            dump_dispatch_cmd(dispatch_cmd, issue_q_base_addr + dispatch_offset, iq_file);
+                        dispatch_offset += dispatch_cmd_stride;
+                        iq_file << std::endl;
+                    } else {
+                        dispatch_offset += sizeof(CQDispatchCmd);
+                    }
+                }
+                offset += cmd_stride;
+            } else {
+                offset += cmd_stride;
+            }
+        } else {
+            // If not a valid command, just move on and try the next.
+            if (!last_span_invalid)
+                last_span_start = curr_addr;
+            last_span_invalid = true;
+            offset += dispatch_constants::ISSUE_Q_ALIGNMENT;
+        }
+        print_progress_bar((float)offset / issue_q_bytes + 0.005);
+    }
+    if (last_span_invalid) {
+        iq_file << fmt::format(
+            "{:#010x}-{:#010x}: No valid prefetch commands detected.",
+            last_span_start,
+            issue_q_base_addr + issue_q_bytes);
+    }
+    std::cout << std::endl;
+}
+
+// Define a queue type, for when they're interchangeable.
+typedef enum e_cq_queue_t {
+    CQ_COMPLETION_QUEUE = 0,
+    CQ_ISSUE_QUEUE      = 1
+} cq_queue_t;
+
+void dump_command_queue_raw_data(
+    std::ofstream &out_file,
+    SystemMemoryManager &sysmem_manager,
+    SystemMemoryCQInterface &cq_interface,
+    cq_queue_t queue_type) {
+    chip_id_t mmio_device_id = tt::Cluster::instance().get_associated_mmio_device(sysmem_manager.get_device_id());
+    uint16_t channel = tt::Cluster::instance().get_assigned_channel_for_device(sysmem_manager.get_device_id());
+
+    // The following variables depend on completion Q vs issue Q
+    uint32_t write_ptr, read_ptr, base_addr, bytes_to_read = 0;
+    string queue_type_name;
+    if (queue_type == CQ_COMPLETION_QUEUE) {
+        write_ptr = get_cq_completion_wr_ptr<true>(
+                        sysmem_manager.get_device_id(), cq_interface.id, sysmem_manager.get_cq_size())
+                    << 4;
+        read_ptr = get_cq_completion_rd_ptr<true>(
+                       sysmem_manager.get_device_id(), cq_interface.id, sysmem_manager.get_cq_size())
+                   << 4;
+        bytes_to_read = cq_interface.completion_fifo_size << 4;  // Page-aligned, Issue Q is not.
+        TT_ASSERT(bytes_to_read % dispatch_constants::TRANSFER_PAGE_SIZE == 0);
+        base_addr = cq_interface.issue_fifo_limit << 4;
+        queue_type_name = "Completion";
+    } else if (queue_type == CQ_ISSUE_QUEUE) {
+        write_ptr =
+            get_cq_issue_wr_ptr<true>(sysmem_manager.get_device_id(), cq_interface.id, sysmem_manager.get_cq_size())
+            << 4;
+        read_ptr =
+            get_cq_issue_rd_ptr<true>(sysmem_manager.get_device_id(), cq_interface.id, sysmem_manager.get_cq_size())
+            << 4;
+        bytes_to_read = cq_interface.issue_fifo_size << 4;
+        base_addr = cq_interface.offset + CQ_START;
+        queue_type_name = "Issue";
+    } else {
+        TT_FATAL("Unrecognized CQ type: {}", queue_type);
+    }
+
+    // Read out in pages
+    vector<uint8_t> read_data;
+    read_data.resize(dispatch_constants::TRANSFER_PAGE_SIZE);
+    out_file << std::endl;
+    out_file << fmt::format(
+                    "Device {}, CQ {}, {} Queue Raw Data:\n",
+                    sysmem_manager.get_device_id(),
+                    cq_interface.id,
+                    queue_type_name)
+             << std::hex;
+    tt::log_info(
+        "Reading Device {} CQ {}, {} Queue Raw Data...",
+        sysmem_manager.get_device_id(),
+        cq_interface.id,
+        queue_type_name);
+    print_progress_bar(0.0, true);
+    for (uint32_t page_offset = 0; page_offset < bytes_to_read; page_offset += dispatch_constants::TRANSFER_PAGE_SIZE) {
+        uint32_t page_addr = base_addr + page_offset;
+        print_progress_bar((float)page_offset / bytes_to_read + 0.005);
+
+        // Print in 16B per line
+        tt::Cluster::instance().read_sysmem(read_data.data(), read_data.size(), page_addr, mmio_device_id, channel);
+        TT_ASSERT(read_data.size() % 16 == 0);
+        for (uint32_t line_offset = 0; line_offset < read_data.size(); line_offset += 16) {
+            uint32_t line_addr = page_addr + line_offset;
+
+            // Issue Q may not be divisible by page size, so break early if we go past the end.
+            if (queue_type == CQ_ISSUE_QUEUE) {
+                if (line_addr + 16 >= base_addr + bytes_to_read) {
+                    break;
+                }
+            }
+
+            out_file << "0x" << std::setfill('0') << std::setw(8) << line_addr << ": ";
+            for (uint32_t idx = 0; idx < 16; idx++) {
+                uint8_t val = read_data[line_offset + idx];
+                out_file << " " << std::setfill('0') << std::setw(2) << +read_data[line_offset + idx];
+            }
+            if (line_addr == write_ptr)
+                out_file << fmt::format(" << write_ptr (0x{:08x})", write_ptr);
+            if (line_addr == read_ptr)
+                out_file << fmt::format(" << read_ptr (0x{:08x})", read_ptr);
+            out_file << std::endl;
+        }
+    }
+    std::cout << std::endl;
+}
+
+void dump_cqs(std::ofstream &cq_file, std::ofstream &iq_file, SystemMemoryManager &sysmem_manager, bool dump_raw_data) {
+    for (SystemMemoryCQInterface &cq_interface : sysmem_manager.get_cq_interfaces()) {
+        chip_id_t mmio_device_id = tt::Cluster::instance().get_associated_mmio_device(sysmem_manager.get_device_id());
+        // Dump completion queue + issue queue
+        dump_completion_queue_entries(cq_file, sysmem_manager, cq_interface);
+        dump_issue_queue_entries(iq_file, sysmem_manager, cq_interface);
+
+        // This is really slow, so don't do it by default. It's sometimes helpful to read the raw bytes though.
+        if (dump_raw_data) {
+            dump_command_queue_raw_data(cq_file, sysmem_manager, cq_interface, CQ_COMPLETION_QUEUE);
+            dump_command_queue_raw_data(iq_file, sysmem_manager, cq_interface, CQ_ISSUE_QUEUE);
+        }
+    }
+}
+
 }  // end namespace internal

--- a/tt_metal/impl/dispatch/debug_tools.hpp
+++ b/tt_metal/impl/dispatch/debug_tools.hpp
@@ -7,11 +7,16 @@
 
 #include "tt_metal/host_api.hpp"
 #include "tt_metal/impl/device/device.hpp"
+#include "command_queue_interface.hpp"
 
 namespace internal {
 
 
 void wait_for_program_vector_to_arrive_and_compare_to_host_program_vector(const char *DISPATCH_MAP_DUMP, tt::tt_metal::Device * device);
 void match_device_program_data_with_host_program_data(const char* host_file, const char* device_file);
+
+// Dumps host-side CQ data into files.
+void dump_cqs(
+    std::ofstream &cq_file, std::ofstream &iq_file, SystemMemoryManager &sysmem_manager, bool dump_raw_data = false);
 
 } // end namespace internal

--- a/tt_metal/impl/dispatch/device_command.hpp
+++ b/tt_metal/impl/dispatch/device_command.hpp
@@ -321,12 +321,13 @@ class DeviceCommand {
     }
 
     template <bool inline_data = false>
-    void add_dispatch_write_host(bool flush_prefetch, uint32_t data_sizeB, const void *data = nullptr) {
+    void add_dispatch_write_host(bool flush_prefetch, uint32_t data_sizeB, bool is_event, const void *data = nullptr) {
         uint32_t payload_sizeB = sizeof(CQDispatchCmd) + (flush_prefetch ? data_sizeB : 0);
         this->add_prefetch_relay_inline(flush_prefetch, payload_sizeB);
 
         auto initialize_write_cmd = [&](CQDispatchCmd *write_cmd) {
             write_cmd->base.cmd_id = CQ_DISPATCH_CMD_WRITE_LINEAR_H_HOST;
+            write_cmd->write_linear_host.is_event = is_event;
             write_cmd->write_linear_host.length =
                 sizeof(CQDispatchCmd) + data_sizeB;  // CQ_DISPATCH_CMD_WRITE_LINEAR_HOST writes dispatch cmd back to completion queue
         };

--- a/tt_metal/impl/dispatch/dispatch_address_map.hpp
+++ b/tt_metal/impl/dispatch/dispatch_address_map.hpp
@@ -14,6 +14,9 @@ static constexpr uint32_t PCIE_ALIGNMENT = NOC_PCIE_READ_ALIGNMENT_BYTES >= NOC_
 
 // Command queue pointers
 constexpr static uint32_t CQ_PREFETCH_Q_RD_PTR = L1_UNRESERVED_BASE;
+// Used to notify host of how far device has gotten, doesn't need L1 alignment because it's only written locally by
+// prefetch kernel.
+constexpr static uint32_t CQ_PREFETCH_Q_PCIE_RD_PTR = CQ_PREFETCH_Q_RD_PTR + sizeof(uint32_t);
 constexpr static uint32_t CQ_COMPLETION_WRITE_PTR = CQ_PREFETCH_Q_RD_PTR + L1_ALIGNMENT;
 constexpr static uint32_t CQ_COMPLETION_READ_PTR = CQ_COMPLETION_WRITE_PTR + L1_ALIGNMENT;
 // Max of 2 CQs. CQ0_COMPLETION_LAST_EVENT and CQ1_COMPLETION_LAST_EVENT track the last completed event in the respective CQs
@@ -28,6 +31,8 @@ constexpr static std::uint64_t DISPATCH_MESSAGE_REMOTE_SENDER_ADDR = DISPATCH_ME
 constexpr static std::uint32_t DISPATCH_L1_UNRESERVED_BASE = (((DISPATCH_MESSAGE_REMOTE_SENDER_ADDR + DISPATCH_MESSAGE_ADDR_RESERVATION) - 1) | (PCIE_ALIGNMENT - 1)) + 1;
 
 // Host addresses in hugepage for dispatch
-static constexpr uint32_t HOST_CQ_ISSUE_READ_PTR = 0; // this seems to be unused
-static constexpr uint32_t HOST_CQ_COMPLETION_WRITE_PTR = HOST_CQ_ISSUE_READ_PTR + PCIE_ALIGNMENT;
-static constexpr uint32_t CQ_START = HOST_CQ_COMPLETION_WRITE_PTR + PCIE_ALIGNMENT;
+static constexpr uint32_t HOST_CQ_ISSUE_READ_PTR = 0; // Used by host
+static constexpr uint32_t HOST_CQ_ISSUE_WRITE_PTR = HOST_CQ_ISSUE_READ_PTR + PCIE_ALIGNMENT;
+static constexpr uint32_t HOST_CQ_COMPLETION_WRITE_PTR = HOST_CQ_ISSUE_WRITE_PTR + PCIE_ALIGNMENT;
+static constexpr uint32_t HOST_CQ_COMPLETION_READ_PTR = HOST_CQ_COMPLETION_WRITE_PTR + PCIE_ALIGNMENT;
+static constexpr uint32_t CQ_START = HOST_CQ_COMPLETION_READ_PTR + PCIE_ALIGNMENT;

--- a/tt_metal/impl/dispatch/kernels/cq_prefetch.cpp
+++ b/tt_metal/impl/dispatch/kernels/cq_prefetch.cpp
@@ -28,24 +28,25 @@ constexpr uint32_t pcie_size = get_compile_time_arg_val(6);
 constexpr uint32_t prefetch_q_base = get_compile_time_arg_val(7);
 constexpr uint32_t prefetch_q_size = get_compile_time_arg_val(8);
 constexpr uint32_t prefetch_q_rd_ptr_addr = get_compile_time_arg_val(9);
+constexpr uint32_t prefetch_q_pcie_rd_ptr_addr = get_compile_time_arg_val(10);
 
-constexpr uint32_t cmddat_q_base = get_compile_time_arg_val(10);
-constexpr uint32_t cmddat_q_size = get_compile_time_arg_val(11);
+constexpr uint32_t cmddat_q_base = get_compile_time_arg_val(11);
+constexpr uint32_t cmddat_q_size = get_compile_time_arg_val(12);
 
 // unused for prefetch_h
-constexpr uint32_t scratch_db_base = get_compile_time_arg_val(12);
-constexpr uint32_t scratch_db_size = get_compile_time_arg_val(13);
-constexpr uint32_t downstream_sync_sem_id = get_compile_time_arg_val(14);
+constexpr uint32_t scratch_db_base = get_compile_time_arg_val(13);
+constexpr uint32_t scratch_db_size = get_compile_time_arg_val(14);
+constexpr uint32_t downstream_sync_sem_id = get_compile_time_arg_val(15);
 
 // prefetch_d specific
-constexpr uint32_t cmddat_q_pages = get_compile_time_arg_val(15);
-constexpr uint32_t my_upstream_cb_sem_id = get_compile_time_arg_val(16);
-constexpr uint32_t upstream_cb_sem_id = get_compile_time_arg_val(17);
-constexpr uint32_t cmddat_q_log_page_size = get_compile_time_arg_val(18);
-constexpr uint32_t cmddat_q_blocks = get_compile_time_arg_val(19);
+constexpr uint32_t cmddat_q_pages = get_compile_time_arg_val(16);
+constexpr uint32_t my_upstream_cb_sem_id = get_compile_time_arg_val(17);
+constexpr uint32_t upstream_cb_sem_id = get_compile_time_arg_val(18);
+constexpr uint32_t cmddat_q_log_page_size = get_compile_time_arg_val(19);
+constexpr uint32_t cmddat_q_blocks = get_compile_time_arg_val(20);
 
-constexpr uint32_t is_d_variant = get_compile_time_arg_val(20);
-constexpr uint32_t is_h_variant = get_compile_time_arg_val(21);
+constexpr uint32_t is_d_variant = get_compile_time_arg_val(21);
+constexpr uint32_t is_h_variant = get_compile_time_arg_val(22);
 
 constexpr uint32_t my_noc_xy = uint32_t(NOC_XY_ENCODING(MY_NOC_X, MY_NOC_Y));
 constexpr uint32_t upstream_noc_xy = uint32_t(NOC_XY_ENCODING(UPSTREAM_NOC_X, UPSTREAM_NOC_Y));
@@ -171,6 +172,7 @@ uint32_t read_from_pcie(volatile tt_l1_ptr prefetch_q_entry_type *& prefetch_q_r
 
     // Tell host we read
     *(volatile tt_l1_ptr uint32_t *) prefetch_q_rd_ptr_addr = (uint32_t)prefetch_q_rd_ptr;
+    *(volatile tt_l1_ptr uint32_t *) prefetch_q_pcie_rd_ptr_addr = (uint32_t)pcie_read_ptr;
 
     prefetch_q_rd_ptr++;
 

--- a/tt_metal/llrt/rtoptions.cpp
+++ b/tt_metal/llrt/rtoptions.cpp
@@ -83,6 +83,15 @@ RunTimeOptions::RunTimeOptions() {
 
     const char *validate_kernel_binaries = std::getenv("TT_METAL_VALIDATE_PROGRAM_BINARIES");
     set_validate_kernel_binaries(validate_kernel_binaries != nullptr && validate_kernel_binaries[0] == '1');
+
+    const char *num_cqs = getenv("TT_METAL_GTEST_NUM_HW_CQS");
+    if (num_cqs != nullptr) {
+        try {
+            set_num_hw_cqs(std::stoi(num_cqs));
+        } catch (const std::invalid_argument& ia) {
+            TT_THROW("Invalid TT_METAL_GTEST_NUM_HW_CQS: {}", num_cqs);
+        }
+    }
 }
 
 const std::string &RunTimeOptions::get_root_dir() {

--- a/tt_metal/llrt/rtoptions.hpp
+++ b/tt_metal/llrt/rtoptions.hpp
@@ -97,6 +97,7 @@ class RunTimeOptions {
     uint32_t watcher_debug_delay = 0;
 
     bool validate_kernel_binaries = false;
+    unsigned num_hw_cqs = 1;
 
    public:
     RunTimeOptions();
@@ -232,6 +233,9 @@ class RunTimeOptions {
     // Whether to compile with -g to include DWARF debug info in the binary.
     inline bool get_riscv_debug_info_enabled() { return riscv_debug_info_enabled; }
     inline void set_riscv_debug_info_enabled(bool enable) { riscv_debug_info_enabled = enable; }
+
+    inline unsigned get_num_hw_cqs() { return num_hw_cqs; }
+    inline void set_num_hw_cqs(unsigned num) { num_hw_cqs = num; }
 
     inline uint32_t get_watcher_debug_delay() { return watcher_debug_delay; }
     void set_watcher_debug_delay(uint32_t delay) { watcher_debug_delay = delay; }

--- a/tt_metal/tools/watcher_dump/watcher_dump.cpp
+++ b/tt_metal/tools/watcher_dump/watcher_dump.cpp
@@ -2,38 +2,72 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 #include <iostream>
+#include <filesystem>
 #include "tt_metal/host_api.hpp"
 #include "impl/debug/watcher_server.hpp"
+#include "impl/dispatch/debug_tools.hpp"
 
 using namespace tt;
-using std::vector;
-using std::string;
 using std::cout, std::endl;
+using std::string;
+using std::vector;
 
-void dump_data(vector<unsigned>& device_ids) {
+string output_dir_name = "generated/watcher/";
+string logfile_name = "cq_dump.txt";
+
+void dump_data(vector<unsigned>& device_ids, bool dump_watcher, bool dump_cqs, bool dump_cqs_raw_data, int num_hw_cqs) {
     // Don't clear L1, this way we can dump the state.
     llrt::OptionsG.set_clear_l1(false);
 
+    std::filesystem::path parent_dir(tt::llrt::OptionsG.get_root_dir() + output_dir_name);
+    std::filesystem::path cq_dir(parent_dir.string() + "command_queue_dump/");
+    std::filesystem::create_directories(cq_dir);
+
+    if (dump_cqs)
+        cout << "Dumping Command Queues into: " << cq_dir.string() << endl;
+    if (dump_watcher)
+        cout << "Dumping Watcher Log into: " << watcher_get_log_file_name() << endl;
+
     // Only look at user-specified devices
     for (unsigned id : device_ids) {
+        string cq_fname = cq_dir.string() + fmt::format("device_{}_completion_q.txt", id);
+        std::ofstream cq_file = std::ofstream(cq_fname);
+        string iq_fname = cq_dir.string() + fmt::format("device_{}_issue_q.txt", id);
+        std::ofstream iq_file = std::ofstream(iq_fname);
         // Minimal setup, since we'll be attaching to a potentially hanging chip.
-        auto* device = tt::tt_metal::CreateDeviceMinimal(id);
+        auto* device = tt::tt_metal::CreateDeviceMinimal(id, num_hw_cqs);
+        if (dump_cqs) {
+            std::unique_ptr<SystemMemoryManager> sysmem_manager =
+                std::make_unique<SystemMemoryManager>(id, num_hw_cqs);
+            internal::dump_cqs(cq_file, iq_file, *sysmem_manager, dump_cqs_raw_data);
+        }
         // Watcher attach wthout watcher init - to avoid clearing mailboxes.
-        watcher_attach(device);
+        if (dump_watcher)
+            watcher_attach(device);
     }
 
     // Watcher doesn't have kernel ids since we didn't create them here, need to read from file.
-    watcher_read_kernel_ids_from_file();
-    watcher_dump();
+    if (dump_watcher) {
+        watcher_read_kernel_ids_from_file();
+        watcher_dump();
+    }
 }
 
 void print_usage(const char* exec_name) {
     cout << "Usage: " << exec_name << " [OPTION]" << endl;
-    cout << "\t-d=LIST, --devices=LIST: Device IDs of chips to dump, LIST is comma separated list (\"0,2,3\") or \"all\"." << endl;
     cout << "\t-h, --help: Display this message." << endl;
+    cout << "\t-d=LIST, --devices=LIST: Device IDs of chips to dump, LIST is comma separated list (\"0,2,3\") or "
+            "\"all\"."
+         << endl;
+    cout << "\t-n=INT, --num-hw-cqs=INT: Number of CQs, should match the original program." << endl;
+    cout << "\t-c, --dump-cqs: Dump Command Queue data." << endl;
+    cout << "\t--dump-cqs-data: Dump Command Queue raw data (bytes), this can take minutes per CQ." << endl;
+    cout << "\t-w, --dump-watcher: Dump watcher data, available data depends on whether watcher was enabled for "
+            "original program."
+         << endl;
 }
 
-int main(int argc, char *argv[]) {
+int main(int argc, char* argv[]) {
     cout << "Running watcher dump tool..." << endl;
     // Default devices is all of them.
     vector<unsigned> device_ids;
@@ -43,13 +77,15 @@ int main(int argc, char *argv[]) {
     }
 
     // Go through user args, handle accordingly.
+    bool dump_watcher = false, dump_cqs = false, dump_cqs_raw_data = false;
+    int num_hw_cqs = 1;
     for (int idx = 1; idx < argc; idx++) {
         string s(argv[idx]);
         if (s == "-h" || s == "--help") {
             print_usage(argv[0]);
             return 0;
         } else if ((s.rfind("-d=", 0) == 0) || (s.rfind("--devices=", 0) == 0)) {
-            string list = s.substr(s.find("=")+1);
+            string list = s.substr(s.find("=") + 1);
             // "all" is acceptable, and the same as the default.
             if (list == "all")
                 continue;
@@ -60,12 +96,22 @@ int main(int argc, char *argv[]) {
             string item;
             while (std::getline(iss, item, ',')) {
                 if (stoi(item) >= num_devices) {
-                    cout << "Error: illegal device (" << stoi(item) << "), allowed range is [0, " << num_devices << ")" << endl;
+                    cout << "Error: illegal device (" << stoi(item) << "), allowed range is [0, " << num_devices << ")"
+                         << endl;
                     print_usage(argv[0]);
                     return 1;
                 }
                 device_ids.push_back(stoi(item));
             }
+        } else if ((s.rfind("-n=", 0) == 0) || (s.rfind("--num-hw-cqs==", 0) == 0)) {
+            string value_str = s.substr(s.find("=") + 1);
+            num_hw_cqs = stoi(value_str.c_str());
+        } else if (s == "-w" || s == "--dump-watcher") {
+            dump_watcher = true;
+        } else if (s == "-c" || s == "--dump-cqs") {
+            dump_cqs = true;
+        } else if (s == "--dump-cqs-data") {
+            dump_cqs_raw_data = true;
         } else {
             cout << "Error: unrecognized command line argument: " << s << endl;
             print_usage(argv[0]);
@@ -74,6 +120,6 @@ int main(int argc, char *argv[]) {
     }
 
     // Call dump function with user config.
-    dump_data(device_ids);
+    dump_data(device_ids, dump_watcher, dump_cqs, dump_cqs_raw_data, num_hw_cqs);
     cout << "Watcher dump tool finished." << endl;
 }

--- a/tt_metal/tools/watcher_dump/watcher_dump.cpp
+++ b/tt_metal/tools/watcher_dump/watcher_dump.cpp
@@ -19,6 +19,10 @@ void dump_data(vector<unsigned>& device_ids, bool dump_watcher, bool dump_cqs, b
     // Don't clear L1, this way we can dump the state.
     llrt::OptionsG.set_clear_l1(false);
 
+    // Watcher should be disabled for this, so we don't (1) overwrite the kernel_names.txt and (2) do any other dumping
+    // than the one we want.
+    llrt::OptionsG.set_watcher_enabled(false);
+
     std::filesystem::path parent_dir(tt::llrt::OptionsG.get_root_dir() + output_dir_name);
     std::filesystem::path cq_dir(parent_dir.string() + "command_queue_dump/");
     std::filesystem::create_directories(cq_dir);

--- a/tt_metal/tt_metal.cpp
+++ b/tt_metal/tt_metal.cpp
@@ -744,9 +744,9 @@ Device *CreateDevice(
     return dev;
 }
 
-Device *CreateDeviceMinimal(chip_id_t device_id) {
+Device *CreateDeviceMinimal(chip_id_t device_id, const uint8_t num_hw_cqs) {
     ZoneScoped;
-    Device *dev = new Device(device_id, 1, DEFAULT_L1_SMALL_SIZE, DEFAULT_TRACE_REGION_SIZE, {}, true);
+    Device *dev = new Device(device_id, num_hw_cqs, DEFAULT_L1_SMALL_SIZE, DEFAULT_TRACE_REGION_SIZE, {}, true);
     tt::Cluster::instance().set_internal_routing_info_for_ethernet_cores(true);
     return dev;
 }


### PR DESCRIPTION
### Ticket
[Link to Github Issue](https://github.com/tenstorrent/tt-metal/issues/8313)

### Problem description
We want to be able to see the CQs in hugepages during the dump.

### What's changed
Update the dump tool to read out the CQ data from hugepages, make a basic attempt at linearly parsing the commands (just throwing out bad ids and commands). There's an option to dump the full bytes to a file for checking if needed, but it's slow (~5min per CQ, instead of a few seconds to do the parsing).

### Checklist
- [x] Post commit CI passes - https://github.com/tenstorrent/tt-metal/actions/runs/10046841976
- [x] Model regression CI testing passes (if applicable) - N/A
- [X] New/Existing tests provide coverage for changes - Existing dump tool test includes the new option
