### PR TITLE
#11333: Resolve hang with Trace and R-Chip Event Synchronization

### DIFF
--- a/tests/scripts/t3000/run_t3000_unit_tests.sh
+++ b/tests/scripts/t3000/run_t3000_unit_tests.sh
@@ -34,7 +34,6 @@ run_t3000_ttnn_tests() {
   echo "LOG_METAL: Running run_t3000_ttnn_tests"
   WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml ./build/test/ttnn/test_multi_device
   WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml ./build/test/ttnn/unit_tests_ttnn
-  pytest -n auto tests/ttnn/unit_tests/test_multi_device_trace.py ; fail+=$?
   WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml pytest tests/ttnn/unit_tests/test_multi_device_trace.py ; fail+=$?
   pytest -n auto tests/ttnn/unit_tests/test_multi_device.py ; fail+=$?
   pytest -n auto tests/ttnn/unit_tests/test_multi_device_async.py ; fail+=$?

--- a/tests/ttnn/unit_tests/test_multi_device_trace.py
+++ b/tests/ttnn/unit_tests/test_multi_device_trace.py
@@ -6,13 +6,40 @@ import torch
 import typing
 import pytest
 import ttnn
+import tt_lib
 import tempfile
 from loguru import logger
 import os
 from tests.ttnn.utils_for_testing import assert_with_pcc
 from ttnn import ShardTensorToMesh, ReplicateTensorToMesh, ConcatMeshToTensor, ListMeshToTensor
 
-NUM_TRACE_LOOPS = int(os.getenv("NUM_TRACE_LOOPS", 7))
+NUM_TRACE_LOOPS = int(os.getenv("NUM_TRACE_LOOPS", 15))
+
+
+def create_event(device):
+    event = []
+    if isinstance(device, ttnn.Device):
+        return tt_lib.device.CreateEvent()
+    else:
+        for dev in device.get_device_ids():
+            event.append(tt_lib.device.CreateEvent())
+    return event
+
+
+def wait_for_event(device, cq_id, event):
+    if isinstance(device, ttnn.Device):
+        tt_lib.device.WaitForEvent(device, cq_id, event)
+    else:
+        for dev, eve in zip(device.get_device_ids(), event):
+            tt_lib.device.WaitForEvent(device.get_device(dev), cq_id, eve)
+
+
+def record_event(device, cq_id, event):
+    if isinstance(device, ttnn.Device):
+        tt_lib.device.RecordEvent(device, cq_id, event)
+    else:
+        for dev, eve in zip(device.get_device_ids(), event):
+            tt_lib.device.RecordEvent(device.get_device(dev), cq_id, eve)
 
 
 @pytest.mark.parametrize(
@@ -20,8 +47,9 @@ NUM_TRACE_LOOPS = int(os.getenv("NUM_TRACE_LOOPS", 7))
 )
 @pytest.mark.parametrize("use_all_gather", [True, False])
 @pytest.mark.parametrize("enable_async", [True])
-@pytest.mark.parametrize("device_params", [{"trace_region_size": 60000}], indirect=True)
-def test_multi_device_single_trace(t3k_device_mesh, shape, use_all_gather, enable_async):
+@pytest.mark.parametrize("enable_multi_cq", [True, False])
+@pytest.mark.parametrize("device_params", [{"trace_region_size": 60000, "num_command_queues": 2}], indirect=True)
+def test_multi_device_single_trace(t3k_device_mesh, shape, use_all_gather, enable_async, enable_multi_cq):
     if t3k_device_mesh.get_num_devices() <= 1:
         pytest.skip("This test requires multiple devices")
 
@@ -41,18 +69,34 @@ def test_multi_device_single_trace(t3k_device_mesh, shape, use_all_gather, enabl
             return ttnn.all_gather(single_dev_output, dim=0, num_links=1)
         return single_dev_output
 
+    if enable_multi_cq:
+        trace_cq = 0
+        data_movement_cq = 1
+
+        def event_sync(event, record_cq, wait_cq):
+            record_event(t3k_device_mesh, record_cq, event)
+            wait_for_event(t3k_device_mesh, wait_cq, event)
+
+    else:
+        trace_cq = 0
+        data_movement_cq = 0
+
+        def event_sync(event, record_cq, wait_cq):
+            pass
+
     # Compile program binaries
     run_op_chain(input_0_dev, input_1_dev)
 
     # Capture Trace
     logger.info("Capture Trace")
 
-    tid = ttnn.begin_trace_capture(t3k_device_mesh, cq_id=0)
+    tid = ttnn.begin_trace_capture(t3k_device_mesh, cq_id=trace_cq)
     output_tensor = run_op_chain(input_0_dev, input_1_dev)
-    ttnn.end_trace_capture(t3k_device_mesh, tid, cq_id=0)
+    ttnn.end_trace_capture(t3k_device_mesh, tid, cq_id=trace_cq)
     logger.info("Done Trace Capture")
 
     for i in range(NUM_TRACE_LOOPS):
+        write_event = create_event(t3k_device_mesh)
         # Create torch inputs
         torch_input_tensor_0 = torch.rand(
             (t3k_device_mesh.get_num_devices(), shape[1], shape[2], shape[3]), dtype=torch.bfloat16
@@ -77,15 +121,15 @@ def test_multi_device_single_trace(t3k_device_mesh, shape, use_all_gather, enabl
 
         # Copy TTNN host tensors into preallocated Mult-Device tensors
         logger.info("Send Inputs to Device")
-        ttnn.copy_host_to_device_tensor(ttnn_input_tensor_0, input_0_dev)
-        ttnn.copy_host_to_device_tensor(ttnn_input_tensor_1, input_1_dev)
+        ttnn.copy_host_to_device_tensor(ttnn_input_tensor_0, input_0_dev, cq_id=data_movement_cq)
+        ttnn.copy_host_to_device_tensor(ttnn_input_tensor_1, input_1_dev, cq_id=data_movement_cq)
+        event_sync(write_event, data_movement_cq, trace_cq)
         logger.info("Execute Trace")
         # Execute trace
-        ttnn.execute_trace(t3k_device_mesh, tid, cq_id=0, blocking=False)
-
+        ttnn.execute_trace(t3k_device_mesh, tid, cq_id=trace_cq, blocking=False)
         if use_all_gather:
             # Device All-Gather: Iterate through tensors on all devices. Ensure they match the full tensor
-            logger.info("Read Back Trace Outputs")
+            logger.info("Read Back Trace Outputs with All Gather")
             device_tensors: typing.List[ttnn.Tensor] = ttnn.get_device_tensors(output_tensor)
             for device_tensor in device_tensors:
                 device_tensor_torch = ttnn.to_torch(device_tensor)
@@ -95,7 +139,9 @@ def test_multi_device_single_trace(t3k_device_mesh, shape, use_all_gather, enabl
             # Perform host All-Gather
             logger.info("Read Back Trace Outputs")
             ttnn_torch_output_tensor = ttnn.to_torch(
-                output_tensor, mesh_composer=ConcatMeshToTensor(t3k_device_mesh, dim=0), device=t3k_device_mesh
+                output_tensor,
+                mesh_composer=ConcatMeshToTensor(t3k_device_mesh, dim=0),
+                device=t3k_device_mesh,
             )
             assert_with_pcc(ttnn_torch_output_tensor, torch_output_golden, pcc=0.96)
 
@@ -112,8 +158,9 @@ def test_multi_device_single_trace(t3k_device_mesh, shape, use_all_gather, enabl
 )
 @pytest.mark.parametrize("use_all_gather", [True, False])
 @pytest.mark.parametrize("enable_async", [True])
-@pytest.mark.parametrize("device_params", [{"trace_region_size": 200000}], indirect=True)
-def test_multi_device_multi_trace(t3k_device_mesh, shape, use_all_gather, enable_async):
+@pytest.mark.parametrize("enable_multi_cq", [True, False])
+@pytest.mark.parametrize("device_params", [{"trace_region_size": 200000, "num_command_queues": 2}], indirect=True)
+def test_multi_device_multi_trace(t3k_device_mesh, shape, use_all_gather, enable_async, enable_multi_cq):
     torch.manual_seed(0)
     if t3k_device_mesh.get_num_devices() <= 1:
         pytest.skip("This test requires multiple devices")
@@ -149,6 +196,21 @@ def test_multi_device_multi_trace(t3k_device_mesh, shape, use_all_gather, enable
             return ttnn.all_gather(single_dev_output, dim=0, num_links=1)
         return single_dev_output
 
+    if enable_multi_cq:
+        trace_cq = 0
+        data_movement_cq = 1
+
+        def event_sync(event, record_cq, wait_cq):
+            record_event(t3k_device_mesh, record_cq, event)
+            wait_for_event(t3k_device_mesh, wait_cq, event)
+
+    else:
+        trace_cq = 0
+        data_movement_cq = 0
+
+        def event_sync(event, record_cq, wait_cq):
+            pass
+
     # Compile program binaries
     run_op_chain(input_0_dev, input_1_dev, weight_dev)
     run_op_chain_1(input_0_dev, input_1_dev, weight_dev)
@@ -156,21 +218,21 @@ def test_multi_device_multi_trace(t3k_device_mesh, shape, use_all_gather, enable
 
     # Capture Trace 0
     logger.info("Capture Trace 0")
-    tid = ttnn.begin_trace_capture(t3k_device_mesh, cq_id=0)
+    tid = ttnn.begin_trace_capture(t3k_device_mesh, cq_id=trace_cq)
     output_tensor = run_op_chain(input_0_dev, input_1_dev, weight_dev)
-    ttnn.end_trace_capture(t3k_device_mesh, tid, cq_id=0)
+    ttnn.end_trace_capture(t3k_device_mesh, tid, cq_id=trace_cq)
 
     # Capture Trace 1
     logger.info("Capture Trace 1")
-    tid_1 = ttnn.begin_trace_capture(t3k_device_mesh, cq_id=0)
+    tid_1 = ttnn.begin_trace_capture(t3k_device_mesh, cq_id=trace_cq)
     output_tensor_1 = run_op_chain_1(input_0_dev, input_1_dev, weight_dev)
-    ttnn.end_trace_capture(t3k_device_mesh, tid_1, cq_id=0)
+    ttnn.end_trace_capture(t3k_device_mesh, tid_1, cq_id=trace_cq)
 
     # Capture Trace 1
     logger.info("Capture Trace 2")
-    tid_2 = ttnn.begin_trace_capture(t3k_device_mesh, cq_id=0)
+    tid_2 = ttnn.begin_trace_capture(t3k_device_mesh, cq_id=trace_cq)
     output_tensor_2 = run_op_chain_2(input_0_dev, input_1_dev, weight_dev)
-    ttnn.end_trace_capture(t3k_device_mesh, tid_2, cq_id=0)
+    ttnn.end_trace_capture(t3k_device_mesh, tid_2, cq_id=trace_cq)
 
     # Execute and verify trace against pytorch
     torch_silu = torch.nn.SiLU()
@@ -181,6 +243,7 @@ def test_multi_device_multi_trace(t3k_device_mesh, shape, use_all_gather, enable
         num_trace_loops = 5
 
     for i in range(num_trace_loops):
+        write_event = create_event(t3k_device_mesh)
         # Create torch inputs
         torch_input_tensor_0 = torch.rand(
             (t3k_device_mesh.get_num_devices(), shape[1], shape[2], shape[3]), dtype=torch.bfloat16
@@ -218,17 +281,17 @@ def test_multi_device_multi_trace(t3k_device_mesh, shape, use_all_gather, enable
 
         # Copy TTNN host tensors into preallocated Mult-Device tensors
         logger.info("Send Inputs to Device")
-        ttnn.copy_host_to_device_tensor(ttnn_input_tensor_0, input_0_dev)
-        ttnn.copy_host_to_device_tensor(ttnn_input_tensor_1, input_1_dev)
-        ttnn.copy_host_to_device_tensor(ttnn_weight, weight_dev)
-
+        ttnn.copy_host_to_device_tensor(ttnn_input_tensor_0, input_0_dev, cq_id=data_movement_cq)
+        ttnn.copy_host_to_device_tensor(ttnn_input_tensor_1, input_1_dev, cq_id=data_movement_cq)
+        ttnn.copy_host_to_device_tensor(ttnn_weight, weight_dev, cq_id=data_movement_cq)
+        event_sync(write_event, data_movement_cq, trace_cq)
         # Execute trace
         logger.info("Execute Trace 0")
-        ttnn.execute_trace(t3k_device_mesh, tid, cq_id=0, blocking=False)
+        ttnn.execute_trace(t3k_device_mesh, tid, cq_id=trace_cq, blocking=False)
         logger.info("Execute Trace 1")
-        ttnn.execute_trace(t3k_device_mesh, tid_1, cq_id=0, blocking=False)
+        ttnn.execute_trace(t3k_device_mesh, tid_1, cq_id=trace_cq, blocking=False)
         logger.info("Execute Trace 2")
-        ttnn.execute_trace(t3k_device_mesh, tid_2, cq_id=0, blocking=False)
+        ttnn.execute_trace(t3k_device_mesh, tid_2, cq_id=trace_cq, blocking=False)
         if use_all_gather:
             # Device All-Gather: Iterate through tensors on all devices. Ensure they match the full tensor
             logger.info("Read Back Trace 0 Outputs")
@@ -252,19 +315,25 @@ def test_multi_device_multi_trace(t3k_device_mesh, shape, use_all_gather, enable
             # Perform host All-Gather
             logger.info("Read Back Trace 0 Outputs")
             ttnn_torch_output_tensor = ttnn.to_torch(
-                output_tensor, mesh_composer=ConcatMeshToTensor(t3k_device_mesh, dim=0), device=t3k_device_mesh
+                output_tensor,
+                mesh_composer=ConcatMeshToTensor(t3k_device_mesh, dim=0),
+                device=t3k_device_mesh,
             )
             assert_with_pcc(ttnn_torch_output_tensor, torch_output_golden, pcc=0.96)
 
             logger.info("Read Back Trace 1 Outputs")
             ttnn_torch_output_tensor = ttnn.to_torch(
-                output_tensor_1, mesh_composer=ConcatMeshToTensor(t3k_device_mesh, dim=0), device=t3k_device_mesh
+                output_tensor_1,
+                mesh_composer=ConcatMeshToTensor(t3k_device_mesh, dim=0),
+                device=t3k_device_mesh,
             )
             assert_with_pcc(ttnn_torch_output_tensor, torch_output_golden_1, pcc=0.96)
 
             logger.info("Read Back Trace 1 Outputs")
             ttnn_torch_output_tensor = ttnn.to_torch(
-                output_tensor_2, mesh_composer=ConcatMeshToTensor(t3k_device_mesh, dim=0), device=t3k_device_mesh
+                output_tensor_2,
+                mesh_composer=ConcatMeshToTensor(t3k_device_mesh, dim=0),
+                device=t3k_device_mesh,
             )
             assert_with_pcc(ttnn_torch_output_tensor, torch_output_golden_2, pcc=0.96)
 

--- a/tt_metal/impl/dispatch/kernels/cq_prefetch.cpp
+++ b/tt_metal/impl/dispatch/kernels/cq_prefetch.cpp
@@ -1161,6 +1161,10 @@ bool process_cmd(uint32_t& cmd_ptr,
         stride = process_debug_cmd(cmd_ptr);
         break;
 
+    case CQ_PREFETCH_CMD_WAIT_FOR_EVENT:
+        stride = CQ_PREFETCH_CMD_BARE_MIN_SIZE;
+        break;
+
     case CQ_PREFETCH_CMD_TERMINATE:
         //DPRINT << "prefetch terminating_" << is_h_variant << is_d_variant << ENDL();;
         ASSERT(!exec_buf);
@@ -1301,13 +1305,10 @@ void kernel_main_h() {
             // prefetch_h will stop execution until it recieves an event update from the
             // dispatch_d core assigned to the other CQ
             uint32_t stride = process_prefetch_h_wait_cmd(cmd_ptr);
-            cmd_ptr += stride;
         }
-        else {
-            // Infer that an exec_buf command is to be executed based on the stall state.
-            bool is_exec_buf = (stall_state == STALLED);
-            cmd_ptr = process_relay_inline_all(cmd_ptr, fence, is_exec_buf);
-        }
+        // Infer that an exec_buf command is to be executed based on the stall state.
+        bool is_exec_buf = (stall_state == STALLED);
+        cmd_ptr = process_relay_inline_all(cmd_ptr, fence, is_exec_buf);
 
         // Note: one fetch_q entry can contain multiple commands
         // The code below assumes these commands arrive individually, packing them would require parsing all cmds


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/11333

### Problem description
  - Issuing a prefetch_h wait_for_event followed by a Trace command was causing data corruption on the remote chip
  - This was due to the Prefetcher coalescing the Trace cmd stream with the wait command. The wait command (along with its packet header) was being locally processed by prefetch_h, while the Trace cmd was sent to Mux without a header -> cmd stream was corrupted by Mux

### What's changed
  - The wait command is now locally processed by prefetch_h and sent to Mux, since it contains the header when commands are coalesced. Prefetch_d will process the wait as no-op
  - This can be made simpler once we have VCs on the packet network
### Checklist
- [x] Post commit CI passes
- [ ] Blackhole Post commit (if applicable)
- [ ] Model regression CI testing passes (if applicable)
- [x] New/Existing tests provide coverage for changes
