### PR TITLE
#10944: Add retry action for unstable CI commands

### DIFF
--- a/.github/actions/retry-command/action.yml
+++ b/.github/actions/retry-command/action.yml
@@ -1,0 +1,44 @@
+name: "Wrap a bash command with retries"
+description: "Wrap a bash command with retries so it attempts it again on failure after a backoff period"
+inputs:
+  command:
+    description: "Command to run"
+    required: true
+  timeout-seconds:
+    description: "Timeout period in seconds for command to complete"
+    required: true
+  backoff-seconds:
+    description: "Backoff period in seconds to wait before trying command again"
+    default: 5
+  max-retries:
+    description: "Max number of retries to retry command"
+    default: 3
+runs:
+  using: "composite"
+  steps:
+    - name: "Invoke command with retries"
+      shell: bash
+      run: |
+        set +e
+
+        max_retries="${{ inputs.max-retries }}"
+        count=0
+
+        while (( count < max_retries )); do
+          echo "Attempt $((count + 1)) of $max_retries..."
+
+          # Execute the command with timeout
+          if timeout ${{ inputs.timeout-seconds }} ${{ inputs.command }}; then
+            echo "Command succeeded."
+            exit 0
+          else
+            echo "Command failed or timed out."
+            count=$((count + 1))
+          fi
+
+          # Optional: Add a delay between retries
+          sleep ${{ inputs.backoff-seconds }}
+        done
+
+        echo "Command failed after $max_retries attempts."
+        exit 1

--- a/.github/actions/retry-command/action.yml
+++ b/.github/actions/retry-command/action.yml
@@ -28,7 +28,7 @@ runs:
           echo "Attempt $((count + 1)) of $max_retries..."
 
           # Execute the command with timeout
-          if timeout ${{ inputs.timeout-seconds }} ${{ inputs.command }}; then
+          if timeout ${{ inputs.timeout-seconds }} "${{ inputs.command }}"; then
             echo "Command succeeded."
             exit 0
           else

--- a/.github/actions/retry-command/action.yml
+++ b/.github/actions/retry-command/action.yml
@@ -32,7 +32,7 @@ runs:
             echo "Command succeeded."
             exit 0
           else
-            echo "Command failed or timed out."
+            echo "Command failed or timed out. Backing off..."
             count=$((count + 1))
           fi
 

--- a/.github/scripts/cloud_utils/mount_weka.sh
+++ b/.github/scripts/cloud_utils/mount_weka.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+set -eo pipefail
+
+sudo systemctl restart mnt-MLPerf.mount
+sudo /etc/rc.local
+ls -al /mnt/MLPerf/bit_error_tests

--- a/.github/workflows/all-static-checks.yaml
+++ b/.github/workflows/all-static-checks.yaml
@@ -58,4 +58,4 @@ jobs:
           timeout-seconds: 10
           max-retries: 5
           backoff-seconds: 5
-          command: sudo ls; sudo ls -hal
+          command: sudo ls && sudo ls -hal

--- a/.github/workflows/all-static-checks.yaml
+++ b/.github/workflows/all-static-checks.yaml
@@ -59,5 +59,4 @@ jobs:
           max-retries: 5
           backoff-seconds: 5
           command: |
-            sudo ls
-            sudo ls -hal
+            sudo ls; sudo ls -hal

--- a/.github/workflows/all-static-checks.yaml
+++ b/.github/workflows/all-static-checks.yaml
@@ -49,3 +49,14 @@ jobs:
         run: |
           if (( $(grep -Rnw 'tests/tt_metal' -e 'tt_lib' | wc -l ) > 0 )); then exit 1; fi
           if (( $(grep -Rnw 'tests/tt_metal' -e 'tt_eager' | wc -l ) > 10 )); then exit 1; fi
+  check-retry:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ./.github/actions/retry-command
+        with:
+          timeout-seconds: 10
+          max-retries: 5
+          backoff-seconds: 5
+          command: |
+            sudo ls

--- a/.github/workflows/all-static-checks.yaml
+++ b/.github/workflows/all-static-checks.yaml
@@ -55,7 +55,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/retry-command
         with:
-          timeout-seconds: 10
+          timeout-seconds: 120
           max-retries: 5
-          backoff-seconds: 5
+          backoff-seconds: 10
           command: ./.github/scripts/cloud_utils/mount_weka.sh

--- a/.github/workflows/all-static-checks.yaml
+++ b/.github/workflows/all-static-checks.yaml
@@ -49,13 +49,3 @@ jobs:
         run: |
           if (( $(grep -Rnw 'tests/tt_metal' -e 'tt_lib' | wc -l ) > 0 )); then exit 1; fi
           if (( $(grep -Rnw 'tests/tt_metal' -e 'tt_eager' | wc -l ) > 10 )); then exit 1; fi
-  check-retry:
-    runs-on: self-hosted
-    steps:
-      - uses: actions/checkout@v4
-      - uses: ./.github/actions/retry-command
-        with:
-          timeout-seconds: 120
-          max-retries: 5
-          backoff-seconds: 10
-          command: ./.github/scripts/cloud_utils/mount_weka.sh

--- a/.github/workflows/all-static-checks.yaml
+++ b/.github/workflows/all-static-checks.yaml
@@ -60,3 +60,4 @@ jobs:
           backoff-seconds: 5
           command: |
             sudo ls
+            sudo ls -hal

--- a/.github/workflows/all-static-checks.yaml
+++ b/.github/workflows/all-static-checks.yaml
@@ -50,7 +50,7 @@ jobs:
           if (( $(grep -Rnw 'tests/tt_metal' -e 'tt_lib' | wc -l ) > 0 )); then exit 1; fi
           if (( $(grep -Rnw 'tests/tt_metal' -e 'tt_eager' | wc -l ) > 10 )); then exit 1; fi
   check-retry:
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/retry-command
@@ -58,4 +58,4 @@ jobs:
           timeout-seconds: 10
           max-retries: 5
           backoff-seconds: 5
-          command: sudo ls && sudo ls -hal
+          command: ./.github/scripts/cloud_utils/mount_weka.sh

--- a/.github/workflows/all-static-checks.yaml
+++ b/.github/workflows/all-static-checks.yaml
@@ -58,5 +58,4 @@ jobs:
           timeout-seconds: 10
           max-retries: 5
           backoff-seconds: 5
-          command: |
-            sudo ls; sudo ls -hal
+          command: sudo ls; sudo ls -hal


### PR DESCRIPTION
### Ticket

#10944 

### Problem description

Weka fails a lot, so we decided to make our retry action because the Action Marketplace ones don't support sudo commands.

### What's changed

We made our retry script using bash within an action.

### Checklist
- [ ] Post commit CI passes
- [ ] Model regression CI testing passes (if applicable)
- [ ] New/Existing tests provide coverage for changes
