### PR TITLE
#11367: Replace tt_lib usage in `tests/ttnn/unit_tests`

### DIFF
--- a/tests/ttnn/unit_tests/operations/complex/test_complex_conj.py
+++ b/tests/ttnn/unit_tests/operations/complex/test_complex_conj.py
@@ -4,7 +4,6 @@
 
 import torch
 
-import tt_lib as ttl
 import pytest
 import ttnn
 from loguru import logger
@@ -22,12 +21,12 @@ from tests.ttnn.unit_tests.operations.complex.utility_funcs import (
 @pytest.mark.parametrize(
     "memcfg",
     (
-        ttl.tensor.MemoryConfig(ttl.tensor.TensorMemoryLayout.INTERLEAVED, ttl.tensor.BufferType.DRAM),
-        ttl.tensor.MemoryConfig(ttl.tensor.TensorMemoryLayout.INTERLEAVED, ttl.tensor.BufferType.L1),
+        ttnn.DRAM_MEMORY_CONFIG,
+        ttnn.L1_MEMORY_CONFIG,
     ),
     ids=["out_DRAM", "out_L1"],
 )
-@pytest.mark.parametrize("dtype", ((ttl.tensor.DataType.FLOAT32,)))
+@pytest.mark.parametrize("dtype", ((ttnn.float32,)))
 @pytest.mark.parametrize("bs", ((1, 1),))
 @pytest.mark.parametrize("hw", ((32, 32),))
 def test_conj(bs, hw, memcfg, dtype, device, function_level_defaults):
@@ -36,8 +35,8 @@ def test_conj(bs, hw, memcfg, dtype, device, function_level_defaults):
     in_data = random_complex_tensor(input_shape, (-90, 90), (-70, 70))
 
     input_tensor = ttnn.complex_tensor(
-        ttl.tensor.Tensor(in_data.real, dtype).to(ttl.tensor.Layout.TILE).to(device, memcfg),
-        ttl.tensor.Tensor(in_data.imag, dtype).to(ttl.tensor.Layout.TILE).to(device, memcfg),
+        ttnn.Tensor(in_data.real, dtype).to(ttnn.TILE_LAYOUT).to(device, memcfg),
+        ttnn.Tensor(in_data.imag, dtype).to(ttnn.TILE_LAYOUT).to(device, memcfg),
     )
 
     tt_dev = ttnn.conj(input_tensor, memory_config=memcfg)

--- a/tests/ttnn/unit_tests/operations/complex/utility_funcs.py
+++ b/tests/ttnn/unit_tests/operations/complex/utility_funcs.py
@@ -4,7 +4,7 @@
 
 import torch
 
-import tt_lib as ttl
+import ttnn
 
 
 def random_complex_tensor(shape, real_range=(-100, 100), imag_range=(-100, 100)):
@@ -15,7 +15,7 @@ def random_complex_tensor(shape, real_range=(-100, 100), imag_range=(-100, 100))
 
 
 def convert_complex_to_torch_tensor(tt_dev):
-    tt_dev_r = tt_dev.real.cpu().to(ttl.tensor.Layout.ROW_MAJOR).to_torch()
-    tt_dev_i = tt_dev.imag.cpu().to(ttl.tensor.Layout.ROW_MAJOR).to_torch()
+    tt_dev_r = tt_dev.real.cpu().to(ttnn.ROW_MAJOR_LAYOUT).to_torch()
+    tt_dev_i = tt_dev.imag.cpu().to(ttnn.ROW_MAJOR_LAYOUT).to_torch()
     tt_to_torch = torch.complex(tt_dev_r, tt_dev_i)
     return tt_to_torch

--- a/tests/ttnn/unit_tests/operations/test_all_gather.py
+++ b/tests/ttnn/unit_tests/operations/test_all_gather.py
@@ -5,7 +5,6 @@
 import torch
 import pytest
 from loguru import logger
-import tt_lib as ttl
 import ttnn
 from tests.tt_eager.python_api_testing.sweep_tests.comparison_funcs import comp_equal, comp_pcc
 from models.utility_functions import skip_for_grayskull, get_devices_for_t3000
@@ -13,7 +12,7 @@ import itertools
 
 
 def is_unsupported_case(input_shape, dim, mem_config, num_devices, num_links, input_dtype, layout):
-    if layout == ttl.tensor.Layout.ROW_MAJOR and input_dtype == ttl.tensor.DataType.BFLOAT8_B:
+    if layout == ttnn.ROW_MAJOR_LAYOUT and input_dtype == ttnn.bfloat8_b:
         return True, "Invalid combination"
 
     if num_devices < 2:
@@ -26,8 +25,8 @@ def is_unsupported_case(input_shape, dim, mem_config, num_devices, num_links, in
 
     ## Check that we can readback results
     fast_dispatch_page_size_limit = 55 * 1024
-    elem_size = 2 if input_dtype == ttl.tensor.DataType.BFLOAT16 else 1
-    if layout == ttl.tensor.Layout.ROW_MAJOR and (input_shape[dim] * elem_size) > fast_dispatch_page_size_limit:
+    elem_size = 2 if input_dtype == ttnn.bfloat16 else 1
+    if layout == ttnn.ROW_MAJOR_LAYOUT and (input_shape[dim] * elem_size) > fast_dispatch_page_size_limit:
         # Fast dispatch currently can't breakup readback of large pages into multiple smaller pages and is
         # limited to ~55K pages.
         return True, "Fast dispatch can't support reading back this page size in one shot"
@@ -37,7 +36,7 @@ def is_unsupported_case(input_shape, dim, mem_config, num_devices, num_links, in
     for i in input_shape:
         tensor_size_bytes *= i
     num_l1_banks = 64
-    if mem_config.buffer_type == ttl.tensor.BufferType.L1 and tensor_size_bytes > num_l1_banks * 50 * 1024:
+    if mem_config.buffer_type == ttnn.BufferType.L1 and tensor_size_bytes > num_l1_banks * 50 * 1024:
         return True, "L1 buffer can't support large tensor sizes"
 
     # Check that each chip has a non-zero amount of data available
@@ -45,7 +44,7 @@ def is_unsupported_case(input_shape, dim, mem_config, num_devices, num_links, in
     if dim == 3:
         min_sized_chunks_on_dim //= 32
     if dim == 2:
-        if layout == ttl.tensor.Layout.TILE:
+        if layout == ttnn.TILE_LAYOUT:
             min_sized_chunks_on_dim //= 32
     if min_sized_chunks_on_dim < num_devices:
         return (
@@ -53,12 +52,7 @@ def is_unsupported_case(input_shape, dim, mem_config, num_devices, num_links, in
             f"Input shape {input_shape} incompatible with {num_devices} on dim {dim} because some chips will have no tensor",
         )
 
-    if (
-        input_shape == [8, 8, 256, 384]
-        and dim == 1
-        and layout == ttl.tensor.Layout.TILE
-        and input_dtype == ttl.tensor.DataType.BFLOAT8_B
-    ):
+    if input_shape == [8, 8, 256, 384] and dim == 1 and layout == ttnn.TILE_LAYOUT and input_dtype == ttnn.bfloat8_b:
         return True, "Known failure"
 
     return False, ""
@@ -108,19 +102,19 @@ def run_all_gather_on_t3000_impl(
     input_tensors = torch.chunk(input_tensor, num_devices, dim)
     tt_input_tensors = []
     for i, t in enumerate(input_tensors):
-        tt_input_tensors.append(ttl.tensor.Tensor(t, input_dtype).to(layout).to(devices[i], mem_config))
+        tt_input_tensors.append(ttnn.Tensor(t, input_dtype).to(layout).to(devices[i], mem_config))
 
     input_tensor_mesh = ttnn.aggregate_as_tensor(tt_input_tensors)
     for i in range(num_iters):
         tt_out_tensor = all_gather_operation(input_tensor_mesh, dim, num_links=num_links, memory_config=mem_config)
 
         for d in devices:
-            ttl.device.Synchronize(d)
+            ttnn.synchronize_device(d)
         logger.info(f"Done iteration {i}")
 
     for i, t in enumerate(ttnn.get_device_tensors(tt_out_tensor)):
-        tt_output_tensor = t.cpu().to(ttl.tensor.Layout.ROW_MAJOR).to_torch()
-        if input_dtype == ttl.tensor.DataType.BFLOAT16:
+        tt_output_tensor = t.cpu().to(ttnn.ROW_MAJOR_LAYOUT).to_torch()
+        if input_dtype == ttnn.bfloat16:
             eq, output = comp_equal(tt_output_tensor, input_tensor)
         else:
             eq, output = comp_pcc(tt_output_tensor, input_tensor)
@@ -166,30 +160,28 @@ def run_all_gather_on_t3000_impl_tight_loop(
 @pytest.mark.parametrize(
     "num_devices, num_links, input_shape, dim, layout",
     [
-        # (4, 2, [4, 1, 256, 32], 0, ttl.tensor.Layout.TILE),        # https://github.com/tenstorrent/tt-metal/issues/9686
-        # (8, 1, [8, 1, 256, 32], 0, ttl.tensor.Layout.TILE),        # https://github.com/tenstorrent/tt-metal/issues/9686
-        (8, 1, [1, 1, 32, 16384], 3, ttl.tensor.Layout.TILE),
-        # (4, 2, [1, 1, 32, 32768], 3, ttl.tensor.Layout.TILE),      # https://github.com/tenstorrent/tt-metal/issues/9686
-        # (4, 2, [4, 1, 256, 32], 0, ttl.tensor.Layout.ROW_MAJOR),   # https://github.com/tenstorrent/tt-metal/issues/9686
-        # (8, 1, [8, 1, 256, 32], 0, ttl.tensor.Layout.ROW_MAJOR),   # https://github.com/tenstorrent/tt-metal/issues/9686
-        # (8, 1, [1, 1, 32, 16384], 3, ttl.tensor.Layout.ROW_MAJOR), # https://github.com/tenstorrent/tt-metal/issues/9686
-        # (4, 2, [1, 1, 32, 32768], 3, ttl.tensor.Layout.ROW_MAJOR), # https://github.com/tenstorrent/tt-metal/issues/9686
+        # (4, 2, [4, 1, 256, 32], 0, ttnn.TILE_LAYOUT),        # https://github.com/tenstorrent/tt-metal/issues/9686
+        # (8, 1, [8, 1, 256, 32], 0, ttnn.TILE_LAYOUT),        # https://github.com/tenstorrent/tt-metal/issues/9686
+        (8, 1, [1, 1, 32, 16384], 3, ttnn.TILE_LAYOUT),
+        # (4, 2, [1, 1, 32, 32768], 3, ttnn.TILE_LAYOUT),      # https://github.com/tenstorrent/tt-metal/issues/9686
+        # (4, 2, [4, 1, 256, 32], 0, ttnn.ROW_MAJOR_LAYOUT),   # https://github.com/tenstorrent/tt-metal/issues/9686
+        # (8, 1, [8, 1, 256, 32], 0, ttnn.ROW_MAJOR_LAYOUT),   # https://github.com/tenstorrent/tt-metal/issues/9686
+        # (8, 1, [1, 1, 32, 16384], 3, ttnn.ROW_MAJOR_LAYOUT), # https://github.com/tenstorrent/tt-metal/issues/9686
+        # (4, 2, [1, 1, 32, 32768], 3, ttnn.ROW_MAJOR_LAYOUT), # https://github.com/tenstorrent/tt-metal/issues/9686
     ],
 )
 @pytest.mark.parametrize(
     "input_dtype",
     [
-        ttl.tensor.DataType.BFLOAT16,
-        # ttl.tensor.DataType.BFLOAT8_B,        # https://github.com/tenstorrent/tt-metal/issues/9686
+        ttnn.bfloat16,
+        # ttnn.bfloat8_b,        # https://github.com/tenstorrent/tt-metal/issues/9686
     ],
 )
 @pytest.mark.parametrize(
     "mem_config",
     [
-        ttl.tensor.MemoryConfig(
-            buffer_type=ttl.tensor.BufferType.DRAM
-        ),  # https://github.com/tenstorrent/tt-metal/issues/9686
-        # ttl.tensor.MemoryConfig(buffer_type=ttl.tensor.BufferType.L1),
+        ttnn.MemoryConfig(buffer_type=ttnn.BufferType.DRAM),  # https://github.com/tenstorrent/tt-metal/issues/9686
+        # ttnn.MemoryConfig(buffer_type=ttnn.BufferType.L1),
     ],
 )
 @pytest.mark.parametrize("num_iters", [1])  # restore to 500: https://github.com/tenstorrent/tt-metal/issues/9686
@@ -230,28 +222,28 @@ def test_all_gather_on_t3000_post_commit_looping(
 @pytest.mark.parametrize(
     "num_devices, num_links, input_shape, dim, layout",
     [
-        (4, 2, [4, 1, 256, 32], 0, ttl.tensor.Layout.TILE),
-        (8, 1, [8, 1, 256, 32], 0, ttl.tensor.Layout.TILE),
-        (8, 1, [1, 1, 32, 16384], 3, ttl.tensor.Layout.TILE),
-        (4, 2, [1, 1, 32, 32768], 3, ttl.tensor.Layout.TILE),
-        (4, 2, [4, 1, 256, 32], 0, ttl.tensor.Layout.ROW_MAJOR),
-        (8, 1, [8, 1, 256, 32], 0, ttl.tensor.Layout.ROW_MAJOR),
-        (8, 1, [1, 1, 32, 16384], 3, ttl.tensor.Layout.ROW_MAJOR),
-        (4, 2, [1, 1, 32, 32768], 3, ttl.tensor.Layout.ROW_MAJOR),
+        (4, 2, [4, 1, 256, 32], 0, ttnn.TILE_LAYOUT),
+        (8, 1, [8, 1, 256, 32], 0, ttnn.TILE_LAYOUT),
+        (8, 1, [1, 1, 32, 16384], 3, ttnn.TILE_LAYOUT),
+        (4, 2, [1, 1, 32, 32768], 3, ttnn.TILE_LAYOUT),
+        (4, 2, [4, 1, 256, 32], 0, ttnn.ROW_MAJOR_LAYOUT),
+        (8, 1, [8, 1, 256, 32], 0, ttnn.ROW_MAJOR_LAYOUT),
+        (8, 1, [1, 1, 32, 16384], 3, ttnn.ROW_MAJOR_LAYOUT),
+        (4, 2, [1, 1, 32, 32768], 3, ttnn.ROW_MAJOR_LAYOUT),
     ],
 )
 @pytest.mark.parametrize(
     "input_dtype",
     [
-        ttl.tensor.DataType.BFLOAT16,
-        # ttl.tensor.DataType.BFLOAT8_B,        # https://github.com/tenstorrent/tt-metal/issues/9686
+        ttnn.bfloat16,
+        # ttnn.bfloat8_b,        # https://github.com/tenstorrent/tt-metal/issues/9686
     ],
 )
 @pytest.mark.parametrize(
     "mem_config",
     [
-        # ttl.tensor.MemoryConfig(buffer_type=ttl.tensor.BufferType.DRAM),        # https://github.com/tenstorrent/tt-metal/issues/9686
-        ttl.tensor.MemoryConfig(buffer_type=ttl.tensor.BufferType.L1),
+        # ttnn.MemoryConfig(buffer_type=ttnn.BufferType.DRAM),        # https://github.com/tenstorrent/tt-metal/issues/9686
+        ttnn.MemoryConfig(buffer_type=ttnn.BufferType.L1),
     ],
 )
 @pytest.mark.parametrize("num_iters", [1000])  # TODO: restore to 500
@@ -292,58 +284,58 @@ def test_all_gather_on_t3000_nightly_commit_looping(
 @pytest.mark.parametrize(
     "num_devices, num_links, input_shape, dim, layout",
     [
-        (4, 2, [4, 1, 33, 256], 0, ttl.tensor.Layout.ROW_MAJOR),  # https://github.com/tenstorrent/tt-metal/issues/9686
-        (8, 1, [8, 1, 33, 256], 0, ttl.tensor.Layout.ROW_MAJOR),  # https://github.com/tenstorrent/tt-metal/issues/9686
-        # (8, 1, [8, 8, 256, 384], 1, ttl.tensor.Layout.ROW_MAJOR),           # https://github.com/tenstorrent/tt-metal/issues/9686
-        # (4, 2, [8, 8, 256, 384], 1, ttl.tensor.Layout.ROW_MAJOR),           # https://github.com/tenstorrent/tt-metal/issues/9686
-        # (4, 2, [8, 8, 256, 384], 1, ttl.tensor.Layout.TILE),           # https://github.com/tenstorrent/tt-metal/issues/9686
-        # (8, 1, [8, 8, 256, 384], 1, ttl.tensor.Layout.TILE),           # https://github.com/tenstorrent/tt-metal/issues/9686
-        # (4, 2, [8, 5, 13, 384], 3, ttl.tensor.Layout.ROW_MAJOR),           # https://github.com/tenstorrent/tt-metal/issues/9686
-        # (8, 1, [8, 5, 13, 512], 3, ttl.tensor.Layout.ROW_MAJOR),           # https://github.com/tenstorrent/tt-metal/issues/9686
-        # (4, 2, [8, 5, 32, 384], 3, ttl.tensor.Layout.TILE),           # https://github.com/tenstorrent/tt-metal/issues/9686
-        # (8, 1, [8, 5, 32, 512], 3, ttl.tensor.Layout.TILE),
+        (4, 2, [4, 1, 33, 256], 0, ttnn.ROW_MAJOR_LAYOUT),  # https://github.com/tenstorrent/tt-metal/issues/9686
+        (8, 1, [8, 1, 33, 256], 0, ttnn.ROW_MAJOR_LAYOUT),  # https://github.com/tenstorrent/tt-metal/issues/9686
+        # (8, 1, [8, 8, 256, 384], 1, ttnn.ROW_MAJOR_LAYOUT),           # https://github.com/tenstorrent/tt-metal/issues/9686
+        # (4, 2, [8, 8, 256, 384], 1, ttnn.ROW_MAJOR_LAYOUT),           # https://github.com/tenstorrent/tt-metal/issues/9686
+        # (4, 2, [8, 8, 256, 384], 1, ttnn.TILE_LAYOUT),           # https://github.com/tenstorrent/tt-metal/issues/9686
+        # (8, 1, [8, 8, 256, 384], 1, ttnn.TILE_LAYOUT),           # https://github.com/tenstorrent/tt-metal/issues/9686
+        # (4, 2, [8, 5, 13, 384], 3, ttnn.ROW_MAJOR_LAYOUT),           # https://github.com/tenstorrent/tt-metal/issues/9686
+        # (8, 1, [8, 5, 13, 512], 3, ttnn.ROW_MAJOR_LAYOUT),           # https://github.com/tenstorrent/tt-metal/issues/9686
+        # (4, 2, [8, 5, 32, 384], 3, ttnn.TILE_LAYOUT),           # https://github.com/tenstorrent/tt-metal/issues/9686
+        # (8, 1, [8, 5, 32, 512], 3, ttnn.TILE_LAYOUT),
         # Only for BFP8B
-        # # ([1, 1, 640, 32768], 3, ttl.tensor.Layout.TILE),        # https://github.com/tenstorrent/tt-metal/issues/9686
+        # # ([1, 1, 640, 32768], 3, ttnn.TILE_LAYOUT),        # https://github.com/tenstorrent/tt-metal/issues/9686
         # # MLP AllGather,  Llama 2 decode attn, mlp. Llama2, Falcon 40B decode mlp attn
-        # (8, 1, [1, 1, 32, 32768], 3, ttl.tensor.Layout.TILE),        # https://github.com/tenstorrent/tt-metal/issues/9686
-        # (4, 2, [1, 1, 32, 16384], 3, ttl.tensor.Layout.TILE),        # https://github.com/tenstorrent/tt-metal/issues/9686
-        # # (4, 2, [1, 1, 32, 32768], 3, ttl.tensor.Layout.TILE),        # https://github.com/tenstorrent/tt-metal/issues/9686
-        # # (8, 1, [1, 1, 32, 32768], 3, ttl.tensor.Layout.ROW_MAJOR),        # https://github.com/tenstorrent/tt-metal/issues/9686
+        # (8, 1, [1, 1, 32, 32768], 3, ttnn.TILE_LAYOUT),        # https://github.com/tenstorrent/tt-metal/issues/9686
+        # (4, 2, [1, 1, 32, 16384], 3, ttnn.TILE_LAYOUT),        # https://github.com/tenstorrent/tt-metal/issues/9686
+        # # (4, 2, [1, 1, 32, 32768], 3, ttnn.TILE_LAYOUT),        # https://github.com/tenstorrent/tt-metal/issues/9686
+        # # (8, 1, [1, 1, 32, 32768], 3, ttnn.ROW_MAJOR_LAYOUT),        # https://github.com/tenstorrent/tt-metal/issues/9686
         # # Input, Selfout, Final AllGather,  Llama2, Falcon 40B decode mlp attn
-        # (8, 1, [1, 1, 32, 8192], 3, ttl.tensor.Layout.TILE),        # https://github.com/tenstorrent/tt-metal/issues/9686
-        # (4, 2, [1, 1, 32, 8192], 3, ttl.tensor.Layout.TILE),        # https://github.com/tenstorrent/tt-metal/issues/9686
-        # (8, 1, [1, 1, 32, 8192], 3, ttl.tensor.Layout.ROW_MAJOR),        # https://github.com/tenstorrent/tt-metal/issues/9686
+        # (8, 1, [1, 1, 32, 8192], 3, ttnn.TILE_LAYOUT),        # https://github.com/tenstorrent/tt-metal/issues/9686
+        # (4, 2, [1, 1, 32, 8192], 3, ttnn.TILE_LAYOUT),        # https://github.com/tenstorrent/tt-metal/issues/9686
+        # (8, 1, [1, 1, 32, 8192], 3, ttnn.ROW_MAJOR_LAYOUT),        # https://github.com/tenstorrent/tt-metal/issues/9686
         # # Falcon 40B prefill
         # # 8 chips
-        # (8, 1, [1, 1, 2048, 8192], 3, ttl.tensor.Layout.TILE),          # https://github.com/tenstorrent/tt-metal/issues/9686
-        # (8, 1, [1, 1, 2048, 8192], 3, ttl.tensor.Layout.ROW_MAJOR),          # https://github.com/tenstorrent/tt-metal/issues/9686
+        # (8, 1, [1, 1, 2048, 8192], 3, ttnn.TILE_LAYOUT),          # https://github.com/tenstorrent/tt-metal/issues/9686
+        # (8, 1, [1, 1, 2048, 8192], 3, ttnn.ROW_MAJOR_LAYOUT),          # https://github.com/tenstorrent/tt-metal/issues/9686
         # # Falcon 40B prefill, also mixtral expert reduction (w/ zero filled tensor)
         # # 8 chips
-        # (8, 1, [1, 1, 2048, 32768], 3, ttl.tensor.Layout.TILE),  # https://github.com/tenstorrent/tt-metal/issues/9686
+        # (8, 1, [1, 1, 2048, 32768], 3, ttnn.TILE_LAYOUT),  # https://github.com/tenstorrent/tt-metal/issues/9686
         # # Llama/falcon40B galaxy mlp weights stationary -> emulation of row/col reduce
-        # (8, 1, [1, 1, 256, 1024], 2, ttl.tensor.Layout.TILE),          # https://github.com/tenstorrent/tt-metal/issues/9686
-        # (8, 1, [1, 1, 246, 4096], 2, ttl.tensor.Layout.ROW_MAJOR),          # https://github.com/tenstorrent/tt-metal/issues/9686
-        # (8, 1, [1, 1, 246, 4096], 2, ttl.tensor.Layout.TILE),          # https://github.com/tenstorrent/tt-metal/issues/9686
-        # (8, 1, [1, 1, 8192, 32], 2, ttl.tensor.Layout.TILE),          # https://github.com/tenstorrent/tt-metal/issues/9686
-        # (8, 1, [1, 1, 1024, 256], 3, ttl.tensor.Layout.TILE),          # https://github.com/tenstorrent/tt-metal/issues/9686
-        # (8, 1, [1, 1, 256, 2048], 2, ttl.tensor.Layout.TILE),          # https://github.com/tenstorrent/tt-metal/issues/9686
-        # (8, 1, [1, 1, 256, 8192], 2, ttl.tensor.Layout.TILE),  # double on reduction dim for 8 chip          # https://github.com/tenstorrent/tt-metal/issues/9686
-        # (8, 1, [8, 1, 256, 32], 0, ttl.tensor.Layout.TILE),          # https://github.com/tenstorrent/tt-metal/issues/9686
-        # (8, 1, [8, 8, 128, 4096], 1, ttl.tensor.Layout.TILE),          # https://github.com/tenstorrent/tt-metal/issues/9686
+        # (8, 1, [1, 1, 256, 1024], 2, ttnn.TILE_LAYOUT),          # https://github.com/tenstorrent/tt-metal/issues/9686
+        # (8, 1, [1, 1, 246, 4096], 2, ttnn.ROW_MAJOR_LAYOUT),          # https://github.com/tenstorrent/tt-metal/issues/9686
+        # (8, 1, [1, 1, 246, 4096], 2, ttnn.TILE_LAYOUT),          # https://github.com/tenstorrent/tt-metal/issues/9686
+        # (8, 1, [1, 1, 8192, 32], 2, ttnn.TILE_LAYOUT),          # https://github.com/tenstorrent/tt-metal/issues/9686
+        # (8, 1, [1, 1, 1024, 256], 3, ttnn.TILE_LAYOUT),          # https://github.com/tenstorrent/tt-metal/issues/9686
+        # (8, 1, [1, 1, 256, 2048], 2, ttnn.TILE_LAYOUT),          # https://github.com/tenstorrent/tt-metal/issues/9686
+        # (8, 1, [1, 1, 256, 8192], 2, ttnn.TILE_LAYOUT),  # double on reduction dim for 8 chip          # https://github.com/tenstorrent/tt-metal/issues/9686
+        # (8, 1, [8, 1, 256, 32], 0, ttnn.TILE_LAYOUT),          # https://github.com/tenstorrent/tt-metal/issues/9686
+        # (8, 1, [8, 8, 128, 4096], 1, ttnn.TILE_LAYOUT),          # https://github.com/tenstorrent/tt-metal/issues/9686
     ],
 )
 @pytest.mark.parametrize(
     "input_dtype",
     [
-        ttl.tensor.DataType.BFLOAT16,
-        # ttl.tensor.DataType.BFLOAT8_B,          # https://github.com/tenstorrent/tt-metal/issues/9686
+        ttnn.bfloat16,
+        # ttnn.bfloat8_b,          # https://github.com/tenstorrent/tt-metal/issues/9686
     ],
 )
 @pytest.mark.parametrize(
     "mem_config",
     [
-        ttl.tensor.MemoryConfig(buffer_type=ttl.tensor.BufferType.DRAM),
-        # ttl.tensor.MemoryConfig(buffer_type=ttl.tensor.BufferType.L1),  # https://github.com/tenstorrent/tt-metal/issues/9686
+        ttnn.MemoryConfig(buffer_type=ttnn.BufferType.DRAM),
+        # ttnn.MemoryConfig(buffer_type=ttnn.BufferType.L1),  # https://github.com/tenstorrent/tt-metal/issues/9686
     ],
 )
 def test_all_gather_on_t3000_post_commit(
@@ -412,19 +404,19 @@ def run_line_all_gather(
     input_tensors = torch.chunk(input_tensor, num_devices, dim)
     tt_input_tensors = []
     for i, t in enumerate(input_tensors):
-        tt_input_tensors.append(ttl.tensor.Tensor(t, input_dtype).to(layout).to(devices[i], mem_config))
+        tt_input_tensors.append(ttnn.Tensor(t, input_dtype).to(layout).to(devices[i], mem_config))
 
     input_tensor_mesh = ttnn.aggregate_as_tensor(tt_input_tensors)
     for i in range(num_iters):
         tt_out_tensor = ttnn.line_all_gather(input_tensor_mesh, dim, num_links=num_links, memory_config=mem_config)
 
         for d in devices:
-            ttl.device.Synchronize(d)
+            ttnn.synchronize_device(d)
         logger.info(f"Done iteration {i}")
 
     for i, t in enumerate(ttnn.get_device_tensors(tt_out_tensor)):
-        tt_output_tensor = t.cpu().to(ttl.tensor.Layout.ROW_MAJOR).to_torch()
-        if input_dtype == ttl.tensor.DataType.BFLOAT16:
+        tt_output_tensor = t.cpu().to(ttnn.ROW_MAJOR_LAYOUT).to_torch()
+        if input_dtype == ttnn.bfloat16:
             eq, output = comp_equal(tt_output_tensor, input_tensor)
         else:
             eq, output = comp_pcc(tt_output_tensor, input_tensor)
@@ -438,36 +430,34 @@ def run_line_all_gather(
 @pytest.mark.parametrize(
     "num_devices, num_links, input_shape, dim, layout",
     [
-        (4, 2, [1, 4, 32, 3584], 1, ttl.tensor.Layout.TILE),
-        (8, 1, [1, 8, 32, 2048], 1, ttl.tensor.Layout.TILE),
-        (8, 1, [1, 8, 32, 4096], 1, ttl.tensor.Layout.TILE),
-        # (4, 1, [4, 1, 33, 256], 0, ttl.tensor.Layout.ROW_MAJOR), # https://github.com/tenstorrent/tt-metal/issues/9686
-        # (8, 1, [8, 1, 33, 256], 0, ttl.tensor.Layout.ROW_MAJOR), # https://github.com/tenstorrent/tt-metal/issues/9686
-        # # (8, 1, [8, 1, 256, 32], 0, ttl.tensor.Layout.TILE),
-        # (8, 1, [8, 8, 256, 384], 1, ttl.tensor.Layout.ROW_MAJOR), # https://github.com/tenstorrent/tt-metal/issues/9686
-        # (4, 2, [8, 8, 256, 384], 1, ttl.tensor.Layout.TILE), # https://github.com/tenstorrent/tt-metal/issues/9686
-        # (8, 1, [8, 8, 256, 384], 1, ttl.tensor.Layout.TILE), # https://github.com/tenstorrent/tt-metal/issues/9686
-        # (4, 1, [8, 5, 13, 384], 3, ttl.tensor.Layout.ROW_MAJOR), # https://github.com/tenstorrent/tt-metal/issues/9686
-        # (8, 1, [8, 5, 13, 512], 3, ttl.tensor.Layout.ROW_MAJOR), # https://github.com/tenstorrent/tt-metal/issues/9686
-        # (4, 1, [8, 5, 32, 384], 3, ttl.tensor.Layout.TILE), # https://github.com/tenstorrent/tt-metal/issues/9686
-        # (8, 1, [8, 5, 32, 512], 3, ttl.tensor.Layout.TILE), # https://github.com/tenstorrent/tt-metal/issues/9686
-        # (4, 1, [1, 1, 32, 16384], 3, ttl.tensor.Layout.TILE),
+        (4, 2, [1, 4, 32, 3584], 1, ttnn.TILE_LAYOUT),
+        (8, 1, [1, 8, 32, 2048], 1, ttnn.TILE_LAYOUT),
+        (8, 1, [1, 8, 32, 4096], 1, ttnn.TILE_LAYOUT),
+        # (4, 1, [4, 1, 33, 256], 0, ttnn.ROW_MAJOR_LAYOUT), # https://github.com/tenstorrent/tt-metal/issues/9686
+        # (8, 1, [8, 1, 33, 256], 0, ttnn.ROW_MAJOR_LAYOUT), # https://github.com/tenstorrent/tt-metal/issues/9686
+        # # (8, 1, [8, 1, 256, 32], 0, ttnn.TILE_LAYOUT),
+        # (8, 1, [8, 8, 256, 384], 1, ttnn.ROW_MAJOR_LAYOUT), # https://github.com/tenstorrent/tt-metal/issues/9686
+        # (4, 2, [8, 8, 256, 384], 1, ttnn.TILE_LAYOUT), # https://github.com/tenstorrent/tt-metal/issues/9686
+        # (8, 1, [8, 8, 256, 384], 1, ttnn.TILE_LAYOUT), # https://github.com/tenstorrent/tt-metal/issues/9686
+        # (4, 1, [8, 5, 13, 384], 3, ttnn.ROW_MAJOR_LAYOUT), # https://github.com/tenstorrent/tt-metal/issues/9686
+        # (8, 1, [8, 5, 13, 512], 3, ttnn.ROW_MAJOR_LAYOUT), # https://github.com/tenstorrent/tt-metal/issues/9686
+        # (4, 1, [8, 5, 32, 384], 3, ttnn.TILE_LAYOUT), # https://github.com/tenstorrent/tt-metal/issues/9686
+        # (8, 1, [8, 5, 32, 512], 3, ttnn.TILE_LAYOUT), # https://github.com/tenstorrent/tt-metal/issues/9686
+        # (4, 1, [1, 1, 32, 16384], 3, ttnn.TILE_LAYOUT),
     ],
 )
 @pytest.mark.parametrize(
     "input_dtype",
     [
-        ttl.tensor.DataType.BFLOAT16,
-        ttl.tensor.DataType.BFLOAT8_B,  # https://github.com/tenstorrent/tt-metal/issues/9686
+        ttnn.bfloat16,
+        ttnn.bfloat8_b,  # https://github.com/tenstorrent/tt-metal/issues/9686
     ],
 )
 @pytest.mark.parametrize(
     "mem_config",
     [
-        ttl.tensor.MemoryConfig(
-            buffer_type=ttl.tensor.BufferType.DRAM
-        ),  # https://github.com/tenstorrent/tt-metal/issues/9686
-        # ttl.tensor.MemoryConfig(buffer_type=ttl.tensor.BufferType.L1),
+        ttnn.MemoryConfig(buffer_type=ttnn.BufferType.DRAM),  # https://github.com/tenstorrent/tt-metal/issues/9686
+        # ttnn.MemoryConfig(buffer_type=ttnn.BufferType.L1),
     ],
 )
 @pytest.mark.parametrize("enable_async", [True, False])
@@ -506,31 +496,31 @@ def test_line_all_gather_on_t3000_post_commit(
 @pytest.mark.parametrize(
     "num_devices, num_links, input_shape, dim, layout",
     [
-        (4, 1, [4, 1, 33, 256], 0, ttl.tensor.Layout.ROW_MAJOR),
-        (8, 1, [8, 1, 33, 256], 0, ttl.tensor.Layout.ROW_MAJOR),
-        # (8, 1, [8, 1, 256, 32], 0, ttl.tensor.Layout.TILE),
-        (8, 1, [8, 8, 256, 384], 1, ttl.tensor.Layout.ROW_MAJOR),
-        (4, 2, [8, 8, 256, 384], 1, ttl.tensor.Layout.TILE),
-        (8, 1, [8, 8, 256, 384], 1, ttl.tensor.Layout.TILE),
-        (4, 1, [8, 5, 13, 384], 3, ttl.tensor.Layout.ROW_MAJOR),
-        (8, 1, [8, 5, 13, 512], 3, ttl.tensor.Layout.ROW_MAJOR),
-        (4, 1, [8, 5, 32, 384], 3, ttl.tensor.Layout.TILE),
-        (8, 1, [8, 5, 32, 512], 3, ttl.tensor.Layout.TILE),
-        (4, 1, [1, 1, 32, 16384], 3, ttl.tensor.Layout.TILE),
+        (4, 1, [4, 1, 33, 256], 0, ttnn.ROW_MAJOR_LAYOUT),
+        (8, 1, [8, 1, 33, 256], 0, ttnn.ROW_MAJOR_LAYOUT),
+        # (8, 1, [8, 1, 256, 32], 0, ttnn.TILE_LAYOUT),
+        (8, 1, [8, 8, 256, 384], 1, ttnn.ROW_MAJOR_LAYOUT),
+        (4, 2, [8, 8, 256, 384], 1, ttnn.TILE_LAYOUT),
+        (8, 1, [8, 8, 256, 384], 1, ttnn.TILE_LAYOUT),
+        (4, 1, [8, 5, 13, 384], 3, ttnn.ROW_MAJOR_LAYOUT),
+        (8, 1, [8, 5, 13, 512], 3, ttnn.ROW_MAJOR_LAYOUT),
+        (4, 1, [8, 5, 32, 384], 3, ttnn.TILE_LAYOUT),
+        (8, 1, [8, 5, 32, 512], 3, ttnn.TILE_LAYOUT),
+        (4, 1, [1, 1, 32, 16384], 3, ttnn.TILE_LAYOUT),
     ],
 )
 @pytest.mark.parametrize(
     "input_dtype",
     [
-        ttl.tensor.DataType.BFLOAT16,
-        ttl.tensor.DataType.BFLOAT8_B,
+        ttnn.bfloat16,
+        ttnn.bfloat8_b,
     ],
 )
 @pytest.mark.parametrize(
     "mem_config",
     [
-        ttl.tensor.MemoryConfig(buffer_type=ttl.tensor.BufferType.DRAM),
-        ttl.tensor.MemoryConfig(buffer_type=ttl.tensor.BufferType.L1),
+        ttnn.MemoryConfig(buffer_type=ttnn.BufferType.DRAM),
+        ttnn.MemoryConfig(buffer_type=ttnn.BufferType.L1),
     ],
 )
 @pytest.mark.parametrize("enable_async", [True, False])
@@ -577,115 +567,115 @@ def test_line_all_gather_on_t3000_nightly(
 @pytest.mark.parametrize(
     "input_shape, dim, layout",
     [
-        ([4, 1, 33, 256], 0, ttl.tensor.Layout.ROW_MAJOR),
-        ([4, 1, 256, 32], 0, ttl.tensor.Layout.TILE),
-        ([8, 5, 13, 512], 3, ttl.tensor.Layout.ROW_MAJOR),
-        ([8, 5, 32, 512], 3, ttl.tensor.Layout.TILE),
-        ([8, 5, 13, 384], 3, ttl.tensor.Layout.ROW_MAJOR),
-        ([8, 5, 32, 384], 3, ttl.tensor.Layout.TILE),
-        ([8, 8, 256, 384], 0, ttl.tensor.Layout.ROW_MAJOR),
-        ([8, 8, 256, 384], 0, ttl.tensor.Layout.TILE),
-        ([8, 8, 256, 384], 1, ttl.tensor.Layout.ROW_MAJOR),
-        ([8, 8, 256, 384], 1, ttl.tensor.Layout.TILE),
-        ([8, 8, 256, 384], 2, ttl.tensor.Layout.ROW_MAJOR),
-        ([8, 8, 256, 384], 2, ttl.tensor.Layout.TILE),
-        ([8, 8, 256, 384], 3, ttl.tensor.Layout.ROW_MAJOR),
-        ([8, 8, 256, 384], 3, ttl.tensor.Layout.TILE),
-        ([8, 8, 256, 768], 3, ttl.tensor.Layout.ROW_MAJOR),
-        ([8, 8, 256, 768], 3, ttl.tensor.Layout.TILE),
-        ([8, 8, 1024, 4096], 1, ttl.tensor.Layout.TILE),
-        ([8, 8, 2048, 4096], 1, ttl.tensor.Layout.TILE),
-        ([8, 8, 128, 4096], 1, ttl.tensor.Layout.ROW_MAJOR),
-        ([8, 8, 1024, 4096], 1, ttl.tensor.Layout.ROW_MAJOR),
-        ([8, 8, 2048, 4096], 1, ttl.tensor.Layout.ROW_MAJOR),
+        ([4, 1, 33, 256], 0, ttnn.ROW_MAJOR_LAYOUT),
+        ([4, 1, 256, 32], 0, ttnn.TILE_LAYOUT),
+        ([8, 5, 13, 512], 3, ttnn.ROW_MAJOR_LAYOUT),
+        ([8, 5, 32, 512], 3, ttnn.TILE_LAYOUT),
+        ([8, 5, 13, 384], 3, ttnn.ROW_MAJOR_LAYOUT),
+        ([8, 5, 32, 384], 3, ttnn.TILE_LAYOUT),
+        ([8, 8, 256, 384], 0, ttnn.ROW_MAJOR_LAYOUT),
+        ([8, 8, 256, 384], 0, ttnn.TILE_LAYOUT),
+        ([8, 8, 256, 384], 1, ttnn.ROW_MAJOR_LAYOUT),
+        ([8, 8, 256, 384], 1, ttnn.TILE_LAYOUT),
+        ([8, 8, 256, 384], 2, ttnn.ROW_MAJOR_LAYOUT),
+        ([8, 8, 256, 384], 2, ttnn.TILE_LAYOUT),
+        ([8, 8, 256, 384], 3, ttnn.ROW_MAJOR_LAYOUT),
+        ([8, 8, 256, 384], 3, ttnn.TILE_LAYOUT),
+        ([8, 8, 256, 768], 3, ttnn.ROW_MAJOR_LAYOUT),
+        ([8, 8, 256, 768], 3, ttnn.TILE_LAYOUT),
+        ([8, 8, 1024, 4096], 1, ttnn.TILE_LAYOUT),
+        ([8, 8, 2048, 4096], 1, ttnn.TILE_LAYOUT),
+        ([8, 8, 128, 4096], 1, ttnn.ROW_MAJOR_LAYOUT),
+        ([8, 8, 1024, 4096], 1, ttnn.ROW_MAJOR_LAYOUT),
+        ([8, 8, 2048, 4096], 1, ttnn.ROW_MAJOR_LAYOUT),
         # Only for BFP8B
-        # ([1, 1, 640, 32768], 3, ttl.tensor.Layout.TILE),
+        # ([1, 1, 640, 32768], 3, ttnn.TILE_LAYOUT),
         # MLP AllGather. Llama 2 decode attn, mlp. Llama2, Falcon 40B decode mlp attn
         # Mixtral 8x7B, functional bringup with expanded tensor getting allgathered
         # Full shape for 8 chips
-        ([1, 1, 32, 32768], 3, ttl.tensor.Layout.TILE),
-        ([1, 1, 32, 32768], 3, ttl.tensor.Layout.ROW_MAJOR),
+        ([1, 1, 32, 32768], 3, ttnn.TILE_LAYOUT),
+        ([1, 1, 32, 32768], 3, ttnn.ROW_MAJOR_LAYOUT),
         # Input, Selfout, Final AllGather
-        ([1, 1, 32, 8192], 3, ttl.tensor.Layout.TILE),
-        ([1, 1, 32, 8192], 3, ttl.tensor.Layout.ROW_MAJOR),
+        ([1, 1, 32, 8192], 3, ttnn.TILE_LAYOUT),
+        ([1, 1, 32, 8192], 3, ttnn.ROW_MAJOR_LAYOUT),
         # MLP AllGather. Llama 2 decode attn, mlp. Llama2, Falcon 40B decode mlp attn
         # Half shape for 4 chips, same per chip shape as 8 chips
-        ([1, 1, 32, 16384], 3, ttl.tensor.Layout.TILE),
-        ([1, 1, 32, 16384], 3, ttl.tensor.Layout.ROW_MAJOR),
+        ([1, 1, 32, 16384], 3, ttnn.TILE_LAYOUT),
+        ([1, 1, 32, 16384], 3, ttnn.ROW_MAJOR_LAYOUT),
         # Input, Selfout, Final AllGather. Llama2, Falcon 40B decode mlp attn
         # Full shape for 8 chips
-        ([1, 1, 32, 8192], 3, ttl.tensor.Layout.TILE),
-        ([1, 1, 32, 8192], 3, ttl.tensor.Layout.ROW_MAJOR),
+        ([1, 1, 32, 8192], 3, ttnn.TILE_LAYOUT),
+        ([1, 1, 32, 8192], 3, ttnn.ROW_MAJOR_LAYOUT),
         # Input, Selfout, Final AllGather. Llama2, Falcon 40B decode mlp attn
         # Half shape for running on 4 chips, same per chip shape as for 8 chips
-        ([1, 1, 32, 4096], 3, ttl.tensor.Layout.TILE),
-        ([1, 1, 32, 4096], 3, ttl.tensor.Layout.ROW_MAJOR),
+        ([1, 1, 32, 4096], 3, ttnn.TILE_LAYOUT),
+        ([1, 1, 32, 4096], 3, ttnn.ROW_MAJOR_LAYOUT),
         # Falcon 40B prefill
         # 8 chips
-        ([1, 1, 2048, 8192], 3, ttl.tensor.Layout.TILE),
-        ([1, 1, 2048, 8192], 3, ttl.tensor.Layout.ROW_MAJOR),
+        ([1, 1, 2048, 8192], 3, ttnn.TILE_LAYOUT),
+        ([1, 1, 2048, 8192], 3, ttnn.ROW_MAJOR_LAYOUT),
         # 4 chips, same per chip shape as 8 chips
-        ([1, 1, 2048, 4096], 3, ttl.tensor.Layout.TILE),
-        ([1, 1, 2048, 4096], 3, ttl.tensor.Layout.ROW_MAJOR),
+        ([1, 1, 2048, 4096], 3, ttnn.TILE_LAYOUT),
+        ([1, 1, 2048, 4096], 3, ttnn.ROW_MAJOR_LAYOUT),
         # Falcon 40B prefill
         # 8 chips
-        ([1, 1, 2048, 32768], 3, ttl.tensor.Layout.TILE),
-        ([1, 1, 2048, 32768], 3, ttl.tensor.Layout.ROW_MAJOR),
+        ([1, 1, 2048, 32768], 3, ttnn.TILE_LAYOUT),
+        ([1, 1, 2048, 32768], 3, ttnn.ROW_MAJOR_LAYOUT),
         # 4 chips, same per chip shape as 8 chips
-        ([1, 1, 2048, 16384], 3, ttl.tensor.Layout.TILE),
-        ([1, 1, 2048, 16384], 3, ttl.tensor.Layout.ROW_MAJOR),
+        ([1, 1, 2048, 16384], 3, ttnn.TILE_LAYOUT),
+        ([1, 1, 2048, 16384], 3, ttnn.ROW_MAJOR_LAYOUT),
         # Mixtral 8x7B, Min sequence length
         # 8 chips
-        # ([1, 1, 32768, 32768], 3, ttl.tensor.Layout.ROW_MAJOR),
-        ([1, 1, 32768, 32768], 3, ttl.tensor.Layout.TILE),  # ultra slow?
+        # ([1, 1, 32768, 32768], 3, ttnn.ROW_MAJOR_LAYOUT),
+        ([1, 1, 32768, 32768], 3, ttnn.TILE_LAYOUT),  # ultra slow?
         # 4 chips, per chip shape same as 8 chips
-        # ([1, 1, 32768, 16384], 3, ttl.tensor.Layout.ROW_MAJOR),
-        # ([1, 1, 32768, 16384], 3, ttl.tensor.Layout.TILE),
+        # ([1, 1, 32768, 16384], 3, ttnn.ROW_MAJOR_LAYOUT),
+        # ([1, 1, 32768, 16384], 3, ttnn.TILE_LAYOUT),
         # Llama galaxy mlp weights stationary -> emulation of row/col reduce
-        ([1, 1, 128, 1024], 2, ttl.tensor.Layout.ROW_MAJOR),
-        ([1, 1, 128, 1024], 2, ttl.tensor.Layout.TILE),
-        # ([1, 1, 32, 8192], 3, ttl.tensor.Layout.ROW_MAJOR), # ALREADY LISTED PREVIOUSLY
-        # ([1, 1, 32, 8192], 3, ttl.tensor.Layout.TILE),      # ALREADY LISTED PREVIOUSLY
-        ([1, 1, 128, 4096], 2, ttl.tensor.Layout.ROW_MAJOR),  #
-        ([1, 1, 128, 4096], 2, ttl.tensor.Layout.TILE),
-        # ([1, 1, 32, 16384], 3, ttl.tensor.Layout.ROW_MAJOR), # ALREADY LISTED PREVIOUSLY. Update for 8 chip, actuall 32k for 8 chip but we are halving it for our 4 chip test
-        # ([1, 1, 32, 16384], 3, ttl.tensor.Layout.TILE),      # ALREADY LISTED PREVIOUSLY. Update for 8 chip, actuall 32k for 8 chip but we are halving it for our 4 chip test
-        ([1, 1, 8192, 32], 2, ttl.tensor.Layout.ROW_MAJOR),
-        ([1, 1, 8192, 32], 2, ttl.tensor.Layout.TILE),
-        ([1, 1, 1024, 128], 3, ttl.tensor.Layout.ROW_MAJOR),  # double on reduction dim for 8 chip
-        ([1, 1, 1024, 128], 3, ttl.tensor.Layout.TILE),  # double on reduction dim for 8 chip
-        ([1, 1, 16384, 32], 2, ttl.tensor.Layout.ROW_MAJOR),  # double on reduction dim for 8 chip
-        ([1, 1, 16384, 32], 2, ttl.tensor.Layout.TILE),  # double on reduction dim for 8 chip
-        ([1, 1, 32768, 32], 2, ttl.tensor.Layout.ROW_MAJOR),  # double on reduction dim for 8 chip
-        ([1, 1, 32768, 32], 2, ttl.tensor.Layout.TILE),  # double on reduction dim for 8 chip
-        ([1, 1, 4096, 128], 3, ttl.tensor.Layout.ROW_MAJOR),  # only for 4 chip
-        ([1, 1, 4096, 128], 3, ttl.tensor.Layout.TILE),  # only for 4 chip
-        ([1, 1, 128, 2048], 2, ttl.tensor.Layout.ROW_MAJOR),  # double on reduction dim for 8 chip
-        ([1, 1, 128, 2048], 2, ttl.tensor.Layout.TILE),  # double on reduction dim for 8 chip
-        # ([1, 1, 32, 8192], 3, ttl.tensor.Layout.ROW_MAJOR), # only for 4 chip - ALREADY LISTED PREVIOUSLY
-        # ([1, 1, 32, 8192], 3, ttl.tensor.Layout.TILE),      # only for 4 chip - ALREADY LISTED PREVIOUSLY
-        ([1, 1, 128, 8192], 2, ttl.tensor.Layout.ROW_MAJOR),  # double on reduction dim for 8 chip
-        ([1, 1, 128, 8192], 2, ttl.tensor.Layout.TILE),  # double on reduction dim for 8 chip
-        ([4, 1, 256, 32], 0, ttl.tensor.Layout.TILE),
-        ([8, 8, 256, 384], 1, ttl.tensor.Layout.ROW_MAJOR),
-        ([1, 1, 256, 1024], 2, ttl.tensor.Layout.ROW_MAJOR),
-        ([1, 1, 1024, 256], 3, ttl.tensor.Layout.ROW_MAJOR),
-        ([1, 1, 256, 2048], 2, ttl.tensor.Layout.ROW_MAJOR),
-        ([1, 1, 256, 8192], 2, ttl.tensor.Layout.ROW_MAJOR),  # double on reduction dim for 8 chip
+        ([1, 1, 128, 1024], 2, ttnn.ROW_MAJOR_LAYOUT),
+        ([1, 1, 128, 1024], 2, ttnn.TILE_LAYOUT),
+        # ([1, 1, 32, 8192], 3, ttnn.ROW_MAJOR_LAYOUT), # ALREADY LISTED PREVIOUSLY
+        # ([1, 1, 32, 8192], 3, ttnn.TILE_LAYOUT),      # ALREADY LISTED PREVIOUSLY
+        ([1, 1, 128, 4096], 2, ttnn.ROW_MAJOR_LAYOUT),  #
+        ([1, 1, 128, 4096], 2, ttnn.TILE_LAYOUT),
+        # ([1, 1, 32, 16384], 3, ttnn.ROW_MAJOR_LAYOUT), # ALREADY LISTED PREVIOUSLY. Update for 8 chip, actuall 32k for 8 chip but we are halving it for our 4 chip test
+        # ([1, 1, 32, 16384], 3, ttnn.TILE_LAYOUT),      # ALREADY LISTED PREVIOUSLY. Update for 8 chip, actuall 32k for 8 chip but we are halving it for our 4 chip test
+        ([1, 1, 8192, 32], 2, ttnn.ROW_MAJOR_LAYOUT),
+        ([1, 1, 8192, 32], 2, ttnn.TILE_LAYOUT),
+        ([1, 1, 1024, 128], 3, ttnn.ROW_MAJOR_LAYOUT),  # double on reduction dim for 8 chip
+        ([1, 1, 1024, 128], 3, ttnn.TILE_LAYOUT),  # double on reduction dim for 8 chip
+        ([1, 1, 16384, 32], 2, ttnn.ROW_MAJOR_LAYOUT),  # double on reduction dim for 8 chip
+        ([1, 1, 16384, 32], 2, ttnn.TILE_LAYOUT),  # double on reduction dim for 8 chip
+        ([1, 1, 32768, 32], 2, ttnn.ROW_MAJOR_LAYOUT),  # double on reduction dim for 8 chip
+        ([1, 1, 32768, 32], 2, ttnn.TILE_LAYOUT),  # double on reduction dim for 8 chip
+        ([1, 1, 4096, 128], 3, ttnn.ROW_MAJOR_LAYOUT),  # only for 4 chip
+        ([1, 1, 4096, 128], 3, ttnn.TILE_LAYOUT),  # only for 4 chip
+        ([1, 1, 128, 2048], 2, ttnn.ROW_MAJOR_LAYOUT),  # double on reduction dim for 8 chip
+        ([1, 1, 128, 2048], 2, ttnn.TILE_LAYOUT),  # double on reduction dim for 8 chip
+        # ([1, 1, 32, 8192], 3, ttnn.ROW_MAJOR_LAYOUT), # only for 4 chip - ALREADY LISTED PREVIOUSLY
+        # ([1, 1, 32, 8192], 3, ttnn.TILE_LAYOUT),      # only for 4 chip - ALREADY LISTED PREVIOUSLY
+        ([1, 1, 128, 8192], 2, ttnn.ROW_MAJOR_LAYOUT),  # double on reduction dim for 8 chip
+        ([1, 1, 128, 8192], 2, ttnn.TILE_LAYOUT),  # double on reduction dim for 8 chip
+        ([4, 1, 256, 32], 0, ttnn.TILE_LAYOUT),
+        ([8, 8, 256, 384], 1, ttnn.ROW_MAJOR_LAYOUT),
+        ([1, 1, 256, 1024], 2, ttnn.ROW_MAJOR_LAYOUT),
+        ([1, 1, 1024, 256], 3, ttnn.ROW_MAJOR_LAYOUT),
+        ([1, 1, 256, 2048], 2, ttnn.ROW_MAJOR_LAYOUT),
+        ([1, 1, 256, 8192], 2, ttnn.ROW_MAJOR_LAYOUT),  # double on reduction dim for 8 chip
     ],
 )
 @pytest.mark.parametrize(
     "input_dtype",
     [
-        ttl.tensor.DataType.BFLOAT16,
-        ttl.tensor.DataType.BFLOAT8_B,
+        ttnn.bfloat16,
+        ttnn.bfloat8_b,
     ],
 )
 @pytest.mark.parametrize(
     "mem_config",
     [
-        ttl.tensor.MemoryConfig(buffer_type=ttl.tensor.BufferType.DRAM),
-        ttl.tensor.MemoryConfig(buffer_type=ttl.tensor.BufferType.L1),
+        ttnn.MemoryConfig(buffer_type=ttnn.BufferType.DRAM),
+        ttnn.MemoryConfig(buffer_type=ttnn.BufferType.L1),
     ],
 )
 def test_all_gather_on_t3000_nightly(
@@ -703,44 +693,44 @@ def test_all_gather_on_t3000_nightly(
     if (
         input_shape == [8, 8, 256, 384]
         and dim == 1
-        and layout == ttl.tensor.Layout.TILE
+        and layout == ttnn.TILE_LAYOUT
         and num_devices == 4
         and num_links == 1
-        and input_dtype == ttl.tensor.DataType.BFLOAT16
-        and mem_config.buffer_type == ttl.tensor.BufferType.DRAM
+        and input_dtype == ttnn.bfloat16
+        and mem_config.buffer_type == ttnn.BufferType.DRAM
     ):
         pytest.xfail(reason="Known failure")
 
     if (
         input_shape == [8, 8, 256, 384]
         and dim == 2
-        and layout == ttl.tensor.Layout.TILE
+        and layout == ttnn.TILE_LAYOUT
         and num_devices == 4
         and num_links == 1
-        and input_dtype == ttl.tensor.DataType.BFLOAT16
-        and mem_config.buffer_type == ttl.tensor.BufferType.DRAM
+        and input_dtype == ttnn.bfloat16
+        and mem_config.buffer_type == ttnn.BufferType.DRAM
     ):
         pytest.xfail(reason="Known failure")
 
     if (
         input_shape == [8, 8, 256, 384]
         and dim == 2
-        and layout == ttl.tensor.Layout.TILE
+        and layout == ttnn.TILE_LAYOUT
         and num_devices == 4
         and num_links == 1
-        and input_dtype == ttl.tensor.DataType.BFLOAT8_B
-        and mem_config.buffer_type == ttl.tensor.BufferType.DRAM
+        and input_dtype == ttnn.bfloat8_b
+        and mem_config.buffer_type == ttnn.BufferType.DRAM
     ):
         pytest.xfail(reason="Known failure")
 
     if (
         input_shape == [8, 8, 256, 384]
         and dim == 2
-        and layout == ttl.tensor.Layout.TILE
+        and layout == ttnn.TILE_LAYOUT
         and num_devices == 4
         and num_links == 2
-        and input_dtype == ttl.tensor.DataType.BFLOAT8_B
-        and mem_config.buffer_type == ttl.tensor.BufferType.DRAM
+        and input_dtype == ttnn.bfloat8_b
+        and mem_config.buffer_type == ttnn.BufferType.DRAM
     ):
         pytest.xfail(reason="Known failure")
 
@@ -818,28 +808,26 @@ def run_all_gather_sharded(
     logger.info(f"shard_grid: {shard_grid}")
     logger.info(f"input_shard_shape: {input_shard_shape}")
 
-    input_shard_spec = ttl.tensor.ShardSpec(
+    input_shard_spec = ttnn.ShardSpec(
         shard_grid,
         input_shard_shape,
         orientation,
         False,
     )
-    input_mem_config = ttl.tensor.MemoryConfig(
-        tensor_mem_layout, buffer_type=ttl.tensor.BufferType.L1, shard_spec=input_shard_spec
-    )
+    input_mem_config = ttnn.MemoryConfig(tensor_mem_layout, buffer_type=ttnn.BufferType.L1, shard_spec=input_shard_spec)
     output_shard_shape = list(input_shard_shape)
     if dim == 3:
         output_shard_shape[1] *= num_devices
     else:
         output_shard_shape[0] *= num_devices
-    output_shard_spec = ttl.tensor.ShardSpec(
+    output_shard_spec = ttnn.ShardSpec(
         shard_grid,
         output_shard_shape,
         orientation,
         False,
     )
-    output_mem_config = ttl.tensor.MemoryConfig(
-        tensor_mem_layout, buffer_type=ttl.tensor.BufferType.L1, shard_spec=output_shard_spec
+    output_mem_config = ttnn.MemoryConfig(
+        tensor_mem_layout, buffer_type=ttnn.BufferType.L1, shard_spec=output_shard_spec
     )
 
     if num_devices < 2:
@@ -856,10 +844,8 @@ def run_all_gather_sharded(
     tt_input_tensors = []
 
     for i, t in enumerate(input_tensors):
-        tt_input_tensors_dups.append(
-            ttl.tensor.Tensor(t, input_dtype).to(tensor_layout).to(devices[i], input_mem_config)
-        )
-        tt_input_tensors.append(ttl.tensor.Tensor(t, input_dtype).to(tensor_layout).to(devices[i], input_mem_config))
+        tt_input_tensors_dups.append(ttnn.Tensor(t, input_dtype).to(tensor_layout).to(devices[i], input_mem_config))
+        tt_input_tensors.append(ttnn.Tensor(t, input_dtype).to(tensor_layout).to(devices[i], input_mem_config))
 
     input_tensor_mesh = ttnn.aggregate_as_tensor(tt_input_tensors)
 
@@ -867,14 +853,14 @@ def run_all_gather_sharded(
     tt_out_tensor = all_gather_operation(input_tensor_mesh, dim, num_links=num_links, memory_config=output_mem_config)
     ## Wait for completion
     for d in devices:
-        ttl.device.Synchronize(d)
+        ttnn.synchronize_device(d)
 
     torch.set_printoptions(sci_mode=False)
     all_eq = True
     reported_mismatch = False
     for i, t in enumerate(ttnn.get_device_tensors(tt_out_tensor)):
-        tt_output_tensor = t.cpu().to(ttl.tensor.Layout.ROW_MAJOR).to_torch()
-        if input_dtype == ttl.tensor.DataType.BFLOAT16:
+        tt_output_tensor = t.cpu().to(ttnn.ROW_MAJOR_LAYOUT).to_torch()
+        if input_dtype == ttnn.bfloat16:
             eq, output = comp_equal(tt_output_tensor, unchunked_input_tensor)
         else:
             eq, output = comp_pcc(tt_output_tensor, unchunked_input_tensor)
@@ -903,24 +889,24 @@ def run_all_gather_sharded(
 @skip_for_grayskull("Requires eth connected devices to run")
 @pytest.mark.parametrize("num_devices", [8])
 @pytest.mark.parametrize("dim", [3])
-@pytest.mark.parametrize("tensor_layout", [ttl.tensor.Layout.TILE])
+@pytest.mark.parametrize("tensor_layout", [ttnn.TILE_LAYOUT])
 # @pytest.mark.parametrize("num_cores", [1])
 @pytest.mark.parametrize(
     "input_dtype",
     [
-        ttl.tensor.DataType.BFLOAT16,  # https://github.com/tenstorrent/tt-metal/issues/9686
-        # ttl.tensor.DataType.BFLOAT8_B,
+        ttnn.bfloat16,  # https://github.com/tenstorrent/tt-metal/issues/9686
+        # ttnn.bfloat8_b,
     ],
 )
 @pytest.mark.parametrize(
     "tensor_mem_layout",
     [
-        ttl.tensor.TensorMemoryLayout.WIDTH_SHARDED,
-        # ttl.tensor.TensorMemoryLayout.HEIGHT_SHARDED,
-        # ttl.tensor.TensorMemoryLayout.BLOCK_SHARDED,
+        ttnn.TensorMemoryLayout.WIDTH_SHARDED,
+        # ttnn.TensorMemoryLayout.HEIGHT_SHARDED,
+        # ttnn.TensorMemoryLayout.BLOCK_SHARDED,
     ],
 )
-@pytest.mark.parametrize("orientation", [ttl.tensor.ShardOrientation.ROW_MAJOR])
+@pytest.mark.parametrize("orientation", [ttnn.ShardOrientation.ROW_MAJOR])
 @pytest.mark.parametrize("num_links", [1])
 @pytest.mark.parametrize(
     "input_shape, input_shard_shape,shard_grid",
@@ -929,22 +915,22 @@ def run_all_gather_sharded(
         (
             (1, 1, 32, 1024),
             (32, 32),
-            ttl.tensor.CoreRangeSet({ttl.tensor.CoreRange(ttl.tensor.CoreCoord(0, 0), ttl.tensor.CoreCoord(7, 3))}),
+            ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(7, 3))}),
         ),
         (  # https://github.com/tenstorrent/tt-metal/issues/9686
             (1, 1, 32, 4096),
             (32, 128),
-            ttl.tensor.CoreRangeSet({ttl.tensor.CoreRange(ttl.tensor.CoreCoord(0, 0), ttl.tensor.CoreCoord(7, 3))}),
+            ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(7, 3))}),
         ),
         (  # https://github.com/tenstorrent/tt-metal/issues/9686
             (1, 1, 32, 2048),
             (32, 64),
-            ttl.tensor.CoreRangeSet({ttl.tensor.CoreRange(ttl.tensor.CoreCoord(0, 0), ttl.tensor.CoreCoord(7, 3))}),
+            ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(7, 3))}),
         ),
         (  # https://github.com/tenstorrent/tt-metal/issues/9686
             (1, 1, 32, 1792),
             (32, 32),
-            ttl.tensor.CoreRangeSet({ttl.tensor.CoreRange(ttl.tensor.CoreCoord(0, 0), ttl.tensor.CoreCoord(7, 6))}),
+            ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(7, 6))}),
         ),
     ),
 )
@@ -986,23 +972,23 @@ def test_all_gather_sharded_post_commit(
 @skip_for_grayskull("Requires eth connected devices to run")
 @pytest.mark.parametrize("num_devices", [8])
 @pytest.mark.parametrize("dim", [3])
-@pytest.mark.parametrize("tensor_layout", [ttl.tensor.Layout.TILE])
+@pytest.mark.parametrize("tensor_layout", [ttnn.TILE_LAYOUT])
 # @pytest.mark.parametrize("num_cores", [1])
 @pytest.mark.parametrize(
     "input_dtype",
     [
-        ttl.tensor.DataType.BFLOAT16,  # https://github.com/tenstorrent/tt-metal/issues/9686
-        # ttl.tensor.DataType.BFLOAT8_B,
+        ttnn.bfloat16,  # https://github.com/tenstorrent/tt-metal/issues/9686
+        # ttnn.bfloat8_b,
     ],
 )
 @pytest.mark.parametrize(
     "tensor_mem_layout",
     [
-        ttl.tensor.TensorMemoryLayout.HEIGHT_SHARDED,
-        # ttl.tensor.TensorMemoryLayout.BLOCK_SHARDED,
+        ttnn.TensorMemoryLayout.HEIGHT_SHARDED,
+        # ttnn.TensorMemoryLayout.BLOCK_SHARDED,
     ],
 )
-@pytest.mark.parametrize("orientation", [ttl.tensor.ShardOrientation.COL_MAJOR])
+@pytest.mark.parametrize("orientation", [ttnn.ShardOrientation.COL_MAJOR])
 @pytest.mark.parametrize("num_links", [1])
 @pytest.mark.parametrize(
     "input_shape, input_shard_shape,shard_grid",
@@ -1011,27 +997,27 @@ def test_all_gather_sharded_post_commit(
         (
             (1, 1, 1024, 32),
             (32, 32),
-            ttl.tensor.CoreRangeSet({ttl.tensor.CoreRange(ttl.tensor.CoreCoord(0, 0), ttl.tensor.CoreCoord(7, 3))}),
+            ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(7, 3))}),
         ),
         (  # https://github.com/tenstorrent/tt-metal/issues/9686
             (1, 1, 4096, 32),
             (128, 32),
-            ttl.tensor.CoreRangeSet({ttl.tensor.CoreRange(ttl.tensor.CoreCoord(0, 0), ttl.tensor.CoreCoord(7, 3))}),
+            ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(7, 3))}),
         ),
         (  # https://github.com/tenstorrent/tt-metal/issues/9686
             (1, 1, 4096, 32),
             (128, 32),
-            ttl.tensor.CoreRangeSet({ttl.tensor.CoreRange(ttl.tensor.CoreCoord(0, 0), ttl.tensor.CoreCoord(7, 3))}),
+            ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(7, 3))}),
         ),
         (  # https://github.com/tenstorrent/tt-metal/issues/9686
             (1, 1, 2048, 32),
             (64, 32),
-            ttl.tensor.CoreRangeSet({ttl.tensor.CoreRange(ttl.tensor.CoreCoord(0, 0), ttl.tensor.CoreCoord(7, 3))}),
+            ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(7, 3))}),
         ),
         (  # https://github.com/tenstorrent/tt-metal/issues/9686
             (1, 1, 1792, 32),
             (32, 32),
-            ttl.tensor.CoreRangeSet({ttl.tensor.CoreRange(ttl.tensor.CoreCoord(0, 0), ttl.tensor.CoreCoord(7, 6))}),
+            ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(7, 6))}),
         ),
     ),
 )
