### PR TITLE
#11424: Replace tt_lib in models/experimental/efficientnet,falcon_40b

### DIFF
--- a/models/experimental/efficientnet/demo/demo_utils.py
+++ b/models/experimental/efficientnet/demo/demo_utils.py
@@ -15,7 +15,7 @@ ROOT = Path(os.path.relpath(ROOT, Path.cwd()))  # relative
 import ast
 import cv2
 import torch
-import tt_lib
+import ttnn
 import torchvision
 from loguru import logger
 from datasets import load_dataset
@@ -37,9 +37,7 @@ def preprocess():
             torchvision.transforms.Resize(256),
             torchvision.transforms.CenterCrop(224),
             torchvision.transforms.ToTensor(),
-            torchvision.transforms.Normalize(
-                mean=[0.485, 0.456, 0.406], std=[0.229, 0.224, 0.225]
-            ),
+            torchvision.transforms.Normalize(mean=[0.485, 0.456, 0.406], std=[0.229, 0.224, 0.225]),
         ]
     )
 
@@ -59,17 +57,15 @@ def load_imagenet_labels():
     with open(ROOT / "imagenet_class_labels.txt", "r") as file:
         class_labels = ast.literal_eval(file.read())
 
-        categories = [
-            class_labels[key] for key in sorted(class_labels.keys(), reverse=False)
-        ]
+        categories = [class_labels[key] for key in sorted(class_labels.keys(), reverse=False)]
 
     return categories
 
 
 def run_gs_demo(efficientnet_model_constructor):
-    device = tt_lib.device.CreateDevice(0)
+    device = ttnn.open_device(0)
 
-    tt_lib.device.SetDefaultDevice(device)
+    ttnn.experimental.device.SetDefaultDevice(device)
 
     img_path = ROOT / "input_image.jpg"
     download_images(img_path)
@@ -84,14 +80,12 @@ def run_gs_demo(efficientnet_model_constructor):
     input_batch = input_tensor.unsqueeze(0)
 
     with torch.no_grad():
-        input_batch = torch2tt_tensor(
-            input_batch, device, tt_layout=tt_lib.tensor.Layout.ROW_MAJOR
-        )
+        input_batch = torch2tt_tensor(input_batch, device, tt_layout=ttnn.ROW_MAJOR_LAYOUT)
         output = model(input_batch)
         output = tt2torch_tensor(output)
         output = output.squeeze(0).squeeze(0)
 
-    tt_lib.device.CloseDevice(device)
+    ttnn.close_device(device)
     probabilities = torch.nn.functional.softmax(output[0], dim=0)
 
     # Check the top 5 categories that are predicted.

--- a/models/experimental/efficientnet/tests/perf_efficientnet.py
+++ b/models/experimental/efficientnet/tests/perf_efficientnet.py
@@ -2,7 +2,7 @@
 
 # SPDX-License-Identifier: Apache-2.0
 
-import tt_lib
+import ttnn
 import torch
 from loguru import logger
 import torchvision
