### PR TITLE
#10332: Make ttnn::event_synchronize block only in the app thread

### DIFF
--- a/tests/ttnn/unit_tests/gtests/test_async_runtime.cpp
+++ b/tests/ttnn/unit_tests/gtests/test_async_runtime.cpp
@@ -65,12 +65,12 @@ TEST_F(MultiCommandQueueSingleDeviceFixture, TestAsyncPreallocatedOutputs) {
     // Record the completion of the write event
     ttnn::record_event(device->command_queue(io_cq), write_event);
     // Host stalls until write is completed, before sending workload
-    ttnn::event_synchronize(device, write_event);
+    ttnn::event_synchronize(write_event);
     // Dispatch workload. Preallocated output_tensor is populated by op/
     ttnn::moreh_sum(workload_dispatch_cq, input_tensor, /*dim*/3, false, output_tensor);
     // Record completion of workload
     ttnn::record_event(device->command_queue(workload_dispatch_cq), workload_event);
-    ttnn::event_synchronize(device, workload_event);
+    ttnn::event_synchronize(workload_event);
     // Read output back, once workload is complete
     ttnn::read_buffer(io_cq, output_tensor, {readback_data});
     // Ensure that reference count book keeping is done correctly

--- a/ttnn/cpp/ttnn/async_runtime.cpp
+++ b/ttnn/cpp/ttnn/async_runtime.cpp
@@ -115,12 +115,7 @@ void queue_synchronize(CommandQueue& cq) {
     Finish(cq);
 }
 
-void event_synchronize(Device* device, std::shared_ptr<Event> event) {
-    device->push_work([event] () {
-        EventSynchronize(event);
-    });
-    device->synchronize();
-}
+void event_synchronize(std::shared_ptr<Event> event) { EventSynchronize(event); }
 
 bool event_query(std::shared_ptr<Event> event) { return EventQuery(event); }
 

--- a/ttnn/cpp/ttnn/async_runtime.hpp
+++ b/ttnn/cpp/ttnn/async_runtime.hpp
@@ -20,7 +20,7 @@ namespace ttnn {
 
     void queue_synchronize(CommandQueue& cq);
 
-    void event_synchronize(Device* device, std::shared_ptr<Event> event);
+    void event_synchronize(std::shared_ptr<Event> event);
 
     bool event_query(std::shared_ptr<Event> event);
 


### PR DESCRIPTION
### Ticket
[Link to Github Issue](https://github.com/tenstorrent/tt-metal/issues/10332)

### Problem description
`ttnn::event_synchronize` (an event synchronization API) exposed to Moreh was stalling in the worker thread, which is suboptimal for Moreh's use-case.

### What's changed
Stall in the application thread instead.

### Checklist
- [x] Post commit CI passes
- [ ] Blackhole Post commit (if applicable)
- [ ] Model regression CI testing passes (if applicable)
- [ ] New/Existing tests provide coverage for changes
