### PR TITLE
#10385: Migrate Unary forward ops to TTNN

### DIFF
--- a/docs/source/ttnn/ttnn/api.rst
+++ b/docs/source/ttnn/ttnn/api.rst
@@ -131,6 +131,7 @@ Pointwise Unary
    ttnn/log2
    ttnn/log_sigmoid
    ttnn/logical_not
+   ttnn/frac
    ttnn/logit
    ttnn/mish
    ttnn/multigammaln

--- a/docs/source/ttnn/ttnn/api.rst
+++ b/docs/source/ttnn/ttnn/api.rst
@@ -290,6 +290,7 @@ Pointwise Binary
    ttnn/logical_or_
    ttnn/logical_xor_
    ttnn/pow
+   ttnn/rpow
    ttnn/ldexp
    ttnn/logical_and
    ttnn/logical_or

--- a/docs/source/ttnn/ttnn/api.rst
+++ b/docs/source/ttnn/ttnn/api.rst
@@ -109,6 +109,7 @@ Pointwise Unary
    ttnn/gelu
    ttnn/glu
    ttnn/hardshrink
+   ttnn/normalize_global
    ttnn/hardsigmoid
    ttnn/hardswish
    ttnn/hardtanh

--- a/docs/source/ttnn/ttnn/ttnn/frac.rst
+++ b/docs/source/ttnn/ttnn/ttnn/frac.rst
@@ -1,0 +1,6 @@
+.. _ttnn.frac:
+
+ttnn.frac
+#########
+
+.. autofunction:: ttnn.frac

--- a/docs/source/ttnn/ttnn/ttnn/normalize_global.rst
+++ b/docs/source/ttnn/ttnn/ttnn/normalize_global.rst
@@ -1,0 +1,6 @@
+.. _ttnn.normalize_global:
+
+ttnn.normalize_global
+#####################
+
+.. autofunction:: ttnn.normalize_global

--- a/docs/source/ttnn/ttnn/ttnn/rpow.rst
+++ b/docs/source/ttnn/ttnn/ttnn/rpow.rst
@@ -1,0 +1,6 @@
+.. _ttnn.rpow:
+
+ttnn.rpow
+#########
+
+.. autofunction:: ttnn.rpow

--- a/tests/tt_eager/python_api_testing/non_working_unit_tests/wormhole/test_normalize_global.py
+++ b/tests/tt_eager/python_api_testing/non_working_unit_tests/wormhole/test_normalize_global.py
@@ -9,6 +9,7 @@ import random
 import pytest
 import torch
 import tt_lib as ttl
+import ttnn
 
 from tests.tt_eager.python_api_testing.sweep_tests import pytorch_ops
 from tests.tt_eager.python_api_testing.sweep_tests.comparison_funcs import comp_pcc
