### PR TITLE
Add sweeps for pack of bw_ops

### DIFF
--- a/tests/tt_eager/python_api_testing/sweep_tests/generation_funcs.py
+++ b/tests/tt_eager/python_api_testing/sweep_tests/generation_funcs.py
@@ -2028,6 +2028,7 @@ def gen_fmod_args(
     high=10,
     dtype=torch.bfloat16,
     do_sanitize_args=True,
+    coregrid=[],
 ):
     for input_info in gen_scalar_args(
         input_shapes,
@@ -2039,6 +2040,7 @@ def gen_fmod_args(
         high,
         dtype,
         do_sanitize_args=do_sanitize_args,
+        coregrid=coregrid,
     ):
         input_info.update({"value": random.randint(-100, 100) + 0.5})
 

--- a/tests/tt_eager/python_api_testing/sweep_tests/pytorch_ops.py
+++ b/tests/tt_eager/python_api_testing/sweep_tests/pytorch_ops.py
@@ -2004,6 +2004,19 @@ def hypot_bw(x, y, z, *args, **kwargs):
     return [in_data.grad, other_data.grad]
 
 
+def i0_bw(x, y, *args, **kwargs):
+    grad_data = x
+    in_data = y
+
+    in_data.requires_grad = True
+    in_data.retain_grad()
+
+    pyt_y = torch.i0(in_data)
+    pyt_y.backward(gradient=grad_data)
+
+    return in_data.grad
+
+
 def global_avg_pool2d(x, *args, **kwargs):
     output_size = (1, 1)
     x = x.to(torch.float32)

--- a/tests/tt_eager/python_api_testing/sweep_tests/pytorch_ops.py
+++ b/tests/tt_eager/python_api_testing/sweep_tests/pytorch_ops.py
@@ -1922,6 +1922,19 @@ def clamp_bw(x, y, scalar, *args, **kwargs):
     return in_data.grad
 
 
+def fmod_bw(x, y, value, *args, **kwargs):
+    grad_data = x
+    in_data = y
+
+    in_data.requires_grad = True
+
+    pyt_y = torch.fmod(in_data, value)
+    in_data.retain_grad()
+    pyt_y.backward(gradient=grad_data)
+
+    return in_data.grad
+
+
 def frac_bw(x, y, *args, **kwargs):
     grad_data = x
     in_data = y

--- a/tests/tt_eager/python_api_testing/sweep_tests/pytorch_ops.py
+++ b/tests/tt_eager/python_api_testing/sweep_tests/pytorch_ops.py
@@ -1922,6 +1922,19 @@ def clamp_bw(x, y, scalar, *args, **kwargs):
     return in_data.grad
 
 
+def frac_bw(x, y, *args, **kwargs):
+    grad_data = x
+    in_data = y
+
+    in_data.requires_grad = True
+
+    pyt_y = torch.frac(in_data)
+    in_data.retain_grad()
+    pyt_y.backward(gradient=grad_data)
+
+    return in_data.grad
+
+
 def global_avg_pool2d(x, *args, **kwargs):
     output_size = (1, 1)
     x = x.to(torch.float32)

--- a/tests/tt_eager/python_api_testing/sweep_tests/pytorch_ops.py
+++ b/tests/tt_eager/python_api_testing/sweep_tests/pytorch_ops.py
@@ -1935,6 +1935,22 @@ def frac_bw(x, y, *args, **kwargs):
     return in_data.grad
 
 
+def gelu_bw(x, y, *args, **kwargs):
+    grad_data = x
+    in_data = y
+
+    in_data.requires_grad = True
+
+    fast_and_approx = kwargs.pop("fast_and_approx")
+    approximate = "tanh" if fast_and_approx else "none"
+
+    pyt_y = torch.nn.functional.gelu(in_data, approximate=approximate)
+    in_data.retain_grad()
+    pyt_y.backward(gradient=grad_data)
+
+    return in_data.grad
+
+
 def global_avg_pool2d(x, *args, **kwargs):
     output_size = (1, 1)
     x = x.to(torch.float32)

--- a/tests/tt_eager/python_api_testing/sweep_tests/pytorch_ops.py
+++ b/tests/tt_eager/python_api_testing/sweep_tests/pytorch_ops.py
@@ -1964,6 +1964,29 @@ def hardshrink_bw(x, y, _lambda, *args, **kwargs):
     return in_data.grad
 
 
+def hardtanh_bw(x, y, *args, **kwargs):
+    grad_data = x
+    in_data = y
+
+    in_data.requires_grad = True
+
+    if "low" in kwargs and "high" in kwargs:
+        low = kwargs.pop("low")
+        high = kwargs.pop("high")
+        pyt_y = torch.nn.functional.hardtanh(in_data, min_val=low, max_val=high)
+
+        in_data.retain_grad()
+        pyt_y.backward(gradient=grad_data)
+
+    else:
+        pyt_y = torch.nn.functional.hardtanh(in_data)
+
+        in_data.retain_grad()
+        pyt_y.backward(gradient=grad_data)
+
+    return in_data.grad
+
+
 def global_avg_pool2d(x, *args, **kwargs):
     output_size = (1, 1)
     x = x.to(torch.float32)

--- a/tests/tt_eager/python_api_testing/sweep_tests/pytorch_ops.py
+++ b/tests/tt_eager/python_api_testing/sweep_tests/pytorch_ops.py
@@ -1987,6 +1987,23 @@ def hardtanh_bw(x, y, *args, **kwargs):
     return in_data.grad
 
 
+def hypot_bw(x, y, z, *args, **kwargs):
+    grad_data = x
+    in_data = y
+    other_data = z
+
+    in_data.requires_grad = True
+    other_data.requires_grad = True
+
+    in_data.retain_grad()
+    other_data.retain_grad()
+
+    pyt_y = torch.hypot(in_data, other_data)
+    pyt_y.backward(gradient=grad_data)
+
+    return [in_data.grad, other_data.grad]
+
+
 def global_avg_pool2d(x, *args, **kwargs):
     output_size = (1, 1)
     x = x.to(torch.float32)

--- a/tests/tt_eager/python_api_testing/sweep_tests/pytorch_ops.py
+++ b/tests/tt_eager/python_api_testing/sweep_tests/pytorch_ops.py
@@ -1951,6 +1951,19 @@ def gelu_bw(x, y, *args, **kwargs):
     return in_data.grad
 
 
+def hardshrink_bw(x, y, _lambda, *args, **kwargs):
+    grad_data = x
+    in_data = y
+
+    in_data.requires_grad = True
+
+    pyt_y = torch.nn.functional.hardshrink(in_data, _lambda)
+    in_data.retain_grad()
+    pyt_y.backward(gradient=grad_data)
+
+    return in_data.grad
+
+
 def global_avg_pool2d(x, *args, **kwargs):
     output_size = (1, 1)
     x = x.to(torch.float32)

--- a/tests/ttnn/python_api_testing/sweep_tests/op_map.py
+++ b/tests/ttnn/python_api_testing/sweep_tests/op_map.py
@@ -837,4 +837,8 @@ op_map = {
         "tt_op": ttnn_ops.hardshrink_bw,
         "pytorch_op": pytorch_ops.hardshrink_bw,
     },
+    "hardtanh-bw": {
+        "tt_op": ttnn_ops.hardtanh_bw,
+        "pytorch_op": pytorch_ops.hardtanh_bw,
+    },
 }

--- a/tests/ttnn/python_api_testing/sweep_tests/op_map.py
+++ b/tests/ttnn/python_api_testing/sweep_tests/op_map.py
@@ -833,4 +833,8 @@ op_map = {
         "tt_op": ttnn_ops.gelu_bw,
         "pytorch_op": pytorch_ops.gelu_bw,
     },
+    "hardshrink-bw": {
+        "tt_op": ttnn_ops.hardshrink_bw,
+        "pytorch_op": pytorch_ops.hardshrink_bw,
+    },
 }

