### PR TITLE
Add sweeps for pack 2 of bw_ops: ceil_bw, celu_bw, cosh_bw, cos_bw

### DIFF
--- a/tests/tt_eager/python_api_testing/sweep_tests/generation_funcs.py
+++ b/tests/tt_eager/python_api_testing/sweep_tests/generation_funcs.py
@@ -1364,6 +1364,33 @@ def gen_elu_args(
         yield input_info
 
 
+def gen_celu_args(
+    input_shapes,
+    dtypes,
+    layouts,
+    mem_configs,
+    low=-10,
+    high=10,
+    dtype=torch.bfloat16,
+    do_sanitize_args=True,
+    coregrid=[],
+):
+    for input_info in gen_dtype_layout_device(
+        input_shapes, dtypes, layouts, mem_configs, do_sanitize_args=do_sanitize_args
+    ):
+        if input_info is not None:
+            if dtype.is_floating_point:
+                scalar = torch.tensor(1, dtype=dtype).uniform_(low, high).item()
+                while scalar == 0.0:
+                    scalar = torch.tensor(1, dtype=dtype).uniform_(low, high).item()
+            else:
+                scalar = torch.tensor(1, dtype=dtype).random_(low, high).item()
+                while scalar == 0.0:
+                    scalar = torch.tensor(1, dtype=dtype).uniform_(low, high).item()
+            input_info.update({"alpha": scalar})
+            yield input_info
+
+
 def gen_fast_and_approx_args(input_shapes, dtypes, layouts, mem_configs, do_sanitize_args=True, coregrid=[]):
     input_info = gen_dtype_layout_device(input_shapes, dtypes, layouts, mem_configs, do_sanitize_args=do_sanitize_args)
 

--- a/tests/tt_eager/python_api_testing/sweep_tests/generation_funcs.py
+++ b/tests/tt_eager/python_api_testing/sweep_tests/generation_funcs.py
@@ -1369,26 +1369,16 @@ def gen_celu_args(
     dtypes,
     layouts,
     mem_configs,
-    low=-10,
+    low=-0.01,
     high=10,
     dtype=torch.bfloat16,
     do_sanitize_args=True,
     coregrid=[],
 ):
-    for input_info in gen_dtype_layout_device(
-        input_shapes, dtypes, layouts, mem_configs, do_sanitize_args=do_sanitize_args
+    for input_info in gen_scalar_symmetric_args(
+        input_shapes, dtypes, layouts, mem_configs, "alpha", low, high, dtype, do_sanitize_args=do_sanitize_args
     ):
-        if input_info is not None:
-            if dtype.is_floating_point:
-                scalar = torch.tensor(1, dtype=dtype).uniform_(low, high).item()
-                while scalar == 0.0:
-                    scalar = torch.tensor(1, dtype=dtype).uniform_(low, high).item()
-            else:
-                scalar = torch.tensor(1, dtype=dtype).random_(low, high).item()
-                while scalar == 0.0:
-                    scalar = torch.tensor(1, dtype=dtype).uniform_(low, high).item()
-            input_info.update({"alpha": scalar})
-            yield input_info
+        yield input_info
 
 
 def gen_fast_and_approx_args(input_shapes, dtypes, layouts, mem_configs, do_sanitize_args=True, coregrid=[]):

--- a/tests/tt_eager/python_api_testing/sweep_tests/pytorch_ops.py
+++ b/tests/tt_eager/python_api_testing/sweep_tests/pytorch_ops.py
@@ -2030,6 +2030,18 @@ def i0_bw(x, y, *args, **kwargs):
     return in_data.grad
 
 
+def ceil_bw(x, y, *args, **kwargs):
+    grad_data = x
+    in_data = y
+    in_data.requires_grad = True
+
+    in_data.retain_grad()
+    pyt_y = torch.ceil(in_data)
+    pyt_y.backward(gradient=grad_data)
+
+    return in_data.grad
+
+
 def global_avg_pool2d(x, *args, **kwargs):
     output_size = (1, 1)
     x = x.to(torch.float32)

--- a/tests/tt_eager/python_api_testing/sweep_tests/pytorch_ops.py
+++ b/tests/tt_eager/python_api_testing/sweep_tests/pytorch_ops.py
@@ -2054,6 +2054,30 @@ def celu_bw(x, y, alpha, *args, **kwargs):
     return in_data.grad
 
 
+def cosh_bw(x, y, *args, **kwargs):
+    grad_data = x
+    in_data = y
+    in_data.requires_grad = True
+
+    in_data.retain_grad()
+    pyt_y = torch.cosh(in_data)
+    pyt_y.backward(gradient=grad_data)
+
+    return in_data.grad
+
+
+def cos_bw(x, y, *args, **kwargs):
+    grad_data = x
+    in_data = y
+    in_data.requires_grad = True
+
+    in_data.retain_grad()
+    pyt_y = torch.cos(in_data)
+    pyt_y.backward(gradient=grad_data)
+
+    return in_data.grad
+
+
 def global_avg_pool2d(x, *args, **kwargs):
     output_size = (1, 1)
     x = x.to(torch.float32)

--- a/tests/tt_eager/python_api_testing/sweep_tests/pytorch_ops.py
+++ b/tests/tt_eager/python_api_testing/sweep_tests/pytorch_ops.py
@@ -2042,6 +2042,18 @@ def ceil_bw(x, y, *args, **kwargs):
     return in_data.grad
 
 
+def celu_bw(x, y, alpha, *args, **kwargs):
+    grad_data = x
+    in_data = y
+    in_data.requires_grad = True
+
+    in_data.retain_grad()
+    pyt_y = torch.celu(in_data, alpha)
+    pyt_y.backward(gradient=grad_data)
+
+    return in_data.grad
+
+
 def global_avg_pool2d(x, *args, **kwargs):
     output_size = (1, 1)
     x = x.to(torch.float32)

--- a/tests/ttnn/python_api_testing/sweep_tests/op_map.py
+++ b/tests/ttnn/python_api_testing/sweep_tests/op_map.py
@@ -849,4 +849,8 @@ op_map = {
         "tt_op": ttnn_ops.i0_bw,
         "pytorch_op": pytorch_ops.i0_bw,
     },
+    "ceil-bw": {
+        "tt_op": ttnn_ops.ceil_bw,
+        "pytorch_op": pytorch_ops.ceil_bw,
+    },
 }

--- a/tests/ttnn/python_api_testing/sweep_tests/op_map.py
+++ b/tests/ttnn/python_api_testing/sweep_tests/op_map.py
@@ -857,4 +857,12 @@ op_map = {
         "tt_op": ttnn_ops.celu_bw,
         "pytorch_op": pytorch_ops.celu_bw,
     },
+    "cosh-bw": {
+        "tt_op": ttnn_ops.cosh_bw,
+        "pytorch_op": pytorch_ops.cosh_bw,
+    },
+    "cos-bw": {
+        "tt_op": ttnn_ops.cos_bw,
+        "pytorch_op": pytorch_ops.cos_bw,
+    },
 }

