### PR TITLE
#10637: updated ttnn.to_layout to handle N-d tensors

### DIFF
--- a/tests/ttnn/unit_tests/test_to_and_from_device.py
+++ b/tests/ttnn/unit_tests/test_to_and_from_device.py
@@ -9,13 +9,41 @@ import torch
 import ttnn
 
 
-@pytest.mark.parametrize("h", [7])
-@pytest.mark.parametrize("w", [8])  # must be even to be put on device
-def test_to_and_from_4D(device, h, w):
-    torch_input_tensor = torch.rand((1, 1, h, w), dtype=torch.bfloat16)
-    tensor = ttnn.from_torch(torch_input_tensor)
-    tensor = ttnn.to_device(tensor, device)
-    tensor = ttnn.from_device(tensor)
+@pytest.mark.parametrize(
+    "shape",
+    [
+        (2,),
+        (2, 4),
+        (2, 3, 4),
+        (2, 3, 4, 6),
+        (2, 3, 4, 5, 6),
+        (2, 3, 4, 5, 6, 8),
+        (2, 3, 4, 5, 6, 7, 8),
+        (2, 3, 4, 5, 6, 7, 8, 10),
+    ],
+)
+def test_to_and_from(device, shape):
+    torch_input_tensor = torch.rand(shape, dtype=torch.bfloat16)
+    tensor = ttnn.from_torch(torch_input_tensor, device=device)
+    torch_output_tensor = ttnn.to_torch(tensor)
+    assert torch.allclose(torch_input_tensor, torch_output_tensor)
+
+
+@pytest.mark.parametrize(
+    "shape",
+    [
+        (2, 3),
+        (2, 3, 4),
+        (2, 3, 4, 5),
+        (2, 3, 4, 5, 6),
+        (2, 3, 4, 5, 6, 7),
+        (2, 3, 4, 5, 6, 7, 8),
+        (2, 3, 4, 5, 6, 7, 8, 9),
+    ],
+)
+def test_to_and_from_using_tile_layout(device, shape):
+    torch_input_tensor = torch.rand(shape, dtype=torch.bfloat16)
+    tensor = ttnn.from_torch(torch_input_tensor, device=device, layout=ttnn.TILE_LAYOUT)
     torch_output_tensor = ttnn.to_torch(tensor)
     assert torch.allclose(torch_input_tensor, torch_output_tensor)
 

--- a/tests/ttnn/unit_tests/test_to_and_from_torch.py
+++ b/tests/ttnn/unit_tests/test_to_and_from_torch.py
@@ -10,11 +10,41 @@ import ttnn
 from tests.ttnn.utils_for_testing import assert_with_pcc
 
 
-@pytest.mark.parametrize("height", [7])
-@pytest.mark.parametrize("width", [3])
-def test_to_and_from_4D(height, width):
-    torch_input_tensor = torch.rand((1, 1, height, width), dtype=torch.bfloat16)
+@pytest.mark.parametrize(
+    "shape",
+    [
+        (2,),
+        (2, 3),
+        (2, 3, 4),
+        (2, 3, 4, 5),
+        (2, 3, 4, 5, 6),
+        (2, 3, 4, 5, 6, 7),
+        (2, 3, 4, 5, 6, 7, 8),
+        (2, 3, 4, 5, 6, 7, 8, 9),
+    ],
+)
+def test_to_and_from(shape):
+    torch_input_tensor = torch.rand(shape, dtype=torch.bfloat16)
     tensor = ttnn.from_torch(torch_input_tensor)
+    torch_output_tensor = ttnn.to_torch(tensor)
+    assert torch.allclose(torch_input_tensor, torch_output_tensor)
+
+
+@pytest.mark.parametrize(
+    "shape",
+    [
+        (2, 3),
+        (2, 3, 4),
+        (2, 3, 4, 5),
+        (2, 3, 4, 5, 6),
+        (2, 3, 4, 5, 6, 7),
+        (2, 3, 4, 5, 6, 7, 8),
+        (2, 3, 4, 5, 6, 7, 8, 9),
+    ],
+)
+def test_to_and_from_using_tile_layout(shape):
+    torch_input_tensor = torch.rand(shape, dtype=torch.bfloat16)
+    tensor = ttnn.from_torch(torch_input_tensor, layout=ttnn.TILE_LAYOUT)
     torch_output_tensor = ttnn.to_torch(tensor)
     assert torch.allclose(torch_input_tensor, torch_output_tensor)
 

