### PR TITLE
Fix line all gather regression

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -17,7 +17,6 @@ import multiprocess
 import signal
 import time
 import psutil
-import itertools
 from datetime import datetime
 
 from loguru import logger

--- a/conftest.py
+++ b/conftest.py
@@ -17,6 +17,7 @@ import multiprocess
 import signal
 import time
 import psutil
+import itertools
 from datetime import datetime
 
 from loguru import logger
@@ -177,8 +178,10 @@ def device_mesh(request, silicon_arch_name, silicon_arch_wormhole_b0, device_par
     if isinstance(param, tuple):
         grid_dims = param
         assert len(grid_dims) == 2, "Device mesh grid shape should have exactly two elements."
-        device_grid = ttnn.DeviceGrid(*grid_dims)
         num_devices_requested = grid_dims[0] * grid_dims[1]
+        if num_devices_requested > len(device_ids):
+            pytest.skip("Requested more devices than available. Test not applicable for machine")
+        device_grid = ttnn.DeviceGrid(*grid_dims)
         assert num_devices_requested <= len(device_ids), "Requested more devices than available."
     else:
         num_devices_requested = min(param, len(device_ids))

--- a/tests/ttnn/unit_tests/operations/test_all_gather_galaxy.py
+++ b/tests/ttnn/unit_tests/operations/test_all_gather_galaxy.py
@@ -1,0 +1,205 @@
+# SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+
+# SPDX-License-Identifier: Apache-2.0
+
+import torch
+import pytest
+from loguru import logger
+import tt_lib as ttl
+import ttnn
+from tests.tt_eager.python_api_testing.sweep_tests.comparison_funcs import comp_equal, comp_pcc
+from models.utility_functions import skip_for_grayskull, get_devices_for_t3000
+import itertools
+
+from tests.ttnn.unit_tests.operations.test_all_gather import is_unsupported_case
+
+from ttnn import ShardTensorToMesh, ShardTensor2dMesh
+
+
+def run_line_all_gather_on_TG_with_mesh_tensor_along_rows(
+    device_mesh,
+    num_devices_per_line,
+    input_shape_per_all_gather,
+    dim,
+    num_links,
+    input_dtype,
+    layout,
+    mem_config,
+    use_program_cache,
+    function_level_defaults,
+    enable_async,
+    num_all_gather_instances=1,
+    num_iters=1,
+    cluster_axis=0,
+):
+    if len(device_mesh.get_devices()) != 32:
+        pytest.skip("Not TG!")
+    for device in device_mesh.get_devices():
+        device.enable_async(enable_async)
+
+    full_mesh_input_shape = input_shape_per_all_gather
+    tensor_height_per_all_gather = input_shape_per_all_gather[-2]
+    full_mesh_input_shape[-2] *= num_all_gather_instances
+
+    full_tensor = torch.zeros(full_mesh_input_shape, dtype=torch.bfloat16)
+
+    for i in range(num_all_gather_instances):
+        full_tensor[0, 0, i * tensor_height_per_all_gather : (i + 1) * tensor_height_per_all_gather, :] = torch.rand(
+            input_shape_per_all_gather
+        ).bfloat16()
+
+    shard_dims = (-1, -2) if cluster_axis == 0 else (-2, -1)
+    ttnn_tensor = ttnn.from_torch(
+        full_tensor,
+        dtype=input_dtype,
+        device=device_mesh,
+        layout=layout,
+        memory_config=mem_config,
+        mesh_mapper=ShardTensor2dMesh(
+            device_mesh, shard_grid=(num_all_gather_instances, num_devices_per_line), shard_dimensions=shard_dims
+        ),
+    )
+    ttnn_tensor = ttnn.to_device(ttnn_tensor, device_mesh)
+
+    for _ in range(num_iters):
+        ttnn_tensor = ttnn.line_all_gather(
+            ttnn_tensor, dim=dim, cluster_axis=cluster_axis, device_mesh=device_mesh, num_links=num_links
+        )
+
+    tt_output_tensor = ttnn.to_torch(mesh_composer=ttnn.from_device(ttnn_tensor))
+    if input_dtype == ttl.tensor.DataType.BFLOAT16:
+        eq, output = comp_equal(tt_output_tensor, full_tensor)
+    else:
+        eq, output = comp_pcc(tt_output_tensor, full_tensor)
+    if not eq:
+        logger.error(f"output mismatch for tensor")
+    assert eq, f"FAILED: {output}"
+
+
+# Enumerate the post-commit cases explicitly
+@skip_for_grayskull("Requires eth connected devices to run")
+@pytest.mark.parametrize(
+    "num_devices, num_links, input_shape, dim, layout",
+    [
+        (8, 1, [1, 1, 32, 1280], 1, ttl.tensor.Layout.TILE),
+        (8, 1, [1, 1, 32, 2048], 1, ttl.tensor.Layout.TILE),
+        (8, 1, [1, 1, 32, 2304], 1, ttl.tensor.Layout.TILE),
+        (8, 1, [1, 1, 32, 4096], 1, ttl.tensor.Layout.TILE),
+    ],
+)
+@pytest.mark.parametrize(
+    "input_dtype",
+    [
+        ttl.tensor.DataType.BFLOAT16,
+        ttl.tensor.DataType.BFLOAT8_B,  # https://github.com/tenstorrent/tt-metal/issues/9686
+    ],
+)
+@pytest.mark.parametrize(
+    "mem_config",
+    [
+        ttl.tensor.MemoryConfig(
+            buffer_type=ttl.tensor.BufferType.DRAM
+        ),  # https://github.com/tenstorrent/tt-metal/issues/9686
+        # ttl.tensor.MemoryConfig(buffer_type=ttl.tensor.BufferType.L1),
+    ],
+)
+@pytest.mark.parametrize("replication_factor", [1])  # , 2, 3, 8])
+@pytest.mark.parametrize("enable_async", [True, False])
+@pytest.mark.parametrize("device_mesh", [pytest.param((8, 4), id="8x4_grid")], indirect=True)
+def test_line_all_gather_on_TG_rows_post_commit(
+    device_mesh,
+    num_devices,
+    input_shape,
+    dim,
+    num_links,
+    input_dtype,
+    layout,
+    mem_config,
+    use_program_cache,
+    function_level_defaults,
+    enable_async,
+    replication_factor,
+    num_iters=1,
+):
+    run_line_all_gather_on_TG_with_mesh_tensor_along_rows(
+        device_mesh,
+        num_devices,
+        input_shape,
+        dim,
+        num_links,
+        input_dtype,
+        layout,
+        mem_config,
+        use_program_cache,
+        function_level_defaults,
+        enable_async=enable_async,
+        num_iters=num_iters,
+        num_all_gather_instances=replication_factor,
+        cluster_axis=0,
+    )
+
+
+@skip_for_grayskull("Requires eth connected devices to run")
+@pytest.mark.parametrize(
+    "num_devices, num_links, input_shape, dim, layout",
+    [
+        (4, 1, [1, 1, 32, 16384], 3, ttl.tensor.Layout.TILE),
+        # (4, 1, [1, 1, 32, 2304], 1, ttl.tensor.Layout.TILE),
+        # (4, 1, [1, 1, 32, 4096], 1, ttl.tensor.Layout.TILE),
+        # (4, 1, [1, 1, 32, 6656], 1, ttl.tensor.Layout.TILE),
+        # (4, 3, [1, 1, 32, 16384], 3, ttl.tensor.Layout.TILE),
+        # (4, 3, [1, 1, 32, 2304], 1, ttl.tensor.Layout.TILE),
+        # (4, 3, [1, 1, 32, 4096], 1, ttl.tensor.Layout.TILE),
+        # (4, 3, [1, 1, 32, 6656], 1, ttl.tensor.Layout.TILE),
+    ],
+)
+@pytest.mark.parametrize(
+    "input_dtype",
+    [
+        ttl.tensor.DataType.BFLOAT16,
+        # ttl.tensor.DataType.BFLOAT8_B, # https://github.com/tenstorrent/tt-metal/issues/9686
+    ],
+)
+@pytest.mark.parametrize(
+    "mem_config",
+    [
+        ttl.tensor.MemoryConfig(
+            buffer_type=ttl.tensor.BufferType.DRAM
+        ),  # https://github.com/tenstorrent/tt-metal/issues/9686
+        # ttl.tensor.MemoryConfig(buffer_type=ttl.tensor.BufferType.L1),
+    ],
+)
+@pytest.mark.parametrize("enable_async", [True])
+@pytest.mark.parametrize("replication_factor", [1])  # , 2, 3, 8])
+@pytest.mark.parametrize("device_mesh", [pytest.param((8, 4), id="8x4_grid")], indirect=True)
+def test_line_all_gather_on_TG_cols_post_commit(
+    device_mesh,
+    num_devices,
+    input_shape,
+    dim,
+    num_links,
+    input_dtype,
+    layout,
+    mem_config,
+    use_program_cache,
+    function_level_defaults,
+    enable_async,
+    replication_factor,
+    num_iters=1,
+):
+    run_line_all_gather_on_TG_with_mesh_tensor_along_rows(
+        device_mesh,
+        num_devices,
+        input_shape,
+        dim,
+        num_links,
+        input_dtype,
+        layout,
+        mem_config,
+        use_program_cache,
+        function_level_defaults,
+        enable_async=enable_async,
+        num_iters=num_iters,
+        num_all_gather_instances=replication_factor,
+        cluster_axis=1,
+    )

--- a/ttnn/cpp/ttnn/operations/ccl/line_all_gather/device/line_all_gather_op.cpp
+++ b/ttnn/cpp/ttnn/operations/ccl/line_all_gather/device/line_all_gather_op.cpp
@@ -102,10 +102,10 @@ Tensor line_all_gather(
                     device_index = i;
                     bool is_last_chip_in_clockwise_direction = i == (num_devices - 1);
                     bool is_last_chip_in_counter_clockwise_direction = i == 0;
-                    std::optional<chip_id_t> receiver_device_id = is_last_chip_in_clockwise_direction ?
+                    receiver_device_id = is_last_chip_in_clockwise_direction ?
                         std::nullopt :
                         std::optional<chip_id_t>(devices.at(i+1)->id());
-                    std::optional<chip_id_t> sender_device_id = is_last_chip_in_counter_clockwise_direction ?
+                    sender_device_id = is_last_chip_in_counter_clockwise_direction ?
                         std::nullopt :
                         std::optional<chip_id_t>(devices.at(i-1)->id());
                     break;

--- a/ttnn/cpp/ttnn/operations/ccl/line_all_gather/device/line_all_gather_op.cpp
+++ b/ttnn/cpp/ttnn/operations/ccl/line_all_gather/device/line_all_gather_op.cpp
@@ -157,8 +157,15 @@ Tensor line_all_gather(
             TT_ASSERT(selected_view != nullptr, "Device not found in any view");
 
             uint32_t num_devices = selected_view->size();
-            uint32_t receiver_device_id = (*selected_view)[(device_index + 1) % num_devices]->id();
-            uint32_t sender_device_id = (*selected_view)[(device_index + num_devices - 1) % num_devices]->id();
+
+            bool is_last_chip_in_clockwise_direction = device_index == (num_devices - 1);
+            bool is_last_chip_in_counter_clockwise_direction = device_index == 0;
+            std::optional<chip_id_t> receiver_device_id = is_last_chip_in_clockwise_direction ?
+                std::nullopt :
+                std::optional<chip_id_t>((*selected_view)[(device_index + 1) % num_devices]->id());
+            std::optional<chip_id_t> sender_device_id = is_last_chip_in_counter_clockwise_direction ?
+                std::nullopt :
+                std::optional<chip_id_t>((*selected_view)[(device_index + num_devices - 1) % num_devices]->id());
 
             return operation::run(
                 ttnn::LineAllGather{


### PR DESCRIPTION
### Ticket
[10874](https://github.com/tenstorrent/tt-metal/issues/10874)

### Problem description
This issue was identified when enabling CCL tests for galaxy. 
There was a regression introduced into line all-gather device selection which was exposed when we tested on galaxy. That's fixed back up here.

### What's changed
Fixed device id selection for all gather

### Checklist
- [x] Post commit CI passes: https://github.com/tenstorrent/tt-metal/actions/runs/10288017875
- [x] t3000 frequent tests: https://github.com/tenstorrent/tt-metal/actions/runs/10293073165
- [x] t3000 unit tests: https://github.com/tenstorrent/tt-metal/actions/runs/10290506744
- [x] TG unit tests: https://github.com/tenstorrent/tt-metal/actions/runs/10290517824
- [x] TG frequent tests: https://github.com/tenstorrent/tt-metal/actions/runs/10293078104
- [x] Blackhole Post commit (if applicable): N/A
- [x] Model regression CI testing passes (if applicable): N/A
- [x] New/Existing tests provide coverage for changes: Yes
