### PR TITLE
#10137: Move remaining binary composite ops to ttnn

### DIFF
--- a/docs/source/ttnn/ttnn/api.rst
+++ b/docs/source/ttnn/ttnn/api.rst
@@ -281,6 +281,8 @@ Pointwise Binary
    ttnn/floor_div
    ttnn/binary_remainder
    ttnn/binary_fmod
+   ttnn/logical_and_
+   ttnn/logical_or_
    ttnn/pow
    ttnn/ldexp
    ttnn/logical_and

--- a/docs/source/ttnn/ttnn/api.rst
+++ b/docs/source/ttnn/ttnn/api.rst
@@ -283,6 +283,7 @@ Pointwise Binary
    ttnn/binary_fmod
    ttnn/logical_and_
    ttnn/logical_or_
+   ttnn/logical_xor_
    ttnn/pow
    ttnn/ldexp
    ttnn/logical_and

--- a/docs/source/ttnn/ttnn/api.rst
+++ b/docs/source/ttnn/ttnn/api.rst
@@ -276,6 +276,11 @@ Pointwise Binary
    ttnn/subalpha
    ttnn/multiply
    ttnn/subtract
+   ttnn/div
+   ttnn/div_no_nan
+   ttnn/floor_div
+   ttnn/binary_remainder
+   ttnn/binary_fmod
    ttnn/pow
    ttnn/ldexp
    ttnn/logical_and

--- a/docs/source/ttnn/ttnn/ttnn/binary_fmod.rst
+++ b/docs/source/ttnn/ttnn/ttnn/binary_fmod.rst
@@ -1,0 +1,6 @@
+.. _ttnn.binary_fmod:
+
+ttnn.binary_fmod
+################
+
+.. autofunction:: ttnn.binary_fmod

--- a/docs/source/ttnn/ttnn/ttnn/binary_remainder.rst
+++ b/docs/source/ttnn/ttnn/ttnn/binary_remainder.rst
@@ -1,0 +1,6 @@
+.. _ttnn.binary_remainder:
+
+ttnn.binary_remainder
+#####################
+
+.. autofunction:: ttnn.binary_remainder

--- a/docs/source/ttnn/ttnn/ttnn/div.rst
+++ b/docs/source/ttnn/ttnn/ttnn/div.rst
@@ -1,0 +1,6 @@
+.. _ttnn.div:
+
+ttnn.div
+########
+
+.. autofunction:: ttnn.div

--- a/docs/source/ttnn/ttnn/ttnn/div_no_nan.rst
+++ b/docs/source/ttnn/ttnn/ttnn/div_no_nan.rst
@@ -1,0 +1,6 @@
+.. _ttnn.div_no_nan:
+
+ttnn.div_no_nan
+###############
+
+.. autofunction:: ttnn.div_no_nan

--- a/docs/source/ttnn/ttnn/ttnn/floor_div.rst
+++ b/docs/source/ttnn/ttnn/ttnn/floor_div.rst
@@ -1,0 +1,6 @@
+.. _ttnn.floor_div:
+
+ttnn.floor_div
+##############
+
+.. autofunction:: ttnn.floor_div

--- a/docs/source/ttnn/ttnn/ttnn/logical_and_.rst
+++ b/docs/source/ttnn/ttnn/ttnn/logical_and_.rst
@@ -1,0 +1,6 @@
+.. _ttnn.logical_and_:
+
+ttnn.logical_and_
+##################
+
+.. autofunction:: ttnn.logical_and_

--- a/docs/source/ttnn/ttnn/ttnn/logical_or_.rst
+++ b/docs/source/ttnn/ttnn/ttnn/logical_or_.rst
@@ -1,0 +1,6 @@
+.. _ttnn.logical_or_:
+
+ttnn.logical_or_
+##################
+
+.. autofunction:: ttnn.logical_or_

--- a/docs/source/ttnn/ttnn/ttnn/logical_xor_.rst
+++ b/docs/source/ttnn/ttnn/ttnn/logical_xor_.rst
@@ -1,0 +1,6 @@
+.. _ttnn.logical_xor_:
+
+ttnn.logical_xor_
+##################
+
+.. autofunction:: ttnn.logical_xor_

--- a/tests/ttnn/unit_tests/operations/test_binary_composite.py
+++ b/tests/ttnn/unit_tests/operations/test_binary_composite.py
@@ -6,6 +6,7 @@ import torch
 import pytest
 import ttnn
 from tests.ttnn.unit_tests.operations.backward.utility_funcs import data_gen_with_range, compare_pcc
