### PR TITLE
#0: change ccl op alternative code owner to @cfjchu

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -115,7 +115,7 @@ ttnn/ @eyonland @arakhmati @cfjchu @xanderchin @TT-BrianLiu @ayerofieiev-tt @dma
 ttnn/**/kernels/ # Removes the owners above from owning kernels unless specified afterwards
 ttnn/setup.py @tt-rkim
 ttnn/CMakeLists.txt @tt-rkim @ayerofieiev-tt
-ttnn/cpp/ttnn/operations/ccl/ @SeanNijjar @TT-BrianLiu
+ttnn/cpp/ttnn/operations/ccl/ @SeanNijjar @cfjchu
 ttnn/cpp/ttnn/operations/pool/ @mywoodstock @pavlejosipovic
 ttnn/cpp/ttnn/operations/conv2d/ @mywoodstock @pavlejosipovic
 ttnn/cpp/ttnn/operations/data_movement/ @tarafdarTT @sjameelTT @yan-zaretskiy


### PR DESCRIPTION
### Ticket
No issue

### Problem description
I thought about it and I think @cfjchu is a more appropriate alternative code owner for CCL operations given he's working on closely related components that interface with each other frequently.

### What's changed
Updated secondary CCL operation code owner from @TT-BrianLiu to @cfjchu

### Checklist
- [ ] Post commit CI passes
  - https://github.com/tenstorrent/tt-metal/actions/runs/10191483270
- [x] Model regression CI testing passes (if applicable)
  - NA
- [x] New/Existing tests provide coverage for changes
  - NA
