### PR TITLE
#9319: Use runner environment variables instead of github context 

### DIFF
--- a/.github/scripts/data_analysis/create_pipeline_csvs.py
+++ b/.github/scripts/data_analysis/create_pipeline_csvs.py
@@ -6,7 +6,7 @@ if __name__ == "__main__":
     github_jobs_json_filename = "workflow_jobs.json"
 
     create_csvs_for_data_analysis(
-        github_context_json_filename,
+        github_runner_environment,
         github_pipeline_json_filename,
         github_jobs_json_filename,
     )

--- a/.github/scripts/data_analysis/create_pipeline_csvs.py
+++ b/.github/scripts/data_analysis/create_pipeline_csvs.py
@@ -1,7 +1,7 @@
-from infra.data_collection.github.utils import create_csvs_for_data_analysis
+from infra.data_collection.github.utils import create_csvs_for_data_analysis, get_github_runner_environment
 
 if __name__ == "__main__":
-    github_context_json_filename = "github_context.json"
+    github_runner_environment = get_github_runner_environment()
     github_pipeline_json_filename = "workflow.json"
     github_jobs_json_filename = "workflow_jobs.json"
 

--- a/.github/workflows/_produce-data.yaml
+++ b/.github/workflows/_produce-data.yaml
@@ -57,28 +57,30 @@ jobs:
           gh api /repos/tenstorrent/tt-metal/actions/runs/${{ github.event.workflow_run.id }}/attempts/${{ github.event.workflow_run.run_attempt }} > workflow.json
           echo "[Info] Workflow run attempt jobs"
           gh api --paginate /repos/tenstorrent/tt-metal/actions/runs/${{ github.event.workflow_run.id }}/attempts/${{ github.event.workflow_run.run_attempt }}/jobs > workflow_jobs.json
-      - name: Output github context values to file
-        run: |
-          echo '${{ toJSON(github) }}' > github_context.json
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.8'
+          cache: 'pip'
+      - name: Install infra dependencies
+        run: pip3 install -r infra/requirements-infra.txt
       - name: Create CSVs and show
         env:
           PYTHONPATH: ${{ github.workspace }}
-        run: pip3 install loguru && python3 .github/scripts/data_analysis/create_pipeline_csvs.py
+        run: python3 .github/scripts/data_analysis/create_pipeline_csvs.py
       - name: Show directory to see output files
         run: ls -hal
       - name: Show CSVs output
         run: cat *.csv
-      - name: Upload context data, even on failure
+      - name: Upload workflow run data, even on failure
         if: ${{ !cancelled() }}
         uses: actions/upload-artifact@v4
         with:
-          name: context-data
+          name: workflow-run-data
           path: |
             if-no-files-found: warn
             path: |
               workflow.json
               workflow_jobs.json
-              github_context.json
   test-produce-benchmark-environment:
     runs-on: ubuntu-latest
     steps:

--- a/infra/data_collection/github/utils.py
+++ b/infra/data_collection/github/utils.py
@@ -80,7 +80,7 @@ def get_data_pipeline_datetime_from_datetime(requested_datetime):
     return requested_datetime.strftime("%Y-%m-%dT%H:%M:%S%z")
 
 
-def get_pipeline_row_from_github_info(github_context_json, github_pipeline_json, github_jobs_json):
+def get_pipeline_row_from_github_info(github_runner_environment, github_pipeline_json, github_jobs_json):
     github_pipeline_id = github_pipeline_json["id"]
     pipeline_submission_ts = github_pipeline_json["created_at"]
 
@@ -95,7 +95,7 @@ def get_pipeline_row_from_github_info(github_context_json, github_pipeline_json,
     logger.warning("Using hardcoded value tt-metal for project value")
     project = "tt-metal"
 
-    trigger = github_context_json["event_name"]
+    trigger = github_runner_environment["github_event_name"]
 
     logger.warning("Using hardcoded value github for vcs_platform value")
     vcs_platform = "github"
@@ -216,22 +216,19 @@ def get_job_rows_from_github_info(github_pipeline_json, github_jobs_json):
 
 
 def create_csvs_for_data_analysis(
-    github_context_json_filename,
+    github_runner_environment,
     github_pipeline_json_filename,
     github_jobs_json_filename,
     github_pipeline_csv_filename=None,
     github_jobs_csv_filename=None,
 ):
-    with open(github_context_json_filename) as github_context_json_file:
-        github_context_json = json.load(github_context_json_file)
-
     with open(github_pipeline_json_filename) as github_pipeline_json_file:
         github_pipeline_json = json.load(github_pipeline_json_file)
 
     with open(github_jobs_json_filename) as github_jobs_json_file:
         github_jobs_json = json.load(github_jobs_json_file)
 
-    pipeline_row = get_pipeline_row_from_github_info(github_context_json, github_pipeline_json, github_jobs_json)
+    pipeline_row = get_pipeline_row_from_github_info(github_runner_environment, github_pipeline_json, github_jobs_json)
 
     job_rows = get_job_rows_from_github_info(github_pipeline_json, github_jobs_json)
 
@@ -271,6 +268,15 @@ def get_github_benchmark_environment_csv_filenames():
     )
     logger.info(f"The following environment CSVs should be created: {csv_filenames}")
     return csv_filenames
+
+
+def get_github_runner_environment():
+    assert "GITHUB_EVENT_NAME" in os.environ
+    github_event_name = os.environ["GITHUB_EVENT_NAME"]
+
+    return {
+        "github_event_name": github_event_name,
+    }
 
 
 def create_csv_for_github_benchmark_environment(github_benchmark_environment_csv_filename):

--- a/infra/requirements-infra.txt
+++ b/infra/requirements-infra.txt
@@ -1,3 +1,5 @@
 ansible==8.5.0
 ansible-lint==6.7.0
 check-copyright @ git+https://github.com/espressif/check-copyright.git@master
+loguru
+pydantic

--- a/infra/requirements-infra.txt
+++ b/infra/requirements-infra.txt
@@ -1,4 +1,4 @@
-ansible==8.5.0
+ansible==6.7.0
 ansible-lint==6.7.0
 check-copyright @ git+https://github.com/espressif/check-copyright.git@master
 loguru


### PR DESCRIPTION
as …it can sometimes fail because of commit messages with bad characters

### Ticket

#9319 

### Problem description

Github context is sometimes not printable / saveable to a file because of bad characters. I've tried various ways to getting it including `printf`, but to no avail.

### What's changed

Use Github runner environment variables, as most github context values are available in github environment variables.

### Checklist
- [ ] Post commit CI passes
- [ ] Model regression CI testing passes (if applicable)
- [ ] New/Existing tests provide coverage for changes
