### PR TITLE
#10830: Remove Binary and ternary composite op from tt_eager

### DIFF
--- a/docs/source/ttnn/ttnn/dependencies/tt_lib.rst
+++ b/docs/source/ttnn/ttnn/dependencies/tt_lib.rst
@@ -270,10 +270,6 @@ Tensor elementwise operations
 
 .. autofunction:: tt_lib.tensor.unary_rdiv_trunc
 
-.. autofunction:: tt_lib.tensor.polyval
-
-.. autofunction:: tt_lib.tensor.mac
-
 .. autofunction:: tt_lib.tensor.assign
 
 .. autofunction:: tt_lib.tensor.rfloor_div
@@ -428,8 +424,6 @@ Other Operations
 ================
 
 .. autofunction:: tt_lib.tensor.sum
-
-.. autofunction:: tt_lib.tensor.lerp
 
 .. autofunction:: tt_lib.tensor.fill_rm
 

--- a/models/experimental/mistral/tt/mistral_attention.py
+++ b/models/experimental/mistral/tt/mistral_attention.py
@@ -157,14 +157,10 @@ class TtAttention(nn.Module):
             self.cache_v[:bsz].scatter_(dim=1, index=scatter_pos, src=xv[:, -self.sliding_window :])
         else:
             self.cache_k = tt_to_torch_tensor(
-                tt_lib.tensor.scatter(
-                    torch_to_tt_tensor_rm(xk, self.device), torch_to_tt_tensor_rm(self.cache_k, self.device)
-                )
+                ttnn.scatter(torch_to_tt_tensor_rm(xk, self.device), torch_to_tt_tensor_rm(self.cache_k, self.device))
             )
             self.cache_v = tt_to_torch_tensor(
-                tt_lib.tensor.scatter(
-                    torch_to_tt_tensor_rm(xv, self.device), torch_to_tt_tensor_rm(self.cache_v, self.device)
-                )
+                ttnn.scatter(torch_to_tt_tensor_rm(xv, self.device), torch_to_tt_tensor_rm(self.cache_v, self.device))
             )
 
         if positions.shape[0] > 1:

