### PR TITLE
Concat_bw fix

### DIFF
--- a/tests/tt_eager/python_api_testing/sweep_tests/common.py
+++ b/tests/tt_eager/python_api_testing/sweep_tests/common.py
@@ -687,6 +687,32 @@ def shapes_and_datagen(
             ):
                 yield shapes, datagen_funcs, test_args
 
+        elif method == "concat_bw":
+
+            def _gen_concat_bw_shapes(shape):
+                shape1 = []
+                shape2 = []
+                grad_shape = []
+
+                num_dims = len(shape)
+
+                dim = random.randint(0, num_dims - 1)
+
+                for i in range(num_dims):
+                    shape1.append(shape[i])
+                    shape2.append(shape[i])
+                    if i == dim:
+                        grad_shape.append(shape1[i] + shape2[i])
+                    else:
+                        grad_shape.append(shape[i])
+
+                return [grad_shape, shape1, shape2]
+
+            for shapes, datagen_funcs, test_args in _gen_shapes_and_args(
+                start_shape, end_shape, interval, _gen_concat_bw_shapes
+            ):
+                yield shapes, datagen_funcs, test_args
+
         else:
             raise NotImplementedError("Method {method} is not a valid choice")
 

--- a/tests/tt_eager/python_api_testing/sweep_tests/pytorch_ops.py
+++ b/tests/tt_eager/python_api_testing/sweep_tests/pytorch_ops.py
@@ -2097,7 +2097,7 @@ def concat_bw(x, y, z, *args, **kwargs):
     pyt_y = torch.concat([in_data, other_data], dim)
     pyt_y.backward(gradient=grad_data)
 
-    return torch.stack([in_data.grad, other_data.grad])
+    return [in_data.grad, other_data.grad]
 
 
 def global_avg_pool2d(x, *args, **kwargs):

--- a/tests/tt_eager/python_api_testing/sweep_tests/pytorch_ops.py
+++ b/tests/tt_eager/python_api_testing/sweep_tests/pytorch_ops.py
@@ -2078,6 +2078,28 @@ def cos_bw(x, y, *args, **kwargs):
     return in_data.grad
 
 
+def concat_bw(x, y, z, *args, **kwargs):
+    grad_data = x
+    in_data = y
+    other_data = z
+
+    in_data.requires_grad = True
+    other_data.requires_grad = True
+
+    in_data.retain_grad()
+    other_data.retain_grad()
+
+    dim = -1
+    for i in range(0, len(x.size())):
+        if x.size(i) == y.size(i) + z.size(i):
+            dim = i
+
+    pyt_y = torch.concat([in_data, other_data], dim)
+    pyt_y.backward(gradient=grad_data)
+
+    return torch.stack([in_data.grad, other_data.grad])
+
+
 def global_avg_pool2d(x, *args, **kwargs):
     output_size = (1, 1)
     x = x.to(torch.float32)

--- a/tests/ttnn/python_api_testing/sweep_tests/op_map.py
+++ b/tests/ttnn/python_api_testing/sweep_tests/op_map.py
@@ -899,6 +899,6 @@ op_map = {
     },
     "concat-bw": {
         "tt_op": ttnn_ops.concat_bw,
-        "pytorch_op": pytorch_ops.concat_bw,
+        "pytorch_op": ttnn_pytorch_ops.concat_bw,
     },
 }

--- a/tests/ttnn/python_api_testing/sweep_tests/op_map.py
+++ b/tests/ttnn/python_api_testing/sweep_tests/op_map.py
@@ -897,4 +897,8 @@ op_map = {
         "tt_op": ttnn_ops.eltwise_bitwise_or,
         "pytorch_op": pytorch_ops.bitwise_or,
     },
+    "concat-bw": {
+        "tt_op": ttnn_ops.concat_bw,
+        "pytorch_op": pytorch_ops.concat_bw,
+    },
 }

--- a/tests/ttnn/python_api_testing/sweep_tests/test_configs/ci_sweep_tests_working/grayskull/ttnn_backward_concat_test.yaml
+++ b/tests/ttnn/python_api_testing/sweep_tests/test_configs/ci_sweep_tests_working/grayskull/ttnn_backward_concat_test.yaml
@@ -16,7 +16,7 @@ test-list:
           high: 100
       comparison:
         function: comp_equal_list
