### PR TITLE
#11442: Start using GitHub cache to start doing incremental builds 

### DIFF
--- a/.github/workflows/build-artifact.yaml
+++ b/.github/workflows/build-artifact.yaml
@@ -60,8 +60,8 @@ jobs:
         run: |
           git submodule update --init --recursive
       - name: Cache build artifacts
-        id: cache-build-artifacts
-        uses: actions/cache@v4
+        id: restore-cache-build-artifacts
+        uses: actions/cache/restore@v4
         with:
           path: build/
           key: build-${{ inputs.build-type }}-${{ matrix.arch }}-${{ inputs.tracy && 'tracy' || 'notracy' }}-${{ github.sha }}
@@ -87,3 +87,10 @@ jobs:
           find build/ -type f -name "*hxx*"
           rm -rf $(find build/ -type f -name "*hxx*")
           rm build/CMakeCache.txt
+      - name: Save build artifacts to cache for incremental builds
+        if: ${{ github.ref == 'refs/heads/main' }}
+        id: save-cache-build-artifacts
+        uses: actions/cache/save@v4
+        with:
+          path: build/
+          key: ${{ steps.restore-cache-build-artifacts.outputs.cache-primary-key }}

--- a/.github/workflows/build-artifact.yaml
+++ b/.github/workflows/build-artifact.yaml
@@ -67,7 +67,6 @@ jobs:
       - name: Re-generate CMake project
         run: nice -n 19 cmake -B build -G Ninja -DCMAKE_BUILD_TYPE=${{ inputs.build-type }} -DENABLE_TRACY=${{ inputs.tracy }}
       - name: Build tt-metal and libs
-        if: ${{ steps.cache-build-artifacts.outputs.cache-hit != 'true' }}
         run: nice -n 19 cmake --build build --target tests
       - name: Install libs
         run: nice -n 19 cmake --build build --target install

--- a/.github/workflows/build-artifact.yaml
+++ b/.github/workflows/build-artifact.yaml
@@ -62,13 +62,14 @@ jobs:
         uses: actions/cache@v4
         with:
           path: build/
-          key: build-${{ github.sha }}-${{ matrix.arch }}-${{ inputs.build-type }}-${{ inputs.tracy && 'tracy' }}
+          key: build-${{ inputs.build-type }}-${{ matrix.arch }}-${{ inputs.tracy && 'tracy' || 'notracy' }}-${{ github.sha }}
       - name: Build tt-metal and libs
         if: ${{ steps.cache-build-artifacts.outputs.cache-hit != 'true' }}
         run: |
           nice -n 19 cmake -B build -G Ninja -DCMAKE_BUILD_TYPE=${{ inputs.build-type }} -DENABLE_TRACY=${{ inputs.tracy }}
           nice -n 19 cmake --build build --target tests
