### PR TITLE
#9817: Add row reshuffling LLK

### DIFF
--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_reshuffle_rows.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_reshuffle_rows.h
@@ -1,0 +1,24 @@
+// SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include "ckernel.h"
+#include "ckernel_defs.h"
+#include "noc_nonblocking_api.h"
+#include "ckernel_sfpu_reshuffle_rows.h"
+
+using namespace sfpi;
+
+namespace ckernel {
+namespace sfpu {
+
+template <bool APPROXIMATION_MODE, int ITERATIONS = 8>
+inline void calculate_reshuffle_rows(uint idx_addr)
+{
+    _calculate_reshuffle_rows_<APPROXIMATION_MODE, ITERATIONS>(idx_addr);
+}
+
+}  // namespace sfpu
+}  // namespace ckernel

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_reshuffle_rows.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_reshuffle_rows.h
@@ -1,0 +1,29 @@
+// SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include "llk_math_eltwise_unary_sfpu_init.h"
+#include "llk_math_eltwise_unary_sfpu_params.h"
+#include "ckernel_sfpu_reshuffle_rows.h"
+
+namespace ckernel {
+
+// New LLK SFPU APIs
+
+template <bool APPROXIMATE>
+inline void llk_math_eltwise_unary_sfpu_reshuffle_rows_init() {
+    llk_math_eltwise_unary_sfpu_init<SfpuType::reshuffle_rows, APPROXIMATE>();
+}
+
+template <bool APPROXIMATE>
+inline void llk_math_eltwise_unary_sfpu_reshuffle_rows(uint dst_index, uint32_t idx_addr, int vector_mode = (int)VectorMode::RC_custom) {
+    llk_math_eltwise_unary_sfpu_params<APPROXIMATE>(
+        ckernel::sfpu::calculate_reshuffle_rows<APPROXIMATE>,
+        dst_index,
+        vector_mode,
+        idx_addr);
+}
+
+}

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu_types.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu_types.h
@@ -86,4 +86,5 @@ enum SfpuType {
     fmod,
     ceil,
     unused,
+    reshuffle_rows,
 };

--- a/tt_metal/include/compute_kernel_api.h
+++ b/tt_metal/include/compute_kernel_api.h
@@ -888,4 +888,5 @@ ALWI void unary_lt_tile_init() {
     MATH(( llk_math_eltwise_unary_sfpu_unary_lt_init<APPROX>() ));
 }
 
+
 } // namespace ckernel

--- a/tt_metal/include/compute_kernel_api/cb_api.h
+++ b/tt_metal/include/compute_kernel_api/cb_api.h
@@ -74,7 +74,6 @@ ALWI void cb_pop_front(uint32_t cbid, uint32_t ntiles) {
     UNPACK(( llk_pop_tiles(cbid, ntiles)  ));
 }
 
