### PR TITLE
#0: moved the name of registered operation to compile-time

### DIFF
--- a/ttnn/cpp/ttnn/operations/ccl/all_gather/all_gather_op.hpp
+++ b/ttnn/cpp/ttnn/operations/ccl/all_gather/all_gather_op.hpp
@@ -24,6 +24,6 @@ struct ExecuteAllGather {
 }  // namespace ccl
 }  // namespace operations
 
-constexpr auto all_gather = ttnn::register_operation<ttnn::operations::ccl::ExecuteAllGather>("ttnn::all_gather");
+constexpr auto all_gather = ttnn::register_operation<"ttnn::all_gather", ttnn::operations::ccl::ExecuteAllGather>();
 
 }  // namespace ttnn

--- a/ttnn/cpp/ttnn/operations/ccl/line_all_gather/line_all_gather_op.hpp
+++ b/ttnn/cpp/ttnn/operations/ccl/line_all_gather/line_all_gather_op.hpp
@@ -24,6 +24,6 @@ struct ExecuteLineAllGather {
 }  // namespace ccl
 }  // namespace operations
 
-constexpr auto line_all_gather = ttnn::register_operation<ttnn::operations::ccl::ExecuteLineAllGather>("ttnn::line_all_gather");
+constexpr auto line_all_gather = ttnn::register_operation<"ttnn::line_all_gather", ttnn::operations::ccl::ExecuteLineAllGather>();
 
 }  // namespace ttnn

--- a/ttnn/cpp/ttnn/operations/ccl/reduce_scatter/reduce_scatter_op.hpp
+++ b/ttnn/cpp/ttnn/operations/ccl/reduce_scatter/reduce_scatter_op.hpp
@@ -26,6 +26,7 @@ struct ExecuteReduceScatter {
 }  // namespace ccl
 }  // namespace operations
 
-constexpr auto reduce_scatter = ttnn::register_operation<ttnn::operations::ccl::ExecuteReduceScatter>("ttnn::reduce_scatter");
+constexpr auto reduce_scatter =
+    ttnn::register_operation<"ttnn::reduce_scatter", ttnn::operations::ccl::ExecuteReduceScatter>();
 
 }  // namespace ttnn

--- a/ttnn/cpp/ttnn/operations/copy.hpp
+++ b/ttnn/cpp/ttnn/operations/copy.hpp
@@ -99,6 +99,6 @@ struct Typecast {
 }  // namespace copy
 }  // namespace operations
 
-constexpr auto typecast = ttnn::register_operation<ttnn::operations::copy::Typecast>("ttnn::typecast");
+constexpr auto typecast = ttnn::register_operation<"ttnn::typecast", ttnn::operations::copy::Typecast>();
 
 }  // namespace ttnn

--- a/ttnn/cpp/ttnn/operations/core/core.hpp
+++ b/ttnn/cpp/ttnn/operations/core/core.hpp
@@ -277,8 +277,9 @@ using operations::core::squeeze_from_4D;
 using operations::core::to_device;
 using operations::core::unsqueeze_to_4D;
 
-constexpr auto to_dtype = ttnn::register_operation<ttnn::operations::core::ToDtype>("ttnn::to_dtype");
-constexpr auto to_memory_config = ttnn::register_operation<ttnn::operations::core::ToMemoryConfig>("ttnn::to_memory_config");
-constexpr auto to_layout = ttnn::register_operation<ttnn::operations::core::ToLayout>("ttnn::to_layout");
+constexpr auto to_dtype = ttnn::register_operation<"ttnn::to_dtype", ttnn::operations::core::ToDtype>();
+constexpr auto to_memory_config =
+    ttnn::register_operation<"ttnn::to_memory_config", ttnn::operations::core::ToMemoryConfig>();
+constexpr auto to_layout = ttnn::register_operation<"ttnn::to_layout", ttnn::operations::core::ToLayout>();
 
 }  // namespace ttnn

--- a/ttnn/cpp/ttnn/operations/creation.hpp
+++ b/ttnn/cpp/ttnn/operations/creation.hpp
@@ -232,18 +232,18 @@ struct Arange {
 }  // namespace creation
 }  // namespace operations
 
-constexpr auto full = ttnn::register_operation<ttnn::operations::creation::Full>("ttnn::full");
+constexpr auto full = ttnn::register_operation<"ttnn::full", ttnn::operations::creation::Full>();
 constexpr auto zeros = REGISTER_OPERATION_FROM_FUNCTION("ttnn::zeros", ttnn::operations::creation::zeros);
 constexpr auto ones = REGISTER_OPERATION_FROM_FUNCTION("ttnn::ones", ttnn::operations::creation::ones);
 constexpr auto empty = REGISTER_OPERATION_FROM_FUNCTION("ttnn::empty", ttnn::operations::creation::empty);
 
-constexpr auto full_like = ttnn::register_operation<ttnn::operations::creation::FullLike>("ttnn::full_like");
+constexpr auto full_like = ttnn::register_operation<"ttnn::full_like", ttnn::operations::creation::FullLike>();
 constexpr auto zeros_like =
     REGISTER_OPERATION_FROM_FUNCTION("ttnn::zeros_like", ttnn::operations::creation::zeros_like);
 constexpr auto ones_like = REGISTER_OPERATION_FROM_FUNCTION("ttnn::ones_like", ttnn::operations::creation::ones_like);
 constexpr auto empty_like =
     REGISTER_OPERATION_FROM_FUNCTION("ttnn::empty_like", ttnn::operations::creation::empty_like);
 
-constexpr auto arange = ttnn::register_operation<ttnn::operations::creation::Arange>("ttnn::arange");
+constexpr auto arange = ttnn::register_operation<"ttnn::arange", ttnn::operations::creation::Arange>();
 
 }  // namespace ttnn

--- a/ttnn/cpp/ttnn/operations/data_movement.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement.hpp
@@ -105,8 +105,9 @@ struct RepeatInterleave {
 }  // namespace data_movement
 }  // namespace operations
 
-constexpr auto upsample = ttnn::register_operation<ttnn::operations::data_movement::UpSample>("ttnn::upsample");
-constexpr auto repeat = ttnn::register_operation<ttnn::operations::data_movement::Repeat>("ttnn::repeat");
-constexpr auto repeat_interleave = ttnn::register_operation<ttnn::operations::data_movement::RepeatInterleave>("ttnn::repeat_interleave");
+constexpr auto upsample = ttnn::register_operation<"ttnn::upsample", ttnn::operations::data_movement::UpSample>();
+constexpr auto repeat = ttnn::register_operation<"ttnn::repeat", ttnn::operations::data_movement::Repeat>();
+constexpr auto repeat_interleave =
+    ttnn::register_operation<"ttnn::repeat_interleave", ttnn::operations::data_movement::RepeatInterleave>();
 
 }  // namespace ttnn

--- a/ttnn/cpp/ttnn/operations/data_movement/concat/concat.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/concat/concat.hpp
@@ -109,6 +109,6 @@ struct Concat {
 }  // namespace data_movement
 }  // namespace operations
 
-constexpr auto concat = ttnn::register_operation<ttnn::operations::data_movement::Concat>("ttnn::concat");
+constexpr auto concat = ttnn::register_operation<"ttnn::concat", ttnn::operations::data_movement::Concat>();
 
 }  // namespace ttnn

--- a/ttnn/cpp/ttnn/operations/data_movement/downsample/downsample.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/downsample/downsample.hpp
@@ -29,5 +29,5 @@ struct ExecuteDownsample {
 };
 } // data_movement
 } // operations
-constexpr auto downsample = ttnn::register_operation<ttnn::operations::data_movement::ExecuteDownsample>("ttnn::downsample");
+constexpr auto downsample = ttnn::register_operation<"ttnn::downsample", ttnn::operations::data_movement::ExecuteDownsample>();
 } // data_movement

--- a/ttnn/cpp/ttnn/operations/data_movement/pad/pad.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/pad/pad.hpp
@@ -335,6 +335,6 @@ struct ExecutePad {
 }  // namespace data_movement
 }  // namespace operations
 
-constexpr auto pad = ttnn::register_operation<ttnn::operations::data_movement::ExecutePad>("ttnn::pad");
+constexpr auto pad = ttnn::register_operation<"ttnn::pad", ttnn::operations::data_movement::ExecutePad>();
 
 }  // namespace ttnn

--- a/ttnn/cpp/ttnn/operations/data_movement/permute/permute.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/permute/permute.hpp
@@ -126,6 +126,6 @@ struct ExecutePermute {
 
 }  // namespace operations::data_movement
 
-constexpr auto permute = ttnn::register_operation<ttnn::operations::data_movement::ExecutePermute>("ttnn::permute");
+constexpr auto permute = ttnn::register_operation<"ttnn::permute", ttnn::operations::data_movement::ExecutePermute>();
 
 }  // namespace ttnn

--- a/ttnn/cpp/ttnn/operations/data_movement/slice/slice.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/slice/slice.hpp
@@ -144,6 +144,6 @@ struct ExecuteSlice {
 }  // namespace data_movement
 }  // namespace operations
 
-constexpr auto slice = ttnn::register_operation<ttnn::operations::data_movement::ExecuteSlice>("ttnn::slice");
+constexpr auto slice = ttnn::register_operation<"ttnn::slice", ttnn::operations::data_movement::ExecuteSlice>();
 
 }  // namespace ttnn

--- a/ttnn/cpp/ttnn/operations/data_movement/tilize/tilize.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/tilize/tilize.hpp
@@ -42,6 +42,6 @@ struct ExecuteTilize {
 
 }  // namespace operations::data_movement
 
-constexpr auto tilize = ttnn::register_operation<ttnn::operations::data_movement::ExecuteTilize>("ttnn::tilize");
+constexpr auto tilize = ttnn::register_operation<"ttnn::tilize", ttnn::operations::data_movement::ExecuteTilize>();
 
 }  // namespace ttnn

--- a/ttnn/cpp/ttnn/operations/data_movement/tilize_with_val_padding/tilize_with_val_padding.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/tilize_with_val_padding/tilize_with_val_padding.hpp
@@ -78,11 +78,11 @@ struct ExecuteTilizeWithZeroPadding {
 }  // namespace operations::data_movement
 
 constexpr auto tilize_with_val_padding =
-    ttnn::register_operation<ttnn::operations::data_movement::ExecuteTilizeWithValPadding>(
-        "ttnn::tilize_with_val_padding");
+    ttnn::register_operation<"ttnn::tilize_with_val_padding", ttnn::operations::data_movement::ExecuteTilizeWithValPadding>(
+        );
 
 constexpr auto tilize_with_zero_padding =
-    ttnn::register_operation<ttnn::operations::data_movement::ExecuteTilizeWithZeroPadding>(
-        "ttnn::tilize_with_zero_padding");
+    ttnn::register_operation<"ttnn::tilize_with_zero_padding", ttnn::operations::data_movement::ExecuteTilizeWithZeroPadding>(
+        );
 
 }  // namespace ttnn

--- a/ttnn/cpp/ttnn/operations/data_movement/transpose/transpose.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/transpose/transpose.hpp
@@ -41,6 +41,6 @@ struct ExecuteTranspose {
 
 }  // namespace operations::data_movement
 
-constexpr auto transpose = ttnn::register_operation<ttnn::operations::data_movement::ExecuteTranspose>("ttnn::transpose");
+constexpr auto transpose = ttnn::register_operation<"ttnn::transpose", ttnn::operations::data_movement::ExecuteTranspose>();
 
 }  // namespace ttnn

--- a/ttnn/cpp/ttnn/operations/eltwise/binary/binary.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary/binary.hpp
@@ -320,65 +320,64 @@ struct RelationalBinary {
 
 }  // operations::binary
 
-constexpr auto add =
-    ttnn::register_operation<operations::binary::BinaryOperation<operations::binary::BinaryOpType::ADD, false>>("ttnn::add");
-constexpr auto add_ =
-    ttnn::register_operation<operations::binary::BinaryOperation<operations::binary::BinaryOpType::ADD, true>>("ttnn::add_");
-constexpr auto subtract =
-    ttnn::register_operation<operations::binary::BinaryOperation<operations::binary::BinaryOpType::SUB, false>>(
-        "ttnn::subtract");
-constexpr auto subtract_ =
-    ttnn::register_operation<operations::binary::BinaryOperation<operations::binary::BinaryOpType::SUB, true>>(
-        "ttnn::subtract_");
-constexpr auto multiply =
-    ttnn::register_operation<operations::binary::BinaryOperation<operations::binary::BinaryOpType::MUL, false>>(
-        "ttnn::multiply");
-constexpr auto multiply_ =
-    ttnn::register_operation<operations::binary::BinaryOperation<operations::binary::BinaryOpType::MUL, true>>(
-        "ttnn::multiply_");
+constexpr auto add = ttnn::register_operation<
+    "ttnn::add",
+    operations::binary::BinaryOperation<operations::binary::BinaryOpType::ADD, false>>();
+constexpr auto add_ = ttnn::register_operation<
+    "ttnn::add_",
+    operations::binary::BinaryOperation<operations::binary::BinaryOpType::ADD, true>>();
+constexpr auto subtract = ttnn::register_operation<
+    "ttnn::subtract",
+    operations::binary::BinaryOperation<operations::binary::BinaryOpType::SUB, false>>();
+constexpr auto subtract_ = ttnn::register_operation<
+    "ttnn::subtract_",
+    operations::binary::BinaryOperation<operations::binary::BinaryOpType::SUB, true>>();
+constexpr auto multiply = ttnn::register_operation<
+    "ttnn::multiply",
+    operations::binary::BinaryOperation<operations::binary::BinaryOpType::MUL, false>>();
+constexpr auto multiply_ = ttnn::register_operation<
+    "ttnn::multiply_",
+    operations::binary::BinaryOperation<operations::binary::BinaryOpType::MUL, true>>();
 
