### PR TITLE
Update Synchronize api to barrier for missing transactions

### DIFF
--- a/docs/source/tt-metalium/tt_metal/apis/host_apis/command_queue/Synchronize.rst
+++ b/docs/source/tt-metalium/tt_metal/apis/host_apis/command_queue/Synchronize.rst
@@ -1,0 +1,6 @@
+.. _tt::tt_metal::Synchronize:
+
+Synchronize
+===========
+
+.. doxygenfunction:: Synchronize

--- a/docs/source/tt-metalium/tt_metal/apis/host_apis/command_queue/command_queue.rst
+++ b/docs/source/tt-metalium/tt_metal/apis/host_apis/command_queue/command_queue.rst
@@ -15,3 +15,4 @@ CommandQueue
   ReleaseTrace
   EnqueueTrace
   Finish
+  Synchronize

--- a/tests/ttnn/unit_tests/test_device_synchronize.py
+++ b/tests/ttnn/unit_tests/test_device_synchronize.py
@@ -1,0 +1,63 @@
+# SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
+
+# SPDX-License-Identifier: Apache-2.0
+
+import os
+import pytest
+import torch
+
+import ttnn
+from models.utility_functions import is_wormhole_b0
+
+
+def is_eth_dispatch():
+    return os.environ.get("WH_ARCH_YAML") == "wormhole_b0_80_arch_eth_dispatch.yaml"
+
+
+@pytest.mark.skipif(is_wormhole_b0() and not is_eth_dispatch(), reason="Requires eth dispatch to run on WH")
+@pytest.mark.parametrize("device_params", [{"num_hw_cqs": 2}], indirect=True)
+def test_read_write_full_synchronize(device):
+    zeros = torch.zeros([1, 1, 65536, 2048]).bfloat16()
+    input = torch.randn([1, 1, 65536, 2048]).bfloat16()
+    host_tensor = ttnn.from_torch(input, ttnn.bfloat16)
+    dev_tensor0 = ttnn.from_torch(zeros, ttnn.bfloat16, device=device)
+    dev_tensor1 = ttnn.from_torch(zeros, ttnn.bfloat16, device=device)
+    ttnn.synchronize_device(device)
+    output0 = dev_tensor0.cpu(blocking=False)
+    output1 = dev_tensor1.cpu(blocking=False)
+    ttnn.synchronize_device(device)
+    output0 = ttnn.to_torch(output0)
+    output1 = ttnn.to_torch(output1)
+    eq = torch.equal(zeros, output0)
+    assert eq
+    eq = torch.equal(zeros, output1)
+    assert eq
+
+    ttnn.copy_host_to_device_tensor(host_tensor, dev_tensor0, 0)
+    ttnn.copy_host_to_device_tensor(host_tensor, dev_tensor1, 1)
+    ttnn.synchronize_device(device)
+    output0 = dev_tensor0.cpu(blocking=False)
+    output1 = dev_tensor1.cpu(blocking=False)
+    ttnn.synchronize_device(device)
+    output0 = ttnn.to_torch(output0)
+    output1 = ttnn.to_torch(output1)
+    eq = torch.equal(input, output0)
+    assert eq
+    eq = torch.equal(input, output1)
+    assert eq
+
+
+@pytest.mark.skipif(is_wormhole_b0() and not is_eth_dispatch(), reason="Requires eth dispatch to run on WH")
+@pytest.mark.parametrize("device_params", [{"num_hw_cqs": 2}], indirect=True)
+def test_read_write_cq_synchronize(device):
+    zeros = torch.zeros([1, 1, 65536, 2048]).bfloat16()
+    input = torch.randn([1, 1, 65536, 2048]).bfloat16()
+    host_tensor = ttnn.from_torch(input, ttnn.bfloat16)
+    dev_tensor = ttnn.from_torch(zeros, ttnn.bfloat16, device=device)
+    ttnn.copy_host_to_device_tensor(host_tensor, dev_tensor, 1)
+    ttnn.synchronize_device(device, 1)
+    output = dev_tensor.cpu(blocking=False)
+    ttnn.synchronize_device(device, 0)
+    output = ttnn.to_torch(output)
+    eq = torch.equal(input, output)
+    assert eq

