### PR TITLE
#0: Revert "Accuracy of RECIP for fp16b (#10464)"

### DIFF
--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_recip.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_recip.h
@@ -12,7 +12,7 @@ namespace ckernel {
 
 // New LLK SFPU APIs
 
-template <bool APPROXIMATE, bool is_fp32_dest_acc_en = false /*unused*/>
+template <bool APPROXIMATE>
 inline void llk_math_eltwise_unary_sfpu_reciprocal(uint dst_index, int vector_mode = (int)VectorMode::RC) {
     llk_math_eltwise_unary_sfpu_params<APPROXIMATE>(
         ckernel::sfpu::calculate_reciprocal<APPROXIMATE>,

--- a/tt_metal/hw/ckernels/grayskull/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_recip.h
+++ b/tt_metal/hw/ckernels/grayskull/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_recip.h
@@ -12,7 +12,7 @@ namespace ckernel {
 
 // New LLK SFPU APIs
 
-template <bool APPROXIMATE, bool is_fp32_dest_acc_en = false /*unused*/>
+template <bool APPROXIMATE>
 inline void llk_math_eltwise_unary_sfpu_reciprocal(uint dst_index, int vector_mode = (int)VectorMode::RC) {
     llk_math_eltwise_unary_sfpu_params<APPROXIMATE>(
         ckernel::sfpu::calculate_reciprocal<APPROXIMATE>,

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_recip.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_recip.h
@@ -17,17 +17,17 @@ namespace ckernel
 namespace sfpu
 {
 
-template <int max_iter = 3, bool save_reg = true /* Unused. Enough registers available. */>
+template <int max_iter = 3,bool save_reg=true /* Unused. Enough registers available. */>
 sfpi_inline vFloat sfpu_reciprocal(const vFloat in)
 {
     return _sfpu_reciprocal_<max_iter>(in);
 }
 
 
-template <bool APPROXIMATION_MODE, int ITERATIONS = 8, bool is_fp32_dest_acc_en = false>
+template <bool APPROXIMATION_MODE, int ITERATIONS=8>
 inline void calculate_reciprocal()
 {
-    _calculate_reciprocal_<APPROXIMATION_MODE, ITERATIONS, is_fp32_dest_acc_en>(ITERATIONS);
+    _calculate_reciprocal_<APPROXIMATION_MODE, ITERATIONS>(ITERATIONS);
 }
 
 template <bool APPROXIMATION_MODE>

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_recip.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_recip.h
@@ -12,10 +12,10 @@ namespace ckernel {
 
 // New LLK SFPU APIs
 
-template <bool APPROXIMATE, bool is_fp32_dest_acc_en = false>
+template <bool APPROXIMATE>
 inline void llk_math_eltwise_unary_sfpu_reciprocal(uint dst_index, int vector_mode = (int)VectorMode::RC) {
     llk_math_eltwise_unary_sfpu_params<APPROXIMATE>(
-        ckernel::sfpu::calculate_reciprocal<APPROXIMATE, 8, is_fp32_dest_acc_en>,
+        ckernel::sfpu::calculate_reciprocal<APPROXIMATE>,
         dst_index,
         vector_mode);
 

--- a/tt_metal/include/compute_kernel_api/eltwise_unary/recip.h
+++ b/tt_metal/include/compute_kernel_api/eltwise_unary/recip.h
@@ -30,7 +30,6 @@ ALWI void recip_tile_init() {
  * in DST register at index tile_index. The DST register buffer must be in
  * acquired state via *acquire_dst* call. This call is blocking and is only
  * available on the compute engine.
- * Only works for Float32, Float16_b, Bfp8_b data formats for full accuracy.
  *
  * Return value: None
  *
@@ -39,7 +38,7 @@ ALWI void recip_tile_init() {
  * | idst           | The index of the tile in DST register buffer to perform the computation on | uint32_t | Must be less than the size of the DST register buffer | True     |
  */
 ALWI void recip_tile(uint32_t idst) {
-    MATH(( llk_math_eltwise_unary_sfpu_reciprocal<APPROX, DST_ACCUM_MODE>(idst) ));
+    MATH(( llk_math_eltwise_unary_sfpu_reciprocal<APPROX>(idst) ));
 }
 
 } // namespace ckernel


### PR DESCRIPTION
This reverts commit f9860f752f5359afb0ccd7419ddbd90f7209b1e8.

Need to revert commit due to Falcon 7b failures