@@ -1073,22 +1059,22 @@ def test_all_gather_height_sharded_post_commit(
 @skip_for_grayskull("Requires eth connected devices to run")
 @pytest.mark.parametrize("num_devices", [8])
 @pytest.mark.parametrize("dim", [3])
-@pytest.mark.parametrize("tensor_layout", [ttl.tensor.Layout.TILE])
+@pytest.mark.parametrize("tensor_layout", [ttnn.TILE_LAYOUT])
 # @pytest.mark.parametrize("num_cores", [1])
 @pytest.mark.parametrize(
     "input_dtype",
     [
-        ttl.tensor.DataType.BFLOAT16,  # https://github.com/tenstorrent/tt-metal/issues/9686
-        # ttl.tensor.DataType.BFLOAT8_B,
+        ttnn.bfloat16,  # https://github.com/tenstorrent/tt-metal/issues/9686
+        # ttnn.bfloat8_b,
     ],
 )
 @pytest.mark.parametrize(
     "tensor_mem_layout",
     [
-        ttl.tensor.TensorMemoryLayout.BLOCK_SHARDED,
+        ttnn.TensorMemoryLayout.BLOCK_SHARDED,
     ],
 )
-@pytest.mark.parametrize("orientation", [ttl.tensor.ShardOrientation.ROW_MAJOR])
+@pytest.mark.parametrize("orientation", [ttnn.ShardOrientation.ROW_MAJOR])
 @pytest.mark.parametrize("num_links", [1])
 @pytest.mark.parametrize(
     "input_shape, input_shard_shape,shard_grid",
@@ -1097,22 +1083,22 @@ def test_all_gather_height_sharded_post_commit(
         (
             (1, 1, 128, 256),
             (32, 32),
-            ttl.tensor.CoreRangeSet({ttl.tensor.CoreRange(ttl.tensor.CoreCoord(0, 0), ttl.tensor.CoreCoord(7, 3))}),
+            ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(7, 3))}),
         ),
         # (  # https://github.com/tenstorrent/tt-metal/issues/9686
         #     (1, 1, 512, 32),
         #     (128, 32),
