### PR TITLE
#10395: Run single card fast dispatch nightly on WH X1 and X2

### DIFF
--- a/.github/workflows/fast-dispatch-full-regressions-and-models.yaml
+++ b/.github/workflows/fast-dispatch-full-regressions-and-models.yaml
@@ -19,14 +19,62 @@ jobs:
       matrix:
         test-group:
           [
-            { name: "Common models GS", arch: grayskull, cmd: tests/scripts/single_card/nightly/run_common_models.sh, timeout: 40 },
-            { name: "Common models N300 WH B0", arch: wormhole_b0, cmd: tests/scripts/single_card/nightly/run_common_models.sh, timeout: 40 },
-            { name: "GS-only ttnn nightly", arch: grayskull, cmd: tests/scripts/single_card/nightly/run_ttnn.sh, timeout: 40 },
-            { name: "GS-only models", arch: grayskull, cmd: tests/scripts/single_card/nightly/run_gs_only.sh, timeout: 40 },
-            { name: "N300 WH-only models", arch: wormhole_b0, cmd: tests/scripts/single_card/nightly/run_wh_b0_only.sh, timeout: 50 },
-            { name: "API tests GS", arch: grayskull, cmd: ./tests/scripts/run_tests.sh --tt-arch grayskull --pipeline-type frequent_api --dispatch-mode fast, timeout: 40 },
-            { name: "API tests N300 WH B0", arch: wormhole_b0, cmd: ./tests/scripts/run_tests.sh --tt-arch wormhole_b0 --pipeline-type frequent_api --dispatch-mode fast, timeout: 40 },
-            { name: "[Unstable] N300 models", arch: wormhole_b0, cmd: tests/scripts/single_card/nightly/run_wh_b0_unstable.sh, timeout: 45 },
+            {
+              name: "Common models GS",
+              arch: grayskull,
+              runs-on: ["grayskull", "cloud-virtual-machine"],
+              cmd: tests/scripts/single_card/nightly/run_common_models.sh,
+              timeout: 40
+            },
+            {
+              name: "Common models N300 WH B0",
+              arch: wormhole_b0,
+              runs-on: ["wormhole_b0", "multi-chip-num-pcie-1", "multi-chip-num-chips-2", "cloud-virtual-machine"],
+              cmd: tests/scripts/single_card/nightly/run_common_models.sh,
+              timeout: 40,
+            },
+            {
+              name: "GS-only ttnn nightly",
+              arch: grayskull,
+              runs-on: ["grayskull", "cloud-virtual-machine"],
+              cmd: tests/scripts/single_card/nightly/run_ttnn.sh,
+              timeout: 40
+            },
+            {
+              name: "GS-only models",
+              arch: grayskull,
+              runs-on: ["grayskull", "cloud-virtual-machine"],
+              cmd: tests/scripts/single_card/nightly/run_gs_only.sh,
+              timeout: 40
+            },
+            {
+              name: "N300 WH-only models",
+              arch: wormhole_b0,
+              runs-on: ["wormhole_b0", "multi-chip-num-pcie-1", "multi-chip-num-chips-2", "cloud-virtual-machine"],
+              cmd: tests/scripts/single_card/nightly/run_wh_b0_only.sh,
+              timeout: 50
+            },
+            {
+              name: "API tests GS",
+              arch: grayskull,
+              runs-on: ["wormhole_b0", "multi-chip-num-pcie-1", "multi-chip-num-chips-2", "cloud-virtual-machine"],
+              cmd: ./tests/scripts/run_tests.sh --tt-arch grayskull --pipeline-type frequent_api --dispatch-mode fast,
+              timeout: 40
+            },
+            {
+              name: "API tests N300 WH B0",
+              arch: wormhole_b0,
+              runs-on: ["wormhole_b0", "multi-chip-num-pcie-1", "multi-chip-num-chips-2", "cloud-virtual-machine"],
+              cmd: ./tests/scripts/run_tests.sh --tt-arch wormhole_b0 --pipeline-type frequent_api --dispatch-mode fast,
+              timeout: 40
+            },
+            {
+              name: "[Unstable] N300 models",
+              arch: wormhole_b0,
+              runs-on: ["wormhole_b0", "multi-chip-num-pcie-1", "multi-chip-num-chips-2", "cloud-virtual-machine"],
+              cmd: tests/scripts/single_card/nightly/run_wh_b0_unstable.sh,
+              timeout: 45
+            },
           ]
     name: FD ${{ matrix.test-group.name }} ${{ matrix.test-group.arch }}
     env:
