### PR TITLE
#11422: Replace tt_lib in models/experimental/t5,vovnet

### DIFF
--- a/models/experimental/t5/demo/demo_utils.py
+++ b/models/experimental/t5/demo/demo_utils.py
@@ -2,7 +2,7 @@
 
 # SPDX-License-Identifier: Apache-2.0
 
-import tt_lib
+import ttnn
 from loguru import logger
 from transformers import AutoTokenizer
 from models.generation_utils import run_generate
@@ -12,8 +12,7 @@ def run_demo_t5(t5_model_constructor):
     input_sentance = "translate English to German: The house is wonderful."
     tokenizer = AutoTokenizer.from_pretrained("t5-base", model_max_length=32)
 
-    device = tt_lib.device.CreateDevice(0)
-
+    device = ttnn.open_device(0)
 
     output_sentance = run_generate(
         input_sentance,
@@ -27,4 +26,4 @@ def run_demo_t5(t5_model_constructor):
     logger.info(f"Input sentance: '{input_sentance}'")
     logger.info(f"Tt output: '{output_sentance}'")
 
-    tt_lib.device.CloseDevice(device)
+    ttnn.close_device(device)

--- a/models/experimental/t5/tests/test_perf_t5.py
+++ b/models/experimental/t5/tests/test_perf_t5.py
@@ -6,7 +6,7 @@ from transformers import AutoTokenizer, T5Model
 import torch
 import json
 import pytest
-import tt_lib
+import ttnn
 from loguru import logger
 
 from models.utility_functions import (
@@ -74,7 +74,7 @@ def run_perf_t5(expected_inference_time, expected_compile_time, device):
             attention_mask=attention_mask,
             decoder_attention_mask=decoder_attention_mask,
         )
-        tt_lib.device.Synchronize(device)
+        ttnn.synchronize_device(device)
         profiler.end(first_key)
         del tt_model_outputs
 
@@ -87,7 +87,7 @@ def run_perf_t5(expected_inference_time, expected_compile_time, device):
             attention_mask=attention_mask,
             decoder_attention_mask=decoder_attention_mask,
         )
-        tt_lib.device.Synchronize(device)
+        ttnn.synchronize_device(device)
         profiler.end(second_key)
         del tt_model_outputs
 

--- a/models/experimental/t5/tests/test_t5_attention.py
+++ b/models/experimental/t5/tests/test_t5_attention.py
@@ -8,7 +8,6 @@ import json
 from transformers import T5Model
 from loguru import logger
 
-import tt_lib
 import ttnn
 import pytest
 

--- a/models/experimental/t5/tests/test_t5_block.py
+++ b/models/experimental/t5/tests/test_t5_block.py
@@ -5,7 +5,6 @@
 import pytest
 import torch
 import json
-import tt_lib
 from loguru import logger
 
 from transformers import T5Model

--- a/models/experimental/t5/tests/test_t5_dense_act_dense.py
+++ b/models/experimental/t5/tests/test_t5_dense_act_dense.py
@@ -4,7 +4,6 @@
 
 import json
 import torch
-import tt_lib
 from loguru import logger
 
 from transformers import T5Model
@@ -24,14 +23,10 @@ def run_test_T5DenseActDense_inference(device, model_name, input_h, input_w):
     config["is_decoder"] = False
 
     if config["is_decoder"]:
-        hf_reference_module = (
-            hugging_face_reference_model.decoder.block[0].layer[2].DenseReluDense
-        )
+        hf_reference_module = hugging_face_reference_model.decoder.block[0].layer[2].DenseReluDense
         base_address = f"decoder.block.0.layer.2.DenseReluDense"
     else:
-        hf_reference_module = (
-            hugging_face_reference_model.encoder.block[0].layer[1].DenseReluDense
-        )
+        hf_reference_module = hugging_face_reference_model.encoder.block[0].layer[1].DenseReluDense
         base_address = f"encoder.block.0.layer.1.DenseReluDense"
 
     # Prepare input
