### PR TITLE
#0: Update usage of ttnn.embedding to respect defaults of old tt_lib.tensor.embeddings

### DIFF
--- a/models/demos/metal_BERT_large_11/tt/embeddings.py
+++ b/models/demos/metal_BERT_large_11/tt/embeddings.py
@@ -142,6 +142,9 @@ class TtEmbeddings:
             padding_idx=self.pad_token,
             memory_config=self.model_config["OUTPUT_EMBEDDINGS_MEMCFG"],
         )
+        input_embeds = ttnn.reshape(
+            inputs_embeds, [inputs_embeds.shape[0], 1, inputs_embeds.shape[1], inputs_embeds.shape[2]]
+        )
         input_ids.deallocate()
 
         token_type_embeddings = ttnn.embedding(
@@ -150,6 +153,10 @@ class TtEmbeddings:
             layout=ttnn.TILE_LAYOUT,
             embeddings_type=ttnn.EmbeddingsType.BINARY,
             memory_config=self.model_config["OUTPUT_EMBEDDINGS_MEMCFG"],
+        )
+        token_type_embeddings = ttnn.reshape(
+            token_type_embeddings,
+            [token_type_embeddings.shape[0], 1, token_type_embeddings.shape[1], token_type_embeddings.shape[2]],
         )
         token_type_ids.deallocate()
 
@@ -167,6 +174,15 @@ class TtEmbeddings:
                 layout=ttnn.TILE_LAYOUT,
                 embeddings_type=ttnn.EmbeddingsType.GENERIC,
                 memory_config=self.model_config["OUTPUT_EMBEDDINGS_MEMCFG"],
+            )
+            position_embeddings_tt_tensor = ttnn.reshape(
+                position_embeddings_tt_tensor,
+                [
+                    position_embeddings_tt_tensor.shape[0],
+                    1,
+                    position_embeddings_tt_tensor.shape[1],
+                    position_embeddings_tt_tensor.shape[2],
+                ],
             )
             # Deallocate inputs_embeds and token_type_embeddings here to avoid having to move final output
             if self.model_config["DEALLOC_INPUT_EMBEDS_AFTER_POSITION_EMBEDS"]:

--- a/models/demos/t3000/falcon40b/tt/falcon_embeddings.py
+++ b/models/demos/t3000/falcon40b/tt/falcon_embeddings.py
@@ -38,6 +38,7 @@ class TtFalconEmbeddings(torch.nn.Module):
             self.embd_weights,
             layout=ttnn.TILE_LAYOUT,
             dtype=self.model_config["WORD_EMBEDDING_OUTPUT_DTYPE"],
+            memory_config=ttnn.DRAM_MEMORY_CONFIG,
         )
         x = ttnn.reshape(x, [x.shape[0], 1, x.shape[1], x.shape[2]])
 

--- a/models/demos/t3000/llama2_70b/tt/llama_embedding.py
+++ b/models/demos/t3000/llama2_70b/tt/llama_embedding.py
@@ -51,7 +51,9 @@ class TtLlamaEmbedding:
         self.emb_weights = ttnn.to_device(embd_weights_ttn, device_mesh)
 
     def __call__(self, x: ttnn.Tensor) -> ttnn.Tensor:
-        x = ttnn.embedding(x, self.emb_weights, layout=ttnn.TILE_LAYOUT, dtype=ttnn.bfloat16)
+        x = ttnn.embedding(
+            x, self.emb_weights, layout=ttnn.TILE_LAYOUT, dtype=ttnn.bfloat16, memory_config=ttnn.DRAM_MEMORY_CONFIG
+        )
         x = ttnn.reshape(x, [x.shape[0], 1, x.shape[1], x.shape[2]])
 
         return x

--- a/models/experimental/llama2_70b/tt/llama_embedding.py
+++ b/models/experimental/llama2_70b/tt/llama_embedding.py
@@ -51,7 +51,9 @@ class TtLlamaEmbedding:
         self.emb_weights = ttnn.to_device(embd_weights_ttn, device_mesh)
 
     def __call__(self, x: ttnn.Tensor) -> ttnn.Tensor:
-        x = ttnn.embedding(x, self.emb_weights, layout=ttnn.TILE_LAYOUT, dtype=ttnn.bfloat16)
+        x = ttnn.embedding(
+            x, self.emb_weights, layout=ttnn.TILE_LAYOUT, dtype=ttnn.bfloat16, memory_config=ttnn.DRAM_MEMORY_CONFIG
+        )
         x = ttnn.reshape(x, [x.shape[0], 1, x.shape[1], x.shape[2]])
 
         return x

--- a/tests/tt_eager/python_api_testing/sweep_tests/tt_lib_ops.py
+++ b/tests/tt_eager/python_api_testing/sweep_tests/tt_lib_ops.py
@@ -2923,6 +2923,7 @@ def embeddings(x, y, *args, device, dtype, layout, input_mem_config, output_mem_
     t1 = ttl.tensor.Tensor(y, dtype[1]).to(device, input_mem_config[1])
 
     t2 = ttnn.embedding(t0, t1, layout=ttnn.ROW_MAJOR_LAYOUT, memory_config=output_mem_config)
+    t2 = ttnn.reshape(t2, [t2.shape[0], 1, t2.shape[1], t2.shape[2]])
 
     tt_data = t2.cpu().to_torch()
 

--- a/tests/tt_eager/python_api_testing/unit_testing/misc/test_embedding.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/misc/test_embedding.py
@@ -35,6 +35,7 @@ def run_embeddings_tests(
 
     out_layout = ttnn.TILE_LAYOUT if tilized else ttnn.ROW_MAJOR_LAYOUT
     ttz = ttnn.embedding(input_tensor, weights_tensor, layout=out_layout, memory_config=out_mem_config)
+    ttz = ttnn.reshape(ttz, [ttz.shape[0], 1, ttz.shape[1], ttz.shape[2]])
 
     if tilized:
         tt_data = ttz.cpu().to(ttl.tensor.Layout.ROW_MAJOR).to_torch()


### PR DESCRIPTION
### Ticket
Link to Github Issue

### Problem description
`ttnn.embedding` failures in nightly fast dispatch pipeline

### What's changed
Restoring previous defaults:
- Default to DRAM_MEMORY_CONFIG if none is specified (instead of input tensor memory config)
- Always reshape to 4D tensor


### Checklist
- [x] Post commit CI passes
  - post-commit all: https://github.com/tenstorrent/tt-metal/actions/runs/10096768720
  - post-commit model: https://github.com/tenstorrent/tt-metal/actions/runs/10096783356
- [x] Model regression CI testing passes (if applicable)
  - T3000 frequent: https://github.com/tenstorrent/tt-metal/actions/runs/10096766049
  - T3000 demo: https://github.com/tenstorrent/tt-metal/actions/runs/10096771384
- [ ] New/Existing tests provide coverage for changes
