### PR TITLE
Replace ttlib to ttnn yolo folder and util function

### DIFF
--- a/models/experimental/yolov3/demo/gs_demo.py
+++ b/models/experimental/yolov3/demo/gs_demo.py
@@ -9,8 +9,6 @@ import cv2
 from pathlib import Path
 from loguru import logger
 
-import tt_lib
-
 from models.experimental.yolov3.reference.models.common import DetectMultiBackend
 from models.experimental.yolov3.tt.yolov3_detection_model import (
     yolov3_fused_model,
@@ -32,6 +30,7 @@ from models.utility_functions import torch2tt_tensor
 
 f = f"{Path(__file__).parent}"
 
+
 def test_gs_demo(model_location_generator, device):
     torch.manual_seed(1234)
 
@@ -44,9 +43,7 @@ def test_gs_demo(model_location_generator, device):
     model_config_path = str(data_path / "yolov3.yaml")
     weights_loc = str(model_path / "yolov3.pt")
 
-    reference_model = DetectMultiBackend(
-        weights_loc, device=torch.device("cpu"), dnn=False, data=data_coco, fp16=False
-    )
+    reference_model = DetectMultiBackend(weights_loc, device=torch.device("cpu"), dnn=False, data=data_coco, fp16=False)
     reference_model = reference_model.model
 
     tt_module = yolov3_fused_model(device, model_location_generator)
@@ -77,9 +74,7 @@ def test_gs_demo(model_location_generator, device):
         conf_thres, iou_thres = 0.25, 0.45
         classes = None  # filter by class
         agnostic_nms = False
-        pred = non_max_suppression(
-            pred, conf_thres, iou_thres, classes, agnostic_nms, max_det=1000
-        )
+        pred = non_max_suppression(pred, conf_thres, iou_thres, classes, agnostic_nms, max_det=1000)
 
         # Process predictions
         for i, det in enumerate(pred):  # per image
@@ -107,11 +102,7 @@ def test_gs_demo(model_location_generator, device):
                 # Write results
                 for *xyxy, conf, cls in reversed(det):
                     if True:  # Write to file
-                        xywh = (
-                            (xyxy2xywh(torch.tensor(xyxy).view(1, 4)) / gn)
-                            .view(-1)
-                            .tolist()
-                        )  # normalized xywh
+                        xywh = (xyxy2xywh(torch.tensor(xyxy).view(1, 4)) / gn).view(-1).tolist()  # normalized xywh
                         line = (cls, *xywh)  # label format
                     # Add bbox to image
                     c = int(cls)  # integer class

--- a/models/experimental/yolov3/tests/perf_yolov3.py
+++ b/models/experimental/yolov3/tests/perf_yolov3.py
@@ -8,7 +8,7 @@ import torch
 from loguru import logger
 
 
-import tt_lib
+import ttnn
 from models.experimental.yolov3.reference.models.common import DetectMultiBackend
 from models.experimental.yolov3.tt.yolov3_detection_model import TtDetectionModel
 from models.experimental.yolov3.reference.models.common import autopad
@@ -69,7 +69,7 @@ def test_perf(device, use_program_cache, model_location_generator):
         if len(im.shape) == 3:
             im = im[None]
 
-        tt_im = torch2tt_tensor(im, device, tt_layout=tt_lib.tensor.Layout.ROW_MAJOR)
+        tt_im = torch2tt_tensor(im, device, tt_layout=ttnn.ROW_MAJOR_LAYOUT)
 
         profiler.start(cpu_key)
         pt_out = reference_model(im)

--- a/models/experimental/yolov3/tests/test_perf_accuracy_yolov3.py
+++ b/models/experimental/yolov3/tests/test_perf_accuracy_yolov3.py
@@ -4,7 +4,7 @@
 
 import os
 import torch
-import tt_lib
+import ttnn
 import pytest
 import numpy as np
 
@@ -75,17 +75,17 @@ def run_perf_yolov3(expected_inference_time, expected_compile_time, model_locati
     if len(im.shape) == 3:
         im = im[None]
 
-    tt_im = torch2tt_tensor(im, device, tt_layout=tt_lib.tensor.Layout.ROW_MAJOR)
+    tt_im = torch2tt_tensor(im, device, tt_layout=ttnn.ROW_MAJOR_LAYOUT)
 
     with torch.no_grad():
         profiler.start(cpu_key)
         pt_out = reference_model(im)
-        tt_lib.device.Synchronize(device)
+        ttnn.synchronize_device(device)
         profiler.end(cpu_key)
 
         profiler.start(first_key)
         tt_out = tt_module(tt_im)
-        tt_lib.device.Synchronize(device)
+        ttnn.synchronize_device(device)
         profiler.end(first_key)
         del tt_out
 
@@ -93,7 +93,7 @@ def run_perf_yolov3(expected_inference_time, expected_compile_time, model_locati
 
         profiler.start(second_key)
         tt_out = tt_module(tt_im)
-        tt_lib.device.Synchronize(device)
+        ttnn.synchronize_device(device)
         profiler.end(second_key)
         del tt_out
 
@@ -187,7 +187,7 @@ def run_perf_yolov3(expected_inference_time, expected_compile_time, model_locati
             target_cls=gt_classes,
         )
         ap_list.append(ap)
-        tt_lib.device.Synchronize(device)
+        ttnn.synchronize_device(device)
         profiler.end(third_key)
 
     mAP = np.mean(ap_list)

--- a/models/experimental/yolov3/tests/test_yolov3_bottleneck.py
+++ b/models/experimental/yolov3/tests/test_yolov3_bottleneck.py
@@ -6,9 +6,6 @@ import torch
 
 from loguru import logger
 
-import tt_lib
-
-
 from models.experimental.yolov3.reference.utils.dataloaders import LoadImages
 from models.experimental.yolov3.reference.utils.general import check_img_size
 from models.experimental.yolov3.reference.models.yolo import Bottleneck
@@ -36,9 +33,7 @@ def test_bottleneck_module(model_location_generator, device):
     model_config_path = str(data_path / "yolov3.yaml")
     weights_loc = str(model_path / "yolov3.pt")
 
-    reference_model = DetectMultiBackend(
-        weights_loc, device=torch.device("cpu"), dnn=False, data=data_coco, fp16=False
-    )
+    reference_model = DetectMultiBackend(weights_loc, device=torch.device("cpu"), dnn=False, data=data_coco, fp16=False)
 
     state_dict = reference_model.state_dict()
 

--- a/models/experimental/yolov3/tests/test_yolov3_concat.py
+++ b/models/experimental/yolov3/tests/test_yolov3_concat.py
@@ -6,9 +6,7 @@ import torch
 
 from loguru import logger
 
-
-
-import tt_lib
+import ttnn
 
 from models.experimental.yolov3.reference.models.common import (
     autopad,
@@ -38,9 +36,7 @@ def test_concat_module(device, model_location_generator):
     model_config_path = str(data_path / "yolov3.yaml")
     weights_loc = str(model_path / "yolov3.pt")
 
-    reference_model = DetectMultiBackend(
-        weights_loc, device=torch.device("cpu"), dnn=False, data=data_coco, fp16=False
-    )
+    reference_model = DetectMultiBackend(weights_loc, device=torch.device("cpu"), dnn=False, data=data_coco, fp16=False)
     state_dict = reference_model.state_dict()
 
     INDEX = 18
@@ -60,8 +56,8 @@ def test_concat_module(device, model_location_generator):
     # Inference
     pred = torch_model([im_1, im_2])
 
-    tt_im_1 = torch2tt_tensor(im_1, device, tt_layout=tt_lib.tensor.Layout.ROW_MAJOR)
-    tt_im_2 = torch2tt_tensor(im_2, device, tt_layout=tt_lib.tensor.Layout.ROW_MAJOR)
+    tt_im_1 = torch2tt_tensor(im_1, device, tt_layout=ttnn.ROW_MAJOR_LAYOUT)
+    tt_im_2 = torch2tt_tensor(im_2, device, tt_layout=ttnn.ROW_MAJOR_LAYOUT)
     x = [tt_im_1, tt_im_2]
     tt_pred = tt_model(x)
 

--- a/models/experimental/yolov3/tests/test_yolov3_conv.py
+++ b/models/experimental/yolov3/tests/test_yolov3_conv.py
@@ -6,8 +6,6 @@ import torch
 
 from loguru import logger
 
-import tt_lib
-
 from models.experimental.yolov3.reference.models.common import (
     autopad,
     DetectMultiBackend,
@@ -35,9 +33,7 @@ def test_conv_module(device, model_location_generator):
     model_config_path = str(data_path / "yolov3.yaml")
     weights_loc = str(model_path / "yolov3.pt")
 
-    reference_model = DetectMultiBackend(
-        weights_loc, device=torch.device("cpu"), dnn=False, data=data_coco, fp16=False
-    )
+    reference_model = DetectMultiBackend(weights_loc, device=torch.device("cpu"), dnn=False, data=data_coco, fp16=False)
     state_dict = reference_model.state_dict()
 
     INDEX = 0

--- a/models/experimental/yolov3/tests/test_yolov3_conv2d.py
+++ b/models/experimental/yolov3/tests/test_yolov3_conv2d.py
@@ -6,7 +6,7 @@ import torch
 
 from loguru import logger
 
-import tt_lib
+import ttnn
 
 from models.experimental.yolov3.reference.models.common import (
     autopad,
@@ -38,9 +38,7 @@ def test_conv2d_module(device, model_location_generator):
     model_config_path = str(data_path / "yolov3.yaml")
     weights_loc = str(model_path / "yolov3.pt")
 
-    reference_model = DetectMultiBackend(
-        weights_loc, device=torch.device("cpu"), dnn=False, data=data_coco, fp16=False
-    )
+    reference_model = DetectMultiBackend(weights_loc, device=torch.device("cpu"), dnn=False, data=data_coco, fp16=False)
     state_dict = reference_model.state_dict()
     torch_model = reference_model.model.model[INDEX].conv
 
@@ -93,7 +91,7 @@ def test_conv2d_module(device, model_location_generator):
 
     # Compare PCC
     tt_out = tt_out.cpu()
-    tt_out = tt_out.to(tt_lib.tensor.Layout.ROW_MAJOR)
+    tt_out = tt_out.to(ttnn.ROW_MAJOR_LAYOUT)
 
     tt_out = tt2torch_tensor(tt_out)
 

--- a/models/experimental/yolov3/tests/test_yolov3_detect.py
+++ b/models/experimental/yolov3/tests/test_yolov3_detect.py
@@ -6,7 +6,7 @@ import torch
 
 from loguru import logger
 
-import tt_lib
+import ttnn
 
 from models.experimental.yolov3.reference.models.common import (
     autopad,
@@ -33,9 +33,7 @@ def test_detect_module(device, model_location_generator):
     model_config_path = str(data_path / "yolov3.yaml")
     weights_loc = str(model_path / "yolov3.pt")
 
-    reference_model = DetectMultiBackend(
-        weights_loc, device=torch.device("cpu"), dnn=False, data=data_coco, fp16=False
-    )
+    reference_model = DetectMultiBackend(weights_loc, device=torch.device("cpu"), dnn=False, data=data_coco, fp16=False)
 
     state_dict = reference_model.state_dict()
 
@@ -73,9 +71,9 @@ def test_detect_module(device, model_location_generator):
         torch_model.eval()
         pt_out = torch_model(test_input)
 
-    tt_a = torch2tt_tensor(a, device, tt_layout=tt_lib.tensor.Layout.ROW_MAJOR)
-    tt_b = torch2tt_tensor(b, device, tt_layout=tt_lib.tensor.Layout.ROW_MAJOR)
-    tt_c = torch2tt_tensor(c, device, tt_layout=tt_lib.tensor.Layout.ROW_MAJOR)
+    tt_a = torch2tt_tensor(a, device, tt_layout=ttnn.ROW_MAJOR_LAYOUT)
+    tt_b = torch2tt_tensor(b, device, tt_layout=ttnn.ROW_MAJOR_LAYOUT)
+    tt_c = torch2tt_tensor(c, device, tt_layout=ttnn.ROW_MAJOR_LAYOUT)
     tt_test_input = [tt_a, tt_b, tt_c]
 
     with torch.no_grad():

--- a/models/experimental/yolov3/tests/test_yolov3_detection_model.py
+++ b/models/experimental/yolov3/tests/test_yolov3_detection_model.py
@@ -6,7 +6,7 @@ import torch
 
 from loguru import logger
 
-import tt_lib
+import ttnn
 
 from models.experimental.yolov3.reference.models.common import (
     autopad,
@@ -34,9 +34,7 @@ def test_detection_model(device, model_location_generator):
     data_coco = str(data_path / "coco128.yaml")
     weights_loc = str(model_path / "yolov3.pt")
 
-    reference_model = DetectMultiBackend(
-        weights_loc, device=torch.device("cpu"), dnn=False, data=data_coco, fp16=False
-    )
+    reference_model = DetectMultiBackend(weights_loc, device=torch.device("cpu"), dnn=False, data=data_coco, fp16=False)
     reference_model = reference_model.model
 
     tt_module = yolov3_fused_model(device, model_location_generator)
@@ -59,7 +57,7 @@ def test_detection_model(device, model_location_generator):
         # Inference- fused torch
         pt_out = reference_model(im)
         # Inference- fused tt
-        tt_im = torch2tt_tensor(im, device, tt_layout=tt_lib.tensor.Layout.ROW_MAJOR)
+        tt_im = torch2tt_tensor(im, device, tt_layout=ttnn.ROW_MAJOR_LAYOUT)
         tt_out = tt_module(tt_im)
 
     # Check all outputs PCC

--- a/models/experimental/yolov3/tests/test_yolov3_upsample.py
+++ b/models/experimental/yolov3/tests/test_yolov3_upsample.py
@@ -6,7 +6,7 @@ import torch
 
 from loguru import logger
 
-import tt_lib
+import ttnn
 
 from models.experimental.yolov3.reference.models.common import (
     autopad,
@@ -34,9 +34,7 @@ def test_upsample_module(device, model_location_generator):
     model_config_path = str(data_path / "yolov3.yaml")
     weights_loc = str(model_path / "yolov3.pt")
 
-    reference_model = DetectMultiBackend(
-        weights_loc, device=torch.device("cpu"), dnn=False, data=data_coco, fp16=False
-    )
+    reference_model = DetectMultiBackend(weights_loc, device=torch.device("cpu"), dnn=False, data=data_coco, fp16=False)
     state_dict = reference_model.state_dict()
 
     INDEX = 17
@@ -57,7 +55,7 @@ def test_upsample_module(device, model_location_generator):
     # Inference
     pred = torch_model(im)
 
-    tt_im = torch2tt_tensor(im, device, tt_layout=tt_lib.tensor.Layout.ROW_MAJOR)
+    tt_im = torch2tt_tensor(im, device, tt_layout=ttnn.ROW_MAJOR_LAYOUT)
     tt_pred = tt_model(tt_im)
 
     # Compare outputs

--- a/models/experimental/yolov3/tt/yolov3_bottleneck.py
+++ b/models/experimental/yolov3/tt/yolov3_bottleneck.py
@@ -13,8 +13,6 @@ from models.experimental.yolov3.reference.models.common import autopad
 from models.experimental.yolov3.tt.yolov3_conv import TtConv
 
 import ttnn
-import tt_lib
-from tt_lib.fallback_ops import fallback_ops
 from models.utility_functions import torch2tt_tensor, tt2torch_tensor
 
 

--- a/models/experimental/yolov3/tt/yolov3_concat.py
+++ b/models/experimental/yolov3/tt/yolov3_concat.py
@@ -10,9 +10,7 @@ import sys
 import torch
 
 from models.experimental.yolov3.reference.models.common import autopad
-import tt_lib
 import ttnn
-from tt_lib.fallback_ops import fallback_ops
 from models.utility_functions import torch2tt_tensor, tt2torch_tensor
 
 

--- a/models/experimental/yolov3/tt/yolov3_conv.py
+++ b/models/experimental/yolov3/tt/yolov3_conv.py
@@ -13,7 +13,6 @@ import ttnn
 from models.experimental.yolov3.tt.yolov3_conv2d import TtConv2D
 from models.experimental.yolov3.reference.models.common import autopad
 from models.experimental.yolov3.reference.models.yolo import Conv, Model
-import tt_lib
 from models.utility_functions import (
     torch2tt_tensor,
     tt2torch_tensor,
@@ -59,7 +58,7 @@ class TtConv(nn.Module):
         self.act = act
         if self.act != True:
             logger.warning(
-                f"Configuration for activation function {self.act} not supported. Using tt_lib.tensor.SiLU act function"
+                f"Configuration for activation function {self.act} not supported. Using ttnn.SiLU act function"
             )
             raise NotImplementedError
 

--- a/models/experimental/yolov3/tt/yolov3_conv2d.py
+++ b/models/experimental/yolov3/tt/yolov3_conv2d.py
@@ -12,7 +12,7 @@ import torch
 from models.experimental.yolov3.reference.models.common import autopad
 from models.experimental.yolov3.reference.models.yolo import Conv, Model
 import ttnn
-from ttnn.fallback_ops import fallback_ops
+from tt_lib.fallback_ops import fallback_ops
 from models.utility_functions import (
     torch2tt_tensor,
     tt2torch_tensor,

--- a/models/experimental/yolov3/tt/yolov3_conv2d.py
+++ b/models/experimental/yolov3/tt/yolov3_conv2d.py
@@ -11,8 +11,8 @@ import torch
 
 from models.experimental.yolov3.reference.models.common import autopad
 from models.experimental.yolov3.reference.models.yolo import Conv, Model
-import tt_lib
-from tt_lib.fallback_ops import fallback_ops
+import ttnn
+from ttnn.fallback_ops import fallback_ops
 from models.utility_functions import (
     torch2tt_tensor,
     tt2torch_tensor,
@@ -70,14 +70,8 @@ class TtConv2D(torch.nn.Module):
         else:
             self.conv_on_device = False
 
-            self.conv_weight = torch_to_tt_tensor_rm(
-                self.conv_weight, self.device, put_on_device=False
-            )
-            self.conv_bias = (
-                torch_to_tt_tensor_rm(self.conv_bias, self.device)
-                if self.conv_bias is not None
-                else None
-            )
+            self.conv_weight = torch_to_tt_tensor_rm(self.conv_weight, self.device, put_on_device=False)
+            self.conv_bias = torch_to_tt_tensor_rm(self.conv_bias, self.device) if self.conv_bias is not None else None
 
             self.conv = fallback_ops.Conv2d(
                 weights=self.conv_weight,
@@ -97,9 +91,7 @@ class TtConv2D(torch.nn.Module):
             x = tt2torch_tensor(x)
             x = self.conv(x)
             x = x + self.conv_bias
-            x = torch2tt_tensor(
-                x, self.device, tt_layout=tt_lib.tensor.Layout.ROW_MAJOR
-            )
+            x = torch2tt_tensor(x, self.device, tt_layout=ttnn.ROW_MAJOR_LAYOUT)
         else:
             x = self.conv(x)
 

--- a/models/experimental/yolov3/tt/yolov3_detect.py
+++ b/models/experimental/yolov3/tt/yolov3_detect.py
@@ -11,8 +11,7 @@ import torch
 
 from models.experimental.yolov3.reference.models.common import autopad
 from models.experimental.yolov3.tt.yolov3_conv import TtConv
-import tt_lib
-from tt_lib.fallback_ops import fallback_ops
+from ttnn.fallback_ops import fallback_ops
 from models.utility_functions import (
     torch2tt_tensor,
     tt2torch_tensor,
@@ -26,9 +25,7 @@ class TtDetect(nn.Module):
     dynamic = False  # force grid reconstruction
     export = False  # export mode
 
-    def __init__(
-        self, device, state_dict, base_address, nc=80, anchors=(), ch=(), inplace=True
-    ):
+    def __init__(self, device, state_dict, base_address, nc=80, anchors=(), ch=(), inplace=True):
         # detection layer
         super().__init__()
 
@@ -44,9 +41,7 @@ class TtDetect(nn.Module):
         self.grid = [torch.empty(0) for _ in range(self.nl)]  # init grid
 
         self.anchor_grid = [torch.empty(0) for _ in range(self.nl)]  # init anchor grid
-        self.register_buffer(
-            "anchors", torch.tensor(anchors).float().view(self.nl, -1, 2)
-        )  # shape(nl,na,2)
+        self.register_buffer("anchors", torch.tensor(anchors).float().view(self.nl, -1, 2))  # shape(nl,na,2)
 
         conv_list = []
         for i, x in enumerate(ch):
@@ -86,13 +81,8 @@ class TtDetect(nn.Module):
 
             bs, _, ny, nx = x[i].shape  # x(bs,255,20,20) to x(bs,3,20,20,85)
 
-            # Cannot be ported further until 5d tensors are supported for tt_lib ops
-            x[i] = (
-                x[i]
-                .view(bs, self.na, self.no, ny, nx)
-                .permute(0, 1, 3, 4, 2)
-                .contiguous()
-            )
+            # Cannot be ported further until 5d tensors are supported for ttnn ops
+            x[i] = x[i].view(bs, self.na, self.no, ny, nx).permute(0, 1, 3, 4, 2).contiguous()
 
             if not self.training:  # inference
                 if self.dynamic or self.grid[i].shape[2:4] != x[i].shape[2:4]:
@@ -106,13 +96,7 @@ class TtDetect(nn.Module):
                 y = torch.cat((xy, wh, conf), 4)
                 z.append(y.view(bs, self.na * nx * ny, self.no))
 
-        return (
-            x
-            if self.training
-            else (torch.cat(z, 1),)
-            if self.export
-            else (torch.cat(z, 1), x)
-        )
+        return x if self.training else (torch.cat(z, 1),) if self.export else (torch.cat(z, 1), x)
 
     def _make_grid(self, nx=20, ny=20, i=0):
         d = self.anchors[i].device
@@ -120,10 +104,6 @@ class TtDetect(nn.Module):
         shape = 1, self.na, ny, nx, 2  # grid shape
         y, x = torch.arange(ny, device=d, dtype=t), torch.arange(nx, device=d, dtype=t)
         yv, xv = torch.meshgrid(y, x, indexing="ij")
-        grid = (
-            torch.stack((xv, yv), 2).expand(shape) - 0.5
-        )  # add grid offset, i.e. y = 2.0 * x - 0.5
-        anchor_grid = (
-            (self.anchors[i] * self.stride[i]).view((1, self.na, 1, 1, 2)).expand(shape)
-        )
+        grid = torch.stack((xv, yv), 2).expand(shape) - 0.5  # add grid offset, i.e. y = 2.0 * x - 0.5
+        anchor_grid = (self.anchors[i] * self.stride[i]).view((1, self.na, 1, 1, 2)).expand(shape)
         return grid, anchor_grid

--- a/models/experimental/yolov3/tt/yolov3_detect.py
+++ b/models/experimental/yolov3/tt/yolov3_detect.py
@@ -11,7 +11,7 @@ import torch
 
 from models.experimental.yolov3.reference.models.common import autopad
 from models.experimental.yolov3.tt.yolov3_conv import TtConv
-from ttnn.fallback_ops import fallback_ops
+from tt_lib.fallback_ops import fallback_ops
 from models.utility_functions import (
     torch2tt_tensor,
     tt2torch_tensor,

--- a/models/experimental/yolov3/tt/yolov3_upsample.py
+++ b/models/experimental/yolov3/tt/yolov3_upsample.py
@@ -3,9 +3,8 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import torch
-import tt_lib
+import ttnn
 from loguru import logger
-from tt_lib.fallback_ops import fallback_ops
 from models.utility_functions import torch2tt_tensor, tt2torch_tensor
 
 
@@ -22,12 +21,10 @@ class TtUpsample(torch.nn.Module):
     ):
         super().__init__()
         self.device = device
-        self.upsample = torch.nn.Upsample(
-            size=size, scale_factor=scale_factor, mode=mode
-        )
+        self.upsample = torch.nn.Upsample(size=size, scale_factor=scale_factor, mode=mode)
 
     def forward(self, x):
         x = tt2torch_tensor(x)
         x = self.upsample(x)
-        x = torch2tt_tensor(x, self.device, tt_layout=tt_lib.tensor.Layout.ROW_MAJOR)
+        x = torch2tt_tensor(x, self.device, tt_layout=ttnn.ROW_MAJOR_LAYOUT)
         return x

--- a/models/experimental/yolov4/ttnn/neck.py
+++ b/models/experimental/yolov4/ttnn/neck.py
@@ -5,7 +5,7 @@
 import torch
 import ttnn
 from models.experimental.yolov4.ttnn.common import Conv
-from tt_lib.fallback_ops import fallback_ops
+from ttnn.fallback_ops import fallback_ops
 
 
 class TtNeck:

--- a/models/experimental/yolov4/ttnn/neck.py
+++ b/models/experimental/yolov4/ttnn/neck.py
@@ -5,7 +5,7 @@
 import torch
 import ttnn
 from models.experimental.yolov4.ttnn.common import Conv
-from ttnn.fallback_ops import fallback_ops
+from tt_lib.fallback_ops import fallback_ops
 
 
 class TtNeck:

--- a/models/experimental/yolov5/demo/gs_demo.py
+++ b/models/experimental/yolov5/demo/gs_demo.py
@@ -13,7 +13,6 @@ if str(ROOT) not in sys.path:
     sys.path.append(str(ROOT))  # add ROOT to PATH
 ROOT = Path(os.path.relpath(ROOT, Path.cwd()))  # relative
 
-import tt_lib
 import torch
 import cv2
 from loguru import logger

--- a/models/experimental/yolov5/tests/perf_yolov5.py
+++ b/models/experimental/yolov5/tests/perf_yolov5.py
@@ -3,7 +3,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import torch
-import tt_lib
 
 from models.experimental.yolov5.reference.models.common import DetectMultiBackend
 from models.experimental.yolov5.tt.yolov5_detection_model import (

--- a/models/experimental/yolov5/tests/test_perf_accuracy_yolov5.py
+++ b/models/experimental/yolov5/tests/test_perf_accuracy_yolov5.py
@@ -5,7 +5,7 @@
 import os
 import sys
 import torch
-import tt_lib
+import ttnn
 import pytest
 import numpy as np
 
@@ -82,12 +82,12 @@ def run_perf_yolov5s(
 
         profiler.start(cpu_key)
         logits = refence_module(test_input)
-        tt_lib.device.Synchronize(device)
+        ttnn.synchronize_device(device)
         profiler.end(cpu_key)
 
         profiler.start(first_key)
         tt_output = tt_module(tt_inputs)
-        tt_lib.device.Synchronize(device)
+        ttnn.synchronize_device(device)
         profiler.end(first_key)
         del tt_output
 
@@ -95,7 +95,7 @@ def run_perf_yolov5s(
 
         profiler.start(second_key)
         tt_output = tt_module(tt_inputs)
-        tt_lib.device.Synchronize(device)
+        ttnn.synchronize_device(device)
         profiler.end(second_key)
         del tt_output
 
@@ -166,7 +166,7 @@ def run_perf_yolov5s(
         )
         ap_list.append(ap)
 
-        tt_lib.device.Synchronize(device)
+        ttnn.synchronize_device(device)
         profiler.end(third_key)
 
     mAP = np.mean(ap_list)

--- a/models/experimental/yolov5/tests/test_yolov5_bottleneck.py
+++ b/models/experimental/yolov5/tests/test_yolov5_bottleneck.py
@@ -2,7 +2,6 @@
 
 # SPDX-License-Identifier: Apache-2.0
 
-import tt_lib
 import torch
 from loguru import logger
 
@@ -21,9 +20,7 @@ def test_Yolov5_bottleneck(device):
     data = None
     half = False
 
-    refence_model = DetectMultiBackend(
-        weights, device=torch.device("cpu"), dnn=dnn, data=data, fp16=half
-    )
+    refence_model = DetectMultiBackend(weights, device=torch.device("cpu"), dnn=dnn, data=data, fp16=half)
     refence_module = refence_model.model.model[2].m[0]
 
     in_channels = refence_module.cv1.conv.in_channels

--- a/models/experimental/yolov5/tests/test_yolov5_c3.py
+++ b/models/experimental/yolov5/tests/test_yolov5_c3.py
@@ -2,7 +2,6 @@
 
 # SPDX-License-Identifier: Apache-2.0
 
-import tt_lib
 import torch
 from loguru import logger
 
@@ -21,9 +20,7 @@ def test_Yolov5_c3(device):
     data = None
     half = False
 
-    refence_model = DetectMultiBackend(
-        weights, device=torch.device("cpu"), dnn=dnn, data=data, fp16=half
-    )
+    refence_model = DetectMultiBackend(weights, device=torch.device("cpu"), dnn=dnn, data=data, fp16=half)
     refence_module = refence_model.model.model[2]
 
     in_channels = refence_module.cv1.conv.in_channels

--- a/models/experimental/yolov5/tests/test_yolov5_concat.py
+++ b/models/experimental/yolov5/tests/test_yolov5_concat.py
@@ -13,7 +13,6 @@ if str(ROOT) not in sys.path:
     sys.path.append(str(ROOT))  # add ROOT to PATH
 ROOT = Path(os.path.relpath(ROOT, Path.cwd()))  # relative
 
-import tt_lib
 import torch
 from loguru import logger
 

--- a/models/experimental/yolov5/tests/test_yolov5_conv.py
+++ b/models/experimental/yolov5/tests/test_yolov5_conv.py
@@ -3,11 +3,10 @@
 # SPDX-License-Identifier: Apache-2.0
 
 
-import tt_lib
+import ttnn
 import torch
 from loguru import logger
 import ttnn
-from tt_lib.fallback_ops import fallback_ops
 from models.experimental.yolov5.reference.models.common import DetectMultiBackend
 from models.experimental.yolov5.tt.yolov5_conv import TtYolov5Conv, TtYolov5Conv2D
 from models.utility_functions import (
@@ -65,7 +64,7 @@ def test_Yolov5_Conv2D(device):
     tt_out = tt_module(test_input)
 
     tt_out = tt_out.cpu()
-    tt_out = tt_out.to(tt_lib.tensor.Layout.ROW_MAJOR)
+    tt_out = tt_out.to(ttnn.ROW_MAJOR_LAYOUT)
 
     tt_out = tt2torch_tensor(tt_out)
 
@@ -223,7 +222,7 @@ def test_Yolov5_Conv2D_real(device):
     tt_out = tt_module(test_input)
 
     tt_out = tt_out.cpu()
-    tt_out = tt_out.to(tt_lib.tensor.Layout.ROW_MAJOR)
+    tt_out = tt_out.to(ttnn.ROW_MAJOR_LAYOUT)
 
     tt_out = tt2torch_tensor(tt_out)
 

--- a/models/experimental/yolov5/tests/test_yolov5_detect.py
+++ b/models/experimental/yolov5/tests/test_yolov5_detect.py
@@ -3,8 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 
-
-import tt_lib
+import ttnn
 import torch
 from loguru import logger
 
@@ -22,9 +21,7 @@ def test_Yolov5_detect(device):
     data = None
     half = False
 
-    refence_model = DetectMultiBackend(
-        weights, device=torch.device("cpu"), dnn=dnn, data=data, fp16=half
-    )
+    refence_model = DetectMultiBackend(weights, device=torch.device("cpu"), dnn=dnn, data=data, fp16=half)
     refence_module = refence_model.model.model[24]
 
     torch.manual_seed(0)
@@ -58,15 +55,9 @@ def test_Yolov5_detect(device):
     tt_module.anchors = refence_module.anchors
     tt_module.stride = torch.tensor([8.0, 16.0, 32.0])
 
-    tt_a = torch2tt_tensor(
-        a, tt_device=device, tt_layout=tt_lib.tensor.Layout.ROW_MAJOR
-    )
-    tt_b = torch2tt_tensor(
-        b, tt_device=device, tt_layout=tt_lib.tensor.Layout.ROW_MAJOR
-    )
-    tt_c = torch2tt_tensor(
-        c, tt_device=device, tt_layout=tt_lib.tensor.Layout.ROW_MAJOR
-    )
+    tt_a = torch2tt_tensor(a, tt_device=device, tt_layout=ttnn.ROW_MAJOR_LAYOUT)
+    tt_b = torch2tt_tensor(b, tt_device=device, tt_layout=ttnn.ROW_MAJOR_LAYOUT)
+    tt_c = torch2tt_tensor(c, tt_device=device, tt_layout=ttnn.ROW_MAJOR_LAYOUT)
     test_input = [tt_a, tt_b, tt_c]
 
     with torch.no_grad():

--- a/models/experimental/yolov5/tests/test_yolov5_detection_model.py
+++ b/models/experimental/yolov5/tests/test_yolov5_detection_model.py
@@ -12,7 +12,6 @@ if str(ROOT) not in sys.path:
     sys.path.append(str(ROOT))  # add ROOT to PATH
 ROOT = Path(os.path.relpath(ROOT, Path.cwd()))  # relative
 
-import tt_lib
 import torch
 from loguru import logger
 from datasets import load_dataset

--- a/models/experimental/yolov5/tests/test_yolov5_sppf.py
+++ b/models/experimental/yolov5/tests/test_yolov5_sppf.py
@@ -3,7 +3,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
 
-import tt_lib
 import torch
 from loguru import logger
 
@@ -22,9 +21,7 @@ def test_Yolov5_sppf(device):
     data = None
     half = False
 
-    refence_model = DetectMultiBackend(
-        weights, device=torch.device("cpu"), dnn=dnn, data=data, fp16=half
-    )
+    refence_model = DetectMultiBackend(weights, device=torch.device("cpu"), dnn=dnn, data=data, fp16=half)
     refence_module = refence_model.model.model[9]
 
     in_channels = refence_module.cv1.conv.in_channels

--- a/models/experimental/yolov5/tt/yolov5_bottleneck.py
+++ b/models/experimental/yolov5/tt/yolov5_bottleneck.py
@@ -3,7 +3,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import torch
-import tt_lib
 from models.experimental.yolov5.tt.yolov5_conv import TtYolov5Conv
 
 

--- a/models/experimental/yolov5/tt/yolov5_c3.py
+++ b/models/experimental/yolov5/tt/yolov5_c3.py
@@ -3,7 +3,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import torch
-import tt_lib
 
 from models.experimental.yolov5.tt.yolov5_conv import TtYolov5Conv
 from models.experimental.yolov5.tt.yolov5_bottleneck import TtYolov5Bottleneck

--- a/models/experimental/yolov5/tt/yolov5_concat.py
+++ b/models/experimental/yolov5/tt/yolov5_concat.py
@@ -3,7 +3,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import torch
-import tt_lib as ttl
 import ttnn
 
 

--- a/models/experimental/yolov5/tt/yolov5_conv.py
+++ b/models/experimental/yolov5/tt/yolov5_conv.py
@@ -5,7 +5,7 @@
 import torch
 import ttnn
 from loguru import logger
-from ttnn.fallback_ops import fallback_ops
+from tt_lib.fallback_ops import fallback_ops
 from models.utility_functions import (
     torch2tt_tensor,
     tt2torch_tensor,

--- a/models/experimental/yolov5/tt/yolov5_conv.py
+++ b/models/experimental/yolov5/tt/yolov5_conv.py
@@ -3,11 +3,9 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import torch
-import tt_lib
 import ttnn
 from loguru import logger
-from tt_lib.fallback_ops import fallback_ops
-
+from ttnn.fallback_ops import fallback_ops
 from models.utility_functions import (
     torch2tt_tensor,
     tt2torch_tensor,
@@ -90,7 +88,7 @@ class TtYolov5Conv2D(torch.nn.Module):
         if self.conv_on_device:
             x = self.conv(x)
             x = x + self.conv_bias
-            x = torch2tt_tensor(x, self.device, tt_layout=tt_lib.tensor.Layout.ROW_MAJOR)
+            x = torch2tt_tensor(x, self.device, tt_layout=ttnn.ROW_MAJOR_LAYOUT)
         else:
             x = self.conv(x)
 

--- a/models/experimental/yolov5/tt/yolov5_detect.py
+++ b/models/experimental/yolov5/tt/yolov5_detect.py
@@ -3,7 +3,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import torch
-from tt_lib.fallback_ops import fallback_ops
 
 from models.utility_functions import tt2torch_tensor
 from models.experimental.yolov5.tt.yolov5_conv import TtYolov5Conv2D
@@ -15,9 +14,7 @@ class TtYolov5Detect(torch.nn.Module):
     dynamic = False  # force grid reconstruction
     export = False  # export mode
 
-    def __init__(
-        self, state_dict, base_address, device, nc=80, anchors=(), ch=(), inplace=True
-    ):  # detection layer
+    def __init__(self, state_dict, base_address, device, nc=80, anchors=(), ch=(), inplace=True):  # detection layer
         super().__init__()
 
         self.device = device
@@ -27,13 +24,9 @@ class TtYolov5Detect(torch.nn.Module):
         self.na = len(anchors[0]) // 2  # number of anchors
         self.grid = [torch.empty(0) for _ in range(self.nl)]  # init grid
         self.anchor_grid = [torch.empty(0) for _ in range(self.nl)]  # init anchor grid
-        self.register_buffer(
-            "anchors", torch.tensor(anchors).float().view(self.nl, -1, 2)
-        )  # shape(nl,na,2)
+        self.register_buffer("anchors", torch.tensor(anchors).float().view(self.nl, -1, 2))  # shape(nl,na,2)
         self.m = torch.nn.ModuleList(
-            TtYolov5Conv2D(
-                state_dict, f"{base_address}.m.{i}", device, x, self.no * self.na, 1
-            )
+            TtYolov5Conv2D(state_dict, f"{base_address}.m.{i}", device, x, self.no * self.na, 1)
             for i, x in enumerate(ch)
         )  # output conv
         self.inplace = inplace  # use inplace ops (e.g. slice assignment)
@@ -45,12 +38,7 @@ class TtYolov5Detect(torch.nn.Module):
             x[i] = tt2torch_tensor(x[i])
 
             bs, _, ny, nx = x[i].shape  # x(bs,255,20,20) to x(bs,3,20,20,85)
-            x[i] = (
-                x[i]
-                .view(bs, self.na, self.no, ny, nx)
-                .permute(0, 1, 3, 4, 2)
-                .contiguous()
-            )
+            x[i] = x[i].view(bs, self.na, self.no, ny, nx).permute(0, 1, 3, 4, 2).contiguous()
 
             if not self.training:  # inference
                 if self.dynamic or self.grid[i].shape[2:4] != x[i].shape[2:4]:
@@ -63,17 +51,9 @@ class TtYolov5Detect(torch.nn.Module):
 
                 z.append(y.view(bs, self.na * nx * ny, self.no))
 
-        return (
-            x
-            if self.training
-            else (torch.cat(z, 1),)
-            if self.export
-            else (torch.cat(z, 1), x)
-        )
+        return x if self.training else (torch.cat(z, 1),) if self.export else (torch.cat(z, 1), x)
 
-    def _make_grid(
-        self, nx=20, ny=20, i=0
-    ):  # , torch_1_10=check_version(torch.__version__, '1.10.0')):
+    def _make_grid(self, nx=20, ny=20, i=0):  # , torch_1_10=check_version(torch.__version__, '1.10.0')):
         d = self.anchors[i].device
         t = self.anchors[i].dtype
         shape = 1, self.na, ny, nx, 2  # grid shape
@@ -82,10 +62,6 @@ class TtYolov5Detect(torch.nn.Module):
         # yv, xv = torch.meshgrid(y, x, indexing='ij') if torch_1_10 else torch.meshgrid(y, x)  # torch>=0.7 compatibility
         yv, xv = torch.meshgrid(y, x)  # torch>=0.7 compatibility
 
-        grid = (
-            torch.stack((xv, yv), 2).expand(shape) - 0.5
-        )  # add grid offset, i.e. y = 2.0 * x - 0.5
-        anchor_grid = (
-            (self.anchors[i] * self.stride[i]).view((1, self.na, 1, 1, 2)).expand(shape)
-        )
+        grid = torch.stack((xv, yv), 2).expand(shape) - 0.5  # add grid offset, i.e. y = 2.0 * x - 0.5
+        anchor_grid = (self.anchors[i] * self.stride[i]).view((1, self.na, 1, 1, 2)).expand(shape)
         return grid, anchor_grid

--- a/models/experimental/yolov5/tt/yolov5_sppf.py
+++ b/models/experimental/yolov5/tt/yolov5_sppf.py
@@ -3,8 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import torch
-from tt_lib.fallback_ops import fallback_ops
-import tt_lib
+from ttnn.fallback_ops import fallback_ops
 import ttnn
 from models.experimental.yolov5.tt.yolov5_conv import TtYolov5Conv
 

--- a/models/experimental/yolov5/tt/yolov5_sppf.py
+++ b/models/experimental/yolov5/tt/yolov5_sppf.py
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import torch
-from ttnn.fallback_ops import fallback_ops
+from tt_lib.fallback_ops import fallback_ops
 import ttnn
 from models.experimental.yolov5.tt.yolov5_conv import TtYolov5Conv
 

--- a/models/experimental/yolov5/tt/yolov5_upsample.py
+++ b/models/experimental/yolov5/tt/yolov5_upsample.py
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import torch
-import tt_lib
+import ttnn
 
 from models.utility_functions import (
     torch2tt_tensor,
@@ -24,15 +24,11 @@ class TtYolov5Upsample(torch.nn.Module):
     ):
         super().__init__()
         self.device = device
-        self.upsample = torch.nn.Upsample(
-            size=size, scale_factor=scale_factor, mode=mode
-        )
+        self.upsample = torch.nn.Upsample(size=size, scale_factor=scale_factor, mode=mode)
 
     def forward(self, x):
         x = tt2torch_tensor(x)
         x = self.upsample(x)
-        x = torch2tt_tensor(
-            x, tt_device=self.device, tt_layout=tt_lib.tensor.Layout.ROW_MAJOR
-        )
+        x = torch2tt_tensor(x, tt_device=self.device, tt_layout=ttnn.ROW_MAJOR_LAYOUT)
 
         return x

--- a/models/utility_functions.py
+++ b/models/utility_functions.py
@@ -6,7 +6,6 @@ from typing import Union
 import time
 import ttnn
 from ttnn import ConcatMeshToTensor
-import tt_lib
 import torch
 import numpy as np
 from loguru import logger
@@ -133,58 +132,58 @@ def enable_persistent_kernel_cache():
     logger.warning(
         "Persistent kernel cache is enabled. Cache invalidation may fail after a rebase and may require deleting the built directory."
     )
-    tt_lib.device.EnablePersistentKernelCache()
+    ttnn.experimental.device.EnablePersistentKernelCache()
 
 
 def disable_persistent_kernel_cache():
     """
     Disables persistent compiled kernel caching. This is the default state.
     """
-    tt_lib.device.DisablePersistentKernelCache()
+    ttnn.experimental.device.DisablePersistentKernelCache()
 
 
 def enable_compilation_reports():
     """
     Enables generating reports of compilation statistics in .reports/tt_metal dir
     """
-    return tt_lib.device.EnableCompilationReports()
+    return ttnn.experimental.device.EnableCompilationReports()
 
 
 def disable_compilation_reports():
     """
     Disables generating reports of compilation statistics
     """
-    return tt_lib.device.DisableCompilationReports()
+    return ttnn.experimental.device.DisableCompilationReports()
 
 
 def enable_memory_reports():
     """
     Enables generating reports of memory allocation statistics in .reports/tt_metal dir
     """
-    return tt_lib.device.EnableMemoryReports()
+    return ttnn.experimental.device.EnableMemoryReports()
 
 
 def disable_memory_reports():
     """
     Disables generating reports of memory allocation statistics
     """
-    return tt_lib.device.DisableMemoryReports()
+    return ttnn.experimental.device.DisableMemoryReports()
 
 
 ### Tensor conversion ###
 def torch2tt_tensor(
     py_tensor: torch.Tensor,
     tt_device,
-    tt_layout=tt_lib.tensor.Layout.TILE,
-    tt_memory_config=tt_lib.tensor.MemoryConfig(tt_lib.tensor.TensorMemoryLayout.INTERLEAVED),
-    tt_dtype=tt_lib.tensor.DataType.BFLOAT16,
+    tt_layout=ttnn.TILE_LAYOUT,
+    tt_memory_config=ttnn.MemoryConfig(ttnn.TensorMemoryLayout.INTERLEAVED),
+    tt_dtype=ttnn.bfloat16,
 ):
     size = list(py_tensor.size())
 
     while len(size) < 4:
         size.insert(0, 1)
 
-    tt_tensor = tt_lib.tensor.Tensor(py_tensor.reshape(size), tt_dtype)
+    tt_tensor = ttnn.Tensor(py_tensor.reshape(size), tt_dtype)
     tt_tensor = tt_tensor.to(tt_layout)
 
     if tt_device is not None:
@@ -219,13 +218,13 @@ def tt_tensors_to_torch_tensors(
 
 def tt2torch_tensor(tt_tensor):
     tt_output = tt_tensor.cpu()
-    if tt_output.get_layout() != tt_lib.tensor.Layout.ROW_MAJOR:
-        tt_output = tt_output.to(tt_lib.tensor.Layout.ROW_MAJOR)
+    if tt_output.get_layout() != ttnn.ROW_MAJOR_LAYOUT:
+        tt_output = tt_output.to(ttnn.ROW_MAJOR_LAYOUT)
     return tt_output.to_torch()
 
 
 def tt_to_torch_tensor(tt_tensor):
-    tt_output = tt_tensor.cpu().to(tt_lib.tensor.Layout.ROW_MAJOR)
+    tt_output = tt_tensor.cpu().to(ttnn.ROW_MAJOR_LAYOUT)
     return tt_output.to_torch()
 
 
@@ -235,7 +234,7 @@ def torch_to_tt_tensor_rm(py_tensor, device, shape=None, put_on_device=True):
         while len(shape) < 4:
             shape.insert(0, 1)
 
-    tt_tensor = tt_lib.tensor.Tensor(py_tensor.reshape(shape), tt_lib.tensor.DataType.BFLOAT16)
+    tt_tensor = ttnn.Tensor(py_tensor.reshape(shape), ttnn.bfloat16)
     if put_on_device:
         tt_tensor = tt_tensor.to(device)
     return tt_tensor
@@ -247,11 +246,11 @@ def torch_to_tt_tensor(py_tensor, device):
         shape.insert(0, 1)
 
     tt_tensor = (
-        tt_lib.tensor.Tensor(py_tensor.reshape(shape), tt_lib.tensor.DataType.BFLOAT16)
+        ttnn.Tensor(py_tensor.reshape(shape), ttnn.bfloat16)
         .to(
-            tt_lib.tensor.Layout.TILE
+            ttnn.TILE_LAYOUT
         )  # change memory layout of TT Tensor to TILE (as operation that will use it expects TILE layout)
-        .to(device)  # move TT Tensor from host to TT accelerator device (device is of type tt_lib.device.Device)
+        .to(device)  # move TT Tensor from host to TT accelerator device (device is of type ttnn.device.Device)
     )
 
     return tt_tensor
@@ -261,8 +260,8 @@ def torch_to_tt_tensor(py_tensor, device):
 def pad_by_zero(
     x: torch.Tensor,
     device=None,
-    tt_memory_config=tt_lib.tensor.MemoryConfig(tt_lib.tensor.TensorMemoryLayout.INTERLEAVED),
-    tt_dtype=tt_lib.tensor.DataType.BFLOAT16,
+    tt_memory_config=ttnn.MemoryConfig(ttnn.TensorMemoryLayout.INTERLEAVED),
+    tt_dtype=ttnn.bfloat16,
 ):
     initial_shape = x.shape
     pad_shape = list(x.shape)
@@ -280,8 +279,8 @@ def pad_by_zero(
                 _nearest_32(pad_shape[-2]) - pad_shape[-2],
             ),
         )
-        x = tt_lib.tensor.Tensor(x, tt_dtype)
-        x = x.to(tt_lib.tensor.Layout.TILE)
+        x = ttnn.Tensor(x, tt_dtype)
+        x = x.to(ttnn.TILE_LAYOUT)
         if device is not None:
             x = x.to(device, tt_memory_config)
 
@@ -295,8 +294,8 @@ def unpad_from_zero(x, desired_shape):
         x = tt2torch_tensor(x)
     else:
         x = x.cpu()
-        if x.get_layout() != tt_lib.tensor.Layout.ROW_MAJOR:
-            x = x.to(tt_lib.tensor.Layout.ROW_MAJOR)
+        if x.get_layout() != ttnn.ROW_MAJOR_LAYOUT:
+            x = x.to(ttnn.ROW_MAJOR_LAYOUT)
         x = x.unpad(
             (0, 0, 0, 0),
             (
@@ -346,8 +345,8 @@ def pad_weight(x):
     """
     This function pads a weight/bias with 0s as a pre-preprocessing step to tilization.
 
-    tt_tensor = tt_lib.tensor.Tensor(
-        py_tensor.reshape(shape), tt_lib.tensor.DataType.BFLOAT16
+    tt_tensor = ttnn.Tensor(
+        py_tensor.reshape(shape), ttnn.bfloat16
     In the 2d case, it pads a vector to the right with 0s, and in the 2+d case,
     it pads the bottom and right corners of the last two dimensions.
 
@@ -924,8 +923,8 @@ def run_conv_on_device_wrapper(conv_weight, conv_params, device, conv_bias=None,
         if N == 1:
             return run_conv_on_device_batch_one(x)
         # need to move on CPU
-        if isinstance(x, tt_lib.tensor.Tensor):
-            xx = x.cpu().to(tt_lib.tensor.Layout.ROW_MAJOR).to_torch()
+        if isinstance(x, ttnn.Tensor):
+            xx = x.cpu().to(ttnn.ROW_MAJOR_LAYOUT).to_torch()
         else:
             xx = x
 
@@ -972,7 +971,7 @@ def run_conv_on_device_wrapper(conv_weight, conv_params, device, conv_bias=None,
         )
 
         logger.info("Going to run conv on tt device")
-        if x.get_layout() != tt_lib.tensor.Layout.ROW_MAJOR:
+        if x.get_layout() != ttnn.ROW_MAJOR_LAYOUT:
             x = ttnn.untilize(x)
         else:
             x_padded_shape = list(x.get_legacy_shape())


### PR DESCRIPTION
### Ticket
#11344 

### Problem description
Replace tt_lib with ttnn

### What's changed
Updated all the ops, function call using ttnn

### Checklist
- [ ] [Nightly fast dispatch tests](https://github.com/tenstorrent/tt-metal/actions/runs/10433832756)
https://github.com/tenstorrent/tt-metal/actions/runs/10465262030

- [ ] [Model perf regressions and output report](https://github.com/tenstorrent/tt-metal/actions/runs/10433830994) 
https://github.com/tenstorrent/tt-metal/actions/runs/10465264289
```
Traceback (most recent call last):
  File "models/perf/merge_perf_results.py", line 27, in <module>
    check_perf_results(fname, expected_cols, check_cols)
  File "/home/ubuntu/actions-runner/_work/tt-metal/tt-metal/models/perf/perf_utils.py", line 86, in check_perf_results
    assert (
AssertionError: Some model(s) Inference Time (sec) are too slow, see above for details on slow models:
``` 

- [x] [Device perf regressions and output report](https://github.com/tenstorrent/tt-metal/actions/runs/10433829931)

-  [x] [[post-commit] models tests](https://github.com/tenstorrent/tt-metal/actions/runs/10433827798)
	