-      args-gen: gen_dtype_layout_device
+      args-gen: gen_concat_args
       args:
         data-layout: ["TILE"]
         data-type: ["BFLOAT16"]
@@ -39,7 +39,7 @@ test-list:
           high: 100
       comparison:
         function: comp_equal_list
-      args-gen: gen_dtype_layout_device
+      args-gen: gen_concat_args
       args:
         data-layout: ["TILE"]
         data-type: ["BFLOAT8_B"]

--- a/tests/ttnn/python_api_testing/sweep_tests/test_configs/ci_sweep_tests_working/grayskull/ttnn_backward_concat_test.yaml
+++ b/tests/ttnn/python_api_testing/sweep_tests/test_configs/ci_sweep_tests_working/grayskull/ttnn_backward_concat_test.yaml
@@ -16,7 +16,7 @@ test-list:
           high: 100
       comparison:
         function: comp_equal_list
-      args-gen: gen_default_dtype_layout_device
+      args-gen: gen_dtype_layout_device
       args:
         data-layout: ["TILE"]
         data-type: ["BFLOAT16"]
@@ -39,7 +39,7 @@ test-list:
           high: 100
       comparison:
         function: comp_equal_list
-      args-gen: gen_default_dtype_layout_device
+      args-gen: gen_dtype_layout_device
       args:
         data-layout: ["TILE"]
         data-type: ["BFLOAT8_B"]

--- a/tests/ttnn/python_api_testing/sweep_tests/test_configs/ci_sweep_tests_working/grayskull/ttnn_backward_concat_test.yaml
+++ b/tests/ttnn/python_api_testing/sweep_tests/test_configs/ci_sweep_tests_working/grayskull/ttnn_backward_concat_test.yaml
@@ -15,7 +15,7 @@ test-list:
           low: -100
           high: 100
       comparison:
-        function: comp_equal
+        function: comp_equal_list
       args-gen: gen_default_dtype_layout_device
       args:
         data-layout: ["TILE"]
@@ -38,7 +38,7 @@ test-list:
           low: -100
           high: 100
       comparison:
-        function: comp_equal
+        function: comp_equal_list
       args-gen: gen_default_dtype_layout_device
       args:
         data-layout: ["TILE"]

--- a/tests/ttnn/python_api_testing/sweep_tests/test_configs/ci_sweep_tests_working/grayskull/ttnn_backward_concat_test.yaml
+++ b/tests/ttnn/python_api_testing/sweep_tests/test_configs/ci_sweep_tests_working/grayskull/ttnn_backward_concat_test.yaml
@@ -1,0 +1,48 @@
+---
+test-list:
+  - concat-bw:
+      shape:
+        start-shape: [1, 1, 32, 32]
+        end-shape: [6, 12, 256, 256]
+        interval: [1, 1, 32, 32]
+        num-shapes: 3
+        num-samples: 64
+        args-sampling-strategy: "all"
+        method: concat_bw
+      datagen:
+        function: gen_rand
+        args:
+          low: -100
+          high: 100
+      comparison:
+        function: comp_equal
+      args-gen: gen_default_dtype_layout_device
+      args:
+        data-layout: ["TILE"]
+        data-type: ["BFLOAT16"]
+        buffer-type: ["DRAM", "L1"]
+        out-buffer-type: ["DRAM", "L1"]
+      output-file: backward_concat_sweep.csv
+  - concat-bw:
+      shape:
+        start-shape: [1, 1, 32, 32]
+        end-shape: [6, 12, 256, 256]
+        interval: [1, 1, 32, 32]
+        num-shapes: 3
+        num-samples: 64
+        args-sampling-strategy: "all"
+        method: concat_bw
+      datagen:
+        function: gen_rand
+        args:
+          low: -100
+          high: 100
+      comparison:
+        function: comp_equal
+      args-gen: gen_default_dtype_layout_device
+      args:
+        data-layout: ["TILE"]
+        data-type: ["BFLOAT8_B"]
+        buffer-type: ["DRAM", "L1"]
+        out-buffer-type: ["DRAM", "L1"]
+      output-file: backward_concat_sweep.csv

