### PR TITLE
#8957: Add ELASTIC_USERNAME env variable, sweep index prefixes, and change default ES URL to yyz-elk

### DIFF
--- a/tests/sweep_framework/README.md
+++ b/tests/sweep_framework/README.md
@@ -182,7 +182,7 @@ The test vectors are stored in a separate Elasticsearch index based on the modul
 
 ### Usage
 
-**NOTE: The environment variable ELASTIC_PASSWORD must be set to connect to the Elasticsearch database which is used to store and retrieve test data.**
+**NOTE: The environment variables ELASTIC_USERNAME and ELASTIC_PASSWORD must be set to connect to the Elasticsearch database which is used to store and retrieve test data.**
 
 To run the test vector generator:
 
@@ -192,7 +192,7 @@ Options:
 
 `--module-name <sweep_name>` OPTIONAL: Select the sweep file to generate parameters for. This should be only the name and not extension of the file. If not set, the generator will generate vectors for all sweep files in the sweeps folder.
 
-`--elastic <elastic_url>` OPTIONAL: Default is `http://localhost:9200`, which in almost all cases should be overridden unless running with a local instance of Elasticsearch.
+`--elastic <elastic_url>` OPTIONAL: Default is `http://yyz-elk:9200`, which in almost all cases should be overridden unless running with a local instance of Elasticsearch.
 
 ## Test Runner
 
@@ -215,7 +215,7 @@ The test runner reads in test vectors from the test vector database and executes
 
 ### Usage
 
-**NOTE: The environment variable ELASTIC_PASSWORD must be set to connect to the Elasticsearch database which is used to store and retrieve test data.**
+**NOTE: The environment variables ELASTIC_USERNAME and ELASTIC_PASSWORD must be set to connect to the Elasticsearch database which is used to store and retrieve test data.**
 
 To run the test runner:
 `python3 tests/sweep_framework/runner.py`
@@ -238,7 +238,7 @@ Options:
 
 ## Query Tool
 
-**NOTE: The environment variable ELASTIC_PASSWORD must be set to connect to the Elasticsearch database which is used to store and retrieve test data.**
+**NOTE: The environment variables ELASTIC_USERNAME and ELASTIC_PASSWORD must be set to connect to the Elasticsearch database which is used to store and retrieve test data.**
 
 This tool is used to query the database to see information on test vectors and test runs.
 
@@ -252,7 +252,7 @@ The vector and result commands will show a detailed view of the data, including 
 
 ### Usage
 
-`query.py [OPTIONS] COMMAND [ARGS]...`
+`query.py [OPTIONS] COMMAND`
 
 Options:
 
@@ -457,4 +457,6 @@ $ python3 tests/sweep_framework/query.py --elastic http://172.18.0.2:9200 --modu
 
 ## Database
 
-Elasticsearch on Apache Lucene database. Network availability and global database info TBD.
+Elasticsearch instance shared with DevInfra hosted on yyz-elk.
+
+Access credentials to be shared separately.

--- a/tests/sweep_framework/elastic_config.py
+++ b/tests/sweep_framework/elastic_config.py
@@ -1,0 +1,11 @@
+# SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
+
+# SPDX-License-Identifier: Apache-2.0
+
+import os
+
+ELASTIC_DEFAULT_URL = "http://yyz-elk:9200"
+ELASTIC_USERNAME = os.getenv("ELASTIC_USERNAME")
+ELASTIC_PASSWORD = os.getenv("ELASTIC_PASSWORD")
+VECTOR_INDEX_PREFIX = "ttnn_sweeps_test_vectors_"
+RESULT_INDEX_PREFIX = "ttnn_sweeps_test_results_"

--- a/tests/sweep_framework/export_to_sqlite.py
+++ b/tests/sweep_framework/export_to_sqlite.py
@@ -9,6 +9,7 @@ import pathlib
 import os
 import sys
 
+ELASTIC_USERNAME = os.getenv("ELASTIC_USERNAME")
 ELASTIC_PASSWORD = os.getenv("ELASTIC_PASSWORD")
 
 if __name__ == "__main__":
