### PR TITLE
Add stagger to avoid di/dt hangs

### DIFF
--- a/tests/device_perf_tests/matmul_stagger/test_matmul_stagger.py
+++ b/tests/device_perf_tests/matmul_stagger/test_matmul_stagger.py
@@ -1,0 +1,38 @@
+# SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+
+# SPDX-License-Identifier: Apache-2.0
+import os
+import pytest
+
+from models.utility_functions import run_for_wormhole_b0
+from tt_metal.tools.profiler.process_model_log import post_process_ops_log, run_device_profiler
+
+MATMUL_VARIANTS = ["matmul1d_regular", "matmul1d_transposed", "matmul2d", "matmul_no_mcast"]
+
+
+# for all matmul variants that can enable stagger, profile op with stagger enabled and disabled,
+# and make sure the execution time of the op is longer with stagger enabled
+@run_for_wormhole_b0()
+@pytest.mark.models_device_performance_bare_metal
+@pytest.mark.parametrize(
+    "matmul_variant",
+    MATMUL_VARIANTS,
+)
+def test_matmul_stagger(matmul_variant):
+    duration_column = "DEVICE FW DURATION [ns]"
+    output_logs_subdir = "test_matmul"
+
+    command = f"pytest tests/device_perf_tests/matmul_stagger/test_run_8x7_matmul.py -k {matmul_variant}"
+
+    os.environ["TT_ENABLE_MATMUL_STAGGER"] = "1"
+    output_logs_subdir_with_stagger = output_logs_subdir + "_with_stagger"
+    run_device_profiler(command, output_logs_subdir_with_stagger)
+    results_with_stagger = post_process_ops_log(output_logs_subdir_with_stagger, [duration_column])
+
+    del os.environ["TT_ENABLE_MATMUL_STAGGER"]
+    run_device_profiler(command, output_logs_subdir)
+    results_without_stagger = post_process_ops_log(output_logs_subdir, [duration_column])
+
+    assert (
+        results_without_stagger[duration_column] < results_with_stagger[duration_column]
+    ), f"There should be a visible perf drop when running {matmul_variant} with stagger"

