### PR TITLE
#11314: reduce eth dispatch scratch db size to account for erisc barrier

### DIFF
--- a/tt_metal/impl/dispatch/command_queue_interface.hpp
+++ b/tt_metal/impl/dispatch/command_queue_interface.hpp
@@ -101,7 +101,7 @@ struct dispatch_constants {
             prefetch_q_entries_ = 128;
             max_prefetch_command_size_ = 32 * 1024;
             cmddat_q_size_ = 64 * 1024;
-            scratch_db_size_ = 20 * 1024;
+            scratch_db_size_ = 20 * 1024 - 128; // ETH_BARRIER reserves 32 bytes at the top of ETH L1, remove by 2xBH alignment
             dispatch_buffer_block_size = 128 * 1024;
             prefetch_d_buffer_size_ = 128 * 1024;
         }


### PR DESCRIPTION
### Ticket
[Link to Github Issue](https://github.com/tenstorrent/tt-metal/issues/11314)
### Problem description
Eth dispatch hitting assert.

### What's changed
reduce scratch db buffer size by 32

### Checklist
- [ ] Post commit CI passes
- [ ] Blackhole Post commit (if applicable)
- [ ] Model regression CI testing passes (if applicable)
- [ ] New/Existing tests provide coverage for changes
