### PR TITLE
#11135: Provide `device_info` as a dictionary value containing device info in environment.csv in a benchmark run

### DIFF
--- a/infra/data_collection/github/utils.py
+++ b/infra/data_collection/github/utils.py
@@ -327,6 +327,13 @@ def create_csv_for_github_benchmark_environment(github_benchmark_environment_csv
     logger.warning("Hardcoded null for device_memory_size")
     device_memory_size = ""
 
+    device_info = json.dumps(
+        {
+            "device_type": device_type,
+            "device_memory_size": device_memory_size,
+        }
+    )
+
     benchmark_environment_row = {
         "git_repo_name": git_repo_name,
         "git_commit_hash": git_commit_hash,
@@ -337,8 +344,7 @@ def create_csv_for_github_benchmark_environment(github_benchmark_environment_csv
         "docker_image": docker_image,
         "device_hostname": device_hostname,
         "device_ip": device_ip,
-        "device_type": device_type,
-        "device_memory_size": device_memory_size,
+        "device_info": device_info,
     }
 
     create_csv(github_benchmark_environment_csv_filename, BENCHMARK_ENVIRONMENT_CSV_FIELDS, [benchmark_environment_row])

--- a/infra/data_collection/github/utils.py
+++ b/infra/data_collection/github/utils.py
@@ -51,8 +51,7 @@ BENCHMARK_ENVIRONMENT_CSV_FIELDS = (
     "docker_image",
     "device_hostname",
     "device_ip",
-    "device_type",
-    "device_memory_size",
+    "device_info",
 )
 
 


### PR DESCRIPTION
### Ticket
#11135

### Problem description

We were asked to change the schema for `device_info` so that it's a JSON instead.

### What's changed

We serialized the device attributes into an object.

### Checklist
- [x] Post commit CI passes
- [x] Blackhole Post commit (if applicable)
- [x] Model regression CI testing passes (if applicable)
- [x] New/Existing tests provide coverage for changes
