### PR TITLE
#11341: Replace tt_lib in bert_tiny, distilbert

### DIFF
--- a/models/experimental/bert_tiny/bert_tiny_helper_funcs.py
+++ b/models/experimental/bert_tiny/bert_tiny_helper_funcs.py
@@ -1,17 +1,12 @@
 # SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
 # SPDX-License-Identifier: Apache-2.0
-import tt_lib
+
 import ttnn
 from typing import Optional
 
 
 def Linear(
-    weight: tt_lib.tensor.Tensor,
-    bias: Optional[tt_lib.tensor.Tensor] = None,
-    device=None,
-    output_mem_config=tt_lib.tensor.MemoryConfig(
-        tt_lib.tensor.TensorMemoryLayout.INTERLEAVED, tt_lib.tensor.BufferType.DRAM
-    ),
+    weight: ttnn.Tensor, bias: Optional[ttnn.Tensor] = None, device=None, output_mem_config=ttnn.DRAM_MEMORY_CONFIG
 ):
     weight_T = ttnn.permute(weight, (1, 0))
 

--- a/models/experimental/bert_tiny/tests/test_bert.py
+++ b/models/experimental/bert_tiny/tests/test_bert.py
@@ -5,7 +5,6 @@
 import pytest
 from loguru import logger
 import ttnn
-import tt_lib
 from models.experimental.bert_tiny.tt.bert import TtBert
 
 from transformers import BertForQuestionAnswering, BertTokenizer
@@ -40,9 +39,7 @@ def test_bert_inference(
         truncation=True,
         return_tensors="pt",
     )
