### PR TITLE
#9823: enabling FD out of idle eth cores on BH and update eth l1 size to correct value

### DIFF
--- a/tests/scripts/run_cpp_unit_tests.sh
+++ b/tests/scripts/run_cpp_unit_tests.sh
@@ -14,7 +14,7 @@ if [[ ! -z "$TT_METAL_SLOW_DISPATCH_MODE" ]]; then
 else
     ./build/test/tt_metal/unit_tests_fast_dispatch
     TT_METAL_GTEST_NUM_HW_CQS=2 ./build/test/tt_metal/unit_tests_fast_dispatch_single_chip_multi_queue --gtest_filter=MultiCommandQueueSingleDeviceFixture.*
-    if [[ "$ARCH_NAME" == "wormhole_b0" ]]; then
+    if [[ "$ARCH_NAME" == "wormhole_b0" || "$ARCH_NAME" == "blackhole" ]]; then
         TT_METAL_GTEST_ETH_DISPATCH=1 ./build/test/tt_metal/unit_tests_fast_dispatch
     fi
     env python tests/scripts/run_tt_eager.py --dispatch-mode fast

--- a/tt_metal/common/core_descriptor.hpp
+++ b/tt_metal/common/core_descriptor.hpp
@@ -20,21 +20,18 @@ struct core_descriptor_t {
 inline std::string get_core_descriptor_file(const tt::ARCH &arch, CoreType dispatch_core_type) {
 
     // Ability to skip this runtime opt, since trimmed SOC desc limits which DRAM channels are available.
-    string tt_metal_home;
+    string core_desc_dir;
     if (getenv("TT_METAL_HOME")) {
-        tt_metal_home = getenv("TT_METAL_HOME");
+        core_desc_dir = getenv("TT_METAL_HOME");
     } else {
-        tt_metal_home = "./";
+        core_desc_dir = "./";
     }
-    if (tt_metal_home.back() != '/') {
-        tt_metal_home += "/";
+    if (core_desc_dir.back() != '/') {
+        core_desc_dir += "/";
     }
-    string wh_arch = "tt_metal/core_descriptors/wormhole_b0_80_arch.yaml";
-    if (dispatch_core_type == CoreType::ETH) {
-        wh_arch = "tt_metal/core_descriptors/wormhole_b0_80_arch_eth_dispatch.yaml";
-    }
-    
-    bool targeting_sim = std::getenv("TT_METAL_SIMULATOR_EN") != nullptr; 
+    core_desc_dir += "tt_metal/core_descriptors/";
+
+    bool targeting_sim = std::getenv("TT_METAL_SIMULATOR_EN") != nullptr;
     if (targeting_sim) {
         switch (arch) {
             case tt::ARCH::Invalid: throw std::runtime_error("Invalid arch not supported"); // will be overwritten in tt_global_state constructor
@@ -42,17 +39,17 @@ inline std::string get_core_descriptor_file(const tt::ARCH &arch, CoreType dispa
             case tt::ARCH::GRAYSKULL: throw std::runtime_error("GRAYSKULL arch not supported for simulator");
             case tt::ARCH::WORMHOLE: throw std::runtime_error("WORMHOLE arch not supported for simulator");
             case tt::ARCH::WORMHOLE_B0: throw std::runtime_error("WORMHOLE_B0 arch not supported for simulator");
-            case tt::ARCH::BLACKHOLE: return tt_metal_home + "tt_metal/core_descriptors/blackhole_simulation_1x2_arch.yaml";
+            case tt::ARCH::BLACKHOLE: return core_desc_dir + "blackhole_simulation_1x2_arch.yaml";
             default: throw std::runtime_error("Unsupported device arch");
         };
     } else {
         switch (arch) {
             case tt::ARCH::Invalid: throw std::runtime_error("Invalid arch not supported"); // will be overwritten in tt_global_state constructor
             case tt::ARCH::JAWBRIDGE: throw std::runtime_error("JAWBRIDGE arch not supported");
-            case tt::ARCH::GRAYSKULL: return tt_metal_home + "tt_metal/core_descriptors/grayskull_120_arch.yaml";
+            case tt::ARCH::GRAYSKULL: return core_desc_dir + "grayskull_120_arch.yaml";
             case tt::ARCH::WORMHOLE: throw std::runtime_error("WORMHOLE arch not supported");
-            case tt::ARCH::WORMHOLE_B0: return tt_metal_home + wh_arch;
-            case tt::ARCH::BLACKHOLE: return tt_metal_home + "tt_metal/core_descriptors/blackhole_140_arch.yaml";
+            case tt::ARCH::WORMHOLE_B0: return core_desc_dir + (dispatch_core_type == CoreType::ETH ? "wormhole_b0_80_arch_eth_dispatch.yaml" : "wormhole_b0_80_arch.yaml");
+            case tt::ARCH::BLACKHOLE: return core_desc_dir + (dispatch_core_type == CoreType::ETH ? "blackhole_140_arch_eth_dispatch.yaml" : "blackhole_140_arch.yaml");
             default: throw std::runtime_error("Unsupported device arch");
         };
     }

--- a/tt_metal/core_descriptors/blackhole_140_arch_eth_dispatch.yaml
+++ b/tt_metal/core_descriptors/blackhole_140_arch_eth_dispatch.yaml
@@ -1,0 +1,35 @@
+# Anything using [[#, #]] is logical coordinates (Can be relative)
+# relative index: 0 means first row, -1 means last row of functional grid...
+
+# product name:
+#   num of HW command queues:
+#     core descriptor config
+
+blackhole:
+  1:
+    compute_with_storage_grid_range: # Logical only start and end [x, y]
+      start: [0, 0]
+      end: [13, 9]
+
+    storage_cores:
+      []
+
+    dispatch_cores:
+      [[0, 0], [0, 1], [0, 2], [0, 3], [0, 4], [0, 5], [0, 6], [0, 7], [0, 8], [0, 9], [0, 10], [0, 11], [0, 12], [0, 13]]
+
+    dispatch_core_type:
+      "ethernet"
+
+  2:
+    compute_with_storage_grid_range: # Logical only start and end [x, y]
+      start: [0, 0]
+      end: [13, 9]
+
+    storage_cores:
+      []
+
+    dispatch_cores:
+      [[0, 0], [0, 1], [0, 2], [0, 3], [0, 4], [0, 5], [0, 6], [0, 7], [0, 8], [0, 9], [0, 10], [0, 11], [0, 12], [0, 13]]
+
+    dispatch_core_type:
+      "ethernet"

--- a/tt_metal/hw/inc/blackhole/dev_mem_map.h
+++ b/tt_metal/hw/inc/blackhole/dev_mem_map.h
@@ -30,12 +30,12 @@
 
 #define MEM_ETH_BASE 0x0
 // -32 for ETH barrier, see comment in eth_l1_address_map
-#define MEM_ETH_SIZE (256 * 1024 - 32)
+#define MEM_ETH_SIZE (512 * 1024 - 32)
 
 #define MEM_LOCAL_BASE 0xFFB00000
 #define MEM_BRISC_LOCAL_SIZE (8 * 1024)
 #define MEM_NCRISC_LOCAL_SIZE (8 * 1024)
-#define MEM_IERISC_LOCAL_SIZE (4 * 1024)
+#define MEM_IERISC_LOCAL_SIZE (8 * 1024)
 #define MEM_TRISC_LOCAL_SIZE (4 * 1024)
 
 /////////////
@@ -43,7 +43,7 @@
 #define MEM_BOOT_CODE_SIZE 4
 #define MEM_BRISC_FIRMWARE_SIZE (10 * 1024)
 #define MEM_NCRISC_FIRMWARE_SIZE (16 * 1024)
-#define MEM_IERISC_FIRMWARE_SIZE (16 * 1024)
+#define MEM_IERISC_FIRMWARE_SIZE (24 * 1024)
 #define MEM_TRISC0_FIRMWARE_SIZE (16 * 1024)
 #define MEM_TRISC1_FIRMWARE_SIZE (16 * 1024)
 #define MEM_TRISC2_FIRMWARE_SIZE (16 * 1024)
@@ -82,7 +82,7 @@
 // Increasing the stack size comes at the expense of less local memory for globals
 #define MEM_BRISC_STACK_SIZE 768
 #define MEM_NCRISC_STACK_SIZE 768
-#define MEM_IERISC_STACK_SIZE 1024
+#define MEM_IERISC_STACK_SIZE 768
 #define MEM_TRISC0_STACK_SIZE 320
 #define MEM_TRISC1_STACK_SIZE 256
 #define MEM_TRISC2_STACK_SIZE 768

--- a/tt_metal/hw/inc/blackhole/eth_l1_address_map.h
+++ b/tt_metal/hw/inc/blackhole/eth_l1_address_map.h
@@ -18,8 +18,8 @@ struct address_map {
   // active/idle eth cores have very different mem maps
   // Reserve some space at the end of l1 for l1_barrier
   static constexpr std::int32_t ERISC_BARRIER_SIZE = 32;
-  static constexpr std::int32_t MAX_SIZE = 256 * 1024 - ERISC_BARRIER_SIZE;
-  static constexpr std::int32_t MAX_L1_LOADING_SIZE = 1 * 256 * 1024 - ERISC_BARRIER_SIZE;
+  static constexpr std::int32_t MAX_SIZE = 512 * 1024 - ERISC_BARRIER_SIZE;
+  static constexpr std::int32_t MAX_L1_LOADING_SIZE = 1 * 512 * 1024 - ERISC_BARRIER_SIZE;
 
   // Sizes
   static constexpr std::int32_t FIRMWARE_SIZE = 32 * 1024;

--- a/tt_metal/hw/inc/mod_div_lib.h
+++ b/tt_metal/hw/inc/mod_div_lib.h
@@ -61,6 +61,14 @@ inline __attribute__((always_inline)) uint32_t fast_udiv_130(uint32_t n)
     return (((uint64_t) n * 0xFC0FC0FD) >> 32) >> 7;
 }
 
+inline __attribute__((always_inline)) uint32_t fast_udiv_140(uint32_t n)
+{
+    // Uses embedding style magic number
+    // * fixed point 1/12 then shifting.
+    // https://web.archive.org/web/20190703172151/http://www.hackersdelight.org/magic.htm
+    return (((uint64_t) n * 0xEA0EA0EB) >> 32) >> 7;
+}
+
 template <uint32_t d>
 inline __attribute__((always_inline)) uint32_t udivsi3_const_divisor(uint32_t n)
 {
@@ -77,6 +85,8 @@ inline __attribute__((always_inline)) uint32_t udivsi3_const_divisor(uint32_t n)
         return fast_udiv_124(n);
     } else if constexpr (d == 130) {
         return fast_udiv_130(n);
+    } else if constexpr (d == 140) {
+        return fast_udiv_140(n);
     } else {
         // generic divide from llvm
         const unsigned n_uword_bits = sizeof(uint32_t) * CHAR_BIT;

--- a/tt_metal/impl/allocator/allocator.cpp
+++ b/tt_metal/impl/allocator/allocator.cpp
@@ -37,8 +37,8 @@ void validate_num_banks(uint32_t num_banks, const BufferType &buffer_type) {
     // Dataflow API does not have a working implementation of generic modulo to determine bank_id for interleaved
     // address gen For non pow2 num banks, special cases need to be added to avoid falling back to generic
     // implementation. See https://github.com/tenstorrent/tt-metal/issues/3321
-    bool custom_mod_bank_id_calculation_exists =
-        (num_banks == 12 or num_banks == 56 or num_banks == 94 or num_banks == 124 or num_banks == 130);
+    std::unordered_set<uint32_t> acceptable_num_non_pow2_mem_banks = {12, 56, 94, 124, 130, 140};
+    bool custom_mod_bank_id_calculation_exists = acceptable_num_non_pow2_mem_banks.count(num_banks) > 0;
     bool doesnt_support_interleaved = buffer_type == BufferType::L1_SMALL;
     bool valid_num_banks = (is_pow2_num_banks or custom_mod_bank_id_calculation_exists or doesnt_support_interleaved);
     if (not valid_num_banks) {

--- a/tt_metal/impl/dispatch/kernels/cq_dispatch.cpp
+++ b/tt_metal/impl/dispatch/kernels/cq_dispatch.cpp
@@ -926,11 +926,11 @@ re_run_command:
             break;
 
         case CQ_DISPATCH_CMD_GO:
-            // DPRINT << "cmd_go" << ENDL();
+            DPRINT << "cmd_go" << ENDL();
             break;
 
         case CQ_DISPATCH_CMD_SINK:
-            // DPRINT << "cmd_sink" << ENDL();
+            DPRINT << "cmd_sink" << ENDL();
             break;
 
         case CQ_DISPATCH_CMD_DEBUG:

--- a/tt_metal/llrt/tt_cluster.cpp
+++ b/tt_metal/llrt/tt_cluster.cpp
@@ -791,10 +791,6 @@ std::unordered_set<chip_id_t> Cluster::get_ethernet_connected_device_ids(chip_id
 std::unordered_set<CoreCoord> Cluster::get_active_ethernet_cores(
     chip_id_t chip_id, bool skip_reserved_tunnel_cores) const {
     std::unordered_set<CoreCoord> active_ethernet_cores;
-    if (this->arch_ == tt::ARCH::BLACKHOLE) {
-        // TODO (abhullar): Uplift with #9823
-        return active_ethernet_cores;
-    }
     const auto &connected_chips = this->get_ethernet_cores_grouped_by_connected_chips(chip_id);
     for (const auto &[other_chip_id, eth_cores] : connected_chips) {
         for (const auto &eth_core : eth_cores) {
@@ -811,18 +807,15 @@ std::unordered_set<CoreCoord> Cluster::get_active_ethernet_cores(
 std::unordered_set<CoreCoord> Cluster::get_inactive_ethernet_cores(chip_id_t chip_id) const {
     std::unordered_set<CoreCoord> active_ethernet_cores = this->get_active_ethernet_cores(chip_id);
     std::unordered_set<CoreCoord> inactive_ethernet_cores;
-    if (this->arch_ == tt::ARCH::BLACKHOLE) {
-        // TODO (abhullar): Uplift with #9823
-        return inactive_ethernet_cores;
-    }
     std::unordered_set<int> channels_to_skip = {};
     // UMD routing FW uses these cores for base routing
     // channel 15 is used by syseng tools.
+    // TODO (abhullar): For BH single-chip bringup we assume all ethernet cores are inactive. Update this with (#9823)
     if (this->is_galaxy_cluster()) {
         // TODO: This may need to change, if we need additional eth cores for dispatch on Galaxy
         channels_to_skip = {0, 1, 2, 3, 15};
     }
-    else {
+    else if (this->arch_ == tt::ARCH::WORMHOLE_B0) {
         channels_to_skip = {8, 9, 15};
     }
     for (const auto &[eth_core, chan] : get_soc_desc(chip_id).logical_eth_core_to_chan_map) {

--- a/tt_metal/soc_descriptors/blackhole_140_arch.yaml
+++ b/tt_metal/soc_descriptors/blackhole_140_arch.yaml
@@ -68,7 +68,7 @@ dram_bank_size:
   4278190080
 
 eth_l1_size:
-  262144
+  524288
 
 arch_name: BLACKHOLE
 


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/9823 (issue not exactly related but in discussing the need for base eth fw, we realized we are unblocked to configure idle erisc cores for FD) 

### Problem description
No support for FD out of idle erisc cores on BH + eth l1 size was set incorrectly 

### What's changed
Added support for FD out of idle erisc cores:
- enable entire core grid for compute
- write series of nops before kernel init to flush icache (https://github.com/tenstorrent/tt-metal/issues/8707)
- mark all eth cores as idle for now 
Updated eth mem map for BH to account for 512KB L1 

### Checklist
- [x] [Post commit CI passes](https://github.com/tenstorrent/tt-metal/actions/runs/10426115091)
- [x] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/runs/10426118828)
- [x] Enabled eth dispatch gtests for BH
