### PR TITLE
#0: Increase timeout to 50 mins for single card model perf pipelines

### DIFF
--- a/.github/workflows/perf-models.yaml
+++ b/.github/workflows/perf-models.yaml
@@ -51,7 +51,7 @@ jobs:
       - uses: ./.github/actions/install-python-deps
       - name: Run performance regressions
         id: performance_tests
-        timeout-minutes: 40
+        timeout-minutes: 50
         run: |
           source ${{ github.workspace }}/python_env/bin/activate
           ./tests/scripts/run_tests.sh --tt-arch $ARCH_NAME --pipeline-type ${{ matrix.model-type }}_models_performance_${{ matrix.test-info.machine-type }}


### PR DESCRIPTION
### Ticket

Didn't make a ticket - just a quick timeout bump to account for llm increasing in runtime

### Problem description

We're frequently taking more than 35 mins for the llm step, where the current timeout is 40min.

### What's changed

`40` > `50`

### Checklist
- [ ] Post commit CI passes
- [ ] Model regression CI testing passes (if applicable)
- [ ] New/Existing tests provide coverage for changes
