### PR TITLE
#10137: Move remaining binary composite ops to ttnn

### DIFF
--- a/docs/source/ttnn/ttnn/api.rst
+++ b/docs/source/ttnn/ttnn/api.rst
@@ -276,6 +276,11 @@ Pointwise Binary
    ttnn/subalpha
    ttnn/multiply
    ttnn/subtract
+   ttnn/div
+   ttnn/div_no_nan
+   ttnn/floor_div
+   ttnn/binary_remainder
+   ttnn/binary_fmod
    ttnn/pow
    ttnn/ldexp
    ttnn/logical_and

--- a/docs/source/ttnn/ttnn/ttnn/binary_fmod.rst
+++ b/docs/source/ttnn/ttnn/ttnn/binary_fmod.rst
@@ -1,0 +1,6 @@
+.. _ttnn.binary_fmod:
+
+ttnn.binary_fmod
+################
+
+.. autofunction:: ttnn.binary_fmod

--- a/docs/source/ttnn/ttnn/ttnn/binary_remainder.rst
+++ b/docs/source/ttnn/ttnn/ttnn/binary_remainder.rst
@@ -1,0 +1,6 @@
+.. _ttnn.binary_remainder:
+
+ttnn.binary_remainder
+#####################
+
+.. autofunction:: ttnn.binary_remainder

--- a/docs/source/ttnn/ttnn/ttnn/div.rst
+++ b/docs/source/ttnn/ttnn/ttnn/div.rst
@@ -1,0 +1,6 @@
+.. _ttnn.div:
+
+ttnn.div
+########
+
+.. autofunction:: ttnn.div

--- a/docs/source/ttnn/ttnn/ttnn/div_no_nan.rst
+++ b/docs/source/ttnn/ttnn/ttnn/div_no_nan.rst
@@ -1,0 +1,6 @@
+.. _ttnn.div_no_nan:
+
+ttnn.div_no_nan
+###############
+
+.. autofunction:: ttnn.div_no_nan

--- a/docs/source/ttnn/ttnn/ttnn/floor_div.rst
+++ b/docs/source/ttnn/ttnn/ttnn/floor_div.rst
@@ -1,0 +1,6 @@
+.. _ttnn.floor_div:
+
+ttnn.floor_div
+##############
+
+.. autofunction:: ttnn.floor_div

--- a/tests/ttnn/unit_tests/operations/test_binary_composite.py
+++ b/tests/ttnn/unit_tests/operations/test_binary_composite.py
@@ -6,6 +6,7 @@ import torch
 import pytest
 import ttnn
 from tests.ttnn.unit_tests.operations.backward.utility_funcs import data_gen_with_range, compare_pcc
