### PR TITLE
#6232: Add embedding backwards op for training

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -102,7 +102,7 @@ ttnn/cpp/ttnn/tensor/ @arakhmati @patrickroberts @yan-zaretskiy @eyonland @cfjch
 ttnn/ @eyonland @arakhmati @patrickroberts @yan-zaretskiy @cfjchu @xanderchin @TT-BrianLiu @ayerofieiev-tt @dmakoviichuk-tt
 ttnn/**/kernels/ # Removes the owners above from owning kernels unless specified afterwards
 ttnn/setup.py @ayerofieiev-tt @dmakoviichuk-tt @tt-rkim
-ttnn/**/CMakeLists.txt @ayerofieiev-tt @dmakoviichuk-tt @yan-zaretskiy 
+ttnn/**/CMakeLists.txt @ayerofieiev-tt @dmakoviichuk-tt @yan-zaretskiy
 ttnn/cpp/ttnn/operations/ccl/ @SeanNijjar @cfjchu
 ttnn/cpp/ttnn/operations/pool/ @mywoodstock @shwetankTT @sankarmanoj-tt @pavlejosipovic
 ttnn/cpp/ttnn/operations/conv2d/ @mywoodstock @shwetankTT @sankarmanoj-tt @pavlejosipovic
@@ -112,6 +112,7 @@ ttnn/cpp/ttnn/operations/eltwise/ @arakhmati @patrickroberts @yan-zaretskiy @eyo
 ttnn/cpp/ttnn/operations/reduction/ @SeanNijjar @tarafdarTT @sjameelTT
 ttnn/cpp/ttnn/operations/normalization/ @yugaoTT @tt-aho
 ttnn/cpp/ttnn/operations/embedding/ @tarafdarTT @tt-aho @TT-BrianLiu
