### PR TITLE
#11610: Add new flags for resetting with tt-smi-metal executable

### DIFF
--- a/tests/sweep_framework/tt_smi_util.py
+++ b/tests/sweep_framework/tt_smi_util.py
@@ -20,9 +20,12 @@ def run_tt_smi(arch: str):
     ]
     args = GRAYSKULL_ARGS if arch == "grayskull" else WORMHOLE_ARGS
 
-    while len(smi_options) != 0:
-        executable = shutil.which(smi_options.pop())
+    for smi_option in smi_options:
+        executable = shutil.which(smi_option)
         if executable is not None:
+            # Corner case for newer version of tt-smi, -tr and -wr are removed on this version (tt-smi-metal).
+            if smi_option == "tt-smi-metal":
+                args = ["-r", "all"]
             smi_process = subprocess.run([executable, *args])
             if smi_process.returncode == 0:
                 print("SWEEPS: TT-SMI Reset Complete Successfully")


### PR DESCRIPTION
### Ticket
#11610 

### Problem description
Fixup for running tt-smi-metal on ci, it uses different flags.

### What's changed
Add case for tt-smi-metal where the flags are -r all instead of using deprecated -tr or -wr.

### Checklist
- [ ] Post commit CI passes
- [ ] Blackhole Post commit (if applicable)
- [ ] Model regression CI testing passes (if applicable)
- [ ] New/Existing tests provide coverage for changes
