### PR TITLE
#10821: Migrate outer, scatter, polyval

### DIFF
--- a/docs/source/ttnn/ttnn/api.rst
+++ b/docs/source/ttnn/ttnn/api.rst
@@ -314,10 +314,12 @@ Pointwise Binary
    ttnn/eq
    ttnn/ne
    ttnn/isclose
-   ttnn/polyval
    ttnn/nextafter
    ttnn/maximum
    ttnn/minimum
+   ttnn/outer
+   ttnn/polyval
+   ttnn/scatter
    ttnn/atan2_bw
    ttnn/embedding_bw
    ttnn/addalpha_bw

--- a/docs/source/ttnn/ttnn/ttnn/outer.rst
+++ b/docs/source/ttnn/ttnn/ttnn/outer.rst
@@ -1,0 +1,6 @@
+.. _ttnn.outer:
+
+ttnn.outer
+############
+
+.. autofunction:: ttnn.outer

--- a/docs/source/ttnn/ttnn/ttnn/scatter.rst
+++ b/docs/source/ttnn/ttnn/ttnn/scatter.rst
@@ -1,0 +1,6 @@
+.. _ttnn.scatter:
+
+ttnn.scatter
+############
+
+.. autofunction:: ttnn.scatter

--- a/tests/tt_eager/python_api_testing/sweep_tests/tt_lib_ops.py
+++ b/tests/tt_eager/python_api_testing/sweep_tests/tt_lib_ops.py
@@ -475,7 +475,7 @@ def eltwise_polyval(
     **kwargs,
 ):
     t0 = setup_tt_tensor(x, device, layout[0], input_mem_config[0], dtype[0])
-    t1 = ttl.tensor.polyval(t0, coeffs, output_mem_config=output_mem_config)
+    t1 = ttnn.polyval(t0, coeffs, memory_config=output_mem_config)
 
     return tt2torch_tensor(t1)
 
@@ -2618,9 +2618,9 @@ eltwise_min = make_binary_op(ttl.tensor.min)
 eltwise_max = make_binary_op(ttl.tensor.max)
 
 matmul = make_binary_op_ttnn(ttnn.matmul)
-outer = make_binary_op(ttl.tensor.outer)
+outer = make_binary_op_ttnn(ttnn.outer)
 
-eltwise_scatter = make_binary_op(ttl.tensor.scatter)
+eltwise_scatter = make_binary_op_ttnn(ttnn.scatter)
 eltwise_nextafter = make_binary_op_ttnn(ttnn.nextafter)
 eltwise_remainder = make_binary_op(ttl.tensor.remainder)
 eltwise_fmod = make_binary_op(ttl.tensor.fmod)

--- a/tests/ttnn/unit_tests/operations/test_binary_composite.py
+++ b/tests/ttnn/unit_tests/operations/test_binary_composite.py
@@ -446,3 +446,43 @@ def test_binary_logical_xor__ttnn(input_shapes, device):
 
     comp_pass = compare_pcc([input_tensor1], [golden_tensor])
     assert comp_pass
