### PR TITLE
#10696: Disable hanging profiler regression test

### DIFF
--- a/tests/scripts/run_profiler_regressions.sh
+++ b/tests/scripts/run_profiler_regressions.sh
@@ -54,9 +54,9 @@ run_profiling_test(){
     source python_env/bin/activate
     export PYTHONPATH=$TT_METAL_HOME
 
-    #run_additional_T3000_test
+    run_additional_T3000_test
 
-    run_async_mode_T3000_test
+    #run_async_mode_T3000_test
 
     TT_METAL_DEVICE_PROFILER=1 pytest $PROFILER_TEST_SCRIPTS_ROOT/test_device_profiler.py
 


### PR DESCRIPTION
Renable all gather in profiler regression and disable async faclon

### Ticket
https://github.com/tenstorrent/tt-metal/issues/10969
### Problem description
Flacon async intermittently hangs

### What's changed
Disable until fixed

### Checklist
- [x] Post commit CI passes : https://github.com/tenstorrent/tt-metal/actions/runs/10268634308
- [x] T3K profiler regression : https://github.com/tenstorrent/tt-metal/actions/runs/10268639933