@@ -42,9 +37,7 @@ def run_test_T5DenseActDense_inference(device, model_name, input_h, input_w):
     pt_out = hf_reference_module(test_input)[0].unsqueeze(1)
 
     # T5-small config file: https://huggingface.co/t5-small/resolve/main/config.json
-    tt_model = TtT5DenseActDense(
-        config, hugging_face_reference_model.state_dict(), base_address, device
-    )
+    tt_model = TtT5DenseActDense(config, hugging_face_reference_model.state_dict(), base_address, device)
     tt_out = tt_model(torch2tt_tensor(test_input, device))
     tt_out = tt2torch_tensor(tt_out)
 

--- a/models/experimental/t5/tests/test_t5_dense_gated_act_dense.py
+++ b/models/experimental/t5/tests/test_t5_dense_gated_act_dense.py
@@ -4,7 +4,6 @@
 
 import json
 import torch
-import tt_lib
 from loguru import logger
 
 from transformers import T5Model, AutoModelForSeq2SeqLM
@@ -25,14 +24,10 @@ def run_test_T5DenseGatedActDense_inference(device):
     config["is_decoder"] = False
 
     if config["is_decoder"]:
-        hf_reference_module = (
-            hugging_face_reference_model.decoder.block[0].layer[2].DenseReluDense
-        )
+        hf_reference_module = hugging_face_reference_model.decoder.block[0].layer[2].DenseReluDense
         base_address = f"decoder.block.0.layer.2.DenseReluDense"
     else:
-        hf_reference_module = (
-            hugging_face_reference_model.encoder.block[0].layer[1].DenseReluDense
-        )
+        hf_reference_module = hugging_face_reference_model.encoder.block[0].layer[1].DenseReluDense
         base_address = f"encoder.block.0.layer.1.DenseReluDense"
 
     # Prepare input
@@ -43,9 +38,7 @@ def run_test_T5DenseGatedActDense_inference(device):
     pt_out = hf_reference_module(test_input)[0].unsqueeze(1)
 
     # T5-small config file: https://huggingface.co/t5-small/resolve/main/config.json
-    tt_model = TtT5DenseGatedActDense(
-        config, hugging_face_reference_model.state_dict(), base_address, device
-    )
+    tt_model = TtT5DenseGatedActDense(config, hugging_face_reference_model.state_dict(), base_address, device)
     tt_out = tt_model(torch2tt_tensor(test_input, device))
     tt_out = tt2torch_tensor(tt_out)
 

--- a/models/experimental/t5/tests/test_t5_for_conditional_generation.py
+++ b/models/experimental/t5/tests/test_t5_for_conditional_generation.py
@@ -2,7 +2,6 @@
 
 # SPDX-License-Identifier: Apache-2.0
 
-import tt_lib
 from loguru import logger
 from transformers import AutoTokenizer
 
@@ -85,18 +84,12 @@ def run_T5ForConditionalGeneration(device, model_constructor, model_name):
 
 
 def test_T5ForConditionalGeneration_t5_small(device):
-    run_T5ForConditionalGeneration(
-        device, t5_small_for_conditional_generation, "t5-small"
-    )
+    run_T5ForConditionalGeneration(device, t5_small_for_conditional_generation, "t5-small")
 
 
 def test_T5ForConditionalGeneration_flan_t5_small(device):
-    run_T5ForConditionalGeneration(
-        device, flan_t5_small_for_conditional_generation, "google/flan-t5-small"
-    )
+    run_T5ForConditionalGeneration(device, flan_t5_small_for_conditional_generation, "google/flan-t5-small")
 
 
 def test_T5ForConditionalGeneration_t5_base(device):
-    run_T5ForConditionalGeneration(
-        device, t5_base_for_conditional_generation, "t5-base"
-    )
+    run_T5ForConditionalGeneration(device, t5_base_for_conditional_generation, "t5-base")

--- a/models/experimental/t5/tests/test_t5_layer_cross_attention.py
+++ b/models/experimental/t5/tests/test_t5_layer_cross_attention.py
@@ -4,7 +4,6 @@
 
 import torch
 import json
