### PR TITLE
#11038: Changed runner-labels

### DIFF
--- a/.github/workflows/bisect-dispatch.yaml
+++ b/.github/workflows/bisect-dispatch.yaml
@@ -9,6 +9,7 @@ on:
         options:
           - grayskull
           - wormhole_b0
+          - blackhole
       runner-label:
         required: true
         type: string

--- a/.github/workflows/bisect-dispatch.yaml
+++ b/.github/workflows/bisect-dispatch.yaml
@@ -40,7 +40,9 @@ jobs:
       TT_METAL_ENV: ${{ vars.TT_METAL_ENV }}
       ARCH_NAME: ${{ inputs.arch }}
     environment: dev
-    runs-on: ${{ inputs.runner-label }}
+    runs-on:
+      - ${{ inputs.runner-label }}
+      - "in-service"
     steps:
       - uses: tenstorrent-metal/metal-workflows/.github/actions/checkout-with-submodule-lfs@v2.0.0
       - name: Set up dyanmic env vars for build

--- a/.github/workflows/build-and-unit-tests.yaml
+++ b/.github/workflows/build-and-unit-tests.yaml
@@ -39,7 +39,8 @@ jobs:
     name: ${{ inputs.arch }} ${{ inputs.runner-label }}
     runs-on:
       - ${{ inputs.runner-label }}
-      - "in-service"
+      - cloud-virtual-machine
+      - in-service
     env:
       TT_METAL_ENV: ${{ vars.TT_METAL_ENV }}
       ARCH_NAME: ${{ inputs.arch}}

--- a/.github/workflows/build-artifact.yaml
+++ b/.github/workflows/build-artifact.yaml
@@ -46,7 +46,7 @@ jobs:
       SILENT: 0
       VERBOSE: 1
     environment: dev
-    runs-on: 
+    runs-on:
       - build
       - in-service
     steps:

--- a/.github/workflows/build-docker-artifact.yaml
+++ b/.github/workflows/build-docker-artifact.yaml
@@ -14,7 +14,9 @@ jobs:
       TT_METAL_DOCKER_IMAGE: tt-metalium/ubuntu-20.04-amd64
       TT_METAL_DOCKER_IMAGE_TAG: ${{ github.sha }}
     environment: dev
-    runs-on: build-docker
+    runs-on:
+      - build-docker
+      - in-service
     steps:
       - uses: tenstorrent-metal/metal-workflows/.github/actions/checkout-with-submodule-lfs@v2.0.0
       - name: Login to GitHub Container Registry
@@ -38,4 +40,4 @@ jobs:
         run: |
           GITHUB_REPO_DOCKER_IMAGE_TAG=ghcr.io/${{ github.repository }}/${{ env.TT_METAL_DOCKER_IMAGE }}:${{ env.IMAGE_TAG }}
           docker tag ${{ env.TT_METAL_DOCKER_IMAGE }}:${{ env.TT_METAL_DOCKER_IMAGE_TAG }} $GITHUB_REPO_DOCKER_IMAGE_TAG
-          docker push $GITHUB_REPO_DOCKER_IMAGE_TAG 
+          docker push $GITHUB_REPO_DOCKER_IMAGE_TAG

--- a/.github/workflows/cpp-post-commit.yaml
+++ b/.github/workflows/cpp-post-commit.yaml
@@ -53,7 +53,8 @@ jobs:
       LD_LIBRARY_PATH: ${{ github.workspace }}/build/lib
     runs-on:
       - ${{ inputs.runner-label }}
-      - "in-service"
+      - cloud-virtual-machine
+      - in-service
     steps:
       - uses: tenstorrent-metal/metal-workflows/.github/actions/checkout-with-submodule-lfs@v2.0.0
       - name: Set up dynamic env vars for build

--- a/.github/workflows/fast-dispatch-build-and-unit-tests.yaml
+++ b/.github/workflows/fast-dispatch-build-and-unit-tests.yaml
@@ -61,7 +61,8 @@ jobs:
       LD_LIBRARY_PATH: ${{ github.workspace }}/build/lib
     runs-on:
       - ${{ inputs.runner-label }}
-      - "in-service"
+      - cloud-virtual-machine
+      - in-service
     steps:
       - uses: tenstorrent-metal/metal-workflows/.github/actions/checkout-with-submodule-lfs@v2.0.0
       - name: Set up dynamic env vars for build