--- a/tests/device_perf_tests/matmul_stagger/test_run_8x7_matmul.py
+++ b/tests/device_perf_tests/matmul_stagger/test_run_8x7_matmul.py
@@ -1,0 +1,123 @@
+# SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+
+# SPDX-License-Identifier: Apache-2.0
+import pytest
+
+from loguru import logger
+import torch
+
+from models.utility_functions import run_for_wormhole_b0
+import ttnn
+from tests.device_perf_tests.matmul_stagger.test_matmul_stagger import MATMUL_VARIANTS
+from tests.tt_eager.python_api_testing.sweep_tests.comparison_funcs import (
+    comp_pcc,
+)
+
+
+@run_for_wormhole_b0()
+@pytest.mark.parametrize(
+    "program_config_variant, seq_len, inner_dim, weights_n, per_core_M, per_core_N, in_block_w, out_subblock_h, out_subblock_w, mcast_in0",
+    (
+        ("MatmulMultiCoreReuseMultiCast1DProgramConfig", 1 * 32, 1 * 32, 56 * 32, 1, 1, 1, 1, 1, True),
+        ("MatmulMultiCoreReuseMultiCast1DProgramConfig", 56 * 32, 1 * 32, 1 * 32, 1, 1, 1, 1, 1, False),
+        ("MatmulMultiCoreReuseMultiCastProgramConfig", 7 * 32, 1 * 32, 8 * 32, 1, 1, 1, 1, 1, False),
+        ("MatmulMultiCoreReuseProgramConfig", 56 * 32, 1 * 32, 56 * 32, 1, 56, 1, 1, 1, False),
+    ),
+    ids=MATMUL_VARIANTS,
+)
+def test_run_8x7_matmul(
+    device,
+    program_config_variant,
+    seq_len,
+    inner_dim,
+    weights_n,
+    per_core_M,
+    per_core_N,
+    in_block_w,
+    out_subblock_h,
+    out_subblock_w,
+    mcast_in0,
+):
+    mem_config = ttnn.MemoryConfig(ttnn.TensorMemoryLayout.INTERLEAVED, ttnn.BufferType.DRAM)
+    dtype = ttnn.DataType.BFLOAT8_B
+    grid_size = (8, 7)
+
+    a_shape = [1, 1, seq_len, inner_dim]
+    b_shape = [1, 1, inner_dim, weights_n]
+
+    A = torch.randn(a_shape)
+    B = torch.randn(b_shape)
+
+    input0 = ttnn.as_tensor(
+        A,
+        dtype=dtype,
+        layout=ttnn.TILE_LAYOUT,
+        device=device,
+        memory_config=mem_config,
+    )
+    input0 = ttnn.to_device(input0, device)
+
+    input1 = ttnn.as_tensor(
+        B,
+        dtype=dtype,
+        layout=ttnn.TILE_LAYOUT,
+        device=device,
+        memory_config=mem_config,
+    )
+    input1 = ttnn.to_device(input1, device)
+
+    if program_config_variant == "MatmulMultiCoreReuseMultiCastProgramConfig":
+        program_config = ttnn.MatmulMultiCoreReuseMultiCastProgramConfig(
+            compute_with_storage_grid_size=grid_size,
+            in0_block_w=in_block_w,
+            out_subblock_h=out_subblock_h,
+            out_subblock_w=out_subblock_w,
+            per_core_M=per_core_M,
+            per_core_N=per_core_N,
+            transpose_mcast=False,
+            fused_activation=None,
+        )
+    elif program_config_variant == "MatmulMultiCoreReuseMultiCast1DProgramConfig":
+        program_config = ttnn.MatmulMultiCoreReuseMultiCast1DProgramConfig(
+            compute_with_storage_grid_size=grid_size,
+            in0_block_w=in_block_w,
+            out_subblock_h=out_subblock_h,
+            out_subblock_w=out_subblock_w,
+            per_core_M=per_core_M,
+            per_core_N=per_core_N,
+            fuse_batch=True,
+            fused_activation=None,
+            mcast_in0=mcast_in0,
+        )
+    else:
+        program_config = ttnn.MatmulMultiCoreReuseProgramConfig(
+            compute_with_storage_grid_size=grid_size,
+            in0_block_w=in_block_w,
+            out_subblock_h=out_subblock_h,
+            out_subblock_w=out_subblock_w,
+            per_core_M=per_core_M,
+            per_core_N=per_core_N,
+        )
+
+    compute_config = ttnn.WormholeComputeKernelConfig(
+        math_fidelity=ttnn.MathFidelity.LoFi,
+        math_approx_mode=False,
+        fp32_dest_acc_en=False,
+        packer_l1_acc=True,
+    )
+
+    out = ttnn.matmul(
+        input0,
+        input1,
+        program_config=program_config,
+        memory_config=mem_config,
+        dtype=dtype,
+        compute_kernel_config=compute_config,
+    )
+
+    pt_out = A @ B
+    out = ttnn.to_torch(out)
+
+    passing, output = comp_pcc(pt_out, out)
+    logger.info(output)
+    assert passing

--- a/tests/scripts/run_performance.sh
+++ b/tests/scripts/run_performance.sh
@@ -94,6 +94,8 @@ run_device_perf_ops() {
     local test_marker=$1
 
     env pytest tests/tt_eager/ops_device_perf/run_op_profiling.py -m $test_marker
+
+    env pytest tests/device_perf_tests/matmul_stagger/test_matmul_stagger.py -m $test_marker
 }
 
 main() {

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_io/llk_io_unpack.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_io/llk_io_unpack.h
@@ -37,6 +37,27 @@ inline void llk_setup_operands() {
     }
 }
 
