### PR TITLE
Use CI fixtures on Mixtral tests

### DIFF
--- a/models/demos/t3000/mixtral8x7b/demo/demo_with_prefill.py
+++ b/models/demos/t3000/mixtral8x7b/demo/demo_with_prefill.py
@@ -8,14 +8,6 @@ import pytest
 from loguru import logger
 from time import time
 
-# Set Mixtral flags for CI, if CI environment is setup
-if os.getenv("CI") == "true":
-    os.environ["MIXTRAL_CKPT_DIR"] = "/mnt/MLPerf/tt_dnn-models/Mistral/Mixtral-8x7B-v0.1/"
-    os.environ["MIXTRAL_TOKENIZER_PATH"] = "/mnt/MLPerf/tt_dnn-models/Mistral/Mixtral-8x7B-v0.1/"
-    os.environ["MIXTRAL_CACHE_PATH"] = "/mnt/MLPerf/tt_dnn-models/Mistral/Mixtral-8x7B-v0.1/"
-    os.environ["TT_METAL_ASYNC_DEVICE_QUEUE"] = "1"
-    os.environ["WH_ARCH_YAML"] = "wormhole_b0_80_arch_eth_dispatch.yaml"
-
 import ttnn
 from ttnn import ReplicateTensorToMesh, ConcatMeshToTensor
 from models.demos.t3000.mixtral8x7b.tt.mixtral_common import (
@@ -47,7 +39,7 @@ class Emb(torch.nn.Module):
 
 
 @torch.no_grad()
-def run_mixtral_demo(user_input, batch_size, device_mesh, instruct_mode):
+def run_mixtral_demo(user_input, batch_size, device_mesh, instruct_mode, is_ci_env):
     assert batch_size == 32, "Batch size must be 32"
     dtype = ttnn.bfloat8_b
 
@@ -261,7 +253,7 @@ def run_mixtral_demo(user_input, batch_size, device_mesh, instruct_mode):
         iteration_time = time() - iteration_time_start
         tokens_per_second_per_user = 1 / iteration_time
         # Print out generated outputs for each user at the end of every iteration
-        if os.getenv("CI") != "true":  # Avoid printing every iteration in CI
+        if not is_ci_env:  # Avoid printing every iteration in CI
             if len(user_input) == 1:
                 logger.info("[User 0] {}".format("".join(tokenizer.decode(all_outputs[0]))))
             else:
@@ -274,15 +266,14 @@ def run_mixtral_demo(user_input, batch_size, device_mesh, instruct_mode):
         )
 
     # In CI only print the final generated output to avoid spamming the logs
-    if os.getenv("CI") == "true":
+    if is_ci_env:
         if len(user_input) == 1:
             logger.info("[User 0] {}".format("".join(tokenizer.decode(all_outputs[0]))))
         else:
             for user in range(batch_size):
                 logger.info("[User {}] {}".format(user, "".join(tokenizer.decode(all_outputs[user]))))
 
-    # When running in CI, check the output against the expected output to avoid accuracy regressions
-    if os.getenv("CI") == "true":
+        # When running in CI, check the output against the expected output to avoid accuracy regressions
         expected_output = "models/demos/t3000/mixtral8x7b/demo/expected_outputs_prefill_128.json"
         with open(expected_output, "r") as f:
             expected_out = json.load(f)
@@ -295,8 +286,6 @@ def run_mixtral_demo(user_input, batch_size, device_mesh, instruct_mode):
         logger.info("[CI-Only] Output token validation passed!")
 
 
-# Avoid running this test when in CI
-@pytest.mark.skipif(os.getenv("CI") == "true", reason="Non-CI tests")
 @pytest.mark.parametrize(
     "input_prompts, instruct_weights",
     [
@@ -305,24 +294,17 @@ def run_mixtral_demo(user_input, batch_size, device_mesh, instruct_mode):
     ],
     ids=["general_weights", "instruct_weights"],
 )
-def test_mixtral8x7b_demo(t3k_device_mesh, use_program_cache, input_prompts, instruct_weights):
-    return run_mixtral_demo(
-        user_input=input_prompts, batch_size=32, device_mesh=t3k_device_mesh, instruct_mode=instruct_weights
-    )
+def test_mixtral8x7b_demo(t3k_device_mesh, use_program_cache, input_prompts, instruct_weights, is_ci_env):
+    if is_ci_env and instruct_weights == True:
+        pytest.skip("CI demo test only runs general weights to reduce CI pipeline load (both are supported)")
 
