### PR TITLE
#9628: Remove std::function for BW Binary ops

### DIFF
--- a/tests/ttnn/unit_tests/operations/backward/test_backward_addalpha.py
+++ b/tests/ttnn/unit_tests/operations/backward/test_backward_addalpha.py
@@ -39,6 +39,28 @@ def test_bw_addalpha(input_shapes, alpha, device):
         (torch.Size([1, 3, 320, 384])),
     ),
 )
+def test_bw_addalpha_wo_alpha(input_shapes, device):
+    in_data, input_tensor = data_gen_with_range(input_shapes, -100, 100, device, True)
+    other_data, other_tensor = data_gen_with_range(input_shapes, -100, 100, device, True)
+    grad_data, grad_tensor = data_gen_with_range(input_shapes, -100, 100, device)
+
+    tt_output_tensor_on_device = ttnn.addalpha_bw(grad_tensor, input_tensor, other_tensor)
+
+    golden_function = ttnn.get_golden_function(ttnn.addalpha_bw)
+    golden_tensor = golden_function(grad_data, in_data, other_data)
+
+    status = compare_pcc(tt_output_tensor_on_device, golden_tensor)
+    assert status
+
+
+@pytest.mark.parametrize(
+    "input_shapes",
+    (
+        (torch.Size([1, 1, 32, 32])),
+        (torch.Size([1, 1, 320, 384])),
+        (torch.Size([1, 3, 320, 384])),
+    ),
+)
 @pytest.mark.parametrize("alpha", [0.05, 2.0, 1.5, 0.12])
 @pytest.mark.parametrize("are_required_outputs", [[True, True], [True, False], [False, True], [False, False]])
 def test_bw_addalpha_with_opt_output(input_shapes, alpha, device, are_required_outputs):
@@ -65,14 +87,50 @@ def test_bw_addalpha_with_opt_output(input_shapes, alpha, device, are_required_o
         queue_id=cq_id,
     )
 
-    in_data.retain_grad()
-    other_data.retain_grad()
+    golden_function = ttnn.get_golden_function(ttnn.addalpha_bw)
+    golden_tensor = golden_function(grad_data, in_data, other_data, alpha)
 
-    pyt_y = torch.add(in_data, other_data, alpha=alpha)
+    status = True
+    for i in range(len(are_required_outputs)):
+        if are_required_outputs[i]:
+            status = status & compare_pcc([tt_output_tensor_on_device[i]], [golden_tensor[i]])
+    assert status
 
-    pyt_y.backward(gradient=grad_data)
 
-    golden_tensor = [in_data.grad, other_data.grad]
+@pytest.mark.parametrize(
+    "input_shapes",
+    (
+        (torch.Size([1, 1, 32, 32])),
+        (torch.Size([1, 1, 320, 384])),
+        (torch.Size([1, 3, 320, 384])),
+    ),
+)
+@pytest.mark.parametrize("are_required_outputs", [[True, True], [True, False], [False, True], [False, False]])
+def test_bw_addalpha_with_opt_output_wo_alpha(input_shapes, device, are_required_outputs):
+    in_data, input_tensor = data_gen_with_range(input_shapes, -100, 100, device, True)
+    other_data, other_tensor = data_gen_with_range(input_shapes, -90, 100, device, True)
+    grad_data, grad_tensor = data_gen_with_range(input_shapes, -70, 90, device)
+    input_grad = None
+    other_grad = None
+
+    if are_required_outputs[0]:
+        _, input_grad = data_gen_with_range(input_shapes, -1, 1, device)
+    if are_required_outputs[1]:
+        _, other_grad = data_gen_with_range(input_shapes, -1, 1, device)
+
+    cq_id = 0
+    tt_output_tensor_on_device = ttnn.addalpha_bw(
+        grad_tensor,
+        input_tensor,
+        other_tensor,
+        are_required_outputs=are_required_outputs,
+        input_a_grad=input_grad,
+        input_b_grad=other_grad,
+        queue_id=cq_id,
+    )
+
+    golden_function = ttnn.get_golden_function(ttnn.addalpha_bw)
+    golden_tensor = golden_function(grad_data, in_data, other_data)
 
     status = True
     for i in range(len(are_required_outputs)):

--- a/tests/ttnn/unit_tests/operations/backward/test_backward_subalpha.py
+++ b/tests/ttnn/unit_tests/operations/backward/test_backward_subalpha.py
@@ -29,3 +29,25 @@ def test_bw_subalpha(input_shapes, alpha, device):
 
     status = compare_pcc(tt_output_tensor_on_device, golden_tensor)
     assert status
