### PR TITLE
Aliu/rm wh arch env

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -83,6 +83,16 @@ def get_tt_cache_path():
     return get_tt_cache_path_
 
 
+def get_dispatch_core_type():
+    import tt_lib as ttl
+
+    # TODO: 11059 move dispatch_core_type to device_params when all tests are updated to not use WH_ARCH_YAML env flag
+    dispatch_core_type = ttl.device.DispatchCoreType.WORKER
+    if ("WH_ARCH_YAML" in os.environ) and os.environ["WH_ARCH_YAML"] == "wormhole_b0_80_arch_eth_dispatch.yaml":
+        dispatch_core_type = ttl.device.DispatchCoreType.ETH
+    return dispatch_core_type
+
+
 @pytest.fixture(scope="function")
 def device_params(request):
     return getattr(request, "param", {})
@@ -97,7 +107,7 @@ def device(request, device_params):
 
     num_devices = ttl.device.GetNumPCIeDevices()
     assert device_id < num_devices, "CreateDevice not supported for non-mmio device"
-    device = ttl.device.CreateDevice(device_id=device_id, **device_params)
+    device = ttl.device.CreateDevice(device_id=device_id, dispatch_core_type=get_dispatch_core_type(), **device_params)
     ttl.device.SetDefaultDevice(device)
 
     yield device
@@ -117,7 +127,7 @@ def pcie_devices(request, device_params):
     request.node.pci_ids = device_ids
 
     # Get only physical devices
-    devices = ttl.device.CreateDevices(device_ids, **device_params)
+    devices = ttl.device.CreateDevices(device_ids, dispatch_core_type=get_dispatch_core_type(), **device_params)
 
     yield [devices[i] for i in range(num_devices)]
 
@@ -136,7 +146,7 @@ def all_devices(request, device_params):
     request.node.pci_ids = [ttl.device.GetPCIeDeviceID(i) for i in device_ids]
 
     # Get only physical devices
-    devices = ttl.device.CreateDevices(device_ids, **device_params)
+    devices = ttl.device.CreateDevices(device_ids, dispatch_core_type=get_dispatch_core_type(), **device_params)
 
     yield [devices[i] for i in range(num_devices)]
 