--- a/tests/ttnn/python_api_testing/sweep_tests/test_configs/ci_sweep_tests_working/wormhole/ttnn_backward_concat_test.yaml
+++ b/tests/ttnn/python_api_testing/sweep_tests/test_configs/ci_sweep_tests_working/wormhole/ttnn_backward_concat_test.yaml
@@ -16,7 +16,7 @@ test-list:
           high: 100
       comparison:
         function: comp_equal_list
-      args-gen: gen_dtype_layout_device
+      args-gen: gen_concat_args
       args:
         data-layout: ["TILE"]
         data-type: ["BFLOAT16"]
@@ -39,7 +39,7 @@ test-list:
           high: 100
       comparison:
         function: comp_equal_list
-      args-gen: gen_dtype_layout_device
+      args-gen: gen_concat_args
       args:
         data-layout: ["TILE"]
         data-type: ["BFLOAT8_B"]

--- a/tests/ttnn/python_api_testing/sweep_tests/test_configs/ci_sweep_tests_working/wormhole/ttnn_backward_concat_test.yaml
+++ b/tests/ttnn/python_api_testing/sweep_tests/test_configs/ci_sweep_tests_working/wormhole/ttnn_backward_concat_test.yaml
@@ -16,7 +16,7 @@ test-list:
           high: 100
       comparison:
         function: comp_equal_list
-      args-gen: gen_default_dtype_layout_device
+      args-gen: gen_dtype_layout_device
       args:
         data-layout: ["TILE"]
         data-type: ["BFLOAT16"]
@@ -39,7 +39,7 @@ test-list:
           high: 100
       comparison:
         function: comp_equal_list
-      args-gen: gen_default_dtype_layout_device
+      args-gen: gen_dtype_layout_device
       args:
         data-layout: ["TILE"]
         data-type: ["BFLOAT8_B"]

--- a/tests/ttnn/python_api_testing/sweep_tests/test_configs/ci_sweep_tests_working/wormhole/ttnn_backward_concat_test.yaml
+++ b/tests/ttnn/python_api_testing/sweep_tests/test_configs/ci_sweep_tests_working/wormhole/ttnn_backward_concat_test.yaml
@@ -15,7 +15,7 @@ test-list:
           low: -100
           high: 100
       comparison:
-        function: comp_equal
+        function: comp_equal_list
       args-gen: gen_default_dtype_layout_device
       args:
         data-layout: ["TILE"]
@@ -38,7 +38,7 @@ test-list:
           low: -100
           high: 100
       comparison:
-        function: comp_equal
+        function: comp_equal_list
       args-gen: gen_default_dtype_layout_device
       args:
         data-layout: ["TILE"]

--- a/tests/ttnn/python_api_testing/sweep_tests/test_configs/ci_sweep_tests_working/wormhole/ttnn_backward_concat_test.yaml
+++ b/tests/ttnn/python_api_testing/sweep_tests/test_configs/ci_sweep_tests_working/wormhole/ttnn_backward_concat_test.yaml
@@ -1,0 +1,48 @@
+---
+test-list:
+  - concat-bw:
+      shape:
+        start-shape: [1, 1, 32, 32]
+        end-shape: [6, 12, 256, 256]
+        interval: [1, 1, 32, 32]
+        num-shapes: 3
+        num-samples: 64
+        args-sampling-strategy: "all"
+        method: concat_bw
+      datagen:
+        function: gen_rand
+        args:
+          low: -100
+          high: 100
+      comparison:
+        function: comp_equal
+      args-gen: gen_default_dtype_layout_device
+      args:
+        data-layout: ["TILE"]
+        data-type: ["BFLOAT16"]
+        buffer-type: ["DRAM", "L1"]
+        out-buffer-type: ["DRAM", "L1"]
+      output-file: backward_concat_sweep.csv
+  - concat-bw:
+      shape:
+        start-shape: [1, 1, 32, 32]
+        end-shape: [6, 12, 256, 256]
+        interval: [1, 1, 32, 32]
+        num-shapes: 3
+        num-samples: 64
+        args-sampling-strategy: "all"
+        method: concat_bw
+      datagen:
+        function: gen_rand
+        args:
+          low: -100
+          high: 100
+      comparison:
+        function: comp_equal
+      args-gen: gen_default_dtype_layout_device
+      args:
+        data-layout: ["TILE"]
+        data-type: ["BFLOAT8_B"]
+        buffer-type: ["DRAM", "L1"]
+        out-buffer-type: ["DRAM", "L1"]
+      output-file: backward_concat_sweep.csv

