### PR TITLE
#10550: Enable remote chip routing before profiler init

### DIFF
--- a/tests/tt_metal/tools/profiler/test_all_devices.py
+++ b/tests/tt_metal/tools/profiler/test_all_devices.py
@@ -1,0 +1,13 @@
+# SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+
+# SPDX-License-Identifier: Apache-2.0
+
+import pytest
+
+
+@pytest.mark.parametrize("num_devices", [(8)])
+def test_all_devices(
+    all_devices,
+    num_devices,
+):
+    print("Testing All Devices")

--- a/tt_metal/detail/tt_metal.hpp
+++ b/tt_metal/detail/tt_metal.hpp
@@ -86,8 +86,8 @@ namespace tt::tt_metal{
 
         // Launches all kernels on cores specified with kernels in the program.
         // All kernels on a given Tensix core must be launched.
-        void LaunchProgram(Device *device, Program &program, bool wait_until_cores_done = true);
-        void LaunchProgram(Device *device, std::shared_ptr<Program> program, bool wait_until_cores_done = true);
+        void LaunchProgram(Device *device, Program &program, bool wait_until_cores_done = true, bool force_slow_dispatch = false);
+        void LaunchProgram(Device *device, std::shared_ptr<Program> program, bool wait_until_cores_done = true, bool force_slow_dispatch = false);
         void WaitProgramDone(Device *device, Program &program);
 
         /**
@@ -116,12 +116,13 @@ namespace tt::tt_metal{
          *
          * Return value: void
          *
-         * | Argument     | Description                                                            | Type                          | Valid Range                        | Required |
-         * |--------------|------------------------------------------------------------------------|-------------------------------|------------------------------------|----------|
-         * | device       | The device to whcih runtime args will be written                       | Device *                      |                                    | Yes      |
-         * | program      | The program holding the runtime args                                   | const Program &               |                                    | Yes      |
+         * | Argument            | Description                                                            | Type                          | Valid Range                        | Required |
+         * |---------------------|------------------------------------------------------------------------|-------------------------------|------------------------------------|----------|
+         * | device              | The device to whcih runtime args will be written                       | Device *                      |                                    | Yes      |
+         * | program             | The program holding the runtime args                                   | const Program &               |                                    | Yes      |
+         * | force_slow_dispatch | Force allowing slow dispatch                                           | bool                          |                                    | No       |
          */
-        void WriteRuntimeArgsToDevice(Device *device, Program &program);
+        void WriteRuntimeArgsToDevice(Device *device, Program &program, bool force_slow_dispatch = false);
 
         // Configures a given device with a given program.
         // - Loads all kernel binaries into L1s of assigned Tensix cores

--- a/tt_metal/tools/profiler/tt_metal_profiler.cpp
+++ b/tt_metal/tools/profiler/tt_metal_profiler.cpp
@@ -101,7 +101,9 @@ void syncDeviceHost(Device *device, CoreCoord logical_core, std::shared_ptr<tt_m
                 .defines = kernel_defines}
             );
     }
-    EnqueueProgram(device->command_queue(), sync_program, false);
+    constexpr bool wait_for_all_cores_done = false;
+    constexpr bool force_slow_dispatch = true;
+    LaunchProgram(device, sync_program, wait_for_all_cores_done, force_slow_dispatch);
 
     std::filesystem::path output_dir = std::filesystem::path(string(PROFILER_RUNTIME_ROOT_DIR) + string(PROFILER_LOGS_DIR_NAME));
     std::filesystem::path log_path = output_dir / "sync_device_info.csv";
@@ -126,7 +128,8 @@ void syncDeviceHost(Device *device, CoreCoord logical_core, std::shared_ptr<tt_m
         writeTimes[i] = (TracyGetCpuTime() - writeStart);
     }
 
-    Finish(device->command_queue());
+    std::unordered_set<CoreCoord> not_done_cores({core});
+    llrt::internal_::wait_until_cores_done(device_id, RUN_MSG_GO, not_done_cores);
 
     log_info ("SYNC PROGRAM FINISH IS DONE ON {}",device_id);
     if ((smallestHostime[device_id] == 0) || (smallestHostime[device_id] > hostStartTime))


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/10550
### Problem description
Without this profiler sync programs cannot be loaded to remote chips as part of init.

### What's changed

Profiler sync program is pushed using slow dispatch

### Checklist
- [x] Post commit CI passes : https://github.com/tenstorrent/tt-metal/actions/runs/10372009819
- [x] T3K Profiler : https://github.com/tenstorrent/tt-metal/actions/runs/10374307593
- [x] Device perf profiler : https://github.com/tenstorrent/tt-metal/actions/runs/10066342947
