### PR TITLE
Fixed device.disable_and_clear_program_cache() not working

### DIFF
--- a/tt_metal/impl/device/program_cache.hpp
+++ b/tt_metal/impl/device/program_cache.hpp
@@ -18,7 +18,7 @@ namespace detail {
 // Generic Program Cache: This data structure is tied to a device handle and can store generic program types from
 // TT-Metal and TT-Eager using tt::stl::concepts::unique_any.
 struct ProgramCache {
-    inline bool contains(uint64_t program_hash) { return this->cache_.count(program_hash) > 0; }
+    inline bool contains(uint64_t program_hash) { return is_enabled() ? this->cache_.count(program_hash) > 0 : false; }
 
     template <typename T>
     inline T& get(uint64_t program_hash) {
@@ -27,6 +27,9 @@ struct ProgramCache {
 
     template <typename T>
     inline void insert(uint64_t program_hash, T&& program) {
+        if ( !is_enabled()) {
+            return;
+        }
         using cache_t = decltype(this->cache_);
         this->cache_.try_emplace(program_hash, program);
     }
@@ -39,7 +42,7 @@ struct ProgramCache {
         is_enabled_ = false;
     }
 
-    bool is_enabled()  {
+    bool is_enabled() const {
         return is_enabled_;
     }
 

--- a/ttnn/cpp/ttnn/device_operation.hpp
+++ b/ttnn/cpp/ttnn/device_operation.hpp
@@ -15,7 +15,6 @@
 #include "tt_stl/concepts.hpp"
 #include "tt_stl/reflection.hpp"
 #include "tt_stl/unique_any.hpp"
-#include "tt_metal/graph_tracking.hpp"
 namespace ttnn {
 
 namespace device_operation {
@@ -294,10 +293,6 @@ typename device_operation_t::tensor_return_value_t run(
 
     auto& program = create_or_get_program_from_cache<device_operation_t>(
         program_cache, program_cache_hit, program_hash, operation_attributes, tensor_args, tensor_return_value);
-
-    if(GraphTracker::instance().block_run_program()) {
-        return tensor_return_value;
-    }
 
     if (USE_FAST_DISPATCH) {
         ZoneScopedN("EnqueueProgram");

--- a/ttnn/cpp/ttnn/device_operation.hpp
+++ b/ttnn/cpp/ttnn/device_operation.hpp
@@ -15,7 +15,7 @@
 #include "tt_stl/concepts.hpp"
 #include "tt_stl/reflection.hpp"
 #include "tt_stl/unique_any.hpp"
-
+#include "tt_metal/graph_tracking.hpp"
 namespace ttnn {
 
 namespace device_operation {
@@ -133,13 +133,15 @@ inline auto& create_or_get_program_from_cache(
                 using program_factory_t = std::decay_t<decltype(program_factory)>;
                 using cached_program_t =
                     decltype(program_factory_t::create(operation_attributes, tensor_args, tensor_return_value));
+
+                auto cached_program_factory = CachedProgramFactory{
+                        program_factory_t::create(operation_attributes, tensor_args, tensor_return_value),
+                        program_factory_index};
+                auto& cached_program = cached_program_factory.cached_program.template get<cached_program_t>();
                 program_cache.insert(
                     program_hash,
-                    CachedProgramFactory{
-                        program_factory_t::create(operation_attributes, tensor_args, tensor_return_value),
-                        program_factory_index});
-                auto& cached_program_factory = program_cache.template get<CachedProgramFactory>(program_hash);
-                auto& cached_program = cached_program_factory.cached_program.template get<cached_program_t>();
+                    std::move(cached_program_factory)
+                    );
                 return cached_program.program;
             },
             program_factory);
@@ -259,6 +261,7 @@ typename device_operation_t::tensor_return_value_t run(
     const typename device_operation_t::operation_attributes_t& operation_attributes,
     const typename device_operation_t::tensor_args_t& tensor_args) {
     ZoneScopedN("TT_DNN_DEVICE_OP");
+
     auto operation_id = assign_operation_id();
 
     tt::stl::reflection::visit_object_of_type<Tensor>(check_tensor_types, tensor_args);
@@ -291,6 +294,10 @@ typename device_operation_t::tensor_return_value_t run(
 
     auto& program = create_or_get_program_from_cache<device_operation_t>(
         program_cache, program_cache_hit, program_hash, operation_attributes, tensor_args, tensor_return_value);
+
+    if(GraphTracker::instance().block_run_program()) {
+        return tensor_return_value;
+    }
 
     if (USE_FAST_DISPATCH) {
         ZoneScopedN("EnqueueProgram");


### PR DESCRIPTION
### Ticket
Not ticket.

### Problem description
In the device_operator.cpp we have check if cache is enabled, and if not we call `create_or_get_program_from_cache`. But in hpp file `create_or_get_program_from_cache` we always adding to cache then reading from it even if it is disabled. And inside of the program cache we call `try_emplace` as result we are reusing old cached value.

This is attempt to fix, but it might not work. Previously we put copy of the cached program. No I am trying to avoid it.

### What's changed
Applied small update to the Program Cache API.
Fixed `create_or_get_program_from_cache`.
Another one possible solution is to try call `operator[]` instead of `try_emplace`.
But as for me adding some value to the map and reading it in the next line immediately doesn't look right.

### Checklist
- [ ] Post commit CI passes
- [ ] Blackhole Post commit (if applicable)
- [ ] Model regression CI testing passes (if applicable)
- [ ] New/Existing tests provide coverage for changes
