### PR TITLE
#10794: Use correct REG_TLB for BH and uplift tlb configs to pull from <arch>_implementation in UMD rather than DEVICE_DATA

### DIFF
--- a/tt_metal/llrt/tlb_config.hpp
+++ b/tt_metal/llrt/tlb_config.hpp
@@ -14,6 +14,6 @@ namespace ll_api {
 
 void configure_static_tlbs(tt::ARCH arch, chip_id_t mmio_device_id, const metal_SocDescriptor &sdesc, tt_device &device_driver);
 
-std::unordered_map<std::string, std::int32_t> get_dynamic_tlb_config();
+std::unordered_map<std::string, std::int32_t> get_dynamic_tlb_config(tt::ARCH arch);
 
 }  // namespace ll_api

--- a/tt_metal/llrt/tt_cluster.cpp
+++ b/tt_metal/llrt/tt_cluster.cpp
@@ -11,7 +11,6 @@
 #include <iostream>
 #include <string>
 
-#include "device_data.hpp"
 #include "hostdevcommon/dprint_common.h"
 #include "rtoptions.hpp"
 #include "third_party/umd/device/tt_silicon_driver_common.hpp"
@@ -254,7 +253,7 @@ void Cluster::open_driver(
         if (is_tg_cluster_) {
             num_host_mem_ch_per_mmio_device = HOST_MEM_CHANNELS;
         }
-        std::unordered_map<std::string, std::int32_t> dynamic_tlb_config = ll_api::get_dynamic_tlb_config();
+        std::unordered_map<std::string, std::int32_t> dynamic_tlb_config = ll_api::get_dynamic_tlb_config(this->arch_);
         // This will remove harvested rows from the soc descriptor
         const bool perform_harvesting = true;
         const bool clean_system_resources = true;
@@ -976,8 +975,6 @@ uint32_t Cluster::get_mmio_device_tunnel_count(chip_id_t mmio_device) const {
 uint32_t Cluster::get_device_tunnel_depth(chip_id_t chip_id) const {
     return this->cluster_desc_->get_ethernet_link_distance(chip_id, this->get_associated_mmio_device(chip_id));
 }
-
-uint32_t Cluster::get_tensix_soft_reset_addr() const { return DEVICE_DATA.TENSIX_SOFT_RESET_ADDR; }
 
 }  // namespace tt
 

--- a/tt_metal/llrt/tt_cluster.hpp
+++ b/tt_metal/llrt/tt_cluster.hpp
@@ -206,8 +206,6 @@ class Cluster {
         return this->device_to_host_mem_channel_.at(device_id);
     }
 
-    uint32_t get_tensix_soft_reset_addr() const;
-
     // Returns collection of devices that are controlled by the specified MMIO device inclusive of the MMIO device
     const std::set<chip_id_t> &get_devices_controlled_by_mmio_device(chip_id_t mmio_device_id) const {
         TT_ASSERT(


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/10794

### Problem description
TLBs were getting configured using values from DEVICE_DATA struct in UMD. UMD has duplicated information in this struct and in `<arch_name>_implementation.hpp` header. 

DEVICE_DATA for BH had incorrect values and the idea is to eventually remove DEVICE_DATA in UMD (as per @joelsmithTT) so we shouldn't be using it in Metal. 

I will try to make a change in UMD to remove DEVICE_DATA

### What's changed
Remove dependence on DEVICE_DATA and use values from `<arch_name>_implementation.hpp`

### Checklist
- [x] [Post commit CI passes](https://github.com/tenstorrent/tt-metal/actions/runs/10150208206)
- [x] [Model regression CI testing passes](https://github.com/tenstorrent/tt-metal/actions/runs/10150218320)
