### PR TITLE
Update noc_fast_write_dw_inline to correctly set NOC_TARG_ADDR_LO

### DIFF
--- a/tests/tt_metal/tt_metal/test_kernels/dataflow/streams/stream_reg_read_write.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/dataflow/streams/stream_reg_read_write.cpp
@@ -1,0 +1,27 @@
+// SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <cstdint>
+
+#include "dataflow_api.h"
+#include "debug/dprint.h"
+
+void kernel_main() {
+    uint32_t target_noc_x = get_arg_val<uint32_t>(0);
+    uint32_t target_noc_y = get_arg_val<uint32_t>(1);
+    uint32_t stream_id = get_arg_val<uint32_t>(2);
+    uint32_t stream_reg = get_arg_val<uint32_t>(3);
+    uint32_t value_to_write = get_arg_val<uint32_t>(4);
+    uint32_t l1_write_addr = get_arg_val<uint32_t>(5);
+
+    // Write to stream register at `reg_addr` on core [target_noc_x, target_noc_y]
+    uint32_t reg_addr = STREAM_REG_ADDR(stream_id, stream_reg);
+    uint64_t dest_addr = NOC_XY_ADDR(target_noc_x, target_noc_y, reg_addr);
+    noc_inline_dw_write(dest_addr, value_to_write);
+    noc_async_write_barrier();
+
+    // Read back value that was written, store in L1 of this core for host to validate
+    noc_async_read(dest_addr, l1_write_addr, 4);
+    noc_async_read_barrier();
+}

--- a/tests/tt_metal/tt_metal/unit_tests/basic/test_noc.cpp
+++ b/tests/tt_metal/tt_metal/unit_tests/basic/test_noc.cpp
@@ -9,6 +9,7 @@
 #include <random>
 
 #include "basic_fixture.hpp"
+#include "device_fixture.hpp"
 #include "tt_metal/detail/tt_metal.hpp"
 #include "tt_metal/host_api.hpp"
 #include "tt_metal/hostdevcommon/common_runtime_address_map.h"  // FIXME: Should remove dependency on this
@@ -126,4 +127,58 @@ TEST_F(BasicFixture, VerifyNocIdentityTranslationTable) {
         }
     }
     ASSERT_TRUE(tt::tt_metal::CloseDevice(device));
+}
+
+// Tests that kernel can write to and read from a stream register address
+// This is meant to exercise noc_inline_dw_write API
+TEST_F(DeviceFixture, DirectedStreamRegWriteRead) {
+    CoreCoord start_core{0, 0};
+    const uint32_t stream_id = 0;
+    const uint32_t stream_reg = 4;
+
+    for (tt_metal::Device *device : this->devices_) {
+        std::set<CoreCoord> storage_only_cores = device->storage_only_cores();
+
+        tt_metal::Program program = tt_metal::CreateProgram();
+        CoreCoord logical_grid_size = device->compute_with_storage_grid_size();
+        CoreCoord end_core{logical_grid_size.x - 1, logical_grid_size.y - 1};
+        CoreRange all_cores(start_core, end_core);
+        tt_metal::KernelHandle kernel_id = tt_metal::CreateKernel(
+            program,
+            "tests/tt_metal/tt_metal/test_kernels/dataflow/streams/stream_reg_read_write.cpp",
+            all_cores,
+            tt_metal::DataMovementConfig{.processor = tt_metal::DataMovementProcessor::RISCV_0, .noc = tt_metal::NOC::NOC_0}
+        );
+
+        uint32_t value_to_write = 0x1234;
+        for (uint32_t x = 0; x < logical_grid_size.x; x++) {
+            for (uint32_t y = 0; y < logical_grid_size.y; y++) {
+                CoreCoord logical_core(x, y);
+                uint32_t logical_target_x = (x + 1) % logical_grid_size.x;
+                uint32_t logical_target_y = (y + 1) % logical_grid_size.y;
+                CoreCoord logical_target_core(logical_target_x, logical_target_y);
+                CoreCoord worker_target_core = device->worker_core_from_logical_core(logical_target_core);
+
+                tt_metal::SetRuntimeArgs(
+                    program, kernel_id, logical_core,
+                    {worker_target_core.x, worker_target_core.y, stream_id, stream_reg, value_to_write, L1_UNRESERVED_BASE}
+                );
+
+                value_to_write++;
+            }
+        }
+
+        tt_metal::detail::LaunchProgram(device, program);
+
+        uint32_t expected_value_to_read = 0x1234;
+        for (uint32_t x = 0; x < logical_grid_size.x; x++) {
+            for (uint32_t y = 0; y < logical_grid_size.y; y++) {
+                CoreCoord logical_core(x, y);
+                std::vector<uint32_t> readback = {0xDEADBEEF};
+                tt_metal::detail::ReadFromDeviceL1(device, logical_core, L1_UNRESERVED_BASE, sizeof(uint32_t), readback);
+                EXPECT_EQ(readback[0], expected_value_to_read);
+                expected_value_to_read++;
+            }
+        }
+    }
 }

