### PR TITLE
#9898: Refactoring moreh nll loss

### DIFF
--- a/ttnn/cpp/ttnn/deprecated/tt_dnn/op_library/moreh_linear_backward/moreh_linear_backward_op.cpp
+++ b/ttnn/cpp/ttnn/deprecated/tt_dnn/op_library/moreh_linear_backward/moreh_linear_backward_op.cpp
@@ -133,7 +133,7 @@ std::vector<std::optional<Tensor>> moreh_linear_backward(
                 moreh_matmul(output_grad, input, true, false, std::nullopt, std::nullopt, weight_grad_mem_config);
             TT_ASSERT(weight_grad.has_value(), "weight_grad tensor should not be std::nullopt");
             std::vector<int64_t> dims = find_reduce_dim(temp_weight_grad.get_legacy_shape(), weight_grad.value().get_legacy_shape());
-            moreh_sum(temp_weight_grad, dims, true, weight_grad.value());
+            moreh_sum(temp_weight_grad, dims, true, weight_grad.value(), weight_grad_mem_config, compute_kernel_config);
         }
         result[1] = weight_grad_tensor;
     }

--- a/ttnn/cpp/ttnn/deprecated/tt_dnn/op_library/moreh_nll_loss/moreh_nll_loss_op.cpp
+++ b/ttnn/cpp/ttnn/deprecated/tt_dnn/op_library/moreh_nll_loss/moreh_nll_loss_op.cpp
@@ -317,10 +317,10 @@ Tensor moreh_nll_loss(
             reduction_mean,
             output_dtype,
             channel_size,
-            output_mem_config,
+            operation::DEFAULT_OUTPUT_MEMORY_CONFIG,
             compute_kernel_config);
 
-        moreh_sum(step1_result, std::nullopt, false, divisor_tensor.value());
+        moreh_sum(step1_result, std::nullopt, false, divisor_tensor.value(), operation::DEFAULT_OUTPUT_MEMORY_CONFIG, compute_kernel_config);
 
         const Tensor& step2_result = moreh_nll_loss_step2(
             input_tensor,
@@ -329,9 +329,9 @@ Tensor moreh_nll_loss(
             divisor_tensor,
             ignore_index,
             reduction_mean,
-            output_mem_config,
+            operation::DEFAULT_OUTPUT_MEMORY_CONFIG,
             compute_kernel_config);
-        return moreh_sum(step2_result, std::nullopt, false, output_tensor);
+        return moreh_sum(step2_result, std::nullopt, false, output_tensor, output_mem_config, compute_kernel_config);
     } else {
         const Tensor& step2_result = moreh_nll_loss_step2(
             input_tensor,
@@ -340,10 +340,10 @@ Tensor moreh_nll_loss(
             std::nullopt,
             ignore_index,
             reduction_mean,
-            output_mem_config,
+            operation::DEFAULT_OUTPUT_MEMORY_CONFIG,
             compute_kernel_config);
 
-        return moreh_sum(step2_result, std::nullopt, false, output_tensor);
+        return moreh_sum(step2_result, std::nullopt, false, output_tensor, output_mem_config, compute_kernel_config);
     }
 }
 

--- a/ttnn/cpp/ttnn/deprecated/tt_dnn/op_library/moreh_nll_loss/moreh_nll_loss_op.cpp
+++ b/ttnn/cpp/ttnn/deprecated/tt_dnn/op_library/moreh_nll_loss/moreh_nll_loss_op.cpp
@@ -317,10 +317,10 @@ Tensor moreh_nll_loss(
             reduction_mean,
             output_dtype,
             channel_size,
-            operation::DEFAULT_OUTPUT_MEMORY_CONFIG,
+            output_mem_config,
             compute_kernel_config);
 
-        moreh_sum(step1_result, std::nullopt, false, divisor_tensor.value(), operation::DEFAULT_OUTPUT_MEMORY_CONFIG, compute_kernel_config);
+        moreh_sum(step1_result, std::nullopt, false, divisor_tensor.value(), output_mem_config, compute_kernel_config);
 
         const Tensor& step2_result = moreh_nll_loss_step2(
             input_tensor,
@@ -329,7 +329,7 @@ Tensor moreh_nll_loss(
             divisor_tensor,
             ignore_index,
             reduction_mean,
-            operation::DEFAULT_OUTPUT_MEMORY_CONFIG,
+            output_mem_config,
             compute_kernel_config);
         return moreh_sum(step2_result, std::nullopt, false, output_tensor, output_mem_config, compute_kernel_config);
     } else {
@@ -340,7 +340,7 @@ Tensor moreh_nll_loss(
             std::nullopt,
             ignore_index,
             reduction_mean,
-            operation::DEFAULT_OUTPUT_MEMORY_CONFIG,
+            output_mem_config,
             compute_kernel_config);
 
         return moreh_sum(step2_result, std::nullopt, false, output_tensor, output_mem_config, compute_kernel_config);


### PR DESCRIPTION
### Ticket
[Link to Github Issue](https://github.com/tenstorrent/tt-metal/issues/9898)

### Problem description
Although the functionality to accept `compute_kernel_config` has been added to `moreh_sum`, this feature has not been applied in the part where `moreh_sum` is called in `moreh_nll_loss` and `moreh_linear_backward`.

### What's changed

Add `compute_kernel_config` to the call to `moreh_sum` in `moreh_nll_loss`  and `moreh_linear_backward`

### Checklist
- [x] Post commit CI passes
- [x] Model regression CI testing passes (if applicable)
- [x] New/Existing tests provide coverage for changes
