### PR TITLE
#11075: Support shard/concat to/from 2d-mesh + enhance mapping to device-mesh

### DIFF
--- a/tt_metal/impl/device/device_mesh.cpp
+++ b/tt_metal/impl/device/device_mesh.cpp
@@ -91,7 +91,7 @@ std::vector<Device*> DeviceMesh::get_devices() const
 
 Device* DeviceMesh::get_device(int row_idx, int col_idx) const {
     if (not is_galaxy_) {
-        TT_THROW("#10419: Current device mesh does not support indexing by row or col indices.");
+        TT_THROW("Non-galaxy device mesh does not currently support indexing over rows and columns of a logical 2D mesh.");
     }
 
     TT_FATAL(
@@ -105,14 +105,14 @@ Device* DeviceMesh::get_device(int row_idx, int col_idx) const {
 
 std::vector<Device*> DeviceMesh::get_devices_on_row(int row_idx) const {
     if (not is_galaxy_) {
-        TT_THROW("#10419: Current device mesh does not support indexing by row or col indices.");
+        TT_THROW("Non-galaxy device mesh does not currently support indexing over rows and columns of a logical 2D mesh.");
     }
     return this->view->get_devices_on_row(row_idx);
 }
 
 std::vector<Device*> DeviceMesh::get_devices_on_column(int col_idx) const {
     if (not is_galaxy_) {
-        TT_THROW("#10419: Current device mesh does not support indexing by row or col indices.");
+        TT_THROW("Non-galaxy device mesh does not currently support indexing over rows and columns of a logical 2D mesh.");
     }
     return this->view->get_devices_on_column(col_idx);
 }
@@ -158,20 +158,18 @@ DeviceGrid DeviceMesh::shape() const
     return this->device_grid;
 }
 
-std::optional<Coordinate> DeviceMesh::find_device(int device_id) const {
-    auto it = std::find_if(mesh_devices.begin(), mesh_devices.end(),
-                           [device_id](const auto& pair) { return pair.first == device_id; });
-    if (it != mesh_devices.end()) {
-        int index = std::distance(mesh_devices.begin(), it);
-        return Coordinate{static_cast<int>(index / num_cols()), static_cast<int>(index % num_cols())};
-    }
-    return std::nullopt;
-}
-
 void DeviceMesh::close_devices() {
     tt::tt_metal::detail::CloseDevices(managed_devices);
     mesh_devices.clear();
     managed_devices.clear();
+}
+
+const DeviceMeshView* DeviceMesh::get_view() const {
+    return this->view.get();
+}
+
+DeviceMeshView* DeviceMesh::get_view() {
+    return this->view.get();
 }
 
 bool validate_worker_modes(const std::vector<Device*>& workers) {

--- a/tt_metal/impl/device/device_mesh.hpp
+++ b/tt_metal/impl/device/device_mesh.hpp
@@ -14,8 +14,8 @@
 
 namespace tt::tt_metal {
 
-using DeviceGrid = std::pair<int, int>;
 using DeviceIds = std::vector<int>;
+class DeviceMeshView;
 
 class DeviceMesh
 {
@@ -40,8 +40,6 @@ public:
     std::vector<Device *> get_devices_on_row(int row_idx) const;
     std::vector<Device *> get_devices_on_column(int col_idx) const;
 
-    std::optional<Coordinate> find_device(int device_id) const;
-
     const DeviceIds get_device_ids() const;
 
     int num_devices() const;
@@ -56,6 +54,8 @@ public:
     tt::ARCH arch() const;
 
     void close_devices();
+    const DeviceMeshView* get_view() const;
+    DeviceMeshView* get_view();
 
    private:
     bool is_galaxy_;

--- a/tt_metal/impl/device/device_mesh_view.cpp
+++ b/tt_metal/impl/device/device_mesh_view.cpp
@@ -36,27 +36,6 @@ DeviceMeshView::DeviceMeshView(const DeviceMesh& mesh, Coordinate top_left, Coor
     validate_coordinates();
 }
 
-DeviceMeshView::DeviceMeshView(const DeviceMesh& global_mesh, const std::vector<device_pointer>& devices)
-    : devices_(devices) {
-    int min_row = std::numeric_limits<int>::max(), min_col = std::numeric_limits<int>::max();
-    int max_row = std::numeric_limits<int>::min(), max_col = std::numeric_limits<int>::min();
-
-    for (const auto& device : devices) {
-        if (auto coord = global_mesh.find_device(device->id())) {
-            device_coordinates_[device->id()] = *coord;
-            min_row = std::min(min_row, coord->row);
-            min_col = std::min(min_col, coord->col);
-            max_row = std::max(max_row, coord->row);
-            max_col = std::max(max_col, coord->col);
-        } else {
-            throw std::runtime_error("Device not found in global mesh");
-        }
-    }
-
-    top_left_ = {min_row, min_col};
-    bottom_right_ = {max_row, max_col};
-}
-
 DeviceMeshView::DeviceMeshView(std::vector<device_pointer> devices, CoordinateMapper mapper)
     : devices_(std::move(devices)) {
     initialize_from_devices(devices_, std::move(mapper));
@@ -78,6 +57,26 @@ DeviceMeshView::const_device_pointer DeviceMeshView::get_device(int row, int col
 
 const std::vector<DeviceMeshView::device_pointer>& DeviceMeshView::get_devices() const {
     return devices_;
+}
+
+DeviceMeshView::DeviceView DeviceMeshView::get_devices(const Coordinate& start, const Coordinate& end) {
+    if (start.row > end.row || start.col > end.col) {
+        log_fatal("Invalid coordinates: start {} must be less than or equal to end {}", start, end);
+    }
+
+    DeviceView devices_in_region;
+    for (int row = start.row; row <= end.row; ++row) {
+        for (int col = start.col; col <= end.col; ++col) {
+            if (auto device = get_device(row, col)) {
+                devices_in_region.push_back(device);
+            }
+        }
+    }
+    return devices_in_region;
+}
+
+DeviceMeshView::DeviceView DeviceMeshView::get_devices(const DeviceGrid& shape) {
+    return get_devices({0, 0}, {shape.first - 1, shape.second - 1});
 }
 
 std::vector<DeviceMeshView::device_pointer> DeviceMeshView::get_devices_on_row(int row) const {
@@ -159,17 +158,23 @@ bool DeviceMeshView::operator==(const DeviceMeshView& other) const {
            bottom_right_ == other.bottom_right_;
 }
 
-std::optional<Coordinate> DeviceMeshView::find_device(int device_id) const {
+Coordinate DeviceMeshView::find_device(chip_id_t device_id) const {
     auto it = device_coordinates_.find(device_id);
     if (it != device_coordinates_.end()) {
         return it->second;
     }
-    return std::nullopt;
+    TT_FATAL(false, fmt::format("Device not found in mesh: {}", device_id));
+}
+
+chip_id_t DeviceMeshView::find_device_id(const Coordinate& coord) const {
+    TT_FATAL(coord.row >= 0 and coord.row < num_rows() and coord.col >= 0 and coord.col < num_cols(),
+        fmt::format("Invalid coordinate: "));
+    return this->devices_.at(coord.row * num_cols() + coord.col)->id();
 }
 
 void DeviceMeshView::initialize_from_devices(const std::vector<device_pointer>& devices, CoordinateMapper mapper) {
-    int min_row = std::numeric_limits<int>::max(), min_col = std::numeric_limits<int>::max();
-    int max_row = std::numeric_limits<int>::min(), max_col = std::numeric_limits<int>::min();
+    std::size_t min_row = std::numeric_limits<std::size_t>::max(), min_col = std::numeric_limits<std::size_t>::max();
+    std::size_t max_row = std::numeric_limits<std::size_t>::min(), max_col = std::numeric_limits<std::size_t>::min();
 
     for (const auto& device : devices) {
         auto coord = mapper(device->id());

--- a/ttnn/cpp/ttnn/tensor/types.cpp
+++ b/ttnn/cpp/ttnn/tensor/types.cpp
@@ -12,6 +12,9 @@ namespace tt_metal {
 static DistributedTensorConfig create_shard_distributed_tensor_config(const std::unordered_map<std::string, std::string>& metadata) {
     return ShardTensor(std::stoi(metadata.at("shard_dim")));
 }
+static DistributedTensorConfig create_shard_2d_distributed_tensor_config(const std::unordered_map<std::string, std::string>& metadata) {
+    return ShardTensor2D(ShardMesh(std::stoi(metadata.at("mesh_shape_y")), std::stoi(metadata.at("mesh_shape_x"))));
+}
 static DistributedTensorConfig create_replicate_distributed_tensor_config(const std::unordered_map<std::string, std::string>& metadata) {
     if (auto it = metadata.find("replication_factor"); it != metadata.end()) {
         return ReplicateTensor(std::stoi(it->second));
@@ -24,7 +27,8 @@ DistributedTensorConfig get_distributed_tensor_config(const std::unordered_map<s
         const std::string& strategy = it->second;
         if (strategy == "shard") {
             return create_shard_distributed_tensor_config(metadata);
-
+        } else if (strategy == "shard_2d") {
+            return create_shard_2d_distributed_tensor_config(metadata);
         } else if (strategy == "replicate") {
             return create_replicate_distributed_tensor_config(metadata);
         }
@@ -177,6 +181,9 @@ bool operator==(const AllGatherTensor&, const AllGatherTensor&) {
 }
 bool operator==(const ShardTensor& lhs, const ShardTensor& rhs) {
     return lhs.shard_dimension == rhs.shard_dimension; // Equal if they have the same shard_dimension.
+}
+bool operator==(const ShardTensor2D& lhs, const ShardTensor2D& rhs) {
+    return lhs.shard_mesh == rhs.shard_mesh; // Equal if they have the same shard_mesh.
 }
 
 bool operator==(const Shape& shape_a, const Shape& shape_b) {

--- a/ttnn/cpp/ttnn/tensor/types.hpp
+++ b/ttnn/cpp/ttnn/tensor/types.hpp
@@ -72,8 +72,15 @@ struct ShardTensor {
 };
 bool operator==(const ShardTensor& lhs, const ShardTensor& rhs);
 
+using ShardMesh = std::pair<std::uint16_t, std::uint16_t>; // (y,x)
+struct ShardTensor2D {
+    ShardMesh shard_mesh; // logic 2D grid that defines the mapping of shards to devices
+    ShardTensor2D(ShardMesh mesh) : shard_mesh(std::move(mesh)) {}
+};
+bool operator==(const ShardTensor2D& lhs, const ShardTensor2D& rhs);
+
 // DistributedTensorConfig is a variant of different ways in which a tensor can be distributed across devices.
-using DistributedTensorConfig = std::variant<ReplicateTensor, ShardTensor, AllGatherTensor>;
+using DistributedTensorConfig = std::variant<ReplicateTensor, ShardTensor, ShardTensor2D, AllGatherTensor>;
 DistributedTensorConfig get_distributed_tensor_config(const std::unordered_map<std::string, std::string>& metadata);
 
 

--- a/ttnn/ttnn/__init__.py
+++ b/ttnn/ttnn/__init__.py
@@ -167,6 +167,7 @@ from ttnn.multi_device import (
     ConcatMeshToTensor,
     ListMeshToTensor,
     visualize_device_mesh,
+    ConcatMesh2dToTensor,
 )
 
 from ttnn.core import (


### PR DESCRIPTION
### Ticket
[Link to Github Issue
](https://github.com/tenstorrent/tt-metal/issues/11075)

### Problem description
1. Align on TTNN supported ShardTensor2dMesh and ConcatMesh2dToTensor with documented usage that should be used by the model-team
2. We did not support non-row major distribution of those shards onto the device-mesh, this now supports that


### What's changed

#### 1. Support for ShardTensor2dMesh and ConcatMesh2dToTensor
- We have custom model implementations in `llama` files that have now been ported over to use `ttnn.ShardTensor2dMesh` and `ttnn.ConcatMesh2dToTensor

#### 2. Enable support for mapping shards as column-major
- There was a baked-in assumption about the order of how those device-shards get distributed onto the mesh. They were *always* row-major (see https://github.com/tenstorrent/tt-metal/issues/11075) for the unsupported case.

### Checklist
- [x] Post commit CI passes
- [x] Blackhole Post commit (if applicable)
- [x] Model regression CI testing passes (if applicable)
- [x] New/Existing tests provide coverage for changes