-        #     ttl.tensor.CoreRangeSet({ttl.tensor.CoreRange(ttl.tensor.CoreCoord(0, 0), ttl.tensor.CoreCoord(7, 3))}),
+        #     ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(7, 3))}),
         # ),
         (  # https://github.com/tenstorrent/tt-metal/issues/9686
             (1, 1, 512, 256),
             (128, 32),
-            ttl.tensor.CoreRangeSet({ttl.tensor.CoreRange(ttl.tensor.CoreCoord(0, 0), ttl.tensor.CoreCoord(7, 3))}),
+            ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(7, 3))}),
         ),
         (  # https://github.com/tenstorrent/tt-metal/issues/9686
             (1, 1, 512, 512),
             (128, 64),
-            ttl.tensor.CoreRangeSet({ttl.tensor.CoreRange(ttl.tensor.CoreCoord(0, 0), ttl.tensor.CoreCoord(7, 3))}),
+            ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(7, 3))}),
         ),
     ),
 )
@@ -1155,24 +1141,24 @@ def test_all_gather_block_sharded_post_commit(
 @skip_for_grayskull("Requires eth connected devices to run")
 @pytest.mark.parametrize("num_devices", [8])
 @pytest.mark.parametrize("dim", [3])
-@pytest.mark.parametrize("tensor_layout", [ttl.tensor.Layout.TILE])
+@pytest.mark.parametrize("tensor_layout", [ttnn.TILE_LAYOUT])
 # @pytest.mark.parametrize("num_cores", [1])
 @pytest.mark.parametrize(
     "input_dtype",
     [
-        ttl.tensor.DataType.BFLOAT16,  # https://github.com/tenstorrent/tt-metal/issues/9686
-        # ttl.tensor.DataType.BFLOAT8_B,
+        ttnn.bfloat16,  # https://github.com/tenstorrent/tt-metal/issues/9686
+        # ttnn.bfloat8_b,
     ],
 )
 @pytest.mark.parametrize(
     "tensor_mem_layout",
     [
-        ttl.tensor.TensorMemoryLayout.WIDTH_SHARDED,
-        # ttl.tensor.TensorMemoryLayout.HEIGHT_SHARDED,
-        # ttl.tensor.TensorMemoryLayout.BLOCK_SHARDED,
+        ttnn.TensorMemoryLayout.WIDTH_SHARDED,
+        # ttnn.TensorMemoryLayout.HEIGHT_SHARDED,
+        # ttnn.TensorMemoryLayout.BLOCK_SHARDED,
     ],
 )
-@pytest.mark.parametrize("orientation", [ttl.tensor.ShardOrientation.ROW_MAJOR])
+@pytest.mark.parametrize("orientation", [ttnn.ShardOrientation.ROW_MAJOR])
 @pytest.mark.parametrize("num_links", [1])
 @pytest.mark.parametrize(
     "input_shape, input_shard_shape,shard_grid",
@@ -1181,27 +1167,27 @@ def test_all_gather_block_sharded_post_commit(
         (
             (1, 1, 32, 1024),
             (32, 32),
-            ttl.tensor.CoreRangeSet({ttl.tensor.CoreRange(ttl.tensor.CoreCoord(0, 0), ttl.tensor.CoreCoord(7, 3))}),
+            ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(7, 3))}),
         ),
         (  # https://github.com/tenstorrent/tt-metal/issues/9686
             (1, 1, 32, 4096),
             (32, 128),
-            ttl.tensor.CoreRangeSet({ttl.tensor.CoreRange(ttl.tensor.CoreCoord(0, 0), ttl.tensor.CoreCoord(7, 3))}),
+            ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(7, 3))}),
         ),
         (  # https://github.com/tenstorrent/tt-metal/issues/9686
             (1, 1, 32, 4096),
             (32, 128),
-            ttl.tensor.CoreRangeSet({ttl.tensor.CoreRange(ttl.tensor.CoreCoord(0, 0), ttl.tensor.CoreCoord(7, 3))}),
+            ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(7, 3))}),
         ),
         (  # https://github.com/tenstorrent/tt-metal/issues/9686
             (1, 1, 32, 2048),
             (32, 64),
-            ttl.tensor.CoreRangeSet({ttl.tensor.CoreRange(ttl.tensor.CoreCoord(0, 0), ttl.tensor.CoreCoord(7, 3))}),
+            ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(7, 3))}),
         ),
         (  # https://github.com/tenstorrent/tt-metal/issues/9686
             (1, 1, 32, 1792),
             (32, 32),
-            ttl.tensor.CoreRangeSet({ttl.tensor.CoreRange(ttl.tensor.CoreCoord(0, 0), ttl.tensor.CoreCoord(7, 6))}),
+            ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(7, 6))}),
         ),
     ),
 )
