### PR TITLE
#4984: Make dispatch use HAL for core types

### DIFF
--- a/tests/tt_metal/tt_metal/perf_microbenchmark/common/util.hpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/common/util.hpp
@@ -19,7 +19,7 @@ inline uint64_t get_t0_to_any_riscfw_end_cycle(tt::tt_metal::Device *device, con
     enum BufferIndex { BUFFER_END_INDEX, DROPPED_MARKER_COUNTER, MARKER_DATA_START };
     enum TimerDataIndex { TIMER_ID, TIMER_VAL_L, TIMER_VAL_H, TIMER_DATA_UINT32_SIZE };
     auto worker_cores_used_in_program =
-        device->worker_cores_from_logical_cores(program.logical_cores()[CoreType::WORKER]);
+        device->worker_cores_from_logical_cores(program.logical_cores()[hal.get_programmable_core_type_index(HalProgrammableCoreType::TENSIX)]);
     auto device_id = device->id();
     uint64_t min_cycle = -1;
     uint64_t max_cycle = 0;

--- a/tests/tt_metal/tt_metal/test_compile_sets_kernel_binaries.cpp
+++ b/tests/tt_metal/tt_metal/test_compile_sets_kernel_binaries.cpp
@@ -14,6 +14,7 @@
 #include "tt_metal/detail/tt_metal.hpp"
 #include "tt_metal/impl/kernels/kernel.hpp"
 #include "tt_metal/impl/device/device_pool.hpp"
+#include "llrt/hal.hpp"
 
 //////////////////////////////////////////////////////////////////////////////////////////
 // TODO: explain what test does
@@ -135,7 +136,8 @@ int main(int argc, char **argv) {
             //                      Compile Application
             ////////////////////////////////////////////////////////////////////////////
             // Check that binary memory objects in the kernel match the ones obtained from the persistent cache
-            const KernelGroup* kernel_group = program.kernels_on_core(core, CoreType::WORKER);
+            uint32_t programmable_core_index = hal.get_programmable_core_type_index(HalProgrammableCoreType::TENSIX);
+            const KernelGroup* kernel_group = program.kernels_on_core(core, programmable_core_index);
             TT_FATAL(
                 kernel_group != nullptr && kernel_group->kernel_ids[DISPATCH_CLASS_TENSIX_COMPUTE].has_value() and
                 kernel_group->kernel_ids[DISPATCH_CLASS_TENSIX_DM0].has_value() and kernel_group->kernel_ids[DISPATCH_CLASS_TENSIX_DM1].has_value());
@@ -175,7 +177,8 @@ int main(int argc, char **argv) {
                     for (int j = 0; j < num_compiles; j++) {
                         uint32_t mask = device->build_key();
                         tt_metal::detail::CompileProgram(device, program);
-                        const KernelGroup* kernel_group = program.kernels_on_core(core, CoreType::WORKER);
+                        uint32_t programmable_core_index = hal.get_programmable_core_type_index(HalProgrammableCoreType::TENSIX);
+                        const KernelGroup* kernel_group = program.kernels_on_core(core, programmable_core_index);
                         auto compute_kernel = tt_metal::detail::GetKernel(program, kernel_group->kernel_ids[DISPATCH_CLASS_TENSIX_COMPUTE].value());
                         auto riscv0_kernel = tt_metal::detail::GetKernel(program, kernel_group->kernel_ids[DISPATCH_CLASS_TENSIX_DM0].value());
                         auto riscv1_kernel = tt_metal::detail::GetKernel(program, kernel_group->kernel_ids[DISPATCH_CLASS_TENSIX_DM1].value());

--- a/tt_metal/detail/tt_metal.hpp
+++ b/tt_metal/detail/tt_metal.hpp
@@ -276,6 +276,5 @@ namespace tt::tt_metal {
         void AllocateBuffer(Buffer* buffer, bool bottom_up);
 
         void DeallocateBuffer(Buffer *buffer);
-
     }
 }

--- a/tt_metal/impl/buffers/semaphore.cpp
+++ b/tt_metal/impl/buffers/semaphore.cpp
@@ -11,7 +11,7 @@ namespace tt_metal {
 Semaphore::Semaphore(const CoreRangeSet &core_range_set, uint32_t id, uint32_t initial_value) :
     core_range_set_(core_range_set), id_(id), initial_value_(initial_value), core_type_(CoreType::WORKER) {}
 
-Semaphore::Semaphore(const CoreRangeSet &core_range_set, uint32_t id, uint32_t initial_value, const CoreType& core_type) :
+Semaphore::Semaphore(const CoreRangeSet &core_range_set, uint32_t id, uint32_t initial_value, CoreType core_type) :
     core_range_set_(core_range_set), id_(id), initial_value_(initial_value), core_type_(core_type) {}
 
 Semaphore::Semaphore(const Semaphore &other) :

--- a/tt_metal/impl/buffers/semaphore.hpp
+++ b/tt_metal/impl/buffers/semaphore.hpp
@@ -4,6 +4,7 @@
 
 #pragma once
 
+#include "llrt/hal.hpp"
 #include "common/core_coord.h"
 #include "hostdevcommon/common_runtime_address_map.h"
 #include "tt_metal/third_party/umd/device/tt_soc_descriptor.h"
@@ -17,7 +18,7 @@ class Semaphore {
    public:
     Semaphore(const CoreRangeSet &core_range_set, uint32_t id, uint32_t initial_value);
 
-    Semaphore(const CoreRangeSet &core_range_set, uint32_t id, uint32_t initial_value, const CoreType& core_type);
+    Semaphore(const CoreRangeSet &core_range_set, uint32_t id, uint32_t initial_value, CoreType core_type);
 
     Semaphore(const Semaphore &other);
 
@@ -46,7 +47,7 @@ class Semaphore {
     CoreRangeSet core_range_set_;             // Ranges of cores where this semaphore is initialized
     uint32_t id_;
     uint32_t initial_value_;              // Initial value of semaphore
-    CoreType core_type_;                       // Type of core. ETH, WORKER.
+    CoreType core_type_;
 };
 
 }  // namespace tt_metal

--- a/tt_metal/impl/dispatch/command_queue.cpp
+++ b/tt_metal/impl/dispatch/command_queue.cpp
@@ -503,9 +503,6 @@ void generate_runtime_args_cmds(
 
 // Generate command sequence for unique (unicast) and common (multicast) runtime args
 void EnqueueProgramCommand::assemble_runtime_args_commands() {
-    // TODO: provide this at a lower level
-    static vector<CoreType> core_types = {CoreType::WORKER, CoreType::ETH};
-
     CoreType dispatch_core_type = dispatch_core_manager::instance().get_dispatch_core_type(this->device->id());
     const uint32_t max_prefetch_command_size = dispatch_constants::get(dispatch_core_type).max_prefetch_command_size();
 
@@ -523,15 +520,15 @@ void EnqueueProgramCommand::assemble_runtime_args_commands() {
     this->cached_program_command_sequences[program.id].runtime_args_command_sequences = {};
 
     uint32_t command_count = 0;
-    for (CoreType core_type : core_types) {
-        for (auto& kg : program.get_kernel_groups(core_type)) {
+    for (uint32_t programmable_core_type_index = 0; programmable_core_type_index < hal.get_programmable_core_type_count(); programmable_core_type_index++) {
+        for (auto& kg : program.get_kernel_groups(programmable_core_type_index)) {
             if (kg.total_rta_size != 0) {
                 // Reserve 2x for unique rtas as we pontentially split the cmds due to not fitting in one prefetch cmd
                 command_count += 2;
             }
         }
         for (int dispatch_class = 0; dispatch_class < DISPATCH_CLASS_MAX; dispatch_class++) {
-            uint32_t common_size = program.get_program_config(core_type).crta_sizes[dispatch_class];
+            uint32_t common_size = program.get_program_config(programmable_core_type_index).crta_sizes[dispatch_class];
             if (common_size != 0) {
                 command_count++;
             }
@@ -540,8 +537,15 @@ void EnqueueProgramCommand::assemble_runtime_args_commands() {
 
     this->cached_program_command_sequences[program.id].runtime_args_command_sequences.reserve(command_count);
     // Unique Runtime Args (Unicast)
-    for (CoreType core_type : core_types) {
-        for (auto& kg : program.get_kernel_groups(core_type)) {
+    for (uint32_t index = 0; index < hal.get_programmable_core_type_count(); index++) {
+        if (hal.get_programmable_core_type(index) == HalProgrammableCoreType::IDLE_ETH) {
+            // Fast dispatch not supported on IDLE_ETH yet
+            // TODO: can't just loop here as code below confuses ACTIVE/IDLE
+            continue;
+        }
+        CoreType core_type = hal.get_core_type(index);
+
+        for (auto& kg : program.get_kernel_groups(index)) {
             if (kg.total_rta_size != 0) {
                 for (const CoreRange& core_range : kg.core_ranges.ranges()) {
                     for (auto x = core_range.start_coord.x; x <= core_range.end_coord.x; x++) {
@@ -574,7 +578,7 @@ void EnqueueProgramCommand::assemble_runtime_args_commands() {
                         }
                     }
                 }
-                uint32_t rta_offset = program.get_program_config(core_type).rta_offset;
+                uint32_t rta_offset = program.get_program_config(index).rta_offset;
                 generate_runtime_args_cmds(
                     this->cached_program_command_sequences[program.id].runtime_args_command_sequences,
                     rta_offset,
@@ -599,7 +603,7 @@ void EnqueueProgramCommand::assemble_runtime_args_commands() {
         }
 
         for (int dispatch_class = 0; dispatch_class < DISPATCH_CLASS_MAX; dispatch_class++) {
-            uint32_t common_size = program.get_program_config(core_type).crta_sizes[dispatch_class];
+            uint32_t common_size = program.get_program_config(index).crta_sizes[dispatch_class];
             for (size_t kernel_id = 0; kernel_id < program.num_kernels(); kernel_id++) {
                 auto kernel = detail::GetKernel(program, kernel_id);
                 if (kernel->get_kernel_core_type() != core_type)
@@ -650,7 +654,7 @@ void EnqueueProgramCommand::assemble_runtime_args_commands() {
             }
 
             if (common_size != 0) {
-                uint32_t crta_offset = program.get_program_config(core_type).crta_offsets[dispatch_class];
+                uint32_t crta_offset = program.get_program_config(index).crta_offsets[dispatch_class];
 
                 // Common rtas are always expected to fit in one prefetch cmd
                 // TODO: use a linear write instead of a packed-write
@@ -974,7 +978,11 @@ void EnqueueProgramCommand::assemble_device_commands(
         constexpr uint32_t go_signal_sizeB = sizeof(launch_msg_t);
         constexpr uint32_t aligned_go_signal_sizeB = align(go_signal_sizeB, L1_ALIGNMENT);
         constexpr uint32_t go_signal_size_words = aligned_go_signal_sizeB / sizeof(uint32_t);
-        for (KernelGroup& kernel_group : program.get_kernel_groups(CoreType::WORKER)) {
+
+        // TODO: eventually the code below could be structured to loop over programmable_indices
+        // and check for mcast/unicast
+        uint32_t programmable_core_index = hal.get_programmable_core_type_index(HalProgrammableCoreType::TENSIX);
+        for (KernelGroup& kernel_group : program.get_kernel_groups(programmable_core_index)) {
             kernel_group.launch_msg.kernel_config.mode = DISPATCH_MODE_DEV;
             kernel_group.launch_msg.kernel_config.dispatch_core_x = this->dispatch_core.x;
             kernel_group.launch_msg.kernel_config.dispatch_core_y = this->dispatch_core.y;
@@ -1003,25 +1011,31 @@ void EnqueueProgramCommand::assemble_device_commands(
                 this->packed_write_max_unicast_sub_cmds,
                 multicast_go_signals_payload);
         }
-        for (KernelGroup& kernel_group : program.get_kernel_groups(CoreType::ETH)) {
-            kernel_group.launch_msg.kernel_config.mode = DISPATCH_MODE_DEV;
-            kernel_group.launch_msg.kernel_config.dispatch_core_x = this->dispatch_core.x;
-            kernel_group.launch_msg.kernel_config.dispatch_core_y = this->dispatch_core.y;
-            kernel_group.launch_msg.kernel_config.kernel_config_base = eth_l1_kernel_config_base;
-            kernel_group.launch_msg.kernel_config.host_assigned_id = program.get_runtime_id();
-            const void* launch_message_data = (const launch_msg_t*)(&kernel_group.launch_msg);
-            for (const CoreRange& core_range : kernel_group.core_ranges.ranges()) {
-                for (auto x = core_range.start_coord.x; x <= core_range.end_coord.x; x++) {
-                    for (auto y = core_range.start_coord.y; y <= core_range.end_coord.y; y++) {
-                        CoreCoord physical_coord =
-                            device->physical_core_from_logical_core(CoreCoord({x, y}), kernel_group.get_core_type());
-                        unicast_go_signal_sub_cmds.emplace_back(CQDispatchWritePackedUnicastSubCmd{
-                            .noc_xy_addr = this->device->get_noc_unicast_encoding(this->noc_index, physical_coord)});
-                        unicast_go_signal_data.emplace_back(launch_message_data, go_signal_sizeB);
+
+        programmable_core_index = hal.get_programmable_core_type_index(HalProgrammableCoreType::ACTIVE_ETH);
+        // TODO: ugly, can be fixed by looping over indices w/ some work
+        if (programmable_core_index != -1) {
+            for (KernelGroup& kernel_group : program.get_kernel_groups(programmable_core_index)) {
+                kernel_group.launch_msg.kernel_config.mode = DISPATCH_MODE_DEV;
+                kernel_group.launch_msg.kernel_config.dispatch_core_x = this->dispatch_core.x;
+                kernel_group.launch_msg.kernel_config.dispatch_core_y = this->dispatch_core.y;
+                kernel_group.launch_msg.kernel_config.kernel_config_base = eth_l1_kernel_config_base;
+                kernel_group.launch_msg.kernel_config.host_assigned_id = program.get_runtime_id();
+                const void* launch_message_data = (const launch_msg_t*)(&kernel_group.launch_msg);
+                for (const CoreRange& core_range : kernel_group.core_ranges.ranges()) {
+                    for (auto x = core_range.start_coord.x; x <= core_range.end_coord.x; x++) {
+                        for (auto y = core_range.start_coord.y; y <= core_range.end_coord.y; y++) {
+                            CoreCoord physical_coord =
+                                device->physical_core_from_logical_core(CoreCoord({x, y}), kernel_group.get_core_type());
+                            unicast_go_signal_sub_cmds.emplace_back(CQDispatchWritePackedUnicastSubCmd{
+                                    .noc_xy_addr = this->device->get_noc_unicast_encoding(this->noc_index, physical_coord)});
+                            unicast_go_signal_data.emplace_back(launch_message_data, go_signal_sizeB);
+                        }
                     }
                 }
             }
         }
+
         if (unicast_go_signal_sub_cmds.size() > 0) {
             cmd_sequence_sizeB += insert_write_packed_payloads<CQDispatchWritePackedUnicastSubCmd>(
                 unicast_go_signal_sub_cmds.size(),
@@ -1234,6 +1248,7 @@ void EnqueueProgramCommand::process() {
     this->manager.get_config_buffer_mgr().free(reservation.first.sync_count);
     this->manager.get_config_buffer_mgr().alloc(
         this->expected_num_workers_completed + program.program_transfer_info.num_active_cores);
+    // TODO: fix hard coded values below
     uint32_t tensix_l1_write_offset = reservation.second[0].addr;
     uint32_t eth_l1_write_offset = reservation.second[1].addr;
 
@@ -1247,8 +1262,9 @@ void EnqueueProgramCommand::process() {
         this->assemble_runtime_args_commands();
 
         // Record kernel groups in this program, only need to do it once.
-        for (CoreType core_type : {CoreType::WORKER, CoreType::ETH}) {
-            RecordKernelGroups(program, core_type, program.get_kernel_groups(core_type));
+        for (uint32_t index = 0; index < hal.get_programmable_core_type_count(); index++) {
+            CoreType core_type = hal.get_core_type(index);
+            RecordKernelGroups(program, core_type, program.get_kernel_groups(index));
         }
     } else {
         static constexpr uint32_t wait_count_offset = (sizeof(CQPrefetchCmd) + offsetof(CQDispatchCmd, wait.count));

--- a/tt_metal/impl/dispatch/worker_config_buffer.cpp
+++ b/tt_metal/impl/dispatch/worker_config_buffer.cpp
@@ -11,33 +11,27 @@ namespace tt_metal {
 
 constexpr uint32_t kernel_config_entry_count = 8;
 
-WorkerConfigBufferMgr::WorkerConfigBufferMgr(const std::vector<uint32_t>& base_addrs, const std::vector<uint32_t>& sizes) {
-
-    size_t num_core_types = sizes.size();
-    TT_ASSERT(base_addrs.size() == sizes.size());
-
-    this->base_addrs_ = base_addrs;
-    this->end_addrs_.resize(num_core_types);
-    for (uint32_t idx = 0; idx < num_core_types; idx++) {
-        this->end_addrs_[idx] = base_addrs[idx] + sizes[idx];
-    }
+WorkerConfigBufferMgr::WorkerConfigBufferMgr() {
 
     entries_.resize(kernel_config_entry_count);
+}
+
+void WorkerConfigBufferMgr::init_add_core(uint32_t base_addr, uint32_t size) {
+
+    this->base_addrs_.push_back(base_addr);
+    this->end_addrs_.push_back(base_addr + size);
+
     for (auto& entry : this->entries_) {
-        entry.resize(num_core_types, {0, 0});
+        entry.push_back({0, 0});
     }
 
     // when free == alloc, buffer is empty
     // entries[alloc_index].addr is always the next address
-    this->alloc_index_.resize(num_core_types);
-    this->free_index_.resize(num_core_types);
-    for (uint32_t idx = 0; idx < num_core_types; idx++) {
-        this->alloc_index_[idx] = 0;
-        this->free_index_[idx] = 0;
-        this->entries_[0][idx].addr = base_addrs[idx];
-    }
+    this->alloc_index_.push_back(0);
+    this->free_index_.push_back(0);
+    this->entries_[0].back().addr = base_addr;
 
-    this->reservation_.resize(num_core_types);
+    this->reservation_.push_back({});
 }
 
 // First part of returned pair is true if reserving size bytes requires a sync on some core type

--- a/tt_metal/impl/dispatch/worker_config_buffer.hpp
+++ b/tt_metal/impl/dispatch/worker_config_buffer.hpp
@@ -34,8 +34,9 @@ struct ConfigBufferSync {
 //
 class WorkerConfigBufferMgr {
   public:
-    WorkerConfigBufferMgr(const std::vector<uint32_t>& base_addrs, const std::vector<uint32_t>& sizes);
+    WorkerConfigBufferMgr();
 
+    void init_add_core(uint32_t base_addr, uint32_t size);
     const std::pair<ConfigBufferSync, std::vector<ConfigBufferEntry>&> reserve(const std::vector<uint32_t>& sizes);
     void free(uint32_t free_up_to_sync_count);
     void alloc(uint32_t when_freeable_sync_count);

--- a/tt_metal/impl/program/program.hpp
+++ b/tt_metal/impl/program/program.hpp
@@ -17,7 +17,7 @@
 namespace tt {
 
 namespace tt_metal {
-    
+
 // Fwd declares
 class Buffer;
 class Kernel;
@@ -28,7 +28,7 @@ class JitBuildOptions;
 class CircularBufferConfig;
 namespace detail{
     void ValidateCircularBufferRegion(const Program &program, const Device *device);
-    KernelHandle AddKernel ( Program & program, std::shared_ptr<Kernel> kernel, const CoreType &core_type);
+    KernelHandle AddKernel (Program &program, std::shared_ptr<Kernel> kernel, const HalProgrammableCoreType core_type);
     std::shared_ptr<Kernel> GetKernel(const Program &program, KernelHandle kernel_id);
     std::shared_ptr<CircularBuffer> GetCircularBuffer(const Program &program, CBHandle id);
     void AddConfigBuffer(Program &program, std::shared_ptr<Buffer> config_buffer);
@@ -37,7 +37,7 @@ namespace detail{
 typedef std::array<std::optional<KernelHandle>, DISPATCH_CLASS_MAX> kernel_id_array_t;
 
 struct KernelGroup {
-    CoreType core_type;
+    uint32_t programmable_core_type_index;
     CoreRangeSet core_ranges;
     kernel_id_array_t kernel_ids;
     uint32_t rta_sizes[DISPATCH_CLASS_MAX];
@@ -47,11 +47,13 @@ struct KernelGroup {
     KernelGroup();
     KernelGroup(
         const Program &program,
-        CoreType core_type,
+        uint32_t programmable_core_type_index,
         kernel_id_array_t kernel_ids,
         bool erisc_is_idle,
         int last_cb_index,
         const CoreRangeSet &new_ranges);
+
+    uint32_t get_programmable_core_type_index() const;
 
     CoreType get_core_type() const;
 };
@@ -85,7 +87,7 @@ class Program {
 
     size_t num_kernels() const {
       size_t count = 0;
-      for (const auto& [core_type, kernels] : kernels_) {
+      for (const auto& kernels : kernels_) {
         count += kernels.size();
       }
       return count;
@@ -95,8 +97,8 @@ class Program {
 
     const std::vector< Semaphore > & semaphores() const { return semaphores_; }
 
-    KernelGroup * kernels_on_core(const CoreCoord &core, const CoreType &core_type);
-    std::vector<KernelGroup>& get_kernel_groups(const CoreType &core_type);
+    KernelGroup * kernels_on_core(const CoreCoord &core, uint32_t programmable_core_type_index);
+    std::vector<KernelGroup>& get_kernel_groups(uint32_t programmable_core_type_index);
     inline void add_buffer(std::shared_ptr<Buffer> buf) { owned_buffer_pool.push_back(buf); }
     inline void release_buffers() { owned_buffer_pool = {}; }
     const std::vector<std::shared_ptr<CircularBuffer>> circular_buffers_on_core(const CoreCoord &core) const;
@@ -117,8 +119,9 @@ class Program {
 
     size_t num_semaphores ( const CoreCoord & core ) const;
     size_t num_semaphores () const;
-    void init_semaphores ( const Device & device, const CoreCoord &logical_core, const CoreType core_type) const;
-    std::unordered_map<CoreType, std::vector<CoreCoord>> logical_cores() const;
+    void init_semaphores ( const Device & device, const CoreCoord &logical_core, CoreType core_type) const;
+    // XXXXX TODO: this should return a const reference
+    std::vector<std::vector<CoreCoord>> logical_cores() const;
 
     // Is worker_crs_ used anywhere?
     const CoreRangeSet& get_worker_core_range_set() const { return worker_crs_; };
@@ -178,8 +181,8 @@ class Program {
     uint64_t id; // Need to make non-const due to move constructor
     uint64_t runtime_id;
     static std::atomic<uint64_t> program_counter;
-    std::unordered_map<CoreType, std::unordered_map<KernelHandle, std::shared_ptr<Kernel> >> kernels_;
-    std::unordered_map<CoreType, CoreCoord> grid_extent_;
+    std::vector<std::unordered_map<KernelHandle, std::shared_ptr<Kernel> >> kernels_;
+    std::vector<CoreCoord> grid_extent_;
 
     std::vector<std::shared_ptr<CircularBuffer>> circular_buffers_;
     std::unordered_map<CBHandle,  std::shared_ptr<CircularBuffer>> circular_buffer_by_id_;
@@ -195,8 +198,8 @@ class Program {
     bool local_circular_buffer_allocation_needed_;
 
     static constexpr uint8_t core_to_kernel_group_invalid_index = 0xff;
-    std::unordered_map<CoreType, std::vector<KernelGroup>> kernel_groups_;
-    std::unordered_map<CoreType, std::vector<uint8_t>> core_to_kernel_group_index_table_;
+    std::vector<std::vector<KernelGroup>> kernel_groups_;
+    std::vector<std::vector<uint8_t>> core_to_kernel_group_index_table_;
     uint32_t tensix_go_signal_count_;
 
     std::vector<std::shared_ptr<Buffer>> config_buffers_;
@@ -208,16 +211,16 @@ class Program {
     friend std::shared_ptr<CircularBuffer> detail::GetCircularBuffer(const Program &program, CBHandle id);
     friend void detail::ValidateCircularBufferRegion(const Program &program, const Device *device);
 
-    friend KernelHandle detail::AddKernel(Program &program, std::shared_ptr<Kernel> kernel, const CoreType &core_type);
+    friend KernelHandle detail::AddKernel(Program &program, std::shared_ptr<Kernel> kernel, const HalProgrammableCoreType core_type);
     friend std::shared_ptr<Kernel> detail::GetKernel(const Program &program, KernelHandle kernel_id);
 
     friend uint32_t CreateSemaphore(Program &program, const std::variant<CoreRange,CoreRangeSet> &core_spec, uint32_t initial_value, CoreType core_type);
-    KernelHandle add_kernel(std::shared_ptr<Kernel> kernel, const CoreType &core_type);
+    KernelHandle add_kernel(std::shared_ptr<Kernel> kernel, const HalProgrammableCoreType &core_type);
 
     CBHandle add_circular_buffer(const CoreRangeSet &core_range_set, const CircularBufferConfig &config);
     std::shared_ptr<CircularBuffer> get_circular_buffer(CBHandle cb_id) const;
 
-    void add_semaphore(const CoreRangeSet & crs, uint32_t semaphore_id, uint32_t init_value, CoreType core_type=CoreType::WORKER);
+    void add_semaphore(const CoreRangeSet & crs, uint32_t semaphore_id, uint32_t init_value, CoreType core_type);
 
     friend void detail::AddConfigBuffer(Program &program, std::shared_ptr<Buffer> config_buffer);
     void add_config_buffer(std::shared_ptr<Buffer> config_buffer);
@@ -227,12 +230,12 @@ class Program {
 
     void set_cb_data_fmt( Device *device, const std::vector<CoreRange> & crs, JitBuildOptions& build_options) const;
 
-    void update_kernel_groups(const CoreType &core_type);
+    void update_kernel_groups(uint32_t programmable_core_type_index);
 
-    ProgramConfig& get_program_config(CoreType core_type);
-    uint32_t& get_program_config_size(CoreType core_type);
+    ProgramConfig& get_program_config(uint32_t programmable_core_type_index);
+    uint32_t& get_program_config_size(uint32_t programmable_core_type_index);
 
-    uint32_t finalize_rt_args(CoreType core_type, uint32_t base_offset);
+    uint32_t finalize_rt_args(uint32_t programmable_core_type_index, uint32_t base_offset);
 
     friend class HWCommandQueue;
     friend class EnqueueProgramCommand;

--- a/tt_metal/llrt/blackhole/bh_hal.cpp
+++ b/tt_metal/llrt/blackhole/bh_hal.cpp
@@ -16,23 +16,14 @@ static inline int hv (enum HalMemAddrType v) {
 
 void Hal::initialize_bh() {
 #if defined(ARCH_BLACKHOLE)
-    constexpr uint32_t num_proc_per_tensix_core = 5;
-    std::vector<DeviceAddr> tensix_mem_map = create_tensix_mem_map();
-    this->core_info_.push_back(
-        {HalProgrammableCoreType::TENSIX, CoreType::WORKER, num_proc_per_tensix_core, tensix_mem_map}
-    );
+    HalCoreInfoType tensix_mem_map = create_tensix_mem_map();
+    this->core_info_.push_back(tensix_mem_map);
 
-    constexpr uint32_t num_proc_per_active_eth_core = 1;
-    std::vector<DeviceAddr> active_eth_mem_map = create_active_eth_mem_map();
-    this->core_info_.push_back(
-        {HalProgrammableCoreType::ACTIVE_ETH, CoreType::ETH, num_proc_per_active_eth_core, active_eth_mem_map}
-    );
+    HalCoreInfoType active_eth_mem_map = create_active_eth_mem_map();
+    this->core_info_.push_back(active_eth_mem_map);
 
-    constexpr uint32_t num_proc_per_idle_eth_core = 1;
-    std::vector<DeviceAddr> idle_eth_mem_map = create_idle_eth_mem_map();
-    this->core_info_.push_back(
-        {HalProgrammableCoreType::IDLE_ETH, CoreType::ETH, num_proc_per_idle_eth_core, idle_eth_mem_map}
-    );
+    HalCoreInfoType idle_eth_mem_map = create_idle_eth_mem_map();
+    this->core_info_.push_back(idle_eth_mem_map);
 #endif
 }
 

--- a/tt_metal/llrt/blackhole/bh_hal.hpp
+++ b/tt_metal/llrt/blackhole/bh_hal.hpp
@@ -10,9 +10,9 @@ namespace tt_metal {
 
 // If you are trying to include this file and you aren't hal...you are doing something wrong
 
-std::vector<DeviceAddr> create_tensix_mem_map();
-std::vector<DeviceAddr> create_active_eth_mem_map();
-std::vector<DeviceAddr> create_idle_eth_mem_map();
+HalCoreInfoType create_tensix_mem_map();
+HalCoreInfoType create_active_eth_mem_map();
+HalCoreInfoType create_idle_eth_mem_map();
 
 }  // namespace tt_metal
 }  // namespace tt

--- a/tt_metal/llrt/blackhole/bh_hal_active_eth_mem_map.cpp
+++ b/tt_metal/llrt/blackhole/bh_hal_active_eth_mem_map.cpp
@@ -7,10 +7,11 @@
 #define COMPILE_FOR_IDLE_ERISC
 
 #include "llrt/hal.hpp"
-#include "llrt/wormhole/wh_hal.hpp"
+#include "llrt/blackhole/bh_hal.hpp"
 #include "hw/inc/blackhole/dev_mem_map.h"
 #include "hw/inc/blackhole/eth_l1_address_map.h"
 #include "hostdevcommon/common_runtime_address_map.h"
+#include "tt_metal/third_party/umd/device/tt_soc_descriptor.h"
 #include "hw/inc/dev_msgs.h"
 
 #define GET_ETH_MAILBOX_ADDRESS_HOST(x) \
@@ -24,18 +25,29 @@ static inline int hv (enum HalMemAddrType v) {
     return static_cast<int>(v);
 }
 
-std::vector<DeviceAddr> create_active_eth_mem_map() {
+HalCoreInfoType create_active_eth_mem_map() {
 
-    std::vector<DeviceAddr> active_eth_mem_map;
-    active_eth_mem_map.resize(hv(HalMemAddrType::COUNT));
-    active_eth_mem_map[hv(HalMemAddrType::BARRIER)] = MEM_L1_BARRIER;
-    active_eth_mem_map[hv(HalMemAddrType::LAUNCH)] = GET_ETH_MAILBOX_ADDRESS_HOST(launch);
-    active_eth_mem_map[hv(HalMemAddrType::WATCHER)] = GET_ETH_MAILBOX_ADDRESS_HOST(watcher);
-    active_eth_mem_map[hv(HalMemAddrType::DPRINT)] = GET_ETH_MAILBOX_ADDRESS_HOST(dprint_buf);
-    active_eth_mem_map[hv(HalMemAddrType::KERNEL_CONFIG_BASE)] = eth_l1_mem::address_map::ERISC_L1_KERNEL_CONFIG_BASE;
-    active_eth_mem_map[hv(HalMemAddrType::UNRESERVED_BASE)] = eth_l1_mem::address_map::ERISC_L1_UNRESERVED_BASE;
+    constexpr uint32_t num_proc_per_idle_eth_core = 1;
 
-    return active_eth_mem_map;
+    std::vector<DeviceAddr> mem_map_bases;
+    mem_map_bases.resize(hv(HalMemAddrType::COUNT));
+    mem_map_bases[hv(HalMemAddrType::BARRIER)] = MEM_L1_BARRIER;
+    mem_map_bases[hv(HalMemAddrType::LAUNCH)] = GET_ETH_MAILBOX_ADDRESS_HOST(launch);
+    mem_map_bases[hv(HalMemAddrType::WATCHER)] = GET_ETH_MAILBOX_ADDRESS_HOST(watcher);
+    mem_map_bases[hv(HalMemAddrType::DPRINT)] = GET_ETH_MAILBOX_ADDRESS_HOST(dprint_buf);
+    mem_map_bases[hv(HalMemAddrType::KERNEL_CONFIG)] = eth_l1_mem::address_map::ERISC_L1_KERNEL_CONFIG_BASE;
+    mem_map_bases[hv(HalMemAddrType::UNRESERVED)] = eth_l1_mem::address_map::ERISC_L1_UNRESERVED_BASE;
+
+    std::vector<uint32_t> mem_map_sizes;
+    mem_map_sizes.resize(hv(HalMemAddrType::COUNT));
+    mem_map_sizes[hv(HalMemAddrType::BARRIER)] = sizeof(uint32_t);
+    mem_map_sizes[hv(HalMemAddrType::LAUNCH)] = sizeof(launch_msg_t);
+    mem_map_sizes[hv(HalMemAddrType::WATCHER)] = sizeof(watcher_msg_t);
+    mem_map_sizes[hv(HalMemAddrType::DPRINT)] = sizeof(dprint_buf_msg_t);
+    mem_map_sizes[hv(HalMemAddrType::KERNEL_CONFIG)] = eth_l1_mem::address_map::ERISC_L1_KERNEL_CONFIG_SIZE;
+    mem_map_sizes[hv(HalMemAddrType::UNRESERVED)] = eth_l1_mem::address_map::MAX_SIZE - eth_l1_mem::address_map::ERISC_L1_UNRESERVED_BASE;
+
+    return {HalProgrammableCoreType::IDLE_ETH, CoreType::ETH, num_proc_per_idle_eth_core, mem_map_bases, mem_map_sizes};
 }
 
 }  // namespace tt_metal

--- a/tt_metal/llrt/blackhole/bh_hal_tensix_mem_map.cpp
+++ b/tt_metal/llrt/blackhole/bh_hal_tensix_mem_map.cpp
@@ -5,10 +5,11 @@
 #if defined(ARCH_BLACKHOLE)
 
 #include "llrt/hal.hpp"
-#include "llrt/wormhole/wh_hal.hpp"
+#include "llrt/blackhole/bh_hal.hpp"
 #include "hw/inc/blackhole/dev_mem_map.h"
 #include "hw/inc/blackhole/eth_l1_address_map.h"  // XXXX FIXME
 #include "hostdevcommon/common_runtime_address_map.h"
+#include "tt_metal/third_party/umd/device/tt_soc_descriptor.h"
 #include "hw/inc/dev_msgs.h"
 
 #define GET_MAILBOX_ADDRESS_HOST(x) ((uint64_t) & (((mailboxes_t *)MEM_MAILBOX_BASE)->x))
@@ -21,18 +22,29 @@ static inline int hv (enum HalMemAddrType v) {
     return static_cast<int>(v);
 }
 
-std::vector<DeviceAddr> create_tensix_mem_map() {
+HalCoreInfoType create_tensix_mem_map() {
 
-    std::vector<DeviceAddr> tensix_mem_map;
-    tensix_mem_map.resize(hv(HalMemAddrType::COUNT));
-    tensix_mem_map[hv(HalMemAddrType::BARRIER)] = MEM_L1_BARRIER;
-    tensix_mem_map[hv(HalMemAddrType::LAUNCH)] = GET_MAILBOX_ADDRESS_HOST(launch);
-    tensix_mem_map[hv(HalMemAddrType::WATCHER)] = GET_MAILBOX_ADDRESS_HOST(watcher);
-    tensix_mem_map[hv(HalMemAddrType::DPRINT)] = GET_MAILBOX_ADDRESS_HOST(dprint_buf);
-    tensix_mem_map[hv(HalMemAddrType::KERNEL_CONFIG_BASE)] = L1_KERNEL_CONFIG_BASE;
-    tensix_mem_map[hv(HalMemAddrType::UNRESERVED_BASE)] = L1_UNRESERVED_BASE;
+    constexpr uint32_t num_proc_per_tensix_core = 5;
 
-    return tensix_mem_map;
+    std::vector<DeviceAddr> mem_map_bases;
+    mem_map_bases.resize(hv(HalMemAddrType::COUNT));
+    mem_map_bases[hv(HalMemAddrType::BARRIER)] = MEM_L1_BARRIER;
+    mem_map_bases[hv(HalMemAddrType::LAUNCH)] = GET_MAILBOX_ADDRESS_HOST(launch);
+    mem_map_bases[hv(HalMemAddrType::WATCHER)] = GET_MAILBOX_ADDRESS_HOST(watcher);
+    mem_map_bases[hv(HalMemAddrType::DPRINT)] = GET_MAILBOX_ADDRESS_HOST(dprint_buf);
+    mem_map_bases[hv(HalMemAddrType::KERNEL_CONFIG)] = L1_KERNEL_CONFIG_BASE;
+    mem_map_bases[hv(HalMemAddrType::UNRESERVED)] = L1_UNRESERVED_BASE;
+
+    std::vector<uint32_t> mem_map_sizes;
+    mem_map_sizes.resize(hv(HalMemAddrType::COUNT));
+    mem_map_sizes[hv(HalMemAddrType::BARRIER)] = sizeof(uint32_t);
+    mem_map_sizes[hv(HalMemAddrType::LAUNCH)] = sizeof(launch_msg_t);
+    mem_map_sizes[hv(HalMemAddrType::WATCHER)] = sizeof(watcher_msg_t);
+    mem_map_sizes[hv(HalMemAddrType::DPRINT)] = sizeof(dprint_buf_msg_t);
+    mem_map_sizes[hv(HalMemAddrType::KERNEL_CONFIG)] = L1_KERNEL_CONFIG_SIZE;
+    mem_map_sizes[hv(HalMemAddrType::UNRESERVED)] = MEM_L1_SIZE - L1_UNRESERVED_BASE;
+
+    return {HalProgrammableCoreType::TENSIX, CoreType::WORKER, num_proc_per_tensix_core, mem_map_bases, mem_map_sizes};
 }
 
 }  // namespace tt_metal

--- a/tt_metal/llrt/grayskull/gs_hal.cpp
+++ b/tt_metal/llrt/grayskull/gs_hal.cpp
@@ -27,17 +27,25 @@ static inline int hv (enum HalMemAddrType v) {
 void Hal::initialize_gs() {
 #if defined (ARCH_GRAYSKULL)
     constexpr uint32_t num_proc_per_tensix_core = 5;
+    std::vector<DeviceAddr> mem_map_bases;
+    mem_map_bases.resize(hv(HalMemAddrType::COUNT));
+    mem_map_bases[hv(HalMemAddrType::BARRIER)] = MEM_L1_BARRIER;
+    mem_map_bases[hv(HalMemAddrType::LAUNCH)] = GET_MAILBOX_ADDRESS_HOST(launch);
+    mem_map_bases[hv(HalMemAddrType::WATCHER)] = GET_MAILBOX_ADDRESS_HOST(watcher);
+    mem_map_bases[hv(HalMemAddrType::DPRINT)] = GET_MAILBOX_ADDRESS_HOST(dprint_buf);
+    mem_map_bases[hv(HalMemAddrType::KERNEL_CONFIG)] = L1_KERNEL_CONFIG_BASE;
+    mem_map_bases[hv(HalMemAddrType::UNRESERVED)] = L1_UNRESERVED_BASE;
 
-    std::vector<DeviceAddr> mem_map;
-    mem_map.resize(hv(HalMemAddrType::COUNT));
-    mem_map[hv(HalMemAddrType::BARRIER)] = MEM_L1_BARRIER;
-    mem_map[hv(HalMemAddrType::LAUNCH)] = GET_MAILBOX_ADDRESS_HOST(launch);
-    mem_map[hv(HalMemAddrType::WATCHER)] = GET_MAILBOX_ADDRESS_HOST(watcher);
-    mem_map[hv(HalMemAddrType::DPRINT)] = GET_MAILBOX_ADDRESS_HOST(dprint_buf);
-    mem_map[hv(HalMemAddrType::KERNEL_CONFIG_BASE)] = L1_KERNEL_CONFIG_BASE;
-    mem_map[hv(HalMemAddrType::UNRESERVED_BASE)] = L1_UNRESERVED_BASE;
+    std::vector<uint32_t> mem_map_sizes;
+    mem_map_sizes.resize(hv(HalMemAddrType::COUNT));
+    mem_map_sizes[hv(HalMemAddrType::BARRIER)] = sizeof(uint32_t);
+    mem_map_sizes[hv(HalMemAddrType::LAUNCH)] = sizeof(launch_msg_t);
+    mem_map_sizes[hv(HalMemAddrType::WATCHER)] = sizeof(watcher_msg_t);
+    mem_map_sizes[hv(HalMemAddrType::DPRINT)] = sizeof(dprint_buf_msg_t);
+    mem_map_sizes[hv(HalMemAddrType::KERNEL_CONFIG)] = L1_KERNEL_CONFIG_SIZE;
+    mem_map_sizes[hv(HalMemAddrType::UNRESERVED)] = MEM_L1_SIZE - L1_UNRESERVED_BASE;
 
-    this->core_info_.push_back({HalProgrammableCoreType::TENSIX, CoreType::WORKER, num_proc_per_tensix_core, mem_map});
+    this->core_info_.push_back({HalProgrammableCoreType::TENSIX, CoreType::WORKER, num_proc_per_tensix_core, mem_map_bases, mem_map_sizes});
 #endif
 }
 

--- a/tt_metal/llrt/hal.cpp
+++ b/tt_metal/llrt/hal.cpp
@@ -42,14 +42,28 @@ void Hal::initialize(tt::ARCH arch) {
     }
 }
 
+uint32_t Hal::get_programmable_core_type_index(HalProgrammableCoreType programmable_core_type_index) const {
+    uint32_t index = static_cast<uint32_t>(programmable_core_type_index);
+
+    // TODO: this assumes unused entries occur at the end
+    // Assumes unused indices go at the end
+    if (index >= core_info_.size()) {
+        return -1;
+    } else {
+        return index;
+    }
+}
+
 HalCoreInfoType::HalCoreInfoType(HalProgrammableCoreType programmable_core_type,
                                  CoreType core_type,
                                  uint32_t core_proc_count,
-                                 const std::vector<DeviceAddr>& core_mem_map) :
+                                 const std::vector<DeviceAddr>& mem_map_bases,
+                                 const std::vector<uint32_t>& mem_map_sizes) :
     programmable_core_type_(programmable_core_type),
     core_type_(core_type),
     proc_count_(core_proc_count),
-    mem_map_(core_mem_map) {
+    mem_map_bases_(mem_map_bases),
+    mem_map_sizes_(mem_map_sizes) {
 }
 
 }  // namespace tt_metal

--- a/tt_metal/llrt/wormhole/wh_hal.cpp
+++ b/tt_metal/llrt/wormhole/wh_hal.cpp
@@ -12,23 +12,14 @@ namespace tt_metal {
 
 void Hal::initialize_wh() {
 #if defined(ARCH_WORMHOLE_B0)
-    constexpr uint32_t num_proc_per_tensix_core = 5;
-    std::vector<DeviceAddr> tensix_mem_map = create_tensix_mem_map();
-    this->core_info_.push_back(
-        {HalProgrammableCoreType::TENSIX, CoreType::WORKER, num_proc_per_tensix_core, tensix_mem_map}
-    );
+    HalCoreInfoType tensix_mem_map = create_tensix_mem_map();
+    this->core_info_.push_back(tensix_mem_map);
 
-    constexpr uint32_t num_proc_per_active_eth_core = 1;
-    std::vector<DeviceAddr> active_eth_mem_map = create_active_eth_mem_map();
-    this->core_info_.push_back(
-        {HalProgrammableCoreType::ACTIVE_ETH, CoreType::ETH, num_proc_per_active_eth_core, active_eth_mem_map}
-    );
+    HalCoreInfoType active_eth_mem_map = create_active_eth_mem_map();
+    this->core_info_.push_back(active_eth_mem_map);
 
-    constexpr uint32_t num_proc_per_idle_eth_core = 1;
-    std::vector<DeviceAddr> idle_eth_mem_map = create_idle_eth_mem_map();
-    this->core_info_.push_back(
-        {HalProgrammableCoreType::IDLE_ETH, CoreType::ETH, num_proc_per_idle_eth_core, idle_eth_mem_map}
-    );
+    HalCoreInfoType idle_eth_mem_map = create_idle_eth_mem_map();
+    this->core_info_.push_back(idle_eth_mem_map);
 #endif
 }
 

--- a/tt_metal/llrt/wormhole/wh_hal.hpp
+++ b/tt_metal/llrt/wormhole/wh_hal.hpp
@@ -10,9 +10,9 @@ namespace tt_metal {
 
 // If you are trying to include this file and you aren't hal...you are doing something wrong
 
-std::vector<DeviceAddr> create_tensix_mem_map();
-std::vector<DeviceAddr> create_active_eth_mem_map();
-std::vector<DeviceAddr> create_idle_eth_mem_map();
+HalCoreInfoType create_tensix_mem_map();
+HalCoreInfoType create_active_eth_mem_map();
+HalCoreInfoType create_idle_eth_mem_map();
 
 }  // namespace tt_metal
 }  // namespace tt

--- a/tt_metal/llrt/wormhole/wh_hal_active_eth_mem_map.cpp
+++ b/tt_metal/llrt/wormhole/wh_hal_active_eth_mem_map.cpp
@@ -11,6 +11,7 @@
 #include "hw/inc/wormhole/dev_mem_map.h"
 #include "hw/inc/wormhole/eth_l1_address_map.h"
 #include "hostdevcommon/common_runtime_address_map.h"
+#include "tt_metal/third_party/umd/device/tt_soc_descriptor.h"
 #include "hw/inc/dev_msgs.h"
 
 #define GET_ETH_MAILBOX_ADDRESS_HOST(x) \
@@ -24,19 +25,29 @@ static inline int hv (enum HalMemAddrType v) {
     return static_cast<int>(v);
 }
 
-std::vector<DeviceAddr> create_active_eth_mem_map() {
+HalCoreInfoType create_active_eth_mem_map() {
 
-    std::vector<DeviceAddr> active_eth_mem_map;
-    active_eth_mem_map.resize(hv(HalMemAddrType::COUNT));
-    active_eth_mem_map[hv(HalMemAddrType::BARRIER)] = MEM_L1_BARRIER;
-    active_eth_mem_map[hv(HalMemAddrType::LAUNCH)] = GET_ETH_MAILBOX_ADDRESS_HOST(launch);
-    active_eth_mem_map[hv(HalMemAddrType::WATCHER)] = GET_ETH_MAILBOX_ADDRESS_HOST(watcher);
-    active_eth_mem_map[hv(HalMemAddrType::DPRINT)] = GET_ETH_MAILBOX_ADDRESS_HOST(dprint_buf);
-    //active_eth_mem_map[HAL_L1_MEM_ADDR_PROFILER] = 4;
-    active_eth_mem_map[hv(HalMemAddrType::KERNEL_CONFIG_BASE)] = eth_l1_mem::address_map::ERISC_L1_KERNEL_CONFIG_BASE;
-    active_eth_mem_map[hv(HalMemAddrType::UNRESERVED_BASE)] = eth_l1_mem::address_map::ERISC_L1_UNRESERVED_BASE;
+    constexpr uint32_t num_proc_per_active_eth_core = 1;
 
-    return active_eth_mem_map;
+    std::vector<DeviceAddr> mem_map_bases;
+    mem_map_bases.resize(hv(HalMemAddrType::COUNT));
+    mem_map_bases[hv(HalMemAddrType::BARRIER)] = MEM_L1_BARRIER;
+    mem_map_bases[hv(HalMemAddrType::LAUNCH)] = GET_ETH_MAILBOX_ADDRESS_HOST(launch);
+    mem_map_bases[hv(HalMemAddrType::WATCHER)] = GET_ETH_MAILBOX_ADDRESS_HOST(watcher);
+    mem_map_bases[hv(HalMemAddrType::DPRINT)] = GET_ETH_MAILBOX_ADDRESS_HOST(dprint_buf);
+    mem_map_bases[hv(HalMemAddrType::KERNEL_CONFIG)] = eth_l1_mem::address_map::ERISC_L1_KERNEL_CONFIG_BASE;
+    mem_map_bases[hv(HalMemAddrType::UNRESERVED)] = eth_l1_mem::address_map::ERISC_L1_UNRESERVED_BASE;
+
+    std::vector<uint32_t> mem_map_sizes;
+    mem_map_sizes.resize(hv(HalMemAddrType::COUNT));
+    mem_map_sizes[hv(HalMemAddrType::BARRIER)] = sizeof(uint32_t);
+    mem_map_sizes[hv(HalMemAddrType::LAUNCH)] = sizeof(launch_msg_t);
+    mem_map_sizes[hv(HalMemAddrType::WATCHER)] = sizeof(watcher_msg_t);
+    mem_map_sizes[hv(HalMemAddrType::DPRINT)] = sizeof(dprint_buf_msg_t);
+    mem_map_sizes[hv(HalMemAddrType::KERNEL_CONFIG)] = eth_l1_mem::address_map::ERISC_L1_KERNEL_CONFIG_SIZE;
+    mem_map_sizes[hv(HalMemAddrType::UNRESERVED)] = eth_l1_mem::address_map::MAX_SIZE - eth_l1_mem::address_map::ERISC_L1_UNRESERVED_BASE;
+
+    return {HalProgrammableCoreType::ACTIVE_ETH, CoreType::ETH, num_proc_per_active_eth_core, mem_map_bases, mem_map_sizes};
 }
 
 }  // namespace tt_metal

--- a/tt_metal/llrt/wormhole/wh_hal_idle_eth_mem_map.cpp
+++ b/tt_metal/llrt/wormhole/wh_hal_idle_eth_mem_map.cpp
@@ -11,6 +11,7 @@
 #include "hw/inc/wormhole/dev_mem_map.h"
 #include "hw/inc/wormhole/eth_l1_address_map.h"
 #include "hostdevcommon/common_runtime_address_map.h"
+#include "tt_metal/third_party/umd/device/tt_soc_descriptor.h"
 #include "hw/inc/dev_msgs.h"
 
 #define GET_IERISC_MAILBOX_ADDRESS_HOST(x) ((uint64_t) & (((mailboxes_t *)MEM_IERISC_MAILBOX_BASE)->x))
@@ -23,18 +24,29 @@ static inline int hv (enum HalMemAddrType v) {
     return static_cast<int>(v);
 }
 
-std::vector<DeviceAddr> create_idle_eth_mem_map() {
+HalCoreInfoType create_idle_eth_mem_map() {
 
-    std::vector<DeviceAddr> idle_eth_mem_map;
-    idle_eth_mem_map.resize(hv(HalMemAddrType::COUNT));
-    idle_eth_mem_map[hv(HalMemAddrType::BARRIER)] = MEM_L1_BARRIER;
-    idle_eth_mem_map[hv(HalMemAddrType::LAUNCH)] = GET_IERISC_MAILBOX_ADDRESS_HOST(launch);
-    idle_eth_mem_map[hv(HalMemAddrType::WATCHER)] = GET_IERISC_MAILBOX_ADDRESS_HOST(watcher);
-    idle_eth_mem_map[hv(HalMemAddrType::DPRINT)] = GET_IERISC_MAILBOX_ADDRESS_HOST(dprint_buf);
-    idle_eth_mem_map[hv(HalMemAddrType::KERNEL_CONFIG_BASE)] = IDLE_ERISC_L1_KERNEL_CONFIG_BASE;
-    idle_eth_mem_map[hv(HalMemAddrType::UNRESERVED_BASE)] = ERISC_L1_UNRESERVED_BASE;
+    constexpr uint32_t num_proc_per_idle_eth_core = 1;
 
-    return idle_eth_mem_map;
+    std::vector<DeviceAddr> mem_map_bases;
+    mem_map_bases.resize(hv(HalMemAddrType::COUNT));
+    mem_map_bases[hv(HalMemAddrType::BARRIER)] = MEM_L1_BARRIER;
+    mem_map_bases[hv(HalMemAddrType::LAUNCH)] = GET_IERISC_MAILBOX_ADDRESS_HOST(launch);
+    mem_map_bases[hv(HalMemAddrType::WATCHER)] = GET_IERISC_MAILBOX_ADDRESS_HOST(watcher);
+    mem_map_bases[hv(HalMemAddrType::DPRINT)] = GET_IERISC_MAILBOX_ADDRESS_HOST(dprint_buf);
+    mem_map_bases[hv(HalMemAddrType::KERNEL_CONFIG)] = IDLE_ERISC_L1_KERNEL_CONFIG_BASE;
+    mem_map_bases[hv(HalMemAddrType::UNRESERVED)] = ERISC_L1_UNRESERVED_BASE;
+
+    std::vector<uint32_t> mem_map_sizes;
+    mem_map_sizes.resize(hv(HalMemAddrType::COUNT));
+    mem_map_sizes[hv(HalMemAddrType::BARRIER)] = sizeof(uint32_t);
+    mem_map_sizes[hv(HalMemAddrType::LAUNCH)] = sizeof(launch_msg_t);
+    mem_map_sizes[hv(HalMemAddrType::WATCHER)] = sizeof(watcher_msg_t);
+    mem_map_sizes[hv(HalMemAddrType::DPRINT)] = sizeof(dprint_buf_msg_t);
+    mem_map_sizes[hv(HalMemAddrType::KERNEL_CONFIG)] = L1_KERNEL_CONFIG_SIZE; // TODO: this is wrong, need idle eth specific value
+    mem_map_sizes[hv(HalMemAddrType::UNRESERVED)] = MEM_ETH_SIZE - ERISC_L1_UNRESERVED_BASE;
+
+    return {HalProgrammableCoreType::IDLE_ETH, CoreType::ETH, num_proc_per_idle_eth_core, mem_map_bases, mem_map_sizes};
 }
 
 }  // namespace tt_metal

--- a/tt_metal/llrt/wormhole/wh_hal_tensix_mem_map.cpp
+++ b/tt_metal/llrt/wormhole/wh_hal_tensix_mem_map.cpp
@@ -9,6 +9,7 @@
 #include "hw/inc/wormhole/dev_mem_map.h"
 #include "hw/inc/wormhole/eth_l1_address_map.h"  // XXXX FIXME
 #include "hostdevcommon/common_runtime_address_map.h"
+#include "tt_metal/third_party/umd/device/tt_soc_descriptor.h"
 #include "hw/inc/dev_msgs.h"
 
 #define GET_MAILBOX_ADDRESS_HOST(x) ((uint64_t) & (((mailboxes_t *)MEM_MAILBOX_BASE)->x))
@@ -21,18 +22,29 @@ static inline int hv (enum HalMemAddrType v) {
     return static_cast<int>(v);
 }
 
-std::vector<DeviceAddr> create_tensix_mem_map() {
+HalCoreInfoType create_tensix_mem_map() {
 
-    std::vector<DeviceAddr> tensix_mem_map;
-    tensix_mem_map.resize(hv(HalMemAddrType::COUNT));
-    tensix_mem_map[hv(HalMemAddrType::BARRIER)] = MEM_L1_BARRIER;
-    tensix_mem_map[hv(HalMemAddrType::LAUNCH)] = GET_MAILBOX_ADDRESS_HOST(launch);
-    tensix_mem_map[hv(HalMemAddrType::WATCHER)] = GET_MAILBOX_ADDRESS_HOST(watcher);
-    tensix_mem_map[hv(HalMemAddrType::DPRINT)] = GET_MAILBOX_ADDRESS_HOST(dprint_buf);
-    tensix_mem_map[hv(HalMemAddrType::KERNEL_CONFIG_BASE)] = L1_KERNEL_CONFIG_BASE;
-    tensix_mem_map[hv(HalMemAddrType::UNRESERVED_BASE)] = L1_UNRESERVED_BASE;
+    constexpr uint32_t num_proc_per_tensix_core = 5;
 
-    return tensix_mem_map;
+    std::vector<DeviceAddr> mem_map_bases;
+    mem_map_bases.resize(hv(HalMemAddrType::COUNT));
+    mem_map_bases[hv(HalMemAddrType::BARRIER)] = MEM_L1_BARRIER;
+    mem_map_bases[hv(HalMemAddrType::LAUNCH)] = GET_MAILBOX_ADDRESS_HOST(launch);
+    mem_map_bases[hv(HalMemAddrType::WATCHER)] = GET_MAILBOX_ADDRESS_HOST(watcher);
+    mem_map_bases[hv(HalMemAddrType::DPRINT)] = GET_MAILBOX_ADDRESS_HOST(dprint_buf);
+    mem_map_bases[hv(HalMemAddrType::KERNEL_CONFIG)] = L1_KERNEL_CONFIG_BASE;
+    mem_map_bases[hv(HalMemAddrType::UNRESERVED)] = L1_UNRESERVED_BASE;
+
+    std::vector<uint32_t> mem_map_sizes;
+    mem_map_sizes.resize(hv(HalMemAddrType::COUNT));
+    mem_map_sizes[hv(HalMemAddrType::BARRIER)] = sizeof(uint32_t);
+    mem_map_sizes[hv(HalMemAddrType::LAUNCH)] = sizeof(launch_msg_t);
+    mem_map_sizes[hv(HalMemAddrType::WATCHER)] = sizeof(watcher_msg_t);
+    mem_map_sizes[hv(HalMemAddrType::DPRINT)] = sizeof(dprint_buf_msg_t);
+    mem_map_sizes[hv(HalMemAddrType::KERNEL_CONFIG)] = L1_KERNEL_CONFIG_SIZE;
+    mem_map_sizes[hv(HalMemAddrType::UNRESERVED)] = MEM_L1_SIZE - L1_UNRESERVED_BASE;
+
+    return {HalProgrammableCoreType::TENSIX, CoreType::WORKER, num_proc_per_tensix_core, mem_map_bases, mem_map_sizes};
 }
 
 }  // namespace tt_metal

--- a/tt_metal/tools/profiler/tt_metal_profiler.cpp
+++ b/tt_metal/tools/profiler/tt_metal_profiler.cpp
@@ -22,10 +22,18 @@ namespace tt_metal {
 
 void DumpDeviceProfileResults(Device* device, const Program& program) {
 #if defined(TRACY_ENABLE)
-    auto const& worker_cores_in_program =
-        device->worker_cores_from_logical_cores(program.logical_cores().at(CoreType::WORKER));
-    auto const& eth_cores_in_program =
-        device->ethernet_cores_from_logical_cores(program.logical_cores().at(CoreType::ETH));
+    std::vector<CoreCoord> worker_cores_in_program;
+    std::vector<CoreCoord> eth_cores_in_program;
+
+    std::vector<std::vector<CoreCoord>>logical_cores = program.logical_cores();
+    for (uint32_t index = 0; index < hal.get_programmable_core_type_count(); index++) {
+        if (hal.get_core_type(index) == CoreType::WORKER) {
+            worker_cores_in_program = device->worker_cores_from_logical_cores(logical_cores[index]);
+        }
+        if (hal.get_core_type(index) == CoreType::ETH) {
+            eth_cores_in_program = device->ethernet_cores_from_logical_cores(logical_cores[index]);
+        }
+    }
 
     std::vector<CoreCoord> cores_in_program;
     cores_in_program.reserve(worker_cores_in_program.size() + eth_cores_in_program.size());

--- a/tt_metal/tt_metal.cpp
+++ b/tt_metal/tt_metal.cpp
@@ -12,6 +12,7 @@
 #include <unordered_set>
 
 #include "dev_msgs.h"
+#include "llrt/hal.hpp"
 #include "impl/allocator/allocator.hpp"
 #include "impl/debug/dprint_server.hpp"
 #include "impl/dispatch/command_queue.hpp"
@@ -67,7 +68,8 @@ void CheckDataMovementConfig(Program &program, const std::string &file_name, con
     for (const auto &core_range : core_ranges.ranges()) {
         for (auto x = core_range.start_coord.x; x <= core_range.end_coord.x; x++) {
             for (auto y = core_range.start_coord.y; y <= core_range.end_coord.y; y++) {
-                const KernelGroup * kernel_group = program.kernels_on_core(CoreCoord(x, y), CoreType::WORKER);
+                const KernelGroup * kernel_group = program.kernels_on_core(CoreCoord(x, y),
+                    hal.get_programmable_core_type_index(HalProgrammableCoreType::TENSIX));
                 if (kernel_group != nullptr) {
                     bool local_noc0_in_use = false; bool local_noc1_in_use = false;
                     if (kernel_group->kernel_ids[DISPATCH_CLASS_TENSIX_DM0].has_value()) {
@@ -648,12 +650,14 @@ void LaunchProgram(Device *device, Program &program, bool wait_until_cores_done,
         // don't get the GO mailbox (eg, storage cores) have all landed
         tt::Cluster::instance().l1_barrier(device->id());
 
-        std::unordered_map<CoreType, std::vector<CoreCoord>> logical_cores_used_in_program = program.logical_cores();
+        std::vector<std::vector<CoreCoord>> logical_cores_used_in_program = program.logical_cores();
         std::unordered_set<CoreCoord> not_done_cores;
-        for (const auto &[core_type, logical_cores] : logical_cores_used_in_program) {
-            for (const auto &logical_core : logical_cores) {
-                launch_msg_t *msg = &program.kernels_on_core(logical_core, core_type)->launch_msg;
+        for (uint32_t programmable_core_type_index = 0; programmable_core_type_index < logical_cores_used_in_program.size(); programmable_core_type_index++) {
+            CoreType core_type = hal.get_core_type(programmable_core_type_index);
+            for (const auto &logical_core : logical_cores_used_in_program[programmable_core_type_index]) {
+                launch_msg_t *msg = &program.kernels_on_core(logical_core, programmable_core_type_index)->launch_msg;
                 msg->kernel_config.host_assigned_id = program.get_runtime_id();
+
                 auto physical_core = device->physical_core_from_logical_core(logical_core, core_type);
                 not_done_cores.insert(physical_core);
                 tt::llrt::write_launch_msg_to_core(device->id(), physical_core, msg, device->get_dev_addr(physical_core, HalMemAddrType::LAUNCH));
@@ -671,9 +675,11 @@ void LaunchProgram(Device *device, Program &program, bool wait_until_cores_done,
 
 void WaitProgramDone(Device *device, Program &program) {
     auto device_id = device->id();
-    std::unordered_map<CoreType, std::vector<CoreCoord>> logical_cores_used_in_program = program.logical_cores();
+    std::vector<std::vector<CoreCoord>> logical_cores_used_in_program = program.logical_cores();
     std::unordered_set<CoreCoord> not_done_cores;
-    for (const auto &[core_type, logical_cores] : logical_cores_used_in_program) {
+    for (uint32_t index = 0; index < hal.get_programmable_core_type_count(); index++) {
+        const auto & logical_cores = logical_cores_used_in_program[index];
+        CoreType core_type = hal.get_core_type(index);
         for (const auto &logical_core : logical_cores) {
             auto physical_core = device->physical_core_from_logical_core(logical_core, core_type);
             not_done_cores.insert(physical_core);
@@ -698,10 +704,12 @@ bool ConfigureDeviceWithProgram(Device *device, Program &program, bool fd_bootlo
     program.allocate_circular_buffers();
     detail::ValidateCircularBufferRegion(program, device);
 
-    std::unordered_map<CoreType, std::vector<CoreCoord>> logical_cores_used_in_program = program.logical_cores();
-    for (const auto &[core_type, logical_cores] : logical_cores_used_in_program) {
+    std::vector<std::vector<CoreCoord>> logical_cores_used_in_program = program.logical_cores();
+    for (uint32_t index = 0; index < hal.get_programmable_core_type_count(); index++) {
+        const auto & logical_cores = logical_cores_used_in_program[index];
+        CoreType core_type = hal.get_core_type(index);
         for (const auto &logical_core : logical_cores) {
-            KernelGroup *kernel_group = program.kernels_on_core(logical_core, core_type);
+            KernelGroup *kernel_group = program.kernels_on_core(logical_core, index);
             CoreCoord physical_core = device->physical_core_from_logical_core(logical_core, core_type);
 
             ConfigureKernelGroup(program, kernel_group, device, logical_core);
@@ -727,7 +735,7 @@ bool ConfigureDeviceWithProgram(Device *device, Program &program, bool fd_bootlo
                         device_id, physical_core, circular_buffer_config_vec);
                 }
             }
-            program.init_semaphores(*device, logical_core, core_type);
+            program.init_semaphores(*device, logical_core, hal.get_core_type(index));
         }
     }
 
@@ -739,10 +747,9 @@ void WriteRuntimeArgsToDevice(Device *device, Program &program, bool force_slow_
     auto device_id = device->id();
     detail::DispatchStateCheck(force_slow_dispatch);
 
-    static vector<CoreType>core_types = {CoreType::WORKER, CoreType::ETH }; // TODO: make this global
-
-    for (CoreType core_type : core_types) {
-        for (auto& kg : program.get_kernel_groups(core_type)) {
+    for (uint32_t index = 0; index < hal.get_programmable_core_type_count(); index++) {
+        CoreType core_type = hal.get_core_type(index);
+        for (auto& kg : program.get_kernel_groups(index)) {
             uint32_t kernel_config_base = kg.launch_msg.kernel_config.kernel_config_base;
             for (const CoreRange &core_range : kg.core_ranges.ranges()) {
                 for (auto x = core_range.start_coord.x; x <= core_range.end_coord.x; x++) {
@@ -869,13 +876,17 @@ KernelHandle CreateKernel(
             if constexpr (std::is_same_v<T, DataMovementConfig>) {
                 CheckDataMovementConfig(program, file_name, core_ranges);
                 kernel = std::make_shared<DataMovementKernel>(file_name, core_ranges, cfg);
-                return detail::AddKernel(program, kernel, CoreType::WORKER);
+                return detail::AddKernel(program, kernel, HalProgrammableCoreType::TENSIX);
             } else if constexpr (std::is_same_v<T, ComputeConfig>) {
                 kernel = std::make_shared<ComputeKernel>(file_name, core_ranges, cfg);
-                return detail::AddKernel(program, kernel, CoreType::WORKER);
+                return detail::AddKernel(program, kernel, HalProgrammableCoreType::TENSIX);
             } else if constexpr (std::is_same_v<T, EthernetConfig>) {
                 kernel = std::make_shared<EthernetKernel>(file_name, core_ranges, cfg);
-                return detail::AddKernel(program, kernel, CoreType::ETH);
+                if (cfg.eth_mode == Eth::IDLE) {
+                    return detail::AddKernel(program, kernel, HalProgrammableCoreType::IDLE_ETH);
+                } else {
+                    return detail::AddKernel(program, kernel, HalProgrammableCoreType::ACTIVE_ETH);
+                }
             }
         },
         config);


### PR DESCRIPTION
I was hoping this would clean up the code base, in actuality it introduced some ugliness mostly due to code being structured around CoreType and not easily portable to looping over abstract core types.  Over time w/ some cleanup some of these uses could go away

### Ticket
#4984 
### Problem description
Lacking abstraction round device

### What's changed
This is a WIP, migrated the dispatch code to use virtualized addresses through the HAL

### Checklist
- [ ] Post commit CI passes
- [ ] Blackhole Post commit (if applicable)
- [ ] Model regression CI testing passes (if applicable)
- [ ] New/Existing tests provide coverage for changes
