### PR TITLE
Add more general sharding support for Pad and Transpose HC

### DIFF
--- a/tests/tt_eager/python_api_testing/unit_testing/misc/test_transpose.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/misc/test_transpose.py
@@ -584,6 +584,8 @@ def run_tranpose_hc_sharded(device, n, c, h, w, grid_size):
         (2, 8, 4, 32, ttnn.CoreGrid(y=8, x=4)),
         (2, 2, 8, 64, ttnn.CoreGrid(y=8, x=1)),
         (16, 4, 224, 224, ttnn.CoreGrid(y=8, x=8)),
+        (20, 4, 224, 224, ttnn.CoreGrid(y=8, x=7)),
+        (24, 3, 224, 224, ttnn.CoreGrid(y=8, x=7)),
     ],
 )
 def test_tranpose_hc_sharded_with_program_cache(device, n, c, h, w, grid_size, use_program_cache):

--- a/tests/tt_eager/python_api_testing/unit_testing/misc/test_transpose.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/misc/test_transpose.py
@@ -527,10 +527,10 @@ def run_tranpose_hc_rm_with_program_cache(device, n, c, h, w, use_program_cache)
     assert_with_pcc(torch_output_tensor, activation_pyt_padded_out, 0.9999)
 
 
-@pytest.mark.parametrize("n", [16])
-@pytest.mark.parametrize("c", [4])
+@pytest.mark.parametrize("n", [20])
+@pytest.mark.parametrize("c", [128])
 @pytest.mark.parametrize("h", [256])
-@pytest.mark.parametrize("w", [256])
+@pytest.mark.parametrize("w", [16])
 def test_tranpose_hc_rm_with_program_cache(device, n, c, h, w, use_program_cache):
     for _ in range(2):
         run_tranpose_hc_rm_with_program_cache(device, n, c, h, w, use_program_cache)
@@ -586,7 +586,6 @@ def run_tranpose_hc_sharded(device, n, c, h, w, grid_size):
         (16, 4, 224, 224, ttnn.CoreGrid(y=8, x=8)),
         (20, 4, 224, 224, ttnn.CoreGrid(y=8, x=7)),
         (24, 3, 224, 224, ttnn.CoreGrid(y=8, x=7)),
-        (16, 128, 256, 16, ttnn.CoreGrid(y=8, x=8)),
     ],
 )
 def test_tranpose_hc_sharded_with_program_cache(device, n, c, h, w, grid_size, use_program_cache):

--- a/tests/tt_eager/python_api_testing/unit_testing/misc/test_transpose.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/misc/test_transpose.py
@@ -469,8 +469,8 @@ def run_tranpose_hw_sharded_rm_with_program_cache(device, n, c, h, w):
 
 
 @pytest.mark.parametrize("n", [16])
-@pytest.mark.parametrize("c", [2])
-@pytest.mark.parametrize("h", [16])
+@pytest.mark.parametrize("c", [128])
+@pytest.mark.parametrize("h", [128])
 @pytest.mark.parametrize("w", [16])
 def test_tranpose_hw_sharded_rm_with_program_cache(device, n, c, h, w, use_program_cache):
     for _ in range(2):
@@ -586,6 +586,7 @@ def run_tranpose_hc_sharded(device, n, c, h, w, grid_size):
         (16, 4, 224, 224, ttnn.CoreGrid(y=8, x=8)),
         (20, 4, 224, 224, ttnn.CoreGrid(y=8, x=7)),
         (24, 3, 224, 224, ttnn.CoreGrid(y=8, x=7)),
+        (16, 128, 256, 16, ttnn.CoreGrid(y=8, x=8)),
     ],
 )
 def test_tranpose_hc_sharded_with_program_cache(device, n, c, h, w, grid_size, use_program_cache):

--- a/tests/ttnn/unit_tests/operations/test_pad.py
+++ b/tests/ttnn/unit_tests/operations/test_pad.py
@@ -68,7 +68,7 @@ def test_pad_rm_with_program_cache(device, n, c, h, w, padding, torch_padding, v
     assert device.num_program_cache_entries() == 1
 
 
-def run_pad_rm_sharded(device, n, c, h, w, padding, torch_padding, value):
+def run_pad_rm_sharded(device, n, c, h, w, padding, torch_padding, value, shard_orient):
     torch.manual_seed(0)
 
     torch_input_tensor = torch.rand((n, c, h, w), dtype=torch.bfloat16)
@@ -82,17 +82,20 @@ def run_pad_rm_sharded(device, n, c, h, w, padding, torch_padding, value):
         memory_config=ttnn.L1_MEMORY_CONFIG,
     )
 
-    H_pad = padding[1][1]
-    W_pad = padding[2][1]
+    n_unpadded = n
+    c_unpadded = c + padding[0][1]
+    h_unpadded = h + padding[1][1]
 
     # shard config
-    num_cores_x = 6
+    num_cores_x = 8
     num_cores_y = 8
+    if num_cores_y > device.core_grid.y:
+        num_cores_y = device.core_grid.y
+    shard_h = (n * c * h + (num_cores_x * num_cores_y) - 1) // (num_cores_x * num_cores_y)
     grid_size = ttnn.CoreGrid(y=num_cores_y, x=num_cores_x)
-
     grid_coord = ttnn.CoreCoord(grid_size.x - 1, grid_size.y - 1)
     shard_grid = ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), grid_coord)})
-    shard_spec = ttnn.ShardSpec(shard_grid, (h, w), ttnn.ShardOrientation.ROW_MAJOR, False)
+    shard_spec = ttnn.ShardSpec(shard_grid, (shard_h, w), shard_orient, False)
     sharded_mem_config = ttnn.MemoryConfig(
         ttnn.types.TensorMemoryLayout.HEIGHT_SHARDED, ttnn.types.BufferType.L1, shard_spec
     )
@@ -101,11 +104,13 @@ def run_pad_rm_sharded(device, n, c, h, w, padding, torch_padding, value):
     # output shard config
     num_cores_x = 8
     num_cores_y = 8
+    if num_cores_y > device.core_grid.y:
+        num_cores_y = device.core_grid.y
+    shard_h = (n_unpadded * c_unpadded * h_unpadded + (num_cores_x * num_cores_y) - 1) // (num_cores_x * num_cores_y)
     grid_size = ttnn.CoreGrid(y=num_cores_y, x=num_cores_x)
-
     grid_coord = ttnn.CoreCoord(grid_size.x - 1, grid_size.y - 1)
     shard_grid = ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), grid_coord)})
-    shard_spec = ttnn.ShardSpec(shard_grid, (h + H_pad, w + W_pad), ttnn.ShardOrientation.ROW_MAJOR, False)
+    shard_spec = ttnn.ShardSpec(shard_grid, (shard_h, w), shard_orient, False)
     output_mem_config = ttnn.MemoryConfig(
         ttnn.types.TensorMemoryLayout.HEIGHT_SHARDED, ttnn.types.BufferType.L1, shard_spec
     )
@@ -117,20 +122,21 @@ def run_pad_rm_sharded(device, n, c, h, w, padding, torch_padding, value):
     tt_output_tensor = ttnn.to_torch(tt_output_tensor)
 
     assert tt_output_tensor.shape == torch_output_tensor.shape
-    assert_with_pcc(torch_output_tensor[0][0][1], tt_output_tensor[0][0][1], 0.9999)
+    assert_with_pcc(torch_output_tensor, tt_output_tensor, 0.9999)
 
 
-@pytest.mark.parametrize("n", [16])
-@pytest.mark.parametrize("c", [4])
-@pytest.mark.parametrize("h", [32])
-@pytest.mark.parametrize("w", [32])
-@pytest.mark.parametrize("padding,torch_padding", [(((0, 1), (0, 16), (0, 16)), (0, 16, 0, 16, 0, 1))])
-@pytest.mark.parametrize("value", [0])
-def test_pad_rm_sharded(device, n, c, h, w, padding, torch_padding, value, use_program_cache):
+@pytest.mark.parametrize("n", [20])
+@pytest.mark.parametrize("c", [3])
+@pytest.mark.parametrize("h", [224])
+@pytest.mark.parametrize("w", [256])
+@pytest.mark.parametrize("padding,torch_padding", [(((0, 1), (0, 32), (0, 0)), (0, 0, 0, 32, 0, 1))])
+@pytest.mark.parametrize("value", [8])
+@pytest.mark.parametrize("shard_orient", [ttnn.ShardOrientation.COL_MAJOR, ttnn.ShardOrientation.ROW_MAJOR])
+def test_pad_rm_sharded(device, n, c, h, w, padding, torch_padding, value, shard_orient, use_program_cache):
     if device.core_grid.y < 8:
         pytest.skip("n300 does not have 8x8 grid")
     for _ in range(2):
-        run_pad_rm_sharded(device, n, c, h, w, padding, torch_padding, value)
+        run_pad_rm_sharded(device, n, c, h, w, padding, torch_padding, value, shard_orient)
         # dummy tensor to change tensor alloc
         dummy_shape = [1, 1, 32, 32]
         py_dummy_tensor = torch.randn(dummy_shape)

--- a/ttnn/cpp/ttnn/operations/data_movement/pad/device/kernels/dataflow/reader_pad_dims_rm_sharded.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/pad/device/kernels/dataflow/reader_pad_dims_rm_sharded.cpp
@@ -7,127 +7,55 @@
 
 
 