@@ -188,7 +198,9 @@ def device_mesh(request, silicon_arch_name, silicon_arch_wormhole_b0, device_par
 
     request.node.pci_ids = [ttl.device.GetPCIeDeviceID(i) for i in device_ids[:num_devices_requested]]
 
-    device_mesh = ttnn.open_device_mesh(device_grid, device_ids[:num_devices_requested], **device_params)
+    device_mesh = ttnn.open_device_mesh(
+        device_grid, device_ids[:num_devices_requested], dispatch_core_type=get_dispatch_core_type(), **device_params
+    )
 
     logger.debug(f"multidevice with {device_mesh.get_num_devices()} devices is created")
     yield device_mesh
@@ -214,7 +226,10 @@ def pcie_device_mesh(request, silicon_arch_name, silicon_arch_wormhole_b0, devic
     request.node.pci_ids = device_ids[:num_pcie_devices_requested]
 
     device_mesh = ttnn.open_device_mesh(
-        ttnn.DeviceGrid(1, num_pcie_devices_requested), device_ids[:num_pcie_devices_requested], **device_params
+        ttnn.DeviceGrid(1, num_pcie_devices_requested),
+        device_ids[:num_pcie_devices_requested],
+        dispatch_core_type=get_dispatch_core_type(),
+        **device_params,
     )
 
     logger.debug(f"multidevice with {device_mesh.get_num_devices()} devices is created")
@@ -243,7 +258,10 @@ def t3k_device_mesh(request, silicon_arch_name, silicon_arch_wormhole_b0, device
     request.node.pci_ids = [ttl.device.GetPCIeDeviceID(i) for i in device_ids[:num_devices_requested]]
 
     device_mesh = ttnn.open_device_mesh(
-        ttnn.DeviceGrid(1, num_devices_requested), device_ids[:num_devices_requested], **device_params
+        ttnn.DeviceGrid(1, num_devices_requested),
+        device_ids[:num_devices_requested],
+        dispatch_core_type=get_dispatch_core_type(),
+        **device_params,
     )
 
     logger.debug(f"multidevice with {device_mesh.get_num_devices()} devices is created")

--- a/tests/scripts/run_cpp_unit_tests.sh
+++ b/tests/scripts/run_cpp_unit_tests.sh
@@ -15,7 +15,7 @@ else
     ./build/test/tt_metal/unit_tests_fast_dispatch
     TT_METAL_GTEST_NUM_HW_CQS=2 ./build/test/tt_metal/unit_tests_fast_dispatch_single_chip_multi_queue --gtest_filter=MultiCommandQueueSingleDeviceFixture.*
     if [[ "$ARCH_NAME" == "wormhole_b0" ]]; then
-        WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml ./build/test/tt_metal/unit_tests_fast_dispatch
+        TT_METAL_GTEST_ETH_DISPATCH=1 ./build/test/tt_metal/unit_tests_fast_dispatch
     fi
     env python tests/scripts/run_tt_eager.py --dispatch-mode fast
     env python tests/scripts/run_tt_metal.py --dispatch-mode fast

--- a/tests/tt_metal/tt_metal/test_clean_init.cpp
+++ b/tests/tt_metal/tt_metal/test_clean_init.cpp
@@ -5,6 +5,7 @@
 #include "tt_metal/host_api.hpp"
 #include "tt_metal/detail/tt_metal.hpp"
 #include "tt_metal/impl/device/device_pool.hpp"
+#include "tt_metal/llrt/rtoptions.hpp"
 #include "common/bfloat16.hpp"
 #include <chrono>
 
@@ -34,7 +35,10 @@ int main(int argc, char **argv) {
     for (unsigned int id = 0; id < num_devices; id++) {
         ids.push_back(id);
     }
-    tt::DevicePool::initialize(ids, 1, DEFAULT_L1_SMALL_SIZE);
+
+
+    const auto &dispatch_core_type = tt::llrt::OptionsG.get_dispatch_core_type();
+    tt::DevicePool::initialize(ids, 1, DEFAULT_L1_SMALL_SIZE, DEFAULT_TRACE_REGION_SIZE, dispatch_core_type);
     std::vector<Device *> devices = tt::DevicePool::instance().get_all_active_devices();
 
     for (int device_id = 0; device_id < num_devices; device_id++) {

--- a/tests/tt_metal/tt_metal/test_compile_sets_kernel_binaries.cpp
+++ b/tests/tt_metal/tt_metal/test_compile_sets_kernel_binaries.cpp
@@ -52,7 +52,7 @@ int main(int argc, char **argv) {
         for (unsigned int id = 0; id < num_devices; id++) {
             ids.push_back(id);
         }
-        tt::DevicePool::initialize(ids, 1, DEFAULT_L1_SMALL_SIZE);
+        tt::DevicePool::initialize(ids, 1, DEFAULT_L1_SMALL_SIZE, DEFAULT_TRACE_REGION_SIZE, DispatchCoreType::WORKER);
         std::vector<Device*> devices = tt::DevicePool::instance().get_all_active_devices();
         std::vector<Program> programs;
         std::set<uint32_t> build_keys;

--- a/tests/tt_metal/tt_metal/unit_tests/allocator/test_l1_banking_allocator.cpp
+++ b/tests/tt_metal/tt_metal/unit_tests/allocator/test_l1_banking_allocator.cpp
@@ -18,7 +18,8 @@ TEST_F(BasicFixture, TestL1BuffersAllocatedTopDown) {
     size_t total_size_bytes = 0;
 
     const metal_SocDescriptor &soc_desc = tt::Cluster::instance().get_soc_desc(device->id());
-    const uint32_t interleaved_l1_bank_size = tt::get_l1_bank_size(device->id(), device->num_hw_cqs());
+    CoreType dispatch_core_type = dispatch_core_manager::instance().get_dispatch_core_type(device->id());
+    const uint32_t interleaved_l1_bank_size = tt::get_l1_bank_size(device->id(), device->num_hw_cqs(), dispatch_core_type);
     uint64_t alloc_limit = interleaved_l1_bank_size - STORAGE_ONLY_UNRESERVED_BASE;
 
     std::vector<std::unique_ptr<Buffer>> buffers;
@@ -45,7 +46,8 @@ TEST_F(BasicFixture, TestL1BuffersDoNotGrowBeyondBankSize) {
     tt::tt_metal::Device *device = tt::tt_metal::CreateDevice(0, 1, 0);
 
     const metal_SocDescriptor &soc_desc = tt::Cluster::instance().get_soc_desc(device->id());
-    const uint32_t interleaved_l1_bank_size = tt::get_l1_bank_size(device->id(), device->num_hw_cqs());    
+    CoreType dispatch_core_type = dispatch_core_manager::instance().get_dispatch_core_type(device->id());
+    const uint32_t interleaved_l1_bank_size = tt::get_l1_bank_size(device->id(), device->num_hw_cqs(), dispatch_core_type);
     uint64_t alloc_limit = interleaved_l1_bank_size - STORAGE_ONLY_UNRESERVED_BASE;
 
     tt::tt_metal::InterleavedBufferConfig l1_config{

--- a/tests/tt_metal/tt_metal/unit_tests/common/device_fixture.hpp
+++ b/tests/tt_metal/tt_metal/unit_tests/common/device_fixture.hpp
@@ -33,7 +33,8 @@ class DeviceFixture : public ::testing::Test {
         for (unsigned int id = 0; id < num_devices_; id++) {
             ids.push_back(id);
         }
-        tt::DevicePool::initialize(ids, 1, DEFAULT_L1_SMALL_SIZE);
+        const auto &dispatch_core_type = tt::llrt::OptionsG.get_dispatch_core_type();
+        tt::DevicePool::initialize(ids, 1, DEFAULT_L1_SMALL_SIZE, DEFAULT_TRACE_REGION_SIZE, dispatch_core_type);
         devices_ = tt::DevicePool::instance().get_all_active_devices();
     }
 

--- a/tests/tt_metal/tt_metal/unit_tests/common/n300_device_fixture.hpp
+++ b/tests/tt_metal/tt_metal/unit_tests/common/n300_device_fixture.hpp
@@ -28,7 +28,9 @@ class N300DeviceFixture : public ::testing::Test {
             for (unsigned int id = 0; id < num_devices_; id++) {
                 ids.push_back(id);
             }
-            tt::DevicePool::initialize(ids, 1, DEFAULT_L1_SMALL_SIZE);
+
+            const auto &dispatch_core_type = tt::llrt::OptionsG.get_dispatch_core_type();
+            tt::DevicePool::initialize(ids, 1, DEFAULT_L1_SMALL_SIZE, DEFAULT_TRACE_REGION_SIZE, dispatch_core_type);
             devices_ = tt::DevicePool::instance().get_all_active_devices();
 
         } else {

--- a/tests/tt_metal/tt_metal/unit_tests_common/basic/test_device_init.cpp
+++ b/tests/tt_metal/tt_metal/unit_tests_common/basic/test_device_init.cpp
@@ -85,7 +85,7 @@ TEST_P(DeviceParamFixture, DeviceInitializeAndTeardown) {
     for (unsigned int id = 0; id < num_devices; id++) {
         ids.push_back(id);
     }
-    tt::DevicePool::initialize(ids, 1, DEFAULT_L1_SMALL_SIZE);
+    tt::DevicePool::initialize(ids, 1, DEFAULT_L1_SMALL_SIZE, DEFAULT_TRACE_REGION_SIZE, tt_metal::DispatchCoreType::WORKER);
     devices = tt::DevicePool::instance().get_all_active_devices();
     for (auto device : devices) {
         ASSERT_TRUE(tt::tt_metal::CloseDevice(device));
@@ -104,7 +104,7 @@ TEST_P(DeviceParamFixture, DeviceLoadBlankKernels) {
     for (unsigned int id = 0; id < num_devices; id++) {
         ids.push_back(id);
     }
-    tt::DevicePool::initialize(ids, 1, DEFAULT_L1_SMALL_SIZE);
+    tt::DevicePool::initialize(ids, 1, DEFAULT_L1_SMALL_SIZE, DEFAULT_TRACE_REGION_SIZE, tt_metal::DispatchCoreType::WORKER);
     devices = tt::DevicePool::instance().get_all_active_devices();
     for (auto device : devices) {
         ASSERT_TRUE(unit_tests_common::basic::test_device_init::load_all_blank_kernels(device));

--- a/tests/tt_metal/tt_metal/unit_tests_common/common/common_fixture.hpp
+++ b/tests/tt_metal/tt_metal/unit_tests_common/common/common_fixture.hpp
@@ -76,7 +76,8 @@ protected:
                 continue;
             ids.push_back(id);
         }
-        tt::DevicePool::initialize(ids, tt::llrt::OptionsG.get_num_hw_cqs(), DEFAULT_L1_SMALL_SIZE);
+        const auto &dispatch_core_type = tt::llrt::OptionsG.get_dispatch_core_type();
+        tt::DevicePool::initialize(ids, tt::llrt::OptionsG.get_num_hw_cqs(), DEFAULT_L1_SMALL_SIZE, DEFAULT_TRACE_REGION_SIZE, dispatch_core_type);
         devices_ = tt::DevicePool::instance().get_all_active_devices();
     }
 

--- a/tests/tt_metal/tt_metal/unit_tests_common/common/dprint_fixture.hpp
+++ b/tests/tt_metal/tt_metal/unit_tests_common/common/dprint_fixture.hpp
@@ -37,15 +37,18 @@ protected:
         watcher_previous_enabled = tt::llrt::OptionsG.get_watcher_enabled();
         tt::llrt::OptionsG.set_watcher_enabled(false);
 
+        // Setup dispatch core manager to get dispatch cores that need to be excluded from printing
+        const auto &dispatch_core_type = tt::llrt::OptionsG.get_dispatch_core_type();
+        tt::tt_metal::dispatch_core_manager::initialize(dispatch_core_type);
+
         // By default, exclude dispatch cores from printing
         unsigned num_cqs = tt::llrt::OptionsG.get_num_hw_cqs();
         std::map<CoreType, std::unordered_set<CoreCoord>> disabled;
         for (unsigned int id = 0; id < tt::tt_metal::GetNumAvailableDevices(); id++) {
-            // TODO: Better way to get this info once we've solidified how it will be set.
-            const tt::core_descriptor_t &core_desc = tt::get_core_descriptor_config(id, num_cqs);
-            for (auto core : tt::get_logical_dispatch_cores(id, num_cqs)) {
+            CoreType internal_core_type = dispatch_core_manager::instance().get_dispatch_core_type(id);
+            for (auto core : tt::get_logical_dispatch_cores(id, num_cqs, internal_core_type)) {
                 log_info(tt::LogTest, "Disable dprint on Device {}: {}", id, core);
-                disabled[core_desc.dispatch_core_type].insert(core);
+                disabled[internal_core_type].insert(core);
             }
         }
         tt::llrt::OptionsG.set_feature_disabled_cores(tt::llrt::RunTimeDebugFeatureDprint, disabled);

--- a/tests/tt_metal/tt_metal/unit_tests_fast_dispatch/command_queue/test_HostAsyncCQ.cpp
+++ b/tests/tt_metal/tt_metal/unit_tests_fast_dispatch/command_queue/test_HostAsyncCQ.cpp
@@ -15,6 +15,7 @@
 #include "tt_metal/impl/device/device.hpp"
 #include "tt_metal/impl/dispatch/command_queue.hpp"
 #include "tt_metal/impl/buffers/circular_buffer.hpp"
+
 using namespace tt::tt_metal;
 
 namespace host_cq_test_utils {

--- a/tests/tt_metal/tt_metal/unit_tests_fast_dispatch/common/command_queue_fixture.hpp
+++ b/tests/tt_metal/tt_metal/unit_tests_fast_dispatch/common/command_queue_fixture.hpp
@@ -7,6 +7,7 @@
 #include "tt_metal/detail/tt_metal.hpp"
 #include "tt_metal/test_utils/env_vars.hpp"
 #include "tt_metal/common/tt_backend_api_types.hpp"
+#include "tt_metal/llrt/rtoptions.hpp"
 
 class CommandQueueFixture : public ::testing::Test {
    protected:
@@ -22,7 +23,8 @@ class CommandQueueFixture : public ::testing::Test {
 
         const int device_id = 0;
 
-        this->device_ = tt::tt_metal::CreateDevice(device_id);
+        const auto &dispatch_core_type = tt::llrt::OptionsG.get_dispatch_core_type();
+        this->device_ = tt::tt_metal::CreateDevice(device_id, 1, DEFAULT_L1_SMALL_SIZE, DEFAULT_TRACE_REGION_SIZE, dispatch_core_type);
     }
 
     void TearDown() override {
@@ -52,7 +54,8 @@ class CommandQueueMultiDeviceFixture : public ::testing::Test {
             chip_ids.push_back(id);
         }
 
-        reserved_devices_ = tt::tt_metal::detail::CreateDevices(chip_ids);
+        const auto &dispatch_core_type = tt::llrt::OptionsG.get_dispatch_core_type();
+        reserved_devices_ = tt::tt_metal::detail::CreateDevices(chip_ids, 1, DEFAULT_L1_SMALL_SIZE, DEFAULT_TRACE_REGION_SIZE, dispatch_core_type);
         for (const auto &[id, device] : reserved_devices_) {
             devices_.push_back(device);
         }
@@ -77,8 +80,9 @@ class CommandQueueSingleCardFixture : public ::testing::Test {
         auto enable_remote_chip = getenv("TT_METAL_ENABLE_REMOTE_CHIP");
         arch_ = tt::get_arch_from_string(tt::test_utils::get_env_arch_name());
 
+        const auto &dispatch_core_type = tt::llrt::OptionsG.get_dispatch_core_type();
         const chip_id_t mmio_device_id = 0;
-        reserved_devices_ = tt::tt_metal::detail::CreateDevices({mmio_device_id});
+        reserved_devices_ = tt::tt_metal::detail::CreateDevices({mmio_device_id}, 1, DEFAULT_L1_SMALL_SIZE, DEFAULT_TRACE_REGION_SIZE, dispatch_core_type);
         if (enable_remote_chip) {
             for (const auto &[id, device] : reserved_devices_) {
                 devices_.push_back(device);

--- a/tests/tt_metal/tt_metal/unit_tests_fast_dispatch/multichip/test_device_pool.cpp
+++ b/tests/tt_metal/tt_metal/unit_tests_fast_dispatch/multichip/test_device_pool.cpp
@@ -19,7 +19,7 @@ TEST_F(FDBasicFixture, DevicePoolOpenClose) {
     std::vector<chip_id_t> device_ids{0};
     int num_hw_cqs = 1;
     int l1_small_size = 1024;
-    tt::DevicePool::initialize(device_ids, num_hw_cqs, l1_small_size);
+    tt::DevicePool::initialize(device_ids, num_hw_cqs, l1_small_size, DEFAULT_TRACE_REGION_SIZE, DispatchCoreType::WORKER);
     std::vector<tt_metal::Device *> devices = tt::DevicePool::instance().get_all_active_devices();
     for (const auto& dev: devices) {
       ASSERT_TRUE((int)(dev->get_l1_small_size()) == l1_small_size);
@@ -46,7 +46,7 @@ TEST_F(FDBasicFixture, DevicePoolReconfigDevices) {
     std::vector<chip_id_t> device_ids{0};
     int num_hw_cqs = 1;
     int l1_small_size = 1024;
-    tt::DevicePool::initialize(device_ids, num_hw_cqs, l1_small_size);
+    tt::DevicePool::initialize(device_ids, num_hw_cqs, l1_small_size, DEFAULT_TRACE_REGION_SIZE, DispatchCoreType::WORKER);
     std::vector<Device *> devices = tt::DevicePool::instance().get_all_active_devices();
     for (const auto& dev: devices) {
       ASSERT_TRUE((int)(dev->get_l1_small_size()) == l1_small_size);
@@ -59,7 +59,7 @@ TEST_F(FDBasicFixture, DevicePoolReconfigDevices) {
         dev->close();
     }
     l1_small_size = 2048;
-    tt::DevicePool::initialize(device_ids, num_hw_cqs, l1_small_size);
+    tt::DevicePool::initialize(device_ids, num_hw_cqs, l1_small_size, DEFAULT_TRACE_REGION_SIZE, DispatchCoreType::WORKER);
     devices = tt::DevicePool::instance().get_all_active_devices();
     for (const auto& dev: devices) {
       ASSERT_TRUE((int)(dev->get_l1_small_size()) == l1_small_size);
@@ -77,7 +77,7 @@ TEST_F(FDBasicFixture, DevicePoolAddDevices) {
     std::vector<chip_id_t> device_ids{0};
     int num_hw_cqs = 1;
     int l1_small_size = 1024;
-    tt::DevicePool::initialize(device_ids, num_hw_cqs, l1_small_size);
+    tt::DevicePool::initialize(device_ids, num_hw_cqs, l1_small_size, DEFAULT_TRACE_REGION_SIZE, DispatchCoreType::WORKER);
     std::vector<Device *> devices = tt::DevicePool::instance().get_all_active_devices();
     for (const auto& dev: devices) {
       ASSERT_TRUE((int)(dev->get_l1_small_size()) == l1_small_size);
@@ -90,7 +90,7 @@ TEST_F(FDBasicFixture, DevicePoolAddDevices) {
         dev->close();
     }
     device_ids = {0, 1, 2, 3};
-    tt::DevicePool::initialize(device_ids, num_hw_cqs, l1_small_size);
+    tt::DevicePool::initialize(device_ids, num_hw_cqs, l1_small_size, DEFAULT_TRACE_REGION_SIZE, DispatchCoreType::WORKER);
     devices = tt::DevicePool::instance().get_all_active_devices();
     ASSERT_TRUE(devices.size() >= 4);
     for (const auto& dev: devices) {
@@ -110,7 +110,7 @@ TEST_F(FDBasicFixture, DevicePoolReduceDevices) {
     std::vector<chip_id_t> device_ids{0, 1, 2, 3};
     int num_hw_cqs = 1;
     int l1_small_size = 1024;
-    tt::DevicePool::initialize(device_ids, num_hw_cqs, l1_small_size);
+    tt::DevicePool::initialize(device_ids, num_hw_cqs, l1_small_size, DEFAULT_TRACE_REGION_SIZE, DispatchCoreType::WORKER);
     std::vector<Device *> devices = tt::DevicePool::instance().get_all_active_devices();
     for (const auto& dev: devices) {
       ASSERT_TRUE((int)(dev->get_l1_small_size()) == l1_small_size);
@@ -123,7 +123,7 @@ TEST_F(FDBasicFixture, DevicePoolReduceDevices) {
         dev->close();
     }
     device_ids = {0};
-    tt::DevicePool::initialize(device_ids, num_hw_cqs, l1_small_size);
+    tt::DevicePool::initialize(device_ids, num_hw_cqs, l1_small_size, DEFAULT_TRACE_REGION_SIZE, DispatchCoreType::WORKER);
     auto dev = tt::DevicePool::instance().get_active_device(0);
     ASSERT_TRUE(dev->id() == 0);
     ASSERT_TRUE((int)(dev->get_l1_small_size()) == l1_small_size);

--- a/tests/tt_metal/tt_metal/unit_tests_fast_dispatch_single_chip_multi_queue/common/command_queue_fixture.hpp
+++ b/tests/tt_metal/tt_metal/unit_tests_fast_dispatch_single_chip_multi_queue/common/command_queue_fixture.hpp
@@ -24,11 +24,12 @@ class MultiCommandQueueSingleDeviceFixture : public ::testing::Test {
             GTEST_SKIP();
         }
         arch_ = tt::get_arch_from_string(tt::test_utils::get_env_arch_name());
+        DispatchCoreType dispatch_core_type = DispatchCoreType::WORKER;
         if (arch_ == tt::ARCH::WORMHOLE_B0 and tt::tt_metal::GetNumAvailableDevices() != 1) {
             tt::log_warning(tt::LogTest, "Ethernet Dispatch not being explicitly used. Set this configuration in Setup()");
-            setenv("WH_ARCH_YAML", "wormhole_b0_80_arch_eth_dispatch.yaml", true);
+            dispatch_core_type = DispatchCoreType::ETH;
         }
-        device_ = tt::tt_metal::CreateDevice(0, num_cqs);
+        device_ = tt::tt_metal::CreateDevice(0, num_cqs, DEFAULT_L1_SMALL_SIZE, DEFAULT_TRACE_REGION_SIZE, dispatch_core_type);
     }
 
     void TearDown() override {

--- a/tests/ttnn/unit_tests/gtests/test_ccl_on_tg.cpp
+++ b/tests/ttnn/unit_tests/gtests/test_ccl_on_tg.cpp
@@ -36,7 +36,7 @@ TEST(TGTests, TestAllGatherDeadlock) {
     }
 
     // Create the device mesh: Grid size is <num_tunnels, tunnel_depth>.
-    auto mesh = ttnn::multi_device::open_device_mesh({cluster_tunnel_count * num_mmio_devices, num_devices_in_tunnel}, all_device_ids, 0, 0, 1);
+    auto mesh = ttnn::multi_device::open_device_mesh({cluster_tunnel_count * num_mmio_devices, num_devices_in_tunnel}, all_device_ids, 0, 0, 1, DispatchCoreType::WORKER);
 
     // Setup input data and output data containers
     MemoryConfig mem_cfg = MemoryConfig{
@@ -127,7 +127,7 @@ TEST(TGTests, TestReduceScatterDeadlock) {
     }
 
     // Create the device mesh: Grid size is <num_tunnels, tunnel_depth>.
-    auto mesh = ttnn::multi_device::open_device_mesh({cluster_tunnel_count * num_mmio_devices, num_devices_in_tunnel}, all_device_ids, 0, 0, 1);
+    auto mesh = ttnn::multi_device::open_device_mesh({cluster_tunnel_count * num_mmio_devices, num_devices_in_tunnel}, all_device_ids, 0, 0, 1, DispatchCoreType::WORKER);
     // Create the outer ring on which Reduce Scatter will be run. This allows us to verify that there are no deadlocks when we send CCLs to the
     // first tunnel (forward path).
     std::vector<Device*> ring_devices = mesh.get_devices_on_row(0); // Tunnel 0

--- a/tests/ttnn/unit_tests/gtests/ttnn_multi_command_queue_fixture.hpp
+++ b/tests/ttnn/unit_tests/gtests/ttnn_multi_command_queue_fixture.hpp
@@ -21,11 +21,12 @@ class MultiCommandQueueSingleDeviceFixture : public ::testing::Test {
             GTEST_SKIP() << "Skipping Multi CQ test suite, since it can only be run in Fast Dispatch Mode.";
         }
 
+        DispatchCoreType dispatch_core_type = DispatchCoreType::WORKER;
         if (arch_ == tt::ARCH::WORMHOLE_B0 and num_devices_ != 1) {
             tt::log_warning(tt::LogTest, "Ethernet Dispatch not being explicitly used. Set this configuration in Setup()");
-            setenv("WH_ARCH_YAML", "wormhole_b0_80_arch_eth_dispatch.yaml", true);
+            dispatch_core_type = DispatchCoreType::ETH;
         }
-        device_ = tt::tt_metal::CreateDevice(0, 2);
+        device_ = tt::tt_metal::CreateDevice(0, 2, DEFAULT_L1_SMALL_SIZE, DEFAULT_TRACE_REGION_SIZE, dispatch_core_type);
     }
 
     void TearDown() override {
@@ -50,10 +51,8 @@ class MultiCommandQueueT3KFixture : public ::testing::Test {
             GTEST_SKIP() << "Skipping T3K Multi CQ test suite on non T3K machine.";
         }
         // Enable Ethernet Dispatch for Multi-CQ tests.
-        tt::log_warning(tt::LogTest, "Ethernet Dispatch not being explicitly used. Set this configuration in Setup()");
-        setenv("WH_ARCH_YAML", "wormhole_b0_80_arch_eth_dispatch.yaml", true);
 
-        devs = tt::tt_metal::detail::CreateDevices({0, 1, 2, 3, 4, 5, 6, 7}, 2);
+        devs = tt::tt_metal::detail::CreateDevices({0, 1, 2, 3, 4, 5, 6, 7}, 2, DEFAULT_L1_SMALL_SIZE, DEFAULT_TRACE_REGION_SIZE, DispatchCoreType::ETH);
     }
 
     void TearDown() override {

--- a/tests/ttnn/unit_tests/gtests/ttnn_test_fixtures.hpp
+++ b/tests/ttnn/unit_tests/gtests/ttnn_test_fixtures.hpp
@@ -26,12 +26,11 @@ class TTNNFixture : public ::testing::Test {
 
     void SetUp() override {
         std::srand(0);
-        tt::Cluster::instance().set_internal_routing_info_for_ethernet_cores(true);
         arch_ = tt::get_arch_from_string(tt::test_utils::get_env_arch_name());
         num_devices_ = tt::tt_metal::GetNumAvailableDevices();
     }
 
-    void TearDown() override { tt::Cluster::instance().set_internal_routing_info_for_ethernet_cores(false); }
+    void TearDown() override {}
 };
 
 class TTNNFixtureWithDevice : public TTNNFixture {
@@ -73,7 +72,8 @@ class T3kMultiDeviceFixture : public ::testing::Test {
             T3K_DEVICE_IDS,
             DEFAULT_L1_SMALL_SIZE,
             DEFAULT_TRACE_REGION_SIZE,
-            DEFAULT_NUM_COMMAND_QUEUES);
+            DEFAULT_NUM_COMMAND_QUEUES,
+            DispatchCoreType::WORKER);
     }
 
     void TearDown() override { device_mesh_.reset(); }

--- a/tt_metal/detail/tt_metal.hpp
+++ b/tt_metal/detail/tt_metal.hpp
@@ -10,13 +10,13 @@
 #include "tt_metal/third_party/umd/device/tt_soc_descriptor.h"
 #include "tt_metal/hostdevcommon/common_values.hpp"
 #include "tt_metal/common/core_coord.h"
-// #include "tt_metal/impl/dispatch/dispatch_core_manager.hpp"
+#include "tt_metal/impl/dispatch/dispatch_core_manager.hpp"
 
 namespace tt::tt_metal {
     class Program;
     class Buffer;
     class Device;
-    
+
     namespace detail {
 
         bool DispatchStateCheck( bool isFastDispatch);
@@ -27,6 +27,7 @@ namespace tt::tt_metal {
             const uint8_t num_hw_cqs = 1,
             const size_t l1_small_size = DEFAULT_L1_SMALL_SIZE,
             const size_t trace_region_size = DEFAULT_TRACE_REGION_SIZE,
+            tt_metal::DispatchCoreType dispatch_core_type = tt_metal::DispatchCoreType::WORKER,
             const std::vector<uint32_t> &l1_bank_remap = {});
 
         void CloseDevices(std::map<chip_id_t, Device *> devices);
@@ -252,7 +253,7 @@ namespace tt::tt_metal {
         bool WriteToDeviceL1(Device *device, const CoreCoord &logical_core, uint32_t address, std::vector<uint32_t> &host_buffer, CoreType core_type = CoreType::WORKER);
 
         bool WriteRegToDevice(Device *device, const CoreCoord &logical_core, uint32_t address, const uint32_t &regval);
-        
+
         /**
          * Copy data from an L1 buffer into a host buffer. Must be a buffer, and not a CB.
          *

--- a/tt_metal/host_api.hpp
+++ b/tt_metal/host_api.hpp
@@ -6,6 +6,7 @@
 
 #include <variant>
 #include <vector>
+#include "tt_metal/impl/dispatch/dispatch_core_manager.hpp"
 #include "tt_metal/impl/program/program.hpp"
 #include "tt_metal/impl/kernels/runtime_args_data.hpp"
 
@@ -70,6 +71,7 @@ Device *CreateDevice(
     const uint8_t num_hw_cqs = 1,
     const size_t l1_small_size = DEFAULT_L1_SMALL_SIZE,
     const size_t trace_region_size = DEFAULT_TRACE_REGION_SIZE,
+    DispatchCoreType dispatch_core_type = DispatchCoreType::WORKER,
     const std::vector<uint32_t> &l1_bank_remap = {});
 
 /**
@@ -83,7 +85,9 @@ Device *CreateDevice(
  * */
 Device *CreateDeviceMinimal(
     chip_id_t device_id,
-    const uint8_t num_hw_cqs = 1);
+    const uint8_t num_hw_cqs = 1,
+    DispatchCoreType dispatch_core_type = DispatchCoreType::WORKER
+    );
 
 /**
  * Resets device and closes device

--- a/tt_metal/impl/device/device.cpp
+++ b/tt_metal/impl/device/device.cpp
@@ -156,6 +156,7 @@ void Device::initialize_cluster() {
 void Device::initialize_allocator(size_t l1_small_size, size_t trace_region_size, const std::vector<uint32_t> &l1_bank_remap) {
     ZoneScoped;
     const metal_SocDescriptor &soc_desc = tt::Cluster::instance().get_soc_desc(this->id_);
+    CoreType dispatch_core_type = dispatch_core_manager::instance().get_dispatch_core_type(this->id_);
     // Construct allocator config from soc_desc
     AllocatorConfig config(
         {.num_dram_channels = static_cast<size_t>(soc_desc.get_num_dram_channels()),
@@ -163,7 +164,7 @@ void Device::initialize_allocator(size_t l1_small_size, size_t trace_region_size
          .dram_bank_offsets = {},
          .worker_grid_size = this->logical_grid_size(),
          .worker_l1_size = static_cast<size_t>(soc_desc.worker_l1_size),
-         .l1_bank_size = static_cast<size_t>(get_l1_bank_size(this->id_, this->num_hw_cqs_)),
+         .l1_bank_size = static_cast<size_t>(get_l1_bank_size(id_, num_hw_cqs_, dispatch_core_type)),
          .l1_small_size = l1_small_size,
          .trace_region_size = trace_region_size,
          .core_type_from_noc_coord_table = {},  // Populated later
@@ -185,18 +186,17 @@ void Device::initialize_allocator(size_t l1_small_size, size_t trace_region_size
         config.core_type_from_noc_coord_table.insert({core.first, AllocCoreType::Invalid});
     }
 
-    for (const CoreCoord& core : tt::get_logical_compute_cores(id_, num_hw_cqs_)) {
+    for (const CoreCoord& core : tt::get_logical_compute_cores(id_, num_hw_cqs_, dispatch_core_type)) {
         this->compute_cores_.insert(core);
         const auto noc_coord = this->worker_core_from_logical_core(core);
         config.core_type_from_noc_coord_table[noc_coord] = AllocCoreType::ComputeAndStore;
     }
-    for (const CoreCoord& core : tt::get_logical_storage_cores(id_, num_hw_cqs_)) {
+    for (const CoreCoord& core : tt::get_logical_storage_cores(id_, num_hw_cqs_, dispatch_core_type)) {
         this->storage_only_cores_.insert(core);
         const auto noc_coord = this->worker_core_from_logical_core(core);
         config.core_type_from_noc_coord_table[noc_coord] = AllocCoreType::StorageOnly;
     }
-    CoreType dispatch_core_type = tt::get_dispatch_core_type(id_, num_hw_cqs_);
-    for (const CoreCoord& core : tt::get_logical_dispatch_cores(id_, num_hw_cqs_)) {
+    for (const CoreCoord &core : tt::get_logical_dispatch_cores(id_, num_hw_cqs_, dispatch_core_type)) {
         const auto noc_coord = this->physical_core_from_logical_core(core, dispatch_core_type);
         config.core_type_from_noc_coord_table[noc_coord] = AllocCoreType::Dispatch;
     }
@@ -1146,7 +1146,7 @@ void Device::setup_tunnel_for_remote_devices() {
                 settings.cb_log_page_size = dispatch_constants::DISPATCH_BUFFER_LOG_PAGE_SIZE;
                 settings.cb_pages = dispatch_constants::get(dispatch_core_type).dispatch_buffer_pages();
                 settings.cb_size_bytes = (1 << settings.cb_log_page_size) * settings.cb_pages;
-                CoreCoord compute_grid_size = tt::get_compute_grid_size(device_id, num_hw_cqs);
+                CoreCoord compute_grid_size = this->compute_with_storage_grid_size();
                 settings.num_compute_cores = uint32_t(compute_grid_size.x * compute_grid_size.y);
                 tunnel_core_allocations[DISPATCH].push_back(std::make_tuple(dispatch_location, settings));
                 settings.semaphores.clear();
@@ -1914,7 +1914,7 @@ void Device::initialize_synchronous_sw_cmd_queue() {
 bool Device::initialize(const uint8_t num_hw_cqs, size_t l1_small_size, size_t trace_region_size, const std::vector<uint32_t> &l1_bank_remap, bool minimal) {
     ZoneScoped;
     log_info(tt::LogMetal, "Initializing device {}. Program cache is {}enabled", this->id_, this->program_cache.is_enabled() ? "": "NOT ");
-    log_info(tt::LogMetal, "Running with {} cqs ", num_hw_cqs);
+    log_debug(tt::LogMetal, "Running with {} cqs ", num_hw_cqs);
     TT_FATAL(num_hw_cqs > 0 and num_hw_cqs <= dispatch_core_manager::MAX_NUM_HW_CQS, "num_hw_cqs can be between 1 and {}", dispatch_core_manager::MAX_NUM_HW_CQS);
     hal.initialize(this->arch());
     this->using_fast_dispatch = false;
@@ -2053,7 +2053,8 @@ CoreCoord Device::logical_grid_size() const {
 }
 
 CoreCoord Device::compute_with_storage_grid_size() const {
-    return tt::get_compute_grid_size(id_, num_hw_cqs_);
+    CoreType dispatch_core_type = dispatch_core_manager::instance().get_dispatch_core_type(id_);
+    return tt::get_compute_grid_size(id_, num_hw_cqs_, dispatch_core_type);
 }
 
 CoreCoord Device::dram_grid_size() const {

--- a/tt_metal/impl/device/device_mesh.cpp
+++ b/tt_metal/impl/device/device_mesh.cpp
@@ -12,7 +12,7 @@
 
 namespace tt::tt_metal {
 
-DeviceMesh::DeviceMesh(const DeviceGrid& device_grid, const DeviceIds &device_ids, size_t l1_small_size, size_t trace_region_size, size_t num_command_queues)
+DeviceMesh::DeviceMesh(const DeviceGrid& device_grid, const DeviceIds &device_ids, size_t l1_small_size, size_t trace_region_size, size_t num_command_queues, DispatchCoreType dispatch_core_type)
     : device_grid(device_grid)
 {
     auto [num_rows, num_cols] = device_grid;
@@ -47,13 +47,13 @@ DeviceMesh::DeviceMesh(const DeviceGrid& device_grid, const DeviceIds &device_id
                 }
             }
         }
-        managed_devices = tt::tt_metal::detail::CreateDevices(galaxy_device_ids, num_command_queues, l1_small_size, trace_region_size);
+        managed_devices = tt::tt_metal::detail::CreateDevices(galaxy_device_ids, num_command_queues, l1_small_size, trace_region_size, dispatch_core_type);
         for (int i = 0; i < num_requested_devices; i++) {
             mesh_devices.emplace_back(device_ids[i], managed_devices.at(galaxy_device_ids[i]));
         }
         this->view = std::make_unique<tt::tt_metal::DeviceMeshView>(*this);
     } else {
-        managed_devices = tt::tt_metal::detail::CreateDevices(device_ids, num_command_queues, l1_small_size, trace_region_size);
+        managed_devices = tt::tt_metal::detail::CreateDevices(device_ids, num_command_queues, l1_small_size, trace_region_size, dispatch_core_type);
         for (int i = 0; i < num_requested_devices; i++) {
             mesh_devices.emplace_back(device_ids[i], managed_devices.at(device_ids[i]));
         }

--- a/tt_metal/impl/device/device_mesh.hpp
+++ b/tt_metal/impl/device/device_mesh.hpp
@@ -25,7 +25,7 @@ public:
     std::vector<std::pair<int, Device *>> mesh_devices;
     std::shared_ptr<DeviceMeshView> view;
 
-    DeviceMesh(const DeviceGrid &device_grid, const DeviceIds &device_ids, size_t l1_small_size, size_t trace_region_size, size_t num_command_queues);
+    DeviceMesh(const DeviceGrid &device_grid, const DeviceIds &device_ids, size_t l1_small_size, size_t trace_region_size, size_t num_command_queues, DispatchCoreType dispatch_core_type);
     ~DeviceMesh();
 
     DeviceMesh(const DeviceMesh &) = delete;

--- a/tt_metal/impl/device/device_pool.hpp
+++ b/tt_metal/impl/device/device_pool.hpp
@@ -27,7 +27,8 @@ class DevicePool {
         std::vector<chip_id_t> device_ids,
         const uint8_t num_hw_cqs,
         size_t l1_small_size,
-        size_t trace_region_size = DEFAULT_TRACE_REGION_SIZE,
+        size_t trace_region_size,
+        DispatchCoreType dispatch_core_type,
         const std::vector<uint32_t> &l1_bank_remap = {}) noexcept;
 
     Device *get_active_device(chip_id_t device_id) const;

--- a/tt_metal/impl/program/program.cpp
+++ b/tt_metal/impl/program/program.cpp
@@ -915,7 +915,8 @@ void Program::compile(Device *device, bool fd_bootloader_mode) {
         //      - eth kernels cannot be on idle eth cores
         bool slow_dispatch = std::getenv("TT_METAL_SLOW_DISPATCH_MODE") != nullptr;
 
-        const std::vector<CoreCoord> &storage_cores = tt::get_logical_storage_cores(device->id(), device->num_hw_cqs());
+        CoreType dispatch_core_type = dispatch_core_manager::instance().get_dispatch_core_type(device->id());
+        const std::vector<CoreCoord> &storage_cores = tt::get_logical_storage_cores(device->id(), device->num_hw_cqs(), dispatch_core_type);
         bool on_storage_only_core =  std::any_of(storage_cores.begin(), storage_cores.end(), [&kernel](const CoreCoord& storage_core) {
             return kernel->is_on_logical_core(storage_core);
         });
@@ -923,8 +924,7 @@ void Program::compile(Device *device, bool fd_bootloader_mode) {
 
         // Kernels used to implement fast dispatch can be placed on dispatch cores
         if (not slow_dispatch and not fd_bootloader_mode) {
-            const std::vector<CoreCoord> &dispatch_cores = tt::get_logical_dispatch_cores(device->id(), device->num_hw_cqs());
-            CoreType dispatch_core_type = dispatch_core_manager::instance().get_dispatch_core_type(device->id());
+            const std::vector<CoreCoord> &dispatch_cores = tt::get_logical_dispatch_cores(device->id(), device->num_hw_cqs(), dispatch_core_type);
 
             bool on_dispatch_core = std::any_of(dispatch_cores.begin(), dispatch_cores.end(), [&kernel, &dispatch_core_type](const CoreCoord &dispatch_core) {
                 if (kernel->get_kernel_core_type() != dispatch_core_type) {

--- a/tt_metal/llrt/rtoptions.cpp
+++ b/tt_metal/llrt/rtoptions.cpp
@@ -97,6 +97,11 @@ RunTimeOptions::RunTimeOptions() {
     if (dispatch_data_collection_str != nullptr) {
         enable_dispatch_data_collection = true;
     }
+
+    if (getenv("TT_METAL_GTEST_ETH_DISPATCH")) {
+        this->dispatch_core_type = tt_metal::DispatchCoreType::ETH;
+    }
+
 }
 
 const std::string &RunTimeOptions::get_root_dir() {

--- a/tt_metal/llrt/rtoptions.hpp
+++ b/tt_metal/llrt/rtoptions.hpp
@@ -15,6 +15,7 @@
 #include <vector>
 
 #include "tt_metal/common/core_coord.h"
+#include "tt_metal/impl/dispatch/dispatch_core_manager.hpp"
 #include "tt_metal/third_party/umd/device/tt_soc_descriptor.h"  // For CoreType
 
 namespace tt {
@@ -100,6 +101,8 @@ class RunTimeOptions {
     unsigned num_hw_cqs = 1;
 
     bool enable_dispatch_data_collection = false;
+
+    tt_metal::DispatchCoreType dispatch_core_type = tt_metal::DispatchCoreType::WORKER;
 
    public:
     RunTimeOptions();
@@ -245,6 +248,8 @@ class RunTimeOptions {
 
     inline bool get_dispatch_data_collection_enabled() { return enable_dispatch_data_collection; }
     inline void set_dispatch_data_collection_enabled(bool enable) { enable_dispatch_data_collection = enable; }
+
+    inline tt_metal::DispatchCoreType get_dispatch_core_type() { return dispatch_core_type; }
 
    private:
     // Helper functions to parse feature-specific environment vaiables.

--- a/tt_metal/tools/profiler/tt_metal_profiler.cpp
+++ b/tt_metal/tools/profiler/tt_metal_profiler.cpp
@@ -319,7 +319,8 @@ void DumpDeviceProfileResults(Device *device, bool lastDump) {
     std::vector<CoreCoord> workerCores;
     auto device_id = device->id();
     auto device_num_hw_cqs = device->num_hw_cqs();
-    for (const CoreCoord& core : tt::get_logical_compute_cores(device_id, device_num_hw_cqs)) {
+    CoreType dispatch_core_type = dispatch_core_manager::instance().get_dispatch_core_type(device_id);
+    for (const CoreCoord& core : tt::get_logical_compute_cores(device_id, device_num_hw_cqs, dispatch_core_type)) {
         const CoreCoord curr_core = device->worker_core_from_logical_core(core);
         workerCores.push_back(curr_core);
     }
@@ -336,11 +337,11 @@ void DumpDeviceProfileResults(Device *device, std::vector<CoreCoord> &worker_cor
 #if defined(TRACY_ENABLE)
     ZoneScoped;
 
+    auto dispatch_core_type = dispatch_core_manager::instance().get_dispatch_core_type(device->id());
     if (tt::llrt::OptionsG.get_profiler_do_dispatch_cores()) {
         auto device_id = device->id();
         auto device_num_hw_cqs = device->num_hw_cqs();
-        for (const CoreCoord& core : tt::get_logical_dispatch_cores(device_id, device_num_hw_cqs)) {
-            CoreType dispatch_core_type = tt::get_dispatch_core_type(device_id, device_num_hw_cqs);
+        for (const CoreCoord& core : tt::get_logical_dispatch_cores(device_id, device_num_hw_cqs, dispatch_core_type)) {
             const auto curr_core = device->physical_core_from_logical_core(core, dispatch_core_type);
             worker_cores.push_back(curr_core);
         }
@@ -383,9 +384,8 @@ void DumpDeviceProfileResults(Device *device, std::vector<CoreCoord> &worker_cor
                         log_warning(msg.c_str());
                         break;
                     }
-                    for (const CoreCoord& core : tt::get_logical_dispatch_cores(device_id, device_num_hw_cqs))
-                    {
-                        CoreType dispatch_core_type = tt::get_dispatch_core_type(device_id, device_num_hw_cqs);
+                    for (const CoreCoord& core :
+                         tt::get_logical_dispatch_cores(device_id, device_num_hw_cqs, dispatch_core_type)) {
                         const auto curr_core = device->physical_core_from_logical_core(core, dispatch_core_type);
                         vector<std::uint32_t> control_buffer = tt::llrt::read_hex_vec_from_core(
                                 device_id,

--- a/tt_metal/tools/watcher_dump/watcher_dump.cpp
+++ b/tt_metal/tools/watcher_dump/watcher_dump.cpp
@@ -39,7 +39,7 @@ void dump_data(vector<unsigned>& device_ids, bool dump_watcher, bool dump_cqs, b
         string iq_fname = cq_dir.string() + fmt::format("device_{}_issue_q.txt", id);
         std::ofstream iq_file = std::ofstream(iq_fname);
         // Minimal setup, since we'll be attaching to a potentially hanging chip.
-        auto* device = tt::tt_metal::CreateDeviceMinimal(id, num_hw_cqs);
+        auto* device = tt::tt_metal::CreateDeviceMinimal(id, num_hw_cqs, DispatchCoreType::WORKER);
         if (dump_cqs) {
             std::unique_ptr<SystemMemoryManager> sysmem_manager =
                 std::make_unique<SystemMemoryManager>(id, num_hw_cqs);

--- a/tt_metal/tt_metal.cpp
+++ b/tt_metal/tt_metal.cpp
@@ -277,13 +277,14 @@ std::map<chip_id_t, Device *> CreateDevices(
     const uint8_t num_hw_cqs,
     const size_t l1_small_size,
     const size_t trace_region_size,
+    DispatchCoreType dispatch_core_type,
     const std::vector<uint32_t> &l1_bank_remap) {
     ZoneScoped;
     bool is_galaxy = tt::Cluster::instance().is_galaxy_cluster();
     if (is_galaxy) {
         TT_FATAL(num_hw_cqs < 2, "Multiple Command Queues are not Currently Supported on Galaxy Systems");
     }
-    tt::DevicePool::initialize(device_ids, num_hw_cqs, l1_small_size, trace_region_size);
+    tt::DevicePool::initialize(device_ids, num_hw_cqs, l1_small_size, trace_region_size, dispatch_core_type);
     std::vector<Device *> devices = tt::DevicePool::instance().get_all_active_devices();
     std::map<chip_id_t, Device *> ret_devices;
     //Only include the mmio device in the active devices set returned to the caller if we are not running
@@ -830,17 +831,18 @@ Device *CreateDevice(
     const uint8_t num_hw_cqs,
     const size_t l1_small_size,
     const size_t trace_region_size,
+    DispatchCoreType dispatch_core_type,
     const std::vector<uint32_t> &l1_bank_remap) {
     ZoneScoped;
 
-    tt::DevicePool::initialize({device_id}, num_hw_cqs, l1_small_size, trace_region_size, l1_bank_remap);
+    tt::DevicePool::initialize({device_id}, num_hw_cqs, l1_small_size, trace_region_size, dispatch_core_type, l1_bank_remap);
     auto dev = tt::DevicePool::instance().get_active_device(device_id);
     return dev;
 }
 
-Device *CreateDeviceMinimal(chip_id_t device_id, const uint8_t num_hw_cqs) {
+Device *CreateDeviceMinimal(chip_id_t device_id, const uint8_t num_hw_cqs, DispatchCoreType dispatch_core_type) {
     ZoneScoped;
-    tt::tt_metal::dispatch_core_manager::initialize();
+    tt::tt_metal::dispatch_core_manager::initialize(dispatch_core_type);
     Device *dev = new Device(device_id, num_hw_cqs, DEFAULT_L1_SMALL_SIZE, DEFAULT_TRACE_REGION_SIZE, {}, true);
     tt::Cluster::instance().set_internal_routing_info_for_ethernet_cores(true);
     return dev;

--- a/ttnn/cpp/pybind11/device.hpp
+++ b/ttnn/cpp/pybind11/device.hpp
@@ -21,6 +21,7 @@ void py_module(py::module& module) {
         py::arg("device_id"),
         py::arg("l1_small_size"),
         py::arg("trace_region_size"),
+        py::arg("dispatch_core_type"),
         py::return_value_policy::reference);
 
     module.def("close_device", &ttnn::close_device, py::arg("device"), py::kw_only());

--- a/ttnn/cpp/pybind11/multi_device.hpp
+++ b/ttnn/cpp/pybind11/multi_device.hpp
@@ -19,13 +19,14 @@ namespace multi_device {
 void py_module(py::module& module) {
     py::class_<DeviceMesh>(module, "DeviceMesh")
         .def(
-            py::init<DeviceGrid, std::vector<int>, size_t, size_t, size_t>(),
+            py::init<DeviceGrid, std::vector<int>, size_t, size_t, size_t, DispatchCoreType>(),
             py::kw_only(),
             py::arg("device_grid"),
             py::arg("device_ids"),
             py::arg("l1_small_size"),
             py::arg("trace_region_size"),
-            py::arg("num_command_queues"))
+            py::arg("num_command_queues"),
+            py::arg("dispatch_core_type"))
         .def("get_num_devices", &DeviceMesh::num_devices)
         .def("get_device_ids", &DeviceMesh::get_device_ids)
         .def(
@@ -100,7 +101,8 @@ void py_module(py::module& module) {
         py::arg("device_ids"),
         py::arg("l1_small_size"),
         py::arg("trace_region_size"),
-        py::arg("num_command_queues"));
+        py::arg("num_command_queues"),
+        py::arg("dispatch_core_type"));
 
     module.def("close_device_mesh", &close_device_mesh, py::arg("device_mesh"), py::kw_only());
     module.def(

--- a/ttnn/cpp/ttnn/deprecated/tt_lib/csrc/tt_lib_bindings.cpp
+++ b/ttnn/cpp/ttnn/deprecated/tt_lib/csrc/tt_lib_bindings.cpp
@@ -36,6 +36,10 @@ void DeviceModule(py::module &m_device) {
         .value("WORMHOLE_B0", tt::ARCH::WORMHOLE_B0)
         .value("BLACKHOLE", tt::ARCH::BLACKHOLE);
 
+    py::enum_<DispatchCoreType>(m_device, "DispatchCoreType", "Enum of types of dispatch cores.")
+        .value("WORKER", DispatchCoreType::WORKER)
+        .value("ETH", DispatchCoreType::ETH);
+
     auto pyDevice = py::class_<Device, std::unique_ptr<Device, py::nodelete>>(m_device, "Device", "Class describing a Tenstorrent accelerator device.");
     pyDevice
         .def(
@@ -87,7 +91,7 @@ void DeviceModule(py::module &m_device) {
         )doc");
     m_device.def(
         "CreateDevice",
-        [](int device_id, uint8_t num_hw_cqs, size_t l1_small_size, size_t trace_region_size) { return CreateDevice(device_id, num_hw_cqs, l1_small_size, trace_region_size); },
+        [](int device_id, uint8_t num_hw_cqs, size_t l1_small_size, size_t trace_region_size, DispatchCoreType dispatch_core_type) { return CreateDevice(device_id, num_hw_cqs, l1_small_size, trace_region_size, dispatch_core_type); },
         R"doc(
         Creates an instance of TT device.
 
@@ -100,11 +104,12 @@ void DeviceModule(py::module &m_device) {
         py::arg("device_id"),
         py::arg("num_hw_cqs") = 1,
         py::arg("l1_small_size") = DEFAULT_L1_SMALL_SIZE,
-        py::arg("trace_region_size") = DEFAULT_TRACE_REGION_SIZE);
+        py::arg("trace_region_size") = DEFAULT_TRACE_REGION_SIZE,
+        py::arg("dispatch_core_type") = DispatchCoreType::WORKER);
     m_device.def(
         "CreateDevices",
-        [](std::vector<int> device_ids, uint8_t num_hw_cqs, size_t l1_small_size, size_t trace_region_size) {
-            return tt::tt_metal::detail::CreateDevices(device_ids, num_hw_cqs, l1_small_size, trace_region_size);
+        [](std::vector<int> device_ids, uint8_t num_hw_cqs, size_t l1_small_size, size_t trace_region_size, DispatchCoreType dispatch_core_type) {
+            return tt::tt_metal::detail::CreateDevices(device_ids, num_hw_cqs, l1_small_size, trace_region_size, dispatch_core_type);
         },
         R"doc(
         Creates an instance of TT device.
@@ -118,7 +123,8 @@ void DeviceModule(py::module &m_device) {
         py::arg("device_ids"),
         py::arg("num_hw_cqs") = 1,
         py::arg("l1_small_size") = DEFAULT_L1_SMALL_SIZE,
-        py::arg("trace_region_size") = DEFAULT_TRACE_REGION_SIZE);
+        py::arg("trace_region_size") = DEFAULT_TRACE_REGION_SIZE,
+        py::arg("dispatch_core_type") = DispatchCoreType::WORKER);
     m_device.def("CloseDevice", &CloseDevice, R"doc(
         Reset an instance of TT accelerator device to default state and relinquish connection to device.
 

--- a/ttnn/cpp/ttnn/device.cpp
+++ b/ttnn/cpp/ttnn/device.cpp
@@ -9,8 +9,8 @@ namespace ttnn {
 
 namespace device {
 
-Device &open_device(int device_id, size_t l1_small_size, size_t trace_region_size) {
-    tt::DevicePool::initialize({device_id}, 1, l1_small_size, trace_region_size, {});
+Device &open_device(int device_id, size_t l1_small_size, size_t trace_region_size, DispatchCoreType dispatch_core_type) {
+    tt::DevicePool::initialize({device_id}, 1, l1_small_size, trace_region_size, dispatch_core_type, {});
     return *(tt::DevicePool::instance().get_active_device(device_id));
 }
 
@@ -28,6 +28,7 @@ void disable_and_clear_program_cache(Device &device) {
 
 void close_device(Device &device) {
     tt::DevicePool::instance().close_device(device.id());
+
 }
 
 bool is_wormhole_or_blackhole(tt::ARCH arch) {

--- a/ttnn/cpp/ttnn/device.hpp
+++ b/ttnn/cpp/ttnn/device.hpp
@@ -11,7 +11,7 @@ namespace device {
 
 using Device = ttnn::Device;
 
-Device &open_device(int device_id, size_t l1_small_size = DEFAULT_L1_SMALL_SIZE, size_t trace_region_size = DEFAULT_TRACE_REGION_SIZE);
+Device &open_device(int device_id, size_t l1_small_size = DEFAULT_L1_SMALL_SIZE, size_t trace_region_size = DEFAULT_TRACE_REGION_SIZE, DispatchCoreType dispatch_core_type = DispatchCoreType::WORKER);
 void close_device(Device &device);
 void enable_program_cache(Device &device);
 void disable_and_clear_program_cache(Device &device);

--- a/ttnn/cpp/ttnn/multi_device.cpp
+++ b/ttnn/cpp/ttnn/multi_device.cpp
@@ -12,8 +12,8 @@
 
 namespace ttnn::multi_device {
 
-DeviceMesh open_device_mesh(const DeviceGrid& device_grid, const DeviceIds& device_ids, size_t l1_small_size, size_t trace_region_size, size_t num_command_queues) {
-    return DeviceMesh(device_grid, device_ids, l1_small_size, trace_region_size, num_command_queues);
+DeviceMesh open_device_mesh(const DeviceGrid& device_grid, const DeviceIds& device_ids, size_t l1_small_size, size_t trace_region_size, size_t num_command_queues, DispatchCoreType dispatch_core_type) {
+    return DeviceMesh(device_grid, device_ids, l1_small_size, trace_region_size, num_command_queues, dispatch_core_type);
 }
 
 void close_device_mesh(DeviceMesh &multi_device) {

--- a/ttnn/cpp/ttnn/multi_device.hpp
+++ b/ttnn/cpp/ttnn/multi_device.hpp
@@ -15,7 +15,7 @@ using Device = ttnn::Device;
 namespace ttnn {
 namespace multi_device {
 
-DeviceMesh open_device_mesh(const DeviceGrid& device_grid, const DeviceIds& device_ids, size_t l1_small_size, size_t trace_region_size, size_t num_command_queues);
+DeviceMesh open_device_mesh(const DeviceGrid& device_grid, const DeviceIds& device_ids, size_t l1_small_size, size_t trace_region_size, size_t num_command_queues, DispatchCoreType dispatch_core_type);
 void close_device_mesh(DeviceMesh &multi_device);
 
 std::vector<ttnn::Tensor> get_device_tensors(const ttnn::Tensor& tensor);

--- a/ttnn/cpp/ttnn/reports.hpp
+++ b/ttnn/cpp/ttnn/reports.hpp
@@ -34,7 +34,8 @@ struct DeviceInfo {
 
 DeviceInfo get_device_info(const Device &device) {
     DeviceInfo info{};
-    const auto descriptor = tt::get_core_descriptor_config(device.id(), device.num_hw_cqs());
+    CoreType dispatch_core_type = dispatch_core_manager::instance().get_dispatch_core_type(device.id());
+    const auto descriptor = tt::get_core_descriptor_config(device.id(), device.num_hw_cqs(), dispatch_core_type);
     info.num_y_cores = device.logical_grid_size().y;
     info.num_x_cores = device.logical_grid_size().x;
     info.num_y_compute_cores = descriptor.compute_grid_size.y;

--- a/ttnn/ttnn/__init__.py
+++ b/ttnn/ttnn/__init__.py
@@ -141,6 +141,7 @@ from ttnn.types import (
 
 from ttnn.device import (
     Device,
+    DispatchCoreType,
     open_device,
     close_device,
     enable_program_cache,
@@ -152,6 +153,7 @@ from ttnn.device import (
 
 from ttnn.multi_device import (
     DeviceMesh,
+    DispatchCoreType,
     open_device_mesh,
     close_device_mesh,
     get_num_pcie_devices,

--- a/ttnn/ttnn/device.py
+++ b/ttnn/ttnn/device.py
@@ -18,12 +18,14 @@ def get_device_core_grid(device):
 # TODO: Device = ttnn._ttnn.Device
 Device = ttnn._ttnn.deprecated.device.Device
 Device.core_grid = property(get_device_core_grid)
+DispatchCoreType = ttnn._ttnn.deprecated.device.DispatchCoreType
 
 
 def open_device(
     device_id: int,
     l1_small_size: int = ttnn._ttnn.deprecated.device.DEFAULT_L1_SMALL_SIZE,
     trace_region_size: int = ttnn._ttnn.deprecated.device.DEFAULT_TRACE_REGION_SIZE,
+    dispatch_core_type: int = DispatchCoreType.WORKER,
 ):
     """
     open_device(device_id: int) -> ttnn.Device:
@@ -31,7 +33,10 @@ def open_device(
     Open a device with the given device_id. If the device is already open, return the existing device.
     """
     return ttnn._ttnn.device.open_device(
-        device_id=device_id, l1_small_size=l1_small_size, trace_region_size=trace_region_size
+        device_id=device_id,
+        l1_small_size=l1_small_size,
+        trace_region_size=trace_region_size,
+        dispatch_core_type=dispatch_core_type,
     )
 
 

--- a/ttnn/ttnn/multi_device.py
+++ b/ttnn/ttnn/multi_device.py
@@ -16,6 +16,7 @@ def get_device_mesh_core_grid(device_mesh):
 
 DeviceMesh = ttnn._ttnn.multi_device.DeviceMesh
 DeviceMesh.core_grid = property(get_device_mesh_core_grid)
+DispatchCoreType = ttnn._ttnn.deprecated.device.DispatchCoreType
 
 
 def _get_rich_table(
@@ -136,6 +137,7 @@ def open_device_mesh(
     l1_small_size: int = ttnn._ttnn.deprecated.device.DEFAULT_L1_SMALL_SIZE,
     trace_region_size: int = ttnn._ttnn.deprecated.device.DEFAULT_TRACE_REGION_SIZE,
     num_command_queues: int = 1,
+    dispatch_core_type: int = DispatchCoreType.WORKER,
 ):
     """
     open_device_mesh(device_grid: ttnn.DeviceGrid, device_ids: int) -> ttnn.DeviceMesh:
@@ -150,6 +152,7 @@ def open_device_mesh(
         l1_small_size=l1_small_size,
         trace_region_size=trace_region_size,
         num_command_queues=num_command_queues,
+        dispatch_core_type=dispatch_core_type,
     )
 
 
@@ -169,6 +172,7 @@ def create_device_mesh(
     l1_small_size: int = ttnn._ttnn.deprecated.device.DEFAULT_L1_SMALL_SIZE,
     trace_region_size: int = ttnn._ttnn.deprecated.device.DEFAULT_TRACE_REGION_SIZE,
     num_command_queues: int = 1,
+    dispatch_core_type: int = DispatchCoreType.WORKER,
 ):
     """
     create_device_mesh(device_grid: ttnn.DeviceGrid, device_ids: List[int]) -> ttnn.DeviceMesh
@@ -181,6 +185,7 @@ def create_device_mesh(
         l1_small_size=l1_small_size,
         trace_region_size=trace_region_size,
         num_command_queues=num_command_queues,
+        dispatch_core_type=dispatch_core_type,
     )
     try:
         yield device_mesh

--- a/ttnn/tutorials/001.ipynb
+++ b/ttnn/tutorials/001.ipynb
@@ -124,8 +124,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "import os\n",
-    "os.environ[\"WH_ARCH_YAML\"] = \"wormhole_b0_80_arch_eth_dispatch.yaml\""
+    "import os\n"
    ]
   },
   {

--- a/ttnn/tutorials/002.ipynb
+++ b/ttnn/tutorials/002.ipynb
@@ -20,8 +20,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "import os\n",
-    "os.environ[\"WH_ARCH_YAML\"] = \"wormhole_b0_80_arch_eth_dispatch.yaml\""
+    "import os\n"
    ]
   },
   {

--- a/ttnn/tutorials/003.ipynb
+++ b/ttnn/tutorials/003.ipynb
@@ -23,8 +23,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "import os\n",
-    "os.environ[\"WH_ARCH_YAML\"] = \"wormhole_b0_80_arch_eth_dispatch.yaml\""
+    "import os\n"
    ]
   },
   {
@@ -128,7 +127,10 @@
     "torch.manual_seed(0)\n",
     "\n",
     "device_id = 0\n",
-    "device = ttnn.open_device(device_id=device_id, l1_small_size=8192)"
+    "dispatch_core_type = ttnn.device.DispatchCoreType.ETH\n",
+    "if \"grayskull\" in os.environ.get(\"ARCH_NAME\"):\n",
+    "    dispatch_core_type = ttnn.device.DispatchCoreType.WORKER\n",
+    "device = ttnn.open_device(device_id=device_id, l1_small_size=8192, dispatch_core_type=dispatch_core_type)"
    ]
   },
   {

--- a/ttnn/tutorials/004.ipynb
+++ b/ttnn/tutorials/004.ipynb
@@ -24,7 +24,6 @@
    "outputs": [],
    "source": [
     "import os\n",
-    "os.environ[\"WH_ARCH_YAML\"] = \"wormhole_b0_80_arch_eth_dispatch.yaml\"\n",
     "os.environ[\"TTNN_CONFIG_OVERRIDES\"] = \"{\\\"enable_fast_runtime_mode\\\": false}\""
    ]
   },
@@ -820,7 +819,10 @@
     }
    ],
    "source": [
-    "device = ttnn.open_device(device_id=0, l1_small_size=8192)"
+    "dispatch_core_type = ttnn.device.DispatchCoreType.ETH\n",
+    "if \"grayskull\" in os.environ.get(\"ARCH_NAME\"):\n",
+    "    dispatch_core_type = ttnn.device.DispatchCoreType.WORKER\n",
+    "device = ttnn.open_device(device_id=0, l1_small_size=8192, dispatch_core_type=dispatch_core_type)"
    ]
   },
   {


### PR DESCRIPTION
### Ticket
[Link to Github Issue](https://github.com/tenstorrent/tt-metal/issues/9514)
### Problem description
WH_ARCH_YAML was being used to select ethernet vs tensix dispatch. Requests from model/op writers and from runtime to remove this.

### What's changed
Removed WH_ARCH_YAML from everywhere in ttmetal ttnn. Using a flag TT_METAL_GTEST_ETH_DISPATCH to toggle runtime cpp testing.

Now all create device and open device apis support passing in dispatch core type.

### Checklist
- [x] Post commit CI passes
- [x] Model regression CI testing passes (if applicable)
- [x] New/Existing tests provide coverage for changes