-          nice -n 19 cmake --build build --target install
+      - name: Install libs
+        run: nice -n 19 cmake --build build --target install
       - name: 'Tar files'
         run: tar -cvf ttm_${{ matrix.arch }}.tar build/lib ttnn/ttnn/*.so build/programming_examples build/test build/tools runtime
       - name: 'Upload Artifact'

--- a/.github/workflows/build-artifact.yaml
+++ b/.github/workflows/build-artifact.yaml
@@ -21,7 +21,7 @@ on:
       arch:
         required: false
         type: string
-        default: '["grayskull", "wormhole_b0"]'
+        default: '["wormhole_b0"]'
       build-type:
         required: false
         type: choice
@@ -30,6 +30,7 @@ on:
           - Debug
           - RelWithDebInfo
           - CI
+        default: "Release"
       tracy:
         required: false
         type: boolean
@@ -63,11 +64,11 @@ jobs:
         with:
           path: build/
           key: build-${{ inputs.build-type }}-${{ matrix.arch }}-${{ inputs.tracy && 'tracy' || 'notracy' }}-${{ github.sha }}
+      - name: Re-generate CMake project
+        run: nice -n 19 cmake -B build -G Ninja -DCMAKE_BUILD_TYPE=${{ inputs.build-type }} -DENABLE_TRACY=${{ inputs.tracy }}
       - name: Build tt-metal and libs
         if: ${{ steps.cache-build-artifacts.outputs.cache-hit != 'true' }}
-        run: |
-          nice -n 19 cmake -B build -G Ninja -DCMAKE_BUILD_TYPE=${{ inputs.build-type }} -DENABLE_TRACY=${{ inputs.tracy }}
-          nice -n 19 cmake --build build --target tests
+        run: nice -n 19 cmake --build build --target tests
       - name: Install libs
         run: nice -n 19 cmake --build build --target install
       - name: 'Tar files'

--- a/.github/workflows/build-artifact.yaml
+++ b/.github/workflows/build-artifact.yaml
@@ -21,7 +21,7 @@ on:
       arch:
         required: false
         type: string
-        default: '["wormhole_b0"]'
+        default: '["grayskull", "wormhole_b0"]'
       build-type:
         required: false
         type: choice
@@ -36,6 +36,7 @@ on:
         type: boolean
         default: false
         description: "Build with tracy enabled"
+
 jobs:
   build-artifact:
     strategy:
@@ -64,6 +65,8 @@ jobs:
         with:
           path: build/
           key: build-${{ inputs.build-type }}-${{ matrix.arch }}-${{ inputs.tracy && 'tracy' || 'notracy' }}-${{ github.sha }}
+          restore-keys:
+            build-${{ inputs.build-type }}-${{ matrix.arch }}-${{ inputs.tracy && 'tracy' || 'notracy' }}
       - name: Re-generate CMake project
         run: nice -n 19 cmake -B build -G Ninja -DCMAKE_BUILD_TYPE=${{ inputs.build-type }} -DENABLE_TRACY=${{ inputs.tracy }}
       - name: Build tt-metal and libs
@@ -79,6 +82,8 @@ jobs:
           path: ttm_${{ matrix.arch }}.tar
       - name: Remove files for incremental builds
         run: |
+          # Pre-compiled headers and CMakeCache rely on mtime and build host paths respectively, so
+          # hard to transfer between machines
           find build/ -type f -name "*hxx*"
           rm -rf $(find build/ -type f -name "*hxx*")
           rm build/CMakeCache.txt

--- a/.github/workflows/build-artifact.yaml
+++ b/.github/workflows/build-artifact.yaml
@@ -59,7 +59,7 @@ jobs:
       - name: Update submodules
         run: |
           git submodule update --init --recursive
-      - name: Cache build artifacts
+      - name: Restore cached build artifacts
         id: restore-cache-build-artifacts
         uses: actions/cache/restore@v4
         with:

--- a/.github/workflows/build-artifact.yaml
+++ b/.github/workflows/build-artifact.yaml
@@ -57,7 +57,14 @@ jobs:
       - name: Update submodules
         run: |
           git submodule update --init --recursive
+      - name: Cache build artifacts
+        id: cache-build-artifacts
+        uses: actions/cache@v4
+        with:
+          path: build/
+          key: build-${{ github.sha }}-${{ matrix.arch }}-${{ inputs.build-type }}-${{ inputs.tracy && 'tracy' }}
       - name: Build tt-metal and libs
+        if: ${{ steps.cache-build-artifacts.outputs.cache-hit != 'true' }}
         run: |
           nice -n 19 cmake -B build -G Ninja -DCMAKE_BUILD_TYPE=${{ inputs.build-type }} -DENABLE_TRACY=${{ inputs.tracy }}
           nice -n 19 cmake --build build --target tests

--- a/.github/workflows/build-artifact.yaml
+++ b/.github/workflows/build-artifact.yaml
@@ -77,3 +77,8 @@ jobs:
         with:
           name: TTMetal_build_${{ matrix.arch }}${{ (inputs.tracy && '_profiler') || '' }}
           path: ttm_${{ matrix.arch }}.tar
+      - name: Remove files for incremental builds
+        run: |
+          find build/ -type f -name "*hxx*"
+          rm -rf $(find build/ -type f -name "*hxx*")
+          rm build/CMakeCache.txt


### PR DESCRIPTION
### Ticket

#11442 

### Problem description

We want to start doing incremental builds. We can start with baby steps by:

- incrementally building stuff from binaries in main only (hence we can do something where we save to cache only in main)
- key by commit / arch / tracy / build type for now. As we see it working stably, we can slowly loosen the bounds on this key so that we can have more matches
- Later on, we can put a restore key to restore from artifacts in main

### What's changed

Cache build folder

### Checklist
- [ ] Post commit CI passes
- [ ] Blackhole Post commit (if applicable)
- [ ] Model regression CI testing passes (if applicable)
- [ ] New/Existing tests provide coverage for changes
