### PR TITLE
#10692: Fix test_llama_perf following rotmat changes

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -131,6 +131,7 @@ models/demos/falcon7b_common @skhorasganiTT @djordje-tt @uaydonat
 models/demos/wormhole/mamba @esmalTT @uaydonat @kpaigwar
 models/demos/wormhole/falcon7b @skhorasganiTT @djordje-tt @uaydonat
 models/demos/wormhole/mistral7b @yieldthought @uaydonat @mtairum
+models/demos/wormhole/llama31_8b @yieldthought @mtairum @uaydonat
 models/demos/t3000/falcon40b @uaydonat @djordje-tt
 models/demos/t3000/falcon7b @skhorasganiTT @djordje-tt @uaydonat
 models/demos/t3000/llama2_70b @cglagovichTT @caixunshiren @uaydonat


### PR DESCRIPTION
### Ticket
[Link to Github Issue](https://github.com/tenstorrent/tt-metal/issues/10692)

### Problem description
Recent changes to main broke test_llama_perf

### What's changed
Apply the iterative rot_mat to this test as well

### Checklist
- [x] [Post commit CI passes](https://github.com/tenstorrent/tt-metal/actions/runs/10162797272)
- [x] Model regression CI testing passes (test now runs, 1/2 fails and should be investigated separately)
- [x] New/Existing tests provide coverage for changes (not applicable)