--- a/tests/ttnn/python_api_testing/sweep_tests/op_map.py
+++ b/tests/ttnn/python_api_testing/sweep_tests/op_map.py
@@ -845,4 +845,8 @@ op_map = {
         "tt_op": ttnn_ops.hypot_bw,
         "pytorch_op": pytorch_ops.hypot_bw,
     },
+    "i0-bw": {
+        "tt_op": ttnn_ops.i0_bw,
+        "pytorch_op": pytorch_ops.i0_bw,
+    },
 }

--- a/tests/ttnn/python_api_testing/sweep_tests/op_map.py
+++ b/tests/ttnn/python_api_testing/sweep_tests/op_map.py
@@ -825,4 +825,8 @@ op_map = {
         "tt_op": ttnn_ops.fmod_bw,
         "pytorch_op": ttnn_pytorch_ops.fmod_bw,
     },
+    "frac-bw": {
+        "tt_op": ttnn_ops.frac_bw,
+        "pytorch_op": pytorch_ops.frac_bw,
+    },
 }

--- a/tests/ttnn/python_api_testing/sweep_tests/op_map.py
+++ b/tests/ttnn/python_api_testing/sweep_tests/op_map.py
@@ -823,7 +823,7 @@ op_map = {
     },
     "fmod-bw": {
         "tt_op": ttnn_ops.fmod_bw,
-        "pytorch_op": ttnn_pytorch_ops.fmod_bw,
+        "pytorch_op": pytorch_ops.fmod_bw,
     },
     "frac-bw": {
         "tt_op": ttnn_ops.frac_bw,

--- a/tests/ttnn/python_api_testing/sweep_tests/op_map.py
+++ b/tests/ttnn/python_api_testing/sweep_tests/op_map.py
@@ -841,4 +841,8 @@ op_map = {
         "tt_op": ttnn_ops.hardtanh_bw,
         "pytorch_op": pytorch_ops.hardtanh_bw,
     },
+    "hypot-bw": {
+        "tt_op": ttnn_ops.hypot_bw,
+        "pytorch_op": pytorch_ops.hypot_bw,
+    },
 }

--- a/tests/ttnn/python_api_testing/sweep_tests/op_map.py
+++ b/tests/ttnn/python_api_testing/sweep_tests/op_map.py
@@ -829,4 +829,8 @@ op_map = {
         "tt_op": ttnn_ops.frac_bw,
         "pytorch_op": pytorch_ops.frac_bw,
     },
+    "gelu-bw": {
+        "tt_op": ttnn_ops.gelu_bw,
+        "pytorch_op": pytorch_ops.gelu_bw,
+    },
 }

--- a/tests/ttnn/python_api_testing/sweep_tests/op_map.py
+++ b/tests/ttnn/python_api_testing/sweep_tests/op_map.py
@@ -821,4 +821,8 @@ op_map = {
         "tt_op": ttnn_ops.logaddexp_bw,
         "pytorch_op": pytorch_ops.logaddexp_bw,
     },
+    "fmod-bw": {
+        "tt_op": ttnn_ops.fmod_bw,
+        "pytorch_op": ttnn_pytorch_ops.fmod_bw,
+    },
 }

--- a/tests/ttnn/python_api_testing/sweep_tests/test_configs/ci_sweep_tests_broken/grayskull/ttnn_backward_hypot_test.yaml
+++ b/tests/ttnn/python_api_testing/sweep_tests/test_configs/ci_sweep_tests_broken/grayskull/ttnn_backward_hypot_test.yaml
@@ -1,0 +1,27 @@
+---
+test-list:
+  - hypot-bw:
+      shape:
+        start-shape: [1, 1, 32, 32]
+        end-shape: [6, 12, 256, 256]
+        interval: [1, 1, 32, 32]
+        num-shapes: 3
+        num-samples: 64
+        args-sampling-strategy: "all"
+      datagen:
+        function: gen_rand
+        args:
+          low: -100
+          high: 100
+      comparison:
+        function: comp_pcc_list
+      args-gen: gen_dtype_layout_device
+      sanitize-args: False
+      output-file: backward_hypot_sweep.csv
+      env:
+        # TT_PCI_DMA_BUF_SIZE: "1048576"
+      args:
+        data-layout: ["TILE"]
+        data-type: ["BFLOAT16", "BFLOAT8_B"]
+        buffer-type: ["DRAM", "L1"]
+        out-buffer-type: ["DRAM", "L1", "SYSTEM_MEMORY"]

--- a/tests/ttnn/python_api_testing/sweep_tests/test_configs/ci_sweep_tests_broken/grayskull/ttnn_backward_hypot_test.yaml
+++ b/tests/ttnn/python_api_testing/sweep_tests/test_configs/ci_sweep_tests_broken/grayskull/ttnn_backward_hypot_test.yaml
@@ -6,7 +6,7 @@ test-list:
         end-shape: [6, 12, 256, 256]
         interval: [1, 1, 32, 32]
         num-shapes: 3
-        num-samples: 64
+        num-samples: 128
         args-sampling-strategy: "all"
       datagen:
         function: gen_rand
@@ -24,4 +24,4 @@ test-list:
         data-layout: ["TILE"]
         data-type: ["BFLOAT16", "BFLOAT8_B"]
         buffer-type: ["DRAM", "L1"]
-        out-buffer-type: ["DRAM", "L1", "SYSTEM_MEMORY"]
+        out-buffer-type: ["DRAM", "L1"]

--- a/tests/ttnn/python_api_testing/sweep_tests/test_configs/ci_sweep_tests_broken/grayskull/ttnn_backward_i0_test.yaml
+++ b/tests/ttnn/python_api_testing/sweep_tests/test_configs/ci_sweep_tests_broken/grayskull/ttnn_backward_i0_test.yaml
@@ -1,0 +1,26 @@
+---
+test-list:
+  - i0-bw:
+      shape:
+        start-shape: [1, 1, 32, 32]
+        end-shape: [6, 12, 256, 256]
+        interval: [1, 1, 32, 32]
+        num-shapes: 2
+        num-samples: 128
+        args-sampling-strategy: "all"
+      datagen:
+        function: gen_rand
+        args:
+          low: -10
+          high: 10
+      comparison:
+        function: comp_pcc
+      args-gen: gen_dtype_layout_device
+      args:
+        data-layout: ["TILE"]
+        data-type: ["BFLOAT16", "BFLOAT8_B"]
+        buffer-type: ["DRAM", "L1"]
+        out-buffer-type: ["DRAM", "L1"]
+      output-file: eltwise_i0_sweep.csv
+      env:
+        # TT_PCI_DMA_BUF_SIZE: "1048576"

--- a/tests/ttnn/python_api_testing/sweep_tests/test_configs/ci_sweep_tests_broken/wormhole/ttnn_backward_hypot_test.yaml
+++ b/tests/ttnn/python_api_testing/sweep_tests/test_configs/ci_sweep_tests_broken/wormhole/ttnn_backward_hypot_test.yaml
@@ -1,0 +1,27 @@
+---
+test-list:
+  - hypot-bw:
+      shape:
+        start-shape: [1, 1, 32, 32]
+        end-shape: [6, 12, 256, 256]
+        interval: [1, 1, 32, 32]
+        num-shapes: 3
+        num-samples: 64
+        args-sampling-strategy: "all"
+      datagen:
+        function: gen_rand
+        args:
+          low: -100
+          high: 100
+      comparison:
+        function: comp_pcc_list
+      args-gen: gen_dtype_layout_device
+      sanitize-args: False
+      output-file: backward_hypot_sweep.csv
+      env:
+        # TT_PCI_DMA_BUF_SIZE: "1048576"
+      args:
+        data-layout: ["TILE"]
+        data-type: ["BFLOAT16", "BFLOAT8_B"]
+        buffer-type: ["DRAM", "L1"]
+        out-buffer-type: ["DRAM", "L1", "SYSTEM_MEMORY"]

--- a/tests/ttnn/python_api_testing/sweep_tests/test_configs/ci_sweep_tests_broken/wormhole/ttnn_backward_hypot_test.yaml
+++ b/tests/ttnn/python_api_testing/sweep_tests/test_configs/ci_sweep_tests_broken/wormhole/ttnn_backward_hypot_test.yaml
@@ -6,7 +6,7 @@ test-list:
         end-shape: [6, 12, 256, 256]
         interval: [1, 1, 32, 32]
         num-shapes: 3
