### PR TITLE
#10608: add ham cycle based algo to get ring device ids

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -139,6 +139,7 @@ def pcie_devices(request, device_params):
 
 @pytest.fixture(scope="function")
 def all_devices(request, device_params):
+    # Todo: #11680 remove this fixture
     import tt_lib as ttl
 
     num_devices = ttl.device.GetNumAvailableDevices()
@@ -199,7 +200,7 @@ def device_mesh(request, silicon_arch_name, silicon_arch_wormhole_b0, device_par
     request.node.pci_ids = [ttl.device.GetPCIeDeviceID(i) for i in device_ids[:num_devices_requested]]
 
     device_mesh = ttnn.open_device_mesh(
-        device_grid, device_ids[:num_devices_requested], dispatch_core_type=get_dispatch_core_type(), **device_params
+        device_grid, dispatch_core_type=get_dispatch_core_type(), **device_params
     )
 
     logger.debug(f"multidevice with {device_mesh.get_num_devices()} devices is created")
@@ -227,7 +228,6 @@ def pcie_device_mesh(request, silicon_arch_name, silicon_arch_wormhole_b0, devic
 
     device_mesh = ttnn.open_device_mesh(
         ttnn.DeviceGrid(1, num_pcie_devices_requested),
-        device_ids[:num_pcie_devices_requested],
         dispatch_core_type=get_dispatch_core_type(),
         **device_params,
     )
@@ -249,7 +249,7 @@ def t3k_device_mesh(request, silicon_arch_name, silicon_arch_wormhole_b0, device
 
     if ttnn.get_num_devices() < 8:
         pytest.skip()
-    device_ids = [0, 4, 5, 1, 2, 6, 7, 3]
+    device_ids = ttnn.get_device_ids()
     try:
         num_devices_requested = min(request.param, len(device_ids))
     except (ValueError, AttributeError):
@@ -259,10 +259,10 @@ def t3k_device_mesh(request, silicon_arch_name, silicon_arch_wormhole_b0, device
 
     device_mesh = ttnn.open_device_mesh(
         ttnn.DeviceGrid(1, num_devices_requested),
-        device_ids[:num_devices_requested],
         dispatch_core_type=get_dispatch_core_type(),
         **device_params,
     )
+    device_mesh.reorder_devices_to_ring()
 
     logger.debug(f"multidevice with {device_mesh.get_num_devices()} devices is created")
     yield device_mesh

--- a/tests/ttnn/unit_tests/gtests/test_ccl_on_tg.cpp
+++ b/tests/ttnn/unit_tests/gtests/test_ccl_on_tg.cpp
@@ -26,17 +26,8 @@ TEST(TGTests, TestAllGatherDeadlock) {
     TT_FATAL(num_devices_in_tunnel == 4, "Expected Galaxy to have tunnel depth of 4");
     TT_FATAL(num_mmio_devices * cluster_tunnel_count == 8, "Expected 8 tunnels in a Galaxy");
 
-    std::vector<chip_id_t> all_device_ids = {};
-    for (uint32_t mmio_idx = 0; mmio_idx < num_mmio_devices; mmio_idx++) {
-        auto tunnels_from_mmio = tt::Cluster::instance().get_tunnels_from_mmio_device(mmio_idx);
-        for (uint32_t tunnel_idx = 0; tunnel_idx < tunnels_from_mmio.size(); tunnel_idx++) {
-            auto remote_devices_in_tunnel = tunnels_from_mmio.at(tunnel_idx);
-            all_device_ids.insert(all_device_ids.end(), remote_devices_in_tunnel.begin(), remote_devices_in_tunnel.end());
-        }
-    }
-
     // Create the device mesh: Grid size is <num_tunnels, tunnel_depth>.
-    auto mesh = ttnn::multi_device::open_device_mesh({cluster_tunnel_count * num_mmio_devices, num_devices_in_tunnel}, all_device_ids, 0, 0, 1, DispatchCoreType::WORKER);
+    auto mesh = ttnn::multi_device::open_device_mesh({cluster_tunnel_count * num_mmio_devices, num_devices_in_tunnel}, 0, 0, 1, DispatchCoreType::WORKER);
 
     // Setup input data and output data containers
     MemoryConfig mem_cfg = MemoryConfig{
@@ -117,17 +108,8 @@ TEST(TGTests, TestReduceScatterDeadlock) {
     TT_FATAL(num_devices_in_tunnel == 4, "Expected Galaxy to have tunnel depth of 4");
     TT_FATAL(num_mmio_devices * cluster_tunnel_count == 8, "Expected 8 tunnels in a Galaxy");
 
-    std::vector<chip_id_t> all_device_ids = {};
-    for (uint32_t mmio_idx = 0; mmio_idx < num_mmio_devices; mmio_idx++) {
-        auto tunnels_from_mmio = tt::Cluster::instance().get_tunnels_from_mmio_device(mmio_idx);
-        for (uint32_t tunnel_idx = 0; tunnel_idx < tunnels_from_mmio.size(); tunnel_idx++) {
-            auto remote_devices_in_tunnel = tunnels_from_mmio.at(tunnel_idx);
-            all_device_ids.insert(all_device_ids.end(), remote_devices_in_tunnel.begin(), remote_devices_in_tunnel.end());
-        }
-    }
-
     // Create the device mesh: Grid size is <num_tunnels, tunnel_depth>.
-    auto mesh = ttnn::multi_device::open_device_mesh({cluster_tunnel_count * num_mmio_devices, num_devices_in_tunnel}, all_device_ids, 0, 0, 1, DispatchCoreType::WORKER);
+    auto mesh = ttnn::multi_device::open_device_mesh({cluster_tunnel_count * num_mmio_devices, num_devices_in_tunnel}, 0, 0, 1, DispatchCoreType::WORKER);
     // Create the outer ring on which Reduce Scatter will be run. This allows us to verify that there are no deadlocks when we send CCLs to the
     // first tunnel (forward path).
     std::vector<Device*> ring_devices = mesh.get_devices_on_row(0); // Tunnel 0

--- a/tests/ttnn/unit_tests/gtests/test_multi_device.cpp
+++ b/tests/ttnn/unit_tests/gtests/test_multi_device.cpp
@@ -45,4 +45,15 @@ TEST_F(T3kMultiDeviceFixture, TestGetDistributedTensorConfigFromMultiDeviceStora
     EXPECT_TRUE(std::holds_alternative<ReplicateTensor>(distributed_tensor_config));
 }
 
+TEST_F(T3kMultiDeviceFixture, TestDeviceMeshRingAPI) {
+    DeviceMesh* device_mesh = this->device_mesh_.get();
+    const auto& ring_devices = device_mesh->get_devices_on_ring();
+    // Verify that the first index is mapped to Device with id 0
+    for (int i = 0; i < ring_devices.size(); i++) {
+        int next_device_id = ring_devices[(i + 1) % ring_devices.size()]->id();
+        const auto& connected_chips = ring_devices[i]->get_ethernet_connected_device_ids();
+        EXPECT_TRUE(std::find(connected_chips.begin(), connected_chips.end(), next_device_id) != connected_chips.end());
+    }
+}
+
 }  // namespace ttnn::multi_device::test

--- a/tests/ttnn/unit_tests/gtests/ttnn_test_fixtures.hpp
+++ b/tests/ttnn/unit_tests/gtests/ttnn_test_fixtures.hpp
@@ -67,11 +67,9 @@ class T3kMultiDeviceFixture : public ::testing::Test {
         if (num_devices < 8 or arch != tt::ARCH::WORMHOLE_B0) {
             GTEST_SKIP() << "Skipping T3K Multi-Device test suite on non T3K machine.";
         }
-        const auto T3K_DEVICE_IDS = DeviceIds{0, 4, 5, 1, 2, 6, 7, 3};
         constexpr auto DEFAULT_NUM_COMMAND_QUEUES = 1;
         device_mesh_ = std::make_unique<DeviceMesh>(
             DeviceGrid{1, num_devices},
-            T3K_DEVICE_IDS,
             DEFAULT_L1_SMALL_SIZE,
             DEFAULT_TRACE_REGION_SIZE,
             DEFAULT_NUM_COMMAND_QUEUES,

--- a/tt_metal/impl/device/device_mesh.cpp
+++ b/tt_metal/impl/device/device_mesh.cpp
@@ -9,7 +9,6 @@
 #include "tt_metal/host_api.hpp"
 #include "tt_metal/detail/tt_metal.hpp"
 
-
 namespace tt::tt_metal {
 
 DeviceMesh::DeviceMesh(const DeviceGrid& device_grid, const DeviceIds &device_ids, size_t l1_small_size, size_t trace_region_size, size_t num_command_queues, DispatchCoreType dispatch_core_type)
@@ -117,10 +116,19 @@ std::vector<Device*> DeviceMesh::get_devices_on_column(int col_idx) const {
     return this->view->get_devices_on_column(col_idx);
 }
 
+std::vector<Device*> DeviceMesh::get_devices_on_ring() const {
+    const auto& devices = this->get_devices();
+    TT_ASSERT(not devices.empty(), "No devices in the mesh");
+
+    return this->view->get_devices_on_ring(devices, devices[0]->id(), devices.size());
+}
+
 const DeviceIds DeviceMesh::get_device_ids() const
 {
+    // Return the logical device ids
     DeviceIds device_ids;
     for (const auto& [device_id, device] : mesh_devices) {
+        // device_id is not always equal to device->id()
         device_ids.push_back(device_id);
     }
     return device_ids;
@@ -181,4 +189,4 @@ bool validate_worker_modes(const std::vector<Device*>& workers) {
     return worker_modes_match;
 }
 
-} // namespace tt::tt_metal
+}  // namespace tt::tt_metal

--- a/tt_metal/impl/device/device_mesh.hpp
+++ b/tt_metal/impl/device/device_mesh.hpp
@@ -39,6 +39,7 @@ public:
     Device *get_device(int row_idx, int col_idx) const;
     std::vector<Device *> get_devices_on_row(int row_idx) const;
     std::vector<Device *> get_devices_on_column(int col_idx) const;
+    std::vector<Device *> get_devices_on_ring() const;
 
     const DeviceIds get_device_ids() const;
 

--- a/tt_metal/impl/device/device_mesh.hpp
+++ b/tt_metal/impl/device/device_mesh.hpp
@@ -25,7 +25,8 @@ public:
     std::vector<std::pair<int, Device *>> mesh_devices;
     std::shared_ptr<DeviceMeshView> view;
 
-    DeviceMesh(const DeviceGrid &device_grid, const DeviceIds &device_ids, size_t l1_small_size, size_t trace_region_size, size_t num_command_queues, DispatchCoreType dispatch_core_type);
+    DeviceMesh(
+        const DeviceGrid &device_grid, size_t l1_small_size, size_t trace_region_size, size_t num_command_queues, DispatchCoreType dispatch_core_type);
     ~DeviceMesh();
 
     DeviceMesh(const DeviceMesh &) = delete;
@@ -40,6 +41,8 @@ public:
     std::vector<Device *> get_devices_on_row(int row_idx) const;
     std::vector<Device *> get_devices_on_column(int col_idx) const;
     std::vector<Device *> get_devices_on_ring() const;
+
+    void reorder_devices_to_ring();
 
     const DeviceIds get_device_ids() const;
 

--- a/tt_metal/impl/device/device_mesh_view.hpp
+++ b/tt_metal/impl/device/device_mesh_view.hpp
@@ -81,6 +81,9 @@ public:
     [[nodiscard]] DeviceViews get_row_views() const;
     [[nodiscard]] DeviceViews get_column_views() const;
 
+    [[nodiscard]] DeviceView get_devices_on_ring(
+        std::vector<device_pointer> devices, int start_device_id, int num_devices_in_ring) const;
+
     template<typename Pred>
     [[nodiscard]] DeviceMeshView subview(Pred&& predicate) const;
 

--- a/ttnn/cpp/pybind11/multi_device.hpp
+++ b/ttnn/cpp/pybind11/multi_device.hpp
@@ -19,10 +19,9 @@ namespace multi_device {
 void py_module(py::module& module) {
     py::class_<DeviceMesh>(module, "DeviceMesh")
         .def(
-            py::init<DeviceGrid, std::vector<int>, size_t, size_t, size_t, DispatchCoreType>(),
+            py::init<DeviceGrid, size_t, size_t, size_t, DispatchCoreType>(),
             py::kw_only(),
             py::arg("device_grid"),
-            py::arg("device_ids"),
             py::arg("l1_small_size"),
             py::arg("trace_region_size"),
             py::arg("num_command_queues"),
@@ -64,6 +63,13 @@ void py_module(py::module& module) {
                 List[Device]: The devices on a row in the device mesh.
         )doc")
         .def(
+            "reorder_devices_to_ring",
+            &DeviceMesh::reorder_devices_to_ring,
+            R"doc(
+            Reorder the devices in the device mesh to form a ring.
+
+        )doc")
+        .def(
             "compute_with_storage_grid_size",
             &DeviceMesh::compute_with_storage_grid_size,
             R"doc(
@@ -72,15 +78,19 @@ void py_module(py::module& module) {
             Returns:
                 CoreCoord: The compute grid size of the first device in the device mesh.
         )doc")
-        .def("dram_grid_size", &DeviceMesh::dram_grid_size,
-        R"doc(
+        .def(
+            "dram_grid_size",
+            &DeviceMesh::dram_grid_size,
+            R"doc(
             Get the dram grid size (x, y) of the first device in the device mesh.
 
             Returns:
                 CoreCoord: The dram grid size of the first device in the device mesh.
         )doc")
-        .def("arch", &DeviceMesh::arch,
-        R"doc(
+        .def(
+            "arch",
+            &DeviceMesh::arch,
+            R"doc(
             Get the arch of the first device in the device mesh.
 
             Returns:
@@ -98,7 +108,6 @@ void py_module(py::module& module) {
         &open_device_mesh,
         py::kw_only(),
         py::arg("device_grid"),
-        py::arg("device_ids"),
         py::arg("l1_small_size"),
         py::arg("trace_region_size"),
         py::arg("num_command_queues"),

--- a/ttnn/cpp/ttnn/multi_device.cpp
+++ b/ttnn/cpp/ttnn/multi_device.cpp
@@ -12,8 +12,9 @@
 
 namespace ttnn::multi_device {
 
-DeviceMesh open_device_mesh(const DeviceGrid& device_grid, const DeviceIds& device_ids, size_t l1_small_size, size_t trace_region_size, size_t num_command_queues, DispatchCoreType dispatch_core_type) {
-    return DeviceMesh(device_grid, device_ids, l1_small_size, trace_region_size, num_command_queues, dispatch_core_type);
+DeviceMesh open_device_mesh(
+    const DeviceGrid& device_grid, size_t l1_small_size, size_t trace_region_size, size_t num_command_queues, DispatchCoreType dispatch_core_type) {
+    return DeviceMesh(device_grid, l1_small_size, trace_region_size, num_command_queues, dispatch_core_type);
 }
 
 void close_device_mesh(DeviceMesh &multi_device) {

--- a/ttnn/cpp/ttnn/multi_device.hpp
+++ b/ttnn/cpp/ttnn/multi_device.hpp
@@ -15,7 +15,8 @@ using Device = ttnn::Device;
 namespace ttnn {
 namespace multi_device {
 
-DeviceMesh open_device_mesh(const DeviceGrid& device_grid, const DeviceIds& device_ids, size_t l1_small_size, size_t trace_region_size, size_t num_command_queues, DispatchCoreType dispatch_core_type);
+DeviceMesh open_device_mesh(
+    const DeviceGrid& device_grid, size_t l1_small_size, size_t trace_region_size, size_t num_command_queues, DispatchCoreType dispatch_core_type);
 void close_device_mesh(DeviceMesh &multi_device);
 
 std::vector<ttnn::Tensor> get_device_tensors(const ttnn::Tensor& tensor);

--- a/ttnn/ttnn/multi_device.py
+++ b/ttnn/ttnn/multi_device.py
@@ -133,22 +133,19 @@ def get_device_ids() -> List[int]:
 
 def open_device_mesh(
     device_grid: ttnn.DeviceGrid,
-    device_ids: List[int],
     l1_small_size: int = ttnn._ttnn.deprecated.device.DEFAULT_L1_SMALL_SIZE,
     trace_region_size: int = ttnn._ttnn.deprecated.device.DEFAULT_TRACE_REGION_SIZE,
     num_command_queues: int = 1,
     dispatch_core_type: int = DispatchCoreType.WORKER,
 ):
     """
-    open_device_mesh(device_grid: ttnn.DeviceGrid, device_ids: int) -> ttnn.DeviceMesh:
+    open_device_mesh(device_grid: ttnn.DeviceGrid) -> ttnn.DeviceMesh:
 
     Open a device with the given device_id. If the device is already open, return the existing device.
     """
-    assert len(device_ids) > 0
 
     return ttnn._ttnn.multi_device.DeviceMesh(
         device_grid=device_grid.as_tuple(),
-        device_ids=device_ids,
         l1_small_size=l1_small_size,
         trace_region_size=trace_region_size,
         num_command_queues=num_command_queues,
@@ -168,20 +165,18 @@ def close_device_mesh(device_mesh):
 @contextlib.contextmanager
 def create_device_mesh(
     device_grid: ttnn.DeviceGrid,
-    device_ids: List[int],
     l1_small_size: int = ttnn._ttnn.deprecated.device.DEFAULT_L1_SMALL_SIZE,
     trace_region_size: int = ttnn._ttnn.deprecated.device.DEFAULT_TRACE_REGION_SIZE,
     num_command_queues: int = 1,
     dispatch_core_type: int = DispatchCoreType.WORKER,
 ):
     """
-    create_device_mesh(device_grid: ttnn.DeviceGrid, device_ids: List[int]) -> ttnn.DeviceMesh
+    create_device_mesh(device_grid: ttnn.DeviceGrid) -> ttnn.DeviceMesh
 
     Context manager for opening and closing a device.
     """
     device_mesh = open_device_mesh(
         device_grid=device_grid,
-        device_ids=device_ids,
         l1_small_size=l1_small_size,
         trace_region_size=trace_region_size,
         num_command_queues=num_command_queues,


### PR DESCRIPTION
### Ticket
[Link to Github Issue](https://github.com/tenstorrent/tt-metal/issues/10613)

### Problem description
T3k had hardcoded device ids to find a ring.

### What's changed
Use a DFS based approach to always find the ring of devices.

### Checklist
- [ ] Post commit CI passes
- [ ] Blackhole Post commit (if applicable)
- [ ] Model regression CI testing passes (if applicable)
- [ ] New/Existing tests provide coverage for changes