+from models.utility_functions import is_grayskull, skip_for_grayskull
 
 
 @pytest.mark.parametrize(
@@ -209,6 +210,182 @@ def test_binary_subalpha_ttnn(input_shapes, alpha, device):
     output_tensor = ttnn.subalpha(input_tensor1, input_tensor2, alpha)
     golden_function = ttnn.get_golden_function(ttnn.subalpha)
     golden_tensor = golden_function(in_data1, in_data2, alpha)
+
+    comp_pass = compare_pcc([output_tensor], [golden_tensor])
+    assert comp_pass
+
+
+@pytest.mark.parametrize("accurate_mode", [False, True])
+@pytest.mark.parametrize("round_mode", ["None", "trunc", "floor"])
+@pytest.mark.parametrize(
+    "input_shapes",
+    (
+        (torch.Size([1, 1, 32, 32])),
+        (torch.Size([1, 1, 320, 384])),
+        (torch.Size([1, 3, 320, 384])),
+    ),
+)
+def test_binary_div_ttnn(accurate_mode, round_mode, input_shapes, device):
+    if is_grayskull():
+        if round_mode in ["trunc", "floor"]:
+            pytest.skip("does not work for Grayskull -skipping")
+    if accurate_mode == False:  # If input_b is non-zero tensor
+        in_data1, input_tensor1 = data_gen_with_range(input_shapes, -100, 100, device)
+        in_data2, input_tensor2 = data_gen_with_range(input_shapes, -150, -1, device)
+    else:
+        in_data1, input_tensor1 = data_gen_with_range(input_shapes, -100, 100, device)
+        in_data2, input_tensor2 = data_gen_with_range(input_shapes, -100, 100, device)
+
+    output_tensor = ttnn.div(input_tensor1, input_tensor2, accurate_mode=accurate_mode, round_mode=round_mode)
+    golden_function = ttnn.get_golden_function(ttnn.div)
+    golden_tensor = golden_function(in_data1, in_data2, round_mode)
+
+    comp_pass = compare_pcc([output_tensor], [golden_tensor])
+    assert comp_pass
+
+
+@pytest.mark.parametrize("accurate_mode", [False, True])
+@pytest.mark.parametrize("round_mode", ["None", "trunc", "floor"])
+@pytest.mark.parametrize(
+    "input_shapes",
+    (
+        (torch.Size([1, 1, 32, 32])),
+        (torch.Size([1, 1, 320, 384])),
+        (torch.Size([1, 3, 320, 384])),
+    ),
+)
+@pytest.mark.parametrize("value", [-5.1, 0.0, 10.9])
+def test_binary_div_overload_ttnn(accurate_mode, round_mode, input_shapes, value, device):
+    if is_grayskull():
+        if round_mode in ["trunc", "floor"]:
+            pytest.skip("does not work for Grayskull -skipping")
+    in_data1, input_tensor1 = data_gen_with_range(input_shapes, -100, 100, device)
+
+    output_tensor = ttnn.div(input_tensor1, value, accurate_mode=accurate_mode, round_mode=round_mode)
+    golden_function = ttnn.get_golden_function(ttnn.div)
+    golden_tensor = golden_function(in_data1, value, round_mode)
+
+    comp_pass = compare_pcc([output_tensor], [golden_tensor])
+    assert comp_pass
+
+
+@pytest.mark.parametrize(
+    "input_shapes",
+    (
+        (torch.Size([1, 1, 32, 32])),
+        (torch.Size([1, 1, 320, 384])),
+        (torch.Size([1, 3, 320, 384])),
+    ),
+)
+def test_binary_div_no_nan_ttnn(input_shapes, device):
+    in_data1, input_tensor1 = data_gen_with_range(input_shapes, -100, 100, device)
+    in_data2, input_tensor2 = data_gen_with_range(input_shapes, -150, 150, device)
+
+    output_tensor = ttnn.div_no_nan(input_tensor1, input_tensor2)
+    golden_function = ttnn.get_golden_function(ttnn.div_no_nan)
+    golden_tensor = golden_function(in_data1, in_data2)
+
+    comp_pass = compare_pcc([output_tensor], [golden_tensor])
+    assert comp_pass
+
+
+@pytest.mark.parametrize(
+    "input_shapes",
+    (
+        (torch.Size([1, 1, 32, 32])),
+        (torch.Size([1, 1, 320, 384])),
+        (torch.Size([1, 3, 320, 384])),
+    ),
+)
+@pytest.mark.parametrize("value", [-5.1, 0.0, 10.9])
+def test_binary_div_no_nan_overload_ttnn(input_shapes, value, device):
+    in_data1, input_tensor1 = data_gen_with_range(input_shapes, -100, 100, device)
+
+    output_tensor = ttnn.div_no_nan(input_tensor1, value)
+    golden_function = ttnn.get_golden_function(ttnn.div_no_nan)
+    golden_tensor = golden_function(in_data1, value)
+
+    comp_pass = compare_pcc([output_tensor], [golden_tensor])
+    assert comp_pass
+
+
+@pytest.mark.parametrize(
+    "input_shapes",
+    (
+        (torch.Size([1, 1, 32, 32])),
+        (torch.Size([1, 1, 320, 384])),
+        (torch.Size([1, 3, 320, 384])),
+    ),
+)
+@skip_for_grayskull("#ToDo: GS implementation needs to be done for Floor")
+def test_binary_floor_div_ttnn(input_shapes, device):
+    in_data1, input_tensor1 = data_gen_with_range(input_shapes, -350, 100, device)
+    in_data2, input_tensor2 = data_gen_with_range(input_shapes, -100, 100, device)
+    output_tensor = ttnn.floor_div(input_tensor1, input_tensor2)
+    golden_function = ttnn.get_golden_function(ttnn.floor_div)
+    golden_tensor = golden_function(in_data1, in_data2)
+
+    comp_pass = compare_pcc([output_tensor], [golden_tensor])
+    assert comp_pass
+
+
+@pytest.mark.parametrize(
+    "input_shapes",
+    (
+        (torch.Size([1, 1, 32, 32])),
+        (torch.Size([1, 1, 320, 384])),
+        (torch.Size([1, 3, 320, 384])),
+    ),
+)
+@pytest.mark.parametrize("value", [-5.1, 0.0, 10.9])
+@skip_for_grayskull("#ToDo: GS implementation needs to be done for Floor")
+def test_binary_floor_div_overload_ttnn(input_shapes, value, device):
+    in_data1, input_tensor1 = data_gen_with_range(input_shapes, -100, 100, device)
+
+    output_tensor = ttnn.floor_div(input_tensor1, value)
+    golden_function = ttnn.get_golden_function(ttnn.floor_div)
+    golden_tensor = golden_function(in_data1, value)
+
+    comp_pass = compare_pcc([output_tensor], [golden_tensor])
+    assert comp_pass
+
+
+@pytest.mark.parametrize(
+    "input_shapes",
+    (
+        (torch.Size([1, 1, 32, 32])),
+        (torch.Size([1, 1, 320, 384])),
+        (torch.Size([1, 3, 320, 384])),
+    ),
+)
+@skip_for_grayskull("#ToDo: GS implementation needs to be done for remainder")
+def test_binary_remainder_ttnn(input_shapes, device):
+    in_data1, input_tensor1 = data_gen_with_range(input_shapes, -150, 150, device)
+    in_data2, input_tensor2 = data_gen_with_range(input_shapes, -100, 100, device)
+    output_tensor = ttnn.binary_remainder(input_tensor1, input_tensor2)
+    golden_function = ttnn.get_golden_function(ttnn.binary_remainder)
+    golden_tensor = golden_function(in_data1, in_data2)
+
+    comp_pass = compare_pcc([output_tensor], [golden_tensor])
+    assert comp_pass
+
+
+@pytest.mark.parametrize(
+    "input_shapes",
+    (
+        (torch.Size([1, 1, 32, 32])),
+        (torch.Size([1, 1, 320, 384])),
+        (torch.Size([1, 3, 320, 384])),
+    ),
+)
+@skip_for_grayskull("#ToDo: GS implementation needs to be done for fmod")
+def test_binary_fmod_ttnn(input_shapes, device):
+    in_data1, input_tensor1 = data_gen_with_range(input_shapes, -150, 150, device)
+    in_data2, input_tensor2 = data_gen_with_range(input_shapes, -100, 100, device)
+
+    output_tensor = ttnn.binary_fmod(input_tensor1, input_tensor2)
+    golden_function = ttnn.get_golden_function(ttnn.binary_fmod)
+    golden_tensor = golden_function(in_data1, in_data2)
 
     comp_pass = compare_pcc([output_tensor], [golden_tensor])
     assert comp_pass

--- a/tests/ttnn/unit_tests/operations/test_binary_composite.py
+++ b/tests/ttnn/unit_tests/operations/test_binary_composite.py
@@ -399,7 +399,7 @@ def test_binary_fmod_ttnn(input_shapes, device):
         (torch.Size([1, 3, 320, 384])),
     ),
 )
-def test_binary_logical_and_ttnn(input_shapes, device):
+def test_binary_logical_and__ttnn(input_shapes, device):
     in_data1, input_tensor1 = data_gen_with_range(input_shapes, -150, 150, device)
     in_data2, input_tensor2 = data_gen_with_range(input_shapes, -100, 100, device)
     ttnn.logical_and_(input_tensor1, input_tensor2)
@@ -418,11 +418,30 @@ def test_binary_logical_and_ttnn(input_shapes, device):
         (torch.Size([1, 3, 320, 384])),
     ),
 )
-def test_binary_logical_or_ttnn(input_shapes, device):
+def test_binary_logical_or__ttnn(input_shapes, device):
     in_data1, input_tensor1 = data_gen_with_range(input_shapes, -150, 150, device)
     in_data2, input_tensor2 = data_gen_with_range(input_shapes, -100, 100, device)
     ttnn.logical_or_(input_tensor1, input_tensor2)
     golden_function = ttnn.get_golden_function(ttnn.logical_or_)
+    golden_tensor = golden_function(in_data1, in_data2)
+
+    comp_pass = compare_pcc([input_tensor1], [golden_tensor])
+    assert comp_pass
+
+
+@pytest.mark.parametrize(
+    "input_shapes",
+    (
+        (torch.Size([1, 1, 32, 32])),
+        (torch.Size([1, 1, 320, 384])),
+        (torch.Size([1, 3, 320, 384])),
+    ),
+)
+def test_binary_logical_xor__ttnn(input_shapes, device):
+    in_data1, input_tensor1 = data_gen_with_range(input_shapes, -150, 150, device)
+    in_data2, input_tensor2 = data_gen_with_range(input_shapes, -100, 100, device)
+    ttnn.logical_xor_(input_tensor1, input_tensor2)
+    golden_function = ttnn.get_golden_function(ttnn.logical_xor_)
     golden_tensor = golden_function(in_data1, in_data2)
 
     comp_pass = compare_pcc([input_tensor1], [golden_tensor])

