### PR TITLE
Add perplexity tests for Mamba single-chip model

### DIFF
--- a/models/demos/wormhole/mamba/tests/test_mamba_perplexity.py
+++ b/models/demos/wormhole/mamba/tests/test_mamba_perplexity.py
@@ -1,0 +1,205 @@
+# SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
+
+# SPDX-License-Identifier: Apache-2.0
+
+import time
+import pytest
+from loguru import logger
+from typing import Tuple, Callable
+
+import numpy as np
+import torch
+from transformers import AutoTokenizer
+from tqdm import tqdm
+
+import ttnn
+
+from models.demos.wormhole.mamba.reference.prefill_decode_model import Mamba, MambaPretrainedModelName
+from models.demos.wormhole.mamba.tt import model_config
+from models.demos.wormhole.mamba.tt.model_config import ModelMode
+from models.demos.wormhole.mamba.tt.mamba_model import MambaTT
+
+from models.datasets.llm_dataset_utils import (
+    prepare_textgen_dataset,
+    prepare_textgen_dataloader,
+    calculate_acc_metrics,
+    verify_acc_metrics,
+)
+from models.utility_functions import skip_for_grayskull
+
+
+def calculate_perplexity(
+    compute_logits_fn: Callable, reset_model_states_fn: Callable, dataloader, vocab_size
+) -> Tuple[float, float, float, float]:
+    running_nll, running_top1_acc, running_top5_acc = 0.0, 0.0, 0.0
+    with torch.no_grad():
+        for input_ids, labels in tqdm(dataloader, desc="Evaluating batches"):
+            batch, seqlen = input_ids.shape
+            logits = compute_logits_fn(input_ids, seqlen)
+            logits = logits.view(batch * seqlen, vocab_size)
+            labels = labels.view(-1)
+            nll, top1_acc, top5_acc = calculate_acc_metrics(logits, labels)
+            running_nll += nll
+            running_top1_acc += top1_acc
+            running_top5_acc += top5_acc
+
+            reset_model_states_fn()
+
+    nll = running_nll / len(dataloader)
+    ppl = np.exp(nll)
+    top1_acc = running_top1_acc / len(dataloader)
+    top5_acc = running_top5_acc / len(dataloader)
+    return float(nll), float(ppl), float(top1_acc), float(top5_acc)
+
+
+@pytest.mark.parametrize(
+    "model_version, mode, batch_size, max_seq_len, num_samples, expected_ppl, expected_top1, expected_top5",
+    (
+        ("state-spaces/mamba-2.8b", ModelMode.DECODE, 32, 64, 64, 21.6, 0.39, 0.65),
+        ("state-spaces/mamba-2.8b", ModelMode.DECODE, 32, 128, 64, 15.4, 0.44, 0.69),
+        ("state-spaces/mamba-2.8b", ModelMode.PREFILL, 32, 64, 64, 21.6, 0.39, 0.65),
+        ("state-spaces/mamba-2.8b", ModelMode.PREFILL, 32, 128, 64, 15.4, 0.44, 0.69),
+    ),
+)
+def test_mamba_reference_perplexity(
+    model_version: MambaPretrainedModelName,
+    mode: ModelMode,
+    batch_size: int,
+    max_seq_len: int,
+    num_samples: int,
+    expected_ppl: int,
+    expected_top1: int,
+    expected_top5: int,
+    is_ci_env,
+):
+    torch.manual_seed(0)
+
+    if is_ci_env:
+        pytest.skip("Disabled on CI due to long execution time")
+    else:
+        logger.warning("Mamba CPU reference test is currently disabled on CI due to long execution times")
+
+    logger.info("Preparing dataset")
+    dataset = prepare_textgen_dataset("wikitext", "wikitext-2-raw-v1", "test")
+    tokenizer = AutoTokenizer.from_pretrained("EleutherAI/gpt-neox-20b")
+    encodings = tokenizer(dataset, return_tensors="pt")["input_ids"].squeeze(0)
+    dataloader = prepare_textgen_dataloader(encodings, batch_size, max_seq_len, num_samples, stride=None)
+
+    reference_model = Mamba.from_pretrained(model_version, batch_size=batch_size)
+    reference_model.args.mode = mode
+    reference_model.eval()
+
+    def decode(input_ids, seqlen: int):
+        logits = []
+        for idx in range(seqlen):
+            next_token = input_ids[:, idx].unsqueeze(-1)  # (B, 1)
+            next_token_logits = reference_model(next_token)
+            logits.append(next_token_logits)
+        return torch.cat(logits, dim=1)
+
+    def prefill(input_ids, _: int):
+        return reference_model(input_ids)
+
+    if mode == ModelMode.DECODE:
+        compute_logits = decode
+    else:
+        compute_logits = prefill
+
+    logger.info(f"Evaluating perplexity (batch_size={batch_size} max_seq_len={max_seq_len} num_samples={num_samples})")
+    start = time.time()
+    nll, ppl, top1_acc, top5_acc = calculate_perplexity(
+        compute_logits, reference_model.initialize_states, dataloader, reference_model.args.vocab_size
+    )
+    end = time.time()
+
+    logger.info(f"Perplexity evaluation time: {(end - start):.2f} s")
+    logger.info(f"Negative log-likelihood: {nll:.4f}")
+    logger.info(f"Perplexity: {ppl:.4f}")
+    logger.info(f"Top-1 accuracy: {top1_acc:.4f}")
+    logger.info(f"Top-5 accuracy: {top5_acc:.4f}")
+
+    calculated_acc_metrics = {"ppl": ppl, "top1_acc": top1_acc, "top5_acc": top5_acc}
+    expected_acc_metrics = {"ppl": expected_ppl, "top1_acc": expected_top1, "top5_acc": expected_top5}
+    verify_acc_metrics(calculated_acc_metrics, expected_acc_metrics)
+
+
+@pytest.mark.timeout(600)
+@skip_for_grayskull("Mamba not supported on Grayskull")
+@pytest.mark.parametrize("device_params", [{"l1_small_size": 16384}], indirect=True)
+@pytest.mark.parametrize(
+    "model_version, mode, batch_size, max_seq_len, num_samples, expected_ppl, expected_top1, expected_top5",
+    (
+        ("state-spaces/mamba-2.8b", ModelMode.DECODE, 32, 64, 64, 28.8, 0.37, 0.61),
+        ("state-spaces/mamba-2.8b", ModelMode.DECODE, 32, 128, 64, 20.6, 0.40, 0.66),
+        ("state-spaces/mamba-2.8b", ModelMode.PREFILL, 1, 64, 64, 27.0, 0.36, 0.62),
+        ("state-spaces/mamba-2.8b", ModelMode.PREFILL, 1, 128, 64, 20.4, 0.40, 0.65),
+    ),
+)
+def test_mamba_perplexity(
+    device: ttnn.Device,
+    model_version: MambaPretrainedModelName,
+    mode: ModelMode,
+    batch_size: int,
+    max_seq_len: int,
+    num_samples: int,
+    expected_ppl: int,
+    expected_top1: int,
+    expected_top5: int,
+    use_program_cache,
+    get_tt_cache_path,
+):
+    torch.manual_seed(0)
+
+    logger.info("Preparing dataset")
+    dataset = prepare_textgen_dataset("wikitext", "wikitext-2-raw-v1", "test")
+    tokenizer = AutoTokenizer.from_pretrained("EleutherAI/gpt-neox-20b")
+    encodings = tokenizer(dataset, return_tensors="pt")["input_ids"].squeeze(0)
+    dataloader = prepare_textgen_dataloader(encodings, batch_size, max_seq_len, num_samples, stride=None)
+
+    reference_model = Mamba.from_pretrained(model_version, batch_size=batch_size)
+    reference_model.args.mode = mode
+    reference_model.eval()
+
+    if mode == ModelMode.DECODE:
+        config = model_config.create_model_config(batch_size, reference_model.args.d_model, mode=mode, seq_len=1)
+        model = MambaTT(reference_model, device, config, tt_cache_path=get_tt_cache_path(model_version))
+
+        def decode(input_ids, seqlen: int):
+            logits = []
+            for idx in range(seqlen):
+                next_token = input_ids[:, idx].unsqueeze(-1)  # (B, 1)
+                next_token_logits = model(next_token)
+                logits.append(next_token_logits)
+            return torch.cat(logits, dim=1)
+
+        compute_logits = decode
+        reset = model.reset
+    else:
+        prefill_chunk_size = max_seq_len
+        config = model_config.create_model_config(
+            batch_size, reference_model.args.d_model, mode=mode, seq_len=prefill_chunk_size
+        )
+        model = MambaTT(reference_model, device, config, tt_cache_path=get_tt_cache_path(model_version))
+
+        def prefill(input_ids, _: int):
+            return model(input_ids)  # assumes input fits into single chunk
+
+        compute_logits = prefill
+        reset = model.reset
+
+    logger.info(f"Evaluating perplexity (batch_size={batch_size} max_seq_len={max_seq_len} num_samples={num_samples})")
+    start = time.time()
+    nll, ppl, top1_acc, top5_acc = calculate_perplexity(
+        compute_logits, reset, dataloader, reference_model.args.vocab_size
+    )
+    end = time.time()
+
+    logger.info(f"Perplexity evaluation time: {(end - start):.2f} s")
+    logger.info(f"Negative log-likelihood: {nll:.4f}")
+    logger.info(f"Perplexity: {ppl:.4f}")
+    logger.info(f"Top-1 accuracy: {top1_acc:.4f}")
+    logger.info(f"Top-5 accuracy: {top5_acc:.4f}")
+
+    calculated_acc_metrics = {"ppl": ppl, "top1_acc": top1_acc, "top5_acc": top5_acc}
+    expected_acc_metrics = {"ppl": expected_ppl, "top1_acc": expected_top1, "top5_acc": expected_top5}
+    verify_acc_metrics(calculated_acc_metrics, expected_acc_metrics)