-        num-samples: 64
+        num-samples: 128
         args-sampling-strategy: "all"
       datagen:
         function: gen_rand
@@ -24,4 +24,4 @@ test-list:
         data-layout: ["TILE"]
         data-type: ["BFLOAT16", "BFLOAT8_B"]
         buffer-type: ["DRAM", "L1"]
-        out-buffer-type: ["DRAM", "L1", "SYSTEM_MEMORY"]
+        out-buffer-type: ["DRAM", "L1"]

--- a/tests/ttnn/python_api_testing/sweep_tests/test_configs/ci_sweep_tests_broken/wormhole/ttnn_backward_i0_test.yaml
+++ b/tests/ttnn/python_api_testing/sweep_tests/test_configs/ci_sweep_tests_broken/wormhole/ttnn_backward_i0_test.yaml
@@ -1,0 +1,26 @@
+---
+test-list:
+  - i0-bw:
+      shape:
+        start-shape: [1, 1, 32, 32]
+        end-shape: [6, 12, 256, 256]
+        interval: [1, 1, 32, 32]
+        num-shapes: 2
+        num-samples: 128
+        args-sampling-strategy: "all"
+      datagen:
+        function: gen_rand
+        args:
+          low: -10
+          high: 10
+      comparison:
+        function: comp_pcc
+      args-gen: gen_dtype_layout_device
+      args:
+        data-layout: ["TILE"]
+        data-type: ["BFLOAT16", "BFLOAT8_B"]
+        buffer-type: ["DRAM", "L1"]
+        out-buffer-type: ["DRAM", "L1"]
+      output-file: eltwise_i0_sweep.csv
+      env:
+        # TT_PCI_DMA_BUF_SIZE: "1048576"

--- a/tests/ttnn/python_api_testing/sweep_tests/test_configs/ci_sweep_tests_working/grayskull/ttnn_backward_fmod_test.yaml
+++ b/tests/ttnn/python_api_testing/sweep_tests/test_configs/ci_sweep_tests_working/grayskull/ttnn_backward_fmod_test.yaml
@@ -15,12 +15,12 @@ test-list:
           high: 100
       comparison:
         function: comp_pcc
-      args-gen: gen_scalar_args
+      args-gen: gen_fmod_args
       args:
         data-layout: ["TILE"]
         data-type: ["BFLOAT16", "BFLOAT8_B"]
-        buffer-type: ["DRAM", "L1", "SYSTEM_MEMORY"]
-        out-buffer-type: ["DRAM", "L1", "SYSTEM_MEMORY"]
+        buffer-type: ["DRAM", "L1"]
+        out-buffer-type: ["DRAM", "L1"]
       output-file: backward_fmod_sweep.csv
       env:
         # TT_PCI_DMA_BUF_SIZE: "1048576"
@@ -39,12 +39,12 @@ test-list:
           high: 100
       comparison:
         function: comp_pcc
-      args-gen: gen_scalar_args
+      args-gen: gen_fmod_args
       args:
         data-layout: ["ROW_MAJOR"]
         data-type: ["BFLOAT16", "BFLOAT8_B"]
-        buffer-type: ["DRAM", "L1", "SYSTEM_MEMORY"]
-        out-buffer-type: ["DRAM", "L1", "SYSTEM_MEMORY"]
+        buffer-type: ["DRAM", "L1"]
+        out-buffer-type: ["DRAM", "L1"]
       output-file: backward_fmod_sweep.csv
       env:
         # TT_PCI_DMA_BUF_SIZE: "1048576"

--- a/tests/ttnn/python_api_testing/sweep_tests/test_configs/ci_sweep_tests_working/grayskull/ttnn_backward_fmod_test.yaml
+++ b/tests/ttnn/python_api_testing/sweep_tests/test_configs/ci_sweep_tests_working/grayskull/ttnn_backward_fmod_test.yaml
@@ -1,0 +1,50 @@
+---
+test-list:
+  - fmod-bw:
+      shape:
+        start-shape: [1, 1, 32, 32]
+        end-shape: [6, 12, 256, 256]
+        interval: [1, 1, 32, 32]
+        num-shapes: 2
+        num-samples: 64
+        args-sampling-strategy: "all"
+      datagen:
+        function: gen_rand
+        args:
+          low: -100
+          high: 100
+      comparison:
+        function: comp_pcc
+      args-gen: gen_scalar_args
+      args:
+        data-layout: ["TILE"]
+        data-type: ["BFLOAT16", "BFLOAT8_B"]
+        buffer-type: ["DRAM", "L1", "SYSTEM_MEMORY"]
+        out-buffer-type: ["DRAM", "L1", "SYSTEM_MEMORY"]
+      output-file: backward_fmod_sweep.csv
+      env:
+        # TT_PCI_DMA_BUF_SIZE: "1048576"
+  - fmod-bw:
+      shape:
+        start-shape: [1, 1, 2, 2]
+        end-shape: [6, 12, 256, 256]
+        interval: [1, 1, 1, 2]
+        num-shapes: 2
+        num-samples: 64
+        args-sampling-strategy: "all"
+      datagen:
+        function: gen_rand
+        args:
+          low: -100
+          high: 100
+      comparison:
+        function: comp_pcc
+      args-gen: gen_scalar_args
+      args:
+        data-layout: ["ROW_MAJOR"]
+        data-type: ["BFLOAT16", "BFLOAT8_B"]
+        buffer-type: ["DRAM", "L1", "SYSTEM_MEMORY"]
+        out-buffer-type: ["DRAM", "L1", "SYSTEM_MEMORY"]
+      output-file: backward_fmod_sweep.csv
+      env:
+        # TT_PCI_DMA_BUF_SIZE: "1048576"

--- a/tests/ttnn/python_api_testing/sweep_tests/test_configs/ci_sweep_tests_working/grayskull/ttnn_backward_frac_test.yaml
+++ b/tests/ttnn/python_api_testing/sweep_tests/test_configs/ci_sweep_tests_working/grayskull/ttnn_backward_frac_test.yaml
@@ -1,0 +1,50 @@
+---
+test-list:
+  - frac-bw:
+      shape:
+        start-shape: [1, 1, 32, 32]
+        end-shape: [6, 12, 256, 256]
+        interval: [1, 1, 32, 32]
+        num-shapes: 2
+        num-samples: 64
+        args-sampling-strategy: "all"
+      datagen:
+        function: gen_rand
+        args:
+          low: -100
+          high: 100
+      comparison:
+        function: comp_pcc
+      args-gen: gen_scalar_args
+      args:
+        data-layout: ["TILE"]
+        data-type: ["BFLOAT16", "BFLOAT8_B"]
+        buffer-type: ["DRAM", "L1"]
+        out-buffer-type: ["DRAM", "L1", "SYSTEM_MEMORY"]
+      output-file: backward_frac_sweep.csv
+      env:
+        # TT_PCI_DMA_BUF_SIZE: "1048576"
+  - frac-bw:
+      shape:
+        start-shape: [1, 1, 2, 2]
+        end-shape: [6, 12, 256, 256]
+        interval: [1, 1, 1, 2]
+        num-shapes: 2
+        num-samples: 64
+        args-sampling-strategy: "all"
+      datagen:
+        function: gen_rand
+        args:
+          low: -100
+          high: 100
+      comparison:
+        function: comp_pcc
+      args-gen: gen_scalar_args
+      args:
+        data-layout: ["ROW_MAJOR"]
+        data-type: ["BFLOAT16", "BFLOAT8_B"]
+        buffer-type: ["DRAM", "L1"]
+        out-buffer-type: ["DRAM", "L1", "SYSTEM_MEMORY"]
+      output-file: backward_frac_sweep.csv
+      env:
+        # TT_PCI_DMA_BUF_SIZE: "1048576"