+    for device in t3k_device_mesh.get_device_ids():
+        t3k_device_mesh.get_device(device).enable_async(True)
 
-# CI only runs general-weights demo
-@pytest.mark.skipif(not os.getenv("CI") == "true", reason="CI-only test")
-@pytest.mark.parametrize(
-    "input_prompts, instruct_weights",
-    [
-        ("models/demos/t3000/mixtral8x7b/demo/input_data_prefill_128.json", False),
-    ],
-    ids=[
-        "general_weights",
-    ],
-)
-def test_mixtral8x7b_demo_CI(t3k_device_mesh, use_program_cache, input_prompts, instruct_weights):
     return run_mixtral_demo(
-        user_input=input_prompts, batch_size=32, device_mesh=t3k_device_mesh, instruct_mode=instruct_weights
+        user_input=input_prompts,
+        batch_size=32,
+        device_mesh=t3k_device_mesh,
+        instruct_mode=instruct_weights,
+        is_ci_env=is_ci_env,
     )

--- a/models/demos/t3000/mixtral8x7b/tests/test_mixtral_attention.py
+++ b/models/demos/t3000/mixtral8x7b/tests/test_mixtral_attention.py
@@ -6,14 +6,6 @@ import torch
 import pytest
 from loguru import logger
 
-# Set Mixtral flags for CI, if CI environment is setup
-if os.getenv("CI") == "true":
-    os.environ["MIXTRAL_CKPT_DIR"] = "/mnt/MLPerf/tt_dnn-models/Mistral/Mixtral-8x7B-v0.1/"
-    os.environ["MIXTRAL_TOKENIZER_PATH"] = "/mnt/MLPerf/tt_dnn-models/Mistral/Mixtral-8x7B-v0.1/"
-    os.environ["MIXTRAL_CACHE_PATH"] = "/mnt/MLPerf/tt_dnn-models/Mistral/Mixtral-8x7B-v0.1/"
-    os.environ["TT_METAL_ASYNC_DEVICE_QUEUE"] = "1"
-    os.environ["WH_ARCH_YAML"] = "wormhole_b0_80_arch_eth_dispatch.yaml"
-
 import ttnn
 from ttnn import ReplicateTensorToMesh, ConcatMeshToTensor
 from models.demos.t3000.mixtral8x7b.tt.mixtral_attention import TtMixtralAttention