-import tt_lib
 import pytest
 from loguru import logger
 

--- a/models/experimental/t5/tests/test_t5_layer_ff.py
+++ b/models/experimental/t5/tests/test_t5_layer_ff.py
@@ -4,7 +4,6 @@
 
 import torch
 import json
-import tt_lib
 from loguru import logger
 
 from transformers import T5Model
@@ -38,9 +37,7 @@ def run_test_T5LayerFF_inference(device, model_name, input_h, input_w):
     pt_out = hf_reference_module(test_input)[0].unsqueeze(1)
 
     # T5-small config file: https://huggingface.co/t5-small/resolve/main/config.json
-    tt_model = TtT5LayerFF(
-        config, hf_reference_model.state_dict(), base_address, device
-    )
+    tt_model = TtT5LayerFF(config, hf_reference_model.state_dict(), base_address, device)
     tt_out = tt_model(torch2tt_tensor(test_input, device))
     tt_out = tt2torch_tensor(tt_out)
 

--- a/models/experimental/t5/tests/test_t5_layer_norm.py
+++ b/models/experimental/t5/tests/test_t5_layer_norm.py
@@ -4,7 +4,6 @@
 
 import torch
 import json
-import tt_lib
 from loguru import logger
 
 from transformers import T5Model
@@ -37,9 +36,7 @@ def run_test_T5LayerNorm_inference(device, model_name, input_h, input_w):
 
     # PyTorch output
     pt_out = hf_reference_module(t5_layer_norm_input)[0].unsqueeze(1)
-    tt_T5LayerNorm_model = TtT5LayerNorm(
-        config, hf_reference_model.state_dict(), base_address, device
-    )
+    tt_T5LayerNorm_model = TtT5LayerNorm(config, hf_reference_model.state_dict(), base_address, device)
 
     # TT hardware execution
     tt_layer_norm_input = torch2tt_tensor(t5_layer_norm_input, device)

--- a/models/experimental/t5/tests/test_t5_layer_self_attention.py
+++ b/models/experimental/t5/tests/test_t5_layer_self_attention.py
@@ -4,7 +4,6 @@
 
 import torch
 import json
-import tt_lib
 import pytest
 from loguru import logger
 

--- a/models/experimental/t5/tests/test_t5_model.py
+++ b/models/experimental/t5/tests/test_t5_model.py
@@ -4,7 +4,6 @@
 
 import torch
 import json
-import tt_lib
 import pytest
 from loguru import logger
 

--- a/models/experimental/t5/tests/test_t5_stack.py
+++ b/models/experimental/t5/tests/test_t5_stack.py
@@ -4,7 +4,6 @@
 
 import torch
 import json
-import tt_lib
 import pytest
 from loguru import logger
 

--- a/models/experimental/t5/tt/t5_attention.py
+++ b/models/experimental/t5/tt/t5_attention.py
@@ -7,7 +7,6 @@ import torch
 from torch import nn
 
 import ttnn
