### PR TITLE
#11422: Replace tt_lib in models/experimental/trocr,vgg,vit

### DIFF
--- a/models/experimental/trocr/demo/gs_demo.py
+++ b/models/experimental/trocr/demo/gs_demo.py
@@ -9,7 +9,7 @@ from loguru import logger
 from transformers import TrOCRProcessor, VisionEncoderDecoderModel
 from torchvision.utils import save_image
 
-import tt_lib
+import ttnn
 
 from models.experimental.trocr.tt.trocr import trocr_causal_llm
 
@@ -19,31 +19,25 @@ from models.experimental.trocr.tt.trocr import trocr_causal_llm
     (("microsoft/trocr-base-handwritten"),),
 )
 def test_gs_demo(model_name):
-    device = tt_lib.device.CreateDevice(0)
+    device = ttnn.open_device(0)
 
-    tt_lib.device.SetDefaultDevice(device)
+    ttnn._ttnn.deprecated.device.SetDefaultDevice(device)
 
     processor = TrOCRProcessor.from_pretrained(model_name)
     model = VisionEncoderDecoderModel.from_pretrained(model_name)
     iam_ocr_sample_input = Image.open("models/sample_data/iam_ocr_image.jpg")
-    pixel_values = processor(
-        images=iam_ocr_sample_input, return_tensors="pt"
-    ).pixel_values
+    pixel_values = processor(images=iam_ocr_sample_input, return_tensors="pt").pixel_values
 
     generationmixin = trocr_causal_llm(device)
     with torch.no_grad():
         torch_generated_ids = model.generate(pixel_values)
         tt_generated_ids = generationmixin.generate(pixel_values)
 
-    torch_generated_text = processor.batch_decode(
-        torch_generated_ids, skip_special_tokens=True
-    )[0]
-    tt_generated_text = processor.batch_decode(
-        tt_generated_ids, skip_special_tokens=True
-    )[0]
+    torch_generated_text = processor.batch_decode(torch_generated_ids, skip_special_tokens=True)[0]
+    tt_generated_text = processor.batch_decode(tt_generated_ids, skip_special_tokens=True)[0]
     save_image(pixel_values, "trocr_input_image.jpg")
     logger.info("Image is saved under trocr_input_image.jpg for reference.")
 
     logger.info("GS's Predicted Output")
     logger.info(tt_generated_text)
-    tt_lib.device.CloseDevice(device)
+    ttnn.close_device(device)

--- a/models/experimental/trocr/tests/test_perf_trocr.py
+++ b/models/experimental/trocr/tests/test_perf_trocr.py
@@ -9,7 +9,6 @@ from loguru import logger
 from PIL import Image
 from transformers import TrOCRProcessor, VisionEncoderDecoderModel
 
