### PR TITLE
#11268: Move tt_serializable_class to general location and update includes

### DIFF
--- a/ttnn/cpp/pybind11/__init__.cpp
+++ b/ttnn/cpp/pybind11/__init__.cpp
@@ -12,6 +12,7 @@
 #include "reports.hpp"
 #include "activation.hpp"
 #include "export_enum.hpp"
+#include "json_class.hpp"
 
 #include "ttnn/deprecated/tt_lib/csrc/tt_lib_bindings.hpp"
 #include "operations/__init__.hpp"

--- a/ttnn/cpp/pybind11/json_class.hpp
+++ b/ttnn/cpp/pybind11/json_class.hpp
@@ -1,0 +1,22 @@
+// SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <pybind11/pybind11.h>
+#include <pybind11/stl.h>
+
+namespace py = pybind11;
+
+template <typename T>
+auto tt_serializable_class(py::module m, auto name, auto desc) {
+    return py::class_<T>(m, name, desc)
+        .def("to_json", [](const T& self) -> std::string { return tt::stl::json::to_json(self).dump(); })
+        .def(
+            "from_json",
+            [](const std::string& json_string) -> T {
+                return tt::stl::json::from_json<T>(nlohmann::json::parse(json_string));
+            })
+        .def("__repr__", [](const T& self) { return fmt::format("{}", self); });
+}

