### PR TITLE
Enable compilation of g++-12 Release build 

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -15,7 +15,7 @@ jobs:
           # {type: RelWithDebInfo,  cxx_compiler: clang++-17, c_compiler: clang-17, runs-on: ubuntu-22.04},
           # {type: Release,  cxx_compiler: clang++-17, c_compiler: clang-17, runs-on: ubuntu-22.04},
           # {type: Debug, cxx_compiler: g++-12, c_compiler: gcc-12, runs-on: ubuntu-22.04, os: ubuntu-22.04},
-          {type: RelWithDebInfo,  cxx_compiler: g++-12, c_compiler: gcc-12, runs-on: ubuntu-22.04, os: ubuntu-22.04},
+          # {type: RelWithDebInfo,  cxx_compiler: g++-12, c_compiler: gcc-12, runs-on: ubuntu-22.04, os: ubuntu-22.04},
           {type: Release,  cxx_compiler: g++-12, c_compiler: gcc-12, runs-on: ubuntu-22.04, os: ubuntu-22.04},
         ]
         arch: [grayskull, wormhole_b0, blackhole]

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -14,8 +14,8 @@ jobs:
           # {type: Debug, cxx_compiler: clang++-17, c_compiler: clang-17, runs-on: ubuntu-22.04},
           # {type: RelWithDebInfo,  cxx_compiler: clang++-17, c_compiler: clang-17, runs-on: ubuntu-22.04},
           # {type: Release,  cxx_compiler: clang++-17, c_compiler: clang-17, runs-on: ubuntu-22.04},
-          {type: Debug, cxx_compiler: g++-12, c_compiler: gcc-12, runs-on: ubuntu-22.04, os: ubuntu-22.04},
-          # {type: RelWithDebInfo,  cxx_compiler: g++-12, c_compiler: gcc-12, runs-on: ubuntu-22.04},
+          # {type: Debug, cxx_compiler: g++-12, c_compiler: gcc-12, runs-on: ubuntu-22.04, os: ubuntu-22.04},
+          {type: RelWithDebInfo,  cxx_compiler: g++-12, c_compiler: gcc-12, runs-on: ubuntu-22.04, os: ubuntu-22.04},
           {type: Release,  cxx_compiler: g++-12, c_compiler: gcc-12, runs-on: ubuntu-22.04, os: ubuntu-22.04},
         ]
         arch: [grayskull, wormhole_b0, blackhole]
@@ -24,7 +24,7 @@ jobs:
       # So we can get all the makefile output we want
       VERBOSE: 1
     runs-on: ${{ matrix.build.runs-on }}
-    name: cmake ${{ matrix.build.type }} ${{ matrix.build.cxx_compiler }} ${{ matrix.arch }} ${{ matrix.build.os }}
+    name: ${{ matrix.build.type }} ${{ matrix.build.cxx_compiler }} ${{ matrix.arch }} ${{ matrix.build.os }}
     steps:
       - uses: tenstorrent-metal/metal-workflows/.github/actions/checkout-with-submodule-lfs@v2.0.0
       - name: Install dependencies

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -42,7 +42,7 @@ jobs:
           echo "TT_METAL_HOME=$(pwd)" >> $GITHUB_ENV
       - name: Build C++ libraries and tests
         run: |
-          cmake -B build -DCMAKE_BUILD_TYPE=${{ matrix.build.type }} -G Ninja
+          cmake -B build -DCMAKE_BUILD_TYPE=${{ matrix.build.type }} -DCMAKE_CXX_COMPILER=${{ matrix.build.cxx_compiler }} -DCMAKE_C_COMPILER=${{ matrix.build.c_compiler }} -G Ninja
           cmake --build build --target tests
       - name: Check disk space
         run: |


### PR DESCRIPTION
### Problem description
g++-12 compilation in post-commit wasn't actually enabled properly

### What's changed
It's now enabled for Release build only. I would move this to run on our self-hosted runners in the near future given how slow it is. We can do this once we start building inside docker. 