### PR TITLE
#10014: Resolve issues with Dispatch FW exposed by LLAMA3 Trace on T3K

### DIFF
--- a/tt_metal/impl/dispatch/kernels/cq_dispatch.cpp
+++ b/tt_metal/impl/dispatch/kernels/cq_dispatch.cpp
@@ -281,18 +281,21 @@ void relay_to_next_cb(uint32_t data_ptr, uint32_t length) {
             dst = get_noc_addr_helper(downstream_noc_xy, downstream_cb_data_ptr);
             ASSERT(downstream_cb_data_ptr < downstream_cb_end);
         }
-
+        // "Reserve" pages for the next write from this block
+        block_noc_writes_to_clear[rd_block_idx]++;
         // Get a page if needed
         if (data_ptr + xfer_size > cb_fence) {
             // Check for block completion
             if (cb_fence == block_next_start_addr[rd_block_idx]) {
+                uint32_t orphan_size = cb_fence - data_ptr;
+                // No more writes from this block. Decrement the number of writes
+                // since they were all accounted for.
+                block_noc_writes_to_clear[rd_block_idx] -= (orphan_size == 0);
                 // Check for dispatch_cb wrap
                 if (rd_block_idx == dispatch_cb_blocks - 1) {
                     ASSERT(cb_fence == dispatch_cb_end);
-                    uint32_t orphan_size = cb_fence - data_ptr;
                     if (orphan_size != 0) {
                         noc_async_write<dispatch_cb_page_size>(data_ptr, dst, orphan_size);
-                        block_noc_writes_to_clear[rd_block_idx]++;
                         length -= orphan_size;
                         xfer_size -= orphan_size;
                         downstream_cb_data_ptr += orphan_size;
@@ -300,12 +303,16 @@ void relay_to_next_cb(uint32_t data_ptr, uint32_t length) {
                             downstream_cb_data_ptr = downstream_cb_base;
                         }
                         dst = get_noc_addr_helper(downstream_noc_xy, downstream_cb_data_ptr);
+                        // All writes from this block have completed.
+                        orphan_size = 0;
                     }
                     cb_fence = dispatch_cb_base;
                     data_ptr = dispatch_cb_base;
                 }
 
                 move_rd_to_next_block<dispatch_cb_blocks>(block_noc_writes_to_clear, rd_block_idx);
+                // Next write will be from next block. "Reserve" pages for it.
+                block_noc_writes_to_clear[rd_block_idx] += (orphan_size == 0);
             }
 
             // Wait for dispatcher to supply a page (this won't go beyond the buffer end)
@@ -323,7 +330,6 @@ void relay_to_next_cb(uint32_t data_ptr, uint32_t length) {
         }
 
         noc_async_write<dispatch_cb_page_size>(data_ptr, dst, xfer_size);
-        block_noc_writes_to_clear[rd_block_idx]++;  // XXXXX maybe just write the noc internal api counter
         cb_release_pages<downstream_noc_xy, downstream_cb_sem_id>(1);  // XXXX optimize, take all available
 
         length -= xfer_size;
@@ -377,14 +383,18 @@ void process_write_linear(uint32_t num_mcast_dests) {
     while (length != 0) {
         uint32_t xfer_size = (length > dispatch_cb_page_size) ? dispatch_cb_page_size : length;
         uint64_t dst = get_noc_addr_helper(dst_noc, dst_addr);
-
+        // "Reserve" pages for the next write from this block
+        block_noc_writes_to_clear[rd_block_idx]++;
         // Get a page if needed
         if (data_ptr + xfer_size > cb_fence) {
             // Check for block completion
             if (cb_fence == block_next_start_addr[rd_block_idx]) {
+                uint32_t orphan_size = cb_fence - data_ptr;
+                // No more writes from this block. Decrement the number of writes
+                // since they were all accounted for.
+                block_noc_writes_to_clear[rd_block_idx] -= (orphan_size == 0);
                 // Check for dispatch_cb wrap
                 if (rd_block_idx == dispatch_cb_blocks - 1) {
-                    uint32_t orphan_size = dispatch_cb_end - data_ptr;
                     if (orphan_size != 0) {
                         if constexpr (multicast) {
                             noc_async_write_multicast<dispatch_cb_page_size>(
@@ -392,19 +402,20 @@ void process_write_linear(uint32_t num_mcast_dests) {
                         } else {
                             noc_async_write<dispatch_cb_page_size>(data_ptr, dst, orphan_size);
                         }
-                        block_noc_writes_to_clear[rd_block_idx]++;
                         length -= orphan_size;
                         xfer_size -= orphan_size;
                         dst_addr += orphan_size;
+                        // All writes from this block have completed.
+                        orphan_size = 0;
                     }
                     cb_fence = dispatch_cb_base;
                     data_ptr = dispatch_cb_base;
                     dst = get_noc_addr_helper(dst_noc, dst_addr);
                 }
-
                 move_rd_to_next_block<dispatch_cb_blocks>(block_noc_writes_to_clear, rd_block_idx);
+                // Next write will be from next block. "Reserve" pages for it.
+                block_noc_writes_to_clear[rd_block_idx] += (orphan_size == 0);
             }
-
             // Wait for dispatcher to supply a page (this won't go beyond the buffer end)
             uint32_t n_pages = cb_acquire_pages<my_noc_xy, my_dispatch_cb_sem_id, dispatch_cb_log_page_size>(
                 cb_fence, block_next_start_addr, rd_block_idx);
@@ -424,8 +435,6 @@ void process_write_linear(uint32_t num_mcast_dests) {
         } else {
             noc_async_write<dispatch_cb_page_size>(data_ptr, dst, xfer_size);
         }
-        block_noc_writes_to_clear[rd_block_idx]++;  // XXXXX maybe just write the noc internal api counter
-
         length -= xfer_size;
         data_ptr += xfer_size;
         dst_addr += xfer_size;
@@ -468,26 +477,33 @@ void process_write_paged() {
             page_size > dispatch_cb_page_size ? min(dispatch_cb_page_size, page_size - dst_addr_offset) : page_size;
         uint64_t dst = addr_gen.get_noc_addr(
             page_id, dst_addr_offset);  // XXXX replace this w/ walking the banks to save mul on GS
-
+        // "Reserve" pages for the next write from this block
+        block_noc_writes_to_clear[rd_block_idx]++;
         // Get a Dispatch page if needed
         if (data_ptr + xfer_size > cb_fence) {
             // Check for block completion
             if (cb_fence == block_next_start_addr[rd_block_idx]) {
+                uint32_t orphan_size = cb_fence - data_ptr;
+                // No more writes from this block. Decrement the number of writes
+                // since they were all accounted for.
+                block_noc_writes_to_clear[rd_block_idx] -= (orphan_size == 0);
                 // Check for dispatch_cb wrap
                 if (rd_block_idx == dispatch_cb_blocks - 1) {
-                    uint32_t orphan_size = dispatch_cb_end - data_ptr;
                     if (orphan_size != 0) {
                         noc_async_write<dispatch_cb_page_size>(data_ptr, dst, orphan_size);
-                        block_noc_writes_to_clear[rd_block_idx]++;
                         write_length -= orphan_size;
                         xfer_size -= orphan_size;
                         dst_addr_offset += orphan_size;
+                        // All writes from this block have completed.
+                        orphan_size = 0;
                     }
                     cb_fence = dispatch_cb_base;
                     data_ptr = dispatch_cb_base;
                     dst = addr_gen.get_noc_addr(page_id, dst_addr_offset);
                 }
                 move_rd_to_next_block<dispatch_cb_blocks>(block_noc_writes_to_clear, rd_block_idx);
+                // Next write will be from next block. "Reserve" pages for it.
+                block_noc_writes_to_clear[rd_block_idx] += (orphan_size == 0);
             }
 
             // Wait for dispatcher to supply a page (this won't go beyond the buffer end)
@@ -505,7 +521,6 @@ void process_write_paged() {
         }
 
         noc_async_write<dispatch_cb_page_size>(data_ptr, dst, xfer_size);
-        block_noc_writes_to_clear[rd_block_idx]++;  // XXXXX maybe just write the noc internal api counter
 
         // If paged write is not completed for a page (dispatch_cb_page_size < page_size) then add offset, otherwise
         // incr page_id.
@@ -573,22 +588,24 @@ void process_write_packed(uint32_t flags) {
         uint64_t dst = get_noc_addr_helper(dst_noc, dst_addr);
         // Get a page if needed
         if (data_ptr + xfer_size > cb_fence) {
-            // Check for block completion
+            // Check for block completion and issue orphan writes for this block
+            // before proceeding to next block
             uint32_t orphan_size = 0;
             if (cb_fence == block_next_start_addr[rd_block_idx]) {
-                // Check for dispatch_cb wrap
+                orphan_size = cb_fence - data_ptr;
+                if (orphan_size != 0) {
+                    cq_noc_async_write_with_state<CQ_NOC_SNdL>(data_ptr, dst, orphan_size, num_dests);
+                    writes++;
+                    mcasts += num_dests;
+                }
+                // Handle wrapping on dispatch cb
                 if (rd_block_idx == dispatch_cb_blocks - 1) {
-                    ASSERT(cb_fence == dispatch_cb_end);
-                    orphan_size = cb_fence - data_ptr;
-                    if (orphan_size != 0) {
-                        cq_noc_async_write_with_state<CQ_NOC_SNdL>(data_ptr, dst, orphan_size, num_dests);
-                        writes++;
-                        mcasts += num_dests;
-                    }
                     cb_fence = dispatch_cb_base;
                     data_ptr = dispatch_cb_base;
                 }
-
+                else {
+                    data_ptr += orphan_size;
+                }
                 block_noc_writes_to_clear[rd_block_idx] += writes;
                 noc_nonposted_writes_num_issued[noc_index] += writes;
                 noc_nonposted_writes_acked[noc_index] += mcasts;
@@ -689,22 +706,28 @@ void process_write_packed_large() {
 
         while (length != 0) {
             uint32_t xfer_size = (length > dispatch_cb_page_size) ? dispatch_cb_page_size : length;
-
+            // "Reserve" pages for the next write from this block
+            writes++;
+            mcasts += num_dests;
             // Get a page if needed
             if (data_ptr + xfer_size > cb_fence) {
                 // Check for block completion
                 if (cb_fence == block_next_start_addr[rd_block_idx]) {
+                    // No more writes from this block. Decrement the number of writes
+                    // since they were all accounted for.
+                    uint32_t orphan_size = cb_fence - data_ptr;
+                    writes -= (orphan_size == 0);
+                    mcasts -= (orphan_size == 0) * num_dests;
                     // Check for dispatch_cb wrap
                     if (rd_block_idx == dispatch_cb_blocks - 1) {
                         ASSERT(cb_fence == dispatch_cb_end);
-                        uint32_t orphan_size = cb_fence - data_ptr;
                         if (orphan_size != 0) {
                             cq_noc_async_write_with_state<CQ_NOC_SnDL>(data_ptr, dst, orphan_size, num_dests);
-                            writes++;
-                            mcasts += num_dests;
                             length -= orphan_size;
                             xfer_size -= orphan_size;
                             dst_addr += orphan_size;
+                            // All writes from this block have completed.
+                            orphan_size = 0;
                         }
                         cb_fence = dispatch_cb_base;
                         data_ptr = dispatch_cb_base;
@@ -715,6 +738,9 @@ void process_write_packed_large() {
                     noc_nonposted_writes_num_issued[noc_index] += writes;
                     writes = 0;
                     move_rd_to_next_block<dispatch_cb_blocks>(block_noc_writes_to_clear, rd_block_idx);
+                    // Next write will be from next block. "Reserve" pages for it.
+                    writes += (orphan_size == 0);
+                    mcasts += (orphan_size == 0) * num_dests;
                 }
 
                 // Wait for dispatcher to supply a page (this won't go beyond the buffer end)
@@ -724,8 +750,7 @@ void process_write_packed_large() {
             }
 
             cq_noc_async_write_with_state<CQ_NOC_SnDL>(data_ptr, dst, xfer_size, num_dests);
-            writes++;
-            mcasts += num_dests;
+
             length -= xfer_size;
             data_ptr += xfer_size;
             dst_addr += xfer_size;

--- a/tt_metal/impl/dispatch/kernels/cq_prefetch.cpp
+++ b/tt_metal/impl/dispatch/kernels/cq_prefetch.cpp
@@ -82,7 +82,7 @@ constexpr uint32_t max_read_packed_cmd =
 constexpr uint32_t l1_cache_elements = max_read_packed_cmd;
 constexpr uint32_t l1_cache_elements_rounded =
     ((l1_cache_elements + l1_to_local_cache_copy_chunk - 1) / l1_to_local_cache_copy_chunk) *
-    l1_to_local_cache_copy_chunk;
+    l1_to_local_cache_copy_chunk +  (l1_to_local_cache_copy_chunk - 1);;
 
 static uint32_t l1_cache[l1_cache_elements_rounded];
 


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/10014

### Problem description
Device hangs exposed by running LLAMA3 on T3K using trace.
  - cq_prefetch: L1 cache for relay_paged_packed was incorrectly sized. 
      - l1_to_local_cache_copy_chunk - 1 words of padding are required, to account for cases where the subcmds/data get 
         split due to exec_buf being too small 
      - Exposed as a corruption in the exec_buf_state_structu, which got overwritten
  - cq_dispatch: When a block boundary is hit, remaining pages for curr block were written after moving to the next block. 
      - Writes were incorrectly accounted for the curr block -> prefetcher could race ahead and overwrite active pages before NOC picked them up. Showing up as an invalid ETH binary

### What's changed
Resize L1 cache on prefetcher. Add orphan write logic on dispatcher when dealing with block completion.

### Checklist
- [x] Post commit CI passes
- [x] Model regression CI testing passes (if applicable)
- [ ] New/Existing tests provide coverage for changes
