### PR TITLE
#10826: support moreh_embedding

### DIFF
--- a/tests/ttnn/unit_tests/operations/test_moreh_embedding.py
+++ b/tests/ttnn/unit_tests/operations/test_moreh_embedding.py
@@ -1,0 +1,65 @@
+# SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+
+# SPDX-License-Identifier: Apache-2.0
+
+import pytest
+import torch
+import ttnn
+from tests.ttnn.utils_for_testing import assert_with_pcc
+from models.utility_functions import torch_random, skip_for_wormhole_b0
+
+
+def run_moreh_embedding(device, input_shape, embedding_dim, num_embeddings, dtype):
+    torch.manual_seed(1234)
+
+    torch_input = torch.randint(0, num_embeddings - 1, input_shape)
+    torch_weight = torch_random((num_embeddings, embedding_dim), -0.1, 0.1, dtype=torch.bfloat16)
+
+    torch_output = torch.nn.functional.embedding(torch_input, torch_weight)
+
+    tt_input = ttnn.to_device(
+        ttnn.from_torch(torch_input, dtype=ttnn.int32, layout=ttnn.TILE_LAYOUT),
+        device,
+    )
+    tt_weights = ttnn.to_device(ttnn.from_torch(torch_weight, dtype=dtype, layout=ttnn.TILE_LAYOUT), device)
+
+    tt_output = ttnn.to_device(
+        ttnn.from_torch(torch.empty_like(torch_output), dtype=dtype, layout=ttnn.TILE_LAYOUT), device
+    )
+
+    ttnn.moreh_embedding(tt_input, tt_weights, output=tt_output)
+    tt_result = ttnn.to_torch(tt_output)
+
+    assert_with_pcc(torch_output, tt_result)
+
+
+@pytest.mark.parametrize("input_shape", [[2, 2], [2, 100], [2, 2, 2], [2, 50, 100]])
+@pytest.mark.parametrize("embedding_dim", [5, 32, 100])
+@pytest.mark.parametrize("num_embeddings", [90])
+@pytest.mark.parametrize("dtype", [ttnn.bfloat16])
+def test_moreh_embedding(
+    device,
+    input_shape,
+    embedding_dim,
+    num_embeddings,
+    dtype,
+):
+    run_moreh_embedding(device, input_shape, embedding_dim, num_embeddings, dtype)
+
+
+@pytest.mark.parametrize("input_shape", [[2, 50, 100]])
+@pytest.mark.parametrize("embedding_dim", [100])
+@pytest.mark.parametrize("num_embeddings", [90])
+@pytest.mark.parametrize("dtype", [ttnn.bfloat16])
+def test_moreh_embedding_callback(
+    device,
+    input_shape,
+    embedding_dim,
+    num_embeddings,
+    dtype,
+):
+    for _ in range(2):
+        run_moreh_embedding(device, input_shape, embedding_dim, num_embeddings, dtype)
+
+        torch_dummy = torch.empty((32, 32), dtype=torch.bfloat16)
+        weights = ttnn.to_device(ttnn.from_torch(torch_dummy, dtype=dtype, layout=ttnn.TILE_LAYOUT), device)

--- a/ttnn/CMakeLists.txt
+++ b/ttnn/CMakeLists.txt
@@ -133,6 +133,8 @@ set(TTNN_SRCS
     ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/loss/loss.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/loss/loss_pybind.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/data_movement/transpose/device/transpose_program_factory.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/moreh_embedding/device/moreh_embedding_device_operation.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/moreh_helper_functions.cpp
 )
 
 ### Setup TTNN as a shared library with optional Python bindings

--- a/ttnn/cpp/pybind11/operations/__init__.hpp
+++ b/ttnn/cpp/pybind11/operations/__init__.hpp
@@ -39,6 +39,7 @@
 #include "ttnn/operations/eltwise/complex/complex_pybind.hpp"
 #include "ttnn/operations/eltwise/complex_unary_backward/complex_unary_backward_pybind.hpp"
 #include "ttnn/operations/loss/loss_pybind.hpp"
+#include "ttnn/operations/moreh_embedding/moreh_embedding_pybind.hpp"
 
 namespace py = pybind11;
 
@@ -126,6 +127,9 @@ void py_module(py::module& module) {
 
     auto m_experimental = module.def_submodule("experimental", "experimental operations");
     experimental::py_module(m_experimental);
+
+    auto m_moreh_embedding = module.def_submodule("moreh_embedding", "moreh_embedding operations");
+    moreh_embedding::py_module(m_moreh_embedding);
 }
 
 }  // namespace operations

