### PR TITLE
#10641: Remove composite ops from tt_eager

### DIFF
--- a/docs/source/ttnn/ttnn/dependencies/tt_lib.rst
+++ b/docs/source/ttnn/ttnn/dependencies/tt_lib.rst
@@ -286,19 +286,11 @@ Tensor elementwise operations
 
 .. autofunction:: tt_lib.tensor.mac
 
-.. autofunction:: tt_lib.tensor.swish
-
-.. autofunction:: tt_lib.tensor.softsign
-
 .. autofunction:: tt_lib.tensor.softshrink
 
 .. autofunction:: tt_lib.tensor.hardshrink
 
 .. autofunction:: tt_lib.tensor.cosh
-
-.. autofunction:: tt_lib.tensor.sinh
-
-.. autofunction:: tt_lib.tensor.tanhshrink
 
 .. autofunction:: tt_lib.tensor.remainder
 
@@ -309,8 +301,6 @@ Tensor elementwise operations
 .. autofunction:: tt_lib.tensor.atan2
 
 .. autofunction:: tt_lib.tensor.logical_xori
-
-.. autofunction:: tt_lib.tensor.subalpha
 
 .. autofunction:: tt_lib.tensor.celu
 
@@ -328,8 +318,6 @@ Tensor elementwise operations
 
 .. autofunction:: tt_lib.tensor.polygamma
 
-.. autofunction:: tt_lib.tensor.trunc
-
 .. autofunction:: tt_lib.tensor.frac
 
 .. autofunction:: tt_lib.tensor.round
@@ -338,15 +326,6 @@ Tensor elementwise operations
 
 .. autofunction:: tt_lib.tensor.rfloor_div
 
-Tensor relational operations
-============================
-
-
-Tensor ternary operations
-=========================
-.. autofunction:: tt_lib.tensor.where
-
-.. autofunction:: tt_lib.tensor.threshold
 
 Tensor manipulation operations
 -=============================
@@ -568,27 +547,19 @@ Other Operations
 
 .. autofunction:: tt_lib.tensor.convert_conv_weight_tensor_to_tiled_layout
 
-.. autofunction:: tt_lib.tensor.xlogy
-
 .. autofunction:: tt_lib.tensor.addcmul
 
 .. autofunction:: tt_lib.tensor.addcdiv
 
 .. autofunction:: tt_lib.tensor.mean_hw
 
-.. autofunction:: tt_lib.tensor.var_hw
-
 .. autofunction:: tt_lib.tensor.logical_noti
-
-.. autofunction:: tt_lib.tensor.std_hw
 
 .. autofunction:: tt_lib.tensor.normalize_global
 
 .. autofunction:: tt_lib.tensor.lamb_optimizer
 
 .. autofunction:: tt_lib.tensor.repeat
-
-.. autofunction:: tt_lib.tensor.pow
 
 .. autofunction:: tt_lib.tensor.argmax
 

--- a/models/demos/t3000/falcon40b/tests/unit_tests/distributed_layernorm/test_distributed_layernorm.py
+++ b/models/demos/t3000/falcon40b/tests/unit_tests/distributed_layernorm/test_distributed_layernorm.py
@@ -168,7 +168,7 @@ class TtDistributedLayernorm:
         # meanx2 = torch.mean(torch.square(xs), dim=-1, keepdim=True)
         meanx2s = []
         for i in range(num_devices):
-            x2_local = ttl.tensor.pow(xs[i], 2)
+            x2_local = ttnn.pow(xs[i], 2)
             meanx2_local = ttl.tensor.reduce(
                 x2_local, ttl.tensor.ReduceOpMath.SUM, ttl.tensor.ReduceOpDim.W, scaler=1.0 / counts[i]
             )
@@ -219,7 +219,7 @@ class TtDistributedLayernorm:
         # var = meanx2 - torch.square(mean)
         var = []
         for i in range(num_devices):
-            var.append(ttl.tensor.pow(mean[i], 2))
+            var.append(ttnn.pow(mean[i], 2))
         for i in range(num_devices):
             var[i] = ttnn.subtract(meanx2[i], var[i])
             meanx2[i].deallocate(True)
@@ -229,7 +229,7 @@ class TtDistributedLayernorm:
         for i in range(num_devices):
             denominators.append(ttnn.add(var[i], self.ln_eps))
         for i in range(num_devices):
-            denominators[i] = ttl.tensor.pow(denominators[i], 0.5)
+            denominators[i] = ttnn.pow(denominators[i], 0.5)
         for i in range(num_devices):
             denominators[i] = ttnn.reciprocal(denominators[i])
 

--- a/models/demos/t3000/falcon40b/tests/unit_tests/distributed_layernorm/test_distributed_layernorm_dlnp1.py
+++ b/models/demos/t3000/falcon40b/tests/unit_tests/distributed_layernorm/test_distributed_layernorm_dlnp1.py
@@ -75,7 +75,7 @@ class TtDistributedLayernormDLNP1:
         # meanx2 = torch.mean(torch.square(xs), dim=-1, keepdim=True)
         meanx2s = []
         for i in range(num_devices):
-            x2_local = ttl.tensor.pow(xs[i], 2)
+            x2_local = ttnn.pow(xs[i], 2)
             meanx2_local = ttl.tensor.reduce(
                 x2_local, ttl.tensor.ReduceOpMath.SUM, ttl.tensor.ReduceOpDim.W, scaler=1.0 / counts[i]
             )

