### PR TITLE
Update CMake infra for UMD and run UMD unit tests in post-commit

### DIFF
--- a/.github/workflows/all-post-commit-workflows.yaml
+++ b/.github/workflows/all-post-commit-workflows.yaml
@@ -24,6 +24,21 @@ jobs:
     with:
       tracy: true
     secrets: inherit
+  # UMD Unit Tests
+  umd-unit-tests:
+    secrets: inherit
+    strategy:
+      fail-fast: false
+      matrix:
+        test-group: [
+          { arch: grayskull, runner-label: E150 },
+          { arch: wormhole_b0, runner-label: N150 },
+          { arch: wormhole_b0, runner-label: N300 },
+        ]
+    uses: ./.github/workflows/umd-unit-tests.yaml
+    with:
+      arch: ${{ matrix.test-group.arch }}
+      runner-label: ${{ matrix.test-group.runner-label }}
   # Slow Dispatch Unit Tests
   sd-unit-tests:
     needs: build-artifact
@@ -38,8 +53,8 @@ jobs:
         ]
     uses: ./.github/workflows/build-and-unit-tests.yaml
     with:
-      arch: ${{ matrix.test-group.arch}}
-      runner-label: ${{ matrix.test-group.runner-label}}
+      arch: ${{ matrix.test-group.arch }}
+      runner-label: ${{ matrix.test-group.runner-label }}
   # Fast Dispatch Unit Tests
   fast-dispatch-unit-tests:
     needs: build-artifact
@@ -54,8 +69,8 @@ jobs:
         ]
     uses: ./.github/workflows/fast-dispatch-build-and-unit-tests.yaml
     with:
-      arch: ${{ matrix.test-group.arch}}
-      runner-label: ${{ matrix.test-group.runner-label}}
+      arch: ${{ matrix.test-group.arch }}
+      runner-label: ${{ matrix.test-group.runner-label }}
   # TTNN FD Unit tests
   ttnn-unit-tests:
     needs: build-artifact
@@ -70,8 +85,8 @@ jobs:
         ]
     uses: ./.github/workflows/ttnn-post-commit.yaml
     with:
-      arch: ${{ matrix.test-group.arch}}
-      runner-label: ${{ matrix.test-group.runner-label}}
+      arch: ${{ matrix.test-group.arch }}
+      runner-label: ${{ matrix.test-group.runner-label }}
   # FD Model Tests
   models-unit-tests:
     needs: build-artifact
@@ -86,8 +101,8 @@ jobs:
         ]
     uses: ./.github/workflows/models-post-commit.yaml
     with:
-      arch: ${{ matrix.test-group.arch}}
-      runner-label: ${{ matrix.test-group.runner-label}}
+      arch: ${{ matrix.test-group.arch }}
+      runner-label: ${{ matrix.test-group.runner-label }}
   # FD C++ Unit Tests
   cpp-unit-tests:
     needs: build-artifact
@@ -102,8 +117,8 @@ jobs:
         ]
     uses: ./.github/workflows/cpp-post-commit.yaml
     with:
-      arch: ${{ matrix.test-group.arch}}
-      runner-label: ${{ matrix.test-group.runner-label}}
+      arch: ${{ matrix.test-group.arch }}
+      runner-label: ${{ matrix.test-group.runner-label }}
 
   profiler-regression:
     needs: build-artifact-profiler

--- a/.github/workflows/blackhole-post-commit.yaml
+++ b/.github/workflows/blackhole-post-commit.yaml
@@ -29,6 +29,12 @@ jobs:
 #     with:
 #       profiler-build: true
 #     secrets: inherit
+  umd-unit-tests:
+    secrets: inherit
+    uses: ./.github/workflows/umd-unit-tests.yaml
+    with:
+      arch: blackhole
+      runner-label: BH
   sd-unit-tests:
     needs: build-artifact
     uses: ./.github/workflows/build-and-unit-tests.yaml

--- a/.github/workflows/umd-unit-tests-wrapper.yaml
+++ b/.github/workflows/umd-unit-tests-wrapper.yaml
@@ -1,0 +1,20 @@
+name: "[post-commit] UMD Unit Tests"
+
+on:
+  workflow_dispatch:
+
+jobs:
+  umd-unit-tests:
+    secrets: inherit
+    strategy:
+      fail-fast: false
+      matrix:
+        test-group: [
+          { arch: grayskull, runner-label: E150 },
+          { arch: wormhole_b0, runner-label: N150 },
+          { arch: wormhole_b0, runner-label: N300 },
+        ]
+    uses: ./.github/workflows/umd-unit-tests.yaml
+    with:
+      arch: ${{ matrix.test-group.arch }}
+      runner-label: ${{ matrix.test-group.runner-label }}