+// Apply delay on odd rows of tensix cores in case of matmul.
+// We do this so that not all cores start at once, therefore reducing the chance of di/dt problems.
+// MM_STAGGER_ODD_ROWS is an externally controlled define, set up in program compilation.
+inline __attribute__ ((__always_inline__)) void apply_mm_stagger(int operand) {
+    #ifdef MM_STAGGER_ODD_ROWS
+    static bool stagger_applied = false;
+    constexpr int stagger_operand = 1;
+    constexpr int stagger_delay_in_cycles = 12288;
+    if (stagger_applied == false && operand == stagger_operand) {
+        stagger_applied = true;
+        constexpr uint32_t noc_id = 0;
+        uint32_t noc_id_logical_reg = NOC_CFG_READ_REG(noc_id, NOC_ID_LOGICAL);
+        uint32_t my_logical_y = (noc_id_logical_reg >> NOC_ADDR_NODE_ID_BITS) & NOC_NODE_ID_MASK;
+        // Apply stagger on odd rows only
+        if (my_logical_y & 0x1) {
+            wait(stagger_delay_in_cycles);
+        }
+    }
+    #endif
+}
+
 // Wait for N tiles available in the incoming stream
 inline void llk_wait_tiles(int operand, std::int32_t num_tiles) {
     // TODO(MO): Manually uncomment until issue #6619 is resolved
@@ -52,6 +73,8 @@ inline void llk_wait_tiles(int operand, std::int32_t num_tiles) {
         tiles_received = (std::uint16_t) reg_read((std::uint32_t)tiles_received_ptr);
         num_tiles_recv = tiles_received - cb_interface[input].tiles_acked;
     } while (num_tiles_recv < num_tiles_u);
+
+    apply_mm_stagger(operand);
 }
 
 // Pop N tiles from the incoming stream

--- a/ttnn/cpp/ttnn/operations/matmul/device/matmul_op.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/matmul_op.cpp
@@ -495,6 +495,21 @@ tt::operations::primary::MatmulProgramConfig get_matmul_program_config(
         input_tensor_a, input_tensor_b, grid_size, fused_activation, compute_kernel_config);
 }
 