--- a/.github/workflows/fast-dispatch-full-regressions-and-models.yaml
+++ b/.github/workflows/fast-dispatch-full-regressions-and-models.yaml
@@ -22,84 +22,84 @@ jobs:
             {
               name: "Common models GS",
               arch: grayskull,
-              runs-on: ["cloud-virtual-machine", "arch-grayskull", "E150", "in-service", "mount-cloud-weka"],
+              runs-on: ["cloud-virtual-machine", "E150", "in-service", "mount-cloud-weka"],
               cmd: tests/scripts/single_card/nightly/run_common_models.sh,
               timeout: 40
             },
             {
               name: "Common models N300 WH B0",
               arch: wormhole_b0,
-              runs-on: ["cloud-virtual-machine", "arch-wormhole_b0", "N300", "in-service", "mount-cloud-weka"],
+              runs-on: ["cloud-virtual-machine", "N300", "in-service", "mount-cloud-weka"],
               cmd: tests/scripts/single_card/nightly/run_common_models.sh,
               timeout: 40,
             },
             {
               name: "Common models N150 WH BO",
               arch: wormhole_b0,
-              runs-on: ["cloud-virtual-machine", "arch-wormhole_b0", "N150", "in-service", "mount-cloud-weka"],
+              runs-on: ["cloud-virtual-machine", "N150", "in-service", "mount-cloud-weka"],
               cmd: tests/scripts/single_card/nightly/run_common_models.sh,
               timeout: 40,
             },
             {
               name: "GS ttnn nightly",
               arch: grayskull,
-              runs-on: ["cloud-virtual-machine", "arch-grayskull", "E150", "in-service", "mount-cloud-weka"],
+              runs-on: ["cloud-virtual-machine", "E150", "in-service", "mount-cloud-weka"],
               cmd: tests/scripts/single_card/nightly/run_ttnn.sh,
               timeout: 40
             },
             {
               name: "WH N150 ttnn nightly",
               arch: wormhole_b0,
-              runs-on: ["cloud-virtual-machine", "arch-wormhole_b0", "N150", "in-service", "mount-cloud-weka"],
+              runs-on: ["cloud-virtual-machine", "N150", "in-service", "mount-cloud-weka"],
               cmd: tests/scripts/single_card/nightly/run_ttnn.sh,
               timeout: 70
             },
             {
               name: "WH N300 ttnn nightly",
               arch: wormhole_b0,
-              runs-on: ["cloud-virtual-machine", "arch-wormhole_b0", "N300", "in-service", "mount-cloud-weka"],
+              runs-on: ["cloud-virtual-machine", "N300", "in-service", "mount-cloud-weka"],
               cmd: tests/scripts/single_card/nightly/run_ttnn.sh,
               timeout: 70
             },
             {
               name: "GS-only models",
               arch: grayskull,
-              runs-on: ["cloud-virtual-machine", "arch-grayskull", "E150", "in-service", "mount-cloud-weka"],
+              runs-on: ["cloud-virtual-machine", "E150", "in-service", "mount-cloud-weka"],
               cmd: tests/scripts/single_card/nightly/run_gs_only.sh,
               timeout: 40
             },
             {
               name: "N300 WH-only models",
               arch: wormhole_b0,
-              runs-on: ["cloud-virtual-machine", "arch-wormhole_b0", "N300", "in-service", "mount-cloud-weka"],
+              runs-on: ["cloud-virtual-machine", "N300", "in-service", "mount-cloud-weka"],
               cmd: tests/scripts/single_card/nightly/run_wh_b0_only.sh,
               timeout: 80
             },
             {
               name: "N150 WH-only models",
               arch: wormhole_b0,
-              runs-on: ["cloud-virtual-machine", "arch-wormhole_b0", "N150", "in-service", "mount-cloud-weka"],
+              runs-on: ["cloud-virtual-machine", "N150", "in-service", "mount-cloud-weka"],
               cmd: tests/scripts/single_card/nightly/run_wh_b0_only.sh,
               timeout: 80
             },
             {
               name: "API tests GS",
               arch: grayskull,
-              runs-on: ["cloud-virtual-machine", "arch-grayskull", "E150", "in-service", "mount-cloud-weka"],
+              runs-on: ["cloud-virtual-machine", "E150", "in-service", "mount-cloud-weka"],
               cmd: ./tests/scripts/run_tests.sh --tt-arch grayskull --pipeline-type frequent_api --dispatch-mode fast,
               timeout: 40
             },
             {
               name: "API tests N300 WH B0",
               arch: wormhole_b0,
-              runs-on: ["cloud-virtual-machine", "arch-wormhole_b0", "N300", "in-service", "mount-cloud-weka"],
+              runs-on: ["cloud-virtual-machine", "N300", "in-service", "mount-cloud-weka"],
               cmd: ./tests/scripts/run_tests.sh --tt-arch wormhole_b0 --pipeline-type frequent_api --dispatch-mode fast,
               timeout: 40
             },
             {
               name: "API tests N150 WH B0",
               arch: wormhole_b0,
-              runs-on: ["cloud-virtual-machine", "arch-wormhole_b0", "N150", "in-service", "mount-cloud-weka"],
+              runs-on: ["cloud-virtual-machine", "N150", "in-service", "mount-cloud-weka"],
               cmd: ./tests/scripts/run_tests.sh --tt-arch wormhole_b0 --pipeline-type frequent_api --dispatch-mode fast,
               timeout: 40
             },
@@ -113,7 +113,7 @@ jobs:
             {
               name: "[Unstable] N300 models",
               arch: wormhole_b0,
-              runs-on: ["cloud-virtual-machine", "arch-wormhole_b0", "N300", "in-service", "mount-cloud-weka"],
+              runs-on: ["cloud-virtual-machine", "N300", "in-service", "mount-cloud-weka"],
               cmd: tests/scripts/single_card/nightly/run_wh_b0_unstable.sh,
               timeout: 55
             },

--- a/.github/workflows/full-regressions-and-models.yaml
+++ b/.github/workflows/full-regressions-and-models.yaml
@@ -25,7 +25,7 @@ jobs:
       LOGURU_LEVEL: INFO
       TT_METAL_SLOW_DISPATCH_MODE: 1
       LD_LIBRARY_PATH: ${{ github.workspace }}/build/lib
-    runs-on: model-runner-${{ matrix.arch }}
+    runs-on: ["model-runner-${{ matrix.arch }}", "in-service"]
     steps:
       - uses: tenstorrent-metal/metal-workflows/.github/actions/checkout-with-submodule-lfs@v2.0.0
       - name: Ensure weka mount is active

--- a/.github/workflows/metal-run-microbenchmarks.yaml
+++ b/.github/workflows/metal-run-microbenchmarks.yaml
@@ -16,7 +16,7 @@ jobs:
         runner-info: [
           {arch: grayskull, runs-on: ["E150", "pipeline-perf", "bare-metal", "in-service"]},
           # Do not run N150 on microbenchmarks for now as we do not have the machines for it
-          # {arch: wormhole_b0, runs-on: ["pipeline-perf", "N150", "bare-metal", "self-reset", "in-service"]},
+          # {arch: wormhole_b0, runs-on: ["pipeline-perf", "N150", "bare-metal", "in-service"]},
           # N300
           {arch: wormhole_b0, runs-on: ["N300", "pipeline-perf", "bare-metal", "in-service"]},
         ]

--- a/.github/workflows/metal-run-microbenchmarks.yaml
+++ b/.github/workflows/metal-run-microbenchmarks.yaml
@@ -16,7 +16,7 @@ jobs:
         runner-info: [
           {arch: grayskull, runs-on: ["E150", "pipeline-perf", "bare-metal", "in-service"]},
           # Do not run N150 on microbenchmarks for now as we do not have the machines for it
-          # {arch: wormhole_b0, runs-on: ["perf-wormhole_b0", "multi-chip-num-pcie-1", "multi-chip-num-chips-1", "self-reset"]},
+          # {arch: wormhole_b0, runs-on: ["pipeline-perf", "N150", "bare-metal", "self-reset", "in-service"]},
           # N300
           {arch: wormhole_b0, runs-on: ["N300", "pipeline-perf", "bare-metal", "in-service"]},
         ]

--- a/.github/workflows/metal-run-microbenchmarks.yaml
+++ b/.github/workflows/metal-run-microbenchmarks.yaml
@@ -14,11 +14,11 @@ jobs:
       fail-fast: false
       matrix:
         runner-info: [
-          {arch: grayskull, runs-on: ["arch-grayskull", "E150", "pipeline-perf", "bare-metal", "in-service"]},
+          {arch: grayskull, runs-on: ["E150", "pipeline-perf", "bare-metal", "in-service"]},
           # Do not run N150 on microbenchmarks for now as we do not have the machines for it
           # {arch: wormhole_b0, runs-on: ["perf-wormhole_b0", "multi-chip-num-pcie-1", "multi-chip-num-chips-1", "self-reset"]},
           # N300
-          {arch: wormhole_b0, runs-on: ["arch-wormhole_b0", "N300", "pipeline-perf", "bare-metal", "in-service"]},
+          {arch: wormhole_b0, runs-on: ["N300", "pipeline-perf", "bare-metal", "in-service"]},
         ]
     env:
       TT_METAL_ENV: ${{ vars.TT_METAL_ENV }}

--- a/.github/workflows/models-post-commit.yaml
+++ b/.github/workflows/models-post-commit.yaml
@@ -53,7 +53,8 @@ jobs:
       LD_LIBRARY_PATH: ${{ github.workspace }}/build/lib
     runs-on:
       - ${{ inputs.runner-label }}
