### PR TITLE
#10583: Enable async mode for all testing scripts to improve throughput

### DIFF
--- a/models/demos/t3000/falcon40b/tests/ci/test_falcon_end_to_end_1_layer_t3000.py
+++ b/models/demos/t3000/falcon40b/tests/ci/test_falcon_end_to_end_1_layer_t3000.py
@@ -63,6 +63,10 @@ from models.utility_functions import (
         ),
     ),
 )
+@pytest.mark.parametrize(
+    "async_mode",
+    (True,),
+)
 def test_FalconCausalLM_end_to_end_with_program_cache(
     num_devices,
     model_version,
@@ -78,6 +82,7 @@ def test_FalconCausalLM_end_to_end_with_program_cache(
     get_tt_cache_path,
     t3k_device_mesh,
     use_program_cache,
+    async_mode,
 ):
     model_config_str = f"{data_type}-{memcfg}"
     if llm_mode == "prefill" and memcfg != "DRAM" or num_devices != 8:
@@ -93,6 +98,8 @@ def test_FalconCausalLM_end_to_end_with_program_cache(
     input_shape = [batch, seq_len]
     model_config = get_model_config(model_config_str, llm_mode, input_shape, num_devices)
     devices = t3k_device_mesh.get_devices()
+    for device in devices:
+        device.enable_async(async_mode)
     compute_grid_size = devices[0].compute_with_storage_grid_size()
     if compute_grid_size.x < model_config["MAX_GRID_SIZE"][0] or compute_grid_size.y < model_config["MAX_GRID_SIZE"][1]:
         pytest.skip(f"Requires grid size of at least {model_config['MAX_GRID_SIZE']} to run")

--- a/models/demos/t3000/falcon40b/tests/ci/test_falcon_end_to_end_60_layer_t3000_prefill_10_loops.py
+++ b/models/demos/t3000/falcon40b/tests/ci/test_falcon_end_to_end_60_layer_t3000_prefill_10_loops.py
@@ -59,6 +59,10 @@ from models.utility_functions import (
         ),
     ),
 )
