### PR TITLE
Support linking mcasts within/across subcmds for kernel bins

### DIFF
--- a/tests/tt_metal/tt_metal/perf_microbenchmark/8_dram_adjacent_core_read/kernels/reader_dram.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/8_dram_adjacent_core_read/kernels/reader_dram.cpp
@@ -19,7 +19,7 @@ void noc_async_read_tile_dram_sharded(uint32_t src_addr, uint32_t dest_addr, uin
     src_noc_xy = dram_bank_to_noc_xy[noc_index][bank_id];
 
     DEBUG_STATUS("NRTW");
-    DEBUG_SANITIZE_NOC_READ_TRANSACTION(get_noc_addr_helper(src_noc_xy, src_addr_), dest_addr, page_size);
+    DEBUG_SANITIZE_NOC_READ_TRANSACTION(noc_index, get_noc_addr_helper(src_noc_xy, src_addr_), dest_addr, page_size);
     while (!noc_cmd_buf_ready(noc_index, NCRISC_RD_CMD_BUF));
     DEBUG_STATUS("NRTD");
 

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/common.h
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/common.h
@@ -1035,6 +1035,7 @@ inline bool gen_rnd_dispatcher_packed_write_large_cmd(Device *device,
         sub_cmd.addr = device_data.get_result_data_addr(range.start_coord);
         sub_cmd.length = xfer_size_bytes;
         sub_cmd.num_mcast_dests = (range.end_coord.x - range.start_coord.x + 1) * (range.end_coord.y - range.start_coord.y + 1);
+        sub_cmd.flags = CQ_DISPATCH_CMD_PACKED_WRITE_LARGE_FLAG_UNLINK;
 
         for (uint32_t i = 0; i < sizeof(CQDispatchWritePackedLargeSubCmd) / sizeof(uint32_t); i++) {
             cmds.push_back(((uint32_t *)&sub_cmd)[i]);

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/common.h
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/common.h
@@ -479,15 +479,22 @@ void configure_kernel_variant(
     CoreCoord my_core,
     CoreCoord phys_my_core,
     CoreCoord phys_upstream_core,
-    CoreCoord phys_downstream_core) {
+    CoreCoord phys_downstream_core,
+    Device * device,
+    NOC my_noc_index,
+    NOC upstream_noc_index,
+    NOC downstream_noc_index) {
+
+    const auto& grid_size = device->grid_size();
 
     std::map<string, string> defines = {
-        {"MY_NOC_X", std::to_string(phys_my_core.x)},
-        {"MY_NOC_Y", std::to_string(phys_my_core.y)},
-        {"UPSTREAM_NOC_X", std::to_string(phys_upstream_core.x)},
-        {"UPSTREAM_NOC_Y", std::to_string(phys_upstream_core.y)},
-        {"DOWNSTREAM_NOC_X", std::to_string(phys_downstream_core.x)},
-        {"DOWNSTREAM_NOC_Y", std::to_string(phys_downstream_core.y)},
+        {"MY_NOC_X", std::to_string(NOC_0_X(my_noc_index, grid_size.x, phys_my_core.x))},
+        {"MY_NOC_Y", std::to_string(NOC_0_Y(my_noc_index, grid_size.y, phys_my_core.y))},
+        {"UPSTREAM_NOC_INDEX", std::to_string(upstream_noc_index)},
+        {"UPSTREAM_NOC_X", std::to_string(NOC_0_X(upstream_noc_index, grid_size.x, phys_upstream_core.x))},
+        {"UPSTREAM_NOC_Y", std::to_string(NOC_0_Y(upstream_noc_index, grid_size.y, phys_upstream_core.y))},
+        {"DOWNSTREAM_NOC_X", std::to_string(NOC_0_X(downstream_noc_index, grid_size.x, phys_downstream_core.x))},
+        {"DOWNSTREAM_NOC_Y", std::to_string(NOC_0_Y(downstream_noc_index, grid_size.y, phys_downstream_core.y))},
     };
     compile_args.push_back(is_dram_variant);
     compile_args.push_back(is_host_variant);
@@ -497,7 +504,7 @@ void configure_kernel_variant(
         {my_core},
         tt::tt_metal::DataMovementConfig {
             .processor = tt::tt_metal::DataMovementProcessor::RISCV_1,
-            .noc = tt::tt_metal::NOC::RISCV_0_default,
+            .noc = my_noc_index,
             .compile_args = compile_args,
             .defines = defines
         }

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/test_dispatcher.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/test_dispatcher.cpp
@@ -508,13 +508,20 @@ int main(int argc, char **argv) {
         args.push_back(prefetcher_iterations_g);
         tt_metal::SetRuntimeArgs(program, sp1, spoof_prefetch_core, args);
 
+        constexpr NOC my_noc_index = NOC::NOC_0;
+        constexpr NOC dispatch_upstream_noc_index = NOC::NOC_1;
+
         configure_kernel_variant<true, true>(program,
             "tt_metal/impl/dispatch/kernels/cq_dispatch.cpp",
             dispatch_compile_args,
             dispatch_core,
             phys_dispatch_core,
             phys_spoof_prefetch_core,
-            {0, 0});
+            {0, 0},
+            device,
+            my_noc_index,
+            dispatch_upstream_noc_index,
+            my_noc_index);
 
         switch (test_type_g) {
         case 0:

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/test_prefetcher.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/test_prefetcher.cpp
@@ -1642,6 +1642,9 @@ void configure_for_single_chip(Device *device,
         dispatch_constants::PREFETCH_D_BUFFER_BLOCKS, // prefetch_d only
     };
 
+    constexpr NOC my_noc_index = NOC::NOC_0;
+    constexpr NOC dispatch_upstream_noc_index = NOC::NOC_1;
+
     if (split_prefetcher_g) {
 
         log_info(LogTest, "split prefetcher test, packetized_path_en={}", packetized_path_en_g);
@@ -1664,7 +1667,11 @@ void configure_for_single_chip(Device *device,
             prefetch_d_core,
             phys_prefetch_d_core,
             phys_prefetch_d_upstream_core,
-            phys_dispatch_core);
+            phys_dispatch_core,
+            device,
+            my_noc_index,
+            my_noc_index,
+            my_noc_index);
 
         // prefetch_h
         prefetch_compile_args[0] = prefetch_d_buffer_base;
@@ -1684,7 +1691,11 @@ void configure_for_single_chip(Device *device,
             prefetch_core,
             phys_prefetch_core_g,
             {0xffffffff, 0xffffffff}, // upstream core unused
-            phys_prefetch_h_downstream_core);
+            phys_prefetch_h_downstream_core,
+            device,
+            my_noc_index,
+            my_noc_index,
+            my_noc_index);
 
         if (packetized_path_en_g) {
 
@@ -1846,7 +1857,11 @@ void configure_for_single_chip(Device *device,
             prefetch_core,
             phys_prefetch_core_g,
             {0xffffffff, 0xffffffff}, // upstream core unused
-            phys_dispatch_core);
+            phys_dispatch_core,
+            device,
+            my_noc_index,
+            my_noc_index,
+            my_noc_index);
     }
 
     std::vector<uint32_t> dispatch_compile_args = {
@@ -1891,7 +1906,11 @@ void configure_for_single_chip(Device *device,
             dispatch_core,
             phys_dispatch_core,
             phys_upstream_from_dispatch_core,
-            phys_dispatch_d_downstream_core);
+            phys_dispatch_d_downstream_core,
+            device,
+            my_noc_index,
+            dispatch_upstream_noc_index,
+            my_noc_index);
 
         // dispatch_h
         dispatch_compile_args[3] = dispatch_h_cb_sem;
@@ -1907,7 +1926,11 @@ void configure_for_single_chip(Device *device,
             dispatch_h_core,
             phys_dispatch_h_core,
             phys_dispatch_h_upstream_core,
-            {0xffffffff,0xffffffff});
+            {0xffffffff,0xffffffff},
+            device,
+            my_noc_index,
+            dispatch_upstream_noc_index,
+            my_noc_index);
 
         if (packetized_path_en_g) {
 
@@ -2064,7 +2087,11 @@ void configure_for_single_chip(Device *device,
             dispatch_core,
             phys_dispatch_core,
             phys_upstream_from_dispatch_core,
-            {0xffffffff,0xffffffff});
+            {0xffffffff,0xffffffff},
+            device,
+            my_noc_index,
+            dispatch_upstream_noc_index,
+            my_noc_index);
     }
 }
 
@@ -2229,6 +2256,9 @@ void configure_for_multi_chip(Device *device,
         dispatch_constants::PREFETCH_D_BUFFER_BLOCKS, // prefetch_d only
     };
 
+    constexpr NOC my_noc_index = NOC::NOC_0;
+    constexpr NOC dispatch_upstream_noc_index = NOC::NOC_1;
+
     if (split_prefetcher_g) {
 
         log_info(LogTest, "split prefetcher test, packetized_path_en={}", packetized_path_en_g);
@@ -2251,7 +2281,11 @@ void configure_for_multi_chip(Device *device,
             prefetch_d_core,
             phys_prefetch_d_core,
             phys_prefetch_d_upstream_core,
-            phys_dispatch_core);
+            phys_dispatch_core,
+            device,
+            my_noc_index,
+            my_noc_index,
+            my_noc_index);
 
         // prefetch_h
         prefetch_compile_args[0] = prefetch_d_buffer_base;
@@ -2271,7 +2305,11 @@ void configure_for_multi_chip(Device *device,
             prefetch_core,
             phys_prefetch_core_g,
             {0xffffffff, 0xffffffff}, // upstream core unused
-            phys_prefetch_h_downstream_core);
+            phys_prefetch_h_downstream_core,
+            device,
+            my_noc_index,
+            my_noc_index,
+            my_noc_index);
 
         if (packetized_path_en_g) {
 
@@ -2518,7 +2556,11 @@ void configure_for_multi_chip(Device *device,
             prefetch_core,
             phys_prefetch_core_g,
             {0xffffffff, 0xffffffff}, // upstream core unused
-            phys_dispatch_core);
+            phys_dispatch_core,
+            device,
+            my_noc_index,
+            my_noc_index,
+            my_noc_index);
     }
 
     std::vector<uint32_t> dispatch_compile_args = {
@@ -2563,7 +2605,11 @@ void configure_for_multi_chip(Device *device,
             dispatch_core,
             phys_dispatch_core,
             phys_upstream_from_dispatch_core,
-            phys_dispatch_d_downstream_core);
+            phys_dispatch_d_downstream_core,
+            device,
+            my_noc_index,
+            dispatch_upstream_noc_index,
+            my_noc_index);
 
         // dispatch_h
         dispatch_compile_args[3] = dispatch_h_cb_sem;
@@ -2578,7 +2624,11 @@ void configure_for_multi_chip(Device *device,
             dispatch_h_core,
             phys_dispatch_h_core,
             phys_dispatch_h_upstream_core,
-            {0xffffffff,0xffffffff});
+            {0xffffffff,0xffffffff},
+            device,
+            my_noc_index,
+            dispatch_upstream_noc_index,
+            my_noc_index);
 
         if (packetized_path_en_g) {
 
@@ -2743,7 +2793,11 @@ void configure_for_multi_chip(Device *device,
             dispatch_core,
             phys_dispatch_core,
             phys_upstream_from_dispatch_core,
-            {0xffffffff,0xffffffff});
+            {0xffffffff,0xffffffff},
+            device,
+            my_noc_index,
+            dispatch_upstream_noc_index,
+            my_noc_index);
     }
 }
 