-      - "in-service"
+      - in-service
+      - cloud-virtual-machine
     steps:
       - uses: tenstorrent-metal/metal-workflows/.github/actions/checkout-with-submodule-lfs@v2.0.0
       - name: Set up dynamic env vars for build

--- a/.github/workflows/perf-device-models-impl.yaml
+++ b/.github/workflows/perf-device-models-impl.yaml
@@ -11,7 +11,7 @@ jobs:
       fail-fast: false
       matrix:
         test-info: [
-          {name: "GS", arch: grayskull, runs-on: ["perf-no-reset-grayskull", "self-reset"], machine-type: "bare_metal", timeout: 40},
+          {name: "GS", arch: grayskull, runs-on: ["perf-no-reset-grayskull", "bare-metal"], machine-type: "bare_metal", timeout: 40},
           {name: "N300 WH B0", arch: wormhole_b0, runs-on: ["arch-wormhole_b0", "N300", "pipeline-perf", "bare-metal", "in-service"], machine-type: "bare_metal", timeout: 30},
         ]
     name: "${{ matrix.test-info.name }} device perf"

--- a/.github/workflows/perf-models.yaml
+++ b/.github/workflows/perf-models.yaml
@@ -18,8 +18,8 @@ jobs:
       fail-fast: false
       matrix:
         test-info: [
-          {name: "GS", arch: grayskull, runs-on: ["arch-grayskull", "E150", "pipeline-perf", "bare-metal", "in-service"], machine-type: "bare_metal"},
-          {name: "N300 WH B0", arch: wormhole_b0, runs-on: ["arch-wormhole_b0", "N300", "pipeline-perf", "bare-metal", "in-service"], machine-type: "bare_metal"},
+          {name: "GS", arch: grayskull, runs-on: ["E150", "pipeline-perf", "bare-metal", "in-service"], machine-type: "bare_metal"},
+          {name: "N300 WH B0", arch: wormhole_b0, runs-on: ["N300", "pipeline-perf", "bare-metal", "in-service"], machine-type: "bare_metal"},
         ]
         model-type: [llm_javelin, cnn_javelin, other]
     name: "${{ matrix.model-type }} ${{ matrix.test-info.name }}"

--- a/.github/workflows/run-profiler-regression.yaml
+++ b/.github/workflows/run-profiler-regression.yaml
@@ -12,11 +12,11 @@ jobs:
       matrix:
         runner-info: [
           # E150
-          {arch: grayskull, runs-on: ["cloud-virtual-machine", "arch-grayskull", "E150", "in-service"], name: E150},
+          {arch: grayskull, runs-on: ["cloud-virtual-machine", "E150", "in-service"], name: E150},
           # N150
-          {arch: wormhole_b0, runs-on: ["cloud-virtual-machine", "arch-wormhole_b0", "N150", "in-service"], name: N150},
+          {arch: wormhole_b0, runs-on: ["cloud-virtual-machine", "N150", "in-service"], name: N150},
           # N300
-          {arch: wormhole_b0, runs-on: ["cloud-virtual-machine", "arch-wormhole_b0", "N300", "in-service"], name: N300},
+          {arch: wormhole_b0, runs-on: ["cloud-virtual-machine", "N300", "in-service"], name: N300},
         ]
     env:
       TT_METAL_ENV: ${{ vars.TT_METAL_ENV }}

--- a/.github/workflows/single-card-demo-tests.yaml
+++ b/.github/workflows/single-card-demo-tests.yaml
@@ -22,13 +22,13 @@ jobs:
           {
             name: "N150",
             arch: wormhole_b0,
-            runs-on: ["cloud-virtual-machine", "arch-wormhole_b0", "N150", "in-service", "mount-cloud-weka"],
+            runs-on: ["cloud-virtual-machine", "N150", "in-service", "mount-cloud-weka"],
             cmd: './tests/scripts/run_tests.sh --tt-arch wormhole_b0 --pipeline-type demos_single_card_n150 --dispatch-mode ""'
           },
           {
             name: "N300",
             arch: wormhole_b0,
-            runs-on: ["cloud-virtual-machine", "arch-wormhole_b0", "N300", "in-service", "mount-cloud-weka"],
+            runs-on: ["cloud-virtual-machine", "N300", "in-service", "mount-cloud-weka"],
             cmd: './tests/scripts/run_tests.sh --tt-arch wormhole_b0 --pipeline-type demos_single_card_n300 --dispatch-mode ""'
           }
         ]

