### PR TITLE
#11538: Re-enable test_ccl_helpers test suite w/ linker fix

### DIFF
--- a/cmake/umd_device.cmake
+++ b/cmake/umd_device.cmake
@@ -36,4 +36,4 @@ target_include_directories(umd_device PRIVATE
     ${UMD_HOME}
     ${UMD_HOME}/device
     ${UMD_HOME}/third_party/fmt/include)
-target_link_libraries(umd_device PRIVATE yaml-cpp::yaml-cpp Boost::interprocess rt simulation)
+target_link_libraries(umd_device PRIVATE yaml-cpp::yaml-cpp Boost::interprocess rt simulation hwloc)

--- a/tests/scripts/run_tt_eager.py
+++ b/tests/scripts/run_tt_eager.py
@@ -30,7 +30,7 @@ from tests.scripts.cmdline_args import (
 )
 
 TT_EAGER_COMMON_TEST_ENTRIES = (
-    # void_for_gs(TestEntry("tt_eager/tests/ops/ccl/test_ccl_helpers", "ops/ccl/test_ccl_helpers")),
+    void_for_gs(TestEntry("tt_eager/tests/ops/ccl/test_ccl_helpers", "ops/ccl/test_ccl_helpers")),
     void_for_gs(TestEntry("tt_eager/tests/ops/ccl/test_ccl_tensor_slicers", "ops/ccl/test_ccl_tensor_slicers")),
     TestEntry("tt_eager/tests/ops/test_eltwise_binary_op", "ops/test_eltwise_binary_op"),
     TestEntry("tt_eager/tests/ops/test_bcast_op", "ops/test_bcast_op"),

--- a/tests/tt_eager/CMakeLists.txt
+++ b/tests/tt_eager/CMakeLists.txt
@@ -3,7 +3,7 @@ add_library(test_eager_common_libs INTERFACE)
 target_link_libraries(test_eager_common_libs INTERFACE test_common_libs)
 
 set(TT_EAGER_TESTS_OPS
-    #ops/ccl/test_ccl_helpers.cpp
+    ops/ccl/test_ccl_helpers.cpp
     ops/ccl/test_ccl_tensor_slicers.cpp
     ops/test_average_pool.cpp
     ops/test_eltwise_binary_op.cpp


### PR DESCRIPTION
### Ticket
[Link to Github Issue
](https://github.com/tenstorrent/tt-metal/issues/11538)

### Problem description
We had to temporarily disable ops/ccl/test_ccl_helpers.cpp when we merged changes to support GCC-12 compile because of linker issues.

### What's changed
1. The `ops/ccl/test_ccl_helpers.cpp` test suite is re-added.
2. `libumd` was missing a dependency on `hwloc`. This wasn't problematic for clang++-17 but it is an issue on gcc.

### Checklist
- [ ] Post commit CI passes
- [ ] Blackhole Post commit (if applicable)
- [ ] Model regression CI testing passes (if applicable)
- [ ] New/Existing tests provide coverage for changes
