### PR TITLE
#11488: remove `-Wno-c++23-extensions` flag

### DIFF
--- a/cmake/compilers.cmake
+++ b/cmake/compilers.cmake
@@ -33,7 +33,7 @@ endfunction()
 function(ADJUST_COMPILER_WARNINGS)
     if(CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
         target_compile_options(compiler_warnings INTERFACE
-            -Wsometimes-uninitialized -Wno-c++11-narrowing -Wno-c++23-extensions -Wno-error=local-type-template-args
+            -Wsometimes-uninitialized -Wno-c++11-narrowing -Wno-error=local-type-template-args
             -Wno-delete-non-abstract-non-virtual-dtor -Wno-c99-designator -Wno-shift-op-parentheses -Wno-non-c-typedef-for-linkage
             -Wno-deprecated-this-capture -Wno-deprecated-volatile -Wno-deprecated-builtins -Wno-deprecated-declarations
         )


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/11488

### Problem description
Remove flag so compiler can pick up C++23 features and warn against them.

### What's changed
Removed the flag

### Checklist
- [x] Post commit CI passes: https://github.com/tenstorrent/tt-metal/actions/runs/10462459938
