### PR TITLE
update all gather tests to use t3k device 

### DIFF
--- a/tests/ttnn/unit_tests/operations/test_all_gather.py
+++ b/tests/ttnn/unit_tests/operations/test_all_gather.py
@@ -60,7 +60,7 @@ def is_unsupported_case(input_shape, dim, mem_config, num_devices, num_links, in
 
 
 def run_all_gather_on_t3000_impl(
-    all_devices,
+    t3k_mesh_device,
     num_devices,
     input_shape,
     dim,
@@ -74,11 +74,11 @@ def run_all_gather_on_t3000_impl(
     num_iters=1,
     enable_async=False,
 ):
-    if len(all_devices) != 8:
+    if t3k_mesh_device.get_num_devices() != 8:
         pytest.skip("Not T3000!")
 
     # Use Async mode based on test input config
-    for device in all_devices:
+    for device in t3k_mesh_device.get_devices():
         device.enable_async(enable_async)
     if enable_async:
         logger.info(f"Using Async Mode for All Gather Op Dispatch")
@@ -91,7 +91,6 @@ def run_all_gather_on_t3000_impl(
     if is_known_failure:
         pytest.skip(f"Skipping unsupported case {message}.")
 
-    devices = get_devices_for_t3000(all_devices, num_devices)
     # for device in devices:
     #    device.disable_and_clear_program_cache()
 
@@ -103,13 +102,13 @@ def run_all_gather_on_t3000_impl(
     input_tensors = torch.chunk(input_tensor, num_devices, dim)
     tt_input_tensors = []
     for i, t in enumerate(input_tensors):
-        tt_input_tensors.append(ttnn.Tensor(t, input_dtype).to(layout).to(devices[i], mem_config))
+        tt_input_tensors.append(ttnn.Tensor(t, input_dtype).to(layout).to(t3k_mesh_device.get_devices()[i], mem_config))
 
     input_tensor_mesh = ttnn.aggregate_as_tensor(tt_input_tensors)
     for i in range(num_iters):
         tt_out_tensor = all_gather_operation(input_tensor_mesh, dim, num_links=num_links, memory_config=mem_config)
 
-        for d in devices:
+        for d in t3k_mesh_device.get_devices():
             ttnn.synchronize_device(d)
         logger.info(f"Done iteration {i}")
 
@@ -125,7 +124,7 @@ def run_all_gather_on_t3000_impl(
 
 
 def run_all_gather_on_t3000_impl_tight_loop(
-    all_devices,
+    t3k_mesh_device,
     num_devices,
     input_shape,
     dim,
@@ -140,7 +139,7 @@ def run_all_gather_on_t3000_impl_tight_loop(
     enable_async=False,
 ):
     run_all_gather_on_t3000_impl(
-        all_devices,
+        t3k_mesh_device,
         num_devices,
         input_shape,
         dim,
@@ -188,7 +187,7 @@ def run_all_gather_on_t3000_impl_tight_loop(
 @pytest.mark.parametrize("num_iters", [1])  # restore to 500: https://github.com/tenstorrent/tt-metal/issues/9686
 @pytest.mark.parametrize("enable_async", [True, False])
 def test_all_gather_on_t3000_post_commit_looping(
-    all_devices,
+    t3k_mesh_device,
     num_devices,
     input_shape,
     dim,
@@ -202,7 +201,7 @@ def test_all_gather_on_t3000_post_commit_looping(
     enable_async,
 ):
     run_all_gather_on_t3000_impl_tight_loop(
-        all_devices,
+        t3k_mesh_device,
         num_devices,
         input_shape,
         dim,
@@ -250,7 +249,7 @@ def test_all_gather_on_t3000_post_commit_looping(
 @pytest.mark.parametrize("num_iters", [1000])  # TODO: restore to 500
 @pytest.mark.parametrize("enable_async", [True, False])
 def test_all_gather_on_t3000_nightly_commit_looping(
-    all_devices,
+    t3k_mesh_device,
     num_devices,
     input_shape,
     dim,
@@ -264,7 +263,7 @@ def test_all_gather_on_t3000_nightly_commit_looping(
     enable_async,
 ):
     run_all_gather_on_t3000_impl_tight_loop(
-        all_devices,
+        t3k_mesh_device,
         num_devices,
         input_shape,
         dim,
@@ -340,7 +339,7 @@ def test_all_gather_on_t3000_nightly_commit_looping(
     ],
 )
 def test_all_gather_on_t3000_post_commit(
-    all_devices,
+    t3k_mesh_device,
     num_devices,
     input_shape,
     dim,
@@ -352,7 +351,7 @@ def test_all_gather_on_t3000_post_commit(
     function_level_defaults,
 ):
     run_all_gather_on_t3000_impl(
-        all_devices,
+        t3k_mesh_device,
         num_devices,
         input_shape,
         dim,
@@ -421,7 +420,7 @@ def run_line_all_gather(
 
 # This run function is deprecated and is only intended to be used by 2-link tests on t3k
 def run_line_all_gather_deprecated(
-    all_devices,
+    t3k_mesh_device,
     num_devices,
     input_shape,
     dim,
@@ -434,10 +433,10 @@ def run_line_all_gather_deprecated(
     enable_async,
     num_iters=1,
 ):
-    if len(all_devices) != 8:
+    if t3k_mesh_device.get_num_devices() != 8:
         pytest.skip("Not T3000!")
 
-    for device in all_devices:
+    for device in t3k_mesh_device.get_devices():
         device.enable_async(enable_async)
 
     logger.info(f"Input shape: {input_shape}")
@@ -449,8 +448,6 @@ def run_line_all_gather_deprecated(
     if is_known_failure:
         pytest.skip(f"Skipping unsupported case {message}.")
 
-    devices = get_devices_for_t3000(all_devices, num_devices)
-
     logger.info(f"Input shape: {input_shape}")
     logger.info(f"dim: {dim}")
 
@@ -459,13 +456,13 @@ def run_line_all_gather_deprecated(
     input_tensors = torch.chunk(input_tensor, num_devices, dim)
     tt_input_tensors = []
     for i, t in enumerate(input_tensors):
-        tt_input_tensors.append(ttnn.Tensor(t, input_dtype).to(layout).to(devices[i], mem_config))
+        tt_input_tensors.append(ttnn.Tensor(t, input_dtype).to(layout).to(t3k_mesh_device.get_devices()[i], mem_config))
 
     input_tensor_mesh = ttnn.aggregate_as_tensor(tt_input_tensors)
     for i in range(num_iters):
         tt_out_tensor = ttnn.line_all_gather(input_tensor_mesh, dim, num_links=num_links, memory_config=mem_config)
 
-        for d in devices:
+        for d in t3k_mesh_device.get_devices():
             ttnn.synchronize_device(d)
         logger.info(f"Done iteration {i}")
 
@@ -575,7 +572,7 @@ def test_line_all_gather_on_t3000_post_commit(
 )
 @pytest.mark.parametrize("enable_async", [True, False])
 def test_line_all_gather_on_t3000_post_commit_two_link(
-    all_devices,
+    t3k_mesh_device,
     num_devices,
     input_shape,
     dim,
@@ -589,7 +586,7 @@ def test_line_all_gather_on_t3000_post_commit_two_link(
     num_iters=1,
 ):
     run_line_all_gather_deprecated(
-        all_devices,
+        t3k_mesh_device,
         num_devices,
         input_shape,
         dim,
@@ -792,7 +789,7 @@ def test_line_all_gather_on_t3000_nightly(
     ],
 )
 def test_all_gather_on_t3000_nightly(
-    all_devices,
+    t3k_mesh_device,
     num_devices,
     input_shape,
     dim,
@@ -848,7 +845,7 @@ def test_all_gather_on_t3000_nightly(
         pytest.xfail(reason="Known failure")
 
     run_all_gather_on_t3000_impl(
-        all_devices,
+        t3k_mesh_device,
         num_devices,
         input_shape,
         dim,
@@ -863,7 +860,7 @@ def test_all_gather_on_t3000_nightly(
 
 
 def run_all_gather_sharded(
-    all_devices,
+    t3k_mesh_device,
     num_devices,
     input_shape,
     input_shard_shape,
@@ -879,7 +876,7 @@ def run_all_gather_sharded(
     function_level_defaults,
     all_gather_operation,
 ):
-    if len(all_devices) != 8:
+    if t3k_mesh_device.get_num_devices() != 8:
         pytest.skip("Not T3000!")
 
     numel = input_shape[0] * input_shape[1] * input_shape[2] * input_shape[3] * num_devices
@@ -903,7 +900,6 @@ def run_all_gather_sharded(
     unchunked_input_tensor = unchunked_input_tensor.bfloat16()
 
     input_tensors = torch.chunk(unchunked_input_tensor, num_devices, dim)
-    devices = get_devices_for_t3000(all_devices, num_devices)
 
     # num_cores =
     # compute_grid_size = devices[0].compute_with_storage_grid_size()
@@ -953,19 +949,19 @@ def run_all_gather_sharded(
     ):
         pytest.skip("Unsupported test case")
 
-    tt_input_tensors_dups = []
     tt_input_tensors = []
 
     for i, t in enumerate(input_tensors):
-        tt_input_tensors_dups.append(ttnn.Tensor(t, input_dtype).to(tensor_layout).to(devices[i], input_mem_config))
-        tt_input_tensors.append(ttnn.Tensor(t, input_dtype).to(tensor_layout).to(devices[i], input_mem_config))
+        tt_input_tensors.append(
+            ttnn.Tensor(t, input_dtype).to(tensor_layout).to(t3k_mesh_device.get_devices()[i], input_mem_config)
+        )
 
     input_tensor_mesh = ttnn.aggregate_as_tensor(tt_input_tensors)
 
     ## Run the actual allgather operation
     tt_out_tensor = all_gather_operation(input_tensor_mesh, dim, num_links=num_links, memory_config=output_mem_config)
     ## Wait for completion
-    for d in devices:
+    for d in t3k_mesh_device.get_devices():
         ttnn.synchronize_device(d)
 
     torch.set_printoptions(sci_mode=False)
@@ -1047,8 +1043,9 @@ def run_all_gather_sharded(
         ),
     ),
 )
+# @pytest.mark.parametrize("device_params", [{"trace_region_size": 60000}], indirect=True)
 def test_all_gather_sharded_post_commit(
-    all_devices,
+    t3k_mesh_device,
     num_devices,
     input_shape,
     input_shard_shape,
@@ -1064,7 +1061,7 @@ def test_all_gather_sharded_post_commit(
     function_level_defaults,
 ):
     run_all_gather_sharded(
-        all_devices,
+        t3k_mesh_device,
         num_devices,
         input_shape,
         input_shard_shape,
@@ -1135,7 +1132,7 @@ def test_all_gather_sharded_post_commit(
     ),
 )
 def test_all_gather_height_sharded_post_commit(
-    all_devices,
+    t3k_mesh_device,
     num_devices,
     input_shape,
     input_shard_shape,
@@ -1151,7 +1148,7 @@ def test_all_gather_height_sharded_post_commit(
     function_level_defaults,
 ):
     run_all_gather_sharded(
-        all_devices,
+        t3k_mesh_device,
         num_devices,
         input_shape,
         input_shard_shape,
@@ -1216,7 +1213,7 @@ def test_all_gather_height_sharded_post_commit(
     ),
 )
 def test_all_gather_block_sharded_post_commit(
-    all_devices,
+    t3k_mesh_device,
     num_devices,
     input_shape,
     input_shard_shape,
@@ -1232,7 +1229,7 @@ def test_all_gather_block_sharded_post_commit(
     function_level_defaults,
 ):
     run_all_gather_sharded(
-        all_devices,
+        t3k_mesh_device,
         num_devices,
         input_shape,
         input_shard_shape,
@@ -1305,7 +1302,7 @@ def test_all_gather_block_sharded_post_commit(
     ),
 )
 def test_line_all_gather_sharded_post_commit(
-    all_devices,
+    t3k_mesh_device,
     num_devices,
     input_shape,
     input_shard_shape,
@@ -1321,7 +1318,7 @@ def test_line_all_gather_sharded_post_commit(
     function_level_defaults,
 ):
     run_all_gather_sharded(
-        all_devices,
+        t3k_mesh_device,
         num_devices,
         input_shape,
         input_shard_shape,
@@ -1465,7 +1462,7 @@ def test_line_all_gather_sharded_post_commit(
 )
 @pytest.mark.parametrize("all_gather_operation", [ttnn.all_gather, ttnn.line_all_gather])
 def test_sharded_all_gather_nightly(
-    all_devices,
+    t3k_mesh_device,
     num_devices,
     input_shape,
     input_shard_shape,
@@ -1482,7 +1479,7 @@ def test_sharded_all_gather_nightly(
     all_gather_operation,
 ):
     run_all_gather_sharded(
-        all_devices,
+        t3k_mesh_device,
         num_devices,
         input_shape,
         input_shard_shape,

--- a/tests/ttnn/unit_tests/operations/test_all_gather_nightly.py
+++ b/tests/ttnn/unit_tests/operations/test_all_gather_nightly.py
@@ -11,9 +11,481 @@ from models.utility_functions import skip_for_grayskull, get_devices_for_t3000
 from tests.ttnn.unit_tests.operations.test_all_gather import (
     is_unsupported_case,
     run_line_all_gather,
-    run_line_all_gather_deprecated,
+    run_all_gather_deprecated,
+    run_all_gather_sharded,
 )
 from ttnn import ShardTensorToMesh
+
+
+nightly_all_gather_shape_dim_layout_configs = [
+    ([4, 1, 33, 256], 0, ttnn.ROW_MAJOR_LAYOUT),
+    ([4, 1, 256, 32], 0, ttnn.TILE_LAYOUT),
+    ([8, 5, 13, 512], 3, ttnn.ROW_MAJOR_LAYOUT),
+    ([8, 5, 32, 512], 3, ttnn.TILE_LAYOUT),
+    ([8, 5, 13, 384], 3, ttnn.ROW_MAJOR_LAYOUT),
+    ([8, 5, 32, 384], 3, ttnn.TILE_LAYOUT),
+    ([8, 8, 256, 384], 0, ttnn.ROW_MAJOR_LAYOUT),
+    ([8, 8, 256, 384], 0, ttnn.TILE_LAYOUT),
+    ([8, 8, 256, 384], 1, ttnn.ROW_MAJOR_LAYOUT),
+    ([8, 8, 256, 384], 1, ttnn.TILE_LAYOUT),
+    ([8, 8, 256, 384], 2, ttnn.ROW_MAJOR_LAYOUT),
+    ([8, 8, 256, 384], 2, ttnn.TILE_LAYOUT),
+    ([8, 8, 256, 384], 3, ttnn.ROW_MAJOR_LAYOUT),
+    ([8, 8, 256, 384], 3, ttnn.TILE_LAYOUT),
+    ([8, 8, 256, 768], 3, ttnn.ROW_MAJOR_LAYOUT),
+    ([8, 8, 256, 768], 3, ttnn.TILE_LAYOUT),
+    ([8, 8, 1024, 4096], 1, ttnn.TILE_LAYOUT),
+    ([8, 8, 2048, 4096], 1, ttnn.TILE_LAYOUT),
+    ([8, 8, 128, 4096], 1, ttnn.ROW_MAJOR_LAYOUT),
+    ([8, 8, 1024, 4096], 1, ttnn.ROW_MAJOR_LAYOUT),
+    ([8, 8, 2048, 4096], 1, ttnn.ROW_MAJOR_LAYOUT),
+    # Only for BFP8B
+    # ([1, 1, 640, 32768], 3, ttnn.TILE_LAYOUT),
+    # MLP AllGather. Llama 2 decode attn, mlp. Llama2, Falcon 40B decode mlp attn
+    # Mixtral 8x7B, functional bringup with expanded tensor getting allgathered
+    # Full shape for 8 chips
+    ([1, 1, 32, 32768], 3, ttnn.TILE_LAYOUT),
+    ([1, 1, 32, 32768], 3, ttnn.ROW_MAJOR_LAYOUT),
+    # Input, Selfout, Final AllGather
+    ([1, 1, 32, 8192], 3, ttnn.TILE_LAYOUT),
+    ([1, 1, 32, 8192], 3, ttnn.ROW_MAJOR_LAYOUT),
+    # MLP AllGather. Llama 2 decode attn, mlp. Llama2, Falcon 40B decode mlp attn
+    # Half shape for 4 chips, same per chip shape as 8 chips
+    ([1, 1, 32, 16384], 3, ttnn.TILE_LAYOUT),
+    ([1, 1, 32, 16384], 3, ttnn.ROW_MAJOR_LAYOUT),
+    # Input, Selfout, Final AllGather. Llama2, Falcon 40B decode mlp attn
+    # Full shape for 8 chips
+    ([1, 1, 32, 8192], 3, ttnn.TILE_LAYOUT),
+    ([1, 1, 32, 8192], 3, ttnn.ROW_MAJOR_LAYOUT),
+    # Input, Selfout, Final AllGather. Llama2, Falcon 40B decode mlp attn
+    # Half shape for running on 4 chips, same per chip shape as for 8 chips
+    ([1, 1, 32, 4096], 3, ttnn.TILE_LAYOUT),
+    ([1, 1, 32, 4096], 3, ttnn.ROW_MAJOR_LAYOUT),
+    # Falcon 40B prefill
+    # 8 chips
+    ([1, 1, 2048, 8192], 3, ttnn.TILE_LAYOUT),
+    ([1, 1, 2048, 8192], 3, ttnn.ROW_MAJOR_LAYOUT),
+    # 4 chips, same per chip shape as 8 chips
+    ([1, 1, 2048, 4096], 3, ttnn.TILE_LAYOUT),
+    ([1, 1, 2048, 4096], 3, ttnn.ROW_MAJOR_LAYOUT),
+    # Falcon 40B prefill
+    # 8 chips
+    ([1, 1, 2048, 32768], 3, ttnn.TILE_LAYOUT),
+    ([1, 1, 2048, 32768], 3, ttnn.ROW_MAJOR_LAYOUT),
+    # 4 chips, same per chip shape as 8 chips
+    ([1, 1, 2048, 16384], 3, ttnn.TILE_LAYOUT),
+    ([1, 1, 2048, 16384], 3, ttnn.ROW_MAJOR_LAYOUT),
+    # Mixtral 8x7B, Min sequence length
+    # 8 chips
+    # ([1, 1, 32768, 32768], 3, ttnn.ROW_MAJOR_LAYOUT),
+    ([1, 1, 32768, 32768], 3, ttnn.TILE_LAYOUT),  # ultra slow?
+    # 4 chips, per chip shape same as 8 chips
+    # ([1, 1, 32768, 16384], 3, ttnn.ROW_MAJOR_LAYOUT),
+    # ([1, 1, 32768, 16384], 3, ttnn.TILE_LAYOUT),
+    # Llama galaxy mlp weights stationary -> emulation of row/col reduce
+    ([1, 1, 128, 1024], 2, ttnn.ROW_MAJOR_LAYOUT),
+    ([1, 1, 128, 1024], 2, ttnn.TILE_LAYOUT),
+    # ([1, 1, 32, 8192], 3, ttnn.ROW_MAJOR_LAYOUT), # ALREADY LISTED PREVIOUSLY
+    # ([1, 1, 32, 8192], 3, ttnn.TILE_LAYOUT),      # ALREADY LISTED PREVIOUSLY
+    ([1, 1, 128, 4096], 2, ttnn.ROW_MAJOR_LAYOUT),  #
+    ([1, 1, 128, 4096], 2, ttnn.TILE_LAYOUT),
+    # ([1, 1, 32, 16384], 3, ttnn.ROW_MAJOR_LAYOUT), # ALREADY LISTED PREVIOUSLY. Update for 8 chip, actuall 32k for 8 chip but we are halving it for our 4 chip test
+    # ([1, 1, 32, 16384], 3, ttnn.TILE_LAYOUT),      # ALREADY LISTED PREVIOUSLY. Update for 8 chip, actuall 32k for 8 chip but we are halving it for our 4 chip test
+    ([1, 1, 8192, 32], 2, ttnn.ROW_MAJOR_LAYOUT),
+    ([1, 1, 8192, 32], 2, ttnn.TILE_LAYOUT),
+    ([1, 1, 1024, 128], 3, ttnn.ROW_MAJOR_LAYOUT),  # double on reduction dim for 8 chip
+    ([1, 1, 1024, 128], 3, ttnn.TILE_LAYOUT),  # double on reduction dim for 8 chip
+    ([1, 1, 16384, 32], 2, ttnn.ROW_MAJOR_LAYOUT),  # double on reduction dim for 8 chip
+    ([1, 1, 16384, 32], 2, ttnn.TILE_LAYOUT),  # double on reduction dim for 8 chip
+    ([1, 1, 32768, 32], 2, ttnn.ROW_MAJOR_LAYOUT),  # double on reduction dim for 8 chip
+    ([1, 1, 32768, 32], 2, ttnn.TILE_LAYOUT),  # double on reduction dim for 8 chip
+    ([1, 1, 4096, 128], 3, ttnn.ROW_MAJOR_LAYOUT),  # only for 4 chip
+    ([1, 1, 4096, 128], 3, ttnn.TILE_LAYOUT),  # only for 4 chip
+    ([1, 1, 128, 2048], 2, ttnn.ROW_MAJOR_LAYOUT),  # double on reduction dim for 8 chip
+    ([1, 1, 128, 2048], 2, ttnn.TILE_LAYOUT),  # double on reduction dim for 8 chip
+    # ([1, 1, 32, 8192], 3, ttnn.ROW_MAJOR_LAYOUT), # only for 4 chip - ALREADY LISTED PREVIOUSLY
+    # ([1, 1, 32, 8192], 3, ttnn.TILE_LAYOUT),      # only for 4 chip - ALREADY LISTED PREVIOUSLY
+    ([1, 1, 128, 8192], 2, ttnn.ROW_MAJOR_LAYOUT),  # double on reduction dim for 8 chip
+    ([1, 1, 128, 8192], 2, ttnn.TILE_LAYOUT),  # double on reduction dim for 8 chip
+    ([4, 1, 256, 32], 0, ttnn.TILE_LAYOUT),
+    ([8, 8, 256, 384], 1, ttnn.ROW_MAJOR_LAYOUT),
+    ([1, 1, 256, 1024], 2, ttnn.ROW_MAJOR_LAYOUT),
+    ([1, 1, 1024, 256], 3, ttnn.ROW_MAJOR_LAYOUT),
+    ([1, 1, 256, 2048], 2, ttnn.ROW_MAJOR_LAYOUT),
+    ([1, 1, 256, 8192], 2, ttnn.ROW_MAJOR_LAYOUT),  # double on reduction dim for 8 chip
+]
+
+
+@skip_for_grayskull("Requires eth connected devices to run")
+@pytest.mark.parametrize(
+    "num_devices, num_links",
+    [
+        (2, 1),
+        (4, 1),
+        (8, 1),
+    ],
+)
+@pytest.mark.parametrize("input_shape, dim, layout", nightly_all_gather_shape_dim_layout_configs)
+@pytest.mark.parametrize(
+    "input_dtype",
+    [
+        ttnn.bfloat16,
+        ttnn.bfloat8_b,
+    ],
+)
+@pytest.mark.parametrize(
+    "mem_config",
+    [
+        ttnn.MemoryConfig(buffer_type=ttnn.BufferType.DRAM),
+        ttnn.MemoryConfig(buffer_type=ttnn.BufferType.L1),
+    ],
+)
+def test_all_gather_on_t3000_nightly(
+    t3k_mesh_device,
+    num_devices,
+    input_shape,
+    dim,
+    num_links,
+    input_dtype,
+    layout,
+    mem_config,
+    use_program_cache,
+    function_level_defaults,
+):
+    if (
+        input_shape == [8, 8, 256, 384]
+        and dim == 1
+        and layout == ttnn.TILE_LAYOUT
+        and num_devices == 4
+        and num_links == 1
+        and input_dtype == ttnn.bfloat16
+        and mem_config.buffer_type == ttnn.BufferType.DRAM
+    ):
+        pytest.xfail(reason="Known failure")
+
+    if (
+        input_shape == [8, 8, 256, 384]
+        and dim == 2
+        and layout == ttnn.TILE_LAYOUT
+        and num_devices == 4
+        and num_links == 1
+        and input_dtype == ttnn.bfloat16
+        and mem_config.buffer_type == ttnn.BufferType.DRAM
+    ):
+        pytest.xfail(reason="Known failure")
+
+    if (
+        input_shape == [8, 8, 256, 384]
+        and dim == 2
+        and layout == ttnn.TILE_LAYOUT
+        and num_devices == 4
+        and num_links == 1
+        and input_dtype == ttnn.bfloat8_b
+        and mem_config.buffer_type == ttnn.BufferType.DRAM
+    ):
+        pytest.xfail(reason="Known failure")
+
+    run_all_gather_on_t3000_impl(
+        t3k_mesh_device,
+        num_devices,
+        input_shape,
+        dim,
+        num_links,
+        input_dtype,
+        layout,
+        mem_config,
+        use_program_cache,
+        function_level_defaults,
+        all_gather_operation=ttnn.all_gather,
+    )
+
+
+## We currently don't have the clean way with the test infra to describe the inner ring of a
+## t3k device using the `t3k_mesh_device` fixture, so we use this test entry for all
+## 4-chip, 2-link tests.
+@skip_for_grayskull("Requires eth connected devices to run")
+@pytest.mark.parametrize(
+    "num_devices, num_links",
+    [
+        (4, 2),
+    ],
+)
+@pytest.mark.parametrize("input_shape, dim, layout", nightly_all_gather_shape_dim_layout_configs)
+@pytest.mark.parametrize(
+    "input_dtype",
+    [
+        ttnn.bfloat16,
+        ttnn.bfloat8_b,
+    ],
+)
+@pytest.mark.parametrize(
+    "mem_config",
+    [
+        ttnn.MemoryConfig(buffer_type=ttnn.BufferType.DRAM),
+        ttnn.MemoryConfig(buffer_type=ttnn.BufferType.L1),
+    ],
+)
+def test_all_gather_on_t3000_2link_tests_nightly(
+    all_devices,
+    num_devices,
+    input_shape,
+    dim,
+    num_links,
+    input_dtype,
+    layout,
+    mem_config,
+    use_program_cache,
+    function_level_defaults,
+):
+    if (
+        input_shape == [8, 8, 256, 384]
+        and dim == 2
+        and layout == ttnn.TILE_LAYOUT
+        and num_devices == 4
+        and num_links == 2
+        and input_dtype == ttnn.bfloat8_b
+        and mem_config.buffer_type == ttnn.BufferType.DRAM
+    ):
+        pytest.xfail(reason="Known failure")
+
+    run_all_gather_deprecated(
+        all_devices,
+        num_devices,
+        input_shape,
+        dim,
+        num_links,
+        input_dtype,
+        layout,
+        mem_config,
+        use_program_cache,
+        function_level_defaults,
+        True,
+        all_gather_operation=ttnn.all_gather,
+        num_iters=1,
+    )
+
+
+# Enumerate the post-commit cases explicitly
+@skip_for_grayskull("Requires eth connected devices to run")
+@pytest.mark.parametrize(
+    "num_devices, num_links, input_shape, dim, layout",
+    [
+        (4, 2, [4, 1, 256, 32], 0, ttnn.TILE_LAYOUT),
+        (8, 1, [8, 1, 256, 32], 0, ttnn.TILE_LAYOUT),
+        (8, 1, [1, 1, 32, 16384], 3, ttnn.TILE_LAYOUT),
+        (4, 2, [1, 1, 32, 32768], 3, ttnn.TILE_LAYOUT),
+        (4, 2, [4, 1, 256, 32], 0, ttnn.ROW_MAJOR_LAYOUT),
+        (8, 1, [8, 1, 256, 32], 0, ttnn.ROW_MAJOR_LAYOUT),
+        (8, 1, [1, 1, 32, 16384], 3, ttnn.ROW_MAJOR_LAYOUT),
+        (4, 2, [1, 1, 32, 32768], 3, ttnn.ROW_MAJOR_LAYOUT),
+    ],
+)
+@pytest.mark.parametrize(
+    "input_dtype",
+    [
+        ttnn.bfloat16,
+        # ttnn.bfloat8_b,        # https://github.com/tenstorrent/tt-metal/issues/9686
+    ],
+)
+@pytest.mark.parametrize(
+    "mem_config",
+    [
+        # ttnn.MemoryConfig(buffer_type=ttnn.BufferType.DRAM),        # https://github.com/tenstorrent/tt-metal/issues/9686
+        ttnn.MemoryConfig(buffer_type=ttnn.BufferType.L1),
+    ],
+)
+@pytest.mark.parametrize("num_iters", [1000])  # TODO: restore to 500
+@pytest.mark.parametrize("enable_async", [True, False])
+def test_all_gather_on_t3000_nightly_commit_looping(
+    t3k_mesh_device,
+    num_devices,
+    input_shape,
+    dim,
+    num_links,
+    input_dtype,
+    layout,
+    mem_config,
+    num_iters,
+    use_program_cache,
+    function_level_defaults,
+    enable_async,
+):
+    run_all_gather_on_t3000_impl_tight_loop(
+        t3k_mesh_device,
+        num_devices,
+        input_shape,
+        dim,
+        num_links,
+        input_dtype,
+        layout,
+        mem_config,
+        use_program_cache,
+        function_level_defaults,
+        all_gather_operation=ttnn.all_gather,
+        num_iters=num_iters,
+        enable_async=enable_async,
+    )
+
+
+# @pytest.mark.parametrize("num_devices", [4, 8])
+@skip_for_grayskull("Requires eth connected devices to run")
+@pytest.mark.parametrize("num_devices", [8])
+@pytest.mark.parametrize("dim", [3])
+@pytest.mark.parametrize("tensor_layout", [ttnn.TILE_LAYOUT])
+# @pytest.mark.parametrize("num_cores", [1])
+@pytest.mark.parametrize(
+    "input_dtype",
+    [
+        ttnn.bfloat16,  # https://github.com/tenstorrent/tt-metal/issues/9686
+        # ttnn.bfloat8_b,
+    ],
+)
+@pytest.mark.parametrize(
+    "tensor_mem_layout",
+    [
+        ttnn.TensorMemoryLayout.WIDTH_SHARDED,
+        # ttnn.TensorMemoryLayout.HEIGHT_SHARDED,
+        # ttnn.TensorMemoryLayout.BLOCK_SHARDED,
+    ],
+)
+@pytest.mark.parametrize("orientation", [ttnn.ShardOrientation.ROW_MAJOR, ttnn.ShardOrientation.COL_MAJOR])
+@pytest.mark.parametrize("num_links", [1])
+@pytest.mark.parametrize(
+    "input_shape, input_shard_shape,shard_grid",
+    (
+        (  # https://github.com/tenstorrent/tt-metal/issues/9686
+            (1, 1, 32, 128),
+            (32, 32),
+            ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(1, 1))}),
+        ),
+        (  # https://github.com/tenstorrent/tt-metal/issues/9686
+            (1, 1, 32, 256),
+            (32, 64),
+            ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(1, 1))}),
+        ),
+        (  # https://github.com/tenstorrent/tt-metal/issues/9686
+            (1, 1, 64, 128),
+            (64, 32),
+            ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(1, 1))}),
+        ),
+        (  # https://github.com/tenstorrent/tt-metal/issues/9686
+            (1, 1, 64, 256),
+            (64, 64),
+            ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(1, 1))}),
+        ),
+        (  # https://github.com/tenstorrent/tt-metal/issues/9686
+            (1, 1, 32, 64),
+            (32, 64),
+            ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(0, 0))}),
+        ),
+        (  # https://github.com/tenstorrent/tt-metal/issues/9686
+            (1, 1, 32, 128),
+            (32, 128),
+            ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(0, 0))}),
+        ),
+        (  # https://github.com/tenstorrent/tt-metal/issues/9686
+            (1, 1, 32, 64),
+            (32, 32),
+            ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(1, 0))}),
+        ),
+        (  # https://github.com/tenstorrent/tt-metal/issues/9686
+            (1, 1, 32, 128),
+            (32, 64),
+            ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(1, 0))}),
+        ),
+        (
+            (1, 1, 32, 128),
+            (32, 32),
+            ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(0, 3))}),
+        ),
+        (
+            (1, 1, 64, 128),
+            (64, 32),
+            ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(0, 3))}),
+        ),
+        (
+            (1, 1, 32, 256),
+            (32, 64),
+            ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(0, 3))}),
+        ),
+        (
+            (1, 1, 64, 256),
+            (64, 64),
+            ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(0, 3))}),
+        ),
+        (  # https://github.com/tenstorrent/tt-metal/issues/9686
+            (1, 1, 32, 256),
+            (32, 32),
+            ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(7, 0))}),
+        ),
+        (  # https://github.com/tenstorrent/tt-metal/issues/9686
+            (1, 1, 32, 512),
+            (32, 64),
+            ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(7, 0))}),
+        ),
+        # LLama
+        (
+            (1, 1, 32, 1024),
+            (32, 32),
+            ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(7, 3))}),
+        ),
+        (  # https://github.com/tenstorrent/tt-metal/issues/9686
+            (1, 1, 32, 4096),
+            (32, 128),
+            ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(7, 3))}),
+        ),
+        (  # https://github.com/tenstorrent/tt-metal/issues/9686
+            (1, 1, 32, 4096),
+            (32, 128),
+            ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(7, 3))}),
+        ),
+        (  # https://github.com/tenstorrent/tt-metal/issues/9686
+            (1, 1, 32, 2048),
+            (32, 64),
+            ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(7, 3))}),
+        ),
+        (  # https://github.com/tenstorrent/tt-metal/issues/9686
+            (1, 1, 32, 1792),
+            (32, 32),
+            ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(7, 6))}),
+        ),
+    ),
+)
+@pytest.mark.parametrize("all_gather_operation", [ttnn.all_gather, ttnn.line_all_gather])
+def test_sharded_all_gather_nightly(
+    t3k_mesh_device,
+    num_devices,
+    input_shape,
+    input_shard_shape,
+    shard_grid,
+    dim,
+    num_links,
+    orientation,
+    input_dtype,
+    tensor_layout,
+    tensor_mem_layout,
+    # num_cores,
+    use_program_cache,
+    function_level_defaults,
+    all_gather_operation,
+):
+    run_all_gather_sharded(
+        t3k_mesh_device,
+        num_devices,
+        input_shape,
+        input_shard_shape,
+        shard_grid,
+        dim,
+        num_links,
+        orientation,
+        input_dtype,
+        tensor_layout,
+        tensor_mem_layout,
+        # num_cores,
+        use_program_cache,
+        function_level_defaults,
+        all_gather_operation=all_gather_operation,
+    )
 
 
 # Enumerate the post-commit cases explicitly
