### PR TITLE
[CCL] Wrapped implementation for ring reduce scatter tensor slicer

### DIFF
--- a/tests/tt_eager/ops/ccl/test_ccl_helpers.cpp
+++ b/tests/tt_eager/ops/ccl/test_ccl_helpers.cpp
@@ -227,6 +227,138 @@ TEST(CclHelper_AdvanceSliceRowMajor, InnerOffset_24_0__InnerShape_24_0__OuterSha
 }
 
 /////////////////////////////////////////
+// TEST AdvanceWrappedSliceRowMajor
+/////////////////////////////////////////
+//                                               x_y             x_y             x_y
+TEST(CclHelper_AdvanceWrappedSliceRowMajor, InnerOffset_0_0__InnerShape_1_1__OuterShape_2_2__NumActiveSlices_1) {
+    const auto expected = ttnn::ccl::coord_t(1, 0);
+    auto const& result = ttnn::ccl::advance_wrapped_slice_row_major({0, 0}, {1, 1}, {2, 2}, 1);
+    ASSERT_EQ(result.x, expected.x);
+    ASSERT_EQ(result.y, expected.y);
+}
+TEST(CclHelper_AdvanceWrappedSliceRowMajor, InnerOffset_1_0__InnerShape_1_1__OuterShape_2_2__NumActiveSlices_1) {
+    const auto expected = ttnn::ccl::coord_t(0, 1);
+    auto const& result = ttnn::ccl::advance_wrapped_slice_row_major({1, 0}, {1, 1}, {2, 2}, 1);
+    ASSERT_EQ(result.x, expected.x);
+    ASSERT_EQ(result.y, expected.y);
+}
+TEST(CclHelper_AdvanceWrappedSliceRowMajor, InnerOffset_0_1__InnerShape_1_1__OuterShape_2_2__NumActiveSlices_1) {
+    const auto expected = ttnn::ccl::coord_t(1, 1);
+    auto const& result = ttnn::ccl::advance_wrapped_slice_row_major({0, 1}, {1, 1}, {2, 2}, 1);
+    ASSERT_EQ(result.x, expected.x);
+    ASSERT_EQ(result.y, expected.y);
+}
+TEST(CclHelper_AdvanceWrappedSliceRowMajor, InnerOffset_0_0__InnerShape_1_1__OuterShape_2_2__NumActiveSlices_2) {
+    const auto expected = ttnn::ccl::coord_t(0, 1);
+    auto const& result = ttnn::ccl::advance_wrapped_slice_row_major({0, 0}, {1, 1}, {2, 2}, 2);
+    ASSERT_EQ(result.x, expected.x);
+    ASSERT_EQ(result.y, expected.y);
+}
+TEST(CclHelper_AdvanceWrappedSliceRowMajor, InnerOffset_1_0__InnerShape_1_1__OuterShape_2_2__NumActiveSlices_2) {
+    const auto expected = ttnn::ccl::coord_t(1, 1);
+    auto const& result = ttnn::ccl::advance_wrapped_slice_row_major({1, 0}, {1, 1}, {2, 2}, 2);
+    ASSERT_EQ(result.x, expected.x);
+    ASSERT_EQ(result.y, expected.y);
+}
+
+
+// Test cases pulled from LLama 70B prefill configurations
+// chip 0 worker 0 link 0 reader unidirectional
+TEST(CclHelper_AdvanceWrappedSliceRowMajor, InnerOffset_0_0__InnerShape_24_1__OuterShape_32_4__NumWorkers_4) {
+    const auto worker_slice_offset = ttnn::ccl::coord_t(0, 0);
+    const auto worker_slice_shape = ttnn::ccl::coord_t(24, 1);
+    const auto tensor_slice_shape = ttnn::ccl::coord_t(32, 4);
+    const uint32_t num_workers = 4;
+
+    const auto expected = ttnn::ccl::coord_t(0, 3); // Updated
+    auto const& result_offset = ttnn::ccl::advance_wrapped_slice_row_major(worker_slice_offset, worker_slice_shape, tensor_slice_shape, num_workers);
+    ASSERT_EQ(result_offset.x, expected.x);
+    ASSERT_EQ(result_offset.y, expected.y);
+
+
+    auto const& result_offset2 = ttnn::ccl::advance_wrapped_slice_row_major(result_offset, worker_slice_shape, tensor_slice_shape, num_workers);
+    ASSERT_TRUE(result_offset2.x >= tensor_slice_shape.x || result_offset2.y >= tensor_slice_shape.y);
+}
+
+TEST(CclHelper_AdvanceWrappedSliceRowMajor, InnerOffset_24_0__InnerShape_24_1__OuterShape_32_4__NumWorkers_4) {
+    const auto worker_slice_offset = ttnn::ccl::coord_t(24, 0);
+    const auto worker_slice_shape = ttnn::ccl::coord_t(24, 1);
+    const auto tensor_slice_shape = ttnn::ccl::coord_t(32, 4);
+    const uint32_t num_workers = 4;
+
+    const auto expected = ttnn::ccl::coord_t(24, 3); // Updated
+    auto const& result_offset = ttnn::ccl::advance_wrapped_slice_row_major(worker_slice_offset, worker_slice_shape, tensor_slice_shape, num_workers);
+    ASSERT_EQ(result_offset.x, expected.x);
+    ASSERT_EQ(result_offset.y, expected.y);
+
+    auto const& result_offset2 = ttnn::ccl::advance_wrapped_slice_row_major(result_offset, worker_slice_shape, tensor_slice_shape, num_workers);
+    ASSERT_TRUE(result_offset2.x >= tensor_slice_shape.x || result_offset2.y >= tensor_slice_shape.y);
+}
+
+TEST(CclHelper_AdvanceWrappedSliceRowMajor, InnerOffset_0_0__InnerShape_44_1__OuterShape_32_4__NumWorkers_2) { // New
+    const auto worker_slice_offset = ttnn::ccl::coord_t(0, 0);
+    const auto worker_slice_shape = ttnn::ccl::coord_t(44, 1);
+    const auto tensor_slice_shape = ttnn::ccl::coord_t(32, 4);
+    const uint32_t num_workers = 2;
+
+    const auto expected = ttnn::ccl::coord_t(24, 2);
+    auto const& result_offset = ttnn::ccl::advance_wrapped_slice_row_major(worker_slice_offset, worker_slice_shape, tensor_slice_shape, num_workers);
+    ASSERT_EQ(result_offset.x, expected.x);
+    ASSERT_EQ(result_offset.y, expected.y);
+
+    auto const& result_offset2 = ttnn::ccl::advance_wrapped_slice_row_major(result_offset, worker_slice_shape, tensor_slice_shape, num_workers);
+    ASSERT_TRUE(result_offset2.x >= tensor_slice_shape.x || result_offset2.y >= tensor_slice_shape.y);
+}
+
+
+// Test that we successfully go out of bounds on the last iteration
+TEST(CclHelper_AdvanceWrappedSliceRowMajor, InnerOffset_0_1__InnerShape_1_1__OuterShape_2_2__NumActiveSlices_2) {
+    auto const& result = ttnn::ccl::advance_wrapped_slice_row_major({0, 1}, {1, 1}, {2, 2}, 2);
+    ASSERT_TRUE(result.x >= 2 || result.y >= 2);
+}
+TEST(CclHelper_AdvanceWrappedSliceRowMajor, InnerOffset_1_1__InnerShape_1_1__OuterShape_2_2__NumActiveSlices_2) {
+    auto const& result = ttnn::ccl::advance_wrapped_slice_row_major({1, 1}, {1, 1}, {2, 2}, 2);
+    ASSERT_TRUE(result.x >= 2 || result.y >= 2);
+}
+
+TEST(CclHelper_AdvanceWrappedSliceRowMajor, InnerOffset_0_0__InnerShape_1_1__OuterShape_2_2__NumActiveSlices_3) {
+    const auto expected = ttnn::ccl::coord_t(1, 1);
+    auto const& result = ttnn::ccl::advance_wrapped_slice_row_major({0, 0}, {1, 1}, {2, 2}, 3);
+    ASSERT_EQ(result.x, expected.x);
+    ASSERT_EQ(result.y, expected.y);
+}
+TEST(CclHelper_AdvanceWrappedSliceRowMajor, InnerOffset_1_1__InnerShape_1_1__OuterShape_2_2__NumActiveSlices_3) {
+    const auto expected = ttnn::ccl::coord_t(1, 1);
+    const auto outer_shape = ttnn::ccl::coord_t(2, 2);
+    const auto inner_offset = ttnn::ccl::coord_t(1, 1);
+    const auto inner_shape = ttnn::ccl::coord_t(1, 1);
+    const uint32_t num_parallel_workers = 3;
+    auto const& result =
+        ttnn::ccl::advance_wrapped_slice_row_major(inner_offset, inner_shape, outer_shape, num_parallel_workers);
+    ASSERT_TRUE(result.x >= outer_shape.x || result.y >= outer_shape.y);
+}
+TEST(CclHelper_AdvanceWrappedSliceRowMajor, InnerOffset_16_1__InnerShape_24_1__OuterShape_32_4__NumWorkers_4) {
+    const auto worker_slice_offset = ttnn::ccl::coord_t(16, 1); // Updated
+    const auto worker_slice_shape = ttnn::ccl::coord_t(24, 1);
+    const auto tensor_slice_shape = ttnn::ccl::coord_t(32, 4);
+    const uint32_t num_workers = 4;
+
+    auto const& result_offset = ttnn::ccl::advance_wrapped_slice_row_major(worker_slice_offset, worker_slice_shape, tensor_slice_shape, num_workers);
+    ASSERT_TRUE(result_offset.x >= tensor_slice_shape.x || result_offset.y >= tensor_slice_shape.y);
+}
+
+
+TEST(CclHelper_AdvanceWrappedSliceRowMajor, InnerOffset_8_2__InnerShape_24_1__OuterShape_32_4__NumWorkers_4) {
+    const auto worker_slice_offset = ttnn::ccl::coord_t(8, 2); // Updated
+    const auto worker_slice_shape = ttnn::ccl::coord_t(24, 1);
+    const auto tensor_slice_shape = ttnn::ccl::coord_t(32, 4);
+    const uint32_t num_workers = 4;
+
+    auto const& result_offset = ttnn::ccl::advance_wrapped_slice_row_major(worker_slice_offset, worker_slice_shape, tensor_slice_shape, num_workers);
+    ASSERT_TRUE(result_offset.x >= tensor_slice_shape.x || result_offset.y >= tensor_slice_shape.y);
+}
+
+/////////////////////////////////////////
 // Test RingReduceScatterTensorSlicer
 /////////////////////////////////////////
 TEST(Ccl_RingReduceScatterTensorSlicer, ComputeWorkerSliceOffsets_AllWorkersSameRow) {
@@ -250,17 +382,18 @@ TEST(Ccl_RingReduceScatterTensorSlicer, ComputeWorkerSliceOffsets_1WorkerWrapToN
     ASSERT_EQ(worker_slice_offsets.at(3), tt_xy_pair(0, 2));
 }
 TEST(Ccl_RingReduceScatterTensorSlicer, ComputeWorkerSliceOffsets_1WorkerWrapToNextRowMisaligned) {
-    {
-        auto worker_slice_shapes = std::vector<tt_xy_pair>(4, {2, 2});
-        tt_xy_pair tensor_slice_shape = {5, 4};
-        auto const& worker_slice_offsets = ttnn::ccl::RingReduceScatterTensorSlicer::compute_worker_slice_offsets(
-            worker_slice_shapes, tensor_slice_shape);
-        ASSERT_EQ(worker_slice_offsets.at(0), tt_xy_pair(0, 0));
-        ASSERT_EQ(worker_slice_offsets.at(1), tt_xy_pair(2, 0));
-        ASSERT_EQ(worker_slice_offsets.at(2), tt_xy_pair(4, 0));
-        ASSERT_EQ(worker_slice_offsets.at(3), tt_xy_pair(0, 2));
-    }
+
+    auto worker_slice_shapes = std::vector<tt_xy_pair>(4, {2, 2});
+    tt_xy_pair tensor_slice_shape = {5, 4};
+    auto const& worker_slice_offsets = ttnn::ccl::RingReduceScatterTensorSlicer::compute_worker_slice_offsets(
+        worker_slice_shapes, tensor_slice_shape);
+    ASSERT_EQ(worker_slice_offsets.at(0), tt_xy_pair(0, 0));
+    ASSERT_EQ(worker_slice_offsets.at(1), tt_xy_pair(2, 0));
+    ASSERT_EQ(worker_slice_offsets.at(2), tt_xy_pair(4, 0));
+    ASSERT_EQ(worker_slice_offsets.at(3), tt_xy_pair(0, 2));
+
 }
+
 TEST(Ccl_RingReduceScatterTensorSlicer, ComputeWorkerSliceOffsets_MultipleWorkersWrapToNextRowAligned) {
     auto worker_slice_shapes = std::vector<tt_xy_pair>(8, {2, 2});
     tt_xy_pair tensor_slice_shape = {10, 4};
@@ -309,6 +442,82 @@ TEST(Ccl_RingReduceScatterTensorSlicer, ComputeWorkerSliceOffsets_NMinus1Workers
     ASSERT_EQ(worker_slice_offsets.at(0), tt_xy_pair(0, 0));
     ASSERT_EQ(worker_slice_offsets.at(1), tt_xy_pair(0, 3));
     ASSERT_EQ(worker_slice_offsets.at(2), tt_xy_pair(0, 6));
+}
+
+/////////////////////////////////////////
+// Test RingReduceScatterWrappedTensorSlicer
+/////////////////////////////////////////
+TEST(Ccl_RingReduceScatterWrappedTensorSlicer, ComputeWorkerSliceWrappedOffsets_AllWorkersSameRow) {
+    auto worker_slice_shapes = std::vector<tt_xy_pair>(4, {2, 1});
+    tt_xy_pair tensor_slice_shape = {8, 1};
+    auto const& worker_slice_offsets = ttnn::ccl::RingReduceScatterWrappedTensorSlicer::compute_worker_slice_offsets(worker_slice_shapes, tensor_slice_shape);
+    ASSERT_EQ(worker_slice_offsets.at(0), tt_xy_pair(0, 0));
+    ASSERT_EQ(worker_slice_offsets.at(1), tt_xy_pair(2, 0));
+    ASSERT_EQ(worker_slice_offsets.at(2), tt_xy_pair(4, 0));
+    ASSERT_EQ(worker_slice_offsets.at(3), tt_xy_pair(6, 0));
+}
+TEST(Ccl_RingReduceScatterWrappedTensorSlicer, ComputeWorkerSliceWrappedOffsets_1WorkerWrapToNextRowAligned) {
+    auto worker_slice_shapes = std::vector<tt_xy_pair>(4, {2, 1});
+    tt_xy_pair tensor_slice_shape = {6, 2};
+    auto const& worker_slice_offsets = ttnn::ccl::RingReduceScatterWrappedTensorSlicer::compute_worker_slice_offsets(worker_slice_shapes, tensor_slice_shape);
+    ASSERT_EQ(worker_slice_offsets.at(0), tt_xy_pair(0, 0));
+    ASSERT_EQ(worker_slice_offsets.at(1), tt_xy_pair(2, 0));
+    ASSERT_EQ(worker_slice_offsets.at(2), tt_xy_pair(4, 0));
+    ASSERT_EQ(worker_slice_offsets.at(3), tt_xy_pair(0, 1));
+}
+TEST(Ccl_RingReduceScatterWrappedTensorSlicer, ComputeWorkerSliceWrappedOffsets_1WorkerWrapToNextRowMisaligned) {
+    auto worker_slice_shapes = std::vector<tt_xy_pair>(4, {2, 1});
+    tt_xy_pair tensor_slice_shape = {5, 2};
+    auto const& worker_slice_offsets = ttnn::ccl::RingReduceScatterWrappedTensorSlicer::compute_worker_slice_offsets(worker_slice_shapes, tensor_slice_shape);
+    ASSERT_EQ(worker_slice_offsets.at(0), tt_xy_pair(0, 0));
+    ASSERT_EQ(worker_slice_offsets.at(1), tt_xy_pair(2, 0));
+    ASSERT_EQ(worker_slice_offsets.at(2), tt_xy_pair(4, 0));
+    ASSERT_EQ(worker_slice_offsets.at(3), tt_xy_pair(1, 1));
+}
+TEST(Ccl_RingReduceScatterWrappedTensorSlicer, ComputeWorkerSliceWrappedOffsets_MultipleWorkersWrapToNextRowAligned) {
+    auto worker_slice_shapes = std::vector<tt_xy_pair>(8, {2, 1});
+    tt_xy_pair tensor_slice_shape = {10, 2};
+    auto const& worker_slice_offsets = ttnn::ccl::RingReduceScatterWrappedTensorSlicer::compute_worker_slice_offsets(worker_slice_shapes, tensor_slice_shape);
+    ASSERT_EQ(worker_slice_offsets.at(0), tt_xy_pair(0, 0));
+    ASSERT_EQ(worker_slice_offsets.at(1), tt_xy_pair(2, 0));
+    ASSERT_EQ(worker_slice_offsets.at(2), tt_xy_pair(4, 0));
+    ASSERT_EQ(worker_slice_offsets.at(3), tt_xy_pair(6, 0));
+    ASSERT_EQ(worker_slice_offsets.at(4), tt_xy_pair(8, 0));
+    ASSERT_EQ(worker_slice_offsets.at(5), tt_xy_pair(0, 1));
+    ASSERT_EQ(worker_slice_offsets.at(6), tt_xy_pair(2, 1));
+    ASSERT_EQ(worker_slice_offsets.at(7), tt_xy_pair(4, 1));
+}
+
+TEST(Ccl_RingReduceScatterWrappedTensorSlicer, ComputeWorkerSliceWrappedOffsets_MultipleWorkersWrapToNextRowMisaligned) {
+    auto worker_slice_shapes = std::vector<tt_xy_pair>(8, {2, 1});
+    tt_xy_pair tensor_slice_shape = {9, 2};
+    auto const& worker_slice_offsets = ttnn::ccl::RingReduceScatterWrappedTensorSlicer::compute_worker_slice_offsets(worker_slice_shapes, tensor_slice_shape);
+    ASSERT_EQ(worker_slice_offsets.at(0), tt_xy_pair(0, 0));
+    ASSERT_EQ(worker_slice_offsets.at(1), tt_xy_pair(2, 0));
+    ASSERT_EQ(worker_slice_offsets.at(2), tt_xy_pair(4, 0));
+    ASSERT_EQ(worker_slice_offsets.at(3), tt_xy_pair(6, 0));
+    ASSERT_EQ(worker_slice_offsets.at(4), tt_xy_pair(8, 0));
+    ASSERT_EQ(worker_slice_offsets.at(5), tt_xy_pair(1, 1));
+    ASSERT_EQ(worker_slice_offsets.at(6), tt_xy_pair(3, 1));
+    ASSERT_EQ(worker_slice_offsets.at(7), tt_xy_pair(5, 1));
+}
+
+TEST(Ccl_RingReduceScatterWrappedTensorSlicer, ComputeWorkerSliceWrappedOffsets_NMinus1WorkersWrapToNextRowAligned) {
+    auto worker_slice_shapes = std::vector<tt_xy_pair>(3, {16, 1});
+    tt_xy_pair tensor_slice_shape = {4, 12};
+    auto const& worker_slice_offsets = ttnn::ccl::RingReduceScatterWrappedTensorSlicer::compute_worker_slice_offsets(worker_slice_shapes, tensor_slice_shape);
+    ASSERT_EQ(worker_slice_offsets.at(0), tt_xy_pair(0, 0));
+    ASSERT_EQ(worker_slice_offsets.at(1), tt_xy_pair(0, 4));
+    ASSERT_EQ(worker_slice_offsets.at(2), tt_xy_pair(0, 8));
+}
+
+TEST(Ccl_RingReduceScatterWrappedTensorSlicer, ComputeWorkerSliceWrappedOffsets_NMinus1WorkersWrapToNextRowMisaligned) {
+    auto worker_slice_shapes = std::vector<tt_xy_pair>(3, {11, 1});
+    tt_xy_pair tensor_slice_shape = {3, 12};
+    auto const& worker_slice_offsets = ttnn::ccl::RingReduceScatterWrappedTensorSlicer::compute_worker_slice_offsets(worker_slice_shapes, tensor_slice_shape);
+    ASSERT_EQ(worker_slice_offsets.at(0), tt_xy_pair(0, 0));
+    ASSERT_EQ(worker_slice_offsets.at(1), tt_xy_pair(2, 3));
+    ASSERT_EQ(worker_slice_offsets.at(2), tt_xy_pair(1, 7));
 }
 
 TEST(
@@ -364,5 +573,65 @@ TEST(
     uint32_t num_workers = 4;
     auto num_iterations = worker_slice.compute_num_worker_slice_iterations(num_workers);
     auto expected = 2;
+    ASSERT_EQ(num_iterations, expected);
+}
+// Wrapped version
+TEST(
+    Ccl_InterleavedTensorWorkerSlice_ComputeNumWrappedWorkerSliceIterations,
+    InnerOffset_0_0__InnerShape_24_1__OuterShape_32_4__NumActiveSlices_4) {
+    auto worker_slice = ttnn::ccl::InterleavedTensorWorkerSlice(
+        tt_xy_pair(99999, 99999),  // tensor shape shouldn't affect the result
+        tt_xy_pair(32, 4),
+        tt_xy_pair(24, 1),
+        tt_xy_pair(0, 0),
+        true);
+    uint32_t num_workers = 4;
+    auto num_iterations = worker_slice.compute_num_worker_slice_iterations(num_workers);
+    auto expected = 2;
+    ASSERT_EQ(num_iterations, expected);
+}
+
+TEST(
+    Ccl_InterleavedTensorWorkerSlice_ComputeNumWrappedWorkerSliceIterations,
+    InnerOffset_24_0__InnerShape_24_1__OuterShape_32_4__NumActiveSlices_4) {
+    auto worker_slice = ttnn::ccl::InterleavedTensorWorkerSlice(
+        tt_xy_pair(99999, 99999),  // tensor shape shouldn't affect the result
+        tt_xy_pair(32, 4),
+        tt_xy_pair(24, 1),
+        tt_xy_pair(24, 0),
+        true);
+    uint32_t num_workers = 4;
+    auto num_iterations = worker_slice.compute_num_worker_slice_iterations(num_workers);
+    auto expected = 2;
+    ASSERT_EQ(num_iterations, expected);
+}
+
+TEST(
+    Ccl_InterleavedTensorWorkerSlice_ComputeNumWrappedWorkerSliceIterations,
+    InnerOffset_16_1__InnerShape_24_1__OuterShape_32_4__NumActiveSlices_4) {
+    auto worker_slice = ttnn::ccl::InterleavedTensorWorkerSlice(
+        tt_xy_pair(99999, 99999),  // tensor shape shouldn't affect the result
+        tt_xy_pair(32, 4),
+        tt_xy_pair(24, 1),
+        tt_xy_pair(16, 1),
+        true); // Updated
+    uint32_t num_workers = 4;
+    auto num_iterations = worker_slice.compute_num_worker_slice_iterations(num_workers);
+    auto expected = 1; // Updated
+    ASSERT_EQ(num_iterations, expected);
+}
+
+TEST(
+    Ccl_InterleavedTensorWorkerSlice_ComputeNumWrappedWorkerSliceIterations,
+    InnerOffset_8_2__InnerShape_24_1__OuterShape_32_4__NumActiveSlices_4) {
+    auto worker_slice = ttnn::ccl::InterleavedTensorWorkerSlice(
+        tt_xy_pair(99999, 99999),  // tensor shape shouldn't affect the result
+        tt_xy_pair(32, 4),
+        tt_xy_pair(24, 1),
+        tt_xy_pair(8, 2),
+        true);
+    uint32_t num_workers = 4;
+    auto num_iterations = worker_slice.compute_num_worker_slice_iterations(num_workers);
+    auto expected = 1;
     ASSERT_EQ(num_iterations, expected);
 }

--- a/tests/ttnn/unit_tests/operations/test_reduce_scatter_post_commit.py
+++ b/tests/ttnn/unit_tests/operations/test_reduce_scatter_post_commit.py
@@ -108,7 +108,7 @@ def run_reduce_scatter_test(
             logger.error(f"output mismatch for tensor {i}")
         else:
             logger.info(f"output match for tensor {i}")
-        assert not mismatch, f"{i} FAILED: {output}"
+    assert not mismatch, f"{i} FAILED: {output}"
 
 
 # ~2:45 extra time in the current state
@@ -123,6 +123,7 @@ def run_reduce_scatter_test(
 @pytest.mark.parametrize(
     "per_chip_output_shape, scatter_dim, layout",
     [
+        ([1, 2, 256, 32 * 8], 3, ttl.tensor.Layout.TILE),  # Input tensor is (16*32) x (64*32) = 8 * input tensor shape
         ([1, 1, 32, 32 * 8], 3, ttl.tensor.Layout.TILE),
         ([1, 8, 1024, 1024], 3, ttl.tensor.Layout.TILE),
         ([1, 4, 2048, 1024], 3, ttl.tensor.Layout.TILE),

--- a/ttnn/cpp/ttnn/operations/ccl/all_gather/device/kernels/dataflow/worker_ring_gather_utils.hpp
+++ b/ttnn/cpp/ttnn/operations/ccl/all_gather/device/kernels/dataflow/worker_ring_gather_utils.hpp
@@ -622,3 +622,96 @@ FORCE_INLINE void write_chunk_v2(
     noc_async_write_barrier();
     cb_pop_front(cb_id, num_pages);
 }
+
+template <typename AddrGen>
+FORCE_INLINE void read_wrapped_chunk_from_output_tensor(
+    uint32_t& curr_page_idx,
+    uint32_t& offset_into_worker_slice,
+     ttnn::ccl::coord_t& offset_worker_slice,
+    const  ttnn::ccl::coord_t& worker_slice_shape,
+
+    // In tiles for tile layout
+    const  ttnn::ccl::coord_t& tensor_shape,
+    const  ttnn::ccl::coord_t& tensor_slice_shape,
+    const uint32_t cb_id,
+    const AddrGen& s,
+    const uint32_t num_pages,
+    const uint32_t page_size,
+    bool& last_page_of_worker) {
+
+    // we expected caller to reset this and the last curr_page_idx when we set it true
+    ASSERT(last_page_of_worker == false);
+    cb_reserve_back(cb_id, num_pages);
+    uint32_t local_l1_read_addr = get_write_ptr(cb_id);
+    for (uint32_t i = 0; i < num_pages; ++i) {
+#ifdef RM_INTERLEAVED
+        uint64_t src_noc_addr = get_noc_addr(curr_page_idx, s);
+        noc_async_read(src_noc_addr, local_l1_read_addr, page_size);
+        ASSERT(false);  // unimplemented
+
+#elif defined TILE_INTERLEAVED
+
+        noc_async_read_tile(curr_page_idx, s, local_l1_read_addr);
+        // common with `write_chunk_v2`
+
+        // Update the curr_page_idx based on how the worker chunks + tensor slice is laid out in global tensor
+        advance_worker_global_page_interleaved(
+            curr_page_idx, // Updated internally
+            offset_into_worker_slice,
+            offset_worker_slice,
+            worker_slice_shape,
+            tensor_slice_shape,
+            tensor_shape,
+            last_page_of_worker
+        );
+
+#endif
+        local_l1_read_addr += page_size;
+    }
+    noc_async_read_barrier();
+    cb_push_back(cb_id, num_pages);
+}
+
+template <typename AddrGen>
+FORCE_INLINE void write_wrapped_chunk(
+    uint32_t& curr_page_idx,
+    uint32_t& offset_into_worker_slice,
+     ttnn::ccl::coord_t& offset_worker_slice,
+    const  ttnn::ccl::coord_t& worker_slice_shape,
+
+    // In tiles for tile layout
+    const  ttnn::ccl::coord_t& tensor_shape,
+    const  ttnn::ccl::coord_t& tensor_slice_shape,
+    uint32_t cb_id,
+    const AddrGen& d,
+    const uint32_t num_pages,
+    const uint32_t page_size,
+    bool& last_page_of_worker) {
+
+    cb_wait_front(cb_id, num_pages);
+    uint32_t l1_read_addr = get_read_ptr(cb_id);
+    for (uint32_t i = 0; i < num_pages; ++i) {
+#ifdef RM_INTERLEAVED
+        uint64_t dst_noc_addr = get_noc_addr(curr_page_idx, d);
+        noc_async_write(l1_read_addr, dst_noc_addr, page_size);
+        ASSERT(false);  // unimplemented
+#elif defined TILE_INTERLEAVED
+        noc_async_write_tile(curr_page_idx, d, l1_read_addr);
+        // Common with `read_chunk_from_output_tensor_v2`
+
+        // Update the curr_page_idx based on how the worker chunks + tensor slice is laid out in global tensor
+        advance_worker_global_page_interleaved(
+            curr_page_idx, // Updated internally
+            offset_into_worker_slice,
+            offset_worker_slice,
+            worker_slice_shape,
+            tensor_slice_shape,
+            tensor_shape,
+            last_page_of_worker
+        );
+#endif
+        l1_read_addr += page_size;
+    }
+    noc_async_write_barrier();
+    cb_pop_front(cb_id, num_pages);
+}

--- a/ttnn/cpp/ttnn/operations/ccl/ccl_common.cpp
+++ b/ttnn/cpp/ttnn/operations/ccl/ccl_common.cpp
@@ -5,6 +5,7 @@
 #include "ccl_common.hpp"
 
 #include <cstdint>
+#include <cmath>
 
 #include "ccl_host_datastructures.hpp"
 
@@ -139,7 +140,8 @@ ccl::EriscDatamoverBuilder create_erisc_datamover_builder(
         termination_mode);
 }
 
-RingReduceScatterTensorSlicer::RingReduceScatterTensorSlicer(
+template <class DERIVED_SLICER_T>
+RingReduceScatterBaseTensorSlicer<DERIVED_SLICER_T>::RingReduceScatterBaseTensorSlicer(
     Tensor const& input_tensor,
     Tensor const& output_tensor,
     int slice_dim,
@@ -199,7 +201,7 @@ RingReduceScatterTensorSlicer::RingReduceScatterTensorSlicer(
     } else {
         log_trace(tt::LogOp, "\tmax_slice_size_in_bytes={}", max_slice_size_in_bytes);
         log_trace(tt::LogOp, "\tinput_page_size={}", input_page_size);
-        this->worker_slice_shapes = create_worker_slice_shapes_for_tile_layout(
+        this->worker_slice_shapes = DERIVED_SLICER_T::create_worker_slice_shapes_for_tile_layout(
             input_tensor.get_legacy_shape(),
             this->tensor_slice_shape,
             total_num_workers,
@@ -219,14 +221,35 @@ RingReduceScatterTensorSlicer::RingReduceScatterTensorSlicer(
                 input_tensor.get_legacy_shape()[2]) /
                tt::constants::TILE_HEIGHT};
     }
-    this->worker_slice_offsets = compute_worker_slice_offsets(this->worker_slice_shapes, this->tensor_slice_shape);
+
+    this->worker_slice_offsets = DERIVED_SLICER_T::compute_worker_slice_offsets(this->worker_slice_shapes, this->tensor_slice_shape);
     TT_ASSERT(this->worker_slice_offsets.size() == this->worker_slice_shapes.size());
 }
 
-uint32_t RingReduceScatterTensorSlicer::get_worker_slice_size_bytes(int worker_index) {
-    auto worker_slice_shape = this->worker_slice_shapes.at(worker_index);
-    return worker_slice_shape.x * worker_slice_shape.y * this->input_page_size;
-}
+RingReduceScatterTensorSlicer::RingReduceScatterTensorSlicer(
+    Tensor const& input_tensor,
+    Tensor const& output_tensor,
+    int slice_dim,
+    uint32_t ring_index,
+    uint32_t ring_size,
+    uint32_t total_num_workers,
+    uint32_t max_slice_size_in_bytes,
+    uint32_t half_cb_n_pages):
+        RingReduceScatterBaseTensorSlicer<RingReduceScatterTensorSlicer>
+            (input_tensor, output_tensor, slice_dim, ring_index, ring_size, total_num_workers, max_slice_size_in_bytes, half_cb_n_pages) {};
+
+
+RingReduceScatterWrappedTensorSlicer::RingReduceScatterWrappedTensorSlicer(
+    Tensor const& input_tensor,
+    Tensor const& output_tensor,
+    int slice_dim,
+    uint32_t ring_index,
+    uint32_t ring_size,
+    uint32_t total_num_workers,
+    uint32_t max_slice_size_in_bytes,
+    uint32_t half_cb_n_pages):
+        RingReduceScatterBaseTensorSlicer<RingReduceScatterWrappedTensorSlicer>
+            (input_tensor, output_tensor, slice_dim, ring_index, ring_size, total_num_workers, max_slice_size_in_bytes, half_cb_n_pages) {};
 
 std::vector<tt_xy_pair> RingReduceScatterTensorSlicer::compute_worker_slice_offsets(
     std::vector<tt_xy_pair> const& worker_slice_shapes, tt_xy_pair const& tensor_slice_shape) {
@@ -257,7 +280,32 @@ std::vector<tt_xy_pair> RingReduceScatterTensorSlicer::compute_worker_slice_offs
     return worker_slice_offsets;
 }
 
-std::vector<tt_xy_pair> RingReduceScatterTensorSlicer::create_worker_slice_shapes_for_row_major_layout(
+std::vector<tt_xy_pair> RingReduceScatterWrappedTensorSlicer::compute_worker_slice_offsets(
+    std::vector<tt_xy_pair> const& worker_slice_shapes, tt_xy_pair const& tensor_slice_shape) {
+    std::vector<tt_xy_pair> worker_slice_offsets;
+    worker_slice_offsets.reserve(worker_slice_shapes.size());
+
+    std::uint32_t flattened_idx = 0;
+
+    for (tt_xy_pair const& worker_slice_shape : worker_slice_shapes) {
+
+        // Convert from flat to (x, y) coordinates
+        std::size_t offset_x = flattened_idx % tensor_slice_shape.x;
+        std::size_t offset_y = flattened_idx / tensor_slice_shape.x;
+
+        // Append the offset to the list
+        worker_slice_offsets.emplace_back(offset_x, offset_y);
+
+        // Update the flattened index
+        flattened_idx += worker_slice_shape.x * worker_slice_shape.y;
+    }
+
+    TT_ASSERT(worker_slice_offsets.size() == worker_slice_shapes.size());
+    return worker_slice_offsets;
+}
+
+template <class DERIVED_SLICER_T>
+std::vector<tt_xy_pair> RingReduceScatterBaseTensorSlicer<DERIVED_SLICER_T>::create_worker_slice_shapes_for_row_major_layout(
     tt_xy_pair const& tensor_slice_shape_in_elems, uint32_t num_workers, uint32_t max_slice_size_in_elements) {
     std::vector<tt_xy_pair> worker_slice_shapes;
     worker_slice_shapes.reserve(num_workers);
@@ -508,6 +556,57 @@ std::vector<tt_xy_pair> RingReduceScatterTensorSlicer::create_worker_slice_shape
         [max_slice_size_in_pages](tt_xy_pair const& worker_slice_shape) {
             TT_ASSERT(worker_slice_shape.x * worker_slice_shape.y <= max_slice_size_in_pages);
         });
+    return worker_slice_shapes;
+}
+
+std::vector<tt_xy_pair> RingReduceScatterWrappedTensorSlicer::create_worker_slice_shapes_for_tile_layout(
+        tt::tt_metal::Shape const& tensor_shape,
+        tt_xy_pair const& tensor_slice_shape_in_tiles,
+        uint32_t num_workers,
+        uint32_t max_slice_size_in_pages,
+        uint32_t half_cb_n_pages)
+{
+    log_trace(tt::LogOp, "\tmax_slice_size_in_pages={}", max_slice_size_in_pages);
+    TT_ASSERT(max_slice_size_in_pages > 0);
+    std::vector<tt_xy_pair> worker_slice_shapes;
+    worker_slice_shapes.reserve(num_workers);
+    const uint32_t total_num_tiles = tensor_slice_shape_in_tiles.x * tensor_slice_shape_in_tiles.y;
+    if (num_workers > total_num_tiles) {
+        log_warning(
+            tt::LogOp,
+            "Reduce Scatter more workers instantiated than is work to be done. Some workers will be idle and do "
+            "nothing");
+        num_workers = total_num_tiles;
+        for (uint32_t w = 0; w < num_workers; ++w) {
+            worker_slice_shapes.emplace_back(1, 1);
+        }
+        for (uint32_t w = num_workers; w < total_num_tiles; ++w) {
+            worker_slice_shapes.emplace_back(0, 0);
+        }
+        return worker_slice_shapes;
+    }
+
+    std::size_t max_slice_size_in_tiles = max_slice_size_in_pages;
+
+    // Assign slices by assuming that the input tensor is flattened into a 1D Shape
+    std::size_t optim_worker_slice_len_tiles = ceil(total_num_tiles / num_workers); // Ceil so that the remainder worker will have a smaller slice
+
+    if (max_slice_size_in_tiles < optim_worker_slice_len_tiles) { // Each worker will have a full slice
+        for (uint32_t w = 0; w < num_workers; ++w) {
+            worker_slice_shapes.emplace_back(max_slice_size_in_tiles, 1);
+        }
+    } else { // Each worker will only have one slice
+        uint32_t remainder_worker_len_tiles = total_num_tiles % optim_worker_slice_len_tiles;
+
+        for (uint32_t w = 0; w < num_workers; ++w) {
+            worker_slice_shapes.emplace_back(optim_worker_slice_len_tiles, 1);
+        }
+        // If there is a remainder worker, we need to adjust the last worker's slice shape to be smaller
+        if (remainder_worker_len_tiles > 0) {
+            worker_slice_shapes.back() = tt_xy_pair{remainder_worker_len_tiles, 1};
+        }
+    }
+
     return worker_slice_shapes;
 }
 

--- a/ttnn/cpp/ttnn/operations/ccl/ccl_common.cpp
+++ b/ttnn/cpp/ttnn/operations/ccl/ccl_common.cpp
@@ -152,6 +152,7 @@ RingReduceScatterBaseTensorSlicer<DERIVED_SLICER_T>::RingReduceScatterBaseTensor
     uint32_t half_cb_n_pages) :
     LegacyCclTensorSlicer() {
     TT_ASSERT(max_slice_size_in_bytes > 0);
+    TT_ASSERT(input_tensor.get_legacy_shape().size() == 4);
     this->row_major = input_tensor.get_layout() == Layout::ROW_MAJOR;
     this->slice_dim_is_width = input_tensor.get_legacy_shape().rank() - 1 == slice_dim;
     this->is_sharded = input_tensor.is_sharded();

--- a/ttnn/cpp/ttnn/operations/ccl/reduce_scatter/device/host/reduce_scatter_full_worker_grid.cpp
+++ b/ttnn/cpp/ttnn/operations/ccl/reduce_scatter/device/host/reduce_scatter_full_worker_grid.cpp
@@ -319,8 +319,8 @@ struct EdmInterfaceAddresses {
 // For now - the mapping between workers and EDM channels is 1:1
 static void add_worker_config_to_edm_builders(
     Device* device,
-    ttnn::ccl::RingReduceScatterTensorSlicer& tensor_slicer,  // TODO: Update to Generic ReduceScatterSlicer when it is implemented
-    ttnn::ccl::CCLOpConfig const& op_config,
+    RingReduceScatterWrappedTensorSlicer& tensor_slicer,  // TODO: Update to Generic ReduceScatterSlicer when it is implemented
+    ccl::CCLOpConfig const& op_config,
     std::vector<CoreCoord> const& worker_cores,
     uint32_t num_channels_per_edm,
 
@@ -528,8 +528,8 @@ static CoreRangeSet select_worker_cores(
 }
 
 static WorkerTransferInfo compute_num_edm_messages_per_channel(
-   ttnn::ccl::CCLOpConfig const& op_config,
-    ttnn::ccl::RingReduceScatterTensorSlicer& tensor_slicer,  // TODO: Update to Generic ReduceScatterSlicer when it is implemented
+    ccl::CCLOpConfig const& op_config,
+    RingReduceScatterWrappedTensorSlicer& tensor_slicer,  // TODO: Update to Generic ReduceScatterSlicer when it is implemented
     std::vector<ttnn::ccl::EriscDatamoverBuilder> const& cw_per_link_edm_builders,
     std::vector<ttnn::ccl::EriscDatamoverBuilder> const& ccw_per_link_edm_builders,
     std::size_t const num_edm_channels,
@@ -754,7 +754,7 @@ operation::ProgramWithCallbacks reduce_scatter_with_workers(
         cb_num_pages,
         cw_per_link_edm_builders.at(0).get_eth_buffer_size_bytes(),
         op_config.get_page_size());
-    auto tensor_slicer =ttnn::ccl::RingReduceScatterTensorSlicer(
+    auto tensor_slicer = ttnn::ccl::RingReduceScatterWrappedTensorSlicer(
         local_chip_tensor,
         local_chip_output_tensor,
         scatter_split_dim,

--- a/ttnn/cpp/ttnn/operations/ccl/reduce_scatter/device/kernels/worker_interleaved_ring_reduce_scatter_reader.cpp
+++ b/ttnn/cpp/ttnn/operations/ccl/reduce_scatter/device/kernels/worker_interleaved_ring_reduce_scatter_reader.cpp
@@ -220,6 +220,8 @@ void kernel_main() {
     uint32_t total_cb_pages_pushed = 0;
     uint32_t total_cb_pages_pushed_to_math = 0;
 
+
+
     // For the first timestep, there is no other input to reduce with, so we just send it straight to the input CB
     // of the output data movement kernel - short-circuiting past the (reducer) math kernel
     // For tile => shape in tiles
@@ -234,7 +236,7 @@ void kernel_main() {
             width_sliced ? args.tensor_slice_shape.x * start_ring_index
                          : args.tensor_slice_shape.y * start_ring_index * args.input_tensor_shape.x;
 
-        auto const& next_slice_offset = advance_slice_row_major(
+        auto const& next_slice_offset = advance_wrapped_slice_row_major(
             args.worker_slice_offset, args.worker_slice_shape, args.tensor_slice_shape, args.num_concurrent_workers);
         bool last_slice_of_worker = next_slice_offset.x >= args.tensor_slice_shape.x ||
                                     next_slice_offset.y >= args.tensor_slice_shape.y;
@@ -244,26 +246,24 @@ void kernel_main() {
         const uint32_t starting_tile_id = curr_ring_slice_start_page_offset + worker_relative_start_offset_into_slice;
         uint32_t curr_tile_id = starting_tile_id;
 
-        coord_t valid_worker_slice_shape = coord_t(
-            std::min(args.worker_slice_shape.x, args.tensor_slice_shape.x - args.worker_slice_offset.x),
-            std::min(args.worker_slice_shape.y, args.tensor_slice_shape.y - args.worker_slice_offset.y));
-
         bool last_page_of_worker = false;
-        uint32_t const worker_slice_n_pages = valid_worker_slice_shape.x * valid_worker_slice_shape.y;
+        uint32_t const worker_slice_n_pages = args.worker_slice_shape.x * args.worker_slice_shape.y;
         ASSERT(
             (args.num_transfers - 1) * worker_slice_n_pages + total_cb_pages_pushed_to_math <=
             args.total_eltwise_kernel_num_pages);
         {
-            coord_t offset_into_worker_slice = {0, 0};
+            uint32_t offset_into_worker_slice = 0;
             for (uint32_t p = 0; p < worker_slice_n_pages; p += args.full_chunk_num_pages) {
                 uint32_t n_pages = std::min(args.full_chunk_num_pages, worker_slice_n_pages - p);
                 ASSERT(!last_page_of_worker);
-                read_chunk_from_output_tensor_v2(
+                read_wrapped_chunk_from_output_tensor(
                     curr_tile_id,
                     offset_into_worker_slice,
-                    valid_worker_slice_shape,
+                    args.worker_slice_offset, // Offset into tensor slice
+                    args.worker_slice_shape,
                     // In tiles for tile layout
                     args.input_tensor_shape,
+                    args.tensor_slice_shape,
                     to_dm_sender_short_circuit_cb,
                     args.s,
                     n_pages,
@@ -282,7 +282,7 @@ void kernel_main() {
 
         for (uint32_t i = 1; i < args.num_transfers; ++i) {
             bool last_transfer = i == args.num_transfers - 1;
-            coord_t offset_into_worker_slice = {0, 0};
+            uint32_t offset_into_worker_slice = 0;
             std::tie(args.my_ring_idx, curr_ring_slice_start_page_offset) = advance_to_next_transfer_slice<is_sharded>(
                 args.ring_size,
                 args.my_ring_idx,
@@ -298,12 +298,14 @@ void kernel_main() {
                 uint32_t n_pages = std::min(args.full_chunk_num_pages, worker_slice_n_pages - p);
                 ASSERT(n_pages > 0);
                 // Fetch from input tensor
-                read_chunk_from_output_tensor_v2(
+                read_wrapped_chunk_from_output_tensor(
                     curr_tile_id,
                     offset_into_worker_slice,
-                    valid_worker_slice_shape,
+                    args.worker_slice_offset, // Offset into tensor slice
+                    args.worker_slice_shape,
                     // In tiles for tile layout
                     args.input_tensor_shape,
+                    args.tensor_slice_shape,
                     cb_id_in1,
                     args.s,
                     n_pages,

--- a/ttnn/cpp/ttnn/operations/ccl/reduce_scatter/device/kernels/worker_interleaved_ring_reduce_scatter_sender.cpp
+++ b/ttnn/cpp/ttnn/operations/ccl/reduce_scatter/device/kernels/worker_interleaved_ring_reduce_scatter_sender.cpp
@@ -64,10 +64,8 @@ void kernel_main() {
     uint32_t total_lifetime_cb_pages_popped_from_math = 0;
     while (worker_slice_base_offset.x < output_tensor_shape.x && worker_slice_base_offset.y < output_tensor_shape.y) {
         // First phase - we only forward messages to EDM
-        coord_t valid_worker_slice_shape = coord_t(
-            std::min(worker_slice_shape.x, output_tensor_shape.x - worker_slice_base_offset.x),
-            std::min(worker_slice_shape.y, output_tensor_shape.y - worker_slice_base_offset.y));
-        uint32_t const num_pages_to_write = valid_worker_slice_shape.x * valid_worker_slice_shape.y;
+
+        uint32_t const num_pages_to_write = worker_slice_shape.x * worker_slice_shape.y;
 
         ASSERT(total_lifetime_cb_pages_popped_from_math + num_pages_to_write <= total_eltwise_kernel_num_pages);
         for (uint32_t i = 0; i < num_transfers; ++i) {
@@ -101,10 +99,11 @@ void kernel_main() {
         uint32_t curr_ring_slice_start_page_offset = 0;
         const uint32_t worker_relative_start_offset_into_slice =
             worker_slice_base_offset.x + (worker_slice_base_offset.y * output_tensor_shape.x);
-        auto current_worker_slice_offset = worker_slice_base_offset;
+
         const uint32_t starting_tile_id = curr_ring_slice_start_page_offset + worker_relative_start_offset_into_slice;
         uint32_t curr_tile_id = starting_tile_id;
 
+        uint32_t offset_into_worker_slice = 0;
         bool last_page_of_worker = false;
         for (uint32_t p = 0; p < num_pages_to_write; p += full_chunk_num_pages) {
             ASSERT(curr_tile_id < output_tensor_shape.x * output_tensor_shape.y);
@@ -112,11 +111,13 @@ void kernel_main() {
             uint32_t n_pages = std::min(full_chunk_num_pages, num_pages_to_write - p);
             ASSERT(n_pages <= half_cb_n_pages);
             ASSERT(full_chunk_num_pages <= half_cb_n_pages);
-            write_chunk_v2(
+            write_wrapped_chunk(
                 curr_tile_id,
-                current_worker_slice_offset,
-                valid_worker_slice_shape,
+                offset_into_worker_slice,
+                worker_slice_base_offset, // Offset into tensor slice
+                worker_slice_shape,
                 output_tensor_shape,  // In tiles for tile layout
+                output_tensor_shape,
                 cb_id_in0,
                 d,
                 n_pages,
@@ -131,7 +132,7 @@ void kernel_main() {
             }
         }
 
-        worker_slice_base_offset = advance_slice_row_major(
+        worker_slice_base_offset = advance_wrapped_slice_row_major(
             worker_slice_base_offset, worker_slice_shape, output_tensor_shape, num_concurrent_workers);
     }
 


### PR DESCRIPTION
### Ticket
- #10272

### Problem description
Currently, the RingReduceScatterTensorSlicer::create_worker_slice_shapes_for_tile_layout uses a specific slicing/chunking scheme where chunks cannot wrap around the end of the tensor width.

### What's changed
The proposed changes view the input tensor as a flattened object, thereby chunking in a linear fashion.

- New `RingReduceScatterBaseTensorSlicer`, which `RingReduceScatterTensorSlicer` and `RingReduceScatterWrappedTensorSlicer` inherit and have separate implementations for:
  - create_worker_slice_shapes_for_tile_layout
  - compute_worker_slice_offsets
- New `advance_wrapped_slice_row_major`
- New `read_wrapped_chunk_from_output_tensor` and `write_wrapped_chunk`
- Updated `test_ccl_helpers.cpp` with new unit tests/refactoring old ones

Device Perf for reduce scatter post commit tests:
![image](https://github.com/user-attachments/assets/b82a8ca1-7036-45e1-8e22-114a1bc65982)


### Checklist
- [x] Post commit CI passes
- [x] Model regression CI testing passes (if applicable)
- [x] New/Existing tests provide coverage for changes
