### PR TITLE
#9750: Move Repeat_interleave to TTNN

### DIFF
--- a/docs/source/ttnn/ttnn/dependencies/tt_lib.rst
+++ b/docs/source/ttnn/ttnn/dependencies/tt_lib.rst
@@ -624,8 +624,6 @@ Other Operations
 
 .. autofunction:: tt_lib.tensor.repeat
 
-.. autofunction:: tt_lib.tensor.repeat_interleave
-
 .. autofunction:: tt_lib.tensor.pow
 
 .. autofunction:: tt_lib.tensor.argmax

--- a/models/experimental/mistral/tt/mistral_attention.py
+++ b/models/experimental/mistral/tt/mistral_attention.py
@@ -106,8 +106,8 @@ class TtAttention(nn.Module):
         dim = 2
         keys = torch_to_tt_tensor_rm(keys, self.device)
         values = torch_to_tt_tensor_rm(values, self.device)
-        keys = tt_lib.tensor.repeat_interleave(keys, repeats, dim, output_mem_config=self.args.out_mem_config)
-        values = tt_lib.tensor.repeat_interleave(values, repeats, dim, output_mem_config=self.args.out_mem_config)
+        keys = ttnn.repeat_interleave(keys, repeats, dim, output_mem_config=self.args.out_mem_config)
+        values = ttnn.repeat_interleave(values, repeats, dim, output_mem_config=self.args.out_mem_config)
         return keys, values
 
     def forward(

--- a/models/experimental/stable_diffusion/tt/upsample_nearest2d.py
+++ b/models/experimental/stable_diffusion/tt/upsample_nearest2d.py
@@ -8,7 +8,7 @@ from torch.nn import functional as F
 
 import numpy as np
 
-import tt_lib as ttl
+import ttnn
 from tt_lib.fallback_ops import fallback_ops
 
 
@@ -24,6 +24,6 @@ class TtUpsampleNearest2d(nn.Module):
         output_shape = list(input.get_legacy_shape())
         output_shape[-1] *= self.scale_factor
         output_shape[-2] *= self.scale_factor
-        input = ttl.tensor.repeat_interleave(input, self.scale_factor, dim=3)
-        input = ttl.tensor.repeat_interleave(input, self.scale_factor, dim=2)
+        input = ttnn.repeat_interleave(input, self.scale_factor, dim=3)
+        input = ttnn.repeat_interleave(input, self.scale_factor, dim=2)
         return input

--- a/tests/tt_eager/python_api_testing/sweep_tests/tt_lib_ops.py
+++ b/tests/tt_eager/python_api_testing/sweep_tests/tt_lib_ops.py
@@ -1345,7 +1345,7 @@ def repeat_interleave(
     **kwargs,
 ):
     t0 = setup_tt_tensor(x, device, layout[0], input_mem_config[0], dtype[0])
-    t1 = ttl.tensor.repeat_interleave(t0, repeat, dim, output_mem_config=output_mem_config)
+    t1 = ttnn.repeat_interleave(t0, repeat, dim, memory_config=output_mem_config)
     output_tensor = ttnn.from_device(t1)
     output_tensor = ttnn.to_layout(output_tensor, ttnn.ROW_MAJOR_LAYOUT)
     output_tensor = ttnn.to_torch(output_tensor)

--- a/tests/ttnn/profiling/ops_for_profiling.py
+++ b/tests/ttnn/profiling/ops_for_profiling.py
@@ -1486,15 +1486,15 @@ def repeat(x):
 
 
 def repeat_interleave_0(x):
-    tt_lib.tensor.repeat_interleave(x, 4, 0)
+    ttnn.repeat_interleave(x, 4, 0)
 
 
 def repeat_interleave_1(x):
-    tt_lib.tensor.repeat_interleave(x, 4, 1)
+    ttnn.repeat_interleave(x, 4, 1)
 
 
 def repeat_interleave_2(x):
-    tt_lib.tensor.repeat_interleave(x, 4, 2)
+    ttnn.repeat_interleave(x, 4, 2)
 
 
 def pow_int(x):
@@ -2228,16 +2228,16 @@ all_unary_ops = [
     },
     {
         "op": repeat_interleave_0,
-        "name": "tt_lib.tensor.repeat_interleave_dim_0",
+        "name": "ttnn.repeat_interleave_dim_0",
     },
     {
         "op": repeat_interleave_1,
-        "name": "tt_lib.tensor.repeat_interleave_dim_1",
+        "name": "ttnn.repeat_interleave_dim_1",
         "num_repeats": 2,
     },
     {
         "op": repeat_interleave_2,
-        "name": "tt_lib.tensor.repeat_interleave_dim_2",
+        "name": "ttnn.repeat_interleave_dim_2",
         "num_repeats": 2,
     },
     {

--- a/ttnn/cpp/ttnn/deprecated/tt_dnn/op_library/composite/composite_ops.cpp
+++ b/ttnn/cpp/ttnn/deprecated/tt_dnn/op_library/composite/composite_ops.cpp
@@ -801,51 +801,6 @@ Tensor addalpha(
         cq_id, input_a, input_b, alpha, output_mem_config, output_tensor);
 }
 
-// repeat interleave supports repeats as 1 to inf, dim between 0 to 2
-Tensor _repeat_interleave(const Tensor& input_a, uint32_t repeat, int32_t dim, const MemoryConfig& output_mem_config) {
-    std::vector<Tensor> combined_tensors;
-    combined_tensors.reserve(repeat);
-    auto shape_wh = input_a.get_legacy_shape();
-    // normalizing the negative dim
-    uint32_t normalized_dim = input_a.get_legacy_shape().get_normalized_index(dim);
-    // check if dim is 1 or 3
-    if (normalized_dim & 1) {
-        constexpr uint32_t tmp_dim = 2;
-        std::vector<int64_t> dims = {0, 1, 2, 3};
-        std::swap(dims[dim], dims[tmp_dim]);
-        Tensor transpose_input = ttnn::permute(input_a, dims);
-        Tensor ril_result = _repeat_interleave(transpose_input, repeat, tmp_dim, output_mem_config);
-        return ttnn::permute(ril_result, dims);
-    }
-
-    if (normalized_dim <= 1) {
-        for (int i = 0; i < repeat; i++) {
-            combined_tensors.push_back(input_a);
-        }
-        // TODO: For dim = 1 facing issue with concat_op
-        if (normalized_dim) {
-            Tensor concat_out = concat(combined_tensors, 2, output_mem_config);
-            return reshape(concat_out, shape_wh[0], shape_wh[1] * repeat, shape_wh[2], shape_wh[3], output_mem_config);
-        } else {
-            Tensor concat_out = concat(combined_tensors, 1, output_mem_config);
-            return reshape(concat_out, shape_wh[0] * repeat, shape_wh[1], shape_wh[2], shape_wh[3], output_mem_config);
-        }
-    } else {
-        Tensor reshape_out =
-            reshape(input_a, 1, 1, shape_wh[0] * shape_wh[1] * shape_wh[2], shape_wh[3], output_mem_config);
-        for (int i = 0; i < repeat; i++) {
-            combined_tensors.push_back(reshape_out);
-        }
-        Tensor concat_out = concat(combined_tensors, 1, output_mem_config);
-        std::vector<int64_t> permute_dims = {0, 2, 1, 3};
-        Tensor permute_out = ttnn::permute(concat_out, permute_dims, output_mem_config);
-        return reshape(permute_out, shape_wh[0], shape_wh[1], shape_wh[2] * repeat, shape_wh[3], output_mem_config);
-    }
-}
-Tensor repeat_interleave(const Tensor& input_a, uint32_t repeat, int32_t dim, const MemoryConfig& output_mem_config) {
-    return operation::decorate_as_composite(__func__, _repeat_interleave)(input_a, repeat, dim, output_mem_config);
-}
-
 // nextafter
 Tensor _nextafter(const Tensor& input_a, const Tensor& input_b, const MemoryConfig& output_mem_config) {
     const float eps = input_a.device()->sfpu_eps();

--- a/ttnn/cpp/ttnn/deprecated/tt_dnn/op_library/composite/composite_ops.hpp
+++ b/ttnn/cpp/ttnn/deprecated/tt_dnn/op_library/composite/composite_ops.hpp
@@ -283,13 +283,6 @@ Tensor addalpha(
     const MemoryConfig& output_mem_config = operation::DEFAULT_OUTPUT_MEMORY_CONFIG,
     std::optional<Tensor> output_tensor = std::nullopt);
 
-// repeat interleave
-Tensor repeat_interleave(
-    const Tensor& input_a,
-    uint32_t repeat,
-    int32_t dim,
-    const MemoryConfig& output_mem_config = operation::DEFAULT_OUTPUT_MEMORY_CONFIG);
-
 // lerp(input, end, weight) = start + weight * (end - start), weight is float
 Tensor lerp(
     const Tensor& input_a,

--- a/ttnn/cpp/ttnn/deprecated/tt_lib/csrc/tt_lib_bindings_tensor_composite_ops.cpp
+++ b/ttnn/cpp/ttnn/deprecated/tt_lib/csrc/tt_lib_bindings_tensor_composite_ops.cpp
@@ -711,29 +711,6 @@ void TensorModuleCompositeOPs(py::module& m_tensor) {
         )doc");
 
     m_tensor.def(
-        "repeat_interleave",
-        &repeat_interleave,
-        py::arg("input").noconvert(),
-        py::arg("repeat"),
-        py::arg("dim"),
-        py::arg("output_mem_config").noconvert() = operation::DEFAULT_OUTPUT_MEMORY_CONFIG,
-        R"doc(
-            Repeated tensor which has the same shape as ``input``, except along the given axis.
-
-            Input tensor must have BFLOAT16 data type.
-
-            Output tensor will have BFLOAT16 data type.
-
-            .. csv-table::
-                :header: "Argument", "Description", "Data type", "Valid range", "Required"
-
-                "input", "Tensor input is applied to", "Tensor", "Tensor of shape [W, Z, Y, X]", "Yes"
-                "repeat", "Repeat value", "int", "1 to inf", "Yes"
-                "dim", "dim value", "int", "0 to 2", "Yes"
-                "output_mem_config", "Layout of tensor in TT Accelerator device memory banks", "MemoryConfig", "Default is interleaved in DRAM", "No"
-        )doc");
-
-    m_tensor.def(
         "full_like",
         [](const Tensor& reference_tensor,
            float value,

--- a/ttnn/cpp/ttnn/operations/data_movement.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement.hpp
@@ -10,12 +10,54 @@
 #include "ttnn/deprecated/tt_dnn/op_library/composite/composite_ops.hpp"
 #include "ttnn/operations/upsample/upsample_op.hpp"
 #include "ttnn/operations/core/core.hpp"
+#include "ttnn/operations/data_movement/permute/permute.hpp"
 
 #include <ranges>
 
 namespace ttnn {
 namespace operations {
 namespace data_movement {
+
+// repeat interleave supports repeats as 1 to inf, dim between 0 to 2
+inline Tensor repeat_interleave(const Tensor& input_a, uint32_t repeat, int32_t dim, const std::optional<MemoryConfig>& output_mem_config) {
+    std::vector<Tensor> combined_tensors;
+    combined_tensors.reserve(repeat);
+    auto shape_wh = input_a.get_legacy_shape();
+    // normalizing the negative dim
+    uint32_t normalized_dim = input_a.get_legacy_shape().get_normalized_index(dim);
+    // check if dim is 1 or 3
+    if (normalized_dim & 1) {
+        constexpr uint32_t tmp_dim = 2;
+        std::vector<int64_t> dims = {0, 1, 2, 3};
+        std::swap(dims[dim], dims[tmp_dim]);
+        Tensor transpose_input = ttnn::permute(input_a, dims);
+        Tensor ril_result = repeat_interleave(transpose_input, repeat, tmp_dim, output_mem_config);
+        return ttnn::permute(ril_result, dims);
+    }
+    if (normalized_dim <= 1) {
+        for (int i = 0; i < repeat; i++) {
+            combined_tensors.push_back(input_a);
+        }
+        // TODO: For dim = 1 facing issue with concat_op
+        if (normalized_dim) {
+            Tensor concat_out = concat(combined_tensors, 2);
+            return reshape(concat_out, shape_wh[0], shape_wh[1] * repeat, shape_wh[2], shape_wh[3]);
+        } else {
+            Tensor concat_out = concat(combined_tensors, 1);
+            return reshape(concat_out, shape_wh[0] * repeat, shape_wh[1], shape_wh[2], shape_wh[3]);
+        }
+    } else {
+        Tensor reshape_out =
+            reshape(input_a, 1, 1, shape_wh[0] * shape_wh[1] * shape_wh[2], shape_wh[3]);
+        for (int i = 0; i < repeat; i++) {
+            combined_tensors.push_back(reshape_out);
+        }
+        Tensor concat_out = concat(combined_tensors, 1);
+        std::vector<int64_t> permute_dims = {0, 2, 1, 3};
+        Tensor permute_out = ttnn::permute(concat_out, permute_dims);
+        return reshape(permute_out, shape_wh[0], shape_wh[1], shape_wh[2] * repeat, shape_wh[3]);
+    }
+}
 
 struct UpSample {
 
@@ -97,7 +139,7 @@ struct RepeatInterleave {
                                                  int32_t dim,
                                                  std::optional<MemoryConfig> output_mem_config = std::nullopt) {
         MemoryConfig mem_config = output_mem_config.value_or(input_tensor.memory_config());
-        auto output_tensor = tt::tt_metal::repeat_interleave(input_tensor, repeats, dim, mem_config);
+        auto output_tensor = repeat_interleave(input_tensor, repeats, dim, mem_config);
         return output_tensor;
     }
 };


### PR DESCRIPTION
Ticket : #9750


### Work Done

- Moved Repeat_Interleave to TTNN.
- Replaced it s usage in CPP and Python files
- Removed tt_lib bindings


### Testing
- [x]  [All post commit test](https://github.com/tenstorrent/tt-metal/actions/runs/10073770132)
- [x] [[post-commit] models tests](https://github.com/tenstorrent/tt-metal/actions/runs/10070267935)
- [x] [Device perf regressions and output report](https://github.com/tenstorrent/tt-metal/actions/runs/10070240546)
- [x] [Model perf regressions and output report](https://github.com/tenstorrent/tt-metal/actions/runs/10070244257)
- [ ] [Nightly fast dispatch model regression CI](https://github.com/tenstorrent/tt-metal/actions/runs/10073788142)
- [x] [T3000 frequent tests](https://github.com/tenstorrent/tt-metal/actions/runs/10070218907)
- [x] [T3000 demo tests](https://github.com/tenstorrent/tt-metal/actions/runs/10070235719)