### PR TITLE
#10643: Remove normalize_hw from tt_eager bindings

### DIFF
--- a/docs/source/ttnn/ttnn/dependencies/tt_lib.rst
+++ b/docs/source/ttnn/ttnn/dependencies/tt_lib.rst
@@ -584,8 +584,6 @@ Other Operations
 
 .. autofunction:: tt_lib.tensor.std_hw
 
-.. autofunction:: tt_lib.tensor.normalize_hw
-
 .. autofunction:: tt_lib.tensor.normalize_global
 
 .. autofunction:: tt_lib.tensor.lamb_optimizer

--- a/tests/ttnn/profiling/ops_for_profiling.py
+++ b/tests/ttnn/profiling/ops_for_profiling.py
@@ -2193,8 +2193,8 @@ all_unary_ops = [
         "name": "tt_lib.tensor.std_hw",
     },
     {
-        "op": tt_lib.tensor.normalize_hw,
-        "name": "tt_lib.tensor.normalize_hw",
+        "op": ttnn.normalize_hw,
+        "name": "ttnn.normalize_hw",
     },
     {
         "op": tt_lib.tensor.normalize_global,

--- a/ttnn/cpp/ttnn/deprecated/tt_dnn/op_library/composite/composite_ops.hpp
+++ b/ttnn/cpp/ttnn/deprecated/tt_dnn/op_library/composite/composite_ops.hpp
@@ -476,9 +476,6 @@ Tensor var_hw(const Tensor& y, const MemoryConfig& output_mem_config = operation
 Tensor std_hw(const Tensor& y, const MemoryConfig& output_mem_config = operation::DEFAULT_OUTPUT_MEMORY_CONFIG);
 // Tensor std(const Tensor& y,const Tensor& mean_y);
 
-// Function normalize
-// use transformation y = (y - mean(y))/std(y) by broadcast
-Tensor normalize_hw(const Tensor& y, const MemoryConfig& output_mem_config = operation::DEFAULT_OUTPUT_MEMORY_CONFIG);
 Tensor normalize_global(
     const Tensor& y, const MemoryConfig& output_mem_config = operation::DEFAULT_OUTPUT_MEMORY_CONFIG);
 

--- a/ttnn/cpp/ttnn/deprecated/tt_lib/csrc/tt_lib_bindings_tensor_composite_ops.cpp
+++ b/ttnn/cpp/ttnn/deprecated/tt_lib/csrc/tt_lib_bindings_tensor_composite_ops.cpp
@@ -256,7 +256,6 @@ void TensorModuleCompositeOPs(py::module& m_tensor) {
                 "queue_id", "queue_id", "uint8_t", "Default is 0", "No"
         )doc");
         // *** composite unary ops ***
-        detail::bind_unary_op(m_tensor, "normalize_hw", tt::tt_metal::normalize_hw, R"doc(Returns a new tensor with the Gaussian normalize of the elements of the input tensor ``{0}`` on H,W axes.)doc");
         detail::bind_unary_op(m_tensor, "normalize_global", tt::tt_metal::normalize_global, R"doc(Returns a new tensor with the Gaussian normalize of the elements of the input tensor ``{0}`` on N,C,H,W axes.)doc");
         detail::bind_unary_op(m_tensor, "var_hw", tt::tt_metal::var_hw, R"doc(  Returns a new tensor with the variance of the input tensor ``{0}`` on H,W axes.)doc");
         detail::bind_unary_op(m_tensor, "std_hw", tt::tt_metal::std_hw, R"doc(Returns a new tensor with the standard deviation of the input tensor ``{0}`` on H,W axes.)doc");


### PR DESCRIPTION
Issue : #10643

Test :

- [x] [All post commit test](https://github.com/tenstorrent/tt-metal/actions/runs/10111351583)
- [x] [[post-commit] models tests](https://github.com/tenstorrent/tt-metal/actions/runs/10109595916)
- [ ] [Device perf regressions and output report](https://github.com/tenstorrent/tt-metal/actions/runs/10111237449)
- [ ] [Model perf regressions and output report](https://github.com/tenstorrent/tt-metal/actions/runs/10109599474)
- [ ] [Nightly fast dispatch model regression CI](https://github.com/tenstorrent/tt-metal/actions/runs/10109601447) - Failed as in main
- [x] [T3000 frequent tests](https://github.com/tenstorrent/tt-metal/actions/runs/10109602821)
- [x] [T3000 demo tests](https://github.com/tenstorrent/tt-metal/actions/runs/10109603874)
- [x] [T3000 unit tests](https://github.com/tenstorrent/tt-metal/actions/runs/10109605594)