### PR TITLE
Create/enable kernel config ring buffer

### DIFF
--- a/tests/tt_metal/tools/profiler/test_device_profiler.py
+++ b/tests/tt_metal/tools/profiler/test_device_profiler.py
@@ -145,12 +145,12 @@ def test_dispatch_cores():
     ZONE_COUNT = 37
     REF_COUNT_DICT = {
         "grayskull": {
-            "Tensix CQ Dispatch": 18,
-            "Tensix CQ Prefetch": 21,
+            "Tensix CQ Dispatch": 19,
+            "Tensix CQ Prefetch": 22,
         },
         "wormhole_b0": {
-            "Tensix CQ Dispatch": 18,
-            "Tensix CQ Prefetch": 21,
+            "Tensix CQ Dispatch": 19,
+            "Tensix CQ Prefetch": 22,
         },
     }
 

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/common.h
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/common.h
@@ -1077,11 +1077,25 @@ inline void gen_bare_dispatcher_host_write_cmd(vector<uint32_t>& cmds, uint32_t 
     add_bare_dispatcher_cmd(cmds, cmd);
 }
 
+inline void gen_dispatcher_set_write_offset_cmd(vector<uint32_t>& cmds, uint32_t wo0, uint32_t wo1 = 0, uint32_t wo2 = 0) {
+
+    CQDispatchCmd cmd;
+    memset(&cmd, 0, sizeof(CQDispatchCmd));
+
+    cmd.base.cmd_id = CQ_DISPATCH_CMD_SET_WRITE_OFFSET;
+    cmd.set_write_offset.offset0 = wo0;
+    cmd.set_write_offset.offset1 = wo1;
+    cmd.set_write_offset.offset2 = wo2;
+    uint32_t payload_length = 0;
+    add_dispatcher_cmd(cmds, cmd, payload_length);
+}
+
 inline void gen_dispatcher_terminate_cmd(vector<uint32_t>& cmds) {
 
     CQDispatchCmd cmd;
     memset(&cmd, 0, sizeof(CQDispatchCmd));
 
     cmd.base.cmd_id = CQ_DISPATCH_CMD_TERMINATE;
-    add_dispatcher_cmd(cmds, cmd, 0);
+    uint32_t payload_length = 0;
+    add_dispatcher_cmd(cmds, cmd, payload_length);
 }

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/common.h
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/common.h
@@ -633,8 +633,8 @@ inline void generate_random_packed_payload(vector<uint32_t>& cmds,
             }
         }
 
-        cmds.resize(padded_size(cmds.size(), L1_ALIGNMENT/sizeof(uint32_t))); // XXXXX L1_ALIGNMENT16/sizeof(uint)
-        data.pad(core, bank_id, L1_ALIGNMENT); // L1_ALIGNMENT16
+        cmds.resize(padded_size(cmds.size(), L1_ALIGNMENT / sizeof(uint32_t)));
+        data.pad(core, bank_id, L1_ALIGNMENT);
         first_core = false;
     }
 }
@@ -654,7 +654,7 @@ inline void generate_random_packed_large_payload(vector<uint32_t>& generated_dat
         uint32_t datum = (use_coherent_data_g) ? ((first_worker.x << 16) | (first_worker.y << 24) | coherent_count++) : std::rand();
         generated_data.push_back(datum);
     }
-    generated_data.resize(padded_size(generated_data.size(), 4)); // XXXXX L1_ALIGNMENT16/sizeof(uint)
+    generated_data.resize(padded_size(generated_data.size(), L1_ALIGNMENT / sizeof(uint32_t)));
 
     for (uint32_t y = range.start_coord.y; y <= range.end_coord.y; y++) {
         for (uint32_t x = range.start_coord.x; x <= range.end_coord.x; x++) {
@@ -662,7 +662,7 @@ inline void generate_random_packed_large_payload(vector<uint32_t>& generated_dat
             for (uint32_t i = 0; i < size_words; i++) {
                 data.push_one(core, bank_id, generated_data[data_base + i]);
             }
-            data.pad(core, bank_id, 16); // L1_ALIGNMENT16
+            data.pad(core, bank_id, L1_ALIGNMENT);
         }
     }
 }
@@ -780,7 +780,7 @@ inline void add_dispatcher_packed_cmd(Device *device,
         CoreCoord phys_worker_core = device->worker_core_from_logical_core(core);
         cmds.push_back(NOC_XY_ENCODING(phys_worker_core.x, phys_worker_core.y));
     }
-    cmds.resize(padded_size(cmds.size(), L1_ALIGNMENT/sizeof(uint32_t))); // XXXXX L1_ALIGNMENT16/sizeof(uint)
+    cmds.resize(padded_size(cmds.size(), L1_ALIGNMENT/sizeof(uint32_t)));
 
     generate_random_packed_payload(cmds, worker_cores, device_data, size_words, repeat);
 
@@ -806,7 +806,7 @@ inline void gen_bare_dispatcher_unicast_write_cmd(Device *device,
     cmd.write_linear.length = length;
     cmd.write_linear.num_mcast_dests = 0;
 
-    TT_FATAL((cmd.write_linear.addr & (16 - 1)) == 0); // XXXXX L1_ALIGNMENT16
+    TT_FATAL((cmd.write_linear.addr & (L1_ALIGNMENT - 1)) == 0);
 
     add_bare_dispatcher_cmd(cmds, cmd);
 }
