### PR TITLE
#11241: Replace tt_lib in models/demos/bert and falcon7b_common

### DIFF
--- a/models/demos/bert/tests/test_ttnn_optimized_bert.py
+++ b/models/demos/bert/tests/test_ttnn_optimized_bert.py
@@ -10,7 +10,6 @@ import transformers
 from models.demos.bert.reference import torch_bert
 from models.demos.bert.tt import ttnn_optimized_sharded_bert
 
-import tt_lib
 import ttnn
 from ttnn.model_preprocessing import preprocess_model_parameters
 
@@ -25,7 +24,7 @@ from models.utility_functions import skip_for_wormhole_b0
 def test_bert_for_question_answering(device, use_program_cache, model_name, batch_size, sequence_size):
     torch.manual_seed(1234)
 
-    tt_lib.device.EnableMemoryReports()
+    ttnn.experimental.device.EnableMemoryReports()
 
     config = transformers.BertConfig.from_pretrained(model_name)
 

--- a/models/demos/falcon7b_common/demo/demo.py
+++ b/models/demos/falcon7b_common/demo/demo.py
@@ -10,7 +10,6 @@ from functools import partial
 import torch
 import torch.nn.functional as F
 import ttnn
-import tt_lib
 from loguru import logger
 from models.demos.falcon7b_common.reference.hf_modeling_falcon import FalconConfig
 from models.demos.falcon7b_common.tt.falcon_causallm import TtFalconCausalLM
