### PR TITLE
Recommend noc_async_write_flushed() on examples

### DIFF
--- a/tt_metal/programming_examples/contributed/vecadd/kernels/tile_write.cpp
+++ b/tt_metal/programming_examples/contributed/vecadd/kernels/tile_write.cpp
@@ -28,7 +28,11 @@ void kernel_main()
         uint32_t cb_out0_addr = get_read_ptr(cb_out0);
         // write the tile to DRAM
         noc_async_write_tile(i, c, cb_out0_addr);
-        noc_async_write_barrier();
+        noc_async_write_barrier(); // This will wait until the write is done. As an alternative,
+                                   // noc_async_write_flushed() can be faster because it waits
+                                   // until the write request is sent. In that case, you have to
+                                   // use noc_async_write_barrier() at least once at the end of
+                                   // data move kernel to make sure all write is done.
         // Mark the tile as consumed
         cb_pop_front(cb_out0, 1);
     }

--- a/tt_metal/programming_examples/matmul_common/kernels/dataflow/writer_bmm_8bank.cpp
+++ b/tt_metal/programming_examples/matmul_common/kernels/dataflow/writer_bmm_8bank.cpp
@@ -35,7 +35,11 @@ void kernel_main() {
         cb_wait_front(cb_id_out0, onetile);
         uint32_t l1_read_addr = get_read_ptr(cb_id_out0);
         noc_async_write_tile(itileC, s, l1_read_addr);
-        noc_async_write_barrier();
+        noc_async_write_barrier(); // This will wait until the write is done. As an alternative,
+                                   // noc_async_write_flushed() can be faster because it waits
+                                   // until the write request is sent. In that case, you have to
+                                   // use noc_async_write_barrier() at least once at the end of
+                                   // data move kernel to make sure all write is done.
         cb_pop_front(cb_id_out0, onetile);
         //DPRINT << 'W' << 'C' << itileC << ' ' << 'a' << dst_addr << ENDL();
         //DPRINT << itileC << ' ' << uint32_t(dst_noc_addr) << ENDL();

--- a/tt_metal/programming_examples/matmul_common/kernels/dataflow/writer_bmm_tile_layout.cpp
+++ b/tt_metal/programming_examples/matmul_common/kernels/dataflow/writer_bmm_tile_layout.cpp
@@ -63,7 +63,13 @@ void kernel_main() {
                     out_tensor_sb_row_start_tile_id += out_tensor_stride_h;
                 }
 
-                noc_async_write_barrier();
+                noc_async_write_barrier(); // This will wait until the write is done. As
+                                           // an alternative, noc_async_write_flushed()
+                                           // can be faster because it waits until the
+                                           // write request is sent. In that case, you
+                                           // have to use noc_async_write_barrier() at
+                                           // least once at the end of data move kernel
+                                           // to make sure all write is done.
                 cb_pop_front(cb_id_out0, out_subblock_tile_count);
                 out_tensor_sbw_start_tile_id += out_tensor_next_subblock_stride_w;
             }

--- a/tt_metal/programming_examples/matmul_common/kernels/dataflow/writer_unary_interleaved_start_id.cpp
+++ b/tt_metal/programming_examples/matmul_common/kernels/dataflow/writer_unary_interleaved_start_id.cpp
@@ -38,7 +38,11 @@ void kernel_main() {
         cb_wait_front(cb_id_out, onetile);
         uint32_t l1_read_addr = get_read_ptr(cb_id_out);
         noc_async_write_tile(i, s, l1_read_addr);
-        noc_async_write_barrier();
+        noc_async_write_barrier(); // This will wait until the write is done. As an alternative,
+                                   // noc_async_write_flushed() can be faster because it waits
+                                   // until the write request is sent. In that case, you have to
+                                   // use noc_async_write_barrier() at least once at the end of
+                                   // data move kernel to make sure all write is done.
         cb_pop_front(cb_id_out, onetile);
     }
 }


### PR DESCRIPTION
As an alternative of `noc_async_write_barrier()`, this commit updates examples to recommend `noc_async_write_flushed()` that can be faster than `noc_async_write_barrier()` because it waits until the write request is sent.

### Ticket
No Github issue, but I met a case that `noc_async_write_barrier()` causes an infinite loop, while `noc_async_write_flushed()` finishes the kernel correctly. You can reproduce it by updating [this line](https://github.com/jaebaek/tenstorrent-tiny-examples/blob/524dee905e4b80a0f5b11bd386d899f047a16315/src/kernels/multicast_advanced.cpp#L98) to `noc_async_write_barrier()`. I explained this issue on [Discord channel](https://discord.com/channels/863154240319258674/1177107133167321158/1272042576664596541).

### Problem description
I met a case that `noc_async_write_barrier()` causes an infinite loop, while `noc_async_write_flushed()` finishes the kernel correctly. You can reproduce it by updating [this line](https://github.com/jaebaek/tenstorrent-tiny-examples/blob/524dee905e4b80a0f5b11bd386d899f047a16315/src/kernels/multicast_advanced.cpp#L98) to `noc_async_write_barrier()`.

### What's changed
I added comments on programming examples for tt-metal to recommend `noc_async_write_flushed()`.

### Checklist
- [ ] Post commit CI passes
- [ ] Blackhole Post commit (if applicable)
- [ ] Model regression CI testing passes (if applicable)
- [ ] New/Existing tests provide coverage for changes