+
+
+@pytest.mark.parametrize(
+    "input_shapes",
+    (
+        (torch.Size([1, 1, 32, 32])),
+        (torch.Size([1, 1, 320, 384])),
+        (torch.Size([1, 3, 320, 384])),
+    ),
+)
+def test_binary_scatter_ttnn(input_shapes, device):
+    in_data1, input_tensor1 = data_gen_with_range(input_shapes, -100, 100, device)
+    in_data2, input_tensor2 = data_gen_with_range(input_shapes, -150, 150, device)
+
+    output_tensor = ttnn.scatter(input_tensor1, input_tensor2)
+    golden_function = ttnn.get_golden_function(ttnn.scatter)
+    golden_tensor = golden_function(in_data1, in_data2)
+
+    comp_pass = compare_pcc([output_tensor], [golden_tensor])
+    assert comp_pass
+
+
+@pytest.mark.parametrize(
+    "input_shapes",
+    (
+        (torch.Size([1, 1, 32, 32])),
+        (torch.Size([1, 1, 320, 384])),
+        (torch.Size([1, 3, 320, 384])),
+    ),
+)
+@pytest.mark.parametrize("coeffs", [[0.0], [-5.0, 2.0], [-3.0, 0.0, 10.0], [-100.0, -25.0, 0.0, 15.0, 100.0]])
+def test_binary_polyval_ttnn(input_shapes, coeffs, device):
+    in_data1, input_tensor1 = data_gen_with_range(input_shapes, -100, 100, device)
+
+    output_tensor = ttnn.polyval(input_tensor1, coeffs)
+    golden_function = ttnn.get_golden_function(ttnn.polyval)
+    golden_tensor = golden_function(in_data1, coeffs)
+
+    comp_pass = compare_pcc([output_tensor], [golden_tensor])
+    assert comp_pass

--- a/ttnn/cpp/ttnn/operations/eltwise/binary/binary_composite.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary/binary_composite.hpp
@@ -142,7 +142,17 @@ struct ExecuteBiasGelu {
 
             return operator()(DefaultQueueId, input_tensor_a, bias, dtype, memory_config, optional_output_tensor, activations);
     }
+};
 
+template <BinaryCompositeOpType binary_comp_op_type>
+struct ExecuteBinaryCompositeOpsPolyval
+{
+    static Tensor operator()(
+        const Tensor& input_tensor_a,
+        const std::vector<float>& coeffs,
+        const std::optional<MemoryConfig>& memory_config = std::nullopt) {
+        return OpHandler<binary_comp_op_type>::handle(input_tensor_a, coeffs, memory_config);
+    }
 };
 
 }  // namespace binary
@@ -205,5 +215,14 @@ constexpr auto logical_xor_ = ttnn::register_operation_with_auto_launch_op<
 constexpr auto bias_gelu = ttnn::register_operation_with_auto_launch_op<
     "ttnn::bias_gelu",
     operations::binary::ExecuteBiasGelu<operations::binary::BinaryOpType::BIAS_GELU, false>>();
+constexpr auto scatter = ttnn::register_operation_with_auto_launch_op<
+    "ttnn::scatter",
+    operations::binary::ExecuteBinaryCompositeOps<operations::binary::BinaryCompositeOpType::SCATTER>>();
+constexpr auto outer = ttnn::register_operation_with_auto_launch_op<
+    "ttnn::outer",
+    operations::binary::ExecuteBinaryCompositeOps<operations::binary::BinaryCompositeOpType::OUTER>>();
+constexpr auto polyval = ttnn::register_operation_with_auto_launch_op<
+    "ttnn::polyval",
+    operations::binary::ExecuteBinaryCompositeOpsPolyval<operations::binary::BinaryCompositeOpType::POLYVAL>>();
 
 }  // namespace ttnn