@@ -18,14 +19,17 @@ if __name__ == "__main__":
     )
 
     parser.add_argument(
-        "--elastic", required=False, help="Elastic Connection String for the vector and results database."
+        "--elastic",
+        required=False,
+        default="http://yyz-elk:9200",
+        help="Elastic Connection String for the vector and results database.",
     )
     args = parser.parse_args(sys.argv[1:])
 
-    ELASTIC_CONNECTION_STRING = args.elastic if args.elastic else "http://localhost:9200"
+    ELASTIC_CONNECTION_STRING = args.elastic
     DUMP_PATH = "tests/sweep_framework/sqlite_dump/"
     sweeps_path = pathlib.Path(__file__).parent / "sweeps"
-    es_client = Elasticsearch(ELASTIC_CONNECTION_STRING, basic_auth=("elastic", ELASTIC_PASSWORD))
+    es_client = Elasticsearch(ELASTIC_CONNECTION_STRING, basic_auth=(ELASTIC_USERNAME, ELASTIC_PASSWORD))
 
     for file in sorted(sweeps_path.glob("*.py")):
         sweep_name = str(pathlib.Path(file).relative_to(sweeps_path))[:-3]

--- a/tests/sweep_framework/export_to_sqlite.py
+++ b/tests/sweep_framework/export_to_sqlite.py
@@ -8,9 +8,7 @@ import argparse
 import pathlib
 import os
 import sys
-
-ELASTIC_USERNAME = os.getenv("ELASTIC_USERNAME")
-ELASTIC_PASSWORD = os.getenv("ELASTIC_PASSWORD")
+from elastic_config import *
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(
@@ -21,7 +19,7 @@ if __name__ == "__main__":
     parser.add_argument(
         "--elastic",
         required=False,
-        default="http://yyz-elk:9200",
+        default=ELASTIC_DEFAULT_URL,
         help="Elastic Connection String for the vector and results database.",
     )
     args = parser.parse_args(sys.argv[1:])
@@ -34,8 +32,8 @@ if __name__ == "__main__":
     for file in sorted(sweeps_path.glob("*.py")):
         sweep_name = str(pathlib.Path(file).relative_to(sweeps_path))[:-3]
         sqlite_client = sqlite3.connect(DUMP_PATH + sweep_name + ".sqlite")
-        vector_index = sweep_name + "_test_vectors"
-        result_index = sweep_name + "_test_results"
+        vector_index = VECTOR_INDEX_PREFIX + sweep_name
+        result_index = RESULT_INDEX_PREFIX + sweep_name
 
         response = es_client.search(index=vector_index, size=10000)
         test_ids = [hit["_id"] for hit in response["hits"]["hits"]]

--- a/tests/sweep_framework/parameter_generator.py
+++ b/tests/sweep_framework/parameter_generator.py
@@ -15,6 +15,7 @@ from serialize import serialize
 from elasticsearch import Elasticsearch, NotFoundError
 from statuses import VectorValidity, VectorStatus
 
+ELASTIC_USERNAME = os.getenv("ELASTIC_USERNAME")
 ELASTIC_PASSWORD = os.getenv("ELASTIC_PASSWORD")
 
 SWEEPS_DIR = pathlib.Path(__file__).parent
@@ -54,7 +55,7 @@ def invalidate_vectors(test_module, vectors) -> None:
 # Output the individual test vectors.
 def export_suite_vectors(module_name, suite_name, vectors):
     # Perhaps we export with some sort of readable id, which can be passed to a runner to run specific sets of input vectors. (export seed as well for reproducability)
-    client = Elasticsearch(ELASTIC_CONNECTION_STRING, basic_auth=("elastic", ELASTIC_PASSWORD))
+    client = Elasticsearch(ELASTIC_CONNECTION_STRING, basic_auth=(ELASTIC_USERNAME, ELASTIC_PASSWORD))
 
     index_name = module_name + "_test_vectors"
 
@@ -122,11 +123,16 @@ if __name__ == "__main__":
     )
 
     parser.add_argument("--module-name", required=False, help="Test Module Name, or all tests if omitted")
