### PR TITLE
#10783: Use kernel path in computing kernel hash rather than kernel file name

### DIFF
--- a/tt_metal/impl/kernels/kernel.cpp
+++ b/tt_metal/impl/kernels/kernel.cpp
@@ -161,7 +161,7 @@ std::string ComputeKernel::config_hash() const {
 std::string Kernel::compute_hash() const {
     return fmt::format(
         "{}_{}_{}_{}",
-        std::hash<std::string>{}(this->name()),
+        std::hash<std::string>{}(this->kernel_path_file_name_),
         fmt::join(this->compile_time_args_, "_"),
         KernelDefinesHash{}(this->defines_),
         this->config_hash());


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/10783

### Problem description
Can have multiple kernels with the same file name, defines and compile time args and they would resolve to same kernel hash

### What's changed
Use full kernel path in hash

### Checklist
- [x] [Post commit CI passes](https://github.com/tenstorrent/tt-metal/actions/runs/10115173270)
- [x] [Model regression CI testing passes](https://github.com/tenstorrent/tt-metal/actions/runs/10115178125)