--- a/tests/ttnn/python_api_testing/sweep_tests/ttnn_ops.py
+++ b/tests/ttnn/python_api_testing/sweep_tests/ttnn_ops.py
@@ -4133,6 +4133,7 @@ def i0_bw(
     **kwargs,
 ):
     t0 = setup_ttnn_tensor(x, device, layout[0], input_mem_config[0], dtype[0])
+
     t1 = setup_ttnn_tensor(y, device, layout[1], input_mem_config[1], dtype[1])
 
     t2 = ttnn.i0_bw(t0, t1, memory_config=output_mem_config)[0]
@@ -4328,4 +4329,3 @@ def eltwise_bitwise_or(
     t1 = ttnn.bitwise_or(t0, value, memory_config=output_mem_config, queue_id=0)
 
     return ttnn_tensor_to_torch(t1)
-

--- a/tests/ttnn/python_api_testing/sweep_tests/ttnn_ops.py
+++ b/tests/ttnn/python_api_testing/sweep_tests/ttnn_ops.py
@@ -4182,7 +4182,7 @@ def concat_bw(
 
     t3 = ttnn.concat_bw(t0, t1, t2, dim=dim, memory_config=output_mem_config)
 
-    return torch.stack([ttnn_tensor_to_torch(t3[0]), ttnn_tensor_to_torch(t3[1])])
+    return [ttnn_tensor_to_torch(t3[0]), ttnn_tensor_to_torch(t3[1])]
 
 
 def cos_bw(

--- a/tests/ttnn/python_api_testing/sweep_tests/ttnn_ops.py
+++ b/tests/ttnn/python_api_testing/sweep_tests/ttnn_ops.py
@@ -4165,6 +4165,7 @@ def concat_bw(
     y,  # input_tensor
     z,  # other_tensor
     *args,
+    dim,
     device,
     dtype,
     layout,
@@ -4172,11 +4173,6 @@ def concat_bw(
     output_mem_config,
     **kwargs,
 ):
-    dim = -1
-    for i in range(0, len(x.size())):
-        if x.size(i) == y.size(i) + z.size(i):
-            dim = i
-
     t0 = setup_ttnn_tensor(x, device, layout[0], input_mem_config[0], dtype[0])
     t1 = setup_ttnn_tensor(y, device, layout[1], input_mem_config[1], dtype[1])
     t2 = setup_ttnn_tensor(z, device, layout[2], input_mem_config[1], dtype[2])

--- a/tests/ttnn/python_api_testing/sweep_tests/ttnn_ops.py
+++ b/tests/ttnn/python_api_testing/sweep_tests/ttnn_ops.py
@@ -4159,6 +4159,32 @@ def cosh_bw(
     return ttnn_tensor_to_torch(t2)
 
 
+def concat_bw(
+    x,  # grad_tensor
+    y,  # input_tensor
+    z,  # other_tensor
+    *args,
+    device,
+    dtype,
+    layout,
+    input_mem_config,
+    output_mem_config,
+    **kwargs,
+):
+    dim = -1
+    for i in range(0, len(x.size())):
+        if x.size(i) == y.size(i) + z.size(i):
+            dim = i
+
+    t0 = setup_ttnn_tensor(x, device, layout[0], input_mem_config[0], dtype[0])
+    t1 = setup_ttnn_tensor(y, device, layout[1], input_mem_config[1], dtype[1])
+    t2 = setup_ttnn_tensor(z, device, layout[2], input_mem_config[1], dtype[2])
+
+    t3 = ttnn.concat_bw(t0, t1, t2, dim=dim, memory_config=output_mem_config)
+
+    return torch.stack([ttnn_tensor_to_torch(t3[0]), ttnn_tensor_to_torch(t3[1])])
+
+
 def cos_bw(
     x,  # grad_tensor
     y,  # input_tensor
@@ -4302,3 +4328,4 @@ def eltwise_bitwise_or(
     t1 = ttnn.bitwise_or(t0, value, memory_config=output_mem_config, queue_id=0)
 
     return ttnn_tensor_to_torch(t1)
+

--- a/tests/ttnn/python_api_testing/sweep_tests/ttnn_pytorch_ops.py
+++ b/tests/ttnn/python_api_testing/sweep_tests/ttnn_pytorch_ops.py
@@ -239,3 +239,17 @@ def preprocessing_model_bert_4(x, *args, **kwargs):
     )
 
     return torch_output.start_logits
+
+
+def concat_bw(x, y, z, dim, *args, **kwargs):
+    golden_function = ttnn.get_golden_function(ttnn.concat_bw)
+    torch_output_tensor = golden_function(
+        x,
+        y,
+        z,
+        dim=dim,
+        head_size=None,
+        attention_mask=None,
+    )
+
+    return torch_output_tensor

--- a/tests/ttnn/unit_tests/operations/backward/test_backward_concat.py
+++ b/tests/ttnn/unit_tests/operations/backward/test_backward_concat.py
@@ -31,7 +31,7 @@ def test_bw_concat(input_shapes, input_shapes_2, dimension, device):
 
     other_data, other_tensor = data_gen_with_range(input_shapes_2, -100, 100, device, True, True)
 
-    pyt_y = torch.cat((in_data, other_data), dim=dimension)
+    pyt_y = torch.concat((in_data, other_data), dim=dimension)
 
     grad_data, grad_tensor = data_gen_with_range(pyt_y.shape, -100, 100, device, True, True)
 
@@ -56,7 +56,7 @@ def test_bw_concat_Default(input_shapes, input_shapes_2, device):
 
     other_data, other_tensor = data_gen_with_range(input_shapes_2, -100, 100, device, True, True)
 
-    pyt_y = torch.cat((in_data, other_data))
+    pyt_y = torch.concat((in_data, other_data))
 
     grad_data, grad_tensor = data_gen_with_range(pyt_y.shape, -100, 100, device, True, True)
 

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_backward/device/binary_backward_op.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_backward/device/binary_backward_op.cpp
@@ -378,10 +378,10 @@ std::vector<Tensor> _concat_bw(
     if (dim == 0) {
         start_index_2 = {input.get_legacy_shape()[0], 0, 0, 0};
     } else if (dim == 1) {
-        start_index_2 = {input.get_legacy_shape()[0] - 1, input.get_legacy_shape()[1], 0, 0};
+        start_index_2 = {0, input.get_legacy_shape()[1], 0, 0};
     } else if (dim == 2) {
         start_index_2 = {
-            input.get_legacy_shape()[0] - 1, input.get_legacy_shape()[1] - 1, input.get_legacy_shape()[2], 0};
+            0, 0, input.get_legacy_shape()[2], 0};
     } else if (dim == 3) {
         start_index_2 = {0, 0, 0, input.get_legacy_shape()[3]};
     }

--- a/ttnn/tt_lib/_internal/comparison_funcs.py
+++ b/ttnn/tt_lib/_internal/comparison_funcs.py
@@ -174,6 +174,27 @@ def comp_pcc_list(golden, calculated, pcc=0.99):
     return passing, total_str
 
 
+def comp_equal_list(golden, calculated):
+    total_str = ""
+    min_pcc = 1
+
+    equal = []
+
+    for i in range(len(golden)):
+        if golden[i].dtype != calculated[i].dtype:
+            calculated[i] = calculated[i].type(golden[i].dtype)
+        _, _, _, output_str = get_atol_rtol_pcc(golden[i], calculated[i])
+
+        equal.append(torch.equal(golden[i], calculated[i]))
+
+        total_str = f"{total_str}Tensor {i}: {output_str}"
+
+    passing = all(equal)
+    if not passing:
+        total_str += ", PCC check failed"
+    return passing, total_str
+
+
 def comp_allclose_and_pcc(golden, calculated, rtol=1e-05, atol=1e-08, pcc=0.99):
     if golden.dtype != calculated.dtype:
         calculated = calculated.type(golden.dtype)

--- a/ttnn/ttnn/operations/binary_backward.py
+++ b/ttnn/ttnn/operations/binary_backward.py
@@ -99,8 +99,10 @@ def _golden_function_backward_with_dim(
 ):
     import torch
 
-    input_tensor_a.requires_grad = True
-    input_tensor_b.requires_grad = True
+    if input_tensor_a.requires_grad is False:
+        input_tensor_a.requires_grad = True
+    if input_tensor_b.requires_grad is False:
+        input_tensor_b.requires_grad = True
 
     input_tensor_a.retain_grad()
     input_tensor_b.retain_grad()

--- a/ttnn/ttnn/operations/binary_backward.py
+++ b/ttnn/ttnn/operations/binary_backward.py
@@ -99,12 +99,16 @@ def _golden_function_backward_with_dim(
 ):
     import torch
 
+    input_tensor_a.requires_grad = True
+    input_tensor_b.requires_grad = True
+
     input_tensor_a.retain_grad()
     input_tensor_b.retain_grad()
+
     if dimension == None:
-        pyt_y = torch.cat((input_tensor_a, input_tensor_b))
+        pyt_y = torch.concat((input_tensor_a, input_tensor_b))
     else:
-        pyt_y = torch.cat((input_tensor_a, input_tensor_b), dim=dimension)
+        pyt_y = torch.concat((input_tensor_a, input_tensor_b), dim=dimension)
     pyt_y.backward(gradient=grad_tensor)
     golden_tensor = [input_tensor_a.grad, input_tensor_b.grad]
     return golden_tensor
@@ -275,8 +279,8 @@ ttnn.attach_golden_function(
 
 ttnn.attach_golden_function(
     ttnn.concat_bw,
-    golden_function=lambda grad, a, b, dimension=None, *args, **kwargs: _golden_function_backward_with_dim(
-        torch.cat, grad, a, b, dimension, *args, **kwargs
+    golden_function=lambda grad, a, b, dim=None, *args, **kwargs: _golden_function_backward_with_dim(
+        torch.concat, grad, a, b, dim, *args, **kwargs
     ),
 )
 


### PR DESCRIPTION
### Ticket
[Link to Github Issue](https://github.com/tenstorrent/tt-metal/issues/11110)

### Problem description
Shape mismatch between ttnn.concat_bw and its golden function

### What's changed
Changes 2 to 5 are only related to sweep tests!
1. In t`t-metal/ttnn/cpp/ttnn/operations/eltwise/binary_backward/device/binary_backward_op.cpp`, at `_concat_bw`, changed `start_index_2` for `dim = 1` and `dim = 2`
2. Added golden_function in pytorch_ops.py
3. Added API call in ttnn_ops.py
4. Added method = "concat_bw" in `tt-metal/tests/tt_eager/python_api_testing/sweep_tests/common.py`
5. Added YAML files at `tt-metal/tests/ttnn/python_api_testing/sweep_tests/test_configs/ci_sweep_tests_working/` for both wormhole and grayskull.


### To confirm
Run command: 
``` 
pytest tests/ttnn/python_api_testing/sweep_tests/run_sweep_test.py --input-path tests/ttnn/python_api_testing/sweep_tests/test_configs/ci_sweep_tests_working/grayskull/ttnn_backward_concat_test.yaml --input-method cli --cli-input results_concat_bw
```
, and check the csv file in results_concat_bw folder. All the rows should contain "pass" in "pass/fail" column.

### Checklist
- [x] Post commit CI passes
- [x] Blackhole Post commit (if applicable)
- [x] Model regression CI testing passes (if applicable)
- [x] New/Existing tests provide coverage for changes
