### PR TITLE
#0: Uplift tensix riscv local mem sizes for BH

### DIFF
--- a/tt_metal/hw/inc/blackhole/dev_mem_map.h
+++ b/tt_metal/hw/inc/blackhole/dev_mem_map.h
@@ -32,10 +32,10 @@
 #define MEM_ETH_SIZE (256 * 1024)
 
 #define MEM_LOCAL_BASE 0xFFB00000
-#define MEM_BRISC_LOCAL_SIZE (4 * 1024)
-#define MEM_NCRISC_LOCAL_SIZE (4 * 1024)
+#define MEM_BRISC_LOCAL_SIZE (8 * 1024)
+#define MEM_NCRISC_LOCAL_SIZE (8 * 1024)
 #define MEM_IERISC_LOCAL_SIZE (4 * 1024)
-#define MEM_TRISC_LOCAL_SIZE (2 * 1024)
+#define MEM_TRISC_LOCAL_SIZE (4 * 1024)
 
 /////////////
 // Firmware/kernel code holes


### PR DESCRIPTION
### Problem description
BH was using incorrect local mem sizes 

### What's changed
Uplifted dev mem map to use correct <riscv>_local_size 

### Checklist
- [x] [Post commit CI passes](https://github.com/tenstorrent/tt-metal/actions/runs/10222408350)