### PR TITLE
#11428: removed manual calls to ttnn::device_operation::run

### DIFF
--- a/docs/source/ttnn/ttnn/adding_new_ttnn_operation.rst
+++ b/docs/source/ttnn/ttnn/adding_new_ttnn_operation.rst
@@ -21,7 +21,7 @@ What steps are needed to add ttnn operation in C++?
 1. There are 2 options for writing a new operation. Optiona ``a`` is to write a device operation and option ``b`` is to write a composite operation
    a. Implement device operation in C++. Device operation is a struct that specifies how to create output tensors and a program to run on the device.
    b. Implement a composite operation in C++. Composite operation simply defines ``operator()`` method that calls other operations.
-2. Register the struct using `ttnn::register_operation` or using ``TTNN_REGISTER_OPERATION``.
+2. Register the struct using `ttnn::register_operation`.
 
 What steps are needed to add ttnn operation in Python?
 ------------------------------------------------------

--- a/ttnn/cpp/ttnn/decorators.hpp
+++ b/ttnn/cpp/ttnn/decorators.hpp
@@ -371,24 +371,9 @@ struct lambda_operation_t {
 };
 }  // namespace detail
 
-// If you are feeling lazy, you can use this macro to create an operation struct from a lambda
-// You  will have to implement async manually
-#define TTNN_REGISTER_OPERATION_FROM_FUNCTION(cpp_fully_qualified_name, function) \
-    (::ttnn::decorators::register_operation<                                 \
-        cpp_fully_qualified_name,                                            \
-        ::ttnn::decorators::detail::lambda_operation_t<[](auto&&... args) {  \
-            return function(std::forward<decltype(args)>(args)...);          \
-        }>>())
-
 }  // namespace decorators
 
 using ttnn::decorators::register_operation;
 using ttnn::decorators::register_operation_with_auto_launch_op;
-
-#define TTNN_REGISTER_OPERATION(NAMESPACE, OPERATION_NAME, OPERATION_TYPE) \
-    namespace NAMESPACE { \
-    constexpr auto OPERATION_NAME = ttnn::decorators::register_operation<reflect::fixed_string{#NAMESPACE "::" #OPERATION_NAME}, OPERATION_TYPE>(); \
-    }
-
 
 }  // namespace ttnn

--- a/ttnn/cpp/ttnn/operations/data_movement/fold/device/fold_device_op.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/fold/device/fold_device_op.cpp
@@ -77,4 +77,19 @@ Fold::tensor_return_value_t Fold::create_output_tensors(const operation_attribut
     }
 }
 
+std::tuple<Fold::operation_attributes_t, Fold::tensor_args_t>
+ Fold::operator()(
+            const ttnn::Tensor &input_tensor,
+            uint8_t stride_h,
+            uint8_t stride_w,
+            const std::optional<const tt::tt_metal::Shape> &output_shape,
+            uint8_t pad_c,
+            uint8_t pad_h,
+            uint8_t pad_w) {
+    bool is_sharded = input_tensor.is_sharded();
+    Fold::operation_attributes_t op_attr = {.stride_h = stride_h, .stride_w = stride_w, .is_sharded = is_sharded};
+    return {op_attr, Fold::tensor_args_t{.input_tensor = input_tensor}};
+}
+
+
 } // namespace ttnn::operations::data_movement

--- a/ttnn/cpp/ttnn/operations/data_movement/fold/device/fold_device_op.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/fold/device/fold_device_op.hpp
@@ -9,6 +9,7 @@
 #include "ttnn/tensor/tensor.hpp"
 #include "ttnn/operation.hpp"
 #include "ttnn/device_operation.hpp"
