### PR TITLE
Aliu/semaphore api change

### DIFF
--- a/tests/tt_eager/ops/ccl/test_ccl_helpers.cpp
+++ b/tests/tt_eager/ops/ccl/test_ccl_helpers.cpp
@@ -15,12 +15,7 @@ TEST(CclHelpers, CreateEriscDatamoverBuilder_Chan4_PageSize2048_RRBufferSharingM
     ttnn::ccl::EriscDataMoverTerminationMode termination_mode = ttnn::ccl::EriscDataMoverTerminationMode::MESSAGE_COUNT_REACHED;
 
     auto edm_builder = create_erisc_datamover_builder(num_channels, page_size, buffer_sharing_mode, termination_mode);
-    std::vector<uint32_t> worker_semaphore_addresses = {
-        0x1000,
-        0x1010,
-        0x1020,
-        0x1030,
-    };
+    std::vector<uint32_t> worker_semaphore_ids = {0, 1, 2, 3};
     std::vector<uint32_t> message_counts = {256, 512, 24, 1};
     std::vector<std::vector<ttnn::ccl::WorkerXY>> const& worker_coords = {
         {ttnn::ccl::WorkerXY{1, 1}, ttnn::ccl::WorkerXY{2, 1}},
@@ -35,8 +30,8 @@ TEST(CclHelpers, CreateEriscDatamoverBuilder_Chan4_PageSize2048_RRBufferSharingM
     for (std::size_t i = 0; i < num_channels; i++) {
         ttnn::ccl::EriscDatamoverBuilder::ChannelBufferInterface const& channel_buffer_interface =
             (is_sender_channel[i])
-                ? edm_builder.add_sender_channel(worker_semaphore_addresses[i], message_counts[i], worker_coords[i])
-                : edm_builder.add_receiver_channel(worker_semaphore_addresses[i], message_counts[i], worker_coords[i]);
+                ? edm_builder.add_sender_channel(worker_semaphore_ids[i], message_counts[i], worker_coords[i])
+                : edm_builder.add_receiver_channel(worker_semaphore_ids[i], message_counts[i], worker_coords[i]);
         channel_buffer_interfaces.push_back(channel_buffer_interface);
         ASSERT_TRUE(channel_buffer_interface.eth_buffer_l1_address > 0);
         ASSERT_TRUE(channel_buffer_interface.eth_semaphore_l1_address > 0);
@@ -48,7 +43,7 @@ TEST(CclHelpers, CreateEriscDatamoverBuilder_Chan4_PageSize2048_RRBufferSharingM
         ASSERT_EQ(active_channels[i].channel, i);
         ASSERT_EQ(active_channels[i].is_sender, is_sender_channel.at(i));
         ASSERT_EQ(active_channels[i].worker_coords, worker_coords.at(i));
-        ASSERT_TRUE(active_channels[i].worker_semaphore_address == worker_semaphore_addresses.at(i));
+        ASSERT_TRUE(active_channels[i].worker_semaphore_id == worker_semaphore_ids.at(i));
         ASSERT_TRUE(active_channels[i].num_eth_messages_to_forward == message_counts.at(i));
     }
 }

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/ethernet/test_ethernet_hop_latencies_no_edm.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/ethernet/test_ethernet_hop_latencies_no_edm.cpp
@@ -86,7 +86,7 @@ std::vector<uint32_t> get_eth_receiver_rt_args(
     uint32_t start_semaphore,
     uint32_t init_handshake_core_x,
     uint32_t init_handshake_core_y,
-    uint32_t init_handshake_addr
+    uint32_t init_handshake_semaphore_id
     ) {
     constexpr std::size_t semaphore_size = 16;
     std::vector<uint32_t> erisc_semaphore_addresses(max_concurrent_samples, eth_l1_mem::address_map::ERISC_L1_UNRESERVED_BASE + 16 + 16);
@@ -107,7 +107,7 @@ std::vector<uint32_t> get_eth_receiver_rt_args(
         start_semaphore,
         init_handshake_core_x,
         init_handshake_core_y,
-        init_handshake_addr};
+        init_handshake_semaphore_id};
     for (std::size_t i = 0; i < max_concurrent_samples; i++) {
         rt_args.push_back(erisc_semaphore_addresses.at(i));
         rt_args.push_back(erisc_buffer_addresses.at(i));
@@ -125,7 +125,7 @@ std::vector<uint32_t> get_eth_sender_rt_args(
     uint32_t sample_page_size,
     uint32_t receiver_x,
     uint32_t receiver_y,
-    uint32_t receiver_start_semaphore) {
+    uint32_t receiver_start_semaphore_id) {
     constexpr std::size_t semaphore_size = 16;
     std::vector<uint32_t> erisc_semaphore_addresses(max_concurrent_samples, eth_l1_mem::address_map::ERISC_L1_UNRESERVED_BASE + 16 + 16);
     std::vector<uint32_t> erisc_buffer_addresses(max_concurrent_samples, eth_l1_mem::address_map::ERISC_L1_UNRESERVED_BASE + 16 + 16 + round_up(semaphore_size * max_concurrent_samples, 16));
@@ -142,7 +142,7 @@ std::vector<uint32_t> get_eth_sender_rt_args(
         sample_page_size,
         receiver_x,
         receiver_y,
-        receiver_start_semaphore};
+        receiver_start_semaphore_id};
     for (std::size_t i = 0; i < max_concurrent_samples; i++) {
         rt_args.push_back(erisc_semaphore_addresses.at(i));
         rt_args.push_back(erisc_buffer_addresses.at(i));

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/ethernet/test_workers_and_erisc_datamover_unidirectional.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/ethernet/test_workers_and_erisc_datamover_unidirectional.cpp
@@ -200,7 +200,7 @@ bool RunWriteBWTest(
     //                               Device 0
     ////////////////////////////////////////////////////////////////////////////
     tt_metal::Program sender_program = tt_metal::Program();
-    uint32_t chip0_worker_semaphores_base_address = tt::tt_metal::CreateSemaphore(sender_program, chip0_sender_worker_core, 0);
+    uint32_t chip0_worker_semaphore_id = tt::tt_metal::CreateSemaphore(sender_program, chip0_sender_worker_core, 0);
 
     chip0_edm_args.push_back(chip0_sender_channels_offset);
 
@@ -239,8 +239,8 @@ bool RunWriteBWTest(
         chip0_next_buffer_address += 16;
         //    8) worker_semaphore_address
         //       worker local L1 semaphores that erisc updates
-        chip0_edm_args.push_back(chip0_worker_semaphores_base_address);
-        log_debug(tt::LogTest, "\t\tworker_semaphores_base_address: {}", chip0_worker_semaphores_base_address);
+        chip0_edm_args.push_back(chip0_worker_semaphore_id);
+        log_debug(tt::LogTest, "\t\tworker_semaphores_base_address: {}", chip0_worker_semaphore_id);
         //    9) sender_num_workers
         //       Informs how many worker X/Y coords to accept in the next loop. Each X/Y pair is 2 uint16s
         const uint32_t chip0_num_workers_on_channel = 1;
@@ -299,7 +299,7 @@ bool RunWriteBWTest(
         chip0_eth_sender_l1_sem_addr,
         // worker L1 semaphore address. Sender writes to this address to signal the worker
         // that the buffer is empty and available to write into
-        chip0_worker_semaphores_base_address,
+        chip0_worker_semaphore_id,
         uint32_t(sender_device->ethernet_core_from_logical_core(eth_sender_core).x),
         uint32_t(sender_device->ethernet_core_from_logical_core(eth_sender_core).y)
         };
@@ -345,7 +345,7 @@ bool RunWriteBWTest(
     ////////////////////////////////////////////////////////////////////////////
     tt_metal::Program receiver_program = tt_metal::Program();
     auto chip1_receiver_worker_core = CoreCoord(0, 0);
-    uint32_t chip1_worker_semaphores_base_address = tt::tt_metal::CreateSemaphore(receiver_program, chip1_receiver_worker_core, 0);
+    uint32_t chip1_worker_semaphore_id = tt::tt_metal::CreateSemaphore(receiver_program, chip1_receiver_worker_core, 0);
 
     uint32_t chip1_receiver_num_channels = chip0_arg_sender_num_channels;
     auto eth_receiver_kernel = tt_metal::CreateKernel(
@@ -397,8 +397,8 @@ bool RunWriteBWTest(
         log_debug(tt::LogTest, "\t\tsender_semaphores_base_address: {}", chip1_next_buffer_address);
         chip1_next_buffer_address += 16;
         //    8) worker_semaphore_address
-        chip1_edm_args.push_back(chip1_worker_semaphores_base_address);
-        log_debug(tt::LogTest, "\t\tworker_semaphores_base_address: {}", chip1_worker_semaphores_base_address);
+        chip1_edm_args.push_back(chip1_worker_semaphore_id);
+        log_debug(tt::LogTest, "\t\tworker_semaphores_base_id: {}", chip1_worker_semaphore_id);
         //    9) sender_num_workers
         //       Informs how many worker X/Y coords to accept in the next loop. Each X/Y pair is 2 uint16s
         const uint32_t chip1_num_workers_on_channel = 1;
@@ -448,8 +448,8 @@ bool RunWriteBWTest(
         chip1_eth_receiver_l1_sem_addr = chip1_next_buffer_address;
         chip1_next_buffer_address += 16;
         //    8) worker_semaphore_address
-        chip1_edm_args.push_back(chip1_worker_semaphores_base_address);
-        log_debug(tt::LogTest, "\t\tworker_semaphores_base_address: {}", chip1_worker_semaphores_base_address);
+        chip1_edm_args.push_back(chip1_worker_semaphore_id);
+        log_debug(tt::LogTest, "\t\tworker_semaphores_base_address: {}", chip1_worker_semaphore_id);
         //    9) sender_num_workers
         //       Informs how many worker X/Y coords to accept in the next loop. Each X/Y pair is 2 uint16s
         const uint32_t chip1_num_workers_on_channel = 1;
@@ -485,7 +485,7 @@ bool RunWriteBWTest(
         input_buffer_page_size,
         (uint32_t)receiver_device->ethernet_core_from_logical_core(eth_receiver_core).x,
         (uint32_t)receiver_device->ethernet_core_from_logical_core(eth_receiver_core).y,
-        chip1_worker_semaphores_base_address};
+        chip1_worker_semaphore_id};
 
     CBHandle cb_src0_receiver_workers = CreateCircularBuffer(receiver_program, chip1_receiver_worker_core, cb_src0_config);
     auto device_1_edm_receiver_worker_receiver_kernel = tt_metal::CreateKernel(

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/old/matmul/kernels/reader_bmm_tile_layout_in0_receiver.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/old/matmul/kernels/reader_bmm_tile_layout_in0_receiver.cpp
@@ -17,8 +17,8 @@ void kernel_main() {
     constexpr uint32_t num_blocks                         = get_compile_time_arg_val(1);
     // in0 mcast args
     constexpr uint32_t in0_mcast_sender_noc_x             = get_compile_time_arg_val(2);
-    constexpr uint32_t in0_mcast_sender_semaphore_addr    = get_compile_time_arg_val(3);
-    constexpr uint32_t in0_mcast_receiver_semaphore_addr  = get_compile_time_arg_val(4);
+    uint32_t in0_mcast_sender_semaphore_addr    = get_semaphore(get_compile_time_arg_val(3));
+    uint32_t in0_mcast_receiver_semaphore_addr  = get_semaphore(get_compile_time_arg_val(4));
     // batch args
     constexpr uint32_t batch                              = get_compile_time_arg_val(5);
 

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/old/matmul/kernels/reader_bmm_tile_layout_in0_sender_padding.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/old/matmul/kernels/reader_bmm_tile_layout_in0_sender_padding.cpp
@@ -34,8 +34,8 @@ void kernel_main() {
     // in0 mcast args
     constexpr uint32_t in0_mcast_dest_noc_start_x         = get_compile_time_arg_val(8);
     constexpr uint32_t in0_mcast_dest_noc_end_x           = get_compile_time_arg_val(9);
-    constexpr uint32_t in0_mcast_sender_semaphore_addr    = get_compile_time_arg_val(10);
-    constexpr uint32_t in0_mcast_receiver_semaphore_addr  = get_compile_time_arg_val(11);
+    uint32_t in0_mcast_sender_semaphore_addr    = get_semaphore(get_compile_time_arg_val(10));
+    uint32_t in0_mcast_receiver_semaphore_addr  = get_semaphore(get_compile_time_arg_val(11));
     constexpr uint32_t in0_mcast_num_dests                = get_compile_time_arg_val(12);
     // batch args
     constexpr uint32_t MtKt                               = get_compile_time_arg_val(13); // if 0

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/old/matmul/kernels/reader_bmm_tile_layout_in1_receiver_writer_padding.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/old/matmul/kernels/reader_bmm_tile_layout_in1_receiver_writer_padding.cpp
@@ -36,8 +36,8 @@ void kernel_main() {
     constexpr uint32_t num_blocks                         = get_compile_time_arg_val(2);
     // in1 mcast args
     constexpr uint32_t in1_mcast_sender_noc_y             = get_compile_time_arg_val(3);
-    constexpr uint32_t in1_mcast_sender_semaphore_addr    = get_compile_time_arg_val(4);
-    constexpr uint32_t in1_mcast_receiver_semaphore_addr  = get_compile_time_arg_val(5);
+    uint32_t in1_mcast_sender_semaphore_addr    = get_semaphore(get_compile_time_arg_val(4));
+    uint32_t in1_mcast_receiver_semaphore_addr  = get_semaphore(get_compile_time_arg_val(5));
     // batch args
     constexpr uint32_t batch                              = get_compile_time_arg_val(6);
 
@@ -66,8 +66,8 @@ void kernel_main() {
 
         // in3 mcast args
         constexpr uint32_t in3_mcast_sender_noc_y             = get_compile_time_arg_val(16);
-        constexpr uint32_t in3_mcast_sender_semaphore_addr    = get_compile_time_arg_val(17);
-        constexpr uint32_t in3_mcast_receiver_semaphore_addr  = get_compile_time_arg_val(18);
+        uint32_t in3_mcast_sender_semaphore_addr    = get_semaphore(get_compile_time_arg_val(17));
+        uint32_t in3_mcast_receiver_semaphore_addr  = get_semaphore(get_compile_time_arg_val(18));
         constexpr uint32_t cb_id_in3 = 3;
         volatile tt_l1_ptr uint32_t* in3_mcast_receiver_semaphore_addr_ptr = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(in3_mcast_receiver_semaphore_addr);
     #endif

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/old/matmul/kernels/reader_bmm_tile_layout_in1_sender_writer_padding.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/old/matmul/kernels/reader_bmm_tile_layout_in1_sender_writer_padding.cpp
@@ -50,8 +50,8 @@ void kernel_main() {
     // in1 mcast args
     constexpr uint32_t in1_mcast_dest_noc_start_y         = get_compile_time_arg_val(9);
     constexpr uint32_t in1_mcast_dest_noc_end_y           = get_compile_time_arg_val(10);
-    constexpr uint32_t in1_mcast_sender_semaphore_addr    = get_compile_time_arg_val(11);
-    constexpr uint32_t in1_mcast_receiver_semaphore_addr  = get_compile_time_arg_val(12);
+    uint32_t in1_mcast_sender_semaphore_addr    = get_semaphore(get_compile_time_arg_val(11));
+    uint32_t in1_mcast_receiver_semaphore_addr  = get_semaphore(get_compile_time_arg_val(12));
     constexpr uint32_t in1_mcast_num_dests                = get_compile_time_arg_val(13);
     // batch args
     constexpr uint32_t KtNt                               = get_compile_time_arg_val(14);
@@ -83,8 +83,8 @@ void kernel_main() {
         constexpr uint32_t in3_tensor_stride_w                = get_compile_time_arg_val(26);
         constexpr uint32_t in3_mcast_dest_noc_start_y         = get_compile_time_arg_val(27);
         constexpr uint32_t in3_mcast_dest_noc_end_y           = get_compile_time_arg_val(28);
-        constexpr uint32_t in3_mcast_sender_semaphore_addr    = get_compile_time_arg_val(29);
-        constexpr uint32_t in3_mcast_receiver_semaphore_addr  = get_compile_time_arg_val(30);
+        uint32_t in3_mcast_sender_semaphore_addr    = get_semaphore(get_compile_time_arg_val(29));
+        uint32_t in3_mcast_receiver_semaphore_addr  = get_semaphore(get_compile_time_arg_val(30));
         constexpr uint32_t in3_mcast_num_dests                = get_compile_time_arg_val(31);
 
         constexpr uint32_t cb_id_in3 = 3;

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/old/matmul/matmul_global_l1.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/old/matmul/matmul_global_l1.cpp
@@ -152,19 +152,19 @@ tt_metal::Program create_program_mcast_in0_in1(
   */
 
   // Mcast args
-  auto in0_mcast_sender_semaphore =
+  auto in0_mcast_sender_semaphore_id =
       tt_metal::CreateSemaphore(program, all_cores, INVALID);
-  auto in0_mcast_receiver_semaphore =
+  auto in0_mcast_receiver_semaphore_id =
       tt_metal::CreateSemaphore(program, all_cores, INVALID);
-  auto in1_mcast_sender_semaphore =
+  auto in1_mcast_sender_semaphore_id =
       tt_metal::CreateSemaphore(program, all_cores, INVALID);
-  auto in1_mcast_receiver_semaphore =
+  auto in1_mcast_receiver_semaphore_id =
       tt_metal::CreateSemaphore(program, all_cores, INVALID);
-  uint32_t in3_mcast_sender_semaphore = 0;
-  uint32_t in3_mcast_receiver_semaphore = 0;
+  uint32_t in3_mcast_sender_semaphore_id = 0;
+  uint32_t in3_mcast_receiver_semaphore_id = 0;
   if (bias_buffer != nullptr) {
-    in3_mcast_sender_semaphore = in1_mcast_sender_semaphore;
-    in3_mcast_receiver_semaphore = in1_mcast_receiver_semaphore;
+    in3_mcast_sender_semaphore_id = in1_mcast_sender_semaphore_id;
+    in3_mcast_receiver_semaphore_id = in1_mcast_receiver_semaphore_id;
   }
   CoreCoord top_left_core = {(std::size_t)start_core_x,
                              (std::size_t)start_core_y};
@@ -209,8 +209,8 @@ tt_metal::Program create_program_mcast_in0_in1(
           bottom_right_core_physical.x,  // in0_mcast_dest_noc_start_x
       (std::uint32_t)
           top_left_core_plus_one_physical.x,  // in0_mcast_dest_noc_end_x
-      (std::uint32_t)in0_mcast_sender_semaphore,
-      (std::uint32_t)in0_mcast_receiver_semaphore,
+      (std::uint32_t)in0_mcast_sender_semaphore_id,
+      (std::uint32_t)in0_mcast_receiver_semaphore_id,
       (std::uint32_t)(num_cores_c - 1),  // in0_mcast_num_dests
       // batch args
       (std::uint32_t)M * K,  // MtKt
@@ -236,8 +236,8 @@ tt_metal::Program create_program_mcast_in0_in1(
           bottom_right_core_physical.y,  // in1_mcast_dest_noc_start_y
       (std::uint32_t)
           top_left_core_plus_one_physical.y,  // in1_mcast_dest_noc_end_y
-      (std::uint32_t)in1_mcast_sender_semaphore,
-      (std::uint32_t)in1_mcast_receiver_semaphore,
+      (std::uint32_t)in1_mcast_sender_semaphore_id,
+      (std::uint32_t)in1_mcast_receiver_semaphore_id,
       (std::uint32_t)(num_cores_r - 1),  // in1_mcast_num_dests
       // batch args
       (std::uint32_t)K * N,        // KtNt
@@ -270,9 +270,9 @@ tt_metal::Program create_program_mcast_in0_in1(
         (std::uint32_t)
             top_left_core_plus_one_physical.y);  // in1_mcast_dest_noc_end_y
     in1_sender_writer_compile_time_args.push_back(
-        (std::uint32_t)in1_mcast_sender_semaphore);
+        (std::uint32_t)in1_mcast_sender_semaphore_id);
     in1_sender_writer_compile_time_args.push_back(
-        (std::uint32_t)in1_mcast_receiver_semaphore);
+        (std::uint32_t)in1_mcast_receiver_semaphore_id);
     in1_sender_writer_compile_time_args.push_back(
         (std::uint32_t)(num_cores_r - 1));  // in1_mcast_num_dests
   }
@@ -283,8 +283,8 @@ tt_metal::Program create_program_mcast_in0_in1(
       (std::uint32_t)K / in0_block_w,  // num_blocks
       // in0 mcast args
       (std::uint32_t)top_left_core_physical.x,  // in0_mcast_sender_noc_x
-      (std::uint32_t)in0_mcast_sender_semaphore,
-      (std::uint32_t)in0_mcast_receiver_semaphore,
+      (std::uint32_t)in0_mcast_sender_semaphore_id,
+      (std::uint32_t)in0_mcast_receiver_semaphore_id,
       // batch args
       (std::uint32_t)B  // batch
   };
@@ -299,8 +299,8 @@ tt_metal::Program create_program_mcast_in0_in1(
       (std::uint32_t)K / in0_block_w,  // num_blocks
       // in1 mcast args
       (std::uint32_t)top_left_core_physical.y,  // in1_mcast_sender_noc_y
-      (std::uint32_t)in1_mcast_sender_semaphore,
-      (std::uint32_t)in1_mcast_receiver_semaphore,
+      (std::uint32_t)in1_mcast_sender_semaphore_id,
+      (std::uint32_t)in1_mcast_receiver_semaphore_id,
       // batch args
       (std::uint32_t)B,  // batch
 
@@ -324,9 +324,9 @@ tt_metal::Program create_program_mcast_in0_in1(
     in1_receiver_writer_compile_time_args.push_back(
         (std::uint32_t)top_left_core_physical.y);  // in1_mcast_sender_noc_y
     in1_receiver_writer_compile_time_args.push_back(
-        (std::uint32_t)in3_mcast_sender_semaphore);
+        (std::uint32_t)in3_mcast_sender_semaphore_id);
     in1_receiver_writer_compile_time_args.push_back(
-        (std::uint32_t)in3_mcast_receiver_semaphore);
+        (std::uint32_t)in3_mcast_receiver_semaphore_id);
   }
 
   std::map<string, string> mm_kernel_defines;

--- a/tests/tt_metal/tt_metal/test_core_range_set.cpp
+++ b/tests/tt_metal/tt_metal/test_core_range_set.cpp
@@ -145,9 +145,8 @@ bool test_program_specified_with_core_range_set(tt_metal::Device *device, tt_met
     std::vector<uint32_t> golden_sem_values;
     for (uint32_t i = 0; i < NUM_SEMAPHORES; i++) {
         uint32_t initial_value = i;
-        auto semaphore_addr = tt_metal::CreateSemaphore(program, core_range_set, initial_value);
+        tt_metal::CreateSemaphore(program, core_range_set, initial_value);
         golden_sem_values.push_back(initial_value);
-        pass &= semaphore_addr == SEMAPHORE_BASE + (size_per_semaphore * i);
     }
 
     check_program_is_mapped_to_correct_cores(program, core_range_set, compute_kernel_args);

--- a/tests/tt_metal/tt_metal/test_kernels/dataflow/reader_matmul_tile_layout_in0_mcast_receiver.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/dataflow/reader_matmul_tile_layout_in0_mcast_receiver.cpp
@@ -42,8 +42,8 @@ void kernel_main() {
     uint32_t in0_mcast_num_dests                = get_arg_val<uint32_t>(21);
     uint32_t in0_mcast_sender_noc_x             = get_arg_val<uint32_t>(22);
     uint32_t in0_mcast_sender_noc_y             = get_arg_val<uint32_t>(23);
-    uint32_t in0_mcast_sender_semaphore_addr    = get_arg_val<uint32_t>(24);
-    uint32_t in0_mcast_receiver_semaphore_addr  = get_arg_val<uint32_t>(25);
+    uint32_t in0_mcast_sender_semaphore_addr = get_semaphore(get_arg_val<uint32_t>(24));
+    uint32_t in0_mcast_receiver_semaphore_addr = get_semaphore(get_arg_val<uint32_t>(25));
 
     constexpr uint32_t num_used_dram_ch = 8;
     constexpr uint32_t num_used_dram_ch_pow2_exponent = 3;

--- a/tests/tt_metal/tt_metal/test_kernels/dataflow/reader_matmul_tile_layout_in0_mcast_sender.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/dataflow/reader_matmul_tile_layout_in0_mcast_sender.cpp
@@ -42,8 +42,8 @@ void kernel_main() {
     uint32_t in0_mcast_num_dests                = get_arg_val<uint32_t>(21);
     uint32_t in0_mcast_sender_noc_x             = get_arg_val<uint32_t>(22);
     uint32_t in0_mcast_sender_noc_y             = get_arg_val<uint32_t>(23);
-    uint32_t in0_mcast_sender_semaphore_addr    = get_arg_val<uint32_t>(24);
-    uint32_t in0_mcast_receiver_semaphore_addr  = get_arg_val<uint32_t>(25);
+    uint32_t in0_mcast_sender_semaphore_addr = get_semaphore(get_arg_val<uint32_t>(24));
+    uint32_t in0_mcast_receiver_semaphore_addr = get_semaphore(get_arg_val<uint32_t>(25));
 
     // const args for tile-based bank-swizzled layout
     // could be added to the arg list in the future to test different

--- a/tests/tt_metal/tt_metal/test_kernels/dataflow/reader_matmul_tile_layout_in0_receiver_in1_receiver.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/dataflow/reader_matmul_tile_layout_in0_receiver_in1_receiver.cpp
@@ -42,8 +42,8 @@ void kernel_main() {
     uint32_t in0_mcast_num_dests                = get_arg_val<uint32_t>(21);
     uint32_t in0_mcast_sender_noc_x             = get_arg_val<uint32_t>(22);
     uint32_t in0_mcast_sender_noc_y             = get_arg_val<uint32_t>(23);
-    uint32_t in0_mcast_sender_semaphore_addr    = get_arg_val<uint32_t>(24);
-    uint32_t in0_mcast_receiver_semaphore_addr  = get_arg_val<uint32_t>(25);
+    uint32_t in0_mcast_sender_semaphore_addr = get_semaphore(get_arg_val<uint32_t>(24));
+    uint32_t in0_mcast_receiver_semaphore_addr = get_semaphore(get_arg_val<uint32_t>(25));
 
     // in1 mcast args
     uint32_t in1_mcast_dest_noc_start_x         = get_arg_val<uint32_t>(26);
@@ -53,8 +53,8 @@ void kernel_main() {
     uint32_t in1_mcast_num_dests                = get_arg_val<uint32_t>(30);
     uint32_t in1_mcast_sender_noc_x             = get_arg_val<uint32_t>(31);
     uint32_t in1_mcast_sender_noc_y             = get_arg_val<uint32_t>(32);
-    uint32_t in1_mcast_sender_semaphore_addr    = get_arg_val<uint32_t>(33);
-    uint32_t in1_mcast_receiver_semaphore_addr  = get_arg_val<uint32_t>(34);
+    uint32_t in1_mcast_sender_semaphore_addr = get_semaphore(get_arg_val<uint32_t>(33));
+    uint32_t in1_mcast_receiver_semaphore_addr = get_semaphore(get_arg_val<uint32_t>(34));
 
     constexpr uint32_t cb_id_in0 = 0;
     constexpr uint32_t cb_id_in1 = 1;

--- a/tests/tt_metal/tt_metal/test_kernels/dataflow/reader_matmul_tile_layout_in0_receiver_in1_sender.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/dataflow/reader_matmul_tile_layout_in0_receiver_in1_sender.cpp
@@ -42,8 +42,8 @@ void kernel_main() {
     uint32_t in0_mcast_num_dests                = get_arg_val<uint32_t>(21);
     uint32_t in0_mcast_sender_noc_x             = get_arg_val<uint32_t>(22);
     uint32_t in0_mcast_sender_noc_y             = get_arg_val<uint32_t>(23);
-    uint32_t in0_mcast_sender_semaphore_addr    = get_arg_val<uint32_t>(24);
-    uint32_t in0_mcast_receiver_semaphore_addr  = get_arg_val<uint32_t>(25);
+    uint32_t in0_mcast_sender_semaphore_addr = get_semaphore(get_arg_val<uint32_t>(24));
+    uint32_t in0_mcast_receiver_semaphore_addr = get_semaphore(get_arg_val<uint32_t>(25));
 
     // in1 mcast args
     uint32_t in1_mcast_dest_noc_start_x         = get_arg_val<uint32_t>(26);
@@ -53,8 +53,8 @@ void kernel_main() {
     uint32_t in1_mcast_num_dests                = get_arg_val<uint32_t>(30);
     uint32_t in1_mcast_sender_noc_x             = get_arg_val<uint32_t>(31);
     uint32_t in1_mcast_sender_noc_y             = get_arg_val<uint32_t>(32);
-    uint32_t in1_mcast_sender_semaphore_addr    = get_arg_val<uint32_t>(33);
-    uint32_t in1_mcast_receiver_semaphore_addr  = get_arg_val<uint32_t>(34);
+    uint32_t in1_mcast_sender_semaphore_addr = get_semaphore(get_arg_val<uint32_t>(33));
+    uint32_t in1_mcast_receiver_semaphore_addr = get_semaphore(get_arg_val<uint32_t>(34));
     // const args for tile-based bank-swizzled layout
     // could be added to the arg list in the future to test different
     // bank-swizzling configurations

--- a/tests/tt_metal/tt_metal/test_kernels/dataflow/reader_matmul_tile_layout_in0_sender_in1_receiver.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/dataflow/reader_matmul_tile_layout_in0_sender_in1_receiver.cpp
@@ -42,8 +42,8 @@ void kernel_main() {
     uint32_t in0_mcast_num_dests                = get_arg_val<uint32_t>(21);
     uint32_t in0_mcast_sender_noc_x             = get_arg_val<uint32_t>(22);
     uint32_t in0_mcast_sender_noc_y             = get_arg_val<uint32_t>(23);
-    uint32_t in0_mcast_sender_semaphore_addr    = get_arg_val<uint32_t>(24);
-    uint32_t in0_mcast_receiver_semaphore_addr  = get_arg_val<uint32_t>(25);
+    uint32_t in0_mcast_sender_semaphore_addr = get_semaphore(get_arg_val<uint32_t>(24));
+    uint32_t in0_mcast_receiver_semaphore_addr = get_semaphore(get_arg_val<uint32_t>(25));
 
     // in1 mcast args
     uint32_t in1_mcast_dest_noc_start_x         = get_arg_val<uint32_t>(26);
@@ -53,8 +53,8 @@ void kernel_main() {
     uint32_t in1_mcast_num_dests                = get_arg_val<uint32_t>(30);
     uint32_t in1_mcast_sender_noc_x             = get_arg_val<uint32_t>(31);
     uint32_t in1_mcast_sender_noc_y             = get_arg_val<uint32_t>(32);
-    uint32_t in1_mcast_sender_semaphore_addr    = get_arg_val<uint32_t>(33);
-    uint32_t in1_mcast_receiver_semaphore_addr  = get_arg_val<uint32_t>(34);
+    uint32_t in1_mcast_sender_semaphore_addr = get_semaphore(get_arg_val<uint32_t>(33));
+    uint32_t in1_mcast_receiver_semaphore_addr = get_semaphore(get_arg_val<uint32_t>(34));
 
     // const args for tile-based bank-swizzled layout
     // could be added to the arg list in the future to test different

--- a/tests/tt_metal/tt_metal/test_kernels/dataflow/reader_matmul_tile_layout_in0_sender_in1_sender.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/dataflow/reader_matmul_tile_layout_in0_sender_in1_sender.cpp
@@ -42,8 +42,8 @@ void kernel_main() {
     uint32_t in0_mcast_num_dests                = get_arg_val<uint32_t>(21);
     uint32_t in0_mcast_sender_noc_x             = get_arg_val<uint32_t>(22);
     uint32_t in0_mcast_sender_noc_y             = get_arg_val<uint32_t>(23);
-    uint32_t in0_mcast_sender_semaphore_addr    = get_arg_val<uint32_t>(24);
-    uint32_t in0_mcast_receiver_semaphore_addr  = get_arg_val<uint32_t>(25);
+    uint32_t in0_mcast_sender_semaphore_addr = get_semaphore(get_arg_val<uint32_t>(24));
+    uint32_t in0_mcast_receiver_semaphore_addr = get_semaphore(get_arg_val<uint32_t>(25));
 
     // in1 mcast args
     uint32_t in1_mcast_dest_noc_start_x         = get_arg_val<uint32_t>(26);
@@ -53,9 +53,8 @@ void kernel_main() {
     uint32_t in1_mcast_num_dests                = get_arg_val<uint32_t>(30);
     uint32_t in1_mcast_sender_noc_x             = get_arg_val<uint32_t>(31);
     uint32_t in1_mcast_sender_noc_y             = get_arg_val<uint32_t>(32);
-    uint32_t in1_mcast_sender_semaphore_addr    = get_arg_val<uint32_t>(33);
-    uint32_t in1_mcast_receiver_semaphore_addr  = get_arg_val<uint32_t>(34);
-
+    uint32_t in1_mcast_sender_semaphore_addr = get_semaphore(get_arg_val<uint32_t>(33));
+    uint32_t in1_mcast_receiver_semaphore_addr = get_semaphore(get_arg_val<uint32_t>(34));
 
     // const args for tile-based bank-swizzled layout
     // could be added to the arg list in the future to test different

--- a/tests/tt_metal/tt_metal/test_kernels/dataflow/reader_matmul_tile_layout_in1_mcast_receiver.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/dataflow/reader_matmul_tile_layout_in1_mcast_receiver.cpp
@@ -42,8 +42,8 @@ void kernel_main() {
     uint32_t in1_mcast_num_dests                = get_arg_val<uint32_t>(21);
     uint32_t in1_mcast_sender_noc_x             = get_arg_val<uint32_t>(22);
     uint32_t in1_mcast_sender_noc_y             = get_arg_val<uint32_t>(23);
-    uint32_t in1_mcast_sender_semaphore_addr    = get_arg_val<uint32_t>(24);
-    uint32_t in1_mcast_receiver_semaphore_addr  = get_arg_val<uint32_t>(25);
+    uint32_t in1_mcast_sender_semaphore_addr = get_semaphore(get_arg_val<uint32_t>(24));
+    uint32_t in1_mcast_receiver_semaphore_addr = get_semaphore(get_arg_val<uint32_t>(25));
 
     constexpr uint32_t num_used_dram_ch = 8;
     constexpr uint32_t num_used_dram_ch_pow2_exponent = 3;

--- a/tests/tt_metal/tt_metal/test_kernels/dataflow/reader_matmul_tile_layout_in1_mcast_sender.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/dataflow/reader_matmul_tile_layout_in1_mcast_sender.cpp
@@ -42,8 +42,8 @@ void kernel_main() {
     uint32_t in1_mcast_num_dests                = get_arg_val<uint32_t>(21);
     uint32_t in1_mcast_sender_noc_x             = get_arg_val<uint32_t>(22);
     uint32_t in1_mcast_sender_noc_y             = get_arg_val<uint32_t>(23);
-    uint32_t in1_mcast_sender_semaphore_addr    = get_arg_val<uint32_t>(24);
-    uint32_t in1_mcast_receiver_semaphore_addr  = get_arg_val<uint32_t>(25);
+    uint32_t in1_mcast_sender_semaphore_addr = get_semaphore(get_arg_val<uint32_t>(24));
+    uint32_t in1_mcast_receiver_semaphore_addr = get_semaphore(get_arg_val<uint32_t>(25));
 
     // const args for tile-based bank-swizzled layout
     // could be added to the arg list in the future to test different

--- a/tests/tt_metal/tt_metal/test_kernels/dataflow/receiver_intermediate_stage.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/dataflow/receiver_intermediate_stage.cpp
@@ -12,8 +12,8 @@ void kernel_main() {
     uint32_t sender_noc_x            = get_arg_val<uint32_t>(0);
     uint32_t sender_noc_y            = get_arg_val<uint32_t>(1);
     uint32_t num_tiles               = get_arg_val<uint32_t>(2);
-    uint32_t sender_semaphore_addr   = get_arg_val<uint32_t>(3);
-    uint32_t receiver_semaphore_addr = get_arg_val<uint32_t>(4);
+    uint32_t sender_semaphore_addr   = get_semaphore(get_arg_val<uint32_t>(3));
+    uint32_t receiver_semaphore_addr = get_semaphore(get_arg_val<uint32_t>(4));
     uint32_t num_repetitions         = get_arg_val<uint32_t>(5);
 
     volatile tt_l1_ptr uint32_t* receiver_semaphore_addr_ptr = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(receiver_semaphore_addr);

--- a/tests/tt_metal/tt_metal/test_kernels/dataflow/sender_intermediate_stage.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/dataflow/sender_intermediate_stage.cpp
@@ -11,9 +11,9 @@ void kernel_main() {
     uint32_t receiver_noc_x          = get_arg_val<uint32_t>(0);
     uint32_t receiver_noc_y          = get_arg_val<uint32_t>(1);
     uint32_t num_tiles               = get_arg_val<uint32_t>(2);
-    uint32_t sender_semaphore_addr   = get_arg_val<uint32_t>(3);
-    uint32_t receiver_semaphore_addr = get_arg_val<uint32_t>(4);
-    uint32_t l1_valid_value_addr     = get_arg_val<uint32_t>(5);
+    uint32_t sender_semaphore_addr   = get_semaphore(get_arg_val<uint32_t>(3));
+    uint32_t receiver_semaphore_addr = get_semaphore(get_arg_val<uint32_t>(4));
+    uint32_t l1_valid_value_addr     = get_semaphore(get_arg_val<uint32_t>(5));
     uint32_t num_repetitions         = get_arg_val<uint32_t>(6);
 
     // initialized by the host to 0 before program launch

--- a/tests/tt_metal/tt_metal/test_kernels/dataflow/unit_tests/erisc/erisc_datamover_receiver_worker_reader.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/dataflow/unit_tests/erisc/erisc_datamover_receiver_worker_reader.cpp
@@ -37,7 +37,7 @@ void kernel_main() {
     const uint32_t receiver_erisc_datamover_noc_x = get_arg_val<uint32_t>(3);
     const uint32_t receiver_erisc_datamover_noc_y = get_arg_val<uint32_t>(4);
     // Worker local L1 semaphore that erisc datamover signals to
-    const uint32_t receiver_read_sem_addr = get_arg_val<uint32_t>(5);
+    const uint32_t receiver_read_sem_addr = get_semaphore(get_arg_val<uint32_t>(5));
 
     DPRINT << " rwr: args: eth_receiver_l1_base_addr="<<
         eth_receiver_l1_base_addr<<

--- a/tests/tt_metal/tt_metal/test_kernels/dataflow/unit_tests/erisc/erisc_datamover_sender_worker_sender.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/dataflow/unit_tests/erisc/erisc_datamover_sender_worker_sender.cpp
@@ -37,7 +37,7 @@ void kernel_main() {
     const uint32_t eth_l1_base_addr = get_arg_val<uint32_t>(0);
     // erisc l1 semaphore address
     const uint32_t eth_sender_l1_sem_addr = get_arg_val<uint32_t>(1);
-    const uint32_t writer_send_sem_addr = get_arg_val<uint32_t>(2);
+    const uint32_t writer_send_sem_addr = get_semaphore(get_arg_val<uint32_t>(2));
     const uint32_t eth_sender_noc_x = get_arg_val<uint32_t>(3);
     const uint32_t eth_sender_noc_y = get_arg_val<uint32_t>(4);
 

--- a/tests/tt_metal/tt_metal/test_kernels/dataflow/unit_tests/erisc/eth_latency_ubench_eth_receiver.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/dataflow/unit_tests/erisc/eth_latency_ubench_eth_receiver.cpp
@@ -165,7 +165,7 @@ void kernel_main() {
     volatile uint32_t* start_semaphore = reinterpret_cast<volatile uint32_t*>(get_arg_val<uint32_t>(arg_idx++));
     const uint32_t init_handshake_noc_x = get_arg_val<uint32_t>(arg_idx++);
     const uint32_t init_handshake_noc_y = get_arg_val<uint32_t>(arg_idx++);
-    const uint32_t init_handshake_addr = get_arg_val<uint32_t>(arg_idx++);
+    const uint32_t init_handshake_addr = get_semaphore(get_arg_val<uint32_t>(arg_idx++));
 
     ASSERT(max_concurrent_samples <= 8);
     volatile eth_channel_sync_t *last_channel_sync_addr = 0;

--- a/tests/tt_metal/tt_metal/test_kernels/dataflow/unit_tests/erisc/eth_latency_ubench_eth_sender.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/dataflow/unit_tests/erisc/eth_latency_ubench_eth_sender.cpp
@@ -80,7 +80,7 @@ void kernel_main() {
     const uint32_t transfer_size = get_arg_val<uint32_t>(arg_idx++);
     const uint32_t local_receiver_noc_x = get_arg_val<uint32_t>(arg_idx++);
     const uint32_t local_receiver_noc_y = get_arg_val<uint32_t>(arg_idx++);
-    const uint32_t receiver_start_semaphore = get_arg_val<uint32_t>(arg_idx++);
+    const uint32_t receiver_start_semaphore = get_semaphore(get_arg_val<uint32_t>(arg_idx++));
 
     ASSERT(max_concurrent_samples <= NUM_CHANNELS);
     uint32_t last_channel_sync_addr = 0;

--- a/tests/tt_metal/tt_metal/test_kernels/dataflow/unit_tests/erisc/eth_latency_ubench_init_coordination_worker.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/dataflow/unit_tests/erisc/eth_latency_ubench_init_coordination_worker.cpp
@@ -13,8 +13,8 @@ void kernel_main() {
     std::array<uint32_t, 8> channels_addrs;
     std::array<uint32_t, 8> channels_sem_addrs;
     uint32_t arg_idx = 0;
-    volatile uint32_t* sem0 = reinterpret_cast<volatile uint32_t*>(get_arg_val<uint32_t>(arg_idx++));
-    volatile uint32_t* sem1 = reinterpret_cast<volatile uint32_t*>(get_arg_val<uint32_t>(arg_idx++));
+    volatile uint32_t* sem0 = reinterpret_cast<volatile uint32_t*>(get_semaphore(get_arg_val<uint32_t>(arg_idx++)));
+    volatile uint32_t* sem1 = reinterpret_cast<volatile uint32_t*>(get_semaphore(get_arg_val<uint32_t>(arg_idx++)));
     uint32_t core0_x = get_arg_val<uint32_t>(arg_idx++);
     uint32_t core0_y = get_arg_val<uint32_t>(arg_idx++);
     uint32_t core0_start_sem = get_arg_val<uint32_t>(arg_idx++);

--- a/tests/tt_metal/tt_metal/unit_tests/basic/initialize_semaphores.cpp
+++ b/tests/tt_metal/tt_metal/unit_tests/basic/initialize_semaphores.cpp
@@ -66,9 +66,9 @@ void create_and_read_max_num_semaphores(
     std::vector<uint32_t> golden;
     for (uint32_t i = 0; i < NUM_SEMAPHORES; i++) {
         uint32_t initial_value = i;
-        auto semaphore_addr = tt_metal::CreateSemaphore(program, core_range, initial_value);
+        auto semaphore_id = tt_metal::CreateSemaphore(program, core_range, initial_value);
         golden.push_back(initial_value);
-        ASSERT_TRUE(semaphore_addr == SEMAPHORE_BASE + (L1_ALIGNMENT * i));
+        ASSERT_TRUE(semaphore_id == i);
     }
 
     ASSERT_TRUE(tt_metal::detail::ConfigureDeviceWithProgram(device, program));
@@ -123,10 +123,10 @@ TEST_F(DeviceFixture, CreateMultipleSemaphoresOnSameCore) {
     tt_metal::Program program = tt_metal::CreateProgram();
 
     CoreCoord core0(0,0);
-    uint32_t sem0_addr = tt_metal::CreateSemaphore(program, core0, 0);
+    uint32_t sem0_id = tt_metal::CreateSemaphore(program, core0, 0);
 
     CoreCoord core1(4,0);
-    uint32_t sem1_addr = tt_metal::CreateSemaphore(program, core1, 1);
+    uint32_t sem1_id = tt_metal::CreateSemaphore(program, core1, 1);
 
     CoreRange core_range({1, 0}, {3, 0});
     CoreRangeSet core_range_set({core_range});
@@ -135,17 +135,17 @@ TEST_F(DeviceFixture, CreateMultipleSemaphoresOnSameCore) {
     CoreRangeSet core_range_set3(set_of_cores);
     CoreRangeSet core_range_set4({CoreRange({5,0}, {6,0})});
 
-    uint32_t sem2_addr = tt_metal::CreateSemaphore(program, core_range_set, 2);
-    uint32_t sem3_addr = tt_metal::CreateSemaphore(program, core_range_set2, 3);
-    uint32_t sem4_addr = tt_metal::CreateSemaphore(program, core_range_set2, 4);
-    uint32_t sem5_addr = tt_metal::CreateSemaphore(program, core_range_set3, 5);
-    uint32_t sem6_addr = tt_metal::CreateSemaphore(program, core_range_set4, 6);
+    uint32_t sem2_id = tt_metal::CreateSemaphore(program, core_range_set, 2);
+    uint32_t sem3_id = tt_metal::CreateSemaphore(program, core_range_set2, 3);
+    uint32_t sem4_id = tt_metal::CreateSemaphore(program, core_range_set2, 4);
+    uint32_t sem5_id = tt_metal::CreateSemaphore(program, core_range_set3, 5);
+    uint32_t sem6_id = tt_metal::CreateSemaphore(program, core_range_set4, 6);
 
-    EXPECT_EQ(sem0_addr, SEMAPHORE_BASE);
-    EXPECT_EQ(sem1_addr, SEMAPHORE_BASE);
-    EXPECT_EQ(sem2_addr, SEMAPHORE_BASE);
-    EXPECT_EQ(sem3_addr, SEMAPHORE_BASE + L1_ALIGNMENT);
-    EXPECT_EQ(sem4_addr, SEMAPHORE_BASE + L1_ALIGNMENT * 2);
-    EXPECT_EQ(sem5_addr, SEMAPHORE_BASE + L1_ALIGNMENT * 3);
-    EXPECT_EQ(sem6_addr, SEMAPHORE_BASE);
+    EXPECT_EQ(sem0_id, 0);
+    EXPECT_EQ(sem1_id, 0);
+    EXPECT_EQ(sem2_id, 0);
+    EXPECT_EQ(sem3_id, 1);
+    EXPECT_EQ(sem4_id, 2);
+    EXPECT_EQ(sem5_id, 3);
+    EXPECT_EQ(sem6_id, 0);
 }

--- a/tests/tt_metal/tt_metal/unit_tests_common/compute/matmul/test_matmul_multi_core_multi_dram_in0_mcast_in1_mcast.cpp
+++ b/tests/tt_metal/tt_metal/unit_tests_common/compute/matmul/test_matmul_multi_core_multi_dram_in0_mcast_in1_mcast.cpp
@@ -19,18 +19,32 @@
 using namespace tt;
 namespace unit_tests_common::matmul::test_matmul_multi_core_multi_dram_in0_mcast_in1_mcast {
 
-std::tuple<tt_metal::Program, tt_metal::KernelHandle, tt_metal::KernelHandle, tt_metal::KernelHandle, tt_metal::KernelHandle, tt_metal::KernelHandle, tt_metal::KernelHandle> create_program(
+std::tuple<
+    tt_metal::Program,
+    tt_metal::KernelHandle,
+    tt_metal::KernelHandle,
+    tt_metal::KernelHandle,
+    tt_metal::KernelHandle,
+    tt_metal::KernelHandle,
+    tt_metal::KernelHandle,
+    uint32_t,
+    uint32_t,
+    uint32_t,
+    uint32_t>
+create_program(
     tt_metal::Device *device,
     int start_core_x,
     int start_core_y,
     int num_cores_r,
     int num_cores_c,
-    int M, int N, int K,
+    int M,
+    int N,
+    int K,
     int in0_block_w,
     int out_subblock_h,
     int out_subblock_w,
-    int per_core_M, int per_core_N) {
-
+    int per_core_M,
+    int per_core_N) {
     tt_metal::Program program = tt_metal::CreateProgram();
 
     uint32_t single_tile_size = 2 * 1024;
@@ -173,13 +187,23 @@ std::tuple<tt_metal::Program, tt_metal::KernelHandle, tt_metal::KernelHandle, tt
         tt_metal::ComputeConfig{.compile_args = compute_kernel_args}
     );
 
+    uint32_t in0_mcast_sender_semaphore_id = tt::tt_metal::CreateSemaphore(program, all_cores, INVALID);
+    uint32_t in0_mcast_receiver_semaphore_id = tt::tt_metal::CreateSemaphore(program, all_cores, INVALID);
+    uint32_t in1_mcast_sender_semaphore_id = tt::tt_metal::CreateSemaphore(program, all_cores, INVALID);
+    uint32_t in1_mcast_receiver_semaphore_id = tt::tt_metal::CreateSemaphore(program, all_cores, INVALID);
 
-    uint32_t in0_mcast_sender_semaphore = tt::tt_metal::CreateSemaphore(program, all_cores, INVALID);
-    uint32_t in0_mcast_receiver_semaphore = tt::tt_metal::CreateSemaphore(program, all_cores, INVALID);
-    uint32_t in1_mcast_sender_semaphore = tt::tt_metal::CreateSemaphore(program, all_cores, INVALID);
-    uint32_t in1_mcast_receiver_semaphore = tt::tt_metal::CreateSemaphore(program, all_cores, INVALID);
-
-    return {std::move(program), mm_reader_kernel_in0_sender_in1_sender, mm_reader_kernel_in0_sender_in1_receiver, mm_reader_kernel_in0_receiver_in1_sender, mm_reader_kernel_in0_receiver_in1_receiver, unary_writer_kernel_noc0, unary_writer_kernel_noc1};
+    return {
+        std::move(program),
+        mm_reader_kernel_in0_sender_in1_sender,
+        mm_reader_kernel_in0_sender_in1_receiver,
+        mm_reader_kernel_in0_receiver_in1_sender,
+        mm_reader_kernel_in0_receiver_in1_receiver,
+        unary_writer_kernel_noc0,
+        unary_writer_kernel_noc1,
+        in0_mcast_sender_semaphore_id,
+        in0_mcast_receiver_semaphore_id,
+        in1_mcast_sender_semaphore_id,
+        in1_mcast_receiver_semaphore_id};
 }
 
 bool write_runtime_args_to_device(
@@ -206,11 +230,10 @@ bool write_runtime_args_to_device(
     uint32_t in0_dram_addr,
     uint32_t in1_dram_addr,
     uint32_t out_dram_addr,
-    uint32_t in0_mcast_sender_semaphore_addr,
-    uint32_t in1_mcast_sender_semaphore_addr,
-    uint32_t in0_mcast_receiver_semaphore_addr,
-    uint32_t in1_mcast_receiver_semaphore_addr) {
-
+    uint32_t in0_mcast_sender_semaphore_id,
+    uint32_t in1_mcast_sender_semaphore_id,
+    uint32_t in0_mcast_receiver_semaphore_id,
+    uint32_t in1_mcast_receiver_semaphore_id) {
     bool pass = true;
     uint32_t single_tile_size = 2 * 1024;
 
@@ -241,48 +264,47 @@ bool write_runtime_args_to_device(
             auto top_core_plus_one_physical = device->worker_core_from_logical_core(top_core_plus_one);
             auto bottom_core_physical = device->worker_core_from_logical_core(bottom_core);
             std::vector<uint32_t> mm_reader_args = {
-                (std::uint32_t) in0_dram_addr, // in0_tensor_addr
-                (std::uint32_t)  K * per_core_M * core_idx_y, // in0_tensor_start_tile_id
-                (std::uint32_t)  1, // in0_tensor_stride_w
-                (std::uint32_t)  K, // in0_tensor_stride_h
-                (std::uint32_t)  in0_block_w, // in0_tensor_next_block_stride
+                (std::uint32_t)in0_dram_addr,                // in0_tensor_addr
+                (std::uint32_t)K * per_core_M * core_idx_y,  // in0_tensor_start_tile_id
+                (std::uint32_t)1,                            // in0_tensor_stride_w
+                (std::uint32_t)K,                            // in0_tensor_stride_h
+                (std::uint32_t)in0_block_w,                  // in0_tensor_next_block_stride
 
-                (std::uint32_t)  in0_block_w, // in0_block_w
-                (std::uint32_t)  per_core_M, // in0_block_h
-                (std::uint32_t)  in0_block_w * per_core_M, // in0_block_num_tiles
+                (std::uint32_t)in0_block_w,               // in0_block_w
+                (std::uint32_t)per_core_M,                // in0_block_h
+                (std::uint32_t)in0_block_w * per_core_M,  // in0_block_num_tiles
 
-                (std::uint32_t)  in1_dram_addr, // in1_tensor_addr
-                (std::uint32_t)  per_core_N * core_idx_x, //in1_tensor_start_tile_id
-                (std::uint32_t)  1, // in1_tensor_stride_w
-                (std::uint32_t)  N, // in1_tensor_stride_h
-                (std::uint32_t)  in0_block_w * N, //in1_tensor_next_block_stride
+                (std::uint32_t)in1_dram_addr,            // in1_tensor_addr
+                (std::uint32_t)per_core_N * core_idx_x,  // in1_tensor_start_tile_id
+                (std::uint32_t)1,                        // in1_tensor_stride_w
+                (std::uint32_t)N,                        // in1_tensor_stride_h
+                (std::uint32_t)in0_block_w * N,          // in1_tensor_next_block_stride
 
-                (std::uint32_t)  per_core_N, // in1_block_w
-                (std::uint32_t)  in0_block_w, //in1_block_h
-                (std::uint32_t)  per_core_N * in0_block_w, // in1_block_num_tiles
+                (std::uint32_t)per_core_N,                // in1_block_w
+                (std::uint32_t)in0_block_w,               // in1_block_h
+                (std::uint32_t)per_core_N * in0_block_w,  // in1_block_num_tiles
 
-                (std::uint32_t)  K / in0_block_w, // num_blocks
+                (std::uint32_t)K / in0_block_w,  // num_blocks
 
-                (std::uint32_t)  right_core_physical.x, // in0_mcast_dest_noc_start_x
-                (std::uint32_t)  right_core_physical.y, // in0_mcast_dest_noc_start_y
-                (std::uint32_t)  left_core_plus_one_physical.x, // in0_mcast_dest_noc_end_x
-                (std::uint32_t)  left_core_plus_one_physical.y, // in0_mcast_dest_noc_end_y
-                (std::uint32_t)  (num_cores_c - 1), // in0_mcast_num_dests
-                (std::uint32_t)  left_core_physical.x, // in0_mcast_sender_noc_x
-                (std::uint32_t)  left_core_physical.y, // in0_mcast_sender_noc_y
-                (std::uint32_t)  in0_mcast_sender_semaphore_addr,
-                (std::uint32_t)  in0_mcast_receiver_semaphore_addr,
+                (std::uint32_t)right_core_physical.x,          // in0_mcast_dest_noc_start_x
+                (std::uint32_t)right_core_physical.y,          // in0_mcast_dest_noc_start_y
+                (std::uint32_t)left_core_plus_one_physical.x,  // in0_mcast_dest_noc_end_x
+                (std::uint32_t)left_core_plus_one_physical.y,  // in0_mcast_dest_noc_end_y
+                (std::uint32_t)(num_cores_c - 1),              // in0_mcast_num_dests
+                (std::uint32_t)left_core_physical.x,           // in0_mcast_sender_noc_x
+                (std::uint32_t)left_core_physical.y,           // in0_mcast_sender_noc_y
+                (std::uint32_t)in0_mcast_sender_semaphore_id,
+                (std::uint32_t)in0_mcast_receiver_semaphore_id,
 
-                (std::uint32_t)  bottom_core_physical.x, // in0_mcast_dest_noc_start_x
-                (std::uint32_t)  bottom_core_physical.y, // in0_mcast_dest_noc_start_y
-                (std::uint32_t)  top_core_plus_one_physical.x, // in0_mcast_dest_noc_end_x
-                (std::uint32_t)  top_core_plus_one_physical.y, // in0_mcast_dest_noc_end_y
-                (std::uint32_t)  (num_cores_r - 1), // in0_mcast_num_dests
-                (std::uint32_t)  top_core_physical.x, // in0_mcast_sender_noc_x
-                (std::uint32_t)  top_core_physical.y, // in0_mcast_sender_noc_y
-                (std::uint32_t)  in1_mcast_sender_semaphore_addr,
-                (std::uint32_t)  in1_mcast_receiver_semaphore_addr
-            };
+                (std::uint32_t)bottom_core_physical.x,        // in0_mcast_dest_noc_start_x
+                (std::uint32_t)bottom_core_physical.y,        // in0_mcast_dest_noc_start_y
+                (std::uint32_t)top_core_plus_one_physical.x,  // in0_mcast_dest_noc_end_x
+                (std::uint32_t)top_core_plus_one_physical.y,  // in0_mcast_dest_noc_end_y
+                (std::uint32_t)(num_cores_r - 1),             // in0_mcast_num_dests
+                (std::uint32_t)top_core_physical.x,           // in0_mcast_sender_noc_x
+                (std::uint32_t)top_core_physical.y,           // in0_mcast_sender_noc_y
+                (std::uint32_t)in1_mcast_sender_semaphore_id,
+                (std::uint32_t)in1_mcast_receiver_semaphore_id};
             std::vector<uint32_t> writer_args = {
                 (std::uint32_t) out_dram_addr, // out_tensor_addr
                 (std::uint32_t) core_idx_x * per_core_N + core_idx_y * per_core_M * N, // out_tensor_start_tile_id
@@ -348,20 +370,32 @@ bool matmul_multi_core_multi_dram_in0_mcast_in1_mcast(tt_metal::Device *device){
     auto identity = create_identity_matrix(K * 32, N * 32, std::min(K, N) * 32); //bflaot16 identity
     auto golden = select_columns(tensor.get_values(), M, K, N);
 
-    auto [program,
-        mm_reader_kernel_in0_sender_in1_sender,
-        mm_reader_kernel_in0_sender_in1_receiver,
-        mm_reader_kernel_in0_receiver_in1_sender,
-        mm_reader_kernel_in0_receiver_in1_receiver,
-        unary_writer_kernel_noc0,
-        unary_writer_kernel_noc1]  = create_program(device,
-                                                    start_core_x, start_core_y,
-                                                    num_cores_r, num_cores_c,
-                                                    M, N, K,
-                                                    in0_block_w, out_subblock_h, out_subblock_w,
-                                                    per_core_M, per_core_N);
-
-
+    auto
+        [program,
+         mm_reader_kernel_in0_sender_in1_sender,
+         mm_reader_kernel_in0_sender_in1_receiver,
+         mm_reader_kernel_in0_receiver_in1_sender,
+         mm_reader_kernel_in0_receiver_in1_receiver,
+         unary_writer_kernel_noc0,
+         unary_writer_kernel_noc1,
+         in0_mcast_sender_semaphore_id,
+         in0_mcast_receiver_semaphore_id,
+         in1_mcast_sender_semaphore_id,
+         in1_mcast_receiver_semaphore_id] =
+            create_program(
+                device,
+                start_core_x,
+                start_core_y,
+                num_cores_r,
+                num_cores_c,
+                M,
+                N,
+                K,
+                in0_block_w,
+                out_subblock_h,
+                out_subblock_w,
+                per_core_M,
+                per_core_N);
 
     log_debug(LogTest, "Scattering inputs (activation & weights) to dram channels using tiled layout");
     auto activations_tilized = test_utils::tilize(tensor.get_values(), M * 32, K * 32);
@@ -376,26 +410,35 @@ bool matmul_multi_core_multi_dram_in0_mcast_in1_mcast(tt_metal::Device *device){
     log_debug(LogTest, "Copying inputs to dram complete");
 
     log_debug(LogTest, "Writing kernel runtime args to device");
-    const vector<Semaphore>& semaphores = program.semaphores();
-    uint32_t in0_mcast_sender_semaphore_noc_addr = semaphores[0].address();
-    uint32_t in1_mcast_sender_semaphore_noc_addr = semaphores[1].address();
-    uint32_t in0_mcast_receiver_semaphore_noc_addr = semaphores[2].address();
-    uint32_t in1_mcast_receiver_semaphore_noc_addr = semaphores[3].address();
 
     pass &= write_runtime_args_to_device(
         device,
         program,
-        start_core_x, start_core_y,
-        num_cores_r, num_cores_c,
-        mm_reader_kernel_in0_sender_in1_sender, mm_reader_kernel_in0_sender_in1_receiver, mm_reader_kernel_in0_receiver_in1_sender, mm_reader_kernel_in0_receiver_in1_receiver,
-        unary_writer_kernel_noc0, unary_writer_kernel_noc1,
-        M, N, K,
+        start_core_x,
+        start_core_y,
+        num_cores_r,
+        num_cores_c,
+        mm_reader_kernel_in0_sender_in1_sender,
+        mm_reader_kernel_in0_sender_in1_receiver,
+        mm_reader_kernel_in0_receiver_in1_sender,
+        mm_reader_kernel_in0_receiver_in1_receiver,
+        unary_writer_kernel_noc0,
+        unary_writer_kernel_noc1,
+        M,
+        N,
+        K,
         in0_block_w,
-        out_subblock_h, out_subblock_w,
-        per_core_M, per_core_N,
-        in0_dram_addr, in1_dram_addr, out_dram_addr,
-        in0_mcast_sender_semaphore_noc_addr, in1_mcast_sender_semaphore_noc_addr, in0_mcast_receiver_semaphore_noc_addr, in1_mcast_receiver_semaphore_noc_addr
-    );
+        out_subblock_h,
+        out_subblock_w,
+        per_core_M,
+        per_core_N,
+        in0_dram_addr,
+        in1_dram_addr,
+        out_dram_addr,
+        in0_mcast_sender_semaphore_id,
+        in1_mcast_sender_semaphore_id,
+        in0_mcast_receiver_semaphore_id,
+        in1_mcast_receiver_semaphore_id);
     log_debug(LogTest, "Writing kernel runtime args to device complete");
 
     log_debug(LogTest, "Running Matmul {} core test", num_cores_r * num_cores_c);

--- a/tests/tt_metal/tt_metal/unit_tests_fast_dispatch/command_queue/test_EnqueueProgram.cpp
+++ b/tests/tt_metal/tt_metal/unit_tests_fast_dispatch/command_queue/test_EnqueueProgram.cpp
@@ -151,7 +151,8 @@ bool test_dummy_EnqueueProgram_with_sems(Device* device, CommandQueue& cq, const
     Program program;
 
     for (uint32_t sem_id = 0; sem_id < program_config.num_sems; sem_id++) {
-        CreateSemaphore(program, program_config.cr_set, sem_id);
+        uint32_t allocated_sem_id  = CreateSemaphore(program, program_config.cr_set, sem_id);
+        pass &= (allocated_sem_id == sem_id);
     }
 
     EnqueueProgram(cq, program, false);

--- a/tests/tt_metal/tt_metal/unit_tests_fast_dispatch/pipelining/basic_pipeline.cpp
+++ b/tests/tt_metal/tt_metal/unit_tests_fast_dispatch/pipelining/basic_pipeline.cpp
@@ -155,28 +155,24 @@ void create_and_run_row_pipeline(tt_metal::Device* device, const PipelineRowConf
     for (auto core : cores) {
         CoreRange cr(core, core);
 
-        auto sender_semaphore = tt_metal::CreateSemaphore(program, cr, INVALID);
-        auto receiver_semaphore = tt_metal::CreateSemaphore(program, cr, INVALID);
-        auto l1_valid_value_semaphore = tt_metal::CreateSemaphore(program, cr, VALID);
-
-        tt::log_debug("SENDER SEM ADDR {}", sender_semaphore);
-        tt::log_debug("RECEIVER SEM ADDR {}", receiver_semaphore);
-        tt::log_debug("L1 VALID VALUE SEM ADDR {}", l1_valid_value_semaphore);
+        auto sender_semaphore_id = tt_metal::CreateSemaphore(program, cr, INVALID);
+        auto receiver_semaphore_id = tt_metal::CreateSemaphore(program, cr, INVALID);
+        auto l1_valid_value_semaphore_id = tt_metal::CreateSemaphore(program, cr, VALID);
 
         vector<uint32_t> init_vec;
         sems.emplace(core, init_vec);
-        sems.at(core).push_back(sender_semaphore);
-        sems.at(core).push_back(receiver_semaphore);
-        sems.at(core).push_back(l1_valid_value_semaphore);
+        sems.at(core).push_back(sender_semaphore_id);
+        sems.at(core).push_back(receiver_semaphore_id);
+        sems.at(core).push_back(l1_valid_value_semaphore_id);
     }
 
     for (int core_id = 0; core_id < num_cores; core_id++) {
         // TODO(agrebenisan):  Once semaphores are properly allocated at 16B-aligned addresses, then
         // will make proper sems. For now, using the original code.
         CoreCoord core = cores[core_id];
-        auto sender_semaphore_addr = sems[core].at(0);
-        auto receiver_semaphore_addr = sems[core].at(1);
-        auto l1_valid_value_addr = sems[core].at(2);
+        auto sender_semaphore_id = sems[core].at(0);
+        auto receiver_semaphore_id = sems[core].at(1);
+        auto l1_valid_value_id = sems[core].at(2);
 
         if (core_id == 0) {
             SetRuntimeArgs(
@@ -192,8 +188,8 @@ void create_and_run_row_pipeline(tt_metal::Device* device, const PipelineRowConf
                 {(uint32_t)device->worker_core_from_logical_core(cores[core_id - 1]).x,
                  (uint32_t)device->worker_core_from_logical_core(cores[core_id - 1]).y,
                  (uint32_t)num_tiles,
-                 (uint32_t)sender_semaphore_addr,
-                 (uint32_t)receiver_semaphore_addr,
+                 (uint32_t)sender_semaphore_id,
+                 (uint32_t)receiver_semaphore_id,
                  (uint32_t)num_repetitions});
         }
 
@@ -211,9 +207,9 @@ void create_and_run_row_pipeline(tt_metal::Device* device, const PipelineRowConf
                 {(uint32_t)device->worker_core_from_logical_core(cores[core_id + 1]).x,
                  (uint32_t)device->worker_core_from_logical_core(cores[core_id + 1]).y,
                  (uint32_t)num_tiles,
-                 (uint32_t)sender_semaphore_addr,
-                 (uint32_t)receiver_semaphore_addr,
-                 (uint32_t)l1_valid_value_addr,
+                 (uint32_t)sender_semaphore_id,
+                 (uint32_t)receiver_semaphore_id,
+                 (uint32_t)l1_valid_value_id,
                  (uint32_t)num_repetitions});
         }
     }
@@ -248,8 +244,6 @@ void create_and_run_row_pipeline(tt_metal::Device* device, const PipelineRowConf
 }  // namespace unit_tests::create_pipeline
 
 TEST_F(CommandQueueFixture, TestPipelineAcrossRows) {
-    // #7222
-    GTEST_SKIP();
     if (this->arch_ != tt::ARCH::GRAYSKULL) {
         GTEST_SKIP();
     }

--- a/tt_metal/impl/buffers/semaphore.cpp
+++ b/tt_metal/impl/buffers/semaphore.cpp
@@ -8,24 +8,32 @@ namespace tt {
 
 namespace tt_metal {
 
-Semaphore::Semaphore(const Semaphore &other) : core_range_set_(other.core_range_set_), address_(other.address_), initial_value_(other.initial_value_), core_type_(other.core_type_) {}
+Semaphore::Semaphore(const Semaphore &other) :
+    core_range_set_(other.core_range_set_),
+    id_(other.id_),
+    initial_value_(other.initial_value_),
+    core_type_(other.core_type_) {}
 
 Semaphore &Semaphore::operator=(const Semaphore &other) {
     if (this != &other) {
         this->core_range_set_ = other.core_range_set_;
-        this->address_ = other.address_;
+        this->id_ = other.id_;
         this->initial_value_ = other.initial_value_;
         this->core_type_ = other.core_type_;
     }
     return *this;
 }
 
-Semaphore::Semaphore(Semaphore &&other) : core_range_set_(other.core_range_set_), address_(other.address_), initial_value_(other.initial_value_), core_type_(other.core_type_) {}
+Semaphore::Semaphore(Semaphore &&other) :
+    core_range_set_(other.core_range_set_),
+    id_(other.id_),
+    initial_value_(other.initial_value_),
+    core_type_(other.core_type_) {}
 
 Semaphore &Semaphore::operator=(Semaphore &&other) {
     if (this != &other) {
         this->core_range_set_ = other.core_range_set_;
-        this->address_ = other.address_;
+        this->id_ = other.id_;
         this->initial_value_ = other.initial_value_;
         this->core_type_ = other.core_type_;
     }
@@ -34,6 +42,13 @@ Semaphore &Semaphore::operator=(Semaphore &&other) {
 
 bool Semaphore::initialized_on_logical_core(const CoreCoord &logical_core) const {
     return this->core_range_set_.core_coord_in_core_ranges(logical_core);
+}
+
+uint32_t Semaphore::address() const {
+    // TODO: need to modify this for ring buffer changes
+    // TODO: no support for active eth cores, where the base addr is eth_l1_mem::address_map::SEMAPHORE_BASE
+    uint32_t address = SEMAPHORE_BASE + (L1_ALIGNMENT * id_);
+    return address;
 }
 
 }  // namespace tt_metal

--- a/tt_metal/impl/buffers/semaphore.hpp
+++ b/tt_metal/impl/buffers/semaphore.hpp
@@ -17,16 +17,11 @@ namespace tt_metal {
 // Semaphores are statically allocated withing range [SEMAPHORE_BASE, SEMAPHORE_BASE + SEMAPHORE_SIZE]
 class Semaphore {
    public:
-    Semaphore(
-        const CoreRangeSet &core_range_set,
-        uint32_t address,
-        uint32_t initial_value) : core_range_set_(core_range_set), address_(address), initial_value_(initial_value), core_type_(CoreType::WORKER) {}
+    Semaphore(const CoreRangeSet &core_range_set, uint32_t id, uint32_t initial_value) :
+        core_range_set_(core_range_set), id_(id), initial_value_(initial_value), core_type_(CoreType::WORKER) {}
 
-    Semaphore(
-        const CoreRangeSet &core_range_set,
-        uint32_t address,
-        uint32_t initial_value,
-        CoreType core_type) : core_range_set_(core_range_set), address_(address), initial_value_(initial_value), core_type_(core_type) {}
+    Semaphore(const CoreRangeSet &core_range_set, uint32_t id, uint32_t initial_value, CoreType core_type) :
+        core_range_set_(core_range_set), id_(id), initial_value_(initial_value), core_type_(core_type) {}
 
     Semaphore(const Semaphore &other);
 
@@ -38,9 +33,10 @@ class Semaphore {
 
     constexpr uint32_t size() const { return SEMAPHORE_SIZE / NUM_SEMAPHORES; }
 
-    uint32_t id() const { return (address_ - SEMAPHORE_BASE) / L1_ALIGNMENT; }
+    uint32_t id() const { return id_; }
 
-    uint32_t address() const { return address_; }
+    // TODO: will be removed, calculated in program compile instead
+    uint32_t address() const;
 
     CoreRangeSet core_range_set() const { return core_range_set_; }
 
@@ -52,7 +48,7 @@ class Semaphore {
 
    private:
     CoreRangeSet core_range_set_;             // Ranges of cores where this semaphore is initialized
-    uint32_t address_;
+    uint32_t id_;
     uint32_t initial_value_;              // Initial value of semaphore
     CoreType core_type_;                       // Type of core. ETH, WORKER.
 };

--- a/tt_metal/impl/program/program.cpp
+++ b/tt_metal/impl/program/program.cpp
@@ -512,9 +512,9 @@ void Program::init_semaphores(const Device &device, const CoreCoord &logical_cor
     }
 }
 
-void Program::add_semaphore(const CoreRangeSet &crs, uint32_t address, uint32_t init_value, CoreType core_type) {
+void Program::add_semaphore(const CoreRangeSet &crs, uint32_t semaphore_id, uint32_t init_value, CoreType core_type) {
     this->invalidate_compile();
-    semaphores_.emplace_back(Semaphore(crs, address, init_value, core_type));
+    semaphores_.emplace_back(Semaphore(crs, semaphore_id, init_value, core_type));
 }
 
 void Program::add_config_buffer(std::shared_ptr<Buffer> config_buffer) { config_buffers_.emplace_back(config_buffer); }

--- a/tt_metal/impl/program/program.hpp
+++ b/tt_metal/impl/program/program.hpp
@@ -228,7 +228,7 @@ class Program {
     CBHandle add_circular_buffer(const CoreRangeSet &core_range_set, const CircularBufferConfig &config);
     std::shared_ptr<CircularBuffer> get_circular_buffer(CBHandle cb_id) const;
 
-    void add_semaphore(const CoreRangeSet & crs, uint32_t address, uint32_t init_value, CoreType core_type=CoreType::WORKER);
+    void add_semaphore(const CoreRangeSet & crs, uint32_t semaphore_id, uint32_t init_value, CoreType core_type=CoreType::WORKER);
 
     friend void detail::AddConfigBuffer(Program &program, std::shared_ptr<Buffer> config_buffer);
     void add_config_buffer(std::shared_ptr<Buffer> config_buffer);

--- a/tt_metal/programming_examples/matmul_common/kernels/dataflow/reader_bmm_tile_layout_in0_receiver_in1_receiver.cpp
+++ b/tt_metal/programming_examples/matmul_common/kernels/dataflow/reader_bmm_tile_layout_in0_receiver_in1_receiver.cpp
@@ -42,8 +42,8 @@ void kernel_main() {
     uint32_t in0_mcast_num_dests                = get_arg_val<uint32_t>(21);
     uint32_t in0_mcast_sender_noc_x             = get_arg_val<uint32_t>(22);
     uint32_t in0_mcast_sender_noc_y             = get_arg_val<uint32_t>(23);
-    uint32_t in0_mcast_sender_semaphore_addr    = get_arg_val<uint32_t>(24);
-    uint32_t in0_mcast_receiver_semaphore_addr  = get_arg_val<uint32_t>(25);
+    uint32_t in0_mcast_sender_semaphore_addr    = get_semaphore(get_arg_val<uint32_t>(24));
+    uint32_t in0_mcast_receiver_semaphore_addr  = get_semaphore(get_arg_val<uint32_t>(25));
 
     // in1 mcast args
     uint32_t in1_mcast_dest_noc_start_x         = get_arg_val<uint32_t>(26);
@@ -53,8 +53,8 @@ void kernel_main() {
     uint32_t in1_mcast_num_dests                = get_arg_val<uint32_t>(30);
     uint32_t in1_mcast_sender_noc_x             = get_arg_val<uint32_t>(31);
     uint32_t in1_mcast_sender_noc_y             = get_arg_val<uint32_t>(32);
-    uint32_t in1_mcast_sender_semaphore_addr    = get_arg_val<uint32_t>(33);
-    uint32_t in1_mcast_receiver_semaphore_addr  = get_arg_val<uint32_t>(34);
+    uint32_t in1_mcast_sender_semaphore_addr    = get_semaphore(get_arg_val<uint32_t>(33));
+    uint32_t in1_mcast_receiver_semaphore_addr  = get_semaphore(get_arg_val<uint32_t>(34));
 
     // batch args
     uint32_t MtKt                               = get_arg_val<uint32_t>(35); // if 0

--- a/tt_metal/programming_examples/matmul_common/kernels/dataflow/reader_bmm_tile_layout_in0_receiver_in1_sender.cpp
+++ b/tt_metal/programming_examples/matmul_common/kernels/dataflow/reader_bmm_tile_layout_in0_receiver_in1_sender.cpp
@@ -42,8 +42,8 @@ void kernel_main() {
     uint32_t in0_mcast_num_dests                = get_arg_val<uint32_t>(21);
     uint32_t in0_mcast_sender_noc_x             = get_arg_val<uint32_t>(22);
     uint32_t in0_mcast_sender_noc_y             = get_arg_val<uint32_t>(23);
-    uint32_t in0_mcast_sender_semaphore_addr    = get_arg_val<uint32_t>(24);
-    uint32_t in0_mcast_receiver_semaphore_addr  = get_arg_val<uint32_t>(25);
+    uint32_t in0_mcast_sender_semaphore_addr    = get_semaphore(get_arg_val<uint32_t>(24));
+    uint32_t in0_mcast_receiver_semaphore_addr  = get_semaphore(get_arg_val<uint32_t>(25));
 
     // in1 mcast args
     uint32_t in1_mcast_dest_noc_start_x         = get_arg_val<uint32_t>(26);
@@ -53,8 +53,8 @@ void kernel_main() {
     uint32_t in1_mcast_num_dests                = get_arg_val<uint32_t>(30);
     uint32_t in1_mcast_sender_noc_x             = get_arg_val<uint32_t>(31);
     uint32_t in1_mcast_sender_noc_y             = get_arg_val<uint32_t>(32);
-    uint32_t in1_mcast_sender_semaphore_addr    = get_arg_val<uint32_t>(33);
-    uint32_t in1_mcast_receiver_semaphore_addr  = get_arg_val<uint32_t>(34);
+    uint32_t in1_mcast_sender_semaphore_addr    = get_semaphore(get_arg_val<uint32_t>(33));
+    uint32_t in1_mcast_receiver_semaphore_addr  = get_semaphore(get_arg_val<uint32_t>(34));
 
     // batch args
     uint32_t MtKt                               = get_arg_val<uint32_t>(35); // if 0

--- a/tt_metal/programming_examples/matmul_common/kernels/dataflow/reader_bmm_tile_layout_in0_sender_in1_receiver.cpp
+++ b/tt_metal/programming_examples/matmul_common/kernels/dataflow/reader_bmm_tile_layout_in0_sender_in1_receiver.cpp
@@ -42,8 +42,8 @@ void kernel_main() {
     uint32_t in0_mcast_num_dests                = get_arg_val<uint32_t>(21);
     uint32_t in0_mcast_sender_noc_x             = get_arg_val<uint32_t>(22);
     uint32_t in0_mcast_sender_noc_y             = get_arg_val<uint32_t>(23);
-    uint32_t in0_mcast_sender_semaphore_addr    = get_arg_val<uint32_t>(24);
-    uint32_t in0_mcast_receiver_semaphore_addr  = get_arg_val<uint32_t>(25);
+    uint32_t in0_mcast_sender_semaphore_addr    = get_semaphore(get_arg_val<uint32_t>(24));
+    uint32_t in0_mcast_receiver_semaphore_addr  = get_semaphore(get_arg_val<uint32_t>(25));
 
     // in1 mcast args
     uint32_t in1_mcast_dest_noc_start_x         = get_arg_val<uint32_t>(26);
@@ -53,8 +53,8 @@ void kernel_main() {
     uint32_t in1_mcast_num_dests                = get_arg_val<uint32_t>(30);
     uint32_t in1_mcast_sender_noc_x             = get_arg_val<uint32_t>(31);
     uint32_t in1_mcast_sender_noc_y             = get_arg_val<uint32_t>(32);
-    uint32_t in1_mcast_sender_semaphore_addr    = get_arg_val<uint32_t>(33);
-    uint32_t in1_mcast_receiver_semaphore_addr  = get_arg_val<uint32_t>(34);
+    uint32_t in1_mcast_sender_semaphore_addr    = get_semaphore(get_arg_val<uint32_t>(33));
+    uint32_t in1_mcast_receiver_semaphore_addr  = get_semaphore(get_arg_val<uint32_t>(34));
 
     // batch args
     uint32_t MtKt                               = get_arg_val<uint32_t>(35); // if 0

--- a/tt_metal/programming_examples/matmul_common/kernels/dataflow/reader_bmm_tile_layout_in0_sender_in1_sender.cpp
+++ b/tt_metal/programming_examples/matmul_common/kernels/dataflow/reader_bmm_tile_layout_in0_sender_in1_sender.cpp
@@ -42,8 +42,8 @@ void kernel_main() {
     uint32_t in0_mcast_num_dests                = get_arg_val<uint32_t>(21);
     uint32_t in0_mcast_sender_noc_x             = get_arg_val<uint32_t>(22);
     uint32_t in0_mcast_sender_noc_y             = get_arg_val<uint32_t>(23);
-    uint32_t in0_mcast_sender_semaphore_addr    = get_arg_val<uint32_t>(24);
-    uint32_t in0_mcast_receiver_semaphore_addr  = get_arg_val<uint32_t>(25);
+    uint32_t in0_mcast_sender_semaphore_addr    = get_semaphore(get_arg_val<uint32_t>(24));
+    uint32_t in0_mcast_receiver_semaphore_addr  = get_semaphore(get_arg_val<uint32_t>(25));
 
     // in1 mcast args
     uint32_t in1_mcast_dest_noc_start_x         = get_arg_val<uint32_t>(26);
@@ -53,8 +53,8 @@ void kernel_main() {
     uint32_t in1_mcast_num_dests                = get_arg_val<uint32_t>(30);
     uint32_t in1_mcast_sender_noc_x             = get_arg_val<uint32_t>(31);
     uint32_t in1_mcast_sender_noc_y             = get_arg_val<uint32_t>(32);
-    uint32_t in1_mcast_sender_semaphore_addr    = get_arg_val<uint32_t>(33);
-    uint32_t in1_mcast_receiver_semaphore_addr  = get_arg_val<uint32_t>(34);
+    uint32_t in1_mcast_sender_semaphore_addr    = get_semaphore(get_arg_val<uint32_t>(33));
+    uint32_t in1_mcast_receiver_semaphore_addr  = get_semaphore(get_arg_val<uint32_t>(34));
 
     // batch args
     uint32_t MtKt                               = get_arg_val<uint32_t>(35); // if 0

--- a/tt_metal/programming_examples/matmul_multicore_reuse_mcast/matmul_multicore_reuse_mcast.cpp
+++ b/tt_metal/programming_examples/matmul_multicore_reuse_mcast/matmul_multicore_reuse_mcast.cpp
@@ -306,10 +306,10 @@ void matmul_multicore_reuse_mcast(std::vector<bfloat16>& a, std::vector<bfloat16
         tt_metal::ComputeConfig{.math_fidelity = math_fidelity, .compile_args = compute_kernel_args}
     );
 
-    auto in0_mcast_sender_semaphore = tt_metal::CreateSemaphore(program, all_cores, INVALID);
-    auto in0_mcast_receiver_semaphore = tt_metal::CreateSemaphore(program, all_cores, INVALID);
-    auto in1_mcast_sender_semaphore = tt_metal::CreateSemaphore(program, all_cores, INVALID);
-    auto in1_mcast_receiver_semaphore = tt_metal::CreateSemaphore(program, all_cores, INVALID);
+    auto in0_mcast_sender_semaphore_id = tt_metal::CreateSemaphore(program, all_cores, INVALID);
+    auto in0_mcast_receiver_semaphore_id = tt_metal::CreateSemaphore(program, all_cores, INVALID);
+    auto in1_mcast_sender_semaphore_id = tt_metal::CreateSemaphore(program, all_cores, INVALID);
+    auto in1_mcast_receiver_semaphore_id = tt_metal::CreateSemaphore(program, all_cores, INVALID);
 
 
     /*
@@ -365,8 +365,8 @@ void matmul_multicore_reuse_mcast(std::vector<bfloat16>& a, std::vector<bfloat16
                 (std::uint32_t)  (num_cores_c - 1), // in0_mcast_num_dests
                 (std::uint32_t)  left_core_physical.x, // in0_mcast_sender_noc_x
                 (std::uint32_t)  left_core_physical.y, // in0_mcast_sender_noc_y
-                (std::uint32_t)  in0_mcast_sender_semaphore,
-                (std::uint32_t)  in0_mcast_receiver_semaphore,
+                (std::uint32_t)  in0_mcast_sender_semaphore_id,
+                (std::uint32_t)  in0_mcast_receiver_semaphore_id,
 
                 (std::uint32_t)  bottom_core_physical.x, // in0_mcast_dest_noc_start_x
                 (std::uint32_t)  bottom_core_physical.y, // in0_mcast_dest_noc_start_y
@@ -375,8 +375,8 @@ void matmul_multicore_reuse_mcast(std::vector<bfloat16>& a, std::vector<bfloat16
                 (std::uint32_t)  (num_cores_r - 1), // in0_mcast_num_dests
                 (std::uint32_t)  top_core_physical.x, // in0_mcast_sender_noc_x
                 (std::uint32_t)  top_core_physical.y, // in0_mcast_sender_noc_y
-                (std::uint32_t)  in1_mcast_sender_semaphore,
-                (std::uint32_t)  in1_mcast_receiver_semaphore,
+                (std::uint32_t)  in1_mcast_sender_semaphore_id,
+                (std::uint32_t)  in1_mcast_receiver_semaphore_id,
 
                 (std::uint32_t)  Mt * Kt, // MtKt
                 (std::uint32_t)  Kt * Nt, // KtNt

--- a/tt_metal/tt_metal.cpp
+++ b/tt_metal/tt_metal.cpp
@@ -37,8 +37,8 @@ void ConfigureKernelGroup(
     }
 }
 
-std::optional<uint32_t> get_semaphore_address(const Program &program, const CoreRange &core_range) {
-    std::optional<uint32_t> address = std::nullopt;
+std::optional<uint32_t> get_semaphore_id(const Program &program, const CoreRange &core_range) {
+    std::optional<uint32_t> semaphore_id = std::nullopt;
     std::vector<uint32_t> semaphore_histogram(NUM_SEMAPHORES, 0);
     for (auto x = core_range.start_coord.x; x <= core_range.end_coord.x; x++) {
         for (auto y = core_range.start_coord.y; y <= core_range.end_coord.y; y++) {
@@ -65,12 +65,12 @@ std::optional<uint32_t> get_semaphore_address(const Program &program, const Core
     }
 
     if (uninitialized_sem_id.has_value()) {
-        address = SEMAPHORE_BASE + (L1_ALIGNMENT * uninitialized_sem_id.value());
+        semaphore_id =  uninitialized_sem_id.value();
     } else {
         TT_THROW("Unable to initialize semaphores on core range " + core_range.str());
     }
 
-    return address;
+    return semaphore_id;
 }
 
 inline void SetRuntimeArgs(
@@ -809,23 +809,23 @@ uint32_t CreateSemaphore(
             } else {
                 crs = c;
             }
-            std::optional<uint32_t> address;
+            std::optional<uint32_t> semaphore_id;
             TT_FATAL(crs.ranges().size() > 0, "Expecting a non-empty CoreRangeSet!");
             for (const auto &core_range : crs.ranges()) {
                 CoreCoord start_core = core_range.start_coord;
                 CoreCoord end_core = core_range.end_coord;
-                std::optional<uint32_t> addr_candidate = get_semaphore_address(program, core_range);
-                if (!address.has_value()) {
-                    address = addr_candidate;
+                std::optional<uint32_t> semaphore_id_candidate = get_semaphore_id(program, core_range);
+                if (!semaphore_id.has_value()) {
+                    semaphore_id = semaphore_id_candidate;
                 } else {
-                    address = std::max(address.value(), addr_candidate.value());
+                    semaphore_id = std::max(semaphore_id.value(), semaphore_id.value());
                 }
             }
-            TT_FATAL(address.has_value(), "Unable to initialize Semaphore!");
+            TT_FATAL(semaphore_id.has_value(), "Unable to initialize Semaphore!");
 
-            program.add_semaphore(crs, address.value(), initial_value, core_type);
+            program.add_semaphore(crs, semaphore_id.value(), initial_value, core_type);
 
-            return address.value();
+            return semaphore_id.value();
         },
         core_spec);
 }

--- a/ttnn/cpp/ttnn/deprecated/tt_dnn/op_library/move/kernels/dataflow/move_interleaved_with_overlap.cpp
+++ b/ttnn/cpp/ttnn/deprecated/tt_dnn/op_library/move/kernels/dataflow/move_interleaved_with_overlap.cpp
@@ -10,7 +10,7 @@ void kernel_main() {
     uint32_t dst_addr = get_arg_val<uint32_t>(1);
     uint32_t start_id = get_arg_val<uint32_t>(2);
     uint32_t num_tiles = get_arg_val<uint32_t>(3);
-    uint32_t semaphore_addr = get_arg_val<uint32_t>(4);
+    uint32_t semaphore_addr = get_semaphore(get_arg_val<uint32_t>(4));
     uint32_t controller_noc_x = get_arg_val<uint32_t>(5);
     uint32_t controller_noc_y = get_arg_val<uint32_t>(6);
     uint32_t control_value = get_arg_val<uint32_t>(7);

--- a/ttnn/cpp/ttnn/deprecated/tt_dnn/op_library/move/kernels/dataflow/move_stick_layout_interleaved_with_overlap.cpp
+++ b/ttnn/cpp/ttnn/deprecated/tt_dnn/op_library/move/kernels/dataflow/move_stick_layout_interleaved_with_overlap.cpp
@@ -10,7 +10,7 @@ void kernel_main() {
     uint32_t dst_addr = get_arg_val<uint32_t>(1);
     uint32_t start_id = get_arg_val<uint32_t>(2);
     uint32_t num_pages = get_arg_val<uint32_t>(3);
-    uint32_t semaphore_addr = get_arg_val<uint32_t>(4);
+    uint32_t semaphore_addr = get_semaphore(get_arg_val<uint32_t>(4));
     uint32_t controller_noc_x = get_arg_val<uint32_t>(5);
     uint32_t controller_noc_y = get_arg_val<uint32_t>(6);
     uint32_t control_value = get_arg_val<uint32_t>(7);

--- a/ttnn/cpp/ttnn/deprecated/tt_dnn/op_library/move/multi_core/move_op_multi_core_overlap.cpp
+++ b/ttnn/cpp/ttnn/deprecated/tt_dnn/op_library/move/multi_core/move_op_multi_core_overlap.cpp
@@ -85,7 +85,7 @@ operation::ProgramWithCallbacks move_multi_core_with_overlap(const Tensor &input
 		.set_page_size(cb_index, aligned_page_size);
     auto cb = tt_metal::CreateCircularBuffer(program, all_cores, cb_config);
 
-    auto semaphore_addr = CreateSemaphore(program, all_cores, 0);
+    auto semaphore_id = CreateSemaphore(program, all_cores, 0);
 
     auto src_buffer = input.buffer();
     auto dst_buffer = output.buffer();
@@ -140,7 +140,7 @@ operation::ProgramWithCallbacks move_multi_core_with_overlap(const Tensor &input
             dst_buffer->address(),
             pages_handled_per_core,
             num_pages_per_core,
-            semaphore_addr,
+            semaphore_id,
             (uint32_t)noc_controller.x,
             (uint32_t)noc_controller.y,
             /*control_value=*/(num_cores - 1),

--- a/ttnn/cpp/ttnn/deprecated/tt_dnn/op_library/sdpa/kernels/dataflow/writer_decode_all.cpp
+++ b/ttnn/cpp/ttnn/deprecated/tt_dnn/op_library/sdpa/kernels/dataflow/writer_decode_all.cpp
@@ -243,7 +243,7 @@ void kernel_main() {
     constexpr uint32_t scale_val = get_compile_time_arg_val(5);
     constexpr uint32_t num_cores_per_batch = get_compile_time_arg_val(6);  // num cores per batch
     constexpr uint32_t num_cores = get_compile_time_arg_val(7);  // num running cores in total
-    constexpr uint32_t semaphore_addr   = get_compile_time_arg_val(8);  // semaphore for reciever
+    uint32_t semaphore_addr   = get_semaphore(get_compile_time_arg_val(8));  // semaphore for reciever
     constexpr bool is_out_sharded = get_compile_time_arg_val(9);
 
     const uint32_t out_addr  = get_arg_val<uint32_t>(0);

--- a/ttnn/cpp/ttnn/deprecated/tt_dnn/op_library/sdpa/multi_core/sdpa_decode_op_multi_core.cpp
+++ b/ttnn/cpp/ttnn/deprecated/tt_dnn/op_library/sdpa/multi_core/sdpa_decode_op_multi_core.cpp
@@ -455,7 +455,7 @@ operation::ProgramWithCallbacks sdpa_decode_multi_core(
     log_debug("reduce_core_physical_ys: {}", reduce_core_physical_ys);
 
     // Common Compile time Args
-    auto in0_mcast_reducer_semaphore = tt_metal::CreateSemaphore(program, core_grid, 0);
+    auto in0_mcast_reducer_semaphore_id = tt_metal::CreateSemaphore(program, core_grid, 0);
 
     std::vector<uint32_t> reader_compile_time_args_common = {
         B, PNHt, St, DHt, Sk_chunk_t, num_active_cores, is_q_sharded
@@ -467,7 +467,7 @@ operation::ProgramWithCallbacks sdpa_decode_multi_core(
         scale_union.u,
         num_cores_per_batch,
         num_active_cores,
-        in0_mcast_reducer_semaphore,
+        in0_mcast_reducer_semaphore_id,
         is_output_sharded,
     };
 

--- a/ttnn/cpp/ttnn/deprecated/tt_dnn/op_library/transformer_tms/kernels/dataflow/reader_mcast_transformer_group_attn_matmul.cpp
+++ b/ttnn/cpp/ttnn/deprecated/tt_dnn/op_library/transformer_tms/kernels/dataflow/reader_mcast_transformer_group_attn_matmul.cpp
@@ -43,8 +43,8 @@ void kernel_main() {
     uint32_t in1_mcast_num_dests                         = get_arg_val<uint32_t>(i++);
     uint32_t in1_mcast_num_cores                         = get_arg_val<uint32_t>(i++);
     uint32_t in1_mcast_grid_size                         = get_arg_val<uint32_t>(i++);
-    uint32_t in1_mcast_sender_semaphore_addr             = get_arg_val<uint32_t>(i++);
-    uint32_t in1_mcast_receiver_semaphore_addr           = get_arg_val<uint32_t>(i++);
+    uint32_t in1_mcast_sender_semaphore_addr             = get_semaphore(get_arg_val<uint32_t>(i++));
+    uint32_t in1_mcast_receiver_semaphore_addr           = get_semaphore(get_arg_val<uint32_t>(i++));
 
     uint32_t in1_mcast_sender_size_bytes                 = get_arg_val<uint32_t>(i++);
     uint32_t in1_mcast_sender_id                         = get_arg_val<uint32_t>(i++);

--- a/ttnn/cpp/ttnn/deprecated/tt_dnn/op_library/transformer_tms/multi_core_group_attn_matmul/multi_core_group_attn_matmul.cpp
+++ b/ttnn/cpp/ttnn/deprecated/tt_dnn/op_library/transformer_tms/multi_core_group_attn_matmul/multi_core_group_attn_matmul.cpp
@@ -111,8 +111,8 @@ operation::ProgramWithCallbacks multi_core_group_attn_matmul(const Tensor &a, co
 
 
     // Mcast args
-    auto in1_mcast_sender_semaphore = tt_metal::CreateSemaphore(program, all_device_cores, INVALID);
-    auto in1_mcast_receiver_semaphore = tt_metal::CreateSemaphore(program, all_device_cores, INVALID);
+    auto in1_mcast_sender_semaphore_id = tt_metal::CreateSemaphore(program, all_device_cores, INVALID);
+    auto in1_mcast_receiver_semaphore_id = tt_metal::CreateSemaphore(program, all_device_cores, INVALID);
 
     // Only first 32 of cores mcast KV heads to match num_rows_in_one_tile in reader kernel, so these coordinates are static if we cache on compute_with_storage_grid_size
     // TODO: If this is not the case, then we should set reader_runtime_args to max possible size and update sender noc coordinates based on input
@@ -285,8 +285,8 @@ operation::ProgramWithCallbacks multi_core_group_attn_matmul(const Tensor &a, co
             in1_is_sharded,
             output_is_sharded,
             reader_noc_is_NOC_0,
-            in1_mcast_sender_semaphore,
-            in1_mcast_receiver_semaphore,
+            in1_mcast_sender_semaphore_id,
+            in1_mcast_receiver_semaphore_id,
             in1_mcast_sender_noc_x,
             in1_mcast_sender_noc_y,
 
@@ -408,8 +408,8 @@ operation::ProgramWithCallbacks multi_core_group_attn_matmul(const Tensor &a, co
             0, // 24: in1_mcast_num_dests
             0, // 25: in1_mcast_num_cores
             mcast_num_cores, // mcast grid size; in1_mcast_num_cores may change depending on if sender is part of the receiver grid or not
-            in1_mcast_sender_semaphore,
-            in1_mcast_receiver_semaphore,
+            in1_mcast_sender_semaphore_id,
+            in1_mcast_receiver_semaphore_id,
             in1_block_num_tiles * in1_single_tile_size, // in1_mcast_sender_size_bytes
             0, // 30: in1_mcast_sender_id
             (uint32_t) in1_mcast_sender_noc_x.size(), // in1_mcast_sender_num_x

--- a/ttnn/cpp/ttnn/operations/ccl/all_gather/device/kernels/dataflow/worker_interleaved_ring_gather_receive_reader.cpp
+++ b/ttnn/cpp/ttnn/operations/ccl/all_gather/device/kernels/dataflow/worker_interleaved_ring_gather_receive_reader.cpp
@@ -15,7 +15,7 @@ void kernel_main() {
     constexpr uint32_t eth_receiver_noc_x = get_compile_time_arg_val(5);
     constexpr uint32_t eth_receiver_noc_y = get_compile_time_arg_val(6);
     constexpr uint32_t eth_receiver_l1_semaphore_addr = get_compile_time_arg_val(7);
-    constexpr uint32_t receiver_read_sem_addr = get_compile_time_arg_val(8);
+    uint32_t receiver_read_sem_addr = get_semaphore(get_compile_time_arg_val(8));
     constexpr uint32_t half_cb_n_pages = get_compile_time_arg_val(9);
     static_assert (half_cb_n_pages > rem_num_pages, "half_cb_n_pages must be greater than 0");
 

--- a/ttnn/cpp/ttnn/operations/ccl/all_gather/device/kernels/dataflow/worker_interleaved_ring_gather_receive_writer.cpp
+++ b/ttnn/cpp/ttnn/operations/ccl/all_gather/device/kernels/dataflow/worker_interleaved_ring_gather_receive_writer.cpp
@@ -45,7 +45,7 @@ void kernel_main() {
     constexpr uint32_t output_addr_offset = get_compile_time_arg_val(18);
     constexpr uint32_t input_start_ring_idx = get_compile_time_arg_val(19);
     // Same per worker receiver writer
-    constexpr uint32_t sem_addr = get_compile_time_arg_val(20);
+    uint32_t sem_addr = get_semaphore(get_compile_time_arg_val(20));
     constexpr bool is_clockwise_direction = get_compile_time_arg_val(21) == 1;
     constexpr uint32_t half_cb_n_pages = get_compile_time_arg_val(22);
     constexpr uint32_t ring_size = get_compile_time_arg_val(23);

--- a/ttnn/cpp/ttnn/operations/ccl/all_gather/device/kernels/dataflow/worker_interleaved_ring_gather_send_reader.cpp
+++ b/ttnn/cpp/ttnn/operations/ccl/all_gather/device/kernels/dataflow/worker_interleaved_ring_gather_send_reader.cpp
@@ -51,7 +51,7 @@ void kernel_main() {
     constexpr uint32_t last_output_addr_offset = get_compile_time_arg_val(19);
     constexpr uint32_t output_addr_offset = get_compile_time_arg_val(20);
     constexpr uint32_t input_start_ring_idx = get_compile_time_arg_val(21);
-    constexpr uint32_t sem_addr = get_compile_time_arg_val(22);
+    uint32_t sem_addr = get_semaphore(get_compile_time_arg_val(22));
     constexpr bool is_clockwise_direction = get_compile_time_arg_val(23) == 1;
     constexpr uint32_t half_cb_n_pages = get_compile_time_arg_val(24);
     constexpr uint32_t ring_size = get_compile_time_arg_val(25);

--- a/ttnn/cpp/ttnn/operations/ccl/all_gather/device/kernels/dataflow/worker_interleaved_ring_gather_send_writer.cpp
+++ b/ttnn/cpp/ttnn/operations/ccl/all_gather/device/kernels/dataflow/worker_interleaved_ring_gather_send_writer.cpp
@@ -39,7 +39,7 @@ void kernel_main() {
     constexpr uint32_t num_rows = get_compile_time_arg_val(14);
     constexpr uint32_t num_cols = get_compile_time_arg_val(15);
     constexpr uint32_t input_start_ring_idx = get_compile_time_arg_val(16);
-    constexpr uint32_t writer_send_sem_addr = get_compile_time_arg_val(17);
+    uint32_t writer_send_sem_addr = get_semaphore(get_compile_time_arg_val(17));
     constexpr uint32_t eth_sender_noc_x = get_compile_time_arg_val(18);
     constexpr uint32_t eth_sender_noc_y = get_compile_time_arg_val(19);
     constexpr uint32_t half_cb_n_pages = get_compile_time_arg_val(20);

--- a/ttnn/cpp/ttnn/operations/ccl/ccl_host_datastructures.hpp
+++ b/ttnn/cpp/ttnn/operations/ccl/ccl_host_datastructures.hpp
@@ -94,20 +94,20 @@ class EriscDatamoverBuilder {
     struct ChannelBufferSpec {
         ChannelBufferSpec(
             bool is_sender,
-            uint32_t worker_semaphore_address,
+            uint32_t worker_semaphore_id,
             uint32_t num_eth_messages_to_forward,
             uint32_t channel,
             std::vector<ccl::WorkerXY> const& worker_coords,
             uint32_t largest_message_size_bytes = 0) :
             worker_coords(worker_coords),
-            worker_semaphore_address(worker_semaphore_address),
+            worker_semaphore_id(worker_semaphore_id),
             num_eth_messages_to_forward(num_eth_messages_to_forward),
             channel(channel),
             largest_message_size_bytes(largest_message_size_bytes),
             is_sender(is_sender) {}
 
         std::vector<ccl::WorkerXY> const worker_coords;
-        uint32_t worker_semaphore_address;
+        uint32_t worker_semaphore_id;
         uint32_t num_eth_messages_to_forward;
         uint32_t channel;
         uint32_t largest_message_size_bytes;
@@ -126,7 +126,7 @@ class EriscDatamoverBuilder {
             args.push_back(this->eth_buffer_size_bytes);
         }
         args.push_back(this->local_semaphore_addresses.at(channel.channel));
-        args.push_back(channel.worker_semaphore_address);
+        args.push_back(channel.worker_semaphore_id);
         args.push_back(channel.worker_coords.size());
         for (auto const& worker_coord : channel.worker_coords) {
             args.push_back(worker_coord.to_uint32());
@@ -191,7 +191,7 @@ class EriscDatamoverBuilder {
 
     [[nodiscard]]
     ChannelBufferInterface add_sender_channel(
-        uint32_t worker_semaphore_address,
+        uint32_t worker_semaphore_id,
         uint32_t num_eth_messages_to_forward,
         std::vector<ccl::WorkerXY> const& worker_coords,
         uint32_t expected_message_size_bytes = 0) {
@@ -199,9 +199,9 @@ class EriscDatamoverBuilder {
         this->num_senders++;
         auto channel = active_channels.size();
         active_channels.emplace_back(
-            true, worker_semaphore_address, num_eth_messages_to_forward, channel, worker_coords, expected_message_size_bytes);
+            true, worker_semaphore_id, num_eth_messages_to_forward, channel, worker_coords, expected_message_size_bytes);
         log_trace(tt::LogOp, "Adding sender channel:");
-        log_trace(tt::LogOp, "\tworker_semaphore_address: {}", active_channels.back().worker_semaphore_address);
+        log_trace(tt::LogOp, "\tworker_semaphore_id: {}", active_channels.back().worker_semaphore_id);
         log_trace(tt::LogOp, "\tnum_eth_messages_to_forward: {}", active_channels.back().num_eth_messages_to_forward);
         log_trace(tt::LogOp, "\tchannel: {}", active_channels.back().channel);
         log_trace(tt::LogOp, "\tis_sender: {}", active_channels.back().is_sender ? 1 : 0);
@@ -221,7 +221,7 @@ class EriscDatamoverBuilder {
 
     [[nodiscard]]
     ChannelBufferInterface add_receiver_channel(
-        uint32_t worker_semaphore_address,
+        uint32_t worker_semaphore_id,
         uint32_t num_eth_messages_to_forward,
         std::vector<ccl::WorkerXY> const& worker_coords,
         uint32_t expected_message_size_bytes = 0) {
@@ -229,9 +229,9 @@ class EriscDatamoverBuilder {
         this->num_receivers++;
         auto channel = active_channels.size();
         active_channels.emplace_back(
-            false, worker_semaphore_address, num_eth_messages_to_forward, channel, worker_coords, expected_message_size_bytes);
+            false, worker_semaphore_id, num_eth_messages_to_forward, channel, worker_coords, expected_message_size_bytes);
         log_trace(tt::LogOp, "Adding receiver channel:");
-        log_trace(tt::LogOp, "\tworker_semaphore_address: {}", active_channels.back().worker_semaphore_address);
+        log_trace(tt::LogOp, "\tworker_semaphore_id: {}", active_channels.back().worker_semaphore_id);
         log_trace(tt::LogOp, "\tnum_eth_messages_to_forward: {}", active_channels.back().num_eth_messages_to_forward);
         log_trace(tt::LogOp, "\tchannel: {}", active_channels.back().channel);
         log_trace(tt::LogOp, "\tnum_workers: {}", worker_coords.size());

--- a/ttnn/cpp/ttnn/operations/ccl/kernels/edm/erisc_datamover.cpp
+++ b/ttnn/cpp/ttnn/operations/ccl/kernels/edm/erisc_datamover.cpp
@@ -23,7 +23,7 @@
 //    5) sender_num_messages_to_send
 //    6) sender_channel_size
 //    7) sender_semaphores_base_address
-//    8) worker_semaphore_address
+//    8) worker_semaphore_id
 //    9) sender_num_workers
 //       Informs how many worker X/Y coords to accept in the next loop. Each X/Y pair is 2 uint16s
 //       10) worker_coord(s)
@@ -149,7 +149,7 @@ void kernel_main() {
         // The erisc's local l1 copy of the semaphore workers remotely increment
         uint32_t const sender_semaphores_base_address = get_arg_val<uint32_t>(args_offset++);
         // worker's semaphore L1 address
-        const uint32_t worker_semaphore_address = get_arg_val<uint32_t>(args_offset++);
+        const uint32_t worker_semaphore_address = get_semaphore(get_arg_val<uint32_t>(args_offset++));
         const uint32_t sender_num_workers = get_arg_val<uint32_t>(args_offset++);
         const uint32_t workers_xy_list_addr = get_arg_addr(args_offset);
         args_offset += sender_num_workers;
@@ -181,7 +181,7 @@ void kernel_main() {
         // Each channel currently constrained to the same buffer size
         uint32_t const receiver_channel_size = get_arg_val<uint32_t>(args_offset++);
         uint32_t const receiver_semaphores_base_address = get_arg_val<uint32_t>(args_offset++);
-        uint32_t const worker_semaphore_address = get_arg_val<uint32_t>(args_offset++);
+        uint32_t const worker_semaphore_address = get_semaphore(get_arg_val<uint32_t>(args_offset++));
         uint32_t const receiver_num_workers = get_arg_val<uint32_t>(args_offset++);
         const uint32_t workers_xy_list_addr = get_arg_addr(args_offset);
         args_offset += receiver_num_workers;

--- a/ttnn/cpp/ttnn/operations/ccl/reduce_scatter/device/kernels/worker_interleaved_ring_reduce_scatter_reader.cpp
+++ b/ttnn/cpp/ttnn/operations/ccl/reduce_scatter/device/kernels/worker_interleaved_ring_reduce_scatter_reader.cpp
@@ -29,7 +29,7 @@ struct reduce_scatter_reader_common_args_t {
 
         my_ring_idx(get_arg_val<uint32_t>(arg_idx++)),
         ring_size(get_arg_val<uint32_t>(arg_idx++)),
-        sem_addr(get_arg_val<uint32_t>(arg_idx++)),
+        sem_addr(get_semaphore(get_arg_val<uint32_t>(arg_idx++))),
 
         is_clockwise_direction(get_arg_val<uint32_t>(arg_idx++) == 1),
         half_cb_n_pages(get_arg_val<uint32_t>(arg_idx++)),

--- a/ttnn/cpp/ttnn/operations/ccl/reduce_scatter/device/kernels/worker_interleaved_ring_reduce_scatter_sender.cpp
+++ b/ttnn/cpp/ttnn/operations/ccl/reduce_scatter/device/kernels/worker_interleaved_ring_reduce_scatter_sender.cpp
@@ -36,7 +36,7 @@ void kernel_main() {
     uint32_t const num_transfers = get_arg_val<uint32_t>(arg_idx++);
     uint32_t const page_size = get_arg_val<uint32_t>(arg_idx++);
     uint32_t const full_chunk_num_pages = get_arg_val<uint32_t>(arg_idx++);
-    uint32_t const writer_send_sem_addr = get_arg_val<uint32_t>(arg_idx++);
+    uint32_t const writer_send_sem_addr = get_semaphore(get_arg_val<uint32_t>(arg_idx++));
     uint32_t const half_cb_n_pages = get_arg_val<uint32_t>(arg_idx++);
     uint32_t const num_concurrent_workers = get_arg_val<uint32_t>(arg_idx++);
 

--- a/ttnn/cpp/ttnn/operations/conv2d/device/kernels/reader_conv_activations_2d_mcast_padded_with_halo_3x3_weights.cpp
+++ b/ttnn/cpp/ttnn/operations/conv2d/device/kernels/reader_conv_activations_2d_mcast_padded_with_halo_3x3_weights.cpp
@@ -57,8 +57,8 @@ void kernel_main() {
     uint32_t act_mcast_dest_noc_end_y                    = get_arg_val<uint32_t>(i); i+=1;
     uint32_t act_mcast_num_dests                         = get_arg_val<uint32_t>(i); i+=1;
     uint32_t act_mcast_num_cores                         = get_arg_val<uint32_t>(i); i+=1;
-    uint32_t act_mcast_sender_semaphore_addr             = get_arg_val<uint32_t>(i); i+=1;
-    uint32_t act_mcast_receiver_semaphore_addr           = get_arg_val<uint32_t>(i); i+=1;
+    uint32_t act_mcast_sender_semaphore_addr             = get_semaphore(get_arg_val<uint32_t>(i)); i+=1;
+    uint32_t act_mcast_receiver_semaphore_addr           = get_semaphore(get_arg_val<uint32_t>(i)); i+=1;
 
     uint32_t act_mcast_sender_size_bytes                 = get_arg_val<uint32_t>(i); i+=1;
     uint32_t act_mcast_sender_id                         = get_arg_val<uint32_t>(i); i+=1;

--- a/ttnn/cpp/ttnn/operations/conv2d/device/kernels/reader_conv_activations_2d_mcast_padded_with_halo_3x3_weights_v2.cpp
+++ b/ttnn/cpp/ttnn/operations/conv2d/device/kernels/reader_conv_activations_2d_mcast_padded_with_halo_3x3_weights_v2.cpp
@@ -51,8 +51,8 @@ void kernel_main() {
     constexpr uint32_t act_w_num_outer = get_compile_time_arg_val(16);
     constexpr uint32_t act_mcast_num_dests = get_compile_time_arg_val(17);
     constexpr uint32_t act_mcast_num_cores = get_compile_time_arg_val(18);
-    constexpr uint32_t act_mcast_sender_semaphore_addr = get_compile_time_arg_val(19);
-    constexpr uint32_t act_mcast_receiver_semaphore_addr = get_compile_time_arg_val(20);
+    uint32_t act_mcast_sender_semaphore_addr = get_semaphore(get_compile_time_arg_val(19));
+    uint32_t act_mcast_receiver_semaphore_addr = get_semaphore(get_compile_time_arg_val(20));
     constexpr uint32_t act_mcast_sender_size_bytes = get_compile_time_arg_val(21);
 
     constexpr bool transpose_mcast = get_compile_time_arg_val(22) == 1;

--- a/ttnn/cpp/ttnn/operations/conv2d/device/kernels/reader_writer_tiled_out_1d_mcast_receiver_conv_weights_tiled_col_to_rm_blocks.cpp
+++ b/ttnn/cpp/ttnn/operations/conv2d/device/kernels/reader_writer_tiled_out_1d_mcast_receiver_conv_weights_tiled_col_to_rm_blocks.cpp
@@ -80,8 +80,8 @@ void kernel_main() {
     // mcast args
     uint32_t weights_mcast_sender_noc_x           = get_arg_val<uint32_t>(i); i+=1;
     uint32_t weights_mcast_sender_noc_y           = get_arg_val<uint32_t>(i); i+=1;
-    uint32_t weights_mcast_sender_semaphore_addr    = get_arg_val<uint32_t>(i); i+=1;
-    uint32_t weights_mcast_receiver_semaphore_addr  = get_arg_val<uint32_t>(i); i+=1;
+    uint32_t weights_mcast_sender_semaphore_addr    = get_semaphore(get_arg_val<uint32_t>(i)); i+=1;
+    uint32_t weights_mcast_receiver_semaphore_addr  = get_semaphore(get_arg_val<uint32_t>(i)); i+=1;
 
     volatile tt_l1_ptr uint32_t* weights_mcast_receiver_semaphore_addr_ptr = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(weights_mcast_receiver_semaphore_addr);
     const uint64_t weights_mcast_sender_semaphore_noc_addr = get_noc_addr(weights_mcast_sender_noc_x, weights_mcast_sender_noc_y, weights_mcast_sender_semaphore_addr);

--- a/ttnn/cpp/ttnn/operations/conv2d/device/kernels/reader_writer_tiled_out_1d_mcast_sender_conv_weights_tiled_col_to_rm_blocks.cpp
+++ b/ttnn/cpp/ttnn/operations/conv2d/device/kernels/reader_writer_tiled_out_1d_mcast_sender_conv_weights_tiled_col_to_rm_blocks.cpp
@@ -89,8 +89,8 @@ void kernel_main() {
     uint32_t weights_mcast_dest_noc_end_y           = get_arg_val<uint32_t>(i); i+=1;
     uint32_t weights_mcast_num_dests                = get_arg_val<uint32_t>(i); i+=1;
     uint32_t weights_mcast_num_cores                = get_arg_val<uint32_t>(i); i+=1;
-    uint32_t weights_mcast_sender_semaphore_addr    = get_arg_val<uint32_t>(i); i+=1;
-    uint32_t weights_mcast_receiver_semaphore_addr  = get_arg_val<uint32_t>(i); i+=1;
+    uint32_t weights_mcast_sender_semaphore_addr    = get_semaphore(get_arg_val<uint32_t>(i)); i+=1;
+    uint32_t weights_mcast_receiver_semaphore_addr  = get_semaphore(get_arg_val<uint32_t>(i)); i+=1;
 
     constexpr uint32_t cb_id_act_second_reader = 7;
     constexpr uint32_t cb_id_sharded_act = 3;

--- a/ttnn/cpp/ttnn/operations/conv2d/device/kernels/writer_and_mcast_receiver_weights_resnet50_first_conv_tiled_out.cpp
+++ b/ttnn/cpp/ttnn/operations/conv2d/device/kernels/writer_and_mcast_receiver_weights_resnet50_first_conv_tiled_out.cpp
@@ -54,8 +54,8 @@ void kernel_main() {
     // mcast args
     uint32_t weights_mcast_sender_noc_x           = get_arg_val<uint32_t>(i); i+=1;
     uint32_t weights_mcast_sender_noc_y           = get_arg_val<uint32_t>(i); i+=1;
-    uint32_t weights_mcast_sender_semaphore_addr    = get_arg_val<uint32_t>(i); i+=1;
-    uint32_t weights_mcast_receiver_semaphore_addr  = get_arg_val<uint32_t>(i); i+=1;
+    uint32_t weights_mcast_sender_semaphore_addr    = get_semaphore(get_arg_val<uint32_t>(i)); i+=1;
+    uint32_t weights_mcast_receiver_semaphore_addr  = get_semaphore(get_arg_val<uint32_t>(i)); i+=1;
 
 
     constexpr bool out_in_dram = get_compile_time_arg_val(0) == 1;

--- a/ttnn/cpp/ttnn/operations/conv2d/device/kernels/writer_and_mcast_sender_weights_resnet50_first_conv_tiled_out.cpp
+++ b/ttnn/cpp/ttnn/operations/conv2d/device/kernels/writer_and_mcast_sender_weights_resnet50_first_conv_tiled_out.cpp
@@ -58,8 +58,8 @@ void kernel_main() {
     uint32_t weights_mcast_dest_noc_end_y           = get_arg_val<uint32_t>(i); i+=1;
     uint32_t weights_mcast_num_dests                = get_arg_val<uint32_t>(i); i+=1;
     uint32_t weights_mcast_num_cores                = get_arg_val<uint32_t>(i); i+=1;
-    uint32_t weights_mcast_sender_semaphore_addr    = get_arg_val<uint32_t>(i); i+=1;
-    uint32_t weights_mcast_receiver_semaphore_addr  = get_arg_val<uint32_t>(i); i+=1;
+    uint32_t weights_mcast_sender_semaphore_addr    = get_semaphore(get_arg_val<uint32_t>(i)); i+=1;
+    uint32_t weights_mcast_receiver_semaphore_addr  = get_semaphore(get_arg_val<uint32_t>(i)); i+=1;
 
 
     constexpr bool out_in_dram = get_compile_time_arg_val(0) == 1;

--- a/ttnn/cpp/ttnn/operations/conv2d/device/kernels/writer_mcast_receiver_depthwise_conv1d.cpp
+++ b/ttnn/cpp/ttnn/operations/conv2d/device/kernels/writer_mcast_receiver_depthwise_conv1d.cpp
@@ -60,8 +60,8 @@ void kernel_main() {
     // mcast args
     uint32_t weights_mcast_sender_noc_x           = get_arg_val<uint32_t>(i); i+=1;
     uint32_t weights_mcast_sender_noc_y           = get_arg_val<uint32_t>(i); i+=1;
-    uint32_t weights_mcast_sender_semaphore_addr    = get_arg_val<uint32_t>(i); i+=1;
-    uint32_t weights_mcast_receiver_semaphore_addr  = get_arg_val<uint32_t>(i); i+=1;
+    uint32_t weights_mcast_sender_semaphore_addr    = get_semaphore(get_arg_val<uint32_t>(i)); i+=1;
+    uint32_t weights_mcast_receiver_semaphore_addr  = get_semaphore(get_arg_val<uint32_t>(i)); i+=1;
 
     volatile tt_l1_ptr uint32_t* weights_mcast_receiver_semaphore_addr_ptr = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(weights_mcast_receiver_semaphore_addr);
 

--- a/ttnn/cpp/ttnn/operations/conv2d/device/kernels/writer_mcast_sender_depthwise_conv1d.cpp
+++ b/ttnn/cpp/ttnn/operations/conv2d/device/kernels/writer_mcast_sender_depthwise_conv1d.cpp
@@ -70,8 +70,8 @@ void kernel_main() {
     uint32_t weights_mcast_dest_noc_end_y           = get_arg_val<uint32_t>(i); i+=1;
     uint32_t weights_mcast_num_dests                = get_arg_val<uint32_t>(i); i+=1;
     uint32_t weights_mcast_num_cores                = get_arg_val<uint32_t>(i); i+=1;
-    uint32_t weights_mcast_sender_semaphore_addr    = get_arg_val<uint32_t>(i); i+=1;
-    uint32_t weights_mcast_receiver_semaphore_addr  = get_arg_val<uint32_t>(i); i+=1;
+    uint32_t weights_mcast_sender_semaphore_addr    = get_semaphore(get_arg_val<uint32_t>(i)); i+=1;
+    uint32_t weights_mcast_receiver_semaphore_addr  = get_semaphore(get_arg_val<uint32_t>(i)); i+=1;
 
     #ifndef SKIP_MCAST
     // Set ur local VALID value, to be mcasted to destinations flag address after the data has been mcasted

--- a/ttnn/cpp/ttnn/operations/conv2d/device/kernels/writer_tiled_out_1d_mcast_receiver_conv_weights_tiled_col_to_rm_blocks.cpp
+++ b/ttnn/cpp/ttnn/operations/conv2d/device/kernels/writer_tiled_out_1d_mcast_receiver_conv_weights_tiled_col_to_rm_blocks.cpp
@@ -60,8 +60,8 @@ void kernel_main() {
     // mcast args
     uint32_t weights_mcast_sender_noc_x           = get_arg_val<uint32_t>(i); i+=1;
     uint32_t weights_mcast_sender_noc_y           = get_arg_val<uint32_t>(i); i+=1;
-    uint32_t weights_mcast_sender_semaphore_addr    = get_arg_val<uint32_t>(i); i+=1;
-    uint32_t weights_mcast_receiver_semaphore_addr  = get_arg_val<uint32_t>(i); i+=1;
+    uint32_t weights_mcast_sender_semaphore_addr    = get_semaphore(get_arg_val<uint32_t>(i)); i+=1;
+    uint32_t weights_mcast_receiver_semaphore_addr  = get_semaphore(get_arg_val<uint32_t>(i)); i+=1;
 
     volatile tt_l1_ptr uint32_t* weights_mcast_receiver_semaphore_addr_ptr = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(weights_mcast_receiver_semaphore_addr);
 

--- a/ttnn/cpp/ttnn/operations/conv2d/device/kernels/writer_tiled_out_1d_mcast_sender_conv_weights_tiled_col_to_rm_blocks.cpp
+++ b/ttnn/cpp/ttnn/operations/conv2d/device/kernels/writer_tiled_out_1d_mcast_sender_conv_weights_tiled_col_to_rm_blocks.cpp
@@ -70,8 +70,8 @@ void kernel_main() {
     uint32_t weights_mcast_dest_noc_end_y           = get_arg_val<uint32_t>(i); i+=1;
     uint32_t weights_mcast_num_dests                = get_arg_val<uint32_t>(i); i+=1;
     uint32_t weights_mcast_num_cores                = get_arg_val<uint32_t>(i); i+=1;
-    uint32_t weights_mcast_sender_semaphore_addr    = get_arg_val<uint32_t>(i); i+=1;
-    uint32_t weights_mcast_receiver_semaphore_addr  = get_arg_val<uint32_t>(i); i+=1;
+    uint32_t weights_mcast_sender_semaphore_addr    = get_semaphore(get_arg_val<uint32_t>(i)); i+=1;
+    uint32_t weights_mcast_receiver_semaphore_addr  = get_semaphore(get_arg_val<uint32_t>(i)); i+=1;
 
     #ifndef SKIP_MCAST
     // Set ur local VALID value, to be mcasted to destinations flag address after the data has been mcasted

--- a/ttnn/cpp/ttnn/operations/conv2d/device/kernels/writer_tiled_out_2d_mcast_receiver_conv_weights_tiled_col_to_rm_blocks.cpp
+++ b/ttnn/cpp/ttnn/operations/conv2d/device/kernels/writer_tiled_out_2d_mcast_receiver_conv_weights_tiled_col_to_rm_blocks.cpp
@@ -74,8 +74,8 @@ void kernel_main() {
     // mcast args
     uint32_t weights_mcast_sender_noc_x           = get_arg_val<uint32_t>(i); i+=1;
     uint32_t weights_mcast_sender_noc_y           = get_arg_val<uint32_t>(i); i+=1;
-    uint32_t weights_mcast_sender_semaphore_addr    = get_arg_val<uint32_t>(i); i+=1;
-    uint32_t weights_mcast_receiver_semaphore_addr  = get_arg_val<uint32_t>(i); i+=1;
+    uint32_t weights_mcast_sender_semaphore_addr    = get_semaphore(get_arg_val<uint32_t>(i)); i+=1;
+    uint32_t weights_mcast_receiver_semaphore_addr  = get_semaphore(get_arg_val<uint32_t>(i)); i+=1;
 
     volatile tt_l1_ptr uint32_t* weights_mcast_receiver_semaphore_addr_ptr = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(weights_mcast_receiver_semaphore_addr);
     uint64_t weights_mcast_sender_semaphore_noc_addr = get_noc_addr(weights_mcast_sender_noc_x, weights_mcast_sender_noc_y, weights_mcast_sender_semaphore_addr);

--- a/ttnn/cpp/ttnn/operations/conv2d/device/kernels/writer_tiled_out_2d_mcast_sender_conv_weights_tiled_col_to_rm_blocks.cpp
+++ b/ttnn/cpp/ttnn/operations/conv2d/device/kernels/writer_tiled_out_2d_mcast_sender_conv_weights_tiled_col_to_rm_blocks.cpp
@@ -84,8 +84,8 @@ void kernel_main() {
     uint32_t weights_mcast_dest_noc_end_y           = get_arg_val<uint32_t>(i); i+=1;
     uint32_t weights_mcast_num_dests                = get_arg_val<uint32_t>(i); i+=1;
     uint32_t weights_mcast_num_cores                = get_arg_val<uint32_t>(i); i+=1;
-    uint32_t weights_mcast_sender_semaphore_addr    = get_arg_val<uint32_t>(i); i+=1;
-    uint32_t weights_mcast_receiver_semaphore_addr  = get_arg_val<uint32_t>(i); i+=1;
+    uint32_t weights_mcast_sender_semaphore_addr    = get_semaphore(get_arg_val<uint32_t>(i)); i+=1;
+    uint32_t weights_mcast_receiver_semaphore_addr  = get_semaphore(get_arg_val<uint32_t>(i)); i+=1;
 
     #ifndef SKIP_MCAST
         // Set ur local VALID value, to be mcasted to destinations flag address after the data has been mcasted

--- a/ttnn/cpp/ttnn/operations/conv2d/device/kernels/writer_tiled_out_mcast_receiver_conv_weights_tiled_col_to_rm_blocks.cpp
+++ b/ttnn/cpp/ttnn/operations/conv2d/device/kernels/writer_tiled_out_mcast_receiver_conv_weights_tiled_col_to_rm_blocks.cpp
@@ -56,8 +56,8 @@ void kernel_main() {
     // mcast args
     uint32_t weights_mcast_sender_noc_x           = get_arg_val<uint32_t>(i); i+=1;
     uint32_t weights_mcast_sender_noc_y           = get_arg_val<uint32_t>(i); i+=1;
-    uint32_t weights_mcast_sender_semaphore_addr    = get_arg_val<uint32_t>(i); i+=1;
-    uint32_t weights_mcast_receiver_semaphore_addr  = get_arg_val<uint32_t>(i); i+=1;
+    uint32_t weights_mcast_sender_semaphore_addr    = get_semaphore(get_arg_val<uint32_t>(i)); i+=1;
+    uint32_t weights_mcast_receiver_semaphore_addr  = get_semaphore(get_arg_val<uint32_t>(i)); i+=1;
 
     constexpr bool out_in_dram = get_compile_time_arg_val(0) == 1;
     constexpr uint32_t cb_id_out0 = get_compile_time_arg_val(1);

--- a/ttnn/cpp/ttnn/operations/conv2d/device/kernels/writer_tiled_out_mcast_sender_conv_weights_tiled_col_to_rm_blocks.cpp
+++ b/ttnn/cpp/ttnn/operations/conv2d/device/kernels/writer_tiled_out_mcast_sender_conv_weights_tiled_col_to_rm_blocks.cpp
@@ -60,8 +60,8 @@ void kernel_main() {
     uint32_t weights_mcast_dest_noc_end_y           = get_arg_val<uint32_t>(i); i+=1;
     uint32_t weights_mcast_num_dests                = get_arg_val<uint32_t>(i); i+=1;
     uint32_t weights_mcast_num_cores                = get_arg_val<uint32_t>(i); i+=1;
-    uint32_t weights_mcast_sender_semaphore_addr    = get_arg_val<uint32_t>(i); i+=1;
-    uint32_t weights_mcast_receiver_semaphore_addr  = get_arg_val<uint32_t>(i); i+=1;
+    uint32_t weights_mcast_sender_semaphore_addr    = get_semaphore(get_arg_val<uint32_t>(i)); i+=1;
+    uint32_t weights_mcast_receiver_semaphore_addr  = get_semaphore(get_arg_val<uint32_t>(i)); i+=1;
 
 
     constexpr bool out_in_dram = get_compile_time_arg_val(0) == 1;

--- a/ttnn/cpp/ttnn/operations/conv2d/device/multi_core_optimized_conv_sharded/optimized_conv_op_sharded_v2.cpp
+++ b/ttnn/cpp/ttnn/operations/conv2d/device/multi_core_optimized_conv_sharded/optimized_conv_op_sharded_v2.cpp
@@ -871,10 +871,10 @@ operation::ProgramWithCallbacks multi_core_optimized_conv_sharded_v2_impl(
 
     CoreRange mcast_sender_cores(top_left_core, top_left_core);  // If single core, this kernel doesn't do mcasting
     CoreRangeSet mcast_receiver_cores{{}};
-    uint32_t weights_mcast_sender_semaphore{};
-    uint32_t weights_mcast_receiver_semaphore{};
-    uint32_t act_mcast_sender_semaphore = 0;
-    uint32_t act_mcast_receiver_semaphore = 0;
+    uint32_t weights_mcast_sender_semaphore_id{};
+    uint32_t weights_mcast_receiver_semaphore_id{};
+    uint32_t act_mcast_sender_semaphore_id = 0;
+    uint32_t act_mcast_receiver_semaphore_id = 0;
     std::vector<uint32_t> act_mcast_noc_y;
     if (weight_width_sliced) {
         // 2D mcast
@@ -885,8 +885,8 @@ operation::ProgramWithCallbacks multi_core_optimized_conv_sharded_v2_impl(
             mcast_sender_cores = CoreRange(top_left_core, CoreCoord(num_cores_x - 1, 0));
             mcast_receiver_cores = {{CoreRange(CoreCoord(0, 1), bottom_right_core)}};
         }
-        weights_mcast_sender_semaphore = tt_metal::CreateSemaphore(program, all_cores, INVALID);
-        weights_mcast_receiver_semaphore = tt_metal::CreateSemaphore(program, all_cores, INVALID);
+        weights_mcast_sender_semaphore_id = tt_metal::CreateSemaphore(program, all_cores, INVALID);
+        weights_mcast_receiver_semaphore_id = tt_metal::CreateSemaphore(program, all_cores, INVALID);
     } else {
         // 1D mcast
         if (total_num_cores > 1) {
@@ -904,8 +904,8 @@ operation::ProgramWithCallbacks multi_core_optimized_conv_sharded_v2_impl(
                 }
             }
             mcast_receiver_cores = mcast_receiver_set;
-            weights_mcast_sender_semaphore = tt_metal::CreateSemaphore(program, all_cores, INVALID);
-            weights_mcast_receiver_semaphore = tt_metal::CreateSemaphore(program, all_cores, INVALID);
+            weights_mcast_sender_semaphore_id = tt_metal::CreateSemaphore(program, all_cores, INVALID);
+            weights_mcast_receiver_semaphore_id = tt_metal::CreateSemaphore(program, all_cores, INVALID);
         }
     }
 
@@ -1062,8 +1062,8 @@ operation::ProgramWithCallbacks multi_core_optimized_conv_sharded_v2_impl(
             writer_mcast_receiver_kernel =
                 "ttnn/cpp/ttnn/operations/conv2d/device/kernels/"
                 "writer_tiled_out_2d_mcast_receiver_conv_weights_tiled_col_to_rm_blocks.cpp";
-            act_mcast_sender_semaphore = tt_metal::CreateSemaphore(program, all_cores, INVALID);
-            act_mcast_receiver_semaphore = tt_metal::CreateSemaphore(program, all_cores, INVALID);
+            act_mcast_sender_semaphore_id = tt_metal::CreateSemaphore(program, all_cores, INVALID);
+            act_mcast_receiver_semaphore_id = tt_metal::CreateSemaphore(program, all_cores, INVALID);
 
             if (transpose_mcast) {
                 act_mcast_noc_y.reserve(num_cores_y);
@@ -1164,8 +1164,8 @@ operation::ProgramWithCallbacks multi_core_optimized_conv_sharded_v2_impl(
         (uint32_t)conv_act_c_blocks,                                      // act_w_num_outer
         (uint32_t)(transpose_mcast ? num_cores_y - 1 : num_cores_x - 1),  // act_mcast_num_dests
         (uint32_t)(transpose_mcast ? num_cores_y - 1 : num_cores_x - 1),  // act_mcast_num_cores
-        (uint32_t)act_mcast_sender_semaphore,
-        (uint32_t)act_mcast_receiver_semaphore,
+        (uint32_t)act_mcast_sender_semaphore_id,
+        (uint32_t)act_mcast_receiver_semaphore_id,
         (uint32_t)in0_block_num_tiles * tilized_act_tile_size,  // act_mcast_sender_size_bytes
         (uint32_t)(transpose_mcast ? 1 : 0),
         (uint32_t)act_block_h_datums_last_block
@@ -1484,16 +1484,16 @@ operation::ProgramWithCallbacks multi_core_optimized_conv_sharded_v2_impl(
 
                     writer_rt_args.push_back(num_cores_x - 1);  // weights_mcast_num_dests
                     writer_rt_args.push_back(num_cores_x - 1);  // weights_mcast_num_cores
-                    writer_rt_args.push_back(weights_mcast_sender_semaphore);
-                    writer_rt_args.push_back(weights_mcast_receiver_semaphore);
+                    writer_rt_args.push_back(weights_mcast_sender_semaphore_id);
+                    writer_rt_args.push_back(weights_mcast_receiver_semaphore_id);
 
                     SetRuntimeArgs(program, writer_mcast_sender_id, core, writer_rt_args);
                 } else {
                     // receiver
                     writer_rt_args.push_back(top_left_core_physical.x);  // weights_mcast_sender_noc_x
                     writer_rt_args.push_back(right_core_physical.y);     // weights_mcast_sender_noc_y
-                    writer_rt_args.push_back(weights_mcast_sender_semaphore);
-                    writer_rt_args.push_back(weights_mcast_receiver_semaphore);
+                    writer_rt_args.push_back(weights_mcast_sender_semaphore_id);
+                    writer_rt_args.push_back(weights_mcast_receiver_semaphore_id);
 
                     SetRuntimeArgs(program, writer_mcast_receiver_id, core, writer_rt_args);
                 }
@@ -1519,16 +1519,16 @@ operation::ProgramWithCallbacks multi_core_optimized_conv_sharded_v2_impl(
 
                     writer_rt_args.push_back(num_cores_y - 1);  // weights_mcast_num_dests
                     writer_rt_args.push_back(num_cores_y - 1);  // weights_mcast_num_cores
-                    writer_rt_args.push_back(weights_mcast_sender_semaphore);
-                    writer_rt_args.push_back(weights_mcast_receiver_semaphore);
+                    writer_rt_args.push_back(weights_mcast_sender_semaphore_id);
+                    writer_rt_args.push_back(weights_mcast_receiver_semaphore_id);
 
                     SetRuntimeArgs(program, writer_mcast_sender_id, core, writer_rt_args);
                 } else {
                     // receiver
                     writer_rt_args.push_back(top_core_physical.x);       // weights_mcast_sender_noc_x
                     writer_rt_args.push_back(top_left_core_physical.y);  // weights_mcast_sender_noc_y
-                    writer_rt_args.push_back(weights_mcast_sender_semaphore);
-                    writer_rt_args.push_back(weights_mcast_receiver_semaphore);
+                    writer_rt_args.push_back(weights_mcast_sender_semaphore_id);
+                    writer_rt_args.push_back(weights_mcast_receiver_semaphore_id);
 
                     SetRuntimeArgs(program, writer_mcast_receiver_id, core, writer_rt_args);
                 }
@@ -1550,16 +1550,16 @@ operation::ProgramWithCallbacks multi_core_optimized_conv_sharded_v2_impl(
                 }
                 writer_rt_args.push_back(total_active_num_cores - 1);  // weights_mcast_num_dests
                 writer_rt_args.push_back(total_num_cores - 1);         // weights_mcast_num_cores
-                writer_rt_args.push_back(weights_mcast_sender_semaphore);
-                writer_rt_args.push_back(weights_mcast_receiver_semaphore);
+                writer_rt_args.push_back(weights_mcast_sender_semaphore_id);
+                writer_rt_args.push_back(weights_mcast_receiver_semaphore_id);
 
                 SetRuntimeArgs(program, writer_mcast_sender_id, core, writer_rt_args);
             } else {
                 // receiver
                 writer_rt_args.push_back(top_left_core_physical.x);  // weights_mcast_sender_noc_x
                 writer_rt_args.push_back(top_left_core_physical.y);  // weights_mcast_sender_noc_y
-                writer_rt_args.push_back(weights_mcast_sender_semaphore);
-                writer_rt_args.push_back(weights_mcast_receiver_semaphore);
+                writer_rt_args.push_back(weights_mcast_sender_semaphore_id);
+                writer_rt_args.push_back(weights_mcast_receiver_semaphore_id);
 
                 // log_debug("Core: {}, WRITER RT ARGS: {}", core, writer_rt_args.size());
                 SetRuntimeArgs(program, writer_mcast_receiver_id, core, writer_rt_args);

--- a/ttnn/cpp/ttnn/operations/matmul/device/kernels/dataflow/reader_bmm_tile_layout_in0_receiver.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/kernels/dataflow/reader_bmm_tile_layout_in0_receiver.cpp
@@ -18,8 +18,8 @@ void kernel_main() {
     // in0/in1 common args
     constexpr uint32_t num_blocks = get_compile_time_arg_val(1);
     // in0 mcast args
-    constexpr uint32_t in0_mcast_sender_semaphore_addr = get_compile_time_arg_val(2);
-    constexpr uint32_t in0_mcast_receiver_semaphore_addr = get_compile_time_arg_val(3);
+    uint32_t in0_mcast_sender_semaphore_addr = get_semaphore(get_compile_time_arg_val(2));
+    uint32_t in0_mcast_receiver_semaphore_addr = get_semaphore(get_compile_time_arg_val(3));
     // batch args
     constexpr uint32_t batch = get_compile_time_arg_val(4);
 

--- a/ttnn/cpp/ttnn/operations/matmul/device/kernels/dataflow/reader_bmm_tile_layout_in0_sender_dram_sharded.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/kernels/dataflow/reader_bmm_tile_layout_in0_sender_dram_sharded.cpp
@@ -13,8 +13,8 @@ void kernel_main() {
     constexpr uint32_t in0_block_num_tiles = get_compile_time_arg_val(0);
     constexpr uint32_t in0_block_size_bytes = get_compile_time_arg_val(1);
     // in0 mcast args
-    constexpr uint32_t in0_mcast_sender_semaphore_addr = get_compile_time_arg_val(2);
-    constexpr uint32_t in0_mcast_receiver_semaphore_addr = get_compile_time_arg_val(3);
+    uint32_t in0_mcast_sender_semaphore_addr = get_semaphore(get_compile_time_arg_val(2));
+    uint32_t in0_mcast_receiver_semaphore_addr = get_semaphore(get_compile_time_arg_val(3));
     constexpr uint32_t in0_mcast_num_dests = get_compile_time_arg_val(4);
     constexpr uint32_t in0_mcast_num_cores = get_compile_time_arg_val(5);
     // block args
@@ -25,7 +25,7 @@ void kernel_main() {
     constexpr uint32_t in0_mcast_dest_noc_end_x = get_compile_time_arg_val(9);
     constexpr uint32_t in0_mcast_dest_noc_end_y = get_compile_time_arg_val(10);
     // in0 semaphore always valid
-    constexpr uint32_t in0_mcast_sender_valid_semaphore = get_compile_time_arg_val(11);
+    uint32_t in0_mcast_sender_valid_semaphore = get_semaphore(get_compile_time_arg_val(11));
 
     constexpr uint32_t num_blocks_per_shard = get_compile_time_arg_val(12);
     constexpr uint32_t num_storage_cores = num_blocks / num_blocks_per_shard;

--- a/ttnn/cpp/ttnn/operations/matmul/device/kernels/dataflow/reader_bmm_tile_layout_in0_sender_padding.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/kernels/dataflow/reader_bmm_tile_layout_in0_sender_padding.cpp
@@ -38,8 +38,8 @@ void kernel_main() {
     // in0/in1 common args
     constexpr uint32_t num_blocks = get_compile_time_arg_val(10);
     // in0 mcast args
-    constexpr uint32_t in0_mcast_sender_semaphore_addr = get_compile_time_arg_val(11);
-    constexpr uint32_t in0_mcast_receiver_semaphore_addr = get_compile_time_arg_val(12);
+    uint32_t in0_mcast_sender_semaphore_addr = get_semaphore(get_compile_time_arg_val(11));
+    uint32_t in0_mcast_receiver_semaphore_addr = get_semaphore(get_compile_time_arg_val(12));
     constexpr uint32_t in0_mcast_num_dests = get_compile_time_arg_val(13);
     constexpr uint32_t in0_mcast_num_cores = get_compile_time_arg_val(14);
     // batch args

--- a/ttnn/cpp/ttnn/operations/matmul/device/kernels/dataflow/reader_bmm_tile_layout_in0_sender_receiver_padding_block_sharded.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/kernels/dataflow/reader_bmm_tile_layout_in0_sender_receiver_padding_block_sharded.cpp
@@ -16,8 +16,8 @@ void kernel_main() {
     // in0/in1 common args
     constexpr uint32_t num_blocks = get_compile_time_arg_val(4);
     // in0 mcast args
-    constexpr uint32_t in0_mcast_sender_semaphore_addr = get_compile_time_arg_val(5);
-    constexpr uint32_t in0_mcast_receiver_semaphore_addr = get_compile_time_arg_val(6);
+    uint32_t in0_mcast_sender_semaphore_addr = get_semaphore(get_compile_time_arg_val(5));
+    uint32_t in0_mcast_receiver_semaphore_addr = get_semaphore(get_compile_time_arg_val(6));
     constexpr uint32_t in0_mcast_num_dests = get_compile_time_arg_val(7);
     constexpr uint32_t in0_mcast_num_cores = get_compile_time_arg_val(8);
     constexpr uint32_t num_x = get_compile_time_arg_val(9);

--- a/ttnn/cpp/ttnn/operations/matmul/device/kernels/dataflow/reader_bmm_tile_layout_in1_receiver_writer_padding.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/kernels/dataflow/reader_bmm_tile_layout_in1_receiver_writer_padding.cpp
@@ -37,8 +37,8 @@ void kernel_main() {
     // in0/in1 common args
     constexpr uint32_t num_blocks = get_compile_time_arg_val(2);
     // in1 mcast args
-    constexpr uint32_t in1_mcast_sender_semaphore_addr = get_compile_time_arg_val(3);
-    constexpr uint32_t in1_mcast_receiver_semaphore_addr = get_compile_time_arg_val(4);
+    uint32_t in1_mcast_sender_semaphore_addr = get_semaphore(get_compile_time_arg_val(3));
+    uint32_t in1_mcast_receiver_semaphore_addr = get_semaphore(get_compile_time_arg_val(4));
     // batch args
     constexpr uint32_t batch = get_compile_time_arg_val(5);
 

--- a/ttnn/cpp/ttnn/operations/matmul/device/kernels/dataflow/reader_bmm_tile_layout_in1_sender_writer_padding.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/kernels/dataflow/reader_bmm_tile_layout_in1_sender_writer_padding.cpp
@@ -51,8 +51,8 @@ void kernel_main() {
     // in0/in1 common args
     constexpr uint32_t num_blocks = get_compile_time_arg_val(8);
     // in1 mcast args
-    constexpr uint32_t in1_mcast_sender_semaphore_addr = get_compile_time_arg_val(9);
-    constexpr uint32_t in1_mcast_receiver_semaphore_addr = get_compile_time_arg_val(10);
+    uint32_t in1_mcast_sender_semaphore_addr = get_semaphore(get_compile_time_arg_val(9));
+    uint32_t in1_mcast_receiver_semaphore_addr = get_semaphore(get_compile_time_arg_val(10));
     constexpr uint32_t in1_mcast_num_dests = get_compile_time_arg_val(11);
     constexpr uint32_t in1_mcast_num_cores = get_compile_time_arg_val(12);
     // batch args

--- a/ttnn/cpp/ttnn/operations/matmul/device/multi_core_reuse_mcast_1d_optimized/bmm_op_multi_core_reuse_mcast_1d_optimized.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/multi_core_reuse_mcast_1d_optimized/bmm_op_multi_core_reuse_mcast_1d_optimized.cpp
@@ -190,8 +190,8 @@ operation::ProgramWithCallbacks create_program_mcast_in0(
     }
 
     // Mcast args
-    auto in0_mcast_sender_semaphore = tt_metal::CreateSemaphore(program, all_cores, INVALID);
-    auto in0_mcast_receiver_semaphore = tt_metal::CreateSemaphore(program, all_cores, INVALID);
+    auto in0_mcast_sender_semaphore_id = tt_metal::CreateSemaphore(program, all_cores, INVALID);
+    auto in0_mcast_receiver_semaphore_id = tt_metal::CreateSemaphore(program, all_cores, INVALID);
 
     CoreCoord top_left_core = in0_mcast_receiver_cores_bounding_box.start_coord;
     CoreCoord bottom_right_core = in0_mcast_receiver_cores_bounding_box.end_coord;
@@ -220,8 +220,8 @@ operation::ProgramWithCallbacks create_program_mcast_in0(
             // in0/in1 common args
             (std::uint32_t)num_blocks,  // num_blocks
             // in0 mcast args
-            (std::uint32_t)in0_mcast_sender_semaphore,
-            (std::uint32_t)in0_mcast_receiver_semaphore,
+            (std::uint32_t)in0_mcast_sender_semaphore_id,
+            (std::uint32_t)in0_mcast_receiver_semaphore_id,
             (std::uint32_t)in0_mcast_receiver_num_dests,  // in0_mcast_num_dests
             (std::uint32_t)in0_mcast_receiver_num_cores,  // in0_mcast_num_cores
             (std::uint32_t)(in0_mcast_sender_cores_grid.x),
@@ -253,8 +253,8 @@ operation::ProgramWithCallbacks create_program_mcast_in0(
             // in0/in1 common args
             (std::uint32_t)num_blocks,  // num_blocks
             // in0 mcast args
-            (std::uint32_t)in0_mcast_sender_semaphore,
-            (std::uint32_t)in0_mcast_receiver_semaphore,
+            (std::uint32_t)in0_mcast_sender_semaphore_id,
+            (std::uint32_t)in0_mcast_receiver_semaphore_id,
             (std::uint32_t)num_cores - 1,                     // in0_mcast_num_dests
             (std::uint32_t)in0_mcast_receiver_num_cores - 1,  // in0_mcast_num_cores
             // batch args
@@ -311,8 +311,8 @@ operation::ProgramWithCallbacks create_program_mcast_in0(
         // in0/in1 common args
         (std::uint32_t)num_blocks,  // num_blocks
         // in0 mcast args
-        (std::uint32_t)in0_mcast_sender_semaphore,
-        (std::uint32_t)in0_mcast_receiver_semaphore,
+        (std::uint32_t)in0_mcast_sender_semaphore_id,
+        (std::uint32_t)in0_mcast_receiver_semaphore_id,
         // batch args
         (std::uint32_t)B  // batch
     };
@@ -910,10 +910,8 @@ operation::ProgramWithCallbacks create_program_mcast_in1(
     }
 
     // Mcast args
-    auto in1_mcast_sender_semaphore = tt_metal::CreateSemaphore(program, all_cores, INVALID);
-    auto in1_mcast_receiver_semaphore = tt_metal::CreateSemaphore(program, all_cores, INVALID);
-    uint32_t in3_mcast_sender_semaphore = 0;
-    uint32_t in3_mcast_receiver_semaphore = 0;
+    auto in1_mcast_sender_semaphore_id = tt_metal::CreateSemaphore(program, all_cores, INVALID);
+    auto in1_mcast_receiver_semaphore_id = tt_metal::CreateSemaphore(program, all_cores, INVALID);
 
     CoreCoord top_left_core = in1_mcast_receiver_cores_bounding_box.start_coord;
     CoreCoord bottom_right_core = in1_mcast_receiver_cores_bounding_box.end_coord;
@@ -970,8 +968,8 @@ operation::ProgramWithCallbacks create_program_mcast_in1(
         // in0/in1 common args
         (std::uint32_t)num_blocks,  // num_blocks
         // in1 mcast args
-        (std::uint32_t)in1_mcast_sender_semaphore,
-        (std::uint32_t)in1_mcast_receiver_semaphore,
+        (std::uint32_t)in1_mcast_sender_semaphore_id,
+        (std::uint32_t)in1_mcast_receiver_semaphore_id,
         (std::uint32_t)num_cores - 1,                     // in1_mcast_num_dests
         (std::uint32_t)in1_mcast_receiver_num_cores - 1,  // in1_mcast_num_cores
         // batch args
@@ -1006,8 +1004,8 @@ operation::ProgramWithCallbacks create_program_mcast_in1(
         // in0/in1 common args
         (std::uint32_t)num_blocks,  // num_blocks
         // in1 mcast args
-        (std::uint32_t)in1_mcast_sender_semaphore,
-        (std::uint32_t)in1_mcast_receiver_semaphore,
+        (std::uint32_t)in1_mcast_sender_semaphore_id,
+        (std::uint32_t)in1_mcast_receiver_semaphore_id,
         // batch args
         (std::uint32_t)B,  // batch
 

--- a/ttnn/cpp/ttnn/operations/matmul/device/multi_core_reuse_mcast_2d_optimized/bmm_op_multi_core_reuse_mcast_2d_optimized.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/multi_core_reuse_mcast_2d_optimized/bmm_op_multi_core_reuse_mcast_2d_optimized.cpp
@@ -261,10 +261,10 @@ operation::ProgramWithCallbacks create_program_mcast_in0_in1(
     }
 
     // Mcast args
-    auto in0_mcast_sender_semaphore = tt_metal::CreateSemaphore(program, all_cores, INVALID);
-    auto in0_mcast_receiver_semaphore = tt_metal::CreateSemaphore(program, all_cores, INVALID);
-    auto in1_mcast_sender_semaphore = tt_metal::CreateSemaphore(program, all_cores, INVALID);
-    auto in1_mcast_receiver_semaphore = tt_metal::CreateSemaphore(program, all_cores, INVALID);
+    auto in0_mcast_sender_semaphore_id = tt_metal::CreateSemaphore(program, all_cores, INVALID);
+    auto in0_mcast_receiver_semaphore_id = tt_metal::CreateSemaphore(program, all_cores, INVALID);
+    auto in1_mcast_sender_semaphore_id = tt_metal::CreateSemaphore(program, all_cores, INVALID);
+    auto in1_mcast_receiver_semaphore_id = tt_metal::CreateSemaphore(program, all_cores, INVALID);
 
     bool in0_is_dram = in0_buffer->buffer_type() == tt_metal::BufferType::DRAM ? 1 : 0;
     bool in1_is_dram = in1_buffer->buffer_type() == tt_metal::BufferType::DRAM ? 1 : 0;
@@ -302,8 +302,8 @@ operation::ProgramWithCallbacks create_program_mcast_in0_in1(
             // in0/in1 common args
             (std::uint32_t)num_blocks,  // num_blocks
             // in0 mcast args
-            (std::uint32_t)in0_mcast_sender_semaphore,
-            (std::uint32_t)in0_mcast_receiver_semaphore,
+            (std::uint32_t)in0_mcast_sender_semaphore_id,
+            (std::uint32_t)in0_mcast_receiver_semaphore_id,
             (std::uint32_t)num_blocks_x,  // in0_mcast_num_dests
             (std::uint32_t)num_blocks_x,  // in0_mcast_num_cores
             (std::uint32_t)num_x,
@@ -334,8 +334,8 @@ operation::ProgramWithCallbacks create_program_mcast_in0_in1(
             // in0/in1 common args
             (std::uint32_t)num_blocks,  // num_blocks
             // in0 mcast args
-            (std::uint32_t)in0_mcast_sender_semaphore,
-            (std::uint32_t)in0_mcast_receiver_semaphore,
+            (std::uint32_t)in0_mcast_sender_semaphore_id,
+            (std::uint32_t)in0_mcast_receiver_semaphore_id,
             (std::uint32_t)(num_blocks_x - 1),  // in0_mcast_num_dests
             (std::uint32_t)(num_blocks_x - 1),  // in0_mcast_num_cores
             // batch args
@@ -360,8 +360,8 @@ operation::ProgramWithCallbacks create_program_mcast_in0_in1(
         // in0/in1 common args
         (std::uint32_t)num_blocks,  // num_blocks
         // in1 mcast args
-        (std::uint32_t)in1_mcast_sender_semaphore,
-        (std::uint32_t)in1_mcast_receiver_semaphore,
+        (std::uint32_t)in1_mcast_sender_semaphore_id,
+        (std::uint32_t)in1_mcast_receiver_semaphore_id,
         (std::uint32_t)(num_blocks_y - 1),  // in1_mcast_num_dests
         (std::uint32_t)(num_blocks_y - 1),  // in1_mcast_num_cores
         // batch args
@@ -399,8 +399,8 @@ operation::ProgramWithCallbacks create_program_mcast_in0_in1(
         // in0/in1 common args
         (std::uint32_t)num_blocks,  // num_blocks
         // in0 mcast args
-        (std::uint32_t)in0_mcast_sender_semaphore,
-        (std::uint32_t)in0_mcast_receiver_semaphore,
+        (std::uint32_t)in0_mcast_sender_semaphore_id,
+        (std::uint32_t)in0_mcast_receiver_semaphore_id,
         // batch args
         (std::uint32_t)B  // batch
     };
@@ -414,8 +414,8 @@ operation::ProgramWithCallbacks create_program_mcast_in0_in1(
         // in0/in1 common args
         (std::uint32_t)num_blocks,  // num_blocks
         // in1 mcast args
-        (std::uint32_t)in1_mcast_sender_semaphore,
-        (std::uint32_t)in1_mcast_receiver_semaphore,
+        (std::uint32_t)in1_mcast_sender_semaphore_id,
+        (std::uint32_t)in1_mcast_receiver_semaphore_id,
         // batch args
         (std::uint32_t)B,  // batch
 

--- a/ttnn/cpp/ttnn/operations/matmul/device/multi_core_reuse_mcast_dram_sharded_optimized/bmm_op_multi_core_reuse_dram_sharded_optimized.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/multi_core_reuse_mcast_dram_sharded_optimized/bmm_op_multi_core_reuse_dram_sharded_optimized.cpp
@@ -533,9 +533,9 @@ operation::ProgramWithCallbacks create_program_dram_sharded(
     log_debug("bounding_box: {}", bounding_box);
 
     // Mcast args
-    auto in0_mcast_sender_semaphore = tt_metal::CreateSemaphore(program, all_cores_in_rect_grid, INVALID);
-    auto in0_mcast_receiver_semaphore = tt_metal::CreateSemaphore(program, all_cores_in_rect_grid, INVALID);
-    auto in0_mcast_sender_valid_semaphore = tt_metal::CreateSemaphore(program, all_cores_in_rect_grid, VALID);
+    auto in0_mcast_sender_semaphore_id = tt_metal::CreateSemaphore(program, all_cores_in_rect_grid, INVALID);
+    auto in0_mcast_receiver_semaphore_id = tt_metal::CreateSemaphore(program, all_cores_in_rect_grid, INVALID);
+    auto in0_mcast_sender_valid_semaphore_id = tt_metal::CreateSemaphore(program, all_cores_in_rect_grid, VALID);
 
     uint32_t start_core_x = 0;
     uint32_t start_core_y = 0;
@@ -577,8 +577,8 @@ operation::ProgramWithCallbacks create_program_dram_sharded(
         (std::uint32_t)in0_block_num_tiles,                         // in0_block_num_tiles
         (std::uint32_t)in0_block_num_tiles * in0_single_tile_size,  // in0_block_size_bytes
         // in0 mcast args
-        (std::uint32_t)in0_mcast_sender_semaphore,
-        (std::uint32_t)in0_mcast_receiver_semaphore,
+        (std::uint32_t)in0_mcast_sender_semaphore_id,
+        (std::uint32_t)in0_mcast_receiver_semaphore_id,
         (std::uint32_t)num_worker_cores,  // in0_mcast_num_dests
         (std::uint32_t)num_mcast_cores,   // in0_mcast_num_cores
         // block
@@ -589,7 +589,7 @@ operation::ProgramWithCallbacks create_program_dram_sharded(
         (std::uint32_t)end_core_noc.x,
         (std::uint32_t)end_core_noc.y,
         // semahpre valid
-        (std::uint32_t)in0_mcast_sender_valid_semaphore,
+        (std::uint32_t)in0_mcast_sender_valid_semaphore_id,
         //
         (std::uint32_t)num_blocks_per_shard};
 

--- a/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/kernels/dataflow/reader_mcast_receiver_unary_sharded_gn_v2.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/kernels/dataflow/reader_mcast_receiver_unary_sharded_gn_v2.cpp
@@ -10,8 +10,8 @@
 
 // split REDUCE across cores
 void kernel_main() {
-    constexpr uint32_t reduce_receiver_semaphore_addr = get_compile_time_arg_val(0);
-    constexpr uint32_t reduce_sender_semaphore_addr   = get_compile_time_arg_val(1);
+    uint32_t reduce_receiver_semaphore_addr = get_semaphore(get_compile_time_arg_val(0));
+    uint32_t reduce_sender_semaphore_addr   = get_semaphore(get_compile_time_arg_val(1));
 
     constexpr uint32_t num_batch_group                  = get_compile_time_arg_val(2);
 

--- a/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/kernels/dataflow/reader_mcast_sender_unary_sharded_gn_v2.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/kernels/dataflow/reader_mcast_sender_unary_sharded_gn_v2.cpp
@@ -10,8 +10,8 @@
 
 // split REDUCE across cores
 void kernel_main() {
-    constexpr uint32_t reduce_receiver_semaphore_addr = get_compile_time_arg_val(0);
-    constexpr uint32_t reduce_sender_semaphore_addr   = get_compile_time_arg_val(1);
+    uint32_t reduce_receiver_semaphore_addr = get_semaphore(get_compile_time_arg_val(0));
+    uint32_t reduce_sender_semaphore_addr   = get_semaphore(get_compile_time_arg_val(1));
 
     constexpr uint32_t num_mcast_cores                = get_compile_time_arg_val(2);
     constexpr uint32_t num_batch_group                  = get_compile_time_arg_val(3);

--- a/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/multi_core/groupnorm_op_multi_core.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/multi_core/groupnorm_op_multi_core.cpp
@@ -429,8 +429,8 @@ operation::ProgramWithCallbacks groupnorm_multi_core_sharded(
     // how many cores in a mcast group
     uint32_t num_cores_per_mcast_group = mcast_groups[0].size();
     // Mcast args
-    auto reduce_sender_semaphore = tt::tt_metal::CreateSemaphore(program, all_cores, INVALID);
-    auto reduce_receiver_semaphore = tt::tt_metal::CreateSemaphore(program, all_cores, INVALID);
+    auto reduce_sender_semaphore_id = tt::tt_metal::CreateSemaphore(program, all_cores, INVALID);
+    auto reduce_receiver_semaphore_id = tt::tt_metal::CreateSemaphore(program, all_cores, INVALID);
     // reader defines
     std::map<string, string> reader_mcast_sender_defines;
     std::map<string, string> reader_mcast_receiver_defines;
@@ -456,8 +456,8 @@ operation::ProgramWithCallbacks groupnorm_multi_core_sharded(
     }
     // reader compile time args
     std::vector<uint32_t> reader_mcast_sender_compile_time_args = {
-        (std::uint32_t) reduce_receiver_semaphore,
-        (std::uint32_t) reduce_sender_semaphore,
+        (std::uint32_t) reduce_receiver_semaphore_id,
+        (std::uint32_t) reduce_sender_semaphore_id,
         (std::uint32_t) num_cores_per_mcast_group,
         (std::uint32_t) num_groups_per_core * num_batches_per_core,
         (std::uint32_t) per_core_Nt,
@@ -468,8 +468,8 @@ operation::ProgramWithCallbacks groupnorm_multi_core_sharded(
         (std::uint32_t) TILE_HEIGHT
     };
     std::vector<uint32_t> reader_mcast_receiver_compile_time_args = {
-        (std::uint32_t) reduce_receiver_semaphore,
-        (std::uint32_t) reduce_sender_semaphore,
+        (std::uint32_t) reduce_receiver_semaphore_id,
+        (std::uint32_t) reduce_sender_semaphore_id,
         (std::uint32_t) num_groups_per_core * num_batches_per_core,
         (std::uint32_t) per_core_Nt,
         (std::uint32_t) per_core_N_bytes_padded,

--- a/ttnn/cpp/ttnn/operations/normalization/layernorm/device/kernels/dataflow/reader_mcast_receiver_unary_sharded_ln.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/layernorm/device/kernels/dataflow/reader_mcast_receiver_unary_sharded_ln.cpp
@@ -10,8 +10,8 @@
 // split REDUCE across cores
 void kernel_main() {
 
-    constexpr uint32_t reduce_receiver_semaphore_addr  = get_compile_time_arg_val(0);
-    constexpr uint32_t reduce_sender_semaphore_addr    = get_compile_time_arg_val(1);
+    uint32_t reduce_receiver_semaphore_addr  = get_semaphore(get_compile_time_arg_val(0));
+    uint32_t reduce_sender_semaphore_addr    = get_semaphore(get_compile_time_arg_val(1));
     constexpr uint32_t num_blocks                      = get_compile_time_arg_val(2);
     constexpr uint32_t block_h                         = get_compile_time_arg_val(3);
     const bool is_all_to_all_worker                    = get_compile_time_arg_val(4) == 1;
@@ -24,7 +24,7 @@ void kernel_main() {
     constexpr bool use_two_stage_reduce                              = (bool) get_compile_time_arg_val(11);
     constexpr uint32_t num_blocks_first_stage                        = get_compile_time_arg_val(12);
     constexpr uint32_t num_blocks_second_stage                       = get_compile_time_arg_val(13);
-    constexpr uint32_t reduce_second_stage_semaphore_addr            = get_compile_time_arg_val(14);
+    uint32_t reduce_second_stage_semaphore_addr            = get_semaphore(get_compile_time_arg_val(14));
 
     const bool is_last_all_to_all_worker                = get_arg_val<uint32_t>(0);
     const uint32_t all_to_all_tile_offset_bytes         = get_arg_val<uint32_t>(1);

--- a/ttnn/cpp/ttnn/operations/normalization/layernorm/device/kernels/dataflow/reader_mcast_sender_unary_sharded_ln.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/layernorm/device/kernels/dataflow/reader_mcast_sender_unary_sharded_ln.cpp
@@ -10,8 +10,8 @@
 // split REDUCE across cores
 void kernel_main() {
 
-    constexpr uint32_t reduce_receiver_semaphore_addr       = get_compile_time_arg_val(0);
-    constexpr uint32_t reduce_sender_semaphore_addr         = get_compile_time_arg_val(1);
+    uint32_t reduce_receiver_semaphore_addr       = get_semaphore(get_compile_time_arg_val(0));
+    uint32_t reduce_sender_semaphore_addr         = get_semaphore(get_compile_time_arg_val(1));
     constexpr uint32_t num_blocks                           = get_compile_time_arg_val(2);
     constexpr uint32_t block_h                              = get_compile_time_arg_val(3);
     constexpr uint32_t block_h_size_bytes                   = get_compile_time_arg_val(4);
@@ -26,7 +26,7 @@ void kernel_main() {
     constexpr bool use_two_stage_reduce                     = (bool) get_compile_time_arg_val(13);
     constexpr uint32_t num_blocks_first_stage               = get_compile_time_arg_val(14);
     constexpr uint32_t num_blocks_second_stage              = get_compile_time_arg_val(15);
-    constexpr uint32_t reduce_second_stage_semaphore_addr   = get_compile_time_arg_val(16);
+    uint32_t reduce_second_stage_semaphore_addr   = get_semaphore(get_compile_time_arg_val(16));
 
     const uint32_t mcast_dest_noc_start_x               = get_arg_val<uint32_t>(0);
     const uint32_t mcast_dest_noc_start_y               = get_arg_val<uint32_t>(1);

--- a/ttnn/cpp/ttnn/operations/normalization/layernorm/device/multi_core/layernorm_op_multi_core.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/layernorm/device/multi_core/layernorm_op_multi_core.cpp
@@ -752,9 +752,9 @@ operation::ProgramWithCallbacks layernorm_multi_core_sharded(
         }
     }
     // Mcast args
-    auto reduce_sender_semaphore = tt::tt_metal::CreateSemaphore(program, all_cores, INVALID);
-    auto reduce_receiver_semaphore = tt::tt_metal::CreateSemaphore(program, all_cores, INVALID);
-    auto reduce_second_stage_semaphore = tt::tt_metal::CreateSemaphore(program, all_cores, INVALID);
+    auto reduce_sender_semaphore_id = tt::tt_metal::CreateSemaphore(program, all_cores, INVALID);
+    auto reduce_receiver_semaphore_id = tt::tt_metal::CreateSemaphore(program, all_cores, INVALID);
+    auto reduce_second_stage_semaphore_id = tt::tt_metal::CreateSemaphore(program, all_cores, INVALID);
     // reader defines
     std::map<string, string> reader_mcast_sender_defines;
     std::map<string, string> reader_mcast_receiver_defines;
@@ -776,8 +776,8 @@ operation::ProgramWithCallbacks layernorm_multi_core_sharded(
     }
     // reader compile time args
     std::vector<uint32_t> reader_mcast_sender_compile_time_args = {
-        (std::uint32_t) reduce_receiver_semaphore,
-        (std::uint32_t) reduce_sender_semaphore,
+        (std::uint32_t) reduce_receiver_semaphore_id,
+        (std::uint32_t) reduce_sender_semaphore_id,
         (std::uint32_t) num_blocks,
         (std::uint32_t) block_ht,
         (std::uint32_t) block_ht * single_tile_size,
@@ -792,11 +792,11 @@ operation::ProgramWithCallbacks layernorm_multi_core_sharded(
         (std::uint32_t) use_two_stage_reduce,
         (std::uint32_t) num_blocks_first_stage,
         (std::uint32_t) num_blocks_second_stage,
-        (std::uint32_t) reduce_second_stage_semaphore
+        (std::uint32_t) reduce_second_stage_semaphore_id
     };
     std::vector<uint32_t> reader_mcast_receiver_all_to_all_compile_time_args = {
-        (std::uint32_t) reduce_receiver_semaphore,
-        (std::uint32_t) reduce_sender_semaphore,
+        (std::uint32_t) reduce_receiver_semaphore_id,
+        (std::uint32_t) reduce_sender_semaphore_id,
         (std::uint32_t) num_blocks,
         (std::uint32_t) block_ht,
         (std::uint32_t) 1,
@@ -809,11 +809,11 @@ operation::ProgramWithCallbacks layernorm_multi_core_sharded(
         (std::uint32_t) use_two_stage_reduce,
         (std::uint32_t) num_blocks_first_stage,
         (std::uint32_t) num_blocks_second_stage,
-        (std::uint32_t) reduce_second_stage_semaphore
+        (std::uint32_t) reduce_second_stage_semaphore_id
     };
     std::vector<uint32_t> reader_mcast_receiver_compile_time_args = {
-        (std::uint32_t) reduce_receiver_semaphore,
-        (std::uint32_t) reduce_sender_semaphore,
+        (std::uint32_t) reduce_receiver_semaphore_id,
+        (std::uint32_t) reduce_sender_semaphore_id,
         (std::uint32_t) num_blocks,
         (std::uint32_t) block_ht,
         (std::uint32_t) 0,
@@ -826,7 +826,7 @@ operation::ProgramWithCallbacks layernorm_multi_core_sharded(
         (std::uint32_t) 0,
         (std::uint32_t) 0,
         (std::uint32_t) 0,
-        (std::uint32_t) reduce_second_stage_semaphore
+        (std::uint32_t) reduce_second_stage_semaphore_id
     };
 
     tt::tt_metal::NOC reader_noc = tt::tt_metal::detail::GetPreferredNOCForDRAMRead(device->arch());

--- a/ttnn/cpp/ttnn/operations/reduction/topk/device/kernels/dataflow/reader_final_topk.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/topk/device/kernels/dataflow/reader_final_topk.cpp
@@ -7,8 +7,8 @@
 
 
 void kernel_main() {
-    constexpr uint32_t receiver_semaphore = get_compile_time_arg_val(0);
-    constexpr uint32_t sender_semaphore = get_compile_time_arg_val(1);
+    uint32_t receiver_semaphore = get_semaphore(get_compile_time_arg_val(0));
+    uint32_t sender_semaphore = get_semaphore(get_compile_time_arg_val(1));
 
     constexpr uint32_t noc_start_x = get_compile_time_arg_val(2);
     constexpr uint32_t noc_start_y = get_compile_time_arg_val(3);

--- a/ttnn/cpp/ttnn/operations/reduction/topk/device/kernels/dataflow/writer_local_topk.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/topk/device/kernels/dataflow/writer_local_topk.cpp
@@ -6,8 +6,8 @@
 
 void kernel_main() {
 
-    constexpr uint32_t receiver_semaphore = get_compile_time_arg_val(0);
-    constexpr uint32_t sender_semaphore = get_compile_time_arg_val(1);
+    uint32_t receiver_semaphore = get_semaphore(get_compile_time_arg_val(0));
+    uint32_t sender_semaphore = get_semaphore(get_compile_time_arg_val(1));
     constexpr uint32_t noc_final_x = get_compile_time_arg_val(2);
     constexpr uint32_t noc_final_y = get_compile_time_arg_val(3);
     constexpr uint32_t Ht = get_compile_time_arg_val(4);

--- a/ttnn/cpp/ttnn/operations/reduction/topk/device/topk_program_factory.hpp
+++ b/ttnn/cpp/ttnn/operations/reduction/topk/device/topk_program_factory.hpp
@@ -326,8 +326,8 @@ operation::ProgramWithCallbacks topk_multicore_interleaved(const Tensor &input_t
 
 
     // Create semaphores
-    auto sender_semaphore = tt::tt_metal::CreateSemaphore(program, core, INVALID);
-    auto receiver_semaphore = tt::tt_metal::CreateSemaphore(program, core, INVALID);
+    auto sender_semaphore_id = tt::tt_metal::CreateSemaphore(program, core, INVALID);
+    auto receiver_semaphore_id = tt::tt_metal::CreateSemaphore(program, core, INVALID);
     std::vector<uint32_t> reader_local_compile_time_args = {
                                                         input_cb_index,
                                                         index_cb_index,
@@ -347,8 +347,8 @@ operation::ProgramWithCallbacks topk_multicore_interleaved(const Tensor &input_t
     CoreCoord local_cores_physical_start = device->worker_core_from_logical_core({0, 0});
     CoreCoord local_cores_physical_end = device->worker_core_from_logical_core({0, num_cores - 2u});
     std::vector<uint32_t> reader_compile_time_args =             {
-                (std::uint32_t) receiver_semaphore,
-                (std::uint32_t) sender_semaphore,
+                (std::uint32_t) receiver_semaphore_id,
+                (std::uint32_t) sender_semaphore_id,
                 (std::uint32_t) local_cores_physical_start.x,
                 (std::uint32_t) local_cores_physical_start.y,
                 (std::uint32_t) local_cores_physical_end.x,
@@ -366,8 +366,8 @@ operation::ProgramWithCallbacks topk_multicore_interleaved(const Tensor &input_t
 
     CoreCoord final_cores_physical = device->worker_core_from_logical_core({0, num_cores - 1u});
     std::vector<uint32_t> writer_compile_time_args = {
-        (std::uint32_t) receiver_semaphore,
-        (std::uint32_t) sender_semaphore,
+        (std::uint32_t) receiver_semaphore_id,
+        (std::uint32_t) sender_semaphore_id,
         (std::uint32_t) final_cores_physical.x,
         (std::uint32_t) final_cores_physical.y,
         Ht,


### PR DESCRIPTION
### Ticket
[Link to Github Issue](https://github.com/tenstorrent/tt-metal/issues/7426)

### Problem description
CreateSemaphore returning address was blocking FD2.1 work to use ring buffers for program configs. Also, just messy and error prone.

### What's changed
Update CreateSemaphore to return its ID. Updated all tests and kernels to observe this.

### Checklist
- [x] Post commit CI passes
- [x] Blackhole Post commit (if applicable)
- [x] t3000 frequent:
- [x] Model regression CI testing passes (if applicable)
- [x] New/Existing tests provide coverage for changes