@@ -1244,24 +1230,24 @@ def test_line_all_gather_sharded_post_commit(
 @skip_for_grayskull("Requires eth connected devices to run")
 @pytest.mark.parametrize("num_devices", [8])
 @pytest.mark.parametrize("dim", [3])
-@pytest.mark.parametrize("tensor_layout", [ttl.tensor.Layout.TILE])
+@pytest.mark.parametrize("tensor_layout", [ttnn.TILE_LAYOUT])
 # @pytest.mark.parametrize("num_cores", [1])
 @pytest.mark.parametrize(
     "input_dtype",
     [
-        ttl.tensor.DataType.BFLOAT16,  # https://github.com/tenstorrent/tt-metal/issues/9686
-        # ttl.tensor.DataType.BFLOAT8_B,
+        ttnn.bfloat16,  # https://github.com/tenstorrent/tt-metal/issues/9686
+        # ttnn.bfloat8_b,
     ],
 )
 @pytest.mark.parametrize(
     "tensor_mem_layout",
     [
-        ttl.tensor.TensorMemoryLayout.WIDTH_SHARDED,
-        # ttl.tensor.TensorMemoryLayout.HEIGHT_SHARDED,
-        # ttl.tensor.TensorMemoryLayout.BLOCK_SHARDED,
+        ttnn.TensorMemoryLayout.WIDTH_SHARDED,
+        # ttnn.TensorMemoryLayout.HEIGHT_SHARDED,
+        # ttnn.TensorMemoryLayout.BLOCK_SHARDED,
     ],
 )
-@pytest.mark.parametrize("orientation", [ttl.tensor.ShardOrientation.ROW_MAJOR, ttl.tensor.ShardOrientation.COL_MAJOR])
+@pytest.mark.parametrize("orientation", [ttnn.ShardOrientation.ROW_MAJOR, ttnn.ShardOrientation.COL_MAJOR])
 @pytest.mark.parametrize("num_links", [1])
 @pytest.mark.parametrize(
     "input_shape, input_shard_shape,shard_grid",
@@ -1269,98 +1255,98 @@ def test_line_all_gather_sharded_post_commit(
         (  # https://github.com/tenstorrent/tt-metal/issues/9686
             (1, 1, 32, 128),
             (32, 32),
-            ttl.tensor.CoreRangeSet({ttl.tensor.CoreRange(ttl.tensor.CoreCoord(0, 0), ttl.tensor.CoreCoord(1, 1))}),
+            ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(1, 1))}),
         ),
         (  # https://github.com/tenstorrent/tt-metal/issues/9686
             (1, 1, 32, 256),
             (32, 64),
-            ttl.tensor.CoreRangeSet({ttl.tensor.CoreRange(ttl.tensor.CoreCoord(0, 0), ttl.tensor.CoreCoord(1, 1))}),
+            ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(1, 1))}),
         ),
         (  # https://github.com/tenstorrent/tt-metal/issues/9686
             (1, 1, 64, 128),
             (64, 32),
-            ttl.tensor.CoreRangeSet({ttl.tensor.CoreRange(ttl.tensor.CoreCoord(0, 0), ttl.tensor.CoreCoord(1, 1))}),
+            ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(1, 1))}),
         ),
         (  # https://github.com/tenstorrent/tt-metal/issues/9686
             (1, 1, 64, 256),
             (64, 64),
-            ttl.tensor.CoreRangeSet({ttl.tensor.CoreRange(ttl.tensor.CoreCoord(0, 0), ttl.tensor.CoreCoord(1, 1))}),
+            ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(1, 1))}),
         ),
         (  # https://github.com/tenstorrent/tt-metal/issues/9686
             (1, 1, 32, 64),
             (32, 64),
-            ttl.tensor.CoreRangeSet({ttl.tensor.CoreRange(ttl.tensor.CoreCoord(0, 0), ttl.tensor.CoreCoord(0, 0))}),
+            ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(0, 0))}),
         ),
         (  # https://github.com/tenstorrent/tt-metal/issues/9686
             (1, 1, 32, 128),
             (32, 128),
-            ttl.tensor.CoreRangeSet({ttl.tensor.CoreRange(ttl.tensor.CoreCoord(0, 0), ttl.tensor.CoreCoord(0, 0))}),
+            ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(0, 0))}),
         ),
         (  # https://github.com/tenstorrent/tt-metal/issues/9686
             (1, 1, 32, 64),
             (32, 32),
-            ttl.tensor.CoreRangeSet({ttl.tensor.CoreRange(ttl.tensor.CoreCoord(0, 0), ttl.tensor.CoreCoord(1, 0))}),
+            ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(1, 0))}),
         ),
         (  # https://github.com/tenstorrent/tt-metal/issues/9686
             (1, 1, 32, 128),
             (32, 64),
-            ttl.tensor.CoreRangeSet({ttl.tensor.CoreRange(ttl.tensor.CoreCoord(0, 0), ttl.tensor.CoreCoord(1, 0))}),
+            ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(1, 0))}),
         ),
         (
             (1, 1, 32, 128),
             (32, 32),
-            ttl.tensor.CoreRangeSet({ttl.tensor.CoreRange(ttl.tensor.CoreCoord(0, 0), ttl.tensor.CoreCoord(0, 3))}),
+            ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(0, 3))}),
         ),
         (
             (1, 1, 64, 128),
             (64, 32),
-            ttl.tensor.CoreRangeSet({ttl.tensor.CoreRange(ttl.tensor.CoreCoord(0, 0), ttl.tensor.CoreCoord(0, 3))}),
+            ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(0, 3))}),
         ),
         (
             (1, 1, 32, 256),
             (32, 64),
-            ttl.tensor.CoreRangeSet({ttl.tensor.CoreRange(ttl.tensor.CoreCoord(0, 0), ttl.tensor.CoreCoord(0, 3))}),
+            ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(0, 3))}),
         ),
         (
             (1, 1, 64, 256),
             (64, 64),
-            ttl.tensor.CoreRangeSet({ttl.tensor.CoreRange(ttl.tensor.CoreCoord(0, 0), ttl.tensor.CoreCoord(0, 3))}),
+            ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(0, 3))}),
         ),
         (  # https://github.com/tenstorrent/tt-metal/issues/9686
             (1, 1, 32, 256),
             (32, 32),
-            ttl.tensor.CoreRangeSet({ttl.tensor.CoreRange(ttl.tensor.CoreCoord(0, 0), ttl.tensor.CoreCoord(7, 0))}),
+            ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(7, 0))}),
         ),
         (  # https://github.com/tenstorrent/tt-metal/issues/9686
             (1, 1, 32, 512),
             (32, 64),
-            ttl.tensor.CoreRangeSet({ttl.tensor.CoreRange(ttl.tensor.CoreCoord(0, 0), ttl.tensor.CoreCoord(7, 0))}),
+            ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(7, 0))}),
         ),
         # LLama
         (
             (1, 1, 32, 1024),
             (32, 32),
-            ttl.tensor.CoreRangeSet({ttl.tensor.CoreRange(ttl.tensor.CoreCoord(0, 0), ttl.tensor.CoreCoord(7, 3))}),
+            ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(7, 3))}),
         ),
         (  # https://github.com/tenstorrent/tt-metal/issues/9686
             (1, 1, 32, 4096),
             (32, 128),
-            ttl.tensor.CoreRangeSet({ttl.tensor.CoreRange(ttl.tensor.CoreCoord(0, 0), ttl.tensor.CoreCoord(7, 3))}),
+            ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(7, 3))}),
         ),
         (  # https://github.com/tenstorrent/tt-metal/issues/9686
             (1, 1, 32, 4096),
             (32, 128),
-            ttl.tensor.CoreRangeSet({ttl.tensor.CoreRange(ttl.tensor.CoreCoord(0, 0), ttl.tensor.CoreCoord(7, 3))}),
+            ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(7, 3))}),
         ),
         (  # https://github.com/tenstorrent/tt-metal/issues/9686
             (1, 1, 32, 2048),
             (32, 64),
-            ttl.tensor.CoreRangeSet({ttl.tensor.CoreRange(ttl.tensor.CoreCoord(0, 0), ttl.tensor.CoreCoord(7, 3))}),
+            ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(7, 3))}),
         ),
         (  # https://github.com/tenstorrent/tt-metal/issues/9686
             (1, 1, 32, 1792),
             (32, 32),
-            ttl.tensor.CoreRangeSet({ttl.tensor.CoreRange(ttl.tensor.CoreCoord(0, 0), ttl.tensor.CoreCoord(7, 6))}),
+            ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(7, 6))}),
         ),
     ),
 )