--- a/.github/workflows/stress-fast-dispatch-build-and-unit-tests.yaml
+++ b/.github/workflows/stress-fast-dispatch-build-and-unit-tests.yaml
@@ -19,8 +19,8 @@ jobs:
       fail-fast: false
       matrix:
         runner-info: [
-          {arch: grayskull, runs-on: ["stress-grayskull", "self-reset", "in-service"], machine-type: "bare_metal", name: "E150"},
-          {arch: wormhole_b0, runs-on: ["stress-wormhole_b0", "self-reset", "in-service"], machine-type: "bare_metal", name: "N300"},
+          {arch: grayskull, runs-on: ["pipeline-stress", "E150", "bare-metal", "self-reset", "in-service"], machine-type: "bare_metal", name: "E150"},
+          {arch: wormhole_b0, runs-on: ["pipeline-stress", "N300", "bare-metal", "self-reset", "in-service"], machine-type: "bare_metal", name: "N300"},
           # E150
           {arch: grayskull, runs-on: ["cloud-virtual-machine", "E150", "in-service"], machine-type: "virtual_machine", name: "E150"},
           # N150

--- a/.github/workflows/stress-fast-dispatch-build-and-unit-tests.yaml
+++ b/.github/workflows/stress-fast-dispatch-build-and-unit-tests.yaml
@@ -19,8 +19,8 @@ jobs:
       fail-fast: false
       matrix:
         runner-info: [
-          {arch: grayskull, runs-on: ["stress-grayskull", "self-reset"], machine-type: "bare_metal", name: "E150"},
-          {arch: wormhole_b0, runs-on: ["stress-wormhole_b0", "self-reset"], machine-type: "bare_metal", name: "N300"},
+          {arch: grayskull, runs-on: ["stress-grayskull", "self-reset", "in-service"], machine-type: "bare_metal", name: "E150"},
+          {arch: wormhole_b0, runs-on: ["stress-wormhole_b0", "self-reset", "in-service"], machine-type: "bare_metal", name: "N300"},
           # E150
           {arch: grayskull, runs-on: ["cloud-virtual-machine", "arch-grayskull", "E150", "in-service"], machine-type: "virtual_machine", name: "E150"},
           # N150

--- a/.github/workflows/stress-fast-dispatch-build-and-unit-tests.yaml
+++ b/.github/workflows/stress-fast-dispatch-build-and-unit-tests.yaml
@@ -22,11 +22,11 @@ jobs:
           {arch: grayskull, runs-on: ["stress-grayskull", "self-reset", "in-service"], machine-type: "bare_metal", name: "E150"},
           {arch: wormhole_b0, runs-on: ["stress-wormhole_b0", "self-reset", "in-service"], machine-type: "bare_metal", name: "N300"},
           # E150
-          {arch: grayskull, runs-on: ["cloud-virtual-machine", "arch-grayskull", "E150", "in-service"], machine-type: "virtual_machine", name: "E150"},
+          {arch: grayskull, runs-on: ["cloud-virtual-machine", "E150", "in-service"], machine-type: "virtual_machine", name: "E150"},
           # N150
-          {arch: wormhole_b0, runs-on: ["cloud-virtual-machine", "arch-wormhole_b0", "N150", "in-service"], machine-type: "virtual_machine", name: "N150"},
+          {arch: wormhole_b0, runs-on: ["cloud-virtual-machine", "N150", "in-service"], machine-type: "virtual_machine", name: "N150"},
           # N300
-          {arch: wormhole_b0, runs-on: ["cloud-virtual-machine", "arch-wormhole_b0", "N300", "in-service"], machine-type: "virtual_machine", name: "N300"},
+          {arch: wormhole_b0, runs-on: ["cloud-virtual-machine", "N300", "in-service"], machine-type: "virtual_machine", name: "N300"},
         ]
     env:
       TT_METAL_ENV: ${{ vars.TT_METAL_ENV }}

--- a/.github/workflows/stress-fast-dispatch-build-and-unit-tests.yaml
+++ b/.github/workflows/stress-fast-dispatch-build-and-unit-tests.yaml
@@ -19,8 +19,8 @@ jobs:
       fail-fast: false
       matrix:
         runner-info: [
-          {arch: grayskull, runs-on: ["pipeline-stress", "E150", "bare-metal", "self-reset", "in-service"], machine-type: "bare_metal", name: "E150"},
-          {arch: wormhole_b0, runs-on: ["pipeline-stress", "N300", "bare-metal", "self-reset", "in-service"], machine-type: "bare_metal", name: "N300"},
+          {arch: grayskull, runs-on: ["pipeline-stress", "E150", "bare-metal", "in-service"], machine-type: "bare_metal", name: "E150"},
+          {arch: wormhole_b0, runs-on: ["pipeline-stress", "N300", "bare-metal", "in-service"], machine-type: "bare_metal", name: "N300"},
           # E150
           {arch: grayskull, runs-on: ["cloud-virtual-machine", "E150", "in-service"], machine-type: "virtual_machine", name: "E150"},
           # N150

--- a/.github/workflows/stress-slow-dispatch-build-and-unit-tests.yaml
+++ b/.github/workflows/stress-slow-dispatch-build-and-unit-tests.yaml
@@ -20,11 +20,11 @@ jobs:
       matrix:
         runner-info: [
           # E150
-          {arch: grayskull, runs-on: ["cloud-virtual-machine", "arch-grayskull", "E150", "in-service"], machine-type: "virtual_machine", name: "E150"},
+          {arch: grayskull, runs-on: ["cloud-virtual-machine", "E150", "in-service"], machine-type: "virtual_machine", name: "E150"},
           # N150
-          {arch: wormhole_b0, runs-on: ["cloud-virtual-machine", "arch-wormhole_b0", "N150", "in-service"], machine-type: "virtual_machine", name: "N150"},
+          {arch: wormhole_b0, runs-on: ["cloud-virtual-machine", "N150", "in-service"], machine-type: "virtual_machine", name: "N150"},
           # N300
-          {arch: wormhole_b0, runs-on: ["cloud-virtual-machine", "arch-wormhole_b0", "N300", "in-service"], machine-type: "virtual_machine", name: "N300"},
+          {arch: wormhole_b0, runs-on: ["cloud-virtual-machine", "N300", "in-service"], machine-type: "virtual_machine", name: "N300"},
         ]
     env:
       TT_METAL_ENV: ${{ vars.TT_METAL_ENV }}

--- a/.github/workflows/t3000-demo-tests.yaml
+++ b/.github/workflows/t3000-demo-tests.yaml
@@ -31,7 +31,7 @@ jobs:
       LOGURU_LEVEL: INFO
       LD_LIBRARY_PATH: ${{ github.workspace }}/build/lib
     environment: dev
-    runs-on: ["config-t3000", "in-service", "pipeline-perf"]
+    runs-on: ["arch-wormhole_b0", "config-t3000", "in-service", "pipeline-perf"]
     steps:
       - uses: tenstorrent-metal/metal-workflows/.github/actions/checkout-with-submodule-lfs@v2.0.0
       - name: Enable performance mode

--- a/.github/workflows/t3000-demo-tests.yaml
+++ b/.github/workflows/t3000-demo-tests.yaml
@@ -31,7 +31,7 @@ jobs:
       LOGURU_LEVEL: INFO
       LD_LIBRARY_PATH: ${{ github.workspace }}/build/lib
     environment: dev
-    runs-on: [arch-wormhole_b0, "config-t3000", "in-service", "pipeline-perf"]
+    runs-on: ["config-t3000", "in-service", "pipeline-perf"]
     steps:
       - uses: tenstorrent-metal/metal-workflows/.github/actions/checkout-with-submodule-lfs@v2.0.0
       - name: Enable performance mode

--- a/.github/workflows/t3000-frequent-tests.yaml
+++ b/.github/workflows/t3000-frequent-tests.yaml
@@ -17,20 +17,13 @@ jobs:
       fail-fast: false
       matrix:
         test-group: [
-          { name: "t3k tteager tests", arch: wormhole_b0, cmd: run_t3000_tteager_tests, timeout: 60,
-          runs-on: ["config-t3000", "in-service", "pipeline-functional"], owner_id: ULMEPM2MA}, #Sean Nijjar
-          { name: "t3k ethernet tests", arch: wormhole_b0, cmd: run_t3000_ethernet_tests, timeout: 60,
-          runs-on: ["config-t3000", "in-service", "pipeline-functional"], owner_id: ULMEPM2MA}, #Sean Nijjar
-          { name: "t3k trace stress tests", arch: wormhole_b0, cmd: run_t3000_trace_stress_tests, timeout: 120,
-          runs-on: ["config-t3000", "in-service", "pipeline-functional"], owner_id: U03NG0A5ND7}, #Aditya Saigal
-          { name: "t3k falcon40b tests", arch: wormhole_b0, cmd: run_t3000_falcon40b_tests, timeout: 120,
-          runs-on: ["config-t3000", "in-service", "pipeline-functional"], owner_id: U04S2UV6L8N}, #Sofija Jovic
-          { name: "t3k llama2_70b tests", arch: wormhole_b0, cmd: run_t3000_llama2_70b_tests, timeout: 60,
-          runs-on: ["config-t3000", "in-service", "pipeline-functional"], owner_id: U03FJB5TM5Y}, #Colman Glagovich
-          { name: "t3k mixtral tests", arch: wormhole_b0, cmd: run_t3000_mixtral_tests, timeout: 60,
-          runs-on: ["config-t3000", "in-service", "pipeline-functional"], owner_id: U03PUAKE719}, #Miguel Tairum Cruz
-          { name: "t3k resnet tests", arch: wormhole_b0, cmd: run_t3000_resnet_tests, timeout: 30,
-          runs-on: ["config-t3000", "in-service", "pipeline-functional"], owner_id: U013121KDH9}, #Austin Ho
+          { name: "t3k tteager tests", arch: wormhole_b0, cmd: run_t3000_tteager_tests, timeout: 60, owner_id: ULMEPM2MA}, #Sean Nijjar
+          { name: "t3k ethernet tests", arch: wormhole_b0, cmd: run_t3000_ethernet_tests, timeout: 60, owner_id: ULMEPM2MA}, #Sean Nijjar
+          { name: "t3k trace stress tests", arch: wormhole_b0, cmd: run_t3000_trace_stress_tests, timeout: 120, owner_id: U03NG0A5ND7}, #Aditya Saigal
+          { name: "t3k falcon40b tests", arch: wormhole_b0, cmd: run_t3000_falcon40b_tests, timeout: 120, owner_id: U04S2UV6L8N}, #Sofija Jovic
+          { name: "t3k llama2_70b tests", arch: wormhole_b0, cmd: run_t3000_llama2_70b_tests, timeout: 60, owner_id: U03FJB5TM5Y}, #Colman Glagovich
+          { name: "t3k mixtral tests", arch: wormhole_b0, cmd: run_t3000_mixtral_tests, timeout: 60, owner_id: U03PUAKE719}, #Miguel Tairum Cruz
+          { name: "t3k resnet tests", arch: wormhole_b0, cmd: run_t3000_resnet_tests, timeout: 30, owner_id: U013121KDH9}, #Austin Ho
         ]
     name: ${{ matrix.test-group.name }}
     env:
@@ -39,7 +32,7 @@ jobs:
       LOGURU_LEVEL: INFO
       LD_LIBRARY_PATH: ${{ github.workspace }}/build/lib
     environment: dev
-    runs-on: ${{ matrix.test-group.runs-on }}
+    runs-on: ["arch-wormhole_b0", "config-t3000", "in-service", "pipeline-functional"]
     steps:
       - uses: tenstorrent-metal/metal-workflows/.github/actions/checkout-with-submodule-lfs@v2.0.0
       - name: Set up dynamic env vars for build

--- a/.github/workflows/t3000-model-perf-tests.yaml
+++ b/.github/workflows/t3000-model-perf-tests.yaml
@@ -18,11 +18,11 @@ jobs:
       matrix:
         test-group: [
           { name: "t3k LLM falcon7b model perf tests", model: "falcob7b", model-type: "LLM", arch: wormhole_b0, cmd: run_t3000_falcon7b_tests, timeout: 75,
-            runs-on: ["arch-wormhole_b0", "config-t3000", "in-service", "pipeline-perf"], owner_id: U053W15B6JF}, # Djordje Ivanovic
+            runs-on: ["config-t3000", "in-service", "pipeline-perf"], owner_id: U053W15B6JF}, # Djordje Ivanovic
           { name: "t3k LLM mixtral model perf tests", model: "mixtral", model-type: "LLM", arch: wormhole_b0, cmd: run_t3000_mixtral_tests, timeout: 75,
-            runs-on: ["arch-wormhole_b0", "config-t3000", "in-service", "pipeline-perf"], owner_id: U03PUAKE719}, # Miguel Tairum
+            runs-on: ["config-t3000", "in-service", "pipeline-perf"], owner_id: U03PUAKE719}, # Miguel Tairum
           { name: "t3k LLM llama2 model perf tests", model: "llama2", model-type: "LLM", arch: wormhole_b0, cmd: run_t3000_llama2_70b_tests, timeout: 75,
-            runs-on: ["arch-wormhole_b0", "config-t3000", "in-service", "pipeline-perf"], owner_id: U03FJB5TM5Y}, # Colman Glagovich
+            runs-on: ["config-t3000", "in-service", "pipeline-perf"], owner_id: U03FJB5TM5Y}, # Colman Glagovich
           { name: "t3k LLM falcon40b model perf tests", model: "falcon40b", model-type: "LLM", arch: wormhole_b0, cmd: run_t3000_falcon40b_tests, timeout: 75,
             runs-on: ["arch-wormhole_b0", "config-t3000", "in-service", "pipeline-perf"], owner_id: U053W15B6JF}, # Djordje Ivanovic
           { name: "t3k CNN resnet50 model perf tests", model: "resnet50", model-type: "CNN", arch: wormhole_b0, cmd: run_t3000_resnet50_tests, timeout: 75,

--- a/.github/workflows/t3000-model-perf-tests.yaml
+++ b/.github/workflows/t3000-model-perf-tests.yaml
@@ -17,16 +17,11 @@ jobs:
       fail-fast: false
       matrix:
         test-group: [
-          { name: "t3k LLM falcon7b model perf tests", model: "falcob7b", model-type: "LLM", arch: wormhole_b0, cmd: run_t3000_falcon7b_tests, timeout: 75,
-            runs-on: ["config-t3000", "in-service", "pipeline-perf"], owner_id: U053W15B6JF}, # Djordje Ivanovic
-          { name: "t3k LLM mixtral model perf tests", model: "mixtral", model-type: "LLM", arch: wormhole_b0, cmd: run_t3000_mixtral_tests, timeout: 75,
-            runs-on: ["config-t3000", "in-service", "pipeline-perf"], owner_id: U03PUAKE719}, # Miguel Tairum
-          { name: "t3k LLM llama2 model perf tests", model: "llama2", model-type: "LLM", arch: wormhole_b0, cmd: run_t3000_llama2_70b_tests, timeout: 75,
-            runs-on: ["config-t3000", "in-service", "pipeline-perf"], owner_id: U03FJB5TM5Y}, # Colman Glagovich
-          { name: "t3k LLM falcon40b model perf tests", model: "falcon40b", model-type: "LLM", arch: wormhole_b0, cmd: run_t3000_falcon40b_tests, timeout: 75,
-            runs-on: ["arch-wormhole_b0", "config-t3000", "in-service", "pipeline-perf"], owner_id: U053W15B6JF}, # Djordje Ivanovic
-          { name: "t3k CNN resnet50 model perf tests", model: "resnet50", model-type: "CNN", arch: wormhole_b0, cmd: run_t3000_resnet50_tests, timeout: 75,
-            runs-on: ["arch-wormhole_b0", "config-t3000", "in-service", "pipeline-perf"], owner_id: U013121KDH9}, # Austin Ho
+          { name: "t3k LLM falcon7b model perf tests", model: "falcob7b", model-type: "LLM", arch: wormhole_b0, cmd: run_t3000_falcon7b_tests, timeout: 75, owner_id: U053W15B6JF}, # Djordje Ivanovic
+          { name: "t3k LLM mixtral model perf tests", model: "mixtral", model-type: "LLM", arch: wormhole_b0, cmd: run_t3000_mixtral_tests, timeout: 75, owner_id: U03PUAKE719}, # Miguel Tairum
+          { name: "t3k LLM llama2 model perf tests", model: "llama2", model-type: "LLM", arch: wormhole_b0, cmd: run_t3000_llama2_70b_tests, timeout: 75, owner_id: U03FJB5TM5Y}, # Colman Glagovich
+          { name: "t3k LLM falcon40b model perf tests", model: "falcon40b", model-type: "LLM", arch: wormhole_b0, cmd: run_t3000_falcon40b_tests, timeout: 75, owner_id: U053W15B6JF}, # Djordje Ivanovic
+          { name: "t3k CNN resnet50 model perf tests", model: "resnet50", model-type: "CNN", arch: wormhole_b0, cmd: run_t3000_resnet50_tests, timeout: 75, owner_id: U013121KDH9}, # Austin Ho
           #{ name: "t3k CNN model perf tests ", model-type: "CNN", arch: wormhole_b0, cmd: run_t3000_cnn_tests, timeout: 120, owner_id: }, #No tests are being run?
         ]
     name: ${{ matrix.test-group.name }}
@@ -36,7 +31,7 @@ jobs:
       LOGURU_LEVEL: INFO
       LD_LIBRARY_PATH: ${{ github.workspace }}/build/lib
     environment: dev
-    runs-on: ${{ matrix.test-group.runs-on }}
+    runs-on: ["arch-wormhole_b0", "config-t3000", "in-service", "pipeline-perf"]
     steps:
       - uses: tenstorrent-metal/metal-workflows/.github/actions/checkout-with-submodule-lfs@v2.0.0
       - name: Enable performance mode

--- a/.github/workflows/t3000-perplexity-tests.yaml
+++ b/.github/workflows/t3000-perplexity-tests.yaml
@@ -20,7 +20,7 @@ jobs:
           {
             name: t3k perplexity tests,
             arch: wormhole_b0,
-            runs-on: ["config-t3000", "in-service", "pipeline-perf", "t3k"],
+            runs-on: ["config-t3000", "in-service", "pipeline-perf"],
           },
         ]
     name: ${{ matrix.test-group.name }}

