### PR TITLE
Add ability to specify build type + Tracy enable/disable in build and test dispatch workflows

### DIFF
--- a/.github/workflows/all-post-commit-workflows.yaml
+++ b/.github/workflows/all-post-commit-workflows.yaml
@@ -22,7 +22,7 @@ jobs:
   build-artifact-profiler:
     uses: ./.github/workflows/build-artifact.yaml
     with:
-      profiler-build: true
+      tracy: true
     secrets: inherit
   sd-unit-tests:
     needs: build-artifact

--- a/.github/workflows/build-artifact.yaml
+++ b/.github/workflows/build-artifact.yaml
@@ -54,8 +54,8 @@ jobs:
       - name: Build tt-metal and libs
         run: |
           nice -n 19 cmake -B build -G Ninja
-          nice -n 19 cmake --build build -DCMAKE_BUILD_TYPE=${{ inputs.build-type }} -DENABLE_TRACY=${{ inputs.enable_tracy }} --target tests
-          nice -n 19 cmake --build build -DCMAKE_BUILD_TYPE=${{ inputs.build-type }} -DENABLE_TRACY=${{ inputs.enable_tracy }} --target install
+          nice -n 19 cmake --build build -DCMAKE_BUILD_TYPE=${{ inputs.build-type }} -DENABLE_TRACY=${{ inputs.tracy }} --target tests
+          nice -n 19 cmake --build build -DCMAKE_BUILD_TYPE=${{ inputs.build-type }} -DENABLE_TRACY=${{ inputs.tracy }} --target install
       - name: 'Tar files'
         run: tar -cvf ttm_${{ matrix.arch }}.tar build/lib ttnn/ttnn/*.so build/programming_examples build/test build/tools runtime
       - name: 'Upload Artifact'

--- a/.github/workflows/build-artifact.yaml
+++ b/.github/workflows/build-artifact.yaml
@@ -24,8 +24,12 @@ on:
         default: '["grayskull", "wormhole_b0"]'
       build-type:
         required: false
-        type: string
-        default: "Release"
+        type: choice
+        options:
+          - Release
+          - Debug
+          - RelWithDebInfo
+          - CI
       tracy:
         required: false
         type: boolean

--- a/.github/workflows/build-artifact.yaml
+++ b/.github/workflows/build-artifact.yaml
@@ -57,9 +57,9 @@ jobs:
           git submodule update --init --recursive
       - name: Build tt-metal and libs
         run: |
-          nice -n 19 cmake -B build -G Ninja
-          nice -n 19 cmake --build build -DCMAKE_BUILD_TYPE=${{ inputs.build-type }} -DENABLE_TRACY=${{ inputs.tracy }} --target tests
-          nice -n 19 cmake --build build -DCMAKE_BUILD_TYPE=${{ inputs.build-type }} -DENABLE_TRACY=${{ inputs.tracy }} --target install
+          nice -n 19 cmake -B build -G Ninja -DCMAKE_BUILD_TYPE=${{ inputs.build-type }} -DENABLE_TRACY=${{ inputs.tracy }}
+          nice -n 19 cmake --build build --target tests
+          nice -n 19 cmake --build build --target install
       - name: 'Tar files'
         run: tar -cvf ttm_${{ matrix.arch }}.tar build/lib ttnn/ttnn/*.so build/programming_examples build/test build/tools runtime
       - name: 'Upload Artifact'

--- a/.github/workflows/build-artifact.yaml
+++ b/.github/workflows/build-artifact.yaml
@@ -15,7 +15,7 @@ on:
         required: false
         type: boolean
         default: false
-        description: "Enable tracy"
+        description: "Build with tracy enabled"
   workflow_dispatch:
     inputs:
       arch:
@@ -34,7 +34,7 @@ on:
         required: false
         type: boolean
         default: false
-        description: "Enable tracy"
+        description: "Build with tracy enabled"
 jobs:
   build-artifact:
     strategy:

--- a/.github/workflows/build-artifact.yaml
+++ b/.github/workflows/build-artifact.yaml
@@ -7,11 +7,6 @@ on:
         required: false
         type: string
         default: '["grayskull", "wormhole_b0"]'
-      profiler-build:
-        required: false
-        type: boolean
-        default: false
-        description: "Enable tracy and profiler build with _profiler attached to end of artifact"
       build-type:
         required: false
         type: string
@@ -27,11 +22,6 @@ on:
         required: false
         type: string
         default: '["grayskull", "wormhole_b0"]'
-      profiler-build:
-        required: false
-        type: boolean
-        default: false
-        description: "Enable tracy and profiler build with _profiler attached to end of artifact"
       build-type:
         required: false
         type: string

--- a/.github/workflows/build-artifact.yaml
+++ b/.github/workflows/build-artifact.yaml
@@ -12,6 +12,15 @@ on:
         type: boolean
         default: false
         description: "Enable tracy and profiler build with _profiler attached to end of artifact"
+      build-type:
+        required: false
+        type: string
+        default: "Release"
+      tracy:
+        required: false
+        type: boolean
+        default: false
+        description: "Enable tracy"
   workflow_dispatch:
     inputs:
       arch:
@@ -23,7 +32,15 @@ on:
         type: boolean
         default: false
         description: "Enable tracy and profiler build with _profiler attached to end of artifact"
-
+      build-type:
+        required: false
+        type: string
+        default: "Release"
+      tracy:
+        required: false
+        type: boolean
+        default: false
+        description: "Enable tracy"
 jobs:
   build-artifact:
     strategy:
@@ -44,19 +61,15 @@ jobs:
       - name: Update submodules
         run: |
           git submodule update --init --recursive
-      - name: Build regular tt-metal and libs
-        if: ${{ !inputs.profiler-build }}
+      - name: Build tt-metal and libs
         run: |
           nice -n 19 cmake -B build -G Ninja
-          nice -n 19 cmake --build build --target tests
-          nice -n 19 cmake --build build --target install
-      - name: Build profiler tt-metal and libs
-        if: ${{ inputs.profiler-build }}
-        run: nice -n 19 ./scripts/build_scripts/build_with_profiler_opt.sh
+          nice -n 19 cmake --build build -DCMAKE_BUILD_TYPE=${{ inputs.build-type }} -DENABLE_TRACY=${{ inputs.enable_tracy }} --target tests
+          nice -n 19 cmake --build build -DCMAKE_BUILD_TYPE=${{ inputs.build-type }} -DENABLE_TRACY=${{ inputs.enable_tracy }} --target install
       - name: 'Tar files'
         run: tar -cvf ttm_${{ matrix.arch }}.tar build/lib ttnn/ttnn/*.so build/programming_examples build/test build/tools runtime
       - name: 'Upload Artifact'
         uses: actions/upload-artifact@v4
         with:
-          name: TTMetal_build_${{ matrix.arch }}${{ (inputs.profiler-build && '_profiler') || '' }}
+          name: TTMetal_build_${{ matrix.arch }}${{ (inputs.tracy && '_profiler') || '' }}
           path: ttm_${{ matrix.arch }}.tar

--- a/.github/workflows/perf-device-models.yaml
+++ b/.github/workflows/perf-device-models.yaml
@@ -10,7 +10,7 @@ jobs:
   build-artifact-profiler:
     uses: ./.github/workflows/build-artifact.yaml
     with:
-      profiler-build: true
+      tracy: true
     secrets: inherit
   device-perf:
     needs: build-artifact-profiler

--- a/.github/workflows/run-profiler-regression-wrapper.yaml
+++ b/.github/workflows/run-profiler-regression-wrapper.yaml
@@ -8,7 +8,7 @@ jobs:
   build-artifact-profiler:
     uses: ./.github/workflows/build-artifact.yaml
     with:
-      profiler-build: true
+      tracy: true
     secrets: inherit
   run-profiler-regression:
     needs: build-artifact-profiler

--- a/.github/workflows/t3000-profiler-tests.yaml
+++ b/.github/workflows/t3000-profiler-tests.yaml
@@ -11,7 +11,7 @@ jobs:
     uses: ./.github/workflows/build-artifact.yaml
     with:
       arch: '["wormhole_b0"]'
-      profiler-build: true
+      tracy: true
     secrets: inherit
   t3000-profiler-tests:
     needs: build-artifact-profiler

--- a/.github/workflows/test-dispatch.yaml
+++ b/.github/workflows/test-dispatch.yaml
@@ -9,6 +9,19 @@ on:
         options:
           - grayskull
           - wormhole_b0
+      build-type:
+        required: false
+        type: choice
+        options:
+          - Release
+          - Debug
+          - RelWithDebInfo
+          - CI
+      tracy:
+        required: false
+        type: boolean
+        default: false
+        description: "Enable tracy"
       runner-label:
         required: true
         type: string
@@ -26,6 +39,8 @@ jobs:
     uses: ./.github/workflows/build-artifact.yaml
     with:
       arch: '[ "${{ inputs.arch }}" ]'
+      build-type: ${{ inputs.build-type }}
+      tracy: ${{ inputs.tracy }}
     secrets: inherit
   test-dispatch:
     needs: build-artifact

--- a/.github/workflows/test-dispatch.yaml
+++ b/.github/workflows/test-dispatch.yaml
@@ -21,7 +21,7 @@ on:
         required: false
         type: boolean
         default: false
-        description: "Enable tracy"
+        description: "Build with tracy enabled"
       runner-label:
         required: true
         type: string

--- a/.github/workflows/test-dispatch.yaml
+++ b/.github/workflows/test-dispatch.yaml
@@ -9,6 +9,9 @@ on:
         options:
           - grayskull
           - wormhole_b0
+      runner-label:
+        required: true
+        type: string
       build-type:
         required: false
         type: choice
@@ -22,9 +25,6 @@ on:
         type: boolean
         default: false
         description: "Build with tracy enabled"
-      runner-label:
-        required: true
-        type: string
       command:
         required: true
         type: string


### PR DESCRIPTION
### Problem description
Build artifact workflow doesn't allow user to specific C++ build type, which is needed for the test dispatch workflow

### What's changed
Added ability to specify build type in build artifact and test dispatch workflows. Tracy enable / disable was reworked to avoid calling a separate script.

### Checklist
https://github.com/tenstorrent/tt-metal/actions/runs/10189144455
https://github.com/tenstorrent/tt-metal/actions/runs/10189046205
https://github.com/tenstorrent/tt-metal/actions/runs/10188979352
https://github.com/tenstorrent/tt-metal/actions/runs/10188976509
https://github.com/tenstorrent/tt-metal/actions/runs/10188962395
https://github.com/tenstorrent/tt-metal/actions/runs/10188960645
- [x] Post commit CI passes