-    output_mem_config = tt_lib.tensor.MemoryConfig(
-        tt_lib.tensor.TensorMemoryLayout.INTERLEAVED, tt_lib.tensor.BufferType.DRAM
-    )
+    output_mem_config = ttnn.DRAM_MEMORY_CONFIG
     state_dict = hugging_face_reference_model.state_dict()
     tt_ouptut_model = TtBert(
         hugging_face_reference_model.config, state_dict=state_dict, device=device, mem_config=output_mem_config

--- a/models/experimental/bert_tiny/tests/test_bert_attention.py
+++ b/models/experimental/bert_tiny/tests/test_bert_attention.py
@@ -5,7 +5,6 @@ import torch
 import pytest
 from loguru import logger
 import ttnn
-import tt_lib
 from models.experimental.bert_tiny.tt.bert_attention import TtBertattention
 from transformers import BertForQuestionAnswering
 from models.utility_functions import (
@@ -28,9 +27,7 @@ def test_bert_attention_inference(
     hugging_face_reference_model = BertForQuestionAnswering.from_pretrained(model_name, torchscript=False)
     state_dict = hugging_face_reference_model.state_dict()
     encoder_idx = 0
-    output_mem_config = tt_lib.tensor.MemoryConfig(
-        tt_lib.tensor.TensorMemoryLayout.INTERLEAVED, tt_lib.tensor.BufferType.DRAM
-    )
+    output_mem_config = ttnn.DRAM_MEMORY_CONFIG
     tt_ouptut_model = TtBertattention(
         hugging_face_reference_model.config,
         encoder_idx,

--- a/models/experimental/bert_tiny/tests/test_bert_encoder.py
+++ b/models/experimental/bert_tiny/tests/test_bert_encoder.py
@@ -5,7 +5,6 @@ import torch
 import pytest
 from loguru import logger
 import ttnn
-import tt_lib
 from models.experimental.bert_tiny.tt.bert_encoder import TtBertencoder
 
 from transformers import BertForQuestionAnswering
@@ -27,9 +26,7 @@ def test_bert_encoder_inference(
 ):
     model_name = str(model_location_generator("mrm8488/bert-tiny-finetuned-squadv2", model_subdir="Bert"))
     hugging_face_reference_model = BertForQuestionAnswering.from_pretrained(model_name, torchscript=False)
-    output_mem_config = tt_lib.tensor.MemoryConfig(
-        tt_lib.tensor.TensorMemoryLayout.INTERLEAVED, tt_lib.tensor.BufferType.DRAM
-    )
+    output_mem_config = ttnn.DRAM_MEMORY_CONFIG
     state_dict = hugging_face_reference_model.state_dict()
     tt_ouptut_model = TtBertencoder(
         hugging_face_reference_model.config, state_dict=state_dict, device=device, mem_config=output_mem_config

--- a/models/experimental/bert_tiny/tests/test_bert_intermediate.py
+++ b/models/experimental/bert_tiny/tests/test_bert_intermediate.py
@@ -5,7 +5,6 @@ import torch
 import pytest
 from loguru import logger
 import ttnn
-import tt_lib
 from models.experimental.bert_tiny.tt.bert_intermediate import TtBertintermediate
 from transformers import BertForQuestionAnswering
 from models.utility_functions import (
@@ -30,9 +29,7 @@ def test_bert_intermediate_inference(
     state_dict = hugging_face_reference_model.state_dict()
     encoder_idx = 0
 
-    output_mem_config = tt_lib.tensor.MemoryConfig(
-        tt_lib.tensor.TensorMemoryLayout.INTERLEAVED, tt_lib.tensor.BufferType.DRAM
-    )
+    output_mem_config = ttnn.DRAM_MEMORY_CONFIG
     tt_intermediate_model = TtBertintermediate(
         hugging_face_reference_model.config,
         encoder_idx,

--- a/models/experimental/bert_tiny/tests/test_bert_layer.py
+++ b/models/experimental/bert_tiny/tests/test_bert_layer.py
@@ -5,7 +5,6 @@ import torch
 import pytest
 from loguru import logger
 import ttnn
-import tt_lib
 from models.experimental.bert_tiny.tt.bert_layer import TtBertlayer
 from transformers import BertForQuestionAnswering
 from models.utility_functions import (
@@ -26,9 +25,7 @@ def test_bert_layer_inference(
 ):
     model_name = str(model_location_generator("mrm8488/bert-tiny-finetuned-squadv2", model_subdir="Bert"))
     hugging_face_reference_model = BertForQuestionAnswering.from_pretrained(model_name, torchscript=False)
-    output_mem_config = tt_lib.tensor.MemoryConfig(
-        tt_lib.tensor.TensorMemoryLayout.INTERLEAVED, tt_lib.tensor.BufferType.DRAM
-    )
+    output_mem_config = ttnn.DRAM_MEMORY_CONFIG
     state_dict = hugging_face_reference_model.state_dict()
     encoder_idx = 1
     tt_ouptut_model = TtBertlayer(

--- a/models/experimental/bert_tiny/tests/test_bert_output.py
+++ b/models/experimental/bert_tiny/tests/test_bert_output.py
@@ -5,7 +5,6 @@ import torch
 import pytest
 from loguru import logger
 import ttnn
-import tt_lib
 
 from models.experimental.bert_tiny.tt.bert_output import TtBertoutput
 from transformers import BertForQuestionAnswering
@@ -30,9 +29,7 @@ def test_bert_output_inference(
 
     state_dict = hugging_face_reference_model.state_dict()
     encoder_idx = 0
-    output_mem_config = tt_lib.tensor.MemoryConfig(
-        tt_lib.tensor.TensorMemoryLayout.INTERLEAVED, tt_lib.tensor.BufferType.DRAM
-    )
+    output_mem_config = ttnn.DRAM_MEMORY_CONFIG
     tt_ouptut_model = TtBertoutput(
         hugging_face_reference_model.config,
         encoder_idx,

--- a/models/experimental/bert_tiny/tests/test_bert_self_attention.py
+++ b/models/experimental/bert_tiny/tests/test_bert_self_attention.py
@@ -5,7 +5,6 @@ import torch
 import pytest
 from loguru import logger
 import ttnn
-import tt_lib
 
 from models.experimental.bert_tiny.tt.bert_self_attention import TtBertselfattention
 from transformers import BertForQuestionAnswering
@@ -30,9 +29,7 @@ def test_bert_self_attention_inference(
 
     state_dict = hugging_face_reference_model.state_dict()
     encoder_idx = 0
-    output_mem_config = tt_lib.tensor.MemoryConfig(
-        tt_lib.tensor.TensorMemoryLayout.INTERLEAVED, tt_lib.tensor.BufferType.DRAM
-    )
+    output_mem_config = ttnn.DRAM_MEMORY_CONFIG
     tt_attention_model = TtBertselfattention(
         hugging_face_reference_model.config, encoder_idx, state_dict, device, output_mem_config
     )

--- a/models/experimental/bert_tiny/tt/bert.py
+++ b/models/experimental/bert_tiny/tt/bert.py
@@ -5,7 +5,6 @@
 import torch.nn as nn
 import torch
 import ttnn
-import tt_lib
 from typing import List, Optional
 from models.experimental.bert_tiny.tt.bert_encoder import TtBertencoder
 from models.utility_functions import tt_to_torch_tensor, torch_to_tt_tensor, torch_to_tt_tensor_rm

--- a/models/experimental/bert_tiny/tt/bert_attention.py
+++ b/models/experimental/bert_tiny/tt/bert_attention.py
@@ -2,7 +2,6 @@
 
 # SPDX-License-Identifier: Apache-2.0
 
-import tt_lib
 import torch.nn as nn
 import ttnn
 from typing import Optional

--- a/models/experimental/bert_tiny/tt/bert_for_question_answering.py
+++ b/models/experimental/bert_tiny/tt/bert_for_question_answering.py
@@ -4,7 +4,6 @@
 
 import torch.nn as nn
 import ttnn
-import tt_lib
 from typing import Optional
 from models.experimental.bert_tiny.tt.bert import TtBert
 
@@ -21,9 +20,7 @@ class TtBertforqa(nn.Module):
         super().__init__()
         self.device = device
         self.config = config
-        self.output_mem_config = tt_lib.tensor.MemoryConfig(
-            tt_lib.tensor.TensorMemoryLayout.INTERLEAVED, tt_lib.tensor.BufferType.DRAM
-        )
+        self.output_mem_config = ttnn.DRAM_MEMORY_CONFIG
 
         self.bert = TtBert(config=self.config, state_dict=state_dict, device=device, mem_config=self.output_mem_config)
 

--- a/models/experimental/bert_tiny/tt/bert_intermediate.py
+++ b/models/experimental/bert_tiny/tt/bert_intermediate.py
@@ -2,7 +2,6 @@
 
 # SPDX-License-Identifier: Apache-2.0
 
-import tt_lib
 import ttnn
 import torch.nn as nn
 from typing import Optional

--- a/models/experimental/bert_tiny/tt/bert_layer.py
+++ b/models/experimental/bert_tiny/tt/bert_layer.py
@@ -2,7 +2,6 @@
 
 # SPDX-License-Identifier: Apache-2.0
 
-import tt_lib
 import torch.nn as nn
 import ttnn
 from typing import Optional

--- a/models/experimental/bert_tiny/tt/bert_output.py
+++ b/models/experimental/bert_tiny/tt/bert_output.py
@@ -2,7 +2,6 @@
 
 # SPDX-License-Identifier: Apache-2.0
 
-import tt_lib
 import ttnn
 import torch.nn as nn
 from typing import Optional

--- a/models/experimental/bert_tiny/tt/bert_self_attention.py
+++ b/models/experimental/bert_tiny/tt/bert_self_attention.py
@@ -3,7 +3,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import torch.nn as nn
-import tt_lib
 import ttnn
 import math
 import torch
@@ -94,11 +93,11 @@ def mha(
         reciprocal_of_sqrt_hidden_dim_tensor = ttnn.to_torch(ttnn.from_device(reciprocal_of_sqrt_hidden_dim_tensor))
         reciprocal_of_sqrt_hidden_dim_tensor = torch_to_tt_tensor(reciprocal_of_sqrt_hidden_dim_tensor, device)
 
-        return tt_lib.tensor.bcast(
+        return ttnn.experimental.tensor.bcast(
             x,
             reciprocal_of_sqrt_hidden_dim_tensor,
-            tt_lib.tensor.BcastOpMath.MUL,
-            tt_lib.tensor.BcastOpDim.HW,
+            ttnn.experimental.tensor.BcastOpMath.MUL,
+            ttnn.experimental.tensor.BcastOpDim.HW,
             output_mem_config=out_mem_config,
         )
 

--- a/models/experimental/distilbert/demo/gs_demo.py
+++ b/models/experimental/distilbert/demo/gs_demo.py
@@ -13,7 +13,7 @@ from models.utility_functions import (
 )
 
 from transformers import AutoTokenizer
-import tt_lib
+import ttnn
 from models.experimental.distilbert.tt.distilbert import *
 
 
@@ -22,9 +22,9 @@ from models.experimental.distilbert.tt.distilbert import *
     (("distilbert-base-uncased-distilled-squad"),),
 )
 def test_gs_demo(model_name):
-    device = tt_lib.device.CreateDevice(0)
+    device = ttnn.open_device(0)
 
-    tt_lib.device.SetDefaultDevice(device)
+    ttnn.experimental.device.SetDefaultDevice(device)
 
     tokenizer = AutoTokenizer.from_pretrained(model_name)
 
@@ -34,26 +34,18 @@ def test_gs_demo(model_name):
     )
     inputs = tokenizer(question, context, return_tensors="pt")
 
-    tt_attn_mask = torch_to_tt_tensor_rm(
-        inputs.attention_mask, device, put_on_device=False
-    )
+    tt_attn_mask = torch_to_tt_tensor_rm(inputs.attention_mask, device, put_on_device=False)
     with torch.no_grad():
         tt_model = distilbert_for_question_answering(device)
         tt_output = tt_model(inputs.input_ids, tt_attn_mask)
 
-        tt_start_logits_torch = (
-            tt_to_torch_tensor(tt_output.start_logits).squeeze(0).squeeze(0)
-        )
-        tt_end_logits_torch = (
-            tt_to_torch_tensor(tt_output.end_logits).squeeze(0).squeeze(0)
-        )
+        tt_start_logits_torch = tt_to_torch_tensor(tt_output.start_logits).squeeze(0).squeeze(0)
+        tt_end_logits_torch = tt_to_torch_tensor(tt_output.end_logits).squeeze(0).squeeze(0)
 
         answer_start_index = tt_start_logits_torch.argmax()
         answer_end_index = tt_end_logits_torch.argmax()
 
-        predict_answer_tokens = inputs.input_ids[
-            0, answer_start_index : answer_end_index + 1
-        ]
+        predict_answer_tokens = inputs.input_ids[0, answer_start_index : answer_end_index + 1]
 
         answer = tokenizer.decode(predict_answer_tokens, skip_special_tokens=True)
     logger.info("Context: ")
@@ -63,4 +55,4 @@ def test_gs_demo(model_name):
     logger.info("GS's Predicted answer: ")
     logger.info(answer)
 
-    tt_lib.device.CloseDevice(device)
+    ttnn.close_device(device)

--- a/models/experimental/distilbert/tests/test_perf_accuracy_distilbert.py
+++ b/models/experimental/distilbert/tests/test_perf_accuracy_distilbert.py
@@ -4,7 +4,7 @@
 
 import torch
 import pytest
-import tt_lib
+import ttnn
 import evaluate
 
 from loguru import logger
@@ -59,7 +59,7 @@ def run_perf_distilbert(expected_inference_time, expected_compile_time, device, 
 
         profiler.start(first_key)
         tt_output = tt_model(inputs.input_ids, tt_attn_mask)
-        tt_lib.device.Synchronize(device)
+        ttnn.synchronize_device(device)
         profiler.end(first_key)
         del tt_output
 
@@ -67,7 +67,7 @@ def run_perf_distilbert(expected_inference_time, expected_compile_time, device, 
 
         profiler.start(second_key)
         tt_output = tt_model(inputs.input_ids, tt_attn_mask)
-        tt_lib.device.Synchronize(device)
+        ttnn.synchronize_device(device)
         profiler.end(second_key)
         del tt_output
 
@@ -117,7 +117,7 @@ def run_perf_distilbert(expected_inference_time, expected_compile_time, device, 
         logger.info("F1 Score :")
         logger.info(eval_score["f1"])
 
-        tt_lib.device.Synchronize(device)
+        ttnn.synchronize_device(device)
         profiler.end(third_key)
 
     first_iter_time = profiler.get(first_key)

--- a/models/experimental/distilbert/tt/distilbert_embedding.py
+++ b/models/experimental/distilbert/tt/distilbert_embedding.py
@@ -11,7 +11,6 @@ from models.utility_functions import (
 )
 
 import ttnn
-import tt_lib
 
 
 class TtDistilBert_Embeddings(nn.Module):
@@ -50,8 +49,8 @@ class TtDistilBert_Embeddings(nn.Module):
     def forward(
         self,
         input_ids: torch.Tensor,
-        input_embeds: Optional[tt_lib.tensor.Tensor] = None,
-    ) -> tt_lib.tensor.Tensor:
+        input_embeds: Optional[ttnn.Tensor] = None,
+    ) -> ttnn.Tensor:
         """
         Torch tensor is passed as input for embedding to address low pcc
         """

--- a/models/experimental/distilbert/tt/distilbert_ffn.py
+++ b/models/experimental/distilbert/tt/distilbert_ffn.py
@@ -7,7 +7,7 @@ import torch.nn as nn
 from models.utility_functions import (
     torch_to_tt_tensor_rm,
 )
-import tt_lib
+import ttnn
 from models.helper_funcs import Linear as TtLinear
 
 
@@ -37,9 +37,9 @@ class TtFFN(nn.Module):
             self.linear_2_bias,
         )
 
-        self.activation = tt_lib.tensor.gelu
+        self.activation = ttnn.gelu
 
-    def forward(self, input: tt_lib.tensor.Tensor) -> tt_lib.tensor.Tensor:
+    def forward(self, input: ttnn.Tensor) -> ttnn.Tensor:
         x = self.linear1(input)
         x = self.activation(x)
         x = self.linear2(x)

--- a/models/experimental/distilbert/tt/distilbert_for_question_answering.py
+++ b/models/experimental/distilbert/tt/distilbert_for_question_answering.py
@@ -11,7 +11,7 @@ from models.utility_functions import (
     torch_to_tt_tensor_rm,
 )
 
-import tt_lib
+import ttnn
 from dataclasses import dataclass
 from models.experimental.distilbert.tt.distilbert_model import TtDistilBertModel
 from models.helper_funcs import Linear as TtLinear
@@ -19,11 +19,11 @@ from models.helper_funcs import Linear as TtLinear
 
 @dataclass
 class TtQuestionAnsweringModelOutput:
-    loss: Optional[tt_lib.tensor.Tensor] = None
-    start_logits: tt_lib.tensor.Tensor = None
-    end_logits: tt_lib.tensor.Tensor = None
-    hidden_states: Optional[Tuple[tt_lib.tensor.Tensor]] = None
-    attentions: Optional[Tuple[tt_lib.tensor.Tensor]] = None
+    loss: Optional[ttnn.Tensor] = None
+    start_logits: ttnn.Tensor = None
+    end_logits: ttnn.Tensor = None
+    hidden_states: Optional[Tuple[ttnn.Tensor]] = None
+    attentions: Optional[Tuple[ttnn.Tensor]] = None
 
 
 class TtDistilBertForQuestionAnswering(nn.Module):
@@ -51,16 +51,16 @@ class TtDistilBertForQuestionAnswering(nn.Module):
 
     def forward(
         self,
-        input_ids: Optional[tt_lib.tensor.Tensor] = None,
-        attention_mask: Optional[tt_lib.tensor.Tensor] = None,
-        head_mask: Optional[tt_lib.tensor.Tensor] = None,
-        inputs_embeds: Optional[tt_lib.tensor.Tensor] = None,
-        start_positions: Optional[tt_lib.tensor.Tensor] = None,
-        end_positions: Optional[tt_lib.tensor.Tensor] = None,
+        input_ids: Optional[ttnn.Tensor] = None,
+        attention_mask: Optional[ttnn.Tensor] = None,
+        head_mask: Optional[ttnn.Tensor] = None,
+        inputs_embeds: Optional[ttnn.Tensor] = None,
+        start_positions: Optional[ttnn.Tensor] = None,
+        end_positions: Optional[ttnn.Tensor] = None,
         output_attentions: Optional[bool] = None,
         output_hidden_states: Optional[bool] = None,
         return_dict: Optional[bool] = None,
-    ) -> Union[TtQuestionAnsweringModelOutput, Tuple[tt_lib.tensor.Tensor, ...]]:
+    ) -> Union[TtQuestionAnsweringModelOutput, Tuple[ttnn.Tensor, ...]]:
         return_dict = return_dict if return_dict is not None else self.config.use_return_dict
 
         distilbert_output = self.distilbert(

--- a/models/experimental/distilbert/tt/distilbert_model.py
+++ b/models/experimental/distilbert/tt/distilbert_model.py
@@ -10,7 +10,6 @@ from models.utility_functions import (
     torch_to_tt_tensor_rm,
 )
 
-import tt_lib
 import ttnn
 from dataclasses import dataclass
 
@@ -20,9 +19,9 @@ from models.experimental.distilbert.tt.distilbert_transformer import TtTransform
 
 @dataclass
 class TtBaseModelOutput:
-    last_hidden_state: tt_lib.tensor.Tensor = None
-    hidden_states: Optional[Tuple[tt_lib.tensor.Tensor]] = None
-    attentions: Optional[Tuple[tt_lib.tensor.Tensor]] = None
+    last_hidden_state: ttnn.Tensor = None
+    hidden_states: Optional[Tuple[ttnn.Tensor]] = None
+    attentions: Optional[Tuple[ttnn.Tensor]] = None
 
 
 class TtDistilBertModel(nn.Module):
@@ -59,10 +58,10 @@ class TtDistilBertModel(nn.Module):
 
     def get_head_mask(
         self,
-        head_mask: Optional[tt_lib.tensor.Tensor],
+        head_mask: Optional[ttnn.Tensor],
         num_hidden_layers: int,
         is_attention_chunked: bool = False,
-    ) -> tt_lib.tensor.Tensor:
+    ) -> ttnn.Tensor:
         if head_mask is not None:
             torch_head_mask = tt_to_torch_tensor(head_mask)
         else:
@@ -83,14 +82,14 @@ class TtDistilBertModel(nn.Module):
 
     def forward(
         self,
-        input_ids: Optional[tt_lib.tensor.Tensor] = None,
-        attention_mask: Optional[tt_lib.tensor.Tensor] = None,
-        head_mask: Optional[tt_lib.tensor.Tensor] = None,
-        inputs_embeds: Optional[tt_lib.tensor.Tensor] = None,
+        input_ids: Optional[ttnn.Tensor] = None,
+        attention_mask: Optional[ttnn.Tensor] = None,
+        head_mask: Optional[ttnn.Tensor] = None,
+        inputs_embeds: Optional[ttnn.Tensor] = None,
         output_attentions: Optional[bool] = None,
         output_hidden_states: Optional[bool] = None,
         return_dict: Optional[bool] = None,
-    ) -> Union[TtBaseModelOutput, Tuple[tt_lib.tensor.Tensor, ...]]:
+    ) -> Union[TtBaseModelOutput, Tuple[ttnn.Tensor, ...]]:
         output_attentions = output_attentions if output_attentions is not None else self.config.output_attentions
         output_hidden_states = (
             output_hidden_states if output_hidden_states is not None else self.config.output_hidden_states

--- a/models/experimental/distilbert/tt/distilbert_transformer.py
+++ b/models/experimental/distilbert/tt/distilbert_transformer.py
@@ -5,16 +5,16 @@
 from typing import Optional, Tuple, Union
 import torch.nn as nn
 
-import tt_lib
+import ttnn
 from dataclasses import dataclass
 from models.experimental.distilbert.tt.distilbert_transformer_block import TtTransformerBlock
 
 
 @dataclass
 class TtBaseModelOutput:
-    last_hidden_state: tt_lib.tensor.Tensor = None
-    hidden_states: Optional[Tuple[tt_lib.tensor.Tensor]] = None
-    attentions: Optional[Tuple[tt_lib.tensor.Tensor]] = None
+    last_hidden_state: ttnn.Tensor = None
+    hidden_states: Optional[Tuple[ttnn.Tensor]] = None
+    attentions: Optional[Tuple[ttnn.Tensor]] = None
 
 
 class TtTransformer(nn.Module):
@@ -40,13 +40,13 @@ class TtTransformer(nn.Module):
 
     def forward(
         self,
-        input: tt_lib.tensor.Tensor,
-        attn_mask: Optional[tt_lib.tensor.Tensor] = None,
-        head_mask: Optional[tt_lib.tensor.Tensor] = None,
+        input: ttnn.Tensor,
+        attn_mask: Optional[ttnn.Tensor] = None,
+        head_mask: Optional[ttnn.Tensor] = None,
         output_attentions: bool = False,
         output_hidden_states: bool = False,
         return_dict: Optional[bool] = None,
-    ) -> Union[TtBaseModelOutput, Tuple[tt_lib.tensor.Tensor, ...]]:
+    ) -> Union[TtBaseModelOutput, Tuple[ttnn.Tensor, ...]]:
         all_hidden_states = () if output_hidden_states else None
         all_attentions = () if output_attentions else None
 
@@ -65,28 +65,20 @@ class TtTransformer(nn.Module):
 
             if output_attentions:
                 if len(layer_outputs) != 2:
-                    raise ValueError(
-                        f"The length of the layer_outputs should be 2, but it is {len(layer_outputs)}"
-                    )
+                    raise ValueError(f"The length of the layer_outputs should be 2, but it is {len(layer_outputs)}")
 
                 attentions = layer_outputs[0]
                 all_attentions = all_attentions + (attentions,)
 
             else:
                 if len(layer_outputs) != 1:
-                    raise ValueError(
-                        f"The length of the layer_outputs should be 1, but it is {len(layer_outputs)}"
-                    )
+                    raise ValueError(f"The length of the layer_outputs should be 1, but it is {len(layer_outputs)}")
 
         if output_hidden_states:
             all_hidden_states = all_hidden_states + (hidden_state,)
 
         if return_dict:
-            return tuple(
-                v
-                for v in [hidden_state, all_hidden_states, all_attentions]
-                if v is not None
-            )
+            return tuple(v for v in [hidden_state, all_hidden_states, all_attentions] if v is not None)
         return TtBaseModelOutput(
             last_hidden_state=hidden_state,
             hidden_states=all_hidden_states,

--- a/models/experimental/distilbert/tt/distilbert_transformer_block.py
+++ b/models/experimental/distilbert/tt/distilbert_transformer_block.py
@@ -10,7 +10,6 @@ from models.utility_functions import (
 )
 
 import ttnn
-import tt_lib
 from models.experimental.distilbert.tt.distilbert_multihead_self_attention import (
     TtMultiHeadSelfAttention,
 )
@@ -54,11 +53,11 @@ class TtTransformerBlock(nn.Module):
 
     def forward(
         self,
-        input: tt_lib.tensor.Tensor,
-        attn_mask: Optional[tt_lib.tensor.Tensor] = None,
-        head_mask: Optional[tt_lib.tensor.Tensor] = None,
+        input: ttnn.Tensor,
+        attn_mask: Optional[ttnn.Tensor] = None,
+        head_mask: Optional[ttnn.Tensor] = None,
         output_attentions: bool = False,
-    ) -> Tuple[tt_lib.tensor.Tensor, ...]:
+    ) -> Tuple[ttnn.Tensor, ...]:
         sa_output = self.attention(
             query=input,
             key=input,


### PR DESCRIPTION
### Ticket
Link to Github Issue #11341 
Master Issue #11240

### Problem description
Replace tt_lib with ttnn in models/experimental/bert_tiny, models/experimental/distilbert

### Checklist
- [x] [Post commit CI passes](https://github.com/tenstorrent/tt-metal/actions/runs/10422478563)
- [x] Model regression CI testing passes (if applicable)
- [x] New/Existing tests provide coverage for changes