@@ -958,7 +958,7 @@ inline void gen_rnd_dispatcher_packed_write_cmd(Device *device,
     bool repeat = std::rand() % 2;
     if (repeat) {
         // TODO fix this if/when we add mcast
-        uint32_t sub_cmds_size = padded_size(gets_data.size() * sizeof(uint32_t), L1_ALIGNMENT); // L1_ALIGNMENT16
+        uint32_t sub_cmds_size = padded_size(gets_data.size() * sizeof(uint32_t), L1_ALIGNMENT);
         if (xfer_size_bytes + sizeof (CQDispatchCmd) + sub_cmds_size > dispatch_buffer_page_size_g) {
             static bool warned = false;
             if (!warned) {
@@ -985,7 +985,7 @@ inline bool gen_rnd_dispatcher_packed_write_large_cmd(Device *device,
     vector<uint32_t> sizes;
     for (int i = 0; i < ntransactions; i++) {
         constexpr uint32_t max_pages = 4;
-        uint32_t xfer_size_16b = (std::rand() % (dispatch_buffer_page_size_g * max_pages / 16)) + 1; // XXXXX L1_ALIGNMENT16
+        uint32_t xfer_size_16b = (std::rand() % (dispatch_buffer_page_size_g * max_pages / L1_ALIGNMENT)) + 1;
         uint32_t xfer_size_words = xfer_size_16b * 4;
         uint32_t xfer_size_bytes = xfer_size_words * sizeof(uint32_t);
         if (perf_test_g) {
@@ -1042,7 +1042,7 @@ inline bool gen_rnd_dispatcher_packed_write_large_cmd(Device *device,
 
         generate_random_packed_large_payload(data, range, device_data, xfer_size_bytes / sizeof(uint32_t));
     }
-    cmds.resize(padded_size(cmds.size(), 4)); // XXXXX L1_ALIGNMENT16/sizeof(uint)
+    cmds.resize(padded_size(cmds.size(), L1_ALIGNMENT / sizeof(uint32_t)));
 
     for (uint32_t datum : data) {
         cmds.push_back(datum);

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/test_prefetcher.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/test_prefetcher.cpp
@@ -615,7 +615,7 @@ void gen_linear_read_cmd(Device *device,
     for (uint32_t i = 0; i < length_words; i++) {
         device_data.push_one(worker_core, device_data.at(worker_core, bank_id, offset + i));
     }
-    device_data.pad(worker_core, bank_id, 16); // XXXX L1_ALIGNMENT
+    device_data.pad(worker_core, bank_id, L1_ALIGNMENT);
 }
 
 void gen_dispatcher_delay_cmd(Device *device,
@@ -1533,7 +1533,7 @@ void configure_for_single_chip(Device *device,
     uint32_t dispatch_buffer_base = l1_buf_base_g;
     uint32_t prefetch_d_buffer_base = l1_buf_base_g;
     uint32_t prefetch_d_buffer_pages = prefetch_d_buffer_size_g >> dispatch_constants::PREFETCH_D_BUFFER_LOG_PAGE_SIZE;
-    dispatch_wait_addr_g = l1_unreserved_base_aligned + 16;
+    dispatch_wait_addr_g = l1_unreserved_base_aligned + L1_ALIGNMENT;
     vector<uint32_t>zero_data(0);
     llrt::write_hex_vec_to_core(device->id(), phys_dispatch_core, zero_data, dispatch_wait_addr_g);
 
@@ -2120,7 +2120,7 @@ void configure_for_multi_chip(Device *device,
     uint32_t prefetch_d_buffer_pages = prefetch_d_buffer_size_g >> dispatch_constants::PREFETCH_D_BUFFER_LOG_PAGE_SIZE;
     prefetch_q_base = l1_buf_base_g;
     prefetch_q_rd_ptr_addr = l1_unreserved_base_aligned;
-    dispatch_wait_addr_g = l1_unreserved_base_aligned + 16;
+    dispatch_wait_addr_g = l1_unreserved_base_aligned + L1_ALIGNMENT;
     vector<uint32_t>zero_data(0);
     llrt::write_hex_vec_to_core(device_r->id(), phys_dispatch_core, zero_data, dispatch_wait_addr_g);
 

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/test_prefetcher.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/test_prefetcher.cpp
@@ -1204,6 +1204,18 @@ void gen_smoke_test(Device *device,
     gen_wait_and_stall_cmd(device, prefetch_cmds, cmd_sizes);
     gen_linear_read_cmd(device, prefetch_cmds, cmd_sizes, device_data, worker_core, 32, device_data.size_at(worker_core, 0) - 32 / sizeof(uint32_t));
 
+    // Touch test write offset
+    // Making sure this really works by doing a write would break lots of
+    // existing test infra, so not tested yet. TODO
+    dispatch_cmds.resize(0);
+    uint32_t write_offset = 48;
+    gen_dispatcher_set_write_offset_cmd(dispatch_cmds, write_offset);
+    add_prefetcher_cmd(prefetch_cmds, cmd_sizes, CQ_PREFETCH_CMD_RELAY_INLINE, dispatch_cmds);
+    dispatch_cmds.resize(0);
+    write_offset = 0;
+    gen_dispatcher_set_write_offset_cmd(dispatch_cmds, write_offset);
+    add_prefetcher_cmd(prefetch_cmds, cmd_sizes, CQ_PREFETCH_CMD_RELAY_INLINE, dispatch_cmds);
+
     // Test host
     if (!use_dram_exec_buf_g) {
         for (int multiplier = 1; multiplier <= 3; multiplier++) {

--- a/tt_metal/hw/inc/grayskull/dev_mem_map.h
+++ b/tt_metal/hw/inc/grayskull/dev_mem_map.h
@@ -87,8 +87,8 @@
 /////////////
 // Stack info
 // Increasing the stack size comes at the expense of less local memory for globals
-#define MEM_BRISC_STACK_SIZE 768
-#define MEM_NCRISC_STACK_SIZE 768
+#define MEM_BRISC_STACK_SIZE 752
+#define MEM_NCRISC_STACK_SIZE 752
 #define MEM_TRISC0_STACK_SIZE 256
 #define MEM_TRISC1_STACK_SIZE 256
 #define MEM_TRISC2_STACK_SIZE 768

--- a/tt_metal/impl/CMakeLists.txt
+++ b/tt_metal/impl/CMakeLists.txt
@@ -14,6 +14,7 @@ set(IMPL_SRC
 	${CMAKE_CURRENT_SOURCE_DIR}/program/program.cpp
 	${CMAKE_CURRENT_SOURCE_DIR}/dispatch/debug_tools.cpp
 	${CMAKE_CURRENT_SOURCE_DIR}/dispatch/command_queue.cpp
+	${CMAKE_CURRENT_SOURCE_DIR}/dispatch/worker_config_buffer.cpp
 	${CMAKE_CURRENT_SOURCE_DIR}/debug/dprint_server.cpp
 	${CMAKE_CURRENT_SOURCE_DIR}/debug/watcher_server.cpp
 	${CMAKE_CURRENT_SOURCE_DIR}/trace/trace.cpp

--- a/tt_metal/impl/dispatch/command_queue.cpp
+++ b/tt_metal/impl/dispatch/command_queue.cpp
@@ -40,6 +40,12 @@ std::condition_variable finish_cv;
 
 namespace tt::tt_metal {
 
+enum DispatchWriteOffsets {
+    DISPATCH_WRITE_OFFSET_ZERO = 0,
+    DISPATCH_WRITE_OFFSET_TENSIX_L1_CONFIG_BASE = 1,
+    DISPATCH_WRITE_OFFSET_ETH_L1_CONFIG_BASE = 2,
+};
+
 // TODO: Delete entries when programs are deleted to save memory
 thread_local std::unordered_map<uint64_t, EnqueueProgramCommand::CachedProgramCommandSequence>
     EnqueueProgramCommand::cached_program_command_sequences = {};
@@ -305,14 +311,18 @@ EnqueueProgramCommand::EnqueueProgramCommand(
     this->packed_write_max_unicast_sub_cmds = get_packed_write_max_unicast_sub_cmds(this->device);
 }
 
-void EnqueueProgramCommand::assemble_preamble_commands(bool prefetch_stall) {
+void EnqueueProgramCommand::assemble_preamble_commands(
+    bool prefetch_stall,
+    uint32_t tensix_l1_config_base,
+    uint32_t eth_l1_config_base) {
     if (prefetch_stall) {
         // Wait command so previous program finishes
         // Wait command with barrier for binaries to commit to DRAM
         // Prefetch stall to prevent prefetcher picking up incomplete binaries from DRAM
         constexpr uint32_t uncached_cmd_sequence_sizeB =
             CQ_PREFETCH_CMD_BARE_MIN_SIZE +  // CQ_PREFETCH_CMD_RELAY_INLINE + CQ_DISPATCH_CMD_WAIT
-            CQ_PREFETCH_CMD_BARE_MIN_SIZE;   // CQ_PREFETCH_CMD_STALL
+            CQ_PREFETCH_CMD_BARE_MIN_SIZE +  // CQ_PREFETCH_CMD_STALL
+            CQ_PREFETCH_CMD_BARE_MIN_SIZE;   // CQ_PREFETCH_CMD_RELAY_INLINE + CQ_DISPATCH_CMD_SET_WRITE_OFFSET
 
         this->cached_program_command_sequences[program.id].preamble_command_sequence =
             HostMemDeviceCommand(uncached_cmd_sequence_sizeB);
@@ -328,12 +338,18 @@ void EnqueueProgramCommand::assemble_preamble_commands(bool prefetch_stall) {
     } else {
         // Wait command so previous program finishes
         constexpr uint32_t cached_cmd_sequence_sizeB =
-            CQ_PREFETCH_CMD_BARE_MIN_SIZE;  // CQ_PREFETCH_CMD_RELAY_INLINE + CQ_DISPATCH_CMD_WAIT
+            CQ_PREFETCH_CMD_BARE_MIN_SIZE +  // CQ_PREFETCH_CMD_RELAY_INLINE + CQ_DISPATCH_CMD_WAIT
+            CQ_PREFETCH_CMD_BARE_MIN_SIZE;   // CQ_PREFETCH_CMD_RELAY_INLINE + CQ_DISPATCH_CMD_SET_WRITE_OFFSET
+
         this->cached_program_command_sequences[program.id].preamble_command_sequence =
             HostMemDeviceCommand(cached_cmd_sequence_sizeB);
         this->cached_program_command_sequences[program.id].preamble_command_sequence.add_dispatch_wait(
             false, DISPATCH_MESSAGE_ADDR, this->expected_num_workers_completed);
     }
+
+    // Send write offsets
+    this->cached_program_command_sequences[program.id].preamble_command_sequence.add_dispatch_set_write_offsets(
+        0, tensix_l1_config_base, eth_l1_config_base);
 }
 
 template <typename PackedSubCmd>
@@ -393,7 +409,8 @@ void generate_runtime_args_cmds(
     std::vector<std::vector<std::reference_wrapper<RuntimeArgsData>>>& rt_args_data,
     const uint32_t max_prefetch_command_size,
     const uint32_t packed_write_max_unicast_sub_cmds,
-    bool no_stride = false) {
+    bool no_stride,
+    enum DispatchWriteOffsets write_offset_index) {
     static_assert(
         std::is_same<PackedSubCmd, CQDispatchWritePackedUnicastSubCmd>::value or
         std::is_same<PackedSubCmd, CQDispatchWritePackedMulticastSubCmd>::value);
@@ -440,7 +457,8 @@ void generate_runtime_args_cmds(
             rt_data_and_sizes,
             packed_write_max_unicast_sub_cmds,
             offset_idx,
-            no_stride);
+            no_stride,
+            write_offset_index);
 
         // Update kernel RTA pointers to point into the generated command
         // Future RTA updates through the API will update the command sequence directly
@@ -492,7 +510,7 @@ void EnqueueProgramCommand::assemble_runtime_args_commands() {
             }
         }
         for (int dispatch_class = 0; dispatch_class < DISPATCH_CLASS_MAX; dispatch_class++) {
-            uint32_t common_size = program.crta_sizes[core_type == CoreType::WORKER][dispatch_class];
+            uint32_t common_size = program.get_program_config(core_type).crta_sizes[dispatch_class];
             if (common_size != 0) {
                 command_count++;
             }
@@ -500,7 +518,6 @@ void EnqueueProgramCommand::assemble_runtime_args_commands() {
     }
 
     this->cached_program_command_sequences[program.id].runtime_args_command_sequences.reserve(command_count);
-
     // Unique Runtime Args (Unicast)
     for (CoreType core_type : core_types) {
         for (auto& kg : program.get_kernel_groups(core_type)) {
@@ -536,26 +553,20 @@ void EnqueueProgramCommand::assemble_runtime_args_commands() {
                         }
                     }
                 }
-
-                // TODO: eventually get this from the dispatch ring buffer
-                uint32_t kernel_config_base;
-                if (core_type == CoreType::WORKER) {
-                    kernel_config_base = L1_KERNEL_CONFIG_BASE;
-                } else {
-                    TT_ASSERT(core_type == CoreType::ETH);
-                    kernel_config_base = eth_l1_mem::address_map::ERISC_L1_KERNEL_CONFIG_BASE;
-                }
-
+                uint32_t rta_offset = program.get_program_config(core_type).rta_offset;
                 generate_runtime_args_cmds(
                     this->cached_program_command_sequences[program.id].runtime_args_command_sequences,
-                    kernel_config_base,
+                    rta_offset,
                     unique_sub_cmds,
                     unique_rt_data_and_sizes,
                     kg.total_rta_size / sizeof(uint32_t),
                     unique_rt_args_data,
                     max_prefetch_command_size,
                     packed_write_max_unicast_sub_cmds,
-                    false);
+                    false,
+                    core_type == CoreType::WORKER ?
+                        DISPATCH_WRITE_OFFSET_TENSIX_L1_CONFIG_BASE :
+                        DISPATCH_WRITE_OFFSET_ETH_L1_CONFIG_BASE);
                 unique_sub_cmds.clear();
                 unique_rt_data_and_sizes.clear();
                 unique_rt_args_data.clear();
@@ -563,7 +574,7 @@ void EnqueueProgramCommand::assemble_runtime_args_commands() {
         }
 
         for (int dispatch_class = 0; dispatch_class < DISPATCH_CLASS_MAX; dispatch_class++) {
-            uint32_t common_size = program.crta_sizes[core_type == CoreType::WORKER][dispatch_class];
+            uint32_t common_size = program.get_program_config(core_type).crta_sizes[dispatch_class];
             for (size_t kernel_id = 0; kernel_id < program.num_kernels(); kernel_id++) {
                 auto kernel = detail::GetKernel(program, kernel_id);
                 if (kernel->get_kernel_core_type() != core_type)
@@ -614,11 +625,7 @@ void EnqueueProgramCommand::assemble_runtime_args_commands() {
             }
 
             if (common_size != 0) {
-                uint32_t common_offset = program.crta_offsets[core_type == CoreType::WORKER][dispatch_class];
-
-                uint32_t common_args_addr = (core_type == CoreType::ETH)
-                                                ? eth_l1_mem::address_map::ERISC_L1_KERNEL_CONFIG_BASE + common_offset
-                                                : L1_KERNEL_CONFIG_BASE + common_offset;
+                uint32_t crta_offset = program.get_program_config(core_type).crta_offsets[dispatch_class];
 
                 // Common rtas are always expected to fit in one prefetch cmd
                 // TODO: use a linear write instead of a packed-write
@@ -626,14 +633,17 @@ void EnqueueProgramCommand::assemble_runtime_args_commands() {
                     [&](auto&& sub_cmds) {
                         generate_runtime_args_cmds(
                             this->cached_program_command_sequences[program.id].runtime_args_command_sequences,
-                            common_args_addr,
+                            crta_offset,
                             sub_cmds,
                             common_rt_data_and_sizes,
                             common_size / sizeof(uint32_t),
                             common_rt_args_data,
                             max_prefetch_command_size,
                             packed_write_max_unicast_sub_cmds,
-                            true);
+                            true,
+                            core_type == CoreType::WORKER ?
+                                DISPATCH_WRITE_OFFSET_TENSIX_L1_CONFIG_BASE :
+                                DISPATCH_WRITE_OFFSET_ETH_L1_CONFIG_BASE);
                         sub_cmds.clear();
                     },
                     common_sub_cmds);
@@ -652,9 +662,13 @@ void EnqueueProgramCommand::assemble_runtime_args_commands() {
     this->cached_program_command_sequences[program.id].runtime_args_fetch_size_bytes = runtime_args_fetch_size_bytes;
 }
 
-void EnqueueProgramCommand::assemble_device_commands() {
+void EnqueueProgramCommand::assemble_device_commands(
+    bool is_cached,
+    uint32_t tensix_l1_kernel_config_base,
+    uint32_t eth_l1_kernel_config_base) {
+
     auto& cached_program_command_sequence = this->cached_program_command_sequences[this->program.id];
-    if (!program.is_finalized()) {
+    if (not is_cached) {
         // Calculate size of command and fill program indices of data to update
         // TODO: Would be nice if we could pull this out of program
         uint32_t cmd_sequence_sizeB = 0;
@@ -932,6 +946,7 @@ void EnqueueProgramCommand::assemble_device_commands() {
             kernel_group.launch_msg.kernel_config.mode = DISPATCH_MODE_DEV;
             kernel_group.launch_msg.kernel_config.dispatch_core_x = this->dispatch_core.x;
             kernel_group.launch_msg.kernel_config.dispatch_core_y = this->dispatch_core.y;
+            kernel_group.launch_msg.kernel_config.kernel_config_base = tensix_l1_kernel_config_base;
             const void* launch_message_data = (const void*)(&kernel_group.launch_msg);
             for (const CoreRange& core_range : kernel_group.core_ranges.ranges()) {
                 CoreCoord physical_start =
@@ -943,6 +958,7 @@ void EnqueueProgramCommand::assemble_device_commands() {
                     .noc_xy_addr = this->device->get_noc_multicast_encoding(
                         this->noc_index, CoreRange(physical_start, physical_end)),
                     .num_mcast_dests = (uint32_t)core_range.size()});
+
                 multicast_go_signal_data.emplace_back(launch_message_data, go_signal_sizeB);
             }
         }
@@ -959,6 +975,7 @@ void EnqueueProgramCommand::assemble_device_commands() {
             kernel_group.launch_msg.kernel_config.mode = DISPATCH_MODE_DEV;
             kernel_group.launch_msg.kernel_config.dispatch_core_x = this->dispatch_core.x;
             kernel_group.launch_msg.kernel_config.dispatch_core_y = this->dispatch_core.y;
+            kernel_group.launch_msg.kernel_config.kernel_config_base = eth_l1_kernel_config_base;
             const void* launch_message_data = (const launch_msg_t*)(&kernel_group.launch_msg);
             for (const CoreRange& core_range : kernel_group.core_ranges.ranges()) {
                 for (auto x = core_range.start_coord.x; x <= core_range.end_coord.x; x++) {
@@ -1144,36 +1161,64 @@ void EnqueueProgramCommand::assemble_device_commands() {
             }
             i++;
         }
+        uint32_t go_signal_count = 0;
         for (auto& go_signal : cached_program_command_sequence.go_signals) {
             go_signal->kernel_config.dispatch_core_x = this->dispatch_core.x;
             go_signal->kernel_config.dispatch_core_y = this->dispatch_core.y;
+            if (go_signal_count < program.tensix_go_signal_count_) {
+                go_signal->kernel_config.kernel_config_base = tensix_l1_kernel_config_base;
+            } else {
+                go_signal->kernel_config.kernel_config_base = eth_l1_kernel_config_base;
+            }
+            go_signal_count++;
         }
     }
 }
 
 void EnqueueProgramCommand::process() {
-    // Calculate all commands size and determine how many fetch q entries to use
 
+    bool is_cached = true;
+    if (not program.is_finalized()) {
+        program.finalize();
+        is_cached = false;
+    }
+
+    const std::pair<ConfigBufferSync, std::vector<ConfigBufferEntry>&> reservation =
+        this->manager.get_config_buffer_mgr().reserve(program.program_config_sizes_);
+    this->manager.get_config_buffer_mgr().free(reservation.first.sync_count);
+    this->manager.get_config_buffer_mgr().alloc(this->expected_num_workers_completed +
+                                                program.program_transfer_info.num_active_cores);
+
+    uint32_t tensix_l1_write_offset = reservation.second[0].addr;
+    uint32_t eth_l1_write_offset = reservation.second[1].addr;
+
+    // Calculate all commands size and determine how many fetch q entries to use
     // Preamble, some waits and stalls
     // can be written directly to the issue queue
-    if (not program.is_finalized()) {
-        // TODO: only build kernel groups here, remove on-the-fly state validation and validate here
-        program.finalize_rt_args();
-
-        this->assemble_preamble_commands(true);
+    if (not is_cached) {
+        this->assemble_preamble_commands(true, tensix_l1_write_offset, eth_l1_write_offset);
         // Runtime Args Command Sequence
         this->assemble_runtime_args_commands();
-        // Main Command Sequence
-        this->assemble_device_commands();
     } else {
-        static constexpr uint32_t count_offset = (sizeof(CQPrefetchCmd) + offsetof(CQDispatchCmd, wait.count));
+        static constexpr uint32_t wait_count_offset = (sizeof(CQPrefetchCmd) + offsetof(CQDispatchCmd, wait.count));
+        static constexpr uint32_t tensix_l1_write_offset_offset =
+            CQ_PREFETCH_CMD_BARE_MIN_SIZE + (sizeof(CQPrefetchCmd) + offsetof(CQDispatchCmd, set_write_offset.offset1));
+        static constexpr uint32_t eth_l1_write_offset_offset =
+            CQ_PREFETCH_CMD_BARE_MIN_SIZE + (sizeof(CQPrefetchCmd) + offsetof(CQDispatchCmd, set_write_offset.offset2));
         TT_ASSERT(
             this->cached_program_command_sequences.find(program.id) != this->cached_program_command_sequences.end(),
             "Program cache hit, but no stored command sequence");
+
         this->cached_program_command_sequences[program.id].preamble_command_sequence.update_cmd_sequence(
-            count_offset, &this->expected_num_workers_completed, sizeof(uint32_t));
-        this->assemble_device_commands();
+            wait_count_offset, &this->expected_num_workers_completed, sizeof(uint32_t));
+        this->cached_program_command_sequences[program.id].preamble_command_sequence.update_cmd_sequence(
+            tensix_l1_write_offset_offset, &tensix_l1_write_offset, sizeof(uint32_t));
+        this->cached_program_command_sequences[program.id].preamble_command_sequence.update_cmd_sequence(
+            eth_l1_write_offset_offset, &eth_l1_write_offset, sizeof(uint32_t));
     }
+
+    // Main Command Sequence
+    this->assemble_device_commands(is_cached, tensix_l1_write_offset, eth_l1_write_offset);
 
     const auto& cached_program_command_sequence = this->cached_program_command_sequences[program.id];
 
@@ -1242,9 +1287,8 @@ void EnqueueProgramCommand::process() {
     }
 
     // Front load generating and caching preamble without stall during program loading stage
-    if (not program.is_finalized()) {
-        this->assemble_preamble_commands(false);
-        program.set_finalized();
+    if (not is_cached) {
+        this->assemble_preamble_commands(false, 0, 0);
     }
 }
 
@@ -1459,7 +1503,9 @@ void EnqueueTerminateCommand::process() {
 
 // HWCommandQueue section
 HWCommandQueue::HWCommandQueue(Device* device, uint32_t id, NOC noc_index) :
-    manager(device->sysmem_manager()), completion_queue_thread{} {
+    manager(device->sysmem_manager()),
+    completion_queue_thread{} {
+
     ZoneScopedN("CommandQueue_constructor");
     this->device = device;
     this->id = id;

--- a/tt_metal/impl/dispatch/command_queue.hpp
+++ b/tt_metal/impl/dispatch/command_queue.hpp
@@ -313,8 +313,8 @@ class EnqueueProgramCommand : public Command {
         SystemMemoryManager& manager,
         uint32_t expected_num_workers_completed);
 
-    void assemble_preamble_commands(bool prefetch_stall);
-    void assemble_device_commands();
+    void assemble_preamble_commands(bool prefetch_stall, uint32_t tensix_l1_config_base, uint32_t eth_l1_config_base);
+    void assemble_device_commands(bool is_cached, uint32_t tensix_l1_kernel_config_base, uint32_t eth_l1_kernel_config_base);
     void assemble_runtime_args_commands();
 
     void process();

--- a/tt_metal/impl/dispatch/command_queue.hpp
+++ b/tt_metal/impl/dispatch/command_queue.hpp
@@ -295,6 +295,7 @@ class EnqueueProgramCommand : public Command {
    public:
     struct CachedProgramCommandSequence {
         HostMemDeviceCommand preamble_command_sequence;
+        HostMemDeviceCommand stall_command_sequence;
         std::vector<HostMemDeviceCommand> runtime_args_command_sequences;
         uint32_t runtime_args_fetch_size_bytes;
         HostMemDeviceCommand program_command_sequence;
@@ -313,7 +314,8 @@ class EnqueueProgramCommand : public Command {
         SystemMemoryManager& manager,
         uint32_t expected_num_workers_completed);
 
-    void assemble_preamble_commands(bool prefetch_stall, uint32_t tensix_l1_config_base, uint32_t eth_l1_config_base);
+    void assemble_preamble_commands(uint32_t tensix_l1_config_base, uint32_t eth_l1_config_base);
+    void assemble_stall_commands(bool prefetch_stall);
     void assemble_device_commands(bool is_cached, uint32_t tensix_l1_kernel_config_base, uint32_t eth_l1_kernel_config_base);
     void assemble_runtime_args_commands();
 

--- a/tt_metal/impl/dispatch/command_queue_interface.hpp
+++ b/tt_metal/impl/dispatch/command_queue_interface.hpp
@@ -10,6 +10,7 @@
 #include "tt_metal/impl/dispatch/cq_commands.hpp"
 #include "tt_metal/impl/dispatch/dispatch_address_map.hpp"
 #include "tt_metal/impl/dispatch/dispatch_core_manager.hpp"
+#include "tt_metal/impl/dispatch/worker_config_buffer.hpp"
 #include "tt_metal/llrt/llrt.hpp"
 
 using namespace tt::tt_metal;
@@ -347,6 +348,8 @@ class SystemMemoryManager {
     vector<uint32_t> bypass_buffer;
     uint32_t bypass_buffer_write_offset;
 
+    WorkerConfigBufferMgr config_buffer_mgr;
+
    public:
     SystemMemoryManager(chip_id_t device_id, uint8_t num_hw_cqs) :
         device_id(device_id),
@@ -354,7 +357,9 @@ class SystemMemoryManager {
         m_dma_buf_size(tt::Cluster::instance().get_m_dma_buf_size(device_id)),
         fast_write_callable(tt::Cluster::instance().get_fast_pcie_static_tlb_write_callable(device_id)),
         bypass_enable(false),
-        bypass_buffer_write_offset(0) {
+        bypass_buffer_write_offset(0),
+        config_buffer_mgr({{L1_KERNEL_CONFIG_BASE, eth_l1_mem::address_map::ERISC_L1_KERNEL_CONFIG_BASE}, {L1_KERNEL_CONFIG_SIZE, eth_l1_mem::address_map::ERISC_L1_KERNEL_CONFIG_SIZE}}) {
+
         this->completion_byte_addrs.resize(num_hw_cqs);
         this->prefetcher_cores.resize(num_hw_cqs);
         this->prefetch_q_writers.reserve(num_hw_cqs);
@@ -720,4 +725,7 @@ class SystemMemoryManager {
         this->prefetch_q_writers[cq_id].write(this->prefetch_q_dev_ptrs[cq_id], command_size_16B);
         this->prefetch_q_dev_ptrs[cq_id] += sizeof(dispatch_constants::prefetch_q_entry_type);
     }
+
+    WorkerConfigBufferMgr& get_config_buffer_mgr() { return config_buffer_mgr; }
+
 };

--- a/tt_metal/impl/dispatch/cq_commands.hpp
+++ b/tt_metal/impl/dispatch/cq_commands.hpp
@@ -201,7 +201,7 @@ struct CQDispatchWritePackedLargeSubCmd {
     uint16_t num_mcast_dests;
 } __attribute__((packed));
 
-inline __attribute__((always_inline)) uint32_t get_packed_write_max_multicast_sub_cmds(uint32_t packed_write_max_unicast_sub_cmds) {
+constexpr inline __attribute__((always_inline)) uint32_t get_packed_write_max_multicast_sub_cmds(uint32_t packed_write_max_unicast_sub_cmds) {
     uint32_t packed_write_max_multicast_sub_cmds = packed_write_max_unicast_sub_cmds * sizeof(CQDispatchWritePackedUnicastSubCmd) / sizeof(CQDispatchWritePackedMulticastSubCmd);
     return packed_write_max_multicast_sub_cmds;
 }

--- a/tt_metal/impl/dispatch/device_command.hpp
+++ b/tt_metal/impl/dispatch/device_command.hpp
@@ -369,11 +369,14 @@ class DeviceCommand {
         }
     }
 
-    void add_dispatch_set_writeoffset(uint32_t write_offset) {
+    void add_dispatch_set_write_offsets(uint32_t write_offset0, uint32_t write_offset1, uint32_t write_offset2) {
         this->add_prefetch_relay_inline(true, sizeof(CQDispatchCmd));
         auto initialize_write_offset_cmd = [&](CQDispatchCmd *write_offset_cmd) {
             *write_offset_cmd = {};
             write_offset_cmd->base.cmd_id = CQ_DISPATCH_CMD_SET_WRITE_OFFSET;
+            write_offset_cmd->set_write_offset.offset0 = write_offset0;
+            write_offset_cmd->set_write_offset.offset1 = write_offset1;
+            write_offset_cmd->set_write_offset.offset2 = write_offset2;
         };
         CQDispatchCmd *write_offset_cmd_dst = this->reserve_space<CQDispatchCmd *>(sizeof(CQDispatchCmd));
 
@@ -542,7 +545,8 @@ class DeviceCommand {
         const std::vector<std::vector<std::tuple<const void *, uint32_t, uint32_t>>> &data_collection,
         uint32_t packed_write_max_unicast_sub_cmds,
         const uint32_t offset_idx = 0,
-        const bool no_stride = false) {
+        const bool no_stride = false,
+        uint32_t write_offset_index = 0) {
         static_assert(
             std::is_same<PackedSubCmd, CQDispatchWritePackedUnicastSubCmd>::value or
             std::is_same<PackedSubCmd, CQDispatchWritePackedMulticastSubCmd>::value);
@@ -565,6 +569,7 @@ class DeviceCommand {
                 (multicast ? CQ_DISPATCH_CMD_PACKED_WRITE_FLAG_MCAST : CQ_DISPATCH_CMD_PACKED_WRITE_FLAG_NONE) |
                 (no_stride ? CQ_DISPATCH_CMD_PACKED_WRITE_FLAG_NO_STRIDE : CQ_DISPATCH_CMD_PACKED_WRITE_FLAG_NONE);
             write_packed_cmd->write_packed.count = num_sub_cmds;
+            write_packed_cmd->write_packed.write_offset_index = write_offset_index;
             write_packed_cmd->write_packed.addr = common_addr;
             write_packed_cmd->write_packed.size = packed_data_sizeB;
         };

--- a/tt_metal/impl/dispatch/kernels/cq_dispatch.cpp
+++ b/tt_metal/impl/dispatch/kernels/cq_dispatch.cpp
@@ -78,7 +78,7 @@ static uint32_t cmd_ptr;   // walks through pages in cb cmd by cmd
 
 static uint32_t downstream_cb_data_ptr = downstream_cb_base;
 
-uint32_t packed_write_max_multicast_sub_cmds = get_packed_write_max_multicast_sub_cmds(packed_write_max_unicast_sub_cmds);
+constexpr uint32_t packed_write_max_multicast_sub_cmds = get_packed_write_max_multicast_sub_cmds(packed_write_max_unicast_sub_cmds);
 constexpr uint32_t max_write_packed_large_cmd =
     CQ_DISPATCH_CMD_PACKED_WRITE_LARGE_MAX_SUB_CMDS *
     sizeof(CQDispatchWritePackedLargeSubCmd) / sizeof(uint32_t);

--- a/tt_metal/impl/dispatch/worker_config_buffer.cpp
+++ b/tt_metal/impl/dispatch/worker_config_buffer.cpp
@@ -122,8 +122,6 @@ const std::pair<ConfigBufferSync, std::vector<ConfigBufferEntry>&> WorkerConfigB
 // Repeatedly move free_index up until it catches up w/ the reserved sync_counts or alloc_index
 void WorkerConfigBufferMgr::free(uint32_t free_up_to_sync_count) {
 
-    TT_ASSERT(this->alloc_index_ != this->free_index_);
-
     size_t num_core_types = this->reservation_.size();
     for (uint32_t idx = 0; idx < num_core_types; idx++) {
         uint32_t free_index = this->free_index_[idx];

--- a/tt_metal/impl/dispatch/worker_config_buffer.cpp
+++ b/tt_metal/impl/dispatch/worker_config_buffer.cpp
@@ -1,0 +1,168 @@
+// SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "tt_metal/common/assert.hpp"
+#include "tt_metal/impl/dispatch/worker_config_buffer.hpp"
+
+namespace tt {
+
+namespace tt_metal {
+
+constexpr uint32_t kernel_config_entry_count = 8;
+
+WorkerConfigBufferMgr::WorkerConfigBufferMgr(const std::vector<uint32_t>& base_addrs, const std::vector<uint32_t>& sizes) {
+
+    size_t num_core_types = sizes.size();
+    TT_ASSERT(base_addrs.size() == sizes.size());
+
+    this->base_addrs_ = base_addrs;
+    this->end_addrs_.resize(num_core_types);
+    for (uint32_t idx = 0; idx < num_core_types; idx++) {
+        this->end_addrs_[idx] = base_addrs[idx] + sizes[idx];
+    }
+
+    entries_.resize(kernel_config_entry_count);
+    for (auto& entry : this->entries_) {
+        entry.resize(num_core_types, {0, 0});
+    }
+
+    // when free == alloc, buffer is empty
+    // entries[alloc_index].addr is always the next address
+    this->alloc_index_.resize(num_core_types);
+    this->free_index_.resize(num_core_types);
+    for (uint32_t idx = 0; idx < num_core_types; idx++) {
+        this->alloc_index_[idx] = 0;
+        this->free_index_[idx] = 0;
+        this->entries_[0][idx].addr = base_addrs[idx];
+    }
+
+    this->reservation_.resize(num_core_types);
+}
+
+// First part of returned pair is true if reserving size bytes requires a sync on some core type
+// The vector contains whether or not the core type needs a sync and if so the sync value
+// To avoid allocs in a perf path, returns a reference to internal data
+const std::pair<ConfigBufferSync, std::vector<ConfigBufferEntry>&> WorkerConfigBufferMgr::reserve(
+    const std::vector<uint32_t>& sizes) {
+
+    ConfigBufferSync sync_info;
+    sync_info.need_sync = false;
+
+    size_t num_core_types = this->reservation_.size();
+    TT_ASSERT(sizes.size() == num_core_types);
+    for (uint32_t idx = 0; idx < num_core_types; idx++) {
+        uint32_t free_index = this->free_index_[idx];
+        uint32_t alloc_index = this->alloc_index_[idx];
+
+        bool done = false;
+        while (!done) {
+            done = true;
+
+            uint32_t size = sizes[idx];
+            uint32_t addr = this->entries_[alloc_index][idx].addr;
+
+            this->reservation_[idx].size = size;
+            if (size == 0) {
+                this->reservation_[idx].addr = addr;
+                break;
+            }
+            TT_ASSERT(size <= this->end_addrs_[idx] - this->base_addrs_[idx]);
+
+            // alloc_index may be ahead or behind free_index
+            // so compare to either end of buffer or next to be freed addr
+            uint32_t end = (addr >= this->entries_[free_index][idx].addr) ?
+                this->end_addrs_[idx] :
+                this->entries_[free_index][idx].addr;
+
+            if (addr + size > end && end == this->end_addrs_[idx]) {
+                // Wrap the ring buffer
+                addr = this->base_addrs_[idx];
+                end = this->entries_[free_index][idx].addr;
+            }
+
+            if (addr + size > end) {
+                // Need a sync...but will this entry free enough space?  Look at the next
+                uint32_t next_free_index = free_index + 1;
+                if (next_free_index == kernel_config_entry_count) {
+                    next_free_index = 0;
+                }
+
+                if (next_free_index == alloc_index) {
+                    // The sync will free the whole buffer, reset to the top
+                    addr = this->base_addrs_[idx];
+                } else {
+                    uint32_t next_end = (addr >= this->entries_[next_free_index][idx].addr) ?
+                        this->end_addrs_[idx] :
+                        this->entries_[next_free_index][idx].addr;
+                    if (addr + size > next_end) {
+                        // Need to free multiple entries
+                        // Move the free index forward to the next entry and retry
+                        free_index = next_free_index;
+                        done = false;
+                        continue;
+                    }
+                }
+
+                sync_info.need_sync = true;
+            } else if (alloc_index + 1 == free_index ||
+                       (alloc_index + 1 == kernel_config_entry_count && free_index == 0)) {
+                // We need a sync because the table of entries is too small
+                sync_info.need_sync = true;
+            }
+
+            sync_info.sync_count = this->entries_[free_index][idx].sync_count;
+            this->reservation_[idx].addr = addr;
+        }
+    }
+
+    return std::pair<ConfigBufferSync, std::vector<ConfigBufferEntry>&>(sync_info, this->reservation_);
+}
+
+// Repeatedly move free_index up until it catches up w/ the reserved sync_counts or alloc_index
+void WorkerConfigBufferMgr::free(uint32_t free_up_to_sync_count) {
+
+    TT_ASSERT(this->alloc_index_ != this->free_index_);
+
+    size_t num_core_types = this->reservation_.size();
+    for (uint32_t idx = 0; idx < num_core_types; idx++) {
+        uint32_t free_index = this->free_index_[idx];
+        if (free_up_to_sync_count >= this->entries_[free_index][idx].sync_count) {
+            if (free_index != this->alloc_index_[idx]) {
+                free_index++;
+                if (free_index == kernel_config_entry_count) {
+                    free_index = 0;
+                }
+                this->free_index_[idx] = free_index;
+            }
+        }
+    }
+}
+
+void WorkerConfigBufferMgr::alloc(uint32_t when_freeable_sync_count) {
+
+    size_t num_core_types = this->reservation_.size();
+    for (uint32_t idx = 0; idx < num_core_types; idx++) {
+        uint32_t alloc_index = this->alloc_index_[idx];
+
+        this->entries_[alloc_index][idx].addr = this->reservation_[idx].addr;
+        this->entries_[alloc_index][idx].size = this->reservation_[idx].size;
+        this->entries_[alloc_index][idx].sync_count = when_freeable_sync_count;
+
+        uint32_t old_alloc_index = alloc_index;
+        alloc_index++;
+        if (alloc_index == kernel_config_entry_count) {
+            alloc_index = 0;
+        }
+
+        this->entries_[alloc_index][idx].addr = this->entries_[old_alloc_index][idx].addr + this->entries_[old_alloc_index][idx].size;
+        this->entries_[alloc_index][idx].size = 0;
+        this->entries_[alloc_index][idx].sync_count = 0xbabababa; // debug
+
+        this->alloc_index_[idx] = alloc_index;
+    }
+}
+
+}  // namespace tt_metal
+
+}  // namespace tt

--- a/tt_metal/impl/dispatch/worker_config_buffer.hpp
+++ b/tt_metal/impl/dispatch/worker_config_buffer.hpp
@@ -1,0 +1,54 @@
+// SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <cstdint>
+#include <vector>
+
+namespace tt {
+
+namespace tt_metal {
+
+struct ConfigBufferEntry {
+    uint32_t addr;
+    uint32_t size;
+    uint32_t sync_count;
+};
+
+struct ConfigBufferSync {
+    bool need_sync;
+    uint32_t sync_count;
+};
+
+// Manages the kernel configuration buffer on the device
+// Interface is stateful, use in the sequence below
+//
+// Usage:
+//   construct with vectors of the kernel config buffer base address and size for each managed CoreType
+//   call reserve to reserve space for each CoreType, returns true if sync is required (along w/ sync values)
+//   issue a sync for each CoreType that needs a sync
+//   call free to free the memory just synced (mandatory whenever a client does a sync)
+//   call alloc with the new sync values to allocate the memory for each CoreType
+//
+class WorkerConfigBufferMgr {
+  public:
+    WorkerConfigBufferMgr(const std::vector<uint32_t>& base_addrs, const std::vector<uint32_t>& sizes);
+
+    const std::pair<ConfigBufferSync, std::vector<ConfigBufferEntry>&> reserve(const std::vector<uint32_t>& sizes);
+    void free(uint32_t free_up_to_sync_count);
+    void alloc(uint32_t when_freeable_sync_count);
+
+  private:
+    std::vector<uint32_t> base_addrs_;
+    std::vector<uint32_t> end_addrs_;
+    std::vector<std::vector<ConfigBufferEntry>> entries_;  // ring buffer of allocated space
+    std::vector<uint32_t> alloc_index_;  // always points to a valid entry
+    std::vector<uint32_t> free_index_;   // points to the next entry to free
+
+    std::vector<ConfigBufferEntry> reservation_;
+};
+
+}  // namespace tt_metal
+}  // namespace tt

--- a/tt_metal/impl/program/program.cpp
+++ b/tt_metal/impl/program/program.cpp
@@ -81,7 +81,7 @@ void DisablePersistentKernelCache() { enable_persistent_kernel_cache = false; }
 std::atomic<uint64_t> Program::program_counter = 0;
 
 Program::Program() :
-    id(program_counter++), worker_crs_({}), local_circular_buffer_allocation_needed_(false), loaded_onto_device(false) {
+    id(program_counter++), worker_crs_({}), local_circular_buffer_allocation_needed_(false), finalized_(false) {
     std::set<CoreType> supported_core_types = {CoreType::WORKER, CoreType::ETH};
     for (const auto &core_type : supported_core_types) {
         kernels_.insert({core_type, {}});
@@ -89,6 +89,10 @@ Program::Program() :
         kernel_groups_.insert({core_type, {}});
         core_to_kernel_group_index_table_.insert({core_type, {}});
     }
+
+    static constexpr uint32_t num_dispatchable_core_types = 2;
+    program_configs_.resize(num_dispatchable_core_types);
+    program_config_sizes_.resize(num_dispatchable_core_types);
 }
 
 KernelHandle Program::add_kernel(std::shared_ptr<Kernel> kernel, const CoreType &core_type) {
@@ -132,12 +136,12 @@ KernelGroup::KernelGroup(
 
     std::memset(&this->launch_msg, 0, sizeof(launch_msg_t));
 
-    // The code below sets the brisc_noc_id for use by the device firmware
-    // Use 0 if neither brisc nor ncrisc specify a noc
+    // Slow dispatch uses fixed addresses for the kernel config, configured here statically
+    // Fast dispatch kernel config mangement happens under the CQ and will re-program the base
     if (core_type == CoreType::WORKER) {
-        // Dynamic address map
         this->launch_msg.kernel_config.kernel_config_base = L1_KERNEL_CONFIG_BASE;
     } else {
+        TT_ASSERT(core_type == CoreType::ETH);
         this->launch_msg.kernel_config.kernel_config_base =
             erisc_is_idle ? IDLE_ERISC_L1_KERNEL_CONFIG_BASE : eth_l1_mem::address_map::ERISC_L1_KERNEL_CONFIG_BASE;
     }
@@ -150,6 +154,8 @@ KernelGroup::KernelGroup(
             this->launch_msg.kernel_config.enables |= 1 << class_id;
 
             if (core_type == CoreType::WORKER) {
+                // The code below sets the brisc_noc_id for use by the device firmware
+                // Use 0 if neither brisc nor ncrisc specify a noc
                 if (class_id == DISPATCH_CLASS_TENSIX_DM0) {
                     // Use brisc's noc if brisc specifies a noc
                     this->launch_msg.kernel_config.brisc_noc_id = std::get<DataMovementConfig>(kernel->config()).noc;
@@ -763,98 +769,132 @@ void Program::populate_dispatch_data(Device *device) {
 template <typename T, std::size_t dim2, std::size_t dim1, std::size_t dim0>
 using Array3D = std::array<std::array<std::array<T, dim0>, dim1>, dim2>;
 
-void Program::finalize_rt_args() {
+uint32_t Program::finalize_rt_args(CoreType core_type, uint32_t base_offset) {
 
-    // Iterate over kernels in the program and "levels" the number of RTAs based on the max
+    // Iterate over kernels in the program and "level" the number of RTAs based on the max
     // Unique RTAs are packed across dispatch classes
-    // Common RTAs come after unique RTAs and are also packed
-    static vector<CoreType>core_types = { CoreType::WORKER, CoreType::ETH }; // TODO: make this global
+    // Common RTAs come after unique RTAs
     vector<uint32_t> max_rtas(DISPATCH_CLASS_MAX);
     vector<uint32_t> max_crtas(DISPATCH_CLASS_MAX);
+    uint32_t max_unique_rta_size = 0;
+    uint32_t total_crta_size = 0;
 
-    for (CoreType core_type : core_types) {
-        uint32_t unique_rta_size = 0;
+    this->get_program_config(core_type).rta_offset = base_offset;
 
-        for (auto& kg : this->get_kernel_groups(core_type)) {
-            for (int dispatch_class = 0; dispatch_class < DISPATCH_CLASS_MAX; dispatch_class++) {
-                max_rtas[dispatch_class] = 0;
-                auto& optional_id = kg.kernel_ids[dispatch_class];
-                if (optional_id) {
-                    auto kernel = detail::GetKernel(*this, optional_id.value());
-                    for (const CoreRange &core_range : kg.core_ranges.ranges()) {
-                        for (auto x = core_range.start_coord.x; x <= core_range.end_coord.x; x++) {
-                            for (auto y = core_range.start_coord.y; y <= core_range.end_coord.y; y++) {
-                                CoreCoord core_coord(x, y);
-                                max_rtas[dispatch_class] =
-                                    std::max(max_rtas[dispatch_class], (uint32_t)kernel->runtime_args(core_coord).size());
-                            }
+    for (auto& kg : this->get_kernel_groups(core_type)) {
+        for (int dispatch_class = 0; dispatch_class < DISPATCH_CLASS_MAX; dispatch_class++) {
+            max_rtas[dispatch_class] = 0;
+            auto& optional_id = kg.kernel_ids[dispatch_class];
+            if (optional_id) {
+                auto kernel = detail::GetKernel(*this, optional_id.value());
+                for (const CoreRange &core_range : kg.core_ranges.ranges()) {
+                    for (auto x = core_range.start_coord.x; x <= core_range.end_coord.x; x++) {
+                        for (auto y = core_range.start_coord.y; y <= core_range.end_coord.y; y++) {
+                            CoreCoord core_coord(x, y);
+                            max_rtas[dispatch_class] =
+                                std::max(max_rtas[dispatch_class], (uint32_t)kernel->runtime_args(core_coord).size());
                         }
                     }
                 }
             }
-
-            uint32_t offset = 0;
-            for (int dispatch_class = 0; dispatch_class < DISPATCH_CLASS_MAX; dispatch_class++) {
-                auto& optional_id = kg.kernel_ids[dispatch_class];
-                kg.rta_sizes[dispatch_class] = max_rtas[dispatch_class] * sizeof(uint32_t);
-                if (optional_id) {
-                    auto kernel = detail::GetKernel(*this, optional_id.value());
-                    kernel->set_runtime_args_count(kg.core_ranges, max_rtas[dispatch_class]);
-                    kg.launch_msg.kernel_config.mem_map[dispatch_class].rta_offset = offset;
-                    offset += max_rtas[dispatch_class] * sizeof(uint32_t);
-                } else {
-                    kg.launch_msg.kernel_config.mem_map[dispatch_class].rta_offset = 0;
-                }
-            }
-
-            kg.total_rta_size = offset;
-            offset = align(offset, L1_ALIGNMENT);
-            unique_rta_size = offset;
         }
 
-        for (int dispatch_class = 0; dispatch_class < DISPATCH_CLASS_MAX; dispatch_class++) {
-            max_crtas[dispatch_class] = 0;
-        }
-        // Find the max # common RTAs across all kernels for each dispatch class
-        for (size_t kernel_id = 0; kernel_id < this->num_kernels(); kernel_id++) {
-            auto kernel = detail::GetKernel(*this, kernel_id);
-            if (core_type == kernel->get_kernel_core_type()) {
-                uint32_t dispatch_class = kernel->dispatch_class();
-                max_crtas[dispatch_class] =
-                    std::max(max_crtas[dispatch_class], (uint32_t)kernel->common_runtime_args().size());
-            }
-        }
-
-        // Calculate the address offset and size for common RTAs for each dispatch class
         uint32_t offset = 0;
         for (int dispatch_class = 0; dispatch_class < DISPATCH_CLASS_MAX; dispatch_class++) {
-            uint32_t size = max_crtas[dispatch_class] * sizeof(uint32_t);
-            this->crta_offsets[core_type == CoreType::WORKER][dispatch_class] = unique_rta_size + offset;
-            this->crta_sizes[core_type == CoreType::WORKER][dispatch_class] = size;
-            offset += size;
-            offset = align(offset, L1_ALIGNMENT);
-        }
-
-        // Set the runtime_args_data sizing info based on the shared max
-        for (size_t kernel_id = 0; kernel_id < this->num_kernels(); kernel_id++) {
-            auto kernel = detail::GetKernel(*this, kernel_id);
-            if (core_type == kernel->get_kernel_core_type()) {
-                uint32_t dispatch_class = kernel->dispatch_class();
-                kernel->set_common_runtime_args_count(max_crtas[dispatch_class]);
+            auto& optional_id = kg.kernel_ids[dispatch_class];
+            kg.rta_sizes[dispatch_class] = max_rtas[dispatch_class] * sizeof(uint32_t);
+            if (optional_id) {
+                auto kernel = detail::GetKernel(*this, optional_id.value());
+                kernel->set_runtime_args_count(kg.core_ranges, max_rtas[dispatch_class]);
+                kg.launch_msg.kernel_config.mem_map[dispatch_class].rta_offset = base_offset + offset;
+                offset += max_rtas[dispatch_class] * sizeof(uint32_t);
+            } else {
+                kg.launch_msg.kernel_config.mem_map[dispatch_class].rta_offset = 0;
             }
         }
 
-        // Set the kernel group common runtime arg offsets use in the launch message
-        for (auto& kg : this->get_kernel_groups(core_type)) {
-            for (int dispatch_class = 0; dispatch_class < DISPATCH_CLASS_MAX; dispatch_class++) {
-                kg.launch_msg.kernel_config.mem_map[dispatch_class].crta_offset = this->crta_offsets[core_type == CoreType::WORKER][dispatch_class];
-            }
-        }
-
-        // TODO: this is asserted here as the leveling above can break the limits enforced by the API
-        // Once we use a ring buffer, memory space will be dynamic and this assert won't matter
-        TT_FATAL(offset <= L1_KERNEL_CONFIG_SIZE);
+        kg.total_rta_size = offset;
+        offset = align(offset, L1_ALIGNMENT);
+        max_unique_rta_size = std::max(offset, max_unique_rta_size);
     }
+
+    for (int dispatch_class = 0; dispatch_class < DISPATCH_CLASS_MAX; dispatch_class++) {
+        max_crtas[dispatch_class] = 0;
+    }
+    // Find the max # common RTAs across all kernels for each dispatch class
+    for (size_t kernel_id = 0; kernel_id < this->num_kernels(); kernel_id++) {
+        auto kernel = detail::GetKernel(*this, kernel_id);
+        if (core_type == kernel->get_kernel_core_type()) {
+            uint32_t dispatch_class = kernel->dispatch_class();
+            max_crtas[dispatch_class] =
+                std::max(max_crtas[dispatch_class], (uint32_t)kernel->common_runtime_args().size());
+        }
+    }
+
+    // Calculate the address offset and size for common RTAs for each dispatch class
+    uint32_t offset = 0;
+    for (int dispatch_class = 0; dispatch_class < DISPATCH_CLASS_MAX; dispatch_class++) {
+        uint32_t size = max_crtas[dispatch_class] * sizeof(uint32_t);
+        this->get_program_config(core_type).crta_offsets[dispatch_class] = base_offset + max_unique_rta_size + offset;
+        this->get_program_config(core_type).crta_sizes[dispatch_class] = size;
+        offset += size;
+        offset = align(offset, L1_ALIGNMENT);
+    }
+    total_crta_size = offset;
+
+    // Set the runtime_args_data sizing info based on the shared max
+    for (size_t kernel_id = 0; kernel_id < this->num_kernels(); kernel_id++) {
+        auto kernel = detail::GetKernel(*this, kernel_id);
+        if (core_type == kernel->get_kernel_core_type()) {
+            uint32_t dispatch_class = kernel->dispatch_class();
+            kernel->set_common_runtime_args_count(max_crtas[dispatch_class]);
+        }
+    }
+
+    // Set the kernel group common runtime arg offsets use in the launch message
+    for (auto& kg : this->get_kernel_groups(core_type)) {
+        for (int dispatch_class = 0; dispatch_class < DISPATCH_CLASS_MAX; dispatch_class++) {
+            kg.launch_msg.kernel_config.mem_map[dispatch_class].crta_offset = this->get_program_config(core_type).crta_offsets[dispatch_class];
+        }
+    }
+
+    // TODO: this is asserted here as the leveling above can break the limits enforced by the API
+    // Once we use a ring buffer, memory space will be dynamic and this assert won't matter
+    TT_FATAL(offset <= L1_KERNEL_CONFIG_SIZE);
+
+    return max_unique_rta_size + total_crta_size;
+}
+
+// TODO: idea was to abstract away which core type is 0, 1 in this routine
+// however, this has to line up w/ the worker_buffer_manager
+// clean this up w/ a more general solution
+ProgramConfig& Program::get_program_config(CoreType core_type) {
+    TT_ASSERT(core_type == CoreType::WORKER || core_type == CoreType::ETH);
+    return this->program_configs_[core_type != CoreType::WORKER];
+ }
+
+uint32_t& Program::get_program_config_size(CoreType core_type) {
+    TT_ASSERT(core_type == CoreType::WORKER || core_type == CoreType::ETH);
+    return this->program_config_sizes_[core_type != CoreType::WORKER];
+ }
+
+void Program::finalize() {
+    static vector<CoreType>core_types = { CoreType::WORKER, CoreType::ETH }; // TODO: make this global
+
+    // Store the number of tensix "go signals" for use by CQ
+    // CQ iterates over these to update runtime addresses, needs to know when eth begins (after tensix)
+    this->tensix_go_signal_count_ = 0;
+    for (auto& kg : this->get_kernel_groups(CoreType::WORKER)) {
+        this->tensix_go_signal_count_ += kg.core_ranges.size();
+    }
+
+    for (CoreType core_type : core_types) {
+        uint32_t offset = 0;
+        offset = finalize_rt_args(core_type, 0);
+        this->get_program_config_size(core_type) = offset;
+    }
+
+    finalized_ = true;
 }
 
 void Program::compile(Device *device) {
@@ -931,7 +971,6 @@ void Program::compile(Device *device) {
         detail::MemoryReporter::inst().flush_program_memory_usage(*this, device);
     }
     compile_needed_[device->id()] = false;
-    this->loaded_onto_device = false;
 }
 
 Program::~Program() {}

--- a/tt_metal/impl/program/program.hpp
+++ b/tt_metal/impl/program/program.hpp
@@ -52,6 +52,13 @@ struct KernelGroup {
     CoreType get_core_type() const;
 };
 
+// Contains the program's worker memory map
+struct ProgramConfig {
+    uint32_t rta_offset;
+    std::array<uint32_t, DISPATCH_CLASS_MAX> crta_offsets;
+    std::array<uint32_t, DISPATCH_CLASS_MAX> crta_sizes;
+};
+
 // TODO: why is this in program.hpp
 template <typename CoreRangeContainer>
 vector<pair<transfer_info_cores, uint32_t>> extract_dst_noc_multicast_info(Device* device, const CoreRangeContainer& ranges, const CoreType core_type) {
@@ -134,9 +141,8 @@ class Program {
 
     void allocate_circular_buffers();
 
-    void finalize_rt_args();
-    bool is_finalized() const { return loaded_onto_device; }
-    void set_finalized() { loaded_onto_device = true; }
+    bool is_finalized() const { return this->finalized_; }
+    void finalize();
 
    private:
     void populate_dispatch_data(Device *device);
@@ -149,7 +155,7 @@ class Program {
     std::unique_ptr<Buffer> buffer;
     ProgramTransferInfo program_transfer_info;
 
-    bool loaded_onto_device;
+    bool finalized_;
     struct CircularBufferAllocator {
         CircularBufferAllocator(const CoreRange &core_range_) : core_range(core_range_) {}
 
@@ -197,12 +203,12 @@ class Program {
     static constexpr uint8_t core_to_kernel_group_invalid_index = 0xff;
     std::unordered_map<CoreType, std::vector<KernelGroup>> kernel_groups_;
     std::unordered_map<CoreType, std::vector<uint8_t>> core_to_kernel_group_index_table_;
+    uint32_t tensix_go_signal_count_;
 
     std::vector<std::shared_ptr<Buffer>> config_buffers_;
 
-    static constexpr uint32_t num_dispatchable_core_types = 2;
-    std::array<std::array<uint32_t, DISPATCH_CLASS_MAX>, num_dispatchable_core_types> crta_offsets;
-    std::array<std::array<uint32_t, DISPATCH_CLASS_MAX>, num_dispatchable_core_types> crta_sizes;
+    std::vector<ProgramConfig> program_configs_;
+    std::vector<uint32_t> program_config_sizes_;
 
     friend CBHandle CreateCircularBuffer(Program &program, const std::variant<CoreCoord, CoreRange, CoreRangeSet> &core_spec, const CircularBufferConfig &config);
     friend std::shared_ptr<CircularBuffer> detail::GetCircularBuffer(const Program &program, CBHandle id);
@@ -229,6 +235,11 @@ class Program {
     void set_cb_data_fmt( Device *device, const std::vector<CoreRange> & crs, JitBuildOptions& build_options) const;
 
     void update_kernel_groups(const CoreType &core_type);
+
+    ProgramConfig& get_program_config(CoreType core_type);
+    uint32_t& get_program_config_size(CoreType core_type);
+
+    uint32_t finalize_rt_args(CoreType core_type, uint32_t base_offset);
 
     friend class HWCommandQueue;
     friend class EnqueueProgramCommand;

--- a/tt_metal/tt_metal.cpp
+++ b/tt_metal/tt_metal.cpp
@@ -513,9 +513,9 @@ void LaunchProgram(Device *device, Program &program, bool wait_until_cores_done)
         detail::DispatchStateCheck(false);
         detail::CompileProgram(device, program);
         if (!program.is_finalized()) {
-            program.finalize_rt_args();
-            program.set_finalized();
+            program.finalize();
         }
+
         detail::WriteRuntimeArgsToDevice(device, program);
         detail::ConfigureDeviceWithProgram(device, program);
 
@@ -622,6 +622,7 @@ void WriteRuntimeArgsToDevice(Device *device, Program &program) {
 
     for (CoreType core_type : core_types) {
         for (auto& kg : program.get_kernel_groups(core_type)) {
+            uint32_t kernel_config_base = kg.launch_msg.kernel_config.kernel_config_base;
             for (const CoreRange &core_range : kg.core_ranges.ranges()) {
                 for (auto x = core_range.start_coord.x; x <= core_range.end_coord.x; x++) {
                     for (auto y = core_range.start_coord.y; y <= core_range.end_coord.y; y++) {
@@ -630,24 +631,11 @@ void WriteRuntimeArgsToDevice(Device *device, Program &program) {
                         for (int dispatch_class = 0; dispatch_class < DISPATCH_CLASS_MAX; dispatch_class++) {
                             auto& optional_id = kg.kernel_ids[dispatch_class];
                             if (optional_id) {
-                                const auto kernel = detail::GetKernel(program, optional_id.value());
+                                const auto &kernel = detail::GetKernel(program, optional_id.value());
                                 const auto &rt_args = kernel->runtime_args(logical_core);
 
-                                uint32_t kernel_config_base;
-                                // TODO: get this from the dispatch ring buffer
-                                if (core_type == CoreType::WORKER) {
-                                    kernel_config_base = L1_KERNEL_CONFIG_BASE;
-                                } else {
-                                    TT_ASSERT(core_type == CoreType::ETH);
-                                    if (kernel->is_idle_eth()) {
-                                        kernel_config_base = IDLE_ERISC_L1_KERNEL_CONFIG_BASE;
-                                    } else {
-                                        kernel_config_base = eth_l1_mem::address_map::ERISC_L1_KERNEL_CONFIG_BASE;
-                                    }
-                                }
-
                                 if (rt_args.size() > 0) {
-                                    auto args_base_addr = kernel_config_base + kg.launch_msg.kernel_config.mem_map[dispatch_class].rta_offset;
+                                    auto rt_args_addr = kernel_config_base + kg.launch_msg.kernel_config.mem_map[dispatch_class].rta_offset;
                                     log_trace(
                                               tt::LogMetal,
                                               "{} - Writing {} unique rtargs to core {} (physical: {}) addr 0x{:x} => args: {}",
@@ -655,9 +643,9 @@ void WriteRuntimeArgsToDevice(Device *device, Program &program) {
                                               rt_args.size(),
                                               logical_core.str(),
                                               physical_core.str(),
-                                              args_base_addr,
+                                              rt_args_addr,
                                               rt_args);
-                                    tt::llrt::write_hex_vec_to_core(device_id, physical_core, rt_args, args_base_addr);
+                                    tt::llrt::write_hex_vec_to_core(device_id, physical_core, rt_args, rt_args_addr);
                                 }
 
                                 const auto &common_rt_args = kernel->common_runtime_args();


### PR DESCRIPTION
### Ticket
#10246

### Problem description
Double buffer runtime args on the device

### What's changed
Runtime args may now be sent while the prior kernel is still running.  Adds asynchrony, improves performance

### Checklist
- [ ] Post commit CI passes
- [ ] Model regression CI testing passes (if applicable)
- [ ] New/Existing tests provide coverage for changes