@@ -121,7 +593,7 @@ def test_line_all_gather_on_t3000_nightly_two_link(
     enable_async,
     num_iters=1,
 ):
-    run_line_all_gather_deprecated(
+    run_all_gather_deprecated(
         all_devices,
         num_devices,
         input_shape,
@@ -133,6 +605,7 @@ def test_line_all_gather_on_t3000_nightly_two_link(
         use_program_cache,
         function_level_defaults,
         enable_async,
+        ttnn.line_all_gather,
         num_iters,
     )
 


### PR DESCRIPTION
### Ticket
This issue was brought up during a PR review during the TTNN migration of CCL ops. Placeholder issue was opened here: https://github.com/tenstorrent/tt-metal/issues/10712

### Problem description
Tests are using out data device test fixtures

### What's changed
Use new multi-device test fixtures for existing all-gather tests that make use of the `all_devices` fixture. The exception to this is that some tests ({4 chip, 2-link}) do not support this device fixture without additional work and/or APIs. Therefore, they're using an older run function. We'll need one more set of changes in the future to move off all_devices for 4-chip/2-link tests.

Additionally migrated the nightly tests to the nightly test file since it made sense at this time.

### Checklist
- [ ] Post commit CI passes: https://github.com/tenstorrent/tt-metal/actions/runs/10722489570
- [ ] T3000 frequent: https://github.com/tenstorrent/tt-metal/actions/runs/10724463553
- [ ] t3000 nightly: https://github.com/tenstorrent/tt-metal/actions/runs/10724466006
- [x] Model regression CI testing passes (if applicable)
  - N/A only updated test files
- [x] New/Existing tests provide coverage for changes
  -  N/A