--- a/tests/ttnn/unit_tests/operations/test_binary_composite.py
+++ b/tests/ttnn/unit_tests/operations/test_binary_composite.py
@@ -389,3 +389,41 @@ def test_binary_fmod_ttnn(input_shapes, device):
 
     comp_pass = compare_pcc([output_tensor], [golden_tensor])
     assert comp_pass
+
+
+@pytest.mark.parametrize(
+    "input_shapes",
+    (
+        (torch.Size([1, 1, 32, 32])),
+        (torch.Size([1, 1, 320, 384])),
+        (torch.Size([1, 3, 320, 384])),
+    ),
+)
+def test_binary_logical_and_ttnn(input_shapes, device):
+    in_data1, input_tensor1 = data_gen_with_range(input_shapes, -150, 150, device)
+    in_data2, input_tensor2 = data_gen_with_range(input_shapes, -100, 100, device)
+    ttnn.logical_and_(input_tensor1, input_tensor2)
+    golden_function = ttnn.get_golden_function(ttnn.logical_and_)
+    golden_tensor = golden_function(in_data1, in_data2)
+
+    comp_pass = compare_pcc([input_tensor1], [golden_tensor])
+    assert comp_pass
+
+
+@pytest.mark.parametrize(
+    "input_shapes",
+    (
+        (torch.Size([1, 1, 32, 32])),
+        (torch.Size([1, 1, 320, 384])),
+        (torch.Size([1, 3, 320, 384])),
+    ),
+)
+def test_binary_logical_or_ttnn(input_shapes, device):
+    in_data1, input_tensor1 = data_gen_with_range(input_shapes, -150, 150, device)
+    in_data2, input_tensor2 = data_gen_with_range(input_shapes, -100, 100, device)
+    ttnn.logical_or_(input_tensor1, input_tensor2)
+    golden_function = ttnn.get_golden_function(ttnn.logical_or_)
+    golden_tensor = golden_function(in_data1, in_data2)
+
+    comp_pass = compare_pcc([input_tensor1], [golden_tensor])
+    assert comp_pass

--- a/ttnn/cpp/ttnn/deprecated/tt_dnn/op_library/composite/composite_ops.cpp
+++ b/ttnn/cpp/ttnn/deprecated/tt_dnn/op_library/composite/composite_ops.cpp
@@ -933,7 +933,6 @@ Tensor addcdiv(
 Tensor _div(const Tensor& input_a, const Tensor& input_b, bool accurate_mode, string round_mode,  const MemoryConfig& output_mem_config) {
     TT_FATAL((round_mode == "None" || round_mode == "trunc" || round_mode == "floor") && "Incorrect rounding mode (expected 'None', 'trunc', or 'floor')");
     Tensor result = ttnn::divide(input_a, input_b);
-
     if(round_mode == "trunc"){
         result = trunc(result);
     }

--- a/ttnn/cpp/ttnn/operations/eltwise/binary/binary_composite.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary/binary_composite.hpp
@@ -148,6 +148,15 @@ constexpr auto div_no_nan = ttnn::register_operation<
 constexpr auto floor_div = ttnn::register_operation<
     "ttnn::floor_div",
     operations::binary::ExecuteBinaryCompositeOpsOverload<operations::binary::BinaryCompositeOpType::FLOOR_DIV>>();
+constexpr auto logical_and_ = ttnn::register_operation<
+    "ttnn::logical_and_",
+    operations::binary::ExecuteBinaryCompositeOps<operations::binary::BinaryCompositeOpType::LOGICAL_AND_>>();
+constexpr auto logical_or_ = ttnn::register_operation<
+    "ttnn::logical_or_",
+    operations::binary::ExecuteBinaryCompositeOps<operations::binary::BinaryCompositeOpType::LOGICAL_OR_>>();
+constexpr auto logical_xor_ = ttnn::register_operation<
+    "ttnn::logical_xor_",
+    operations::binary::ExecuteBinaryCompositeOps<operations::binary::BinaryCompositeOpType::LOGICAL_XOR_>>();
 // newly imported
 
 }  // namespace ttnn

--- a/ttnn/cpp/ttnn/operations/eltwise/binary/binary_composite.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary/binary_composite.hpp
@@ -54,58 +54,47 @@ struct ExecuteBinaryCompositeOpsIsClose
 template <BinaryCompositeOpType binary_comp_op_type>
 struct ExecuteDivLikeOps
 {
-    static Tensor execute_on_worker_thread(
+    static Tensor operator()(
         const Tensor& input_tensor_a,
         const Tensor& input_tensor_b,
-        const std::optional<MemoryConfig>& memory_config = std::nullopt)
-        {
-            auto op_type = get_binary_div_like_ops<binary_comp_op_type>();
-            return op_type(input_tensor_a, input_tensor_b, memory_config);
-        }
-
-    static Tensor execute_on_worker_thread(
+        const std::optional<MemoryConfig>& memory_config = std::nullopt) {
+        return OpHandler<binary_comp_op_type>::handle(input_tensor_a, input_tensor_b, memory_config);
+    }
+    static Tensor operator()(
         const Tensor& input_tensor_a,
         float value,
-        const std::optional<MemoryConfig>& memory_config = std::nullopt)
-        {
-            auto op_type = get_binary_div_like_ops_overload<binary_comp_op_type>();
-            return op_type(input_tensor_a, value, memory_config);
-        }
+        const std::optional<MemoryConfig>& memory_config = std::nullopt) {
+        return OpHandler<binary_comp_op_type>::handle(input_tensor_a, value, memory_config);
+    }
 };
 
 template <BinaryCompositeOpType binary_comp_op_type>
 struct ExecuteBinaryCompositeOpsDiv
 {
-    static Tensor execute_on_worker_thread(
+    static Tensor operator()(
         const Tensor& input_tensor_a,
         const Tensor& input_tensor_b,
         bool accurate_mode = false,
-        string round_mode = "None",
-        const std::optional<MemoryConfig>& memory_config = std::nullopt)
-        {
-            auto op_type = get_binary_div<binary_comp_op_type>();
-            return op_type(input_tensor_a, input_tensor_b, accurate_mode, round_mode, memory_config);
-        }
-
-    static Tensor execute_on_worker_thread(
+        std::string round_mode = "None",
+        const std::optional<MemoryConfig>& memory_config = std::nullopt) {
+        return OpHandler<binary_comp_op_type>::handle(input_tensor_a, input_tensor_b, accurate_mode, round_mode, memory_config);
+    }
+    static Tensor operator()(
         const Tensor& input_tensor_a,
         float value,
         bool accurate_mode = false,
-        string round_mode = "None",
-        const std::optional<MemoryConfig>& memory_config = std::nullopt)
-        {
-            auto op_type = get_binary_div_overload<binary_comp_op_type>();
-            return op_type(input_tensor_a, value, accurate_mode, round_mode, memory_config);
-        }
+        std::string round_mode = "None",
+        const std::optional<MemoryConfig>& memory_config = std::nullopt) {
+        return OpHandler<binary_comp_op_type>::handle(input_tensor_a, value, accurate_mode, round_mode, memory_config);
+    }
 };
 
 }  // namespace binary
 }  // namespace operations
 
-    // newly imported
-    constexpr auto hypot = ttnn::register_operation_with_auto_launch_op<
-        "ttnn::hypot",
-        operations::binary::ExecuteBinaryCompositeOps<operations::binary::BinaryCompositeOpType::HYPOT>>();
+constexpr auto hypot = ttnn::register_operation_with_auto_launch_op<
+    "ttnn::hypot",
+    operations::binary::ExecuteBinaryCompositeOps<operations::binary::BinaryCompositeOpType::HYPOT>>();
 constexpr auto xlogy = ttnn::register_operation_with_auto_launch_op<
     "ttnn::xlogy",
     operations::binary::ExecuteBinaryCompositeOps<operations::binary::BinaryCompositeOpType::XLOGY>>();