-    parser.add_argument("--elastic", required=False, help="Elastic Connection String for vector database.")
+    parser.add_argument(
+        "--elastic",
+        required=False,
+        default="http://yyz-elk:9200",
+        help="Elastic Connection String for vector database.",
+    )
 
     args = parser.parse_args(sys.argv[1:])
 
     global ELASTIC_CONNECTION_STRING
-    ELASTIC_CONNECTION_STRING = args.elastic if args.elastic else "http://localhost:9200"
+    ELASTIC_CONNECTION_STRING = args.elastic
 
     generate_tests(args.module_name)

--- a/tests/sweep_framework/parameter_generator.py
+++ b/tests/sweep_framework/parameter_generator.py
@@ -14,9 +14,7 @@ from permutations import *
 from serialize import serialize
 from elasticsearch import Elasticsearch, NotFoundError
 from statuses import VectorValidity, VectorStatus
-
-ELASTIC_USERNAME = os.getenv("ELASTIC_USERNAME")
-ELASTIC_PASSWORD = os.getenv("ELASTIC_PASSWORD")
+from elastic_config import *
 
 SWEEPS_DIR = pathlib.Path(__file__).parent
 SWEEP_SOURCES_DIR = SWEEPS_DIR / "sweeps"
@@ -57,7 +55,7 @@ def export_suite_vectors(module_name, suite_name, vectors):
     # Perhaps we export with some sort of readable id, which can be passed to a runner to run specific sets of input vectors. (export seed as well for reproducability)
     client = Elasticsearch(ELASTIC_CONNECTION_STRING, basic_auth=(ELASTIC_USERNAME, ELASTIC_PASSWORD))
 
-    index_name = module_name + "_test_vectors"
+    index_name = VECTOR_INDEX_PREFIX + module_name
 
     try:
         response = client.search(
@@ -126,7 +124,7 @@ if __name__ == "__main__":
     parser.add_argument(
         "--elastic",
         required=False,
-        default="http://yyz-elk:9200",
+        default=ELASTIC_DEFAULT_URL,
         help="Elastic Connection String for vector database.",
     )
 

--- a/tests/sweep_framework/query.py
+++ b/tests/sweep_framework/query.py
@@ -11,6 +11,7 @@ from tests.sweep_framework.statuses import TestStatus
 from beautifultable import BeautifulTable, STYLE_COMPACT
 from termcolor import colored
 
+ELASTIC_USERNAME = os.getenv("ELASTIC_USERNAME")
 ELASTIC_PASSWORD = os.getenv("ELASTIC_PASSWORD")
 
 
@@ -19,7 +20,7 @@ ELASTIC_PASSWORD = os.getenv("ELASTIC_PASSWORD")
 @click.option("--suite-name", default=None, help="Suite name to filter by.")
 @click.option("--vector-id", default=None, help="Individual Vector ID to filter by.")
 @click.option("--run-id", default=None, help="Individual Run ID to filter by.")
-@click.option("--elastic", default="http://localhost:9200", help="Elastic Connection String")
+@click.option("--elastic", default="http://yyz-elk:9200", help="Elastic Connection String")
 @click.option(
     "--all", is_flag=True, default=False, help="Displays total run statistics instead of the most recent run."
 )
@@ -42,7 +43,7 @@ def vector(ctx):
         print("QUERY: Module name and vector ID are required for test vector lookup.")
         exit(1)
 
-    client = Elasticsearch(ctx.obj["elastic"], basic_auth=("elastic", ELASTIC_PASSWORD))
+    client = Elasticsearch(ctx.obj["elastic"], basic_auth=(ELASTIC_USERNAME, ELASTIC_PASSWORD))
     response = client.get(index=(ctx.obj["module_name"] + "_test_vectors"), id=ctx.obj["vector_id"])
     pprint.pp(response["_source"])
 
@@ -54,7 +55,7 @@ def result(ctx):
         print("QUERY: Module name and run ID are required for run result lookup.")
         exit(1)
 
-    client = Elasticsearch(ctx.obj["elastic"], basic_auth=("elastic", ELASTIC_PASSWORD))
+    client = Elasticsearch(ctx.obj["elastic"], basic_auth=(ELASTIC_USERNAME, ELASTIC_PASSWORD))
     response = client.get(index=(ctx.obj["module_name"] + "_test_results"), id=ctx.obj["run_id"])
     pprint.pp(response["_source"])
 
@@ -72,7 +73,7 @@ def summary(ctx):
         colored("FAIL (Watcher)", "light_red"),
     ]
 
