### PR TITLE
#0: Remove non-ethernet dispatch trace tests

### DIFF
--- a/tests/scripts/t3000/run_t3000_frequent_tests.sh
+++ b/tests/scripts/t3000/run_t3000_frequent_tests.sh
@@ -90,7 +90,6 @@ run_t3000_trace_stress_tests() {
   start_time=$(date +%s)
 
   echo "LOG_METAL: Running run_t3000_trace_stress_tests"
-  NUM_TRACE_LOOPS=15 pytest -n auto tests/ttnn/unit_tests/test_multi_device_trace.py ; fail+=$?
   NUM_TRACE_LOOPS=15 WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml pytest -n auto tests/ttnn/unit_tests/test_multi_device_trace.py ; fail+=$?
 
   # Record the end time


### PR DESCRIPTION
### Ticket
Link to Github Issue

### Problem description
Tensix Dispatch with 2 CQs is not supported on the remote chip, causing 2 CQ tests on the frequent pipeline to assert

### What's changed
Similar to what was done in the T3K unit tests, we remove the tensix dispatch based trace tests here, since they're redundant and are breaking pipelines.

### Checklist
- [ ] Post commit CI passes
- [ ] Blackhole Post commit (if applicable)
- [ ] Model regression CI testing passes (if applicable)
- [ ] New/Existing tests provide coverage for changes
