### PR TITLE
Add device perf CI to Mixtral8x7b

### DIFF
--- a/models/demos/t3000/falcon40b/tests/test_perf_device_falcon.py
+++ b/models/demos/t3000/falcon40b/tests/test_perf_device_falcon.py
@@ -1,0 +1,67 @@
+import os
+import sys
+import glob
+import pytest
+
+from models.demos.t3000.mixtral8x7b.scripts.op_perf_results import main as calculate_op_perf_results
+from tt_metal.tools.profiler.process_model_log import run_device_profiler
+
+
+@pytest.mark.models_device_performance_bare_metal
+@pytest.mark.parametrize(
+    "test, skip_first, skip_last, expected_throughput",
+    [
+        ["prefill_seq128_bfp8_layers1", 3, 7, 1900],
+        ["prefill_seq2048_bfp8_layers1", 3, 9, 3400],
+    ],
+)
+def test_perf_device_bare_metal(test, skip_first, skip_last, expected_throughput):
+    """
+    Test the performance of the device in bare metal mode.
+
+    Args:
+        test (str): The test configuration.
+        skip_first (int): The number of starting ops not in layer of LLM to skip.
+        skip_last (int): The number of final ops not in layer of LLM to skip.
+        expected_throughput (int): The expected throughput in tokens per second.
+    Raises:
+        AssertionError: If the measured throughput is less than the expected throughput.
+    """
+    # Prepare the command and other arguments to run the profiler
+    subdir = f"falcon_40b"
+    args = f"wormhole_b0-True-{subdir}-{test}-8chips"
+    llm_mode, seq_len, *_ = test.split("_")
+    seq_len = seq_len.replace("seq", "")
+    command = f"pytest models/demos/t3000/falcon40b/tests/test_perf_falcon.py::test_device_perf_bare_metal[{args}]"
+    env_vars = os.environ.copy()
+
+    # Run the profiler to get the ops performance results
+    output_logs_dir = run_device_profiler(command, subdir, env_vars)
+
+    # Get the latest date dir
+    latest_date_dir = max(os.listdir(output_logs_dir))
+    latest_date_dir = os.path.join(output_logs_dir, latest_date_dir)
+
+    # Get latest dir with ops_perf_results and extract the filename
+    ops_perf_filename = glob.glob(f"{latest_date_dir}/ops_perf_results*.csv", recursive=True)[0]
+
+    # Prepare the arguments to calculate the ops performance results
+    sys.argv = [
+        "op_perf_results.py",
+        f"{ops_perf_filename}",
+        "--signpost",
+        "PERF_RUN",
+        "--skip-first",
+        f"{skip_first}",
+        "--skip-last",
+        f"{skip_last}",
+        f"--{llm_mode}",
+        "--seqlen",
+        f"{seq_len}",
+        "--estimate-full-model",
+        "60",
+    ]
+
+    # Calculate the ops performance results
+    tokens_per_sec = calculate_op_perf_results()
+    assert tokens_per_sec >= expected_throughput

--- a/models/demos/t3000/mixtral8x7b/scripts/op_perf_results.py
+++ b/models/demos/t3000/mixtral8x7b/scripts/op_perf_results.py
@@ -91,6 +91,8 @@ def main():
     if args.write_ops_to_csv:
         write_blocks_to_csv(blocks, args.write_ops_to_csv)
 
+    return tokens_per_s
+
 
 def read_rows(csv_file):
     with open(csv_file, "r") as f:

--- a/models/demos/t3000/mixtral8x7b/tests/test_mixtral_device_perf.py
+++ b/models/demos/t3000/mixtral8x7b/tests/test_mixtral_device_perf.py
@@ -17,7 +17,7 @@ from tt_metal.tools.profiler.process_model_log import run_device_profiler
         ["decode_2k", 23],
         ["prefill_128", 1000],
         ["prefill_1k", 2550],