--- a/tests/ttnn/python_api_testing/sweep_tests/op_map.py
+++ b/tests/ttnn/python_api_testing/sweep_tests/op_map.py
@@ -853,4 +853,8 @@ op_map = {
         "tt_op": ttnn_ops.ceil_bw,
         "pytorch_op": pytorch_ops.ceil_bw,
     },
+    "celu-bw": {
+        "tt_op": ttnn_ops.celu_bw,
+        "pytorch_op": pytorch_ops.celu_bw,
+    },
 }

--- a/tests/ttnn/python_api_testing/sweep_tests/test_configs/ci_sweep_tests_broken/grayskull/ttnn_backward_celu_test.yaml
+++ b/tests/ttnn/python_api_testing/sweep_tests/test_configs/ci_sweep_tests_broken/grayskull/ttnn_backward_celu_test.yaml
@@ -1,0 +1,26 @@
+---
+test-list:
+  - celu-bw:
+      shape:
+        start-shape: [1, 1, 32, 32]
+        end-shape: [6, 12, 256, 256]
+        interval: [1, 1, 32, 32]
+        num-shapes: 2
+        num-samples: 128
+        args-sampling-strategy: "all"
+      datagen:
+        function: gen_rand
+        args:
+          low: -100
+          high: 100
+      comparison:
+        function: comp_pcc
+      args-gen: gen_celu_args
+      args:
+        data-layout: ["TILE"]
+        data-type: ["BFLOAT16"]
+        buffer-type: ["DRAM", "L1"]
+        out-buffer-type: ["DRAM", "L1"]
+      output-file: backward_celu_sweep.csv
+      env:
+        # TT_PCI_DMA_BUF_SIZE: "1048576"