--- a/ttnn/cpp/ttnn/deprecated/tt_dnn/op_library/untilize/multi_core/untilize_op_multi_core.cpp
+++ b/ttnn/cpp/ttnn/deprecated/tt_dnn/op_library/untilize/multi_core/untilize_op_multi_core.cpp
@@ -516,19 +516,10 @@ operation::ProgramWithCallbacks untilize_with_unpadding_multi_core_interleaved(
                 .fp32_dest_acc_en = fp32_dest_acc_en, .compile_args = {nblocks_per_core_cliff, num_tiles_per_row}});
     }
 
-    auto input_w = input_shape.rank() >= 4 ? input_shape[-4] : 1;
-    auto input_z = input_shape.rank() >= 3 ? input_shape[-3] : 1;
-    auto input_y = input_shape.rank() >= 2 ? input_shape[-2] : 1;
-    auto input_x = input_shape[-1];
-
-    auto output_w = output_shape.rank() >= 4 ? output_shape[-4] : 1;
-    auto output_z = output_shape.rank() >= 3 ? output_shape[-3] : 1;
-    auto output_y = output_shape.rank() >= 2 ? output_shape[-2] : 1;
-    auto output_x = output_shape[-1];
-
-    Padding padding(
-        {{0, input_w - output_w}, {0, input_z - output_z}, {0, input_y - output_y}, {0, input_x - output_x}},
-        Padding::PadValue::Any);
+    Padding padding(input_shape.rank());
+    for (auto index = 0; index < input_shape.rank(); index++) {
+        padding[index].back = input_shape[index] - output_shape[index];
+    }
     auto core_assignments =
         distribute_work(output_shape, padding, ncores, nblocks_per_core, has_cliff, nblocks_per_core_cliff);
 

--- a/ttnn/cpp/ttnn/deprecated/tt_dnn/op_library/work_split_tilize.hpp
+++ b/ttnn/cpp/ttnn/deprecated/tt_dnn/op_library/work_split_tilize.hpp
@@ -179,9 +179,9 @@ inline std::vector<std::vector<BlockRep>> distribute_work(
     auto input_z = unpadded.rank() >= 3 ? unpadded[-3] : 1;
     auto input_y = unpadded.rank() >= 2 ? unpadded[-2] : 1;
 
-    auto padding_w = unpadded.rank() >= 4 ? padding[unpadded.get_normalized_index(-4)].back : 0;
-    auto padding_z = unpadded.rank() >= 3 ? padding[unpadded.get_normalized_index(-3)].back : 0;
-    auto padding_y = unpadded.rank() >= 2 ? padding[unpadded.get_normalized_index(-2)].back : 0;
+    auto padding_w = unpadded.rank() >= 4 ? padding[padding.get_normalized_index(-4)].back : 0;
+    auto padding_z = unpadded.rank() >= 3 ? padding[padding.get_normalized_index(-3)].back : 0;
+    auto padding_y = unpadded.rank() >= 2 ? padding[padding.get_normalized_index(-2)].back : 0;
 
     // total work is a full rep followed by a padding.
     auto full_rep_blocks = FullRep(input_y, padding_y, input_z, padding_z, input_w).to_block_reps();

--- a/ttnn/cpp/ttnn/reports.hpp
+++ b/ttnn/cpp/ttnn/reports.hpp
@@ -64,10 +64,6 @@ struct BufferInfo {
 std::vector<BufferInfo> get_buffers() {
     std::vector<BufferInfo> buffer_infos;
     for (const auto &[key, buffer] : tt::tt_metal::detail::BUFFER_MAP.value()) {
-        if (not buffer->is_l1()) {
-            continue;
-        }
-
         auto [device_id, address] = key;
         auto device = buffer->device();
 


### PR DESCRIPTION
### Ticket
[Link to Github Issue](https://github.com/tenstorrent/tt-metal/issues/10637)

### Problem description
`ttnn.from_torch` wasn't working with tensors >4D because `ttnn.to_layout` didn't support them

### What's changed
Updated `ttnn.to_layout` to work with N-d tensors

### Checklist
- [ ] Post commit CI passes
- [ ] Model regression CI testing passes (if applicable)
- [ ] New/Existing tests provide coverage for changes
