### PR TITLE
#11224: Add details about serialization and validation fallback

### DIFF
--- a/tests/sweep_framework/parameter_generator.py
+++ b/tests/sweep_framework/parameter_generator.py
@@ -56,6 +56,7 @@ def export_suite_vectors(module_name, suite_name, vectors):
     client = Elasticsearch(ELASTIC_CONNECTION_STRING, basic_auth=(ELASTIC_USERNAME, ELASTIC_PASSWORD))
 
     index_name = VECTOR_INDEX_PREFIX + module_name
+    warnings = []
 
     try:
         response = client.search(
@@ -82,7 +83,7 @@ def export_suite_vectors(module_name, suite_name, vectors):
     for i in range(len(vectors)):
         vector = dict()
         for elem in vectors[i].keys():
-            vector[elem] = serialize(vectors[i][elem])
+            vector[elem] = serialize(vectors[i][elem], warnings)
         id = hashlib.sha224(str(vectors[i]).encode("utf-8")).hexdigest()
         new_vector_ids.add(id)
         vector["timestamp"] = current_time
@@ -95,7 +96,7 @@ def export_suite_vectors(module_name, suite_name, vectors):
         return
     else:
         print(
-            f"SWEEPS: New vectors found for module {module_name}, suite {suite_name}. Archiving old vectors and saving new suite."
+            f"SWEEPS: New vectors found for module {module_name}, suite {suite_name}. Archiving old vectors and saving new suite. This step may take several minutes."
         )
         for old_vector_id in old_vector_ids:
             client.update(index=index_name, id=old_vector_id, doc={"status.keyword": str(VectorStatus.ARCHIVED)})
@@ -117,6 +118,21 @@ def generate_tests(module_name):
         generate_vectors(module_name)
 
 
+def clean_module(module_name):
+    client = Elasticsearch(ELASTIC_CONNECTION_STRING, basic_auth=(ELASTIC_USERNAME, ELASTIC_PASSWORD))
+    vector_index = VECTOR_INDEX_PREFIX + module_name
+
+    if not client.indices.exists(index=vector_index):
+        print(f"SWEEPS: Could not clean vectors for module {module_name} as there is no corresponding index.")
+        exit(1)
+
+    update_script = {"source": f"ctx._source.status = '{str(VectorStatus.ARCHIVED)}'", "lang": "painless"}
+    client.update_by_query(index=vector_index, query={"match_all": {}}, script=update_script, refresh=True)
+    print(f"SWEEPS: Marked all vectors in index {vector_index} as archived. Proceeding with generation...")
+
+    client.close()
+
+
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(
         prog="Sweep Test Vector Generator",
@@ -124,6 +140,13 @@ if __name__ == "__main__":
     )
 
     parser.add_argument("--module-name", required=False, help="Test Module Name, or all tests if omitted")
+    parser.add_argument(
+        "--clean",
+        action="store_true",
+        default=False,
+        required=False,
+        help="Must be set with module_name. Setting this flag will mark ALL old vectors for an sweep as Archived, and generate the new set. Use this if you make a mistake when generating your vectors and want to refresh to the current state of your op test file.",
+    )
     parser.add_argument(
         "--elastic",
         required=False,
@@ -135,5 +158,11 @@ if __name__ == "__main__":
 
     global ELASTIC_CONNECTION_STRING
     ELASTIC_CONNECTION_STRING = args.elastic
+
+    if args.clean and not args.module_name:
+        print("SWEEPS: The clean flag must be set in conjunction with a module name.")
+        exit(1)
+    elif args.clean:
+        clean_module(args.module_name)
 
     generate_tests(args.module_name)

--- a/tests/sweep_framework/serialize.py
+++ b/tests/sweep_framework/serialize.py
@@ -7,9 +7,14 @@ import tt_lib
 from statuses import VectorValidity
 
 
-def serialize(object):
+def serialize(object, warnings=[]):
     if "to_json" in dir(object):
         return {"type": str(type(object)).split("'")[1], "data": object.to_json()}
+    elif "pybind" in str(type(type(object))) and type(object) and type(object) not in warnings:
+        print(
+            f"SWEEPS: Warning: pybinded ttnn class detected without a to_json method. Your type may need to pybind the to_json and from_json methods in C++, see the FAQ in the sweeps README for instructions. The type is {type(object)}. You can ignore this if this is an enum type."
+        )
+        warnings.append(type(object))
     else:
         return str(object)
 


### PR DESCRIPTION
#11224: Add details about serialization and parameter limitations in README, and add validation warnings. Add a way to archive incorrect vectors

### Ticket
#11224 

### Problem description
1. There is no way to clear/cleanup vectors created by mistake, and clear garbage data.
2. There is no information on what types of serialization works, warnings when the serialization may fail, and no documentation on the limitations of setting test parameters.

### What's changed
1. Add warnings to logging info that tells developers when their types may need to pybind the to_json and from_json methods.
2. Add information regarding this process to the README, as well as the limitations to creating their parameter sets
3. Add a `--clean` flag to the `parameter_generator.py` tool to allow for cleanup when these mistake do occur. This flag will archive all existing vectors and regenerate new test vectors based on the updated state of the op test file. 

### Checklist
- [x] Post commit CI passes
- [ ] Blackhole Post commit (if applicable)
- [ ] Model regression CI testing passes (if applicable)
- [ ] New/Existing tests provide coverage for changes