+void add_stagger_defines_if_needed(const tt::ARCH arch, const int num_cores, std::map<string, string>& mm_kernel_defines) {
+    // Empirically deduced di/dt problems appear for matmuls using more than 48 cores;
+    // when there is 48 cores or less, we never enable stagger since the delay impacts op performance
+    constexpr uint32_t WH_B0_MM_MAX_CORES_NO_STAGGER = 48;
+
+    // Apply stagger delay on Wormhole B0 on odd rows, so that only half of cores start doing work at once.
+    // This is done to mitigate di/dt issues, in case the environment var is set.
+    // See issue #9857.
+    const bool enable_stagger = std::getenv("TT_ENABLE_MATMUL_STAGGER");
+    if (enable_stagger && arch == tt::ARCH::WORMHOLE_B0 && num_cores > WH_B0_MM_MAX_CORES_NO_STAGGER) {
+        mm_kernel_defines["MM_STAGGER_ODD_ROWS"] = "1";
+        log_warning(tt::LogOp, "Stagger enabled for matmul op using {} cores.", num_cores);
+    }
+}
+
 std::tuple<uint32_t, uint32_t> get_subblock_sizes(
     uint32_t m_tiles_per_core, uint32_t n_tiles_per_core, bool fp32_dest_acc_en) {
     uint32_t out_subblock_h, out_subblock_w;
@@ -1289,9 +1304,7 @@ operation::ProgramWithCallbacks Matmul::create_program(
                     program_config.fused_activation,
                     program_config.mcast_in0,
                     this->untilize_out);
-            } else if constexpr (std::is_same_v<
-                                     ProgramConfigType,
-                                     MatmulMultiCoreReuseMultiCastDRAMShardedProgramConfig>) {
+            } else if constexpr (std::is_same_v<ProgramConfigType, MatmulMultiCoreReuseMultiCastDRAMShardedProgramConfig>) {
                 return matmul_multi_core_reuse_dram_sharded_optimized(
                     input_tensor_a,
                     input_tensor_b,

--- a/ttnn/cpp/ttnn/operations/matmul/device/matmul_op.hpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/matmul_op.hpp
@@ -359,4 +359,7 @@ tt::operations::primary::MatmulProgramConfig get_matmul_program_config(
     const bool matmul = false,
     const std::optional<const CoreCoord> user_core_coord = std::nullopt,
     std::optional<const DeviceComputeKernelConfig> compute_kernel_config = std::nullopt);
+
+void add_stagger_defines_if_needed(const tt::ARCH arch, const int num_cores, std::map<string, string>& mm_kernel_defines);
+
 }  // namespace bmm_op_utils

--- a/ttnn/cpp/ttnn/operations/matmul/device/multi_core_reuse_mcast_1d_optimized/bmm_op_multi_core_reuse_mcast_1d_optimized.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/multi_core_reuse_mcast_1d_optimized/bmm_op_multi_core_reuse_mcast_1d_optimized.cpp
@@ -340,6 +340,8 @@ operation::ProgramWithCallbacks create_program_mcast_in0(
         mm_kernel_defines["FP32_DEST_ACC_EN"] = "1";
     }
 
+    bmm_op_utils::add_stagger_defines_if_needed(device->arch(), num_cores, mm_kernel_defines);
+
     if (output_is_sharded) {
         mm_kernel_in1_sender_writer_defines["OUT_SHARDED"] = "1";
     }
@@ -1051,6 +1053,9 @@ operation::ProgramWithCallbacks create_program_mcast_in1(
     if (fp32_dest_acc_en) {
         mm_kernel_defines["FP32_DEST_ACC_EN"] = "1";
     }
+
+    bmm_op_utils::add_stagger_defines_if_needed(device->arch(), num_cores, mm_kernel_defines);
+
     if (in0_is_sharded) {
         mm_kernel_in0_sender_defines["IN0_SHARDED"] = "1";
     }

--- a/ttnn/cpp/ttnn/operations/matmul/device/multi_core_reuse_optimized/bmm_op_multi_core_reuse_optimized.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/multi_core_reuse_optimized/bmm_op_multi_core_reuse_optimized.cpp
@@ -41,7 +41,6 @@ operation::ProgramWithCallbacks create_program(
     tt::DataFormat in1_data_format,
     tt::DataFormat output_data_format,
     bool untilize_out
-
 ) {
     tt_metal::Program program{};
 
@@ -212,6 +211,8 @@ operation::ProgramWithCallbacks create_program(
     if (fp32_dest_acc_en) {
         mm_kernel_defines["FP32_DEST_ACC_EN"] = "1";
     }
+
+    bmm_op_utils::add_stagger_defines_if_needed(device->arch(), num_cores, mm_kernel_defines);
 
     // Create compute kernel
     auto mm_kernel_group_1_id = tt_metal::CreateKernel(


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/9857

### Problem description
To address di/dt issues, new firmware was rolled out (80.10.0.0), however we still need to add stagger to matmuls with big grid size to fix some of the repros (fw changes are not enough). 

### What's changed
Stagger refers to the delay we apply to some cores to avoid having them all start at the same time and trigger the di/dt behavior. We decided to delay every other row of cores for 12k cycles, in case matmul op uses more than 48 cores. The stagger applies to B0 architecture only, and can be disabled with a program config parameter or environment variable if needed. 

### CI (updated before merging)
- post commit: https://github.com/tenstorrent/tt-metal/actions/runs/10298815133
- device perf: https://github.com/tenstorrent/tt-metal/actions/runs/10286896659