### PR TITLE
FIx elt_binary with fused silu sharded version 

### DIFF
--- a/tests/tt_eager/python_api_testing/unit_testing/misc/test_eltwise_binary.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/misc/test_eltwise_binary.py
@@ -16,8 +16,12 @@ from models.utility_functions import torch2tt_tensor, tt2torch_tensor, pad_by_ze
 @pytest.mark.skipif(is_grayskull(), reason="GS does not support fp32")
 @pytest.mark.parametrize(
     "dtype",
-    [ttnn.bfloat16, ttnn.float32],
-    ids=["bfloat16", "float32"],
+    [
+        ttnn.bfloat16,
+    ],
+    ids=[
+        "bfloat16",
+    ],
 )
 @pytest.mark.parametrize(
     "test_func_name, torch_func_name",
@@ -28,12 +32,25 @@ from models.utility_functions import torch2tt_tensor, tt2torch_tensor, pad_by_ze
     [True, False],
     ids=["silu", "no-silu"],
 )
-def test_run_elt_binary(dtype, test_func_name, torch_func_name, pre_in0_silu, device):
-    shape = [2, 16, 256, 256]
+@pytest.mark.parametrize(
+    "shard",
+    [False, True],
+    ids=["interleaved", "sharded"],
+)
+def test_run_elt_binary(dtype, test_func_name, torch_func_name, pre_in0_silu, device, shard):
+    shape = (1, 1, 32, 1024)
 
     torch.manual_seed(10)
 
-    mem_config = ttnn.MemoryConfig(ttnn.TensorMemoryLayout.INTERLEAVED, ttnn.BufferType.L1)
+    if shard:
+        mem_config = ttnn.create_sharded_memory_config(
+            shape=shape,
+            core_grid=ttnn.CoreGrid(y=1, x=8),
+            strategy=ttnn.ShardStrategy.WIDTH,
+            orientation=ttnn.ShardOrientation.ROW_MAJOR,
+        )
+    else:
+        mem_config = ttnn.MemoryConfig(ttnn.TensorMemoryLayout.INTERLEAVED, ttnn.BufferType.L1)
 
     in0 = torch.randn(shape).bfloat16().float()
     in1 = torch.randn(shape).bfloat16().float()
@@ -42,7 +59,7 @@ def test_run_elt_binary(dtype, test_func_name, torch_func_name, pre_in0_silu, de
 
     if pre_in0_silu:
         torch_silu = torch.nn.SiLU()
-        out_t = test_func_name(in0_t, in1_t, input_tensor_a_activation=ttnn.UnaryOpType.SILU)
+        out_t = test_func_name(in0_t, in1_t, input_tensor_a_activation=ttnn.UnaryOpType.SILU, memory_config=mem_config)
     else:
         out_t = test_func_name(in0_t, in1_t)
     out = tt2torch_tensor(out_t)

--- a/ttnn/cpp/ttnn/operations/eltwise/binary/common/binary_op_utils.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary/common/binary_op_utils.cpp
@@ -152,7 +152,7 @@ std::map<std::string, std::string> get_defines(
     }
 
     if (input_tensor_a_activation.has_value() ) {
-        defines.merge(ttnn::operations::unary::utils::get_defines(input_tensor_a_activation.value().op_type, std::nullopt, "PRE_IN0_0"));
+        defines.merge(ttnn::operations::unary::utils::get_defines(input_tensor_a_activation.value().op_type, std::nullopt, "PRE_IN0_0", idst));
     }
 
     return defines;

--- a/ttnn/cpp/ttnn/operations/eltwise/binary/device/element_wise_multi_core_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary/device/element_wise_multi_core_program_factory.cpp
@@ -335,13 +335,13 @@ BinaryDeviceOperation::ElementWiseMultiCore::cached_program_t BinaryDeviceOperat
 
     if (eltwise_defines.find("SFPU_OP_INIT_PRE_IN0_0") != eltwise_defines.end()) {
         tt_metal::CircularBufferConfig cb_interm_config =
-            tt_metal::CircularBufferConfig(1 * src0_single_tile_size, {{CB::c_intermed0, src0_cb_data_format}})
+            tt_metal::CircularBufferConfig(max_block_size * src0_single_tile_size, {{CB::c_intermed0, src0_cb_data_format}})
                 .set_page_size(CB::c_intermed0, src0_single_tile_size);
         auto cb_interm = tt_metal::CreateCircularBuffer(program, all_device_cores, cb_interm_config);
     }
     if (eltwise_defines.find("SFPU_OP_INIT_PRE_IN1_0") != eltwise_defines.end()) {
         tt_metal::CircularBufferConfig cb_interm2_config =
-            tt_metal::CircularBufferConfig(1 * src1_single_tile_size, {{CB::c_intermed1, src1_cb_data_format}})
+            tt_metal::CircularBufferConfig(max_block_size * src1_single_tile_size, {{CB::c_intermed1, src1_cb_data_format}})
                 .set_page_size(CB::c_intermed1, src1_single_tile_size);
         auto cb_interm2 = tt_metal::CreateCircularBuffer(program, all_device_cores, cb_interm2_config);
     }


### PR DESCRIPTION
### Ticket
[Link to Github Issue](https://github.com/tenstorrent/tt-metal/issues/11062#event-13855579254)

### Problem description
 Presently, the feature only allows fusing activation when the inputs are interleaved. If the inputs are sharded, the kernel result into a hang.

### What's changed
add idst to defines

### Checklist
- [x] Post commit CI https://github.com/tenstorrent/tt-metal/actions/runs/10374275125
