### PR TITLE
unpin python 3.8 venv dependency

### DIFF
--- a/.github/actions/install-metal-deps/dependencies.json
+++ b/.github/actions/install-metal-deps/dependencies.json
@@ -2,7 +2,7 @@
   "ubuntu-20.04": [
     "software-properties-common=0.99.9.12",
     "build-essential=12.8ubuntu1.1",
-    "python3.8-venv=3.8.10-0ubuntu1~20.04.10",
+    "python3.8-venv",
     "libhwloc-dev",
     "graphviz",
     "patchelf"


### PR DESCRIPTION
### Problem description
The version of `python3.8-venv` that we depended on is gone. 

### What's changed
`python3.8-venv` has been unpinned as I hope it's stable enough by now

