### PR TITLE
#11260: Properly handle read return in noc semaphore increment

### DIFF
--- a/tt_metal/hw/firmware/src/ncrisc.cc
+++ b/tt_metal/hw/firmware/src/ncrisc.cc
@@ -32,7 +32,6 @@ uint32_t noc_nonposted_writes_num_issued[NUM_NOCS] __attribute__((used));
 uint32_t noc_nonposted_writes_acked[NUM_NOCS] __attribute__((used));
 uint32_t noc_nonposted_atomics_acked[NUM_NOCS] __attribute__((used));
 uint32_t noc_posted_writes_num_issued[NUM_NOCS] __attribute__((used));
-uint32_t atomic_ret_val __attribute__((section("l1_data"))) __attribute__((used));
 
 CBInterface cb_interface[NUM_CIRCULAR_BUFFERS] __attribute__((used));
 

--- a/tt_metal/hw/firmware/src/ncrisck.cc
+++ b/tt_metal/hw/firmware/src/ncrisck.cc
@@ -27,8 +27,6 @@ uint32_t noc_nonposted_writes_num_issued[NUM_NOCS];
 uint32_t noc_nonposted_writes_acked[NUM_NOCS];
 uint32_t noc_nonposted_atomics_acked[NUM_NOCS];
 uint32_t noc_posted_writes_num_issued[NUM_NOCS];
-uint32_t atomic_ret_val __attribute__ ((section ("l1_data")));
-
 
 void kernel_launch() {
 

--- a/tt_metal/impl/dispatch/kernels/packet_demux.cpp
+++ b/tt_metal/impl/dispatch/kernels/packet_demux.cpp
@@ -190,8 +190,6 @@ inline uint8_t dest_output_queue_id(uint32_t dest_endpoint_id) {
 
 void kernel_main() {
 
-    noc_init();
-
     write_test_results(test_results, PQ_TEST_STATUS_INDEX, PACKET_QUEUE_TEST_STARTED);
     write_test_results(test_results, PQ_TEST_MISC_INDEX, 0xff000000);
     write_test_results(test_results, PQ_TEST_MISC_INDEX+1, 0xbb000000 | demux_fan_out);

--- a/tt_metal/impl/dispatch/kernels/packet_mux.cpp
+++ b/tt_metal/impl/dispatch/kernels/packet_mux.cpp
@@ -140,8 +140,6 @@ constexpr uint32_t input_packetize_dest_endpoint[MAX_SWITCH_FAN_IN] =
 
 void kernel_main() {
 
-    noc_init();
-
     write_test_results(test_results, PQ_TEST_STATUS_INDEX, PACKET_QUEUE_TEST_STARTED);
     write_test_results(test_results, PQ_TEST_MISC_INDEX, 0xff000000);
     write_test_results(test_results, PQ_TEST_MISC_INDEX+1, 0xaa000000 | mux_fan_in);


### PR DESCRIPTION
### Ticket
[Link to Github Issue](https://github.com/tenstorrent/tt-metal/issues/11260)

### Problem description
noc_init called by mux/demux packet kernels is corrupting BRISC FW on the cores dedicated to those kernels.

### What's changed
noc_init is only be called by BRISC FW. 

### Checklist
- [x] Post commit CI passes: https://github.com/tenstorrent/tt-metal/actions/runs/10358439488
- [x] Blackhole Post commit: https://github.com/tenstorrent/tt-metal/actions/runs/10357571335
- [x] Model regression CI testing passes: https://github.com/tenstorrent/tt-metal/actions/runs/10357575745
- [x] Device perf regression: https://github.com/tenstorrent/tt-metal/actions/runs/10357581741
- [x] T3K model perf: https://github.com/tenstorrent/tt-metal/actions/runs/10357605387 
