### PR TITLE
#0: remove pinned `python3.8-venv` in docker requirements

### DIFF
--- a/scripts/docker/requirements.txt
+++ b/scripts/docker/requirements.txt
@@ -16,6 +16,6 @@ libhwloc-dev
 libhdf5-serial-dev
 ruby=1:2.7+1
 python3-dev=3.8.2-0ubuntu2
-python3.8-venv=3.8.10-0ubuntu1~20.04.10
+python3.8-venv
 cargo
 ninja-build


### PR DESCRIPTION
### Ticket
Link to Github Issue

### Problem description
Provide context for the problem.

### What's changed
Describe the approach used to solve the problem.
Summarize the changes made and its impact.

### Checklist
- [ ] Post commit CI passes
- [ ] Blackhole Post commit (if applicable)
- [ ] Model regression CI testing passes (if applicable)
- [ ] New/Existing tests provide coverage for changes