--- a/tests/tt_metal/tt_metal/unit_tests/fast_dispatch_kernels/test_write_host.cpp
+++ b/tests/tt_metal/tt_metal/unit_tests/fast_dispatch_kernels/test_write_host.cpp
@@ -184,13 +184,20 @@ bool test_write_host(Device *device, uint32_t data_size, std::pair<uint32_t, uin
     vector<uint32_t> args = {1};
     tt::tt_metal::SetRuntimeArgs(program, sp1, spoof_prefetch_core, args);
 
+    constexpr NOC my_noc_index = NOC::NOC_0;
+    constexpr NOC dispatch_upstream_noc_index = NOC::NOC_1;
+
     configure_kernel_variant<true, true>(program,
         "tt_metal/impl/dispatch/kernels/cq_dispatch.cpp",
         dispatch_compile_args,
         dispatch_core,
         phys_dispatch_core,
         phys_spoof_prefetch_core,
-        {0, 0});
+        {0, 0},
+        device,
+        my_noc_index,
+        my_noc_index,
+        my_noc_index);
 
     // Need a separate thread for SD
     if (read_ptr_update.has_value()) {

--- a/tests/tt_metal/tt_metal/unit_tests_common/common/watcher_fixture.hpp
+++ b/tests/tt_metal/tt_metal/unit_tests_common/common/watcher_fixture.hpp
@@ -34,6 +34,7 @@ protected:
     bool watcher_previous_dump_all;
     bool watcher_previous_append;
     bool watcher_previous_auto_unpause;
+    bool watcher_previous_noinline;
     bool test_mode_previous;
     void SetUp() override {
         // Enable watcher for this test, save the previous state so we can restore it later.
@@ -42,12 +43,14 @@ protected:
         watcher_previous_dump_all = tt::llrt::OptionsG.get_watcher_dump_all();
         watcher_previous_append = tt::llrt::OptionsG.get_watcher_append();
         watcher_previous_auto_unpause = tt::llrt::OptionsG.get_watcher_auto_unpause();
+        watcher_previous_noinline = tt::llrt::OptionsG.get_watcher_noinline();
         test_mode_previous = tt::llrt::OptionsG.get_test_mode_enabled();
         tt::llrt::OptionsG.set_watcher_enabled(true);
         tt::llrt::OptionsG.set_watcher_interval(interval_ms);
         tt::llrt::OptionsG.set_watcher_dump_all(false);
         tt::llrt::OptionsG.set_watcher_append(false);
         tt::llrt::OptionsG.set_watcher_auto_unpause(true);
+        tt::llrt::OptionsG.set_watcher_noinline(true);
         tt::llrt::OptionsG.set_test_mode_enabled(true);
         tt::watcher_clear_log();
 
@@ -65,6 +68,7 @@ protected:
         tt::llrt::OptionsG.set_watcher_dump_all(watcher_previous_dump_all);
         tt::llrt::OptionsG.set_watcher_append(watcher_previous_append);
         tt::llrt::OptionsG.set_watcher_auto_unpause(watcher_previous_auto_unpause);
+        tt::llrt::OptionsG.set_watcher_noinline(watcher_previous_noinline);
         tt::llrt::OptionsG.set_test_mode_enabled(test_mode_previous);
         tt::watcher_server_set_error_flag(false);
     }

--- a/tt_metal/hw/firmware/src/brisc.cc
+++ b/tt_metal/hw/firmware/src/brisc.cc
@@ -411,7 +411,7 @@ int main() {
                 uint64_t dispatch_addr =
                     NOC_XY_ADDR(NOC_X(mailboxes->launch.kernel_config.dispatch_core_x),
                         NOC_Y(mailboxes->launch.kernel_config.dispatch_core_y), DISPATCH_MESSAGE_ADDR);
-                DEBUG_SANITIZE_NOC_ADDR(dispatch_addr, 4);
+                DEBUG_SANITIZE_NOC_ADDR(noc_index, dispatch_addr, 4);
                 noc_fast_atomic_increment(
                     noc_index,
                     NCRISC_AT_CMD_BUF,

--- a/tt_metal/hw/firmware/src/idle_erisc.cc
+++ b/tt_metal/hw/firmware/src/idle_erisc.cc
@@ -142,7 +142,7 @@ int main() {
                 uint64_t dispatch_addr =
                     NOC_XY_ADDR(NOC_X(mailboxes->launch.kernel_config.dispatch_core_x),
                         NOC_Y(mailboxes->launch.kernel_config.dispatch_core_y), DISPATCH_MESSAGE_ADDR);
-                DEBUG_SANITIZE_NOC_ADDR(dispatch_addr, 4);
+                DEBUG_SANITIZE_NOC_ADDR(noc_index, dispatch_addr, 4);
                 noc_fast_atomic_increment(noc_index, NCRISC_AT_CMD_BUF, dispatch_addr, NOC_UNICAST_WRITE_VC, 1, 31 /*wrap*/, false /*linked*/);
             }
 

--- a/tt_metal/hw/inc/dataflow_api.h
+++ b/tt_metal/hw/inc/dataflow_api.h
@@ -509,7 +509,7 @@ void noc_async_read(std::uint64_t src_noc_addr, std::uint32_t dst_local_l1_addr,
         Read responses - assigned VCs dynamically
     */
     DEBUG_STATUS("NARW");
-    DEBUG_SANITIZE_NOC_READ_TRANSACTION(src_noc_addr, dst_local_l1_addr, size);
+    DEBUG_SANITIZE_NOC_READ_TRANSACTION(noc_index, src_noc_addr, dst_local_l1_addr, size);
     ncrisc_noc_fast_read_any_len(noc_index, NCRISC_RD_CMD_BUF, src_noc_addr, dst_local_l1_addr, size);
     DEBUG_STATUS("NARD");
 }
@@ -528,7 +528,7 @@ void noc_async_read_one_packet(std::uint64_t src_noc_addr, std::uint32_t dst_loc
     DEBUG_STATUS("RPD");
 
     DEBUG_STATUS("NARW");
-    DEBUG_SANITIZE_NOC_READ_TRANSACTION(src_noc_addr, dst_local_l1_addr, size);
+    DEBUG_SANITIZE_NOC_READ_TRANSACTION(noc_index, src_noc_addr, dst_local_l1_addr, size);
 
     NOC_CMD_BUF_WRITE_REG(noc_index, NCRISC_RD_CMD_BUF, NOC_RET_ADDR_LO, dst_local_l1_addr);
     NOC_CMD_BUF_WRITE_REG(noc_index, NCRISC_RD_CMD_BUF, NOC_TARG_ADDR_LO, (uint32_t)src_noc_addr);
@@ -678,7 +678,7 @@ FORCE_INLINE
 void noc_async_write_one_packet(std::uint32_t src_local_l1_addr, std::uint64_t dst_noc_addr, std::uint32_t size) {
 
     DEBUG_STATUS("NWPW");
-    DEBUG_SANITIZE_NOC_WRITE_TRANSACTION(dst_noc_addr, src_local_l1_addr, size);
+    DEBUG_SANITIZE_NOC_WRITE_TRANSACTION(noc_index, dst_noc_addr, src_local_l1_addr, size);
     while (!noc_cmd_buf_ready(noc_index, NCRISC_WR_CMD_BUF));
     DEBUG_STATUS("NWPD");
 
@@ -712,7 +712,7 @@ void noc_async_write_multicast_one_packet(
     bool linked = false,
     bool multicast_path_reserve = true) {
     DEBUG_STATUS("NMPW");
-    DEBUG_SANITIZE_NOC_MULTI_WRITE_TRANSACTION(dst_noc_addr_multicast, src_local_l1_addr, size);
+    DEBUG_SANITIZE_NOC_MULTI_WRITE_TRANSACTION(noc_index, dst_noc_addr_multicast, src_local_l1_addr, size);
     while (!noc_cmd_buf_ready(noc_index, NCRISC_WR_CMD_BUF));
     DEBUG_STATUS("NWPD");
 
@@ -949,7 +949,7 @@ struct InterleavedAddrGenFast {
         }
 
         DEBUG_STATUS("NRTW");
-        DEBUG_SANITIZE_NOC_READ_TRANSACTION(get_noc_addr_helper(src_noc_xy, src_addr), dest_addr, this->page_size);
+        DEBUG_SANITIZE_NOC_READ_TRANSACTION(noc_index, get_noc_addr_helper(src_noc_xy, src_addr), dest_addr, this->page_size);
         while (!noc_cmd_buf_ready(noc_index, NCRISC_RD_CMD_BUF));
         DEBUG_STATUS("NRTD");
 
@@ -996,7 +996,7 @@ struct InterleavedAddrGenFast {
         }
 
         DEBUG_STATUS("NWTW");
-        DEBUG_SANITIZE_NOC_WRITE_TRANSACTION(get_noc_addr_helper(dest_noc_xy, dest_addr), src_addr, this->page_size);
+        DEBUG_SANITIZE_NOC_WRITE_TRANSACTION(noc_index, get_noc_addr_helper(dest_noc_xy, dest_addr), src_addr, this->page_size);
         while (!noc_cmd_buf_ready(noc_index, NCRISC_WR_CMD_BUF));
         DEBUG_STATUS("NWTD");
 
@@ -1052,7 +1052,7 @@ struct InterleavedPow2AddrGenFast {
         }
 
         DEBUG_STATUS("NRPW");
-        DEBUG_SANITIZE_NOC_READ_TRANSACTION(get_noc_addr_helper(src_noc_xy, src_addr), dest_addr, 1 << log_base_2_of_page_size);
+        DEBUG_SANITIZE_NOC_READ_TRANSACTION(noc_index, get_noc_addr_helper(src_noc_xy, src_addr), dest_addr, 1 << log_base_2_of_page_size);
         while (!noc_cmd_buf_ready(noc_index, NCRISC_RD_CMD_BUF));
         DEBUG_STATUS("NRPD");
 
@@ -1095,7 +1095,7 @@ struct InterleavedPow2AddrGenFast {
         DEBUG_STATUS("RPW");
         while (!noc_cmd_buf_ready(noc_index, NCRISC_RD_CMD_BUF));
         DEBUG_STATUS("RPD");
-        DEBUG_SANITIZE_NOC_READ_TRANSACTION(get_noc_addr_helper(src_noc_xy, src_addr), dest_addr, size);
+        DEBUG_SANITIZE_NOC_READ_TRANSACTION(noc_index, get_noc_addr_helper(src_noc_xy, src_addr), dest_addr, size);
 
         NOC_CMD_BUF_WRITE_REG(noc_index, NCRISC_RD_CMD_BUF, NOC_RET_ADDR_LO, dest_addr);
         NOC_CMD_BUF_WRITE_REG(noc_index, NCRISC_RD_CMD_BUF, NOC_TARG_ADDR_LO, src_addr);      // (uint32_t)src_addr
@@ -1134,7 +1134,7 @@ struct InterleavedPow2AddrGenFast {
         }
 
         DEBUG_STATUS("NWPW");
-        DEBUG_SANITIZE_NOC_WRITE_TRANSACTION(get_noc_addr_helper(dest_noc_xy, dest_addr), src_addr,write_size_bytes);
+        DEBUG_SANITIZE_NOC_WRITE_TRANSACTION(noc_index, get_noc_addr_helper(dest_noc_xy, dest_addr), src_addr,write_size_bytes);
         while (!noc_cmd_buf_ready(noc_index, NCRISC_WR_CMD_BUF));
         DEBUG_STATUS("NWPD");
 
@@ -1247,7 +1247,7 @@ void noc_async_write(std::uint32_t src_local_l1_addr, std::uint64_t dst_noc_addr
         noc_async_write_one_packet(src_local_l1_addr, dst_noc_addr, size);
     } else {
         DEBUG_STATUS("NAWW");
-        DEBUG_SANITIZE_NOC_WRITE_TRANSACTION(dst_noc_addr, src_local_l1_addr,size);
+        DEBUG_SANITIZE_NOC_WRITE_TRANSACTION(noc_index, dst_noc_addr, src_local_l1_addr,size);
         ncrisc_noc_fast_write_any_len(
             noc_index,
             NCRISC_WR_CMD_BUF,
@@ -1282,7 +1282,7 @@ uint32_t eth_get_semaphore(uint32_t semaphore_id) {
 inline
 void noc_semaphore_set_remote(std::uint32_t src_local_l1_addr, std::uint64_t dst_noc_addr) {
     DEBUG_STATUS("NSSW");
-    DEBUG_SANITIZE_NOC_WRITE_TRANSACTION(dst_noc_addr, src_local_l1_addr, 4);
+    DEBUG_SANITIZE_NOC_WRITE_TRANSACTION(noc_index, dst_noc_addr, src_local_l1_addr, 4);
     ncrisc_noc_fast_write_any_len(
         noc_index,
         NCRISC_WR_REG_CMD_BUF,
@@ -1342,7 +1342,7 @@ void noc_async_write_multicast(
         noc_async_write_multicast_one_packet(src_local_l1_addr, dst_noc_addr_multicast, size, num_dests, linked, multicast_path_reserve);
     } else {
         DEBUG_STATUS("NMWW");
-        DEBUG_SANITIZE_NOC_MULTI_WRITE_TRANSACTION(dst_noc_addr_multicast, src_local_l1_addr,size);
+        DEBUG_SANITIZE_NOC_MULTI_WRITE_TRANSACTION(noc_index, dst_noc_addr_multicast, src_local_l1_addr,size);
         ncrisc_noc_fast_write_any_len(
             noc_index,
             NCRISC_WR_CMD_BUF,
@@ -1386,7 +1386,7 @@ inline
 void noc_semaphore_set_multicast(
     std::uint32_t src_local_l1_addr, std::uint64_t dst_noc_addr_multicast, std::uint32_t num_dests, bool linked = false, bool multicast_path_reserve = true) {
     DEBUG_STATUS("NSMW");
-    DEBUG_SANITIZE_NOC_MULTI_WRITE_TRANSACTION(dst_noc_addr_multicast, src_local_l1_addr, 4);
+    DEBUG_SANITIZE_NOC_MULTI_WRITE_TRANSACTION(noc_index, dst_noc_addr_multicast, src_local_l1_addr, 4);
     ncrisc_noc_fast_write_any_len(
         noc_index,
         NCRISC_WR_REG_CMD_BUF,
@@ -1427,7 +1427,7 @@ inline
 void noc_semaphore_set_multicast_loopback_src(
     std::uint32_t src_local_l1_addr, std::uint64_t dst_noc_addr_multicast, std::uint32_t num_dests, bool linked = false, bool multicast_path_reserve = true) {
     DEBUG_STATUS("NSMW");
-    DEBUG_SANITIZE_NOC_MULTI_WRITE_TRANSACTION(dst_noc_addr_multicast, src_local_l1_addr, 4);
+    DEBUG_SANITIZE_NOC_MULTI_WRITE_TRANSACTION(noc_index, dst_noc_addr_multicast, src_local_l1_addr, 4);
     ncrisc_noc_fast_write_any_len_loopback_src(
         noc_index,
         NCRISC_WR_REG_CMD_BUF,
@@ -1451,7 +1451,7 @@ void noc_async_write_multicast_loopback_src(
     bool linked = false,
     bool multicast_path_reserve = true) {
     DEBUG_STATUS("NMLW");
-    DEBUG_SANITIZE_NOC_MULTI_WRITE_TRANSACTION(dst_noc_addr_multicast, src_local_l1_addr, size);
+    DEBUG_SANITIZE_NOC_MULTI_WRITE_TRANSACTION(noc_index, dst_noc_addr_multicast, src_local_l1_addr, size);
     ncrisc_noc_fast_write_any_len_loopback_src(
         noc_index,
         NCRISC_WR_CMD_BUF,
@@ -1613,7 +1613,7 @@ FORCE_INLINE
 void noc_inline_dw_write(uint64_t addr, uint32_t val, uint8_t be = 0xF) {
 
     DEBUG_STATUS("NWIW");
-    DEBUG_SANITIZE_NOC_ADDR(addr, 4);
+    DEBUG_SANITIZE_NOC_ADDR(noc_index, addr, 4);
     noc_fast_write_dw_inline(
                 noc_index,
                 NCRISC_WR_REG_CMD_BUF,
@@ -1643,15 +1643,15 @@ void noc_inline_dw_write(uint64_t addr, uint32_t val, uint8_t be = 0xF) {
  * | incr      | The value to increment by                                      | uint32_t | Any uint32_t value                                            | True     |
  */
 inline
-void noc_semaphore_inc(uint64_t addr, uint32_t incr, uint8_t noc_idx = noc_index) {
+void noc_semaphore_inc(uint64_t addr, uint32_t incr, uint8_t noc_id = noc_index) {
     /*
     [REFER TO grayskull/noc/noc.h for the documentation of noc_atomic_increment()]
     Generic increment with 32-bit wrap.
   */
     DEBUG_STATUS("NSIW");
-    DEBUG_SANITIZE_NOC_ADDR(addr, 4);
+    DEBUG_SANITIZE_NOC_ADDR(noc_id, addr, 4);
     DEBUG_INSERT_DELAY(TransactionAtomic);
-    noc_fast_atomic_increment(noc_idx, NCRISC_AT_CMD_BUF, addr, NOC_UNICAST_WRITE_VC, incr, 31 /*wrap*/, false /*linked*/, false /*posted*/);
+    noc_fast_atomic_increment(noc_id, NCRISC_AT_CMD_BUF, addr, NOC_UNICAST_WRITE_VC, incr, 31 /*wrap*/, false /*linked*/, false /*posted*/);
     DEBUG_STATUS("NSID");
 }
 

--- a/tt_metal/hw/inc/dataflow_api.h
+++ b/tt_metal/hw/inc/dataflow_api.h
@@ -1520,9 +1520,9 @@ void noc_async_writes_flushed() {
  * Return value: None
  */
 FORCE_INLINE
-void noc_async_atomic_barrier() {
+void noc_async_atomic_barrier(uint8_t noc_idx = noc_index) {
     DEBUG_STATUS("NABW");
-    while (!ncrisc_noc_nonposted_atomics_flushed(noc_index))
+    while (!ncrisc_noc_nonposted_atomics_flushed(noc_idx))
         ;
     DEBUG_STATUS("NABD");
 }
@@ -1643,7 +1643,7 @@ void noc_inline_dw_write(uint64_t addr, uint32_t val, uint8_t be = 0xF) {
  * | incr      | The value to increment by                                      | uint32_t | Any uint32_t value                                            | True     |
  */
 inline
-void noc_semaphore_inc(uint64_t addr, uint32_t incr) {
+void noc_semaphore_inc(uint64_t addr, uint32_t incr, uint8_t noc_idx = noc_index) {
     /*
     [REFER TO grayskull/noc/noc.h for the documentation of noc_atomic_increment()]
     Generic increment with 32-bit wrap.
@@ -1651,7 +1651,7 @@ void noc_semaphore_inc(uint64_t addr, uint32_t incr) {
     DEBUG_STATUS("NSIW");
     DEBUG_SANITIZE_NOC_ADDR(addr, 4);
     DEBUG_INSERT_DELAY(TransactionAtomic);
-    noc_fast_atomic_increment(noc_index, NCRISC_AT_CMD_BUF, addr, NOC_UNICAST_WRITE_VC, incr, 31 /*wrap*/, false /*linked*/, false /*posted*/);
+    noc_fast_atomic_increment(noc_idx, NCRISC_AT_CMD_BUF, addr, NOC_UNICAST_WRITE_VC, incr, 31 /*wrap*/, false /*linked*/, false /*posted*/);
     DEBUG_STATUS("NSID");
 }
 

--- a/tt_metal/hw/inc/dataflow_internal.h
+++ b/tt_metal/hw/inc/dataflow_internal.h
@@ -32,7 +32,7 @@ FORCE_INLINE
 void noc_fast_read(uint32_t src_addr, uint32_t dest_addr) {
     DEBUG_STATUS("NFRW");
     DEBUG_SANITIZE_NOC_READ_TRANSACTION(
-        (uint64_t)(src_addr) | (uint64_t)NOC_CMD_BUF_READ_REG(noc_index, NCRISC_RD_CMD_BUF, NOC_TARG_ADDR_COORDINATE) << 32,
+        noc_index, (uint64_t)(src_addr) | (uint64_t)NOC_CMD_BUF_READ_REG(noc_index, NCRISC_RD_CMD_BUF, NOC_TARG_ADDR_COORDINATE) << 32,
         dest_addr,
         NOC_CMD_BUF_READ_REG(noc_index, NCRISC_RD_CMD_BUF, NOC_AT_LEN_BE)
     );
@@ -81,7 +81,7 @@ void noc_fast_write_set_len(uint32_t len_bytes) {
 FORCE_INLINE
 void noc_fast_write(uint32_t src_addr, uint64_t dest_addr) {
     DEBUG_SANITIZE_NOC_WRITE_TRANSACTION(
-        dest_addr | (uint64_t)NOC_CMD_BUF_READ_REG(noc_index, NCRISC_WR_CMD_BUF, NOC_RET_ADDR_COORDINATE) << 32,
+        noc_index, dest_addr | (uint64_t)NOC_CMD_BUF_READ_REG(noc_index, NCRISC_WR_CMD_BUF, NOC_RET_ADDR_COORDINATE) << 32,
         dest_addr,
         NOC_CMD_BUF_READ_REG(noc_index, NCRISC_WR_CMD_BUF, NOC_AT_LEN_BE)
     );

--- a/tt_metal/hw/inc/debug/sanitize_noc.h
+++ b/tt_metal/hw/inc/debug/sanitize_noc.h
@@ -199,7 +199,8 @@ void debug_sanitize_noc_and_worker_addr(
 // TODO: Clean these up with #7453
 #define DEBUG_SANITIZE_NOC_READ_TRANSACTION_FROM_STATE(noc_id)                                   \
     DEBUG_SANITIZE_NOC_READ_TRANSACTION(                                                         \
-        ((uint64_t)NOC_CMD_BUF_READ_REG(noc_id, NCRISC_RD_CMD_BUF, NOC_TARG_ADDR_COORDINATE) << NOC_ADDR_COORD_SHIFT) |   \
+        noc_id,                                                                                  \
+            ((uint64_t)NOC_CMD_BUF_READ_REG(noc_id, NCRISC_RD_CMD_BUF, NOC_TARG_ADDR_COORDINATE) << NOC_ADDR_COORD_SHIFT) |   \
             ((uint64_t)NOC_CMD_BUF_READ_REG(noc_id, NCRISC_RD_CMD_BUF, NOC_TARG_ADDR_MID) << 32) | \
             ((uint64_t)NOC_CMD_BUF_READ_REG(noc_id, NCRISC_RD_CMD_BUF, NOC_TARG_ADDR_LO)), \
         NOC_CMD_BUF_READ_REG(noc_id, NCRISC_RD_CMD_BUF, NOC_RET_ADDR_LO),                        \
@@ -208,52 +209,56 @@ void debug_sanitize_noc_and_worker_addr(
 
 #define DEBUG_SANITIZE_NOC_WRITE_TRANSACTION_FROM_STATE(noc_id)                               \
     DEBUG_SANITIZE_NOC_WRITE_TRANSACTION(                                                     \
-        ((uint64_t)NOC_CMD_BUF_READ_REG(noc_id, NCRISC_WR_CMD_BUF, NOC_RET_ADDR_COORDINATE) << NOC_ADDR_COORD_SHIFT) | \
+        noc_id,                                                                               \
+            ((uint64_t)NOC_CMD_BUF_READ_REG(noc_id, NCRISC_WR_CMD_BUF, NOC_RET_ADDR_COORDINATE) << NOC_ADDR_COORD_SHIFT) | \
             ((uint64_t)NOC_CMD_BUF_READ_REG(noc_id, NCRISC_WR_CMD_BUF, NOC_RET_ADDR_MID) << 32) | \
             ((uint64_t)NOC_CMD_BUF_READ_REG(noc_id, NCRISC_WR_CMD_BUF, NOC_RET_ADDR_LO)),     \
         NOC_CMD_BUF_READ_REG(noc_id, NCRISC_WR_CMD_BUF, NOC_TARG_ADDR_LO),                    \
         NOC_CMD_BUF_READ_REG(noc_id, NCRISC_WR_CMD_BUF, NOC_AT_LEN_BE));                      \
     debug_insert_delay((uint8_t)TransactionWrite);
-#define DEBUG_SANITIZE_NOC_ADDR(a, l)                                                      \
-    debug_sanitize_noc_addr(noc_index, a, 0, l, DEBUG_SANITIZE_NOC_UNICAST, DEBUG_SANITIZE_NOC_READ); \
+#define DEBUG_SANITIZE_NOC_ADDR(noc_id, a, l)                                                      \
+    debug_sanitize_noc_addr(noc_id, a, 0, l, DEBUG_SANITIZE_NOC_UNICAST, DEBUG_SANITIZE_NOC_READ); \
     LOG_LEN(l)
-#define DEBUG_SANITIZE_NOC_TRANSACTION(noc_a, worker_a, l, multicast, dir)  \
-    debug_sanitize_noc_and_worker_addr(noc_index, noc_a, worker_a, l, multicast, dir); \
+#define DEBUG_SANITIZE_NOC_TRANSACTION(noc_id, noc_a, worker_a, l, multicast, dir)  \
+    debug_sanitize_noc_and_worker_addr(noc_id, noc_a, worker_a, l, multicast, dir); \
     LOG_LEN(l)
-#define DEBUG_SANITIZE_NOC_READ_TRANSACTION(noc_a, worker_a, l)                                                  \
-    debug_sanitize_noc_and_worker_addr(noc_index, noc_a, worker_a, l, DEBUG_SANITIZE_NOC_UNICAST, DEBUG_SANITIZE_NOC_READ); \
+#define DEBUG_SANITIZE_NOC_READ_TRANSACTION(noc_id, noc_a, worker_a, l)                                                  \
+    debug_sanitize_noc_and_worker_addr(noc_id, noc_a, worker_a, l, DEBUG_SANITIZE_NOC_UNICAST, DEBUG_SANITIZE_NOC_READ); \
     LOG_LEN(l);                                                                                                  \
     debug_insert_delay((uint8_t)TransactionRead);
-#define DEBUG_SANITIZE_NOC_MULTI_READ_TRANSACTION(noc_a, worker_a, l)                                              \
-    debug_sanitize_noc_and_worker_addr(noc_index, noc_a, worker_a, l, DEBUG_SANITIZE_NOC_MULTICAST, DEBUG_SANITIZE_NOC_READ); \
+#define DEBUG_SANITIZE_NOC_MULTI_READ_TRANSACTION(noc_id, noc_a, worker_a, l)                                              \
+    debug_sanitize_noc_and_worker_addr(noc_id, noc_a, worker_a, l, DEBUG_SANITIZE_NOC_MULTICAST, DEBUG_SANITIZE_NOC_READ); \
     LOG_LEN(l);                                                                                                    \
     debug_insert_delay((uint8_t)TransactionRead);
-#define DEBUG_SANITIZE_NOC_WRITE_TRANSACTION(noc_a, worker_a, l)                                                  \
-    debug_sanitize_noc_and_worker_addr(noc_index, noc_a, worker_a, l, DEBUG_SANITIZE_NOC_UNICAST, DEBUG_SANITIZE_NOC_WRITE); \
+#define DEBUG_SANITIZE_NOC_WRITE_TRANSACTION(noc_id, noc_a, worker_a, l)                                                  \
+    debug_sanitize_noc_and_worker_addr(noc_id, noc_a, worker_a, l, DEBUG_SANITIZE_NOC_UNICAST, DEBUG_SANITIZE_NOC_WRITE); \
     LOG_LEN(l);                                                                                                   \
     debug_insert_delay((uint8_t)TransactionWrite)
-#define DEBUG_SANITIZE_NOC_MULTI_WRITE_TRANSACTION(noc_a, worker_a, l)                                              \
-    debug_sanitize_noc_and_worker_addr(noc_index, noc_a, worker_a, l, DEBUG_SANITIZE_NOC_MULTICAST, DEBUG_SANITIZE_NOC_WRITE); \
+#define DEBUG_SANITIZE_NOC_MULTI_WRITE_TRANSACTION(noc_id, noc_a, worker_a, l)                                              \
+    debug_sanitize_noc_and_worker_addr(noc_id, noc_a, worker_a, l, DEBUG_SANITIZE_NOC_MULTICAST, DEBUG_SANITIZE_NOC_WRITE); \
     LOG_LEN(l);                                                                                                     \
     debug_insert_delay((uint8_t)TransactionWrite);
 
 #define DEBUG_SANITIZE_NOC_READ_TRANSACTION_WITH_ADDR_AND_SIZE_STATE(noc_id, noc_a_lower, worker_a)         \
     DEBUG_SANITIZE_NOC_READ_TRANSACTION(                                                                    \
-        ((uint64_t)NOC_CMD_BUF_READ_REG(noc_id, NCRISC_RD_CMD_BUF, NOC_TARG_ADDR_COORDINATE) << NOC_ADDR_COORD_SHIFT) | \
+        noc_id,                                                                                             \
+            ((uint64_t)NOC_CMD_BUF_READ_REG(noc_id, NCRISC_RD_CMD_BUF, NOC_TARG_ADDR_COORDINATE) << NOC_ADDR_COORD_SHIFT) | \
             ((uint64_t)NOC_CMD_BUF_READ_REG(noc_id, NCRISC_RD_CMD_BUF, NOC_TARG_ADDR_MID) << 32) | \
             noc_a_lower, \
         worker_a,                                                                                           \
         NOC_CMD_BUF_READ_REG(noc_id, NCRISC_RD_CMD_BUF, NOC_AT_LEN_BE));
 #define DEBUG_SANITIZE_NOC_READ_TRANSACTION_WITH_ADDR_STATE(noc_id, noc_a_lower, worker_a, l)               \
     DEBUG_SANITIZE_NOC_READ_TRANSACTION(                                                                    \
-        ((uint64_t)NOC_CMD_BUF_READ_REG(noc_id, NCRISC_RD_CMD_BUF, NOC_TARG_ADDR_COORDINATE) << NOC_ADDR_COORD_SHIFT) | \
+        noc_id,                                                                                             \
+            ((uint64_t)NOC_CMD_BUF_READ_REG(noc_id, NCRISC_RD_CMD_BUF, NOC_TARG_ADDR_COORDINATE) << NOC_ADDR_COORD_SHIFT) | \
             ((uint64_t)NOC_CMD_BUF_READ_REG(noc_id, NCRISC_RD_CMD_BUF, NOC_TARG_ADDR_MID) << 32) | \
             noc_a_lower, \
         worker_a,                                                                                           \
         l);
 #define DEBUG_SANITIZE_NOC_WRITE_TRANSACTION_WITH_ADDR_AND_SIZE_STATE(noc_id, noc_a_lower, worker_a)           \
     DEBUG_SANITIZE_NOC_WRITE_TRANSACTION(                                                                      \
-        ((uint64_t)NOC_CMD_BUF_READ_REG(noc_id, NCRISC_WR_CMD_BUF, NOC_TARG_ADDR_COORDINATE) << NOC_ADDR_COORD_SHIFT) | \
+        noc_id,                                                                                                \
+            ((uint64_t)NOC_CMD_BUF_READ_REG(noc_id, NCRISC_WR_CMD_BUF, NOC_TARG_ADDR_COORDINATE) << NOC_ADDR_COORD_SHIFT) | \
             ((uint64_t)NOC_CMD_BUF_READ_REG(noc_id, NCRISC_WR_CMD_BUF, NOC_TARG_ADDR_MID) << 32) | \
             noc_a_lower, \
         worker_a,                                                                                              \
@@ -282,12 +287,12 @@ inline void debug_insert_delay(uint8_t transaction_type) {
 
 #else  // !WATCHER_ENABLED
 
-#define DEBUG_SANITIZE_NOC_ADDR(a, l) LOG_LEN(l)
-#define DEBUG_SANITIZE_NOC_TRANSACTION(noc_a, worker_a, l, multicast, dir) LOG_LEN(l)
-#define DEBUG_SANITIZE_NOC_READ_TRANSACTION(noc_a, worker_a, l) LOG_LEN(l)
-#define DEBUG_SANITIZE_NOC_MULTI_READ_TRANSACTION(noc_a, worker_a, l) LOG_LEN(l)
-#define DEBUG_SANITIZE_NOC_WRITE_TRANSACTION(noc_a, worker_a, l) LOG_LEN(l)
-#define DEBUG_SANITIZE_NOC_MULTI_WRITE_TRANSACTION(noc_a, worker_a, l) LOG_LEN(l)
+#define DEBUG_SANITIZE_NOC_ADDR(noc_id, a, l) LOG_LEN(l)
+#define DEBUG_SANITIZE_NOC_TRANSACTION(noc_id, noc_a, worker_a, l, multicast, dir) LOG_LEN(l)
+#define DEBUG_SANITIZE_NOC_READ_TRANSACTION(noc_id, noc_a, worker_a, l) LOG_LEN(l)
+#define DEBUG_SANITIZE_NOC_MULTI_READ_TRANSACTION(noc_id, noc_a, worker_a, l) LOG_LEN(l)
+#define DEBUG_SANITIZE_NOC_WRITE_TRANSACTION(noc_id, noc_a, worker_a, l) LOG_LEN(l)
+#define DEBUG_SANITIZE_NOC_MULTI_WRITE_TRANSACTION(noc_id, noc_a, worker_a, l) LOG_LEN(l)
 #define DEBUG_SANITIZE_NOC_READ_TRANSACTION_WITH_ADDR_AND_SIZE_STATE(noc_id, noc_a_lower, worker_a) \
     LOG_READ_LEN_FROM_STATE(noc_id)
 #define DEBUG_SANITIZE_NOC_READ_TRANSACTION_WITH_ADDR_STATE(noc_id, noc_a_lower, worker_a, l) LOG_LEN(l)

--- a/tt_metal/hw/inc/ethernet/tunneling.h
+++ b/tt_metal/hw/inc/ethernet/tunneling.h
@@ -96,7 +96,7 @@ void notify_dispatch_core_done(uint64_t dispatch_addr) {
         while (!noc_cmd_buf_ready(n, NCRISC_AT_CMD_BUF))
             ;
     }
-    DEBUG_SANITIZE_NOC_ADDR(dispatch_addr, 4);
+    DEBUG_SANITIZE_NOC_ADDR(noc_index, dispatch_addr, 4);
     noc_fast_atomic_increment(
         noc_index, NCRISC_AT_CMD_BUF, dispatch_addr, NOC_UNICAST_WRITE_VC, 1, 31 /*wrap*/, false /*linked*/);
 }

--- a/tt_metal/impl/device/device.cpp
+++ b/tt_metal/impl/device/device.cpp
@@ -493,19 +493,22 @@ void Device::configure_kernel_variant(
     CoreCoord upstream_physical_core,
     CoreCoord downstream_physical_core,
     std::map<string, string> defines_in,
-    NOC noc_index,
+    NOC my_noc_index,
+    NOC upstream_noc_index,
+    NOC downstream_noc_index,
     bool is_active_eth_core) {
 
-    const auto& grid_size = tt::Cluster::instance().get_soc_desc(this->id()).grid_size;
+    const auto& grid_size = this->grid_size();
 
     std::map<string, string> defines = {
         {"DISPATCH_KERNEL", "1"},
-        {"MY_NOC_X", std::to_string(NOC_0_X(noc_index, grid_size.x, kernel_physical_core.x))},
-        {"MY_NOC_Y", std::to_string(NOC_0_Y(noc_index, grid_size.y, kernel_physical_core.y))},
-        {"UPSTREAM_NOC_X", std::to_string(NOC_0_X(noc_index, grid_size.x, upstream_physical_core.x))},
-        {"UPSTREAM_NOC_Y", std::to_string(NOC_0_Y(noc_index, grid_size.y, upstream_physical_core.y))},
-        {"DOWNSTREAM_NOC_X", std::to_string(NOC_0_X(noc_index, grid_size.x, downstream_physical_core.x))},
-        {"DOWNSTREAM_NOC_Y", std::to_string(NOC_0_Y(noc_index, grid_size.y, downstream_physical_core.y))},
+        {"MY_NOC_X", std::to_string(NOC_0_X(my_noc_index, grid_size.x, kernel_physical_core.x))},
+        {"MY_NOC_Y", std::to_string(NOC_0_Y(my_noc_index, grid_size.y, kernel_physical_core.y))},
+        {"UPSTREAM_NOC_INDEX", std::to_string(upstream_noc_index)},
+        {"UPSTREAM_NOC_X", std::to_string(NOC_0_X(upstream_noc_index, grid_size.x, upstream_physical_core.x))},
+        {"UPSTREAM_NOC_Y", std::to_string(NOC_0_Y(upstream_noc_index, grid_size.y, upstream_physical_core.y))},
+        {"DOWNSTREAM_NOC_X", std::to_string(NOC_0_X(downstream_noc_index, grid_size.x, downstream_physical_core.x))},
+        {"DOWNSTREAM_NOC_Y", std::to_string(NOC_0_Y(downstream_noc_index, grid_size.y, downstream_physical_core.y))},
     };
     defines.insert(defines_in.begin(), defines_in.end());
 
@@ -516,7 +519,7 @@ void Device::configure_kernel_variant(
             kernel_core,
             tt::tt_metal::DataMovementConfig {
                 .processor = tt::tt_metal::DataMovementProcessor::RISCV_1,
-                .noc = noc_index,
+                .noc = my_noc_index,
                 .compile_args = compile_args,
                 .defines = defines
             }
@@ -528,7 +531,7 @@ void Device::configure_kernel_variant(
             kernel_core,
             tt::tt_metal::EthernetConfig{
                 .eth_mode = is_active_eth_core ? Eth::SENDER : Eth::IDLE,
-                .noc = noc_index,
+                .noc = my_noc_index,
                 .compile_args = compile_args,
                 .defines = defines
             }
@@ -1342,6 +1345,14 @@ void Device::compile_command_queue_programs() {
     constexpr uint32_t prefetch_d_downstream_cb_sem = 2;
     constexpr uint32_t dispatch_downstream_cb_sem = 1;
 
+    // TODO: this->hw_command_queues_[cq_id]->noc_index is also hardcoded to NOC_0 elsewhere, should have one definition and remove assertion
+    constexpr NOC my_noc_index = NOC::NOC_0;
+    constexpr NOC dispatch_upstream_noc_index = NOC::NOC_1;
+    static_assert(my_noc_index != dispatch_upstream_noc_index, "Dispatch NOC used to communicate with upstream must be different from NOC used for other transactions");
+    for (uint8_t cq_id = 0; cq_id < this->num_hw_cqs(); cq_id++) {
+        TT_ASSERT(this->hw_command_queues_[cq_id]->noc_index == my_noc_index, "Command Queue NOC index must match");
+    }
+
     if (this->is_mmio_capable()) {
         auto device_id = this->id();
         uint32_t num_compute_cores = this->compute_with_storage_grid_size().x * this->compute_with_storage_grid_size().y;
@@ -1356,8 +1367,6 @@ void Device::compile_command_queue_programs() {
 
             CoreCoord prefetch_physical_core = get_physical_core_coordinate(prefetch_core, dispatch_core_type);
             CoreCoord dispatch_physical_core = get_physical_core_coordinate(dispatch_core, dispatch_core_type);
-
-            NOC noc_index = this->hw_command_queues_[cq_id]->noc_index;
 
             log_debug(LogDevice, "Dispatching out of {} cores",  magic_enum::enum_name(dispatch_core_type));
             log_debug(LogDevice, "Prefetch HD logical location: {} physical core: {}", prefetch_core.str(), prefetch_physical_core.str());
@@ -1405,7 +1414,9 @@ void Device::compile_command_queue_programs() {
                 CoreCoord{0, 0},
                 dispatch_physical_core,
                 std::map<string, string> {},
-                noc_index
+                my_noc_index,
+                my_noc_index,
+                my_noc_index
             );
 
             tt::tt_metal::CreateSemaphore(*command_queue_program_ptr, prefetch_core, 0, dispatch_core_type); // prefetch_sync_sem
@@ -1446,7 +1457,9 @@ void Device::compile_command_queue_programs() {
                 prefetch_physical_core,
                 CoreCoord{0, 0},
                 std::map<string, string> {},
-                noc_index
+                my_noc_index,
+                dispatch_upstream_noc_index,
+                my_noc_index
             );
 
             tt::tt_metal::CreateSemaphore(*command_queue_program_ptr, dispatch_core, 0, dispatch_core_type); // dispatch_sem
@@ -1494,7 +1507,6 @@ void Device::compile_command_queue_programs() {
             /////////////////Following section is for mmio device serving Remote Device
             uint32_t cq_id = 0;
             for (auto [prefetch_core, prefetch_settings] : mmio_device_worker_variants[DispatchWorkerType::PREFETCH]) {
-                NOC noc_index = this->hw_command_queues_[cq_id]->noc_index;
                 for (auto sem : prefetch_settings.semaphores) {
                     //size of semaphores vector is number of needed semaphores on the core.
                     //Value of each vector entry is the initialization value for the semaphore.
@@ -1510,7 +1522,9 @@ void Device::compile_command_queue_programs() {
                     prefetch_settings.upstream_cores[0],
                     prefetch_settings.downstream_cores[0],
                     std::map<string, string> {},
-                    this->hw_command_queues_[cq_id]->noc_index
+                    my_noc_index,
+                    my_noc_index,
+                    my_noc_index
                 );
                 cq_id = (cq_id + 1) % num_hw_cqs;
             }
@@ -1531,7 +1545,9 @@ void Device::compile_command_queue_programs() {
                 CoreCoord{0, 0},
                 CoreCoord{0, 0},
                 std::map<string, string> {{"SKIP_NOC_LOGGING", "1"}},
-                this->hw_command_queues_[0]->noc_index // Only one Mux - use NOC for CQ 0
+                my_noc_index, // Only one Mux - use NOC for CQ 0
+                my_noc_index,
+                my_noc_index
             );
 
             auto [tunneler_core, tunneler_settings] = mmio_device_worker_variants[DispatchWorkerType::US_TUNNELER_REMOTE][0];
@@ -1545,7 +1561,9 @@ void Device::compile_command_queue_programs() {
                 CoreCoord{0, 0},
                 CoreCoord{0, 0},
                 std::map<string, string> {{"SKIP_NOC_LOGGING", "1"}},
-                this->hw_command_queues_[0]->noc_index, // Only one Remote Tunneler - use NOC for CQ 0
+                my_noc_index, // Only one Remote Tunneler - use NOC for CQ 0
+                my_noc_index,
+                my_noc_index,
                 true
             );
 
@@ -1565,7 +1583,9 @@ void Device::compile_command_queue_programs() {
                 CoreCoord{0, 0},
                 CoreCoord{0, 0},
                 std::map<string, string> {{"SKIP_NOC_LOGGING", "1"}},
-                this->hw_command_queues_[0]->noc_index // Only one Demux - use NOC for CQ 0
+                my_noc_index, // Only one Demux - use NOC for CQ 0
+                my_noc_index,
+                my_noc_index
             );
             cq_id = 0;
             for (auto [dispatch_core, dispatch_settings] : mmio_device_worker_variants[DispatchWorkerType::DISPATCH]) {
@@ -1584,7 +1604,9 @@ void Device::compile_command_queue_programs() {
                     dispatch_settings.upstream_cores[0],
                     CoreCoord{0xffffffff, 0xffffffff},
                     std::map<string, string> {},
-                    this->hw_command_queues_[cq_id]->noc_index
+                    my_noc_index,
+                    dispatch_upstream_noc_index,
+                    my_noc_index
                 );
                 cq_id = (cq_id + 1) % num_hw_cqs;
             }
@@ -1603,7 +1625,9 @@ void Device::compile_command_queue_programs() {
             CoreCoord{0, 0},
             CoreCoord{0, 0},
             std::map<string, string> {{"SKIP_NOC_LOGGING", "1"}},
-            this->hw_command_queues_[0]->noc_index, // Only one Local Tunneler - use NOC for CQ 0
+            my_noc_index, // Only one Local Tunneler - use NOC for CQ 0
+            my_noc_index,
+            my_noc_index,
             true
         );
 
@@ -1620,7 +1644,9 @@ void Device::compile_command_queue_programs() {
                 CoreCoord{0, 0},
                 CoreCoord{0, 0},
                 std::map<string, string> {{"SKIP_NOC_LOGGING", "1"}},
-                this->hw_command_queues_[0]->noc_index, // Only one Remote Tunneler - use NOC for CQ 0
+                my_noc_index, // Only one Remote Tunneler - use NOC for CQ 0
+                my_noc_index,
+                my_noc_index,
                 true
             );
         }
@@ -1641,7 +1667,9 @@ void Device::compile_command_queue_programs() {
             CoreCoord{0, 0},
             CoreCoord{0, 0},
             std::map<string, string> {{"SKIP_NOC_LOGGING", "1"}},
-            this->hw_command_queues_[0]->noc_index // Only one Demux - use NOC for CQ 0
+            my_noc_index, // Only one Demux - use NOC for CQ 0
+            my_noc_index,
+            my_noc_index
         );
         uint32_t cq_id = 0;
         for (auto [prefetch_d_core, prefetch_d_settings] : device_worker_variants[DispatchWorkerType::PREFETCH_D]) {
@@ -1660,7 +1688,9 @@ void Device::compile_command_queue_programs() {
                 prefetch_d_settings.upstream_cores[0],
                 prefetch_d_settings.downstream_cores[0],
                 std::map<string, string> {},
-                this->hw_command_queues_[cq_id]->noc_index
+                my_noc_index,
+                my_noc_index,
+                my_noc_index
             );
             cq_id = (cq_id + 1) % num_hw_cqs;
         }
@@ -1681,7 +1711,9 @@ void Device::compile_command_queue_programs() {
                 dispatch_d_settings.upstream_cores[0],
                 dispatch_d_settings.downstream_cores[0],
                 std::map<string, string> {},
-                this->hw_command_queues_[cq_id]->noc_index
+                my_noc_index,
+                dispatch_upstream_noc_index,
+                my_noc_index
             );
             cq_id = (cq_id + 1) % num_hw_cqs;
         }
@@ -1703,7 +1735,9 @@ void Device::compile_command_queue_programs() {
             CoreCoord{0, 0},
             CoreCoord{0, 0},
             std::map<string, string> {{"SKIP_NOC_LOGGING", "1"}},
-            this->hw_command_queues_[0]->noc_index // Only one Mux - use NOC for CQ 0
+            my_noc_index, // Only one Mux - use NOC for CQ 0
+            my_noc_index,
+            my_noc_index
         );
 
         detail::CompileProgram(this, *command_queue_program_ptr, /*fd_bootloader_mode=*/true);
@@ -2008,6 +2042,10 @@ uint32_t Device::dram_size_per_channel() const {
     return tt::Cluster::instance().get_soc_desc(id_).dram_bank_size;
 }
 
+CoreCoord Device::grid_size() const {
+    return tt::Cluster::instance().get_soc_desc(id_).grid_size;
+}
+
 CoreCoord Device::logical_grid_size() const {
     return tt::Cluster::instance().get_soc_desc(id_).worker_grid_size;
 }
@@ -2077,7 +2115,7 @@ std::vector<CoreCoord> Device::ethernet_cores_from_logical_cores(const std::vect
 }
 
 uint32_t Device::get_noc_unicast_encoding(uint8_t noc_index, const CoreCoord& physical_core) const {
-    const auto& grid_size = tt::Cluster::instance().get_soc_desc(this->id()).grid_size;
+    const auto& grid_size = this->grid_size();
     return NOC_XY_ENCODING(
         NOC_0_X(noc_index, grid_size.x, physical_core.x),
         NOC_0_Y(noc_index, grid_size.y, physical_core.y)
@@ -2085,7 +2123,7 @@ uint32_t Device::get_noc_unicast_encoding(uint8_t noc_index, const CoreCoord& ph
 }
 
 uint32_t Device::get_noc_multicast_encoding(uint8_t noc_index, const CoreRange& physical_cores) const {
-    const auto& grid_size = tt::Cluster::instance().get_soc_desc(this->id()).grid_size;
+    const auto& grid_size = this->grid_size();
 
     // NOC 1 mcasts from bottom left to top right, so we need to reverse the coords
     if (noc_index == 0) {

--- a/tt_metal/impl/device/device.hpp
+++ b/tt_metal/impl/device/device.hpp
@@ -90,6 +90,8 @@ class Device {
     uint32_t l1_size_per_core() const;
     uint32_t dram_size_per_channel() const;
 
+    CoreCoord grid_size() const;
+
     CoreCoord logical_grid_size() const;
 
     CoreCoord compute_with_storage_grid_size() const;
@@ -225,7 +227,7 @@ class Device {
     void init_command_queue_device();
     void initialize_synchronous_sw_cmd_queue();
     void configure_kernel_variant(Program& program, string path, std::vector<uint32_t> compile_args, CoreCoord kernel_core, CoreCoord Kernel_physical_core,
-                                  CoreType dispatch_core_type, CoreCoord upstream_physical_core, CoreCoord downstream_physical_core, std::map<string, string> defines_in, NOC noc_index, bool is_active_eth_core = false);
+                                  CoreType dispatch_core_type, CoreCoord upstream_physical_core, CoreCoord downstream_physical_core, std::map<string, string> defines_in, NOC my_noc_index, NOC upstream_noc_index, NOC downstream_noc_index, bool is_active_eth_core = false);
     void compile_command_queue_programs();
     void configure_command_queue_programs();
     void clear_l1_state();

--- a/tt_metal/impl/dispatch/command_queue.cpp
+++ b/tt_metal/impl/dispatch/command_queue.cpp
@@ -909,7 +909,8 @@ void EnqueueProgramCommand::assemble_device_commands(
                             .noc_xy_addr = noc_encoding,
                             .addr = dst_addr,
                             .length = (uint16_t)write_length,
-                            .num_mcast_dests = (uint16_t)num_mcast_dests});
+                            .num_mcast_dests = (uint8_t)num_mcast_dests,
+                            .flags = CQ_DISPATCH_CMD_PACKED_WRITE_LARGE_FLAG_NONE});
                         RecordDispatchData(
                             program, DISPATCH_DATA_BINARY, write_length, kg_transfer_info.riscvs[kernel_idx]);
                         dst_addr += write_length;
@@ -924,6 +925,10 @@ void EnqueueProgramCommand::assemble_device_commands(
                         kernel_bins_write_packed_large_data_aligned_sizeB.back() += read_length;
                     }
                 }
+            }
+            // Unlink the last subcmd of the current core range
+            if (!write_linear) {
+                kernel_bins_dispatch_subcmds.back().back().flags |= CQ_DISPATCH_CMD_PACKED_WRITE_LARGE_FLAG_UNLINK;
             }
         }
         for (uint32_t i = 0; i < kernel_bins_dispatch_subcmds.size(); ++i) {

--- a/tt_metal/impl/dispatch/command_queue.hpp
+++ b/tt_metal/impl/dispatch/command_queue.hpp
@@ -44,10 +44,6 @@ enum class EnqueueCommandType {
 
 string EnqueueCommandTypeToString(EnqueueCommandType ctype);
 
-// TEMPORARY! TODO(agrebenisan): need to use proper macro based on loading noc
-#define NOC_X(x) x
-#define NOC_Y(y) y
-
 class CommandQueue;
 class CommandInterface;
 

--- a/tt_metal/impl/dispatch/cq_commands.hpp
+++ b/tt_metal/impl/dispatch/cq_commands.hpp
@@ -178,7 +178,6 @@ struct CQDispatchWritePagedCmd {
 constexpr uint32_t CQ_DISPATCH_CMD_PACKED_WRITE_FLAG_NONE      = 0x00;
 constexpr uint32_t CQ_DISPATCH_CMD_PACKED_WRITE_FLAG_MCAST     = 0x01;
 constexpr uint32_t CQ_DISPATCH_CMD_PACKED_WRITE_FLAG_NO_STRIDE = 0x02;
-constexpr uint32_t CQ_DISPATCH_CMD_PACKED_WRITE_RELAY = 0x03;
 
 struct CQDispatchWritePackedCmd {
     uint8_t flags;            // see above
@@ -197,11 +196,14 @@ struct CQDispatchWritePackedMulticastSubCmd {
     uint32_t num_mcast_dests;
 } __attribute__((packed));
 
+constexpr uint32_t CQ_DISPATCH_CMD_PACKED_WRITE_LARGE_FLAG_NONE   = 0x00;
+constexpr uint32_t CQ_DISPATCH_CMD_PACKED_WRITE_LARGE_FLAG_UNLINK = 0x01;
 struct CQDispatchWritePackedLargeSubCmd {
     uint32_t noc_xy_addr;
     uint32_t addr;
     uint16_t length;          // multiples of L1 cache line alignment
-    uint16_t num_mcast_dests;
+    uint8_t num_mcast_dests;
+    uint8_t flags;
 } __attribute__((packed));
 
 constexpr inline __attribute__((always_inline)) uint32_t get_packed_write_max_multicast_sub_cmds(uint32_t packed_write_max_unicast_sub_cmds) {

--- a/tt_metal/impl/dispatch/kernels/cq_common.hpp
+++ b/tt_metal/impl/dispatch/kernels/cq_common.hpp
@@ -117,18 +117,30 @@ void cq_noc_async_write_with_state(uint32_t src_addr, uint64_t dst_addr, uint32_
 
 // More generic version of cq_noc_async_write_with_state: Allows writing an abitrary amount of data, when the NOC config (dst_noc,
 // VC..) have been specified.
+template<bool write_last_packet = true>
 FORCE_INLINE
-void cq_noc_async_write_with_state_any_len(uint32_t src_addr, uint64_t dst_addr, uint32_t size = 0, uint32_t ndests = 1) {
-    while(size > NOC_MAX_BURST_SIZE) {
+uint32_t cq_noc_async_write_with_state_any_len(uint32_t src_addr, uint64_t dst_addr, uint32_t size = 0, uint32_t ndests = 1) {
+    if (size > NOC_MAX_BURST_SIZE) {
         cq_noc_async_write_with_state<CQ_NOC_SnDL>(src_addr, dst_addr, NOC_MAX_BURST_SIZE, ndests);
         src_addr += NOC_MAX_BURST_SIZE;
         dst_addr += NOC_MAX_BURST_SIZE;
         size -= NOC_MAX_BURST_SIZE;
+        while(size > NOC_MAX_BURST_SIZE) {
+            cq_noc_async_write_with_state<CQ_NOC_SnDl>(src_addr, dst_addr, NOC_MAX_BURST_SIZE, ndests);
+            src_addr += NOC_MAX_BURST_SIZE;
+            dst_addr += NOC_MAX_BURST_SIZE;
+            size -= NOC_MAX_BURST_SIZE;
+        }
     }
-    cq_noc_async_write_with_state<CQ_NOC_SnDL>(src_addr, dst_addr, size, ndests);
+    if constexpr (write_last_packet) {
+        cq_noc_async_write_with_state<CQ_NOC_SnDL>(src_addr, dst_addr, size, ndests);
+        return 0;
+    } else {
+        return size;
+    }
 }
 
-template<enum CQNocFlags flags, bool mcast = false>
+template<enum CQNocFlags flags, bool mcast = false, bool linked = false>
 FORCE_INLINE
 void cq_noc_async_write_init_state(uint32_t src_addr, uint64_t dst_addr, uint32_t size = 0) {
 
@@ -139,9 +151,8 @@ void cq_noc_async_write_init_state(uint32_t src_addr, uint64_t dst_addr, uint32_
     }
     DEBUG_STATUS("NSID");
 
-    constexpr bool multicast_path_reserve = mcast;
+    constexpr bool multicast_path_reserve = true;
     constexpr bool posted = false;
-    constexpr bool linked = false;
     constexpr uint32_t vc = mcast ? NOC_DISPATCH_MULTICAST_WRITE_VC : NOC_UNICAST_WRITE_VC;
 
     constexpr uint32_t noc_cmd_field =

--- a/tt_metal/impl/dispatch/kernels/cq_dispatch.cpp
+++ b/tt_metal/impl/dispatch/kernels/cq_dispatch.cpp
@@ -80,6 +80,8 @@ static uint32_t cmd_ptr;   // walks through pages in cb cmd by cmd
 static uint32_t downstream_cb_data_ptr = downstream_cb_base;
 static uint32_t write_offset[3];  // added to write address on non-host writes
 
+static uint32_t upstream_total_acquired_page_count;
+
 constexpr uint32_t packed_write_max_multicast_sub_cmds = get_packed_write_max_multicast_sub_cmds(packed_write_max_unicast_sub_cmds);
 constexpr uint32_t max_write_packed_large_cmd =
     CQ_DISPATCH_CMD_PACKED_WRITE_LARGE_MAX_SUB_CMDS *
@@ -181,7 +183,7 @@ void process_write_host_h() {
             }
             // Wait for dispatcher to supply a page (this won't go beyond the buffer end)
             uint32_t n_pages = cb_acquire_pages<my_noc_xy, my_dispatch_cb_sem_id, dispatch_cb_log_page_size>(
-                cb_fence, block_next_start_addr, rd_block_idx);
+                cb_fence, block_next_start_addr, rd_block_idx, upstream_total_acquired_page_count);
 
             cb_fence += n_pages * dispatch_cb_page_size;
 
@@ -325,7 +327,7 @@ void relay_to_next_cb(uint32_t data_ptr, uint32_t length) {
 
             // Wait for dispatcher to supply a page (this won't go beyond the buffer end)
             uint32_t n_pages = cb_acquire_pages<my_noc_xy, my_dispatch_cb_sem_id, dispatch_cb_log_page_size>(
-                cb_fence, block_next_start_addr, rd_block_idx);
+                cb_fence, block_next_start_addr, rd_block_idx, upstream_total_acquired_page_count);
             cb_fence += n_pages * dispatch_cb_page_size;
 
             // Release pages for prefetcher
@@ -404,7 +406,7 @@ void process_write_linear(uint32_t num_mcast_dests) {
             }
             // Wait for dispatcher to supply a page (this won't go beyond the buffer end)
             uint32_t n_pages = cb_acquire_pages<my_noc_xy, my_dispatch_cb_sem_id, dispatch_cb_log_page_size>(
-                cb_fence, block_next_start_addr, rd_block_idx);
+                cb_fence, block_next_start_addr, rd_block_idx, upstream_total_acquired_page_count);
 
             cb_fence += n_pages * dispatch_cb_page_size;
 
@@ -481,7 +483,7 @@ void process_write_paged() {
             }
             // Wait for dispatcher to supply a page (this won't go beyond the buffer end)
             uint32_t n_pages = cb_acquire_pages<my_noc_xy, my_dispatch_cb_sem_id, dispatch_cb_log_page_size>(
-                cb_fence, block_next_start_addr, rd_block_idx);
+                cb_fence, block_next_start_addr, rd_block_idx, upstream_total_acquired_page_count);
 
             cb_fence += n_pages * dispatch_cb_page_size;
 
@@ -601,7 +603,7 @@ void process_write_packed(uint32_t flags) {
 
             // Wait for dispatcher to supply a page (this won't go beyond the buffer end)
             uint32_t n_pages = cb_acquire_pages<my_noc_xy, my_dispatch_cb_sem_id, dispatch_cb_log_page_size>(
-                cb_fence, block_next_start_addr, rd_block_idx);
+                cb_fence, block_next_start_addr, rd_block_idx, upstream_total_acquired_page_count);
             cb_fence += n_pages * dispatch_cb_page_size;
 
             // This is done here so the common case doesn't have to restore the pointers
@@ -712,7 +714,7 @@ void process_write_packed_large() {
                     move_rd_to_next_block<dispatch_cb_blocks>(block_noc_writes_to_clear, rd_block_idx);
                 }
                 uint32_t n_pages = cb_acquire_pages<my_noc_xy, my_dispatch_cb_sem_id, dispatch_cb_log_page_size>(
-                    cb_fence, block_next_start_addr, rd_block_idx);
+                    cb_fence, block_next_start_addr, rd_block_idx, upstream_total_acquired_page_count);
                 cb_fence += n_pages * dispatch_cb_page_size;
             }
             // Transfer size is min(remaining_length, data_available_in_cb)
@@ -765,7 +767,7 @@ void process_write_packed_large() {
 
             // Wait for dispatcher to supply a page (this won't go beyond the buffer end)
             uint32_t n_pages = cb_acquire_pages<my_noc_xy, my_dispatch_cb_sem_id, dispatch_cb_log_page_size>(
-                cb_fence, block_next_start_addr, rd_block_idx);
+                cb_fence, block_next_start_addr, rd_block_idx, upstream_total_acquired_page_count);
             cb_fence += n_pages * dispatch_cb_page_size;
         }
         data_ptr += pad_size;
@@ -1029,11 +1031,14 @@ static inline bool process_cmd_h(uint32_t &cmd_ptr) {
 
 void kernel_main() {
     DPRINT << "dispatch_" << is_h_variant << is_d_variant << ": start" << ENDL();
+    // Initialize local state of any additional nocs used instead of the default
     if constexpr (my_noc_index != upstream_noc_index) {
         noc_local_state_init(upstream_noc_index);
     }
 
     static_assert(is_d_variant || split_dispatch_page_preamble_size == 0);
+
+    upstream_total_acquired_page_count = 0;
 
     for (uint32_t i = 0; i < dispatch_cb_blocks; i++) {
         uint32_t next_block = i + 1;
@@ -1066,7 +1071,7 @@ void kernel_main() {
                 dispatch_cb_log_page_size,
                 my_noc_xy,
                 my_dispatch_cb_sem_id>(
-                cmd_ptr, cb_fence, block_noc_writes_to_clear, block_next_start_addr, rd_block_idx);
+                cmd_ptr, cb_fence, block_noc_writes_to_clear, block_next_start_addr, rd_block_idx, upstream_total_acquired_page_count);
         }
 
         IDLE_ERISC_HEARTBEAT_AND_RETURN(heartbeat);
@@ -1106,8 +1111,7 @@ void kernel_main() {
     cb_release_pages<upstream_noc_index, upstream_noc_xy, upstream_dispatch_cb_sem_id>(npages);
 
     // Confirm expected number of pages, spinning here is a leak
-    // TODO: We need to pass in our static counter here
-    // cb_wait_all_pages<my_dispatch_cb_sem_id>(0);
+    cb_wait_all_pages<my_dispatch_cb_sem_id>(upstream_total_acquired_page_count);
 
     DPRINT << "dispatch_" << is_h_variant << is_d_variant << ": out" << ENDL();
 }

--- a/tt_metal/impl/dispatch/kernels/cq_dispatch.cpp
+++ b/tt_metal/impl/dispatch/kernels/cq_dispatch.cpp
@@ -676,7 +676,8 @@ void process_write_packed_large() {
         uint32_t length = sub_cmd_ptr->length;
         uint32_t num_dests = sub_cmd_ptr->num_mcast_dests;
         uint32_t pad_size = align(length, alignment) - length;
-        uint32_t unlink = sub_cmd_ptr->flags & CQ_DISPATCH_CMD_PACKED_WRITE_LARGE_FLAG_UNLINK;
+        // TODO: Enable linking across subcmds after writes to prefetcher is switched to other NOC
+        uint32_t unlink = true; // sub_cmd_ptr->flags & CQ_DISPATCH_CMD_PACKED_WRITE_LARGE_FLAG_UNLINK;
 
         // Only re-init state after we have unlinked the last transaction
         // Otherwise we assume NOC coord hasn't changed
@@ -1094,7 +1095,8 @@ void kernel_main() {
     cb_release_pages<upstream_noc_xy, upstream_dispatch_cb_sem_id>(npages);
 
     // Confirm expected number of pages, spinning here is a leak
-    cb_wait_all_pages<my_dispatch_cb_sem_id>(0);
+    // TODO: We need to pass in our static counter here
+    // cb_wait_all_pages<my_dispatch_cb_sem_id>(0);
 
     DPRINT << "dispatch_" << is_h_variant << is_d_variant << ": out" << ENDL();
 }

--- a/tt_metal/impl/dispatch/kernels/cq_dispatch.cpp
+++ b/tt_metal/impl/dispatch/kernels/cq_dispatch.cpp
@@ -166,7 +166,7 @@ void process_write_host_h() {
     // We will send the cmd back in the first X bytes, this makes the logic of reserving/pushing completion queue
     // pages much simpler since we are always sending writing full pages (except for last page)
     uint32_t length = cmd->write_linear_host.length;
-    DPRINT << "process_write_host_h: " << length << ENDL();
+    // DPRINT << "process_write_host_h: " << length << ENDL();
     uint32_t data_ptr = cmd_ptr;
     cq_noc_async_write_init_state<CQ_NOC_sNdl>(0, pcie_noc_xy, 0);
     while (length != 0) {
@@ -260,7 +260,7 @@ void relay_to_next_cb(uint32_t data_ptr, uint32_t length) {
         preamble_size == 0 || preamble_size == sizeof(dispatch_packet_header_t),
         "Dispatcher preamble size must be 0 or sizeof(dispatch_packet_header_t)");
 
-    DPRINT << "relay_to_next_cb: " << data_ptr << " " << cb_fence << " " << length << ENDL();
+    // DPRINT << "relay_to_next_cb: " << data_ptr << " " << cb_fence << " " << length << ENDL();
 
     // First page should be valid since it has the command
     ASSERT(data_ptr <= dispatch_cb_end - dispatch_cb_page_size);
@@ -466,8 +466,8 @@ void process_write_paged() {
     addr_gen.page_size = page_size;
     uint64_t dst_addr_offset = 0;  // Offset into page.
 
-    DPRINT << "process_write_paged - pages: " << pages << " page_size: " << page_size
-           << " dispatch_cb_page_size: " << dispatch_cb_page_size << ENDL();
+    // DPRINT << "process_write_paged - pages: " << pages << " page_size: " << page_size
+    //        << " dispatch_cb_page_size: " << dispatch_cb_page_size << ENDL();
 
     while (write_length != 0) {
         // TODO #7360: Have more performant handling when page_size > dispatch_cb_page_size by not doing multiple writes
@@ -564,7 +564,7 @@ void process_write_packed(uint32_t flags) {
     volatile uint32_t tt_l1_ptr *l1_addr = (uint32_t *)(cmd_ptr + sizeof(CQDispatchCmd));
     cq_noc_async_write_init_state<CQ_NOC_snDL, mcast>(0, dst_addr, xfer_size);
 
-    DPRINT << "dispatch_write_packed: " << xfer_size << " " << stride << " " << data_ptr << " " << count << " " << dst_addr << " " << ENDL();
+    // DPRINT << "dispatch_write_packed: " << xfer_size << " " << stride << " " << data_ptr << " " << count << " " << dst_addr << " " << ENDL();
     uint32_t writes = 0;
     uint32_t mcasts = 0;
     WritePackedSubCmd *sub_cmd_ptr = (WritePackedSubCmd *)l1_cache;
@@ -916,9 +916,13 @@ re_run_command:
             process_wait();
             break;
 
-        case CQ_DISPATCH_CMD_GO: DPRINT << "cmd_go" << ENDL(); break;
+        case CQ_DISPATCH_CMD_GO:
+            // DPRINT << "cmd_go" << ENDL();
+            break;
 
-        case CQ_DISPATCH_CMD_SINK: DPRINT << "cmd_sink" << ENDL(); break;
+        case CQ_DISPATCH_CMD_SINK:
+            // DPRINT << "cmd_sink" << ENDL();
+            break;
 
         case CQ_DISPATCH_CMD_DEBUG:
             DPRINT << "cmd_debug" << ENDL();

--- a/tt_metal/impl/dispatch/kernels/cq_dispatch.cpp
+++ b/tt_metal/impl/dispatch/kernels/cq_dispatch.cpp
@@ -683,8 +683,7 @@ void process_write_packed_large() {
         uint32_t length = sub_cmd_ptr->length;
         uint32_t num_dests = sub_cmd_ptr->num_mcast_dests;
         uint32_t pad_size = align(length, alignment) - length;
-        // TODO: Enable linking across subcmds after writes to prefetcher is switched to other NOC
-        uint32_t unlink = true; // sub_cmd_ptr->flags & CQ_DISPATCH_CMD_PACKED_WRITE_LARGE_FLAG_UNLINK;
+        uint32_t unlink = sub_cmd_ptr->flags & CQ_DISPATCH_CMD_PACKED_WRITE_LARGE_FLAG_UNLINK;
 
         // Only re-init state after we have unlinked the last transaction
         // Otherwise we assume NOC coord hasn't changed
@@ -692,7 +691,7 @@ void process_write_packed_large() {
         if (init_state) {
             uint32_t dst_noc = sub_cmd_ptr->noc_xy_addr;
             // TODO: Linking should be set to true once atomic txn is handled properly
-            cq_noc_async_write_init_state<CQ_NOC_sNdl, true, false>(0, get_noc_addr_helper(dst_noc, dst_addr));
+            cq_noc_async_write_init_state<CQ_NOC_sNdl, true, true>(0, get_noc_addr_helper(dst_noc, dst_addr));
         }
 
         sub_cmd_ptr++;

--- a/tt_metal/impl/dispatch/kernels/cq_prefetch.cpp
+++ b/tt_metal/impl/dispatch/kernels/cq_prefetch.cpp
@@ -48,6 +48,7 @@ constexpr uint32_t cmddat_q_blocks = get_compile_time_arg_val(20);
 constexpr uint32_t is_d_variant = get_compile_time_arg_val(21);
 constexpr uint32_t is_h_variant = get_compile_time_arg_val(22);
 
+constexpr uint8_t my_noc_index = NOC_INDEX;
 constexpr uint32_t my_noc_xy = uint32_t(NOC_XY_ENCODING(MY_NOC_X, MY_NOC_Y));
 constexpr uint32_t upstream_noc_xy = uint32_t(NOC_XY_ENCODING(UPSTREAM_NOC_X, UPSTREAM_NOC_Y));
 constexpr uint32_t downstream_noc_xy = uint32_t(NOC_XY_ENCODING(DOWNSTREAM_NOC_X, DOWNSTREAM_NOC_Y));
@@ -348,7 +349,7 @@ static uint32_t process_relay_inline_cmd(uint32_t cmd_ptr,
     downstream_data_ptr = round_up_pow2(downstream_data_ptr, downstream_cb_page_size);
 
     noc_async_writes_flushed();
-    cb_release_pages<downstream_noc_xy, downstream_cb_sem_id>(npages);
+    cb_release_pages<my_noc_index, downstream_noc_xy, downstream_cb_sem_id>(npages);
 
     return cmd->relay_inline.stride;
 }
@@ -496,7 +497,7 @@ uint32_t process_relay_paged_cmd_large(uint32_t cmd_ptr,
         write_length -= amt_to_write;
         uint32_t npages = write_pages_to_dispatcher<0, false>
             (downstream_data_ptr, scratch_write_addr, amt_to_write);
-        cb_release_pages<downstream_noc_xy, downstream_cb_sem_id>(npages);
+        cb_release_pages<my_noc_index, downstream_noc_xy, downstream_cb_sem_id>(npages);
 
         read_length -= amt_read;
 
@@ -512,9 +513,9 @@ uint32_t process_relay_paged_cmd_large(uint32_t cmd_ptr,
             (downstream_data_ptr, scratch_write_addr, amt_to_write);
 
         // One page was acquired w/ the cmd in CMD_RELAY_INLINE_NOFLUSH with 16 bytes written
-        cb_release_pages<downstream_noc_xy, downstream_cb_sem_id>(npages + 1);
+        cb_release_pages<my_noc_index, downstream_noc_xy, downstream_cb_sem_id>(npages + 1);
     } else {
-        cb_release_pages<downstream_noc_xy, downstream_cb_sem_id>(1);
+        cb_release_pages<my_noc_index, downstream_noc_xy, downstream_cb_sem_id>(1);
     }
 
     downstream_data_ptr = round_up_pow2(downstream_data_ptr, downstream_cb_page_size);
@@ -612,7 +613,7 @@ uint32_t process_relay_paged_cmd(uint32_t cmd_ptr,
         // Third step - write from DB
         uint32_t npages = write_pages_to_dispatcher<0, false>
             (downstream_data_ptr, scratch_write_addr, amt_to_write);
-        cb_release_pages<downstream_noc_xy, downstream_cb_sem_id>(npages);
+        cb_release_pages<my_noc_index, downstream_noc_xy, downstream_cb_sem_id>(npages);
 
         read_length -= amt_read;
 
@@ -632,7 +633,7 @@ uint32_t process_relay_paged_cmd(uint32_t cmd_ptr,
     downstream_data_ptr = round_up_pow2(downstream_data_ptr, downstream_cb_page_size);
 
     // One page was acquired w/ the cmd in CMD_RELAY_INLINE_NOFLUSH with 16 bytes written
-    cb_release_pages<downstream_noc_xy, downstream_cb_sem_id>(npages + 1);
+    cb_release_pages<my_noc_index, downstream_noc_xy, downstream_cb_sem_id>(npages + 1);
 
     return CQ_PREFETCH_CMD_BARE_MIN_SIZE;
 }
@@ -731,7 +732,7 @@ void process_relay_paged_packed_sub_cmds(uint32_t total_length) {
         // Third step - write from DB
         uint32_t npages = write_pages_to_dispatcher<0, false>
             (downstream_data_ptr, scratch_write_addr, amt_to_write);
-        cb_release_pages<downstream_noc_xy, downstream_cb_sem_id>(npages);
+        cb_release_pages<my_noc_index, downstream_noc_xy, downstream_cb_sem_id>(npages);
 
         total_length -= amt_read;
 
@@ -748,7 +749,7 @@ void process_relay_paged_packed_sub_cmds(uint32_t total_length) {
     downstream_data_ptr = round_up_pow2(downstream_data_ptr, downstream_cb_page_size);
 
     // One page was acquired w/ the cmd in CMD_RELAY_INLINE_NOFLUSH with 16 bytes written
-    cb_release_pages<downstream_noc_xy, downstream_cb_sem_id>(npages + 1);
+    cb_release_pages<my_noc_index, downstream_noc_xy, downstream_cb_sem_id>(npages + 1);
 }
 
 template<bool cmddat_wrap_enable>
@@ -830,7 +831,7 @@ uint32_t process_relay_linear_cmd(uint32_t cmd_ptr,
         // Third step - write from DB
         uint32_t npages = write_pages_to_dispatcher<0, false>(downstream_data_ptr, scratch_write_addr, amt_to_write);
 
-        cb_release_pages<downstream_noc_xy, downstream_cb_sem_id>(npages);
+        cb_release_pages<my_noc_index, downstream_noc_xy, downstream_cb_sem_id>(npages);
 
         read_length -= amt_to_read;
 
@@ -847,7 +848,7 @@ uint32_t process_relay_linear_cmd(uint32_t cmd_ptr,
     downstream_data_ptr = round_up_pow2(downstream_data_ptr, downstream_cb_page_size);
 
     // One page was acquired w/ the cmd in CMD_RELAY_INLINE_NOFLUSH
-    cb_release_pages<downstream_noc_xy, downstream_cb_sem_id>(npages + 1);
+    cb_release_pages<my_noc_index, downstream_noc_xy, downstream_cb_sem_id>(npages + 1);
 
     return CQ_PREFETCH_CMD_BARE_MIN_SIZE;
 }
@@ -942,7 +943,7 @@ static uint32_t process_exec_buf_relay_inline_cmd(uint32_t& cmd_ptr,
     downstream_data_ptr = round_up_pow2(downstream_data_ptr, downstream_cb_page_size);
 
     noc_async_writes_flushed();
-    cb_release_pages<downstream_noc_xy, downstream_cb_sem_id>(npages);
+    cb_release_pages<my_noc_index, downstream_noc_xy, downstream_cb_sem_id>(npages);
 
     return stride;
 }
@@ -1230,7 +1231,7 @@ static uint32_t process_relay_inline_all(uint32_t data_ptr, uint32_t fence, bool
     }
 
     noc_async_writes_flushed();
-    cb_release_pages<downstream_noc_xy, downstream_cb_sem_id>(npages);
+    cb_release_pages<my_noc_index, downstream_noc_xy, downstream_cb_sem_id>(npages);
 
     return fence;
 }
@@ -1365,7 +1366,7 @@ void kernel_main_d() {
         // TODO: evaluate less costly free pattern (blocks?)
         uint32_t total_length = length + sizeof(CQPrefetchHToPrefetchDHeader);
         uint32_t pages_to_free = (total_length + cmddat_q_page_size - 1) >> cmddat_q_log_page_size;
-        cb_release_pages<upstream_noc_xy, upstream_cb_sem_id>(pages_to_free);
+        cb_release_pages<my_noc_index, upstream_noc_xy, upstream_cb_sem_id>(pages_to_free);
 
         // Move to next page
         cmd_ptr = round_up_pow2(cmd_ptr, cmddat_q_page_size);

--- a/tt_metal/impl/dispatch/kernels/cq_prefetch.cpp
+++ b/tt_metal/impl/dispatch/kernels/cq_prefetch.cpp
@@ -76,6 +76,8 @@ static uint32_t block_next_start_addr[cmddat_q_blocks];
 static uint32_t block_noc_writes_to_clear[cmddat_q_blocks];
 static uint32_t rd_block_idx;
 
+static uint32_t upstream_total_acquired_page_count;
+
 // Currently capping the same as dispatch
 constexpr uint32_t max_read_packed_cmd =
     CQ_PREFETCH_CMD_RELAY_PAGED_PACKED_MAX_SUB_CMDS *
@@ -404,18 +406,19 @@ static uint32_t write_pages_to_dispatcher(uint32_t& downstream_data_ptr,
         cb_acquire_pages<my_noc_xy, my_downstream_cb_sem_id>(npages);
     }
 
-    uint64_t noc_addr;
-    if (downstream_data_ptr == downstream_cb_end) {
-        downstream_data_ptr = downstream_cb_base;
-    } else if (downstream_data_ptr + amt_to_write > downstream_cb_end) {  // wrap
-        uint32_t last_chunk_size = downstream_cb_end - downstream_data_ptr;
-        noc_addr = get_noc_addr_helper(downstream_noc_xy, downstream_data_ptr);
-        noc_async_write(scratch_write_addr, noc_addr, last_chunk_size);
-        downstream_data_ptr = downstream_cb_base;
-        scratch_write_addr += last_chunk_size;
-        amt_to_write -= last_chunk_size;
+    if (downstream_data_ptr + amt_to_write >= downstream_cb_end) {  // wrap
+        if (downstream_data_ptr == downstream_cb_end) {
+            downstream_data_ptr = downstream_cb_base;
+        } else {
+            uint32_t last_chunk_size = downstream_cb_end - downstream_data_ptr;
+            uint64_t noc_addr = get_noc_addr_helper(downstream_noc_xy, downstream_data_ptr);
+            noc_async_write(scratch_write_addr, noc_addr, last_chunk_size);
+            downstream_data_ptr = downstream_cb_base;
+            scratch_write_addr += last_chunk_size;
+            amt_to_write -= last_chunk_size;
+        }
     }
-    noc_addr = get_noc_addr_helper(downstream_noc_xy, downstream_data_ptr);
+    uint64_t noc_addr = get_noc_addr_helper(downstream_noc_xy, downstream_data_ptr);
     noc_async_write(scratch_write_addr, noc_addr, amt_to_write);
     downstream_data_ptr += amt_to_write;
 
@@ -1254,7 +1257,8 @@ inline uint32_t relay_cb_get_cmds(uint32_t& fence, uint32_t& data_ptr) {
                                    fence,
                                    block_noc_writes_to_clear,
                                    block_next_start_addr,
-                                   rd_block_idx);
+                                   rd_block_idx,
+                                   upstream_total_acquired_page_count);
     }
 
     volatile tt_l1_ptr CQPrefetchHToPrefetchDHeader *cmd_ptr =
@@ -1280,7 +1284,8 @@ inline uint32_t relay_cb_get_cmds(uint32_t& fence, uint32_t& data_ptr) {
                                    fence,
                                    block_noc_writes_to_clear,
                                    block_next_start_addr,
-                                   rd_block_idx);
+                                   rd_block_idx,
+                                   upstream_total_acquired_page_count);
         IDLE_ERISC_RETURN(length - sizeof(CQPrefetchHToPrefetchDHeader));
     }
 
@@ -1402,6 +1407,7 @@ void kernel_main_hd() {
 
 void kernel_main() {
     DPRINT << "prefetcher_" << is_h_variant << is_d_variant << ": start" << ENDL();
+    upstream_total_acquired_page_count = 0;
 
     volatile tt_l1_ptr uint32_t* sem_addr =
         reinterpret_cast<volatile tt_l1_ptr uint32_t*>(get_semaphore(my_downstream_cb_sem_id));


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/11014

### Problem description
We took a performance hit due to 35d7055, as we were previously never reserving our mcast path in dispatch, leading to potential deadlock. This pr enabling the linking option for mcast to minimize required reservations/VC allocations to recover performance.

### What's changed
Changed cb_acquire_pages to use a free running counter instead of issuing atomic inc. This allows us to enable linking within subcmds and removes unnecessary atomic txns/barriers.
Changed dispatch upstream communication to use the alternative noc. The is an rtl issue where no other txns can be issued when linking is enabled, even if they use a different command buffer/VC. This enables linking across subcmds.

### Checklist
- [x] Post commit CI passes
- [x] Blackhole Post commit (if applicable)
- [x] Model regression CI testing passes (if applicable)
- [x] New/Existing tests provide coverage for changes