--- a/tt_metal/detail/tt_metal.hpp
+++ b/tt_metal/detail/tt_metal.hpp
@@ -317,13 +317,6 @@ namespace tt::tt_metal{
             return true;
         }
 
-        inline void Synchronize(Device *device)
-        {
-            if (std::getenv("TT_METAL_SLOW_DISPATCH_MODE") == nullptr) {
-                Finish(device->command_queue());
-            }
-        }
-
         inline void SetLazyCommandQueueMode(bool lazy)
         {
             DispatchStateCheck(true);

--- a/tt_metal/host_api.hpp
+++ b/tt_metal/host_api.hpp
@@ -579,6 +579,19 @@ void EventSynchronize(std::shared_ptr<Event> event);
  */
 bool EventQuery(std::shared_ptr<Event> event);
 
+/**
+ * Synchronize the device with host by waiting for all operations to complete.
+ * If cq_id is provided then only the operations associated with that cq_id are waited for,
+ * otherwise operations for all command queues are waited on.
+ *
+ * Return value: void
+ *
+ * | Argument     | Description                                                            | Type                          | Valid Range                        | Required |
+ * |--------------|------------------------------------------------------------------------|-------------------------------|------------------------------------|----------|
+ * | device       | The device to synchronize.                                             | Device *                      |                                    | Yes      |
+ * | cq_id        | The specific command queue id to synchronize  .                        | uint8_t                       |                                    | No       |
+ */
+void Synchronize(Device *device, const std::optional<uint8_t> cq_id = std::nullopt);
 
 }  // namespace tt_metal
 

--- a/tt_metal/impl/dispatch/command_queue.cpp
+++ b/tt_metal/impl/dispatch/command_queue.cpp
@@ -1365,14 +1365,16 @@ EnqueueRecordEventCommand::EnqueueRecordEventCommand(
     SystemMemoryManager& manager,
     uint32_t event_id,
     uint32_t expected_num_workers_completed,
-    bool clear_count) :
+    bool clear_count,
+    bool write_barrier) :
     command_queue_id(command_queue_id),
     device(device),
     noc_index(noc_index),
     manager(manager),
     event_id(event_id),
     expected_num_workers_completed(expected_num_workers_completed),
