### PR TITLE
Refactor how kernel binaries are stored and how we write them to workers for FD

### DIFF
--- a/tests/tt_metal/tools/profiler/test_device_profiler.py
+++ b/tests/tt_metal/tools/profiler/test_device_profiler.py
@@ -145,12 +145,12 @@ def test_dispatch_cores():
     ZONE_COUNT = 37
     REF_COUNT_DICT = {
         "grayskull": {
-            "Tensix CQ Dispatch": 19,
-            "Tensix CQ Prefetch": 22,
+            "Tensix CQ Dispatch": 11,
+            "Tensix CQ Prefetch": 14,
         },
         "wormhole_b0": {
-            "Tensix CQ Dispatch": 19,
-            "Tensix CQ Prefetch": 22,
+            "Tensix CQ Dispatch": 11,
+            "Tensix CQ Prefetch": 14,
         },
     }
 

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/3_pcie_transfer/test_rw_buffer.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/3_pcie_transfer/test_rw_buffer.cpp
@@ -77,7 +77,7 @@ int main(int argc, char** argv) {
             log_error(tt::LogTest, "Command line arguments found exception", e.what());
         }
 
-        TT_ASSERT(transfer_size % page_size == 0, "Transfer size {}B should be divisble by page size {}B", transfer_size, page_size);
+        TT_ASSERT(transfer_size % page_size == 0, "Transfer size {}B should be divisible by page size {}B", transfer_size, page_size);
 
         // Device setup
         int device_id = 0;

