### PR TITLE
#10820: Move bias_gelu_unary under ttnn.bias_gelu

### DIFF
--- a/docs/source/ttnn/ttnn/dependencies/tt_lib.rst
+++ b/docs/source/ttnn/ttnn/dependencies/tt_lib.rst
@@ -316,8 +316,6 @@ Tensor elementwise operations
 
 .. autofunction:: tt_lib.tensor.addalpha
 
-.. autofunction:: tt_lib.tensor.bias_gelu_unary
-
 .. autofunction:: tt_lib.tensor.logit
 
 .. autofunction:: tt_lib.tensor.logical_andi

--- a/tests/tt_eager/python_api_testing/sweep_tests/tt_lib_ops.py
+++ b/tests/tt_eager/python_api_testing/sweep_tests/tt_lib_ops.py
@@ -2331,7 +2331,7 @@ def eltwise_pow(
 @setup_host_and_device
 def eltwise_bias_gelu_unary(x, *args, bias, device, dtype, layout, input_mem_config, output_mem_config, **kwargs):
     t0 = setup_tt_tensor(x, device, layout[0], input_mem_config[0], dtype[0])
-    t1 = ttl.tensor.bias_gelu_unary(t0, bias, output_mem_config=output_mem_config)
+    t1 = ttnn.bias_gelu(t0, bias, memory_config=output_mem_config)
 
     return tt2torch_tensor(t1)
 

--- a/tests/ttnn/unit_tests/operations/test_binary_scalar.py
+++ b/tests/ttnn/unit_tests/operations/test_binary_scalar.py
@@ -5,6 +5,7 @@
 import torch
 import pytest
 import ttnn
+import random
 from tests.ttnn.unit_tests.operations.backward.utility_funcs import data_gen_with_range, compare_pcc
 
 
@@ -25,15 +26,17 @@ from tests.ttnn.unit_tests.operations.backward.utility_funcs import data_gen_wit
         (ttnn.ge),
         (ttnn.le),
         (ttnn.eq),
+        (ttnn.bias_gelu),
     ),
 )
-def test_unary_relops_ttnn(input_shapes, device, ttnn_fn):
+def test_binary_scalar_ops(input_shapes, device, ttnn_fn):
     in_data, input_tensor = data_gen_with_range(input_shapes, -100, 100, device)
     _, output_tensor = data_gen_with_range(input_shapes, -1, 1, device)
     cq_id = 0
-    ttnn_fn(input_tensor, 4.5, output_tensor=output_tensor, queue_id=cq_id)
+    scalar = random.randint(-80, 80)
+    ttnn_fn(input_tensor, scalar, output_tensor=output_tensor, queue_id=cq_id)
     golden_fn = ttnn.get_golden_function(ttnn_fn)
-    golden_tensor = golden_fn(in_data, 4.5)
+    golden_tensor = golden_fn(in_data, scalar)
 
     comp_pass = compare_pcc([output_tensor], [golden_tensor])
     assert comp_pass

--- a/tests/ttnn/unit_tests/operations/test_elt_binary.py
+++ b/tests/ttnn/unit_tests/operations/test_elt_binary.py
@@ -76,6 +76,12 @@ def test_xlogy(device, h, w):
     run_elt_binary_test_range(device, h, w, ttnn.xlogy, 1e-6, 1e6)
 
 
+@pytest.mark.parametrize("h", [64])
+@pytest.mark.parametrize("w", [128])
+def test_bias_gelu(device, h, w):
+    run_elt_binary_test_range(device, h, w, ttnn.bias_gelu, -100, 100)
+
+
 def run_elt_binary_test_min_max(device, h, w, ttnn_function, low, high, pcc=0.9999):
     torch.manual_seed(0)
     low = low

--- a/ttnn/cpp/ttnn/deprecated/tt_dnn/op_library/composite/composite_ops.cpp
+++ b/ttnn/cpp/ttnn/deprecated/tt_dnn/op_library/composite/composite_ops.cpp
@@ -94,14 +94,6 @@ Tensor hardshrink(const Tensor& a, float param, const MemoryConfig& output_mem_c
     return operation::decorate_as_composite(__func__, _hardshrink)(a, param, output_mem_config);
 }
 
