### PR TITLE
#0: Fix corner case for process_relay_paged_cmd_large and typo for inline write for BH

### DIFF
--- a/tt_metal/impl/dispatch/kernels/cq_common.hpp
+++ b/tt_metal/impl/dispatch/kernels/cq_common.hpp
@@ -210,7 +210,7 @@ void cq_noc_inline_dw_write_with_state(uint64_t dst_addr, uint32_t val = 0, uint
     }
     if constexpr (flags & CQ_NOC_FLAG_NOC) {
 #ifdef ARCH_BLACKHOLE
-        NOC_CMD_BUF_WRITE_REG(noc_index, NCRISC_WR_REG_CMD_BUF, NOC_TARG_ADDR_MID, (uint32_t)(dest_addr >> 32) & 0x1000000F);
+        NOC_CMD_BUF_WRITE_REG(noc_index, NCRISC_WR_REG_CMD_BUF, NOC_TARG_ADDR_MID, (uint32_t)(dst_addr >> 32) & 0x1000000F);
 #endif
         NOC_CMD_BUF_WRITE_REG(noc_index, NCRISC_WR_REG_CMD_BUF, NOC_TARG_ADDR_COORDINATE, (uint32_t)(dst_addr >> NOC_ADDR_COORD_SHIFT) & NOC_COORDINATE_MASK);
     }


### PR DESCRIPTION
### Problem description
Watcher asserting for 0 len txns in ./tests/scripts/run_cpp_fd2_tests.sh
BH failing due to typo for new inline write api.

### What's changed
Add checks to avoid reading more than we should in process_relay_paged_cmd_large to avoid looping and issuing 0 len writes.
Fix typo for BH.

### Checklist
- [x] Post commit CI passes
- [x] Blackhole Post commit (if applicable)
- [ ] Model regression CI testing passes (if applicable)
- [x] New/Existing tests provide coverage for changes
