### PR TITLE
#9628: Remove get_function_type1_w_float in binary bw

### DIFF
--- a/ttnn/cpp/ttnn/operations/eltwise/binary_backward/binary_backward.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_backward/binary_backward.hpp
@@ -36,7 +36,7 @@ struct ExecuteBinaryBackwardTensor {
 };
 
 //OpHandler_binary_bw_opt_float_default : get_function_binary_bw_opt_float_default
-template <BinaryBackwardOpType unary_backward_op_type>
+template <BinaryBackwardOpType binary_backward_op_type>
 struct ExecuteBinaryBackwardOptionalFloatDefault {
 
     static inline std::vector<ttnn::Tensor> create_async_output_tensors(
@@ -58,7 +58,7 @@ struct ExecuteBinaryBackwardOptionalFloatDefault {
         std::optional<Tensor> input_b_grad = std::nullopt) {
 
         auto output_memory_config = memory_config.value_or(input_tensor_a_arg.memory_config());
-        auto op_type = get_function_binary_bw_opt_float_default<unary_backward_op_type>();
+        auto op_type = get_function_binary_bw_opt_float_default<binary_backward_op_type>();
         return op_type(queue_id, grad_tensor_arg, input_tensor_a_arg, input_tensor_b_arg, parameter, output_memory_config, are_required_outputs, input_a_grad, input_b_grad);
     }
 
@@ -73,15 +73,15 @@ struct ExecuteBinaryBackwardOptionalFloatDefault {
         std::optional<Tensor> input_b_grad = std::nullopt) {
 
         auto output_memory_config = memory_config.value_or(input_tensor_a_arg.memory_config());
-        auto op_type = get_function_binary_bw_opt_float_default<unary_backward_op_type>();
+        auto op_type = get_function_binary_bw_opt_float_default<binary_backward_op_type>();
         return op_type(DefaultQueueId, grad_tensor_arg, input_tensor_a_arg, input_tensor_b_arg, parameter, output_memory_config, are_required_outputs, input_a_grad, input_b_grad);
     }
 
 };
 
-//OpHandler_binary_bw_float : get_function_binary_bw_float
+//OpHandler_binary_bw_float_default : get_function_binary_bw_float_default
 template <BinaryBackwardOpType binary_backward_op_type>
-struct ExecuteBinaryBackwardFloat {
+struct ExecuteBinaryBackwardFloatDefault {
 
     static inline std::vector<ttnn::Tensor> create_async_output_tensors(
         const std::vector<Tensor> &input_tensors, const std::vector<std::optional<const Tensor>>& optional_inputs) {
@@ -96,7 +96,7 @@ struct ExecuteBinaryBackwardFloat {
         const Tensor &input_tensor_b_arg,
         float parameter,
         const std::optional<MemoryConfig> &memory_config = std::nullopt) {
-        auto op_type = get_function_binary_bw_float<binary_backward_op_type>();
+        auto op_type = get_function_binary_bw_float_default<binary_backward_op_type>();
         auto output_memory_config = memory_config.value_or(input_tensor_a_arg.memory_config());
         return op_type(grad_tensor_arg, input_tensor_a_arg, input_tensor_b_arg, parameter, output_memory_config);
         }
@@ -120,6 +120,29 @@ struct ExecuteBinaryBackwardIntDefault {
         int parameter,
         const std::optional<MemoryConfig> &memory_config = std::nullopt) {
         auto op_type = get_function_binary_bw_int_default<binary_backward_op_type>();
+        auto output_memory_config = memory_config.value_or(input_tensor_a_arg.memory_config());
+        return op_type(grad_tensor_arg, input_tensor_a_arg, input_tensor_b_arg, parameter, output_memory_config);
+        }
+};
+
+//OpHandler_binary_bw_float : get_function_binary_bw_float
+template <BinaryBackwardOpType binary_backward_op_type>
+struct ExecuteBinaryBackwardFloat {
+
+    static inline std::vector<ttnn::Tensor> create_async_output_tensors(
+        const std::vector<Tensor> &input_tensors, const std::vector<std::optional<const Tensor>>& optional_inputs) {
+        const auto& input_tensor = input_tensors.at(0);
+        return {Tensor(operation::get_workers_for_op_output({input_tensor})),
+                                            Tensor(operation::get_workers_for_op_output({input_tensor}))};
+    }
+
+    static std::vector<Tensor> execute_on_main_thread(
+        const Tensor &grad_tensor_arg,
+        const Tensor &input_tensor_a_arg,
+        const Tensor &input_tensor_b_arg,
+        float parameter,
+        const std::optional<MemoryConfig> &memory_config = std::nullopt) {
+        auto op_type = get_function_binary_bw_float<binary_backward_op_type>();
         auto output_memory_config = memory_config.value_or(input_tensor_a_arg.memory_config());
         return op_type(grad_tensor_arg, input_tensor_a_arg, input_tensor_b_arg, parameter, output_memory_config);
         }
@@ -223,11 +246,14 @@ constexpr auto embedding_bw = ttnn::register_operation<operations::binary_backwa
 //OpHandler_binary_bw_opt_float_default : get_function_binary_bw_opt_float_default
 constexpr auto addalpha_bw = ttnn::register_operation<operations::binary_backward::ExecuteBinaryBackwardOptionalFloatDefault<operations::binary_backward::BinaryBackwardOpType::ADDALPHA_BW>>("ttnn::addalpha_bw");
 
-//OpHandler_binary_bw_float : get_function_binary_bw_float
-constexpr auto subalpha_bw = ttnn::register_operation<operations::binary_backward::ExecuteBinaryBackwardFloat<operations::binary_backward::BinaryBackwardOpType::SUBALPHA_BW>>("ttnn::subalpha_bw");
+//OpHandler_binary_bw_float_default : get_function_binary_bw_float_default
+constexpr auto subalpha_bw = ttnn::register_operation<operations::binary_backward::ExecuteBinaryBackwardFloatDefault<operations::binary_backward::BinaryBackwardOpType::SUBALPHA_BW>>("ttnn::subalpha_bw");
 
 //OpHandler_binary_bw_int_default : get_function_binary_bw_int_default
 constexpr auto concat_bw = ttnn::register_operation<operations::binary_backward::ExecuteBinaryBackwardIntDefault<operations::binary_backward::BinaryBackwardOpType::CONCAT_BW>>("ttnn::concat_bw");
+
+//OpHandler_binary_bw_float : get_function_binary_bw_float
+constexpr auto lerp_bw = ttnn::register_operation<operations::binary_backward::ExecuteBinaryBackwardFloat<operations::binary_backward::BinaryBackwardOpType::LERP_BW>>("ttnn::lerp_bw");
 
 //type 1
 constexpr auto xlogy_bw = ttnn::register_operation<operations::binary_backward::ExecuteBinaryBackward<operations::binary_backward::BinaryBackwardOpType::XLOGY_BW>>("ttnn::xlogy_bw");
@@ -238,8 +264,5 @@ constexpr auto logaddexp2_bw = ttnn::register_operation<operations::binary_backw
 constexpr auto squared_difference_bw = ttnn::register_operation<operations::binary_backward::ExecuteBinaryBackward<operations::binary_backward::BinaryBackwardOpType::SQUARED_DIFFERENCE_BW>>("ttnn::squared_difference_bw");
 constexpr auto min_bw = ttnn::register_operation<operations::binary_backward::ExecuteBinaryBackward<operations::binary_backward::BinaryBackwardOpType::MIN_BW>>("ttnn::min_bw");
 constexpr auto max_bw = ttnn::register_operation<operations::binary_backward::ExecuteBinaryBackward<operations::binary_backward::BinaryBackwardOpType::MAX_BW>>("ttnn::max_bw");
-constexpr auto lerp_bw = ttnn::register_operation<operations::binary_backward::ExecuteBinaryBackward<operations::binary_backward::BinaryBackwardOpType::LERP_BW>>("ttnn::lerp_bw");
-
-//type 2
 
 }  // namespace ttnn

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_backward/binary_backward.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_backward/binary_backward.hpp
@@ -169,19 +169,6 @@ struct ExecuteBinaryBackward {
         return op_type(grad_tensor_arg, input_tensor_a_arg, input_tensor_b_arg, memory_config);
         }
 
-        // Type 1: Type 1 with 1 float
-
-        static std::vector<ttnn::Tensor> execute_on_worker_thread(
-            const Tensor &grad_tensor_arg,
-            const Tensor &input_tensor_a_arg,
-            float alpha,
-            const Tensor &input_tensor_b_arg,
-            const std::optional<MemoryConfig> &memory_config = std::nullopt) {
-            auto op_type = BinaryBackwardFunction::get_function_type1_w_float(binary_backward_op_type);
-            auto output_memory_config = memory_config.value_or(input_tensor_a_arg.memory_config());
-            return op_type(grad_tensor_arg, input_tensor_a_arg, input_tensor_b_arg, alpha, output_memory_config);
-        }
-
         // Type 1: Type 1 with 1 string
         static std::vector<ttnn::Tensor> execute_on_worker_thread(
             const Tensor &grad_tensor_arg,

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_backward/binary_backward.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_backward/binary_backward.hpp
@@ -15,7 +15,7 @@ namespace operations::binary_backward {
 
 //OpHandler_binary_bw : get_function_binary_bw
 template <BinaryBackwardOpType binary_backward_op_type>
-struct ExecuteBinaryBackwardType1 {
+struct ExecuteBinaryBackwardTensor {
 
     static inline std::vector<ttnn::Tensor> create_async_output_tensors(
         const std::vector<Tensor> &input_tensors, const std::vector<std::optional<const Tensor>>& optional_inputs) {
@@ -24,7 +24,6 @@ struct ExecuteBinaryBackwardType1 {
                                             Tensor(operation::get_workers_for_op_output({input_tensor}))};
     }
 
-    //Type 1: 1 inputs, 1 grad tensor, 1 float, 1 default string
     static std::vector<Tensor> execute_on_main_thread(
         const Tensor &grad_tensor_arg,
         const Tensor &input_tensor_a_arg,
@@ -82,7 +81,7 @@ struct ExecuteBinaryBackwardOptionalFloatDefault {
 
 //OpHandler_binary_bw_float : get_function_binary_bw_float
 template <BinaryBackwardOpType binary_backward_op_type>
-struct ExecuteBinaryBackwardType1Float {
+struct ExecuteBinaryBackwardFloat {
 
     static inline std::vector<ttnn::Tensor> create_async_output_tensors(
         const std::vector<Tensor> &input_tensors, const std::vector<std::optional<const Tensor>>& optional_inputs) {
@@ -91,7 +90,6 @@ struct ExecuteBinaryBackwardType1Float {
                                             Tensor(operation::get_workers_for_op_output({input_tensor}))};
     }
 
-    //Type 1: 1 inputs, 1 grad tensor, 1 float, 1 default string
     static std::vector<Tensor> execute_on_main_thread(
         const Tensor &grad_tensor_arg,
         const Tensor &input_tensor_a_arg,
@@ -103,6 +101,30 @@ struct ExecuteBinaryBackwardType1Float {
         return op_type(grad_tensor_arg, input_tensor_a_arg, input_tensor_b_arg, parameter, output_memory_config);
         }
 };
+
+//OpHandler_binary_bw_int_default : get_function_binary_bw_int_default
+template <BinaryBackwardOpType binary_backward_op_type>
+struct ExecuteBinaryBackwardIntDefault {
+
+    static inline std::vector<ttnn::Tensor> create_async_output_tensors(
+        const std::vector<Tensor> &input_tensors, const std::vector<std::optional<const Tensor>>& optional_inputs) {
+        const auto& input_tensor = input_tensors.at(0);
+        return {Tensor(operation::get_workers_for_op_output({input_tensor})),
+                                            Tensor(operation::get_workers_for_op_output({input_tensor}))};
+    }
+
+    static std::vector<Tensor> execute_on_main_thread(
+        const Tensor &grad_tensor_arg,
+        const Tensor &input_tensor_a_arg,
+        const Tensor &input_tensor_b_arg,
+        int parameter,
+        const std::optional<MemoryConfig> &memory_config = std::nullopt) {
+        auto op_type = get_function_binary_bw_int_default<binary_backward_op_type>();
+        auto output_memory_config = memory_config.value_or(input_tensor_a_arg.memory_config());
+        return op_type(grad_tensor_arg, input_tensor_a_arg, input_tensor_b_arg, parameter, output_memory_config);
+        }
+};
+
 template <BinaryBackwardOpType binary_backward_op_type>
 struct ExecuteBinaryBackward {
     static inline std::vector<ttnn::Tensor> create_async_output_tensors(
@@ -194,15 +216,18 @@ struct ExecuteBinaryBackward {
 }  // operations::binary
 
 //OpHandler_binary_bw : get_function_binary_bw
-constexpr auto atan2_bw = ttnn::register_operation<operations::binary_backward::ExecuteBinaryBackwardType1<operations::binary_backward::BinaryBackwardOpType::ATAN2_BW>>("ttnn::atan2_bw");
-constexpr auto rsub_bw = ttnn::register_operation<operations::binary_backward::ExecuteBinaryBackwardType1<operations::binary_backward::BinaryBackwardOpType::RSUB_BW>>("ttnn::rsub_bw");
-constexpr auto embedding_bw = ttnn::register_operation<operations::binary_backward::ExecuteBinaryBackwardType1<operations::binary_backward::BinaryBackwardOpType::EMBEDDING_BW>>("ttnn::embedding_bw");
+constexpr auto atan2_bw = ttnn::register_operation<operations::binary_backward::ExecuteBinaryBackwardTensor<operations::binary_backward::BinaryBackwardOpType::ATAN2_BW>>("ttnn::atan2_bw");
+constexpr auto rsub_bw = ttnn::register_operation<operations::binary_backward::ExecuteBinaryBackwardTensor<operations::binary_backward::BinaryBackwardOpType::RSUB_BW>>("ttnn::rsub_bw");
+constexpr auto embedding_bw = ttnn::register_operation<operations::binary_backward::ExecuteBinaryBackwardTensor<operations::binary_backward::BinaryBackwardOpType::EMBEDDING_BW>>("ttnn::embedding_bw");
 
 //OpHandler_binary_bw_opt_float_default : get_function_binary_bw_opt_float_default
 constexpr auto addalpha_bw = ttnn::register_operation<operations::binary_backward::ExecuteBinaryBackwardOptionalFloatDefault<operations::binary_backward::BinaryBackwardOpType::ADDALPHA_BW>>("ttnn::addalpha_bw");
 
 //OpHandler_binary_bw_float : get_function_binary_bw_float
-constexpr auto subalpha_bw = ttnn::register_operation<operations::binary_backward::ExecuteBinaryBackwardType1Float<operations::binary_backward::BinaryBackwardOpType::SUBALPHA_BW>>("ttnn::subalpha_bw");
+constexpr auto subalpha_bw = ttnn::register_operation<operations::binary_backward::ExecuteBinaryBackwardFloat<operations::binary_backward::BinaryBackwardOpType::SUBALPHA_BW>>("ttnn::subalpha_bw");
+
+//OpHandler_binary_bw_int_default : get_function_binary_bw_int_default
+constexpr auto concat_bw = ttnn::register_operation<operations::binary_backward::ExecuteBinaryBackwardIntDefault<operations::binary_backward::BinaryBackwardOpType::CONCAT_BW>>("ttnn::concat_bw");
 
 //type 1
 constexpr auto xlogy_bw = ttnn::register_operation<operations::binary_backward::ExecuteBinaryBackward<operations::binary_backward::BinaryBackwardOpType::XLOGY_BW>>("ttnn::xlogy_bw");
@@ -211,7 +236,6 @@ constexpr auto ldexp_bw = ttnn::register_operation<operations::binary_backward::
 constexpr auto logaddexp_bw = ttnn::register_operation<operations::binary_backward::ExecuteBinaryBackward<operations::binary_backward::BinaryBackwardOpType::LOGADDEXP_BW>>("ttnn::logaddexp_bw");
 constexpr auto logaddexp2_bw = ttnn::register_operation<operations::binary_backward::ExecuteBinaryBackward<operations::binary_backward::BinaryBackwardOpType::LOGADDEXP2_BW>>("ttnn::logaddexp2_bw");
 constexpr auto squared_difference_bw = ttnn::register_operation<operations::binary_backward::ExecuteBinaryBackward<operations::binary_backward::BinaryBackwardOpType::SQUARED_DIFFERENCE_BW>>("ttnn::squared_difference_bw");
-constexpr auto concat_bw = ttnn::register_operation<operations::binary_backward::ExecuteBinaryBackward<operations::binary_backward::BinaryBackwardOpType::CONCAT_BW>>("ttnn::concat_bw");
 constexpr auto min_bw = ttnn::register_operation<operations::binary_backward::ExecuteBinaryBackward<operations::binary_backward::BinaryBackwardOpType::MIN_BW>>("ttnn::min_bw");
 constexpr auto max_bw = ttnn::register_operation<operations::binary_backward::ExecuteBinaryBackward<operations::binary_backward::BinaryBackwardOpType::MAX_BW>>("ttnn::max_bw");
 constexpr auto lerp_bw = ttnn::register_operation<operations::binary_backward::ExecuteBinaryBackward<operations::binary_backward::BinaryBackwardOpType::LERP_BW>>("ttnn::lerp_bw");

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_backward/binary_backward_pybind.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_backward/binary_backward_pybind.hpp
@@ -358,23 +358,6 @@ Example:
                const ttnn::Tensor& grad_tensor,
                const ttnn::Tensor& input_tensor_a,
                const ttnn::Tensor& input_tensor_b,
-               const float alpha,
-               const std::optional<ttnn::MemoryConfig>& memory_config) -> std::vector<ttnn::Tensor> {
-                return self(grad_tensor, input_tensor_a, alpha, input_tensor_b, memory_config);
-            },
-            py::arg("grad_tensor"),
-            py::arg("input_tensor_a"),
-            py::arg("input_tensor_b"),
-            py::arg("alpha"),
-            py::kw_only(),
-            py::arg("memory_config") = std::nullopt},
-
-
-        ttnn::pybind_overload_t{
-            [](const binary_backward_operation_t& self,
-               const ttnn::Tensor& grad_tensor,
-               const ttnn::Tensor& input_tensor_a,
-               const ttnn::Tensor& input_tensor_b,
                const string mode,
                const std::optional<ttnn::MemoryConfig>& memory_config) -> std::vector<ttnn::Tensor> {
                 return self(grad_tensor, input_tensor_a, mode, input_tensor_b, memory_config);

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_backward/device/binary_backward_op.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_backward/device/binary_backward_op.cpp
@@ -636,16 +636,6 @@ std::function<std::vector<ttnn::Tensor>(const Tensor&, const Tensor&, const Tens
     }
 }
 
-std::function<std::vector<Tensor>(const Tensor&, const Tensor&, const Tensor&, float, const MemoryConfig&)> BinaryBackwardFunction::get_function_type1_w_float(BinaryBackwardOpType OpType){
-    switch (OpType) {
-        case BinaryBackwardOpType::LERP_BW:
-            return _lerp_bw;
-        default:
-            TT_ASSERT(false && "Undefined op type");
-            return 0;
-    }
-}
-
 std::function<std::vector<ttnn::Tensor>(const Tensor&, const Tensor&, const Tensor&, std::string, const MemoryConfig&)> BinaryBackwardFunction::get_function_type1_w_string(BinaryBackwardOpType OpType){
     switch (OpType) {
         case BinaryBackwardOpType::BIAS_GELU_BW:

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_backward/device/binary_backward_op.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_backward/device/binary_backward_op.cpp
@@ -514,7 +514,7 @@ std::vector<Tensor> _div_bw(
 
 // lerp(input, end, weight) = self: grad * (1 - weight), end: grad * weight
 std::vector<Tensor> _lerp_bw(
-    const Tensor& grad, const Tensor& input, const Tensor& end, float weight, const MemoryConfig& output_mem_config) {
+    const Tensor& grad, const Tensor& input, const Tensor& end, float weight, const std::optional<MemoryConfig>& output_mem_config) {
     std::vector<Tensor> grad_tensor;
     float sub_scalar = 1.0f - weight;
     Tensor result_1 = ttnn::multiply(grad, sub_scalar, std::nullopt, output_mem_config);
@@ -638,8 +638,6 @@ std::function<std::vector<ttnn::Tensor>(const Tensor&, const Tensor&, const Tens
 
 std::function<std::vector<Tensor>(const Tensor&, const Tensor&, const Tensor&, float, const MemoryConfig&)> BinaryBackwardFunction::get_function_type1_w_float(BinaryBackwardOpType OpType){
     switch (OpType) {
-        case BinaryBackwardOpType::CONCAT_BW:
-            return _concat_bw;
         case BinaryBackwardOpType::LERP_BW:
             return _lerp_bw;
         default:

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_backward/device/binary_backward_op.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_backward/device/binary_backward_op.cpp
@@ -339,7 +339,7 @@ std::vector<Tensor> _assign_bw(
 }
 
 std::vector<Tensor> _concat_bw(
-    const Tensor& grad, const Tensor& input, const Tensor& other, int dim, const MemoryConfig& output_mem_config) {
+    const Tensor& grad, const Tensor& input, const Tensor& other, int dim, const std::optional<MemoryConfig>& output_mem_config) {
     std::vector<Tensor> grad_tensor;
     std::vector<uint32_t> start_index = {0, 0, 0, 0};
     std::vector<uint32_t> end_index = {

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_backward/device/binary_backward_op.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_backward/device/binary_backward_op.hpp
@@ -58,6 +58,9 @@ std::vector<Tensor> _embedding_bw( const Tensor& grad, const Tensor& input, cons
 //OpHandler_binary_bw_float : get_function_binary_bw_float
 std::vector<ttnn::Tensor> _subalpha_bw( const Tensor& grad, const Tensor& input, const Tensor& other, float alpha = 1.0f, const std::optional<MemoryConfig>& output_mem_config = std::nullopt);
 
+//OpHandler_binary_bw_int_default : get_function_binary_bw_int_default
+std::vector<ttnn::Tensor> _concat_bw( const Tensor& grad, const Tensor& input, const Tensor& other, int dim = 0, const std::optional<MemoryConfig>& output_mem_config = std::nullopt);
+
 //OpHandler_binary_bw_opt_float_default : get_function_binary_bw_opt_float_default
 std::vector<std::optional<ttnn::Tensor>> _addalpha_bw( uint8_t queue_id, const Tensor& grad, const Tensor& input, const Tensor& other, float alpha = 1.0f, const std::optional<MemoryConfig>& output_mem_config = std::nullopt, const std::vector<bool>& are_required_outputs = std::vector<bool>{true, true}, std::optional<Tensor> input_grad = std::nullopt, std::optional<Tensor> other_grad = std::nullopt);
 
@@ -70,6 +73,9 @@ struct OpHandler_binary_bw_opt_float_default;
 
 template <BinaryBackwardOpType OpType>
 struct OpHandler_binary_bw_float;
+
+template <BinaryBackwardOpType OpType>
+struct OpHandler_binary_bw_int_default;
 
 template <>
 struct OpHandler_binary_bw<BinaryBackwardOpType::ATAN2_BW> {
@@ -106,6 +112,13 @@ struct OpHandler_binary_bw_float<BinaryBackwardOpType::SUBALPHA_BW> {
     }
 };
 
+template <>
+struct OpHandler_binary_bw_int_default<BinaryBackwardOpType::CONCAT_BW> {
+    static std::vector<Tensor> handle( const Tensor& grad, const Tensor& input, const Tensor& other, int dim, const std::optional<MemoryConfig>& output_mem_config ) {
+        return _concat_bw(grad, input, other, dim, output_mem_config);
+    }
+};
+
 // Template functions to get the function pointers
 template <BinaryBackwardOpType OpType>
 auto get_function_binary_bw() {
@@ -122,4 +135,8 @@ auto get_function_binary_bw_float() {
     return &OpHandler_binary_bw_float<OpType>::handle;
 }
 
+template <BinaryBackwardOpType OpType>
+auto get_function_binary_bw_int_default() {
+    return &OpHandler_binary_bw_int_default<OpType>::handle;
+}
 }  // namespace ttnn::operations::binary_backward

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_backward/device/binary_backward_op.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_backward/device/binary_backward_op.hpp
@@ -55,8 +55,11 @@ std::vector<Tensor> _atan2_bw( const Tensor& grad, const Tensor& input, const Te
 std::vector<Tensor> _rsub_bw( const Tensor& grad, const Tensor& input, const Tensor& other, const std::optional<MemoryConfig>& output_mem_config);
 std::vector<Tensor> _embedding_bw( const Tensor& grad, const Tensor& input, const Tensor& other, const std::optional<MemoryConfig>& output_mem_config);
 
-//OpHandler_binary_bw_float : get_function_binary_bw_float
+//OpHandler_binary_bw_float_default : get_function_binary_bw_float_default
 std::vector<ttnn::Tensor> _subalpha_bw( const Tensor& grad, const Tensor& input, const Tensor& other, float alpha = 1.0f, const std::optional<MemoryConfig>& output_mem_config = std::nullopt);
+
+//OpHandler_binary_bw_float : get_function_binary_bw_float
+std::vector<ttnn::Tensor> _lerp_bw( const Tensor& grad, const Tensor& input, const Tensor& other, float weight , const std::optional<MemoryConfig>& output_mem_config);
 
 //OpHandler_binary_bw_int_default : get_function_binary_bw_int_default
 std::vector<ttnn::Tensor> _concat_bw( const Tensor& grad, const Tensor& input, const Tensor& other, int dim = 0, const std::optional<MemoryConfig>& output_mem_config = std::nullopt);
@@ -72,10 +75,13 @@ template <BinaryBackwardOpType OpType>
 struct OpHandler_binary_bw_opt_float_default;
 
 template <BinaryBackwardOpType OpType>
-struct OpHandler_binary_bw_float;
+struct OpHandler_binary_bw_float_default;
 
 template <BinaryBackwardOpType OpType>
 struct OpHandler_binary_bw_int_default;
+
+template <BinaryBackwardOpType OpType>
+struct OpHandler_binary_bw_float;
 
 template <>
 struct OpHandler_binary_bw<BinaryBackwardOpType::ATAN2_BW> {
@@ -106,7 +112,7 @@ struct OpHandler_binary_bw<BinaryBackwardOpType::EMBEDDING_BW> {
 };
 
 template <>
-struct OpHandler_binary_bw_float<BinaryBackwardOpType::SUBALPHA_BW> {
+struct OpHandler_binary_bw_float_default<BinaryBackwardOpType::SUBALPHA_BW> {
     static std::vector<Tensor> handle( const Tensor& grad, const Tensor& input, const Tensor& other, float alpha, const std::optional<MemoryConfig>& output_mem_config ) {
         return _subalpha_bw(grad, input, other, alpha, output_mem_config);
     }
@@ -116,6 +122,13 @@ template <>
 struct OpHandler_binary_bw_int_default<BinaryBackwardOpType::CONCAT_BW> {
     static std::vector<Tensor> handle( const Tensor& grad, const Tensor& input, const Tensor& other, int dim, const std::optional<MemoryConfig>& output_mem_config ) {
         return _concat_bw(grad, input, other, dim, output_mem_config);
+    }
+};
+
+template <>
+struct OpHandler_binary_bw_float<BinaryBackwardOpType::LERP_BW> {
+    static std::vector<Tensor> handle( const Tensor& grad, const Tensor& input, const Tensor& other, float weight, const std::optional<MemoryConfig>& output_mem_config ) {
+        return _lerp_bw(grad, input, other, weight, output_mem_config);
     }
 };
 
@@ -131,12 +144,17 @@ auto get_function_binary_bw_opt_float_default() {
 }
 
 template <BinaryBackwardOpType OpType>
-auto get_function_binary_bw_float() {
-    return &OpHandler_binary_bw_float<OpType>::handle;
+auto get_function_binary_bw_float_default() {
+    return &OpHandler_binary_bw_float_default<OpType>::handle;
 }
 
 template <BinaryBackwardOpType OpType>
 auto get_function_binary_bw_int_default() {
     return &OpHandler_binary_bw_int_default<OpType>::handle;
+}
+
+template <BinaryBackwardOpType OpType>
+auto get_function_binary_bw_float() {
+    return &OpHandler_binary_bw_float<OpType>::handle;
 }
 }  // namespace ttnn::operations::binary_backward

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_backward/device/binary_backward_op.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_backward/device/binary_backward_op.hpp
@@ -44,7 +44,6 @@ enum class BinaryBackwardOpType {
 };
 struct BinaryBackwardFunction{
 static std::function<std::vector<ttnn::Tensor>(const Tensor&, const Tensor&, const Tensor&, const MemoryConfig&)> get_function_type1(BinaryBackwardOpType OpType); //get_function_binary_bw
-static std::function<std::vector<ttnn::Tensor>(const Tensor&, const Tensor&, const Tensor&, float, const MemoryConfig&)> get_function_type1_w_float(BinaryBackwardOpType OpType);
 static std::function<std::vector<ttnn::Tensor>(const Tensor&, const Tensor&, const Tensor&, std::string, const MemoryConfig&)> get_function_type1_w_string(BinaryBackwardOpType OpType);
 static std::function<std::vector<std::optional<ttnn::Tensor>>(uint8_t , const Tensor&, const Tensor&, const Tensor&, const MemoryConfig&, const std::vector<bool>&, std::optional<Tensor>, std::optional<Tensor>)> get_function_type3(BinaryBackwardOpType OpType);
 static std::function<std::vector<std::optional<ttnn::Tensor>>(const Tensor&, const Tensor&, const Tensor&, const MemoryConfig&, const std::vector<bool>&, std::optional<Tensor>, std::optional<Tensor>)> get_function_type3_wo_qid(BinaryBackwardOpType OpType);

--- a/ttnn/ttnn/operations/binary_backward.py
+++ b/ttnn/ttnn/operations/binary_backward.py
@@ -72,11 +72,14 @@ def _golden_function_backward(torch_op, grad_tensor, input_tensor_a, input_tenso
 
 
 def _golden_function_backward_with_dim(
-    torch_op, grad_tensor, input_tensor_a, input_tensor_b, dimension, *args, **kwargs
+    torch_op, grad_tensor, input_tensor_a, input_tensor_b, dimension=None, *args, **kwargs
 ):
     input_tensor_a.retain_grad()
     input_tensor_b.retain_grad()
-    pyt_y = torch.cat((input_tensor_a, input_tensor_b), dim=dimension)
+    if dimension == None:
+        pyt_y = torch.cat((input_tensor_a, input_tensor_b))
+    else:
+        pyt_y = torch.cat((input_tensor_a, input_tensor_b), dim=dimension)
     pyt_y.backward(gradient=grad_tensor)
     golden_tensor = [input_tensor_a.grad, input_tensor_b.grad]
     return golden_tensor
@@ -217,7 +220,7 @@ ttnn.attach_golden_function(
 
 ttnn.attach_golden_function(
     ttnn.concat_bw,
-    golden_function=lambda grad, a, b, dimension, *args, **kwargs: _golden_function_backward_with_dim(
+    golden_function=lambda grad, a, b, dimension=None, *args, **kwargs: _golden_function_backward_with_dim(
         torch.cat, grad, a, b, dimension, *args, **kwargs
     ),
 )


### PR DESCRIPTION
Work done:

- Remove `std::function` for
  - `concat_bw`
    - Update golden function in test file
    - Check default value 
  - `lerp_bw`
- Rename struct names as mentioned
- Remove `get_function_type1_w_float`