--- a/tt_metal/hw/inc/blackhole/dev_mem_map.h
+++ b/tt_metal/hw/inc/blackhole/dev_mem_map.h
@@ -78,8 +78,8 @@
 /////////////
 // Stack info
 // Increasing the stack size comes at the expense of less local memory for globals
-#define MEM_BRISC_STACK_SIZE 1024
-#define MEM_NCRISC_STACK_SIZE 1024
+#define MEM_BRISC_STACK_SIZE 768
+#define MEM_NCRISC_STACK_SIZE 768
 #define MEM_IERISC_STACK_SIZE 1024
 #define MEM_TRISC0_STACK_SIZE 256
 #define MEM_TRISC1_STACK_SIZE 256

--- a/tt_metal/hw/inc/blackhole/noc_nonblocking_api.h
+++ b/tt_metal/hw/inc/blackhole/noc_nonblocking_api.h
@@ -324,7 +324,7 @@ inline __attribute__((always_inline)) void noc_fast_write_dw_inline(
     while (!noc_cmd_buf_ready(noc, cmd_buf));
     NOC_CMD_BUF_WRITE_REG(noc, cmd_buf, NOC_AT_DATA, val);
     NOC_CMD_BUF_WRITE_REG(noc, cmd_buf, NOC_CTRL, noc_cmd_field);
-    NOC_CMD_BUF_WRITE_REG(noc, cmd_buf, NOC_TARG_ADDR_LO, (uint32_t)(dest_addr & ~(NOC_WORD_BYTES-1)));
+    NOC_CMD_BUF_WRITE_REG(noc, cmd_buf, NOC_TARG_ADDR_LO, (uint32_t)(dest_addr));
     NOC_CMD_BUF_WRITE_REG(noc, cmd_buf, NOC_TARG_ADDR_MID, (uint32_t)(dest_addr >> 32) & 0x1000000F);
     NOC_CMD_BUF_WRITE_REG(noc, cmd_buf, NOC_TARG_ADDR_COORDINATE, (uint32_t)(dest_addr >> NOC_ADDR_COORD_SHIFT) & NOC_COORDINATE_MASK);
     NOC_CMD_BUF_WRITE_REG(noc, cmd_buf, NOC_AT_LEN_BE, be32);


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/9800

### Problem description
BH variant of `noc_fast_write_dw_inline` was setting `NOC_TARG_ADDR_LO` incorrectly by masking upper portion of the address

### What's changed
Fix incorrect masking. This fixes packetized path for test_prefetch/dispatch

### Checklist
- [x] [Post commit CI passes](https://github.com/tenstorrent/tt-metal/actions/runs/10104034913)
- [x] New/Existing tests provide coverage for changes: Added DeviceFixture.DirectedStreamRegWriteRead to do directed write/read from stream reg address to catch future bugs with noc_inline_dw_write
