### PR TITLE
#11259: Update links to organization GitHub Pages

### DIFF
--- a/INSTALLING.md
+++ b/INSTALLING.md
@@ -153,7 +153,7 @@ pip install -r tt_metal/python_env/requirements-dev.txt
 
 5. Start coding
 
-You are all set! Visit the [TT-NN Basic examples page](https://tenstorrent.github.io/tt-metal/latest/ttnn/ttnn/usage.html#basic-examples) or get started with [simple kernels on TT-Metalium](https://tenstorrent.github.io/tt-metal/latest/tt-metalium/tt_metal/examples/index.html).
+You are all set! Visit the [TT-NN Basic examples page](https://tenstorrent.github.io/ttnn/latest/ttnn/usage.html#basic-examples) or get started with [simple kernels on TT-Metalium](https://tenstorrent.github.io/tt-metalium/latest//tt_metal/examples/index.html).
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 
 <h3>
 
-[API Reference](https://tenstorrent.github.io/tt-metal/latest/ttnn) | [Model Demos](./models/demos/)
+[API Reference](https://tenstorrent.github.io/ttnn/latest/index.html) | [Model Demos](./models/demos/)
 
 </h3>
 
@@ -109,11 +109,11 @@ print(output)
 
 <h3>
 
-[Programming Guide](./METALIUM_GUIDE.md) | [API Reference](https://tenstorrent.github.io/tt-metal/latest/tt-metalium)
+[Programming Guide](./METALIUM_GUIDE.md) | [API Reference](https://tenstorrent.github.io/tt-metalium/latest/tt_metal/apis/index.html)
 
 </h3>
 </div>
 
 ## Getting started
 
-Get started with [simple kernels](https://tenstorrent.github.io/tt-metal/latest/tt-metalium/tt_metal/examples/index.html).
+Get started with [simple kernels](https://tenstorrent.github.io/tt-metalium/latest/tt_metal/examples/index.html).

--- a/models/experimental/functional_unet/README.md
+++ b/models/experimental/functional_unet/README.md
@@ -2,7 +2,7 @@
 ## How to Run
 
 To run the demo, make sure to build the project, activate the environment, and set the appropriate environment variables.
-For more information, refer [installation and build guide](https://tenstorrent.github.io/tt-metal/latest/get_started/get_started.html#install-and-build).
+For more information, refer [installation and build guide](https://tenstorrent.github.io/tt-metalium/latest/get_started/get_started.html#install-and-build).
 
 Use `pytest --disable-warnings models/experimental/functional_unet/demo/demo.py::test_unet_demo` to run all variants of the demo.
 

--- a/ttnn/tutorials/001.ipynb
+++ b/ttnn/tutorials/001.ipynb
@@ -275,7 +275,7 @@
    "source": [
     "## Layout\n",
     "\n",
-    "TensTorrent hardware is most efficiently utilized when running tensors using [tile layout](https://tenstorrent.github.io/tt-metal/latest/ttnn/tensor.html#layout).\n",
+    "TensTorrent hardware is most efficiently utilized when running tensors using [tile layout](https://tenstorrent.github.io/ttnn/latest/ttnn/tensor.html#layout).\n",
     "The current tile size is hard-coded to [32, 32]. It was determined to be the optimal size for a tile given the compute, memory and data transfer constraints.\n",
     "\n",
     "\n",

--- a/ttnn/tutorials/005.ipynb
+++ b/ttnn/tutorials/005.ipynb
@@ -13,7 +13,7 @@
    "id": "253a1334-d62f-4cff-806e-62ce5289b580",
    "metadata": {},
    "source": [
-    "See the documentation on [profiling](https://tenstorrent.github.io/tt-metal/latest/ttnn/dependencies/ops_perf_report.html) !"
+    "See the documentation on [profiling](https://tenstorrent.github.io/ttnn/latest/ttnn/profiling_ttnn_operations.html) !"
    ]
   },
   {


### PR DESCRIPTION
### Ticket

#11259

### Problem description

For docs changes, we want to use new docs site.

### What's changed

Find and replace docs links to github.io.

### Checklist
- [ ] Post commit CI passes
- [ ] Blackhole Post commit (if applicable)
- [ ] Model regression CI testing passes (if applicable)
- [ ] New/Existing tests provide coverage for changes
