### PR TITLE
#10691: Upload benchmark CSVs from single-card demos

### DIFF
--- a/.github/workflows/single-card-demo-tests.yaml
+++ b/.github/workflows/single-card-demo-tests.yaml
@@ -1,4 +1,4 @@
-name: "[Single-card] Demo tests"
+name: "(Single-card) Demo tests"
 
 on:
   workflow_dispatch:

--- a/.github/workflows/single-card-demo-tests.yaml
+++ b/.github/workflows/single-card-demo-tests.yaml
@@ -63,3 +63,18 @@ jobs:
           cd $TT_METAL_HOME
           export PYTHONPATH=$TT_METAL_HOME
           ${{ matrix.test-group.cmd }}
+      - name: Save environment data
+        if: ${{ success() }}
+        env:
+          PYTHONPATH: ${{ github.workspace }}
+        run: |
+          source ${{ github.workspace }}/python_env/bin/activate
+          python3 .github/scripts/data_analysis/create_benchmark_environment_csv.py
+      - name: Upload benchmark data
+        if: ${{ success() }}
+        uses: ./.github/actions/upload-data-via-sftp
+        with:
+          ssh-private-key: ${{ secrets.SFTP_BENCHMARK_WRITER_KEY }}
+          sftp-batchfile: .github/actions/upload-data-via-sftp/benchmark_data_batchfile.txt
+          username: ${{ secrets.SFTP_BENCHMARK_WRITER_USERNAME }}
+          hostname: ${{ secrets.SFTP_BENCHMARK_WRITER_HOSTNAME }}


### PR DESCRIPTION
### Ticket

#10691 

### Problem description

We want to upload benchmarks from single-card runs.

### What's changed

Add environment save + upload steps to single card.

### Checklist
- [ ] Post commit CI passes
- [ ] Blackhole Post commit (if applicable)
- [ ] Model regression CI testing passes (if applicable)
- [ ] New/Existing tests provide coverage for changes
