### PR TITLE
#0: Add program API to issue prefetch_h stall for CCLs

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -8,5 +8,5 @@ add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/tt_metal/tt_metal)
 add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/tt_eager) # this should go away and be replaced with link to ttnn
 add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/ttnn/unit_tests/gtests)
 
-set(TESTS_DEPENDS_LIST metal_tests eager_tests unit_tests_ttnn test_multi_device ttnn watcher_dump)
+set(TESTS_DEPENDS_LIST metal_tests eager_tests unit_tests_ttnn test_multi_device galaxy_unit_tests_ttnn ttnn watcher_dump)
 add_custom_target(tests DEPENDS ${TESTS_DEPENDS_LIST})

--- a/tests/scripts/tg/run_tg_unit_tests.sh
+++ b/tests/scripts/tg/run_tg_unit_tests.sh
@@ -7,6 +7,7 @@ run_tg_tests() {
   echo "LOG_METAL: running run_tg_unit_tests"
 
   TT_METAL_ENABLE_REMOTE_CHIP=1 ./build/test/tt_metal/unit_tests_fast_dispatch --gtest_filter="CommandQueueSingleCardFixture.*"
+  ./build/test/ttnn/galaxy_unit_tests_ttnn
 }
 
 main() {

--- a/tests/ttnn/unit_tests/gtests/CMakeLists.txt
+++ b/tests/ttnn/unit_tests/gtests/CMakeLists.txt
@@ -11,6 +11,7 @@ set(TTNN_UNIT_TESTS_SRC
 
 add_executable(unit_tests_ttnn ${TTNN_UNIT_TESTS_SRC})
 add_executable(test_multi_device ${CMAKE_CURRENT_SOURCE_DIR}/test_multi_device.cpp)
+add_executable(galaxy_unit_tests_ttnn ${CMAKE_CURRENT_SOURCE_DIR}/test_ccl_on_tg.cpp)
 
 # Common function to set up target properties
 function(setup_ttnn_test_target target_name)
@@ -28,3 +29,4 @@ endfunction()
 # Set up properties for both targets
 setup_ttnn_test_target(unit_tests_ttnn)
 setup_ttnn_test_target(test_multi_device)
+setup_ttnn_test_target(galaxy_unit_tests_ttnn)

--- a/tests/ttnn/unit_tests/gtests/test_ccl_on_tg.cpp
+++ b/tests/ttnn/unit_tests/gtests/test_ccl_on_tg.cpp
@@ -1,0 +1,104 @@
+// SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "common/bfloat16.hpp"
+#include "ttnn/tensor/tensor.hpp"
+#include "ttnn/operations/ccl/line_all_gather/device/line_all_gather_op.hpp"
+#include "ttnn/cpp/ttnn/multi_device.hpp"
+#include "ttnn/async_runtime.hpp"
+#include "ttnn_multi_command_queue_fixture.hpp"
+
+using namespace tt;
+using namespace tt_metal;
+
+TEST(TGTests, TestAllGatherDeadlock) {
+    if (not tt::Cluster::instance().is_galaxy_cluster()) {
+        GTEST_SKIP() << "Skipping Galaxy test, since this is not a Galaxy System";
+    }
+    // Construct the remote devices in this cluster. TTNN Device Mesh APIs need this to be passed in.
+    // Do this using TT Cluster APIs, since device IDs may change in the future.
+    uint32_t num_devices_in_tunnel = tt::Cluster::instance().get_mmio_device_max_tunnel_depth(0);
+    uint32_t num_mmio_devices = tt::Cluster::instance().number_of_pci_devices();
+    uint32_t cluster_tunnel_count = tt::Cluster::instance().get_mmio_device_tunnel_count(0);
+    TT_FATAL(num_devices_in_tunnel == 4, "Expected Galaxy to have tunnel depth of 4");
+    TT_FATAL(num_mmio_devices * cluster_tunnel_count == 8, "Expected 8 tunnels in a Galaxy");
+
+    std::vector<chip_id_t> all_device_ids = {};
+    for (uint32_t mmio_idx = 0; mmio_idx < num_mmio_devices; mmio_idx++) {
+        auto tunnels_from_mmio = tt::Cluster::instance().get_tunnels_from_mmio_device(mmio_idx);
+        for (uint32_t tunnel_idx = 0; tunnel_idx < tunnels_from_mmio.size(); tunnel_idx++) {
+            auto remote_devices_in_tunnel = tunnels_from_mmio.at(tunnel_idx);
+            all_device_ids.insert(all_device_ids.end(), remote_devices_in_tunnel.begin(), remote_devices_in_tunnel.end());
+        }
+    }
+
+    // Create the device mesh: Grid size is <num_tunnels, tunnel_depth>.
+    auto mesh = ttnn::multi_device::open_device_mesh({cluster_tunnel_count * num_mmio_devices, num_devices_in_tunnel}, all_device_ids, 0, 0, 1);
+
+    // Setup input data and output data containers
+    MemoryConfig mem_cfg = MemoryConfig{
+        .memory_layout = tt::tt_metal::TensorMemoryLayout::INTERLEAVED,
+        .buffer_type = BufferType::DRAM,
+        .shard_spec = std::nullopt};
+    ttnn::Shape shape = ttnn::Shape(Shape({1, 1, 32, 16384}));
+    uint32_t buf_size_datums = 32 * 16384;
+    uint32_t datum_size_bytes = 2;
+    auto host_data = std::shared_ptr<bfloat16 []>(new bfloat16[buf_size_datums]);
+    auto readback_data = std::shared_ptr<bfloat16 []>(new bfloat16[buf_size_datums * num_devices_in_tunnel]);
+    uint32_t outer_loops = 200;
+
+
+    // Input to CCL is a tensor of 1s. The output should contain 4x the amount of data, but all values should be 1.
+    for (int j = 0; j < buf_size_datums; j++) {
+        host_data[j] = bfloat16(static_cast<float>(1));
+    }
+    // Iterate over each tunnel and run line all-gather multiple times.
+    // For each tunnel, send adversarial traffic to the first chip, that can hang the network if the CCL is not tagged.
+    for (uint32_t row = 0; row < 8; row++) {
+        auto devs = mesh.get_devices_on_row(row);
+        std::vector<uint32_t> device_ids = {};
+        for (auto dev : devs) {
+            device_ids.push_back(dev->id());
+        }
+        log_info(LogTest, "Running CCL Op on row {} for {} loops", row, outer_loops);
+        log_info(LogTest, "Devices on row: {}", device_ids);
+        for (int i = 0; i < outer_loops; i++) {
+            std::vector<Tensor> output_tensors = {};
+            uint32_t dev_idx = 0;
+            if (i % 100 == 0) {
+                log_info(LogTest, "Running iteration {}", i);
+            }
+            for (auto& dev : devs) {
+                auto input_buffer = ttnn::allocate_buffer_on_device(buf_size_datums * datum_size_bytes, dev, shape, DataType::BFLOAT16, Layout::TILE, mem_cfg);
+                auto input_storage = tt::tt_metal::DeviceStorage{input_buffer};
+                Tensor input_tensor = Tensor(input_storage, shape, DataType::BFLOAT16, Layout::TILE);
+                // Push inputs.
+                ttnn::write_buffer(0, input_tensor, {host_data});
+                // Configure CCL running on this device.
+                uint32_t receiver_device_id = device_ids[(dev_idx) + 1 % num_devices_in_tunnel];
+                uint32_t sender_device_id = device_ids[(dev_idx + num_devices_in_tunnel - 1) % num_devices_in_tunnel];
+                auto all_gather_op = ttnn::LineAllGather{
+                                        3, 2, num_devices_in_tunnel, dev_idx, receiver_device_id, sender_device_id, input_tensor.memory_config(), ttnn::all_gather_op::Topology::Linear};
+                // Send CCL to this device. All CCLs will complete simultaneously.
+                output_tensors.push_back(ttnn::run_operation(0, all_gather_op, {input_tensor}).at(0));
+                // Expose deadlock: After the CCL is sent to the first device in the tunnel, send enough data to it to backpressure prefetch_h. This will block the
+                // demux, which will prevent the CCL from being sent to additional chips. If the CCL has been tagged as having multi-device dependencies, deadlock should
+                // get bypassed.
+                if (!dev_idx) {
+                    ttnn::write_buffer(0, input_tensor, {host_data});
+                }
+                dev_idx++;
+            }
+            // Readback data and verify correctness.
+            for (auto& tensor : output_tensors) {
+                ASSERT_EQ(tensor.get_shape(), ttnn::Shape(Shape({1, 1, 32, 16384 * device_ids.size()})));
+                ttnn::read_buffer(0, tensor, {readback_data});
+                for (int j = 0; j < device_ids.size() * 32 * 16384; j++) {
+                    ASSERT_EQ(readback_data[j].to_float(), 1);
+                }
+            }
+        }
+    }
+    ttnn::multi_device::close_device_mesh(mesh);
+}

--- a/tt_metal/impl/dispatch/command_queue.cpp
+++ b/tt_metal/impl/dispatch/command_queue.cpp
@@ -2034,6 +2034,26 @@ void HWCommandQueue::enqueue_program(Program& program, bool blocking) {
         expected_workers_completed);
     this->enqueue_command(command, blocking);
 
+    if (program.has_multi_device_dependencies() and not this->device->is_mmio_capable() and tt::Cluster::instance().is_galaxy_cluster() and not this->tid.has_value()) {
+        // Issue #19078 - Temporary workaround to avoid deadlocks on Galaxy, until Ethernet Routing Fabric supports VCs:
+        // For programs that require syncs between devices (ex: CCLs), it must be ensured that all devices in a tunnel
+        // receive the full set of program commands. Due to demux being a shared resource (it has a single input queue) and cannot
+        // toggle its output queue id, until a txn is completed (prefetch_d corresponding to the current packet is unblocked), it
+        // is possible that all devices do not get the program commands and enter a deadlock (dispatch_d gets blocked waiting for
+        // the multi-device program to complete, causing prefetch_d to backpressure, as its picked up other commands -> demux has
+        // CCL program commands for other devices in its queue, but is blocked sending a downstream command to the backpressured
+        // prefetch_d).
+        // To resolve this, prefetch_h for all devices involved in the multi-device program will stall sending commands, until
+        // dispatch_d has notified prefetch_h that workers have completed execution (all chips got the program commands, and there
+        // is no further scope of a deadlock).
+        // This pipeline flush does not need to be issued when using trace, since prefetch_h will stall sending pages to prefetch_d
+        // until it has been notified of trace completion (due to cmddat_q reuse). Additionally, events can currently not be traced,
+        // thus this is skipped during trace capture.
+        std::shared_ptr<Event> event = std::make_shared<Event>();
+        this->enqueue_record_event(event);
+        this->enqueue_wait_for_event(event);
+    }
+
 #ifdef DEBUG
     if (tt::llrt::OptionsG.get_validate_kernel_binaries()) {
         TT_FATAL(!this->manager.get_bypass_mode(), "Tracing cannot be used while validating program binaries");

--- a/tt_metal/impl/program/program.hpp
+++ b/tt_metal/impl/program/program.hpp
@@ -144,6 +144,9 @@ class Program {
     bool is_finalized() const { return this->finalized_; }
     void finalize();
 
+    void capture_multi_device_dependencies() { capture_multi_device_dependencies_ = true; }
+    bool has_multi_device_dependencies() { return capture_multi_device_dependencies_; }
+
    private:
     void populate_dispatch_data(Device *device);
 
@@ -209,7 +212,7 @@ class Program {
 
     std::vector<ProgramConfig> program_configs_;
     std::vector<uint32_t> program_config_sizes_;
-
+    bool capture_multi_device_dependencies_ = false;
     friend CBHandle CreateCircularBuffer(Program &program, const std::variant<CoreCoord, CoreRange, CoreRangeSet> &core_spec, const CircularBufferConfig &config);
     friend std::shared_ptr<CircularBuffer> detail::GetCircularBuffer(const Program &program, CBHandle id);
     friend void detail::ValidateCircularBufferRegion(const Program &program, const Device *device);

--- a/ttnn/cpp/ttnn/async_runtime.cpp
+++ b/ttnn/cpp/ttnn/async_runtime.cpp
@@ -74,7 +74,7 @@ void write_buffer(
     const std::optional<std::size_t> transfer_size) {
     uint32_t dst_ref_count = dst.tensor_attributes->record_main_thread_ref_count();
     for (const auto worker : dst.get_workers()) {
-        auto src_for_device = src.at(worker->id());
+        auto src_for_device = (src.size() == 1) ? src.at(0) : src.at(worker->id());
         worker->push_work([worker, src_for_device, dst, cq_id, transfer_size]() {
             auto shard = tt::tt_metal::get_shard_for_device(dst, worker);
             tt::tt_metal::memcpy(worker->command_queue(cq_id), shard, src_for_device.get(), transfer_size);
@@ -93,7 +93,7 @@ void read_buffer(
     TT_ASSERT(src_offset == 0, "src_offset is not supported");
     uint32_t src_ref_count = src.tensor_attributes->record_main_thread_ref_count();
     for (const auto worker : src.get_workers()) {
-        auto dst_for_device = dst.at(worker->id());
+        auto dst_for_device = (dst.size() == 1) ? dst.at(0) : dst.at(worker->id());
         worker->push_work([worker, dst_for_device, src, cq_id, transfer_size, src_offset, blocking]() {
             const auto& shard = tt::tt_metal::get_shard_for_device(src, worker);
             tt::tt_metal::memcpy(worker->command_queue(cq_id), dst_for_device.get(), shard, transfer_size, blocking);

--- a/ttnn/cpp/ttnn/operations/ccl/all_gather/device/multi_core/all_gather_op_multi_core.cpp
+++ b/ttnn/cpp/ttnn/operations/ccl/all_gather/device/multi_core/all_gather_op_multi_core.cpp
@@ -145,6 +145,8 @@ operation::ProgramWithCallbacks all_gather_multi_core_with_workers(const Tensor&
     std::unique_ptr<ccl::CclOpTensorConfig> output_tensor_config = ttnn::ccl::CclOpTensorConfig::build_all_gather_tensor_config(output_tensor);
 
     tt::tt_metal::Program program{};
+    // Issue #10978: CCLs need to be tagged as having multi-device dependencies, when running on Galaxy.
+    program.capture_multi_device_dependencies();
     const auto& device = input_tensor.device();
     auto const& all_gather_config = AllGatherConfig(input_tensor, output_tensor, dim, ring_size, num_links, topology);
     auto const& topology_config = ttnn::ccl::RingTopology(device, topology, sender_device_id, receiver_device_id, num_links, ring_size, ring_index);


### PR DESCRIPTION
### Ticket

### Problem description
Deadlocks due to deep (more than 1 r-chip) tunnels and CCL operations:
When running CCL on Galaxy, it is possible to enter a deadlock due to `Demux` being a shared resource (has 1 input queue) across `prefetch_h`.
Given that programs can be sent to devices out-of-order, device 1 may get a CCL program and a series of single-chip programs (device 2 may not have received its CCL program yet). This can cause `prefetch_d` on device 1 to backpressure, since its not able to acquire any pages on `dispatch_d` (since `dispatch_d` is stalled waiting for workers to complete CCL), which causes `Demux` to stall on device 1 and not send further CCL commands to device 2 --> deadlock, since CCL can never complete.

### What's changed
Added event synchronization to `EnqueueProgram` to bypass this deadlock.
If a program is tagged as a CCL using the `capture_multi_device_dependencies` API, `prefetch_h` will send a `record_event` command to its `dispatch_d` and then wait for the event to complete, i.e. no further commands can be sent over the tunnel to any chip until the CCL is complete --> none of the outputs should backpressure.

This change only supports eager execution. Similar functionality to be added for trace.

TODO: Add tests, once we have CCLs ready on Galaxy.

### Checklist
- [x] Post commit CI passes
- [ ] Model regression CI testing passes (if applicable)
- [x] New/Existing tests provide coverage for changes
