### PR TITLE
#0: Add map_location to fix CUDA error while using torch.load

### DIFF
--- a/models/demos/wormhole/llama31_8b/demo/demo.py
+++ b/models/demos/wormhole/llama31_8b/demo/demo.py
@@ -89,7 +89,7 @@ def run_llama_demo(user_input, batch_size, device, instruct_mode, is_ci_env):
     model_args.n_layers = 32
 
     logger.info("Loading weights...")
-    state_dict = torch.load(model_args.consolidated_weights_path)
+    state_dict = torch.load(model_args.consolidated_weights_path, map_location=torch.device("cpu"))
     state_dict = {
         k: v
         for k, v in state_dict.items()

--- a/models/demos/wormhole/llama31_8b/demo/demo_with_prefill.py
+++ b/models/demos/wormhole/llama31_8b/demo/demo_with_prefill.py
@@ -130,7 +130,7 @@ def run_llama_demo(user_input, batch_size, device, instruct_mode, is_ci_env):
     model_args.n_layers = 32
 
     logger.info("Loading weights...")
-    state_dict = torch.load(model_args.consolidated_weights_path)
+    state_dict = torch.load(model_args.consolidated_weights_path, map_location=torch.device("cpu"))
     state_dict = {
         k: v
         for k, v in state_dict.items()


### PR DESCRIPTION
### Ticket
-

### Problem description
We face CUDA error 
`RuntimeError: Attempting to deserialize object on a CUDA device but torch.cuda.is_available() is False. If you are running on a CPU-only machine, please use torch.load with map_location=torch.device('cpu') to map your storages to the CPU.`

### What's changed
Adding the map_location parameter to torch.load fixes the issue.
from `state_dict = torch.load(model_args.consolidated_weights_path)`
to `state_dict = torch.load(model_args.consolidated_weights_path, map_location=torch.device("cpu"))`

### Checklist
- [ ] Post commit CI passes
- [ ] Blackhole Post commit (if applicable)
- [ ] Model regression CI testing passes (if applicable)
- [ ] New/Existing tests provide coverage for changes
