### PR TITLE
#0: Fix length_adjust max value in test_prefetcher

### DIFF
--- a/tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/test_prefetcher.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/test_prefetcher.cpp
@@ -817,7 +817,7 @@ void gen_rnd_dram_paged_cmd(Device *device,
 
     uint32_t length_adjust = std::rand() % page_size;
     length_adjust = (length_adjust >> 5) << 5;
-    if (length_adjust > 64 * 1024) length_adjust = 63 * 1024;
+    if (length_adjust >= 64 * 1024) length_adjust = 63 * 1024;
 
     if (device_data.size() * sizeof(uint32_t) + page_size * pages - length_adjust + l1_buf_base_g >=
         device->l1_size_per_core()) {


### PR DESCRIPTION
### Problem description
Wrong comparison operator was used, so we could choose a value that overflows to 0

### What's changed
Changed comparison to prevent overflow

### Checklist
- [x] Post commit CI passes
- [x] New/Existing tests provide coverage for changes