@@ -28,6 +20,9 @@ from models.utility_functions import (
 
 
 def test_mixtral_attention_inference(t3k_device_mesh, use_program_cache, reset_seeds):
+    for device in t3k_device_mesh.get_device_ids():
+        t3k_device_mesh.get_device(device).enable_async(True)
+
     pcc = 0.99
     dtype = ttnn.bfloat8_b
     model_args = TtModelArgs(t3k_device_mesh.get_device(0))

--- a/models/demos/t3000/mixtral8x7b/tests/test_mixtral_attention_prefill.py
+++ b/models/demos/t3000/mixtral8x7b/tests/test_mixtral_attention_prefill.py
@@ -6,13 +6,6 @@ import torch
 import pytest
 from loguru import logger
 
-# Set Mixtral flags for CI, if CI environment is setup
-if os.getenv("CI") == "true":
-    os.environ["MIXTRAL_CKPT_DIR"] = "/mnt/MLPerf/tt_dnn-models/Mistral/Mixtral-8x7B-v0.1/"
-    os.environ["MIXTRAL_TOKENIZER_PATH"] = "/mnt/MLPerf/tt_dnn-models/Mistral/Mixtral-8x7B-v0.1/"
-    os.environ["MIXTRAL_CACHE_PATH"] = "/mnt/MLPerf/tt_dnn-models/Mistral/Mixtral-8x7B-v0.1/"
-    os.environ["TT_METAL_ASYNC_DEVICE_QUEUE"] = "1"
-
 import ttnn
 from ttnn import ReplicateTensorToMesh, ConcatMeshToTensor
 from models.demos.t3000.mixtral8x7b.tt.mixtral_attention import TtMixtralAttention
@@ -41,6 +34,9 @@ from models.utility_functions import (
 )
 @torch.no_grad()
 def test_mixtral_attention_inference(t3k_device_mesh, use_program_cache, reset_seeds, seq_len):
+    for device in t3k_device_mesh.get_device_ids():
+        t3k_device_mesh.get_device(device).enable_async(True)
+
     pcc = 0.99
     dtype = ttnn.bfloat8_b
     model_args = TtModelArgs(t3k_device_mesh.get_device(0))

--- a/models/demos/t3000/mixtral8x7b/tests/test_mixtral_decoder.py
+++ b/models/demos/t3000/mixtral8x7b/tests/test_mixtral_decoder.py
@@ -6,14 +6,6 @@ import torch
 import pytest
 from loguru import logger
 
-# Set Mixtral flags for CI, if CI environment is setup
-if os.getenv("CI") == "true":
-    os.environ["MIXTRAL_CKPT_DIR"] = "/mnt/MLPerf/tt_dnn-models/Mistral/Mixtral-8x7B-v0.1/"
-    os.environ["MIXTRAL_TOKENIZER_PATH"] = "/mnt/MLPerf/tt_dnn-models/Mistral/Mixtral-8x7B-v0.1/"
-    os.environ["MIXTRAL_CACHE_PATH"] = "/mnt/MLPerf/tt_dnn-models/Mistral/Mixtral-8x7B-v0.1/"
-    os.environ["TT_METAL_ASYNC_DEVICE_QUEUE"] = "1"
-    os.environ["WH_ARCH_YAML"] = "wormhole_b0_80_arch_eth_dispatch.yaml"
-
 import ttnn
 from models.demos.t3000.mixtral8x7b.tt.mixtral_common import prepare_inputs_ttnn, get_single_rot_mat
 from models.demos.t3000.mixtral8x7b.tt.mixtral_decoder import TtTransformerBlock
@@ -29,6 +21,9 @@ def test_mixtral_decoder_inference(t3k_device_mesh, use_program_cache, reset_see
     s: sequence length
     h: hidden size
     """
+    for device in t3k_device_mesh.get_device_ids():
+        t3k_device_mesh.get_device(device).enable_async(True)
+
     pcc = 0.99
     dtype = ttnn.bfloat8_b
 

--- a/models/demos/t3000/mixtral8x7b/tests/test_mixtral_decoder_prefill.py
+++ b/models/demos/t3000/mixtral8x7b/tests/test_mixtral_decoder_prefill.py
@@ -6,14 +6,6 @@ import torch
 import pytest
 from loguru import logger
 
-# Set Mixtral flags for CI, if CI environment is setup
-if os.getenv("CI") == "true":
-    os.environ["MIXTRAL_CKPT_DIR"] = "/mnt/MLPerf/tt_dnn-models/Mistral/Mixtral-8x7B-v0.1/"
-    os.environ["MIXTRAL_TOKENIZER_PATH"] = "/mnt/MLPerf/tt_dnn-models/Mistral/Mixtral-8x7B-v0.1/"
-    os.environ["MIXTRAL_CACHE_PATH"] = "/mnt/MLPerf/tt_dnn-models/Mistral/Mixtral-8x7B-v0.1/"
-    os.environ["TT_METAL_ASYNC_DEVICE_QUEUE"] = "1"
-    os.environ["WH_ARCH_YAML"] = "wormhole_b0_80_arch_eth_dispatch.yaml"
-
 import ttnn
 from models.demos.t3000.mixtral8x7b.tt.mixtral_common import (
     prepare_inputs_ttnn_prefill,
@@ -43,6 +35,9 @@ def test_mixtral_decoder_inference(t3k_device_mesh, use_program_cache, reset_see
     s: sequence length
     h: hidden size
     """
+    for device in t3k_device_mesh.get_device_ids():
+        t3k_device_mesh.get_device(device).enable_async(True)
+
     pcc = 0.99
     dtype = ttnn.bfloat8_b
 

--- a/models/demos/t3000/mixtral8x7b/tests/test_mixtral_embedding.py
+++ b/models/demos/t3000/mixtral8x7b/tests/test_mixtral_embedding.py
@@ -6,14 +6,6 @@ import torch
 import pytest
 from loguru import logger
 
-# Set Mixtral flags for CI, if CI environment is setup
-if os.getenv("CI") == "true":
-    os.environ["MIXTRAL_CKPT_DIR"] = "/mnt/MLPerf/tt_dnn-models/Mistral/Mixtral-8x7B-v0.1/"
-    os.environ["MIXTRAL_TOKENIZER_PATH"] = "/mnt/MLPerf/tt_dnn-models/Mistral/Mixtral-8x7B-v0.1/"
-    os.environ["MIXTRAL_CACHE_PATH"] = "/mnt/MLPerf/tt_dnn-models/Mistral/Mixtral-8x7B-v0.1/"
-    os.environ["TT_METAL_ASYNC_DEVICE_QUEUE"] = "1"
-    os.environ["WH_ARCH_YAML"] = "wormhole_b0_80_arch_eth_dispatch.yaml"
-
 import ttnn
 from models.demos.t3000.mixtral8x7b.tt.mixtral_embedding import TtMixtralEmbedding
 from models.demos.t3000.mixtral8x7b.reference.tokenizer import Tokenizer
@@ -34,6 +26,8 @@ class Emb(torch.nn.Module):
 
 
 def test_mixtral_embedding(device, use_program_cache, reset_seeds):
+    device.enable_async(True)
+
     dtype = ttnn.bfloat16
 
     model_args = TtModelArgs(device)

--- a/models/demos/t3000/mixtral8x7b/tests/test_mixtral_mlp.py
+++ b/models/demos/t3000/mixtral8x7b/tests/test_mixtral_mlp.py
@@ -5,14 +5,6 @@ import os
 import torch
 from loguru import logger
 
-# Set Mixtral flags for CI, if CI environment is setup
-if os.getenv("CI") == "true":
-    os.environ["MIXTRAL_CKPT_DIR"] = "/mnt/MLPerf/tt_dnn-models/Mistral/Mixtral-8x7B-v0.1/"
-    os.environ["MIXTRAL_TOKENIZER_PATH"] = "/mnt/MLPerf/tt_dnn-models/Mistral/Mixtral-8x7B-v0.1/"
-    os.environ["MIXTRAL_CACHE_PATH"] = "/mnt/MLPerf/tt_dnn-models/Mistral/Mixtral-8x7B-v0.1/"
-    os.environ["TT_METAL_ASYNC_DEVICE_QUEUE"] = "1"
-    os.environ["WH_ARCH_YAML"] = "wormhole_b0_80_arch_eth_dispatch.yaml"
-
 import ttnn
 from ttnn import ReplicateTensorToMesh, ConcatMeshToTensor
 
@@ -27,6 +19,9 @@ from models.utility_functions import (
 
 
 def test_mixtral_mlp_inference(t3k_device_mesh, use_program_cache, reset_seeds):
+    for device in t3k_device_mesh.get_device_ids():
+        t3k_device_mesh.get_device(device).enable_async(True)
+
     # Specify different dtypes for each feedForward weights
     dtypes = {
         "w1": ttnn.bfloat4_b,

--- a/models/demos/t3000/mixtral8x7b/tests/test_mixtral_mlp_prefill.py
+++ b/models/demos/t3000/mixtral8x7b/tests/test_mixtral_mlp_prefill.py
@@ -6,14 +6,6 @@ import torch
 from loguru import logger
 import pytest
 
-# Set Mixtral flags for CI, if CI environment is setup
-if os.getenv("CI") == "true":
-    os.environ["MIXTRAL_CKPT_DIR"] = "/mnt/MLPerf/tt_dnn-models/Mistral/Mixtral-8x7B-v0.1/"
-    os.environ["MIXTRAL_TOKENIZER_PATH"] = "/mnt/MLPerf/tt_dnn-models/Mistral/Mixtral-8x7B-v0.1/"
-    os.environ["MIXTRAL_CACHE_PATH"] = "/mnt/MLPerf/tt_dnn-models/Mistral/Mixtral-8x7B-v0.1/"
-    os.environ["TT_METAL_ASYNC_DEVICE_QUEUE"] = "1"
-    os.environ["WH_ARCH_YAML"] = "wormhole_b0_80_arch_eth_dispatch.yaml"
-
 import ttnn
 from ttnn import ReplicateTensorToMesh, ConcatMeshToTensor
 
@@ -36,6 +28,9 @@ from models.utility_functions import (
     ),
 )
 def test_mixtral_mlp_inference(t3k_device_mesh, use_program_cache, reset_seeds, seq_len):
+    for device in t3k_device_mesh.get_device_ids():
+        t3k_device_mesh.get_device(device).enable_async(True)
+
     # Specify different dtypes for each feedForward weights
     dtypes = {
         "w1": ttnn.bfloat8_b,

--- a/models/demos/t3000/mixtral8x7b/tests/test_mixtral_model.py
+++ b/models/demos/t3000/mixtral8x7b/tests/test_mixtral_model.py
@@ -8,14 +8,6 @@ import numpy as np
 from loguru import logger
 from sklearn.metrics import top_k_accuracy_score
 
-# Set Mixtral flags for CI, if CI environment is setup
-if os.getenv("CI") == "true":
-    os.environ["MIXTRAL_CKPT_DIR"] = "/mnt/MLPerf/tt_dnn-models/Mistral/Mixtral-8x7B-v0.1/"
-    os.environ["MIXTRAL_TOKENIZER_PATH"] = "/mnt/MLPerf/tt_dnn-models/Mistral/Mixtral-8x7B-v0.1/"
-    os.environ["MIXTRAL_CACHE_PATH"] = "/mnt/MLPerf/tt_dnn-models/Mistral/Mixtral-8x7B-v0.1/"
-    os.environ["TT_METAL_ASYNC_DEVICE_QUEUE"] = "1"
-    os.environ["WH_ARCH_YAML"] = "wormhole_b0_80_arch_eth_dispatch.yaml"
-
 import ttnn
 from ttnn import ReplicateTensorToMesh, ConcatMeshToTensor
 
@@ -37,6 +29,9 @@ class Emb(torch.nn.Module):
 
 
 def test_mixtral_model_inference(t3k_device_mesh, use_program_cache, reset_seeds):
+    for device in t3k_device_mesh.get_device_ids():
+        t3k_device_mesh.get_device(device).enable_async(True)
+
     valid_pcc = 0.97
     dtype = ttnn.bfloat8_b
     iterations = 10

--- a/models/demos/t3000/mixtral8x7b/tests/test_mixtral_moe.py
+++ b/models/demos/t3000/mixtral8x7b/tests/test_mixtral_moe.py
@@ -6,14 +6,6 @@ import torch
 import pytest
 from loguru import logger
 
-# Set Mixtral flags for CI, if CI environment is setup
-if os.getenv("CI") == "true":
-    os.environ["MIXTRAL_CKPT_DIR"] = "/mnt/MLPerf/tt_dnn-models/Mistral/Mixtral-8x7B-v0.1/"
-    os.environ["MIXTRAL_TOKENIZER_PATH"] = "/mnt/MLPerf/tt_dnn-models/Mistral/Mixtral-8x7B-v0.1/"
-    os.environ["MIXTRAL_CACHE_PATH"] = "/mnt/MLPerf/tt_dnn-models/Mistral/Mixtral-8x7B-v0.1/"
-    os.environ["TT_METAL_ASYNC_DEVICE_QUEUE"] = "1"
-    os.environ["WH_ARCH_YAML"] = "wormhole_b0_80_arch_eth_dispatch.yaml"
-
 import ttnn
 from ttnn import ReplicateTensorToMesh, ConcatMeshToTensor
 
@@ -29,6 +21,9 @@ from models.utility_functions import (
 
 
 def test_mixtral_moe_inference(t3k_device_mesh, use_program_cache, reset_seeds):
+    for device in t3k_device_mesh.get_device_ids():
+        t3k_device_mesh.get_device(device).enable_async(True)
+
     pcc = 0.99
     iterations = 1
     dtype = ttnn.bfloat8_b

--- a/models/demos/t3000/mixtral8x7b/tests/test_mixtral_moe_prefill.py
+++ b/models/demos/t3000/mixtral8x7b/tests/test_mixtral_moe_prefill.py
@@ -6,14 +6,6 @@ import torch
 import pytest
 from loguru import logger
 
-# Set Mixtral flags for CI, if CI environment is setup
-if os.getenv("CI") == "true":
-    os.environ["MIXTRAL_CKPT_DIR"] = "/mnt/MLPerf/tt_dnn-models/Mistral/Mixtral-8x7B-v0.1/"
-    os.environ["MIXTRAL_TOKENIZER_PATH"] = "/mnt/MLPerf/tt_dnn-models/Mistral/Mixtral-8x7B-v0.1/"
-    os.environ["MIXTRAL_CACHE_PATH"] = "/mnt/MLPerf/tt_dnn-models/Mistral/Mixtral-8x7B-v0.1/"
-    os.environ["TT_METAL_ASYNC_DEVICE_QUEUE"] = "1"
-    os.environ["WH_ARCH_YAML"] = "wormhole_b0_80_arch_eth_dispatch.yaml"
-
 import ttnn
 from ttnn import ReplicateTensorToMesh, ConcatMeshToTensor
 
@@ -38,6 +30,9 @@ from models.utility_functions import (
     ),
 )
 def test_mixtral_moe_inference(t3k_device_mesh, use_program_cache, reset_seeds, seq_len):
+    for device in t3k_device_mesh.get_device_ids():
+        t3k_device_mesh.get_device(device).enable_async(True)
+
     pcc = 0.99
     iterations = 1
     dtype = ttnn.bfloat8_b

--- a/models/demos/t3000/mixtral8x7b/tests/test_mixtral_perplexity.py
+++ b/models/demos/t3000/mixtral8x7b/tests/test_mixtral_perplexity.py
@@ -12,14 +12,6 @@ import sys
 from tqdm import tqdm
 import numpy as np
 
-# Set Mixtral flags for CI, if CI environment is setup
-if os.getenv("CI") == "true":
-    os.environ["MIXTRAL_CKPT_DIR"] = "/mnt/MLPerf/tt_dnn-models/Mistral/Mixtral-8x7B-v0.1/"
-    os.environ["MIXTRAL_TOKENIZER_PATH"] = "/mnt/MLPerf/tt_dnn-models/Mistral/Mixtral-8x7B-v0.1/"
-    os.environ["MIXTRAL_CACHE_PATH"] = "/mnt/MLPerf/tt_dnn-models/Mistral/Mixtral-8x7B-v0.1/"
-    os.environ["TT_METAL_ASYNC_DEVICE_QUEUE"] = "1"
-    os.environ["WH_ARCH_YAML"] = "wormhole_b0_80_arch_eth_dispatch.yaml"
-
 import ttnn
 from ttnn import ReplicateTensorToMesh, ConcatMeshToTensor
 from models.demos.t3000.mixtral8x7b.tt.mixtral_common import (
@@ -292,6 +284,9 @@ def test_mixtral_perplexity(
     assert (
         llm_mode == "decode"
     ), "Only decode mode is supported for now"  # TODO Add prefill support when it reaches main
+
+    for device in t3k_device_mesh.get_device_ids():
+        t3k_device_mesh.get_device(device).enable_async(True)
 
     return run_test_perplexity(
         device_mesh=t3k_device_mesh,

--- a/models/demos/t3000/mixtral8x7b/tests/test_mixtral_rms_norm.py
+++ b/models/demos/t3000/mixtral8x7b/tests/test_mixtral_rms_norm.py
@@ -6,14 +6,6 @@ import torch
 import pytest
 from loguru import logger
 
-# Set Mixtral flags for CI, if CI environment is setup
-if os.getenv("CI") == "true":
-    os.environ["MIXTRAL_CKPT_DIR"] = "/mnt/MLPerf/tt_dnn-models/Mistral/Mixtral-8x7B-v0.1/"
-    os.environ["MIXTRAL_TOKENIZER_PATH"] = "/mnt/MLPerf/tt_dnn-models/Mistral/Mixtral-8x7B-v0.1/"
-    os.environ["MIXTRAL_CACHE_PATH"] = "/mnt/MLPerf/tt_dnn-models/Mistral/Mixtral-8x7B-v0.1/"
-    os.environ["TT_METAL_ASYNC_DEVICE_QUEUE"] = "1"
-    os.environ["WH_ARCH_YAML"] = "wormhole_b0_80_arch_eth_dispatch.yaml"
-
 import ttnn
 from ttnn import ReplicateTensorToMesh, ConcatMeshToTensor
 
@@ -28,6 +20,9 @@ from models.utility_functions import (
 
 
 def test_mixtral_rms_norm_inference(t3k_device_mesh, use_program_cache, reset_seeds):
+    for device in t3k_device_mesh.get_device_ids():
+        t3k_device_mesh.get_device(device).enable_async(True)
+
     dtype = ttnn.bfloat8_b
 
     model_args = TtModelArgs(t3k_device_mesh.get_device(0))

--- a/models/demos/t3000/mixtral8x7b/tests/test_mixtral_topk.py
+++ b/models/demos/t3000/mixtral8x7b/tests/test_mixtral_topk.py
@@ -7,14 +7,6 @@ import pytest
 from loguru import logger
 from sklearn.metrics import top_k_accuracy_score
 
-# Set Mixtral flags for CI, if CI environment is setup
-if os.getenv("CI") == "true":
-    os.environ["MIXTRAL_CKPT_DIR"] = "/mnt/MLPerf/tt_dnn-models/Mistral/Mixtral-8x7B-v0.1/"
-    os.environ["MIXTRAL_TOKENIZER_PATH"] = "/mnt/MLPerf/tt_dnn-models/Mistral/Mixtral-8x7B-v0.1/"
-    os.environ["MIXTRAL_CACHE_PATH"] = "/mnt/MLPerf/tt_dnn-models/Mistral/Mixtral-8x7B-v0.1/"
-    os.environ["TT_METAL_ASYNC_DEVICE_QUEUE"] = "1"
-    os.environ["WH_ARCH_YAML"] = "wormhole_b0_80_arch_eth_dispatch.yaml"
-
 import ttnn
 from models.demos.t3000.mixtral8x7b.tt.mixtral_common import prepare_inputs_ttnn, preprocess_inputs, load_inputs
 from models.demos.t3000.mixtral8x7b.tt.mixtral_model import TtTransformer
@@ -46,6 +38,9 @@ class Emb(torch.nn.Module):
 def test_mixtral_model_inference(
     t3k_device_mesh, use_program_cache, reset_seeds, iterations, expected_top1, expected_top5
 ):
+    for device in t3k_device_mesh.get_device_ids():
+        t3k_device_mesh.get_device(device).enable_async(True)
+
     dtype = ttnn.bfloat8_b
     seqlen = 1  # Generating one token per user at a time
     batch = 32

--- a/models/demos/t3000/mixtral8x7b/tt/model_config.py
+++ b/models/demos/t3000/mixtral8x7b/tt/model_config.py
@@ -29,9 +29,9 @@ class TtModelArgs:
     num_experts_per_tok = 2
 
     # Default folder location for weights and cached files
-    DEFAULT_CKPT_DIR = os.getenv("MIXTRAL_CKPT_DIR", "/proj_sw/user_dev/hf_data/mistral/Mixtral-8x7B-v0.1")
-    DEFAULT_TOKENIZER_PATH = os.getenv("MIXTRAL_TOKENIZER_PATH", "/proj_sw/user_dev/hf_data/mistral/Mixtral-8x7B-v0.1")
-    DEFAULT_CACHE_PATH = os.getenv("MIXTRAL_CACHE_PATH", "/proj_sw/user_dev/hf_data/mistral/Mixtral-8x7B-v0.1")
+    DEFAULT_CKPT_DIR = os.getenv("MIXTRAL_CKPT_DIR", "/mnt/MLPerf/tt_dnn-models/Mistral/Mixtral-8x7B-v0.1/")
+    DEFAULT_TOKENIZER_PATH = os.getenv("MIXTRAL_TOKENIZER_PATH", "/mnt/MLPerf/tt_dnn-models/Mistral/Mixtral-8x7B-v0.1/")
+    DEFAULT_CACHE_PATH = os.getenv("MIXTRAL_CACHE_PATH", "/mnt/MLPerf/tt_dnn-models/Mistral/Mixtral-8x7B-v0.1/")
 
     # Keys to be used by the different modules of Mixtral
     OP_KEYS = (

--- a/tests/scripts/t3000/run_t3000_demo_tests.sh
+++ b/tests/scripts/t3000/run_t3000_demo_tests.sh
@@ -67,8 +67,8 @@ run_t3000_mixtral_tests() {
   echo "LOG_METAL: Running run_t3000_mixtral8x7b_tests"
 
   # mixtral8x7b 8 chip demo test - 100 token generation with general weights (env flags set inside the test)
-  pytest -n auto models/demos/t3000/mixtral8x7b/demo/demo.py --timeout=720 ; fail+=$?
-  pytest -n auto models/demos/t3000/mixtral8x7b/demo/demo_with_prefill.py --timeout=720 ; fail+=$?
+  WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml pytest -n auto models/demos/t3000/mixtral8x7b/demo/demo.py --timeout=720 ; fail+=$?
+  WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml pytest -n auto models/demos/t3000/mixtral8x7b/demo/demo_with_prefill.py --timeout=720 ; fail+=$?
 
   # Record the end time
   end_time=$(date +%s)

--- a/tests/scripts/t3000/run_t3000_frequent_tests.sh
+++ b/tests/scripts/t3000/run_t3000_frequent_tests.sh
@@ -51,8 +51,8 @@ run_t3000_mixtral_tests() {
   echo "LOG_METAL: Running run_t3000_mixtral_tests"
 
   # mixtral8x7b 8 chip decode model test (env flags set inside the test)
-  pytest -n auto models/demos/t3000/mixtral8x7b/tests/test_mixtral_model.py --timeout=600; fail+=$?
-  pytest -n auto models/demos/t3000/mixtral8x7b/tests/test_mixtral_model_prefill.py --timeout=600; fail+=$?
+  WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml pytest -n auto models/demos/t3000/mixtral8x7b/tests/test_mixtral_model.py --timeout=600; fail+=$?
+  WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml pytest -n auto models/demos/t3000/mixtral8x7b/tests/test_mixtral_model_prefill.py --timeout=600; fail+=$?
 
   # Record the end time
   end_time=$(date +%s)

--- a/tests/scripts/t3000/run_t3000_model_perf_tests.sh
+++ b/tests/scripts/t3000/run_t3000_model_perf_tests.sh
@@ -27,7 +27,7 @@ run_t3000_mixtral_tests() {
 
   echo "LOG_METAL: Running run_t3000_mixtral_tests"
 
-  env pytest -n auto models/demos/t3000/mixtral8x7b/tests/test_mixtral_perf.py -m "model_perf_t3000" ; fail+=$?
+  env WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml pytest -n auto models/demos/t3000/mixtral8x7b/tests/test_mixtral_perf.py -m "model_perf_t3000" ; fail+=$?
 
   # Record the end time
   end_time=$(date +%s)

--- a/tests/scripts/t3000/run_t3000_unit_tests.sh
+++ b/tests/scripts/t3000/run_t3000_unit_tests.sh
@@ -94,15 +94,15 @@ run_t3000_mixtral_tests() {
 
   echo "LOG_METAL: Running run_t3000_mixtral_tests"
 
-  pytest -n auto models/demos/t3000/mixtral8x7b/tests/test_mixtral_attention.py ; fail+=$?
-  pytest -n auto models/demos/t3000/mixtral8x7b/tests/test_mixtral_mlp.py ; fail+=$?
-  pytest -n auto models/demos/t3000/mixtral8x7b/tests/test_mixtral_rms_norm.py ; fail+=$?
-  pytest -n auto models/demos/t3000/mixtral8x7b/tests/test_mixtral_embedding.py ; fail+=$?
-  pytest -n auto models/demos/t3000/mixtral8x7b/tests/test_mixtral_moe.py ; fail+=$?
-  pytest -n auto models/demos/t3000/mixtral8x7b/tests/test_mixtral_decoder.py ; fail+=$?
+  WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml pytest -n auto models/demos/t3000/mixtral8x7b/tests/test_mixtral_attention.py ; fail+=$?
+  WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml pytest -n auto models/demos/t3000/mixtral8x7b/tests/test_mixtral_mlp.py ; fail+=$?
+  WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml pytest -n auto models/demos/t3000/mixtral8x7b/tests/test_mixtral_rms_norm.py ; fail+=$?
+  WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml pytest -n auto models/demos/t3000/mixtral8x7b/tests/test_mixtral_embedding.py ; fail+=$?
+  WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml pytest -n auto models/demos/t3000/mixtral8x7b/tests/test_mixtral_moe.py ; fail+=$?
+  WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml pytest -n auto models/demos/t3000/mixtral8x7b/tests/test_mixtral_decoder.py ; fail+=$?
   # Mixtral prefill tests
-  pytest -n auto models/demos/t3000/mixtral8x7b/tests/test_mixtral_mlp_prefill.py ; fail+=$?
-  pytest -n auto models/demos/t3000/mixtral8x7b/tests/test_mixtral_moe_prefill.py ; fail+=$?
+  WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml pytest -n auto models/demos/t3000/mixtral8x7b/tests/test_mixtral_mlp_prefill.py ; fail+=$?
+  WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml pytest -n auto models/demos/t3000/mixtral8x7b/tests/test_mixtral_moe_prefill.py ; fail+=$?
   # Record the end time
   end_time=$(date +%s)
   duration=$((end_time - start_time))


### PR DESCRIPTION
### Ticket
#10405

### Problem description
Move all instances of CI flag checks to inside test fixtures `is_ci_env`.

### Checklist
- [x] [All-Post commit](https://github.com/tenstorrent/tt-metal/actions/runs/10092953374)
- [x] [T3k unit tests](https://github.com/tenstorrent/tt-metal/actions/runs/10095481149)
- [x] [T3k frequent tests](https://github.com/tenstorrent/tt-metal/actions/runs/10092357123)
- [x] [T3k demo tests](https://github.com/tenstorrent/tt-metal/actions/runs/10092351299)
- [x] [T3k perf tests](https://github.com/tenstorrent/tt-metal/actions/runs/10094583620)
