### PR TITLE
#11241: Replace tt_lib in models/demos/ttnn_*

### DIFF
--- a/models/demos/ttnn_falcon7b/tests/test_falcon_rotary_embedding.py
+++ b/models/demos/ttnn_falcon7b/tests/test_falcon_rotary_embedding.py
@@ -12,7 +12,6 @@ import ttnn
 from ttnn.model_preprocessing import preprocess_model_parameters
 from tests.ttnn.utils_for_testing import assert_with_pcc
 from models.utility_functions import comp_pcc, divup
-import tt_lib as ttl
 import ttnn
 
 from models.demos.ttnn_falcon7b.tt.falcon_rotary_embedding import TtFalconRotaryEmbedding

--- a/models/demos/ttnn_falcon7b/tests/test_metal_falcon.py
+++ b/models/demos/ttnn_falcon7b/tests/test_metal_falcon.py
@@ -9,7 +9,6 @@ from loguru import logger
 from ttnn.model_preprocessing import preprocess_model_parameters
 from models.demos.ttnn_falcon7b.tt.common import create_custom_preprocessor
 
-import tt_lib
 from models.demos.ttnn_falcon7b.tt.falcon_causallm import TtFalconCausalLM
 
 from models.demos.ttnn_falcon7b.tt.model_config import (
@@ -222,7 +221,7 @@ def test_perf_bare_metal(
     if is_e75(device) and batch == 32:
         pytest.skip("Falcon batch 32 is not supported on E75")
 
-    tt_lib.device.EnableMemoryReports()
+    ttnn.experimental.device.EnableMemoryReports()
 
     model_config = get_model_config(model_config_str)
     tt_cache_path = get_tt_cache_path(model_version)

--- a/models/demos/ttnn_falcon7b/tt/falcon_causallm.py
+++ b/models/demos/ttnn_falcon7b/tt/falcon_causallm.py
@@ -4,7 +4,6 @@
 
 from typing import Optional, Tuple
 
-import tt_lib
 import ttnn
 
 from models.demos.ttnn_falcon7b.tt.falcon_model import TtFalconModelShared
@@ -43,14 +42,14 @@ class TtFalconCausalLM(TtFalconModelShared):
 
     def __call__(
         self,
-        input_embeddings: tt_lib.tensor.Tensor,
+        input_embeddings: ttnn.Tensor,
         llm_mode: str,
-        attention_mask: tt_lib.tensor.Tensor = None,
+        attention_mask: ttnn.Tensor = None,
         user_id: int = 0,
-        layer_past: Optional[Tuple[Tuple[tt_lib.tensor.Tensor]]] = None,
+        layer_past: Optional[Tuple[Tuple[ttnn.Tensor]]] = None,
         layer_past_len: int = 0,
         use_cache: bool = False,
-    ) -> tt_lib.tensor.Tensor:
+    ) -> ttnn.Tensor:
         hidden_states, presents = super().__call__(
             input_embeddings=input_embeddings,
             attention_mask=attention_mask,

--- a/models/demos/ttnn_falcon7b/tt/model_config.py
+++ b/models/demos/ttnn_falcon7b/tt/model_config.py
@@ -2,7 +2,7 @@
 
 # SPDX-License-Identifier: Apache-2.0
 
-import tt_lib as ttl
+import ttnn
 from loguru import logger
 from pathlib import Path
 
@@ -92,9 +92,9 @@ def pretty_print_model_config(model_config):
 
 def get_model_config(model_config_str):
     assert model_config_str in ACCEPTABLE_MODEL_CONFIG_STRS
-    DRAM_MEMCFG = ttl.tensor.MemoryConfig(ttl.tensor.TensorMemoryLayout.INTERLEAVED, ttl.tensor.BufferType.DRAM)
-    L1_MEMCFG = ttl.tensor.MemoryConfig(ttl.tensor.TensorMemoryLayout.INTERLEAVED, ttl.tensor.BufferType.L1)
-    BFP8_DTYPE = ttl.tensor.DataType.BFLOAT8_B
+    DRAM_MEMCFG = ttnn.DRAM_MEMORY_CONFIG
+    L1_MEMCFG = ttnn.L1_MEMORY_CONFIG
+    BFP8_DTYPE = ttnn.bfloat8_b
 
     # Set default dtype and mem_config based on model_config_str
     if model_config_str in ("BFLOAT16-DRAM", "BFLOAT16-L1"):
@@ -102,7 +102,7 @@ def get_model_config(model_config_str):
         # TODO: Set default memcfg for BFLOAT16-L1 to L1
         # mem_config = DRAM_MEMCFG if mem_config_str == "DRAM" else L1_MEMCFG
         mem_config = DRAM_MEMCFG
-        dtype = ttl.tensor.DataType.BFLOAT16 if dtype_str == "BFLOAT16" else ttl.tensor.DataType.BFLOAT8_B
+        dtype = ttnn.bfloat16 if dtype_str == "BFLOAT16" else ttnn.bfloat8_b
     else:
         raise NotImplementedError(f"Model config {model_config_str} is not supported!")
 

--- a/models/demos/ttnn_resnet/tests/multi_device/test_perf_ttnn_resnet.py
+++ b/models/demos/ttnn_resnet/tests/multi_device/test_perf_ttnn_resnet.py
@@ -7,7 +7,6 @@ from loguru import logger
 from transformers import AutoImageProcessor
 import pytest
 import ttnn
-import tt_lib
 from ttnn.model_preprocessing import (
     preprocess_model_parameters,
 )
@@ -45,10 +44,10 @@ def buffer_address(tensor):
 
 def dump_device_profiler(device):
     if isinstance(device, ttnn.Device):
-        tt_lib.device.DumpDeviceProfiler(device)
+        ttnn.experimental.device.DumpDeviceProfiler(device)
     else:
         for dev in device.get_device_ids():
-            tt_lib.device.DumpDeviceProfiler(device.get_device(dev))
+            ttnn.experimental.device.DumpDeviceProfiler(device.get_device(dev))
 
 
 # TODO: Create ttnn apis for this

--- a/models/demos/ttnn_resnet/tests/multi_device/test_ttnn_resnet50_performant.py
+++ b/models/demos/ttnn_resnet/tests/multi_device/test_ttnn_resnet50_performant.py
@@ -4,7 +4,6 @@
 
 import pytest
 import torch
-import tt_lib
 import ttnn
 from models.utility_functions import (
     is_wormhole_b0,

--- a/models/demos/ttnn_resnet/tests/test_perf_ttnn_resnet.py
+++ b/models/demos/ttnn_resnet/tests/test_perf_ttnn_resnet.py
@@ -8,7 +8,6 @@ import torchvision
 from transformers import AutoImageProcessor
 import pytest
 import ttnn
-import tt_lib
 from ttnn.model_preprocessing import (
     preprocess_model_parameters,
 )
@@ -37,7 +36,8 @@ except ModuleNotFoundError:
     use_signpost = False
 
 # TODO: Create ttnn apis for this
-ttnn.dump_device_profiler = tt_lib.device.DumpDeviceProfiler
+ttnn.dump_device_profiler = ttnn.experimental.device.DumpDeviceProfiler
+
 
 model_config = {
     "MATH_FIDELITY": ttnn.MathFidelity.LoFi,

--- a/models/demos/ttnn_resnet/tests/test_ttnn_resnet50_performant.py
+++ b/models/demos/ttnn_resnet/tests/test_ttnn_resnet50_performant.py
@@ -4,7 +4,6 @@
 
 import pytest
 import torch
-import tt_lib
 import ttnn
 from models.utility_functions import (
     is_wormhole_b0,


### PR DESCRIPTION
### Ticket
Link to Github Issue #11241 

### Problem description
Replace tt_lib in models/demos/ttnn_falcon7b and ttnn_resnet

### What's changed
Replace tt_lib in models/demos/ttnn_falcon7b and ttnn_resnet


### Checklist
- [ ] Post commit CI. https://github.com/tenstorrent/tt-metal/actions/runs/10426381452

- [ ] Demo tests https://github.com/tenstorrent/tt-metal/actions/runs/10420364761

- [ ] t3k demos

- [ ] nightly FD - https://github.com/tenstorrent/tt-metal/actions/runs/10420287833 *

- [ ] pc model - https://github.com/tenstorrent/tt-metal/actions/runs/10420382109

- [ ] model perf - https://github.com/tenstorrent/tt-metal/actions/runs/10419707216 *

- [ ] Blackhole Post commit (if applicable)
- [ ] Model regression CI testing passes (if applicable)
- [ ] New/Existing tests provide coverage for changes
