### PR TITLE
Add sweeps for complex ops: add, div, sub to TTNN

### DIFF
--- a/tests/tt_eager/python_api_testing/sweep_tests/pytorch_ops.py
+++ b/tests/tt_eager/python_api_testing/sweep_tests/pytorch_ops.py
@@ -757,7 +757,7 @@ def silu(x, *args, **kwargs):
     return torch.nn.functional.silu(x)
 
 
-def div(x, y, *args, accurate_mode, round_mode, **kwargs):
+def div(x, y, *args, accurate_mode=None, round_mode=None, **kwargs):
     if round_mode == "None":
         return torch.div(x, y)
     return torch.div(x, y, rounding_mode=round_mode)
@@ -2457,3 +2457,8 @@ def complex_conj_bw(x, y, *args, **kwargs):
     pyt_y.backward(gradient=grad_data)
 
     return in_data.grad
+
+
+def complex_div_no_nan(x, y, *args, **kwargs):
+    result = torch.where(y.real == 0 and y.imag == 0, 0, x / y)
+    return result

--- a/tests/ttnn/python_api_testing/sweep_tests/op_map.py
+++ b/tests/ttnn/python_api_testing/sweep_tests/op_map.py
@@ -1030,4 +1030,8 @@ op_map = {
         "tt_op": ttnn_ops.complex_eltwise_divide,
         "pytorch_op": pytorch_ops.div,
     },
+    "complex-eltwise-sub": {
+        "tt_op": ttnn_ops.complex_eltwise_sub,
+        "pytorch_op": pytorch_ops.sub,
+    },
 }

--- a/tests/ttnn/python_api_testing/sweep_tests/op_map.py
+++ b/tests/ttnn/python_api_testing/sweep_tests/op_map.py
@@ -1021,7 +1021,7 @@ op_map = {
     "backward-unary-remainder": {
         "tt_op": ttnn_ops.unary_remainder_bw,
         "pytorch_op": pytorch_ops.unary_remainder_bw,
-    }
+    },
     "complex-eltwise-add": {
         "tt_op": ttnn_ops.complex_eltwise_add,
         "pytorch_op": pytorch_ops.add,

--- a/tests/ttnn/python_api_testing/sweep_tests/op_map.py
+++ b/tests/ttnn/python_api_testing/sweep_tests/op_map.py
@@ -1026,4 +1026,8 @@ op_map = {
         "tt_op": ttnn_ops.complex_eltwise_add,
         "pytorch_op": pytorch_ops.add,
     },
+    "complex-eltwise-divide": {
+        "tt_op": ttnn_ops.complex_eltwise_divide,
+        "pytorch_op": pytorch_ops.div,
+    },
 }

--- a/tests/ttnn/python_api_testing/sweep_tests/op_map.py
+++ b/tests/ttnn/python_api_testing/sweep_tests/op_map.py
@@ -1021,5 +1021,9 @@ op_map = {
     "backward-unary-remainder": {
         "tt_op": ttnn_ops.unary_remainder_bw,
         "pytorch_op": pytorch_ops.unary_remainder_bw,
+    }
+    "complex-eltwise-add": {
+        "tt_op": ttnn_ops.complex_eltwise_add,
+        "pytorch_op": pytorch_ops.add,
     },
 }

--- a/tests/ttnn/python_api_testing/sweep_tests/test_configs/ci_sweep_tests_working/grayskull/ttnn_complex_eltwise_add_test.yaml
+++ b/tests/ttnn/python_api_testing/sweep_tests/test_configs/ci_sweep_tests_working/grayskull/ttnn_complex_eltwise_add_test.yaml
@@ -1,0 +1,25 @@
+---
+test-list:
+  - complex-eltwise-add:
+      shape:
+        start-shape: [1, 1, 32, 64]
+        end-shape: [6, 12, 256, 256]
+        interval: [1, 1, 32, 64]
+        num-dims: [2, 3, 4]
+        num-shapes: 2
+        num-samples: 128
+        args-sampling-strategy: "all"
+      datagen:
+        function: gen_rand_complex
+        args:
+          low: -100
+          high: 100
+      comparison:
+        function: comp_pcc
+      args-gen: gen_dtype_layout_device
+      args:
+        data-layout: ["TILE"]
+        data-type: ["BFLOAT16", "BFLOAT8_B"]
+        buffer-type: ["DRAM", "L1"]
+        out-buffer-type: ["DRAM", "L1"]
+      output-file: complex_eltwise_add_sweep.csv