@@ -54,18 +54,18 @@ def test_perf_efficientnet_b0(
     test_input = make_input_tensor(imagenet_sample_input)
 
     hf_model = torchvision.models.efficientnet_b0()
-    tt_input = torch2tt_tensor(test_input, tt_device=device, tt_layout=tt_lib.tensor.Layout.ROW_MAJOR)
+    tt_input = torch2tt_tensor(test_input, tt_device=device, tt_layout=ttnn.ROW_MAJOR_LAYOUT)
     tt_model = efficientnet_b0(device)
 
     with torch.no_grad():
         profiler.start(cpu_key)
         hf_model(test_input)
-        tt_lib.device.Synchronize(device)
+        ttnn.synchronize_device(device)
         profiler.end(cpu_key)
 
         profiler.start(first_key)
         tt_output = tt_model(tt_input)
-        tt_lib.device.Synchronize(device)
+        ttnn.synchronize_device(device)
         profiler.end(first_key)
         del tt_output
 
@@ -73,7 +73,7 @@ def test_perf_efficientnet_b0(
 
         profiler.start(second_key)
         tt_output = tt_model(tt_input)
-        tt_lib.device.Synchronize(device)
+        ttnn.synchronize_device(device)
         profiler.end(second_key)
         del tt_output
 

--- a/models/experimental/efficientnet/tests/test_efficientnet_conv.py
+++ b/models/experimental/efficientnet/tests/test_efficientnet_conv.py
@@ -2,7 +2,7 @@
 
 # SPDX-License-Identifier: Apache-2.0
 
-import tt_lib
+import ttnn
 import torch
 from loguru import logger
 import torchvision
@@ -54,9 +54,7 @@ def run_efficientnet_conv2d(state_dict, base_address, reference_module, device):
         conv_on_device=False,
     )
 
-    test_input = torch2tt_tensor(
-        test_input, tt_device=device, tt_layout=tt_lib.tensor.Layout.ROW_MAJOR
-    )
+    test_input = torch2tt_tensor(test_input, tt_device=device, tt_layout=ttnn.ROW_MAJOR_LAYOUT)
     tt_out = tt_module(test_input)
     tt_out = tt2torch_tensor(tt_out)
 
@@ -136,9 +134,7 @@ def run_efficientnet_conv_norm_activation(
         is_lite=is_lite,
     )
 
-    test_input = torch2tt_tensor(
-        test_input, tt_device=device, tt_layout=tt_lib.tensor.Layout.ROW_MAJOR
-    )
+    test_input = torch2tt_tensor(test_input, tt_device=device, tt_layout=ttnn.ROW_MAJOR_LAYOUT)
     tt_out = tt_module(test_input)
     tt_out = tt2torch_tensor(tt_out)
 

--- a/models/experimental/efficientnet/tests/test_efficientnet_fused_mbconv.py
+++ b/models/experimental/efficientnet/tests/test_efficientnet_fused_mbconv.py
@@ -2,7 +2,7 @@
 
 # SPDX-License-Identifier: Apache-2.0
 
-import tt_lib
+import ttnn
 import torch
 from loguru import logger
 import torchvision
@@ -44,9 +44,7 @@ def test_efficientnet_fused_mbconv(device):
         stochastic_depth_prob=0.0,
     )
 
-    test_input = torch2tt_tensor(
-        test_input, tt_device=device, tt_layout=tt_lib.tensor.Layout.ROW_MAJOR
-    )
+    test_input = torch2tt_tensor(test_input, tt_device=device, tt_layout=ttnn.ROW_MAJOR_LAYOUT)
 
     tt_out = tt_module(test_input)
     tt_out = tt2torch_tensor(tt_out)

--- a/models/experimental/efficientnet/tests/test_efficientnet_mbconv.py
+++ b/models/experimental/efficientnet/tests/test_efficientnet_mbconv.py
@@ -2,7 +2,7 @@
 
 # SPDX-License-Identifier: Apache-2.0
 
-import tt_lib
+import ttnn
 import torch
 from loguru import logger
 import torchvision
