### PR TITLE
#4984: Move watcher msg into their own struct

### DIFF
--- a/tests/tt_metal/tt_metal/unit_tests_common/watcher/test_noc_sanitize_delays.cpp
+++ b/tests/tt_metal/tt_metal/unit_tests_common/watcher/test_noc_sanitize_delays.cpp
@@ -147,7 +147,7 @@ void RunDelayTestOnCore(WatcherDelayFixture* fixture, Device* device, CoreCoord 
         read_vec = tt::llrt::read_hex_vec_from_core (
             device->id(),
             phys_core,
-            GET_MAILBOX_ADDRESS_HOST(debug_insert_delays), sizeof(debug_insert_delays_msg_t));
+            GET_MAILBOX_ADDRESS_HOST(watcher.debug_insert_delays), sizeof(debug_insert_delays_msg_t));
 
         log_info(tt::LogTest, "Read back debug_insert_delays: 0x{:x}", read_vec[0]);
         EXPECT_TRUE((read_vec[0] >> 24) == 0x3);

--- a/tt_metal/hw/inc/debug/assert.h
+++ b/tt_metal/hw/inc/debug/assert.h
@@ -10,7 +10,7 @@
 
 void assert_and_hang(uint32_t line_num) {
     // Write the line number into the memory mailbox for host to read.
-    debug_assert_msg_t tt_l1_ptr *v = GET_MAILBOX_ADDRESS_DEV(assert_status);
+    debug_assert_msg_t tt_l1_ptr *v = GET_MAILBOX_ADDRESS_DEV(watcher.assert_status);
     if (v->tripped == DebugAssertOK) {
         v->line_num = line_num;
         v->tripped = DebugAssertTripped;

--- a/tt_metal/hw/inc/debug/ring_buffer.h
+++ b/tt_metal/hw/inc/debug/ring_buffer.h
@@ -16,7 +16,7 @@ constexpr static int16_t DEBUG_RING_BUFFER_STARTING_INDEX = -1;
 #if defined(WATCHER_ENABLED) && !defined(WATCHER_DISABLE_RING_BUFFER)
 
 void push_to_ring_buffer(uint32_t val) {
-    auto buf = GET_MAILBOX_ADDRESS_DEV(debug_ring_buf);
+    auto buf = GET_MAILBOX_ADDRESS_DEV(watcher.debug_ring_buf);
     volatile tt_l1_ptr int16_t* curr_ptr = &buf->current_ptr;
     volatile tt_l1_ptr uint16_t* wrapped = &buf->wrapped;
     uint32_t* data = buf->data;

--- a/tt_metal/hw/inc/debug/sanitize_noc.h
+++ b/tt_metal/hw/inc/debug/sanitize_noc.h
@@ -70,7 +70,7 @@ typedef bool debug_sanitize_noc_cast_t;
 //  - this isn't racy between riscvs so long as each gets their own noc_index
 inline void debug_sanitize_post_noc_addr_and_hang(
     uint64_t noc_addr, uint32_t l1_addr, uint32_t len, debug_sanitize_noc_cast_t multicast, uint16_t invalid) {
-    debug_sanitize_noc_addr_msg_t tt_l1_ptr *v = *GET_MAILBOX_ADDRESS_DEV(sanitize_noc);
+    debug_sanitize_noc_addr_msg_t tt_l1_ptr *v = *GET_MAILBOX_ADDRESS_DEV(watcher.sanitize_noc);
 
     if (v[noc_index].invalid == DebugSanitizeNocInvalidOK) {
         v[noc_index].noc_addr = noc_addr;
@@ -256,7 +256,7 @@ void debug_sanitize_noc_and_worker_addr(
 // Delay for debugging purposes
 inline void debug_insert_delay(uint8_t transaction_type) {
 #if defined(WATCHER_DEBUG_DELAY)
-    debug_insert_delays_msg_t tt_l1_ptr *v = GET_MAILBOX_ADDRESS_DEV(debug_insert_delays);
+    debug_insert_delays_msg_t tt_l1_ptr *v = GET_MAILBOX_ADDRESS_DEV(watcher.debug_insert_delays);
 
     bool delay = false;
     switch (transaction_type) {

--- a/tt_metal/hw/inc/debug/status.h
+++ b/tt_metal/hw/inc/debug/status.h
@@ -49,7 +49,7 @@ inline void write_debug_status(volatile tt_l1_ptr uint32_t *debug_status) {
 #endif
 
 #define DEBUG_STATUS_MAILBOX \
-    (volatile tt_l1_ptr uint32_t *)&((*GET_MAILBOX_ADDRESS_DEV(debug_status))[DEBUG_STATUS_MAILBOX_OFFSET])
+    (volatile tt_l1_ptr uint32_t *)&((*GET_MAILBOX_ADDRESS_DEV(watcher.debug_status))[DEBUG_STATUS_MAILBOX_OFFSET])
 
 #define DEBUG_STATUS(x) write_debug_status<helper(x)>(DEBUG_STATUS_MAILBOX)
 

--- a/tt_metal/hw/inc/dev_msgs.h
+++ b/tt_metal/hw/inc/dev_msgs.h
@@ -210,18 +210,23 @@ enum watcher_enable_msg_t {
 };
 
 constexpr int num_riscv_per_core = 5;
-struct mailboxes_t {
-    struct ncrisc_halt_msg_t ncrisc_halt;
-    struct slave_sync_msg_t slave_sync;
-    volatile uint32_t l1_barrier;
-    struct launch_msg_t launch;
-    volatile uint32_t watcher_enable;
+
+struct watcher_msg_t {
+    volatile uint32_t enable;
     struct debug_status_msg_t debug_status[num_riscv_per_core];
     struct debug_sanitize_noc_addr_msg_t sanitize_noc[NUM_NOCS];
     struct debug_assert_msg_t assert_status;
     struct debug_pause_msg_t pause_status;
     struct debug_insert_delays_msg_t debug_insert_delays;
     struct debug_ring_buf_msg_t debug_ring_buf;
+};
+
+struct mailboxes_t {
+    struct ncrisc_halt_msg_t ncrisc_halt;
+    struct slave_sync_msg_t slave_sync;
+    volatile uint32_t l1_barrier;
+    struct launch_msg_t launch;
+    struct watcher_msg_t watcher;
     struct dprint_buf_msg_t dprint_buf;
 };
 


### PR DESCRIPTION
### Ticket
Link to Github Issue

### Problem description
Provide context for the problem.

### What's changed
Describe the approach used to solve the problem.
Summarize the changes made and its impact.

### Checklist
- [ ] Post commit CI passes
- [ ] Blackhole Post commit (if applicable)
- [ ] Model regression CI testing passes (if applicable)
- [ ] New/Existing tests provide coverage for changes