+
+
+@pytest.mark.parametrize(
+    "input_shapes",
+    (
+        (torch.Size([1, 1, 32, 32])),
+        (torch.Size([1, 1, 320, 384])),
+        (torch.Size([1, 3, 320, 384])),
+    ),
+)
+def test_bw_subalpha_default(input_shapes, device):
+    in_data, input_tensor = data_gen_with_range(input_shapes, -100, 100, device, True)
+    other_data, other_tensor = data_gen_with_range(input_shapes, -100, 100, device, True)
+    grad_data, grad_tensor = data_gen_with_range(input_shapes, -100, 100, device)
+
+    tt_output_tensor_on_device = ttnn.subalpha_bw(grad_tensor, input_tensor, other_tensor)
+
+    golden_function = ttnn.get_golden_function(ttnn.subalpha_bw)
+    golden_tensor = golden_function(grad_data, in_data, other_data)
+
+    status = compare_pcc(tt_output_tensor_on_device, golden_tensor)
+    assert status

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_backward/binary_backward.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_backward/binary_backward.hpp
@@ -13,7 +13,7 @@ namespace ttnn {
 
 namespace operations::binary_backward {
 
-//OpHandler_binary_bw : get_function_binary_bw_type1
+//OpHandler_binary_bw : get_function_binary_bw
 template <BinaryBackwardOpType binary_backward_op_type>
 struct ExecuteBinaryBackwardType1 {
 
@@ -30,13 +30,13 @@ struct ExecuteBinaryBackwardType1 {
         const Tensor &input_tensor_a_arg,
         const Tensor &input_tensor_b_arg,
         const std::optional<MemoryConfig> &memory_config = std::nullopt) {
-        auto op_type = get_function_binary_bw_type1<binary_backward_op_type>();
+        auto op_type = get_function_binary_bw<binary_backward_op_type>();
         auto output_memory_config = memory_config.value_or(input_tensor_a_arg.memory_config());
         return op_type(grad_tensor_arg, input_tensor_a_arg, input_tensor_b_arg, output_memory_config);
         }
 };
 
-//OpHandler_binary_bw_opt_float_default : get_function_binary_bw_type1_opt_float_default
+//OpHandler_binary_bw_opt_float_default : get_function_binary_bw_opt_float_default
 template <BinaryBackwardOpType unary_backward_op_type>
 struct ExecuteBinaryBackwardOptionalFloatDefault {
 
@@ -59,7 +59,7 @@ struct ExecuteBinaryBackwardOptionalFloatDefault {
         std::optional<Tensor> input_b_grad = std::nullopt) {
 
         auto output_memory_config = memory_config.value_or(input_tensor_a_arg.memory_config());
-        auto op_type = get_function_binary_bw_type1_opt_float_default<unary_backward_op_type>();
+        auto op_type = get_function_binary_bw_opt_float_default<unary_backward_op_type>();
         return op_type(queue_id, grad_tensor_arg, input_tensor_a_arg, input_tensor_b_arg, parameter, output_memory_config, are_required_outputs, input_a_grad, input_b_grad);
     }
 
@@ -74,13 +74,13 @@ struct ExecuteBinaryBackwardOptionalFloatDefault {
         std::optional<Tensor> input_b_grad = std::nullopt) {
 
         auto output_memory_config = memory_config.value_or(input_tensor_a_arg.memory_config());
-        auto op_type = get_function_binary_bw_type1_opt_float_default<unary_backward_op_type>();
+        auto op_type = get_function_binary_bw_opt_float_default<unary_backward_op_type>();
         return op_type(DefaultQueueId, grad_tensor_arg, input_tensor_a_arg, input_tensor_b_arg, parameter, output_memory_config, are_required_outputs, input_a_grad, input_b_grad);
     }
 
 };
 
-//OpHandler_binary_bw_float : get_function_binary_bw_type1_float
+//OpHandler_binary_bw_float : get_function_binary_bw_float
 template <BinaryBackwardOpType binary_backward_op_type>
 struct ExecuteBinaryBackwardType1Float {
 
@@ -98,7 +98,7 @@ struct ExecuteBinaryBackwardType1Float {
         const Tensor &input_tensor_b_arg,
         float parameter,
         const std::optional<MemoryConfig> &memory_config = std::nullopt) {
-        auto op_type = get_function_binary_bw_type1<binary_backward_op_type>();
+        auto op_type = get_function_binary_bw_float<binary_backward_op_type>();
         auto output_memory_config = memory_config.value_or(input_tensor_a_arg.memory_config());
         return op_type(grad_tensor_arg, input_tensor_a_arg, input_tensor_b_arg, parameter, output_memory_config);
         }
@@ -193,15 +193,15 @@ struct ExecuteBinaryBackward {
 
 }  // operations::binary
 
-//OpHandler_binary_bw : get_function_binary_bw_type1
+//OpHandler_binary_bw : get_function_binary_bw
 constexpr auto atan2_bw = ttnn::register_operation<operations::binary_backward::ExecuteBinaryBackwardType1<operations::binary_backward::BinaryBackwardOpType::ATAN2_BW>>("ttnn::atan2_bw");
 constexpr auto rsub_bw = ttnn::register_operation<operations::binary_backward::ExecuteBinaryBackwardType1<operations::binary_backward::BinaryBackwardOpType::RSUB_BW>>("ttnn::rsub_bw");
 constexpr auto embedding_bw = ttnn::register_operation<operations::binary_backward::ExecuteBinaryBackwardType1<operations::binary_backward::BinaryBackwardOpType::EMBEDDING_BW>>("ttnn::embedding_bw");
 
-//OpHandler_binary_bw_opt_float_default : get_function_binary_bw_type1_opt_float_default
+//OpHandler_binary_bw_opt_float_default : get_function_binary_bw_opt_float_default
 constexpr auto addalpha_bw = ttnn::register_operation<operations::binary_backward::ExecuteBinaryBackwardOptionalFloatDefault<operations::binary_backward::BinaryBackwardOpType::ADDALPHA_BW>>("ttnn::addalpha_bw");
 
-//OpHandler_binary_bw_float : get_function_binary_bw_type1_float
+//OpHandler_binary_bw_float : get_function_binary_bw_float
 constexpr auto subalpha_bw = ttnn::register_operation<operations::binary_backward::ExecuteBinaryBackwardType1Float<operations::binary_backward::BinaryBackwardOpType::SUBALPHA_BW>>("ttnn::subalpha_bw");
 
 //type 1

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_backward/binary_backward.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_backward/binary_backward.hpp
@@ -80,6 +80,29 @@ struct ExecuteBinaryBackwardOptionalFloatDefault {
 
 };
 
+//OpHandler_binary_bw_float : get_function_binary_bw_type1_float
+template <BinaryBackwardOpType binary_backward_op_type>
+struct ExecuteBinaryBackwardType1Float {
+
+    static inline std::vector<ttnn::Tensor> create_async_output_tensors(
+        const std::vector<Tensor> &input_tensors, const std::vector<std::optional<const Tensor>>& optional_inputs) {
+        const auto& input_tensor = input_tensors.at(0);
+        return {Tensor(operation::get_workers_for_op_output({input_tensor})),
+                                            Tensor(operation::get_workers_for_op_output({input_tensor}))};
+    }
+
+    //Type 1: 1 inputs, 1 grad tensor, 1 float, 1 default string
+    static std::vector<Tensor> execute_on_main_thread(
+        const Tensor &grad_tensor_arg,
+        const Tensor &input_tensor_a_arg,
+        const Tensor &input_tensor_b_arg,
+        float parameter,
+        const std::optional<MemoryConfig> &memory_config = std::nullopt) {
+        auto op_type = get_function_binary_bw_type1<binary_backward_op_type>();
+        auto output_memory_config = memory_config.value_or(input_tensor_a_arg.memory_config());
+        return op_type(grad_tensor_arg, input_tensor_a_arg, input_tensor_b_arg, parameter, output_memory_config);
+        }
+};
 template <BinaryBackwardOpType binary_backward_op_type>
 struct ExecuteBinaryBackward {
     static inline std::vector<ttnn::Tensor> create_async_output_tensors(
@@ -213,8 +236,10 @@ constexpr auto embedding_bw = ttnn::register_operation<operations::binary_backwa
 //OpHandler_binary_bw_opt_float_default : get_function_binary_bw_type1_opt_float_default
 constexpr auto addalpha_bw = ttnn::register_operation<operations::binary_backward::ExecuteBinaryBackwardOptionalFloatDefault<operations::binary_backward::BinaryBackwardOpType::ADDALPHA_BW>>("ttnn::addalpha_bw");
 
+//OpHandler_binary_bw_float : get_function_binary_bw_type1_float
+constexpr auto subalpha_bw = ttnn::register_operation<operations::binary_backward::ExecuteBinaryBackwardType1Float<operations::binary_backward::BinaryBackwardOpType::SUBALPHA_BW>>("ttnn::subalpha_bw");
+
 //type 1
-constexpr auto subalpha_bw = ttnn::register_operation<operations::binary_backward::ExecuteBinaryBackward<operations::binary_backward::BinaryBackwardOpType::SUBALPHA_BW>>("ttnn::subalpha_bw");
 constexpr auto xlogy_bw = ttnn::register_operation<operations::binary_backward::ExecuteBinaryBackward<operations::binary_backward::BinaryBackwardOpType::XLOGY_BW>>("ttnn::xlogy_bw");
 constexpr auto hypot_bw = ttnn::register_operation<operations::binary_backward::ExecuteBinaryBackward<operations::binary_backward::BinaryBackwardOpType::HYPOT_BW>>("ttnn::hypot_bw");
 constexpr auto ldexp_bw = ttnn::register_operation<operations::binary_backward::ExecuteBinaryBackward<operations::binary_backward::BinaryBackwardOpType::LDEXP_BW>>("ttnn::ldexp_bw");

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_backward/binary_backward.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_backward/binary_backward.hpp
@@ -189,41 +189,6 @@ struct ExecuteBinaryBackward {
         return op_type(grad_tensor_arg, input_tensor_a_arg, input_tensor_b_arg, output_memory_config, are_required_outputs, input_a_grad, input_b_grad);
     }
 
-    // Type 2 : Q_ID, type1 args, optional output tensor for inputs based on are_required_outputs value
-
-    static std::vector<std::optional<ttnn::Tensor>> execute_on_main_thread(
-        uint8_t queue_id,
-        const Tensor &grad_tensor_arg,
-        const Tensor &input_tensor_a_arg,
-        const Tensor &input_tensor_b_arg,
-        float alpha,
-        const std::optional<MemoryConfig> &memory_config = std::nullopt,
-        const std::vector<bool>& are_required_outputs = std::vector<bool>{true, true},
-        std::optional<Tensor> input_a_grad = std::nullopt,
-        std::optional<Tensor> input_b_grad = std::nullopt) {
-
-        auto output_memory_config = memory_config.value_or(input_tensor_a_arg.memory_config());
-        auto op_type = BinaryBackwardFunction::get_function_type2(binary_backward_op_type);
-        return op_type(queue_id, grad_tensor_arg, input_tensor_a_arg, input_tensor_b_arg, alpha, output_memory_config, are_required_outputs, input_a_grad, input_b_grad);
-    }
-
-    // Type 2 : type1 args, optional output tensor for inputs based on are_required_outputs value
-
-    static std::vector<std::optional<ttnn::Tensor>> execute_on_main_thread(
-        const Tensor &grad_tensor_arg,
-        const Tensor &input_tensor_a_arg,
-        const Tensor &input_tensor_b_arg,
-        float alpha,
-        const std::optional<MemoryConfig> &memory_config = std::nullopt,
-        const std::vector<bool>& are_required_outputs = std::vector<bool>{true, true},
-        std::optional<Tensor> input_a_grad = std::nullopt,
-        std::optional<Tensor> input_b_grad = std::nullopt) {
-
-        auto output_memory_config = memory_config.value_or(input_tensor_a_arg.memory_config());
-        auto op_type = BinaryBackwardFunction::get_function_type2_wo_qid(binary_backward_op_type);
-        return op_type(grad_tensor_arg, input_tensor_a_arg, input_tensor_b_arg, alpha, output_memory_config, are_required_outputs, input_a_grad, input_b_grad);
-    }
-
 };
 
 }  // operations::binary

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_backward/binary_backward_pybind.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_backward/binary_backward_pybind.hpp
@@ -322,52 +322,6 @@ Example:
             py::arg("memory_config") = std::nullopt,
             py::arg("are_required_outputs") = std::vector<bool>{true, true},
             py::arg("input_a_grad") = std::nullopt,
-            py::arg("input_b_grad") = std::nullopt},
-
-        ttnn::pybind_overload_t{
-            [](const binary_backward_operation_t& self,
-               const ttnn::Tensor& grad_tensor,
-               const ttnn::Tensor& input_tensor_a,
-               const ttnn::Tensor& input_tensor_b,
-               const float alpha,
-               const std::optional<ttnn::MemoryConfig>& memory_config,
-               const std::vector<bool>& are_required_outputs,
-               const std::optional<ttnn::Tensor>& input_a_grad,
-               const std::optional<ttnn::Tensor>& input_b_grad,
-               const uint8_t& queue_id) -> std::vector<optional<ttnn::Tensor>> {
-                return self(queue_id, grad_tensor, input_tensor_a, input_tensor_b, alpha, memory_config, are_required_outputs, input_a_grad, input_b_grad);
-            },
-            py::arg("grad_tensor"),
-            py::arg("input_tensor_a"),
-            py::arg("input_tensor_b"),
-            py::arg("alpha") = 1.0f,
-            py::kw_only(),
-            py::arg("memory_config") = std::nullopt,
-            py::arg("are_required_outputs") = std::vector<bool>{true, true},
-            py::arg("input_a_grad") = std::nullopt,
-            py::arg("input_b_grad") = std::nullopt,
-            py::arg("queue_id") = 0},
-
-        ttnn::pybind_overload_t{
-            [](const binary_backward_operation_t& self,
-               const ttnn::Tensor& grad_tensor,
-               const ttnn::Tensor& input_tensor_a,
-               const ttnn::Tensor& input_tensor_b,
-               const float alpha,
-               const std::optional<ttnn::MemoryConfig>& memory_config,
-               const std::vector<bool>& are_required_outputs,
-               const std::optional<ttnn::Tensor>& input_a_grad,
-               const std::optional<ttnn::Tensor>& input_b_grad) -> std::vector<optional<ttnn::Tensor>> {
-                return self(grad_tensor, input_tensor_a, input_tensor_b, alpha, memory_config, are_required_outputs, input_a_grad, input_b_grad);
-            },
-            py::arg("grad_tensor"),
-            py::arg("input_tensor_a"),
-            py::arg("input_tensor_b"),
-            py::arg("alpha") = 1.0f,
-            py::kw_only(),
-            py::arg("memory_config") = std::nullopt,
-            py::arg("are_required_outputs") = std::vector<bool>{true, true},
-            py::arg("input_a_grad") = std::nullopt,
             py::arg("input_b_grad") = std::nullopt});
 }
 

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_backward/binary_backward_pybind.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_backward/binary_backward_pybind.hpp
@@ -20,7 +20,7 @@ namespace binary_backward {
 
 namespace detail {
 
-//OpHandler_binary_bw : get_function_binary_bw_type1
+//OpHandler_binary_bw : get_function_binary_bw
 template <typename binary_backward_operation_t>
 void bind_binary_backward_type_1(py::module& module, const binary_backward_operation_t& operation, const std::string& description) {
     auto doc = fmt::format(
@@ -67,7 +67,7 @@ Example:
             py::arg("memory_config") = std::nullopt});
 }
 
-//OpHandler_binary_bw_opt_float_default : get_function_binary_bw_type1_opt_float_default
+//OpHandler_binary_bw_opt_float_default : get_function_binary_bw_opt_float_default
 template <typename binary_backward_operation_t>
 void bind_binary_backward_opt_float_default(py::module& module, const binary_backward_operation_t& operation, const std::string& parameter_name, const std::string& parameter_doc, float parameter_value, const std::string& description) {
     auto doc = fmt::format(
@@ -129,7 +129,7 @@ void bind_binary_backward_opt_float_default(py::module& module, const binary_bac
     );
 }
 
-//OpHandler_binary_bw_float : get_function_binary_bw_type1_float
+//OpHandler_binary_bw_float : get_function_binary_bw_float
 template <typename binary_backward_operation_t>
 void bind_binary_backward_float_default(py::module& module, const binary_backward_operation_t& operation, const std::string& parameter_name, const std::string& parameter_doc, float parameter_value, const std::string& description) {
     auto doc = fmt::format(

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_backward/binary_backward_pybind.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_backward/binary_backward_pybind.hpp
@@ -129,6 +129,60 @@ void bind_binary_backward_opt_float_default(py::module& module, const binary_bac
     );
 }
 
+//OpHandler_binary_bw_float : get_function_binary_bw_type1_float
+template <typename binary_backward_operation_t>
+void bind_binary_backward_float_default(py::module& module, const binary_backward_operation_t& operation, const std::string& parameter_name, const std::string& parameter_doc, float parameter_value, const std::string& description) {
+    auto doc = fmt::format(
+        R"doc({0}(grad_tensor: ttnn.Tensor, input_tensor_a: ttnn.Tensor, input_tensor_b: ttnn.Tensor, {2}: float, *, memory_config: ttnn.MemoryConfig) -> std::vector<Tensor>
+
+        {5}
+
+        Args:
+            * :attr:`grad_tensor`
+            * :attr:`input_tensor_a`
+            * :attr:`input_tensor_b`
+            * :attr:`{3}` (float):Default value = {4}
+
+        Keyword args:
+            * :attr:`memory_config` (Optional[ttnn.MemoryConfig]): memory config for the output tensor
+
+        Example:
+
+            >>> grad_tensor = ttnn.to_device(ttnn.from_torch(torch.tensor((1, 2), dtype=torch.bfloat16)), device)
+            >>> tensor1 = ttnn.to_device(ttnn.from_torch(torch.tensor((1, 2), dtype=torch.bfloat16)), device)
+            >>> tensor2 = ttnn.to_device(ttnn.from_torch(torch.tensor((0, 1), dtype=torch.bfloat16)), device)
+            >>> output = {1}(grad_tensor, tensor1, tensor2, float)
+        )doc",
+        operation.base_name(),
+        operation.python_fully_qualified_name(),
+        parameter_name,
+        parameter_doc,
+        parameter_value,
+        description);
+
+
+    bind_registered_operation(
+        module,
+        operation,
+        doc,
+        ttnn::pybind_overload_t{
+            [](const binary_backward_operation_t& self,
+               const ttnn::Tensor& grad_tensor,
+               const ttnn::Tensor& input_tensor_a,
+               const ttnn::Tensor& input_tensor_b,
+               float parameter,
+               const std::optional<ttnn::MemoryConfig>& memory_config) -> std::vector<ttnn::Tensor> {
+                return self(grad_tensor, input_tensor_a, input_tensor_b, parameter, memory_config);
+            },
+            py::arg("grad_tensor"),
+            py::arg("input_tensor_a"),
+            py::arg("input_tensor_b"),
+            py::arg(parameter_name.c_str()) = parameter_value,
+            py::kw_only(),
+            py::arg("memory_config") = std::nullopt}
+    );
+}
+
 template <typename binary_backward_operation_t>
 void bind_binary_backward(py::module& module, const binary_backward_operation_t& operation, const std::string& description) {
     auto doc = fmt::format(
@@ -332,9 +386,10 @@ void py_module(py::module& module) {
         R"doc(Performs backward operations for embedding_bw function and it returns specific indices of the embedding table specified by the :attr:`grad_tensor`.
         The input tensor( :attr:`input_tensor_a`, :attr:`input_tensor_b`) should be unique.)doc");
 
-    detail::bind_binary_backward(
+    detail::bind_binary_backward_float_default(
         module,
         ttnn::subalpha_bw,
+        "alpha", "Alpha value", 1.0f,
         R"doc(Performs backward operations for subalpha of :attr:`input_tensor_a` and :attr:`input_tensor_b` with given :attr:`grad_tensor`.)doc");
 
     detail::bind_binary_backward_opt_float_default(

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_backward/device/binary_backward_op.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_backward/device/binary_backward_op.cpp
@@ -101,7 +101,7 @@ std::vector<std::optional<ttnn::Tensor>> _addalpha_bw(
 }
 
 std::vector<ttnn::Tensor> _subalpha_bw(
-    const Tensor& grad, const Tensor& input, const Tensor& other, float alpha, const MemoryConfig& output_mem_config) {
+    const Tensor& grad, const Tensor& input, const Tensor& other, float alpha, const std::optional<MemoryConfig>& output_mem_config) {
     std::vector<Tensor> grad_tensor;
     grad_tensor.emplace_back(grad);
     Tensor grad_b = ttnn::multiply(ttnn::neg(grad, output_mem_config), alpha, std::nullopt, output_mem_config);
@@ -383,7 +383,7 @@ std::vector<Tensor> _binary_comp_bw(const Tensor& grad, const Tensor& input, con
 }
 
 std::vector<Tensor> _rsub_bw( const Tensor& grad, const Tensor& input, const Tensor& other, const std::optional<MemoryConfig>& output_mem_config) {
-    std::vector<Tensor> grad_tensor = ttnn::operations::binary_backward::_subalpha_bw(grad, input, other, 1.0f, output_mem_config.value_or(input.memory_config()));
+    std::vector<Tensor> grad_tensor = _subalpha_bw(grad, input, other, 1.0f, output_mem_config.value_or(input.memory_config()));
     std::swap(grad_tensor[0], grad_tensor[1]);
     return grad_tensor;
 }
@@ -638,8 +638,6 @@ std::function<std::vector<ttnn::Tensor>(const Tensor&, const Tensor&, const Tens
 
 std::function<std::vector<Tensor>(const Tensor&, const Tensor&, const Tensor&, float, const MemoryConfig&)> BinaryBackwardFunction::get_function_type1_w_float(BinaryBackwardOpType OpType){
     switch (OpType) {
-        case BinaryBackwardOpType::SUBALPHA_BW:
-            return _subalpha_bw;
         case BinaryBackwardOpType::CONCAT_BW:
             return _concat_bw;
         case BinaryBackwardOpType::LERP_BW:

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_backward/device/binary_backward_op.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_backward/device/binary_backward_op.cpp
@@ -660,22 +660,6 @@ std::function<std::vector<ttnn::Tensor>(const Tensor&, const Tensor&, const Tens
     }
 }
 
-std::function<std::vector<std::optional<ttnn::Tensor>>(uint8_t , const Tensor&, const Tensor&, const Tensor&, float, const MemoryConfig&, const std::vector<bool>&, std::optional<Tensor>, std::optional<Tensor>)> BinaryBackwardFunction::get_function_type2(BinaryBackwardOpType OpType){
-    switch (OpType) {
-        default:
-            TT_ASSERT(false && "Undefined op type");
-            return 0;
-    }
-}
-
-std::function<std::vector<std::optional<ttnn::Tensor>>(const Tensor&, const Tensor&, const Tensor&, float, const MemoryConfig&, const std::vector<bool>&, std::optional<Tensor>, std::optional<Tensor>)> BinaryBackwardFunction::get_function_type2_wo_qid(BinaryBackwardOpType OpType){
-    switch (OpType) {
-        default:
-            TT_ASSERT(false && "Undefined op type");
-            return 0;
-    }
-}
-
 std::function<std::vector<std::optional<ttnn::Tensor>>(uint8_t , const Tensor&, const Tensor&, const Tensor&, const MemoryConfig&, const std::vector<bool>&, std::optional<Tensor>, std::optional<Tensor>)> BinaryBackwardFunction::get_function_type3(BinaryBackwardOpType OpType){
     switch (OpType) {
         case BinaryBackwardOpType::ADD_BW:

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_backward/device/binary_backward_op.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_backward/device/binary_backward_op.hpp
@@ -43,22 +43,22 @@ enum class BinaryBackwardOpType {
     MUL_BW,
 };
 struct BinaryBackwardFunction{
-static std::function<std::vector<ttnn::Tensor>(const Tensor&, const Tensor&, const Tensor&, const MemoryConfig&)> get_function_type1(BinaryBackwardOpType OpType); //get_function_binary_bw_type1
+static std::function<std::vector<ttnn::Tensor>(const Tensor&, const Tensor&, const Tensor&, const MemoryConfig&)> get_function_type1(BinaryBackwardOpType OpType); //get_function_binary_bw
 static std::function<std::vector<ttnn::Tensor>(const Tensor&, const Tensor&, const Tensor&, float, const MemoryConfig&)> get_function_type1_w_float(BinaryBackwardOpType OpType);
 static std::function<std::vector<ttnn::Tensor>(const Tensor&, const Tensor&, const Tensor&, std::string, const MemoryConfig&)> get_function_type1_w_string(BinaryBackwardOpType OpType);
 static std::function<std::vector<std::optional<ttnn::Tensor>>(uint8_t , const Tensor&, const Tensor&, const Tensor&, const MemoryConfig&, const std::vector<bool>&, std::optional<Tensor>, std::optional<Tensor>)> get_function_type3(BinaryBackwardOpType OpType);
 static std::function<std::vector<std::optional<ttnn::Tensor>>(const Tensor&, const Tensor&, const Tensor&, const MemoryConfig&, const std::vector<bool>&, std::optional<Tensor>, std::optional<Tensor>)> get_function_type3_wo_qid(BinaryBackwardOpType OpType);
 };
 
-//OpHandler_binary_bw : get_function_binary_bw_type1
+//OpHandler_binary_bw : get_function_binary_bw
 std::vector<Tensor> _atan2_bw( const Tensor& grad, const Tensor& input, const Tensor& other, const std::optional<MemoryConfig>& output_mem_config);
 std::vector<Tensor> _rsub_bw( const Tensor& grad, const Tensor& input, const Tensor& other, const std::optional<MemoryConfig>& output_mem_config);
 std::vector<Tensor> _embedding_bw( const Tensor& grad, const Tensor& input, const Tensor& other, const std::optional<MemoryConfig>& output_mem_config);
 
-//OpHandler_binary_bw_float : get_function_binary_bw_type1_float
+//OpHandler_binary_bw_float : get_function_binary_bw_float
 std::vector<ttnn::Tensor> _subalpha_bw( const Tensor& grad, const Tensor& input, const Tensor& other, float alpha = 1.0f, const std::optional<MemoryConfig>& output_mem_config = std::nullopt);
 
-//OpHandler_binary_bw_opt_float_default : get_function_binary_bw_type1_opt_float_default
+//OpHandler_binary_bw_opt_float_default : get_function_binary_bw_opt_float_default
 std::vector<std::optional<ttnn::Tensor>> _addalpha_bw( uint8_t queue_id, const Tensor& grad, const Tensor& input, const Tensor& other, float alpha = 1.0f, const std::optional<MemoryConfig>& output_mem_config = std::nullopt, const std::vector<bool>& are_required_outputs = std::vector<bool>{true, true}, std::optional<Tensor> input_grad = std::nullopt, std::optional<Tensor> other_grad = std::nullopt);
 
 // OpHandler struct template
@@ -100,7 +100,7 @@ struct OpHandler_binary_bw<BinaryBackwardOpType::EMBEDDING_BW> {
 };
 
 template <>
-struct OpHandler_binary_bw<BinaryBackwardOpType::SUBALPHA_BW> {
+struct OpHandler_binary_bw_float<BinaryBackwardOpType::SUBALPHA_BW> {
     static std::vector<Tensor> handle( const Tensor& grad, const Tensor& input, const Tensor& other, float alpha, const std::optional<MemoryConfig>& output_mem_config ) {
         return _subalpha_bw(grad, input, other, alpha, output_mem_config);
     }
@@ -108,17 +108,17 @@ struct OpHandler_binary_bw<BinaryBackwardOpType::SUBALPHA_BW> {
 
 // Template functions to get the function pointers
 template <BinaryBackwardOpType OpType>
-auto get_function_binary_bw_type1() {
+auto get_function_binary_bw() {
     return &OpHandler_binary_bw<OpType>::handle;
 }
 
 template <BinaryBackwardOpType OpType>
-auto get_function_binary_bw_type1_opt_float_default() {
+auto get_function_binary_bw_opt_float_default() {
     return &OpHandler_binary_bw_opt_float_default<OpType>::handle;
 }
 
 template <BinaryBackwardOpType OpType>
-auto get_function_binary_bw_type1_float() {
+auto get_function_binary_bw_float() {
     return &OpHandler_binary_bw_float<OpType>::handle;
 }
 

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_backward/device/binary_backward_op.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_backward/device/binary_backward_op.hpp
@@ -46,8 +46,6 @@ struct BinaryBackwardFunction{
 static std::function<std::vector<ttnn::Tensor>(const Tensor&, const Tensor&, const Tensor&, const MemoryConfig&)> get_function_type1(BinaryBackwardOpType OpType); //get_function_binary_bw_type1
 static std::function<std::vector<ttnn::Tensor>(const Tensor&, const Tensor&, const Tensor&, float, const MemoryConfig&)> get_function_type1_w_float(BinaryBackwardOpType OpType);
 static std::function<std::vector<ttnn::Tensor>(const Tensor&, const Tensor&, const Tensor&, std::string, const MemoryConfig&)> get_function_type1_w_string(BinaryBackwardOpType OpType);
-static std::function<std::vector<std::optional<ttnn::Tensor>>(uint8_t , const Tensor&, const Tensor&, const Tensor&, float, const MemoryConfig&, const std::vector<bool>&, std::optional<Tensor>, std::optional<Tensor>)> get_function_type2(BinaryBackwardOpType OpType);
-static std::function<std::vector<std::optional<ttnn::Tensor>>(const Tensor&, const Tensor&, const Tensor&, float, const MemoryConfig&, const std::vector<bool>&, std::optional<Tensor>, std::optional<Tensor>)> get_function_type2_wo_qid(BinaryBackwardOpType OpType);
 static std::function<std::vector<std::optional<ttnn::Tensor>>(uint8_t , const Tensor&, const Tensor&, const Tensor&, const MemoryConfig&, const std::vector<bool>&, std::optional<Tensor>, std::optional<Tensor>)> get_function_type3(BinaryBackwardOpType OpType);
 static std::function<std::vector<std::optional<ttnn::Tensor>>(const Tensor&, const Tensor&, const Tensor&, const MemoryConfig&, const std::vector<bool>&, std::optional<Tensor>, std::optional<Tensor>)> get_function_type3_wo_qid(BinaryBackwardOpType OpType);
 };

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_backward/device/binary_backward_op.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_backward/device/binary_backward_op.hpp
@@ -57,6 +57,9 @@ std::vector<Tensor> _atan2_bw( const Tensor& grad, const Tensor& input, const Te
 std::vector<Tensor> _rsub_bw( const Tensor& grad, const Tensor& input, const Tensor& other, const std::optional<MemoryConfig>& output_mem_config);
 std::vector<Tensor> _embedding_bw( const Tensor& grad, const Tensor& input, const Tensor& other, const std::optional<MemoryConfig>& output_mem_config);
 
+//OpHandler_binary_bw_float : get_function_binary_bw_type1_float
+std::vector<ttnn::Tensor> _subalpha_bw( const Tensor& grad, const Tensor& input, const Tensor& other, float alpha = 1.0f, const std::optional<MemoryConfig>& output_mem_config = std::nullopt);
+
 //OpHandler_binary_bw_opt_float_default : get_function_binary_bw_type1_opt_float_default
 std::vector<std::optional<ttnn::Tensor>> _addalpha_bw( uint8_t queue_id, const Tensor& grad, const Tensor& input, const Tensor& other, float alpha = 1.0f, const std::optional<MemoryConfig>& output_mem_config = std::nullopt, const std::vector<bool>& are_required_outputs = std::vector<bool>{true, true}, std::optional<Tensor> input_grad = std::nullopt, std::optional<Tensor> other_grad = std::nullopt);
 
@@ -66,6 +69,9 @@ struct OpHandler_binary_bw;
 
 template <BinaryBackwardOpType OpType>
 struct OpHandler_binary_bw_opt_float_default;
+
+template <BinaryBackwardOpType OpType>
+struct OpHandler_binary_bw_float;
 
 template <>
 struct OpHandler_binary_bw<BinaryBackwardOpType::ATAN2_BW> {
@@ -95,6 +101,13 @@ struct OpHandler_binary_bw<BinaryBackwardOpType::EMBEDDING_BW> {
     }
 };
 
+template <>
+struct OpHandler_binary_bw<BinaryBackwardOpType::SUBALPHA_BW> {
+    static std::vector<Tensor> handle( const Tensor& grad, const Tensor& input, const Tensor& other, float alpha, const std::optional<MemoryConfig>& output_mem_config ) {
+        return _subalpha_bw(grad, input, other, alpha, output_mem_config);
+    }
+};
+
 // Template functions to get the function pointers
 template <BinaryBackwardOpType OpType>
 auto get_function_binary_bw_type1() {
@@ -104,6 +117,11 @@ auto get_function_binary_bw_type1() {
 template <BinaryBackwardOpType OpType>
 auto get_function_binary_bw_type1_opt_float_default() {
     return &OpHandler_binary_bw_opt_float_default<OpType>::handle;
+}
+
+template <BinaryBackwardOpType OpType>
+auto get_function_binary_bw_type1_float() {
+    return &OpHandler_binary_bw_float<OpType>::handle;
 }
 
 }  // namespace ttnn::operations::binary_backward

--- a/ttnn/ttnn/operations/binary_backward.py
+++ b/ttnn/ttnn/operations/binary_backward.py
@@ -68,8 +68,13 @@ def _golden_function_backward_with_dim(
     return golden_tensor
 
 
-def _golden_function_backward_with_float(torch_op, grad_tensor, input_tensor_a, input_tensor_b, alpha, *args, **kwargs):
-    pyt_y = torch_op(input_tensor_a, input_tensor_b, alpha=alpha)
+def _golden_function_backward_with_float(
+    torch_op, grad_tensor, input_tensor_a, input_tensor_b, alpha=None, *args, **kwargs
+):
+    if alpha == None:
+        pyt_y = torch_op(input_tensor_a, input_tensor_b)
+    else:
+        pyt_y = torch_op(input_tensor_a, input_tensor_b, alpha=alpha)
     input_tensor_a.retain_grad()
     input_tensor_b.retain_grad()
     pyt_y.backward(gradient=grad_tensor)
@@ -169,7 +174,7 @@ ttnn.attach_golden_function(
 
 ttnn.attach_golden_function(
     ttnn.subalpha_bw,
-    golden_function=lambda grad, a, b, alpha, *args, **kwargs: _golden_function_backward_with_float(
+    golden_function=lambda grad, a, b, alpha=None, *args, **kwargs: _golden_function_backward_with_float(
         torch.sub, grad, a, b, alpha, *args, **kwargs
     ),
 )

--- a/ttnn/ttnn/operations/binary_backward.py
+++ b/ttnn/ttnn/operations/binary_backward.py
@@ -181,7 +181,7 @@ ttnn.attach_golden_function(
 
 ttnn.attach_golden_function(
     ttnn.addalpha_bw,
-    golden_function=lambda grad, a, b, alpha, *args, **kwargs: _golden_function_backward_with_float(
+    golden_function=lambda grad, a, b, alpha=None, *args, **kwargs: _golden_function_backward_with_float(
         torch.add, grad, a, b, alpha, *args, **kwargs
     ),
 )


### PR DESCRIPTION
- Remove std::function for `subalpha_bw`
- Update `addalpha_bw` test file 
  - to check for default 
  - update golden function
- Remove 
  - `get_function_type2`
  - `get_function_type2_wo_qid`
  
https://github.com/tenstorrent/tt-metal/actions/runs/10020084845 - passed
 