@@ -19,9 +19,7 @@ from models.experimental.efficientnet.tt.efficientnet_mbconv import (
 from models.experimental.efficientnet.tt.efficientnet_model import reference_efficientnet_lite0
 
 
-def run_efficientnet_mbconv(
-    device, state_dict, base_address, reference_module, mb_conv_config, is_lite
-):
+def run_efficientnet_mbconv(device, state_dict, base_address, reference_module, mb_conv_config, is_lite):
     torch.manual_seed(0)
     test_input = torch.rand(1, mb_conv_config.input_channels, 64, 64)
     pt_out = reference_module(test_input)
@@ -35,9 +33,7 @@ def run_efficientnet_mbconv(
         is_lite=is_lite,
     )
 
-    test_input = torch2tt_tensor(
-        test_input, tt_device=device, tt_layout=tt_lib.tensor.Layout.ROW_MAJOR
-    )
+    test_input = torch2tt_tensor(test_input, tt_device=device, tt_layout=ttnn.ROW_MAJOR_LAYOUT)
 
     tt_out = tt_module(test_input)
     tt_out = tt2torch_tensor(tt_out)

--- a/models/experimental/efficientnet/tests/test_efficientnet_model.py
+++ b/models/experimental/efficientnet/tests/test_efficientnet_model.py
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import pytest
-import tt_lib
+import ttnn
 import torch
 from loguru import logger
 import torchvision
@@ -75,7 +75,7 @@ def run_efficientnet_model_test(
 
     tt_model = tt_model_class(device)
 
-    test_input = torch2tt_tensor(test_input, tt_device=device, tt_layout=tt_lib.tensor.Layout.ROW_MAJOR)
+    test_input = torch2tt_tensor(test_input, tt_device=device, tt_layout=ttnn.ROW_MAJOR_LAYOUT)
 
     with torch.no_grad():
         tt_model.eval()
@@ -185,7 +185,7 @@ def test_efficientnet_v2_s_model_synt(device, imagenet_sample_input):
 
 
 @pytest.mark.skip(reason="Not tested")
-def test_efficientnet_v2_m_model_synt(imagenet_sample_input):
+def test_efficientnet_v2_m_model_synt(device, imagenet_sample_input):
     run_efficientnet_model_test(
         device,
         torchvision.models.efficientnet_v2_m,

--- a/models/experimental/efficientnet/tests/test_efficientnet_squeeze_excitation.py
+++ b/models/experimental/efficientnet/tests/test_efficientnet_squeeze_excitation.py
@@ -2,7 +2,7 @@
 
 # SPDX-License-Identifier: Apache-2.0
 
-import tt_lib
+import ttnn
 import torch
 from loguru import logger
 import torchvision
@@ -43,9 +43,7 @@ def test_efficientnet_squeeze_excitation_b0(device):
         squeeze_channels=squeeze_channels,
     )
 
-    test_input = torch2tt_tensor(
-        test_input, tt_device=device, tt_layout=tt_lib.tensor.Layout.ROW_MAJOR
-    )
+    test_input = torch2tt_tensor(test_input, tt_device=device, tt_layout=ttnn.ROW_MAJOR_LAYOUT)
     tt_out = tt_module(test_input)
     tt_out = tt2torch_tensor(tt_out)
 
@@ -87,9 +85,7 @@ def test_efficientnet_squeeze_excitation_v2_s(device):
         squeeze_channels=squeeze_channels,
     )
 
-    test_input = torch2tt_tensor(
-        test_input, tt_device=device, tt_layout=tt_lib.tensor.Layout.ROW_MAJOR
-    )
+    test_input = torch2tt_tensor(test_input, tt_device=device, tt_layout=ttnn.ROW_MAJOR_LAYOUT)
     tt_out = tt_module(test_input)
     tt_out = tt2torch_tensor(tt_out)
 

--- a/models/experimental/efficientnet/tt/efficientnet_conv.py
+++ b/models/experimental/efficientnet/tt/efficientnet_conv.py
@@ -3,7 +3,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import torch
-import tt_lib
 import ttnn
 
 from loguru import logger
@@ -185,10 +184,10 @@ class TtEfficientnetConv2dNormActivation(torch.nn.Module):
         running_mean = state_dict[f"{bn_base_address}.running_mean"]
         running_var = state_dict[f"{bn_base_address}.running_var"]
 
-        bnorm_weights = torch2tt_tensor(bnorm_weights, device, tt_layout=tt_lib.tensor.Layout.ROW_MAJOR)
-        bnrom_bias = torch2tt_tensor(bnrom_bias, device, tt_layout=tt_lib.tensor.Layout.ROW_MAJOR)
-        running_mean = torch2tt_tensor(running_mean, device, tt_layout=tt_lib.tensor.Layout.ROW_MAJOR)
-        running_var = torch2tt_tensor(running_var, device, tt_layout=tt_lib.tensor.Layout.ROW_MAJOR)
+        bnorm_weights = torch2tt_tensor(bnorm_weights, device, tt_layout=ttnn.ROW_MAJOR_LAYOUT)
+        bnrom_bias = torch2tt_tensor(bnrom_bias, device, tt_layout=ttnn.ROW_MAJOR_LAYOUT)
+        running_mean = torch2tt_tensor(running_mean, device, tt_layout=ttnn.ROW_MAJOR_LAYOUT)
+        running_var = torch2tt_tensor(running_var, device, tt_layout=ttnn.ROW_MAJOR_LAYOUT)
 
         self.bnorm = fallback_ops.BatchNorm2d(
             weights=bnorm_weights,

--- a/models/experimental/efficientnet/tt/efficientnet_mbconv.py
+++ b/models/experimental/efficientnet/tt/efficientnet_mbconv.py
@@ -4,7 +4,6 @@
 
 import torch
 import ttnn
-import tt_lib
 import math
 
 from dataclasses import dataclass

--- a/models/experimental/efficientnet/tt/efficientnet_model.py
+++ b/models/experimental/efficientnet/tt/efficientnet_model.py
@@ -4,7 +4,6 @@
 
 import torch
 import ttnn
-import tt_lib
 
 import copy
 from typing import List, Sequence, Union, Tuple, Optional, Any
@@ -151,7 +150,7 @@ class TtEfficientNet(torch.nn.Module):
         self.classifier_weight = torch2tt_tensor(
             state_dict["fc.weight" if is_lite else "classifier.1.weight"],
             device,
-            tt_layout=tt_lib.tensor.Layout.ROW_MAJOR,
+            tt_layout=ttnn.ROW_MAJOR_LAYOUT,
         )
 
         bias_key = "fc.bias" if is_lite else "classifier.1.bias"
@@ -160,7 +159,7 @@ class TtEfficientNet(torch.nn.Module):
             self.classifier_bias = torch2tt_tensor(
                 state_dict[bias_key],
                 device,
-                tt_layout=tt_lib.tensor.Layout.ROW_MAJOR,
+                tt_layout=ttnn.ROW_MAJOR_LAYOUT,
             )
         else:
             self.classifier_bias = None
@@ -173,7 +172,7 @@ class TtEfficientNet(torch.nn.Module):
 
         last_shape = x.get_legacy_shape()[-1] * x.get_legacy_shape()[-2] * x.get_legacy_shape()[-3]
         # ttnn.reshape_on_device won't work here since input tensor is of shape [1, n, 1, 1]
-        x = tt_lib.fallback_ops.reshape(x, x.get_legacy_shape()[0], 1, 1, last_shape)
+        x = fallback_ops.reshape(x, x.get_legacy_shape()[0], 1, 1, last_shape)
 
         x = ttnn.matmul(x, self.classifier_weight)
 

--- a/models/experimental/efficientnet/tt/efficientnet_squeeze_excitation.py
+++ b/models/experimental/efficientnet/tt/efficientnet_squeeze_excitation.py
@@ -3,7 +3,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import torch
-import tt_lib
 import ttnn
 
 from tt_lib.fallback_ops import fallback_ops

--- a/models/experimental/falcon_40b/tests/test_reproduce_nd_matmul.py
+++ b/models/experimental/falcon_40b/tests/test_reproduce_nd_matmul.py
@@ -5,7 +5,6 @@
 from loguru import logger
 import pytest
 
-import tt_lib as ttl
 import ttnn
 from models.utility_functions import comp_pcc, tt2torch_tensor, torch2tt_tensor
 import torch
@@ -36,13 +35,13 @@ def test_reproduce_matmul_1d(
 ):
     torch.manual_seed(1234)
 
-    in0_mem_config = ttl.tensor.MemoryConfig(ttl.tensor.TensorMemoryLayout.INTERLEAVED, ttl.tensor.BufferType.DRAM)
-    in1_mem_config = ttl.tensor.MemoryConfig(ttl.tensor.TensorMemoryLayout.INTERLEAVED, ttl.tensor.BufferType.DRAM)
-    out_mem_config = ttl.tensor.MemoryConfig(ttl.tensor.TensorMemoryLayout.INTERLEAVED, ttl.tensor.BufferType.DRAM)
+    in0_mem_config = ttnn.DRAM_MEMORY_CONFIG
+    in1_mem_config = ttnn.DRAM_MEMORY_CONFIG
+    out_mem_config = ttnn.DRAM_MEMORY_CONFIG
 
-    in0_dtype = ttl.tensor.DataType.BFLOAT8_B
-    in1_dtype = ttl.tensor.DataType.BFLOAT8_B
-    out_dtype = ttl.tensor.DataType.BFLOAT8_B
+    in0_dtype = ttnn.bfloat8_b
+    in1_dtype = ttnn.bfloat8_b
+    out_dtype = ttnn.bfloat8_b
 
     a_shape = [1, 1, seq_len, inner_dim]
     b_shape = [1, 1, inner_dim, weights_n]
@@ -50,8 +49,8 @@ def test_reproduce_matmul_1d(
     A = torch.randn(a_shape)
     B = torch.randn(b_shape)
 
-    a_t = torch2tt_tensor(A, device, ttl.tensor.Layout.TILE, in0_mem_config, in0_dtype)
-    b_t = torch2tt_tensor(B, device, ttl.tensor.Layout.TILE, in1_mem_config, in1_dtype)
+    a_t = torch2tt_tensor(A, device, ttnn.TILE_LAYOUT, in0_mem_config, in0_dtype)
+    b_t = torch2tt_tensor(B, device, ttnn.TILE_LAYOUT, in1_mem_config, in1_dtype)
 
     program_config = ttnn.MatmulMultiCoreReuseMultiCast1DProgramConfig(
         compute_with_storage_grid_size=(8, 8),
@@ -65,8 +64,8 @@ def test_reproduce_matmul_1d(
         mcast_in0=True,
     )
 
-    compute_config = ttl.tensor.WormholeComputeKernelConfig(
-        math_fidelity=ttl.tensor.MathFidelity.LoFi,
+    compute_config = ttnn.WormholeComputeKernelConfig(
+        math_fidelity=ttnn.MathFidelity.LoFi,
         math_approx_mode=True,
         fp32_dest_acc_en=True,
         packer_l1_acc=False,  # fails with l1 acc turned on as well, just needs more iterations
@@ -138,13 +137,13 @@ def test_reproduce_matmul_2d(
 ):
     torch.manual_seed(1234)
 
-    in0_mem_config = ttl.tensor.MemoryConfig(ttl.tensor.TensorMemoryLayout.INTERLEAVED, ttl.tensor.BufferType.DRAM)
-    in1_mem_config = ttl.tensor.MemoryConfig(ttl.tensor.TensorMemoryLayout.INTERLEAVED, ttl.tensor.BufferType.DRAM)
-    out_mem_config = ttl.tensor.MemoryConfig(ttl.tensor.TensorMemoryLayout.INTERLEAVED, ttl.tensor.BufferType.DRAM)
+    in0_mem_config = ttnn.DRAM_MEMORY_CONFIG
+    in1_mem_config = ttnn.DRAM_MEMORY_CONFIG
+    out_mem_config = ttnn.DRAM_MEMORY_CONFIG
 
-    in0_dtype = ttl.tensor.DataType.BFLOAT8_B
-    in1_dtype = ttl.tensor.DataType.BFLOAT8_B
-    out_dtype = ttl.tensor.DataType.BFLOAT8_B
+    in0_dtype = ttnn.bfloat8_b
+    in1_dtype = ttnn.bfloat8_b
+    out_dtype = ttnn.bfloat8_b
 
     a_shape = [1, 1, seq_len, inner_dim]
     b_shape = [1, 1, inner_dim, weights_n]
@@ -152,8 +151,8 @@ def test_reproduce_matmul_2d(
     A = torch.randn(a_shape)
     B = torch.randn(b_shape)
 
-    a_t = torch2tt_tensor(A, device, ttl.tensor.Layout.TILE, in0_mem_config, in0_dtype)
-    b_t = torch2tt_tensor(B, device, ttl.tensor.Layout.TILE, in1_mem_config, in1_dtype)
+    a_t = torch2tt_tensor(A, device, ttnn.TILE_LAYOUT, in0_mem_config, in0_dtype)
+    b_t = torch2tt_tensor(B, device, ttnn.TILE_LAYOUT, in1_mem_config, in1_dtype)
 
     program_config = ttnn.MatmulMultiCoreReuseMultiCastProgramConfig(
         compute_with_storage_grid_size=(8, 8),
@@ -166,8 +165,8 @@ def test_reproduce_matmul_2d(
         fused_activation=None,
     )
 
-    compute_config = ttl.tensor.WormholeComputeKernelConfig(
-        math_fidelity=ttl.tensor.MathFidelity.LoFi,
+    compute_config = ttnn.WormholeComputeKernelConfig(
+        math_fidelity=ttnn.MathFidelity.LoFi,
         math_approx_mode=True,
         fp32_dest_acc_en=True,
         packer_l1_acc=True,


### PR DESCRIPTION
### Ticket
Link to Github Issue #11424
Master Issue #11240

### Problem description
Replace tt_lib with ttnn in models/experimental/efficientnet, falcon_40b

### Checklist
- [x] [Post commit CI passes](https://github.com/tenstorrent/tt-metal/actions/runs/10422756832)
- [x] Model regression CI testing passes (if applicable)
- [x] New/Existing tests provide coverage for changes