-import tt_lib
 from models.utility_functions import (
     disable_persistent_kernel_cache,
     enable_persistent_kernel_cache,

--- a/models/experimental/trocr/tests/test_tt_trocr_attention.py
+++ b/models/experimental/trocr/tests/test_tt_trocr_attention.py
@@ -8,8 +8,6 @@ import pytest
 from loguru import logger
 from transformers import VisionEncoderDecoderModel
 
-import tt_lib
-
 from models.experimental.trocr.tt.trocr_attention import TtTrOCRAttention
 from models.utility_functions import (
     torch_to_tt_tensor_rm,
@@ -25,9 +23,7 @@ from models.utility_functions import (
 )
 def test_trocr_attention_inference(device, pcc, reset_seeds):
     with torch.no_grad():
-        model = VisionEncoderDecoderModel.from_pretrained(
-            "microsoft/trocr-base-handwritten"
-        )
+        model = VisionEncoderDecoderModel.from_pretrained("microsoft/trocr-base-handwritten")
 
         config = model.encoder.config
 

--- a/models/experimental/trocr/tests/test_tt_trocr_causal_llm.py
+++ b/models/experimental/trocr/tests/test_tt_trocr_causal_llm.py
@@ -10,8 +10,6 @@ from PIL import Image
 from transformers import TrOCRProcessor, VisionEncoderDecoderModel
 from transformers import VisionEncoderDecoderModel
 
-import tt_lib
-
 from models.experimental.trocr.trocr_generate_utils import GenerationMixin
 
 
@@ -21,9 +19,7 @@ from models.experimental.trocr.trocr_generate_utils import GenerationMixin
 )
 def test_trocr_causal_llm_inference(device, pcc, reset_seeds):
     with torch.no_grad():
-        model = VisionEncoderDecoderModel.from_pretrained(
-            "microsoft/trocr-base-handwritten"
-        )
+        model = VisionEncoderDecoderModel.from_pretrained("microsoft/trocr-base-handwritten")
         generationmixin = GenerationMixin(
             model=model,
             config=model.decoder.config,
@@ -32,9 +28,7 @@ def test_trocr_causal_llm_inference(device, pcc, reset_seeds):
         )
         processor = TrOCRProcessor.from_pretrained("microsoft/trocr-base-handwritten")
         iam_ocr_sample_input = Image.open("models/sample_data/iam_ocr_image.jpg")
-        pixel_values = processor(
-            images=iam_ocr_sample_input, return_tensors="pt"
-        ).pixel_values
+        pixel_values = processor(images=iam_ocr_sample_input, return_tensors="pt").pixel_values
 
         with torch.no_grad():
             input_ids = generationmixin.generate(pixel_values)

--- a/models/experimental/trocr/tests/test_tt_trocr_decoder.py
+++ b/models/experimental/trocr/tests/test_tt_trocr_decoder.py
@@ -8,8 +8,6 @@ import pytest
 from loguru import logger
 from transformers import VisionEncoderDecoderModel
 
-import tt_lib
-
 from models.experimental.trocr.tt.trocr_decoder import TtTrOCRDecoder
 from models.utility_functions import (
     torch_to_tt_tensor_rm,
@@ -19,16 +17,13 @@ from models.utility_functions import (
 )
 
 
-
 @pytest.mark.parametrize(
     "pcc",
     ((0.66),),
 )
 def test_trocr_decoder_inference(device, pcc, reset_seeds):
     with torch.no_grad():
-        model = VisionEncoderDecoderModel.from_pretrained(
-            "microsoft/trocr-base-handwritten"
-        )
+        model = VisionEncoderDecoderModel.from_pretrained("microsoft/trocr-base-handwritten")
 
         config = model.decoder.config
 

--- a/models/experimental/trocr/tests/test_tt_trocr_decoder_layer.py
+++ b/models/experimental/trocr/tests/test_tt_trocr_decoder_layer.py
@@ -8,8 +8,6 @@ import pytest
 from loguru import logger
 from transformers import VisionEncoderDecoderModel
 
-import tt_lib
-
 from models.experimental.trocr.tt.trocr_decoder_layer import TtTrOCRDecoderLayer
 from models.utility_functions import (
     torch_to_tt_tensor_rm,
@@ -19,16 +17,13 @@ from models.utility_functions import (
 )
 
 
-
 @pytest.mark.parametrize(
     "pcc",
     ((0.99),),
 )
 def test_trocr_decoder_layer_inference(device, pcc, reset_seeds):
     with torch.no_grad():
-        model = VisionEncoderDecoderModel.from_pretrained(
-            "microsoft/trocr-base-handwritten"
-        )
+        model = VisionEncoderDecoderModel.from_pretrained("microsoft/trocr-base-handwritten")
 
         config = model.decoder.config
 

--- a/models/experimental/trocr/tests/test_tt_trocr_embed_tokens.py
+++ b/models/experimental/trocr/tests/test_tt_trocr_embed_tokens.py
@@ -8,7 +8,6 @@ import pytest
 from loguru import logger
 from transformers import VisionEncoderDecoderModel
 
-import tt_lib
 
 from models.experimental.trocr.tt.trocr_embed_tokens import TtTrOCREmbedTokens
 from models.utility_functions import (
@@ -25,9 +24,7 @@ from models.utility_functions import (
 )
 def test_trocr_embed_tokens_inference(device, pcc, reset_seeds):
     with torch.no_grad():
-        model = VisionEncoderDecoderModel.from_pretrained(
-            "microsoft/trocr-base-handwritten"
-        )
+        model = VisionEncoderDecoderModel.from_pretrained("microsoft/trocr-base-handwritten")
 
         config = model.decoder.config
 

--- a/models/experimental/trocr/tests/test_tt_trocr_learned_positional_embeddings.py
+++ b/models/experimental/trocr/tests/test_tt_trocr_learned_positional_embeddings.py
@@ -8,7 +8,6 @@ import pytest
 from loguru import logger
 from transformers import VisionEncoderDecoderModel
 
-import tt_lib
 
 from models.experimental.trocr.tt.trocr_learned_positional_embeddings import TtTrOCRLearnedPositionalEmbedding
 from models.utility_functions import (
@@ -24,9 +23,7 @@ from models.utility_functions import (
 )
 def test_trocr_attention_inference(device, pcc, reset_seeds):
     with torch.no_grad():
-        model = VisionEncoderDecoderModel.from_pretrained(
-            "microsoft/trocr-base-handwritten"
-        )
+        model = VisionEncoderDecoderModel.from_pretrained("microsoft/trocr-base-handwritten")
 
         config = model.decoder.config
 
@@ -65,6 +62,4 @@ def test_trocr_attention_inference(device, pcc, reset_seeds):
         else:
             logger.warning("TrOCRLearnedPositionalEmbeddings Failed!")
 
-        assert (
-            passing
-        ), f"TrOCRLearnedPositionalEmbeddings output does not meet PCC requirement {pcc}."
+        assert passing, f"TrOCRLearnedPositionalEmbeddings output does not meet PCC requirement {pcc}."

--- a/models/experimental/trocr/tt/trocr_attention.py
+++ b/models/experimental/trocr/tt/trocr_attention.py
@@ -8,7 +8,6 @@ import math
 from typing import Optional, Tuple
 
 import ttnn
-import tt_lib
 from tt_lib import fallback_ops
 
 from models.helper_funcs import Linear
@@ -91,20 +90,20 @@ class TtTrOCRAttention(nn.Module):
         )
         self.out_proj = Linear(embed_dim, embed_dim, self.out_proj_weight, self.out_proj_bias)
 
-    def _shape(self, tensor: tt_lib.tensor.Tensor, seq_len: int, bsz: int):
+    def _shape(self, tensor: ttnn.Tensor, seq_len: int, bsz: int):
         tensor = fallback_ops.reshape(tensor, bsz, seq_len, self.num_heads, self.head_dim)
         tensor = ttnn.transpose(tensor, 1, -2)
         return tensor
 
     def forward(
         self,
-        hidden_states: tt_lib.tensor.Tensor,
-        key_value_states: Optional[tt_lib.tensor.Tensor] = None,
-        past_key_value: Optional[Tuple[tt_lib.tensor.Tensor]] = None,
-        attention_mask: Optional[tt_lib.tensor.Tensor] = None,
-        layer_head_mask: Optional[tt_lib.tensor.Tensor] = None,
+        hidden_states: ttnn.Tensor,
+        key_value_states: Optional[ttnn.Tensor] = None,
+        past_key_value: Optional[Tuple[ttnn.Tensor]] = None,
+        attention_mask: Optional[ttnn.Tensor] = None,
+        layer_head_mask: Optional[ttnn.Tensor] = None,
         output_attentions: bool = False,
-    ) -> Tuple[tt_lib.tensor.Tensor, Optional[tt_lib.tensor.Tensor], Optional[Tuple[tt_lib.tensor.Tensor]],]:
+    ) -> Tuple[ttnn.Tensor, Optional[ttnn.Tensor], Optional[Tuple[ttnn.Tensor]],]:
         """Input shape: Batch x Time x Channel"""
 
         # if key_value_states are provided this layer is used as a cross-attention layer

--- a/models/experimental/trocr/tt/trocr_decoder.py
+++ b/models/experimental/trocr/tt/trocr_decoder.py
@@ -10,7 +10,6 @@ from typing import Optional, Tuple
 from dataclasses import dataclass
 
 import ttnn
-import tt_lib
 from tt_lib import fallback_ops
 
 from models.utility_functions import torch_to_tt_tensor_rm, tt_to_torch_tensor
@@ -29,11 +28,11 @@ from models.experimental.trocr.trocr_utils import (
 
 @dataclass
 class TtBaseModelOutputWithPastAndCrossAttentions:
-    last_hidden_state: tt_lib.tensor.Tensor = None
-    past_key_values: Optional[Tuple[Tuple[tt_lib.tensor.Tensor]]] = None
-    hidden_states: Optional[Tuple[tt_lib.tensor.Tensor]] = None
-    attentions: Optional[Tuple[tt_lib.tensor.Tensor]] = None
-    cross_attentions: Optional[Tuple[tt_lib.tensor.Tensor]] = None
+    last_hidden_state: ttnn.Tensor = None
+    past_key_values: Optional[Tuple[Tuple[ttnn.Tensor]]] = None
+    hidden_states: Optional[Tuple[ttnn.Tensor]] = None
+    attentions: Optional[Tuple[ttnn.Tensor]] = None
+    cross_attentions: Optional[Tuple[ttnn.Tensor]] = None
 
 
 class TtTrOCRDecoder(nn.Module):
@@ -136,19 +135,19 @@ class TtTrOCRDecoder(nn.Module):
 
     def forward(
         self,
-        input_ids: Optional[tt_lib.tensor.Tensor] = None,
-        attention_mask: Optional[tt_lib.tensor.Tensor] = None,
-        encoder_hidden_states: Optional[tt_lib.tensor.Tensor] = None,
-        encoder_attention_mask: Optional[tt_lib.tensor.Tensor] = None,
-        head_mask: Optional[tt_lib.tensor.Tensor] = None,
-        cross_attn_head_mask: Optional[tt_lib.tensor.Tensor] = None,
-        past_key_values: Optional[Tuple[Tuple[tt_lib.tensor.Tensor]]] = None,
-        inputs_embeds: Optional[tt_lib.tensor.Tensor] = None,
+        input_ids: Optional[ttnn.Tensor] = None,
+        attention_mask: Optional[ttnn.Tensor] = None,
+        encoder_hidden_states: Optional[ttnn.Tensor] = None,
+        encoder_attention_mask: Optional[ttnn.Tensor] = None,
+        head_mask: Optional[ttnn.Tensor] = None,
+        cross_attn_head_mask: Optional[ttnn.Tensor] = None,
+        past_key_values: Optional[Tuple[Tuple[ttnn.Tensor]]] = None,
+        inputs_embeds: Optional[ttnn.Tensor] = None,
         use_cache: Optional[bool] = None,
         output_attentions: Optional[bool] = None,
         output_hidden_states: Optional[bool] = None,
         return_dict: Optional[bool] = None,
-    ) -> tt_lib.tensor.Tensor:
+    ) -> ttnn.Tensor:
         output_attentions = output_attentions if output_attentions is not None else self.config.output_attentions
         output_hidden_states = (
             output_hidden_states if output_hidden_states is not None else self.config.output_hidden_states

--- a/models/experimental/trocr/tt/trocr_decoder_layer.py
+++ b/models/experimental/trocr/tt/trocr_decoder_layer.py
@@ -6,7 +6,6 @@ import torch.nn as nn
 from typing import Optional, Tuple
 
 import ttnn
-import tt_lib
 from models.utility_functions import torch_to_tt_tensor_rm
 from models.helper_funcs import Linear
 from models.experimental.trocr.tt.trocr_attention import TtTrOCRAttention
@@ -108,16 +107,16 @@ class TtTrOCRDecoderLayer(nn.Module):
 
     def forward(
         self,
-        hidden_states: tt_lib.tensor.Tensor,
-        attention_mask: Optional[tt_lib.tensor.Tensor] = None,
-        encoder_hidden_states: Optional[tt_lib.tensor.Tensor] = None,
-        encoder_attention_mask: Optional[tt_lib.tensor.Tensor] = None,
-        layer_head_mask: Optional[tt_lib.tensor.Tensor] = None,
-        cross_attn_layer_head_mask: Optional[tt_lib.tensor.Tensor] = None,
-        past_key_value: Optional[Tuple[tt_lib.tensor.Tensor]] = None,
+        hidden_states: ttnn.Tensor,
+        attention_mask: Optional[ttnn.Tensor] = None,
+        encoder_hidden_states: Optional[ttnn.Tensor] = None,
+        encoder_attention_mask: Optional[ttnn.Tensor] = None,
+        layer_head_mask: Optional[ttnn.Tensor] = None,
+        cross_attn_layer_head_mask: Optional[ttnn.Tensor] = None,
+        past_key_value: Optional[Tuple[ttnn.Tensor]] = None,
         output_attentions: Optional[bool] = False,
         use_cache: Optional[bool] = True,
-    ) -> tt_lib.tensor.Tensor:
+    ) -> ttnn.Tensor:
         residual = hidden_states
 
         # Self Attention

--- a/models/experimental/trocr/tt/trocr_embed_tokens.py
+++ b/models/experimental/trocr/tt/trocr_embed_tokens.py
@@ -6,7 +6,7 @@ import torch.nn as nn
 
 from models.utility_functions import tt_to_torch_tensor, torch_to_tt_tensor_rm
 from models.experimental.trocr.tt.trocr_configuration import TtTrOCRConfig
-import tt_lib
+import ttnn
 
 
 class TtTrOCREmbedTokens(nn.Module):
@@ -20,11 +20,9 @@ class TtTrOCREmbedTokens(nn.Module):
         super().__init__()
         self.device = device
         weights = state_dict[f"{base_address}.weight"]
-        self.embed_tokens = nn.Embedding(
-            config.vocab_size, config.d_model, padding_idx=1, _weight=weights
-        )
+        self.embed_tokens = nn.Embedding(config.vocab_size, config.d_model, padding_idx=1, _weight=weights)
 
-    def forward(self, input_ids: tt_lib.tensor.Tensor) -> tt_lib.tensor.Tensor:
+    def forward(self, input_ids: ttnn.Tensor) -> ttnn.Tensor:
         input_ids = tt_to_torch_tensor(input_ids).squeeze(0)
         position = self.embed_tokens(input_ids.long())
         position = torch_to_tt_tensor_rm(position, self.device, put_on_device=False)

--- a/models/experimental/trocr/tt/trocr_for_causal_llm.py
+++ b/models/experimental/trocr/tt/trocr_for_causal_llm.py
@@ -9,7 +9,7 @@ import copy
 from typing import Optional, Tuple, Union
 from dataclasses import dataclass
 
-import tt_lib
+import ttnn
 from models.utility_functions import torch_to_tt_tensor_rm
 from models.experimental.trocr.tt.trocr_decoder_wrapper import TtTrOCRDecoderWrapper
 from models.helper_funcs import Linear
@@ -17,12 +17,12 @@ from models.helper_funcs import Linear
 
 @dataclass
 class TtCausalLMOutputWithCrossAttentions(nn.Module):
-    loss: Optional[tt_lib.tensor.Tensor] = None
-    logits: tt_lib.tensor.Tensor = None
-    past_key_values: Optional[Tuple[Tuple[tt_lib.tensor.Tensor]]] = None
-    hidden_states: Optional[Tuple[tt_lib.tensor.Tensor]] = None
-    attentions: Optional[Tuple[tt_lib.tensor.Tensor]] = None
-    cross_attentions: Optional[Tuple[tt_lib.tensor.Tensor]] = None
+    loss: Optional[ttnn.Tensor] = None
+    logits: ttnn.Tensor = None
+    past_key_values: Optional[Tuple[Tuple[ttnn.Tensor]]] = None
+    hidden_states: Optional[Tuple[ttnn.Tensor]] = None
+    attentions: Optional[Tuple[ttnn.Tensor]] = None
+    cross_attentions: Optional[Tuple[ttnn.Tensor]] = None
 
 
 class TtTrOCRForCausalLM(nn.Module):
@@ -39,9 +39,7 @@ class TtTrOCRForCausalLM(nn.Module):
         self.config = config
         self.device = device
         super().__init__()
-        self.model = TtTrOCRDecoderWrapper(
-            config, base_address=base_address, state_dict=state_dict, device=device
-        )
+        self.model = TtTrOCRDecoderWrapper(config, base_address=base_address, state_dict=state_dict, device=device)
 
         self.output_projection_weight = torch_to_tt_tensor_rm(
             state_dict[f"{base_address}.output_projection.weight"],
@@ -56,33 +54,25 @@ class TtTrOCRForCausalLM(nn.Module):
 
     def forward(
         self,
-        input_ids: Optional[tt_lib.tensor.Tensor] = None,
-        attention_mask: Optional[tt_lib.tensor.Tensor] = None,
-        encoder_hidden_states: Optional[tt_lib.tensor.Tensor] = None,
-        encoder_attention_mask: Optional[tt_lib.tensor.Tensor] = None,
-        head_mask: Optional[tt_lib.tensor.Tensor] = None,
-        cross_attn_head_mask: Optional[tt_lib.tensor.Tensor] = None,
-        past_key_values: Optional[Tuple[Tuple[tt_lib.tensor.Tensor]]] = None,
-        inputs_embeds: Optional[tt_lib.tensor.Tensor] = None,
-        labels: Optional[tt_lib.tensor.Tensor] = None,
+        input_ids: Optional[ttnn.Tensor] = None,
+        attention_mask: Optional[ttnn.Tensor] = None,
+        encoder_hidden_states: Optional[ttnn.Tensor] = None,
+        encoder_attention_mask: Optional[ttnn.Tensor] = None,
+        head_mask: Optional[ttnn.Tensor] = None,
+        cross_attn_head_mask: Optional[ttnn.Tensor] = None,
+        past_key_values: Optional[Tuple[Tuple[ttnn.Tensor]]] = None,
+        inputs_embeds: Optional[ttnn.Tensor] = None,
+        labels: Optional[ttnn.Tensor] = None,
         use_cache: Optional[bool] = None,
         output_attentions: Optional[bool] = None,
         output_hidden_states: Optional[bool] = None,
         return_dict: Optional[bool] = None,
     ) -> Union[Tuple, TtCausalLMOutputWithCrossAttentions]:
-        output_attentions = (
-            output_attentions
-            if output_attentions is not None
-            else self.config.output_attentions
-        )
+        output_attentions = output_attentions if output_attentions is not None else self.config.output_attentions
         output_hidden_states = (
-            output_hidden_states
-            if output_hidden_states is not None
-            else self.config.output_hidden_states
+            output_hidden_states if output_hidden_states is not None else self.config.output_hidden_states
         )
-        return_dict = (
-            return_dict if return_dict is not None else self.config.use_return_dict
-        )
+        return_dict = return_dict if return_dict is not None else self.config.use_return_dict
 
         # decoder outputs consists of (dec_features, layer_state, dec_hidden, dec_attn)
         outputs = self.model.decoder(

--- a/models/experimental/trocr/tt/trocr_learned_positional_embeddings.py
+++ b/models/experimental/trocr/tt/trocr_learned_positional_embeddings.py
@@ -5,7 +5,7 @@
 import torch
 import torch.nn as nn
 
-import tt_lib
+import ttnn
 
 
 class TtTrOCRLearnedPositionalEmbedding(nn.Embedding):
@@ -31,7 +31,7 @@ class TtTrOCRLearnedPositionalEmbedding(nn.Embedding):
         self.weights = state_dict[f"{self.base_address}.weight"]
         super().__init__(num_embeddings + self.offset, embedding_dim, _weight=self.weights)
 
-    def forward(self, input_ids: tt_lib.tensor.Tensor, past_key_values_length: int = 0):
+    def forward(self, input_ids: ttnn.Tensor, past_key_values_length: int = 0):
         """`input_ids' shape is expected to be [bsz x seqlen]."""
         bsz, seq_len = input_ids.get_legacy_shape()[2:]
         positions = torch.arange(

--- a/models/experimental/vgg/demo/gs_demo.py
+++ b/models/experimental/vgg/demo/gs_demo.py
@@ -5,7 +5,7 @@
 import os
 import torch
 import pytest
-import tt_lib
+import ttnn
 
 from loguru import logger
 from pathlib import Path
@@ -17,7 +17,7 @@ from models.experimental.vgg.vgg_utils import store_weights, get_tt_cache_path
 
 @pytest.mark.parametrize(
     "dtype",
-    (tt_lib.tensor.DataType.BFLOAT16,),
+    (ttnn.bfloat16,),
 )
 @pytest.mark.parametrize(
     "batch_size",

--- a/models/experimental/vgg/tests/test_perf_vgg.py
+++ b/models/experimental/vgg/tests/test_perf_vgg.py
@@ -9,7 +9,7 @@ from torchvision import models
 from loguru import logger
 
 
-import tt_lib
+import ttnn
 
 from models.experimental.vgg.tt.vgg import *
 from models.utility_functions import (
@@ -48,14 +48,14 @@ def run_perf_vgg(imagenet_sample_input, expected_inference_time, expected_compil
 
         profiler.start(first_key)
         tt_output = tt_vgg(tt_image)
-        tt_lib.device.Synchronize(device)
+        ttnn.synchronize_device(device)
         profiler.end(first_key)
 
         enable_persistent_kernel_cache()
 
         profiler.start(second_key)
         tt_output = tt_vgg(tt_image)
-        tt_lib.device.Synchronize(device)
+        ttnn.synchronize_device(device)
         profiler.end(second_key)
 
     first_iter_time = profiler.get(first_key)

--- a/models/experimental/vgg/tests/test_vgg11.py
+++ b/models/experimental/vgg/tests/test_vgg11.py
@@ -4,7 +4,7 @@
 
 import torch
 import pytest
-import tt_lib
+import ttnn
 
 from torchvision import models
 from loguru import logger
@@ -18,7 +18,7 @@ _batch_size = 1
 
 @pytest.mark.parametrize(
     "dtype",
-    ((tt_lib.tensor.DataType.BFLOAT16),),
+    ((ttnn.bfloat16),),
 )
 @pytest.mark.parametrize(
     "pcc",

--- a/models/experimental/vgg/tests/test_vgg16.py
+++ b/models/experimental/vgg/tests/test_vgg16.py
@@ -4,7 +4,7 @@
 
 import torch
 import pytest
-import tt_lib
+import ttnn
 
 from torchvision import models
 from loguru import logger
@@ -19,7 +19,7 @@ _batch_size = 1
 
 @pytest.mark.parametrize(
     "dtype",
-    ((tt_lib.tensor.DataType.BFLOAT16),),
+    ((ttnn.bfloat16),),
 )
 @pytest.mark.parametrize(
     "pcc",

--- a/models/experimental/vgg/vgg_utils.py
+++ b/models/experimental/vgg/vgg_utils.py
@@ -4,7 +4,7 @@
 
 import os
 import torch
-import tt_lib
+import ttnn
 from tt_lib.utils import pad_weight
 
 from pathlib import Path
@@ -15,17 +15,17 @@ def format_tensor(x, target_layout, device, output_mem_config, pad_value=0.0):
     if x.get_layout() == target_layout:
         return x
 
-    if x.get_layout() == tt_lib.tensor.Layout.ROW_MAJOR and target_layout == tt_lib.tensor.Layout.TILE:
-        x_padded_shape = tt_lib.tensor.pad_to_tile_shape(x.get_legacy_shape(), False, False, True, True)
+    if x.get_layout() == ttnn.ROW_MAJOR_LAYOUT and target_layout == ttnn.TILE_LAYOUT:
+        x_padded_shape = ttnn.experimental.tensor.pad_to_tile_shape(x.get_legacy_shape(), False, False, True, True)
         if x.get_legacy_shape() != x_padded_shape:
-            return tt_lib.tensor.format_input_tensor(
+            return ttnn.experimental.tensor.format_input_tensor(
                 x, device, x_padded_shape, pad_value, target_layout, output_mem_config
             )
         else:
             return ttnn.tilize(x, memory_config=output_mem_config, use_multicore=True)
-    elif x.get_layout() == tt_lib.tensor.Layout.TILE and target_layout == tt_lib.tensor.Layout.ROW_MAJOR:
+    elif x.get_layout() == ttnn.TILE_LAYOUT and target_layout == ttnn.ROW_MAJOR_LAYOUT:
         if x.get_legacy_shape() != x.shape_without_padding():
-            return tt_lib.tensor.format_output_tensor(
+            return ttnn.experimental.tensor.format_output_tensor(
                 x, x.shape_without_padding(), device, target_layout, output_mem_config
             )
         else:
@@ -46,45 +46,45 @@ def cache_weights_in_weka(device, model_location_generator):
         if "classifier" in key:
             if "weight" in key:
                 if "0" in key or "3" in key:
-                    value = tt_lib.tensor.Tensor(
+                    value = ttnn.Tensor(
                         value.reshape(-1).tolist(),
                         value.shape,
-                        tt_lib.tensor.DataType.BFLOAT16,
-                        tt_lib.tensor.Layout.ROW_MAJOR,
-                    ).to(tt_lib.tensor.Layout.TILE)
+                        ttnn.bfloat16,
+                        ttnn.ROW_MAJOR_LAYOUT,
+                    ).to(ttnn.TILE_LAYOUT)
                 else:
                     value = pad_weight(value)
-                    value = tt_lib.tensor.Tensor(
+                    value = ttnn.Tensor(
                         value.reshape(-1).tolist(),
                         value.shape,
-                        tt_lib.tensor.DataType.BFLOAT16,
-                        tt_lib.tensor.Layout.ROW_MAJOR,
-                    ).to(tt_lib.tensor.Layout.TILE)
+                        ttnn.bfloat16,
+                        ttnn.ROW_MAJOR_LAYOUT,
+                    ).to(ttnn.TILE_LAYOUT)
             else:
                 if "0" in key or "3" in key:
-                    value = tt_lib.tensor.Tensor(
+                    value = ttnn.Tensor(
                         value.reshape(-1).tolist(),
                         value.shape,
-                        tt_lib.tensor.DataType.BFLOAT16,
-                        tt_lib.tensor.Layout.ROW_MAJOR,
+                        ttnn.bfloat16,
+                        ttnn.ROW_MAJOR_LAYOUT,
                     )
                 else:
                     extra_zeros = torch.zeros(1, 1, 1, 24)
                     value = torch.cat((value, extra_zeros), dim=-1)
-                    value = tt_lib.tensor.Tensor(
+                    value = ttnn.Tensor(
                         value.reshape(-1).tolist(),
                         value.shape,
-                        tt_lib.tensor.DataType.BFLOAT16,
-                        tt_lib.tensor.Layout.ROW_MAJOR,
+                        ttnn.bfloat16,
+                        ttnn.ROW_MAJOR_LAYOUT,
                     )
         else:
-            value = tt_lib.tensor.Tensor(
+            value = ttnn.Tensor(
                 value.reshape(-1).tolist(),
                 value.shape,
-                tt_lib.tensor.DataType.BFLOAT16,
-                tt_lib.tensor.Layout.ROW_MAJOR,
+                ttnn.bfloat16,
+                ttnn.ROW_MAJOR_LAYOUT,
             )
-        tt_lib.tensor.dump_tensor(file_name + str(key) + ".bin", value)
+        ttnn.experimental.tensor.dump_tensor(file_name + str(key) + ".bin", value)
 
 
 def store_weights(model_version, file_name, dtype, base_addresses):
@@ -104,21 +104,21 @@ def store_weights(model_version, file_name, dtype, base_addresses):
             value = value.unsqueeze(0)
 
         if value.shape[-2] % 32 == 0 and value.shape[-1] % 32 == 0:
-            value = tt_lib.tensor.Tensor(
+            value = ttnn.Tensor(
                 value.reshape(-1).tolist(),
                 value.shape,
                 dtype,
-                tt_lib.tensor.Layout.ROW_MAJOR,
-            ).to(tt_lib.tensor.Layout.TILE)
+                ttnn.ROW_MAJOR_LAYOUT,
+            ).to(ttnn.TILE_LAYOUT)
         else:
-            value = tt_lib.tensor.Tensor(
+            value = ttnn.Tensor(
                 value.reshape(-1).tolist(),
                 value.shape,
                 dtype,
-                tt_lib.tensor.Layout.ROW_MAJOR,
+                ttnn.ROW_MAJOR_LAYOUT,
             )
 
-        tt_lib.tensor.dump_tensor(file_name + str(key) + str(dtype) + ".bin", value)
+        ttnn.experimental.tensor.dump_tensor(file_name + str(key) + str(dtype) + ".bin", value)
 
 
 def get_tt_cache_path(model_version):

--- a/models/experimental/vit/demo/gs_demo.py
+++ b/models/experimental/vit/demo/gs_demo.py
@@ -8,7 +8,7 @@ from loguru import logger
 from PIL import Image
 from transformers import AutoImageProcessor, ViTForImageClassification
 
-import tt_lib
+import ttnn
 
 from models.utility_functions import torch_to_tt_tensor_rm, tt_to_torch_tensor
 from models.experimental.vit.tt.modeling_vit import vit_for_image_classification
@@ -18,19 +18,15 @@ def test_gs_demo():
     image = Image.open("models/sample_data/huggingface_cat_image.jpg")
 
     # Initialize the device
-    device = tt_lib.device.CreateDevice(0)
+    device = ttnn.open_device(0)
 
-    tt_lib.device.SetDefaultDevice(device)
+    ttnn._ttnn.deprecated.device.SetDefaultDevice(device)
 
     image_processor = AutoImageProcessor.from_pretrained("google/vit-base-patch16-224")
-    HF_model = ViTForImageClassification.from_pretrained(
-        "google/vit-base-patch16-224"
-    )  # loaded for the labels
+    HF_model = ViTForImageClassification.from_pretrained("google/vit-base-patch16-224")  # loaded for the labels
     inputs = image_processor(image, return_tensors="pt")
 
-    tt_inputs = torch_to_tt_tensor_rm(
-        inputs["pixel_values"], device, put_on_device=False
-    )
+    tt_inputs = torch_to_tt_tensor_rm(inputs["pixel_values"], device, put_on_device=False)
     tt_model = vit_for_image_classification(device)
 
     with torch.no_grad():

--- a/models/experimental/vit/tests/test_perf_accuracy_vit.py
+++ b/models/experimental/vit/tests/test_perf_accuracy_vit.py
@@ -8,7 +8,7 @@ import pytest
 from loguru import logger
 from transformers import AutoImageProcessor, ViTForImageClassification
 
-import tt_lib
+import ttnn
 
 from models.experimental.vit.tt.modeling_vit import vit_for_image_classification
 from models.utility_functions import (
@@ -48,15 +48,13 @@ def run_perf_vit(
 
     tt_inputs = torch_to_tt_tensor_rm(inputs["pixel_values"], device, put_on_device=False)
 
-    tt_inputs = tt_inputs.to(
-        device, tt_lib.tensor.MemoryConfig(tt_lib.tensor.TensorMemoryLayout.INTERLEAVED, tt_lib.tensor.BufferType.L1)
-    )
+    tt_inputs = tt_inputs.to(device, ttnn.L1_MEMORY_CONFIG)
     tt_model = vit_for_image_classification(device)
 
     with torch.no_grad():
         profiler.start(cpu_key)
         logits = HF_model(**inputs).logits
-        tt_lib.device.Synchronize(device)
+        ttnn.synchronize_device(device)
         profiler.end(cpu_key)
 
         profiler.start(first_key)
@@ -67,7 +65,7 @@ def run_perf_vit(
 
         profiler.start(second_key)
         tt_output = tt_model(tt_inputs)[0]
-        tt_lib.device.Synchronize(device)
+        ttnn.synchronize_device(device)
         profiler.end(second_key)
 
         input_loc = str(model_location_generator("ImageNet_data"))
@@ -81,7 +79,7 @@ def run_perf_vit(
 
             tt_inputs = tt_inputs.to(
                 device,
-                tt_lib.tensor.MemoryConfig(tt_lib.tensor.TensorMemoryLayout.INTERLEAVED, tt_lib.tensor.BufferType.L1),
+                ttnn.L1_MEMORY_CONFIG,
             )
             tt_output = tt_model(tt_inputs)[0]
             tt_output = tt_output.cpu().to_torch().to(torch.float)

--- a/models/experimental/vit/tests/test_vit_attention.py
+++ b/models/experimental/vit/tests/test_vit_attention.py
@@ -9,8 +9,6 @@ import torch
 from loguru import logger
 from transformers import ViTForImageClassification as HF_ViTForImageClassication
 
-import tt_lib
-
 from models.experimental.vit.tt.modeling_vit import TtViTAttention
 from models.utility_functions import (
     torch_to_tt_tensor_rm,

--- a/models/experimental/vit/tests/test_vit_encoder.py
+++ b/models/experimental/vit/tests/test_vit_encoder.py
@@ -10,8 +10,6 @@ from loguru import logger
 from transformers import ViTForImageClassification as HF_ViTForImageClassication
 from transformers import AutoImageProcessor as HF_AutoImageProcessor
 
-import tt_lib
-
 from models.experimental.vit.tt.modeling_vit import TtViTEncoder
 from models.utility_functions import (
     torch_to_tt_tensor_rm,

--- a/models/experimental/vit/tests/test_vit_image_classification.py
+++ b/models/experimental/vit/tests/test_vit_image_classification.py
@@ -9,8 +9,6 @@ from loguru import logger
 from transformers import ViTForImageClassification as HF_ViTForImageClassication
 from transformers import AutoImageProcessor as HF_AutoImageProcessor
 
-import tt_lib
-
 from models.experimental.vit.tt.modeling_vit import TtViTForImageClassification
 from models.utility_functions import (
     torch_to_tt_tensor_rm,

--- a/models/experimental/vit/tests/test_vit_intermediate.py
+++ b/models/experimental/vit/tests/test_vit_intermediate.py
@@ -9,8 +9,6 @@ import torch
 from loguru import logger
 from transformers import ViTForImageClassification as HF_ViTForImageClassication
 
-import tt_lib
-
 from models.experimental.vit.tt.modeling_vit import TtViTIntermediate
 from models.utility_functions import (
     torch_to_tt_tensor_rm,

--- a/models/experimental/vit/tests/test_vit_layer.py
+++ b/models/experimental/vit/tests/test_vit_layer.py
@@ -9,8 +9,6 @@ import torch
 from loguru import logger
 from transformers import ViTForImageClassification as HF_ViTForImageClassication
 
-import tt_lib
-
 from models.experimental.vit.tt.modeling_vit import TtViTLayer
 from models.utility_functions import (
     torch_to_tt_tensor_rm,

--- a/models/experimental/vit/tests/test_vit_model.py
+++ b/models/experimental/vit/tests/test_vit_model.py
@@ -9,8 +9,6 @@ import torch
 from loguru import logger
 from transformers import ViTForImageClassification as HF_ViTForImageClassication
 
-import tt_lib
-
 from models.experimental.vit.tt.modeling_vit import TtViTModel
 from models.utility_functions import (
     torch_to_tt_tensor_rm,

--- a/models/experimental/vit/tests/test_vit_output.py
+++ b/models/experimental/vit/tests/test_vit_output.py
@@ -9,8 +9,6 @@ import torch
 from loguru import logger
 from transformers import ViTForImageClassification as HF_ViTForImageClassication
 
-import tt_lib
-
 from models.experimental.vit.tt.modeling_vit import TtViTOutput
 from models.utility_functions import (
     torch_to_tt_tensor_rm,

--- a/models/experimental/vit/tests/test_vit_selfattention.py
+++ b/models/experimental/vit/tests/test_vit_selfattention.py
@@ -9,7 +9,6 @@ import torch
 from loguru import logger
 from transformers import ViTForImageClassification as HF_ViTForImageClassication
 
-import tt_lib
 
 from models.experimental.vit.tt.modeling_vit import TtViTSelfAttention
 from models.utility_functions import (

--- a/models/experimental/vit/tests/test_vit_selfoutput.py
+++ b/models/experimental/vit/tests/test_vit_selfoutput.py
@@ -9,8 +9,6 @@ import torch
 from loguru import logger
 from transformers import ViTForImageClassification as HF_ViTForImageClassication
 
-import tt_lib
-
 from models.experimental.vit.tt.modeling_vit import TtViTSelfOutput
 from models.utility_functions import (
     torch_to_tt_tensor_rm,

--- a/models/experimental/vit/tt/activations.py
+++ b/models/experimental/vit/tt/activations.py
@@ -18,7 +18,6 @@
 
 from collections import OrderedDict
 
-import tt_lib
 import ttnn
 from torch import nn
 
@@ -27,11 +26,9 @@ class GELUActivation(nn.Module):
     def __init__(self):
         super().__init__()
         self.act = ttnn.gelu
-        self.out_mem_config_l1 = tt_lib.tensor.MemoryConfig(
-            tt_lib.tensor.TensorMemoryLayout.INTERLEAVED, tt_lib.tensor.BufferType.L1
-        )
+        self.out_mem_config_l1 = ttnn.L1_MEMORY_CONFIG
 
-    def forward(self, input: tt_lib.tensor.Tensor) -> tt_lib.tensor.Tensor:
+    def forward(self, input: ttnn.Tensor) -> ttnn.Tensor:
         return self.act(input, memory_config=self.out_mem_config_l1)
 
 

--- a/models/experimental/vit/vit_utils.py
+++ b/models/experimental/vit/vit_utils.py
@@ -4,13 +4,14 @@
 
 from models.helper_funcs import Linear as linear
 from models.utility_functions import torch_to_tt_tensor_rm
-import tt_lib
+import ttnn
+
 
 def make_address(base_address, op_name):
     return op_name if base_address == "" else f"{base_address}.{op_name}"
 
 
-def make_linear(in_feature, out_feature, op_name, state_dict, base_address, device, mem_config=tt_lib.tensor.MemoryConfig(tt_lib.tensor.TensorMemoryLayout.INTERLEAVED, tt_lib.tensor.BufferType.DRAM)):
+def make_linear(in_feature, out_feature, op_name, state_dict, base_address, device, mem_config=ttnn.DRAM_MEMORY_CONFIG):
     q_weight = state_dict[make_address(base_address, f"{op_name}.weight")]
     q_weight = torch_to_tt_tensor_rm(q_weight, device)
     if make_address(base_address, f"{op_name}.bias") in state_dict:


### PR DESCRIPTION
Issue : #11422 Tracking Issue : #11240 , Master Issue : #10532 

### Work Done:

- Replace tt_lib usage in `models/experimental/trocr`
- Replace tt_lib usage in `models/experimental/vgg`
- Replace tt_lib usage in `models/experimental/vit`

### Checklist
- [x] All Post commit CI 
- [ ]  Nightly Fast Dispatch Test
- [ ] Model regression CI testing passes 

