### PR TITLE
#9319: Set job_submission_ts = job_start_ts if submission time seems to be after start time

### DIFF
--- a/infra/data_collection/github/utils.py
+++ b/infra/data_collection/github/utils.py
@@ -143,8 +143,9 @@ def get_job_row_from_github_job(github_job):
     labels = github_job["labels"]
 
     if not host_name:
-        logger.debug("Detected null host_name, so will return unknown location")
+        logger.debug("Detected null host_name, so will return unknown location and host_name")
         location = "unknown"
+        host_name = "unknown"
     elif "GitHub Actions " in host_name:
         location = "github"
     else:

--- a/infra/data_collection/github/utils.py
+++ b/infra/data_collection/github/utils.py
@@ -186,6 +186,15 @@ def get_job_row_from_github_job(github_job):
 
     job_start_ts = github_job["started_at"]
 
+    job_submission_ts_dt = get_datetime_from_github_datetime(job_submission_ts)
+    job_start_ts_dt = get_datetime_from_github_datetime(job_start_ts)
+
+    if job_submission_ts_dt > job_start_ts_dt:
+        logger.warning(
+            f"Job {github_job_id} seems to have a start time that's earlier than submission. Setting equal for data"
+        )
+        job_submission_ts = job_start_ts
+
     job_end_ts = github_job["completed_at"]
 
     job_success = github_job["conclusion"] == "success"


### PR DESCRIPTION
…

### Ticket
#9319

### Problem description

Sometimes `job_submission_ts` is reported as a time after `job_start_ts`. This is likely because of async issues on github's timeestamp reporting for their runners.

We set them equal for data reporting if that's the case.

### What's changed

Check if `job_submission_ts` > `job_start_ts`. If so, set equal

### Checklist
- [ ] Post commit CI passes
- [ ] Model regression CI testing passes (if applicable)
- [ ] New/Existing tests provide coverage for changes