--- a/.github/workflows/umd-unit-tests.yaml
+++ b/.github/workflows/umd-unit-tests.yaml
@@ -1,0 +1,59 @@
+name: "[internal] UMD Unit tests"
+
+on:
+  workflow_call:
+    inputs:
+      arch:
+        required: true
+        type: string
+      runner-label:
+        required: true
+        type: string
+      timeout:
+        required: false
+        type: number
+        default: 15
+  workflow_dispatch:
+    inputs:
+      arch:
+        required: true
+        type: choice
+        options:
+          - grayskull
+          - wormhole_b0
+          - blackhole
+      runner-label:
+        required: true
+        type: choice
+        options:
+          - E150
+          - N150
+          - N300
+          - BH
+      timeout:
+        required: false
+        type: number
+        default: 15
+
+jobs:
+  umd-unit-tests:
+    name: ${{ inputs.arch }} ${{ inputs.runner-label }}
+    runs-on:
+      - ${{ inputs.runner-label }}
+      - "in-service"
+    env:
+      TT_METAL_ENV: ${{ vars.TT_METAL_ENV }}
+      ARCH_NAME: ${{ inputs.arch }}
+      LOGURU_LEVEL: INFO
+    steps:
+      - uses: tenstorrent-metal/metal-workflows/.github/actions/checkout-with-submodule-lfs@v2.0.0
+      - name: Set up dynamic env vars for build
+        run: |
+          echo "TT_METAL_HOME=$(pwd)" >> $GITHUB_ENV
+      - name: Build UMD device and tests
+        run: |
+          cmake -B build -G Ninja
+          cmake --build build --target umd_tests
+      - name: Run UMD unit tests
+        timeout-minutes: ${{ inputs.timeout }}
+        run: build/test/umd/${{ inputs.arch }}/unit_tests

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -114,6 +114,9 @@ if (NOT NUMA_LIBRARY)
     message(FATAL_ERROR "NUMA library not found")
 endif()
 
+# Bring in UMD and all it's dependencies
+add_subdirectory(${PROJECT_SOURCE_DIR}/tt_metal/third_party/umd)
+
 ############################################################################################################################
 # Constructing interface libs for common compiler flags, header directories, and libraries
 #   These interface libs are linked with PUBLIC scope at lowest common target (tt_metal/common) and at tt_metal_libs level
@@ -126,7 +129,7 @@ if(CMAKE_CXX_COMPILER_ID MATCHES "Clang")
     if(NOT LIBC++ OR NOT LIBC++ABI)
         message(FATAL_ERROR "libc++ or libc++abi not found. Make sure you have libc++ and libc++abi installed and in your PATH")
     endif()
-    
+
     target_link_libraries(stdlib INTERFACE ${LIBC++} ${LIBC++ABI})
     target_compile_options(stdlib INTERFACE -stdlib=libc++)
 else()
@@ -166,21 +169,21 @@ target_compile_options(compiler_flags INTERFACE -DARCH_${ARCH_NAME_DEF})
 
 add_library(metal_header_directories INTERFACE)
 target_include_directories(metal_header_directories INTERFACE ${PROJECT_SOURCE_DIR}/tt_metal/hw/inc)
-target_include_directories(metal_header_directories SYSTEM INTERFACE ${reflect_SOURCE_DIR} ${flatbuffers_SOURCE_DIR}/include ${nanomsg_SOURCE_DIR}/include)
+target_include_directories(metal_header_directories SYSTEM INTERFACE ${reflect_SOURCE_DIR} ${flatbuffers_include_dir} ${nng_include_dir})
 foreach(lib ${BoostPackages})
     target_include_directories(metal_header_directories INTERFACE ${Boost${lib}_SOURCE_DIR}/include)
 endforeach()
 
 if ("$ENV{ARCH_NAME}" STREQUAL "wormhole_b0")
     target_include_directories(metal_header_directories INTERFACE tt_metal/hw/inc/wormhole
-        tt_metal/hw/inc/wormhole/wormhole_b0_defines
+        ${PROJECT_SOURCE_DIR}/tt_metal/hw/inc/wormhole/wormhole_b0_defines
         ${UMD_HOME}/device/wormhole
         ${UMD_HOME}/src/firmware/riscv/wormhole
     )
 else()
     target_compile_options(compiler_flags INTERFACE -DDISABLE_ISSUE_3487_FIX)
     target_include_directories(metal_header_directories INTERFACE
-        tt_metal/hw/inc/$ENV{ARCH_NAME}
+        ${PROJECT_SOURCE_DIR}/tt_metal/hw/inc/$ENV{ARCH_NAME}
         ${UMD_HOME}/device/$ENV{ARCH_NAME}
         ${UMD_HOME}/src/firmware/riscv/$ENV{ARCH_NAME}
     )
