### PR TITLE
#0: Mark ttnn::operations::ternary::where as inline to avoid duplicated symbols

### DIFF
--- a/ttnn/cpp/ttnn/operations/ternary.hpp
+++ b/ttnn/cpp/ttnn/operations/ternary.hpp
@@ -14,7 +14,7 @@ namespace operations {
 
 namespace ternary {
 
-Tensor where(
+inline Tensor where(
     const Tensor& predicate,
     const Tensor& true_value,
     const Tensor& false_value,
@@ -28,7 +28,7 @@ Tensor where(
     return ttnn::reshape(output, original_shape);
 }
 
-Tensor where(
+inline Tensor where(
     const Tensor& predicate,
     const float true_value,
     const Tensor& false_value,
@@ -41,7 +41,7 @@ Tensor where(
     return ttnn::reshape(output, original_shape);
 }
 
-Tensor where(
+inline Tensor where(
     const Tensor& predicate,
     const Tensor& true_value,
     const float false_value,
@@ -54,7 +54,7 @@ Tensor where(
     return ttnn::reshape(output, original_shape);
 }
 
-Tensor where(
+inline Tensor where(
     const Tensor& predicate,
     const float true_value,
     const float false_value,


### PR DESCRIPTION
### Ticket
None

### Problem description
The `where` function exists in a header but is not marked either `inline` or `static` causing every translation unit to contain it's symbol (not sure if TTNN suppresses this issue via flags, but it exists for 3rd party projects). And thus linking fails if a project contains 2 `.cpp` files that both includes the file.

### What's changed
`where` is marked as inline to avoid symbol being generated.

### Checklist
- [ ] Post commit CI passes
- [ ] Model regression CI testing passes (if applicable)
- [ ] New/Existing tests provide coverage for changes
