### PR TITLE
Enable double buffered EDM channel mode for all-gather

### DIFF
--- a/ttnn/cpp/ttnn/operations/ccl/all_gather/device/all_gather_op.hpp
+++ b/ttnn/cpp/ttnn/operations/ccl/all_gather/device/all_gather_op.hpp
@@ -47,7 +47,6 @@ class AllGatherConfig {
 
     uint32_t get_num_eth_buffers_per_edm() const { return this->num_eth_buffers; }
     uint32_t get_num_workers_per_link() const { return this->num_workers_per_link; }
-    uint32_t get_num_buffers_per_worker() const { return this->num_buffers_per_worker; }
     uint32_t get_num_workers() const { return this->num_workers_per_link * this->num_links; }
 
     uint32_t get_eth_buffer_size() const { return this->eth_buffer_size; }
@@ -57,7 +56,7 @@ class AllGatherConfig {
     uint32_t get_eth_buffers_l1_base_byte_address() const { return this->eth_buffers_l1_base_byte_address; }
 
     uint32_t get_semaphore_size() const { return this->semaphore_size; }
-    std::size_t get_num_buffers_per_channel() const { return this->num_buffers_per_worker; }
+    std::size_t get_num_buffers_per_channel() const { return this->num_edm_buffers_per_channel; }
 
     uint32_t get_num_edm_channels_in_clockwise_direction() const {
         return this->enable_bidirectional ?
@@ -91,7 +90,7 @@ class AllGatherConfig {
         log_trace(tt::LogOp, "\terisc_handshake_address: {}", erisc_handshake_address);
         log_trace(tt::LogOp, "\tnum_buffers: {}", num_eth_buffers);
         log_trace(tt::LogOp, "\tnum_workers_per_link: {}", num_workers_per_link);
-        log_trace(tt::LogOp, "\tnum_buffers_per_worker: {}", num_buffers_per_worker);
+        log_trace(tt::LogOp, "\tnum_edm_buffers_per_channel: {}", num_edm_buffers_per_channel);
         log_trace(tt::LogOp, "\teth_buffer_size: {}", eth_buffer_size);
         log_trace(tt::LogOp, "\tsemaphore_size: {}", semaphore_size);
         log_trace(tt::LogOp, "\tsemaphore_offset: {}", semaphore_offset);
@@ -107,7 +106,7 @@ class AllGatherConfig {
     uint32_t num_links;
     uint32_t num_eth_buffers;
     uint32_t num_workers_per_link;
-    uint32_t num_buffers_per_worker;
+    uint32_t num_edm_buffers_per_channel;
     uint32_t eth_buffer_size;
     uint32_t semaphore_size;
     uint32_t semaphore_offset;

--- a/ttnn/cpp/ttnn/operations/ccl/all_gather/device/kernels/dataflow/worker_interleaved_ring_gather_receive_reader.cpp
+++ b/ttnn/cpp/ttnn/operations/ccl/all_gather/device/kernels/dataflow/worker_interleaved_ring_gather_receive_reader.cpp
@@ -5,58 +5,50 @@
 #include <cstdint>
 #include "dataflow_api.h"
 #include "ttnn/cpp/ttnn/operations/ccl/all_gather/device/kernels/dataflow/worker_ring_gather_utils.hpp"
+#include "ttnn/cpp/ttnn/operations/ccl/kernel_common/worker_edm_adapters.hpp"
+
 
 void kernel_main() {
     constexpr uint32_t num_transfers = get_compile_time_arg_val(0);
     constexpr uint32_t num_full_chunks = get_compile_time_arg_val(1);
     constexpr uint32_t page_size = get_compile_time_arg_val(2);
-    constexpr uint32_t num_pages = get_compile_time_arg_val(3);
+    constexpr uint32_t num_pages_per_full_chunk = get_compile_time_arg_val(3);
     constexpr uint32_t rem_num_pages = get_compile_time_arg_val(4);
     constexpr uint32_t eth_receiver_noc_x = get_compile_time_arg_val(5);
     constexpr uint32_t eth_receiver_noc_y = get_compile_time_arg_val(6);
     constexpr uint32_t eth_receiver_l1_semaphore_addr = get_compile_time_arg_val(7);
-    uint32_t receiver_read_sem_addr = get_semaphore(get_compile_time_arg_val(8));
+    volatile uint32_t *receiver_read_sem_addr = reinterpret_cast<volatile uint32_t *>(get_semaphore(get_compile_time_arg_val(8)));
     constexpr uint32_t half_cb_n_pages = get_compile_time_arg_val(9);
+    constexpr uint32_t num_buffers_per_channel = get_compile_time_arg_val(10);
     static_assert (half_cb_n_pages > rem_num_pages, "half_cb_n_pages must be greater than 0");
 
     const uint32_t eth_receiver_l1_base_addr = get_arg_val<uint32_t>(0);
 
     constexpr uint32_t cb_id_in0 = tt::CB::c_in0;
 
-    // Eth receiver will set this semaphore when data is available
-    volatile tt_l1_ptr uint32_t* receiver_read_semaphore_addr_ptr = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(receiver_read_sem_addr);
+    ccl::edm::WorkerToEdmReader<ttnn::ccl::EriscDataMoverTerminationMode::MESSAGE_COUNT_REACHED> reader(
+        ttnn::ccl::WorkerXY(eth_receiver_noc_x, eth_receiver_noc_y),
+        eth_receiver_l1_base_addr,
+        num_buffers_per_channel,
+        eth_receiver_l1_semaphore_addr,
+        (num_full_chunks > 0 ? num_pages_per_full_chunk : rem_num_pages) * page_size,
+        receiver_read_sem_addr);
 
-    uint32_t total_num_transfers = (num_full_chunks + (rem_num_pages > 0 ? 1 : 0)) * num_transfers;
-    uint32_t eth_core = eth_receiver_noc_x | (eth_receiver_noc_y << 16);
-    uint32_t transfers_completed = 0;
-    // Address of the buffer on the eth receiver, this is different per receiver worker core
-    const uint64_t eth_receiver_l1_base_noc_addr = get_noc_addr(eth_receiver_noc_x, eth_receiver_noc_y, eth_receiver_l1_base_addr);
-    // Address of the semaphore on the eth receiver, this is the same per receiver worker core
-    const uint64_t eth_receiver_l1_semaphore_noc_addr = get_noc_addr(eth_receiver_noc_x, eth_receiver_noc_y, eth_receiver_l1_semaphore_addr);
     for (uint32_t i = 0; i < num_transfers; ++i) {
         if constexpr (num_full_chunks > 0) {
             for (uint32_t c = 0; c < num_full_chunks; ++c) {
-                uint64_t eth_receiver_l1_curr_noc_addr = eth_receiver_l1_base_noc_addr;
-                noc_semaphore_wait(receiver_read_semaphore_addr_ptr, 1);
-                noc_semaphore_set(receiver_read_semaphore_addr_ptr, 0);
-                // Read page by page so that writer can be kicked off instead of being blocked waiting for full chunk to be read
-                // Look into perf/optimizations for this
-                fetch_chunk(cb_id_in0, num_pages, page_size, eth_receiver_l1_base_noc_addr);
-                noc_semaphore_inc(eth_receiver_l1_semaphore_noc_addr, 1);
-                transfers_completed++;
+                reader.wait_for_payload_available();
+                reader.fetch_payload_blocking(cb_id_in0, num_pages_per_full_chunk, page_size, false);
             }
         }
         if constexpr (rem_num_pages > 0) {
-            uint64_t eth_receiver_l1_curr_noc_addr = eth_receiver_l1_base_noc_addr;
-            noc_semaphore_wait(receiver_read_semaphore_addr_ptr, 1);
-            noc_semaphore_set(receiver_read_semaphore_addr_ptr, 0);
-            fetch_chunk(cb_id_in0, rem_num_pages, page_size, eth_receiver_l1_base_noc_addr);
-            noc_semaphore_inc(eth_receiver_l1_semaphore_noc_addr, 1);
-            ASSERT(num_pages == 0 || num_pages > rem_num_pages);
+            reader.wait_for_payload_available();
+            reader.fetch_payload_blocking(cb_id_in0, rem_num_pages, page_size, false);
+            ASSERT(num_pages_per_full_chunk == 0 || num_pages_per_full_chunk > rem_num_pages);
             ASSERT(half_cb_n_pages > rem_num_pages);
             push_filler_pages_to_cb(cb_id_in0, half_cb_n_pages - rem_num_pages);
-            transfers_completed++;
         }
     }
 
+    reader.close();
 }

--- a/ttnn/cpp/ttnn/operations/ccl/all_gather/device/kernels/dataflow/worker_interleaved_ring_gather_send_writer.cpp
+++ b/ttnn/cpp/ttnn/operations/ccl/all_gather/device/kernels/dataflow/worker_interleaved_ring_gather_send_writer.cpp
@@ -6,6 +6,7 @@
 #include "dataflow_api.h"
 #include "ttnn/cpp/ttnn/operations/ccl/all_gather/device/kernels/dataflow/worker_ring_gather_utils.hpp"
 #include "ttnn/cpp/ttnn/operations/ccl/shared_with_host/sharded_tensor_addr_gen.hpp"
+#include "ttnn/cpp/ttnn/operations/ccl/kernel_common/worker_edm_adapters.hpp"
 
 void kernel_main() {
     uint32_t arg_idx = 0;
@@ -27,7 +28,7 @@ void kernel_main() {
     constexpr uint32_t num_full_chunks = get_compile_time_arg_val(2);
     constexpr uint32_t page_size = get_compile_time_arg_val(3);
     constexpr uint32_t output_page_size = get_compile_time_arg_val(4);
-    constexpr uint32_t num_pages = get_compile_time_arg_val(5);
+    constexpr uint32_t num_pages_per_full_chunk = get_compile_time_arg_val(5);
     constexpr uint32_t rem_num_pages = get_compile_time_arg_val(6);
     constexpr uint32_t input_start_idx = get_compile_time_arg_val(7);
     constexpr uint32_t output_start_idx = get_compile_time_arg_val(8);
@@ -39,21 +40,23 @@ void kernel_main() {
     constexpr uint32_t num_rows = get_compile_time_arg_val(14);
     constexpr uint32_t num_cols = get_compile_time_arg_val(15);
     constexpr uint32_t input_start_ring_idx = get_compile_time_arg_val(16);
-    uint32_t writer_send_sem_addr = get_semaphore(get_compile_time_arg_val(17));
+    volatile uint32_t *const writer_send_sem_ptr = reinterpret_cast<volatile uint32_t *const >(get_semaphore(get_compile_time_arg_val(17)));
     constexpr uint32_t eth_sender_noc_x = get_compile_time_arg_val(18);
     constexpr uint32_t eth_sender_noc_y = get_compile_time_arg_val(19);
     constexpr uint32_t half_cb_n_pages = get_compile_time_arg_val(20);
+    constexpr uint32_t num_buffers_per_channel = get_compile_time_arg_val(21);
+
     static_assert(half_cb_n_pages > rem_num_pages, "half_cb_n_pages must be greater than or equal to rem_num_pages");
 
     #ifdef SHARDED_MEM_LAYOUT
-    constexpr tt::tt_metal::TensorMemoryLayout output_tensor_memory_layout = static_cast<tt::tt_metal::TensorMemoryLayout>(get_compile_time_arg_val(21));
-    constexpr uint32_t output_tensor_shard_grid_height = get_compile_time_arg_val(22);
-    constexpr uint32_t output_tensor_shard_grid_width = get_compile_time_arg_val(23);
-    constexpr uint32_t output_tensor_shard_grid_start_y_logical = get_compile_time_arg_val(24);
-    constexpr uint32_t output_tensor_shard_grid_start_x_logical = get_compile_time_arg_val(25);
-    constexpr uint32_t output_tensor_shard_pages_per_shard_y = get_compile_time_arg_val(26);
-    constexpr uint32_t output_tensor_shard_pages_per_shard_x = get_compile_time_arg_val(27);
-    constexpr bool output_tensor_shard_grid_transposed = get_compile_time_arg_val(28) != 0;
+    constexpr tt::tt_metal::TensorMemoryLayout output_tensor_memory_layout = static_cast<tt::tt_metal::TensorMemoryLayout>(get_compile_time_arg_val(22));
+    constexpr uint32_t output_tensor_shard_grid_height = get_compile_time_arg_val(23);
+    constexpr uint32_t output_tensor_shard_grid_width = get_compile_time_arg_val(24);
+    constexpr uint32_t output_tensor_shard_grid_start_y_logical = get_compile_time_arg_val(25);
+    constexpr uint32_t output_tensor_shard_grid_start_x_logical = get_compile_time_arg_val(26);
+    constexpr uint32_t output_tensor_shard_pages_per_shard_y = get_compile_time_arg_val(27);
+    constexpr uint32_t output_tensor_shard_pages_per_shard_x = get_compile_time_arg_val(28);
+    constexpr bool output_tensor_shard_grid_transposed = get_compile_time_arg_val(29) != 0;
     #endif
 
     constexpr uint32_t cb_id_in0 = tt::CB::c_in0;
@@ -105,32 +108,32 @@ void kernel_main() {
         #endif
     #endif
 
-    // Used to wait until eth sender has space available
-    volatile tt_l1_ptr uint32_t* writer_send_semaphore_addr_ptr = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(writer_send_sem_addr);
+    ccl::edm::WorkerToEdmSender<ttnn::ccl::EriscDataMoverTerminationMode::MESSAGE_COUNT_REACHED> sender(
+        ttnn::ccl::WorkerXY(eth_sender_noc_x, eth_sender_noc_y),
+        eth_sender_l1_base_addr,
+        num_buffers_per_channel,
+        eth_sender_l1_sem_addr,
+        (num_full_chunks > 0 ? num_pages_per_full_chunk : rem_num_pages) * page_size,
+        writer_send_sem_ptr);
 
     uint32_t output_page_idx = output_start_idx;
     uint32_t col_idx = col_start_idx;
     uint32_t row_idx = row_start_idx;
     // This is different per writer core
-    const uint64_t eth_l1_sender_base_noc_addr = get_noc_addr(eth_sender_noc_x, eth_sender_noc_y, eth_sender_l1_base_addr);
-    // Used to signal eth sender that data is available. This is different per writer core
-    const uint64_t eth_l1_sender_semaphore_addr = get_noc_addr(eth_sender_noc_x, eth_sender_noc_y, eth_sender_l1_sem_addr);
 
     uint32_t ID = (my_y[0] << 16) | my_x[0];
 
     if constexpr(num_full_chunks > 0) {
         for (uint32_t c = 0; c < num_full_chunks; ++c) {
-            noc_semaphore_wait(writer_send_semaphore_addr_ptr, 1);
-            noc_semaphore_set(writer_send_semaphore_addr_ptr, 0);
-            write_and_send_chunk(output_page_idx, col_idx, row_idx, cb_id_in0, d, num_cols, num_rows, col_offset, row_offset, num_pages, page_size, eth_l1_sender_base_noc_addr, eth_l1_sender_semaphore_addr);
+            sender.wait_for_empty_write_slot();
+            write_and_send_chunk(output_page_idx, col_idx, row_idx, cb_id_in0, d, num_cols, num_rows, col_offset, row_offset, num_pages_per_full_chunk, page_size, sender);
         }
     }
 
     if constexpr(rem_num_pages > 0) {
-        noc_semaphore_wait(writer_send_semaphore_addr_ptr, 1);
-        noc_semaphore_set(writer_send_semaphore_addr_ptr, 0);
-        write_and_send_chunk(output_page_idx, col_idx, row_idx, cb_id_in0, d, num_cols, num_rows, col_offset, row_offset, rem_num_pages, page_size, eth_l1_sender_base_noc_addr,eth_l1_sender_semaphore_addr);
-        ASSERT(num_pages == 0 || num_pages > rem_num_pages);
+        sender.wait_for_empty_write_slot();
+        write_and_send_chunk(output_page_idx, col_idx, row_idx, cb_id_in0, d, num_cols, num_rows, col_offset, row_offset, rem_num_pages, page_size, sender);
+        ASSERT(num_pages_per_full_chunk == 0 || num_pages_per_full_chunk > rem_num_pages);
         ASSERT(half_cb_n_pages > rem_num_pages);
         pop_filler_pages_from_cb(cb_id_in0, half_cb_n_pages - rem_num_pages);
     }
@@ -139,20 +142,18 @@ void kernel_main() {
     for (uint32_t i = 1; i < num_transfers; ++i) {
         if constexpr(num_full_chunks > 0) {
             for (uint32_t c = 0; c < num_full_chunks; ++c) {
-                noc_semaphore_wait(writer_send_semaphore_addr_ptr, 1);
-                noc_semaphore_set(writer_send_semaphore_addr_ptr, 0);
-                send_chunk(cb_id_in0, num_pages, page_size, eth_l1_sender_base_noc_addr);
-                noc_semaphore_inc(eth_l1_sender_semaphore_addr, 1);
+                sender.wait_for_empty_write_slot();
+                sender.send_payload_blocking(cb_id_in0, num_pages_per_full_chunk, page_size);
             }
         }
         if constexpr(rem_num_pages > 0) {
-            noc_semaphore_wait(writer_send_semaphore_addr_ptr, 1);
-            noc_semaphore_set(writer_send_semaphore_addr_ptr, 0);
-            send_chunk(cb_id_in0, rem_num_pages, page_size, eth_l1_sender_base_noc_addr);
-            noc_semaphore_inc(eth_l1_sender_semaphore_addr, 1);
-            ASSERT(num_pages == 0 || num_pages > rem_num_pages);
+            sender.wait_for_empty_write_slot();
+            sender.send_payload_blocking(cb_id_in0, rem_num_pages, page_size);
+            ASSERT(num_pages_per_full_chunk == 0 || num_pages_per_full_chunk > rem_num_pages);
             ASSERT(half_cb_n_pages > rem_num_pages);
             pop_filler_pages_from_cb(cb_id_in0, half_cb_n_pages - rem_num_pages);
         }
     }
+
+    sender.close();
 }

--- a/ttnn/cpp/ttnn/operations/ccl/ccl_host_datastructures.cpp
+++ b/ttnn/cpp/ttnn/operations/ccl/ccl_host_datastructures.cpp
@@ -59,36 +59,11 @@ CCLOpConfig::CCLOpConfig(
     input_sharded(input_tensors.at(0).is_sharded()),
     output_sharded(output_tensors.at(0).is_sharded()),
     page_size(input_tensors.at(0).buffer()->page_size()),
-    input_shard_size_bytes(
-        input_tensors.at(0).is_sharded() ? static_cast<std::optional<uint32_t>>(
-                                                (input_tensors.at(0).buffer()->page_size() *
-                                                input_tensors.at(0).buffer()->shard_spec().tensor2d_shape[0] *
-                                                input_tensors.at(0).buffer()->shard_spec().tensor2d_shape[1]) /
-                                                input_tensors.at(0).shard_spec()->num_cores())
-                                            : std::nullopt),
-    output_shard_size_bytes(
-        output_tensors.at(0).is_sharded() ? static_cast<std::optional<uint32_t>>(
-                                                (output_tensors.at(0).buffer()->page_size() *
-                                                    output_tensors.at(0).buffer()->shard_spec().tensor2d_shape[0] *
-                                                    output_tensors.at(0).buffer()->shard_spec().tensor2d_shape[1]) /
-                                                input_tensors.at(0).shard_spec()->num_cores())
-                                            : std::nullopt),
     shard_grid_size(output_tensors.at(0).is_sharded() ? input_tensors.at(0).shard_spec()->num_cores() : 0),
     topology(topology),
     is_row_major(input_tensors.at(0).get_layout() == Layout::ROW_MAJOR) {
-    TT_ASSERT(!this->is_input_sharded() || input_shard_size_bytes.has_value());
-    TT_ASSERT(!this->is_output_sharded() || output_shard_size_bytes.has_value());
 }
 
-uint32_t CCLOpConfig::get_input_shard_size_bytes() const {
-    TT_ASSERT(input_shard_size_bytes.has_value());
-    return input_shard_size_bytes.value();
-}
-
-uint32_t CCLOpConfig::get_output_shard_size_bytes() const {
-    TT_ASSERT(output_shard_size_bytes.has_value());
-    return output_shard_size_bytes.value();
-}
 
 uint32_t CCLOpConfig::get_page_size() const { return this->page_size; }
 

--- a/ttnn/cpp/ttnn/operations/ccl/ccl_host_datastructures.hpp
+++ b/ttnn/cpp/ttnn/operations/ccl/ccl_host_datastructures.hpp
@@ -48,8 +48,6 @@ struct CCLOpConfig {
     CCLOpConfig(
         std::vector<Tensor>& input_tensors, const std::vector<Tensor>& output_tensors, Topology topology);
 
-    uint32_t get_input_shard_size_bytes() const;
-    uint32_t get_output_shard_size_bytes() const;
     uint32_t get_page_size() const;
     Topology get_topology() const;
     bool is_input_sharded() const;
@@ -60,8 +58,6 @@ struct CCLOpConfig {
     std::map<string, string> emit_worker_defines() const;
 
    private:
-    std::optional<uint32_t> input_shard_size_bytes;
-    std::optional<uint32_t> output_shard_size_bytes;
     uint32_t page_size;
     uint32_t shard_grid_size;
     Topology topology;

--- a/ttnn/cpp/ttnn/operations/ccl/kernel_common/worker_edm_utils.hpp
+++ b/ttnn/cpp/ttnn/operations/ccl/kernel_common/worker_edm_utils.hpp
@@ -20,8 +20,14 @@ static FORCE_INLINE coord_t coord_from_args(uint32_t& arg_idx) {
     return coord_t(x, y);
 }
 
+enum EDM_IO_BLOCKING_MODE {
+    BLOCKING,
+    NON_BLOCKING
+};
+
 }  // namespace ccl
 }  // namespace ttnn
+
 
 FORCE_INLINE void push_filler_pages_to_cb(const uint32_t& cb_id, uint32_t num_pages) {
     ASSERT(num_pages < cb_interface[cb_id].fifo_num_pages);
@@ -42,33 +48,15 @@ FORCE_INLINE void fetch_chunk(
     noc_async_read_barrier();
     cb_push_back(cb_id, num_pages);
 }
-FORCE_INLINE void fetch_chunk_sharded(
-    const uint32_t& cb_id, const uint32_t& num_pages, const uint32_t& page_size, uint64_t remote_l1_read_addr) {
-    cb_reserve_back(cb_id, num_pages);
-    uint32_t l1_write_addr = get_write_ptr(cb_id);
-    noc_async_read(remote_l1_read_addr, l1_write_addr, num_pages * page_size);
-    noc_async_read_barrier();
-    cb_push_back(cb_id, num_pages);
-}
 
+template<ttnn::ccl::EDM_IO_BLOCKING_MODE blocking_mode = ttnn::ccl::EDM_IO_BLOCKING_MODE::BLOCKING>
 FORCE_INLINE void send_chunk(
     const uint32_t& cb_id, const uint32_t& num_pages, const uint32_t& page_size, uint64_t remote_l1_write_addr) {
     cb_wait_front(cb_id, num_pages);
     uint32_t l1_read_addr = get_read_ptr(cb_id);
     noc_async_write(l1_read_addr, remote_l1_write_addr, page_size * num_pages);
-    noc_async_write_barrier();
-    cb_pop_front(cb_id, num_pages);
-}
-FORCE_INLINE void send_chunk_sharded(
-    const uint32_t& cb_id,
-    const uint32_t& num_pages,
-    const uint32_t& page_size,
-    uint64_t remote_l1_write_addr,
-    uint64_t eth_l1_sender_semaphore_addr) {
-    cb_wait_front(cb_id, num_pages);
-    uint32_t l1_read_addr = get_read_ptr(cb_id);
-    noc_async_write(l1_read_addr, remote_l1_write_addr, page_size * num_pages);
-    noc_semaphore_inc(eth_l1_sender_semaphore_addr, 1);
-    noc_async_write_barrier();
-    cb_pop_front(cb_id, num_pages);
+    if constexpr (blocking_mode == ttnn::ccl::EDM_IO_BLOCKING_MODE::BLOCKING) {
+        noc_async_write_barrier();
+        cb_pop_front(cb_id, num_pages);
+    }
 }


### PR DESCRIPTION
### Ticket
[Link to Github Issue](https://github.com/tenstorrent/tt-metal/issues/11608)

### Problem description
Perf opportunity

### What's changed
Enable double buffering of EDM channels for the all-gather op for improved latency hiding.

### Note on perf drops. 
Those are all line-all-gather tests and while investigating the performance delta I've identified a performance reporting "problem" for line allgather that is unique to lines and leads to uncomparable number. The issue is that, especially with async mode, the chip dispatch order varies and in some cases the last programmed chip is a middle chip, and in other cases it is an end chip. In the case of an end chip, the overall latency would much worse because the data going out would not start going until the last chip starts. However, if the middle chips are programmed last, the data has less distance to travel after the kernels start on those chips. 

### Checklist
- [x] Post commit CI passes: https://github.com/tenstorrent/tt-metal/actions/runs/10446454699
- [x] t3000 frequent: https://github.com/tenstorrent/tt-metal/actions/runs/10455203888
- [x] t3000 model perf: https://github.com/tenstorrent/tt-metal/actions/runs/10455194758
- [x] Blackhole Post commit (if applicable)
- [x] Model regression CI testing passes (if applicable)
- [x] New/Existing tests provide coverage for changes


# New Perf
<img width="1233" alt="image" src="https://github.com/user-attachments/assets/3a078997-caa7-4364-ae86-75d7f31db7d5">

## Some Highlights
23k cycle 32x8192, bfp8 8 chip allgather 
-> ~13k cycle reduction
67k cycle 32x32768, bfp8, 8 chip allgather 
-> ~9k cycle reduction
=> further total of 48k cycles saving per layer for llama, falcon

First  20GBps e2e all-gathers measured
