### PR TITLE
#0: Flip shape assert for converting RM to TILE to TT_FATAL

### DIFF
--- a/ttnn/cpp/ttnn/tensor/tensor_impl.hpp
+++ b/ttnn/cpp/ttnn/tensor/tensor_impl.hpp
@@ -213,7 +213,7 @@ static std::vector<uint32_t> to_vector(const Shape& shape) {
 
 template <typename T, template <typename> typename BufferType>
 inline std::vector<T> convert_layout_row_major_to_tile(const Shape& shape, const BufferType<T>& data_to_convert) {
-    TT_ASSERT(
+    TT_FATAL(
         (shape[-2] % tt::constants::TILE_HEIGHT == 0 && shape[-1] % tt::constants::TILE_WIDTH == 0),
         "Unsupported shape for tensor conversion");
     return convert_layout(


### PR DESCRIPTION
### Problem description
This function gets called when calling the user function some_tensor.to(layout).
Should be fatal not assert since this needs to be checked based on user input.

### What's changed
Changed assertion from TT_ASSERT to TT_FATAL.

### Checklist
- [x] Post commit CI passes
- [ ] Blackhole Post commit (if applicable)
- [x] Model regression CI testing passes (if applicable)
- [x] New/Existing tests provide coverage for changes