--- a/tests/ttnn/python_api_testing/sweep_tests/test_configs/ci_sweep_tests_working/grayskull/ttnn_complex_eltwise_divide_test.yaml
+++ b/tests/ttnn/python_api_testing/sweep_tests/test_configs/ci_sweep_tests_working/grayskull/ttnn_complex_eltwise_divide_test.yaml
@@ -1,0 +1,25 @@
+---
+test-list:
+  - complex-eltwise-divide:
+      shape:
+        start-shape: [1, 1, 32, 64]
+        end-shape: [6, 12, 256, 256]
+        interval: [1, 1, 32, 64]
+        num-dims: [2, 3, 4]
+        num-shapes: 2
+        num-samples: 128
+        args-sampling-strategy: "all"
+      datagen:
+        function: gen_rand_complex
+        args:
+          low: -100
+          high: 100
+      comparison:
+        function: comp_pcc
+      args-gen: gen_dtype_layout_device
+      args:
+        data-layout: ["TILE"]
+        data-type: ["BFLOAT16"]
+        buffer-type: ["DRAM", "L1"]
+        out-buffer-type: ["DRAM", "L1"]
+      output-file: complex_divide_sweep.csv

--- a/tests/ttnn/python_api_testing/sweep_tests/test_configs/ci_sweep_tests_working/grayskull/ttnn_complex_eltwise_sub_test.yaml
+++ b/tests/ttnn/python_api_testing/sweep_tests/test_configs/ci_sweep_tests_working/grayskull/ttnn_complex_eltwise_sub_test.yaml
@@ -1,0 +1,25 @@
+---
+test-list:
+  - complex-eltwise-sub:
+      shape:
+        start-shape: [1, 1, 32, 64]
+        end-shape: [6, 12, 256, 256]
+        interval: [1, 1, 32, 64]
+        num-dims: [2, 3, 4]
+        num-shapes: 2
+        num-samples: 128
+        args-sampling-strategy: "all"
+      datagen:
+        function: gen_rand_complex
+        args:
+          low: -100
+          high: 100
+      comparison:
+        function: comp_pcc
+      args-gen: gen_dtype_layout_device
+      args:
+        data-layout: ["TILE"]
+        data-type: ["BFLOAT16", "BFLOAT8_B"]
+        buffer-type: ["DRAM", "L1"]
+        out-buffer-type: ["DRAM", "L1"]
+      output-file: complex_sub_sweep.csv

--- a/tests/ttnn/python_api_testing/sweep_tests/test_configs/ci_sweep_tests_working/wormhole/ttnn_complex_eltwise_add_test.yaml
+++ b/tests/ttnn/python_api_testing/sweep_tests/test_configs/ci_sweep_tests_working/wormhole/ttnn_complex_eltwise_add_test.yaml
@@ -1,0 +1,25 @@
+---
+test-list:
+  - complex-eltwise-add:
+      shape:
+        start-shape: [1, 1, 32, 64]
+        end-shape: [6, 12, 256, 256]
+        interval: [1, 1, 32, 64]
+        num-dims: [2, 3, 4]
+        num-shapes: 2
+        num-samples: 128
+        args-sampling-strategy: "all"
+      datagen:
+        function: gen_rand_complex
+        args:
+          low: -100
+          high: 100
+      comparison:
+        function: comp_pcc
+      args-gen: gen_dtype_layout_device
+      args:
+        data-layout: ["TILE"]
+        data-type: ["BFLOAT16", "BFLOAT8_B"]
+        buffer-type: ["DRAM", "L1"]
+        out-buffer-type: ["DRAM", "L1"]
+      output-file: complex_add_sweep.csv

--- a/tests/ttnn/python_api_testing/sweep_tests/test_configs/ci_sweep_tests_working/wormhole/ttnn_complex_eltwise_divide_test.yaml
+++ b/tests/ttnn/python_api_testing/sweep_tests/test_configs/ci_sweep_tests_working/wormhole/ttnn_complex_eltwise_divide_test.yaml
@@ -1,0 +1,25 @@
+---
+test-list:
+  - complex-eltwise-divide:
+      shape:
+        start-shape: [1, 1, 32, 64]
+        end-shape: [6, 12, 256, 256]
+        interval: [1, 1, 32, 64]
+        num-dims: [2, 3, 4]
+        num-shapes: 2
+        num-samples: 128
+        args-sampling-strategy: "all"
+      datagen:
+        function: gen_rand_complex
+        args:
+          low: -100
+          high: 100
+      comparison:
+        function: comp_pcc
+      args-gen: gen_dtype_layout_device
+      args:
+        data-layout: ["TILE"]
+        data-type: ["BFLOAT16"]
+        buffer-type: ["DRAM", "L1"]
+        out-buffer-type: ["DRAM", "L1"]
+      output-file: complex_divide_sweep.csv

