### PR TITLE
build type selection re-vamp + cleanup

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -16,7 +16,6 @@ jobs:
         os: [ubuntu-20.04]
     env:
       ARCH_NAME: ${{ matrix.arch }}
-      CONFIG: ${{ matrix.build.type }}
       # So we can get all the makefile output we want
       VERBOSE: 1
     runs-on: ${{ matrix.build.runs-on }}
@@ -38,7 +37,7 @@ jobs:
           echo "TT_METAL_HOME=$(pwd)" >> $GITHUB_ENV
       - name: Build tt-metal libraries
         run: |
-          cmake -B build -G Ninja
+          cmake -B build -DCMAKE_BUILD_TYPE=${{ matrix.build.type }} -G Ninja
           cmake --build build
       - name: Build tt-metal C++ tests
         run: |

--- a/.github/workflows/eager-package.yaml
+++ b/.github/workflows/eager-package.yaml
@@ -20,7 +20,6 @@ jobs:
     env:
       TT_METAL_ENV: ${{ vars.TT_METAL_ENV }}
       ARCH_NAME: ${{ inputs.arch }}
-      CONFIG: Release
       TT_METAL_CREATE_STATIC_LIB: 1
     steps:
       - uses: tenstorrent-metal/metal-workflows/.github/actions/checkout-with-submodule-lfs@v2.0.0

--- a/.github/workflows/stress-fast-dispatch-build-and-unit-tests.yaml
+++ b/.github/workflows/stress-fast-dispatch-build-and-unit-tests.yaml
@@ -31,7 +31,6 @@ jobs:
     env:
       TT_METAL_ENV: ${{ vars.TT_METAL_ENV }}
       ARCH_NAME: ${{ matrix.runner-info.arch }}
-      CONFIG: ci
       TT_METAL_WATCHER: 60
     environment: dev
     runs-on: ${{ matrix.runner-info.runs-on }}

--- a/.github/workflows/stress-slow-dispatch-build-and-unit-tests.yaml
+++ b/.github/workflows/stress-slow-dispatch-build-and-unit-tests.yaml
@@ -29,7 +29,6 @@ jobs:
     env:
       TT_METAL_ENV: ${{ vars.TT_METAL_ENV }}
       ARCH_NAME: ${{ matrix.runner-info.arch }}
-      CONFIG: ci
       TT_METAL_SLOW_DISPATCH_MODE: 1
       TT_METAL_WATCHER: 60
     environment: dev

--- a/.gitignore
+++ b/.gitignore
@@ -10,7 +10,7 @@ test_hlk_args_init_gen
 tt_build
 tt_debug
 build
-build_debug
+build_*
 /python_env/
 
 /llk_out/

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -37,10 +37,7 @@ CHECK_COMPILERS()
 # Setting build type flags
 #   Will default to assert build, unless CONFIG env variable is set or manually set -DCMAKE_BUILD_TYPE
 ############################################################################################################################
-if(DEFINED ENV{CONFIG})
-    message(STATUS "CONFIG is set, CMAKE_BUILD_TYPE being set to $ENV{CONFIG}")
-    set(CMAKE_BUILD_TYPE $ENV{CONFIG})
-elseif(NOT CMAKE_BUILD_TYPE)
+if(NOT CMAKE_BUILD_TYPE)
     message(STATUS "Setting build type to 'Release' as none was specified.")
     set(CMAKE_BUILD_TYPE "Release" CACHE STRING "Release build is the default" FORCE)
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -35,11 +35,21 @@ CHECK_COMPILERS()
 
 ############################################################################################################################
 # Setting build type flags
-#   Will default to assert build, unless CONFIG env variable is set or manually set -DCMAKE_BUILD_TYPE
+#   Will default to Release build unless manually set with -DCMAKE_BUILD_TYPE
 ############################################################################################################################
+# Define valid build types
+set(VALID_BUILD_TYPES Debug Release RelWithDebInfo CI)
+
 if(NOT CMAKE_BUILD_TYPE)
     message(STATUS "Setting build type to 'Release' as none was specified.")
     set(CMAKE_BUILD_TYPE "Release" CACHE STRING "Release build is the default" FORCE)
