### PR TITLE
#11483: Bringing program hash computaion to op_profiler

### DIFF
--- a/ttnn/cpp/ttnn/device_operation.hpp
+++ b/ttnn/cpp/ttnn/device_operation.hpp
@@ -312,7 +312,6 @@ void launch_on_worker_thread(auto cq_id, auto operation_id, const auto& operatio
             operation_id,
             device->id(),
             program,
-            program_hash,
             operation_attributes,
             tensor_args,
             tensor_return_value);
@@ -347,7 +346,6 @@ void launch_on_worker_thread(auto cq_id, auto operation_id, const auto& operatio
             operation_id,
             device->id(),
             *program_ptr,
-            program_hash,
             operation_attributes,
             tensor_args,
             tensor_return_value);


### PR DESCRIPTION
### Ticket
[11483](https://github.com/tenstorrent/tt-metal/issues/11483)

### Problem description
Op profiler doesn't see program cache is disabled and fetches wrong op info because sees zero as the hash for every op.

### What's changed

Calculate program hash in op_profiler itself.

### Checklist
- [x] Post commit CI passes : https://github.com/tenstorrent/tt-metal/actions/runs/10395186748
- [x] T3K profiler : https://github.com/tenstorrent/tt-metal/actions/runs/10395181795
- [x] Device perf : https://github.com/tenstorrent/tt-metal/actions/runs/10395184035