--- a/tests/ttnn/python_api_testing/sweep_tests/test_configs/ci_sweep_tests_working/wormhole/ttnn_complex_eltwise_sub_test.yaml
+++ b/tests/ttnn/python_api_testing/sweep_tests/test_configs/ci_sweep_tests_working/wormhole/ttnn_complex_eltwise_sub_test.yaml
@@ -1,0 +1,25 @@
+---
+test-list:
+  - complex-eltwise-sub:
+      shape:
+        start-shape: [1, 1, 32, 64]
+        end-shape: [6, 12, 256, 256]
+        interval: [1, 1, 32, 64]
+        num-dims: [2, 3, 4]
+        num-shapes: 2
+        num-samples: 128
+        args-sampling-strategy: "all"
+      datagen:
+        function: gen_rand_complex
+        args:
+          low: -100
+          high: 100
+      comparison:
+        function: comp_pcc
+      args-gen: gen_dtype_layout_device
+      args:
+        data-layout: ["TILE"]
+        data-type: ["BFLOAT16", "BFLOAT8_B"]
+        buffer-type: ["DRAM", "L1"]
+        out-buffer-type: ["DRAM", "L1"]
+      output-file: complex_sub_sweep.csv

--- a/tests/ttnn/python_api_testing/sweep_tests/ttnn_ops.py
+++ b/tests/ttnn/python_api_testing/sweep_tests/ttnn_ops.py
@@ -4885,7 +4885,6 @@ def complex_eltwise_divide(
     return torch.complex(ttnn_tensor_to_torch(t2.real).to(torch.float), ttnn_tensor_to_torch(t2.imag).to(torch.float))
 
 
-
 def unary_remainder_bw(
     x,  # grad_tensor
     y,  # input_tensor
@@ -4907,3 +4906,27 @@ def unary_remainder_bw(
     return ttnn_tensor_to_torch(t2)
 
 
+def complex_eltwise_sub(
+    x,
+    y,
+    *args,
+    device,
+    dtype,
+    layout,
+    input_mem_config,
+    output_mem_config,
+    **kwargs,
+):
+    t0 = ttnn.complex_tensor(
+        setup_ttnn_tensor(x.real, device, layout[0], input_mem_config[0], dtype[0]),
+        setup_ttnn_tensor(x.imag, device, layout[0], input_mem_config[0], dtype[0]),
+    )
+
+    t1 = ttnn.complex_tensor(
+        setup_ttnn_tensor(y.real, device, layout[1], input_mem_config[1], dtype[1]),
+        setup_ttnn_tensor(y.imag, device, layout[1], input_mem_config[1], dtype[1]),
+    )
+
+    t2 = ttnn.subtract(t0, t1, memory_config=output_mem_config)
+
+    return torch.complex(ttnn_tensor_to_torch(t2.real).to(torch.float), ttnn_tensor_to_torch(t2.imag).to(torch.float))

--- a/tests/ttnn/python_api_testing/sweep_tests/ttnn_ops.py
+++ b/tests/ttnn/python_api_testing/sweep_tests/ttnn_ops.py
@@ -4859,6 +4859,33 @@ def eltwise_remainder(
     return ttnn_tensor_to_torch(t2)
 
 
+def complex_eltwise_divide(
+    x,
+    y,
+    *args,
+    device,
+    dtype,
+    layout,
+    input_mem_config,
+    output_mem_config,
+    **kwargs,
+):
+    t0 = ttnn.complex_tensor(
+        setup_ttnn_tensor(x.real, device, layout[0], input_mem_config[0], dtype[0]),
+        setup_ttnn_tensor(x.imag, device, layout[0], input_mem_config[0], dtype[0]),
+    )
+
+    t1 = ttnn.complex_tensor(
+        setup_ttnn_tensor(y.real, device, layout[1], input_mem_config[1], dtype[1]),
+        setup_ttnn_tensor(y.imag, device, layout[1], input_mem_config[1], dtype[1]),
+    )
+
+    t2 = ttnn.divide(t0, t1, memory_config=output_mem_config)
+
+    return torch.complex(ttnn_tensor_to_torch(t2.real).to(torch.float), ttnn_tensor_to_torch(t2.imag).to(torch.float))
+
+
+
 def unary_remainder_bw(
     x,  # grad_tensor
     y,  # input_tensor
@@ -4880,10 +4907,3 @@ def unary_remainder_bw(
     return ttnn_tensor_to_torch(t2)
 
 
-def bcast_add_h(x, y, *args, device, dtype, layout, input_mem_config, output_mem_config, **kwargs):
-    t0 = setup_ttnn_tensor(x, device, layout[0], input_mem_config[0], dtype[0])
-    t1 = setup_ttnn_tensor(y, device, layout[1], input_mem_config[1], dtype[1])
-
-    t2 = ttnn.add(t0, t1, memory_config=output_mem_config)
-
-    return ttnn_tensor_to_torch(t2)

--- a/tests/ttnn/python_api_testing/sweep_tests/ttnn_ops.py
+++ b/tests/ttnn/python_api_testing/sweep_tests/ttnn_ops.py
@@ -4808,7 +4808,6 @@ def unary_remainder(
     output_mem_config,
     **kwargs,
 ):
-    
     t0 = setup_ttnn_tensor(x, device, layout[0], input_mem_config[0], dtype[0])
     t1 = ttnn.remainder(t0, scalar, memory_config=output_mem_config)
 

--- a/tests/ttnn/python_api_testing/sweep_tests/ttnn_ops.py
+++ b/tests/ttnn/python_api_testing/sweep_tests/ttnn_ops.py
@@ -4808,10 +4808,37 @@ def unary_remainder(
     output_mem_config,
     **kwargs,
 ):
+    
     t0 = setup_ttnn_tensor(x, device, layout[0], input_mem_config[0], dtype[0])
     t1 = ttnn.remainder(t0, scalar, memory_config=output_mem_config)
 
     return ttnn_tensor_to_torch(t1)
+
+
+def complex_eltwise_add(
+    x,
+    y,
+    *args,
+    device,
+    dtype,
+    layout,
+    input_mem_config,
+    output_mem_config,
+    **kwargs,
+):
+    t0 = ttnn.complex_tensor(
+        setup_ttnn_tensor(x.real, device, layout[0], input_mem_config[0], dtype[0]),
+        setup_ttnn_tensor(x.imag, device, layout[0], input_mem_config[0], dtype[0]),
+    )
+
+    t1 = ttnn.complex_tensor(
+        setup_ttnn_tensor(y.real, device, layout[1], input_mem_config[1], dtype[1]),
+        setup_ttnn_tensor(y.imag, device, layout[1], input_mem_config[1], dtype[1]),
+    )
+
+    t2 = ttnn.add(t0, t1, memory_config=output_mem_config)
+
+    return torch.complex(ttnn_tensor_to_torch(t2.real).to(torch.float), ttnn_tensor_to_torch(t2.imag).to(torch.float))
 
 
 def eltwise_remainder(
@@ -4849,5 +4876,14 @@ def unary_remainder_bw(
     t1 = setup_ttnn_tensor(y, device, layout[1], input_mem_config[1], dtype[1])
 
     t2 = ttnn.remainder_bw(t0, t1, scalar, memory_config=output_mem_config)[0]
+
+    return ttnn_tensor_to_torch(t2)
+
+
+def bcast_add_h(x, y, *args, device, dtype, layout, input_mem_config, output_mem_config, **kwargs):
+    t0 = setup_ttnn_tensor(x, device, layout[0], input_mem_config[0], dtype[0])
+    t1 = setup_ttnn_tensor(y, device, layout[1], input_mem_config[1], dtype[1])
+
+    t2 = ttnn.add(t0, t1, memory_config=output_mem_config)
 
     return ttnn_tensor_to_torch(t2)


### PR DESCRIPTION
### Ticket
[Link to Github Issue](https://github.com/tenstorrent/tt-metal/issues/10147)

### Problem description
Migrated sweeps from tt_eager to ttnn for the next set of complex ops:

- [x] add
- [x] div
- [x] sub

### What's changed

1. Corresponding ops' YAML files added to ttnn (for both GS and WH)
2. Added API calls for ops to ttnn_ops.py
3. Added mappings for ops to ttnn/op_map.py

### Checklist
- [x] Post commit CI passes
- [x] Blackhole Post commit (if applicable)
- [x] Model regression CI testing passes (if applicable)
- [x] New/Existing tests provide coverage for changes
