### PR TITLE
#10565: Cleanup and Remove std function for bw, complex ops

### DIFF
--- a/ttnn/cpp/ttnn/operations/eltwise/binary_backward/binary_backward.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_backward/binary_backward.hpp
@@ -21,9 +21,8 @@ struct ExecuteBinaryBackwardTensor {
         const Tensor &input_tensor_a_arg,
         const Tensor &input_tensor_b_arg,
         const std::optional<MemoryConfig> &memory_config = std::nullopt) {
-        auto op_type = get_function_binary_bw<binary_backward_op_type>();
         auto output_memory_config = memory_config.value_or(input_tensor_a_arg.memory_config());
-        return op_type(grad_tensor_arg, input_tensor_a_arg, input_tensor_b_arg, output_memory_config);
+        return OpHandler<binary_backward_op_type>::handle(grad_tensor_arg, input_tensor_a_arg, input_tensor_b_arg, output_memory_config);
     }
 };
 
@@ -41,8 +40,7 @@ struct ExecuteBinaryBackwardOptionalFloatDefault {
         std::optional<Tensor> input_a_grad = std::nullopt,
         std::optional<Tensor> input_b_grad = std::nullopt) {
         auto output_memory_config = memory_config.value_or(input_tensor_a_arg.memory_config());
-        auto op_type = get_function_binary_bw_opt_float_default<binary_backward_op_type>();
-        return op_type(queue_id, grad_tensor_arg, input_tensor_a_arg, input_tensor_b_arg, parameter, output_memory_config, are_required_outputs, input_a_grad, input_b_grad);
+        return OpHandler<binary_backward_op_type>::handle(queue_id, grad_tensor_arg, input_tensor_a_arg, input_tensor_b_arg, parameter, output_memory_config, are_required_outputs, input_a_grad, input_b_grad);
     }
 
     static std::vector<std::optional<Tensor>> operator()(
@@ -55,8 +53,7 @@ struct ExecuteBinaryBackwardOptionalFloatDefault {
         std::optional<Tensor> input_a_grad = std::nullopt,
         std::optional<Tensor> input_b_grad = std::nullopt) {
         auto output_memory_config = memory_config.value_or(input_tensor_a_arg.memory_config());
-        auto op_type = get_function_binary_bw_opt_float_default<binary_backward_op_type>();
-        return op_type(DefaultQueueId, grad_tensor_arg, input_tensor_a_arg, input_tensor_b_arg, parameter, output_memory_config, are_required_outputs, input_a_grad, input_b_grad);
+        return OpHandler<binary_backward_op_type>::handle(DefaultQueueId, grad_tensor_arg, input_tensor_a_arg, input_tensor_b_arg, parameter, output_memory_config, are_required_outputs, input_a_grad, input_b_grad);
     }
 };
 
@@ -69,9 +66,8 @@ struct ExecuteBinaryBackwardFloatDefault {
         const Tensor &input_tensor_b_arg,
         float parameter,
         const std::optional<MemoryConfig> &memory_config = std::nullopt) {
-        auto op_type = get_function_binary_bw_float_default<binary_backward_op_type>();
         auto output_memory_config = memory_config.value_or(input_tensor_a_arg.memory_config());
-        return op_type(grad_tensor_arg, input_tensor_a_arg, input_tensor_b_arg, parameter, output_memory_config);
+        return OpHandler<binary_backward_op_type>::handle(grad_tensor_arg, input_tensor_a_arg, input_tensor_b_arg, parameter, output_memory_config);
     }
 };
 
@@ -84,9 +80,8 @@ struct ExecuteBinaryBackwardIntDefault {
         const Tensor &input_tensor_b_arg,
         int parameter,
         const std::optional<MemoryConfig> &memory_config = std::nullopt) {
-        auto op_type = get_function_binary_bw_int_default<binary_backward_op_type>();
         auto output_memory_config = memory_config.value_or(input_tensor_a_arg.memory_config());
-        return op_type(grad_tensor_arg, input_tensor_a_arg, input_tensor_b_arg, parameter, output_memory_config);
+        return OpHandler<binary_backward_op_type>::handle(grad_tensor_arg, input_tensor_a_arg, input_tensor_b_arg, parameter, output_memory_config);
     }
 };
 
@@ -99,9 +94,33 @@ struct ExecuteBinaryBackwardFloat {
         const Tensor &input_tensor_b_arg,
         float parameter,
         const std::optional<MemoryConfig> &memory_config = std::nullopt) {
-        auto op_type = get_function_binary_bw_float<binary_backward_op_type>();
         auto output_memory_config = memory_config.value_or(input_tensor_a_arg.memory_config());
-        return op_type(grad_tensor_arg, input_tensor_a_arg, input_tensor_b_arg, parameter, output_memory_config);
+        return OpHandler<binary_backward_op_type>::handle(grad_tensor_arg, input_tensor_a_arg, input_tensor_b_arg, parameter, output_memory_config);
+    }
+};
+
+//OpHandler_binary_bw_opt : get_function_binary_bw_opt
+template <BinaryBackwardOpType binary_backward_op_type>
+struct ExecuteBinaryBackwardOpt {
+
+    static std::vector<std::optional<ttnn::Tensor>> operator()(
+        uint8_t queue_id,
+        const Tensor &grad_tensor_arg,
+        const Tensor &input_tensor_a_arg,
+        const Tensor &input_tensor_b_arg,
+        const std::optional<MemoryConfig> &memory_config = std::nullopt,
+        const std::vector<bool> &are_required_outputs = std::vector<bool>{true, true},
+        std::optional<Tensor> input_a_grad = std::nullopt,
+        std::optional<Tensor> input_b_grad = std::nullopt) {
+        auto output_memory_config = memory_config.value_or(input_tensor_a_arg.memory_config());
+        return OpHandler<binary_backward_op_type>::handle(queue_id,
+            grad_tensor_arg,
+            input_tensor_a_arg,
+            input_tensor_b_arg,
+            output_memory_config,
+            are_required_outputs,
+            input_a_grad,
+            input_b_grad);
     }
 };
 
@@ -119,63 +138,39 @@ struct ExecuteBinaryBackward {
         return op_type(grad_tensor_arg, input_tensor_a_arg, input_tensor_b_arg, output_memory_config);
     }
 
-        // Type 1: Type 1 with 1 string
-        static std::vector<ttnn::Tensor> operator()(
-            const Tensor &grad_tensor_arg,
-            const Tensor &input_tensor_a_arg,
-            string value,
-            const Tensor &input_tensor_b_arg,
-            const std::optional<MemoryConfig> &memory_config = std::nullopt) {
-            auto op_type = BinaryBackwardFunction::get_function_type1_w_string(binary_backward_op_type);
-            auto output_memory_config = memory_config.value_or(input_tensor_a_arg.memory_config());
-            return op_type(grad_tensor_arg, input_tensor_a_arg, input_tensor_b_arg, value, output_memory_config);
-        }
+    // Type 1: Type 1 with 1 string
+    static std::vector<ttnn::Tensor> operator()(
+        const Tensor &grad_tensor_arg,
+        const Tensor &input_tensor_a_arg,
+        string value,
+        const Tensor &input_tensor_b_arg,
+        const std::optional<MemoryConfig> &memory_config = std::nullopt) {
+        auto op_type = BinaryBackwardFunction::get_function_type1_w_string(binary_backward_op_type);
+        auto output_memory_config = memory_config.value_or(input_tensor_a_arg.memory_config());
+        return op_type(grad_tensor_arg, input_tensor_a_arg, input_tensor_b_arg, value, output_memory_config);
+    }
 
-        // Type 3 : Q_ID, type1 args, optional output tensor for inputs based on are_required_outputs value
+    // Type 3 : Q_ID, type1 args, optional output tensor for inputs based on are_required_outputs value
 
-        static std::vector<std::optional<ttnn::Tensor>> operator()(
-            uint8_t queue_id,
-            const Tensor &grad_tensor_arg,
-            const Tensor &input_tensor_a_arg,
-            const Tensor &input_tensor_b_arg,
-            const std::optional<MemoryConfig> &memory_config = std::nullopt,
-            const std::vector<bool> &are_required_outputs = std::vector<bool>{true, true},
-            std::optional<Tensor> input_a_grad = std::nullopt,
-            std::optional<Tensor> input_b_grad = std::nullopt) {
-            auto output_memory_config = memory_config.value_or(input_tensor_a_arg.memory_config());
-            auto op_type = BinaryBackwardFunction::get_function_type3(binary_backward_op_type);
-            return op_type(
-                queue_id,
-                grad_tensor_arg,
-                input_tensor_a_arg,
-                input_tensor_b_arg,
-                output_memory_config,
-                are_required_outputs,
-                input_a_grad,
-                input_b_grad);
-        }
-
-        // Type 3 : type1 args, optional output tensor for inputs based on are_required_outputs value
-
-        static std::vector<std::optional<ttnn::Tensor>> operator()(
-            const Tensor &grad_tensor_arg,
-            const Tensor &input_tensor_a_arg,
-            const Tensor &input_tensor_b_arg,
-            const std::optional<MemoryConfig> &memory_config = std::nullopt,
-            const std::vector<bool> &are_required_outputs = std::vector<bool>{true, true},
-            std::optional<Tensor> input_a_grad = std::nullopt,
-            std::optional<Tensor> input_b_grad = std::nullopt) {
-            auto output_memory_config = memory_config.value_or(input_tensor_a_arg.memory_config());
-            auto op_type = BinaryBackwardFunction::get_function_type3_wo_qid(binary_backward_op_type);
-            return op_type(
-                grad_tensor_arg,
-                input_tensor_a_arg,
-                input_tensor_b_arg,
-                output_memory_config,
-                are_required_outputs,
-                input_a_grad,
-                input_b_grad);
-        }
+    static std::vector<std::optional<ttnn::Tensor>> operator()(
+        uint8_t queue_id,
+        const Tensor &grad_tensor_arg,
+        const Tensor &input_tensor_a_arg,
+        const Tensor &input_tensor_b_arg,
+        const std::optional<MemoryConfig> &memory_config = std::nullopt,
+        const std::vector<bool> &are_required_outputs = std::vector<bool>{true, true},
+        std::optional<Tensor> input_a_grad = std::nullopt,
+        std::optional<Tensor> input_b_grad = std::nullopt) {
+        auto output_memory_config = memory_config.value_or(input_tensor_a_arg.memory_config());
+        return OpHandler<binary_backward_op_type>::handle(queue_id,
+            grad_tensor_arg,
+            input_tensor_a_arg,
+            input_tensor_b_arg,
+            output_memory_config,
+            are_required_outputs,
+            input_a_grad,
+            input_b_grad);
+    }
 };
 
 }  // operations::binary

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_backward/binary_backward_pybind.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_backward/binary_backward_pybind.hpp
@@ -20,7 +20,6 @@ namespace binary_backward {
 
 namespace detail {
 
-//OpHandler_binary_bw : get_function_binary_bw
 template <typename binary_backward_operation_t>
 void bind_binary_backward_ops(py::module& module, const binary_backward_operation_t& operation, const std::string& description) {
     auto doc = fmt::format(
@@ -67,7 +66,6 @@ Example:
             py::arg("memory_config") = std::nullopt});
 }
 
-//OpHandler_binary_bw_int_default : get_function_binary_bw_int_default
 template <typename binary_backward_operation_t>
 void bind_binary_backward_int_default(py::module& module, const binary_backward_operation_t& operation, const std::string& parameter_name, const std::string& parameter_doc, int parameter_value, const std::string& description) {
     auto doc = fmt::format(
@@ -121,7 +119,6 @@ void bind_binary_backward_int_default(py::module& module, const binary_backward_
     );
 }
 
-//OpHandler_binary_bw_opt_float_default : get_function_binary_bw_opt_float_default
 template <typename binary_backward_operation_t>
 void bind_binary_backward_opt_float_default(py::module& module, const binary_backward_operation_t& operation, const std::string& parameter_name, const std::string& parameter_doc, float parameter_value, const std::string& description) {
     auto doc = fmt::format(
@@ -183,7 +180,6 @@ void bind_binary_backward_opt_float_default(py::module& module, const binary_bac
     );
 }
 
-//OpHandler_binary_bw_float_default : get_function_binary_bw_float_default
 template <typename binary_backward_operation_t>
 void bind_binary_backward_float_default(py::module& module, const binary_backward_operation_t& operation, const std::string& parameter_name, const std::string& parameter_doc, float parameter_value, const std::string& description) {
     auto doc = fmt::format(
@@ -237,7 +233,64 @@ void bind_binary_backward_float_default(py::module& module, const binary_backwar
     );
 }
 
-//OpHandler_binary_bw_float : get_function_binary_bw_float
+template <typename binary_backward_operation_t>
+void bind_binary_backward_opt(py::module& module, const binary_backward_operation_t& operation, const std::string& parameter_name, const std::string& parameter_doc, float parameter_value, const std::string& description) {
+    auto doc = fmt::format(
+        R"doc({0}(grad_tensor: ttnn.Tensor, input_tensor_a: ttnn.Tensor, input_tensor_b: ttnn.Tensor, {2}: float, *, memory_config: ttnn.MemoryConfig) -> std::vector<Tensor>
+
+        {5}
+
+        Args:
+            * :attr:`grad_tensor`
+            * :attr:`input_tensor_a`
+            * :attr:`input_tensor_b`
+            * :attr:`{3}` (float):Default value = {4}
+
+        Keyword args:
+            * :attr:`memory_config` (Optional[ttnn.MemoryConfig]): memory config for the output tensor
+
+        Example:
+
+            >>> grad_tensor = ttnn.to_device(ttnn.from_torch(torch.tensor((1, 2), dtype=torch.bfloat16)), device)
+            >>> tensor1 = ttnn.to_device(ttnn.from_torch(torch.tensor((1, 2), dtype=torch.bfloat16)), device)
+            >>> tensor2 = ttnn.to_device(ttnn.from_torch(torch.tensor((0, 1), dtype=torch.bfloat16)), device)
+            >>> output = {1}(grad_tensor, tensor1, tensor2, float)
+        )doc",
+        operation.base_name(),
+        operation.python_fully_qualified_name(),
+        parameter_name,
+        parameter_doc,
+        parameter_value,
+        description);
+
+
+    bind_registered_operation(
+        module,
+        operation,
+        doc,
+        ttnn::pybind_overload_t{
+            [](const binary_backward_operation_t& self,
+               const ttnn::Tensor& grad_tensor,
+               const ttnn::Tensor& input_tensor_a,
+               const ttnn::Tensor& input_tensor_b,
+               const std::optional<ttnn::MemoryConfig>& memory_config,
+               const std::vector<bool>& are_required_outputs,
+               const std::optional<ttnn::Tensor>& input_a_grad,
+               const std::optional<ttnn::Tensor>& input_b_grad,
+               const uint8_t& queue_id) -> std::vector<optional<ttnn::Tensor>> {
+                return self(queue_id, grad_tensor, input_tensor_a, input_tensor_b, memory_config, are_required_outputs, input_a_grad, input_b_grad);
+            },
+            py::arg("grad_tensor"),
+            py::arg("input_tensor_a"),
+            py::arg("input_tensor_b"),
+            py::kw_only(),
+            py::arg("memory_config") = std::nullopt,
+            py::arg("are_required_outputs") = std::vector<bool>{true, true},
+            py::arg("input_a_grad") = std::nullopt,
+            py::arg("input_b_grad") = std::nullopt,
+            py::arg("queue_id") = 0});
+}
+
 template <typename binary_backward_operation_t>
 void bind_binary_backward_float(py::module& module, const binary_backward_operation_t& operation, const std::string& parameter_name, const std::string& parameter_doc, const std::string& description) {
     auto doc = fmt::format(
@@ -287,6 +340,7 @@ void bind_binary_backward_float(py::module& module, const binary_backward_operat
             py::kw_only(),
             py::arg("memory_config") = std::nullopt});
 }
+
 template <typename binary_backward_operation_t>
 void bind_binary_backward(py::module& module, const binary_backward_operation_t& operation, const std::string& description) {
     auto doc = fmt::format(
@@ -345,49 +399,7 @@ Example:
             py::arg("input_tensor_b"),
             py::arg("mode"),
             py::kw_only(),
-            py::arg("memory_config") = std::nullopt},
-
-        ttnn::pybind_overload_t{
-            [](const binary_backward_operation_t& self,
-               const ttnn::Tensor& grad_tensor,
-               const ttnn::Tensor& input_tensor_a,
-               const ttnn::Tensor& input_tensor_b,
-               const std::optional<ttnn::MemoryConfig>& memory_config,
-               const std::vector<bool>& are_required_outputs,
-               const std::optional<ttnn::Tensor>& input_a_grad,
-               const std::optional<ttnn::Tensor>& input_b_grad,
-               const uint8_t& queue_id) -> std::vector<optional<ttnn::Tensor>> {
-                return self(queue_id, grad_tensor, input_tensor_a, input_tensor_b, memory_config, are_required_outputs, input_a_grad, input_b_grad);
-            },
-            py::arg("grad_tensor"),
-            py::arg("input_tensor_a"),
-            py::arg("input_tensor_b"),
-            py::kw_only(),
-            py::arg("memory_config") = std::nullopt,
-            py::arg("are_required_outputs") = std::vector<bool>{true, true},
-            py::arg("input_a_grad") = std::nullopt,
-            py::arg("input_b_grad") = std::nullopt,
-            py::arg("queue_id") = 0},
-
-        ttnn::pybind_overload_t{
-            [](const binary_backward_operation_t& self,
-               const ttnn::Tensor& grad_tensor,
-               const ttnn::Tensor& input_tensor_a,
-               const ttnn::Tensor& input_tensor_b,
-               const std::optional<ttnn::MemoryConfig>& memory_config,
-               const std::vector<bool>& are_required_outputs,
-               const std::optional<ttnn::Tensor>& input_a_grad,
-               const std::optional<ttnn::Tensor>& input_b_grad) -> std::vector<optional<ttnn::Tensor>> {
-                return self(grad_tensor, input_tensor_a, input_tensor_b, memory_config, are_required_outputs, input_a_grad, input_b_grad);
-            },
-            py::arg("grad_tensor"),
-            py::arg("input_tensor_a"),
-            py::arg("input_tensor_b"),
-            py::kw_only(),
-            py::arg("memory_config") = std::nullopt,
-            py::arg("are_required_outputs") = std::vector<bool>{true, true},
-            py::arg("input_a_grad") = std::nullopt,
-            py::arg("input_b_grad") = std::nullopt});
+            py::arg("memory_config") = std::nullopt});
 }
 
 }  // namespace detail

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_backward/device/binary_backward_op.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_backward/device/binary_backward_op.cpp
@@ -12,9 +12,9 @@
 #include "ttnn/operations/data_movement/slice/slice.hpp"
 #include "ttnn/operations/embedding/embedding.hpp"
 #include "ttnn/deprecated/tt_dnn/op_library/bcast/bcast_op.hpp"