-constexpr auto eq =
-    ttnn::register_operation<operations::binary::RelationalBinary<operations::binary::BinaryOpType::EQ, false>>(
-        "ttnn::eq");
-constexpr auto ne =
-    ttnn::register_operation<operations::binary::RelationalBinary<operations::binary::BinaryOpType::NE, false>>(
-        "ttnn::ne");
-constexpr auto ge =
-    ttnn::register_operation<operations::binary::RelationalBinary<operations::binary::BinaryOpType::GTE, false>>(
-        "ttnn::ge");
-constexpr auto gt =
-    ttnn::register_operation<operations::binary::RelationalBinary<operations::binary::BinaryOpType::GT, false>>(
-        "ttnn::gt");
-constexpr auto le =
-    ttnn::register_operation<operations::binary::RelationalBinary<operations::binary::BinaryOpType::LTE, false>>(
-        "ttnn::le");
-constexpr auto lt =
-    ttnn::register_operation<operations::binary::RelationalBinary<operations::binary::BinaryOpType::LT, false>>(
-        "ttnn::lt");
-constexpr auto logical_and =
-    ttnn::register_operation<operations::binary::BinaryOperation<operations::binary::BinaryOpType::LOGICAL_AND, false>>(
-        "ttnn::logical_and");
-constexpr auto logical_or =
-    ttnn::register_operation<operations::binary::BinaryOperation<operations::binary::BinaryOpType::LOGICAL_OR, false>>(
-        "ttnn::logical_or");
-constexpr auto ldexp =
-    ttnn::register_operation<operations::binary::BinaryOperation<operations::binary::BinaryOpType::LDEXP, false>>("ttnn::ldexp");
+constexpr auto eq = ttnn::
+    register_operation<"ttnn::eq", operations::binary::RelationalBinary<operations::binary::BinaryOpType::EQ, false>>();
+constexpr auto ne = ttnn::
+    register_operation<"ttnn::ne", operations::binary::RelationalBinary<operations::binary::BinaryOpType::NE, false>>();
+constexpr auto ge = ttnn::register_operation<
+    "ttnn::ge",
+    operations::binary::RelationalBinary<operations::binary::BinaryOpType::GTE, false>>();
+constexpr auto gt = ttnn::
+    register_operation<"ttnn::gt", operations::binary::RelationalBinary<operations::binary::BinaryOpType::GT, false>>();
+constexpr auto le = ttnn::register_operation<
+    "ttnn::le",
+    operations::binary::RelationalBinary<operations::binary::BinaryOpType::LTE, false>>();
+constexpr auto lt = ttnn::
+    register_operation<"ttnn::lt", operations::binary::RelationalBinary<operations::binary::BinaryOpType::LT, false>>();
+constexpr auto logical_and = ttnn::register_operation<
+    "ttnn::logical_and",
+    operations::binary::BinaryOperation<operations::binary::BinaryOpType::LOGICAL_AND, false>>();
+constexpr auto logical_or = ttnn::register_operation<
+    "ttnn::logical_or",
+    operations::binary::BinaryOperation<operations::binary::BinaryOpType::LOGICAL_OR, false>>();
+constexpr auto ldexp = ttnn::register_operation<
+    "ttnn::ldexp",
+    operations::binary::BinaryOperation<operations::binary::BinaryOpType::LDEXP, false>>();
 
-constexpr auto logaddexp =
-    ttnn::register_operation<operations::binary::BinaryOperation<operations::binary::BinaryOpType::LOGADDEXP, false>>(
-        "ttnn::logaddexp");
-constexpr auto logaddexp2 =
-    ttnn::register_operation<operations::binary::BinaryOperation<operations::binary::BinaryOpType::LOGADDEXP2, false>>(
-        "ttnn::logaddexp2");
-constexpr auto squared_difference =
-    ttnn::register_operation<operations::binary::BinaryOperation<operations::binary::BinaryOpType::SQUARED_DIFFERENCE, false>>(
-        "ttnn::squared_difference");
-constexpr auto divide =
-    ttnn::register_operation<operations::binary::BinaryOperation<operations::binary::BinaryOpType::DIV_FAST, false>>(
-        "ttnn::divide");
-constexpr auto bias_gelu =
-    ttnn::register_operation<operations::binary::BinaryOperation<operations::binary::BinaryOpType::BIAS_GELU, false>>(
-        "ttnn::bias_gelu");
+constexpr auto logaddexp = ttnn::register_operation<
+    "ttnn::logaddexp",
+    operations::binary::BinaryOperation<operations::binary::BinaryOpType::LOGADDEXP, false>>();
+constexpr auto logaddexp2 = ttnn::register_operation<
+    "ttnn::logaddexp2",
+    operations::binary::BinaryOperation<operations::binary::BinaryOpType::LOGADDEXP2, false>>();
+constexpr auto squared_difference = ttnn::register_operation<
+    "ttnn::squared_difference",
+    operations::binary::BinaryOperation<operations::binary::BinaryOpType::SQUARED_DIFFERENCE, false>>();
+constexpr auto divide = ttnn::register_operation<
+    "ttnn::divide",
+    operations::binary::BinaryOperation<operations::binary::BinaryOpType::DIV_FAST, false>>();
+constexpr auto bias_gelu = ttnn::register_operation<
+    "ttnn::bias_gelu",
+    operations::binary::BinaryOperation<operations::binary::BinaryOpType::BIAS_GELU, false>>();
 
 template <typename InputBType>
 ttnn::Tensor operator+(const ttnn::Tensor &input_tensor_a, InputBType scalar) {

--- a/ttnn/cpp/ttnn/operations/eltwise/binary/binary_composite.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary/binary_composite.hpp
@@ -60,16 +60,36 @@ struct ExecuteBinaryCompositeOpsIsClose
 }  // namespace binary
 }  // namespace operations
 
-// newly imported
-constexpr auto hypot = ttnn::register_operation<operations::binary::ExecuteBinaryCompositeOps<operations::binary::BinaryCompositeOpType::HYPOT>>("ttnn::hypot");
-constexpr auto xlogy = ttnn::register_operation<operations::binary::ExecuteBinaryCompositeOps<operations::binary::BinaryCompositeOpType::XLOGY>>("ttnn::xlogy");
-constexpr auto minimum = ttnn::register_operation<operations::binary::ExecuteBinaryCompositeOps<operations::binary::BinaryCompositeOpType::MINIMUM>>("ttnn::minimum");
-constexpr auto maximum = ttnn::register_operation<operations::binary::ExecuteBinaryCompositeOps<operations::binary::BinaryCompositeOpType::MAXIMUM>>("ttnn::maximum");
-constexpr auto atan2 = ttnn::register_operation<operations::binary::ExecuteBinaryCompositeOps<operations::binary::BinaryCompositeOpType::ATAN2>>("ttnn::atan2");
-constexpr auto logical_xor = ttnn::register_operation<operations::binary::ExecuteBinaryCompositeOps<operations::binary::BinaryCompositeOpType::LOGICAL_XOR>>("ttnn::logical_xor");
-constexpr auto nextafter = ttnn::register_operation<operations::binary::ExecuteBinaryCompositeOps<operations::binary::BinaryCompositeOpType::NEXTAFTER>>("ttnn::nextafter");
-constexpr auto addalpha = ttnn::register_operation<operations::binary::ExecuteBinaryCompositeOpsFloat<operations::binary::BinaryCompositeOpType::ADDALPHA>>("ttnn::addalpha");
-constexpr auto subalpha = ttnn::register_operation<operations::binary::ExecuteBinaryCompositeOpsFloat<operations::binary::BinaryCompositeOpType::SUBALPHA>>("ttnn::subalpha");
-constexpr auto isclose = ttnn::register_operation<operations::binary::ExecuteBinaryCompositeOpsIsClose<operations::binary::BinaryCompositeOpType::ISCLOSE>>("ttnn::isclose");
+    // newly imported
+    constexpr auto hypot = ttnn::register_operation<
+        "ttnn::hypot",
+        operations::binary::ExecuteBinaryCompositeOps<operations::binary::BinaryCompositeOpType::HYPOT>>();
+constexpr auto xlogy = ttnn::register_operation<
+    "ttnn::xlogy",
+    operations::binary::ExecuteBinaryCompositeOps<operations::binary::BinaryCompositeOpType::XLOGY>>();
+constexpr auto minimum = ttnn::register_operation<
+    "ttnn::minimum",
+    operations::binary::ExecuteBinaryCompositeOps<operations::binary::BinaryCompositeOpType::MINIMUM>>();
+constexpr auto maximum = ttnn::register_operation<
+    "ttnn::maximum",
+    operations::binary::ExecuteBinaryCompositeOps<operations::binary::BinaryCompositeOpType::MAXIMUM>>();
+constexpr auto atan2 = ttnn::register_operation<
+    "ttnn::atan2",
+    operations::binary::ExecuteBinaryCompositeOps<operations::binary::BinaryCompositeOpType::ATAN2>>();
+constexpr auto logical_xor = ttnn::register_operation<
+    "ttnn::logical_xor",
+    operations::binary::ExecuteBinaryCompositeOps<operations::binary::BinaryCompositeOpType::LOGICAL_XOR>>();
+constexpr auto nextafter = ttnn::register_operation<
+    "ttnn::nextafter",
+    operations::binary::ExecuteBinaryCompositeOps<operations::binary::BinaryCompositeOpType::NEXTAFTER>>();
+constexpr auto addalpha = ttnn::register_operation<
+    "ttnn::addalpha",
+    operations::binary::ExecuteBinaryCompositeOpsFloat<operations::binary::BinaryCompositeOpType::ADDALPHA>>();
+constexpr auto subalpha = ttnn::register_operation<
+    "ttnn::subalpha",
+    operations::binary::ExecuteBinaryCompositeOpsFloat<operations::binary::BinaryCompositeOpType::SUBALPHA>>();
+constexpr auto isclose = ttnn::register_operation<
+    "ttnn::isclose",
+    operations::binary::ExecuteBinaryCompositeOpsIsClose<operations::binary::BinaryCompositeOpType::ISCLOSE>>();
 
 }  // namespace ttnn

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_backward/binary_backward.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_backward/binary_backward.hpp
@@ -180,30 +180,30 @@ struct ExecuteBinaryBackward {
 }  // operations::binary
 
 //OpHandler_binary_bw : get_function_binary_bw
-constexpr auto atan2_bw = ttnn::register_operation<operations::binary_backward::ExecuteBinaryBackwardTensor<operations::binary_backward::BinaryBackwardOpType::ATAN2_BW>>("ttnn::atan2_bw");
-constexpr auto rsub_bw = ttnn::register_operation<operations::binary_backward::ExecuteBinaryBackwardTensor<operations::binary_backward::BinaryBackwardOpType::RSUB_BW>>("ttnn::rsub_bw");
-constexpr auto embedding_bw = ttnn::register_operation<operations::binary_backward::ExecuteBinaryBackwardTensor<operations::binary_backward::BinaryBackwardOpType::EMBEDDING_BW>>("ttnn::embedding_bw");
-constexpr auto xlogy_bw = ttnn::register_operation<operations::binary_backward::ExecuteBinaryBackwardTensor<operations::binary_backward::BinaryBackwardOpType::XLOGY_BW>>("ttnn::xlogy_bw");
-constexpr auto hypot_bw = ttnn::register_operation<operations::binary_backward::ExecuteBinaryBackwardTensor<operations::binary_backward::BinaryBackwardOpType::HYPOT_BW>>("ttnn::hypot_bw");
-constexpr auto ldexp_bw = ttnn::register_operation<operations::binary_backward::ExecuteBinaryBackwardTensor<operations::binary_backward::BinaryBackwardOpType::LDEXP_BW>>("ttnn::ldexp_bw");
-constexpr auto logaddexp_bw = ttnn::register_operation<operations::binary_backward::ExecuteBinaryBackwardTensor<operations::binary_backward::BinaryBackwardOpType::LOGADDEXP_BW>>("ttnn::logaddexp_bw");
+constexpr auto atan2_bw = ttnn::register_operation<"ttnn::atan2_bw", operations::binary_backward::ExecuteBinaryBackwardTensor<operations::binary_backward::BinaryBackwardOpType::ATAN2_BW>>();
+constexpr auto rsub_bw = ttnn::register_operation<"ttnn::rsub_bw", operations::binary_backward::ExecuteBinaryBackwardTensor<operations::binary_backward::BinaryBackwardOpType::RSUB_BW>>();
+constexpr auto embedding_bw = ttnn::register_operation<"ttnn::embedding_bw", operations::binary_backward::ExecuteBinaryBackwardTensor<operations::binary_backward::BinaryBackwardOpType::EMBEDDING_BW>>();
+constexpr auto xlogy_bw = ttnn::register_operation<"ttnn::xlogy_bw", operations::binary_backward::ExecuteBinaryBackwardTensor<operations::binary_backward::BinaryBackwardOpType::XLOGY_BW>>();
+constexpr auto hypot_bw = ttnn::register_operation<"ttnn::hypot_bw", operations::binary_backward::ExecuteBinaryBackwardTensor<operations::binary_backward::BinaryBackwardOpType::HYPOT_BW>>();
+constexpr auto ldexp_bw = ttnn::register_operation<"ttnn::ldexp_bw", operations::binary_backward::ExecuteBinaryBackwardTensor<operations::binary_backward::BinaryBackwardOpType::LDEXP_BW>>();
+constexpr auto logaddexp_bw = ttnn::register_operation<"ttnn::logaddexp_bw", operations::binary_backward::ExecuteBinaryBackwardTensor<operations::binary_backward::BinaryBackwardOpType::LOGADDEXP_BW>>();
 
 //OpHandler_binary_bw_opt_float_default : get_function_binary_bw_opt_float_default
-constexpr auto addalpha_bw = ttnn::register_operation<operations::binary_backward::ExecuteBinaryBackwardOptionalFloatDefault<operations::binary_backward::BinaryBackwardOpType::ADDALPHA_BW>>("ttnn::addalpha_bw");
+constexpr auto addalpha_bw = ttnn::register_operation<"ttnn::addalpha_bw", operations::binary_backward::ExecuteBinaryBackwardOptionalFloatDefault<operations::binary_backward::BinaryBackwardOpType::ADDALPHA_BW>>();
 
 //OpHandler_binary_bw_float_default : get_function_binary_bw_float_default
-constexpr auto subalpha_bw = ttnn::register_operation<operations::binary_backward::ExecuteBinaryBackwardFloatDefault<operations::binary_backward::BinaryBackwardOpType::SUBALPHA_BW>>("ttnn::subalpha_bw");
+constexpr auto subalpha_bw = ttnn::register_operation<"ttnn::subalpha_bw", operations::binary_backward::ExecuteBinaryBackwardFloatDefault<operations::binary_backward::BinaryBackwardOpType::SUBALPHA_BW>>();
 
 //OpHandler_binary_bw_int_default : get_function_binary_bw_int_default
-constexpr auto concat_bw = ttnn::register_operation<operations::binary_backward::ExecuteBinaryBackwardIntDefault<operations::binary_backward::BinaryBackwardOpType::CONCAT_BW>>("ttnn::concat_bw");
+constexpr auto concat_bw = ttnn::register_operation<"ttnn::concat_bw", operations::binary_backward::ExecuteBinaryBackwardIntDefault<operations::binary_backward::BinaryBackwardOpType::CONCAT_BW>>();
 
 //OpHandler_binary_bw_float : get_function_binary_bw_float
-constexpr auto lerp_bw = ttnn::register_operation<operations::binary_backward::ExecuteBinaryBackwardFloat<operations::binary_backward::BinaryBackwardOpType::LERP_BW>>("ttnn::lerp_bw");
+constexpr auto lerp_bw = ttnn::register_operation<"ttnn::lerp_bw", operations::binary_backward::ExecuteBinaryBackwardFloat<operations::binary_backward::BinaryBackwardOpType::LERP_BW>>();
 
 //type 1