+#include "ttnn/decorators.hpp"
 
 namespace ttnn::operations::data_movement {
 
@@ -70,7 +71,19 @@ struct Fold {
     static void validate_on_program_cache_hit(const operation_attributes_t&, const tensor_args_t&);
     static shape_return_value_t compute_output_shapes(const operation_attributes_t&, const tensor_args_t&);
     static tensor_return_value_t create_output_tensors(const operation_attributes_t&, const tensor_args_t&);
+
+    static std::tuple<operation_attributes_t, tensor_args_t> operator()(
+        const ttnn::Tensor& input_tensor,
+        uint8_t stride_h,
+        uint8_t stride_w,
+        const std::optional<const tt::tt_metal::Shape>& output_shape,
+        uint8_t pad_c,
+        uint8_t pad_h,
+        uint8_t pad_w);
 };
 
-
 } // namespace ttnn::operations::data_movement
+
+namespace ttnn::prim {
+constexpr auto fold = ttnn::register_operation<"ttnn::prim::fold", ttnn::operations::data_movement::Fold>();
+} // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/eltwise/binary/binary.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary/binary.cpp
@@ -434,12 +434,17 @@ Tensor RelationalBinary<binary_op_type>::operator()(
         dtype = optional_output_tensor.value().get_dtype();
     }
 
-    return ttnn::device_operation::run<BinaryDeviceOperation>(
+    return ttnn::prim::binary(
         queue_id,
-        BinaryDeviceOperation::operation_attributes_t{
-            //TODO:: Remove the passing of the inplace flag from BinaryDeviceOperation(#11247)
-            binary_op_type, false, activations, input_tensor_a_activation, output_memory_config, dtype, std::nullopt},
-        BinaryDeviceOperation::tensor_args_t{input_tensor_a, input_tensor_b, optional_output_tensor});
+        input_tensor_a,
+        input_tensor_b,
+        binary_op_type,
+        false,
+        dtype,
+        output_memory_config,
+        optional_output_tensor,
+        activations,
+        input_tensor_a_activation);
 }
 
 template <BinaryOpType binary_op_type>

--- a/ttnn/cpp/ttnn/operations/eltwise/binary/binary.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary/binary.hpp
@@ -243,7 +243,7 @@ constexpr auto le_ = ttnn::register_operation_with_auto_launch_op<
 constexpr auto lt_ = ttnn::register_operation_with_auto_launch_op<
     "ttnn::lt_",
     operations::binary::InplaceRelationalBinary<operations::binary::BinaryOpType::LT>>();
-    
+
 template <typename InputBType>
 ttnn::Tensor operator+(const ttnn::Tensor &input_tensor_a, InputBType scalar) {
     return add(input_tensor_a, scalar);

--- a/ttnn/cpp/ttnn/operations/eltwise/binary/device/binary_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary/device/binary_device_operation.hpp
@@ -181,4 +181,6 @@ struct BinaryDeviceOperation {
 }  // namespace ttnn::operations::binary
 
 
-TTNN_REGISTER_OPERATION(ttnn::prim, binary, ttnn::operations::binary::BinaryDeviceOperation);
+namespace ttnn::prim {
+constexpr auto binary = ttnn::register_operation<"ttnn::prim::binary", ttnn::operations::binary::BinaryDeviceOperation>();
+} // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/examples/example/device/example_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/examples/example/device/example_device_operation.hpp
@@ -149,4 +149,8 @@ struct ExampleDeviceOperation {
 }  // namespace ttnn::operations::examples
 
 // Register the operation with the ttnn::register_operation API to make it available to the user as ttnn::prim::example
-TTNN_REGISTER_OPERATION(ttnn::prim, example, ttnn::operations::examples::ExampleDeviceOperation);
+namespace ttnn::prim {
+constexpr auto example = ttnn::register_operation<
+    "ttnn::prim::example",
+    ttnn::operations::examples::ExampleDeviceOperation>();
+}  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/experimental/transformer/nlp_create_qkv_heads/device/nlp_create_qkv_heads_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/nlp_create_qkv_heads/device/nlp_create_qkv_heads_device_operation.cpp
@@ -135,4 +135,27 @@ NlpCreateHeadsDeviceOperation::program_factory_t NlpCreateHeadsDeviceOperation::
         return Interleaved{};
     }
 }