-// Function: bias gelu
-// Ref: http://www.xavierdupre.fr/app/mlprodict/helpsphinx/onnxops/onnx_commicrosoft_BiasGelu.html
-Tensor _bias_gelu_unary(const Tensor& a, float bias, const MemoryConfig& output_mem_config) {
-    return ttnn::gelu(ttnn::add(a, bias), true, output_mem_config);
-}
-Tensor bias_gelu_unary(const Tensor& a, float bias, const MemoryConfig& output_mem_config) {
-    return operation::decorate_as_composite(__func__, _bias_gelu_unary)(a, bias, output_mem_config);
-}
 
 // Function: softsign
 // Ref: https://pytorch.org/docs/stable/generated/torch.nn.Softsign.html

--- a/ttnn/cpp/ttnn/deprecated/tt_dnn/op_library/composite/composite_ops.hpp
+++ b/ttnn/cpp/ttnn/deprecated/tt_dnn/op_library/composite/composite_ops.hpp
@@ -36,11 +36,6 @@ Tensor softshrink(
 Tensor hardshrink(
     const Tensor& a, float param, const MemoryConfig& output_mem_config = operation::DEFAULT_OUTPUT_MEMORY_CONFIG);
 
-// Function: bias gelu
-// Ref: http://www.xavierdupre.fr/app/mlprodict/helpsphinx/onnxops/onnx_commicrosoft_BiasGelu.html
-Tensor bias_gelu_unary(
-    const Tensor& a, float bias, const MemoryConfig& output_mem_config = operation::DEFAULT_OUTPUT_MEMORY_CONFIG);
-
 // Function: softsign
 // Ref: https://pytorch.org/docs/stable/generated/torch.nn.Softsign.html
 Tensor softsign(const Tensor& a, const MemoryConfig& output_mem_config = operation::DEFAULT_OUTPUT_MEMORY_CONFIG);

--- a/ttnn/cpp/ttnn/deprecated/tt_lib/csrc/tt_lib_bindings_tensor_composite_ops.cpp
+++ b/ttnn/cpp/ttnn/deprecated/tt_lib/csrc/tt_lib_bindings_tensor_composite_ops.cpp
@@ -305,13 +305,6 @@ void TensorModuleCompositeOPs(py::module& m_tensor) {
         R"doc("value limits (-lambda to +lambda)", "float", ">= 0")doc");
     detail::bind_unary_op_with_param(
         m_tensor,
-        "bias_gelu_unary",
-        &bias_gelu_unary,
-        py::arg("bias"),
-        R"doc(Applies the Gelu activation function to the elements of the biased ``{1}`` input tensor ``{0}``.)doc",
-        R"doc("value limits (-bias to +bias)", "float", ">= 0")doc");
-    detail::bind_unary_op_with_param(
-        m_tensor,
         "polyval",
         &polyval,
         py::arg("coeffs"),

--- a/ttnn/cpp/ttnn/operations/eltwise/binary/binary.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary/binary.hpp
@@ -386,9 +386,6 @@ constexpr auto squared_difference = ttnn::register_operation_with_auto_launch_op
 constexpr auto divide = ttnn::register_operation_with_auto_launch_op<
     "ttnn::divide",
     operations::binary::BinaryOperation<operations::binary::BinaryOpType::DIV_FAST, false>>();
-constexpr auto bias_gelu = ttnn::register_operation_with_auto_launch_op<
-    "ttnn::bias_gelu",
-    operations::binary::BinaryOperation<operations::binary::BinaryOpType::BIAS_GELU, false>>();
 
 template <typename InputBType>
 ttnn::Tensor operator+(const ttnn::Tensor &input_tensor_a, InputBType scalar) {

--- a/ttnn/ttnn/operations/binary.py
+++ b/ttnn/ttnn/operations/binary.py
@@ -173,10 +173,10 @@ def _golden_function(input_tensor_a, input_tensor_b, *args, **kwargs):
 ttnn.attach_golden_function(ttnn.divide, golden_function=_golden_function)
 
 
-def _golden_function(input_tensor_a, input_tensor_b, *args, **kwargs):
+def _golden_function(a, b, *args, **kwargs):
     import torch
 
-    return torch.nn.functional.gelu(torch.add(x, y))
+    return torch.nn.functional.gelu(torch.add(a, b))
 
 
 ttnn.attach_golden_function(ttnn.bias_gelu, golden_function=_golden_function)


### PR DESCRIPTION
### Ticket
Link to Github Issue #10820 

### Problem description
Move bias_gelu_unary to eltwise/binary with overload

### What's changed
Move bias_gelu_unary to eltwise/binary with overload
overload bias_gelu to handle tensor-tensor and tensor-scalar inputs

### Checklist
- [x] Post commit CI https://github.com/tenstorrent/tt-metal/actions/runs/10150146534
- [ ] Model regression CI testing passes (if applicable)
- [x] New/Existing tests provide coverage for changes