--- a/.github/workflows/t3000-perplexity-tests.yaml
+++ b/.github/workflows/t3000-perplexity-tests.yaml
@@ -20,7 +20,7 @@ jobs:
           {
             name: t3k perplexity tests,
             arch: wormhole_b0,
-            runs-on: ["config-t3000", "in-service", "pipeline-perf"],
+            runs-on: ["arch-wormhole_b0", "config-t3000", "in-service", "pipeline-perf"],
           },
         ]
     name: ${{ matrix.test-group.name }}

--- a/.github/workflows/t3000-perplexity-tests.yaml
+++ b/.github/workflows/t3000-perplexity-tests.yaml
@@ -20,7 +20,7 @@ jobs:
           {
             name: t3k perplexity tests,
             arch: wormhole_b0,
-            runs-on: [arch-wormhole_b0, "config-t3000", "in-service", "pipeline-perf", "t3k"],
+            runs-on: ["config-t3000", "in-service", "pipeline-perf", "t3k"],
           },
         ]
     name: ${{ matrix.test-group.name }}

--- a/.github/workflows/t3000-profiler-tests.yaml
+++ b/.github/workflows/t3000-profiler-tests.yaml
@@ -22,7 +22,7 @@ jobs:
           {
             name: "T3000 profiler tests",
             arch: wormhole_b0,
-            runs-on: ["config-t3000", "in-service", "pipeline-perf"],
+            runs-on: ["arch-wormhole_b0", "config-t3000", "in-service", "pipeline-perf"],
             cmd: './tests/scripts/run_profiler_regressions.sh'
           },
         ]

