### PR TITLE
#0: added llama3-tg nightly demo test

### DIFF
--- a/models/demos/t3000/llama2_70b/tt/llama_common.py
+++ b/models/demos/t3000/llama2_70b/tt/llama_common.py
@@ -126,6 +126,10 @@ def setup_llama_env(llama_version="llama3", batch=32, seq_len=1, n_devices=8, ma
             ckpt_dir = "/mnt/MLPerf/tt_dnn-models/llama-3/llama-3-70b-repacked/"
             tokenizer_path = "/mnt/MLPerf/tt_dnn-models/llama-3/tokenizer.model"
             cache_path = Path("/mnt/MLPerf/tt_dnn-models/llama-3/llama-data-cache/weights-cache-3")
+        elif llama_version == "llama3-tg":
+            ckpt_dir = "/mnt/MLPerf/tt_dnn-models/llama-3/llama-3-70b-repacked/"
+            tokenizer_path = "/mnt/MLPerf/tt_dnn-models/llama-3/tokenizer.model"
+            cache_path = Path("/mnt/MLPerf/tt_dnn-models/llama-3/llama-data-cache/weights-cache-tg")
         elif llama_version == "llama3-405b":
             ckpt_dir = "/mnt/MLPerf/tt_dnn-models/llama-3-405b/llama-3-405b-repacked/"
             tokenizer_path = "/mnt/MLPerf/tt_dnn-models/llama-3-405b/tokenizer.model"
@@ -139,6 +143,12 @@ def setup_llama_env(llama_version="llama3", batch=32, seq_len=1, n_devices=8, ma
             ckpt_dir = os.getenv("LLAMA3_CKPT_DIR", "/proj_sw/llama3-data-repacked/llama-3-70b/")
             tokenizer_path = os.getenv("LLAMA3_TOKENIZER_PATH", "/proj_sw/llama3-data-repacked/tokenizer.model")
             cache_path = Path(os.getenv("LLAMA3_CACHE_PATH", "/proj_sw/llama-cache/llama-3-70b"))
+        elif llama_version == "llama3-tg":
+            ckpt_dir = os.getenv("LLAMA3_CKPT_DIR", "/proj_sw/user_dev/llama3-data-repacked/llama-3-70b/")
+            tokenizer_path = os.getenv(
+                "LLAMA3_TOKENIZER_PATH", "/proj_sw/user_dev/llama3-data-repacked/tokenizer.model"
+            )
+            cache_path = Path(os.getenv("LLAMA3_CACHE_PATH", "/proj_sw/user_dev/llama3-data-cache/weights-cache-2"))
         elif llama_version == "llama3-405b":
             ckpt_dir = os.getenv("LLAMA3_405B_CKPT_DIR", "/proj_sw/user_dev/llama3-405B-data-repacked/llama-3-405b/")
             tokenizer_path = os.getenv(

--- a/models/demos/t3000/llama2_70b/tt/model_config.py
+++ b/models/demos/t3000/llama2_70b/tt/model_config.py
@@ -116,7 +116,7 @@ def get_model_config(
     n_heads = model_config_entries["num_attention_heads"]
     n_kv_heads = model_config_entries["num_kv_heads"]
 
-    if llama_version == "llama3":
+    if llama_version == "llama3" or llama_version == "llama3-tg":
         model_config["FFN_EXPANDED_HIDDEN_SIZE"] = 28 * 1024
     elif llama_version == "llama3-405b":
         model_config["FFN_EXPANDED_HIDDEN_SIZE"] = 52 * 1024

--- a/models/demos/tg/llama3_70b/demo/README.md
+++ b/models/demos/tg/llama3_70b/demo/README.md
@@ -48,9 +48,9 @@ After setting up the repacked weights and tokenizer, you can run the demo using 
     1. The first run will cache the weights. This will take some time.
     2. The second run will use the cached weights, thereby running much faster.
 
+    Command to run the decode demo using greedy sampling
     ```bash
-    # Run the decode demo using greedy sampling
-    pytest models/demos/tg/llama3_70b/demo/demo.py::test_LlamaModel_demo[wormhole_b0-True-short_context-check_disabled-greedy-tt-70b-glx-80L-decode_only-text_completion-llama3-4x8_grid]
+    pytest models/demos/tg/llama3_70b/demo/demo.py::test_LlamaModel_demo[wormhole_b0-True-short_context-check_disabled-greedy-tt-70b-glx-80L-decode_only-text_completion-llama3-tg-4x8_grid]
     ```
 
 ## Details

--- a/models/demos/tg/llama3_70b/demo/demo.py
+++ b/models/demos/tg/llama3_70b/demo/demo.py
@@ -76,7 +76,7 @@ def construct_arg(**kwargs):
     return DemoArgs(model=model_args, tt=tt_args, data=data_args)
 
 
-def main(args):
+def run_demo(args):
     # Set random reproducible seed
     torch.manual_seed(0)
 
@@ -436,7 +436,6 @@ def test_LlamaModel_demo(
 
     check_device_mesh(device_mesh, model_config)
 
-    # TODO: Renable when issue #11089 is resolved
     for i in device_mesh.get_device_ids():
         device = device_mesh.get_device(i)
         device.enable_async(True)
@@ -464,4 +463,4 @@ def test_LlamaModel_demo(
         decode_only=decode_only,
         ground_truth=ground_truth,
     )
-    main(args)
+    run_demo(args)

--- a/models/demos/tg/llama3_70b/demo/demo.py
+++ b/models/demos/tg/llama3_70b/demo/demo.py
@@ -58,6 +58,8 @@ class DataArgs:
     chat: bool = False
     sample_len: int = None
     ground_truth: str = None
+    print_output_as_generated: bool = True
+    print_output_at_end: bool = False
 
 
 @dataclass
@@ -115,6 +117,9 @@ def main(args):
             ) as f:  # Open a file for writing
                 output_json = json.dumps(all_text, indent=4)
                 f.write(output_json)
+            if data_args.print_output_at_end:
+                for idx, text in enumerate(all_text):
+                    print(f"User {idx}: \n\tOutput: {text}")
 
     # Check against ground truth
     if data_args.ground_truth:
@@ -264,7 +269,8 @@ def run_decode(
         # Decode the entire sequence generated so far and log it
         for user_id in range(max(0, bsz - 3), bsz):
             text = tokenizer.decode(tokens[user_id, : cur_pos + 1].tolist())
-            logger.info(f"Loop {cur_pos} user {user_id}: {text}\n")
+            if data_args.print_output_as_generated:
+                logger.info(f"Loop {cur_pos} user {user_id}: {text}\n")
 
         if return_full_logits:
             full_logits.append(logits.clone().detach())
@@ -348,7 +354,7 @@ def top_pk_logits_efficient(logits, p=0.9, k=10, temperature=1.0, return_probs=F
 )
 @pytest.mark.parametrize(
     "llama_version",
-    (("llama3"),),
+    (("llama3-tg"),),
 )
 @pytest.mark.parametrize(
     "chat, prompts_file",
@@ -431,9 +437,9 @@ def test_LlamaModel_demo(
     check_device_mesh(device_mesh, model_config)
 
     # TODO: Renable when issue #11089 is resolved
-    # for i in device_mesh.get_device_ids():
-    #     device = device_mesh.get_device(i)
-    #     device.enable_async(True)
+    for i in device_mesh.get_device_ids():
+        device = device_mesh.get_device(i)
+        device.enable_async(True)
 
     args = construct_arg(
         implementation=implementation,

--- a/models/demos/tg/llama3_70b/tests/test_llama_attention_galaxy.py
+++ b/models/demos/tg/llama3_70b/tests/test_llama_attention_galaxy.py
@@ -346,10 +346,7 @@ def run_test_LlamaAttention_inference(
 )
 @pytest.mark.parametrize(
     "llama_version",
-    (
-        # ("llama2"),
-        ("llama3"),
-    ),
+    (("llama3-tg"),),
 )
 @pytest.mark.parametrize(
     "batch, seq_len, pcc",

--- a/models/demos/tg/llama3_70b/tests/test_llama_decoder_galaxy.py
+++ b/models/demos/tg/llama3_70b/tests/test_llama_decoder_galaxy.py
@@ -333,10 +333,7 @@ def run_test_LlamaDecoder_inference(
 )
 @pytest.mark.parametrize(
     "llama_version",
-    (
-        # ("llama2"),
-        ("llama3"),
-    ),
+    (("llama3-tg"),),
 )
 @pytest.mark.parametrize(
     "batch, seq_len, pcc",

--- a/models/demos/tg/llama3_70b/tests/test_llama_demo_nightly.py
+++ b/models/demos/tg/llama3_70b/tests/test_llama_demo_nightly.py
@@ -1,0 +1,127 @@
+# SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+
+# SPDX-License-Identifier: Apache-2.0
+
+from dataclasses import dataclass
+import os
+import json
+import torch
+import torch.nn.functional as F
+
+from time import time
+import pytest
+from loguru import logger
+from models.utility_functions import skip_for_grayskull
+from models.demos.t3000.llama2_70b.tt.llama_common import (
+    setup_llama_env,
+    check_device_mesh,
+)
+from models.demos.tg.llama3_70b.demo.demo import main, construct_arg
+
+
+@pytest.mark.timeout(240000)
+@skip_for_grayskull("Requires eth connected devices to run")
+@pytest.mark.parametrize(
+    "cluster_shape, device_mesh", [pytest.param((4, 8), (8, 4), id="4x8_grid")], indirect=["device_mesh"]
+)
+@pytest.mark.parametrize(
+    "llama_version",
+    (("llama3-tg"),),
+)
+@pytest.mark.parametrize(
+    "chat, prompts_file",
+    ((False, "models/demos/t3000/llama2_70b/demo/data/multi_prompt.json"),),
+    ids=("text_completion",),
+)
+@pytest.mark.parametrize("decode_only", (True,), ids=("decode_only",))
+@pytest.mark.parametrize("num_layers", (80,), ids=("80L",))
+@pytest.mark.parametrize(
+    "implementation, skip_model_load, n_devices",
+    (
+        (
+            "tt",
+            False,
+            8,
+        ),
+    ),
+    ids=("tt-70b-glx",),
+)
+@pytest.mark.parametrize(
+    "max_output_tokens, output_at_end, top_p, top_k, temperature",
+    ((128, True, 1, 1, 1.0),),
+    ids=("greedy",),
+)
+@pytest.mark.parametrize(
+    "ground_truth",
+    (None,),
+    ids=("check_disabled",),
+)
+@pytest.mark.parametrize(
+    "max_batch_size, max_context_len",
+    ((32, 2048),),
+    ids=("short_context",),
+)
+def test_llama3_tg_nightly_demo(
+    # model args
+    implementation,
+    skip_model_load,
+    num_layers,
+    # Generation args
+    max_output_tokens,
+    prompts_file,
+    output_at_end,
+    top_p,
+    top_k,
+    temperature,
+    chat,
+    # TT args
+    device_mesh,
+    cluster_shape,
+    n_devices,
+    decode_only,
+    llama_version,
+    ground_truth,
+    max_batch_size,
+    max_context_len,
+    use_program_cache,
+):
+    logger.info("Running LlamaModel demo")
+
+    ## Get model config
+    model_config, ckpt_dir, tokenizer_path, cache_path = setup_llama_env(
+        llama_version=llama_version,
+    )
+
+    check_device_mesh(device_mesh, model_config)
+
+    # TODO: Renable when issue #11089 is resolved
+    for i in device_mesh.get_device_ids():
+        device = device_mesh.get_device(i)
+        device.enable_async(True)
+
+    args = construct_arg(
+        implementation=implementation,
+        llama_version=llama_version,
+        ckpt_dir=ckpt_dir,
+        tokenizer_path=tokenizer_path,
+        skip_model_load=skip_model_load,
+        num_layers=num_layers,
+        max_batch_size=max_batch_size,
+        max_kv_context_len=max_context_len,
+        max_output_tokens=max_output_tokens,
+        prompts_file=prompts_file,
+        output_at_end=output_at_end,
+        top_p=top_p,
+        top_k=top_k,
+        temperature=temperature,
+        chat=chat,
+        device_mesh=device_mesh,
+        cluster_shape=cluster_shape,
+        n_devices=n_devices,
+        cache_path=cache_path,
+        decode_only=decode_only,
+        ground_truth=ground_truth,
+        print_output_as_generated=False,
+        print_output_at_end=True,
+    )
+    main(args)

--- a/models/demos/tg/llama3_70b/tests/test_llama_demo_nightly.py
+++ b/models/demos/tg/llama3_70b/tests/test_llama_demo_nightly.py
@@ -16,7 +16,7 @@ from models.demos.t3000.llama2_70b.tt.llama_common import (
     setup_llama_env,
     check_device_mesh,
 )
-from models.demos.tg.llama3_70b.demo.demo import main, construct_arg
+from models.demos.tg.llama3_70b.demo.demo import run_demo, construct_arg
 
 
 @pytest.mark.timeout(240000)
@@ -124,4 +124,4 @@ def test_llama3_tg_nightly_demo(
         print_output_as_generated=False,
         print_output_at_end=True,
     )
-    main(args)
+    run_demo(args)

--- a/models/demos/tg/llama3_70b/tests/test_llama_mlp_galaxy.py
+++ b/models/demos/tg/llama3_70b/tests/test_llama_mlp_galaxy.py
@@ -150,11 +150,7 @@ def run_test_LlamaMLP_inference(
 )
 @pytest.mark.parametrize(
     "llama_version",
-    (
-        # ("llama2"),
-        ("llama3"),
-        # ("llama3-405b"),
-    ),
+    (("llama3-tg"),),
 )
 @pytest.mark.parametrize(
     "batch, seq_len, pcc",

--- a/models/demos/tg/llama3_70b/tests/test_llama_model_galaxy.py
+++ b/models/demos/tg/llama3_70b/tests/test_llama_model_galaxy.py
@@ -247,10 +247,7 @@ def run_test_LlamaModel_inference(
 )
 @pytest.mark.parametrize(
     "llama_version",
-    (
-        # ("llama2"),
-        ("llama3"),
-    ),
+    (("llama3-tg"),),
 )
 @pytest.mark.parametrize(
     "pcc,n_layers",

--- a/models/demos/tg/llama3_70b/tests/test_llama_model_galaxy_ci.py
+++ b/models/demos/tg/llama3_70b/tests/test_llama_model_galaxy_ci.py
@@ -15,10 +15,7 @@ from models.demos.tg.llama3_70b.tests.test_llama_model_galaxy import run_test_Ll
 )
 @pytest.mark.parametrize(
     "llama_version",
-    (
-        # ("llama2"),
-        ("llama3"),
-    ),
+    (("llama3-tg"),),
 )
 @pytest.mark.parametrize(
     "pcc, n_layers",


### PR DESCRIPTION
### Ticket
[Link to Github Issue
](https://github.com/tenstorrent-metal/metal-internal-workflows/issues/291)
### Problem description
We needed a demo nightly test which can be added to future nightly TG pipeline.

### What's changed
1. Distinguishing version as llama3 and llama3-tg
2. Renabled device async on demo
3. added `test_llama_demo_nightly.py`

### Checklist
- [ ] Post commit CI passes
- [ ] Blackhole Post commit (if applicable)
- [ ] Model regression CI testing passes (if applicable)
- [x] New/Existing tests provide coverage for changes
