### PR TITLE
#9866: CCL ops support for Galaxy 2D grid configuration

### DIFF
--- a/tests/ttnn/multichip_unit_tests/test_multidevice_TG.py
+++ b/tests/ttnn/multichip_unit_tests/test_multidevice_TG.py
@@ -12,6 +12,7 @@ from tests.tt_eager.python_api_testing.sweep_tests.comparison_funcs import comp_
 
 from ttnn import (
     ShardTensorToMesh,
+    ShardTensor2dMesh,
     ReplicateTensorToMesh,
     ConcatMeshToTensor,
     ListMeshToTensor,
@@ -67,7 +68,7 @@ def test_galaxy_matmul_1d_fracture(device_mesh):
     assert out_pass
 
 
-class ShardTensor2dMesh(TensorToMesh):
+class CustomShardTensor2dMesh(TensorToMesh):
     def __init__(self, device_mesh, dims, cluster_shape):
         super().__init__(device_mesh)
         self.dims = dims
@@ -158,14 +159,14 @@ def test_galaxy_matmul_2d_fracture(M, K, N, weights_dtype, cluster_shape, device
         layout=ttnn.TILE_LAYOUT,
         memory_config=act_mem_config if M == 32 else ttnn.DRAM_MEMORY_CONFIG,
         device=device_mesh,
-        mesh_mapper=ShardTensor2dMesh(device_mesh, dims=act_shard_dim, cluster_shape=cluster_shape),
+        mesh_mapper=CustomShardTensor2dMesh(device_mesh, dims=act_shard_dim, cluster_shape=cluster_shape),
     )
     weights = ttnn.from_torch(
         weights_pt,
         dtype=weights_dtype,
         layout=ttnn.TILE_LAYOUT,
         device=device_mesh,
-        mesh_mapper=ShardTensor2dMesh(device_mesh, dims=weight_shard_dim, cluster_shape=cluster_shape),
+        mesh_mapper=CustomShardTensor2dMesh(device_mesh, dims=weight_shard_dim, cluster_shape=cluster_shape),
     )
 
     gt = act_pt @ weights_pt
@@ -233,7 +234,7 @@ def test_galaxy_matmul_2d_fracture_dram_sharded(M, K, N, weights_dtype, cluster_
         layout=ttnn.TILE_LAYOUT,
         device=device_mesh,
         memory_config=act_mem_config,
-        mesh_mapper=ShardTensor2dMesh(device_mesh, dims=act_shard_dim, cluster_shape=cluster_shape),
+        mesh_mapper=CustomShardTensor2dMesh(device_mesh, dims=act_shard_dim, cluster_shape=cluster_shape),
     )
 
     compute_kernel_lofi = ttnn.WormholeComputeKernelConfig(
@@ -263,7 +264,7 @@ def test_galaxy_matmul_2d_fracture_dram_sharded(M, K, N, weights_dtype, cluster_
         layout=ttnn.TILE_LAYOUT,
         device=device_mesh,
         memory_config=weight_mem_config,
-        mesh_mapper=ShardTensor2dMesh(device_mesh, dims=weight_shard_dim, cluster_shape=cluster_shape),
+        mesh_mapper=CustomShardTensor2dMesh(device_mesh, dims=weight_shard_dim, cluster_shape=cluster_shape),
     )
 
     DRAM_SHARDED_PROGCFG = ttnn.MatmulMultiCoreReuseMultiCastDRAMShardedProgramConfig(
@@ -313,7 +314,7 @@ def test_galaxy_eltwise_mul_2d_fracture(M, N, cluster_shape, device_mesh):
         dtype=ttnn.bfloat16,
         layout=ttnn.TILE_LAYOUT,
         device=device_mesh,
-        mesh_mapper=ShardTensor2dMesh(device_mesh, dims=(None, 3), cluster_shape=cluster_shape),
+        mesh_mapper=CustomShardTensor2dMesh(device_mesh, dims=(None, 3), cluster_shape=cluster_shape),
     )
 
     FF3 = ttnn.from_torch(
@@ -321,7 +322,7 @@ def test_galaxy_eltwise_mul_2d_fracture(M, N, cluster_shape, device_mesh):
         dtype=ttnn.bfloat16,
         layout=ttnn.TILE_LAYOUT,
         device=device_mesh,
-        mesh_mapper=ShardTensor2dMesh(device_mesh, dims=(None, 3), cluster_shape=cluster_shape),
+        mesh_mapper=CustomShardTensor2dMesh(device_mesh, dims=(None, 3), cluster_shape=cluster_shape),
     )
 
     gt = FF1_pt * FF3_pt
@@ -439,7 +440,7 @@ def test_galaxy_attn_matmul(M, N, head_dim, num_heads, cluster_shape, device_mes
         dtype=ttnn.bfloat8_b,
         layout=ttnn.TILE_LAYOUT,
         device=device_mesh,
-        mesh_mapper=ShardTensor2dMesh(device_mesh, dims=(None, 3), cluster_shape=cluster_shape),
+        mesh_mapper=CustomShardTensor2dMesh(device_mesh, dims=(None, 3), cluster_shape=cluster_shape),
     )
 
     compute_kernel_attn = ttnn.WormholeComputeKernelConfig(
@@ -1145,3 +1146,120 @@ def test_galaxy_layernorm(M, N, device_mesh):
     logger.info(f"PCC value: {output_pcc}")
 
     assert out_pass
+
+
+@pytest.mark.parametrize("device_mesh", [pytest.param((8, 4), id="8x4_grid")], indirect=True)
+def test_device_submesh(device_mesh):
+    rows, cols, tile_size = 8, 4, 32
+    full_tensor = torch.rand((1, 1, tile_size * rows, tile_size * cols), dtype=torch.bfloat16)
+
+    ttnn_tensor = ttnn.from_torch(
+        full_tensor, mesh_mapper=ShardTensor2dMesh(device_mesh, shard_grid=(rows, cols), shard_dimensions=(-2, -1))
+    )
+    ttnn_tensor = ttnn.to_device(ttnn_tensor, device_mesh)
+
+    device_tensors: typing.List[ttnn.Tensor] = ttnn.get_device_tensors(ttnn_tensor)
+    for index, device_tensor in enumerate(device_tensors):
+        row_idx = index // cols
+        col_idx = index % cols
+
+        device_tensor_torch = ttnn.to_torch(device_tensor)
+        row_start, row_end = row_idx * tile_size, (row_idx + 1) * tile_size
+        col_start, col_end = col_idx * tile_size, (col_idx + 1) * tile_size
+        assert torch.all(device_tensor_torch == full_tensor[0, 0, row_start:row_end, col_start:col_end])
+
+
+@pytest.mark.parametrize("device_mesh", [pytest.param((1, 4), id="8x4_grid")], indirect=True)
+def test_device_line_all_gather_1x4(device_mesh):
+    rows, cols, tile_size = 1, 4, 32
+    full_tensor = torch.rand((1, 1, tile_size * rows, tile_size * cols), dtype=torch.bfloat16)
+
+    ttnn_tensor = ttnn.from_torch(
+        full_tensor, mesh_mapper=ShardTensor2dMesh(device_mesh, shard_grid=(rows, cols), shard_dimensions=(-2, -1))
+    )
+    ttnn_tensor = ttnn.to_device(ttnn_tensor, device_mesh)
+    ttnn_tensor = ttnn.line_all_gather(ttnn_tensor, dim=3, num_links=1)
+
+    device_tensors: typing.List[ttnn.Tensor] = ttnn.get_device_tensors(ttnn_tensor)
+    for index, device_tensor in enumerate(device_tensors):
+        device_tensor_torch = ttnn.to_torch(device_tensor)
+        print(device_tensor_torch)
+        assert torch.all(device_tensor_torch == full_tensor)
+
+
+@pytest.mark.parametrize("device_mesh", [pytest.param((8, 1), id="8x4_grid")], indirect=True)
+def test_device_line_all_gather_8x1(device_mesh):
+    rows, cols, tile_size = 8, 1, 32
+    full_tensor = torch.rand((1, 1, tile_size * rows, tile_size * cols), dtype=torch.bfloat16)
+
+    ttnn_tensor = ttnn.from_torch(
+        full_tensor, mesh_mapper=ShardTensor2dMesh(device_mesh, shard_grid=(rows, cols), shard_dimensions=(-2, -1))
+    )
+    ttnn_tensor = ttnn.to_device(ttnn_tensor, device_mesh)
+    ttnn_tensor = ttnn.line_all_gather(ttnn_tensor, dim=2, cluster_axis=0, device_mesh=device_mesh, num_links=1)
+
+    device_tensors: typing.List[ttnn.Tensor] = ttnn.get_device_tensors(ttnn_tensor)
+    for index, device_tensor in enumerate(device_tensors):
+        device_tensor_torch = ttnn.to_torch(device_tensor)
+        assert torch.all(device_tensor_torch == full_tensor)
+
+
+@pytest.mark.parametrize("device_mesh", [pytest.param((8, 4), id="8x4_grid")], indirect=True)
+@pytest.mark.parametrize("cluster_axis", (0, 1))
+@pytest.mark.parametrize("dim", (2, 3))
+def test_device_line_all_gather_8x4_data(device_mesh, cluster_axis: int, dim: int):
+    """
+    Test the line-all-gather operation on a 8x4 mesh.
+
+    Data Pattern for initial sharding [TILE_SIZE*DEVICE_MESH_ROWS, TILE_SIZE*DEVICE_MESH_COLS]:
+    [1, 1, 1, 1, 1, 1, 1, 1]
+    [2, 2, 2, 2, 2, 2, 2, 2]
+    [3, 3, 3, 3, 3, 3, 3, 3]
+    [...]
+    [8, 8, 8, 8, 8, 8, 8, 8]
+
+    Data-pattern per-device before line-all-gather:
+    - Each device receives a shard of the tensor with shape: [1, 1, 32, 32]
+
+    Expected data-pattern per-device after line-all-gather:
+    - Every device along the column contains the whole column tensor
+    - output: [[1],[2],[3],[4],[5],[6],[7],[8]], shape: [1, 1, TILE_SIZE * DEVICE_MESH_ROWS, 32]
+    """
+
+    (rows, cols), tile_size = device_mesh.shape, 32
+    full_tensor = torch.zeros((1, 1, tile_size * rows, tile_size * cols), dtype=torch.bfloat16)
+
+    for i in range(rows):
+        full_tensor[0, 0, i * tile_size : (i + 1) * tile_size, :] = torch.full((tile_size, tile_size * cols), i + 1.0)
+
+    ttnn_tensor = ttnn.from_torch(
+        full_tensor, mesh_mapper=ShardTensor2dMesh(device_mesh, shard_grid=(rows, cols), shard_dimensions=(-2, -1))
+    )
+    ttnn_tensor = ttnn.to_device(ttnn_tensor, device_mesh)
+    ttnn_tensor = ttnn.line_all_gather(
+        ttnn_tensor, dim=dim, cluster_axis=cluster_axis, device_mesh=device_mesh, num_links=1
+    )
+
+    device_tensors: typing.List[ttnn.Tensor] = ttnn.get_device_tensors(ttnn_tensor)
+
+    # device iteration happens in logical row-major
+    for index, device_tensor in enumerate(device_tensors):
+        row_index = index // cols
+        col_index = index % cols
+        device_tensor_torch = ttnn.to_torch(device_tensor)
+
+        if dim == 2:
+            if cluster_axis == 0:  # cluster along rows
+                expected = full_tensor[..., :tile_size]
+            else:  # cluster along columns
+                expected = full_tensor[..., row_index * tile_size : (row_index + 1) * tile_size, :tile_size].repeat(
+                    1, 1, cols, 1
+                )
+        elif dim == 3:
+            if cluster_axis == 0:  # cluster along rows
+                expected = full_tensor[..., :tile_size]
+                expected = torch.permute(expected, (0, 1, 3, 2))
+            else:  # cluster along columns
+                expected = full_tensor[..., row_index * tile_size : (row_index + 1) * tile_size, :]
+
+        assert torch.allclose(device_tensor_torch, expected, atol=1e-3)

--- a/tt_metal/impl/CMakeLists.txt
+++ b/tt_metal/impl/CMakeLists.txt
@@ -3,6 +3,7 @@ set(IMPL_SRC
     ${CMAKE_CURRENT_SOURCE_DIR}/device/device.cpp
 	${CMAKE_CURRENT_SOURCE_DIR}/device/device_pool.cpp
 	${CMAKE_CURRENT_SOURCE_DIR}/device/multi_device.cpp
+	${CMAKE_CURRENT_SOURCE_DIR}/device/device_mesh_view.cpp
 	${CMAKE_CURRENT_SOURCE_DIR}/buffers/buffer.cpp
 	${CMAKE_CURRENT_SOURCE_DIR}/buffers/circular_buffer.cpp
 	${CMAKE_CURRENT_SOURCE_DIR}/buffers/semaphore.cpp

--- a/tt_metal/impl/device/device_mesh_view.cpp
+++ b/tt_metal/impl/device/device_mesh_view.cpp
@@ -1,0 +1,197 @@
+// SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "tt_metal/impl/device/device_mesh_view.hpp"
+#include "tt_metal/impl/device/multi_device.hpp"
+#include <algorithm>
+#include <stdexcept>
+
+namespace tt::tt_metal {
+
+using DeviceMesh = ttnn::multi_device::DeviceMesh;
+
+DeviceMeshView::DeviceMeshView(const DeviceMesh& mesh)
+    : top_left_(0, 0), bottom_right_(mesh.num_rows() - 1, mesh.num_cols() - 1) {
+    for (int row = 0; row < mesh.num_rows(); ++row) {
+        for (int col = 0; col < mesh.num_cols(); ++col) {
+            if (auto device = mesh.get_device(row, col)) {
+                devices_.push_back(device);
+                device_coordinates_[(device)->id()] = {row, col};
+            }
+        }
+    }
+}
+
+DeviceMeshView::DeviceMeshView(const DeviceMesh& mesh, Coordinate top_left, Coordinate bottom_right)
+    : top_left_(top_left), bottom_right_(bottom_right) {
+    for (int row = top_left.row; row <= bottom_right.row; ++row) {
+        for (int col = top_left.col; col <= bottom_right.col; ++col) {
+            if (auto device = mesh.get_device(row, col)) {
+                devices_.push_back(device);
+                device_coordinates_[(device)->id()] = {row, col};
+            }
+        }
+    }
+    validate_coordinates();
+}
+
+DeviceMeshView::DeviceMeshView(const DeviceMesh& global_mesh, const std::vector<device_pointer>& devices)
+    : devices_(devices) {
+    int min_row = std::numeric_limits<int>::max(), min_col = std::numeric_limits<int>::max();
+    int max_row = std::numeric_limits<int>::min(), max_col = std::numeric_limits<int>::min();
+
+    for (const auto& device : devices) {
+        if (auto coord = global_mesh.find_device(device->id())) {
+            device_coordinates_[device->id()] = *coord;
+            min_row = std::min(min_row, coord->row);
+            min_col = std::min(min_col, coord->col);
+            max_row = std::max(max_row, coord->row);
+            max_col = std::max(max_col, coord->col);
+        } else {
+            throw std::runtime_error("Device not found in global mesh");
+        }
+    }
+
+    top_left_ = {min_row, min_col};
+    bottom_right_ = {max_row, max_col};
+}
+
+DeviceMeshView::DeviceMeshView(std::vector<device_pointer> devices, CoordinateMapper mapper)
+    : devices_(std::move(devices)) {
+    initialize_from_devices(devices_, std::move(mapper));
+}
+
+DeviceMeshView::device_pointer DeviceMeshView::get_device(int row, int col) {
+    return const_cast<device_pointer>(std::as_const(*this).get_device(row, col));
+}
+
+DeviceMeshView::const_device_pointer DeviceMeshView::get_device(int row, int col) const {
+    for (const auto& device : devices_) {
+        auto it = device_coordinates_.find(device->id());
+        if (it != device_coordinates_.end() && it->second.row == row && it->second.col == col) {
+            return device;
+        }
+    }
+    return nullptr;
+}
+
+const std::vector<DeviceMeshView::device_pointer>& DeviceMeshView::get_devices() const {
+    return devices_;
+}
+
+std::vector<DeviceMeshView::device_pointer> DeviceMeshView::get_devices_on_row(int row) const {
+    std::vector<device_pointer> row_devices;
+    for (const auto& device : devices_) {
+        auto it = device_coordinates_.find(device->id());
+        if (it != device_coordinates_.end() && it->second.row == row) {
+            row_devices.push_back(device);
+        }
+    }
+    return row_devices;
+}
+
+std::vector<DeviceMeshView::device_pointer> DeviceMeshView::get_devices_on_column(int col) const {
+    std::vector<device_pointer> col_devices;
+    for (const auto& device : devices_) {
+        auto it = device_coordinates_.find(device->id());
+        if (it != device_coordinates_.end() && it->second.col == col) {
+            col_devices.push_back(device);
+        }
+    }
+    return col_devices;
+}
+
+std::vector<std::vector<DeviceMeshView::device_pointer>> DeviceMeshView::get_row_views() const {
+    std::vector<std::vector<device_pointer>> row_views;
+    for (int row = top_left_.row; row <= bottom_right_.row; ++row) {
+        row_views.push_back(get_devices_on_row(row));
+    }
+    return row_views;
+}
+
+std::vector<std::vector<DeviceMeshView::device_pointer>> DeviceMeshView::get_column_views() const {
+    std::vector<std::vector<device_pointer>> column_views;
+    for (int col = top_left_.col; col <= bottom_right_.col; ++col) {
+        column_views.push_back(get_devices_on_column(col));
+    }
+    return column_views;
+}
+
+template<typename Pred>
+DeviceMeshView DeviceMeshView::subview(Pred&& predicate) const {
+    std::vector<device_pointer> filtered_devices;
+    std::copy_if(devices_.begin(), devices_.end(), std::back_inserter(filtered_devices), std::forward<Pred>(predicate));
+    return DeviceMeshView(filtered_devices, [this](int device_id) {
+        auto it = device_coordinates_.find(device_id);
+        return it != device_coordinates_.end() ? std::optional<Coordinate>(it->second) : std::nullopt;
+    });
+}
+
+bool DeviceMeshView::empty() const noexcept {
+    return devices_.empty();
+}
+
+size_t DeviceMeshView::size() const noexcept {
+    return devices_.size();
+}
+
+std::pair<int, int> DeviceMeshView::shape() const noexcept {
+    return {num_rows(), num_cols()};
+}
+
+bool DeviceMeshView::contains(const Coordinate& coord) const noexcept {
+    return coord.row >= top_left_.row && coord.row <= bottom_right_.row &&
+           coord.col >= top_left_.col && coord.col <= bottom_right_.col;
+}
+
+DeviceMeshView::const_device_pointer DeviceMeshView::at(const Coordinate& coord) const noexcept {
+    if (contains(coord)) {
+        return get_device(coord.row, coord.col);
+    }
+    return nullptr;
+}
+
+bool DeviceMeshView::operator==(const DeviceMeshView& other) const {
+    return devices_ == other.devices_ &&
+           device_coordinates_ == other.device_coordinates_ &&
+           top_left_ == other.top_left_ &&
+           bottom_right_ == other.bottom_right_;
+}
+
+std::optional<Coordinate> DeviceMeshView::find_device(int device_id) const {
+    auto it = device_coordinates_.find(device_id);
+    if (it != device_coordinates_.end()) {
+        return it->second;
+    }
+    return std::nullopt;
+}
+
+void DeviceMeshView::initialize_from_devices(const std::vector<device_pointer>& devices, CoordinateMapper mapper) {
+    int min_row = std::numeric_limits<int>::max(), min_col = std::numeric_limits<int>::max();
+    int max_row = std::numeric_limits<int>::min(), max_col = std::numeric_limits<int>::min();
+
+    for (const auto& device : devices) {
+        auto coord = mapper(device->id());
+        if (!coord) {
+            throw std::runtime_error("Failed to map device ID to coordinate");
+        }
+
+        device_coordinates_[device->id()] = *coord;
+        min_row = std::min(min_row, coord->row);
+        min_col = std::min(min_col, coord->col);
+        max_row = std::max(max_row, coord->row);
+        max_col = std::max(max_col, coord->col);
+    }
+
+    top_left_ = {min_row, min_col};
+    bottom_right_ = {max_row, max_col};
+}
+
+void DeviceMeshView::validate_coordinates() const {
+    if (top_left_.row > bottom_right_.row || top_left_.col > bottom_right_.col) {
+        throw std::invalid_argument("Invalid coordinates: top_left must be less than or equal to bottom_right");
+    }
+}
+
+} // namespace tt::tt_metal

--- a/tt_metal/impl/device/device_mesh_view.hpp
+++ b/tt_metal/impl/device/device_mesh_view.hpp
@@ -1,0 +1,104 @@
+// SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <memory>
+#include <vector>
+#include <unordered_map>
+#include <optional>
+#include <functional>
+
+#include "tt_metal/impl/device/device.hpp"
+
+// Forward declaration of DeviceMesh
+namespace ttnn {
+namespace multi_device {
+class DeviceMesh;
+} // namespace multi_device
+} // namespace ttnn
+
+namespace tt::tt_metal {
+
+struct Coordinate {
+    int row;
+    int col;
+    auto operator<=>(const Coordinate&) const = default;
+};
+
+/**
+ * @brief The DeviceMeshView class provides a view of a specific sub-region within the DeviceMesh.
+ *
+ * Once a DeviceMesh is initialized, DeviceMeshView allows the creation of multiple "views" on the
+ * DeviceMesh, enabling more granular control over a cluster of initialized devices. This approach
+ * differs from simply creating a new DeviceMesh on a subset of devices.
+ *
+ * DeviceMeshView serves two primary purposes:
+ *
+ * 1. It facilitates the creation of abstractions that define parallelization strategies, such as
+ *    tensor-parallel or pipeline-parallel, by assigning views of the DeviceMesh.
+ *
+ * 2. It acts as a query interface for the DeviceMesh, allowing the retrieval of devices based on
+ *    specific sub-regions. This is particularly useful for collective communication operations
+ *    (CCL-ops), such as line all-gather, which require column or row views of the device mesh.
+ */
+class DeviceMeshView {
+public:
+    using device_pointer = Device*;
+    using const_device_pointer = const Device*;
+    using DeviceView = std::vector<device_pointer>;
+    using DeviceViews = std::vector<std::vector<device_pointer>>;
+    using CoordinateMapper = std::function<std::optional<Coordinate>(int device_id)>;
+
+    DeviceMeshView(const ttnn::multi_device::DeviceMesh& mesh);
+    DeviceMeshView(const ttnn::multi_device::DeviceMesh& mesh, Coordinate top_left, Coordinate bottom_right);
+    DeviceMeshView(const ttnn::multi_device::DeviceMesh& global_mesh, const std::vector<device_pointer>& devices);
+    DeviceMeshView(std::vector<device_pointer> devices, CoordinateMapper mapper);
+
+    [[nodiscard]] device_pointer get_device(int row, int col);
+    [[nodiscard]] const_device_pointer get_device(int row, int col) const;
+
+    [[nodiscard]] const std::vector<device_pointer>& get_devices() const;
+    [[nodiscard]] DeviceView get_devices_on_row(int row) const;
+    [[nodiscard]] DeviceView get_devices_on_column(int col) const;
+
+    [[nodiscard]] DeviceViews get_row_views() const;
+    [[nodiscard]] DeviceViews get_column_views() const;
+
+    template<typename Pred>
+    [[nodiscard]] DeviceMeshView subview(Pred&& predicate) const;
+
+    [[nodiscard]] bool empty() const noexcept;
+    [[nodiscard]] size_t size() const noexcept;
+    [[nodiscard]] std::pair<int, int> shape() const noexcept;
+    [[nodiscard]] bool contains(const Coordinate& coord) const noexcept;
+    [[nodiscard]] const_device_pointer at(const Coordinate& coord) const noexcept;
+
+    bool operator==(const DeviceMeshView& other) const;
+
+    auto begin() const { return devices_.begin(); }
+    auto end() const { return devices_.end(); }
+
+    [[nodiscard]] int num_rows() const { return bottom_right_.row - top_left_.row + 1; }
+    [[nodiscard]] int num_cols() const { return bottom_right_.col - top_left_.col + 1; }
+    [[nodiscard]] int num_devices() const { return devices_.size(); }
+
+    [[nodiscard]] std::optional<Coordinate> find_device(int device_id) const;
+
+private:
+    std::vector<device_pointer> devices_;
+    std::unordered_map<int, Coordinate> device_coordinates_;
+    Coordinate top_left_;
+    Coordinate bottom_right_;
+
+    void initialize_from_devices(const std::vector<device_pointer>& devices, CoordinateMapper mapper);
+    void validate_coordinates() const;
+};
+
+// Helper function to create a DeviceMeshView
+inline DeviceMeshView make_device_mesh_view(std::vector<Device*> devices, DeviceMeshView::CoordinateMapper mapper) {
+    return DeviceMeshView(std::move(devices), std::move(mapper));
+}
+
+} // namespace tt::tt_metal

--- a/tt_metal/impl/device/multi_device.hpp
+++ b/tt_metal/impl/device/multi_device.hpp
@@ -5,10 +5,16 @@
 #pragma once
 
 #include <memory>
+#include <vector>
+#include <map>
+#include <optional>
 
 #include "tt_metal/impl/device/device.hpp"
+#include "tt_metal/impl/device/device_mesh_view.hpp"
 
 using Device = tt::tt_metal::Device;
+using DeviceMeshView = tt::tt_metal::DeviceMeshView;
+using Coordinate = tt::tt_metal::Coordinate;
 
 
 namespace ttnn {
@@ -23,6 +29,7 @@ public:
     DeviceGrid device_grid;
     std::map<chip_id_t, Device *> managed_devices;
     std::vector<std::pair<int, Device *>> mesh_devices;
+    std::unique_ptr<DeviceMeshView> view;
 
     DeviceMesh(const DeviceGrid &device_grid, const DeviceIds &device_ids, size_t l1_small_size, size_t trace_region_size, size_t num_command_queues);
     ~DeviceMesh();
@@ -39,9 +46,14 @@ public:
     std::vector<Device *> get_devices_on_row(int row_idx) const;
     std::vector<Device *> get_devices_on_column(int col_idx) const;
 
+    std::optional<Coordinate> find_device(int device_id) const;
+
     const DeviceIds get_device_ids() const;
 
     int num_devices() const;
+    int num_rows() const;
+    int num_cols() const;
+    DeviceGrid shape() const;
 
     CoreCoord compute_with_storage_grid_size() const;
 
@@ -52,8 +64,7 @@ public:
     void close_devices();
 
    private:
-    int num_rows;
-    int num_cols;
+    bool is_galaxy_;
 };
 
 

--- a/tt_metal/impl/module.mk
+++ b/tt_metal/impl/module.mk
@@ -7,6 +7,7 @@ TT_METAL_IMPL_SRCS = \
 	tt_metal/impl/device/device.cpp \
 	tt_metal/impl/device/device_pool.cpp \
 	tt_metal/impl/device/multi_device.cpp \
+	tt_metal/impl/device/device_mesh_view.cpp \
 	tt_metal/impl/buffers/buffer.cpp \
 	tt_metal/impl/buffers/circular_buffer.cpp \
 	tt_metal/impl/buffers/semaphore.cpp \

--- a/ttnn/cpp/pybind11/multi_device.hpp
+++ b/ttnn/cpp/pybind11/multi_device.hpp
@@ -84,6 +84,12 @@ void py_module(py::module& module) {
 
             Returns:
                 Arch: The arch of the first device in the device mesh.
+        )doc")
+        .def_property_readonly("shape", &ttnn::multi_device::DeviceMesh::shape, R"doc(
+            Get the shape of the device mesh.
+
+            Returns:
+                Tuple[int, int]: The shape of the device mesh as (num_rows, num_cols).
         )doc");
 
     module.def(

--- a/ttnn/cpp/ttnn/operations/ccl/line_all_gather/device/line_all_gather_op.cpp
+++ b/ttnn/cpp/ttnn/operations/ccl/line_all_gather/device/line_all_gather_op.cpp
@@ -4,6 +4,7 @@
 
 #include "ttnn/operations/ccl/line_all_gather/device/line_all_gather_op.hpp"
 #include "ttnn/operations/ccl/all_gather/device/all_gather_op.hpp"
+#include "tt_metal/impl/device/device_mesh_view.hpp"
 #include "tt_dnn/op_library/math.hpp"
 
 #include "tt_metal/host_api.hpp"
@@ -124,6 +125,55 @@ Tensor line_all_gather(
         {input_tensor},
         output_tensors);
     return output_tensors.at(0);
+}
+
+Tensor line_all_gather(
+    const Tensor& input_tensor,
+    const uint32_t dim,
+    const uint32_t cluster_axis,
+    const multi_device::DeviceMesh& device_mesh,
+    const uint32_t num_links,
+    const std::optional<MemoryConfig>& memory_config) {
+
+    const auto view = tt::tt_metal::DeviceMeshView(device_mesh);
+    const auto device_views = (cluster_axis == 0) ? view.get_column_views() : view.get_row_views();
+
+    std::vector<Tensor> output_tensors = {Tensor(operation::get_workers_for_op_output({input_tensor}))};
+
+    operation::launch_op(
+        [&dim, &num_links, &memory_config, &device_views](
+            const std::vector<Tensor>& input_tensors,
+            const std::vector<std::optional<const Tensor>>& optional_input_tensors,
+            const std::vector<std::optional<Tensor>>& optional_output_tensors) mutable -> std::vector<Tensor> {
+
+            const auto& input_tensor = input_tensors[0];
+            const tt::tt_metal::DeviceMeshView::DeviceView* selected_view = nullptr;
+
+            uint32_t device_index = 0;
+            for (const auto& view : device_views) {
+                auto it = std::find(view.begin(), view.end(), input_tensor.device());
+                if (it != view.end()) {
+                    selected_view = &view;
+                    device_index = std::distance(view.begin(), it);
+                    break;
+                }
+            }
+
+            TT_ASSERT(selected_view != nullptr, "Device not found in any view");
+
+            uint32_t num_devices = selected_view->size();
+            uint32_t receiver_device_id = (*selected_view)[(device_index + 1) % num_devices]->id();
+            uint32_t sender_device_id = (*selected_view)[(device_index + num_devices - 1) % num_devices]->id();
+
+            return operation::run(
+                ttnn::LineAllGather{
+                    dim, num_links, num_devices, device_index, receiver_device_id, sender_device_id, memory_config.value_or(input_tensor.memory_config()), ttnn::all_gather_op::Topology::Linear},
+                {input_tensor});
+        },
+        {input_tensor},
+        output_tensors);
+    return output_tensors.at(0);
+
 }
 
 } // namespace ccl

--- a/ttnn/cpp/ttnn/operations/ccl/line_all_gather/device/line_all_gather_op.hpp
+++ b/ttnn/cpp/ttnn/operations/ccl/line_all_gather/device/line_all_gather_op.hpp
@@ -54,6 +54,14 @@ Tensor line_all_gather(
     const uint32_t num_links = 1,
     const std::optional<MemoryConfig>& memory_config = std::nullopt);
 
+Tensor line_all_gather(
+    const Tensor& input_tensor,
+    const uint32_t dim,
+    const uint32_t cluster_axis,
+    const multi_device::DeviceMesh& device_mesh,
+    const uint32_t num_links = 1,
+    const std::optional<MemoryConfig>& memory_config = std::nullopt);
+
 } // namespace ccl
 } // namespace operations
 

--- a/ttnn/cpp/ttnn/operations/ccl/line_all_gather/line_all_gather.cpp
+++ b/ttnn/cpp/ttnn/operations/ccl/line_all_gather/line_all_gather.cpp
@@ -3,12 +3,28 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "ttnn/operations/ccl/line_all_gather/line_all_gather.hpp"
+
 #include "ttnn/operations/ccl/line_all_gather/device/line_all_gather_op.hpp"
 
 namespace ttnn::operations::ccl {
 
-ttnn::Tensor ExecuteLineAllGather::operator()(const ttnn::Tensor& input_tensor, const uint32_t dim, const uint32_t num_links, const std::optional<ttnn::MemoryConfig>& memory_config) {
+ttnn::Tensor ExecuteLineAllGather::operator()(
+    const ttnn::Tensor& input_tensor,
+    const uint32_t dim,
+    const uint32_t num_links,
+    const std::optional<ttnn::MemoryConfig>& memory_config) {
     return ttnn::operations::ccl::line_all_gather(input_tensor, dim, num_links, memory_config);
+}
+
+ttnn::Tensor ExecuteLineAllGather::operator()(
+    const ttnn::Tensor& input_tensor,
+    const uint32_t dim,
+    const uint32_t cluster_axis,
+    const multi_device::DeviceMesh& device_mesh,
+    const uint32_t num_links,
+    const std::optional<ttnn::MemoryConfig>& memory_config) {
+    return ttnn::operations::ccl::line_all_gather(
+        input_tensor, dim, cluster_axis, device_mesh, num_links, memory_config);
 }
 
 }  // namespace ttnn::operations::ccl

--- a/ttnn/cpp/ttnn/operations/ccl/line_all_gather/line_all_gather.hpp
+++ b/ttnn/cpp/ttnn/operations/ccl/line_all_gather/line_all_gather.hpp
@@ -16,6 +16,14 @@ struct ExecuteLineAllGather {
         const uint32_t dim,
         const uint32_t num_links = 1,
         const std::optional<ttnn::MemoryConfig>& memory_config = std::nullopt);
+
+    static ttnn::Tensor operator()(
+        const ttnn::Tensor& input_tensor,
+        const uint32_t dim,
+        const uint32_t cluster_axis,
+        const multi_device::DeviceMesh& device_mesh,
+        const uint32_t num_links = 1,
+        const std::optional<ttnn::MemoryConfig>& memory_config = std::nullopt);
 };
 
 }  // namespace ccl

