### PR TITLE
#11656: Bump single-card demos timeout to 70 min

### DIFF
--- a/.github/workflows/single-card-demo-tests.yaml
+++ b/.github/workflows/single-card-demo-tests.yaml
@@ -57,7 +57,7 @@ jobs:
         run: tar -xvf ttm_${{ matrix.test-group.arch }}.tar
       - uses: ./.github/actions/install-python-deps
       - name: Run demo regression tests
-        timeout-minutes: 45
+        timeout-minutes: 70
         run: |
           source ${{ github.workspace }}/python_env/bin/activate
           cd $TT_METAL_HOME


### PR DESCRIPTION
### Ticket

#11656 

### Problem description

More models and more unstable hugging face connections causing to take longer to run these models.

### What's changed

Bump timeout.

### Checklist
- [ ] Post commit CI passes
- [ ] Blackhole Post commit (if applicable)
- [ ] Model regression CI testing passes (if applicable)
- [ ] New/Existing tests provide coverage for changes
