### PR TITLE
#10703: Make ttnn::Buffer allocation thread/memory safe

### DIFF
--- a/tests/ttnn/unit_tests/gtests/test_async_runtime.cpp
+++ b/tests/ttnn/unit_tests/gtests/test_async_runtime.cpp
@@ -167,10 +167,15 @@ TEST_F(MultiCommandQueueSingleDeviceFixture, TestAsyncRuntimeBufferDestructor) {
     // Inside the loop, initialize a buffer with limited lifetime.
     // This will asynchronously allocate the buffer, wait for the allocation to complete (address to be assigned to the buffer), destroy the buffer (which will asynchronously
     // deallocate the buffer) in a loop
+    uint32_t address = 0;
     for (int loop = 0; loop < 100000; loop++) {
         {
             auto input_buffer_dummy = ttnn::allocate_buffer_on_device(buf_size_datums * datum_size_bytes, device, shape, DataType::BFLOAT16, Layout::TILE, mem_cfg);
-            device->synchronize();
+            if (loop == 0) {
+                address = input_buffer_dummy->address();
+            } else {
+                EXPECT_EQ(input_buffer_dummy->address(), address);
+            }
         }
     }
 }

--- a/tt_metal/impl/buffers/buffer.hpp
+++ b/tt_metal/impl/buffers/buffer.hpp
@@ -175,7 +175,7 @@ class Buffer {
 
     void set_size(uint64_t size) { size_ = size; }
     // Returns address of buffer in the first bank
-    uint32_t address() const { return static_cast<uint32_t>(address_); }
+    virtual uint32_t address() const { return static_cast<uint32_t>(address_); }
 
     void set_address(uint64_t addr) { address_ = addr; }
 

--- a/ttnn/cpp/ttnn/async_runtime.cpp
+++ b/ttnn/cpp/ttnn/async_runtime.cpp
@@ -19,12 +19,12 @@ DeviceBuffer allocate_interleaved_buffer_on_device(
     Layout layout,
     const MemoryConfig& memory_config) {
     uint32_t page_size = tt::tt_metal::tensor_impl::get_page_size(data_type, layout, buffer_size_bytes, shape.value);
-    return std::make_shared<Buffer>(device, buffer_size_bytes, page_size, memory_config.buffer_type);
+    return Buffer::Create(device, buffer_size_bytes, page_size, memory_config.buffer_type);
 }
 
 DeviceBuffer allocate_contiguous_buffer_on_device(
     uint32_t buffer_size_bytes, Device* device, const MemoryConfig& memory_config) {
-    return std::make_shared<Buffer>(device, buffer_size_bytes, buffer_size_bytes, memory_config.buffer_type);
+    return Buffer::Create(device, buffer_size_bytes, buffer_size_bytes, memory_config.buffer_type);
 }
 
 DeviceBuffer allocate_sharded_buffer_on_device(
@@ -43,9 +43,7 @@ DeviceBuffer allocate_sharded_buffer_on_device(
     if (layout == Layout::TILE) {
         page_size = tt::tt_metal::tensor_impl::get_page_size(data_type, layout, buffer_size_bytes, shape.value);
     }
-
-    return std::make_shared<Buffer>(
-        device, buffer_size_bytes, page_size, memory_config.buffer_type, memory_config.memory_layout, shard_params);
+    return Buffer::Create(device, buffer_size_bytes, page_size, memory_config.buffer_type, memory_config.memory_layout, shard_params);
 }
 
 DeviceBuffer allocate_buffer_on_device(


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/10703

### Problem description
ttnn Buffer allocation was not thread or memory safe.

### What's changed
Make `ttnn::Buffer` inherit from `enable_shared_from_this`, to ensure that worker thread and main thread can have joint ownership (this will bypass a segfault that could show up in a degenerate allocation, where the user allocates a buffer asynchronously and does nothing with it).
Remove the `GLOBAL_ADDRESS_MAP` and use a `static thread_local` map instead.
Make `buffer.address()` async aware.

### Checklist
- [ ] Post commit CI passes
- [ ] Blackhole Post commit (if applicable)
- [ ] Model regression CI testing passes (if applicable)
- [ ] New/Existing tests provide coverage for changes