-constexpr auto logaddexp2_bw = ttnn::register_operation<operations::binary_backward::ExecuteBinaryBackward<operations::binary_backward::BinaryBackwardOpType::LOGADDEXP2_BW>>("ttnn::logaddexp2_bw");
-constexpr auto squared_difference_bw = ttnn::register_operation<operations::binary_backward::ExecuteBinaryBackward<operations::binary_backward::BinaryBackwardOpType::SQUARED_DIFFERENCE_BW>>("ttnn::squared_difference_bw");
-constexpr auto min_bw = ttnn::register_operation<operations::binary_backward::ExecuteBinaryBackward<operations::binary_backward::BinaryBackwardOpType::MIN_BW>>("ttnn::min_bw");
-constexpr auto max_bw = ttnn::register_operation<operations::binary_backward::ExecuteBinaryBackward<operations::binary_backward::BinaryBackwardOpType::MAX_BW>>("ttnn::max_bw");
+constexpr auto logaddexp2_bw = ttnn::register_operation<"ttnn::logaddexp2_bw", operations::binary_backward::ExecuteBinaryBackward<operations::binary_backward::BinaryBackwardOpType::LOGADDEXP2_BW>>();
+constexpr auto squared_difference_bw = ttnn::register_operation<"ttnn::squared_difference_bw", operations::binary_backward::ExecuteBinaryBackward<operations::binary_backward::BinaryBackwardOpType::SQUARED_DIFFERENCE_BW>>();
+constexpr auto min_bw = ttnn::register_operation<"ttnn::min_bw", operations::binary_backward::ExecuteBinaryBackward<operations::binary_backward::BinaryBackwardOpType::MIN_BW>>();
+constexpr auto max_bw = ttnn::register_operation<"ttnn::max_bw", operations::binary_backward::ExecuteBinaryBackward<operations::binary_backward::BinaryBackwardOpType::MAX_BW>>();
 
 }  // namespace ttnn

--- a/ttnn/cpp/ttnn/operations/eltwise/complex_unary/complex_unary.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/complex_unary/complex_unary.hpp
@@ -37,14 +37,27 @@ struct ExecuteComplexUnaryType2 {
 }
 
 //OpHandler_complex_type1 = get_function_complex_unary --> Tensor return type
-constexpr auto real = ttnn::register_operation<operations::complex_unary::ExecuteComplexUnaryType1<operations::complex_unary::ComplexUnaryOpType::REAL>>("ttnn::real");
-constexpr auto imag = ttnn::register_operation<operations::complex_unary::ExecuteComplexUnaryType1<operations::complex_unary::ComplexUnaryOpType::IMAG>>("ttnn::imag");
-constexpr auto angle = ttnn::register_operation<operations::complex_unary::ExecuteComplexUnaryType1<operations::complex_unary::ComplexUnaryOpType::ANGLE>>("ttnn::angle");
-constexpr auto is_imag = ttnn::register_operation<operations::complex_unary::ExecuteComplexUnaryType1<operations::complex_unary::ComplexUnaryOpType::IS_IMAG>>("ttnn::is_imag");
-constexpr auto is_real = ttnn::register_operation<operations::complex_unary::ExecuteComplexUnaryType1<operations::complex_unary::ComplexUnaryOpType::IS_REAL>>("ttnn::is_real");
+constexpr auto real = ttnn::register_operation<
+    "ttnn::real",
+    operations::complex_unary::ExecuteComplexUnaryType1<operations::complex_unary::ComplexUnaryOpType::REAL>>();
+constexpr auto imag = ttnn::register_operation<
+    "ttnn::imag",
+    operations::complex_unary::ExecuteComplexUnaryType1<operations::complex_unary::ComplexUnaryOpType::IMAG>>();
+constexpr auto angle = ttnn::register_operation<
+    "ttnn::angle",
+    operations::complex_unary::ExecuteComplexUnaryType1<operations::complex_unary::ComplexUnaryOpType::ANGLE>>();
+constexpr auto is_imag = ttnn::register_operation<
+    "ttnn::is_imag",
+    operations::complex_unary::ExecuteComplexUnaryType1<operations::complex_unary::ComplexUnaryOpType::IS_IMAG>>();
+constexpr auto is_real = ttnn::register_operation<
+    "ttnn::is_real",
+    operations::complex_unary::ExecuteComplexUnaryType1<operations::complex_unary::ComplexUnaryOpType::IS_REAL>>();
 
 //OpHandler_complex_type2 = get_function_complex_unary_type2 --> ComplexTensor return type
-constexpr auto conj = ttnn::register_operation<operations::complex_unary::ExecuteComplexUnaryType2<operations::complex_unary::ComplexUnaryOpType::CONJ>>("ttnn::conj");
-constexpr auto polar = ttnn::register_operation<operations::complex_unary::ExecuteComplexUnaryType2<operations::complex_unary::ComplexUnaryOpType::POLAR>>("ttnn::polar");
-
+constexpr auto conj = ttnn::register_operation<
+    "ttnn::conj",
+    operations::complex_unary::ExecuteComplexUnaryType2<operations::complex_unary::ComplexUnaryOpType::CONJ>>();
+constexpr auto polar = ttnn::register_operation<
+    "ttnn::polar",
+    operations::complex_unary::ExecuteComplexUnaryType2<operations::complex_unary::ComplexUnaryOpType::POLAR>>();
 }

--- a/ttnn/cpp/ttnn/operations/eltwise/complex_unary_backward/complex_unary_backward.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/complex_unary_backward/complex_unary_backward.hpp
@@ -39,12 +39,12 @@ struct ExecuteComplexUnaryBackwardTensor {
 }
 
 //OpHandler_complex : get_function_complex
-constexpr auto polar_bw = ttnn::register_operation<operations::complex_unary_backward::ExecuteComplexUnaryBackward<operations::complex_unary_backward::ComplexUnaryBackwardOpType::POLAR_BW>>("ttnn::polar_bw");
-constexpr auto conj_bw = ttnn::register_operation<operations::complex_unary_backward::ExecuteComplexUnaryBackward<operations::complex_unary_backward::ComplexUnaryBackwardOpType::CONJ_BW>>("ttnn::conj_bw");
+constexpr auto polar_bw = ttnn::register_operation<"ttnn::polar_bw", operations::complex_unary_backward::ExecuteComplexUnaryBackward<operations::complex_unary_backward::ComplexUnaryBackwardOpType::POLAR_BW>>();
+constexpr auto conj_bw = ttnn::register_operation<"ttnn::conj_bw", operations::complex_unary_backward::ExecuteComplexUnaryBackward<operations::complex_unary_backward::ComplexUnaryBackwardOpType::CONJ_BW>>();
 
 //OpHandler_tensor_complex : get_function_tensor_complex
-constexpr auto imag_bw = ttnn::register_operation<operations::complex_unary_backward::ExecuteComplexUnaryBackwardTensor<operations::complex_unary_backward::ComplexUnaryBackwardOpType::IMAG_BW>>("ttnn::imag_bw");
-constexpr auto real_bw = ttnn::register_operation<operations::complex_unary_backward::ExecuteComplexUnaryBackwardTensor<operations::complex_unary_backward::ComplexUnaryBackwardOpType::REAL_BW>>("ttnn::real_bw");
-constexpr auto angle_bw = ttnn::register_operation<operations::complex_unary_backward::ExecuteComplexUnaryBackwardTensor<operations::complex_unary_backward::ComplexUnaryBackwardOpType::ANGLE_BW>>("ttnn::angle_bw");
+constexpr auto imag_bw = ttnn::register_operation<"ttnn::imag_bw", operations::complex_unary_backward::ExecuteComplexUnaryBackwardTensor<operations::complex_unary_backward::ComplexUnaryBackwardOpType::IMAG_BW>>();
+constexpr auto real_bw = ttnn::register_operation<"ttnn::real_bw", operations::complex_unary_backward::ExecuteComplexUnaryBackwardTensor<operations::complex_unary_backward::ComplexUnaryBackwardOpType::REAL_BW>>();
+constexpr auto angle_bw = ttnn::register_operation<"ttnn::angle_bw", operations::complex_unary_backward::ExecuteComplexUnaryBackwardTensor<operations::complex_unary_backward::ComplexUnaryBackwardOpType::ANGLE_BW>>();
 
 }

--- a/ttnn/cpp/ttnn/operations/eltwise/ternary/ternary_composite.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/ternary/ternary_composite.hpp
@@ -32,7 +32,11 @@ struct ExecuteTernaryCompositeOps
 }  // namespace ternary
 }  // namespace operations
 
-constexpr auto addcmul = ttnn::register_operation<operations::ternary::ExecuteTernaryCompositeOps<operations::ternary::TernaryCompositeOpType::ADDCMUL>>("ttnn::addcmul");
-constexpr auto addcdiv = ttnn::register_operation<operations::ternary::ExecuteTernaryCompositeOps<operations::ternary::TernaryCompositeOpType::ADDCDIV>>("ttnn::addcdiv");
+constexpr auto addcmul = ttnn::register_operation<
+    "ttnn::addcmul",
+    operations::ternary::ExecuteTernaryCompositeOps<operations::ternary::TernaryCompositeOpType::ADDCMUL>>();
+constexpr auto addcdiv = ttnn::register_operation<
+    "ttnn::addcdiv",
+    operations::ternary::ExecuteTernaryCompositeOps<operations::ternary::TernaryCompositeOpType::ADDCDIV>>();
 
 }  // namespace ttnn

--- a/ttnn/cpp/ttnn/operations/eltwise/ternary/where_op.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/ternary/where_op.hpp
@@ -112,7 +112,6 @@ struct ExecuteTernaryWhere
 }  // namespace ternary
 }  // namespace operations
 
-constexpr auto where = ttnn::register_operation<operations::ternary::ExecuteTernaryWhere>("ttnn::where");
-
+constexpr auto where = ttnn::register_operation<"ttnn::where", operations::ternary::ExecuteTernaryWhere>();
 
 }  // namespace ttnn

--- a/ttnn/cpp/ttnn/operations/eltwise/ternary_backward/ternary_backward.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/ternary_backward/ternary_backward.hpp
@@ -111,8 +111,17 @@ struct ExecuteTernaryBackwardOptional {
 }  // operations::ternary_backward
 
 //type 1
-constexpr auto addcmul_bw = ttnn::register_operation<operations::ternary_backward::ExecuteTernaryBackwardFloat<operations::ternary_backward::TernaryBackwardOpType::ADDCMUL_BW>>("ttnn::addcmul_bw");
-constexpr auto addcdiv_bw = ttnn::register_operation<operations::ternary_backward::ExecuteTernaryBackwardFloat<operations::ternary_backward::TernaryBackwardOpType::ADDCDIV_BW>>("ttnn::addcdiv_bw");
-constexpr auto where_bw = ttnn::register_operation<operations::ternary_backward::ExecuteTernaryBackwardOptional<operations::ternary_backward::TernaryBackwardOpType::WHERE_BW>>("ttnn::where_bw");
+constexpr auto addcmul_bw = ttnn::register_operation<
+    "ttnn::addcmul_bw",
+    operations::ternary_backward::ExecuteTernaryBackwardFloat<
+        operations::ternary_backward::TernaryBackwardOpType::ADDCMUL_BW>>();
+constexpr auto addcdiv_bw = ttnn::register_operation<
+    "ttnn::addcdiv_bw",
+    operations::ternary_backward::ExecuteTernaryBackwardFloat<
+        operations::ternary_backward::TernaryBackwardOpType::ADDCDIV_BW>>();
+constexpr auto where_bw = ttnn::register_operation<
+    "ttnn::where_bw",
+    operations::ternary_backward::ExecuteTernaryBackwardOptional<
+        operations::ternary_backward::TernaryBackwardOpType::WHERE_BW>>();
 
 }  // namespace ttnn

--- a/ttnn/cpp/ttnn/operations/eltwise/unary/unary.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary/unary.hpp
@@ -328,23 +328,28 @@ struct AsymmetricBinop {
 }  // namespace unary
 }  // namespace operations
 