--- a/ttnn/cpp/ttnn/operations/moreh_embedding/device/kernels/dataflow/reader_moreh_embeddings.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh_embedding/device/kernels/dataflow/reader_moreh_embeddings.cpp
@@ -1,0 +1,118 @@
+// SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "dataflow_api.h"
+#include "ttnn/cpp/ttnn/deprecated/tt_dnn/kernels/dataflow/moreh_common.hpp"
+
+void kernel_main() {
+    uint32_t i = 0;
+    const auto input_addr = get_arg_val<uint32_t>(i++);
+    const auto weight_addr = get_arg_val<uint32_t>(i++);
+    const auto num_tiles_per_core = get_arg_val<uint32_t>(i++);
+    const auto start_id = get_arg_val<uint32_t>(i++);
+    const auto H = get_arg_val<uint32_t>(i++);
+    const auto W = get_arg_val<uint32_t>(i++);
+    const auto embedding_dim = get_arg_val<uint32_t>(i++);
+
+    constexpr uint32_t cb_input = tt::CB::c_in0;
+    constexpr uint32_t cb_weight = tt::CB::c_in1;
+    constexpr uint32_t cb_output = tt::CB::c_out0;
+
+    const uint32_t input_tile_bytes = get_tile_size(cb_input);
+    auto input_element_size = input_tile_bytes / 1024;
+    auto input_noc_read_size = FACE_WIDTH * input_element_size;
+
+    constexpr bool input_is_dram = get_compile_time_arg_val(0) == 1;
+    const InterleavedAddrGen<input_is_dram> addrg_input = {
+        .bank_base_address = input_addr,
+        .page_size = input_tile_bytes,
+    };
+
+    const uint32_t weight_tile_bytes = get_tile_size(cb_weight);
+    auto weight_element_size = weight_tile_bytes / 1024;
+    auto weight_noc_read_size = FACE_WIDTH * weight_element_size;
+
+    constexpr bool weight_is_dram = get_compile_time_arg_val(1) == 1;
+    const InterleavedAddrGen<weight_is_dram> addrg_weight = {
+        .bank_base_address = weight_addr,
+        .page_size = weight_tile_bytes,
+    };
+
+    uint32_t end_id = start_id + num_tiles_per_core;
+
+    uint32_t Ht = (H + TILE_HEIGHT - 1) / TILE_HEIGHT;
+    uint32_t Wt = (W + TILE_HEIGHT - 1) / TILE_HEIGHT;
+    uint32_t Et = (embedding_dim + TILE_WIDTH - 1) / TILE_WIDTH;
+
+    // for 2d case
+    // input: (H, W): int32
+    // weight: (num_embeddings, embedding_dim)
+    // output: (H, W, embedding_dim)
+
+    for (uint32_t i = start_id; i < end_id; ++i) {
+        // output (..., H, W, Embedding_dim)
+        // Ht = div_up(H, TILE_HEIGHT)
+        // Wt = div_up(W, TILE_HEIGHT)
+        // Et = div_up(Embedding_dim, TILE_WIDTH)
+        uint32_t et = i % Et;
+        uint32_t wt = (i / Et) % Wt;
+        uint32_t h = (i / (Wt * Et)) % H;
+        uint32_t input_outer_idx = i / (Wt * Et) / H;
+
+        // read input
+        uint32_t ht = h / TILE_HEIGHT;
+
+        cb_reserve_back(cb_input, 1);
+
+        uint32_t l1_write_addr = get_write_ptr(cb_input);
+
+        // read input to l1 [0~31]
+        uint32_t noc_offset = 0;
+        for (uint32_t idx = 0; idx < 2; ++idx) {
+            uint32_t input_noc_id = input_outer_idx * Ht * Wt + ht * Wt + wt;
+            auto src_noc_addr = get_noc_addr(input_noc_id, addrg_input, noc_offset);
+
+            uint32_t src_offset = get_tilized_idx(h, idx * FACE_WIDTH) * input_element_size;
+
+            noc_async_read(src_noc_addr + src_offset, l1_write_addr, input_noc_read_size);
+            noc_async_read_barrier();
+
+            l1_write_addr += input_noc_read_size;
+        }
+
+        cb_push_back(cb_input, 1);
+
+        cb_wait_front(cb_input, 1);
+        cb_reserve_back(cb_output, 1);
+
+        auto input_ptr = get_read_ptr<int32_t>(cb_input);
+        auto output_ptr = get_write_ptr<uint16_t>(cb_output);
+
+        uint32_t w_start = wt * TILE_HEIGHT;
+        uint32_t w_end = min(wt * TILE_HEIGHT + TILE_HEIGHT, W);
+        for (uint32_t w = w_start; w < w_end; w++) {
+            // read idx
+            int32_t weight_h = input_ptr[w % TILE_HEIGHT];
+            uint32_t weight_ht = weight_h / TILE_HEIGHT;
+
+            // read weight (num_embeddings, embedding_dim)
+            uint32_t weight_noc_offset = 0;
+            for (uint32_t idx = 0; idx < 2; ++idx) {
+                uint32_t weight_noc_id = weight_ht * Et + et;
+                auto weight_noc_addr = get_noc_addr(weight_noc_id, addrg_weight, weight_noc_offset);
+
+                uint32_t src_offset = get_tilized_idx(weight_h, idx * FACE_WIDTH) * weight_element_size;
+                uint32_t l1_offset = get_tilized_idx(w, idx * FACE_WIDTH) * weight_element_size;
+
+                uint32_t l1_addr = get_write_ptr(cb_output);
+
+                noc_async_read(weight_noc_addr + src_offset, l1_addr + l1_offset, FACE_WIDTH * weight_element_size);
+                noc_async_read_barrier();
+            }
+        }
+
+        cb_pop_front(cb_input, 1);
+        cb_push_back(cb_output, 1);
+    }
+}

--- a/ttnn/cpp/ttnn/operations/moreh_embedding/device/kernels/dataflow/writer_moreh_embeddings.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh_embedding/device/kernels/dataflow/writer_moreh_embeddings.cpp
@@ -1,0 +1,32 @@
+// SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "dataflow_api.h"
+
+void kernel_main() {
+    uint32_t i = 0;
+    const auto output_addr = get_arg_val<uint32_t>(i++);
+    const auto num_tiles_per_core = get_arg_val<uint32_t>(i++);
+    const auto start_id = get_arg_val<uint32_t>(i++);
+
+    constexpr uint32_t cb_output = tt::CB::c_out0;
+
+    const uint32_t output_tile_bytes = get_tile_size(cb_output);
+    const auto output_data_format = get_dataformat(cb_output);
+
+    constexpr bool output_is_dram = get_compile_time_arg_val(0) == 1;
+    const InterleavedAddrGenFast<output_is_dram> output_addrg = {
+        .bank_base_address = output_addr, .page_size = output_tile_bytes, .data_format = output_data_format};
+
+    constexpr uint32_t onetile = 1;
+    uint32_t end_id = start_id + num_tiles_per_core;
+
+    for (uint32_t i = start_id; i < end_id; ++i) {
+        cb_wait_front(cb_output, onetile);
+        uint32_t output_l1_write_addr = get_read_ptr(cb_output);
+        noc_async_write_tile(i, output_addrg, output_l1_write_addr);
+        noc_async_write_barrier();
+        cb_pop_front(cb_output, onetile);
+    }
+}