@@ -34,7 +82,7 @@ jobs:
       ARCH_NAME: ${{ matrix.test-group.arch }}
       LOGURU_LEVEL: INFO
       LD_LIBRARY_PATH: ${{ github.workspace }}/build/lib
-    runs-on: model-runner-${{ matrix.test-group.arch }}
+    runs-on: ${{ matrix.test-group.runs-on }}
     steps:
       - uses: tenstorrent-metal/metal-workflows/.github/actions/checkout-with-submodule-lfs@v2.0.0
       - name: Ensure weka mount is active

--- a/.github/workflows/fast-dispatch-full-regressions-and-models.yaml
+++ b/.github/workflows/fast-dispatch-full-regressions-and-models.yaml
@@ -127,8 +127,8 @@ jobs:
           max_attempts: 5
           retry_wait_seconds: 10
           command: |
-            sudo systemctl restart mnt-MLPerf.mount
-            sudo /etc/rc.local
+            timeout 120 sudo systemctl restart mnt-MLPerf.mount
+            timeout 45 sudo /etc/rc.local
             ls -al /mnt/MLPerf/bit_error_tests
       - name: Set up dyanmic env vars for build
         run: |

--- a/.github/workflows/fast-dispatch-full-regressions-and-models.yaml
+++ b/.github/workflows/fast-dispatch-full-regressions-and-models.yaml
@@ -59,7 +59,7 @@ jobs:
               arch: wormhole_b0,
               runs-on: ["wormhole_b0", "multi-chip-num-pcie-1", "multi-chip-num-chips-2", "cloud-virtual-machine"],
               cmd: tests/scripts/single_card/nightly/run_ttnn.sh,
-              timeout: 40
+              timeout: 70
             },
             {
               name: "GS-only models",
@@ -73,14 +73,14 @@ jobs:
               arch: wormhole_b0,
               runs-on: ["wormhole_b0", "multi-chip-num-pcie-1", "multi-chip-num-chips-2", "cloud-virtual-machine"],
               cmd: tests/scripts/single_card/nightly/run_wh_b0_only.sh,
-              timeout: 50
+              timeout: 80
             },
             {
               name: "N150 WH-only models",
               arch: wormhole_b0,
               runs-on: ["wormhole_b0", "multi-chip-num-pcie-1", "multi-chip-num-chips-1", "cloud-virtual-machine"],
               cmd: tests/scripts/single_card/nightly/run_wh_b0_only.sh,
-              timeout: 40
+              timeout: 80
             },
             {
               name: "API tests GS",

--- a/.github/workflows/fast-dispatch-full-regressions-and-models.yaml
+++ b/.github/workflows/fast-dispatch-full-regressions-and-models.yaml
@@ -127,8 +127,8 @@ jobs:
           max_attempts: 5
           retry_wait_seconds: 10
           command: |
-            bash -c 'sudo systemctl restart mnt-MLPerf.mount'
-            bash -c 'sudo /etc/rc.local'
+            timeout 120 sudo systemctl restart mnt-MLPerf.mount
+            timeout 45 sudo /etc/rc.local
             ls -al /mnt/MLPerf/bit_error_tests
       - name: Set up dyanmic env vars for build
         run: |

--- a/.github/workflows/fast-dispatch-full-regressions-and-models.yaml
+++ b/.github/workflows/fast-dispatch-full-regressions-and-models.yaml
@@ -52,7 +52,7 @@ jobs:
               arch: wormhole_b0,
               runs-on: ["wormhole_b0", "multi-chip-num-pcie-1", "multi-chip-num-chips-1", "cloud-virtual-machine"],
               cmd: tests/scripts/single_card/nightly/run_ttnn.sh,
-              timeout: 55
+              timeout: 70
             },
             {
               name: "WH N300 ttnn nightly",

--- a/.github/workflows/fast-dispatch-full-regressions-and-models.yaml
+++ b/.github/workflows/fast-dispatch-full-regressions-and-models.yaml
@@ -41,9 +41,23 @@ jobs:
               timeout: 40,
             },
             {
-              name: "GS-only ttnn nightly",
+              name: "GS ttnn nightly",
               arch: grayskull,
               runs-on: ["grayskull", "cloud-virtual-machine"],
+              cmd: tests/scripts/single_card/nightly/run_ttnn.sh,
+              timeout: 40
+            },
+            {
+              name: "WH N150 ttnn nightly",
+              arch: wormhole_b0,
+              runs-on: ["wormhole_b0", "multi-chip-num-pcie-1", "multi-chip-num-chips-1", "cloud-virtual-machine"],
+              cmd: tests/scripts/single_card/nightly/run_ttnn.sh,
+              timeout: 40
+            },
+            {
+              name: "WH N300 ttnn nightly",
+              arch: wormhole_b0,
+              runs-on: ["wormhole_b0", "multi-chip-num-pcie-1", "multi-chip-num-chips-2", "cloud-virtual-machine"],
               cmd: tests/scripts/single_card/nightly/run_ttnn.sh,
               timeout: 40
             },

