### PR TITLE
#11280: Enable sharded buffer l1 read/writes test on BH

### DIFF
--- a/tests/tt_metal/tt_metal/unit_tests_fast_dispatch/command_queue/test_EnqueueWriteBuffer_and_EnqueueReadBuffer.cpp
+++ b/tests/tt_metal/tt_metal/unit_tests_fast_dispatch/command_queue/test_EnqueueWriteBuffer_and_EnqueueReadBuffer.cpp
@@ -670,9 +670,8 @@ TEST_F(CommandQueueSingleCardFixture, ShardedBufferL1ReadWrites) {
     std::map<std::string, std::vector<std::array<uint32_t, 2>>> test_params;
 
     for (Device *device : devices_) {
-        if (device->arch() == tt::ARCH::BLACKHOLE) {
-            GTEST_SKIP(); // debug why this passes on BH with watcher enabled?
-        }
+        // This test hangs on Blackhole A0 when using static VCs through static TLBs and there are large number of reads/writes issued
+        //  workaround is to use dynamic VC (implemented in UMD)
         if (tt::Cluster::instance().is_galaxy_cluster()) {
             test_params = {
                 {"cores",


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/11280

### Problem description
Enabling a test that is passing with UMD workaround

### What's changed
Enable tet

### Checklist
- [x] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/runs/10337057146)
