### PR TITLE
#10908: split ttnn unit tests into 6 groups to avoid ND issue

### DIFF
--- a/.github/workflows/ttnn-post-commit.yaml
+++ b/.github/workflows/ttnn-post-commit.yaml
@@ -20,12 +20,16 @@ jobs:
         ]
         test-group:
           - name: ttnn group 1
-            cmd: pytest $TT_METAL_HOME/tests/ttnn/unit_tests -xv --splits 2 --group 1 -m "not disable_fast_runtime_mode"
+            cmd: pytest $TT_METAL_HOME/tests/ttnn/unit_tests -xv --splits 3 --group 1 -m "not disable_fast_runtime_mode"
           - name: ttnn group 2
-            cmd: pytest $TT_METAL_HOME/tests/ttnn/unit_tests -xv --splits 2 --group 2 -m "not disable_fast_runtime_mode" && ./tests/scripts/run_ttnn_examples.sh
+            cmd: pytest $TT_METAL_HOME/tests/ttnn/unit_tests -xv --splits 3 --group 2 -m "not disable_fast_runtime_mode"
           - name: ttnn group 3
+            cmd: pytest $TT_METAL_HOME/tests/ttnn/unit_tests -xv --splits 3 --group 3 -m "not disable_fast_runtime_mode"
+          - name: ttnn group 4
             cmd: pytest $TT_METAL_HOME/tests/ttnn/unit_tests -xv -m requires_fast_runtime_mode_off
             fast_runtime_mode_off: true
+          - name: ttnn examples
+            cmd: ./test/scripts/run_ttnn_examples.sh
           - name: ttnn cpp tests
             cmd: ./build/test/ttnn/unit_tests_ttnn
     name: ${{ matrix.test-group.name }} ${{ matrix.runner-info.arch }} ${{ matrix.runner-info.name }}

--- a/.github/workflows/ttnn-post-commit.yaml
+++ b/.github/workflows/ttnn-post-commit.yaml
@@ -29,7 +29,7 @@ jobs:
             cmd: pytest $TT_METAL_HOME/tests/ttnn/unit_tests -xv -m requires_fast_runtime_mode_off
             fast_runtime_mode_off: true
           - name: ttnn examples
-            cmd: ./test/scripts/run_ttnn_examples.sh
+            cmd: ./tests/scripts/run_ttnn_examples.sh
           - name: ttnn cpp tests
             cmd: ./build/test/ttnn/unit_tests_ttnn
     name: ${{ matrix.test-group.name }} ${{ matrix.runner-info.arch }} ${{ matrix.runner-info.name }}

--- a/.github/workflows/ttnn-post-commit.yaml
+++ b/.github/workflows/ttnn-post-commit.yaml
@@ -19,13 +19,9 @@ jobs:
           {arch: wormhole_b0, runs-on: ["wormhole_b0", "multi-chip-num-pcie-1", "multi-chip-num-chips-2"], name: N300},
         ]
         test-group:
-          - name: ttnn group 1
-            cmd: pytest $TT_METAL_HOME/tests/ttnn/unit_tests -xv --splits 3 --group 1 -m "not disable_fast_runtime_mode"
-          - name: ttnn group 2
-            cmd: pytest $TT_METAL_HOME/tests/ttnn/unit_tests -xv --splits 3 --group 2 -m "not disable_fast_runtime_mode"
-          - name: ttnn group 3
-            cmd: pytest $TT_METAL_HOME/tests/ttnn/unit_tests -xv --splits 3 --group 3 -m "not disable_fast_runtime_mode"
-          - name: ttnn group 4
+          - name: ttnn unit tests
+            cmd: pytest $TT_METAL_HOME/tests/ttnn/unit_tests -xv
+          - name: ttnn unit tests with fast runtime mode off
             cmd: pytest $TT_METAL_HOME/tests/ttnn/unit_tests -xv -m requires_fast_runtime_mode_off
             fast_runtime_mode_off: true
           - name: ttnn examples

--- a/.github/workflows/ttnn-post-commit.yaml
+++ b/.github/workflows/ttnn-post-commit.yaml
@@ -20,13 +20,15 @@ jobs:
         ]
         test-group:
           - name: ttnn group 1
-            cmd: pytest $TT_METAL_HOME/tests/ttnn/unit_tests -xv --splits 4 --group 1
+            cmd: pytest $TT_METAL_HOME/tests/ttnn/unit_tests -xv --splits 5 --group 1
           - name: ttnn group 2