-#define REGISTER_UNARY_OPERATION(operation_name, operation_type)                                      \
-    constexpr auto operation_name = ttnn::register_operation<                                         \
-        ttnn::operations::unary::ExecuteUnary<ttnn::operations::unary::UnaryOpType::operation_type>>( \
-        "ttnn::" #operation_name);
+#define REGISTER_UNARY_OPERATION(operation_name, operation_type) \
+    constexpr auto operation_name = ttnn::register_operation<    \
+        "ttnn::" #operation_name,                                \
+        ttnn::operations::unary::ExecuteUnary<ttnn::operations::unary::UnaryOpType::operation_type>>();
 
-#define REGISTER_UNARY_OPERATION_WITH_FAST_AND_APPROXIMATE_MODE(operation_name, operation_type)   \
-    constexpr auto operation_name =                                                               \
-        ttnn::register_operation<ttnn::operations::unary::ExecuteUnaryWithFastAndApproximateMode< \
-            ttnn::operations::unary::UnaryOpType::operation_type>>("ttnn::" #operation_name);
+#define REGISTER_UNARY_OPERATION_WITH_FAST_AND_APPROXIMATE_MODE(operation_name, operation_type) \
+    constexpr auto operation_name = ttnn::register_operation<                                   \
+        "ttnn::" #operation_name,                                                               \
+        ttnn::operations::unary::ExecuteUnaryWithFastAndApproximateMode<                        \
+            ttnn::operations::unary::UnaryOpType::operation_type>>();
 
-#define REGISTER_UNARY_OPERATION_WITH_FLOAT_PARAMETER(operation_name, operation_type)                                 \
-    constexpr auto operation_name = ttnn::register_operation<ttnn::operations::unary::ExecuteUnaryWithFloatParameter< \
-        ttnn::operations::unary::UnaryOpType::operation_type>>("ttnn::" #operation_name);
+#define REGISTER_UNARY_OPERATION_WITH_FLOAT_PARAMETER(operation_name, operation_type) \
+    constexpr auto operation_name = ttnn::register_operation<                         \
+        "ttnn::" #operation_name,                                                     \
+        ttnn::operations::unary::ExecuteUnaryWithFloatParameter<                      \
+            ttnn::operations::unary::UnaryOpType::operation_type>>();
 
-#define REGISTER_UNARY_OPERATION_WITH_INTEGER_PARAMETER(operation_name, operation_type, data_type)                                 \
-    constexpr auto operation_name = ttnn::register_operation<ttnn::operations::unary::ExecuteUnaryWithIntegerParameter< \
-        ttnn::operations::unary::UnaryOpType::operation_type, data_type>>("ttnn::" #operation_name);
+#define REGISTER_UNARY_OPERATION_WITH_INTEGER_PARAMETER(operation_name, operation_type, data_type) \
+    constexpr auto operation_name = ttnn::register_operation<                                      \
+        "ttnn::" #operation_name,                                                                  \
+        ttnn::operations::unary::                                                                  \
+            ExecuteUnaryWithIntegerParameter<ttnn::operations::unary::UnaryOpType::operation_type, data_type>>();
 
 REGISTER_UNARY_OPERATION(abs, ABS);
 REGISTER_UNARY_OPERATION(acos, ACOS);
@@ -386,9 +391,9 @@ REGISTER_UNARY_OPERATION(square, SQUARE);
 REGISTER_UNARY_OPERATION(tan, TAN);
 REGISTER_UNARY_OPERATION(tanh, TANH);
 
-constexpr auto log_sigmoid = ttnn::register_operation<ttnn::operations::unary::ExecuteUnary<
+constexpr auto log_sigmoid = ttnn::register_operation<"ttnn::log_sigmoid", ttnn::operations::unary::ExecuteUnary<
     ttnn::operations::unary::UnaryOpType::SIGMOID,
-    ttnn::operations::unary::UnaryOpType::LOG>>("ttnn::log_sigmoid");
+    ttnn::operations::unary::UnaryOpType::LOG>>();
 
 // Unaries with fast_and_approximate_mode
 REGISTER_UNARY_OPERATION_WITH_FAST_AND_APPROXIMATE_MODE(exp, EXP);
@@ -423,15 +428,28 @@ REGISTER_UNARY_OPERATION_WITH_INTEGER_PARAMETER(bitwise_not, BITWISE_NOT, int32_
 REGISTER_UNARY_OPERATION(tiled_prod, TILED_PROD);
 
 // Other unaries
-constexpr auto identity = ttnn::register_operation<ttnn::operations::unary::Identity>("ttnn::identity");
-constexpr auto softplus = ttnn::register_operation<ttnn::operations::unary::Softplus>("ttnn::softplus");
-constexpr auto sigmoid_accurate = ttnn::register_operation<ttnn::operations::unary::Sigmoid_accurate>("ttnn::sigmoid_accurate");
-constexpr auto unary_chain = ttnn::register_operation<ttnn::operations::unary::Unary_chain>("ttnn::unary_chain");
+constexpr auto identity = ttnn::register_operation<"ttnn::identity", ttnn::operations::unary::Identity>();
+constexpr auto softplus = ttnn::register_operation<"ttnn::softplus", ttnn::operations::unary::Softplus>();
+constexpr auto sigmoid_accurate =
+    ttnn::register_operation<"ttnn::sigmoid_accurate", ttnn::operations::unary::Sigmoid_accurate>();
+constexpr auto unary_chain = ttnn::register_operation<"ttnn::unary_chain", ttnn::operations::unary::Unary_chain>();
 
-constexpr auto add_sfpu = ttnn::register_operation<ttnn::operations::unary::SymmetricBinop<ttnn::operations::unary::UnaryOpType::ADD_UNARY_SFPU>>("ttnn::add_sfpu");
-constexpr auto mul_sfpu = ttnn::register_operation<ttnn::operations::unary::SymmetricBinop<ttnn::operations::unary::UnaryOpType::MUL_UNARY_SFPU>>("ttnn::mul_sfpu");
+constexpr auto add_sfpu = ttnn::register_operation<
+    "ttnn::add_sfpu",
+    ttnn::operations::unary::SymmetricBinop<ttnn::operations::unary::UnaryOpType::ADD_UNARY_SFPU>>();
+constexpr auto mul_sfpu = ttnn::register_operation<
+    "ttnn::mul_sfpu",
+    ttnn::operations::unary::SymmetricBinop<ttnn::operations::unary::UnaryOpType::MUL_UNARY_SFPU>>();
 
-constexpr auto sub_sfpu = ttnn::register_operation<ttnn::operations::unary::AsymmetricBinop<ttnn::operations::unary::UnaryOpType::SUB_UNARY_SFPU, ttnn::operations::unary::UnaryOpType::RSUB>>("ttnn::sub_sfpu");
-constexpr auto div_sfpu = ttnn::register_operation<ttnn::operations::unary::AsymmetricBinop<ttnn::operations::unary::UnaryOpType::DIV_UNARY_SFPU, ttnn::operations::unary::UnaryOpType::RDIV>>("ttnn::div_sfpu");
+constexpr auto sub_sfpu = ttnn::register_operation<
+    "ttnn::sub_sfpu",
+    ttnn::operations::unary::AsymmetricBinop<
+        ttnn::operations::unary::UnaryOpType::SUB_UNARY_SFPU,
+        ttnn::operations::unary::UnaryOpType::RSUB>>();
+constexpr auto div_sfpu = ttnn::register_operation<
+    "ttnn::div_sfpu",
+    ttnn::operations::unary::AsymmetricBinop<
+        ttnn::operations::unary::UnaryOpType::DIV_UNARY_SFPU,
+        ttnn::operations::unary::UnaryOpType::RDIV>>();
 
 }  // namespace ttnn

--- a/ttnn/cpp/ttnn/operations/eltwise/unary/unary_composite.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary/unary_composite.hpp
@@ -213,7 +213,7 @@ Tensor triu(
 
 // auto prelu = ttnn::leaky_relu;  // Alias for leaky_relu. TODO(#8544): implement PReLU properly
 
-constexpr auto pow = ttnn::register_operation<ttnn::operations::unary::Power>("ttnn::pow");
+constexpr auto pow = ttnn::register_operation<"ttnn::pow", ttnn::operations::unary::Power>();
 
 // Other unaries
 
@@ -262,39 +262,101 @@ constexpr auto tril = REGISTER_OPERATION_FROM_FUNCTION("ttnn::tril", WRAP_WITH_R
 constexpr auto triu = REGISTER_OPERATION_FROM_FUNCTION("ttnn::triu", WRAP_WITH_RESHAPE(ttnn::operations::unary::triu));
 
 // newly imported
-constexpr auto tanhshrink = ttnn::register_operation<operations::unary::ExecuteUnaryCompositeOp<operations::unary::UnaryCompositeOpType::TANHSHRINK>>("ttnn::tanhshrink");
-constexpr auto deg2rad= ttnn::register_operation<operations::unary::ExecuteUnaryCompositeOp<operations::unary::UnaryCompositeOpType::DEG2RAD>>("ttnn::deg2rad");
-constexpr auto rad2deg= ttnn::register_operation<operations::unary::ExecuteUnaryCompositeOp<operations::unary::UnaryCompositeOpType::RAD2DEG>>("ttnn::rad2deg");
-constexpr auto acosh = ttnn::register_operation<operations::unary::ExecuteUnaryCompositeOp<operations::unary::UnaryCompositeOpType::ACOSH>>("ttnn::acosh");
-constexpr auto asinh = ttnn::register_operation<operations::unary::ExecuteUnaryCompositeOp<operations::unary::UnaryCompositeOpType::ASINH>>("ttnn::asinh");
-constexpr auto atanh = ttnn::register_operation<operations::unary::ExecuteUnaryCompositeOp<operations::unary::UnaryCompositeOpType::ATANH>>("ttnn::atanh");
-constexpr auto cbrt = ttnn::register_operation<operations::unary::ExecuteUnaryCompositeOp<operations::unary::UnaryCompositeOpType::CBRT>>("ttnn::cbrt");
-constexpr auto cosh = ttnn::register_operation<operations::unary::ExecuteUnaryCompositeOp<operations::unary::UnaryCompositeOpType::COSH>>("ttnn::cosh");
-constexpr auto digamma = ttnn::register_operation<operations::unary::ExecuteUnaryCompositeOp<operations::unary::UnaryCompositeOpType::DIGAMMA>>("ttnn::digamma");
-constexpr auto lgamma = ttnn::register_operation<operations::unary::ExecuteUnaryCompositeOp<operations::unary::UnaryCompositeOpType::LGAMMA>>("ttnn::lgamma");
-constexpr auto log1p = ttnn::register_operation<operations::unary::ExecuteUnaryCompositeOp<operations::unary::UnaryCompositeOpType::LOG1P>>("ttnn::log1p");
-constexpr auto mish = ttnn::register_operation<operations::unary::ExecuteUnaryCompositeOp<operations::unary::UnaryCompositeOpType::MISH>>("ttnn::mish");
-constexpr auto multigammaln = ttnn::register_operation<operations::unary::ExecuteUnaryCompositeOp<operations::unary::UnaryCompositeOpType::MULTIGAMMALN>>("ttnn::multigammaln");
-constexpr auto sinh = ttnn::register_operation<operations::unary::ExecuteUnaryCompositeOp<operations::unary::UnaryCompositeOpType::SINH>>("ttnn::sinh");
-constexpr auto softsign= ttnn::register_operation<operations::unary::ExecuteUnaryCompositeOp<operations::unary::UnaryCompositeOpType::SOFTSIGN>>("ttnn::softsign");
-constexpr auto swish = ttnn::register_operation<operations::unary::ExecuteUnaryCompositeOp<operations::unary::UnaryCompositeOpType::SWISH>>("ttnn::swish");
-constexpr auto trunc = ttnn::register_operation<operations::unary::ExecuteUnaryCompositeOp<operations::unary::UnaryCompositeOpType::TRUNC>>("ttnn::trunc");
-constexpr auto var_hw = ttnn::register_operation<operations::unary::ExecuteUnaryCompositeOp<operations::unary::UnaryCompositeOpType::VAR_HW>>("ttnn::var_hw");
-constexpr auto std_hw = ttnn::register_operation<operations::unary::ExecuteUnaryCompositeOp<operations::unary::UnaryCompositeOpType::STD_HW>>("ttnn::std_hw");
-constexpr auto normalize_hw = ttnn::register_operation<operations::unary::ExecuteUnaryCompositeOp<operations::unary::UnaryCompositeOpType::NORMALIZE_HW>>("ttnn::normalize_hw");
+constexpr auto tanhshrink = ttnn::register_operation<
+    "ttnn::tanhshrink",
+    operations::unary::ExecuteUnaryCompositeOp<operations::unary::UnaryCompositeOpType::TANHSHRINK>>();
+constexpr auto deg2rad = ttnn::register_operation<
+    "ttnn::deg2rad",
+    operations::unary::ExecuteUnaryCompositeOp<operations::unary::UnaryCompositeOpType::DEG2RAD>>();
+constexpr auto rad2deg = ttnn::register_operation<
+    "ttnn::rad2deg",
+    operations::unary::ExecuteUnaryCompositeOp<operations::unary::UnaryCompositeOpType::RAD2DEG>>();
+constexpr auto acosh = ttnn::register_operation<
+    "ttnn::acosh",
+    operations::unary::ExecuteUnaryCompositeOp<operations::unary::UnaryCompositeOpType::ACOSH>>();
+constexpr auto asinh = ttnn::register_operation<
+    "ttnn::asinh",
+    operations::unary::ExecuteUnaryCompositeOp<operations::unary::UnaryCompositeOpType::ASINH>>();
+constexpr auto atanh = ttnn::register_operation<
+    "ttnn::atanh",
+    operations::unary::ExecuteUnaryCompositeOp<operations::unary::UnaryCompositeOpType::ATANH>>();
+constexpr auto cbrt = ttnn::register_operation<
+    "ttnn::cbrt",
+    operations::unary::ExecuteUnaryCompositeOp<operations::unary::UnaryCompositeOpType::CBRT>>();
+constexpr auto cosh = ttnn::register_operation<
+    "ttnn::cosh",
+    operations::unary::ExecuteUnaryCompositeOp<operations::unary::UnaryCompositeOpType::COSH>>();
+constexpr auto digamma = ttnn::register_operation<
+    "ttnn::digamma",
+    operations::unary::ExecuteUnaryCompositeOp<operations::unary::UnaryCompositeOpType::DIGAMMA>>();
+constexpr auto lgamma = ttnn::register_operation<
+    "ttnn::lgamma",
+    operations::unary::ExecuteUnaryCompositeOp<operations::unary::UnaryCompositeOpType::LGAMMA>>();
+constexpr auto log1p = ttnn::register_operation<
+    "ttnn::log1p",
+    operations::unary::ExecuteUnaryCompositeOp<operations::unary::UnaryCompositeOpType::LOG1P>>();
+constexpr auto mish = ttnn::register_operation<
+    "ttnn::mish",
+    operations::unary::ExecuteUnaryCompositeOp<operations::unary::UnaryCompositeOpType::MISH>>();
+constexpr auto multigammaln = ttnn::register_operation<
+    "ttnn::multigammaln",
+    operations::unary::ExecuteUnaryCompositeOp<operations::unary::UnaryCompositeOpType::MULTIGAMMALN>>();
+constexpr auto sinh = ttnn::register_operation<
+    "ttnn::sinh",
+    operations::unary::ExecuteUnaryCompositeOp<operations::unary::UnaryCompositeOpType::SINH>>();
+constexpr auto softsign = ttnn::register_operation<
+    "ttnn::softsign",
+    operations::unary::ExecuteUnaryCompositeOp<operations::unary::UnaryCompositeOpType::SOFTSIGN>>();
+constexpr auto swish = ttnn::register_operation<
+    "ttnn::swish",
+    operations::unary::ExecuteUnaryCompositeOp<operations::unary::UnaryCompositeOpType::SWISH>>();
+constexpr auto trunc = ttnn::register_operation<
+    "ttnn::trunc",
+    operations::unary::ExecuteUnaryCompositeOp<operations::unary::UnaryCompositeOpType::TRUNC>>();
+constexpr auto var_hw = ttnn::register_operation<
+    "ttnn::var_hw",
+    operations::unary::ExecuteUnaryCompositeOp<operations::unary::UnaryCompositeOpType::VAR_HW>>();
+constexpr auto std_hw = ttnn::register_operation<
+    "ttnn::std_hw",
+    operations::unary::ExecuteUnaryCompositeOp<operations::unary::UnaryCompositeOpType::STD_HW>>();
+constexpr auto normalize_hw = ttnn::register_operation<
+    "ttnn::normalize_hw",
+    operations::unary::ExecuteUnaryCompositeOp<operations::unary::UnaryCompositeOpType::NORMALIZE_HW>>();
 
-constexpr auto hardswish= ttnn::register_operation<operations::unary::ExecuteUnaryCompositeOpWithScaleShift<operations::unary::UnaryCompositeOpType::HARDSWISH>>("ttnn::hardswish");
-constexpr auto hardsigmoid = ttnn::register_operation<operations::unary::ExecuteUnaryCompositeOpWithScaleShift<operations::unary::UnaryCompositeOpType::HARDSIGMOID>>("ttnn::hardsigmoid");
+constexpr auto hardswish = ttnn::register_operation<
+    "ttnn::hardswish",
+    operations::unary::ExecuteUnaryCompositeOpWithScaleShift<operations::unary::UnaryCompositeOpType::HARDSWISH>>();
+constexpr auto hardsigmoid = ttnn::register_operation<
+    "ttnn::hardsigmoid",
+    operations::unary::ExecuteUnaryCompositeOpWithScaleShift<operations::unary::UnaryCompositeOpType::HARDSIGMOID>>();
 
-constexpr auto hardtanh = ttnn::register_operation<operations::unary::ExecuteUnaryCompositeOpWithLowHigh<operations::unary::UnaryCompositeOpType::HARDTANH>>("ttnn::hardtanh");
-constexpr auto clip = ttnn::register_operation<operations::unary::ExecuteUnaryCompositeOpWithLowHigh<operations::unary::UnaryCompositeOpType::CLIP>>("ttnn::clip");
-constexpr auto clamp = ttnn::register_operation<operations::unary::ExecuteUnaryCompositeOpWithLowHigh<operations::unary::UnaryCompositeOpType::CLAMP>>("ttnn::clamp");
-constexpr auto selu = ttnn::register_operation<operations::unary::ExecuteUnaryCompositeOpWithScaleAlpha<operations::unary::UnaryCompositeOpType::SELU>>("ttnn::selu");
-constexpr auto threshold = ttnn::register_operation<operations::unary::ExecuteUnaryCompositeOpWithThresholdValue<operations::unary::UnaryCompositeOpType::THRESHOLD>>("ttnn::threshold");
+constexpr auto hardtanh = ttnn::register_operation<
+    "ttnn::hardtanh",
+    operations::unary::ExecuteUnaryCompositeOpWithLowHigh<operations::unary::UnaryCompositeOpType::HARDTANH>>();
+constexpr auto clip = ttnn::register_operation<
+    "ttnn::clip",
+    operations::unary::ExecuteUnaryCompositeOpWithLowHigh<operations::unary::UnaryCompositeOpType::CLIP>>();
+constexpr auto clamp = ttnn::register_operation<
+    "ttnn::clamp",
+    operations::unary::ExecuteUnaryCompositeOpWithLowHigh<operations::unary::UnaryCompositeOpType::CLAMP>>();
+constexpr auto selu = ttnn::register_operation<
+    "ttnn::selu",
+    operations::unary::ExecuteUnaryCompositeOpWithScaleAlpha<operations::unary::UnaryCompositeOpType::SELU>>();
+constexpr auto threshold = ttnn::register_operation<
+    "ttnn::threshold",
+    operations::unary::ExecuteUnaryCompositeOpWithThresholdValue<operations::unary::UnaryCompositeOpType::THRESHOLD>>();
 
-constexpr auto glu = ttnn::register_operation<operations::unary::ExecuteUnaryCompositeOpWithDim<operations::unary::UnaryCompositeOpType::GLU>>("ttnn::glu");
-constexpr auto reglu = ttnn::register_operation<operations::unary::ExecuteUnaryCompositeOpWithDim<operations::unary::UnaryCompositeOpType::REGLU>>("ttnn::reglu");
-constexpr auto geglu = ttnn::register_operation<operations::unary::ExecuteUnaryCompositeOpWithDim<operations::unary::UnaryCompositeOpType::GEGLU>>("ttnn::geglu");
-constexpr auto swiglu = ttnn::register_operation<operations::unary::ExecuteUnaryCompositeOpWithDim<operations::unary::UnaryCompositeOpType::SWIGLU>>("ttnn::swiglu");
+constexpr auto glu = ttnn::register_operation<
+    "ttnn::glu",
+    operations::unary::ExecuteUnaryCompositeOpWithDim<operations::unary::UnaryCompositeOpType::GLU>>();
+constexpr auto reglu = ttnn::register_operation<
+    "ttnn::reglu",
+    operations::unary::ExecuteUnaryCompositeOpWithDim<operations::unary::UnaryCompositeOpType::REGLU>>();
+constexpr auto geglu = ttnn::register_operation<
+    "ttnn::geglu",
+    operations::unary::ExecuteUnaryCompositeOpWithDim<operations::unary::UnaryCompositeOpType::GEGLU>>();
+constexpr auto swiglu = ttnn::register_operation<
+    "ttnn::swiglu",
+    operations::unary::ExecuteUnaryCompositeOpWithDim<operations::unary::UnaryCompositeOpType::SWIGLU>>();
 
 }  // namespace ttnn

--- a/ttnn/cpp/ttnn/operations/eltwise/unary_backward/unary_backward.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary_backward/unary_backward.hpp
@@ -276,107 +276,293 @@ struct ExecuteUnaryBackward {
 }  // operations::unary
 
 //ExecuteUnaryBackwardTwoFloat : get_function_type1_w_two_float
-constexpr auto threshold_bw = ttnn::register_operation<operations::unary_backward::ExecuteUnaryBackwardTwoFloat<operations::unary_backward::UnaryBackwardOpType::THRESHOLD_BW>>("ttnn::threshold_bw");
+constexpr auto threshold_bw = ttnn::register_operation<
+    "ttnn::threshold_bw",
+    operations::unary_backward::ExecuteUnaryBackwardTwoFloat<
+        operations::unary_backward::UnaryBackwardOpType::THRESHOLD_BW>>();
 
 //OpHandler_optional_float_params_with_default : get_function_optional_float_params_with_default
-constexpr auto clamp_bw = ttnn::register_operation<operations::unary_backward::ExecuteUnaryBackwardOptionalFloatParamsWithDefault<operations::unary_backward::UnaryBackwardOpType::CLAMP_BW>>("ttnn::clamp_bw");
+constexpr auto clamp_bw = ttnn::register_operation<
+    "ttnn::clamp_bw",
+    operations::unary_backward::ExecuteUnaryBackwardOptionalFloatParamsWithDefault<
+        operations::unary_backward::UnaryBackwardOpType::CLAMP_BW>>();
 
 //ExecuteUnaryBackwardTwoFloatWithDefault : get_function_type1_w_two_float_with_default
-constexpr auto softplus_bw = ttnn::register_operation<operations::unary_backward::ExecuteUnaryBackwardTwoFloatWithDefault<operations::unary_backward::UnaryBackwardOpType::SOFTPLUS_BW>>("ttnn::softplus_bw");
-constexpr auto hardtanh_bw = ttnn::register_operation<operations::unary_backward::ExecuteUnaryBackwardTwoFloatWithDefault<operations::unary_backward::UnaryBackwardOpType::HARDTANH_BW>>("ttnn::hardtanh_bw");
+constexpr auto softplus_bw = ttnn::register_operation<
+    "ttnn::softplus_bw",
+    operations::unary_backward::ExecuteUnaryBackwardTwoFloatWithDefault<
+        operations::unary_backward::UnaryBackwardOpType::SOFTPLUS_BW>>();
+constexpr auto hardtanh_bw = ttnn::register_operation<
+    "ttnn::hardtanh_bw",
+    operations::unary_backward::ExecuteUnaryBackwardTwoFloatWithDefault<
+        operations::unary_backward::UnaryBackwardOpType::HARDTANH_BW>>();
 
 //ExecuteUnaryBackwardFloatStringDefault : get_function_type1_float_string_default
-constexpr auto div_bw = ttnn::register_operation<operations::unary_backward::ExecuteUnaryBackwardFloatStringDefault<operations::unary_backward::UnaryBackwardOpType::DIV_BW>>("ttnn::div_bw");
-constexpr auto rdiv_bw = ttnn::register_operation<operations::unary_backward::ExecuteUnaryBackwardFloatStringDefault<operations::unary_backward::UnaryBackwardOpType::RDIV_BW>>("ttnn::rdiv_bw");
-constexpr auto bias_gelu_bw = ttnn::register_operation<operations::unary_backward::ExecuteUnaryBackwardFloatStringDefault<operations::unary_backward::UnaryBackwardOpType::BIAS_GELU_BW>>("ttnn::bias_gelu_bw");
+constexpr auto div_bw = ttnn::register_operation<
+    "ttnn::div_bw",
+    operations::unary_backward::ExecuteUnaryBackwardFloatStringDefault<
+        operations::unary_backward::UnaryBackwardOpType::DIV_BW>>();
+constexpr auto rdiv_bw = ttnn::register_operation<
+    "ttnn::rdiv_bw",
+    operations::unary_backward::ExecuteUnaryBackwardFloatStringDefault<
+        operations::unary_backward::UnaryBackwardOpType::RDIV_BW>>();
+constexpr auto bias_gelu_bw = ttnn::register_operation<
+    "ttnn::bias_gelu_bw",
+    operations::unary_backward::ExecuteUnaryBackwardFloatStringDefault<
+        operations::unary_backward::UnaryBackwardOpType::BIAS_GELU_BW>>();
 
 //ExecuteUnaryBackwardStringDefault : get_function_type1_string_default
-constexpr auto gelu_bw = ttnn::register_operation<operations::unary_backward::ExecuteUnaryBackwardStringDefault<operations::unary_backward::UnaryBackwardOpType::GELU_BW>>("ttnn::gelu_bw");
+constexpr auto gelu_bw = ttnn::register_operation<
+    "ttnn::gelu_bw",
+    operations::unary_backward::ExecuteUnaryBackwardStringDefault<
+        operations::unary_backward::UnaryBackwardOpType::GELU_BW>>();
 
 //ExecuteUnaryBackwardShape : get_function_type1_shape
-constexpr auto repeat_bw = ttnn::register_operation<operations::unary_backward::ExecuteUnaryBackwardShape<operations::unary_backward::UnaryBackwardOpType::REPEAT_BW>>("ttnn::repeat_bw");
+constexpr auto repeat_bw = ttnn::register_operation<
+    "ttnn::repeat_bw",
+    operations::unary_backward::ExecuteUnaryBackwardShape<
+        operations::unary_backward::UnaryBackwardOpType::REPEAT_BW>>();
 
 //OpHandler_unary_optional_float : get_function_unary_optional_float
-constexpr auto pow_bw = ttnn::register_operation<operations::unary_backward::ExecuteUnaryBackwardOptionalFloat<operations::unary_backward::UnaryBackwardOpType::POW_BW>>("ttnn::pow_bw");
+constexpr auto pow_bw = ttnn::register_operation<
+    "ttnn::pow_bw",
+    operations::unary_backward::ExecuteUnaryBackwardOptionalFloat<
+        operations::unary_backward::UnaryBackwardOpType::POW_BW>>();
 
 //OpHandler_unary_optional : get_function_unary_optional
-constexpr auto exp_bw = ttnn::register_operation<operations::unary_backward::ExecuteUnaryBackwardOptional<operations::unary_backward::UnaryBackwardOpType::EXP_BW>>("ttnn::exp_bw");
-constexpr auto tanh_bw = ttnn::register_operation<operations::unary_backward::ExecuteUnaryBackwardOptional<operations::unary_backward::UnaryBackwardOpType::TANH_BW>>("ttnn::tanh_bw");
-constexpr auto sqrt_bw = ttnn::register_operation<operations::unary_backward::ExecuteUnaryBackwardOptional<operations::unary_backward::UnaryBackwardOpType::SQRT_BW>>("ttnn::sqrt_bw");
+constexpr auto exp_bw = ttnn::register_operation<
+    "ttnn::exp_bw",
+    operations::unary_backward::ExecuteUnaryBackwardOptional<
+        operations::unary_backward::UnaryBackwardOpType::EXP_BW>>();
+constexpr auto tanh_bw = ttnn::register_operation<
+    "ttnn::tanh_bw",
+    operations::unary_backward::ExecuteUnaryBackwardOptional<
+        operations::unary_backward::UnaryBackwardOpType::TANH_BW>>();
+constexpr auto sqrt_bw = ttnn::register_operation<
+    "ttnn::sqrt_bw",
+    operations::unary_backward::ExecuteUnaryBackwardOptional<
+        operations::unary_backward::UnaryBackwardOpType::SQRT_BW>>();
 
 //OpHandler_prod_bw : get_function_prod_bw
-constexpr auto prod_bw = ttnn::register_operation<operations::unary_backward::ExecuteUnaryBackwardProdBW<operations::unary_backward::UnaryBackwardOpType::PROD_BW>>("ttnn::prod_bw");
+constexpr auto prod_bw = ttnn::register_operation<
+    "ttnn::prod_bw",
+    operations::unary_backward::ExecuteUnaryBackwardProdBW<operations::unary_backward::UnaryBackwardOpType::PROD_BW>>();
 
-constexpr auto mul_bw = ttnn::register_operation<operations::unary_backward::ExecuteUnaryBackward<operations::unary_backward::UnaryBackwardOpType::MUL_BW>>("ttnn::mul_bw");
-constexpr auto assign_bw = ttnn::register_operation<operations::unary_backward::ExecuteUnaryBackward<operations::unary_backward::UnaryBackwardOpType::ASSIGN_BW>>("ttnn::assign_bw");
-constexpr auto multigammaln_bw = ttnn::register_operation<operations::unary_backward::ExecuteUnaryBackward<operations::unary_backward::UnaryBackwardOpType::MULTIGAMMALN_BW>>("ttnn::multigammaln_bw");
-constexpr auto add_bw = ttnn::register_operation<operations::unary_backward::ExecuteUnaryBackward<operations::unary_backward::UnaryBackwardOpType::ADD_BW>>("ttnn::add_bw");
-constexpr auto eq_bw = ttnn::register_operation<operations::unary_backward::ExecuteUnaryBackward<operations::unary_backward::UnaryBackwardOpType::EQ_BW>>("ttnn::eq_bw");
-constexpr auto gt_bw = ttnn::register_operation<operations::unary_backward::ExecuteUnaryBackward<operations::unary_backward::UnaryBackwardOpType::GT_BW>>("ttnn::gt_bw");
-constexpr auto lt_bw = ttnn::register_operation<operations::unary_backward::ExecuteUnaryBackward<operations::unary_backward::UnaryBackwardOpType::LT_BW>>("ttnn::lt_bw");
-constexpr auto le_bw = ttnn::register_operation<operations::unary_backward::ExecuteUnaryBackward<operations::unary_backward::UnaryBackwardOpType::LE_BW>>("ttnn::le_bw");
-constexpr auto ge_bw = ttnn::register_operation<operations::unary_backward::ExecuteUnaryBackward<operations::unary_backward::UnaryBackwardOpType::GE_BW>>("ttnn::ge_bw");
-constexpr auto ne_bw = ttnn::register_operation<operations::unary_backward::ExecuteUnaryBackward<operations::unary_backward::UnaryBackwardOpType::NE_BW>>("ttnn::ne_bw");
-constexpr auto lgamma_bw = ttnn::register_operation<operations::unary_backward::ExecuteUnaryBackward<operations::unary_backward::UnaryBackwardOpType::LGAMMA_BW>>("ttnn::lgamma_bw");
-constexpr auto fill_bw = ttnn::register_operation<operations::unary_backward::ExecuteUnaryBackward<operations::unary_backward::UnaryBackwardOpType::FILL_BW>>("ttnn::fill_bw");
-constexpr auto hardsigmoid_bw = ttnn::register_operation<operations::unary_backward::ExecuteUnaryBackward<operations::unary_backward::UnaryBackwardOpType::HARDSIGMOID_BW>>("ttnn::hardsigmoid_bw");
-constexpr auto cos_bw = ttnn::register_operation<operations::unary_backward::ExecuteUnaryBackward<operations::unary_backward::UnaryBackwardOpType::COS_BW>>("ttnn::cos_bw");
-constexpr auto acosh_bw = ttnn::register_operation<operations::unary_backward::ExecuteUnaryBackward<operations::unary_backward::UnaryBackwardOpType::ACOSH_BW>>("ttnn::acosh_bw");
-constexpr auto acos_bw = ttnn::register_operation<operations::unary_backward::ExecuteUnaryBackward<operations::unary_backward::UnaryBackwardOpType::ACOS_BW>>("ttnn::acos_bw");
-constexpr auto atan_bw = ttnn::register_operation<operations::unary_backward::ExecuteUnaryBackward<operations::unary_backward::UnaryBackwardOpType::ATAN_BW>>("ttnn::atan_bw");
-constexpr auto rad2deg_bw = ttnn::register_operation<operations::unary_backward::ExecuteUnaryBackward<operations::unary_backward::UnaryBackwardOpType::RAD2DEG_BW>>("ttnn::rad2deg_bw");
-constexpr auto sub_bw = ttnn::register_operation<operations::unary_backward::ExecuteUnaryBackward<operations::unary_backward::UnaryBackwardOpType::SUB_BW>>("ttnn::sub_bw");
-constexpr auto frac_bw = ttnn::register_operation<operations::unary_backward::ExecuteUnaryBackward<operations::unary_backward::UnaryBackwardOpType::FRAC_BW>>("ttnn::frac_bw");
-constexpr auto trunc_bw = ttnn::register_operation<operations::unary_backward::ExecuteUnaryBackward<operations::unary_backward::UnaryBackwardOpType::TRUNC_BW>>("ttnn::trunc_bw");
-constexpr auto log_sigmoid_bw = ttnn::register_operation<operations::unary_backward::ExecuteUnaryBackward<operations::unary_backward::UnaryBackwardOpType::LOG_SIGMOID_BW>>("ttnn::log_sigmoid_bw");
-constexpr auto fill_zero_bw = ttnn::register_operation<operations::unary_backward::ExecuteUnaryBackward<operations::unary_backward::UnaryBackwardOpType::FILL_ZERO_BW>>("ttnn::fill_zero_bw");
-constexpr auto i0_bw = ttnn::register_operation<operations::unary_backward::ExecuteUnaryBackward<operations::unary_backward::UnaryBackwardOpType::I0_BW>>("ttnn::i0_bw");
-constexpr auto tan_bw = ttnn::register_operation<operations::unary_backward::ExecuteUnaryBackward<operations::unary_backward::UnaryBackwardOpType::TAN_BW>>("ttnn::tan_bw");
-constexpr auto sigmoid_bw = ttnn::register_operation<operations::unary_backward::ExecuteUnaryBackward<operations::unary_backward::UnaryBackwardOpType::SIGMOID_BW>>("ttnn::sigmoid_bw");
-constexpr auto rsqrt_bw = ttnn::register_operation<operations::unary_backward::ExecuteUnaryBackward<operations::unary_backward::UnaryBackwardOpType::RSQRT_BW>>("ttnn::rsqrt_bw");
-constexpr auto neg_bw = ttnn::register_operation<operations::unary_backward::ExecuteUnaryBackward<operations::unary_backward::UnaryBackwardOpType::NEG_BW>>("ttnn::neg_bw");
-constexpr auto relu_bw = ttnn::register_operation<operations::unary_backward::ExecuteUnaryBackward<operations::unary_backward::UnaryBackwardOpType::RELU_BW>>("ttnn::relu_bw");
-constexpr auto logit_bw = ttnn::register_operation<operations::unary_backward::ExecuteUnaryBackward<operations::unary_backward::UnaryBackwardOpType::LOGIT_BW>>("ttnn::logit_bw");
-constexpr auto hardshrink_bw = ttnn::register_operation<operations::unary_backward::ExecuteUnaryBackward<operations::unary_backward::UnaryBackwardOpType::HARDSHRINK_BW>>("ttnn::hardshrink_bw");
-constexpr auto softshrink_bw = ttnn::register_operation<operations::unary_backward::ExecuteUnaryBackward<operations::unary_backward::UnaryBackwardOpType::SOFTSHRINK_BW>>("ttnn::softshrink_bw");
-constexpr auto leaky_relu_bw = ttnn::register_operation<operations::unary_backward::ExecuteUnaryBackward<operations::unary_backward::UnaryBackwardOpType::LEAKY_RELU_BW>>("ttnn::leaky_relu_bw");
-constexpr auto elu_bw = ttnn::register_operation<operations::unary_backward::ExecuteUnaryBackward<operations::unary_backward::UnaryBackwardOpType::ELU_BW>>("ttnn::elu_bw");
-constexpr auto celu_bw = ttnn::register_operation<operations::unary_backward::ExecuteUnaryBackward<operations::unary_backward::UnaryBackwardOpType::CELU_BW>>("ttnn::celu_bw");
-constexpr auto rpow_bw = ttnn::register_operation<operations::unary_backward::ExecuteUnaryBackward<operations::unary_backward::UnaryBackwardOpType::RPOW_BW>>("ttnn::rpow_bw");
-constexpr auto floor_bw = ttnn::register_operation<operations::unary_backward::ExecuteUnaryBackward<operations::unary_backward::UnaryBackwardOpType::FLOOR_BW>>("ttnn::floor_bw");
-constexpr auto round_bw = ttnn::register_operation<operations::unary_backward::ExecuteUnaryBackward<operations::unary_backward::UnaryBackwardOpType::ROUND_BW>>("ttnn::round_bw");
-constexpr auto log_bw = ttnn::register_operation<operations::unary_backward::ExecuteUnaryBackward<operations::unary_backward::UnaryBackwardOpType::LOG_BW>>("ttnn::log_bw");
-constexpr auto relu6_bw = ttnn::register_operation<operations::unary_backward::ExecuteUnaryBackward<operations::unary_backward::UnaryBackwardOpType::RELU6_BW>>("ttnn::relu6_bw");
-constexpr auto abs_bw = ttnn::register_operation<operations::unary_backward::ExecuteUnaryBackward<operations::unary_backward::UnaryBackwardOpType::ABS_BW>>("ttnn::abs_bw");
-constexpr auto silu_bw = ttnn::register_operation<operations::unary_backward::ExecuteUnaryBackward<operations::unary_backward::UnaryBackwardOpType::SILU_BW>>("ttnn::silu_bw");
-constexpr auto selu_bw = ttnn::register_operation<operations::unary_backward::ExecuteUnaryBackward<operations::unary_backward::UnaryBackwardOpType::SELU_BW>>("ttnn::selu_bw");
-constexpr auto square_bw = ttnn::register_operation<operations::unary_backward::ExecuteUnaryBackward<operations::unary_backward::UnaryBackwardOpType::SQUARE_BW>>("ttnn::square_bw");
-constexpr auto hardswish_bw = ttnn::register_operation<operations::unary_backward::ExecuteUnaryBackward<operations::unary_backward::UnaryBackwardOpType::HARDSWISH_BW>>("ttnn::hardswish_bw");
-constexpr auto tanhshrink_bw = ttnn::register_operation<operations::unary_backward::ExecuteUnaryBackward<operations::unary_backward::UnaryBackwardOpType::TANHSHRINK_BW>>("ttnn::tanhshrink_bw");
-constexpr auto atanh_bw = ttnn::register_operation<operations::unary_backward::ExecuteUnaryBackward<operations::unary_backward::UnaryBackwardOpType::ATANH_BW>>("ttnn::atanh_bw");
-constexpr auto asin_bw = ttnn::register_operation<operations::unary_backward::ExecuteUnaryBackward<operations::unary_backward::UnaryBackwardOpType::ASIN_BW>>("ttnn::asin_bw");
-constexpr auto asinh_bw = ttnn::register_operation<operations::unary_backward::ExecuteUnaryBackward<operations::unary_backward::UnaryBackwardOpType::ASINH_BW>>("ttnn::asinh_bw");
-constexpr auto sin_bw = ttnn::register_operation<operations::unary_backward::ExecuteUnaryBackward<operations::unary_backward::UnaryBackwardOpType::SIN_BW>>("ttnn::sin_bw");
-constexpr auto sinh_bw = ttnn::register_operation<operations::unary_backward::ExecuteUnaryBackward<operations::unary_backward::UnaryBackwardOpType::SINH_BW>>("ttnn::sinh_bw");
-constexpr auto log10_bw = ttnn::register_operation<operations::unary_backward::ExecuteUnaryBackward<operations::unary_backward::UnaryBackwardOpType::LOG10_BW>>("ttnn::log10_bw");
-constexpr auto log1p_bw = ttnn::register_operation<operations::unary_backward::ExecuteUnaryBackward<operations::unary_backward::UnaryBackwardOpType::LOG1P_BW>>("ttnn::log1p_bw");
-constexpr auto erfc_bw = ttnn::register_operation<operations::unary_backward::ExecuteUnaryBackward<operations::unary_backward::UnaryBackwardOpType::ERFC_BW>>("ttnn::erfc_bw");
-constexpr auto ceil_bw = ttnn::register_operation<operations::unary_backward::ExecuteUnaryBackward<operations::unary_backward::UnaryBackwardOpType::CEIL_BW>>("ttnn::ceil_bw");
-constexpr auto softsign_bw = ttnn::register_operation<operations::unary_backward::ExecuteUnaryBackward<operations::unary_backward::UnaryBackwardOpType::SOFTSIGN_BW>>("ttnn::softsign_bw");
-constexpr auto cosh_bw = ttnn::register_operation<operations::unary_backward::ExecuteUnaryBackward<operations::unary_backward::UnaryBackwardOpType::COSH_BW>>("ttnn::cosh_bw");
-constexpr auto logiteps_bw = ttnn::register_operation<operations::unary_backward::ExecuteUnaryBackward<operations::unary_backward::UnaryBackwardOpType::LOGITEPS_BW>>("ttnn::logiteps_bw");
-constexpr auto log2_bw = ttnn::register_operation<operations::unary_backward::ExecuteUnaryBackward<operations::unary_backward::UnaryBackwardOpType::LOG2_BW>>("ttnn::log2_bw");
-constexpr auto sign_bw = ttnn::register_operation<operations::unary_backward::ExecuteUnaryBackward<operations::unary_backward::UnaryBackwardOpType::SIGN_BW>>("ttnn::sign_bw");
-constexpr auto fmod_bw = ttnn::register_operation<operations::unary_backward::ExecuteUnaryBackward<operations::unary_backward::UnaryBackwardOpType::FMOD_BW>>("ttnn::fmod_bw");
-constexpr auto remainder_bw = ttnn::register_operation<operations::unary_backward::ExecuteUnaryBackward<operations::unary_backward::UnaryBackwardOpType::REMAINDER_BW>>("ttnn::remainder_bw");
-constexpr auto div_no_nan_bw = ttnn::register_operation<operations::unary_backward::ExecuteUnaryBackward<operations::unary_backward::UnaryBackwardOpType::DIV_NO_NAN_BW>>("ttnn::div_no_nan_bw");
-constexpr auto exp2_bw = ttnn::register_operation<operations::unary_backward::ExecuteUnaryBackward<operations::unary_backward::UnaryBackwardOpType::EXP2_BW>>("ttnn::exp2_bw");
-constexpr auto expm1_bw = ttnn::register_operation<operations::unary_backward::ExecuteUnaryBackward<operations::unary_backward::UnaryBackwardOpType::EXPM1_BW>>("ttnn::expm1_bw");
-constexpr auto reciprocal_bw = ttnn::register_operation<operations::unary_backward::ExecuteUnaryBackward<operations::unary_backward::UnaryBackwardOpType::RECIPROCAL_BW>>("ttnn::reciprocal_bw");
-constexpr auto digamma_bw = ttnn::register_operation<operations::unary_backward::ExecuteUnaryBackward<operations::unary_backward::UnaryBackwardOpType::DIGAMMA_BW>>("ttnn::digamma_bw");
-constexpr auto erfinv_bw = ttnn::register_operation<operations::unary_backward::ExecuteUnaryBackward<operations::unary_backward::UnaryBackwardOpType::ERFINV_BW>>("ttnn::erfinv_bw");
-constexpr auto erf_bw = ttnn::register_operation<operations::unary_backward::ExecuteUnaryBackward<operations::unary_backward::UnaryBackwardOpType::ERF_BW>>("ttnn::erf_bw");
-constexpr auto deg2rad_bw = ttnn::register_operation<operations::unary_backward::ExecuteUnaryBackward<operations::unary_backward::UnaryBackwardOpType::DEG2RAD_BW>>("ttnn::deg2rad_bw");
-constexpr auto polygamma_bw = ttnn::register_operation<operations::unary_backward::ExecuteUnaryBackward<operations::unary_backward::UnaryBackwardOpType::POLYGAMMA_BW>>("ttnn::polygamma_bw");
+constexpr auto mul_bw = ttnn::register_operation<
+    "ttnn::mul_bw",
+    operations::unary_backward::ExecuteUnaryBackward<operations::unary_backward::UnaryBackwardOpType::MUL_BW>>();
+constexpr auto assign_bw = ttnn::register_operation<
+    "ttnn::assign_bw",
+    operations::unary_backward::ExecuteUnaryBackward<operations::unary_backward::UnaryBackwardOpType::ASSIGN_BW>>();
+constexpr auto multigammaln_bw = ttnn::register_operation<
+    "ttnn::multigammaln_bw",
+    operations::unary_backward::ExecuteUnaryBackward<
+        operations::unary_backward::UnaryBackwardOpType::MULTIGAMMALN_BW>>();
+constexpr auto add_bw = ttnn::register_operation<
+    "ttnn::add_bw",
+    operations::unary_backward::ExecuteUnaryBackward<operations::unary_backward::UnaryBackwardOpType::ADD_BW>>();
+constexpr auto eq_bw = ttnn::register_operation<
+    "ttnn::eq_bw",
+    operations::unary_backward::ExecuteUnaryBackward<operations::unary_backward::UnaryBackwardOpType::EQ_BW>>();
+constexpr auto gt_bw = ttnn::register_operation<
+    "ttnn::gt_bw",
+    operations::unary_backward::ExecuteUnaryBackward<operations::unary_backward::UnaryBackwardOpType::GT_BW>>();
+constexpr auto lt_bw = ttnn::register_operation<
+    "ttnn::lt_bw",
+    operations::unary_backward::ExecuteUnaryBackward<operations::unary_backward::UnaryBackwardOpType::LT_BW>>();
+constexpr auto le_bw = ttnn::register_operation<
+    "ttnn::le_bw",
+    operations::unary_backward::ExecuteUnaryBackward<operations::unary_backward::UnaryBackwardOpType::LE_BW>>();
+constexpr auto ge_bw = ttnn::register_operation<
+    "ttnn::ge_bw",
+    operations::unary_backward::ExecuteUnaryBackward<operations::unary_backward::UnaryBackwardOpType::GE_BW>>();
+constexpr auto ne_bw = ttnn::register_operation<
+    "ttnn::ne_bw",
+    operations::unary_backward::ExecuteUnaryBackward<operations::unary_backward::UnaryBackwardOpType::NE_BW>>();
+constexpr auto lgamma_bw = ttnn::register_operation<
+    "ttnn::lgamma_bw",
+    operations::unary_backward::ExecuteUnaryBackward<operations::unary_backward::UnaryBackwardOpType::LGAMMA_BW>>();
+constexpr auto fill_bw = ttnn::register_operation<
+    "ttnn::fill_bw",
+    operations::unary_backward::ExecuteUnaryBackward<operations::unary_backward::UnaryBackwardOpType::FILL_BW>>();
+constexpr auto hardsigmoid_bw = ttnn::register_operation<
+    "ttnn::hardsigmoid_bw",
+    operations::unary_backward::ExecuteUnaryBackward<
+        operations::unary_backward::UnaryBackwardOpType::HARDSIGMOID_BW>>();
+constexpr auto cos_bw = ttnn::register_operation<
+    "ttnn::cos_bw",
+    operations::unary_backward::ExecuteUnaryBackward<operations::unary_backward::UnaryBackwardOpType::COS_BW>>();
+constexpr auto acosh_bw = ttnn::register_operation<
+    "ttnn::acosh_bw",
+    operations::unary_backward::ExecuteUnaryBackward<operations::unary_backward::UnaryBackwardOpType::ACOSH_BW>>();
+constexpr auto acos_bw = ttnn::register_operation<
+    "ttnn::acos_bw",
+    operations::unary_backward::ExecuteUnaryBackward<operations::unary_backward::UnaryBackwardOpType::ACOS_BW>>();
+constexpr auto atan_bw = ttnn::register_operation<
+    "ttnn::atan_bw",
+    operations::unary_backward::ExecuteUnaryBackward<operations::unary_backward::UnaryBackwardOpType::ATAN_BW>>();
+constexpr auto rad2deg_bw = ttnn::register_operation<
+    "ttnn::rad2deg_bw",
+    operations::unary_backward::ExecuteUnaryBackward<operations::unary_backward::UnaryBackwardOpType::RAD2DEG_BW>>();
+constexpr auto sub_bw = ttnn::register_operation<
+    "ttnn::sub_bw",
+    operations::unary_backward::ExecuteUnaryBackward<operations::unary_backward::UnaryBackwardOpType::SUB_BW>>();
+constexpr auto frac_bw = ttnn::register_operation<
+    "ttnn::frac_bw",
+    operations::unary_backward::ExecuteUnaryBackward<operations::unary_backward::UnaryBackwardOpType::FRAC_BW>>();
+constexpr auto trunc_bw = ttnn::register_operation<
+    "ttnn::trunc_bw",
+    operations::unary_backward::ExecuteUnaryBackward<operations::unary_backward::UnaryBackwardOpType::TRUNC_BW>>();
+constexpr auto log_sigmoid_bw = ttnn::register_operation<
+    "ttnn::log_sigmoid_bw",
+    operations::unary_backward::ExecuteUnaryBackward<
+        operations::unary_backward::UnaryBackwardOpType::LOG_SIGMOID_BW>>();
+constexpr auto fill_zero_bw = ttnn::register_operation<
+    "ttnn::fill_zero_bw",
+    operations::unary_backward::ExecuteUnaryBackward<operations::unary_backward::UnaryBackwardOpType::FILL_ZERO_BW>>();
+constexpr auto i0_bw = ttnn::register_operation<
+    "ttnn::i0_bw",
+    operations::unary_backward::ExecuteUnaryBackward<operations::unary_backward::UnaryBackwardOpType::I0_BW>>();
+constexpr auto tan_bw = ttnn::register_operation<
+    "ttnn::tan_bw",
+    operations::unary_backward::ExecuteUnaryBackward<operations::unary_backward::UnaryBackwardOpType::TAN_BW>>();
+constexpr auto sigmoid_bw = ttnn::register_operation<
+    "ttnn::sigmoid_bw",
+    operations::unary_backward::ExecuteUnaryBackward<operations::unary_backward::UnaryBackwardOpType::SIGMOID_BW>>();
+constexpr auto rsqrt_bw = ttnn::register_operation<
+    "ttnn::rsqrt_bw",
+    operations::unary_backward::ExecuteUnaryBackward<operations::unary_backward::UnaryBackwardOpType::RSQRT_BW>>();
+constexpr auto neg_bw = ttnn::register_operation<
+    "ttnn::neg_bw",
+    operations::unary_backward::ExecuteUnaryBackward<operations::unary_backward::UnaryBackwardOpType::NEG_BW>>();
+constexpr auto relu_bw = ttnn::register_operation<
+    "ttnn::relu_bw",
+    operations::unary_backward::ExecuteUnaryBackward<operations::unary_backward::UnaryBackwardOpType::RELU_BW>>();
+constexpr auto logit_bw = ttnn::register_operation<
+    "ttnn::logit_bw",
+    operations::unary_backward::ExecuteUnaryBackward<operations::unary_backward::UnaryBackwardOpType::LOGIT_BW>>();
+constexpr auto hardshrink_bw = ttnn::register_operation<
+    "ttnn::hardshrink_bw",
+    operations::unary_backward::ExecuteUnaryBackward<operations::unary_backward::UnaryBackwardOpType::HARDSHRINK_BW>>();
+constexpr auto softshrink_bw = ttnn::register_operation<
+    "ttnn::softshrink_bw",
+    operations::unary_backward::ExecuteUnaryBackward<operations::unary_backward::UnaryBackwardOpType::SOFTSHRINK_BW>>();
+constexpr auto leaky_relu_bw = ttnn::register_operation<
+    "ttnn::leaky_relu_bw",
+    operations::unary_backward::ExecuteUnaryBackward<operations::unary_backward::UnaryBackwardOpType::LEAKY_RELU_BW>>();
+constexpr auto elu_bw = ttnn::register_operation<
+    "ttnn::elu_bw",
+    operations::unary_backward::ExecuteUnaryBackward<operations::unary_backward::UnaryBackwardOpType::ELU_BW>>();
+constexpr auto celu_bw = ttnn::register_operation<
+    "ttnn::celu_bw",
+    operations::unary_backward::ExecuteUnaryBackward<operations::unary_backward::UnaryBackwardOpType::CELU_BW>>();
+constexpr auto rpow_bw = ttnn::register_operation<
+    "ttnn::rpow_bw",
+    operations::unary_backward::ExecuteUnaryBackward<operations::unary_backward::UnaryBackwardOpType::RPOW_BW>>();
+constexpr auto floor_bw = ttnn::register_operation<
+    "ttnn::floor_bw",
+    operations::unary_backward::ExecuteUnaryBackward<operations::unary_backward::UnaryBackwardOpType::FLOOR_BW>>();
+constexpr auto round_bw = ttnn::register_operation<
+    "ttnn::round_bw",
+    operations::unary_backward::ExecuteUnaryBackward<operations::unary_backward::UnaryBackwardOpType::ROUND_BW>>();
+constexpr auto log_bw = ttnn::register_operation<
+    "ttnn::log_bw",
+    operations::unary_backward::ExecuteUnaryBackward<operations::unary_backward::UnaryBackwardOpType::LOG_BW>>();
+constexpr auto relu6_bw = ttnn::register_operation<
+    "ttnn::relu6_bw",
+    operations::unary_backward::ExecuteUnaryBackward<operations::unary_backward::UnaryBackwardOpType::RELU6_BW>>();
+constexpr auto abs_bw = ttnn::register_operation<
+    "ttnn::abs_bw",
+    operations::unary_backward::ExecuteUnaryBackward<operations::unary_backward::UnaryBackwardOpType::ABS_BW>>();
+constexpr auto silu_bw = ttnn::register_operation<
+    "ttnn::silu_bw",
+    operations::unary_backward::ExecuteUnaryBackward<operations::unary_backward::UnaryBackwardOpType::SILU_BW>>();
+constexpr auto selu_bw = ttnn::register_operation<
+    "ttnn::selu_bw",
+    operations::unary_backward::ExecuteUnaryBackward<operations::unary_backward::UnaryBackwardOpType::SELU_BW>>();
+constexpr auto square_bw = ttnn::register_operation<
+    "ttnn::square_bw",
+    operations::unary_backward::ExecuteUnaryBackward<operations::unary_backward::UnaryBackwardOpType::SQUARE_BW>>();
+constexpr auto hardswish_bw = ttnn::register_operation<
+    "ttnn::hardswish_bw",
+    operations::unary_backward::ExecuteUnaryBackward<operations::unary_backward::UnaryBackwardOpType::HARDSWISH_BW>>();
+constexpr auto tanhshrink_bw = ttnn::register_operation<
+    "ttnn::tanhshrink_bw",
+    operations::unary_backward::ExecuteUnaryBackward<operations::unary_backward::UnaryBackwardOpType::TANHSHRINK_BW>>();
+constexpr auto atanh_bw = ttnn::register_operation<
+    "ttnn::atanh_bw",
+    operations::unary_backward::ExecuteUnaryBackward<operations::unary_backward::UnaryBackwardOpType::ATANH_BW>>();
+constexpr auto asin_bw = ttnn::register_operation<
+    "ttnn::asin_bw",
+    operations::unary_backward::ExecuteUnaryBackward<operations::unary_backward::UnaryBackwardOpType::ASIN_BW>>();
+constexpr auto asinh_bw = ttnn::register_operation<
+    "ttnn::asinh_bw",
+    operations::unary_backward::ExecuteUnaryBackward<operations::unary_backward::UnaryBackwardOpType::ASINH_BW>>();
+constexpr auto sin_bw = ttnn::register_operation<
+    "ttnn::sin_bw",
+    operations::unary_backward::ExecuteUnaryBackward<operations::unary_backward::UnaryBackwardOpType::SIN_BW>>();
+constexpr auto sinh_bw = ttnn::register_operation<
+    "ttnn::sinh_bw",
+    operations::unary_backward::ExecuteUnaryBackward<operations::unary_backward::UnaryBackwardOpType::SINH_BW>>();
+constexpr auto log10_bw = ttnn::register_operation<
+    "ttnn::log10_bw",
+    operations::unary_backward::ExecuteUnaryBackward<operations::unary_backward::UnaryBackwardOpType::LOG10_BW>>();
+constexpr auto log1p_bw = ttnn::register_operation<
+    "ttnn::log1p_bw",
+    operations::unary_backward::ExecuteUnaryBackward<operations::unary_backward::UnaryBackwardOpType::LOG1P_BW>>();
+constexpr auto erfc_bw = ttnn::register_operation<
+    "ttnn::erfc_bw",
+    operations::unary_backward::ExecuteUnaryBackward<operations::unary_backward::UnaryBackwardOpType::ERFC_BW>>();
+constexpr auto ceil_bw = ttnn::register_operation<
+    "ttnn::ceil_bw",
+    operations::unary_backward::ExecuteUnaryBackward<operations::unary_backward::UnaryBackwardOpType::CEIL_BW>>();
+constexpr auto softsign_bw = ttnn::register_operation<
+    "ttnn::softsign_bw",
+    operations::unary_backward::ExecuteUnaryBackward<operations::unary_backward::UnaryBackwardOpType::SOFTSIGN_BW>>();
+constexpr auto cosh_bw = ttnn::register_operation<
+    "ttnn::cosh_bw",
+    operations::unary_backward::ExecuteUnaryBackward<operations::unary_backward::UnaryBackwardOpType::COSH_BW>>();
+constexpr auto logiteps_bw = ttnn::register_operation<
+    "ttnn::logiteps_bw",
+    operations::unary_backward::ExecuteUnaryBackward<operations::unary_backward::UnaryBackwardOpType::LOGITEPS_BW>>();
+constexpr auto log2_bw = ttnn::register_operation<
+    "ttnn::log2_bw",
+    operations::unary_backward::ExecuteUnaryBackward<operations::unary_backward::UnaryBackwardOpType::LOG2_BW>>();
+constexpr auto sign_bw = ttnn::register_operation<
+    "ttnn::sign_bw",
+    operations::unary_backward::ExecuteUnaryBackward<operations::unary_backward::UnaryBackwardOpType::SIGN_BW>>();
+constexpr auto fmod_bw = ttnn::register_operation<
+    "ttnn::fmod_bw",
+    operations::unary_backward::ExecuteUnaryBackward<operations::unary_backward::UnaryBackwardOpType::FMOD_BW>>();
+constexpr auto remainder_bw = ttnn::register_operation<
+    "ttnn::remainder_bw",
+    operations::unary_backward::ExecuteUnaryBackward<operations::unary_backward::UnaryBackwardOpType::REMAINDER_BW>>();
+constexpr auto div_no_nan_bw = ttnn::register_operation<
+    "ttnn::div_no_nan_bw",
+    operations::unary_backward::ExecuteUnaryBackward<operations::unary_backward::UnaryBackwardOpType::DIV_NO_NAN_BW>>();
+constexpr auto exp2_bw = ttnn::register_operation<
+    "ttnn::exp2_bw",
+    operations::unary_backward::ExecuteUnaryBackward<operations::unary_backward::UnaryBackwardOpType::EXP2_BW>>();
+constexpr auto expm1_bw = ttnn::register_operation<
+    "ttnn::expm1_bw",
+    operations::unary_backward::ExecuteUnaryBackward<operations::unary_backward::UnaryBackwardOpType::EXPM1_BW>>();
+constexpr auto reciprocal_bw = ttnn::register_operation<
+    "ttnn::reciprocal_bw",
+    operations::unary_backward::ExecuteUnaryBackward<operations::unary_backward::UnaryBackwardOpType::RECIPROCAL_BW>>();
+constexpr auto digamma_bw = ttnn::register_operation<
+    "ttnn::digamma_bw",
+    operations::unary_backward::ExecuteUnaryBackward<operations::unary_backward::UnaryBackwardOpType::DIGAMMA_BW>>();
+constexpr auto erfinv_bw = ttnn::register_operation<
+    "ttnn::erfinv_bw",
+    operations::unary_backward::ExecuteUnaryBackward<operations::unary_backward::UnaryBackwardOpType::ERFINV_BW>>();
+constexpr auto erf_bw = ttnn::register_operation<
+    "ttnn::erf_bw",
+    operations::unary_backward::ExecuteUnaryBackward<operations::unary_backward::UnaryBackwardOpType::ERF_BW>>();
+constexpr auto deg2rad_bw = ttnn::register_operation<
+    "ttnn::deg2rad_bw",
+    operations::unary_backward::ExecuteUnaryBackward<operations::unary_backward::UnaryBackwardOpType::DEG2RAD_BW>>();
+constexpr auto polygamma_bw = ttnn::register_operation<
+    "ttnn::polygamma_bw",
+    operations::unary_backward::ExecuteUnaryBackward<operations::unary_backward::UnaryBackwardOpType::POLYGAMMA_BW>>();
 
 }  // namespace ttnn

--- a/ttnn/cpp/ttnn/operations/embedding/embedding/embedding.hpp
+++ b/ttnn/cpp/ttnn/operations/embedding/embedding/embedding.hpp
@@ -72,6 +72,6 @@ struct Embedding {
 }  // namespace embedding
 }  // namespace operations
 
-constexpr auto embedding = ttnn::register_operation<ttnn::operations::embedding::Embedding>("ttnn::embedding");
+constexpr auto embedding = ttnn::register_operation<"ttnn::embedding", ttnn::operations::embedding::Embedding>();
 
 }  // namespace ttnn

--- a/ttnn/cpp/ttnn/operations/examples/example/example.hpp
+++ b/ttnn/cpp/ttnn/operations/examples/example/example.hpp
@@ -37,6 +37,6 @@ namespace ttnn {
 
 // Register the operation. The name, in this case, "ttnn::example" should match the namespace of the operation
 // And the name will be directly mapped to python, where it will become "ttnn.example"
-constexpr auto example = ttnn::register_operation<operations::examples::ExampleOperation>("ttnn::example");
+constexpr auto example = ttnn::register_operation<"ttnn::example", operations::examples::ExampleOperation>();
 
 }  // namespace ttnn

--- a/ttnn/cpp/ttnn/operations/experimental/transformer/transformer.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/transformer.hpp
@@ -37,8 +37,9 @@ struct ConcatenateHeadsOperation {
 
 namespace experimental::transformer {
 
-constexpr auto concatenate_heads = ttnn::register_operation<ttnn::operations::experimental::transformer::ConcatenateHeadsOperation>(
-    "ttnn::experimental::transformer::concatenate_heads");
+constexpr auto concatenate_heads = ttnn::register_operation<
+    "ttnn::experimental::transformer::concatenate_heads",
+    ttnn::operations::experimental::transformer::ConcatenateHeadsOperation>();
 
 }  // namespace experimental::transformer
 

--- a/ttnn/cpp/ttnn/operations/kv_cache.hpp
+++ b/ttnn/cpp/ttnn/operations/kv_cache.hpp
@@ -41,9 +41,9 @@ struct ExecuteUpdateCache {
 
 namespace kv_cache {
 constexpr auto fill_cache_for_user_ =
-    ttnn::register_operation<ttnn::operations::kv_cache::ExecuteFillCache>("ttnn::kv_cache::fill_cache_for_user_");
-constexpr auto update_cache_for_token_ =
-    ttnn::register_operation<ttnn::operations::kv_cache::ExecuteUpdateCache>("ttnn::kv_cache::update_cache_for_token_");
+    ttnn::register_operation<"ttnn::kv_cache::fill_cache_for_user_", ttnn::operations::kv_cache::ExecuteFillCache>();
+constexpr auto update_cache_for_token_ = ttnn::
+    register_operation<"ttnn::kv_cache::update_cache_for_token_", ttnn::operations::kv_cache::ExecuteUpdateCache>();
 }  // namespace kv_cache
 
 }  // namespace ttnn

--- a/ttnn/cpp/ttnn/operations/normalization/groupnorm/groupnorm.hpp
+++ b/ttnn/cpp/ttnn/operations/normalization/groupnorm/groupnorm.hpp
@@ -84,6 +84,7 @@ struct ExecuteGroupNorm {
 }  // namespace normalization
 }  // namespace operations
 
-constexpr auto group_norm = ttnn::register_operation<ttnn::operations::normalization::ExecuteGroupNorm>("ttnn::group_norm");
+constexpr auto group_norm =
+    ttnn::register_operation<"ttnn::group_norm", ttnn::operations::normalization::ExecuteGroupNorm>();
 
 }  // namespace ttnn

--- a/ttnn/cpp/ttnn/operations/normalization/layernorm/layernorm.hpp
+++ b/ttnn/cpp/ttnn/operations/normalization/layernorm/layernorm.hpp
@@ -38,6 +38,7 @@ struct ExecuteLayerNorm {
 
 }  // namespace operations::normalization
 
-constexpr auto layer_norm = ttnn::register_operation<ttnn::operations::normalization::ExecuteLayerNorm>("ttnn::layer_norm");
+constexpr auto layer_norm =
+    ttnn::register_operation<"ttnn::layer_norm", ttnn::operations::normalization::ExecuteLayerNorm>();
 
 }  // namespace ttnn