--- a/ttnn/cpp/ttnn/operations/ccl/line_all_gather/line_all_gather_pybind.cpp
+++ b/ttnn/cpp/ttnn/operations/ccl/line_all_gather/line_all_gather_pybind.cpp
@@ -32,6 +32,23 @@ void bind_line_all_gather(pybind11::module& module, const ccl_operation_t& opera
             py::arg("dim"),
             py::kw_only(),
             py::arg("num_links") = 1,
+            py::arg("memory_config") = std::nullopt},
+        ttnn::pybind_overload_t{
+            [](const ccl_operation_t& self,
+               const ttnn::Tensor& input_tensor,
+               const uint32_t dim,
+               const uint32_t cluster_axis,
+               const multi_device::DeviceMesh& device_mesh,
+               const uint32_t num_links,
+               const std::optional<ttnn::MemoryConfig>& memory_config) -> ttnn::Tensor {
+                return self(input_tensor, dim, cluster_axis, device_mesh, num_links, memory_config);
+            },
+            py::arg("input_tensor"),
+            py::arg("dim"),
+            py::arg("cluster_axis"),
+            py::arg("device_mesh"),
+            py::kw_only(),
+            py::arg("num_links") = 1,
             py::arg("memory_config") = std::nullopt});
 }
 
@@ -46,10 +63,18 @@ void py_bind_line_all_gather(pybind11::module& module) {
         R"doc(line_all_gather(input_tensor: ttnn.Tensor, dim: int, *, num_links: int = 1, memory_config: Optional[ttnn.MemoryConfig] = None) -> ttnn.Tensor
 
         Performs an all-gather operation on multi-device :attr:`input_tensor` across all devices.
-
         Args:
-            * :attr:`input_tensor` (ttnn.Tensor): multi-device tensor
-            * :attr:`dim` (int)
+            * :attr:`input_tensor` (ttnn.Tensor):
+                multi-device tensor
+            * :attr:`dim` (int):
+                Dimension to perform the all-gather operation on.
+                After the all-gather operation, the size of the :attr:`dim`
+                dimension will larger by number of devices in the line.
+            * :attr:`cluster_axis` (int):
+                Provided a MeshTensor, the axis corresponding to DeviceMesh
+                to perform the line-all-gather operation on.
+            * :attr:`device_mesh` (DeviceMesh):
+                Device mesh to perform the line-all-gather operation on.
 
         Keyword Args:
             * :attr:`num_links` (int): Number of links to use for the all-gather operation.

--- a/ttnn/ttnn/__init__.py
+++ b/ttnn/ttnn/__init__.py
@@ -161,6 +161,7 @@ from ttnn.multi_device import (
     synchronize_devices,
     TensorToMesh,
     ShardTensorToMesh,
+    ShardTensor2dMesh,
     ReplicateTensorToMesh,
     MeshToTensor,
     ConcatMeshToTensor,


### PR DESCRIPTION
This adds support for CCL operation (line-gather) on a Galaxy 2D DeviceMesh. Given a Tensor with data sharded across a DeviceMesh, this issues a series of line all-gather operations.

### Ticket
[Link to Github Issue](https://github.com/tenstorrent/tt-metal/issues/9866)

### Problem description
This is to enable model-team to dispatch a series of line-all-gather operations as a primitive in all-reduce after a tensor-parallel matmul operation.

### What's changed
### 1. Introduce new DeviceMeshView:

This provides a view of a specific sub-region within the DeviceMesh. Once a DeviceMesh is initialized, DeviceMeshView allows the creation of multiple "views" on the DeviceMesh, enabling more granular control over a cluster of initialized devices. This approach differs from simply creating a new DeviceMesh on a subset of devices.

DeviceMeshView serves two primary purposes:

a. It facilitates the creation of abstractions that define parallelization strategies, such as tensor-parallel or pipeline-parallel, by assigning views of the DeviceMesh.

b. It acts as a query interface for the DeviceMesh, allowing the retrieval of devices based on specific sub-regions. This is particularly useful for collective communication operations (CCL-ops), such as line all-gather, which require column or row views of the device mesh.

### 2. New API for dispatching `ttnn.line_all_gather` on a Tensor distributed over a 2D DeviceMesh

```python
# API
        R"doc(line_all_gather(input_tensor: ttnn.Tensor, dim: int, *, num_links: int = 1, memory_config: Optional[ttnn.MemoryConfig] = None) -> ttnn.Tensor
        Performs an all-gather operation on the :attr:`dim` dimension for :attr:`input_tensor` on devices along `cluster_dim` dimension of the DeviceMesh.
        Args:
            * :attr:`input_tensor` (ttnn.Tensor):
                multi-device tensor
            * :attr:`dim` (int):
                Dimension to perform the all-gather operation on.
                After the all-gather operation, the size of the :attr:`dim`
                dimension will larger by number of devices in the line.
            * :attr:`cluster_axis` (int):
                Provided a MeshTensor, the axis corresponding to DeviceMesh
                to perform the line-all-gather operation on.
            * :attr:`device_mesh` (DeviceMesh):
                Device mesh to perform the line-all-gather operation on.

```

```python

# Example Usage:

    (mesh_rows, mesh_cols), tile_size = device_mesh.shape, 32
    full_tensor = torch.rand((1, 1, tile_size * rows, tile_size * cols), dtype=torch.bfloat16)

    ttnn_tensor: ttnn.Tensor = ttnn.from_torch(
        full_tensor, mesh_mapper=ShardTensor2dMesh(device_mesh, shard_grid=(rows, cols), shard_dimensions=(-2, -1))
    )
    ttnn_tensor = ttnn.to_device(ttnn_tensor, device_mesh)
    ttnn_tensor = ttnn.line_all_gather(
        ttnn_tensor, dim=dim, cluster_axis=cluster_axis, device_mesh=device_mesh, num_links=1
    )

```

![image](https://github.com/user-attachments/assets/1f6c01f6-19c5-43fd-97b5-0ce1abd17615)







### Checklist
- [x] Post commit CI passes
- [x] Model regression CI testing passes (if applicable)
- [x] New/Existing tests provide coverage for changes