+from models.utility_functions import is_grayskull, skip_for_grayskull
 
 
 @pytest.mark.parametrize(
@@ -209,6 +210,182 @@ def test_binary_subalpha_ttnn(input_shapes, alpha, device):
     output_tensor = ttnn.subalpha(input_tensor1, input_tensor2, alpha)
     golden_function = ttnn.get_golden_function(ttnn.subalpha)
     golden_tensor = golden_function(in_data1, in_data2, alpha)
+
+    comp_pass = compare_pcc([output_tensor], [golden_tensor])
+    assert comp_pass
+
+
+@pytest.mark.parametrize("accurate_mode", [False, True])
+@pytest.mark.parametrize("round_mode", ["None", "trunc", "floor"])
+@pytest.mark.parametrize(
+    "input_shapes",
+    (
+        (torch.Size([1, 1, 32, 32])),
+        (torch.Size([1, 1, 320, 384])),
+        (torch.Size([1, 3, 320, 384])),
+    ),
+)
+def test_binary_div_ttnn(accurate_mode, round_mode, input_shapes, device):
+    if is_grayskull():
+        if round_mode in ["trunc", "floor"]:
+            pytest.skip("does not work for Grayskull -skipping")
+    if accurate_mode == False:  # If input_b is non-zero tensor
+        in_data1, input_tensor1 = data_gen_with_range(input_shapes, -100, 100, device)
+        in_data2, input_tensor2 = data_gen_with_range(input_shapes, -150, -1, device)
+    else:
+        in_data1, input_tensor1 = data_gen_with_range(input_shapes, -100, 100, device)
+        in_data2, input_tensor2 = data_gen_with_range(input_shapes, -100, 100, device)
+
+    output_tensor = ttnn.div(input_tensor1, input_tensor2, accurate_mode=accurate_mode, round_mode=round_mode)
+    golden_function = ttnn.get_golden_function(ttnn.div)
+    golden_tensor = golden_function(in_data1, in_data2, round_mode)
+
+    comp_pass = compare_pcc([output_tensor], [golden_tensor])
+    assert comp_pass
+
+
+@pytest.mark.parametrize("accurate_mode", [False, True])
+@pytest.mark.parametrize("round_mode", ["None", "trunc", "floor"])
+@pytest.mark.parametrize(
+    "input_shapes",
+    (
+        (torch.Size([1, 1, 32, 32])),
+        (torch.Size([1, 1, 320, 384])),
+        (torch.Size([1, 3, 320, 384])),
+    ),
+)
+@pytest.mark.parametrize("value", [-5.1, 0.0, 10.9])
+def test_binary_div_overload_ttnn(accurate_mode, round_mode, input_shapes, value, device):
+    if is_grayskull():
+        if round_mode in ["trunc", "floor"]:
+            pytest.skip("does not work for Grayskull -skipping")
+    in_data1, input_tensor1 = data_gen_with_range(input_shapes, -100, 100, device)
+
+    output_tensor = ttnn.div(input_tensor1, value, accurate_mode=accurate_mode, round_mode=round_mode)
+    golden_function = ttnn.get_golden_function(ttnn.div)
+    golden_tensor = golden_function(in_data1, value, round_mode)
+
+    comp_pass = compare_pcc([output_tensor], [golden_tensor])
+    assert comp_pass
+
+
+@pytest.mark.parametrize(
+    "input_shapes",
+    (
+        (torch.Size([1, 1, 32, 32])),
+        (torch.Size([1, 1, 320, 384])),
+        (torch.Size([1, 3, 320, 384])),
+    ),
+)
+def test_binary_div_no_nan_ttnn(input_shapes, device):
+    in_data1, input_tensor1 = data_gen_with_range(input_shapes, -100, 100, device)
+    in_data2, input_tensor2 = data_gen_with_range(input_shapes, -150, 150, device)
+
+    output_tensor = ttnn.div_no_nan(input_tensor1, input_tensor2)
+    golden_function = ttnn.get_golden_function(ttnn.div_no_nan)
+    golden_tensor = golden_function(in_data1, in_data2)
+
+    comp_pass = compare_pcc([output_tensor], [golden_tensor])
+    assert comp_pass
+
+
+@pytest.mark.parametrize(
+    "input_shapes",
+    (
+        (torch.Size([1, 1, 32, 32])),
+        (torch.Size([1, 1, 320, 384])),
+        (torch.Size([1, 3, 320, 384])),
+    ),
+)
+@pytest.mark.parametrize("value", [-5.1, 0.0, 10.9])
+def test_binary_div_no_nan_overload_ttnn(input_shapes, value, device):
+    in_data1, input_tensor1 = data_gen_with_range(input_shapes, -100, 100, device)
+
+    output_tensor = ttnn.div_no_nan(input_tensor1, value)
+    golden_function = ttnn.get_golden_function(ttnn.div_no_nan)
+    golden_tensor = golden_function(in_data1, value)
+
+    comp_pass = compare_pcc([output_tensor], [golden_tensor])
+    assert comp_pass
+
+
+@pytest.mark.parametrize(
+    "input_shapes",
+    (
+        (torch.Size([1, 1, 32, 32])),
+        (torch.Size([1, 1, 320, 384])),
+        (torch.Size([1, 3, 320, 384])),
+    ),
+)
+@skip_for_grayskull("#ToDo: GS implementation needs to be done for Floor")
+def test_binary_floor_div_ttnn(input_shapes, device):
+    in_data1, input_tensor1 = data_gen_with_range(input_shapes, -350, 100, device)
+    in_data2, input_tensor2 = data_gen_with_range(input_shapes, -100, 100, device)
+    output_tensor = ttnn.floor_div(input_tensor1, input_tensor2)
+    golden_function = ttnn.get_golden_function(ttnn.floor_div)
+    golden_tensor = golden_function(in_data1, in_data2)
+
+    comp_pass = compare_pcc([output_tensor], [golden_tensor])
+    assert comp_pass
+
+
+@pytest.mark.parametrize(
+    "input_shapes",
+    (
+        (torch.Size([1, 1, 32, 32])),
+        (torch.Size([1, 1, 320, 384])),
+        (torch.Size([1, 3, 320, 384])),
+    ),
+)
+@pytest.mark.parametrize("value", [-5.1, 0.0, 10.9])
+@skip_for_grayskull("#ToDo: GS implementation needs to be done for Floor")
+def test_binary_floor_div_overload_ttnn(input_shapes, value, device):
+    in_data1, input_tensor1 = data_gen_with_range(input_shapes, -100, 100, device)
+
+    output_tensor = ttnn.floor_div(input_tensor1, value)
+    golden_function = ttnn.get_golden_function(ttnn.floor_div)
+    golden_tensor = golden_function(in_data1, value)
+
+    comp_pass = compare_pcc([output_tensor], [golden_tensor])
+    assert comp_pass
+
+
+@pytest.mark.parametrize(
+    "input_shapes",
+    (
+        (torch.Size([1, 1, 32, 32])),
+        (torch.Size([1, 1, 320, 384])),
+        (torch.Size([1, 3, 320, 384])),
+    ),
+)
+@skip_for_grayskull("#ToDo: GS implementation needs to be done for remainder")
+def test_binary_remainder_ttnn(input_shapes, device):
+    in_data1, input_tensor1 = data_gen_with_range(input_shapes, -150, 150, device)
+    in_data2, input_tensor2 = data_gen_with_range(input_shapes, -100, 100, device)
+    output_tensor = ttnn.binary_remainder(input_tensor1, input_tensor2)
+    golden_function = ttnn.get_golden_function(ttnn.binary_remainder)
+    golden_tensor = golden_function(in_data1, in_data2)
+
+    comp_pass = compare_pcc([output_tensor], [golden_tensor])
+    assert comp_pass
+
+
+@pytest.mark.parametrize(
+    "input_shapes",
+    (
+        (torch.Size([1, 1, 32, 32])),
+        (torch.Size([1, 1, 320, 384])),
+        (torch.Size([1, 3, 320, 384])),
+    ),
+)
+@skip_for_grayskull("#ToDo: GS implementation needs to be done for fmod")
+def test_binary_fmod_ttnn(input_shapes, device):
+    in_data1, input_tensor1 = data_gen_with_range(input_shapes, -150, 150, device)
+    in_data2, input_tensor2 = data_gen_with_range(input_shapes, -100, 100, device)
+
+    output_tensor = ttnn.binary_fmod(input_tensor1, input_tensor2)
+    golden_function = ttnn.get_golden_function(ttnn.binary_fmod)
+    golden_tensor = golden_function(in_data1, in_data2)
 
     comp_pass = compare_pcc([output_tensor], [golden_tensor])
     assert comp_pass

--- a/ttnn/cpp/ttnn/operations/eltwise/binary/binary_pybind.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary/binary_pybind.hpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+// SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -253,6 +253,114 @@ void bind_binary_composite_with_rtol_atol(py::module& module, const binary_opera
             py::arg("memory_config") = std::nullopt});
 }
 
