### PR TITLE
#11519: Restore path reservation for mms and convs

### DIFF
--- a/ttnn/cpp/ttnn/operations/conv/conv2d/device/kernels/reader_conv_activations_2d_mcast_padded_with_halo_3x3_weights.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/device/kernels/reader_conv_activations_2d_mcast_padded_with_halo_3x3_weights.cpp
@@ -210,7 +210,7 @@ void kernel_main() {
             uint32_t tilized_act_start_address = get_read_ptr(tilized_in0_cb_id);
             uint64_t act_multicast_data_addr = act_multicast_noc_addr | get_write_ptr(cb_id_act);
             // num_dests will source, since we are copying to a different local CB as well
-            noc_async_write_multicast_loopback_src(tilized_act_start_address, act_multicast_data_addr, act_mcast_sender_size_bytes, act_mcast_num_cores + 1);
+            noc_async_write_multicast_loopback_src(tilized_act_start_address, act_multicast_data_addr, act_mcast_sender_size_bytes, act_mcast_num_cores + 1, true, true);
 
             // Note: no need for write barrier, since these two multicasts are done on the same noc id, same vc, same cmd_buf
             // Also, this only works because we are setting VCs statically (using NOC_CMD_STATIC_VC).

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/device/kernels/reader_conv_activations_2d_mcast_padded_with_halo_3x3_weights_v2.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/device/kernels/reader_conv_activations_2d_mcast_padded_with_halo_3x3_weights_v2.cpp
@@ -159,13 +159,13 @@ void kernel_main() {
 
                 uint64_t act_multicast_data_addr = act_multicast_noc_addr | get_write_ptr(cb_id_act);
                 // num_dests will source, since we are copying to a different local CB as well
-                noc_async_write_multicast_loopback_src(tilized_act_start_address, act_multicast_data_addr, act_mcast_sender_size_bytes, act_mcast_num_cores + 1, false, false);
+                noc_async_write_multicast_loopback_src(tilized_act_start_address, act_multicast_data_addr, act_mcast_sender_size_bytes, act_mcast_num_cores + 1, true, true);
 
                 // Note: no need for write barrier, since these two multicasts are done on the same noc id, same vc, same cmd_buf
                 // Also, this only works because we are setting VCs statically (using NOC_CMD_STATIC_VC).
 
                 // We should also multicast VALID flag to destinations for receiver semaphore
-                noc_semaphore_set_multicast_loopback_src(act_mcast_sender_semaphore_valid_addr, act_mcast_receiver_semaphore_noc_addr, act_mcast_num_cores + 1, false, false);
+                noc_semaphore_set_multicast_loopback_src(act_mcast_sender_semaphore_valid_addr, act_mcast_receiver_semaphore_noc_addr, act_mcast_num_cores + 1);
 
                 noc_semaphore_wait(act_mcast_receiver_semaphore_addr_ptr, VALID);
             } else {

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/device/kernels/writer_and_mcast_sender_weights_resnet50_first_conv_tiled_out.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/device/kernels/writer_and_mcast_sender_weights_resnet50_first_conv_tiled_out.cpp
@@ -142,7 +142,7 @@ void kernel_main() {
         weights_mcast_dest_noc_end_y,
         weights_start_address);
         // num_dests must not include source, since we are NOT really doing a local copy!
-        noc_async_write_multicast(weights_start_address, weights_multicast_data_addr, weights_block_size_bytes, weights_mcast_num_cores);
+        noc_async_write_multicast(weights_start_address, weights_multicast_data_addr, weights_block_size_bytes, weights_mcast_num_cores, true, true);
 
         // Note: no need for write barrier, since these two multicasts are done on the same noc id, same vc, same cmd_buf
         // Also, this only works because we are setting VCs statically (using NOC_CMD_STATIC_VC).
@@ -198,7 +198,7 @@ void kernel_main() {
         weights_mcast_dest_noc_end_y,
         bias_start_address);
     // num_dests must not include source, since we are NOT really doing a local copy!
-    noc_async_write_multicast(bias_start_address, bias_multicast_data_addr, bias_block_size_bytes, weights_mcast_num_cores);
+    noc_async_write_multicast(bias_start_address, bias_multicast_data_addr, bias_block_size_bytes, weights_mcast_num_cores, true, true);
 
     // Note: no need for write barrier, since these two multicasts are done on the same noc id, same vc, same cmd_buf
     // Also, this only works because we are setting VCs statically (using NOC_CMD_STATIC_VC).

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/device/kernels/writer_mcast_sender_depthwise_conv1d.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/device/kernels/writer_mcast_sender_depthwise_conv1d.cpp
@@ -169,14 +169,14 @@ void kernel_main() {
                         weights_mcast_dest_noc_end_y,
                         weights_start_address);
                         // num_dests must not include source, since we are NOT really doing a local copy!
-                        noc_async_write_multicast(weights_start_address, weights_multicast_data_addr, weights_block_size_bytes, weights_mcast_num_cores, false, false);
+                        noc_async_write_multicast(weights_start_address, weights_multicast_data_addr, weights_block_size_bytes, weights_mcast_num_cores, true, true);
 
                         // Note: no need for write barrier, since these two multicasts are done on the same noc id, same vc, same cmd_buf
                         // Also, this only works because we are setting VCs statically (using NOC_CMD_STATIC_VC).
 
                         // We should also multicast the flag to destinations
                         // num_dests must not include source, since we are NOT really doing a local copy!
-                        noc_semaphore_set_multicast(weights_mcast_receiver_semaphore_addr, weights_mcast_receiver_semaphore_noc_addr, weights_mcast_num_cores, false, false);
+                        noc_semaphore_set_multicast(weights_mcast_receiver_semaphore_addr, weights_mcast_receiver_semaphore_noc_addr, weights_mcast_num_cores);
                         #endif
 
                         weight_current_block_start_tile_id += weight_next_block_stride_h;

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/device/kernels/writer_tiled_out_1d_mcast_sender_conv_weights_tiled_col_to_rm_blocks.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/device/kernels/writer_tiled_out_1d_mcast_sender_conv_weights_tiled_col_to_rm_blocks.cpp
@@ -203,14 +203,14 @@ void kernel_main() {
                         weights_mcast_dest_noc_end_y,
                         weights_start_address);
                         // num_dests must not include source, since we are NOT really doing a local copy!
-                        noc_async_write_multicast(weights_start_address, weights_multicast_data_addr, weights_block_size_bytes, weights_mcast_num_cores, false, false);
+                        noc_async_write_multicast(weights_start_address, weights_multicast_data_addr, weights_block_size_bytes, weights_mcast_num_cores, true, true);
 
                         // Note: no need for write barrier, since these two multicasts are done on the same noc id, same vc, same cmd_buf
                         // Also, this only works because we are setting VCs statically (using NOC_CMD_STATIC_VC).
 
                         // We should also multicast the flag to destinations
                         // num_dests must not include source, since we are NOT really doing a local copy!
-                        noc_semaphore_set_multicast(weights_mcast_receiver_semaphore_addr, weights_mcast_receiver_semaphore_noc_addr, weights_mcast_num_cores, false, false);
+                        noc_semaphore_set_multicast(weights_mcast_receiver_semaphore_addr, weights_mcast_receiver_semaphore_noc_addr, weights_mcast_num_cores);
                         #endif
 
                         weight_current_block_start_tile_id += weight_next_block_stride_h;
@@ -251,14 +251,14 @@ void kernel_main() {
                     weights_mcast_dest_noc_end_y,
                     bias_start_address);
                     // num_dests must not include source, since we are NOT really doing a local copy!
-                    noc_async_write_multicast(bias_start_address, bias_multicast_data_addr, bias_block_size_bytes, weights_mcast_num_cores, false, false);
+                    noc_async_write_multicast(bias_start_address, bias_multicast_data_addr, bias_block_size_bytes, weights_mcast_num_cores, true, true);
 
                     // Note: no need for write barrier, since these two multicasts are done on the same noc id, same vc, same cmd_buf
                     // Also, this only works because we are setting VCs statically (using NOC_CMD_STATIC_VC).
 
                     // We should also multicast the flag to destinations
                     // num_dests must not include source, since we are NOT really doing a local copy!
-                    noc_semaphore_set_multicast(weights_mcast_receiver_semaphore_addr, weights_mcast_receiver_semaphore_noc_addr, weights_mcast_num_cores, false, false);
+                    noc_semaphore_set_multicast(weights_mcast_receiver_semaphore_addr, weights_mcast_receiver_semaphore_noc_addr, weights_mcast_num_cores);
                     #endif
 
                     cb_push_back(bias_cb_id, bias_ntiles);

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/device/kernels/writer_tiled_out_2d_mcast_sender_conv_weights_tiled_col_to_rm_blocks.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/device/kernels/writer_tiled_out_2d_mcast_sender_conv_weights_tiled_col_to_rm_blocks.cpp
@@ -198,14 +198,14 @@ void kernel_main() {
                         weights_mcast_dest_noc_end_y,
                         weights_start_address);
                     // num_dests must not include source, since we are NOT really doing a local copy!
-                    noc_async_write_multicast(weights_start_address, weights_multicast_data_addr, weights_block_size_bytes, weights_mcast_num_cores, false, false);
+                    noc_async_write_multicast(weights_start_address, weights_multicast_data_addr, weights_block_size_bytes, weights_mcast_num_cores, true, true);
 
                     // Note: no need for write barrier, since these two multicasts are done on the same noc id, same vc, same cmd_buf
                     // Also, this only works because we are setting VCs statically (using NOC_CMD_STATIC_VC).
 
                     // We should also multicast the flag to destinations
                     // num_dests must not include source, since we are NOT really doing a local copy!
-                    noc_semaphore_set_multicast(weights_mcast_receiver_semaphore_addr, weights_mcast_receiver_semaphore_noc_addr, weights_mcast_num_cores, false, false);
+                    noc_semaphore_set_multicast(weights_mcast_receiver_semaphore_addr, weights_mcast_receiver_semaphore_noc_addr, weights_mcast_num_cores);
                 #endif
 
                 cb_push_back(cb_id_weight, weight_block_num_tiles);
@@ -243,14 +243,14 @@ void kernel_main() {
                         weights_mcast_dest_noc_end_y,
                         bias_start_address);
                     // num_dests must not include source, since we are NOT really doing a local copy!
-                    noc_async_write_multicast(bias_start_address, bias_multicast_data_addr, bias_block_size_bytes, weights_mcast_num_cores, false, false);
+                    noc_async_write_multicast(bias_start_address, bias_multicast_data_addr, bias_block_size_bytes, weights_mcast_num_cores, true, true);
 
                     // Note: no need for write barrier, since these two multicasts are done on the same noc id, same vc, same cmd_buf
                     // Also, this only works because we are setting VCs statically (using NOC_CMD_STATIC_VC).
 
                     // We should also multicast the flag to destinations
                     // num_dests must not include source, since we are NOT really doing a local copy!
-                    noc_semaphore_set_multicast(weights_mcast_receiver_semaphore_addr, weights_mcast_receiver_semaphore_noc_addr, weights_mcast_num_cores, false, false);
+                    noc_semaphore_set_multicast(weights_mcast_receiver_semaphore_addr, weights_mcast_receiver_semaphore_noc_addr, weights_mcast_num_cores);
                 #endif
 
                 cb_push_back(bias_cb_id, bias_ntiles);

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/device/kernels/writer_tiled_out_mcast_sender_conv_weights_tiled_col_to_rm_blocks.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/device/kernels/writer_tiled_out_mcast_sender_conv_weights_tiled_col_to_rm_blocks.cpp
@@ -204,7 +204,7 @@ void kernel_main() {
                     weights_mcast_dest_noc_end_y,
                     weights_start_address);
                     // num_dests must not include source, since we are NOT really doing a local copy!
-                    noc_async_write_multicast(weights_start_address, weights_multicast_data_addr, weights_block_size_bytes, weights_mcast_num_cores);
+                    noc_async_write_multicast(weights_start_address, weights_multicast_data_addr, weights_block_size_bytes, weights_mcast_num_cores, true, true);
 
                     // Note: no need for write barrier, since these two multicasts are done on the same noc id, same vc, same cmd_buf
                     // Also, this only works because we are setting VCs statically (using NOC_CMD_STATIC_VC).
@@ -252,7 +252,7 @@ void kernel_main() {
                 weights_mcast_dest_noc_end_y,
                 bias_start_address);
                 // num_dests must not include source, since we are NOT really doing a local copy!
-                noc_async_write_multicast(bias_start_address, bias_multicast_data_addr, bias_block_size_bytes, weights_mcast_num_cores);
+                noc_async_write_multicast(bias_start_address, bias_multicast_data_addr, bias_block_size_bytes, weights_mcast_num_cores, true, true);
 
                 // Note: no need for write barrier, since these two multicasts are done on the same noc id, same vc, same cmd_buf
                 // Also, this only works because we are setting VCs statically (using NOC_CMD_STATIC_VC).

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/device/kernels/writer_tiled_out_mcast_sender_conv_weights_tiled_col_to_rm_blocks_num_blocks_weight_h_eq_1.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/device/kernels/writer_tiled_out_mcast_sender_conv_weights_tiled_col_to_rm_blocks_num_blocks_weight_h_eq_1.cpp
@@ -194,7 +194,7 @@ void kernel_main() {
         weights_mcast_dest_noc_end_y,
         weights_start_address);
         // num_dests must not include source, since we are NOT really doing a local copy!
-        noc_async_write_multicast(weights_start_address, weights_multicast_data_addr, weights_block_size_bytes, weights_mcast_num_cores);
+        noc_async_write_multicast(weights_start_address, weights_multicast_data_addr, weights_block_size_bytes, weights_mcast_num_cores, true, true);
 
         // Note: no need for write barrier, since these two multicasts are done on the same noc id, same vc, same cmd_buf
         // Also, this only works because we are setting VCs statically (using NOC_CMD_STATIC_VC).
@@ -238,7 +238,7 @@ void kernel_main() {
             weights_mcast_dest_noc_end_y,
             bias_start_address);
             // num_dests must not include source, since we are NOT really doing a local copy!
-            noc_async_write_multicast(bias_start_address, bias_multicast_data_addr, bias_block_size_bytes, weights_mcast_num_cores);
+            noc_async_write_multicast(bias_start_address, bias_multicast_data_addr, bias_block_size_bytes, weights_mcast_num_cores, true, true);
 
             // Note: no need for write barrier, since these two multicasts are done on the same noc id, same vc, same cmd_buf
             // Also, this only works because we are setting VCs statically (using NOC_CMD_STATIC_VC).

--- a/ttnn/cpp/ttnn/operations/experimental/matmul/group_attn_matmul/device/kernels/dataflow/reader_mcast_transformer_group_attn_matmul.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/matmul/group_attn_matmul/device/kernels/dataflow/reader_mcast_transformer_group_attn_matmul.cpp
@@ -218,13 +218,13 @@ void kernel_main() {
                                 if (mcast_in1_to_local_cb) { // directly mcast data in in1 sharded cb
                                     if (in1_sender_in_receiver_grid) {
                                         // if sender is in receiver grid, num_dests will include source, since we are copying to a different local CB as well
-                                        noc_async_write_multicast_loopback_src(in1_sharded_cb_addr, in1_multicast_data_addr, in1_mcast_sender_size_bytes, in1_mcast_num_cores + 1, true, true);
+                                        noc_async_write_multicast_loopback_src(in1_sharded_cb_addr, in1_multicast_data_addr, in1_mcast_sender_size_bytes, in1_mcast_num_cores + 1);
                                     } else {
                                         // if sender is not in receiver grid, do a regular multicast but from in1_sharded_cb_addr
-                                        noc_async_write_multicast(in1_sharded_cb_addr, in1_multicast_data_addr, in1_mcast_sender_size_bytes, in1_mcast_num_cores, true, true);
+                                        noc_async_write_multicast(in1_sharded_cb_addr, in1_multicast_data_addr, in1_mcast_sender_size_bytes, in1_mcast_num_cores);
                                     }
                                 } else { // mcast from l1_write_addr_in1 which is populated locally by copying from in1 sharded or interleaved
-                                    noc_async_write_multicast(l1_write_addr_in1, in1_multicast_data_addr, in1_mcast_sender_size_bytes, in1_mcast_num_cores, true, true);
+                                    noc_async_write_multicast(l1_write_addr_in1, in1_multicast_data_addr, in1_mcast_sender_size_bytes, in1_mcast_num_cores);
                                 }
 
                                 // Note: no need for write barrier, since these two multicasts are done on the same noc id, same vc, same cmd_buf

--- a/ttnn/cpp/ttnn/operations/experimental/matmul/group_attn_matmul/device/kernels/dataflow/reader_mcast_transformer_group_attn_matmul.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/matmul/group_attn_matmul/device/kernels/dataflow/reader_mcast_transformer_group_attn_matmul.cpp
@@ -218,13 +218,13 @@ void kernel_main() {
                                 if (mcast_in1_to_local_cb) { // directly mcast data in in1 sharded cb
                                     if (in1_sender_in_receiver_grid) {
                                         // if sender is in receiver grid, num_dests will include source, since we are copying to a different local CB as well
-                                        noc_async_write_multicast_loopback_src(in1_sharded_cb_addr, in1_multicast_data_addr, in1_mcast_sender_size_bytes, in1_mcast_num_cores + 1);
+                                        noc_async_write_multicast_loopback_src(in1_sharded_cb_addr, in1_multicast_data_addr, in1_mcast_sender_size_bytes, in1_mcast_num_cores + 1, true, true);
                                     } else {
                                         // if sender is not in receiver grid, do a regular multicast but from in1_sharded_cb_addr
-                                        noc_async_write_multicast(in1_sharded_cb_addr, in1_multicast_data_addr, in1_mcast_sender_size_bytes, in1_mcast_num_cores);
+                                        noc_async_write_multicast(in1_sharded_cb_addr, in1_multicast_data_addr, in1_mcast_sender_size_bytes, in1_mcast_num_cores, true, true);
                                     }
                                 } else { // mcast from l1_write_addr_in1 which is populated locally by copying from in1 sharded or interleaved
-                                    noc_async_write_multicast(l1_write_addr_in1, in1_multicast_data_addr, in1_mcast_sender_size_bytes, in1_mcast_num_cores);
+                                    noc_async_write_multicast(l1_write_addr_in1, in1_multicast_data_addr, in1_mcast_sender_size_bytes, in1_mcast_num_cores, true, true);
                                 }
 
                                 // Note: no need for write barrier, since these two multicasts are done on the same noc id, same vc, same cmd_buf

--- a/ttnn/cpp/ttnn/operations/matmul/device/kernels/dataflow/reader_bmm_tile_layout_in0_sender_dram_sharded.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/kernels/dataflow/reader_bmm_tile_layout_in0_sender_dram_sharded.cpp
@@ -94,15 +94,11 @@ void kernel_main() {
 #ifndef SKIP_MCAST
             // num_dests must not include source, since we are NOT really doing a local copy!
             noc_async_write_multicast(
-                local_read_addr, in0_multicast_data_addr, in0_block_size_bytes, in0_mcast_num_cores, false, false);
+                local_read_addr, in0_multicast_data_addr, in0_block_size_bytes, in0_mcast_num_cores, true, true);
 #endif
 
             noc_semaphore_set_multicast(
-                in0_mcast_receiver_semaphore_addr,
-                in0_mcast_receiver_semaphore_noc_addr,
-                in0_mcast_num_cores,
-                false,
-                false);
+                in0_mcast_receiver_semaphore_addr, in0_mcast_receiver_semaphore_noc_addr, in0_mcast_num_cores);
 
             local_read_addr += in0_block_size_bytes;
         }
@@ -127,14 +123,10 @@ void kernel_main() {
                 uint64_t in0_multicast_data_addr = in0_multicast_data_noc | in0_start_address;
 #ifndef SKIP_MCAST
                 noc_async_write_multicast_loopback_src(
-                    local_read_addr, in0_multicast_data_addr, in0_block_size_bytes, in0_mcast_num_cores, false, false);
+                    local_read_addr, in0_multicast_data_addr, in0_block_size_bytes, in0_mcast_num_cores, true, true);
 #endif
                 noc_semaphore_set_multicast_loopback_src(
-                    in0_mcast_sender_valid_semaphore,
-                    in0_mcast_receiver_semaphore_noc_addr,
-                    in0_mcast_num_cores,
-                    false,
-                    false);
+                    in0_mcast_sender_valid_semaphore, in0_mcast_receiver_semaphore_noc_addr, in0_mcast_num_cores);
 
                 local_read_addr += in0_block_size_bytes;
 

--- a/ttnn/cpp/ttnn/operations/matmul/device/kernels/dataflow/reader_bmm_tile_layout_in0_sender_padding.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/kernels/dataflow/reader_bmm_tile_layout_in0_sender_padding.cpp
@@ -159,7 +159,7 @@ void kernel_main() {
 
             // num_dests must not include source, since we are NOT really doing a local copy!
             noc_async_write_multicast(
-                in0_start_address, in0_multicast_data_addr, in0_block_size_bytes, in0_mcast_num_cores, false, false);
+                in0_start_address, in0_multicast_data_addr, in0_block_size_bytes, in0_mcast_num_cores, true, true);
 
             // Note: no need for write barrier, since these two multicasts are done on the same noc id, same vc, same
             // cmd_buf Also, this only works because we are setting VCs statically (using NOC_CMD_STATIC_VC).
@@ -169,9 +169,7 @@ void kernel_main() {
             noc_semaphore_set_multicast(
                 in0_mcast_receiver_semaphore_addr,
                 in0_mcast_receiver_semaphore_noc_addr,
-                in0_mcast_num_cores,
-                false,
-                false);
+                in0_mcast_num_cores);
 #endif
 
 #ifndef IN0_SHARDED

--- a/ttnn/cpp/ttnn/operations/matmul/device/kernels/dataflow/reader_bmm_tile_layout_in0_sender_padding_block_sharded.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/kernels/dataflow/reader_bmm_tile_layout_in0_sender_padding_block_sharded.cpp
@@ -126,7 +126,7 @@ void kernel_main() {
 
             // num_dests must not include source, since we are NOT really doing a local copy!
             noc_async_write_multicast(
-                in0_start_address, in0_multicast_data_addr, in0_block_size_bytes, in0_mcast_num_cores, false, false);
+                in0_start_address, in0_multicast_data_addr, in0_block_size_bytes, in0_mcast_num_cores, true, true);
 
             // Note: no need for write barrier, since these two multicasts are done on the same noc id, same vc, same
             // cmd_buf Also, this only works because we are setting VCs statically (using NOC_CMD_STATIC_VC).
@@ -134,11 +134,7 @@ void kernel_main() {
             // We should also multicast the flag to destinations
             // num_dests must not include source, since we are NOT really doing a local copy!
             noc_semaphore_set_multicast(
-                in0_mcast_receiver_semaphore_addr,
-                in0_mcast_receiver_semaphore_noc_addr,
-                in0_mcast_num_cores,
-                false,
-                false);
+                in0_mcast_receiver_semaphore_addr, in0_mcast_receiver_semaphore_noc_addr, in0_mcast_num_cores);
 #endif
 
             cb_push_back(cb_id_in0, in0_block_num_tiles);

--- a/ttnn/cpp/ttnn/operations/matmul/device/kernels/dataflow/reader_bmm_tile_layout_in0_sender_receiver_padding_block_sharded.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/kernels/dataflow/reader_bmm_tile_layout_in0_sender_receiver_padding_block_sharded.cpp
@@ -171,9 +171,7 @@ void kernel_main() {
                                 local_read_addr,
                                 in0_multicast_data_addr,
                                 in0_block_size_bytes,
-                                in0_mcast_num_cores - 1,
-                                false,
-                                false);
+                                in0_mcast_num_cores - 1);
                         }
                     }
                     // Mcast from different CB to another CB
