### PR TITLE
#11426: Replace tt_lib in models/experimental/grok,hrnet,lenet,helper…

### DIFF
--- a/models/experimental/grok/demo/demo.py
+++ b/models/experimental/grok/demo/demo.py
@@ -4,7 +4,6 @@
 import os
 import torch
 import json
-import tt_lib as ttl
 import pytest
 from loguru import logger
 from time import time
@@ -201,8 +200,8 @@ def run_grok_demo(user_input, batch_size, device_mesh, instruct_mode):
     finished_generation = [False] * batch_size
 
     # TODO Debug (only device 0 is doing argmax, otherwise it throws an error)
-    # Alternatively, send the output back to device: tt_lib.tensor.Tensor.to()
-    ttl.device.SetDefaultDevice(device_mesh.get_device(0))
+    # Alternatively, send the output back to device: ttnn.Tensor.to()
+    ttnn.experimental.device.SetDefaultDevice(device_mesh.get_device(0))
 
     # Keep running inference as long as there is a user in the batch still decoding or max tokens per user are decoded
     for iteration in range(max_generated_tokens):

--- a/models/experimental/grok/tests/test_grok_perf.py
+++ b/models/experimental/grok/tests/test_grok_perf.py
@@ -13,7 +13,6 @@ if os.getenv("CI") == "true":
 
 import ttnn
 from ttnn import ConcatMeshToTensor
-import tt_lib
 
 if not os.getenv("CI") == "true":  # Enable tracy signpost support in local runs only
     from tracy import signpost
