### PR TITLE
#5383: [Falcon7b] Remove per-token printing in single-card ci demo tests

### DIFF
--- a/models/demos/falcon7b_common/demo/demo.py
+++ b/models/demos/falcon7b_common/demo/demo.py
@@ -135,6 +135,7 @@ def run_falcon_demo_kv(
     expected_greedy_output_path=None,  # Path for expected outputs for greedy decoding
     save_generated_text_path=None,  # If provided, save generated text to this path (e.g. set to expected_greedy_output_path to update expected output)
     csv_perf_targets={},  # Optional perf targets for CSV output
+    is_ci_env=False,  # Whether is running in CI environment
 ):
     profiler = BenchmarkProfiler()
     profiler.start("run")
@@ -430,7 +431,7 @@ def run_falcon_demo_kv(
         N_decode = 30
         N_warmup_decode = N_warmup_iter["inference_decode"]
     print_per_generated_token = (
-        expected_greedy_output_path is None and num_devices == 1
+        expected_greedy_output_path is None and num_devices == 1 and not is_ci_env
     )  # print per generated token if not verifying outputs and single device
     for output_token_index in (
         range(N_decode) if print_per_generated_token else tqdm(range(N_decode), desc="Generating tokens")

--- a/models/demos/t3000/falcon7b/demo_t3000.py
+++ b/models/demos/t3000/falcon7b/demo_t3000.py
@@ -84,4 +84,5 @@ def test_demo_multichip(
         expected_perf_metrics=expected_perf_metrics,
         expected_greedy_output_path=expected_greedy_output_path,
         csv_perf_targets=csv_perf_targets,
+        is_ci_env=is_ci_env,
     )

--- a/models/demos/tg/falcon7b/demo_tg.py
+++ b/models/demos/tg/falcon7b/demo_tg.py
@@ -96,4 +96,5 @@ def test_demo_multichip(
         expected_perf_metrics=expected_perf_metrics,
         expected_greedy_output_path=expected_greedy_output_path,
         csv_perf_targets=csv_perf_targets,
+        is_ci_env=is_ci_env,
     )

--- a/models/demos/wormhole/falcon7b/demo_wormhole.py
+++ b/models/demos/wormhole/falcon7b/demo_wormhole.py
@@ -74,4 +74,5 @@ def test_demo(
         expected_perf_metrics=expected_perf_metrics,
         expected_greedy_output_path=expected_greedy_output_path,
         csv_perf_targets=csv_perf_targets,
+        is_ci_env=is_ci_env,
     )


### PR DESCRIPTION
### Ticket
N/A

### Problem description
Printing per generated token was logging too much info for single-card demo ci runs of Falcon7b

### What's changed
Removed per-token printing for ci demo runs

### Checklist
- [x] Post commit CI passes
- [x] Blackhole Post commit (if applicable)
- [x] Model regression CI testing passes (if applicable)
- [x] New/Existing tests provide coverage for changes
