### PR TITLE
Add measurement of time-to-first-token to Falcon7b demos, assert on required benchmarking fields

### DIFF
--- a/models/demos/utils/llm_demo_utils.py
+++ b/models/demos/utils/llm_demo_utils.py
@@ -12,7 +12,7 @@ def create_benchmark_data(profiler: BenchmarkProfiler, measurements: dict, N_war
     Create a benchmark data object and populate the object with the given measurements.
 
     Pre-requisites:
-    - The measurements dictionary should contain the following keys: "compile_prefill", "compile_decode", "prefill_t/s", "decode_t/s", "decode_t/s/u"
+    - The measurements dictionary should contain the following keys: "compile_prefill", "compile_decode", "prefill_t/s", "prefill_time_to_token", "decode_t/s", "decode_t/s/u"
     - The profiler object should contain the start and end times for the steps "compile_prefill", "compile_decode", "inference_prefill", "inference_decode"
 
     Optional (should be provided if measuring perf, not required for token verification):
@@ -29,6 +29,7 @@ def create_benchmark_data(profiler: BenchmarkProfiler, measurements: dict, N_war
             "compile_prefill",
             "compile_decode",
             "prefill_t/s",
+            "prefill_time_to_token",
             "decode_t/s",
             "decode_t/s/u",
         ]
@@ -49,6 +50,17 @@ def create_benchmark_data(profiler: BenchmarkProfiler, measurements: dict, N_war
             N_warmup_iter["inference_prefill"] if "inference_prefill" in N_warmup_iter else None
         ),
         target=targets["prefill_t/s"] if "prefill_t/s" in targets else None,
+    )
+    benchmark_data.add_measurement(
+        profiler,
+        0,
+        "inference_prefill",
+        "time_to_token",
+        measurements["prefill_time_to_token"],
+        step_warm_up_num_iterations=(
+            N_warmup_iter["inference_prefill"] if "inference_prefill" in N_warmup_iter else None
+        ),
+        target=None,
     )
     benchmark_data.add_measurement(
         profiler,
@@ -98,6 +110,7 @@ def verify_perf(measurements: dict, expected_perf_metrics: dict):
     expected_measurements = {
         "compile_prefill": False,
         "compile_decode": False,
+        "prefill_time_to_token": False,
         "prefill_t/s": True,
         "decode_t/s": True,
         "decode_t/s/u": True,

--- a/models/perf/benchmarking_utils.py
+++ b/models/perf/benchmarking_utils.py
@@ -71,6 +71,7 @@ class BenchmarkData:
         device_power: float = None,
         device_temperature: float = None,
     ):
+        assert None not in [profiler, iteration, step_name, measurement_name, value], "Missing required fields"
         assert profiler.contains_step(
             step_name, iteration
         ), f"Completed step '{step_name}' for iteration {iteration} not found in profiler"
@@ -105,6 +106,7 @@ class BenchmarkData:
         output_sequence_length: int = None,
         image_dimension: int = None,
     ):
+        assert None not in [profiler, run_type, ml_model_name], "Missing required fields"
         assert profiler.contains_step("run"), "Run step not found in profiler"
         run_start_ts = profiler.get_str_start("run")
         run_end_ts = profiler.get_str_end("run")


### PR DESCRIPTION
### Ticket
#5383 

### Problem description
- The time-to-first-token metric was not being measured by the Falcon7b demo
- The benchmarking utility functions were not asserting on the required csv fields not being None

### What's changed
- Measure, log, and save time-to-first-token in Falcon7b demos
- Add asserts on required fields in BenchmarkData::add_measurement and BenchmarkData::prep_csvs

### Checklist
- [x] Post commit CI passes
- [x] Model regression CI testing passes (if applicable)
- [x] New/Existing tests provide coverage for changes
