### PR TITLE
#9750: Move Repeat_interleave to ttnn data_movement

### DIFF
--- a/docs/source/ttnn/ttnn/dependencies/tt_lib.rst
+++ b/docs/source/ttnn/ttnn/dependencies/tt_lib.rst
@@ -608,8 +608,6 @@ Other Operations
 
 .. autofunction:: tt_lib.tensor.repeat
 
-.. autofunction:: tt_lib.tensor.repeat_interleave
-
 .. autofunction:: tt_lib.tensor.pow
 
 .. autofunction:: tt_lib.tensor.argmax

--- a/models/experimental/mistral/tt/mistral_attention.py
+++ b/models/experimental/mistral/tt/mistral_attention.py
@@ -106,8 +106,8 @@ class TtAttention(nn.Module):
         dim = 2
         keys = torch_to_tt_tensor_rm(keys, self.device)
         values = torch_to_tt_tensor_rm(values, self.device)
-        keys = tt_lib.tensor.repeat_interleave(keys, repeats, dim, output_mem_config=self.args.out_mem_config)
-        values = tt_lib.tensor.repeat_interleave(values, repeats, dim, output_mem_config=self.args.out_mem_config)
+        keys = ttnn.repeat_interleave(keys, repeats, dim, memory_config=self.args.out_mem_config)
+        values = ttnn.repeat_interleave(values, repeats, dim, memory_config=self.args.out_mem_config)
         return keys, values
 
     def forward(

--- a/models/experimental/stable_diffusion/tt/upsample_nearest2d.py
+++ b/models/experimental/stable_diffusion/tt/upsample_nearest2d.py
@@ -8,7 +8,7 @@ from torch.nn import functional as F
 
 import numpy as np
 
-import tt_lib as ttl
+import ttnn
 from tt_lib.fallback_ops import fallback_ops
 
 
@@ -24,6 +24,6 @@ class TtUpsampleNearest2d(nn.Module):
         output_shape = list(input.get_legacy_shape())
         output_shape[-1] *= self.scale_factor
         output_shape[-2] *= self.scale_factor
-        input = ttl.tensor.repeat_interleave(input, self.scale_factor, dim=3)
-        input = ttl.tensor.repeat_interleave(input, self.scale_factor, dim=2)
+        input = ttnn.repeat_interleave(input, self.scale_factor, dim=3)
+        input = ttnn.repeat_interleave(input, self.scale_factor, dim=2)
         return input

--- a/tests/tt_eager/python_api_testing/sweep_tests/tt_lib_ops.py
+++ b/tests/tt_eager/python_api_testing/sweep_tests/tt_lib_ops.py
@@ -1277,7 +1277,7 @@ def repeat_interleave(
     **kwargs,
 ):
     t0 = setup_tt_tensor(x, device, layout[0], input_mem_config[0], dtype[0])
-    t1 = ttl.tensor.repeat_interleave(t0, repeat, dim, output_mem_config=output_mem_config)
+    t1 = ttnn.repeat_interleave(t0, repeat, dim, memory_config=output_mem_config)
     output_tensor = ttnn.from_device(t1)
     output_tensor = ttnn.to_layout(output_tensor, ttnn.ROW_MAJOR_LAYOUT)
     output_tensor = ttnn.to_torch(output_tensor)

--- a/tests/ttnn/profiling/ops_for_profiling.py
+++ b/tests/ttnn/profiling/ops_for_profiling.py
@@ -1496,15 +1496,15 @@ def repeat(x):
 
 
 def repeat_interleave_0(x):
-    tt_lib.tensor.repeat_interleave(x, 4, 0)
+    ttnn.repeat_interleave(x, 4, 0)
 
 
 def repeat_interleave_1(x):
-    tt_lib.tensor.repeat_interleave(x, 4, 1)
+    ttnn.repeat_interleave(x, 4, 1)
 
 
 def repeat_interleave_2(x):
-    tt_lib.tensor.repeat_interleave(x, 4, 2)
+    ttnn.repeat_interleave(x, 4, 2)
 
 
 def pow_int(x):
@@ -2238,16 +2238,16 @@ all_unary_ops = [
     },
     {
         "op": repeat_interleave_0,
-        "name": "tt_lib.tensor.repeat_interleave_dim_0",
+        "name": "ttnn.repeat_interleave_dim_0",
     },
     {
         "op": repeat_interleave_1,
-        "name": "tt_lib.tensor.repeat_interleave_dim_1",
+        "name": "ttnn.repeat_interleave_dim_1",
         "num_repeats": 2,
     },
     {
         "op": repeat_interleave_2,
-        "name": "tt_lib.tensor.repeat_interleave_dim_2",
+        "name": "ttnn.repeat_interleave_dim_2",
         "num_repeats": 2,
     },
     {

--- a/tests/ttnn/unit_tests/gtests/test_repeat_interleave.cpp
+++ b/tests/ttnn/unit_tests/gtests/test_repeat_interleave.cpp
@@ -8,7 +8,7 @@
 #include "ttnn/device.hpp"
 #include "ttnn/operations/core/core.hpp"
 #include "ttnn/async_runtime.hpp"
-#include "ttnn/operations/data_movement.hpp"
+#include "ttnn/operations/data_movement/repeat_interleave/repeat_interleave.hpp"
 #include "tt_numpy/functions.hpp"
 #include "tt_metal/common/logger.hpp"
 

--- a/ttnn/CMakeLists.txt
+++ b/ttnn/CMakeLists.txt
@@ -55,6 +55,7 @@ set(TTNN_SRCS
     ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/embedding/device/embedding_device_operation.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/data_movement/slice/device/slice_op.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/data_movement/permute/permute_impl.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/data_movement/repeat_interleave/repeat_interleave.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/normalization/softmax/device/softmax_op.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/normalization/softmax/device/multi_core/softmax_op_multi_core.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/data_movement/pad/device/pad_op.cpp

--- a/ttnn/cpp/ttnn/deprecated/tt_dnn/op_library/composite/composite_ops.cpp
+++ b/ttnn/cpp/ttnn/deprecated/tt_dnn/op_library/composite/composite_ops.cpp
@@ -774,50 +774,6 @@ Tensor addalpha(
         cq_id, input_a, input_b, alpha, output_mem_config, output_tensor);
 }
 
-// repeat interleave supports repeats as 1 to inf, dim between 0 to 2
-Tensor _repeat_interleave(const Tensor& input_a, uint32_t repeat, int32_t dim, const MemoryConfig& output_mem_config) {
-    std::vector<Tensor> combined_tensors;
-    combined_tensors.reserve(repeat);
-    auto shape_wh = input_a.get_legacy_shape();
-    // normalizing the negative dim
-    uint32_t normalized_dim = input_a.get_legacy_shape().get_normalized_index(dim);
-    // check if dim is 1 or 3
-    if (normalized_dim & 1) {
-        constexpr uint32_t tmp_dim = 2;
-        std::vector<int64_t> dims = {0, 1, 2, 3};
-        std::swap(dims[dim], dims[tmp_dim]);
-        Tensor transpose_input = ttnn::permute(input_a, dims);
-        Tensor ril_result = _repeat_interleave(transpose_input, repeat, tmp_dim, output_mem_config);
-        return ttnn::permute(ril_result, dims);
-    }
-
-    if (normalized_dim <= 1) {
-        for (int i = 0; i < repeat; i++) {
-            combined_tensors.push_back(input_a);
-        }
-        // TODO: For dim = 1 facing issue with concat_op
-        if (normalized_dim) {
-            Tensor concat_out = concat(combined_tensors, 2, output_mem_config);
-            return reshape(concat_out, shape_wh[0], shape_wh[1] * repeat, shape_wh[2], shape_wh[3], output_mem_config);
-        } else {
-            Tensor concat_out = concat(combined_tensors, 1, output_mem_config);
-            return reshape(concat_out, shape_wh[0] * repeat, shape_wh[1], shape_wh[2], shape_wh[3], output_mem_config);
-        }
-    } else {
-        Tensor reshape_out =
-            reshape(input_a, 1, 1, shape_wh[0] * shape_wh[1] * shape_wh[2], shape_wh[3], output_mem_config);
-        for (int i = 0; i < repeat; i++) {
-            combined_tensors.push_back(reshape_out);
-        }
-        Tensor concat_out = concat(combined_tensors, 1, output_mem_config);
-        std::vector<int64_t> permute_dims = {0, 2, 1, 3};
-        Tensor permute_out = ttnn::permute(concat_out, permute_dims, output_mem_config);
-        return reshape(permute_out, shape_wh[0], shape_wh[1], shape_wh[2] * repeat, shape_wh[3], output_mem_config);
-    }
-}
-Tensor repeat_interleave(const Tensor& input_a, uint32_t repeat, int32_t dim, const MemoryConfig& output_mem_config) {
-    return operation::decorate_as_composite(__func__, _repeat_interleave)(input_a, repeat, dim, output_mem_config);
-}
 
 // addcmul(input,tensor1,tensor2,value)=input+value×tensor1×tensor2
 Tensor _addcmul(

--- a/ttnn/cpp/ttnn/deprecated/tt_dnn/op_library/composite/composite_ops.hpp
+++ b/ttnn/cpp/ttnn/deprecated/tt_dnn/op_library/composite/composite_ops.hpp
@@ -272,13 +272,6 @@ Tensor addalpha(
     const MemoryConfig& output_mem_config = operation::DEFAULT_OUTPUT_MEMORY_CONFIG,
     std::optional<Tensor> output_tensor = std::nullopt);
 
-// repeat interleave
-Tensor repeat_interleave(
-    const Tensor& input_a,
-    uint32_t repeat,
-    int32_t dim,
-    const MemoryConfig& output_mem_config = operation::DEFAULT_OUTPUT_MEMORY_CONFIG);
-
 // lerp(input, end, weight) = start + weight * (end - start), weight is float
 Tensor lerp(
     const Tensor& input_a,

--- a/ttnn/cpp/ttnn/deprecated/tt_lib/csrc/tt_lib_bindings_tensor_composite_ops.cpp
+++ b/ttnn/cpp/ttnn/deprecated/tt_lib/csrc/tt_lib_bindings_tensor_composite_ops.cpp
@@ -663,29 +663,6 @@ void TensorModuleCompositeOPs(py::module& m_tensor) {
         )doc");
 
     m_tensor.def(
-        "repeat_interleave",
-        &repeat_interleave,
-        py::arg("input").noconvert(),
-        py::arg("repeat"),
-        py::arg("dim"),
-        py::arg("output_mem_config").noconvert() = operation::DEFAULT_OUTPUT_MEMORY_CONFIG,
-        R"doc(
-            Repeated tensor which has the same shape as ``input``, except along the given axis.
-
-            Input tensor must have BFLOAT16 data type.
-
-            Output tensor will have BFLOAT16 data type.
-
-            .. csv-table::
-                :header: "Argument", "Description", "Data type", "Valid range", "Required"
-
-                "input", "Tensor input is applied to", "Tensor", "Tensor of shape [W, Z, Y, X]", "Yes"
-                "repeat", "Repeat value", "int", "1 to inf", "Yes"
-                "dim", "dim value", "int", "0 to 2", "Yes"
-                "output_mem_config", "Layout of tensor in TT Accelerator device memory banks", "MemoryConfig", "Default is interleaved in DRAM", "No"
-        )doc");
-
-    m_tensor.def(
         "full_like",
         [](const Tensor& reference_tensor,
            float value,

--- a/ttnn/cpp/ttnn/operations/data_movement.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement.hpp
@@ -85,28 +85,11 @@ struct Repeat {
     }
 };
 
-struct RepeatInterleave {
-
-    // # This operation does not support the following cases:
-    // #   - Shape([2[32], 2[32]]) -> repeats = 2, dim = 0
-    // #   - Shape([2[32], 2[32]]) -> repeats = Tensor[1,2], dim = 1
-    static ttnn::Tensor operator()(
-        const ttnn::Tensor& input_tensor,
-        uint32_t repeats,
-        int32_t dim,
-        std::optional<MemoryConfig> output_mem_config = std::nullopt) {
-        MemoryConfig mem_config = output_mem_config.value_or(input_tensor.memory_config());
-        auto output_tensor = tt::tt_metal::repeat_interleave(input_tensor, repeats, dim, mem_config);
-        return output_tensor;
-    }
-};
 
 }  // namespace data_movement
 }  // namespace operations
 
 constexpr auto upsample = ttnn::register_operation_with_auto_launch_op<"ttnn::upsample", ttnn::operations::data_movement::UpSample>();
 constexpr auto repeat = ttnn::register_operation_with_auto_launch_op<"ttnn::repeat", ttnn::operations::data_movement::Repeat>();
-constexpr auto repeat_interleave =
-    ttnn::register_operation_with_auto_launch_op<"ttnn::repeat_interleave", ttnn::operations::data_movement::RepeatInterleave>();
 
 }  // namespace ttnn

--- a/ttnn/cpp/ttnn/operations/data_movement/data_movement_pybind.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/data_movement_pybind.hpp
@@ -16,6 +16,7 @@
 #include "ttnn/operations/data_movement/slice/slice_pybind.hpp"
 #include "ttnn/operations/data_movement/tilize/tilize_pybind.hpp"
 #include "ttnn/operations/data_movement/tilize_with_val_padding/tilize_with_val_padding_pybind.hpp"
+#include "ttnn/operations/data_movement/repeat_interleave/repeat_interleave_pybind.hpp"
 
 namespace py = pybind11;
 
@@ -41,43 +42,6 @@ void bind_upsample(py::module& module) {
         doc,
         ttnn::pybind_arguments_t{
             py::arg("input_tensor"), py::arg("scale_factor"), py::arg("memory_config") = std::nullopt});
-}
-
-void bind_repeat_interleave(py::module& module) {
-    auto doc = R"doc(
-repeat_interleave(input_tensor: ttnn.Tensor, repeats : int, dim: int = 0) -> ttnn.Tensor
-
-Repeats elements of a :attr:`tensor` in the given :attr:`dim`.
-
-Args:
-    * :attr:`input_tensor`: the input_tensor to apply the repeate interleave operation.
-    * :attr:`repeats`: The number of repetitions for each element. repeats is broadcasted to fit the shape of the given axis.
-    * :attr:`dim`: the dimension to expand with the repetitions.
-
-Example:
-
-torch_input_tensor =
-    torch_result = torch.repeat_interleave(torch_input_tensor, repeats, dim=dim)
-
-    input_tensor = ttnn.from_torch(torch_input_tensor, layout=ttnn.TILE_LAYOUT, device=device)
-
-    output = ttnn.repeat_interleave(input_tensor, repeats, dim=dim)
-    >>> a = ttnn.from_torch(torch.rand(1, 1, 32, 32, dtype=torch.bfloat16), layout=ttnn.TILE_LAYOUT, device=device)
-    >>> b = ttnn.repeat_interleave(a, 2, dim=0)
-    >>> print(a.shape, b.shape)
-    ttnn.Shape([1, 1, 32, 32]) ttnn.Shape([2, 1, 32, 32])
-        )doc";
-
-    ttnn::bind_registered_operation(
-        module,
-        ttnn::repeat_interleave,
-        doc,
-        ttnn::pybind_arguments_t{
-            py::arg("input_tensor"),
-            py::arg("repeats"),
-            py::arg("dim"),
-            py::kw_only(),
-            py::arg("memory_config") = std::nullopt});
 }
 
 void bind_repeat(py::module& module) {
@@ -119,7 +83,7 @@ void py_module(py::module& module) {
     detail::bind_slice(module);
     detail::bind_downsample(module);
     bind_repeat(module);
-    bind_repeat_interleave(module);
+    detail::bind_repeat_interleave(module);
     detail::bind_tilize(module);
     detail::bind_tilize_with_val_padding(module);
     detail::bind_tilize_with_zero_padding(module);

--- a/ttnn/cpp/ttnn/operations/data_movement/repeat_interleave/repeat_interleave.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/repeat_interleave/repeat_interleave.cpp
@@ -1,0 +1,58 @@
+// SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+
+#include "repeat_interleave.hpp"
+
+
+namespace ttnn {
+namespace operations {
+namespace data_movement {
+
+
+// repeat interleave supports repeats as 1 to inf, dim between 0 to 2
+ttnn::Tensor ExecuteRepeatInterleave::operator()(const ttnn::Tensor& input_a, uint32_t repeat, int32_t dim, std::optional<MemoryConfig> output_mem_config) {
+    std::vector<Tensor> combined_tensors;
+    combined_tensors.reserve(repeat);
+    auto shape_wh = input_a.get_legacy_shape();
+    MemoryConfig mem_config = output_mem_config.value_or(input_a.memory_config());
+    // normalizing the negative dim
+    uint32_t normalized_dim = input_a.get_legacy_shape().get_normalized_index(dim);
+    // check if dim is 1 or 3
+    if (normalized_dim & 1) {
+        constexpr uint32_t tmp_dim = 2;
+        std::vector<int64_t> dims = {0, 1, 2, 3};
+        std::swap(dims[dim], dims[tmp_dim]);
+        Tensor transpose_input = ttnn::permute(input_a, dims);
+        Tensor ril_result = ExecuteRepeatInterleave::operator()(transpose_input, repeat, tmp_dim, mem_config);
+        return ttnn::permute(ril_result, dims);
+    }
+    if (normalized_dim <= 1) {
+        for (int i = 0; i < repeat; i++) {
+            combined_tensors.push_back(input_a);
+        }
+        // TODO: For dim = 1 facing issue with concat_op
+        if (normalized_dim) {
+            Tensor concat_out = concat(combined_tensors, 2);
+            return reshape(concat_out, shape_wh[0], shape_wh[1] * repeat, shape_wh[2], shape_wh[3]);
+        } else {
+            Tensor concat_out = concat(combined_tensors, 1);
+            return reshape(concat_out, shape_wh[0] * repeat, shape_wh[1], shape_wh[2], shape_wh[3]);
+        }
+    } else {
+        Tensor reshape_out =
+            reshape(input_a, 1, 1, shape_wh[0] * shape_wh[1] * shape_wh[2], shape_wh[3]);
+        for (int i = 0; i < repeat; i++) {
+            combined_tensors.push_back(reshape_out);
+        }
+        Tensor concat_out = concat(combined_tensors, 1);
+        std::vector<int64_t> permute_dims = {0, 2, 1, 3};
+        Tensor permute_out = ttnn::permute(concat_out, permute_dims);
+        return reshape(permute_out, shape_wh[0], shape_wh[1], shape_wh[2] * repeat, shape_wh[3]);
+    }
+}
+
+}  // namespace data_movement
+}  // namespace operations
+}  // namespace ttnn

--- a/ttnn/cpp/ttnn/operations/data_movement/repeat_interleave/repeat_interleave.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/repeat_interleave/repeat_interleave.hpp
@@ -1,0 +1,38 @@
+// SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include "ttnn/tensor/types.hpp"
+#include "ttnn/deprecated/tt_dnn/op_library/concat/concat_op.hpp"
+#include "ttnn/deprecated/tt_dnn/op_library/repeat/repeat_op.hpp"
+#include "ttnn/operations/core/core.hpp"
+#include "ttnn/operations/data_movement/permute/permute.hpp"
+
+#include <ranges>
+
+namespace ttnn {
+namespace operations {
+namespace data_movement {
+
+
+struct ExecuteRepeatInterleave {
+
+    // # This operation does not support the following cases:
+    // #   - Shape([2[32], 2[32]]) -> repeats = 2, dim = 0
+    // #   - Shape([2[32], 2[32]]) -> repeats = Tensor[1,2], dim = 1
+    static ttnn::Tensor operator()(
+        const ttnn::Tensor& input_tensor,
+        uint32_t repeats,
+        int32_t dim,
+        std::optional<MemoryConfig> output_mem_config = std::nullopt);
+};
+
+}  // namespace data_movement
+}  // namespace operations
+
+constexpr auto repeat_interleave =
+    ttnn::register_operation_with_auto_launch_op<"ttnn::repeat_interleave", ttnn::operations::data_movement::ExecuteRepeatInterleave>();
+
+}  // namespace ttnn

--- a/ttnn/cpp/ttnn/operations/data_movement/repeat_interleave/repeat_interleave.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/repeat_interleave/repeat_interleave.hpp
@@ -22,6 +22,7 @@ struct ExecuteRepeatInterleave {
     // # This operation does not support the following cases:
     // #   - Shape([2[32], 2[32]]) -> repeats = 2, dim = 0
     // #   - Shape([2[32], 2[32]]) -> repeats = Tensor[1,2], dim = 1
+
     static ttnn::Tensor operator()(
         const ttnn::Tensor& input_tensor,
         uint32_t repeats,

--- a/ttnn/cpp/ttnn/operations/data_movement/repeat_interleave/repeat_interleave_pybind.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/repeat_interleave/repeat_interleave_pybind.hpp
@@ -1,0 +1,57 @@
+// SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <pybind11/pybind11.h>
+#include <pybind11/stl.h>
+
+#include "ttnn/cpp/pybind11/decorators.hpp"
+
+#include "repeat_interleave.hpp"
+
+
+
+namespace ttnn::operations::data_movement::detail {
+namespace py = pybind11;
+
+void bind_repeat_interleave(py::module& module) {
+    auto doc =
+    R"doc(repeat_interleave(input_tensor: ttnn.Tensor, repeats : int, dim: int = 0) -> ttnn.Tensor
+
+        Repeats elements of a :attr:`tensor` in the given :attr:`dim`.
+
+        Args:
+            * :attr:`input_tensor`: the input_tensor to apply the repeate interleave operation.
+            * :attr:`repeats`: The number of repetitions for each element. repeats is broadcasted to fit the shape of the given axis.
+            * :attr:`dim`: the dimension to expand with the repetitions.
+
+        Example:
+
+        torch_input_tensor =
+            torch_result = torch.repeat_interleave(torch_input_tensor, repeats, dim=dim)
+
+            input_tensor = ttnn.from_torch(torch_input_tensor, layout=ttnn.TILE_LAYOUT, device=device)
+
+            output = ttnn.repeat_interleave(input_tensor, repeats, dim=dim)
+            >>> a = ttnn.from_torch(torch.rand(1, 1, 32, 32, dtype=torch.bfloat16), layout=ttnn.TILE_LAYOUT, device=device)
+            >>> b = ttnn.repeat_interleave(a, 2, dim=0)
+            >>> print(a.shape, b.shape)
+            ttnn.Shape([1, 1, 32, 32]) ttnn.Shape([2, 1, 32, 32])
+        )doc";
+
+    ttnn::bind_registered_operation(
+        module,
+        ttnn::repeat_interleave,
+        doc,
+        ttnn::pybind_arguments_t{
+            py::arg("input_tensor"),
+            py::arg("repeats"),
+            py::arg("dim"),
+            py::kw_only(),
+            py::arg("memory_config") = std::nullopt});
+}
+
+
+} // namespace ttnn::operations::data_movement::detail


### PR DESCRIPTION
### Ticket
Link to Github Issue  #9750 

### Problem description
Migrate Repeat_interleave to TTNN

### What's changed
- Migrate Repeat_interleave to TTNN
- Implement Repeat_interleave in ttnn/data_movement
- remove from data_movement.hpp
- ttnn api change in tests and models

### Checklist
- [x] Post commit CI https://github.com/tenstorrent/tt-metal/actions/runs/10105539280
- [x] [post-commit] models tests https://github.com/tenstorrent/tt-metal/actions/runs/10085925883
- [x] post commit c++ https://github.com/tenstorrent/tt-metal/actions/runs/10085923511
- [ ] Device perf regressions and output report
- [ ] Model perf regressions and output report
- [ ] Nightly fast dispatch- as main- https://github.com/tenstorrent/tt-metal/actions/runs/10085921131
- [x] T3000 frequent tests https://github.com/tenstorrent/tt-metal/actions/runs/10085917088
- [x] T3000 demo tests https://github.com/tenstorrent/tt-metal/actions/runs/10085918467
- [x] T3000 unit tests https://github.com/tenstorrent/tt-metal/actions/runs/10085915842
- [x] New/Existing tests provide coverage for changes