--- a/tt_metal/impl/program/program.cpp
+++ b/tt_metal/impl/program/program.cpp
@@ -604,7 +604,7 @@ void Program::populate_dispatch_data(Device *device) {
             vector<pair<transfer_info_cores, uint32_t>> dst_noc_multicast_info =
                 extract_dst_noc_multicast_info<std::set<CoreRange>>(
                     device, semaphore.core_range_set().ranges(), semaphore.core_type());
-            transfer_info_2 transfer_info = {
+            transfer_info transfer_info = {
                 .dst_base_addr = semaphore.address(),
                 .dst_noc_info = dst_noc_multicast_info,
                 .linked = false,
@@ -613,7 +613,7 @@ void Program::populate_dispatch_data(Device *device) {
         } else if (semaphore.core_type() == CoreType::ETH) {
             vector<pair<transfer_info_cores, uint32_t>> dst_noc_unicast_info =
                 extract_dst_noc_unicast_info(semaphore.core_range_set().ranges(), semaphore.core_type());
-            transfer_info_2 transfer_info = {
+            transfer_info transfer_info = {
                 .dst_base_addr = semaphore.address(),
                 .dst_noc_info = dst_noc_unicast_info,
                 .linked = false,
@@ -627,72 +627,77 @@ void Program::populate_dispatch_data(Device *device) {
     // Assume here and in command queue that kg_buffers is populated with multicast buffers first then unicast buffers
     // Program Binaries and Go Signals
     // TODO: cleanup put the WORKERS and ETH logic together..
-    for (KernelGroup &kernel_group : this->get_kernel_groups(CoreType::WORKER)) {
-        vector<pair<transfer_info_cores, uint32_t>> dst_noc_multicast_info = extract_dst_noc_multicast_info<std::set<CoreRange>>(
-            device, kernel_group.core_ranges.ranges(), kernel_group.get_core_type());
 
-        // So far, we don't support linking optimizations for kernel groups
-        // which use multiple core ranges
-        bool linked = dst_noc_multicast_info.size() == 1;
-        vector<KernelHandle> kernel_ids;
-        for (auto& optional_id : kernel_group.kernel_ids) {
-            if (optional_id) {
-                kernel_ids.push_back(optional_id.value());
-            }
-        }
-        for (size_t i = 0; i < kernel_ids.size(); i++) {
-            KernelHandle kernel_id = kernel_ids[i];
-            vector<RISCV> sub_kernels;
-            std::shared_ptr<Kernel> kernel = detail::GetKernel(*this, kernel_id);
+    // All program binaries will be packed into a single buffer in memory
+    std::vector<uint32_t> binaries_data;
+    // Map is used to look up transfer info by kernel id when we populate data ordered by core groups
+    std::unordered_map<KernelHandle, kernel_bins_transfer_info> kernel_transfer_info;
+    // This is generic for workers and eth cores
+    for (const auto &[core_type, kernels] : this->kernels_) {
+        for (const auto &[kernel_id, kernel] : kernels) {
+            std::vector<RISCV> sub_kernels;
             if (kernel->processor() == RISCV::COMPUTE) {
                 sub_kernels = {RISCV::TRISC0, RISCV::TRISC1, RISCV::TRISC2};
             } else {
                 sub_kernels = {kernel->processor()};
             }
-
-            uint32_t sub_kernel_index = 0;
             const auto &binaries = kernel->binaries(device->build_key());
+            std::vector<uint32_t> dst_base_addrs;
+            std::vector<uint32_t> page_offsets;
+            std::vector<uint32_t> lengths;
+            uint32_t transfer_info_index = 0;
 
-            for (size_t j = 0; j < binaries.size(); j++) {
-                const ll_api::memory &kernel_bin = binaries[j];
-                uint32_t k = 0;
+            for (size_t sub_kernel_index = 0; sub_kernel_index < binaries.size(); ++sub_kernel_index) {
+                const ll_api::memory &kernel_bin = binaries[sub_kernel_index];
                 uint32_t num_spans = kernel_bin.num_spans();
-
-                std::vector<uint32_t> dst_base_addrs(num_spans);
-                std::vector<uint32_t> page_offsets(num_spans);
-                std::vector<uint32_t> lengths(num_spans);
-                vector<uint32_t> binaries_data;
+                dst_base_addrs.resize(dst_base_addrs.size() + num_spans);
+                page_offsets.resize(page_offsets.size() + num_spans);
+                lengths.resize(lengths.size() + num_spans);
 
                 kernel_bin.process_spans([&](vector<uint32_t>::const_iterator mem_ptr, uint64_t dst, uint32_t len) {
-                    linked &= (i != kernel_ids.size() - 1) or (j != binaries.size() - 1) or (k != num_spans - 1);
                     uint64_t relo_addr =
                         tt::llrt::relocate_dev_addr(dst, processor_to_local_mem_addr.at(sub_kernels[sub_kernel_index]));
 
-                    dst_base_addrs[k] = (uint32_t)relo_addr;
-                    page_offsets[k] = binaries_data.size() * sizeof(uint32_t) / HostMemDeviceCommand::PROGRAM_PAGE_SIZE;
-                    lengths[k] = len * sizeof(uint32_t);
+                    dst_base_addrs[transfer_info_index] = (uint32_t)relo_addr;
+                    page_offsets[transfer_info_index] =
+                        binaries_data.size() * sizeof(uint32_t) / HostMemDeviceCommand::PROGRAM_PAGE_SIZE;
+                    lengths[transfer_info_index] = len * sizeof(uint32_t);
 
-                    binaries_data.resize(binaries_data.size() + len);
-                    std::copy(mem_ptr, mem_ptr + len, binaries_data.end() - len);
+                    binaries_data.insert(binaries_data.end(), mem_ptr, mem_ptr + len);
                     binaries_data.resize(
                         align(binaries_data.size(), HostMemDeviceCommand::PROGRAM_PAGE_SIZE / sizeof(uint32_t)), 0);
-                    k++;
+                    transfer_info_index++;
                 });
-                kernel_bins_transfer_info kernel_bins_transfer_info = {
-                    .dst_base_addrs = dst_base_addrs,
-                    .page_offsets = page_offsets,
-                    .lengths = lengths,
-                    .dst_noc_info = dst_noc_multicast_info,
-                    .linked = false,
-                    .data = binaries_data};
-                this->program_transfer_info.kernel_bins.push_back(kernel_bins_transfer_info);
+            }
+            kernel_bins_transfer_info kb_transfer_info = {
+                .dst_base_addrs = dst_base_addrs, .page_offsets = page_offsets, .lengths = lengths};
+            kernel_transfer_info.insert({kernel_id, kb_transfer_info});
+        }
+    }
 
-                this->kg_buffers.push_back(std::make_unique<Buffer>(
-                    device,
-                    binaries_data.size() * sizeof(uint32_t),
-                    HostMemDeviceCommand::PROGRAM_PAGE_SIZE,
-                    BufferType::DRAM));
-                sub_kernel_index++;
+    if (binaries_data.size() > 0) {
+        this->kernels_buffer = std::make_shared<Buffer>(
+            device, binaries_data.size() * sizeof(uint32_t), HostMemDeviceCommand::PROGRAM_PAGE_SIZE, BufferType::DRAM);
+
+        this->program_transfer_info.binary_data = binaries_data;
+    }
+
+    for (KernelGroup &kernel_group : this->get_kernel_groups(CoreType::WORKER)) {
+        std::vector<pair<transfer_info_cores, uint32_t>> dst_noc_multicast_info =
+            extract_dst_noc_multicast_info<std::set<CoreRange>>(
+                device, kernel_group.core_ranges.ranges(), kernel_group.get_core_type());
+
+        vector<KernelHandle> kernel_ids;
+        for (auto &optional_id : kernel_group.kernel_ids) {
+            if (optional_id) {
+                kernel_ids.push_back(optional_id.value());
+            }
+        }
+
+        for (const auto &[cores, num_mcast_dsts] : dst_noc_multicast_info) {
+            for (const auto &kernel_id : kernel_ids) {
+                this->program_transfer_info.kernel_bins.emplace_back(
+                    cores, num_mcast_dsts, kernel_transfer_info.at(kernel_id));
             }
         }
     }
@@ -704,57 +709,11 @@ void Program::populate_dispatch_data(Device *device) {
         if (kernel_group.core_type == CoreType::ETH && kernel_group.kernel_ids[DISPATCH_CLASS_ETH_DM0]) {
             kernel_ids.push_back(kernel_group.kernel_ids[DISPATCH_CLASS_ETH_DM0].value());
         }
-        for (size_t i = 0; i < kernel_ids.size(); i++) {
-            KernelHandle kernel_id = kernel_ids[i];
-            vector<RISCV> sub_kernels;
-            std::shared_ptr<Kernel> kernel = detail::GetKernel(*this, kernel_id);
-            if (kernel->processor() == RISCV::COMPUTE) {
-                sub_kernels = {RISCV::TRISC0, RISCV::TRISC1, RISCV::TRISC2};
-            } else {
-                sub_kernels = {kernel->processor()};
-            }
 
-            uint32_t sub_kernel_index = 0;
-            const auto &binaries = kernel->binaries(device->build_key());
-            for (size_t j = 0; j < binaries.size(); j++) {
-                const ll_api::memory &kernel_bin = binaries[j];
-                uint32_t k = 0;
-                uint32_t num_spans = kernel_bin.num_spans();
-
-                std::vector<uint32_t> dst_base_addrs(num_spans);
-                std::vector<uint32_t> page_offsets(num_spans);
-                std::vector<uint32_t> lengths(num_spans);
-                vector<uint32_t> binaries_data;
-
-                kernel_bin.process_spans([&](vector<uint32_t>::const_iterator mem_ptr, uint64_t dst, uint32_t len) {
-                    uint64_t relo_addr =
-                        tt::llrt::relocate_dev_addr(dst, processor_to_local_mem_addr.at(sub_kernels[sub_kernel_index]));
-
-                    dst_base_addrs[k] = (uint32_t)relo_addr;
-                    page_offsets[k] = binaries_data.size() * sizeof(uint32_t) / HostMemDeviceCommand::PROGRAM_PAGE_SIZE;
-                    lengths[k] = len * sizeof(uint32_t);
-
-                    binaries_data.resize(binaries_data.size() + len);
-                    std::copy(mem_ptr, mem_ptr + len, binaries_data.end() - len);
-                    binaries_data.resize(
-                        align(binaries_data.size(), HostMemDeviceCommand::PROGRAM_PAGE_SIZE / sizeof(uint32_t)), 0);
-                    k++;
-                });
-                kernel_bins_transfer_info kernel_bins_transfer_info = {
-                    .dst_base_addrs = dst_base_addrs,
-                    .page_offsets = page_offsets,
-                    .lengths = lengths,
-                    .dst_noc_info = dst_noc_unicast_info,
-                    .linked = false,
-                    .data = binaries_data};
-                this->program_transfer_info.kernel_bins.push_back(kernel_bins_transfer_info);
-
-                this->kg_buffers.push_back(std::make_unique<Buffer>(
-                    device,
-                    binaries_data.size() * sizeof(uint32_t),
-                    HostMemDeviceCommand::PROGRAM_PAGE_SIZE,
-                    BufferType::DRAM));
-                sub_kernel_index++;
+        for (const auto &[cores, num_mcast_dsts] : dst_noc_unicast_info) {
+            for (const auto &kernel_id : kernel_ids) {
+                this->program_transfer_info.kernel_bins.emplace_back(
+                    cores, num_mcast_dsts, kernel_transfer_info.at(kernel_id));
             }
         }
     }

--- a/tt_metal/impl/program/program.hpp
+++ b/tt_metal/impl/program/program.hpp
@@ -154,8 +154,7 @@ class Program {
     std::vector<std::shared_ptr<Buffer>> owned_buffer_pool = {};
 
     // The buffer that holds the kernel/binaries/etc for this program
-    std::vector<std::shared_ptr<Buffer>> kg_buffers;
-    std::unique_ptr<Buffer> buffer;
+    std::shared_ptr<Buffer> kernels_buffer = nullptr;
     ProgramTransferInfo program_transfer_info;
 
     bool finalized_;

--- a/tt_metal/impl/program/program_device_map.hpp
+++ b/tt_metal/impl/program/program_device_map.hpp
@@ -2,42 +2,37 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-#include <unordered_map>
 #include <cstdint>
+#include <unordered_map>
+#include <variant>
+#include <vector>
 
-// TODO: AL delete?
-//
-struct transfer_info {
-    std::uint32_t size_in_bytes;
-    std::uint32_t dst;
-    std::uint32_t dst_noc_encoding;
-    std::uint32_t num_receivers;
-    bool last_transfer_in_group;
-    bool linked;
-};
+#include "tt_metal/common/core_coord.h"
+
+namespace tt::tt_metal {
 
 using transfer_info_cores = std::variant<CoreCoord, CoreRange>;
 
-struct transfer_info_2 {
+struct transfer_info {
     std::uint32_t dst_base_addr;
-    vector<pair<transfer_info_cores, uint32_t>> dst_noc_info;  // noc_encoding, num_mcast_dests
+    std::vector<std::pair<transfer_info_cores, std::uint32_t>> dst_noc_info;  // noc_encoding, num_mcast_dests
     bool linked;
-    vector<std::uint32_t> data;
-};
-struct kernel_bins_transfer_info {
-    vector<std::uint32_t> dst_base_addrs;           // BRISC, NCRISC, TRISC etc..
-    vector<std::uint32_t> page_offsets;             // offsets into paged buffer in DRAM
-    vector<std::uint32_t> lengths;                  // WriteLinear lengths
-    vector<pair<transfer_info_cores, uint32_t>> dst_noc_info;  // noc_encoding, num_mcast_dests
-    bool linked;
-    vector<std::uint32_t> data;                     // all binaries' data for kernel group
+    std::vector<std::uint32_t> data;
 };
 
-enum class PageTransferType { MULTICAST, UNICAST };
+struct kernel_bins_transfer_info {
+    std::vector<std::uint32_t> dst_base_addrs;  // BRISC, NCRISC, TRISC etc..
+    std::vector<std::uint32_t> page_offsets;    // offsets into paged buffer in DRAM
+    std::vector<std::uint32_t> lengths;         // WriteLinear lengths
+};
 
 struct ProgramTransferInfo {
     std::uint32_t num_active_cores;
-    std::unordered_map<uint32_t, vector<transfer_info_2>> multicast_semaphores;    // WritePacked, sorted by dst
-    std::unordered_map<uint32_t, vector<transfer_info_2>> unicast_semaphores;      // WritePacked, sorted by dst
-    vector<kernel_bins_transfer_info> kernel_bins;                                 // RelayPaged, WriteLinear
+    std::unordered_map<std::uint32_t, std::vector<transfer_info>> multicast_semaphores;  // WritePacked, sorted by dst
+    std::unordered_map<std::uint32_t, std::vector<transfer_info>> unicast_semaphores;    // WritePacked, sorted by dst
+    std::vector<std::tuple<transfer_info_cores, std::uint32_t, kernel_bins_transfer_info>>
+        kernel_bins;                         // noc_encoding, num_mcast_dests, transfer_info
+    std::vector<std::uint32_t> binary_data;  // Holds binary data for all program kernels
 };
+
+}  // namespace tt::tt_metal


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/11014

### Problem description
To enable linking within/across sub cmds for kernel binaries, need to reorganize how we iterate/write binaries from being binary/address major, core range minor to core range major, binary/address minor

### What's changed

- Packed all kernels of a program into a single buffer. This reduces wasted memory as well as removing our binary duplication across kernel groups.
- Change iteration to be core range major, binary minor. Currently reviewing HW issues with linking when we an additional transaction on a different command buffer/VC, so we don't enable linking in this PR.
- Additional change to uplift write to pcie from device to use new noc apis, and not reprogram NOC coord

### Checklist
- [x] Post commit CI passes
- [ ] Blackhole Post commit (if applicable)
- [x] Model regression CI testing passes (if applicable)
- [x] New/Existing tests provide coverage for changes
