### PR TITLE
#0: Update kwarg for padding_idx for ttnn.embedding in bert

### DIFF
--- a/models/demos/metal_BERT_large_11/tt/embeddings.py
+++ b/models/demos/metal_BERT_large_11/tt/embeddings.py
@@ -139,7 +139,7 @@ class TtEmbeddings:
             self.word_embeddings_weight,
             layout=ttnn.TILE_LAYOUT,
             embeddings_type=ttnn.EmbeddingsType.PADDED,
-            pad_token=self.pad_token,
+            padding_idx=self.pad_token,
             memory_config=self.model_config["OUTPUT_EMBEDDINGS_MEMCFG"],
         )
         input_ids.deallocate()


### PR DESCRIPTION
### Ticket
Link to Github Issue

### Problem description
Need to update kwarg for `ttnn.embedding`.

### What's changed
Update `pad_token` to `padding_idx`.

### Checklist
- [ ] Post commit CI passes
- [ ] Model regression CI testing passes (if applicable)
- [ ] New/Existing tests provide coverage for changes