--- a/ttnn/cpp/ttnn/operations/eltwise/binary/binary_pybind.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary/binary_pybind.hpp
@@ -286,13 +286,16 @@ template <typename binary_operation_t>
 void bind_div(py::module& module, const binary_operation_t& operation, const std::string& description) {
     auto doc = fmt::format(
         R"doc({0}(input_tensor_a: ttnn.Tensor, input_tensor_b: ttnn.Tensor, *, memory_config: Optional[ttnn.MemoryConfig] = None) -> ttnn.Tensor
+
             Args:
                 * :attr:`input_tensor_a`
                 * :attr:`input_tensor_b` (ttnn.Tensor or Number)
                 * :attr:`accurate_mode`: ``false`` if input_tensor_b is non-zero, else ``true``.
                 * :attr:`round_mode`
+
             Keyword Args:
                 * :attr:`memory_config` (Optional[ttnn.MemoryConfig]): Memory configuration for the operation.
+
             Example:
                 >>> tensor1 = ttnn.to_device(ttnn.from_torch(torch.tensor((1, 2), dtype=torch.bfloat16)), device)
                 >>> tensor2 = ttnn.to_device(ttnn.from_torch(torch.tensor((0, 1), dtype=torch.bfloat16)), device)
@@ -336,6 +339,44 @@ void bind_div(py::module& module, const binary_operation_t& operation, const std
             py::kw_only(),
             py::arg("accurate_mode") = false,
             py::arg("round_mode") = "None",
+            py::arg("memory_config") = std::nullopt});
+}
+
+template <typename binary_operation_t>
+void bind_polyval(py::module& module, const binary_operation_t& operation, const std::string& description) {
+    auto doc = fmt::format(
+        R"doc({0}(input_tensor_a: ttnn.Tensor, coeffs: Vector of floats, *, memory_config: Optional[ttnn.MemoryConfig] = None) -> ttnn.Tensor
+
+            Args:
+                * :attr:`input_tensor_a`
+                * :attr:`coeffs` (Vector of floats)
+
+            Keyword Args:
+                * :attr:`memory_config` (Optional[ttnn.MemoryConfig]): Memory configuration for the operation.
+
+            Example:
+                >>> tensor1 = ttnn.to_device(ttnn.from_torch(torch.tensor((1, 2), dtype=torch.bfloat16)), device)
+                >>> coeffs = (1, 2, 3, 4)
+                >>> output = {1}(tensor1, coeffs)
+        )doc",
+        operation.base_name(),
+        operation.python_fully_qualified_name(),
+        description);
+
+    bind_registered_operation(
+        module,
+        operation,
+        doc,
+        ttnn::pybind_overload_t{
+            [](const binary_operation_t& self,
+            const Tensor& input_tensor_a,
+            const std::vector<float>& coeffs,
+            const std::optional<MemoryConfig>& memory_config) {
+                    return self(input_tensor_a, coeffs, memory_config);
+                },
+            py::arg("input_tensor_a"),
+            py::arg("coeffs"),
+            py::kw_only(),
             py::arg("memory_config") = std::nullopt});
 }
 
@@ -571,6 +612,24 @@ void py_module(py::module& module) {
         ttnn::floor_div,
         R"doc(Compute floor division :attr:`input_tensor_a` and :attr:`input_tensor_b` and returns the tensor with the same layout as :attr:`input_tensor_a`
         .. math:: \mathrm{{input\_tensor\_a}}_i || \mathrm{{input\_tensor\_b}}_i)doc");
+
+    detail::bind_binary_composite(
+        module,
+        ttnn::scatter,
+        R"doc(Compute scatter :attr:`input_tensor_a` and :attr:`input_tensor_b` and returns the tensor with the same layout as :attr:`input_tensor_a`
+        .. math:: \mathrm{{input\_tensor\_a}}_i || \mathrm{{input\_tensor\_b}}_i)doc");
+
+    detail::bind_binary_composite(
+        module,
+        ttnn::outer,
+        R"doc(Compute outer :attr:`input_tensor_a` and :attr:`input_tensor_b` and returns the tensor with the same layout as :attr:`input_tensor_a`
+        .. math:: \mathrm{{input\_tensor\_a}}_i || \mathrm{{input\_tensor\_b}}_i)doc");
+
+    detail::bind_polyval(
+        module,
+        ttnn::polyval,
+        R"doc(Compute polyval of all elements of :attr:`input_tensor_a` with coefficient :attr:`coeffs` and returns the tensor with the same layout as :attr:`input_tensor_a`
+        .. math:: \mathrm{{input\_tensor\_a}}_i || \mathrm{{coeffs}}_i)doc");
 
 }
 

--- a/ttnn/cpp/ttnn/operations/eltwise/binary/device/binary_composite_op.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary/device/binary_composite_op.hpp
@@ -9,9 +9,7 @@
 #include <optional>
 #include "ttnn/tensor/tensor.hpp"
 #include "third_party/magic_enum/magic_enum.hpp"
