### PR TITLE
#11647: Move logical inplace ops to binary.cpp

### DIFF
--- a/ttnn/cpp/ttnn/operations/eltwise/binary/binary.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary/binary.cpp
@@ -487,6 +487,14 @@ Tensor InplaceRelationalBinary<binary_op_type>::invoke(
     return RelationalBinary<binary_op_type>::invoke(input_tensor_a, scalar, std::nullopt, std::nullopt, input_tensor_a, std::nullopt, std::nullopt);
 }
 
+template <BinaryOpType binary_op_type>
+Tensor InplaceLogicalBinary<binary_op_type>::invoke(
+    const Tensor &input_tensor_a_arg,
+    const Tensor &input_tensor_b_arg) {
+
+    return BinaryOperation<binary_op_type, false>::invoke(input_tensor_a_arg, input_tensor_b_arg, std::nullopt, std::nullopt, input_tensor_a_arg, std::nullopt, std::nullopt);
+}
+
 template struct BinaryOperationOverload<BinaryOpType::ADD, false>;
 template struct BinaryOperation<BinaryOpType::ADD, true>;
 template struct BinaryOperationOverload<BinaryOpType::SUB, false>;
@@ -514,5 +522,8 @@ template struct InplaceRelationalBinary<BinaryOpType::LT>;
 template struct InplaceRelationalBinary<BinaryOpType::GTE>;
 template struct InplaceRelationalBinary<BinaryOpType::LTE>;
 
+
+template struct InplaceLogicalBinary<BinaryOpType::LOGICAL_AND>;
+template struct InplaceLogicalBinary<BinaryOpType::LOGICAL_OR>;
 
 }  // namespace ttnn::operations::binary

--- a/ttnn/cpp/ttnn/operations/eltwise/binary/binary.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary/binary.hpp
@@ -171,6 +171,13 @@ struct InplaceRelationalBinary {
         const float scalar);
 };
 
+template <BinaryOpType binary_op_type>
+struct InplaceLogicalBinary {
+    static Tensor invoke(
+        const Tensor& input_tensor_a,
+        const Tensor& input_tensor_b);
+};
+
 }  // binary
 }  // operations
 
@@ -243,6 +250,12 @@ constexpr auto le_ = ttnn::register_operation_with_auto_launch_op<
 constexpr auto lt_ = ttnn::register_operation_with_auto_launch_op<
     "ttnn::lt_",
     operations::binary::InplaceRelationalBinary<operations::binary::BinaryOpType::LT>>();
+constexpr auto logical_and_ = ttnn::register_operation_with_auto_launch_op<
+    "ttnn::logical_and_",
+    operations::binary::InplaceLogicalBinary<operations::binary::BinaryOpType::LOGICAL_AND>>();
+constexpr auto logical_or_ = ttnn::register_operation_with_auto_launch_op<
+    "ttnn::logical_or_",
+    operations::binary::InplaceLogicalBinary<operations::binary::BinaryOpType::LOGICAL_OR>>();
 
 template <typename InputBType>
 ttnn::Tensor operator+(const ttnn::Tensor &input_tensor_a, InputBType scalar) {

--- a/ttnn/cpp/ttnn/operations/eltwise/binary/binary_composite.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary/binary_composite.hpp
@@ -233,12 +233,6 @@ constexpr auto div_no_nan = ttnn::register_operation_with_auto_launch_op<
 constexpr auto floor_div = ttnn::register_operation_with_auto_launch_op<
     "ttnn::floor_div",
     operations::binary::ExecuteDivLikeOps<operations::binary::BinaryCompositeOpType::FLOOR_DIV>>();
-constexpr auto logical_and_ = ttnn::register_operation_with_auto_launch_op<
-    "ttnn::logical_and_",
-    operations::binary::ExecuteBinaryCompositeOps<operations::binary::BinaryCompositeOpType::LOGICAL_AND_>>();
-constexpr auto logical_or_ = ttnn::register_operation_with_auto_launch_op<
-    "ttnn::logical_or_",
-    operations::binary::ExecuteBinaryCompositeOps<operations::binary::BinaryCompositeOpType::LOGICAL_OR_>>();
 constexpr auto logical_xor_ = ttnn::register_operation_with_auto_launch_op<
     "ttnn::logical_xor_",
     operations::binary::ExecuteBinaryCompositeOps<operations::binary::BinaryCompositeOpType::LOGICAL_XOR_>>();

--- a/ttnn/cpp/ttnn/operations/eltwise/binary/binary_pybind.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary/binary_pybind.hpp
@@ -634,6 +634,40 @@ void bind_inplace_operation(py::module& module, const binary_operation_t& operat
             py::arg("input_a"),
             py::arg("input_b")});
 }