@@ -1405,22 +1391,20 @@ def test_sharded_all_gather_nightly(
 @pytest.mark.skip("#7705: Hanging on various configs")
 @pytest.mark.parametrize(
     "input_shape, dim, layout",
-    [([4, 1, 33, 256], 0, ttl.tensor.Layout.ROW_MAJOR), ([4, 1, 256, 32], 0, ttl.tensor.Layout.TILE)],
+    [([4, 1, 33, 256], 0, ttnn.ROW_MAJOR_LAYOUT), ([4, 1, 256, 32], 0, ttnn.TILE_LAYOUT)],
 )
 @pytest.mark.parametrize(
     "mem_config",
     [
-        ttl.tensor.MemoryConfig(buffer_type=ttl.tensor.BufferType.DRAM),
-        ttl.tensor.MemoryConfig(buffer_type=ttl.tensor.BufferType.L1),
+        ttnn.MemoryConfig(buffer_type=ttnn.BufferType.DRAM),
+        ttnn.MemoryConfig(buffer_type=ttnn.BufferType.L1),
     ],
 )
 @pytest.mark.parametrize("num_links", [1, 2])
 def test_all_gather_fp32(  # https://github.com/tenstorrent/tt-metal/issues/9686 ... need to tag with post_commit
     pcie_devices, input_shape, dim, num_links, layout, mem_config, use_program_cache, function_level_defaults
 ):
-    if (
-        layout == ttl.tensor.Layout.ROW_MAJOR or num_links == 2
-    ) and mem_config.buffer_type == ttl.tensor.BufferType.DRAM:
+    if (layout == ttnn.ROW_MAJOR_LAYOUT or num_links == 2) and mem_config.buffer_type == ttnn.BufferType.DRAM:
         pytest.skip("All gather tests are hanging for RM in DRAM")
     devices = pcie_devices
     input_tensor = torch.rand(input_shape).bfloat16()
@@ -1436,12 +1420,12 @@ def test_all_gather_fp32(  # https://github.com/tenstorrent/tt-metal/issues/9686
     input_tensors = torch.chunk(input_tensor, num_devices, dim)
     tt_input_tensors = []
     for i, t in enumerate(input_tensors):
-        tt_input_tensors.append(ttl.tensor.Tensor(t, ttl.tensor.DataType.FLOAT32).to(layout).to(devices[i], mem_config))
+        tt_input_tensors.append(ttnn.Tensor(t, ttnn.float32).to(layout).to(devices[i], mem_config))
 
     input_tensor_mesh = ttnn.aggregate_as_tensor(tt_input_tensors)
     tt_out_tensor = ttnn.all_gather(input_tensor_mesh, dim, num_links=num_links, memory_config=mem_config)
 
     for i, t in enumerate(ttnn.get_device_tensors(tt_out_tensor)):
-        tt_output_tensor = t.cpu().to(ttl.tensor.Layout.ROW_MAJOR).to_torch()
+        tt_output_tensor = t.cpu().to(ttnn.ROW_MAJOR_LAYOUT).to_torch()
         eq, output = comp_equal(tt_output_tensor, input_tensor)
         assert eq, f"{i} FAILED: {output}"

--- a/tests/ttnn/unit_tests/operations/test_all_gather_TG_post_commit.py
+++ b/tests/ttnn/unit_tests/operations/test_all_gather_TG_post_commit.py
@@ -5,7 +5,6 @@
 import torch
 import pytest
 from loguru import logger
-import tt_lib as ttl
 import ttnn
 from tests.tt_eager.python_api_testing.sweep_tests.comparison_funcs import comp_equal, comp_pcc
 from models.utility_functions import skip_for_grayskull
@@ -153,7 +152,7 @@ def run_line_all_gather_on_TG_with_mesh_tensor_along_rows(
 
     if debug:
         for i, t in enumerate(ttnn.get_device_tensors(ttnn_tensor_out)):
-            t = t.cpu().to(ttl.tensor.Layout.ROW_MAJOR).to_torch()
+            t = t.cpu().to(ttnn.ROW_MAJOR_LAYOUT).to_torch()
             print(f"OUTPUT TENSOR {i}")
             print_tile_corners_of_tensor(t)
 
@@ -169,7 +168,7 @@ def run_line_all_gather_on_TG_with_mesh_tensor_along_rows(
         print_tile_corners_of_tensor(tt_output_tensor)
 
     ## This full_tensor will only be 1/num_devices_per_line of the tt_output_tensor. We should just be able to concatenate it along the
-    if input_dtype == ttl.tensor.DataType.BFLOAT16:
+    if input_dtype == ttnn.bfloat16:
         eq, output = comp_equal(tt_output_tensor, full_mesh_output_golden)
         if not eq and debug:
             report_mismatches(full_mesh_output_golden, tt_output_tensor)
@@ -185,25 +184,25 @@ def run_line_all_gather_on_TG_with_mesh_tensor_along_rows(
 @pytest.mark.parametrize(
     "num_devices, num_links, input_shape, dim, layout",
     [
-        (4, 3, [1, 1, 32, 1280], 0, ttl.tensor.Layout.TILE),
-        (4, 3, [1, 1, 32, 16384], 3, ttl.tensor.Layout.TILE),
-        (4, 3, [1, 1, 32, 2304], 1, ttl.tensor.Layout.TILE),
-        (4, 3, [1, 1, 32, 4096], 1, ttl.tensor.Layout.TILE),
-        (4, 3, [1, 1, 32, 6656], 1, ttl.tensor.Layout.TILE),
+        (4, 3, [1, 1, 32, 1280], 0, ttnn.TILE_LAYOUT),
+        (4, 3, [1, 1, 32, 16384], 3, ttnn.TILE_LAYOUT),
+        (4, 3, [1, 1, 32, 2304], 1, ttnn.TILE_LAYOUT),
+        (4, 3, [1, 1, 32, 4096], 1, ttnn.TILE_LAYOUT),
+        (4, 3, [1, 1, 32, 6656], 1, ttnn.TILE_LAYOUT),
     ],
 )
 @pytest.mark.parametrize(
     "input_dtype",
     [
-        ttl.tensor.DataType.BFLOAT16,
-        ttl.tensor.DataType.BFLOAT8_B,
+        ttnn.bfloat16,
+        ttnn.bfloat8_b,
     ],
 )
 @pytest.mark.parametrize(
     "mem_config",
     [
-        ttl.tensor.MemoryConfig(buffer_type=ttl.tensor.BufferType.DRAM),
-        ttl.tensor.MemoryConfig(buffer_type=ttl.tensor.BufferType.L1),
+        ttnn.MemoryConfig(buffer_type=ttnn.BufferType.DRAM),
+        ttnn.MemoryConfig(buffer_type=ttnn.BufferType.L1),
     ],
 )
 @pytest.mark.parametrize("replication_factor", [8])  # 1, 8])
@@ -246,24 +245,24 @@ def test_line_all_gather_on_TG_rows_post_commit(
 @pytest.mark.parametrize(
     "num_devices, num_links, input_shape, dim, layout",
     [
-        # (8, 4, [1, 1, 32, 1280], 1, ttl.tensor.Layout.TILE), # Rightmost column of tiles per input not copied to final output
-        (8, 4, [1, 1, 32, 2048], 1, ttl.tensor.Layout.TILE),  # passes
-        (8, 4, [1, 1, 32, 2304], 1, ttl.tensor.Layout.TILE),  # passes
-        (8, 4, [1, 1, 32, 4096], 1, ttl.tensor.Layout.TILE),  # passes
+        # (8, 4, [1, 1, 32, 1280], 1, ttnn.TILE_LAYOUT), # Rightmost column of tiles per input not copied to final output
+        (8, 4, [1, 1, 32, 2048], 1, ttnn.TILE_LAYOUT),  # passes
+        (8, 4, [1, 1, 32, 2304], 1, ttnn.TILE_LAYOUT),  # passes
+        (8, 4, [1, 1, 32, 4096], 1, ttnn.TILE_LAYOUT),  # passes
     ],
 )
 @pytest.mark.parametrize(
     "input_dtype",
     [
-        ttl.tensor.DataType.BFLOAT16,
-        # ttl.tensor.DataType.BFLOAT8_B,
+        ttnn.bfloat16,
+        # ttnn.bfloat8_b,
     ],
 )
 @pytest.mark.parametrize(
     "mem_config",
     [
-        ttl.tensor.MemoryConfig(buffer_type=ttl.tensor.BufferType.DRAM),
-        # ttl.tensor.MemoryConfig(buffer_type=ttl.tensor.BufferType.L1),
+        ttnn.MemoryConfig(buffer_type=ttnn.BufferType.DRAM),
+        # ttnn.MemoryConfig(buffer_type=ttnn.BufferType.L1),
     ],
 )
 @pytest.mark.parametrize("enable_async", [False])

--- a/tests/ttnn/unit_tests/operations/test_complex.py
+++ b/tests/ttnn/unit_tests/operations/test_complex.py
@@ -8,7 +8,6 @@ import sys
 
 import torch
 
-import tt_lib as ttl
 import ttnn
 import pytest
 from loguru import logger
@@ -86,23 +85,23 @@ class Complex:
 @pytest.mark.parametrize(
     "memcfg",
     (
-        ttl.tensor.MemoryConfig(ttl.tensor.TensorMemoryLayout.INTERLEAVED, ttl.tensor.BufferType.DRAM),
-        ttl.tensor.MemoryConfig(ttl.tensor.TensorMemoryLayout.INTERLEAVED, ttl.tensor.BufferType.L1),
+        ttnn.DRAM_MEMORY_CONFIG,
+        ttnn.L1_MEMORY_CONFIG,
     ),
     ids=["out_DRAM", "out_L1"],
 )
-@pytest.mark.parametrize("dtype", ((ttl.tensor.DataType.BFLOAT16,)))
+@pytest.mark.parametrize("dtype", ((ttnn.bfloat16,)))
 @pytest.mark.parametrize("bs", ((1, 1), (1, 2), (2, 2)))
 def test_level2_real(bs, memcfg, dtype, device, function_level_defaults):
     input_shape = torch.Size([bs[0], bs[1], 32, 64])
     # check real
     x = Complex(input_shape)
     xtt = ttnn.complex_tensor(
-        ttl.tensor.Tensor(x.real, dtype).to(ttl.tensor.Layout.TILE).to(device, memcfg),
-        ttl.tensor.Tensor(x.imag, dtype).to(ttl.tensor.Layout.TILE).to(device, memcfg),
+        ttnn.Tensor(x.real, dtype).to(ttnn.TILE_LAYOUT).to(device, memcfg),
+        ttnn.Tensor(x.imag, dtype).to(ttnn.TILE_LAYOUT).to(device, memcfg),
     )
     tt_dev = ttnn.real(xtt, memory_config=memcfg)
-    tt_dev = tt_dev.cpu().to(ttl.tensor.Layout.ROW_MAJOR).to_torch()
+    tt_dev = tt_dev.cpu().to(ttnn.ROW_MAJOR_LAYOUT).to_torch()
     tt_cpu = x.real
     passing, output = comp_equal(tt_cpu, tt_dev)
     logger.info(output)
@@ -112,23 +111,23 @@ def test_level2_real(bs, memcfg, dtype, device, function_level_defaults):
 @pytest.mark.parametrize(
     "memcfg",
     (
-        ttl.tensor.MemoryConfig(ttl.tensor.TensorMemoryLayout.INTERLEAVED, ttl.tensor.BufferType.DRAM),
-        ttl.tensor.MemoryConfig(ttl.tensor.TensorMemoryLayout.INTERLEAVED, ttl.tensor.BufferType.L1),
+        ttnn.DRAM_MEMORY_CONFIG,
+        ttnn.L1_MEMORY_CONFIG,
     ),
     ids=["out_DRAM", "out_L1"],
 )
-@pytest.mark.parametrize("dtype", ((ttl.tensor.DataType.BFLOAT16,)))
+@pytest.mark.parametrize("dtype", ((ttnn.bfloat16,)))
 @pytest.mark.parametrize("bs", ((1, 1), (1, 2), (2, 2)))
 def test_level2_imag(bs, memcfg, dtype, device, function_level_defaults):
     input_shape = torch.Size([bs[0], bs[1], 32, 64])
     # check imag
     x = Complex(input_shape)
     xtt = ttnn.complex_tensor(
-        ttl.tensor.Tensor(x.real, dtype).to(ttl.tensor.Layout.TILE).to(device, memcfg),
-        ttl.tensor.Tensor(x.imag, dtype).to(ttl.tensor.Layout.TILE).to(device, memcfg),
+        ttnn.Tensor(x.real, dtype).to(ttnn.TILE_LAYOUT).to(device, memcfg),
+        ttnn.Tensor(x.imag, dtype).to(ttnn.TILE_LAYOUT).to(device, memcfg),
     )
     tt_dev = ttnn.imag(xtt, memory_config=memcfg)
-    tt_dev = tt_dev.cpu().to(ttl.tensor.Layout.ROW_MAJOR).to_torch()
+    tt_dev = tt_dev.cpu().to(ttnn.ROW_MAJOR_LAYOUT).to_torch()
     tt_cpu = x.imag
     passing, output = comp_equal(tt_cpu, tt_dev)
     logger.info(output)
@@ -138,23 +137,23 @@ def test_level2_imag(bs, memcfg, dtype, device, function_level_defaults):
 @pytest.mark.parametrize(
     "memcfg",
     (
-        ttl.tensor.MemoryConfig(ttl.tensor.TensorMemoryLayout.INTERLEAVED, ttl.tensor.BufferType.DRAM),
-        ttl.tensor.MemoryConfig(ttl.tensor.TensorMemoryLayout.INTERLEAVED, ttl.tensor.BufferType.L1),
+        ttnn.DRAM_MEMORY_CONFIG,
+        ttnn.L1_MEMORY_CONFIG,
     ),
     ids=["out_DRAM", "out_L1"],
 )
-@pytest.mark.parametrize("dtype", ((ttl.tensor.DataType.BFLOAT16,)))
+@pytest.mark.parametrize("dtype", ((ttnn.bfloat16,)))
 @pytest.mark.parametrize("bs", ((1, 1), (1, 2), (2, 2)))
 def test_level2_abs(bs, memcfg, dtype, device, function_level_defaults):
     input_shape = torch.Size([bs[0], bs[1], 32, 64])
     # check abs
     x = Complex(input_shape)
     xtt = ttnn.complex_tensor(
-        ttl.tensor.Tensor(x.real, dtype).to(ttl.tensor.Layout.TILE).to(device, memcfg),
-        ttl.tensor.Tensor(x.imag, dtype).to(ttl.tensor.Layout.TILE).to(device, memcfg),
+        ttnn.Tensor(x.real, dtype).to(ttnn.TILE_LAYOUT).to(device, memcfg),
+        ttnn.Tensor(x.imag, dtype).to(ttnn.TILE_LAYOUT).to(device, memcfg),
     )
     tt_dev = ttnn.abs(xtt, memory_config=memcfg)
-    tt_dev = tt_dev.cpu().to(ttl.tensor.Layout.ROW_MAJOR).to_torch()
+    tt_dev = tt_dev.cpu().to(ttnn.ROW_MAJOR_LAYOUT).to_torch()
     tt_cpu = x.abs().real
     if is_wormhole_b0():
         passing, output = comp_pcc(tt_cpu, tt_dev, pcc=0.8)
@@ -167,23 +166,23 @@ def test_level2_abs(bs, memcfg, dtype, device, function_level_defaults):
 @pytest.mark.parametrize(
     "memcfg",
     (
-        ttl.tensor.MemoryConfig(ttl.tensor.TensorMemoryLayout.INTERLEAVED, ttl.tensor.BufferType.DRAM),
-        ttl.tensor.MemoryConfig(ttl.tensor.TensorMemoryLayout.INTERLEAVED, ttl.tensor.BufferType.L1),
+        ttnn.DRAM_MEMORY_CONFIG,
+        ttnn.L1_MEMORY_CONFIG,
     ),
     ids=["out_DRAM", "out_L1"],
 )
-@pytest.mark.parametrize("dtype", ((ttl.tensor.DataType.BFLOAT16,)))
+@pytest.mark.parametrize("dtype", ((ttnn.bfloat16,)))
 @pytest.mark.parametrize("bs", ((1, 1), (1, 2), (2, 2)))
 def test_level2_abs(bs, memcfg, dtype, device, function_level_defaults):
     input_shape = torch.Size([bs[0], bs[1], 32, 64])
     # check abs
     x = Complex(input_shape)
     xtt = ttnn.complex_tensor(
-        ttl.tensor.Tensor(x.real, dtype).to(ttl.tensor.Layout.TILE).to(device, memcfg),
-        ttl.tensor.Tensor(x.imag, dtype).to(ttl.tensor.Layout.TILE).to(device, memcfg),
+        ttnn.Tensor(x.real, dtype).to(ttnn.TILE_LAYOUT).to(device, memcfg),
+        ttnn.Tensor(x.imag, dtype).to(ttnn.TILE_LAYOUT).to(device, memcfg),
     )
     tt_dev = ttnn.abs(xtt, memory_config=memcfg)
-    tt_dev = tt_dev.cpu().to(ttl.tensor.Layout.ROW_MAJOR).to_torch()
+    tt_dev = tt_dev.cpu().to(ttnn.ROW_MAJOR_LAYOUT).to_torch()
     tt_cpu = x.abs().real
     if is_wormhole_b0():
         passing, output = comp_pcc(tt_cpu, tt_dev, pcc=0.8)
@@ -196,24 +195,24 @@ def test_level2_abs(bs, memcfg, dtype, device, function_level_defaults):
 @pytest.mark.parametrize(
     "memcfg",
     (
-        ttl.tensor.MemoryConfig(ttl.tensor.TensorMemoryLayout.INTERLEAVED, ttl.tensor.BufferType.DRAM),
-        ttl.tensor.MemoryConfig(ttl.tensor.TensorMemoryLayout.INTERLEAVED, ttl.tensor.BufferType.L1),
+        ttnn.DRAM_MEMORY_CONFIG,
+        ttnn.L1_MEMORY_CONFIG,
     ),
     ids=["out_DRAM", "out_L1"],
 )
-@pytest.mark.parametrize("dtype", ((ttl.tensor.DataType.BFLOAT16,)))
+@pytest.mark.parametrize("dtype", ((ttnn.bfloat16,)))
 @pytest.mark.parametrize("bs", ((1, 1), (1, 2), (2, 2)))
 def test_level2_conj(bs, memcfg, dtype, device, function_level_defaults):
     input_shape = torch.Size([bs[0], bs[1], 32, 64])
     # check abs
     x = Complex(input_shape)
     xtt = ttnn.complex_tensor(
-        ttl.tensor.Tensor(x.real, dtype).to(ttl.tensor.Layout.TILE).to(device, memcfg),
-        ttl.tensor.Tensor(x.imag, dtype).to(ttl.tensor.Layout.TILE).to(device, memcfg),
+        ttnn.Tensor(x.real, dtype).to(ttnn.TILE_LAYOUT).to(device, memcfg),
+        ttnn.Tensor(x.imag, dtype).to(ttnn.TILE_LAYOUT).to(device, memcfg),
     )
     tt_dev = ttnn.conj(xtt, memory_config=memcfg)
-    tt_dev_r = tt_dev.real.cpu().to(ttl.tensor.Layout.ROW_MAJOR).to_torch()
-    tt_dev_i = tt_dev.imag.cpu().to(ttl.tensor.Layout.ROW_MAJOR).to_torch()
+    tt_dev_r = tt_dev.real.cpu().to(ttnn.ROW_MAJOR_LAYOUT).to_torch()
+    tt_dev_i = tt_dev.imag.cpu().to(ttnn.ROW_MAJOR_LAYOUT).to_torch()
     tt_dev = Complex(re=tt_dev_r, im=tt_dev_i).metal
     tt_cpu = x.conj().metal
     if is_wormhole_b0():
@@ -227,12 +226,12 @@ def test_level2_conj(bs, memcfg, dtype, device, function_level_defaults):
 @pytest.mark.parametrize(
     "memcfg",
     (
-        ttl.tensor.MemoryConfig(ttl.tensor.TensorMemoryLayout.INTERLEAVED, ttl.tensor.BufferType.DRAM),
-        ttl.tensor.MemoryConfig(ttl.tensor.TensorMemoryLayout.INTERLEAVED, ttl.tensor.BufferType.L1),
+        ttnn.DRAM_MEMORY_CONFIG,
+        ttnn.L1_MEMORY_CONFIG,
     ),
     ids=["out_DRAM", "out_L1"],
 )
-@pytest.mark.parametrize("dtype", ((ttl.tensor.DataType.BFLOAT16,)))
+@pytest.mark.parametrize("dtype", ((ttnn.bfloat16,)))
 @pytest.mark.parametrize("bs", ((1, 1), (1, 2), (2, 2)))
 def test_level2_recip(bs, memcfg, dtype, device, function_level_defaults):
     input_shape = torch.Size([bs[0], bs[1], 32, 64])
@@ -240,12 +239,12 @@ def test_level2_recip(bs, memcfg, dtype, device, function_level_defaults):
     x = Complex(input_shape)
     x = x.div(x * 0.5)
     xtt = ttnn.complex_tensor(
-        ttl.tensor.Tensor(x.real, dtype).to(ttl.tensor.Layout.TILE).to(device, memcfg),
-        ttl.tensor.Tensor(x.imag, dtype).to(ttl.tensor.Layout.TILE).to(device, memcfg),
+        ttnn.Tensor(x.real, dtype).to(ttnn.TILE_LAYOUT).to(device, memcfg),
+        ttnn.Tensor(x.imag, dtype).to(ttnn.TILE_LAYOUT).to(device, memcfg),
     )
     tt_dev = ttnn.reciprocal(xtt, memory_config=memcfg)
-    tt_dev_r = tt_dev.real.cpu().to(ttl.tensor.Layout.ROW_MAJOR).to_torch()
-    tt_dev_i = tt_dev.imag.cpu().to(ttl.tensor.Layout.ROW_MAJOR).to_torch()
+    tt_dev_r = tt_dev.real.cpu().to(ttnn.ROW_MAJOR_LAYOUT).to_torch()
+    tt_dev_i = tt_dev.imag.cpu().to(ttnn.ROW_MAJOR_LAYOUT).to_torch()
     tt_dev = Complex(re=tt_dev_r, im=tt_dev_i).metal
     tt_cpu = x.recip().metal
 
@@ -260,12 +259,12 @@ def test_level2_recip(bs, memcfg, dtype, device, function_level_defaults):
 @pytest.mark.parametrize(
     "memcfg",
     (
-        ttl.tensor.MemoryConfig(ttl.tensor.TensorMemoryLayout.INTERLEAVED, ttl.tensor.BufferType.DRAM),
-        ttl.tensor.MemoryConfig(ttl.tensor.TensorMemoryLayout.INTERLEAVED, ttl.tensor.BufferType.L1),
+        ttnn.DRAM_MEMORY_CONFIG,
+        ttnn.L1_MEMORY_CONFIG,
     ),
     ids=["out_DRAM", "out_L1"],
 )
-@pytest.mark.parametrize("dtype", ((ttl.tensor.DataType.BFLOAT16,)))
+@pytest.mark.parametrize("dtype", ((ttnn.bfloat16,)))
 @pytest.mark.parametrize("bs", ((1, 1), (1, 2), (2, 2)))
 def test_level2_add(bs, memcfg, dtype, device, function_level_defaults):
     input_shape = torch.Size([bs[0], bs[1], 32, 64])
@@ -274,17 +273,17 @@ def test_level2_add(bs, memcfg, dtype, device, function_level_defaults):
     y = Complex(input_shape) * -0.5
 
     xtt = ttnn.complex_tensor(
-        ttl.tensor.Tensor(x.real, dtype).to(ttl.tensor.Layout.TILE).to(device, memcfg),
-        ttl.tensor.Tensor(x.imag, dtype).to(ttl.tensor.Layout.TILE).to(device, memcfg),
+        ttnn.Tensor(x.real, dtype).to(ttnn.TILE_LAYOUT).to(device, memcfg),
+        ttnn.Tensor(x.imag, dtype).to(ttnn.TILE_LAYOUT).to(device, memcfg),
     )
     ytt = ttnn.complex_tensor(
-        ttl.tensor.Tensor(y.real, dtype).to(ttl.tensor.Layout.TILE).to(device, memcfg),
-        ttl.tensor.Tensor(y.imag, dtype).to(ttl.tensor.Layout.TILE).to(device, memcfg),
+        ttnn.Tensor(y.real, dtype).to(ttnn.TILE_LAYOUT).to(device, memcfg),
+        ttnn.Tensor(y.imag, dtype).to(ttnn.TILE_LAYOUT).to(device, memcfg),
     )
 
     tt_dev = ttnn.add(xtt, ytt, memory_config=memcfg)
-    tt_dev_r = tt_dev.real.cpu().to(ttl.tensor.Layout.ROW_MAJOR).to_torch()
-    tt_dev_i = tt_dev.imag.cpu().to(ttl.tensor.Layout.ROW_MAJOR).to_torch()
+    tt_dev_r = tt_dev.real.cpu().to(ttnn.ROW_MAJOR_LAYOUT).to_torch()
+    tt_dev_i = tt_dev.imag.cpu().to(ttnn.ROW_MAJOR_LAYOUT).to_torch()
     tt_dev = Complex(re=tt_dev_r, im=tt_dev_i).metal
     tt_cpu = x.add(y).metal
 
@@ -296,12 +295,12 @@ def test_level2_add(bs, memcfg, dtype, device, function_level_defaults):
 @pytest.mark.parametrize(
     "memcfg",
     (
-        ttl.tensor.MemoryConfig(ttl.tensor.TensorMemoryLayout.INTERLEAVED, ttl.tensor.BufferType.DRAM),
-        ttl.tensor.MemoryConfig(ttl.tensor.TensorMemoryLayout.INTERLEAVED, ttl.tensor.BufferType.L1),
+        ttnn.DRAM_MEMORY_CONFIG,
+        ttnn.L1_MEMORY_CONFIG,
     ),
     ids=["out_DRAM", "out_L1"],
 )
-@pytest.mark.parametrize("dtype", ((ttl.tensor.DataType.BFLOAT16,)))
+@pytest.mark.parametrize("dtype", ((ttnn.bfloat16,)))
 @pytest.mark.parametrize("bs", ((1, 1), (1, 2), (2, 2)))
 def test_level2_sub(bs, memcfg, dtype, device, function_level_defaults):
     input_shape = torch.Size([bs[0], bs[1], 32, 64])
@@ -310,17 +309,17 @@ def test_level2_sub(bs, memcfg, dtype, device, function_level_defaults):
     y = Complex(input_shape) * -0.5
 
     xtt = ttnn.complex_tensor(
-        ttl.tensor.Tensor(x.real, dtype).to(ttl.tensor.Layout.TILE).to(device, memcfg),
-        ttl.tensor.Tensor(x.imag, dtype).to(ttl.tensor.Layout.TILE).to(device, memcfg),
+        ttnn.Tensor(x.real, dtype).to(ttnn.TILE_LAYOUT).to(device, memcfg),
+        ttnn.Tensor(x.imag, dtype).to(ttnn.TILE_LAYOUT).to(device, memcfg),
     )
     ytt = ttnn.complex_tensor(
-        ttl.tensor.Tensor(y.real, dtype).to(ttl.tensor.Layout.TILE).to(device, memcfg),
-        ttl.tensor.Tensor(y.imag, dtype).to(ttl.tensor.Layout.TILE).to(device, memcfg),
+        ttnn.Tensor(y.real, dtype).to(ttnn.TILE_LAYOUT).to(device, memcfg),
+        ttnn.Tensor(y.imag, dtype).to(ttnn.TILE_LAYOUT).to(device, memcfg),
     )
 
     tt_dev = ttnn.subtract(xtt, ytt, memory_config=memcfg)
-    tt_dev_r = tt_dev.real.cpu().to(ttl.tensor.Layout.ROW_MAJOR).to_torch()
-    tt_dev_i = tt_dev.imag.cpu().to(ttl.tensor.Layout.ROW_MAJOR).to_torch()
+    tt_dev_r = tt_dev.real.cpu().to(ttnn.ROW_MAJOR_LAYOUT).to_torch()
+    tt_dev_i = tt_dev.imag.cpu().to(ttnn.ROW_MAJOR_LAYOUT).to_torch()
     tt_dev = Complex(re=tt_dev_r, im=tt_dev_i).metal
 
     tt_cpu = x.sub(y).metal
@@ -333,12 +332,12 @@ def test_level2_sub(bs, memcfg, dtype, device, function_level_defaults):
 @pytest.mark.parametrize(
     "memcfg",
     (
-        ttl.tensor.MemoryConfig(ttl.tensor.TensorMemoryLayout.INTERLEAVED, ttl.tensor.BufferType.DRAM),
-        ttl.tensor.MemoryConfig(ttl.tensor.TensorMemoryLayout.INTERLEAVED, ttl.tensor.BufferType.L1),
+        ttnn.DRAM_MEMORY_CONFIG,
+        ttnn.L1_MEMORY_CONFIG,
     ),
     ids=["out_DRAM", "out_L1"],
 )
-@pytest.mark.parametrize("dtype", ((ttl.tensor.DataType.BFLOAT16,)))
+@pytest.mark.parametrize("dtype", ((ttnn.bfloat16,)))
 @pytest.mark.parametrize("bs", ((1, 1), (1, 2), (2, 2)))
 def test_level2_mul(bs, memcfg, dtype, device, function_level_defaults):
     input_shape = torch.Size([bs[0], bs[1], 32, 64])
@@ -347,17 +346,17 @@ def test_level2_mul(bs, memcfg, dtype, device, function_level_defaults):
     y = Complex(input_shape) * -0.5
 
     xtt = ttnn.complex_tensor(
-        ttl.tensor.Tensor(x.real, dtype).to(ttl.tensor.Layout.TILE).to(device, memcfg),
-        ttl.tensor.Tensor(x.imag, dtype).to(ttl.tensor.Layout.TILE).to(device, memcfg),
+        ttnn.Tensor(x.real, dtype).to(ttnn.TILE_LAYOUT).to(device, memcfg),
+        ttnn.Tensor(x.imag, dtype).to(ttnn.TILE_LAYOUT).to(device, memcfg),
     )
     ytt = ttnn.complex_tensor(
-        ttl.tensor.Tensor(y.real, dtype).to(ttl.tensor.Layout.TILE).to(device, memcfg),
-        ttl.tensor.Tensor(y.imag, dtype).to(ttl.tensor.Layout.TILE).to(device, memcfg),
+        ttnn.Tensor(y.real, dtype).to(ttnn.TILE_LAYOUT).to(device, memcfg),
+        ttnn.Tensor(y.imag, dtype).to(ttnn.TILE_LAYOUT).to(device, memcfg),
     )
 
     tt_dev = ttnn.multiply(xtt, ytt, memory_config=memcfg)
-    tt_dev_r = tt_dev.real.cpu().to(ttl.tensor.Layout.ROW_MAJOR).to_torch()
-    tt_dev_i = tt_dev.imag.cpu().to(ttl.tensor.Layout.ROW_MAJOR).to_torch()
+    tt_dev_r = tt_dev.real.cpu().to(ttnn.ROW_MAJOR_LAYOUT).to_torch()
+    tt_dev_i = tt_dev.imag.cpu().to(ttnn.ROW_MAJOR_LAYOUT).to_torch()
     tt_dev = Complex(re=tt_dev_r, im=tt_dev_i).metal
 
     tt_cpu = x.mul(y).metal
@@ -370,12 +369,12 @@ def test_level2_mul(bs, memcfg, dtype, device, function_level_defaults):
 @pytest.mark.parametrize(
     "memcfg",
     (
-        ttl.tensor.MemoryConfig(ttl.tensor.TensorMemoryLayout.INTERLEAVED, ttl.tensor.BufferType.DRAM),
-        ttl.tensor.MemoryConfig(ttl.tensor.TensorMemoryLayout.INTERLEAVED, ttl.tensor.BufferType.L1),
+        ttnn.DRAM_MEMORY_CONFIG,
+        ttnn.L1_MEMORY_CONFIG,
     ),
     ids=["out_DRAM", "out_L1"],
 )
-@pytest.mark.parametrize("dtype", ((ttl.tensor.DataType.BFLOAT16,)))
+@pytest.mark.parametrize("dtype", ((ttnn.bfloat16,)))
 @pytest.mark.parametrize("bs", ((1, 1), (1, 2), (2, 2)))
 def test_level2_div(bs, memcfg, dtype, device, function_level_defaults):
     input_shape = torch.Size([bs[0], bs[1], 32, 64])
@@ -384,17 +383,17 @@ def test_level2_div(bs, memcfg, dtype, device, function_level_defaults):
     y = Complex(input_shape) * 1
 
     xtt = ttnn.complex_tensor(
-        ttl.tensor.Tensor(x.real, dtype).to(ttl.tensor.Layout.TILE).to(device, memcfg),
-        ttl.tensor.Tensor(x.imag, dtype).to(ttl.tensor.Layout.TILE).to(device, memcfg),
+        ttnn.Tensor(x.real, dtype).to(ttnn.TILE_LAYOUT).to(device, memcfg),
+        ttnn.Tensor(x.imag, dtype).to(ttnn.TILE_LAYOUT).to(device, memcfg),
     )
     ytt = ttnn.complex_tensor(
-        ttl.tensor.Tensor(y.real, dtype).to(ttl.tensor.Layout.TILE).to(device, memcfg),
-        ttl.tensor.Tensor(y.imag, dtype).to(ttl.tensor.Layout.TILE).to(device, memcfg),
+        ttnn.Tensor(y.real, dtype).to(ttnn.TILE_LAYOUT).to(device, memcfg),
+        ttnn.Tensor(y.imag, dtype).to(ttnn.TILE_LAYOUT).to(device, memcfg),
     )
 
     tt_dev = ttnn.divide(xtt, xtt, memory_config=memcfg)
-    tt_dev_r = tt_dev.real.cpu().to(ttl.tensor.Layout.ROW_MAJOR).to_torch()
-    tt_dev_i = tt_dev.imag.cpu().to(ttl.tensor.Layout.ROW_MAJOR).to_torch()
+    tt_dev_r = tt_dev.real.cpu().to(ttnn.ROW_MAJOR_LAYOUT).to_torch()
+    tt_dev_i = tt_dev.imag.cpu().to(ttnn.ROW_MAJOR_LAYOUT).to_torch()
     tt_dev = Complex(re=tt_dev_r, im=tt_dev_i).metal
 
     tt_cpu = x.div(y).metal
@@ -407,23 +406,23 @@ def test_level2_div(bs, memcfg, dtype, device, function_level_defaults):
 @pytest.mark.parametrize(
     "memcfg",
     (
-        ttl.tensor.MemoryConfig(ttl.tensor.TensorMemoryLayout.INTERLEAVED, ttl.tensor.BufferType.DRAM),
-        ttl.tensor.MemoryConfig(ttl.tensor.TensorMemoryLayout.INTERLEAVED, ttl.tensor.BufferType.L1),
+        ttnn.DRAM_MEMORY_CONFIG,
+        ttnn.L1_MEMORY_CONFIG,
     ),
     ids=["out_DRAM", "out_L1"],
 )
-@pytest.mark.parametrize("dtype", ((ttl.tensor.DataType.BFLOAT16,)))
+@pytest.mark.parametrize("dtype", ((ttnn.bfloat16,)))
 @pytest.mark.parametrize("bs", ((1, 1), (1, 2), (2, 2)))
 def test_level2_is_real(bs, memcfg, dtype, device, function_level_defaults):
     input_shape = torch.Size([bs[0], bs[1], 32, 64])
     # check abs
     x = Complex(input_shape)
     xtt = ttnn.complex_tensor(
-        ttl.tensor.Tensor(x.real, dtype).to(ttl.tensor.Layout.TILE).to(device, memcfg),
-        ttl.tensor.Tensor(0 * x.imag, dtype).to(ttl.tensor.Layout.TILE).to(device, memcfg),
+        ttnn.Tensor(x.real, dtype).to(ttnn.TILE_LAYOUT).to(device, memcfg),
+        ttnn.Tensor(0 * x.imag, dtype).to(ttnn.TILE_LAYOUT).to(device, memcfg),
     )
     tt_dev = ttnn.is_real(xtt, memory_config=memcfg)
-    tt_dev = tt_dev.cpu().to(ttl.tensor.Layout.ROW_MAJOR).to_torch()
+    tt_dev = tt_dev.cpu().to(ttnn.ROW_MAJOR_LAYOUT).to_torch()
     tt_cpu = torch.ones(x.real.shape)
     if is_wormhole_b0():
         passing, output = comp_pcc(tt_cpu, tt_dev, pcc=0.8)
@@ -437,23 +436,23 @@ def test_level2_is_real(bs, memcfg, dtype, device, function_level_defaults):
 @pytest.mark.parametrize(
     "memcfg",
     (
-        ttl.tensor.MemoryConfig(ttl.tensor.TensorMemoryLayout.INTERLEAVED, ttl.tensor.BufferType.DRAM),
-        ttl.tensor.MemoryConfig(ttl.tensor.TensorMemoryLayout.INTERLEAVED, ttl.tensor.BufferType.L1),
+        ttnn.DRAM_MEMORY_CONFIG,
+        ttnn.L1_MEMORY_CONFIG,
     ),
     ids=["out_DRAM", "out_L1"],
 )
-@pytest.mark.parametrize("dtype", ((ttl.tensor.DataType.BFLOAT16,)))
+@pytest.mark.parametrize("dtype", ((ttnn.bfloat16,)))
 @pytest.mark.parametrize("bs", ((1, 1), (1, 2), (2, 2)))
 def test_level2_is_imag(bs, memcfg, dtype, device, function_level_defaults):
     input_shape = torch.Size([bs[0], bs[1], 32, 64])
     # check abs
     x = Complex(input_shape)
     xtt = ttnn.complex_tensor(
-        ttl.tensor.Tensor(0 * x.real, dtype).to(ttl.tensor.Layout.TILE).to(device, memcfg),
-        ttl.tensor.Tensor(x.imag, dtype).to(ttl.tensor.Layout.TILE).to(device, memcfg),
+        ttnn.Tensor(0 * x.real, dtype).to(ttnn.TILE_LAYOUT).to(device, memcfg),
+        ttnn.Tensor(x.imag, dtype).to(ttnn.TILE_LAYOUT).to(device, memcfg),
     )
     tt_dev = ttnn.is_imag(xtt, memory_config=memcfg)
-    tt_dev = tt_dev.cpu().to(ttl.tensor.Layout.ROW_MAJOR).to_torch()
+    tt_dev = tt_dev.cpu().to(ttnn.ROW_MAJOR_LAYOUT).to_torch()
     tt_cpu = torch.ones(x.imag.shape)
     if is_wormhole_b0():
         passing, output = comp_pcc(tt_cpu, tt_dev, pcc=0.8)
@@ -466,23 +465,23 @@ def test_level2_is_imag(bs, memcfg, dtype, device, function_level_defaults):
 @pytest.mark.parametrize(
     "memcfg",
     (
-        ttl.tensor.MemoryConfig(ttl.tensor.TensorMemoryLayout.INTERLEAVED, ttl.tensor.BufferType.DRAM),
-        ttl.tensor.MemoryConfig(ttl.tensor.TensorMemoryLayout.INTERLEAVED, ttl.tensor.BufferType.L1),
+        ttnn.DRAM_MEMORY_CONFIG,
+        ttnn.L1_MEMORY_CONFIG,
     ),
     ids=["out_DRAM", "out_L1"],
 )
-@pytest.mark.parametrize("dtype", ((ttl.tensor.DataType.BFLOAT16,)))
+@pytest.mark.parametrize("dtype", ((ttnn.bfloat16,)))
 @pytest.mark.parametrize("bs", ((1, 1), (1, 2), (2, 2)))
 def test_level2_angle(bs, memcfg, dtype, device, function_level_defaults):
     input_shape = torch.Size([bs[0], bs[1], 32, 64])
     # check imag
     x = Complex(input_shape)
     xtt = ttnn.complex_tensor(
-        ttl.tensor.Tensor(x.real, dtype).to(ttl.tensor.Layout.TILE).to(device, memcfg),
-        ttl.tensor.Tensor(x.imag, dtype).to(ttl.tensor.Layout.TILE).to(device, memcfg),
+        ttnn.Tensor(x.real, dtype).to(ttnn.TILE_LAYOUT).to(device, memcfg),
+        ttnn.Tensor(x.imag, dtype).to(ttnn.TILE_LAYOUT).to(device, memcfg),
     )
     tt_dev = ttnn.angle(xtt, memory_config=memcfg)
-    tt_dev = tt_dev.cpu().to(ttl.tensor.Layout.ROW_MAJOR).to_torch()
+    tt_dev = tt_dev.cpu().to(ttnn.ROW_MAJOR_LAYOUT).to_torch()
     x_real = torch.tensor(x.real, dtype=torch.bfloat16)
     x_imag = torch.tensor(x.imag, dtype=torch.bfloat16)
     x_torch = torch.complex(x_real.float(), x_imag.float())
@@ -495,12 +494,12 @@ def test_level2_angle(bs, memcfg, dtype, device, function_level_defaults):
 @pytest.mark.parametrize(
     "memcfg",
     (
-        ttl.tensor.MemoryConfig(ttl.tensor.TensorMemoryLayout.INTERLEAVED, ttl.tensor.BufferType.DRAM),
-        ttl.tensor.MemoryConfig(ttl.tensor.TensorMemoryLayout.INTERLEAVED, ttl.tensor.BufferType.L1),
+        ttnn.DRAM_MEMORY_CONFIG,
+        ttnn.L1_MEMORY_CONFIG,
     ),
     ids=["out_DRAM", "out_L1"],
 )
-@pytest.mark.parametrize("dtype", ((ttl.tensor.DataType.BFLOAT16,)))
+@pytest.mark.parametrize("dtype", ((ttnn.bfloat16,)))
 @pytest.mark.parametrize("bs", ((1, 1), (1, 2), (2, 2)))
 def test_level2_polar(bs, memcfg, dtype, device, function_level_defaults):
     input_shape = torch.Size([bs[0], bs[1], 32, 32])
@@ -511,12 +510,12 @@ def test_level2_polar(bs, memcfg, dtype, device, function_level_defaults):
     x = Complex(None, re=torch.ones(input_shape), im=torch.rand(input_shape))
 
     xtt = ttnn.complex_tensor(
-        ttl.tensor.Tensor(x.real, dtype).to(ttl.tensor.Layout.TILE).to(device, memcfg),
-        ttl.tensor.Tensor(x.imag, dtype).to(ttl.tensor.Layout.TILE).to(device, memcfg),
+        ttnn.Tensor(x.real, dtype).to(ttnn.TILE_LAYOUT).to(device, memcfg),
+        ttnn.Tensor(x.imag, dtype).to(ttnn.TILE_LAYOUT).to(device, memcfg),
     )
     tt_dev = ttnn.polar(xtt, memory_config=memcfg)
-    tt_dev_real = tt_dev.real.cpu().to(ttl.tensor.Layout.ROW_MAJOR).to_torch()
-    tt_dev_imag = tt_dev.imag.cpu().to(ttl.tensor.Layout.ROW_MAJOR).to_torch()
+    tt_dev_real = tt_dev.real.cpu().to(ttnn.ROW_MAJOR_LAYOUT).to_torch()
+    tt_dev_imag = tt_dev.imag.cpu().to(ttnn.ROW_MAJOR_LAYOUT).to_torch()
     tt_cpu = torch.polar(x.real, x.imag)
     tt_cpu_real = tt_cpu.real.to(torch.bfloat16).to(float)
     tt_cpu_imag = tt_cpu.imag.to(torch.bfloat16).to(float)

--- a/tests/ttnn/unit_tests/operations/test_complex_tensor.py
+++ b/tests/ttnn/unit_tests/operations/test_complex_tensor.py
@@ -4,7 +4,6 @@
 
 import torch
 
-import tt_lib as ttl
 import pytest
 import ttnn
 from loguru import logger
@@ -21,12 +20,12 @@ from tests.ttnn.unit_tests.operations.complex.utility_funcs import (
 @pytest.mark.parametrize(
     "memcfg",
     (
-        ttl.tensor.MemoryConfig(ttl.tensor.TensorMemoryLayout.INTERLEAVED, ttl.tensor.BufferType.DRAM),
-        ttl.tensor.MemoryConfig(ttl.tensor.TensorMemoryLayout.INTERLEAVED, ttl.tensor.BufferType.L1),
+        ttnn.DRAM_MEMORY_CONFIG,
+        ttnn.L1_MEMORY_CONFIG,
     ),
     ids=["out_DRAM", "out_L1"],
 )
-@pytest.mark.parametrize("dtype", ((ttl.tensor.DataType.FLOAT32,)))
+@pytest.mark.parametrize("dtype", ((ttnn.float32,)))
 @pytest.mark.parametrize("bs", ((1, 1),))
 @pytest.mark.parametrize("hw", ((32, 32),))
 def test_create_complex_tensor(bs, hw, memcfg, dtype, device, function_level_defaults):
@@ -35,8 +34,8 @@ def test_create_complex_tensor(bs, hw, memcfg, dtype, device, function_level_def
     in_data = random_complex_tensor(input_shape, (-90, 90), (-70, 70))
 
     input_tensor = ttnn.complex_tensor(
-        ttl.tensor.Tensor(in_data.real, dtype).to(ttl.tensor.Layout.TILE).to(device, memcfg),
-        ttl.tensor.Tensor(in_data.imag, dtype).to(ttl.tensor.Layout.TILE).to(device, memcfg),
+        ttnn.Tensor(in_data.real, dtype).to(ttnn.TILE_LAYOUT).to(device, memcfg),
+        ttnn.Tensor(in_data.imag, dtype).to(ttnn.TILE_LAYOUT).to(device, memcfg),
     )
 
     tt_dev = input_tensor

--- a/tests/ttnn/unit_tests/operations/test_conv1d.py
+++ b/tests/ttnn/unit_tests/operations/test_conv1d.py
@@ -15,7 +15,6 @@ from models.utility_functions import (
 )
 from tests.ttnn.utils_for_testing import assert_with_pcc, check_with_pcc, check_with_pcc_without_tensor_printout
 import ttnn
-import tt_lib
 import math
 import os
 import torch.nn as nn

--- a/tests/ttnn/unit_tests/operations/test_conv2d.py
+++ b/tests/ttnn/unit_tests/operations/test_conv2d.py
@@ -9,7 +9,6 @@ import pytest
 from models.utility_functions import skip_for_wormhole_b0, skip_for_grayskull, is_grayskull, is_wormhole_b0
 from tests.ttnn.utils_for_testing import assert_with_pcc, check_with_pcc, check_with_pcc_without_tensor_printout
 import ttnn
-import tt_lib
 import math
 import os
 
@@ -47,14 +46,14 @@ def prepare_conv_input_and_copy_to_device_interleaved(
 
     if mem_config is not None:
         # Remove the else block when resolved (https://github.com/tenstorrent/tt-metal/issues/6310):
-        if mem_config.memory_layout == tt_lib.tensor.TensorMemoryLayout.HEIGHT_SHARDED:
+        if mem_config.memory_layout == ttnn.TensorMemoryLayout.HEIGHT_SHARDED:
             tt_input_tensor_on_device = tt_input_tensor.to(device, mem_config)
         else:
-            interleaved_mem_config = tt_lib.tensor.MemoryConfig(
-                tt_lib.tensor.TensorMemoryLayout.INTERLEAVED, tt_lib.tensor.BufferType.DRAM
-            )
+            interleaved_mem_config = ttnn.DRAM_MEMORY_CONFIG
             tt_input_tensor_on_device = tt_input_tensor.to(device, interleaved_mem_config)
-            tt_input_tensor_on_device = tt_lib.tensor.interleaved_to_sharded(tt_input_tensor_on_device, mem_config)
+            tt_input_tensor_on_device = ttnn.experimental.tensor.interleaved_to_sharded(
+                tt_input_tensor_on_device, mem_config
+            )
     else:
         tt_input_tensor_on_device = ttnn.to_device(tt_input_tensor, device)
 
@@ -507,7 +506,7 @@ def test_resnet50_conv_wh(
     ):
         pytest.skip("Skipping test because it won't fit in L1!")
 
-    use_shallow_conv_variant = (input_channels == 16) and device.arch() != tt_lib.device.Arch.WORMHOLE_B0
+    use_shallow_conv_variant = (input_channels == 16) and device.arch() != ttnn.device.Arch.WORMHOLE_B0
     run_conv(
         device,
         math_fidelity,
@@ -627,7 +626,7 @@ def test_resnet50_conv_wh_fp32(
     ):
         pytest.skip("Skipping test because it won't fit in L1!")
 
-    use_shallow_conv_variant = (input_channels == 16) and device.arch() != tt_lib.device.Arch.WORMHOLE_B0
+    use_shallow_conv_variant = (input_channels == 16) and device.arch() != ttnn.device.Arch.WORMHOLE_B0
     run_conv(
         device,
         math_fidelity,

--- a/tests/ttnn/unit_tests/operations/test_eltwise_typecast.py
+++ b/tests/ttnn/unit_tests/operations/test_eltwise_typecast.py
@@ -4,8 +4,8 @@
 
 import pytest
 import torch
+import ttnn
 from functools import partial
-import tt_lib as ttl
 from models.utility_functions import skip_for_grayskull
 
 
@@ -18,35 +18,35 @@ from tests.tt_eager.python_api_testing.sweep_tests.run_pytorch_ci_tests import (
 )
 
 mem_configs = [
-    ttl.tensor.MemoryConfig(ttl.tensor.TensorMemoryLayout.INTERLEAVED, ttl.tensor.BufferType.DRAM),
-    ttl.tensor.MemoryConfig(ttl.tensor.TensorMemoryLayout.INTERLEAVED, ttl.tensor.BufferType.L1),
+    ttnn.DRAM_MEMORY_CONFIG,
+    ttnn.L1_MEMORY_CONFIG,
 ]
 
 
 @pytest.mark.parametrize(
     "pt_input_dtype, tt_input_dtype, tt_output_dtype",
     (
-        (torch.bfloat16, ttl.tensor.DataType.BFLOAT16, ttl.tensor.DataType.FLOAT32),
-        (torch.float32, ttl.tensor.DataType.FLOAT32, ttl.tensor.DataType.BFLOAT16),
-        (torch.bfloat16, ttl.tensor.DataType.BFLOAT16, ttl.tensor.DataType.INT32),
-        (torch.int, ttl.tensor.DataType.INT32, ttl.tensor.DataType.BFLOAT16),
-        (torch.bfloat16, ttl.tensor.DataType.BFLOAT16, ttl.tensor.DataType.UINT16),
-        (torch.int, ttl.tensor.DataType.UINT16, ttl.tensor.DataType.BFLOAT16),
-        (torch.bfloat16, ttl.tensor.DataType.BFLOAT16, ttl.tensor.DataType.UINT32),
-        (torch.int, ttl.tensor.DataType.UINT32, ttl.tensor.DataType.BFLOAT16),
-        (torch.float32, ttl.tensor.DataType.FLOAT32, ttl.tensor.DataType.INT32),
-        (torch.int, ttl.tensor.DataType.INT32, ttl.tensor.DataType.FLOAT32),
-        (torch.float32, ttl.tensor.DataType.FLOAT32, ttl.tensor.DataType.UINT16),
-        (torch.int, ttl.tensor.DataType.UINT16, ttl.tensor.DataType.FLOAT32),
-        (torch.float32, ttl.tensor.DataType.FLOAT32, ttl.tensor.DataType.UINT32),
-        (torch.int, ttl.tensor.DataType.UINT32, ttl.tensor.DataType.FLOAT32),
-        (torch.bfloat16, ttl.tensor.DataType.BFLOAT8_B, ttl.tensor.DataType.INT32),
-        (torch.int, ttl.tensor.DataType.INT32, ttl.tensor.DataType.BFLOAT8_B),
-        (torch.bfloat16, ttl.tensor.DataType.BFLOAT8_B, ttl.tensor.DataType.UINT16),
-        (torch.int, ttl.tensor.DataType.UINT16, ttl.tensor.DataType.BFLOAT8_B),
-        (torch.bfloat16, ttl.tensor.DataType.BFLOAT8_B, ttl.tensor.DataType.UINT32),
-        (torch.int, ttl.tensor.DataType.UINT32, ttl.tensor.DataType.BFLOAT8_B),
-        (torch.int, ttl.tensor.DataType.UINT16, ttl.tensor.DataType.UINT32),
+        (torch.bfloat16, ttnn.bfloat16, ttnn.float32),
+        (torch.float32, ttnn.float32, ttnn.bfloat16),
+        (torch.bfloat16, ttnn.bfloat16, ttnn.int32),
+        (torch.int, ttnn.int32, ttnn.bfloat16),
+        (torch.bfloat16, ttnn.bfloat16, ttnn.uint16),
+        (torch.int, ttnn.uint16, ttnn.bfloat16),
+        (torch.bfloat16, ttnn.bfloat16, ttnn.uint32),
+        (torch.int, ttnn.uint32, ttnn.bfloat16),
+        (torch.float32, ttnn.float32, ttnn.int32),
+        (torch.int, ttnn.int32, ttnn.float32),
+        (torch.float32, ttnn.float32, ttnn.uint16),
+        (torch.int, ttnn.uint16, ttnn.float32),
+        (torch.float32, ttnn.float32, ttnn.uint32),
+        (torch.int, ttnn.uint32, ttnn.float32),
+        (torch.bfloat16, ttnn.bfloat8_b, ttnn.int32),
+        (torch.int, ttnn.int32, ttnn.bfloat8_b),
+        (torch.bfloat16, ttnn.bfloat8_b, ttnn.uint16),
+        (torch.int, ttnn.uint16, ttnn.bfloat8_b),
+        (torch.bfloat16, ttnn.bfloat8_b, ttnn.uint32),
+        (torch.int, ttnn.uint32, ttnn.bfloat8_b),
+        (torch.int, ttnn.uint16, ttnn.uint32),
     ),
 )
 @pytest.mark.parametrize(

--- a/tests/ttnn/unit_tests/operations/test_fast_reduce_nc.py
+++ b/tests/ttnn/unit_tests/operations/test_fast_reduce_nc.py
@@ -6,7 +6,6 @@ import pytest
 import torch
 from loguru import logger
 
-from ttnn import experimental as ttl
 import ttnn
 from models.utility_functions import comp_allclose_and_pcc, comp_pcc, skip_for_grayskull
 from tests.tt_eager.python_api_testing.unit_testing.misc.test_utils import (
@@ -21,7 +20,7 @@ from tests.tt_eager.python_api_testing.unit_testing.misc.test_utils import (
 def get_tensors(input_shape, output_shape, device, *, with_padding=True, use_randint=True, dataformat=ttnn.bfloat16):
     npu_dtype = dataformat
     cpu_dtype = torch.bfloat16
-    npu_layout = ttl.tensor.Layout.TILE
+    npu_layout = ttnn.TILE_LAYOUT
 
     if use_randint:
         torch_input = torch.randint(-2, 3, input_shape, dtype=cpu_dtype, requires_grad=True)
@@ -31,11 +30,11 @@ def get_tensors(input_shape, output_shape, device, *, with_padding=True, use_ran
         torch_output = torch.rand(output_shape, dtype=cpu_dtype)
 
     if with_padding:
-        tt_input = ttl.tensor.Tensor(torch_input, npu_dtype).pad_to_tile(float("nan")).to(npu_layout).to(device)
-        tt_output = ttl.tensor.Tensor(torch_output, npu_dtype).pad_to_tile(float("nan")).to(npu_layout).to(device)
+        tt_input = ttnn.Tensor(torch_input, npu_dtype).pad_to_tile(float("nan")).to(npu_layout).to(device)
+        tt_output = ttnn.Tensor(torch_output, npu_dtype).pad_to_tile(float("nan")).to(npu_layout).to(device)
     else:
-        tt_input = ttl.tensor.Tensor(torch_input, npu_dtype).to(npu_layout).to(device)
-        tt_output = ttl.tensor.Tensor(torch_output, npu_dtype).to(npu_layout).to(device)
+        tt_input = ttnn.Tensor(torch_input, npu_dtype).to(npu_layout).to(device)
+        tt_output = ttnn.Tensor(torch_output, npu_dtype).to(npu_layout).to(device)
 
     return tt_input, tt_output, torch_input
 
@@ -77,7 +76,7 @@ def test_fast_reduce_nc(input_shape, dims, compute_kernel_options, dataformat, d
     torch_output = torch.sum(torch_input, dims, True)
 
     compute_kernel_config = get_compute_kernel_options(compute_kernel_options)
-    cpu_layout = ttl.tensor.Layout.ROW_MAJOR
+    cpu_layout = ttnn.ROW_MAJOR_LAYOUT
     tt_output = ttnn.experimental.fast_reduce_nc(
         tt_input, dims=dims, output=None, compute_kernel_config=compute_kernel_config
     )
@@ -114,37 +113,37 @@ def test_fast_reduce_nc_with_prgm_caching(dims, device, use_program_cache):
         # shift input/output tensor by creating very small tensor between loop
         inp = torch.rand(1, 1, 32, 32)
         test_tensor = (
-            ttl.tensor.Tensor(
+            ttnn.Tensor(
                 inp.reshape(-1).tolist(),
                 inp.shape,
                 ttnn.bfloat16,
-                ttl.tensor.Layout.ROW_MAJOR,
+                ttnn.ROW_MAJOR_LAYOUT,
             )
-            .to(ttl.tensor.Layout.TILE)
+            .to(ttnn.TILE_LAYOUT)
             .to(device)
         )
-        shard_spec_1_cores_grid = ttl.tensor.CoreRangeSet(
+        shard_spec_1_cores_grid = ttnn.CoreRangeSet(
             {
-                ttl.tensor.CoreRange(
-                    ttl.tensor.CoreCoord(0, 0),
-                    ttl.tensor.CoreCoord(0, 0),
+                ttnn.CoreRange(
+                    ttnn.CoreCoord(0, 0),
+                    ttnn.CoreCoord(0, 0),
                 ),
             }
         )
-        test_mem_cfg = ttl.tensor.MemoryConfig(
-            ttl.tensor.TensorMemoryLayout.HEIGHT_SHARDED,
-            ttl.tensor.BufferType.L1,
-            ttl.tensor.ShardSpec(
+        test_mem_cfg = ttnn.MemoryConfig(
+            ttnn.TensorMemoryLayout.HEIGHT_SHARDED,
+            ttnn.BufferType.L1,
+            ttnn.ShardSpec(
                 shard_spec_1_cores_grid,  # Volume must match # of attn heads
                 [
                     32,  # Each core has 32 users
                     32,  # head dim
                 ],
-                ttl.tensor.ShardOrientation.ROW_MAJOR,
+                ttnn.ShardOrientation.ROW_MAJOR,
                 False,
             ),
         )
-        test_tensor = ttl.tensor.interleaved_to_sharded(test_tensor, sharded_mem_config=test_mem_cfg)
+        test_tensor = ttnn.experimental.tensor.interleaved_to_sharded(test_tensor, sharded_mem_config=test_mem_cfg)
 
         # Test op
         for dim in dims:
@@ -154,7 +153,7 @@ def test_fast_reduce_nc_with_prgm_caching(dims, device, use_program_cache):
 
         torch_output = torch.sum(torch_input, dims, True)
 
-        cpu_layout = ttl.tensor.Layout.ROW_MAJOR
+        cpu_layout = ttnn.ROW_MAJOR_LAYOUT
         tt_output = ttnn.experimental.fast_reduce_nc(tt_input, dims=dims, output=None)
         tt_output_cpu = tt_output.cpu().to(cpu_layout).unpad_from_tile(output_shape_1).to_torch()
 
@@ -180,7 +179,7 @@ def test_fast_reduce_nc_with_prgm_caching(dims, device, use_program_cache):
 
         torch_output = torch.sum(torch_input, dims, True)
 
-        cpu_layout = ttl.tensor.Layout.ROW_MAJOR
+        cpu_layout = ttnn.ROW_MAJOR_LAYOUT
         tt_output = ttnn.experimental.fast_reduce_nc(tt_input, dims=dims, output=None)
         tt_output_cpu = tt_output.cpu().to(cpu_layout).unpad_from_tile(output_shape_2).to_torch()
 

--- a/tests/ttnn/unit_tests/operations/test_fold_op.py
+++ b/tests/ttnn/unit_tests/operations/test_fold_op.py
@@ -205,7 +205,7 @@ def test_fold(act_shape, stride_h, stride_w, device):
         torch_input,
         device,
         ttnn.ROW_MAJOR_LAYOUT,
-        tt_memory_config=ttnn.MemoryConfig(ttnn.TensorMemoryLayout.INTERLEAVED, ttnn.BufferType.L1),
+        tt_memory_config=ttnn.L1_MEMORY_CONFIG,
     )
 
     tt_out = ttnn.fold(tt_input, stride_h, stride_w)

--- a/tests/ttnn/unit_tests/operations/test_maxpool2d.py
+++ b/tests/ttnn/unit_tests/operations/test_maxpool2d.py
@@ -173,7 +173,7 @@ def test_run_max_pool(
         device=device,
     )
 
-    # interleaved_mem_config = ttnn.MemoryConfig(ttnn.TensorMemoryLayout.INTERLEAVED, ttnn.BufferType.L1)
+    # interleaved_mem_config = ttnn.L1_MEMORY_CONFIG
     # output = ttnn.to_memory_config(output, interleaved_mem_config)
     output_host = output.cpu()
     output_pytorch_padded = ttnn.to_torch(output_host)

--- a/tests/ttnn/unit_tests/operations/test_new_conv2d.py
+++ b/tests/ttnn/unit_tests/operations/test_new_conv2d.py
@@ -15,7 +15,6 @@ from models.utility_functions import (
 )
 from tests.ttnn.utils_for_testing import assert_with_pcc, check_with_pcc, check_with_pcc_without_tensor_printout
 import ttnn
-import tt_lib
 import math
 import os
 import torch.nn as nn
@@ -511,7 +510,7 @@ def test_resnet50_conv_wh(
     ):
         pytest.skip("Skipping test because it won't fit in L1!")
 
-    use_shallow_conv_variant = (input_channels == 16) and device.arch() != tt_lib.device.Arch.WORMHOLE_B0
+    use_shallow_conv_variant = (input_channels == 16) and device.arch() != ttnn.device.Arch.WORMHOLE_B0
     run_conv(
         device,
         math_fidelity,
@@ -634,7 +633,7 @@ def test_resnet50_conv_wh_fp32(
     ):
         pytest.skip("Skipping test because it won't fit in L1!")
 
-    use_shallow_conv_variant = (input_channels == 16) and device.arch() != tt_lib.device.Arch.WORMHOLE_B0
+    use_shallow_conv_variant = (input_channels == 16) and device.arch() != ttnn.device.Arch.WORMHOLE_B0
     run_conv(
         device,
         math_fidelity,

--- a/tests/ttnn/unit_tests/operations/test_reduce_scatter_nightly.py
+++ b/tests/ttnn/unit_tests/operations/test_reduce_scatter_nightly.py
@@ -5,7 +5,6 @@
 import torch
 import pytest
 from loguru import logger
-import tt_lib as ttl
 import ttnn
 from tests.tt_eager.python_api_testing.sweep_tests.comparison_funcs import comp_equal, comp_pcc
 from tests.ttnn.unit_tests.operations.test_reduce_scatter_post_commit import (
@@ -27,38 +26,38 @@ import itertools
 @pytest.mark.parametrize(
     "per_chip_output_shape, scatter_dim, layout",
     [
-        ([1, 8, 1024, 1024], 3, ttl.tensor.Layout.TILE),
-        ([1, 4, 1024, 1024], 3, ttl.tensor.Layout.TILE),
-        ([1, 4, 2048, 1024], 3, ttl.tensor.Layout.TILE),
-        ([1, 1, 32, 32], 3, ttl.tensor.Layout.TILE),
-        ([1, 1, 32, 64], 3, ttl.tensor.Layout.TILE),
-        ([1, 1, 64, 64], 3, ttl.tensor.Layout.TILE),
-        ([1, 1, 32, 128], 3, ttl.tensor.Layout.TILE),
-        ([1, 1, 32, 256], 3, ttl.tensor.Layout.TILE),
-        ([1, 1, 32, 512], 3, ttl.tensor.Layout.TILE),
-        ([1, 1, 32, 1024], 3, ttl.tensor.Layout.TILE),
-        ([1, 1, 32, 2048], 3, ttl.tensor.Layout.TILE),
-        ([1, 1, 128, 1024], 3, ttl.tensor.Layout.TILE),
+        ([1, 8, 1024, 1024], 3, ttnn.TILE_LAYOUT),
+        ([1, 4, 1024, 1024], 3, ttnn.TILE_LAYOUT),
+        ([1, 4, 2048, 1024], 3, ttnn.TILE_LAYOUT),
+        ([1, 1, 32, 32], 3, ttnn.TILE_LAYOUT),
+        ([1, 1, 32, 64], 3, ttnn.TILE_LAYOUT),
+        ([1, 1, 64, 64], 3, ttnn.TILE_LAYOUT),
+        ([1, 1, 32, 128], 3, ttnn.TILE_LAYOUT),
+        ([1, 1, 32, 256], 3, ttnn.TILE_LAYOUT),
+        ([1, 1, 32, 512], 3, ttnn.TILE_LAYOUT),
+        ([1, 1, 32, 1024], 3, ttnn.TILE_LAYOUT),
+        ([1, 1, 32, 2048], 3, ttnn.TILE_LAYOUT),
+        ([1, 1, 128, 1024], 3, ttnn.TILE_LAYOUT),
         # Has worker slice size warning - defaults to 1x1
-        ([1, 1, 128, 8192], 3, ttl.tensor.Layout.TILE),
+        ([1, 1, 128, 8192], 3, ttnn.TILE_LAYOUT),
         # Always fails with bfp8_b
-        ([1, 1, 2048, 1024], 3, ttl.tensor.Layout.TILE),
+        ([1, 1, 2048, 1024], 3, ttnn.TILE_LAYOUT),
         # Has worker slice size warning - defaults to 1x1
-        ([1, 1, 2048, 8192], 3, ttl.tensor.Layout.TILE),
+        ([1, 1, 2048, 8192], 3, ttnn.TILE_LAYOUT),
     ],
 )
 @pytest.mark.parametrize(
     "input_dtype",
     [
-        ttl.tensor.DataType.BFLOAT16,
-        ttl.tensor.DataType.BFLOAT8_B,
+        ttnn.bfloat16,
+        ttnn.bfloat8_b,
     ],
 )
 @pytest.mark.parametrize(
     "mem_config",
     [
-        ttl.tensor.MemoryConfig(buffer_type=ttl.tensor.BufferType.DRAM),
-        ttl.tensor.MemoryConfig(buffer_type=ttl.tensor.BufferType.L1),
+        ttnn.MemoryConfig(buffer_type=ttnn.BufferType.DRAM),
+        ttnn.MemoryConfig(buffer_type=ttnn.BufferType.L1),
     ],
 )
 @pytest.mark.parametrize("math_op", [ttnn.ReduceType.Sum])

--- a/tests/ttnn/unit_tests/operations/test_reduce_scatter_post_commit.py
+++ b/tests/ttnn/unit_tests/operations/test_reduce_scatter_post_commit.py
@@ -5,7 +5,6 @@
 import torch
 import pytest
 from loguru import logger
-import tt_lib as ttl
 import ttnn
 from tests.tt_eager.python_api_testing.sweep_tests.comparison_funcs import comp_equal, comp_pcc
 from models.utility_functions import skip_for_grayskull, get_devices_for_t3000
@@ -15,15 +14,15 @@ def is_unsupported_case(input_shape, scatter_dim, math_op, mem_config, num_devic
     if scatter_dim != 3:
         return True, "Only support for scatter_dim=3 is tested so far"
 
-    elem_size = 2 if input_dtype == ttl.tensor.DataType.BFLOAT16 else 1
+    elem_size = 2 if input_dtype == ttnn.bfloat16 else 1
     tensor_size_bytes = elem_size
     for i in input_shape:
         tensor_size_bytes *= i
     num_l1_banks = 64
-    if mem_config.buffer_type == ttl.tensor.BufferType.L1 and tensor_size_bytes > num_l1_banks * 50 * 1024:
+    if mem_config.buffer_type == ttnn.BufferType.L1 and tensor_size_bytes > num_l1_banks * 50 * 1024:
         return True, "L1 buffer can't support large tensor sizes"
 
-    # if input_dtype == ttl.tensor.DataType.BFLOAT8_B and tuple(input_shape) == (1, 1, 2048, 1024) and scatter_dim == 3:
+    # if input_dtype == ttnn.bfloat8_b and tuple(input_shape) == (1, 1, 2048, 1024) and scatter_dim == 3:
     #     return True, "Known failure with bfp8_b data format"
 
     return False, ""
@@ -75,7 +74,7 @@ def run_reduce_scatter_test(
         input_tensors[-1] = torch.arange(numel).reshape(canonical_input_shape).bfloat16()
     for i, canonical_input_tensor in enumerate(input_tensors):
         tt_input_tensors.append(
-            ttl.tensor.Tensor(canonical_input_tensor, input_dtype)
+            ttnn.Tensor(canonical_input_tensor, input_dtype)
             .to(layout)
             .to(t3k_device_mesh.get_device(t3k_device_mesh.get_device_ids()[i]), mem_config)
         )
@@ -94,7 +93,7 @@ def run_reduce_scatter_test(
         )
 
         for device_id in t3k_device_mesh.get_device_ids():
-            ttl.device.Synchronize(t3k_device_mesh.get_device(device_id))
+            ttnn.synchronize_device(t3k_device_mesh.get_device(device_id))
         logger.info(f"Done iteration {i}")
 
     # Compute golden
@@ -111,7 +110,7 @@ def run_reduce_scatter_test(
     assert len(golden_output_tensors) == len(tt_out_tensors)
     mismatch = False
     for i, t in enumerate(tt_out_tensors):
-        tt_output_tensor = t.cpu().to(ttl.tensor.Layout.ROW_MAJOR).to_torch()
+        tt_output_tensor = t.cpu().to(ttnn.ROW_MAJOR_LAYOUT).to_torch()
         eq, output = comp_pcc(tt_output_tensor, golden_output_tensors[i])
         mismatch = mismatch or not eq
         if not eq:
@@ -143,26 +142,26 @@ def run_reduce_scatter_test(
 @pytest.mark.parametrize(
     "per_chip_output_shape, scatter_dim, layout",
     [
-        ([1, 2, 256, 32 * 8], 3, ttl.tensor.Layout.TILE),  # Input tensor is (16*32) x (64*32) = 8 * input tensor shape
-        ([1, 1, 32, 32 * 8], 3, ttl.tensor.Layout.TILE),
-        ([1, 8, 1024, 1024], 3, ttl.tensor.Layout.TILE),
-        ([1, 4, 2048, 1024], 3, ttl.tensor.Layout.TILE),
+        ([1, 2, 256, 32 * 8], 3, ttnn.TILE_LAYOUT),  # Input tensor is (16*32) x (64*32) = 8 * input tensor shape
+        ([1, 1, 32, 32 * 8], 3, ttnn.TILE_LAYOUT),
+        ([1, 8, 1024, 1024], 3, ttnn.TILE_LAYOUT),
+        ([1, 4, 2048, 1024], 3, ttnn.TILE_LAYOUT),
         # # # Has worker slice size warning - defaults to 1x1
-        ([1, 1, 128, 8192], 3, ttl.tensor.Layout.TILE),
+        ([1, 1, 128, 8192], 3, ttnn.TILE_LAYOUT),
     ],
 )
 @pytest.mark.parametrize(
     "input_dtype",
     [
-        ttl.tensor.DataType.BFLOAT16,
-        ttl.tensor.DataType.BFLOAT8_B,
+        ttnn.bfloat16,
+        ttnn.bfloat8_b,
     ],
 )
 @pytest.mark.parametrize(
     "mem_config",
     [
-        ttl.tensor.MemoryConfig(buffer_type=ttl.tensor.BufferType.DRAM),
-        ttl.tensor.MemoryConfig(buffer_type=ttl.tensor.BufferType.L1),
+        ttnn.MemoryConfig(buffer_type=ttnn.BufferType.DRAM),
+        ttnn.MemoryConfig(buffer_type=ttnn.BufferType.L1),
     ],
 )
 @pytest.mark.parametrize("math_op", [ttnn.ReduceType.Sum])
@@ -233,24 +232,22 @@ def run_reduce_scatter_sharded_test(
         input_shard_shape[0] *= num_devices
     tt_input_tensors = []
 
-    input_shard_spec = ttl.tensor.ShardSpec(
+    input_shard_spec = ttnn.ShardSpec(
         shard_grid,
         tuple(input_shard_shape),
         orientation,
         False,
     )
 
-    output_shard_spec = ttl.tensor.ShardSpec(
+    output_shard_spec = ttnn.ShardSpec(
         shard_grid,
         output_shard_shape,
         orientation,
         False,
     )
-    input_mem_config = ttl.tensor.MemoryConfig(
-        tensor_mem_layout, buffer_type=ttl.tensor.BufferType.L1, shard_spec=input_shard_spec
-    )
-    output_mem_config = ttl.tensor.MemoryConfig(
-        tensor_mem_layout, buffer_type=ttl.tensor.BufferType.L1, shard_spec=output_shard_spec
+    input_mem_config = ttnn.MemoryConfig(tensor_mem_layout, buffer_type=ttnn.BufferType.L1, shard_spec=input_shard_spec)
+    output_mem_config = ttnn.MemoryConfig(
+        tensor_mem_layout, buffer_type=ttnn.BufferType.L1, shard_spec=output_shard_spec
     )
 
     canonical_input_shape = list(per_chip_output_shape)
@@ -266,7 +263,7 @@ def run_reduce_scatter_sharded_test(
         input_tensors[-1] = torch.arange(numel).reshape(canonical_input_shape).bfloat16()
     for i, canonical_input_tensor in enumerate(input_tensors):
         tt_input_tensors.append(
-            ttl.tensor.Tensor(canonical_input_tensor, input_dtype)
+            ttnn.Tensor(canonical_input_tensor, input_dtype)
             .to(tensor_layout)
             .to(t3k_device_mesh.get_device(t3k_device_mesh.get_device_ids()[i]), input_mem_config)
         )
@@ -283,7 +280,7 @@ def run_reduce_scatter_sharded_test(
         )
 
         for device_id in t3k_device_mesh.get_device_ids():
-            ttl.device.Synchronize(t3k_device_mesh.get_device(device_id))
+            ttnn.synchronize_device(t3k_device_mesh.get_device(device_id))
         logger.info(f"Done iteration {i}")
 
     # Compute golden
@@ -300,7 +297,7 @@ def run_reduce_scatter_sharded_test(
     assert len(golden_output_tensors) == len(tt_out_tensors)
     mismatch = False
     for i, t in enumerate(tt_out_tensors):
-        tt_output_tensor = t.cpu().to(ttl.tensor.Layout.ROW_MAJOR).to_torch()
+        tt_output_tensor = t.cpu().to(ttnn.ROW_MAJOR_LAYOUT).to_torch()
         eq, output = comp_pcc(tt_output_tensor, golden_output_tensors[i])
         mismatch = mismatch or not eq
         if not eq:
@@ -322,18 +319,18 @@ def run_reduce_scatter_sharded_test(
 @pytest.mark.parametrize(
     "tensor_mem_layout",
     [
-        ttl.tensor.TensorMemoryLayout.WIDTH_SHARDED,
-        # ttl.tensor.TensorMemoryLayout.HEIGHT_SHARDED,
-        # ttl.tensor.TensorMemoryLayout.BLOCK_SHARDED,
+        ttnn.TensorMemoryLayout.WIDTH_SHARDED,
+        # ttnn.TensorMemoryLayout.HEIGHT_SHARDED,
+        # ttnn.TensorMemoryLayout.BLOCK_SHARDED,
     ],
 )
-@pytest.mark.parametrize("tensor_layout", [ttl.tensor.Layout.TILE])
-@pytest.mark.parametrize("orientation", [ttl.tensor.ShardOrientation.ROW_MAJOR])
+@pytest.mark.parametrize("tensor_layout", [ttnn.TILE_LAYOUT])
+@pytest.mark.parametrize("orientation", [ttnn.ShardOrientation.ROW_MAJOR])
 @pytest.mark.parametrize(
     "input_dtype",
     [
-        ttl.tensor.DataType.BFLOAT16,
-        ttl.tensor.DataType.BFLOAT8_B,
+        ttnn.bfloat16,
+        ttnn.bfloat8_b,
     ],
 )
 @pytest.mark.parametrize(
@@ -343,22 +340,22 @@ def run_reduce_scatter_sharded_test(
         (
             (1, 1, 32, 1024),
             (32, 32),
-            ttl.tensor.CoreRangeSet({ttl.tensor.CoreRange(ttl.tensor.CoreCoord(0, 0), ttl.tensor.CoreCoord(7, 3))}),
+            ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(7, 3))}),
         ),
         (  # https://github.com/tenstorrent/tt-metal/issues/9686
             (1, 1, 32, 4096),
             (32, 128),
-            ttl.tensor.CoreRangeSet({ttl.tensor.CoreRange(ttl.tensor.CoreCoord(0, 0), ttl.tensor.CoreCoord(7, 3))}),
+            ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(7, 3))}),
         ),
         (  # https://github.com/tenstorrent/tt-metal/issues/9686
             (1, 1, 32, 2048),
             (32, 64),
-            ttl.tensor.CoreRangeSet({ttl.tensor.CoreRange(ttl.tensor.CoreCoord(0, 0), ttl.tensor.CoreCoord(7, 3))}),
+            ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(7, 3))}),
         ),
         (  # https://github.com/tenstorrent/tt-metal/issues/9686
             (1, 1, 32, 1792),
             (32, 32),
-            ttl.tensor.CoreRangeSet({ttl.tensor.CoreRange(ttl.tensor.CoreCoord(0, 0), ttl.tensor.CoreCoord(7, 6))}),
+            ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(7, 6))}),
         ),
     ),
 )
@@ -414,15 +411,15 @@ def test_width_sharded_reduce_scatter_post_commit(
 @pytest.mark.parametrize(
     "tensor_mem_layout",
     [
-        ttl.tensor.TensorMemoryLayout.HEIGHT_SHARDED,
+        ttnn.TensorMemoryLayout.HEIGHT_SHARDED,
     ],
 )
-@pytest.mark.parametrize("tensor_layout", [ttl.tensor.Layout.TILE])
-@pytest.mark.parametrize("orientation", [ttl.tensor.ShardOrientation.COL_MAJOR])  # Hangs with ROW_MAJOR
+@pytest.mark.parametrize("tensor_layout", [ttnn.TILE_LAYOUT])
+@pytest.mark.parametrize("orientation", [ttnn.ShardOrientation.COL_MAJOR])  # Hangs with ROW_MAJOR
 @pytest.mark.parametrize(
     "input_dtype",
     [
-        ttl.tensor.DataType.BFLOAT16,
+        ttnn.bfloat16,
     ],
 )
 @pytest.mark.parametrize(
@@ -432,7 +429,7 @@ def test_width_sharded_reduce_scatter_post_commit(
         (
             (1, 1, 1024, 32),
             (32, 32),
-            ttl.tensor.CoreRangeSet({ttl.tensor.CoreRange(ttl.tensor.CoreCoord(0, 0), ttl.tensor.CoreCoord(7, 3))}),
+            ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(7, 3))}),
         ),
     ),
 )
@@ -487,15 +484,15 @@ def test_height_sharded_reduce_scatter_post_commit(
 @pytest.mark.parametrize(
     "tensor_mem_layout",
     [
-        ttl.tensor.TensorMemoryLayout.BLOCK_SHARDED,
+        ttnn.TensorMemoryLayout.BLOCK_SHARDED,
     ],
 )
-@pytest.mark.parametrize("tensor_layout", [ttl.tensor.Layout.TILE])
-@pytest.mark.parametrize("orientation", [ttl.tensor.ShardOrientation.ROW_MAJOR])
+@pytest.mark.parametrize("tensor_layout", [ttnn.TILE_LAYOUT])
+@pytest.mark.parametrize("orientation", [ttnn.ShardOrientation.ROW_MAJOR])
 @pytest.mark.parametrize(
     "input_dtype",
     [
-        ttl.tensor.DataType.BFLOAT16,
+        ttnn.bfloat16,
     ],
 )
 @pytest.mark.parametrize(
@@ -505,7 +502,7 @@ def test_height_sharded_reduce_scatter_post_commit(
         (
             (1, 1, 256, 512),
             (64, 64),
-            ttl.tensor.CoreRangeSet({ttl.tensor.CoreRange(ttl.tensor.CoreCoord(0, 0), ttl.tensor.CoreCoord(7, 3))}),
+            ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(7, 3))}),
         ),
     ),
 )

--- a/tests/ttnn/unit_tests/operations/test_silu.py
+++ b/tests/ttnn/unit_tests/operations/test_silu.py
@@ -10,8 +10,6 @@ import torch
 
 # import torch.nn as nn
 
-# import tt_lib
-import tt_lib as ttl
 import ttnn
 
 from tests.ttnn.utils_for_testing import check_with_pcc_without_tensor_printout
@@ -48,7 +46,7 @@ def run_elt_silu_relu(
     input_tensor = ttnn.from_torch(
         tt_input, device=device, memory_config=ttnn.L1_MEMORY_CONFIG, layout=ttnn.TILE_LAYOUT, dtype=dtype
     )
-    interleaved_mem_config = ttnn.MemoryConfig(ttl.tensor.TensorMemoryLayout.INTERLEAVED, ttl.tensor.BufferType.L1)
+    interleaved_mem_config = ttnn.L1_MEMORY_CONFIG
     input_tensor = ttnn.to_memory_config(input_tensor, interleaved_mem_config)
     # input_shape = [1, 1, _nearest_y(batch_size * input_height * input_width, 32), input_channels]
     input_2d_height = input_tensor.get_legacy_shape()[2]

--- a/tests/ttnn/unit_tests/operations/test_ssm_1d_sum_reduce.py
+++ b/tests/ttnn/unit_tests/operations/test_ssm_1d_sum_reduce.py
@@ -36,15 +36,15 @@ def run_ssm_1d_sum_reduce(H: int, W: int, latent_size: int, dtype, in_mem_config
 @pytest.mark.parametrize(
     "out_mem_config",
     (
-        ttnn.MemoryConfig(ttnn.TensorMemoryLayout.INTERLEAVED, ttnn.BufferType.DRAM),
-        ttnn.MemoryConfig(ttnn.TensorMemoryLayout.INTERLEAVED, ttnn.BufferType.L1),
+        ttnn.DRAM_MEMORY_CONFIG,
+        ttnn.L1_MEMORY_CONFIG,
     ),
 )
 @pytest.mark.parametrize(
     "in_mem_config",
     (
-        ttnn.MemoryConfig(ttnn.TensorMemoryLayout.INTERLEAVED, ttnn.BufferType.DRAM),
-        ttnn.MemoryConfig(ttnn.TensorMemoryLayout.INTERLEAVED, ttnn.BufferType.L1),
+        ttnn.DRAM_MEMORY_CONFIG,
+        ttnn.L1_MEMORY_CONFIG,
     ),
 )
 @pytest.mark.parametrize(
@@ -66,7 +66,7 @@ def test_ssm_reduce(H, W, latent_size, dtype, out_mem_config, in_mem_config, dev
 
 def test_ssm_1d_sum_reduce_with_program_cache(device, use_program_cache):
     H, W, latent = 32, 163840, 32
-    mem_config = ttnn.MemoryConfig(ttnn.TensorMemoryLayout.INTERLEAVED, ttnn.BufferType.L1)
+    mem_config = ttnn.L1_MEMORY_CONFIG
     dtype = ttnn.bfloat16
 
     for _ in range(2):

--- a/tests/ttnn/unit_tests/operations/test_ssm_repeat_and_interleave_eltwise_mul.py
+++ b/tests/ttnn/unit_tests/operations/test_ssm_repeat_and_interleave_eltwise_mul.py
@@ -6,7 +6,6 @@
 import torch
 import ttnn
 
-import tt_lib as ttl
 import pytest
 from loguru import logger
 
@@ -25,8 +24,8 @@ def run_ssm_eltwise_mul_test(batch_size, in0_W, in1_W, dtype, in0_mem_config, in
     B = torch.randn(B_shape)
     X = torch.randn(X_shape)
 
-    tt_input_tensor_B = ttl.tensor.Tensor(B, dtype).to(ttl.tensor.Layout.TILE).to(device, in0_mem_config)
-    tt_input_tensor_X = ttl.tensor.Tensor(X, dtype).to(ttl.tensor.Layout.TILE).to(device, in1_mem_config)
+    tt_input_tensor_B = ttnn.Tensor(B, dtype).to(ttnn.TILE_LAYOUT).to(device, in0_mem_config)
+    tt_input_tensor_X = ttnn.Tensor(X, dtype).to(ttnn.TILE_LAYOUT).to(device, in1_mem_config)
 
     tt_out = ttnn.experimental.repeat_and_interleave_eltwise_mul(
         tt_input_tensor_B, tt_input_tensor_X, memory_config=out_mem_config, dtype=dtype
@@ -56,27 +55,27 @@ def run_ssm_eltwise_mul_test(batch_size, in0_W, in1_W, dtype, in0_mem_config, in
 @pytest.mark.parametrize(
     "out_mem_config",
     (
-        ttl.tensor.MemoryConfig(ttl.tensor.TensorMemoryLayout.INTERLEAVED, ttl.tensor.BufferType.DRAM),
-        ttl.tensor.MemoryConfig(ttl.tensor.TensorMemoryLayout.INTERLEAVED, ttl.tensor.BufferType.L1),
+        ttnn.DRAM_MEMORY_CONFIG,
+        ttnn.L1_MEMORY_CONFIG,
     ),
 )
 @pytest.mark.parametrize(
     "in1_mem_config",
     (
-        ttl.tensor.MemoryConfig(ttl.tensor.TensorMemoryLayout.INTERLEAVED, ttl.tensor.BufferType.DRAM),
-        ttl.tensor.MemoryConfig(ttl.tensor.TensorMemoryLayout.INTERLEAVED, ttl.tensor.BufferType.L1),
+        ttnn.DRAM_MEMORY_CONFIG,
+        ttnn.L1_MEMORY_CONFIG,
     ),
 )
 @pytest.mark.parametrize(
     "in0_mem_config",
     (
-        ttl.tensor.MemoryConfig(ttl.tensor.TensorMemoryLayout.INTERLEAVED, ttl.tensor.BufferType.DRAM),
-        ttl.tensor.MemoryConfig(ttl.tensor.TensorMemoryLayout.INTERLEAVED, ttl.tensor.BufferType.L1),
+        ttnn.DRAM_MEMORY_CONFIG,
+        ttnn.L1_MEMORY_CONFIG,
     ),
 )
 @pytest.mark.parametrize(
     "dtype",
-    (ttl.tensor.DataType.BFLOAT16, ttl.tensor.DataType.BFLOAT8_B),
+    (ttnn.bfloat16, ttnn.bfloat8_b),
 )
 @pytest.mark.parametrize(
     "in0_W, in1_W",
@@ -95,8 +94,8 @@ def test_ssm_eltwise_mul(batch, in0_W, in1_W, dtype, in0_mem_config, in1_mem_con
 
 
 def test_ssm_eltwise_mul_with_program_cache(device, use_program_cache):
-    mem_config = ttl.tensor.MemoryConfig(ttl.tensor.TensorMemoryLayout.INTERLEAVED, ttl.tensor.BufferType.L1)
-    dtype = ttl.tensor.DataType.BFLOAT16
+    mem_config = ttnn.L1_MEMORY_CONFIG
+    dtype = ttnn.bfloat16
 
     for _ in range(2):
         batch, in0_W, in1_W = 64, 32, 5120
@@ -107,6 +106,6 @@ def test_ssm_eltwise_mul_with_program_cache(device, use_program_cache):
         run_ssm_eltwise_mul_test(batch, in0_W, in1_W, dtype, mem_config, mem_config, mem_config, device)
         dummy_shape = [1, 1, 32, 32]
         py_dummy_tensor = torch.randn(dummy_shape)
-        tt_dummy_tensor = ttl.tensor.Tensor(py_dummy_tensor, dtype).to(ttl.tensor.Layout.TILE).to(device, mem_config)
+        tt_dummy_tensor = ttnn.Tensor(py_dummy_tensor, dtype).to(ttnn.TILE_LAYOUT).to(device, mem_config)
 
     assert device.num_program_cache_entries() == 3

--- a/tests/ttnn/unit_tests/operations/test_typecast.py
+++ b/tests/ttnn/unit_tests/operations/test_typecast.py
@@ -7,7 +7,6 @@ import pytest
 import torch
 
 import ttnn
-import tt_lib
 from models.utility_functions import is_grayskull
 
 from tests.ttnn.utils_for_testing import assert_with_pcc

--- a/tests/ttnn/unit_tests/test_reshape.py
+++ b/tests/ttnn/unit_tests/test_reshape.py
@@ -7,7 +7,6 @@ import pytest
 import torch
 
 import ttnn
-import tt_lib as ttl
 
 from tests.ttnn.utils_for_testing import assert_with_pcc
 


### PR DESCRIPTION
Issue : #11367 , Tracking Issue : #11242 , Master Issue : #10532

- [All post-commit tests](https://github.com/tenstorrent/tt-metal/actions/runs/10420170266) - PASSED
- [[post-commit] C++ tests](https://github.com/tenstorrent/tt-metal/actions/runs/10421194186) - PASSED
- [Device perf regressions and output report](https://github.com/tenstorrent/tt-metal/actions/runs/10421195636) - PASSED
- [[post-commit] models tests ](https://github.com/tenstorrent/tt-metal/actions/runs/10421197108) - PASSED
- [Model perf regressions and output report](https://github.com/tenstorrent/tt-metal/actions/runs/10421202687) - PASSED
- [(T3K) T3000 model perf tests](https://github.com/tenstorrent/tt-metal/actions/runs/10421203980)
- [(T3K) T3000 unit tests](https://github.com/tenstorrent/tt-metal/actions/runs/10421205108)
- [(T3K) T3000 demo tests](https://github.com/tenstorrent/tt-metal/actions/runs/10421212987)
- [(T3K) T3000 frequent tests](https://github.com/tenstorrent/tt-metal/actions/runs/10421215248) - PASSED
- [Nightly fast dispatch tests](https://github.com/tenstorrent/tt-metal/actions/runs/10421214050) 
- [(Single-card) Demo tests](https://github.com/tenstorrent/tt-metal/actions/runs/10421219387)