--- a/tests/ttnn/python_api_testing/sweep_tests/test_configs/ci_sweep_tests_working/grayskull/ttnn_backward_frac_test.yaml
+++ b/tests/ttnn/python_api_testing/sweep_tests/test_configs/ci_sweep_tests_working/grayskull/ttnn_backward_frac_test.yaml
@@ -15,12 +15,12 @@ test-list:
           high: 100
       comparison:
         function: comp_pcc
-      args-gen: gen_scalar_args
+      args-gen: gen_dtype_layout_device
       args:
         data-layout: ["TILE"]
         data-type: ["BFLOAT16", "BFLOAT8_B"]
         buffer-type: ["DRAM", "L1"]
-        out-buffer-type: ["DRAM", "L1", "SYSTEM_MEMORY"]
+        out-buffer-type: ["DRAM", "L1"]
       output-file: backward_frac_sweep.csv
       env:
         # TT_PCI_DMA_BUF_SIZE: "1048576"
@@ -39,12 +39,12 @@ test-list:
           high: 100
       comparison:
         function: comp_pcc
-      args-gen: gen_scalar_args
+      args-gen: gen_dtype_layout_device
       args:
         data-layout: ["ROW_MAJOR"]
         data-type: ["BFLOAT16", "BFLOAT8_B"]
         buffer-type: ["DRAM", "L1"]
-        out-buffer-type: ["DRAM", "L1", "SYSTEM_MEMORY"]
+        out-buffer-type: ["DRAM", "L1"]
       output-file: backward_frac_sweep.csv
       env:
         # TT_PCI_DMA_BUF_SIZE: "1048576"

--- a/tests/ttnn/python_api_testing/sweep_tests/test_configs/ci_sweep_tests_working/grayskull/ttnn_backward_gelu_test.yaml
+++ b/tests/ttnn/python_api_testing/sweep_tests/test_configs/ci_sweep_tests_working/grayskull/ttnn_backward_gelu_test.yaml
@@ -6,7 +6,7 @@ test-list:
         end-shape: [6, 12, 256, 256]
         interval: [1, 1, 32, 32]
         num-shapes: 2
-        num-samples: 64
+        num-samples: 128
         args-sampling-strategy: "all"
       datagen:
         function: gen_rand
@@ -20,7 +20,7 @@ test-list:
         data-layout: ["TILE"]
         data-type: ["BFLOAT16"]
         buffer-type: ["DRAM", "L1"]
-        out-buffer-type: ["DRAM", "L1", "SYSTEM_MEMORY"]
+        out-buffer-type: ["DRAM", "L1"]
       output-file: backward_gelu_sweep.csv
       env:
         # TT_PCI_DMA_BUF_SIZE: "1048576"

--- a/tests/ttnn/python_api_testing/sweep_tests/test_configs/ci_sweep_tests_working/grayskull/ttnn_backward_gelu_test.yaml
+++ b/tests/ttnn/python_api_testing/sweep_tests/test_configs/ci_sweep_tests_working/grayskull/ttnn_backward_gelu_test.yaml
@@ -1,0 +1,26 @@
+---
+test-list:
+  - gelu-bw:
+      shape:
+        start-shape: [1, 1, 32, 32]
+        end-shape: [6, 12, 256, 256]
+        interval: [1, 1, 32, 32]
+        num-shapes: 2
+        num-samples: 64
+        args-sampling-strategy: "all"
+      datagen:
+        function: gen_rand
+        args:
+          low: -100
+          high: 100
+      comparison:
+        function: comp_pcc
+      args-gen: gen_fast_and_approx_args
+      args:
+        data-layout: ["TILE"]
+        data-type: ["BFLOAT16"]
+        buffer-type: ["DRAM", "L1"]
+        out-buffer-type: ["DRAM", "L1", "SYSTEM_MEMORY"]
+      output-file: backward_gelu_sweep.csv
+      env:
+        # TT_PCI_DMA_BUF_SIZE: "1048576"

--- a/tests/ttnn/python_api_testing/sweep_tests/test_configs/ci_sweep_tests_working/grayskull/ttnn_backward_hardshrink_test.yaml
+++ b/tests/ttnn/python_api_testing/sweep_tests/test_configs/ci_sweep_tests_working/grayskull/ttnn_backward_hardshrink_test.yaml
@@ -1,0 +1,26 @@
+---
+test-list:
+  - hardshrink-bw:
+      shape:
+        start-shape: [1, 1, 32, 32]
+        end-shape: [6, 12, 256, 256]
+        interval: [1, 1, 32, 32]
+        num-shapes: 2
+        num-samples: 64
+        args-sampling-strategy: "all"
+      datagen:
+        function: gen_rand
+        args:
+          low: -100
+          high: 100
+      comparison:
+        function: comp_pcc
+      args-gen: gen_shrink_args
+      args:
+        data-layout: ["TILE"]
+        data-type: ["BFLOAT16"]
+        buffer-type: ["DRAM", "L1"]
+        out-buffer-type: ["DRAM", "L1", "SYSTEM_MEMORY"]
+      output-file: backward_hardshrink_sweep.csv
+      env:
+        # TT_PCI_DMA_BUF_SIZE: "1048576"

--- a/tests/ttnn/python_api_testing/sweep_tests/test_configs/ci_sweep_tests_working/grayskull/ttnn_backward_hardshrink_test.yaml
+++ b/tests/ttnn/python_api_testing/sweep_tests/test_configs/ci_sweep_tests_working/grayskull/ttnn_backward_hardshrink_test.yaml
@@ -6,7 +6,7 @@ test-list:
         end-shape: [6, 12, 256, 256]
         interval: [1, 1, 32, 32]
         num-shapes: 2
-        num-samples: 64
+        num-samples: 128
         args-sampling-strategy: "all"
       datagen:
         function: gen_rand
@@ -20,7 +20,7 @@ test-list:
         data-layout: ["TILE"]
         data-type: ["BFLOAT16"]
         buffer-type: ["DRAM", "L1"]
-        out-buffer-type: ["DRAM", "L1", "SYSTEM_MEMORY"]
+        out-buffer-type: ["DRAM", "L1"]
       output-file: backward_hardshrink_sweep.csv
       env:
         # TT_PCI_DMA_BUF_SIZE: "1048576"

--- a/tests/ttnn/python_api_testing/sweep_tests/test_configs/ci_sweep_tests_working/grayskull/ttnn_backward_hardtanh_test.yaml
+++ b/tests/ttnn/python_api_testing/sweep_tests/test_configs/ci_sweep_tests_working/grayskull/ttnn_backward_hardtanh_test.yaml
@@ -1,0 +1,26 @@
+---
+test-list:
+  - hardtanh-bw:
+      shape:
+        start-shape: [1, 1, 32, 32]
+        end-shape: [6, 12, 256, 256]
+        interval: [1, 1, 32, 32]
+        num-shapes: 2
+        num-samples: 64
+        args-sampling-strategy: "all"
+      datagen:
+        function: gen_rand
+        args:
+          low: -100
+          high: 100
+      comparison:
+        function: comp_pcc
+      args-gen: gen_dtype_layout_device
+      args:
+        data-layout: ["TILE"]
+        data-type: ["BFLOAT16"]
+        buffer-type: ["DRAM", "L1"]
+        out-buffer-type: ["DRAM", "L1", "SYSTEM_MEMORY"]
+      output-file: backward_hardtanh_sweep.csv
+      env:
+        # TT_PCI_DMA_BUF_SIZE: "1048576"

--- a/tests/ttnn/python_api_testing/sweep_tests/test_configs/ci_sweep_tests_working/grayskull/ttnn_backward_hardtanh_test.yaml
+++ b/tests/ttnn/python_api_testing/sweep_tests/test_configs/ci_sweep_tests_working/grayskull/ttnn_backward_hardtanh_test.yaml
@@ -6,7 +6,7 @@ test-list:
         end-shape: [6, 12, 256, 256]
         interval: [1, 1, 32, 32]
         num-shapes: 2
-        num-samples: 64
+        num-samples: 128
         args-sampling-strategy: "all"
       datagen:
         function: gen_rand