--- a/.github/workflows/t3000-profiler-tests.yaml
+++ b/.github/workflows/t3000-profiler-tests.yaml
@@ -22,7 +22,7 @@ jobs:
           {
             name: "T3000 profiler tests",
             arch: wormhole_b0,
-            runs-on: [arch-wormhole_b0, "config-t3000", "in-service", "pipeline-perf"],
+            runs-on: ["config-t3000", "in-service", "pipeline-perf"],
             cmd: './tests/scripts/run_profiler_regressions.sh'
           },
         ]

--- a/.github/workflows/t3000-unit-tests.yaml
+++ b/.github/workflows/t3000-unit-tests.yaml
@@ -31,7 +31,7 @@ jobs:
       LOGURU_LEVEL: INFO
       LD_LIBRARY_PATH: ${{ github.workspace }}/build/lib
     environment: dev
-    runs-on: ["config-t3000", "in-service", "pipeline-functional"]
+    runs-on: ["arch-wormhole_b0", "config-t3000", "in-service", "pipeline-functional"]
     steps:
       - uses: tenstorrent-metal/metal-workflows/.github/actions/checkout-with-submodule-lfs@v2.0.0
       - name: Set up dynamic env vars for build

--- a/.github/workflows/tg-demo-tests.yaml
+++ b/.github/workflows/tg-demo-tests.yaml
@@ -20,7 +20,7 @@ jobs:
           {
             name: "TG demo tests",
             arch: wormhole_b0,
-            runs-on: [arch-wormhole_b0, "config-tg", "in-service", "runner-test", "bare-metal", "pipeline-functional"],
+            runs-on: ["config-tg", "in-service", "bare-metal", "pipeline-functional"],
             cmd: './tests/scripts/run_tests.sh --tt-arch wormhole_b0 --pipeline-type demos_tg_device --dispatch-mode ""'
           },
         ]

--- a/.github/workflows/tg-demo-tests.yaml
+++ b/.github/workflows/tg-demo-tests.yaml
@@ -20,7 +20,7 @@ jobs:
           {
             name: "TG demo tests",
             arch: wormhole_b0,
-            runs-on: ["config-tg", "in-service", "bare-metal", "pipeline-functional"],
+            runs-on: ["arch-wormhole_b0", "config-tg", "in-service", "bare-metal", "pipeline-functional"],
             cmd: './tests/scripts/run_tests.sh --tt-arch wormhole_b0 --pipeline-type demos_tg_device --dispatch-mode ""'
           },
         ]

--- a/.github/workflows/tg-frequent-tests.yaml
+++ b/.github/workflows/tg-frequent-tests.yaml
@@ -20,7 +20,7 @@ jobs:
           {
             name: "TG frequent tests",
             arch: wormhole_b0,
-            runs-on: ["config-tg", "in-service", "bare-metal", "pipeline-functional"],
+            runs-on: ["arch-wormhole_b0", "config-tg", "in-service", "bare-metal", "pipeline-functional"],
             cmd: './tests/scripts/run_tests.sh --tt-arch wormhole_b0 --pipeline-type frequent_tg_device --dispatch-mode ""'
           },
         ]