-#include "ttnn/deprecated/tt_dnn/op_library/composite/composite_ops.hpp"
 #include "ttnn/operations/eltwise/unary/device/unary_composite_op.hpp"
 #include "ttnn/operations/eltwise/binary/binary_composite.hpp"
+#include "ttnn/operations/eltwise/unary_backward/unary_backward.hpp"
 
 #include "tt_metal/common/constants.hpp"
 #include "tt_metal/host_api.hpp"
@@ -377,7 +377,7 @@ std::vector<Tensor> _bias_gelu_bw(
     TT_FATAL((approximate == "none" || approximate == "tanh") && "Incorrect approximation type (expected 'none', 'tanh')");
     std::vector<Tensor> grad_tensor;
     Tensor input = ttnn::add(input_a, input_b);
-    grad_tensor = ttnn::operations::unary_backward::_gelu_bw(grad, input, approximate = approximate, output_mem_config);
+    grad_tensor = ttnn::gelu_bw(grad, input, approximate = approximate, output_mem_config);
     grad_tensor.emplace_back(grad_tensor[0]);
     return grad_tensor;
 }

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_backward/device/binary_backward_op.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_backward/device/binary_backward_op.cpp
@@ -112,7 +112,7 @@ std::vector<ttnn::Tensor> _subalpha_bw(
 }
 
 std::vector<ttnn::Tensor> _sub_bw(
-    const Tensor& grad, const Tensor& input, const Tensor& other, const MemoryConfig& output_mem_config) {
+    const Tensor& grad, const Tensor& input, const Tensor& other, const std::optional<MemoryConfig>& output_mem_config) {
     return _subalpha_bw(grad, input, other, 1.0, output_mem_config);
 }
 
@@ -142,18 +142,6 @@ std::vector<ttnn::Tensor> _add_bw_inter(
         }
     }
     return output_tensors;
