### PR TITLE
#8865: Optimize binary override_runtime_arguments

### DIFF
--- a/tests/ttnn/profiling/ops_for_profiling.py
+++ b/tests/ttnn/profiling/ops_for_profiling.py
@@ -77,6 +77,11 @@ def bcast_hw_shape_func(input_shape):
     return input_shape, input_shape_1
 
 
+def bcast_hw_shape_func_11(input_shape):
+    input_shape_1 = [input_shape[-4], input_shape[-3], 1, 1]
+    return input_shape, input_shape_1
+
+
 def complex_add(x, y):
     tt_lib.tensor.complex_add(
         x, y, tt_lib.tensor.MemoryConfig(tt_lib.tensor.TensorMemoryLayout.INTERLEAVED, tt_lib.tensor.BufferType.DRAM)
@@ -444,6 +449,11 @@ all_binary_ops = [
     {
         "op": ttnn.mul,
         "name": "ttnn.mul",
+    },
+    {
+        "op": ttnn.mul,
+        "name": "ttnn.mul_bcast_hw",
+        "shape_func": bcast_hw_shape_func_11,
     },
     {
         "op": ttnn.divide,

--- a/tests/ttnn/python_api_testing/sweep_tests/test_configs/ci_sweep_tests_working/wormhole/ttnn_eltwise_mul_bcast_test.yaml
+++ b/tests/ttnn/python_api_testing/sweep_tests/test_configs/ci_sweep_tests_working/wormhole/ttnn_eltwise_mul_bcast_test.yaml
@@ -1,0 +1,29 @@
+---
+test-list:
+  - ttnn-mul:
+      shape:
+        start-shape: [1, 1, 32, 32]
+        end-shape: [6, 12, 256, 256]
+        interval: [1, 1, 32, 32]
+        num-dims: [2, 3, 4]
+        num-shapes: 2
+        num-samples: 1024
+        args-sampling-strategy: "all"
+        method: "tt_nn-bcast"
+      env:
+        # TT_PCI_DMA_BUF_SIZE: "1048576"
+      datagen:
+        function: gen_rand
+        args:
+          low: -100
+          high: 100
+      comparison:
+        function: comp_pcc
+      args-gen: gen_dtype_layout_device
+      sanitize-args: False
+      args:
+        data-layout: ["TILE"]
+        data-type: ["BFLOAT16"]
+        buffer-type: ["DRAM", "L1"]
+        out-buffer-type: ["DRAM", "L1"]
+      output-file: mul_sweep.csv

--- a/ttnn/cpp/ttnn/operations/eltwise/binary/device/broadcast_height_and_width_multi_core_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary/device/broadcast_height_and_width_multi_core_program_factory.cpp
@@ -318,51 +318,45 @@ void BinaryDeviceOperation::BroadcastHeightAndWidthMultiCore::override_runtime_a
         core_group_2 = CoreRangeSet({});
     }
 
+    auto& cached_reader_args = GetRuntimeArgs(program, binary_reader_kernel_id);
+    auto& cached_eltwise_args = GetRuntimeArgs(program, bcast_kernel_id);
+    auto& cached_writer_args = GetRuntimeArgs(program, unary_writer_kernel_id);
+
     for (uint32_t i = 0, num_tiles_read = 0; i < num_cores_total; i++) {
         const CoreCoord& core = cores.at(i);
         uint32_t num_tensor_tiles_per_core;
+
+        auto& binary_reader_args = cached_reader_args.at(core.x).at(core.y);
+        auto& bcast_kernel_args = cached_eltwise_args.at(core.x).at(core.y);
+        auto& unary_writer_args = cached_writer_args.at(core.x).at(core.y);
+
         if (core_group_1.core_coord_in_core_ranges(core)) {
             num_tensor_tiles_per_core = num_tiles_per_core_group_1;
         } else if (core_group_2.core_coord_in_core_ranges(core)) {
             num_tensor_tiles_per_core = num_tiles_per_core_group_2;
         } else {
-            tt_metal::SetRuntimeArgs(program, binary_reader_kernel_id, core, std::vector<uint32_t>(7, 0));
-            tt_metal::SetRuntimeArgs(program, bcast_kernel_id, core, std::vector<uint32_t>(3, 0));
-            tt_metal::SetRuntimeArgs(program, unary_writer_kernel_id, core, std::vector<uint32_t>(3, 0));
+            binary_reader_args[2] = 0;
+            bcast_kernel_args[2] = 0;
+            unary_writer_args[1] = 0;
             continue;
         }
 
-        tt_metal::SetRuntimeArgs(
-            program,
-            binary_reader_kernel_id,
-            core,
-            {src_buffer_a->address(),  // 0
-             src_dram_buffer_b->address(),
-             num_tensor_tiles_per_core,
-             HtWt,
-             num_tiles_read / HtWt * HtWt,
-             num_tiles_read % HtWt,
-             bnc1 ? 0 : num_tiles_read / HtWt});
+        binary_reader_args[0] = src_buffer_a->address();
+        binary_reader_args[1] = src_dram_buffer_b->address();
+        binary_reader_args[2] = num_tensor_tiles_per_core;
+        binary_reader_args[3] = HtWt;
+        binary_reader_args[4] = num_tiles_read / HtWt * HtWt;
+        binary_reader_args[5] = num_tiles_read % HtWt;
+        binary_reader_args[6] = bnc1 ? 0 : num_tiles_read / HtWt;
 
-        tt_metal::SetRuntimeArgs(
-            program,
-            bcast_kernel_id,
-            core,
-            {
-                1,                         // B
-                1,                         // Ht
-                num_tensor_tiles_per_core  // Wt
-            });
+        bcast_kernel_args[0] = 1;                         // B
+        bcast_kernel_args[1] = 1;                         // Ht
+        bcast_kernel_args[2] = num_tensor_tiles_per_core; // Wt
 
-        tt_metal::SetRuntimeArgs(
-            program,
-            unary_writer_kernel_id,
-            core,
-            {
-                dst_buffer->address(),
-                num_tensor_tiles_per_core,
-                num_tiles_read,
-            });
+        unary_writer_args[0] = dst_buffer->address();
+        unary_writer_args[1] = num_tensor_tiles_per_core;
+        unary_writer_args[2] = num_tiles_read;
+
         num_tiles_read += num_tensor_tiles_per_core;
     }
 

--- a/ttnn/cpp/ttnn/operations/eltwise/binary/device/broadcast_height_and_width_multi_core_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary/device/broadcast_height_and_width_multi_core_program_factory.cpp
@@ -185,7 +185,7 @@ BinaryDeviceOperation::BroadcastHeightAndWidthMultiCore::create(
             num_tensor_tiles_per_core = num_tiles_per_core_group_2;
         } else {
             tt_metal::SetRuntimeArgs(program, binary_reader_kernel_id, core, std::vector<uint32_t>(7, 0));
-            tt_metal::SetRuntimeArgs(program, bcast_kernel_id, core, std::vector<uint32_t>(3, 0));
+            tt_metal::SetRuntimeArgs(program, bcast_kernel_id, core, {1, 1, 0});
             tt_metal::SetRuntimeArgs(program, unary_writer_kernel_id, core, std::vector<uint32_t>(3, 0));
             continue;
         }
@@ -349,8 +349,6 @@ void BinaryDeviceOperation::BroadcastHeightAndWidthMultiCore::override_runtime_a
         binary_reader_args[5] = num_tiles_read % HtWt;
         binary_reader_args[6] = bnc1 ? 0 : num_tiles_read / HtWt;
 
-        bcast_kernel_args[0] = 1;                         // B
-        bcast_kernel_args[1] = 1;                         // Ht
         bcast_kernel_args[2] = num_tensor_tiles_per_core; // Wt
 
         unary_writer_args[0] = dst_buffer->address();


### PR DESCRIPTION
Optimised dispatch time for binary bcast ops.

Measurements on main:

```
op,count,python min dispatch time (ms),python mean dispatch time(ms),python mean dispatch + sync time (ms),C++ mean dispatch time (ms)
ttnn.mul_unary main,200,0.067,0.07,0.121,0.051
```

Measurements on this branch (after optimization):

```
op,count,python min dispatch time (ms),python mean dispatch time(ms),python mean dispatch + sync time (ms),C++ mean dispatch time (ms)
ttnn.mul_bcast_hw opt,200,0.036,0.038,0.203,0.018
ttnn.mul_unary opt,200,0.038,0.041,0.114,0.018
```

All post-commit tests
https://github.com/tenstorrent/tt-metal/actions/runs/10091467334

[TG] TG model perf tests
https://github.com/tenstorrent/tt-metal/actions/runs/10091476698

[TGG] TGG model perf tests
https://github.com/tenstorrent/tt-metal/actions/runs/10091472096

[TGG] TGG demo tests
https://github.com/tenstorrent/tt-metal/actions/runs/10091482220

Model perf regressions and output report
https://github.com/tenstorrent/tt-metal/actions/runs/10106798518