--- a/ttnn/cpp/ttnn/operations/normalization/rmsnorm/rmsnorm.hpp
+++ b/ttnn/cpp/ttnn/operations/normalization/rmsnorm/rmsnorm.hpp
@@ -37,6 +37,6 @@ struct ExecuteRMSNorm {
 
 }  // namespace operations::normalization
 
-constexpr auto rms_norm = ttnn::register_operation<ttnn::operations::normalization::ExecuteRMSNorm>("ttnn::rms_norm");
+constexpr auto rms_norm = ttnn::register_operation<"ttnn::rms_norm", ttnn::operations::normalization::ExecuteRMSNorm>();
 
 }  // namespace ttnn

--- a/ttnn/cpp/ttnn/operations/normalization/softmax/softmax.hpp
+++ b/ttnn/cpp/ttnn/operations/normalization/softmax/softmax.hpp
@@ -113,10 +113,16 @@ struct ExecuteScaleCausalMaskHWSoftmaxInPlace {
 
 }  // namespace operations::normalization
 
-constexpr auto softmax = ttnn::register_operation<ttnn::operations::normalization::ExecuteSoftmax>("ttnn::softmax");
-constexpr auto scale_mask_softmax = ttnn::register_operation<ttnn::operations::normalization::ExecuteScaleMaskSoftmax>("ttnn::scale_mask_softmax");
-constexpr auto softmax_in_place = ttnn::register_operation<ttnn::operations::normalization::ExecuteSoftmaxInPlace>("ttnn::softmax_in_place");
-constexpr auto scale_mask_softmax_in_place = ttnn::register_operation<ttnn::operations::normalization::ExecuteScaleMaskSoftmaxInPlace>("ttnn::scale_mask_softmax_in_place");
-constexpr auto scale_causal_mask_hw_dims_softmax_in_place = ttnn::register_operation<ttnn::operations::normalization::ExecuteScaleCausalMaskHWSoftmaxInPlace>("ttnn::scale_causal_mask_hw_dims_softmax_in_place");
+constexpr auto softmax = ttnn::register_operation<"ttnn::softmax", ttnn::operations::normalization::ExecuteSoftmax>();
+constexpr auto scale_mask_softmax =
+    ttnn::register_operation<"ttnn::scale_mask_softmax", ttnn::operations::normalization::ExecuteScaleMaskSoftmax>();
+constexpr auto softmax_in_place =
+    ttnn::register_operation<"ttnn::softmax_in_place", ttnn::operations::normalization::ExecuteSoftmaxInPlace>();
+constexpr auto scale_mask_softmax_in_place = ttnn::register_operation<
+    "ttnn::scale_mask_softmax_in_place",
+    ttnn::operations::normalization::ExecuteScaleMaskSoftmaxInPlace>();
+constexpr auto scale_causal_mask_hw_dims_softmax_in_place = ttnn::register_operation<
+    "ttnn::scale_causal_mask_hw_dims_softmax_in_place",
+    ttnn::operations::normalization::ExecuteScaleCausalMaskHWSoftmaxInPlace>();
 
 }  // namespace ttnn