--- a/models/demos/wormhole/mamba/tt/mamba_block.py
+++ b/models/demos/wormhole/mamba/tt/mamba_block.py
@@ -76,18 +76,16 @@ class TtMambaBlock(torch.nn.Module):
         )
         self.conv1d_bias = self.conv1d_bias_prefill
 
-        if self.configs["mode"] == ModelMode.DECODE:
-            self.conv_states = []
-            for i in range(4):
-                self.conv_states.append(
-                    load_fn(
-                        f"conv_state{i}",
-                        torch_tensor=torch.zeros(1, 1, self.batch_size, self.args.d_inner),
-                        postfix=f"{args.batch_size}",
-                    )
+        self.conv_states = []
+        for i in range(4):
+            self.conv_states.append(
+                load_fn(
+                    f"conv_state{i}",
+                    torch_tensor=torch.zeros(1, 1, self.batch_size, self.args.d_inner),
+                    postfix=f"{args.batch_size}",
                 )
-        elif self.configs["mode"] == ModelMode.PREFILL:
-            self.convolution_cache = TensorCache(configs["num_users"], 4, self.args.d_inner, device)
+            )
+        self.convolution_cache = TensorCache(configs["num_users"], 4, self.args.d_inner, device)
 
         mamba_conv_config = MambaConvConfig(
             input_length=self.configs["outer_dim"] + (args.d_conv - 1),

--- a/models/demos/wormhole/mamba/tt/mamba_model.py
+++ b/models/demos/wormhole/mamba/tt/mamba_model.py
@@ -90,8 +90,6 @@ class MambaTT(torch.nn.Module):
 
         logger.info(f"Initalizing Mamba with {self.num_layers} layers")
 
-        self.embedding = reference_model.embedding
-
         loader = TtTensorLoader(reference_model.state_dict(), self.device, tt_cache_path=tt_cache_path)
         self.layers = [
             TtResidualBlock(self.args, device, configs, loader.get_tensor_loader(i)) for i in range(self.num_layers)

--- a/models/demos/wormhole/mamba/tt/mamba_ssm.py
+++ b/models/demos/wormhole/mamba/tt/mamba_ssm.py
@@ -110,14 +110,11 @@ class TtMambaSSM(torch.nn.Module):
         self.D = self.D_prefill
 
         # hidden state
-
-        if self.configs["mode"] == ModelMode.DECODE:
-            prev_hidden_states = torch.zeros((1, 1, self.batch_size, self.hidden_size * self.n))
-            self.tt_hidden_states = load_fn(
-                f"tt_hidden_state_{self.batch_size}", torch_tensor=prev_hidden_states, tt_layout=ttnn.TILE_LAYOUT
-            )
-        else:
-            self.hidden_state_cache = TensorCache(self.configs["num_users"], 1, self.hidden_size * self.n, device)
+        prev_hidden_states = torch.zeros((1, 1, self.batch_size, self.hidden_size * self.n))
+        self.tt_hidden_states = load_fn(
+            f"tt_hidden_state_{self.batch_size}", torch_tensor=prev_hidden_states, tt_layout=ttnn.TILE_LAYOUT
+        )
+        self.hidden_state_cache = TensorCache(self.configs["num_users"], 1, self.hidden_size * self.n, device)
 
         self.compute_kernel_config = ttl.tensor.WormholeComputeKernelConfig(
             math_fidelity=ttl.tensor.MathFidelity.HiFi2,

--- a/tests/nightly/wh_b0_only_eth/models/demos/wormhole/mamba/test_mamba_perplexity.py
+++ b/tests/nightly/wh_b0_only_eth/models/demos/wormhole/mamba/test_mamba_perplexity.py
@@ -1,0 +1,1 @@
+../../../../../../../models/demos/wormhole/mamba/tests/test_mamba_perplexity.py


### PR DESCRIPTION
### Summary
This change adds perplexity tests for the Mamba WH model. I have added these tests to the nightly pipeline, since there is not currently any dedicated pipeline for single-chip perplexity tests. There are also test cases for the CPU reference model as a sanity check but these are currently disabled in CI because they take a long time to complete.

### Checklist
- [x] Post commit CI passes
- [x] Model regression CI testing passes (if applicable)
- [x] New/Existing tests provide coverage for changes
