### PR TITLE
#7560: Fix FD noc api to set multicast_path_reserve when mcasting

### DIFF
--- a/tt_metal/impl/dispatch/kernels/cq_common.hpp
+++ b/tt_metal/impl/dispatch/kernels/cq_common.hpp
@@ -121,7 +121,7 @@ void cq_noc_async_write_init_state(uint32_t src_addr, uint64_t dst_addr, uint32_
     }
     DEBUG_STATUS("NSID");
 
-    constexpr bool multicast_path_reserve = false;
+    constexpr bool multicast_path_reserve = mcast;
     constexpr bool posted = false;
     constexpr bool linked = false;
     constexpr uint32_t vc = mcast ? NOC_MULTICAST_WRITE_VC : NOC_UNICAST_WRITE_VC;

--- a/tt_metal/impl/dispatch/kernels/cq_common.hpp
+++ b/tt_metal/impl/dispatch/kernels/cq_common.hpp
@@ -124,7 +124,7 @@ void cq_noc_async_write_init_state(uint32_t src_addr, uint64_t dst_addr, uint32_
     constexpr bool multicast_path_reserve = mcast;
     constexpr bool posted = false;
     constexpr bool linked = false;
-    constexpr uint32_t vc = mcast ? NOC_MULTICAST_WRITE_VC : NOC_UNICAST_WRITE_VC;
+    constexpr uint32_t vc = mcast ? NOC_DISPATCH_MULTICAST_WRITE_VC : NOC_UNICAST_WRITE_VC;
 
     constexpr uint32_t noc_cmd_field =
         NOC_CMD_CPY | NOC_CMD_WR |


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/7560

### Problem description
Stable diffusion was still seeing hangs after di/dt fixes. Was narrowed down to a commit that changed the FD eth cores used for prefetch/dispatch, which affected timing. The real latent bug was that multicast_path_reserve was not being set with the new noc apis used in some FD commands, leading to potential NOC deadlock.

### What's changed
Always set multicast_path_reserve for now for all mcast transactions with the new apis.

### Checklist
- [x] Post commit CI passes
- [x] Model regression CI testing passes (if applicable)
- [x] New/Existing tests provide coverage for changes
