### PR TITLE
#8957: Add user and host data to sweeps results

### DIFF
--- a/tests/sweep_framework/query.py
+++ b/tests/sweep_framework/query.py
@@ -242,6 +242,8 @@ def detail(ctx):
         colored("Details", "light_red"),
         colored("Git Hash", "light_red"),
         colored("e2e Perf", "light_red"),
+        colored("User", "light_red"),
+        colored("Host", "light_red"),
     ]
 
     client = Elasticsearch(ctx.obj["elastic"], basic_auth=("elastic", ELASTIC_PASSWORD))
@@ -277,6 +279,8 @@ def detail(ctx):
                     detail,
                     source["git_hash"],
                     source["e2e_perf"] + " ms" if source["e2e_perf"] != "None" else "None",
+                    source["user"],
+                    source["host"],
                 ],
                 result["_id"],
             )


### PR DESCRIPTION
### Ticket
#8957

### Problem description
It was not possible to tell who ran the sweep tests, and on what machine they were run on.

### What's changed
Adds user and host data to test results so we know which user/machine the test was run by/on.

### Checklist
- [x] Post commit CI passes
- [ ] Model regression CI testing passes (if applicable)
- [ ] New/Existing tests provide coverage for changes