--- a/ttnn/cpp/ttnn/operations/pool/avgpool/avg_pool.hpp
+++ b/ttnn/cpp/ttnn/operations/pool/avgpool/avg_pool.hpp
@@ -44,6 +44,6 @@ struct GlobalAveragePool2D {
 }  // namespace operations
 
 constexpr auto global_avg_pool2d =
-    ttnn::register_operation<ttnn::operations::pool::GlobalAveragePool2D>("ttnn::global_avg_pool2d");
+    ttnn::register_operation<"ttnn::global_avg_pool2d", ttnn::operations::pool::GlobalAveragePool2D>();
 
 }  // namespace ttnn

--- a/ttnn/cpp/ttnn/operations/reduction/argmax/argmax.hpp
+++ b/ttnn/cpp/ttnn/operations/reduction/argmax/argmax.hpp
@@ -36,6 +36,6 @@ struct ExecuteArgMax {
 
 }  // namespace operations::reduction
 
-constexpr auto argmax = ttnn::register_operation<ttnn::operations::reduction::ExecuteArgMax>("ttnn::argmax");
+constexpr auto argmax = ttnn::register_operation<"ttnn::argmax", ttnn::operations::reduction::ExecuteArgMax>();
 
 }  // namespace ttnn

--- a/ttnn/cpp/ttnn/operations/reduction/generic/generic_reductions.hpp
+++ b/ttnn/cpp/ttnn/operations/reduction/generic/generic_reductions.hpp
@@ -157,28 +157,28 @@ struct Reduce {
 }  // namespace operations::reduction
 
 // Generic reductions
