### PR TITLE
#10750: Change editable install condition to use self.inplace as that seems to be more reliable and forcefully use `pip==20.0.2`

### DIFF
--- a/.github/actions/install-python-deps/action.yml
+++ b/.github/actions/install-python-deps/action.yml
@@ -19,4 +19,5 @@ runs:
           tt_metal/python_env/requirements-dev.txt
           docs/requirements-docs.txt
           pyproject.toml
+          create_venv.sh
         install-cmd: ./create_venv.sh

--- a/create_venv.sh
+++ b/create_venv.sh
@@ -25,6 +25,9 @@ echo "Creating virtual env in: $PYTHON_ENV_DIR"
 $PYTHON_CMD -m venv $PYTHON_ENV_DIR
 source $PYTHON_ENV_DIR/bin/activate
 
+echo "Forcefully using a version of pip that will work with our view of editable installs"
+pip install --force-reinstall pip==20.0.2
+
 echo "Setting up virtual env"
 python3 -m pip config set global.extra-index-url https://download.pytorch.org/whl/cpu
 python3 -m pip install setuptools wheel

--- a/setup.py
+++ b/setup.py
@@ -166,7 +166,7 @@ class CMakeBuild(build_ext):
             self.copy_file(src, full_lib_path)
 
     def is_editable_install_(self):
-        return not os.path.exists(self.build_lib)
+        return self.inplace
 
 
 # Include tt_metal_C for kernels and src/ and tools


### PR DESCRIPTION
…

### Ticket

#10750

### Problem description

Editable install was not being properly detected in dev builds.
`pip 23` was causing us grief with editable installs.

### What's changed

`self.inplace` should be more reliable.
We forcefully install `pip==20.0.2`.

### Checklist
- [ ] Post commit CI passes
- [ ] Model regression CI testing passes (if applicable)
- [ ] New/Existing tests provide coverage for changes
