### PR TITLE
#11470: Add device generator support for sweep framework

### DIFF
--- a/tests/sweep_framework/README.md
+++ b/tests/sweep_framework/README.md
@@ -173,16 +173,18 @@ def invalidate_vector(test_vector) -> Tuple[bool, Optional[str]]:
 Vectors marked invalid will not be run by the test runner, but it will be recorded that it was skipped due to its invalidity.
 
 ### Device Fixture
-Each op test file can optionally have a `device_fixture` generator which will be picked up by the infra for when a developer wants to use a custom (multi-chip, mesh, or otherwise) device configuration.
+Each op test file can optionally have a `device_mesh_fixture` generator which will be picked up by the infra for when a developer wants to use a custom (multi-chip, mesh, or otherwise) device configuration.
 
-This function should have two stages, setup and teardown of the device. These stages will be executed before, and after the test suite is executed. They are seperated by the yield statement.
+This function should have two stages, setup and teardown of the device. These stages will be executed before, and after the test suite is executed. They are separated by the yield statement.
 
 The `yield` statement in the generator should yield all of the devices at once, if there are multiple. This object will be passed to `run()` when the tests are executed as the `device` parameter.
+
+The `yield` statement must give a tuple of your device object, and a label for this device configuration. See the below example.
 
 #### Example
 
 ```
-def device_fixture() -> (device, device_config_name):
+def device_mesh_fixture():
     # SETUP (called before test suite is executed)
     import tt_lib as ttl
 
@@ -198,8 +200,8 @@ def device_fixture() -> (device, device_config_name):
     print("ADD: Opened device mesh")
     # YIELD to test infrastructure
     # IMPORTANT: Whatever device object(s) you want to pass to your run function need to be ONE object here, as this generator will only be referenced once before executing the tests.
-    # i.e. If you have four seperate devices to use in your test, use 'yield [device1, device2, device3, device4]' inside of a list here.
-    yield (device_mesh, "T3000")
+    # i.e. If you have four separate devices to use in your test, use 'yield ([device1, device2, device3, device4], "4 Device Setup")' inside of a list.
+    yield (device_mesh, "T3000 Mesh")
 
     # TEARDOWN (called after test suite is finished executing)
     print("ADD: Closing device mesh")
@@ -217,7 +219,7 @@ The run function will be called by the test runner with all defined parameters p
 
 This is where to define the test case itself including setup and teardown and golden comparison.
 
-If you defined a `device_fixture` generator, the object you yielded will be passed into this function as `device`. Otherwise, `device` will be the default ttnn device opened by the infra.
+If you defined a `device_mesh_fixture` generator, the object you yielded will be passed into this function as `device`. Otherwise, `device` will be the default ttnn device opened by the infra.
 
 The runner expects one of two returns from the run function:
 

--- a/tests/sweep_framework/README.md
+++ b/tests/sweep_framework/README.md
@@ -182,7 +182,7 @@ The `yield` statement in the generator should yield all of the devices at once, 
 #### Example
 
 ```
-def device_fixture():
+def device_fixture() -> (device, device_config_name):
     # SETUP (called before test suite is executed)
     import tt_lib as ttl
 
@@ -199,7 +199,7 @@ def device_fixture():
     # YIELD to test infrastructure
     # IMPORTANT: Whatever device object(s) you want to pass to your run function need to be ONE object here, as this generator will only be referenced once before executing the tests.
     # i.e. If you have four seperate devices to use in your test, use 'yield [device1, device2, device3, device4]' inside of a list here.
-    yield device_mesh
+    yield (device_mesh, "T3000")
 
     # TEARDOWN (called after test suite is finished executing)
     print("ADD: Closing device mesh")

--- a/tests/sweep_framework/device_fixtures.py
+++ b/tests/sweep_framework/device_fixtures.py
@@ -1,0 +1,14 @@
+# SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
+
+# SPDX-License-Identifier: Apache-2.0
+
+import ttnn
+
+
+def default_device():
+    device = ttnn.open_device(0)
+
+    yield (device, "default")
+
+    ttnn.close_device(device)
+    del device

--- a/tests/sweep_framework/runner.py
+++ b/tests/sweep_framework/runner.py
@@ -38,15 +38,15 @@ def get_username():
 
 def get_devices(test_module):
     try:
-        return test_module.device_fixture()
+        return test_module.device_mesh_fixture()
     except:
         return default_device()
 
 
 def run(test_module, input_queue, output_queue):
-    device_generator, device_name = get_devices(test_module)
-    print(f"SWEEPS: Opening device configuration, {device_name}.")
-    device = next(device_generator)
+    device_generator = get_devices(test_module)
+    device, device_name = next(device_generator)
+    print(f"SWEEPS: Opened device configuration, {device_name}.")
     try:
         while True:
             test_vector = input_queue.get(block=True, timeout=1)
@@ -65,10 +65,10 @@ def run(test_module, input_queue, output_queue):
             output_queue.put([status, message, e2e_perf])
     except Empty as e:
         try:
-            # Run teardown in device_fixture
+            # Run teardown in device_mesh_fixture
             next(device_generator)
         except StopIteration:
-            print("SWEEPS: Closing device configuration.")
+            print(f"SWEEPS: Closed device configuration, {device_name}.")
 
 
 def get_timeout(test_module):

--- a/tests/sweep_framework/sweeps/add.py
+++ b/tests/sweep_framework/sweeps/add.py
@@ -76,7 +76,7 @@ def invalidate_vector(test_vector) -> Tuple[bool, Optional[str]]:
 # This is the run instructions for the test, defined by the developer.
 # The run function must take the above-defined parameters as inputs.
 # The runner will call this run function with each test vector, and the returned results from this function will be stored.
-# If you defined a device_fixture above, the object you yielded will be passed into this function as 'device'. Otherwise, it will be the default ttnn device opened by the infra.
+# If you defined a device_mesh_fixture above, the object you yielded will be passed into this function as 'device'. Otherwise, it will be the default ttnn device opened by the infra.
 def run(
     batch_sizes,
     height,

--- a/tests/sweep_framework/sweeps/add.py
+++ b/tests/sweep_framework/sweeps/add.py
@@ -76,6 +76,7 @@ def invalidate_vector(test_vector) -> Tuple[bool, Optional[str]]:
 # This is the run instructions for the test, defined by the developer.
 # The run function must take the above-defined parameters as inputs.
 # The runner will call this run function with each test vector, and the returned results from this function will be stored.
+# If you defined a device_fixture above, the object you yielded will be passed into this function as 'device'. Otherwise, it will be the default ttnn device opened by the infra.
 def run(
     batch_sizes,
     height,


### PR DESCRIPTION
### Ticket
#11470 

### Problem description
See issue.

### What's changed
Add the ability to define a device_fixture in the op sweep files. 
This means that developers can specify their own device configurations to pass to their tests, instead of the default device from the infra. 

### Checklist
- [ ] Post commit CI passes
- [ ] Blackhole Post commit (if applicable)
- [ ] Model regression CI testing passes (if applicable)
- [ ] New/Existing tests provide coverage for changes