--- a/.github/workflows/tg-frequent-tests.yaml
+++ b/.github/workflows/tg-frequent-tests.yaml
@@ -20,7 +20,7 @@ jobs:
           {
             name: "TG frequent tests",
             arch: wormhole_b0,
-            runs-on: [arch-wormhole_b0, "config-tg", "in-service", "runner-test", "bare-metal", "pipeline-functional"],
+            runs-on: ["config-tg", "in-service", "bare-metal", "pipeline-functional"],
             cmd: './tests/scripts/run_tests.sh --tt-arch wormhole_b0 --pipeline-type frequent_tg_device --dispatch-mode ""'
           },
         ]

--- a/.github/workflows/tg-model-perf-tests.yaml
+++ b/.github/workflows/tg-model-perf-tests.yaml
@@ -21,14 +21,14 @@ jobs:
             name: "TG LLM model perf tests",
             model-type: "LLM",
             arch: wormhole_b0,
-            runs-on: ["config-tg", "in-service", "bare-metal", "pipeline-perf"],
+            runs-on: ["arch-wormhole_b0", "config-tg", "in-service", "bare-metal", "pipeline-perf"],
             cmd: './tests/scripts/run_tests.sh --tt-arch wormhole_b0 --pipeline-type llm_model_perf_tg_device --dispatch-mode ""'
           },
           {
             name: "TG CNN model perf tests",
             model-type: "CNN",
             arch: wormhole_b0,
-            runs-on: ["config-tg", "in-service", "bare-metal", "pipeline-perf"],
+            runs-on: ["arch-wormhole_b0", "config-tg", "in-service", "bare-metal", "pipeline-perf"],
             cmd: './tests/scripts/run_tests.sh --tt-arch wormhole_b0 --pipeline-type cnn_model_perf_tg_device --dispatch-mode ""'
           },
         ]

--- a/.github/workflows/tg-model-perf-tests.yaml
+++ b/.github/workflows/tg-model-perf-tests.yaml
@@ -18,17 +18,17 @@ jobs:
       matrix:
         test-group: [
           {
-            name: "TG LLM model perf tests", 
+            name: "TG LLM model perf tests",
             model-type: "LLM",
-            arch: wormhole_b0, 
-            runs-on: [arch-wormhole_b0, "config-tg", "in-service", "runner-test", "bare-metal", "pipeline-perf"],
+            arch: wormhole_b0,
+            runs-on: ["config-tg", "in-service", "bare-metal", "pipeline-perf"],
             cmd: './tests/scripts/run_tests.sh --tt-arch wormhole_b0 --pipeline-type llm_model_perf_tg_device --dispatch-mode ""'
           },
           {
-            name: "TG CNN model perf tests", 
+            name: "TG CNN model perf tests",
             model-type: "CNN",
-            arch: wormhole_b0, 
-            runs-on: [arch-wormhole_b0, "config-tg", "in-service", "runner-test", "bare-metal", "pipeline-perf"],
+            arch: wormhole_b0,
+            runs-on: ["config-tg", "in-service", "bare-metal", "pipeline-perf"],
             cmd: './tests/scripts/run_tests.sh --tt-arch wormhole_b0 --pipeline-type cnn_model_perf_tg_device --dispatch-mode ""'
           },
         ]

--- a/.github/workflows/tg-nightly-tests.yaml
+++ b/.github/workflows/tg-nightly-tests.yaml
@@ -26,7 +26,7 @@ jobs:
       LOGURU_LEVEL: INFO
       LD_LIBRARY_PATH: ${{ github.workspace }}/build/lib
     environment: dev
-    runs-on: ["arch-wormhole_b0", "config-tg", "in-service", "pipeline-functional", "mount-cloud-weka"]
+    runs-on: ["config-tg", "in-service", "pipeline-functional", "mount-cloud-weka"]
     steps:
       - uses: tenstorrent-metal/metal-workflows/.github/actions/checkout-with-submodule-lfs@v2.0.0
       - uses: ./.github/actions/retry-command

--- a/.github/workflows/tg-nightly-tests.yaml
+++ b/.github/workflows/tg-nightly-tests.yaml
@@ -26,7 +26,7 @@ jobs:
       LOGURU_LEVEL: INFO
       LD_LIBRARY_PATH: ${{ github.workspace }}/build/lib
     environment: dev
-    runs-on: ["config-tg", "in-service", "pipeline-functional", "mount-cloud-weka"]
+    runs-on: ["arch-wormhole_b0", "config-tg", "in-service", "pipeline-functional", "mount-cloud-weka"]
     steps:
       - uses: tenstorrent-metal/metal-workflows/.github/actions/checkout-with-submodule-lfs@v2.0.0
       - uses: ./.github/actions/retry-command

--- a/.github/workflows/tg-unit-tests.yaml
+++ b/.github/workflows/tg-unit-tests.yaml
@@ -19,7 +19,7 @@ jobs:
           {
             name: "TG UMD unit tests",
             arch: wormhole_b0,
-            runs-on: [arch-wormhole_b0, "config-tg", "in-service", "runner-test", "bare-metal", "pipeline-functional"],
+            runs-on: ["arch-wormhole_b0", "config-tg", "in-service", "runner-test", "bare-metal", "pipeline-functional"],
             cmd: "./build/test/umd/galaxy/unit_tests_glx"
           },
         ]

--- a/.github/workflows/tg-unit-tests.yaml
+++ b/.github/workflows/tg-unit-tests.yaml
@@ -53,7 +53,7 @@ jobs:
           {
             name: "TG unit tests",
             arch: wormhole_b0,
-            runs-on: [arch-wormhole_b0, "config-tg", "in-service", "runner-test", "bare-metal", "pipeline-functional"],
+            runs-on: ["config-tg", "in-service", "bare-metal", "pipeline-functional"],
             cmd: './tests/scripts/run_tests.sh --tt-arch wormhole_b0 --pipeline-type unit_tg_device --dispatch-mode ""'
           },
         ]

--- a/.github/workflows/tgg-demo-tests.yaml
+++ b/.github/workflows/tgg-demo-tests.yaml
@@ -20,7 +20,7 @@ jobs:
           {
             name: "TGG demo tests",
             arch: wormhole_b0,
-            runs-on: [arch-wormhole_b0, "config-tgg", "in-service", "runner-test", "bare-metal", "pipeline-functional"],
+            runs-on: ["config-tgg", "in-service", "bare-metal", "pipeline-functional"],
             cmd: './tests/scripts/run_tests.sh --tt-arch wormhole_b0 --pipeline-type demos_tgg_device --dispatch-mode ""'
           },
         ]