-import tt_lib
 
 from loguru import logger
 from models.utility_functions import (
@@ -317,9 +316,7 @@ class TtT5Attention(nn.Module):
         self.dropout = config["dropout_rate"]
         self.inner_dim = self.n_heads * self.key_value_proj_dim
         self.device = device
-        self.mem_config = tt_lib.tensor.MemoryConfig(
-            tt_lib.tensor.TensorMemoryLayout.INTERLEAVED, tt_lib.tensor.BufferType.L1
-        )
+        self.mem_config = ttnn.L1_MEMORY_CONFIG
 
         self.q_weights = torch2tt_tensor(state_dict[f"{base_address}.q.weight"], device)
         self.k_weights = torch2tt_tensor(state_dict[f"{base_address}.k.weight"], device)

--- a/models/experimental/t5/tt/t5_dense_act_dense.py
+++ b/models/experimental/t5/tt/t5_dense_act_dense.py
@@ -3,7 +3,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
 from torch import nn
-import tt_lib
 import ttnn
 from models.utility_functions import torch2tt_tensor
 
@@ -15,9 +14,7 @@ class TtT5DenseActDense(nn.Module):
         d_model = config["d_model"]
         d_ff = config["d_ff"]
         dropout_rate = config["dropout_rate"]
-        self.mem_config = tt_lib.tensor.MemoryConfig(
-            tt_lib.tensor.TensorMemoryLayout.INTERLEAVED, tt_lib.tensor.BufferType.L1
-        )
+        self.mem_config = ttnn.L1_MEMORY_CONFIG
 
         # dense_act_fn = config["dense_act_fn"]
 

--- a/models/experimental/t5/tt/t5_dense_gated_act_dense.py
+++ b/models/experimental/t5/tt/t5_dense_gated_act_dense.py
@@ -3,7 +3,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import torch
-import tt_lib
 import ttnn
 from loguru import logger
 import math
@@ -28,9 +27,7 @@ class TtT5DenseGatedActDense(torch.nn.Module):
         super().__init__()
 
         self.device = device
-        self.mem_config = tt_lib.tensor.MemoryConfig(
-            tt_lib.tensor.TensorMemoryLayout.INTERLEAVED, tt_lib.tensor.BufferType.L1
-        )
+        self.mem_config = ttnn.L1_MEMORY_CONFIG
 
         enc_dec = "decoder" if config["is_decoder"] else "encoder"
 

--- a/models/experimental/t5/tt/t5_for_conditional_generation.py
+++ b/models/experimental/t5/tt/t5_for_conditional_generation.py
@@ -6,7 +6,6 @@ import copy
 import torch
 import warnings
 from torch import nn
-import tt_lib
 import ttnn
 import json
 from typing import Optional, Tuple

--- a/models/experimental/t5/tt/t5_layer_cross_attention.py
+++ b/models/experimental/t5/tt/t5_layer_cross_attention.py
@@ -4,7 +4,6 @@
 
 import torch
 import ttnn
-import tt_lib
 
 from models.utility_functions import (
     torch2tt_tensor,

--- a/models/experimental/t5/tt/t5_layer_ff.py
+++ b/models/experimental/t5/tt/t5_layer_ff.py
@@ -4,7 +4,6 @@
 
 import torch
 import ttnn
-import tt_lib
 
 from models.experimental.t5.tt.t5_layer_norm import TtT5LayerNorm
 from models.experimental.t5.tt.t5_dense_act_dense import TtT5DenseActDense

--- a/models/experimental/t5/tt/t5_layer_norm.py
+++ b/models/experimental/t5/tt/t5_layer_norm.py
@@ -3,7 +3,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import torch
-import tt_lib
 from models.utility_functions import pad_by_zero
 
 import ttnn

--- a/models/experimental/t5/tt/t5_layer_self_attention.py
+++ b/models/experimental/t5/tt/t5_layer_self_attention.py
@@ -4,7 +4,6 @@
 
 import torch
 import ttnn
-import tt_lib
 
 from models.utility_functions import (
     torch2tt_tensor,

--- a/models/experimental/vovnet/demo/gs_demo.py
+++ b/models/experimental/vovnet/demo/gs_demo.py
@@ -8,21 +8,18 @@ import timm
 from torchvision.utils import save_image
 from loguru import logger
 
-import tt_lib
-
 from models.experimental.vovnet.tt.vovnet import vovnet_for_image_classification
 from models.utility_functions import (
     torch_to_tt_tensor_rm,
     tt_to_torch_tensor,
 )
 
+
 @pytest.mark.parametrize(
     "model_name",
     (("hf_hub:timm/ese_vovnet19b_dw.ra_in1k"),),
 )
-def test_vovnet_model_inference(
-    device, imagenet_sample_input, imagenet_label_dict, model_name, reset_seeds
-):
+def test_vovnet_model_inference(device, imagenet_sample_input, imagenet_label_dict, model_name, reset_seeds):
     model = timm.create_model(model_name, pretrained=True)
 
     torch_model = model

--- a/models/experimental/vovnet/tests/perf_vovnet.py
+++ b/models/experimental/vovnet/tests/perf_vovnet.py
@@ -7,8 +7,6 @@ import torch
 
 from loguru import logger
 
-import tt_lib
-
 from models.experimental.vovnet.tt.vovnet import vovnet_for_image_classification
 from models.utility_functions import (
     Profiler,

--- a/models/experimental/vovnet/tests/test_tt_classifier_head.py
+++ b/models/experimental/vovnet/tests/test_tt_classifier_head.py
@@ -8,8 +8,6 @@ import timm
 
 from loguru import logger
 
-import tt_lib
-
 from models.experimental.vovnet.tt.classifier_head import TtClassifierHead
 from models.utility_functions import (
     torch_to_tt_tensor_rm,
@@ -17,6 +15,7 @@ from models.utility_functions import (
     comp_allclose,
     comp_pcc,
 )
+
 
 @pytest.mark.parametrize(
     "pcc",

--- a/models/experimental/vovnet/tests/test_tt_conv_norm_act.py
+++ b/models/experimental/vovnet/tests/test_tt_conv_norm_act.py
@@ -8,8 +8,6 @@ import timm
 
 from loguru import logger
 
-import tt_lib
-
 from models.utility_functions import (
     torch_to_tt_tensor_rm,
     tt_to_torch_tensor,
@@ -23,9 +21,7 @@ from models.experimental.vovnet.tt.conv_norm_act import TtConvNormAct
     "pcc",
     ((0.99),),
 )
-def test_vovnet_conv_norm_act_inference(
-    device, pcc, imagenet_sample_input, reset_seeds
-):
+def test_vovnet_conv_norm_act_inference(device, pcc, imagenet_sample_input, reset_seeds):
     base_address = f"stem.0"
 
     model = timm.create_model("hf_hub:timm/ese_vovnet19b_dw.ra_in1k", pretrained=True)
@@ -45,7 +41,7 @@ def test_vovnet_conv_norm_act_inference(
         act_kwargs=None,
         state_dict=model.state_dict(),
         base_address=base_address,
-        device=device
+        device=device,
     )
 
     # run torch model

--- a/models/experimental/vovnet/tests/test_tt_effective_se_module.py
+++ b/models/experimental/vovnet/tests/test_tt_effective_se_module.py
@@ -8,8 +8,6 @@ import timm
 
 from loguru import logger
 
-import tt_lib
-
 from models.experimental.vovnet.tt.effective_se_module import TtEffectiveSEModule
 from models.utility_functions import (
     torch_to_tt_tensor_rm,
@@ -17,9 +15,6 @@ from models.utility_functions import (
     comp_allclose,
     comp_pcc,
 )
-
-
-
 
 
 @pytest.mark.parametrize(

--- a/models/experimental/vovnet/tests/test_tt_osa_block.py
+++ b/models/experimental/vovnet/tests/test_tt_osa_block.py
@@ -9,8 +9,6 @@ import timm
 
 from loguru import logger
 
-import tt_lib
-
 from models.utility_functions import (
     torch_to_tt_tensor_rm,
     tt_to_torch_tensor,

--- a/models/experimental/vovnet/tests/test_tt_osa_stage.py
+++ b/models/experimental/vovnet/tests/test_tt_osa_stage.py
@@ -9,8 +9,6 @@ import timm
 
 from loguru import logger
 
-import tt_lib
-
 from models.utility_functions import (
     torch_to_tt_tensor_rm,
     tt_to_torch_tensor,

--- a/models/experimental/vovnet/tests/test_tt_select_adaptivepool2d.py
+++ b/models/experimental/vovnet/tests/test_tt_select_adaptivepool2d.py
@@ -8,8 +8,6 @@ import timm
 
 from loguru import logger
 
-import tt_lib
-
 from models.utility_functions import (
     torch_to_tt_tensor_rm,
     tt_to_torch_tensor,
@@ -29,13 +27,7 @@ def test_select_adaptive_pool2d_inference(device, pcc, reset_seeds):
 
     torch_model = model.head.global_pool
 
-    tt_model = TtSelectAdaptivePool2d(
-        output_size=1,
-        pool_type="Fast",
-        flatten=True,
-        input_fmt="NCHW",
-        device=device
-    )
+    tt_model = TtSelectAdaptivePool2d(output_size=1, pool_type="Fast", flatten=True, input_fmt="NCHW", device=device)
 
     # run torch model
     input = torch.randn(1, 1024, 7, 7)

--- a/models/experimental/vovnet/tests/test_tt_separable_conv_norm_act.py
+++ b/models/experimental/vovnet/tests/test_tt_separable_conv_norm_act.py
@@ -5,7 +5,6 @@
 import torch
 import pytest
 import timm
-import tt_lib
 
 from loguru import logger
 

--- a/models/experimental/vovnet/tests/test_tt_sequential_append_list.py
+++ b/models/experimental/vovnet/tests/test_tt_sequential_append_list.py
@@ -8,8 +8,6 @@ import timm
 
 from loguru import logger
 
-import tt_lib
-
 from models.utility_functions import (
     torch_to_tt_tensor_rm,
     tt_to_torch_tensor,
@@ -17,6 +15,7 @@ from models.utility_functions import (
     comp_pcc,
 )
 from models.experimental.vovnet.tt.sequential_append_list import TtSequentialAppendList
+
 
 @pytest.mark.parametrize(
     "pcc",

--- a/models/experimental/vovnet/tests/test_tt_vovnet.py
+++ b/models/experimental/vovnet/tests/test_tt_vovnet.py
@@ -7,8 +7,6 @@ import timm
 
 from loguru import logger
 
-import tt_lib
-
 from models.utility_functions import (
     torch_to_tt_tensor_rm,
     tt_to_torch_tensor,
@@ -22,9 +20,7 @@ from models.experimental.vovnet.tt.vovnet import vovnet_for_image_classification
     "model_name, pcc",
     (("hf_hub:timm/ese_vovnet19b_dw.ra_in1k", 0.99),),
 )
-def test_vovnet_model_inference(
-    device, pcc, imagenet_sample_input, model_name, reset_seeds
-):
+def test_vovnet_model_inference(device, pcc, imagenet_sample_input, model_name, reset_seeds):
     model = timm.create_model(model_name, pretrained=True)
 
     torch_model = model

--- a/models/experimental/vovnet/tt/classifier_head.py
+++ b/models/experimental/vovnet/tt/classifier_head.py
@@ -4,7 +4,6 @@
 
 import torch.nn as nn
 
-import tt_lib
 import tt_lib.fallback_ops
 
 from models.helper_funcs import Linear
@@ -47,19 +46,11 @@ class TtClassifierHead(nn.Module):
         self.base_address = base_address
 
         self.global_pool = TtSelectAdaptivePool2d(
-            output_size=1,
-            pool_type="Fast",
-            flatten=True,
-            input_fmt="NCHW",
-            device=None
+            output_size=1, pool_type="Fast", flatten=True, input_fmt="NCHW", device=None
         )
 
-        self.weight = torch_to_tt_tensor_rm(
-            state_dict[f"{base_address}.fc.weight"], self.device, put_on_device=False
-        )
-        self.bias = torch_to_tt_tensor_rm(
-            state_dict[f"{base_address}.fc.bias"], self.device, put_on_device=False
-        )
+        self.weight = torch_to_tt_tensor_rm(state_dict[f"{base_address}.fc.weight"], self.device, put_on_device=False)
+        self.bias = torch_to_tt_tensor_rm(state_dict[f"{base_address}.fc.bias"], self.device, put_on_device=False)
 
         self.shape = (1, 1, 1, 1000)
 

--- a/models/experimental/vovnet/tt/conv_norm_act.py
+++ b/models/experimental/vovnet/tt/conv_norm_act.py
@@ -9,7 +9,6 @@ import ttnn
 from models.utility_functions import torch_to_tt_tensor_rm
 from models.experimental.vovnet.vovnet_utils import create_batchnorm
 
-import tt_lib
 from tt_lib.fallback_ops import fallback_ops
 
 
@@ -54,7 +53,7 @@ class TtConvNormAct(nn.Module):
             device=self.device,
         )
 
-    def forward(self, x: tt_lib.tensor.Tensor) -> tt_lib.tensor.Tensor:
+    def forward(self, x: ttnn.Tensor) -> ttnn.Tensor:
         x = self.conv(x)
         x = self.bn(x)
         x = ttnn.relu(x)

--- a/models/experimental/vovnet/tt/effective_se_module.py
+++ b/models/experimental/vovnet/tt/effective_se_module.py
@@ -9,7 +9,6 @@ from models.utility_functions import (
     torch_to_tt_tensor_rm,
 )
 import ttnn
-import tt_lib
 from tt_lib import fallback_ops
 
 
@@ -51,7 +50,7 @@ class TtEffectiveSEModule(nn.Module):
 
         self.activation = ttnn.hardsigmoid
 
-    def forward(self, input: tt_lib.tensor.Tensor) -> tt_lib.tensor.Tensor:
+    def forward(self, input: ttnn.Tensor) -> ttnn.Tensor:
         out = tt_to_torch_tensor(input)
         out = out.mean((2, 3), keepdim=True)
         if self.add_maxpool:

--- a/models/experimental/vovnet/tt/osa_block.py
+++ b/models/experimental/vovnet/tt/osa_block.py
@@ -3,8 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import torch.nn as nn
-
-import tt_lib
+import ttnn
 
 from models.experimental.vovnet.tt.conv_norm_act import TtConvNormAct
 from models.experimental.vovnet.tt.sequential_append_list import (
@@ -13,8 +12,6 @@ from models.experimental.vovnet.tt.sequential_append_list import (
 from models.experimental.vovnet.tt.effective_se_module import (
     TtEffectiveSEModule,
 )
-
-
 
 
 class TtOsaBlock(nn.Module):
@@ -99,7 +96,7 @@ class TtOsaBlock(nn.Module):
             device=device,
         )
 
-    def forward(self, x: tt_lib.tensor.Tensor) -> tt_lib.tensor.Tensor:
+    def forward(self, x: ttnn.Tensor) -> ttnn.Tensor:
         output = [x]
         if self.conv_reduction is not None:
             x = self.conv_reduction(x)

--- a/models/experimental/vovnet/tt/osa_stage.py
+++ b/models/experimental/vovnet/tt/osa_stage.py
@@ -4,11 +4,9 @@
 
 import torch.nn as nn
 
-import tt_lib
-
 from tt_lib import fallback_ops
 from models.experimental.vovnet.tt.osa_block import TtOsaBlock
-
+import ttnn
 
 
 class TtOsaStage(nn.Module):
@@ -55,7 +53,7 @@ class TtOsaStage(nn.Module):
             in_chs = out_chs
         self.blocks = nn.Sequential(*blocks)
 
-    def forward(self, x: tt_lib.tensor.Tensor) -> tt_lib.tensor.Tensor:
+    def forward(self, x: ttnn.Tensor) -> ttnn.Tensor:
         if self.pool is not None:
             x = self.pool(x)
         x = self.blocks(x)

--- a/models/experimental/vovnet/tt/select_adaptive_pool2d.py
+++ b/models/experimental/vovnet/tt/select_adaptive_pool2d.py
@@ -5,7 +5,6 @@
 import torch.nn as nn
 from typing import Union, Tuple
 
-import tt_lib
 import tt_lib.fallback_ops
 
 
@@ -23,9 +22,7 @@ class TtSelectAdaptivePool2d(nn.Module):
         super(TtSelectAdaptivePool2d, self).__init__()
         self.device = device
         assert input_fmt in ("NCHW", "NHWC")
-        self.pool_type = (
-            pool_type or ""
-        )  # convert other falsy values to empty string for consistent TS typing
+        self.pool_type = pool_type or ""  # convert other falsy values to empty string for consistent TS typing
         if not pool_type:
             self.pool = nn.Identity()  # pass through
             self.flatten = nn.Flatten(1)

--- a/models/experimental/vovnet/tt/separable_conv_norm_act.py
+++ b/models/experimental/vovnet/tt/separable_conv_norm_act.py
@@ -5,7 +5,6 @@
 
 import torch.nn as nn
 
-import tt_lib
 import ttnn
 
 from tt_lib import fallback_ops
@@ -74,7 +73,7 @@ class TtSeparableConvNormAct(nn.Module):
 
         self.bn = create_batchnorm(out_channels, state_dict, base_address=f"{base_address}.bn", device=None)
 
-    def forward(self, x: tt_lib.tensor.Tensor) -> tt_lib.tensor.Tensor:
+    def forward(self, x: ttnn.Tensor) -> ttnn.Tensor:
         x = self.conv_dw(x)
         x = self.conv_pw(x)
         x = self.bn(x)

--- a/models/experimental/vovnet/tt/sequential_append_list.py
+++ b/models/experimental/vovnet/tt/sequential_append_list.py
@@ -5,9 +5,7 @@
 import torch.nn as nn
 
 from typing import List
-
-import tt_lib
-
+import ttnn
 from models.experimental.vovnet.tt.separable_conv_norm_act import (
     TtSeparableConvNormAct,
 )
@@ -45,7 +43,7 @@ class TtSequentialAppendList(nn.Sequential):
             )
             self.mid_convs.append(conv)
 
-    def forward(self, x: tt_lib.tensor.Tensor, concat_list: List[tt_lib.tensor.Tensor]) -> tt_lib.tensor.Tensor:
+    def forward(self, x: ttnn.Tensor, concat_list: List[ttnn.Tensor]) -> ttnn.Tensor:
         for i, module in enumerate(self.mid_convs):
             if i == 0:
                 concat_list.append(module(x))

--- a/models/experimental/vovnet/tt/vovnet.py
+++ b/models/experimental/vovnet/tt/vovnet.py
@@ -4,8 +4,7 @@
 
 import torch.nn as nn
 import timm
-
-import tt_lib
+import ttnn
 
 from models.experimental.vovnet.tt.classifier_head import TtClassifierHead
 from models.experimental.vovnet.tt.conv_norm_act import TtConvNormAct
@@ -104,9 +103,7 @@ class TtVoVNet(nn.Module):
 
         stages = []
         for i in range(4):  # num_stages
-            downsample = (
-                stem_stride == 2 or i > 0
-            )  # first stage has no stride/downsample if stem_stride is 4
+            downsample = stem_stride == 2 or i > 0  # first stage has no stride/downsample if stem_stride is 4
             stages += [
                 TtOsaStage(
                     in_chs=in_ch_list[i],
@@ -137,7 +134,7 @@ class TtVoVNet(nn.Module):
             state_dict=self.state_dict,
         )
 
-    def forward(self, x: tt_lib.tensor.Tensor) -> tt_lib.tensor.Tensor:
+    def forward(self, x: ttnn.Tensor) -> ttnn.Tensor:
         x = self.stem(x)
         x = self.stages(x)
         x = self.head(x)


### PR DESCRIPTION
Issue : https://github.com/tenstorrent/tt-metal/issues/11422 Tracking Issue : https://github.com/tenstorrent/tt-metal/issues/11240 , Master Issue : https://github.com/tenstorrent/tt-metal/issues/10532
### Work Done:

- Replace tt_lib usage in `models/experimental/t5`
-  Replace tt_lib usage in `models/experimental/vovnet`

### Checklist
- [x] All Post commit CI 
- [ ]  Nightly Fast Dispatch Test
- [ ] Model regression CI testing passes 

