### PR TITLE
#7494: Added unit tests to verify that values to semaphores and circular buffers are being correctly written out when core range sets are used

### DIFF
--- a/tests/tt_metal/tt_metal/unit_tests_fast_dispatch/command_queue/test_EnqueueProgram.cpp
+++ b/tests/tt_metal/tt_metal/unit_tests_fast_dispatch/command_queue/test_EnqueueProgram.cpp
@@ -146,11 +146,6 @@ bool test_dummy_EnqueueProgram_with_sems(Device* device, CommandQueue& cq, Progr
 
     bool are_all_semaphore_values_correct = true;
 
-    for (uint32_t sem_id = 0; sem_id < program_config.num_sems; sem_id++) {
-        const uint32_t allocated_sem_id  = CreateSemaphore(program, program_config.cr_set, sem_id);
-        are_all_semaphore_values_correct &= (allocated_sem_id == sem_id);
-    }
-
     const bool is_blocking_op = false;
     EnqueueProgram(cq, program, is_blocking_op);
     Finish(cq);

--- a/tests/tt_metal/tt_metal/unit_tests_fast_dispatch/command_queue/test_EnqueueProgram.cpp
+++ b/tests/tt_metal/tt_metal/unit_tests_fast_dispatch/command_queue/test_EnqueueProgram.cpp
@@ -153,6 +153,8 @@ bool test_dummy_EnqueueProgram_with_cbs_update_size(Device* device, CommandQueue
 }
 
 bool test_dummy_EnqueueProgram_with_sems(Device* device, CommandQueue& cq, Program& program, const DummyProgramConfig& program_config, const vector<vector<uint32_t>>& expected_semaphore_vals) {
+    TT_ASSERT(program_config.cr_set.size() == expected_semaphore_vals.size());
+
     bool are_all_semaphore_values_correct = true;
 
     for (uint32_t sem_id = 0; sem_id < program_config.num_sems; sem_id++) {
@@ -168,6 +170,7 @@ bool test_dummy_EnqueueProgram_with_sems(Device* device, CommandQueue& cq, Progr
     for (const CoreRange& core_range : program_config.cr_set.ranges())
     {
         const vector<uint32_t>& expected_semaphore_vals_for_core = expected_semaphore_vals[expected_semaphore_vals_idx];
+        TT_ASSERT(expected_semaphore_vals_for_core.size() == program_config.num_sems);
         expected_semaphore_vals_idx++;
         for (const CoreCoord& core_coord : core_range)
         {


### PR DESCRIPTION
### Ticket
[Link to Github Issue](https://github.com/tenstorrent/tt-metal/issues/7494)

### Problem description
The existing tests didn't test that values to semaphores and circular buffers are being correctly written out when a `CoreRangeSet` containing multiple `CoreRange`s is used.

### What's changed
I've added unit tests to check that values to semaphore and circular buffers are being correctly written out when `CoreRangeSet`s containing multiple `CoreRange`s are used.

### Checklist
- [ ] [Post commit CI passes](https://github.com/tenstorrent/tt-metal/actions/runs/10117940813)
- [ ] Model regression CI testing passes (if applicable)
- [ ] New/Existing tests provide coverage for changes