--- a/.github/workflows/tgg-demo-tests.yaml
+++ b/.github/workflows/tgg-demo-tests.yaml
@@ -20,7 +20,7 @@ jobs:
           {
             name: "TGG demo tests",
             arch: wormhole_b0,
-            runs-on: ["config-tgg", "in-service", "bare-metal", "pipeline-functional"],
+            runs-on: ["arch-wormhole_b0", "config-tgg", "in-service", "bare-metal", "pipeline-functional"],
             cmd: './tests/scripts/run_tests.sh --tt-arch wormhole_b0 --pipeline-type demos_tgg_device --dispatch-mode ""'
           },
         ]

--- a/.github/workflows/tgg-frequent-tests.yaml
+++ b/.github/workflows/tgg-frequent-tests.yaml
@@ -20,7 +20,7 @@ jobs:
           {
             name: "TGG frequent tests",
             arch: wormhole_b0,
-            runs-on: [arch-wormhole_b0, "config-tgg", "in-service", "runner-test", "bare-metal", "pipeline-functional"],
+            runs-on: ["config-tgg", "in-service", "bare-metal", "pipeline-functional"],
             cmd: './tests/scripts/run_tests.sh --tt-arch wormhole_b0 --pipeline-type frequent_tgg_device --dispatch-mode ""'
           },
         ]

--- a/.github/workflows/tgg-frequent-tests.yaml
+++ b/.github/workflows/tgg-frequent-tests.yaml
@@ -20,7 +20,7 @@ jobs:
           {
             name: "TGG frequent tests",
             arch: wormhole_b0,
-            runs-on: ["config-tgg", "in-service", "bare-metal", "pipeline-functional"],
+            runs-on: ["arch-wormhole_b0", "config-tgg", "in-service", "bare-metal", "pipeline-functional"],
             cmd: './tests/scripts/run_tests.sh --tt-arch wormhole_b0 --pipeline-type frequent_tgg_device --dispatch-mode ""'
           },
         ]

--- a/.github/workflows/tgg-model-perf-tests.yaml
+++ b/.github/workflows/tgg-model-perf-tests.yaml
@@ -18,17 +18,17 @@ jobs:
       matrix:
         test-group: [
           {
-            name: "TGG LLM model perf tests", 
+            name: "TGG LLM model perf tests",
             model-type: "LLM",
-            arch: wormhole_b0, 
-            runs-on: [arch-wormhole_b0, "config-tgg", "in-service", "runner-test", "bare-metal", "pipeline-perf"],
+            arch: wormhole_b0,
+            runs-on: ["config-tgg", "in-service", "bare-metal", "pipeline-perf"],
             cmd: './tests/scripts/run_tests.sh --tt-arch wormhole_b0 --pipeline-type llm_model_perf_tgg_device --dispatch-mode ""'
           },
           {
-            name: "TGG CNN model perf tests", 
+            name: "TGG CNN model perf tests",
             model-type: "CNN",
-            arch: wormhole_b0, 
-            runs-on: [arch-wormhole_b0, "config-tgg", "in-service", "runner-test", "bare-metal", "pipeline-perf"],
+            arch: wormhole_b0,
+            runs-on: ["config-tgg", "in-service", "bare-metal", "pipeline-perf"],
             cmd: './tests/scripts/run_tests.sh --tt-arch wormhole_b0 --pipeline-type cnn_model_perf_tgg_device --dispatch-mode ""'
           },
         ]

--- a/.github/workflows/tgg-model-perf-tests.yaml
+++ b/.github/workflows/tgg-model-perf-tests.yaml
@@ -21,14 +21,14 @@ jobs:
             name: "TGG LLM model perf tests",
             model-type: "LLM",
             arch: wormhole_b0,
-            runs-on: ["config-tgg", "in-service", "bare-metal", "pipeline-perf"],
+            runs-on: ["arch-wormhole_b0", "config-tgg", "in-service", "bare-metal", "pipeline-perf"],
             cmd: './tests/scripts/run_tests.sh --tt-arch wormhole_b0 --pipeline-type llm_model_perf_tgg_device --dispatch-mode ""'
           },
           {
             name: "TGG CNN model perf tests",
             model-type: "CNN",
             arch: wormhole_b0,
-            runs-on: ["config-tgg", "in-service", "bare-metal", "pipeline-perf"],
+            runs-on: ["arch-wormhole_b0", "config-tgg", "in-service", "bare-metal", "pipeline-perf"],
             cmd: './tests/scripts/run_tests.sh --tt-arch wormhole_b0 --pipeline-type cnn_model_perf_tgg_device --dispatch-mode ""'
           },
         ]

--- a/.github/workflows/tgg-unit-tests.yaml
+++ b/.github/workflows/tgg-unit-tests.yaml
@@ -20,7 +20,7 @@ jobs:
           {
             name: "TGG unit tests",
             arch: wormhole_b0,
-            runs-on: [arch-wormhole_b0, "config-tgg", "in-service", "runner-test", "bare-metal", "pipeline-functional"],
+            runs-on: ["config-tgg", "in-service", "bare-metal", "pipeline-functional"],
             cmd: './tests/scripts/run_tests.sh --tt-arch wormhole_b0 --pipeline-type unit_tgg_device --dispatch-mode ""'
           },
         ]

--- a/infra/data_collection/github/utils.py
+++ b/infra/data_collection/github/utils.py
@@ -189,11 +189,11 @@ def get_job_row_from_github_job(github_job):
         logger.info("Seems to have no config- label, so assuming no special config requested")
         detected_config = None
 
-    if labels_have_overlap(["grayskull", "arch-grayskull"], labels):
+    if labels_have_overlap(["E150", "grayskull", "arch-grayskull"], labels):
         detected_arch = "grayskull"
-    elif labels_have_overlap(["wormhole_b0", "arch-wormhole_b0"], labels):
+    elif labels_have_overlap(["N150", "N300", "wormhole_b0", "arch-wormhole_b0"], labels):
         detected_arch = "wormhole_b0"
-    elif labels_have_overlap(["arch-blackhole"], labels):
+    elif labels_have_overlap(["BH", "arch-blackhole"], labels):
         detected_arch = "blackhole"
     else:
         detected_arch = None


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/11038

### Problem description
Too many labels on runners. clean up labels and improve transparency

### What's changed
Replaced "grayskull" and "wormhole_b0" with "in-service" 
Replaced "multi-chip*" and "multi-pci*" with product codes E150/N150/N300 
Removed "runner-test"
Removed "arch-wormhole_b0" "arch-grayskull" from single-chip cards
Removed "perf-wormhole_b0" and replaced with generic "pipeline-perf"
Added generic pipeline-stress label and removed "stress-wormhole_b0" "stress-grayskull"
Added cloud-virtual-machine labels to pipelines for VMs (since bare-metal machines also carry some product codes)
to prevent 

### Checklist
- [ ] Post commit CI passes
- [ ] Model regression CI testing passes (if applicable)
- [ ] New/Existing tests provide coverage for changes
