### PR TITLE
#10360: Cut down on build time by targeting tests target directly

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -35,12 +35,9 @@ jobs:
       - name: Set up dynamic env vars for build
         run: |
           echo "TT_METAL_HOME=$(pwd)" >> $GITHUB_ENV
-      - name: Build tt-metal libraries
+      - name: Build C++ libraries and tests
         run: |
           cmake -B build -DCMAKE_BUILD_TYPE=${{ matrix.build.type }} -G Ninja
-          cmake --build build
-      - name: Build tt-metal C++ tests
-        run: |
           cmake --build build --target tests
       - uses: ./.github/actions/slack-report
         if: ${{ failure() }}


### PR DESCRIPTION
### Ticket
#10360 

### Problem description
Build times are bad

### What's changed

Make builds faster by targeting `tests` cmake target directly. This keeps more cores busy with compile work because metal libraries build much faster than ttnn -> metal tests can start building right away when metal libraries are done building.

### Checklist
- [x] Post commit CI passes