-}
-
-std::vector<std::optional<Tensor>> _add_bw_overload(
-    const Tensor& grad,
-    const Tensor& input,
-    const Tensor& other,
-    const MemoryConfig& output_mem_config,
-    const std::vector<bool>& are_required_outputs,
-    std::optional<Tensor> input_grad,
-    std::optional<Tensor> other_grad) {
-    uint8_t default_queue_id = 0;
-    return _addalpha_bw(default_queue_id, grad, input, other, 1.0f, output_mem_config, are_required_outputs, input_grad, other_grad);
 }
 
 std::vector<ttnn::Tensor> _xlogy_bw(
@@ -322,20 +310,8 @@ std::vector<ttnn::Tensor> _eq_bw_inter(
     return output_tensors;
 }
 
-std::vector<std::optional<Tensor>> _eq_bw_overload(
-    const Tensor& grad,
-    const Tensor& input,
-    const Tensor& other,
-    const MemoryConfig& output_mem_config,
-    const std::vector<bool>& are_required_outputs,
-    std::optional<Tensor> input_grad,
-    std::optional<Tensor> other_grad) {
-    uint8_t default_queue_id = 0;
-    return _eq_bw(default_queue_id, grad, input, other, output_mem_config, are_required_outputs, input_grad, other_grad);
-}
-
 std::vector<Tensor> _assign_bw(
-    const Tensor& grad, const Tensor& input, const Tensor& other, const MemoryConfig& output_mem_config) {
+    const Tensor& grad, const Tensor& input, const Tensor& other, const std::optional<MemoryConfig>& output_mem_config) {
     std::vector<Tensor> grad_tensor;
     grad_tensor.emplace_back(grad);
     grad_tensor.emplace_back(grad);
@@ -377,7 +353,7 @@ std::vector<Tensor> _concat_bw(
     return grad_tensor;
 }
 
-std::vector<Tensor> _binary_comp_bw(const Tensor& grad, const Tensor& input, const Tensor& other, const MemoryConfig& output_mem_config) {
+std::vector<Tensor> _binary_comp_bw(const Tensor& grad, const Tensor& input, const Tensor& other, const std::optional<MemoryConfig>& output_mem_config) {
     std::vector<Tensor> grad_tensor;
     Tensor zero_grad = ttnn::operations::creation::zeros_like(grad, grad.get_dtype(), grad.get_layout(), std::nullopt, output_mem_config);
     grad_tensor.emplace_back(zero_grad);
@@ -407,7 +383,7 @@ std::vector<Tensor> _bias_gelu_bw(
 }
 
 
-std::vector<Tensor> _gt_bw(const Tensor& grad, const Tensor& input, const Tensor& other, const MemoryConfig& output_mem_config) {
+std::vector<Tensor> _gt_bw(const Tensor& grad, const Tensor& input, const Tensor& other, const std::optional<MemoryConfig>& output_mem_config) {
     return _binary_comp_bw(grad, input, other, output_mem_config);
 }
 
@@ -467,13 +443,13 @@ std::vector<Tensor> _div_bw(
     const Tensor& input,
     const Tensor& other,
     string round_mode,
-    const MemoryConfig& output_mem_config) {
+    const std::optional<MemoryConfig>& output_mem_config) {
     std::vector<Tensor> grad_tensor;
     if (round_mode == "None") {
         Tensor grad_a = ttnn::multiply(grad, ttnn::reciprocal(other, output_mem_config), std::nullopt, output_mem_config);
         Tensor t_inf = ttnn::operations::creation::full_like(input, std::numeric_limits<float>::infinity(), input.get_dtype(), input.get_layout(), std::nullopt, output_mem_config);
         Tensor t_nan = ttnn::operations::creation::full_like(input, std::nanf(""), input.get_dtype(), input.get_layout(), std::nullopt, output_mem_config);
-        grad_tensor.emplace_back(where(
+        grad_tensor.emplace_back(ttnn::where(
             ttnn::eqz(other, output_mem_config),
             where(
                 ttnn::eqz(grad, output_mem_config),
@@ -581,25 +557,10 @@ std::vector<ttnn::Tensor> _mul_bw_inter(
     return output_tensors;
 }
 
-std::vector<std::optional<Tensor>> _mul_bw_overload(
-    const Tensor& grad,
-    const Tensor& input,
-    const Tensor& other,
-    const MemoryConfig& output_mem_config,
-    const std::vector<bool>& are_required_outputs,
-    std::optional<Tensor> input_grad,
-    std::optional<Tensor> other_grad) {
-        uint8_t default_queue_id = 0;
-    return _mul_bw(default_queue_id, grad, input, other, output_mem_config, are_required_outputs, input_grad, other_grad);
-}
-
-
 std::function<std::vector<ttnn::Tensor>(const Tensor&, const Tensor&, const Tensor&, const MemoryConfig&)> BinaryBackwardFunction::get_function_type1(BinaryBackwardOpType OpType){
     switch (OpType) {
         case BinaryBackwardOpType::EMBEDDING_BW:
             return _embedding_bw;
-        case BinaryBackwardOpType::SUB_BW:
-            return _sub_bw;
         case BinaryBackwardOpType::LOGADDEXP2_BW:
             return _logaddexp2_bw;
         case BinaryBackwardOpType::SQUARED_DIFFERENCE_BW:
@@ -608,12 +569,8 @@ std::function<std::vector<ttnn::Tensor>(const Tensor&, const Tensor&, const Tens
             return _add_bw_inter;
         case BinaryBackwardOpType::EQ_BW:
             return _eq_bw_inter;
-        case BinaryBackwardOpType::ASSIGN_BW:
-            return _assign_bw;
         case BinaryBackwardOpType::LE_BW:
             return _le_bw;
-        case BinaryBackwardOpType::GT_BW:
-            return _gt_bw;
         case BinaryBackwardOpType::LT_BW:
             return _lt_bw;
         case BinaryBackwardOpType::NE_BW:
@@ -636,36 +593,6 @@ std::function<std::vector<ttnn::Tensor>(const Tensor&, const Tensor&, const Tens
     switch (OpType) {
         case BinaryBackwardOpType::BIAS_GELU_BW:
             return _bias_gelu_bw;
-        case BinaryBackwardOpType::DIV_BW:
-            return _div_bw;
-        default:
-            TT_ASSERT(false && "Undefined op type");
-            return 0;
-    }
-}
-
-std::function<std::vector<std::optional<ttnn::Tensor>>(uint8_t , const Tensor&, const Tensor&, const Tensor&, const MemoryConfig&, const std::vector<bool>&, std::optional<Tensor>, std::optional<Tensor>)> BinaryBackwardFunction::get_function_type3(BinaryBackwardOpType OpType){
-    switch (OpType) {
-        case BinaryBackwardOpType::ADD_BW:
-            return _add_bw;
-        case BinaryBackwardOpType::EQ_BW:
-            return _eq_bw;
-        case BinaryBackwardOpType::MUL_BW:
-            return _mul_bw;
-        default:
-            TT_ASSERT(false && "Undefined op type");
-            return 0;
-    }
-}
-
-std::function<std::vector<std::optional<ttnn::Tensor>>(const Tensor&, const Tensor&, const Tensor&, const MemoryConfig&, const std::vector<bool>&, std::optional<Tensor>, std::optional<Tensor>)> BinaryBackwardFunction::get_function_type3_wo_qid(BinaryBackwardOpType OpType){
-    switch (OpType) {
-        case BinaryBackwardOpType::ADD_BW:
-            return _add_bw_overload;
-        case BinaryBackwardOpType::EQ_BW:
-            return _eq_bw_overload;
-        case BinaryBackwardOpType::MUL_BW:
-            return _mul_bw_overload;
         default:
             TT_ASSERT(false && "Undefined op type");
             return 0;

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_backward/device/binary_backward_op.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_backward/device/binary_backward_op.hpp
@@ -45,11 +45,8 @@ enum class BinaryBackwardOpType {
 struct BinaryBackwardFunction{
 static std::function<std::vector<ttnn::Tensor>(const Tensor&, const Tensor&, const Tensor&, const MemoryConfig&)> get_function_type1(BinaryBackwardOpType OpType); //get_function_binary_bw
 static std::function<std::vector<ttnn::Tensor>(const Tensor&, const Tensor&, const Tensor&, std::string, const MemoryConfig&)> get_function_type1_w_string(BinaryBackwardOpType OpType);
-static std::function<std::vector<std::optional<ttnn::Tensor>>(uint8_t , const Tensor&, const Tensor&, const Tensor&, const MemoryConfig&, const std::vector<bool>&, std::optional<Tensor>, std::optional<Tensor>)> get_function_type3(BinaryBackwardOpType OpType);
-static std::function<std::vector<std::optional<ttnn::Tensor>>(const Tensor&, const Tensor&, const Tensor&, const MemoryConfig&, const std::vector<bool>&, std::optional<Tensor>, std::optional<Tensor>)> get_function_type3_wo_qid(BinaryBackwardOpType OpType);
 };
 
-//OpHandler_binary_bw : get_function_binary_bw
 std::vector<Tensor> _atan2_bw( const Tensor& grad, const Tensor& input, const Tensor& other, const std::optional<MemoryConfig>& output_mem_config);
 std::vector<Tensor> _rsub_bw( const Tensor& grad, const Tensor& input, const Tensor& other, const std::optional<MemoryConfig>& output_mem_config);
 std::vector<Tensor> _embedding_bw( const Tensor& grad, const Tensor& input, const Tensor& other, const std::optional<MemoryConfig>& output_mem_config);
@@ -57,135 +54,153 @@ std::vector<Tensor> _xlogy_bw( const Tensor& grad, const Tensor& input, const Te
 std::vector<Tensor> _hypot_bw( const Tensor& grad, const Tensor& input, const Tensor& other, const std::optional<MemoryConfig>& output_mem_config);
 std::vector<Tensor> _ldexp_bw( const Tensor& grad, const Tensor& input, const Tensor& other, const std::optional<MemoryConfig>& output_mem_config);
 std::vector<Tensor> _logaddexp_bw( const Tensor& grad, const Tensor& input, const Tensor& other, const std::optional<MemoryConfig>& output_mem_config);
+std::vector<Tensor> _sub_bw( const Tensor& grad, const Tensor& input, const Tensor& other, const std::optional<MemoryConfig>& output_mem_config);
+std::vector<Tensor> _gt_bw( const Tensor& grad, const Tensor& input, const Tensor& other, const std::optional<MemoryConfig>& output_mem_config);
+std::vector<Tensor> _assign_bw( const Tensor& grad, const Tensor& input, const Tensor& other, const std::optional<MemoryConfig>& output_mem_config);
 
-//OpHandler_binary_bw_float_default : get_function_binary_bw_float_default
 std::vector<ttnn::Tensor> _subalpha_bw( const Tensor& grad, const Tensor& input, const Tensor& other, float alpha = 1.0f, const std::optional<MemoryConfig>& output_mem_config = std::nullopt);
 
-//OpHandler_binary_bw_float : get_function_binary_bw_float
 std::vector<ttnn::Tensor> _lerp_bw( const Tensor& grad, const Tensor& input, const Tensor& other, float weight , const std::optional<MemoryConfig>& output_mem_config);
 
-//OpHandler_binary_bw_int_default : get_function_binary_bw_int_default
+std::vector<ttnn::Tensor> _div_bw( const Tensor& grad, const Tensor& input, const Tensor& other, string round_mode = "None" , const std::optional<MemoryConfig>& output_mem_config = std::nullopt);
+
 std::vector<ttnn::Tensor> _concat_bw( const Tensor& grad, const Tensor& input, const Tensor& other, int dim = 0, const std::optional<MemoryConfig>& output_mem_config = std::nullopt);
 
-//OpHandler_binary_bw_opt_float_default : get_function_binary_bw_opt_float_default
 std::vector<std::optional<ttnn::Tensor>> _addalpha_bw( uint8_t queue_id, const Tensor& grad, const Tensor& input, const Tensor& other, float alpha = 1.0f, const std::optional<MemoryConfig>& output_mem_config = std::nullopt, const std::vector<bool>& are_required_outputs = std::vector<bool>{true, true}, std::optional<Tensor> input_grad = std::nullopt, std::optional<Tensor> other_grad = std::nullopt);
+
+std::vector<std::optional<ttnn::Tensor>> _add_bw(uint8_t queue_id, const Tensor& grad, const Tensor& input, const Tensor& other, const MemoryConfig& output_mem_config, const std::vector<bool>& are_required_outputs, std::optional<Tensor> input_grad, std::optional<Tensor> other_grad);
+std::vector<std::optional<ttnn::Tensor>> _mul_bw(uint8_t queue_id, const Tensor& grad, const Tensor& input, const Tensor& other, const MemoryConfig& output_mem_config, const std::vector<bool>& are_required_outputs, std::optional<Tensor> input_grad, std::optional<Tensor> other_grad);
+std::vector<std::optional<ttnn::Tensor>> _eq_bw(uint8_t queue_id, const Tensor& grad, const Tensor& input, const Tensor& other, const MemoryConfig& output_mem_config, const std::vector<bool>& are_required_outputs, std::optional<Tensor> input_grad, std::optional<Tensor> other_grad);
 
 // OpHandler struct template
 template <BinaryBackwardOpType OpType>
-struct OpHandler_binary_bw;
+struct OpHandler;
 
-template <BinaryBackwardOpType OpType>
-struct OpHandler_binary_bw_opt_float_default;
-
-template <BinaryBackwardOpType OpType>
-struct OpHandler_binary_bw_float_default;
-
-template <BinaryBackwardOpType OpType>
-struct OpHandler_binary_bw_int_default;
-
-template <BinaryBackwardOpType OpType>
-struct OpHandler_binary_bw_float;
 
 template <>
-struct OpHandler_binary_bw<BinaryBackwardOpType::ATAN2_BW> {
+struct OpHandler<BinaryBackwardOpType::ATAN2_BW> {
     static std::vector<Tensor> handle( const Tensor& grad, const Tensor& input, const Tensor& other, const std::optional<MemoryConfig>& output_mem_config ) {
         return _atan2_bw(grad, input, other, output_mem_config);
     }
 };
 
 template <>
-struct OpHandler_binary_bw<BinaryBackwardOpType::XLOGY_BW> {
+struct OpHandler<BinaryBackwardOpType::XLOGY_BW> {
     static std::vector<Tensor> handle( const Tensor& grad, const Tensor& input, const Tensor& other, const std::optional<MemoryConfig>& output_mem_config ) {
         return _xlogy_bw(grad, input, other, output_mem_config);
     }
 };
 
 template <>
-struct OpHandler_binary_bw<BinaryBackwardOpType::HYPOT_BW> {
+struct OpHandler<BinaryBackwardOpType::HYPOT_BW> {
     static std::vector<Tensor> handle( const Tensor& grad, const Tensor& input, const Tensor& other, const std::optional<MemoryConfig>& output_mem_config ) {
         return _hypot_bw(grad, input, other, output_mem_config);
     }
 };
 
 template <>
-struct OpHandler_binary_bw<BinaryBackwardOpType::LDEXP_BW> {
+struct OpHandler<BinaryBackwardOpType::LDEXP_BW> {
     static std::vector<Tensor> handle( const Tensor& grad, const Tensor& input, const Tensor& other, const std::optional<MemoryConfig>& output_mem_config ) {
         return _ldexp_bw(grad, input, other, output_mem_config);
     }
 };
 
 template <>
-struct OpHandler_binary_bw<BinaryBackwardOpType::LOGADDEXP_BW> {
+struct OpHandler<BinaryBackwardOpType::LOGADDEXP_BW> {
     static std::vector<Tensor> handle( const Tensor& grad, const Tensor& input, const Tensor& other, const std::optional<MemoryConfig>& output_mem_config ) {
         return _logaddexp_bw(grad, input, other, output_mem_config);
     }
 };
 
 template <>
-struct OpHandler_binary_bw<BinaryBackwardOpType::RSUB_BW> {
+struct OpHandler<BinaryBackwardOpType::RSUB_BW> {
     static std::vector<Tensor> handle( const Tensor& grad, const Tensor& input, const Tensor& other, const std::optional<MemoryConfig>& output_mem_config ) {
         return _rsub_bw(grad, input, other, output_mem_config);
     }
 };
 
 template <>
-struct OpHandler_binary_bw_opt_float_default<BinaryBackwardOpType::ADDALPHA_BW> {
+struct OpHandler<BinaryBackwardOpType::SUB_BW> {
+    static std::vector<Tensor> handle( const Tensor& grad, const Tensor& input, const Tensor& other, const std::optional<MemoryConfig>& output_mem_config ) {
+        return _sub_bw(grad, input, other, output_mem_config);
+    }
+};
+
+template <>
+struct OpHandler<BinaryBackwardOpType::GT_BW> {
+    static std::vector<Tensor> handle( const Tensor& grad, const Tensor& input, const Tensor& other, const std::optional<MemoryConfig>& output_mem_config ) {
+        return _gt_bw(grad, input, other, output_mem_config);
+    }
+};
+
+template <>
+struct OpHandler<BinaryBackwardOpType::ASSIGN_BW> {
+    static std::vector<Tensor> handle( const Tensor& grad, const Tensor& input, const Tensor& other, const std::optional<MemoryConfig>& output_mem_config ) {
+        return _assign_bw(grad, input, other, output_mem_config);
+    }
+};
+
+template <>
+struct OpHandler<BinaryBackwardOpType::ADDALPHA_BW> {
     static std::vector<std::optional<ttnn::Tensor>> handle( uint8_t queue_id, const Tensor& grad, const Tensor& input, const Tensor& other, float alpha, const MemoryConfig& output_mem_config, const std::vector<bool>& are_required_outputs, std::optional<Tensor> input_grad, std::optional<Tensor> other_grad ) {
         return _addalpha_bw( queue_id, grad, input, other, alpha, output_mem_config, are_required_outputs, input_grad, other_grad);
     }
 };
 
 template <>
-struct OpHandler_binary_bw<BinaryBackwardOpType::EMBEDDING_BW> {
+struct OpHandler<BinaryBackwardOpType::EMBEDDING_BW> {
     static std::vector<Tensor> handle( const Tensor& grad, const Tensor& input, const Tensor& other, const std::optional<MemoryConfig>& output_mem_config ) {
         return _embedding_bw(grad, input, other, output_mem_config);
     }
 };
 
 template <>
-struct OpHandler_binary_bw_float_default<BinaryBackwardOpType::SUBALPHA_BW> {
+struct OpHandler<BinaryBackwardOpType::SUBALPHA_BW> {
     static std::vector<Tensor> handle( const Tensor& grad, const Tensor& input, const Tensor& other, float alpha, const std::optional<MemoryConfig>& output_mem_config ) {
         return _subalpha_bw(grad, input, other, alpha, output_mem_config);
     }
 };
 
 template <>
-struct OpHandler_binary_bw_int_default<BinaryBackwardOpType::CONCAT_BW> {
+struct OpHandler<BinaryBackwardOpType::DIV_BW> {
+    static std::vector<Tensor> handle( const Tensor& grad, const Tensor& input, const Tensor& other, string round_mode, const std::optional<MemoryConfig>& output_mem_config ) {
+        return _div_bw(grad, input, other, round_mode, output_mem_config);
+    }
+};
+
+template <>
+struct OpHandler<BinaryBackwardOpType::CONCAT_BW> {
     static std::vector<Tensor> handle( const Tensor& grad, const Tensor& input, const Tensor& other, int dim, const std::optional<MemoryConfig>& output_mem_config ) {
         return _concat_bw(grad, input, other, dim, output_mem_config);
     }
 };
 
 template <>
-struct OpHandler_binary_bw_float<BinaryBackwardOpType::LERP_BW> {
+struct OpHandler<BinaryBackwardOpType::ADD_BW> {
+    static std::vector<std::optional<Tensor>> handle(uint8_t queue_id, const Tensor& grad, const Tensor& input, const Tensor& other, const MemoryConfig& output_mem_config, const std::vector<bool>& are_required_outputs, std::optional<Tensor> input_grad, std::optional<Tensor> other_grad) {
+        return _add_bw(queue_id, grad, input, other, output_mem_config, are_required_outputs, input_grad, other_grad);
+    }
+};
+
+template <>
+struct OpHandler<BinaryBackwardOpType::LERP_BW> {
     static std::vector<Tensor> handle( const Tensor& grad, const Tensor& input, const Tensor& other, float weight, const std::optional<MemoryConfig>& output_mem_config ) {
         return _lerp_bw(grad, input, other, weight, output_mem_config);
     }
 };
 
-// Template functions to get the function pointers
-template <BinaryBackwardOpType OpType>
-auto get_function_binary_bw() {
-    return &OpHandler_binary_bw<OpType>::handle;
-}
+template <>
+struct OpHandler<BinaryBackwardOpType::MUL_BW> {
+    static std::vector<std::optional<Tensor>> handle(uint8_t queue_id, const Tensor& grad, const Tensor& input, const Tensor& other, const MemoryConfig& output_mem_config, const std::vector<bool>& are_required_outputs, std::optional<Tensor> input_grad, std::optional<Tensor> other_grad) {
+        return _mul_bw(queue_id, grad, input, other, output_mem_config, are_required_outputs, input_grad, other_grad);
+    }
+};
 
-template <BinaryBackwardOpType OpType>
-auto get_function_binary_bw_opt_float_default() {
-    return &OpHandler_binary_bw_opt_float_default<OpType>::handle;
-}
+template <>
+struct OpHandler<BinaryBackwardOpType::EQ_BW> {
+    static std::vector<std::optional<Tensor>> handle(uint8_t queue_id, const Tensor& grad, const Tensor& input, const Tensor& other, const MemoryConfig& output_mem_config, const std::vector<bool>& are_required_outputs, std::optional<Tensor> input_grad, std::optional<Tensor> other_grad) {
+        return _eq_bw(queue_id, grad, input, other, output_mem_config, are_required_outputs, input_grad, other_grad);
+    }
+};
 
-template <BinaryBackwardOpType OpType>
-auto get_function_binary_bw_float_default() {
-    return &OpHandler_binary_bw_float_default<OpType>::handle;
-}
-
-template <BinaryBackwardOpType OpType>
-auto get_function_binary_bw_int_default() {
-    return &OpHandler_binary_bw_int_default<OpType>::handle;
-}
-
-template <BinaryBackwardOpType OpType>
-auto get_function_binary_bw_float() {
-    return &OpHandler_binary_bw_float<OpType>::handle;
-}
 }  // namespace ttnn::operations::binary_backward

--- a/ttnn/cpp/ttnn/operations/eltwise/complex_binary/complex_binary.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/complex_binary/complex_binary.hpp
@@ -22,8 +22,7 @@ struct ExecuteComplexBinaryType1 {
         const ComplexTensor &input_tensor_a_arg,
         const ComplexTensor &input_tensor_b_arg,
         const MemoryConfig &memory_config) {
-        auto op_type = get_function_complex_binary<complex_binary_op_type>();
-        return op_type(input_tensor_a_arg, input_tensor_b_arg, memory_config);
+        return OpHandler<complex_binary_op_type>::handle(input_tensor_a_arg, input_tensor_b_arg, memory_config);
     }
 };
 

--- a/ttnn/cpp/ttnn/operations/eltwise/complex_binary/device/complex_binary_op.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/complex_binary/device/complex_binary_op.hpp
@@ -55,31 +55,31 @@ ComplexTensor _mul(const ComplexTensor& input_a, const ComplexTensor& input_b, c
 ComplexTensor _div(const ComplexTensor& input_a, const ComplexTensor& input_b, const MemoryConfig& output_mem_config);
 
 template <ComplexBinaryOpType OpType>
-struct OpHandler_complex_binary_type1;
+struct OpHandler;
 
 template <>
-struct OpHandler_complex_binary_type1<ComplexBinaryOpType::ADD> {
+struct OpHandler<ComplexBinaryOpType::ADD> {
     static ComplexTensor handle( const ComplexTensor& input_a, const ComplexTensor& input_b, const MemoryConfig& output_mem_config ) {
         return _add(input_a, input_b, output_mem_config);
     }
 };
 
 template <>
-struct OpHandler_complex_binary_type1<ComplexBinaryOpType::SUB> {
+struct OpHandler<ComplexBinaryOpType::SUB> {
     static ComplexTensor handle( const ComplexTensor& input_a, const ComplexTensor& input_b, const MemoryConfig& output_mem_config ) {
         return _sub(input_a, input_b, output_mem_config);
     }
 };
 
 template <>
-struct OpHandler_complex_binary_type1<ComplexBinaryOpType::MUL> {
+struct OpHandler<ComplexBinaryOpType::MUL> {
     static ComplexTensor handle( const ComplexTensor& input_a, const ComplexTensor& input_b, const MemoryConfig& output_mem_config ) {
         return _mul(input_a, input_b, output_mem_config);
     }
 };
 
 template <>
-struct OpHandler_complex_binary_type1<ComplexBinaryOpType::DIV> {
+struct OpHandler<ComplexBinaryOpType::DIV> {
     static ComplexTensor handle( const ComplexTensor& input_a, const ComplexTensor& input_b, const MemoryConfig& output_mem_config ) {
         return _div(input_a, input_b, output_mem_config);
     }
@@ -87,7 +87,7 @@ struct OpHandler_complex_binary_type1<ComplexBinaryOpType::DIV> {
 
 template <ComplexBinaryOpType OpType>
 auto get_function_complex_binary() {
-    return &OpHandler_complex_binary_type1<OpType>::handle;
+    return &OpHandler<OpType>::handle;
 }
 
 }  // namespace ttnn::operations::complex_binary

--- a/ttnn/cpp/ttnn/operations/eltwise/complex_binary_backward/complex_binary_backward.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/complex_binary_backward/complex_binary_backward.hpp
@@ -25,8 +25,7 @@ struct ExecuteComplexBinaryBackwardWFloat {
         const ComplexTensor &input_tensor_b_arg,
         float alpha,
         const MemoryConfig &memory_config) {
-        auto op_type = get_function_w_float<complex_binary_backward_op_type>();
-        return op_type(grad_tensor_arg, input_tensor_a_arg, input_tensor_b_arg, alpha, memory_config);
+        return OpHandler<complex_binary_backward_op_type>::handle(grad_tensor_arg, input_tensor_a_arg, input_tensor_b_arg, alpha, memory_config);
     }
 };
 
@@ -40,8 +39,7 @@ struct ExecuteComplexBinaryBackwardWoFloat {
         const ComplexTensor &input_tensor_a_arg,
         const ComplexTensor &input_tensor_b_arg,
         const MemoryConfig &memory_config) {
-        auto op_type = get_function_wo_float<complex_binary_backward_op_type>();
-        return op_type(grad_tensor_arg, input_tensor_a_arg, input_tensor_b_arg, memory_config);
+        return OpHandler<complex_binary_backward_op_type>::handle(grad_tensor_arg, input_tensor_a_arg, input_tensor_b_arg, memory_config);
     }
 };
 

--- a/ttnn/cpp/ttnn/operations/eltwise/complex_binary_backward/complex_binary_backward.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/complex_binary_backward/complex_binary_backward.hpp
@@ -17,8 +17,6 @@ using ComplexTensor = complex_binary::ComplexTensor;
 template <ComplexBinaryBackwardOpType complex_binary_backward_op_type>
 struct ExecuteComplexBinaryBackwardWFloat {
 
-    //Type 1: 2 inputs, 1 grad tensor 1 float
-
     static std::vector<ComplexTensor> operator()(
         const ComplexTensor &grad_tensor_arg,
         const ComplexTensor &input_tensor_a_arg,
@@ -31,8 +29,6 @@ struct ExecuteComplexBinaryBackwardWFloat {
 
 template <ComplexBinaryBackwardOpType complex_binary_backward_op_type>
 struct ExecuteComplexBinaryBackwardWoFloat {
-
-    //Type 1: 2 inputs, 1 grad tensor
 
     static std::vector<ComplexTensor> operator()(
         const ComplexTensor &grad_tensor_arg,

--- a/ttnn/cpp/ttnn/operations/eltwise/complex_binary_backward/device/complex_binary_backward_op.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/complex_binary_backward/device/complex_binary_backward_op.cpp
@@ -9,7 +9,7 @@
 #include "ttnn/operations/eltwise/complex_unary/device/complex_unary_op.hpp"
 #include "ttnn/operations/eltwise/binary/binary.hpp"
 #include "ttnn/operations/eltwise/complex_binary/device/complex_binary_op.hpp"
-
+#include "ttnn/operations/eltwise/complex_unary/complex_unary.hpp"
 
 namespace ttnn::operations::complex_binary_backward {
 using ComplexTensor = complex_binary::ComplexTensor;
@@ -50,9 +50,9 @@ std::vector<ComplexTensor> _complex_sub_bw(const ComplexTensor& grad, const Comp
 // grad_other = grad * input.conj()
 std::vector<ComplexTensor> _complex_mul_bw(const ComplexTensor& grad, const ComplexTensor& input, const ComplexTensor& other, const MemoryConfig& output_mem_config) {
     std::vector<ComplexTensor> grad_tensor;
-    ComplexTensor grad_a = ttnn::operations::complex_binary::_mul(grad, ttnn::operations::complex_unary::_conj(other,output_mem_config), output_mem_config);
+    ComplexTensor grad_a = ttnn::operations::complex_binary::_mul(grad, ttnn::conj(other,output_mem_config), output_mem_config);
     grad_tensor.emplace_back(grad_a);
-    ComplexTensor grad_b = ttnn::operations::complex_binary::_mul(grad, ttnn::operations::complex_unary::_conj(input,output_mem_config), output_mem_config);
+    ComplexTensor grad_b = ttnn::operations::complex_binary::_mul(grad, ttnn::conj(input,output_mem_config), output_mem_config);
     grad_tensor.emplace_back(grad_b);
     return grad_tensor;
 }
@@ -63,18 +63,18 @@ std::vector<ComplexTensor> _complex_mul_bw(const ComplexTensor& grad, const Comp
 std::vector<ComplexTensor> _complex_div_bw(const ComplexTensor& grad, const ComplexTensor& input, const ComplexTensor& other, const MemoryConfig& output_mem_config) {
     std::vector<ComplexTensor> grad_tensor;
     Tensor condition_nan = ttnn::logical_and(ttnn::eqz(other.real(),output_mem_config), ttnn::eqz(other.imag(),output_mem_config), std::nullopt, output_mem_config);
-    ComplexTensor grad_a = ttnn::operations::complex_binary::_div(grad, ttnn::operations::complex_unary::_conj(other,output_mem_config), output_mem_config);
-    Tensor grad_a_r = where(condition_nan, ttnn::operations::creation::full_like(grad.real(), std::nanf(""), std::nullopt, std::nullopt, std::nullopt, output_mem_config), ttnn::operations::complex_unary::_real(grad_a,output_mem_config),  output_mem_config);
-    Tensor grad_a_i = where(condition_nan, ttnn::operations::creation::full_like(grad.imag(), std::nanf(""), std::nullopt, std::nullopt, std::nullopt, output_mem_config), ttnn::operations::complex_unary::_imag(grad_a,output_mem_config),  output_mem_config);
+    ComplexTensor grad_a = ttnn::operations::complex_binary::_div(grad, ttnn::conj(other,output_mem_config), output_mem_config);
+    Tensor grad_a_r = where(condition_nan, ttnn::operations::creation::full_like(grad.real(), std::nanf(""), std::nullopt, std::nullopt, std::nullopt, output_mem_config), ttnn::real(grad_a,output_mem_config),  output_mem_config);
+    Tensor grad_a_i = where(condition_nan, ttnn::operations::creation::full_like(grad.imag(), std::nanf(""), std::nullopt, std::nullopt, std::nullopt, output_mem_config), ttnn::imag(grad_a,output_mem_config),  output_mem_config);
     grad_a = ComplexTensor({grad_a_r, grad_a_i});
     grad_a_r.deallocate();
     grad_a_i.deallocate();
     grad_tensor.emplace_back(grad_a);
     ComplexTensor neg_grad = ComplexTensor({ttnn::neg(grad.real(),output_mem_config), ttnn::neg(grad.imag(),output_mem_config)});
-    ComplexTensor grad_b = ttnn::operations::complex_binary::_mul(neg_grad, ttnn::operations::complex_unary::_conj(ttnn::operations::complex_binary::_div(ttnn::operations::complex_binary::_div(input, other, output_mem_config), other, output_mem_config ),output_mem_config), output_mem_config);
+    ComplexTensor grad_b = ttnn::operations::complex_binary::_mul(neg_grad, ttnn::conj(ttnn::operations::complex_binary::_div(ttnn::operations::complex_binary::_div(input, other, output_mem_config), other, output_mem_config ),output_mem_config), output_mem_config);
     neg_grad.deallocate();
-    Tensor grad_b_r = where(condition_nan, ttnn::operations::creation::full_like(grad.real(), std::nanf(""), std::nullopt, std::nullopt, std::nullopt, output_mem_config), ttnn::operations::complex_unary::_real(grad_b,output_mem_config),  output_mem_config);
-    Tensor grad_b_i = where(condition_nan, ttnn::operations::creation::full_like(grad.imag(), std::nanf(""), std::nullopt, std::nullopt, std::nullopt, output_mem_config), ttnn::operations::complex_unary::_imag(grad_b,output_mem_config),  output_mem_config);
+    Tensor grad_b_r = where(condition_nan, ttnn::operations::creation::full_like(grad.real(), std::nanf(""), std::nullopt, std::nullopt, std::nullopt, output_mem_config), ttnn::real(grad_b,output_mem_config),  output_mem_config);
+    Tensor grad_b_i = where(condition_nan, ttnn::operations::creation::full_like(grad.imag(), std::nanf(""), std::nullopt, std::nullopt, std::nullopt, output_mem_config), ttnn::imag(grad_b,output_mem_config),  output_mem_config);
     grad_b = ComplexTensor({grad_b_r, grad_b_i});
     grad_b_r.deallocate();
     grad_b_i.deallocate();

--- a/ttnn/cpp/ttnn/operations/eltwise/complex_binary_backward/device/complex_binary_backward_op.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/complex_binary_backward/device/complex_binary_backward_op.hpp
@@ -28,47 +28,34 @@ std::vector<ComplexTensor> _complex_mul_bw(const ComplexTensor& grad, const Comp
 std::vector<ComplexTensor> _complex_div_bw(const ComplexTensor& grad, const ComplexTensor& input, const ComplexTensor& other, const MemoryConfig& output_mem_config);
 
 template <ComplexBinaryBackwardOpType OpType>
-struct OpHandler_complex_wo_float;
-
-template <ComplexBinaryBackwardOpType OpType>
-struct OpHandler_complex_w_float;
+struct OpHandler;
 
 template <>
-struct OpHandler_complex_wo_float<ComplexBinaryBackwardOpType::COMPLEX_MUL_BW> {
+struct OpHandler<ComplexBinaryBackwardOpType::COMPLEX_MUL_BW> {
     static std::vector<ComplexTensor> handle( const ComplexTensor& grad, const ComplexTensor& input, const ComplexTensor& other, const MemoryConfig& output_mem_config ) {
         return _complex_mul_bw(grad, input, other, output_mem_config);
     }
 };
 
 template <>
-struct OpHandler_complex_wo_float<ComplexBinaryBackwardOpType::COMPLEX_DIV_BW> {
+struct OpHandler<ComplexBinaryBackwardOpType::COMPLEX_DIV_BW> {
     static std::vector<ComplexTensor> handle( const ComplexTensor& grad, const ComplexTensor& input, const ComplexTensor& other, const MemoryConfig& output_mem_config ) {
         return _complex_div_bw(grad, input, other, output_mem_config);
     }
 };
 
 template <>
-struct OpHandler_complex_w_float<ComplexBinaryBackwardOpType::COMPLEX_ADD_BW> {
+struct OpHandler<ComplexBinaryBackwardOpType::COMPLEX_ADD_BW> {
     static std::vector<ComplexTensor> handle( const ComplexTensor& grad, const ComplexTensor& input, const ComplexTensor& other, float alpha, const MemoryConfig& output_mem_config ) {
         return _complex_add_bw(grad, input, other, alpha, output_mem_config);
     }
 };
 
 template <>
-struct OpHandler_complex_w_float<ComplexBinaryBackwardOpType::COMPLEX_SUB_BW> {
+struct OpHandler<ComplexBinaryBackwardOpType::COMPLEX_SUB_BW> {
     static std::vector<ComplexTensor> handle( const ComplexTensor& grad, const ComplexTensor& input, const ComplexTensor& other, float alpha, const MemoryConfig& output_mem_config ) {
         return _complex_sub_bw(grad, input, other, alpha, output_mem_config);
     }
 };
-
-template <ComplexBinaryBackwardOpType OpType>
-auto get_function_wo_float() {
-    return &OpHandler_complex_wo_float<OpType>::handle;
-}
-
-template <ComplexBinaryBackwardOpType OpType>
-auto get_function_w_float() {
-    return &OpHandler_complex_w_float<OpType>::handle;
-}
 
 }  // namespace ttnn::operations::complex_binary_backward

--- a/ttnn/cpp/ttnn/operations/eltwise/complex_unary/complex_unary.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/complex_unary/complex_unary.hpp
@@ -20,8 +20,7 @@ struct ExecuteComplexUnaryType1 {
 
     //Type 1: 1 input tensor
     static Tensor operator()(const ComplexTensor &input_tensor_arg, const MemoryConfig &memory_config) {
-        auto op_type = get_function_complex_unary<complex_unary_op_type>();
-        return op_type(input_tensor_arg, memory_config);
+        return OpHandler<complex_unary_op_type>::handle(input_tensor_arg, memory_config);
     }
 };
 
@@ -29,8 +28,7 @@ struct ExecuteComplexUnaryType1 {
 template <ComplexUnaryOpType complex_unary_op_type>
 struct ExecuteComplexUnaryType2 {
     static ComplexTensor operator()(const ComplexTensor &input_tensor_arg, const MemoryConfig &memory_config) {
-        auto op_type = get_function_complex_unary_type2<complex_unary_op_type>();
-        return op_type(input_tensor_arg, memory_config);
+        return OpHandler<complex_unary_op_type>::handle(input_tensor_arg, memory_config);
     }
 };
 

--- a/ttnn/cpp/ttnn/operations/eltwise/complex_unary/device/complex_unary_op.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/complex_unary/device/complex_unary_op.cpp
@@ -4,7 +4,6 @@
 
 
 #include "ttnn/deprecated/tt_dnn/op_library/bcast/bcast_op.hpp"
-#include "ttnn/deprecated/tt_dnn/op_library/composite/composite_ops.hpp"
 #include "tt_metal/common/constants.hpp"
 #include "tt_metal/host_api.hpp"
 #include "tt_metal/tools/profiler/op_profiler.hpp"

--- a/ttnn/cpp/ttnn/operations/eltwise/complex_unary/device/complex_unary_op.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/complex_unary/device/complex_unary_op.hpp
@@ -41,69 +41,66 @@ ComplexTensor _reciprocal(const ComplexTensor& input, const MemoryConfig& output
 ComplexTensor _polar(const ComplexTensor& input, const MemoryConfig& output_mem_config);
 
 template <ComplexUnaryOpType OpType>
-struct OpHandler_complex_type1;
-
-template <ComplexUnaryOpType OpType>
-struct OpHandler_complex_type2;
+struct OpHandler;
 
 template <>
-struct OpHandler_complex_type1<ComplexUnaryOpType::REAL> {
+struct OpHandler<ComplexUnaryOpType::REAL> {
     static Tensor handle( const ComplexTensor& input, const MemoryConfig& output_mem_config ) {
         return _real(input, output_mem_config);
     }
 };
 
 template <>
-struct OpHandler_complex_type1<ComplexUnaryOpType::IMAG> {
+struct OpHandler<ComplexUnaryOpType::IMAG> {
     static Tensor handle( const ComplexTensor& input, const MemoryConfig& output_mem_config ) {
         return _imag(input, output_mem_config);
     }
 };
 
 template <>
-struct OpHandler_complex_type1<ComplexUnaryOpType::ANGLE> {
+struct OpHandler<ComplexUnaryOpType::ANGLE> {
     static Tensor handle( const ComplexTensor& input, const MemoryConfig& output_mem_config ) {
         return _angle(input, output_mem_config);
     }
 };
 
 template <>
-struct OpHandler_complex_type1<ComplexUnaryOpType::IS_IMAG> {
+struct OpHandler<ComplexUnaryOpType::IS_IMAG> {
     static Tensor handle( const ComplexTensor& input, const MemoryConfig& output_mem_config ) {
         return _is_imag(input, output_mem_config);
     }
 };
 
 template <>
-struct OpHandler_complex_type1<ComplexUnaryOpType::IS_REAL> {
+struct OpHandler<ComplexUnaryOpType::IS_REAL> {
     static Tensor handle( const ComplexTensor& input, const MemoryConfig& output_mem_config ) {
         return _is_real(input, output_mem_config);
     }
 };
 
 template <>
-struct OpHandler_complex_type1<ComplexUnaryOpType::ABS> {
+struct OpHandler<ComplexUnaryOpType::ABS> {
     static Tensor handle( const ComplexTensor& input, const MemoryConfig& output_mem_config ) {
         return _abs(input, output_mem_config);
     }
 };
 
 template <>
-struct OpHandler_complex_type2<ComplexUnaryOpType::CONJ> {
+struct OpHandler<ComplexUnaryOpType::CONJ> {
     static ComplexTensor handle( const ComplexTensor& input, const MemoryConfig& output_mem_config ) {
         return _conj(input, output_mem_config);
     }
 };
 
 template <>
-struct OpHandler_complex_type2<ComplexUnaryOpType::RECIPROCAL> {
+struct OpHandler<ComplexUnaryOpType::RECIPROCAL> {
     static ComplexTensor handle( const ComplexTensor& input, const MemoryConfig& output_mem_config ) {
         return _reciprocal(input, output_mem_config);
     }
 };
 
 template <>
-struct OpHandler_complex_type2<ComplexUnaryOpType::POLAR> {
+struct OpHandler<ComplexUnaryOpType::POLAR> {
     static ComplexTensor handle( const ComplexTensor& input, const MemoryConfig& output_mem_config ) {
         return _polar(input, output_mem_config);
     }
@@ -111,12 +108,12 @@ struct OpHandler_complex_type2<ComplexUnaryOpType::POLAR> {
 
 template <ComplexUnaryOpType OpType>
 auto get_function_complex_unary() {
-    return &OpHandler_complex_type1<OpType>::handle;
+    return &OpHandler<OpType>::handle;
 }
 
 template <ComplexUnaryOpType OpType>
 auto get_function_complex_unary_type2() {
-    return &OpHandler_complex_type2<OpType>::handle;
+    return &OpHandler<OpType>::handle;
 }
 
 

--- a/ttnn/cpp/ttnn/operations/eltwise/complex_unary_backward/complex_unary_backward.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/complex_unary_backward/complex_unary_backward.hpp
@@ -14,7 +14,6 @@ namespace ttnn {
 namespace operations::complex_unary_backward {
 using ComplexTensor = complex_binary::ComplexTensor;
 
-//OpHandler_complex : get_function_complex
 template <ComplexUnaryBackwardOpType complex_unary_backward_op_type>
 struct ExecuteComplexUnaryBackward {
     static std::vector<ComplexTensor> operator()(
@@ -25,7 +24,6 @@ struct ExecuteComplexUnaryBackward {
     }
 };
 
-//OpHandler_tensor_complex : get_function_tensor_complex
 template <ComplexUnaryBackwardOpType complex_unary_backward_op_type>
 struct ExecuteComplexUnaryBackwardTensor {
     static std::vector<ComplexTensor> operator()(
@@ -36,11 +34,9 @@ struct ExecuteComplexUnaryBackwardTensor {
 
 }
 
-//OpHandler_complex : get_function_complex
 constexpr auto polar_bw = ttnn::register_operation<"ttnn::polar_bw", operations::complex_unary_backward::ExecuteComplexUnaryBackward<operations::complex_unary_backward::ComplexUnaryBackwardOpType::POLAR_BW>>();
 constexpr auto conj_bw = ttnn::register_operation<"ttnn::conj_bw", operations::complex_unary_backward::ExecuteComplexUnaryBackward<operations::complex_unary_backward::ComplexUnaryBackwardOpType::CONJ_BW>>();
 
-//OpHandler_tensor_complex : get_function_tensor_complex
 constexpr auto imag_bw = ttnn::register_operation<"ttnn::imag_bw", operations::complex_unary_backward::ExecuteComplexUnaryBackwardTensor<operations::complex_unary_backward::ComplexUnaryBackwardOpType::IMAG_BW>>();
 constexpr auto real_bw = ttnn::register_operation<"ttnn::real_bw", operations::complex_unary_backward::ExecuteComplexUnaryBackwardTensor<operations::complex_unary_backward::ComplexUnaryBackwardOpType::REAL_BW>>();
 constexpr auto angle_bw = ttnn::register_operation<"ttnn::angle_bw", operations::complex_unary_backward::ExecuteComplexUnaryBackwardTensor<operations::complex_unary_backward::ComplexUnaryBackwardOpType::ANGLE_BW>>();

--- a/ttnn/cpp/ttnn/operations/eltwise/complex_unary_backward/complex_unary_backward.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/complex_unary_backward/complex_unary_backward.hpp
@@ -21,8 +21,7 @@ struct ExecuteComplexUnaryBackward {
         const ComplexTensor &grad_tensor_arg,
         const ComplexTensor &input_tensor_arg,
         const MemoryConfig &memory_config) {
-        auto op_type = get_function_complex<complex_unary_backward_op_type>();
-        return op_type(grad_tensor_arg, input_tensor_arg, memory_config);
+        return OpHandler<complex_unary_backward_op_type>::handle(grad_tensor_arg, input_tensor_arg, memory_config);
     }
 };
 
@@ -31,8 +30,7 @@ template <ComplexUnaryBackwardOpType complex_unary_backward_op_type>
 struct ExecuteComplexUnaryBackwardTensor {
     static std::vector<ComplexTensor> operator()(
         const Tensor &grad_tensor_arg, const ComplexTensor &input_tensor_arg, const MemoryConfig &memory_config) {
-        auto op_type = get_function_tensor_complex<complex_unary_backward_op_type>();
-        return op_type(grad_tensor_arg, input_tensor_arg, memory_config);
+        return OpHandler<complex_unary_backward_op_type>::handle(grad_tensor_arg, input_tensor_arg, memory_config);
     }
 };
 

--- a/ttnn/cpp/ttnn/operations/eltwise/complex_unary_backward/complex_unary_backward_pybind.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/complex_unary_backward/complex_unary_backward_pybind.hpp
@@ -21,7 +21,6 @@ namespace complex_unary_backward {
 namespace detail {
 using ComplexTensor = complex_binary::ComplexTensor;
 
-//OpHandler_complex : get_function_complex
 template <typename complex_unary_backward_operation_t>
 void bind_complex_unary_backward(py::module& module, const complex_unary_backward_operation_t& operation, const std::string& description) {
     auto doc = fmt::format(
@@ -63,7 +62,6 @@ Example:
             py::arg("memory_config")});
 }
 
-//OpHandler_tensor_complex : get_function_tensor_complex
 template <typename complex_unary_backward_operation_t>
 void bind_complex_unary_backward_tensor(py::module& module, const complex_unary_backward_operation_t& operation, const std::string& description) {
     auto doc = fmt::format(

--- a/ttnn/cpp/ttnn/operations/eltwise/complex_unary_backward/device/complex_unary_backward_op.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/complex_unary_backward/device/complex_unary_backward_op.hpp
@@ -25,80 +25,65 @@ enum class ComplexUnaryBackwardOpType {
     COMPLEX_RECIP_BW,
 };
 
-//OpHandler_complex : get_function_complex
 std::vector<ComplexTensor> _polar_bw(const ComplexTensor& grad, const ComplexTensor& input, const MemoryConfig& output_mem_config);
 std::vector<ComplexTensor> _conj_bw(const ComplexTensor& grad, const ComplexTensor& input, const MemoryConfig& output_mem_config);
 std::vector<ComplexTensor> _complex_recip_bw(const ComplexTensor& grad, const ComplexTensor& input, const MemoryConfig& output_mem_config);
 
-//OpHandler_tensor_complex : get_function_tensor_complex
 std::vector<ComplexTensor> _imag_bw(const Tensor& grad, const ComplexTensor& input, const MemoryConfig& output_mem_config);
 std::vector<ComplexTensor> _real_bw(const Tensor& grad, const ComplexTensor& input, const MemoryConfig& output_mem_config);
 std::vector<ComplexTensor> _angle_bw(const Tensor& grad, const ComplexTensor& input, const MemoryConfig& output_mem_config);
 std::vector<ComplexTensor> _complex_abs_bw(const Tensor& grad, const ComplexTensor& input, const MemoryConfig& output_mem_config);
 
 template <ComplexUnaryBackwardOpType OpType>
-struct OpHandler_complex;
-
-template <ComplexUnaryBackwardOpType OpType>
-struct OpHandler_tensor_complex;
+struct OpHandler;
 
 template <>
-struct OpHandler_complex<ComplexUnaryBackwardOpType::POLAR_BW> {
+struct OpHandler<ComplexUnaryBackwardOpType::POLAR_BW> {
     static std::vector<ComplexTensor> handle( const ComplexTensor& grad, const ComplexTensor& input, const MemoryConfig& output_mem_config ) {
         return _polar_bw(grad, input, output_mem_config);
     }
 };
 
 template <>
-struct OpHandler_complex<ComplexUnaryBackwardOpType::CONJ_BW> {
+struct OpHandler<ComplexUnaryBackwardOpType::CONJ_BW> {
     static std::vector<ComplexTensor> handle( const ComplexTensor& grad, const ComplexTensor& input, const MemoryConfig& output_mem_config ) {
         return _conj_bw(grad, input, output_mem_config);
     }
 };
 
 template <>
-struct OpHandler_complex<ComplexUnaryBackwardOpType::COMPLEX_RECIP_BW> {
+struct OpHandler<ComplexUnaryBackwardOpType::COMPLEX_RECIP_BW> {
     static std::vector<ComplexTensor> handle( const ComplexTensor& grad, const ComplexTensor& input, const MemoryConfig& output_mem_config ) {
         return _complex_recip_bw(grad, input, output_mem_config);
     }
 };
 
 template <>
-struct OpHandler_tensor_complex<ComplexUnaryBackwardOpType::IMAG_BW> {
+struct OpHandler<ComplexUnaryBackwardOpType::IMAG_BW> {
     static std::vector<ComplexTensor> handle( const Tensor& grad, const ComplexTensor& input, const MemoryConfig& output_mem_config ) {
         return _imag_bw(grad, input, output_mem_config);
     }
 };
 
 template <>
-struct OpHandler_tensor_complex<ComplexUnaryBackwardOpType::REAL_BW> {
+struct OpHandler<ComplexUnaryBackwardOpType::REAL_BW> {
     static std::vector<ComplexTensor> handle( const Tensor& grad, const ComplexTensor& input, const MemoryConfig& output_mem_config ) {
         return _real_bw(grad, input, output_mem_config);
     }
 };
 
 template <>
-struct OpHandler_tensor_complex<ComplexUnaryBackwardOpType::ANGLE_BW> {
+struct OpHandler<ComplexUnaryBackwardOpType::ANGLE_BW> {
     static std::vector<ComplexTensor> handle( const Tensor& grad, const ComplexTensor& input, const MemoryConfig& output_mem_config ) {
         return _angle_bw(grad, input, output_mem_config);
     }
 };
 
 template <>
-struct OpHandler_tensor_complex<ComplexUnaryBackwardOpType::COMPLEX_ABS_BW> {
+struct OpHandler<ComplexUnaryBackwardOpType::COMPLEX_ABS_BW> {
     static std::vector<ComplexTensor> handle( const Tensor& grad, const ComplexTensor& input, const MemoryConfig& output_mem_config ) {
         return _complex_abs_bw(grad, input, output_mem_config);
     }
 };
-
-template <ComplexUnaryBackwardOpType OpType>
-auto get_function_complex() {
-    return &OpHandler_complex<OpType>::handle;
-}
-
-template <ComplexUnaryBackwardOpType OpType>
-auto get_function_tensor_complex() {
-    return &OpHandler_tensor_complex<OpType>::handle;
-}
 
 }  // namespace ttnn::operations::complex_unary_backward

--- a/ttnn/cpp/ttnn/operations/eltwise/ternary_backward/device/ternary_backward_op.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/ternary_backward/device/ternary_backward_op.hpp
@@ -32,12 +32,6 @@ std::vector<OptionalTensor> _where_bw(uint8_t, const Tensor&, const Tensor&, con
 template <TernaryBackwardOpType OpType>
 struct OpHandler;
 
-template <TernaryBackwardOpType OpType>
-struct OpHandler_float;
-
-template <TernaryBackwardOpType OpType>
-struct OpHandler_Where;
-
 template <>
 struct OpHandler<TernaryBackwardOpType::LERP_BW> {
     static std::vector<Tensor> handle(const Tensor& t1, const Tensor& t2, const Tensor& t3, const Tensor& t4,
@@ -47,7 +41,7 @@ struct OpHandler<TernaryBackwardOpType::LERP_BW> {
 };
 
 template <>
-struct OpHandler_float<TernaryBackwardOpType::ADDCMUL_BW> {
+struct OpHandler<TernaryBackwardOpType::ADDCMUL_BW> {
     static std::vector<Tensor> handle(const Tensor& t1, const Tensor& t2, const Tensor& t3, const Tensor& t4,
                                         float value, const MemoryConfig& mem_cfg) {
         return _addcmul_bw(t1, t2, t3, t4, value, mem_cfg);
@@ -55,7 +49,7 @@ struct OpHandler_float<TernaryBackwardOpType::ADDCMUL_BW> {
 };
 
 template <>
-struct OpHandler_float<TernaryBackwardOpType::ADDCDIV_BW> {
+struct OpHandler<TernaryBackwardOpType::ADDCDIV_BW> {
     static std::vector<Tensor> handle(const Tensor& t1, const Tensor& t2, const Tensor& t3, const Tensor& t4,
                                         float value, const MemoryConfig& mem_cfg) {
         return _addcdiv_bw(t1, t2, t3, t4, value, mem_cfg);
@@ -63,26 +57,12 @@ struct OpHandler_float<TernaryBackwardOpType::ADDCDIV_BW> {
 };
 
 template <>
-struct OpHandler_Where<TernaryBackwardOpType::WHERE_BW> {
+struct OpHandler<TernaryBackwardOpType::WHERE_BW> {
     static std::vector<OptionalTensor> handle(uint8_t queue_id, const Tensor& t1, const Tensor& t2, const Tensor& t3,
                                                      const Tensor& t4, const MemoryConfig& mem_cfg, const std::vector<bool>& are_required_outputs,
                                                      OptionalTensor input_grad, OptionalTensor other_grad) {
         return _where_bw(queue_id, t1, t2, t3, t4, mem_cfg, are_required_outputs, input_grad, other_grad);
     }
 };
-
-// Template functions to get the function pointers
-template <TernaryBackwardOpType OpType>
-auto get_ternary_fn() {
-    return &OpHandler<OpType>::handle;
-}
-template <TernaryBackwardOpType OpType>
-auto get_ternary_fn_float() {
-    return &OpHandler_float<OpType>::handle;
-}
-template <TernaryBackwardOpType OpType>
-auto get_ternary_fn_opt_output() {
-    return &OpHandler_Where<OpType>::handle;
-}
 
 }  // namespace ttnn::operations::ternary_backward

--- a/ttnn/cpp/ttnn/operations/eltwise/ternary_backward/ternary_backward.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/ternary_backward/ternary_backward.hpp
@@ -32,8 +32,7 @@ struct ExecuteTernaryBackward {
         const Tensor &input_tensor_b_arg,
         const Tensor &input_tensor_c_arg,
         const MemoryConfig &memory_config) {
-        auto op_type = get_ternary_fn<ternary_backward_op_type>();
-        return op_type(grad_tensor_arg, input_tensor_a_arg, input_tensor_b_arg, input_tensor_c_arg, memory_config);
+        return OpHandler<ternary_backward_op_type>::handle(grad_tensor_arg, input_tensor_a_arg, input_tensor_b_arg, input_tensor_c_arg, memory_config);
     }
 };
 
@@ -57,8 +56,7 @@ struct ExecuteTernaryBackwardFloat {
         const Tensor &input_tensor_c_arg,
         float alpha,
         const MemoryConfig &memory_config) {
-        auto op_type = get_ternary_fn_float<ternary_backward_op_type>();
-        return op_type(grad_tensor_arg, input_tensor_a_arg, input_tensor_b_arg, input_tensor_c_arg, alpha, memory_config);
+        return OpHandler<ternary_backward_op_type>::handle(grad_tensor_arg, input_tensor_a_arg, input_tensor_b_arg, input_tensor_c_arg, alpha, memory_config);
     }
 };
 
@@ -86,8 +84,7 @@ struct ExecuteTernaryBackwardOptional {
         OptionalTensor input_a_grad = std::nullopt,
         OptionalTensor input_b_grad = std::nullopt) {
         auto output_memory_config = memory_config.value_or(input_tensor_a_arg.memory_config());
-        auto op_type = get_ternary_fn_opt_output<ternary_backward_op_type>();
-        return op_type(queue_id, grad_tensor_arg, input_tensor_a_arg, input_tensor_b_arg, input_tensor_c_arg, output_memory_config, are_required_outputs, input_a_grad, input_b_grad);
+        return OpHandler<ternary_backward_op_type>::handle(queue_id, grad_tensor_arg, input_tensor_a_arg, input_tensor_b_arg, input_tensor_c_arg, output_memory_config, are_required_outputs, input_a_grad, input_b_grad);
     }
 
     //type1 args, optional output tensor for inputs based on are_required_outputs value
@@ -102,8 +99,7 @@ struct ExecuteTernaryBackwardOptional {
         OptionalTensor input_a_grad = std::nullopt,
         OptionalTensor input_b_grad = std::nullopt) {
         auto output_memory_config = memory_config.value_or(input_tensor_a_arg.memory_config());
-        auto op_type = get_ternary_fn_opt_output<ternary_backward_op_type>();
-        return op_type(DefaultQueueId, grad_tensor_arg, input_tensor_a_arg, input_tensor_b_arg, input_tensor_c_arg, output_memory_config, are_required_outputs, input_a_grad, input_b_grad);
+        return OpHandler<ternary_backward_op_type>::handle(DefaultQueueId, grad_tensor_arg, input_tensor_a_arg, input_tensor_b_arg, input_tensor_c_arg, output_memory_config, are_required_outputs, input_a_grad, input_b_grad);
     }
 };
 

--- a/ttnn/cpp/ttnn/operations/eltwise/unary_backward/device/unary_backward_op.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary_backward/device/unary_backward_op.cpp
@@ -6,7 +6,6 @@
 
 #include "third_party/magic_enum/magic_enum.hpp"
 #include "ttnn/deprecated/tt_dnn/op_library/bcast/bcast_op.hpp"
-#include "ttnn/deprecated/tt_dnn/op_library/composite/composite_ops.hpp"
 #include "tt_metal/common/constants.hpp"
 #include "tt_metal/host_api.hpp"
 #include "tt_metal/tools/profiler/op_profiler.hpp"

--- a/ttnn/cpp/ttnn/operations/eltwise/unary_backward/device/unary_backward_op.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary_backward/device/unary_backward_op.hpp
@@ -106,209 +106,245 @@ struct UnaryBackwardFunction{
     static std::function<std::vector<ttnn::Tensor>(const Tensor&, const Tensor&, float, const MemoryConfig&)> get_function_type1_w_float(UnaryBackwardOpType OpType);
 };
 
-//OpHandler_two_float : get_function_type1_w_two_float
 std::vector<Tensor> _threshold_bw( const Tensor& grad, const Tensor& input, float threshold, float value, const std::optional<MemoryConfig>& output_mem_config);
 
-//OpHandler_two_float_with_default : get_function_type1_w_two_float_with_default
+std::vector<Tensor> _remainder_bw( const Tensor& grad, const Tensor& input, float scalar, const std::optional<MemoryConfig>& output_mem_config);
+std::vector<Tensor> _fmod_bw( const Tensor& grad, const Tensor& input, float scalar, const std::optional<MemoryConfig>& output_mem_config);
+std::vector<Tensor> _sub_bw( const Tensor& grad, const Tensor& input, float scalar, const std::optional<MemoryConfig>& output_mem_config);
+std::vector<Tensor> _gt_bw( const Tensor& grad, const Tensor& input, float other, const std::optional<MemoryConfig>& output_mem_config);
+
+std::vector<Tensor> _assign_bw( const Tensor& grad, const Tensor& input, const std::optional<MemoryConfig>& output_mem_config);
+std::vector<Tensor> _multigammaln_bw( const Tensor& grad, const Tensor& input, const std::optional<MemoryConfig>& output_mem_config);
+std::vector<Tensor> _lgamma_bw( const Tensor& grad, const Tensor& input, const std::optional<MemoryConfig>& output_mem_config);
+std::vector<Tensor> _fill_bw( const Tensor& grad, const Tensor& input, const std::optional<MemoryConfig>& output_mem_config);
+std::vector<Tensor> _hardsigmoid_bw( const Tensor& grad, const Tensor& input, const std::optional<MemoryConfig>& output_mem_config);
+std::vector<Tensor> _cos_bw( const Tensor& grad, const Tensor& input, const std::optional<MemoryConfig>& output_mem_config);
+std::vector<Tensor> _acosh_bw( const Tensor& grad, const Tensor& input, const std::optional<MemoryConfig>& output_mem_config);
+
 std::vector<Tensor> _softplus_bw( const Tensor& grad, const Tensor& input, float beta = 1.0, float threshold = 20.0, const std::optional<MemoryConfig>& output_mem_config = std::nullopt);
 std::vector<Tensor> _hardtanh_bw( const Tensor& grad, const Tensor& input, float min = -1.0, float max = 1.0, const std::optional<MemoryConfig>& output_mem_config = std::nullopt);
 
-//OpHandler_optional_float_params_with_default : get_function_optional_float_params_with_default
+std::vector<Tensor> _add_bw( const Tensor& grad, const Tensor& input, float alpha, const std::optional<MemoryConfig>& output_mem_config = std::nullopt);
+std::vector<Tensor> _mul_bw( const Tensor& grad, const Tensor& input, float scalar, const std::optional<MemoryConfig>& output_mem_config = std::nullopt);
+std::vector<Tensor> _eq_bw( const Tensor& grad, const Tensor& input, float other, const std::optional<MemoryConfig>& output_mem_config = std::nullopt);
+
 std::vector<Tensor> _clamp_bw( const Tensor& grad, const Tensor& input, std::optional<float> min = std::nullopt, std::optional<float> max = std::nullopt, const std::optional<MemoryConfig>& output_mem_config = std::nullopt);
 
-//OpHandler_float_string_default : get_function_type1_float_string_default
 std::vector<Tensor> _div_bw( const Tensor& grad, const Tensor& input, float scalar, string round_mode = "None", const std::optional<MemoryConfig>& output_mem_config = std::nullopt);
 std::vector<Tensor> _rdiv_bw( const Tensor& grad, const Tensor& input, float scalar, string round_mode = "None", const std::optional<MemoryConfig>& output_mem_config = std::nullopt);
 std::vector<Tensor> _bias_gelu_bw( const Tensor& grad, const Tensor& input, float bias, string approximate = "none", const std::optional<MemoryConfig>& output_mem_config = std::nullopt);
 
-//OpHandler_string_default : get_function_type1_string_default
 std::vector<Tensor> _gelu_bw( const Tensor& grad, const Tensor& input, string approximate = "none", const std::optional<MemoryConfig>& output_mem_config = std::nullopt);
 
-//OpHandler_shape : get_function_type1_shape
 std::vector<Tensor> _repeat_bw(const Tensor& grad, const Tensor& input, const tt::tt_metal::Shape& shape, const std::optional<MemoryConfig>& output_mem_config);
 
-//OpHandler_unary_optional_float : get_function_unary_optional_float
 std::vector<std::optional<Tensor>> _pow_bw(uint8_t queue_id, const Tensor& grad, const Tensor& input, float exponent, const MemoryConfig& output_mem_config , const std::vector<bool>& are_required_outputs, std::optional<Tensor> input_grad);
 
-//OpHandler_unary_optional : get_function_unary_optional
 std::vector<std::optional<Tensor>> _exp_bw(uint8_t queue_id, const Tensor& grad, const Tensor& input, const MemoryConfig& output_mem_config, const std::vector<bool>& are_required_outputs, std::optional<Tensor> input_grad);
 std::vector<std::optional<Tensor>> _tanh_bw(uint8_t queue_id, const Tensor& grad, const Tensor& input, const MemoryConfig& output_mem_config, const std::vector<bool>& are_required_outputs, std::optional<Tensor> input_grad);
 std::vector<std::optional<Tensor>> _sqrt_bw(uint8_t queue_id, const Tensor& grad, const Tensor& input, const MemoryConfig& output_mem_config, const std::vector<bool>& are_required_outputs, std::optional<Tensor> input_grad);
 
-//OpHandler_prod_bw : get_function_prod_bw
 std::vector<Tensor> _prod_bw( const Tensor& grad, const Tensor& input, bool all_dimensions = true, int64_t dim = 0, const std::optional<MemoryConfig>& output_mem_config = std::nullopt);
 Tensor change_layout_to_tile(const Tensor& temp, const MemoryConfig& output_mem_config);
 
 // OpHandler struct template
 template <UnaryBackwardOpType OpType>
-struct OpHandler_two_float;
-
-template <UnaryBackwardOpType OpType>
-struct OpHandler_two_float_with_default;
-
-template <UnaryBackwardOpType OpType>
-struct OpHandler_float_string_default;
-
-template <UnaryBackwardOpType OpType>
-struct OpHandler_string_default;
-
-template <UnaryBackwardOpType OpType>
-struct OpHandler_shape;
-
-template <UnaryBackwardOpType OpType>
-struct OpHandler_unary_optional_float;
-
-template <UnaryBackwardOpType OpType>
-struct OpHandler_unary_optional;
-
-template <UnaryBackwardOpType OpType>
-struct OpHandler_prod_bw;
-
-template <UnaryBackwardOpType OpType>
-struct OpHandler_optional_float_params_with_default;
+struct OpHandler;
 
 template <>
-struct OpHandler_optional_float_params_with_default<UnaryBackwardOpType::CLAMP_BW> {
+struct OpHandler<UnaryBackwardOpType::CLAMP_BW> {
     static std::vector<Tensor> handle( const Tensor& grad, const Tensor& input, std::optional<float> min, std::optional<float> max, const std::optional<MemoryConfig>& output_mem_config ) {
         return _clamp_bw(grad, input, min, max, output_mem_config);
     }
 };
 
 template <>
-struct OpHandler_two_float_with_default<UnaryBackwardOpType::HARDTANH_BW> {
+struct OpHandler<UnaryBackwardOpType::HARDTANH_BW> {
     static std::vector<Tensor> handle( const Tensor& grad, const Tensor& input, float min, float max, const std::optional<MemoryConfig>& output_mem_config ) {
         return _hardtanh_bw(grad, input, min, max, output_mem_config);
     }
 };
 
 template <>
-struct OpHandler_two_float<UnaryBackwardOpType::THRESHOLD_BW> {
+struct OpHandler<UnaryBackwardOpType::THRESHOLD_BW> {
     static std::vector<Tensor> handle( const Tensor& grad, const Tensor& input, float threshold, float value, const std::optional<MemoryConfig>& output_mem_config ) {
         return _threshold_bw(grad, input, threshold, value, output_mem_config);
     }
 };
 
 template <>
-struct OpHandler_two_float_with_default<UnaryBackwardOpType::SOFTPLUS_BW> {
+struct OpHandler<UnaryBackwardOpType::REMAINDER_BW> {
+    static std::vector<Tensor> handle( const Tensor& grad, const Tensor& input, float scalar, const std::optional<MemoryConfig>& output_mem_config ) {
+        return _remainder_bw(grad, input, scalar, output_mem_config);
+    }
+};
+
+template <>
+struct OpHandler<UnaryBackwardOpType::FMOD_BW> {
+    static std::vector<Tensor> handle( const Tensor& grad, const Tensor& input, float scalar, const std::optional<MemoryConfig>& output_mem_config ) {
+        return _fmod_bw(grad, input, scalar, output_mem_config);
+    }
+};
+
+template <>
+struct OpHandler<UnaryBackwardOpType::GT_BW> {
+    static std::vector<Tensor> handle( const Tensor& grad, const Tensor& input, float other, const std::optional<MemoryConfig>& output_mem_config ) {
+        return _gt_bw(grad, input, other, output_mem_config);
+    }
+};
+
+template <>
+struct OpHandler<UnaryBackwardOpType::ASSIGN_BW> {
+    static std::vector<Tensor> handle( const Tensor& grad, const Tensor& input, const std::optional<MemoryConfig>& output_mem_config ) {
+        return _assign_bw(grad, input, output_mem_config);
+    }
+};
+
+template <>
+struct OpHandler<UnaryBackwardOpType::MULTIGAMMALN_BW> {
+    static std::vector<Tensor> handle( const Tensor& grad, const Tensor& input, const std::optional<MemoryConfig>& output_mem_config ) {
+        return _multigammaln_bw(grad, input, output_mem_config);
+    }
+};
+
+template <>
+struct OpHandler<UnaryBackwardOpType::LGAMMA_BW> {
+    static std::vector<Tensor> handle( const Tensor& grad, const Tensor& input, const std::optional<MemoryConfig>& output_mem_config ) {
+        return _lgamma_bw(grad, input, output_mem_config);
+    }
+};
+
+template <>
+struct OpHandler<UnaryBackwardOpType::FILL_BW> {
+    static std::vector<Tensor> handle( const Tensor& grad, const Tensor& input, const std::optional<MemoryConfig>& output_mem_config ) {
+        return _fill_bw(grad, input, output_mem_config);
+    }
+};
+
+template <>
+struct OpHandler<UnaryBackwardOpType::HARDSIGMOID_BW> {
+    static std::vector<Tensor> handle( const Tensor& grad, const Tensor& input, const std::optional<MemoryConfig>& output_mem_config ) {
+        return _hardsigmoid_bw(grad, input, output_mem_config);
+    }
+};
+
+template <>
+struct OpHandler<UnaryBackwardOpType::COS_BW> {
+    static std::vector<Tensor> handle( const Tensor& grad, const Tensor& input, const std::optional<MemoryConfig>& output_mem_config ) {
+        return _cos_bw(grad, input, output_mem_config);
+    }
+};
+
+template <>
+struct OpHandler<UnaryBackwardOpType::ACOSH_BW> {
+    static std::vector<Tensor> handle( const Tensor& grad, const Tensor& input, const std::optional<MemoryConfig>& output_mem_config ) {
+        return _acosh_bw(grad, input, output_mem_config);
+    }
+};
+
+template <>
+struct OpHandler<UnaryBackwardOpType::SUB_BW> {
+    static std::vector<Tensor> handle( const Tensor& grad, const Tensor& input, float scalar, const std::optional<MemoryConfig>& output_mem_config ) {
+        return _sub_bw(grad, input, scalar, output_mem_config);
+    }
+};
+
+template <>
+struct OpHandler<UnaryBackwardOpType::SOFTPLUS_BW> {
     static std::vector<Tensor> handle( const Tensor& grad, const Tensor& input, float beta, float threshold, const std::optional<MemoryConfig>& output_mem_config ) {
         return _softplus_bw(grad, input, beta, threshold, output_mem_config);
     }
 };
 
 template <>
-struct OpHandler_float_string_default<UnaryBackwardOpType::DIV_BW> {
+struct OpHandler<UnaryBackwardOpType::DIV_BW> {
     static std::vector<Tensor> handle( const Tensor& grad, const Tensor& input, float scalar, string round_mode, const std::optional<MemoryConfig>& output_mem_config ) {
         return _div_bw(grad, input, scalar, round_mode, output_mem_config);
     }
 };
 
 template <>
-struct OpHandler_float_string_default<UnaryBackwardOpType::RDIV_BW> {
+struct OpHandler<UnaryBackwardOpType::RDIV_BW> {
     static std::vector<Tensor> handle( const Tensor& grad, const Tensor& input, float scalar, string round_mode, const std::optional<MemoryConfig>& output_mem_config ) {
         return _rdiv_bw(grad, input, scalar, round_mode, output_mem_config);
     }
 };
 
 template <>
-struct OpHandler_float_string_default<UnaryBackwardOpType::BIAS_GELU_BW> {
+struct OpHandler<UnaryBackwardOpType::BIAS_GELU_BW> {
     static std::vector<Tensor> handle( const Tensor& grad, const Tensor& input, float bias, string approximate, const std::optional<MemoryConfig>& output_mem_config ) {
         return _bias_gelu_bw(grad, input, bias, approximate, output_mem_config);
     }
 };
 
 template <>
-struct OpHandler_unary_optional_float<UnaryBackwardOpType::POW_BW> {
+struct OpHandler<UnaryBackwardOpType::POW_BW> {
     static std::vector<std::optional<Tensor>> handle( uint8_t queue_id, const Tensor& grad, const Tensor& input, float exponent, const MemoryConfig& output_mem_config, const std::vector<bool>& are_required_outputs, std::optional<Tensor> input_grad ) {
         return _pow_bw(queue_id, grad, input, exponent, output_mem_config, are_required_outputs, input_grad);
     }
 };
 
 template <>
-struct OpHandler_unary_optional<UnaryBackwardOpType::EXP_BW> {
+struct OpHandler<UnaryBackwardOpType::EXP_BW> {
     static std::vector<std::optional<Tensor>> handle( uint8_t queue_id, const Tensor& grad, const Tensor& input, const MemoryConfig& output_mem_config, const std::vector<bool>& are_required_outputs, std::optional<Tensor> input_grad ) {
         return _exp_bw(queue_id, grad, input, output_mem_config, are_required_outputs, input_grad);
     }
 };
 
 template <>
-struct OpHandler_unary_optional<UnaryBackwardOpType::TANH_BW> {
+struct OpHandler<UnaryBackwardOpType::TANH_BW> {
     static std::vector<std::optional<Tensor>> handle( uint8_t queue_id, const Tensor& grad, const Tensor& input, const MemoryConfig& output_mem_config, const std::vector<bool>& are_required_outputs, std::optional<Tensor> input_grad ) {
         return _tanh_bw(queue_id, grad, input, output_mem_config, are_required_outputs, input_grad);
     }
 };
 
 template <>
-struct OpHandler_unary_optional<UnaryBackwardOpType::SQRT_BW> {
+struct OpHandler<UnaryBackwardOpType::SQRT_BW> {
     static std::vector<std::optional<Tensor>> handle( uint8_t queue_id, const Tensor& grad, const Tensor& input, const MemoryConfig& output_mem_config, const std::vector<bool>& are_required_outputs, std::optional<Tensor> input_grad ) {
         return _sqrt_bw(queue_id, grad, input, output_mem_config, are_required_outputs, input_grad);
     }
 };
 
 template <>
-struct OpHandler_string_default<UnaryBackwardOpType::GELU_BW> {
+struct OpHandler<UnaryBackwardOpType::GELU_BW> {
     static std::vector<Tensor> handle( const Tensor& grad, const Tensor& input, string approximate, const std::optional<MemoryConfig>& output_mem_config ) {
         return _gelu_bw(grad, input, approximate, output_mem_config);
     }
 };
 
 template <>
-struct OpHandler_shape<UnaryBackwardOpType::REPEAT_BW> {
+struct OpHandler<UnaryBackwardOpType::REPEAT_BW> {
     static std::vector<Tensor> handle( const Tensor& grad, const Tensor& input, const tt::tt_metal::Shape& shape, const std::optional<MemoryConfig>& output_mem_config ) {
         return _repeat_bw(grad, input, shape, output_mem_config);
     }
 };
 
 template <>
-struct OpHandler_prod_bw<UnaryBackwardOpType::PROD_BW> {
+struct OpHandler<UnaryBackwardOpType::PROD_BW> {
     static std::vector<Tensor> handle( const Tensor& grad, const Tensor& input, bool all_dimensions, int64_t dim, const std::optional<MemoryConfig>& output_mem_config ) {
         return _prod_bw(grad, input, all_dimensions, dim, output_mem_config);
     }
 };
 
-// Template functions to get the function pointers
-template <UnaryBackwardOpType OpType>
-auto get_function_type1_w_two_float() {
-    return &OpHandler_two_float<OpType>::handle;
-}
+template <>
+struct OpHandler<UnaryBackwardOpType::ADD_BW> {
+    static std::vector<Tensor> handle( const Tensor& grad, const Tensor& input, float alpha, const std::optional<MemoryConfig>& output_mem_config ) {
+        return _add_bw(grad, input, alpha, output_mem_config);
+    }
+};
 
-template <UnaryBackwardOpType OpType>
-auto get_function_type1_w_two_float_with_default() {
-    return &OpHandler_two_float_with_default<OpType>::handle;
-}
+template <>
+struct OpHandler<UnaryBackwardOpType::MUL_BW> {
+    static std::vector<Tensor> handle( const Tensor& grad, const Tensor& input, float scalar, const std::optional<MemoryConfig>& output_mem_config ) {
+        return _mul_bw(grad, input, scalar, output_mem_config);
+    }
+};
 
-template <UnaryBackwardOpType OpType>
-auto get_function_type1_float_string_default() {
-    return &OpHandler_float_string_default<OpType>::handle;
-}
-
-template <UnaryBackwardOpType OpType>
-auto get_function_type1_string_default() {
-    return &OpHandler_string_default<OpType>::handle;
-}
-
-template <UnaryBackwardOpType OpType>
-auto get_function_type1_shape() {
-    return &OpHandler_shape<OpType>::handle;
-}
-
-template <UnaryBackwardOpType OpType>
-auto get_function_unary_optional_float() {
-    return &OpHandler_unary_optional_float<OpType>::handle;
-}
-
-template <UnaryBackwardOpType OpType>
-auto get_function_unary_optional() {
-    return &OpHandler_unary_optional<OpType>::handle;
-}
-
-template <UnaryBackwardOpType OpType>
-auto get_function_prod_bw() {
-    return &OpHandler_prod_bw<OpType>::handle;
-}
-
-template <UnaryBackwardOpType OpType>
-auto get_function_optional_float_params_with_default() {
-    return &OpHandler_optional_float_params_with_default<OpType>::handle;
-}
+template <>
+struct OpHandler<UnaryBackwardOpType::EQ_BW> {
+    static std::vector<Tensor> handle( const Tensor& grad, const Tensor& input, float other, const std::optional<MemoryConfig>& output_mem_config ) {
+        return _eq_bw(grad, input, other, output_mem_config);
+    }
+};
 
 }  // namespace ttnn::operations::unary_backward

--- a/ttnn/cpp/ttnn/operations/eltwise/unary_backward/unary_backward.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary_backward/unary_backward.hpp
@@ -13,17 +13,8 @@ namespace ttnn {
 
 namespace operations::unary_backward {
 
-//OpHandler_two_float : get_function_type1_w_two_float
 template <UnaryBackwardOpType unary_backward_op_type>
 struct ExecuteUnaryBackwardTwoFloat {
-
-    static inline std::vector<Tensor> create_async_output_tensors(
-        const std::vector<Tensor> &input_tensors, const std::vector<std::optional<const Tensor>>& optional_inputs) {
-        const auto& input_tensor = input_tensors.at(0);
-        return {Tensor(operation::get_workers_for_op_output({input_tensor}))};
-    }
-
-    //Type 1: 1 inputs, 1 grad tensor, 2 float
     static std::vector<Tensor> operator()(
         const Tensor &grad_tensor_arg,
         const Tensor &input_tensor_arg,
@@ -35,17 +26,8 @@ struct ExecuteUnaryBackwardTwoFloat {
     }
 };
 
-//OpHandler_float : get_function_type1_w_float
 template <UnaryBackwardOpType unary_backward_op_type>
 struct ExecuteUnaryBackwardFloat {
-
-    static inline std::vector<Tensor> create_async_output_tensors(
-        const std::vector<Tensor> &input_tensors, const std::vector<std::optional<const Tensor>>& optional_inputs) {
-        const auto& input_tensor = input_tensors.at(0);
-        return {Tensor(operation::get_workers_for_op_output({input_tensor}))};
-    }
-
-    //Type 1: 1 inputs, 1 grad tensor, 1 float
     static std::vector<Tensor> operator()(
         const Tensor &grad_tensor_arg,
         const Tensor &input_tensor_arg,
@@ -57,17 +39,8 @@ struct ExecuteUnaryBackwardFloat {
 
 };
 
-//OpHandler : get_function_type1
 template <UnaryBackwardOpType unary_backward_op_type>
 struct ExecuteUnaryBackwardWoFloat {
-
-    static inline std::vector<Tensor> create_async_output_tensors(
-        const std::vector<Tensor> &input_tensors, const std::vector<std::optional<const Tensor>>& optional_inputs) {
-        const auto& input_tensor = input_tensors.at(0);
-        return {Tensor(operation::get_workers_for_op_output({input_tensor}))};
-    }
-
-    //Type 1: 1 inputs, 1 grad tensor
     static std::vector<Tensor> operator()(
         const Tensor &grad_tensor_arg,
         const Tensor &input_tensor_arg,
@@ -78,10 +51,8 @@ struct ExecuteUnaryBackwardWoFloat {
 
 };
 
-//OpHandler_two_float_with_default : get_function_type1_w_two_float_with_default
 template <UnaryBackwardOpType unary_backward_op_type>
 struct ExecuteUnaryBackwardTwoFloatWithDefault {
-    //Type 1: 1 inputs, 1 grad tensor, 2 float
     static std::vector<Tensor> operator()(
         const Tensor &grad_tensor_arg,
         const Tensor &input_tensor_arg,
@@ -93,17 +64,8 @@ struct ExecuteUnaryBackwardTwoFloatWithDefault {
     }
 };
 
-//OpHandler_optional_float_params_with_default : get_function_optional_float_params_with_default
 template <UnaryBackwardOpType unary_backward_op_type>
 struct ExecuteUnaryBackwardOptionalFloatParamsWithDefault {
-
-    static inline std::vector<Tensor> create_async_output_tensors(
-        const std::vector<Tensor> &input_tensors, const std::vector<std::optional<const Tensor>>& optional_inputs) {
-        const auto& input_tensor = input_tensors.at(0);
-        return {Tensor(operation::get_workers_for_op_output({input_tensor}))};
-    }
-
-    //Type 1: 1 inputs, 1 grad tensor, 2 float
     static std::vector<Tensor> operator()(
         const Tensor &grad_tensor_arg,
         const Tensor &input_tensor_arg,
@@ -115,17 +77,8 @@ struct ExecuteUnaryBackwardOptionalFloatParamsWithDefault {
     }
 };
 
-//OpHandler_float_string_default : get_function_type1_float_string_default
 template <UnaryBackwardOpType unary_backward_op_type>
 struct ExecuteUnaryBackwardFloatStringDefault {
-
-    static inline std::vector<Tensor> create_async_output_tensors(
-        const std::vector<Tensor> &input_tensors, const std::vector<std::optional<const Tensor>>& optional_inputs) {
-        const auto& input_tensor = input_tensors.at(0);
-        return {Tensor(operation::get_workers_for_op_output({input_tensor}))};
-    }
-
-    //Type 1: 1 inputs, 1 grad tensor, 1 float, 1 default string
     static std::vector<Tensor> operator()(
         const Tensor &grad_tensor_arg,
         const Tensor &input_tensor_arg,
@@ -137,17 +90,8 @@ struct ExecuteUnaryBackwardFloatStringDefault {
     }
 };
 
-//OpHandler_string_default : get_function_type1_string_default
 template <UnaryBackwardOpType unary_backward_op_type>
 struct ExecuteUnaryBackwardStringDefault {
-
-    static inline std::vector<Tensor> create_async_output_tensors(
-        const std::vector<Tensor> &input_tensors, const std::vector<std::optional<const Tensor>>& optional_inputs) {
-        const auto& input_tensor = input_tensors.at(0);
-        return {Tensor(operation::get_workers_for_op_output({input_tensor}))};
-    }
-
-    //Type 1: 1 inputs, 1 grad tensor, 1 float, 1 default string
     static std::vector<Tensor> operator()(
         const Tensor &grad_tensor_arg,
         const Tensor &input_tensor_arg,
@@ -158,17 +102,8 @@ struct ExecuteUnaryBackwardStringDefault {
     }
 };
 
-//OpHandler_shape : get_function_type1_shape
 template <UnaryBackwardOpType unary_backward_op_type>
 struct ExecuteUnaryBackwardShape {
-
-    static inline std::vector<Tensor> create_async_output_tensors(
-        const std::vector<Tensor> &input_tensors, const std::vector<std::optional<const Tensor>>& optional_inputs) {
-        const auto& input_tensor = input_tensors.at(0);
-        return {Tensor(operation::get_workers_for_op_output({input_tensor}))};
-    }
-
-    //Type 1: 1 inputs, 1 grad tensor, 1 shape
     static std::vector<Tensor> operator()(
         const Tensor &grad_tensor_arg,
         const Tensor &input_tensor_arg,
@@ -179,17 +114,8 @@ struct ExecuteUnaryBackwardShape {
     }
 };
 
-//OpHandler_unary_optional_float : get_function_unary_optional_float
 template <UnaryBackwardOpType unary_backward_op_type>
 struct ExecuteUnaryBackwardOptionalFloat {
-
-    static inline std::vector<Tensor> create_async_output_tensors(
-        const std::vector<Tensor> &input_tensors, const std::vector<std::optional<const Tensor>>& optional_inputs) {
-        const auto& input_tensor = input_tensors.at(0);
-        return {Tensor(operation::get_workers_for_op_output({input_tensor}))};
-    }
-
-    //Q_ID, type1 args, optional output tensor for input based on are_required_outputs value
     static std::vector<std::optional<Tensor>> operator()(
         uint8_t queue_id,
         const Tensor &grad_tensor_arg,
@@ -201,31 +127,10 @@ struct ExecuteUnaryBackwardOptionalFloat {
         auto output_memory_config = memory_config.value_or(input_tensor_arg.memory_config());
         return OpHandler<unary_backward_op_type>::handle(queue_id, grad_tensor_arg, input_tensor_arg, parameter, output_memory_config, are_required_outputs, input_grad);
     }
-
-    //type1 args, optional output tensor for inputs based on are_required_outputs value
-    static std::vector<std::optional<Tensor>> operator()(
-        const Tensor &grad_tensor_arg,
-        const Tensor &input_tensor_arg,
-        float parameter,
-        const std::optional<MemoryConfig> &memory_config = std::nullopt,
-        const std::vector<bool> &are_required_outputs = std::vector<bool>{true},
-        std::optional<Tensor> input_grad = std::nullopt) {
-        auto output_memory_config = memory_config.value_or(input_tensor_arg.memory_config());
-        return OpHandler<unary_backward_op_type>::handle(DefaultQueueId, grad_tensor_arg, input_tensor_arg, parameter, output_memory_config, are_required_outputs, input_grad);
-    }
 };
 
-//OpHandler_unary_optional : get_function_unary_optional
 template <UnaryBackwardOpType unary_backward_op_type>
 struct ExecuteUnaryBackwardOptional {
-
-    static inline std::vector<Tensor> create_async_output_tensors(
-        const std::vector<Tensor> &input_tensors, const std::vector<std::optional<const Tensor>>& optional_inputs) {
-        const auto& input_tensor = input_tensors.at(0);
-        return {Tensor(operation::get_workers_for_op_output({input_tensor}))};
-    }
-
-    //Q_ID, type1 args, optional output tensor for input based on are_required_outputs value
     static std::vector<std::optional<Tensor>> operator()(
         uint8_t queue_id,
         const Tensor &grad_tensor_arg,
@@ -236,29 +141,10 @@ struct ExecuteUnaryBackwardOptional {
         auto output_memory_config = memory_config.value_or(input_tensor_arg.memory_config());
         return OpHandler<unary_backward_op_type>::handle(queue_id, grad_tensor_arg, input_tensor_arg, output_memory_config, are_required_outputs, input_grad);
     }
-
-    //type1 args, optional output tensor for inputs based on are_required_outputs value
-    static std::vector<std::optional<Tensor>> operator()(
-        const Tensor &grad_tensor_arg,
-        const Tensor &input_tensor_arg,
-        const std::optional<MemoryConfig> &memory_config = std::nullopt,
-        const std::vector<bool> &are_required_outputs = std::vector<bool>{true},
-        std::optional<Tensor> input_grad = std::nullopt) {
-        auto output_memory_config = memory_config.value_or(input_tensor_arg.memory_config());
-        return OpHandler<unary_backward_op_type>::handle(DefaultQueueId, grad_tensor_arg, input_tensor_arg, output_memory_config, are_required_outputs, input_grad);
-    }
 };
 
-//OpHandler_prod_bw : get_function_prod_bw
 template <UnaryBackwardOpType unary_backward_op_type>
 struct ExecuteUnaryBackwardProdBW {
-
-    static inline std::vector<Tensor> create_async_output_tensors(
-        const std::vector<Tensor> &input_tensors, const std::vector<std::optional<const Tensor>>& optional_inputs) {
-        const auto& input_tensor = input_tensors.at(0);
-        return {Tensor(operation::get_workers_for_op_output({input_tensor}))};
-    }
-
     static std::vector<Tensor> operator()(
         const Tensor &grad_tensor_arg,
         const Tensor &input_tensor_arg,
@@ -272,14 +158,6 @@ struct ExecuteUnaryBackwardProdBW {
 
 template <UnaryBackwardOpType unary_backward_op_type>
 struct ExecuteUnaryBackward {
-
-    static inline std::vector<ttnn::Tensor> create_async_output_tensors(
-        const std::vector<Tensor> &input_tensors, const std::vector<std::optional<const Tensor>>& optional_inputs) {
-        const auto& input_tensor = input_tensors.at(0);
-        return {Tensor(operation::get_workers_for_op_output({input_tensor}))};
-    }
-
-    //Type 1: 2 inputs, 1 grad tensor
 
     static std::vector<ttnn::Tensor> operator()(
         const Tensor &grad_tensor_arg,
@@ -305,13 +183,11 @@ struct ExecuteUnaryBackward {
 
 }  // operations::unary
 
-//ExecuteUnaryBackwardTwoFloat : get_function_type1_w_two_float
 constexpr auto threshold_bw = ttnn::register_operation<
     "ttnn::threshold_bw",
     operations::unary_backward::ExecuteUnaryBackwardTwoFloat<
         operations::unary_backward::UnaryBackwardOpType::THRESHOLD_BW>>();
 
-//ExecuteUnaryBackwardFloat : get_function_type1_w_float
 constexpr auto remainder_bw = ttnn::register_operation<
     "ttnn::remainder_bw",
     operations::unary_backward::ExecuteUnaryBackwardFloat<
@@ -332,7 +208,6 @@ constexpr auto gt_bw = ttnn::register_operation<
     operations::unary_backward::ExecuteUnaryBackwardFloat<
         operations::unary_backward::UnaryBackwardOpType::GT_BW>>();
 
-//ExecuteUnaryBackwardWoFloat : get_function_type1
 constexpr auto assign_bw = ttnn::register_operation<
     "ttnn::assign_bw",
     operations::unary_backward::ExecuteUnaryBackwardWoFloat<
@@ -368,7 +243,6 @@ constexpr auto acosh_bw = ttnn::register_operation<
     operations::unary_backward::ExecuteUnaryBackwardWoFloat<
         operations::unary_backward::UnaryBackwardOpType::ACOSH_BW>>();
 
-//ExecuteUnaryBackwardFloat : get_function_type1_w_float
 constexpr auto mul_bw = ttnn::register_operation<
     "ttnn::mul_bw",
     operations::unary_backward::ExecuteUnaryBackwardFloat<
@@ -384,13 +258,11 @@ constexpr auto eq_bw = ttnn::register_operation<
     operations::unary_backward::ExecuteUnaryBackwardFloat<
         operations::unary_backward::UnaryBackwardOpType::EQ_BW>>();
 
-//OpHandler_optional_float_params_with_default : get_function_optional_float_params_with_default
 constexpr auto clamp_bw = ttnn::register_operation<
     "ttnn::clamp_bw",
     operations::unary_backward::ExecuteUnaryBackwardOptionalFloatParamsWithDefault<
         operations::unary_backward::UnaryBackwardOpType::CLAMP_BW>>();
 
-//ExecuteUnaryBackwardTwoFloatWithDefault : get_function_type1_w_two_float_with_default
 constexpr auto softplus_bw = ttnn::register_operation<
     "ttnn::softplus_bw",
     operations::unary_backward::ExecuteUnaryBackwardTwoFloatWithDefault<
@@ -400,7 +272,6 @@ constexpr auto hardtanh_bw = ttnn::register_operation<
     operations::unary_backward::ExecuteUnaryBackwardTwoFloatWithDefault<
         operations::unary_backward::UnaryBackwardOpType::HARDTANH_BW>>();
 
-//ExecuteUnaryBackwardFloatStringDefault : get_function_type1_float_string_default
 constexpr auto div_bw = ttnn::register_operation<
     "ttnn::div_bw",
     operations::unary_backward::ExecuteUnaryBackwardFloatStringDefault<
@@ -414,25 +285,21 @@ constexpr auto bias_gelu_bw = ttnn::register_operation<
     operations::unary_backward::ExecuteUnaryBackwardFloatStringDefault<
         operations::unary_backward::UnaryBackwardOpType::BIAS_GELU_BW>>();
 
-//ExecuteUnaryBackwardStringDefault : get_function_type1_string_default
 constexpr auto gelu_bw = ttnn::register_operation<
     "ttnn::gelu_bw",
     operations::unary_backward::ExecuteUnaryBackwardStringDefault<
         operations::unary_backward::UnaryBackwardOpType::GELU_BW>>();
 
-//ExecuteUnaryBackwardShape : get_function_type1_shape
 constexpr auto repeat_bw = ttnn::register_operation<
     "ttnn::repeat_bw",
     operations::unary_backward::ExecuteUnaryBackwardShape<
         operations::unary_backward::UnaryBackwardOpType::REPEAT_BW>>();
 
-//OpHandler_unary_optional_float : get_function_unary_optional_float
 constexpr auto pow_bw = ttnn::register_operation<
     "ttnn::pow_bw",
     operations::unary_backward::ExecuteUnaryBackwardOptionalFloat<
         operations::unary_backward::UnaryBackwardOpType::POW_BW>>();
 
-//OpHandler_unary_optional : get_function_unary_optional
 constexpr auto exp_bw = ttnn::register_operation<
     "ttnn::exp_bw",
     operations::unary_backward::ExecuteUnaryBackwardOptional<
@@ -446,7 +313,6 @@ constexpr auto sqrt_bw = ttnn::register_operation<
     operations::unary_backward::ExecuteUnaryBackwardOptional<
         operations::unary_backward::UnaryBackwardOpType::SQRT_BW>>();
 
-//OpHandler_prod_bw : get_function_prod_bw
 constexpr auto prod_bw = ttnn::register_operation<
     "ttnn::prod_bw",
     operations::unary_backward::ExecuteUnaryBackwardProdBW<operations::unary_backward::UnaryBackwardOpType::PROD_BW>>();

--- a/ttnn/cpp/ttnn/operations/eltwise/unary_backward/unary_backward.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary_backward/unary_backward.hpp
@@ -30,10 +30,52 @@ struct ExecuteUnaryBackwardTwoFloat {
         float min,
         float max,
         const std::optional<MemoryConfig> &memory_config = std::nullopt) {
-        auto op_type = get_function_type1_w_two_float<unary_backward_op_type>();
         auto output_memory_config = memory_config.value_or(input_tensor_arg.memory_config());
-        return op_type(grad_tensor_arg, input_tensor_arg, min, max, output_memory_config);
+        return OpHandler<unary_backward_op_type>::handle(grad_tensor_arg, input_tensor_arg, min, max, output_memory_config);
     }
+};
+
+//OpHandler_float : get_function_type1_w_float
+template <UnaryBackwardOpType unary_backward_op_type>
+struct ExecuteUnaryBackwardFloat {
+
+    static inline std::vector<Tensor> create_async_output_tensors(
+        const std::vector<Tensor> &input_tensors, const std::vector<std::optional<const Tensor>>& optional_inputs) {
+        const auto& input_tensor = input_tensors.at(0);
+        return {Tensor(operation::get_workers_for_op_output({input_tensor}))};
+    }
+
+    //Type 1: 1 inputs, 1 grad tensor, 1 float
+    static std::vector<Tensor> operator()(
+        const Tensor &grad_tensor_arg,
+        const Tensor &input_tensor_arg,
+        float scalar,
+        const std::optional<MemoryConfig> &memory_config = std::nullopt) {
+        auto output_memory_config = memory_config.value_or(input_tensor_arg.memory_config());
+        return OpHandler<unary_backward_op_type>::handle(grad_tensor_arg, input_tensor_arg, scalar, output_memory_config);
+        }
+
+};
+
+//OpHandler : get_function_type1
+template <UnaryBackwardOpType unary_backward_op_type>
+struct ExecuteUnaryBackwardWoFloat {
+
+    static inline std::vector<Tensor> create_async_output_tensors(
+        const std::vector<Tensor> &input_tensors, const std::vector<std::optional<const Tensor>>& optional_inputs) {
+        const auto& input_tensor = input_tensors.at(0);
+        return {Tensor(operation::get_workers_for_op_output({input_tensor}))};
+    }
+
+    //Type 1: 1 inputs, 1 grad tensor
+    static std::vector<Tensor> operator()(
+        const Tensor &grad_tensor_arg,
+        const Tensor &input_tensor_arg,
+        const std::optional<MemoryConfig> &memory_config = std::nullopt) {
+        auto output_memory_config = memory_config.value_or(input_tensor_arg.memory_config());
+        return OpHandler<unary_backward_op_type>::handle(grad_tensor_arg, input_tensor_arg, output_memory_config);
+        }
+
 };
 
 //OpHandler_two_float_with_default : get_function_type1_w_two_float_with_default
@@ -46,9 +88,8 @@ struct ExecuteUnaryBackwardTwoFloatWithDefault {
         float parameter_a,
         float parameter_b,
         const std::optional<MemoryConfig> &memory_config = std::nullopt) {
-        auto op_type = get_function_type1_w_two_float_with_default<unary_backward_op_type>();
         auto output_memory_config = memory_config.value_or(input_tensor_arg.memory_config());
-        return op_type(grad_tensor_arg, input_tensor_arg, parameter_a, parameter_b, output_memory_config);
+        return OpHandler<unary_backward_op_type>::handle(grad_tensor_arg, input_tensor_arg, parameter_a, parameter_b, output_memory_config);
     }
 };
 
@@ -69,9 +110,8 @@ struct ExecuteUnaryBackwardOptionalFloatParamsWithDefault {
         std::optional<float> parameter_a,
         std::optional<float> parameter_b,
         const std::optional<MemoryConfig> &memory_config = std::nullopt) {
-        auto op_type = get_function_optional_float_params_with_default<unary_backward_op_type>();
         auto output_memory_config = memory_config.value_or(input_tensor_arg.memory_config());
-        return op_type(grad_tensor_arg, input_tensor_arg, parameter_a, parameter_b, output_memory_config);
+        return OpHandler<unary_backward_op_type>::handle(grad_tensor_arg, input_tensor_arg, parameter_a, parameter_b, output_memory_config);
     }
 };
 
@@ -92,9 +132,8 @@ struct ExecuteUnaryBackwardFloatStringDefault {
         float parameter_a,
         string parameter_b,
         const std::optional<MemoryConfig> &memory_config = std::nullopt) {
-        auto op_type = get_function_type1_float_string_default<unary_backward_op_type>();
         auto output_memory_config = memory_config.value_or(input_tensor_arg.memory_config());
-        return op_type(grad_tensor_arg, input_tensor_arg, parameter_a, parameter_b, output_memory_config);
+        return OpHandler<unary_backward_op_type>::handle(grad_tensor_arg, input_tensor_arg, parameter_a, parameter_b, output_memory_config);
     }
 };
 
@@ -114,9 +153,8 @@ struct ExecuteUnaryBackwardStringDefault {
         const Tensor &input_tensor_arg,
         string parameter_a,
         const std::optional<MemoryConfig> &memory_config = std::nullopt) {
-        auto op_type = get_function_type1_string_default<unary_backward_op_type>();
         auto output_memory_config = memory_config.value_or(input_tensor_arg.memory_config());
-        return op_type(grad_tensor_arg, input_tensor_arg, parameter_a, output_memory_config);
+        return OpHandler<unary_backward_op_type>::handle(grad_tensor_arg, input_tensor_arg, parameter_a, output_memory_config);
     }
 };
 
@@ -136,9 +174,8 @@ struct ExecuteUnaryBackwardShape {
         const Tensor &input_tensor_arg,
         const tt::tt_metal::Shape &parameter_a,
         const std::optional<MemoryConfig> &memory_config = std::nullopt) {
-        auto op_type = get_function_type1_shape<unary_backward_op_type>();
         auto output_memory_config = memory_config.value_or(input_tensor_arg.memory_config());
-        return op_type(grad_tensor_arg, input_tensor_arg, parameter_a, output_memory_config);
+        return OpHandler<unary_backward_op_type>::handle(grad_tensor_arg, input_tensor_arg, parameter_a, output_memory_config);
     }
 };
 
@@ -162,8 +199,7 @@ struct ExecuteUnaryBackwardOptionalFloat {
         const std::vector<bool> &are_required_outputs = std::vector<bool>{true},
         std::optional<Tensor> input_grad = std::nullopt) {
         auto output_memory_config = memory_config.value_or(input_tensor_arg.memory_config());
-        auto op_type = get_function_unary_optional_float<unary_backward_op_type>();
-        return op_type(queue_id, grad_tensor_arg, input_tensor_arg, parameter, output_memory_config, are_required_outputs, input_grad);
+        return OpHandler<unary_backward_op_type>::handle(queue_id, grad_tensor_arg, input_tensor_arg, parameter, output_memory_config, are_required_outputs, input_grad);
     }
 
     //type1 args, optional output tensor for inputs based on are_required_outputs value
@@ -175,8 +211,7 @@ struct ExecuteUnaryBackwardOptionalFloat {
         const std::vector<bool> &are_required_outputs = std::vector<bool>{true},
         std::optional<Tensor> input_grad = std::nullopt) {
         auto output_memory_config = memory_config.value_or(input_tensor_arg.memory_config());
-        auto op_type = get_function_unary_optional_float<unary_backward_op_type>();
-        return op_type(DefaultQueueId, grad_tensor_arg, input_tensor_arg, parameter, output_memory_config, are_required_outputs, input_grad);
+        return OpHandler<unary_backward_op_type>::handle(DefaultQueueId, grad_tensor_arg, input_tensor_arg, parameter, output_memory_config, are_required_outputs, input_grad);
     }
 };
 
@@ -199,8 +234,7 @@ struct ExecuteUnaryBackwardOptional {
         const std::vector<bool> &are_required_outputs = std::vector<bool>{true},
         std::optional<Tensor> input_grad = std::nullopt) {
         auto output_memory_config = memory_config.value_or(input_tensor_arg.memory_config());
-        auto op_type = get_function_unary_optional<unary_backward_op_type>();
-        return op_type(queue_id, grad_tensor_arg, input_tensor_arg, output_memory_config, are_required_outputs, input_grad);
+        return OpHandler<unary_backward_op_type>::handle(queue_id, grad_tensor_arg, input_tensor_arg, output_memory_config, are_required_outputs, input_grad);
     }
 
     //type1 args, optional output tensor for inputs based on are_required_outputs value
@@ -211,8 +245,7 @@ struct ExecuteUnaryBackwardOptional {
         const std::vector<bool> &are_required_outputs = std::vector<bool>{true},
         std::optional<Tensor> input_grad = std::nullopt) {
         auto output_memory_config = memory_config.value_or(input_tensor_arg.memory_config());
-        auto op_type = get_function_unary_optional<unary_backward_op_type>();
-        return op_type(DefaultQueueId, grad_tensor_arg, input_tensor_arg, output_memory_config, are_required_outputs, input_grad);
+        return OpHandler<unary_backward_op_type>::handle(DefaultQueueId, grad_tensor_arg, input_tensor_arg, output_memory_config, are_required_outputs, input_grad);
     }
 };
 
@@ -232,9 +265,8 @@ struct ExecuteUnaryBackwardProdBW {
         bool all_dimensions = true,
         int64_t dim = 0,
         const std::optional<MemoryConfig> &memory_config = std::nullopt) {
-        auto op_type = get_function_prod_bw<unary_backward_op_type>();
         auto output_memory_config = memory_config.value_or(input_tensor_arg.memory_config());
-        return op_type(grad_tensor_arg, input_tensor_arg, all_dimensions, dim, output_memory_config);
+        return OpHandler<unary_backward_op_type>::handle(grad_tensor_arg, input_tensor_arg, all_dimensions, dim, output_memory_config);
     }
 };
 
@@ -278,6 +310,79 @@ constexpr auto threshold_bw = ttnn::register_operation<
     "ttnn::threshold_bw",
     operations::unary_backward::ExecuteUnaryBackwardTwoFloat<
         operations::unary_backward::UnaryBackwardOpType::THRESHOLD_BW>>();
+
+//ExecuteUnaryBackwardFloat : get_function_type1_w_float
+constexpr auto remainder_bw = ttnn::register_operation<
+    "ttnn::remainder_bw",
+    operations::unary_backward::ExecuteUnaryBackwardFloat<
+        operations::unary_backward::UnaryBackwardOpType::REMAINDER_BW>>();
+
+constexpr auto fmod_bw = ttnn::register_operation<
+    "ttnn::fmod_bw",
+    operations::unary_backward::ExecuteUnaryBackwardFloat<
+        operations::unary_backward::UnaryBackwardOpType::FMOD_BW>>();
+
+constexpr auto sub_bw = ttnn::register_operation<
+    "ttnn::sub_bw",
+    operations::unary_backward::ExecuteUnaryBackwardFloat<
+        operations::unary_backward::UnaryBackwardOpType::SUB_BW>>();
+
+constexpr auto gt_bw = ttnn::register_operation<
+    "ttnn::gt_bw",
+    operations::unary_backward::ExecuteUnaryBackwardFloat<
+        operations::unary_backward::UnaryBackwardOpType::GT_BW>>();
+
+//ExecuteUnaryBackwardWoFloat : get_function_type1
+constexpr auto assign_bw = ttnn::register_operation<
+    "ttnn::assign_bw",
+    operations::unary_backward::ExecuteUnaryBackwardWoFloat<
+        operations::unary_backward::UnaryBackwardOpType::ASSIGN_BW>>();
+
+constexpr auto multigammaln_bw = ttnn::register_operation<
+    "ttnn::multigammaln_bw",
+    operations::unary_backward::ExecuteUnaryBackwardWoFloat<
+        operations::unary_backward::UnaryBackwardOpType::MULTIGAMMALN_BW>>();
+
+constexpr auto lgamma_bw = ttnn::register_operation<
+    "ttnn::lgamma_bw",
+    operations::unary_backward::ExecuteUnaryBackwardWoFloat<
+        operations::unary_backward::UnaryBackwardOpType::LGAMMA_BW>>();
+
+constexpr auto fill_bw = ttnn::register_operation<
+    "ttnn::fill_bw",
+    operations::unary_backward::ExecuteUnaryBackwardWoFloat<
+        operations::unary_backward::UnaryBackwardOpType::FILL_BW>>();
+
+constexpr auto hardsigmoid_bw = ttnn::register_operation<
+    "ttnn::hardsigmoid_bw",
+    operations::unary_backward::ExecuteUnaryBackwardWoFloat<
+        operations::unary_backward::UnaryBackwardOpType::HARDSIGMOID_BW>>();
+
+constexpr auto cos_bw = ttnn::register_operation<
+    "ttnn::cos_bw",
+    operations::unary_backward::ExecuteUnaryBackwardWoFloat<
+        operations::unary_backward::UnaryBackwardOpType::COS_BW>>();
+
+constexpr auto acosh_bw = ttnn::register_operation<
+    "ttnn::acosh_bw",
+    operations::unary_backward::ExecuteUnaryBackwardWoFloat<
+        operations::unary_backward::UnaryBackwardOpType::ACOSH_BW>>();
+
+//ExecuteUnaryBackwardFloat : get_function_type1_w_float
+constexpr auto mul_bw = ttnn::register_operation<
+    "ttnn::mul_bw",
+    operations::unary_backward::ExecuteUnaryBackwardFloat<
+        operations::unary_backward::UnaryBackwardOpType::MUL_BW>>();
+
+constexpr auto add_bw = ttnn::register_operation<
+    "ttnn::add_bw",
+    operations::unary_backward::ExecuteUnaryBackwardFloat<
+        operations::unary_backward::UnaryBackwardOpType::ADD_BW>>();
+
+constexpr auto eq_bw = ttnn::register_operation<
+    "ttnn::eq_bw",
+    operations::unary_backward::ExecuteUnaryBackwardFloat<
+        operations::unary_backward::UnaryBackwardOpType::EQ_BW>>();
 
 //OpHandler_optional_float_params_with_default : get_function_optional_float_params_with_default
 constexpr auto clamp_bw = ttnn::register_operation<
@@ -346,25 +451,6 @@ constexpr auto prod_bw = ttnn::register_operation<
     "ttnn::prod_bw",
     operations::unary_backward::ExecuteUnaryBackwardProdBW<operations::unary_backward::UnaryBackwardOpType::PROD_BW>>();
 
-constexpr auto mul_bw = ttnn::register_operation<
-    "ttnn::mul_bw",
-    operations::unary_backward::ExecuteUnaryBackward<operations::unary_backward::UnaryBackwardOpType::MUL_BW>>();
-constexpr auto assign_bw = ttnn::register_operation<
-    "ttnn::assign_bw",
-    operations::unary_backward::ExecuteUnaryBackward<operations::unary_backward::UnaryBackwardOpType::ASSIGN_BW>>();
-constexpr auto multigammaln_bw = ttnn::register_operation<
-    "ttnn::multigammaln_bw",
-    operations::unary_backward::ExecuteUnaryBackward<
-        operations::unary_backward::UnaryBackwardOpType::MULTIGAMMALN_BW>>();
-constexpr auto add_bw = ttnn::register_operation<
-    "ttnn::add_bw",
-    operations::unary_backward::ExecuteUnaryBackward<operations::unary_backward::UnaryBackwardOpType::ADD_BW>>();
-constexpr auto eq_bw = ttnn::register_operation<
-    "ttnn::eq_bw",
-    operations::unary_backward::ExecuteUnaryBackward<operations::unary_backward::UnaryBackwardOpType::EQ_BW>>();
-constexpr auto gt_bw = ttnn::register_operation<
-    "ttnn::gt_bw",
-    operations::unary_backward::ExecuteUnaryBackward<operations::unary_backward::UnaryBackwardOpType::GT_BW>>();
 constexpr auto lt_bw = ttnn::register_operation<
     "ttnn::lt_bw",
     operations::unary_backward::ExecuteUnaryBackward<operations::unary_backward::UnaryBackwardOpType::LT_BW>>();
@@ -377,22 +463,6 @@ constexpr auto ge_bw = ttnn::register_operation<
 constexpr auto ne_bw = ttnn::register_operation<
     "ttnn::ne_bw",
     operations::unary_backward::ExecuteUnaryBackward<operations::unary_backward::UnaryBackwardOpType::NE_BW>>();
-constexpr auto lgamma_bw = ttnn::register_operation<
-    "ttnn::lgamma_bw",
-    operations::unary_backward::ExecuteUnaryBackward<operations::unary_backward::UnaryBackwardOpType::LGAMMA_BW>>();
-constexpr auto fill_bw = ttnn::register_operation<
-    "ttnn::fill_bw",
-    operations::unary_backward::ExecuteUnaryBackward<operations::unary_backward::UnaryBackwardOpType::FILL_BW>>();
-constexpr auto hardsigmoid_bw = ttnn::register_operation<
-    "ttnn::hardsigmoid_bw",
-    operations::unary_backward::ExecuteUnaryBackward<
-        operations::unary_backward::UnaryBackwardOpType::HARDSIGMOID_BW>>();
-constexpr auto cos_bw = ttnn::register_operation<
-    "ttnn::cos_bw",
-    operations::unary_backward::ExecuteUnaryBackward<operations::unary_backward::UnaryBackwardOpType::COS_BW>>();
-constexpr auto acosh_bw = ttnn::register_operation<
-    "ttnn::acosh_bw",
-    operations::unary_backward::ExecuteUnaryBackward<operations::unary_backward::UnaryBackwardOpType::ACOSH_BW>>();
 constexpr auto acos_bw = ttnn::register_operation<
     "ttnn::acos_bw",
     operations::unary_backward::ExecuteUnaryBackward<operations::unary_backward::UnaryBackwardOpType::ACOS_BW>>();
@@ -402,9 +472,6 @@ constexpr auto atan_bw = ttnn::register_operation<
 constexpr auto rad2deg_bw = ttnn::register_operation<
     "ttnn::rad2deg_bw",
     operations::unary_backward::ExecuteUnaryBackward<operations::unary_backward::UnaryBackwardOpType::RAD2DEG_BW>>();
-constexpr auto sub_bw = ttnn::register_operation<
-    "ttnn::sub_bw",
-    operations::unary_backward::ExecuteUnaryBackward<operations::unary_backward::UnaryBackwardOpType::SUB_BW>>();
 constexpr auto frac_bw = ttnn::register_operation<
     "ttnn::frac_bw",
     operations::unary_backward::ExecuteUnaryBackward<operations::unary_backward::UnaryBackwardOpType::FRAC_BW>>();
@@ -529,12 +596,6 @@ constexpr auto log2_bw = ttnn::register_operation<
 constexpr auto sign_bw = ttnn::register_operation<
     "ttnn::sign_bw",
     operations::unary_backward::ExecuteUnaryBackward<operations::unary_backward::UnaryBackwardOpType::SIGN_BW>>();
-constexpr auto fmod_bw = ttnn::register_operation<
-    "ttnn::fmod_bw",
-    operations::unary_backward::ExecuteUnaryBackward<operations::unary_backward::UnaryBackwardOpType::FMOD_BW>>();
-constexpr auto remainder_bw = ttnn::register_operation<
-    "ttnn::remainder_bw",
-    operations::unary_backward::ExecuteUnaryBackward<operations::unary_backward::UnaryBackwardOpType::REMAINDER_BW>>();
 constexpr auto div_no_nan_bw = ttnn::register_operation<
     "ttnn::div_no_nan_bw",
     operations::unary_backward::ExecuteUnaryBackward<operations::unary_backward::UnaryBackwardOpType::DIV_NO_NAN_BW>>();

--- a/ttnn/cpp/ttnn/operations/eltwise/unary_backward/unary_backward_pybind.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary_backward/unary_backward_pybind.hpp
@@ -22,7 +22,7 @@ namespace operations {
 namespace unary_backward {
 
 namespace detail {
-// OpHandler_two_float : get_function_type1_w_two_float
+
 template <typename unary_backward_operation_t>
 void bind_unary_backward_two_float(
     py::module& module, const unary_backward_operation_t& operation, const std::string& description) {
@@ -71,7 +71,98 @@ void bind_unary_backward_two_float(
             py::arg("memory_config") = std::nullopt});
 }
 
-// OpHandler_two_float_with_default : get_function_type1_w_two_float_with_default
+template <typename unary_backward_operation_t>
+void bind_unary_backward_float(py::module& module, const unary_backward_operation_t& operation, const std::string& description) {
+    auto doc = fmt::format(
+        R"doc({0}(grad_tensor: ttnn.Tensor, input_tensor: ttnn.Tensor, min: float, max: float, *, memory_config: ttnn.MemoryConfig) -> std::vector<Tensor>
+
+        {2}
+
+        Args:
+            * :attr:`grad_tensor`
+            * :attr:`input_tensor`
+            * :attr:`float`
+            * :attr:`float`
+
+        Keyword args:
+            * :attr:`memory_config` [ttnn.MemoryConfig]: memory config for the output tensor
+
+        Example:
+
+            >>> grad_tensor = ttnn.to_device(ttnn.from_torch(torch.tensor((1, 2), dtype=torch.bfloat16)), device)
+            >>> input = ttnn.to_device(ttnn.from_torch(torch.tensor((1, 2), dtype=torch.bfloat16)), device)
+            >>> output = {1}(grad_tensor, input, float, float)
+        )doc",
+        operation.base_name(),
+        operation.python_fully_qualified_name(),
+        description);
+
+    bind_registered_operation(
+        module,
+        operation,
+        doc,
+        ttnn::pybind_overload_t{
+            [](const unary_backward_operation_t& self,
+               const ttnn::Tensor& grad_tensor,
+               const ttnn::Tensor& input_tensor,
+               float scalar,
+               const std::optional<MemoryConfig>& memory_config)  {
+                return self(grad_tensor, input_tensor, scalar, memory_config);
+            },
+            py::arg("grad_tensor"),
+            py::arg("input_tensor"),
+            py::arg("scalar"),
+            py::kw_only(),
+            py::arg("memory_config") = std::nullopt}
+
+    );
+}
+
+template <typename unary_backward_operation_t>
+void bind_unary_backward_wo_float(py::module& module, const unary_backward_operation_t& operation, const std::string& description) {
+    auto doc = fmt::format(
+        R"doc({0}(grad_tensor: ttnn.Tensor, input_tensor: ttnn.Tensor, min: float, max: float, *, memory_config: ttnn.MemoryConfig) -> std::vector<Tensor>
+
+        {2}
+
+        Args:
+            * :attr:`grad_tensor`
+            * :attr:`input_tensor`
+            * :attr:`float`
+            * :attr:`float`
+
+        Keyword args:
+            * :attr:`memory_config` [ttnn.MemoryConfig]: memory config for the output tensor
+
+        Example:
+
+            >>> grad_tensor = ttnn.to_device(ttnn.from_torch(torch.tensor((1, 2), dtype=torch.bfloat16)), device)
+            >>> input = ttnn.to_device(ttnn.from_torch(torch.tensor((1, 2), dtype=torch.bfloat16)), device)
+            >>> output = {1}(grad_tensor, input, float, float)
+        )doc",
+        operation.base_name(),
+        operation.python_fully_qualified_name(),
+        description);
+
+    bind_registered_operation(
+        module,
+        operation,
+        doc,
+        ttnn::pybind_overload_t{
+            [](const unary_backward_operation_t& self,
+               const ttnn::Tensor& grad_tensor,
+               const ttnn::Tensor& input_tensor,
+               const std::optional<MemoryConfig>& memory_config)  {
+                return self(grad_tensor, input_tensor, memory_config);
+            },
+            py::arg("grad_tensor"),
+            py::arg("input_tensor"),
+            py::kw_only(),
+            py::arg("memory_config") = std::nullopt}
+
+    );
+}
+
 template <typename unary_backward_operation_t>
 void bind_unary_backward_two_float_with_default(
     py::module& module,
@@ -134,7 +225,6 @@ void bind_unary_backward_two_float_with_default(
             py::arg("memory_config") = std::nullopt});
 }
 
-// OpHandler_optional_float_params_with_default : get_function_optional_float_params_with_default
 template <typename unary_backward_operation_t>
 void bind_unary_backward_optional_float_params_with_default(
     py::module& module,
@@ -197,7 +287,6 @@ void bind_unary_backward_optional_float_params_with_default(
             py::arg("memory_config") = std::nullopt});
 }
 
-// OpHandler_float_string_default : get_function_type1_float_string_default
 template <typename unary_backward_operation_t>
 void bind_unary_backward_float_string_default(
     py::module& module,
@@ -258,7 +347,6 @@ void bind_unary_backward_float_string_default(
             py::arg("memory_config") = std::nullopt});
 }
 
-// OpHandler_float_string_default : get_function_type1_float_string_default
 template <typename unary_backward_operation_t>
 void bind_unary_backward_string_default(
     py::module& module,
@@ -312,7 +400,6 @@ void bind_unary_backward_string_default(
             py::arg("memory_config") = std::nullopt});
 }
 
-// OpHandler_unary_optional_float : get_function_unary_optional_float
 template <typename unary_backward_operation_t>
 void bind_unary_backward_unary_optional_float(
     py::module& module,
@@ -374,7 +461,6 @@ void bind_unary_backward_unary_optional_float(
             py::arg("queue_id") = 0});
 }
 
-// OpHandler_float_shape : get_function_type1_float_shape
 template <typename unary_backward_operation_t>
 void bind_unary_backward_shape(
     py::module& module,
@@ -426,7 +512,6 @@ void bind_unary_backward_shape(
             py::arg("memory_config") = std::nullopt});
 }
 
-// OpHandler_unary_optional : get_function_unary_optional
 template <typename unary_backward_operation_t>
 void bind_unary_backward_unary_optional(
     py::module& module, const unary_backward_operation_t& operation, const std::string& description) {
@@ -478,7 +563,6 @@ void bind_unary_backward_unary_optional(
             py::arg("queue_id") = 0});
 }
 
-// OpHandler_prod_bw : get_function_prod_bw
 template <typename unary_backward_operation_t>
 void bind_unary_backward_prod_bw(py::module& module, const unary_backward_operation_t& operation) {
     auto doc = fmt::format(
@@ -524,6 +608,53 @@ void bind_unary_backward_prod_bw(py::module& module, const unary_backward_operat
             py::arg("dim") = 0,
             py::arg("memory_config") = std::nullopt});
 }
+
+
+template <typename unary_backward_operation_t>
+void bind_unary_backward_opt(py::module& module, const unary_backward_operation_t& operation, const std::string& description) {
+    auto doc = fmt::format(
+R"doc({0}(grad_tensor: ttnn.Tensor, input_tensor: ttnn.Tensor *, memory_config: ttnn.MemoryConfig) -> std::vector<Tensor>
+
+{2}
+
+Args:
+    * :attr:`grad_tensor`
+    * :attr:`input_tensor`
+
+Keyword args:
+    * :attr:`memory_config` (Optional[ttnn.MemoryConfig]): memory config for the output tensor
+
+Example:
+
+    >>> grad_tensor = ttnn.to_device(ttnn.from_torch(torch.tensor((1, 2), dtype=torch.bfloat16)), device)
+    >>> input = ttnn.to_device(ttnn.from_torch(torch.tensor((1, 2), dtype=torch.bfloat16)), device)
+    >>> output = {1}(grad_tensor, input)
+)doc",
+        operation.base_name(),
+        operation.python_fully_qualified_name(),
+        description);
+
+    bind_registered_operation(
+        module,
+        operation,
+        doc,
+        ttnn::pybind_overload_t{
+            [](const unary_backward_operation_t& self,
+               const ttnn::Tensor& grad_tensor,
+               const ttnn::Tensor& input_tensor,
+               const float alpha,
+               const std::optional<ttnn::MemoryConfig>& memory_config) -> std::vector<ttnn::Tensor> {
+                return self(grad_tensor, input_tensor, alpha, memory_config);
+            },
+            py::arg("grad_tensor"),
+            py::arg("input_tensor"),
+            py::arg("alpha"),
+            py::kw_only(),
+            py::arg("memory_config") = std::nullopt}
+);
+
+}
+
 
 template <typename unary_backward_operation_t>
 void bind_unary_backward(
@@ -586,7 +717,7 @@ Example:
 }  // namespace detail
 
 void py_module(py::module& module) {
-    detail::bind_unary_backward(
+    detail::bind_unary_backward_opt(
         module,
         ttnn::mul_bw,
         R"doc(Performs backward operations for multiply on :attr:`input_tensor`, :attr:`alpha` or attr:`input_tensor_a`, attr:`input_tensor_b`, with given :attr:`grad_tensor`.)doc");
@@ -629,7 +760,7 @@ void py_module(py::module& module) {
         20.0,
         R"doc(Performs backward operations for softplus on :attr:`input_tensor`, :attr:`beta`, :attr:`threshold` with given :attr:`grad_tensor`.)doc");
 
-    detail::bind_unary_backward(
+    detail::bind_unary_backward_wo_float(
         module,
         ttnn::assign_bw,
         R"doc(Performs backward operations for assign on :attr:`input_tensor` or attr:`input_tensor_a`, attr:`input_tensor_b`, with given :attr:`grad_tensor`.)doc");
@@ -705,27 +836,27 @@ void py_module(py::module& module) {
         ttnn::sqrt_bw,
         R"doc(Performs backward operations for square-root on :attr:`input_tensor` with given :attr:`grad_tensor`.)doc");
 
-    detail::bind_unary_backward(
+    detail::bind_unary_backward_wo_float(
         module,
         ttnn::multigammaln_bw,
         R"doc(Performs backward operations for multigammaln on :attr:`input_tensor` with given :attr:`grad_tensor` and value of P is taken as 4.
         mvlgamma is refered as multigammaln.
         Input value must be greater than 2.5f)doc");
 
-    detail::bind_unary_backward(
+    detail::bind_unary_backward_opt(
         module,
         ttnn::add_bw,
         R"doc(Performs backward operations for addition on :attr:`input_tensor`, :attr:`alpha` or attr:`input_tensor_a`, attr:`input_tensor_b`, with given :attr:`grad_tensor`.)doc");
 
     detail::bind_unary_backward_prod_bw(module, ttnn::prod_bw);
 
-    detail::bind_unary_backward(
+    detail::bind_unary_backward_opt(
         module,
         ttnn::eq_bw,
         R"doc(Performs backward operations for equal to comparison on :attr:`input_tensor`, :attr:`alpha` or attr:`input_tensor_a`, attr:`input_tensor_b`, with given :attr:`grad_tensor`.
         Returns an tensor of zeros like input tensors.)doc");
 
-    detail::bind_unary_backward(
+    detail::bind_unary_backward_float(
         module,
         ttnn::gt_bw,
         R"doc(Performs backward operations for greater than comparison on :attr:`input_tensor`, :attr:`alpha` or attr:`input_tensor_a`, attr:`input_tensor_b`. with given :attr:`grad_tensor`.
@@ -755,28 +886,28 @@ void py_module(py::module& module) {
         R"doc(Performs backward operations for not equal comparison on :attr:`input_tensor`, :attr:`alpha` or attr:`input_tensor_a`, attr:`input_tensor_b`, with given :attr:`grad_tensor`.
         Returns an tensor of zeros like input tensors.)doc");
 
-    detail::bind_unary_backward(
+    detail::bind_unary_backward_wo_float(
         module,
         ttnn::lgamma_bw,
         R"doc(Performs backward operations for lgamma on :attr:`input_tensor` with given :attr:`grad_tensor`.)doc");
 
-    detail::bind_unary_backward(
+    detail::bind_unary_backward_wo_float(
         module,
         ttnn::fill_bw,
         R"doc(Performs backward operations for fill on :attr:`input_tensor` with given :attr:`grad_tensor`.
         Returns an tensor like :attr:`grad_tensor` with sum of tensor values.)doc");
 
-    detail::bind_unary_backward(
+    detail::bind_unary_backward_wo_float(
         module,
         ttnn::hardsigmoid_bw,
         R"doc(Performs backward operations for hardsigmoid on :attr:`input_tensor` with given :attr:`grad_tensor`.)doc");
 
-    detail::bind_unary_backward(
+    detail::bind_unary_backward_wo_float(
         module,
         ttnn::cos_bw,
         R"doc(Performs backward operations for cos on :attr:`input_tensor` with given :attr:`grad_tensor`.)doc");
 
-    detail::bind_unary_backward(
+    detail::bind_unary_backward_wo_float(
         module,
         ttnn::acosh_bw,
         R"doc(Performs backward operations for inverse cosine (acos) on :attr:`input_tensor` with given :attr:`grad_tensor`.)doc");
@@ -796,7 +927,7 @@ void py_module(py::module& module) {
         ttnn::rad2deg_bw,
         R"doc(Performs backward operations for radian to degree conversion (rad2deg) on :attr:`input_tensor` with given :attr:`grad_tensor`.)doc");
 
-    detail::bind_unary_backward(
+    detail::bind_unary_backward_float(
         module,
         ttnn::sub_bw,
         R"doc(Performs backward operations for subtraction on :attr:`input_tensor`, :attr:`alpha` or attr:`input_tensor_a`, attr:`input_tensor_b`, with given :attr:`grad_tensor`.)doc");
@@ -1006,12 +1137,12 @@ void py_module(py::module& module) {
         ttnn::sign_bw,
         R"doc(Performs backward operations for sign on :attr:`input_tensor` with given :attr:`grad_tensor`.)doc");
 
-    detail::bind_unary_backward(
+    detail::bind_unary_backward_float(
         module,
         ttnn::fmod_bw,
         R"doc(Performs backward operations for fmod on :attr:`input_tensor`, :attr:`eps` with given :attr:`grad_tensor`.)doc");
 
-    detail::bind_unary_backward(
+    detail::bind_unary_backward_float(
         module,
         ttnn::remainder_bw,
         R"doc(Performs backward operations for remainder on :attr:`input_tensor`, :attr:`scalar` with given :attr:`grad_tensor`.)doc");


### PR DESCRIPTION
Work Done in this PR:

- Clean up OpHandlers for the following
     - Unary , Binary, Ternary, Complex Backward ops
     - Complex Forward ops
- Remove std::function for unary and binary backward ops ( Issue : #10565 , #10568 - Tracking Issue : #10564 )

### Checklist
- [x] Post commit CI passes - https://github.com/tenstorrent/tt-metal/actions/runs/10111293765
