### PR TITLE
#10899: fix BERT memory overflow and layernorm shape mismatch issue

### DIFF
--- a/models/demos/metal_BERT_large_11/tt/embeddings.py
+++ b/models/demos/metal_BERT_large_11/tt/embeddings.py
@@ -154,10 +154,6 @@ class TtEmbeddings:
             embeddings_type=ttnn.EmbeddingsType.BINARY,
             memory_config=self.model_config["OUTPUT_EMBEDDINGS_MEMCFG"],
         )
-        token_type_embeddings = ttnn.reshape(
-            token_type_embeddings,
-            [token_type_embeddings.shape[0], 1, token_type_embeddings.shape[1], token_type_embeddings.shape[2]],
-        )
         token_type_ids.deallocate()
 
         if self.position_embedding_type == "absolute":
@@ -182,6 +178,15 @@ class TtEmbeddings:
                     1,
                     position_embeddings_tt_tensor.shape[1],
                     position_embeddings_tt_tensor.shape[2],
+                ],
+            )
+            inputs_plus_token_type_embeddings_tt_tensor = ttnn.reshape(
+                inputs_plus_token_type_embeddings_tt_tensor,
+                [
+                    inputs_plus_token_type_embeddings_tt_tensor.shape[0],
+                    1,
+                    inputs_plus_token_type_embeddings_tt_tensor.shape[1],
+                    inputs_plus_token_type_embeddings_tt_tensor.shape[2],
                 ],
             )
             # Deallocate inputs_embeds and token_type_embeddings here to avoid having to move final output

--- a/models/demos/metal_BERT_large_11/tt/model_config.py
+++ b/models/demos/metal_BERT_large_11/tt/model_config.py
@@ -196,7 +196,7 @@ def get_model_config(batch, device_grid_size, model_config_str):
         model_config.update(new_config_values)
 
     elif model_config_str == "BFLOAT8_B-L1" or model_config_str == "BFLOAT8_B-DRAM":
-        grid_size = [12, batch]
+        grid_size = tt_lib.tensor.CoreCoord(tuple([12, batch]))
         new_config_values = {
             "OP3_PRE_SOFTMAX_BMM_CONFIG": ttnn.MatmulMultiCoreReuseProgramConfig(
                 compute_with_storage_grid_size=grid_size,
@@ -293,14 +293,14 @@ def get_model_config(batch, device_grid_size, model_config_str):
     elif model_config_str == "BFLOAT8_B-SHARDED":
         activation_grid_dim = 8
         if batch <= device_grid_size.x and activation_grid_dim <= device_grid_size.y:
-            grid_size = [batch, activation_grid_dim]
+            grid_size = tt_lib.tensor.CoreCoord(tuple([batch, activation_grid_dim]))
             shard_orientation = (
                 tt_lib.tensor.ShardOrientation.ROW_MAJOR
                 if is_wormhole_b0()
                 else tt_lib.tensor.ShardOrientation.COL_MAJOR
             )
         elif activation_grid_dim <= device_grid_size.x and batch <= device_grid_size.y:
-            grid_size = [activation_grid_dim, batch]
+            grid_size = tt_lib.tensor.CoreCoord(tuple([activation_grid_dim, batch]))
             shard_orientation = tt_lib.tensor.ShardOrientation.ROW_MAJOR
         else:
             assert False, f"Device grid size does not support batch {batch} {model_config_str} configuration"


### PR DESCRIPTION
### Ticket
#10899

### Problem description
The perf test for BERT is failing ever since we started using embeddings. Git commit: abfbed5fdfab6910bfccedc470aa3a8166a2c7f4 fixed one issue but introduced another due to some extra memory utilization when a reshape is called. Python does not garbage collect greedily enough and we end up having allocation issues. As well, this hid a layernorm shape mismatch and a QKV heads creation issue.

### What's changed
- Removed the unnecessary reshape causing the allocation issue
- Reshaped an input into layernorm that should have been reshaped
- Correctly called the qkv heads split api that was incorrectly called before

### Checklist
- [x] Post commit CI passes
- [x] Model regression CI testing passes (if applicable)
- [ ] New/Existing tests provide coverage for changes
