### PR TITLE
Add git_branch_name and github_pipeline_link to environment CSVs for benchmarking

### DIFF
--- a/infra/data_collection/github/utils.py
+++ b/infra/data_collection/github/utils.py
@@ -45,7 +45,9 @@ BENCHMARK_ENVIRONMENT_CSV_FIELDS = (
     "git_repo_name",
     "git_commit_hash",
     "git_commit_ts",
+    "git_branch_name",
     "github_pipeline_id",
+    "github_pipeline_link",
     "github_job_id",
     "user_name",
     "docker_image",
@@ -328,8 +330,13 @@ def create_csv_for_github_benchmark_environment(github_benchmark_environment_csv
     logger.warning("Hardcoded null for git_commit_ts")
     git_commit_ts = ""
 
+    assert "GITHUB_REF_NAME" in os.environ
+    git_branch_name = os.environ["GITHUB_REF_NAME"]
+
     assert "GITHUB_RUN_ID" in os.environ
     github_pipeline_id = os.environ["GITHUB_RUN_ID"]
+
+    github_pipeline_link = f"https://github.com/{git_repo_name}/actions/runs/{github_pipeline_id}"
 
     logger.warning("Hardcoded null for github_job_id")
     github_job_id = ""
@@ -364,7 +371,9 @@ def create_csv_for_github_benchmark_environment(github_benchmark_environment_csv
         "git_repo_name": git_repo_name,
         "git_commit_hash": git_commit_hash,
         "git_commit_ts": git_commit_ts,
+        "git_branch_name": git_branch_name,
         "github_pipeline_id": github_pipeline_id,
+        "github_pipeline_link": github_pipeline_link,
         "github_job_id": github_job_id,
         "user_name": user_name,
         "docker_image": docker_image,


### PR DESCRIPTION

### Ticket
#10680

### Problem description
- The git branch name and git pipeline link entries in the environment CSVs for benchmarking were NULL.

### What's changed
- Populated the git branch name and pipeline link entries.

### Checklist
- [x] Post commit CI passes
- [x] Blackhole Post commit (if applicable)
- [x] Model regression CI testing passes (if applicable)
- [x] New/Existing tests provide coverage for changes

Produce data for external analysis test: https://github.com/tenstorrent/tt-metal/actions/runs/10479182948