--- a/tests/ttnn/python_api_testing/sweep_tests/test_configs/ci_sweep_tests_broken/wormhole/ttnn_backward_celu_test.yaml
+++ b/tests/ttnn/python_api_testing/sweep_tests/test_configs/ci_sweep_tests_broken/wormhole/ttnn_backward_celu_test.yaml
@@ -1,0 +1,26 @@
+---
+test-list:
+  - celu-bw:
+      shape:
+        start-shape: [1, 1, 32, 32]
+        end-shape: [6, 12, 256, 256]
+        interval: [1, 1, 32, 32]
+        num-shapes: 2
+        num-samples: 128
+        args-sampling-strategy: "all"
+      datagen:
+        function: gen_rand
+        args:
+          low: -100
+          high: 100
+      comparison:
+        function: comp_pcc
+      args-gen: gen_celu_args
+      args:
+        data-layout: ["TILE"]
+        data-type: ["BFLOAT16"]
+        buffer-type: ["DRAM", "L1"]
+        out-buffer-type: ["DRAM", "L1"]
+      output-file: backward_celu_sweep.csv
+      env:
+        # TT_PCI_DMA_BUF_SIZE: "1048576"

--- a/tests/ttnn/python_api_testing/sweep_tests/test_configs/ci_sweep_tests_working/grayskull/ttnn_backward_ceil_test.yaml
+++ b/tests/ttnn/python_api_testing/sweep_tests/test_configs/ci_sweep_tests_working/grayskull/ttnn_backward_ceil_test.yaml
@@ -1,0 +1,50 @@
+---
+test-list:
+  - ceil-bw:
+      shape:
+        start-shape: [1, 1, 32, 32]
+        end-shape: [6, 12, 256, 256]
+        interval: [1, 1, 32, 32]
+        num-shapes: 2
+        num-samples: 64
+        args-sampling-strategy: "all"
+      datagen:
+        function: gen_rand
+        args:
+          low: -100
+          high: 100
+      comparison:
+        function: comp_pcc
+      args-gen: gen_default_dtype_layout_device
+      args:
+        data-layout: ["TILE"]
+        data-type: ["BFLOAT16", "BFLOAT8_B"]
+        buffer-type: ["DRAM", "L1"]
+        out-buffer-type: ["DRAM", "L1"]
+      output-file: backward_ceil_sweep.csv
+      env:
+        # TT_PCI_DMA_BUF_SIZE: "1048576"
+  - ceil-bw:
+      shape:
+        start-shape: [1, 1, 2, 2]
+        end-shape: [6, 12, 256, 256]
+        interval: [1, 1, 1, 2]
+        num-shapes: 2
+        num-samples: 64
+        args-sampling-strategy: "all"
+      datagen:
+        function: gen_rand
+        args:
+          low: -100
+          high: 100
+      comparison:
+        function: comp_pcc
+      args-gen: gen_default_dtype_layout_device
+      args:
+        data-layout: ["ROW_MAJOR"]
+        data-type: ["BFLOAT16", "BFLOAT8_B"]
+        buffer-type: ["DRAM", "L1"]
+        out-buffer-type: ["DRAM", "L1"]
+      output-file: backward_ceil_sweep.csv
+      env:
+        # TT_PCI_DMA_BUF_SIZE: "1048576"

