### PR TITLE
#11368: Add Single and Multi-Dev Event APIs to TTNN

### DIFF
--- a/models/demos/resnet/tt/metalResnetBlock50.py
+++ b/models/demos/resnet/tt/metalResnetBlock50.py
@@ -2199,7 +2199,7 @@ class ResNet(nn.Module):
                 shard_spec,
             )
             if write_event is not None:
-                tt_lib.device.WaitForEvent(self.device, 0, write_event)
+                ttnn.wait_for_event(self.device, 0, write_event)
             if x.storage_type() != tt_lib.tensor.StorageType.DEVICE:
                 x = x.to(self.device, mem_config)
             elif x.memory_config().is_sharded():
@@ -2210,7 +2210,7 @@ class ResNet(nn.Module):
             else:
                 x = tt_lib.tensor.interleaved_to_sharded(x, mem_config)
             if op_event is not None:
-                tt_lib.device.RecordEvent(self.device, 0, op_event)
+                ttnn.record_event(self.device, 0, op_event)
 
         x = self.conv1(x)
         if x_in is not None:

--- a/models/demos/ttnn_resnet/tests/multi_device/test_ttnn_resnet50_performant.py
+++ b/models/demos/ttnn_resnet/tests/multi_device/test_ttnn_resnet50_performant.py
@@ -21,32 +21,6 @@ except ModuleNotFoundError:
     use_signpost = False
 
 
-def create_event(device):
-    event = []
-    if isinstance(device, ttnn.Device):
-        event.append(tt_lib.device.CreateEvent())
-    else:
-        for dev in device.get_device_ids():
-            event.append(tt_lib.device.CreateEvent())
-    return event
-
-
-def wait_for_event(device, cq_id, event):
-    if isinstance(device, ttnn.Device):
-        tt_lib.device.WaitForEvent(device, cq_id, event)
-    else:
-        for dev, eve in zip(device.get_device_ids(), event):
-            tt_lib.device.WaitForEvent(device.get_device(dev), cq_id, eve)
-
-
-def record_event(device, cq_id, event):
-    if isinstance(device, ttnn.Device):
-        tt_lib.device.RecordEvent(device, cq_id, event)
-    else:
-        for dev, eve in zip(device.get_device_ids(), event):
-            tt_lib.device.RecordEvent(device.get_device(dev), cq_id, eve)
-
-
 def buffer_address(tensor):
     addr = []
     for ten in ttnn.get_device_tensors(tensor):
@@ -54,10 +28,7 @@ def buffer_address(tensor):
     return addr
 
 
-# TODO: Create ttnn apis for these
-ttnn.create_event = create_event
-ttnn.wait_for_event = wait_for_event
-ttnn.record_event = record_event
+# TODO: Create ttnn apis for this
 ttnn.buffer_address = buffer_address
 
 