--- a/.github/workflows/fast-dispatch-full-regressions-and-models.yaml
+++ b/.github/workflows/fast-dispatch-full-regressions-and-models.yaml
@@ -121,11 +121,15 @@ jobs:
     steps:
       - uses: tenstorrent-metal/metal-workflows/.github/actions/checkout-with-submodule-lfs@v2.0.0
       - name: Ensure weka mount is active
-        timeout-minutes: 3
-        run: |
-          sudo systemctl restart mnt-MLPerf.mount
-          sudo /etc/rc.local
-          ls -al /mnt/MLPerf/bit_error_tests
+        uses: nick-fields/retry@v3.0.0
+        with:
+          timeout_seconds: 180
+          max_attempts: 5
+          retry_wait_seconds: 10
+          command: |
+            sudo systemctl restart mnt-MLPerf.mount
+            sudo /etc/rc.local
+            ls -al /mnt/MLPerf/bit_error_tests
       - name: Set up dyanmic env vars for build
         run: |
           echo "TT_METAL_HOME=$(pwd)" >> $GITHUB_ENV

--- a/.github/workflows/fast-dispatch-full-regressions-and-models.yaml
+++ b/.github/workflows/fast-dispatch-full-regressions-and-models.yaml
@@ -22,91 +22,91 @@ jobs:
             {
               name: "Common models GS",
               arch: grayskull,
-              runs-on: ["cloud-virtual-machine", "arch-grayskull", "E150", "in-service"],
+              runs-on: ["cloud-virtual-machine", "arch-grayskull", "E150", "in-service", "mount-cloud-weka"],
               cmd: tests/scripts/single_card/nightly/run_common_models.sh,
               timeout: 40
             },
             {
               name: "Common models N300 WH B0",
               arch: wormhole_b0,
-              runs-on: ["cloud-virtual-machine", "arch-wormhole_b0", "N300", "in-service"],
+              runs-on: ["cloud-virtual-machine", "arch-wormhole_b0", "N300", "in-service", "mount-cloud-weka"],
               cmd: tests/scripts/single_card/nightly/run_common_models.sh,
               timeout: 40,
             },
             {
               name: "Common models N150 WH BO",
               arch: wormhole_b0,
-              runs-on: ["cloud-virtual-machine", "arch-wormhole_b0", "N150", "in-service"],
+              runs-on: ["cloud-virtual-machine", "arch-wormhole_b0", "N150", "in-service", "mount-cloud-weka"],
               cmd: tests/scripts/single_card/nightly/run_common_models.sh,
               timeout: 40,
             },
             {
               name: "GS ttnn nightly",
               arch: grayskull,
-              runs-on: ["cloud-virtual-machine", "arch-grayskull", "E150", "in-service"],
+              runs-on: ["cloud-virtual-machine", "arch-grayskull", "E150", "in-service", "mount-cloud-weka"],
               cmd: tests/scripts/single_card/nightly/run_ttnn.sh,
               timeout: 40
             },
             {
               name: "WH N150 ttnn nightly",
               arch: wormhole_b0,
-              runs-on: ["cloud-virtual-machine", "arch-wormhole_b0", "N150", "in-service"],
+              runs-on: ["cloud-virtual-machine", "arch-wormhole_b0", "N150", "in-service", "mount-cloud-weka"],
               cmd: tests/scripts/single_card/nightly/run_ttnn.sh,
               timeout: 70
             },
             {
               name: "WH N300 ttnn nightly",
               arch: wormhole_b0,
-              runs-on: ["cloud-virtual-machine", "arch-wormhole_b0", "N300", "in-service"],
+              runs-on: ["cloud-virtual-machine", "arch-wormhole_b0", "N300", "in-service", "mount-cloud-weka"],
               cmd: tests/scripts/single_card/nightly/run_ttnn.sh,
               timeout: 70
             },
             {
               name: "GS-only models",
               arch: grayskull,
-              runs-on: ["cloud-virtual-machine", "arch-grayskull", "E150", "in-service"],
+              runs-on: ["cloud-virtual-machine", "arch-grayskull", "E150", "in-service", "mount-cloud-weka"],
               cmd: tests/scripts/single_card/nightly/run_gs_only.sh,
               timeout: 40
             },
             {
               name: "N300 WH-only models",
               arch: wormhole_b0,
-              runs-on: ["cloud-virtual-machine", "arch-wormhole_b0", "N300", "in-service"],
+              runs-on: ["cloud-virtual-machine", "arch-wormhole_b0", "N300", "in-service", "mount-cloud-weka"],
               cmd: tests/scripts/single_card/nightly/run_wh_b0_only.sh,
               timeout: 80
             },
             {
               name: "N150 WH-only models",
               arch: wormhole_b0,
-              runs-on: ["cloud-virtual-machine", "arch-wormhole_b0", "N150", "in-service"],
+              runs-on: ["cloud-virtual-machine", "arch-wormhole_b0", "N150", "in-service", "mount-cloud-weka"],
               cmd: tests/scripts/single_card/nightly/run_wh_b0_only.sh,
               timeout: 80
             },
             {
               name: "API tests GS",
               arch: grayskull,
-              runs-on: ["cloud-virtual-machine", "arch-grayskull", "E150", "in-service"],
+              runs-on: ["cloud-virtual-machine", "arch-grayskull", "E150", "in-service", "mount-cloud-weka"],
               cmd: ./tests/scripts/run_tests.sh --tt-arch grayskull --pipeline-type frequent_api --dispatch-mode fast,
               timeout: 40
             },
             {
               name: "API tests N300 WH B0",
               arch: wormhole_b0,
-              runs-on: ["cloud-virtual-machine", "arch-wormhole_b0", "N300", "in-service"],
+              runs-on: ["cloud-virtual-machine", "arch-wormhole_b0", "N300", "in-service", "mount-cloud-weka"],
               cmd: ./tests/scripts/run_tests.sh --tt-arch wormhole_b0 --pipeline-type frequent_api --dispatch-mode fast,
               timeout: 40
             },
             {
               name: "API tests N150 WH B0",
               arch: wormhole_b0,
-              runs-on: ["cloud-virtual-machine", "arch-wormhole_b0", "N150", "in-service"],
+              runs-on: ["cloud-virtual-machine", "arch-wormhole_b0", "N150", "in-service", "mount-cloud-weka"],
               cmd: ./tests/scripts/run_tests.sh --tt-arch wormhole_b0 --pipeline-type frequent_api --dispatch-mode fast,
               timeout: 40
             },
             {
               name: "[Unstable] N300 models",
               arch: wormhole_b0,
-              runs-on: ["cloud-virtual-machine", "arch-wormhole_b0", "N300", "in-service"],
+              runs-on: ["cloud-virtual-machine", "arch-wormhole_b0", "N300", "in-service", "mount-cloud-weka"],
               cmd: tests/scripts/single_card/nightly/run_wh_b0_unstable.sh,
               timeout: 45
             },

