### PR TITLE
#11029: Allow num CQs to be toggled when running on R-Chip

### DIFF
--- a/tt_metal/impl/device/device.cpp
+++ b/tt_metal/impl/device/device.cpp
@@ -1976,7 +1976,7 @@ bool Device::close() {
     this->hw_command_queues_.clear();
     this->sysmem_manager_.reset();
     this->allocator_.reset();
-
+    this->tunnel_device_dispatch_workers_.clear();
     this->initialized_ = false;
 
     return true;


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/11029#event-13732901283

### Problem description
Toggling the number of CQs on remote chips in the same process was causing hangs.

### What's changed
`tunnel_device_dispatch_workers_ ` was not cleared when a device was closed. The next time dispatch settings were assigned to this map using `.insert`, the settings were not updated.
This led to single CQ dispatch settings being used for multi-CQ workloads.

### Checklist
- [ ] Post commit CI passes
- [ ] Model regression CI testing passes (if applicable)
- [x] New/Existing tests provide coverage for changes
