### PR TITLE
#10049: Make BH dram bank size the full addressable dram size

### DIFF
--- a/tt_metal/soc_descriptors/blackhole_140_arch.yaml
+++ b/tt_metal/soc_descriptors/blackhole_140_arch.yaml
@@ -65,8 +65,7 @@ worker_l1_size:
   1499136
 
 dram_bank_size:
-  # 4278190080 TODO (abhullar): upper 2GB of DRAM is untested on some BH machines. Test this limitation
-  2147483648
+  4278190080
 
 eth_l1_size:
   262144


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/10049

### Problem description
Some BH machines initially didn't test upper 2GB of DRAM so dram bank size was cut off to 2GB 

### What's changed
This has been addressed and now we can set dram bank size to be full addressable dram range