+
+template <typename binary_operation_t>
+void bind_logical_inplace_operation(py::module& module, const binary_operation_t& operation, const std::string& description) {
+    auto doc = fmt::format(
+        R"doc({0}(input_a: ttnn.Tensor, input_b: ttnn.Tensor) -> ttnn.Tensor
+
+        {2}
+
+            Args:
+                * :attr:`input_a` (ttnn.Tensor)
+                * :attr:`input_b` (ttnn.Tensor)
+
+            Example::
+                >>> tensor1 = ttnn.from_torch(torch.tensor((1, 2), dtype=torch.bfloat16), device=device)
+                >>> tensor2 = ttnn.from_torch(torch.tensor((1, 2), dtype=torch.bfloat16), device=device)
+                >>> output = {1}(tensor1, tensor2)
+        )doc",
+        operation.base_name(),
+        operation.python_fully_qualified_name(),
+        description);
+
+    bind_registered_operation(
+        module,
+        operation,
+        doc,
+
+        ttnn::pybind_overload_t{
+            [](const binary_operation_t& self,
+            const Tensor& input_tensor_a,
+            const Tensor& input_tensor_b) {
+                return self(input_tensor_a, input_tensor_b); },
+            py::arg("input_a"),
+            py::arg("input_b")});
+}
 }  // namespace detail
 
 void py_module(py::module& module) {
@@ -809,7 +843,7 @@ void py_module(py::module& module) {
         R"doc(Compute logical_xor :attr:`input_tensor_a` and :attr:`input_tensor_b` and returns the tensor with the same layout as :attr:`input_tensor_a`
         .. math:: \mathrm{{input\_tensor\_a}}_i || \mathrm{{input\_tensor\_b}}_i)doc");
 
-    detail::bind_binary_composite(
+    detail::bind_logical_inplace_operation(
         module,
         ttnn::logical_or_,
         R"doc(Compute inplace logical OR of :attr:`input_tensor_a` and :attr:`input_tensor_b` and returns the tensor with the same layout as :attr:`input_tensor_a`
@@ -821,7 +855,7 @@ void py_module(py::module& module) {
         R"doc(Compute inplace logical XOR of :attr:`input_tensor_a` and :attr:`input_tensor_b` and returns the tensor with the same layout as :attr:`input_tensor_a`
         .. math:: \mathrm{{input\_tensor\_a}}_i || \mathrm{{input\_tensor\_b}}_i)doc");
 
-    detail::bind_binary_composite(
+    detail::bind_logical_inplace_operation(
         module,
         ttnn::logical_and_,
         R"doc(Compute inplace logical AND of :attr:`input_tensor_a` and :attr:`input_tensor_b` and returns the tensor with the same layout as :attr:`input_tensor_a`

--- a/ttnn/cpp/ttnn/operations/eltwise/binary/device/binary_composite_op.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary/device/binary_composite_op.cpp
@@ -303,14 +303,6 @@ Tensor _floor_div(const Tensor& input_a, const Tensor& input_b, const std::optio
         result);
 }
 
-Tensor _logical_and_(const Tensor& input_a, const Tensor& input_b, const std::optional<MemoryConfig>& output_mem_config) {
-    return ttnn::logical_and(input_a, input_b, std::nullopt, output_mem_config, input_a);
-}
-
-Tensor _logical_or_(const Tensor& input_a, const Tensor& input_b, const std::optional<MemoryConfig>& output_mem_config) {
-    return ttnn::logical_or(input_a, input_b, std::nullopt, output_mem_config, input_a);
-}
-
 Tensor _logical_xor_(const Tensor& input_a, const Tensor& input_b, const std::optional<MemoryConfig>& output_mem_config) {
     Tensor in_a_eq_zero = ttnn::eqz(input_a, output_mem_config, input_a );
     Tensor in_b_eq_zero = ttnn::nez(input_b, output_mem_config, input_b );

--- a/ttnn/cpp/ttnn/operations/eltwise/binary/device/binary_composite_op.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary/device/binary_composite_op.hpp
@@ -27,8 +27,6 @@ enum class BinaryCompositeOpType {
     DIV,
     DIV_NO_NAN,
     FLOOR_DIV,
-    LOGICAL_AND_,
-    LOGICAL_OR_,
     LOGICAL_XOR_,
     SCATTER,
     OUTER,
@@ -51,8 +49,6 @@ Tensor _div_no_nan(const Tensor&, const Tensor&, const std::optional<MemoryConfi
 Tensor _div_no_nan_overload(const Tensor&, float, const std::optional<MemoryConfig>&);
 Tensor _floor_div(const Tensor&, const Tensor&, const std::optional<MemoryConfig>&);
 Tensor _floor_div_overload(const Tensor&, float, const std::optional<MemoryConfig>&);
-Tensor _logical_or_(const Tensor&, const Tensor&, const std::optional<MemoryConfig>&);
-Tensor _logical_and_(const Tensor&, const Tensor&, const std::optional<MemoryConfig>&);
 Tensor _logical_xor_(const Tensor&, const Tensor&, const std::optional<MemoryConfig>&);
 Tensor _scatter(const Tensor&, const Tensor&, const std::optional<MemoryConfig>&);
 Tensor _outer(const Tensor&, const Tensor&, const std::optional<MemoryConfig>&);
@@ -113,23 +109,9 @@ struct OpHandler<BinaryCompositeOpType::LOGICAL_XOR> {
 };
 
 template <>
-struct OpHandler<BinaryCompositeOpType::LOGICAL_AND_> {
-    static Tensor handle(const Tensor& t1, const Tensor& t2, const std::optional<MemoryConfig>& mem_cfg) {
-        return _logical_and_(t1, t2, mem_cfg);
-    }
-};
-
-template <>
 struct OpHandler<BinaryCompositeOpType::LOGICAL_XOR_> {
     static Tensor handle(const Tensor& t1, const Tensor& t2, const std::optional<MemoryConfig>& mem_cfg) {
         return _logical_xor_(t1, t2, mem_cfg);
-    }
-};
-
-template <>
-struct OpHandler<BinaryCompositeOpType::LOGICAL_OR_> {
-    static Tensor handle(const Tensor& t1, const Tensor& t2, const std::optional<MemoryConfig>& mem_cfg) {
-        return _logical_or_(t1, t2, mem_cfg);
     }
 };
 


### PR DESCRIPTION
Ticket : #11647

### Work Done
Moved logical_and_ , logical_or_ to binary.cpp

### Checklist
- [x] [All Post commit CI ](https://github.com/tenstorrent/tt-metal/actions/runs/10469488359)

