### PR TITLE
#10606: provide validation and output tensor info for high level comp…

### DIFF
--- a/tests/ttnn/unit_tests/operations/test_matmul.py
+++ b/tests/ttnn/unit_tests/operations/test_matmul.py
@@ -649,3 +649,21 @@ def test_sd_matmul(device, batch_size, channel_a, channel_b, m_size, k_size, n_s
 
     output_tensor = ttnn.to_torch(output_tensor)
     assert_with_pcc(torch_output_tensor, output_tensor, pcc=pcc)
+
+
+def test_get_expected_usage_info(device):
+    torch.manual_seed(0)
+    a = ttnn.from_torch(torch.ones([1, 1, 384, 256], dtype=torch.bfloat16), layout=ttnn.TILE_LAYOUT, device=device)
+    b = ttnn.from_torch(torch.ones([1, 1, 256, 64], dtype=torch.bfloat16), layout=ttnn.TILE_LAYOUT, device=device)
+    assert ttnn.operations.matmul.get_matmul_cbs_size_in_bytes(a, b) == 1
+    assert ttnn.operations.matmul.get_linear_cbs_size_in_bytes(a, b) == 1
+    assert ttnn.operations.matmul.get_matmul_output_tensor_size_in_bytes(a, b) == 49152
+    assert ttnn.operations.matmul.get_linear_output_tensor_size_in_bytes(a, b) == 49152
+    assert ttnn.operations.matmul.get_matmul_output_tensor_buffer_type() == ttnn.BufferType.DRAM
+    assert ttnn.operations.matmul.get_linear_output_tensor_buffer_type() == ttnn.BufferType.DRAM
+    assert ttnn.operations.matmul.get_matmul_validate_string(a, b) == ""
+    assert ttnn.operations.matmul.get_linear_validate_string(a, b) == ""
+    assert ttnn.operations.matmul.get_linear_cbs_size_in_bytes(a, a) == 0
+    assert ttnn.operations.matmul.get_matmul_output_tensor_size_in_bytes(a, a) == 0
+    assert ttnn.operations.matmul.get_matmul_output_tensor_buffer_type() == ttnn.BufferType.DRAM
+    assert ttnn.operations.matmul.get_matmul_validate_string(a, a) != ""

--- a/ttnn/cpp/ttnn/operations/matmul/device/matmul_op.hpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/matmul_op.hpp
@@ -4,6 +4,7 @@
 
 #pragma once
 #include <optional>
+#include <sstream>
 
 #include "ttnn/tensor/tensor.hpp"
 
@@ -139,7 +140,6 @@ using MatmulProgramConfig = std::variant<
     MatmulMultiCoreReuseMultiCastDRAMShardedProgramConfig
 >;
 
-
 struct Matmul {
     const std::optional<const MatmulProgramConfig> program_config = std::nullopt;
     const std::optional<bool> bcast_batch = std::nullopt;
@@ -197,6 +197,35 @@ MatmulProgramConfig create_matmul_1d_systolic_array_program_config(const ttnn::t
 
 MatmulProgramConfig create_matmul_program_config(const Tensor& input_tensor_a, const Tensor& input_tensor_b, const std::optional<const CoreCoord> user_core_coord, std::optional<UnaryWithParam> fused_activation, std::optional<const DeviceComputeKernelConfig> compute_kernel_config);
 
+const struct Matmul generate_matmul_struct(
+    const Tensor &input_tensor_a,
+    const Tensor &input_tensor_b,
+    const struct Matmul& parameters);
+
+std::string get_matmul_validate_string(
+    const Tensor &input_tensor_a,
+    const Tensor &input_tensor_b,
+    std::optional<const Tensor> optional_bias,
+    const struct Matmul& parameters);
+
+uint32_t get_matmul_cbs_size_in_bytes(
+    const Tensor &input_tensor_a,
+    const Tensor &input_tensor_b,
+    std::optional<const Tensor> optional_bias,
+    const struct Matmul& parameters);
+
+uint32_t get_matmul_output_tensor_size_in_bytes(
+    const Tensor &input_tensor_a,
+    const Tensor &input_tensor_b,
+    std::optional<const Tensor> optional_bias,
+    const struct Matmul& parameters);
+
+std::stringstream get_matmul_validate_stream(
+    const Tensor &input_tensor_a,
+    const Tensor &input_tensor_b,
+    std::optional<const Tensor> optional_bias,
+    const struct Matmul& matmul);
+
 inline Tensor matmul(
     const Tensor &input_tensor_a,
     const Tensor &input_tensor_b,
@@ -211,20 +240,13 @@ inline Tensor matmul(
         optional_input_tensors.push_back(std::nullopt);
         output_tensors = {Tensor(operation::get_workers_for_op_output({input_tensor_a, input_tensor_b}))};
     }
+    const struct Matmul& matmul = generate_matmul_struct(input_tensor_a, input_tensor_b, parameters);
 
     operation::launch_op(
-            [parameters] (const std::vector<Tensor>& input_tensors, const std::vector<std::optional<const Tensor>>& optional_input_tensors, const std::vector<std::optional<Tensor>>& optional_output_tensors) mutable -> std::vector<Tensor> {
+            [matmul] (const std::vector<Tensor>& input_tensors, const std::vector<std::optional<const Tensor>>& optional_input_tensors, const std::vector<std::optional<Tensor>>& optional_output_tensors) mutable -> std::vector<Tensor> {
         const auto& input_tensor_a = input_tensors.at(0);
         const auto& input_tensor_b = input_tensors.at(1);
-        auto arch = input_tensor_a.device()->arch();
-        const bool has_user_grid = parameters.user_core_coord.has_value();
-        const bool has_program_config = parameters.program_config.has_value();
-        const auto increase_fidelity = !has_program_config && !has_user_grid;
-        auto math_fidelity = increase_fidelity ? MathFidelity::HiFi2 : MathFidelity::LoFi;
-        auto kernel_config_val = init_device_compute_kernel_config(arch, parameters.compute_kernel_config, math_fidelity);
-        bool broadcast_batch = parameters.bcast_batch.value_or(get_broadcast_batch(input_tensor_a, input_tensor_b, parameters.program_config));
-        TT_FATAL(!(has_user_grid && has_program_config), "Cannot use both user core grid/coordinates and a program config");
-        return operation::run(Matmul{parameters.program_config, broadcast_batch, parameters.output_mem_config, parameters.output_dtype.value_or(input_tensor_a.get_dtype()), kernel_config_val, parameters.untilize_out, parameters.user_core_coord, parameters.user_fused_activation, parameters.user_run_batched}, {input_tensor_a, input_tensor_b}, optional_input_tensors);
+        return operation::run(matmul, {input_tensor_a, input_tensor_b}, optional_input_tensors);
     },
     {input_tensor_a, input_tensor_b}, output_tensors, optional_input_tensors);
     return output_tensors.at(0);

--- a/ttnn/cpp/ttnn/operations/matmul/matmul.hpp
+++ b/ttnn/cpp/ttnn/operations/matmul/matmul.hpp
@@ -43,6 +43,26 @@ ttnn::Tensor matmul(
     const std::optional<const ttnn::Tensor>& bias,
     const struct tt::operations::primary::Matmul& parameters);
 
+const std::string get_matmul_validate_string(
+    const ttnn::Tensor& input_tensor_a,
+    const ttnn::Tensor& input_tensor_b,
+    const std::optional<const ttnn::Tensor>& bias,
+    const struct tt::operations::primary::Matmul& parameters);
+
+const uint32_t get_matmul_cbs_size_in_bytes(
+    const ttnn::Tensor& input_tensor_a,
+    const ttnn::Tensor& input_tensor_b,
+    const std::optional<const ttnn::Tensor>& bias,
+    const struct tt::operations::primary::Matmul& parameters);
+
+const uint32_t get_matmul_output_tensor_size_in_bytes(
+    const ttnn::Tensor& input_tensor_a,
+    const ttnn::Tensor& input_tensor_b,
+    const std::optional<const ttnn::Tensor>& bias,
+    const struct tt::operations::primary::Matmul& parameters);
+
+const BufferType get_matmul_output_tensor_buffer_type(
+    const struct tt::operations::primary::Matmul& parameters);
 }  // namespace matmul
 }  // namespace operations
 }  // namespace ttnn

--- a/ttnn/cpp/ttnn/operations/matmul/matmul_pybind.hpp
+++ b/ttnn/cpp/ttnn/operations/matmul/matmul_pybind.hpp
@@ -206,6 +206,246 @@ void py_module(py::module& module) {
         py::arg("activation") = std::nullopt,
         py::arg("compute_kernel_config") = std::nullopt,
         py::arg("core_grid") = std::nullopt);
+
+    module.def(
+        "get_matmul_validate_string",
+        [](const ttnn::Tensor& input_tensor_a,
+           const ttnn::Tensor& input_tensor_b,
+           const bool transpose_a = false,
+           const bool transpose_b = false,
+           const ttnn::MemoryConfig& memory_config = ttnn::DRAM_MEMORY_CONFIG,
+           const std::optional<const DataType> dtype = std::nullopt,
+           const std::optional<const ttnn::MatmulProgramConfig> program_config = std::nullopt,
+           const std::optional<const std::string>& activation = std::nullopt,
+           const std::optional<const DeviceComputeKernelConfig> compute_kernel_config = std::nullopt,
+           const std::optional<const ttnn::CoreGrid> core_grid = std::nullopt) -> std::string {
+            std::optional<CoreCoord> user_core_coord;
+            if (core_grid.has_value()) {
+                user_core_coord = CoreCoord(core_grid->x, core_grid->y);
+            }
+            bool user_run_batched = ttnn::operations::matmul::detail::is_input_batched(input_tensor_b.get_shape());
+            return ttnn::operations::matmul::get_matmul_validate_string(
+                input_tensor_a,
+                input_tensor_b,
+                /*bias=*/std::nullopt,
+                Matmul{program_config, /*bcast_batch=*/std::nullopt, memory_config, dtype, compute_kernel_config, /*untilize_out=*/false, user_core_coord, get_fused_activation(activation), user_run_batched, transpose_a, transpose_b});
+        },
+        py::arg("input_tensor_a"),
+        py::arg("input_tensor_b"),
+        py::kw_only(),
+        py::arg("transpose_a") = false,
+        py::arg("transpose_b") = false,
+        py::arg("memory_config") = DRAM_MEMORY_CONFIG,
+        py::arg("dtype") = std::nullopt,
+        py::arg("program_config") = std::nullopt,
+        py::arg("activation") = std::nullopt,
+        py::arg("compute_kernel_config") = std::nullopt,
+        py::arg("core_grid") = std::nullopt);
+
+    module.def(
+        "get_linear_validate_string",
+        [](const ttnn::Tensor& input_tensor_a,
+           const ttnn::Tensor& input_tensor_b,
+           const std::optional<const ttnn::Tensor>& bias = std::nullopt,
+           const bool transpose_a = false,
+           const bool transpose_b = false,
+           const ttnn::MemoryConfig& memory_config = ttnn::DRAM_MEMORY_CONFIG,
+           const std::optional<const DataType> dtype = std::nullopt,
+           const std::optional<const ttnn::MatmulProgramConfig> program_config = std::nullopt,
+           const std::optional<const std::string>& activation = std::nullopt,
+           const std::optional<const DeviceComputeKernelConfig> compute_kernel_config = std::nullopt,
+           const std::optional<const ttnn::CoreGrid> core_grid = std::nullopt) -> std::string {
+            std::optional<CoreCoord> user_core_coord;
+            if (core_grid.has_value()) {
+                user_core_coord = CoreCoord(core_grid->x, core_grid->y);
+            }
+            bool b_is_batched = ttnn::operations::matmul::detail::is_input_batched(input_tensor_b.get_shape());
+            TT_FATAL(!(b_is_batched && bias.has_value()), "Batched input not supported when bias exists (linear operation).");
+
+            return ttnn::operations::matmul::get_matmul_validate_string(
+                input_tensor_a,
+                input_tensor_b,
+                bias,
+                tt::operations::primary::Matmul{program_config, /*bcast_batch=*/std::nullopt, memory_config, dtype, compute_kernel_config, /*untilize_out=*/false, user_core_coord, get_fused_activation(activation), /*user_run_batched=*/false, transpose_a, transpose_b});
+        },
+        py::arg("input_tensor_a"),
+        py::arg("input_tensor_b"),
+        py::kw_only(),
+        py::arg("bias") = std::nullopt,
+        py::arg("transpose_a") = false,
+        py::arg("transpose_b") = false,
+        py::arg("memory_config") = DRAM_MEMORY_CONFIG,
+        py::arg("dtype") = std::nullopt,
+        py::arg("program_config") = std::nullopt,
+        py::arg("activation") = std::nullopt,
+        py::arg("compute_kernel_config") = std::nullopt,
+        py::arg("core_grid") = std::nullopt);
+
+    module.def(
+        "get_matmul_cbs_size_in_bytes",
+        [](const ttnn::Tensor& input_tensor_a,
+           const ttnn::Tensor& input_tensor_b,
+           const bool transpose_a = false,
+           const bool transpose_b = false,
+           const ttnn::MemoryConfig& memory_config = ttnn::DRAM_MEMORY_CONFIG,
+           const std::optional<const DataType> dtype = std::nullopt,
+           const std::optional<const ttnn::MatmulProgramConfig> program_config = std::nullopt,
+           const std::optional<const std::string>& activation = std::nullopt,
+           const std::optional<const DeviceComputeKernelConfig> compute_kernel_config = std::nullopt,
+           const std::optional<const ttnn::CoreGrid> core_grid = std::nullopt) -> uint32_t {
+            std::optional<CoreCoord> user_core_coord;
+            if (core_grid.has_value()) {
+                user_core_coord = CoreCoord(core_grid->x, core_grid->y);
+            }
+            bool user_run_batched = ttnn::operations::matmul::detail::is_input_batched(input_tensor_b.get_shape());
+            return ttnn::operations::matmul::get_matmul_cbs_size_in_bytes(
+                input_tensor_a,
+                input_tensor_b,
+                /*bias=*/std::nullopt,
+                Matmul{program_config, /*bcast_batch=*/std::nullopt, memory_config, dtype, compute_kernel_config, /*untilize_out=*/false, user_core_coord, get_fused_activation(activation), user_run_batched, transpose_a, transpose_b});
+        },
+        py::arg("input_tensor_a"),
+        py::arg("input_tensor_b"),
+        py::kw_only(),
+        py::arg("transpose_a") = false,
+        py::arg("transpose_b") = false,
+        py::arg("memory_config") = DRAM_MEMORY_CONFIG,
+        py::arg("dtype") = std::nullopt,
+        py::arg("program_config") = std::nullopt,
+        py::arg("activation") = std::nullopt,
+        py::arg("compute_kernel_config") = std::nullopt,
+        py::arg("core_grid") = std::nullopt);
+
+    module.def(
+        "get_linear_cbs_size_in_bytes",
+        [](const ttnn::Tensor& input_tensor_a,
+           const ttnn::Tensor& input_tensor_b,
+           const std::optional<const ttnn::Tensor>& bias = std::nullopt,
+           const bool transpose_a = false,
+           const bool transpose_b = false,
+           const ttnn::MemoryConfig& memory_config = ttnn::DRAM_MEMORY_CONFIG,
+           const std::optional<const DataType> dtype = std::nullopt,
+           const std::optional<const ttnn::MatmulProgramConfig> program_config = std::nullopt,
+           const std::optional<const std::string>& activation = std::nullopt,
+           const std::optional<const DeviceComputeKernelConfig> compute_kernel_config = std::nullopt,
+           const std::optional<const ttnn::CoreGrid> core_grid = std::nullopt) -> uint32_t {
+            std::optional<CoreCoord> user_core_coord;
+            if (core_grid.has_value()) {
+                user_core_coord = CoreCoord(core_grid->x, core_grid->y);
+            }
+            bool b_is_batched = ttnn::operations::matmul::detail::is_input_batched(input_tensor_b.get_shape());
+            TT_FATAL(!(b_is_batched && bias.has_value()), "Batched input not supported when bias exists (linear operation).");
+
+            return ttnn::operations::matmul::get_matmul_cbs_size_in_bytes(
+                input_tensor_a,
+                input_tensor_b,
+                bias,
+                tt::operations::primary::Matmul{program_config, /*bcast_batch=*/std::nullopt, memory_config, dtype, compute_kernel_config, /*untilize_out=*/false, user_core_coord, get_fused_activation(activation), /*user_run_batched=*/false, transpose_a, transpose_b});
+        },
+        py::arg("input_tensor_a"),
+        py::arg("input_tensor_b"),
+        py::kw_only(),
+        py::arg("bias") = std::nullopt,
+        py::arg("transpose_a") = false,
+        py::arg("transpose_b") = false,
+        py::arg("memory_config") = DRAM_MEMORY_CONFIG,
+        py::arg("dtype") = std::nullopt,
+        py::arg("program_config") = std::nullopt,
+        py::arg("activation") = std::nullopt,
+        py::arg("compute_kernel_config") = std::nullopt,
+        py::arg("core_grid") = std::nullopt);
+
+    module.def(
+        "get_matmul_output_tensor_size_in_bytes",
+        [](const ttnn::Tensor& input_tensor_a,
+           const ttnn::Tensor& input_tensor_b,
+           const bool transpose_a = false,
+           const bool transpose_b = false,
+           const ttnn::MemoryConfig& memory_config = ttnn::DRAM_MEMORY_CONFIG,
+           const std::optional<const DataType> dtype = std::nullopt,
+           const std::optional<const ttnn::MatmulProgramConfig> program_config = std::nullopt,
+           const std::optional<const std::string>& activation = std::nullopt,
+           const std::optional<const DeviceComputeKernelConfig> compute_kernel_config = std::nullopt,
+           const std::optional<const ttnn::CoreGrid> core_grid = std::nullopt) -> uint32_t {
+            std::optional<CoreCoord> user_core_coord;
+            if (core_grid.has_value()) {
+                user_core_coord = CoreCoord(core_grid->x, core_grid->y);
+            }
+            bool user_run_batched = ttnn::operations::matmul::detail::is_input_batched(input_tensor_b.get_shape());
+            return ttnn::operations::matmul::get_matmul_output_tensor_size_in_bytes(
+                input_tensor_a,
+                input_tensor_b,
+                /*bias=*/std::nullopt,
+                Matmul{program_config, /*bcast_batch=*/std::nullopt, memory_config, dtype, compute_kernel_config, /*untilize_out=*/false, user_core_coord, get_fused_activation(activation), user_run_batched, transpose_a, transpose_b});
+        },
+        py::arg("input_tensor_a"),
+        py::arg("input_tensor_b"),
+        py::kw_only(),
+        py::arg("transpose_a") = false,
+        py::arg("transpose_b") = false,
+        py::arg("memory_config") = DRAM_MEMORY_CONFIG,
+        py::arg("dtype") = std::nullopt,
+        py::arg("program_config") = std::nullopt,
+        py::arg("activation") = std::nullopt,
+        py::arg("compute_kernel_config") = std::nullopt,
+        py::arg("core_grid") = std::nullopt);
+
+    module.def(
+        "get_linear_output_tensor_size_in_bytes",
+        [](const ttnn::Tensor& input_tensor_a,
+           const ttnn::Tensor& input_tensor_b,
+           const std::optional<const ttnn::Tensor>& bias = std::nullopt,
+           const bool transpose_a = false,
+           const bool transpose_b = false,
+           const ttnn::MemoryConfig& memory_config = ttnn::DRAM_MEMORY_CONFIG,
+           const std::optional<const DataType> dtype = std::nullopt,
+           const std::optional<const ttnn::MatmulProgramConfig> program_config = std::nullopt,
+           const std::optional<const std::string>& activation = std::nullopt,
+           const std::optional<const DeviceComputeKernelConfig> compute_kernel_config = std::nullopt,
+           const std::optional<const ttnn::CoreGrid> core_grid = std::nullopt) -> uint32_t {
+            std::optional<CoreCoord> user_core_coord;
+            if (core_grid.has_value()) {
+                user_core_coord = CoreCoord(core_grid->x, core_grid->y);
+            }
+            bool b_is_batched = ttnn::operations::matmul::detail::is_input_batched(input_tensor_b.get_shape());
+            TT_FATAL(!(b_is_batched && bias.has_value()), "Batched input not supported when bias exists (linear operation).");
+
+            return ttnn::operations::matmul::get_matmul_output_tensor_size_in_bytes(
+                input_tensor_a,
+                input_tensor_b,
+                bias,
+                tt::operations::primary::Matmul{program_config, /*bcast_batch=*/std::nullopt, memory_config, dtype, compute_kernel_config, /*untilize_out=*/false, user_core_coord, get_fused_activation(activation), /*user_run_batched=*/false, transpose_a, transpose_b});
+        },
+        py::arg("input_tensor_a"),
+        py::arg("input_tensor_b"),
+        py::kw_only(),
+        py::arg("bias") = std::nullopt,
+        py::arg("transpose_a") = false,
+        py::arg("transpose_b") = false,
+        py::arg("memory_config") = DRAM_MEMORY_CONFIG,
+        py::arg("dtype") = std::nullopt,
+        py::arg("program_config") = std::nullopt,
+        py::arg("activation") = std::nullopt,
+        py::arg("compute_kernel_config") = std::nullopt,
+        py::arg("core_grid") = std::nullopt);
+
+    module.def(
+        "get_matmul_output_tensor_buffer_type",
+        [](const ttnn::MemoryConfig& memory_config = ttnn::DRAM_MEMORY_CONFIG) -> BufferType {
+            return ttnn::operations::matmul::get_matmul_output_tensor_buffer_type(
+                tt::operations::primary::Matmul{/*program_config=*/std::nullopt, /*bcast_batch=*/std::nullopt, memory_config});
+        },
+        py::kw_only(),
+        py::arg("memory_config") = DRAM_MEMORY_CONFIG);
+
+    module.def(
+        "get_linear_output_tensor_buffer_type",
+        [](const ttnn::MemoryConfig& memory_config = ttnn::DRAM_MEMORY_CONFIG) -> BufferType {
+            return ttnn::operations::matmul::get_matmul_output_tensor_buffer_type(
+                tt::operations::primary::Matmul{/*program_config=*/std::nullopt, /*bcast_batch=*/std::nullopt, memory_config});
+        },
+        py::kw_only(),
+        py::arg("memory_config") = DRAM_MEMORY_CONFIG);
 }
 
 }  // namespace matmul

