### PR TITLE
#11129: Pass in None host_name, card_type, os, location if it's not detected. Usually for jobs that didn't acquire a runner

### DIFF
--- a/infra/data_collection/github/utils.py
+++ b/infra/data_collection/github/utils.py
@@ -143,9 +143,8 @@ def get_job_row_from_github_job(github_job):
     labels = github_job["labels"]
 
     if not host_name:
-        logger.debug("Detected null host_name, so will return unknown location and host_name")
-        location = "unknown"
-        host_name = "unknown"
+        location = None
+        host_name = None
     elif "GitHub Actions " in host_name:
         location = "github"
     else:
@@ -165,7 +164,7 @@ def get_job_row_from_github_job(github_job):
         logger.warning("Assuming ubuntu-20.04 for tt cloud, but may not be the case soon")
         ubuntu_version = "ubuntu-20.04"
     else:
-        ubuntu_version = "unknown"
+        ubuntu_version = None
 
     os = ubuntu_version
 
@@ -181,7 +180,7 @@ def get_job_row_from_github_job(github_job):
     elif "wormhole_b0" in labels:
         card_type = "wormhole_b0"
     else:
-        card_type = "unknown"
+        card_type = None
 
     job_submission_ts = github_job["created_at"]
 

--- a/infra/data_collection/pydantic_models.py
+++ b/infra/data_collection/pydantic_models.py
@@ -62,10 +62,10 @@ class Job(BaseModel):
     job_matrix_config: Optional[dict] = Field(
         None, description="This attribute is included for future feature enhancement."
     )
-    host_name: str = Field(description="Unique host name.")
-    card_type: str = Field(description="Card type and version.")
-    os: str = Field(description="Operating system of the host.")
-    location: str = Field(description="Where the host is located.")
+    host_name: Optional[str] = Field(description="Unique host name.")
+    card_type: Optional[str] = Field(description="Card type and version.")
+    os: Optional[str] = Field(description="Operating system of the host.")
+    location: Optional[str] = Field(description="Where the host is located.")
     tests: List[Test] = []
 
 


### PR DESCRIPTION
…

### Ticket

#11129 

### Problem description

We were sending `"unknown"` as a string literal for `host_name` for jobs that didn't acquire a runner. We should no longer do this, and instead properly send what we know to keep the data model consistent. 

### What's changed

Put `null` instead of `"unknown"`.

### Checklist
- [x] Post commit CI passes
- [x] Blackhole Post commit (if applicable)
- [x] Model regression CI testing passes (if applicable)
- [x] New/Existing tests provide coverage for changes