-constexpr auto sum =
-    ttnn::register_operation<ttnn::operations::reduction::Reduce<ttnn::operations::reduction::ReduceType::Sum>>(
-        "ttnn::sum");
+constexpr auto sum = ttnn::register_operation<
+    "ttnn::sum",
+    ttnn::operations::reduction::Reduce<ttnn::operations::reduction::ReduceType::Sum>>();
 
-constexpr auto mean =
-    ttnn::register_operation<ttnn::operations::reduction::Reduce<ttnn::operations::reduction::ReduceType::Mean>>(
-        "ttnn::mean");
+constexpr auto mean = ttnn::register_operation<
+    "ttnn::mean",
+    ttnn::operations::reduction::Reduce<ttnn::operations::reduction::ReduceType::Mean>>();
 
-constexpr auto max =
-    ttnn::register_operation<ttnn::operations::reduction::Reduce<ttnn::operations::reduction::ReduceType::Max>>(
-        "ttnn::max");
+constexpr auto max = ttnn::register_operation<
+    "ttnn::max",
+    ttnn::operations::reduction::Reduce<ttnn::operations::reduction::ReduceType::Max>>();
 
-constexpr auto min =
-    ttnn::register_operation<ttnn::operations::reduction::Reduce<ttnn::operations::reduction::ReduceType::Min>>(
-        "ttnn::min");
+constexpr auto min = ttnn::register_operation<
+    "ttnn::min",
+    ttnn::operations::reduction::Reduce<ttnn::operations::reduction::ReduceType::Min>>();
 
