### PR TITLE
#10916: Add LD_LIBRARY_PATH for e2e perf models on single chip

### DIFF
--- a/.github/workflows/perf-models.yaml
+++ b/.github/workflows/perf-models.yaml
@@ -27,6 +27,7 @@ jobs:
       TT_METAL_ENV: ${{ vars.TT_METAL_ENV }}
       ARCH_NAME: ${{ matrix.test-info.arch }}
       LOGURU_LEVEL: INFO
+      LD_LIBRARY_PATH: ${{ github.workspace }}/build/lib
     environment: dev
     runs-on: ${{ matrix.test-info.runs-on }}
     steps:


### PR DESCRIPTION
### Ticket
#10916

### Problem description

Certain build artifacts on new builders seemed to not be linked to our SOs.

### What's changed

Add `LD_LIBRARY_PATH` since the rpath is wrong.

### Checklist
- [x] Post commit CI passes
- [x] Model regression CI testing passes (if applicable)
- [x] New/Existing tests provide coverage for changes