--- a/tests/ttnn/python_api_testing/sweep_tests/test_configs/ci_sweep_tests_working/grayskull/ttnn_backward_cos_test.yaml
+++ b/tests/ttnn/python_api_testing/sweep_tests/test_configs/ci_sweep_tests_working/grayskull/ttnn_backward_cos_test.yaml
@@ -1,0 +1,28 @@
+---
+test-list:
+  - cos-bw:
+      shape:
+        start-shape: [1, 1, 32, 32]
+        end-shape: [6, 12, 256, 256]
+        interval: [1, 1, 32, 32]
+        num-dims: [2, 3, 4]
+        num-shapes: 2
+        num-samples: 128
+        args-sampling-strategy: "all"
+      env:
+        # TT_PCI_DMA_BUF_SIZE: "1048576"
+      datagen:
+        function: gen_rand
+        args:
+          low: 0
+          high: 6.283185307179586
+      comparison:
+        function: comp_pcc
+      args-gen: gen_dtype_layout_device
+      sanitize-args: False
+      args:
+        data-layout: ["TILE"]
+        data-type: ["BFLOAT16", "BFLOAT8_B"]
+        buffer-type: ["DRAM", "L1"]
+        out-buffer-type: ["DRAM", "L1"]
+      output-file: backward_cos_sweep.csv

--- a/tests/ttnn/python_api_testing/sweep_tests/test_configs/ci_sweep_tests_working/grayskull/ttnn_backward_cosh_test.yaml
+++ b/tests/ttnn/python_api_testing/sweep_tests/test_configs/ci_sweep_tests_working/grayskull/ttnn_backward_cosh_test.yaml
@@ -1,0 +1,28 @@
+---
+test-list:
+  - cosh-bw:
+      shape:
+        start-shape: [1, 1, 32, 32]
+        end-shape: [6, 12, 256, 256]
+        interval: [1, 1, 32, 32]
+        num-dims: [2, 3, 4]
+        num-shapes: 2
+        num-samples: 128
+        args-sampling-strategy: "all"
+      env:
+        # TT_PCI_DMA_BUF_SIZE: "1048576"
+      datagen:
+        function: gen_rand
+        args:
+          low: -9
+          high: 9
+      comparison:
+        function: comp_pcc
+      args-gen: gen_dtype_layout_device
+      sanitize-args: False
+      args:
+        data-layout: ["TILE"]
+        data-type: ["BFLOAT16"]
+        buffer-type: ["DRAM", "L1"]
+        out-buffer-type: ["DRAM", "L1"]
+      output-file: backward_cosh_sweep.csv

--- a/tests/ttnn/python_api_testing/sweep_tests/test_configs/ci_sweep_tests_working/wormhole/ttnn_backward_ceil_test.yaml
+++ b/tests/ttnn/python_api_testing/sweep_tests/test_configs/ci_sweep_tests_working/wormhole/ttnn_backward_ceil_test.yaml
@@ -1,0 +1,50 @@
+---
+test-list:
+  - ceil-bw:
+      shape:
+        start-shape: [1, 1, 32, 32]
+        end-shape: [6, 12, 256, 256]
+        interval: [1, 1, 32, 32]
+        num-shapes: 2
+        num-samples: 64
+        args-sampling-strategy: "all"
+      datagen:
+        function: gen_rand
+        args:
+          low: -100
+          high: 100
+      comparison:
+        function: comp_pcc
+      args-gen: gen_default_dtype_layout_device
+      args:
+        data-layout: ["TILE"]
+        data-type: ["BFLOAT16", "BFLOAT8_B"]
+        buffer-type: ["DRAM", "L1"]
+        out-buffer-type: ["DRAM", "L1"]
+      output-file: backward_ceil_sweep.csv
+      env:
+        # TT_PCI_DMA_BUF_SIZE: "1048576"
+  - ceil-bw:
+      shape:
+        start-shape: [1, 1, 2, 2]
+        end-shape: [6, 12, 256, 256]
+        interval: [1, 1, 1, 2]
+        num-shapes: 2
+        num-samples: 64
+        args-sampling-strategy: "all"
+      datagen:
+        function: gen_rand
+        args:
+          low: -100
+          high: 100
+      comparison:
+        function: comp_pcc
+      args-gen: gen_default_dtype_layout_device
+      args:
+        data-layout: ["ROW_MAJOR"]
+        data-type: ["BFLOAT16", "BFLOAT8_B"]
+        buffer-type: ["DRAM", "L1"]
+        out-buffer-type: ["DRAM", "L1"]
+      output-file: backward_ceil_sweep.csv
+      env:
+        # TT_PCI_DMA_BUF_SIZE: "1048576"

