### PR TITLE
#11536: add galaxy umd tests to TG unit tests pipeline

### DIFF
--- a/.github/workflows/tg-unit-tests.yaml
+++ b/.github/workflows/tg-unit-tests.yaml
@@ -11,6 +11,39 @@ jobs:
     with:
       arch: '["wormhole_b0"]'
     secrets: inherit
+  TG-UMD-tests:
+    strategy:
+      fail-fast: false
+      matrix:
+        test-group: [
+          {
+            name: "TG UMD unit tests",
+            arch: wormhole_b0,
+            runs-on: [arch-wormhole_b0, "config-tg", "in-service", "runner-test", "bare-metal", "pipeline-functional"],
+            cmd: "./build/test/umd/galaxy/unit_tests_glx"
+          },
+        ]
+    name: ${{ matrix.test-group.name }}
+    env:
+      TT_METAL_ENV: ${{ vars.TT_METAL_ENV }}
+      ARCH_NAME: ${{ matrix.test-group.arch }}
+      LOGURU_LEVEL: INFO
+    environment: dev
+    runs-on: ${{ matrix.test-group.runs-on }}
+    steps:
+      - uses: tenstorrent-metal/metal-workflows/.github/actions/checkout-with-submodule-lfs@v2.0.0
+      - name: Set up dynamic env vars for build
+        run: |
+          echo "TT_METAL_HOME=$(pwd)" >> $GITHUB_ENV
+      - name: Build UMD device and tests
+        run: |
+          cmake -B build -G Ninja
+          cmake --build build --target umd_tests
+      - name: Run UMD unit regression tests
+        timeout-minutes: 10
+        run: |
+          cd $TT_METAL_HOME
+          ${{ matrix.test-group.cmd }}
   TG-tests:
     needs: build-artifact
     strategy:

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -8,5 +8,5 @@ add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/tt_metal/tt_metal)
 add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/tt_eager) # this should go away and be replaced with link to ttnn
 add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/ttnn/unit_tests/gtests)
 
-set(TESTS_DEPENDS_LIST metal_tests eager_tests unit_tests_ttnn unit_tests_ttnn_ccl test_multi_device galaxy_unit_tests_ttnn ttnn watcher_dump)
+set(TESTS_DEPENDS_LIST metal_tests eager_tests unit_tests_ttnn unit_tests_ttnn_ccl test_multi_device galaxy_unit_tests_ttnn ttnn watcher_dump umd_tests)
 add_custom_target(tests DEPENDS ${TESTS_DEPENDS_LIST})


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/11536

### Problem description
Need to be running UMD unit tests.

### What's changed

- Build umd_tests with top level `tests` target (i.e. `ninja tests -C build` will now build umd tests. 
- Added tests to `TG - Unit Tests` pipeline

Related umd bump/PR: https://github.com/tenstorrent/tt-umd/pull/35

### Checklist
- [x] TG - Unit Tests: https://github.com/tenstorrent/tt-metal/actions/runs/10479808155