@@ -116,7 +115,7 @@ def top_pk_logits_efficient(logits, p=0.9, k=10, temperature=1.0, return_probs=F
 
 def synchronize_devices(devices):
     for device in devices:
-        tt_lib.device.Synchronize(device)
+        ttnn.synchronize_device(device)
 
 
 def run_falcon_demo_kv(

--- a/models/demos/falcon7b_common/tests/run_falcon_end_to_end.py
+++ b/models/demos/falcon7b_common/tests/run_falcon_end_to_end.py
@@ -8,7 +8,7 @@ from loguru import logger
 import numpy as np
 from sklearn.metrics import top_k_accuracy_score
 
-import tt_lib
+import ttnn
 from models.demos.falcon7b_common.tt.falcon_causallm import TtFalconCausalLM
 
 from models.demos.falcon7b_common.tt.falcon_common import (
@@ -230,12 +230,12 @@ def run_test_FalconCausalLM_end_to_end(
                 use_cache=use_cache,
             )
         for device in devices:
-            tt_lib.device.Synchronize(device)
+            ttnn.synchronize_device(device)
         profiler.end("first_model_run_with_compile", force_enable=e2e_perf)
 
         # Dump device profiler data before second run to avoid exceeding profiler memory limits when using tracy
         for device in devices:
-            tt_lib.device.DumpDeviceProfiler(device)
+            ttnn.experimental.device.DumpDeviceProfiler(device)
 
         del tt_out
         del tt_layer_past
@@ -313,7 +313,7 @@ def run_test_FalconCausalLM_end_to_end(
             device_perf_run=device_perf,
         )
     for device in devices:
-        tt_lib.device.Synchronize(device)
+        ttnn.synchronize_device(device)
     profiler.end(f"model_run_for_inference")
 
     if llm_mode == "prefill":

--- a/models/demos/falcon7b_common/tests/test_falcon_end_to_end.py
+++ b/models/demos/falcon7b_common/tests/test_falcon_end_to_end.py
@@ -5,7 +5,7 @@
 import numpy as np
 import pytest
 import torch
-import tt_lib
+import ttnn
 from loguru import logger
 from models.demos.falcon7b_common.tests.test_utils import (
     concat_device_out_layer_present,
@@ -160,7 +160,7 @@ def run_test_FalconCausalLM_end_to_end(
             use_cache=use_cache,
         )
     for device in devices:
-        tt_lib.device.Synchronize(device)
+        ttnn.synchronize_device(device)
     profiler.end("first_model_run_with_compile", force_enable=True)
     del tt_out
     del tt_layer_past
@@ -236,7 +236,7 @@ def run_test_FalconCausalLM_end_to_end(
             use_cache=use_cache,
         )
     for device in devices:
-        tt_lib.device.Synchronize(device)
+        ttnn.synchronize_device(device)
     profiler.end(f"model_run_for_inference")
 
     if llm_mode == "prefill":

--- a/models/demos/falcon7b_common/tt/falcon_lm_head.py
+++ b/models/demos/falcon7b_common/tt/falcon_lm_head.py
@@ -4,7 +4,6 @@
 
 from typing import List
 
-import tt_lib
 import ttnn
 
 from models.utility_functions import nearest_y
@@ -23,7 +22,7 @@ def falcon_lm_head_matmul_2d(
     out_dtype: ttnn.experimental.tensor.DataType,
 ):
     assert (
-        hidden_states.device().arch() == tt_lib.device.Arch.WORMHOLE_B0
+        hidden_states.device().arch() == ttnn.device.Arch.WORMHOLE_B0
     ), "Falcon LM head is only supported for Wormhole BO arch"
 
     seq_len = hidden_states.get_legacy_shape()[-2]

--- a/models/demos/falcon7b_common/tt/falcon_model.py
+++ b/models/demos/falcon7b_common/tt/falcon_model.py
@@ -8,8 +8,6 @@ from typing import List, Optional, Tuple
 import torch
 import ttnn
 
-import tt_lib
-
 from models.demos.falcon7b_common.tt.falcon_decoder import TtFalconDecoderLayer
 from models.demos.falcon7b_common.tt.model_utils import get_weights_cached, layernorm
 from models.utility_functions import nearest_32, torch_tensors_to_tt_tensors
@@ -286,7 +284,7 @@ class TtFalconModelShared(torch.nn.Module):
 
             if device_perf_run and idx % 8 == 0:
                 for i in range(self.num_devices):
-                    tt_lib.device.DumpDeviceProfiler(layer_output[i].device())
+                    ttnn.experimental.device.DumpDeviceProfiler(layer_output[i].device())
 
         # apply final norm layer
         layer_output = layernorm(

--- a/models/demos/falcon7b_common/tt/model_utils.py
+++ b/models/demos/falcon7b_common/tt/model_utils.py
@@ -37,7 +37,7 @@ def get_weights_cached(
         weights = weights_dict[str(path)]
     elif not overwrite and path.exists():
         # Load cached weights
-        weights_host = ttnn.experimental.tensor.load_tensor(str(path))
+        weights_host = ttnn.load_tensor(str(path))
         # Duplicate weights on all devices
         weights = [weights_host.to(device, model_config[f"{weight_config_str}_MEMCFG"]) for device in devices]
         # Add to weights_dict

--- a/ttnn/ttnn/experimental_loader/__init__.py
+++ b/ttnn/ttnn/experimental_loader/__init__.py
@@ -11,8 +11,11 @@ import types
 
 def register_tt_lib_operations_as_ttnn_operations(module):
     module_name = module.__name__
-    if not module_name.startswith("ttnn._ttnn.deprecated.tensor") and not module_name.startswith(
-        "ttnn._ttnn.deprecated.operations"
+    if not (
+        module_name.startswith("ttnn._ttnn.deprecated.tensor")
+        or module_name.startswith("ttnn._ttnn.deprecated.operations")
+        or module_name.startswith("ttnn._ttnn.deprecated.device")
+        or module_name.startswith("ttnn._ttnn.deprecated.profiler")
     ):
         return
     ttnn_module_name = module_name.replace("ttnn._ttnn.deprecated", "ttnn.experimental")
@@ -44,3 +47,5 @@ def register_tt_lib_operations_as_ttnn_operations(module):
 
 register_tt_lib_operations_as_ttnn_operations(ttnn._ttnn.deprecated.tensor)
 register_tt_lib_operations_as_ttnn_operations(ttnn._ttnn.deprecated.operations)
+register_tt_lib_operations_as_ttnn_operations(ttnn._ttnn.deprecated.device)
+register_tt_lib_operations_as_ttnn_operations(ttnn._ttnn.deprecated.profiler)


### PR DESCRIPTION
### Ticket
Link to Github Issue #11242 

### Problem description
Replace usage of tt_lib with ttnn

### What's changed
- Replaced usage of tt_lib with ttnn
- Also added device and profiler modules from tt_lib_bindings.cpp to  ttnn.experimental.*

### Checklist

- [x] Post commit CI https://github.com/tenstorrent/tt-metal/actions/runs/10390425575

- [ ] Demo tests SC https://github.com/tenstorrent/tt-metal/actions/runs/10388620729

- [ ] t3k demos https://github.com/tenstorrent/tt-metal/actions/runs/10389230627

- [ ] nightly FD https://github.com/tenstorrent/tt-metal/actions/runs/10388617522

- [ ] PC model tests https://github.com/tenstorrent/tt-metal/actions/runs/10380749509

- [x] model perf https://github.com/tenstorrent/tt-metal/actions/runs/10386170948

- [ ] Blackhole Post commit (if applicable)
- [ ] Model regression CI testing passes (if applicable)
- [ ] New/Existing tests provide coverage for changes
