### PR TITLE
#10634: Fix bad std::variant type check on MultiDeviceHostStorage

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -8,5 +8,5 @@ add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/tt_metal/tt_metal)
 add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/tt_eager) # this should go away and be replaced with link to ttnn
 add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/ttnn/unit_tests/gtests)
 
-set(TESTS_DEPENDS_LIST metal_tests eager_tests unit_tests_ttnn ttnn watcher_dump)
+set(TESTS_DEPENDS_LIST metal_tests eager_tests unit_tests_ttnn test_multi_device ttnn watcher_dump)
 add_custom_target(tests DEPENDS ${TESTS_DEPENDS_LIST})

--- a/tests/scripts/t3000/run_t3000_unit_tests.sh
+++ b/tests/scripts/t3000/run_t3000_unit_tests.sh
@@ -32,6 +32,7 @@ run_t3000_ttnn_tests() {
   start_time=$(date +%s)
 
   echo "LOG_METAL: Running run_t3000_ttnn_tests"
+  WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml ./build/test/ttnn/test_multi_device
   WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml ./build/test/ttnn/unit_tests_ttnn
   pytest -n auto tests/ttnn/unit_tests/test_multi_device_trace.py ; fail+=$?
   WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml pytest tests/ttnn/unit_tests/test_multi_device_trace.py ; fail+=$?

--- a/tests/ttnn/unit_tests/gtests/CMakeLists.txt
+++ b/tests/ttnn/unit_tests/gtests/CMakeLists.txt
@@ -10,13 +10,21 @@ set(TTNN_UNIT_TESTS_SRC
 )
 
 add_executable(unit_tests_ttnn ${TTNN_UNIT_TESTS_SRC})
+add_executable(test_multi_device ${CMAKE_CURRENT_SOURCE_DIR}/test_multi_device.cpp)
 
-target_link_libraries(unit_tests_ttnn PUBLIC test_common_libs ttnn tt_metal)
-target_include_directories(unit_tests_ttnn PRIVATE
-    ${UMD_HOME}
-    ${PROJECT_SOURCE_DIR}
-    ${PROJECT_SOURCE_DIR}/tt_metal
-    ${PROJECT_SOURCE_DIR}/tests
-    ${CMAKE_CURRENT_SOURCE_DIR}
-)
-set_target_properties(unit_tests_ttnn PROPERTIES RUNTIME_OUTPUT_DIRECTORY ${PROJECT_BINARY_DIR}/test/ttnn)
+# Common function to set up target properties
+function(setup_ttnn_test_target target_name)
+    target_link_libraries(${target_name} PUBLIC test_common_libs ttnn tt_metal)
+    target_include_directories(${target_name} PRIVATE
+        ${UMD_HOME}
+        ${PROJECT_SOURCE_DIR}
+        ${PROJECT_SOURCE_DIR}/tt_metal
+        ${PROJECT_SOURCE_DIR}/tests
+        ${CMAKE_CURRENT_SOURCE_DIR}
+    )
+    set_target_properties(${target_name} PROPERTIES RUNTIME_OUTPUT_DIRECTORY ${PROJECT_BINARY_DIR}/test/ttnn)
+endfunction()
+
+# Set up properties for both targets
+setup_ttnn_test_target(unit_tests_ttnn)
+setup_ttnn_test_target(test_multi_device)

--- a/tests/ttnn/unit_tests/gtests/test_multi_device.cpp
+++ b/tests/ttnn/unit_tests/gtests/test_multi_device.cpp
@@ -1,0 +1,39 @@
+// SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "gtest/gtest.h"
+#include "ttnn_test_fixtures.hpp"
+#include "ttnn/cpp/ttnn/tensor/types.hpp"
+#include "ttnn/cpp/ttnn/operations/creation.hpp"
+
+namespace ttnn::multi_device::test {
+
+using namespace tt::tt_metal;
+
+Tensor create_host_multi_device_tensor(const Tensor& tensor, const ReplicateTensor& strategy) {
+    std::vector<OwnedBuffer> owned_buffers;
+    std::vector<tt::tt_metal::Shape> shapes;
+
+    for (int i = 0; i < strategy.replication_factor; i++) {
+        owned_buffers.push_back(std::get<OwnedStorage>(tensor.get_storage()).buffer);
+        shapes.push_back(tensor.get_legacy_shape());
+    }
+
+    return Tensor{
+        MultiDeviceHostStorage(strategy, owned_buffers, shapes),
+        tensor.get_legacy_shape(),
+        tensor.get_dtype(),
+        tensor.get_layout()};
+}
+
+TEST_F(T3kMultiDeviceFixture, TestGetTensorsFromMultiDeviceStorage) {
+    DeviceMesh* device_mesh = this->device_mesh_.get();
+    const auto input_tensor = ttnn::ones(ttnn::Shape(std::array<uint32_t, 2>{32, 32}), ttnn::bfloat16);
+    const auto replicated_tensor = create_host_multi_device_tensor(input_tensor, ReplicateTensor(8));
+    const auto device_tensors = get_tensors_from_multi_device_storage(replicated_tensor);
+
+    EXPECT_EQ(device_tensors.size(), 8);
+}
+
+}  // namespace ttnn::multi_device::test

--- a/tests/ttnn/unit_tests/gtests/ttnn_test_fixtures.hpp
+++ b/tests/ttnn/unit_tests/gtests/ttnn_test_fixtures.hpp
@@ -12,6 +12,8 @@
 
 #include "ttnn/device.hpp"
 #include "tests/tt_metal/test_utils/env_vars.hpp"
+#include "tt_metal/hostdevcommon/common_values.hpp"
+#include "tt_metal/impl/device/multi_device.hpp"
 
 namespace ttnn {
 
@@ -46,3 +48,34 @@ class TTNNFixtureWithDevice : public TTNNFixture {
 };
 
 }  // namespace ttnn
+
+
+namespace ttnn::multi_device::test {
+
+class T3kMultiDeviceFixture : public ::testing::Test {
+   protected:
+    void SetUp() override {
+        auto slow_dispatch = getenv("TT_METAL_SLOW_DISPATCH_MODE");
+        const auto arch = tt::get_arch_from_string(tt::test_utils::get_env_arch_name());
+        const size_t num_devices = tt::tt_metal::GetNumAvailableDevices();
+        if (slow_dispatch) {
+            GTEST_SKIP() << "Skipping Multi-Device test suite, since it can only be run in Fast Dispatch Mode.";
+        }
+        if (num_devices < 8 or arch != tt::ARCH::WORMHOLE_B0) {
+            GTEST_SKIP() << "Skipping T3K Multi-Device test suite on non T3K machine.";
+        }
+        const auto T3K_DEVICE_IDS = ttnn::multi_device::DeviceIds{0, 4, 5, 1, 2, 6, 7, 3};
+        constexpr auto DEFAULT_NUM_COMMAND_QUEUES = 1;
+        device_mesh_ = std::make_unique<ttnn::multi_device::DeviceMesh>(
+            ttnn::multi_device::DeviceGrid{1, num_devices},
+            T3K_DEVICE_IDS,
+            DEFAULT_L1_SMALL_SIZE,
+            DEFAULT_TRACE_REGION_SIZE,
+            DEFAULT_NUM_COMMAND_QUEUES);
+    }
+
+    void TearDown() override { device_mesh_.reset(); }
+    std::unique_ptr<ttnn::multi_device::DeviceMesh> device_mesh_;
+};
+
+}  // namespace ttnn::multi_device::test

--- a/ttnn/cpp/ttnn/tensor/tensor_utils.cpp
+++ b/ttnn/cpp/ttnn/tensor/tensor_utils.cpp
@@ -537,7 +537,7 @@ std::vector<Tensor> get_tensors_from_multi_device_storage(const Tensor& multi_de
         }
         return tensors;
     } else if (multi_device_tensor.storage_type() == StorageType::MULTI_DEVICE_HOST) {
-        TT_ASSERT(std::holds_alternative<MultiDeviceStorage>(multi_device_tensor.get_storage()), fmt::format("Unexpected type {} in {}:{} ",tt::stl::get_active_type_name_in_variant(multi_device_tensor.get_storage()),__FILE__, __LINE__));
+        TT_ASSERT(std::holds_alternative<MultiDeviceHostStorage>(multi_device_tensor.get_storage()), fmt::format("Unexpected type {} in {}:{} ",tt::stl::get_active_type_name_in_variant(multi_device_tensor.get_storage()),__FILE__, __LINE__));
         const auto& tensor_storage = std::get<MultiDeviceHostStorage>(multi_device_tensor.get_storage());
         for (int i = 0; i < tensor_storage.num_buffers(); ++i) {
             tensors.push_back(Tensor{

--- a/ttnn/cpp/ttnn/tensor/tensor_utils.hpp
+++ b/ttnn/cpp/ttnn/tensor/tensor_utils.hpp
@@ -107,7 +107,8 @@ bool is_multi_device_tensor(const Tensor& tensor);
 std::vector<Tensor> get_tensors_from_multi_device_storage(const Tensor& multi_device_tensor);
 
 // Given a list of per-device shards, return a multi-device tensor
-Tensor create_multi_device_tensor(const std::vector<Tensor>& tensors);
+Tensor create_multi_device_tensor(
+    const std::vector<Tensor>& tensors, StorageType storage_type, const DistributedTensorConfig& strategy);
 
 // Given a multi-device tensor, and a function that transforms a tensor, apply the function to all per-device
 // tensors.

--- a/ttnn/cpp/ttnn/tensor/types.cpp
+++ b/ttnn/cpp/ttnn/tensor/types.cpp
@@ -13,7 +13,10 @@ static DistributedTensorConfig create_shard_distributed_tensor_config(const std:
     return ShardTensor(std::stoi(metadata.at("shard_dim")));
 }
 static DistributedTensorConfig create_replicate_distributed_tensor_config(const std::unordered_map<std::string, std::string>& metadata) {
-    return ReplicateTensor{};
+    if (auto it = metadata.find("replication_factor"); it != metadata.end()) {
+        return ReplicateTensor(std::stoi(it->second));
+    }
+    TT_THROW("Unsupported Replication strategy:");
 }
 
 DistributedTensorConfig get_distributed_tensor_config(const std::unordered_map<std::string, std::string>& metadata) {
@@ -166,8 +169,8 @@ const uint32_t Shape::get_normalized_index(std::int64_t index) const {
     return normalized_index;
 }
 
-bool operator==(const ReplicateTensor&, const ReplicateTensor&) {
-    return true; // All instances are considered equal because there are no data members.
+bool operator==(const ReplicateTensor& a, const ReplicateTensor& b) {
+    return a.replication_factor == b.replication_factor; // All instances are considered equal because there are no data members.
 }
 bool operator==(const AllGatherTensor&, const AllGatherTensor&) {
     return true; // All instances are considered equal because there are no data members.

--- a/ttnn/cpp/ttnn/tensor/types.hpp
+++ b/ttnn/cpp/ttnn/tensor/types.hpp
@@ -60,7 +60,11 @@ enum class StorageType {
 
 struct AllGatherTensor{};
 bool operator==(const AllGatherTensor&, const AllGatherTensor&);
-struct ReplicateTensor {};
+struct ReplicateTensor {
+    int replication_factor = 1;
+    ReplicateTensor() = default;
+    ReplicateTensor(int replication_factor) : replication_factor(replication_factor) {}
+};
 bool operator==(const ReplicateTensor&, const ReplicateTensor&);
 struct ShardTensor {
     int shard_dimension;

--- a/ttnn/ttnn/multi_device.py
+++ b/ttnn/ttnn/multi_device.py
@@ -145,6 +145,7 @@ class ReplicateTensorToMesh(TensorToMesh):
     def config(self):
         return {
             "strategy": "replicate",
+            "replication_factor": str(self.device_mesh.get_num_devices()),
         }
 
 


### PR DESCRIPTION
### Ticket
[Link to Github Issue](https://github.com/tenstorrent/tt-metal/issues/10634)

### Problem description
Seems like a bad copy-paste was introduced as we're calling TT_ASSERT on wrong std::variant type.

### What's changed
Fixed the TT_ASSERT

### Checklist
- [x] Post commit CI passes
- [x] Model regression CI testing passes (if applicable)
- [x] New/Existing tests provide coverage for changes
