### PR TITLE
#9992: WH bugfix on add2ints_riscv kernel (correct result now shows),…

### DIFF
--- a/tt_metal/programming_examples/add_2_integers_in_riscv/kernels/reader_writer_add_in_riscv.cpp
+++ b/tt_metal/programming_examples/add_2_integers_in_riscv/kernels/reader_writer_add_in_riscv.cpp
@@ -1,16 +1,18 @@
-// SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+// SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
 
 void kernel_main() {
-    uint32_t src0_dram  = get_arg_val<uint32_t>(0);
-    uint32_t src1_dram  = get_arg_val<uint32_t>(1);
-    uint32_t dst_dram  = get_arg_val<uint32_t>(2);
+    uint32_t dram_noc_x = get_arg_val<uint32_t>(0);
+    uint32_t dram_noc_y = get_arg_val<uint32_t>(1);
+    uint32_t src0_dram  = get_arg_val<uint32_t>(2);
+    uint32_t src1_dram  = get_arg_val<uint32_t>(3);
+    uint32_t dst_dram  = get_arg_val<uint32_t>(4);
 
     // NoC coords (x,y)= (1,0)
-    uint64_t src0_dram_noc_addr = get_noc_addr(1, 0, src0_dram);
-    uint64_t src1_dram_noc_addr = get_noc_addr(1, 0, src1_dram);
-    uint64_t dst_dram_noc_addr = get_noc_addr(1, 0, dst_dram);
+    uint64_t src0_dram_noc_addr = get_noc_addr(dram_noc_x, dram_noc_y, src0_dram);
+    uint64_t src1_dram_noc_addr = get_noc_addr(dram_noc_x, dram_noc_y, src1_dram);
+    uint64_t dst_dram_noc_addr = get_noc_addr(dram_noc_x, dram_noc_y, dst_dram);
 
     constexpr uint32_t cb_id_in0 = tt::CB::c_in0; // index=0
     constexpr uint32_t cb_id_in1 = tt::CB::c_in1; // index=1

--- a/tt_metal/programming_examples/hello_world_datatypes_kernel/hello_world_datatypes_kernel.cpp
+++ b/tt_metal/programming_examples/hello_world_datatypes_kernel/hello_world_datatypes_kernel.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+// SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -27,6 +27,12 @@ int main(int argc, char **argv) {
         .buffer_type = tt_metal::BufferType::DRAM
     };
     std::shared_ptr<tt::tt_metal::Buffer> dram_buffer = CreateBuffer(buffer_config);
+
+    // Configure and Create Circular Buffer (to move data from DRAM to L1)
+
+    constexpr uint32_t src0_cb_index = CB::c_in0;
+    CircularBufferConfig cb_src0_config = CircularBufferConfig(buffer_size, {{src0_cb_index, tt::DataFormat::Float16_b}}).set_page_size(src0_cb_index, buffer_size);
+    CBHandle cb_src0 = tt_metal::CreateCircularBuffer(program, core, cb_src0_config);
 
     // Configure and Create Data Movement Kernels
 

--- a/tt_metal/programming_examples/hello_world_datatypes_kernel/kernels/dataflow/float_dataflow_kernel.cpp
+++ b/tt_metal/programming_examples/hello_world_datatypes_kernel/kernels/dataflow/float_dataflow_kernel.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+// SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -21,7 +21,7 @@ void kernel_main() {
         noc_async_read_barrier();
 
         float* data = (float*) l1_addr;
-        DPRINT << "Master, I have retrieved the value stored on Device 0 DRAM. It is: " << F32(*data) << ENDL();
+        DPRINT << "Master, I have retrieved the value stored on Device 0 DRAM. Here we go.  It is: " << F32(*data) << ENDL();
 
         cb_push_back(cb_id, 0);
 


### PR DESCRIPTION
… GS bugfix on helloworld datatypes kernel (cmake hang gone)

### Ticket
[Link to Github Issue](https://github.com/tenstorrent/tt-metal/issues/9992)

### Problem description
User reported incorrect result of add_2_integers_in_riscv on a Wormhole device.  Debugging determined that the incorrect DRAM NOC addresses were being referenced, and the operands pulled from DRAM were sometimes correct (in lucky cases) but in almost all cases were arbitrary and undesirable large integers.  

### What's changed
Correct DRAM NOC coordinates were given to the host and device code.  This now allowed us to add dynamic DRAM NOC coordinate functionality, wherein different NOC coordinates can be passed into the Runtime arguments depending on the user's architecture (given by the Ubuntu env var).  Default NOC coordinate pair is for a Grayskull device.  If the user's architecture is Wormhole, then a correct NOC coordinate pair is passed.  In either architecture case, NOC coordinates can be changed in the source code as per the user's liking.

Also, as an aside, this bugfix resolves an issue on the hello_world_datatypes_kernel programming example, in which another user reported a hang on Grayskull after building METALIUM with the latest CMAKE scheme.  This has been resolved after explicitly defining a circular buffer in the host code.

### Checklist
- [x] Post commit CI passes
- [x] Model regression CI testing passes (if applicable)
- [x] New/Existing tests provide coverage for changes