-        ["prefill_2k", 2714],
+        ["prefill_2k", 2700],
     ],
     ids=[
         "decode_32",

--- a/models/demos/t3000/mixtral8x7b/tests/test_mixtral_device_perf.py
+++ b/models/demos/t3000/mixtral8x7b/tests/test_mixtral_device_perf.py
@@ -1,0 +1,69 @@
+import os
+import sys
+import glob
+import pytest
+
+from models.demos.t3000.mixtral8x7b.scripts.op_perf_results import main as calculate_op_perf_results
+from tt_metal.tools.profiler.process_model_log import run_device_profiler
+
+
+@pytest.mark.models_device_performance_bare_metal
+@pytest.mark.parametrize(
+    "test, signpost, llm_mode, expected_throughput",
+    [
+        # ["32-150-0.085", "decode" ,"Model perf run", 26],
+        # ["128-150-0.085", "decode", "Model perf run", 26],  # FIXME: #9028
+        # ["1024-150-0.085", "decode", "Model perf run", 26],
+        # ["2048-150-0.085", "decode", "Model perf run", 26],
+    ],
+)
+def test_perf_device_bare_metal(test, llm_mode, signpost, expected_throughput):
+    """
+    Test the performance of the device in bare metal mode.
+    Args:
+        test (str): The test configuration.
+        signpost (str): The name of the signpost used for profiling.
+        expected_throughput (int): The expected throughput in tokens per second.
+    Raises:
+        AssertionError: If the measured throughput is less than the expected throughput.
+    """
+    # Prepare the command and other arguments to run the profiler
+    subdir = f"Mixtral8x7b"
+    args = f"wormhole_b0-True-{test}"
+    seq_len, *_ = test.split("-")
+    # seq_len = seq_len.replace("seq", "")
+    command = f"pytest models/demos/t3000/mixtral8x7b/tests/test_mixtral_perf.py::test_mixtral_model_perf[{args}]"
+    env_vars = os.environ.copy()
+
+    # Run the profiler to get the ops performance results
+    output_logs_dir = run_device_profiler(command, subdir, env_vars)
+    print(f"Miguel: output_logs_dir = {output_logs_dir}")
+
+    # Get the latest date dir
+    latest_date_dir = max(os.listdir(output_logs_dir))
+    latest_date_dir = os.path.join(output_logs_dir, latest_date_dir)
+
+    # Get latest dir with ops_perf_results and extract the filename
+    ops_perf_filename = glob.glob(f"{latest_date_dir}/ops_perf_results*.csv", recursive=True)[0]
+
+    # TODO All llm_mode == prefill below
+    # Prepare the arguments to calculate the ops performance results
+    sys.argv = [
+        "op_perf_results.py",
+        f"{ops_perf_filename}",
+        "--signpost",
+        f"{signpost}",
+        # "--skip-first",
+        # f"{skip_first}",
+        # "--skip-last",
+        # f"{skip_last}",
+        # f"--{llm_mode}",
+        "--seqlen",
+        f"{seq_len}",
+        # "--estimate-full-model",
+        # "60",
+    ]
+
+    # Calculate the ops performance results
+    tokens_per_sec = calculate_op_perf_results()
+    assert tokens_per_sec >= expected_throughput

--- a/tests/scripts/run_performance.sh
+++ b/tests/scripts/run_performance.sh
@@ -84,6 +84,8 @@ run_device_perf_models() {
         #env WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml pytest models/experimental/functional_unet/tests -m $test_marker
 
         env WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml pytest models/demos/falcon7b_common/tests -m $test_marker
+
+        env WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml pytest models/demos/t3000/falcon40b/tests/test_perf_device_falcon.py -m $test_marker
     fi
 
     ## Merge all the generated reports

--- a/tests/scripts/run_performance.sh
+++ b/tests/scripts/run_performance.sh
@@ -84,8 +84,6 @@ run_device_perf_models() {
         #env WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml pytest models/experimental/functional_unet/tests -m $test_marker
 
         env WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml pytest models/demos/falcon7b_common/tests -m $test_marker
-
-        env WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml pytest models/demos/t3000/falcon40b/tests/test_perf_device_falcon.py -m $test_marker
     fi
 
     ## Merge all the generated reports

--- a/tt_metal/tools/profiler/process_model_log.py
+++ b/tt_metal/tools/profiler/process_model_log.py
@@ -33,10 +33,12 @@ def post_process_ops_log(output_logs_subdir, columns, sum_vals=True, op_name="",
     return results
 
 
-def run_device_profiler(command, output_logs_subdir):
+def run_device_profiler(command, output_logs_subdir, env_vars=None):
     output_logs_dir = PROFILER_OUTPUT_DIR / output_logs_subdir
+    print(output_logs_dir)
     profiler_cmd = f"python -m tracy -p -r -o {output_logs_dir} -t 5000 -m {command}"
-    subprocess.run([profiler_cmd], shell=True, check=True)
+    subprocess.run([profiler_cmd], shell=True, check=True, env=env_vars)
+    return output_logs_dir
 
 
 def get_samples_per_s(time_ns, num_samples):


### PR DESCRIPTION
### Ticket
#11045 

Based on @djordje-tt work in branch: https://github.com/tenstorrent/tt-metal/compare/divanovic/falcon40b_ci_device_perf

### Problem description
Runs Mixtral test perf script with tracy support followed by a script that gathers all device timings and reports back the device performance.

### Checklist
- [ ] Post commit CI passes
- [ ] New T3k device perf CI