@@ -20,7 +20,7 @@ test-list:
         data-layout: ["TILE"]
         data-type: ["BFLOAT16"]
         buffer-type: ["DRAM", "L1"]
-        out-buffer-type: ["DRAM", "L1", "SYSTEM_MEMORY"]
+        out-buffer-type: ["DRAM", "L1"]
       output-file: backward_hardtanh_sweep.csv
       env:
         # TT_PCI_DMA_BUF_SIZE: "1048576"

--- a/tests/ttnn/python_api_testing/sweep_tests/test_configs/ci_sweep_tests_working/wormhole/ttnn_backward_fmod_test.yaml
+++ b/tests/ttnn/python_api_testing/sweep_tests/test_configs/ci_sweep_tests_working/wormhole/ttnn_backward_fmod_test.yaml
@@ -1,0 +1,50 @@
+---
+test-list:
+  - fmod-bw:
+      shape:
+        start-shape: [1, 1, 32, 32]
+        end-shape: [6, 12, 256, 256]
+        interval: [1, 1, 32, 32]
+        num-shapes: 2
+        num-samples: 64
+        args-sampling-strategy: "all"
+      datagen:
+        function: gen_rand
+        args:
+          low: -100
+          high: 100
+      comparison:
+        function: comp_pcc
+      args-gen: gen_scalar_args
+      args:
+        data-layout: ["TILE"]
+        data-type: ["BFLOAT16", "BFLOAT8_B"]
+        buffer-type: ["DRAM", "L1"]
+        out-buffer-type: ["DRAM", "L1", "SYSTEM_MEMORY"]
+      output-file: backward_fmod_sweep.csv
+      env:
+        # TT_PCI_DMA_BUF_SIZE: "1048576"
+  - fmod-bw:
+      shape:
+        start-shape: [1, 1, 2, 2]
+        end-shape: [6, 12, 256, 256]
+        interval: [1, 1, 1, 2]
+        num-shapes: 2
+        num-samples: 64
+        args-sampling-strategy: "all"
+      datagen:
+        function: gen_rand
+        args:
+          low: -100
+          high: 100
+      comparison:
+        function: comp_pcc
+      args-gen: gen_scalar_args
+      args:
+        data-layout: ["ROW_MAJOR"]
+        data-type: ["BFLOAT16", "BFLOAT8_B"]
+        buffer-type: ["DRAM", "L1"]
+        out-buffer-type: ["DRAM", "L1", "SYSTEM_MEMORY"]
+      output-file: backward_fmod_sweep.csv
+      env:
+        # TT_PCI_DMA_BUF_SIZE: "1048576"

--- a/tests/ttnn/python_api_testing/sweep_tests/test_configs/ci_sweep_tests_working/wormhole/ttnn_backward_fmod_test.yaml
+++ b/tests/ttnn/python_api_testing/sweep_tests/test_configs/ci_sweep_tests_working/wormhole/ttnn_backward_fmod_test.yaml
@@ -15,12 +15,12 @@ test-list:
           high: 100
       comparison:
         function: comp_pcc
-      args-gen: gen_scalar_args
+      args-gen: gen_fmod_args
       args:
         data-layout: ["TILE"]
         data-type: ["BFLOAT16", "BFLOAT8_B"]
         buffer-type: ["DRAM", "L1"]
-        out-buffer-type: ["DRAM", "L1", "SYSTEM_MEMORY"]
+        out-buffer-type: ["DRAM", "L1"]
       output-file: backward_fmod_sweep.csv
       env:
         # TT_PCI_DMA_BUF_SIZE: "1048576"
@@ -39,12 +39,12 @@ test-list:
           high: 100
       comparison:
         function: comp_pcc
-      args-gen: gen_scalar_args
+      args-gen: gen_fmod_args
       args:
         data-layout: ["ROW_MAJOR"]
         data-type: ["BFLOAT16", "BFLOAT8_B"]
         buffer-type: ["DRAM", "L1"]
-        out-buffer-type: ["DRAM", "L1", "SYSTEM_MEMORY"]
+        out-buffer-type: ["DRAM", "L1"]
       output-file: backward_fmod_sweep.csv
       env:
         # TT_PCI_DMA_BUF_SIZE: "1048576"

--- a/tests/ttnn/python_api_testing/sweep_tests/test_configs/ci_sweep_tests_working/wormhole/ttnn_backward_frac_test.yaml
+++ b/tests/ttnn/python_api_testing/sweep_tests/test_configs/ci_sweep_tests_working/wormhole/ttnn_backward_frac_test.yaml
@@ -1,0 +1,50 @@
+---
+test-list:
+  - frac-bw:
+      shape:
+        start-shape: [1, 1, 32, 32]
+        end-shape: [6, 12, 256, 256]
+        interval: [1, 1, 32, 32]
+        num-shapes: 2
+        num-samples: 64
+        args-sampling-strategy: "all"
+      datagen:
+        function: gen_rand
+        args:
+          low: -100
+          high: 100
+      comparison:
+        function: comp_pcc
+      args-gen: gen_scalar_args
+      args:
+        data-layout: ["TILE"]
+        data-type: ["BFLOAT16", "BFLOAT8_B"]
+        buffer-type: ["DRAM", "L1"]
+        out-buffer-type: ["DRAM", "L1", "SYSTEM_MEMORY"]
+      output-file: backward_frac_sweep.csv
+      env:
+        # TT_PCI_DMA_BUF_SIZE: "1048576"
+  - frac-bw:
+      shape:
+        start-shape: [1, 1, 2, 2]
+        end-shape: [6, 12, 256, 256]
+        interval: [1, 1, 1, 2]
+        num-shapes: 2
+        num-samples: 64
+        args-sampling-strategy: "all"
+      datagen:
+        function: gen_rand
+        args:
+          low: -100
+          high: 100
+      comparison:
+        function: comp_pcc
+      args-gen: gen_scalar_args
+      args:
+        data-layout: ["ROW_MAJOR"]
+        data-type: ["BFLOAT16", "BFLOAT8_B"]
+        buffer-type: ["DRAM", "L1", "SYSTEM_MEMORY"]
+        out-buffer-type: ["DRAM", "L1", "SYSTEM_MEMORY"]
+      output-file: backward_frac_sweep.csv
+      env:
+        # TT_PCI_DMA_BUF_SIZE: "1048576"

--- a/tests/ttnn/python_api_testing/sweep_tests/test_configs/ci_sweep_tests_working/wormhole/ttnn_backward_frac_test.yaml
+++ b/tests/ttnn/python_api_testing/sweep_tests/test_configs/ci_sweep_tests_working/wormhole/ttnn_backward_frac_test.yaml
@@ -15,12 +15,12 @@ test-list:
           high: 100
       comparison:
         function: comp_pcc
-      args-gen: gen_scalar_args
+      args-gen: gen_dtype_layout_device
       args:
         data-layout: ["TILE"]
         data-type: ["BFLOAT16", "BFLOAT8_B"]
         buffer-type: ["DRAM", "L1"]
-        out-buffer-type: ["DRAM", "L1", "SYSTEM_MEMORY"]
+        out-buffer-type: ["DRAM", "L1"]
       output-file: backward_frac_sweep.csv
       env:
         # TT_PCI_DMA_BUF_SIZE: "1048576"
@@ -39,12 +39,12 @@ test-list:
           high: 100
       comparison:
         function: comp_pcc
-      args-gen: gen_scalar_args
+      args-gen: gen_dtype_layout_device
       args:
         data-layout: ["ROW_MAJOR"]
         data-type: ["BFLOAT16", "BFLOAT8_B"]
-        buffer-type: ["DRAM", "L1", "SYSTEM_MEMORY"]
-        out-buffer-type: ["DRAM", "L1", "SYSTEM_MEMORY"]
+        buffer-type: ["DRAM", "L1"]
+        out-buffer-type: ["DRAM", "L1"]
       output-file: backward_frac_sweep.csv
       env:
         # TT_PCI_DMA_BUF_SIZE: "1048576"

