### PR TITLE
#11118: Add COPY for requirements-sweeps.txt in dockerfile

### DIFF
--- a/dockerfile/ubuntu-20.04-amd64.Dockerfile
+++ b/dockerfile/ubuntu-20.04-amd64.Dockerfile
@@ -34,6 +34,8 @@ ENV PYTHON_ENV_DIR=${TT_METAL_INFRA_DIR}/tt-metal/python_env
 
 # Copy requirements from tt-metal folders with requirements.txt docs
 COPY /docs/requirements-docs.txt ${TT_METAL_INFRA_DIR}/tt-metal/docs/.
+# Copy requirements from tt-metal folders for sweeps (requirements-sweeps.txt)
+COPY /tests/sweep_framework/requirements-sweeps.txt ${TT_METAL_INFRA_DIR}/tt-metal/tests/sweep_framework/.
 COPY /tt_metal/python_env/* ${TT_METAL_INFRA_DIR}/tt-metal/tt_metal/python_env/.
 RUN python3 -m pip config set global.extra-index-url https://download.pytorch.org/whl/cpu \
     && python3 -m pip install setuptools wheel


### PR DESCRIPTION
### Ticket
#11118 

### Problem description
CI docker image build failing because requirements-sweeps.txt is not copied to infra folder.

### What's changed
Added copy instruction to dockerfile to copy requirements file to infra folder. 

### Checklist
- [ ] Post commit CI passes
- [ ] Blackhole Post commit (if applicable)
- [ ] Model regression CI testing passes (if applicable)
- [ ] New/Existing tests provide coverage for changes
