### PR TITLE
Migration of rsub yaml files and api calls to ttnn

### DIFF
--- a/tests/tt_eager/python_api_testing/sweep_tests/op_map.py
+++ b/tests/tt_eager/python_api_testing/sweep_tests/op_map.py
@@ -640,10 +640,6 @@ op_map = {
         "tt_op": tt_lib_ops.eltwise_rpow,
         "pytorch_op": pytorch_ops.eltwise_rpow,
     },
-    "eltwise-rsub": {
-        "tt_op": tt_lib_ops.eltwise_rsub,
-        "pytorch_op": pytorch_ops.eltwise_rsub,
-    },
     "eltwise-identity": {
         "tt_op": tt_lib_ops.eltwise_identity,
         "pytorch_op": pytorch_ops.eltwise_identity,

--- a/tests/tt_eager/python_api_testing/sweep_tests/pytests/tt_dnn/test_eltwise_unary.py
+++ b/tests/tt_eager/python_api_testing/sweep_tests/pytests/tt_dnn/test_eltwise_unary.py
@@ -1047,7 +1047,7 @@ class TestEltwiseUnary:
             device,
         )
 
-    @pytest.mark.parametrize("fn_kind", ["rdiv"])
+    @pytest.mark.parametrize("fn_kind", ["rsub", "rdiv"])
     def test_run_eltwise_reverse_ops(
         self,
         input_shapes,
@@ -1057,7 +1057,8 @@ class TestEltwiseUnary:
         input_mem_config,
         output_mem_config,
     ):