--- a/ttnn/cpp/ttnn/operations/moreh_embedding/device/moreh_embedding_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh_embedding/device/moreh_embedding_device_operation.cpp
@@ -1,0 +1,128 @@
+// SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "ttnn/operations/moreh_embedding/device/moreh_embedding_device_operation.hpp"
+
+#include "tt_metal/common/constants.hpp"
+#include "tt_metal/detail/util.hpp"
+#include "tt_metal/host_api.hpp"
+#include "ttnn/deprecated/tt_dnn/op_library/math.hpp"
+#include "ttnn/deprecated/tt_dnn/op_library/work_split.hpp"
+#include "ttnn/operations/moreh_embedding/device/moreh_embedding_program_factory.hpp"
+
+using namespace tt::constants;
+using namespace std;
+using namespace tt::tt_metal;
+
+namespace ttnn::operations::moreh_embedding {
+
+void MorehEmbeddings::validate_with_output_tensors(const std::vector<Tensor> &input_tensors, const std::vector<std::optional<Tensor>> &output_tensors) const {
+    TT_FATAL(input_tensors.size() == 2, "Must have between 2 input tensors");
+    auto &input = input_tensors[0];
+    const auto &weight = input_tensors[1];
+
+    TT_FATAL(this->max_norm.has_value() == false, "The max_norm feature is currently not available.");
+
+    TT_FATAL(input.get_layout() == Layout::TILE);
+    TT_FATAL(input.get_dtype() == DataType::INT32, "Input must be INT32");
+    TT_FATAL(
+        input.memory_config().memory_layout == TensorMemoryLayout::INTERLEAVED,
+        "Moreh Embedding does not currently support sharding");
+
+    TT_FATAL(weight.get_layout() == Layout::TILE);
+    TT_FATAL(weight.get_dtype() == DataType::BFLOAT16);
+    TT_FATAL(
+        weight.memory_config().memory_layout == TensorMemoryLayout::INTERLEAVED,
+        "Moreh Embedding does not currently support sharding");
+    TT_FATAL(weight.get_legacy_shape().rank() == 2, "weight rank must be 2");
+
+    TT_FATAL(
+        this->output_mem_config.memory_layout == TensorMemoryLayout::INTERLEAVED,
+        "Moreh Embedding does not currently support sharding");
+
+    if (output_tensors[0].has_value()) {
+        auto &output = output_tensors[0].value();
+        TT_FATAL(output.get_layout() == Layout::TILE);
+        TT_FATAL(output.get_dtype() == DataType::BFLOAT16);
+        TT_FATAL(
+            output.memory_config().memory_layout == TensorMemoryLayout::INTERLEAVED,
+            "Moreh Embedding does not currently support sharding");
+    }
+
+}
+
+std::vector<tt::tt_metal::Shape> MorehEmbeddings::compute_output_shapes(
+    const std::vector<Tensor> &input_tensors) const {
+    using namespace tt;
+    using namespace tt::tt_metal;
+
+    const auto &input = input_tensors.at(0);
+    auto input_shape = input.get_legacy_shape();
+    auto input_shape_without_padding = input_shape.without_padding();
+    auto input_rank = input_shape.rank();
+
+    const auto &weight = input_tensors.at(1);
+    auto weight_shape = weight.get_legacy_shape().without_padding();
+
+    auto embedding_dim = weight_shape[-1];
+
+    auto dimensions_pads = std::vector<Padding::PadDimension>();
+    std::vector<uint32_t> output_shape_vec;
+
+    for (uint32_t dim = 0; dim < input_rank; dim++) {
+        // padding for h dim
+        if (dim == input_rank - 1) {
+            uint32_t up32_shape = round_up(input_shape[dim], 32);
+            uint32_t padding_back = up32_shape - input_shape_without_padding[dim];
+            output_shape_vec.push_back(up32_shape);
+            dimensions_pads.push_back(Padding::PadDimension{.front = 0, .back = padding_back});
+        } else {
+            output_shape_vec.push_back(input_shape_without_padding[dim]);
+            dimensions_pads.push_back(Padding::PadDimension{.front = 0, .back = 0});
+        }
+    }
+
+    // padding for w dim
+    uint32_t up32_shape = round_up(embedding_dim, 32);
+    uint32_t padding_back = up32_shape - embedding_dim;
+    output_shape_vec.push_back(up32_shape);
+    dimensions_pads.push_back(Padding::PadDimension{.front = 0, .back = padding_back});
+
+    const auto padding = Padding(dimensions_pads, Padding::PadValue::Any);
+    auto output_shape = tt::tt_metal::Shape(output_shape_vec, padding);
+
+    return {output_shape};
+}
+
+std::vector<Tensor> MorehEmbeddings::create_output_tensors(const std::vector<Tensor> &input_tensors, const std::vector<std::optional<Tensor>> &output_tensors) const {
+    if (output_tensors[0].has_value()) {
+        return {output_tensors[0].value()};
+    }
+
+    const auto &weight_tensor = input_tensors.at(1);
+    return operation::generic_create_output_tensors(
+        *this, input_tensors, this->output_dtype, Layout::TILE, this->output_mem_config);
+}
+
+operation::ProgramWithCallbacks MorehEmbeddings::create_program(
+    const std::vector<Tensor> &input_tensors, std::vector<Tensor> &output_tensors) const {
+    const auto &input = input_tensors.at(0);
+    const auto &weight = input_tensors.at(1);
+    auto &output_tensor = output_tensors.at(0);
+
+    auto device = input.device();
+    auto grid_coord = device->compute_with_storage_grid_size();
+    const CoreRange all_cores({0, 0}, {grid_coord.x - 1, grid_coord.y - 1});
+
+    return detail::moreh_embeddings_(
+        input,
+        weight,
+        this->max_norm,
+        this->norm_type,
+        output_tensor,
+        core_range.value_or(all_cores),
+        this->compute_kernel_config);
+}
+
+}  // namespace ttnn::operations::moreh_embedding

--- a/ttnn/cpp/ttnn/operations/moreh_embedding/device/moreh_embedding_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/moreh_embedding/device/moreh_embedding_device_operation.hpp
@@ -1,0 +1,34 @@
+// SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <optional>
+
+#include "ttnn/deprecated/tt_dnn/op_library/compute_kernel_config.hpp"
+#include "ttnn/run_operation.hpp"
+#include "ttnn/tensor/tensor.hpp"
+
+using namespace tt::constants;
+
+namespace ttnn::operations::moreh_embedding {
+
+struct MorehEmbeddings {
+    const MemoryConfig output_mem_config;
+    const DataType output_dtype;
+    const std::optional<float> max_norm;
+    const float norm_type;
+    const std::optional<CoreRange> core_range;  // unused for now
+    const DeviceComputeKernelConfig compute_kernel_config;
+
+    void validate_with_output_tensors(
+        const std::vector<Tensor> &input_tensors, const std::vector<std::optional<Tensor>> &output_tensors) const;
+    std::vector<tt::tt_metal::Shape> compute_output_shapes(const std::vector<Tensor> &input_tensors) const;
+    std::vector<Tensor> create_output_tensors(
+        const std::vector<Tensor> &input_tensors, const std::vector<std::optional<Tensor>> &output_tensors) const;
+    operation::ProgramWithCallbacks create_program(
+        const std::vector<Tensor> &input_tensors,
+        std::vector<Tensor> &output_tensors) const;
+};
+}  // namespace ttnn::operations::moreh_embedding