@@ -104,7 +103,7 @@ def test_grok_model_perf(
     compile_and_iter_time = profiler.get("model_run_for_inference_0")
 
     for device_id in t3k_device_mesh.get_device_ids():
-        tt_lib.device.DumpDeviceProfiler(t3k_device_mesh.get_device(device_id))
+        ttnn.experimental.device.DumpDeviceProfiler(t3k_device_mesh.get_device(device_id))
 
     if not os.getenv("CI") == "true":  # Enable tracy signpost support in local runs only
         signpost("Model perf run")

--- a/models/experimental/grok/tt/model_config.py
+++ b/models/experimental/grok/tt/model_config.py
@@ -182,7 +182,7 @@ class TtModelArgs:
 
         self.model_config["SHARDED_NORM_OUTPUT_MEMCFG"] = self.model_config["SHARDED_NORM_INPUT_MEMCFG"]
 
-        # Create program configs for the different ttlib matmul ops
+        # Create program configs for the different ttnn matmul ops
         # TODO: update for 6144 not 4096?
         self.model_config["ROT_MAT_MM_PROGCFG"] = ttnn.MatmulMultiCoreReuseMultiCast1DProgramConfig(
             compute_with_storage_grid_size=(8, 4),

--- a/models/experimental/hrnet/tt/basicblock.py
+++ b/models/experimental/hrnet/tt/basicblock.py
@@ -5,7 +5,6 @@
 import torch.nn as nn
 
 import ttnn
-import tt_lib
 from tt_lib.fallback_ops import fallback_ops
 from models.utility_functions import torch_to_tt_tensor_rm
 from models.experimental.hrnet.hrnet_utils import create_batchnorm

--- a/models/experimental/hrnet/tt/high_resolution_module.py
+++ b/models/experimental/hrnet/tt/high_resolution_module.py
@@ -6,7 +6,6 @@ import torch.nn as nn
 import logging
 
 import ttnn
-import tt_lib
 from tt_lib.fallback_ops import fallback_ops
 from models.utility_functions import torch_to_tt_tensor_rm
 from models.experimental.hrnet.hrnet_utils import create_batchnorm
@@ -20,7 +19,7 @@ class TtInterpolate(nn.Module):
         self.scale_factor = scale_factor
         self.mode = mode
 
-    def forward(self, x: tt_lib.tensor.Tensor):
+    def forward(self, x: ttnn.Tensor):
         out = fallback_ops.interpolate(x, scale_factor=self.scale_factor, mode=self.mode)
         return out
 
@@ -220,7 +219,7 @@ class TtHighResolutionModule(nn.Module):
     def get_num_inchannels(self):
         return self.num_inchannels
 
-    def forward(self, x: tt_lib.tensor.Tensor):
+    def forward(self, x: ttnn.Tensor):
         if self.num_branches == 1:
             return [self.branches[0](x[0])]
 

--- a/models/experimental/hrnet/tt/hrnet_model.py
+++ b/models/experimental/hrnet/tt/hrnet_model.py
@@ -7,7 +7,6 @@ import torch.nn as nn
 import timm
 
 import ttnn
-import tt_lib
 from tt_lib.fallback_ops import fallback_ops
 from models.utility_functions import torch_to_tt_tensor_rm
 
@@ -358,7 +357,7 @@ class TtHighResolutionNet(nn.Module):
 
         return nn.Sequential(*modules), num_inchannels
 
-    def forward(self, x: tt_lib.tensor.Tensor):
+    def forward(self, x: ttnn.Tensor):
         x = self.conv1(x)
         x = self.bn1(x)
         x = self.relu(x)

--- a/models/experimental/lenet/demo/gs_demo.py
+++ b/models/experimental/lenet/demo/gs_demo.py
@@ -4,10 +4,11 @@
 
 import torch
 from loguru import logger
-import tt_lib
+import ttnn
 
 from models.experimental.lenet.tt.lenet import lenet5
 from models.experimental.lenet.lenet_utils import load_torch_lenet, prepare_image
+
 
 def test_gs_demo(device, mnist_sample_input, model_location_generator):
     sample_image = mnist_sample_input
@@ -17,11 +18,11 @@ def test_gs_demo(device, mnist_sample_input, model_location_generator):
     with torch.no_grad():
         tt_lenet = lenet5(num_classes, device, model_location_generator)
 
-        tt_image = tt_lib.tensor.Tensor(
+        tt_image = ttnn.Tensor(
             image.reshape(-1).tolist(),
             image.shape,
-            tt_lib.tensor.DataType.BFLOAT16,
-            tt_lib.tensor.Layout.ROW_MAJOR,
+            ttnn.bfloat16,
+            ttnn.ROW_MAJOR_LAYOUT,
         )
 
         tt_output = tt_lenet(tt_image)

--- a/models/experimental/lenet/tests/test_lenet.py
+++ b/models/experimental/lenet/tests/test_lenet.py
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import pytest
-import tt_lib
+import ttnn
 import torch
 from loguru import logger
 
@@ -12,15 +12,11 @@ from models.experimental.lenet.tt.lenet import lenet5
 from models.utility_functions import comp_pcc, torch2tt_tensor
 
 
-
-
 @pytest.mark.parametrize(
     "pcc",
     ((0.99),),
 )
-def test_lenet_inference(
-    device, pcc, mnist_sample_input, model_location_generator, reset_seeds
-):
+def test_lenet_inference(device, pcc, mnist_sample_input, model_location_generator, reset_seeds):
     num_classes = 10
     batch_size = 1
     with torch.no_grad():
@@ -36,7 +32,7 @@ def test_lenet_inference(
         torch_output = torch_LeNet(image).unsqueeze(1).unsqueeze(1)
         _, torch_predicted = torch.max(torch_output.data, -1)
 
-        tt_image = torch2tt_tensor(image, device, tt_lib.tensor.Layout.ROW_MAJOR)
+        tt_image = torch2tt_tensor(image, device, ttnn.ROW_MAJOR_LAYOUT)
 
         tt_output = tt_lenet(tt_image)
         tt_output = tt_output.cpu()

--- a/models/experimental/lenet/tests/test_lenet_perf.py
+++ b/models/experimental/lenet/tests/test_lenet_perf.py
@@ -5,7 +5,7 @@
 import torch
 from loguru import logger
 import pytest
-import tt_lib
+import ttnn
 
 from models.utility_functions import (
     profiler,
@@ -23,9 +23,7 @@ from models.experimental.lenet.lenet_utils import load_torch_lenet, prepare_imag
     "pcc, PERF_CNT",
     ((0.99, 2),),
 )
-def test_lenet_perf_inference(
-    device, pcc, PERF_CNT, mnist_sample_input, model_location_generator, reset_seeds
-):
+def test_lenet_perf_inference(device, pcc, PERF_CNT, mnist_sample_input, model_location_generator, reset_seeds):
     disable_persistent_kernel_cache()
     image = prepare_image(mnist_sample_input)
     num_classes = 10
@@ -46,7 +44,7 @@ def test_lenet_perf_inference(
         _, torch_predicted = torch.max(torch_output.data, -1)
         profiler.end("\nExec time of reference model")
 
-        tt_image = torch2tt_tensor(image, device, tt_lib.tensor.Layout.ROW_MAJOR)
+        tt_image = torch2tt_tensor(image, device, ttnn.ROW_MAJOR_LAYOUT)
 
         profiler.start("\nExecution time of tt_vgg first run")
         tt_output = tt_lenet(tt_image)

--- a/models/experimental/lenet/tests/test_perf_accuracy_lenet.py
+++ b/models/experimental/lenet/tests/test_perf_accuracy_lenet.py
@@ -7,7 +7,7 @@ from torch.utils.data import DataLoader
 from torchvision import transforms, datasets
 from loguru import logger
 import pytest
-import tt_lib
+import ttnn
 import evaluate
 from torch import Generator
 
@@ -55,14 +55,14 @@ def run_perf_inference(device, pcc, iterations, model_location_generator, reset_
 
         profiler.start(cpu_key)
         torch_output = torch_LeNet(test_input)
-        tt_lib.device.Synchronize(device)
+        ttnn.synchronize_device(device)
         profiler.end(cpu_key)
 
         tt_image = torch_to_tt_tensor_rm(test_input, device, put_on_device=False)
 
         profiler.start(first_key)
         tt_output = tt_lenet(tt_image)
-        tt_lib.device.Synchronize(device)
+        ttnn.synchronize_device(device)
         profiler.end(first_key)
         del tt_output
 
@@ -70,7 +70,7 @@ def run_perf_inference(device, pcc, iterations, model_location_generator, reset_
 
         profiler.start(second_key)
         tt_output = tt_lenet(tt_image)
-        tt_lib.device.Synchronize(device)
+        ttnn.synchronize_device(device)
         profiler.end(second_key)
         del tt_output
 
@@ -79,7 +79,7 @@ def run_perf_inference(device, pcc, iterations, model_location_generator, reset_
         profiler.start(third_key)
         accuracy_metric = evaluate.load("accuracy")
 
-        tt_lib.device.Synchronize(device)
+        ttnn.synchronize_device(device)
         for idx, (image, label) in enumerate(dataloader):
             if idx == iterations:
                 break

--- a/models/experimental/lenet/tt/lenet.py
+++ b/models/experimental/lenet/tt/lenet.py
@@ -2,7 +2,6 @@
 
 # SPDX-License-Identifier: Apache-2.0
 
-import tt_lib
 import ttnn
 import torch
 import torch.nn as nn
@@ -74,42 +73,42 @@ class TtLeNet5(nn.Module):
         self.fc_weights = torch2tt_tensor(
             fc_weights.reshape(list((1, 1) + fc_weights.shape)),
             self.device,
-            tt_lib.tensor.Layout.ROW_MAJOR,
+            ttnn.ROW_MAJOR_LAYOUT,
         )
         fc_bias = state_dict[f"fc.bias"]
         self.fc_bias = torch2tt_tensor(
             fc_bias.reshape(list((1, 1, 1) + fc_bias.shape)),
             self.device,
-            tt_lib.tensor.Layout.ROW_MAJOR,
+            ttnn.ROW_MAJOR_LAYOUT,
         )
 
         fc1_weights = state_dict[f"fc1.weight"]
         self.fc1_weights = torch2tt_tensor(
             fc1_weights.reshape(list((1, 1) + fc1_weights.shape)),
             self.device,
-            tt_lib.tensor.Layout.ROW_MAJOR,
+            ttnn.ROW_MAJOR_LAYOUT,
         )
         fc1_bias = state_dict[f"fc1.bias"]
         self.fc1_bias = torch2tt_tensor(
             fc1_bias.reshape(list((1, 1, 1) + fc1_bias.shape)),
             self.device,
-            tt_lib.tensor.Layout.ROW_MAJOR,
+            ttnn.ROW_MAJOR_LAYOUT,
         )
 
         fc2_weights = state_dict[f"fc2.weight"]
         self.fc2_weights = torch2tt_tensor(
             fc2_weights.reshape(list((1, 1) + fc2_weights.shape)),
             self.device,
-            tt_lib.tensor.Layout.ROW_MAJOR,
+            ttnn.ROW_MAJOR_LAYOUT,
         )
         fc2_bias = state_dict[f"fc2.bias"]
         self.fc2_bias = torch2tt_tensor(
             fc2_bias.reshape(list((1, 1, 1) + fc2_bias.shape)),
             self.device,
-            tt_lib.tensor.Layout.ROW_MAJOR,
+            ttnn.ROW_MAJOR_LAYOUT,
         )
 
-    def forward(self, x: tt_lib.tensor.Tensor) -> tt_lib.tensor.Tensor:
+    def forward(self, x: ttnn.Tensor) -> ttnn.Tensor:
         out = self.conv1(x)  # HOST (fallback)
 
         out = self.batch_norm1(out)  # HOST (fallback)

--- a/models/helper_funcs.py
+++ b/models/helper_funcs.py
@@ -3,21 +3,16 @@
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import List, Union, Optional
-from tt_lib import tensor
-import tt_lib as ttl
 import ttnn
 from loguru import logger
-import tt_lib
 
 
 def Linear(
     in_features: int,
     out_features: int,
-    weight: tensor.Tensor,
-    bias: Optional[tensor.Tensor] = None,
-    output_mem_config=tt_lib.tensor.MemoryConfig(
-        tt_lib.tensor.TensorMemoryLayout.INTERLEAVED, tt_lib.tensor.BufferType.DRAM
-    ),
+    weight: ttnn.Tensor,
+    bias: Optional[ttnn.Tensor] = None,
+    output_mem_config=ttnn.DRAM_MEMORY_CONFIG,
 ):
     """
     Returns a function that performs a Linear operation with optional bias.


### PR DESCRIPTION
Issue : https://github.com/tenstorrent/tt-metal/issues/11426 Tracking Issue : https://github.com/tenstorrent/tt-metal/issues/11240 , Master Issue : https://github.com/tenstorrent/tt-metal/issues/10532
### Work Done:

- Replace tt_lib usage in `models/experimental/grok`
- Replace tt_lib usage in `models/experimental/hrnet`
- Replace tt_lib usage in `models/experimental/lenet`
- Replace tt_lib usage in `models/helper_funcs.py`


### Checklist
- [x] All Post commit CI 
- [ ] Nightly Fast Dispatch Test
- [ ] Model regression CI testing passes 