--- a/tests/ttnn/python_api_testing/sweep_tests/test_configs/ci_sweep_tests_working/wormhole/ttnn_backward_gelu_test.yaml
+++ b/tests/ttnn/python_api_testing/sweep_tests/test_configs/ci_sweep_tests_working/wormhole/ttnn_backward_gelu_test.yaml
@@ -6,7 +6,7 @@ test-list:
         end-shape: [6, 12, 256, 256]
         interval: [1, 1, 32, 32]
         num-shapes: 2
-        num-samples: 64
+        num-samples: 128
         args-sampling-strategy: "all"
       datagen:
         function: gen_rand
@@ -20,7 +20,7 @@ test-list:
         data-layout: ["TILE"]
         data-type: ["BFLOAT16"]
         buffer-type: ["DRAM", "L1"]
-        out-buffer-type: ["DRAM", "L1", "SYSTEM_MEMORY"]
+        out-buffer-type: ["DRAM", "L1"]
       output-file: backward_gelu_sweep.csv
       env:
         # TT_PCI_DMA_BUF_SIZE: "1048576"

--- a/tests/ttnn/python_api_testing/sweep_tests/test_configs/ci_sweep_tests_working/wormhole/ttnn_backward_gelu_test.yaml
+++ b/tests/ttnn/python_api_testing/sweep_tests/test_configs/ci_sweep_tests_working/wormhole/ttnn_backward_gelu_test.yaml
@@ -1,0 +1,26 @@
+---
+test-list:
+  - gelu-bw:
+      shape:
+        start-shape: [1, 1, 32, 32]
+        end-shape: [6, 12, 256, 256]
+        interval: [1, 1, 32, 32]
+        num-shapes: 2
+        num-samples: 64
+        args-sampling-strategy: "all"
+      datagen:
+        function: gen_rand
+        args:
+          low: -100
+          high: 100
+      comparison:
+        function: comp_pcc
+      args-gen: gen_fast_and_approx_args
+      args:
+        data-layout: ["TILE"]
+        data-type: ["BFLOAT16"]
+        buffer-type: ["DRAM", "L1"]
+        out-buffer-type: ["DRAM", "L1", "SYSTEM_MEMORY"]
+      output-file: backward_gelu_sweep.csv
+      env:
+        # TT_PCI_DMA_BUF_SIZE: "1048576"

--- a/tests/ttnn/python_api_testing/sweep_tests/test_configs/ci_sweep_tests_working/wormhole/ttnn_backward_hardshrink_test.yaml
+++ b/tests/ttnn/python_api_testing/sweep_tests/test_configs/ci_sweep_tests_working/wormhole/ttnn_backward_hardshrink_test.yaml
@@ -1,0 +1,26 @@
+---
+test-list:
+  - hardshrink-bw:
+      shape:
+        start-shape: [1, 1, 32, 32]
+        end-shape: [6, 12, 256, 256]
+        interval: [1, 1, 32, 32]
+        num-shapes: 2
+        num-samples: 64
+        args-sampling-strategy: "all"
+      datagen:
+        function: gen_rand
+        args:
+          low: -100
+          high: 100
+      comparison:
+        function: comp_pcc
+      args-gen: gen_shrink_args
+      args:
+        data-layout: ["TILE"]
+        data-type: ["BFLOAT16"]
+        buffer-type: ["DRAM", "L1"]
+        out-buffer-type: ["DRAM", "L1", "SYSTEM_MEMORY"]
+      output-file: backward_hardshrink_sweep.csv
+      env:
+        # TT_PCI_DMA_BUF_SIZE: "1048576"

--- a/tests/ttnn/python_api_testing/sweep_tests/test_configs/ci_sweep_tests_working/wormhole/ttnn_backward_hardshrink_test.yaml
+++ b/tests/ttnn/python_api_testing/sweep_tests/test_configs/ci_sweep_tests_working/wormhole/ttnn_backward_hardshrink_test.yaml
@@ -6,7 +6,7 @@ test-list:
         end-shape: [6, 12, 256, 256]
         interval: [1, 1, 32, 32]
         num-shapes: 2
-        num-samples: 64
+        num-samples: 128
         args-sampling-strategy: "all"
       datagen:
         function: gen_rand
@@ -20,7 +20,7 @@ test-list:
         data-layout: ["TILE"]
         data-type: ["BFLOAT16"]
         buffer-type: ["DRAM", "L1"]
-        out-buffer-type: ["DRAM", "L1", "SYSTEM_MEMORY"]
+        out-buffer-type: ["DRAM", "L1"]
       output-file: backward_hardshrink_sweep.csv
       env:
         # TT_PCI_DMA_BUF_SIZE: "1048576"

--- a/tests/ttnn/python_api_testing/sweep_tests/test_configs/ci_sweep_tests_working/wormhole/ttnn_backward_hardtanh_test.yaml
+++ b/tests/ttnn/python_api_testing/sweep_tests/test_configs/ci_sweep_tests_working/wormhole/ttnn_backward_hardtanh_test.yaml
@@ -1,0 +1,26 @@
+---
+test-list:
+  - hardtanh-bw:
+      shape:
+        start-shape: [1, 1, 32, 32]
+        end-shape: [6, 12, 256, 256]
+        interval: [1, 1, 32, 32]
+        num-shapes: 2
+        num-samples: 64
+        args-sampling-strategy: "all"
+      datagen:
+        function: gen_rand
+        args:
+          low: -100
+          high: 100
+      comparison:
+        function: comp_pcc
+      args-gen: gen_dtype_layout_device
+      args:
+        data-layout: ["TILE"]
+        data-type: ["BFLOAT16"]
+        buffer-type: ["DRAM", "L1"]
+        out-buffer-type: ["DRAM", "L1", "SYSTEM_MEMORY"]
+      output-file: backward_hardtanh_sweep.csv
+      env:
+        # TT_PCI_DMA_BUF_SIZE: "1048576"

--- a/tests/ttnn/python_api_testing/sweep_tests/test_configs/ci_sweep_tests_working/wormhole/ttnn_backward_hardtanh_test.yaml
+++ b/tests/ttnn/python_api_testing/sweep_tests/test_configs/ci_sweep_tests_working/wormhole/ttnn_backward_hardtanh_test.yaml
@@ -6,7 +6,7 @@ test-list:
         end-shape: [6, 12, 256, 256]
         interval: [1, 1, 32, 32]
         num-shapes: 2
-        num-samples: 64
+        num-samples: 128
         args-sampling-strategy: "all"
       datagen:
         function: gen_rand
@@ -20,7 +20,7 @@ test-list:
         data-layout: ["TILE"]
         data-type: ["BFLOAT16"]
         buffer-type: ["DRAM", "L1"]
-        out-buffer-type: ["DRAM", "L1", "SYSTEM_MEMORY"]
+        out-buffer-type: ["DRAM", "L1"]
       output-file: backward_hardtanh_sweep.csv
       env:
         # TT_PCI_DMA_BUF_SIZE: "1048576"

