### PR TITLE
#11349: Add missing include in `kernel_types.hpp`

### DIFF
--- a/tt_metal/impl/kernels/kernel_types.hpp
+++ b/tt_metal/impl/kernels/kernel_types.hpp
@@ -7,6 +7,7 @@
 #include "common/base_types.hpp"
 #include "tt_metal/impl/kernels/data_types.hpp"
 #include "tt_metal/detail/util.hpp"
+#include "tt_metal/llrt/tt_cluster.hpp"
 #include <map>
 #include <vector>
 #include <string>


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/11349

### Problem description

In `kernel_types.hpp`, `tt::Cluster::instance` is being used, but the `tt_cluster.hpp` file, where the `tt::Cluster` class is defined, is not included.

Because of this, files that include `kernel_types.hpp` may encounter build errors depending on the order of includes.

### What's changed
To resolve this issue, `tt_cluster.hpp` should be included in `kernel_types.hpp.`


### Checklist
- [ ] Post commit CI passes
- [ ] Blackhole Post commit (if applicable)
- [ ] Model regression CI testing passes (if applicable)
- [ ] New/Existing tests provide coverage for changes
