### PR TITLE
Ngrujic/transpose opt

### DIFF
--- a/tests/ttnn/profiling/ops_for_profiling.py
+++ b/tests/ttnn/profiling/ops_for_profiling.py
@@ -1202,8 +1202,28 @@ def reshape(x):
     ttnn.reshape(x, [shape[-4], shape[-3], shape[-1], shape[-2]])
 
 
-def transpose(x):
-    ttnn.transpose(x, dim0=2, dim1=3)
+def transpose_01(x):
+    ttnn.transpose(x, 0, 1)
+
+
+def transpose_02(x):
+    ttnn.transpose(x, 0, 2)
+
+
+def transpose_03(x):
+    ttnn.transpose(x, 0, 3)
+
+
+def transpose_12(x):
+    ttnn.transpose(x, 1, 2)
+
+
+def transpose_13(x):
+    ttnn.transpose(x, 1, 3)
+
+
+def transpose_23(x):
+    ttnn.transpose(x, 2, 3)
 
 
 def permute(x):
@@ -1857,8 +1877,28 @@ all_unary_ops = [
         "name": "ttnn.reshape",
     },
     {
-        "op": transpose,
-        "name": "ttnn.transpose",
+        "op": transpose_01,
+        "name": "ttnn.transpose_01",
+    },
+    {
+        "op": transpose_02,
+        "name": "ttnn.transpose_02",
+    },
+    {
+        "op": transpose_03,
+        "name": "ttnn.transpose_03",
+    },
+    {
+        "op": transpose_12,
+        "name": "ttnn.transpose_12",
+    },
+    {
+        "op": transpose_13,
+        "name": "ttnn.transpose_13",
+    },
+    {
+        "op": transpose_23,
+        "name": "ttnn.transpose_23",
     },
     {
         "op": permute,

--- a/tests/ttnn/python_api_testing/sweep_tests/op_map.py
+++ b/tests/ttnn/python_api_testing/sweep_tests/op_map.py
@@ -2,6 +2,7 @@
 
 # SPDX-License-Identifier: Apache-2.0
 
+from functools import partial
 from tests.tt_eager.python_api_testing.sweep_tests import pytorch_ops
 from tests.ttnn.python_api_testing.sweep_tests import ttnn_pytorch_ops
 from tests.ttnn.python_api_testing.sweep_tests import ttnn_ops
@@ -367,6 +368,30 @@ op_map = {
     "ttnn-reshape": {
         "tt_op": ttnn_ops.reshape,
         "pytorch_op": pytorch_ops.reshape,
+    },
+    "ttnn-transpose_01": {
+        "tt_op": ttnn_ops.transpose_01,
+        "pytorch_op": partial(pytorch_ops.transpose, dim0=0, dim1=1),
+    },
+    "ttnn-transpose_02": {
+        "tt_op": ttnn_ops.transpose_02,
+        "pytorch_op": partial(pytorch_ops.transpose, dim0=0, dim1=2),
+    },
+    "ttnn-transpose_03": {
+        "tt_op": ttnn_ops.transpose_03,
+        "pytorch_op": partial(pytorch_ops.transpose, dim0=0, dim1=3),
+    },
+    "ttnn-transpose_12": {
+        "tt_op": ttnn_ops.transpose_12,
+        "pytorch_op": partial(pytorch_ops.transpose, dim0=1, dim1=2),
+    },
+    "ttnn-transpose_13": {
+        "tt_op": ttnn_ops.transpose_13,
+        "pytorch_op": partial(pytorch_ops.transpose, dim0=0, dim1=3),
+    },
+    "ttnn-transpose_23": {
+        "tt_op": ttnn_ops.transpose_23,
+        "pytorch_op": partial(pytorch_ops.transpose, dim0=2, dim1=3),
     },
     "ttnn-gelu": {
         "tt_op": ttnn_ops.gelu,

--- a/tests/ttnn/python_api_testing/sweep_tests/test_configs/ci_sweep_tests_working/wormhole/ttnn_transpose_01_test.yaml
+++ b/tests/ttnn/python_api_testing/sweep_tests/test_configs/ci_sweep_tests_working/wormhole/ttnn_transpose_01_test.yaml
@@ -1,0 +1,54 @@
+---
+test-list:
+  - ttnn-transpose_01:
+      shape:
+        start-shape: [1, 1, 32, 32]
+        end-shape: [6, 12, 256, 256]
+        interval: [1, 1, 32, 32]
+        num-dims: [4]
+        num-shapes: 1
+        num-samples: 64
+        args-sampling-strategy: "all"
+      env:
+        # TT_PCI_DMA_BUF_SIZE: "1048576"
+      datagen:
+        function: gen_rand
+        args:
+          low: -100
+          high: 100
+      comparison:
+        function: comp_equal
+      args-gen: gen_dtype_layout_device
+      sanitize-args: False
+      args:
+        data-layout: ["TILE"]
+        data-type: ["BFLOAT16", "BFLOAT8_B"]
+        buffer-type: ["DRAM", "L1"]
+        out-buffer-type: ["DRAM", "L1", "SYSTEM_MEMORY"]
+      output-file: tranpose_01_sweep.csv
+  - ttnn-transpose_01:
+      shape:
+        start-shape: [1, 1, 2, 2]
+        end-shape: [6, 12, 256, 256]
+        interval: [1, 1, 1, 2]
+        num-dims: [2, 3, 4]
+        num-shapes: 1
+        num-samples: 64
+        args-sampling-strategy: "all"
+      env:
+        # TT_PCI_DMA_BUF_SIZE: "1048576"
+      datagen:
+        function: gen_rand
+        args:
+          low: -100
+          high: 100
+      comparison:
+        function: comp_equal
+      args-gen: gen_dtype_layout_device
+      sanitize-args: False
+      args:
+        data-layout: ["ROW_MAJOR"]
+        data-type: ["BFLOAT16"]
+        buffer-type: ["DRAM", "L1"]
+        out-buffer-type: ["DRAM", "L1"]
+      output-file: tranpose_01_sweep.csv

--- a/tests/ttnn/python_api_testing/sweep_tests/test_configs/ci_sweep_tests_working/wormhole/ttnn_transpose_02_test.yaml
+++ b/tests/ttnn/python_api_testing/sweep_tests/test_configs/ci_sweep_tests_working/wormhole/ttnn_transpose_02_test.yaml
@@ -1,10 +1,10 @@
 ---
 test-list:
-  - ttnn-transpose_01:
+  - ttnn-transpose_02:
       shape:
         start-shape: [1, 1, 32, 32]
         end-shape: [6, 12, 256, 256]
-        interval: [1, 1, 1, 1]
+        interval: [1, 1, 32, 32]
         num-dims: [4]
         num-shapes: 1
         num-samples: 1024
@@ -22,7 +22,7 @@ test-list:
       sanitize-args: False
       args:
         data-layout: ["TILE"]
-        data-type: ["BFLOAT16", "BFLOAT8_B"]
+        data-type: ["BFLOAT16"]
         buffer-type: ["DRAM", "L1"]
         out-buffer-type: ["DRAM", "L1", "SYSTEM_MEMORY"]
-      output-file: tranpose_01_sweep.csv
+      output-file: tranpose_02_sweep.csv

--- a/tests/ttnn/python_api_testing/sweep_tests/test_configs/ci_sweep_tests_working/wormhole/ttnn_transpose_12_test.yaml
+++ b/tests/ttnn/python_api_testing/sweep_tests/test_configs/ci_sweep_tests_working/wormhole/ttnn_transpose_12_test.yaml
@@ -1,10 +1,10 @@
 ---
 test-list:
-  - ttnn-transpose_01:
+  - ttnn-transpose_12:
       shape:
         start-shape: [1, 1, 32, 32]
         end-shape: [6, 12, 256, 256]
-        interval: [1, 1, 1, 1]
+        interval: [1, 1, 32, 32]
         num-dims: [4]
         num-shapes: 1
         num-samples: 1024
@@ -22,7 +22,7 @@ test-list:
       sanitize-args: False
       args:
         data-layout: ["TILE"]
-        data-type: ["BFLOAT16", "BFLOAT8_B"]
+        data-type: ["BFLOAT16"]
         buffer-type: ["DRAM", "L1"]
         out-buffer-type: ["DRAM", "L1", "SYSTEM_MEMORY"]
-      output-file: tranpose_01_sweep.csv
+      output-file: tranpose_12_sweep.csv

--- a/tests/ttnn/python_api_testing/sweep_tests/test_configs/ci_sweep_tests_working/wormhole/ttnn_transpose_13_test.yaml
+++ b/tests/ttnn/python_api_testing/sweep_tests/test_configs/ci_sweep_tests_working/wormhole/ttnn_transpose_13_test.yaml
@@ -1,10 +1,10 @@
 ---
 test-list:
-  - ttnn-transpose_01:
+  - ttnn-transpose_13:
       shape:
         start-shape: [1, 1, 32, 32]
         end-shape: [6, 12, 256, 256]
-        interval: [1, 1, 1, 1]
+        interval: [1, 1, 32, 32]
         num-dims: [4]
         num-shapes: 1
         num-samples: 1024
@@ -25,4 +25,4 @@ test-list:
         data-type: ["BFLOAT16", "BFLOAT8_B"]
         buffer-type: ["DRAM", "L1"]
         out-buffer-type: ["DRAM", "L1", "SYSTEM_MEMORY"]
-      output-file: tranpose_01_sweep.csv
+      output-file: tranpose_13_sweep.csv

--- a/tests/ttnn/python_api_testing/sweep_tests/test_configs/ci_sweep_tests_working/wormhole/ttnn_transpose_23_test.yaml
+++ b/tests/ttnn/python_api_testing/sweep_tests/test_configs/ci_sweep_tests_working/wormhole/ttnn_transpose_23_test.yaml
@@ -1,0 +1,54 @@
+---
+test-list:
+  - ttnn-transpose_23:
+      shape:
+        start-shape: [1, 1, 32, 32]
+        end-shape: [6, 12, 256, 256]
+        interval: [1, 1, 32, 32]
+        num-dims: [4]
+        num-shapes: 1
+        num-samples: 512
+        args-sampling-strategy: "all"
+      env:
+        # TT_PCI_DMA_BUF_SIZE: "1048576"
+      datagen:
+        function: gen_rand
+        args:
+          low: -100
+          high: 100
+      comparison:
+        function: comp_equal
+      args-gen: gen_dtype_layout_device
+      sanitize-args: False
+      args:
+        data-layout: ["TILE"]
+        data-type: ["BFLOAT16"]
+        buffer-type: ["DRAM", "L1"]
+        out-buffer-type: ["DRAM", "L1", "SYSTEM_MEMORY"]
+      output-file: tranpose_23_sweep.csv
+  - ttnn-transpose_23:
+      shape:
+        start-shape: [1, 1, 32, 32]
+        end-shape: [6, 12, 256, 256]
+        interval: [1, 1, 32, 32]
+        num-dims: [4]
+        num-shapes: 1
+        num-samples: 512
+        args-sampling-strategy: "all"
+      env:
+        # TT_PCI_DMA_BUF_SIZE: "1048576"
+      datagen:
+        function: gen_rand
+        args:
+          low: -100
+          high: 100
+      comparison:
+        function: comp_pcc
+      args-gen: gen_dtype_layout_device
+      sanitize-args: False
+      args:
+        data-layout: ["TILE"]
+        data-type: ["BFLOAT8_B"]
+        buffer-type: ["DRAM", "L1"]
+        out-buffer-type: ["DRAM", "L1", "SYSTEM_MEMORY"]
+      output-file: tranpose_23_sweep.csv

--- a/tests/ttnn/python_api_testing/sweep_tests/ttnn_ops.py
+++ b/tests/ttnn/python_api_testing/sweep_tests/ttnn_ops.py
@@ -869,6 +869,96 @@ def reshape(
     return ttnn_tensor_to_torch(t1)
 
 
+def transpose_01(
+    x,
+    *args,
+    device,
+    dtype,
+    layout,
+    input_mem_config,
+    output_mem_config,
+    **kwargs,
+):
+    t0 = setup_ttnn_tensor(x, device, layout[0], input_mem_config[0], dtype[0])
+    t1 = ttnn.transpose(t0, 0, 1)  # , memory_config=memory_config_to_ttnn(output_mem_config))
+    return ttnn_tensor_to_torch(t1)
+
+
+def transpose_02(
+    x,
+    *args,
+    device,
+    dtype,
+    layout,
+    input_mem_config,
+    output_mem_config,
+    **kwargs,
+):
+    t0 = setup_ttnn_tensor(x, device, layout[0], input_mem_config[0], dtype[0])
+    t1 = ttnn.transpose(t0, 0, 2)  # , memory_config=memory_config_to_ttnn(output_mem_config))
+    return ttnn_tensor_to_torch(t1)
+
+
+def transpose_03(
+    x,
+    *args,
+    device,
+    dtype,
+    layout,
+    input_mem_config,
+    output_mem_config,
+    **kwargs,
+):
+    t0 = setup_ttnn_tensor(x, device, layout[0], input_mem_config[0], dtype[0])
+    t1 = ttnn.transpose(t0, 0, 3)  # , memory_config=memory_config_to_ttnn(output_mem_config))
+    return ttnn_tensor_to_torch(t1)
+
+
+def transpose_12(
+    x,
+    *args,
+    device,
+    dtype,
+    layout,
+    input_mem_config,
+    output_mem_config,
+    **kwargs,
+):
+    t0 = setup_ttnn_tensor(x, device, layout[0], input_mem_config[0], dtype[0])
+    t1 = ttnn.transpose(t0, 1, 2)  # , memory_config=memory_config_to_ttnn(output_mem_config))
+    return ttnn_tensor_to_torch(t1)
+
+
+def transpose_13(
+    x,
+    *args,
+    device,
+    dtype,
+    layout,
+    input_mem_config,
+    output_mem_config,
+    **kwargs,
+):
+    t0 = setup_ttnn_tensor(x, device, layout[0], input_mem_config[0], dtype[0])
+    t1 = ttnn.transpose(t0, 1, 3)  # , memory_config=memory_config_to_ttnn(output_mem_config))
+    return ttnn_tensor_to_torch(t1)
+
+
+def transpose_23(
+    x,
+    *args,
+    device,
+    dtype,
+    layout,
+    input_mem_config,
+    output_mem_config,
+    **kwargs,
+):
+    t0 = setup_ttnn_tensor(x, device, layout[0], input_mem_config[0], dtype[0])
+    t1 = ttnn.transpose(t0, 2, 3)  # , memory_config=memory_config_to_ttnn(output_mem_config))
+    return ttnn_tensor_to_torch(t1)
+
+
 def gelu(
     x,
     *args,

--- a/ttnn/cpp/ttnn/operations/data_movement/transpose/device/transpose_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/transpose/device/transpose_program_factory.cpp
@@ -14,21 +14,21 @@ namespace ttnn::operations::data_movement::detail {
 
 using namespace tt::constants;
 
-// Each element of outer vector corresponds to a core
-// Each core has a pair of std::vector<uint32_t>
-// First of pair is reader args
-// Second of pair is writer args
-std::vector<std::pair<std::vector<uint32_t>, std::vector<uint32_t> > > get_runtime_args_mc_cn(const Tensor &input_tensor,
-                                                                                        Tensor &output_tensor,
-                                                                                        uint32_t num_cores_total,
-                                                                                        uint32_t num_cores,
-                                                                                        uint32_t num_cores_y,
-                                                                                        CoreRangeSet core_group_1,
-                                                                                        uint32_t num_tiles_per_core_group_1,
-                                                                                        CoreRangeSet core_group_2,
-                                                                                        uint32_t num_tiles_per_core_group_2
-                                                                                        ){
-
+template <bool IS_CREATING>
+void override_runtime_args_mc_cn(
+    const Program& program,
+    tt::tt_metal::KernelHandle reader_kernel_id,
+    tt::tt_metal::KernelHandle writer_kernel_id,
+    const Tensor &input_tensor,
+    Tensor &output_tensor,
+    uint32_t num_cores_total,
+    uint32_t num_cores,
+    uint32_t num_cores_y,
+    CoreRangeSet core_group_1,
+    uint32_t num_tiles_per_core_group_1,
+    CoreRangeSet core_group_2,
+    uint32_t num_tiles_per_core_group_2
+){
     auto input_buffer = input_tensor.buffer();
     auto output_buffer = output_tensor.buffer();
     auto input_shape = input_tensor.get_legacy_shape();
@@ -46,11 +46,13 @@ std::vector<std::pair<std::vector<uint32_t>, std::vector<uint32_t> > > get_runti
     uint32_t batch_step = CHtWt - HtWt;
     uint32_t channel_step = NCHtWt - HtWt;
 
-    std::vector<std::pair<std::vector<uint32_t>, std::vector<uint32_t> > > ret_val(num_cores_total);
+    auto& cached_reader_args = GetRuntimeArgs(program, reader_kernel_id);
+    auto& cached_writer_args = GetRuntimeArgs(program, writer_kernel_id);
 
-    for(uint32_t i = 0, num_tiles_read = 0; i < num_cores_total; i++) {
+    for (uint32_t i = 0, num_tiles_read = 0; i < num_cores_total; i++) {
         CoreCoord core = {i / num_cores_y, i % num_cores_y};
         uint32_t num_tiles_per_core;
+
         if (core_group_1.core_coord_in_core_ranges(core)) {
             num_tiles_per_core = num_tiles_per_core_group_1;
         } else if (core_group_2.core_coord_in_core_ranges(core)) {
@@ -59,36 +61,66 @@ std::vector<std::pair<std::vector<uint32_t>, std::vector<uint32_t> > > get_runti
             //no-op
             num_tiles_per_core = 0;
         }
+
         uint32_t hw = num_tiles_read % HtWt;
         uint32_t curr_c = num_tiles_read / HtWt;
         uint32_t n = curr_c % N;
         uint32_t start_tile = num_tiles_read + curr_c * batch_step - curr_c / N * channel_step;
 
-        std::vector<uint32_t> reader_runtime_args = {
-            input_buffer->address(),
-            N,
-            C,
-            HtWt,
-            batch_step,
-            channel_step,
-            num_tiles_per_core,
-            start_tile,
-            hw,
-            n
-        };
+        if constexpr (IS_CREATING) {
+            tt::tt_metal::SetRuntimeArgs(
+                program,
+                reader_kernel_id,
+                core,
+                {
+                    input_buffer->address(),
+                    N,
+                    C,
+                    HtWt,
+                    batch_step,
+                    channel_step,
+                    num_tiles_per_core,
+                    start_tile,
+                    hw,
+                    n
+                }
+            );
 
+            tt::tt_metal::SetRuntimeArgs(
+                program,
+                writer_kernel_id,
+                core,
+                {
+                    output_buffer->address(),
+                    num_tiles_per_core,
+                    num_tiles_read
+                }
+            );
+        }
+        else {
+            auto& reader_args = cached_reader_args.at(core.x).at(core.y);
+            auto& writer_args = cached_writer_args.at(core.x).at(core.y);
 
-        std::vector<uint32_t> writer_runtime_args = {
-                output_buffer->address(),
-                num_tiles_per_core,
-                num_tiles_read
-            };
-        ret_val[i] = std::make_pair(std::move(reader_runtime_args), std::move(writer_runtime_args));
+            reader_args[0] = input_buffer->address();
+            reader_args[1] = N;
+            reader_args[2] = C;
+            reader_args[3] = HtWt;
+            reader_args[4] = batch_step;
+            reader_args[5] = channel_step;
+            reader_args[6] = num_tiles_per_core;
+            reader_args[7] = start_tile;
+            reader_args[8] = hw;
+            reader_args[9] = n;
+
+            writer_args[0] = output_buffer->address();
+            writer_args[1] = num_tiles_per_core;
+            writer_args[2] = num_tiles_read;
+        }
+
         num_tiles_read += num_tiles_per_core;
     }
-
-    return ret_val;
 }
+
 
 operation::ProgramWithCallbacks transpose_cn_multi_core(const Tensor &a, Tensor &output) {
 
@@ -114,7 +146,6 @@ operation::ProgramWithCallbacks transpose_cn_multi_core(const Tensor &a, Tensor 
     CoreRange total_cores({0, 0}, {num_cores_x - 1, num_cores_y - 1});
 
     auto [num_cores, all_cores, core_group_1, core_group_2, num_tiles_per_core_group_1, num_tiles_per_core_group_2] = split_work_to_cores(compute_with_storage_grid_size, num_tensor_tiles);
-
 
     tt::tt_metal::Buffer *dst_buffer = output.buffer();
     TT_ASSERT(dst_buffer != nullptr, "Output buffer should be allocated on device!");
@@ -148,32 +179,16 @@ operation::ProgramWithCallbacks transpose_cn_multi_core(const Tensor &a, Tensor 
         total_cores,
         tt::tt_metal::WriterDataMovementConfig(writer_compile_time_args));
 
-    auto all_runtime_args = get_runtime_args_mc_cn(a, output, num_cores_total, num_cores, num_cores_y, core_group_1, num_tiles_per_core_group_1, core_group_2, num_tiles_per_core_group_2);
-
-    for(uint32_t i = 0; i < num_cores_total; i++) {
-        CoreCoord core = {i / num_cores_y, i % num_cores_y};
-        tt::tt_metal::SetRuntimeArgs(
-            program,
-            reader_kernel_id,
-            core,
-            all_runtime_args[i].first
-        );
-
-        tt::tt_metal::SetRuntimeArgs(
-            program,
-            writer_kernel_id,
-            core,
-            all_runtime_args[i].second
-
-        );
-    }
-
+    override_runtime_args_mc_cn<true>(
+        program,
+        reader_kernel_id,
+        writer_kernel_id,
+        a, output, num_cores_total, num_cores, num_cores_y, core_group_1, num_tiles_per_core_group_1, core_group_2, num_tiles_per_core_group_2);
 
     auto override_runtime_args_callback = [
             reader_kernel_id,
             writer_kernel_id,
             compute_with_storage_grid_size
-
         ]
     (
         const void* operation,
@@ -182,52 +197,41 @@ operation::ProgramWithCallbacks transpose_cn_multi_core(const Tensor &a, Tensor 
         const std::vector<std::optional<const Tensor>>&,
         const std::vector<Tensor>& output_tensors
     ) {
-
         auto src_tensor = input_tensors.at(0);
-
         auto dst_tensor = output_tensors.at(0);
 
         uint32_t num_cores_x = compute_with_storage_grid_size.x;
         uint32_t num_cores_y = compute_with_storage_grid_size.y;
 
         uint32_t num_cores_total = num_cores_x * num_cores_y;
-
         uint32_t num_tensor_tiles = src_tensor.volume() / TILE_HW;
 
         auto [num_cores, all_cores, core_group_1, core_group_2, num_tiles_per_core_group_1, num_tiles_per_core_group_2] = split_work_to_cores(compute_with_storage_grid_size, num_tensor_tiles);
-        auto all_runtime_args =  get_runtime_args_mc_cn(src_tensor, dst_tensor, num_cores_total, num_cores, num_cores_y, core_group_1, num_tiles_per_core_group_1, core_group_2, num_tiles_per_core_group_2);
 
-        for(uint32_t i = 0; i < num_cores_total; i++) {
-            CoreCoord core = {i / num_cores_y, i % num_cores_y};
-
-            {
-                SetRuntimeArgs(program, reader_kernel_id, core, all_runtime_args[i].first);
-            }
-
-            {
-                SetRuntimeArgs(program, writer_kernel_id, core, all_runtime_args[i].second);
-            }
-        }
+        override_runtime_args_mc_cn<false>(
+            program,
+            reader_kernel_id,
+            writer_kernel_id, src_tensor, dst_tensor, num_cores_total, num_cores, num_cores_y, core_group_1, num_tiles_per_core_group_1, core_group_2, num_tiles_per_core_group_2);
     };
 
     return {.program=std::move(program), .override_runtime_arguments_callback=override_runtime_args_callback};
 }
 
-// Each element of outer vector corresponds to a core
-// Each core has a pair of std::vector<uint32_t>
-// First of pair is reader args
-// Second of pair is writer args
-std::vector<std::pair<std::vector<uint32_t>, std::vector<uint32_t> > > get_runtime_args_mc_hc(const Tensor &input_tensor,
-                                                                                        Tensor &output_tensor,
-                                                                                        uint32_t num_cores_total,
-                                                                                        uint32_t num_cores,
-                                                                                        uint32_t num_cores_y,
-                                                                                        CoreRangeSet core_group_1,
-                                                                                        uint32_t num_tiles_per_core_group_1,
-                                                                                        CoreRangeSet core_group_2,
-                                                                                        uint32_t num_tiles_per_core_group_2
-                                                                                        ){
-
+template <bool IS_CREATING>
+void override_runtime_args_mc_hc(
+    const Program& program,
+    tt::tt_metal::KernelHandle reader_kernel_id,
+    tt::tt_metal::KernelHandle writer_kernel_id,
+    const Tensor &input_tensor,
+    Tensor &output_tensor,
+    uint32_t num_cores_total,
+    uint32_t num_cores,
+    uint32_t num_cores_y,
+    CoreRangeSet core_group_1,
+    uint32_t num_tiles_per_core_group_1,
+    CoreRangeSet core_group_2,
+    uint32_t num_tiles_per_core_group_2
+){
     auto input_buffer = input_tensor.buffer();
     auto output_buffer = output_tensor.buffer();
     auto input_shape = input_tensor.get_legacy_shape();
@@ -245,11 +249,13 @@ std::vector<std::pair<std::vector<uint32_t>, std::vector<uint32_t> > > get_runti
     uint32_t CtHWt = Ct*H*Wt;
     uint32_t CtWt = Ct * Wt;
 
-    std::vector<std::pair<std::vector<uint32_t>, std::vector<uint32_t> > > ret_val(num_cores_total);
+    auto& cached_reader_args = GetRuntimeArgs(program, reader_kernel_id);
+    auto& cached_writer_args = GetRuntimeArgs(program, writer_kernel_id);
 
     for(uint32_t i = 0, num_tiles_read = 0; i < num_cores_total; i++) {
         CoreCoord core = {i / num_cores_y, i % num_cores_y};
         uint32_t num_tiles_per_core;
+
         if (core_group_1.core_coord_in_core_ranges(core)) {
             num_tiles_per_core = num_tiles_per_core_group_1;
         } else if (core_group_2.core_coord_in_core_ranges(core)) {
@@ -258,51 +264,87 @@ std::vector<std::pair<std::vector<uint32_t>, std::vector<uint32_t> > > get_runti
             //no-op
             num_tiles_per_core = 0;
         }
+
         uint32_t h = num_tiles_read / CtWt % H; // Current h index output of current batch
         uint32_t ct = num_tiles_read / Wt % Ct; // Current Ct index output tile of current batch
 
-        std::vector<uint32_t> reader_runtime_args = {
-            input_buffer->address(),
-            Wt,
-            H,
-            Ct,
-            HW_bytes,
-            CHW_bytes,
-            num_tiles_read, num_tiles_per_core,
-            num_tiles_read / CtHWt * CHW_bytes,
-            h,
-            h / TILE_HEIGHT * Wt,
-            ct,
-            ct * TILE_HEIGHT * HW_bytes,
-            num_tiles_read % Wt
-        };
+        if constexpr (IS_CREATING) {
+            tt::tt_metal::SetRuntimeArgs(
+                program,
+                reader_kernel_id,
+                core,
+                {
+                    input_buffer->address(),
+                    Wt,
+                    H,
+                    Ct,
+                    HW_bytes,
+                    CHW_bytes,
+                    num_tiles_read,
+                    num_tiles_per_core,
+                    num_tiles_read / CtHWt * CHW_bytes,
+                    h,
+                    h / TILE_HEIGHT * Wt,
+                    ct,
+                    ct * TILE_HEIGHT * HW_bytes,
+                    num_tiles_read % Wt
+                }
+            );
 
+            tt::tt_metal::SetRuntimeArgs(
+                program,
+                writer_kernel_id,
+                core,
+                {
+                    output_buffer->address(),
+                    num_tiles_per_core,
+                    num_tiles_read
+                }
+            );
+        }
+        else {
+            auto& reader_args = cached_reader_args.at(core.x).at(core.y);
+            auto& writer_args = cached_writer_args.at(core.x).at(core.y);
 
-        std::vector<uint32_t> writer_runtime_args = {
-                output_buffer->address(),
-                num_tiles_per_core,
-                num_tiles_read
-            };
-        ret_val[i] = {reader_runtime_args, writer_runtime_args};
+            reader_args[0] = input_buffer->address();
+            reader_args[1] = Wt;
+            reader_args[2] = H;
+            reader_args[3] = Ct;
+            reader_args[4] = HW_bytes;
+            reader_args[5] = CHW_bytes;
+            reader_args[6] = num_tiles_read;
+            reader_args[7] = num_tiles_per_core;
+            reader_args[8] = num_tiles_read / CtHWt * CHW_bytes;
+            reader_args[9] = h;
+            reader_args[10] = h / TILE_HEIGHT * Wt;
+            reader_args[11] = ct;
+            reader_args[12] = ct * TILE_HEIGHT * HW_bytes;
+            reader_args[13] = num_tiles_read % Wt;
+
+            writer_args[0] = output_buffer->address();
+            writer_args[1] = num_tiles_per_core;
+            writer_args[2] = num_tiles_read;
+        }
+
         num_tiles_read += num_tiles_per_core;
     }
-
-
-
-    return ret_val;
 }
 
-std::vector<std::pair<std::vector<uint32_t>, std::vector<uint32_t> > > get_runtime_args_mc_hc_rm(const Tensor &input_tensor,
-                                                                                        Tensor &output_tensor,
-                                                                                        uint32_t num_cores_total,
-                                                                                        uint32_t num_cores,
-                                                                                        uint32_t num_cores_y,
-                                                                                        CoreRangeSet core_group_1,
-                                                                                        uint32_t num_w_sticks_per_core_group_1,
-                                                                                        CoreRangeSet core_group_2,
-                                                                                        uint32_t num_w_sticks_per_core_group_2
-                                                                                        ){
-
+template <bool IS_CREATING>
+void override_runtime_args_mc_hc_rm(
+    const Program& program,
+    tt::tt_metal::KernelHandle reader_kernel_id,
+    tt::tt_metal::KernelHandle writer_kernel_id,
+    const Tensor &input_tensor,
+    Tensor &output_tensor,
+    uint32_t num_cores_total,
+    uint32_t num_cores,
+    uint32_t num_cores_y,
+    CoreRangeSet core_group_1,
+    uint32_t num_w_sticks_per_core_group_1,
+    CoreRangeSet core_group_2,
+    uint32_t num_w_sticks_per_core_group_2
+){
     auto input_buffer = input_tensor.buffer();
     auto output_buffer = output_tensor.buffer();
     auto input_shape = input_tensor.get_legacy_shape();
@@ -311,13 +353,16 @@ std::vector<std::pair<std::vector<uint32_t>, std::vector<uint32_t> > > get_runti
     uint32_t W = input_shape[3], H = input_shape[2], C = input_shape[1], N = input_shape[0];
     uint32_t W_bytes = W * input_tensor.element_size();
 
-    std::vector<std::pair<std::vector<uint32_t>, std::vector<uint32_t> > > ret_val(num_cores_total);
-
     uint32_t max_read_size = 2048; // TILE size
     uint32_t curr_c = 0, curr_h = 0, curr_n = 0;
-    for(uint32_t i = 0, curr_sticks_read = 0, curr_sticks_write = 0; i < num_cores_total; i++) {
+
+    auto& cached_reader_args = GetRuntimeArgs(program, reader_kernel_id);
+    auto& cached_writer_args = GetRuntimeArgs(program, writer_kernel_id);
+
+    for (uint32_t i = 0, curr_sticks_read = 0, curr_sticks_write = 0; i < num_cores_total; i++) {
         CoreCoord core = {i / num_cores_y, i % num_cores_y};
         uint32_t num_sticks_per_core;
+
         if (core_group_1.core_coord_in_core_ranges(core)) {
             num_sticks_per_core = num_w_sticks_per_core_group_1;
         } else if (core_group_2.core_coord_in_core_ranges(core)) {
@@ -327,7 +372,6 @@ std::vector<std::pair<std::vector<uint32_t>, std::vector<uint32_t> > > get_runti
             num_sticks_per_core = 0;
         }
 
-
         // issue more reads before calling barrier
         uint32_t num_sticks_per_core_read = 0, num_read_per_barrier = 0;
         if (num_sticks_per_core != 0) {
@@ -335,26 +379,51 @@ std::vector<std::pair<std::vector<uint32_t>, std::vector<uint32_t> > > get_runti
             num_read_per_barrier = num_sticks_per_core / num_sticks_per_core_read;
         }
 
-        // reader
-        std::vector<uint32_t> reader_runtime_args = {
-            input_buffer->address(),
-            num_sticks_per_core_read,
-            num_read_per_barrier,
-            curr_sticks_read,
-            curr_c,
-            curr_h,
-            curr_n
-        };
+        if constexpr (IS_CREATING) {
+            tt::tt_metal::SetRuntimeArgs(
+                program,
+                reader_kernel_id,
+                core,
+                {
+                    input_buffer->address(),
+                    num_sticks_per_core_read,
+                    num_read_per_barrier,
+                    curr_sticks_read,
+                    curr_c,
+                    curr_h,
+                    curr_n
+                }
+            );
 
-        // writer
-        std::vector<uint32_t> writer_runtime_args = {
-            output_buffer->address(),
-            num_sticks_per_core_read,
-            num_read_per_barrier,
-            curr_sticks_write
-        };
+            tt::tt_metal::SetRuntimeArgs(
+                program,
+                writer_kernel_id,
+                core,
+                {
+                    output_buffer->address(),
+                    num_sticks_per_core_read,
+                    num_read_per_barrier,
+                    curr_sticks_write
+                }
+            );
+        }
+        else {
+            auto& reader_args = cached_reader_args.at(core.x).at(core.y);
+            auto& writer_args = cached_writer_args.at(core.x).at(core.y);
 
-        ret_val[i] = {reader_runtime_args, writer_runtime_args};
+            reader_args[0] = input_buffer->address();
+            reader_args[1] = num_sticks_per_core_read;
+            reader_args[2] = num_read_per_barrier;
+            reader_args[3] = curr_sticks_read;
+            reader_args[4] = curr_c;
+            reader_args[5] = curr_h;
+            reader_args[6] = curr_n;
+
+            writer_args[0] = output_buffer->address();
+            writer_args[1] = num_sticks_per_core_read;
+            writer_args[2] = num_read_per_barrier;
+            writer_args[3] = curr_sticks_write;
+        }
 
         curr_sticks_write += num_sticks_per_core;
 
@@ -374,16 +443,12 @@ std::vector<std::pair<std::vector<uint32_t>, std::vector<uint32_t> > > get_runti
                 }
             }
         }
-
     }
-
-    return ret_val;
 }
 
 operation::ProgramWithCallbacks transpose_hc_multi_core(const Tensor &a, Tensor &output) {
 
     const auto shape = a.get_legacy_shape();
-
     uint32_t sub_tile_line_bytes = 16 * a.element_size();
 
     uint32_t num_tensor_tiles = a.volume() / TILE_HW;
@@ -492,35 +557,25 @@ operation::ProgramWithCallbacks transpose_hc_multi_core(const Tensor &a, Tensor 
         total_cores,
         tt::tt_metal::WriterDataMovementConfig(writer_compile_time_args));
 
-
-    auto all_runtime_args = row_major ?
-                            get_runtime_args_mc_hc_rm(a, output, num_cores_total, num_cores, num_cores_y, core_group_1, num_tiles_per_core_group_1, core_group_2, num_tiles_per_core_group_2) :
-                            get_runtime_args_mc_hc(a, output, num_cores_total, num_cores, num_cores_y, core_group_1, num_tiles_per_core_group_1, core_group_2, num_tiles_per_core_group_2);
-
-    for(uint32_t i = 0; i < num_cores_total; i++) {
-        CoreCoord core = {i / num_cores_y, i % num_cores_y};
-        tt::tt_metal::SetRuntimeArgs(
+    if (row_major) {
+        override_runtime_args_mc_hc_rm<true>(
             program,
             reader_kernel_id,
-            core,
-            all_runtime_args[i].first
-        );
-
-        tt::tt_metal::SetRuntimeArgs(
-            program,
             writer_kernel_id,
-            core,
-            all_runtime_args[i].second
-
-        );
+            a, output, num_cores_total, num_cores, num_cores_y, core_group_1, num_tiles_per_core_group_1, core_group_2, num_tiles_per_core_group_2);
     }
-
+    else {
+        override_runtime_args_mc_hc<true>(
+            program,
+            reader_kernel_id,
+            writer_kernel_id,
+            a, output, num_cores_total, num_cores, num_cores_y, core_group_1, num_tiles_per_core_group_1, core_group_2, num_tiles_per_core_group_2);
+    }
 
     auto override_runtime_args_callback = [
             reader_kernel_id,
             writer_kernel_id,
             compute_with_storage_grid_size
-
         ]
     (
         const void* operation,
@@ -529,9 +584,7 @@ operation::ProgramWithCallbacks transpose_hc_multi_core(const Tensor &a, Tensor 
         const std::vector<std::optional<const Tensor>>&,
         const std::vector<Tensor>& output_tensors
     ) {
-
         auto src_tensor = input_tensors.at(0);
-
         auto dst_tensor = output_tensors.at(0);
 
         uint32_t num_cores_x = compute_with_storage_grid_size.x;
@@ -546,21 +599,20 @@ operation::ProgramWithCallbacks transpose_hc_multi_core(const Tensor &a, Tensor 
         bool row_major = src_tensor.get_layout() == Layout::ROW_MAJOR;
 
         auto [num_cores, all_cores, core_group_1, core_group_2, num_tiles_per_core_group_1, num_tiles_per_core_group_2] = split_work_to_cores(compute_with_storage_grid_size, row_major ? NCH : num_tensor_tiles);
-        auto all_runtime_args = row_major ?
-                                get_runtime_args_mc_hc_rm(src_tensor, dst_tensor, num_cores_total, num_cores, num_cores_y, core_group_1, num_tiles_per_core_group_1, core_group_2, num_tiles_per_core_group_2) :
-                                get_runtime_args_mc_hc(src_tensor, dst_tensor, num_cores_total, num_cores, num_cores_y, core_group_1, num_tiles_per_core_group_1, core_group_2, num_tiles_per_core_group_2);
 
-
-        for(uint32_t i = 0; i < num_cores_total; i++) {
-            CoreCoord core = {i / num_cores_y, i % num_cores_y};
-
-            {
-                SetRuntimeArgs(program, reader_kernel_id, core, all_runtime_args[i].first);
-            }
-
-            {
-                SetRuntimeArgs(program, writer_kernel_id, core, all_runtime_args[i].second);
-            }
+        if (row_major) {
+            override_runtime_args_mc_hc_rm<false>(
+                program,
+                reader_kernel_id,
+                writer_kernel_id,
+                src_tensor, dst_tensor, num_cores_total, num_cores, num_cores_y, core_group_1, num_tiles_per_core_group_1, core_group_2, num_tiles_per_core_group_2);
+        }
+        else {
+            override_runtime_args_mc_hc<false>(
+                program,
+                reader_kernel_id,
+                writer_kernel_id,
+                src_tensor, dst_tensor, num_cores_total, num_cores, num_cores_y, core_group_1, num_tiles_per_core_group_1, core_group_2, num_tiles_per_core_group_2);
         }
     };
 
@@ -569,7 +621,6 @@ operation::ProgramWithCallbacks transpose_hc_multi_core(const Tensor &a, Tensor 
 
 
 operation::ProgramWithCallbacks transpose_hc_multi_core_sharded(const Tensor &a, Tensor &output) {
-
 
     tt::tt_metal::Program program = tt::tt_metal::CreateProgram();
 
@@ -615,8 +666,6 @@ operation::ProgramWithCallbacks transpose_hc_multi_core_sharded(const Tensor &a,
     tt::tt_metal::CircularBufferConfig cb_output_config = tt::tt_metal::CircularBufferConfig(shard_height * stick_size_bytes, {{output_cb_index, dst_cb_data_format}})
         .set_page_size(output_cb_index, stick_size_bytes).set_globally_allocated_address(*output.buffer());;
     auto cb_output = tt::tt_metal::CreateCircularBuffer(program, all_cores, cb_output_config);
-
-
 
     std::vector<uint32_t> reader_compile_time_args = {
         (std::uint32_t) src0_cb_index,
@@ -780,7 +829,6 @@ operation::ProgramWithCallbacks transpose_hc_multi_core_sharded(const Tensor &a,
             writer_read_stick_offset = num_sticks_per_shard_core_reader * read_stick_stride;
         }
 
-
         // reader rt args
         std::vector<uint32_t> reader_runtime_args = {
             (std::uint32_t) num_sticks_per_shard_core_reader,
@@ -822,8 +870,6 @@ operation::ProgramWithCallbacks transpose_hc_multi_core_sharded(const Tensor &a,
     }
 
 
-
-
     auto override_runtime_args_callback = [
             reader_kernel_id,
             cb_src0,
@@ -854,18 +900,22 @@ operation::ProgramWithCallbacks transpose_hc_multi_core_sharded(const Tensor &a,
    return {.program=std::move(program), .override_runtime_arguments_callback=override_runtime_args_callback};
 }
 
-std::vector< std::array< std::vector<uint32_t>, 3 > > get_runtime_args_wh(const Tensor &input_tensor,
-                                                       Tensor &output_tensor,
-                                                       uint32_t num_cores_total,
-                                                       uint32_t num_cores,
-                                                       uint32_t num_cores_y,
-                                                       CoreRangeSet core_group_1,
-                                                       uint32_t num_tiles_per_core_group_1,
-                                                       CoreRangeSet core_group_2,
-                                                       uint32_t num_tiles_per_core_group_2
-                                                        )
-{
-
+template <bool IS_CREATING>
+void override_runtime_args_wh(
+    const Program& program,
+    tt::tt_metal::KernelHandle reader_kernel_id,
+    tt::tt_metal::KernelHandle compute_kernel_id,
+    tt::tt_metal::KernelHandle writer_kernel_id,
+    const Tensor &input_tensor,
+    Tensor &output_tensor,
+    uint32_t num_cores_total,
+    uint32_t num_cores,
+    uint32_t num_cores_y,
+    CoreRangeSet core_group_1,
+    uint32_t num_tiles_per_core_group_1,
+    CoreRangeSet core_group_2,
+    uint32_t num_tiles_per_core_group_2
+){
     auto input_shape = input_tensor.get_legacy_shape();
     auto output_shape = output_tensor.get_legacy_shape();
 
@@ -876,14 +926,16 @@ std::vector< std::array< std::vector<uint32_t>, 3 > > get_runtime_args_wh(const 
     uint32_t Ht = H/TILE_HEIGHT;
 
     uint32_t num_tensor_tiles = input_tensor.volume() / TILE_HW;
-
     auto HtWt = Ht * Wt;
-    std::vector< std::array< std::vector<uint32_t>, 3 > > ret_val(num_cores_total);
 
+    auto& cached_reader_args = GetRuntimeArgs(program, reader_kernel_id);
+    auto& cached_compute_args = GetRuntimeArgs(program, compute_kernel_id);
+    auto& cached_writer_args = GetRuntimeArgs(program, writer_kernel_id);
 
     for(uint32_t i = 0, num_tiles_read = 0; i < num_cores_total; i++) {
         CoreCoord core = {i / num_cores_y, i % num_cores_y};
         uint32_t num_tiles_per_core;
+
         if (core_group_1.core_coord_in_core_ranges(core)) {
             num_tiles_per_core = num_tiles_per_core_group_1;
         } else if (core_group_2.core_coord_in_core_ranges(core)) {
@@ -891,51 +943,118 @@ std::vector< std::array< std::vector<uint32_t>, 3 > > get_runtime_args_wh(const 
         } else {
             //noop
             num_tiles_per_core = 0;
+
+            if constexpr (!IS_CREATING) {
+                auto& reader_args = cached_reader_args.at(core.x).at(core.y);
+                auto& compute_args = cached_compute_args.at(core.x).at(core.y);
+                auto& writer_args = cached_writer_args.at(core.x).at(core.y);
+
+                reader_args[1] = 0;
+                compute_args[0] = 0;
+                writer_args[1] = 0;
+                continue;
+            }
         }
+
         uint32_t h = num_tiles_read % Ht;
         uint32_t w = num_tiles_read / Ht % Wt;
 
-        std::vector<uint32_t> compute_runtime_args = {num_tiles_per_core};
+        if constexpr (IS_CREATING) {
+            tt::tt_metal::SetRuntimeArgs(
+                program,
+                reader_kernel_id,
+                core,
+                {
+                    input_tensor.buffer()->address(),
+                    num_tiles_per_core,
+                    tt::round_down(num_tiles_read, HtWt) + h * Wt + w,
+                    h,
+                    w,
+                    Ht,
+                    Wt,
+                    HtWt
+                }
+            );
 
+            tt::tt_metal::SetRuntimeArgs(
+                program,
+                compute_kernel_id,
+                core,
+                { num_tiles_per_core }
+            );
 
-        std::vector<uint32_t> reader_runtime_args = {
-                input_tensor.buffer()->address(),
-                num_tiles_per_core,
-                tt::round_down(num_tiles_read, HtWt) + h * Wt + w,
-                h,
-                w,
-                Ht,
-                Wt,
-                HtWt
-        };
+            tt::tt_metal::SetRuntimeArgs(
+                program,
+                writer_kernel_id,
+                core,
+                {
+                    output_tensor.buffer()->address(),
+                    num_tiles_per_core,
+                    num_tiles_read
+                }
+            );
+        }
+        else {
+            auto& reader_args = cached_reader_args.at(core.x).at(core.y);
+            auto& compute_args = cached_compute_args.at(core.x).at(core.y);
+            auto& writer_args = cached_writer_args.at(core.x).at(core.y);
 
+            reader_args[0] = input_tensor.buffer()->address();
+            reader_args[1] = num_tiles_per_core;
+            reader_args[2] = tt::round_down(num_tiles_read, HtWt) + h * Wt + w;
+            reader_args[3] = h;
+            reader_args[4] = w;
+            reader_args[5] = Ht;
+            reader_args[6] = Wt;
+            reader_args[7] = HtWt;
 
+            compute_args[0] = num_tiles_per_core;
 
-        std::vector<uint32_t> writer_runtime_args = {
-                output_tensor.buffer()->address(),
-                num_tiles_per_core,
-                num_tiles_read
-        };
+            writer_args[0] = output_tensor.buffer()->address();
+            writer_args[1] = num_tiles_per_core;
+            writer_args[2] = num_tiles_read;
+        }
+
+        // std::vector<uint32_t> compute_runtime_args = {num_tiles_per_core};
+
+        // std::vector<uint32_t> reader_runtime_args = {
+        //         input_tensor.buffer()->address(),
+        //         num_tiles_per_core,
+        //         tt::round_down(num_tiles_read, HtWt) + h * Wt + w,
+        //         h,
+        //         w,
+        //         Ht,
+        //         Wt,
+        //         HtWt
+        // };
+
+        // std::vector<uint32_t> writer_runtime_args = {
+        //         output_tensor.buffer()->address(),
+        //         num_tiles_per_core,
+        //         num_tiles_read
+        // };
+
         num_tiles_read += num_tiles_per_core;
-        ret_val[i] = {reader_runtime_args, compute_runtime_args, writer_runtime_args};
     }
-
-    return ret_val;
 }
 
 
-std::vector< std::array< std::vector<uint32_t>, 3 > > get_runtime_args_wh_rm(const Tensor &input_tensor,
-                                                       Tensor &output_tensor,
-                                                       uint32_t num_cores_total,
-                                                       uint32_t num_cores,
-                                                       uint32_t num_cores_y,
-                                                       CoreRangeSet core_group_1,
-                                                       uint32_t num_hw_blocks_per_core_group_1,
-                                                       CoreRangeSet core_group_2,
-                                                       uint32_t num_hw_blocks_per_core_group_2
-                                                        )
-{
-
+template<bool IS_CREATING>
+void override_runtime_args_wh_rm(
+    const Program& program,
+    tt::tt_metal::KernelHandle reader_kernel_id,
+    tt::tt_metal::KernelHandle compute_kernel_id,
+    tt::tt_metal::KernelHandle writer_kernel_id,
+    const Tensor &input_tensor,
+    Tensor &output_tensor,
+    uint32_t num_cores_total,
+    uint32_t num_cores,
+    uint32_t num_cores_y,
+    CoreRangeSet core_group_1,
+    uint32_t num_hw_blocks_per_core_group_1,
+    CoreRangeSet core_group_2,
+    uint32_t num_hw_blocks_per_core_group_2
+){
     auto input_shape = input_tensor.shape();
     auto output_shape = output_tensor.shape();
 
@@ -943,11 +1062,14 @@ std::vector< std::array< std::vector<uint32_t>, 3 > > get_runtime_args_wh_rm(con
     uint32_t ht = (H + TILE_HEIGHT - 1) / TILE_HEIGHT;
     uint32_t wt = (W + TILE_WIDTH - 1) / TILE_WIDTH;
 
-    std::vector< std::array< std::vector<uint32_t>, 3 > > ret_val(num_cores_total);
+    auto& cached_reader_args = GetRuntimeArgs(program, reader_kernel_id);
+    auto& cached_compute_args = GetRuntimeArgs(program, compute_kernel_id);
+    auto& cached_writer_args = GetRuntimeArgs(program, writer_kernel_id);
 
-    for(uint32_t i = 0, num_sticks_read = 0, num_sticks_write = 0; i < num_cores_total; i++) {
+    for (uint32_t i = 0, num_sticks_read = 0, num_sticks_write = 0; i < num_cores_total; i++) {
         CoreCoord core = {i / num_cores_y, i % num_cores_y};
         uint32_t num_hw_blocks_per_core;
+
         if (core_group_1.core_coord_in_core_ranges(core)) {
             num_hw_blocks_per_core = num_hw_blocks_per_core_group_1;
         } else if (core_group_2.core_coord_in_core_ranges(core)) {
@@ -956,29 +1078,73 @@ std::vector< std::array< std::vector<uint32_t>, 3 > > get_runtime_args_wh_rm(con
             //noop
             num_hw_blocks_per_core = 0;
         }
-        // compute
-        std::vector<uint32_t> compute_runtime_args = {num_hw_blocks_per_core};
 
-        // reader
-        std::vector<uint32_t> reader_runtime_args = {
-                input_tensor.buffer()->address(),
-                num_sticks_read,
-                num_hw_blocks_per_core,
-        };
+        if constexpr (IS_CREATING) {
+            tt::tt_metal::SetRuntimeArgs(
+                program,
+                reader_kernel_id,
+                core,
+                {
+                    input_tensor.buffer()->address(),
+                    num_sticks_read,
+                    num_hw_blocks_per_core,
+                }
+            );
 
-        // writer
-        std::vector<uint32_t> writer_runtime_args = {
-                output_tensor.buffer()->address(),
-                num_sticks_write,
-                num_hw_blocks_per_core,
-        };
+            tt::tt_metal::SetRuntimeArgs(
+                program,
+                compute_kernel_id,
+                core,
+                { num_hw_blocks_per_core }
+            );
+
+            tt::tt_metal::SetRuntimeArgs(
+                program,
+                writer_kernel_id,
+                core,
+                {
+                    output_tensor.buffer()->address(),
+                    num_sticks_write,
+                    num_hw_blocks_per_core,
+                }
+            );
+        }
+        else {
+            auto& reader_args = cached_reader_args.at(core.x).at(core.y);
+            auto& compute_args = cached_compute_args.at(core.x).at(core.y);
+            auto& writer_args = cached_writer_args.at(core.x).at(core.y);
+
+            reader_args[0] = input_tensor.buffer()->address();
+            reader_args[1] = num_sticks_read;
+            reader_args[2] = num_hw_blocks_per_core;
+
+            compute_args[0] = num_hw_blocks_per_core;
+
+            writer_args[0] = output_tensor.buffer()->address();
+            writer_args[1] = num_sticks_write;
+            writer_args[2] = num_hw_blocks_per_core;
+        }
+
+        // // compute
+        // std::vector<uint32_t> compute_runtime_args = {num_hw_blocks_per_core};
+
+        // // reader
+        // std::vector<uint32_t> reader_runtime_args = {
+        //         input_tensor.buffer()->address(),
+        //         num_sticks_read,
+        //         num_hw_blocks_per_core,
+        // };
+
+        // // writer
+        // std::vector<uint32_t> writer_runtime_args = {
+        //         output_tensor.buffer()->address(),
+        //         num_sticks_write,
+        //         num_hw_blocks_per_core,
+        // };
 
         num_sticks_read += num_hw_blocks_per_core * H;
         num_sticks_write += num_hw_blocks_per_core * W;
-        ret_val[i] = {reader_runtime_args, compute_runtime_args, writer_runtime_args};
     }
-
-    return ret_val;
 }
 
 
@@ -1126,40 +1292,20 @@ operation::ProgramWithCallbacks transpose_wh_multi_core(const Tensor &a, Tensor 
         tt::tt_metal::ComputeConfig{.fp32_dest_acc_en=fp32_dest_acc_en, .compile_args = compute_kernel_args,}
     );
 
-    auto all_runtime_args = row_major ? get_runtime_args_wh_rm(a, output, num_cores_total, num_cores, num_cores_y,
-                                            core_group_1, num_tiles_per_core_group_1, core_group_2,
-                                            num_tiles_per_core_group_2) :
-                                        get_runtime_args_wh(a, output, num_cores_total, num_cores, num_cores_y,
-                                            core_group_1, num_tiles_per_core_group_1, core_group_2,
-                                            num_tiles_per_core_group_2);
-
-    for(uint32_t i = 0; i < num_cores_total; i++) {
-        CoreCoord core = {i / num_cores_y, i % num_cores_y};
-
-        tt::tt_metal::SetRuntimeArgs(
-            program,
-            reader_kernel_id,
-            core,
-            all_runtime_args[i][0]
-
-        );
-
-        tt::tt_metal::SetRuntimeArgs(
-            program,
-            compute_kernel_id,
-            core,
-            all_runtime_args[i][1]
-
-        );
-
-        tt::tt_metal::SetRuntimeArgs(
-            program,
-            writer_kernel_id,
-            core,
-            all_runtime_args[i][2]
-        );
+    if (row_major) {
+        override_runtime_args_wh_rm<true>(
+            program, reader_kernel_id, compute_kernel_id, writer_kernel_id,
+            a, output, num_cores_total, num_cores, num_cores_y,
+            core_group_1, num_tiles_per_core_group_1, core_group_2,
+            num_tiles_per_core_group_2);
     }
-
+    else {
+        override_runtime_args_wh<true>(
+            program, reader_kernel_id, compute_kernel_id, writer_kernel_id,
+            a, output, num_cores_total, num_cores, num_cores_y,
+            core_group_1, num_tiles_per_core_group_1, core_group_2,
+            num_tiles_per_core_group_2);
+    }
 
     auto override_runtime_args_callback = [
             reader_kernel_id,
@@ -1186,28 +1332,20 @@ operation::ProgramWithCallbacks transpose_wh_multi_core(const Tensor &a, Tensor 
         bool row_major = src_tensor.get_layout() == Layout::ROW_MAJOR;
 
         auto [num_cores, all_cores, core_group_1, core_group_2, num_tiles_per_core_group_1, num_tiles_per_core_group_2] = split_work_to_cores(compute_with_storage_grid_size, row_major ? NC : num_tensor_tiles);
-        auto all_runtime_args = row_major ? get_runtime_args_wh_rm(src_tensor, dst_tensor, num_cores_total, num_cores, num_cores_y,
-                                                core_group_1, num_tiles_per_core_group_1, core_group_2,
-                                                num_tiles_per_core_group_2) :
-                                            get_runtime_args_wh(src_tensor, dst_tensor, num_cores_total, num_cores, num_cores_y,
-                                                core_group_1, num_tiles_per_core_group_1, core_group_2,
-                                                num_tiles_per_core_group_2);
 
-        for(uint32_t i = 0, num_tiles_read = 0; i < num_cores_total; i++) {
-            CoreCoord core = {i / num_cores_y, i % num_cores_y};
-
-            {
-                SetRuntimeArgs(program, reader_kernel_id, core, all_runtime_args[i][0]);
-            }
-
-            {
-                SetRuntimeArgs(program, compute_kernel_id, core, all_runtime_args[i][1]);
-            }
-
-            {
-                SetRuntimeArgs(program, writer_kernel_id, core, all_runtime_args[i][2]);
-            }
-
+        if (row_major) {
+            override_runtime_args_wh_rm<false>(
+                program, reader_kernel_id, compute_kernel_id, writer_kernel_id,
+                src_tensor, dst_tensor, num_cores_total, num_cores, num_cores_y,
+                core_group_1, num_tiles_per_core_group_1, core_group_2,
+                num_tiles_per_core_group_2);
+        }
+        else {
+            override_runtime_args_wh<false>(
+                program, reader_kernel_id, compute_kernel_id, writer_kernel_id,
+                src_tensor, dst_tensor, num_cores_total, num_cores, num_cores_y,
+                core_group_1, num_tiles_per_core_group_1, core_group_2,
+                num_tiles_per_core_group_2);
         }
     };
 
@@ -1215,7 +1353,6 @@ operation::ProgramWithCallbacks transpose_wh_multi_core(const Tensor &a, Tensor 
 }
 
 operation::ProgramWithCallbacks transpose_wh_multi_core_sharded(const Tensor &a, Tensor &output) {
-
 
     tt::tt_metal::Program program = tt::tt_metal::CreateProgram();
 


### PR DESCRIPTION
Reduced override runtime args time for transpose op. Before opt:

```
op,count,python min dispatch time (ms),python mean dispatch time(ms),python mean dispatch + sync time (ms),C++ mean dispatch time (ms)
ttnn.transpose_01,200,0.053,0.056,0.102,0.039
ttnn.transpose_02,200,0.219,0.23,150.421,0.132
ttnn.transpose_12,200,0.1,0.102,38.139,0.055
ttnn.transpose_13,200,0.262,0.272,412.861,0.173
ttnn.transpose_23,200,0.071,0.073,0.131,0.056
```

After opt:
```
op,count,python min dispatch time (ms),python mean dispatch time(ms),python mean dispatch + sync time (ms),C++ mean dispatch time (ms)
ttnn.transpose_01,200,0.029,0.031,0.101,0.014
ttnn.transpose_02,200,0.142,0.146,150.418,0.052
ttnn.transpose_03,200,882.164,884.192,885.21,0.148
ttnn.transpose_12,200,0.069,0.071,38.135,0.025
ttnn.transpose_13,200,0.148,0.152,412.887,0.057
ttnn.transpose_23,200,0.031,0.032,0.129,0.015
```

All post-commit tests
https://github.com/tenstorrent/tt-metal/actions/runs/10400750010

Model perf regressions and output report
https://github.com/tenstorrent/tt-metal/actions/runs/10400755742

[TGG] TGG demo tests
https://github.com/tenstorrent/tt-metal/actions/runs/10400761524

[TGG] TGG model perf tests
https://github.com/tenstorrent/tt-metal/actions/runs/10400766979

[TG] TG model perf tests
https://github.com/tenstorrent/tt-metal/actions/runs/10400746966