-    clear_count(clear_count) {}
+    clear_count(clear_count),
+    write_barrier(write_barrier) {}
 
 void EnqueueRecordEventCommand::process() {
     std::vector<uint32_t> event_payload(dispatch_constants::EVENT_PADDED_SIZE / sizeof(uint32_t), 0);
@@ -1404,7 +1406,7 @@ void EnqueueRecordEventCommand::process() {
     HugepageDeviceCommand command_sequence(cmd_region, cmd_sequence_sizeB);
 
     command_sequence.add_dispatch_wait(
-        false, DISPATCH_MESSAGE_ADDR, this->expected_num_workers_completed, this->clear_count);
+        this->write_barrier, DISPATCH_MESSAGE_ADDR, this->expected_num_workers_completed, this->clear_count);
 
     CoreType core_type = dispatch_core_manager::instance().get_dispatch_core_type(this->device->id());
     uint16_t channel = tt::Cluster::instance().get_assigned_channel_for_device(this->device->id());
@@ -2101,7 +2103,8 @@ void HWCommandQueue::enqueue_record_event(std::shared_ptr<Event> event, bool cle
         this->manager,
         event->event_id,
         this->expected_num_workers_completed,
-        clear_count);
+        clear_count,
+        true);
     this->enqueue_command(command, false);
 
     if (clear_count) {

--- a/tt_metal/impl/dispatch/command_queue.hpp
+++ b/tt_metal/impl/dispatch/command_queue.hpp
@@ -335,6 +335,7 @@ class EnqueueRecordEventCommand : public Command {
     uint32_t event_id;
     uint32_t expected_num_workers_completed;
     bool clear_count;
+    bool write_barrier;
 
    public:
     EnqueueRecordEventCommand(
@@ -344,7 +345,8 @@ class EnqueueRecordEventCommand : public Command {
         SystemMemoryManager& manager,
         uint32_t event_id,
         uint32_t expected_num_workers_completed,
-        bool clear_count = false);
+        bool clear_count = false,
+        bool write_barrier = true);
 
     void process();
 

--- a/ttnn/ttnn/device.py
+++ b/ttnn/ttnn/device.py
@@ -4,6 +4,7 @@
 
 import contextlib
 import os
+from typing import Optional
 
 import ttnn
 from ttnn._ttnn.deprecated.device import Arch
@@ -52,13 +53,15 @@ def disable_and_clear_program_cache(device):
     ttnn._ttnn.device.disable_and_clear_program_cache(device)
 
 
-def synchronize_device(device):
+def synchronize_device(device: "ttnn.Device", queue_id: Optional[int] = None) -> None:
     """
-    synchronize_device(device: ttnn.Device) -> None:
+    synchronize_device(device: ttnn.Device, queue_id: Optional[int] = None) -> None:
 
     Synchronize the device with host by waiting for all operations to complete.
+    If queue_id is provided then only the operations associated with that queue_id are waited for,
+    otherwise operations for all command queues are waited on.
     """
-    ttnn._ttnn.deprecated.device.Synchronize(device)
+    ttnn._ttnn.deprecated.device.Synchronize(device, queue_id)
 
 
 @contextlib.contextmanager

--- a/ttnn/ttnn/multi_device.py
+++ b/ttnn/ttnn/multi_device.py
@@ -4,7 +4,7 @@
 
 import contextlib
 
-from typing import List, Dict, Optional, Callable, Tuple, Optional, Callable
+from typing import List, Dict, Optional, Callable, Tuple, Optional, Callable, Union
 
 import ttnn
 
@@ -188,17 +188,19 @@ def create_device_mesh(
         close_device_mesh(device_mesh)
 
 
-def synchronize_devices(devices):
+def synchronize_devices(devices: Union["ttnn.Device", "ttnn.DeviceMesh"], queue_id: Optional[int] = None) -> None:
     """
-    synchronize_device(device: ttnn.Device) -> None:
+    synchronize_devices(devices: Union[ttnn.Device, ttnn.DeviceMesh], queue_id: Optional[int] = None) -> None:
 
-    Synchronize the device with host by waiting for all operations to complete.
+    Synchronize the devices with host by waiting for all operations to complete.
+    If queue_id is provided then only the operations associated with that queue_id are waited for,
+    otherwise operations for all command queues are waited on.
     """
     if isinstance(devices, ttnn.Device):
-        ttnn._ttnn.deprecated.device.Synchronize(devices)
+        ttnn._ttnn.deprecated.device.Synchronize(devices, queue_id)
     else:
         for device in devices.get_device_ids():
-            ttnn._ttnn.deprecated.device.Synchronize(devices.get_device(device))
+            ttnn._ttnn.deprecated.device.Synchronize(devices.get_device(device), queue_id)
 
 
 class TensorToMesh:


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/11303

### Problem description
Synchronize call was only syncing for CQ 0, and not CQ 1 if running with multi cq.
Record event only waits for programs to complete, and not outstanding write transactions.

### What's changed
Update Synchronize api to sync for all cqs by default, and support targetting specific cqs.
Update record event to also issue a noc write barrier.

### Checklist
- [x] Post commit CI passes
- [x] Blackhole Post commit (if applicable)
- [x] Model regression CI testing passes (if applicable)
- [x] New/Existing tests provide coverage for changes