-    client = Elasticsearch(ctx.obj["elastic"], basic_auth=("elastic", ELASTIC_PASSWORD))
+    client = Elasticsearch(ctx.obj["elastic"], basic_auth=(ELASTIC_USERNAME, ELASTIC_PASSWORD))
     sweeps_path = pathlib.Path(__file__).parent / "sweeps"
 
     if ctx.obj["module_name"] is None:
@@ -246,7 +247,7 @@ def detail(ctx):
         colored("Host", "light_red"),
     ]
 
-    client = Elasticsearch(ctx.obj["elastic"], basic_auth=("elastic", ELASTIC_PASSWORD))
+    client = Elasticsearch(ctx.obj["elastic"], basic_auth=(ELASTIC_USERNAME, ELASTIC_PASSWORD))
     sweeps_path = pathlib.Path(__file__).parent / "sweeps"
 
     matches = []

--- a/tests/sweep_framework/runner.py
+++ b/tests/sweep_framework/runner.py
@@ -16,6 +16,7 @@ from statuses import TestStatus, VectorValidity, VectorStatus
 import architecture
 from elasticsearch import Elasticsearch, NotFoundError
 
+ELASTIC_USERNAME = os.getenv("ELASTIC_USERNAME")
 ELASTIC_PASSWORD = os.getenv("ELASTIC_PASSWORD")
 ARCH = os.getenv("ARCH_NAME")
 
@@ -160,7 +161,7 @@ def get_suite_vectors(client, vector_index, suite):
 
 
 def run_sweeps(module_name, suite_name, vector_id):
-    client = Elasticsearch(ELASTIC_CONNECTION_STRING, basic_auth=("elastic", ELASTIC_PASSWORD))
+    client = Elasticsearch(ELASTIC_CONNECTION_STRING, basic_auth=(ELASTIC_USERNAME, ELASTIC_PASSWORD))
     pbar_manager = enlighten.get_manager()
 
     sweeps_path = pathlib.Path(__file__).parent / "sweeps"
@@ -247,7 +248,7 @@ def run_sweeps(module_name, suite_name, vector_id):
 def export_test_results(header_info, results):
     if len(results) == 0:
         return
-    client = Elasticsearch(ELASTIC_CONNECTION_STRING, basic_auth=("elastic", ELASTIC_PASSWORD))
+    client = Elasticsearch(ELASTIC_CONNECTION_STRING, basic_auth=(ELASTIC_USERNAME, ELASTIC_PASSWORD))
     sweep_name = header_info[0]["sweep_name"]
     results_index = sweep_name + "_test_results"
 
@@ -283,7 +284,10 @@ if __name__ == "__main__":
     )
 
     parser.add_argument(
-        "--elastic", required=False, help="Elastic Connection String for the vector and results database."
+        "--elastic",
+        required=False,
+        default="http://yyz-elk:9200",
+        help="Elastic Connection String for the vector and results database.",
     )
     parser.add_argument("--module-name", required=False, help="Test Module Name, or all tests if omitted.")
     parser.add_argument("--suite-name", required=False, help="Suite of Test Vectors to run, or all tests if omitted.")
@@ -319,7 +323,7 @@ if __name__ == "__main__":
         print("ERROR: Module name is required if vector id is specified.")
 
     global ELASTIC_CONNECTION_STRING
-    ELASTIC_CONNECTION_STRING = args.elastic if args.elastic else "http://localhost:9200"
+    ELASTIC_CONNECTION_STRING = args.elastic
 
     global MEASURE_PERF
     MEASURE_PERF = args.perf


### PR DESCRIPTION
### Ticket
#8957 

### What's changed
Change the infrastructure to support the global yyz-elk Elasticsearch instance by default, and use environment variables to pass the username.
Add "ttnn_sweeps" prefix to all indices related to sweeping

### Checklist
- [ ] Post commit CI passes
- [ ] Model regression CI testing passes (if applicable)
- [ ] New/Existing tests provide coverage for changes
