### PR TITLE
#10815: Update the composite ops with ttnn support

### DIFF
--- a/docs/source/ttnn/ttnn/dependencies/tt_lib.rst
+++ b/docs/source/ttnn/ttnn/dependencies/tt_lib.rst
@@ -274,23 +274,7 @@ Tensor elementwise operations
 
 .. autofunction:: tt_lib.tensor.mac
 
-.. autofunction:: tt_lib.tensor.softshrink
-
-.. autofunction:: tt_lib.tensor.hardshrink
-
-.. autofunction:: tt_lib.tensor.logical_xori
-
-.. autofunction:: tt_lib.tensor.celu
-
-.. autofunction:: tt_lib.tensor.logit
-
-.. autofunction:: tt_lib.tensor.logical_andi
-
 .. autofunction:: tt_lib.tensor.assign
-
-.. autofunction:: tt_lib.tensor.logical_ori
-
-.. autofunction:: tt_lib.tensor.frac
 
 .. autofunction:: tt_lib.tensor.rfloor_div
 
@@ -348,8 +332,6 @@ Broadcast and Reduce
 .. autofunction:: tt_lib.tensor.global_sum
 
 .. autofunction:: tt_lib.tensor.global_mean
-
-.. autofunction:: tt_lib.tensor.rpow
 
 
 Fallback Operations
@@ -506,10 +488,6 @@ Other Operations
 .. autofunction:: tt_lib.tensor.convert_conv_weight_tensor_to_tiled_layout
 
 .. autofunction:: tt_lib.tensor.mean_hw
-
-.. autofunction:: tt_lib.tensor.logical_noti
-
-.. autofunction:: tt_lib.tensor.normalize_global
 
 .. autofunction:: tt_lib.tensor.lamb_optimizer
 

--- a/tests/tt_eager/python_api_testing/sweep_tests/op_map.py
+++ b/tests/tt_eager/python_api_testing/sweep_tests/op_map.py
@@ -140,10 +140,6 @@ op_map = {
         "tt_op": tt_lib_ops.eltwise_i0,
         "pytorch_op": pytorch_ops.i0,
     },
