### PR TITLE
#0: Fix Graph Tracing tracks CBs deallocation

### DIFF
--- a/ttnn/cpp/ttnn/graph_processor.cpp
+++ b/ttnn/cpp/ttnn/graph_processor.cpp
@@ -170,13 +170,13 @@ namespace ttnn {
     }
 
     void GraphProcessor::track_program(tt::tt_metal::Program* program) {
+        // All previous CBs are deallocated before a new program run
+        track_deallocate_cb();
+
         if (run_mode == RunMode::NORMAL) {
             // we will track real buffer allocations during program run
             return;
         }
-
-        // All previous CBs are deallocated before a new program run
-        track_deallocate_cb();
 
         for (auto& cb : program->circular_buffers()) {
             track_allocate_cb(cb->core_ranges(), 0, cb->size());

--- a/ttnn/cpp/ttnn/graph_processor.cpp
+++ b/ttnn/cpp/ttnn/graph_processor.cpp
@@ -174,6 +174,10 @@ namespace ttnn {
             // we will track real buffer allocations during program run
             return;
         }
+
+        // All previous CBs are deallocated before a new program run
+        track_deallocate_cb();
+
         for (auto& cb : program->circular_buffers()) {
             track_allocate_cb(cb->core_ranges(), 0, cb->size());
         }


### PR DESCRIPTION
### Ticket
None

### Problem description
Graph trace misses CB deallocation event. Thats a recent regression.

### What's changed
Fixing by adding a CB deallocation event in track_program

### Checklist
- [x] Post commit CI [passes](https://github.com/tenstorrent/tt-metal/actions/runs/10482408305)