### PR TITLE
Removed mutex lock

### DIFF
--- a/ttnn/CMakeLists.txt
+++ b/ttnn/CMakeLists.txt
@@ -3,6 +3,7 @@ set(TTNN_SRCS
     ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/device.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/async_runtime.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/run_operation.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/types.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operation_history.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/core/to_layout/to_layout_op.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/conv2d/conv2d.cpp

--- a/ttnn/cpp/ttnn/types.cpp
+++ b/ttnn/cpp/ttnn/types.cpp
@@ -1,0 +1,49 @@
+// SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "ttnn/types.hpp"
+
+namespace ttnn::types {
+
+Buffer::Buffer(Device *device, uint64_t size, uint64_t page_size, const BufferType buffer_type,
+        const TensorMemoryLayout buffer_layout,
+        std::optional< ShardSpecBuffer> shard_parameters
+    ) : tt::tt_metal::Buffer(device, size, page_size, buffer_type, buffer_layout, shard_parameters, false) {
+        this->buffer_id = get_unique_id(); // Each buffer has a unique ID
+        this->allocate();
+}
+
+Buffer::~Buffer() {
+    this->deallocate();
+}
+
+void Buffer::allocate() {
+    TT_ASSERT(this->device());
+    this->device()->push_work([this] () mutable {
+        bool bottom_up = this->buffer_type() == BufferType::DRAM;
+        tt::tt_metal::detail::AllocateBuffer(this, bottom_up);
+        // The address inserted here, will be used during asynchronous deallocate
+    });
+}
+
+void Buffer::deallocate() {
+    if (this->device() == nullptr or not this->device()->initialized_ or this->size() == 0) {
+        return;
+    }
+    this->set_size(0);
+    TT_ASSERT(this->device()->allocator_ != nullptr, "Expected allocator to be initialized!");
+    // Extract the required buffer attributes from main thread (these are guaranteed to be correctly populated) and send to worker
+    this->device()->push_work([dev = this->device(), id = this->buffer_id, type = this->buffer_type(), buffer_address = this->address()] () mutable {
+        tt::tt_metal::allocator::deallocate_buffer(*(dev->allocator_), buffer_address, type);
+    });
+}
+
+uint32_t Buffer::get_unique_id() {
+    return buf_id++;
+}
+
+std::atomic<uint32_t> Buffer::buf_id = 0;
+
+
+}  // namespace ttnn

--- a/ttnn/cpp/ttnn/types.hpp
+++ b/ttnn/cpp/ttnn/types.hpp
@@ -55,76 +55,21 @@ struct CoreGrid {
     }
 };
 
-// Keep track of live buffers and the device addresses they were assigned.
-// When a buffer is created, it is provided a buffer_id using get_buf_id().
-// The address for this buffer is assigned to buffer_id when the buffer is asynchronously allocated.
-// When the buffer destructor is called, or the buffer is asynchronously deallocated, the worker thread
-// will look up the address for buffer_id to free memory on device.
-class buffer_address_map {
-    public:
-        void insert(uint32_t buf_id, uint32_t buf_addr) {
-            std::scoped_lock<std::mutex> lock(this->map_mutex);
-            this->buf_id_to_address_map.insert({buf_id, buf_addr});
-        }
-        void erase(uint32_t buf_id) {
-            std::scoped_lock<std::mutex> lock(this->map_mutex);
-            this->buf_id_to_address_map.erase(buf_id);
-        }
-        uint32_t buffer_address(uint32_t buf_id) {
-            std::scoped_lock<std::mutex> lock(this->map_mutex);
-            return this->buf_id_to_address_map.at(buf_id);
-        }
-        uint32_t get_buf_id() {
-            return buf_id++;
-        }
-
-    private:
-    std::atomic<uint32_t> buf_id = 0;
-    std::mutex map_mutex;
-    std::unordered_map<uint32_t, uint32_t> buf_id_to_address_map = {};
-};
-
-inline buffer_address_map GLOBAL_BUFFER_ADDRESS_MAP;
-
 // This buffer class is compatible with multithreaded runtime (which lives in tt_eager)
 // It is derived from the tt_metal::Buffer class, but defines its own asynchronous allocation functions
 class Buffer : public tt::tt_metal::Buffer {
     public:
         Buffer(Device *device, uint64_t size, uint64_t page_size, const BufferType buffer_type,
                 const TensorMemoryLayout buffer_layout = TensorMemoryLayout::INTERLEAVED,
-                std::optional< ShardSpecBuffer> shard_parameters = std::nullopt
-            ) : tt::tt_metal::Buffer(device, size, page_size, buffer_type, buffer_layout, shard_parameters, false) {
-                this->buffer_id = GLOBAL_BUFFER_ADDRESS_MAP.get_buf_id(); // Each buffer has a unique ID
-                this->allocate();
-            }
-        ~Buffer() {
-            this->deallocate();
-        }
+                std::optional< ShardSpecBuffer> shard_parameters = std::nullopt);
+        ~Buffer();
     private:
         uint32_t buffer_id = 0;
-        void allocate() {
-            TT_ASSERT(this->device());
-            this->device()->push_work([this] () mutable {
-                bool bottom_up = this->buffer_type() == BufferType::DRAM;
-                tt::tt_metal::detail::AllocateBuffer(this, bottom_up);
-                // The address inserted here, will be used during asynchronous deallocate
-                GLOBAL_BUFFER_ADDRESS_MAP.insert(this->buffer_id, this->address());
+        void allocate();
+        void deallocate();
+        static uint32_t get_unique_id();
 
-            });
-        }
-        void deallocate() {
-            if (this->device() == nullptr or not this->device()->initialized_ or this->size() == 0) {
-                return;
-            }
-            this->set_size(0);
-            TT_ASSERT(this->device()->allocator_ != nullptr, "Expected allocator to be initialized!");
-            // Extract the required buffer attributes from main thread (these are guaranteed to be correctly populated) and send to worker
-            this->device()->push_work([dev = this->device(), id = this->buffer_id, type = this->buffer_type()] () mutable {
-                // At this point, the address for this buffer has made it to GLOBAL_BUFFER_ADDRESS_MAP, since the worker has allocated the buffer.
-                tt::tt_metal::allocator::deallocate_buffer(*(dev->allocator_), GLOBAL_BUFFER_ADDRESS_MAP.buffer_address(id), type);
-                GLOBAL_BUFFER_ADDRESS_MAP.erase(id);
-            });
-        }
+        static std::atomic<uint32_t> buf_id;
 };
 
 static std::ostream &operator<<(std::ostream &os, const CoreGrid &core_grid) {


### PR DESCRIPTION
### Ticket
Accidentally found additional std::mutex lock 
Here is explanation why it was required.
https://github.com/tenstorrent/tt-metal/commit/1fb79a459478acd439fe22dcd27d22161d09794e

### Problem description
Global class with mutex is used for every buffer allocations/deallocations.
I don't see why we need it.

### What's changed
Removed GLOBAL_BUFFER_ADDRESS_MAP.
Also moved all Buffer methods to the cpp file.

### Checklist
- [ ] Post commit CI passes
- [ ] Model regression CI testing passes (if applicable)
- [ ] New/Existing tests provide coverage for changes
