### PR TITLE
#11511: Add option to Enable ASAN in CMake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -93,6 +93,9 @@ else()
 endif()
 message(STATUS "Build shared libs: ${BUILD_SHARED_LIBS}")
 
+option(ENABLE_ASAN "Enable build with AddressSanitizer" OFF)
+message(STATUS "Build with ASAN: ${ENABLE_ASAN}")
+
 include(GNUInstallDirs)
 set(CMAKE_INSTALL_PREFIX "${PROJECT_BINARY_DIR}")
 set(CMAKE_INSTALL_LIBDIR "${PROJECT_BINARY_DIR}/lib")
@@ -156,7 +159,7 @@ target_compile_options(compiler_warnings INTERFACE -Werror -Wdelete-non-virtual-
 ADJUST_COMPILER_WARNINGS()
 
 add_library(compiler_flags INTERFACE)
-target_link_libraries(compiler_flags INTERFACE compiler_warnings stdlib)
+target_link_libraries(compiler_flags INTERFACE linker_flags compiler_warnings stdlib)
 target_compile_options(compiler_flags INTERFACE -mavx2 -fPIC -DFMT_HEADER_ONLY -fvisibility-inlines-hidden -fno-lto)
 
 if(ENABLE_CODE_TIMERS)
@@ -165,6 +168,10 @@ endif()
 if(ENABLE_TRACY)
     target_compile_options(compiler_flags INTERFACE -DTRACY_ENABLE -fno-omit-frame-pointer)
     target_link_options(linker_flags INTERFACE -rdynamic)
+endif()
+if(ENABLE_ASAN)
+    target_compile_options(compiler_flags INTERFACE -fsanitize=address)
+    target_link_options(linker_flags INTERFACE -fsanitize=address)
 endif()
 
 string(TOUPPER $ENV{ARCH_NAME} ARCH_NAME_DEF)

--- a/build_metal.sh
+++ b/build_metal.sh
@@ -51,21 +51,23 @@ set -eo pipefail
 
 # Function to display help
 show_help() {
-    echo "Usage: $0 [-h] [-e] [-c] [-b build_type] [-t]"
+    echo "Usage: $0 [-h] [-e] [-c] [-b build_type] [-t] [-a]"
     echo "  -h  Show this help message."
     echo "  -e  Enable CMAKE_EXPORT_COMPILE_COMMANDS."
     echo "  -c  Enable ccache for the build."
     echo "  -b  Set the build type. Default is Release. Other options are Debug, RelWithDebInfo, and CI."
     echo "  -t  Enable build time trace (clang only)."
+    echo "  -a  Enable AddressSanitizer."
 }
 
 # Parse CLI options
 export_compile_commands="OFF"
 enable_ccache="OFF"
 enable_time_trace="OFF"
+enable_asan="OFF"
 build_type="Release"
 
-while getopts "hectb:" opt; do
+while getopts "hectab:" opt; do
     case ${opt} in
         h )
             show_help
@@ -79,6 +81,9 @@ while getopts "hectb:" opt; do
             ;;
         t )
             enable_time_trace="ON"
+            ;;
+        a )
+            enable_asan="ON"
             ;;
         b )
             build_type="$OPTARG"
@@ -100,6 +105,7 @@ echo "Export compile commands: $export_compile_commands"
 echo "Enable ccache: $enable_ccache"
 echo "Build type: $build_type"
 echo "Enable time trace: $enable_time_trace"
+echo "Enable AddressSanitizer: $enable_asan"
 
 # Create and link the build directory
 mkdir -p build_$build_type
@@ -115,6 +121,10 @@ fi
 
 if [ "$enable_time_trace" = "ON" ]; then
     cmake_args="$cmake_args -DENABLE_BUILD_TIME_TRACE=ON"
+fi
+
+if [ "$enable_asan" = "ON" ]; then
+    cmake_args="$cmake_args -DENABLE_ASAN=ON"
 fi
 
 # Configure cmake

--- a/tt_metal/CMakeLists.txt
+++ b/tt_metal/CMakeLists.txt
@@ -36,7 +36,7 @@ target_precompile_headers(tt_metal PRIVATE
     <vector>
 )
 
-target_link_libraries(tt_metal PUBLIC compiler_flags linker_flags $<$<BOOL:${ENABLE_TRACY}>:TracyClient>)  # linker_flags = -rdynamic if tracy enabled
+target_link_libraries(tt_metal PUBLIC compiler_flags $<$<BOOL:${ENABLE_TRACY}>:TracyClient>)
 target_include_directories(tt_metal PUBLIC
     ${UMD_HOME}
     ${PROJECT_SOURCE_DIR}

--- a/ttnn/CMakeLists.txt
+++ b/ttnn/CMakeLists.txt
@@ -332,7 +332,7 @@ set(TTNN_PUBLIC_INCLUDE_DIRS
     ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/deprecated # symlink to tt_eager; should become native folder once merge complete
     ${CMAKE_CURRENT_SOURCE_DIR}/cpp
     ${PROJECT_SOURCE_DIR}/tt_metal/third_party/fmt)
-set(TTNN_PUBLIC_LINK_LIBRARIES compiler_flags metal_header_directories metal_common_libs tt_metal linker_flags) # linker_flags = -rdynamic if tracy enabled
+set(TTNN_PUBLIC_LINK_LIBRARIES compiler_flags metal_header_directories metal_common_libs tt_metal)
 set(TTNN_PUBLIC_LINK_DIRS "")
 
 set(TTNN_PRECOMPILED_HEADERS


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/11453

### Problem description
Tests should be run with sanitizers for additional error detection. 

### What's changed
- Add `ENABLE_ASAN` option to CMake
- Refactor `compiler_flags` interface target to depend on `linker_flags` interface target so that `-fsanitize` is consistently used in compilation and link stages.

### Checklist
- [x] Post commit CI passes (https://github.com/tenstorrent/tt-metal/actions/runs/10477908189)
- [ ] Blackhole Post commit (if applicable)
- [ ] Model regression CI testing passes (if applicable)
- [ ] New/Existing tests provide coverage for changes