@@ -185,8 +183,8 @@ void kernel_main() {
                             in0_multicast_data_addr,
                             in0_block_size_bytes,
                             in0_mcast_num_cores,
-                            false,
-                            false);
+                            true,
+                            true);
                     }
 
                     // We should also multicast the flag to destinations
@@ -199,9 +197,7 @@ void kernel_main() {
                         noc_semaphore_set_multicast_loopback_src(
                             in0_mcast_sender_semaphore_valid_addr,
                             in0_mcast_receiver_semaphore_noc_addr,
-                            in0_mcast_num_cores,
-                            false,
-                            false);
+                            in0_mcast_num_cores);
                     }
                 } else {
                     // If we are not part of receiver grid, always do a regular noc_async_write_multicast to all cores
@@ -211,16 +207,14 @@ void kernel_main() {
                         in0_multicast_data_addr,
                         in0_block_size_bytes,
                         in0_mcast_num_cores,
-                        false,
-                        false);
+                        true,
+                        true);
 
                     // We should also multicast the flag to destinations
                     noc_semaphore_set_multicast(
                         in0_mcast_sender_semaphore_valid_addr,
                         in0_mcast_receiver_semaphore_noc_addr,
-                        in0_mcast_num_cores,
-                        false,
-                        false);
+                        in0_mcast_num_cores);
                 }
                 // Note: no need for write barrier, since these two multicasts are done on the same noc id, same vc,
                 // same cmd_buf Also, this only works because we are setting VCs statically (using NOC_CMD_STATIC_VC).