-            cmd: pytest $TT_METAL_HOME/tests/ttnn/unit_tests -xv --splits 4 --group 2
+            cmd: pytest $TT_METAL_HOME/tests/ttnn/unit_tests -xv --splits 5 --group 2
           - name: ttnn group 3
-            cmd: pytest $TT_METAL_HOME/tests/ttnn/unit_tests -xv --splits 4 --group 3
+            cmd: pytest $TT_METAL_HOME/tests/ttnn/unit_tests -xv --splits 5 --group 3
           - name: ttnn group 4
-            cmd: pytest $TT_METAL_HOME/tests/ttnn/unit_tests -xv --splits 4 --group 4
+            cmd: pytest $TT_METAL_HOME/tests/ttnn/unit_tests -xv --splits 5 --group 4
+          - name: ttnn group 5
+            cmd: pytest $TT_METAL_HOME/tests/ttnn/unit_tests -xv --splits 5 --group 5
           - name: ttnn fast runtime off
             cmd: pytest $TT_METAL_HOME/tests/ttnn/unit_tests -xv -m requires_fast_runtime_mode_off
             fast_runtime_mode_off: true

--- a/.github/workflows/ttnn-post-commit.yaml
+++ b/.github/workflows/ttnn-post-commit.yaml
@@ -20,15 +20,17 @@ jobs:
         ]
         test-group:
           - name: ttnn group 1
-            cmd: pytest $TT_METAL_HOME/tests/ttnn/unit_tests -xv --splits 5 --group 1
+            cmd: pytest $TT_METAL_HOME/tests/ttnn/unit_tests -xv --splits 6 --group 1
           - name: ttnn group 2
-            cmd: pytest $TT_METAL_HOME/tests/ttnn/unit_tests -xv --splits 5 --group 2
+            cmd: pytest $TT_METAL_HOME/tests/ttnn/unit_tests -xv --splits 6 --group 2
           - name: ttnn group 3
-            cmd: pytest $TT_METAL_HOME/tests/ttnn/unit_tests -xv --splits 5 --group 3
+            cmd: pytest $TT_METAL_HOME/tests/ttnn/unit_tests -xv --splits 6 --group 3
           - name: ttnn group 4
-            cmd: pytest $TT_METAL_HOME/tests/ttnn/unit_tests -xv --splits 5 --group 4
+            cmd: pytest $TT_METAL_HOME/tests/ttnn/unit_tests -xv --splits 6 --group 4
           - name: ttnn group 5
-            cmd: pytest $TT_METAL_HOME/tests/ttnn/unit_tests -xv --splits 5 --group 5
+            cmd: pytest $TT_METAL_HOME/tests/ttnn/unit_tests -xv --splits 6 --group 5
+          - name: ttnn group 6
+            cmd: pytest $TT_METAL_HOME/tests/ttnn/unit_tests -xv --splits 6 --group 6
           - name: ttnn fast runtime off
             cmd: pytest $TT_METAL_HOME/tests/ttnn/unit_tests -xv -m requires_fast_runtime_mode_off
             fast_runtime_mode_off: true

--- a/.github/workflows/ttnn-post-commit.yaml
+++ b/.github/workflows/ttnn-post-commit.yaml
@@ -34,10 +34,8 @@ jobs:
           - name: ttnn fast runtime off
             cmd: pytest $TT_METAL_HOME/tests/ttnn/unit_tests -xv -m requires_fast_runtime_mode_off
             fast_runtime_mode_off: true
-          - name: ttnn examples
-            cmd: ./tests/scripts/run_ttnn_examples.sh
-          - name: ttnn cpp tests
-            cmd: ./build/test/ttnn/unit_tests_ttnn
+          - name: ttnn examples and cpp tests
+            cmd: ./build/test/ttnn/unit_tests_ttnn && ./tests/scripts/run_ttnn_examples.sh
     name: ${{ matrix.test-group.name }} ${{ matrix.runner-info.arch }} ${{ matrix.runner-info.name }}
     env:
       TT_METAL_ENV: ${{ vars.TT_METAL_ENV }}

--- a/.github/workflows/ttnn-post-commit.yaml
+++ b/.github/workflows/ttnn-post-commit.yaml
@@ -19,13 +19,19 @@ jobs:
           {arch: wormhole_b0, runs-on: ["wormhole_b0", "multi-chip-num-pcie-1", "multi-chip-num-chips-2"], name: N300},
         ]
         test-group:
-          - name: ttnn unit tests
-            cmd: pytest $TT_METAL_HOME/tests/ttnn/unit_tests -xv
-          - name: ttnn unit tests with fast runtime mode off
+          - name: ttnn group 1
+            cmd: pytest $TT_METAL_HOME/tests/ttnn/unit_tests -xv --splits 4 --group 1
+          - name: ttnn group 2
+            cmd: pytest $TT_METAL_HOME/tests/ttnn/unit_tests -xv --splits 4 --group 2
+          - name: ttnn group 3
+            cmd: pytest $TT_METAL_HOME/tests/ttnn/unit_tests -xv --splits 4 --group 3
+          - name: ttnn group 4
+            cmd: pytest $TT_METAL_HOME/tests/ttnn/unit_tests -xv --splits 4 --group 4
+          - name: ttnn fast runtime off
             cmd: pytest $TT_METAL_HOME/tests/ttnn/unit_tests -xv -m requires_fast_runtime_mode_off
             fast_runtime_mode_off: true
           - name: ttnn examples
-            cmd: ./tests/scripts/run_ttnn_examples.sh
+            cmd: ./test/scripts/run_ttnn_examples.sh
           - name: ttnn cpp tests
             cmd: ./build/test/ttnn/unit_tests_ttnn
     name: ${{ matrix.test-group.name }} ${{ matrix.runner-info.arch }} ${{ matrix.runner-info.name }}

--- a/.github/workflows/ttnn-post-commit.yaml
+++ b/.github/workflows/ttnn-post-commit.yaml
@@ -35,7 +35,7 @@ jobs:
             cmd: pytest $TT_METAL_HOME/tests/ttnn/unit_tests -xv -m requires_fast_runtime_mode_off
             fast_runtime_mode_off: true
           - name: ttnn examples
-            cmd: ./test/scripts/run_ttnn_examples.sh
+            cmd: ./tests/scripts/run_ttnn_examples.sh
           - name: ttnn cpp tests
             cmd: ./build/test/ttnn/unit_tests_ttnn
     name: ${{ matrix.test-group.name }} ${{ matrix.runner-info.arch }} ${{ matrix.runner-info.name }}

--- a/.github/workflows/ttnn-post-commit.yaml
+++ b/.github/workflows/ttnn-post-commit.yaml
@@ -20,17 +20,17 @@ jobs:
         ]
         test-group:
           - name: ttnn group 1
-            cmd: pytest $TT_METAL_HOME/tests/ttnn/unit_tests -xv --splits 6 --group 1
+            cmd: pytest $TT_METAL_HOME/tests/ttnn/unit_tests -xv --splits 6 --group 1 -m "not disable_fast_runtime_mode"
           - name: ttnn group 2
-            cmd: pytest $TT_METAL_HOME/tests/ttnn/unit_tests -xv --splits 6 --group 2
+            cmd: pytest $TT_METAL_HOME/tests/ttnn/unit_tests -xv --splits 6 --group 2 -m "not disable_fast_runtime_mode"
           - name: ttnn group 3
-            cmd: pytest $TT_METAL_HOME/tests/ttnn/unit_tests -xv --splits 6 --group 3
+            cmd: pytest $TT_METAL_HOME/tests/ttnn/unit_tests -xv --splits 6 --group 3 -m "not disable_fast_runtime_mode"
           - name: ttnn group 4
-            cmd: pytest $TT_METAL_HOME/tests/ttnn/unit_tests -xv --splits 6 --group 4
+            cmd: pytest $TT_METAL_HOME/tests/ttnn/unit_tests -xv --splits 6 --group 4 -m "not disable_fast_runtime_mode"
           - name: ttnn group 5
-            cmd: pytest $TT_METAL_HOME/tests/ttnn/unit_tests -xv --splits 6 --group 5
+            cmd: pytest $TT_METAL_HOME/tests/ttnn/unit_tests -xv --splits 6 --group 5 -m "not disable_fast_runtime_mode"
           - name: ttnn group 6
-            cmd: pytest $TT_METAL_HOME/tests/ttnn/unit_tests -xv --splits 6 --group 6
+            cmd: pytest $TT_METAL_HOME/tests/ttnn/unit_tests -xv --splits 6 --group 6 -m "not disable_fast_runtime_mode"
           - name: ttnn fast runtime off
             cmd: pytest $TT_METAL_HOME/tests/ttnn/unit_tests -xv -m requires_fast_runtime_mode_off
             fast_runtime_mode_off: true


### PR DESCRIPTION
### Ticket
[Link to Github Issue](https://github.com/tenstorrent/tt-metal/issues/10908)

### What's changed
TTNN tests have been split 6 ways to avoid ND issue in post-commit

### Checklist
- [x] Post commit CI passes