+template <typename binary_operation_t>
+void bind_binary_composite_with_overload(py::module& module, const binary_operation_t& operation, const std::string& description) {
+    auto doc = fmt::format(
+        R"doc({0}(input_tensor_a: ttnn.Tensor, input_tensor_b: ttnn.Tensor, *, memory_config: Optional[ttnn.MemoryConfig] = None) -> ttnn.Tensor
+
+            Args:
+                * :attr:`input_tensor_a`
+                * :attr:`input_tensor_b` (ttnn.Tensor or Number)
+
+            Keyword Args:
+                * :attr:`memory_config` (Optional[ttnn.MemoryConfig]): Memory configuration for the operation.
+
+            Example:
+
+                >>> tensor1 = ttnn.to_device(ttnn.from_torch(torch.tensor((1, 2), dtype=torch.bfloat16)), device)
+                >>> tensor2 = ttnn.to_device(ttnn.from_torch(torch.tensor((0, 1), dtype=torch.bfloat16)), device)
+                >>> output = {1}(tensor1, tensor2/scalar)
+        )doc",
+        operation.base_name(),
+        operation.python_fully_qualified_name(),
+        description);
+
+    bind_registered_operation(
+        module,
+        operation,
+        doc,
+        ttnn::pybind_overload_t{
+            [](const binary_operation_t& self,
+               const Tensor& input_tensor_a,
+               const Tensor& input_tensor_b,
+               const std::optional<MemoryConfig>& memory_config) {
+                    return self(input_tensor_a, input_tensor_b, memory_config);
+                },
+            py::arg("input_tensor_a"),
+            py::arg("input_tensor_b"),
+            py::kw_only(),
+            py::arg("memory_config") = std::nullopt},
+
+        ttnn::pybind_overload_t{
+            [](const binary_operation_t& self,
+               const Tensor& input_tensor_a,
+               float value,
+               const std::optional<MemoryConfig>& memory_config) {
+                    return self(input_tensor_a, value, memory_config);
+                },
+            py::arg("input_tensor_a"),
+            py::arg("value"),
+            py::kw_only(),
+            py::arg("memory_config") = std::nullopt});
+}
+
+template <typename binary_operation_t>
+void bind_div(py::module& module, const binary_operation_t& operation, const std::string& description) {
+    auto doc = fmt::format(
+        R"doc({0}(input_tensor_a: ttnn.Tensor, input_tensor_b: ttnn.Tensor, *, memory_config: Optional[ttnn.MemoryConfig] = None) -> ttnn.Tensor
+            Args:
+                * :attr:`input_tensor_a`
+                * :attr:`input_tensor_b` (ttnn.Tensor or Number)
+                * :attr:`accurate_mode`: ``false`` if input_tensor_b is non-zero, else ``true``.
+                * :attr:`round_mode`
+            Keyword Args:
+                * :attr:`memory_config` (Optional[ttnn.MemoryConfig]): Memory configuration for the operation.
+            Example:
+                >>> tensor1 = ttnn.to_device(ttnn.from_torch(torch.tensor((1, 2), dtype=torch.bfloat16)), device)
+                >>> tensor2 = ttnn.to_device(ttnn.from_torch(torch.tensor((0, 1), dtype=torch.bfloat16)), device)
+                >>> output = {1}(tensor1, tensor2/scalar)
+        )doc",
+        operation.base_name(),
+        operation.python_fully_qualified_name(),
+        description);
+
+    bind_registered_operation(
+        module,
+        operation,
+        doc,
+        ttnn::pybind_overload_t{
+            [](const binary_operation_t& self,
+               const Tensor& input_tensor_a,
+               const Tensor& input_tensor_b,
+               bool accurate_mode,
+               string round_mode,
+               const std::optional<MemoryConfig>& memory_config) {
+                    return self(input_tensor_a, input_tensor_b, accurate_mode, round_mode, memory_config);
+                },
+            py::arg("input_tensor_a"),
+            py::arg("input_tensor_b"),
+            py::kw_only(),
+            py::arg("accurate_mode") = false,
+            py::arg("round_mode") = "None",
+            py::arg("memory_config") = std::nullopt},
+
+        ttnn::pybind_overload_t{
+            [](const binary_operation_t& self,
+               const Tensor& input_tensor_a,
+               float value,
+               bool accurate_mode,
+               string round_mode,
+               const std::optional<MemoryConfig>& memory_config) {
+                    return self(input_tensor_a, value, accurate_mode, round_mode, memory_config);
+                },
+            py::arg("input_tensor_a"),
+            py::arg("value"),
+            py::kw_only(),
+            py::arg("accurate_mode") = false,
+            py::arg("round_mode") = "None",
+            py::arg("memory_config") = std::nullopt});
+}
+
 }  // namespace detail
 
 void py_module(py::module& module) {
@@ -420,6 +528,18 @@ void py_module(py::module& module) {
         R"doc(Compute logical_xor :attr:`input_tensor_a` and :attr:`input_tensor_b` and returns the tensor with the same layout as :attr:`input_tensor_a`
         .. math:: \mathrm{{input\_tensor\_a}}_i || \mathrm{{input\_tensor\_b}}_i)doc");
 
+    detail::bind_binary_composite(
+        module,
+        ttnn::binary_remainder,
+        R"doc(Compute modulus :attr:`input_tensor_a` and :attr:`input_tensor_b` and returns the tensor with the same layout as :attr:`input_tensor_a`
+        .. math:: \mathrm{{input\_tensor\_a}}_i || \mathrm{{input\_tensor\_b}}_i)doc");
+
+    detail::bind_binary_composite(
+        module,
+        ttnn::binary_fmod,
+        R"doc(Compute fmod :attr:`input_tensor_a` and :attr:`input_tensor_b` and returns the tensor with the same layout as :attr:`input_tensor_a`
+        .. math:: \mathrm{{input\_tensor\_a}}_i || \mathrm{{input\_tensor\_b}}_i)doc");
+
     detail::bind_binary_composite_with_alpha(
         module,
         ttnn::addalpha,
@@ -436,6 +556,24 @@ void py_module(py::module& module) {
         module,
         ttnn::isclose,
         R"doc(Compute isclose :attr:`input_tensor_a` and :attr:`input_tensor_b` and returns the tensor with the same layout as :attr:`input_tensor_a`
+        .. math:: \mathrm{{input\_tensor\_a}}_i || \mathrm{{input\_tensor\_b}}_i)doc");
+
+    detail::bind_div(
+        module,
+        ttnn::div,
+        R"doc(Compute div :attr:`input_tensor_a` and :attr:`input_tensor_b` and returns the tensor with the same layout as :attr:`input_tensor_a`
+        .. math:: \mathrm{{input\_tensor\_a}}_i || \mathrm{{input\_tensor\_b}}_i)doc");
+
+    detail::bind_binary_composite_with_overload(
+        module,
+        ttnn::div_no_nan,
+        R"doc(Compute div_no_nan :attr:`input_tensor_a` and :attr:`input_tensor_b` and returns the tensor with the same layout as :attr:`input_tensor_a`
+        .. math:: \mathrm{{input\_tensor\_a}}_i || \mathrm{{input\_tensor\_b}}_i)doc");
+
+    detail::bind_binary_composite_with_overload(
+        module,
+        ttnn::floor_div,
+        R"doc(Compute floor division :attr:`input_tensor_a` and :attr:`input_tensor_b` and returns the tensor with the same layout as :attr:`input_tensor_a`
         .. math:: \mathrm{{input\_tensor\_a}}_i || \mathrm{{input\_tensor\_b}}_i)doc");
 }
 

--- a/ttnn/ttnn/operations/binary.py
+++ b/ttnn/ttnn/operations/binary.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+# SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
 
 # SPDX-License-Identifier: Apache-2.0
 
@@ -263,6 +263,26 @@ def _golden_function_nextafter(input_tensor_a, input_tensor_b, *args, **kwargs):
 ttnn.attach_golden_function(ttnn._ttnn.operations.binary.nextafter, golden_function=_golden_function_nextafter)
 
 
+def _golden_function_binary_remainder(input_tensor_a, input_tensor_b, *args, **kwargs):
+    import torch
+
+    return torch.remainder(input_tensor_a, input_tensor_b)
+
+
+ttnn.attach_golden_function(
+    ttnn._ttnn.operations.binary.binary_remainder, golden_function=_golden_function_binary_remainder
+)
+
+
+def _golden_function_binary_fmod(input_tensor_a, input_tensor_b, *args, **kwargs):
+    import torch
+
+    return torch.fmod(input_tensor_a, input_tensor_b)
+
+
+ttnn.attach_golden_function(ttnn._ttnn.operations.binary.binary_fmod, golden_function=_golden_function_binary_fmod)
+
+
 def _golden_function_isclose(input_tensor_a, input_tensor_b, *args, rtol=1e-05, atol=1e-08, equal_nan=False, **kwargs):
     import torch
 
@@ -270,6 +290,41 @@ def _golden_function_isclose(input_tensor_a, input_tensor_b, *args, rtol=1e-05, 
 
 
 ttnn.attach_golden_function(ttnn._ttnn.operations.binary.isclose, golden_function=_golden_function_isclose)
+
+
+def _golden_function_div(input_tensor_a, input_tensor_b, round_mode, *args, **kwargs):
+    import torch
+
+    if round_mode == "None":
+        return torch.div(input_tensor_a, input_tensor_b, rounding_mode=None)
+    return torch.div(input_tensor_a, input_tensor_b, rounding_mode=round_mode)
+
+
+ttnn.attach_golden_function(ttnn._ttnn.operations.binary.div, golden_function=_golden_function_div)
+
+
+def _golden_function_div_no_nan(input_tensor_a, input_tensor_b, *args, **kwargs):
+    import torch
+
+    if isinstance(input_tensor_b, float):
+        if input_tensor_b == 0:
+            return torch.zeros_like(input_tensor_a)
+        else:
+            return input_tensor_a / input_tensor_b
+    else:
+        return torch.where(input_tensor_b == 0, 0, input_tensor_a / input_tensor_b)
+
+
+ttnn.attach_golden_function(ttnn._ttnn.operations.binary.div_no_nan, golden_function=_golden_function_div_no_nan)
+
+
+def _golden_function_floor_div(input_tensor_a, input_tensor_b, *args, **kwargs):
+    import torch
+
+    return torch.floor_divide(input_tensor_a, input_tensor_b)
+
+
+ttnn.attach_golden_function(ttnn._ttnn.operations.binary.floor_div, golden_function=_golden_function_floor_div)
 
 
 def torch_squared_difference(x, y, *args, **kwargs):


### PR DESCRIPTION
### Ticket
[Link to Github Issue](https://github.com/tenstorrent/tt-metal/issues/10137)

### Problem description

Migrate composite Binary op into ttnn

### What's changed

- [x] div
- [x] div_no_nan
- [x] remainder
- [x] fmod
- [x] floor_div



### Checklist
- [x] Post commit CI passes
- [ ] Model regression CI testing passes (if applicable)
- [ ] New/Existing tests provide coverage for changes