--- a/ttnn/cpp/ttnn/operations/moreh_embedding/device/moreh_embedding_program_factory.hpp
+++ b/ttnn/cpp/ttnn/operations/moreh_embedding/device/moreh_embedding_program_factory.hpp
@@ -1,0 +1,182 @@
+// SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "tt_log.h"
+#include "tt_metal/common/constants.hpp"
+#include "tt_metal/detail/util.hpp"
+#include "tt_metal/host_api.hpp"
+#include "ttnn/cpp/ttnn/operations/moreh_helper_functions.hpp"
+#include "ttnn/deprecated/tt_dnn/op_library/moreh_helper_functions.hpp"
+
+using namespace tt;
+
+namespace ttnn::operations::moreh_embedding::detail {
+
+operation::ProgramWithCallbacks moreh_embeddings_copy(
+    const Tensor &input, const Tensor &weight, Tensor &output, const CoreRange core_range) {
+    ////////////////////////////////////////////////////////////////////////////
+    //                      Buffer Setup
+    ////////////////////////////////////////////////////////////////////////////
+
+    tt_metal::Buffer *input_buffer = input.buffer();
+    tt_metal::Buffer *weight_buffer = weight.buffer();
+    tt_metal::Buffer *out_buffer = output.buffer();
+
+    ////////////////////////////////////////////////////////////////////////////
+    //                      Device Setup
+    ////////////////////////////////////////////////////////////////////////////
+    // This should allocate a DRAM buffer on the device
+    Device *device = input.device();
+    auto dst_addr = output.buffer()->address();
+
+    ////////////////////////////////////////////////////////////////////////////
+    //                      Application Setup
+    ////////////////////////////////////////////////////////////////////////////
+    Program program{};
+
+    bool in0_is_dram = input.buffer()->buffer_type() == tt_metal::BufferType::DRAM ? 1 : 0;
+    bool weight_is_dram = weight.buffer()->buffer_type() == tt_metal::BufferType::DRAM ? 1 : 0;
+    bool out_is_dram = output.buffer()->buffer_type() == tt_metal::BufferType::DRAM ? 1 : 0;
+
+    uint32_t input_element_size_bytes = input.element_size();
+    uint32_t weight_element_size_bytes = weight.element_size();
+
+    // row major, page size is last dim
+    uint32_t input_page_size = input.get_legacy_shape()[-1] * input_element_size_bytes;
+    uint32_t weight_page_size = weight.get_legacy_shape()[-1] * weight_element_size_bytes;
+
+    uint32_t num_embeddings = weight.get_legacy_shape().without_padding()[-2];
+    uint32_t embedding_dim = weight.get_legacy_shape().without_padding()[-1];
+
+    uint32_t H = output.get_legacy_shape().without_padding()[-3];
+    uint32_t W = output.get_legacy_shape().without_padding()[-2];
+    uint32_t units_to_divide = output.volume() / (output.get_legacy_shape()[-2] * output.get_legacy_shape()[-1]) *
+                               div_up(W, TILE_HEIGHT) * div_up(embedding_dim, TILE_HEIGHT);
+
+    auto [num_cores, all_cores, core_group_1, core_group_2, units_per_core_group_1, units_per_core_group_2] =
+        split_work_to_cores(core_range, units_to_divide);
+
+    // create circular buffers
+    tt::DataFormat data_format = tt_metal::datatype_to_dataformat_converter(weight.get_dtype());
+
+    CreateCircularBuffer(
+        program,
+        all_cores,
+        data_format,
+        {
+            {CB::c_in0, 1, tt::DataFormat::Int32},  // input
+            {CB::c_in1, 1},                         // weight
+            {CB::c_out0, 1},                        // output
+        });
+
+    const std::vector<uint32_t> reader_compile_time_args{
+        static_cast<uint32_t>(is_dram(input)),
+        static_cast<uint32_t>(is_dram(weight)),
+    };
+
+    const std::vector<uint32_t> writer_compile_time_args{static_cast<uint32_t>(is_dram(output))};
+
+    std::map<string, string> reader_defines;
+    std::map<string, string> writer_defines;
+
+    auto reader_kernel_id = CreateReadKernel(
+        program,
+        "ttnn/cpp/ttnn/operations/moreh_embedding/device/kernels/dataflow/reader_moreh_embeddings.cpp",
+        all_cores,
+        reader_compile_time_args,
+        reader_defines);
+
+    auto writer_kernel_id = CreateWriteKernel(
+        program,
+        "ttnn/cpp/ttnn/operations/moreh_embedding/device/kernels/dataflow/writer_moreh_embeddings.cpp",
+        all_cores,
+        writer_compile_time_args,
+        writer_defines);
+
+    const auto input_addr = input.buffer()->address();
+    const auto weight_addr = weight.buffer()->address();
+    const auto output_addr = output.buffer()->address();
+
+    // Set Runtime Args
+    uint32_t core_h = core_range.end_coord.y - core_range.start_coord.y + 1;
+
+    auto core_x_offset = core_range.start_coord.x;
+    auto core_y_offset = core_range.start_coord.y;
+    for (uint32_t i = 0, tile_offset = 0; i < num_cores; i++) {
+        CoreCoord core = {i / core_h + core_x_offset, i % core_h + core_y_offset};
+        uint32_t units_per_core;
+        if (core_group_1.core_coord_in_core_ranges(core)) {
+            units_per_core = units_per_core_group_1;
+        } else if (core_group_2.core_coord_in_core_ranges(core)) {
+            units_per_core = units_per_core_group_2;
+        } else {
+            TT_THROW("Core not in specified core ranges");
+        }
+
+        vector<uint32_t> reader_args = {input_addr, weight_addr, units_per_core, tile_offset, H, W, embedding_dim};
+
+        vector<uint32_t> writer_args = {
+            output_addr,
+            units_per_core,
+            tile_offset,
+        };
+
+        SetRuntimeArgs(program, reader_kernel_id, core, reader_args);
+        SetRuntimeArgs(program, writer_kernel_id, core, writer_args);
+
+        tile_offset += units_per_core;
+    }
+
+    auto override_runtime_args_callback = [reader_kernel_id, writer_kernel_id, num_cores, core_h](
+                                                const void* operation,
+                                                Program& program,
+                                                const std::vector<Tensor>& input_tensors,
+                                                const std::vector<std::optional<const Tensor>>& optional_input_tensors,
+                                                const std::vector<Tensor>& output_tensors
+                                              ) {
+
+        const auto& input = input_tensors.at(0);
+        const auto& weight = input_tensors.at(1);
+        const auto& output = output_tensors.at(0);
+
+        auto input_dram_buffer = input.buffer();
+        auto weight_dram_buffer = weight.buffer();
+        auto output_dram_buffer = output.buffer();
+
+        for (uint32_t icore = 0; icore < num_cores; icore++) {
+            CoreCoord core = {icore / core_h, icore % core_h};
+            {
+                auto &runtime_args = GetRuntimeArgs(program, reader_kernel_id, core);
+                runtime_args[0] = input_dram_buffer->address();
+                runtime_args[1] = weight_dram_buffer->address();
+            }
+
+            {
+                auto &runtime_args = GetRuntimeArgs(program, writer_kernel_id, core);
+                runtime_args[0] = output_dram_buffer->address();
+            }
+        }
+    };
+
+    // return {std::move(program), override_runtime_args_callback};
+
+    return {.program = std::move(program), .override_runtime_arguments_callback = override_runtime_args_callback};
+}
+
+operation::ProgramWithCallbacks moreh_embeddings_(
+    const Tensor &intput,
+    const Tensor &weight,
+    const std::optional<float> max_norm,
+    const float norm_type,
+    Tensor &output,
+    const CoreRange core_range,
+    const DeviceComputeKernelConfig compute_kernel_config) {
+    // do weight norm
+    if (max_norm.has_value()) {
+        auto max_norm_val = max_norm.value();
+    }
+
+    return moreh_embeddings_copy(intput, weight, output, core_range);
+}
+}  // namespace ttnn::operations::moreh_embedding::detail

--- a/ttnn/cpp/ttnn/operations/moreh_embedding/device/moreh_embedding_program_factory.hpp
+++ b/ttnn/cpp/ttnn/operations/moreh_embedding/device/moreh_embedding_program_factory.hpp
@@ -39,14 +39,6 @@ operation::ProgramWithCallbacks moreh_embeddings_copy(
     bool weight_is_dram = weight.buffer()->buffer_type() == tt_metal::BufferType::DRAM ? 1 : 0;
     bool out_is_dram = output.buffer()->buffer_type() == tt_metal::BufferType::DRAM ? 1 : 0;
 
-    uint32_t input_element_size_bytes = input.element_size();
-    uint32_t weight_element_size_bytes = weight.element_size();
-
-    // row major, page size is last dim
-    uint32_t input_page_size = input.get_legacy_shape()[-1] * input_element_size_bytes;
-    uint32_t weight_page_size = weight.get_legacy_shape()[-1] * weight_element_size_bytes;
-
-    uint32_t num_embeddings = weight.get_legacy_shape().without_padding()[-2];
     uint32_t embedding_dim = weight.get_legacy_shape().without_padding()[-1];
 
     uint32_t H = output.get_legacy_shape().without_padding()[-3];
@@ -158,8 +150,6 @@ operation::ProgramWithCallbacks moreh_embeddings_copy(
             }
         }
     };
