### PR TITLE
#11224: Fix return value on sweep serialization warning

### DIFF
--- a/tests/sweep_framework/serialize.py
+++ b/tests/sweep_framework/serialize.py
@@ -15,6 +15,7 @@ def serialize(object, warnings=[]):
             f"SWEEPS: Warning: pybinded ttnn class detected without a to_json method. Your type may need to pybind the to_json and from_json methods in C++, see the FAQ in the sweeps README for instructions. The type is {type(object)}. You can ignore this if this is an enum type."
         )
         warnings.append(type(object))
+        return str(object)
     else:
         return str(object)
 


### PR DESCRIPTION
### Ticket
#11224 
### Problem description
Adding the warning for serialization did not return the value anyway, essentially making it an error instead of warning

### What's changed
Return the string serialized value for ttnn types without `to_json` and `from_json` functions anyways when printing the warning. 

### Checklist
- [ ] Post commit CI passes
- [ ] Blackhole Post commit (if applicable)
- [ ] Model regression CI testing passes (if applicable)
- [ ] New/Existing tests provide coverage for changes
