### PR TITLE
#0: TG - Frequent tests fix

### DIFF
--- a/tests/ttnn/multichip_unit_tests/test_multidevice_TG.py
+++ b/tests/ttnn/multichip_unit_tests/test_multidevice_TG.py
@@ -377,7 +377,7 @@ def test_galaxy_eltwise_add(M, N, device_mesh):
 
 
 @pytest.mark.parametrize(
-    "mesh_shape, device_mesh", [pytest.param((4, 8), (8, 4), id="8x4_grid")], indirect=["device_mesh"]
+    "mesh_shape, device_mesh", [pytest.param((8, 4), (8, 4), id="8x4_grid")], indirect=["device_mesh"]
 )
 @pytest.mark.parametrize(
     "M, N, head_dim, num_heads",


### PR DESCRIPTION
### Problem description
Galaxy attention matmuls are failing due to incorrect mesh shape.
### What's changed
mesh shape dims are swapped for correct assignment.

### Checklist
- [x] TG Frequent tests: https://github.com/tenstorrent/tt-metal/actions/runs/10401127096
