### PR TITLE
Mo/11571 external op attributes

### DIFF
--- a/ttnn/cpp/ttnn/deprecated/tt_lib/csrc/tt_lib_bindings_tensor_pytensor.cpp
+++ b/ttnn/cpp/ttnn/deprecated/tt_lib/csrc/tt_lib_bindings_tensor_pytensor.cpp
@@ -559,7 +559,8 @@ Tensor convert_python_tensors_to_tt_tensors(py::list tensor_shards, std::optiona
                 // auto tensor = detail::convert_torch_tensor_to_tt_tensor(value);
                 // input_tensors.push_back(tensor);
             } else {
-                attributes.push_back({name, fmt::format("{}", value)});
+                // TODO(MO): Exclude tensor data as it is not an attribute
+                //attributes.push_back({name, fmt::format("{}", value)});
             }
         };
 


### PR DESCRIPTION
### Ticket
[11571](https://github.com/tenstorrent/tt-metal/issues/11571)

### Problem description
Entire sensor data is getting pushed in the attributes list for external ops

### What's changed
Stop generating the attribute list until a solution is found

### Checklist
- [x] Post commit CI passes: https://github.com/tenstorrent/tt-metal/actions/runs/10426041960
- [x] Device perf: https://github.com/tenstorrent/tt-metal/actions/runs/10426048090
- [x] T3K profiler: https://github.com/tenstorrent/tt-metal/actions/runs/10426045609
