### PR TITLE
#10755: visualize tensor that is mapped onto device-mesh

### DIFF
--- a/tests/ttnn/multichip_unit_tests/test_multidevice_TG.py
+++ b/tests/ttnn/multichip_unit_tests/test_multidevice_TG.py
@@ -1365,3 +1365,27 @@ def test_shard_and_concat_2d_non_divisible(device_mesh):
     )
 
     assert torch.allclose(read_back_tensor, full_tensor, atol=1e-6)
+
+
+@pytest.mark.parametrize("device_mesh", [pytest.param((8, 4), id="8x4_grid")], indirect=True)
+def test_visualize_device_mesh_with_tensor_row_major(device_mesh):
+    rows, cols, tile_size = 4, 4, 32
+    full_tensor = torch.rand((1, 1, tile_size * rows, tile_size * cols), dtype=torch.bfloat16)
+
+    ttnn_tensor = ttnn.from_torch(
+        full_tensor, mesh_mapper=ShardTensor2dMesh(device_mesh, mesh_shape=(rows, cols), dims=(-2, -1))
+    )
+    ttnn_tensor = ttnn.to_device(ttnn_tensor, device_mesh)
+    ttnn.visualize_device_mesh(device_mesh, tensor=ttnn_tensor)
+
+
+@pytest.mark.parametrize("device_mesh", [pytest.param((8, 4), id="8x4_grid")], indirect=True)
+def test_visualize_device_mesh_with_tensor_col_major(device_mesh):
+    rows, cols, tile_size = 8, 2, 32
+    full_tensor = torch.rand((1, 1, tile_size * rows, tile_size * cols), dtype=torch.bfloat16)
+
+    ttnn_tensor = ttnn.from_torch(
+        full_tensor, mesh_mapper=ShardTensor2dMesh(device_mesh, mesh_shape=(rows, cols), dims=(-2, -1))
+    )
+    ttnn_tensor = ttnn.to_device(ttnn_tensor, device_mesh)
+    ttnn.visualize_device_mesh(device_mesh, tensor=ttnn_tensor)

--- a/ttnn/ttnn/multi_device.py
+++ b/ttnn/ttnn/multi_device.py
@@ -4,7 +4,7 @@
 
 import contextlib
 
-from typing import List, Dict, Optional, Callable, Tuple
+from typing import List, Dict, Optional, Callable, Tuple, Optional, Callable
 
 import ttnn
 
@@ -18,14 +18,24 @@ DeviceMesh = ttnn._ttnn.multi_device.DeviceMesh
 DeviceMesh.core_grid = property(get_device_mesh_core_grid)
 
 
-def visualize_device_mesh(device_mesh):
+def _get_rich_table(
+    device_mesh: "ttnn.DeviceMesh", style_cell: Optional[Callable] = None, annotate_cell: Optional[Callable] = None
+):
     from rich import box, padding
     from rich.align import Align
-    from rich.console import Console
     from rich.table import Table
+    from rich.text import Text
+    from loguru import logger
+
+    CELL_SIZE = 30
 
     # Setup rich table
-    rows, cols = device_mesh.shape
+    try:
+        rows, cols = device_mesh.shape
+    except AttributeError as e:
+        logger.error("Error getting device mesh shape: {}.", e)
+        rows, cols = 0, 0
+
     mesh_table = Table(
         title=f"DeviceMesh(rows={rows}, cols={cols}):",
         show_header=False,
@@ -37,18 +47,68 @@ def visualize_device_mesh(device_mesh):
     )
 
     for _ in range(cols):
-        mesh_table.add_column(justify="center", vertical="middle")
+        mesh_table.add_column(justify="center", vertical="middle", width=CELL_SIZE)
 
     # Populate table
     for row_idx in range(rows):
         row_cells = []
         for col_idx in range(cols):
-            device = device_mesh.get_device(row_idx, col_idx)
-            cell_content = f"Dev. ID: {device.id()}\n ({row_idx}, {col_idx})" if device else "Empty"
-            cell = padding.Padding(Align(cell_content, "center", vertical="middle"), (0, 0))
+            try:
+                device = device_mesh.get_device(row_idx, col_idx)
+            except Exception as e:
+                logger.error("Error fetching device from DeviceMesh at row {}, col {}: {}.", row_idx, col_idx, e)
+                device = None
+
+            try:
+                device_id = f"Dev. ID: {device.id()}" if device else "Empty"
+                coords = f"({row_idx}, {col_idx})"
+                annotation = annotate_cell(device) if annotate_cell and device else ""
+
+                cell_content = Text(f"{device_id}\n{coords}\n{annotation}", justify="center")
+                cell_content.truncate(CELL_SIZE * 3, overflow="ellipsis")  # 3 lines max
+            except AttributeError as e:
+                logger.error("Error formatting cell content at row {}, col {}: {}.", row_idx, col_idx, e)
+                cell_content = Text("Error", justify="center")
+
+            cell_style = style_cell(device) if style_cell and device else None
+            cell = Align(cell_content, "center", vertical="middle")
+            if cell_style:
+                cell.style = cell_style
             row_cells.append(cell)
         mesh_table.add_row(*row_cells)
+    return mesh_table
 
+
+def visualize_device_mesh(device_mesh: "ttnn.DeviceMesh", tensor: "ttnn.Tensor" = None):
+    """
+    Visualize the device mesh and the given tensor (if specified).
+    """
+    from rich.console import Console
+    from rich.style import Style
+    from loguru import logger
+
+    style_cell, annotate_cell = None, None
+    if tensor is not None:
+        try:
+            mapped_devices = set(device.id() for device in tensor.devices())
+        except Exception as e:
+            logger.error(f"Error getting devices for tensor: {e}")
+            mapped_devices = set()
+
+        def color_mapped_devices(device):
+            try:
+                return Style(bgcolor="dark_green") if device.id() in mapped_devices else None
+            except Exception as e:
+                logger.error(f"Error getting device ID: {e}")
+                return None
+
+        def annotate_with_tensor_shape(device):
+            return f"{tensor.shape}" if device.id() in mapped_devices else ""
+
+        style_cell = color_mapped_devices
+        annotate_cell = annotate_with_tensor_shape
+
+    mesh_table = _get_rich_table(device_mesh, style_cell=style_cell, annotate_cell=annotate_cell)
     Console().print(mesh_table)
 
 


### PR DESCRIPTION
### Ticket
[Link to Github Issue
](https://github.com/tenstorrent/tt-metal/issues/10755)

### Problem description
We want to give users a way to visualize the tensor mapped onto the device-mesh and see whether their sharding was done correctly.

### What's changed

We now provide an API for a user to visualize an optionally specified tensor on device-mesh in the terminal:

```
ttnn.visualize_device_mesh(device_mesh, tensor=ttnn_tensor)
```

<img width="779" alt="Screen Shot 2024-08-08 at 12 56 33 PM" src="https://github.com/user-attachments/assets/67744a07-05da-4f2f-ac93-9d97a8a9f8f1">


### Checklist
- [x] Post commit CI passes
- [x] Blackhole Post commit (if applicable)
- [x] Model regression CI testing passes (if applicable)
- [x] New/Existing tests provide coverage for changes