--- a/tests/tt_eager/python_api_testing/sweep_tests/tt_lib_ops.py
+++ b/tests/tt_eager/python_api_testing/sweep_tests/tt_lib_ops.py
@@ -390,6 +390,78 @@ def mean_hw(x, *args, device, dtype, layout, input_mem_config, output_mem_config
 
 
 @setup_host_and_device
+def eltwise_polyval(
+    x,
+    *args,
+    coeffs,
+    device,
+    dtype,
+    layout,
+    input_mem_config,
+    output_mem_config,
+    **kwargs,
+):
+    t0 = setup_tt_tensor(x, device, layout[0], input_mem_config[0], dtype[0])
+    t1 = ttnn.polyval(t0, coeffs, memory_config=output_mem_config)
+
+    return tt2torch_tensor(t1)
+
+
+@setup_host_and_device
+def eltwise_mac(x, y, z, *args, device, dtype, layout, input_mem_config, output_mem_config, **kwargs):
+    t0 = setup_tt_tensor(x, device, layout[0], input_mem_config[0], dtype[0])
+    t1 = setup_tt_tensor(y, device, layout[1], input_mem_config[1], dtype[1])
+    t2 = setup_tt_tensor(z, device, layout[2], input_mem_config[2], dtype[2])
+    t3 = ttnn.mac(t0, t1, t2, memory_config=output_mem_config)
+
+    return tt2torch_tensor(t3)
+
+
+@setup_host_and_device
+def eltwise_addcmul(
+    x,
+    y,
+    z,
+    *args,
+    scalar,
+    device,
+    dtype,
+    layout,
+    input_mem_config,
+    output_mem_config,
+    **kwargs,
+):
+    t0 = setup_tt_tensor(x, device, layout[0], input_mem_config[0], dtype[0])
+    t1 = setup_tt_tensor(y, device, layout[1], input_mem_config[1], dtype[1])
+    t2 = setup_tt_tensor(z, device, layout[2], input_mem_config[2], dtype[2])
+    t3 = ttnn.addcmul(t0, t1, t2, value=scalar, memory_config=output_mem_config)
+
+    return tt2torch_tensor(t3)
+
+
+@setup_host_and_device
+def eltwise_addcdiv(
+    x,
+    y,
+    z,
+    *args,
+    scalar,
+    device,
+    dtype,
+    layout,
+    input_mem_config,
+    output_mem_config,
+    **kwargs,
+):
+    t0 = setup_tt_tensor(x, device, layout[0], input_mem_config[0], dtype[0])
+    t1 = setup_tt_tensor(y, device, layout[1], input_mem_config[1], dtype[1])
+    t2 = setup_tt_tensor(z, device, layout[2], input_mem_config[2], dtype[2])
+    t3 = ttnn.addcdiv(t0, t1, t2, value=scalar, memory_config=output_mem_config)
+
+    return tt2torch_tensor(t3)
+
+
+@setup_host_and_device
 def unary_div_bw(
     x,  # grad_tensor
     y,  # input_tensor
@@ -495,6 +567,26 @@ def binary_assign_bw(
 
 
 @setup_host_and_device
+def eltwise_lerp_binary(
+    x,
+    y,
+    *args,
+    weight,
+    device,
+    dtype,
+    layout,
+    input_mem_config,
+    output_mem_config,
+    **kwargs,
+):
+    t0 = setup_tt_tensor(x, device, layout[0], input_mem_config[0], dtype[0])
+    t1 = setup_tt_tensor(y, device, layout[1], input_mem_config[1], dtype[1])
+    t2 = ttnn.lerp(t0, t1, weight, memory_config=output_mem_config)
+
+    return tt2torch_tensor(t2)
+
+
+@setup_host_and_device
 def eltwise_softplus(
     x,
     *args,
@@ -591,6 +683,16 @@ def add_layernorm(
     )
 
     return tt2torch_tensor(t4)
+
+
+@setup_host_and_device
+def eltwise_lerp_ternary(x, y, z, *args, device, dtype, layout, input_mem_config, output_mem_config, **kwargs):
+    t0 = setup_tt_tensor(x, device, layout[0], input_mem_config[0], dtype[0])
+    t1 = setup_tt_tensor(y, device, layout[1], input_mem_config[1], dtype[1])
+    t2 = setup_tt_tensor(z, device, layout[2], input_mem_config[2], dtype[2])
+    t3 = ttnn.lerp(t0, t1, t2, memory_config=output_mem_config)
+
+    return tt2torch_tensor(t3)
 
 
 @setup_host_and_device
@@ -2308,7 +2410,7 @@ def make_binary_op(ttl_tensor_binop):
     ):
         t0 = setup_tt_tensor(x, device, layout[0], input_mem_config[0], dtype[0])
         t1 = setup_tt_tensor(y, device, layout[1], input_mem_config[1], dtype[1])
-        t2 = ttl_tensor_binop(t0, t1, output_mem_config=output_mem_config)
+        t2 = ttl_tensor_binop(t0, t1, memory_config=output_mem_config)
 
         return tt2torch_tensor(t2)
 
@@ -2356,13 +2458,13 @@ eltwise_logical_and = make_binary_op_ttnn(ttnn.logical_and)
 eltwise_logical_or = make_binary_op_ttnn(ttnn.logical_or)
 eltwise_bias_gelu = make_binary_op_ttnn(ttnn.bias_gelu)
 
-eltwise_min = make_binary_op_ttnn(ttnn.minimum)
-eltwise_max = make_binary_op_ttnn(ttnn.maximum)
+eltwise_min = make_binary_op(ttnn.minimum)
+eltwise_max = make_binary_op(ttnn.maximum)
 
 matmul = make_binary_op_ttnn(ttnn.matmul)
-outer = make_binary_op_ttnn(ttnn.outer)
+outer = make_binary_op(ttnn.outer)
 
-eltwise_scatter = make_binary_op_ttnn(ttnn.scatter)
+eltwise_scatter = make_binary_op(ttnn.scatter)
 eltwise_nextafter = make_binary_op_ttnn(ttnn.nextafter)
 
 

--- a/tests/ttnn/profiling/ops_for_profiling.py
+++ b/tests/ttnn/profiling/ops_for_profiling.py
@@ -2570,8 +2570,8 @@ def linear_shape_func(input_shape):
 
 all_ternary_ops = [
     {
-        "op": tt_lib.tensor.mac,
-        "name": "tt_lib.tensor.mac",
+        "op": ttnn.mac,
+        "name": "ttnn.mac",
     },
     {
         "op": ttnn.where,

--- a/ttnn/cpp/ttnn/deprecated/tt_dnn/op_library/composite/composite_ops.hpp
+++ b/ttnn/cpp/ttnn/deprecated/tt_dnn/op_library/composite/composite_ops.hpp
@@ -27,22 +27,10 @@ using binary_tensor_op_t = Tensor(const Tensor& a, const Tensor& b);
 // Note: inline doesn't allow pybind to work well so we keep few function not inlined.
 
 
-// Function: MAC
-// compute multiply-accumulate: y = a * b + c,  over various 8 combinations of a, b, c
-// being a scalar or tensor
-Tensor mac(
-    const Tensor& a,
-    const Tensor& b,
-    const Tensor& c,
-    const MemoryConfig& output_mem_config = operation::DEFAULT_OUTPUT_MEMORY_CONFIG);
-Tensor mac(
-    const Tensor& a, float b, float c, const MemoryConfig& output_mem_config = operation::DEFAULT_OUTPUT_MEMORY_CONFIG);
 
-// compute polyval by Horner's rule
-Tensor polyval(
-    const Tensor& input_tensor,
-    std::vector<float> coeffs,
-    const MemoryConfig& output_mem_config = operation::DEFAULT_OUTPUT_MEMORY_CONFIG);
+Tensor celu(
+    const Tensor& x, float alpha, const MemoryConfig& output_mem_config = operation::DEFAULT_OUTPUT_MEMORY_CONFIG);
+
 
 Tensor unary_rdiv_trunc(
     float value,
@@ -55,26 +43,112 @@ Tensor rfloor_div(
     const MemoryConfig& output_mem_config = operation::DEFAULT_OUTPUT_MEMORY_CONFIG);
 
 
-// lerp(input, end, weight) = start + weight * (end - start), weight is float
-Tensor lerp(
-    const Tensor& input_a,
-    const Tensor& input_b,
+
+// cbrt(a) = pow(a,1/3) or (cbrt(a))**3 = a.
+Tensor cbrt(const Tensor& input_a, const MemoryConfig& output_mem_config = operation::DEFAULT_OUTPUT_MEMORY_CONFIG);
+
+// on-device tensor creation 0s like @reference_tensor
+Tensor zeros_like(
+    uint8_t queue_id,
+    const Tensor& reference_tensor,
+    const MemoryConfig& output_mem_config = operation::DEFAULT_OUTPUT_MEMORY_CONFIG,
+    std::optional<Tensor> output_tensor= std::nullopt);
+
+Tensor zeros_like(
+    const Tensor& reference_tensor,
+    const MemoryConfig& output_mem_config = operation::DEFAULT_OUTPUT_MEMORY_CONFIG,
+    std::optional<Tensor> output_tensor= std::nullopt);
+
+// on-device tensor creation 1s like @reference_tensor
+Tensor ones_like(
+    const Tensor& reference_tensor, const MemoryConfig& output_mem_config = operation::DEFAULT_OUTPUT_MEMORY_CONFIG);
+
+// on-device tensor creation with value like @reference_tensor
+Tensor full_like(
+    uint8_t queue_id,
+    const Tensor& reference_tensor,
     float value,
+    const MemoryConfig& output_mem_config = operation::DEFAULT_OUTPUT_MEMORY_CONFIG,
+    std::optional<Tensor> output_tensor= std::nullopt);
+Tensor full_like(
+    const Tensor& reference_tensor,
+    float value,
+    const MemoryConfig& output_mem_config = operation::DEFAULT_OUTPUT_MEMORY_CONFIG,
+    std::optional<Tensor> output_tensor= std::nullopt);
+
+// on-device tensor creation 0s with shape
+Tensor empty(
+    const Shape shape,
+    DataType data_type = DataType::BFLOAT16,
+    Layout layout = Layout::ROW_MAJOR,
+    Device* device = nullptr,
     const MemoryConfig& output_mem_config = operation::DEFAULT_OUTPUT_MEMORY_CONFIG);
 
-// lerp(input, end, weight) = start + weight * (end - start), weight is tensor
-Tensor lerp(
+// on-device tensor creation 0s with shape
+Tensor zeros(
+    const Shape shape,
+    DataType data_type = DataType::BFLOAT16,
+    Layout layout = Layout::ROW_MAJOR,
+    Device* device = nullptr,
+    const MemoryConfig& output_mem_config = operation::DEFAULT_OUTPUT_MEMORY_CONFIG);
+
+// on-device tensor creation 1s with shape
+Tensor ones(
+    const Shape shape,
+    DataType data_type = DataType::BFLOAT16,
+    Layout layout = Layout::ROW_MAJOR,
+    Device* device = nullptr,
+    const MemoryConfig& output_mem_config = operation::DEFAULT_OUTPUT_MEMORY_CONFIG);
+
+Tensor arange(
+    int32_t start,
+    int32_t end,
+    int32_t step = 1,
+    Device* device = nullptr,
+    const MemoryConfig& output_mem_config = operation::DEFAULT_OUTPUT_MEMORY_CONFIG);
+
+// on-device tensor creation with shape and filled with value
+Tensor full(
+    const Shape shape,
+    float value,
+    DataType data_type = DataType::BFLOAT16,
+    Layout layout = Layout::ROW_MAJOR,
+    Device* device = nullptr,
+    const MemoryConfig& output_mem_config = operation::DEFAULT_OUTPUT_MEMORY_CONFIG);
+
+// machine epsilon
+Tensor eps(
+    const Shape shape,
+    Layout layout,
+    Device* device,
+    const MemoryConfig& output_mem_config = operation::DEFAULT_OUTPUT_MEMORY_CONFIG);
+
+// logit(input, eps)=log(input / 1 - input)
+Tensor logit(
+    const Tensor& input_a, float eps, const MemoryConfig& output_mem_config = operation::DEFAULT_OUTPUT_MEMORY_CONFIG);
+
+Tensor logical_xori(
     const Tensor& input_a,
-    const Tensor& input_b,
-    const Tensor& input_c,
+    float immediate,
     const MemoryConfig& output_mem_config = operation::DEFAULT_OUTPUT_MEMORY_CONFIG);
 
-Tensor scatter(
-    const Tensor& input_a,
-    const Tensor& input_b,
-    const MemoryConfig& output_mem_config = operation::DEFAULT_OUTPUT_MEMORY_CONFIG);
+/** hyperbolic operations **/
 
-Tensor outer(Tensor& a, Tensor& b, const MemoryConfig& output_mem_config = operation::DEFAULT_OUTPUT_MEMORY_CONFIG);
+// digamma
+Tensor digamma(const Tensor& input_a, const MemoryConfig& output_mem_config = operation::DEFAULT_OUTPUT_MEMORY_CONFIG);
+
+// cosh(x) = (exp(x) + exp(-x))/2
+Tensor cosh(const Tensor& input_a, const MemoryConfig& output_mem_config = operation::DEFAULT_OUTPUT_MEMORY_CONFIG);
+
+/** Inverse hyperbolic operations **/
+// asinh(x) = log(x + sqrt(x^2 + 1))
+Tensor asinh(const Tensor& input_a, const MemoryConfig& output_mem_config = operation::DEFAULT_OUTPUT_MEMORY_CONFIG);
+
+// acosh(x) = log(x + sqrt(x^2 - 1))
+Tensor acosh(const Tensor& input_a, const MemoryConfig& output_mem_config = operation::DEFAULT_OUTPUT_MEMORY_CONFIG);
+
+// atanh[x] = 0.5 * ln((1 + x) / (1 - x))
+Tensor atanh(const Tensor& input_a, const MemoryConfig& output_mem_config = operation::DEFAULT_OUTPUT_MEMORY_CONFIG);
 
 
 }  // namespace tt_metal

--- a/ttnn/cpp/ttnn/deprecated/tt_lib/csrc/tt_lib_bindings_tensor_composite_ops.cpp
+++ b/ttnn/cpp/ttnn/deprecated/tt_lib/csrc/tt_lib_bindings_tensor_composite_ops.cpp
@@ -14,88 +14,6 @@ namespace tt::tt_metal::detail {
 
 void TensorModuleCompositeOPs(py::module& m_tensor) {
 
-
-    m_tensor.def(
-        "outer",
-        &outer,
-        py::arg("input_a").noconvert(),
-        py::arg("input_b").noconvert(),
-        py::arg("output_mem_config").noconvert() = operation::DEFAULT_OUTPUT_MEMORY_CONFIG,
-        R"doc(
-            Perform a non-batched outer product multiplication ``arg0 x arg1`` with two tensors.
-
-            Both input tensors must have BFLOAT16 data type but shape [1,1,N,1] and [1,1,1,M] respectively
-            or reshapeable with only one major dimension while other 3 being squeezable dimensions.
-
-            Output tensor will have BFLOAT16 data type but of shape [1,1,N,M].
-
-            .. csv-table::
-                :header: "Argument", "Description", "Data type", "Valid range", "Required"
-
-                "input_a", "First tensor to multiply", "Tensor", "Tensor of shape [1, 1, N, 1]", "Yes"
-                "input_b", "Second tensor to multiply", "Tensor", "Tensor of shape [1, 1, 1, M]", "Yes"
-                "output_mem_config", "Layout of tensor in TT Accelerator device memory banks", "MemoryConfig", "Default is interleaved in DRAM", "No"
-        )doc");
-
-        // *** composite unary ops ***
-    detail::bind_unary_op_with_param(
-        m_tensor,
-        "polyval",
-        &polyval,
-        py::arg("coeffs"),
-        R"doc(Returns tensor with the polyval of all of elements of the input tensor ``{0}`` with coefficients ``{1}``.)doc",
-        R"doc("coefficients value with highest degree first", "List of float", "List size > 0")doc");
-
-    m_tensor.def(
-        "lerp",
-        py::overload_cast<const Tensor&, const Tensor&, float, const MemoryConfig&>(&lerp),
-        py::arg("input").noconvert(),
-        py::arg("end").noconvert(),
-        py::arg("weight"),
-        py::arg("output_mem_config").noconvert() = operation::DEFAULT_OUTPUT_MEMORY_CONFIG,
-        R"doc(
-            Applies the linear interpolation of two tensors ``input`` and ``end`` based on a
-            scalar ``weight`` and returns the resulting out tensor.
-
-            Input tensor must have BFLOAT16 data type.
-
-            Output tensor will have BFLOAT16 data type.
-
-            .. csv-table::
-                :header: "Argument", "Description", "Data type", "Valid range", "Required"
-
-                "input", "Tensor lerp is applied to", "Tensor", "Tensor of shape [W, Z, Y, X]", "Yes"
-                "end", "End value", "Tensor", "Tensor of shape [W, Z, Y, X]", "Yes"
-                "weight", "Weight value", "float", "", "Yes"
-                "output_mem_config", "Layout of tensor in TT Accelerator device memory banks", "MemoryConfig", "Default is interleaved in DRAM", "No"
-        )doc");
-
-    m_tensor.def(
-        "lerp",
-        py::overload_cast<const Tensor&, const Tensor&, const Tensor&, const MemoryConfig&>(&lerp),
-        py::arg("input").noconvert(),
-        py::arg("end").noconvert(),
-        py::arg("weight").noconvert(),
-        py::arg("output_mem_config").noconvert() = operation::DEFAULT_OUTPUT_MEMORY_CONFIG,
-        R"doc(
-            Applies the linear interpolation of two tensors ``input`` and ``end`` based on a
-            tensor ``weight`` and returns the resulting out tensor.
-
-            Input tensor must have BFLOAT16 data type.
-
-            Output tensor will have BFLOAT16 data type.
-
-            .. csv-table::
-                :header: "Argument", "Description", "Data type", "Valid range", "Required"
-
-                "input", "Tensor lerp is applied to", "Tensor", "Tensor of shape [W, Z, Y, X]", "Yes"
-                "end", "End value", "Tensor", "Tensor of shape [W, Z, Y, X]", "Yes"
-                "weight", "Weight value", "Tensor", "Tensor of shape [W, Z, Y, X]", "Yes"
-                "output_mem_config", "Layout of tensor in TT Accelerator device memory banks", "MemoryConfig", "Default is interleaved in DRAM", "No"
-        )doc");
-
-
-
 #if 0
         m_tensor.def("bitwise_complement", &bitwise_complement, R"doc(
             Returns tensor with the bitwise complement of elements of the input tensor ``arg0``.
@@ -172,7 +90,7 @@ void TensorModuleCompositeOPs(py::module& m_tensor) {
             +----------+---------------------------+-----------+------------------------------+----------+
         )doc");
 #endif
-        
+
         m_tensor.def("unary_rdiv_trunc", py::overload_cast<float, const Tensor&, const MemoryConfig&>(&unary_rdiv_trunc),
             py::arg("value").noconvert(), py::arg("input").noconvert(),  py::arg("output_mem_config").noconvert() = operation::DEFAULT_OUTPUT_MEMORY_CONFIG, R"doc(
             Performs the element-wise division of a scalar ``value`` by a tensor ``input`` and rounds the result using trunc mode. Support provided only for Wormhole_B0.
@@ -206,45 +124,6 @@ void TensorModuleCompositeOPs(py::module& m_tensor) {
                 "output_mem_config", "Layout of tensor in TT Accelerator device memory banks", "MemoryConfig", "Default is interleaved in DRAM", "No"
         )doc");
 
-        m_tensor.def("mac", py::overload_cast<const Tensor&, const Tensor&, const Tensor&, const MemoryConfig&>(&mac),
-            py::arg("input").noconvert(), py::arg("tensor1").noconvert(), py::arg("tensor2").noconvert(), py::arg("output_mem_config").noconvert() = operation::DEFAULT_OUTPUT_MEMORY_CONFIG, R"doc(
-            Returns tensor with the multiply and accumulation of all of elements of the input tensors ``input, tensor1, tensor2``.
-            Output is ``input x tensor1 + tensor2`` elementwise operator.
-            Input tensor must have BFLOAT16 data type.
-
-            Output tensor will have BFLOAT16 data type.
-
-            .. csv-table::
-                :header: "Argument", "Description", "Data type", "Valid range", "Required"
-
-                "input", "Tensor mac is applied to", "Tensor", "Tensor of shape [W, Z, Y, X]", "Yes"
-                "tensor1", "Tensor to be multiplied", "Tensor", "Tensor of shape [W, Z, Y, X]", "Yes"
-                "tensor2", "Tensor to be added", "Tensor", "Tensor of shape [W, Z, Y, X]", "Yes"
-                "output_mem_config", "Layout of tensor in TT Accelerator device memory banks", "MemoryConfig", "Default is interleaved in DRAM", "No"
-        )doc");
-
-    m_tensor.def(
-        "mac",
-        py::overload_cast<const Tensor&, float, float, const MemoryConfig&>(&mac),
-        py::arg("input").noconvert(),
-        py::arg("float1"),
-        py::arg("float2"),
-        py::arg("output_mem_config").noconvert() = operation::DEFAULT_OUTPUT_MEMORY_CONFIG,
-        R"doc(
-            Returns tensor with the multiply and accumulation of all of elements of the input tensor ``input11 with``float1, float2``.
-            Output is ``tensor1 x float1 + float2`` elementwise operator.
-            Input tensor must have BFLOAT16 data type.
-
-            Output tensor will have BFLOAT16 data type.
-
-            .. csv-table::
-                :header: "Argument", "Description", "Data type", "Valid range", "Required"
-
-                "input", "Tensor mac is applied to", "Tensor", "Tensor of shape [W, Z, Y, X]", "Yes"
-                "float1", "Value to be multiplied", "float", "", "Yes"
-                "float2", "Value to be added", "float", "", "Yes"
-                "output_mem_config", "Layout of tensor in TT Accelerator device memory banks", "MemoryConfig", "Default is interleaved in DRAM", "No"
-        )doc");
 
     m_tensor.def(
         "lamb_optimizer",
@@ -282,7 +161,6 @@ void TensorModuleCompositeOPs(py::module& m_tensor) {
                 "output_mem_config", "Layout of tensor in TT Accelerator device memory banks", "MemoryConfig", "Default is interleaved in DRAM", "No"
         )doc");
 
-        detail::bind_binary_op<false, true, false, false>(m_tensor, "scatter", &tt::tt_metal::scatter, R"doc(Performs scatter operation on elements of the input tensors ``{0}`` and ``{1}``,specifically to copy channel data.)doc");
 
     // loss functions
     m_tensor.def(

--- a/ttnn/cpp/ttnn/operations/eltwise/binary/binary_composite.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary/binary_composite.hpp
@@ -79,7 +79,7 @@ struct ExecuteBinaryCompositeOpsDiv
         const Tensor& input_tensor_a,
         const Tensor& input_tensor_b,
         bool accurate_mode = false,
-        std::string round_mode = "None",
+        const std::string& round_mode = "None",
         const std::optional<MemoryConfig>& memory_config = std::nullopt) {
         return OpHandler<binary_comp_op_type>::handle(input_tensor_a, input_tensor_b, accurate_mode, round_mode, memory_config);
     }
@@ -87,7 +87,7 @@ struct ExecuteBinaryCompositeOpsDiv
         const Tensor& input_tensor_a,
         float value,
         bool accurate_mode = false,
-        std::string round_mode = "None",
+        const std::string& round_mode = "None",
         const std::optional<MemoryConfig>& memory_config = std::nullopt) {
         return OpHandler<binary_comp_op_type>::handle(input_tensor_a, value, accurate_mode, round_mode, memory_config);
     }

--- a/ttnn/cpp/ttnn/operations/eltwise/binary/binary_pybind.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary/binary_pybind.hpp
@@ -316,7 +316,7 @@ void bind_div(py::module& module, const binary_operation_t& operation, const std
                const Tensor& input_tensor_a,
                const Tensor& input_tensor_b,
                bool accurate_mode,
-               std::string round_mode,
+               const std::string& round_mode,
                const std::optional<MemoryConfig>& memory_config) {
                     return self(input_tensor_a, input_tensor_b, accurate_mode, round_mode, memory_config);
                 },
@@ -332,7 +332,7 @@ void bind_div(py::module& module, const binary_operation_t& operation, const std
                const Tensor& input_tensor_a,
                float value,
                bool accurate_mode,
-               std::string round_mode,
+               const std::string& round_mode,
                const std::optional<MemoryConfig>& memory_config) {
                     return self(input_tensor_a, value, accurate_mode, round_mode, memory_config);
                 },

--- a/ttnn/cpp/ttnn/operations/eltwise/binary/device/binary_composite_op.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary/device/binary_composite_op.cpp
@@ -157,7 +157,7 @@ Tensor _logical_xor(const Tensor& input_a, const Tensor& input_b, const std::opt
     return result;
 }
 
-Tensor _div_overload(const Tensor& input_a, float value, bool accurate_mode, std::string round_mode, const std::optional<MemoryConfig>& output_mem_config) {
+Tensor _div_overload(const Tensor& input_a, float value, bool accurate_mode, const std::string& round_mode, const std::optional<MemoryConfig>& output_mem_config) {
     TT_FATAL((round_mode == "None" || round_mode == "trunc" || round_mode == "floor") && "Incorrect rounding mode (expected 'None', 'trunc', or 'floor')");
     Tensor result = ttnn::multiply(input_a, (1.0f/value), std::nullopt, output_mem_config);
     if(round_mode == "trunc"){
@@ -169,7 +169,7 @@ Tensor _div_overload(const Tensor& input_a, float value, bool accurate_mode, std
     return result;
 }
 
-Tensor _div(const Tensor& input_a, const Tensor& input_b, bool accurate_mode, std::string round_mode, const std::optional<MemoryConfig>& output_mem_config) {
+Tensor _div(const Tensor& input_a, const Tensor& input_b, bool accurate_mode, const std::string& round_mode, const std::optional<MemoryConfig>& output_mem_config) {
     TT_FATAL((round_mode == "None" || round_mode == "trunc" || round_mode == "floor") && "Incorrect rounding mode (expected 'None', 'trunc', or 'floor')");
     auto arch = input_a.device()->arch();
     if (arch == tt::ARCH::WORMHOLE_B0) {

--- a/ttnn/cpp/ttnn/operations/eltwise/binary/device/binary_composite_op.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary/device/binary_composite_op.hpp
@@ -49,8 +49,8 @@ Tensor _binary_fmod(const Tensor&, const Tensor&, const std::optional<MemoryConf
 Tensor _addalpha(const Tensor&, const Tensor&, float, const std::optional<MemoryConfig>&);
 Tensor _subalpha(const Tensor&, const Tensor&, float, const std::optional<MemoryConfig>&);
 Tensor _isclose(const Tensor&, const Tensor&, float, float, const bool, const std::optional<MemoryConfig>&);
-Tensor _div(const Tensor&, const Tensor&, bool, std::string, const std::optional<MemoryConfig>&);
-Tensor _div_overload(const Tensor&, float, bool, std::string, const std::optional<MemoryConfig>&);
+Tensor _div(const Tensor&, const Tensor&, bool, const std::string&, const std::optional<MemoryConfig>&);
+Tensor _div_overload(const Tensor&, float, bool, const std::string&, const std::optional<MemoryConfig>&);
 Tensor _div_no_nan(const Tensor&, const Tensor&, const std::optional<MemoryConfig>&);
 Tensor _div_no_nan_overload(const Tensor&, float, const std::optional<MemoryConfig>&);
 Tensor _floor_div(const Tensor&, const Tensor&, const std::optional<MemoryConfig>&);
@@ -174,10 +174,10 @@ struct OpHandler<BinaryCompositeOpType::ISCLOSE> {
 
 template <>
 struct OpHandler<BinaryCompositeOpType::DIV> {
-    static Tensor handle(const Tensor& t1, const Tensor& t2, bool accurate_mode, std::string round_mode, const std::optional<MemoryConfig>& mem_cfg) {
+    static Tensor handle(const Tensor& t1, const Tensor& t2, bool accurate_mode, const std::string& round_mode, const std::optional<MemoryConfig>& mem_cfg) {
         return _div(t1, t2, accurate_mode, round_mode, mem_cfg);
     }
-    static Tensor handle(const Tensor& t1, float value, bool accurate_mode, std::string round_mode, const std::optional<MemoryConfig>& mem_cfg) {
+    static Tensor handle(const Tensor& t1, float value, bool accurate_mode, const std::string& round_mode, const std::optional<MemoryConfig>& mem_cfg) {
         return _div_overload(t1, value, accurate_mode, round_mode, mem_cfg);
     }
 };

--- a/ttnn/cpp/ttnn/operations/eltwise/unary/device/unary_composite_op.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary/device/unary_composite_op.cpp
@@ -2,6 +2,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
+
 #include "unary_composite_op.hpp"
 
 #include <functional>


### PR DESCRIPTION
### Ticket
Link to Github Issue #10830 

To remove composite ops from tt_eager

List of ops
- [x] Polyval
- [x]  Outer
- [x]  Scatter
- [x]  Lerp (Ternary)
- [x]  Mac (Ternary)

### Checklist
- [ ] Post commit CI passes
- [ ] Model regression CI testing passes (if applicable)
- [ ] New/Existing tests provide coverage for changes