--- a/.github/workflows/fast-dispatch-full-regressions-and-models.yaml
+++ b/.github/workflows/fast-dispatch-full-regressions-and-models.yaml
@@ -52,7 +52,7 @@ jobs:
               arch: wormhole_b0,
               runs-on: ["wormhole_b0", "multi-chip-num-pcie-1", "multi-chip-num-chips-1", "cloud-virtual-machine"],
               cmd: tests/scripts/single_card/nightly/run_ttnn.sh,
-              timeout: 40
+              timeout: 55
             },
             {
               name: "WH N300 ttnn nightly",

--- a/.github/workflows/fast-dispatch-full-regressions-and-models.yaml
+++ b/.github/workflows/fast-dispatch-full-regressions-and-models.yaml
@@ -127,8 +127,8 @@ jobs:
           max_attempts: 5
           retry_wait_seconds: 10
           command: |
-            timeout 120 sudo systemctl restart mnt-MLPerf.mount
-            timeout 45 sudo /etc/rc.local
+            bash -c 'sudo systemctl restart mnt-MLPerf.mount'
+            bash -c 'sudo /etc/rc.local'
             ls -al /mnt/MLPerf/bit_error_tests
       - name: Set up dyanmic env vars for build
         run: |

--- a/.github/workflows/fast-dispatch-full-regressions-and-models.yaml
+++ b/.github/workflows/fast-dispatch-full-regressions-and-models.yaml
@@ -122,9 +122,9 @@ jobs:
       - uses: tenstorrent-metal/metal-workflows/.github/actions/checkout-with-submodule-lfs@v2.0.0
       - uses: ./.github/actions/retry-command
         with:
-          timeout-seconds: 150
+          timeout-seconds: 100
           max-retries: 10
-          backoff-seconds: 15
+          backoff-seconds: 60
           command: ./.github/scripts/cloud_utils/mount_weka.sh
       - name: Set up dyanmic env vars for build
         run: |

--- a/.github/workflows/fast-dispatch-full-regressions-and-models.yaml
+++ b/.github/workflows/fast-dispatch-full-regressions-and-models.yaml
@@ -120,16 +120,12 @@ jobs:
     runs-on: ${{ matrix.test-group.runs-on }}
     steps:
       - uses: tenstorrent-metal/metal-workflows/.github/actions/checkout-with-submodule-lfs@v2.0.0
-      - name: Ensure weka mount is active
-        uses: nick-fields/retry@v3.0.0
+      - uses: ./.github/actions/retry-command
         with:
-          timeout_seconds: 180
-          max_attempts: 5
-          retry_wait_seconds: 10
-          command: |
-            timeout 120 sudo systemctl restart mnt-MLPerf.mount
-            timeout 45 sudo /etc/rc.local
-            ls -al /mnt/MLPerf/bit_error_tests
+          timeout-seconds: 150
+          max-retries: 10
+          backoff-seconds: 15
+          command: ./.github/scripts/cloud_utils/mount_weka.sh
       - name: Set up dyanmic env vars for build
         run: |
           echo "TT_METAL_HOME=$(pwd)" >> $GITHUB_ENV

--- a/.github/workflows/fast-dispatch-full-regressions-and-models.yaml
+++ b/.github/workflows/fast-dispatch-full-regressions-and-models.yaml
@@ -34,6 +34,13 @@ jobs:
               timeout: 40,
             },
             {
+              name: "Common models N150 WH BO",
+              arch: wormhole_b0,
+              runs-on: ["wormhole_b0", "multi-chip-num-pcie-1", "multi-chip-num-chips-1", "cloud-virtual-machine"],
+              cmd: tests/scripts/single_card/nightly/run_common_models.sh,
+              timeout: 40,
+            },
+            {
               name: "GS-only ttnn nightly",
               arch: grayskull,
               runs-on: ["grayskull", "cloud-virtual-machine"],
@@ -55,9 +62,16 @@ jobs:
               timeout: 50
             },
             {
+              name: "N150 WH-only models",
+              arch: wormhole_b0,
+              runs-on: ["wormhole_b0", "multi-chip-num-pcie-1", "multi-chip-num-chips-1", "cloud-virtual-machine"],
+              cmd: tests/scripts/single_card/nightly/run_wh_b0_only.sh,
+              timeout: 40
+            },
+            {
               name: "API tests GS",
               arch: grayskull,
-              runs-on: ["wormhole_b0", "multi-chip-num-pcie-1", "multi-chip-num-chips-2", "cloud-virtual-machine"],
+              runs-on: ["grayskull", "cloud-virtual-machine"],
               cmd: ./tests/scripts/run_tests.sh --tt-arch grayskull --pipeline-type frequent_api --dispatch-mode fast,
               timeout: 40
             },