+endif()
+
+# Check if the specified build type is valid
+list(FIND VALID_BUILD_TYPES ${CMAKE_BUILD_TYPE} _build_type_index)
+
+if(_build_type_index EQUAL -1)
+    message(FATAL_ERROR "Invalid build type: ${CMAKE_BUILD_TYPE}. Valid options are: ${VALID_BUILD_TYPES}")
 endif()
 
 message(STATUS "Build type: ${CMAKE_BUILD_TYPE}")

--- a/build_metal.sh
+++ b/build_metal.sh
@@ -24,9 +24,9 @@ Notes:
         agnostic of the build system (Ninja or Make)
 
 Different configs: to change build type or use tracy, you have to change the configuration cmake step (step #2)
-    - changing build types: `CONFIG=<type> cmake -B build -G Ninja`
-        - valid build_types: `Release`, `Debug`, `RelWithDebInfo`
-        - Release is the default if you do not set CONFIG
+    - changing build types: `cmake -B build -DCMAKE_BUILD_TYPE=<type> -G Ninja`
+        - valid CMAKE_BUILD_TYPE values: `Release`, `Debug`, `RelWithDebInfo`, `CI`
+        - Release is the default if you do not set CMAKE_BUILD_TYPE
     - tracy: `cmake -B build -G Ninja -DENABLE_TRACY=ON`
 
 Now you can have multiple build folders with different configs, if you want to switch just run `ninja install -C <your_build_folder` to install different pybinds
@@ -37,7 +37,7 @@ Now you can have multiple build folders with different configs, if you want to s
 Example:
     ./create_venv.sh
     cmake -B build -G Ninja && ninja -C build                       # <- build in Release, inside folder called `build`
-    CONFIG=Debug cmake -B build_debug -G Ninja && ninja -C build    # <- build in Debug, inside folder called `build_debug`
+    cmake -DCMAKE_BUILD_TYPE=Debug -B build_debug -G Ninja && ninja -C build    # <- build in Debug, inside folder called `build_debug`
     source python_env/bin/activate                                  # <- you can not run pytests yet since pybinds have not been installed
     ninja install -C build                                          # <- install Release pybinds
     <run a pytest>                                                  # <- this test ran in Release config

--- a/build_metal.sh
+++ b/build_metal.sh
@@ -63,7 +63,7 @@ show_help() {
 export_compile_commands="OFF"
 enable_ccache="OFF"
 build_type="Release"
-while getopts "hect:" opt; do
+while getopts "hecb:" opt; do
     case ${opt} in
         h )
             show_help
@@ -75,7 +75,7 @@ while getopts "hect:" opt; do
         c )
             enable_ccache="ON"
             ;;
-        t )
+        b )
             build_type="$OPTARG"
             ;;
         \? )

--- a/scripts/docker/run_docker_func.sh
+++ b/scripts/docker/run_docker_func.sh
@@ -46,7 +46,6 @@ function run_docker_common {
         -e TT_METAL_HOME=${TT_METAL_HOME} \
         -e LOGURU_LEVEL=${LOGURU_LEVEL} \
         -e LD_LIBRARY_PATH=${LD_LIBRARY_PATH} \
-        -e CONFIG=${CONFIG} \
         -e ARCH_NAME=${ARCH_NAME} \
         -e PYTHONPATH=${TT_METAL_HOME} \
         -e XDG_CACHE_HOME=${TT_METAL_HOME}/.pipcache \


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/10552

### What's changed
A few changes:
1) using CONFIG env variable to select the build type is obselete.
2) Add checks in CMake to ensure build type is one of `Release`,`Debug`, `RelWithDebInfo`, `CI`
3) Add `-b` option to select build type in `build_metal.sh`, valid options are listed above
4) If you use `build_metal.sh`, build folder is now a symlink that points to `Build_Release`, `Build_Debug`, ..., to take advantage of incremental builds when switching between build types.

### Checklist
- [ ] Post commit CI passes