-inline __attribute__((always_inline))
-void fill_pad_cb_with_val(const uint32_t cb_id, const uint32_t num_bytes, const uint32_t val) {
-
-    volatile tt_l1_ptr uint32_t* ptr = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(get_write_ptr(cb_id));
-
-    for (uint32_t i = 0; i < num_bytes / 2; ++i) {
-        ptr[i] = val;
-    }
-}
 
 void kernel_main() {
 
-    uint32_t read_pad_only = get_arg_val<uint32_t>(0);
-    uint32_t read_noc_x = get_arg_val<uint32_t>(1);
-    uint32_t read_noc_y  = get_arg_val<uint32_t>(2);
+    constexpr uint32_t stick_size_bytes         = get_compile_time_arg_val(0);
+    constexpr uint32_t num_sticks_padded        = get_compile_time_arg_val(1);
 
-    constexpr uint32_t H = get_compile_time_arg_val(0);
-    constexpr uint32_t W_size_bytes = get_compile_time_arg_val(1);
-    constexpr uint32_t H_padded = get_compile_time_arg_val(2);
-    constexpr uint32_t W_padded_size_bytes = get_compile_time_arg_val(3);
-    constexpr uint32_t rem_W_padded_size_bytes = get_compile_time_arg_val(4);
-
-    #define not_pad_by_zero get_compile_time_arg_val(5) == 1
-    constexpr uint32_t packed_pad_value = get_compile_time_arg_val(6);
-    constexpr uint32_t row_major_min_bytes = get_compile_time_arg_val(7);
-    constexpr uint32_t num_rem_sticks_read = get_compile_time_arg_val(8);
-    constexpr uint32_t num_sticks_padded_read = get_compile_time_arg_val(9);
-
-    constexpr bool HW_has_no_padding = (W_size_bytes == W_padded_size_bytes && H == H_padded);
-
-
+    const uint32_t num_cores_read                 = get_arg_val<uint32_t>(0);
+    tt_l1_ptr uint32_t * read_noc_x               = (tt_l1_ptr uint32_t*)(get_arg_addr(1));
+    tt_l1_ptr uint32_t * read_noc_y               = (tt_l1_ptr uint32_t*)(get_arg_addr(2));
+    tt_l1_ptr uint32_t * num_stick_chunks         = (tt_l1_ptr uint32_t*)(get_arg_addr(1 + num_cores_read * 2));
+    tt_l1_ptr uint32_t * chunk_start_id           = (tt_l1_ptr uint32_t*)(get_arg_addr(1 + num_cores_read * 3));
+    tt_l1_ptr uint32_t * chunk_num_sticks         = (tt_l1_ptr uint32_t*)(chunk_start_id + 1);
 
     constexpr auto cb_in0 = tt::CB::c_in0;
-    constexpr auto cb_pad = tt::CB::c_in1;
     constexpr auto cb_out0 = tt::CB::c_out0;
 
-    const uint32_t stick_size_bytes = W_size_bytes;
-    const uint32_t rem_stick_size_bytes = rem_W_padded_size_bytes;
-
-
-    uint64_t zeros_noc_addr = get_noc_addr(MEM_ZEROS_BASE);
-
-    uint64_t pad_val_addr = get_read_ptr(cb_pad);
-    uint64_t pad_val_noc_addr = get_noc_addr(pad_val_addr);
-
-    #if (not_pad_by_zero)
-        fill_pad_cb_with_val(cb_pad, row_major_min_bytes, packed_pad_value);
-    #endif
-
+    cb_reserve_back(cb_out0, num_sticks_padded);
     uint32_t l1_read_addr = get_write_ptr(cb_in0);
-    uint64_t read_noc_addr = get_noc_addr(read_noc_x, read_noc_y, l1_read_addr);
     uint32_t l1_write_addr = get_write_ptr(cb_out0);
 
-    cb_reserve_back(cb_out0, H_padded);
+    uint32_t chunk_ptr_offset = 0;
+    uint32_t read_noc_xy_ptr_offset = 0;
 
-    if (read_pad_only) {
-        #if (not_pad_by_zero)
-        noc_async_read_one_packet_set_state(pad_val_noc_addr, row_major_min_bytes);
-        #else
-        noc_async_read_one_packet_set_state(zeros_noc_addr, W_padded_size_bytes);
-        #endif
 
-        for (uint32_t iter = 0; iter < H_padded; ++iter) {
-            #if (not_pad_by_zero)
-            if constexpr(rem_W_padded_size_bytes != 0) {
-                for (uint32_t j = 0; j < num_sticks_padded_read; ++j) {
-                    noc_async_read_one_packet_with_state(pad_val_noc_addr, l1_write_addr);
-                    l1_write_addr += row_major_min_bytes;
-                }
+    for (uint32_t curr_core = 0; curr_core < num_cores_read; ++curr_core) {
+
+        uint64_t src_noc_addr = get_noc_addr(read_noc_x[read_noc_xy_ptr_offset], read_noc_y[read_noc_xy_ptr_offset], l1_read_addr);
+
+        uint32_t curr_core_num_chunks = num_stick_chunks[curr_core];
+
+        for (uint32_t curr_chunk = 0; curr_chunk < curr_core_num_chunks; ++curr_chunk) {
+
+            uint32_t curr_start_id = chunk_start_id[chunk_ptr_offset];
+            uint32_t curr_num_sticks = chunk_num_sticks[chunk_ptr_offset];
+
+            uint32_t l1_read_offset = curr_start_id * stick_size_bytes;
+            uint32_t read_data_size_bytes = curr_num_sticks * stick_size_bytes;
+
+            if (curr_start_id != (uint32_t)-1) {
+                noc_async_read(src_noc_addr + l1_read_offset, l1_write_addr, read_data_size_bytes);
             }
-            #else
-                noc_async_read_one_packet_with_state(zeros_noc_addr, l1_write_addr);
-                l1_write_addr += W_padded_size_bytes;
-            #endif
-        }
-    } else {
 
-        if constexpr(HW_has_no_padding) {
-            noc_async_read_one_packet_set_state(read_noc_addr, stick_size_bytes);
+            l1_write_addr += read_data_size_bytes;
+            chunk_ptr_offset += 2;
         }
 
-        for (uint32_t iter = 0; iter < H; ++iter) {
-            if constexpr(HW_has_no_padding) {
-                noc_async_read_one_packet_with_state(read_noc_addr, l1_write_addr);
-            } else {
-                noc_async_read(read_noc_addr, l1_write_addr, stick_size_bytes);
-            }
-            read_noc_addr += stick_size_bytes;
-            l1_write_addr += stick_size_bytes;
-
-            #if (not_pad_by_zero)
-            if constexpr(rem_W_padded_size_bytes != 0) {
-                for (uint32_t j = 0; j < num_rem_sticks_read; ++j) {
-                    noc_async_read(pad_val_noc_addr, l1_write_addr, row_major_min_bytes);
-                    l1_write_addr += row_major_min_bytes;
-                }
-            }
-            #else
-            if constexpr(rem_W_padded_size_bytes != 0) {
-                noc_async_read(zeros_noc_addr, l1_write_addr, rem_stick_size_bytes);
-                l1_write_addr += rem_stick_size_bytes;
-            }
-            #endif
-        }
-
-        for (uint32_t iter = 0; iter < H_padded - H; ++iter) {
-            #if (not_pad_by_zero)
-            if constexpr(rem_W_padded_size_bytes != 0) {
-                for (uint32_t j = 0; j < num_sticks_padded_read; ++j) {
-                    noc_async_read(pad_val_noc_addr, l1_write_addr, row_major_min_bytes);
-                    l1_write_addr += row_major_min_bytes;
-                }
-            }
-            #else
-                noc_async_read(zeros_noc_addr, l1_write_addr, W_padded_size_bytes);
-                l1_write_addr += W_padded_size_bytes;
-            #endif
-        }
+        read_noc_xy_ptr_offset += 2;
     }
 
     noc_async_read_barrier();
-    cb_push_back(cb_out0, H_padded);
-
+    cb_push_back(cb_out0, num_sticks_padded);
 }

--- a/ttnn/cpp/ttnn/operations/data_movement/pad/device/kernels/dataflow/writer_pad_dims_rm_sharded.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/pad/device/kernels/dataflow/writer_pad_dims_rm_sharded.cpp
@@ -8,128 +8,92 @@
 
 
 inline __attribute__((always_inline))
-void fill_pad_cb_with_val(const uint32_t cb_id, const uint32_t num_bytes, const uint32_t val) {
+void fill_pad_cb_with_val(const uint32_t cb_id, const uint32_t num_bytes_risc, uint32_t num_noc_transfer, const uint32_t val) {
 
     volatile tt_l1_ptr uint32_t* ptr = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(get_write_ptr(cb_id));
 
-    for (uint32_t i = 0; i < num_bytes / 2; ++i) {
+    for (uint32_t i = 0; i < num_bytes_risc / 2; ++i) {
         ptr[i] = val;
     }
+
+    uint32_t pad_val_addr = get_read_ptr(cb_id);
+    uint64_t pad_val_noc_addr = get_noc_addr(pad_val_addr);
+    uint32_t l1_write_addr = pad_val_addr + num_bytes_risc;
+
+    for (uint32_t i = 0; i < num_noc_transfer; ++i) {
+        noc_async_read(pad_val_noc_addr, l1_write_addr, num_bytes_risc);
+        l1_write_addr += num_bytes_risc;
+    }
+    noc_async_read_barrier();
 }
 
 void kernel_main() {
 
-    uint32_t read_pad_only = get_arg_val<uint32_t>(0);
-    uint32_t read_noc_x = get_arg_val<uint32_t>(1);
-    uint32_t read_noc_y  = get_arg_val<uint32_t>(2);
+    uint32_t num_sticks_per_core = get_arg_val<uint32_t>(0);
+    uint32_t start_id  = get_arg_val<uint32_t>(1);
+    tt_l1_ptr uint32_t * start_dim_offset = (tt_l1_ptr uint32_t*)(get_arg_addr(2));
 
-    constexpr uint32_t H = get_compile_time_arg_val(0);
-    constexpr uint32_t W_size_bytes = get_compile_time_arg_val(1);
-    constexpr uint32_t H_padded = get_compile_time_arg_val(2);
-    constexpr uint32_t W_padded_size_bytes = get_compile_time_arg_val(3);
-    constexpr uint32_t rem_W_padded_size_bytes = get_compile_time_arg_val(4);
+    constexpr uint32_t N = get_compile_time_arg_val(0);
+    constexpr uint32_t H = get_compile_time_arg_val(1);
+    constexpr uint32_t C = get_compile_time_arg_val(2);
+    constexpr uint32_t stick_size_bytes = get_compile_time_arg_val(3);
+    constexpr uint32_t N_padded = get_compile_time_arg_val(4);
+    constexpr uint32_t H_padded = get_compile_time_arg_val(5);
+    constexpr uint32_t C_padded = get_compile_time_arg_val(6);
 
-    #define not_pad_by_zero get_compile_time_arg_val(5) == 1
-    constexpr uint32_t packed_pad_value = get_compile_time_arg_val(6);
-    constexpr uint32_t row_major_min_bytes = get_compile_time_arg_val(7);
-    constexpr uint32_t num_rem_sticks_read = get_compile_time_arg_val(8);
-    constexpr uint32_t num_sticks_padded_read = get_compile_time_arg_val(9);
-    constexpr uint32_t read_addr_offset = get_compile_time_arg_val(10);
-    constexpr uint32_t write_addr_offset = get_compile_time_arg_val(11);
+    #define not_pad_by_zero get_compile_time_arg_val(7) == 1
+    #if (not_pad_by_zero)
+    constexpr uint32_t packed_pad_value = get_compile_time_arg_val(8);
+    constexpr uint32_t row_major_min_bytes = get_compile_time_arg_val(9);
+    constexpr uint32_t num_sticks_padded_read = get_compile_time_arg_val(10);
+    #endif
 
-    if constexpr(H_padded == 0) return;
 
-    constexpr bool HW_has_no_padding = (W_size_bytes == W_padded_size_bytes && H == H_padded);
-
-    constexpr auto cb_in0 = tt::CB::c_in0;
-    constexpr auto cb_pad = tt::CB::c_in2;
+    constexpr auto cb_pad = tt::CB::c_in1;
     constexpr auto cb_out0 = tt::CB::c_out0;
-
-    const uint32_t stick_size_bytes = W_size_bytes;
-    const uint32_t rem_stick_size_bytes = rem_W_padded_size_bytes;
-
 
     uint64_t zeros_noc_addr = get_noc_addr(MEM_ZEROS_BASE);
 
-    uint64_t pad_val_addr = get_read_ptr(cb_pad);
+    uint32_t pad_val_addr = get_read_ptr(cb_pad);
     uint64_t pad_val_noc_addr = get_noc_addr(pad_val_addr);
 
     #if (not_pad_by_zero)
-        fill_pad_cb_with_val(cb_pad, row_major_min_bytes, packed_pad_value);
+        fill_pad_cb_with_val(cb_pad, row_major_min_bytes, num_sticks_padded_read, packed_pad_value);
     #endif
 
-    uint32_t l1_read_addr = get_write_ptr(cb_in0) + read_addr_offset;
-    uint64_t read_noc_addr = get_noc_addr(read_noc_x, read_noc_y, l1_read_addr);
-    uint32_t l1_write_addr = get_write_ptr(cb_out0) + write_addr_offset;
+    uint32_t l1_write_addr = get_write_ptr(cb_out0);
 
-    cb_reserve_back(cb_out0, H_padded);
+    uint32_t i_stick = start_id;
+    uint32_t curr_c = start_dim_offset[2], curr_h = start_dim_offset[1], curr_n = start_dim_offset[3];
+    for (uint32_t iter = 0; iter < num_sticks_per_core; ++iter) {
+        bool read_stick = curr_h < H and curr_c < C and curr_n < N;
 
-    if (read_pad_only) {
-        #if (not_pad_by_zero)
-        noc_async_read_one_packet_set_state(pad_val_noc_addr, row_major_min_bytes);
-        #else
-        noc_async_read_one_packet_set_state(zeros_noc_addr, W_padded_size_bytes);
-        #endif
-
-        for (uint32_t iter = 0; iter < H_padded; ++iter) {
-            #if (not_pad_by_zero)
-            if constexpr(rem_W_padded_size_bytes != 0) {
-                for (uint32_t j = 0; j < num_sticks_padded_read; ++j) {
-                    noc_async_read_one_packet_with_state(pad_val_noc_addr, l1_write_addr);
-                    l1_write_addr += row_major_min_bytes;
-                }
-            }
-            #else
-                noc_async_read_one_packet_with_state(zeros_noc_addr, l1_write_addr);
-                l1_write_addr += W_padded_size_bytes;
-            #endif
-        }
-    } else {
-
-        if constexpr(HW_has_no_padding) {
-            noc_async_read_one_packet_set_state(read_noc_addr, stick_size_bytes);
-        }
-
-        for (uint32_t iter = 0; iter < H; ++iter) {
-            if constexpr(HW_has_no_padding) {
-                noc_async_read_one_packet_with_state(read_noc_addr, l1_write_addr);
-            } else {
-                noc_async_read(read_noc_addr, l1_write_addr, stick_size_bytes);
-            }
-            read_noc_addr += stick_size_bytes;
+        if (read_stick) {
             l1_write_addr += stick_size_bytes;
+            i_stick++;
+
+        } else {
 
             #if (not_pad_by_zero)
-            if constexpr(rem_W_padded_size_bytes != 0) {
-                for (uint32_t j = 0; j < num_rem_sticks_read; ++j) {
-                    noc_async_read(pad_val_noc_addr, l1_write_addr, row_major_min_bytes);
-                    l1_write_addr += row_major_min_bytes;
-                }
-            }
+                noc_async_read(pad_val_noc_addr, l1_write_addr, stick_size_bytes);
+                l1_write_addr += stick_size_bytes;
             #else
-            if constexpr(rem_W_padded_size_bytes != 0) {
-                noc_async_read(zeros_noc_addr, l1_write_addr, rem_stick_size_bytes);
-                l1_write_addr += rem_stick_size_bytes;
-            }
+                noc_async_read(zeros_noc_addr, l1_write_addr, stick_size_bytes);
+                l1_write_addr += stick_size_bytes;
             #endif
         }
 
-        for (uint32_t iter = 0; iter < H_padded - H; ++iter) {
-            #if (not_pad_by_zero)
-            if constexpr(rem_W_padded_size_bytes != 0) {
-                for (uint32_t j = 0; j < num_sticks_padded_read; ++j) {
-                    noc_async_read(pad_val_noc_addr, l1_write_addr, row_major_min_bytes);
-                    l1_write_addr += row_major_min_bytes;
-                }
+        curr_h++;
+        if (curr_h == H_padded) {
+            curr_c++;
+            curr_h = 0;
+            if (curr_c == C_padded) {
+                curr_n++;
+                curr_c = 0;
             }
-            #else
-                noc_async_read(zeros_noc_addr, l1_write_addr, W_padded_size_bytes);
-                l1_write_addr += W_padded_size_bytes;
-            #endif
         }
     }
 
     noc_async_read_barrier();
-    cb_push_back(cb_out0, H_padded);
 
 }

--- a/ttnn/cpp/ttnn/operations/data_movement/pad/device/pad_op.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/pad/device/pad_op.cpp
@@ -38,10 +38,6 @@ void Pad::validate_with_output_tensors(
 
         TT_FATAL(this->output_mem_config.is_sharded());
         TT_FATAL(this->output_mem_config.memory_layout == TensorMemoryLayout::HEIGHT_SHARDED);
-
-        const auto shard_spec = input_tensor.shard_spec().value();
-        TT_FATAL(shard_spec.shape[1] == input_tensor.get_legacy_shape()[-1]);
-        TT_FATAL(shard_spec.shape[0] == input_tensor.get_legacy_shape()[-2]);
     }
 }
 

--- a/ttnn/cpp/ttnn/operations/data_movement/pad/device/pad_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/pad/device/pad_program_factory.cpp
@@ -1122,6 +1122,176 @@ operation::ProgramWithCallbacks pad_rm_reader_writer_multi_core_v2(const Tensor 
     return {.program=std::move(program), .override_runtime_arguments_callback=override_runtime_args_callback};
 }
 
+inline std::vector<std::vector<uint32_t>> group_contiguous_and_repeated_values(std::vector<uint32_t>& values) {
+    std::vector<std::vector<uint32_t>> chunks;
+    if (values.empty()) return chunks;
+
+    // Initialize the first chunk
+    std::vector<uint32_t> current_chunk;
+    current_chunk.push_back(values[0]);
+
+    for (size_t i = 1; i < values.size(); ++i) {
+        if (values[i] == values[i - 1] + 1 or values[i] == values[i - 1]) {
+            current_chunk.push_back(values[i]);
+        } else {
+            chunks.push_back(current_chunk);
+            current_chunk.clear();
+            current_chunk.push_back(values[i]);
+        }
+    }
+    // Add the last chunk
+    chunks.push_back(current_chunk);
+    return chunks;
+}
+
+inline std::vector<std::pair<std::vector<uint32_t>, std::vector<uint32_t>>> get_pad_runtime_args_rm_sharded(
+    const Tensor& input_tensor,
+    Tensor& output_tensor,
+    uint32_t num_cores_padded,
+    bool row_major,
+    uint32_t num_cores_x_padded,
+    uint32_t num_cores_y_padded,
+    uint32_t shard_height_padded,
+    uint32_t shard_height_unpadded,
+    uint32_t num_cores_x_unpadded,
+    uint32_t num_cores_y_unpadded) {
+
+    tt::tt_metal::Device* device = input_tensor.device();
+
+    auto input_buffer = input_tensor.buffer();
+    auto output_buffer = output_tensor.buffer();
+    auto input_shape = input_tensor.get_legacy_shape();
+    auto output_shape = output_tensor.get_legacy_shape();
+
+    uint32_t W = input_shape[3], H = input_shape[2], C = input_shape[1], N = input_shape[0];
+    uint32_t W_bytes = W * input_tensor.element_size();
+
+    uint32_t W_padded = output_shape[3], H_padded = output_shape[2], C_padded = output_shape[1], N_padded = output_shape[0];
+    uint32_t W_padded_bytes = W_padded * input_tensor.element_size();
+
+    std::uint32_t num_dims = static_cast<std::uint32_t>(input_shape.rank());
+    std::vector<uint32_t> start_dim_offset(num_dims, 0);
+
+    std::vector<std::pair<std::vector<uint32_t>, std::vector<uint32_t> > > ret_val(num_cores_padded);
+
+    uint32_t curr_c = 0, curr_h = 0, curr_n = 0;
+    for(uint32_t i = 0, curr_sticks_read = 0; i < num_cores_padded; i++) {
+        CoreCoord core;
+        if (row_major) {
+            core = {i % num_cores_x_padded, i / num_cores_x_padded};
+        } else {
+            core = {i / num_cores_y_padded, i % num_cores_y_padded};
+        }
+        uint32_t num_sticks_per_core_unpadded = shard_height_unpadded;
+        uint32_t num_sticks_per_core_padded = shard_height_padded;
+
+        // writer rt args, set on top here as interleaved version.
+        std::vector<uint32_t> writer_kernel_args = {
+            num_sticks_per_core_padded,
+            curr_sticks_read
+        };
+        writer_kernel_args.insert(writer_kernel_args.end(), start_dim_offset.begin(), start_dim_offset.end());
+
+        // figure out the start read stick id for each core, and the start id for each dim
+        std::vector<int> stick_ids_per_core;
+        int pad_stick_id = -1;
+        for (uint32_t i = 0; i < num_sticks_per_core_padded; ++i) {
+            if (curr_h < H and curr_c < C and curr_n < N) {
+                stick_ids_per_core.push_back(curr_sticks_read);
+                curr_sticks_read++;
+            } else {
+                stick_ids_per_core.push_back(pad_stick_id);
+            }
+
+            curr_h++;
+            if (curr_h == H_padded) {
+                curr_c++;
+                curr_h = 0;
+                if (curr_c == C_padded) {
+                    curr_n++;
+                    curr_c = 0;
+                }
+            }
+        }
+
+        start_dim_offset = {0, curr_h, curr_c, curr_n};
+
+        // figure out the stick id in a shard, and the core id for the stick.
+        std::map<std::pair<float, float>, std::vector<uint32_t>> core_stick_map;
+        std::pair<float, float> prev_xy_pair;
+        for (uint32_t j = 0; j < num_sticks_per_core_padded; ++j) {
+            int stick_id = stick_ids_per_core[j];
+
+            // if it is pad stick, we need to leave a gap between the previous non-pad stick and next non-pad stick.
+            if (stick_id < 0) {
+                std::pair<float, float> xy_pair = {prev_xy_pair.first, prev_xy_pair.second + 0.5};
+                core_stick_map[prev_xy_pair].push_back(stick_id);
+            } else {
+                uint32_t shard_id = stick_id / num_sticks_per_core_unpadded;
+                uint32_t stick_id_in_shard = stick_id - (shard_id * num_sticks_per_core_unpadded);
+
+                uint32_t shard_grid_inner_dim = row_major ? num_cores_x_unpadded : num_cores_y_unpadded;
+                uint32_t shard_grid_outer_dim_id = shard_id / shard_grid_inner_dim;
+                uint32_t shard_grid_inner_dim_id = shard_id - (shard_grid_outer_dim_id * shard_grid_inner_dim);
+
+                uint32_t worker_y_logical = row_major ? shard_grid_outer_dim_id : shard_grid_inner_dim_id;
+                uint32_t worker_x_logical = row_major ? shard_grid_inner_dim_id : shard_grid_outer_dim_id;
+
+                if (worker_x_logical < num_cores_x_unpadded and worker_y_logical < num_cores_y_unpadded) {
+                    auto core_physical = device->worker_core_from_logical_core(CoreCoord{worker_x_logical, worker_y_logical});
+                    // save stick id in a shard, and core coord into a map
+                    std::pair<float, float> xy_pair = row_major ? std::make_pair(core_physical.y, core_physical.x)
+                                                                        : std::make_pair(core_physical.x, core_physical.y);
+                    core_stick_map[xy_pair].push_back(stick_id_in_shard);
+                    prev_xy_pair = xy_pair;
+                }
+            }
+        }
+
+        // reader rt args
+        vector<uint32_t> reader_kernel_args;
+        reader_kernel_args.push_back(core_stick_map.size()); // num_cores
+
+        tt::log_debug("num_cores: {}", core_stick_map.size());
+
+        for (auto core_stick_pair : core_stick_map) {
+            auto xy_pair = core_stick_pair.first;
+            if (row_major) {
+                reader_kernel_args.push_back((std::uint32_t) xy_pair.second); // noc x
+                reader_kernel_args.push_back((std::uint32_t) xy_pair.first); // noc y
+            } else {
+                reader_kernel_args.push_back((std::uint32_t) xy_pair.first); // noc x
+                reader_kernel_args.push_back((std::uint32_t) xy_pair.second); // noc y
+            }
+
+            tt::log_debug("xy_pair.first: {}", xy_pair.first);
+            tt::log_debug("xy_pair.second: {}", xy_pair.second);
+        }
+
+        // coalesce the sticks into chunks
+        vector<std::vector<std::vector<uint32_t>>> stick_chunks_per_core;
+        for (auto core_stick_pair : core_stick_map) {
+            auto stick_chunks = group_contiguous_and_repeated_values(core_stick_pair.second);
+            stick_chunks_per_core.push_back(stick_chunks);
+
+            reader_kernel_args.push_back(stick_chunks.size()); // num_chunks for current core
+            tt::log_debug("chunk_size: {}", stick_chunks.size());
+        }
+        for (auto stick_chunks : stick_chunks_per_core) {
+            for (auto chunk : stick_chunks) {
+                reader_kernel_args.push_back(chunk[0]); // start id of a chunk
+                tt::log_debug("chunk_start_id: {}", chunk[0]);
+
+                reader_kernel_args.push_back(chunk.size()); // length of a chunk
+                tt::log_debug("chunk_length: {}", chunk.size());
+            }
+        }
+
+        ret_val[i] = {reader_kernel_args, writer_kernel_args};
+    }
+
+    return ret_val;
+}
 
 operation::ProgramWithCallbacks pad_rm_sharded(const Tensor &a,
                                                                 Tensor &output,
@@ -1132,50 +1302,70 @@ operation::ProgramWithCallbacks pad_rm_sharded(const Tensor &a,
 
     auto output_shape = output_tensor_shape;
     uint32_t W = a.shape()[3], H = a.shape()[2], C = a.shape()[1], N = a.shape()[0];
-    uint32_t total_height = H * C * N;
+    uint32_t num_unpadded_sticks = H * C * N;
     uint32_t W_padded = output_tensor_shape[3], H_padded = output_tensor_shape[2], C_padded = output_tensor_shape[1], N_padded = output_tensor_shape[0];
-    uint32_t total_height_padded = H_padded * C_padded * N_padded;
+    uint32_t num_padded_sticks = H_padded * C_padded * N_padded;
 
-    auto stick_size = W * a.element_size();
+    // stick sizes
+    auto stick_size_unpadded = W * a.element_size();
     auto stick_size_padded = W_padded * a.element_size();
-    auto rem_stick_size_padded = stick_size_padded - stick_size;
+    auto rem_stick_size_padded = stick_size_padded - stick_size_unpadded;
     uint32_t row_major_min_bytes = 16;
+
+    // TODO: add a general case, where we can pad on any dim.
+    TT_FATAL(stick_size_unpadded == stick_size_padded, "sharded pad does not support pad on last dim currently as that will cause perf degradation");
 
     tt::DataFormat cb_data_format = tt::tt_metal::datatype_to_dataformat_converter(a.get_dtype());
     tt::DataFormat dst_cb_data_format = tt::tt_metal::datatype_to_dataformat_converter(output.get_dtype());
 
     Device *device = a.device();
 
-    auto shard_spec = output.shard_spec().value();
-    uint32_t shard_height_padded = shard_spec.shape[0];
-    uint32_t shard_width_padded = shard_spec.shape[1];
-    bool row_major = shard_spec.orientation == ShardOrientation::ROW_MAJOR;
-    bool split_reader = false; // need to disable for now, the writer cause noc congestion
+    // input shard spec
+    auto shard_spec_unpadded = a.shard_spec().value();
+    uint32_t shard_height_unpadded = shard_spec_unpadded.shape[0];
+    uint32_t shard_width_unpadded = shard_spec_unpadded.shape[1];
+    bool row_major = shard_spec_unpadded.orientation == ShardOrientation::ROW_MAJOR;
 
-    tt::log_debug("total_height: {}", total_height);
-    tt::log_debug("total_height_padded: {}", total_height_padded);
-    tt::log_debug("shard_height_padded: {}", shard_height_padded);
+    auto& all_cores_unpadded = shard_spec_unpadded.grid;
+    uint32_t num_cores_unpadded = shard_spec_unpadded.num_cores();
+    auto bbox_unpadded = shard_spec_unpadded.grid.bounding_box();
+    CoreCoord grid_size_unpadded = {bbox_unpadded.end_coord.x + 1, bbox_unpadded.end_coord.y+1};
+    uint32_t num_cores_x_unpadded = grid_size_unpadded.x;
+    uint32_t num_cores_y_unpadded = grid_size_unpadded.y;
 
-    auto& all_cores = shard_spec.grid;
-    uint32_t num_cores = shard_spec.num_cores();
-    auto bbox = shard_spec.grid.bounding_box();
-    CoreCoord grid_size = {bbox.end_coord.x + 1, bbox.end_coord.y+1};
-    uint32_t num_cores_x = grid_size.x;
-    uint32_t num_cores_y = grid_size.y;
+    tt::log_debug("num_unpadded_sticks: {}", num_unpadded_sticks);
+    tt::log_debug("shard_height_unpadded: {}", shard_height_unpadded);
+    tt::log_debug("all_cores_unpadded: {}", all_cores_unpadded);
+    tt::log_debug("num_cores_unpadded: {}", num_cores_unpadded);
 
-    tt::log_debug("all_cores: {}", all_cores);
-    tt::log_debug("num_cores: {}", num_cores);
+
+    // output shard spec
+    auto shard_spec_padded = output.shard_spec().value();
+    uint32_t shard_height_padded = shard_spec_padded.shape[0];
+    uint32_t shard_width_padded = shard_spec_padded.shape[1];
+
+    auto& all_cores_padded = shard_spec_padded.grid;
+    uint32_t num_cores_padded = shard_spec_padded.num_cores();
+    auto bbox_padded = shard_spec_padded.grid.bounding_box();
+    CoreCoord grid_size_padded = {bbox_padded.end_coord.x + 1, bbox_padded.end_coord.y+1};
+    uint32_t num_cores_x_padded = grid_size_padded.x;
+    uint32_t num_cores_y_padded = grid_size_padded.y;
+
+    tt::log_debug("num_unpadded_sticks: {}", num_unpadded_sticks);
+    tt::log_debug("shard_height_unpadded: {}", shard_height_unpadded);
+    tt::log_debug("all_cores_unpadded: {}", all_cores_unpadded);
+    tt::log_debug("num_cores_unpadded: {}", num_cores_unpadded);
 
 
     uint32_t src0_cb_index = 0;
-    tt::tt_metal::CircularBufferConfig cb_src0_config = tt::tt_metal::CircularBufferConfig(H * stick_size, {{src0_cb_index, cb_data_format}})
-        .set_page_size(src0_cb_index, stick_size).set_globally_allocated_address(*a.buffer());
-    auto cb_src0 = tt::tt_metal::CreateCircularBuffer(program, all_cores, cb_src0_config);
+    tt::tt_metal::CircularBufferConfig cb_src0_config = tt::tt_metal::CircularBufferConfig(shard_height_unpadded * stick_size_unpadded, {{src0_cb_index, cb_data_format}})
+        .set_page_size(src0_cb_index, stick_size_unpadded).set_globally_allocated_address(*a.buffer());
+    auto cb_src0 = tt::tt_metal::CreateCircularBuffer(program, all_cores_unpadded, cb_src0_config);
 
     uint32_t output_cb_index = tt::CB::c_out0; // output operands start at index 16
-    tt::tt_metal::CircularBufferConfig cb_output_config = tt::tt_metal::CircularBufferConfig(H_padded * stick_size_padded, {{output_cb_index, dst_cb_data_format}})
+    tt::tt_metal::CircularBufferConfig cb_output_config = tt::tt_metal::CircularBufferConfig(shard_height_padded * stick_size_padded, {{output_cb_index, dst_cb_data_format}})
         .set_page_size(output_cb_index, stick_size_padded).set_globally_allocated_address(*output.buffer());
-    auto cb_output = tt::tt_metal::CreateCircularBuffer(program, all_cores, cb_output_config);
+    auto cb_output = tt::tt_metal::CreateCircularBuffer(program, all_cores_padded, cb_output_config);
 
     // construct const buffer with the pad_value
     bool not_pad_by_zero = pad_value != 0;
@@ -1183,111 +1373,63 @@ operation::ProgramWithCallbacks pad_rm_sharded(const Tensor &a,
         uint32_t src1_cb_index = 1;
         tt::tt_metal::CircularBufferConfig cb_src1_config = tt::tt_metal::CircularBufferConfig(row_major_min_bytes, {{src1_cb_index, cb_data_format}})
             .set_page_size(src1_cb_index, row_major_min_bytes);
-        auto cb_src1 = tt::tt_metal::CreateCircularBuffer(program, all_cores, cb_src1_config);
-
-        if (split_reader) {
-            uint32_t src2_cb_index = 2;
-            tt::tt_metal::CircularBufferConfig cb_src2_config = tt::tt_metal::CircularBufferConfig(row_major_min_bytes, {{src2_cb_index, cb_data_format}})
-                .set_page_size(src2_cb_index, row_major_min_bytes);
-            auto cb_src2 = tt::tt_metal::CreateCircularBuffer(program, all_cores, cb_src2_config);
-        }
+        auto cb_src1 = tt::tt_metal::CreateCircularBuffer(program, all_cores_padded, cb_src1_config);
     }
 
 
     bfloat16 bfloat_pad_value = bfloat16(pad_value);
     uint32_t packed_pad_value = pack_two_bfloat16_into_uint32({bfloat_pad_value, bfloat_pad_value});
 
-    uint32_t H_padded_first = split_reader ? H_padded / 2 : H_padded;
-    uint32_t H_padded_last = H_padded - H_padded_first;
-    uint32_t H_first = H_padded_first > H ? H : H_padded_first;
-    uint32_t H_last = H - H_first;
+    std::vector<uint32_t> reader_ct_args = {(std::uint32_t) stick_size_padded,
+                                            (std::uint32_t) shard_height_padded};
 
-    std::vector<uint32_t> reader_ct_args = {(std::uint32_t) H_first,
-                                            (std::uint32_t) stick_size,
-                                            (std::uint32_t) H_padded_first,
+    std::vector<uint32_t> writer_ct_args = {(std::uint32_t) N,
+                                            (std::uint32_t) H,
+                                            (std::uint32_t) C,
                                             (std::uint32_t) stick_size_padded,
-                                            (std::uint32_t) (stick_size_padded - stick_size),
+                                            (std::uint32_t) N_padded,
+                                            (std::uint32_t) H_padded,
+                                            (std::uint32_t) C_padded,
                                             (std::uint32_t) not_pad_by_zero,
                                             (std::uint32_t) packed_pad_value,
                                             (std::uint32_t) row_major_min_bytes,
-                                            (std::uint32_t) (rem_stick_size_padded / row_major_min_bytes),
                                             (std::uint32_t) (stick_size_padded / row_major_min_bytes)};
 
-    std::vector<uint32_t> writer_ct_args = {(std::uint32_t) H_last,
-                                            (std::uint32_t) stick_size,
-                                            (std::uint32_t) H_padded_last,
-                                            (std::uint32_t) stick_size_padded,
-                                            (std::uint32_t) (stick_size_padded - stick_size),
-                                            (std::uint32_t) not_pad_by_zero,
-                                            (std::uint32_t) packed_pad_value,
-                                            (std::uint32_t) row_major_min_bytes,
-                                            (std::uint32_t) (rem_stick_size_padded / row_major_min_bytes),
-                                            (std::uint32_t) (stick_size_padded / row_major_min_bytes),
-                                            (std::uint32_t) (H_first * stick_size),
-                                            (std::uint32_t) (H_padded_first * stick_size_padded)};
+    KernelHandle reader_kernel_id = CreateKernel(
+        program,
+        "ttnn/cpp/ttnn/operations/data_movement/pad/device/kernels/dataflow/reader_pad_dims_rm_sharded.cpp",
+        all_cores_padded,
+        tt::tt_metal::ReaderDataMovementConfig(reader_ct_args));
 
-    KernelHandle reader_kernel_id = CreateKernel(program,
-                                                        "ttnn/cpp/ttnn/operations/data_movement/pad/device/kernels/dataflow/reader_pad_dims_rm_sharded.cpp",
-                                                        all_cores,
-                                                        tt::tt_metal::ReaderDataMovementConfig(reader_ct_args));
-    KernelHandle writer_kernel_id = CreateKernel(program,
-                                                        "ttnn/cpp/ttnn/operations/data_movement/pad/device/kernels/dataflow/writer_pad_dims_rm_sharded.cpp",
-                                                        all_cores,
-                                                        tt::tt_metal::WriterDataMovementConfig(writer_ct_args));
+    KernelHandle writer_kernel_id = CreateKernel(
+        program,
+        "ttnn/cpp/ttnn/operations/data_movement/pad/device/kernels/dataflow/writer_pad_dims_rm_sharded.cpp",
+        all_cores_padded,
+        tt::tt_metal::WriterDataMovementConfig(writer_ct_args));
 
-    uint32_t height = 0;
-    std::vector<CoreCoord> cores;
-    for (uint32_t i = 0; i < num_cores; i++) {
+    auto all_runtime_args = get_pad_runtime_args_rm_sharded(
+        a,
+        output,
+        num_cores_padded,
+        row_major,
+        num_cores_x_padded,
+        num_cores_y_padded,
+        shard_height_padded,
+        shard_height_unpadded,
+        num_cores_x_unpadded,
+        num_cores_y_unpadded
+        );
+
+    for (uint32_t i = 0; i < num_cores_padded; i++) {
         CoreCoord core;
         if (row_major) {
-            core = {i % num_cores_x, i / num_cores_x};
+            core = {i % num_cores_x_padded, i / num_cores_x_padded};
         } else {
-            core = {i / num_cores_y, i % num_cores_y};
+            core = {i / num_cores_y_padded, i % num_cores_y_padded};
         }
-
-        height += shard_height_padded;
-
-        if (height <= total_height_padded) {
-            cores.push_back(core);
-            tt::log_debug("core: {}", core);
-        }
+        tt::tt_metal::SetRuntimeArgs(program, reader_kernel_id, core, all_runtime_args[i].first);
+        tt::tt_metal::SetRuntimeArgs(program, writer_kernel_id, core, all_runtime_args[i].second);
     }
-
-    uint32_t curr_core = 0;
-    uint32_t curr_c = 0;
-    bool read_pad_only = false;
-    for (auto core : cores) {
-
-        tt::log_debug("curr_core: {}", curr_core);
-        CoreCoord phy_coord = device->worker_core_from_logical_core(cores[curr_core]);
-
-        std::vector<uint32_t> reader_runtime_args = {
-            (std::uint32_t) read_pad_only,
-            (std::uint32_t) phy_coord.x,
-            (std::uint32_t) phy_coord.y,
-        };
-        tt::tt_metal::SetRuntimeArgs(program, reader_kernel_id, core, reader_runtime_args);
-
-        std::vector<uint32_t> writer_runtime_args = reader_runtime_args;
-        tt::tt_metal::SetRuntimeArgs(program, writer_kernel_id, core, writer_runtime_args);
-
-
-        curr_c++;
-        if (curr_c >= C) {
-            if (curr_c == C_padded) {
-                read_pad_only = false;
-                curr_c = 0;
-                curr_core++;
-            } else {
-                read_pad_only = true;
-            }
-        } else {
-            read_pad_only = false;
-            curr_core++;
-        }
-
-    }
-
 
     auto override_runtime_args_callback = [
             cb_src0,

--- a/ttnn/cpp/ttnn/operations/data_movement/slice/device/slice_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/slice/device/slice_program_factory.cpp
@@ -261,7 +261,7 @@ operation::ProgramWithCallbacks slice_rm_multi_core(
     return {.program = std::move(program), .override_runtime_arguments_callback = override_runtime_args_callback};
 }
 
-std::vector<std::vector<uint32_t>> group_contiguous_values(std::vector<uint32_t>& values) {
+inline std::vector<std::vector<uint32_t>> group_contiguous_values(std::vector<uint32_t>& values) {
     std::vector<std::vector<uint32_t>> chunks;
     if (values.empty()) return chunks;
 

--- a/ttnn/cpp/ttnn/operations/data_movement/transpose/device/kernels/dataflow/reader_unary_transpose_hc_sharded_rm.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/transpose/device/kernels/dataflow/reader_unary_transpose_hc_sharded_rm.cpp
@@ -8,36 +8,119 @@
 
 
 void kernel_main() {
-    uint32_t num_sticks_per_shard_core = get_arg_val<uint32_t>(0);
-    uint32_t num_cores_read = get_arg_val<uint32_t>(1);
-    uint32_t read_stick_stride = get_arg_val<uint32_t>(2);
-    tt_l1_ptr uint32_t * read_stick_offset = (tt_l1_ptr uint32_t*)(get_arg_addr(3));
-    tt_l1_ptr uint32_t * noc_coord_x = (tt_l1_ptr uint32_t*)(get_arg_addr(3 + num_cores_read));
-    tt_l1_ptr uint32_t * noc_coord_y = (tt_l1_ptr uint32_t*)(get_arg_addr(3 + num_cores_read * 2));
+    #ifdef USE_SPECIAL_CASE
 
-    constexpr uint32_t cb_in0 = get_compile_time_arg_val(0);
-    constexpr uint32_t cb_out0 = get_compile_time_arg_val(1);
-    constexpr uint32_t stick_size_bytes = get_compile_time_arg_val(2);
+        uint32_t num_sticks_per_shard_core = get_arg_val<uint32_t>(0);
+        uint32_t num_cores_read = get_arg_val<uint32_t>(1);
+        uint32_t read_stick_stride = get_arg_val<uint32_t>(2);
+        tt_l1_ptr uint32_t * read_stick_offset = (tt_l1_ptr uint32_t*)(get_arg_addr(3));
+        tt_l1_ptr uint32_t * noc_coord_x = (tt_l1_ptr uint32_t*)(get_arg_addr(3 + num_cores_read));
+        tt_l1_ptr uint32_t * noc_coord_y = (tt_l1_ptr uint32_t*)(get_arg_addr(3 + num_cores_read * 2));
 
-    uint32_t write_stick_stride = stick_size_bytes * num_cores_read;
+        constexpr uint32_t cb_in0 = get_compile_time_arg_val(0);
+        constexpr uint32_t cb_out0 = get_compile_time_arg_val(1);
+        constexpr uint32_t stick_size_bytes = get_compile_time_arg_val(2);
+
+        uint32_t write_stick_stride = stick_size_bytes * num_cores_read;
 
 
-    uint32_t l1_write_offset = 0;
-    for (uint32_t core = 0; core < num_cores_read; ++core) {
-        uint32_t l1_read_addr = get_read_ptr(cb_in0) + read_stick_offset[core];
-        uint64_t noc_read_addr = get_noc_addr(noc_coord_x[core], noc_coord_y[core], l1_read_addr);
-        uint32_t l1_write_addr = get_write_ptr(cb_out0) + l1_write_offset;
+        uint32_t l1_write_offset = 0;
+        for (uint32_t core = 0; core < num_cores_read; ++core) {
+            uint32_t l1_read_addr = get_read_ptr(cb_in0) + read_stick_offset[core];
+            uint64_t noc_read_addr = get_noc_addr(noc_coord_x[core], noc_coord_y[core], l1_read_addr);
+            uint32_t l1_write_addr = get_write_ptr(cb_out0) + l1_write_offset;
 
-        noc_async_read_one_packet_set_state(noc_read_addr, stick_size_bytes);
+            noc_async_read_one_packet_set_state(noc_read_addr, stick_size_bytes);
 
-        for (uint32_t i = 0; i < num_sticks_per_shard_core; ++i) {
-            noc_async_read_one_packet_with_state(noc_read_addr, l1_write_addr);
-            noc_read_addr += read_stick_stride;
-            l1_write_addr += write_stick_stride;
+            for (uint32_t i = 0; i < num_sticks_per_shard_core; ++i) {
+                noc_async_read_one_packet_with_state(noc_read_addr, l1_write_addr);
+                noc_read_addr += read_stick_stride;
+                l1_write_addr += write_stick_stride;
+            }
+            l1_write_offset += stick_size_bytes;
+            noc_async_read_barrier();
         }
-        l1_write_offset += stick_size_bytes;
+
+    #else
+
+        constexpr uint32_t cb_in0 = get_compile_time_arg_val(0);
+        constexpr uint32_t cb_out0 = get_compile_time_arg_val(1);
+        constexpr uint32_t N = get_compile_time_arg_val(2);
+        constexpr uint32_t H = get_compile_time_arg_val(3);
+        constexpr uint32_t C = get_compile_time_arg_val(4);
+        constexpr uint32_t W_size_bytes = get_compile_time_arg_val(5);
+        constexpr bool row_major = get_compile_time_arg_val(6) == 1;
+        constexpr uint32_t num_cores_x = get_compile_time_arg_val(7);
+        constexpr uint32_t num_cores_y = get_compile_time_arg_val(8);
+
+        uint32_t arg_idx = 0;
+        uint32_t num_sticks_per_core = get_arg_val<uint32_t>(arg_idx++);
+        uint32_t start_id  = get_arg_val<uint32_t>(arg_idx++);
+        uint32_t curr_c  = get_arg_val<uint32_t>(arg_idx++);
+        uint32_t curr_h  = get_arg_val<uint32_t>(arg_idx++);
+        uint32_t curr_n  = get_arg_val<uint32_t>(arg_idx++);
+
+        const uint32_t * const shard_grid_x_map = reinterpret_cast<const uint32_t * const>(get_arg_addr(arg_idx));
+        arg_idx += num_cores_x;
+        const uint32_t * const shard_grid_y_map = reinterpret_cast<const uint32_t * const>(get_arg_addr(arg_idx));
+        arg_idx += num_cores_y;
+
+
+        constexpr uint32_t CH = C * H;
+
+        const uint32_t stick_size_bytes = W_size_bytes;
+
+        cb_reserve_back(cb_out0, num_sticks_per_core);
+        uint32_t l1_write_addr = get_write_ptr(cb_out0);
+
+        uint32_t i_stick = start_id;
+        for (uint32_t iter = 0; iter < num_sticks_per_core; ++iter) {
+
+            uint32_t shard_id = i_stick / num_sticks_per_core;
+            uint32_t stick_id_in_shard = i_stick - (shard_id * num_sticks_per_core);
+
+            uint32_t shard_grid_inner_dim;
+            if constexpr(row_major) {
+                shard_grid_inner_dim = num_cores_x;
+            } else {
+                shard_grid_inner_dim = num_cores_y;
+            }
+            uint32_t shard_grid_outer_dim_id = shard_id / shard_grid_inner_dim;
+            uint32_t shard_grid_inner_dim_id = shard_id - (shard_grid_outer_dim_id * shard_grid_inner_dim);
+
+            uint32_t worker_x_physical, worker_y_physical;
+            if constexpr(row_major) {
+                worker_x_physical = shard_grid_x_map[shard_grid_inner_dim_id];
+                worker_y_physical = shard_grid_y_map[shard_grid_outer_dim_id];
+            } else {
+                worker_x_physical = shard_grid_x_map[shard_grid_outer_dim_id];
+                worker_y_physical = shard_grid_y_map[shard_grid_inner_dim_id];
+            }
+
+            uint32_t l1_read_addr = get_read_ptr(cb_in0) + stick_id_in_shard * stick_size_bytes;
+
+            uint64_t read_noc_addr = get_noc_addr(worker_x_physical, worker_y_physical, l1_read_addr);
+            noc_async_read(read_noc_addr, l1_write_addr, stick_size_bytes);
+            l1_write_addr += stick_size_bytes;
+
+            curr_c++;
+            i_stick += H;
+            if (curr_c == C) { // end of channel dim
+                curr_h++;
+                curr_c = 0;
+                if (curr_h == H) { // end of H dim
+                    curr_n++;
+                    curr_c = 0;
+                    curr_h = 0;
+                    i_stick = i_stick - H + 1;
+                } else {
+                    i_stick = i_stick - CH + 1;
+                }
+            }
+        }
+
         noc_async_read_barrier();
-    }
+        cb_push_back(cb_out0, num_sticks_per_core);
 
-
+    #endif
 }

--- a/ttnn/cpp/ttnn/operations/data_movement/transpose/device/kernels/dataflow/reader_unary_transpose_hc_sharded_rm.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/transpose/device/kernels/dataflow/reader_unary_transpose_hc_sharded_rm.cpp
@@ -10,34 +10,59 @@
 void kernel_main() {
     #ifdef USE_SPECIAL_CASE
 
-        uint32_t num_sticks_per_shard_core = get_arg_val<uint32_t>(0);
-        uint32_t num_cores_read = get_arg_val<uint32_t>(1);
-        uint32_t read_stick_stride = get_arg_val<uint32_t>(2);
-        tt_l1_ptr uint32_t * read_stick_offset = (tt_l1_ptr uint32_t*)(get_arg_addr(3));
-        tt_l1_ptr uint32_t * noc_coord_x = (tt_l1_ptr uint32_t*)(get_arg_addr(3 + num_cores_read));
-        tt_l1_ptr uint32_t * noc_coord_y = (tt_l1_ptr uint32_t*)(get_arg_addr(3 + num_cores_read * 2));
+        bool read_single_h_block_per_core = get_arg_val<uint32_t>(0) == 1;
+        uint32_t num_C_blocks_per_core = get_arg_val<uint32_t>(1);
+        uint32_t num_sticks_per_shard_core = get_arg_val<uint32_t>(2);
+        uint32_t num_cores_read = get_arg_val<uint32_t>(3);
+        uint32_t read_stick_stride = get_arg_val<uint32_t>(4);
+        uint32_t read_stick_offset = get_arg_val<uint32_t>(5);
+        tt_l1_ptr uint32_t * noc_coord_x = (tt_l1_ptr uint32_t*)(get_arg_addr(6));
+        tt_l1_ptr uint32_t * noc_coord_y = (tt_l1_ptr uint32_t*)(get_arg_addr(6 + num_cores_read));
 
         constexpr uint32_t cb_in0 = get_compile_time_arg_val(0);
         constexpr uint32_t cb_out0 = get_compile_time_arg_val(1);
         constexpr uint32_t stick_size_bytes = get_compile_time_arg_val(2);
 
-        uint32_t write_stick_stride = stick_size_bytes * num_cores_read;
+        if (read_single_h_block_per_core) {
+            uint32_t write_stick_stride = stick_size_bytes * num_cores_read;
+            uint32_t l1_write_offset = 0;
 
+            for (uint32_t core = 0; core < num_cores_read; ++core) {
+                uint32_t l1_read_addr = get_read_ptr(cb_in0) + read_stick_offset;
+                uint64_t noc_read_addr = get_noc_addr(noc_coord_x[core], noc_coord_y[core], l1_read_addr);
+                uint32_t l1_write_addr = get_write_ptr(cb_out0) + l1_write_offset;
 
-        uint32_t l1_write_offset = 0;
-        for (uint32_t core = 0; core < num_cores_read; ++core) {
-            uint32_t l1_read_addr = get_read_ptr(cb_in0) + read_stick_offset[core];
-            uint64_t noc_read_addr = get_noc_addr(noc_coord_x[core], noc_coord_y[core], l1_read_addr);
-            uint32_t l1_write_addr = get_write_ptr(cb_out0) + l1_write_offset;
+                noc_async_read_one_packet_set_state(noc_read_addr, stick_size_bytes);
 
-            noc_async_read_one_packet_set_state(noc_read_addr, stick_size_bytes);
-
-            for (uint32_t i = 0; i < num_sticks_per_shard_core; ++i) {
-                noc_async_read_one_packet_with_state(noc_read_addr, l1_write_addr);
-                noc_read_addr += read_stick_stride;
-                l1_write_addr += write_stick_stride;
+                for (uint32_t i = 0; i < num_sticks_per_shard_core; ++i) {
+                    noc_async_read_one_packet_with_state(noc_read_addr, l1_write_addr);
+                    noc_read_addr += read_stick_stride;
+                    l1_write_addr += write_stick_stride;
+                }
+                l1_write_offset += stick_size_bytes;
+                noc_async_read_barrier();
             }
-            l1_write_offset += stick_size_bytes;
+        } else {
+            uint32_t l1_write_addr = get_write_ptr(cb_out0);
+            uint32_t l1_read_addr = get_read_ptr(cb_in0) + read_stick_offset;
+
+            for (uint32_t c = 0; c < num_C_blocks_per_core; ++c) {
+
+                for (uint32_t core = 0; core < num_cores_read; ++core) {
+
+                    uint64_t noc_read_addr = get_noc_addr(noc_coord_x[core], noc_coord_y[core], l1_read_addr);
+
+                    noc_async_read_one_packet_set_state(noc_read_addr, stick_size_bytes);
+
+                    for (uint32_t i = 0; i < num_sticks_per_shard_core; ++i) {
+                        noc_async_read_one_packet_with_state(noc_read_addr, l1_write_addr);
+                        noc_read_addr += read_stick_stride;
+                        l1_write_addr += stick_size_bytes;
+                    }
+                }
+
+                l1_read_addr += stick_size_bytes;
+            }
             noc_async_read_barrier();
         }
 

--- a/ttnn/cpp/ttnn/operations/data_movement/transpose/device/kernels/dataflow/writer_unary_transpose_hc_sharded_rm.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/transpose/device/kernels/dataflow/writer_unary_transpose_hc_sharded_rm.cpp
@@ -7,37 +7,60 @@
 
 
 
-
 void kernel_main() {
-    uint32_t num_sticks_per_shard_core = get_arg_val<uint32_t>(0);
-    uint32_t num_cores_read = get_arg_val<uint32_t>(1);
-    uint32_t read_stick_stride = get_arg_val<uint32_t>(2);
-    uint32_t src_read_stick_offset = get_arg_val<uint32_t>(3);
-    tt_l1_ptr uint32_t * read_stick_offset = (tt_l1_ptr uint32_t*)(get_arg_addr(4));
-    tt_l1_ptr uint32_t * noc_coord_x = (tt_l1_ptr uint32_t*)(get_arg_addr(4 + num_cores_read));
-    tt_l1_ptr uint32_t * noc_coord_y = (tt_l1_ptr uint32_t*)(get_arg_addr(4 + num_cores_read * 2));
+
+    bool read_single_h_block_per_core = get_arg_val<uint32_t>(0) == 1;
+    uint32_t num_C_blocks_per_core = get_arg_val<uint32_t>(1);
+    uint32_t num_sticks_per_shard_core = get_arg_val<uint32_t>(2);
+    uint32_t num_cores_read = get_arg_val<uint32_t>(3);
+    uint32_t read_stick_stride = get_arg_val<uint32_t>(4);
+    uint32_t src_read_stick_offset = get_arg_val<uint32_t>(5);
+    uint32_t dst_write_stick_offset = get_arg_val<uint32_t>(6);
+    uint32_t read_stick_offset = get_arg_val<uint32_t>(7);
+    tt_l1_ptr uint32_t * noc_coord_x = (tt_l1_ptr uint32_t*)(get_arg_addr(8));
+    tt_l1_ptr uint32_t * noc_coord_y = (tt_l1_ptr uint32_t*)(get_arg_addr(8 + num_cores_read));
 
     constexpr uint32_t cb_in0 = get_compile_time_arg_val(0);
     constexpr uint32_t cb_out0 = get_compile_time_arg_val(1);
     constexpr uint32_t stick_size_bytes = get_compile_time_arg_val(2);
 
-    uint32_t write_stick_stride = stick_size_bytes * num_cores_read;
-    uint32_t dst_write_stick_offset = src_read_stick_offset * num_cores_read;
+    if (read_single_h_block_per_core) {
+        uint32_t write_stick_stride = stick_size_bytes * num_cores_read;
 
-
-    uint32_t l1_write_offset = 0;
-    for (uint32_t core = 0; core < num_cores_read; ++core) {
-        uint32_t l1_read_addr = get_read_ptr(cb_in0) + read_stick_offset[core] + src_read_stick_offset;
-        uint64_t noc_read_addr = get_noc_addr(noc_coord_x[core], noc_coord_y[core], l1_read_addr);
-        uint32_t l1_write_addr = get_write_ptr(cb_out0) + l1_write_offset + dst_write_stick_offset;
-        for (uint32_t i = 0; i < num_sticks_per_shard_core; ++i) {
-            noc_async_read_one_packet(noc_read_addr, l1_write_addr, stick_size_bytes);
-            noc_read_addr += read_stick_stride;
-            l1_write_addr += write_stick_stride;
+        uint32_t l1_write_offset = 0;
+        for (uint32_t core = 0; core < num_cores_read; ++core) {
+            uint32_t l1_read_addr = get_read_ptr(cb_in0) + read_stick_offset + src_read_stick_offset;
+            uint64_t noc_read_addr = get_noc_addr(noc_coord_x[core], noc_coord_y[core], l1_read_addr);
+            uint32_t l1_write_addr = get_write_ptr(cb_out0) + l1_write_offset + dst_write_stick_offset;
+            for (uint32_t i = 0; i < num_sticks_per_shard_core; ++i) {
+                noc_async_read_one_packet(noc_read_addr, l1_write_addr, stick_size_bytes);
+                noc_read_addr += read_stick_stride;
+                l1_write_addr += write_stick_stride;
+            }
+            l1_write_offset += stick_size_bytes;
+            noc_async_read_barrier();
         }
-        l1_write_offset += stick_size_bytes;
+    } else {
+        uint32_t l1_write_addr = get_write_ptr(cb_out0) + dst_write_stick_offset;
+        uint32_t l1_read_addr = get_read_ptr(cb_in0) + read_stick_offset + src_read_stick_offset;
+
+        for (uint32_t c = 0; c < num_C_blocks_per_core; ++c) {
+
+            for (uint32_t core = 0; core < num_cores_read; ++core) {
+
+                uint64_t noc_read_addr = get_noc_addr(noc_coord_x[core], noc_coord_y[core], l1_read_addr);
+
+                noc_async_read_one_packet_set_state(noc_read_addr, stick_size_bytes);
+
+                for (uint32_t i = 0; i < num_sticks_per_shard_core; ++i) {
+                    noc_async_read_one_packet_with_state(noc_read_addr, l1_write_addr);
+                    noc_read_addr += read_stick_stride;
+                    l1_write_addr += stick_size_bytes;
+                }
+            }
+            l1_read_addr += stick_size_bytes;
+        }
         noc_async_read_barrier();
     }
-
 
 }

--- a/ttnn/cpp/ttnn/operations/data_movement/transpose/device/kernels/dataflow/writer_unary_transpose_hc_sharded_rm.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/transpose/device/kernels/dataflow/writer_unary_transpose_hc_sharded_rm.cpp
@@ -16,9 +16,9 @@ void kernel_main() {
     uint32_t read_stick_stride = get_arg_val<uint32_t>(4);
     uint32_t src_read_stick_offset = get_arg_val<uint32_t>(5);
     uint32_t dst_write_stick_offset = get_arg_val<uint32_t>(6);
-    uint32_t read_stick_offset = get_arg_val<uint32_t>(7);
-    tt_l1_ptr uint32_t * noc_coord_x = (tt_l1_ptr uint32_t*)(get_arg_addr(8));
-    tt_l1_ptr uint32_t * noc_coord_y = (tt_l1_ptr uint32_t*)(get_arg_addr(8 + num_cores_read));
+    tt_l1_ptr uint32_t * read_stick_offset = (tt_l1_ptr uint32_t*)(get_arg_addr(7));
+    tt_l1_ptr uint32_t * noc_coord_x = (tt_l1_ptr uint32_t*)(get_arg_addr(7 + num_cores_read));
+    tt_l1_ptr uint32_t * noc_coord_y = (tt_l1_ptr uint32_t*)(get_arg_addr(7 + num_cores_read * 2));
 
     constexpr uint32_t cb_in0 = get_compile_time_arg_val(0);
     constexpr uint32_t cb_out0 = get_compile_time_arg_val(1);
@@ -29,7 +29,7 @@ void kernel_main() {
 
         uint32_t l1_write_offset = 0;
         for (uint32_t core = 0; core < num_cores_read; ++core) {
-            uint32_t l1_read_addr = get_read_ptr(cb_in0) + read_stick_offset + src_read_stick_offset;
+            uint32_t l1_read_addr = get_read_ptr(cb_in0) + read_stick_offset[core] + src_read_stick_offset;
             uint64_t noc_read_addr = get_noc_addr(noc_coord_x[core], noc_coord_y[core], l1_read_addr);
             uint32_t l1_write_addr = get_write_ptr(cb_out0) + l1_write_offset + dst_write_stick_offset;
             for (uint32_t i = 0; i < num_sticks_per_shard_core; ++i) {
@@ -42,13 +42,13 @@ void kernel_main() {
         }
     } else {
         uint32_t l1_write_addr = get_write_ptr(cb_out0) + dst_write_stick_offset;
-        uint32_t l1_read_addr = get_read_ptr(cb_in0) + read_stick_offset + src_read_stick_offset;
+        uint32_t l1_read_addr = get_read_ptr(cb_in0) + src_read_stick_offset;
 
         for (uint32_t c = 0; c < num_C_blocks_per_core; ++c) {
 
             for (uint32_t core = 0; core < num_cores_read; ++core) {
 
-                uint64_t noc_read_addr = get_noc_addr(noc_coord_x[core], noc_coord_y[core], l1_read_addr);
+                uint64_t noc_read_addr = get_noc_addr(noc_coord_x[core], noc_coord_y[core], l1_read_addr + read_stick_offset[core]);
 
                 noc_async_read_one_packet_set_state(noc_read_addr, stick_size_bytes);
 

--- a/ttnn/cpp/ttnn/operations/data_movement/transpose/device/transpose_op.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/transpose/device/transpose_op.cpp
@@ -46,9 +46,6 @@ void Transpose::validate(const std::vector<Tensor> &input_tensors) const {
             TT_FATAL(input_tensor.memory_config().memory_layout == TensorMemoryLayout::HEIGHT_SHARDED);
             const auto shard_spec = input_tensor.shard_spec().value();
             TT_FATAL(shard_spec.shape[1] == W);
-            TT_FATAL(shard_spec.shape[0] % H == 0 or H % shard_spec.shape[0] == 0);
-            TT_FATAL(shard_spec.shape[0] % C == 0 or C % shard_spec.shape[0] == 0);
-            TT_FATAL(C % H == 0 or H % C == 0);
             TT_FATAL(this->output_mem_config.is_sharded());
             TT_FATAL(this->output_mem_config.memory_layout == TensorMemoryLayout::HEIGHT_SHARDED);
         } else {


### PR DESCRIPTION
### Problem description
Previous Pad only support sharding the full HW dim on one core, with this change it can be sharded for non full HW dim.
Add general version of transpose HC as well. Keep the original shard method as special case, as this gives the best perf.


### Checklist
- [x] Post commit CI passes https://github.com/tenstorrent/tt-metal/actions/runs/10456567664