+
+
+std::tuple<NlpCreateHeadsDeviceOperation::operation_attributes_t, NlpCreateHeadsDeviceOperation::tensor_args_t>
+NlpCreateHeadsDeviceOperation::operator()(
+        const Tensor& input_tensor_q,
+        const std::optional<Tensor>& input_tensor_kv,
+        const uint32_t num_q_heads,
+        const std::optional<uint32_t> num_kv_heads,
+        uint32_t head_dim,
+        const bool transpose_k_heads,
+        const std::optional<MemoryConfig>& memory_config,
+        std::optional<std::vector<std::optional<Tensor>>> optional_output_tensors) {
+
+    return {operation_attributes_t{.num_q_heads = num_q_heads,
+                                   .num_kv_heads = num_kv_heads.value_or(num_q_heads),
+                                   .head_dim = head_dim,
+                                   .transpose_k_heads = transpose_k_heads,
+                                   .output_mem_config = memory_config.value_or(input_tensor_q.memory_config())},
+            tensor_args_t{.input_tensor_q = input_tensor_q,
+                          .input_tensor_kv = input_tensor_kv,
+                          .optional_output_tensors = optional_output_tensors.value_or(std::vector<std::optional<Tensor>>{})}};
+}
+
 }  // namespace ttnn::operations::experimental::transformer

--- a/ttnn/cpp/ttnn/operations/experimental/transformer/nlp_create_qkv_heads/device/nlp_create_qkv_heads_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/nlp_create_qkv_heads/device/nlp_create_qkv_heads_device_operation.hpp
@@ -12,6 +12,7 @@
 #include "ttnn/common/constants.hpp"
 #include "ttnn/tensor/tensor.hpp"
 #include "ttnn/device_operation.hpp"
+#include "ttnn/decorators.hpp"
 
 namespace ttnn::operations::experimental::transformer {
 
@@ -111,6 +112,20 @@ struct NlpCreateHeadsDeviceOperation {
 
     // Create the output tensors based on the operation attributes and tensor args
     static tensor_return_value_t create_output_tensors(const operation_attributes_t&, const tensor_args_t&);
+
+    static std::tuple<operation_attributes_t, tensor_args_t> operator()(
+        const Tensor& input_tensor_q,
+        const std::optional<Tensor>& input_tensor_kv,
+        const uint32_t num_q_heads,
+        const std::optional<uint32_t> num_kv_heads,
+        uint32_t head_dim,
+        const bool transpose_k_heads,
+        const std::optional<MemoryConfig>& memory_config,
+        std::optional<std::vector<std::optional<Tensor>>> optional_output_tensors);
 };
 
 } // namespace ttnn::operations::experimental::transformer
+
+namespace ttnn::prim {
+constexpr auto nlp_create_qkv_heads = ttnn::register_operation<"ttnn::prim::nlp_create_qkv_heads", ttnn::operations::experimental::transformer::NlpCreateHeadsDeviceOperation>();
+} // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/experimental/transformer/nlp_create_qkv_heads/nlp_create_qkv_heads.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/nlp_create_qkv_heads/nlp_create_qkv_heads.cpp
@@ -27,16 +27,7 @@ namespace ttnn::operations::experimental::transformer {
                 head_dim = input_tensor_q.get_legacy_shape()[3] / (num_q_heads + 2 * num_kv_heads_val);
             }
 