--- a/ttnn/cpp/ttnn/tensor/tensor.hpp
+++ b/ttnn/cpp/ttnn/tensor/tensor.hpp
@@ -400,6 +400,13 @@ static Tensor create_device_tensor(
     return create_device_tensor(shape.value(), dtype, layout, device, memory_config);
 }
 
+uint32_t get_expected_packed_size_in_bytes(
+    const Shape &shape,
+    DataType dtype,
+    Layout layout,
+    Device *device,
+    const MemoryConfig &memory_config = {.memory_layout = tt::tt_metal::TensorMemoryLayout::INTERLEAVED});
+
 // template<typename Buffer>
 // void *get_host_buffer(const Tensor &tensor);
 void *get_raw_host_data_ptr(const Tensor &tensor);

--- a/ttnn/ttnn/operations/matmul.py
+++ b/ttnn/ttnn/operations/matmul.py
@@ -238,6 +238,204 @@ def linear(
     )
 
 
+def get_matmul_validate_string(
+    input_tensor_a: ttnn.Tensor,
+    input_tensor_b: ttnn.Tensor,
+    *,
+    transpose_a: bool = False,
+    transpose_b: bool = False,
+    memory_config: ttnn.MemoryConfig = ttnn.DRAM_MEMORY_CONFIG,
+    dtype: Optional[ttnn.DataType] = None,
+    core_grid: Optional[ttnn.CoreGrid] = None,
+    program_config: Optional[MatmulProgramConfig] = None,
+) -> str:
+    """
+    Gets information about expected resource usage.
+    """
+    return ttnn._ttnn.operations.matmul.get_matmul_validate_string(
+        input_tensor_a,
+        input_tensor_b,
+        transpose_a=transpose_a,
+        transpose_b=transpose_b,
+        memory_config=memory_config,
+        dtype=dtype,
+        program_config=program_config,
+        core_grid=core_grid,
+    )
+
+
+def get_linear_validate_string(
+    input_tensor_a: ttnn.Tensor,
+    input_tensor_b: ttnn.Tensor,
+    *,
+    bias: Optional[ttnn.Tensor] = None,
+    transpose_a: bool = False,
+    transpose_b: bool = False,
+    memory_config: ttnn.MemoryConfig = ttnn.DRAM_MEMORY_CONFIG,
+    dtype: Optional[ttnn.DataType] = None,
+    core_grid: Optional[ttnn.CoreGrid] = None,
+    program_config: Optional[MatmulProgramConfig] = None,
+    activation: Optional[str] = None,
+    compute_kernel_config: Optional[ttnn.DeviceComputeKernelConfig] = None,
+) -> str:
+    """
+    Gets information about expected resource usage.
+    """
+    return ttnn._ttnn.operations.matmul.get_linear_validate_string(
+        input_tensor_a,
+        input_tensor_b,
+        bias=bias,
+        transpose_a=transpose_a,
+        transpose_b=transpose_b,
+        memory_config=memory_config,
+        dtype=dtype,
+        program_config=program_config,
+        activation=activation,
+        compute_kernel_config=compute_kernel_config,
+        core_grid=core_grid,
+    )
+
+
+def get_matmul_cbs_size_in_bytes(
+    input_tensor_a: ttnn.Tensor,
+    input_tensor_b: ttnn.Tensor,
+    *,
+    transpose_a: bool = False,
+    transpose_b: bool = False,
+    memory_config: ttnn.MemoryConfig = ttnn.DRAM_MEMORY_CONFIG,
+    dtype: Optional[ttnn.DataType] = None,
+    core_grid: Optional[ttnn.CoreGrid] = None,
+    program_config: Optional[MatmulProgramConfig] = None,
+) -> int:
+    """
+    Gets information about expected resource usage.
+    """
+    return ttnn._ttnn.operations.matmul.get_matmul_cbs_size_in_bytes(
+        input_tensor_a,
+        input_tensor_b,
+        transpose_a=transpose_a,
+        transpose_b=transpose_b,
+        memory_config=memory_config,
+        dtype=dtype,
+        program_config=program_config,
+        core_grid=core_grid,
+    )
+
+
+def get_linear_cbs_size_in_bytes(
+    input_tensor_a: ttnn.Tensor,
+    input_tensor_b: ttnn.Tensor,
+    *,
+    bias: Optional[ttnn.Tensor] = None,
+    transpose_a: bool = False,
+    transpose_b: bool = False,
+    memory_config: ttnn.MemoryConfig = ttnn.DRAM_MEMORY_CONFIG,
+    dtype: Optional[ttnn.DataType] = None,
+    core_grid: Optional[ttnn.CoreGrid] = None,
+    program_config: Optional[MatmulProgramConfig] = None,
+    activation: Optional[str] = None,
+    compute_kernel_config: Optional[ttnn.DeviceComputeKernelConfig] = None,
+) -> int:
+    """
+    Gets information about expected resource usage.
+    """
+    return ttnn._ttnn.operations.matmul.get_linear_cbs_size_in_bytes(
+        input_tensor_a,
+        input_tensor_b,
+        bias=bias,
+        transpose_a=transpose_a,
+        transpose_b=transpose_b,
+        memory_config=memory_config,
+        dtype=dtype,
+        program_config=program_config,
+        activation=activation,
+        compute_kernel_config=compute_kernel_config,
+        core_grid=core_grid,
+    )
+
+
+def get_matmul_output_tensor_size_in_bytes(
+    input_tensor_a: ttnn.Tensor,
+    input_tensor_b: ttnn.Tensor,
+    *,
+    transpose_a: bool = False,
+    transpose_b: bool = False,
+    memory_config: ttnn.MemoryConfig = ttnn.DRAM_MEMORY_CONFIG,
+    dtype: Optional[ttnn.DataType] = None,
+    core_grid: Optional[ttnn.CoreGrid] = None,
+    program_config: Optional[MatmulProgramConfig] = None,
+) -> int:
+    """
+    Gets information about expected resource usage.
+    """
+    return ttnn._ttnn.operations.matmul.get_matmul_output_tensor_size_in_bytes(
+        input_tensor_a,
+        input_tensor_b,
+        transpose_a=transpose_a,
+        transpose_b=transpose_b,
+        memory_config=memory_config,
+        dtype=dtype,
+        program_config=program_config,
+        core_grid=core_grid,
+    )
+
+
+def get_linear_output_tensor_size_in_bytes(
+    input_tensor_a: ttnn.Tensor,
+    input_tensor_b: ttnn.Tensor,
+    *,
+    bias: Optional[ttnn.Tensor] = None,
+    transpose_a: bool = False,
+    transpose_b: bool = False,
+    memory_config: ttnn.MemoryConfig = ttnn.DRAM_MEMORY_CONFIG,
+    dtype: Optional[ttnn.DataType] = None,
+    core_grid: Optional[ttnn.CoreGrid] = None,
+    program_config: Optional[MatmulProgramConfig] = None,
+    activation: Optional[str] = None,
+    compute_kernel_config: Optional[ttnn.DeviceComputeKernelConfig] = None,
+) -> int:
+    """
+    Gets information about expected resource usage.
+    """
+    return ttnn._ttnn.operations.matmul.get_linear_output_tensor_size_in_bytes(
+        input_tensor_a,
+        input_tensor_b,
+        bias=bias,
+        transpose_a=transpose_a,
+        transpose_b=transpose_b,
+        memory_config=memory_config,
+        dtype=dtype,
+        program_config=program_config,
+        activation=activation,
+        compute_kernel_config=compute_kernel_config,
+        core_grid=core_grid,
+    )
+
+
+def get_matmul_output_tensor_buffer_type(
+    *,
+    memory_config: ttnn.MemoryConfig = ttnn.DRAM_MEMORY_CONFIG,
+) -> ttnn.BufferType:
+    """
+    Gets information about expected resource usage.
+    """
+    return ttnn._ttnn.operations.matmul.get_matmul_output_tensor_buffer_type(
+        memory_config=memory_config,
+    )
+
+
+def get_linear_output_tensor_buffer_type(
+    *,
+    memory_config: ttnn.MemoryConfig = ttnn.DRAM_MEMORY_CONFIG,
+) -> ttnn.BufferType:
+    """
+    Gets information about expected resource usage.
+    """
+    return ttnn._ttnn.operations.matmul.get_linear_output_tensor_buffer_type(
+        memory_config=memory_config,
+    )
+
+
 ttnn.Tensor.__matmul__ = lambda self, *args, **kwargs: matmul(self, *args, **kwargs)
 
 


