### PR TITLE
#11228: Change all queries of the ES database to use the keyword field to prevent fuzzy matching

### DIFF
--- a/tests/sweep_framework/parameter_generator.py
+++ b/tests/sweep_framework/parameter_generator.py
@@ -62,7 +62,10 @@ def export_suite_vectors(module_name, suite_name, vectors):
             index=index_name,
             query={
                 "bool": {
-                    "must": [{"match": {"status": str(VectorStatus.CURRENT)}}, {"match": {"suite_name": suite_name}}]
+                    "must": [
+                        {"match": {"status": str(VectorStatus.CURRENT)}},
+                        {"match": {"suite_name.keyword": suite_name}},
+                    ]
                 }
             },
             size=10000,
@@ -95,7 +98,7 @@ def export_suite_vectors(module_name, suite_name, vectors):
             f"SWEEPS: New vectors found for module {module_name}, suite {suite_name}. Archiving old vectors and saving new suite."
         )
         for old_vector_id in old_vector_ids:
-            client.update(index=index_name, id=old_vector_id, doc={"status": str(VectorStatus.ARCHIVED)})
+            client.update(index=index_name, id=old_vector_id, doc={"status.keyword": str(VectorStatus.ARCHIVED)})
         for new_vector_id in serialized_vectors.keys():
             client.index(index=index_name, id=new_vector_id, body=serialized_vectors[new_vector_id])
         print(f"SWEEPS: Generated {len(serialized_vectors)} test vectors for suite {suite_name}.")

--- a/tests/sweep_framework/query.py
+++ b/tests/sweep_framework/query.py
@@ -108,7 +108,9 @@ def summary(ctx):
             else:
                 row = []
                 for status in TestStatus:
-                    row.append(client.count(index=results_index, query={"match": {"status": str(status)}})["count"])
+                    row.append(
+                        client.count(index=results_index, query={"match": {"status.keyword": str(status)}})["count"]
+                    )
 
             table.rows.append(row, module_name)
     elif ctx.obj["suite_name"] is None:

--- a/tests/sweep_framework/runner.py
+++ b/tests/sweep_framework/runner.py
@@ -148,7 +148,11 @@ def sanitize_inputs(test_vectors):
 def get_suite_vectors(client, vector_index, suite):
     response = client.search(
         index=vector_index,
-        query={"bool": {"must": [{"match": {"status": str(VectorStatus.CURRENT)}}, {"match": {"suite_name": suite}}]}},
+        query={
+            "bool": {
+                "must": [{"match": {"status": str(VectorStatus.CURRENT)}}, {"match": {"suite_name.keyword": suite}}]
+            }
+        },
         size=10000,
     )
     test_ids = [hit["_id"] for hit in response["hits"]["hits"]]


### PR DESCRIPTION
### Ticket
#11228 

### Problem description
See issue.

### What's changed
Changed all queries in the whole sweeping system to use only exact matches on the keyword field instead of the base text field which yields word-matches as well as complete matches. 

### Checklist
- [ ] Post commit CI passes
- [ ] Blackhole Post commit (if applicable)
- [ ] Model regression CI testing passes (if applicable)
- [ ] New/Existing tests provide coverage for changes
