### PR TITLE
#9628: Remove std::function for BW Binary ops

### DIFF
--- a/ttnn/cpp/ttnn/operations/eltwise/binary_backward/binary_backward.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_backward/binary_backward.hpp
@@ -208,12 +208,12 @@ struct ExecuteBinaryBackward {
 //OpHandler_binary_bw : get_function_binary_bw_type1
 constexpr auto atan2_bw = ttnn::register_operation<operations::binary_backward::ExecuteBinaryBackwardType1<operations::binary_backward::BinaryBackwardOpType::ATAN2_BW>>("ttnn::atan2_bw");
 constexpr auto rsub_bw = ttnn::register_operation<operations::binary_backward::ExecuteBinaryBackwardType1<operations::binary_backward::BinaryBackwardOpType::RSUB_BW>>("ttnn::rsub_bw");
+constexpr auto embedding_bw = ttnn::register_operation<operations::binary_backward::ExecuteBinaryBackwardType1<operations::binary_backward::BinaryBackwardOpType::EMBEDDING_BW>>("ttnn::embedding_bw");
 
 //OpHandler_binary_bw_opt_float_default : get_function_binary_bw_type1_opt_float_default
 constexpr auto addalpha_bw = ttnn::register_operation<operations::binary_backward::ExecuteBinaryBackwardOptionalFloatDefault<operations::binary_backward::BinaryBackwardOpType::ADDALPHA_BW>>("ttnn::addalpha_bw");
 
 //type 1
-constexpr auto embedding_bw = ttnn::register_operation<operations::binary_backward::ExecuteBinaryBackward<operations::binary_backward::BinaryBackwardOpType::EMBEDDING_BW>>("ttnn::embedding_bw");
 constexpr auto subalpha_bw = ttnn::register_operation<operations::binary_backward::ExecuteBinaryBackward<operations::binary_backward::BinaryBackwardOpType::SUBALPHA_BW>>("ttnn::subalpha_bw");
 constexpr auto xlogy_bw = ttnn::register_operation<operations::binary_backward::ExecuteBinaryBackward<operations::binary_backward::BinaryBackwardOpType::XLOGY_BW>>("ttnn::xlogy_bw");
 constexpr auto hypot_bw = ttnn::register_operation<operations::binary_backward::ExecuteBinaryBackward<operations::binary_backward::BinaryBackwardOpType::HYPOT_BW>>("ttnn::hypot_bw");

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_backward/binary_backward.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_backward/binary_backward.hpp
@@ -207,6 +207,7 @@ struct ExecuteBinaryBackward {
 
 //OpHandler_binary_bw : get_function_binary_bw_type1
 constexpr auto atan2_bw = ttnn::register_operation<operations::binary_backward::ExecuteBinaryBackwardType1<operations::binary_backward::BinaryBackwardOpType::ATAN2_BW>>("ttnn::atan2_bw");
+constexpr auto rsub_bw = ttnn::register_operation<operations::binary_backward::ExecuteBinaryBackwardType1<operations::binary_backward::BinaryBackwardOpType::RSUB_BW>>("ttnn::rsub_bw");
 
 //OpHandler_binary_bw_opt_float_default : get_function_binary_bw_type1_opt_float_default
 constexpr auto addalpha_bw = ttnn::register_operation<operations::binary_backward::ExecuteBinaryBackwardOptionalFloatDefault<operations::binary_backward::BinaryBackwardOpType::ADDALPHA_BW>>("ttnn::addalpha_bw");
@@ -221,7 +222,6 @@ constexpr auto logaddexp_bw = ttnn::register_operation<operations::binary_backwa
 constexpr auto logaddexp2_bw = ttnn::register_operation<operations::binary_backward::ExecuteBinaryBackward<operations::binary_backward::BinaryBackwardOpType::LOGADDEXP2_BW>>("ttnn::logaddexp2_bw");
 constexpr auto squared_difference_bw = ttnn::register_operation<operations::binary_backward::ExecuteBinaryBackward<operations::binary_backward::BinaryBackwardOpType::SQUARED_DIFFERENCE_BW>>("ttnn::squared_difference_bw");
 constexpr auto concat_bw = ttnn::register_operation<operations::binary_backward::ExecuteBinaryBackward<operations::binary_backward::BinaryBackwardOpType::CONCAT_BW>>("ttnn::concat_bw");
-constexpr auto rsub_bw = ttnn::register_operation<operations::binary_backward::ExecuteBinaryBackward<operations::binary_backward::BinaryBackwardOpType::RSUB_BW>>("ttnn::rsub_bw");
 constexpr auto min_bw = ttnn::register_operation<operations::binary_backward::ExecuteBinaryBackward<operations::binary_backward::BinaryBackwardOpType::MIN_BW>>("ttnn::min_bw");
 constexpr auto max_bw = ttnn::register_operation<operations::binary_backward::ExecuteBinaryBackward<operations::binary_backward::BinaryBackwardOpType::MAX_BW>>("ttnn::max_bw");
 constexpr auto lerp_bw = ttnn::register_operation<operations::binary_backward::ExecuteBinaryBackward<operations::binary_backward::BinaryBackwardOpType::LERP_BW>>("ttnn::lerp_bw");

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_backward/binary_backward.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_backward/binary_backward.hpp
@@ -13,6 +13,29 @@ namespace ttnn {
 
 namespace operations::binary_backward {
 
+//OpHandler_binary_bw : get_function_binary_bw_type1
+template <BinaryBackwardOpType binary_backward_op_type>
+struct ExecuteBinaryBackwardType1 {
+
+    static inline std::vector<ttnn::Tensor> create_async_output_tensors(
+        const std::vector<Tensor> &input_tensors, const std::vector<std::optional<const Tensor>>& optional_inputs) {
+        const auto& input_tensor = input_tensors.at(0);
+        return {Tensor(operation::get_workers_for_op_output({input_tensor})),
+                                            Tensor(operation::get_workers_for_op_output({input_tensor}))};
+    }
+
+    //Type 1: 1 inputs, 1 grad tensor, 1 float, 1 default string
+    static std::vector<Tensor> execute_on_main_thread(
+        const Tensor &grad_tensor_arg,
+        const Tensor &input_tensor_a_arg,
+        const Tensor &input_tensor_b_arg,
+        const std::optional<MemoryConfig> &memory_config = std::nullopt) {
+        auto op_type = get_function_binary_bw_type1<binary_backward_op_type>();
+        auto output_memory_config = memory_config.value_or(input_tensor_a_arg.memory_config());
+        return op_type(grad_tensor_arg, input_tensor_a_arg, input_tensor_b_arg, output_memory_config);
+        }
+};
+
 template <BinaryBackwardOpType binary_backward_op_type>
 struct ExecuteBinaryBackward {
     static inline std::vector<ttnn::Tensor> create_async_output_tensors(
@@ -138,8 +161,10 @@ struct ExecuteBinaryBackward {
 
 }  // operations::binary
 
+//OpHandler_binary_bw : get_function_binary_bw_type1
+constexpr auto atan2_bw = ttnn::register_operation<operations::binary_backward::ExecuteBinaryBackwardType1<operations::binary_backward::BinaryBackwardOpType::ATAN2_BW>>("ttnn::atan2_bw");
+
 //type 1
-constexpr auto atan2_bw = ttnn::register_operation<operations::binary_backward::ExecuteBinaryBackward<operations::binary_backward::BinaryBackwardOpType::ATAN2_BW>>("ttnn::atan2_bw");
 constexpr auto embedding_bw = ttnn::register_operation<operations::binary_backward::ExecuteBinaryBackward<operations::binary_backward::BinaryBackwardOpType::EMBEDDING_BW>>("ttnn::embedding_bw");
 constexpr auto subalpha_bw = ttnn::register_operation<operations::binary_backward::ExecuteBinaryBackward<operations::binary_backward::BinaryBackwardOpType::SUBALPHA_BW>>("ttnn::subalpha_bw");
 constexpr auto xlogy_bw = ttnn::register_operation<operations::binary_backward::ExecuteBinaryBackward<operations::binary_backward::BinaryBackwardOpType::XLOGY_BW>>("ttnn::xlogy_bw");

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_backward/binary_backward.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_backward/binary_backward.hpp
@@ -36,6 +36,50 @@ struct ExecuteBinaryBackwardType1 {
         }
 };
 
+//OpHandler_binary_bw_opt_float_default : get_function_binary_bw_type1_opt_float_default
+template <BinaryBackwardOpType unary_backward_op_type>
+struct ExecuteBinaryBackwardOptionalFloatDefault {
+
+    static inline std::vector<ttnn::Tensor> create_async_output_tensors(
+        const std::vector<Tensor> &input_tensors, const std::vector<std::optional<const Tensor>>& optional_inputs) {
+        const auto& input_tensor = input_tensors.at(0);
+        return {Tensor(operation::get_workers_for_op_output({input_tensor})),
+                                            Tensor(operation::get_workers_for_op_output({input_tensor}))};
+    }
+
+    static std::vector<std::optional<Tensor>> execute_on_main_thread(
+        uint8_t queue_id,
+        const Tensor &grad_tensor_arg,
+        const Tensor &input_tensor_a_arg,
+        const Tensor &input_tensor_b_arg,
+        float parameter,
+        const std::optional<MemoryConfig> &memory_config = std::nullopt,
+        const std::vector<bool>& are_required_outputs = std::vector<bool>{true, true},
+        std::optional<Tensor> input_a_grad = std::nullopt,
+        std::optional<Tensor> input_b_grad = std::nullopt) {
+
+        auto output_memory_config = memory_config.value_or(input_tensor_a_arg.memory_config());
+        auto op_type = get_function_binary_bw_type1_opt_float_default<unary_backward_op_type>();
+        return op_type(queue_id, grad_tensor_arg, input_tensor_a_arg, input_tensor_b_arg, parameter, output_memory_config, are_required_outputs, input_a_grad, input_b_grad);
+    }
+
+    static std::vector<std::optional<Tensor>> execute_on_main_thread(
+        const Tensor &grad_tensor_arg,
+        const Tensor &input_tensor_a_arg,
+        const Tensor &input_tensor_b_arg,
+        float parameter,
+        const std::optional<MemoryConfig> &memory_config = std::nullopt,
+        const std::vector<bool>& are_required_outputs = std::vector<bool>{true, true},
+        std::optional<Tensor> input_a_grad = std::nullopt,
+        std::optional<Tensor> input_b_grad = std::nullopt) {
+
+        auto output_memory_config = memory_config.value_or(input_tensor_a_arg.memory_config());
+        auto op_type = get_function_binary_bw_type1_opt_float_default<unary_backward_op_type>();
+        return op_type(DefaultQueueId, grad_tensor_arg, input_tensor_a_arg, input_tensor_b_arg, parameter, output_memory_config, are_required_outputs, input_a_grad, input_b_grad);
+    }
+
+};
+
 template <BinaryBackwardOpType binary_backward_op_type>
 struct ExecuteBinaryBackward {
     static inline std::vector<ttnn::Tensor> create_async_output_tensors(
@@ -164,6 +208,9 @@ struct ExecuteBinaryBackward {
 //OpHandler_binary_bw : get_function_binary_bw_type1
 constexpr auto atan2_bw = ttnn::register_operation<operations::binary_backward::ExecuteBinaryBackwardType1<operations::binary_backward::BinaryBackwardOpType::ATAN2_BW>>("ttnn::atan2_bw");
 
+//OpHandler_binary_bw_opt_float_default : get_function_binary_bw_type1_opt_float_default
+constexpr auto addalpha_bw = ttnn::register_operation<operations::binary_backward::ExecuteBinaryBackwardOptionalFloatDefault<operations::binary_backward::BinaryBackwardOpType::ADDALPHA_BW>>("ttnn::addalpha_bw");
+
 //type 1
 constexpr auto embedding_bw = ttnn::register_operation<operations::binary_backward::ExecuteBinaryBackward<operations::binary_backward::BinaryBackwardOpType::EMBEDDING_BW>>("ttnn::embedding_bw");
 constexpr auto subalpha_bw = ttnn::register_operation<operations::binary_backward::ExecuteBinaryBackward<operations::binary_backward::BinaryBackwardOpType::SUBALPHA_BW>>("ttnn::subalpha_bw");
@@ -180,6 +227,5 @@ constexpr auto max_bw = ttnn::register_operation<operations::binary_backward::Ex
 constexpr auto lerp_bw = ttnn::register_operation<operations::binary_backward::ExecuteBinaryBackward<operations::binary_backward::BinaryBackwardOpType::LERP_BW>>("ttnn::lerp_bw");
 
 //type 2
-constexpr auto addalpha_bw = ttnn::register_operation<operations::binary_backward::ExecuteBinaryBackward<operations::binary_backward::BinaryBackwardOpType::ADDALPHA_BW>>("ttnn::addalpha_bw");
 
 }  // namespace ttnn

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_backward/binary_backward_pybind.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_backward/binary_backward_pybind.hpp
@@ -326,7 +326,7 @@ void py_module(py::module& module) {
         ttnn::atan2_bw,
         R"doc(Performs backward operations for atan2 of :attr:`input_tensor_a` and :attr:`input_tensor_b` with given :attr:`grad_tensor`.)doc");
 
-    detail::bind_binary_backward(
+    detail::bind_binary_backward_type_1(
         module,
         ttnn::embedding_bw,
         R"doc(Performs backward operations for embedding_bw function and it returns specific indices of the embedding table specified by the :attr:`grad_tensor`.

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_backward/binary_backward_pybind.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_backward/binary_backward_pybind.hpp
@@ -67,6 +67,67 @@ Example:
             py::arg("memory_config") = std::nullopt});
 }
 
+//OpHandler_binary_bw_opt_float_default : get_function_binary_bw_type1_opt_float_default
+template <typename binary_backward_operation_t>
+void bind_binary_backward_opt_float_default(py::module& module, const binary_backward_operation_t& operation, const std::string& parameter_name, const std::string& parameter_doc, float parameter_value, const std::string& description) {
+    auto doc = fmt::format(
+        R"doc({0}(grad_tensor: ttnn.Tensor, input_tensor_a: ttnn.Tensor, input_tensor_b: ttnn.Tensor, {2}: float, *, memory_config: ttnn.MemoryConfig) -> std::vector<Tensor>
+
+        {5}
+
+        Args:
+            * :attr:`grad_tensor`
+            * :attr:`input_tensor_a`
+            * :attr:`input_tensor_b`
+            * :attr:`{3}` (float):Default value = {4}
+
+        Keyword args:
+            * :attr:`memory_config` (Optional[ttnn.MemoryConfig]): memory config for the output tensor
+
+        Example:
+
+            >>> grad_tensor = ttnn.to_device(ttnn.from_torch(torch.tensor((1, 2), dtype=torch.bfloat16)), device)
+            >>> tensor1 = ttnn.to_device(ttnn.from_torch(torch.tensor((1, 2), dtype=torch.bfloat16)), device)
+            >>> tensor2 = ttnn.to_device(ttnn.from_torch(torch.tensor((0, 1), dtype=torch.bfloat16)), device)
+            >>> output = {1}(grad_tensor, tensor1, tensor2, float)
+        )doc",
+        operation.base_name(),
+        operation.python_fully_qualified_name(),
+        parameter_name,
+        parameter_doc,
+        parameter_value,
+        description);
+
+
+    bind_registered_operation(
+        module,
+        operation,
+        doc,
+        ttnn::pybind_overload_t{
+            [](const binary_backward_operation_t& self,
+               const ttnn::Tensor& grad_tensor,
+               const ttnn::Tensor& input_tensor_a,
+               const ttnn::Tensor& input_tensor_b,
+               float parameter,
+               const std::optional<ttnn::MemoryConfig>& memory_config,
+               const std::vector<bool>& are_required_outputs,
+               const std::optional<ttnn::Tensor>& input_a_grad,
+               const std::optional<ttnn::Tensor>& input_b_grad,
+               const uint8_t& queue_id) -> std::vector<optional<ttnn::Tensor>> {
+                return self(queue_id, grad_tensor, input_tensor_a, input_tensor_b, parameter, memory_config, are_required_outputs, input_a_grad, input_b_grad);
+            },
+            py::arg("grad_tensor"),
+            py::arg("input_tensor_a"),
+            py::arg("input_tensor_b"),
+            py::arg(parameter_name.c_str()) = parameter_value,
+            py::kw_only(),
+            py::arg("memory_config") = std::nullopt,
+            py::arg("are_required_outputs") = std::vector<bool>{true, true},
+            py::arg("input_a_grad") = std::nullopt,
+            py::arg("input_b_grad") = std::nullopt,
+            py::arg("queue_id") = 0}
+    );
+}
 
 template <typename binary_backward_operation_t>
 void bind_binary_backward(py::module& module, const binary_backward_operation_t& operation, const std::string& description) {
@@ -276,9 +337,10 @@ void py_module(py::module& module) {
         ttnn::subalpha_bw,
         R"doc(Performs backward operations for subalpha of :attr:`input_tensor_a` and :attr:`input_tensor_b` with given :attr:`grad_tensor`.)doc");
 
-    detail::bind_binary_backward(
+    detail::bind_binary_backward_opt_float_default(
         module,
         ttnn::addalpha_bw,
+        "alpha", "Alpha value", 1.0f,
         R"doc(Performs backward operations for addalpha on :attr:`input_tensor_b` , attr:`input_tensor_a`, attr:`alpha` with given attr:`grad_tensor`.)doc");
 
     detail::bind_binary_backward(

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_backward/binary_backward_pybind.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_backward/binary_backward_pybind.hpp
@@ -383,7 +383,7 @@ void py_module(py::module& module) {
         ttnn::concat_bw,
         R"doc(Performs backward operations for concat on :attr:`input_tensor_a` and :attr:`input_tensor_b` with given attr:`grad_tensor`.)doc");
 
-    detail::bind_binary_backward(
+    detail::bind_binary_backward_type_1(
         module,
         ttnn::rsub_bw,
         R"doc(Performs backward operations for subraction of :attr:`input_tensor_a` from :attr:`input_tensor_b` with given attr:`grad_tensor` (reversed order of subtraction operator).)doc");

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_backward/device/binary_backward_op.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_backward/device/binary_backward_op.cpp
@@ -69,7 +69,7 @@ std::vector<std::optional<ttnn::Tensor>> _addalpha_bw(
     const Tensor& input,
     const Tensor& other,
     float alpha,
-    const MemoryConfig& output_mem_config,
+    const std::optional<MemoryConfig>& output_mem_config,
     const std::vector<bool>& are_required_outputs,
     std::optional<Tensor> input_grad,
     std::optional<Tensor> other_grad) {
@@ -98,38 +98,6 @@ std::vector<std::optional<ttnn::Tensor>> _addalpha_bw(
 
     return std::move(result);
 
-}
-
-std::vector<ttnn::Tensor> _addalpha_bw_inter(
-    const Tensor& grad, const Tensor& input, const Tensor& other, float alpha, const MemoryConfig& output_mem_config) {
-
-    auto result = _addalpha_bw(0, grad, input, other, alpha, output_mem_config, {true, true}, std::nullopt, std::nullopt);
-
-    std::vector<ttnn::Tensor> output_tensors;
-    output_tensors.reserve(result.size());
-
-    for (const auto& opt_tensor : result) {
-        if (opt_tensor) {
-            output_tensors.emplace_back(*opt_tensor);
-        } else {
-            output_tensors.emplace_back();
-        }
-    }
-    return output_tensors;
-}
-
-
-std::vector<std::optional<Tensor>> _addalpha_bw_overload(
-    const Tensor& grad,
-    const Tensor& input,
-    const Tensor& other,
-    float alpha,
-    const MemoryConfig& output_mem_config,
-    const std::vector<bool>& are_required_outputs,
-    std::optional<Tensor> input_grad,
-    std::optional<Tensor> other_grad) {
-        uint8_t default_queue_id = 0;
-    return _addalpha_bw(default_queue_id, grad, input, other, alpha, output_mem_config, are_required_outputs, input_grad, other_grad);
 }
 
 std::vector<ttnn::Tensor> _subalpha_bw(
@@ -674,8 +642,6 @@ std::function<std::vector<Tensor>(const Tensor&, const Tensor&, const Tensor&, f
     switch (OpType) {
         case BinaryBackwardOpType::SUBALPHA_BW:
             return _subalpha_bw;
-        case BinaryBackwardOpType::ADDALPHA_BW:
-            return _addalpha_bw_inter;
         case BinaryBackwardOpType::CONCAT_BW:
             return _concat_bw;
         case BinaryBackwardOpType::LERP_BW:
@@ -700,8 +666,6 @@ std::function<std::vector<ttnn::Tensor>(const Tensor&, const Tensor&, const Tens
 
 std::function<std::vector<std::optional<ttnn::Tensor>>(uint8_t , const Tensor&, const Tensor&, const Tensor&, float, const MemoryConfig&, const std::vector<bool>&, std::optional<Tensor>, std::optional<Tensor>)> BinaryBackwardFunction::get_function_type2(BinaryBackwardOpType OpType){
     switch (OpType) {
-        case BinaryBackwardOpType::ADDALPHA_BW:
-            return _addalpha_bw;
         default:
             TT_ASSERT(false && "Undefined op type");
             return 0;
@@ -710,8 +674,6 @@ std::function<std::vector<std::optional<ttnn::Tensor>>(uint8_t , const Tensor&, 
 
 std::function<std::vector<std::optional<ttnn::Tensor>>(const Tensor&, const Tensor&, const Tensor&, float, const MemoryConfig&, const std::vector<bool>&, std::optional<Tensor>, std::optional<Tensor>)> BinaryBackwardFunction::get_function_type2_wo_qid(BinaryBackwardOpType OpType){
     switch (OpType) {
-        case BinaryBackwardOpType::ADDALPHA_BW:
-            return _addalpha_bw_overload;
         default:
             TT_ASSERT(false && "Undefined op type");
             return 0;

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_backward/device/binary_backward_op.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_backward/device/binary_backward_op.cpp
@@ -23,8 +23,9 @@
 namespace ttnn::operations::binary_backward {
 
 std::vector<ttnn::Tensor> _atan2_bw(
-    const Tensor& grad, const Tensor& input, const Tensor& other, const MemoryConfig& output_mem_config) {
+    const Tensor& grad, const Tensor& input, const Tensor& other, const std::optional<MemoryConfig>& output_mem_config) {
     std::vector<Tensor> grad_tensor;
+    auto output_memory_config = output_mem_config.value_or(input.memory_config()); //TODO: Remove after ternary forward ops migration is completed
     float t_nan = std::nanf("");
     using ttnn::operations::unary::UnaryWithParam;
     using ttnn::operations::unary::UnaryOpType;
@@ -32,13 +33,13 @@ std::vector<ttnn::Tensor> _atan2_bw(
     UnaryWithParam {UnaryOpType::SQUARE},
     UnaryWithParam {UnaryOpType::RECIP}};
     Tensor recip_mul =
-        ttnn::multiply(grad, ttnn::unary_chain(hypot(input, other), ops_chain, output_mem_config), std::nullopt, output_mem_config);
-    Tensor grad_a = ttnn::multiply(other, recip_mul, std::nullopt, output_mem_config);
-    Tensor cond = ttnn::logical_and(ttnn::eqz(input, output_mem_config), ttnn::eqz(other, output_mem_config));
-    grad_a = where(cond, t_nan, grad_a, output_mem_config);
+        ttnn::multiply(grad, ttnn::unary_chain(hypot(input, other), ops_chain, output_memory_config), std::nullopt, output_memory_config);
+    Tensor grad_a = ttnn::multiply(other, recip_mul, std::nullopt, output_memory_config);
+    Tensor cond = ttnn::logical_and(ttnn::eqz(input, output_memory_config), ttnn::eqz(other, output_memory_config));
+    grad_a = where(cond, t_nan, grad_a, output_memory_config);
     grad_tensor.emplace_back(grad_a);
-    Tensor grad_b = ttnn::multiply(ttnn::neg(input), recip_mul, std::nullopt, output_mem_config);
-    grad_b = where(cond, t_nan, grad_b, output_mem_config);
+    Tensor grad_b = ttnn::multiply(ttnn::neg(input), recip_mul, std::nullopt, output_memory_config);
+    grad_b = where(cond, t_nan, grad_b, output_memory_config);
     recip_mul.deallocate();
     cond.deallocate();
     grad_tensor.emplace_back(grad_b);
@@ -623,8 +624,6 @@ std::vector<std::optional<Tensor>> _mul_bw_overload(
 
 std::function<std::vector<ttnn::Tensor>(const Tensor&, const Tensor&, const Tensor&, const MemoryConfig&)> BinaryBackwardFunction::get_function_type1(BinaryBackwardOpType OpType){
     switch (OpType) {
-        case BinaryBackwardOpType::ATAN2_BW:
-            return _atan2_bw;
         case BinaryBackwardOpType::EMBEDDING_BW:
             return _embedding_bw;
         case BinaryBackwardOpType::SUB_BW:

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_backward/device/binary_backward_op.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_backward/device/binary_backward_op.cpp
@@ -48,7 +48,7 @@ std::vector<ttnn::Tensor> _atan2_bw(
 
 
 std::vector<ttnn::Tensor> _embedding_bw(
-    const Tensor& grad, const Tensor& input, const Tensor& weight, const MemoryConfig& output_mem_config) {
+    const Tensor& grad, const Tensor& input, const Tensor& weight, const std::optional<MemoryConfig>& output_mem_config) {
     TT_FATAL(input.get_dtype() == DataType::UINT32, "Input must be UINT32");
     TT_FATAL(
         grad.get_legacy_shape()[0] == 1 && grad.get_legacy_shape()[1] == 1,

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_backward/device/binary_backward_op.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_backward/device/binary_backward_op.cpp
@@ -382,8 +382,8 @@ std::vector<Tensor> _binary_comp_bw(const Tensor& grad, const Tensor& input, con
     return grad_tensor;
 }
 
-std::vector<Tensor> _rsub_bw( const Tensor& grad, const Tensor& input, const Tensor& other, const MemoryConfig& output_mem_config) {
-    std::vector<Tensor> grad_tensor = _subalpha_bw(grad, input, other, 1.0f, output_mem_config);
+std::vector<Tensor> _rsub_bw( const Tensor& grad, const Tensor& input, const Tensor& other, const std::optional<MemoryConfig>& output_mem_config) {
+    std::vector<Tensor> grad_tensor = ttnn::operations::binary_backward::_subalpha_bw(grad, input, other, 1.0f, output_mem_config.value_or(input.memory_config()));
     std::swap(grad_tensor[0], grad_tensor[1]);
     return grad_tensor;
 }
@@ -616,8 +616,6 @@ std::function<std::vector<ttnn::Tensor>(const Tensor&, const Tensor&, const Tens
             return _assign_bw;
         case BinaryBackwardOpType::LE_BW:
             return _le_bw;
-        case BinaryBackwardOpType::RSUB_BW:
-            return _rsub_bw;
         case BinaryBackwardOpType::GT_BW:
             return _gt_bw;
         case BinaryBackwardOpType::LT_BW:

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_backward/device/binary_backward_op.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_backward/device/binary_backward_op.hpp
@@ -55,6 +55,7 @@ static std::function<std::vector<std::optional<ttnn::Tensor>>(const Tensor&, con
 //OpHandler_binary_bw : get_function_binary_bw_type1
 std::vector<Tensor> _atan2_bw( const Tensor& grad, const Tensor& input, const Tensor& other, const std::optional<MemoryConfig>& output_mem_config);
 std::vector<Tensor> _rsub_bw( const Tensor& grad, const Tensor& input, const Tensor& other, const std::optional<MemoryConfig>& output_mem_config);
+std::vector<Tensor> _embedding_bw( const Tensor& grad, const Tensor& input, const Tensor& other, const std::optional<MemoryConfig>& output_mem_config);
 
 //OpHandler_binary_bw_opt_float_default : get_function_binary_bw_type1_opt_float_default
 std::vector<std::optional<ttnn::Tensor>> _addalpha_bw( uint8_t queue_id, const Tensor& grad, const Tensor& input, const Tensor& other, float alpha = 1.0f, const std::optional<MemoryConfig>& output_mem_config = std::nullopt, const std::vector<bool>& are_required_outputs = std::vector<bool>{true, true}, std::optional<Tensor> input_grad = std::nullopt, std::optional<Tensor> other_grad = std::nullopt);
@@ -84,6 +85,13 @@ template <>
 struct OpHandler_binary_bw_opt_float_default<BinaryBackwardOpType::ADDALPHA_BW> {
     static std::vector<std::optional<ttnn::Tensor>> handle( uint8_t queue_id, const Tensor& grad, const Tensor& input, const Tensor& other, float alpha, const MemoryConfig& output_mem_config, const std::vector<bool>& are_required_outputs, std::optional<Tensor> input_grad, std::optional<Tensor> other_grad ) {
         return _addalpha_bw( queue_id, grad, input, other, alpha, output_mem_config, are_required_outputs, input_grad, other_grad);
+    }
+};
+
+template <>
+struct OpHandler_binary_bw<BinaryBackwardOpType::EMBEDDING_BW> {
+    static std::vector<Tensor> handle( const Tensor& grad, const Tensor& input, const Tensor& other, const std::optional<MemoryConfig>& output_mem_config ) {
+        return _embedding_bw(grad, input, other, output_mem_config);
     }
 };
 

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_backward/device/binary_backward_op.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_backward/device/binary_backward_op.hpp
@@ -55,9 +55,15 @@ static std::function<std::vector<std::optional<ttnn::Tensor>>(const Tensor&, con
 //OpHandler_binary_bw : get_function_binary_bw_type1
 std::vector<Tensor> _atan2_bw( const Tensor& grad, const Tensor& input, const Tensor& other, const std::optional<MemoryConfig>& output_mem_config);
 
+//OpHandler_binary_bw_opt_float_default : get_function_binary_bw_type1_opt_float_default
+std::vector<std::optional<ttnn::Tensor>> _addalpha_bw( uint8_t queue_id, const Tensor& grad, const Tensor& input, const Tensor& other, float alpha = 1.0f, const std::optional<MemoryConfig>& output_mem_config = std::nullopt, const std::vector<bool>& are_required_outputs = std::vector<bool>{true, true}, std::optional<Tensor> input_grad = std::nullopt, std::optional<Tensor> other_grad = std::nullopt);
+
 // OpHandler struct template
 template <BinaryBackwardOpType OpType>
 struct OpHandler_binary_bw;
+
+template <BinaryBackwardOpType OpType>
+struct OpHandler_binary_bw_opt_float_default;
 
 template <>
 struct OpHandler_binary_bw<BinaryBackwardOpType::ATAN2_BW> {
@@ -66,10 +72,22 @@ struct OpHandler_binary_bw<BinaryBackwardOpType::ATAN2_BW> {
     }
 };
 
+template <>
+struct OpHandler_binary_bw_opt_float_default<BinaryBackwardOpType::ADDALPHA_BW> {
+    static std::vector<std::optional<ttnn::Tensor>> handle( uint8_t queue_id, const Tensor& grad, const Tensor& input, const Tensor& other, float alpha, const MemoryConfig& output_mem_config, const std::vector<bool>& are_required_outputs, std::optional<Tensor> input_grad, std::optional<Tensor> other_grad ) {
+        return _addalpha_bw( queue_id, grad, input, other, alpha, output_mem_config, are_required_outputs, input_grad, other_grad);
+    }
+};
+
 // Template functions to get the function pointers
 template <BinaryBackwardOpType OpType>
 auto get_function_binary_bw_type1() {
     return &OpHandler_binary_bw<OpType>::handle;
+}
+
+template <BinaryBackwardOpType OpType>
+auto get_function_binary_bw_type1_opt_float_default() {
+    return &OpHandler_binary_bw_opt_float_default<OpType>::handle;
 }
 
 }  // namespace ttnn::operations::binary_backward

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_backward/device/binary_backward_op.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_backward/device/binary_backward_op.hpp
@@ -43,7 +43,7 @@ enum class BinaryBackwardOpType {
     MUL_BW,
 };
 struct BinaryBackwardFunction{
-static std::function<std::vector<ttnn::Tensor>(const Tensor&, const Tensor&, const Tensor&, const MemoryConfig&)> get_function_type1(BinaryBackwardOpType OpType);
+static std::function<std::vector<ttnn::Tensor>(const Tensor&, const Tensor&, const Tensor&, const MemoryConfig&)> get_function_type1(BinaryBackwardOpType OpType); //get_function_binary_bw_type1
 static std::function<std::vector<ttnn::Tensor>(const Tensor&, const Tensor&, const Tensor&, float, const MemoryConfig&)> get_function_type1_w_float(BinaryBackwardOpType OpType);
 static std::function<std::vector<ttnn::Tensor>(const Tensor&, const Tensor&, const Tensor&, std::string, const MemoryConfig&)> get_function_type1_w_string(BinaryBackwardOpType OpType);
 static std::function<std::vector<std::optional<ttnn::Tensor>>(uint8_t , const Tensor&, const Tensor&, const Tensor&, float, const MemoryConfig&, const std::vector<bool>&, std::optional<Tensor>, std::optional<Tensor>)> get_function_type2(BinaryBackwardOpType OpType);
@@ -51,4 +51,25 @@ static std::function<std::vector<std::optional<ttnn::Tensor>>(const Tensor&, con
 static std::function<std::vector<std::optional<ttnn::Tensor>>(uint8_t , const Tensor&, const Tensor&, const Tensor&, const MemoryConfig&, const std::vector<bool>&, std::optional<Tensor>, std::optional<Tensor>)> get_function_type3(BinaryBackwardOpType OpType);
 static std::function<std::vector<std::optional<ttnn::Tensor>>(const Tensor&, const Tensor&, const Tensor&, const MemoryConfig&, const std::vector<bool>&, std::optional<Tensor>, std::optional<Tensor>)> get_function_type3_wo_qid(BinaryBackwardOpType OpType);
 };
+
+//OpHandler_binary_bw : get_function_binary_bw_type1
+std::vector<Tensor> _atan2_bw( const Tensor& grad, const Tensor& input, const Tensor& other, const std::optional<MemoryConfig>& output_mem_config);
+
+// OpHandler struct template
+template <BinaryBackwardOpType OpType>
+struct OpHandler_binary_bw;
+
+template <>
+struct OpHandler_binary_bw<BinaryBackwardOpType::ATAN2_BW> {
+    static std::vector<Tensor> handle( const Tensor& grad, const Tensor& input, const Tensor& other, const std::optional<MemoryConfig>& output_mem_config ) {
+        return _atan2_bw(grad, input, other, output_mem_config);
+    }
+};
+
+// Template functions to get the function pointers
+template <BinaryBackwardOpType OpType>
+auto get_function_binary_bw_type1() {
+    return &OpHandler_binary_bw<OpType>::handle;
+}
+
 }  // namespace ttnn::operations::binary_backward

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_backward/device/binary_backward_op.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_backward/device/binary_backward_op.hpp
@@ -54,6 +54,7 @@ static std::function<std::vector<std::optional<ttnn::Tensor>>(const Tensor&, con
 
 //OpHandler_binary_bw : get_function_binary_bw_type1
 std::vector<Tensor> _atan2_bw( const Tensor& grad, const Tensor& input, const Tensor& other, const std::optional<MemoryConfig>& output_mem_config);
+std::vector<Tensor> _rsub_bw( const Tensor& grad, const Tensor& input, const Tensor& other, const std::optional<MemoryConfig>& output_mem_config);
 
 //OpHandler_binary_bw_opt_float_default : get_function_binary_bw_type1_opt_float_default
 std::vector<std::optional<ttnn::Tensor>> _addalpha_bw( uint8_t queue_id, const Tensor& grad, const Tensor& input, const Tensor& other, float alpha = 1.0f, const std::optional<MemoryConfig>& output_mem_config = std::nullopt, const std::vector<bool>& are_required_outputs = std::vector<bool>{true, true}, std::optional<Tensor> input_grad = std::nullopt, std::optional<Tensor> other_grad = std::nullopt);
@@ -69,6 +70,13 @@ template <>
 struct OpHandler_binary_bw<BinaryBackwardOpType::ATAN2_BW> {
     static std::vector<Tensor> handle( const Tensor& grad, const Tensor& input, const Tensor& other, const std::optional<MemoryConfig>& output_mem_config ) {
         return _atan2_bw(grad, input, other, output_mem_config);
+    }
+};
+
+template <>
+struct OpHandler_binary_bw<BinaryBackwardOpType::RSUB_BW> {
+    static std::vector<Tensor> handle( const Tensor& grad, const Tensor& input, const Tensor& other, const std::optional<MemoryConfig>& output_mem_config ) {
+        return _rsub_bw(grad, input, other, output_mem_config);
     }
 };
 

--- a/ttnn/cpp/ttnn/operations/eltwise/unary_backward/unary_backward_pybind.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary_backward/unary_backward_pybind.hpp
@@ -192,7 +192,7 @@ void bind_unary_backward_float_string_default(py::module& module, const unary_ba
         Args:
             * :attr:`grad_tensor`
             * :attr:`input_tensor_a` or :attr:`input_tensor`
-            * :attr:`input_tensor_b` or:attr:`{2}` (float): {3}
+            * :attr:`input_tensor_b` or :attr:`{2}` (float): {3}
 
         Keyword args:
             * :attr:`{4}` (string): {5} , Default value = {6}


### PR DESCRIPTION
Remove std::function for

- atan2_bw
- addalpha_bw
- rsub_bw
- emebedding_bw

https://github.com/tenstorrent/tt-metal/actions/runs/10018306876 - passed