### PR TITLE
#0: remove decorate_as_composite

### DIFF
--- a/ttnn/cpp/ttnn/operations/data_movement/fold/fold.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/fold/fold.cpp
@@ -106,7 +106,7 @@ Tensor fold(uint8_t queue_id,
             uint8_t pad_h,
             uint8_t pad_w) {
     if (use_transpose_as_fold) {
-        return operation::decorate_as_composite(__func__, fold_with_transpose_)(input_tensor, output_shape, stride_h, stride_w, pad_c, pad_h, pad_w, queue_id).at(0);
+        return fold_with_transpose_(input_tensor, output_shape, stride_h, stride_w, pad_c, pad_h, pad_w, queue_id).at(0);
     }
     bool is_sharded = input_tensor.is_sharded();
     Fold::operation_attributes_t op_attr = {.stride_h = stride_h, .stride_w = stride_w, .is_sharded = is_sharded};

--- a/ttnn/cpp/ttnn/operations/data_movement/permute/permute.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/permute/permute.cpp
@@ -129,7 +129,7 @@ ttnn::Tensor permute_launch(const ttnn::Tensor &a, const std::vector<std::int64_
             if (normalized_dims == seq_dims) {
                 return {AutoFormat::move_tensor_to_mem_config(a, output_mem_config)};
             }
-            return {operation::decorate_as_composite(__func__, permute_impl)(a, normalized_dims, output_mem_config)};
+            return {permute_impl(a, normalized_dims, output_mem_config)};
         }, {a}, output_tensors);
     return output_tensors.at(0);
 }

--- a/ttnn/cpp/ttnn/run_operation.hpp
+++ b/ttnn/cpp/ttnn/run_operation.hpp
@@ -41,11 +41,6 @@ auto generic_create_output_tensors(
     return output_tensors;
 }
 
-// TODO: delete all uses of decorate_as_composite
-constexpr auto decorate_as_composite(const char* name, auto function) {
-    return function;
-}
-
 #ifdef DEBUG
 namespace detail {
 


### PR DESCRIPTION
### Ticket
n/a

### Problem description
`decorate_as_composite` was deprecated

### What's changed
- Deleted all its uses and removed it

### Checklist
- [ ] Post commit CI passes
- [ ] Blackhole Post commit (if applicable)
- [ ] Model regression CI testing passes (if applicable)
- [ ] New/Existing tests provide coverage for changes
