### PR TITLE
#10765: Upgrade to pip 20.1.1 since the editable install method should work with that version

### DIFF
--- a/create_venv.sh
+++ b/create_venv.sh
@@ -26,7 +26,7 @@ $PYTHON_CMD -m venv $PYTHON_ENV_DIR
 source $PYTHON_ENV_DIR/bin/activate
 
 echo "Forcefully using a version of pip that will work with our view of editable installs"
-pip install --force-reinstall pip==21.3.1
+pip install --force-reinstall pip==20.1.1
 
 echo "Setting up virtual env"
 python3 -m pip config set global.extra-index-url https://download.pytorch.org/whl/cpu

--- a/create_venv.sh
+++ b/create_venv.sh
@@ -26,7 +26,7 @@ $PYTHON_CMD -m venv $PYTHON_ENV_DIR
 source $PYTHON_ENV_DIR/bin/activate
 
 echo "Forcefully using a version of pip that will work with our view of editable installs"
-pip install --force-reinstall pip==20.0.2
+pip install --force-reinstall pip==22.3.1
 
 echo "Setting up virtual env"
 python3 -m pip config set global.extra-index-url https://download.pytorch.org/whl/cpu

--- a/create_venv.sh
+++ b/create_venv.sh
@@ -26,7 +26,7 @@ $PYTHON_CMD -m venv $PYTHON_ENV_DIR
 source $PYTHON_ENV_DIR/bin/activate
 
 echo "Forcefully using a version of pip that will work with our view of editable installs"
-pip install --force-reinstall pip==22.3.1
+pip install --force-reinstall pip==21.3.1
 
 echo "Setting up virtual env"
 python3 -m pip config set global.extra-index-url https://download.pytorch.org/whl/cpu


### PR DESCRIPTION
…

### Ticket

#10765 

### Problem description

Our take on editable installs doesn't work on pip 23 or later it seems like
So we're trying to use latest working version. We force a venv re-creation by changing `create_venv.sh` here.

### What's changed

Update pip to 22.3.1 in `create_venv.sh`

### Checklist
- [ ] Post commit CI passes
- [ ] Model regression CI testing passes (if applicable)
- [ ] New/Existing tests provide coverage for changes