+@pytest.mark.parametrize(
+    "async_mode",
+    (True,),
+)
 def test_FalconCausalLM_prefill_end_to_end_t3000_ci_loops_10(
     model_version,
     seq_len,
@@ -70,6 +74,7 @@ def test_FalconCausalLM_prefill_end_to_end_t3000_ci_loops_10(
     get_tt_cache_path,
     t3k_device_mesh,
     use_program_cache,
+    async_mode,
 ):
     num_devices = 8
     llm_mode = "prefill"
@@ -84,6 +89,8 @@ def test_FalconCausalLM_prefill_end_to_end_t3000_ci_loops_10(
     model_config_str = f"{data_type}-{memcfg}"
     model_config = get_model_config(model_config_str, llm_mode, input_shape, num_devices)
     devices = t3k_device_mesh.get_devices()
+    for device in devices:
+        device.enable_async(async_mode)
     compute_grid_size = devices[0].compute_with_storage_grid_size()
     if compute_grid_size.x < model_config["MAX_GRID_SIZE"][0] or compute_grid_size.y < model_config["MAX_GRID_SIZE"][1]:
         pytest.skip(f"Requires grid size of at least {model_config['MAX_GRID_SIZE']} to run")

--- a/models/demos/t3000/falcon40b/tests/test_demo.py
+++ b/models/demos/t3000/falcon40b/tests/test_demo.py
@@ -48,6 +48,9 @@ def test_demo(
     use_program_cache,
 ):
     input_file = "models/demos/t3000/falcon40b/demo/input_data.json"
+    # Enable async mode
+    for device in t3k_device_mesh.get_devices():
+        device.enable_async(True)
 
     generated_text, measurements = run_falcon_demo_kv(
         user_input=input_file,

--- a/models/demos/t3000/falcon40b/tests/test_falcon_end_to_end.py
+++ b/models/demos/t3000/falcon40b/tests/test_falcon_end_to_end.py
@@ -445,6 +445,10 @@ def run_test_FalconCausalLM_end_to_end(
         ),
     ),
 )
+@pytest.mark.parametrize(
+    "async_mode",
+    (True,),
+)
 def test_FalconCausalLM_end_to_end_with_program_cache(
     num_devices,
     model_version,
@@ -460,6 +464,7 @@ def test_FalconCausalLM_end_to_end_with_program_cache(
     get_tt_cache_path,
     t3k_device_mesh,
     use_program_cache,
+    async_mode,
 ):
     model_config_str = f"{data_type}-{memcfg}"
     if llm_mode == "prefill" and memcfg != "DRAM" or num_devices != 8:
@@ -520,6 +525,9 @@ def test_FalconCausalLM_end_to_end_with_program_cache(
     input_shape = [batch, seq_len]
     model_config = get_model_config(model_config_str, llm_mode, input_shape, num_devices)
     devices = t3k_device_mesh.get_devices()
+    # Set async mode
+    for device in devices:
+        device.enable_async(async_mode)
     compute_grid_size = devices[0].compute_with_storage_grid_size()
     if compute_grid_size.x < model_config["MAX_GRID_SIZE"][0] or compute_grid_size.y < model_config["MAX_GRID_SIZE"][1]:
         pytest.skip(f"Requires grid size of at least {model_config['MAX_GRID_SIZE']} to run")

--- a/models/demos/t3000/falcon40b/tests/test_perf_falcon.py
+++ b/models/demos/t3000/falcon40b/tests/test_perf_falcon.py
@@ -330,7 +330,7 @@ def run_test_FalconCausalLM_end_to_end(
 @pytest.mark.parametrize(
     "llm_mode, batch, seq_len, kv_cache_len, expected_compile_time, expected_inference_time, num_layers, model_config_str",
     (
-        ("prefill", 1, 32, 0, 60, 0.37 + 0.04, 60, "BFLOAT8_B-DRAM"),
+        ("prefill", 1, 32, 0, 62, 0.37 + 0.04, 60, "BFLOAT8_B-DRAM"),
         ("prefill", 1, 128, 0, 60, 0.39 + 0.04, 60, "BFLOAT8_B-DRAM"),
         ("prefill", 1, 2048, 0, 60, 0.94 + 0.1, 60, "BFLOAT8_B-DRAM"),
         ("prefill", 1, 32, 0, 60, 0.42 + 0.04, 60, "BFLOAT16-DRAM"),

--- a/models/demos/t3000/falcon40b/tests/test_perf_falcon.py
+++ b/models/demos/t3000/falcon40b/tests/test_perf_falcon.py
@@ -353,6 +353,10 @@ def run_test_FalconCausalLM_end_to_end(
     ("tiiuae/falcon-40b-instruct",),
     ids=["falcon_40b"],
 )
+@pytest.mark.parametrize(
+    "async_mode",
+    (True,),
+)
 def test_perf_bare_metal(
     num_devices,
     model_version,
@@ -370,6 +374,7 @@ def test_perf_bare_metal(
     t3k_device_mesh,
     use_program_cache,
     is_ci_env,
+    async_mode,
 ):
     if llm_mode == "prefill" and (model_config_str not in ["BFLOAT8_B-DRAM", "BFLOAT16-DRAM"] or num_devices != 8):
         pytest.skip("Prefill is only supported for DRAM memory config and 8 chips!")
@@ -379,6 +384,8 @@ def test_perf_bare_metal(
     input_shape = [batch, seq_len]
     model_config = get_model_config(model_config_str, llm_mode, input_shape, num_devices)
     devices = t3k_device_mesh.get_devices()
+    for device in devices:
+        device.enable_async(async_mode)
     compute_grid_size = devices[0].compute_with_storage_grid_size()
     if compute_grid_size.x < model_config["MAX_GRID_SIZE"][0] or compute_grid_size.y < model_config["MAX_GRID_SIZE"][1]:
         pytest.skip(f"Requires grid size of at least {model_config['MAX_GRID_SIZE']} to run")

--- a/models/demos/t3000/falcon40b/tt/falcon_mlp.py
+++ b/models/demos/t3000/falcon40b/tt/falcon_mlp.py
@@ -8,7 +8,7 @@ import ttnn
 from typing import List
 from models.demos.t3000.falcon40b.tt.model_utils import falcon_prefill_matmul, determine_tensor_deallocation
 
-from ttnn import ShardTensorToMesh
+from ttnn import ShardTensorToMesh, ReplicateTensorToMesh
 
 
 class TtFalconMLP:
@@ -78,12 +78,13 @@ class TtFalconMLP:
             out_shape = (1, 1, seq_len, self.dense_4h_to_h_weights.shape[-1])
             out_tensor = torch.zeros(out_shape).bfloat16()
 
-            self.output = ttnn.from_torch(
+            self.output = ttnn.as_tensor(
                 out_tensor,
                 self.model_config["DENSE_4H_TO_H_MM_OUTPUT_DTYPE"],
-                device=self.device_mesh,
                 layout=ttnn.TILE_LAYOUT,
+                device=self.device_mesh,
                 memory_config=self.model_config["DEFAULT_MEMCFG"],
+                mesh_mapper=ReplicateTensorToMesh(self.device_mesh),
             )
 
     def __call__(


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/10583

### Problem description
Falcon40b doesn't support Async mode

### What's changed
Enabling Async mode improves e2e perf for all seq_lens.

### Checklist

- [x] [perf tests](https://github.com/tenstorrent/tt-metal/actions/runs/10161536977)
- [x] [frequent](https://github.com/tenstorrent/tt-metal/actions/runs/10161520535)
- [x] [demo tests](https://github.com/tenstorrent/tt-metal/actions/runs/10161547970)
- [ ] [perplexity tests](https://github.com/tenstorrent/tt-metal/actions/runs/10161558018)
- [x] [unit tests](https://github.com/tenstorrent/tt-metal/actions/runs/10161565866)
