### PR TITLE
#0: fix vector access bug for line allgather when updating runtime args

### DIFF
--- a/ttnn/cpp/ttnn/operations/ccl/all_gather/device/multi_core/all_gather_op_multi_core.cpp
+++ b/ttnn/cpp/ttnn/operations/ccl/all_gather/device/multi_core/all_gather_op_multi_core.cpp
@@ -202,28 +202,21 @@ operation::ProgramWithCallbacks all_gather_multi_core_with_workers(const Tensor&
     // number of worker cores is 2x this since there is 1 worker for the sender buffer and 1 worker for the receiver buffer
     uint32_t total_worker_core_pairs_used = num_links * all_gather_config.get_num_eth_buffers_per_edm() * num_full_send_directions;
 
-    std::vector<KernelHandle> worker_reader_sender_kernels;
-    worker_reader_sender_kernels.reserve(total_worker_core_pairs_used);
-    std::vector<KernelHandle> worker_writer_sender_kernels;
-    worker_writer_sender_kernels.reserve(total_worker_core_pairs_used);
-
-    std::vector<KernelHandle> worker_reader_receiver_kernels;
-    worker_reader_receiver_kernels.reserve(total_worker_core_pairs_used);
-    std::vector<KernelHandle> worker_writer_receiver_kernels;
-    worker_writer_receiver_kernels.reserve(total_worker_core_pairs_used);
-
-    std::vector<CoreCoord> all_worker_sender_cores;
-    all_worker_sender_cores.reserve(total_worker_core_pairs_used);
-    std::vector<CoreCoord> all_worker_receiver_cores;
-    all_worker_receiver_cores.reserve(total_worker_core_pairs_used);
-
     uint32_t num_input_pages = input_tensor.buffer()->size() / input_page_size;
     uint32_t min_pages_per_link = num_input_pages / num_links;
-
 
     std::vector<EriscDatamoverBuilder> clockwise_edm_builders;
     std::vector<EriscDatamoverBuilder> counter_clockwise_edm_builders;
     TT_ASSERT(num_full_send_directions > 0);
+
+    std::vector<std::pair<KernelHandle, CoreCoord>> receive_reader_kernel_core_list;
+    std::vector<std::pair<KernelHandle, CoreCoord>> receive_writer_kernel_core_list;
+    std::vector<std::pair<KernelHandle, CoreCoord>> send_reader_kernel_core_list;
+    std::vector<std::pair<KernelHandle, CoreCoord>> send_writer_kernel_core_list;
+    receive_reader_kernel_core_list.reserve(total_worker_core_pairs_used);
+    receive_writer_kernel_core_list.reserve(total_worker_core_pairs_used);
+    send_reader_kernel_core_list.reserve(total_worker_core_pairs_used);
+    send_writer_kernel_core_list.reserve(total_worker_core_pairs_used);
 
     // TODO: move to all-gather config
     auto edm_sem_addrs_per_link = std::vector<std::vector<uint32_t>>(num_links);
@@ -391,8 +384,6 @@ operation::ProgramWithCallbacks all_gather_multi_core_with_workers(const Tensor&
 
             auto sender_worker_cores = corerange_to_cores(sender_workers, std::nullopt, true);
             auto receiver_worker_cores = corerange_to_cores(receiver_workers, std::nullopt, true);
-            all_worker_sender_cores.insert(all_worker_sender_cores.end(), sender_worker_cores.begin(), sender_worker_cores.end());
-            all_worker_receiver_cores.insert(all_worker_receiver_cores.end(), receiver_worker_cores.begin(), receiver_worker_cores.end());
 
             TT_ASSERT(rem_pages < pages_per_chunk || num_full_chunks == 0);
             TT_ASSERT(rem_pages <= max_pages_per_chunk);
@@ -722,8 +713,7 @@ operation::ProgramWithCallbacks all_gather_multi_core_with_workers(const Tensor&
                         send_reader_kernel_path,
                         sender_worker_cores.at(b),
                         tt::tt_metal::ReaderDataMovementConfig(worker_send_reader_ct_args, worker_defines));
-
-                    worker_reader_sender_kernels.push_back(worker_reader_sender_kernel_id);
+                    send_reader_kernel_core_list.push_back({worker_reader_sender_kernel_id, sender_worker_cores.at(b)});
 
                     tt::tt_metal::SetRuntimeArgs(
                         program,
@@ -898,7 +888,7 @@ operation::ProgramWithCallbacks all_gather_multi_core_with_workers(const Tensor&
                         sender_worker_cores.at(b),
                         tt::tt_metal::WriterDataMovementConfig(worker_sender_writer_ct_args, worker_defines));
 
-                    worker_writer_sender_kernels.push_back(worker_sender_writer_kernel_id);
+                    send_writer_kernel_core_list.push_back({worker_sender_writer_kernel_id, sender_worker_cores.at(b)});
 
                     tt::tt_metal::SetRuntimeArgs(
                         program,
@@ -1074,7 +1064,7 @@ operation::ProgramWithCallbacks all_gather_multi_core_with_workers(const Tensor&
                         receiver_worker_cores.at(b),
                         tt::tt_metal::ReaderDataMovementConfig(worker_receiver_reader_ct_args, worker_defines));
 
-                    worker_reader_receiver_kernels.push_back(worker_receiver_reader_kernel_id);
+                    receive_reader_kernel_core_list.push_back({worker_receiver_reader_kernel_id, receiver_worker_cores.at(b)});
 
                     tt::tt_metal::SetRuntimeArgs(
                         program,
@@ -1226,8 +1216,7 @@ operation::ProgramWithCallbacks all_gather_multi_core_with_workers(const Tensor&
                         receiver_worker_cores.at(b),
                         tt::tt_metal::WriterDataMovementConfig(worker_receive_writer_ct_args, worker_defines));
 
-                    worker_writer_receiver_kernels.push_back(worker_receive_writer_kernel_id);
-
+                    receive_writer_kernel_core_list.push_back({worker_receive_writer_kernel_id, receiver_worker_cores.at(b)});
                     tt::tt_metal::SetRuntimeArgs(
                         program,
                         worker_receive_writer_kernel_id,
@@ -1263,7 +1252,7 @@ operation::ProgramWithCallbacks all_gather_multi_core_with_workers(const Tensor&
         receiver_device_id,
         sender_device_id);
 
-    auto override_runtime_arguments_callback = [num_links, total_worker_core_pairs_used, worker_reader_sender_kernels, worker_writer_sender_kernels, worker_reader_receiver_kernels, worker_writer_receiver_kernels, all_worker_sender_cores, all_worker_receiver_cores] (
+    auto override_runtime_arguments_callback = [num_links, receive_reader_kernel_core_list, receive_writer_kernel_core_list, send_reader_kernel_core_list, send_writer_kernel_core_list] (
         const void* operation,
         Program& program,
         const std::vector<Tensor>& input_tensors,
@@ -1273,39 +1262,46 @@ operation::ProgramWithCallbacks all_gather_multi_core_with_workers(const Tensor&
         bool is_sharded = input_tensors[0].is_sharded();
         const auto& input = input_tensors[0];
         const auto& output = output_tensors[0];
-        for (uint32_t i = 0; i < total_worker_core_pairs_used; ++i) {
+        for (auto const& [kernel_id, core] : receive_writer_kernel_core_list) {
             if (is_sharded) {
-                auto &worker_reader_sender_runtime_args = GetRuntimeArgs(program, worker_reader_sender_kernels.at(i), all_worker_sender_cores.at(i));
-                worker_reader_sender_runtime_args[7] = input.buffer()->address();
+                auto &worker_writer_receiver_runtime_args = GetRuntimeArgs(program, kernel_id, core);
+                worker_writer_receiver_runtime_args.at(10) = output.buffer()->address();
+                log_trace(tt::LogOp, "override worker_writer_receiver_runtime_args:");
+                for (uint32_t j = 0; j < worker_writer_receiver_runtime_args.size(); ++j) {
+                    log_trace(tt::LogOp, "\tworker_writer_receiver_runtime_args[{}]: {}", j, worker_writer_receiver_runtime_args.at(j));
+                }
+            } else {
+                auto &worker_writer_receiver_runtime_args = GetRuntimeArgs(program, kernel_id, core);
+                worker_writer_receiver_runtime_args.at(0) = output.buffer()->address();
+            }
+        }
+        for (auto const& [kernel_id, core] : send_reader_kernel_core_list) {
+            if (is_sharded) {
+                auto &worker_reader_sender_runtime_args = GetRuntimeArgs(program, kernel_id, core);
+                worker_reader_sender_runtime_args.at(7) = input.buffer()->address();
                 uint32_t num_dest_cores = worker_reader_sender_runtime_args.at(12);
-                worker_reader_sender_runtime_args[12 + num_dest_cores + 4] = output.buffer()->address();
+                worker_reader_sender_runtime_args.at(12 + num_dest_cores + 4) = output.buffer()->address();
                 log_trace(tt::LogOp, "override worker_reader_sender_runtime_args:");
                 for (uint32_t j = 0; j < worker_reader_sender_runtime_args.size(); ++j) {
                     log_trace(tt::LogOp, "\tworker_reader_sender_runtime_args[{}]: {}", j, worker_reader_sender_runtime_args.at(j));
                 }
-
-                auto &worker_writer_sender_runtime_args = GetRuntimeArgs(program, worker_writer_sender_kernels.at(i), all_worker_sender_cores.at(i));
-                worker_writer_sender_runtime_args[12] = output.buffer()->address();
+            } else {
+                auto &worker_reader_sender_runtime_args = GetRuntimeArgs(program, kernel_id, core);
+                worker_reader_sender_runtime_args.at(0) = input.buffer()->address();
+                worker_reader_sender_runtime_args.at(1) = output.buffer()->address();
+            }
+        }
+        for (auto const& [kernel_id, core] : send_writer_kernel_core_list) {
+            if (is_sharded) {
+                auto &worker_writer_sender_runtime_args = GetRuntimeArgs(program, kernel_id, core);
+                worker_writer_sender_runtime_args.at(12) = output.buffer()->address();
                 log_trace(tt::LogOp, "override worker_writer_sender_runtime_args:");
                 for (uint32_t j = 0; j < worker_writer_sender_runtime_args.size(); ++j) {
-                    log_trace(tt::LogOp, "\tworker_writer_sender_runtime_args[{}]: {}", j, worker_reader_sender_runtime_args.at(j));
-                }
-
-                auto &worker_writer_receiver_runtime_args = GetRuntimeArgs(program, worker_writer_receiver_kernels.at(i), all_worker_receiver_cores.at(i));
-                worker_writer_receiver_runtime_args[10] = output.buffer()->address();
-                log_trace(tt::LogOp, "override worker_writer_receiver_runtime_args:");
-                for (uint32_t j = 0; j < worker_writer_receiver_runtime_args.size(); ++j) {
-                    log_trace(tt::LogOp, "\tworker_writer_receiver_runtime_args[{}]: {}", j, worker_reader_sender_runtime_args.at(j));
+                    log_trace(tt::LogOp, "\tworker_writer_sender_runtime_args[{}]: {}", j, worker_writer_sender_runtime_args.at(j));
                 }
             } else {
-                auto &worker_reader_sender_runtime_args = GetRuntimeArgs(program, worker_reader_sender_kernels.at(i), all_worker_sender_cores.at(i));
-                worker_reader_sender_runtime_args[0] = input.buffer()->address();
-                worker_reader_sender_runtime_args[1] = output.buffer()->address();
-                auto &worker_writer_sender_runtime_args = GetRuntimeArgs(program, worker_writer_sender_kernels.at(i), all_worker_sender_cores.at(i));
-                worker_writer_sender_runtime_args[0] = output.buffer()->address();
-
-                auto &worker_writer_receiver_runtime_args = GetRuntimeArgs(program, worker_writer_receiver_kernels.at(i), all_worker_receiver_cores.at(i));
-                worker_writer_receiver_runtime_args[0] = output.buffer()->address();
+                auto &worker_writer_sender_runtime_args = GetRuntimeArgs(program, kernel_id, core);
+                worker_writer_sender_runtime_args.at(0) = output.buffer()->address();
             }
         }
     };


### PR DESCRIPTION
### Ticket
[Link to Github Issue](https://github.com/tenstorrent/tt-metal/issues/10963#event-13715097160)

### Problem description
OoB array access leads to occasional seg fault on galaxy (could happen on any system technically) when updating rt args for line allgather.

### What's changed
Cleaned up rt arg fetching logic. The old logic was incorrect for the end-chips where the first receiver core is not the same as the overall first sender/receiver core pair index.

Separated it out to track kernel ID -> core mapping separately by kernel type to fix the issue

### Checklist
- [x] Post commit CI passes
  - https://github.com/tenstorrent/tt-metal/actions/runs/10188038782
- [x] t3k unit tests:
  - https://github.com/tenstorrent/tt-metal/actions/runs/10187115513
- [x] t3k frequent tests
  - https://github.com/tenstorrent/tt-metal/actions/runs/10187110331
- [x] Model regression CI testing passes (if applicable)
- [ ] New/Existing tests provide coverage for changes