@@ -203,10 +206,6 @@ if(ENABLE_TRACY)
     include(${PROJECT_SOURCE_DIR}/cmake/tracy.cmake)
 endif()
 
-# Build umd_device
-include(${PROJECT_SOURCE_DIR}/cmake/umd_device.cmake)
-
-add_subdirectory(${PROJECT_SOURCE_DIR}/tt_metal/hw)
 add_subdirectory(${PROJECT_SOURCE_DIR}/tt_metal)
 add_subdirectory(${PROJECT_SOURCE_DIR}/ttnn)
 

--- a/cmake/dependencies.cmake
+++ b/cmake/dependencies.cmake
@@ -7,7 +7,6 @@ set(ENV{CPM_SOURCE_CACHE} "${PROJECT_SOURCE_DIR}/.cpmcache")
 
 include(${PROJECT_SOURCE_DIR}/cmake/fetch_boost.cmake)
 
-fetch_boost_library(interprocess)
 fetch_boost_library(smart_ptr)
 
 ############################################################################################################################
@@ -55,39 +54,4 @@ CPMAddPackage(
   NAME reflect
   GITHUB_REPOSITORY boost-ext/reflect
   GIT_TAG v1.1.1
-)
-
-############################################################################################################################
-# Packages needed for tt-metal simulator
-#   NNG for IPC/TCP communication
-#   Google Flatbuffers for serialization
-#   libuv for process mgmt
-############################################################################################################################
-CPMAddPackage(
-  NAME nanomsg
-  GITHUB_REPOSITORY nanomsg/nng
-  GIT_TAG v1.8.0
-  OPTIONS
-      "BUILD_SHARED_LIBS ON"
-      "NNG_TESTS OFF"
-      "NNG_TOOLS OFF"
-)
-CPMAddPackage(
-  NAME flatbuffers
-  GITHUB_REPOSITORY google/flatbuffers
-  GIT_TAG v24.3.25
-  OPTIONS
-      "FLATBUFFERS_BUILD_FLATC OFF"
-      "FLATBUFFERS_BUILD_TESTS OFF"
-      "FLATBUFFERS_INSTALL OFF"
-      "FLATBUFFERS_BUILD_FLATLIB OFF"
-      "FLATBUFFERS_SKIP_MONSTER_EXTRA ON"
-      "FLATBUFFERS_STRICT_MODE ON"
-)
-CPMAddPackage(
-  NAME libuv
-  GITHUB_REPOSITORY libuv/libuv
-  GIT_TAG v1.48.0
-  OPTIONS
-      "LIBUV_BUILD_TESTS OFF"
 )

--- a/tt_metal/CMakeLists.txt
+++ b/tt_metal/CMakeLists.txt
@@ -1,4 +1,6 @@
 
+add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/hw)
+
 add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/common)
 add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/jit_build)
 add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/llrt)
@@ -18,7 +20,7 @@ set(TT_METAL_OBJECTS
 
 add_library(tt_metal ${TT_METAL_OBJECTS})
 
-target_link_libraries(tt_metal PUBLIC umd_device metal_common_libs)
+target_link_libraries(tt_metal PUBLIC metal_header_directories umd_device metal_common_libs)
 
 target_precompile_headers(tt_metal PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}/third_party/magic_enum/magic_enum.hpp
@@ -33,8 +35,7 @@ target_precompile_headers(tt_metal PRIVATE
     <vector>
 )
 
-target_link_libraries(tt_metal PUBLIC compiler_flags linker_flags metal_header_directories $<$<BOOL:${ENABLE_TRACY}>:TracyClient>)  # linker_flags = -rdynamic if tracy enabled
-target_link_directories(tt_metal PUBLIC ${PROJECT_BINARY_DIR}/lib)    # required so tt_metal can find device library
+target_link_libraries(tt_metal PUBLIC compiler_flags linker_flags $<$<BOOL:${ENABLE_TRACY}>:TracyClient>)  # linker_flags = -rdynamic if tracy enabled
 target_include_directories(tt_metal PUBLIC
     ${UMD_HOME}
     ${PROJECT_SOURCE_DIR}


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/11495

### Problem description
As described in issue.

### What's changed
- bump umd for test fixes
- move umd deps from metal `dependencies.cmake` to umd's `dependencies.cmake`, this includes: boost::interprocess, NNG, flatbuffer, libuv
- add umd unit tests pipeline and into post-commit & BH post-commit (takes around ~3-5 mins)

Related UMD PR: https://github.com/tenstorrent/tt-umd/pull/31

### Checklist
- [x] Post commit: https://github.com/tenstorrent/tt-metal/actions/runs/10427592889
- [x] Blackhole post-commit: https://github.com/tenstorrent/tt-metal/actions/runs/10411663526
