### PR TITLE
Fix ND hangs on metal Resnet in async mode

### DIFF
--- a/models/demos/resnet/tests/test_metal_resnet50_performant.py
+++ b/models/demos/resnet/tests/test_metal_resnet50_performant.py
@@ -33,6 +33,7 @@ from models.utility_functions import skip_for_wormhole_b0
     [tt_lib.tensor.MathFidelity.LoFi],
     ids=["LoFi"],
 )
+@pytest.mark.parametrize("enable_async_mode", [True, False], indirect=True)
 def test_run_resnet50_inference(
     device,
     use_program_cache,
@@ -41,6 +42,7 @@ def test_run_resnet50_inference(
     activations_dtype,
     math_fidelity,
     imagenet_sample_input,
+    enable_async_mode,
     model_location_generator,
 ):
     run_resnet50_inference(
@@ -73,7 +75,7 @@ def test_run_resnet50_inference(
     [tt_lib.tensor.MathFidelity.LoFi],
     ids=["LoFi"],
 )
-@pytest.mark.parametrize("enable_async", [True, False])
+@pytest.mark.parametrize("enable_async_mode", [True, False], indirect=True)
 def test_run_resnet50_trace_inference(
     device,
     use_program_cache,
@@ -82,11 +84,9 @@ def test_run_resnet50_trace_inference(
     activations_dtype,
     math_fidelity,
     imagenet_sample_input,
-    enable_async,
+    enable_async_mode,
     model_location_generator,
 ):
-    device.enable_async(enable_async)
-
     run_resnet50_inference(
         device,
         batch_size,
@@ -97,8 +97,6 @@ def test_run_resnet50_trace_inference(
         run_trace_model,
         model_location_generator,
     )
-
-    device.enable_async(False)
 
 
 @skip_for_wormhole_b0("This test is not supported on WHB0, please use the TTNN version.")
@@ -119,6 +117,7 @@ def test_run_resnet50_trace_inference(
     [tt_lib.tensor.MathFidelity.LoFi],
     ids=["LoFi"],
 )
+@pytest.mark.parametrize("enable_async_mode", [True, False], indirect=True)
 def test_run_resnet50_2cqs_inference(
     device,
     use_program_cache,
@@ -127,6 +126,7 @@ def test_run_resnet50_2cqs_inference(
     activations_dtype,
     math_fidelity,
     imagenet_sample_input,
+    enable_async_mode,
     model_location_generator,
 ):
     run_resnet50_inference(
@@ -161,7 +161,7 @@ def test_run_resnet50_2cqs_inference(
     [tt_lib.tensor.MathFidelity.LoFi],
     ids=["LoFi"],
 )
-@pytest.mark.parametrize("enable_async", [True, False])
+@pytest.mark.parametrize("enable_async_mode", [True, False], indirect=True)
 def test_run_resnet50_trace_2cqs_inference(
     device,
     use_program_cache,
@@ -170,11 +170,9 @@ def test_run_resnet50_trace_2cqs_inference(
     activations_dtype,
     math_fidelity,
     imagenet_sample_input,
-    enable_async,
+    enable_async_mode,
     model_location_generator,
 ):
-    device.enable_async(enable_async)
-
     run_resnet50_inference(
         device,
         batch_size,
@@ -185,5 +183,3 @@ def test_run_resnet50_trace_2cqs_inference(
         run_trace_2cq_model,
         model_location_generator,
     )
-
-    device.enable_async(False)

--- a/models/demos/resnet/tests/test_perf_resnet.py
+++ b/models/demos/resnet/tests/test_perf_resnet.py
@@ -366,11 +366,12 @@ def test_perf_bare_metal(
 @pytest.mark.parametrize("device_params", [{"l1_small_size": 32768, "trace_region_size": 1500000}], indirect=True)
 @pytest.mark.models_performance_bare_metal
 @pytest.mark.parametrize(
-    "batch_size, enable_async, expected_inference_time, expected_compile_time",
+    "batch_size, enable_async_mode, expected_inference_time, expected_compile_time",
     (
         (20, True, 0.0064, 19),
         (20, False, 0.0064, 19),
     ),
+    indirect=["enable_async_mode"],
 )
 def test_perf_trace_bare_metal(
     device,
@@ -379,11 +380,10 @@ def test_perf_trace_bare_metal(
     expected_inference_time,
     expected_compile_time,
     hf_cat_image_sample_input,
-    enable_async,
+    enable_async_mode,
     model_location_generator,
 ):
-    device.enable_async(enable_async)
-    mode = "async" if enable_async else "sync"
+    mode = "async" if enable_async_mode else "sync"
     run_perf_resnet(
         batch_size,
         expected_inference_time,
@@ -393,7 +393,6 @@ def test_perf_trace_bare_metal(
         f"resnet50_trace_{mode}",
         model_location_generator,
     )
-    device.enable_async(False)
 
 
 @skip_for_wormhole_b0(reason_str="Not tested on single WH")

--- a/ttnn/cpp/ttnn/operations/pool/downsample/downsample.hpp
+++ b/ttnn/cpp/ttnn/operations/pool/downsample/downsample.hpp
@@ -18,5 +18,5 @@ struct ExecuteDownsample {
 }  // namespace operations
 
 constexpr auto downsample =
-    ttnn::register_operation<"ttnn::downsample", ttnn::operations::downsample::ExecuteDownsample>();
+    ttnn::register_operation_with_auto_launch_op<"ttnn::downsample", ttnn::operations::downsample::ExecuteDownsample>();
 }  // namespace ttnn


### PR DESCRIPTION
### Problem description
Saw ND hangs on async mode tests for metal Resnet on CI.

### What's changed
Downsample op had launch_op removed so op no longer runs on worker thread in async mode. This adds launch_op usage back.

### Checklist
- [x] Post commit CI passes
- [ ] Blackhole Post commit (if applicable)
- [x] Model regression CI testing passes (if applicable)
- [x] New/Existing tests provide coverage for changes
