### PR TITLE
#11389: Add a cloud preset to allow easy connection to the tt-cloud elasticsearch instance

### DIFF
--- a/tests/sweep_framework/elastic_config.py
+++ b/tests/sweep_framework/elastic_config.py
@@ -3,9 +3,27 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import os
+from elasticsearch import Elasticsearch
 
-ELASTIC_DEFAULT_URL = "http://yyz-elk:9200"
+ELASTIC_CORP_URL = "http://yyz-elk:9200"
+ELASTIC_CLOUD_URL = "http://e12cs07:9200"
 ELASTIC_USERNAME = os.getenv("ELASTIC_USERNAME")
 ELASTIC_PASSWORD = os.getenv("ELASTIC_PASSWORD")
 VECTOR_INDEX_PREFIX = "ttnn_sweeps_test_vectors_"
 RESULT_INDEX_PREFIX = "ttnn_sweeps_test_results_"
+
+
+def get_elastic_url(elastic_arg):
+    if elastic_arg == "corp":
+        print(
+            "SWEEPS: Connecting to Elasticsearch on corporate network. If you are on tt-cloud, please pass '--elastic cloud' to your test command."
+        )
+        return ELASTIC_CORP_URL
+    elif elastic_arg == "cloud":
+        print(
+            "SWEEPS: Connecting to Elasticsearch on tt-cloud network. If you are on corporate, please pass '--elastic corp' to your test command."
+        )
+        return ELASTIC_CLOUD_URL
+    else:
+        print(f"SWEEPS: Connecting to Elasticsearch on {elastic_arg}.")
+        return elastic_arg

--- a/tests/sweep_framework/export_to_sqlite.py
+++ b/tests/sweep_framework/export_to_sqlite.py
@@ -19,12 +19,12 @@ if __name__ == "__main__":
     parser.add_argument(
         "--elastic",
         required=False,
-        default=ELASTIC_DEFAULT_URL,
-        help="Elastic Connection String for the vector and results database.",
+        default="corp",
+        help="Elastic Connection String for the vector and results database. Available presets are ['corp', 'cloud']",
     )
     args = parser.parse_args(sys.argv[1:])
 
-    ELASTIC_CONNECTION_STRING = args.elastic
+    ELASTIC_CONNECTION_STRING = get_elastic_url(args.elastic)
     DUMP_PATH = "tests/sweep_framework/sqlite_dump/"
     sweeps_path = pathlib.Path(__file__).parent / "sweeps"
     es_client = Elasticsearch(ELASTIC_CONNECTION_STRING, basic_auth=(ELASTIC_USERNAME, ELASTIC_PASSWORD))

--- a/tests/sweep_framework/parameter_generator.py
+++ b/tests/sweep_framework/parameter_generator.py
@@ -150,14 +150,14 @@ if __name__ == "__main__":
     parser.add_argument(
         "--elastic",
         required=False,
-        default=ELASTIC_DEFAULT_URL,
-        help="Elastic Connection String for vector database.",
+        default="corp",
+        help="Elastic Connection String for vector database. Available presets are ['corp', 'cloud']",
     )
 
     args = parser.parse_args(sys.argv[1:])
 
     global ELASTIC_CONNECTION_STRING
-    ELASTIC_CONNECTION_STRING = args.elastic
+    ELASTIC_CONNECTION_STRING = get_elastic_url(args.elastic)
 
     if args.clean and not args.module_name:
         print("SWEEPS: The clean flag must be set in conjunction with a module name.")

--- a/tests/sweep_framework/query.py
+++ b/tests/sweep_framework/query.py
@@ -18,7 +18,7 @@ from elastic_config import *
 @click.option("--suite-name", default=None, help="Suite name to filter by.")
 @click.option("--vector-id", default=None, help="Individual Vector ID to filter by.")
 @click.option("--run-id", default=None, help="Individual Run ID to filter by.")
-@click.option("--elastic", default=ELASTIC_DEFAULT_URL, help="Elastic Connection String")
+@click.option("--elastic", default="corp", help="Elastic Connection String. Available presets are ['corp', 'cloud']")
 @click.option(
     "--all", is_flag=True, default=False, help="Displays total run statistics instead of the most recent run."
 )
@@ -30,7 +30,7 @@ def cli(ctx, module_name, suite_name, vector_id, run_id, elastic, all):
     ctx.obj["suite_name"] = suite_name
     ctx.obj["vector_id"] = vector_id
     ctx.obj["run_id"] = run_id
-    ctx.obj["elastic"] = elastic
+    ctx.obj["elastic"] = get_elastic_url(elastic)
     ctx.obj["all"] = all
 
 

--- a/tests/sweep_framework/runner.py
+++ b/tests/sweep_framework/runner.py
@@ -298,8 +298,8 @@ if __name__ == "__main__":
     parser.add_argument(
         "--elastic",
         required=False,
-        default=ELASTIC_DEFAULT_URL,
-        help="Elastic Connection String for the vector and results database.",
+        default="corp",
+        help="Elastic Connection String for the vector and results database. Available presets are ['corp', 'cloud']",
     )
     parser.add_argument("--module-name", required=False, help="Test Module Name, or all tests if omitted.")
     parser.add_argument("--suite-name", required=False, help="Suite of Test Vectors to run, or all tests if omitted.")
@@ -335,7 +335,7 @@ if __name__ == "__main__":
         print("ERROR: Module name is required if vector id is specified.")
 
     global ELASTIC_CONNECTION_STRING
-    ELASTIC_CONNECTION_STRING = args.elastic
+    ELASTIC_CONNECTION_STRING = get_elastic_url(args.elastic)
 
     global MEASURE_PERF
     MEASURE_PERF = args.perf


### PR DESCRIPTION
### Ticket
#11389 

### What's changed
We have added a elasticsearch instance for use on tt-cloud, add a preset to allow easy connection to that host.

### Checklist
- [ ] Post commit CI passes
- [ ] Blackhole Post commit (if applicable)
- [ ] Model regression CI testing passes (if applicable)
- [ ] New/Existing tests provide coverage for changes
