### PR TITLE
#10543: exposed methods of device operations to C++ and python registered primitive operations

### DIFF
--- a/tests/ttnn/unit_tests/operations/test_add.py
+++ b/tests/ttnn/unit_tests/operations/test_add.py
@@ -264,3 +264,7 @@ def test_prim_add(device, shape):
 
     assert_with_pcc(torch_output_tensor, output_tensor, 0.99988)
     assert output_tensor.shape == shape
+
+    assert shape == ttnn.prim.binary.compute_output_shapes(
+        input_tensor_a, input_tensor_b, ttnn.BinaryOpType.ADD, in_place=True
+    )

--- a/tests/ttnn/unit_tests/operations/test_examples.py
+++ b/tests/ttnn/unit_tests/operations/test_examples.py
@@ -28,6 +28,22 @@ def test_example(device, height, width):
 
 @pytest.mark.parametrize("height", [64])
 @pytest.mark.parametrize("width", [128])
+def test_example_compute_output_shapes(height, width):
+    input_tensor = ttnn.zeros((height, width), layout=ttnn.TILE_LAYOUT)
+    output_shape = ttnn.prim.example.compute_output_shapes(input_tensor)
+    assert output_shape == input_tensor.shape
+
+
+@pytest.mark.parametrize("height", [64])
+@pytest.mark.parametrize("width", [128])
+def test_example_create_output_tensors(device, height, width):
+    input_tensor = ttnn.zeros((height, width), layout=ttnn.TILE_LAYOUT, device=device)
+    output_tensor = ttnn.prim.example.create_output_tensors(input_tensor)
+    assert output_tensor.shape == input_tensor.shape
+
+
+@pytest.mark.parametrize("height", [64])
+@pytest.mark.parametrize("width", [128])
 def test_composite_example(device, height, width):
     torch.manual_seed(0)
 

--- a/ttnn/cpp/ttnn/decorators.hpp
+++ b/ttnn/cpp/ttnn/decorators.hpp
@@ -9,6 +9,8 @@
 #include "tt_metal/third_party/tracy/public/tracy/Tracy.hpp"
 #include "ttnn/core.hpp"
 #include "ttnn/operation.hpp"
+#include "ttnn/operation.hpp"
+#include "ttnn/device_operation.hpp"
 #include "ttnn/run_operation.hpp"
 #include "ttnn/tensor/tensor.hpp"
 #include "ttnn/common/constants.hpp"
@@ -300,6 +302,42 @@ struct registered_operation_t {
         auto output = invoke(std::forward<args_t>(args)...);
         tt::log_debug(tt::LogOp, "Finished  C++ ttnn operation: {}", std::string_view{cpp_fully_qualified_name});
         return output;
+    }
+
+    // Methods for querying properties of the primitive operation
+    template <typename... args_t>
+    requires(PrimitiveOperationConcept<operation_t>)
+    auto select_program_factory(args_t&&... args) const {
+        auto [operation_attributes, tensors_args] = operation_t::operator()(std::forward<decltype(args)>(args)...);
+        return operation_t::select_program_factory(operation_attributes, tensors_args);
+    }
+
+    template <typename... args_t>
+    requires(PrimitiveOperationConcept<operation_t>)
+    void validate_on_program_cache_miss(args_t&&... args) const {
+        auto [operation_attributes, tensors_args] = operation_t::operator()(std::forward<decltype(args)>(args)...);
+        operation_t::validate_on_program_cache_miss(operation_attributes, tensors_args);
+    }
+
+    template <typename... args_t>
+    requires(PrimitiveOperationConcept<operation_t>)
+    void validate_on_program_cache_hit(args_t&&... args) const {
+        auto [operation_attributes, tensors_args] = operation_t::operator()(std::forward<decltype(args)>(args)...);
+        operation_t::validate_on_program_cache_hit(operation_attributes, tensors_args);
+    }
+
+    template <typename... args_t>
+    requires(PrimitiveOperationConcept<operation_t>)
+    auto compute_output_shapes(args_t&&... args) const {
+        auto [operation_attributes, tensors_args] = operation_t::operator()(std::forward<decltype(args)>(args)...);
+        return operation_t::compute_output_shapes(operation_attributes, tensors_args);
+    }
+
+    template <typename... args_t>
+    requires(PrimitiveOperationConcept<operation_t>)
+    auto create_output_tensors(args_t&&... args) const {
+        auto [operation_attributes, tensors_args] = operation_t::operator()(std::forward<decltype(args)>(args)...);
+        return operation_t::create_output_tensors(operation_attributes, tensors_args);
     }
 
 };


### PR DESCRIPTION
### Ticket
n/a

### Problem description
There are potential use cases for accessing methods such as `compute_output_shapes`, `create_output_tensors`, etc of device operations by the compilers

### What's changed
- Added methods to the C++ registered_operation_t
- Auto-pybind them using `bind_registered_operation`
- Attach them to python `FastOperation` and `Operation` objects