-            return ttnn::device_operation::run<NlpCreateHeadsDeviceOperation>(
-                queue_id,
-                NlpCreateHeadsDeviceOperation::operation_attributes_t{.num_q_heads = num_q_heads,
-                                                                    .num_kv_heads = num_kv_heads_val,
-                                                                    .head_dim = head_dim,
-                                                                    .transpose_k_heads = transpose_k_heads,
-                                                                    .output_mem_config = memory_config.value_or(input_tensor_q.memory_config())},
-                NlpCreateHeadsDeviceOperation::tensor_args_t{.input_tensor_q = input_tensor_q,
-                                                            .input_tensor_kv = input_tensor_kv,
-                                                            .optional_output_tensors = optional_output_tensors.value_or(std::vector<std::optional<Tensor>>{})});
+            return ttnn::prim::nlp_create_qkv_heads(queue_id, input_tensor_q, input_tensor_kv, num_q_heads, num_kv_heads, head_dim, transpose_k_heads, memory_config, optional_output_tensors);
     };
 
     std::tuple<ttnn::Tensor, ttnn::Tensor, ttnn::Tensor> NlpCreateHeadsOperation::operator() (

--- a/ttnn/cpp/ttnn/operations/pool/maxpool/device/max_pool2d_device_op.cpp
+++ b/ttnn/cpp/ttnn/operations/pool/maxpool/device/max_pool2d_device_op.cpp
@@ -140,4 +140,16 @@ operation::OpPerformanceModel MaxPoolNew::create_op_performance_model(const oper
     return result;
 }
 
+
+std::tuple<MaxPoolNew::operation_attributes_t, MaxPoolNew::tensor_args_t> MaxPoolNew::operator()(
+    const Tensor& input_tensor,
+    const sliding_window::SlidingWindowConfig& sliding_window_config,
+    DataType output_dtype,
+    MemoryConfig memory_config) {
+    return {
+        operation_attributes_t{sliding_window_config, output_dtype, memory_config},
+        tensor_args_t{input_tensor}
+    };
+}
+
 } // namespace ttnn::operations::pool

--- a/ttnn/cpp/ttnn/operations/pool/maxpool/device/max_pool2d_device_op.hpp
+++ b/ttnn/cpp/ttnn/operations/pool/maxpool/device/max_pool2d_device_op.hpp
@@ -13,6 +13,7 @@
 #include "ttnn/types.hpp"
 #include "ttnn/operations/conv2d/conv2d.hpp"
 #include "ttnn/cpp/ttnn/operations/sliding_window/sliding_window.hpp"
+#include "ttnn/decorators.hpp"
 
 
 namespace ttnn::operations {
@@ -68,7 +69,17 @@ struct MaxPoolNew {
     static tt::stl::hash::hash_t compute_program_hash(const operation_attributes_t&, const tensor_args_t&);
     static operation::OpPerformanceModel create_op_performance_model(const operation_attributes_t&, const tensor_args_t&, const Tensor&);
 
+    static std::tuple<operation_attributes_t, tensor_args_t> operator()(
+        const Tensor& input_tensor,
+        const sliding_window::SlidingWindowConfig& sliding_window_config,
+        DataType output_dtype,
+        MemoryConfig memory_config);
+
 };
 
 }  // namespace pool
 }  // namespace ttnn::operations
+
+namespace ttnn::prim {
+constexpr auto max_pool_new = ttnn::register_operation<"ttnn::prim::max_pool_new", ttnn::operations::pool::MaxPoolNew>();
+}  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/pool/maxpool/max_pool2d.cpp
+++ b/ttnn/cpp/ttnn/operations/pool/maxpool/max_pool2d.cpp
@@ -98,16 +98,12 @@ Tensor MaxPoolNewOp::operator()(uint8_t queue_id, const Tensor& input_tensor, ui
         input_tensor_sharded.memory_config(),
         is_out_tiled);
 
-    MaxPoolNew::operation_attributes_t op_attr{
-        .sliding_window_config_ = sliding_window_config,
-        .output_dtype_ = DataType::BFLOAT16,      // input_tensor.dtype(), // currently only bfp16 output is supported
-        .memory_config_ = memory_config};
-
-    // and then call the maxpool uop
-    return ttnn::device_operation::run<MaxPoolNew>(
+    return ttnn::prim::max_pool_new(
         queue_id,
-        op_attr,
-        MaxPoolNew::tensor_args_t{.input_tensor_ = haloed_tensor});
+        haloed_tensor,
+        sliding_window_config,
+        DataType::BFLOAT16,      // input_tensor.dtype(), // currently only bfp16 output is supported
+        memory_config);
 }
 
 // device template specializations

--- a/ttnn/cpp/ttnn/operations/pool/maxpool/max_pool2d.hpp
+++ b/ttnn/cpp/ttnn/operations/pool/maxpool/max_pool2d.hpp
@@ -12,7 +12,6 @@
 
 #include "device/max_pool2d_device_op.hpp"
 
