### PR TITLE
#11610: Disable schedule on old sweeps workflow

### DIFF
--- a/.github/workflows/ttnn-run-sweeps.yaml
+++ b/.github/workflows/ttnn-run-sweeps.yaml
@@ -1,8 +1,6 @@
 name: "ttnn - Run sweeps"
 
 on:
-  schedule:
-    - cron: "0 1,7,13,19 * * *"
   workflow_dispatch:
   workflow_call:
 


### PR DESCRIPTION
### Ticket
#11610 

### Problem description
Disable sweeps workflow schedule while it's being worked on to use the new framework.

### Checklist
- [ ] Post commit CI passes
- [ ] Blackhole Post commit (if applicable)
- [ ] Model regression CI testing passes (if applicable)
- [ ] New/Existing tests provide coverage for changes
