### PR TITLE
#11322: Fix UNet functional and performance demo crash

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -140,6 +140,7 @@ models/demos/tg/falcon7b @skhorasganiTT @djordje-tt @uaydonat
 models/demos/grayskull @uaydonat @eyonland
 models/demos/resnet @mywoodstock @shwetankTT @tt-aho
 models/demos/ttnn_resnet @mywoodstock @shwetankTT @tt-aho
+models/experimental/functional_unet @esmalTT @uaydonat @mywoodstock
 models/perf/ @uaydonat @tt-rkim
 models/perf/benchmarking_utils.py @skhorasganiTT @tt-rkim
 
@@ -158,6 +159,7 @@ tests/python_api_testing/conv/ @mywoodstock @sankarmanoj-tt
 tests/python_api_testing/unit_testing/fallback_ops @tt-aho
 tests/ttnn/integration_tests/stable_diffusion @esmalTT @uaydonat @mywoodstock
 tests/device_perf_tests/stable_diffusion/test_perf_stable_diffusion.py @esmalTT @uaydonat @mywoodstock
+tests/ttnn/integration_tests/unet @esmalTT @uaydonat @mywoodstock
 scripts/profiler/ @mo-tenstorrent
 scripts/docker @ttmchiou @TT-billteng @tt-rkim
 

--- a/models/experimental/functional_unet/tests/test_unet_shallow_functional.py
+++ b/models/experimental/functional_unet/tests/test_unet_shallow_functional.py
@@ -61,8 +61,5 @@ def test_unet_pcc(device, perf_mode, batch, groups):
         output_tensor = torch.permute(output_tensor, (0, 3, 1, 2))
         output_tensor = output_tensor.to(torch_input_tensor.dtype)
 
-        # Disable pcc checking due to hang
-        # if device.arch() == ttl.device.Arch.WORMHOLE_B0:
-        #    assert_with_pcc(torch_output_tensor, output_tensor, pcc=0.99)
-        # else:
-        #    assert_with_pcc(torch_output_tensor, output_tensor, pcc=0.97)
+        assert_with_pcc(torch_output_tensor, output_tensor, pcc=0.99)
+


### PR DESCRIPTION
### Ticket
#11322 

### Problem description
UNet was broken due to a runtime exception being thrown during the final 1x1 convolution layer. This occurred because it is currently not covered by any tests on CI.

### What's changed
Instead of fixing the issue in the deprecated convolution API, I converted the broken layer to the new convolution API. This makes the most sense since we will eventually have to convert the entire model to this new API.

I will enable the tests in CI in a follow-on issue (#11323)

### Checklist
- [x] Post commit CI passes
- [x] Model regression CI testing passes (if applicable)