--- a/tests/ttnn/python_api_testing/sweep_tests/test_configs/ci_sweep_tests_working/wormhole/ttnn_backward_cos_test.yaml
+++ b/tests/ttnn/python_api_testing/sweep_tests/test_configs/ci_sweep_tests_working/wormhole/ttnn_backward_cos_test.yaml
@@ -1,0 +1,28 @@
+---
+test-list:
+  - cos-bw:
+      shape:
+        start-shape: [1, 1, 32, 32]
+        end-shape: [6, 12, 256, 256]
+        interval: [1, 1, 32, 32]
+        num-dims: [2, 3, 4]
+        num-shapes: 2
+        num-samples: 128
+        args-sampling-strategy: "all"
+      env:
+        # TT_PCI_DMA_BUF_SIZE: "1048576"
+      datagen:
+        function: gen_rand
+        args:
+          low: 0
+          high: 6.283185307179586
+      comparison:
+        function: comp_pcc
+      args-gen: gen_dtype_layout_device
+      sanitize-args: False
+      args:
+        data-layout: ["TILE"]
+        data-type: ["BFLOAT16", "BFLOAT8_B"]
+        buffer-type: ["DRAM", "L1"]
+        out-buffer-type: ["DRAM", "L1"]
+      output-file: backward_cos_sweep.csv

--- a/tests/ttnn/python_api_testing/sweep_tests/test_configs/ci_sweep_tests_working/wormhole/ttnn_backward_cosh_test.yaml
+++ b/tests/ttnn/python_api_testing/sweep_tests/test_configs/ci_sweep_tests_working/wormhole/ttnn_backward_cosh_test.yaml
@@ -1,0 +1,28 @@
+---
+test-list:
+  - cosh-bw:
+      shape:
+        start-shape: [1, 1, 32, 32]
+        end-shape: [6, 12, 256, 256]
+        interval: [1, 1, 32, 32]
+        num-dims: [2, 3, 4]
+        num-shapes: 2
+        num-samples: 128
+        args-sampling-strategy: "all"
+      env:
+        # TT_PCI_DMA_BUF_SIZE: "1048576"
+      datagen:
+        function: gen_rand
+        args:
+          low: -9
+          high: 9
+      comparison:
+        function: comp_pcc
+      args-gen: gen_dtype_layout_device
+      sanitize-args: False
+      args:
+        data-layout: ["TILE"]
+        data-type: ["BFLOAT16"]
+        buffer-type: ["DRAM", "L1"]
+        out-buffer-type: ["DRAM", "L1"]
+      output-file: backward_cosh_sweep.csv

