### PR TITLE
Add Falcon7b-decode device perf tests

### DIFF
--- a/models/demos/falcon7b_common/tests/run_falcon_end_to_end.py
+++ b/models/demos/falcon7b_common/tests/run_falcon_end_to_end.py
@@ -165,27 +165,28 @@ def run_test_FalconCausalLM_end_to_end(
     )
     profiler.end("TtFalcon_model_setup")
 
+    # Generate dummy kv_cache --------------------------------------------------------------
+    (
+        past_key_values,
+        tt_layer_past,
+        kv_len,
+    ) = get_rand_falcon_inputs(
+        llm_mode,
+        seq_len,
+        batch,
+        kv_cache_len,
+        devices,
+        global_batch,
+        head_dim,
+        max_position_embeddings,
+        configuration,
+        model_config,
+        num_layers=num_layers,
+        generate_attention_inputs=False,
+    )
+
     if not device_perf:
         # Do warmp up run unless testing device perf -------------------------------------------
-        # Generate dummy kv_cache --------------------------------------------------------------
-        (
-            past_key_values,
-            tt_layer_past,
-            kv_len,
-        ) = get_rand_falcon_inputs(
-            llm_mode,
-            seq_len,
-            batch,
-            kv_cache_len,
-            devices,
-            global_batch,
-            head_dim,
-            max_position_embeddings,
-            configuration,
-            model_config,
-            num_layers=num_layers,
-            generate_attention_inputs=False,
-        )
 
         profiler.start("processing_of_input")
         # TODO: Generate attention_mask on device


### PR DESCRIPTION
### Ticket
#5383 

### Problem description
- There were no Falcon7b device perf tests for decode-128/1024/2047 and prefill-1024

### What's changed
- Added the missing device perf tests
- Modified run_falcon_end_to_end to generate kv_cache in the same pattern as test_perf_falcon, to maintain the same rand decode inputs and pcc

### Checklist
- [x] Post commit CI passes
- [x] Model regression CI testing passes (if applicable)
- [x] New/Existing tests provide coverage for changes