@@ -133,30 +122,29 @@ constexpr auto subalpha = ttnn::register_operation_with_auto_launch_op<
 constexpr auto isclose = ttnn::register_operation_with_auto_launch_op<
     "ttnn::isclose",
     operations::binary::ExecuteBinaryCompositeOpsIsClose<operations::binary::BinaryCompositeOpType::ISCLOSE>>();
-constexpr auto binary_remainder = ttnn::register_operation<
+constexpr auto binary_remainder = ttnn::register_operation_with_auto_launch_op<
     "ttnn::binary_remainder",
     operations::binary::ExecuteBinaryCompositeOps<operations::binary::BinaryCompositeOpType::BINARY_REMAINDER>>();
-constexpr auto binary_fmod = ttnn::register_operation<
+constexpr auto binary_fmod = ttnn::register_operation_with_auto_launch_op<
     "ttnn::binary_fmod",
     operations::binary::ExecuteBinaryCompositeOps<operations::binary::BinaryCompositeOpType::BINARY_FMOD>>();
-constexpr auto div = ttnn::register_operation<
+constexpr auto div = ttnn::register_operation_with_auto_launch_op<
     "ttnn::div",
     operations::binary::ExecuteBinaryCompositeOpsDiv<operations::binary::BinaryCompositeOpType::DIV>>();
-constexpr auto div_no_nan = ttnn::register_operation<
+constexpr auto div_no_nan = ttnn::register_operation_with_auto_launch_op<
     "ttnn::div_no_nan",
-    operations::binary::ExecuteBinaryCompositeOpsOverload<operations::binary::BinaryCompositeOpType::DIV_NO_NAN>>();
-constexpr auto floor_div = ttnn::register_operation<
+    operations::binary::ExecuteDivLikeOps<operations::binary::BinaryCompositeOpType::DIV_NO_NAN>>();
+constexpr auto floor_div = ttnn::register_operation_with_auto_launch_op<
     "ttnn::floor_div",
-    operations::binary::ExecuteBinaryCompositeOpsOverload<operations::binary::BinaryCompositeOpType::FLOOR_DIV>>();
-constexpr auto logical_and_ = ttnn::register_operation<
+    operations::binary::ExecuteDivLikeOps<operations::binary::BinaryCompositeOpType::FLOOR_DIV>>();
+constexpr auto logical_and_ = ttnn::register_operation_with_auto_launch_op<
     "ttnn::logical_and_",
     operations::binary::ExecuteBinaryCompositeOps<operations::binary::BinaryCompositeOpType::LOGICAL_AND_>>();
-constexpr auto logical_or_ = ttnn::register_operation<
+constexpr auto logical_or_ = ttnn::register_operation_with_auto_launch_op<
     "ttnn::logical_or_",
     operations::binary::ExecuteBinaryCompositeOps<operations::binary::BinaryCompositeOpType::LOGICAL_OR_>>();
-constexpr auto logical_xor_ = ttnn::register_operation<
+constexpr auto logical_xor_ = ttnn::register_operation_with_auto_launch_op<
     "ttnn::logical_xor_",
     operations::binary::ExecuteBinaryCompositeOps<operations::binary::BinaryCompositeOpType::LOGICAL_XOR_>>();
-// newly imported
 
 }  // namespace ttnn

--- a/ttnn/cpp/ttnn/operations/eltwise/binary/binary_composite.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary/binary_composite.hpp
@@ -52,14 +52,14 @@ struct ExecuteBinaryCompositeOpsIsClose
 };
 
 template <BinaryCompositeOpType binary_comp_op_type>
-struct ExecuteBinaryCompositeOpsOverload
+struct ExecuteDivLikeOps
 {
     static Tensor execute_on_worker_thread(
         const Tensor& input_tensor_a,
         const Tensor& input_tensor_b,
         const std::optional<MemoryConfig>& memory_config = std::nullopt)
         {
-            auto op_type = get_function_divnonan_floordiv<binary_comp_op_type>();
+            auto op_type = get_binary_div_like_ops<binary_comp_op_type>();
             return op_type(input_tensor_a, input_tensor_b, memory_config);
         }
 
@@ -68,7 +68,7 @@ struct ExecuteBinaryCompositeOpsOverload
         float value,
         const std::optional<MemoryConfig>& memory_config = std::nullopt)
         {
-            auto op_type = get_function_divnonan_floordiv_overload<binary_comp_op_type>();
+            auto op_type = get_binary_div_like_ops_overload<binary_comp_op_type>();
             return op_type(input_tensor_a, value, memory_config);
         }
 };
@@ -83,7 +83,7 @@ struct ExecuteBinaryCompositeOpsDiv
         string round_mode = "None",
         const std::optional<MemoryConfig>& memory_config = std::nullopt)
         {
-            auto op_type = get_function_div<binary_comp_op_type>();
+            auto op_type = get_binary_div<binary_comp_op_type>();
             return op_type(input_tensor_a, input_tensor_b, accurate_mode, round_mode, memory_config);
         }
 
@@ -94,7 +94,7 @@ struct ExecuteBinaryCompositeOpsDiv
         string round_mode = "None",
         const std::optional<MemoryConfig>& memory_config = std::nullopt)
         {
-            auto op_type = get_function_div_overload<binary_comp_op_type>();
+            auto op_type = get_binary_div_overload<binary_comp_op_type>();
             return op_type(input_tensor_a, value, accurate_mode, round_mode, memory_config);
         }
 };

