### PR TITLE
#11487: register sharded_partial with auto launch

### DIFF
--- a/ttnn/cpp/ttnn/operations/data_movement/sharded_partial/interleaved_to_sharded_partial/interleaved_to_sharded_partial.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/sharded_partial/interleaved_to_sharded_partial/interleaved_to_sharded_partial.hpp
@@ -28,5 +28,5 @@ struct InterleavedToShardedPartialOperation {
 
 }  // namespace operations::data_movement
 
-constexpr auto interleaved_to_sharded_partial = ttnn::register_operation<"ttnn::interleaved_to_sharded_partial", ttnn::operations::data_movement::InterleavedToShardedPartialOperation>();
+constexpr auto interleaved_to_sharded_partial = ttnn::register_operation_with_auto_launch_op<"ttnn::interleaved_to_sharded_partial", ttnn::operations::data_movement::InterleavedToShardedPartialOperation>();
 }  // namespace ttnn

--- a/ttnn/cpp/ttnn/operations/data_movement/sharded_partial/sharded_to_interleaved_partial/sharded_to_interleaved_partial.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/sharded_partial/sharded_to_interleaved_partial/sharded_to_interleaved_partial.hpp
@@ -25,6 +25,6 @@ struct ShardedToInterleavedPartialOperation {
 
 }  // namespace operations::data_movement
 
-constexpr auto sharded_to_interleaved_partial = ttnn::register_operation<"ttnn::sharded_to_interleaved_partial", ttnn::operations::data_movement::ShardedToInterleavedPartialOperation>();
+constexpr auto sharded_to_interleaved_partial = ttnn::register_operation_with_auto_launch_op<"ttnn::sharded_to_interleaved_partial", ttnn::operations::data_movement::ShardedToInterleavedPartialOperation>();
 
 }  // namespace ttnn


### PR DESCRIPTION
### Ticket
[Link to Github Issue](https://github.com/tenstorrent/tt-metal/issues/11487)

### Problem description
ND issue in async sharded partial. Used wrong decorator that does not support async.

### What's changed
Used proper async decorator for sharded partial ops

### Checklist
- [ ] Post commit CI passes
- [ ] Blackhole Post commit (if applicable)
- [ ] Model regression CI testing passes (if applicable)
- [ ] New/Existing tests provide coverage for changes