-#include "ttnn/cpp/ttnn/operations/eltwise/ternary/where_op.hpp"
-#include "ttnn/cpp/ttnn/operations/copy.hpp"
-#include "ttnn/operations/eltwise/unary/unary_composite.hpp"
+#include "ttnn/operations/core/core.hpp"
 
 
 namespace ttnn::operations::binary{
@@ -35,6 +33,9 @@ enum class BinaryCompositeOpType {
     LOGICAL_AND_,
     LOGICAL_OR_,
     LOGICAL_XOR_,
+    SCATTER,
+    OUTER,
+    POLYVAL,
 };
 
 Tensor _hypot(const Tensor&, const Tensor&, const std::optional<MemoryConfig>&);
@@ -58,6 +59,10 @@ Tensor _floor_div_overload(const Tensor&, float, const std::optional<MemoryConfi
 Tensor _logical_or_(const Tensor&, const Tensor&, const std::optional<MemoryConfig>&);
 Tensor _logical_and_(const Tensor&, const Tensor&, const std::optional<MemoryConfig>&);
 Tensor _logical_xor_(const Tensor&, const Tensor&, const std::optional<MemoryConfig>&);
+Tensor _scatter(const Tensor&, const Tensor&, const std::optional<MemoryConfig>&);
+Tensor _outer(const Tensor&, const Tensor&, const std::optional<MemoryConfig>&);
+Tensor _polyval(const Tensor&, const std::vector<float>&, const std::optional<MemoryConfig>&);
+
 
 // OpHandler struct template
 template <BinaryCompositeOpType OpType>
@@ -195,6 +200,27 @@ struct OpHandler<BinaryCompositeOpType::FLOOR_DIV> {
     }
     static Tensor handle(const Tensor& t1, float value, const std::optional<MemoryConfig>& mem_cfg) {
         return _floor_div_overload(t1, value, mem_cfg);
+    }
+};
+
+template <>
+struct OpHandler<BinaryCompositeOpType::SCATTER> {
+    static Tensor handle(const Tensor& t1, const Tensor& t2, const std::optional<MemoryConfig>& mem_cfg) {
+        return _scatter(t1, t2, mem_cfg);
+    }
+};
+
+template <>
+struct OpHandler<BinaryCompositeOpType::OUTER> {
+    static Tensor handle(const Tensor& t1, const Tensor& t2, const std::optional<MemoryConfig>& mem_cfg) {
+        return _outer(t1, t2, mem_cfg);
+    }
+};
+
+template <>
+struct OpHandler<BinaryCompositeOpType::POLYVAL> {
+    static Tensor handle(const Tensor& t1, const std::vector<float>& coeffs, const std::optional<MemoryConfig>& mem_cfg) {
+        return _polyval(t1, coeffs, mem_cfg);
     }
 };
 

--- a/ttnn/cpp/ttnn/operations/reduction/prod/prod.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/prod/prod.cpp
@@ -57,13 +57,13 @@ inline Tensor prod_nc(const Tensor& temp, int64_t dim, const MemoryConfig& outpu
     // Apply prod
     std::vector<int64_t> dimension = {(dim == 1 || dim == -3) ? 1 : 0};
     tt::tt_metal::Shape input_shape = formatted_input_tensor.get_legacy_shape();
-    tt::tt_metal::Shape required = {
+    std::array<uint32_t, 4> required = {
         ((dim == 1 || dim == -3) ? input_shape[0] : 1),
         ((dim == 1 || dim == -3) ? 1 : input_shape[1]),
         input_shape[2],
         input_shape[3]};
 
-    auto ttnn_shape = ttnn::Shape(tt::tt_metal::Shape{required});
+    auto ttnn_shape = ttnn::Shape({required});
     auto ttnn_device = formatted_input_tensor.device();
 
     return tt::operations::primary::prod_nc(

--- a/ttnn/ttnn/operations/binary.py
+++ b/ttnn/ttnn/operations/binary.py
@@ -360,53 +360,31 @@ def torch_squared_difference(x, y, *args, **kwargs):
     return torch.square(torch.sub(x, y))
 
 
-def torch_polyval(input_tensor, coeff):
-    curVal = 0
-    for curValIndex in range(len(coeff) - 1):
-        curVal = (curVal + coeff[curValIndex]) * input_tensor[0]
-    return curVal + coeff[len(coeff) - 1]
+def _golden_function_scatter(input_tensor_a, input_tensor_b, *args, **kwargs):
+    input_tensor_b[:, :, : input_tensor_a.shape[-2], : input_tensor_a.shape[-1]] = input_tensor_a
+    return input_tensor_b
 
 
-def _golden_function(input_tensor: ttnn.Tensor, coeff: List[float], **_):
-    return torch_polyval(input_tensor, coeff)
+ttnn.attach_golden_function(ttnn._ttnn.operations.binary.scatter, golden_function=_golden_function_scatter)
 
 
-@ttnn.register_python_operation(
-    name="ttnn.polyval",
-    golden_function=_golden_function,
-)
-def polyval(
-    input_tensor: ttnn.Tensor,
-    coeff: List[float],
-    *,
-    memory_config: ttnn.MemoryConfig = ttnn.DRAM_MEMORY_CONFIG,
-    dtype: Optional[ttnn.DataType] = None,
-) -> ttnn.Tensor:
-    r"""
-    polyval(input_tensor_a: ttnn.Tensor, coeff: List[float], *, memory_config: ttnn.MemoryConfig = ttnn.DRAM_MEMORY_CONFIG, dtype: Optional[ttnn.DataType] = None) -> ttnn.Tensor
+def _golden_function_outer(input_tensor_a, input_tensor_b, *args, **kwargs):
+    import torch
 
-    Returns tensor with the polyval of all of elements of the input tensor input with coefficients coeffs.
-
-    .. math::
-        \mathrm{{input\_tensor\_a}}_i , \mathrm{{coeff}}_i
-
-    Args:
-        * :attr:`input_tensor_a`
-        * :attr:`coeff`
-
-    Keyword args:
-        :attr:`memory_config`
-        :attr:`dtype`
+    return torch.outer(input_tensor_a.squeeze(), input_tensor_b.squeeze())
 
 
-    """
+ttnn.attach_golden_function(ttnn._ttnn.operations.binary.outer, golden_function=_golden_function_outer)
 
-    output = ttnn.experimental.tensor.polyval(
-        input_tensor,
-        coeff,
-        output_mem_config=memory_config,
-    )
-    return output
+
+def _golden_function_polyval(input_tensor_a, coeffs, *args, **kwargs):
+    result = 0.0
+    for coeff in coeffs:
+        result = result * input_tensor_a + coeff
+    return result
+
+
+ttnn.attach_golden_function(ttnn._ttnn.operations.binary.polyval, golden_function=_golden_function_polyval)
 
 
 __all__ = []


### PR DESCRIPTION
### Ticket
Link to Github Issue #10821 

### Problem description
Migrate outer, scatter, polyval with fix for ttnn::Shape changes

### What's changed
Migrate outer, scatter, polyval with fix for ttnn::Shape changes

### Checklist
- [x] Post commit CI https://github.com/tenstorrent/tt-metal/actions/runs/10149977497
- [x] post commit models https://github.com/tenstorrent/tt-metal/actions/runs/10141959637
- [x] t3k unit tests https://github.com/tenstorrent/tt-metal/actions/runs/10141953883
- [ ] Nightly fast dispatch https://github.com/tenstorrent/tt-metal/actions/runs/10149980183
- [x] New/Existing tests provide coverage for changes