--- a/models/demos/t3000/llama2_70b/tt/llama_common.py
+++ b/models/demos/t3000/llama2_70b/tt/llama_common.py
@@ -200,13 +200,13 @@ def get_weight_cache_path_galaxy(base_cache_path, tensor_str, device_idx, num_de
 
 
 def rms_decomp(x, norm_weight, eps):
-    squared = tt_lib.tensor.pow(x, 2)
+    squared = ttnn.pow(x, 2)
     # mean_squared = tt_lib.tensor.mean(squared, )
     sum_squared = tt_lib.tensor.reduce(squared, tt_lib.tensor.ReduceOpMath.SUM, tt_lib.tensor.ReduceOpDim.W, scaler=1.0)
     # Tensor is 1,1,32,1+31 now
     mean_squared = ttnn.multiply(sum_squared, (1 / x.shape[-1]))
     mean_squared_eps = ttnn.add(mean_squared, eps)
-    rms = tt_lib.tensor.pow(mean_squared_eps, 0.5)
+    rms = ttnn.pow(mean_squared_eps, 0.5)
     rms_recip = ttnn.reciprocal(rms)
     normed_x = tt_lib.tensor.bcast(x, rms_recip, math_op=tt_lib.tensor.BcastOpMath.MUL, dim=tt_lib.tensor.BcastOpDim.W)
     norm_out = ttnn.mul(normed_x, norm_weight)

--- a/models/experimental/llama2_70b/tt/llama_common.py
+++ b/models/experimental/llama2_70b/tt/llama_common.py
@@ -146,7 +146,7 @@ def get_weight_cache_path_galaxy(base_cache_path, tensor_str, device_idx, num_de
 
 
 def rms_decomp(x, norm_weight, eps):
-    squared = tt_lib.tensor.pow(x, 2)
+    squared = ttnn.pow(x, 2)
     # mean_squared = tt_lib.tensor.mean(squared, )
     sum_squared = tt_lib.tensor.reduce(squared, tt_lib.tensor.ReduceOpMath.SUM, tt_lib.tensor.ReduceOpDim.W, scaler=1.0)
     # Tensor is 1,1,32,1+31 now

--- a/tests/tt_eager/python_api_testing/sweep_tests/tt_lib_ops.py
+++ b/tests/tt_eager/python_api_testing/sweep_tests/tt_lib_ops.py
@@ -230,7 +230,7 @@ def eltwise_threshold(
     **kwargs,
 ):
     t0 = setup_tt_tensor(x, device, layout[0], input_mem_config[0], dtype[0])
-    t1 = ttl.tensor.threshold(t0, threshold, value, output_mem_config=output_mem_config)
+    t1 = ttnn.threshold(t0, threshold, value, memory_config=output_mem_config)
 
     return tt2torch_tensor(t1)
 
@@ -783,7 +783,7 @@ def eltwise_subalpha(
 ):
     t0 = setup_tt_tensor(x, device, layout[0], input_mem_config[0], dtype[0])
     t1 = setup_tt_tensor(y, device, layout[1], input_mem_config[1], dtype[1])
-    t2 = ttl.tensor.subalpha(t0, t1, alpha, output_mem_config=output_mem_config)
+    t2 = ttnn.subalpha(t0, t1, alpha, memory_config=output_mem_config)
 
     return tt2torch_tensor(t2)
 
@@ -1632,7 +1632,7 @@ def where(x, y, z, device, dtype, layout, input_mem_config, output_mem_config, *
     t0 = setup_tt_tensor(x, device, layout[0], input_mem_config[0], dtype[0])
     t1 = setup_tt_tensor(y, device, layout[1], input_mem_config[1], dtype[1])
     t2 = setup_tt_tensor(z, device, layout[2], input_mem_config[2], dtype[2])
-    t3 = ttl.tensor.where(t0, t1, t2, output_mem_config=output_mem_config)
+    t3 = ttnn.where(t0, t1, t2, memory_config=output_mem_config)
 
     return tt2torch_tensor(t3)
 
@@ -1644,7 +1644,7 @@ def where_optional(x, y, z, out, device, dtype, layout, input_mem_config, output
     t2 = setup_tt_tensor(z, device, layout[2], input_mem_config[2], dtype[2])
     t3 = setup_tt_tensor(out, device, layout[3], input_mem_config[3], dtype[3])
     cq_id = 0
-    ttl.tensor.where(t0, t1, t2, output_tensor=t3, queue_id=cq_id)
+    ttnn.where(t0, t1, t2, output_tensor=t3, queue_id=cq_id)
 
     return tt2torch_tensor(t3)
 
@@ -1656,7 +1656,7 @@ def where_scalar_optional(
     t0 = setup_tt_tensor(x, device, layout[0], input_mem_config[0], dtype[0])
     t3 = setup_tt_tensor(out, device, layout[1], input_mem_config[1], dtype[1])
     cq_id = 0
-    ttl.tensor.where(t0, scalar_true, scalar_false, output_tensor=t3, queue_id=cq_id)
+    ttnn.where(t0, scalar_true, scalar_false, output_tensor=t3, queue_id=cq_id)
 
     return tt2torch_tensor(t3)
 
@@ -2493,14 +2493,14 @@ eltwise_exp = make_unary_op_optional_output_with_fast_approx(ttnn.exp)
 eltwise_softplus = make_unary_op_optional_output(ttnn.softplus)
 eltwise_atanh = make_unary_op(ttl.tensor.atanh)
 eltwise_cosh = make_unary_op(ttl.tensor.cosh)
-eltwise_sinh = make_unary_op(ttl.tensor.sinh)
+eltwise_sinh = make_ttnn_unary_op(ttnn.sinh)
 eltwise_tanh = make_unary_op_optional_output(ttnn.tanh)
 eltwise_asinh = make_unary_op(ttl.tensor.asinh)
 eltwise_acosh = make_unary_op(ttl.tensor.acosh)
-eltwise_tanhshrink = make_unary_op(ttl.tensor.tanhshrink)
+eltwise_tanhshrink = make_ttnn_unary_op(ttnn.tanhshrink)
 eltwise_lgamma = make_ttnn_unary_op(ttnn.lgamma)
 eltwise_multigammaln = make_ttnn_unary_op(ttnn.multigammaln)
-eltwise_softsign = make_unary_op(ttl.tensor.softsign)
+eltwise_softsign = make_ttnn_unary_op(ttnn.softsign)
 eltwise_relu = make_unary_op_optional_output(ttnn.relu)
 eltwise_relu6 = make_unary_op_optional_output(ttnn.relu6)
 eltwise_sqrt = make_unary_op_optional_output(ttnn.sqrt)
@@ -2517,7 +2517,7 @@ eltwise_recip = make_unary_op_optional_output(ttnn.reciprocal)
 eltwise_sigmoid = make_unary_op_optional_output(ttnn.sigmoid)
 eltwise_sigmoid_accurate = make_unary_op_optional_output(ttnn.sigmoid_accurate)
 eltwise_log_sigmoid = make_unary_op_optional_output(ttnn.log_sigmoid)
-eltwise_swish = make_unary_op(ttl.tensor.swish)
+eltwise_swish = make_ttnn_unary_op(ttnn.swish)
 eltwise_log1p = make_ttnn_unary_op(ttnn.log1p)
 eltwise_mish = make_ttnn_unary_op(ttnn.mish)
 eltwise_hardswish = make_ttnn_unary_op(ttnn.hardswish)
@@ -2544,7 +2544,7 @@ transpose_nw = make_unary_op(partial(ttl.tensor.transpose, dim0=0, dim1=-1))
 transpose_cw = make_unary_op(partial(ttl.tensor.transpose, dim0=1, dim1=-1))
 eltwise_floor = make_unary_op_optional_output(ttnn.floor)
 eltwise_ceil = make_unary_op_optional_output(ttnn.ceil)
-eltwise_trunc = make_unary_op(ttl.tensor.trunc)
+eltwise_trunc = make_ttnn_unary_op(ttnn.trunc)
 eltwise_frac = make_unary_op(ttl.tensor.frac)
 
 

--- a/tests/tt_eager/python_api_testing/unit_testing/misc/test_pow_fractional.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/misc/test_pow_fractional.py
@@ -36,11 +36,11 @@ def test_pow_fractional_composite(device):
     yt_trunc = yt - yt_floor
     pow_trunc_log = ttnn.multiply(ttnn.log(xt), yt_trunc)
     pow_frac = ttnn.exp(pow_trunc_log)
-    xtt = ttnn.mul(ttl.tensor.pow(xt, yt_floor), pow_frac)
+    xtt = ttnn.mul(ttnn.pow(xt, yt_floor), pow_frac)
     assert list(xtt.get_legacy_shape()) == [N, C, H, W]
     tt_got_back = xtt.cpu().to(ttl.tensor.Layout.ROW_MAJOR).to_torch()
 
-    xtt_fp = ttl.tensor.pow(xt, yt)
+    xtt_fp = ttnn.pow(xt, yt.item())
     fp_tt_got_back = xtt_fp.cpu().to(ttl.tensor.Layout.ROW_MAJOR).to_torch()
 
     pt_ref = torch.pow(x, y)

--- a/tests/ttnn/profiling/ops_for_profiling.py
+++ b/tests/ttnn/profiling/ops_for_profiling.py
@@ -1508,11 +1508,11 @@ def repeat_interleave_2(x):
 
 
 def pow_int(x):
-    tt_lib.tensor.pow(x, 3)
+    ttnn.pow(x, 3)
 
 
 def pow_float(x):
-    tt_lib.tensor.pow(x, 3.3)
+    ttnn.pow(x, 3.3)
 
 
 def argmax_1(x):

--- a/ttnn/cpp/ttnn/deprecated/tt_dnn/op_library/composite/composite_ops.hpp
+++ b/ttnn/cpp/ttnn/deprecated/tt_dnn/op_library/composite/composite_ops.hpp
@@ -36,10 +36,6 @@ Tensor softshrink(
 Tensor hardshrink(
     const Tensor& a, float param, const MemoryConfig& output_mem_config = operation::DEFAULT_OUTPUT_MEMORY_CONFIG);
 
-// Function: softsign
-// Ref: https://pytorch.org/docs/stable/generated/torch.nn.Softsign.html
-Tensor softsign(const Tensor& a, const MemoryConfig& output_mem_config = operation::DEFAULT_OUTPUT_MEMORY_CONFIG);
-
 // Function: MAC
 // compute multiply-accumulate: y = a * b + c,  over various 8 combinations of a, b, c
 // being a scalar or tensor
@@ -51,21 +47,8 @@ Tensor mac(
 Tensor mac(
     const Tensor& a, float b, float c, const MemoryConfig& output_mem_config = operation::DEFAULT_OUTPUT_MEMORY_CONFIG);
 
-// Function Selu - scaled exponential linear
-// use transformation y = scale * alpha * (exp(X)-1) by broadcast
-// Ref: https://pytorch.org/docs/stable/generated/torch.nn.SELU.html
-Tensor selu(
-    const Tensor& x,
-    const float scale = 1.0507009873554804934193349852946,
-    const float alpha = 1.6732632423543772848170429916717,
-    const MemoryConfig& output_mem_config = operation::DEFAULT_OUTPUT_MEMORY_CONFIG);
-
 Tensor celu(
     const Tensor& x, float alpha, const MemoryConfig& output_mem_config = operation::DEFAULT_OUTPUT_MEMORY_CONFIG);
-
-// Function Swish = same as SILU
-// use transformation y = x * sigmoid( x ) by broadcast
-Tensor swish(const Tensor& a, const MemoryConfig& output_mem_config = operation::DEFAULT_OUTPUT_MEMORY_CONFIG);
 
 // compute polyval by Horner's rule
 Tensor polyval(
@@ -84,10 +67,6 @@ Tensor max(
     const Tensor& input_a,
     const Tensor& input_b,
     const MemoryConfig& output_mem_config = operation::DEFAULT_OUTPUT_MEMORY_CONFIG);
-
-// tanhshrink = x - tanh(x)
-Tensor tanhshrink(
-    const Tensor& input_a, const MemoryConfig& output_mem_config = operation::DEFAULT_OUTPUT_MEMORY_CONFIG);
 
 Tensor logical_andi(
     const Tensor& input_a,
@@ -159,8 +138,6 @@ Tensor fmod(
     const Tensor& input_b,
     const MemoryConfig& output_mem_config = operation::DEFAULT_OUTPUT_MEMORY_CONFIG);
 
-Tensor trunc(const Tensor& input, const MemoryConfig& output_mem_config = operation::DEFAULT_OUTPUT_MEMORY_CONFIG);
-
 Tensor frac(
     const Tensor& input,
     const MemoryConfig& output_mem_config = operation::DEFAULT_OUTPUT_MEMORY_CONFIG);
@@ -185,12 +162,6 @@ Tensor rfloor_div(
     const Tensor& input,
     const MemoryConfig& output_mem_config = operation::DEFAULT_OUTPUT_MEMORY_CONFIG);
 
-// xlogy(x,y))=x*log(y)
-Tensor xlogy(
-    const Tensor& input_a,
-    const Tensor& input_b,
-    const MemoryConfig& output_mem_config = operation::DEFAULT_OUTPUT_MEMORY_CONFIG);
-
 // logical_noti
 Tensor logical_noti(
     const Tensor& input_a,
@@ -213,13 +184,6 @@ atan2(y, x) =   x < 0 and y < 0 atan(y/x) - pi
 Tensor atan2(
     const Tensor& input_a,
     const Tensor& input_b,
-    const MemoryConfig& output_mem_config = operation::DEFAULT_OUTPUT_MEMORY_CONFIG);
-
-// subalpha(input,other,alpha)=input-alpha*other
-Tensor subalpha(
-    const Tensor& input_a,
-    const Tensor& input_b,
-    float alpha,
     const MemoryConfig& output_mem_config = operation::DEFAULT_OUTPUT_MEMORY_CONFIG);
 
 // addalpha(input, other, alpha) = input + (alpha * other)
@@ -257,69 +221,9 @@ Tensor scatter(
     const Tensor& input_b,
     const MemoryConfig& output_mem_config = operation::DEFAULT_OUTPUT_MEMORY_CONFIG);
 
-// threshold(a,t,v) = (a < t)*v + (a > t)*a
-Tensor threshold(
-    const Tensor& input_a,
-    float threshold,
-    float value,
-    const MemoryConfig& output_mem_config = operation::DEFAULT_OUTPUT_MEMORY_CONFIG);
 
 // cbrt(a) = pow(a,1/3) or (cbrt(a))**3 = a.
 Tensor cbrt(const Tensor& input_a, const MemoryConfig& output_mem_config = operation::DEFAULT_OUTPUT_MEMORY_CONFIG);
-
-// where - ternary operator y = (predicate) ? value_true : value_false; elementwise
-Tensor where(
-    uint8_t queue_id,
-    const Tensor& predicate,
-    const Tensor& value_true,
-    const Tensor& value_false,
-    const MemoryConfig& output_mem_config = operation::DEFAULT_OUTPUT_MEMORY_CONFIG,
-    std::optional<Tensor> output_tensor = std::nullopt);
-Tensor where(
-    uint8_t queue_id,
-    const Tensor& predicate,
-    const float value_true,
-    const Tensor& value_false,
-    const MemoryConfig& output_mem_config = operation::DEFAULT_OUTPUT_MEMORY_CONFIG,
-    std::optional<Tensor> output_tensor = std::nullopt);
-Tensor where(
-    uint8_t queue_id,
-    const Tensor& predicate,
-    const Tensor& value_true,
-    const float value_false,
-    const MemoryConfig& output_mem_config = operation::DEFAULT_OUTPUT_MEMORY_CONFIG,
-    std::optional<Tensor> output_tensor = std::nullopt);
-Tensor where(
-    uint8_t queue_id,
-    const Tensor& predicate,
-    const float value_true,
-    const float value_false,
-    const MemoryConfig& output_mem_config = operation::DEFAULT_OUTPUT_MEMORY_CONFIG,
-    std::optional<Tensor> output_tensor = std::nullopt);
-Tensor where(
-    const Tensor& predicate,
-    const Tensor& value_true,
-    const Tensor& value_false,
-    const MemoryConfig& output_mem_config = operation::DEFAULT_OUTPUT_MEMORY_CONFIG,
-    std::optional<Tensor> output_tensor = std::nullopt);
-Tensor where(
-    const Tensor& predicate,
-    const float value_true,
-    const Tensor& value_false,
-    const MemoryConfig& output_mem_config = operation::DEFAULT_OUTPUT_MEMORY_CONFIG,
-    std::optional<Tensor> output_tensor = std::nullopt);
-Tensor where(
-    const Tensor& predicate,
-    const Tensor& value_true,
-    const float value_false,
-    const MemoryConfig& output_mem_config = operation::DEFAULT_OUTPUT_MEMORY_CONFIG,
-    std::optional<Tensor> output_tensor = std::nullopt);
-Tensor where(
-    const Tensor& predicate,
-    const float value_true,
-    const float value_false,
-    const MemoryConfig& output_mem_config = operation::DEFAULT_OUTPUT_MEMORY_CONFIG,
-    std::optional<Tensor> output_tensor = std::nullopt);
 
 // on-device tensor creation 0s like @reference_tensor
 Tensor zeros_like(
@@ -434,8 +338,6 @@ Tensor logical_xori(
     const MemoryConfig& output_mem_config = operation::DEFAULT_OUTPUT_MEMORY_CONFIG);
 
 /** hyperbolic operations **/
-// sinh(x) = (exp(x) - exp(-x))/2
-Tensor sinh(const Tensor& input_a, const MemoryConfig& output_mem_config = operation::DEFAULT_OUTPUT_MEMORY_CONFIG);
 
 // digamma
 Tensor digamma(const Tensor& input_a, const MemoryConfig& output_mem_config = operation::DEFAULT_OUTPUT_MEMORY_CONFIG);
@@ -461,16 +363,6 @@ Tensor atanh(const Tensor& input_a, const MemoryConfig& output_mem_config = oper
  */
 Tensor outer(Tensor& a, Tensor& b, const MemoryConfig& output_mem_config = operation::DEFAULT_OUTPUT_MEMORY_CONFIG);
 
-// Function variance of whole tensor.
-// Tensor variance(const Tensor& y,const Tensor& mean_y);
-Tensor var_hw(const Tensor& y, const MemoryConfig& output_mem_config = operation::DEFAULT_OUTPUT_MEMORY_CONFIG);
-
-// Function std
-// compute standard deviation of tensor y = sqrt( E((y-<y>)^2)/ y.volume() )
-// Ref: torch.std
-Tensor std_hw(const Tensor& y, const MemoryConfig& output_mem_config = operation::DEFAULT_OUTPUT_MEMORY_CONFIG);
-// Tensor std(const Tensor& y,const Tensor& mean_y);
-
 Tensor normalize_global(
     const Tensor& y, const MemoryConfig& output_mem_config = operation::DEFAULT_OUTPUT_MEMORY_CONFIG);
 
@@ -493,40 +385,6 @@ Tensor triu(
     const Tensor& input_a,
     int32_t diag = 0,
     const MemoryConfig& output_mem_config = operation::DEFAULT_OUTPUT_MEMORY_CONFIG);
-
-// power_fp : power with floating point exponent
-Tensor power_fp(
-    uint8_t queue_id,
-    const Tensor& input_a,
-    float exponent,
-    const MemoryConfig& output_mem_config = operation::DEFAULT_OUTPUT_MEMORY_CONFIG,
-    std::optional<Tensor> output_tensor = std::nullopt);
-
-Tensor pow(
-    const Tensor& input_a,
-    float exponent,
-    const MemoryConfig& output_mem_config = operation::DEFAULT_OUTPUT_MEMORY_CONFIG,
-    std::optional<Tensor> output_tensor = std::nullopt);
-
-Tensor pow(
-    const Tensor& input_a,
-    int exponent,
-    const MemoryConfig& output_mem_config = operation::DEFAULT_OUTPUT_MEMORY_CONFIG,
-    std::optional<Tensor> output_tensor = std::nullopt);
-
-Tensor pow(
-    uint8_t queue_id,
-    const Tensor& input_a,
-    float exponent,
-    const MemoryConfig& output_mem_config = operation::DEFAULT_OUTPUT_MEMORY_CONFIG,
-    std::optional<Tensor> output_tensor = std::nullopt);
-
-Tensor pow(
-    uint8_t queue_id,
-    const Tensor& input_a,
-    int exponent,
-    const MemoryConfig& output_mem_config = operation::DEFAULT_OUTPUT_MEMORY_CONFIG,
-    std::optional<Tensor> output_tensor = std::nullopt);
 
 Tensor argmax(
     const Tensor& input_a,

--- a/ttnn/cpp/ttnn/deprecated/tt_dnn/op_library/optimizer/optimizer_ops.cpp
+++ b/ttnn/cpp/ttnn/deprecated/tt_dnn/op_library/optimizer/optimizer_ops.cpp
@@ -11,6 +11,7 @@
 
 #include "ttnn/operations/eltwise/binary/binary.hpp"
 #include "ttnn/operations/eltwise/unary/unary.hpp"
+#include "ttnn/cpp/ttnn/operations/eltwise/ternary/where_op.hpp"
 
 namespace tt {
 
@@ -53,7 +54,7 @@ std::vector<Tensor> _lamb_optimizer(const Tensor& data, const Tensor& grad, cons
     Tensor ones = ones_like(weight_norm, output_mem_config);
 
     Tensor trust_ratio_mid = ttnn::multiply(weight_norm, ttnn::reciprocal(ttnn::add(adam_norm, eps, std::nullopt, output_mem_config),output_mem_config), std::nullopt, output_mem_config);
-    Tensor trust_ratio = where(ttnn::gtz(weight_norm, output_mem_config), where(ttnn::gtz(adam_norm, output_mem_config), trust_ratio_mid, ones, output_mem_config), ones);
+    Tensor trust_ratio = ttnn::where(ttnn::gtz(weight_norm, output_mem_config), ttnn::where(ttnn::gtz(adam_norm, output_mem_config), trust_ratio_mid, ones, output_mem_config), ones);
 
     Tensor param = ttnn::subtract(
         data,

--- a/ttnn/cpp/ttnn/deprecated/tt_lib/csrc/tt_lib_bindings_tensor_composite_ops.cpp
+++ b/ttnn/cpp/ttnn/deprecated/tt_lib/csrc/tt_lib_bindings_tensor_composite_ops.cpp
@@ -14,66 +14,6 @@ namespace tt::tt_metal::detail {
 using ComplexTensor = ttnn::operations::complex_binary::ComplexTensor;
 
 void TensorModuleCompositeOPs(py::module& m_tensor) {
-    m_tensor.def(
-        "pow",
-        [](const Tensor& input,
-           const float exponent,
-           const MemoryConfig& output_mem_config,
-           std::optional<Tensor> output_tensor,
-           uint8_t queue_id) {
-            return pow(queue_id, input, exponent, output_mem_config, output_tensor);
-        },
-        py::arg("input"),
-        py::arg("exponent"),
-        py::arg("output_mem_config").noconvert() = operation::DEFAULT_OUTPUT_MEMORY_CONFIG,
-        py::arg("output_tensor").noconvert() = std::nullopt,
-        py::arg("queue_id").noconvert() = 0,
-        R"doc(
-            Returns a tensor filled with power of input ``input`` raised to value of ``exponent``.
-
-            Input tensor must have BFLOAT16 data type.
-
-            Output tensor will have BFLOAT16 data type.
-
-            .. csv-table::
-                :header: "Argument", "Description", "Data type", "Valid range", "Required"
-
-                "input", "Input tensor for which power is computed", "Tensor", "Tensor of any shape", "Yes"
-                "exponent", "exponent value", "float", "positive floating point value", "Yes"
-                "output_mem_config", "Layout of tensor in TT Accelerator device memory banks", "MemoryConfig", "Default is interleaved in DRAM", "No"
-                "output_tensor", "optional output tensor", "Tensor", "default is None", "No"
-                "queue_id", "Command queue id", "integer", "default to 0", "No"
-        )doc");
-    m_tensor.def(
-        "pow",
-        [](const Tensor& input,
-           const int exponent,
-           const MemoryConfig& output_mem_config,
-           std::optional<Tensor> output_tensor,
-           uint8_t queue_id) {
-            return pow(queue_id, input, exponent, output_mem_config, output_tensor);
-        },
-        py::arg("input"),
-        py::arg("exponent"),
-        py::arg("output_mem_config").noconvert() = operation::DEFAULT_OUTPUT_MEMORY_CONFIG,
-        py::arg("output_tensor").noconvert() = std::nullopt,
-        py::arg("queue_id").noconvert() = 0,
-        R"doc(
-            Returns a tensor filled with power of input ``input`` raised to value of ``exponent``.
-
-            Input tensor must have BFLOAT16 data type.
-
-            Output tensor will have BFLOAT16 data type.
-
-            .. csv-table::
-                :header: "Argument", "Description", "Data type", "Valid range", "Required"
-
-                "input", "Input tensor for which power is computed", "Tensor", "Tensor of any shape", "Yes"
-                "exponent", "exponent value", "integer", "positive integer value", "Yes"
-                "output_mem_config", "Layout of tensor in TT Accelerator device memory banks", "MemoryConfig", "Default is interleaved in DRAM", "No"
-                "output_tensor", "optional output tensor", "Tensor", "default is None", "No"
-                "queue_id", "Command queue id", "integer", "default to 0", "No"
-        )doc");
 
     m_tensor.def(
         "sfpu_eps",
@@ -119,150 +59,9 @@ void TensorModuleCompositeOPs(py::module& m_tensor) {
                 "output_mem_config", "Layout of tensor in TT Accelerator device memory banks", "MemoryConfig", "Default is interleaved in DRAM", "No"
         )doc");
 
-        m_tensor.def("where",
-        [](const Tensor& predicate,
-           const Tensor& value_true,
-           const Tensor& value_false,
-           const MemoryConfig& output_mem_config,
-           std::optional<Tensor> output_tensor,
-           uint8_t queue_id) {
-            return where(queue_id, predicate, value_true, value_false, output_mem_config, output_tensor);
-        },
-            py::arg("predicate"),
-            py::arg("true_value"),
-            py::arg("false_value"),
-            py::arg("output_mem_config").noconvert() = operation::DEFAULT_OUTPUT_MEMORY_CONFIG,
-            py::arg("output_tensor").noconvert() = std::nullopt,
-            py::arg("queue_id").noconvert() = 0,
-            R"doc(
-            Perform an ternary where operation on two tensors based on third @predicate.
-
-            where(predicate, true_value, false_value) implements (predicate) ? true_value : false_value.
-
-            All three input tensors must have BFLOAT16 data type, and be of equal shape.
-
-            Output tensor will have BFLOAT16 data type.
-
-            .. csv-table::
-                :header: "Argument", "Description", "Data type", "Valid range", "Required"
-
-                "predicate", "Predicate Tensor", "Tensor", "Tensor of shape [W, Z, Y, X]", "Yes"
-                "true_value", "True Tensor", "Tensor", "Tensor of shape [W, Z, Y, X]", "Yes"
-                "false_value", "False Tensor", "Tensor", "Tensor of shape [W, Z, Y, X]", "Yes"
-                "output_mem_config", "Layout of tensor in TT Accelerator device memory banks", "MemoryConfig", "Default is interleaved in DRAM", "No"
-                "output_tensor", "optional output tensor", "Tensor", "default is None", "No"
-                "queue_id", "queue_id", "uint8_t", "Default is 0", "No"
-        )doc");
-        m_tensor.def("where",
-        [](const Tensor& predicate,
-           const float value_true,
-           const Tensor& value_false,
-           const MemoryConfig& output_mem_config,
-           std::optional<Tensor> output_tensor,
-           uint8_t queue_id) {
-            return where(queue_id, predicate, value_true, value_false, output_mem_config, output_tensor);
-        },
-            py::arg("predicate"),
-            py::arg("true_value"),
-            py::arg("false_value"),
-            py::arg("output_mem_config").noconvert() = operation::DEFAULT_OUTPUT_MEMORY_CONFIG,
-            py::arg("output_tensor").noconvert() = std::nullopt,
-            py::arg("queue_id").noconvert() = 0,
-            R"doc(
-            Perform an ternary where operation on two tensors based on third @predicate.
-
-            where(predicate, true_value, false_value) implements (predicate) ? true_value : false_value.
-
-            All three input tensors must have BFLOAT16 data type, and be of equal shape.
-
-            Output tensor will have BFLOAT16 data type.
-
-            .. csv-table::
-                :header: "Argument", "Description", "Data type", "Valid range", "Required"
-
-                "predicate", "Predicate Tensor", "Tensor", "Tensor of shape [W, Z, Y, X]", "Yes"
-                "true_value", "float", "float", "float scalar", "Yes"
-                "false_value", "Tensor", "Tensor", "Tensor of shape [W, Z, Y, X]", "Yes"
-                "output_mem_config", "Layout of tensor in TT Accelerator device memory banks", "MemoryConfig", "Default is interleaved in DRAM", "No"
-                "output_tensor", "optional output tensor", "Tensor", "default is None", "No"
-                "queue_id", "queue_id", "uint8_t", "Default is 0", "No"
-        )doc");
-        m_tensor.def("where",
-        [](const Tensor& predicate,
-           const Tensor& value_true,
-           const float value_false,
-           const MemoryConfig& output_mem_config,
-           std::optional<Tensor> output_tensor,
-           uint8_t queue_id) {
-            return where(queue_id, predicate, value_true, value_false, output_mem_config, output_tensor);
-        },
-            py::arg("predicate"),
-            py::arg("true_value"),
-            py::arg("false_value"),
-            py::arg("output_mem_config").noconvert() = operation::DEFAULT_OUTPUT_MEMORY_CONFIG,
-            py::arg("output_tensor").noconvert() = std::nullopt,
-            py::arg("queue_id").noconvert() = 0,
-            R"doc(
-            Perform an ternary where operation on two tensors based on third @predicate.
-
-            where(predicate, true_value, false_value) implements (predicate) ? true_value : false_value.
-
-            All three input tensors must have BFLOAT16 data type, and be of equal shape.
-
-            Output tensor will have BFLOAT16 data type.
-
-            .. csv-table::
-                :header: "Argument", "Description", "Data type", "Valid range", "Required"
-
-                "predicate", "Predicate Tensor", "Tensor", "Tensor of shape [W, Z, Y, X]", "Yes"
-                "true_value", "True Tensor", "Tensor", "Tensor of shape [W, Z, Y, X]", "Yes"
-                "false_value", "float", "float", "float scalar", "Yes"
-                "output_mem_config", "Layout of tensor in TT Accelerator device memory banks", "MemoryConfig", "Default is interleaved in DRAM", "No"
-                "output_tensor", "optional output tensor", "Tensor", "default is None", "No"
-                "queue_id", "queue_id", "uint8_t", "Default is 0", "No"
-        )doc");
-        m_tensor.def("where",
-        [](const Tensor& predicate,
-           const float value_true,
-           const float value_false,
-           const MemoryConfig& output_mem_config,
-           std::optional<Tensor> output_tensor,
-           uint8_t queue_id) {
-            return where(queue_id, predicate, value_true, value_false, output_mem_config, output_tensor);
-        },
-            py::arg("predicate"),
-            py::arg("true_value"),
-            py::arg("false_value"),
-            py::arg("output_mem_config").noconvert() = operation::DEFAULT_OUTPUT_MEMORY_CONFIG,
-            py::arg("output_tensor").noconvert() = std::nullopt,
-            py::arg("queue_id").noconvert() = 0,
-            R"doc(
-            Perform an ternary where operation on two tensors based on third @predicate.
-
-            where(predicate, true_value, false_value) implements (predicate) ? true_value : false_value.
-
-            All three input tensors must have BFLOAT16 data type, and be of equal shape.
-
-            Output tensor will have BFLOAT16 data type.
-
-            .. csv-table::
-                :header: "Argument", "Description", "Data type", "Valid range", "Required"
-
-                "predicate", "Predicate Tensor", "Tensor", "Tensor of shape [W, Z, Y, X]", "Yes"
-                "true_value", "float", "float", "Tensor of shape [W, Z, Y, X]", "Yes"
-                "false_value", "float", "float", "float scalar", "Yes"
-                "output_mem_config", "Layout of tensor in TT Accelerator device memory banks", "MemoryConfig", "Default is interleaved in DRAM", "No"
-                "output_tensor", "optional output tensor", "Tensor", "default is None", "No"
-                "queue_id", "queue_id", "uint8_t", "Default is 0", "No"
-        )doc");
         // *** composite unary ops ***
         detail::bind_unary_op(m_tensor, "normalize_global", tt::tt_metal::normalize_global, R"doc(Returns a new tensor with the Gaussian normalize of the elements of the input tensor ``{0}`` on N,C,H,W axes.)doc");
-        detail::bind_unary_op(m_tensor, "var_hw", tt::tt_metal::var_hw, R"doc(  Returns a new tensor with the variance of the input tensor ``{0}`` on H,W axes.)doc");
-        detail::bind_unary_op(m_tensor, "std_hw", tt::tt_metal::std_hw, R"doc(Returns a new tensor with the standard deviation of the input tensor ``{0}`` on H,W axes.)doc");
-        detail::bind_unary_op(m_tensor, "sinh", &tt::tt_metal::sinh, R"doc(Returns tensor with the hyperbolic sine of elements of the input tensor ``{0}`` in range [-9,9] with high accuracy.)doc");
         detail::bind_unary_op(m_tensor, "cosh", &tt::tt_metal::cosh, R"doc(Returns tensor with the hyperbolic cosine of elements of the input tensor ``{0}`` in range [-9,9] with high accuracy.)doc");
-        detail::bind_unary_op(m_tensor, "softsign", &softsign, R"doc(Applies the softsign function to the elements of the input tensor ``{0}``.)doc");
-        detail::bind_unary_op(m_tensor, "swish", swish, R"doc(Returns tensor with the swish all of elements of the input tensor ``{0}``.)doc");
         detail::bind_unary_op(m_tensor, "cbrt", &cbrt, R"doc(Returns tensor with the cbrt activation of elements of the input tensor ``{0}``.)doc");
         detail::bind_unary_op(m_tensor, "asinh", &asinh, R"doc(Returns tensor with the inverse hyperbolic sine of elements of the input tensor ``{0}`` in range [-1e-6, 1e6].
             for +input , output = asinh(input)
@@ -275,13 +74,6 @@ void TensorModuleCompositeOPs(py::module& m_tensor) {
             for  input > 1, output = acosh(input)
             for  input ==1, ouptut = 0
             for  input < 1, output =  nan)doc");
-    detail::bind_unary_op(
-        m_tensor,
-        "tanhshrink",
-        &tanhshrink,
-        R"doc(Applies tanh on the input tensor ``{0}`` and subtracted from the input tensor.
-
-            ``tanhshrink(x) = x - tanh(x)``)doc");
     detail::bind_unary_op(
         m_tensor,
         "digamma",
@@ -505,29 +297,6 @@ void TensorModuleCompositeOPs(py::module& m_tensor) {
 
                 "input", "Tensor celu is applied to", "Tensor", "Tensor of shape [W, Z, Y, X]", "Yes"
                 "alpha", "alpha value (PyTorch default)", "float", "default to 1.0", "Yes"
-                "output_mem_config", "Layout of tensor in TT Accelerator device memory banks", "MemoryConfig", "Default is interleaved in DRAM", "No"
-        )doc");
-
-    m_tensor.def(
-        "subalpha",
-        &subalpha,
-        py::arg("input_a").noconvert(),
-        py::arg("input_b").noconvert(),
-        py::arg("alpha") = 1.0f,
-        py::arg("output_mem_config").noconvert() = operation::DEFAULT_OUTPUT_MEMORY_CONFIG,
-        R"doc(
-            Subtracts ``input_b``, scaled by ``alpha``, from ``input_a``.
-
-            Input tensor must have BFLOAT16 data type.
-
-            Output tensor will have BFLOAT16 data type.
-
-            .. csv-table::
-                :header: "Argument", "Description", "Data type", "Valid range", "Required"
-
-                "input_a", "Tensor subalpha is applied to", "Tensor", "Tensor of shape [W, Z, Y, X]", "Yes"
-                "input_b", "Tensor", "Tensor", "Tensor of shape [W, Z, Y, X]", "Yes"
-                "alpha", "Alpha value", "float", "default to 1.0f", "No"
                 "output_mem_config", "Layout of tensor in TT Accelerator device memory banks", "MemoryConfig", "Default is interleaved in DRAM", "No"
         )doc");
 
@@ -1110,21 +879,6 @@ void TensorModuleCompositeOPs(py::module& m_tensor) {
                 "output_mem_config", "Layout of tensor in TT Accelerator device memory banks", "MemoryConfig", "Default is interleaved in DRAM", "No"
         )doc");
 
-        m_tensor.def("trunc",&trunc,
-            py::arg("input").noconvert(),py::arg("output_mem_config").noconvert() = operation::DEFAULT_OUTPUT_MEMORY_CONFIG,R"doc(
-            Performs the element-wise trunc operation on ``input``. Support provided only for Wormhole_B0.
-
-            Input tensor must have BFLOAT16 data type.
-
-            Output tensor will have BFLOAT16 data type.
-
-            .. csv-table::
-                :header: "Argument", "Description", "Data type", "Valid range", "Required"
-
-                "input", "Input Tensor", "Tensor", "Tensor of shape [W, Z, Y, X]", "Yes"
-                "output_mem_config", "Layout of tensor in TT Accelerator device memory banks", "MemoryConfig", "Default is interleaved in DRAM", "No"
-        )doc");
-
         m_tensor.def("frac",&frac,
             py::arg("input").noconvert(),py::arg("output_mem_config").noconvert() = operation::DEFAULT_OUTPUT_MEMORY_CONFIG,R"doc(
             Performs the element-wise frac operation on ``input``. Support provided only for Wormhole_B0.
@@ -1245,30 +999,6 @@ void TensorModuleCompositeOPs(py::module& m_tensor) {
         )doc");
 
     m_tensor.def(
-        "threshold",
-        &threshold,
-        py::arg("input").noconvert(),
-        py::arg("threshold"),
-        py::arg("value"),
-        py::arg("output_mem_config").noconvert() = operation::DEFAULT_OUTPUT_MEMORY_CONFIG,
-        R"doc(
-            Returns tensor with the threshold activation on elements of the input tensors ``arg0`` at threshold ``threshold``,
-            and value ``value``.
-
-            Input tensor must have BFLOAT16 data type.
-
-            Output tensor will have BFLOAT16 data type.
-
-            .. csv-table::
-                :header: "Argument", "Description", "Data type", "Valid range", "Required"
-
-                "input", "Tensor threshold is applied to", "Tensor", "Tensor of shape [W, Z, Y, X]", "Yes"
-                "threshold", "Value to threshold at", "float", "", "Yes"
-                "value", "Value to replace with", "float", "", "Yes"
-                "output_mem_config", "Layout of tensor in TT Accelerator device memory banks", "MemoryConfig", "Default is interleaved in DRAM", "No"
-        )doc");
-
-    m_tensor.def(
         "lamb_optimizer",
         &lamb_optimizer,
         py::arg("data").noconvert(),
@@ -1360,7 +1090,6 @@ void TensorModuleCompositeOPs(py::module& m_tensor) {
         detail::bind_binary_op<false, true, false, false>(m_tensor, "max", &tt::tt_metal::max, R"doc(Perform an eltwise-binary max on two tensors.)doc");
         detail::bind_binary_op<false, true, false, false>(m_tensor, "min", &tt::tt_metal::min, R"doc(Perform an eltwise-binary min on two tensors.)doc");
         detail::bind_binary_op<false, true, false, false>(m_tensor, "scatter", &tt::tt_metal::scatter, R"doc(Performs scatter operation on elements of the input tensors ``{0}`` and ``{1}``,specifically to copy channel data.)doc");
-        detail::bind_binary_op<false, true, false, false>(m_tensor, "xlogy", &xlogy, R"doc(Performs eltwise-binary xlogy (``{0} * log( {1} )``) on two tensors.)doc");
         detail::bind_binary_op<false, true, false, false>(m_tensor, "atan2", &atan2, R"doc(Returns tensor with the atan2 activation on elements of the input tensors ``{0}`` and ``{1}``.)doc");
 
 	    // *** type-2 complex operations in new submodule 'type2_complex' ***

--- a/ttnn/cpp/ttnn/operations/eltwise/complex_binary_backward/device/complex_binary_backward_op.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/complex_binary_backward/device/complex_binary_backward_op.cpp
@@ -10,6 +10,7 @@
 #include "ttnn/operations/eltwise/binary/binary.hpp"
 #include "ttnn/operations/eltwise/complex_binary/device/complex_binary_op.hpp"
 #include "ttnn/operations/eltwise/complex_unary/complex_unary.hpp"
+#include "ttnn/cpp/ttnn/operations/eltwise/ternary/where_op.hpp"
 
 namespace ttnn::operations::complex_binary_backward {
 using ComplexTensor = complex_binary::ComplexTensor;

--- a/ttnn/cpp/ttnn/operations/eltwise/complex_unary_backward/device/complex_unary_backward_op.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/complex_unary_backward/device/complex_unary_backward_op.cpp
@@ -14,6 +14,8 @@
 #include "ttnn/operations/eltwise/complex_unary/device/complex_unary_op.hpp"
 #include "ttnn/operations/eltwise/complex_binary/device/complex_binary_op.hpp"
 #include "ttnn/operations/eltwise/complex_unary/complex_unary.hpp"
+#include "ttnn/cpp/ttnn/operations/eltwise/ternary/where_op.hpp"
+
 
 namespace ttnn::operations::complex_unary_backward {
 using ComplexTensor = complex_binary::ComplexTensor;

--- a/ttnn/cpp/ttnn/operations/eltwise/ternary_backward/device/ternary_backward_op.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/ternary_backward/device/ternary_backward_op.cpp
@@ -8,6 +8,7 @@
 #include "ttnn/operations/eltwise/unary/unary.hpp"
 #include "ttnn/operations/eltwise/binary/binary.hpp"
 #include "ttnn/deprecated/tt_dnn/op_library/bcast/bcast_op.hpp"
+#include "ttnn/cpp/ttnn/operations/eltwise/ternary/where_op.hpp"
 
 #include "tt_metal/common/constants.hpp"
 #include "tt_metal/host_api.hpp"
@@ -75,9 +76,9 @@ std::vector<OptionalTensor> _where_bw(
     std::vector<OptionalTensor> result;
     if (are_required_outputs.at(0)) {
         if(input_grad.has_value()){
-            tt::tt_metal::where(queue_id, condition, grad, 0.0f, output_mem_config, input_grad);
+            where(queue_id, condition, grad, 0.0f, output_mem_config, input_grad);
         } else {
-            input_grad = tt::tt_metal::where(queue_id, condition, grad, 0.0f, output_mem_config);
+            input_grad = where(queue_id, condition, grad, 0.0f, output_mem_config);
         }
         result.emplace_back(input_grad);
     } else {
@@ -85,9 +86,9 @@ std::vector<OptionalTensor> _where_bw(
     }
     if (are_required_outputs.at(1)) {
         if(other_grad.has_value()){
-            tt::tt_metal::where(queue_id, condition, 0.0f, grad, output_mem_config, other_grad);
+            where(queue_id, condition, 0.0f, grad, output_mem_config, other_grad);
         } else {
-            other_grad = tt::tt_metal::where(queue_id, condition, 0.0f, grad, output_mem_config);
+            other_grad = where(queue_id, condition, 0.0f, grad, output_mem_config);
         }
         result.emplace_back(other_grad);
     } else {

--- a/ttnn/cpp/ttnn/operations/eltwise/unary/device/unary_composite_op.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary/device/unary_composite_op.cpp
@@ -13,6 +13,7 @@
 #include "ttnn/deprecated/tt_dnn/op_library/reshape/reshape_op.hpp"
 #include "ttnn/deprecated/tt_numpy/functions.hpp"
 #include "ttnn/operations/data_movement/slice/slice.hpp"
+#include "ttnn/operations/eltwise/unary/unary_composite.hpp"
 #include "ttnn/run_operation.hpp"
 #include "ttnn/types.hpp"
 
@@ -367,6 +368,8 @@ Tensor _trunc(const Tensor& input, const std::optional<MemoryConfig>& output_mem
     return result;
 }
 
+// Function variance of whole tensor.
+// Tensor variance(const Tensor& y,const Tensor& mean_y);
 Tensor _variance_impl(
     const Tensor& y, const Tensor& mean_y, Tensor& y_minus_mean_y, const std::optional<MemoryConfig>& output_mem_config) {
     constexpr float correction = 0.0f;
@@ -773,7 +776,7 @@ Tensor _normalize_global(const Tensor& y,  const std::optional<MemoryConfig>& ou
 Tensor _frac(const Tensor& input, const std::optional<MemoryConfig>& output_mem_config) {
     auto arch = input.device()->arch();
     TT_FATAL(arch == tt::ARCH::WORMHOLE_B0, "Op is only supported on Wormhole");
-    Tensor trunc_res = trunc(input);
+    Tensor trunc_res = ttnn::trunc(input);
     Tensor result = ttnn::subtract(input, trunc_res, std::nullopt, output_mem_config);
     return result;
 }

--- a/ttnn/cpp/ttnn/operations/experimental/reduction/argmax/argmax.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/reduction/argmax/argmax.cpp
@@ -6,6 +6,7 @@
 #include "ttnn/operations/data_movement/permute/permute.hpp"
 #include "ttnn/operations/eltwise/binary/binary.hpp"
 #include "ttnn/operations/experimental/reduction/argmax/argmax.hpp"
+#include "ttnn/cpp/ttnn/operations/eltwise/ternary/where_op.hpp"
 
 namespace ttnn::operations::experimental::reduction {
 
@@ -16,7 +17,7 @@ Tensor create_mask(const Tensor& input_a, const std::optional<MemoryConfig>& out
         return input_a;
     float t_inf = -std::numeric_limits<float>::infinity();
     Tensor masked_input = tt::numpy::mask_padded_input<::bfloat16>(padded_shape, unpadded_shape, DataType::BFLOAT16);
-    masked_input = where(masked_input, input_a, t_inf, output_mem_config.value());
+    masked_input = ttnn::where(masked_input, input_a, t_inf, output_mem_config.value());
     return masked_input;
 }
 // Argmax returns the index of maximum element in the tensor
@@ -57,11 +58,11 @@ Tensor _argmax(const Tensor& input_t, int64_t _dim, bool all, const std::optiona
                     Tensor cmp_results = ttnn::eq(input_a, max_tensor, std::nullopt, output_memory_config);
                     Tensor max_indices = ttnn::multiply(cmp_results, tindex, std::nullopt, output_memory_config);
                     cmp_results.deallocate();
-                    Tensor result = where(ttnn::eqz(max_indices), size, max_indices, output_memory_config);
+                    Tensor result = ttnn::where(ttnn::eqz(max_indices), size, max_indices, output_memory_config);
                     max_indices.deallocate();
                     result = min(result, dim, output_memory_config);
                     Tensor res_index = ttnn::zeros_like(result);
-                    result = where(ttnn::eq(result, size), res_index, result, output_memory_config);
+                    result = ttnn::where(ttnn::eq(result, size), res_index, result, output_memory_config);
                     std::vector<int64_t> permute_dims = {3, 0, 1, 2};
                     if (is_width) {
                         res_index = ttnn::add(res_index, result, std::nullopt, output_memory_config);
@@ -95,10 +96,10 @@ Tensor _argmax(const Tensor& input_t, int64_t _dim, bool all, const std::optiona
                     Tensor max_indices = ttnn::multiply(cmp_results, tindex, std::nullopt, output_memory_config);
                     cmp_results.deallocate();
                     Tensor midx = full_like(max_indices, size);
-                    Tensor result = where(ttnn::eqz(max_indices), midx, max_indices, output_memory_config);
+                    Tensor result = ttnn::where(ttnn::eqz(max_indices), midx, max_indices, output_memory_config);
                     result = min(result, dim, output_memory_config);
                     Tensor res_index = ttnn::zeros_like(result);
-                    result = where(ttnn::eq(result, full_like(result, size)), res_index, result, output_memory_config);
+                    result = ttnn::where(ttnn::eq(result, full_like(result, size)), res_index, result, output_memory_config);
                     if (is_channel) {
                         std::vector<int64_t> permute_dims = {1, 0, 2, 3};
                         Tensor transpose_res = ttnn::permute(result, permute_dims, output_memory_config);
@@ -119,7 +120,7 @@ Tensor _argmax(const Tensor& input_t, int64_t _dim, bool all, const std::optiona
             Tensor cmp_results = ttnn::eq(input_a, max_tensor, std::nullopt, output_memory_config);
             Tensor max_indices = ttnn::multiply(cmp_results, tindex, std::nullopt, output_memory_config);
             cmp_results.deallocate();
-            Tensor result = where(ttnn::eqz(max_indices), size, max_indices, output_memory_config);
+            Tensor result = ttnn::where(ttnn::eqz(max_indices), size, max_indices, output_memory_config);
             max_indices.deallocate();
             result = global_min(result, output_memory_config);
             return {result};

--- a/ttnn/cpp/ttnn/operations/reduction/generic/generic_reductions.hpp
+++ b/ttnn/cpp/ttnn/operations/reduction/generic/generic_reductions.hpp
@@ -13,6 +13,7 @@
 #include "ttnn/operations/core/core.hpp"
 #include "ttnn/operations/eltwise/binary/binary.hpp"
 #include "ttnn/operations/eltwise/unary/unary.hpp"
+#include "ttnn/operations/eltwise/unary/unary_composite.hpp"
 
 namespace ttnn {
 namespace operations::reduction {
@@ -128,14 +129,14 @@ struct Reduce {
                 auto mean_tensor = tt::tt_metal::reduce(
                     input_tensor, tt::tt_metal::ReduceOpMath::SUM, reduce_op_dim, 1.0 / reduced_volume, memory_config);
                 auto mean_square_tensor = tt::tt_metal::reduce(
-                    tt::tt_metal::pow(input_tensor, 2.0f, memory_config),
+                    ttnn::pow(input_tensor, 2.0f, memory_config),
                     tt::tt_metal::ReduceOpMath::SUM,
                     reduce_op_dim,
                     1.0 / reduced_volume,
                     memory_config);
                 output_tensor = ttnn::subtract(
                     mean_square_tensor,
-                    tt::tt_metal::pow(mean_tensor, 2.0f, memory_config),
+                    ttnn::pow(mean_tensor, 2.0f, memory_config),
                     std::nullopt,
                     memory_config);
                 if constexpr (reduce_type == ReduceType::Std) {


### PR DESCRIPTION
### Ticket
Link to Github Issue #10641

### Problem description
To remove composite ops from tt_eager
- [x] pow
- [x] power_fp
- [x] rad2deg
- [x] selu
- [x] sinh
- [x] softsign
- [x] std_hw
- [x] subalpha
- [x] swish
- [x] tanhshrink
- [x] threshold
- [x] trunc
- [x] var_hw
- [x] where
- [x] xlogy


### What's changed
replace tt_eager apis with corresponding ttnn apis

### Checklist
- [x] Post commit CI https://github.com/tenstorrent/tt-metal/actions/runs/10155752270
- [x] Post commit models https://github.com/tenstorrent/tt-metal/actions/runs/10151173739
- [ ] Nightly fast dispatch  same as main https://github.com/tenstorrent/tt-metal/actions/runs/10151170717
- [x] post commit C++ https://github.com/tenstorrent/tt-metal/actions/runs/10141684074
- [x] Model regression CI testing passes https://github.com/tenstorrent/tt-metal/actions/runs/10141672136
- [x] t3k unit tests https://github.com/tenstorrent/tt-metal/actions/runs/10141662613
- [x] New/Existing tests provide coverage for changes
