### PR TITLE
#11659: Remove section attribute conflict

### DIFF
--- a/tt_metal/hw/firmware/src/erisc.cc
+++ b/tt_metal/hw/firmware/src/erisc.cc
@@ -18,7 +18,7 @@
 extern "C" {
 #endif
 
-void ApplicationHandler(void) __attribute__((__section__(".init")));
+  void ApplicationHandler(void);
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/11659

### Problem description
found when testing gcc-12 - the conflict is diagnosable there, in gcc-10 it silently takes the second one.

### What's changed

Remove first attribute.

### Checklist
- [ yes] Post commit CI passes - https://github.com/tenstorrent/tt-metal/actions/runs/10473768385
- [ ] Blackhole Post commit (if applicable)
- [ ] Model regression CI testing passes (if applicable)
- [ ] New/Existing tests provide coverage for changes