### PR DESCRIPTION
…ilers

### Ticket
Link to Github Issue https://github.com/tenstorrent/tt-metal/issues/10606

### Problem description
- High level compilers will need information about what the op does before the op executes.

### What's changed
- Provide information related to matmul
- Validate string - if emtpy, validation passed, if not, then the error message
- Output tensor size in bytes
- Output tensor buffer type
- Placeholder for circular buffer size in bytes - specific code will be added later (will be non-trivial, and this PR is already more than large enough)
- Assert functionality updated to be able to retrieve the error stream
- Tensor functionality updated to be able to get output tensor size in bytes

Note 1:
- does not factor in information from potential add and activation calls after matmul

Note 2:
Something that will need to be done in a subsequent PR, is to incorporate potential calls to ttnn.add and the activation functions.
If all three would be called, the code would look like:
output_tensor=matmul(...)
output_tensor=ttnn.add(output_tensor,...)
output_tensor=tttn.gelu(output_tensor,...)

However, depending on what is done, the signatures of the methods might change.

For CBs, I would want to take the max for all three functions.
For output tensors, I would just multiply the size by e.g. 2 or 3. The create tensor methods use uint32_t. Maybe that should be changed to size_t.
Alternatively, it may be possible to return a vector of information. Then you'd need to worry about how to define that the memory is all used at the same time vs de-allocated after each usage.

### Checklist
- [ ] Post commit CI passes
- [ ] Model regression CI testing passes (if applicable)
- [ ] New/Existing tests provide coverage for changes
