### PR TITLE
#9908: Use mm tiles for reduce sum on w dim

### DIFF
--- a/ttnn/cpp/ttnn/deprecated/tt_dnn/kernels/dataflow/generate_mm_scaler.hpp
+++ b/ttnn/cpp/ttnn/deprecated/tt_dnn/kernels/dataflow/generate_mm_scaler.hpp
@@ -8,7 +8,7 @@
 
 // Tile is assumed to have 16-bit elements
 // Scaler is assumed to be a 16-bit value double packed into a u32
-FORCE_INLINE void generate_reduce_scaler(const uint32_t cb_id, const uint32_t scaler) {
+FORCE_INLINE void generate_mm_scaler(const uint32_t cb_id, const uint32_t scaler) {
     cb_reserve_back(cb_id, 1);
 
     constexpr uint32_t num_zeros_reads = 2048 / MEM_ZEROS_SIZE;
@@ -25,13 +25,12 @@ FORCE_INLINE void generate_reduce_scaler(const uint32_t cb_id, const uint32_t sc
     }
     noc_async_read_barrier();
 
-    if (scaler != 0) {
-        for (int k = 0; k < 4; ++k) {
-            uint32_t idx = k << 7;
-            for (int j = 0; j < 8; ++j) {
-                ptr[idx + j] = scaler;
-            }
-        }
+    uint32_t single_packed_scalar = scaler & 0xFFFF;
+    for (int i = 0; i < 128; i += 8) {
+        ptr[i] = single_packed_scalar;
+    }
+    for (int i = 256; i < 384; i += 8) {
+        ptr[i] = single_packed_scalar;
     }
 
     cb_push_back(cb_id, 1);

--- a/ttnn/cpp/ttnn/deprecated/tt_dnn/op_library/reduce/kernels/compute/reduce_w.cpp
+++ b/ttnn/cpp/ttnn/deprecated/tt_dnn/op_library/reduce/kernels/compute/reduce_w.cpp
@@ -4,20 +4,28 @@
 
 #include <cstdint>
 
+#ifndef REDUCE_ROW_SUM_VIA_MM
 #include "compute_kernel_api/reduce.h"
+#else
+#include "compute_kernel_api/matmul.h"
+#endif
 
 namespace NAMESPACE {
+
 void MAIN {
 
     uint32_t Ht = get_compile_time_arg_val(0);
     uint32_t Wt = get_compile_time_arg_val(1);
     uint32_t NC = get_compile_time_arg_val(2);
 
+#ifndef REDUCE_ROW_SUM_VIA_MM
     reduce_init<true>(tt::CB::c_in0, tt::CB::c_in2);
+#else
+    mm_init(tt::CB::c_in0, tt::CB::c_in2);
+#endif
 
-    cb_wait_front(tt::CB::c_in2, 1); // scaler tile from the reader
+    cb_wait_front(tt::CB::c_in2, 1);  // scaler tile from the reader
     for (uint32_t nc = 0; nc < NC; nc++) {
-
         constexpr int onetile = 1;
         int reduce_dst_idx = 0;
         for(uint32_t ht = 0; ht < Ht; ++ht) {
@@ -28,7 +36,11 @@ void MAIN {
             for(uint32_t wt = 0; wt < Wt; ++wt) {
                 cb_wait_front(tt::CB::c_in0, onetile);
                 // REDUCE_OP is expected to come from add_define
+#ifndef REDUCE_ROW_SUM_VIA_MM
                 reduce_tile(tt::CB::c_in0, tt::CB::c_in2, 0, 0, reduce_dst_idx);
+#else
+                matmul_tiles(tt::CB::c_in0, tt::CB::c_in2, 0, 0, 0, false);
+#endif
                 cb_pop_front(tt::CB::c_in0, onetile);
             }
 

--- a/ttnn/cpp/ttnn/deprecated/tt_dnn/op_library/reduce/kernels/dataflow/reader_unary_reduce_interleaved_start_id.cpp
+++ b/ttnn/cpp/ttnn/deprecated/tt_dnn/op_library/reduce/kernels/dataflow/reader_unary_reduce_interleaved_start_id.cpp
@@ -4,8 +4,11 @@
 
 #include <stdint.h>
 #include "dataflow_api.h"
+#ifndef REDUCE_ROW_SUM_VIA_MM
 #include "ttnn/cpp/ttnn/deprecated/tt_dnn/kernels/dataflow/generate_reduce_scaler.hpp"
-
+#else
+#include "ttnn/cpp/ttnn/deprecated/tt_dnn/kernels/dataflow/generate_mm_scaler.hpp"
+#endif
 
 void kernel_main() {
     uint32_t src_addr  = get_arg_val<uint32_t>(0);
@@ -15,7 +18,11 @@ void kernel_main() {
     constexpr uint32_t scaler = get_compile_time_arg_val(1);
 
     constexpr uint32_t cb_id_in2 = 2;
-    generate_reduce_scaler(cb_id_in2, scaler);
+    #ifndef REDUCE_ROW_SUM_VIA_MM
+        generate_reduce_scaler(cb_id_in2, scaler);
+    #else
+        generate_mm_scaler(cb_id_in2, scaler);
+    #endif
 
     constexpr uint32_t cb_id_in0 = 0;
 

--- a/ttnn/cpp/ttnn/deprecated/tt_dnn/op_library/reduce/reduce_op.cpp
+++ b/ttnn/cpp/ttnn/deprecated/tt_dnn/op_library/reduce/reduce_op.cpp
@@ -19,6 +19,7 @@
 
 
 #include <limits>
+#include <optional>
 
 using namespace tt::constants;
 
@@ -39,6 +40,9 @@ std::map<string, string> get_defines(ReduceOpMath reduce_op, ReduceOpDim reduce_
     }
     defines["REDUCE_OP"] = (do_max ? "PoolType::MAX" : "PoolType::SUM" );
     defines["REDUCE_DIM"] = reduce_dim_str;
+    if (reduce_dim == ReduceOpDim::W && reduce_op == ReduceOpMath::SUM) {
+        defines["REDUCE_ROW_SUM_VIA_MM"] = 1;
+    }
     return defines;
 }
 
@@ -110,12 +114,12 @@ operation::ProgramWithCallbacks Reduce::create_program(const std::vector<Tensor>
 
     switch (parallelization_strategy){
         case ReduceOpParallelizationStrategy::MULTI_CORE_H:
-            return reduce_multi_core_h(input_tensor, output_tensor, this->math_op, this->scaler);
+            return reduce_multi_core_h(input_tensor, output_tensor, this->math_op, compute_kernel_config, this->scaler);
         case ReduceOpParallelizationStrategy::MULTI_CORE_W:
-            return reduce_multi_core_w(input_tensor, output_tensor, this->math_op, this->scaler);
+            return reduce_multi_core_w(input_tensor, output_tensor, this->math_op, compute_kernel_config, this->scaler);
         case ReduceOpParallelizationStrategy::MULTI_CORE_HW:
         case ReduceOpParallelizationStrategy::SINGLE_CORE_HW:
-            return reduce_single_core_hw(input_tensor, output_tensor, this->math_op, this->scaler);
+            return reduce_single_core_hw(input_tensor, output_tensor, this->math_op, compute_kernel_config, this->scaler);
         default:
             TT_THROW("Unsupported parallelization strategy");
     }
@@ -143,18 +147,18 @@ ReduceOpParallelizationStrategy Reduce::get_parallelization_strategy(const std::
 
 //reduce min
 //reduce min = - reduce_max( -x )
-Tensor reduce_min(const Tensor &input_tensor, ReduceOpDim reduce_dim, float scaler = 1.0f, const MemoryConfig& output_mem_config = operation::DEFAULT_OUTPUT_MEMORY_CONFIG) {
+Tensor reduce_min(const Tensor &input_tensor, ReduceOpDim reduce_dim, float scaler = 1.0f, const MemoryConfig& output_mem_config = operation::DEFAULT_OUTPUT_MEMORY_CONFIG, const std::optional<DeviceComputeKernelConfig>& compute_kernel_config = std::nullopt) {
     Tensor input = input_tensor;
     if(input.get_layout()==Layout::ROW_MAJOR && input.storage_type() == StorageType::DEVICE){
         input = ttnn::operations::unary_backward::change_layout_to_tile(input, output_mem_config);
         }
     Tensor n_input_tensor = ttnn::neg(input,output_mem_config);
-    Tensor max_reduce = reduce(n_input_tensor,ReduceOpMath::MAX,reduce_dim,scaler,output_mem_config);
+    Tensor max_reduce = reduce(n_input_tensor,ReduceOpMath::MAX,reduce_dim,scaler,output_mem_config, std::nullopt, compute_kernel_config);
     Tensor min_tensor = ttnn::neg(max_reduce,output_mem_config);
     return min_tensor;
 }
 
-Tensor reduce(const Tensor &input_tensor, ReduceOpMath reduce_math, ReduceOpDim reduce_dim, float scaler, const MemoryConfig& output_mem_config, const std::optional<DataType>& output_dtype) {
+Tensor reduce(const Tensor &input_tensor, ReduceOpMath reduce_math, ReduceOpDim reduce_dim, float scaler, const MemoryConfig& output_mem_config, const std::optional<DataType>& output_dtype, const std::optional<DeviceComputeKernelConfig>& compute_kernel_config) {
     if ( reduce_math == ReduceOpMath::MIN ) {
         return reduce_min(input_tensor,reduce_dim,scaler,output_mem_config);
     }
@@ -163,10 +167,13 @@ Tensor reduce(const Tensor &input_tensor, ReduceOpMath reduce_math, ReduceOpDim 
     auto is_multicore_hw = parallelization_strategy == ReduceOpParallelizationStrategy::MULTI_CORE_HW;
     float pad_value = reduce_math == ReduceOpMath::MAX ? -std::numeric_limits<float>::infinity() : 0;
 
+    DeviceComputeKernelConfig config = compute_kernel_config.value_or(
+        init_device_compute_kernel_config(input_tensor.device()->arch(), std::nullopt, MathFidelity::HiFi4));
+
     std::vector<Tensor> output_tensors = {Tensor(operation::get_workers_for_op_output({input_tensor}))};
     if (is_multicore_hw) {
         operation::launch_op(
-        [reduce_math, reduce_dim, pad_value, scaler, output_dtype, output_mem_config] (const std::vector<Tensor>& input_tensors, const std::vector<std::optional<const Tensor>>& optional_input_tensors, const std::vector<std::optional<Tensor>>& optional_output_tensors) mutable -> std::vector<Tensor> {
+        [reduce_math, reduce_dim, pad_value, scaler, output_dtype, output_mem_config, config] (const std::vector<Tensor>& input_tensors, const std::vector<std::optional<const Tensor>>& optional_input_tensors, const std::vector<std::optional<Tensor>>& optional_output_tensors) mutable -> std::vector<Tensor> {
             const auto& input_tensor = input_tensors.at(0);
             Device * device;
 
@@ -182,26 +189,26 @@ Tensor reduce(const Tensor &input_tensor, ReduceOpMath reduce_math, ReduceOpDim 
             if (!AutoFormat::check_input_tensor_format(input_tensor, input_tensor_pad_shape)) {
                 formatted_input_tensor = AutoFormat::format_input_tensor(input_tensor, device, input_tensor_pad_shape, pad_value, Layout::TILE);
             }
-            const Tensor output_tensor = operation::run_without_autoformat(Reduce{reduce_math, ReduceOpDim::W, 1.0, output_mem_config, output_dtype.value_or(input_tensor.get_dtype())}, {formatted_input_tensor}).at(0);
-            return operation::run_without_autoformat(Reduce{reduce_math, ReduceOpDim::H, scaler, output_mem_config, output_dtype.value_or(input_tensor.get_dtype())}, {output_tensor});
+            const Tensor output_tensor = operation::run_without_autoformat(Reduce{reduce_math, ReduceOpDim::W, 1.0, output_mem_config, output_dtype.value_or(input_tensor.get_dtype()), config}, {formatted_input_tensor}).at(0);
+            return operation::run_without_autoformat(Reduce{reduce_math, ReduceOpDim::H, scaler, output_mem_config, output_dtype.value_or(input_tensor.get_dtype()), config}, {output_tensor});
         }, {input_tensor}, output_tensors);
     } else {
         operation::launch_with_autoformat(
-        [reduce_math, reduce_dim, pad_value, scaler, output_dtype, output_mem_config] (const std::vector<Tensor>& input_tensors, const std::vector<std::optional<const Tensor>>& optional_input_tensors, const std::vector<std::optional<Tensor>>& optional_output_tensors) mutable -> std::vector<Tensor> {
+        [reduce_math, reduce_dim, pad_value, scaler, output_dtype, output_mem_config, config] (const std::vector<Tensor>& input_tensors, const std::vector<std::optional<const Tensor>>& optional_input_tensors, const std::vector<std::optional<Tensor>>& optional_output_tensors) mutable -> std::vector<Tensor> {
             const auto& input_tensor = input_tensors.at(0);
-            return operation::run_with_autoformat(Reduce{reduce_math, reduce_dim, scaler, output_mem_config, output_dtype.value_or(input_tensor.get_dtype())}, {input_tensor}, {}, {}, pad_value);
+            return operation::run_with_autoformat(Reduce{reduce_math, reduce_dim, scaler, output_mem_config, output_dtype.value_or(input_tensor.get_dtype()), config}, {input_tensor}, {}, {}, pad_value);
         }, {input_tensor}, output_tensors);
     }
     return output_tensors.at(0);
 }
-Tensor mean_hw(const Tensor& input_tensor, const MemoryConfig& output_mem_config) {
-    return mean(input_tensor,2,output_mem_config);
+Tensor mean_hw(const Tensor& input_tensor, const MemoryConfig& output_mem_config, const std::optional<DeviceComputeKernelConfig>& compute_kernel_config) {
+    return mean(input_tensor,2,output_mem_config, compute_kernel_config);
 }
 Tensor global_mean(const Tensor& input_tensor, const MemoryConfig& output_mem_config) {
     float inv_volume = 1.0f/input_tensor.volume();
     return ttnn::mul_sfpu( inv_volume, global_sum(input_tensor,output_mem_config), output_mem_config);
 }
-Tensor mean(const Tensor& input_tensor,uint aggregate_dims /* = 2 */, const MemoryConfig& output_mem_config) {
+Tensor mean(const Tensor& input_tensor,uint aggregate_dims /* = 2 */, const MemoryConfig& output_mem_config, const std::optional<DeviceComputeKernelConfig>& compute_kernel_config) {
     tt::tt_metal::Shape shape = input_tensor.get_legacy_shape();
 
     TT_FATAL( aggregate_dims >= 2 && aggregate_dims <= 4, "mean aggregate dimensions should be [HW],[CHW] or [NCHW]");
@@ -217,19 +224,19 @@ Tensor mean(const Tensor& input_tensor,uint aggregate_dims /* = 2 */, const Memo
     }
 
     float inv_scale_hw = 1.0f/(shape[3]*shape[2]);
-    Tensor scaled_sum_hw = reduce(input_tensor,ReduceOpMath::SUM,ReduceOpDim::HW,inv_scale_hw,output_mem_config);
+    Tensor scaled_sum_hw = reduce(input_tensor,ReduceOpMath::SUM,ReduceOpDim::HW,inv_scale_hw,output_mem_config, std::nullopt, compute_kernel_config);
     return scaled_sum_hw;
 }
 
 template <ReduceOpMath OpKind>
-Tensor reduce_on_dim(const Tensor &input_tensor, uint dim, const MemoryConfig& output_mem_config) {
+Tensor reduce_on_dim(const Tensor &input_tensor, uint dim, const MemoryConfig& output_mem_config, const std::optional<DeviceComputeKernelConfig>& compute_kernel_config) {
     TT_FATAL( dim >= 0 && dim <= 3, "dimension have to be 0-3 only corresponding to N,C,H,W");
     constexpr float scaler1 = 1.0;
 
     if ( dim == 3 ) {
-        return reduce(input_tensor, OpKind, ReduceOpDim::W, scaler1, output_mem_config);
+        return reduce(input_tensor, OpKind, ReduceOpDim::W, scaler1, output_mem_config, std::nullopt, compute_kernel_config);
     } else if ( dim == 2 ) {
-        return reduce(input_tensor, OpKind, ReduceOpDim::H, scaler1, output_mem_config);
+        return reduce(input_tensor, OpKind, ReduceOpDim::H, scaler1, output_mem_config, std::nullopt, compute_kernel_config);
     }
 
     // Other sum dims will autoformat first before doing composite operations
@@ -260,7 +267,7 @@ Tensor reduce_on_dim(const Tensor &input_tensor, uint dim, const MemoryConfig& o
             formatted_input_tensor = AutoFormat::format_input_tensor(input_tensor, device, input_tensor_pad_shape, pad_value, Layout::TILE);
         }
         Tensor output = ttnn::transpose(formatted_input_tensor, 1, -2, output_mem_config);
-        output = reduce_on_dim<OpKind>(output, 2, output_mem_config);
+        output = reduce_on_dim<OpKind>(output, 2, output_mem_config, compute_kernel_config);
         output = ttnn::transpose(output, 1, -2, output_mem_config);
         return AutoFormat::format_output_tensor(output, out_shape, device, Layout::TILE);
     } else {
@@ -274,34 +281,35 @@ Tensor reduce_on_dim(const Tensor &input_tensor, uint dim, const MemoryConfig& o
             formatted_input_tensor = AutoFormat::format_input_tensor(input_tensor, device, input_tensor_pad_shape, 0.0, Layout::TILE);
         }
         Tensor output = ttnn::transpose(input_tensor, 0, -2, output_mem_config);
-        output = reduce_on_dim<OpKind>(output, 2, output_mem_config);
+        output = reduce_on_dim<OpKind>(output, 2, output_mem_config, compute_kernel_config);
         output = ttnn::transpose(output, 0, -2, output_mem_config);
         return AutoFormat::format_output_tensor(output, out_shape, device, Layout::TILE);
     }
 }
 
 
-Tensor sum(const Tensor &input_tensor, uint dim, const MemoryConfig& output_mem_config) {
+Tensor sum(const Tensor &input_tensor, uint dim, const MemoryConfig& output_mem_config, const std::optional<DeviceComputeKernelConfig>& compute_kernel_config) {
     TT_FATAL( dim >= 0 && dim <= 3, "dimension have to be 0-3 only corresponding to N,C,H,W");
-    return reduce_on_dim<ReduceOpMath::SUM>(input_tensor, dim, output_mem_config);
+    return reduce_on_dim<ReduceOpMath::SUM>(input_tensor, dim, operation::DEFAULT_OUTPUT_MEMORY_CONFIG, compute_kernel_config);
 }
 
-Tensor min(const Tensor &input_tensor, uint dim, const MemoryConfig& output_mem_config) {
+Tensor min(const Tensor &input_tensor, uint dim, const MemoryConfig& output_mem_config, const std::optional<DeviceComputeKernelConfig>& compute_kernel_config) {
     TT_FATAL( dim >= 0 && dim <= 3, "dimension have to be 0-3 only corresponding to N,C,H,W");
-    return reduce_on_dim<ReduceOpMath::MIN>(input_tensor, dim, output_mem_config);
+    return reduce_on_dim<ReduceOpMath::MIN>(input_tensor, dim, output_mem_config, compute_kernel_config);
 }
 
-Tensor max(const Tensor &input_tensor, uint dim, const MemoryConfig& output_mem_config) {
+Tensor max(const Tensor &input_tensor, uint dim, const MemoryConfig& output_mem_config, const std::optional<DeviceComputeKernelConfig>& compute_kernel_config) {
     TT_FATAL( dim >= 0 && dim <= 3, "dimension have to be 0-3 only corresponding to N,C,H,W");
-    return reduce_on_dim<ReduceOpMath::MAX>(input_tensor, dim, output_mem_config);
+    return reduce_on_dim<ReduceOpMath::MAX>(input_tensor, dim, output_mem_config, compute_kernel_config);
 }
 
 
-using ReduceFnT = Tensor(*)(const Tensor&,unsigned int, const MemoryConfig&);
-Tensor global_reduce(ReduceFnT f,const Tensor& val, const MemoryConfig& output_mem_config) {
+using ReduceFnT = Tensor(*)(const Tensor&,unsigned int, const MemoryConfig&, const std::optional<DeviceComputeKernelConfig>&);
+Tensor global_reduce(ReduceFnT f,const Tensor& val, const MemoryConfig& output_mem_config, const std::optional<DeviceComputeKernelConfig>& compute_kernel_config) {
     Tensor result = val;
-    for(int rank = val.get_legacy_shape().rank()-1; rank >=0; rank--)
-        result = f(result, rank, output_mem_config);
+    for(int rank = val.get_legacy_shape().rank()-1; rank >=0; rank--) {
+        result = f(result, rank, output_mem_config, compute_kernel_config);
+    }
 
     std::array<std::uint32_t, 4> intended_shape_array = {};
     intended_shape_array.fill(1);
@@ -313,16 +321,16 @@ Tensor global_reduce(ReduceFnT f,const Tensor& val, const MemoryConfig& output_m
     return result;
 }
 
-Tensor global_sum(const Tensor& val, const MemoryConfig& output_mem_config) {
-    return  global_reduce(sum,val,output_mem_config);
+Tensor global_sum(const Tensor& val, const MemoryConfig& output_mem_config, const std::optional<DeviceComputeKernelConfig>& compute_kernel_config) {
+    return global_reduce(sum,val,output_mem_config, compute_kernel_config);
 }
 
-Tensor global_max(const Tensor& val, const MemoryConfig& output_mem_config) {
-    return  global_reduce(max,val,output_mem_config);
+Tensor global_max(const Tensor& val, const MemoryConfig& output_mem_config, const std::optional<DeviceComputeKernelConfig>& compute_kernel_config) {
+    return global_reduce(max,val,output_mem_config, compute_kernel_config);
 }
 
-Tensor global_min(const Tensor& val, const MemoryConfig& output_mem_config) {
-    return  global_reduce(min,val,output_mem_config);
+Tensor global_min(const Tensor& val, const MemoryConfig& output_mem_config, const std::optional<DeviceComputeKernelConfig>& compute_kernel_config) {
+    return global_reduce(min,val,output_mem_config, compute_kernel_config);
 }
 
 }  // namespace tt_metal

--- a/ttnn/cpp/ttnn/deprecated/tt_dnn/op_library/reduce/reduce_op.hpp
+++ b/ttnn/cpp/ttnn/deprecated/tt_dnn/op_library/reduce/reduce_op.hpp
@@ -4,6 +4,8 @@
 
 #pragma once
 
+
+#include "ttnn/cpp/ttnn/deprecated/tt_dnn/op_library/compute_kernel_config.hpp"
 #include "ttnn/tensor/tensor.hpp"
 #include "tt_metal/host_api.hpp"
 
@@ -16,9 +18,9 @@ namespace tt {
 namespace tt_metal {
 
 // TODO: Accept parallelization
-operation::ProgramWithCallbacks reduce_single_core_hw(const Tensor &input_tensor, Tensor &output_tensor, ReduceOpMath reduce_math, float scaler = 1.0f);
-operation::ProgramWithCallbacks reduce_multi_core_h(const Tensor &input_tensor, Tensor &output_tensor, ReduceOpMath reduce_math, float scaler = 1.0f);
-operation::ProgramWithCallbacks reduce_multi_core_w(const Tensor &input_tensor, Tensor &output_tensor, ReduceOpMath reduce_math, float scaler = 1.0f);
+operation::ProgramWithCallbacks reduce_single_core_hw(const Tensor &input_tensor, Tensor &output_tensor, ReduceOpMath reduce_math, const DeviceComputeKernelConfig& compute_kernel_config, float scaler = 1.0f);
+operation::ProgramWithCallbacks reduce_multi_core_h(const Tensor &input_tensor, Tensor &output_tensor, ReduceOpMath reduce_math, const DeviceComputeKernelConfig& compute_kernel_config, float scaler = 1.0f);
+operation::ProgramWithCallbacks reduce_multi_core_w(const Tensor &input_tensor, Tensor &output_tensor, ReduceOpMath reduce_math, const DeviceComputeKernelConfig& compute_kernel_config, float scaler = 1.0f);
 
 struct Reduce {
     const ReduceOpMath math_op;
@@ -26,6 +28,7 @@ struct Reduce {
     const float scaler;
     const MemoryConfig output_mem_config;
     const DataType output_dtype;
+    DeviceComputeKernelConfig compute_kernel_config;
 
     void validate(const std::vector<Tensor> &input_tensors) const;
     std::vector<Shape> compute_output_shapes(const std::vector<Tensor> &input_tensors) const;
@@ -34,16 +37,52 @@ struct Reduce {
     ReduceOpParallelizationStrategy get_parallelization_strategy(const std::vector<Tensor>& input_tensors) const;
 };
 
-Tensor reduce(const Tensor &input_tensor, ReduceOpMath reduce_math, ReduceOpDim reduce_dim, float scaler = 1.0f, const MemoryConfig& output_mem_config = operation::DEFAULT_OUTPUT_MEMORY_CONFIG, const std::optional<DataType>& output_dtype=std::nullopt);
-Tensor sum(const Tensor &input_tensor, uint dim, const MemoryConfig& output_mem_config = operation::DEFAULT_OUTPUT_MEMORY_CONFIG);
-Tensor max(const Tensor &input_tensor, uint dim, const MemoryConfig& output_mem_config = operation::DEFAULT_OUTPUT_MEMORY_CONFIG);
-Tensor min(const Tensor &input_tensor, uint dim, const MemoryConfig& output_mem_config = operation::DEFAULT_OUTPUT_MEMORY_CONFIG);
-Tensor mean(const Tensor& input_tensor, uint aggregate_dims=2, const MemoryConfig& output_mem_config = operation::DEFAULT_OUTPUT_MEMORY_CONFIG);
-Tensor mean_hw(const Tensor& input_tensor, const MemoryConfig& output_mem_config = operation::DEFAULT_OUTPUT_MEMORY_CONFIG);
-Tensor global_mean(const Tensor& input_tensor, const MemoryConfig& output_mem_config = operation::DEFAULT_OUTPUT_MEMORY_CONFIG);
-Tensor global_sum(const Tensor& input_tensor, const MemoryConfig& output_mem_config = operation::DEFAULT_OUTPUT_MEMORY_CONFIG);
-Tensor global_max(const Tensor& val, const MemoryConfig& output_mem_config);
-Tensor global_min(const Tensor& val, const MemoryConfig& output_mem_config);
+Tensor reduce(
+    const Tensor& input_tensor,
+    ReduceOpMath reduce_math,
+    ReduceOpDim reduce_dim,
+    float scaler = 1.0f,
+    const MemoryConfig& output_mem_config = operation::DEFAULT_OUTPUT_MEMORY_CONFIG,
+    const std::optional<DataType>& output_dtype = std::nullopt,
+    const std::optional<DeviceComputeKernelConfig>& compute_kernel_config = std::nullopt);
+Tensor sum(
+    const Tensor& input_tensor,
+    uint dim,
+    const MemoryConfig& output_mem_config = operation::DEFAULT_OUTPUT_MEMORY_CONFIG,
+    const std::optional<DeviceComputeKernelConfig>& compute_kernel_config = std::nullopt);
+Tensor max(
+    const Tensor& input_tensor,
+    uint dim,
+    const MemoryConfig& output_mem_config = operation::DEFAULT_OUTPUT_MEMORY_CONFIG,
+    const std::optional<DeviceComputeKernelConfig>& compute_kernel_config = std::nullopt);
+Tensor min(
+    const Tensor& input_tensor,
+    uint dim,
+    const MemoryConfig& output_mem_config = operation::DEFAULT_OUTPUT_MEMORY_CONFIG,
+    const std::optional<DeviceComputeKernelConfig>& compute_kernel_config = std::nullopt);
+Tensor mean(
+    const Tensor& input_tensor,
+    uint aggregate_dims = 2,
+    const MemoryConfig& output_mem_config = operation::DEFAULT_OUTPUT_MEMORY_CONFIG,
+    const std::optional<DeviceComputeKernelConfig>& compute_kernel_config = std::nullopt);
+Tensor mean_hw(
+    const Tensor& input_tensor,
+    const MemoryConfig& output_mem_config = operation::DEFAULT_OUTPUT_MEMORY_CONFIG,
+    const std::optional<DeviceComputeKernelConfig>& compute_kernel_config = std::nullopt);
+Tensor global_mean(
+    const Tensor& input_tensor, const MemoryConfig& output_mem_config = operation::DEFAULT_OUTPUT_MEMORY_CONFIG);
+Tensor global_sum(
+    const Tensor& input_tensor,
+    const MemoryConfig& output_mem_config = operation::DEFAULT_OUTPUT_MEMORY_CONFIG,
+    const std::optional<DeviceComputeKernelConfig>& compute_kernel_config = std::nullopt);
+Tensor global_max(
+    const Tensor& val,
+    const MemoryConfig& output_mem_config,
+    const std::optional<DeviceComputeKernelConfig>& compute_kernel_config = std::nullopt);
+Tensor global_min(
+    const Tensor& val,
+    const MemoryConfig& output_mem_config,
+    const std::optional<DeviceComputeKernelConfig>& compute_kernel_config = std::nullopt);
 
 }  // namespace tt_metal
 

--- a/ttnn/cpp/ttnn/deprecated/tt_lib/csrc/tt_lib_bindings_tensor.cpp
+++ b/ttnn/cpp/ttnn/deprecated/tt_lib/csrc/tt_lib_bindings_tensor.cpp
@@ -336,7 +336,7 @@ void TensorModule(py::module& m_tensor) {
         .def_readwrite("fp32_dest_acc_en", &WormholeComputeKernelConfig::fp32_dest_acc_en)
         .def_readwrite("packer_l1_acc", &WormholeComputeKernelConfig::packer_l1_acc);
 
-    detail::bind_unary_op(
+    detail::bind_unary_op<true, false, true>(
         m_tensor,
         "mean_hw",
         tt::tt_metal::mean_hw,
@@ -346,31 +346,31 @@ void TensorModule(py::module& m_tensor) {
         "global_mean",
         tt::tt_metal::global_mean,
         R"doc(  Returns a new tensor with the mean of the input tensor ``{0}`` on all axes.)doc");
-    detail::bind_unary_op(
+    detail::bind_unary_op<true, false, true>(
         m_tensor,
         "global_sum",
         tt::tt_metal::global_sum,
         R"doc(  Returns a new tensor with the sum of the input tensor ``{0}`` on all axes.)doc");
-    detail::bind_unary_op(
+    detail::bind_unary_op<true, false, true>(
         m_tensor,
         "global_max",
         tt::tt_metal::global_max,
         R"doc(  Returns a new tensor with the max of the input tensor ``{0}`` on all axes.)doc");
-    detail::bind_unary_op(
+    detail::bind_unary_op<true, false, true>(
         m_tensor,
         "global_min",
         tt::tt_metal::global_min,
         R"doc(  Returns a new tensor with the min of the input tensor ``{0}`` on all axes.)doc");
 
-    detail::bind_unary_op_with_param(
+    detail::bind_unary_op_with_param<true, false, true>(
         m_tensor,
         "sum",
         &sum,
         py::arg("dim"),
-        R"doc(Returns a tensor that is a sum  of input tensor with shape ``[W, Z, Y, X]`` along dimensions ``{1}``; input tensor in TILE LAYOUT.)doc",
-        R"doc("dimension along which to apply sum", "int", "0, 1, 2, or 3")doc");
+        R"doc(Returns a tensor that is a sum  of input tensor with shape ``[W, Z, Y, X]`` along dimensions ``{1}``;
+        input tensor in TILE LAYOUT.)doc", R"doc("dimension along which to apply sum", "int", "0, 1, 2, or 3")doc");
 
-    detail::bind_unary_op_with_param(
+    detail::bind_unary_op_with_param<true, false, true>(
         m_tensor,
         "max",
         tt::tt_metal::max,

--- a/ttnn/cpp/ttnn/deprecated/tt_lib/csrc/tt_lib_bindings_tensor_dm_ops.cpp
+++ b/ttnn/cpp/ttnn/deprecated/tt_lib/csrc/tt_lib_bindings_tensor_dm_ops.cpp
@@ -253,7 +253,7 @@ namespace tt::tt_metal::detail{
         )doc");
 
         m_tensor.def("reduce", &reduce,
-            py::arg("input").noconvert(), py::arg("math_op"), py::arg("dim"), py::arg("scaler"), py::arg("output_mem_config").noconvert() = operation::DEFAULT_OUTPUT_MEMORY_CONFIG, py::arg("output_dtype").noconvert() = std::nullopt, R"doc(
+            py::arg("input").noconvert(), py::arg("math_op"), py::arg("dim"), py::arg("scaler"), py::arg("output_mem_config").noconvert() = operation::DEFAULT_OUTPUT_MEMORY_CONFIG, py::arg("output_dtype").noconvert() = std::nullopt, py::arg("compute_kernel_config").noconvert() = std::nullopt, R"doc(
             Perform a reduction of input tensor ``input`` using mathematical operation ``math_op`` on dimension ``dim``.
 
             For ``arg2=ReduceOpDim::W`` reduce is done on dimension X.

--- a/ttnn/cpp/ttnn/deprecated/tt_lib/csrc/tt_lib_bindings_tensor_impl.hpp
+++ b/ttnn/cpp/ttnn/deprecated/tt_lib/csrc/tt_lib_bindings_tensor_impl.hpp
@@ -69,8 +69,10 @@ void bind_op_with_mem_config_and_dtype_and_opt_output(py::module_ &module, std::
     }
 }
 
-template <bool mem_config_arg = true, bool dtype_arg = true, typename Func, typename... Extra>
-void bind_op_with_mem_config_and_dtype(py::module_ &module, std::string op_name, Func &&f, std::string docstring, Extra&&... extra) {
+template <bool mem_config_arg = true, bool dtype_arg = true, bool kernel_config = false, typename Func, typename... Extra>
+void bind_op_with_mem_config_and_dtype(
+    py::module_ &module, std::string op_name, Func &&f, std::string docstring, Extra &&...extra) {
+    const std::string kernel_config_name = "compute_kernel_config";
     if constexpr (mem_config_arg && dtype_arg) {
         const std::string mem_config_name = "output_mem_config";
         docstring += fmt::format(R"doc(
@@ -82,31 +84,79 @@ void bind_op_with_mem_config_and_dtype(py::module_ &module, std::string op_name,
             "{0}", "Output tensor data type", "DataType", "Default is None (Use input dtype)", "No")doc",
             dtype_name
         );
-        module.def(op_name.c_str(), f,
-            std::forward<Extra>(extra)..., py::arg(mem_config_name.c_str()).noconvert() = operation::DEFAULT_OUTPUT_MEMORY_CONFIG, py::arg(dtype_name.c_str()).noconvert() = std::nullopt, docstring.c_str()
-        );
+        if constexpr (kernel_config) {
+            module.def(
+                op_name.c_str(),
+                f,
+                std::forward<Extra>(extra)...,
+                py::arg(mem_config_name.c_str()).noconvert() = operation::DEFAULT_OUTPUT_MEMORY_CONFIG,
+                py::arg(dtype_name.c_str()).noconvert() = std::nullopt,
+                py::arg(kernel_config_name.c_str()).noconvert() = std::nullopt,
+                docstring.c_str());
+        } else {
+            module.def(
+                op_name.c_str(),
+                f,
+                std::forward<Extra>(extra)...,
+                py::arg(mem_config_name.c_str()).noconvert() = operation::DEFAULT_OUTPUT_MEMORY_CONFIG,
+                py::arg(dtype_name.c_str()).noconvert() = std::nullopt,
+                docstring.c_str());
+        }
     } else if constexpr (mem_config_arg) {
         const std::string mem_config_name = "output_mem_config";
         docstring += fmt::format(R"doc(
             "{0}", "Layout of tensor in TT Accelerator device memory banks", "MemoryConfig", "Default is {1} in {2}", "No")doc",
             mem_config_name, magic_enum::enum_name(operation::DEFAULT_OUTPUT_MEMORY_CONFIG.memory_layout), magic_enum::enum_name(operation::DEFAULT_OUTPUT_MEMORY_CONFIG.buffer_type)
         );
-        module.def(op_name.c_str(), f,
-            std::forward<Extra>(extra)..., py::arg(mem_config_name.c_str()).noconvert() = operation::DEFAULT_OUTPUT_MEMORY_CONFIG, docstring.c_str()
-        );
+        if constexpr (kernel_config) {
+            module.def(
+                op_name.c_str(),
+                f,
+                std::forward<Extra>(extra)...,
+                py::arg(mem_config_name.c_str()).noconvert() = operation::DEFAULT_OUTPUT_MEMORY_CONFIG,
+                py::arg(kernel_config_name.c_str()).noconvert() = std::nullopt,
+                docstring.c_str());
+        } else {
+            module.def(
+                op_name.c_str(),
+                f,
+                std::forward<Extra>(extra)...,
+                py::arg(mem_config_name.c_str()).noconvert() = operation::DEFAULT_OUTPUT_MEMORY_CONFIG,
+                docstring.c_str());
+        }
     } else if constexpr (dtype_arg) {
         const std::string dtype_name = "output_dtype";
         docstring += fmt::format(R"doc(
             "{0}", "Output tensor data type", "DataType", "Default is None (Use input dtype)", "No")doc",
             dtype_name
         );
-        module.def(op_name.c_str(), f,
-            std::forward<Extra>(extra)..., py::arg(dtype_name.c_str()).noconvert() = std::nullopt, docstring.c_str()
-        );
+        if constexpr (kernel_config) {
+            module.def(
+                op_name.c_str(),
+                f,
+                std::forward<Extra>(extra)...,
+                py::arg(dtype_name.c_str()).noconvert() = std::nullopt,
+                py::arg(kernel_config_name.c_str()).noconvert() = std::nullopt,
+                docstring.c_str());
+        } else {
+            module.def(
+                op_name.c_str(),
+                f,
+                std::forward<Extra>(extra)...,
+                py::arg(dtype_name.c_str()).noconvert() = std::nullopt,
+                docstring.c_str());
+        }
     } else {
-        module.def(op_name.c_str(), f,
-            std::forward<Extra>(extra)..., docstring.c_str()
-        );
+        if constexpr (kernel_config) {
+            module.def(
+                op_name.c_str(),
+                f,
+                std::forward<Extra>(extra)...,
+                py::arg(kernel_config_name.c_str()).noconvert() = std::nullopt,
+                docstring.c_str());
+        } else {
+            module.def(op_name.c_str(), f, std::forward<Extra>(extra)..., docstring.c_str());
+        }
     }
 }
 
@@ -154,7 +204,7 @@ void bind_binary_op(py::module_ &module, std::string op_name, Func &&f, std::str
 }
 
 //TODO @tt-aho: Update to handle variable number of params
-template <bool mem_config_arg = true, bool dtype_arg = false, typename Func>
+template <bool mem_config_arg = true, bool dtype_arg = false, bool kernel_config = false, typename Func>
 void bind_unary_op(py::module_ &module, std::string op_name, Func &&f, std::string op_desc) {
     const std::string tensor_name = "input";
     op_desc = fmt::format(fmt::runtime(op_desc), tensor_name);
@@ -172,10 +222,10 @@ void bind_unary_op(py::module_ &module, std::string op_name, Func &&f, std::stri
         op_desc, tensor_name, op_name
     );
 
-    bind_op_with_mem_config_and_dtype<mem_config_arg, dtype_arg>(module, op_name, f, docstring, py::arg(tensor_name.c_str()).noconvert());
+    bind_op_with_mem_config_and_dtype<mem_config_arg, dtype_arg, kernel_config>(module, op_name, f, docstring, py::arg(tensor_name.c_str()).noconvert());
 }
 
-template <bool mem_config_arg = true, bool dtype_arg = false, typename Func, typename PyArg, typename std::enable_if<std::is_base_of<py::arg, PyArg>::value, int>::type = 0>
+template <bool mem_config_arg = true, bool dtype_arg = false, bool kernel_config = false, typename Func, typename PyArg, typename std::enable_if<std::is_base_of<py::arg, PyArg>::value, int>::type = 0>
 void bind_unary_op_with_param(py::module_ &module, std::string op_name, Func &&f, PyArg param, std::string op_desc, std::string param_desc) {
     const std::string tensor_name = "input";
     std::string param_name = std::string(param.name);
@@ -199,7 +249,7 @@ void bind_unary_op_with_param(py::module_ &module, std::string op_name, Func &&f
             "{0}", {1}, "{2}")doc",
         param_name, param_desc, required_param
     );
-    bind_op_with_mem_config_and_dtype<mem_config_arg, dtype_arg>(module, op_name, f, docstring, py::arg(tensor_name.c_str()).noconvert(), param);
+    bind_op_with_mem_config_and_dtype<mem_config_arg, dtype_arg, kernel_config>(module, op_name, f, docstring, py::arg(tensor_name.c_str()).noconvert(), param);
 }
 
 template <typename E, typename... Extra>

--- a/ttnn/cpp/ttnn/operations/reduction/generic/generic_reductions.hpp
+++ b/ttnn/cpp/ttnn/operations/reduction/generic/generic_reductions.hpp
@@ -31,7 +31,8 @@ struct Reduce {
         const Tensor& input_tensor_arg,
         const std::optional<std::variant<int, std::vector<int>>>& dim_arg,
         const bool keepdim,
-        const std::optional<MemoryConfig>& memory_config_arg = std::nullopt) {
+        const std::optional<MemoryConfig>& memory_config_arg = std::nullopt,
+        const std::optional<DeviceComputeKernelConfig>& compute_kernel_config = std::nullopt) {
         if (not keepdim) {
             TT_THROW("keepdim=False is not supported");
         }
@@ -86,11 +87,11 @@ struct Reduce {
             if constexpr (reduce_type == ReduceType::Mean) {
                 output_tensor = tt::tt_metal::global_mean(input_tensor, memory_config);
             } else if constexpr (reduce_type == ReduceType::Sum) {
-                output_tensor = tt::tt_metal::global_sum(input_tensor, memory_config);
+                output_tensor = tt::tt_metal::global_sum(input_tensor, memory_config, compute_kernel_config);
             } else if constexpr (reduce_type == ReduceType::Max) {
-                output_tensor = tt::tt_metal::global_max(input_tensor, memory_config);
+                output_tensor = tt::tt_metal::global_max(input_tensor, memory_config, compute_kernel_config);
             } else if constexpr (reduce_type == ReduceType::Min) {
-                output_tensor = tt::tt_metal::global_min(input_tensor, memory_config);
+                output_tensor = tt::tt_metal::global_min(input_tensor, memory_config, compute_kernel_config);
             } else {
                 TT_THROW("Unsupported reduction operation");
             }
@@ -113,25 +114,25 @@ struct Reduce {
 
             if constexpr (reduce_type == ReduceType::Sum) {
                 output_tensor = tt::tt_metal::reduce(
-                    input_tensor, tt::tt_metal::ReduceOpMath::SUM, reduce_op_dim, 1.0, memory_config);
+                    input_tensor, tt::tt_metal::ReduceOpMath::SUM, reduce_op_dim, 1.0, memory_config, std::nullopt, compute_kernel_config);
             } else if constexpr (reduce_type == ReduceType::Mean) {
                 output_tensor = tt::tt_metal::reduce(
-                    input_tensor, tt::tt_metal::ReduceOpMath::SUM, reduce_op_dim, 1.0 / reduced_volume, memory_config);
+                    input_tensor, tt::tt_metal::ReduceOpMath::SUM, reduce_op_dim, 1.0 / reduced_volume, memory_config, std::nullopt, compute_kernel_config);
             } else if constexpr (reduce_type == ReduceType::Max) {
                 output_tensor = tt::tt_metal::reduce(
-                    input_tensor, tt::tt_metal::ReduceOpMath::MAX, reduce_op_dim, 1.0, memory_config);
+                    input_tensor, tt::tt_metal::ReduceOpMath::MAX, reduce_op_dim, 1.0, memory_config, std::nullopt, compute_kernel_config);
             } else if constexpr (reduce_type == ReduceType::Min) {
                 output_tensor = tt::tt_metal::reduce(
-                    input_tensor, tt::tt_metal::ReduceOpMath::MIN, reduce_op_dim, 1.0, memory_config);
+                    input_tensor, tt::tt_metal::ReduceOpMath::MIN, reduce_op_dim, 1.0, memory_config, std::nullopt, compute_kernel_config);
             } else if constexpr (reduce_type == ReduceType::Var or reduce_type == ReduceType::Std) {
                 auto mean_tensor = tt::tt_metal::reduce(
-                    input_tensor, tt::tt_metal::ReduceOpMath::SUM, reduce_op_dim, 1.0 / reduced_volume, memory_config);
+                    input_tensor, tt::tt_metal::ReduceOpMath::SUM, reduce_op_dim, 1.0 / reduced_volume, memory_config, std::nullopt, compute_kernel_config);
                 auto mean_square_tensor = tt::tt_metal::reduce(
                     ttnn::pow(input_tensor, 2.0f, memory_config),
                     tt::tt_metal::ReduceOpMath::SUM,
                     reduce_op_dim,
                     1.0 / reduced_volume,
-                    memory_config);
+                    memory_config, std::nullopt, compute_kernel_config);
                 output_tensor = ttnn::subtract(
                     mean_square_tensor,
                     ttnn::pow(mean_tensor, 2.0f, memory_config),

--- a/ttnn/cpp/ttnn/operations/reduction/generic/generic_reductions_pybind.hpp
+++ b/ttnn/cpp/ttnn/operations/reduction/generic/generic_reductions_pybind.hpp
@@ -26,7 +26,8 @@ void bind_reduction_operation(py::module& module, const reduction_operation_t& o
             py::arg("input_tensor"),
             py::arg("dim") = std::nullopt,
             py::arg("keepdim") = true,
-            py::arg("memory_config") = std::nullopt});
+            py::arg("memory_config") = std::nullopt,
+            py::arg("compute_kernel_config") = std::nullopt});
 }
 
 }  // namespace ttnn::operations::reduction::detail


### PR DESCRIPTION
LLK impl for reduce row has precision issues.
Reduce column doesn't seem to have the same issue.

For reduce sum on row(w) dim the issue is
workedaround by using llk for mm tiles
instead of reduce to achieve the same result.
Reduce w impl of LLK doesn't allow for 32 bit acc
in addition to the precision issues.

32 bit acc is exposed as an option for all reduce
ops.

Math fidelity is exposed for all reduce ops as well to give developers to get perf with math fidelity
in similar fashion to matmul ops.
Current state is that math fidelity is hard coded
to HiFi4 which is the most expensive one.