### PR TITLE
Share host assigned ID with device FW

### DIFF
--- a/tt_metal/hw/firmware/src/brisc.cc
+++ b/tt_metal/hw/firmware/src/brisc.cc
@@ -369,6 +369,7 @@ int main() {
 
         {
             DeviceZoneScopedMainN("BRISC-FW");
+            DeviceZoneSetCounter(mailboxes->launch.kernel_config.host_assigned_id);
 
             // Copies from L1 to IRAM on chips where NCRISC has IRAM
             l1_to_ncrisc_iram_copy(mailboxes->launch.kernel_config.ncrisc_kernel_size16, ncrisc_kernel_start_offset16);

--- a/tt_metal/hw/firmware/src/erisc.cc
+++ b/tt_metal/hw/firmware/src/erisc.cc
@@ -79,6 +79,7 @@ void __attribute__((section("erisc_l1_code.1"), noinline)) Application(void) {
         // FD: assume that no more host -> remote writes are pending
         if (mailboxes->launch.go.run == RUN_MSG_GO) {
             DeviceZoneScopedMainN("ERISC-FW");
+            DeviceZoneSetCounter(mailboxes->launch.kernel_config.host_assigned_id);
             DEBUG_STATUS("R");
             uint32_t kernel_config_base = mailboxes->launch.kernel_config.kernel_config_base;
             rta_l1_base = (uint32_t tt_l1_ptr *)(kernel_config_base +

--- a/tt_metal/hw/firmware/src/idle_erisc.cc
+++ b/tt_metal/hw/firmware/src/idle_erisc.cc
@@ -109,6 +109,7 @@ int main() {
 
         {
             DeviceZoneScopedMainN("ERISC-IDLE-FW");
+            DeviceZoneSetCounter(mailboxes->launch.kernel_config.host_assigned_id);
 
             noc_index = mailboxes->launch.kernel_config.brisc_noc_id;
 

--- a/tt_metal/hw/inc/dev_msgs.h
+++ b/tt_metal/hw/inc/dev_msgs.h
@@ -77,6 +77,8 @@ struct kernel_config_msg_t {
     volatile uint16_t watcher_kernel_ids[DISPATCH_CLASS_MAX];
     volatile uint16_t ncrisc_kernel_size16;  // size in 16 byte units
 
+    volatile uint16_t host_assigned_id;
+
     // Ring buffer of kernel configuration data
     volatile uint32_t kernel_config_base;
     dyn_mem_map_t mem_map[DISPATCH_CLASS_MAX];
@@ -89,6 +91,7 @@ struct kernel_config_msg_t {
     volatile uint8_t dispatch_core_y;
     volatile uint8_t exit_erisc_kernel;
     volatile uint8_t pad1;
+    volatile uint16_t pad2;
 } __attribute__((packed));
 
 struct go_msg_t {

--- a/tt_metal/impl/dispatch/command_queue.cpp
+++ b/tt_metal/impl/dispatch/command_queue.cpp
@@ -979,6 +979,7 @@ void EnqueueProgramCommand::assemble_device_commands(
             kernel_group.launch_msg.kernel_config.dispatch_core_x = this->dispatch_core.x;
             kernel_group.launch_msg.kernel_config.dispatch_core_y = this->dispatch_core.y;
             kernel_group.launch_msg.kernel_config.kernel_config_base = tensix_l1_kernel_config_base;
+            kernel_group.launch_msg.kernel_config.host_assigned_id = program.get_runtime_id();
             const void* launch_message_data = (const void*)(&kernel_group.launch_msg);
             for (const CoreRange& core_range : kernel_group.core_ranges.ranges()) {
                 CoreCoord physical_start =
@@ -1002,12 +1003,12 @@ void EnqueueProgramCommand::assemble_device_commands(
                 this->packed_write_max_unicast_sub_cmds,
                 multicast_go_signals_payload);
         }
-
         for (KernelGroup& kernel_group : program.get_kernel_groups(CoreType::ETH)) {
             kernel_group.launch_msg.kernel_config.mode = DISPATCH_MODE_DEV;
             kernel_group.launch_msg.kernel_config.dispatch_core_x = this->dispatch_core.x;
             kernel_group.launch_msg.kernel_config.dispatch_core_y = this->dispatch_core.y;
             kernel_group.launch_msg.kernel_config.kernel_config_base = eth_l1_kernel_config_base;
+            kernel_group.launch_msg.kernel_config.host_assigned_id = program.get_runtime_id();
             const void* launch_message_data = (const launch_msg_t*)(&kernel_group.launch_msg);
             for (const CoreRange& core_range : kernel_group.core_ranges.ranges()) {
                 for (auto x = core_range.start_coord.x; x <= core_range.end_coord.x; x++) {
@@ -1185,6 +1186,7 @@ void EnqueueProgramCommand::assemble_device_commands(
         }
     } else {
         uint32_t i = 0;
+        ZoneScopedN("program_loaded_on_device");
         for (const auto& cbs_on_core_range : cached_program_command_sequence.circular_buffers_on_core_ranges) {
             uint32_t* cb_config_payload = cached_program_command_sequence.cb_configs_payloads[i];
             for (const shared_ptr<CircularBuffer>& cb : cbs_on_core_range) {
@@ -1213,6 +1215,7 @@ void EnqueueProgramCommand::assemble_device_commands(
                 go_signal->kernel_config.kernel_config_base = eth_l1_kernel_config_base;
             }
             go_signal_count++;
+            go_signal->kernel_config.host_assigned_id = program.get_runtime_id();
         }
     }
 }

--- a/tt_metal/impl/program/program.cpp
+++ b/tt_metal/impl/program/program.cpp
@@ -107,7 +107,7 @@ void DisablePersistentKernelCache() { enable_persistent_kernel_cache = false; }
 std::atomic<uint64_t> Program::program_counter = 0;
 
 Program::Program() :
-    id(program_counter++), worker_crs_({}), local_circular_buffer_allocation_needed_(false), finalized_(false) {
+    id(program_counter++), runtime_id(0), worker_crs_({}), local_circular_buffer_allocation_needed_(false), finalized_(false) {
     std::set<CoreType> supported_core_types = {CoreType::WORKER, CoreType::ETH};
     for (const auto &core_type : supported_core_types) {
         kernels_.insert({core_type, {}});
@@ -996,6 +996,8 @@ void Program::compile(Device *device, bool fd_bootloader_mode) {
     }
     compile_needed_[device->id()] = false;
 }
+
+void Program::set_runtime_id(uint64_t id) { this->runtime_id = id; }
 
 Program::~Program() {}
 }  // namespace tt::tt_metal

--- a/tt_metal/impl/program/program.hpp
+++ b/tt_metal/impl/program/program.hpp
@@ -75,11 +75,13 @@ class Program {
     Program(Program &&other) = default;
     Program& operator=(Program &&other) = default;
 
+    void set_runtime_id(uint64_t id);
     ~Program();
 
     void construct_core_range_set_for_worker_cores();
 
     const uint64_t get_id() const { return this->id; }
+    const uint64_t get_runtime_id() const { return this->runtime_id; }
 
     size_t num_kernels() const {
       size_t count = 0;
@@ -174,6 +176,7 @@ class Program {
     };
 
     uint64_t id; // Need to make non-const due to move constructor
+    uint64_t runtime_id;
     static std::atomic<uint64_t> program_counter;
     std::unordered_map<CoreType, std::unordered_map<KernelHandle, std::shared_ptr<Kernel> >> kernels_;
     std::unordered_map<CoreType, CoreCoord> grid_extent_;

--- a/tt_metal/tools/profiler/process_device_log.py
+++ b/tt_metal/tools/profiler/process_device_log.py
@@ -209,7 +209,15 @@ def import_device_profile_log(logPath):
                 timerID = {"id": int(row[4].strip()), "zone_name": "", "zone_phase": "", "src_line": "", "src_file": ""}
                 timeData = int(row[5].strip())
                 statData = 0
-                if len(row) > 6:
+                if len(row) == 13:
+                    statData = int(row[6].strip())
+                    timerID["run_id"] = int(row[7].strip())
+                    timerID["run_host_id"] = int(row[8].strip())
+                    timerID["zone_name"] = row[9].strip()
+                    timerID["zone_phase"] = row[10].strip()
+                    timerID["src_line"] = int(row[11].strip())
+                    timerID["src_file"] = row[12].strip()
+                elif len(row) == 12:
                     statData = int(row[6].strip())
                     timerID["run_id"] = int(row[7].strip())
                     timerID["zone_name"] = row[8].strip()

--- a/tt_metal/tools/profiler/profiler.hpp
+++ b/tt_metal/tools/profiler/profiler.hpp
@@ -72,6 +72,7 @@ class DeviceProfiler {
         // Dumping profile result to file
         void dumpResultToFile(
                 uint32_t runID,
+                uint32_t runHostID,
                 int device_id,
                 CoreCoord core,
                 int core_flat,

--- a/tt_metal/tt_metal.cpp
+++ b/tt_metal/tt_metal.cpp
@@ -653,7 +653,7 @@ void LaunchProgram(Device *device, Program &program, bool wait_until_cores_done,
         for (const auto &[core_type, logical_cores] : logical_cores_used_in_program) {
             for (const auto &logical_core : logical_cores) {
                 launch_msg_t *msg = &program.kernels_on_core(logical_core, core_type)->launch_msg;
-
+                msg->kernel_config.host_assigned_id = program.get_runtime_id();
                 auto physical_core = device->physical_core_from_logical_core(logical_core, core_type);
                 not_done_cores.insert(physical_core);
                 tt::llrt::write_launch_msg_to_core(device->id(), physical_core, msg, device->get_dev_addr(physical_core, HalMemAddrType::LAUNCH));

--- a/ttnn/cpp/ttnn/device_operation.hpp
+++ b/ttnn/cpp/ttnn/device_operation.hpp
@@ -298,6 +298,8 @@ void launch_on_worker_thread(auto cq_id, auto operation_id, const auto& operatio
         auto& program = create_or_get_program_from_cache<device_operation_t>(
             program_cache, program_cache_hit, program_hash, operation_attributes, tensor_args, tensor_return_value);
 
+        program.set_runtime_id(operation_id);
+
         if (USE_FAST_DISPATCH) {
             ZoneScopedN("EnqueueProgram");
             auto& queue = device->command_queue(cq_id);
@@ -331,6 +333,8 @@ void launch_on_worker_thread(auto cq_id, auto operation_id, const auto& operatio
                     program_factory_t::create(operation_attributes, tensor_args, tensor_return_value).program);
             },
             program);
+
+        program_ptr->set_runtime_id(operation_id);
 
         if (USE_FAST_DISPATCH) {
             ZoneScopedN("EnqueueProgram");


### PR DESCRIPTION
### Ticket
[Ticket](https://github.com/orgs/tenstorrent/projects/26/views/1?pane=issue&itemId=62021112)

### Problem description
Device has no info on what part of host execution path is requesting its launch. 

### What's changed

- Sharing `host_assigned_id` with BRISC FW. 
- Setting `host_assigned_id` to op id for default profiler flow. 

### Checklist
- [x] Post commit CI passes : https://github.com/tenstorrent/tt-metal/actions/runs/10409317913
- [x] T3K profiler : https://github.com/tenstorrent/tt-metal/actions/runs/10409319985
- [x] Device perf : https://github.com/tenstorrent/tt-metal/actions/runs/10409322644