-
-    // return {std::move(program), override_runtime_args_callback};
 
     return {.program = std::move(program), .override_runtime_arguments_callback = override_runtime_args_callback};
 }

--- a/ttnn/cpp/ttnn/operations/moreh_embedding/moreh_embedding.hpp
+++ b/ttnn/cpp/ttnn/operations/moreh_embedding/moreh_embedding.hpp
@@ -1,0 +1,72 @@
+// SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include "ttnn/decorators.hpp"
+#include "ttnn/operations/core/core.hpp"
+#include "ttnn/operations/moreh_embedding/device/moreh_embedding_device_operation.hpp"
+#include "ttnn/run_operation.hpp"
+
+namespace ttnn {
+
+namespace operations {
+
+namespace moreh_embedding {
+
+struct MorehEmbeddingOperation {
+    static inline Tensor operator()(
+        uint8_t queue_id,
+        const Tensor& input,
+        const Tensor& weight,
+        std::optional<float> max_norm = std::nullopt,
+        float norm_type = 2.0,
+        std::optional<Tensor> output = std::nullopt,
+        const std::optional<const DataType> dtype = std::nullopt,
+        const std::optional<MemoryConfig>& memory_config = std::nullopt,
+        std::optional<const DeviceComputeKernelConfig> compute_kernel_config = std::nullopt) {
+        auto device = input.device();
+
+        auto kernel_config_val =
+            init_device_compute_kernel_config(device->arch(), compute_kernel_config, MathFidelity::HiFi4);
+
+        auto embeddings = operation::run(
+                              MorehEmbeddings{
+                                  .output_mem_config = memory_config.value_or(input.memory_config()),
+                                  .output_dtype = dtype.value_or(weight.get_dtype()),
+                                  .max_norm = max_norm,
+                                  .norm_type = norm_type,
+                                  .core_range = std::nullopt,
+                                  .compute_kernel_config = kernel_config_val,
+                              },
+                              {input, weight},
+                              {},
+                              {output})
+                              .at(0);
+        return embeddings;
+    }
+
+    static inline auto operator()(
+        const Tensor& input,
+        const Tensor& weight,
+        std::optional<bool> max_norm = std::nullopt,
+        float norm_type = 2.0,
+        std::optional<Tensor> output = std::nullopt,
+        const std::optional<const DataType> dtype = std::nullopt,
+        const std::optional<MemoryConfig>& memory_config = std::nullopt,
+        std::optional<const DeviceComputeKernelConfig> compute_kernel_config = std::nullopt) {
+        constexpr auto DefaultQueueId = 0;
+        return operator()(
+            DefaultQueueId, input, weight, max_norm, norm_type, output, dtype, memory_config, compute_kernel_config);
+    }
+};
+
+}  // namespace moreh_embedding
+}  // namespace operations
+
+constexpr auto moreh_embedding = ttnn::register_operation_with_auto_launch_op<
+    "ttnn::moreh_embedding",
+    ttnn::operations::moreh_embedding::MorehEmbeddingOperation>();
+
+}  // namespace ttnn

--- a/ttnn/cpp/ttnn/operations/moreh_embedding/moreh_embedding_pybind.hpp
+++ b/ttnn/cpp/ttnn/operations/moreh_embedding/moreh_embedding_pybind.hpp
@@ -15,35 +15,23 @@ namespace py = pybind11;
 
 void py_module(py::module& module) {
     const auto doc =
-        R"doc(embedding(inxput_tensor: ttnn.Tensor, weight: ttnn.Tensor, *, padding_idx: Optional[int] = None, layout: ttnn.Layout = ttnn.ROW_MAJOR_LAYOUT, memory_config: Optional[ttnn.MemoryConfig] = None) -> ttnn.Tensor
+        R"doc(moreh_embedding(input: ttnn.Tensor, weight: ttnn.Tensor, *, max_norm: Optional[float] = None, norm_type = float = 2.0 , output: Optional[ttnn.Tensor] = None, dtype: Optional[ttnn.DataType] = None, memory_config: Optional[ttnn.MemoryConfig] = None, compute_kernel_config: Optional[ttnn.MemoryConfig] = None) -> ttnn.Tensor
 
-            Retrieves word embeddings using input_tensor. The input_tensor is a list of indices, and the embedding matrix, and the output is the corresponding word embeddings.
+            Retrieves word embeddings using input. The input is a list of indices, and the embedding matrix, and the output is the corresponding word embeddings.
 
             Args:
-                * :attr:`input_tensor`: the indices ttnn.Tensor
+                * :attr:`input`: the indices ttnn.Tensor
                 * :attr:`weight`: the embeddings ttnn.Tensor that correspond to the indices ttnn.Tensor
 
             Keyword Args:
+                * :attr:`max_norm`: If given, each embedding vector with norm larger than max_norm is renormalized to have norm max_norm. Note: this will modify weight in-place.
+                * :attr:`norm_type`: The p of the p-norm to compute for the max_norm option. Default 2.
+                * :attr:`output`: the optional output tensor. Default is None.
                 * :attr:`dtype`: the data type for the output tensor. Default is None.
-                * :attr:`output_tensor`: the optional output tensor. Default is None.
                 * :attr:`memory_config`: the memory configuration of the output tensor. Default is input tensor memory config.
+                * :attr:`compute_kernel_config`: the compute kernel configuration for the op. If not provided, the default configuration of the op is used.
                 * :attr:`queue_id`: the command queue id. Default is 0.
-
-            Example:
-                >>> device_id = 0
-                >>> device = ttnn.open_device(device_id=device_id)
-                >>> input_tensor = ttnn.to_device(ttnn.from_torch(torch.tensor([[1, 2, 4, 5], [4, 3, 2, 9]]), dtype=ttnn.uint32), device)
-                >>> # an embedding matrix containing 10 tensors of size 4
-                >>> weight = ttnn.to_device(ttnn.from_torch(torch.rand(10, 4), dtype=ttnn.bfloat16), device)
-                >>> ttnn.embedding(input_tensor, weight)
-                ttnn.Tensor([ [[1, 0.106445, 0.988281, 0.59375],
-                    [0.212891, 0.964844, 0.199219, 0.996094],
-                    [3.78362e-38, 0, 7.89785e-39, 0],
-                    [8.04479e-38, 0, 1.25815e-38, 0]],
-                [[2.71833e-38, 0, 3.59995e-38, 0],
-                    [7.60398e-38, 0, 1.83671e-38, 0],
-                    [2.22242e-38, 0, 1.88263e-38, 0],
-                    [1.35917e-38, 0, 4.49994e-39, 0]]], dtype=bfloat16 ))doc";
+            )doc";
     using OperationType = decltype(ttnn::moreh_embedding);
     bind_registered_operation(
         module,

--- a/ttnn/cpp/ttnn/operations/moreh_embedding/moreh_embedding_pybind.hpp
+++ b/ttnn/cpp/ttnn/operations/moreh_embedding/moreh_embedding_pybind.hpp
@@ -1,0 +1,77 @@
+// SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <pybind11/pybind11.h>
+#include <pybind11/stl.h>
+
+#include "ttnn/cpp/pybind11/decorators.hpp"
+#include "ttnn/operations/moreh_embedding/moreh_embedding.hpp"
+
+namespace ttnn::operations::moreh_embedding {
+namespace py = pybind11;
+
+void py_module(py::module& module) {
+    const auto doc =
+        R"doc(embedding(inxput_tensor: ttnn.Tensor, weight: ttnn.Tensor, *, padding_idx: Optional[int] = None, layout: ttnn.Layout = ttnn.ROW_MAJOR_LAYOUT, memory_config: Optional[ttnn.MemoryConfig] = None) -> ttnn.Tensor
+
+            Retrieves word embeddings using input_tensor. The input_tensor is a list of indices, and the embedding matrix, and the output is the corresponding word embeddings.
+
+            Args:
+                * :attr:`input_tensor`: the indices ttnn.Tensor
+                * :attr:`weight`: the embeddings ttnn.Tensor that correspond to the indices ttnn.Tensor
+
+            Keyword Args:
+                * :attr:`dtype`: the data type for the output tensor. Default is None.
+                * :attr:`output_tensor`: the optional output tensor. Default is None.
+                * :attr:`memory_config`: the memory configuration of the output tensor. Default is input tensor memory config.
+                * :attr:`queue_id`: the command queue id. Default is 0.
+
+            Example:
+                >>> device_id = 0
+                >>> device = ttnn.open_device(device_id=device_id)
+                >>> input_tensor = ttnn.to_device(ttnn.from_torch(torch.tensor([[1, 2, 4, 5], [4, 3, 2, 9]]), dtype=ttnn.uint32), device)
+                >>> # an embedding matrix containing 10 tensors of size 4
+                >>> weight = ttnn.to_device(ttnn.from_torch(torch.rand(10, 4), dtype=ttnn.bfloat16), device)
+                >>> ttnn.embedding(input_tensor, weight)
+                ttnn.Tensor([ [[1, 0.106445, 0.988281, 0.59375],
+                    [0.212891, 0.964844, 0.199219, 0.996094],
+                    [3.78362e-38, 0, 7.89785e-39, 0],
+                    [8.04479e-38, 0, 1.25815e-38, 0]],
+                [[2.71833e-38, 0, 3.59995e-38, 0],
+                    [7.60398e-38, 0, 1.83671e-38, 0],
+                    [2.22242e-38, 0, 1.88263e-38, 0],
+                    [1.35917e-38, 0, 4.49994e-39, 0]]], dtype=bfloat16 ))doc";
+    using OperationType = decltype(ttnn::moreh_embedding);
+    bind_registered_operation(
+        module,
+        ttnn::moreh_embedding,
+        doc,
+        ttnn::pybind_overload_t{
+            [](const OperationType& self,
+               const ttnn::Tensor& input,
+               const ttnn::Tensor& weight,
+               std::optional<float> max_norm,
+               float norm_type,
+               std::optional<ttnn::Tensor>& output,
+               const std::optional<const DataType> dtype,
+               const std::optional<ttnn::MemoryConfig>& memory_config,
+               std::optional<const DeviceComputeKernelConfig> compute_kernel_config,
+               uint8_t queue_id) {
+                return self(queue_id, input, weight, max_norm, norm_type, output, dtype, memory_config);
+            },
+            py::arg("input").noconvert(),
+            py::arg("weight").noconvert(),
+            py::kw_only(),
+            py::arg("max_norm") = std::nullopt,
+            py::arg("norm_type") = 2.0,
+            py::arg("output").noconvert() = std::nullopt,
+            py::arg("dtype").noconvert() = std::nullopt,
+            py::arg("memory_config") = std::nullopt,
+            py::arg("compute_kernel_config").noconvert() = std::nullopt,
+            py::arg("queue_id") = 0});
+}
+
+}  // namespace ttnn::operations::moreh_embedding

