### PR TITLE
#11632: fix reduce scatter regression

### DIFF
--- a/ttnn/cpp/ttnn/operations/ccl/reduce_scatter/device/host/reduce_scatter_full_worker_grid.cpp
+++ b/ttnn/cpp/ttnn/operations/ccl/reduce_scatter/device/host/reduce_scatter_full_worker_grid.cpp
@@ -765,8 +765,8 @@ operation::ProgramWithCallbacks reduce_scatter_with_workers(
     auto worker_receiver_semaphore_id = tt::tt_metal::CreateSemaphore(program, worker_core_range, 0);
     auto worker_sender_semaphore_id = tt::tt_metal::CreateSemaphore(program, worker_core_range, 0);
 
-    uint32_t cb_num_pages =
-        (cw_per_link_edm_builders.at(0).get_eth_buffer_size_bytes() / op_config.get_page_size()) * 2;
+    uint32_t cb_num_pages = std::min(input_tensor_num_units_per_tensor_slice,
+        (cw_per_link_edm_builders.at(0).get_eth_buffer_size_bytes() / op_config.get_page_size())) * 2;
     uint32_t cb_num_pages_per_packet = cb_num_pages / 2;
     log_trace(tt::LogOp, "cb_num_pages: {}", cb_num_pages);
     auto const& [cb_src0_workers, cb_src1_workers, cb_dst0_sender_workers, cb_short_circuit_sender_workers] =


### PR DESCRIPTION
### Ticket
#11632 

### Problem description
After change, for single core shard grids, reduce scatter requested too much memory for CBs

### What's changed
Don't allocate more than total tensor size.

### Checklist
- [x] Post commit CI passes: https://github.com/tenstorrent/tt-metal/actions/runs/10463972466
- [x] t3k frequent: https://github.com/tenstorrent/tt-metal/actions/runs/10463970828
- [x] tg frequent: https://github.com/tenstorrent/tt-metal/actions/runs/10463973843
- [x] t3k nightly: https://github.com/tenstorrent/tt-metal/actions/runs/10463991073
- [x] Blackhole Post commit (if applicable)
- [x] Model regression CI testing passes (if applicable): https://github.com/tenstorrent/tt-metal/actions/runs/10464001377
- [x] New/Existing tests provide coverage for changes
