### PR TITLE
#10147: Where_bw in ttnn_ops fixed

### DIFF
--- a/tests/ttnn/python_api_testing/sweep_tests/ttnn_ops.py
+++ b/tests/ttnn/python_api_testing/sweep_tests/ttnn_ops.py
@@ -3628,6 +3628,10 @@ def rsub_bw(
 
 
 def where_bw(
+    x,  # grad_tensor
+    y,  # input_tensor
+    z,  # other_tensor1
+    w,  # other_tensor2
     device,
     dtype,
     layout,
@@ -3639,8 +3643,8 @@ def where_bw(
     y = y > 0
 
     t1 = setup_ttnn_tensor(y, device, layout[1], input_mem_config[1], dtype[1])
-    t2 = setup_ttnn_tensor(y, device, layout[2], input_mem_config[2], dtype[2])
-    t3 = setup_ttnn_tensor(y, device, layout[3], input_mem_config[3], dtype[3])
+    t2 = setup_ttnn_tensor(z, device, layout[2], input_mem_config[2], dtype[2])
+    t3 = setup_ttnn_tensor(w, device, layout[3], input_mem_config[3], dtype[3])
 
     t4 = ttnn.where_bw(t0, t1, t2, t3, memory_config=output_mem_config)
 


### PR DESCRIPTION
### Ticket
[Link to Github Issue](https://github.com/tenstorrent/tt-metal/issues/10147)

### Problem description
Wrong list of arguments in where_bw() in ttnn_ops

### What's changed
Inserted the right input arguments
