### PR TITLE
#4984: Move eth l1_barrier

### DIFF
--- a/tt_metal/hw/inc/blackhole/dev_mem_map.h
+++ b/tt_metal/hw/inc/blackhole/dev_mem_map.h
@@ -29,7 +29,8 @@
 #define MEM_L1_SIZE (1464 * 1024)
 
 #define MEM_ETH_BASE 0x0
-#define MEM_ETH_SIZE (256 * 1024)
+// -32 for ETH barrier, see comment in eth_l1_address_map
+#define MEM_ETH_SIZE (256 * 1024 - 32)
 
 #define MEM_LOCAL_BASE 0xFFB00000
 #define MEM_BRISC_LOCAL_SIZE (8 * 1024)

--- a/tt_metal/hw/inc/blackhole/eth_l1_address_map.h
+++ b/tt_metal/hw/inc/blackhole/eth_l1_address_map.h
@@ -13,8 +13,13 @@ namespace eth_l1_mem {
 
 struct address_map {
 
-  static constexpr std::int32_t MAX_SIZE = 256 * 1024;
-  static constexpr std::int32_t MAX_L1_LOADING_SIZE = 1 * 256 * 1024;
+  // UMD doesn't distinguish between active/idle eth cores
+  // UMD needs space for l1_barrier
+  // active/idle eth cores have very different mem maps
+  // Reserve some space at the end of l1 for l1_barrier
+  static constexpr std::int32_t ERISC_BARRIER_SIZE = 32;
+  static constexpr std::int32_t MAX_SIZE = 256 * 1024 - ERISC_BARRIER_SIZE;
+  static constexpr std::int32_t MAX_L1_LOADING_SIZE = 1 * 256 * 1024 - ERISC_BARRIER_SIZE;
 
   // Sizes
   static constexpr std::int32_t FIRMWARE_SIZE = 32 * 1024;
@@ -39,12 +44,11 @@ struct address_map {
   //    -  53 * 1024 eth app reserved buffer space
   //    - 106 * 1024 L1 unreserved buffer space
   static constexpr std::int32_t MAX_NUM_CONCURRENT_TRANSACTIONS = 8;
-  static constexpr std::int32_t ERISC_BARRIER_SIZE = 32;
   static constexpr std::int32_t ERISC_APP_ROUTING_INFO_SIZE = 48;
   static constexpr std::int32_t ERISC_APP_SYNC_INFO_SIZE = 160 + 16 * MAX_NUM_CONCURRENT_TRANSACTIONS;
 
-  static constexpr std::int32_t ERISC_BARRIER_BASE = TILE_HEADER_BUFFER_BASE;
-  static constexpr std::int32_t ERISC_APP_ROUTING_INFO_BASE = ERISC_BARRIER_BASE + ERISC_BARRIER_SIZE;
+  static constexpr std::int32_t ERISC_BARRIER_BASE = MAX_SIZE;
+  static constexpr std::int32_t ERISC_APP_ROUTING_INFO_BASE = TILE_HEADER_BUFFER_BASE;
   static constexpr std::int32_t ERISC_APP_SYNC_INFO_BASE = ERISC_APP_ROUTING_INFO_BASE + ERISC_APP_ROUTING_INFO_SIZE;
   static constexpr std::uint32_t SEMAPHORE_BASE = ERISC_APP_SYNC_INFO_BASE + ERISC_APP_SYNC_INFO_SIZE;
 

--- a/tt_metal/hw/inc/wormhole/dev_mem_map.h
+++ b/tt_metal/hw/inc/wormhole/dev_mem_map.h
@@ -29,7 +29,8 @@
 #define MEM_L1_SIZE (1464 * 1024)
 
 #define MEM_ETH_BASE 0x0
-#define MEM_ETH_SIZE (256 * 1024)
+// -32 for ETH barrier, see comment in eth_l1_address_map
+#define MEM_ETH_SIZE (256 * 1024 - 32)
 
 #define MEM_LOCAL_BASE 0xFFB00000
 #define MEM_BRISC_LOCAL_SIZE (4 * 1024)

--- a/tt_metal/hw/inc/wormhole/eth_l1_address_map.h
+++ b/tt_metal/hw/inc/wormhole/eth_l1_address_map.h
@@ -13,8 +13,13 @@ namespace eth_l1_mem {
 
 struct address_map {
 
-  static constexpr std::int32_t MAX_SIZE = 256 * 1024;
-  static constexpr std::int32_t MAX_L1_LOADING_SIZE = 1 * 256 * 1024;
+  // UMD doesn't distinguish between active/idle eth cores
+  // UMD needs space for l1_barrier
+  // active/idle eth cores have very different mem maps
+  // Reserve some space at the end of l1 for l1_barrier
+  static constexpr std::int32_t ERISC_BARRIER_SIZE = 32;
+  static constexpr std::int32_t MAX_SIZE = 256 * 1024 - ERISC_BARRIER_SIZE;
+  static constexpr std::int32_t MAX_L1_LOADING_SIZE = 1 * 256 * 1024 - ERISC_BARRIER_SIZE;
 
   // Sizes
   static constexpr std::int32_t FIRMWARE_SIZE = 32 * 1024;
@@ -39,12 +44,11 @@ struct address_map {
   //    -  53 * 1024 eth app reserved buffer space
   //    - 106 * 1024 L1 unreserved buffer space
   static constexpr std::int32_t MAX_NUM_CONCURRENT_TRANSACTIONS = 8;
-  static constexpr std::int32_t ERISC_BARRIER_SIZE = 32;
   static constexpr std::int32_t ERISC_APP_ROUTING_INFO_SIZE = 48;
   static constexpr std::int32_t ERISC_APP_SYNC_INFO_SIZE = 160 + 16 * MAX_NUM_CONCURRENT_TRANSACTIONS;
 
-  static constexpr std::int32_t ERISC_BARRIER_BASE = TILE_HEADER_BUFFER_BASE;
-  static constexpr std::int32_t ERISC_APP_ROUTING_INFO_BASE = ERISC_BARRIER_BASE + ERISC_BARRIER_SIZE;
+  static constexpr std::int32_t ERISC_BARRIER_BASE = MAX_SIZE;
+  static constexpr std::int32_t ERISC_APP_ROUTING_INFO_BASE = TILE_HEADER_BUFFER_BASE;
   static constexpr std::int32_t ERISC_APP_SYNC_INFO_BASE = ERISC_APP_ROUTING_INFO_BASE + ERISC_APP_ROUTING_INFO_SIZE;
   static constexpr std::uint32_t SEMAPHORE_BASE = ERISC_APP_SYNC_INFO_BASE + ERISC_APP_SYNC_INFO_SIZE;
 


### PR DESCRIPTION
UMD doesn't distinguish between idle/active eth cores The l1_barrier for idle eth cores was invalid
Short term fix: move the barrier to the end of the memory range

### Ticket
#4984 

### Problem description
See above

### What's changed
Moved the l1_barrier to the end of L1 on eth cores

### Checklist
- [ ] Post commit CI passes
- [ ] Blackhole Post commit (if applicable)
- [ ] Model regression CI testing passes (if applicable)
- [ ] New/Existing tests provide coverage for changes