--- a/tests/ttnn/python_api_testing/sweep_tests/ttnn_ops.py
+++ b/tests/ttnn/python_api_testing/sweep_tests/ttnn_ops.py
@@ -3846,7 +3846,7 @@ def fmod_bw(
     x,  # grad_tensor
     y,  # input_tensor
     *args,
-    scalar,
+    value,
     device,
     dtype,
     layout,
@@ -3856,8 +3856,8 @@ def fmod_bw(
 ):
     t0 = setup_ttnn_tensor(x, device, layout[0], input_mem_config[0], dtype[0])
     t1 = setup_ttnn_tensor(y, device, layout[1], input_mem_config[1], dtype[1])
-    
-    t3 = ttnn.fmod_bw(t0, t1, scalar, memory_config=output_mem_config)[0]
+
+    t3 = ttnn.fmod_bw(t0, t1, value, memory_config=output_mem_config)[0]
 
     return ttnn_tensor_to_torch(t3)
 

--- a/tests/ttnn/python_api_testing/sweep_tests/ttnn_ops.py
+++ b/tests/ttnn/python_api_testing/sweep_tests/ttnn_ops.py
@@ -3882,6 +3882,25 @@ def eltwise_subalpha(
     return ttnn_tensor_to_torch(t2)
 
 
+def frac_bw(
+    x,  # grad_tensor
+    y,  # input_tensor
+    *args,
+    device,
+    dtype,
+    layout,
+    input_mem_config,
+    output_mem_config,
+    **kwargs,
+):
+    t0 = setup_ttnn_tensor(x, device, layout[0], input_mem_config[0], dtype[0])
+    t1 = setup_ttnn_tensor(y, device, layout[1], input_mem_config[1], dtype[1])
+
+    t3 = ttnn.frac_bw(t0, t1, memory_config=output_mem_config)[0]
+
+    return ttnn_tensor_to_torch(t3)
+
+
 def log2_bw(
     x,
     y,

--- a/tests/ttnn/python_api_testing/sweep_tests/ttnn_ops.py
+++ b/tests/ttnn/python_api_testing/sweep_tests/ttnn_ops.py
@@ -4036,3 +4036,21 @@ def hardshrink_bw(
     return ttnn_tensor_to_torch(t3)
 >>>>>>> #10147: Added hardsrhink_bw sweeps to ttnn
 
+
+def hardtanh_bw(
+    x,  # grad_tensor
+    y,  # input_tensor
+    *args,
+    device,
+    dtype,
+    layout,
+    input_mem_config,
+    output_mem_config,
+    **kwargs,
+):
+    t0 = setup_ttnn_tensor(x, device, layout[0], input_mem_config[0], dtype[0])
+    t1 = setup_ttnn_tensor(y, device, layout[1], input_mem_config[1], dtype[1])
+
+    t3 = ttnn.hardtanh_bw(t0, t1, memory_config=output_mem_config)[0]
+
+    return ttnn_tensor_to_torch(t3)

--- a/tests/ttnn/python_api_testing/sweep_tests/ttnn_ops.py
+++ b/tests/ttnn/python_api_testing/sweep_tests/ttnn_ops.py
@@ -4075,3 +4075,22 @@ def hypot_bw(
     t3 = ttnn.hypot_bw(t0, t1, t2, memory_config=output_mem_config)
 
     return [ttnn_tensor_to_torch(t3[0]), ttnn_tensor_to_torch(t3[1])]
+
+
+def i0_bw(
+    x,  # grad_tensor
+    y,  # input_tensor
+    *args,
+    device,
+    dtype,
+    layout,
+    input_mem_config,
+    output_mem_config,
+    **kwargs,
+):
+    t0 = setup_ttnn_tensor(x, device, layout[0], input_mem_config[0], dtype[0])
+    t1 = setup_ttnn_tensor(y, device, layout[1], input_mem_config[1], dtype[1])
+
+    t3 = ttnn.i0_bw(t0, t1, memory_config=output_mem_config)[0]
+
+    return ttnn_tensor_to_torch(t3)

--- a/tests/ttnn/python_api_testing/sweep_tests/ttnn_ops.py
+++ b/tests/ttnn/python_api_testing/sweep_tests/ttnn_ops.py
@@ -3842,6 +3842,26 @@ def log10_bw(
     return ttnn_tensor_to_torch(t2)
 
 
+def fmod_bw(
+    x,  # grad_tensor
+    y,  # input_tensor
+    *args,
+    scalar,
+    device,
+    dtype,
+    layout,
+    input_mem_config,
+    output_mem_config,
+    **kwargs,
+):
+    t0 = setup_ttnn_tensor(x, device, layout[0], input_mem_config[0], dtype[0])
+    t1 = setup_ttnn_tensor(y, device, layout[1], input_mem_config[1], dtype[1])
+    
+    t3 = ttnn.fmod_bw(t0, t1, scalar, memory_config=output_mem_config)[0]
+
+    return ttnn_tensor_to_torch(t3)
+
+
 def eltwise_subalpha(
     x,
     y,

--- a/tests/ttnn/python_api_testing/sweep_tests/ttnn_ops.py
+++ b/tests/ttnn/python_api_testing/sweep_tests/ttnn_ops.py
@@ -3857,9 +3857,9 @@ def fmod_bw(
     t0 = setup_ttnn_tensor(x, device, layout[0], input_mem_config[0], dtype[0])
     t1 = setup_ttnn_tensor(y, device, layout[1], input_mem_config[1], dtype[1])
 
-    t3 = ttnn.fmod_bw(t0, t1, value, memory_config=output_mem_config)[0]
+    t2 = ttnn.fmod_bw(t0, t1, value, memory_config=output_mem_config)[0]
 
-    return ttnn_tensor_to_torch(t3)
+    return ttnn_tensor_to_torch(t2)
 
 
 def eltwise_subalpha(
@@ -3896,9 +3896,9 @@ def frac_bw(
     t0 = setup_ttnn_tensor(x, device, layout[0], input_mem_config[0], dtype[0])
     t1 = setup_ttnn_tensor(y, device, layout[1], input_mem_config[1], dtype[1])
 
-    t3 = ttnn.frac_bw(t0, t1, memory_config=output_mem_config)[0]
+    t2 = ttnn.frac_bw(t0, t1, memory_config=output_mem_config)[0]
 
-    return ttnn_tensor_to_torch(t3)
+    return ttnn_tensor_to_torch(t2)
 
 
 def log2_bw(
@@ -3937,9 +3937,9 @@ def gelu_bw(
 
     approximate = "tanh" if fast_and_approx else "none"
 
-    t3 = ttnn.gelu_bw(t0, t1, approximate=approximate, memory_config=output_mem_config)[0]
+    t2 = ttnn.gelu_bw(t0, t1, approximate=approximate, memory_config=output_mem_config)[0]
 
-    return ttnn_tensor_to_torch(t3)
+    return ttnn_tensor_to_torch(t2)
 
 
 def log1p_bw(
@@ -3957,11 +3957,10 @@ def log1p_bw(
     t1 = setup_ttnn_tensor(y, device, layout[1], input_mem_config[1], dtype[1])
 
     t2 = ttnn.log1p_bw(t0, t1, memory_config=output_mem_config)[0]
-    
+
     return ttnn_tensor_to_torch(t2)
 
 
-<<<<<<< HEAD
 def log_sigmoid_bw(
     x,
     y,
@@ -4007,13 +4006,6 @@ def logaddexp2_bw(
     y,  # input_tensor
     z,  # other_tensor
     *args,
-=======
-def hardshrink_bw(
-    x,  # grad_tensor
-    y,  # input_tensor
-    *args,
-    _lambda,
->>>>>>> #10147: Added hardsrhink_bw sweeps to ttnn
     device,
     dtype,
     layout,
@@ -4023,18 +4015,31 @@ def hardshrink_bw(
 ):
     t0 = setup_ttnn_tensor(x, device, layout[0], input_mem_config[0], dtype[0])
     t1 = setup_ttnn_tensor(y, device, layout[1], input_mem_config[1], dtype[1])
-<<<<<<< HEAD
     t2 = setup_ttnn_tensor(z, device, layout[2], input_mem_config[2], dtype[2])
 
     t3 = ttnn.logaddexp2_bw(t0, t1, t2, memory_config=output_mem_config)
 
     return [ttnn_tensor_to_torch(t3[0]), ttnn_tensor_to_torch(t3[1])]
-=======
 
-    t3 = ttnn.hardshrink_bw(t0, t1, lambd=_lambda, memory_config=output_mem_config)[0]
 
-    return ttnn_tensor_to_torch(t3)
->>>>>>> #10147: Added hardsrhink_bw sweeps to ttnn
+def hardshrink_bw(
+    x,  # grad_tensor
+    y,  # input_tensor
+    *args,
+    _lambda,
+    device,
+    dtype,
+    layout,
+    input_mem_config,
+    output_mem_config,
+    **kwargs,
+):
+    t0 = setup_ttnn_tensor(x, device, layout[0], input_mem_config[0], dtype[0])
+    t1 = setup_ttnn_tensor(y, device, layout[1], input_mem_config[1], dtype[1])
+
+    t2 = ttnn.hardshrink_bw(t0, t1, lambd=_lambda, memory_config=output_mem_config)[0]
+
+    return ttnn_tensor_to_torch(t2)
 
 
 def hardtanh_bw(
@@ -4051,9 +4056,9 @@ def hardtanh_bw(
     t0 = setup_ttnn_tensor(x, device, layout[0], input_mem_config[0], dtype[0])
     t1 = setup_ttnn_tensor(y, device, layout[1], input_mem_config[1], dtype[1])
 
-    t3 = ttnn.hardtanh_bw(t0, t1, memory_config=output_mem_config)[0]
+    t2 = ttnn.hardtanh_bw(t0, t1, memory_config=output_mem_config)[0]
 
-    return ttnn_tensor_to_torch(t3)
+    return ttnn_tensor_to_torch(t2)
 
 
 def hypot_bw(
@@ -4091,6 +4096,6 @@ def i0_bw(
     t0 = setup_ttnn_tensor(x, device, layout[0], input_mem_config[0], dtype[0])
     t1 = setup_ttnn_tensor(y, device, layout[1], input_mem_config[1], dtype[1])
 
-    t3 = ttnn.i0_bw(t0, t1, memory_config=output_mem_config)[0]
+    t2 = ttnn.i0_bw(t0, t1, memory_config=output_mem_config)[0]
 
-    return ttnn_tensor_to_torch(t3)
+    return ttnn_tensor_to_torch(t2)

--- a/tests/ttnn/python_api_testing/sweep_tests/ttnn_ops.py
+++ b/tests/ttnn/python_api_testing/sweep_tests/ttnn_ops.py
@@ -3920,6 +3920,28 @@ def log2_bw(
     return ttnn_tensor_to_torch(t2)
 
 
+def gelu_bw(
+    x,  # grad_tensor
+    y,  # input_tensor
+    *args,
+    fast_and_approx,
+    device,
+    dtype,
+    layout,
+    input_mem_config,
+    output_mem_config,
+    **kwargs,
+):
+    t0 = setup_ttnn_tensor(x, device, layout[0], input_mem_config[0], dtype[0])
+    t1 = setup_ttnn_tensor(y, device, layout[1], input_mem_config[1], dtype[1])
+
+    approximate = "tanh" if fast_and_approx else "none"
+
+    t3 = ttnn.gelu_bw(t0, t1, approximate=approximate, memory_config=output_mem_config)[0]
+
+    return ttnn_tensor_to_torch(t3)
+
+
 def log1p_bw(
     x,
     y,
@@ -3998,3 +4020,4 @@ def logaddexp2_bw(
     t3 = ttnn.logaddexp2_bw(t0, t1, t2, memory_config=output_mem_config)
 
     return [ttnn_tensor_to_torch(t3[0]), ttnn_tensor_to_torch(t3[1])]
+

--- a/tests/ttnn/python_api_testing/sweep_tests/ttnn_ops.py
+++ b/tests/ttnn/python_api_testing/sweep_tests/ttnn_ops.py
@@ -4054,3 +4054,24 @@ def hardtanh_bw(
     t3 = ttnn.hardtanh_bw(t0, t1, memory_config=output_mem_config)[0]
 
     return ttnn_tensor_to_torch(t3)
+
+
+def hypot_bw(
+    x,  # grad_tensor
+    y,  # input_tensor
+    z,  # other_tensor
+    *args,
+    device,
+    dtype,
+    layout,
+    input_mem_config,
+    output_mem_config,
+    **kwargs,
+):
+    t0 = setup_ttnn_tensor(x, device, layout[0], input_mem_config[0], dtype[0])
+    t1 = setup_ttnn_tensor(y, device, layout[1], input_mem_config[1], dtype[1])
+    t2 = setup_ttnn_tensor(z, device, layout[2], input_mem_config[2], dtype[2])
+
+    t3 = ttnn.hypot_bw(t0, t1, t2, memory_config=output_mem_config)
+
+    return [ttnn_tensor_to_torch(t3[0]), ttnn_tensor_to_torch(t3[1])]

--- a/tests/ttnn/python_api_testing/sweep_tests/ttnn_ops.py
+++ b/tests/ttnn/python_api_testing/sweep_tests/ttnn_ops.py
@@ -3957,10 +3957,11 @@ def log1p_bw(
     t1 = setup_ttnn_tensor(y, device, layout[1], input_mem_config[1], dtype[1])
 
     t2 = ttnn.log1p_bw(t0, t1, memory_config=output_mem_config)[0]
-
+    
     return ttnn_tensor_to_torch(t2)
 
 
+<<<<<<< HEAD
 def log_sigmoid_bw(
     x,
     y,
@@ -4006,6 +4007,13 @@ def logaddexp2_bw(
     y,  # input_tensor
     z,  # other_tensor
     *args,
+=======
+def hardshrink_bw(
+    x,  # grad_tensor
+    y,  # input_tensor
+    *args,
+    _lambda,
+>>>>>>> #10147: Added hardsrhink_bw sweeps to ttnn
     device,
     dtype,
     layout,
@@ -4015,9 +4023,16 @@ def logaddexp2_bw(
 ):
     t0 = setup_ttnn_tensor(x, device, layout[0], input_mem_config[0], dtype[0])
     t1 = setup_ttnn_tensor(y, device, layout[1], input_mem_config[1], dtype[1])
+<<<<<<< HEAD
     t2 = setup_ttnn_tensor(z, device, layout[2], input_mem_config[2], dtype[2])
 
     t3 = ttnn.logaddexp2_bw(t0, t1, t2, memory_config=output_mem_config)
 
     return [ttnn_tensor_to_torch(t3[0]), ttnn_tensor_to_torch(t3[1])]
+=======
+
+    t3 = ttnn.hardshrink_bw(t0, t1, lambd=_lambda, memory_config=output_mem_config)[0]
+
+    return ttnn_tensor_to_torch(t3)
+>>>>>>> #10147: Added hardsrhink_bw sweeps to ttnn
 

--- a/tests/ttnn/python_api_testing/sweep_tests/ttnn_pytorch_ops.py
+++ b/tests/ttnn/python_api_testing/sweep_tests/ttnn_pytorch_ops.py
@@ -239,15 +239,3 @@ def preprocessing_model_bert_4(x, *args, **kwargs):
     )
 
     return torch_output.start_logits
-
-
-def fmod_bw(x, y, scalar, *args, **kwarg):
-    grad_data = x
-    in_data = y
-    in_data.requires_grad = True
-
-    in_data.retain_grad()
-    golden_function = ttnn.get_golden_function(ttnn.fmod_bw)
-    torch_output = golden_function(grad_data, in_data, scalar)
-
-    return torch_output[0]

--- a/tests/ttnn/python_api_testing/sweep_tests/ttnn_pytorch_ops.py
+++ b/tests/ttnn/python_api_testing/sweep_tests/ttnn_pytorch_ops.py
@@ -239,3 +239,15 @@ def preprocessing_model_bert_4(x, *args, **kwargs):
     )
 
     return torch_output.start_logits
+
+
+def fmod_bw(x, y, scalar, *args, **kwarg):
+    grad_data = x
+    in_data = y
+    in_data.requires_grad = True
+
+    in_data.retain_grad()
+    golden_function = ttnn.get_golden_function(ttnn.fmod_bw)
+    torch_output = golden_function(grad_data, in_data, scalar)
+
+    return torch_output[0]


### PR DESCRIPTION
### Ticket
[Link to Github Issue](https://github.com/tenstorrent/tt-metal/issues/10147)

### Problem description
Missing sweeps YAML files and API calls for:
- fmod_bw
- frac_bw
- gelu_bw
- hardshrink_bw
- hardtanh_bw
- hypot_bw
- i0_bw

### What's changed
Added YAML files (GS and WH), mappings in ttnn/op_map.py, API calls in ttnn_ops.py and corresponding golden functions in tt_eager/pytorch_ops.py for:
- [x] fmod_bw
- [x] frac_bw
- [x] gelu_bw
- [x] hardshrink_bw
- [x] hardtanh_bw
- [x] hypot_bw
- [x] i0_bw