--- a/ttnn/cpp/ttnn/deprecated/tt_lib/csrc/tt_lib_bindings_tensor.cpp
+++ b/ttnn/cpp/ttnn/deprecated/tt_lib/csrc/tt_lib_bindings_tensor.cpp
@@ -169,9 +169,6 @@ void TensorModule(py::module& m_tensor) {
                     mem_config = tt_lib.tensor.MemoryConfig(tt_lib.tensor.TensorMemoryLayout.SINGLE_BANK)
             )doc")
         .def(
-            "__repr__",
-            [](const MemoryConfig& memory_config) -> std::string { return fmt::format("{}", memory_config); })
-        .def(
             "__hash__",
             [](const MemoryConfig& memory_config) -> tt::stl::hash::hash_t {
                 return tt::stl::hash::detail::hash_object(memory_config);
@@ -214,7 +211,6 @@ void TensorModule(py::module& m_tensor) {
     auto pyCoreRange = tt_serializable_class<CoreRange>(m_tensor, "CoreRange", R"doc(
         Class defining a range of cores)doc");
     pyCoreRange.def(py::init<>([](const CoreCoord& start, const CoreCoord& end) { return CoreRange{start, end}; }))
-        .def("__repr__", [](const CoreRange& core_range) -> std::string { return fmt::format("{}", core_range); })
         .def_readonly("start", &CoreRange::start_coord)
         .def_readonly("end", &CoreRange::end_coord)
         .def("grid_size", &CoreRange::grid_size);
@@ -222,9 +218,6 @@ void TensorModule(py::module& m_tensor) {
     auto pyCoreRangeSet = tt_serializable_class<CoreRangeSet>(m_tensor, "CoreRangeSet", R"doc(
         Class defining a set of CoreRanges required for sharding)doc");
     pyCoreRangeSet.def(py::init<>([](const std::set<CoreRange>& core_ranges) { return CoreRangeSet(core_ranges); }))
-        .def(
-            "__repr__",
-            [](const CoreRangeSet& core_range_set) -> std::string { return fmt::format("{}", core_range_set); })
         .def(
             "bounding_box",
             &CoreRangeSet::bounding_box,
@@ -256,7 +249,6 @@ void TensorModule(py::module& m_tensor) {
         .def("num_cores", &ShardSpec::num_cores, "Number of cores")
         .def(py::self == py::self)
         .def(py::self != py::self)
-        .def("__repr__", [](const ShardSpec& shard_spec) -> std::string { return fmt::format("{}", shard_spec); });
     ;
 
     auto py_owned_buffer_for_int32_t =

--- a/ttnn/cpp/ttnn/operations/matmul/matmul_pybind.hpp
+++ b/ttnn/cpp/ttnn/operations/matmul/matmul_pybind.hpp
@@ -9,6 +9,7 @@
 
 #include "tt_metal/common/core_coord.h"
 #include "ttnn/operations/matmul/matmul.hpp"
+#include "ttnn/cpp/pybind11/json_class.hpp"
 #include "ttnn/types.hpp"
 
 namespace py = pybind11;
@@ -20,22 +21,12 @@ namespace matmul {
 using namespace tt::operations::primary;
 using ttnn::operations::unary::UnaryWithParam;
 
-template <typename T>
-auto tt_pybind_class(py::module m, auto name, auto desc) {
-    return py::class_<T>(m, name, desc)
-        .def("to_json", [](const T& self) -> std::string { return tt::stl::json::to_json(self).dump(); })
-        .def(
-            "from_json",
-            [](const std::string& json_string) -> T { return tt::stl::json::from_json<T>(nlohmann::json::parse(json_string)); })
-        .def("__repr__", [](const T& self) { return fmt::format("{}", self); });
-}
-
 void py_module(py::module& module) {
-    auto matmul_program_config = tt_pybind_class<MatmulProgramConfig>(module, "MatmulProgramConfig", R"doc(
+    auto matmul_program_config = tt_serializable_class<MatmulProgramConfig>(module, "MatmulProgramConfig", R"doc(
         Class defining matmul program config
     )doc");
 
-    auto matmul_multi_core_reuse_program_config = tt_pybind_class<MatmulMultiCoreReuseProgramConfig>(module, "MatmulMultiCoreReuseProgramConfig", R"doc(
+    auto matmul_multi_core_reuse_program_config = tt_serializable_class<MatmulMultiCoreReuseProgramConfig>(module, "MatmulMultiCoreReuseProgramConfig", R"doc(
         Class defining matmul multi core reuse program config
     )doc");
 
@@ -56,7 +47,7 @@ void py_module(py::module& module) {
         .def_readwrite("per_core_M", &MatmulMultiCoreReuseProgramConfig::per_core_M)
         .def_readwrite("per_core_N", &MatmulMultiCoreReuseProgramConfig::per_core_N);
 
-    auto matmul_multi_core_reuse_multicast_program_config = tt_pybind_class<MatmulMultiCoreReuseMultiCastProgramConfig>(module, "MatmulMultiCoreReuseMultiCastProgramConfig", R"doc(
+    auto matmul_multi_core_reuse_multicast_program_config = tt_serializable_class<MatmulMultiCoreReuseMultiCastProgramConfig>(module, "MatmulMultiCoreReuseMultiCastProgramConfig", R"doc(
         Class defining matmul multi core reuse multi cast program config
     )doc");
 
@@ -93,7 +84,7 @@ void py_module(py::module& module) {
         .def_readwrite("fused_activation", &MatmulMultiCoreReuseMultiCastProgramConfig::fused_activation)
         .def_readwrite("fuse_batch", &MatmulMultiCoreReuseMultiCastProgramConfig::fuse_batch);
 
-    auto matmul_multi_core_reuse_multicast_1d_program_config = tt_pybind_class<MatmulMultiCoreReuseMultiCast1DProgramConfig>(module, "MatmulMultiCoreReuseMultiCast1DProgramConfig", R"doc(
+    auto matmul_multi_core_reuse_multicast_1d_program_config = tt_serializable_class<MatmulMultiCoreReuseMultiCast1DProgramConfig>(module, "MatmulMultiCoreReuseMultiCast1DProgramConfig", R"doc(
         Class defining matmul multi core reuse multi cast 1D program config
     )doc");
 
@@ -130,7 +121,7 @@ void py_module(py::module& module) {
         .def_readwrite("fused_activation", &MatmulMultiCoreReuseMultiCast1DProgramConfig::fused_activation)
         .def_readwrite("mcast_in0", &MatmulMultiCoreReuseMultiCast1DProgramConfig::mcast_in0);
 
-    auto matmul_multi_core_reuse_multicast_dram_sharded_program_config = tt_pybind_class<MatmulMultiCoreReuseMultiCastDRAMShardedProgramConfig>(module, "MatmulMultiCoreReuseMultiCastDRAMShardedProgramConfig", R"doc(
+    auto matmul_multi_core_reuse_multicast_dram_sharded_program_config = tt_serializable_class<MatmulMultiCoreReuseMultiCastDRAMShardedProgramConfig>(module, "MatmulMultiCoreReuseMultiCastDRAMShardedProgramConfig", R"doc(
         Class defining matmul multi core reuse multi cast DRAM sharded program config
     )doc");
 


### PR DESCRIPTION
### Ticket
#11268 

### Problem description
`tt_pybind_class` template is duplicated and will need to be duplicated more for use in different pybinds. 

### What's changed
Move tt_serializable_class to general location and include it where we need it. Remove copies in `tt_lib_bindings_tensor.cpp` and `matmul_pybind.hpp`

### Checklist
- [x] Post commit CI passes
- [ ] Blackhole Post commit (if applicable)
- [ ] Model regression CI testing passes (if applicable)
- [ ] New/Existing tests provide coverage for changes
