### PR TITLE
#11554: Replace tt_lib in sweeps, integration_tests

### DIFF
--- a/tests/ttnn/integration_tests/stable_diffusion/test_basic_transformer_block.py
+++ b/tests/ttnn/integration_tests/stable_diffusion/test_basic_transformer_block.py
@@ -7,7 +7,6 @@ import pytest
 import torch
 from diffusers import StableDiffusionPipeline
 import ttnn
-import tt_lib as ttl
 
 from models.demos.wormhole.stable_diffusion.custom_preprocessing import custom_preprocessor
 from models.demos.wormhole.stable_diffusion.tt.ttnn_functional_basic_transformer_block import basic_transformer_block
@@ -104,8 +103,8 @@ def test_basic_transformer_block_512x512(device, model_name, N, C, H, W, index, 
         hidden_states,
         grid_size,
         [hidden_states.volume() // hidden_states.shape[-1] // grid_size[1], hidden_states.shape[-1] // grid_size[0]],
-        ttl.tensor.TensorMemoryLayout.BLOCK_SHARDED,
-        ttl.tensor.ShardOrientation.ROW_MAJOR,
+        ttnn.TensorMemoryLayout.BLOCK_SHARDED,
+        ttnn.ShardOrientation.ROW_MAJOR,
     )
     ttnn_output = model(
         hidden_states=hidden_states,

--- a/tests/ttnn/integration_tests/stable_diffusion/test_sharded_matmuls.py
+++ b/tests/ttnn/integration_tests/stable_diffusion/test_sharded_matmuls.py
@@ -7,7 +7,6 @@ import math
 import pytest
 import ttnn
 
-import tt_lib as ttl
 from tests.ttnn.utils_for_testing import assert_with_pcc
 from models.utility_functions import (
     skip_for_grayskull,
@@ -1618,20 +1617,14 @@ def test_matmul(
     if bias:
         in_2_torch = torch.randn(in_2_shape)
 
-    dram_interleaved_memory_config = ttl.tensor.MemoryConfig(
-        memory_layout=ttl.tensor.TensorMemoryLayout.INTERLEAVED,
-        buffer_type=ttl.tensor.BufferType.DRAM,
-    )
-    l1_interleaved_memory_config = ttl.tensor.MemoryConfig(
-        memory_layout=ttl.tensor.TensorMemoryLayout.INTERLEAVED,
-        buffer_type=ttl.tensor.BufferType.L1,
-    )
+    dram_interleaved_memory_config = ttnn.DRAM_MEMORY_CONFIG
+    l1_interleaved_memory_config = ttnn.L1_MEMORY_CONFIG
 
-    block_sharded_memory_config = ttl.tensor.MemoryConfig(
-        memory_layout=ttl.tensor.TensorMemoryLayout.BLOCK_SHARDED, buffer_type=ttl.tensor.BufferType.L1
+    block_sharded_memory_config = ttnn.MemoryConfig(
+        memory_layout=ttnn.TensorMemoryLayout.BLOCK_SHARDED, buffer_type=ttnn.BufferType.L1
     )
-    height_sharded_memory_config = ttl.tensor.MemoryConfig(
-        memory_layout=ttl.tensor.TensorMemoryLayout.HEIGHT_SHARDED, buffer_type=ttl.tensor.BufferType.L1
+    height_sharded_memory_config = ttnn.MemoryConfig(
+        memory_layout=ttnn.TensorMemoryLayout.HEIGHT_SHARDED, buffer_type=ttnn.BufferType.L1
     )
 
     # compare output to regular case
@@ -1659,8 +1652,8 @@ def test_matmul(
             tt_dtype=ttnn.experimental.tensor.DataType.BFLOAT8_B,
         )
 
-    compute_kernel_config = ttl.tensor.WormholeComputeKernelConfig(
-        math_fidelity=ttl.tensor.MathFidelity.LoFi,
+    compute_kernel_config = ttnn.WormholeComputeKernelConfig(
+        math_fidelity=ttnn.MathFidelity.LoFi,
         math_approx_mode=True,
         fp32_dest_acc_en=False,
         packer_l1_acc=False,

--- a/tests/ttnn/integration_tests/vit/test_performance_deviceOPs_ttnn_optim_sharded_vit.py
+++ b/tests/ttnn/integration_tests/vit/test_performance_deviceOPs_ttnn_optim_sharded_vit.py
@@ -14,7 +14,6 @@ from datasets import load_dataset
 from transformers import AutoImageProcessor
 
 import ttnn
-import tt_lib
 from models.experimental.functional_vit.tt import ttnn_optimized_sharded_vit
 from models.utility_functions import torch_random, skip_for_wormhole_b0, torch2tt_tensor
 from ttnn.model_preprocessing import preprocess_model_parameters
@@ -43,7 +42,7 @@ def get_expected_times(functional_vit):
 @pytest.mark.parametrize("image_channels", [3])
 @pytest.mark.parametrize("functional_vit", [ttnn_optimized_sharded_vit])
 def test_performance_vit_embeddings(device, model_name, batch_size, image_size, image_channels, functional_vit):
-    # tt_lib.device.EnableMemoryReports()
+    # ttnn.experimental.device.EnableMemoryReports()
 
     config = transformers.ViTConfig.from_pretrained(model_name)
     model = transformers.ViTForImageClassification.from_pretrained("google/vit-base-patch16-224")
@@ -83,27 +82,23 @@ def test_performance_vit_embeddings(device, model_name, batch_size, image_size, 
     patch_size = 16
     torch_pixel_values = torch_pixel_values.reshape(batch_size, img_h, img_w // patch_size, 4 * patch_size)
     N, H, W, C = torch_pixel_values.shape
-    shard_grid = tt_lib.tensor.CoreRangeSet(
+    shard_grid = ttnn.CoreRangeSet(
         {
-            tt_lib.tensor.CoreRange(
-                tt_lib.tensor.CoreCoord(0, 0),
-                tt_lib.tensor.CoreCoord(7, 0),
+            ttnn.CoreRange(
+                ttnn.CoreCoord(0, 0),
+                ttnn.CoreCoord(7, 0),
             ),
         }
     )
     n_cores = 8
-    shard_spec = tt_lib.tensor.ShardSpec(
-        shard_grid, [N * H * W // n_cores, C], tt_lib.tensor.ShardOrientation.ROW_MAJOR, False
-    )
+    shard_spec = ttnn.ShardSpec(shard_grid, [N * H * W // n_cores, C], ttnn.ShardOrientation.ROW_MAJOR, False)
 
     pixel_values = torch2tt_tensor(
         torch_pixel_values,
         device,
-        tt_lib.tensor.Layout.ROW_MAJOR,
-        tt_memory_config=tt_lib.tensor.MemoryConfig(
-            tt_lib.tensor.TensorMemoryLayout.HEIGHT_SHARDED, tt_lib.tensor.BufferType.L1, shard_spec
-        ),
-        tt_dtype=tt_lib.tensor.DataType.BFLOAT16,
+        ttnn.ROW_MAJOR_LAYOUT,
+        tt_memory_config=ttnn.MemoryConfig(ttnn.TensorMemoryLayout.HEIGHT_SHARDED, ttnn.BufferType.L1, shard_spec),
+        tt_dtype=ttnn.bfloat16,
     )
     # pixel_values = ttnn.from_torch(pixel_values, dtype=ttnn.bfloat16, layout=ttnn.ROW_MAJOR_LAYOUT, device=device)
 
@@ -279,27 +274,23 @@ def test_performance_vit_e2e(
         patch_size = 16
         torch_pixel_values = torch_pixel_values.reshape(batch_size, img_h, img_w // patch_size, 4 * patch_size)
         N, H, W, C = torch_pixel_values.shape
-        shard_grid = tt_lib.tensor.CoreRangeSet(
+        shard_grid = ttnn.CoreRangeSet(
             {
-                tt_lib.tensor.CoreRange(
-                    tt_lib.tensor.CoreCoord(0, 0),
-                    tt_lib.tensor.CoreCoord(7, 0),
+                ttnn.CoreRange(
+                    ttnn.CoreCoord(0, 0),
+                    ttnn.CoreCoord(7, 0),
                 ),
             }
         )
         n_cores = 8
-        shard_spec = tt_lib.tensor.ShardSpec(
-            shard_grid, [N * H * W // n_cores, C], tt_lib.tensor.ShardOrientation.ROW_MAJOR, False
-        )
+        shard_spec = ttnn.ShardSpec(shard_grid, [N * H * W // n_cores, C], ttnn.ShardOrientation.ROW_MAJOR, False)
 
         pixel_values = torch2tt_tensor(
             torch_pixel_values,
             device,
-            tt_lib.tensor.Layout.ROW_MAJOR,
-            tt_memory_config=tt_lib.tensor.MemoryConfig(
-                tt_lib.tensor.TensorMemoryLayout.HEIGHT_SHARDED, tt_lib.tensor.BufferType.L1, shard_spec
-            ),
-            tt_dtype=tt_lib.tensor.DataType.BFLOAT16,
+            ttnn.ROW_MAJOR_LAYOUT,
+            tt_memory_config=ttnn.MemoryConfig(ttnn.TensorMemoryLayout.HEIGHT_SHARDED, ttnn.BufferType.L1, shard_spec),
+            tt_dtype=ttnn.bfloat16,
         )
         # pixel_values = ttnn.from_torch(pixel_values, dtype=ttnn.bfloat16, layout=ttnn.ROW_MAJOR_LAYOUT, device=device)
 

--- a/tests/ttnn/integration_tests/vit/test_performance_ttnn_optim_interleaved_vit.py
+++ b/tests/ttnn/integration_tests/vit/test_performance_ttnn_optim_interleaved_vit.py
@@ -197,27 +197,23 @@ def test_performance_vit_e2e(
         patch_size = 16
         pixel_values = pixel_values.reshape(batch_size, img_h, img_w // patch_size, 4 * patch_size)
         N, H, W, C = pixel_values.shape
-        shard_grid = tt_lib.tensor.CoreRangeSet(
+        shard_grid = ttnn.CoreRangeSet(
             {
-                tt_lib.tensor.CoreRange(
-                    tt_lib.tensor.CoreCoord(0, 0),
-                    tt_lib.tensor.CoreCoord(7, 0),
+                ttnn.CoreRange(
+                    ttnn.CoreCoord(0, 0),
+                    ttnn.CoreCoord(7, 0),
                 ),
             }
         )
         n_cores = 8
-        shard_spec = tt_lib.tensor.ShardSpec(
-            shard_grid, [N * H * W // n_cores, C], tt_lib.tensor.ShardOrientation.ROW_MAJOR, False
-        )
+        shard_spec = ttnn.ShardSpec(shard_grid, [N * H * W // n_cores, C], ttnn.ShardOrientation.ROW_MAJOR, False)
 
         pixel_values = torch2tt_tensor(
             pixel_values,
             device,
-            tt_lib.tensor.Layout.ROW_MAJOR,
-            tt_memory_config=tt_lib.tensor.MemoryConfig(
-                tt_lib.tensor.TensorMemoryLayout.HEIGHT_SHARDED, tt_lib.tensor.BufferType.L1, shard_spec
-            ),
-            tt_dtype=tt_lib.tensor.DataType.BFLOAT16,
+            ttnn.ROW_MAJOR_LAYOUT,
+            tt_memory_config=ttnn.MemoryConfig(ttnn.TensorMemoryLayout.HEIGHT_SHARDED, ttnn.BufferType.L1, shard_spec),
+            tt_dtype=ttnn.bfloat16,
         )
         # pixel_values = ttnn.from_torch(pixel_values, dtype=ttnn.bfloat16, layout=ttnn.ROW_MAJOR_LAYOUT, device=device)
 

--- a/tests/ttnn/sweep_tests/sweeps/__init__.py
+++ b/tests/ttnn/sweep_tests/sweeps/__init__.py
@@ -112,9 +112,9 @@ def _run_single_test(run, skip, xfail, permutation, *, device):
             status = "crashed"
             message = f"Exception: {e}"
     finally:
-        import tt_lib as ttl
+        import ttnn
 
-        ttl.device.DeallocateBuffers(device)
+        ttnn.experimental.device.DeallocateBuffers(device)
     return status, message
 
 


### PR DESCRIPTION
Issue : #11554 , Tracking Issue : #11242 , Master Issue : #10532

- [All post-commit tests](https://github.com/tenstorrent/tt-metal/actions/runs/10421102144) - PASSED
- [[post-commit] C++ tests](https://github.com/tenstorrent/tt-metal/actions/runs/10421134654) - PASSED
- [Device perf regressions and output report](https://github.com/tenstorrent/tt-metal/actions/runs/10421136138) - PASSED
- [[post-commit] models tests](https://github.com/tenstorrent/tt-metal/actions/runs/10421137591) -PASSED
- [Model perf regressions and output report](https://github.com/tenstorrent/tt-metal/actions/runs/10421139015)
- [(T3K) T3000 model perf tests](https://github.com/tenstorrent/tt-metal/actions/runs/10421143596) -PASSED
- [(T3K) T3000 unit tests](https://github.com/tenstorrent/tt-metal/actions/runs/10421145873)
- [(T3K) T3000 demo tests](https://github.com/tenstorrent/tt-metal/actions/runs/10421148344)
- [Nightly fast dispatch tests](https://github.com/tenstorrent/tt-metal/actions/runs/10421152449)
- [(T3K) T3000 frequent tests](https://github.com/tenstorrent/tt-metal/actions/runs/10421157355) - PASSED
- [(Single-card) Demo tests](https://github.com/tenstorrent/tt-metal/actions/runs/10421160188) - PASSED