-
 namespace ttnn {
 namespace operations::pool {
 

--- a/ttnn/cpp/ttnn/run_operation.cpp
+++ b/ttnn/cpp/ttnn/run_operation.cpp
@@ -15,6 +15,7 @@
 #include "tt_metal/tt_stl/reflection.hpp"
 #include "ttnn/config.hpp"
 #include "ttnn/device_operation.hpp"
+#include "ttnn/decorators.hpp"
 
 namespace tt::tt_metal {
     std::atomic<uint32_t> operation_id_atomic_count = 0;
@@ -90,7 +91,7 @@ template void override_addresses<OptionalTensors>(
     const OptionalConstTensors& optional_input_tensors,
     const OptionalTensors& output_tensors);
 
-
+}  // namespace detail
 
 template<typename OutputTensors>
 struct OldInfraDeviceOperation {
@@ -139,7 +140,7 @@ struct OldInfraDeviceOperation {
 
             if (override_addresses_callback.has_value()) {
                 // Deprecated
-                override_addresses(
+                detail::override_addresses(
                     override_addresses_callback.value(),
                     program,
                     tensor_args.input_tensors,
@@ -202,11 +203,33 @@ struct OldInfraDeviceOperation {
     static std::string get_type_name(const operation_attributes_t& attributes) {
         return attributes.get_type_name();
     }
+
+    static std::tuple<operation_attributes_t, tensor_args_t> operator()(
+        operation_attributes_t&& operation_attributes,
+        const operation::Tensors& input_tensors,
+        const operation::OptionalConstTensors& optional_input_tensors,
+        const operation::OptionalTensors& optional_output_tensors
+    ) {
+        return std::make_tuple(
+            std::move(operation_attributes),
+            tensor_args_t{input_tensors, optional_input_tensors, optional_output_tensors}
+        );
+    }
 };
 
 
-}  // namespace detail
+} // namespace tt::tt_metal::operation
 
+namespace ttnn::prim {
+constexpr auto old_infra_device_operation = ttnn::register_operation<
+    "ttnn::prim::old_infra_device_operation",
+    tt::tt_metal::operation::OldInfraDeviceOperation<tt::tt_metal::operation::Tensors>>();
+constexpr auto old_infra_device_operation_with_optional_output_tensors = ttnn::register_operation<
+    "ttnn::prim::old_infra_device_operation_with_optional_output_tensors",
+    tt::tt_metal::operation::OldInfraDeviceOperation<tt::tt_metal::operation::OptionalTensors>>();
+}  // namespace ttnn::prim
+
+namespace tt::tt_metal::operation {
 
 template <class OutputTensors>
 OutputTensors run(
@@ -216,10 +239,11 @@ OutputTensors run(
     const OptionalTensors& optional_output_tensors,
     uint8_t cq_id) {
 
-    return ttnn::device_operation::run<detail::OldInfraDeviceOperation<OutputTensors>>(
-        cq_id,
-        typename detail::OldInfraDeviceOperation<OutputTensors>::operation_attributes_t{std::move(operation)},
-        typename detail::OldInfraDeviceOperation<OutputTensors>::tensor_args_t{input_tensors, optional_input_tensors, optional_output_tensors});
+    if constexpr (std::is_same_v<OutputTensors, Tensors>) {
+        return ttnn::prim::old_infra_device_operation(cq_id, std::move(operation), input_tensors, optional_input_tensors, optional_output_tensors);
+    } else {
+        return ttnn::prim::old_infra_device_operation_with_optional_output_tensors(cq_id, std::move(operation), input_tensors, optional_input_tensors, optional_output_tensors);
+    }
 }
 
 template Tensors run(


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/11428

### Problem description
`ttnn::device_operation::run` shouldn't be called manually 

### What's changed
Replaced all calls of `ttnn::device_operation::run` with calls to `ttnn::prim` operations

### Checklist
- [ ] Post commit CI passes
- [ ] Blackhole Post commit (if applicable)
- [ ] Model regression CI testing passes (if applicable)
- [ ] New/Existing tests provide coverage for changes
