### PR TITLE
Update cq_prefetch to use stateful noc apis when writing downstream

### DIFF
--- a/tests/scripts/run_cpp_fd2_tests.sh
+++ b/tests/scripts/run_cpp_fd2_tests.sh
@@ -30,7 +30,7 @@ run_test() {
 
 run_test_with_watcher() {
     echo $1
-    TT_METAL_WATCHER=1 $1
+    TT_METAL_WATCHER=1 TT_METAL_WATCHER_NOINLINE=1 $1
     echo
 };
 

--- a/tt_metal/impl/dispatch/kernels/cq_prefetch.cpp
+++ b/tt_metal/impl/dispatch/kernels/cq_prefetch.cpp
@@ -1103,7 +1103,7 @@ bool process_cmd(uint32_t& cmd_ptr,
                  uint32_t& downstream_data_ptr,
                  uint32_t& stride) {
 
-    DeviceZoneScopedND("PROCESS-CMD", block_noc_writes_to_clear, rd_block_idx );
+    // DeviceZoneScopedND("PROCESS-CMD", block_noc_writes_to_clear, rd_block_idx );
     volatile CQPrefetchCmd tt_l1_ptr *cmd = (volatile CQPrefetchCmd tt_l1_ptr *)cmd_ptr;
     bool done = false;
 

--- a/tt_metal/impl/dispatch/kernels/cq_prefetch.cpp
+++ b/tt_metal/impl/dispatch/kernels/cq_prefetch.cpp
@@ -1103,7 +1103,7 @@ bool process_cmd(uint32_t& cmd_ptr,
                  uint32_t& downstream_data_ptr,
                  uint32_t& stride) {
 
-    // DeviceZoneScopedND("PROCESS-CMD", block_noc_writes_to_clear, rd_block_idx );
+    // DeviceZoneScopedNDC("PROCESS-CMD", block_noc_writes_to_clear, rd_block_idx, ProgramNocCoord::RESTORE_NOC_COORD );
     volatile CQPrefetchCmd tt_l1_ptr *cmd = (volatile CQPrefetchCmd tt_l1_ptr *)cmd_ptr;
     bool done = false;
 
@@ -1418,7 +1418,7 @@ void kernel_main_hd() {
     bool done = false;
     uint32_t heartbeat = 0;
     while (!done) {
-        DeviceZoneScopedND("KERNEL-MAIN-HD", block_noc_writes_to_clear, rd_block_idx );
+        DeviceZoneScopedNDC("KERNEL-MAIN-HD", block_noc_writes_to_clear, rd_block_idx, ProgramNocCoord::RESTORE_NOC_COORD );
         constexpr uint32_t preamble_size = 0;
         fetch_q_get_cmds<preamble_size>(fence, cmd_ptr, pcie_read_ptr);
 


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/11578

### Problem description
cq_prefetch used generic noc write apis which constantly reprograms registers like noc coord, when prefetcher only ever writes to a single target so doesn't need to be reprogrammed.

### What's changed
Use stateful noc apis for downstream writes for prefetcher

### Checklist
- [ ] Post commit CI passes
- [ ] Blackhole Post commit (if applicable)
- [ ] Model regression CI testing passes (if applicable)
- [ ] New/Existing tests provide coverage for changes
