### PR TITLE
#0: Fix for config=debug on blackhole

### DIFF
--- a/tt_metal/impl/dispatch/device_command.hpp
+++ b/tt_metal/impl/dispatch/device_command.hpp
@@ -343,11 +343,9 @@ class DeviceCommand {
 
         if (inline_data) {
             TT_ASSERT(data != nullptr);  // compiled out?
-            uint32_t increment_sizeB = align(data_sizeB, PCIE_ALIGNMENT);
-            this->add_data(data, data_sizeB, increment_sizeB);
-        } else {
-            this->cmd_write_offsetB = align(this->cmd_write_offsetB, PCIE_ALIGNMENT);
+            this->add_data(data, data_sizeB, data_sizeB);
         }
+        this->cmd_write_offsetB = align(this->cmd_write_offsetB, PCIE_ALIGNMENT);
     }
 
     void add_prefetch_exec_buf(uint32_t base_addr, uint32_t log_page_size, uint32_t pages) {


### PR DESCRIPTION

### Problem description
Hitting assert for writing outside of device command with config=debug on BH due to erroneously padding data that is written back to host

### What's changed
Add data and then pad to alignment 

### Checklist
- [x] [Post commit CI passes](https://github.com/tenstorrent/tt-metal/actions/runs/9997851195)
- [x] [Model regression CI testing](https://github.com/tenstorrent/tt-metal/actions/runs/9997862093)