-        values = {"rdiv": (1.0, 100.0)}
+        values = {"rdiv": (1.0, 100.0), "rsub": (1.0, 50.0)}
+
         low_v, high_v = values[fn_kind]
         datagen_func = [
             generation_funcs.gen_func_with_cast(
@@ -1084,7 +1085,7 @@ class TestEltwiseUnary:
             ttnn_op=True,
         )
 
-    @pytest.mark.parametrize("fn_kind", ["rdiv"])
+    @pytest.mark.parametrize("fn_kind", ["rsub", "rdiv"])
     def test_run_eltwise_reverse_neg_ops(
         self,
         input_shapes,
@@ -1094,7 +1095,8 @@ class TestEltwiseUnary:
         input_mem_config,
         output_mem_config,
     ):
-        values = {"rdiv": (1.0, 100.0)}
+        values = {"rdiv": (1.0, 100.0), "rsub": (1.0, 50.0)}
+
         low_v, high_v = values[fn_kind]
         datagen_func = [
             generation_funcs.gen_func_with_cast(
@@ -1102,6 +1104,7 @@ class TestEltwiseUnary:
                 torch.bfloat16,
             )
         ]
+
         comparison_func = comparison_funcs.comp_pcc
         test_args = generation_funcs.gen_default_dtype_layout_device(input_shapes)[0]
         test_args.update(

--- a/tests/tt_eager/python_api_testing/sweep_tests/tt_lib_ops.py
+++ b/tests/tt_eager/python_api_testing/sweep_tests/tt_lib_ops.py
@@ -2244,24 +2244,6 @@ def untilize_with_unpadding(
 
 
 @setup_host_and_device
-def eltwise_rsub(
-    x,
-    *args,
-    device,
-    dtype,
-    layout,
-    input_mem_config,
-    output_mem_config,
-    **kwargs,
-):
-    factor = kwargs["factor"]
-    t0 = setup_tt_tensor(x, device, layout[0], input_mem_config[0], dtype[0])
-    t1 = ttnn.rsub(t0, factor, memory_config=output_mem_config)
-
-    return tt2torch_tensor(t1)
-
-
-@setup_host_and_device
 def eltwise_identity(
     x,
     *args,

--- a/tests/ttnn/python_api_testing/sweep_tests/op_map.py
+++ b/tests/ttnn/python_api_testing/sweep_tests/op_map.py
@@ -721,6 +721,10 @@ op_map = {
         "tt_op": ttnn_ops.eltwise_rdiv,
         "pytorch_op": pytorch_ops.eltwise_rdiv,
     },
+    "eltwise-rsub": {
+        "tt_op": ttnn_ops.eltwise_rsub,
+        "pytorch_op": pytorch_ops.eltwise_rsub,
+    },
     "log-bw": {
         "tt_op": ttnn_ops.log_bw,
         "pytorch_op": pytorch_ops.log_bw,

--- a/tests/ttnn/python_api_testing/sweep_tests/test_configs/ci_sweep_tests_working/grayskull/ttnn_eltwise_rsub_test.yaml
+++ b/tests/ttnn/python_api_testing/sweep_tests/test_configs/ci_sweep_tests_working/grayskull/ttnn_eltwise_rsub_test.yaml
@@ -5,8 +5,8 @@ test-list:
         start-shape: [1, 1, 32, 32]
         end-shape: [12, 24, 512, 512]
         interval: [1, 1, 32, 32]
-        num-shapes: 2
-        num-samples: 64
+        num-shapes: 1
+        num-samples: 128
         args-sampling-strategy: "all"
       datagen:
         function: gen_rand
@@ -17,16 +17,10 @@ test-list:
         function: comp_pcc
       args-gen: gen_rop_args
       args:
-        inputs:
-          - input-1:
-            data-layout: ["TILE"]
-            data-type: ["BFLOAT16"]
-            buffer-type: ["DRAM", "L1", "SYSTEM_MEMORY"]
-          - input-2:
-            data-layout: ["TILE"]
-            data-type: ["BFLOAT16"]
-            buffer-type: ["DRAM", "L1", "SYSTEM_MEMORY"]
-        out-buffer-type: ["DRAM"]
+        data-layout: ["TILE"]
+        data-type: ["BFLOAT16", "BFLOAT8_B"]
+        buffer-type: ["DRAM", "L1"]
+        out-buffer-type: ["DRAM", "L1", "SYSTEM_MEMORY"]
       output-file: eltwise_rsub_sweep.csv
       env:
         # TT_PCI_DMA_BUF_SIZE: "1048576"

--- a/tests/ttnn/python_api_testing/sweep_tests/test_configs/ci_sweep_tests_working/wormhole/ttnn_eltwise_rsub_test.yaml
+++ b/tests/ttnn/python_api_testing/sweep_tests/test_configs/ci_sweep_tests_working/wormhole/ttnn_eltwise_rsub_test.yaml
@@ -5,8 +5,8 @@ test-list:
         start-shape: [1, 1, 32, 32]
         end-shape: [12, 24, 512, 512]
         interval: [1, 1, 32, 32]
-        num-shapes: 2
-        num-samples: 64
+        num-shapes: 1
+        num-samples: 128
         args-sampling-strategy: "all"
       datagen:
         function: gen_rand
@@ -17,16 +17,10 @@ test-list:
         function: comp_pcc
       args-gen: gen_rop_args
       args:
-        inputs:
-          - input-1:
-            data-layout: ["TILE"]
-            data-type: ["BFLOAT16"]
-            buffer-type: ["DRAM", "L1", "SYSTEM_MEMORY"]
-          - input-2:
-            data-layout: ["TILE"]
-            data-type: ["BFLOAT16"]
-            buffer-type: ["DRAM", "L1", "SYSTEM_MEMORY"]
-        out-buffer-type: ["DRAM"]
+        data-layout: ["TILE"]
+        data-type: ["BFLOAT16", "BFLOAT8_B"]
+        buffer-type: ["DRAM", "L1"]
+        out-buffer-type: ["DRAM", "L1", "SYSTEM_MEMORY"]
       output-file: eltwise_rsub_sweep.csv
       env:
         # TT_PCI_DMA_BUF_SIZE: "1048576"

--- a/tests/ttnn/python_api_testing/sweep_tests/ttnn_ops.py
+++ b/tests/ttnn/python_api_testing/sweep_tests/ttnn_ops.py
@@ -3552,6 +3552,23 @@ def eltwise_rdiv(
     return ttnn_tensor_to_torch(t1)
 
 
+def eltwise_rsub(
+    x,
+    *args,
+    device,
+    dtype,
+    layout,
+    input_mem_config,
+    output_mem_config,
+    **kwargs,
+):
+    factor = kwargs["factor"]
+    t0 = setup_ttnn_tensor(x, device, layout[0], input_mem_config[0], dtype[0])
+    t1 = ttnn.rsub(t0, factor, memory_config=output_mem_config)
+
+    return ttnn_tensor_to_torch(t1)
+
+
 def neg_bw(
     x,
     y,


### PR DESCRIPTION
### Ticket
[Link to Github Issue](https://github.com/tenstorrent/tt-metal/issues/10147)

### Problem description
Migration of rsub sweeps and API calls from tt_eager to ttnn

### What's changed
1. Created sweep YAML files for ttnn_rsub (both GS and WH)
2. Removed sweep YAML files for tt_eager ttnn_rsub (both GS and WH)
3. Added corresponding API calls in ttnn_ops and ttnn/op_map for ttnn_rsub
4. Removed corresponding API calls in tt_lib_ops and tt_eager/op_map for or tt_eager rsub