--- a/ttnn/cpp/ttnn/operations/matmul/device/kernels/dataflow/reader_bmm_tile_layout_in1_sender_writer_padding.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/kernels/dataflow/reader_bmm_tile_layout_in1_sender_writer_padding.cpp
@@ -245,7 +245,7 @@ void kernel_main() {
 
             // num_dests must not include source, since we are NOT really doing a local copy!
             noc_async_write_multicast(
-                in1_start_address, in1_multicast_data_addr, in1_block_size_bytes, in1_mcast_num_cores, false, false);
+                in1_start_address, in1_multicast_data_addr, in1_block_size_bytes, in1_mcast_num_cores, true, true);
 
             // Note: no need for write barrier, since these two multicasts are done on the same noc id, same vc, same
             // cmd_buf Also, this only works because we are setting VCs statically (using NOC_CMD_STATIC_VC).
@@ -255,10 +255,7 @@ void kernel_main() {
             noc_semaphore_set_multicast(
                 in1_mcast_receiver_semaphore_addr,
                 in1_mcast_receiver_semaphore_noc_addr,
-                in1_mcast_num_cores,
-                false,
-                false);
-
+                in1_mcast_num_cores);
 #endif
 
 #ifndef IN1_SHARDED
@@ -329,7 +326,7 @@ void kernel_main() {
 
             // num_dests must not include source, since we are NOT really doing a local copy!
             noc_async_write_multicast(
-                in3_start_address, in3_multicast_data_addr, in3_block_size_bytes, in1_mcast_num_cores, false, false);
+                in3_start_address, in3_multicast_data_addr, in3_block_size_bytes, in1_mcast_num_cores, true, true);
             // Note: no need for write barrier, since these two multicasts are done on the same noc id, same vc, same
             // cmd_buf Also, this only works because we are setting VCs statically (using NOC_CMD_STATIC_VC).
 
