### PR TITLE
#10883: Update argmax and argmin with operator function

### DIFF
--- a/ttnn/cpp/ttnn/operations/experimental/reduction/argmax/argmax.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/reduction/argmax/argmax.cpp
@@ -24,7 +24,7 @@ Tensor create_mask(const Tensor& input_a, const std::optional<MemoryConfig>& out
     return masked_input;
 }
 // Argmax returns the index of maximum element in the tensor
-Tensor _argmax(const Tensor& input_t, int64_t _dim, bool all, const std::optional<MemoryConfig>& output_mem_config) {
+Tensor ArgmaxOperation::operator()(const Tensor& input_t, int64_t _dim, bool all, const std::optional<MemoryConfig>& output_mem_config) {
 
     auto output_memory_config = output_mem_config.value_or(input_t.memory_config());
     std::vector<Tensor> output_tensors = {Tensor(operation::get_workers_for_op_output({input_t}))};
@@ -134,9 +134,10 @@ Tensor _argmax(const Tensor& input_t, int64_t _dim, bool all, const std::optiona
 
 }
 
-Tensor _argmin(const Tensor& input_a, int64_t _dim, bool all, const std::optional<MemoryConfig>& output_mem_config) {
-    Tensor neg_input = ttnn::neg(input_a, output_mem_config);
-    return _argmax(neg_input, _dim, all, output_mem_config);
+Tensor ArgminOperation::operator()(const Tensor& input_a, int64_t _dim, bool all, const std::optional<MemoryConfig>& output_mem_config) {
+    auto output_memory_config = output_mem_config.value_or(input_a.memory_config());
+    Tensor neg_input = ttnn::neg(input_a, output_memory_config);
+    return ttnn::experimental::argmax(neg_input, _dim, all, output_memory_config);
 }
 
 }  // namespace ttnn::operations::experimental::reduction

--- a/ttnn/cpp/ttnn/operations/experimental/reduction/argmax/argmax.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/reduction/argmax/argmax.hpp
@@ -4,36 +4,27 @@
 
 #pragma once
 
-#include "ttnn/run_operation.hpp"
 #include "ttnn/decorators.hpp"
-#include "ttnn/operations/core/core.hpp"
 
 namespace ttnn {
 namespace operations::experimental {
 
 namespace reduction {
 
-Tensor _argmax(const Tensor& input_t, int64_t _dim, bool all, const std::optional<MemoryConfig>& output_mem_config = std::nullopt);
-Tensor _argmin(const Tensor& input_t, int64_t _dim, bool all, const std::optional<MemoryConfig>& output_mem_config = std::nullopt);
-
-struct ExecuteArgMax {
+struct ArgmaxOperation {
     static Tensor operator()(
         const Tensor& input_tensor,
         int64_t dim,
         bool all,
-        const std::optional<MemoryConfig>& memory_config = std::nullopt) {
-        return _argmax(input_tensor, dim, all, memory_config.value_or(input_tensor.memory_config()));
-    }
+        const std::optional<MemoryConfig>& memory_config = std::nullopt);
 };
 
-struct ExecuteArgMin {
+struct ArgminOperation {
     static Tensor operator()(
         const Tensor& input_tensor,
         int64_t dim,
         bool all,
-        const std::optional<MemoryConfig>& memory_config = std::nullopt) {
-        return _argmin(input_tensor, dim, all, memory_config.value_or(input_tensor.memory_config()));
-    }
+        const std::optional<MemoryConfig>& memory_config = std::nullopt);
 };
 
 }  // namespace reduction
@@ -43,11 +34,11 @@ namespace experimental {
 
 constexpr auto argmax = ttnn::register_operation_with_auto_launch_op<
   "ttnn::experimental::argmax",
-  ttnn::operations::experimental::reduction::ExecuteArgMax>();
+  ttnn::operations::experimental::reduction::ArgmaxOperation>();
 
 constexpr auto argmin = ttnn::register_operation_with_auto_launch_op<
     "ttnn::experimental::argmin",
-    ttnn::operations::experimental::reduction::ExecuteArgMin>();
+    ttnn::operations::experimental::reduction::ArgminOperation>();
 
 }
 }  // namespace ttnn


### PR DESCRIPTION
### Ticket
Link to Github Issue #10883 

Problem description
additional structs used in Argmax , Argmin op

What's changed
Use operator() in Argmax , Argmin op

### Checklist
- [x] [Post commit CI](https://github.com/tenstorrent/tt-metal/pull/10938)
- [x] [model ci test](https://github.com/tenstorrent/tt-metal/actions/runs/10184850847)
- [x] [post commit c++ test](https://github.com/tenstorrent/tt-metal/actions/runs/10184836491)
- [x] [T3000](https://github.com/tenstorrent/tt-metal/actions/runs/10216036799)
- [x] [Device regression](https://github.com/tenstorrent/tt-metal/actions/runs/10216047234)
