### PR TITLE
#11181: Add a global sync before closing devices (needed for non-blocking CCLs)

### DIFF
--- a/tt_metal/tt_metal.cpp
+++ b/tt_metal/tt_metal.cpp
@@ -190,6 +190,15 @@ std::map<chip_id_t, Device *> CreateDevices(
 }
 
 void CloseDevices(std::map<chip_id_t, Device *> devices) {
+    // Global Sync across all devices in the pool.
+    // We need to ensure that commands sent to each device have been completed
+    // before closing any device + modifying routing info.
+    // If this is not done, non-blocking CCLs followed by a close will hang, since
+    // the main thread will modify device state while the CCL is running on device.
+    for (const auto &[device_id, dev] : devices) {
+        dev->synchronize(); // Synchronize worker queue
+        detail::Synchronize(dev); // Synchronize device
+    }
     tt::Cluster::instance().set_internal_routing_info_for_ethernet_cores(false);
     std::map<chip_id_t, Device *> mmio_devices = {};
     bool is_galaxy = tt::Cluster::instance().is_galaxy_cluster();


### PR DESCRIPTION
### Ticket
[Link to Github Issue](https://github.com/tenstorrent/tt-metal/issues/11181)

### Problem description
CCLs on Galaxy were hanging during device teardown. The issue was that CCLs could be issued asynchronously (may not be followed by a sync across all devices), and the devices were then closed. This lead to device state being modified during `CloseDevices`, which could cause a CCL that was in progress to hang.

### What's changed
Add a global sync, across all devices that are to be closed before modifying device state.

### Checklist
- [x] Post commit CI passes
- [ ] Blackhole Post commit (if applicable)
- [ ] Model regression CI testing passes (if applicable)
- [ ] New/Existing tests provide coverage for changes
