### PR TITLE
Allocate program binaries top down

### DIFF
--- a/tt_metal/impl/buffers/buffer.hpp
+++ b/tt_metal/impl/buffers/buffer.hpp
@@ -150,7 +150,8 @@ class Buffer {
         device_(nullptr),
         buffer_type_(BufferType::DRAM),
         buffer_layout_(TensorMemoryLayout::INTERLEAVED),
-        shard_parameters_(std::nullopt) {}
+        shard_parameters_(std::nullopt),
+        bottom_up_(std::nullopt) {}
 
     Buffer(
         Device *device,
@@ -159,6 +160,7 @@ class Buffer {
         const BufferType buffer_type,
         const TensorMemoryLayout buffer_layout = TensorMemoryLayout::INTERLEAVED,
         const std::optional<ShardSpecBuffer>& shard_parameter = std::nullopt,
+        const std::optional<bool> bottom_up = std::nullopt,
         bool allocate = true);
 
     Buffer(const Buffer &other);
@@ -260,6 +262,8 @@ class Buffer {
     BufferType buffer_type_;
     TensorMemoryLayout buffer_layout_;
     std::optional<ShardSpecBuffer> shard_parameters_;
+   protected:
+    std::optional<bool> bottom_up_;
 };
 
 BufferPageMapping generate_buffer_page_mapping(const Buffer &buffer);

--- a/tt_metal/impl/program/program.cpp
+++ b/tt_metal/impl/program/program.cpp
@@ -679,8 +679,9 @@ void Program::populate_dispatch_data(Device *device) {
     }
 
     if (binaries_data.size() > 0) {
+        // We allocate program binaries top down to minimize fragmentation with other buffers in DRAM, which are typically allocated bottom up
         this->kernels_buffer = std::make_shared<Buffer>(
-            device, binaries_data.size() * sizeof(uint32_t), HostMemDeviceCommand::PROGRAM_PAGE_SIZE, BufferType::DRAM);
+            device, binaries_data.size() * sizeof(uint32_t), HostMemDeviceCommand::PROGRAM_PAGE_SIZE, BufferType::DRAM, TensorMemoryLayout::INTERLEAVED, std::nullopt, false);
 
         this->program_transfer_info.binary_data = binaries_data;
     }


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/11300

### Problem description
DRAM binaries are typically allocated bottom up. Program binaries are persistent when program cache is enabled with FD so we want to allocate them top down to minimize conflicts/fragmentation with other DRAM buffers.

### What's changed
Add flag for allocating top down/bottom up to Buffer to allow for overriding default scheme determined by buffer type.
Make program binaries be allocated top down in DRAM to minimize conflicts/fragmentation with other DRAM buffers, which are allocated bottom up by default.

### Checklist
- [x] Post commit CI passes
- [x] Blackhole Post commit (if applicable)
- [x] Model regression CI testing passes (if applicable)
- [x] New/Existing tests provide coverage for changes
