### PR TITLE
#11109: refactoring moreh_getitem forward

### DIFF
--- a/tests/tt_eager/python_api_testing/unit_testing/misc/test_moreh_getitem.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/misc/test_moreh_getitem.py
@@ -10,14 +10,14 @@ from models.utility_functions import comp_allclose_and_pcc
 from loguru import logger
 
 
-def to_output_4d_shape(shape, index_dims, index_size):
-    output_4d_shape = list(shape)
+def to_output_5d_shape(shape, index_dims, index_size):
+    output_5d_shape = list(shape)
     for index_dim in index_dims:
-        output_4d_shape[index_dim] = 1
+        output_5d_shape[index_dim] = 1
 
-    output_4d_shape[index_dims[-1]] = index_size
+    output_5d_shape[index_dims[-1]] = index_size
 
-    return output_4d_shape
+    return output_5d_shape
 
 
 @pytest.mark.parametrize(
@@ -26,6 +26,7 @@ def to_output_4d_shape(shape, index_dims, index_size):
         ((10, 70), 0),
         ((10, 5, 70), 1),
         ((10, 5, 7, 70), 2),
+        ((10, 2, 5, 7, 70), 3),
     ),
 )
 @pytest.mark.parametrize(
@@ -67,6 +68,8 @@ def test_getitem_RAW_MJOR_one_index(shape_index_dim, dtype, index_size, device):
         tt_cpu = x[:, :, idx]
     elif index_dim == 3:
         tt_cpu = x[:, :, :, idx]
+    elif index_dim == 4:
+        tt_cpu = x[:, :, :, :, idx]
 
     tt_npu = ttnn.experimental.operations.primary.moreh_getitem(dev_x, [dev_idx], [index_dim])
 
@@ -82,8 +85,9 @@ def test_getitem_RAW_MJOR_one_index(shape_index_dim, dtype, index_size, device):
 @pytest.mark.parametrize(
     "shape_index_dims",
     (
-        ((10, 15, 7, 80), (0, 1)),
-        ((10, 15, 7, 80), (1, 2)),
+        ((10, 3, 5, 7, 80), (0, 1)),
+        ((10, 3, 5, 7, 80), (1, 2)),
+        ((10, 3, 5, 7, 80), (2, 3)),
     ),
 )
 @pytest.mark.parametrize(
@@ -126,6 +130,8 @@ def test_getitem_RAW_MAJOR_two_indices(shape_index_dims, dtype, index_size, devi
         tt_cpu = x[indices[0], indices[1]]
     if index_dims == (1, 2):
         tt_cpu = x[:, indices[0], indices[1]]
+    if index_dims == (2, 3):
+        tt_cpu = x[:, :, indices[0], indices[1]]
     tt_npu = ttnn.experimental.operations.primary.moreh_getitem(dev_x, dev_indices, index_dims)
 
     assert list(tt_npu.get_legacy_shape()) == list(tt_cpu.shape)
@@ -139,7 +145,11 @@ def test_getitem_RAW_MAJOR_two_indices(shape_index_dims, dtype, index_size, devi
 
 @pytest.mark.parametrize(
     "shape_index_dims",
-    (((10, 15, 7, 80), (0, 1, 2)),),
+    (
+        ((10, 15, 7, 80), (0, 1, 2)),
+        ((10, 3, 5, 7, 80), (0, 1, 2)),
+        ((10, 3, 5, 7, 80), (1, 2, 3)),
+    ),
 )
 @pytest.mark.parametrize(
     "index_size",
@@ -179,6 +189,8 @@ def test_getitem_RAW_MAJOR_three_indices(shape_index_dims, dtype, index_size, de
 
     if index_dims == (0, 1, 2):
         tt_cpu = x[indices[0], indices[1], indices[2]]
+    if index_dims == (1, 2, 3):
+        tt_cpu = x[:, indices[0], indices[1], indices[2]]
     tt_npu = ttnn.experimental.operations.primary.moreh_getitem(dev_x, dev_indices, index_dims)
 
     assert list(tt_npu.get_legacy_shape()) == list(tt_cpu.shape)
@@ -193,20 +205,40 @@ def test_getitem_RAW_MAJOR_three_indices(shape_index_dims, dtype, index_size, de
 @pytest.mark.parametrize(
     "shape_index_dim",
     (
+        ((7, 70), 0),
+        ((5, 64), 1),
+        ((10, 7, 70), 0),
+        ((10, 5, 64), 1),
+        ((10, 15, 70), 2),
         ((10, 5, 7, 70), 0),
-        ((1, 10, 5, 64), 1),
-        ((1, 1, 10, 70), 2),
-        ((1, 1, 2, 6), 3),
-        ((1, 1, 1, 30), 3),
-        ((5, 7, 3, 80), 3),
+        ((10, 5, 5, 64), 1),
+        ((10, 5, 15, 70), 2),
+        ((10, 5, 15, 70), 3),
+        ((10, 3, 5, 7, 70), 0),
+        ((1, 10, 3, 5, 64), 1),
+        ((1, 1, 10, 15, 70), 2),
+        ((1, 1, 10, 15, 70), 3),
+        ((1, 1, 1, 2, 6), 4),
+        ((1, 1, 1, 1, 30), 4),
+        ((1, 5, 7, 3, 80), 4),
     ),
     ids=[
-        "N",
-        "C",
-        "H",
-        "W1",
-        "W2",
-        "W_LARGE",
+        "2d_W",
+        "2d_H",
+        "3d_D",
+        "3d_H",
+        "3d_W",
+        "4d_C",
+        "4d_D",
+        "4d_H",
+        "4d_W",
+        "5d_N",
+        "5d_C",
+        "5d_D",
+        "5d_H",
+        "5d_W1",
+        "5d_W2",
+        "5d_W_LARGE",
     ],
 )
 @pytest.mark.parametrize(
@@ -251,7 +283,7 @@ def test_getitem_tilized_one_index(shape_index_dim, dtype, index_size, row_major
     else:
         dev_idx = (
             ttnn.Tensor(idx, ttnn.int32)
-            .reshape(1, 1, 1, index_size)
+            .reshape([1, 1, 1, 1, index_size])
             .pad_to_tile(float("nan"))
             .to(ttnn.TILE_LAYOUT)
             .to(device)
@@ -265,13 +297,15 @@ def test_getitem_tilized_one_index(shape_index_dim, dtype, index_size, row_major
         tt_cpu = x[:, :, idx]
     elif index_dim == 3:
         tt_cpu = x[:, :, :, idx]
+    elif index_dim == 4:
+        tt_cpu = x[:, :, :, :, idx]
 
     tt_npu = ttnn.experimental.operations.primary.moreh_getitem(dev_x, [dev_idx], [index_dim])
     tt_npu = tt_npu.cpu().to(ttnn.ROW_MAJOR_LAYOUT)
 
-    cpu_4d_shape = to_output_4d_shape(shape, [index_dim], index_size)
+    cpu_5d_shape = to_output_5d_shape(shape, [index_dim], index_size)
 
-    tt_npu = tt_npu.unpad_from_tile(cpu_4d_shape)
+    tt_npu = tt_npu.unpad_from_tile(cpu_5d_shape)
     tt_dev = tt_npu.to_torch().reshape(tt_cpu.shape).to(dtype)
 
     passing, out = comp_allclose_and_pcc(tt_cpu, tt_dev)
@@ -283,11 +317,18 @@ def test_getitem_tilized_one_index(shape_index_dim, dtype, index_size, row_major
 @pytest.mark.parametrize(
     "shape_index_dims",
     (
-        ((10, 15, 7, 70), (0, 1)),
-        ((10, 15, 7, 70), (1, 2)),
-        ((10, 15, 7, 70), (2, 3)),
+        ((7, 70), (0, 1)),
+        ((10, 7, 70), (0, 1)),
+        ((10, 5, 64), (1, 2)),
+        ((10, 5, 7, 70), (0, 1)),
+        ((10, 5, 5, 64), (1, 2)),
+        ((10, 5, 15, 70), (2, 3)),
+        ((10, 3, 5, 7, 70), (0, 1)),
+        ((10, 3, 5, 7, 70), (1, 2)),
+        ((10, 3, 5, 7, 70), (2, 3)),
+        ((10, 3, 5, 7, 70), (3, 4)),
     ),
-    ids=["NC", "CH", "HW"],
+    ids=["2d_HW", "3d_DH", "3d_HW", "4d_CD", "4d_DH", "4d_HW", "5d_NC", "5d_CD", "5d_DH", "5d_HW"],
 )
 @pytest.mark.parametrize(
     "dtype",
@@ -334,7 +375,7 @@ def test_getitem_tilized_two_indices(shape_index_dims, dtype, index_size, row_ma
         else:
             dev_idx = (
                 ttnn.Tensor(idx, ttnn.int32)
-                .reshape(1, 1, 1, index_size)
+                .reshape([1, 1, 1, 1, index_size])
                 .pad_to_tile(float("nan"))
                 .to(ttnn.TILE_LAYOUT)
                 .to(device)
@@ -348,13 +389,15 @@ def test_getitem_tilized_two_indices(shape_index_dims, dtype, index_size, row_ma
         tt_cpu = x[:, indices[0], indices[1]]
     if index_dims == (2, 3):
         tt_cpu = x[:, :, indices[0], indices[1]]
+    if index_dims == (3, 4):
+        tt_cpu = x[:, :, :, indices[0], indices[1]]
 
     tt_npu = ttnn.experimental.operations.primary.moreh_getitem(dev_x, dev_indices, index_dims)
     tt_npu = tt_npu.cpu().to(ttnn.ROW_MAJOR_LAYOUT)
 
-    output_4d_shape = to_output_4d_shape(shape, index_dims, index_size)
+    output_5d_shape = to_output_5d_shape(shape, index_dims, index_size)
 
-    tt_npu = tt_npu.unpad_from_tile(output_4d_shape)
+    tt_npu = tt_npu.unpad_from_tile(output_5d_shape)
     tt_dev = tt_npu.to_torch().reshape(tt_cpu.shape).to(dtype)
 
     passing, out = comp_allclose_and_pcc(tt_cpu, tt_dev)
@@ -366,10 +409,14 @@ def test_getitem_tilized_two_indices(shape_index_dims, dtype, index_size, row_ma
 @pytest.mark.parametrize(
     "shape_index_dims",
     (
-        ((10, 15, 7, 70), (0, 1, 2)),
-        ((10, 15, 7, 70), (1, 2, 3)),
+        ((5, 7, 70), (0, 1, 2)),
+        ((3, 5, 7, 70), (0, 1, 2)),
+        ((3, 5, 7, 70), (1, 2, 3)),
+        ((10, 3, 5, 7, 70), (0, 1, 2)),
+        ((10, 3, 5, 7, 70), (1, 2, 3)),
+        ((10, 3, 5, 7, 70), (2, 3, 4)),
     ),
-    ids=["NC", "CH"],
+    ids=["3d_DHW", "4d_CDH", "4d_DHW", "5d_NCD", "5d_CDH", "5d_DHW"],
 )
 @pytest.mark.parametrize(
     "dtype",
@@ -416,7 +463,7 @@ def test_getitem_tilized_three_indices(shape_index_dims, dtype, index_size, row_
         else:
             dev_idx = (
                 ttnn.Tensor(idx, ttnn.int32)
-                .reshape(1, 1, 1, index_size)
+                .reshape([1, 1, 1, 1, index_size])
                 .pad_to_tile(float("nan"))
                 .to(ttnn.TILE_LAYOUT)
                 .to(device)
@@ -428,13 +475,15 @@ def test_getitem_tilized_three_indices(shape_index_dims, dtype, index_size, row_
         tt_cpu = x[indices[0], indices[1], indices[2]]
     if index_dims == (1, 2, 3):
         tt_cpu = x[:, indices[0], indices[1], indices[2]]
+    if index_dims == (2, 3, 4):
+        tt_cpu = x[:, :, indices[0], indices[1], indices[2]]
 
     tt_npu = ttnn.experimental.operations.primary.moreh_getitem(dev_x, dev_indices, index_dims)
     tt_npu = tt_npu.cpu().to(ttnn.ROW_MAJOR_LAYOUT)
 
-    output_4d_shape = to_output_4d_shape(shape, index_dims, index_size)
+    output_5d_shape = to_output_5d_shape(shape, index_dims, index_size)
 
-    tt_npu = tt_npu.unpad_from_tile(output_4d_shape)
+    tt_npu = tt_npu.unpad_from_tile(output_5d_shape)
     tt_dev = tt_npu.to_torch().reshape(tt_cpu.shape).to(dtype)
 
     passing, out = comp_allclose_and_pcc(tt_cpu, tt_dev)
@@ -445,8 +494,12 @@ def test_getitem_tilized_three_indices(shape_index_dims, dtype, index_size, row_
 
 @pytest.mark.parametrize(
     "shape_index_dims",
-    (((10, 15, 7, 80), (0, 1, 2, 3)),),
-    ids=["NCHW"],
+    (
+        ((3, 5, 7, 80), (0, 1, 2, 3)),
+        ((10, 3, 5, 7, 80), (0, 1, 2, 3)),
+        ((10, 3, 5, 7, 80), (1, 2, 3, 4)),
+    ),
+    ids=["4d_CDHW", "5d_NCDH", "5d_CDHW"],
 )
 @pytest.mark.parametrize(
     "dtype",
@@ -493,7 +546,87 @@ def test_getitem_tilized_four_indices(shape_index_dims, dtype, index_size, row_m
         else:
             dev_idx = (
                 ttnn.Tensor(idx, ttnn.int32)
-                .reshape(1, 1, 1, index_size)
+                .reshape([1, 1, 1, 1, index_size])
+                .pad_to_tile(float("nan"))
+                .to(ttl.tensor.Layout.TILE)
+                .to(device)
+            )
+        indices.append(idx)
+        dev_indices.append(dev_idx)
+
+    if index_dims == (0, 1, 2, 3):
+        tt_cpu = x[indices[0], indices[1], indices[2], indices[3]]
+    if index_dims == (1, 2, 3, 4):
+        tt_cpu = x[:, indices[0], indices[1], indices[2], indices[3]]
+
+    tt_npu = ttl.operations.primary.moreh_getitem(dev_x, dev_indices, index_dims)
+    tt_npu = tt_npu.cpu().to(ttl.tensor.Layout.ROW_MAJOR)
+
+    output_5d_shape = to_output_5d_shape(shape, index_dims, index_size)
+
+    tt_npu = tt_npu.unpad_from_tile(output_5d_shape)
+
+    tt_dev = tt_npu.to_torch().reshape(tt_cpu.shape).to(dtype)
+
+    passing, out = comp_allclose_and_pcc(tt_cpu, tt_dev)
+    logger.info(out)
+
+    assert passing
+
+
+@pytest.mark.parametrize(
+    "shape_index_dims",
+    (((10, 3, 5, 7, 80), (0, 1, 2, 3, 4)),),
+    ids=["NCDHW"],
+)
+@pytest.mark.parametrize(
+    "dtype",
+    (
+        torch.int32,
+        torch.bfloat16,
+    ),
+    ids=["int32", "bfloat16"],
+)
+@pytest.mark.parametrize(
+    "index_size",
+    (
+        4,
+        100,
+    ),
+)
+@pytest.mark.parametrize(
+    "row_major_index",
+    (
+        True,
+        False,
+    ),
+)
+def test_getitem_tilized_five_indices(shape_index_dims, dtype, index_size, row_major_index, device):
+    shape, index_dims = shape_index_dims
+    torch.manual_seed(2)
+
+    if dtype == torch.int32:
+        tt_dtype = ttl.tensor.DataType.INT32
+    if dtype == torch.bfloat16:
+        tt_dtype = ttl.tensor.DataType.BFLOAT16
+
+    x = torch.randint(low=0, high=10, size=shape).to(dtype)
+
+    dev_x = (
+        ttl.tensor.Tensor(x, tt_dtype).reshape(shape).pad_to_tile(float("nan")).to(ttl.tensor.Layout.TILE).to(device)
+    )
+
+    indices = []
+    dev_indices = []
+    for index_dim in index_dims:
+        idx_value_max = shape[index_dim] - 1
+        idx = torch.randint(-idx_value_max - 1, idx_value_max, (index_size,))
+        if row_major_index:
+            dev_idx = ttl.tensor.Tensor(idx, ttl.tensor.DataType.INT32).to(device)
+        else:
+            dev_idx = (
+                ttnn.Tensor(idx, ttnn.int32)
+                .reshape([1, 1, 1, 1, index_size])
                 .pad_to_tile(float("nan"))
                 .to(ttnn.TILE_LAYOUT)
                 .to(device)
@@ -501,14 +634,14 @@ def test_getitem_tilized_four_indices(shape_index_dims, dtype, index_size, row_m
         indices.append(idx)
         dev_indices.append(dev_idx)
 
-    tt_cpu = x[indices[0], indices[1], indices[2], indices[3]]
+    tt_cpu = x[indices[0], indices[1], indices[2], indices[3], indices[4]]
 
     tt_npu = ttnn.experimental.operations.primary.moreh_getitem(dev_x, dev_indices, index_dims)
     tt_npu = tt_npu.cpu().to(ttnn.ROW_MAJOR_LAYOUT)
 
-    output_4d_shape = to_output_4d_shape(shape, index_dims, index_size)
+    output_5d_shape = to_output_5d_shape(shape, index_dims, index_size)
 
-    tt_npu = tt_npu.unpad_from_tile(output_4d_shape)
+    tt_npu = tt_npu.unpad_from_tile(output_5d_shape)
 
     tt_dev = tt_npu.to_torch().reshape(tt_cpu.shape).to(dtype)
 

--- a/ttnn/cpp/ttnn/deprecated/tt_dnn/op_library/moreh_getitem/moreh_getitem_rm/kernels/reader_moreh_getitem.cpp
+++ b/ttnn/cpp/ttnn/deprecated/tt_dnn/op_library/moreh_getitem/moreh_getitem_rm/kernels/reader_moreh_getitem.cpp
@@ -12,14 +12,17 @@ void kernel_main() {
     uint32_t index1_addr = get_arg_val<uint32_t>(i++);
     uint32_t index2_addr = get_arg_val<uint32_t>(i++);
     uint32_t index3_addr = get_arg_val<uint32_t>(i++);
+    uint32_t index4_addr = get_arg_val<uint32_t>(i++);
 
     // input
     uint32_t input_stick_idx_stride_n = get_arg_val<uint32_t>(i++);
     uint32_t input_stick_idx_stride_c = get_arg_val<uint32_t>(i++);
+    uint32_t input_stick_idx_stride_d = get_arg_val<uint32_t>(i++);
     uint32_t input_stick_idx_stride_h = get_arg_val<uint32_t>(i++);
 
     uint32_t input_size_n = get_arg_val<uint32_t>(i++);
     uint32_t input_size_c = get_arg_val<uint32_t>(i++);
+    uint32_t input_size_d = get_arg_val<uint32_t>(i++);
     uint32_t input_size_h = get_arg_val<uint32_t>(i++);
     uint32_t input_size_w = get_arg_val<uint32_t>(i++);
 
@@ -28,10 +31,12 @@ void kernel_main() {
     uint32_t index1_is_defined = get_arg_val<uint32_t>(i++);
     uint32_t index2_is_defined = get_arg_val<uint32_t>(i++);
     uint32_t index3_is_defined = get_arg_val<uint32_t>(i++);
+    uint32_t index4_is_defined = get_arg_val<uint32_t>(i++);
     uint32_t index0_stick_size = get_arg_val<uint32_t>(i++);
     uint32_t index1_stick_size = get_arg_val<uint32_t>(i++);
     uint32_t index2_stick_size = get_arg_val<uint32_t>(i++);
     uint32_t index3_stick_size = get_arg_val<uint32_t>(i++);
+    uint32_t index4_stick_size = get_arg_val<uint32_t>(i++);
     uint32_t index_size = get_arg_val<uint32_t>(i++);
     int32_t index_start_dim = static_cast<int32_t>(get_arg_val<uint32_t>(i++));
     int32_t index_end_dim = static_cast<int32_t>(get_arg_val<uint32_t>(i++));
@@ -39,6 +44,7 @@ void kernel_main() {
     // output
     uint32_t output_size_n = get_arg_val<uint32_t>(i++);
     uint32_t output_size_c = get_arg_val<uint32_t>(i++);
+    uint32_t output_size_d = get_arg_val<uint32_t>(i++);
     uint32_t output_size_h = get_arg_val<uint32_t>(i++);
     uint32_t output_size_w = get_arg_val<uint32_t>(i++);
 
@@ -47,18 +53,19 @@ void kernel_main() {
     uint32_t num_sticks = get_arg_val<uint32_t>(i++);
     uint32_t stick_size = get_arg_val<uint32_t>(i++);
 
-
     constexpr auto cb_in0 = tt::CB::c_in0;
     constexpr auto cb_in1 = tt::CB::c_in1;
     constexpr auto cb_in2 = tt::CB::c_in2;
     constexpr auto cb_in3 = tt::CB::c_in3;
     constexpr auto cb_in4 = tt::CB::c_in4;
+    constexpr auto cb_in5 = tt::CB::c_in5;
 
     constexpr bool in_is_dram = get_compile_time_arg_val(0) == 1;
     constexpr bool index0_is_dram = get_compile_time_arg_val(1) == 1;
     constexpr bool index1_is_dram = get_compile_time_arg_val(2) == 1;
     constexpr bool index2_is_dram = get_compile_time_arg_val(3) == 1;
     constexpr bool index3_is_dram = get_compile_time_arg_val(4) == 1;
+    constexpr bool index4_is_dram = get_compile_time_arg_val(5) == 1;
 
     const InterleavedAddrGen<in_is_dram> s0 = {.bank_base_address = src_addr, .page_size = stick_size};
 
@@ -70,46 +77,54 @@ void kernel_main() {
         .bank_base_address = index2_addr, .page_size = index2_stick_size};
     const InterleavedAddrGen<index3_is_dram> index3 = {
         .bank_base_address = index3_addr, .page_size = index3_stick_size};
+    const InterleavedAddrGen<index4_is_dram> index4 = {
+        .bank_base_address = index4_addr, .page_size = index4_stick_size};
 
-    uint32_t index_is_defined[4] = {
+    uint32_t index_is_defined[5] = {
         index0_is_defined,
         index1_is_defined,
         index2_is_defined,
         index3_is_defined,
+        index4_is_defined,
     };
 
-    tt::CB index_cbs[4] = {
+    tt::CB index_cbs[5] = {
         cb_in1,
         cb_in2,
         cb_in3,
         cb_in4,
+        cb_in5,
     };
 
-    uint32_t input_size_list[4] = {
+    uint32_t input_size_list[5] = {
         input_size_n,
         input_size_c,
+        input_size_d,
         input_size_h,
         input_size_w,
     };
 
-    uint32_t output_size_list[4] = {
+    uint32_t output_size_list[5] = {
         output_size_n,
         output_size_c,
+        output_size_d,
         output_size_h,
         output_size_w,
     };
 
-    uint32_t input_stick_idx_strides[3] = {
+    uint32_t input_stick_idx_strides[4] = {
         input_stick_idx_stride_n,
         input_stick_idx_stride_c,
+        input_stick_idx_stride_d,
         input_stick_idx_stride_h,
     };
 
-    uint32_t index_stick_sizes[4] = {
+    uint32_t index_stick_sizes[5] = {
         index0_stick_size,
         index1_stick_size,
         index2_stick_size,
         index3_stick_size,
+        index4_stick_size,
     };
 
     uint32_t end_id = start_id + num_sticks;
@@ -119,8 +134,8 @@ void kernel_main() {
         uint32_t output_stick_idx = i;
         uint32_t index_index = 0;
         bool is_first_index = true;
-        int32_t output_dim = 2;
-        for (int32_t dim = 2; dim >= 0; dim--) {
+        int32_t output_dim = 3;
+        for (int32_t dim = 3; dim >= 0; dim--) {
 
             uint32_t input_stick_idx_stride = input_stick_idx_strides[dim];
             auto output_size = output_size_list[output_dim];
@@ -145,6 +160,9 @@ void kernel_main() {
                 }
                 if (dim == 2) {
                     index_noc_addr = get_noc_addr(0, index2);
+                }
+                if (dim == 3) {
+                    index_noc_addr = get_noc_addr(0, index3);
                 }
                 noc_async_read(index_noc_addr, index_l1_addr, index_stick_sizes[dim]);
                 noc_async_read_barrier();

--- a/ttnn/cpp/ttnn/deprecated/tt_dnn/op_library/moreh_getitem/moreh_getitem_tilized/kernels/common.hpp
+++ b/ttnn/cpp/ttnn/deprecated/tt_dnn/op_library/moreh_getitem/moreh_getitem_tilized/kernels/common.hpp
@@ -58,3 +58,42 @@ Idx4d get_tile_indices(Idx4d stick_index_4d) {
 
     return tile_index_4d;
 }
+
+struct Idx5d
+{
+    uint32_t n;
+    uint32_t c;
+    uint32_t d;
+    uint32_t h;
+    uint32_t w;
+};
+
+Idx5d get_stick_indices(uint32_t stick_idx, uint32_t size_c, uint32_t size_d, uint32_t size_h, uint32_t num_stick_width) {
+    Idx5d stick_index_5d;
+
+    stick_index_5d.w = stick_idx % num_stick_width;
+    uint32_t stick_ncdh = stick_idx / num_stick_width;
+
+    stick_index_5d.h = stick_ncdh % size_h;
+    uint32_t stick_ncd = stick_ncdh / size_h;
+
+    stick_index_5d.d = stick_ncd % size_d;
+    uint32_t stick_nc = stick_ncd / size_d;
+
+    stick_index_5d.c = stick_nc % size_c;
+    stick_index_5d.n = stick_nc / size_c;
+
+    return stick_index_5d;
+}
+
+Idx5d get_tile_indices(Idx5d stick_index_5d) {
+    Idx5d tile_index_5d;
+
+    tile_index_5d.n = stick_index_5d.n;
+    tile_index_5d.c = stick_index_5d.c;
+    tile_index_5d.d = stick_index_5d.d;
+    tile_index_5d.h = stick_index_5d.h / TILE_HEIGHT;
+    tile_index_5d.w = stick_index_5d.w / 2;
+
+    return tile_index_5d;
+}

--- a/ttnn/cpp/ttnn/deprecated/tt_dnn/op_library/moreh_getitem/moreh_getitem_tilized/kernels/reader_moreh_getitem_tilize.cpp
+++ b/ttnn/cpp/ttnn/deprecated/tt_dnn/op_library/moreh_getitem/moreh_getitem_tilized/kernels/reader_moreh_getitem_tilize.cpp
@@ -14,21 +14,26 @@ void kernel_main() {
     uint32_t index1_addr = get_arg_val<uint32_t>(i++);
     uint32_t index2_addr = get_arg_val<uint32_t>(i++);
     uint32_t index3_addr = get_arg_val<uint32_t>(i++);
+    uint32_t index4_addr = get_arg_val<uint32_t>(i++);
 
     // input
     uint32_t input_stick_idx_stride_n = get_arg_val<uint32_t>(i++);
     uint32_t input_stick_idx_stride_c = get_arg_val<uint32_t>(i++);
+    uint32_t input_stick_idx_stride_d = get_arg_val<uint32_t>(i++);
     uint32_t input_stick_idx_stride_h = get_arg_val<uint32_t>(i++);
     uint32_t input_stick_idx_stride_w = get_arg_val<uint32_t>(i++);
     uint32_t input_size_c_without_padding = get_arg_val<uint32_t>(i++);
+    uint32_t input_size_d_without_padding = get_arg_val<uint32_t>(i++);
     uint32_t input_size_h_without_padding = get_arg_val<uint32_t>(i++);
     uint32_t input_noc_id_stride_n = get_arg_val<uint32_t>(i++);
     uint32_t input_noc_id_stride_c = get_arg_val<uint32_t>(i++);
+    uint32_t input_noc_id_stride_d = get_arg_val<uint32_t>(i++);
     uint32_t input_noc_id_stride_h = get_arg_val<uint32_t>(i++);
     uint32_t input_num_stick_width = get_arg_val<uint32_t>(i++);
 
     uint32_t input_size_n = get_arg_val<uint32_t>(i++);
     uint32_t input_size_c = get_arg_val<uint32_t>(i++);
+    uint32_t input_size_d = get_arg_val<uint32_t>(i++);
     uint32_t input_size_h = get_arg_val<uint32_t>(i++);
     uint32_t input_size_w = get_arg_val<uint32_t>(i++);
 
@@ -37,15 +42,18 @@ void kernel_main() {
     uint32_t index1_is_defined = get_arg_val<uint32_t>(i++);
     uint32_t index2_is_defined = get_arg_val<uint32_t>(i++);
     uint32_t index3_is_defined = get_arg_val<uint32_t>(i++);
+    uint32_t index4_is_defined = get_arg_val<uint32_t>(i++);
     uint32_t index0_stick_size = get_arg_val<uint32_t>(i++);
     uint32_t index1_stick_size = get_arg_val<uint32_t>(i++);
     uint32_t index2_stick_size = get_arg_val<uint32_t>(i++);
     uint32_t index3_stick_size = get_arg_val<uint32_t>(i++);
+    uint32_t index4_stick_size = get_arg_val<uint32_t>(i++);
     uint32_t index_size = get_arg_val<uint32_t>(i++);
 
     // output
     uint32_t output_size_n = get_arg_val<uint32_t>(i++);
     uint32_t output_size_c = get_arg_val<uint32_t>(i++);
+    uint32_t output_size_d = get_arg_val<uint32_t>(i++);
     uint32_t output_size_h = get_arg_val<uint32_t>(i++);
     uint32_t output_size_w = get_arg_val<uint32_t>(i++);
     uint32_t output_num_stick_width = get_arg_val<uint32_t>(i++);
@@ -61,12 +69,14 @@ void kernel_main() {
     constexpr auto cb_in2 = tt::CB::c_in2;
     constexpr auto cb_in3 = tt::CB::c_in3;
     constexpr auto cb_in4 = tt::CB::c_in4;
+    constexpr auto cb_in5 = tt::CB::c_in5;
 
     constexpr bool in_is_dram = get_compile_time_arg_val(0) == 1;
     constexpr bool index0_is_dram = get_compile_time_arg_val(1) == 1;
     constexpr bool index1_is_dram = get_compile_time_arg_val(2) == 1;
     constexpr bool index2_is_dram = get_compile_time_arg_val(3) == 1;
     constexpr bool index3_is_dram = get_compile_time_arg_val(4) == 1;
+    constexpr bool index4_is_dram = get_compile_time_arg_val(5) == 1;
 
     const InterleavedAddrGen<in_is_dram> s0 = {
         .bank_base_address = src_addr,
@@ -81,38 +91,45 @@ void kernel_main() {
         .bank_base_address = index2_addr, .page_size = INDEX_TILE_SIZE};
     const InterleavedAddrGen<index3_is_dram> index3 = {
         .bank_base_address = index3_addr, .page_size = INDEX_TILE_SIZE};
+    const InterleavedAddrGen<index4_is_dram> index4 = {
+        .bank_base_address = index4_addr, .page_size = INDEX_TILE_SIZE};
 
-    uint32_t index_is_defined[4] = {
+    uint32_t index_is_defined[5] = {
         index0_is_defined,
         index1_is_defined,
         index2_is_defined,
         index3_is_defined,
+        index4_is_defined,
     };
 
-    tt::CB index_cbs[4] = {
+    tt::CB index_cbs[5] = {
         cb_in1,
         cb_in2,
         cb_in3,
         cb_in4,
+        cb_in5,
     };
 
-    uint32_t input_size_list[4] = {
+    uint32_t input_size_list[5] = {
         input_size_n,
         input_size_c,
+        input_size_d,
         input_size_h,
         input_size_w,
     };
 
-    uint32_t output_size_list[4] = {
+    uint32_t output_size_list[5] = {
         output_size_n,
         output_size_c,
+        output_size_d,
         output_size_h,
         output_size_w,
     };
 
-    uint32_t input_stick_idx_strides[4] = {
+    uint32_t input_stick_idx_strides[5] = {
         input_stick_idx_stride_n,
         input_stick_idx_stride_c,
+        input_stick_idx_stride_d,
         input_stick_idx_stride_h,
         input_stick_idx_stride_w,
     };
@@ -129,7 +146,7 @@ void kernel_main() {
         uint32_t index_index = 0;
         bool is_first_index = true;
 
-        for (int32_t dim = 3; dim >= 0; dim--) {
+        for (int32_t dim = 4; dim >= 0; dim--) {
             uint32_t input_stick_idx_stride = input_stick_idx_strides[dim];
 
             if (index_is_defined[dim]) {
@@ -154,6 +171,9 @@ void kernel_main() {
                 if (dim == 2) {
                     index_noc_addr = get_noc_addr(index_noc_id, index2);
                 }
+                if (dim == 3) {
+                    index_noc_addr = get_noc_addr(index_noc_id, index3);
+                }
                 noc_async_read(index_noc_addr, index_l1_addr, INDEX_TILE_SIZE);
                 noc_async_read_barrier();
 
@@ -177,6 +197,9 @@ void kernel_main() {
                 if (dim == 2) {
                     index_noc_addr = get_noc_addr(0, index2, noc_offset);
                 }
+                if (dim == 3) {
+                    index_noc_addr = get_noc_addr(0, index3, noc_offset);
+                }
                 noc_async_read(index_noc_addr, index_l1_addr, NOC_MINIMUM_READ_SIZE);
                 noc_async_read_barrier();
 
@@ -196,7 +219,7 @@ void kernel_main() {
             } else {
                 uint32_t index_val;
 
-                if (dim == 3) {
+                if (dim == 4) {
                     index_val = output_stick_idx % input_num_stick_width;
                     input_stick_idx += index_val * input_stick_idx_stride;
                 } else {
@@ -205,7 +228,7 @@ void kernel_main() {
                     input_stick_idx += index_val * input_stick_idx_stride;
                 }
             }
-            if (dim == 3) {
+            if (dim == 4) {
                 output_stick_idx /= output_num_stick_width;
             } else {
                 auto output_size = output_size_list[dim];
@@ -217,14 +240,16 @@ void kernel_main() {
         cb_reserve_back(cb_in0, 1);
         uint32_t l1_write_addr = get_write_ptr(cb_in0);
 
-        Idx4d stick_index_4d = get_stick_indices(input_stick_idx, input_size_c_without_padding, input_size_h_without_padding, input_num_stick_width);
-        Idx4d tile_index_4d = get_tile_indices(stick_index_4d);
+        Idx5d stick_index_5d = get_stick_indices(input_stick_idx, input_size_c_without_padding, input_size_d_without_padding, input_size_h_without_padding, input_num_stick_width);
+        Idx5d tile_index_5d = get_tile_indices(stick_index_5d);
 
-        uint32_t noc_id =   tile_index_4d.n * input_noc_id_stride_n +
-                            tile_index_4d.c * input_noc_id_stride_c +
-                            tile_index_4d.h * input_noc_id_stride_h +
-                            tile_index_4d.w;
-        uint32_t noc_offset = get_noc_offset_in_tile(stick_index_4d.h , stick_index_4d.w, tile_index_4d.h, element_size);
+        uint32_t noc_id =   tile_index_5d.n * input_noc_id_stride_n +
+                            tile_index_5d.c * input_noc_id_stride_c +
+                            tile_index_5d.d * input_noc_id_stride_d +
+                            tile_index_5d.h * input_noc_id_stride_h +
+                            tile_index_5d.w;
+
+        uint32_t noc_offset = get_noc_offset_in_tile(stick_index_5d.h , stick_index_5d.w, tile_index_5d.h, element_size);
 
         uint64_t src_noc_addr = get_noc_addr(noc_id, s0, noc_offset);
 

--- a/ttnn/cpp/ttnn/deprecated/tt_dnn/op_library/moreh_getitem/moreh_getitem_tilized/kernels/reader_moreh_getitem_tilize_w.cpp
+++ b/ttnn/cpp/ttnn/deprecated/tt_dnn/op_library/moreh_getitem/moreh_getitem_tilized/kernels/reader_moreh_getitem_tilize_w.cpp
@@ -13,21 +13,26 @@ void kernel_main() {
     uint32_t index1_addr = get_arg_val<uint32_t>(i++);
     uint32_t index2_addr = get_arg_val<uint32_t>(i++);
     uint32_t index3_addr = get_arg_val<uint32_t>(i++);
+    uint32_t index4_addr = get_arg_val<uint32_t>(i++);
 
     // input
     uint32_t input_stick_idx_stride_n = get_arg_val<uint32_t>(i++);
     uint32_t input_stick_idx_stride_c = get_arg_val<uint32_t>(i++);
+    uint32_t input_stick_idx_stride_d = get_arg_val<uint32_t>(i++);
     uint32_t input_stick_idx_stride_h = get_arg_val<uint32_t>(i++);
     uint32_t input_stick_idx_stride_w = get_arg_val<uint32_t>(i++);
     uint32_t input_size_c_without_padding = get_arg_val<uint32_t>(i++);
+    uint32_t input_size_d_without_padding = get_arg_val<uint32_t>(i++);
     uint32_t input_size_h_without_padding = get_arg_val<uint32_t>(i++);
     uint32_t input_num_stick_width = get_arg_val<uint32_t>(i++);
     uint32_t input_noc_id_stride_n = get_arg_val<uint32_t>(i++);
     uint32_t input_noc_id_stride_c = get_arg_val<uint32_t>(i++);
+    uint32_t input_noc_id_stride_d = get_arg_val<uint32_t>(i++);
     uint32_t input_noc_id_stride_h = get_arg_val<uint32_t>(i++);
 
     uint32_t input_size_n = get_arg_val<uint32_t>(i++);
     uint32_t input_size_c = get_arg_val<uint32_t>(i++);
+    uint32_t input_size_d = get_arg_val<uint32_t>(i++);
     uint32_t input_size_h = get_arg_val<uint32_t>(i++);
     uint32_t input_size_w = get_arg_val<uint32_t>(i++);
 
@@ -36,15 +41,18 @@ void kernel_main() {
     uint32_t index1_is_defined = get_arg_val<uint32_t>(i++);
     uint32_t index2_is_defined = get_arg_val<uint32_t>(i++);
     uint32_t index3_is_defined = get_arg_val<uint32_t>(i++);
+    uint32_t index4_is_defined = get_arg_val<uint32_t>(i++);
     uint32_t index0_stick_size = get_arg_val<uint32_t>(i++);
     uint32_t index1_stick_size = get_arg_val<uint32_t>(i++);
     uint32_t index2_stick_size = get_arg_val<uint32_t>(i++);
     uint32_t index3_stick_size = get_arg_val<uint32_t>(i++);
+    uint32_t index4_stick_size = get_arg_val<uint32_t>(i++);
     uint32_t index_size = get_arg_val<uint32_t>(i++);
 
     // output
     uint32_t output_size_n = get_arg_val<uint32_t>(i++);
     uint32_t output_size_c = get_arg_val<uint32_t>(i++);
+    uint32_t output_size_d = get_arg_val<uint32_t>(i++);
     uint32_t output_size_h = get_arg_val<uint32_t>(i++);
     uint32_t output_size_w = get_arg_val<uint32_t>(i++);
     uint32_t output_num_stick_width = get_arg_val<uint32_t>(i++);
@@ -61,12 +69,14 @@ void kernel_main() {
     constexpr auto cb_in2 = tt::CB::c_in2;
     constexpr auto cb_in3 = tt::CB::c_in3;
     constexpr auto cb_in4 = tt::CB::c_in4;
+    constexpr auto cb_in5 = tt::CB::c_in5;
 
     constexpr bool in_is_dram = get_compile_time_arg_val(0) == 1;
     constexpr bool index0_is_dram = get_compile_time_arg_val(1) == 1;
     constexpr bool index1_is_dram = get_compile_time_arg_val(2) == 1;
     constexpr bool index2_is_dram = get_compile_time_arg_val(3) == 1;
     constexpr bool index3_is_dram = get_compile_time_arg_val(4) == 1;
+    constexpr bool index4_is_dram = get_compile_time_arg_val(5) == 1;
 
     const InterleavedAddrGen<in_is_dram> s0 = {
         .bank_base_address = src_addr,
@@ -81,38 +91,45 @@ void kernel_main() {
         .bank_base_address = index2_addr, .page_size = INDEX_TILE_SIZE};
     const InterleavedAddrGen<index3_is_dram> index3 = {
         .bank_base_address = index3_addr, .page_size = INDEX_TILE_SIZE};
+    const InterleavedAddrGen<index4_is_dram> index4 = {
+        .bank_base_address = index4_addr, .page_size = INDEX_TILE_SIZE};
 
-    uint32_t index_is_defined[4] = {
+    uint32_t index_is_defined[5] = {
         index0_is_defined,
         index1_is_defined,
         index2_is_defined,
         index3_is_defined,
+        index4_is_defined,
     };
 
-    tt::CB index_cbs[4] = {
+    tt::CB index_cbs[5] = {
         cb_in1,
         cb_in2,
         cb_in3,
         cb_in4,
+        cb_in5,
     };
 
-    uint32_t input_size_list[4] = {
+    uint32_t input_size_list[5] = {
         input_size_n,
         input_size_c,
+        input_size_d,
         input_size_h,
         input_size_w,
     };
 
-    uint32_t output_size_list[4] = {
+    uint32_t output_size_list[5] = {
         output_size_n,
         output_size_c,
+        output_size_d,
         output_size_h,
         output_size_w,
     };
 
-    uint32_t input_stick_idx_strides[4] = {
+    uint32_t input_stick_idx_strides[5] = {
         input_stick_idx_stride_n,
         input_stick_idx_stride_c,
+        input_stick_idx_stride_d,
         input_stick_idx_stride_h,
         input_stick_idx_stride_w,
     };
@@ -139,7 +156,7 @@ void kernel_main() {
             uint32_t output_stick_w = index_index / FACE_WIDTH;
             uint32_t output_stick_idx = output_stick_h * output_num_stick_width + output_stick_w;
             uint32_t input_stick_idx = 0;
-            for (int32_t dim = 3; dim >= 0; dim--) {
+            for (int32_t dim = 4; dim >= 0; dim--) {
                 uint32_t input_stick_idx_stride = input_stick_idx_strides[dim];
 
                 if (index_is_defined[dim]) {
@@ -151,7 +168,7 @@ void kernel_main() {
                     uint64_t index_noc_addr;
 
                     uint32_t index_noc_id;
-                    if (dim == 3) {
+                    if (dim == 4) {
                         index_noc_id = index_index / TILE_WIDTH;
                     } else {
                         index_noc_id = index_index / TILE_HEIGHT;
@@ -170,10 +187,13 @@ void kernel_main() {
                     if (dim == 3) {
                         index_noc_addr = get_noc_addr(index_noc_id, index3);
                     }
+                    if (dim == 4) {
+                        index_noc_addr = get_noc_addr(index_noc_id, index4);
+                    }
                     noc_async_read(index_noc_addr, index_l1_addr, INDEX_TILE_SIZE);
                     noc_async_read_barrier();
 
-                    if (dim == 3) {
+                    if (dim == 4) {
                         volatile tt_l1_ptr int32_t* index_l1_ptr =
                             reinterpret_cast<volatile tt_l1_ptr int32_t*>(index_l1_addr);
                         uint32_t index_dim_offset = index_index % FACE_WIDTH;
@@ -218,6 +238,9 @@ void kernel_main() {
                     if (dim == 3) {
                         index_noc_addr = get_noc_addr(0, index3, noc_offset);
                     }
+                    if (dim == 4) {
+                        index_noc_addr = get_noc_addr(0, index4, noc_offset);
+                    }
                     noc_async_read(index_noc_addr, index_l1_addr, NOC_MINIMUM_READ_SIZE);
                     noc_async_read_barrier();
 
@@ -231,7 +254,7 @@ void kernel_main() {
                         index_val += input_size_list[dim];
                     }
 
-                    if (dim == 3) {
+                    if (dim == 4) {
                         w_index = index_val;
                         input_stick_idx += index_val / FACE_WIDTH;
                     }
@@ -247,7 +270,7 @@ void kernel_main() {
                     index_val = output_stick_idx % output_size;
                     input_stick_idx += index_val * input_stick_idx_stride;
                 }
-                if (dim == 3) {
+                if (dim == 4) {
                     output_stick_idx /= output_num_stick_width;
                 } else {
                     auto output_size = output_size_list[dim];
@@ -258,15 +281,16 @@ void kernel_main() {
             cb_reserve_back(cb_in0, 1);
             uint32_t l1_write_addr = get_write_ptr(cb_in0);
 
-            Idx4d stick_index_4d = get_stick_indices(input_stick_idx, input_size_c_without_padding, input_size_h_without_padding, input_num_stick_width);
-            Idx4d tile_index_4d = get_tile_indices(stick_index_4d);
+            Idx5d stick_index_5d = get_stick_indices(input_stick_idx, input_size_c_without_padding, input_size_d_without_padding, input_size_h_without_padding, input_num_stick_width);
+            Idx5d tile_index_5d = get_tile_indices(stick_index_5d);
 
-            uint32_t noc_id =   tile_index_4d.n * input_noc_id_stride_n +
-                                tile_index_4d.c * input_noc_id_stride_c +
-                                tile_index_4d.h * input_noc_id_stride_h +
-                                tile_index_4d.w;
+            uint32_t noc_id =   tile_index_5d.n * input_noc_id_stride_n +
+                                tile_index_5d.c * input_noc_id_stride_c +
+                                tile_index_5d.d * input_noc_id_stride_d +
+                                tile_index_5d.h * input_noc_id_stride_h +
+                                tile_index_5d.w;
 
-            uint32_t noc_offset = get_noc_offset_in_tile(stick_index_4d.h , stick_index_4d.w, tile_index_4d.h, element_size);
+            uint32_t noc_offset = get_noc_offset_in_tile(stick_index_5d.h , stick_index_5d.w, tile_index_5d.h, element_size);
 
             if (num_elements_per_alignment == 8) {
                 noc_offset += ((w_index / 8) % 2) * NOC_MINIMUM_READ_SIZE;

--- a/ttnn/cpp/ttnn/deprecated/tt_dnn/op_library/moreh_getitem/moreh_getitem_tilized/kernels/writer_moreh_getitem_tilize.cpp
+++ b/ttnn/cpp/ttnn/deprecated/tt_dnn/op_library/moreh_getitem/moreh_getitem_tilized/kernels/writer_moreh_getitem_tilize.cpp
@@ -12,10 +12,12 @@ void kernel_main() {
 
     // output
     uint32_t output_size_c_without_padding = get_arg_val<uint32_t>(i++);
+    uint32_t output_size_d_without_padding = get_arg_val<uint32_t>(i++);
     uint32_t output_size_h_without_padding = get_arg_val<uint32_t>(i++);
     uint32_t output_size_w_without_padding = get_arg_val<uint32_t>(i++);
     uint32_t output_noc_id_stride_n = get_arg_val<uint32_t>(i++);
     uint32_t output_noc_id_stride_c = get_arg_val<uint32_t>(i++);
+    uint32_t output_noc_id_stride_d = get_arg_val<uint32_t>(i++);
     uint32_t output_noc_id_stride_h = get_arg_val<uint32_t>(i++);
     uint32_t output_num_stick_width = get_arg_val<uint32_t>(i++);
 
@@ -41,15 +43,16 @@ void kernel_main() {
 
         uint32_t stick_idx = i;
 
-        Idx4d stick_index_4d = get_stick_indices(stick_idx, output_size_c_without_padding, output_size_h_without_padding, output_num_stick_width);
-        Idx4d tile_index_4d = get_tile_indices(stick_index_4d);
+        Idx5d stick_index_5d = get_stick_indices(stick_idx, output_size_c_without_padding, output_size_d_without_padding, output_size_h_without_padding, output_num_stick_width);
+        Idx5d tile_index_5d = get_tile_indices(stick_index_5d);
 
-        uint32_t noc_id =   tile_index_4d.n * output_noc_id_stride_n +
-                            tile_index_4d.c * output_noc_id_stride_c +
-                            tile_index_4d.h * output_noc_id_stride_h +
-                            tile_index_4d.w;
+        uint32_t noc_id =   tile_index_5d.n * output_noc_id_stride_n +
+                            tile_index_5d.c * output_noc_id_stride_c +
+                            tile_index_5d.d * output_noc_id_stride_d +
+                            tile_index_5d.h * output_noc_id_stride_h +
+                            tile_index_5d.w;
 
-        uint32_t noc_offset = get_noc_offset_in_tile(stick_index_4d.h, stick_index_4d.w, tile_index_4d.h, element_size);
+        uint32_t noc_offset = get_noc_offset_in_tile(stick_index_5d.h, stick_index_5d.w, tile_index_5d.h, element_size);
 
         uint64_t dst_noc_addr = get_noc_addr(noc_id, s0, noc_offset);
 

--- a/ttnn/cpp/ttnn/deprecated/tt_dnn/op_library/moreh_getitem/moreh_getitem_tilized/kernels/writer_moreh_getitem_tilize_w.cpp
+++ b/ttnn/cpp/ttnn/deprecated/tt_dnn/op_library/moreh_getitem/moreh_getitem_tilized/kernels/writer_moreh_getitem_tilize_w.cpp
@@ -12,10 +12,12 @@ void kernel_main() {
 
     // output
     uint32_t output_size_c_without_padding = get_arg_val<uint32_t>(i++);
+    uint32_t output_size_d_without_padding = get_arg_val<uint32_t>(i++);
     uint32_t output_size_h_without_padding = get_arg_val<uint32_t>(i++);
     uint32_t output_size_w_without_padding = get_arg_val<uint32_t>(i++);
     uint32_t output_noc_id_stride_n = get_arg_val<uint32_t>(i++);
     uint32_t output_noc_id_stride_c = get_arg_val<uint32_t>(i++);
+    uint32_t output_noc_id_stride_d = get_arg_val<uint32_t>(i++);
     uint32_t output_noc_id_stride_h = get_arg_val<uint32_t>(i++);
     uint32_t output_num_stick_width = get_arg_val<uint32_t>(i++);
 
@@ -54,15 +56,16 @@ void kernel_main() {
         uint32_t stick_x = w_start / FACE_WIDTH;
         uint32_t stick_idx = stick_y * output_num_stick_width + stick_x;
 
-        Idx4d stick_index_4d = get_stick_indices(stick_idx, output_size_c_without_padding, output_size_h_without_padding, output_num_stick_width);
-        Idx4d tile_index_4d = get_tile_indices(stick_index_4d);
+        Idx5d stick_index_5d = get_stick_indices(stick_idx, output_size_c_without_padding, output_size_d_without_padding, output_size_h_without_padding, output_num_stick_width);
+        Idx5d tile_index_5d = get_tile_indices(stick_index_5d);
 
-        uint32_t noc_id =   tile_index_4d.n * output_noc_id_stride_n +
-                            tile_index_4d.c * output_noc_id_stride_c +
-                            tile_index_4d.h * output_noc_id_stride_h +
-                            tile_index_4d.w;
+        uint32_t noc_id =   tile_index_5d.n * output_noc_id_stride_n +
+                            tile_index_5d.c * output_noc_id_stride_c +
+                            tile_index_5d.d * output_noc_id_stride_d +
+                            tile_index_5d.h * output_noc_id_stride_h +
+                            tile_index_5d.w;
 
-        uint32_t noc_offset = get_noc_offset_in_tile(stick_index_4d.h, stick_index_4d.w, tile_index_4d.h, element_size);
+        uint32_t noc_offset = get_noc_offset_in_tile(stick_index_5d.h, stick_index_5d.w, tile_index_5d.h, element_size);
 
         if (num_elements_per_alignment == 8) {
             noc_offset += ((w_start / 8) % 2) * NOC_MINIMUM_READ_SIZE;

--- a/ttnn/cpp/ttnn/deprecated/tt_dnn/op_library/moreh_getitem/moreh_getitem_tilized/moreh_getitem_tilized.cpp
+++ b/ttnn/cpp/ttnn/deprecated/tt_dnn/op_library/moreh_getitem/moreh_getitem_tilized/moreh_getitem_tilized.cpp
@@ -35,25 +35,53 @@ operation::ProgramWithCallbacks moreh_getitem_tilized(
     log_debug(LogTest, "moreh_getitem_tilized");
 
     auto input_shape = input.get_legacy_shape();
-    Shape output_shape = output.get_legacy_shape();
+    auto input_shape_without_padding = input_shape.without_padding();
+    auto output_shape = output.get_legacy_shape();
+    auto output_shape_without_padding = output_shape.without_padding();
+
+    std::array<uint32_t, 5> new_input_shape{};
+    std::array<uint32_t, 5> new_output_shape{};
+    std::array<uint32_t, 5> new_input_padded_shape{};
+    std::array<uint32_t, 5> new_output_padded_shape{};
+
+    new_input_shape.fill(1);
+    new_input_padded_shape.fill(1);
+    auto input_dim_offset = 5 - input_shape.rank();
+    for (auto index = 0; index < input_shape.rank(); index++) {
+        new_input_shape[index + input_dim_offset] = input_shape_without_padding[index];
+        new_input_padded_shape[index + input_dim_offset] = input_shape[index];
+    }
+
+    new_output_shape.fill(1);
+    new_output_padded_shape.fill(1);
+    auto output_dim_offset = 5 - input_shape.rank();
+    for (auto index = 0; index < output_shape.rank(); index++) {
+        new_output_shape[index + output_dim_offset] = output_shape_without_padding[index];
+        new_output_padded_shape[index + output_dim_offset] = output_shape[index];
+    }
+
+    Shape input_5d_shape(new_input_shape, new_input_padded_shape);
+    Shape output_5d_shape(new_output_shape, new_output_padded_shape);
 
     bool is_w_index_exist = false;
     for (auto dim : index_dims) {
-        if (dim == 3) {
+        if (dim + input_dim_offset == 4) {
             is_w_index_exist = true;
         }
     }
+
+    auto input_5d_without_padding = input_5d_shape.without_padding();
+    auto output_5d_without_padding = output_5d_shape.without_padding();
 
     auto index_layout = index_tensors.front().get_layout();
     bool is_row_major_index = (index_layout == Layout::ROW_MAJOR);
 
     if (is_w_index_exist) {
         // compute index info
-        IndexInfo index_info[4] = {0};
+        IndexInfo index_info[5] = {0};
 
-        uint32_t dim_offset = 4 - input_shape.rank();
         for (uint32_t i = 0; i < index_tensors.size(); i++) {
-            auto dim = index_dims[i] + dim_offset;
+            auto dim = index_dims[i] + input_dim_offset;
             auto index = index_tensors.at(i);
 
             index_info[dim].is_defined = true;
@@ -68,13 +96,13 @@ operation::ProgramWithCallbacks moreh_getitem_tilized(
         uint32_t output_unit_size = output.element_size();
 
         // split work
-        auto input_shape_without_padding = input_shape.without_padding();
-        auto output_shape_without_padding = output_shape.without_padding();
+        auto input_5d_shape_without_padding = input_5d_shape.without_padding();
+        auto output_5d_shape_without_padding = output_5d_shape.without_padding();
         uint32_t alignment_size = 32;
         uint32_t num_elements_per_alignment = alignment_size / output_unit_size;
         uint32_t num_units =
-            output_shape_without_padding[0] * output_shape_without_padding[1] * output_shape_without_padding[2] *
-            ((output_shape_without_padding[3] + num_elements_per_alignment - 1) / num_elements_per_alignment);
+            output_5d_shape_without_padding[0] * output_5d_shape_without_padding[1] * output_5d_shape_without_padding[2] *
+            output_5d_shape_without_padding[3] * ((output_5d_shape_without_padding[4] + num_elements_per_alignment - 1) / num_elements_per_alignment);
         log_debug(LogTest, "num_units {}", num_units);
 
         uint32_t core_w = core_range.end_coord.x - core_range.start_coord.x + 1;
@@ -98,7 +126,7 @@ operation::ProgramWithCallbacks moreh_getitem_tilized(
                 .set_page_size(src_cb_index, rounded_input_page_size);
         auto cb_src0 = tt_metal::CreateCircularBuffer(program, all_cores, cb_src0_config);
 
-        for (uint32_t dim = 0; dim < 4; dim++) {
+        for (uint32_t dim = 0; dim < 5; dim++) {
             if (!index_info[dim].is_defined)
                 continue;
 
@@ -146,6 +174,7 @@ operation::ProgramWithCallbacks moreh_getitem_tilized(
                 index_info[1].is_dram,
                 index_info[2].is_dram,
                 index_info[3].is_dram,
+                index_info[4].is_dram,
             },
             reader_defines);
         auto writer_kernel_id = CreateWriteKernel(
@@ -156,30 +185,34 @@ operation::ProgramWithCallbacks moreh_getitem_tilized(
             writer_defines);
 
         uint32_t face_width = 16;
-        uint32_t input_num_stick_width = div_up(input_shape_without_padding[3], face_width);
-        uint32_t num_alignment_width = div_up(output_shape_without_padding[3], num_elements_per_alignment);
-        uint32_t output_num_stick_width = div_up(output_shape_without_padding[3], face_width);
+        uint32_t input_num_stick_width = div_up(input_5d_shape_without_padding[4], face_width);
+        uint32_t num_alignment_width = div_up(output_5d_shape_without_padding[4], num_elements_per_alignment);
+        uint32_t output_num_stick_width = div_up(output_5d_shape_without_padding[4], face_width);
 
-        uint32_t input_num_tile_c = input_shape[1];
-        uint32_t input_num_tile_height = input_shape[2] / TILE_HEIGHT;
-        uint32_t input_num_tile_width = input_shape[3] / TILE_WIDTH;
-
+        uint32_t input_num_tile_c = input_5d_shape[1];
+        uint32_t input_num_tile_d = input_5d_shape[2];
+        uint32_t input_num_tile_height = input_5d_shape[3] / TILE_HEIGHT;
+        uint32_t input_num_tile_width = input_5d_shape[4] / TILE_WIDTH;
         uint32_t input_noc_id_stride_h = input_num_tile_width;
-        uint32_t input_noc_id_stride_c = input_noc_id_stride_h * input_num_tile_height;
+        uint32_t input_noc_id_stride_d = input_noc_id_stride_h * input_num_tile_height;
+        uint32_t input_noc_id_stride_c = input_noc_id_stride_d * input_num_tile_d;
         uint32_t input_noc_id_stride_n = input_noc_id_stride_c * input_num_tile_c;
 
-        uint32_t output_num_tile_c = output_shape[1];
-        uint32_t output_num_tile_height = output_shape[2] / TILE_HEIGHT;
-        uint32_t output_num_tile_width = output_shape[3] / TILE_WIDTH;
+        uint32_t output_num_tile_c = output_5d_shape[1];
+        uint32_t output_num_tile_d = output_5d_shape[2];
+        uint32_t output_num_tile_height = output_5d_shape[3] / TILE_HEIGHT;
+        uint32_t output_num_tile_width = output_5d_shape[4] / TILE_WIDTH;
 
         uint32_t output_noc_id_stride_h = output_num_tile_width;
-        uint32_t output_noc_id_stride_c = output_noc_id_stride_h * output_num_tile_height;
+        uint32_t output_noc_id_stride_d = output_noc_id_stride_h * output_num_tile_height;
+        uint32_t output_noc_id_stride_c = output_noc_id_stride_d * output_num_tile_d;
         uint32_t output_noc_id_stride_n = output_noc_id_stride_c * output_num_tile_c;
 
         uint32_t input_stick_idx_stride_w = 1;
         uint32_t input_stick_idx_stride_h = input_num_stick_width;
-        uint32_t input_stick_idx_stride_c = input_stick_idx_stride_h * input_shape.without_padding()[2];
-        uint32_t input_stick_idx_stride_n = input_stick_idx_stride_c * input_shape.without_padding()[1];
+        uint32_t input_stick_idx_stride_d = input_stick_idx_stride_h * input_5d_shape.without_padding()[3];
+        uint32_t input_stick_idx_stride_c = input_stick_idx_stride_d * input_5d_shape.without_padding()[2];
+        uint32_t input_stick_idx_stride_n = input_stick_idx_stride_c * input_5d_shape.without_padding()[1];
 
         // Set Runtime Args
         auto core_x_offset = core_range.start_coord.x;
@@ -200,40 +233,48 @@ operation::ProgramWithCallbacks moreh_getitem_tilized(
                 index_info[1].address,
                 index_info[2].address,
                 index_info[3].address,
+                index_info[4].address,
 
                 // input
                 input_stick_idx_stride_n,
                 input_stick_idx_stride_c,
+                input_stick_idx_stride_d,
                 input_stick_idx_stride_h,
                 input_stick_idx_stride_w,
-                input_shape_without_padding[1],
-                input_shape_without_padding[2],
+                input_5d_shape_without_padding[1],
+                input_5d_shape_without_padding[2],
+                input_5d_shape_without_padding[3],
                 input_num_stick_width,
                 input_noc_id_stride_n,
                 input_noc_id_stride_c,
+                input_noc_id_stride_d,
                 input_noc_id_stride_h,
 
-                input_shape_without_padding[0],
-                input_shape_without_padding[1],
-                input_shape_without_padding[2],
-                input_shape_without_padding[3],
+                input_5d_shape_without_padding[0],
+                input_5d_shape_without_padding[1],
+                input_5d_shape_without_padding[2],
+                input_5d_shape_without_padding[3],
+                input_5d_shape_without_padding[4],
 
                 // index
                 index_info[0].is_defined,
                 index_info[1].is_defined,
                 index_info[2].is_defined,
                 index_info[3].is_defined,
+                index_info[4].is_defined,
                 index_info[0].unit_size,
                 index_info[1].unit_size,
                 index_info[2].unit_size,
                 index_info[3].unit_size,
+                index_info[4].unit_size,
                 index_size,
 
                 // output
-                output_shape_without_padding[0],
-                output_shape_without_padding[1],
-                output_shape_without_padding[2],
-                output_shape_without_padding[3],
+                output_5d_shape_without_padding[0],
+                output_5d_shape_without_padding[1],
+                output_5d_shape_without_padding[2],
+                output_5d_shape_without_padding[3],
+                output_5d_shape_without_padding[4],
                 output_num_stick_width,
 
                 // etc
@@ -249,11 +290,13 @@ operation::ProgramWithCallbacks moreh_getitem_tilized(
                 output.buffer()->address(),
 
                 // output
-                output_shape_without_padding[1],
-                output_shape_without_padding[2],
-                output_shape_without_padding[3],
+                output_5d_shape_without_padding[1],
+                output_5d_shape_without_padding[2],
+                output_5d_shape_without_padding[3],
+                output_5d_shape_without_padding[4],
                 output_noc_id_stride_n,
                 output_noc_id_stride_c,
+                output_noc_id_stride_d,
                 output_noc_id_stride_h,
                 output_num_stick_width,
 
@@ -276,7 +319,7 @@ operation::ProgramWithCallbacks moreh_getitem_tilized(
                                                num_cores,
                                                core_h,
                                                index_dims,
-                                               dim_offset](
+                                               input_dim_offset](
                                                   const Program &program,
                                                   const std::vector<Buffer *> &input_buffers,
                                                   const std::vector<Buffer *> &output_buffers) {
@@ -285,10 +328,10 @@ operation::ProgramWithCallbacks moreh_getitem_tilized(
             auto src_buffer = input_buffers.at(0);
             auto dst_buffer = output_buffers.at(0);
 
-            IndexInfo index_info[4] = {0};
+            IndexInfo index_info[5] = {0};
 
             for (uint32_t i = 0; i < index_dims.size(); i++) {
-                auto dim = index_dims[i] + dim_offset;
+                auto dim = index_dims[i] + input_dim_offset;
                 auto index_buffer = input_buffers.at(i + 1);
 
                 index_info[dim].address = index_buffer->address();
@@ -304,6 +347,7 @@ operation::ProgramWithCallbacks moreh_getitem_tilized(
                     runtime_args[2] = index_info[1].address;
                     runtime_args[3] = index_info[2].address;
                     runtime_args[4] = index_info[3].address;
+                    runtime_args[4] = index_info[4].address;
                 }
 
                 {
@@ -316,11 +360,10 @@ operation::ProgramWithCallbacks moreh_getitem_tilized(
         return {std::move(program), override_runtime_args_callback};
     } else {
         // compute index info
-        IndexInfo index_info[4] = {0};
+        IndexInfo index_info[5] = {0};
 
-        uint32_t dim_offset = 4 - input_shape.rank();
         for (uint32_t i = 0; i < index_tensors.size(); i++) {
-            auto dim = index_dims[i] + dim_offset;
+            auto dim = index_dims[i] + input_dim_offset;
             auto index = index_tensors.at(i);
 
             index_info[dim].is_defined = true;
@@ -334,11 +377,11 @@ operation::ProgramWithCallbacks moreh_getitem_tilized(
         uint32_t output_unit_size = 16 * output.element_size();
 
         // split work
-        auto input_shape_without_padding = input_shape.without_padding();
-        auto output_shape_without_padding = output_shape.without_padding();
-        uint32_t num_units = output_shape_without_padding[0] * output_shape_without_padding[1] *
-                             output_shape_without_padding[2] * ((output_shape_without_padding[3] + 15) / 16);
-        log_debug(LogTest, "num_units {}", num_units);
+        auto input_5d_shape_without_padding = input_5d_shape.without_padding();
+        auto output_5d_shape_without_padding = output_5d_shape.without_padding();
+        uint32_t num_units = output_5d_shape_without_padding[0] * output_5d_shape_without_padding[1] *
+                             output_5d_shape_without_padding[2] * output_5d_shape_without_padding[3] * ((output_5d_shape_without_padding[4] + 15) / 16);
+        log_debug("num_units {}", num_units);
 
         uint32_t core_w = core_range.end_coord.x - core_range.start_coord.x + 1;
         uint32_t core_h = core_range.end_coord.y - core_range.start_coord.y + 1;
@@ -361,7 +404,7 @@ operation::ProgramWithCallbacks moreh_getitem_tilized(
                 .set_page_size(src_cb_index, rounded_input_page_size);
         auto cb_src0 = tt_metal::CreateCircularBuffer(program, all_cores, cb_src0_config);
 
-        for (uint32_t dim = 0; dim < 4; dim++) {
+        for (uint32_t dim = 0; dim < 5; dim++) {
             if (!index_info[dim].is_defined)
                 continue;
 
@@ -404,6 +447,7 @@ operation::ProgramWithCallbacks moreh_getitem_tilized(
                 index_info[1].is_dram,
                 index_info[2].is_dram,
                 index_info[3].is_dram,
+                index_info[4].is_dram,
             },
             reader_defines);
         auto writer_kernel_id = CreateWriteKernel(
@@ -414,30 +458,34 @@ operation::ProgramWithCallbacks moreh_getitem_tilized(
             writer_defines);
 
         uint32_t face_width = 16;
-        uint32_t input_num_stick_width = div_up(input_shape_without_padding[3], face_width);
-        uint32_t output_num_stick_width = div_up(output_shape_without_padding[3], face_width);
+        uint32_t input_num_stick_width = div_up(input_5d_shape_without_padding[4], face_width);
+        uint32_t output_num_stick_width = div_up(output_5d_shape_without_padding[4], face_width);
 
-        uint32_t input_num_tile_c = input_shape[1];
-        uint32_t input_num_tile_height = input_shape[2] / TILE_HEIGHT;
-        uint32_t input_num_tile_width = input_shape[3] / TILE_WIDTH;
+        uint32_t input_num_tile_c = input_5d_shape[1];
+        uint32_t input_num_tile_d = input_5d_shape[2];
+        uint32_t input_num_tile_height = input_5d_shape[3] / TILE_HEIGHT;
+        uint32_t input_num_tile_width = input_5d_shape[4] / TILE_WIDTH;
 
         uint32_t input_noc_id_stride_h = input_num_tile_width;
-        uint32_t input_noc_id_stride_c = input_noc_id_stride_h * input_num_tile_height;
+        uint32_t input_noc_id_stride_d = input_noc_id_stride_h * input_num_tile_height;
+        uint32_t input_noc_id_stride_c = input_noc_id_stride_d * input_num_tile_d;
         uint32_t input_noc_id_stride_n = input_noc_id_stride_c * input_num_tile_c;
 
-        uint32_t output_num_tile_c = output_shape[1];
-        uint32_t output_num_tile_height = output_shape[2] / TILE_HEIGHT;
-        uint32_t output_num_tile_width = output_shape[3] / TILE_WIDTH;
+        uint32_t output_num_tile_c = output_5d_shape[1];
+        uint32_t output_num_tile_d = output_5d_shape[2];
+        uint32_t output_num_tile_height = output_5d_shape[3] / TILE_HEIGHT;
+        uint32_t output_num_tile_width = output_5d_shape[4] / TILE_WIDTH;
 
         uint32_t output_noc_id_stride_h = output_num_tile_width;
-        uint32_t output_noc_id_stride_c = output_noc_id_stride_h * output_num_tile_height;
+        uint32_t output_noc_id_stride_d = output_noc_id_stride_h * output_num_tile_height;
+        uint32_t output_noc_id_stride_c = output_noc_id_stride_d * output_num_tile_d;
         uint32_t output_noc_id_stride_n = output_noc_id_stride_c * output_num_tile_c;
 
         uint32_t input_stick_idx_stride_w = 1;
         uint32_t input_stick_idx_stride_h = input_num_stick_width;
-        uint32_t input_stick_idx_stride_c = input_stick_idx_stride_h * input_shape.without_padding()[2];
-        uint32_t input_stick_idx_stride_n = input_stick_idx_stride_c * input_shape.without_padding()[1];
-
+        uint32_t input_stick_idx_stride_d = input_stick_idx_stride_h * input_5d_shape.without_padding()[3];
+        uint32_t input_stick_idx_stride_c = input_stick_idx_stride_d * input_5d_shape.without_padding()[2];
+        uint32_t input_stick_idx_stride_n = input_stick_idx_stride_c * input_5d_shape.without_padding()[1];
 
         // Set Runtime Args
         auto core_x_offset = core_range.start_coord.x;
@@ -458,40 +506,48 @@ operation::ProgramWithCallbacks moreh_getitem_tilized(
                 index_info[1].address,
                 index_info[2].address,
                 index_info[3].address,
+                index_info[4].address,
 
                 // input
                 input_stick_idx_stride_n,
                 input_stick_idx_stride_c,
+                input_stick_idx_stride_d,
                 input_stick_idx_stride_h,
                 input_stick_idx_stride_w,
-                input_shape_without_padding[1],
-                input_shape_without_padding[2],
+                input_5d_shape_without_padding[1],
+                input_5d_shape_without_padding[2],
+                input_5d_shape_without_padding[3],
                 input_noc_id_stride_n,
                 input_noc_id_stride_c,
+                input_noc_id_stride_d,
                 input_noc_id_stride_h,
                 input_num_stick_width,
 
-                input_shape_without_padding[0],
-                input_shape_without_padding[1],
-                input_shape_without_padding[2],
-                input_shape_without_padding[3],
+                input_5d_shape_without_padding[0],
+                input_5d_shape_without_padding[1],
+                input_5d_shape_without_padding[2],
+                input_5d_shape_without_padding[3],
+                input_5d_shape_without_padding[4],
 
                 // index
                 index_info[0].is_defined,
                 index_info[1].is_defined,
                 index_info[2].is_defined,
                 index_info[3].is_defined,
+                index_info[4].is_defined,
                 index_info[0].unit_size,
                 index_info[1].unit_size,
                 index_info[2].unit_size,
                 index_info[3].unit_size,
+                index_info[4].unit_size,
                 index_size,
 
                 // output
-                output_shape[0],
-                output_shape[1],
-                output_shape_without_padding[2],
-                output_shape_without_padding[3],
+                output_5d_shape[0],
+                output_5d_shape[1],
+                output_5d_shape[2],
+                output_5d_shape_without_padding[3],
+                output_5d_shape_without_padding[4],
                 output_num_stick_width,
 
                 //etc
@@ -506,11 +562,13 @@ operation::ProgramWithCallbacks moreh_getitem_tilized(
                 output.buffer()->address(),
 
                 // output
-                output_shape_without_padding[1],
-                output_shape_without_padding[2],
-                output_shape_without_padding[3],
+                output_5d_shape_without_padding[1],
+                output_5d_shape_without_padding[2],
+                output_5d_shape_without_padding[3],
+                output_5d_shape_without_padding[4],
                 output_noc_id_stride_n,
                 output_noc_id_stride_c,
+                output_noc_id_stride_d,
                 output_noc_id_stride_h,
                 output_num_stick_width,
 
@@ -531,7 +589,7 @@ operation::ProgramWithCallbacks moreh_getitem_tilized(
                                                num_cores,
                                                core_h,
                                                index_dims,
-                                               dim_offset](
+                                               input_dim_offset](
                                                   const Program &program,
                                                   const std::vector<Buffer *> &input_buffers,
                                                   const std::vector<Buffer *> &output_buffers) {
@@ -540,10 +598,10 @@ operation::ProgramWithCallbacks moreh_getitem_tilized(
             auto src_buffer = input_buffers.at(0);
             auto dst_buffer = output_buffers.at(0);
 
-            IndexInfo index_info[4] = {0};
+            IndexInfo index_info[5] = {0};
 
             for (uint32_t i = 0; i < index_dims.size(); i++) {
-                auto dim = index_dims[i] + dim_offset;
+                auto dim = index_dims[i] + input_dim_offset;
                 auto index_buffer = input_buffers.at(i + 1);
 
                 index_info[dim].address = index_buffer->address();
@@ -559,6 +617,7 @@ operation::ProgramWithCallbacks moreh_getitem_tilized(
                     runtime_args[2] = index_info[1].address;
                     runtime_args[3] = index_info[2].address;
                     runtime_args[4] = index_info[3].address;
+                    runtime_args[5] = index_info[4].address;
                 }
 
                 {


### PR DESCRIPTION
### Ticket
[Link to Github Issue
](https://github.com/tenstorrent/tt-metal/issues/11109)
### Problem description
moreh_getitem needs refactoring as it currently does not support n-dimensional tensors (max 5d)

### What's changed
Refactoring moreh_getitem


### Checklist
- [ ] Post commit CI passes
- [ ] Blackhole Post commit (if applicable)
- [ ] Model regression CI testing passes (if applicable)
- [ ] New/Existing tests provide coverage for changes
