### PR TITLE
#9527: Reverting changes on falcon for t3000

### DIFF
--- a/models/demos/metal_BERT_large_11/tt/bert_model.py
+++ b/models/demos/metal_BERT_large_11/tt/bert_model.py
@@ -78,7 +78,13 @@ class TtBertBatchDram:
         # TODO: Replace with custom op with fused bias?
         def qa_linear_(activation):
             output = ttnn.matmul(activation, weight, memory_config=model_config["QA_LINEAR_OUTPUT_MEMCFG"])
-            output_plus_bias = ttnn.add(output, bias, memory_config=model_config["QA_LINEAR_OUTPUT_MEMCFG"])
+            output_plus_bias = ttnn.experimental.tensor.bcast(
+                output,
+                bias,
+                ttnn.experimental.tensor.BcastOpMath.ADD,
+                ttnn.experimental.tensor.BcastOpDim.H,
+                model_config["QA_LINEAR_OUTPUT_MEMCFG"],
+            )
             return output_plus_bias
 
         self.qa_linear = qa_linear_

--- a/models/demos/t3000/falcon40b/tt/model_utils.py
+++ b/models/demos/t3000/falcon40b/tt/model_utils.py
@@ -480,15 +480,19 @@ def fused_partial_layernorm(
             )
 
             # Apply first layernorm gamma+beta
-            xs_output_slice_1 = ttnn.multiply(
+            xs_output_slice_1 = ttnn.experimental.tensor.bcast(
                 xs_slice,
                 ln_gamma_1,
-                memory_config=memconfig,
+                math_op=ttnn.experimental.tensor.BcastOpMath.MUL,
+                dim=ttnn.experimental.tensor.BcastOpDim.H,
+                output_mem_config=memconfig,
             )
-            xs_output_slice_1 = ttnn.add(
+            xs_output_slice_1 = ttnn.experimental.tensor.bcast(
                 xs_output_slice_1,
                 ln_beta_1,
-                memory_config=memconfig,
+                math_op=ttnn.experimental.tensor.BcastOpMath.ADD,
+                dim=ttnn.experimental.tensor.BcastOpDim.H,
+                output_mem_config=memconfig,
             )
 
             ttnn.sharded_to_interleaved_partial(
@@ -501,15 +505,19 @@ def fused_partial_layernorm(
             xs_output_slice_1.deallocate(True)
 
             # Apply second layernorm gamma+beta inplace
-            xs_slice = ttnn.multiply(
+            xs_slice = ttnn.experimental.tensor.bcast(
                 xs_slice,
                 ln_gamma_2,
-                memory_config=memconfig,
+                math_op=ttnn.experimental.tensor.BcastOpMath.MUL,
+                dim=ttnn.experimental.tensor.BcastOpDim.H,
+                output_mem_config=memconfig,
             )
-            xs_slice = ttnn.add(
+            xs_slice = ttnn.experimental.tensor.bcast(
                 xs_slice,
                 ln_beta_2,
-                memory_config=memconfig,
+                math_op=ttnn.experimental.tensor.BcastOpMath.ADD,
+                dim=ttnn.experimental.tensor.BcastOpDim.H,
+                output_mem_config=memconfig,
             )
 
             ttnn.sharded_to_interleaved_partial(
@@ -535,28 +543,36 @@ def fused_partial_layernorm(
         )
 
         # Apply first layernorm gamma+beta
-        xs_output1 = ttnn.multiply(
+        xs_output1 = ttnn.experimental.tensor.bcast(
             xs_output2,
             ln_gamma_1,
-            memory_config=memconfig,
+            math_op=ttnn.experimental.tensor.BcastOpMath.MUL,
+            dim=ttnn.experimental.tensor.BcastOpDim.H,
+            output_mem_config=memconfig,
         )
-        xs_output1 = ttnn.add(
+        xs_output1 = ttnn.experimental.tensor.bcast(
             xs_output1,
             ln_beta_1,
-            memory_config=memconfig,
+            math_op=ttnn.experimental.tensor.BcastOpMath.ADD,
+            dim=ttnn.experimental.tensor.BcastOpDim.H,
+            output_mem_config=memconfig,
         )
         xs_output1 = ttnn.experimental.tensor.sharded_to_interleaved(xs_output1, output_mem_config=dram_memcfg)
 
         # Apply second layernorm gamma+beta
-        xs_output2 = ttnn.multiply(
+        xs_output2 = ttnn.experimental.tensor.bcast(
             xs_output2,
             ln_gamma_2,
-            memory_config=memconfig,
+            math_op=ttnn.experimental.tensor.BcastOpMath.MUL,
+            dim=ttnn.experimental.tensor.BcastOpDim.H,
+            output_mem_config=memconfig,
         )
-        xs_output2 = ttnn.add(
+        xs_output2 = ttnn.experimental.tensor.bcast(
             xs_output2,
             ln_beta_2,
-            memory_config=memconfig,
+            math_op=ttnn.experimental.tensor.BcastOpMath.ADD,
+            dim=ttnn.experimental.tensor.BcastOpDim.H,
+            output_mem_config=memconfig,
         )
         xs_output2 = ttnn.experimental.tensor.sharded_to_interleaved(xs_output2, output_mem_config=dram_memcfg)
 

--- a/models/experimental/bert/fused_ops/layernorm.py
+++ b/models/experimental/bert/fused_ops/layernorm.py
@@ -114,7 +114,7 @@ def Layernorm(gamma: float, beta: float, epsilon: float, H, W, device, num_dims=
             H_ = overrideH
 
         # first compute the mean (m)
-        means = tensor.sum(x, 3, scalar=1.0 / W)  # -> NCH1
+        means = ttnn.sum(x, 3, scalar=1.0 / W)  # -> NCH1
         x_minus_mean = ttnn.subtract(x, means)  # need to blank out the H for non-multiple of 32
         if False and refx is not None:
             ry, rmean, rvar, rstd, rinvstd, ry1 = ref_ln(refx, refgamma, refbeta)


### PR DESCRIPTION
### Ticket
#9527 

### Problem description
There was a case in the t3000 where bcast is still needing to be used.
We also had a failure on bert and reverting changes here as well.

### What's changed
Reverted code in this case.

### Checklist
- [x] Post commit CI passes (https://github.com/tenstorrent/tt-metal/actions/runs/10430948519)
- [ ] Blackhole Post commit (if applicable)
- [x] Model regression CI testing passes (https://github.com/tenstorrent/tt-metal/actions/runs/10434743534)
- [ ] New/Existing tests provide coverage for changes
