### PR TITLE
Remove test timeout at script-level

### DIFF
--- a/tests/scripts/run_performance.sh
+++ b/tests/scripts/run_performance.sh
@@ -34,7 +34,7 @@ run_perf_models_llm_javelin() {
     env WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml pytest -n auto models/demos/falcon7b_common/tests -m $test_marker
 
     if [ "$tt_arch" == "wormhole_b0" ]; then
-        env WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml pytest -n auto models/demos/wormhole/mamba/tests -m $test_marker --timeout=360
+        env WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml pytest -n auto models/demos/wormhole/mamba/tests -m $test_marker
     fi
 
     env WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml pytest -n auto models/demos/wormhole/mistral7b/tests -m $test_marker


### PR DESCRIPTION
### Summary
We should control the test timeout using the decorators inside the test files themselves instead of in the `run_performance.sh` script. This is more consistent with what other models are doing.

This is required if we want to add more end-to-end test cases (such as for prefill in https://github.com/tenstorrent/tt-metal/pull/11248).