--- a/ttnn/cpp/ttnn/operations/eltwise/binary/binary_pybind.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary/binary_pybind.hpp
@@ -521,13 +521,19 @@ void py_module(py::module& module) {
     detail::bind_binary_composite(
         module,
         ttnn::logical_or_,
-        R"doc(Compute logical OR of :attr:`input_tensor_a` and :attr:`input_tensor_b` and returns the tensor with the same layout as :attr:`input_tensor_a`
+        R"doc(Compute inplace logical OR of :attr:`input_tensor_a` and :attr:`input_tensor_b` and returns the tensor with the same layout as :attr:`input_tensor_a`
+        .. math:: \mathrm{{input\_tensor\_a}}_i || \mathrm{{input\_tensor\_b}}_i)doc");
+
+    detail::bind_binary_composite(
+        module,
+        ttnn::logical_xor_,
+        R"doc(Compute inplace logical XOR of :attr:`input_tensor_a` and :attr:`input_tensor_b` and returns the tensor with the same layout as :attr:`input_tensor_a`
         .. math:: \mathrm{{input\_tensor\_a}}_i || \mathrm{{input\_tensor\_b}}_i)doc");
 
     detail::bind_binary_composite(
         module,
         ttnn::logical_and_,
-        R"doc(Compute logical AND of :attr:`input_tensor_a` and :attr:`input_tensor_b` and returns the tensor with the same layout as :attr:`input_tensor_a`
+        R"doc(Compute inplace logical AND of :attr:`input_tensor_a` and :attr:`input_tensor_b` and returns the tensor with the same layout as :attr:`input_tensor_a`
         .. math:: \mathrm{{input\_tensor\_a}}_i || \mathrm{{input\_tensor\_b}}_i)doc");
 
     detail::bind_binary_composite_with_alpha(

--- a/ttnn/cpp/ttnn/operations/eltwise/binary/binary_pybind.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary/binary_pybind.hpp
@@ -311,7 +311,7 @@ void bind_div(py::module& module, const binary_operation_t& operation, const std
                const Tensor& input_tensor_a,
                const Tensor& input_tensor_b,
                bool accurate_mode,
-               string round_mode,
+               std::string round_mode,
                const std::optional<MemoryConfig>& memory_config) {
                     return self(input_tensor_a, input_tensor_b, accurate_mode, round_mode, memory_config);
                 },
@@ -327,7 +327,7 @@ void bind_div(py::module& module, const binary_operation_t& operation, const std
                const Tensor& input_tensor_a,
                float value,
                bool accurate_mode,
-               string round_mode,
+               std::string round_mode,
                const std::optional<MemoryConfig>& memory_config) {
                     return self(input_tensor_a, value, accurate_mode, round_mode, memory_config);
                 },

--- a/ttnn/cpp/ttnn/operations/eltwise/binary/binary_pybind.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary/binary_pybind.hpp
@@ -232,7 +232,7 @@ void bind_binary_composite_with_rtol_atol(py::module& module, const binary_opera
 }
 
 template <typename binary_operation_t>
-void bind_binary_composite_with_overload(py::module& module, const binary_operation_t& operation, const std::string& description) {
+void bind_div_like_ops(py::module& module, const binary_operation_t& operation, const std::string& description) {
     auto doc = fmt::format(
         R"doc({0}(input_tensor_a: ttnn.Tensor, input_tensor_b: ttnn.Tensor, *, memory_config: Optional[ttnn.MemoryConfig] = None) -> ttnn.Tensor
 
@@ -518,6 +518,18 @@ void py_module(py::module& module) {
         R"doc(Compute fmod :attr:`input_tensor_a` and :attr:`input_tensor_b` and returns the tensor with the same layout as :attr:`input_tensor_a`
         .. math:: \mathrm{{input\_tensor\_a}}_i || \mathrm{{input\_tensor\_b}}_i)doc");
 
+    detail::bind_binary_composite(
+        module,
+        ttnn::logical_or_,
+        R"doc(Compute logical OR of :attr:`input_tensor_a` and :attr:`input_tensor_b` and returns the tensor with the same layout as :attr:`input_tensor_a`
+        .. math:: \mathrm{{input\_tensor\_a}}_i || \mathrm{{input\_tensor\_b}}_i)doc");
+
+    detail::bind_binary_composite(
+        module,
+        ttnn::logical_and_,
+        R"doc(Compute logical AND of :attr:`input_tensor_a` and :attr:`input_tensor_b` and returns the tensor with the same layout as :attr:`input_tensor_a`
+        .. math:: \mathrm{{input\_tensor\_a}}_i || \mathrm{{input\_tensor\_b}}_i)doc");
+
     detail::bind_binary_composite_with_alpha(
         module,
         ttnn::addalpha,
@@ -542,17 +554,18 @@ void py_module(py::module& module) {
         R"doc(Compute div :attr:`input_tensor_a` and :attr:`input_tensor_b` and returns the tensor with the same layout as :attr:`input_tensor_a`
         .. math:: \mathrm{{input\_tensor\_a}}_i || \mathrm{{input\_tensor\_b}}_i)doc");
 
-    detail::bind_binary_composite_with_overload(
+    detail::bind_div_like_ops(
         module,
         ttnn::div_no_nan,
         R"doc(Compute div_no_nan :attr:`input_tensor_a` and :attr:`input_tensor_b` and returns the tensor with the same layout as :attr:`input_tensor_a`
         .. math:: \mathrm{{input\_tensor\_a}}_i || \mathrm{{input\_tensor\_b}}_i)doc");
 
-    detail::bind_binary_composite_with_overload(
+    detail::bind_div_like_ops(
         module,
         ttnn::floor_div,
         R"doc(Compute floor division :attr:`input_tensor_a` and :attr:`input_tensor_b` and returns the tensor with the same layout as :attr:`input_tensor_a`
         .. math:: \mathrm{{input\_tensor\_a}}_i || \mathrm{{input\_tensor\_b}}_i)doc");
+
 }
 
 }  // namespace binary

--- a/ttnn/cpp/ttnn/operations/eltwise/binary/binary_pybind.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary/binary_pybind.hpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+// SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -231,6 +231,114 @@ void bind_binary_composite_with_rtol_atol(py::module& module, const binary_opera
             py::arg("memory_config") = std::nullopt});
 }
 
+template <typename binary_operation_t>
+void bind_binary_composite_with_overload(py::module& module, const binary_operation_t& operation, const std::string& description) {
+    auto doc = fmt::format(
+        R"doc({0}(input_tensor_a: ttnn.Tensor, input_tensor_b: ttnn.Tensor, *, memory_config: Optional[ttnn.MemoryConfig] = None) -> ttnn.Tensor
+
+            Args:
+                * :attr:`input_tensor_a`
+                * :attr:`input_tensor_b` (ttnn.Tensor or Number)
+
+            Keyword Args:
+                * :attr:`memory_config` (Optional[ttnn.MemoryConfig]): Memory configuration for the operation.
+
+            Example:
+
+                >>> tensor1 = ttnn.to_device(ttnn.from_torch(torch.tensor((1, 2), dtype=torch.bfloat16)), device)
+                >>> tensor2 = ttnn.to_device(ttnn.from_torch(torch.tensor((0, 1), dtype=torch.bfloat16)), device)
+                >>> output = {1}(tensor1, tensor2/scalar)
+        )doc",
+        operation.base_name(),
+        operation.python_fully_qualified_name(),
+        description);
+
+    bind_registered_operation(
+        module,
+        operation,
+        doc,
+        ttnn::pybind_overload_t{
+            [](const binary_operation_t& self,
+               const Tensor& input_tensor_a,
+               const Tensor& input_tensor_b,
+               const std::optional<MemoryConfig>& memory_config) {
+                    return self(input_tensor_a, input_tensor_b, memory_config);
+                },
+            py::arg("input_tensor_a"),
+            py::arg("input_tensor_b"),
+            py::kw_only(),
+            py::arg("memory_config") = std::nullopt},
+
+        ttnn::pybind_overload_t{
+            [](const binary_operation_t& self,
+               const Tensor& input_tensor_a,
+               float value,
+               const std::optional<MemoryConfig>& memory_config) {
+                    return self(input_tensor_a, value, memory_config);
+                },
+            py::arg("input_tensor_a"),
+            py::arg("value"),
+            py::kw_only(),
+            py::arg("memory_config") = std::nullopt});
+}
+
+template <typename binary_operation_t>
+void bind_div(py::module& module, const binary_operation_t& operation, const std::string& description) {
+    auto doc = fmt::format(
+        R"doc({0}(input_tensor_a: ttnn.Tensor, input_tensor_b: ttnn.Tensor, *, memory_config: Optional[ttnn.MemoryConfig] = None) -> ttnn.Tensor
+            Args:
+                * :attr:`input_tensor_a`
+                * :attr:`input_tensor_b` (ttnn.Tensor or Number)
+                * :attr:`accurate_mode`: ``false`` if input_tensor_b is non-zero, else ``true``.
+                * :attr:`round_mode`
+            Keyword Args:
+                * :attr:`memory_config` (Optional[ttnn.MemoryConfig]): Memory configuration for the operation.
+            Example:
+                >>> tensor1 = ttnn.to_device(ttnn.from_torch(torch.tensor((1, 2), dtype=torch.bfloat16)), device)
+                >>> tensor2 = ttnn.to_device(ttnn.from_torch(torch.tensor((0, 1), dtype=torch.bfloat16)), device)
+                >>> output = {1}(tensor1, tensor2/scalar)
+        )doc",
+        operation.base_name(),
+        operation.python_fully_qualified_name(),
+        description);
+
+    bind_registered_operation(
+        module,
+        operation,
+        doc,
+        ttnn::pybind_overload_t{
+            [](const binary_operation_t& self,
+               const Tensor& input_tensor_a,
+               const Tensor& input_tensor_b,
+               bool accurate_mode,
+               string round_mode,
+               const std::optional<MemoryConfig>& memory_config) {
+                    return self(input_tensor_a, input_tensor_b, accurate_mode, round_mode, memory_config);
+                },
+            py::arg("input_tensor_a"),
+            py::arg("input_tensor_b"),
+            py::kw_only(),
+            py::arg("accurate_mode") = false,
+            py::arg("round_mode") = "None",
+            py::arg("memory_config") = std::nullopt},
+
+        ttnn::pybind_overload_t{
+            [](const binary_operation_t& self,
+               const Tensor& input_tensor_a,
+               float value,
+               bool accurate_mode,
+               string round_mode,
+               const std::optional<MemoryConfig>& memory_config) {
+                    return self(input_tensor_a, value, accurate_mode, round_mode, memory_config);
+                },
+            py::arg("input_tensor_a"),
+            py::arg("value"),
+            py::kw_only(),
+            py::arg("accurate_mode") = false,
+            py::arg("round_mode") = "None",
+            py::arg("memory_config") = std::nullopt});
+}
+
 }  // namespace detail
 
 void py_module(py::module& module) {
@@ -398,6 +506,18 @@ void py_module(py::module& module) {
         R"doc(Compute logical_xor :attr:`input_tensor_a` and :attr:`input_tensor_b` and returns the tensor with the same layout as :attr:`input_tensor_a`
         .. math:: \mathrm{{input\_tensor\_a}}_i || \mathrm{{input\_tensor\_b}}_i)doc");
 
+    detail::bind_binary_composite(
+        module,
+        ttnn::binary_remainder,
+        R"doc(Compute modulus :attr:`input_tensor_a` and :attr:`input_tensor_b` and returns the tensor with the same layout as :attr:`input_tensor_a`
+        .. math:: \mathrm{{input\_tensor\_a}}_i || \mathrm{{input\_tensor\_b}}_i)doc");
+
+    detail::bind_binary_composite(
+        module,
+        ttnn::binary_fmod,
+        R"doc(Compute fmod :attr:`input_tensor_a` and :attr:`input_tensor_b` and returns the tensor with the same layout as :attr:`input_tensor_a`
+        .. math:: \mathrm{{input\_tensor\_a}}_i || \mathrm{{input\_tensor\_b}}_i)doc");
+
     detail::bind_binary_composite_with_alpha(
         module,
         ttnn::addalpha,
@@ -414,6 +534,24 @@ void py_module(py::module& module) {
         module,
         ttnn::isclose,
         R"doc(Compute isclose :attr:`input_tensor_a` and :attr:`input_tensor_b` and returns the tensor with the same layout as :attr:`input_tensor_a`
+        .. math:: \mathrm{{input\_tensor\_a}}_i || \mathrm{{input\_tensor\_b}}_i)doc");
+
+    detail::bind_div(
+        module,
+        ttnn::div,
+        R"doc(Compute div :attr:`input_tensor_a` and :attr:`input_tensor_b` and returns the tensor with the same layout as :attr:`input_tensor_a`
+        .. math:: \mathrm{{input\_tensor\_a}}_i || \mathrm{{input\_tensor\_b}}_i)doc");
+
+    detail::bind_binary_composite_with_overload(
+        module,
+        ttnn::div_no_nan,
+        R"doc(Compute div_no_nan :attr:`input_tensor_a` and :attr:`input_tensor_b` and returns the tensor with the same layout as :attr:`input_tensor_a`
+        .. math:: \mathrm{{input\_tensor\_a}}_i || \mathrm{{input\_tensor\_b}}_i)doc");
+
+    detail::bind_binary_composite_with_overload(
+        module,
+        ttnn::floor_div,
+        R"doc(Compute floor division :attr:`input_tensor_a` and :attr:`input_tensor_b` and returns the tensor with the same layout as :attr:`input_tensor_a`
         .. math:: \mathrm{{input\_tensor\_a}}_i || \mathrm{{input\_tensor\_b}}_i)doc");
 }
 

--- a/ttnn/cpp/ttnn/operations/eltwise/binary/device/binary_composite_op.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary/device/binary_composite_op.cpp
@@ -11,7 +11,6 @@
 #include "ttnn/cpp/ttnn/operations/eltwise/ternary/where_op.hpp"
 #include "ttnn/cpp/ttnn/operations/copy.hpp"
 #include "ttnn/cpp/ttnn/operations/eltwise/binary/binary_composite.hpp"
-#include "ttnn/cpp/ttnn/operations/eltwise/unary/unary_composite.hpp"
 
 namespace ttnn::operations::binary{
 
@@ -158,7 +157,7 @@ Tensor _div_overload(const Tensor& input_a, float value, bool accurate_mode, str
     TT_FATAL((round_mode == "None" || round_mode == "trunc" || round_mode == "floor") && "Incorrect rounding mode (expected 'None', 'trunc', or 'floor')");
     Tensor result = ttnn::multiply(input_a, (1.0f/value), std::nullopt, output_mem_config);
     if(round_mode == "trunc"){
-        result = ttnn::trunc(result);
+        result = trunc(result);
     }
     else if(round_mode == "floor"){
         result = ttnn::floor(result);
@@ -176,7 +175,7 @@ Tensor _div(const Tensor& input_a, const Tensor& input_b, bool accurate_mode, st
         Tensor result = ttnn::divide(a, b);
 
         if(round_mode == "trunc"){
-            result = ttnn::trunc(result);
+            result = trunc(result);
         }
         else if(round_mode == "floor"){
             result = ttnn::floor(result);
@@ -200,7 +199,7 @@ Tensor _div(const Tensor& input_a, const Tensor& input_b, bool accurate_mode, st
         Tensor result = ttnn::divide(input_a, input_b);
 
         if(round_mode == "trunc"){
-            result = ttnn::trunc(result);
+            result = trunc(result);
         }
         else if(round_mode == "floor"){
             result = ttnn::floor(result);
@@ -297,6 +296,14 @@ Tensor _logical_and_(const Tensor& input_a, const Tensor& input_b, const std::op
 
 Tensor _logical_or_(const Tensor& input_a, const Tensor& input_b, const std::optional<MemoryConfig>& output_mem_config) {
     return ttnn::logical_or(input_a, input_b, std::nullopt, output_mem_config, input_a);
+}
+
+Tensor _logical_xor_(const Tensor& input_a, const Tensor& input_b, const std::optional<MemoryConfig>& output_mem_config) {
+    Tensor in_a_eq_zero = ttnn::eqz(input_a, output_mem_config, input_a );
+    Tensor in_b_eq_zero = ttnn::nez(input_b, output_mem_config, input_b );
+    in_b_eq_zero = ttnn::eqz(input_b, output_mem_config);
+    Tensor result = ttnn::where(input_a, input_b, in_b_eq_zero, output_mem_config, input_a);
+    return result;
 }
 
 } // namespace ttnn::operations::binary

--- a/ttnn/cpp/ttnn/operations/eltwise/binary/device/binary_composite_op.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary/device/binary_composite_op.hpp
@@ -28,7 +28,7 @@ enum class BinaryCompositeOpType {
     FLOOR_DIV,
     LOGICAL_AND_,
     LOGICAL_OR_,
-
+    LOGICAL_XOR_,
 };
 
 Tensor _hypot(const Tensor&, const Tensor&, const std::optional<MemoryConfig>&);
@@ -51,6 +51,7 @@ Tensor _floor_div(const Tensor&, const Tensor&, const std::optional<MemoryConfig
 Tensor _floor_div_overload(const Tensor&, float, const std::optional<MemoryConfig>&);
 Tensor _logical_or_(const Tensor&, const Tensor&, const std::optional<MemoryConfig>&);
 Tensor _logical_and_(const Tensor&, const Tensor&, const std::optional<MemoryConfig>&);
+Tensor _logical_xor_(const Tensor&, const Tensor&, const std::optional<MemoryConfig>&);
 
 // OpHandler struct template
 template <BinaryCompositeOpType OpType>

--- a/ttnn/cpp/ttnn/operations/eltwise/binary/device/binary_composite_op.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary/device/binary_composite_op.hpp
@@ -26,6 +26,8 @@ enum class BinaryCompositeOpType {
     DIV,
     DIV_NO_NAN,
     FLOOR_DIV,
+    LOGICAL_AND_,
+    LOGICAL_OR_,
 
 };
 
@@ -47,6 +49,8 @@ Tensor _div_no_nan(const Tensor&, const Tensor&, const std::optional<MemoryConfi
 Tensor _div_no_nan_overload(const Tensor&, float, const std::optional<MemoryConfig>&);
 Tensor _floor_div(const Tensor&, const Tensor&, const std::optional<MemoryConfig>&);
 Tensor _floor_div_overload(const Tensor&, float, const std::optional<MemoryConfig>&);
+Tensor _logical_or_(const Tensor&, const Tensor&, const std::optional<MemoryConfig>&);
+Tensor _logical_and_(const Tensor&, const Tensor&, const std::optional<MemoryConfig>&);
 
 // OpHandler struct template
 template <BinaryCompositeOpType OpType>
@@ -140,22 +144,22 @@ struct OpHandler<BinaryCompositeOpType::ISCLOSE> {
 using HandleFunctionPtr1 = Tensor (*)(const Tensor&, const Tensor&, const std::optional<MemoryConfig>&);
 using HandleFunctionPtr2 = Tensor (*)(const Tensor&, float, const std::optional<MemoryConfig>&);
 template <BinaryCompositeOpType OpType>
-auto get_function_divnonan_floordiv() -> HandleFunctionPtr1 {
+auto get_binary_div_like_ops() -> HandleFunctionPtr1 {
     return &OpHandler_Overload<OpType>::handle;
 }
 template <BinaryCompositeOpType OpType>
-auto get_function_divnonan_floordiv_overload() -> HandleFunctionPtr2 {
+auto get_binary_div_like_ops_overload() -> HandleFunctionPtr2 {
     return &OpHandler_Overload<OpType>::handle;
 }
 
 using HandleFunctionPtr3 = Tensor (*)(const Tensor&, const Tensor&, bool, std::string, const std::optional<MemoryConfig>&);
 using HandleFunctionPtr4 = Tensor (*)(const Tensor&, float, bool, std::string, const std::optional<MemoryConfig>&);
 template <BinaryCompositeOpType OpType>
-auto get_function_div() -> HandleFunctionPtr3 {
+auto get_binary_div() -> HandleFunctionPtr3 {
     return &OpHandler_Div<OpType>::handle;
 }
 template <BinaryCompositeOpType OpType>
-auto get_function_div_overload() -> HandleFunctionPtr4 {
+auto get_binary_div_overload() -> HandleFunctionPtr4 {
     return &OpHandler_Div<OpType>::handle;
 }
 

--- a/ttnn/cpp/ttnn/operations/eltwise/binary/device/binary_composite_op.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary/device/binary_composite_op.hpp
@@ -21,6 +21,11 @@ enum class BinaryCompositeOpType {
     MAXIMUM,
     ATAN2,
     LOGICAL_XOR,
+    BINARY_REMAINDER,
+    BINARY_FMOD,
+    DIV,
+    DIV_NO_NAN,
+    FLOOR_DIV,
 
 };
 
@@ -31,9 +36,17 @@ Tensor _maximum(const Tensor&, const Tensor&, const std::optional<MemoryConfig>&
 Tensor _atan2(const Tensor&, const Tensor&, const std::optional<MemoryConfig>&);
 Tensor _logical_xor(const Tensor&, const Tensor&, const std::optional<MemoryConfig>&);
 Tensor _nextafter(const Tensor&, const Tensor&, const std::optional<MemoryConfig>&);
+Tensor _binary_remainder(const Tensor&, const Tensor&, const std::optional<MemoryConfig>&);
+Tensor _binary_fmod(const Tensor&, const Tensor&, const std::optional<MemoryConfig>&);
 Tensor _addalpha(const Tensor&, const Tensor&, float, const std::optional<MemoryConfig>&);
 Tensor _subalpha(const Tensor&, const Tensor&, float, const std::optional<MemoryConfig>&);
 Tensor _isclose(const Tensor&, const Tensor&, float, float, const bool, const std::optional<MemoryConfig>&);
+Tensor _div(const Tensor&, const Tensor&, bool, string, const std::optional<MemoryConfig>&);
+Tensor _div_overload(const Tensor&, float, bool, string, const std::optional<MemoryConfig>&);
+Tensor _div_no_nan(const Tensor&, const Tensor&, const std::optional<MemoryConfig>&);
+Tensor _div_no_nan_overload(const Tensor&, float, const std::optional<MemoryConfig>&);
+Tensor _floor_div(const Tensor&, const Tensor&, const std::optional<MemoryConfig>&);
+Tensor _floor_div_overload(const Tensor&, float, const std::optional<MemoryConfig>&);
 
 // OpHandler struct template
 template <BinaryCompositeOpType OpType>
@@ -44,6 +57,12 @@ struct OpHandler;
 
 template <BinaryCompositeOpType OpType>
 struct OpHandler;
+
+template <BinaryCompositeOpType OpType>
+struct OpHandler_Div;
+
+template <BinaryCompositeOpType OpType>
+struct OpHandler_Overload;
 
 
 template <>
@@ -117,5 +136,27 @@ struct OpHandler<BinaryCompositeOpType::ISCLOSE> {
     }
 };
 
+
+using HandleFunctionPtr1 = Tensor (*)(const Tensor&, const Tensor&, const std::optional<MemoryConfig>&);
+using HandleFunctionPtr2 = Tensor (*)(const Tensor&, float, const std::optional<MemoryConfig>&);
+template <BinaryCompositeOpType OpType>
+auto get_function_divnonan_floordiv() -> HandleFunctionPtr1 {
+    return &OpHandler_Overload<OpType>::handle;
+}
+template <BinaryCompositeOpType OpType>
+auto get_function_divnonan_floordiv_overload() -> HandleFunctionPtr2 {
+    return &OpHandler_Overload<OpType>::handle;
+}
+
+using HandleFunctionPtr3 = Tensor (*)(const Tensor&, const Tensor&, bool, std::string, const std::optional<MemoryConfig>&);
+using HandleFunctionPtr4 = Tensor (*)(const Tensor&, float, bool, std::string, const std::optional<MemoryConfig>&);
+template <BinaryCompositeOpType OpType>
+auto get_function_div() -> HandleFunctionPtr3 {
+    return &OpHandler_Div<OpType>::handle;
+}
+template <BinaryCompositeOpType OpType>
+auto get_function_div_overload() -> HandleFunctionPtr4 {
+    return &OpHandler_Div<OpType>::handle;
+}
 
 }

--- a/ttnn/ttnn/operations/binary.py
+++ b/ttnn/ttnn/operations/binary.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+# SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
 
 # SPDX-License-Identifier: Apache-2.0
 
@@ -126,6 +126,15 @@ def _golden_function(input_tensor_a, input_tensor_b, *args, **kwargs):
 
 
 ttnn.attach_golden_function(ttnn.logical_or_, golden_function=_golden_function)
+
+
+def _golden_function(input_tensor_a, input_tensor_b, *args, **kwargs):
+    import torch
+
+    return input_tensor_a.logical_xor_(input_tensor_b)
+
+
+ttnn.attach_golden_function(ttnn.logical_xor_, golden_function=_golden_function)
 
 
 def _golden_function(input_tensor_a, input_tensor_b, *args, **kwargs):

--- a/ttnn/ttnn/operations/binary.py
+++ b/ttnn/ttnn/operations/binary.py
@@ -254,6 +254,24 @@ def _golden_function_logical_xor(input_tensor_a, input_tensor_b, *args, **kwargs
 ttnn.attach_golden_function(ttnn._ttnn.operations.binary.logical_xor, golden_function=_golden_function_logical_xor)
 
 
+def _golden_function_logical_and(input_tensor_a, input_tensor_b, *args, **kwargs):
+    import torch
+
+    return torch.logical_and(input_tensor_a, input_tensor_b)
+
+
+ttnn.attach_golden_function(ttnn._ttnn.operations.binary.logical_and, golden_function=_golden_function_logical_and)
+
+
+def _golden_function_logical_or(input_tensor_a, input_tensor_b, *args, **kwargs):
+    import torch
+
+    return torch.logical_or(input_tensor_a, input_tensor_b)
+
+
+ttnn.attach_golden_function(ttnn._ttnn.operations.binary.logical_or, golden_function=_golden_function_logical_or)
+
+
 def _golden_function_atan2(input_tensor_a, input_tensor_b, *args, **kwargs):
     import torch
 

--- a/ttnn/ttnn/operations/binary.py
+++ b/ttnn/ttnn/operations/binary.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
+# SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
 
 # SPDX-License-Identifier: Apache-2.0
 
@@ -113,19 +113,19 @@ ttnn.attach_golden_function(ttnn.le, golden_function=_golden_function)
 def _golden_function(input_tensor_a, input_tensor_b, *args, **kwargs):
     import torch
 
-    return torch.logical_and(input_tensor_a, input_tensor_b)
+    return input_tensor_a.logical_and_(input_tensor_b)
 
 
-ttnn.attach_golden_function(ttnn.logical_and, golden_function=_golden_function)
+ttnn.attach_golden_function(ttnn.logical_and_, golden_function=_golden_function)
 
 
 def _golden_function(input_tensor_a, input_tensor_b, *args, **kwargs):
     import torch
 
-    return torch.logical_or(input_tensor_a, input_tensor_b)
+    return input_tensor_a.logical_or_(input_tensor_b)
 
 
-ttnn.attach_golden_function(ttnn.logical_or, golden_function=_golden_function)
+ttnn.attach_golden_function(ttnn.logical_or_, golden_function=_golden_function)
 
 
 def _golden_function(input_tensor_a, input_tensor_b, *args, **kwargs):
@@ -263,26 +263,6 @@ def _golden_function_nextafter(input_tensor_a, input_tensor_b, *args, **kwargs):
 ttnn.attach_golden_function(ttnn._ttnn.operations.binary.nextafter, golden_function=_golden_function_nextafter)
 
 
-def _golden_function_binary_remainder(input_tensor_a, input_tensor_b, *args, **kwargs):
-    import torch
-
-    return torch.remainder(input_tensor_a, input_tensor_b)
-
-
-ttnn.attach_golden_function(
-    ttnn._ttnn.operations.binary.binary_remainder, golden_function=_golden_function_binary_remainder
-)
-
-
-def _golden_function_binary_fmod(input_tensor_a, input_tensor_b, *args, **kwargs):
-    import torch
-
-    return torch.fmod(input_tensor_a, input_tensor_b)
-
-
-ttnn.attach_golden_function(ttnn._ttnn.operations.binary.binary_fmod, golden_function=_golden_function_binary_fmod)
-
-
 def _golden_function_isclose(input_tensor_a, input_tensor_b, *args, rtol=1e-05, atol=1e-08, equal_nan=False, **kwargs):
     import torch
 
@@ -325,6 +305,26 @@ def _golden_function_floor_div(input_tensor_a, input_tensor_b, *args, **kwargs):
 
 
 ttnn.attach_golden_function(ttnn._ttnn.operations.binary.floor_div, golden_function=_golden_function_floor_div)
+
+
+def _golden_function_binary_remainder(input_tensor_a, input_tensor_b, *args, **kwargs):
+    import torch
+
+    return torch.remainder(input_tensor_a, input_tensor_b)
+
+
+ttnn.attach_golden_function(
+    ttnn._ttnn.operations.binary.binary_remainder, golden_function=_golden_function_binary_remainder
+)
+
+
+def _golden_function_binary_fmod(input_tensor_a, input_tensor_b, *args, **kwargs):
+    import torch
+
+    return torch.fmod(input_tensor_a, input_tensor_b)
+
+
+ttnn.attach_golden_function(ttnn._ttnn.operations.binary.binary_fmod, golden_function=_golden_function_binary_fmod)
 
 
 def torch_squared_difference(x, y, *args, **kwargs):

--- a/ttnn/ttnn/operations/binary.py
+++ b/ttnn/ttnn/operations/binary.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+# SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
 
 # SPDX-License-Identifier: Apache-2.0
 
@@ -263,6 +263,26 @@ def _golden_function_nextafter(input_tensor_a, input_tensor_b, *args, **kwargs):
 ttnn.attach_golden_function(ttnn._ttnn.operations.binary.nextafter, golden_function=_golden_function_nextafter)
 
 
+def _golden_function_binary_remainder(input_tensor_a, input_tensor_b, *args, **kwargs):
+    import torch
+
+    return torch.remainder(input_tensor_a, input_tensor_b)
+
+
+ttnn.attach_golden_function(
+    ttnn._ttnn.operations.binary.binary_remainder, golden_function=_golden_function_binary_remainder
+)
+
+
+def _golden_function_binary_fmod(input_tensor_a, input_tensor_b, *args, **kwargs):
+    import torch
+
+    return torch.fmod(input_tensor_a, input_tensor_b)
+
+
+ttnn.attach_golden_function(ttnn._ttnn.operations.binary.binary_fmod, golden_function=_golden_function_binary_fmod)
+
+
 def _golden_function_isclose(input_tensor_a, input_tensor_b, *args, rtol=1e-05, atol=1e-08, equal_nan=False, **kwargs):
     import torch
 
@@ -270,6 +290,41 @@ def _golden_function_isclose(input_tensor_a, input_tensor_b, *args, rtol=1e-05, 
 
 
 ttnn.attach_golden_function(ttnn._ttnn.operations.binary.isclose, golden_function=_golden_function_isclose)
+
+
+def _golden_function_div(input_tensor_a, input_tensor_b, round_mode, *args, **kwargs):
+    import torch
+
+    if round_mode == "None":
+        return torch.div(input_tensor_a, input_tensor_b, rounding_mode=None)
+    return torch.div(input_tensor_a, input_tensor_b, rounding_mode=round_mode)
+
+
+ttnn.attach_golden_function(ttnn._ttnn.operations.binary.div, golden_function=_golden_function_div)
+
+
+def _golden_function_div_no_nan(input_tensor_a, input_tensor_b, *args, **kwargs):
+    import torch
+
+    if isinstance(input_tensor_b, float):
+        if input_tensor_b == 0:
+            return torch.zeros_like(input_tensor_a)
+        else:
+            return input_tensor_a / input_tensor_b
+    else:
+        return torch.where(input_tensor_b == 0, 0, input_tensor_a / input_tensor_b)
+
+
+ttnn.attach_golden_function(ttnn._ttnn.operations.binary.div_no_nan, golden_function=_golden_function_div_no_nan)
+
+
+def _golden_function_floor_div(input_tensor_a, input_tensor_b, *args, **kwargs):
+    import torch
+
+    return torch.floor_divide(input_tensor_a, input_tensor_b)
+
+
+ttnn.attach_golden_function(ttnn._ttnn.operations.binary.floor_div, golden_function=_golden_function_floor_div)
 
 
 def torch_squared_difference(x, y, *args, **kwargs):


### PR DESCRIPTION
### Ticket
[Link to Github Issue](https://github.com/tenstorrent/tt-metal/issues/10137)

### Problem description

Migrate composite Binary op into ttnn

### What's changed

- [x] div
- [x] div_no_nan
- [x] remainder
- [x] fmod
- [x] floor_div
- [x] logical_and_
- [x] logical_or_
- [x] logical_xor_



### Checklist
- [x] Post commit CI passes
- [ ] Model regression CI testing passes (if applicable)
- [ ] New/Existing tests provide coverage for changes
