### PR TITLE
Fix/re-enable a few watcher tests

### DIFF
--- a/tests/tt_metal/tt_metal/test_kernels/misc/watcher_pause.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/misc/watcher_pause.cpp
@@ -16,6 +16,9 @@ namespace NAMESPACE {
 void MAIN {
 #endif
     uint32_t wait_cycles = get_arg_val<uint32_t>(0);
+#if defined(COMPILE_FOR_IDLE_ERISC)
+    wait_cycles = 0x5f5e1000U;
+#endif
 
     // Do a wait followed by a pause, triscs can't wait.
 #ifndef COMPILE_FOR_TRISC

--- a/tests/tt_metal/tt_metal/test_kernels/misc/watcher_waypoints.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/misc/watcher_waypoints.cpp
@@ -4,6 +4,7 @@
 
 #include <cstdint>
 #include "debug/status.h"
+#include "debug/ring_buffer.h"
 
 // Helper function to sync execution by forcing other riscs to wait for brisc, which in turn waits
 // for a set number of cycles.
@@ -32,6 +33,10 @@ void MAIN {
 #endif
     uint32_t sync_wait_cycles = get_arg_val<uint32_t>(0);
     uint32_t sync_address     = get_arg_val<uint32_t>(1);
+    WATCHER_RING_BUFFER_PUSH(sync_wait_cycles);
+#if defined(COMPILE_FOR_IDLE_ERISC)
+    sync_wait_cycles = 0x5f5e1000U;
+#endif
 
     // Post a new waypoint with a delay after (to let the watcher poll it)
     hacky_sync(1, sync_wait_cycles, sync_address);

--- a/tests/tt_metal/tt_metal/unit_tests_common/watcher/test_pause.cpp
+++ b/tests/tt_metal/tt_metal/unit_tests_common/watcher/test_pause.cpp
@@ -127,10 +127,6 @@ static void RunTest(WatcherFixture* fixture, Device* device) {
 }
 
 TEST_F(WatcherFixture, TestWatcherPause) {
-    if (this->IsSlowDispatch()) {
-        log_info(tt::LogTest, "Skip, see #9993");
-        GTEST_SKIP();
-    }
     for (Device* device : this->devices_) {
         this->RunTestOnDevice(RunTest, device);
     }

--- a/tests/tt_metal/tt_metal/unit_tests_common/watcher/test_ringbuf.cpp
+++ b/tests/tt_metal/tt_metal/unit_tests_common/watcher/test_ringbuf.cpp
@@ -192,10 +192,6 @@ TEST_F(WatcherFixture, TestWatcherRingBufferIErisc) {
         log_info(tt::LogTest, "Skip due to #7771");
         GTEST_SKIP();
     }
-    if (this->IsSlowDispatch()) {
-        log_info(tt::LogTest, "Skip, see #9993");
-        GTEST_SKIP();
-    }
     for (Device* device : this->devices_) {
         this->RunTestOnDevice(
             [](WatcherFixture *fixture, Device *device){RunTest(fixture, device, DebugIErisc);},

--- a/tests/tt_metal/tt_metal/unit_tests_common/watcher/test_waypoint.cpp
+++ b/tests/tt_metal/tt_metal/unit_tests_common/watcher/test_waypoint.cpp
@@ -144,7 +144,7 @@ static void RunTest(WatcherFixture* fixture, Device* device) {
                     k_id_s = "";
                 }
                 expected = fmt::format(
-                    "Device {} ethnet core(x={:2},y={:2}) phys(x={:2},y={:2}): {},   X,   X,   X,   X  k_id:{}",
+                    "Device {} ethnet core(x={:2},y={:2}) phys(x={:2},y={:2}): {},   X,   X,   X,   X  rmsg:* k_id:{}",
                     device->id(), logical_core.x, logical_core.y, phys_core.x, phys_core.y,
                     waypoint,
                     k_id_s
@@ -196,7 +196,7 @@ static void RunTest(WatcherFixture* fixture, Device* device) {
     }
 }
 
-TEST_F(WatcherFixture, DISABLED_TestWatcherWaypoints) {
+TEST_F(WatcherFixture, TestWatcherWaypoints) {
     for (Device* device : this->devices_) {
         this->RunTestOnDevice(RunTest, device);
     }

--- a/tests/tt_metal/tt_metal/unit_tests_common/watcher/test_waypoint.cpp
+++ b/tests/tt_metal/tt_metal/unit_tests_common/watcher/test_waypoint.cpp
@@ -81,11 +81,6 @@ static void RunTest(WatcherFixture* fixture, Device* device) {
     // TODO: revert this when #7771 is fixed.
     if (!fixture->IsSlowDispatch())
         has_idle_eth_cores = false;
-    // TODO: revert this when #6860 is fixed.
-    if (fixture->NumDevices() > 2) {// T3000
-        has_eth_cores = false;
-        has_idle_eth_cores = false;
-    }
     if (has_eth_cores) {
         KernelHandle erisc_kid;
         std::set<CoreRange> eth_core_ranges;

--- a/tt_metal/impl/device/device.cpp
+++ b/tt_metal/impl/device/device.cpp
@@ -406,13 +406,6 @@ void Device::initialize_and_launch_firmware() {
         }
     }
 
-    // Clear idle erisc mailbox
-    for (const auto &eth_core : this->get_inactive_ethernet_cores()) {
-        CoreCoord physical_core = this->ethernet_core_from_logical_core(eth_core);
-        std::vector<uint32_t> zero_vec_mailbox(128 / sizeof(uint32_t), 0);
-        llrt::write_hex_vec_to_core(this->id(), physical_core, zero_vec_mailbox, MEM_IERISC_MAILBOX_BASE);
-    }
-
     // Clear erisc sync info
     std::vector<uint32_t> zero_vec_erisc_init(eth_l1_mem::address_map::ERISC_APP_SYNC_INFO_SIZE / sizeof(uint32_t), 0);
     for (const auto &eth_core : this->get_active_ethernet_cores()) {


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/9566
Also appears to fix (or these tests were previously fixed, or I can't reproduce): https://github.com/tenstorrent/tt-metal/issues/9993 If I just couldn't repro on local + 10 CI runs and this is still around we can disable again.



### Problem description
A few watcher tests were failing, specifically issues on IERISC.

### What's changed
A couple issues were layered on top of each other:

1. A strange merge conflict resulted in the mailbox being cleared for idle eth cores - not required anymore and it was being done improperly. This caused bad watcher behaviour since part of the watcher buffers were being cleared after init.
2. Some expected outputs needed updating after I added RMSG display to eth cores.
3. I'm still seeing the issue we saw earlier with runtime args being incorrect on idle eth cores, workaround for these tests is to hard-code the arg in the kernel for ierisc and the tests themselves appear fine. @pgkeller I can repro the issue every time on my machine, but i recall you weren't able to? I think it's probably better tracked as a separate runtime issue. I checked with Allan and he thinks these are the only tests that use runtime args on idle eth cores.

Also re-enabled a test from a long-fixed issue in the second commit, seems to run fine: https://github.com/tenstorrent/tt-metal/actions/runs/10000503412

### Checklist
- [X] Post commit CI passes - ran each test a few hundred times locally and it seems fine, 10 CI runs and everything looks fine so far: https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml?query=branch%3Adma%2Fwatcher_tests_reenable
- [X] Model regression CI testing passes (if applicable) - N/A
- [X] New/Existing tests provide coverage for changes - N/A