@@ -65,6 +79,13 @@ jobs:
               name: "API tests N300 WH B0",
               arch: wormhole_b0,
               runs-on: ["wormhole_b0", "multi-chip-num-pcie-1", "multi-chip-num-chips-2", "cloud-virtual-machine"],
+              cmd: ./tests/scripts/run_tests.sh --tt-arch wormhole_b0 --pipeline-type frequent_api --dispatch-mode fast,
+              timeout: 40
+            },
+            {
+              name: "API tests N150 WH B0",
+              arch: wormhole_b0,
+              runs-on: ["wormhole_b0", "multi-chip-num-pcie-1", "multi-chip-num-chips-1", "cloud-virtual-machine"],
               cmd: ./tests/scripts/run_tests.sh --tt-arch wormhole_b0 --pipeline-type frequent_api --dispatch-mode fast,
               timeout: 40
             },

--- a/.github/workflows/fast-dispatch-full-regressions-and-models.yaml
+++ b/.github/workflows/fast-dispatch-full-regressions-and-models.yaml
@@ -22,91 +22,91 @@ jobs:
             {
               name: "Common models GS",
               arch: grayskull,
-              runs-on: ["grayskull", "cloud-virtual-machine"],
+              runs-on: ["cloud-virtual-machine", "arch-grayskull", "E150", "in-service"],
               cmd: tests/scripts/single_card/nightly/run_common_models.sh,
               timeout: 40
             },
             {
               name: "Common models N300 WH B0",
               arch: wormhole_b0,
-              runs-on: ["wormhole_b0", "multi-chip-num-pcie-1", "multi-chip-num-chips-2", "cloud-virtual-machine"],
+              runs-on: ["cloud-virtual-machine", "arch-wormhole_b0", "N300", "in-service"],
               cmd: tests/scripts/single_card/nightly/run_common_models.sh,
               timeout: 40,
             },
             {
               name: "Common models N150 WH BO",
               arch: wormhole_b0,
-              runs-on: ["wormhole_b0", "multi-chip-num-pcie-1", "multi-chip-num-chips-1", "cloud-virtual-machine"],
+              runs-on: ["cloud-virtual-machine", "arch-wormhole_b0", "N150", "in-service"],
               cmd: tests/scripts/single_card/nightly/run_common_models.sh,
               timeout: 40,
             },
             {
               name: "GS ttnn nightly",
               arch: grayskull,
-              runs-on: ["grayskull", "cloud-virtual-machine"],
+              runs-on: ["cloud-virtual-machine", "arch-grayskull", "E150", "in-service"],
               cmd: tests/scripts/single_card/nightly/run_ttnn.sh,
               timeout: 40
             },
             {
               name: "WH N150 ttnn nightly",
               arch: wormhole_b0,
-              runs-on: ["wormhole_b0", "multi-chip-num-pcie-1", "multi-chip-num-chips-1", "cloud-virtual-machine"],
+              runs-on: ["cloud-virtual-machine", "arch-wormhole_b0", "N150", "in-service"],
               cmd: tests/scripts/single_card/nightly/run_ttnn.sh,
               timeout: 70
             },
             {
               name: "WH N300 ttnn nightly",
               arch: wormhole_b0,
-              runs-on: ["wormhole_b0", "multi-chip-num-pcie-1", "multi-chip-num-chips-2", "cloud-virtual-machine"],
+              runs-on: ["cloud-virtual-machine", "arch-wormhole_b0", "N300", "in-service"],
               cmd: tests/scripts/single_card/nightly/run_ttnn.sh,
               timeout: 70
             },
             {
               name: "GS-only models",
               arch: grayskull,
-              runs-on: ["grayskull", "cloud-virtual-machine"],
+              runs-on: ["cloud-virtual-machine", "arch-grayskull", "E150", "in-service"],
               cmd: tests/scripts/single_card/nightly/run_gs_only.sh,
               timeout: 40
             },
             {
               name: "N300 WH-only models",
               arch: wormhole_b0,
-              runs-on: ["wormhole_b0", "multi-chip-num-pcie-1", "multi-chip-num-chips-2", "cloud-virtual-machine"],
+              runs-on: ["cloud-virtual-machine", "arch-wormhole_b0", "N300", "in-service"],
               cmd: tests/scripts/single_card/nightly/run_wh_b0_only.sh,
               timeout: 80
             },
             {
               name: "N150 WH-only models",
               arch: wormhole_b0,
-              runs-on: ["wormhole_b0", "multi-chip-num-pcie-1", "multi-chip-num-chips-1", "cloud-virtual-machine"],
+              runs-on: ["cloud-virtual-machine", "arch-wormhole_b0", "N150", "in-service"],
               cmd: tests/scripts/single_card/nightly/run_wh_b0_only.sh,
               timeout: 80
             },
             {
               name: "API tests GS",
               arch: grayskull,
-              runs-on: ["grayskull", "cloud-virtual-machine"],
+              runs-on: ["cloud-virtual-machine", "arch-grayskull", "E150", "in-service"],
               cmd: ./tests/scripts/run_tests.sh --tt-arch grayskull --pipeline-type frequent_api --dispatch-mode fast,
               timeout: 40
             },
             {
               name: "API tests N300 WH B0",
               arch: wormhole_b0,
-              runs-on: ["wormhole_b0", "multi-chip-num-pcie-1", "multi-chip-num-chips-2", "cloud-virtual-machine"],
+              runs-on: ["cloud-virtual-machine", "arch-wormhole_b0", "N300", "in-service"],
               cmd: ./tests/scripts/run_tests.sh --tt-arch wormhole_b0 --pipeline-type frequent_api --dispatch-mode fast,
               timeout: 40
             },
             {
               name: "API tests N150 WH B0",
               arch: wormhole_b0,
-              runs-on: ["wormhole_b0", "multi-chip-num-pcie-1", "multi-chip-num-chips-1", "cloud-virtual-machine"],
+              runs-on: ["cloud-virtual-machine", "arch-wormhole_b0", "N150", "in-service"],
               cmd: ./tests/scripts/run_tests.sh --tt-arch wormhole_b0 --pipeline-type frequent_api --dispatch-mode fast,
               timeout: 40
             },
             {
               name: "[Unstable] N300 models",
               arch: wormhole_b0,
-              runs-on: ["wormhole_b0", "multi-chip-num-pcie-1", "multi-chip-num-chips-2", "cloud-virtual-machine"],
+              runs-on: ["cloud-virtual-machine", "arch-wormhole_b0", "N300", "in-service"],
               cmd: tests/scripts/single_card/nightly/run_wh_b0_unstable.sh,
               timeout: 45
             },