+ttnn/cpp/ttnn/operations/embedding_backward/ @TT-BrianLiu @yan-zaretskiy
 ttnn/cpp/ttnn/operations/moreh*/** @razorback3 @dongjin-na
 tests/ttnn/ @eyonland @arakhmati @patrickroberts @yan-zaretskiy @cfjchu @xanderchin @TT-BrianLiu @ayerofieiev-tt @dmakoviichuk-tt @razorback3 @dongjin-na
 tests/sweep_framework/ @xanderchin @jdesousa-TT @sjameelTT

--- a/ttnn/CMakeLists.txt
+++ b/ttnn/CMakeLists.txt
@@ -134,6 +134,10 @@ set(ALL_TTNN_SRCS
     ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/eltwise/unary/unary.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/eltwise/unary_backward/device/unary_backward_op.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/embedding/device/embedding_device_operation.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/embedding_backward/embedding_backward.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/embedding_backward/embedding_backward_pybind.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/embedding_backward/device/embedding_backward_device_operation.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/embedding_backward/device/embedding_backward_program_factory.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/examples/example/device/example_device_operation.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/examples/example/device/multi_core_program_factory.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/examples/example/device/single_core_program_factory.cpp

--- a/ttnn/cpp/pybind11/operations/__init__.hpp
+++ b/ttnn/cpp/pybind11/operations/__init__.hpp
@@ -32,6 +32,7 @@
 #include "ttnn/operations/eltwise/complex_unary/complex_unary_pybind.hpp"
 #include "ttnn/operations/data_movement/data_movement_pybind.hpp"
 #include "ttnn/operations/embedding/embedding_pybind.hpp"
+#include "ttnn/operations/embedding_backward/embedding_backward_pybind.hpp"
 #include "ttnn/operations/matmul/matmul_pybind.hpp"
 #include "ttnn/operations/transformer/transformer_pybind.hpp"
 #include "ttnn/operations/experimental/experimental_pybind.hpp"
@@ -90,6 +91,9 @@ void py_module(py::module& module) {
 
     auto m_embedding = module.def_submodule("embedding", "embedding operations");
     embedding::py_module(m_embedding);
+
+    auto m_embedding_backward = module.def_submodule("embedding_backward", "embedding backward operations");
+    embedding_backward::py_bind_embedding_backward(m_embedding_backward);
 
     auto m_loss = module.def_submodule("loss", "loss operations");
     loss::py_bind_loss_functions(m_loss);

--- a/ttnn/cpp/ttnn/deprecated/tt_dnn/op_library/math.hpp
+++ b/ttnn/cpp/ttnn/deprecated/tt_dnn/op_library/math.hpp
@@ -2,6 +2,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
+#pragma once
 
 #include "tt_metal/common/assert.hpp"
 namespace tt::tt_metal {

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_backward/binary_backward.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_backward/binary_backward.hpp
@@ -209,7 +209,6 @@ struct ExecuteBackwardDiv  {
 
 constexpr auto atan2_bw = ttnn::register_operation<"ttnn::atan2_bw", operations::binary_backward::ExecuteBinaryBackwardTensor<operations::binary_backward::BinaryBackwardOpType::ATAN2_BW>>();
 constexpr auto rsub_bw = ttnn::register_operation<"ttnn::rsub_bw", operations::binary_backward::ExecuteBinaryBackwardTensor<operations::binary_backward::BinaryBackwardOpType::RSUB_BW>>();
-constexpr auto embedding_bw = ttnn::register_operation<"ttnn::embedding_bw", operations::binary_backward::ExecuteBinaryBackwardTensor<operations::binary_backward::BinaryBackwardOpType::EMBEDDING_BW>>();
 constexpr auto xlogy_bw = ttnn::register_operation<"ttnn::xlogy_bw", operations::binary_backward::ExecuteBinaryBackwardTensor<operations::binary_backward::BinaryBackwardOpType::XLOGY_BW>>();
 constexpr auto hypot_bw = ttnn::register_operation<"ttnn::hypot_bw", operations::binary_backward::ExecuteBinaryBackwardTensor<operations::binary_backward::BinaryBackwardOpType::HYPOT_BW>>();
 constexpr auto ldexp_bw = ttnn::register_operation<"ttnn::ldexp_bw", operations::binary_backward::ExecuteBinaryBackwardTensor<operations::binary_backward::BinaryBackwardOpType::LDEXP_BW>>();

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_backward/binary_backward_pybind.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_backward/binary_backward_pybind.hpp
@@ -672,18 +672,6 @@ void py_module(py::module& module) {
         |    BFLOAT16, BFLOAT8_B     |       ROW_MAJOR, TILE           |      2, 3, 4      |
         +----------------------------+---------------------------------+-------------------+)doc");
 
-    detail::bind_binary_backward_ops(
-        module,
-        ttnn::embedding_bw,
-        R"doc(Performs backward operations for embedding_bw function and it returns specific indices of the embedding table specified by the :attr:`grad_tensor`.
-        The input tensor( :attr:`input_tensor_a`, :attr:`input_tensor_b`) should be unique.)doc",
-        R"doc(
-        +----------------------------+---------------------------------+-------------------+
-        |     Dtypes                 |         Layouts                 |     Ranks         |
-        +----------------------------+---------------------------------+-------------------+
-        |    BFLOAT16, BFLOAT8_B     |       ROW_MAJOR, TILE           |      2, 3, 4      |
-        +----------------------------+---------------------------------+-------------------+)doc");
-
     detail::bind_binary_backward_float_default(
         module,
         ttnn::subalpha_bw,

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_backward/device/binary_backward_op.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_backward/device/binary_backward_op.cpp
@@ -2,6 +2,8 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
+#include "ttnn/decorators.hpp"
+
 #include "ttnn/operations/eltwise/binary/binary.hpp"
 
 #include "ttnn/operations/eltwise/unary/unary.hpp"
@@ -10,7 +12,6 @@
 
 #include "ttnn/operations/data_movement/slice/slice.hpp"
 #include "ttnn/operations/data_movement/copy/copy.hpp"
-#include "ttnn/operations/embedding/embedding.hpp"
 #include "ttnn/deprecated/tt_dnn/op_library/bcast/bcast_op.hpp"
 #include "ttnn/operations/eltwise/unary/device/unary_composite_op.hpp"
 #include "ttnn/cpp/ttnn/operations/eltwise/unary/unary_composite.hpp"
@@ -50,23 +51,6 @@ std::vector<ttnn::Tensor> _atan2_bw(
     recip_mul.deallocate();
     cond.deallocate();
     grad_tensor.emplace_back(grad_b);
-    return grad_tensor;
-}
-
-
-std::vector<ttnn::Tensor> _embedding_bw(
-    const Tensor& grad, const Tensor& input, const Tensor& weight, const std::optional<MemoryConfig>& output_mem_config) {
-    TT_FATAL(input.get_dtype() == DataType::UINT32, "Input must be UINT32");
-    TT_FATAL(
-        grad.get_legacy_shape()[0] == 1 && grad.get_legacy_shape()[1] == 1,
-        "First two dimensions for the grad must be 1");
-    TT_FATAL(
-        input.get_legacy_shape()[1] == 1 && input.get_legacy_shape()[2] == 1,
-        "Only dim 0 && 3 for the input can be non 1");
-    std::vector<Tensor> grad_tensor;
-    Tensor grad_a = ttnn::embedding(input, grad);
-    grad_tensor.emplace_back(grad_a);
-
     return grad_tensor;
 }
 

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_backward/device/binary_backward_op.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_backward/device/binary_backward_op.hpp
@@ -14,7 +14,6 @@ namespace ttnn::operations::binary_backward {
 
 enum class BinaryBackwardOpType {
     ATAN2_BW,
-    EMBEDDING_BW,
     ADDALPHA_BW,
     SUBALPHA_BW,
     SUB_BW,
@@ -37,7 +36,6 @@ enum class BinaryBackwardOpType {
 
 std::vector<Tensor> _atan2_bw( const Tensor& grad, const Tensor& input, const Tensor& other, const std::optional<MemoryConfig>& output_mem_config);
 std::vector<Tensor> _rsub_bw( const Tensor& grad, const Tensor& input, const Tensor& other, const std::optional<MemoryConfig>& output_mem_config);
-std::vector<Tensor> _embedding_bw( const Tensor& grad, const Tensor& input, const Tensor& other, const std::optional<MemoryConfig>& output_mem_config);
 std::vector<Tensor> _xlogy_bw( const Tensor& grad, const Tensor& input, const Tensor& other, const std::optional<MemoryConfig>& output_mem_config);
 std::vector<Tensor> _hypot_bw( const Tensor& grad, const Tensor& input, const Tensor& other, const std::optional<MemoryConfig>& output_mem_config);
 std::vector<Tensor> _ldexp_bw( const Tensor& grad, const Tensor& input, const Tensor& other, const std::optional<MemoryConfig>& output_mem_config);
@@ -154,13 +152,6 @@ template <>
 struct OpHandler<BinaryBackwardOpType::ADDALPHA_BW> {
     static std::vector<std::optional<ttnn::Tensor>> handle( uint8_t queue_id, const Tensor& grad, const Tensor& input, const Tensor& other, float alpha, const MemoryConfig& output_mem_config, const std::vector<bool>& are_required_outputs, std::optional<Tensor> input_grad, std::optional<Tensor> other_grad ) {
         return _addalpha_bw( queue_id, grad, input, other, alpha, output_mem_config, are_required_outputs, input_grad, other_grad);
-    }
-};
-
-template <>
-struct OpHandler<BinaryBackwardOpType::EMBEDDING_BW> {
-    static std::vector<Tensor> handle( const Tensor& grad, const Tensor& input, const Tensor& other, const std::optional<MemoryConfig>& output_mem_config ) {
-        return _embedding_bw(grad, input, other, output_mem_config);
     }
 };
 

--- a/ttnn/cpp/ttnn/operations/embedding/device/embedding_program_factory.hpp
+++ b/ttnn/cpp/ttnn/operations/embedding/device/embedding_program_factory.hpp
@@ -2,6 +2,8 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
+#pragma once
+
 #include "tt_metal/host_api.hpp"
 #include "tt_metal/common/constants.hpp"
 #include "tt_metal/detail/util.hpp"

--- a/ttnn/cpp/ttnn/operations/embedding_backward/device/embedding_backward_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/embedding_backward/device/embedding_backward_device_operation.cpp
@@ -1,0 +1,95 @@
+// SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "ttnn/operations/embedding_backward/device/embedding_backward_device_operation.hpp"
+
+#include "tt_metal/common/constants.hpp"
+#include "ttnn/cpp/ttnn/run_operation.hpp"
+
+using namespace tt::constants;
+using namespace std;
+using namespace tt::tt_metal;
+
+namespace ttnn::operations::embedding_backward {
+
+void EmbeddingBackward::validate(const std::vector<Tensor> &input_tensors) const {
+    TT_FATAL(input_tensors.size() == 2, "Must have between 2 input tensors");
+
+    const auto &index_tensor = input_tensors.at(0);
+    const auto &grad_tensor = input_tensors.at(1);
+    const auto &index_tensor_shape = index_tensor.get_legacy_shape();
+    const auto &grad_tensor_shape = grad_tensor.get_legacy_shape();
+
+    TT_FATAL(
+        index_tensor.device()->arch() == tt::ARCH::WORMHOLE_B0,
+        "Embedding backwards is only implemented for Wormhole!");
+
+    TT_FATAL(index_tensor.get_layout() == Layout::ROW_MAJOR);
+    TT_FATAL(
+        index_tensor.get_dtype() == DataType::UINT32 or index_tensor.get_dtype() == DataType::BFLOAT16,
+        "Index tensor must be UINT32 or BFLOAT16");
+
+    TT_FATAL(
+        index_tensor_shape[1] == 1 && index_tensor_shape[2] == 1,
+        fmt::format(
+            "Only dim 0 && 3 for the index tensor can be non 1, but found {} && {}.",
+            index_tensor_shape[1],
+            index_tensor_shape[2]));
+
+    TT_FATAL(
+        index_tensor_shape[-1] % TILE_WIDTH == 0,
+        "Number of columns in the index tensor must be divisible by tile width");
+
+    TT_FATAL(grad_tensor.get_layout() == Layout::TILE);
+    TT_FATAL(
+        grad_tensor.get_dtype() == DataType::BFLOAT16 or grad_tensor.get_dtype() == DataType::BFLOAT8_B,
+        "Output gradient tensor must be BFLOAT16 or BFLOAT8_B");
+    TT_FATAL(
+        grad_tensor.get_dtype() == this->output_dtype, "Output and input gradient tensors must have the same dtype");
+
+    TT_FATAL(
+        grad_tensor.memory_config().memory_layout == TensorMemoryLayout::INTERLEAVED or
+            index_tensor.memory_config().memory_layout == TensorMemoryLayout::INTERLEAVED or
+            this->output_mem_config.memory_layout == TensorMemoryLayout::INTERLEAVED,
+        "Embedding b/w does not currently support sharding");
+
+    TT_FATAL(
+        grad_tensor_shape[0] == 1 && grad_tensor_shape[1] == 1,
+        fmt::format(
+            "First two dimensions for the gradient tensor must be 1, but found {} && {}.",
+            grad_tensor_shape[0],
+            grad_tensor_shape[1]));
+
+    TT_FATAL(
+        grad_tensor_shape[-1] % TILE_WIDTH == 0,
+        "Number of columns in the gradient tensor must be divisible by tile width");
+
+    TT_FATAL(
+        grad_tensor_shape[2] == index_tensor_shape[0] * index_tensor_shape[-1],
+        "Number of rows in gradient tensor must be equal to number of indices in index tensor");
+}
+
+std::vector<tt::tt_metal::Shape> EmbeddingBackward::compute_output_shapes(
+    const std::vector<Tensor> &input_tensors) const {
+    const auto &grad_tensor = input_tensors.at(1);
+    auto embedding_dim = grad_tensor.get_legacy_shape()[-1];
+
+    tt::tt_metal::Shape output_shape({1, 1, this->num_embeddings, embedding_dim});
+    return {output_shape};
+}
+
+std::vector<Tensor> EmbeddingBackward::create_output_tensors(const std::vector<Tensor> &input_tensors) const {
+    return operation::generic_create_output_tensors(
+        *this, input_tensors, this->output_dtype, Layout::TILE, this->output_mem_config);
+}
+
+operation::ProgramWithCallbacks EmbeddingBackward::create_program(
+    const std::vector<Tensor> &input_tensors, std::vector<Tensor> &output_tensors) const {
+    const auto &index_tensor = input_tensors.at(0);
+    const auto &grad_tensor = input_tensors.at(1);
+    auto &output_tensor = output_tensors.at(0);
+    return detail::embedding_backward_multi_core(index_tensor, grad_tensor, output_tensor, this->num_embeddings);
+}
+
+}  // namespace ttnn::operations::embedding_backward

--- a/ttnn/cpp/ttnn/operations/embedding_backward/device/embedding_backward_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/embedding_backward/device/embedding_backward_device_operation.hpp
@@ -1,0 +1,33 @@
+// SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <optional>
+
+#include "ttnn/tensor/tensor.hpp"
+
+using namespace tt::constants;
+
+namespace ttnn::operations::embedding_backward {
+
+namespace detail {
+operation::ProgramWithCallbacks embedding_backward_multi_core(
+    const Tensor &index_tensor, const Tensor &grad_tensor, Tensor &output, const uint32_t num_embeddings);
+}
+
+struct EmbeddingBackward {
+    MemoryConfig output_mem_config;
+    DataType output_dtype;
+    uint32_t num_embeddings;
+
+    void validate(const std::vector<Tensor> &input_tensors) const;
+    std::vector<tt::tt_metal::Shape> compute_output_shapes(const std::vector<Tensor> &input_tensors) const;
+    std::vector<Tensor> create_output_tensors(const std::vector<Tensor> &input_tensors) const;
+    operation::ProgramWithCallbacks create_program(
+        const std::vector<Tensor> &input_tensors, std::vector<Tensor> &output_tensors) const;
+    tt::stl::reflection::Attributes attributes() const;
+};
+
+}  // namespace ttnn::operations::embedding_backward

--- a/ttnn/cpp/ttnn/operations/embedding_backward/device/embedding_backward_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/embedding_backward/device/embedding_backward_program_factory.cpp
@@ -1,0 +1,186 @@
+// SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "tt_metal/common/constants.hpp"
+#include "tt_metal/detail/util.hpp"
+#include "tt_metal/host_api.hpp"
+#include "ttnn/deprecated/tt_dnn/op_library/cb_utils.hpp"
+#include "ttnn/deprecated/tt_dnn/op_library/math.hpp"
+#include "ttnn/deprecated/tt_dnn/op_library/work_split.hpp"
+#include "ttnn/operations/embedding_backward/device/embedding_backward_device_operation.hpp"
+
+using namespace tt;
+using namespace tt::constants;
+
+namespace ttnn::operations::embedding_backward::detail {
+
+operation::ProgramWithCallbacks embedding_backward_multi_core(
+    const Tensor &index_tensor, const Tensor &grad_tensor, Tensor &output, const uint32_t num_embeddings) {
+    ////////////////////////////////////////////////////////////////////////////
+    //                 Buffer Setup
+    ////////////////////////////////////////////////////////////////////////////
+
+    tt_metal::Buffer *index_tensor_buffer = index_tensor.buffer();
+    tt_metal::Buffer *grad_tensor_buffer = grad_tensor.buffer();
+    tt_metal::Buffer *out_buffer = output.buffer();
+
+    Device *device = grad_tensor.device();
+    auto dst_addr = out_buffer->address();
+
+    ////////////////////////////////////////////////////////////////////////////
+    //                      Application Setup
+    ////////////////////////////////////////////////////////////////////////////
+
+    Program program{};
+
+    bool grad_is_dram = grad_tensor_buffer->buffer_type() == tt_metal::BufferType::DRAM ? 1 : 0;
+    bool index_is_dram = index_tensor_buffer->buffer_type() == tt_metal::BufferType::DRAM ? 1 : 0;
+    bool out_is_dram = out_buffer->buffer_type() == tt_metal::BufferType::DRAM ? 1 : 0;
+
+    uint32_t grad_element_size_bytes = grad_tensor.element_size();
+    uint32_t index_element_size_bytes = index_tensor.element_size();
+    constexpr uint32_t INPUT_SIZE = 32;
+
+    tt::DataFormat grad_cb_data_format = datatype_to_dataformat_converter(grad_tensor.get_dtype());
+    uint32_t grad_single_tile_size = tt::tt_metal::detail::TileSize(grad_cb_data_format);
+
+    tt::DataFormat index_cb_data_format = datatype_to_dataformat_converter(index_tensor.get_dtype());
+    uint32_t index_single_page_size =
+        INPUT_SIZE * index_element_size_bytes;  // Only need 32 at most at a time, which is less than full page size
+    uint32_t index_page_size = index_tensor.get_legacy_shape()[-1] * index_element_size_bytes;
+
+    tt::DataFormat mask_cb_data_format = tt::DataFormat::UInt8;
+    uint32_t mask_single_page_size = INPUT_SIZE * 1;  // UInt8 is 1 byte per element
+
+    tt::DataFormat output_cb_data_format = datatype_to_dataformat_converter(output.get_dtype());
+    uint32_t output_single_tile_size = tt::tt_metal::detail::TileSize(output_cb_data_format);
+
+    uint32_t embedding_dim = grad_tensor.get_legacy_shape()[-1];
+    uint32_t embedding_tiles = embedding_dim / TILE_WIDTH;
+
+    uint32_t batch_size = index_tensor.get_legacy_shape()[0];
+    uint32_t seq_len_tiles = index_tensor.get_legacy_shape()[-1] / TILE_WIDTH;
+    uint32_t input_height_tiles = batch_size * seq_len_tiles;
+
+    uint32_t num_embeddings_tiles = num_embeddings / TILE_HEIGHT;
+
+    // We split work based on the number of tiles in the embedding dimension
+    auto grid_size = device->compute_with_storage_grid_size();
+    auto [num_cores, all_cores, core_group_1, core_group_2, num_tiles_per_core_group_1, num_tiles_per_core_group_2] =
+        split_work_to_cores(grid_size, embedding_tiles);
+    uint32_t max_tiles_per_core = std::max(num_tiles_per_core_group_1, num_tiles_per_core_group_2);
+
+    log_debug(LogType::LogOp, "Embedding hidden size tiles: {}", embedding_tiles);
+    log_debug(LogType::LogOp, "Num parallel cores: {}", num_cores);
+    log_debug(LogType::LogOp, "Max hidden size tiles per core: {}", max_tiles_per_core);
+
+    ////////////////////////////////////////////////////////////////////////////
+    //                 Circular buffers
+    ////////////////////////////////////////////////////////////////////////////
+
+    // To read from grad tensor
+    create_cb(CB::c_in0, program, all_cores, grad_single_tile_size, max_tiles_per_core, grad_cb_data_format);
+
+    // To store index values for a single tile
+    create_cb(CB::c_in1, program, all_cores, index_single_page_size, 1, index_cb_data_format);
+
+    // To read from output tensor
+    create_cb(CB::c_in2, program, all_cores, output_single_tile_size, max_tiles_per_core, output_cb_data_format);
+
+    // To store mask values for a single tile
+    create_cb(CB::c_intermed0, program, all_cores, mask_single_page_size, 1, mask_cb_data_format);
+
+    // L1 scratch space to pass chunk_count from reader to UNPACK
+    create_cb(
+        CB::c_intermed1, program, all_cores, 16, 1, grad_cb_data_format);  // grad_cb_data_format doesn't matter here
+
+    // For tiles to be written to the output
+    create_cb(CB::c_out0, program, all_cores, output_single_tile_size, max_tiles_per_core, output_cb_data_format);
+
+    ////////////////////////////////////////////////////////////////////////////
+    //                 Kernels
+    ////////////////////////////////////////////////////////////////////////////
+
+    // reader
+
+    bool index_stick_size_is_power_of_two = is_power_of_two_at_least_32(index_page_size);
+    uint32_t index_log2_stick_size = index_stick_size_is_power_of_two ? log2(index_page_size) : 0;
+
+    std::vector<uint32_t> reader_compile_time_args = {
+        grad_is_dram,
+        index_is_dram,
+        out_is_dram,
+        index_page_size,
+        index_stick_size_is_power_of_two,
+        index_log2_stick_size,
+        index_tensor.get_dtype() == DataType::BFLOAT16,  // TODO: Only supports either BFLOAT16 or UINT32
+        output.get_dtype() == DataType::BFLOAT16,        // TODO: Only supports either BFLOAT16 or BFLOAT8_B
+        max_tiles_per_core,
+        batch_size,
+        seq_len_tiles,
+        num_embeddings_tiles};
+
+    auto reader_kernel_id = tt_metal::CreateKernel(
+        program,
+        "ttnn/cpp/ttnn/operations/embedding_backward/device/kernels/dataflow/reader_embedding_backward.cpp",
+        all_cores,
+        tt_metal::ReaderDataMovementConfig(reader_compile_time_args));
+
+    std::vector<uint32_t> reader_runtime_args = {
+        grad_tensor_buffer->address(),
+        index_tensor_buffer->address(),
+        out_buffer->address(),
+        embedding_tiles,  // how many pages to skip to get to the next row
+        0,                // offset to the first tile in a row
+        0,                // how many tiles to process in a row
+    };
+
+    auto compute_kernel_id = tt_metal::CreateKernel(
+        program,
+        "ttnn/cpp/ttnn/operations/embedding_backward/device/kernels/compute/embedding_backward.cpp",
+        all_cores,
+        tt_metal::ComputeConfig{.compile_args = {max_tiles_per_core, input_height_tiles}});
+
+    ////////////////////////////////////////////////////////////////////////////
+    //                 Run-time arguments
+    ////////////////////////////////////////////////////////////////////////////
+
+    auto cores = corerange_to_cores(all_cores);
+    uint32_t offset = 0;
+    for (auto core : cores) {
+        reader_runtime_args[4] = offset;
+        if (core_group_1.core_coord_in_core_ranges(core)) {
+            reader_runtime_args[5] = num_tiles_per_core_group_1;
+        } else {
+            reader_runtime_args[5] = num_tiles_per_core_group_2;
+        }
+        SetRuntimeArgs(program, reader_kernel_id, core, reader_runtime_args);
+        SetRuntimeArgs(program, compute_kernel_id, core, {reader_runtime_args[5]});
+
+        offset += reader_runtime_args[5];
+    }
+
+    auto override_runtime_args_callback = [reader_kernel_id, cores, device](
+                                              const Program &program,
+                                              const std::vector<Buffer *> &input_buffers,
+                                              const std::vector<Buffer *> &output_buffers) {
+        auto grad_dram_buffer = input_buffers.at(0);
+        auto index_dram_buffer = input_buffers.at(1);
+        auto output_dram_buffer = output_buffers.at(0);
+
+        auto &runtime_args_by_core = GetRuntimeArgs(program, reader_kernel_id);
+        for (const auto &core : cores) {
+            {
+                auto &runtime_args = runtime_args_by_core[core.x][core.y];
+                runtime_args[0] = grad_dram_buffer->address();
+                runtime_args[1] = index_dram_buffer->address();
+                runtime_args[2] = output_dram_buffer->address();
+            }
+        }
+    };
+
+    return {std::move(program), override_runtime_args_callback};
+}
+
+}  // namespace ttnn::operations::embedding_backward::detail

--- a/ttnn/cpp/ttnn/operations/embedding_backward/device/kernels/compute/embedding_backward.cpp
+++ b/ttnn/cpp/ttnn/operations/embedding_backward/device/kernels/compute/embedding_backward.cpp
@@ -1,0 +1,73 @@
+// SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "compute_kernel_api/eltwise_unary/eltwise_unary.h"
+#include "compute_kernel_api/reshuffle.h"
+#include "compute_kernel_api/tile_move_copy.h"
+
+namespace NAMESPACE {
+void MAIN {
+    const uint32_t tiles_per_core = get_arg_val<uint32_t>(0);
+
+    constexpr uint32_t max_tiles_per_core = get_compile_time_arg_val(0);
+    constexpr uint32_t input_height = get_compile_time_arg_val(1);
+
+    constexpr uint32_t cb_grad = tt::CB::c_in0;
+    constexpr uint32_t cb_index = tt::CB::c_in1;
+    constexpr uint32_t cb_out_intermed = tt::CB::c_in2;
+    constexpr uint32_t cb_mask = tt::CB::c_intermed0;
+    constexpr uint32_t cb_chunk_count_scratch = tt::CB::c_intermed1;
+    constexpr uint32_t cb_out = tt::CB::c_out0;
+
+    unary_op_init_common(cb_grad);
+
+    for (uint32_t i = 0; i < input_height; ++i) {
+        cb_wait_front(cb_grad, max_tiles_per_core);
+
+        // Get chunk_count from reader
+        volatile uint32_t *chunk_addr_ptr;
+        cb_get_tile(cb_chunk_count_scratch, 0, &chunk_addr_ptr);
+        uint32_t chunk_count = chunk_addr_ptr[4];  // Need to shift because read ptr is off by 1 << 4 in BBE
+        cb_release_tile(cb_chunk_count_scratch);
+
+        for (uint32_t chunk = 0; chunk < chunk_count; ++chunk) {  // chunk_count
+            cb_wait_front(cb_mask, 1);
+            // get cb_index pointer from unpack to math thread
+            volatile uint *idx_addr_ptr;
+            uint32_t tile_to_get = 0;
+            cb_get_tile(cb_mask, tile_to_get, &idx_addr_ptr);
+            uint32_t idx_addr = reinterpret_cast<uint32_t>(idx_addr_ptr);
+
+            cb_wait_front(cb_out_intermed, max_tiles_per_core);
+
+            cb_reserve_back(cb_out, max_tiles_per_core);
+
+            for (uint32_t hidden_dim = 0; hidden_dim < tiles_per_core; hidden_dim++) {
+                tile_regs_acquire();
+                tile_regs_wait();
+
+                copy_tile(cb_grad, hidden_dim, 0);
+
+                copy_tile(cb_out_intermed, hidden_dim, 1);
+
+                reshuffle_rows_tile_init();
+                reshuffle_rows_tile(0, idx_addr);
+
+                pack_tile(1, cb_out, hidden_dim);  // reshuffle puts output into Tile 1 in DEST
+
+                tile_regs_commit();
+                tile_regs_release();
+            }
+
+            cb_push_back(cb_out, max_tiles_per_core);
+            cb_pop_front(cb_out_intermed, max_tiles_per_core);
+
+            cb_release_tile(cb_mask);
+            cb_pop_front(cb_mask, 1);
+        }
+
+        cb_pop_front(cb_grad, max_tiles_per_core);
+    }
+}
+}  // namespace NAMESPACE

--- a/ttnn/cpp/ttnn/operations/embedding_backward/device/kernels/dataflow/reader_embedding_backward.cpp
+++ b/ttnn/cpp/ttnn/operations/embedding_backward/device/kernels/dataflow/reader_embedding_backward.cpp
@@ -1,0 +1,222 @@
+// SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "dataflow_api.h"
+
+constexpr uint32_t INPUT_SIZE = 32;
+
+FORCE_INLINE uint64_t get_index_noc_address(uint32_t tile_idx, uint32_t offset = 0) {
+    const std::uint32_t index_tensor_addr = get_arg_val<uint32_t>(1);
+    constexpr bool index_stick_size_is_power_of_two = get_compile_time_arg_val(4) == 1;
+    constexpr bool index_is_dram = get_compile_time_arg_val(1) == 1;
+
+    if constexpr (index_stick_size_is_power_of_two) {
+        constexpr uint32_t index_log2_stick_size = get_compile_time_arg_val(5);
+        InterleavedPow2AddrGen<index_is_dram> index = {
+            .bank_base_address = index_tensor_addr, .log_base_2_of_page_size = index_log2_stick_size};
+        return get_noc_addr(tile_idx, index, offset);
+    } else {
+        constexpr uint32_t index_page_size = get_compile_time_arg_val(3);
+        InterleavedAddrGen<index_is_dram> index = {
+            .bank_base_address = index_tensor_addr, .page_size = index_page_size};
+        return get_noc_addr(tile_idx, index, offset);
+    }
+}
+
+FORCE_INLINE uint32_t get_index(uint32_t input_l1_addr, uint32_t idx) {
+    constexpr bool is_index_bfloat16 = get_compile_time_arg_val(6) == 1;
+    if constexpr (is_index_bfloat16) {
+        auto input_l1_ptr = reinterpret_cast<volatile tt_l1_ptr uint16_t *>(input_l1_addr);
+        union {
+            float f;
+            uint32_t u;
+        } u;
+        u.u = (uint32_t)input_l1_ptr[idx] << 16;
+        return static_cast<uint32_t>(u.f);
+    } else {
+        auto input_l1_ptr = reinterpret_cast<volatile tt_l1_ptr uint32_t *>(input_l1_addr);
+        return input_l1_ptr[idx];
+    }
+}
+
+// TODO: Helper for printing mask (can remove this)
+FORCE_INLINE uint32_t get_mask(uint32_t input_l1_addr, uint32_t idx) {
+    auto input_l1_ptr = reinterpret_cast<volatile tt_l1_ptr uint8_t *>(input_l1_addr);
+    return input_l1_ptr[idx];
+}
+
+FORCE_INLINE uint32_t process_index_chunk(uint32_t index_l1_addr, uint32_t chunk_indexes[INPUT_SIZE]) {
+    uint32_t chunk_count = 0;
+
+    for (uint32_t i = 0; i < INPUT_SIZE; ++i) {
+        uint32_t idx = get_index(index_l1_addr, i);
+        uint32_t chunk_id = idx >> 5;  // equivalent to idx / 32
+
+        bool is_new_chunk = true;
+        for (uint32_t chunk = 0; chunk < chunk_count; ++chunk) {
+            if (chunk_indexes[chunk] == chunk_id) {
+                is_new_chunk = false;
+                break;
+            }
+        }
+
+        if (is_new_chunk) {
+            chunk_indexes[chunk_count++] = chunk_id;
+        }
+    }
+
+    return chunk_count;
+}
+
+FORCE_INLINE void generate_mask(uint32_t index_l1_addr, uint32_t chunk_id, uint32_t mask_l1_addr) {
+    auto mask_l1_ptr = reinterpret_cast<volatile tt_l1_ptr uint8_t *>(mask_l1_addr);
+
+    uint32_t x_min = chunk_id << 5;  // equivalent to chunk_id * 32
+    uint32_t x_max = x_min + INPUT_SIZE;
+
+    for (uint32_t i = 0; i < INPUT_SIZE; ++i) {
+        uint32_t idx = get_index(index_l1_addr, i);
+        uint8_t mask = ~static_cast<uint8_t>(0);  // equivalent to numeric_limits<uint8_t>::max()
+        if (idx >= x_min && idx < x_max) {
+            mask = idx & (INPUT_SIZE - 1);  // equivalent to idx % INPUT_SIZE
+        }
+        mask_l1_ptr[i] = mask;
+    }
+}
+
+FORCE_INLINE void generate_zeros_cb(uint32_t input_l1_addr) {
+    constexpr bool is_output_bfloat16 = get_compile_time_arg_val(7) == 1;
+    auto input_l1_ptr = reinterpret_cast<volatile tt_l1_ptr uint32_t *>(input_l1_addr);
+
+    if constexpr (is_output_bfloat16) {
+        // 512 * 4 = 2048 bytes = single tile of bfloat16
+        for (uint32_t i = 0; i < 512; ++i) {
+            input_l1_ptr[i] = 0;
+        }
+    } else {
+        // 272 * 4 = 1088 bytes = single tile of bfloat8_b
+        for (uint32_t i = 0; i < 272; ++i) {
+            input_l1_ptr[i] = 0;
+        }
+    }
+}
+
+void kernel_main() {
+    const uint32_t grad_tensor_addr = get_arg_val<uint32_t>(0);
+    const uint32_t output_tensor_addr = get_arg_val<uint32_t>(2);
+    const uint32_t tiles_per_hidden = get_arg_val<uint32_t>(3);
+    const uint32_t hidden_offset = get_arg_val<uint32_t>(4);
+    const uint32_t tiles_per_core = get_arg_val<uint32_t>(5);
+
+    constexpr bool grad_is_dram = get_compile_time_arg_val(0) == 1;
+    constexpr bool out_is_dram = get_compile_time_arg_val(2) == 1;
+    constexpr uint32_t max_tiles_per_core = get_compile_time_arg_val(8);
+    constexpr uint32_t batch_size = get_compile_time_arg_val(9);
+    constexpr uint32_t seq_len_tiles = get_compile_time_arg_val(10);
+    constexpr uint32_t num_embeddings = get_compile_time_arg_val(11);
+
+    constexpr uint32_t cb_grad = tt::CB::c_in0;
+    constexpr uint32_t cb_index = tt::CB::c_in1;
+    constexpr uint32_t cb_out_intermed = tt::CB::c_in2;
+    constexpr uint32_t cb_mask = tt::CB::c_intermed0;
+    constexpr uint32_t cb_chunk_count_scratch = tt::CB::c_intermed1;
+    constexpr uint32_t cb_id_out0 = tt::CB::c_out0;
+
+    constexpr uint32_t grad_page_size = get_tile_size(cb_grad);
+    constexpr uint32_t out_page_size = get_tile_size(cb_id_out0);
+    constexpr DataFormat grad_data_format = get_dataformat(cb_grad);
+    constexpr DataFormat out_data_format = get_dataformat(cb_id_out0);
+
+    const InterleavedAddrGenFast<grad_is_dram> grad_s = {
+        .bank_base_address = grad_tensor_addr, .page_size = grad_page_size, .data_format = grad_data_format};
+
+    const InterleavedAddrGenFast<out_is_dram> out_s = {
+        .bank_base_address = output_tensor_addr, .page_size = out_page_size, .data_format = out_data_format};
+
+    uint32_t index_block_size = get_tile_size(cb_index) >> 5;  // we only need 32 elements
+    uint32_t index_l1_addr = get_write_ptr(cb_index);          // static
+
+    uint32_t chunk_indexes[INPUT_SIZE];
+
+    // ZERO out output this core is responsible for
+    uint32_t out_read_ptr = get_read_ptr(cb_out_intermed);
+    // Fill one tile with zeros
+    generate_zeros_cb(out_read_ptr);
+    // Fill all of output (for this core) to zeros
+    uint32_t out_tile_idx = hidden_offset;
+    for (uint32_t i = 0; i < num_embeddings; ++i) {
+        for (uint32_t hidden_dim = 0; hidden_dim < tiles_per_core; hidden_dim++) {
+            noc_async_write_tile(out_tile_idx + hidden_dim, out_s, out_read_ptr);
+        }
+        out_tile_idx += tiles_per_hidden;
+    }
+    noc_async_write_barrier();
+
+    uint32_t chunk_count_l1_addr = get_read_ptr(cb_chunk_count_scratch);
+    auto chunk_count_ptr = reinterpret_cast<volatile tt_l1_ptr uint32_t *>(chunk_count_l1_addr);
+
+    uint32_t grad_tile_idx = hidden_offset;
+    for (uint32_t b = 0; b < batch_size; ++b) {
+        uint64_t index_seq_noc_addr = get_index_noc_address(b);
+        for (uint32_t s = 0; s < seq_len_tiles; ++s) {
+            noc_async_read(index_seq_noc_addr, index_l1_addr, index_block_size);
+            noc_async_read_barrier();
+
+            index_seq_noc_addr += index_block_size;
+
+            // maps the next chunk of indexes to the corresponding output masks
+            uint32_t chunk_count = process_index_chunk(index_l1_addr, chunk_indexes);
+
+            // Pass chunk_count to compute UNPACK
+            chunk_count_ptr[0] = chunk_count;
+
+            cb_reserve_back(cb_grad, max_tiles_per_core);
+            uint32_t grad_write_ptr = get_write_ptr(cb_grad);
+            for (uint32_t hidden_dim = 0; hidden_dim < tiles_per_core; hidden_dim++) {
+                noc_async_read_tile(grad_tile_idx + hidden_dim, grad_s, grad_write_ptr);
+                grad_write_ptr += grad_page_size;
+            }
+            noc_async_read_barrier();
+            cb_push_back(cb_grad, max_tiles_per_core);
+            grad_tile_idx += tiles_per_hidden;
+
+            for (uint32_t chunk = 0; chunk < chunk_count; ++chunk) {
+                uint32_t chunk_idx = chunk_indexes[chunk];
+
+                cb_reserve_back(cb_mask, 1);
+                uint32_t mask_l1_addr = get_write_ptr(cb_mask);
+                generate_mask(index_l1_addr, chunk_idx, mask_l1_addr);
+
+// TODO: Remove debug prints
+#if 0
+                for (uint32_t i = 0; i < INPUT_SIZE; ++i) {
+                    uint32_t idx = get_index(index_l1_addr, i);
+                    uint32_t msk = get_mask(mask_l1_addr, i);
+                    DPRINT << chunk << ": " << idx << " -> " << msk << ENDL();
+                }
+#endif
+                cb_push_back(cb_mask, 1);
+
+                cb_reserve_back(cb_out_intermed, max_tiles_per_core);
+                uint32_t out_write_ptr = get_write_ptr(cb_out_intermed);
+                out_tile_idx = chunk_idx * tiles_per_hidden + hidden_offset;
+                for (uint32_t hidden_dim = 0; hidden_dim < tiles_per_core; hidden_dim++) {
+                    noc_async_read_tile(out_tile_idx + hidden_dim, out_s, out_write_ptr);
+                    out_write_ptr += out_page_size;
+                }
+                noc_async_read_barrier();
+                cb_push_back(cb_out_intermed, max_tiles_per_core);
+
+                cb_wait_front(cb_id_out0, max_tiles_per_core);
+                uint32_t out_read_ptr = get_read_ptr(cb_id_out0);
+                for (uint32_t hidden_dim = 0; hidden_dim < tiles_per_core; hidden_dim++) {
+                    noc_async_write_tile(out_tile_idx + hidden_dim, out_s, out_read_ptr);
+                    out_read_ptr += out_page_size;
+                }
+                noc_async_write_barrier();
+                cb_pop_front(cb_id_out0, max_tiles_per_core);
+            }  // chunk_count
+        }  // seq_len_tiles
+    }  // batch_size
+}

--- a/ttnn/cpp/ttnn/operations/embedding_backward/embedding_backward.cpp
+++ b/ttnn/cpp/ttnn/operations/embedding_backward/embedding_backward.cpp
@@ -1,0 +1,58 @@
+// SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "ttnn/operations/embedding_backward/embedding_backward.hpp"
+
+#include "ttnn/cpp/ttnn/common/constants.hpp"
+#include "ttnn/operations/core/core.hpp"
+#include "ttnn/operations/embedding_backward/device/embedding_backward_device_operation.hpp"
+#include "ttnn/run_operation.hpp"
+
+namespace ttnn::operations::embedding_backward {
+
+Tensor EmbeddingBackwardOperation::invoke(
+    uint8_t queue_id,
+    const Tensor& input_tensor_arg,
+    const Tensor& weight_tensor_arg,
+    const Tensor& output_gradient_tensor_arg,
+    const std::optional<const DataType> dtype,
+    const std::optional<MemoryConfig>& memory_config,
+    std::optional<Tensor> optional_output_tensor) {
+    auto num_embeddings = weight_tensor_arg.get_shape()[-2];
+
+    auto batch_size = input_tensor_arg.get_shape()[0];
+    auto sentence_size = input_tensor_arg.get_shape()[-1];
+    auto input_tensor =
+        ttnn::reshape(input_tensor_arg, ttnn::Shape{std::array<uint32_t, 4>{batch_size, 1, 1, sentence_size}});
+
+    auto input_gradient =
+        operation::run(
+            EmbeddingBackward{
+                .output_mem_config = memory_config.value_or(output_gradient_tensor_arg.memory_config()),
+                .output_dtype = dtype.value_or(output_gradient_tensor_arg.get_dtype()),
+                .num_embeddings = num_embeddings},
+            {input_tensor, output_gradient_tensor_arg})
+            .at(0);
+
+    return input_gradient;
+}
+
+Tensor EmbeddingBackwardOperation::invoke(
+    const Tensor& input_tensor_arg,
+    const Tensor& weight_tensor_arg,
+    const Tensor& output_gradient_tensor_arg,
+    const std::optional<const DataType> dtype,
+    const std::optional<MemoryConfig>& memory_config,
+    std::optional<Tensor> optional_output_tensor) {
+    return invoke(
+        ttnn::DefaultQueueId,
+        input_tensor_arg,
+        weight_tensor_arg,
+        output_gradient_tensor_arg,
+        dtype,
+        memory_config,
+        optional_output_tensor);
+}
+
+}  // namespace ttnn::operations::embedding_backward

--- a/ttnn/cpp/ttnn/operations/embedding_backward/embedding_backward.hpp
+++ b/ttnn/cpp/ttnn/operations/embedding_backward/embedding_backward.hpp
@@ -1,0 +1,41 @@
+// SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include "ttnn/decorators.hpp"
+
+namespace ttnn {
+
+namespace operations {
+
+namespace embedding_backward {
+
+struct EmbeddingBackwardOperation {
+    static Tensor invoke(
+        uint8_t queue_id,
+        const Tensor& input_tensor_arg,
+        const Tensor& weight_tensor_arg,
+        const Tensor& output_gradient_tensor_arg,
+        const std::optional<const DataType> dtype = std::nullopt,
+        const std::optional<MemoryConfig>& memory_config = std::nullopt,
+        std::optional<Tensor> optional_output_tensor = std::nullopt);
+
+    static Tensor invoke(
+        const Tensor& input_tensor_arg,
+        const Tensor& weight_tensor_arg,
+        const Tensor& output_gradient_tensor_arg,
+        const std::optional<const DataType> dtype = std::nullopt,
+        const std::optional<MemoryConfig>& memory_config = std::nullopt,
+        std::optional<Tensor> optional_output_tensor = std::nullopt);
+};
+
+}  // namespace embedding_backward
+}  // namespace operations
+
+constexpr auto embedding_bw = ttnn::register_operation_with_auto_launch_op<
+    "ttnn::embedding_bw",
+    ttnn::operations::embedding_backward::EmbeddingBackwardOperation>();
+
+}  // namespace ttnn

--- a/ttnn/cpp/ttnn/operations/embedding_backward/embedding_backward_pybind.cpp
+++ b/ttnn/cpp/ttnn/operations/embedding_backward/embedding_backward_pybind.cpp
@@ -1,0 +1,83 @@
+// SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <pybind11/pybind11.h>
+#include <pybind11/stl.h>
+
+#include "ttnn/cpp/pybind11/decorators.hpp"
+#include "ttnn/operations/embedding_backward/embedding_backward_pybind.hpp"
+#include "ttnn/operations/embedding_backward/embedding_backward.hpp"
+
+namespace ttnn::operations::embedding_backward {
+namespace py = pybind11;
+
+void py_bind_embedding_backward(py::module& module) {
+    const auto doc =
+        R"doc(embedding_bw(input_tensor: ttnn.Tensor, weight: ttnn.Tensor, output_gradient_tensor: ttnn.Tensor, *, dtype: Optional[ttnn.DataType] = None, optional_output_tensor: Optional[ttnn.Tensor] = None, memory_config: Optional[ttnn.MemoryConfig] = None, queue_id: int = 0) -> ttnn.Tensor
+
+            Returns the input gradients of the output gradients tensor with respect to the input indices.
+
+            Args:
+                * :attr:`input_tensor`: the indices ttnn.Tensor
+                * :attr:`weight`: the embeddings ttnn.Tensor that correspond to the indices ttnn.Tensor. This tensor is only used to extract the vocabulary size.
+                * :attr:`output_gradient_tensor`: the output gradient ttnn.Tensor from the previous backwards op.
+
+            Keyword Args:
+                * :attr:`dtype`: the data type for the output tensor. Default is None.
+                * :attr:`output_tensor`: the optional output tensor. Default is None.
+                * :attr:`memory_config`: the memory configuration of the output tensor. Default is input tensor memory config.
+                * :attr:`queue_id`: the command queue id. Default is 0.
+
+            Example:
+                >>> device_id = 0
+                >>> device = ttnn.open_device(device_id=device_id)
+                >>> batch_size, seq_len, embedding_dim, num_embeddings = 2, 1024, 4096, 3200
+
+                >>> input_shape = (batch_size, seq_len)
+                >>> input_index = torch.randint(0, num_embeddings, input_shape)
+                >>> input_tensor = ttnn.from_torch(input_index, dtype=ttnn.uint32, device=device)
+
+                >>> weights_shape = (num_embeddings, embedding_dim)
+                >>> weights = torch.randn(weights_shape, requires_grad=True)
+                >>> weights_ttnn = ttnn.from_torch(weights, dtype=ttnn.bfloat16, layout=ttnn.TILE_LAYOUT, device=device)
+
+                >>> grad_shape = (1, 1, batch_size * seq_len, embedding_dim)
+                >>> grad_data = torch.randn(grad_shape, requires_grad=True)
+                >>> grad_tensor = ttnn.from_torch(grad_data, dtype=ttnn.bfloat16, layout=ttnn.TILE_LAYOUT, device=device)
+
+                >>> output = ttnn.embedding_bw(input_tensor, weights_ttnn, grad_tensor, dtype=ttnn.bfloat16))doc";
+    using OperationType = decltype(ttnn::embedding_bw);
+    bind_registered_operation(
+        module,
+        ttnn::embedding_bw,
+        doc,
+        ttnn::pybind_overload_t{
+            [](const OperationType& self,
+               const ttnn::Tensor& input_tensor,
+               const ttnn::Tensor& weight_tensor,
+               const ttnn::Tensor& output_gradient_tensor,
+               const std::optional<const DataType> dtype,
+               std::optional<ttnn::Tensor>& optional_output_tensor,
+               const std::optional<ttnn::MemoryConfig>& memory_config,
+               uint8_t queue_id) {
+                return self(
+                    queue_id,
+                    input_tensor,
+                    weight_tensor,
+                    output_gradient_tensor,
+                    dtype,
+                    memory_config,
+                    optional_output_tensor);
+            },
+            py::arg("input_tensor").noconvert(),
+            py::arg("weight_tensor").noconvert(),
+            py::arg("output_gradient_tensor").noconvert(),
+            py::kw_only(),
+            py::arg("dtype").noconvert() = std::nullopt,
+            py::arg("output_tensor").noconvert() = std::nullopt,
+            py::arg("memory_config") = std::nullopt,
+            py::arg("queue_id") = 0});
+}
+
+}  // namespace ttnn::operations::embedding_backward

--- a/ttnn/cpp/ttnn/operations/embedding_backward/embedding_backward_pybind.hpp
+++ b/ttnn/cpp/ttnn/operations/embedding_backward/embedding_backward_pybind.hpp
@@ -1,0 +1,13 @@
+// SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include "pybind11/pybind_fwd.hpp"
+
+namespace ttnn::operations::embedding_backward {
+
+void py_bind_embedding_backward(pybind11::module& module);
+
+}  // namespace ttnn::operations::embedding_backward

--- a/ttnn/ttnn/operations/binary_backward.py
+++ b/ttnn/ttnn/operations/binary_backward.py
@@ -19,30 +19,6 @@ THIS_MODULE = sys.modules[__name__]
 __all__ = []
 
 
-def _golden_function(grad_tensor, input_index, weights, input_shapes, *args, **kwargs):
-    import torch
-
-    batch_size = input_shapes[0]
-    no_of_embeddings = input_shapes[1] * input_shapes[2]
-    embedding_dim = input_shapes[3]
-
-    weights.retain_grad()
-
-    pyt_y = torch.nn.functional.embedding(
-        input_index.reshape((batch_size, no_of_embeddings)),
-        weights.reshape((batch_size * no_of_embeddings, embedding_dim)),
-    ).reshape((1, 1, batch_size * no_of_embeddings, embedding_dim))
-
-    pyt_y.backward(gradient=grad_tensor)
-
-    golden_output_tensor_a = weights.grad
-
-    return golden_output_tensor_a
-
-
-ttnn.attach_golden_function(ttnn.embedding_bw, golden_function=_golden_function)
-
-
 def _golden_function_backward(torch_op, grad_tensor, input_tensor_a, input_tensor_b, *args, **kwargs):
     import torch
 


### PR DESCRIPTION
### Ticket
[Link to Github Issue](https://github.com/tenstorrent/tt-metal/issues/6232)

### Problem description
Embedding backwards is required for LLM training. This PR adds the new `embedding_bw` op on device, which uses the new `reshuffle_tile` LLK op introduced here: https://github.com/tenstorrent/tt-metal/issues/9817.

### What's changed
This PR adds the new `embedding_bw` op as a new `ttnn` op and removes the old implementation, which was faulty. 

### Checklist
- [x] Post commit CI passes
  - all post-commit: https://github.com/tenstorrent/tt-metal/actions/runs/10491100340
  - ttnn post-commit: https://github.com/tenstorrent/tt-metal/actions/runs/10491103136
- [ ] Blackhole Post commit (if applicable)
- [ ] Model regression CI testing passes (if applicable)
- [x] New/Existing tests provide coverage for changes
