### PR TITLE
#10919: Create pybinding for complex_tensor in ttnn

### DIFF
--- a/tests/tt_eager/python_api_testing/unit_testing/misc/test_complex.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/misc/test_complex.py
@@ -437,7 +437,7 @@ def test_level1_polar(bs, memcfg, dtype, device, function_level_defaults):
     # we set imag = angle theta
     x = Complex(None, re=torch.ones(input_shape), im=torch.rand(input_shape))
 
-    xtt = ttl.tensor.complex_tensor(
+    xtt = ttnn.complex_tensor(
         ttl.tensor.Tensor(x.real, dtype).to(ttl.tensor.Layout.TILE).to(device, memcfg),
         ttl.tensor.Tensor(x.imag, dtype).to(ttl.tensor.Layout.TILE).to(device, memcfg),
     )

--- a/tests/ttnn/unit_tests/operations/backward/complex_ops/test_backward_abs.py
+++ b/tests/ttnn/unit_tests/operations/backward/complex_ops/test_backward_abs.py
@@ -41,7 +41,7 @@ def test_level2_abs_bw(bs, hw, memcfg, dtype, device, function_level_defaults):
     in_data = random_complex_tensor(input_shape, (-90, 90), (-70, 70))
     in_data.requires_grad = True
 
-    input_tensor = ttl.tensor.complex_tensor(
+    input_tensor = ttnn.complex_tensor(
         ttl.tensor.Tensor(in_data.real, dtype).to(ttl.tensor.Layout.TILE).to(device, memcfg),
         ttl.tensor.Tensor(in_data.imag, dtype).to(ttl.tensor.Layout.TILE).to(device, memcfg),
     )
@@ -81,7 +81,7 @@ def test_level2_abs_bw_inp_zero(bs, hw, memcfg, dtype, device, function_level_de
     in_data = random_complex_tensor(input_shape, (0, 0), (0, 0))
     in_data.requires_grad = True
 
-    input_tensor = ttl.tensor.complex_tensor(
+    input_tensor = ttnn.complex_tensor(
         ttl.tensor.Tensor(in_data.real, dtype).to(ttl.tensor.Layout.TILE).to(device, memcfg),
         ttl.tensor.Tensor(in_data.imag, dtype).to(ttl.tensor.Layout.TILE).to(device, memcfg),
     )

--- a/tests/ttnn/unit_tests/operations/backward/complex_ops/test_backward_angle.py
+++ b/tests/ttnn/unit_tests/operations/backward/complex_ops/test_backward_angle.py
@@ -40,7 +40,7 @@ def test_level2_angle_bw(bs, hw, memcfg, dtype, device, function_level_defaults)
     in_data = random_complex_tensor(input_shape, (-90, 90), (-70, 70))
     in_data.requires_grad = True
 
-    input_tensor = ttl.tensor.complex_tensor(
+    input_tensor = ttnn.complex_tensor(
         ttl.tensor.Tensor(in_data.real, dtype).to(ttl.tensor.Layout.TILE).to(device, memcfg),
         ttl.tensor.Tensor(in_data.imag, dtype).to(ttl.tensor.Layout.TILE).to(device, memcfg),
     )

--- a/tests/ttnn/unit_tests/operations/backward/complex_ops/test_backward_complex_add.py
+++ b/tests/ttnn/unit_tests/operations/backward/complex_ops/test_backward_complex_add.py
@@ -45,17 +45,17 @@ def test_level2_complex_add_bw(bs, hw, alpha, memcfg, dtype, device, function_le
     other_data = random_complex_tensor(input_shape, (-20, 90), (-30, 100))
     other_data.requires_grad = True
 
-    input_tensor = ttl.tensor.complex_tensor(
+    input_tensor = ttnn.complex_tensor(
         ttl.tensor.Tensor(in_data.real, dtype).to(ttl.tensor.Layout.TILE).to(device, memcfg),
         ttl.tensor.Tensor(in_data.imag, dtype).to(ttl.tensor.Layout.TILE).to(device, memcfg),
     )
-    other_tensor = ttl.tensor.complex_tensor(
+    other_tensor = ttnn.complex_tensor(
         ttl.tensor.Tensor(other_data.real, dtype).to(ttl.tensor.Layout.TILE).to(device, memcfg),
         ttl.tensor.Tensor(other_data.imag, dtype).to(ttl.tensor.Layout.TILE).to(device, memcfg),
     )
 
     grad_data = random_complex_tensor(input_shape, (-50, 50), (-60, 60))
-    grad_tensor = ttl.tensor.complex_tensor(
+    grad_tensor = ttnn.complex_tensor(
         ttl.tensor.Tensor(grad_data.real, dtype).to(ttl.tensor.Layout.TILE).to(device, memcfg),
         ttl.tensor.Tensor(grad_data.imag, dtype).to(ttl.tensor.Layout.TILE).to(device, memcfg),
     )

--- a/tests/ttnn/unit_tests/operations/backward/complex_ops/test_backward_complex_div.py
+++ b/tests/ttnn/unit_tests/operations/backward/complex_ops/test_backward_complex_div.py
@@ -48,17 +48,17 @@ def test_level2_complex_div_bw(bs, hw, memcfg, dtype, device, function_level_def
     other_data = random_complex_tensor(input_shape, (-20, 90), (-30, 100))
     other_data.requires_grad = True
 
-    input_tensor = ttl.tensor.complex_tensor(
+    input_tensor = ttnn.complex_tensor(
         ttl.tensor.Tensor(in_data.real, dtype).to(ttl.tensor.Layout.TILE).to(device, memcfg),
         ttl.tensor.Tensor(in_data.imag, dtype).to(ttl.tensor.Layout.TILE).to(device, memcfg),
     )
-    other_tensor = ttl.tensor.complex_tensor(
+    other_tensor = ttnn.complex_tensor(
         ttl.tensor.Tensor(other_data.real, dtype).to(ttl.tensor.Layout.TILE).to(device, memcfg),
         ttl.tensor.Tensor(other_data.imag, dtype).to(ttl.tensor.Layout.TILE).to(device, memcfg),
     )
 
     grad_data = random_complex_tensor(input_shape, (-50, 50), (-60, 60))
-    grad_tensor = ttl.tensor.complex_tensor(
+    grad_tensor = ttnn.complex_tensor(
         ttl.tensor.Tensor(grad_data.real, dtype).to(ttl.tensor.Layout.TILE).to(device, memcfg),
         ttl.tensor.Tensor(grad_data.imag, dtype).to(ttl.tensor.Layout.TILE).to(device, memcfg),
     )
@@ -99,17 +99,17 @@ def test_level2_complex_div_bw_other_zero(bs, hw, memcfg, dtype, device, functio
     other_data = random_complex_tensor(input_shape, (0, 0), (0, 0))
     other_data.requires_grad = True
 
-    input_tensor = ttl.tensor.complex_tensor(
+    input_tensor = ttnn.complex_tensor(
         ttl.tensor.Tensor(in_data.real, dtype).to(ttl.tensor.Layout.TILE).to(device, memcfg),
         ttl.tensor.Tensor(in_data.imag, dtype).to(ttl.tensor.Layout.TILE).to(device, memcfg),
     )
-    other_tensor = ttl.tensor.complex_tensor(
+    other_tensor = ttnn.complex_tensor(
         ttl.tensor.Tensor(other_data.real, dtype).to(ttl.tensor.Layout.TILE).to(device, memcfg),
         ttl.tensor.Tensor(other_data.imag, dtype).to(ttl.tensor.Layout.TILE).to(device, memcfg),
     )
 
     grad_data = random_complex_tensor(input_shape, (-50, 50), (-60, 60))
-    grad_tensor = ttl.tensor.complex_tensor(
+    grad_tensor = ttnn.complex_tensor(
         ttl.tensor.Tensor(grad_data.real, dtype).to(ttl.tensor.Layout.TILE).to(device, memcfg),
         ttl.tensor.Tensor(grad_data.imag, dtype).to(ttl.tensor.Layout.TILE).to(device, memcfg),
     )

--- a/tests/ttnn/unit_tests/operations/backward/complex_ops/test_backward_complex_mul.py
+++ b/tests/ttnn/unit_tests/operations/backward/complex_ops/test_backward_complex_mul.py
@@ -45,17 +45,17 @@ def test_level2_complex_mul_bw(bs, hw, memcfg, dtype, device, function_level_def
     other_data = random_complex_tensor(input_shape, (-20, 90), (-30, 100))
     other_data.requires_grad = True
 
-    input_tensor = ttl.tensor.complex_tensor(
+    input_tensor = ttnn.complex_tensor(
         ttl.tensor.Tensor(in_data.real, dtype).to(ttl.tensor.Layout.TILE).to(device, memcfg),
         ttl.tensor.Tensor(in_data.imag, dtype).to(ttl.tensor.Layout.TILE).to(device, memcfg),
     )
-    other_tensor = ttl.tensor.complex_tensor(
+    other_tensor = ttnn.complex_tensor(
         ttl.tensor.Tensor(other_data.real, dtype).to(ttl.tensor.Layout.TILE).to(device, memcfg),
         ttl.tensor.Tensor(other_data.imag, dtype).to(ttl.tensor.Layout.TILE).to(device, memcfg),
     )
 
     grad_data = random_complex_tensor(input_shape, (-50, 50), (-60, 60))
-    grad_tensor = ttl.tensor.complex_tensor(
+    grad_tensor = ttnn.complex_tensor(
         ttl.tensor.Tensor(grad_data.real, dtype).to(ttl.tensor.Layout.TILE).to(device, memcfg),
         ttl.tensor.Tensor(grad_data.imag, dtype).to(ttl.tensor.Layout.TILE).to(device, memcfg),
     )

--- a/tests/ttnn/unit_tests/operations/backward/complex_ops/test_backward_complex_sub.py
+++ b/tests/ttnn/unit_tests/operations/backward/complex_ops/test_backward_complex_sub.py
@@ -40,17 +40,17 @@ def test_level2_complex_sub_bw(bs, hw, alpha, memcfg, dtype, device, function_le
     other_data = random_complex_tensor(input_shape, (-20, 90), (-30, 100))
     other_data.requires_grad = True
 
-    input_tensor = ttl.tensor.complex_tensor(
+    input_tensor = ttnn.complex_tensor(
         ttl.tensor.Tensor(in_data.real, dtype).to(ttl.tensor.Layout.TILE).to(device, memcfg),
         ttl.tensor.Tensor(in_data.imag, dtype).to(ttl.tensor.Layout.TILE).to(device, memcfg),
     )
-    other_tensor = ttl.tensor.complex_tensor(
+    other_tensor = ttnn.complex_tensor(
         ttl.tensor.Tensor(other_data.real, dtype).to(ttl.tensor.Layout.TILE).to(device, memcfg),
         ttl.tensor.Tensor(other_data.imag, dtype).to(ttl.tensor.Layout.TILE).to(device, memcfg),
     )
 
     grad_data = random_complex_tensor(input_shape, (-50, 50), (-60, 60))
-    grad_tensor = ttl.tensor.complex_tensor(
+    grad_tensor = ttnn.complex_tensor(
         ttl.tensor.Tensor(grad_data.real, dtype).to(ttl.tensor.Layout.TILE).to(device, memcfg),
         ttl.tensor.Tensor(grad_data.imag, dtype).to(ttl.tensor.Layout.TILE).to(device, memcfg),
     )

--- a/tests/ttnn/unit_tests/operations/backward/complex_ops/test_backward_conj.py
+++ b/tests/ttnn/unit_tests/operations/backward/complex_ops/test_backward_conj.py
@@ -40,13 +40,13 @@ def test_level2_conj_bw(bs, hw, memcfg, dtype, device, function_level_defaults):
     in_data = random_complex_tensor(input_shape, (-90, 90), (-70, 70))
     in_data.requires_grad = True
 
-    input_tensor = ttl.tensor.complex_tensor(
+    input_tensor = ttnn.complex_tensor(
         ttl.tensor.Tensor(in_data.real, dtype).to(ttl.tensor.Layout.TILE).to(device, memcfg),
         ttl.tensor.Tensor(in_data.imag, dtype).to(ttl.tensor.Layout.TILE).to(device, memcfg),
     )
 
     grad_data = random_complex_tensor(input_shape, (-50, 50), (-60, 60))
-    grad_tensor = ttl.tensor.complex_tensor(
+    grad_tensor = ttnn.complex_tensor(
         ttl.tensor.Tensor(grad_data.real, dtype).to(ttl.tensor.Layout.TILE).to(device, memcfg),
         ttl.tensor.Tensor(grad_data.imag, dtype).to(ttl.tensor.Layout.TILE).to(device, memcfg),
     )

--- a/tests/ttnn/unit_tests/operations/backward/complex_ops/test_backward_imag.py
+++ b/tests/ttnn/unit_tests/operations/backward/complex_ops/test_backward_imag.py
@@ -40,7 +40,7 @@ def test_level2_imag_bw(bs, hw, memcfg, dtype, device, function_level_defaults):
     in_data = random_complex_tensor(input_shape, (-90, 90), (-70, 70))
     in_data.requires_grad = True
 
-    input_tensor = ttl.tensor.complex_tensor(
+    input_tensor = ttnn.complex_tensor(
         ttl.tensor.Tensor(in_data.real, dtype).to(ttl.tensor.Layout.TILE).to(device, memcfg),
         ttl.tensor.Tensor(in_data.imag, dtype).to(ttl.tensor.Layout.TILE).to(device, memcfg),
     )

--- a/tests/ttnn/unit_tests/operations/backward/complex_ops/test_backward_polar.py
+++ b/tests/ttnn/unit_tests/operations/backward/complex_ops/test_backward_polar.py
@@ -42,13 +42,13 @@ def test_level2_polar_bw(bs, hw, memcfg, dtype, device, function_level_defaults)
     in_data = random_complex_tensor(input_shape, (-90, 90), (0, 2 * pi))
     in_data.requires_grad = True
 
-    input_tensor = ttl.tensor.complex_tensor(
+    input_tensor = ttnn.complex_tensor(
         ttl.tensor.Tensor(in_data.real, dtype).to(ttl.tensor.Layout.TILE).to(device, memcfg),
         ttl.tensor.Tensor(in_data.imag, dtype).to(ttl.tensor.Layout.TILE).to(device, memcfg),
     )
 
     grad_data = random_complex_tensor(input_shape, (-50, 50), (-60, 60))
-    grad_tensor = ttl.tensor.complex_tensor(
+    grad_tensor = ttnn.complex_tensor(
         ttl.tensor.Tensor(grad_data.real, dtype).to(ttl.tensor.Layout.TILE).to(device, memcfg),
         ttl.tensor.Tensor(grad_data.imag, dtype).to(ttl.tensor.Layout.TILE).to(device, memcfg),
     )

--- a/tests/ttnn/unit_tests/operations/backward/complex_ops/test_backward_real.py
+++ b/tests/ttnn/unit_tests/operations/backward/complex_ops/test_backward_real.py
@@ -40,7 +40,7 @@ def test_level2_real_bw(bs, hw, memcfg, dtype, device, function_level_defaults):
     in_data = random_complex_tensor(input_shape, (-90, 90), (-70, 70))
     in_data.requires_grad = True
 
-    input_tensor = ttl.tensor.complex_tensor(
+    input_tensor = ttnn.complex_tensor(
         ttl.tensor.Tensor(in_data.real, dtype).to(ttl.tensor.Layout.TILE).to(device, memcfg),
         ttl.tensor.Tensor(in_data.imag, dtype).to(ttl.tensor.Layout.TILE).to(device, memcfg),
     )

--- a/tests/ttnn/unit_tests/operations/backward/complex_ops/test_backward_recip.py
+++ b/tests/ttnn/unit_tests/operations/backward/complex_ops/test_backward_recip.py
@@ -41,13 +41,13 @@ def test_level2_recip_bw(bs, hw, memcfg, dtype, device, function_level_defaults)
     in_data = random_complex_tensor(input_shape, (-90, 90), (-70, 70))
     in_data.requires_grad = True
 
-    input_tensor = ttl.tensor.complex_tensor(
+    input_tensor = ttnn.complex_tensor(
         ttl.tensor.Tensor(in_data.real, dtype).to(ttl.tensor.Layout.TILE).to(device, memcfg),
         ttl.tensor.Tensor(in_data.imag, dtype).to(ttl.tensor.Layout.TILE).to(device, memcfg),
     )
 
     grad_data = random_complex_tensor(input_shape, (-50, 50), (-60, 60))
-    grad_tensor = ttl.tensor.complex_tensor(
+    grad_tensor = ttnn.complex_tensor(
         ttl.tensor.Tensor(grad_data.real, dtype).to(ttl.tensor.Layout.TILE).to(device, memcfg),
         ttl.tensor.Tensor(grad_data.imag, dtype).to(ttl.tensor.Layout.TILE).to(device, memcfg),
     )
@@ -93,13 +93,13 @@ def test_level2_recip_bw_inp_zero(bs, hw, memcfg, dtype, device, function_level_
     in_data = random_complex_tensor(input_shape, (0, 0), (0, 0))
     in_data.requires_grad = True
 
-    input_tensor = ttl.tensor.complex_tensor(
+    input_tensor = ttnn.complex_tensor(
         ttl.tensor.Tensor(in_data.real, dtype).to(ttl.tensor.Layout.TILE).to(device, memcfg),
         ttl.tensor.Tensor(in_data.imag, dtype).to(ttl.tensor.Layout.TILE).to(device, memcfg),
     )
 
     grad_data = random_complex_tensor(input_shape, (-50, 50), (-60, 60))
-    grad_tensor = ttl.tensor.complex_tensor(
+    grad_tensor = ttnn.complex_tensor(
         ttl.tensor.Tensor(grad_data.real, dtype).to(ttl.tensor.Layout.TILE).to(device, memcfg),
         ttl.tensor.Tensor(grad_data.imag, dtype).to(ttl.tensor.Layout.TILE).to(device, memcfg),
     )

--- a/tests/ttnn/unit_tests/operations/complex/test_complex_conj.py
+++ b/tests/ttnn/unit_tests/operations/complex/test_complex_conj.py
@@ -1,0 +1,52 @@
+# SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
+
+# SPDX-License-Identifier: Apache-2.0
+
+import torch
+
+import tt_lib as ttl
+import pytest
+import ttnn
+from loguru import logger
+from tests.ttnn.unit_tests.operations.backward.utility_funcs import data_gen_with_range
+from tests.tt_eager.python_api_testing.sweep_tests.comparison_funcs import comp_pcc, comp_equal, comp_allclose
+
+from models.utility_functions import is_wormhole_b0, skip_for_grayskull
+from tests.ttnn.unit_tests.operations.complex.utility_funcs import (
+    convert_complex_to_torch_tensor,
+    random_complex_tensor,
+)
+
+
+@skip_for_grayskull()
+@pytest.mark.parametrize(
+    "memcfg",
+    (
+        ttl.tensor.MemoryConfig(ttl.tensor.TensorMemoryLayout.INTERLEAVED, ttl.tensor.BufferType.DRAM),
+        ttl.tensor.MemoryConfig(ttl.tensor.TensorMemoryLayout.INTERLEAVED, ttl.tensor.BufferType.L1),
+    ),
+    ids=["out_DRAM", "out_L1"],
+)
+@pytest.mark.parametrize("dtype", ((ttl.tensor.DataType.FLOAT32,)))
+@pytest.mark.parametrize("bs", ((1, 1),))
+@pytest.mark.parametrize("hw", ((32, 32),))
+def test_conj(bs, hw, memcfg, dtype, device, function_level_defaults):
+    input_shape = torch.Size([bs[0], bs[1], hw[0], hw[1]])
+
+    in_data = random_complex_tensor(input_shape, (-90, 90), (-70, 70))
+
+    input_tensor = ttnn.complex_tensor(
+        ttl.tensor.Tensor(in_data.real, dtype).to(ttl.tensor.Layout.TILE).to(device, memcfg),
+        ttl.tensor.Tensor(in_data.imag, dtype).to(ttl.tensor.Layout.TILE).to(device, memcfg),
+    )
+
+    tt_dev = ttnn.conj(input_tensor, memory_config=memcfg)
+
+    tt_to_torch = convert_complex_to_torch_tensor(tt_dev)
+
+    golden_function = ttnn.get_golden_function(ttnn.conj)
+    golden_tensor = golden_function(in_data)
+
+    passing, output = comp_pcc(golden_tensor, tt_to_torch)
+    logger.info(output)
+    assert passing

--- a/tests/ttnn/unit_tests/operations/complex/utility_funcs.py
+++ b/tests/ttnn/unit_tests/operations/complex/utility_funcs.py
@@ -1,0 +1,21 @@
+# SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+
+# SPDX-License-Identifier: Apache-2.0
+
+import torch
+
+import tt_lib as ttl
+
+
+def random_complex_tensor(shape, real_range=(-100, 100), imag_range=(-100, 100)):
+    torch.manual_seed(213919)
+    real_part = (real_range[1] - real_range[0]) * torch.rand(shape) + real_range[0]
+    imag_part = (imag_range[1] - imag_range[0]) * torch.rand(shape) + imag_range[0]
+    return torch.complex(real_part, imag_part)
+
+
+def convert_complex_to_torch_tensor(tt_dev):
+    tt_dev_r = tt_dev.real.cpu().to(ttl.tensor.Layout.ROW_MAJOR).to_torch()
+    tt_dev_i = tt_dev.imag.cpu().to(ttl.tensor.Layout.ROW_MAJOR).to_torch()
+    tt_to_torch = torch.complex(tt_dev_r, tt_dev_i)
+    return tt_to_torch

--- a/tests/ttnn/unit_tests/operations/test_complex.py
+++ b/tests/ttnn/unit_tests/operations/test_complex.py
@@ -97,7 +97,7 @@ def test_level2_real(bs, memcfg, dtype, device, function_level_defaults):
     input_shape = torch.Size([bs[0], bs[1], 32, 64])
     # check real
     x = Complex(input_shape)
-    xtt = ttl.tensor.complex_tensor(
+    xtt = ttnn.complex_tensor(
         ttl.tensor.Tensor(x.real, dtype).to(ttl.tensor.Layout.TILE).to(device, memcfg),
         ttl.tensor.Tensor(x.imag, dtype).to(ttl.tensor.Layout.TILE).to(device, memcfg),
     )
@@ -123,7 +123,7 @@ def test_level2_imag(bs, memcfg, dtype, device, function_level_defaults):
     input_shape = torch.Size([bs[0], bs[1], 32, 64])
     # check imag
     x = Complex(input_shape)
-    xtt = ttl.tensor.complex_tensor(
+    xtt = ttnn.complex_tensor(
         ttl.tensor.Tensor(x.real, dtype).to(ttl.tensor.Layout.TILE).to(device, memcfg),
         ttl.tensor.Tensor(x.imag, dtype).to(ttl.tensor.Layout.TILE).to(device, memcfg),
     )
@@ -149,7 +149,7 @@ def test_level2_abs(bs, memcfg, dtype, device, function_level_defaults):
     input_shape = torch.Size([bs[0], bs[1], 32, 64])
     # check abs
     x = Complex(input_shape)
-    xtt = ttl.tensor.complex_tensor(
+    xtt = ttnn.complex_tensor(
         ttl.tensor.Tensor(x.real, dtype).to(ttl.tensor.Layout.TILE).to(device, memcfg),
         ttl.tensor.Tensor(x.imag, dtype).to(ttl.tensor.Layout.TILE).to(device, memcfg),
     )
@@ -178,7 +178,7 @@ def test_level2_abs(bs, memcfg, dtype, device, function_level_defaults):
     input_shape = torch.Size([bs[0], bs[1], 32, 64])
     # check abs
     x = Complex(input_shape)
-    xtt = ttl.tensor.complex_tensor(
+    xtt = ttnn.complex_tensor(
         ttl.tensor.Tensor(x.real, dtype).to(ttl.tensor.Layout.TILE).to(device, memcfg),
         ttl.tensor.Tensor(x.imag, dtype).to(ttl.tensor.Layout.TILE).to(device, memcfg),
     )
@@ -207,7 +207,7 @@ def test_level2_conj(bs, memcfg, dtype, device, function_level_defaults):
     input_shape = torch.Size([bs[0], bs[1], 32, 64])
     # check abs
     x = Complex(input_shape)
-    xtt = ttl.tensor.complex_tensor(
+    xtt = ttnn.complex_tensor(
         ttl.tensor.Tensor(x.real, dtype).to(ttl.tensor.Layout.TILE).to(device, memcfg),
         ttl.tensor.Tensor(x.imag, dtype).to(ttl.tensor.Layout.TILE).to(device, memcfg),
     )
@@ -239,7 +239,7 @@ def test_level2_recip(bs, memcfg, dtype, device, function_level_defaults):
     # check abs
     x = Complex(input_shape)
     x = x.div(x * 0.5)
-    xtt = ttl.tensor.complex_tensor(
+    xtt = ttnn.complex_tensor(
         ttl.tensor.Tensor(x.real, dtype).to(ttl.tensor.Layout.TILE).to(device, memcfg),
         ttl.tensor.Tensor(x.imag, dtype).to(ttl.tensor.Layout.TILE).to(device, memcfg),
     )
@@ -274,11 +274,11 @@ def test_level2_add(bs, memcfg, dtype, device, function_level_defaults):
     x = Complex(input_shape)
     y = Complex(input_shape) * -0.5
 
-    xtt = ttl.tensor.complex_tensor(
+    xtt = ttnn.complex_tensor(
         ttl.tensor.Tensor(x.real, dtype).to(ttl.tensor.Layout.TILE).to(device, memcfg),
         ttl.tensor.Tensor(x.imag, dtype).to(ttl.tensor.Layout.TILE).to(device, memcfg),
     )
-    ytt = ttl.tensor.complex_tensor(
+    ytt = ttnn.complex_tensor(
         ttl.tensor.Tensor(y.real, dtype).to(ttl.tensor.Layout.TILE).to(device, memcfg),
         ttl.tensor.Tensor(y.imag, dtype).to(ttl.tensor.Layout.TILE).to(device, memcfg),
     )
@@ -311,11 +311,11 @@ def test_level2_sub(bs, memcfg, dtype, device, function_level_defaults):
     x = Complex(input_shape)
     y = Complex(input_shape) * -0.5
 
-    xtt = ttl.tensor.complex_tensor(
+    xtt = ttnn.complex_tensor(
         ttl.tensor.Tensor(x.real, dtype).to(ttl.tensor.Layout.TILE).to(device, memcfg),
         ttl.tensor.Tensor(x.imag, dtype).to(ttl.tensor.Layout.TILE).to(device, memcfg),
     )
-    ytt = ttl.tensor.complex_tensor(
+    ytt = ttnn.complex_tensor(
         ttl.tensor.Tensor(y.real, dtype).to(ttl.tensor.Layout.TILE).to(device, memcfg),
         ttl.tensor.Tensor(y.imag, dtype).to(ttl.tensor.Layout.TILE).to(device, memcfg),
     )
@@ -349,11 +349,11 @@ def test_level2_mul(bs, memcfg, dtype, device, function_level_defaults):
     x = Complex(input_shape)
     y = Complex(input_shape) * -0.5
 
-    xtt = ttl.tensor.complex_tensor(
+    xtt = ttnn.complex_tensor(
         ttl.tensor.Tensor(x.real, dtype).to(ttl.tensor.Layout.TILE).to(device, memcfg),
         ttl.tensor.Tensor(x.imag, dtype).to(ttl.tensor.Layout.TILE).to(device, memcfg),
     )
-    ytt = ttl.tensor.complex_tensor(
+    ytt = ttnn.complex_tensor(
         ttl.tensor.Tensor(y.real, dtype).to(ttl.tensor.Layout.TILE).to(device, memcfg),
         ttl.tensor.Tensor(y.imag, dtype).to(ttl.tensor.Layout.TILE).to(device, memcfg),
     )
@@ -387,11 +387,11 @@ def test_level2_div(bs, memcfg, dtype, device, function_level_defaults):
     x = Complex(input_shape) * 0.5
     y = Complex(input_shape) * 1
 
-    xtt = ttl.tensor.complex_tensor(
+    xtt = ttnn.complex_tensor(
         ttl.tensor.Tensor(x.real, dtype).to(ttl.tensor.Layout.TILE).to(device, memcfg),
         ttl.tensor.Tensor(x.imag, dtype).to(ttl.tensor.Layout.TILE).to(device, memcfg),
     )
-    ytt = ttl.tensor.complex_tensor(
+    ytt = ttnn.complex_tensor(
         ttl.tensor.Tensor(y.real, dtype).to(ttl.tensor.Layout.TILE).to(device, memcfg),
         ttl.tensor.Tensor(y.imag, dtype).to(ttl.tensor.Layout.TILE).to(device, memcfg),
     )
@@ -422,7 +422,7 @@ def test_level2_is_real(bs, memcfg, dtype, device, function_level_defaults):
     input_shape = torch.Size([bs[0], bs[1], 32, 64])
     # check abs
     x = Complex(input_shape)
-    xtt = ttl.tensor.complex_tensor(
+    xtt = ttnn.complex_tensor(
         ttl.tensor.Tensor(x.real, dtype).to(ttl.tensor.Layout.TILE).to(device, memcfg),
         ttl.tensor.Tensor(0 * x.imag, dtype).to(ttl.tensor.Layout.TILE).to(device, memcfg),
     )
@@ -452,7 +452,7 @@ def test_level2_is_imag(bs, memcfg, dtype, device, function_level_defaults):
     input_shape = torch.Size([bs[0], bs[1], 32, 64])
     # check abs
     x = Complex(input_shape)
-    xtt = ttl.tensor.complex_tensor(
+    xtt = ttnn.complex_tensor(
         ttl.tensor.Tensor(0 * x.real, dtype).to(ttl.tensor.Layout.TILE).to(device, memcfg),
         ttl.tensor.Tensor(x.imag, dtype).to(ttl.tensor.Layout.TILE).to(device, memcfg),
     )
@@ -481,7 +481,7 @@ def test_level2_angle(bs, memcfg, dtype, device, function_level_defaults):
     input_shape = torch.Size([bs[0], bs[1], 32, 64])
     # check imag
     x = Complex(input_shape)
-    xtt = ttl.tensor.complex_tensor(
+    xtt = ttnn.complex_tensor(
         ttl.tensor.Tensor(x.real, dtype).to(ttl.tensor.Layout.TILE).to(device, memcfg),
         ttl.tensor.Tensor(x.imag, dtype).to(ttl.tensor.Layout.TILE).to(device, memcfg),
     )
@@ -514,7 +514,7 @@ def test_level2_polar(bs, memcfg, dtype, device, function_level_defaults):
     # we set imag = angle theta
     x = Complex(None, re=torch.ones(input_shape), im=torch.rand(input_shape))
 
-    xtt = ttl.tensor.complex_tensor(
+    xtt = ttnn.complex_tensor(
         ttl.tensor.Tensor(x.real, dtype).to(ttl.tensor.Layout.TILE).to(device, memcfg),
         ttl.tensor.Tensor(x.imag, dtype).to(ttl.tensor.Layout.TILE).to(device, memcfg),
     )

--- a/tests/ttnn/unit_tests/operations/test_complex_tensor.py
+++ b/tests/ttnn/unit_tests/operations/test_complex_tensor.py
@@ -1,0 +1,49 @@
+# SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
+
+# SPDX-License-Identifier: Apache-2.0
+
+import torch
+
+import tt_lib as ttl
+import pytest
+import ttnn
+from loguru import logger
+from tests.ttnn.unit_tests.operations.backward.utility_funcs import data_gen_with_range
+from tests.tt_eager.python_api_testing.sweep_tests.comparison_funcs import comp_pcc, comp_equal, comp_allclose
+
+from models.utility_functions import is_wormhole_b0
+from tests.ttnn.unit_tests.operations.complex.utility_funcs import (
+    convert_complex_to_torch_tensor,
+    random_complex_tensor,
+)
+
+
+@pytest.mark.parametrize(
+    "memcfg",
+    (
+        ttl.tensor.MemoryConfig(ttl.tensor.TensorMemoryLayout.INTERLEAVED, ttl.tensor.BufferType.DRAM),
+        ttl.tensor.MemoryConfig(ttl.tensor.TensorMemoryLayout.INTERLEAVED, ttl.tensor.BufferType.L1),
+    ),
+    ids=["out_DRAM", "out_L1"],
+)
+@pytest.mark.parametrize("dtype", ((ttl.tensor.DataType.FLOAT32,)))
+@pytest.mark.parametrize("bs", ((1, 1),))
+@pytest.mark.parametrize("hw", ((32, 32),))
+def test_create_complex_tensor(bs, hw, memcfg, dtype, device, function_level_defaults):
+    input_shape = torch.Size([bs[0], bs[1], hw[0], hw[1]])
+
+    in_data = random_complex_tensor(input_shape, (-90, 90), (-70, 70))
+
+    input_tensor = ttnn.complex_tensor(
+        ttl.tensor.Tensor(in_data.real, dtype).to(ttl.tensor.Layout.TILE).to(device, memcfg),
+        ttl.tensor.Tensor(in_data.imag, dtype).to(ttl.tensor.Layout.TILE).to(device, memcfg),
+    )
+
+    tt_dev = input_tensor
+    tt_to_torch = convert_complex_to_torch_tensor(tt_dev)
+
+    golden_tensor = in_data
+
+    passing, output = comp_pcc(golden_tensor, tt_to_torch)
+    logger.info(output)
+    assert passing

--- a/ttnn/CMakeLists.txt
+++ b/ttnn/CMakeLists.txt
@@ -30,19 +30,20 @@ set(TTNN_SRCS
     ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/eltwise/binary/device/element_wise_multi_core_program_factory.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/eltwise/binary_backward/device/binary_backward_op.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/eltwise/ternary_backward/device/ternary_backward_op.cpp
-    ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/eltwise/complex_binary_backward/device/complex_binary_backward_op.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/upsample/upsample_op.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/upsample/device/upsample_op_multi_core.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/upsample/device/upsample_op_single_core.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/eltwise/unary/unary.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/eltwise/complex/complex.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/eltwise/unary/device/unary_op.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/eltwise/unary_backward/device/unary_backward_op.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/eltwise/complex_unary/device/complex_unary_op.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/eltwise/complex_unary_backward/device/complex_unary_backward_op.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/eltwise/complex_binary_backward/device/complex_binary_backward_op.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/eltwise/complex_binary/device/complex_binary_op.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/eltwise/unary/device/unary_composite_op.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/eltwise/ternary/ternary_composite_op.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/eltwise/ternary/where_op.cpp
-    ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/eltwise/complex_unary_backward/device/complex_unary_backward_op.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/ccl/all_gather/device/all_gather_op.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/ccl/ccl_common.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/ccl/all_gather/all_gather.cpp

--- a/ttnn/cpp/pybind11/operations/__init__.hpp
+++ b/ttnn/cpp/pybind11/operations/__init__.hpp
@@ -32,9 +32,9 @@
 #include "ttnn/operations/embedding/embedding_pybind.hpp"
 #include "ttnn/operations/matmul/matmul_pybind.hpp"
 #include "ttnn/operations/transformer/transformer_pybind.hpp"
-#include "ttnn/operations/eltwise/complex_unary_backward/complex_unary_backward_pybind.hpp"
-#include "ttnn/operations/eltwise/complex_binary_backward/complex_binary_backward_pybind.hpp"
 #include "ttnn/operations/experimental/experimental_pybind.hpp"
+#include "ttnn/operations/eltwise/complex/complex_pybind.hpp"
+#include "ttnn/operations/eltwise/complex_unary_backward/complex_unary_backward_pybind.hpp"
 
 namespace py = pybind11;
 
@@ -48,9 +48,6 @@ void py_module(py::module& module) {
 
     auto m_unary = module.def_submodule("unary", "unary operations");
     unary::py_module(m_unary);
-
-    auto m_complex_unary_backward = module.def_submodule("complex_unary_backward", "complex_unary_backward operations");
-    complex_unary_backward::py_module(m_complex_unary_backward);
 
     auto m_binary = module.def_submodule("binary", "binary operations");
     binary::py_module(m_binary);
@@ -69,8 +66,14 @@ void py_module(py::module& module) {
     ccl::py_bind_line_all_gather(m_ccl);
     ccl::py_bind_reduce_scatter(m_ccl);
 
+    auto m_complex = module.def_submodule("complex", "complex tensor creation");
+    complex::py_module(m_complex);
+
     auto m_complex_unary = module.def_submodule("complex_unary", "complex_unary operations");
     complex_unary::py_module(m_complex_unary);
+
+    auto m_complex_unary_backward = module.def_submodule("complex_unary_backward", "complex_unary_backward operations");
+    complex_unary_backward::py_module(m_complex_unary_backward);
 
     auto m_ternary = module.def_submodule("ternary", "ternary operations");
     ternary::py_module(m_ternary);

--- a/ttnn/cpp/ttnn/deprecated/tt_dnn/op_library/complex/complex_ops.cpp
+++ b/ttnn/cpp/ttnn/deprecated/tt_dnn/op_library/complex/complex_ops.cpp
@@ -12,7 +12,6 @@
 #include "ttnn/operations/eltwise/binary/binary.hpp"
 #include "ttnn/operations/eltwise/unary/unary.hpp"
 #include "ttnn/operations/eltwise/complex_unary/device/complex_unary_op.hpp"
-#include "ttnn/operations/eltwise/complex_binary/device/complex_binary_op.hpp"
 #include "ttnn/operations/eltwise/binary/binary_composite.hpp"
 
 namespace tt {

--- a/ttnn/cpp/ttnn/deprecated/tt_lib/csrc/tt_lib_bindings_tensor_composite_ops.cpp
+++ b/ttnn/cpp/ttnn/deprecated/tt_lib/csrc/tt_lib_bindings_tensor_composite_ops.cpp
@@ -8,10 +8,10 @@
 #include "ttnn/deprecated/tt_dnn/op_library/optimizer/optimizer_ops.hpp"
 #include "tt_lib_bindings_tensor.hpp"
 #include "tt_lib_bindings_tensor_impl.hpp"
-#include "ttnn/operations/eltwise/complex_binary/device/complex_binary_op.hpp"
+
 
 namespace tt::tt_metal::detail {
-using ComplexTensor = ttnn::operations::complex_binary::ComplexTensor;
+
 
 void TensorModuleCompositeOPs(py::module& m_tensor) {
 
@@ -936,22 +936,6 @@ void TensorModuleCompositeOPs(py::module& m_tensor) {
 
         detail::bind_binary_op<false, true, false, false>(m_tensor, "scatter", &tt::tt_metal::scatter, R"doc(Performs scatter operation on elements of the input tensors ``{0}`` and ``{1}``,specifically to copy channel data.)doc");
 
-	    // *** type-2 complex operations in new submodule 'type2_complex' ***
-        auto m_type2_cplx = m_tensor.def_submodule("complex", "Complex type2");
-        py::class_<ComplexTensor> pycplx_cls(m_type2_cplx, "ComplexTensor");
-
-        pycplx_cls.def_property_readonly("real",&ComplexTensor::real);
-        pycplx_cls.def_property_readonly("imag",&ComplexTensor::imag);
-        pycplx_cls.def("deallocate",&ComplexTensor::deallocate);
-
-        m_tensor.def("complex_tensor",
-		     [](Tensor& r, Tensor& i) -> ComplexTensor {
-		       return ComplexTensor({r,i});
-		     },
-            py::arg("real"),
-            py::arg("imag"),
-	        R"doc(Create a complex tensor object from real and imag parts ``{0}`` and ``{1}``.)doc"
-        );
 
     // loss functions
     m_tensor.def(

--- a/ttnn/cpp/ttnn/operations/eltwise/binary/binary_pybind.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary/binary_pybind.hpp
@@ -10,9 +10,8 @@
 #include "ttnn/cpp/pybind11/decorators.hpp"
 #include "ttnn/operations/eltwise/binary/binary.hpp"
 #include "ttnn/operations/eltwise/binary/binary_composite.hpp"
-#include "ttnn/operations/eltwise/complex_binary/complex_binary.hpp"
 #include "ttnn/types.hpp"
-#include "ttnn/operations/eltwise/complex_binary/device/complex_binary_op.hpp"
+#include "ttnn/operations/eltwise/complex/complex.hpp"
 
 namespace py = pybind11;
 
@@ -23,7 +22,6 @@ namespace binary {
 
 namespace detail {
 
-using ComplexTensor = complex_binary::ComplexTensor;
 
 template <typename binary_operation_t>
 void bind_binary_operation(py::module& module, const binary_operation_t& operation, const std::string& description) {

--- a/ttnn/cpp/ttnn/operations/eltwise/complex/complex.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/complex/complex.cpp
@@ -1,0 +1,43 @@
+// SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+
+#include "complex.hpp"
+
+
+namespace ttnn {
+namespace operations::complex {
+
+
+ComplexTensor::ComplexTensor(std::array<Tensor, 2> val): m_real_imag(val) {
+            TT_ASSERT( m_real_imag[0].get_legacy_shape() == m_real_imag[1].get_legacy_shape() , "Tensor shapes of real and imag should be identical");
+        }
+
+const Tensor& ComplexTensor::operator[](uint32_t index) const {
+            return m_real_imag[index];
+        }
+
+const Tensor& ComplexTensor::real() const {
+            return m_real_imag[0];
+        }
+
+const Tensor& ComplexTensor::imag() const {
+            return m_real_imag[1];
+        }
+
+void ComplexTensor::deallocate() {
+            m_real_imag[0].deallocate();
+            m_real_imag[1].deallocate();
+        }
+
+
+ComplexTensor CreateComplexTensor::operator()(
+        const Tensor &input_tensor_a_arg,
+        const Tensor &input_tensor_b_arg) {
+            return ComplexTensor({input_tensor_a_arg, input_tensor_b_arg});
+    }
+
+}  // namespace operations::complex
+
+} // namespace ttnn

--- a/ttnn/cpp/ttnn/operations/eltwise/complex/complex.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/complex/complex.hpp
@@ -1,0 +1,44 @@
+// SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <functional>
+#include <array>
+
+#include "ttnn/tensor/tensor.hpp"
+#include "ttnn/decorators.hpp"
+
+namespace ttnn {
+namespace operations::complex {
+
+class ComplexTensor {
+    private:
+        std::array<Tensor, 2> m_real_imag;
+
+    public:
+        ComplexTensor(std::array<Tensor, 2> val);
+        const Tensor& operator[](uint32_t index) const;
+        const Tensor& real() const;
+        const Tensor& imag() const;
+        void deallocate();
+};
+
+struct CreateComplexTensor {
+
+    static ComplexTensor operator()(
+        const Tensor &input_tensor_a_arg,
+        const Tensor &input_tensor_b_arg);
+};
+
+}  // namespace operations::complex
+
+using ComplexTensor = operations::complex::ComplexTensor;
+
+constexpr auto complex_tensor = ttnn::register_operation<
+    "ttnn::complex_tensor",
+    operations::complex::CreateComplexTensor>();
+
+
+} // namespace ttnn

--- a/ttnn/cpp/ttnn/operations/eltwise/complex/complex_pybind.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/complex/complex_pybind.hpp
@@ -1,0 +1,65 @@
+// SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <pybind11/operators.h>
+#include <pybind11/pybind11.h>
+#include <pybind11/stl.h>
+
+#include "complex.hpp"
+
+namespace py = pybind11;
+
+namespace ttnn::operations::complex {
+
+namespace detail {
+
+void bind_complex_tensor_type(py::module& m) {
+    py::class_<ComplexTensor>(m, "ComplexTensor")
+        .def(py::init<std::array<Tensor, 2>>())
+        .def_property_readonly("real", &ComplexTensor::real)
+        .def_property_readonly("imag", &ComplexTensor::imag)
+        .def("deallocate", &ComplexTensor::deallocate)
+        .def("__getitem__", &ComplexTensor::operator[]);
+
+}
+
+void bind_complex_tensor(py::module& module) {
+    auto doc = fmt::format(
+        R"doc({0}real: ttnn.Tensor, imag: ttnn.Tensor -> ComplexTensor
+
+            Create a complex tensor from real and imaginary part tensors.
+
+            Args:
+                * :attr:`real`
+                * :attr:`imag`
+
+            Example:
+
+                >>> real = ttnn.to_device(ttnn.from_torch(torch.tensor((1, 2), dtype=torch.bfloat16)), device)
+                >>> imag = ttnn.to_device(ttnn.from_torch(torch.tensor((1, 2), dtype=torch.bfloat16)), device)
+                >>> complex_tensor = ttnn.complex_tensor(real, imag)
+        )doc",
+        ttnn::complex_tensor.base_name());
+
+    bind_registered_operation(
+        module,
+        ttnn::complex_tensor,
+        doc,
+        ttnn::pybind_arguments_t{
+            py::arg("real"),
+            py::arg("imag")}
+    );
+}
+
+} // detail
+
+
+void py_module(py::module& module) {
+   detail::bind_complex_tensor_type(module);
+   detail::bind_complex_tensor(module);
+}
+
+} // ttnn::operations::complex

--- a/ttnn/cpp/ttnn/operations/eltwise/complex_binary/complex_binary_pybind.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/complex_binary/complex_binary_pybind.hpp
@@ -8,6 +8,7 @@
 #include <pybind11/stl.h>
 
 #include "ttnn/cpp/pybind11/decorators.hpp"
+#include "ttnn/operations/eltwise/complex/complex.hpp"
 #include "ttnn/types.hpp"
 
 namespace py = pybind11;

--- a/ttnn/cpp/ttnn/operations/eltwise/complex_binary/device/complex_binary_op.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/complex_binary/device/complex_binary_op.cpp
@@ -6,6 +6,7 @@
 #include "tt_metal/host_api.hpp"
 #include "tt_metal/tools/profiler/op_profiler.hpp"
 #include "ttnn/operations/eltwise/binary/binary.hpp"
+#include "ttnn/operations/eltwise/complex/complex.hpp"
 #include "ttnn/operations/eltwise/complex_unary/device/complex_unary_op.hpp"
 
 namespace ttnn::operations::complex_binary {

--- a/ttnn/cpp/ttnn/operations/eltwise/complex_binary/device/complex_binary_op.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/complex_binary/device/complex_binary_op.hpp
@@ -8,6 +8,7 @@
 #include <optional>
 #include "ttnn/tensor/tensor.hpp"
 #include "third_party/magic_enum/magic_enum.hpp"
+#include "ttnn/operations/eltwise/complex/complex.hpp"
 
 namespace ttnn::operations::complex_binary {
 
@@ -17,34 +18,6 @@ enum class ComplexBinaryOpType {
     SUB,
     MUL,
     DIV,
-};
-
-class ComplexTensor {
-    private:
-        std::array<Tensor,2> m_real_imag;
-
-    public:
-
-        ComplexTensor(std::array<Tensor,2> val): m_real_imag(val) {
-            TT_ASSERT( m_real_imag[0].get_legacy_shape() == m_real_imag[1].get_legacy_shape() , "Tensor shapes of real and imag should be identical");
-        }
-
-        const Tensor& operator[](uint32_t index) const {
-            return m_real_imag[index];
-        }
-
-        const Tensor& real() const {
-            return m_real_imag[0];
-        }
-
-        const Tensor& imag() const {
-            return m_real_imag[1];
-        }
-
-        void deallocate() {
-            m_real_imag[0].deallocate();
-            m_real_imag[1].deallocate();
-        }
 };
 
 // OpHandler_complex_binary_type1 = get_function_complex_binary

--- a/ttnn/cpp/ttnn/operations/eltwise/complex_binary_backward/complex_binary_backward.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/complex_binary_backward/complex_binary_backward.hpp
@@ -12,7 +12,6 @@
 namespace ttnn {
 
 namespace operations::complex_binary_backward {
-using ComplexTensor = complex_binary::ComplexTensor;
 
 template <ComplexBinaryBackwardOpType complex_binary_backward_op_type>
 struct ExecuteComplexBinaryBackwardWFloat {

--- a/ttnn/cpp/ttnn/operations/eltwise/complex_binary_backward/complex_binary_backward_pybind.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/complex_binary_backward/complex_binary_backward_pybind.hpp
@@ -9,6 +9,7 @@
 
 #include "ttnn/cpp/pybind11/decorators.hpp"
 #include "ttnn/operations/eltwise/complex_binary_backward/complex_binary_backward.hpp"
+#include "ttnn/operations/eltwise/complex/complex.hpp"
 #include "ttnn/types.hpp"
 
 namespace py = pybind11;
@@ -18,7 +19,6 @@ namespace operations {
 namespace complex_binary_backward {
 
 namespace detail {
-using ComplexTensor = complex_binary::ComplexTensor;
 
 template <typename complex_binary_backward_operation_t>
 void bind_complex_binary_backward_w_float(py::module& module, const complex_binary_backward_operation_t& operation, const std::string& description) {

--- a/ttnn/cpp/ttnn/operations/eltwise/complex_binary_backward/device/complex_binary_backward_op.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/complex_binary_backward/device/complex_binary_backward_op.cpp
@@ -2,18 +2,18 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
+#include "complex_binary_backward_op.hpp"
 #include "tt_metal/common/constants.hpp"
 #include "tt_metal/host_api.hpp"
 #include "tt_metal/tools/profiler/op_profiler.hpp"
-#include "ttnn/operations/eltwise/complex_binary_backward/device/complex_binary_backward_op.hpp"
 #include "ttnn/operations/eltwise/complex_unary/device/complex_unary_op.hpp"
 #include "ttnn/operations/eltwise/binary/binary.hpp"
 #include "ttnn/operations/eltwise/complex_binary/device/complex_binary_op.hpp"
 #include "ttnn/operations/eltwise/complex_unary/complex_unary.hpp"
 #include "ttnn/cpp/ttnn/operations/eltwise/ternary/where_op.hpp"
 
+
 namespace ttnn::operations::complex_binary_backward {
-using ComplexTensor = complex_binary::ComplexTensor;
 
 // complex add
 // self: grad, other: grad * alpha

--- a/ttnn/cpp/ttnn/operations/eltwise/complex_binary_backward/device/complex_binary_backward_op.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/complex_binary_backward/device/complex_binary_backward_op.hpp
@@ -8,10 +8,9 @@
 #include <optional>
 #include "ttnn/tensor/tensor.hpp"
 #include "third_party/magic_enum/magic_enum.hpp"
-#include "ttnn/operations/eltwise/complex_binary/device/complex_binary_op.hpp"
+#include "ttnn/operations/eltwise/complex/complex.hpp"
 
 namespace ttnn::operations::complex_binary_backward {
-using ComplexTensor = complex_binary::ComplexTensor;
 
 constexpr uint8_t DefaultQueueId = 0;
 enum class ComplexBinaryBackwardOpType {

--- a/ttnn/cpp/ttnn/operations/eltwise/complex_unary/complex_unary.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/complex_unary/complex_unary.hpp
@@ -12,7 +12,6 @@
 namespace ttnn {
 
 namespace operations::complex_unary {
-using ComplexTensor = complex_binary::ComplexTensor;
 
 template <ComplexUnaryOpType complex_unary_op_type>
 struct ExecuteComplexUnaryTensor {

--- a/ttnn/cpp/ttnn/operations/eltwise/complex_unary/complex_unary_pybind.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/complex_unary/complex_unary_pybind.hpp
@@ -9,6 +9,7 @@
 
 #include "ttnn/cpp/pybind11/decorators.hpp"
 #include "ttnn/operations/eltwise/complex_unary/complex_unary.hpp"
+#include "ttnn/operations/eltwise/complex/complex.hpp"
 #include "ttnn/types.hpp"
 
 namespace py = pybind11;
@@ -18,7 +19,6 @@ namespace operations {
 namespace complex_unary {
 
 namespace detail {
-using ComplexTensor = complex_binary::ComplexTensor;
 
 template <typename complex_unary_operation_t>
 void bind_complex_unary_tensor(py::module& module, const complex_unary_operation_t& operation, const std::string& description) {

--- a/ttnn/cpp/ttnn/operations/eltwise/complex_unary/device/complex_unary_op.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/complex_unary/device/complex_unary_op.cpp
@@ -2,18 +2,16 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-
+#include "complex_unary_op.hpp"
 #include "ttnn/deprecated/tt_dnn/op_library/bcast/bcast_op.hpp"
 #include "tt_metal/common/constants.hpp"
 #include "tt_metal/host_api.hpp"
 #include "tt_metal/tools/profiler/op_profiler.hpp"
 #include "ttnn/operations/eltwise/binary/binary.hpp"
-#include "ttnn/operations/eltwise/complex_binary_backward/device/complex_binary_backward_op.hpp"
-#include "ttnn/operations/eltwise/complex_binary/device/complex_binary_op.hpp"
 #include "ttnn/operations/eltwise/binary/binary_composite.hpp"
+#include "ttnn/operations/eltwise/complex/complex.hpp"
 
 namespace ttnn::operations::complex_unary {
-using ComplexTensor = complex_binary::ComplexTensor;
 
 Tensor _real(const ComplexTensor& input, const MemoryConfig& output_mem_config) {
     return input[0];

--- a/ttnn/cpp/ttnn/operations/eltwise/complex_unary/device/complex_unary_op.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/complex_unary/device/complex_unary_op.hpp
@@ -8,10 +8,9 @@
 #include <optional>
 #include "ttnn/tensor/tensor.hpp"
 #include "third_party/magic_enum/magic_enum.hpp"
-#include "ttnn/operations/eltwise/complex_binary/device/complex_binary_op.hpp"
+#include "ttnn/operations/eltwise/complex/complex.hpp"
 
 namespace ttnn::operations::complex_unary {
-using ComplexTensor = complex_binary::ComplexTensor;
 
 constexpr uint8_t DefaultQueueId = 0;
 enum class ComplexUnaryOpType {

--- a/ttnn/cpp/ttnn/operations/eltwise/complex_unary_backward/complex_unary_backward.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/complex_unary_backward/complex_unary_backward.hpp
@@ -12,7 +12,7 @@
 namespace ttnn {
 
 namespace operations::complex_unary_backward {
-using ComplexTensor = complex_binary::ComplexTensor;
+
 
 template <ComplexUnaryBackwardOpType complex_unary_backward_op_type>
 struct ExecuteComplexUnaryBackward {

--- a/ttnn/cpp/ttnn/operations/eltwise/complex_unary_backward/complex_unary_backward_pybind.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/complex_unary_backward/complex_unary_backward_pybind.hpp
@@ -9,6 +9,7 @@
 
 #include "ttnn/cpp/pybind11/decorators.hpp"
 #include "ttnn/operations/eltwise/complex_unary_backward/complex_unary_backward.hpp"
+#include "ttnn/operations/eltwise/complex/complex.hpp"
 #include "ttnn/types.hpp"
 
 namespace py = pybind11;
@@ -18,7 +19,6 @@ namespace operations {
 namespace complex_unary_backward {
 
 namespace detail {
-using ComplexTensor = complex_binary::ComplexTensor;
 
 template <typename complex_unary_backward_operation_t>
 void bind_complex_unary_backward(py::module& module, const complex_unary_backward_operation_t& operation, const std::string& description) {

--- a/ttnn/cpp/ttnn/operations/eltwise/complex_unary_backward/device/complex_unary_backward_op.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/complex_unary_backward/device/complex_unary_backward_op.cpp
@@ -3,13 +3,11 @@
 // SPDX-License-Identifier: Apache-2.0
 
 
+#include "complex_unary_backward_op.hpp"
 #include "third_party/magic_enum/magic_enum.hpp"
-
 #include "tt_metal/common/constants.hpp"
 #include "tt_metal/host_api.hpp"
 #include "tt_metal/tools/profiler/op_profiler.hpp"
-#include "ttnn/operations/eltwise/complex_unary_backward/device/complex_unary_backward_op.hpp"
-#include "ttnn/operations/eltwise/complex_binary_backward/device/complex_binary_backward_op.hpp"
 #include "ttnn/operations/eltwise/binary/binary.hpp"
 #include "ttnn/operations/eltwise/complex_unary/device/complex_unary_op.hpp"
 #include "ttnn/operations/eltwise/complex_binary/device/complex_binary_op.hpp"
@@ -18,7 +16,6 @@
 
 
 namespace ttnn::operations::complex_unary_backward {
-using ComplexTensor = complex_binary::ComplexTensor;
 
 // polar
 // grad_abs = torch.real(grad_conj * torch.sgn(result))

--- a/ttnn/cpp/ttnn/operations/eltwise/complex_unary_backward/device/complex_unary_backward_op.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/complex_unary_backward/device/complex_unary_backward_op.hpp
@@ -8,10 +8,9 @@
 #include <optional>
 #include "ttnn/tensor/tensor.hpp"
 #include "third_party/magic_enum/magic_enum.hpp"
-#include "ttnn/operations/eltwise/complex_binary/device/complex_binary_op.hpp"
+#include "ttnn/operations/eltwise/complex/complex.hpp"
 
 namespace ttnn::operations::complex_unary_backward {
-using ComplexTensor = complex_binary::ComplexTensor;
 
 constexpr uint8_t DefaultQueueId = 0;
 enum class ComplexUnaryBackwardOpType {

--- a/ttnn/cpp/ttnn/operations/eltwise/unary/unary_pybind.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary/unary_pybind.hpp
@@ -12,7 +12,7 @@
 #include "ttnn/operations/eltwise/unary/unary_composite.hpp"
 #include "ttnn/operations/eltwise/complex_unary/complex_unary.hpp"
 #include "ttnn/types.hpp"
-#include "ttnn/operations/eltwise/complex_binary/device/complex_binary_op.hpp"
+#include "ttnn/operations/eltwise/complex/complex.hpp"
 
 namespace py = pybind11;
 
@@ -23,7 +23,6 @@ namespace unary {
 namespace detail {
 
 using FusedActivations = std::vector<ttnn::operations::unary::UnaryWithParam>;
-using ComplexTensor = complex_binary::ComplexTensor;
 
 template <typename unary_operation_t>
 void bind_unary_operation(py::module& module, const unary_operation_t& operation, const std::string& info_doc = "" ) {

--- a/ttnn/cpp/ttnn/operations/eltwise/unary_backward/unary_backward_pybind.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary_backward/unary_backward_pybind.hpp
@@ -9,9 +9,6 @@
 
 #include "ttnn/cpp/pybind11/decorators.hpp"
 #include "ttnn/operations/eltwise/binary_backward/binary_backward.hpp"
-#include "ttnn/operations/eltwise/complex_binary/device/complex_binary_op.hpp"
-#include "ttnn/operations/eltwise/complex_binary_backward/complex_binary_backward.hpp"
-#include "ttnn/operations/eltwise/complex_unary_backward/complex_unary_backward.hpp"
 #include "ttnn/operations/eltwise/unary_backward/unary_backward.hpp"
 #include "ttnn/types.hpp"
 


### PR DESCRIPTION
### Ticket
Link to Github Issue #10919

### Problem description
need pybinding for complex_tensor in ttnn 
to remove ttl.tensor.complex_tensor 

### What's changed
Created pybinding for complex_tensor in ttnn
replaced ttl.tensor.complex_tensor with ttnn.complex_tensor in tests
removed unnecessary includes

### Checklist
- [x] Post commit CI https://github.com/tenstorrent/tt-metal/actions/runs/10175195276
- [ ] Nightly fast dispatch https://github.com/tenstorrent/tt-metal/actions/runs/10175279556
- [x] New/Existing tests provide coverage for changes