--- a/.github/workflows/ttnn-run-sweeps.yaml
+++ b/.github/workflows/ttnn-run-sweeps.yaml
@@ -25,7 +25,7 @@ jobs:
       TT_METAL_ENV: ${{ vars.TT_METAL_ENV }}
       ARCH_NAME: ${{ matrix.arch }}
     environment: dev
-    runs-on: model-runner-${{ matrix.arch }}
+    runs-on: ${{ matrix.arch }}
     steps:
       - uses: tenstorrent-metal/metal-workflows/.github/actions/checkout-with-submodule-lfs@v2.0.0
       - name: Set up dynamic env vars for build

--- a/models/demos/metal_BERT_large_11/tests/test_bert_batch_dram.py
+++ b/models/demos/metal_BERT_large_11/tests/test_bert_batch_dram.py
@@ -290,7 +290,7 @@ def test_bert_batch_dram(
         elif batch == 8 and device.core_grid.y == 7:
             pytest.skip("This test is only supported for 8x8 grids")
         elif not is_x2_harvested(device):
-            pytest.skip("This test is only supported on WH X2")
+            pytest.skip("This test is only supported on WH X1")
 
     model_config = get_model_config(batch, device.compute_with_storage_grid_size(), model_config_str)
     tt_cache_path = get_tt_cache_path(model_version)

--- a/models/demos/metal_BERT_large_11/tests/test_bert_batch_dram.py
+++ b/models/demos/metal_BERT_large_11/tests/test_bert_batch_dram.py
@@ -22,7 +22,6 @@ from models.utility_functions import (
     profiler,
     is_e75,
     skip_for_wormhole_b0,
-    is_x2_harvested,
 )
 
 
@@ -289,8 +288,6 @@ def test_bert_batch_dram(
             pytest.skip("Only batch_8-BFLOAT8_B-SHARDED supported for WH B0")
         elif batch == 8 and device.core_grid.y == 7:
             pytest.skip("This test is only supported for 8x8 grids")
-        elif not is_x2_harvested(device):
-            pytest.skip("This test is only supported on WH X1")
 
     model_config = get_model_config(batch, device.compute_with_storage_grid_size(), model_config_str)
     tt_cache_path = get_tt_cache_path(model_version)

--- a/models/demos/metal_BERT_large_11/tests/test_bert_batch_dram.py
+++ b/models/demos/metal_BERT_large_11/tests/test_bert_batch_dram.py
@@ -22,6 +22,7 @@ from models.utility_functions import (
     profiler,
     is_e75,
     skip_for_wormhole_b0,
+    is_x2_harvested,
 )
 
 
@@ -288,6 +289,8 @@ def test_bert_batch_dram(
             pytest.skip("Only batch_8-BFLOAT8_B-SHARDED supported for WH B0")
         elif batch == 8 and device.core_grid.y == 7:
             pytest.skip("This test is only supported for 8x8 grids")
+        elif not is_x2_harvested(device):
+            pytest.skip("This test is only supported on WH X1")
 
     model_config = get_model_config(batch, device.compute_with_storage_grid_size(), model_config_str)
     tt_cache_path = get_tt_cache_path(model_version)

--- a/models/demos/metal_BERT_large_11/tests/test_bert_batch_dram.py
+++ b/models/demos/metal_BERT_large_11/tests/test_bert_batch_dram.py
@@ -290,7 +290,7 @@ def test_bert_batch_dram(
         elif batch == 8 and device.core_grid.y == 7:
             pytest.skip("This test is only supported for 8x8 grids")
         elif not is_x2_harvested(device):
-            pytest.skip("This test is only supported on WH X1")
+            pytest.skip("This test is only supported on WH X2")
 
     model_config = get_model_config(batch, device.compute_with_storage_grid_size(), model_config_str)
     tt_cache_path = get_tt_cache_path(model_version)

--- a/tests/scripts/single_card/nightly/run_ttnn.sh
+++ b/tests/scripts/single_card/nightly/run_ttnn.sh
@@ -10,7 +10,11 @@ fail=0
 
 echo "Running ttnn nightly tests"
 
-env WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml pytest -n auto tests/ttnn/integration_tests -m "not models_performance_bare_metal and not models_device_performance_bare_metal" ; fail+=$?
+if [[ "$ARCH_NAME" == "wormhole_b0" ]]; then
+  export WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml
+fi
+
+env pytest -n auto tests/ttnn/integration_tests -m "not models_performance_bare_metal and not models_device_performance_bare_metal" ; fail+=$?
 
 if [[ $fail -ne 0 ]]; then
   exit 1

--- a/tests/scripts/single_card/nightly/run_ttnn.sh
+++ b/tests/scripts/single_card/nightly/run_ttnn.sh
@@ -8,7 +8,7 @@ if [[ -z "$TT_METAL_HOME" ]]; then
 fi
 fail=0
 
-echo "Running ttnn nightly tests for GS only"
+echo "Running ttnn nightly tests"
 
 env pytest -n auto tests/ttnn/integration_tests -m "not models_performance_bare_metal and not models_device_performance_bare_metal" ; fail+=$?
 

--- a/tests/scripts/single_card/nightly/run_ttnn.sh
+++ b/tests/scripts/single_card/nightly/run_ttnn.sh
@@ -10,7 +10,7 @@ fail=0
 
 echo "Running ttnn nightly tests"
 
-env pytest -n auto tests/ttnn/integration_tests -m "not models_performance_bare_metal and not models_device_performance_bare_metal" ; fail+=$?
+env WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml pytest -n auto tests/ttnn/integration_tests -m "not models_performance_bare_metal and not models_device_performance_bare_metal" ; fail+=$?
 
 if [[ $fail -ne 0 ]]; then
   exit 1

--- a/tests/ttnn/integration_tests/stable_diffusion/test_down_block_2d.py
+++ b/tests/ttnn/integration_tests/stable_diffusion/test_down_block_2d.py
@@ -11,6 +11,7 @@ from tests.ttnn.utils_for_testing import assert_with_pcc
 from ttnn.model_preprocessing import preprocess_model_parameters
 from models.utility_functions import (
     skip_for_grayskull,
+    skip_for_wormhole_b0,
 )
 from models.demos.wormhole.stable_diffusion.custom_preprocessing import custom_preprocessor
 from models.demos.wormhole.stable_diffusion.tt.ttnn_functional_downblock_2d import (
@@ -26,6 +27,7 @@ from models.demos.wormhole.stable_diffusion.tt2.ttnn_functional_utility_function
 
 
 @skip_for_grayskull()
+@skip_for_wormhole_b0(reason_str="#10923: Seems to hang")
 @pytest.mark.parametrize(
     "input_shape",
     [

--- a/tests/ttnn/integration_tests/stable_diffusion/test_unet_2d_condition_model_new_conv.py
+++ b/tests/ttnn/integration_tests/stable_diffusion/test_unet_2d_condition_model_new_conv.py
@@ -12,6 +12,7 @@ import time
 from tests.ttnn.utils_for_testing import assert_with_pcc
 from models.utility_functions import (
     skip_for_grayskull,
+    skip_for_wormhole_b0,
     comp_pcc,
     enable_persistent_kernel_cache,
     profiler,
@@ -139,6 +140,7 @@ def test_unet_2d_condition_model_256x256(device, batch_size, in_channels, input_
 
 
 @skip_for_grayskull()
+@skip_for_wormhole_b0(reason_str="#10923: Seems to hang")
 @pytest.mark.parametrize(
     "device_params", [{"l1_small_size": 32768}], ids=["device_params=l1_small_size_24576"], indirect=True
 )

--- a/tests/ttnn/integration_tests/stable_diffusion/test_unet_mid_block_2d_cross_attn.py
+++ b/tests/ttnn/integration_tests/stable_diffusion/test_unet_mid_block_2d_cross_attn.py
@@ -11,6 +11,7 @@ from diffusers import StableDiffusionPipeline
 from tests.ttnn.utils_for_testing import assert_with_pcc
 from models.utility_functions import (
     skip_for_grayskull,
+    skip_for_wormhole_b0,
 )
 from ttnn.model_preprocessing import preprocess_model_parameters
 from models.demos.wormhole.stable_diffusion.custom_preprocessing import custom_preprocessor
@@ -27,6 +28,7 @@ from models.demos.wormhole.stable_diffusion.tt2.ttnn_functional_utility_function
 
 
 @skip_for_grayskull()
+@skip_for_wormhole_b0(reason_str="#10923: Seems to hang")
 @pytest.mark.parametrize(
     "hidden_state_shapes,",
     [


### PR DESCRIPTION
### Ticket

#10395 

### Problem description

We don't have regression on X1 nor do we run ttnn integration tests at all on WH.

We matrix across E150, N150, and N300 for single card. No reason to not do this on nightly.

### What's changed

- Attempt all tests on all cards
- Skip and file issues for those that don't work for certain configs
- Add `runs-on` configs to nightly fast dispatch github yaml

### Checklist
- [ ] Post commit CI passes
- [ ] Model regression CI testing passes (if applicable)
- [ ] New/Existing tests provide coverage for changes