@@ -338,10 +335,7 @@ void kernel_main() {
             noc_semaphore_set_multicast(
                 in1_mcast_receiver_semaphore_addr,
                 in1_mcast_receiver_semaphore_noc_addr,
-                in1_mcast_num_cores,
-                false,
-                false);
-
+                in1_mcast_num_cores);
 #endif
 
             cb_push_back(cb_id_in3, in1_block_w);

--- a/ttnn/cpp/ttnn/operations/normalization/layernorm/device/kernels/dataflow/reader_mcast_sender_unary_sharded_ln.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/layernorm/device/kernels/dataflow/reader_mcast_sender_unary_sharded_ln.cpp
@@ -181,8 +181,8 @@ void kernel_main() {
 
                 uint32_t num_tiles_bytes = block == num_all_to_all_workers_first_stage - 1 ? num_tiles_per_worker_last_bytes : num_tiles_per_worker_bytes;
 
-                noc_async_write_multicast(l1_read_addr_ex_global, multicast_data_noc | l1_read_addr_ex_global, num_tiles_bytes, num_blocks-1, false, false);
-                noc_semaphore_set_multicast(reduce_sender_semaphore_addr, reduce_sender_semaphore_noc_addr, num_blocks-1, false, false);
+                noc_async_write_multicast(l1_read_addr_ex_global, multicast_data_noc | l1_read_addr_ex_global, num_tiles_bytes, num_blocks-1, true, true);
+                noc_semaphore_set_multicast(reduce_sender_semaphore_addr, reduce_sender_semaphore_noc_addr, num_blocks-1);
 
                 l1_read_addr_ex_global += num_tiles_bytes;
                 noc_async_write_barrier();


### PR DESCRIPTION
We found out that disable path reservation for noc mcast is not safe even for mm and convs use case where multiple mcast happen at same time but they do not overlap.

Green pipelines:
All post commit
https://github.com/tenstorrent/tt-metal/actions/runs/10409389521

T3000 model perf tests
https://github.com/tenstorrent/tt-metal/actions/runs/10410083918

Red pipelines:
Model perf regressions and output report
https://github.com/tenstorrent/tt-metal/actions/runs/10410076664
I've verified that failing tests (llm javelin) fail locally on main as well.

