### PR TITLE
#9450: add env flag to skip recompiling and reloading FW

### DIFF
--- a/tt_metal/impl/device/device.cpp
+++ b/tt_metal/impl/device/device.cpp
@@ -20,6 +20,7 @@
 #include "dev_msgs.h"
 #include "noc/noc_parameters.h"
 #include "tt_metal/impl/device/device_pool.hpp"
+#include "tt_metal/detail/persistent_kernel_cache.hpp"
 #include "llrt/hal.hpp"
 
 namespace tt {
@@ -263,19 +264,23 @@ void Device::initialize_firmware(CoreCoord phys_core, launch_msg_t *launch_msg) 
         auto active_eth_cores = this->get_active_ethernet_cores();
 
         if (active_eth_cores.find(logical_core_from_ethernet_core(phys_core)) != active_eth_cores.end()) {
-            int eriscv_id = build_processor_type_to_index(JitBuildProcessorType::ETHERNET).first + 0;
-            ll_api::memory binary_mem = llrt::get_risc_binary(firmware_build_states_[eriscv_id]->get_target_out_path(""));
-            uint32_t kernel_size16 = llrt::get_binary_code_size16(binary_mem, eriscv_id);
-            log_debug(LogDevice, "ERISC fw binary size: {} in bytes", kernel_size16 * 16);
-            llrt::test_load_write_read_risc_binary(binary_mem, this->id(), phys_core, eriscv_id);
+            if (not llrt::OptionsG.get_skip_loading_fw()) {
+                int eriscv_id = build_processor_type_to_index(JitBuildProcessorType::ETHERNET).first + 0;
+                ll_api::memory binary_mem = llrt::get_risc_binary(firmware_build_states_[eriscv_id]->get_target_out_path(""));
+                uint32_t kernel_size16 = llrt::get_binary_code_size16(binary_mem, eriscv_id);
+                log_debug(LogDevice, "ERISC fw binary size: {} in bytes", kernel_size16 * 16);
+                llrt::test_load_write_read_risc_binary(binary_mem, this->id(), phys_core, eriscv_id);
+            }
             llrt::launch_erisc_app_fw_on_core(this->id(), phys_core);
         } else {
             tt::Cluster::instance().assert_risc_reset_at_core(tt_cxy_pair(this->id(), phys_core));
-            int eriscv_id = build_processor_type_to_index(JitBuildProcessorType::ETHERNET).first + 1;
-            ll_api::memory binary_mem = llrt::get_risc_binary(firmware_build_states_[eriscv_id]->get_target_out_path(""));
-            uint32_t kernel_size16 = llrt::get_binary_code_size16(binary_mem, eriscv_id);
-            log_debug(LogDevice, "ERISC fw binary size: {} in bytes", kernel_size16 * 16);
-            llrt::test_load_write_read_risc_binary(binary_mem, this->id(), phys_core, eriscv_id);
+            if (not llrt::OptionsG.get_skip_loading_fw()) {
+                int eriscv_id = build_processor_type_to_index(JitBuildProcessorType::ETHERNET).first + 1;
+                ll_api::memory binary_mem = llrt::get_risc_binary(firmware_build_states_[eriscv_id]->get_target_out_path(""));
+                uint32_t kernel_size16 = llrt::get_binary_code_size16(binary_mem, eriscv_id);
+                log_debug(LogDevice, "ERISC fw binary size: {} in bytes", kernel_size16 * 16);
+                llrt::test_load_write_read_risc_binary(binary_mem, this->id(), phys_core, eriscv_id);
+            }
             llrt::program_risc_startup_addr(this->id(), phys_core);
         }
     } else {
@@ -288,7 +293,9 @@ void Device::initialize_firmware(CoreCoord phys_core, launch_msg_t *launch_msg) 
                 launch_msg->kernel_config.ncrisc_kernel_size16 = kernel_size16;
             }
             log_debug(LogDevice, "RISC {} fw binary size: {} in bytes", riscv_id, kernel_size16 * 16);
-            llrt::test_load_write_read_risc_binary(binary_mem, this->id(), phys_core, riscv_id);
+            if (not llrt::OptionsG.get_skip_loading_fw()) {
+                llrt::test_load_write_read_risc_binary(binary_mem, this->id(), phys_core, riscv_id);
+            }
         }
     }
     //This is an initialization launch message.
@@ -1863,7 +1870,14 @@ void Device::init_command_queue_host() {
 
 void Device::init_command_queue_device() {
 
-    this->compile_command_queue_programs();
+    if (llrt::OptionsG.get_skip_loading_fw()) {
+        detail::EnablePersistentKernelCache();
+        this->compile_command_queue_programs();
+        detail::DisablePersistentKernelCache();
+    } else {
+        this->compile_command_queue_programs();
+    }
+
     if (this->is_mmio_capable()) {
         TT_ASSERT(this->command_queue_programs.size() == 1);
     } else {
@@ -2374,11 +2388,11 @@ std::shared_ptr<TraceBuffer> Device::get_trace(const uint32_t tid) {
     }
 }
 
-void Device::DisableAllocs() { 
-    tt::tt_metal::allocator::disable_allocs(*(this->allocator_)); 
+void Device::DisableAllocs() {
+    tt::tt_metal::allocator::disable_allocs(*(this->allocator_));
 }
 
-void Device::EnableAllocs() { 
+void Device::EnableAllocs() {
     tt::tt_metal::allocator::enable_allocs(*(this->allocator_));
 }
 

--- a/tt_metal/llrt/rtoptions.cpp
+++ b/tt_metal/llrt/rtoptions.cpp
@@ -102,6 +102,9 @@ RunTimeOptions::RunTimeOptions() {
         this->dispatch_core_type = tt_metal::DispatchCoreType::ETH;
     }
 
+    if (getenv("TT_METAL_SKIP_LOADING_FW")) {
+        this->skip_loading_fw = true;
+    }
 }
 
 const std::string &RunTimeOptions::get_root_dir() {

--- a/tt_metal/llrt/rtoptions.hpp
+++ b/tt_metal/llrt/rtoptions.hpp
@@ -94,6 +94,8 @@ class RunTimeOptions {
 
     bool clear_l1 = false;
 
+    bool skip_loading_fw = false;
+
     bool riscv_debug_info_enabled = false;
     uint32_t watcher_debug_delay = 0;
 
@@ -235,6 +237,8 @@ class RunTimeOptions {
 
     inline bool get_clear_l1() { return clear_l1; }
     inline void set_clear_l1(bool clear) { clear_l1 = clear; }
+
+    inline bool get_skip_loading_fw() { return skip_loading_fw; }
 
     // Whether to compile with -g to include DWARF debug info in the binary.
     inline bool get_riscv_debug_info_enabled() { return riscv_debug_info_enabled; }


### PR DESCRIPTION
### Ticket
[Link to Github Issue
](https://github.com/tenstorrent/tt-metal/issues/9450)
### Problem description
Galaxy FW init is so slow that it's hindering developers. We have plans to optimize kernel compile and writing FW to remote chips, but those are not getting into main anytime soon.

### What's changed
Added an env flag to skip recompiling and reloading FW. Safe to use when a previous workload has passed.

### Checklist
- [ ] Post commit CI passes
- [ ] Blackhole Post commit (if applicable)
- [ ] Model regression CI testing passes (if applicable)
- [ ] New/Existing tests provide coverage for changes
