### PR TITLE
#10123: fixed errors  in reflection

### DIFF
--- a/tt_metal/tt_stl/reflection.hpp
+++ b/tt_metal/tt_stl/reflection.hpp
@@ -440,108 +440,249 @@ std::ostream& operator<<(std::ostream& os, const T& object) {
     return os;
 }
 
+template <typename T>
+struct visit_object_of_type_t;
+
 template <typename object_t, typename T>
+void visit_object_of_type(auto&& callback, T&& object) { return visit_object_of_type_t<std::decay_t<T>>{}.template operator()<object_t>(callback, object); }
+
+template<typename T>
+requires (not tt::stl::concepts::Reflectable<std::decay_t<T>>) and (not  requires { std::decay_t<T>::attribute_names; })
+struct visit_object_of_type_t<T> {
+
+    template<typename object_t>
     requires std::same_as<std::decay_t<T>, object_t>
-constexpr auto visit_object_of_type(auto callback, T&& value) {
-    callback(value);
-}
-
-template <typename object_t, typename T>
-constexpr auto visit_object_of_type(auto callback, const std::optional<T>& value) {
-    if (value.has_value()) {
-        visit_object_of_type<object_t>(callback, value.value());
+    void operator()(auto&& callback, T&& value) const {
+        callback(value);
     }
-}
 
-template <typename object_t, typename T>
-constexpr auto visit_object_of_type(auto callback, const std::vector<T>& value) {
-    for (auto& tensor : value) {
-        visit_object_of_type<object_t>(callback, tensor);
+    template<typename object_t>
+    requires (not std::same_as<std::decay_t<T>, object_t>)
+    void operator()(auto&& callback, T&& value) const {
+        TT_THROW("Unsupported visit of object of type: {}", get_type_name<T>());
     }
-}
 
-template <typename object_t, typename T, auto N>
-constexpr auto visit_object_of_type(auto callback, const std::array<T, N>& value) {
-    for (auto& tensor : value) {
-        visit_object_of_type<object_t>(callback, tensor);
-    }
-}
-
-template <typename object_t, typename... Ts>
-constexpr auto visit_object_of_type(auto callback, const std::tuple<Ts...>& value) {
-    constexpr auto num_attributes = sizeof...(Ts);
-    [&callback, &value]<size_t... Ns>(std::index_sequence<Ns...>) {
-        (visit_object_of_type<object_t>(callback, std::get<Ns>(value)), ...);
-    }(std::make_index_sequence<num_attributes>{});
-}
-
-template <typename object_t, typename T>
-    requires(not std::same_as<std::decay_t<T>, object_t>) and requires { std::decay_t<T>::attribute_names; }
-constexpr auto visit_object_of_type(auto callback, T&& object) {
-    constexpr auto num_attributes = std::tuple_size_v<decltype(std::decay_t<T>::attribute_names)>;
-    visit_object_of_type<object_t>(callback, object.attribute_values());
-}
-
-template <typename object_t, typename T>
-    requires(not std::same_as<std::decay_t<T>, object_t>) and
-            requires { tt::stl::concepts::Reflectable<std::decay_t<T>>; }
-constexpr auto visit_object_of_type(auto callback, T&& object) {
-    reflect::for_each(
-        [&callback, &object](auto I) { visit_object_of_type<object_t>(callback, reflect::get<I>(object)); }, object);
-}
-
-template <typename object_t, typename... Ts>
-constexpr auto visit_object_of_type(auto callback, Ts&&... objects) {
-    (visit_object_of_type<object_t>(callback, objects), ...);
-}
-
-template <typename object_t, typename T>
+    template<typename object_t>
     requires std::same_as<std::decay_t<T>, object_t>
-constexpr auto get_first_object_of_type(T&& value) {
-    return std::cref(value);
-}
-
-template <typename object_t, typename T>
-constexpr auto get_first_object_of_type(const std::optional<T>& value) {
-    if (value.has_value()) {
-        const auto& tensor = value.value();
-        return get_first_object_of_type<object_t>(tensor);
+    void operator()(auto&& callback, const T& value) const {
+        callback(value);
     }
-}
 
-template <typename object_t, typename T>
-constexpr auto get_first_object_of_type(const std::vector<T>& value) {
-    for (auto& tensor : value) {
-        return get_first_object_of_type<object_t>(tensor);
+    template<typename object_t>
+    requires (not std::same_as<std::decay_t<T>, object_t>)
+    void operator()(auto&& callback, const T& value) const {
+        TT_THROW("Unsupported visit of object of type: {}", get_type_name<T>());
     }
-}
+};
 
-template <typename object_t, typename T, auto N>
-constexpr auto get_first_object_of_type(const std::array<T, N>& value) {
-    for (auto& tensor : value) {
-        return get_first_object_of_type<object_t>(tensor);
+template<typename T>
+struct visit_object_of_type_t<std::optional<T>> {
+
+    template<typename object_t>
+    void operator()(auto&& callback, const std::optional<T>& value) const {
+        if (value.has_value()) {
+            visit_object_of_type<object_t>(callback, value.value());
+        }
     }
+};
+
+template<typename T>
+struct visit_object_of_type_t<std::vector<T>> {
+
+    template<typename object_t>
+    void operator()(auto&& callback, const std::vector<T>& value) const {
+        for (auto& tensor : value) {
+            visit_object_of_type<object_t>(callback, tensor);
+        }
+    }
+};
+
+template<typename T, auto N>
+struct visit_object_of_type_t<std::array<T, N>> {
+
+    template<typename object_t>
+    void operator()(auto&& callback, const std::array<T, N>& value) const {
+        for (auto& tensor : value) {
+            visit_object_of_type<object_t>(callback, tensor);
+        }
+    }
+};
+
+template<typename... Ts>
+struct visit_object_of_type_t<std::tuple<Ts...>> {
+
+    template<typename object_t>
+    void operator()(auto&& callback, const std::tuple<Ts...>& value) const {
+        [&callback, &value]<size_t... Ns>(std::index_sequence<Ns...>) {
+            (visit_object_of_type<object_t>(callback, std::get<Ns>(value)), ...);
+        }(std::make_index_sequence<sizeof...(Ts)>{});
+    }
+};
+
+template<typename T>
+requires requires { std::decay_t<T>::attribute_names; }
+struct visit_object_of_type_t<T> {
+
+    template<typename object_t>
+    requires std::same_as<std::decay_t<T>, object_t>
+    void operator()(auto&& callback, T&& value) const {
+        callback(value);
+    }
+
+    template<typename object_t>
+    requires(not std::same_as<std::decay_t<T>, object_t>)
+    void operator()(auto&& callback, T&& object) const {
+        constexpr auto num_attributes = std::tuple_size_v<decltype(std::decay_t<T>::attribute_names)>;
+        visit_object_of_type<object_t>(callback, object.attribute_values());
+    }
+
+    template<typename object_t>
+    requires std::same_as<std::decay_t<T>, object_t>
+    void operator()(auto&& callback, const T& value) const {
+        callback(value);
+    }
+
+    template<typename object_t>
+    requires(not std::same_as<std::decay_t<T>, object_t>)
+    void operator()(auto&& callback, const T& object) const {
+        constexpr auto num_attributes = std::tuple_size_v<decltype(std::decay_t<T>::attribute_names)>;
+        visit_object_of_type<object_t>(callback, object.attribute_values());
+    }
+};
+
+template<typename T>
+requires tt::stl::concepts::Reflectable<std::decay_t<T>>
+struct visit_object_of_type_t<T> {
+
+    template<typename object_t>
+    requires std::same_as<std::decay_t<T>, object_t>
+    void operator()(auto&& callback, T&& value) const {
+        callback(value);
+    }
+
+    template<typename object_t>
+    requires(not std::same_as<std::decay_t<T>, object_t>)
+    void operator()(auto&& callback, T&& object) const {
+        reflect::for_each(
+            [&callback, &object](auto I) { visit_object_of_type<object_t>(callback, reflect::get<I>(object)); }, object);
+    }
+
+    template<typename object_t>
+    requires std::same_as<std::decay_t<T>, object_t>
+    void operator()(auto&& callback, const T& value) const {
+        callback(value);
+    }
+
+    template<typename object_t>
+    requires(not std::same_as<std::decay_t<T>, object_t>)
+    void operator()(auto&& callback, const T& object) const {
+        reflect::for_each(
+            [&callback, &object](auto I) { visit_object_of_type<object_t>(callback, reflect::get<I>(object)); }, object);
+    }
+};
+
+template<typename T>
+struct get_first_object_of_type_t;
+
+template<typename object_t, typename T>
+auto get_first_object_of_type(const T& value) {
+    return get_first_object_of_type_t<std::decay_t<T>>{}.template operator()<object_t>(value);
 }
 
-template <typename object_t, typename... Ts>
-constexpr auto get_first_object_of_type(const std::tuple<Ts...>& value) {
-    constexpr auto num_attributes = sizeof...(Ts);
-    return get_first_object_of_type<object_t>(std::get<0>(value));
-}
+template<typename T>
+requires (not tt::stl::concepts::Reflectable<std::decay_t<T>>) and (not  requires { std::decay_t<T>::attribute_names; })
+struct get_first_object_of_type_t<T> {
 
-template <typename object_t, typename T>
-    requires (not std::same_as<std::decay_t<T>, object_t>) and requires { std::decay_t<T>::attribute_names; }
-constexpr auto get_first_object_of_type(T&& object) {
-    constexpr auto num_attributes = std::tuple_size_v<decltype(std::decay_t<T>::attribute_names)>;
-    return get_first_object_of_type<object_t>(object.attribute_values());
-}
+    template<typename object_t>
+    requires std::same_as<std::decay_t<T>, object_t>
+    const auto operator()(const T& value) const {
+        return value;
+    }
 
-template <typename object_t, typename T>
-    requires(not std::same_as<std::decay_t<T>, object_t>) and
-            requires { tt::stl::concepts::Reflectable<std::decay_t<T>>; }
-constexpr auto get_first_object_of_type(T&& object) {
-    return get_first_object_of_type<object_t>(reflect::get<0>(object));
-}
+    template<typename object_t>
+    requires(not std::same_as<std::decay_t<T>, object_t>)
+    const auto operator()(const T& value) const {
+        TT_THROW("Unsupported get first object of type: {}", get_type_name<T>());
+    }
+};
+
+template<typename T>
+struct get_first_object_of_type_t<std::optional<T>> {
+
+    template<typename object_t>
+    const auto operator()(const std::optional<T>& value) const {
+        if (value.has_value()) {
+            const auto& tensor = value.value();
+            return get_first_object_of_type<object_t>(tensor);
+        }
+    }
+};
+
+template<typename T>
+struct get_first_object_of_type_t<std::vector<T>> {
+
+    template<typename object_t>
+    const auto operator()(const std::vector<T>& value) const {
+        for (auto& tensor : value) {
+            return get_first_object_of_type<object_t>(tensor);
+        }
+    }
+};
+
+template<typename T, auto N>
+struct get_first_object_of_type_t<std::array<T, N>> {
+
+    template<typename object_t>
+    const auto operator()(const std::array<T, N>& value) const {
+        for (auto& tensor : value) {
+            return get_first_object_of_type<object_t>(tensor);
+        }
+    }
+};
+
+template<typename... Ts>
+struct get_first_object_of_type_t<std::tuple<Ts...>> {
+
+    template<typename object_t>
+    const auto operator()(const std::tuple<Ts...>& value) const {
+        return get_first_object_of_type<object_t>(std::get<0>(value));
+    }
+};
+
+template<typename T>
+requires requires { std::decay_t<T>::attribute_names; }
+struct get_first_object_of_type_t<T> {
+
+    template<typename object_t>
+    requires(std::same_as<std::decay_t<T>, object_t>)
+    const auto operator()(const T& object) const {
+        return object;
+    }
+
+    template<typename object_t>
+    requires(not std::same_as<std::decay_t<T>, object_t>)
+    const auto operator()(const T& object) const {
+        constexpr auto num_attributes = std::tuple_size_v<decltype(std::decay_t<T>::attribute_names)>;
+        return get_first_object_of_type<object_t>(object.attribute_values());
+    }
+};
+
+template<typename T>
+requires tt::stl::concepts::Reflectable<std::decay_t<T>>
+struct get_first_object_of_type_t<T> {
+
+    template<typename object_t>
+    requires(std::same_as<std::decay_t<T>, object_t>)
+    const auto operator()(const T& object) const {
+        return object;
+    }
+
+    template<typename object_t>
+    requires(not std::same_as<std::decay_t<T>, object_t>)
+    const auto operator()(const T& object) const {
+        return get_first_object_of_type<object_t>(reflect::get<0>(object));
+    }
+};
 
 }  // namespace reflection
 }  // namespace stl

--- a/ttnn/cpp/ttnn/device_operation.hpp
+++ b/ttnn/cpp/ttnn/device_operation.hpp
@@ -267,7 +267,7 @@ typename device_operation_t::tensor_return_value_t run(
     static_assert(not std::same_as<tensor_return_value_t, void>, "Operation return type cannot be \"void\"");
 
     // TODO: support the case when tensor args are empty? Or add an overload for that case?
-    auto device = tt::stl::reflection::get_first_object_of_type<Tensor>(tensor_args).get().device();
+    auto device = tt::stl::reflection::get_first_object_of_type<Tensor>(tensor_args).device();
     auto& program_cache = device->program_cache;
 
     auto program_hash = compute_program_hash<device_operation_t>(operation_attributes, tensor_args);


### PR DESCRIPTION
### Problem description
`visit_object_of_type` and `get_first_object_of_type` didn't work properly in all cases because they were implemented using function overloading

### What's changed
Changed both function to be implemented using struct specialization, so that the compiler knows what to pick correctly at all times

### Checklist
- [ ] Post commit CI passes
- [ ] Blackhole Post commit (if applicable)
- [ ] Model regression CI testing passes (if applicable)
- [ ] New/Existing tests provide coverage for changes