-
 /**
  * A blocking call that waits for the specified number of tiles to be free in the specified circular buffer. This call
  * is used by the producer to wait for the consumer to consume (ie. free up) the specified number of tiles.
@@ -92,7 +91,6 @@ ALWI void cb_reserve_back(uint32_t cbid, uint32_t ntiles)
 {
     PACK(( llk_wait_for_free_tiles<false,false,false>(cbid,ntiles)  ));
 }
-
 
 /**
  * Pushes a given number of tiles in the back of the specified CB’s queue.
@@ -127,5 +125,43 @@ ALWI void cb_push_back(uint32_t cbid, uint32_t ntiles)
     PACK(( llk_push_tiles<false,false>(cbid, ntiles)  ));
 }
 
+/**
+ * Sends the pointer to the given tile index of the specified CB from the UNPACK
+ * thread to the MATH and PACK threads, using mailbox writes. Also posts UNPACK_OPERAND_SYNC
+ * semaphore for each of these threads.
+ *
+ * Return value: None
+ *
+ * | Argument  | Description                          | Type     | Valid Range                                                                                       | Required |
+ * |-----------|--------------------------------------|----------|---------------------------------------------------------------------------------------------------|----------|
+ * | cb_id     | The index of the cirular buffer (CB) | uint32_t | 0 to 31                                                                                           | True     |
+ * | index     | The tile index within the CB         | uint32_t | It must be less or equal than the size of the CB (the total number of tiles that fit into the CB) | True     |
+ * | p_tile    | The pointer that will be populated   | void*    | N/A                                                                                               | True     |
+ */
+ALWI void cb_get_tile(uint32_t cb_id, uint32_t index, volatile void* p_tile) {
+    UNPACK(llk_unpack_get_tile(cb_id, index, (uint32_t*)p_tile));
+
+    MATH(llk_math_get_tile(cb_id, index, (uint32_t*)p_tile));
+
+    PACK(llk_pack_get_tile(cb_id, index, (uint32_t*)p_tile));
+}
+
+/**
+ * Blocks UNPACK thread on UNPACK_OPERAND_SYNC semaphore being decremented by
+ * MATH and PACK threads.
+ *
+ * Return value: None
+ *
+ * | Argument  | Description                          | Type     | Valid Range                                                                                       | Required |
+ * |-----------|--------------------------------------|----------|---------------------------------------------------------------------------------------------------|----------|
+ * | cb_id     | The index of the cirular buffer (CB) | uint32_t | 0 to 31                                                                                           | True     |
+ */
+ALWI void cb_release_tile(uint32_t cb_id) {
+    UNPACK(llk_unpack_release_tile(cb_id));
+
+    MATH(llk_math_release_tile(cb_id));
+
+    PACK(llk_pack_release_tile(cb_id));
+}
 
 } // namespace ckernel

--- a/tt_metal/include/compute_kernel_api/reshuffle.h
+++ b/tt_metal/include/compute_kernel_api/reshuffle.h
@@ -1,0 +1,43 @@
+// SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include "compute_kernel_api/common_globals.h"
+#ifdef TRISC_MATH
+#include "llk_math_eltwise_unary_sfpu_reshuffle_rows.h"
+#define MAIN math_main()
+#define MATH(x) x
+#else
+#define MATH(x)
+#endif
+
+namespace ckernel {
+
+//row reshuffle
+/**
+ * Reshuffles the rows of the input tile to locations given by indices stored
+ * at L1 address provided in idx_addr. The DST register buffer must be in
+ * acquired state via *acquire_dst* call. This call is blocking and is only
+ * available on the compute engine.
+ *
+ * Return value: None
+ *
+ * | Argument        | Description                                                                | Type     | Valid Range                                           | Required |
+ * |-----------------|----------------------------------------------------------------------------|----------|-------------------------------------------------------|----------|
+ * | idst            | The index of the tile in DST register buffer to perform the computation on | uint32_t | Must be less than the size of the DST register buffer | True     |
+ * | idx_addr        | Address at which array of output row indices is stored                     | uint32_t |                                                       | True     |
+ */
+ALWI void reshuffle_rows_tile(uint32_t idst, uint32_t idx_addr) {
+    MATH(( llk_math_eltwise_unary_sfpu_reshuffle_rows<APPROX>(idst,idx_addr) ));
+}
+
+/**
+ * Please refer to documentation for any_init.
+ */
+ALWI void reshuffle_rows_tile_init() {
+    MATH(( llk_math_eltwise_unary_sfpu_reshuffle_rows_init<APPROX>() ));
+}
+
+} // namespace ckernel


### PR DESCRIPTION
### Ticket
[Link to Github Issue](https://github.com/tenstorrent/tt-metal/issues/9817)

### Problem description
Backwards embedding op requires new reshuffle llk.

### What's changed
Bringing in support for new LLK. There are no tests for this in this PR. The test will be brought in with the implementation of `embedding_bw` op. For reference, there are some tests here: https://github.com/tenstorrent/tt-metal/commits/rd/reshuffle_rows/

### Checklist
- [x] Post commit CI passes: https://github.com/tenstorrent/tt-metal/actions/runs/10045898663
- [ ] Model regression CI testing passes (if applicable)
- [ ] New/Existing tests provide coverage for changes