@@ -21,7 +22,8 @@ def run_normalize_global_test(input_shape, dtype, dlayout, in_mem_config, out_me
     x = torch.Tensor(size=input_shape).uniform_(-100, 100)
 
     # compute ref value
-    ref_value = pytorch_ops.normalize_global(x)
+    golden_function = ttnn.get_golden_function(ttnn.normalize_global)
+    ref_value = golden_function(x)
 
     tt_result = tt_lib_ops.normalize_global(
         x=x,
@@ -42,7 +44,7 @@ def run_normalize_global_test(input_shape, dtype, dlayout, in_mem_config, out_me
 
 test_sweep_args = [
     (
-        (4, 8, 32, 22),
+        (4, 8, 32, 32),
         [ttl.tensor.DataType.BFLOAT16],
         [ttl.tensor.Layout.ROW_MAJOR],
         [
@@ -52,7 +54,7 @@ test_sweep_args = [
         14854324,
     ),
     (
-        (4, 8, 32, 22),
+        (4, 8, 32, 32),
         [ttl.tensor.DataType.BFLOAT16],
         [ttl.tensor.Layout.ROW_MAJOR],
         [
@@ -62,7 +64,7 @@ test_sweep_args = [
         14854324,
     ),
     (
-        (4, 12, 32, 104),
+        (4, 12, 32, 128),
         [ttl.tensor.DataType.BFLOAT16],
         [ttl.tensor.Layout.ROW_MAJOR],
         [
@@ -72,7 +74,7 @@ test_sweep_args = [
         14854324,
     ),
     (
-        (4, 12, 32, 104),
+        (4, 12, 32, 128),
         [ttl.tensor.DataType.BFLOAT16],
         [ttl.tensor.Layout.ROW_MAJOR],
         [

--- a/tests/tt_eager/python_api_testing/sweep_tests/tt_lib_ops.py
+++ b/tests/tt_eager/python_api_testing/sweep_tests/tt_lib_ops.py
@@ -432,6 +432,16 @@ def var_hw(x, *args, device, dtype, layout, input_mem_config, output_mem_config,
 
 
 @setup_host_and_device
+def normalize_global(x, *args, device, dtype, layout, input_mem_config, output_mem_config, **kwargs):
+    t0 = setup_tt_tensor(x, device, layout[0], input_mem_config[0], dtype[0])
+    t1 = ttnn.normalize_global(t0)
+
+    output = tt2torch_tensor(t1)
+
+    return output
+
+
+@setup_host_and_device
 def normalize_hw(x, *args, device, dtype, layout, input_mem_config, output_mem_config, **kwargs):
     t0 = setup_tt_tensor(x, device, layout[0], input_mem_config[0], dtype[0])
     t1 = ttnn.normalize_hw(t0)
@@ -2458,7 +2468,6 @@ def make_unary_op_optional_output_with_fast_approx(ttl_tensor_unop):
 # mean_global = make_unary_op(ttl.tensor.global_mean)
 # var_global = make_unary_op(ttl.tensor.global_var)
 # std_global = make_unary_op(ttl.tensor.global_std)
-normalize_global = make_unary_op(ttl.tensor.normalize_global)
 # eltwise_softmax_in_place = make_unary_op(ttl.tensor.softmax_in_place)
 eltwise_cos = make_unary_op_optional_output(ttnn.cos)
 eltwise_sin = make_unary_op_optional_output(ttnn.sin)

--- a/tests/ttnn/unit_tests/operations/test_composite.py
+++ b/tests/ttnn/unit_tests/operations/test_composite.py
@@ -637,9 +637,26 @@ def test_unary_logical_not_ttnn(input_shapes, device):
 @pytest.mark.parametrize(
     "input_shapes",
     (
-        (torch.Size([1, 1, 32, 64])),
+        (torch.Size([1, 1, 32, 32])),
         (torch.Size([1, 1, 320, 384])),
         (torch.Size([1, 3, 320, 384])),
+    ),
+)
+def test_unary_frac(input_shapes, device):
+    in_data, input_tensor = data_gen_with_range(input_shapes, -1e6, 1e6, device)
+    output_tensor = ttnn.frac(input_tensor)
+    golden_function = ttnn.get_golden_function(ttnn.frac)
+    golden_tensor = golden_function(in_data)
+
+    comp_pass = compare_pcc([output_tensor], [golden_tensor])
+    assert comp_pass
+
+
+@pytest.mark.parametrize(
+    "input_shapes",
+    (
+        (torch.Size([1, 1, 32, 64])),  # Single core
+        (torch.Size([1, 3, 320, 32 * 8])),  # Multi core
     ),
 )
 @pytest.mark.parametrize(

--- a/tests/ttnn/unit_tests/operations/test_composite.py
+++ b/tests/ttnn/unit_tests/operations/test_composite.py
@@ -634,6 +634,7 @@ def test_unary_logical_not_ttnn(input_shapes, device):
     assert comp_pass
 
 
+@skip_for_grayskull("Not supported for Grayskull")
 @pytest.mark.parametrize(
     "input_shapes",
     (

--- a/ttnn/cpp/ttnn/operations/eltwise/binary/device/binary_composite_op.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary/device/binary_composite_op.hpp
@@ -11,6 +11,8 @@
 #include "third_party/magic_enum/magic_enum.hpp"
 #include "ttnn/cpp/ttnn/operations/eltwise/ternary/where_op.hpp"
 #include "ttnn/cpp/ttnn/operations/copy.hpp"
+#include "ttnn/operations/eltwise/unary/unary_composite.hpp"
+
 
 namespace ttnn::operations::binary{
 

--- a/ttnn/cpp/ttnn/operations/eltwise/unary/device/unary_composite_op.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary/device/unary_composite_op.cpp
@@ -447,12 +447,12 @@ Tensor _hardswish(const Tensor& a, float value_1, float value_2, const std::opti
 // Ref: https://pytorch.org/docs/stable/generated/torch.clamp.html#torch.clamp
 Tensor _clip(const Tensor& a, float low, float high, const std::optional<MemoryConfig>& output_mem_config) {
     auto output_memory_config = output_mem_config.value_or(a.memory_config());
-    const Tensor h_const = full_like(a, high);
+    const Tensor h_const = ttnn::full_like(a, high);
     Tensor a_max = tt::tt_metal::min(a, h_const, output_memory_config);
     if (low == 0.0f) {
         return ttnn::relu(a_max, output_memory_config);
     } else {
-        const Tensor l_const = full_like(a, low);
+        const Tensor l_const = ttnn::full_like(a, low);
         return tt::tt_metal::max(a_max, l_const, output_memory_config);
     }
 }
@@ -690,8 +690,8 @@ Tensor _softshrink(const Tensor& a, float param, const std::optional<MemoryConfi
 
 // logit(input, eps)=log(input / 1 - input)
 Tensor _logit(const Tensor& input_a, float eps, const std::optional<MemoryConfig>& output_mem_config) {
-    Tensor t_eps = full_like(input_a, eps);
-    Tensor t1m_eps = full_like(input_a, (1 - eps));
+    Tensor t_eps = ttnn::full_like(input_a, eps);
+    Tensor t1m_eps = ttnn::full_like(input_a, (1 - eps));
     Tensor logit_input = ttnn::where(
         ttnn::ltz(t_eps, output_mem_config),
         input_a,

--- a/ttnn/cpp/ttnn/operations/eltwise/unary/device/unary_composite_op.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary/device/unary_composite_op.cpp
@@ -733,4 +733,14 @@ Tensor _celu(const Tensor& input_a, float alpha, const std::optional<MemoryConfi
 Tensor _logical_not_(const Tensor& x, const std::optional<MemoryConfig>& output_mem_config) {
     return ttnn::logical_not(x, output_mem_config, x);
 }
+
+// rpow: y = k**(a) = exp( a**log(k) )
+Tensor _rpow(const Tensor& a, float k, const std::optional<MemoryConfig>& output_mem_config) {
+    TT_ASSERT(k > 0.0, "rpow cannot be calcualted for non-positive numbers");
+    float log_k = logf(k);
+
+    Tensor result = ttnn::multiply(a, log_k);
+    return ttnn::exp(result, false);
+}
+
 }  // namespace ttnn::operations::unary

--- a/ttnn/cpp/ttnn/operations/eltwise/unary/device/unary_composite_op.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary/device/unary_composite_op.cpp
@@ -767,4 +767,12 @@ Tensor _normalize_global(const Tensor& y,  const std::optional<MemoryConfig>& ou
     return _make_global_from_hw_impl(_normalize, y, output_mem_config);
 }
 
+Tensor _frac(const Tensor& input, const std::optional<MemoryConfig>& output_mem_config) {
+    auto arch = input.device()->arch();
+    TT_FATAL(arch == tt::ARCH::WORMHOLE_B0, "Op is only supported on Wormhole");
+    Tensor trunc_res = trunc(input);
+    Tensor result = ttnn::subtract(input, trunc_res, std::nullopt, output_mem_config);
+    return result;
+}
+
 }  // namespace ttnn::operations::unary

--- a/ttnn/cpp/ttnn/operations/eltwise/unary/device/unary_composite_op.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary/device/unary_composite_op.hpp
@@ -56,8 +56,8 @@ enum class UnaryCompositeOpType {
     LOGIT,
     CELU,
     LOGICAL_NOT_,
+    RPOW,
 };
-
 Tensor _tanhshrink (const Tensor&, const std::optional<MemoryConfig>&);
 Tensor _acosh(const Tensor&, const std::optional<MemoryConfig>&);
 Tensor _asinh(const Tensor&, const std::optional<MemoryConfig>&);
@@ -95,7 +95,6 @@ Tensor _geglu(const Tensor&, int32_t, const std::optional<MemoryConfig>& );
 Tensor _swiglu(const Tensor&, int32_t, const std::optional<MemoryConfig>& );
 Tensor _power(uint8_t, const Tensor&, float, const std::optional<MemoryConfig>&, std::optional<Tensor>);
 Tensor _power(uint8_t, const Tensor&, uint32_t, const std::optional<MemoryConfig>&, std::optional<Tensor>);
-Tensor _rdiv(uint8_t, const Tensor&, float, const std::optional<MemoryConfig>&, std::optional<Tensor>);
 Tensor _tril(const Tensor&, int32_t diag = 0, const std::optional<MemoryConfig>& output_mem_config = std::nullopt);
 Tensor _triu(const Tensor&, int32_t diag = 0, const std::optional<MemoryConfig>& output_mem_config = std::nullopt);
 Tensor _round(const Tensor&, int32_t decimal =0 , const std::optional<MemoryConfig>& output_mem_config = std::nullopt);
@@ -378,7 +377,7 @@ struct OpHandler<UnaryCompositeOpType::HARDSHRINK> {
     static Tensor handle(const Tensor& t1, float lambd, const std::optional<MemoryConfig>& mem_cfg ) {
         return _hardshrink(t1, lambd, mem_cfg);
     }
-};
+}
 
 template <>
 struct OpHandler<UnaryCompositeOpType::SOFTSHRINK> {
@@ -410,4 +409,10 @@ struct OpHandler<UnaryCompositeOpType::LOGICAL_NOT_> {
     }
 };
 
+template <>
+struct OpHandler<UnaryCompositeOpType::RPOW> {
+    static Tensor handle(const Tensor& t1, float param, const std::optional<MemoryConfig>& mem_cfg ) {
+        return _rpow(t1, param, mem_cfg);
+    }
+};
 }

--- a/ttnn/cpp/ttnn/operations/eltwise/unary/device/unary_composite_op.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary/device/unary_composite_op.hpp
@@ -58,6 +58,7 @@ enum class UnaryCompositeOpType {
     LOGICAL_NOT_,
     RPOW,
     NORMALIZE_GLOBAL,
+    FRAC,
 };
 Tensor _tanhshrink (const Tensor&, const std::optional<MemoryConfig>&);
 Tensor _acosh(const Tensor&, const std::optional<MemoryConfig>&);
@@ -98,6 +99,7 @@ Tensor _power(uint8_t, const Tensor&, float, const std::optional<MemoryConfig>&,
 Tensor _power(uint8_t, const Tensor&, uint32_t, const std::optional<MemoryConfig>&, std::optional<Tensor>);
 Tensor _tril(const Tensor&, int32_t diag = 0, const std::optional<MemoryConfig>& output_mem_config = std::nullopt);
 Tensor _triu(const Tensor&, int32_t diag = 0, const std::optional<MemoryConfig>& output_mem_config = std::nullopt);
+Tensor _rdiv(uint8_t, const Tensor&, float, const std::optional<MemoryConfig>&, std::optional<Tensor>);
 Tensor _round(const Tensor&, int32_t decimal =0 , const std::optional<MemoryConfig>& output_mem_config = std::nullopt);
 Tensor _polygamma(const Tensor&, int32_t, const std::optional<MemoryConfig>& );
 Tensor _hardshrink(const Tensor& a, float lambd = 0.5f, const std::optional<MemoryConfig>& output_mem_config = std::nullopt);
@@ -107,6 +109,7 @@ Tensor _celu(const Tensor& a, float alpha = 1.0f, const std::optional<MemoryConf
 Tensor _logical_not_ (const Tensor&, const std::optional<MemoryConfig>&);
 Tensor _rpow(const Tensor& a, float param, const std::optional<MemoryConfig>& );
 Tensor _normalize_global(const Tensor&, const std::optional<MemoryConfig>&);
+Tensor _frac (const Tensor&, const std::optional<MemoryConfig>&);
 
 // OpHandler struct template
 template <UnaryCompositeOpType OpType>
@@ -387,7 +390,7 @@ struct OpHandler<UnaryCompositeOpType::HARDSHRINK> {
     static Tensor handle(const Tensor& t1, float lambd, const std::optional<MemoryConfig>& mem_cfg ) {
         return _hardshrink(t1, lambd, mem_cfg);
     }
-}
+};
 
 template <>
 struct OpHandler<UnaryCompositeOpType::SOFTSHRINK> {
@@ -423,6 +426,13 @@ template <>
 struct OpHandler<UnaryCompositeOpType::RPOW> {
     static Tensor handle(const Tensor& t1, float param, const std::optional<MemoryConfig>& mem_cfg ) {
         return _rpow(t1, param, mem_cfg);
+    }
+};
+
+template <>
+struct OpHandler<UnaryCompositeOpType::FRAC> {
+    static Tensor handle(const Tensor& t1, const std::optional<MemoryConfig>& mem_cfg ) {
+        return _frac(t1, mem_cfg);
     }
 };
 }

--- a/ttnn/cpp/ttnn/operations/eltwise/unary/device/unary_composite_op.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary/device/unary_composite_op.hpp
@@ -57,6 +57,7 @@ enum class UnaryCompositeOpType {
     CELU,
     LOGICAL_NOT_,
     RPOW,
+    NORMALIZE_GLOBAL,
 };
 Tensor _tanhshrink (const Tensor&, const std::optional<MemoryConfig>&);
 Tensor _acosh(const Tensor&, const std::optional<MemoryConfig>&);
@@ -104,6 +105,8 @@ Tensor _softshrink(const Tensor& a, float lambd = 0.5f, const std::optional<Memo
 Tensor _logit(const Tensor& a, float eps = 0.0f, const std::optional<MemoryConfig>& output_mem_config = std::nullopt);
 Tensor _celu(const Tensor& a, float alpha = 1.0f, const std::optional<MemoryConfig>& output_mem_config = std::nullopt);
 Tensor _logical_not_ (const Tensor&, const std::optional<MemoryConfig>&);
+Tensor _rpow(const Tensor& a, float param, const std::optional<MemoryConfig>& );
+Tensor _normalize_global(const Tensor&, const std::optional<MemoryConfig>&);
 
 // OpHandler struct template
 template <UnaryCompositeOpType OpType>
@@ -162,6 +165,13 @@ template <>
 struct OpHandler<UnaryCompositeOpType::COSH> {
     static Tensor handle(const Tensor& t1, const std::optional<MemoryConfig>& mem_cfg ) {
         return _cosh(t1, mem_cfg);
+    }
+};
+
+template <>
+struct OpHandler<UnaryCompositeOpType::NORMALIZE_GLOBAL> {
+    static Tensor handle(const Tensor& t1, const std::optional<MemoryConfig>& mem_cfg ) {
+        return _normalize_global(t1, mem_cfg);
     }
 };
 

--- a/ttnn/cpp/ttnn/operations/eltwise/unary/unary_composite.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary/unary_composite.hpp
@@ -174,20 +174,10 @@ auto transform_first_matching_arg(Lambda lambda, First&& first, Rest&&... rest) 
 
 constexpr auto rdiv = ttnn::register_operation_with_auto_launch_op<"ttnn::rdiv", operations::unary::ExecuteRdiv>();
 
-<<<<<<< HEAD
 constexpr auto pow = ttnn::register_operation_with_auto_launch_op<
     "ttnn::pow",
     operations::unary::ExecutePower>();
 constexpr auto tanhshrink = ttnn::register_operation_with_auto_launch_op<
-=======
-constexpr auto tril = REGISTER_OPERATION_FROM_FUNCTION("ttnn::tril", WRAP_WITH_RESHAPE(ttnn::operations::unary::tril));
-constexpr auto triu = REGISTER_OPERATION_FROM_FUNCTION("ttnn::triu", WRAP_WITH_RESHAPE(ttnn::operations::unary::triu));
-
-<<<<<<< HEAD
-constexpr auto pow = ttnn::register_operation_with_auto_launch_op<"ttnn::pow", ttnn::operations::unary::ExecutePower>();
-
-// newly importedconstexpr auto tanhshrink = ttnn::register_operation_with_auto_launch_op<
->>>>>>> 10385: Migrate normalize_global to TTNN
     "ttnn::tanhshrink",
     operations::unary::ExecuteUnaryCompositeOp<operations::unary::UnaryCompositeOpType::TANHSHRINK>>();
 constexpr auto deg2rad = ttnn::register_operation_with_auto_launch_op<
@@ -316,5 +306,9 @@ constexpr auto rpow = ttnn::register_operation_with_auto_launch_op<
 constexpr auto normalize_global = ttnn::register_operation_with_auto_launch_op<
     "ttnn::normalize_global",
     operations::unary::ExecuteUnaryCompositeOp<operations::unary::UnaryCompositeOpType::NORMALIZE_GLOBAL>>();
+constexpr auto frac = ttnn::register_operation_with_auto_launch_op<
+    "ttnn::frac",
+    operations::unary::ExecuteUnaryCompositeOp<operations::unary::UnaryCompositeOpType::FRAC>>();
+
 
 }  // namespace ttnn

--- a/ttnn/cpp/ttnn/operations/eltwise/unary/unary_composite.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary/unary_composite.hpp
@@ -288,23 +288,20 @@ constexpr auto logit = ttnn::register_operation_with_auto_launch_op<
 constexpr auto celu = ttnn::register_operation_with_auto_launch_op<
     "ttnn::celu",
     operations::unary::ExecuteUnaryCompositeOpWithFloat<operations::unary::UnaryCompositeOpType::CELU>>();
-
-
 constexpr auto tril = ttnn::register_operation_with_auto_launch_op<
     "ttnn::tril",
     operations::unary::ExecuteUnaryCompositeOpWithInt<operations::unary::UnaryCompositeOpType::TRIL>>();
-
 constexpr auto triu = ttnn::register_operation_with_auto_launch_op<
     "ttnn::triu",
     operations::unary::ExecuteUnaryCompositeOpWithInt<operations::unary::UnaryCompositeOpType::TRIU>>();
-
-
 constexpr auto round = ttnn::register_operation_with_auto_launch_op<
     "ttnn::round",
     operations::unary::ExecuteUnaryCompositeOpWithInt<operations::unary::UnaryCompositeOpType::ROUND>>();
-
 constexpr auto polygamma = ttnn::register_operation_with_auto_launch_op<
     "ttnn::polygamma",
     operations::unary::ExecuteUnaryCompositeOpWithInt<operations::unary::UnaryCompositeOpType::POLYGAMMA>>();
+constexpr auto rpow = ttnn::register_operation_with_auto_launch_op<
+    "ttnn::rpow",
+    operations::unary::ExecuteUnaryCompositeOpWithFloat<operations::unary::UnaryCompositeOpType::RPOW>>();
 
 }  // namespace ttnn

--- a/ttnn/cpp/ttnn/operations/eltwise/unary/unary_composite.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary/unary_composite.hpp
@@ -174,10 +174,20 @@ auto transform_first_matching_arg(Lambda lambda, First&& first, Rest&&... rest) 
 
 constexpr auto rdiv = ttnn::register_operation_with_auto_launch_op<"ttnn::rdiv", operations::unary::ExecuteRdiv>();
 
+<<<<<<< HEAD
 constexpr auto pow = ttnn::register_operation_with_auto_launch_op<
     "ttnn::pow",
     operations::unary::ExecutePower>();
 constexpr auto tanhshrink = ttnn::register_operation_with_auto_launch_op<
+=======
+constexpr auto tril = REGISTER_OPERATION_FROM_FUNCTION("ttnn::tril", WRAP_WITH_RESHAPE(ttnn::operations::unary::tril));
+constexpr auto triu = REGISTER_OPERATION_FROM_FUNCTION("ttnn::triu", WRAP_WITH_RESHAPE(ttnn::operations::unary::triu));
+
+<<<<<<< HEAD
+constexpr auto pow = ttnn::register_operation_with_auto_launch_op<"ttnn::pow", ttnn::operations::unary::ExecutePower>();
+
+// newly importedconstexpr auto tanhshrink = ttnn::register_operation_with_auto_launch_op<
+>>>>>>> 10385: Migrate normalize_global to TTNN
     "ttnn::tanhshrink",
     operations::unary::ExecuteUnaryCompositeOp<operations::unary::UnaryCompositeOpType::TANHSHRINK>>();
 constexpr auto deg2rad = ttnn::register_operation_with_auto_launch_op<
@@ -303,5 +313,8 @@ constexpr auto polygamma = ttnn::register_operation_with_auto_launch_op<
 constexpr auto rpow = ttnn::register_operation_with_auto_launch_op<
     "ttnn::rpow",
     operations::unary::ExecuteUnaryCompositeOpWithFloat<operations::unary::UnaryCompositeOpType::RPOW>>();
+constexpr auto normalize_global = ttnn::register_operation_with_auto_launch_op<
+    "ttnn::normalize_global",
+    operations::unary::ExecuteUnaryCompositeOp<operations::unary::UnaryCompositeOpType::NORMALIZE_GLOBAL>>();
 
 }  // namespace ttnn

--- a/ttnn/cpp/ttnn/operations/eltwise/unary/unary_pybind.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary/unary_pybind.hpp
@@ -1280,7 +1280,8 @@ void py_module(py::module& module) {
     detail::bind_unary_composite(module, ttnn::std_hw, R"doc(Performs std_hw function on :attr:`input_tensor`.)doc");
     detail::bind_unary_composite(module, ttnn::normalize_hw, R"doc(Performs normalize_hw function on :attr:`input_tensor`.)doc");
     detail::bind_unary_composite(module, ttnn::logical_not_, R"doc(Performs logical_not inplace function on :attr:`input_tensor`.)doc");
-
+    detail::bind_unary_composite(module, ttnn::normalize_global, R"doc(Performs normalize_global function on :attr:`input_tensor`.)doc");
+    
     detail::bind_unary_composite_floats_with_default(
         module,
         ttnn::hardswish,

--- a/ttnn/cpp/ttnn/operations/eltwise/unary/unary_pybind.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary/unary_pybind.hpp
@@ -985,20 +985,21 @@ void bind_unary_composite_float_with_default(py::module& module, const unary_ope
 template <typename unary_operation_t>
 void bind_unary_composite_float(py::module& module, const unary_operation_t& operation, const std::string& parameter_name_a, const std::string& parameter_a_doc, const std::string& description) {
     auto doc = fmt::format(
-        R"doc({0}(input_tensor: ttnn.Tensor, {2}: float, {4}: float, *, memory_config: ttnn.MemoryConfig) -> std::vector<Tensor>
+        R"doc({0}(input_tensor: ttnn.Tensor, {2}: float, *, memory_config: ttnn.MemoryConfig) -> std::vector<Tensor>
 
-        {5}
+        {4}
 
         Args:
             * :attr:`input_tensor`
+            * :attr:`{2}`
 
         Keyword args:
-            * :attr:`{2}` (float): {3}
             * :attr:`memory_config` [ttnn.MemoryConfig]: memory config for the output tensor
-            
+
         Example:
+
             >>> tensor = ttnn.from_torch(torch.tensor((1, 2), dtype=torch.bfloat16), device=device)
-            >>> output = {1}(tensor, {2}, {4})
+            >>> output = {1}(tensor, {2})
         )doc",
         operation.base_name(),
         operation.python_fully_qualified_name(),
@@ -1014,7 +1015,7 @@ void bind_unary_composite_float(py::module& module, const unary_operation_t& ope
                const ttnn::Tensor& input_tensor,
                float parameter_a,
                const std::optional<MemoryConfig>& memory_config)  {
-                return self(input_tensor, parameter_a,, memory_config);
+                return self(input_tensor, parameter_a, memory_config);
             },
             py::arg("input_tensor"),
             py::arg(parameter_name_a.c_str()),
@@ -1281,7 +1282,8 @@ void py_module(py::module& module) {
     detail::bind_unary_composite(module, ttnn::normalize_hw, R"doc(Performs normalize_hw function on :attr:`input_tensor`.)doc");
     detail::bind_unary_composite(module, ttnn::logical_not_, R"doc(Performs logical_not inplace function on :attr:`input_tensor`.)doc");
     detail::bind_unary_composite(module, ttnn::normalize_global, R"doc(Performs normalize_global function on :attr:`input_tensor`.)doc");
-    
+    detail::bind_unary_composite(module, ttnn::frac, R"doc(Performs frac function on :attr:`input_tensor`.)doc");
+
     detail::bind_unary_composite_floats_with_default(
         module,
         ttnn::hardswish,
@@ -1366,8 +1368,6 @@ void py_module(py::module& module) {
         ttnn::logit,
         "eps", "eps", 0.0f,
         R"doc(Performs logit function on :attr:`input_tensor`, :attr:`eps`. Not available for Wormhole_B0.)doc");
-
-
     detail::bind_unary_composite_float(
         module,
         ttnn::rpow,

--- a/ttnn/cpp/ttnn/operations/eltwise/unary/unary_pybind.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary/unary_pybind.hpp
@@ -983,6 +983,46 @@ void bind_unary_composite_float_with_default(py::module& module, const unary_ope
 }
 
 template <typename unary_operation_t>
+void bind_unary_composite_float(py::module& module, const unary_operation_t& operation, const std::string& parameter_name_a, const std::string& parameter_a_doc, const std::string& description) {
+    auto doc = fmt::format(
+        R"doc({0}(input_tensor: ttnn.Tensor, {2}: float, {4}: float, *, memory_config: ttnn.MemoryConfig) -> std::vector<Tensor>
+
+        {5}
+
+        Args:
+            * :attr:`input_tensor`
+
+        Keyword args:
+            * :attr:`{2}` (float): {3}
+            * :attr:`memory_config` [ttnn.MemoryConfig]: memory config for the output tensor
+            
+        Example:
+            >>> tensor = ttnn.from_torch(torch.tensor((1, 2), dtype=torch.bfloat16), device=device)
+            >>> output = {1}(tensor, {2}, {4})
+        )doc",
+        operation.base_name(),
+        operation.python_fully_qualified_name(),
+        parameter_name_a,
+        parameter_a_doc,
+        description);
+    bind_registered_operation(
+        module,
+        operation,
+        doc,
+        ttnn::pybind_overload_t{
+            [](const unary_operation_t& self,
+               const ttnn::Tensor& input_tensor,
+               float parameter_a,
+               const std::optional<MemoryConfig>& memory_config)  {
+                return self(input_tensor, parameter_a,, memory_config);
+            },
+            py::arg("input_tensor"),
+            py::arg(parameter_name_a.c_str()),
+            py::kw_only(),
+            py::arg("memory_config") = std::nullopt});
+}
+
+template <typename unary_operation_t>
 void bind_unary_operation_with_scale_and_shift(py::module& module, const unary_operation_t& operation) {
     auto doc = fmt::format(
         R"doc({0}(input_tensor: ttnn.Tensor, scale, shift, *, memory_config: Optional[ttnn.MemoryConfig] = None) -> ttnn.Tensor
@@ -1327,6 +1367,11 @@ void py_module(py::module& module) {
         R"doc(Performs logit function on :attr:`input_tensor`, :attr:`eps`. Not available for Wormhole_B0.)doc");
 
 
+    detail::bind_unary_composite_float(
+        module,
+        ttnn::rpow,
+        "exponent", "exponent value",
+        R"doc(Performs rpow function on :attr:`input_tensor`, :attr:`exponent`.)doc");
 }
 
 }  // namespace unary

--- a/ttnn/ttnn/operations/unary.py
+++ b/ttnn/ttnn/operations/unary.py
@@ -626,7 +626,9 @@ def _golden_function_normalize_global(input_tensor_a, *args, **kwargs):
     return input_tensor_a
 
 
-ttnn.attach_golden_function(ttnn._ttnn.operations.unary.normalize_global, golden_function=_golden_function_normalize_global)
+ttnn.attach_golden_function(
+    ttnn._ttnn.operations.unary.normalize_global, golden_function=_golden_function_normalize_global
+)
 
 
 def _golden_function_rpow(input_tensor_a, dim, *args, **kwargs):

--- a/ttnn/ttnn/operations/unary.py
+++ b/ttnn/ttnn/operations/unary.py
@@ -636,4 +636,13 @@ def _golden_function_rpow(input_tensor_a, dim, *args, **kwargs):
 
 
 ttnn.attach_golden_function(ttnn._ttnn.operations.unary.rpow, golden_function=_golden_function_rpow)
+
+
+def _golden_function_frac(input_tensor_a, *args, **kwargs):
+    import torch
+
+    return torch.frac(input_tensor_a)
+
+
+ttnn.attach_golden_function(ttnn._ttnn.operations.unary.frac, golden_function=_golden_function_frac)
 __all__ = []

--- a/ttnn/ttnn/operations/unary.py
+++ b/ttnn/ttnn/operations/unary.py
@@ -614,4 +614,26 @@ def _golden_function_swiglu(input_tensor_a, dim, *args, **kwargs):
 
 
 ttnn.attach_golden_function(ttnn._ttnn.operations.unary.swiglu, golden_function=_golden_function_swiglu)
+
+
+def _golden_function_normalize_global(input_tensor_a, *args, **kwargs):
+    import torch
+
+    mx = torch.mean(input_tensor_a, [0, 1, 2, 3], keepdim=True)
+    sx = torch.std(input_tensor_a, [0, 1, 2, 3], keepdim=True)
+    input_tensor_a = (input_tensor_a - mx) / sx
+
+    return input_tensor_a
+
+
+ttnn.attach_golden_function(ttnn._ttnn.operations.unary.normalize_global, golden_function=_golden_function_normalize_global)
+
+
+def _golden_function_rpow(input_tensor_a, dim, *args, **kwargs):
+    import torch
+
+    return torch.pow(dim, input_tensor_a)
+
+
+ttnn.attach_golden_function(ttnn._ttnn.operations.unary.rpow, golden_function=_golden_function_rpow)
 __all__ = []


### PR DESCRIPTION
Issue : https://github.com/tenstorrent/tt-metal/issues/10385

Work Done:

Migrated 3 Unary ops to TTNN.
List of Ops:

- [x] rpow
- [x] Normalize_global
- [x]  frac

##Checklist
- [x] Post commit CI https://github.com/tenstorrent/tt-metal/actions/runs/10112439857
- [ ] [post-commit] models tests 
- [ ] Nightly fast dispatch- 
- [x] New/Existing tests provide coverage for changes