### PR TITLE
llama3: Fuse silu with eltwise mul after FF1

### DIFF
--- a/models/demos/tg/llama3_70b/tt/llama_mlp_galaxy.py
+++ b/models/demos/tg/llama3_70b/tt/llama_mlp_galaxy.py
@@ -237,20 +237,19 @@ class TtLlamaMLP_galaxy:
         )
 
         w1_out = ttnn.to_memory_config(w1_out, self.FULL_GRID_MEMCFG)
-        w1_out = ttnn.silu(w1_out)
-
-        w1_out = ttnn.to_memory_config(w1_out, self.FF2_ACT_MEMCFG)
-        w3_out = ttnn.to_memory_config(w3_out, self.FF2_ACT_MEMCFG)
+        w3_out = ttnn.to_memory_config(w3_out, self.FULL_GRID_MEMCFG)
 
         hidden_states = ttnn.mul(
             w1_out,
             w3_out,
             memory_config=ttnn.L1_WIDTH_SHARDED_MEMORY_CONFIG,
+            input_tensor_a_activation=ttnn.UnaryOpType.SILU,
             dtype=ttnn.bfloat16,
         )
         w1_out.deallocate(True)
         w3_out.deallocate(True)
 
+        hidden_states = ttnn.to_memory_config(hidden_states, self.FF2_ACT_MEMCFG)
         hidden_states = ttnn.matmul(
             hidden_states,
             self.w2,


### PR DESCRIPTION
### Ticket
[Link to Github Issue
](https://github.com/tenstorrent/tt-metal/issues/11062)
### Problem description
Fuse Silu on FF1 output with eltwise_mul
### What's changed
Removed individual Silu Op and fused with eltwise mul.
Perf improved by 4000ns, and helped get rid of Silu Unary Op
### Checklist
- [ ] Post commit CI passes
- [ ] Blackhole Post commit (if applicable)
- [ ] Model regression CI testing passes (if applicable)
- [ ] New/Existing tests provide coverage for changes
