### PR TITLE
#0: Remove TT_METAL_ASYNC_DEVICE_QUEUE env var. Use enable_async_mode  fixture instead

### DIFF
--- a/models/common/tests/test_rmsnorm.py
+++ b/models/common/tests/test_rmsnorm.py
@@ -8,7 +8,6 @@ from loguru import logger
 
 # Set flags for CI, if CI environment is setup
 if os.getenv("CI") == "true":
-    os.environ["TT_METAL_ASYNC_DEVICE_QUEUE"] = "1"
     os.environ["WH_ARCH_YAML"] = "wormhole_b0_80_arch_eth_dispatch.yaml"
 
 import ttnn
@@ -64,7 +63,8 @@ class RefModel(torch.nn.Module):
     "is_sharded",
     (True, False),
 )
-def test_rmsnorm_singledevice(device, is_sharded, use_program_cache, reset_seeds):
+@pytest.mark.parametrize("enable_async_mode", [True], indirect=True)
+def test_rmsnorm_singledevice(device, is_sharded, use_program_cache, reset_seeds, enable_async_mode):
     dim = 4096
     dtype = ttnn.bfloat8_b
 
@@ -108,7 +108,8 @@ def test_rmsnorm_singledevice(device, is_sharded, use_program_cache, reset_seeds
     "is_sharded",
     (True, False),
 )
-def test_rmsnorm_multidevice(t3k_device_mesh, is_sharded, use_program_cache, reset_seeds):
+@pytest.mark.parametrize("enable_async_mode", [True], indirect=True)
+def test_rmsnorm_multidevice(t3k_device_mesh, is_sharded, use_program_cache, reset_seeds, enable_async_mode):
     dim = 4096
     dtype = ttnn.bfloat8_b
 

--- a/models/demos/t3000/mixtral8x7b/README.md
+++ b/models/demos/t3000/mixtral8x7b/README.md
@@ -16,9 +16,8 @@ python models/demos/t3000/mixtral8x7b/scripts/repack_weights.py <path_to_checkpo
 ```
 
 ### Set up environment
-1. Set async and dispatch over ethernet cores env vars:
+1. Enable dispatch over ethernet cores env vars:
 ```
-export TT_METAL_ASYNC_DEVICE_QUEUE=1
 export WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml
 ```
 

--- a/models/experimental/grok/README.md
+++ b/models/experimental/grok/README.md
@@ -15,19 +15,14 @@ python models/experimental/grok/scripts/repack_weights.py <path_to_checkpoint_di
 ```
 
 ### Set up environment
-1. Set async env var:
-```
-export TT_METAL_ASYNC_DEVICE_QUEUE=1
-```
-
-2. Prepare the weight cache directory:
+1. Prepare the weight cache directory:
 
 ```
 # Make a directory for ttnn us to cache weights into. This speeds up subsequent runs.
 mkdir <weight_cache_dir>
 ```
 
-3. Set up environment variables:
+2. Set up environment variables:
 ```
 export GROK_CKPT_DIR=<repacked_output_dir>
 export GROK_TOKENIZER_PATH=<path_to_tokenizer_dir>
@@ -43,7 +38,7 @@ Note that the cached weights folder structure will contain the general and instr
   ...
 ```
 
-4. Cache the weights (first-time setup):
+3. Cache the weights (first-time setup):
 ```
 # Build a full 32 layer model to cache the weights. This will take some time.
 pytest -svv models/experimental/grok/tests/test_grok_model.py::test_grok_model_inference[wormhole_b0-True-1-32-output]

--- a/models/experimental/grok/demo/demo.py
+++ b/models/experimental/grok/demo/demo.py
@@ -13,7 +13,6 @@ if os.getenv("CI") == "true":
     os.environ["GROK_CKPT_DIR"] = "/mnt/MLPerf/tt_dnn-models/Grok/Grok-1/"
     os.environ["GROK_TOKENIZER_PATH"] = "/mnt/MLPerf/tt_dnn-models/Grok/Grok-1/"
     os.environ["GROK_CACHE_PATH"] = "/mnt/MLPerf/tt_dnn-models/Grok/Grok-1/"
-    os.environ["TT_METAL_ASYNC_DEVICE_QUEUE"] = "1"
     os.environ["WH_ARCH_YAML"] = "wormhole_b0_80_arch_eth_dispatch.yaml"
 
 import ttnn
@@ -306,7 +305,8 @@ def run_grok_demo(user_input, batch_size, device_mesh, instruct_mode):
     ],
     ids=["general_weights", "instruct_weights"],
 )
-def test_grok8x7b_demo(t3k_device_mesh, use_program_cache, input_prompts, instruct_weights):
+@pytest.mark.parametrize("enable_async_mode", [True], indirect=True)
+def test_grok8x7b_demo(t3k_device_mesh, use_program_cache, input_prompts, instruct_weights, enable_async_mode):
     return run_grok_demo(
         user_input=input_prompts, batch_size=32, device_mesh=t3k_device_mesh, instruct_mode=instruct_weights
     )

--- a/tt_metal/impl/dispatch/work_executor.hpp
+++ b/tt_metal/impl/dispatch/work_executor.hpp
@@ -99,7 +99,7 @@ class WorkExecutor {
     ~WorkExecutor() { reset(); }
 
     inline void initialize() {
-        this->work_executor_mode = default_worker_executor_mode();
+        this->work_executor_mode = WorkExecutorMode::SYNCHRONOUS;
         this->worker_queue_mode = default_worker_queue_mode();
         this->worker_state = WorkerState::IDLE;
         this->worker_queue.parent_thread_id = 0;
@@ -254,12 +254,6 @@ class WorkExecutor {
         }
         this->worker_thread.join();
         this->worker_state = WorkerState::IDLE;
-    }
-
-    static WorkExecutorMode default_worker_executor_mode() {
-        static int value =
-            parse_env<int>("TT_METAL_ASYNC_DEVICE_QUEUE", static_cast<int>(WorkExecutorMode::SYNCHRONOUS));
-        return static_cast<WorkExecutorMode>(value);
     }
 
     static WorkerQueueMode default_worker_queue_mode() {


### PR DESCRIPTION
### Problem description
Async mode env var usage needs to be deprecated. We have python APIs to enable async mode, which should be used instead.

### What's changed
Delete the `TT_METAL_ASYNC_DEVICE_QUEUE` env var and replace its usage in model tests with `enable_async_mode` fixture

### Checklist
- [x] Post commit CI passes
- [ ] Blackhole Post commit (if applicable)
- [ ] Model regression CI testing passes (if applicable)
- [ ] New/Existing tests provide coverage for changes