@@ -303,25 +274,25 @@ def test_run_resnet50_2cqs_inference(
     op_event = ttnn.create_event(device_mesh)
     write_event = ttnn.create_event(device_mesh)
     # Initialize the op event so we can write
-    ttnn.record_event(device_mesh, 0, op_event)
+    ttnn.record_event(0, op_event)
 
     # First run configures convs JIT
-    ttnn.wait_for_event(device_mesh, 1, op_event)
+    ttnn.wait_for_event(1, op_event)
     ttnn.copy_host_to_device_tensor(tt_inputs_host, tt_image_res, 1)
-    ttnn.record_event(device_mesh, 1, write_event)
-    ttnn.wait_for_event(device_mesh, 0, write_event)
+    ttnn.record_event(1, write_event)
+    ttnn.wait_for_event(0, write_event)
     test_infra.input_tensor = ttnn.to_memory_config(tt_image_res, input_mem_config)
-    ttnn.record_event(device_mesh, 0, op_event)
+    ttnn.record_event(0, op_event)
     test_infra.run()
     test_infra.validate()
 
     # Optimized run
-    ttnn.wait_for_event(device_mesh, 1, op_event)
+    ttnn.wait_for_event(1, op_event)
     ttnn.copy_host_to_device_tensor(tt_inputs_host, tt_image_res, 1)
-    ttnn.record_event(device_mesh, 1, write_event)
-    ttnn.wait_for_event(device_mesh, 0, write_event)
+    ttnn.record_event(1, write_event)
+    ttnn.wait_for_event(0, write_event)
     test_infra.input_tensor = ttnn.to_memory_config(tt_image_res, input_mem_config)
-    ttnn.record_event(device_mesh, 0, op_event)
+    ttnn.record_event(0, op_event)
     test_infra.run()
     test_infra.validate()
 
@@ -330,12 +301,12 @@ def test_run_resnet50_2cqs_inference(
         signpost(header="start")
     outputs = []
     for iter in range(0, 2):
-        ttnn.wait_for_event(device_mesh, 1, op_event)
+        ttnn.wait_for_event(1, op_event)
         ttnn.copy_host_to_device_tensor(tt_inputs_host, tt_image_res, 1)
-        ttnn.record_event(device_mesh, 1, write_event)
-        ttnn.wait_for_event(device_mesh, 0, write_event)
+        ttnn.record_event(1, write_event)
+        ttnn.wait_for_event(0, write_event)
         test_infra.input_tensor = ttnn.to_memory_config(tt_image_res, input_mem_config)
-        ttnn.record_event(device_mesh, 0, op_event)
+        ttnn.record_event(0, op_event)
         outputs.append(ttnn.from_device(test_infra.run(), blocking=False))
 
     ttnn.synchronize_devices(device_mesh)
@@ -399,36 +370,36 @@ def test_run_resnet50_trace_2cqs_inference(
     op_event = ttnn.create_event(device_mesh)
     write_event = ttnn.create_event(device_mesh)
     # Initialize the op event so we can write
-    ttnn.record_event(device_mesh, 0, op_event)
+    ttnn.record_event(0, op_event)
 
     # First run configures convs JIT
-    ttnn.wait_for_event(device_mesh, 1, op_event)
+    ttnn.wait_for_event(1, op_event)
     ttnn.copy_host_to_device_tensor(tt_inputs_host, tt_image_res, 1)
-    ttnn.record_event(device_mesh, 1, write_event)
-    ttnn.wait_for_event(device_mesh, 0, write_event)
+    ttnn.record_event(1, write_event)
+    ttnn.wait_for_event(0, write_event)
     test_infra.input_tensor = ttnn.to_memory_config(tt_image_res, input_mem_config)
-    ttnn.record_event(device_mesh, 0, op_event)
+    ttnn.record_event(0, op_event)
     test_infra.run()
     test_infra.validate()
 
     # Optimized run
-    ttnn.wait_for_event(device_mesh, 1, op_event)
+    ttnn.wait_for_event(1, op_event)
     ttnn.copy_host_to_device_tensor(tt_inputs_host, tt_image_res, 1)
-    ttnn.record_event(device_mesh, 1, write_event)
-    ttnn.wait_for_event(device_mesh, 0, write_event)
+    ttnn.record_event(1, write_event)
+    ttnn.wait_for_event(0, write_event)
     test_infra.input_tensor = ttnn.to_memory_config(tt_image_res, input_mem_config)
     first_out_addr = ttnn.buffer_address(test_infra.input_tensor)
-    ttnn.record_event(device_mesh, 0, op_event)
+    ttnn.record_event(0, op_event)
     test_infra.run()
     test_infra.validate()
 
     # Capture
-    ttnn.wait_for_event(device_mesh, 1, op_event)
+    ttnn.wait_for_event(1, op_event)
     ttnn.copy_host_to_device_tensor(tt_inputs_host, tt_image_res, 1)
-    ttnn.record_event(device_mesh, 1, write_event)
-    ttnn.wait_for_event(device_mesh, 0, write_event)
+    ttnn.record_event(1, write_event)
+    ttnn.wait_for_event(0, write_event)
     test_infra.input_tensor = ttnn.to_memory_config(tt_image_res, input_mem_config)
-    ttnn.record_event(device_mesh, 0, op_event)
+    ttnn.record_event(0, op_event)
     tid = ttnn.begin_trace_capture(device_mesh, cq_id=0)
     test_infra.run()
     test_infra.input_tensor = ttnn.allocate_tensor_on_device(
@@ -447,15 +418,15 @@ def test_run_resnet50_trace_2cqs_inference(
         signpost(header="start")
     outputs = []
     for iter in range(0, 1):
-        ttnn.wait_for_event(device_mesh, 1, op_event)
+        ttnn.wait_for_event(1, op_event)
         ttnn.copy_host_to_device_tensor(tt_inputs_host, tt_image_res, 1)
-        ttnn.record_event(device_mesh, 1, write_event)
-        ttnn.wait_for_event(device_mesh, 0, write_event)
+        ttnn.record_event(1, write_event)
+        ttnn.wait_for_event(0, write_event)
         # TODO: Add in place support to ttnn to_memory_config
         test_infra.input_tensor = ttnn.experimental.tensor.reshard(
             tt_image_res, input_mem_config, test_infra.input_tensor
         )
-        ttnn.record_event(device_mesh, 0, op_event)
+        ttnn.record_event(0, op_event)
         ttnn.execute_trace(device_mesh, tid, cq_id=0, blocking=False)
         outputs.append(ttnn.from_device(test_infra.output_tensor, blocking=False))
     ttnn.synchronize_devices(device_mesh)

--- a/models/demos/ttnn_resnet/tests/test_ttnn_resnet50_performant.py
+++ b/models/demos/ttnn_resnet/tests/test_ttnn_resnet50_performant.py
@@ -21,12 +21,6 @@ except ModuleNotFoundError:
     use_signpost = False
 
 
-# TODO: Create ttnn apis for these
-ttnn.create_event = tt_lib.device.CreateEvent
-ttnn.wait_for_event = tt_lib.device.WaitForEvent
-ttnn.record_event = tt_lib.device.RecordEvent
-
-
 # TODO: Move these into Resnet model preprocessing/member functions
 def setup_l1_sharded_input(device, tt_inputs, tt_resnet50):
     padded_input_shape, input_mem_config, _ = ttnn.get_conv_padded_input_shape_and_mem_config(
@@ -211,28 +205,28 @@ def test_run_resnet50_2cqs_inference(
         device, test_infra.input_tensor, test_infra.ttnn_resnet50_model
     )
     tt_image_res = tt_inputs_host.to(device, sharded_mem_config_DRAM)
-    op_event = ttnn.create_event()
-    write_event = ttnn.create_event()
+    op_event = ttnn.create_event(device)
+    write_event = ttnn.create_event(device)
     # Initialize the op event so we can write
-    ttnn.record_event(device, 0, op_event)
+    ttnn.record_event(0, op_event)
 
     # First run configures convs JIT
-    ttnn.wait_for_event(device, 1, op_event)
+    ttnn.wait_for_event(1, op_event)
     ttnn.copy_host_to_device_tensor(tt_inputs_host, tt_image_res, 1)
-    ttnn.record_event(device, 1, write_event)
-    ttnn.wait_for_event(device, 0, write_event)
+    ttnn.record_event(1, write_event)
+    ttnn.wait_for_event(0, write_event)
     test_infra.input_tensor = ttnn.to_memory_config(tt_image_res, input_mem_config)
-    ttnn.record_event(device, 0, op_event)
+    ttnn.record_event(0, op_event)
     test_infra.run()
     test_infra.validate()
 
     # Optimized run
-    ttnn.wait_for_event(device, 1, op_event)
+    ttnn.wait_for_event(1, op_event)
     ttnn.copy_host_to_device_tensor(tt_inputs_host, tt_image_res, 1)
-    ttnn.record_event(device, 1, write_event)
-    ttnn.wait_for_event(device, 0, write_event)
+    ttnn.record_event(1, write_event)
+    ttnn.wait_for_event(0, write_event)
     test_infra.input_tensor = ttnn.to_memory_config(tt_image_res, input_mem_config)
-    ttnn.record_event(device, 0, op_event)
+    ttnn.record_event(0, op_event)
     test_infra.run()
     test_infra.validate()
 
@@ -241,12 +235,12 @@ def test_run_resnet50_2cqs_inference(
         signpost(header="start")
     outputs = []
     for iter in range(0, 2):
-        ttnn.wait_for_event(device, 1, op_event)
+        ttnn.wait_for_event(1, op_event)
         ttnn.copy_host_to_device_tensor(tt_inputs_host, tt_image_res, 1)
-        ttnn.record_event(device, 1, write_event)
-        ttnn.wait_for_event(device, 0, write_event)
+        ttnn.record_event(1, write_event)
+        ttnn.wait_for_event(0, write_event)
         test_infra.input_tensor = ttnn.to_memory_config(tt_image_res, input_mem_config)
-        ttnn.record_event(device, 0, op_event)
+        ttnn.record_event(0, op_event)
         outputs.append(ttnn.from_device(test_infra.run(), blocking=False))
     ttnn.synchronize_device(device)
     if use_signpost:
@@ -296,39 +290,39 @@ def test_run_resnet50_trace_2cqs_inference(
         device, test_infra.input_tensor, test_infra.ttnn_resnet50_model
     )
     tt_image_res = tt_inputs_host.to(device, sharded_mem_config_DRAM)
-    op_event = ttnn.create_event()
-    write_event = ttnn.create_event()
+    op_event = ttnn.create_event(device)
+    write_event = ttnn.create_event(device)
     # Initialize the op event so we can write
-    ttnn.record_event(device, 0, op_event)
+    ttnn.record_event(0, op_event)
 
     # First run configures convs JIT
-    ttnn.wait_for_event(device, 1, op_event)
+    ttnn.wait_for_event(1, op_event)
     ttnn.copy_host_to_device_tensor(tt_inputs_host, tt_image_res, 1)
-    ttnn.record_event(device, 1, write_event)
-    ttnn.wait_for_event(device, 0, write_event)
+    ttnn.record_event(1, write_event)
+    ttnn.wait_for_event(0, write_event)
     test_infra.input_tensor = ttnn.to_memory_config(tt_image_res, input_mem_config)
-    ttnn.record_event(device, 0, op_event)
+    ttnn.record_event(0, op_event)
     test_infra.run()
     test_infra.validate()
 
     # Optimized run
-    ttnn.wait_for_event(device, 1, op_event)
+    ttnn.wait_for_event(1, op_event)
     ttnn.copy_host_to_device_tensor(tt_inputs_host, tt_image_res, 1)
-    ttnn.record_event(device, 1, write_event)
-    ttnn.wait_for_event(device, 0, write_event)
+    ttnn.record_event(1, write_event)
+    ttnn.wait_for_event(0, write_event)
     test_infra.input_tensor = ttnn.to_memory_config(tt_image_res, input_mem_config)
     first_out_addr = test_infra.input_tensor.buffer_address()
-    ttnn.record_event(device, 0, op_event)
+    ttnn.record_event(0, op_event)
     test_infra.run()
     test_infra.validate()
 
     # Capture
-    ttnn.wait_for_event(device, 1, op_event)
+    ttnn.wait_for_event(1, op_event)
     ttnn.copy_host_to_device_tensor(tt_inputs_host, tt_image_res, 1)
-    ttnn.record_event(device, 1, write_event)
-    ttnn.wait_for_event(device, 0, write_event)
+    ttnn.record_event(1, write_event)
+    ttnn.wait_for_event(0, write_event)
     test_infra.input_tensor = ttnn.to_memory_config(tt_image_res, input_mem_config)
-    ttnn.record_event(device, 0, op_event)
+    ttnn.record_event(0, op_event)
     tid = ttnn.begin_trace_capture(device, cq_id=0)
     test_infra.run()
     test_infra.input_tensor = ttnn.allocate_tensor_on_device(
@@ -347,15 +341,15 @@ def test_run_resnet50_trace_2cqs_inference(
         signpost(header="start")
     outputs = []
     for iter in range(0, 2):
-        ttnn.wait_for_event(device, 1, op_event)
+        ttnn.wait_for_event(1, op_event)
         ttnn.copy_host_to_device_tensor(tt_inputs_host, tt_image_res, 1)
-        ttnn.record_event(device, 1, write_event)
-        ttnn.wait_for_event(device, 0, write_event)
+        ttnn.record_event(1, write_event)
+        ttnn.wait_for_event(0, write_event)
         # TODO: Add in place support to ttnn to_memory_config
         test_infra.input_tensor = ttnn.experimental.tensor.reshard(
             tt_image_res, input_mem_config, test_infra.input_tensor
         )
-        ttnn.record_event(device, 0, op_event)
+        ttnn.record_event(0, op_event)
         ttnn.execute_trace(device, tid, cq_id=0, blocking=False)
         outputs.append(ttnn.from_device(test_infra.output_tensor, blocking=False))
 

--- a/tests/scripts/t3000/run_t3000_unit_tests.sh
+++ b/tests/scripts/t3000/run_t3000_unit_tests.sh
@@ -35,6 +35,7 @@ run_t3000_ttnn_tests() {
   WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml ./build/test/ttnn/test_multi_device
   WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml ./build/test/ttnn/unit_tests_ttnn
   WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml pytest tests/ttnn/unit_tests/test_multi_device_trace.py ; fail+=$?
+  WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml pytest tests/ttnn/unit_tests/test_multi_device_events.py ; fail+=$?
   pytest -n auto tests/ttnn/unit_tests/test_multi_device.py ; fail+=$?
   pytest -n auto tests/ttnn/unit_tests/test_multi_device_async.py ; fail+=$?
   # Record the end time

--- a/tests/ttnn/unit_tests/test_multi_device_events.py
+++ b/tests/ttnn/unit_tests/test_multi_device_events.py
@@ -1,0 +1,89 @@
+# SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
+
+# SPDX-License-Identifier: Apache-2.0
+
+import torch
+import typing
+import pytest
+import ttnn
+import tempfile
+from loguru import logger
+import os
+from tests.ttnn.utils_for_testing import assert_with_pcc
+from ttnn import ShardTensorToMesh, ReplicateTensorToMesh, ConcatMeshToTensor, ListMeshToTensor
+
+
+@pytest.mark.parametrize("shape", [(1, 1, 512, 512)])
+@pytest.mark.parametrize("device_params", [{"num_command_queues": 2}], indirect=True)
+def test_multi_device_events(t3k_device_mesh, shape):
+    if t3k_device_mesh.get_num_devices() <= 1:
+        pytest.skip("This test requires multiple devices")
+
+    # Enable Program Cache and Async Mode
+    for device_id in t3k_device_mesh.get_device_ids():
+        t3k_device_mesh.get_device(device_id).enable_async(True)
+        t3k_device_mesh.get_device(device_id).enable_program_cache()
+
+    # Preallocate activation tensors.
+    input_0_dev = ttnn.allocate_tensor_on_device(ttnn.Shape(shape), ttnn.bfloat16, ttnn.TILE_LAYOUT, t3k_device_mesh)
+    input_1_dev = ttnn.allocate_tensor_on_device(ttnn.Shape(shape), ttnn.bfloat16, ttnn.TILE_LAYOUT, t3k_device_mesh)
+
+    # Send workload/ops on CQ 0 and Data on CQ 1. Use events for synchronization
+    workload_cq = 0
+    data_movement_cq = 1
+
+    # Op chain to run on device, using the workload_cq
+    def run_op_chain(input_0, input_1, workload_cq):
+        return ttnn.neg(ttnn.add(ttnn.mul(input_1, ttnn.neg(ttnn.gelu(input_0))), ttnn.relu(input_1)))
+
+    for i in range(10):
+        # Create events to synchronize data movement with workload execution.
+        write_event = ttnn.create_event(t3k_device_mesh)
+        workload_event = ttnn.create_event(t3k_device_mesh)
+        # Create torch inputs, for validation
+        torch_input_tensor_0 = torch.rand(
+            (t3k_device_mesh.get_num_devices(), shape[1], shape[2], shape[3]), dtype=torch.bfloat16
+        )
+        torch_input_tensor_1 = torch.rand(
+            (t3k_device_mesh.get_num_devices(), shape[1], shape[2], shape[3]), dtype=torch.bfloat16
+        )
+        # Compute torch golden for validation
+        torch_output_golden = torch.neg(
+            torch.add(
+                torch.mul(torch_input_tensor_1, torch.neg(torch.nn.functional.gelu(torch_input_tensor_0))),
+                torch.relu(torch_input_tensor_1),
+            )
+        )
+        # Convert torch tensors to TTNN Multi-Device Host Tensors
+        ttnn_input_tensor_0 = ttnn.from_torch(
+            torch_input_tensor_0, layout=ttnn.TILE_LAYOUT, mesh_mapper=ShardTensorToMesh(t3k_device_mesh, dim=0)
+        )
+        ttnn_input_tensor_1 = ttnn.from_torch(
+            torch_input_tensor_1, layout=ttnn.TILE_LAYOUT, mesh_mapper=ShardTensorToMesh(t3k_device_mesh, dim=0)
+        )
+
+        # Copy TTNN host tensors into preallocated Mult-Device tensors, using data-movement CQ
+        logger.info("Send Inputs to Device")
+        ttnn.copy_host_to_device_tensor(ttnn_input_tensor_0, input_0_dev, cq_id=data_movement_cq)
+        ttnn.copy_host_to_device_tensor(ttnn_input_tensor_1, input_1_dev, cq_id=data_movement_cq)
+        # Wait for write to be completed before issuing workload
+        ttnn.record_event(data_movement_cq, write_event)
+        ttnn.wait_for_event(workload_cq, write_event)
+        logger.info("Execute Workload")
+        # Execute workload
+        ttnn_output = run_op_chain(input_0_dev, input_1_dev, workload_cq)
+        # Wait for workload to be completed before issuing read
+        ttnn.record_event(workload_cq, workload_event)
+        ttnn.wait_for_event(data_movement_cq, workload_event)
+        logger.info("Read Back Workload Outputs")
+        # Read device outputs and validate
+        ttnn_torch_output_tensor = ttnn.to_torch(
+            ttnn_output,
+            mesh_composer=ConcatMeshToTensor(t3k_device_mesh, dim=0),
+            device=t3k_device_mesh,
+            cq_id=data_movement_cq,
+        )
+        assert_with_pcc(ttnn_torch_output_tensor, torch_output_golden, pcc=0.96)
+
+    for device_id in t3k_device_mesh.get_device_ids():
+        t3k_device_mesh.get_device(device_id).enable_async(False)

--- a/ttnn/CMakeLists.txt
+++ b/ttnn/CMakeLists.txt
@@ -3,6 +3,7 @@ set(ALL_TTNN_SRCS
     ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/config.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/device.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/multi_device.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/events.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operation_history.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/run_operation.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/ccl/all_gather/all_gather.cpp
@@ -234,6 +235,7 @@ set(ALL_TTNN_SRCS
     ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/data_movement/sharded_partial/interleaved_to_sharded_partial/interleaved_to_sharded_partial.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/data_movement/sharded_partial/interleaved_to_sharded_partial/interleaved_to_sharded_partial_pybind.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/data_movement/sharded_partial/interleaved_to_sharded_partial/device/interleaved_to_sharded_partial_op.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/cpp/pybind11/events.cpp
 )
 
 # Split src and python bindings

--- a/ttnn/cpp/pybind11/__init__.cpp
+++ b/ttnn/cpp/pybind11/__init__.cpp
@@ -7,6 +7,7 @@
 
 #include "core.hpp"
 #include "device.hpp"
+#include "events.hpp"
 #include "multi_device.hpp"
 #include "types.hpp"
 #include "reports.hpp"
@@ -39,6 +40,9 @@ PYBIND11_MODULE(_ttnn, module) {
 
     auto m_multi_device = module.def_submodule("multi_device", "ttnn multi_device");
     ttnn::multi_device::py_module(m_multi_device);
+
+    auto m_events = module.def_submodule("events", "ttnn events");
+    ttnn::events::py_module(m_events);
 
     auto m_reports = module.def_submodule("reports", "ttnn reports");
     ttnn::reports::py_module(m_reports);

--- a/ttnn/cpp/pybind11/events.cpp
+++ b/ttnn/cpp/pybind11/events.cpp
@@ -1,0 +1,89 @@
+// SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "events.hpp"
+
+namespace ttnn::events {
+
+    void py_module(py::module& module) {
+        py::class_<Event, std::shared_ptr<Event>>(module, "event");
+        py::class_<MultiDeviceEvent>(module, "multi_device_event");
+        // Single Device APIs
+        module.def(
+            "create_event",
+            py::overload_cast<Device*>(&create_event),
+            py::arg("device"),
+            R"doc(
+            Create an Event Object on a single device.
+
+            Args:
+                device (Device): The device on which this event will be used for synchronization.
+            )doc");
+
+        module.def(
+            "record_event",
+            py::overload_cast<uint8_t, const std::shared_ptr<Event>&>(&record_event),
+            py::arg("cq_id"),
+            py::arg("event"),
+            R"doc(
+            Record the completion of commands on this CQ, preceeding this call.
+
+            Args:
+                cq_id (int): The Command Queue on which event completion will be recorded.
+                event (event): The event used to record completion of preceeding commands.
+            )doc");
+
+        module.def(
+            "wait_for_event",
+            py::overload_cast<uint8_t, const std::shared_ptr<Event>&>(&wait_for_event),
+            py::arg("cq_id"),
+            py::arg("event"),
+            R"doc(
+            Insert a barrier - Make a CQ wait until an event is recorded.
+
+            Args:
+                cq_id (int): The Command Queue on which the barrier is being issued.
+                event (event): The Command Queue will stall until this event is completed.
+            )doc");
+
+        // Multi Device APIs
+        module.def(
+            "create_event",
+            py::overload_cast<DeviceMesh*>(&create_event),
+            py::arg("device_mesh"),
+            R"doc(
+            Create an Event Object on a mesh of devices.
+
+            Args:
+                device_mesh (DeviceMesh): The mesh on which this event will be used for synchronization.
+            )doc");
+
+        module.def(
+            "record_event",
+            py::overload_cast<uint8_t, const MultiDeviceEvent&>(&record_event),
+            py::arg("cq_id"),
+            py::arg("multi_device_event"),
+            R"doc(
+            Record the completion of commands on this CQ, preceeding this call.
+
+            Args:
+                cq_id (int): The Command Queue on which event completion will be recorded.
+                event (event): The event used to record completion of preceeding commands.
+            )doc");
+
+        module.def(
+            "wait_for_event",
+            py::overload_cast<uint8_t, const MultiDeviceEvent&>(&wait_for_event),
+            py::arg("cq_id"),
+            py::arg("multi_device_event"),
+            R"doc(
+            Record the completion of commands on this CQ, preceeding this call.
+
+            Args:
+                cq_id (int): The Command Queue on which event completion will be recorded.
+                event (event): The event used to record completion of preceeding commands.
+            )doc");
+    }
+
+} // namespace ttnn::events

--- a/ttnn/cpp/pybind11/events.hpp
+++ b/ttnn/cpp/pybind11/events.hpp
@@ -1,0 +1,16 @@
+// SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include "pybind11/pybind_fwd.hpp"
+#include "ttnn/events.hpp"
+
+namespace py = pybind11;
+
+namespace ttnn::events {
+
+    void py_module(py::module& module);
+
+} // namespace ttnn::events

--- a/ttnn/cpp/pybind11/operations/core.hpp
+++ b/ttnn/cpp/pybind11/operations/core.hpp
@@ -83,7 +83,7 @@ void py_module(py::module& module) {
         py::arg("device"),
         py::arg("memory_config") = std::nullopt);
 
-    module.def("from_device", &ttnn::operations::core::from_device, py::arg("tensor"), py::arg("blocking") = true);
+    module.def("from_device", &ttnn::operations::core::from_device, py::arg("tensor"), py::arg("blocking") = true, py::kw_only(), py::arg("cq_id") = ttnn::DefaultQueueId);
 
     module.def("deallocate", &ttnn::operations::core::deallocate, py::arg("tensor"), py::arg("force") = true);
 
@@ -172,14 +172,14 @@ void py_module(py::module& module) {
         &ttnn::operations::core::copy_host_to_device_tensor,
         py::arg("host_tensor"),
         py::arg("device_tensor"),
-        py::arg("cq_id") = 0);
+        py::arg("cq_id") = ttnn::DefaultQueueId);
 
     module.def(
         "begin_trace_capture",
         py::overload_cast<Device*, const uint8_t>(&ttnn::operations::core::begin_trace_capture),
         py::arg("device"),
         py::kw_only(),
-        py::arg("cq_id") = 0);
+        py::arg("cq_id") = ttnn::DefaultQueueId);
 
     module.def(
         "end_trace_capture",
@@ -187,7 +187,7 @@ void py_module(py::module& module) {
         py::arg("device"),
         py::arg("trace_id"),
         py::kw_only(),
-        py::arg("cq_id") = 0);
+        py::arg("cq_id") = ttnn::DefaultQueueId);
 
     module.def(
         "execute_trace",
@@ -195,7 +195,7 @@ void py_module(py::module& module) {
         py::arg("device"),
         py::arg("trace_id"),
         py::kw_only(),
-        py::arg("cq_id") = 0,
+        py::arg("cq_id") = ttnn::DefaultQueueId,
         py::arg("blocking") = true);
 
     module.def(
@@ -209,7 +209,7 @@ void py_module(py::module& module) {
         py::overload_cast<DeviceMesh*, const uint8_t>(&ttnn::operations::core::begin_trace_capture),
         py::arg("device_mesh"),
         py::kw_only(),
-        py::arg("cq_id") = 0);
+        py::arg("cq_id") = ttnn::DefaultQueueId);
 
     module.def(
         "end_trace_capture",
@@ -217,7 +217,7 @@ void py_module(py::module& module) {
         py::arg("device_mesh"),
         py::arg("trace_id"),
         py::kw_only(),
-        py::arg("cq_id") = 0);
+        py::arg("cq_id") = ttnn::DefaultQueueId);
 
     module.def(
         "execute_trace",
@@ -225,7 +225,7 @@ void py_module(py::module& module) {
         py::arg("device_mesh"),
         py::arg("trace_id"),
         py::kw_only(),
-        py::arg("cq_id") = 0,
+        py::arg("cq_id") = ttnn::DefaultQueueId,
         py::arg("blocking") = true);
 
     module.def(

--- a/ttnn/cpp/ttnn/deprecated/tt_lib/csrc/tt_lib_bindings.cpp
+++ b/ttnn/cpp/ttnn/deprecated/tt_lib/csrc/tt_lib_bindings.cpp
@@ -283,30 +283,6 @@ void DeviceModule(py::module &m_device) {
         Release captured Trace on Device handle
     )doc");
 
-    auto pyEvent = py::class_<Event, std::shared_ptr<Event>>(m_device, "Event", "Event class");
-    m_device.def("CreateEvent",
-        [] () {
-            return std::make_shared<Event>();
-        }, R"doc(
-        Create new event
-    )doc");
-    m_device.def("RecordEvent",
-        [] (Device* device, const uint8_t cq_id, std::shared_ptr<Event> event) {
-            device->push_work([device, cq_id, event] {
-                EnqueueRecordEvent(device->command_queue(cq_id), event);
-            });
-        }, R"doc(
-        Record an event
-    )doc");
-    m_device.def("WaitForEvent",
-        [] (Device* device, const uint8_t cq_id, std::shared_ptr<Event> event) {
-            device->push_work([device, cq_id, event] {
-                EnqueueWaitForEvent(device->command_queue(cq_id), event);
-            });
-        }, R"doc(
-        Wait for an event
-    )doc");
-
     m_device.attr("DEFAULT_L1_SMALL_SIZE") = py::int_(DEFAULT_L1_SMALL_SIZE);
     m_device.attr("DEFAULT_TRACE_REGION_SIZE") = py::int_(DEFAULT_TRACE_REGION_SIZE);
 }

--- a/ttnn/cpp/ttnn/events.cpp
+++ b/ttnn/cpp/ttnn/events.cpp
@@ -1,0 +1,58 @@
+// SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "events.hpp"
+
+#include <memory>
+
+namespace ttnn::events {
+
+MultiDeviceEvent::MultiDeviceEvent(DeviceMesh* device_mesh) {
+    TT_ASSERT(device_mesh != nullptr, "Must provide a valid device_mesh when initializing an event on multiple devices.");
+    auto& devices = device_mesh->mesh_devices;
+    this->events = std::vector<std::shared_ptr<Event>>(devices.size());
+    for (int event_idx = 0; event_idx < devices.size(); event_idx++) {
+        this->events[event_idx] = std::make_shared<Event>();
+        this->events[event_idx]->device = devices[event_idx].second;
+    }
+}
+
+std::shared_ptr<Event> create_event(Device* device) {
+    std::shared_ptr<Event> event = std::make_shared<Event>();
+    event->device = device;
+    return event;
+}
+
+void record_event(uint8_t cq_id, const std::shared_ptr<Event>& event) {
+    Device* device = event->device;
+    device->push_work([device, event, cq_id] {
+        EnqueueRecordEvent(device->command_queue(cq_id), event);
+    });
+}
+
+void wait_for_event(uint8_t cq_id, const std::shared_ptr<Event>& event) {
+    Device* device = event->device;
+    device->push_work([device, event, cq_id] {
+        EnqueueWaitForEvent(device->command_queue(cq_id), event);
+    });
+}
+
+MultiDeviceEvent create_event(DeviceMesh* device_mesh) {
+    return MultiDeviceEvent(device_mesh);
+}
+
+void record_event(uint8_t cq_id, const MultiDeviceEvent& multi_device_event) {
+    for (auto& event : multi_device_event.events) {
+        record_event(cq_id, event);
+    }
+}
+
+void wait_for_event(uint8_t cq_id, const MultiDeviceEvent& multi_device_event) {
+    for (auto& event : multi_device_event.events) {
+        wait_for_event(cq_id, event);
+    }
+}
+
+
+}

--- a/ttnn/cpp/ttnn/events.hpp
+++ b/ttnn/cpp/ttnn/events.hpp
@@ -1,0 +1,27 @@
+// SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <memory>
+
+#include "tt_metal/impl/device/device_mesh.hpp"
+
+namespace ttnn::events {
+
+struct MultiDeviceEvent
+{
+    MultiDeviceEvent(DeviceMesh* device_mesh);
+    std::vector<std::shared_ptr<Event>> events;
+};
+// Single Device APIs
+std::shared_ptr<Event> create_event(Device* device);
+void record_event(uint8_t cq_id, const std::shared_ptr<Event>& event);
+void wait_for_event(uint8_t cq_id, const std::shared_ptr<Event>& event);
+// Multi Device APIs
+MultiDeviceEvent create_event(DeviceMesh* device_mesh);
+void record_event(uint8_t cq_id, const MultiDeviceEvent& event);
+void wait_for_event(uint8_t cq_id, const MultiDeviceEvent& event);
+
+} // namespace ttnn::events

--- a/ttnn/cpp/ttnn/operations/core/core.cpp
+++ b/ttnn/cpp/ttnn/operations/core/core.cpp
@@ -138,7 +138,7 @@ void copy_host_to_device_tensor(ttnn::Tensor host_tensor, ttnn::Tensor device_te
     tt::tt_metal::write_tensor(host_tensor, device_tensor, cq_id);
 }
 
-ttnn::Tensor from_device(const ttnn::Tensor& tensor, bool blocking) { return tensor.cpu(blocking); }
+ttnn::Tensor from_device(const ttnn::Tensor& tensor, bool blocking, uint8_t cq_id) { return tensor.cpu(blocking, cq_id); }
 
 void deallocate(Tensor& tensor, bool force) { tensor.deallocate(force); }
 

--- a/ttnn/cpp/ttnn/operations/core/core.hpp
+++ b/ttnn/cpp/ttnn/operations/core/core.hpp
@@ -67,9 +67,9 @@ ttnn::Tensor allocate_tensor_on_device(
     DeviceMesh* device_mesh,
     const std::optional<MemoryConfig>& memory_config);
 
-void copy_host_to_device_tensor(ttnn::Tensor host_tensor, ttnn::Tensor device_tensor, uint8_t cq_id = 0);
+void copy_host_to_device_tensor(ttnn::Tensor host_tensor, ttnn::Tensor device_tensor, uint8_t cq_id = ttnn::DefaultQueueId);
 
-ttnn::Tensor from_device(const ttnn::Tensor& tensor, bool blocking = true);
+ttnn::Tensor from_device(const ttnn::Tensor& tensor, bool blocking = true, uint8_t cq_id = ttnn::DefaultQueueId);
 
 void deallocate(Tensor& tensor, bool force = true);
 
@@ -85,11 +85,11 @@ void execute_trace(Device* device, const uint32_t tid, const uint8_t cq_id, bool
 void release_trace(Device* device, const uint32_t tid);
 
 // Trace APIs - Multi Device
-uint32_t begin_trace_capture(DeviceMesh* device, const uint8_t cq_id = 0);
+uint32_t begin_trace_capture(DeviceMesh* device, const uint8_t cq_id = ttnn::DefaultQueueId);
 
-void end_trace_capture(DeviceMesh* device, const uint32_t tid, const uint8_t cq_id = 0);
+void end_trace_capture(DeviceMesh* device, const uint32_t tid, const uint8_t cq_id = ttnn::DefaultQueueId);
 
-void execute_trace(DeviceMesh* device, const uint32_t tid, const uint8_t cq_id = 0, bool blocking = true);
+void execute_trace(DeviceMesh* device, const uint32_t tid, const uint8_t cq_id = ttnn::DefaultQueueId, bool blocking = true);
 
 void release_trace(DeviceMesh* device, const uint32_t tid);
 

--- a/ttnn/cpp/ttnn/tensor/tensor.hpp
+++ b/ttnn/cpp/ttnn/tensor/tensor.hpp
@@ -15,6 +15,7 @@
 #include "common/bfloat8.hpp"
 #include "common/test_tiles.hpp"
 #include "common/tt_backend_api_types.hpp"
+#include "ttnn/common/constants.hpp"
 #include "ttnn/tensor/types.hpp"
 #include "tt_metal/impl/buffers/buffer.hpp"
 #include "tt_metal/impl/device/device.hpp"
@@ -261,8 +262,7 @@ struct Tensor {
 
     Tensor pad(const Shape &output_tensor_shape, const Shape &input_tensor_start, float pad_value) const;
 
-    Tensor cpu(CommandQueue &queue, bool blocking = true) const;
-    Tensor cpu(bool blocking = true) const;
+    Tensor cpu(bool blocking = true, uint8_t cq_id = ttnn::DefaultQueueId) const;
 
     Tensor cpu_sharded() const;
 
@@ -439,7 +439,7 @@ Tensor allocate_tensor_on_device(
     Layout layout,
     DeviceMesh *device_mesh,
     const MemoryConfig &memory_config = {.memory_layout = tt::tt_metal::TensorMemoryLayout::INTERLEAVED});
-void write_tensor(Tensor host_tensor, Tensor device_tensor, uint8_t cq_id = 0);
+void write_tensor(Tensor host_tensor, Tensor device_tensor, uint8_t cq_id = ttnn::DefaultQueueId);
 
 // Maps a tensor to the set of devices in the device-mesh that the shards will be distributed across.
 std::vector<Device*> distribute_tensor_to_mesh(const Tensor& tensor, DeviceMesh& device_mesh);

--- a/ttnn/cpp/ttnn/tensor/tensor_impl.hpp
+++ b/ttnn/cpp/ttnn/tensor/tensor_impl.hpp
@@ -275,7 +275,7 @@ inline void read_data_from_device_buffer(DeviceBuffer device_buffer, vector<T>& 
 // ======================================================================================
 
 template <typename T>
-Tensor to_host(const Tensor& tensor, bool blocking = true);
+Tensor to_host(const Tensor& tensor, bool blocking = true, uint8_t cq_id = ttnn::DefaultQueueId);
 
 template <typename T>
 Tensor to_host_sharded(const Tensor& tensor);

--- a/ttnn/ttnn/__init__.py
+++ b/ttnn/ttnn/__init__.py
@@ -95,6 +95,8 @@ def manage_config(name, value):
 
 from ttnn._ttnn.multi_device import get_device_tensor, get_device_tensors, aggregate_as_tensor
 
+from ttnn._ttnn.events import create_event, record_event, wait_for_event
+
 from ttnn.types import (
     TILE_SIZE,
     DataType,

--- a/ttnn/ttnn/operations/core.py
+++ b/ttnn/ttnn/operations/core.py
@@ -291,6 +291,7 @@ def to_torch(
     torch_rank: Optional[int] = None,
     mesh_composer: Optional[ttnn.MeshToTensor] = None,
     device: Optional[ttnn.Device] = None,
+    cq_id: Optional[int] = 0,
 ) -> "torch.Tensor":
     """
     to_torch(tensor: ttnn.Tensor, torch_rank: Optional[int] = None) -> torch.Tensor
@@ -309,7 +310,7 @@ def to_torch(
                 [ 0.9023, -0.5820,  0.5312]], dtype=torch.bfloat16)
     """
     if ttnn.is_tensor_storage_on_device(tensor):
-        tensor = ttnn.from_device(tensor)
+        tensor = ttnn.from_device(tensor, cq_id=cq_id)
 
     if tensor.layout != ttnn.ROW_MAJOR_LAYOUT:
         tensor = tensor.to(ttnn.ROW_MAJOR_LAYOUT, device)


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/11368

### Problem description
Event APIs are currently not exposed through ttnn, and don't support multi-device workloads. As a result, models using 2 CQs rely on hacks to perform event synchronization using deprecated tt_lib APIs.

### What's changed
  - Add event APIs to ttnn, supporting single and multi-device use cases
  - Remove tt_lib Event APIs, since they are deprecated and only support single device execution
     - Replaced `ttlib.CreateEvent`, `ttlib.RecordEvent` and `ttlib.WaitForEvent` with `ttnn.create_event`, `ttnn.record_event` and `ttnn.wait_for_event` 
  - Migrate all RN50 tests to use ttnn Event APIs
  - Add `cq_id` to ttnn read functions (from_device and to_torch), since it unblocks users from issuing device -> host data-movement on CQ1 using ttnn

#### API Description
Events are required to prevent pipeline hazards in multi-CQ workloads.

An event object can be initialized on a `device` or a `device_mesh` using:
`event = create_event(device)`
or 
`event = create_event(device_mesh)`

To record the completion of commands issued to a particular CQ (ex: CQ 0), the following API can be used:
`ttnn.record_event(cq_0, event)`

To ensure that a particular CQ (ex: CQ 1) executes commands after an event is recorded/set of commands have been processed, a barrier can be inserted using:
`ttnn.wait_for_event(cq_1, event)`

The `record_event` and `wait_for_event` APIs can be used to insert barriers, in order to resolve dependencies between CQs.

### Checklist
- [x] Post commit CI passes
- [ ] Blackhole Post commit (if applicable)
- [ ] Model regression CI testing passes (if applicable)
- [x] New/Existing tests provide coverage for changes
