### PR TITLE
#0: removed unused Mistral GS device test from CI

### DIFF
--- a/tests/scripts/run_performance.sh
+++ b/tests/scripts/run_performance.sh
@@ -74,8 +74,6 @@ run_device_perf_models() {
 
         env pytest models/demos/bert/tests -m $test_marker
 
-        env pytest models/demos/wormhole/mistral7b/tests -m $test_marker
-
         env pytest models/demos/resnet/tests -m $test_marker
     fi
 


### PR DESCRIPTION
### Problem description
Removes missing Mistral test from CI script, to avoid pipeline error.
