### PR TITLE
#10863: Refactor and cleanup namespace / filenames for DeviceMesh

### DIFF
--- a/tests/ttnn/unit_tests/gtests/ttnn_test_fixtures.hpp
+++ b/tests/ttnn/unit_tests/gtests/ttnn_test_fixtures.hpp
@@ -11,9 +11,10 @@
 #include "gtest/gtest.h"
 
 #include "ttnn/device.hpp"
+#include "ttnn/types.hpp"
 #include "tests/tt_metal/test_utils/env_vars.hpp"
 #include "tt_metal/hostdevcommon/common_values.hpp"
-#include "tt_metal/impl/device/multi_device.hpp"
+#include "tt_metal/impl/device/device_mesh.hpp"
 
 namespace ttnn {
 
@@ -64,10 +65,10 @@ class T3kMultiDeviceFixture : public ::testing::Test {
         if (num_devices < 8 or arch != tt::ARCH::WORMHOLE_B0) {
             GTEST_SKIP() << "Skipping T3K Multi-Device test suite on non T3K machine.";
         }
-        const auto T3K_DEVICE_IDS = ttnn::multi_device::DeviceIds{0, 4, 5, 1, 2, 6, 7, 3};
+        const auto T3K_DEVICE_IDS = DeviceIds{0, 4, 5, 1, 2, 6, 7, 3};
         constexpr auto DEFAULT_NUM_COMMAND_QUEUES = 1;
-        device_mesh_ = std::make_unique<ttnn::multi_device::DeviceMesh>(
-            ttnn::multi_device::DeviceGrid{1, num_devices},
+        device_mesh_ = std::make_unique<DeviceMesh>(
+            DeviceGrid{1, num_devices},
             T3K_DEVICE_IDS,
             DEFAULT_L1_SMALL_SIZE,
             DEFAULT_TRACE_REGION_SIZE,
@@ -75,7 +76,7 @@ class T3kMultiDeviceFixture : public ::testing::Test {
     }
 
     void TearDown() override { device_mesh_.reset(); }
-    std::unique_ptr<ttnn::multi_device::DeviceMesh> device_mesh_;
+    std::unique_ptr<DeviceMesh> device_mesh_;
 };
 
 }  // namespace ttnn::multi_device::test

--- a/tt_metal/impl/CMakeLists.txt
+++ b/tt_metal/impl/CMakeLists.txt
@@ -2,7 +2,7 @@
 set(IMPL_SRC
     ${CMAKE_CURRENT_SOURCE_DIR}/device/device.cpp
 	${CMAKE_CURRENT_SOURCE_DIR}/device/device_pool.cpp
-	${CMAKE_CURRENT_SOURCE_DIR}/device/multi_device.cpp
+	${CMAKE_CURRENT_SOURCE_DIR}/device/device_mesh.cpp
 	${CMAKE_CURRENT_SOURCE_DIR}/device/device_mesh_view.cpp
 	${CMAKE_CURRENT_SOURCE_DIR}/buffers/buffer.cpp
 	${CMAKE_CURRENT_SOURCE_DIR}/buffers/circular_buffer.cpp

--- a/tt_metal/impl/device/device_mesh.cpp
+++ b/tt_metal/impl/device/device_mesh.cpp
@@ -4,15 +4,13 @@
 
 #include <memory>
 
-#include "tt_metal/impl/device/multi_device.hpp"
+#include "tt_metal/impl/device/device_mesh.hpp"
 #include "tt_metal/impl/device/device_mesh_view.hpp"
 #include "tt_metal/host_api.hpp"
 #include "tt_metal/detail/tt_metal.hpp"
 
 
-namespace ttnn {
-
-namespace multi_device {
+namespace tt::tt_metal {
 
 DeviceMesh::DeviceMesh(const DeviceGrid& device_grid, const DeviceIds &device_ids, size_t l1_small_size, size_t trace_region_size, size_t num_command_queues)
     : device_grid(device_grid)
@@ -176,14 +174,6 @@ void DeviceMesh::close_devices() {
     managed_devices.clear();
 }
 
-}  // namespace multi_device
-
-}  // namespace ttnn
-
-namespace tt {
-
-namespace tt_metal {
-
 bool validate_worker_modes(const std::vector<Device*>& workers) {
     bool worker_modes_match = true;
     auto first_worker_mode = workers.at(0)->get_worker_mode();
@@ -193,6 +183,4 @@ bool validate_worker_modes(const std::vector<Device*>& workers) {
     return worker_modes_match;
 }
 
-}
-
-}
+} // namespace tt::tt_metal

--- a/tt_metal/impl/device/device_mesh.hpp
+++ b/tt_metal/impl/device/device_mesh.hpp
@@ -12,14 +12,8 @@
 #include "tt_metal/impl/device/device.hpp"
 #include "tt_metal/impl/device/device_mesh_view.hpp"
 
-using Device = tt::tt_metal::Device;
-using DeviceMeshView = tt::tt_metal::DeviceMeshView;
-using Coordinate = tt::tt_metal::Coordinate;
+namespace tt::tt_metal {
 
-
-namespace ttnn {
-
-namespace multi_device {
 using DeviceGrid = std::pair<int, int>;
 using DeviceIds = std::vector<int>;
 
@@ -67,14 +61,6 @@ public:
     bool is_galaxy_;
 };
 
+bool validate_worker_modes(const std::vector<Device*>& workers);
 
-}  // namespace multi_device
-
-}  // namespace ttnn
-
-namespace tt {
-namespace tt_metal {
-    using DeviceMesh = ttnn::multi_device::DeviceMesh;
-    bool validate_worker_modes(const std::vector<Device*>& workers);
-} // namespace tt_metal
-} // namespace tt
+} // namespace tt::tt_metal

--- a/tt_metal/impl/device/device_mesh_view.cpp
+++ b/tt_metal/impl/device/device_mesh_view.cpp
@@ -3,13 +3,13 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "tt_metal/impl/device/device_mesh_view.hpp"
-#include "tt_metal/impl/device/multi_device.hpp"
+#include "tt_metal/impl/device/device_mesh.hpp"
 #include <algorithm>
 #include <stdexcept>
 
 namespace tt::tt_metal {
 
-using DeviceMesh = ttnn::multi_device::DeviceMesh;
+using DeviceMesh = tt::tt_metal::DeviceMesh;
 
 DeviceMeshView::DeviceMeshView(const DeviceMesh& mesh)
     : top_left_(0, 0), bottom_right_(mesh.num_rows() - 1, mesh.num_cols() - 1) {

--- a/tt_metal/impl/device/device_mesh_view.hpp
+++ b/tt_metal/impl/device/device_mesh_view.hpp
@@ -12,14 +12,10 @@
 
 #include "tt_metal/impl/device/device.hpp"
 
-// Forward declaration of DeviceMesh
-namespace ttnn {
-namespace multi_device {
-class DeviceMesh;
-} // namespace multi_device
-} // namespace ttnn
-
 namespace tt::tt_metal {
+
+// Forward declaration of DeviceMesh
+class DeviceMesh;
 
 struct Coordinate {
     int row;
@@ -51,9 +47,9 @@ public:
     using DeviceViews = std::vector<std::vector<device_pointer>>;
     using CoordinateMapper = std::function<std::optional<Coordinate>(int device_id)>;
 
-    DeviceMeshView(const ttnn::multi_device::DeviceMesh& mesh);
-    DeviceMeshView(const ttnn::multi_device::DeviceMesh& mesh, Coordinate top_left, Coordinate bottom_right);
-    DeviceMeshView(const ttnn::multi_device::DeviceMesh& global_mesh, const std::vector<device_pointer>& devices);
+    DeviceMeshView(const DeviceMesh& mesh);
+    DeviceMeshView(const DeviceMesh& mesh, Coordinate top_left, Coordinate bottom_right);
+    DeviceMeshView(const DeviceMesh& global_mesh, const std::vector<device_pointer>& devices);
     DeviceMeshView(std::vector<device_pointer> devices, CoordinateMapper mapper);
 
     [[nodiscard]] device_pointer get_device(int row, int col);

--- a/tt_metal/impl/module.mk
+++ b/tt_metal/impl/module.mk
@@ -6,7 +6,7 @@ TT_METAL_IMPL_CFLAGS = $(CFLAGS) -Werror -Wno-int-to-pointer-cast
 TT_METAL_IMPL_SRCS = \
 	tt_metal/impl/device/device.cpp \
 	tt_metal/impl/device/device_pool.cpp \
-	tt_metal/impl/device/multi_device.cpp \
+	tt_metal/impl/device/device_mesh.cpp \
 	tt_metal/impl/device/device_mesh_view.cpp \
 	tt_metal/impl/buffers/buffer.cpp \
 	tt_metal/impl/buffers/circular_buffer.cpp \

--- a/ttnn/cpp/pybind11/multi_device.hpp
+++ b/ttnn/cpp/pybind11/multi_device.hpp
@@ -26,17 +26,17 @@ void py_module(py::module& module) {
             py::arg("l1_small_size"),
             py::arg("trace_region_size"),
             py::arg("num_command_queues"))
-        .def("get_num_devices", &ttnn::multi_device::DeviceMesh::num_devices)
-        .def("get_device_ids", &ttnn::multi_device::DeviceMesh::get_device_ids)
+        .def("get_num_devices", &DeviceMesh::num_devices)
+        .def("get_device_ids", &DeviceMesh::get_device_ids)
         .def(
             "get_device",
-            py::overload_cast<int>(&ttnn::multi_device::DeviceMesh::get_device, py::const_),
+            py::overload_cast<int>(&DeviceMesh::get_device, py::const_),
             py::return_value_policy::reference)
         .def(
             "get_device",
-            py::overload_cast<int, int>(&ttnn::multi_device::DeviceMesh::get_device, py::const_),
+            py::overload_cast<int, int>(&DeviceMesh::get_device, py::const_),
             py::return_value_policy::reference)
-        .def("get_devices", &ttnn::multi_device::DeviceMesh::get_devices, py::return_value_policy::reference, R"doc(
+        .def("get_devices", &DeviceMesh::get_devices, py::return_value_policy::reference, R"doc(
             Get the devices in the device mesh.
 
             Returns:
@@ -44,7 +44,7 @@ void py_module(py::module& module) {
         )doc")
         .def(
             "get_devices_on_row",
-            &ttnn::multi_device::DeviceMesh::get_devices_on_row,
+            &DeviceMesh::get_devices_on_row,
             py::return_value_policy::reference,
             R"doc(
             Get the devices in a row of the device mesh.
@@ -54,7 +54,7 @@ void py_module(py::module& module) {
         )doc")
         .def(
             "get_devices_on_column",
-            &ttnn::multi_device::DeviceMesh::get_devices_on_column,
+            &DeviceMesh::get_devices_on_column,
             py::return_value_policy::reference,
             R"doc(
             Get the devices in a row of the device mesh.
@@ -64,28 +64,28 @@ void py_module(py::module& module) {
         )doc")
         .def(
             "compute_with_storage_grid_size",
-            &ttnn::multi_device::DeviceMesh::compute_with_storage_grid_size,
+            &DeviceMesh::compute_with_storage_grid_size,
             R"doc(
             Get the compute grid size (x, y) of the first device in the device mesh denoting region that can be targeted by ops.
 
             Returns:
                 CoreCoord: The compute grid size of the first device in the device mesh.
         )doc")
-        .def("dram_grid_size", &ttnn::multi_device::DeviceMesh::dram_grid_size,
+        .def("dram_grid_size", &DeviceMesh::dram_grid_size,
         R"doc(
             Get the dram grid size (x, y) of the first device in the device mesh.
 
             Returns:
                 CoreCoord: The dram grid size of the first device in the device mesh.
         )doc")
-        .def("arch", &ttnn::multi_device::DeviceMesh::arch,
+        .def("arch", &DeviceMesh::arch,
         R"doc(
             Get the arch of the first device in the device mesh.
 
             Returns:
                 Arch: The arch of the first device in the device mesh.
         )doc")
-        .def_property_readonly("shape", &ttnn::multi_device::DeviceMesh::shape, R"doc(
+        .def_property_readonly("shape", &DeviceMesh::shape, R"doc(
             Get the shape of the device mesh.
 
             Returns:

--- a/ttnn/cpp/ttnn/multi_device.cpp
+++ b/ttnn/cpp/ttnn/multi_device.cpp
@@ -8,7 +8,7 @@
 
 #include "ttnn/tensor/tensor.hpp"
 #include "ttnn/tensor/tensor_utils.hpp"
-#include "tt_metal/impl/device/multi_device.hpp"
+#include "tt_metal/impl/device/device_mesh.hpp"
 
 namespace ttnn::multi_device {
 

--- a/ttnn/cpp/ttnn/multi_device.hpp
+++ b/ttnn/cpp/ttnn/multi_device.hpp
@@ -8,14 +8,12 @@
 
 #include "ttnn/types.hpp"
 #include "ttnn/tensor/tensor.hpp"
-#include "tt_metal/impl/device/multi_device.hpp"
+#include "tt_metal/impl/device/device_mesh.hpp"
 
 using Device = ttnn::Device;
 
-namespace ttnn::multi_device {
-
-using DeviceGrid = std::pair<int, int>;
-using DeviceIds = std::vector<int>;
+namespace ttnn {
+namespace multi_device {
 
 DeviceMesh open_device_mesh(const DeviceGrid& device_grid, const DeviceIds& device_ids, size_t l1_small_size, size_t trace_region_size, size_t num_command_queues);
 void close_device_mesh(DeviceMesh &multi_device);
@@ -24,4 +22,8 @@ std::vector<ttnn::Tensor> get_device_tensors(const ttnn::Tensor& tensor);
 
 Tensor aggregate_as_tensor(std::vector<Tensor>& tensor_shards);
 
-}  // namespace ttnn::multi_device
+}  // namespace multi_device
+
+using namespace multi_device;
+
+}  // namespace ttnn

--- a/ttnn/cpp/ttnn/operations/ccl/line_all_gather/device/line_all_gather_op.cpp
+++ b/ttnn/cpp/ttnn/operations/ccl/line_all_gather/device/line_all_gather_op.cpp
@@ -131,11 +131,11 @@ Tensor line_all_gather(
     const Tensor& input_tensor,
     const uint32_t dim,
     const uint32_t cluster_axis,
-    const multi_device::DeviceMesh& device_mesh,
+    const DeviceMesh& device_mesh,
     const uint32_t num_links,
     const std::optional<MemoryConfig>& memory_config) {
 
-    const auto view = tt::tt_metal::DeviceMeshView(device_mesh);
+    const auto view = DeviceMeshView(device_mesh);
     const auto device_views = (cluster_axis == 0) ? view.get_column_views() : view.get_row_views();
 
     std::vector<Tensor> output_tensors = {Tensor(operation::get_workers_for_op_output({input_tensor}))};
@@ -147,7 +147,7 @@ Tensor line_all_gather(
             const std::vector<std::optional<Tensor>>& optional_output_tensors) mutable -> std::vector<Tensor> {
 
             const auto& input_tensor = input_tensors[0];
-            const tt::tt_metal::DeviceMeshView::DeviceView* selected_view = nullptr;
+            const DeviceMeshView::DeviceView* selected_view = nullptr;
 
             uint32_t device_index = 0;
             for (const auto& view : device_views) {

--- a/ttnn/cpp/ttnn/operations/ccl/line_all_gather/device/line_all_gather_op.hpp
+++ b/ttnn/cpp/ttnn/operations/ccl/line_all_gather/device/line_all_gather_op.hpp
@@ -58,7 +58,7 @@ Tensor line_all_gather(
     const Tensor& input_tensor,
     const uint32_t dim,
     const uint32_t cluster_axis,
-    const multi_device::DeviceMesh& device_mesh,
+    const DeviceMesh& device_mesh,
     const uint32_t num_links = 1,
     const std::optional<MemoryConfig>& memory_config = std::nullopt);
 

--- a/ttnn/cpp/ttnn/operations/ccl/line_all_gather/line_all_gather.cpp
+++ b/ttnn/cpp/ttnn/operations/ccl/line_all_gather/line_all_gather.cpp
@@ -20,7 +20,7 @@ ttnn::Tensor ExecuteLineAllGather::operator()(
     const ttnn::Tensor& input_tensor,
     const uint32_t dim,
     const uint32_t cluster_axis,
-    const multi_device::DeviceMesh& device_mesh,
+    const DeviceMesh& device_mesh,
     const uint32_t num_links,
     const std::optional<ttnn::MemoryConfig>& memory_config) {
     return ttnn::operations::ccl::line_all_gather(

--- a/ttnn/cpp/ttnn/operations/ccl/line_all_gather/line_all_gather.hpp
+++ b/ttnn/cpp/ttnn/operations/ccl/line_all_gather/line_all_gather.hpp
@@ -21,7 +21,7 @@ struct ExecuteLineAllGather {
         const ttnn::Tensor& input_tensor,
         const uint32_t dim,
         const uint32_t cluster_axis,
-        const multi_device::DeviceMesh& device_mesh,
+        const DeviceMesh& device_mesh,
         const uint32_t num_links = 1,
         const std::optional<ttnn::MemoryConfig>& memory_config = std::nullopt);
 };

--- a/ttnn/cpp/ttnn/operations/ccl/line_all_gather/line_all_gather_pybind.cpp
+++ b/ttnn/cpp/ttnn/operations/ccl/line_all_gather/line_all_gather_pybind.cpp
@@ -38,7 +38,7 @@ void bind_line_all_gather(pybind11::module& module, const ccl_operation_t& opera
                const ttnn::Tensor& input_tensor,
                const uint32_t dim,
                const uint32_t cluster_axis,
-               const multi_device::DeviceMesh& device_mesh,
+               const DeviceMesh& device_mesh,
                const uint32_t num_links,
                const std::optional<ttnn::MemoryConfig>& memory_config) -> ttnn::Tensor {
                 return self(input_tensor, dim, cluster_axis, device_mesh, num_links, memory_config);

--- a/ttnn/cpp/ttnn/operations/conv2d/conv2d_pybind.hpp
+++ b/ttnn/cpp/ttnn/operations/conv2d/conv2d_pybind.hpp
@@ -74,7 +74,7 @@ void py_module(py::module& module) {
         "conv2d",
         [](const ttnn::Tensor& input_tensor,
             const ttnn::Tensor& weight_tensor,
-            ttnn::multi_device::DeviceMesh * device,
+            DeviceMesh * device,
             uint32_t in_channels,
             uint32_t out_channels,
             uint32_t batch_size,
@@ -87,7 +87,7 @@ void py_module(py::module& module) {
             uint32_t groups,
             std::optional<const ttnn::Tensor> bias_tensor = std::nullopt,
             std::optional<const Conv2dConfig> conv_config_ = std::nullopt) -> std::tuple<ttnn::Tensor, uint32_t, uint32_t, ttnn::Tensor, std::optional<ttnn::Tensor>> {
-            return ttnn::operations::conv2d::conv2d<ttnn::multi_device::DeviceMesh>(
+            return ttnn::operations::conv2d::conv2d<DeviceMesh>(
                 input_tensor, weight_tensor, device, in_channels, out_channels, batch_size, input_height, input_width, kernel_size, stride, padding, dilation,
                     groups, bias_tensor, conv_config_);
         },
@@ -174,7 +174,7 @@ void py_module(py::module& module) {
 
     module.def(
         "get_conv_padded_input_shape_and_mem_config",
-        [](ttnn::multi_device::DeviceMesh * device,
+        [](DeviceMesh * device,
             const ttnn::Tensor& input_tensor,
             const Conv2dConfig& conv_config,
             uint32_t batch_size,
@@ -182,7 +182,7 @@ void py_module(py::module& module) {
             uint32_t width,
             uint32_t in_channels,
             uint32_t out_channels) -> std::tuple<ttnn::Shape, ttnn::MemoryConfig, bool> {
-            return ttnn::operations::conv2d::get_conv_padded_input_shape_and_mem_config<ttnn::multi_device::DeviceMesh>(
+            return ttnn::operations::conv2d::get_conv_padded_input_shape_and_mem_config<DeviceMesh>(
                 device, input_tensor, conv_config, batch_size, height, width, in_channels, out_channels);
         },
         py::kw_only(),

--- a/ttnn/cpp/ttnn/tensor/tensor.hpp
+++ b/ttnn/cpp/ttnn/tensor/tensor.hpp
@@ -18,7 +18,7 @@
 #include "ttnn/tensor/types.hpp"
 #include "tt_metal/impl/buffers/buffer.hpp"
 #include "tt_metal/impl/device/device.hpp"
-#include "tt_metal/impl/device/multi_device.hpp"
+#include "tt_metal/impl/device/device_mesh.hpp"
 #include "tt_metal/tt_stl/reflection.hpp"
 
 namespace tt {

--- a/ttnn/cpp/ttnn/types.hpp
+++ b/ttnn/cpp/ttnn/types.hpp
@@ -14,6 +14,10 @@ namespace ttnn {
 namespace types {
 
 using Device = tt::tt_metal::Device;
+using DeviceGrid = tt::tt_metal::DeviceGrid;
+using DeviceIds = tt::tt_metal::DeviceIds;
+using DeviceMesh = tt::tt_metal::DeviceMesh;
+using DeviceMeshView = tt::tt_metal::DeviceMeshView;
 
 constexpr auto TILE_SIZE = 32;
 


### PR DESCRIPTION
### Ticket
[Link to Github Issue
](https://github.com/tenstorrent/tt-metal/issues/10863)


### Problem description
This PR is entirely a refactor/clean-up on the namespacing for `DeviceMesh` class.

### What's changed
1. We've now renamed the files `tt_metal/impl/device/multi_device.*pp` -> `tt_metal/impl/device/device_mesh.*pp`
2. We've moved the class underneath the `tt::tt_metal` namespace to better map the files under the `tt_metal` directory.

### Checklist
- [x] Post commit CI passes
- [x] Model regression CI testing passes (if applicable)
- [x] New/Existing tests provide coverage for changes