--- a/ttnn/cpp/ttnn/operations/moreh_helper_functions.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh_helper_functions.cpp
@@ -1,0 +1,277 @@
+
+#include "ttnn/cpp/ttnn/operations/moreh_helper_functions.hpp"
+
+#include "common/constants.hpp"
+#include "tt_metal/host_api.hpp"
+#include "ttnn/deprecated/tt_dnn/op_library/work_split.hpp"
+
+namespace ttnn {
+namespace operations {
+
+using namespace tt;
+using namespace tt::tt_metal;
+
+[[maybe_unused]] tt::tt_metal::KernelHandle CreateReadKernel(
+    Program &program,
+    const std::string &file_name,
+    const std::variant<CoreCoord, CoreRange, CoreRangeSet> &core_spec,
+    const std::vector<uint32_t> &compile_args,
+    std::map<string, string> defines) {
+    return tt::tt_metal::CreateKernel(
+        program,
+        file_name,
+        core_spec,
+        tt_metal::DataMovementConfig{
+            .processor = tt_metal::DataMovementProcessor::RISCV_1,
+            .noc = detail::GetPreferredNOCForDRAMRead(tt::Cluster::instance().arch()),
+            .compile_args = compile_args,
+            .defines = defines});
+}
+
+[[maybe_unused]] tt::tt_metal::KernelHandle CreateWriteKernel(
+    Program &program,
+    const std::string &file_name,
+    const std::variant<CoreCoord, CoreRange, CoreRangeSet> &core_spec,
+    const std::vector<uint32_t> &compile_args,
+    std::map<string, string> defines) {
+    return tt_metal::CreateKernel(
+        program,
+        file_name,
+        core_spec,
+        tt_metal::DataMovementConfig{
+            .processor = tt_metal::DataMovementProcessor::RISCV_0,
+            .noc = detail::GetPreferredNOCForDRAMWrite(tt::Cluster::instance().arch()),
+            .compile_args = compile_args,
+            .defines = defines});
+}
+
+[[maybe_unused]] std::vector<tt::tt_metal::KernelHandle> CreateComputeKernel(
+    Program &program,
+    const std::string &file_name,
+    std::vector<ComputeKernelArg> args,
+    std::map<std::string, std::string> defines,
+    MathFidelity math_fidelity,
+    bool fp32_dest_acc_en,
+    bool math_approx_mode,
+    bool preserve_fp32_precision) {
+    std::vector<tt::tt_metal::KernelHandle> compute_kernel_ids{};
+    tt::tt_metal::KernelHandle compute_kernel_id{};
+    for (auto arg : args) {
+        compute_kernel_id = CreateComputeKernel(
+            program,
+            file_name,
+            arg,
+            defines,
+            math_fidelity,
+            fp32_dest_acc_en,
+            math_approx_mode,
+            preserve_fp32_precision);
+        compute_kernel_ids.push_back(compute_kernel_id);
+    }
+    return compute_kernel_ids;
+}
+
+[[maybe_unused]] tt::tt_metal::KernelHandle CreateComputeKernel(
+    Program &program,
+    const std::string &file_name,
+    ComputeKernelArg arg,
+    std::map<std::string, std::string> defines,
+    MathFidelity math_fidelity,
+    bool fp32_dest_acc_en,
+    bool math_approx_mode,
+    bool preserve_fp32_precision) {
+    tt::tt_metal::KernelHandle compute_kernel_id{0};
+    if (arg.num_tile_per_core_group > 0) {
+        compute_kernel_id = CreateKernel(
+            program,
+            file_name,
+            arg.core_spec,
+            tt_metal::ComputeConfig{
+                .math_fidelity = math_fidelity,
+                .fp32_dest_acc_en = fp32_dest_acc_en,
+                .preserve_fp32_precision = preserve_fp32_precision,
+                .math_approx_mode = math_approx_mode,
+                .compile_args = arg.compile_args,
+                .defines = defines});
+    }
+    return compute_kernel_id;
+}
+
+[[maybe_unused]] std::vector<CBHandle> CreateCircularBuffer(
+    Program &program,
+    const std::variant<CoreCoord, CoreRange, CoreRangeSet> &core_range,
+    tt::DataFormat data_format,
+    std::vector<CircularBufferArg> args) {
+    std::vector<CBHandle> cb_ids{};
+    CBHandle cb_id{};
+    for (auto arg : args) {
+        cb_id = CreateCircularBuffer(program, core_range, data_format, arg);
+        cb_ids.push_back(cb_id);
+    }
+    return cb_ids;
+}
+
+[[maybe_unused]] CBHandle CreateCircularBuffer(
+    Program &program,
+    const std::variant<CoreCoord, CoreRange, CoreRangeSet> &core_range,
+    tt::DataFormat data_format,
+    CircularBufferArg arg) {
+    CBHandle cb_id{0};
+    if (arg.num_tiles > 0) {
+        auto _buffer_index = arg.buffer_index;
+        auto _num_tiles = arg.num_tiles;
+        auto _data_format = (arg.data_format != tt::DataFormat::Invalid) ? arg.data_format : data_format;
+        auto _core_range = (arg.core_range != std::nullopt) ? arg.core_range : core_range;
+
+        tt_metal::CircularBufferConfig cb_config =
+            tt_metal::CircularBufferConfig(
+                _num_tiles * tt_metal::detail::TileSize(_data_format), {{_buffer_index, _data_format}})
+                .set_page_size(_buffer_index, tt_metal::detail::TileSize(_data_format));
+
+        cb_id = tt_metal::CreateCircularBuffer(program, _core_range.value(), cb_config);
+    }
+    return cb_id;
+}
+
+void UpdateCircularBuffer(
+    Program &program,
+    tt::DataFormat data_format,
+    std::vector<CBHandle> cb_handles,
+    std::vector<CircularBufferArg> args) {
+    for (uint32_t idx = 0; idx < args.size(); idx++) {
+        UpdateCircularBuffer(program, data_format, cb_handles[idx], args[idx]);
+    }
+}
+
+void UpdateCircularBuffer(Program &program, tt::DataFormat data_format, CBHandle cb_handle, CircularBufferArg arg) {
+    if (arg.num_tiles > 0) {
+        auto _buffer_index = arg.buffer_index;
+        auto _num_tiles = arg.num_tiles;
+        auto _data_format = (arg.data_format != tt::DataFormat::Invalid) ? arg.data_format : data_format;
+        auto _buffer_ptr = arg.buffer_ptr;
+
+        auto single_tile_size = tt_metal::detail::TileSize(_data_format);
+
+        UpdateCircularBufferTotalSize(program, cb_handle, _num_tiles * single_tile_size);
+        UpdateCircularBufferPageSize(program, cb_handle, _buffer_index, single_tile_size);
+        if (_buffer_ptr != nullptr) {
+            UpdateDynamicCircularBufferAddress(program, cb_handle, *_buffer_ptr);  // for sharded
+        }
+    }
+}
+
+bool is_hw_dim(uint32_t dim, uint32_t rank) {
+    if (rank == 1 || rank == 2) {
+        return true;
+    }
+    if (rank >= 3) {
+        if (dim >= rank - 2) {
+            return true;
+        }
+    }
+    return false;
+}
+
+uint32_t compute_inner(tt::tt_metal::Shape shape, uint32_t dim) {
+    uint32_t num_inner = 1;
+    auto rank = shape.rank();
+
+    for (uint32_t i = rank - dim; i < rank; i++) {
+        auto size = shape[i];
+        if (is_hw_dim(i, rank)) {
+            size = tt::div_up(size, constants::TILE_WIDTH);
+        }
+        num_inner *= size;
+    }
+
+    return num_inner;
+}
+
+uint32_t compute_outer(tt::tt_metal::Shape shape, uint32_t dim) {
+    uint32_t num_outer = 1;
+    auto rank = shape.rank();
+
+    for (uint32_t i = 0; i < rank - dim; i++) {
+        auto size = shape[i];
+        if (is_hw_dim(i, rank)) {
+            size = tt::div_up(size, constants::TILE_WIDTH);
+        }
+        num_outer *= size;
+    }
+    return num_outer;
+}
+
+std::tuple<CoreRangeSet, CoreRangeSet, CoreRangeSet> add_core_offset(
+    CoreRangeSet all_cores,
+    CoreRangeSet core_group_1,
+    CoreRangeSet core_group_2,
+    uint32_t offset_x,
+    uint32_t offset_y) {
+    std::set<CoreRange> new_all_cores_set;
+    std::set<CoreRange> new_core_group_1_set;
+    std::set<CoreRange> new_core_group_2_set;
+
+    for (auto core : all_cores.ranges()) {
+        new_all_cores_set.insert(CoreRange(
+            {core.start_coord.x + offset_x, core.start_coord.y + offset_y},
+            {core.end_coord.x + offset_x, core.end_coord.y + offset_y}));
+    }
+
+    for (auto core : core_group_1.ranges()) {
+        new_core_group_1_set.insert(CoreRange(
+            {core.start_coord.x + offset_x, core.start_coord.y + offset_y},
+            {core.end_coord.x + offset_x, core.end_coord.y + offset_y}));
+    }
+
+    for (auto core : core_group_2.ranges()) {
+        new_core_group_2_set.insert(CoreRange(
+            {core.start_coord.x + offset_x, core.start_coord.y + offset_y},
+            {core.end_coord.x + offset_x, core.end_coord.y + offset_y}));
+    }
+
+    CoreRangeSet new_all_cores(new_all_cores_set);
+    CoreRangeSet new_core_group_1(new_core_group_1_set);
+    CoreRangeSet new_core_group_2(new_core_group_2_set);
+
+    return std::make_tuple(new_all_cores, new_core_group_1, new_core_group_2);
+}
+
+std::tuple<uint32_t, CoreRangeSet, CoreRangeSet, CoreRangeSet, uint32_t, uint32_t> split_work_to_cores(
+    CoreRange core_range, uint32_t units_to_divide) {
+    uint32_t core_w = core_range.end_coord.x - core_range.start_coord.x + 1;
+    uint32_t core_h = core_range.end_coord.y - core_range.start_coord.y + 1;
+    CoreCoord grid_size = {core_w, core_h};
+    auto
+        [num_cores,
+         all_cores_t,
+         core_group_1_t,
+         core_group_2_t,
+         num_tiles_per_core_group_1,
+         num_tiles_per_core_group_2] = tt::tt_metal::split_work_to_cores(grid_size, units_to_divide);
+
+    auto core_x_offset = core_range.start_coord.x;
+    auto core_y_offset = core_range.start_coord.y;
+
+    auto [all_cores, core_group_1, core_group_2] =
+        add_core_offset(all_cores_t, core_group_1_t, core_group_2_t, core_x_offset, core_y_offset);
+
+    {
+        auto iter = core_group_1.ranges();
+        for_each(
+            iter.begin(), iter.end(), [](CoreRange core) { log_debug(LogTest, "Use core_group_1 {}", core.str()); });
+    }
+    log_debug(LogTest, "num_tiles_per_core_group_1 {}", num_tiles_per_core_group_1);
+
+    {
+        auto iter = core_group_2.ranges();
+        for_each(
+            iter.begin(), iter.end(), [](CoreRange core) { log_debug(LogTest, "Use core_group_2 {}", core.str()); });
+    }
+    log_debug(LogTest, "num_tiles_per_core_group_2 {}", num_tiles_per_core_group_2);
+
+    return std::make_tuple(
+        num_cores, all_cores, core_group_1, core_group_2, num_tiles_per_core_group_1, num_tiles_per_core_group_2);
+}
+
+}  // namespace operations
+}  // namespace ttnn

