### PR TITLE
Fix rmsnorm is_sharded

### DIFF
--- a/models/common/rmsnorm.py
+++ b/models/common/rmsnorm.py
@@ -11,12 +11,12 @@ SHARD_HEIGHT = TILE  # Current ttnn.rms_norm implementation requires shard heigh
 
 class RMSNorm(LightweightModule):
     """
-    Sharded RMSNorm supporting replication over a DeviceMesh and sharding within devices.
+    RMSNorm supporting replication over a DeviceMesh and sharding within devices.
 
     This class implements a Root Mean Square Normalization (RMSNorm) that can be
     distributed across multiple devices and cores. If the `device` parameter is a
     DeviceMesh, the weights and computations are replicated across all devices in
-    the mesh. Requires an interleaved input tensor, can optionally output a sharded tensor.
+    the mesh. Expects an interleaved input tensor, can optionally output a sharded tensor.
 
     Args:
         device: The device or DeviceMesh on which to perform the computations.
@@ -28,6 +28,7 @@ class RMSNorm(LightweightModule):
         weight_memory_config: Configuration for the weight memory, default is DRAM_MEMORY_CONFIG.
         weight_dtype: The data type for the tensors, bfp8_b hits >0.999 PCC in the models we tested.
         model_config: Optional configuration dictionary for the model.
+        is_sharded: Sharded version is faster for some models but doesn't support all batch sizes.
         eps (float): Small value to avoid division by zero in normalization, default is 1e-05.
 
     If model_config is provided, it must specify SHARDED_NORM_INPUT_MEMCFG, SHARDED_NORM_PRGM_CFG
@@ -71,7 +72,7 @@ class RMSNorm(LightweightModule):
             mesh_mapper=ttnn.ReplicateTensorToMesh(device) if is_device_mesh else None,
         )
 
-        if not is_sharded:
+        if is_sharded:
             if model_config:
                 self.input_config = model_config["SHARDED_NORM_INPUT_MEMCFG"]
                 self.program_config = model_config["SHARDED_NORM_PRGM_CFG"]
@@ -99,10 +100,7 @@ class RMSNorm(LightweightModule):
                 self.output_config = self.input_config
 
     def forward(self, x: ttnn.Tensor, out_sharded=False) -> ttnn.Tensor:
-        if not self.is_sharded:  # Interleaved rmsnorm
-            x = ttnn.rms_norm(x, weight=self.weight, epsilon=self.eps)
-            return x
-        else:  # Sharded rmsnorm
+        if self.is_sharded:  # sharded version converts from interleaved inputs and optionally back
             x = ttnn.experimental.tensor.interleaved_to_sharded(
                 x,
                 sharded_mem_config=self.input_config,
@@ -119,3 +117,7 @@ class RMSNorm(LightweightModule):
             x_interleaved = ttnn.experimental.tensor.sharded_to_interleaved(x)
             x.deallocate(True)
             return x_interleaved
+        else:  # Interleaved rmsnorm does not need program or memory configs
+            assert not out_sharded, "Non-sharded version of RMSNorm cannot output a sharded tensor"
+            x = ttnn.rms_norm(x, weight=self.weight, epsilon=self.eps)
+            return x

--- a/models/common/tests/test_rmsnorm.py
+++ b/models/common/tests/test_rmsnorm.py
@@ -60,7 +60,11 @@ class RefModel(torch.nn.Module):
 
 
 @skip_for_grayskull("Requires wormhole_b0 to run")
-def test_rmsnorm_singledevice(device, use_program_cache, reset_seeds):
+@pytest.mark.parametrize(
+    "is_sharded",
+    (True, False),
+)
+def test_rmsnorm_singledevice(device, is_sharded, use_program_cache, reset_seeds):
     dim = 4096
     dtype = ttnn.bfloat8_b
 
@@ -72,6 +76,7 @@ def test_rmsnorm_singledevice(device, use_program_cache, reset_seeds):
         dim=dim,
         state_dict=state_dict,
         weight_key="rmsnorm",
+        is_sharded=is_sharded,
     )
     input = torch.rand(1, 1, 32, dim)
     reference_output = reference_model(input)
@@ -99,7 +104,11 @@ def test_rmsnorm_singledevice(device, use_program_cache, reset_seeds):
 
 
 @skip_for_grayskull("Requires wormhole_b0 to run")
-def test_rmsnorm_multidevice(t3k_device_mesh, use_program_cache, reset_seeds):
+@pytest.mark.parametrize(
+    "is_sharded",
+    (True, False),
+)
+def test_rmsnorm_multidevice(t3k_device_mesh, is_sharded, use_program_cache, reset_seeds):
     dim = 4096
     dtype = ttnn.bfloat8_b
 
@@ -111,6 +120,7 @@ def test_rmsnorm_multidevice(t3k_device_mesh, use_program_cache, reset_seeds):
         dim=dim,
         state_dict=state_dict,
         weight_key="rmsnorm",
+        is_sharded=is_sharded,
     )
     input = torch.rand(1, 1, 32, dim)
     reference_output = reference_model(input)


### PR DESCRIPTION
### Ticket
[Link to Github Issue](https://github.com/tenstorrent/tt-metal/issues/10448)

### Problem description
RMSNorm was defaulting to sharded, which did not support prefill and reduced perf slightly

### What's changed
Make sharing optional and default to non-sharded implementation.

### Checklist
- [x] Post commit CI passes ([link](https://github.com/tenstorrent/tt-metal/actions/runs/10006503594))
- [x] Model regression CI testing passes ([link](https://github.com/tenstorrent/tt-metal/actions/runs/10006513118))
- [x] New/Existing tests provide coverage for changes