--- a/tests/ttnn/python_api_testing/sweep_tests/ttnn_ops.py
+++ b/tests/ttnn/python_api_testing/sweep_tests/ttnn_ops.py
@@ -4001,6 +4001,25 @@ def logaddexp_bw(
     return [ttnn_tensor_to_torch(t3[0]), ttnn_tensor_to_torch(t3[1])]
 
 
+def ceil_bw(
+    x,  # grad_tensor
+    y,  # input_tensor
+    *args,
+    device,
+    dtype,
+    layout,
+    input_mem_config,
+    output_mem_config,
+    **kwargs,
+):
+    t0 = setup_ttnn_tensor(x, device, layout[0], input_mem_config[0], dtype[0])
+    t1 = setup_ttnn_tensor(y, device, layout[1], input_mem_config[1], dtype[1])
+
+    t2 = ttnn.ceil_bw(t0, t1, memory_config=output_mem_config)[0]
+
+    return ttnn_tensor_to_torch(t2)
+
+
 def logaddexp2_bw(
     x,  # grad_tensor
     y,  # input_tensor
@@ -4099,3 +4118,4 @@ def i0_bw(
     t2 = ttnn.i0_bw(t0, t1, memory_config=output_mem_config)[0]
 
     return ttnn_tensor_to_torch(t2)
+

--- a/tests/ttnn/python_api_testing/sweep_tests/ttnn_ops.py
+++ b/tests/ttnn/python_api_testing/sweep_tests/ttnn_ops.py
@@ -4061,6 +4061,25 @@ def hardshrink_bw(
     return ttnn_tensor_to_torch(t2)
 
 
+def celu_bw(
+    x,  # grad_tensor
+    y,  # input_tensor
+    *args,
+    alpha,
+    device,
+    dtype,
+    layout,
+    input_mem_config,
+    output_mem_config,
+    **kwargs,
+):
+    t0 = setup_ttnn_tensor(x, device, layout[0], input_mem_config[0], dtype[0])
+    t1 = setup_ttnn_tensor(y, device, layout[1], input_mem_config[1], dtype[1])
+    
+    t2 = ttnn.celu_bw(t0, t1, alpha=alpha, memory_config=output_mem_config)[0]
+
+    return ttnn_tensor_to_torch(t2)
+
 def hardtanh_bw(
     x,  # grad_tensor
     y,  # input_tensor

--- a/tests/ttnn/python_api_testing/sweep_tests/ttnn_ops.py
+++ b/tests/ttnn/python_api_testing/sweep_tests/ttnn_ops.py
@@ -4075,10 +4075,11 @@ def celu_bw(
 ):
     t0 = setup_ttnn_tensor(x, device, layout[0], input_mem_config[0], dtype[0])
     t1 = setup_ttnn_tensor(y, device, layout[1], input_mem_config[1], dtype[1])
-    
+
     t2 = ttnn.celu_bw(t0, t1, alpha=alpha, memory_config=output_mem_config)[0]
 
     return ttnn_tensor_to_torch(t2)
+
 
 def hardtanh_bw(
     x,  # grad_tensor
@@ -4138,3 +4139,40 @@ def i0_bw(
 
     return ttnn_tensor_to_torch(t2)
 
+
+def cosh_bw(
+    x,  # grad_tensor
+    y,  # input_tensor
+    *args,
+    device,
+    dtype,
+    layout,
+    input_mem_config,
+    output_mem_config,
+    **kwargs,
+):
+    t0 = setup_ttnn_tensor(x, device, layout[0], input_mem_config[0], dtype[0])
+    t1 = setup_ttnn_tensor(y, device, layout[1], input_mem_config[1], dtype[1])
+
+    t2 = ttnn.cosh_bw(t0, t1, memory_config=output_mem_config)[0]
+
+    return ttnn_tensor_to_torch(t2)
+
+
+def cos_bw(
+    x,  # grad_tensor
+    y,  # input_tensor
+    *args,
+    device,
+    dtype,
+    layout,
+    input_mem_config,
+    output_mem_config,
+    **kwargs,
+):
+    t0 = setup_ttnn_tensor(x, device, layout[0], input_mem_config[0], dtype[0])
+    t1 = setup_ttnn_tensor(y, device, layout[1], input_mem_config[1], dtype[1])
+
+    t2 = ttnn.cos_bw(t0, t1, memory_config=output_mem_config)[0]
+
+    return ttnn_tensor_to_torch(t2)


### PR DESCRIPTION
### Ticket
[Link to Github Issue](https://github.com/tenstorrent/tt-metal/issues/10147)

### Problem description
Missing sweeps and API calls for backward_ops:
- ceil_bw
- celu_bw
- cosh_bw
- cos_bw

### What's changed
Aded YAML files, API calls in ttnn_ops.py and corresponding golden functions in pytorch_ops.py for:

- [x]  ceil_bw
- [x]  celu_bw
- [x]  cosh_bw
- [x]  cos_bw

### Checklist
- [x] Post commit CI passes
- [x] Model regression CI testing passes (if applicable)
- [x] New/Existing tests provide coverage for changes