--- a/ttnn/cpp/ttnn/operations/moreh_helper_functions.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh_helper_functions.cpp
@@ -1,4 +1,10 @@
 
+/*
+ * SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 #include "ttnn/cpp/ttnn/operations/moreh_helper_functions.hpp"
 
 #include "common/constants.hpp"

--- a/ttnn/cpp/ttnn/operations/moreh_helper_functions.hpp
+++ b/ttnn/cpp/ttnn/operations/moreh_helper_functions.hpp
@@ -1,0 +1,110 @@
+/*
+ * SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#pragma once
+
+#include <optional>
+#include <variant>
+#include <vector>
+
+#include "tt_metal/impl/buffers/circular_buffer_types.hpp"
+#include "tt_metal/impl/kernels/kernel_types.hpp"
+#include "ttnn/cpp/ttnn/tensor/tensor.hpp"
+
+namespace ttnn {
+namespace operations {
+
+inline bool is_dram(const Tensor &tensor) { return tensor.memory_config().buffer_type == BufferType::DRAM; }
+inline bool is_dram(const std::optional<const Tensor> tensor) {
+    return tensor.has_value() ? is_dram(tensor.value()) : true;
+}
+inline bool is_dram(const std::optional<std::reference_wrapper<const Tensor>> tensor) {
+    return tensor.has_value() ? is_dram(tensor->get()) : true;
+}
+inline bool is_dram(const Buffer *buffer) { return buffer->buffer_type() == BufferType::DRAM; }
+
+struct ComputeKernelArg {
+    const std::variant<CoreCoord, CoreRange, CoreRangeSet> &core_spec;
+    uint32_t num_tile_per_core_group;
+    const std::vector<uint32_t> &compile_args = {};
+};
+
+[[maybe_unused]] tt::tt_metal::KernelHandle CreateReadKernel(
+    Program &program,
+    const std::string &file_name,
+    const std::variant<CoreCoord, CoreRange, CoreRangeSet> &core_spec,
+    const std::vector<uint32_t> &compile_args = {},
+    std::map<string, string> defines = {});
+
+[[maybe_unused]] tt::tt_metal::KernelHandle CreateWriteKernel(
+    Program &program,
+    const std::string &file_name,
+    const std::variant<CoreCoord, CoreRange, CoreRangeSet> &core_spec,
+    const std::vector<uint32_t> &compile_args = {},
+    std::map<string, string> defines = {});
+
+struct CircularBufferArg {
+    uint32_t buffer_index = 0;
+    uint32_t num_tiles = 0;
+    tt::DataFormat data_format = tt::DataFormat::Invalid;
+    std::optional<std::variant<CoreCoord, CoreRange, CoreRangeSet>> core_range = std::nullopt;
+    tt::tt_metal::Buffer *buffer_ptr = nullptr;
+};
+
+[[maybe_unused]] std::vector<tt::tt_metal::KernelHandle> CreateComputeKernel(
+    Program &program,
+    const std::string &file_name,
+    std::vector<ComputeKernelArg> args,
+    std::map<std::string, std::string> defines = {},
+    MathFidelity math_fidelity = MathFidelity::HiFi4,
+    bool fp32_dest_acc_en = false,
+    bool math_approx_mode = false,
+    bool preserve_fp32_precision = false);
+
+[[maybe_unused]] tt::tt_metal::KernelHandle CreateComputeKernel(
+    Program &program,
+    const std::string &file_name,
+    ComputeKernelArg arg,
+    std::map<std::string, std::string> defines = {},
+    MathFidelity math_fidelity = MathFidelity::HiFi4,
+    bool fp32_dest_acc_en = false,
+    bool math_approx_mode = false,
+    bool preserve_fp32_precision = false);
+
+[[maybe_unused]] std::vector<CBHandle> CreateCircularBuffer(
+    Program &program,
+    const std::variant<CoreCoord, CoreRange, CoreRangeSet> &core_range,
+    tt::DataFormat data_format,
+    std::vector<CircularBufferArg> args);
+
+[[maybe_unused]] CBHandle CreateCircularBuffer(
+    Program &program,
+    const std::variant<CoreCoord, CoreRange, CoreRangeSet> &core_range,
+    tt::DataFormat data_format,
+    CircularBufferArg arg);
+
+void UpdateCircularBuffer(
+    Program &program,
+    tt::DataFormat data_format,
+    std::vector<CBHandle> cb_handles,
+    std::vector<CircularBufferArg> args);
+
+void UpdateCircularBuffer(Program &program, tt::DataFormat data_format, CBHandle cb_handle, CircularBufferArg arg);
+
+bool is_hw_dim(uint32_t dim, uint32_t rank);
+
+uint32_t compute_inner(tt::tt_metal::Shape shape, uint32_t dim);
+
+uint32_t compute_outer(tt::tt_metal::Shape shape, uint32_t dim);
+
+std::tuple<CoreRangeSet, CoreRangeSet, CoreRangeSet> add_core_offset(
+    CoreRangeSet all_cores, CoreRangeSet core_group_1, CoreRangeSet core_group_2, uint32_t offset_x, uint32_t offset_y);
+
+std::tuple<uint32_t, CoreRangeSet, CoreRangeSet, CoreRangeSet, uint32_t, uint32_t> split_work_to_cores(
+    CoreRange core_range, uint32_t units_to_divide);
+
+}  // namespace operations
+}  // namespace ttnn


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/10826

### Problem description
Moreh needs to support non-4D embeddings, fp32 destination accumulation, and int32 input tensors.
Additionally, the embedding implementation in tt does not include support for norm.

### What's changed
I am planning to implement a separate moreh_embedding.

### Checklist
- [x] Post commit CI passes
- [ ] Blackhole Post commit (if applicable)
- [ ] Model regression CI testing passes (if applicable)
- [x] New/Existing tests provide coverage for changes