-    "eltwise-logical_noti": {
-        "tt_op": tt_lib_ops.eltwise_logical_noti,
-        "pytorch_op": pytorch_ops.logical_noti,
-    },
     "eltwise-bitwise_complement": {
         "tt_op": None,  # tt_lib_ops.eltwise_bitwise_complement,
         "pytorch_op": None,  # pytorch_ops.bitwise_complement,
@@ -296,10 +292,6 @@ op_map = {
         "tt_op": tt_lib_ops.eltwise_logical_and,
         "pytorch_op": pytorch_ops.logical_and,
     },
-    "eltwise-logical_andi": {
-        "tt_op": tt_lib_ops.eltwise_logical_andi,
-        "pytorch_op": pytorch_ops.logical_andi,
-    },
     "eltwise-leaky_relu": {
         "tt_op": tt_lib_ops.eltwise_leaky_relu,
         "pytorch_op": pytorch_ops.leaky_relu,
@@ -407,10 +399,6 @@ op_map = {
     "lamb-optimizer": {
         "tt_op": tt_lib_ops.lamb_optimizer,
         "pytorch_op": pytorch_ops.lamb_optimizer,
-    },
-    "eltwise-logical_xori": {
-        "tt_op": tt_lib_ops.eltwise_logical_xori,
-        "pytorch_op": pytorch_ops.logical_xori,
     },
     "eltwise-log": {
         "tt_op": tt_lib_ops.eltwise_log,
@@ -596,10 +584,6 @@ op_map = {
     "eltwise-logical_or": {
         "tt_op": tt_lib_ops.eltwise_logical_or,
         "pytorch_op": pytorch_ops.logical_or,
-    },
-    "eltwise-logical_ori": {
-        "tt_op": tt_lib_ops.eltwise_logical_ori,
-        "pytorch_op": pytorch_ops.logical_ori,
     },
     # Eltwise binary with optional output
     "eltwise-ne-optional": {

--- a/tests/tt_eager/python_api_testing/sweep_tests/pytests/tt_dnn/test_composite.py
+++ b/tests/tt_eager/python_api_testing/sweep_tests/pytests/tt_dnn/test_composite.py
@@ -31,12 +31,8 @@ def custom_compare(*args, **kwargs):
     function = kwargs.pop("function")
     if function in [
         "logical_xor",
-        "logical_ori",
         "logical_or",
-        "logical_xori",
-        "logical_noti",
         "logical_not",
-        "logical_andi",
         "is_close",
     ]:
         comparison_func = comparison_funcs.comp_equal
@@ -97,11 +93,7 @@ if is_wormhole_b0():
                 # "bias_gelu_unary",
                 "addalpha",
                 "logit",
-                # "logical_ori",
                 "logical_xor",
-                # "logical_xori",
-                # "logical_noti",
-                # "logical_andi",
                 "isclose",
                 "digamma",
                 "lgamma",
@@ -145,9 +137,6 @@ def test_run_eltwise_composite_test(fn, input_shapes, device, function_level_def
     options["asinh"] = (-100, 100)
     options["isclose"] = (-100, 100)
     options["acosh"] = (1, 100)
-    options["logical_ori"] = (-100, 100)
-    options["logical_andi"] = (-100, 100)
-    options["logical_xori"] = (-100, 100)
 
     generator = generation_funcs.gen_rand
 
@@ -157,7 +146,9 @@ def test_run_eltwise_composite_test(fn, input_shapes, device, function_level_def
     if is_grayskull():
         if fn in ["mish"]:
             pytest.skip("does not work for Grayskull -skipping")
-    if fn in ["logical_xor", "logical_xori", "logical_ori", "logical_andi"]:
+    if fn in [
+        "logical_xor",
+    ]:
         datagen_func = [
             generation_funcs.gen_func_with_cast(
                 partial(generator, low=options[fn][0], high=options[fn][1]),
@@ -191,7 +182,6 @@ def test_run_eltwise_composite_test(fn, input_shapes, device, function_level_def
         "isclose",
         "assign_binary",
         "nextafter",
-        # "scatter",
     ]:
         num_inputs = 2
 
@@ -221,8 +211,6 @@ def test_run_eltwise_composite_test(fn, input_shapes, device, function_level_def
         test_args.update({"eps": np.random.randint(-10, 0.99)})
     elif fn in ["polygamma"]:
         test_args.update({"k": np.random.randint(1, 10)})
-    elif fn in ["logical_ori", "logical_andi", "logical_xori", "logical_noti"]:
-        test_args.update({"immediate": np.random.randint(0, 100)})
     elif fn in ["isclose"]:
         test_args.update(
             {

--- a/tests/tt_eager/python_api_testing/sweep_tests/pytorch_ops.py
+++ b/tests/tt_eager/python_api_testing/sweep_tests/pytorch_ops.py
@@ -502,9 +502,8 @@ def polygamma(x, *args, k, **kwargs):
     return torch.special.polygamma(n=k, input=x)
 
 
-def logical_xori(x, *args, **kwargs):
-    value = kwargs.pop("immediate")
-    result = torch.logical_xor(x, torch.tensor(value, dtype=torch.int32))
+def logical_xor_(x, y, *args, **kwargs):
+    result = x.logical_xor_(y)
     return result
 
 
@@ -744,9 +743,8 @@ def multigammaln(x, *args, **kwargs):
     return torch.special.multigammaln(x, 4)
 
 
-def logical_andi(x, *args, **kwargs):
-    value = kwargs.pop("immediate")
-    result = torch.logical_and(x, torch.tensor(value, dtype=torch.int32))
+def logical_and_(x, y, *args, **kwargs):
+    result = x.logical_and_(y)
     return result
 
 
@@ -960,9 +958,8 @@ def logical_and(x, y, *args, **kwargs):
     return result
 
 
-def logical_noti(x, *args, **kwargs):
-    immediate = kwargs.pop("immediate")
-    result = torch.logical_not(torch.full_like(x, immediate)).to(torch.int32)
+def logical_not_(x, *args, **kwargs):
+    result = x.logical_not_()
     return result
 
 
@@ -1162,9 +1159,8 @@ def logical_or(x, y, *args, **kwargs):
     return torch.logical_or(x, y)
 
 
-def logical_ori(x, *args, **kwargs):
-    value = kwargs.pop("immediate")
-    result = torch.logical_or(x, torch.tensor(value, dtype=torch.int32))
+def logical_or_(x, y, *args, **kwargs):
+    result = x.logical_or_(y)
     return result
 
 

--- a/tests/tt_eager/python_api_testing/sweep_tests/tt_lib_ops.py
+++ b/tests/tt_eager/python_api_testing/sweep_tests/tt_lib_ops.py
@@ -254,24 +254,6 @@ def eltwise_leaky_relu(
 
 
 @setup_host_and_device
-def eltwise_logical_noti(
-    x,
-    *args,
-    immediate,
-    device,
-    dtype,
-    layout,
-    input_mem_config,
-    output_mem_config,
-    **kwargs,
-):
-    t0 = setup_tt_tensor(x, device, layout[0], input_mem_config[0], dtype[0])
-    t1 = ttl.tensor.logical_noti(t0, immediate, output_mem_config=output_mem_config)
-
-    return tt2torch_tensor(t1)
-
-
-@setup_host_and_device
 def eltwise_elu(
     x,
     *args,
@@ -644,7 +626,7 @@ def eltwise_celu(
     **kwargs,
 ):
     t0 = setup_tt_tensor(x, device, layout[0], input_mem_config[0], dtype[0])
-    t2 = ttl.tensor.celu(t0, alpha, output_mem_config=output_mem_config)
+    t2 = ttnn.celu(t0, alpha=alpha, memory_config=output_mem_config)
 
     return tt2torch_tensor(t2)
 
@@ -652,7 +634,7 @@ def eltwise_celu(
 @setup_host_and_device
 def eltwise_logit(x, *args, eps, device, dtype, layout, input_mem_config, output_mem_config, **kwargs):
     t0 = setup_tt_tensor(x, device, layout[0], input_mem_config[0], dtype[0])
-    t1 = ttl.tensor.logit(t0, eps, output_mem_config=output_mem_config)
+    t1 = ttnn.logit(t0, eps=eps, memory_config=output_mem_config)
 
     return tt2torch_tensor(t1)
 
@@ -661,24 +643,6 @@ def eltwise_logit(x, *args, eps, device, dtype, layout, input_mem_config, output
 def eltwise_polygamma(x, *args, k, device, dtype, layout, input_mem_config, output_mem_config, **kwargs):
     t0 = setup_tt_tensor(x, device, layout[0], input_mem_config[0], dtype[0])
     t1 = ttnn.polygamma(t0, k=k, memory_config=output_mem_config)
-
-    return tt2torch_tensor(t1)
-
-
-@setup_host_and_device
-def eltwise_logical_xori(
-    x,
-    *args,
-    immediate,
-    device,
-    dtype,
-    layout,
-    input_mem_config,
-    output_mem_config,
-    **kwargs,
-):
-    t0 = setup_tt_tensor(x, device, layout[0], input_mem_config[0], dtype[0])
-    t1 = ttl.tensor.logical_xori(t0, immediate, output_mem_config=output_mem_config)
 
     return tt2torch_tensor(t1)
 
@@ -1284,42 +1248,6 @@ def prod(
         return output_tensor[:1, :1, :1, :1]
     else:
         return output_tensor
-
-
-@setup_host_and_device
-def eltwise_logical_andi(
-    x,
-    *args,
-    immediate,
-    device,
-    dtype,
-    layout,
-    input_mem_config,
-    output_mem_config,
-    **kwargs,
-):
-    t0 = setup_tt_tensor(x, device, layout[0], input_mem_config[0], dtype[0])
-    t1 = ttl.tensor.logical_andi(t0, immediate, output_mem_config=output_mem_config)
-
-    return tt2torch_tensor(t1)
-
-
-@setup_host_and_device
-def eltwise_logical_ori(
-    x,
-    *args,
-    immediate,
-    device,
-    dtype,
-    layout,
-    input_mem_config,
-    output_mem_config,
-    **kwargs,
-):
-    t0 = setup_tt_tensor(x, device, layout[0], input_mem_config[0], dtype[0])
-    t1 = ttl.tensor.logical_ori(t0, immediate, output_mem_config=output_mem_config)
-
-    return tt2torch_tensor(t1)
 
 
 @setup_host_and_device
@@ -2019,7 +1947,7 @@ def eltwise_rpow(
 ):
     factor = kwargs["factor"]
     t0 = setup_tt_tensor(x, device, layout[0], input_mem_config[0], dtype[0])
-    t1 = ttl.tensor.rpow(t0, factor, output_mem_config=output_mem_config)
+    t1 = ttnn.rpow(t0, factor, memory_config=output_mem_config)
 
     return tt2torch_tensor(t1)
 
@@ -2258,7 +2186,7 @@ eltwise_assign_unary = make_unary_op(ttl.tensor.assign)
 eltwise_floor = make_unary_op_optional_output(ttnn.floor)
 eltwise_ceil = make_unary_op_optional_output(ttnn.ceil)
 eltwise_trunc = make_ttnn_unary_op(ttnn.trunc)
-eltwise_frac = make_unary_op(ttl.tensor.frac)
+eltwise_frac = make_ttnn_unary_op(ttnn.frac)
 
 
 def make_binary_op(ttl_tensor_binop):

--- a/tests/ttnn/profiling/ops_for_profiling.py
+++ b/tests/ttnn/profiling/ops_for_profiling.py
@@ -148,6 +148,18 @@ def embeddings_shape_func(input_shape):
     return input_shape_0, input_shape_1
 
 
+def logical_and_(x, y):
+    ttnn.logical_and_(x, y)
+
+
+def logical_or_(x, y):
+    ttnn.logical_or_(x, y)
+
+
+def logical_xor_(x, y):
+    ttnn.logical_xor_(x, y)
+
+
 def unary_add_bw(x, y):
     ttnn.add_bw(x, y, 3)
 
@@ -659,6 +671,18 @@ all_binary_ops = [
     {
         "op": lerp_binary,
         "name": "ttnn.lerp_binary",
+    },
+    {
+        "op": logical_and_,
+        "name": "ttnn.logical_and_",
+    },
+    {
+        "op": logical_or_,
+        "name": "ttnn.logical_or_",
+    },
+    {
+        "op": logical_xor_,
+        "name": "ttnn.logical_xor_",
     },
     {
         "op": ttnn.xlogy,
@@ -1205,24 +1229,12 @@ def heaviside(x):
     ttnn.heaviside(x, 0.5)
 
 
-def logical_xori(x):
-    tt_lib.tensor.logical_xori(x, 2)
-
-
 def bias_gelu_unary(x):
     tt_lib.tensor.bias_gelu_unary(x, 2)
 
 
 def logit(x):
     ttnn.logit(x, eps=0.0001)
-
-
-def logical_andi(x):
-    tt_lib.tensor.logical_andi(x, 2)
-
-
-def logical_ori(x):
-    tt_lib.tensor.logical_ori(x, 2)
 
 
 def polygamma(x):
@@ -1366,7 +1378,7 @@ def max_dim_23(x):
 
 
 def rpow(x):
-    tt_lib.tensor.rpow(x, 3)
+    ttnn.rpow(x, 3)
 
 
 def rsub(x):
@@ -1467,8 +1479,8 @@ def convert_conv_weight_tensor_to_tiled_layout(x):
     tt_lib.tensor.convert_conv_weight_tensor_to_tiled_layout(x, in1_block_h=32, in1_block_w=32)
 
 
-def logical_noti(x):
-    tt_lib.tensor.logical_noti(x, 2)
+def logical_not_(x):
+    ttnn.logical_not_(x)
 
 
 def glu_1(x):
@@ -1840,10 +1852,6 @@ all_unary_ops = [
         "name": "ttnn.atanh",
     },
     {
-        "op": logical_xori,
-        "name": "tt_lib.tensor.logical_xori",
-    },
-    {
         "op": ttnn.logical_not,
         "name": "ttnn.logical_not",
     },
@@ -1881,10 +1889,6 @@ all_unary_ops = [
         "num_repeats": 3,
     },
     {
-        "op": logical_andi,
-        "name": "tt_lib.tensor.logical_andi",
-    },
-    {
         "op": ttnn.erfinv,
         "name": "ttnn.erfinv",
     },
@@ -1907,10 +1911,6 @@ all_unary_ops = [
     {
         "op": ttnn.tan,
         "name": "ttnn.tan",
-    },
-    {
-        "op": logical_ori,
-        "name": "tt_lib.tensor.logical_ori",
     },
     {
         "op": polygamma,
@@ -2099,7 +2099,7 @@ all_unary_ops = [
     },
     {
         "op": rpow,
-        "name": "tt_lib.tensor.rpow",
+        "name": "ttnn.rpow",
     },
     {
         "op": rsub,
@@ -2199,8 +2199,8 @@ all_unary_ops = [
         "name": "ttnn.var_hw",
     },
     {
-        "op": logical_noti,
-        "name": "tt_lib.tensor.logical_noti",
+        "op": logical_not_,
+        "name": "ttnn.logical_not_",
     },
     {
         "op": ttnn.std_hw,
@@ -2211,8 +2211,8 @@ all_unary_ops = [
         "name": "ttnn.normalize_hw",
     },
     {
-        "op": tt_lib.tensor.normalize_global,
-        "name": "tt_lib.tensor.normalize_global",
+        "op": normalize_global,
+        "name": "ttnn.normalize_global",
     },
     {
         "op": glu_1,

--- a/tests/ttnn/python_api_testing/sweep_tests/ttnn_ops.py
+++ b/tests/ttnn/python_api_testing/sweep_tests/ttnn_ops.py
@@ -520,7 +520,7 @@ def eltwise_celu(
     **kwargs,
 ):
     t0 = setup_ttnn_tensor(x, device, layout[0], input_mem_config[0], dtype[0])
-    t1 = ttnn.celu(t0, alpha, memory_config=memory_config_to_ttnn(output_mem_config))
+    t1 = ttnn.celu(t0, alpha=alpha, memory_config=memory_config_to_ttnn(output_mem_config))
 
     return ttnn_tensor_to_torch(t1)
 
@@ -537,7 +537,7 @@ def eltwise_logit(
     **kwargs,
 ):
     t0 = setup_ttnn_tensor(x, device, layout[0], input_mem_config[0], dtype[0])
-    t1 = ttnn.logit(t0, eps=0, memory_config=memory_config_to_ttnn(output_mem_config))
+    t1 = ttnn.logit(t0, eps=eps, memory_config=memory_config_to_ttnn(output_mem_config))
 
     return ttnn_tensor_to_torch(t1)
 

--- a/tests/ttnn/sweep_tests/sweeps/sweeps/hardshrink.py
+++ b/tests/ttnn/sweep_tests/sweeps/sweeps/hardshrink.py
@@ -49,7 +49,7 @@ def run(
         torch_input_tensor, dtype=input_dtype, device=device, layout=layout, memory_config=input_memory_config
     )
 
-    output_tensor = ttnn.hardshrink(input_tensor, lambd, memory_config=output_memory_config)
+    output_tensor = ttnn.hardshrink(input_tensor, lambd=lambd, memory_config=output_memory_config)
     output_tensor = ttnn.to_torch(output_tensor)
 
     return check_with_pcc(torch_output_tensor, output_tensor, 0.999)

--- a/tests/ttnn/sweep_tests/sweeps/sweeps/logit.py
+++ b/tests/ttnn/sweep_tests/sweeps/sweeps/logit.py
@@ -48,7 +48,7 @@ def run(
         torch_input_tensor, dtype=input_dtype, device=device, layout=layout, memory_config=input_memory_config
     )
 
-    output_tensor = ttnn.logit(input_tensor, scalar, memory_config=output_memory_config)
+    output_tensor = ttnn.logit(input_tensor, eps=scalar, memory_config=output_memory_config)
     output_tensor = ttnn.to_torch(output_tensor)
 
     return check_with_pcc(torch_output_tensor, output_tensor, 0.999)

--- a/tests/ttnn/sweep_tests/sweeps/sweeps/softshrink.py
+++ b/tests/ttnn/sweep_tests/sweeps/sweeps/softshrink.py
@@ -49,7 +49,7 @@ def run(
         torch_input_tensor, dtype=input_dtype, device=device, layout=layout, memory_config=input_memory_config
     )
 
-    output_tensor = ttnn.softshrink(input_tensor, lambd, memory_config=output_memory_config)
+    output_tensor = ttnn.softshrink(input_tensor, lambd=lambd, memory_config=output_memory_config)
     output_tensor = ttnn.to_torch(output_tensor)
 
     return check_with_pcc(torch_output_tensor, output_tensor, 0.999)

--- a/ttnn/cpp/ttnn/deprecated/tt_dnn/op_library/composite/composite_ops.cpp
+++ b/ttnn/cpp/ttnn/deprecated/tt_dnn/op_library/composite/composite_ops.cpp
@@ -68,51 +68,6 @@ Tensor mk_filled_tensor_like(
     }
 }
 
-// Function: softshrink
-// Ref: https://pytorch.org/docs/stable/generated/torch.nn.Softshrink.html
-Tensor _softshrink(const Tensor& a, float param, const MemoryConfig& output_mem_config) {
-    TT_ASSERT(param >= 0);
-    Tensor t_a_plus_param = ttnn::add(a, param, std::nullopt, output_mem_config);
-    Tensor t1 = ttnn::multiply(ttnn::ltz(t_a_plus_param, output_mem_config), t_a_plus_param, std::nullopt, output_mem_config);
-    t_a_plus_param.deallocate();
-    Tensor t_a_minus_param = ttnn::subtract(a, param, std::nullopt, output_mem_config);
-    Tensor t2 =
-        ttnn::multiply(ttnn::gtz(t_a_minus_param, output_mem_config), t_a_minus_param, std::nullopt, output_mem_config);
-    t_a_minus_param.deallocate();
-    return ttnn::add(t1, t2, std::nullopt, output_mem_config);
-}
-Tensor softshrink(const Tensor& a, float param, const MemoryConfig& output_mem_config) {
-    return operation::decorate_as_composite(__func__, _softshrink)(a, param, output_mem_config);
-}
-
-// Function: hardshrink
-// Ref: https://pytorch.org/docs/stable/generated/torch.nn.Hardshrink.html
-Tensor _hardshrink(const Tensor& a, float param, const MemoryConfig& output_mem_config) {
-    TT_ASSERT(param >= 0);
-    Tensor t1 = ttnn::multiply(ttnn::ltz(ttnn::add(a, param)), a, std::nullopt, output_mem_config);
-    Tensor t2 = ttnn::multiply(ttnn::gtz(ttnn::subtract(a, param)), a, std::nullopt, output_mem_config);
-    return ttnn::add(t1, t2, std::nullopt, output_mem_config);
-}
-Tensor hardshrink(const Tensor& a, float param, const MemoryConfig& output_mem_config) {
-    return operation::decorate_as_composite(__func__, _hardshrink)(a, param, output_mem_config);
-}
-
-
-// ELU :
-//  Theano defines it as,
-//  return tensor.switch(x > 0, x, alpha * tensor.expm1(x))
-
-// rpow: y = k**(a) = exp( a**log(k) )
-Tensor rpow(const Tensor& a, float k, const MemoryConfig& output_mem_config) {
-    TT_ASSERT(k > 0.0, "rpow cannot be calcualted for non-positive numbers");
-    float log_k = logf(k);
-
-    Tensor scalar = ttnn::operations::creation::create_scalar(log_k, a.get_dtype(), Layout::TILE, a.device());
-    Tensor result = ttnn::multiply(a, scalar, std::nullopt, output_mem_config);
-    scalar.deallocate();
-    return ttnn::exp(result, false, output_mem_config);
-}
-
 // compute polyval by Horner's rule
 Tensor _polyval(const Tensor& input_tensor, std::vector<float> coeffs, const MemoryConfig& output_mem_config) {
     TT_ASSERT(coeffs.size() != 0 && "coeffs should be 1 or more coefficients");
@@ -197,18 +152,6 @@ Tensor mac(const Tensor& input_a, float b, float c, const MemoryConfig& output_m
     return operation::decorate_as_composite(__func__, _mac_overload)(input_a, b, c, output_mem_config);
 }
 
-Tensor _logical_andi(const Tensor& input_a, float immediate, const MemoryConfig& output_mem_config) {
-    if (std::fpclassify(immediate) == FP_ZERO) {
-        return full_like(input_a, immediate, output_mem_config);
-    } else {
-        return ttnn::nez(input_a);
-    }
-}
-Tensor logical_andi(const Tensor& input_a, float immediate, const MemoryConfig& output_mem_config) {
-    return operation::decorate_as_composite(__func__, _logical_andi)(input_a, immediate, output_mem_config);
-}
-
-
 // lerp(input, end, weight) = start + weight * (end - start)
 Tensor _lerp(const Tensor& input_a, const Tensor& input_b, float value, const MemoryConfig& output_mem_config) {
     Tensor t_value =
@@ -241,37 +184,6 @@ Tensor _ldexp(const Tensor& input_a, const Tensor& input_b, const MemoryConfig& 
     return result;
 }
 
-Tensor _logical_ori(const Tensor& input_a, float immediate, const MemoryConfig& output_mem_config) {
-    if (std::fpclassify(immediate) == FP_ZERO) {
-        return ttnn::nez(input_a, output_mem_config);
-    } else {
-        return full_like(input_a, 1, output_mem_config);
-    }
-}
-Tensor logical_ori(const Tensor& input_a, float immediate, const MemoryConfig& output_mem_config) {
-    return operation::decorate_as_composite(__func__, _logical_ori)(input_a, immediate, output_mem_config);
-}
-
-Tensor _logical_noti(const Tensor& input_a, float immediate, const MemoryConfig& output_mem_config) {
-    Tensor t_imm = full_like(input_a, immediate, output_mem_config);
-    Tensor result = ttnn::logical_not(t_imm, output_mem_config);
-    return result;
-}
-Tensor logical_noti(const Tensor& input_a, float immediate, const MemoryConfig& output_mem_config) {
-    return operation::decorate_as_composite(__func__, _logical_noti)(input_a, immediate, output_mem_config);
-}
-
-Tensor _frac(const Tensor& input, const MemoryConfig& output_mem_config) {
-    auto arch = input.device()->arch();
-    TT_FATAL(arch == tt::ARCH::WORMHOLE_B0, "Op is only supported on Wormhole");
-    Tensor trunc_res = ttnn::trunc(input, output_mem_config);
-    Tensor result = ttnn::subtract(input, trunc_res, std::nullopt, output_mem_config);
-    return result;
-}
-Tensor frac(const Tensor& input, const MemoryConfig& output_mem_config) {
-    return operation::decorate_as_composite(__func__, _frac)(input, output_mem_config);
-}
-
 Tensor _unary_rdiv_trunc(
     float value,
     const Tensor& input,
@@ -300,99 +212,6 @@ Tensor _rfloor_div(float value, const Tensor& input, const MemoryConfig& output_
 }
 Tensor rfloor_div(float value, const Tensor& input, const MemoryConfig& output_mem_config) {
     return operation::decorate_as_composite(__func__, _rfloor_div)(value, input, output_mem_config);
-}
-
-// logit(input, eps)=log(input / 1 - input)
-Tensor _logit(const Tensor& input_a, float eps, const MemoryConfig& output_mem_config) {
-    Tensor t_eps = full_like(input_a, eps, output_mem_config);
-    Tensor t1m_eps = full_like(input_a, (1 - eps), output_mem_config);
-    Tensor logit_input = ttnn::where(
-        ttnn::ltz(t_eps, output_mem_config),
-        input_a,
-        ttnn::where(
-            ttnn::lt(input_a, t_eps, std::nullopt, output_mem_config),
-            t_eps,
-            ttnn::where(ttnn::gt(input_a, t1m_eps, std::nullopt, output_mem_config), t1m_eps, input_a, output_mem_config),
-            output_mem_config),
-        output_mem_config);
-    t_eps.deallocate();
-    t1m_eps.deallocate();
-    Tensor linput_m1 = ttnn::rsub(logit_input, 1.0, output_mem_config);
-    Tensor log_input =
-        ttnn::multiply(logit_input, ttnn::reciprocal(linput_m1, output_mem_config), std::nullopt, output_mem_config);
-    linput_m1.deallocate();
-    Tensor t_inf =
-        ttnn::multiply(ttnn::sign(input_a, output_mem_config), std::numeric_limits<float>::infinity(), std::nullopt, output_mem_config);
-    Tensor logit_result = ttnn::where(
-        ttnn::eq(logit_input, 1.0, std::nullopt, output_mem_config),
-        t_inf,
-        ttnn::where(ttnn::ltz(log_input, output_mem_config), std::nanf(" "), ttnn::log(log_input, output_mem_config), output_mem_config),
-        output_mem_config);
-    return logit_result;
-}
-Tensor logit(const Tensor& input_a, float eps, const MemoryConfig& output_mem_config) {
-    return operation::decorate_as_composite(__func__, _logit)(input_a, eps, output_mem_config);
-}
-
-// logical_xori
-Tensor _logical_xori(const Tensor& input_a, float value, const MemoryConfig& output_mem_config) {
-    if (std::fpclassify(value) == FP_ZERO) {
-        return ttnn::nez(input_a);
-    } else {
-        return ttnn::eqz(input_a);  // eqz( input_a ) = not( nez( input_a ) )
-    }
-}
-Tensor logical_xori(const Tensor& input_a, float value, const MemoryConfig& output_mem_config) {
-    return operation::decorate_as_composite(__func__, _logical_xori)(input_a, value, output_mem_config);
-}
-
-// Celu
-// torch.where(x > 0, x, alpha * (torch.exp(x / alpha) - 1))
-Tensor _celu(const Tensor& input_a, float alpha, const MemoryConfig& output_mem_config) {
-    float recip_val = 1.0f / alpha;
-    using ttnn::operations::unary::UnaryWithParam;
-    using ttnn::operations::unary::UnaryOpType;
-    std::vector<UnaryWithParam> ops_chain = {
-    UnaryWithParam{UnaryOpType::MUL_UNARY_SFPU, recip_val},
-    UnaryWithParam{UnaryOpType::EXP, 1.0f},
-    UnaryWithParam{UnaryOpType::SUB_UNARY_SFPU, 1.0f}, UnaryWithParam{UnaryOpType::MUL_UNARY_SFPU, alpha} };
-
-    Tensor result = ttnn::unary_chain(input_a, ops_chain, output_mem_config);
-    result = ttnn::where(ttnn::gtz(input_a, output_mem_config), input_a, result, output_mem_config);
-    return result;
-}
-Tensor celu(const Tensor& input_a, float alpha, const MemoryConfig& output_mem_config) {
-    return operation::decorate_as_composite(__func__, _celu)(input_a, alpha, output_mem_config);
-}
-
-
-using HWFunctionT = std::function<Tensor(const Tensor& y, const MemoryConfig&)>;
-Tensor _make_global_from_hw_impl(
-    HWFunctionT fn, const Tensor& y, const MemoryConfig& output_mem_config = operation::DEFAULT_OUTPUT_MEMORY_CONFIG) {
-    const Shape s_orig = y.get_legacy_shape();
-    TT_FATAL(s_orig.rank() == 4, "Cannot support non-rank 4 Tensor");
-
-    // format to HW
-    Tensor y_hw = reshape(y, 1, 1, s_orig[2], s_orig[3] * s_orig[1] * s_orig[0], output_mem_config);
-
-    // compute @fn
-    Tensor z_0 = fn(y_hw, output_mem_config);
-    TT_FATAL(y_hw.get_legacy_shape() == z_0.get_legacy_shape(), "shape match");
-    y_hw.deallocate();
-
-    // reformat
-    Tensor z_1 = reshape(z_0, s_orig[0], s_orig[1], s_orig[2], s_orig[3], output_mem_config);
-    z_0.deallocate();
-
-    return z_1;
-}
-
-// Global Norm
-Tensor _normalize_global(const Tensor& y, const MemoryConfig& output_mem_config) {
-    return _make_global_from_hw_impl(ttnn::normalize_hw, y, output_mem_config);
-}
-Tensor normalize_global(const Tensor& y, const MemoryConfig& output_mem_config) {
-    return operation::decorate_as_composite(__func__, _normalize_global)(y, output_mem_config);
 }
 
 Tensor _scatter(const Tensor& input_a, const Tensor& input_b, const MemoryConfig& output_mem_config) {
@@ -544,26 +363,6 @@ Tensor _outer(Tensor& a, Tensor& b, const MemoryConfig& output_mem_config) {
 Tensor outer(Tensor& a, Tensor& b, const MemoryConfig& output_mem_config) {
     return operation::decorate_as_composite(__func__, _outer)(a, b, output_mem_config);
 }
-
-std::vector<Tensor> split_tensor_for_glu(const Tensor& input_a, int32_t dim, const MemoryConfig& output_mem_config) {
-    std::vector<Tensor> t_split;
-    Shape inshape = input_a.get_legacy_shape();
-    TT_FATAL(((inshape[dim] / 2) % TILE_WIDTH == 0), "Split tensor dimension should be in full tile");
-    std::vector<uint32_t> s_a = {0, 0, 0, 0};
-    std::vector<uint32_t> e_a = {inshape[0] - 1, inshape[1] - 1, inshape[2] - 1, inshape[3] / 2 - 1};
-
-    std::vector<uint32_t> s_b = {0, 0, 0, inshape[3] / 2};
-    std::vector<uint32_t> e_b = {inshape[0] - 1, inshape[1] - 1, inshape[2] - 1, inshape[3] - 1};
-
-    Tensor t_a = ttnn::slice(0, input_a, s_a, e_a, output_mem_config);
-    Tensor t_b = ttnn::slice(0, input_a, s_b, e_b, output_mem_config);
-
-    t_split.emplace_back(t_a);
-    t_split.emplace_back(t_b);
-
-    return t_split;
-}
-
 
 // on-device tensor creation with shape and filled with value
 Tensor _sfpu_eps(const Shape shape, Layout layout, Device* device, const MemoryConfig& output_mem_config) {

--- a/ttnn/cpp/ttnn/deprecated/tt_dnn/op_library/composite/composite_ops.hpp
+++ b/ttnn/cpp/ttnn/deprecated/tt_dnn/op_library/composite/composite_ops.hpp
@@ -26,15 +26,6 @@ using binary_tensor_op_t = Tensor(const Tensor& a, const Tensor& b);
 
 // Note: inline doesn't allow pybind to work well so we keep few function not inlined.
 
-// Function: softshrink
-// Ref: https://pytorch.org/docs/stable/generated/torch.nn.Softshrink.html
-Tensor softshrink(
-    const Tensor& a, float param, const MemoryConfig& output_mem_config = operation::DEFAULT_OUTPUT_MEMORY_CONFIG);
-
-// Function: hardshrink
-// Ref: https://pytorch.org/docs/stable/generated/torch.nn.Hardshrink.html
-Tensor hardshrink(
-    const Tensor& a, float param, const MemoryConfig& output_mem_config = operation::DEFAULT_OUTPUT_MEMORY_CONFIG);
 
 // Function: MAC
 // compute multiply-accumulate: y = a * b + c,  over various 8 combinations of a, b, c
@@ -47,26 +38,14 @@ Tensor mac(
 Tensor mac(
     const Tensor& a, float b, float c, const MemoryConfig& output_mem_config = operation::DEFAULT_OUTPUT_MEMORY_CONFIG);
 
-Tensor celu(
-    const Tensor& x, float alpha, const MemoryConfig& output_mem_config = operation::DEFAULT_OUTPUT_MEMORY_CONFIG);
-
 // compute polyval by Horner's rule
 Tensor polyval(
     const Tensor& input_tensor,
     std::vector<float> coeffs,
     const MemoryConfig& output_mem_config = operation::DEFAULT_OUTPUT_MEMORY_CONFIG);
 
-Tensor logical_andi(
-    const Tensor& input_a,
-    float immediate,
-    const MemoryConfig& output_mem_config = operation::DEFAULT_OUTPUT_MEMORY_CONFIG);
-
 Tensor unary_rdiv_trunc(
     float value,
-    const Tensor& input,
-    const MemoryConfig& output_mem_config = operation::DEFAULT_OUTPUT_MEMORY_CONFIG);
-
-Tensor frac(
     const Tensor& input,
     const MemoryConfig& output_mem_config = operation::DEFAULT_OUTPUT_MEMORY_CONFIG);
 
@@ -75,25 +54,6 @@ Tensor rfloor_div(
     const Tensor& input,
     const MemoryConfig& output_mem_config = operation::DEFAULT_OUTPUT_MEMORY_CONFIG);
 
-// logical_noti
-Tensor logical_noti(
-    const Tensor& input_a,
-    float immediate,
-    const MemoryConfig& output_mem_config = operation::DEFAULT_OUTPUT_MEMORY_CONFIG);
-
-
-/*
-Returns a new tensor with the signed angles in radians between vectors
-
-                x > 0 and y>= 0 atan(y/x)
-                x > 0 and y < 0 -atan(y/x)
-                x < 0 and y > 0 pi - atan(y/x)
-atan2(y, x) =   x < 0 and y < 0 atan(y/x) - pi
-                x < 0 and y = 0 pi
-                x = 0 and y > 0 pi/2
-                x = 0 and y < 0 -pi/2
-                x = 0 and y = 0 0.0
-*/
 
 // lerp(input, end, weight) = start + weight * (end - start), weight is float
 Tensor lerp(
@@ -120,6 +80,7 @@ Tensor zeros_like(
     const Tensor& reference_tensor,
     const MemoryConfig& output_mem_config = operation::DEFAULT_OUTPUT_MEMORY_CONFIG,
     std::optional<Tensor> output_tensor= std::nullopt);
+
 Tensor zeros_like(
     const Tensor& reference_tensor,
     const MemoryConfig& output_mem_config = operation::DEFAULT_OUTPUT_MEMORY_CONFIG,
@@ -182,9 +143,6 @@ Tensor full(
     Device* device = nullptr,
     const MemoryConfig& output_mem_config = operation::DEFAULT_OUTPUT_MEMORY_CONFIG);
 
-// rpow: y = k**(a)
-Tensor rpow(const Tensor& a, float k, const MemoryConfig& output_mem_config = operation::DEFAULT_OUTPUT_MEMORY_CONFIG);
-
 // machine epsilon
 Tensor eps(
     const Shape shape,
@@ -192,32 +150,7 @@ Tensor eps(
     Device* device,
     const MemoryConfig& output_mem_config = operation::DEFAULT_OUTPUT_MEMORY_CONFIG);
 
-// logit(input, eps)=log(input / 1 - input)
-Tensor logit(
-    const Tensor& input_a, float eps, const MemoryConfig& output_mem_config = operation::DEFAULT_OUTPUT_MEMORY_CONFIG);
-
-Tensor logical_xori(
-    const Tensor& input_a,
-    float immediate,
-    const MemoryConfig& output_mem_config = operation::DEFAULT_OUTPUT_MEMORY_CONFIG);
-
-/** hyperbolic operations **/
-
-/**
- * outer product = matrix multiply when a = [1,1,N,1] and b = [1,1,1,M]
- * and result is of size [1,1,N,M].
- * - implementation supports any 1D "squeezable tensor" at input operands
- *   by running reshape.
- */
 Tensor outer(Tensor& a, Tensor& b, const MemoryConfig& output_mem_config = operation::DEFAULT_OUTPUT_MEMORY_CONFIG);
-
-Tensor normalize_global(
-    const Tensor& y, const MemoryConfig& output_mem_config = operation::DEFAULT_OUTPUT_MEMORY_CONFIG);
-
-Tensor logical_ori(
-    const Tensor& input_a,
-    float immediate,
-    const MemoryConfig& output_mem_config = operation::DEFAULT_OUTPUT_MEMORY_CONFIG);
 
 // on-device tensor creation with shape and filled with value
 Tensor sfpu_eps(const Shape shape, Layout layout, Device* device, const MemoryConfig& output_mem_config);

--- a/ttnn/cpp/ttnn/deprecated/tt_lib/csrc/tt_lib_bindings_tensor_composite_ops.cpp
+++ b/ttnn/cpp/ttnn/deprecated/tt_lib/csrc/tt_lib_bindings_tensor_composite_ops.cpp
@@ -60,23 +60,6 @@ void TensorModuleCompositeOPs(py::module& m_tensor) {
         )doc");
 
         // *** composite unary ops ***
-        detail::bind_unary_op(m_tensor, "normalize_global", tt::tt_metal::normalize_global, R"doc(Returns a new tensor with the Gaussian normalize of the elements of the input tensor ``{0}`` on N,C,H,W axes.)doc");
-    detail::bind_unary_op_with_param(
-        m_tensor,
-        "softshrink",
-        &softshrink,
-        py::arg("lambda"),
-        R"doc(Applies the softshrink function to the elements of the input tensor ``{0}`` between limits ``-{1}`` low and
-            the ``+{1}`` high limits.)doc",
-        R"doc("value limits (-lambda to +lambda)", "float", ">= 0")doc");
-    detail::bind_unary_op_with_param(
-        m_tensor,
-        "hardshrink",
-        &hardshrink,
-        py::arg("lambda"),
-        R"doc(Applies the hardshrink function to the elements of the input tensor ``{0}`` between limits ``-{1}`` low and
-            the ``+{1}`` high limits.)doc",
-        R"doc("value limits (-lambda to +lambda)", "float", ">= 0")doc");
     detail::bind_unary_op_with_param(
         m_tensor,
         "polyval",
@@ -84,39 +67,6 @@ void TensorModuleCompositeOPs(py::module& m_tensor) {
         py::arg("coeffs"),
         R"doc(Returns tensor with the polyval of all of elements of the input tensor ``{0}`` with coefficients ``{1}``.)doc",
         R"doc("coefficients value with highest degree first", "List of float", "List size > 0")doc");
-
-
-    detail::bind_unary_op_with_param(
-        m_tensor,
-        "logical_andi",
-        &logical_andi,
-        py::arg("immediate"),
-        R"doc(Perform an eltwise logical AND (``{0} && {1}``) on input tensor and immediate value.)doc",
-        R"doc("Scalar", "float", "")doc");
-
-    detail::bind_unary_op_with_param(
-        m_tensor,
-        "logical_noti",
-        &logical_noti,
-        py::arg("immediate"),
-        R"doc(Perform an eltwise logical NOT (``!{1}``) on immediate value.)doc",
-        R"doc("immediate", "float", "")doc");
-
-    detail::bind_unary_op_with_param(
-        m_tensor,
-        "rpow",
-        rpow,
-        py::arg("base"),
-        R"doc(Returns tensor  raising ``{1}`` value to power of respective elements of the input exponent tensor ``{0}``.)doc",
-        R"doc("base value", "float", ">0.0")doc");
-
-    detail::bind_unary_op_with_param(
-        m_tensor,
-        "logical_ori",
-        &logical_ori,
-        py::arg("immediate"),
-        R"doc(Perform an eltwise logical OR (``{0} || {1}``) on input tensor and immediate value.)doc",
-        R"doc("Scalar", "float", "")doc");
 
     m_tensor.def(
         "lerp",
@@ -166,26 +116,6 @@ void TensorModuleCompositeOPs(py::module& m_tensor) {
                 "output_mem_config", "Layout of tensor in TT Accelerator device memory banks", "MemoryConfig", "Default is interleaved in DRAM", "No"
         )doc");
 
-    m_tensor.def(
-        "celu",
-        &celu,
-        py::arg("input").noconvert(),
-        py::arg("alpha") = 1.0f,
-        py::arg("output_mem_config").noconvert() = operation::DEFAULT_OUTPUT_MEMORY_CONFIG,
-        R"doc(
-            Applies the celu function to the elements of the input tensor ``input``.
-
-            Input tensor must have BFLOAT16 data type.
-
-            Output tensor will have BFLOAT16 data type.
-
-            .. csv-table::
-                :header: "Argument", "Description", "Data type", "Valid range", "Required"
-
-                "input", "Tensor celu is applied to", "Tensor", "Tensor of shape [W, Z, Y, X]", "Yes"
-                "alpha", "alpha value (PyTorch default)", "float", "default to 1.0", "Yes"
-                "output_mem_config", "Layout of tensor in TT Accelerator device memory banks", "MemoryConfig", "Default is interleaved in DRAM", "No"
-        )doc");
 
     m_tensor.def(
         "full_like",
@@ -485,20 +415,6 @@ void TensorModuleCompositeOPs(py::module& m_tensor) {
                 "output_mem_config", "Layout of tensor in TT Accelerator device memory banks", "MemoryConfig", "Default is interleaved in DRAM", "No"
         )doc");
 
-        m_tensor.def("frac",&frac,
-            py::arg("input").noconvert(),py::arg("output_mem_config").noconvert() = operation::DEFAULT_OUTPUT_MEMORY_CONFIG,R"doc(
-            Performs the element-wise frac operation on ``input``. Support provided only for Wormhole_B0.
-
-            Input tensor must have BFLOAT16 data type.
-
-            Output tensor will have BFLOAT16 data type.
-
-            .. csv-table::
-                :header: "Argument", "Description", "Data type", "Valid range", "Required"
-
-                "input", "Input Tensor", "Tensor", "Tensor of shape [W, Z, Y, X]", "Yes"
-                "output_mem_config", "Layout of tensor in TT Accelerator device memory banks", "MemoryConfig", "Default is interleaved in DRAM", "No"
-        )doc");
 
         m_tensor.def("rfloor_div", py::overload_cast<float, const Tensor&, const MemoryConfig&>(&rfloor_div),
             py::arg("value").noconvert(), py::arg("input").noconvert(), py::arg("output_mem_config").noconvert() = operation::DEFAULT_OUTPUT_MEMORY_CONFIG,R"doc(
@@ -592,20 +508,6 @@ void TensorModuleCompositeOPs(py::module& m_tensor) {
                 "output_mem_config", "Layout of tensor in TT Accelerator device memory banks", "MemoryConfig", "Default is interleaved in DRAM", "No"
         )doc");
 
-        detail::bind_unary_op_with_param(
-            m_tensor, "logit", &logit,
-            py::arg("eps"),
-            R"doc(Returns a tensor that is a logit  of input tensor with shape ``[W, Z, Y, X]`` along clamp ``{1}``.)doc",
-            R"doc("dimension to logit along", "int", "0, 1, 2, or 3")doc"
-        );
-
-        detail::bind_unary_op_with_param(
-            m_tensor, "logical_xori", &logical_xori,
-            py::arg("immediate"),
-            R"doc(Perform an eltwise logical XOR (``{0} ^ {1}``) on input tensor and immediate value.)doc",
-            R"doc("Scalar", "float", "")doc"
-        );
-
         // *** complex operations ***
         detail::bind_unary_op(m_tensor, "angle", py::overload_cast<const Tensor&,const MemoryConfig&>(&tt::tt_metal::angle), R"doc(Returns elementwise angle of complex tensor ``{0}``.)doc");
         detail::bind_unary_op(m_tensor, "real", py::overload_cast<const Tensor&,const MemoryConfig&>(&tt::tt_metal::real), R"doc(Returns real portion of complex tensor ``{0}``.)doc");
@@ -627,7 +529,6 @@ void TensorModuleCompositeOPs(py::module& m_tensor) {
         m_tensor.def("complex_add", py::overload_cast<const Tensor&,const Tensor&,const MemoryConfig&>(&tt::tt_metal::complex_add),
             py::arg("input_a"), py::arg("input_b"),
             py::arg("output_mem_config").noconvert() = std::nullopt,R"doc(Perform an eltwise-binary addition ``input_a + input_b`` on two complex tensors.)doc");
-
         m_tensor.def("complex_sub", py::overload_cast<const Tensor&,const Tensor&,const MemoryConfig&>(&tt::tt_metal::complex_sub),
             py::arg("input_a"), py::arg("input_b"),
             py::arg("output_mem_config").noconvert() = std::nullopt,R"doc(Perform an eltwise-binary subtraction ``input_a - input_b`` on two complex tensors.)doc");

--- a/ttnn/cpp/ttnn/operations/eltwise/binary/device/binary_composite_op.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary/device/binary_composite_op.hpp
@@ -11,7 +11,6 @@
 #include "third_party/magic_enum/magic_enum.hpp"
 #include "ttnn/operations/core/core.hpp"
 
-
 namespace ttnn::operations::binary{
 
 enum class BinaryCompositeOpType {

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_backward/device/binary_backward_op.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_backward/device/binary_backward_op.cpp
@@ -12,6 +12,7 @@
 #include "ttnn/operations/embedding/embedding.hpp"
 #include "ttnn/deprecated/tt_dnn/op_library/bcast/bcast_op.hpp"
 #include "ttnn/operations/eltwise/unary/device/unary_composite_op.hpp"
+#include "ttnn/cpp/ttnn/operations/eltwise/unary/unary_composite.hpp"
 #include "ttnn/operations/eltwise/binary/binary_composite.hpp"
 #include "ttnn/operations/eltwise/unary_backward/unary_backward.hpp"
 #include "ttnn/operations/eltwise/binary_backward/binary_backward.hpp"
@@ -202,7 +203,7 @@ std::vector<ttnn::Tensor> _ldexp_bw(
     const Tensor& grad, const Tensor& input, const Tensor& other, const std::optional<MemoryConfig>& output_mem_config) {
     std::vector<Tensor> grad_tensor;
     auto output_memory_config = output_mem_config.value_or(input.memory_config());
-    Tensor tpow_o = ttnn::multiply(grad, rpow(other, 2.0, output_memory_config), std::nullopt, output_memory_config);
+    Tensor tpow_o = ttnn::multiply(grad, ttnn::rpow(other, 2.0, output_memory_config), std::nullopt, output_memory_config);
     grad_tensor.emplace_back(tpow_o);
     Tensor result = ttnn::multiply(input, ttnn::multiply(tpow_o, M_LN2, std::nullopt, output_memory_config), std::nullopt, output_memory_config);
     grad_tensor.emplace_back(result);
@@ -241,10 +242,10 @@ std::vector<ttnn::Tensor> _logaddexp2_bw(
     std::vector<Tensor> grad_tensor;
     auto output_memory_config = output_mem_config.value_or(input_a.memory_config());
     Tensor oppow =
-        ttnn::add(rpow(ttnn::subtract(other, input_a, std::nullopt, output_memory_config), 2, output_memory_config), 1, std::nullopt, output_memory_config);
+        ttnn::add(ttnn::rpow(ttnn::subtract(other, input_a, std::nullopt, output_memory_config), 2, output_memory_config), 1, std::nullopt, output_memory_config);
     Tensor grad_a = ttnn::multiply(grad, ttnn::reciprocal(oppow, output_memory_config), std::nullopt, output_memory_config);
     grad_tensor.emplace_back(grad_a);
-    oppow = ttnn::add(rpow(ttnn::subtract(input_a, other, std::nullopt, output_memory_config), 2, output_memory_config), 1, std::nullopt, output_memory_config);
+    oppow = ttnn::add(ttnn::rpow(ttnn::subtract(input_a, other, std::nullopt, output_memory_config), 2, output_memory_config), 1, std::nullopt, output_memory_config);
     Tensor grad_b = ttnn::multiply(grad, ttnn::reciprocal(oppow, output_memory_config), std::nullopt, output_memory_config);
     grad_tensor.emplace_back(grad_b);
     return grad_tensor;

--- a/ttnn/cpp/ttnn/operations/eltwise/unary_backward/device/unary_backward_op.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary_backward/device/unary_backward_op.cpp
@@ -18,7 +18,6 @@
 #include "ttnn/operations/reduction/prod/prod.hpp"
 #include "ttnn/operations/eltwise/ternary/where.hpp"
 #include "ttnn/operations/eltwise/unary/unary_composite.hpp"
-
 namespace ttnn::operations::unary_backward {
 
 std::vector<Tensor> _clamp_bw(
@@ -629,8 +628,7 @@ std::vector<Tensor> _square_bw(const Tensor& grad, const Tensor& input, const st
 std::vector<Tensor> _hardshrink_bw(
     const Tensor& grad, const Tensor& input_tensor, float lambd, const std::optional<MemoryConfig>& output_mem_config) {
     std::vector<Tensor> grad_tensor;
-    auto output_memory_config = output_mem_config.value_or(input_tensor.memory_config());
-    Tensor hardshrink_result = tt::tt_metal::hardshrink(input_tensor, lambd, output_memory_config);
+    Tensor hardshrink_result = ttnn::hardshrink(input_tensor, lambd, output_mem_config);
     Tensor result = where(ttnn::eqz(hardshrink_result, output_mem_config), 0.0f, grad, output_mem_config);
     grad_tensor.emplace_back(result);
     return grad_tensor;


### PR DESCRIPTION
Issue : #10815 
Tracking Issue : #10640 

List of ops
- [x] Hardshrink
- [x] Softshrink
- [x] Logit
- [x] Celu
- [x] Rpow
- [x] Normalize_global
- [x] Frac
- [x] Logical_noti (Logical_not_)
- [x] Logical_andi (Logical_and_)
- [x] Logical_ori (Logical_or_)
- [x] Logical_xori (Logical_xor_)

### Checklist
- [x] [Post commit CI ](https://github.com/tenstorrent/tt-metal/actions/runs/10195823308)
- [x] [post-commit models tests](https://github.com/tenstorrent/tt-metal/actions/runs/10192187289)
- [x] [Model perf regressions and output report](https://github.com/tenstorrent/tt-metal/actions/runs/10192195546)
- [x] [Device perf regressions and output report](https://github.com/tenstorrent/tt-metal/actions/runs/10192200002)
- [ ] [Nightly fast dispatch model regression CI](https://github.com/tenstorrent/tt-metal/actions/runs/10192220254)
- [x] [T3000 frequent tests](https://github.com/tenstorrent/tt-metal/actions/runs/10192224300)
- [x] [T3000 demo tests](https://github.com/tenstorrent/tt-metal/actions/runs/10192228788)
- [x] [T3000 unit tests](https://github.com/tenstorrent/tt-metal/actions/runs/10192233740)