-constexpr auto std =
-    ttnn::register_operation<ttnn::operations::reduction::Reduce<ttnn::operations::reduction::ReduceType::Std>>(
-        "ttnn::std");
+constexpr auto std = ttnn::register_operation<
+    "ttnn::std",
+    ttnn::operations::reduction::Reduce<ttnn::operations::reduction::ReduceType::Std>>();
 
-constexpr auto var =
-    ttnn::register_operation<ttnn::operations::reduction::Reduce<ttnn::operations::reduction::ReduceType::Var>>(
-        "ttnn::var");
+constexpr auto var = ttnn::register_operation<
+    "ttnn::var",
+    ttnn::operations::reduction::Reduce<ttnn::operations::reduction::ReduceType::Var>>();
 
 }  // namespace ttnn

--- a/ttnn/cpp/ttnn/operations/reduction/topk/topk.hpp
+++ b/ttnn/cpp/ttnn/operations/reduction/topk/topk.hpp
@@ -63,6 +63,6 @@ struct ExecuteTopK {
 
 }  // namespace operations::reduction
 
-constexpr auto topk = ttnn::register_operation<ttnn::operations::reduction::ExecuteTopK>("ttnn::topk");
+constexpr auto topk = ttnn::register_operation<"ttnn::topk", ttnn::operations::reduction::ExecuteTopK>();
 
 }  // namespace ttnn

--- a/ttnn/cpp/ttnn/operations/transformer/transformer.hpp
+++ b/ttnn/cpp/ttnn/operations/transformer/transformer.hpp
@@ -306,18 +306,20 @@ constexpr auto split_query_key_value_and_split_heads = REGISTER_OPERATION_FROM_F
     "ttnn::transformer::split_query_key_value_and_split_heads",
     ttnn::operations::transformer::split_query_key_value_and_split_heads);
 
-constexpr auto concatenate_heads = ttnn::register_operation<ttnn::operations::transformer::ExecuteConcatenateHeads>(
-    "ttnn::transformer::concatenate_heads");
+constexpr auto concatenate_heads = ttnn::register_operation<
+    "ttnn::transformer::concatenate_heads",
+    ttnn::operations::transformer::ExecuteConcatenateHeads>();
 
-constexpr auto rotary_embedding = ttnn::register_operation<ttnn::operations::transformer::ExecuteRotaryEmbedding>(
-    "ttnn::transformer::rotary_embedding");
+constexpr auto rotary_embedding = ttnn::
+    register_operation<"ttnn::transformer::rotary_embedding", ttnn::operations::transformer::ExecuteRotaryEmbedding>();
 
-constexpr auto attention_softmax =
-    ttnn::register_operation<ttnn::operations::transformer::ExecuteAttentionSoftmax<false>>(
-        "ttnn::transformer::attention_softmax");
-constexpr auto attention_softmax_ =
-    ttnn::register_operation<ttnn::operations::transformer::ExecuteAttentionSoftmax<true>>(
-        "ttnn::transformer::attention_softmax_");
+constexpr auto attention_softmax = ttnn::register_operation<
+    "ttnn::transformer::attention_softmax",
+    ttnn::operations::transformer::ExecuteAttentionSoftmax<false>>();
+
+constexpr auto attention_softmax_ = ttnn::register_operation<
+    "ttnn::transformer::attention_softmax_",
+    ttnn::operations::transformer::ExecuteAttentionSoftmax<true>>();
 
 }  // namespace transformer
 


### PR DESCRIPTION
### Ticket


### Problem description
ttnn operations were using run-time variable to store the name because the infra was added before C++20

### What's changed
Changed it to be compile-time

### Checklist
- [ ] Post commit CI passes
- [ ] Model regression CI testing passes (if applicable)
- [ ] New/Existing tests provide coverage for changes
