### PR TITLE
LLK Test Coverage Follow-up

### DIFF
--- a/tests/tt_metal/tt_metal/test_kernels/compute/eltwise_copy_block_matmul_partials.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/compute/eltwise_copy_block_matmul_partials.cpp
@@ -1,0 +1,48 @@
+// SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <cstdint>
+#include "compute_kernel_api/eltwise_unary/sfpu_split_includes.h"
+#include "compute_kernel_api/eltwise_binary.h"
+#include "compute_kernel_api/tile_move_copy.h"
+#include "compute_kernel_api/eltwise_unary/eltwise_unary.h"
+#include "compute_kernel_api.h"
+
+#define START_IN_TILE_ID              (0)
+#define START_DST_TILE_ID             (0)
+namespace NAMESPACE {
+void MAIN {
+
+    constexpr uint32_t num_tiles = get_compile_time_arg_val(0);
+    constexpr uint32_t num_single_transfer = get_compile_time_arg_val(1);
+    constexpr uint32_t in_cb_id = get_compile_time_arg_val(2);
+    constexpr uint32_t out_cb_id = get_compile_time_arg_val(3);
+
+    constexpr uint32_t outer_loop = num_tiles / num_single_transfer;
+
+    unary_op_init_common(in_cb_id, out_cb_id);
+
+    // Run the outer loop
+    for(uint32_t b = 0; b < outer_loop; ++b) {
+        // Wait for num_single_transfer tiles to be available in in_cb
+        cb_wait_front(in_cb_id, num_single_transfer);
+        // Acquire DEST reg for MATH/PACK
+        acquire_dst(tt::DstMode::Half);
+        // Reserve out_cb space for num_single_transfer tiles
+        cb_reserve_back(out_cb_id, num_single_transfer);
+
+        // Copy num_single_transfer tiles from in_cb to DEST
+        copy_block_matmul_partials(in_cb_id, START_IN_TILE_ID, START_DST_TILE_ID, num_single_transfer);
+        // Pack num_single_transfer tiles to out_cb
+        matmul_pack_tile(START_DST_TILE_ID, out_cb_id, num_single_transfer);
+
+        // Release DEST reg marking compute/pack complete
+        release_dst(tt::DstMode::Half);
+        // Move rd ptr from in_cb by num_single_transfer places
+        cb_pop_front(in_cb_id, num_single_transfer);
+        // Move wr prt from out_cb by num_single_transfer places
+        cb_push_back(out_cb_id, num_single_transfer);
+    }
+}
+}

--- a/tests/tt_metal/tt_metal/test_kernels/compute/matmul_block.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/compute/matmul_block.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+// SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/tests/tt_metal/tt_metal/test_kernels/compute/matmul_block.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/compute/matmul_block.cpp
@@ -1,0 +1,107 @@
+// SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <cstdint>
+#include "compute_kernel_api/tile_move_copy.h"
+#include "compute_kernel_api/matmul.h"
+
+namespace NAMESPACE {
+void MAIN {
+
+    uint32_t block_tile_dim = get_compile_time_arg_val(0);
+    uint32_t dst_tile_rows = get_compile_time_arg_val(1);
+    uint32_t dst_tile_cols = get_compile_time_arg_val(2);
+    uint32_t block_cnt = get_compile_time_arg_val(3);
+    uint32_t in0_block_tile_cnt = get_compile_time_arg_val(4);
+    uint32_t in1_block_tile_cnt = get_compile_time_arg_val(5);
+    uint32_t out_block_tile_cnt = get_compile_time_arg_val(6);
+
+#if (TEST_INIT_SHORT == 1)
+#if (WITH_DT == 1)
+    // Intentionally wrong init with different data formats
+    mm_block_init(
+        tt::CB::c_in0,
+        tt::CB::c_in2,
+        tt::CB::c_out0,
+        false,
+        dst_tile_cols - 1,
+        dst_tile_rows - 1,
+        block_tile_dim - 1
+    );
+    // Corrected init short with dt
+    mm_block_init_short_with_dt(
+        tt::CB::c_in0,
+        tt::CB::c_in1,
+        tt::CB::c_in2,
+        false,
+        dst_tile_cols,
+        dst_tile_rows,
+        block_tile_dim
+    );
+#elif (WITH_DT == 0)
+    // Intentionally wrong init with same data formats
+    mm_block_init(
+        tt::CB::c_in1,
+        tt::CB::c_in0,
+        tt::CB::c_out0,
+        false,
+        dst_tile_cols - 1,
+        dst_tile_rows - 1,
+        block_tile_dim - 1
+    );
+    // Corrected init short
+    mm_block_init_short(
+        tt::CB::c_in0,
+        tt::CB::c_in1,
+        false,
+        dst_tile_cols,
+        dst_tile_rows,
+        block_tile_dim
+    );
+#endif
+#elif (TEST_INIT_SHORT == 0)
+        mm_block_init(
+        tt::CB::c_in0,
+        tt::CB::c_in1,
+        tt::CB::c_out0,
+        false,
+        dst_tile_cols,
+        dst_tile_rows,
+        block_tile_dim
+    );
+#endif
+
+    acquire_dst(tt::DstMode::Full);
+    for(uint32_t b=0;b<block_cnt;++b)
+    {
+        cb_wait_front(tt::CB::c_in0, in0_block_tile_cnt);
+        cb_wait_front(tt::CB::c_in1, in1_block_tile_cnt);
+
+        matmul_block(
+            tt::CB::c_in0,
+            tt::CB::c_in1,
+            0,
+            0,
+            0,
+            false,
+            dst_tile_cols,
+            dst_tile_rows,
+            block_tile_dim
+        );
+
+        cb_pop_front(tt::CB::c_in0, in0_block_tile_cnt);
+        cb_pop_front(tt::CB::c_in1, in1_block_tile_cnt);
+    }
+
+    // Pack out
+    cb_reserve_back(tt::CB::c_out0, out_block_tile_cnt);
+    for(uint32_t i=0 ; i<out_block_tile_cnt;++i)
+    {
+        pack_tile(i, tt::CB::c_out0);
+    }
+    cb_push_back(tt::CB::c_out0, out_block_tile_cnt);
+
+    release_dst(tt::DstMode::Full);
+}
+}

--- a/tests/tt_metal/tt_metal/test_kernels/compute/reconfig.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/compute/reconfig.cpp
@@ -1,0 +1,108 @@
+// SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "compute_kernel_api/eltwise_binary.h"
+#include <cstdint>
+#include "compute_kernel_api/eltwise_unary/sfpu_split_includes.h"
+#include "compute_kernel_api/tile_move_copy.h"
+#include "compute_kernel_api/pack.h"
+#include "compute_kernel_api/unpack.h"
+
+#define START_IN_TILE_ID              (0)
+#define START_DST_TILE_ID             (0)
+
+namespace NAMESPACE {
+void MAIN {
+    uint32_t num_tiles = get_arg_val<uint32_t>(0);
+    uint32_t ublock_size_tiles = get_arg_val<uint32_t>(1);
+
+    constexpr auto cb_in0 = tt::CB::c_in0; // Bfp8_b
+    constexpr auto cb_in1 = tt::CB::c_in1; // Bfp16_b
+    constexpr auto cb_in2 = tt::CB::c_in2; // Bfp16_b
+    constexpr auto cb_out0 = tt::CB::c_out0; // Bfp16_b
+    constexpr auto cb_out1 = tt::CB::c_out1; // Bfp8_b
+
+
+    binary_op_init_common(cb_in0, cb_in1, cb_out0);
+    add_tiles_init_nof();
+    for (uint32_t block = 0; block < num_tiles; ++block) {
+
+        cb_wait_front(cb_in0, ublock_size_tiles);
+        cb_wait_front(cb_in1, ublock_size_tiles);
+        cb_reserve_back(cb_out0, ublock_size_tiles);
+        cb_reserve_back(cb_out1, ublock_size_tiles);
+
+        acquire_dst(tt::DstMode::Half);
+
+        // ------------------------- Copy to DEST -----------------------------
+
+        // Tests both inits, 1st one inits UNPACK for Bfp8_b
+        // data inside CB_0, 2nd one inits it to Bfp16_b
+        // which is inside CB_2
+        copy_tile_init();
+        copy_tile_to_dst_init_short_with_dt(cb_in0, cb_in2);
+
+        cb_wait_front(cb_in2, ublock_size_tiles);
+        copy_block_matmul_partials(cb_in2, START_IN_TILE_ID, START_DST_TILE_ID, ublock_size_tiles);
+        cb_pop_front(cb_in2, ublock_size_tiles);
+
+        // -------------------- Addition with acc -----------------------------
+
+        // Init like CB_0 is in A and CB_1 is in B
+        add_tiles_init(cb_in0, cb_in1, true);
+
+        // Reconfigure UNPACK for correct source formats, tests reconfig calls
+#if (EXPLICIT_RECONFIG == 1)
+#if (SPLIT_SRC_RECONFIG == 1)
+        // Indices for old_operand, new_operand
+        unpack_reconfig_data_format_srca(cb_in0, cb_in1);
+        unpack_reconfig_data_format_srcb(cb_in1, cb_in0);
+#elif (SPLIT_SRC_RECONFIG == 0)
+        // Indices for old_A, new_A, old_B, new_B
+        unpack_reconfig_data_format(cb_in0, cb_in1, cb_in1, cb_in0);
+#endif // SPLIT_SRC_RECONFIG
+#elif (EXPLICIT_RECONFIG == 0)
+#if (SPLIT_SRC_RECONFIG == 1)
+        // Indices for new_operand
+        unpack_reconfig_data_format_srca(cb_in1);
+        unpack_reconfig_data_format_srcb(cb_in0);
+#elif (SPLIT_SRC_RECONFIG == 0)
+        // Indices for new_A, new_B
+        unpack_reconfig_data_format(cb_in1, cb_in0);
+#endif // SPLIT_SRC_RECONFIG
+#endif // EXPLICIT_RECONFIG
+
+        for (uint32_t i = 0; i < ublock_size_tiles; ++i) {
+            add_tiles(cb_in1, cb_in0, i, i, i);
+        }
+
+        // ----------------------- Pack to 2 outs -----------------------------
+
+        // Reconfig for L1 accumulation with old calc values
+#if (L1_ACC == 1)
+        pack_reconfig_l1_acc(true);
+#endif
+        // Configured already for CB_16, Bfp16_b
+        matmul_pack_tile(START_DST_TILE_ID, cb_out0, ublock_size_tiles);
+        // Reconfig for CB_17, Bfp8_b, then pack to CB_17
+#if (EXPLICIT_RECONFIG == 1)
+        // Indices for old_output, new_output
+        pack_reconfig_data_format(cb_out0, cb_out1);
+#elif (EXPLICIT_RECONFIG == 0)
+        // Indices for new_output
+        pack_reconfig_data_format(cb_out1);
+#endif
+        // Not testing for L1 accumulation
+        pack_reconfig_l1_acc(false);
+
+        matmul_pack_tile(START_DST_TILE_ID, cb_out1, ublock_size_tiles);
+        release_dst(tt::DstMode::Half);
+
+        cb_pop_front(cb_in0, ublock_size_tiles);
+        cb_pop_front(cb_in1, ublock_size_tiles);
+        cb_push_back(cb_out0, ublock_size_tiles);
+        cb_push_back(cb_out1, ublock_size_tiles);
+    }
+}
+}  // namespace NAMESPACE

--- a/tests/tt_metal/tt_metal/test_kernels/compute/reduce_w.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/compute/reduce_w.cpp
@@ -29,8 +29,14 @@ void MAIN {
             acquire_dst(tt::DstMode::Half);
             for(uint32_t wt = 0; wt < Wt; ++wt) {
                 cb_wait_front(tt::CB::c_in0, onetile);
+#if (MATH_ONLY == 1)
+                UNPACK(( llk_unpack_AB(tt::CB::c_in0, tt::CB::c_in2, 0, 0) ));
+                // REDUCE_OP is expected to come from add_define
+                reduce_tile_math(reduce_dst_idx);
+#elif (MATH_ONLY == 0)
                 // REDUCE_OP is expected to come from add_define
                 reduce_tile(tt::CB::c_in0, tt::CB::c_in2, 0, 0, reduce_dst_idx);
+#endif
                 cb_pop_front(tt::CB::c_in0, onetile);
             }
 

--- a/tests/tt_metal/tt_metal/test_kernels/dataflow/reader_unary_push_n.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/dataflow/reader_unary_push_n.cpp
@@ -1,0 +1,33 @@
+// SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "dataflow_api.h"
+
+void kernel_main() {
+    uint32_t src_addr  = get_arg_val<uint32_t>(0);
+    uint32_t src_noc_x = get_arg_val<uint32_t>(1);
+    uint32_t src_noc_y = get_arg_val<uint32_t>(2);
+    uint32_t num_tiles = get_arg_val<uint32_t>(3);
+    uint32_t cb_id_in0 = get_arg_val<uint32_t>(4);
+    uint32_t ublock_size_tiles = get_arg_val<uint32_t>(5);
+    bool reader_only = get_arg_val<uint32_t>(6);
+
+    uint32_t ublock_size_bytes = get_tile_size(cb_id_in0) * ublock_size_tiles;
+
+    for (uint32_t i = 0; i<num_tiles; i += ublock_size_tiles) {
+        uint64_t src_noc_addr = get_noc_addr(src_noc_x, src_noc_y, src_addr);
+        if (reader_only == false) {
+            cb_reserve_back(cb_id_in0, ublock_size_tiles);
+        }
+        uint32_t l1_write_addr = get_write_ptr(cb_id_in0);
+
+        noc_async_read(src_noc_addr, l1_write_addr, ublock_size_bytes);
+
+        noc_async_read_barrier();
+        if (reader_only == false) {
+            cb_push_back(cb_id_in0, ublock_size_tiles);
+        }
+        src_addr += ublock_size_bytes;
+    }
+}

--- a/tests/tt_metal/tt_metal/test_kernels/dataflow/writer_binary.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/dataflow/writer_binary.cpp
@@ -1,0 +1,41 @@
+// SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "dataflow_api.h"
+
+void kernel_main() {
+    uint32_t dst0_addr  = get_arg_val<uint32_t>(0);
+    uint32_t dst0_noc_x = get_arg_val<uint32_t>(1);
+    uint32_t dst0_noc_y = get_arg_val<uint32_t>(2);
+    uint32_t cb_id_out0 = get_arg_val<uint32_t>(3);
+    uint32_t dst1_addr  = get_arg_val<uint32_t>(4);
+    uint32_t dst1_noc_x = get_arg_val<uint32_t>(5);
+    uint32_t dst1_noc_y = get_arg_val<uint32_t>(6);
+    uint32_t cb_id_out1 = get_arg_val<uint32_t>(7);
+    uint32_t num_tiles = get_arg_val<uint32_t>(8);
+    uint32_t ublock_size_tiles = get_arg_val<uint32_t>(9);
+
+    uint32_t ublock0_size_bytes = get_tile_size(cb_id_out0) * ublock_size_tiles;
+    uint32_t ublock1_size_bytes = get_tile_size(cb_id_out1) * ublock_size_tiles;
+
+    for (uint32_t i = 0; i < num_tiles; i += ublock_size_tiles) {
+        uint64_t dst0_noc_addr = get_noc_addr(dst0_noc_x, dst0_noc_y, dst0_addr);
+        uint64_t dst1_noc_addr = get_noc_addr(dst1_noc_x, dst1_noc_y, dst1_addr);
+
+        cb_wait_front(cb_id_out0, ublock_size_tiles);
+        cb_wait_front(cb_id_out1, ublock_size_tiles);
+        uint32_t l1_read_addr0 = get_read_ptr(cb_id_out0);
+        uint32_t l1_read_addr1 = get_read_ptr(cb_id_out1);
+
+        noc_async_write(l1_read_addr0, dst0_noc_addr, ublock0_size_bytes);
+        noc_async_write(l1_read_addr1, dst1_noc_addr, ublock1_size_bytes);
+
+        noc_async_write_barrier();
+
+        cb_pop_front(cb_id_out0, ublock_size_tiles);
+        cb_pop_front(cb_id_out1, ublock_size_tiles);
+        dst0_addr += ublock0_size_bytes;
+        dst1_addr += ublock1_size_bytes;
+    }
+}

--- a/tests/tt_metal/tt_metal/test_kernels/dataflow/writer_unary_pop_n.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/dataflow/writer_unary_pop_n.cpp
@@ -1,0 +1,33 @@
+// SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "dataflow_api.h"
+
+void kernel_main() {
+    uint32_t dst_addr  = get_arg_val<uint32_t>(0);
+    uint32_t dst_noc_x = get_arg_val<uint32_t>(1);
+    uint32_t dst_noc_y = get_arg_val<uint32_t>(2);
+    uint32_t num_tiles = get_arg_val<uint32_t>(3);
+    uint32_t cb_id_out0 = get_arg_val<uint32_t>(4);
+    uint32_t ublock_size_tiles = get_arg_val<uint32_t>(5);
+    bool writer_only = get_arg_val<uint32_t>(6);
+
+    uint32_t ublock_size_bytes = get_tile_size(cb_id_out0) * ublock_size_tiles;
+
+    for (uint32_t i = 0; i < num_tiles; i += ublock_size_tiles) {
+        uint64_t dst_noc_addr = get_noc_addr(dst_noc_x, dst_noc_y, dst_addr);
+        if (writer_only == false) {
+            cb_wait_front(cb_id_out0, ublock_size_tiles);
+        }
+        uint32_t l1_read_addr = get_read_ptr(cb_id_out0);
+
+        noc_async_write(l1_read_addr, dst_noc_addr, ublock_size_bytes);
+
+        noc_async_write_barrier();
+        if (writer_only == false) {
+            cb_pop_front(cb_id_out0, ublock_size_tiles);
+        }
+        dst_addr += ublock_size_bytes;
+    }
+}

--- a/tests/tt_metal/tt_metal/unit_tests/CMakeLists.txt
+++ b/tests/tt_metal/tt_metal/unit_tests/CMakeLists.txt
@@ -21,6 +21,8 @@ set(UNIT_TESTS_SRC
     ${CMAKE_CURRENT_SOURCE_DIR}/compute/test_sfpu_compute.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/compute/test_dropout_sfpu_compute.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/compute/test_untilize_tilize.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/compute/test_copy_block_matmul_partials.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/compute/test_reconfig.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/compute/test_transpose.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/core_coord/test_CoreRange_adjacent.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/core_coord/test_CoreRange_contains.cpp

--- a/tests/tt_metal/tt_metal/unit_tests/compute/test_copy_block_matmul_partials.cpp
+++ b/tests/tt_metal/tt_metal/unit_tests/compute/test_copy_block_matmul_partials.cpp
@@ -1,0 +1,205 @@
+// SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "device_fixture.hpp"
+
+using namespace tt;
+
+namespace unit_tests::compute::matmul_partials {
+
+struct CopyBlockMatmulPartialsConfig {
+    uint32_t single_tile_size;
+    uint32_t num_tiles;
+    uint32_t reader_ublock;
+    uint32_t writer_ublock;
+    uint32_t compute_ublock;
+    uint32_t src0_cb_index;
+    uint32_t ouput_cb_index;
+};
+
+void run_single_core_copy_block_matmul_partials(tt_metal::Device* device, const CopyBlockMatmulPartialsConfig& test_config) {
+
+
+    ////////////////////////////////////////////////////////////////////////////
+    //                      Application Setup
+    ////////////////////////////////////////////////////////////////////////////
+    tt_metal::Program program = tt_metal::CreateProgram();
+
+    CoreCoord core = {0, 0};
+    uint32_t single_tile_size = test_config.single_tile_size;
+    uint32_t num_tiles = test_config.num_tiles;
+    uint32_t dram_buffer_size = single_tile_size * num_tiles;
+
+    tt_metal::InterleavedBufferConfig dram_config{
+                                    .device=device,
+                                    .size = dram_buffer_size,
+                                    .page_size = dram_buffer_size,
+                                    .buffer_type = tt_metal::BufferType::DRAM
+                                    };
+
+    auto src_dram_buffer_bf16 = CreateBuffer(dram_config);
+    uint32_t dram_buffer_src_addr = src_dram_buffer_bf16->address();
+    auto dst_dram_buffer = CreateBuffer(dram_config);
+    uint32_t dram_buffer_dst_addr = dst_dram_buffer->address();
+
+    auto dram_src_noc_xy = src_dram_buffer_bf16->noc_coordinates();
+    auto dram_dst_noc_xy = dst_dram_buffer->noc_coordinates();
+
+    uint32_t src0_cb_index = test_config.src0_cb_index;
+    uint32_t num_input_tiles = test_config.reader_ublock;
+    tt_metal::CircularBufferConfig cb_src0_config = tt_metal::CircularBufferConfig(num_input_tiles * single_tile_size, {{src0_cb_index, tt::DataFormat::Float16_b}})
+        .set_page_size(src0_cb_index, single_tile_size);
+    auto cb_src0 = tt_metal::CreateCircularBuffer(program, core, cb_src0_config);
+
+    uint32_t ouput_cb_index = test_config.ouput_cb_index;
+    uint32_t num_output_tiles = test_config.writer_ublock;
+    tt_metal::CircularBufferConfig cb_output_config = tt_metal::CircularBufferConfig(num_output_tiles * single_tile_size, {{ouput_cb_index, tt::DataFormat::Float16_b}})
+        .set_page_size(ouput_cb_index, single_tile_size);
+    auto cb_output = tt_metal::CreateCircularBuffer(program, core, cb_output_config);
+
+    auto unary_reader_kernel = tt_metal::CreateKernel(
+        program,
+        "tests/tt_metal/tt_metal/test_kernels/dataflow/reader_unary_push_n.cpp",
+        core,
+        tt_metal::DataMovementConfig{.processor = tt_metal::DataMovementProcessor::RISCV_1, .noc = tt_metal::NOC::RISCV_1_default});
+
+    auto unary_writer_kernel = tt_metal::CreateKernel(
+        program,
+        "tests/tt_metal/tt_metal/test_kernels/dataflow/writer_unary_pop_n.cpp",
+        core,
+        tt_metal::DataMovementConfig{.processor = tt_metal::DataMovementProcessor::RISCV_0, .noc = tt_metal::NOC::RISCV_0_default});
+
+    vector<uint32_t> compute_kernel_args = {
+        uint(num_tiles), // total tiles to transfer
+        uint(test_config.compute_ublock), // tiles to transfer in a single iteration/copy_block call
+        uint(src0_cb_index), // Input CB idx
+        uint(ouput_cb_index) // Output CB idx
+    };
+
+    auto eltwise_unary_kernel = tt_metal::CreateKernel(
+        program,
+        "tests/tt_metal/tt_metal/test_kernels/compute/eltwise_copy_block_matmul_partials.cpp",
+        core,
+        tt_metal::ComputeConfig{.compile_args = compute_kernel_args}
+    );
+
+
+    ////////////////////////////////////////////////////////////////////////////
+    //                      Execute Application
+    ////////////////////////////////////////////////////////////////////////////
+    std::vector<uint32_t> src_vec_bf16 = create_random_vector_of_bfloat16(
+        dram_buffer_size, 100, std::chrono::system_clock::now().time_since_epoch().count());
+    tt_metal::detail::WriteToBuffer(src_dram_buffer_bf16, src_vec_bf16);
+
+    tt_metal::SetRuntimeArgs(
+        program,
+        unary_reader_kernel,
+        core,
+        {dram_buffer_src_addr,
+        (std::uint32_t)dram_src_noc_xy.x,
+        (std::uint32_t)dram_src_noc_xy.y,
+        num_tiles,
+        src0_cb_index,
+        test_config.reader_ublock,
+        false});
+
+    tt_metal::SetRuntimeArgs(
+        program,
+        unary_writer_kernel,
+        core,
+        {dram_buffer_dst_addr,
+        (std::uint32_t)dram_dst_noc_xy.x,
+        (std::uint32_t)dram_dst_noc_xy.y,
+        num_tiles,
+        ouput_cb_index,
+        test_config.writer_ublock,
+        false});
+
+    tt_metal::detail::LaunchProgram(device, program);
+
+    std::vector<uint32_t> result_vec_bf16;
+    tt_metal::detail::ReadFromBuffer(dst_dram_buffer, result_vec_bf16);
+
+
+    ////////////////////////////////////////////////////////////////////////////
+    //                      Validation & Teardown
+    ////////////////////////////////////////////////////////////////////////////
+    EXPECT_EQ(src_vec_bf16.size(), result_vec_bf16.size());
+    EXPECT_EQ(src_vec_bf16, result_vec_bf16);
+
+
+}
+} // namespace unit_tests::compute::matmul_partials
+
+////////////////////////////////////////////////////////////////////////////
+//                             Tests
+// ------------------------------------------------------------------------
+// These tests aim to cover usage of these calls:
+// - copy_block_matmul_partials
+// - matmul_pack_tile
+//
+// Tests which contain a string in RXWYCZ format in their name cover
+// different scenarios in reader/writer/compute kernel usage. Letters
+// R, W and C represent reader, writer and compute kernel, respectively,
+// while the numbers X, Y and Z represent how many tiles will a kernel
+// move in a single loop iteration. This is important because depending
+// on these numbers, synchronization points are met at different places.
+// Since there can be a maximum of 8 32-by-32 tiles in DEST reg when using
+// half of it (for MATH/PACK sync purporses), highest bandwidth is achieved
+// when all three parameters are 8. It's also possible to enforce MATH/PACK
+// serialization by telling writer to wait for a single tile to be avail-
+// able in output CB.
+//
+////////////////////////////////////////////////////////////////////////////
+TEST_F(DeviceFixture, ComputeCopyBlockMatmulPartialsR8W8C8) {
+    unit_tests::compute::matmul_partials::CopyBlockMatmulPartialsConfig test_config = {
+        .single_tile_size = 2 * 1024,
+        .num_tiles = 8,
+        .reader_ublock = 8,
+        .writer_ublock = 8,
+        .compute_ublock = 8,
+        .src0_cb_index = 0,
+        .ouput_cb_index = 16
+    };
+    unit_tests::compute::matmul_partials::run_single_core_copy_block_matmul_partials(this->devices_.at(0), test_config);
+}
+
+TEST_F(DeviceFixture, ComputeCopyBlockMatmulPartialsR8W8C1) {
+    unit_tests::compute::matmul_partials::CopyBlockMatmulPartialsConfig test_config = {
+        .single_tile_size = 2 * 1024,
+        .num_tiles = 8,
+        .reader_ublock = 8,
+        .writer_ublock = 8,
+        .compute_ublock = 1,
+        .src0_cb_index = 0,
+        .ouput_cb_index = 16
+    };
+    unit_tests::compute::matmul_partials::run_single_core_copy_block_matmul_partials(this->devices_.at(0), test_config);
+}
+
+TEST_F(DeviceFixture, ComputeCopyBlockMatmulPartialsR8W1C1) {
+    unit_tests::compute::matmul_partials::CopyBlockMatmulPartialsConfig test_config = {
+        .single_tile_size = 2 * 1024,
+        .num_tiles = 8,
+        .reader_ublock = 8,
+        .writer_ublock = 1,
+        .compute_ublock = 1,
+        .src0_cb_index = 0,
+        .ouput_cb_index = 16
+    };
+    unit_tests::compute::matmul_partials::run_single_core_copy_block_matmul_partials(this->devices_.at(0), test_config);
+}
+
+TEST_F(DeviceFixture, ComputeCopyBlockMatmulPartialsR1W1C1) {
+    unit_tests::compute::matmul_partials::CopyBlockMatmulPartialsConfig test_config = {
+        .single_tile_size = 2 * 1024,
+        .num_tiles = 1,
+        .reader_ublock = 1,
+        .writer_ublock = 1,
+        .compute_ublock = 1,
+        .src0_cb_index = 0,
+        .ouput_cb_index = 16
+    };
+    unit_tests::compute::matmul_partials::run_single_core_copy_block_matmul_partials(this->devices_.at(0), test_config);
+}

--- a/tests/tt_metal/tt_metal/unit_tests/compute/test_reconfig.cpp
+++ b/tests/tt_metal/tt_metal/unit_tests/compute/test_reconfig.cpp
@@ -1,0 +1,354 @@
+// SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "device_fixture.hpp"
+#include "tt_metal/common/bfloat8.hpp"
+#include "tt_metal/test_utils/comparison.hpp"
+
+using namespace tt;
+using namespace tt::test_utils;
+
+namespace unit_tests::compute::reconfig {
+
+struct ReconfigConfig {
+    size_t num_tiles = 0;
+    size_t ublock_size_tiles = 0;
+    bool explicit_reconfig = false;
+    bool split_src_reconfig = false;
+    bool l1_acc = false;
+};
+
+/// @brief Does Dramx3 --> Reader --> CB --> Add with acc --> CB --> Writer --> Dram
+/// @param device
+/// @param test_config - Configuration of the test -- see struct
+/// @return
+bool single_core_reconfig(tt_metal::Device* device, const ReconfigConfig& test_config) {
+    bool pass = true;
+
+
+    ////////////////////////////////////////////////////////////////////////////
+    //                      Application Setup
+    ////////////////////////////////////////////////////////////////////////////
+    uint32_t in0_id = 0;
+    uint32_t in1_id = 1;
+    uint32_t in2_id = 2;
+    uint32_t out0_id = 16;
+    uint32_t out1_id = 17;
+    static float out0_result_old = 0;
+    // Since golden is not perfect, don't change these values much
+    float in0_val = 1.8601;
+    float in1_val = 0.0003;
+    float in2_val = 2.03456;
+    uint32_t single_tile_size_bfp16b = 2 * 32 * 32;              // Single 32x32 tile size for Float16_b
+    uint32_t single_tile_size_bfp8b = 1 * 32 * 32 + 64;          // Single 32x32 tile size for Bfp8_b
+    const size_t dram_buffer_size_bfp16b = test_config.num_tiles * single_tile_size_bfp16b;
+    const size_t dram_buffer_size_bfp8b = test_config.num_tiles * single_tile_size_bfp8b;
+
+    CoreCoord core = {0, 0};
+    tt_metal::Program program = tt_metal::CreateProgram();
+
+    tt::tt_metal::InterleavedBufferConfig dram_config_bfp16b{
+        .device = device, .size = dram_buffer_size_bfp16b, .page_size = dram_buffer_size_bfp16b, .buffer_type = tt::tt_metal::BufferType::DRAM};
+
+    tt::tt_metal::InterleavedBufferConfig dram_config_bfp8b{
+        .device = device, .size = dram_buffer_size_bfp8b, .page_size = dram_buffer_size_bfp8b, .buffer_type = tt::tt_metal::BufferType::DRAM};
+
+    // This will be srcB in Bfp8_b
+    auto input0_dram_buffer = CreateBuffer(dram_config_bfp8b);
+    uint32_t input0_dram_byte_address = input0_dram_buffer->address();
+    auto input0_dram_noc_xy = input0_dram_buffer->noc_coordinates();
+
+    // This will be srcA in Float16_b
+    auto input1_dram_buffer = CreateBuffer(dram_config_bfp16b);
+    uint32_t input1_dram_byte_address = input1_dram_buffer->address();
+    auto input1_dram_noc_xy = input1_dram_buffer->noc_coordinates();
+
+    // This will be DEST in Float16_b
+    auto input2_dram_buffer = CreateBuffer(dram_config_bfp16b);
+    uint32_t input2_dram_byte_address = input2_dram_buffer->address();
+    auto input2_dram_noc_xy = input2_dram_buffer->noc_coordinates();
+
+    // This will be Output0 in Float16_b
+    auto output0_dram_buffer = CreateBuffer(dram_config_bfp16b);
+    uint32_t output0_dram_byte_address = output0_dram_buffer->address();
+    auto output0_dram_noc_xy = output0_dram_buffer->noc_coordinates();
+
+    // This will be Output1 in Bfp8_b
+    auto output1_dram_buffer = CreateBuffer(dram_config_bfp8b);
+    uint32_t output1_dram_byte_address = output1_dram_buffer->address();
+    auto output1_dram_noc_xy = output1_dram_buffer->noc_coordinates();
+
+    tt_metal::CircularBufferConfig l1_input0_cb_config =
+        tt_metal::CircularBufferConfig(dram_buffer_size_bfp8b, {{in0_id, tt::DataFormat::Bfp8_b}})
+            .set_page_size(in0_id, single_tile_size_bfp8b);
+    auto l1_input0_cb = tt_metal::CreateCircularBuffer(program, core, l1_input0_cb_config);
+
+    tt_metal::CircularBufferConfig l1_input1_cb_config =
+        tt_metal::CircularBufferConfig(dram_buffer_size_bfp16b, {{in1_id, tt::DataFormat::Float16_b}})
+            .set_page_size(in1_id, single_tile_size_bfp16b);
+    auto l1_input1_cb = tt_metal::CreateCircularBuffer(program, core, l1_input1_cb_config);
+
+    tt_metal::CircularBufferConfig l1_input2_cb_config =
+        tt_metal::CircularBufferConfig(dram_buffer_size_bfp16b, {{in2_id, tt::DataFormat::Float16_b}})
+            .set_page_size(in2_id, single_tile_size_bfp16b);
+    auto l1_input2_cb = tt_metal::CreateCircularBuffer(program, core, l1_input2_cb_config);
+
+    tt_metal::CircularBufferConfig l1_output0_cb_config =
+        tt_metal::CircularBufferConfig(dram_buffer_size_bfp16b, {{out0_id, tt::DataFormat::Float16_b}})
+            .set_page_size(out0_id, single_tile_size_bfp16b);
+    auto l1_output0_cb = tt_metal::CreateCircularBuffer(program, core, l1_output0_cb_config);
+
+    tt_metal::CircularBufferConfig l1_output1_cb_config =
+        tt_metal::CircularBufferConfig(dram_buffer_size_bfp8b, {{out1_id, tt::DataFormat::Bfp8_b}})
+            .set_page_size(out1_id, single_tile_size_bfp8b);
+    auto l1_output1_cb = tt_metal::CreateCircularBuffer(program, core, l1_output1_cb_config);
+
+    vector<uint32_t> compute_kernel_args = {};
+    std::map<string, string> defines;
+
+    defines["DST_ACCUM_MODE"] = "1";
+    if (test_config.explicit_reconfig) {
+        defines["EXPLICIT_RECONFIG"] = "1";
+    } else {
+        defines["EXPLICIT_RECONFIG"] = "0";
+    }
+    if (test_config.split_src_reconfig) {
+        defines["SPLIT_SRC_RECONFIG"] = "1";
+    } else {
+        defines["SPLIT_SRC_RECONFIG"] = "0";
+    }
+    if (test_config.l1_acc) {
+        defines["L1_ACC"] = "1";
+    } else {
+        defines["L1_ACC"] = "0";
+    }
+
+    auto reader_kernel = tt_metal::CreateKernel(
+        program,
+        "tests/tt_metal/tt_metal/test_kernels/dataflow/reader_binary.cpp",
+        core,
+        tt_metal::DataMovementConfig{
+            .processor = tt_metal::DataMovementProcessor::RISCV_1, .noc = tt_metal::NOC::RISCV_1_default, .defines=defines});
+
+    auto writer_kernel = tt_metal::CreateKernel(
+        program,
+        "tests/tt_metal/tt_metal/test_kernels/dataflow/writer_binary.cpp",
+        core,
+        tt_metal::DataMovementConfig{
+            .processor = tt_metal::DataMovementProcessor::RISCV_0, .noc = tt_metal::NOC::RISCV_0_default});
+
+    auto compute_kernel = tt_metal::CreateKernel(
+        program,
+        "tests/tt_metal/tt_metal/test_kernels/compute/reconfig.cpp",
+        core,
+        tt_metal::ComputeConfig{.compile_args = compute_kernel_args, .defines = defines});
+
+    SetRuntimeArgs(
+        program,
+        compute_kernel,
+        core,
+        {
+            uint32_t(test_config.num_tiles),
+            uint32_t(test_config.ublock_size_tiles),
+        });
+
+
+    ////////////////////////////////////////////////////////////////////////////
+    //                      Stimulus Generation
+    ////////////////////////////////////////////////////////////////////////////
+    // Since we're testing compute threads' reconfiguration, it's not necessary
+    // for input tensors to be filled with random values, only that one src reg
+    // is in different format than the other. If thread reconfiguration is done
+    // incorrectly or underlying API/LLK is broken, this will be shown in either
+    // difference in output sizes or values.
+    std::vector<uint32_t> src0_vec = create_constant_vector_of_bfp8(
+            dram_buffer_size_bfp8b,
+            in0_val,
+            false);
+    std::vector<uint32_t> src1_vec = create_constant_vector_of_bfloat16(
+            dram_buffer_size_bfp16b,
+            in1_val);
+    std::vector<uint32_t> src2_vec = create_constant_vector_of_bfloat16(
+            dram_buffer_size_bfp16b,
+            in2_val);
+
+
+    ////////////////////////////////////////////////////////////////////////////
+    //                      Golden Generation
+    ////////////////////////////////////////////////////////////////////////////
+    auto input0 = unpack_bfp8_tiles_into_float_vec(src0_vec, true, false);
+    auto input1 = unpack_uint32_vec_into_bfloat16_vec(src1_vec);
+    auto input2 = unpack_uint32_vec_into_bfloat16_vec(src2_vec);
+
+    // Intermediate result stored in temp_golden should be represented in
+    // 19 bits since that's the width of srcA/B/FPU. This is why it's
+    // float32 in golden. As for golden1, it should be Bfp8_b in the end,
+    // but since there's no available conversion from Float16_b to Bfp8_b,
+    // it's left in float and then converted to Bfp8_b.
+    std::vector<float> temp_golden(input1.size());
+    std::vector<bfloat16> golden0(input1.size());
+    std::vector<float> golden1(input1.size());
+    for (auto i = 0; i < temp_golden.size(); i++) {
+        temp_golden[i] = input1[i].to_float() + bfloat16(input0[i]).to_float();
+        golden0[i] = bfloat16(temp_golden[i] + input2[i].to_float());
+        golden1[i] = bfloat16(temp_golden[i] + input2[i].to_float()).to_float();
+        if (test_config.l1_acc) {
+            golden0[i] = bfloat16(golden0[i].to_float() + out0_result_old);
+        } else {
+            out0_result_old = golden0[i].to_float();
+        }
+    }
+    std::vector<uint32_t> packed_golden0 = pack_vector<uint32_t, bfloat16>(golden0);
+    std::vector<uint32_t> packed_golden1 = pack_fp32_vec_as_bfp8_tiles(golden1, true, false);
+
+    // ////////////////////////////////////////////////////////////////////////////
+    // //                      Compile and Execute Application
+    // ////////////////////////////////////////////////////////////////////////////
+    tt_metal::detail::WriteToBuffer(input0_dram_buffer, src0_vec);
+    tt_metal::detail::WriteToBuffer(input1_dram_buffer, src1_vec);
+    tt_metal::detail::WriteToBuffer(input2_dram_buffer, src2_vec);
+
+    tt_metal::SetRuntimeArgs(
+        program,
+        reader_kernel,
+        core,
+        {
+            (uint32_t)input0_dram_byte_address,
+            (uint32_t)input0_dram_noc_xy.x,
+            (uint32_t)input0_dram_noc_xy.y,
+            (uint32_t)input1_dram_byte_address,
+            (uint32_t)input1_dram_noc_xy.x,
+            (uint32_t)input1_dram_noc_xy.y,
+            (uint32_t)test_config.num_tiles,
+            (uint32_t)input2_dram_byte_address,
+            (uint32_t)input2_dram_noc_xy.x,
+            (uint32_t)input2_dram_noc_xy.y,
+        });
+    tt_metal::SetRuntimeArgs(
+        program,
+        writer_kernel,
+        core,
+        {
+            (uint32_t)output0_dram_byte_address,
+            (uint32_t)output0_dram_noc_xy.x,
+            (uint32_t)output0_dram_noc_xy.y,
+            (uint32_t)out0_id,
+            (uint32_t)output1_dram_byte_address,
+            (uint32_t)output1_dram_noc_xy.x,
+            (uint32_t)output1_dram_noc_xy.y,
+            (uint32_t)out1_id,
+            (uint32_t)test_config.num_tiles,
+            (uint32_t)test_config.ublock_size_tiles,
+        });
+
+    tt_metal::detail::LaunchProgram(device, program);
+
+
+    // ////////////////////////////////////////////////////////////////////////////
+    // //                      Comparison Checking
+    // ////////////////////////////////////////////////////////////////////////////
+    std::vector<uint32_t> dest0_buffer_data(src1_vec.size());
+    std::vector<uint32_t> dest1_buffer_data(src0_vec.size());
+    tt_metal::detail::ReadFromBuffer(output0_dram_buffer, dest0_buffer_data);
+    tt_metal::detail::ReadFromBuffer(output1_dram_buffer, dest1_buffer_data);
+
+    pass &= is_close_packed_vectors<bfloat16, uint32_t>(
+        dest0_buffer_data,
+        packed_golden0,
+        [&](const bfloat16& a, const bfloat16& b) {
+            return is_close(a, b, 0.015f);
+        });
+    pass &= is_close_packed_vectors<bfloat16, uint32_t>(
+        dest1_buffer_data,
+        packed_golden1,
+        [&](const bfloat16& a, const bfloat16& b) {
+            return is_close(a, b, 0.015f);
+        });
+
+    return pass;
+}
+}  // namespace unit_tests::compute::binary
+
+TEST_F(DeviceFixture, TileCopyReconfigExplicitSplit) {
+    auto arch = this->arch_;
+    if (arch == tt::ARCH::GRAYSKULL) {
+        GTEST_SKIP();
+    }
+    unit_tests::compute::reconfig::ReconfigConfig test_config = {
+        .num_tiles = 1,
+        .ublock_size_tiles = 1,
+        .explicit_reconfig = true,
+        .split_src_reconfig = true
+    };
+    for (unsigned int id = 0; id < num_devices_; id++) {
+        ASSERT_TRUE(unit_tests::compute::reconfig::single_core_reconfig(devices_.at(id), test_config));
+    }
+}
+
+TEST_F(DeviceFixture, TileCopyReconfigExplicitJoined) {
+    auto arch = this->arch_;
+    if (arch == tt::ARCH::GRAYSKULL) {
+        GTEST_SKIP();
+    }
+    unit_tests::compute::reconfig::ReconfigConfig test_config = {
+        .num_tiles = 1,
+        .ublock_size_tiles = 1,
+        .explicit_reconfig = true,
+        .split_src_reconfig = false
+    };
+    for (unsigned int id = 0; id < num_devices_; id++) {
+        ASSERT_TRUE(unit_tests::compute::reconfig::single_core_reconfig(devices_.at(id), test_config));
+    }
+}
+
+TEST_F(DeviceFixture, TileCopyReconfigImplicitSplit) {
+    auto arch = this->arch_;
+    if (arch == tt::ARCH::GRAYSKULL) {
+        GTEST_SKIP();
+    }
+    unit_tests::compute::reconfig::ReconfigConfig test_config = {
+        .num_tiles = 1,
+        .ublock_size_tiles = 1,
+        .explicit_reconfig = false,
+        .split_src_reconfig = true
+    };
+    for (unsigned int id = 0; id < num_devices_; id++) {
+        ASSERT_TRUE(unit_tests::compute::reconfig::single_core_reconfig(devices_.at(id), test_config));
+    }
+}
+
+TEST_F(DeviceFixture, TileCopyReconfigImplicitJoined) {
+    auto arch = this->arch_;
+    if (arch == tt::ARCH::GRAYSKULL) {
+        GTEST_SKIP();
+    }
+    unit_tests::compute::reconfig::ReconfigConfig test_config = {
+        .num_tiles = 1,
+        .ublock_size_tiles = 1,
+        .explicit_reconfig = false,
+        .split_src_reconfig = false
+    };
+    for (unsigned int id = 0; id < num_devices_; id++) {
+        ASSERT_TRUE(unit_tests::compute::reconfig::single_core_reconfig(devices_.at(id), test_config));
+    }
+}
+
+TEST_F(DeviceFixture, TileCopyReconfigL1Acc) {
+    auto arch = this->arch_;
+    if (arch == tt::ARCH::GRAYSKULL) {
+        GTEST_SKIP();
+    }
+    unit_tests::compute::reconfig::ReconfigConfig test_config = {
+        .num_tiles = 1,
+        .ublock_size_tiles = 1,
+    };
+    for (unsigned int id = 0; id < num_devices_; id++) {
+        test_config.l1_acc = false;
+        ASSERT_TRUE(unit_tests::compute::reconfig::single_core_reconfig(devices_.at(id), test_config));
+        log_info(LogTest, "Passed without L1 accumulation");
+        test_config.l1_acc = true;
+        ASSERT_TRUE(unit_tests::compute::reconfig::single_core_reconfig(devices_.at(id), test_config));
+        log_info(LogTest, "Passed with L1 accumulation");
+    }
+}

--- a/tests/tt_metal/tt_metal/unit_tests_common/compute/matmul/matmul_utils.hpp
+++ b/tests/tt_metal/tt_metal/unit_tests_common/compute/matmul/matmul_utils.hpp
@@ -9,7 +9,7 @@
 #include "tt_metal/detail/tt_metal.hpp"
 #include "common/bfloat16.hpp"
 #include "tt_metal/test_utils/deprecated/tensor.hpp"
-#include "test_tiles.hpp"
+#include "tt_metal/common/test_tiles.hpp"
 #include "hostdevcommon/common_values.hpp"
 #include "tt_metal/impl/dispatch/command_queue.hpp"
 

--- a/tests/tt_metal/tt_metal/unit_tests_common/compute/matmul/test_matmul_X_tile.cpp
+++ b/tests/tt_metal/tt_metal/unit_tests_common/compute/matmul/test_matmul_X_tile.cpp
@@ -22,7 +22,9 @@ namespace unit_tests_common::matmul::test_matmul_X_tile{
 
 struct MatmulTileConfig {
     uint32_t M, K, N;
-    bool with_bias;
+    bool with_bias = false;
+    bool test_init_short = false;
+    bool with_dt = true;
     string reader_kernel;
     string compute_kernel;
     vector<uint32_t> compute_kernel_args;
@@ -77,6 +79,7 @@ bool matmul_tile(CommonFixture *fixture, tt_metal::Device *device, const MatmulT
     auto cb_src1 = tt_metal::CreateCircularBuffer(program, core, cb_src1_config);
 
     std::shared_ptr<tt_metal::Buffer> src2_dram_buffer;
+    std::shared_ptr<tt_metal::Buffer> dst1_dram_buffer;
     if (cfg.with_bias) { // with_bias only when M, N, or K > 1
         tt_metal::InterleavedBufferConfig bias_config{
                     .device=device,
@@ -90,7 +93,34 @@ bool matmul_tile(CommonFixture *fixture, tt_metal::Device *device, const MatmulT
         tt_metal::CircularBufferConfig cb_src2_config = tt_metal::CircularBufferConfig(num_input_tiles * single_tile_size, {{src2_cb_index, tt::DataFormat::Float16_b}})
             .set_page_size(src2_cb_index, single_tile_size);
         auto cb_src2 = tt_metal::CreateCircularBuffer(program, core, cb_src2_config);
+    } else if (cfg.test_init_short) {// This will be dummy input in uint16_t
+        uint32_t in2_id = 2;
+        uint32_t out1_id = 17;
+
+        tt_metal::InterleavedBufferConfig dummy_config{
+                    .device=device,
+                    .size = single_tile_size * N,
+                    .page_size = single_tile_size * N,
+                    .buffer_type = tt_metal::BufferType::DRAM
+        };
+
+        // This will be srcB in uint16_t
+        src2_dram_buffer = CreateBuffer(dummy_config);
+
+        // This will be dummy output in uint16_t
+        dst1_dram_buffer = CreateBuffer(dummy_config);
+
+        tt_metal::CircularBufferConfig cb_src2_config =
+        tt_metal::CircularBufferConfig(num_input_tiles * single_tile_size, {{in2_id, tt::DataFormat::UInt16}})
+            .set_page_size(in2_id, single_tile_size);
+        auto cb_src2 = tt_metal::CreateCircularBuffer(program, core, cb_src2_config);
+
+        tt_metal::CircularBufferConfig cb_dst1_config =
+        tt_metal::CircularBufferConfig(num_input_tiles * single_tile_size, {{out1_id, tt::DataFormat::UInt16}})
+            .set_page_size(out1_id, single_tile_size);
+        auto cb_dst1 = tt_metal::CreateCircularBuffer(program, core, cb_dst1_config);
     }
+
     uint32_t ouput_cb_index = 16;
     vector<uint32_t> reader_l1_args;
     if (cfg.M > 1 || cfg.N > 1 || cfg.K > 1){
@@ -141,6 +171,19 @@ bool matmul_tile(CommonFixture *fixture, tt_metal::Device *device, const MatmulT
         };
     }
 
+    std::map<string, string> compute_defines;
+
+    if (cfg.with_dt) {
+        compute_defines["WITH_DT"] = "1";
+    } else {
+        compute_defines["WITH_DT"] = "0";
+    }
+    if (cfg.test_init_short) {
+        compute_defines["TEST_INIT_SHORT"] = "1";
+    } else {
+        compute_defines["TEST_INIT_SHORT"] = "0";
+    }
+
     auto mm_reader_kernel = tt_metal::CreateKernel(
         program,
         cfg.reader_kernel,
@@ -157,13 +200,13 @@ bool matmul_tile(CommonFixture *fixture, tt_metal::Device *device, const MatmulT
         program,
         cfg.compute_kernel,
         core,
-        tt_metal::ComputeConfig{.compile_args = cfg.compute_kernel_args}
+        tt_metal::ComputeConfig{.compile_args = cfg.compute_kernel_args, .defines = compute_defines}
     );
 
     fixture->WriteBuffer(device, src0_dram_buffer, activations);
     fixture->WriteBuffer(device, src1_dram_buffer, weights);
 
-    if (cfg.with_bias){
+    if (cfg.with_bias || cfg.test_init_short){
         vector<uint32_t> bias(N * 512, 0);
         fixture->WriteBuffer(device, src2_dram_buffer, bias);
 
@@ -212,7 +255,10 @@ bool matmul_tile(CommonFixture *fixture, tt_metal::Device *device, const MatmulT
     }
     DeallocateBuffer(*src0_dram_buffer);
     DeallocateBuffer(*src1_dram_buffer);
-    if (cfg.with_bias) {
+    if (cfg.with_bias || cfg.test_init_short) {
+        if (cfg.test_init_short) {
+            DeallocateBuffer(*dst1_dram_buffer);
+        }
         DeallocateBuffer(*src2_dram_buffer);
     }
     DeallocateBuffer(*dst_dram_buffer);
@@ -223,7 +269,6 @@ bool matmul_tile(CommonFixture *fixture, tt_metal::Device *device, const MatmulT
 TEST_F(CommonFixture, MatmulSingleTile){
     unit_tests_common::matmul::test_matmul_X_tile::MatmulTileConfig matmul_config = {
         .M = 1, .K = 1, .N = 1,
-        .with_bias = false,
         .reader_kernel = "tests/tt_metal/tt_metal/test_kernels/dataflow/reader_matmul_blocked.cpp",
         .compute_kernel = "tests/tt_metal/tt_metal/test_kernels/compute/matmul.cpp",
         .compute_kernel_args = {
@@ -256,7 +301,6 @@ TEST_F(CommonFixture, MatmulMultiTile){
     uint32_t K = 4;
     unit_tests_common::matmul::test_matmul_X_tile::MatmulTileConfig matmul_config = {
         .M = M, .K = K, .N = N,
-        .with_bias = false,
         .reader_kernel = "tests/tt_metal/tt_metal/test_kernels/dataflow/reader_matmul_with_bias_blocked.cpp",
         .compute_kernel = "tests/tt_metal/tt_metal/test_kernels/compute/matmul_with_bias.cpp",
         .compute_kernel_args = {
@@ -289,5 +333,119 @@ TEST_F(CommonFixture, MatmulMultiTile){
         matmul_config.with_bias = true;
         ASSERT_TRUE(unit_tests_common::matmul::test_matmul_X_tile::matmul_tile(this, devices_.at(id), matmul_config, activations_tile_transposed, weights, tensor));
         log_info(LogTest, "Multi tile with bias passed");
+    }
+}
+
+TEST_F(CommonFixture, MatmulBlock){
+    uint32_t M = 4;
+    uint32_t N = 4;
+    uint32_t K = 4;
+    unit_tests_common::matmul::test_matmul_X_tile::MatmulTileConfig matmul_config = {
+        .M = M, .K = K, .N = N,
+        .test_init_short = false,
+        .with_dt = false,
+        .reader_kernel = "tests/tt_metal/tt_metal/test_kernels/dataflow/reader_matmul_with_bias_blocked.cpp",
+        .compute_kernel = "tests/tt_metal/tt_metal/test_kernels/compute/matmul_block.cpp",
+        .compute_kernel_args = {
+            1, // block_tile_dim, within block, how many tiles are on the K dim
+            M, // dst_tile_rows
+            N, // dst_tile_cols
+            K, // block_cnt, across blocks, how many tiles are on the K dim
+            M, // in0_block_tile_cnt, M * block_tile_dim
+            N, // in1_block_tile_cnt,  N * block_tile_dim
+            (M * N), // out_block_tile_cnt
+        }
+    };
+
+    SHAPE shape = {1, 1, M * 32, K * 32};
+    tt::deprecated::Tensor<bfloat16> tensor = tt::deprecated::initialize_tensor<bfloat16>(shape, tt::deprecated::Initialize::RANDOM, 100, std::chrono::system_clock::now().time_since_epoch().count());
+    auto activations_tilized = test_utils::tilize(tensor.get_values(), M * 32, K * 32);
+    auto activations_tile_layout = convert_to_tile_layout(activations_tilized);
+    auto activations = pack_bfloat16_vec_into_uint32_vec(activations_tile_layout);
+    auto activations_tile_transposed = transpose_tiles(activations, M, K, 1);
+
+    auto identity = create_identity_matrix(K * 32, N * 32, std::min(K, N) * 32); //bfloat16 32x32 identity
+    auto identity_tilized = test_utils::tilize(identity, K * 32, N * 32);
+    auto weights_tile_layout = convert_to_tile_layout(identity_tilized);
+    auto weights = pack_bfloat16_vec_into_uint32_vec(weights_tile_layout);
+
+    for(unsigned int id = 0; id < devices_.size(); id++){
+        ASSERT_TRUE(unit_tests_common::matmul::test_matmul_X_tile::matmul_tile(this, devices_.at(id), matmul_config, activations_tile_transposed, weights, tensor));
+    }
+}
+
+TEST_F(CommonFixture, MatmulBlockInitShort){
+    uint32_t M = 4;
+    uint32_t N = 4;
+    uint32_t K = 4;
+    unit_tests_common::matmul::test_matmul_X_tile::MatmulTileConfig matmul_config = {
+        .M = M, .K = K, .N = N,
+        .test_init_short = true,
+        .with_dt = false,
+        .reader_kernel = "tests/tt_metal/tt_metal/test_kernels/dataflow/reader_matmul_with_bias_blocked.cpp",
+        .compute_kernel = "tests/tt_metal/tt_metal/test_kernels/compute/matmul_block.cpp",
+        .compute_kernel_args = {
+            1, // block_tile_dim, within block, how many tiles are on the K dim
+            M, // dst_tile_rows
+            N, // dst_tile_cols
+            K, // block_cnt, across blocks, how many tiles are on the K dim
+            M, // in0_block_tile_cnt, M * block_tile_dim
+            N, // in1_block_tile_cnt,  N * block_tile_dim
+            (M * N), // out_block_tile_cnt
+        }
+    };
+
+    SHAPE shape = {1, 1, M * 32, K * 32};
+    tt::deprecated::Tensor<bfloat16> tensor = tt::deprecated::initialize_tensor<bfloat16>(shape, tt::deprecated::Initialize::RANDOM, 100, std::chrono::system_clock::now().time_since_epoch().count());
+    auto activations_tilized = test_utils::tilize(tensor.get_values(), M * 32, K * 32);
+    auto activations_tile_layout = convert_to_tile_layout(activations_tilized);
+    auto activations = pack_bfloat16_vec_into_uint32_vec(activations_tile_layout);
+    auto activations_tile_transposed = transpose_tiles(activations, M, K, 1);
+
+    auto identity = create_identity_matrix(K * 32, N * 32, std::min(K, N) * 32); //bfloat16 32x32 identity
+    auto identity_tilized = test_utils::tilize(identity, K * 32, N * 32);
+    auto weights_tile_layout = convert_to_tile_layout(identity_tilized);
+    auto weights = pack_bfloat16_vec_into_uint32_vec(weights_tile_layout);
+
+    for(unsigned int id = 0; id < devices_.size(); id++){
+        ASSERT_TRUE(unit_tests_common::matmul::test_matmul_X_tile::matmul_tile(this, devices_.at(id), matmul_config, activations_tile_transposed, weights, tensor));
+    }
+}
+
+TEST_F(CommonFixture, MatmulBlockInitShortWithDt){
+    uint32_t M = 4;
+    uint32_t N = 4;
+    uint32_t K = 4;
+    unit_tests_common::matmul::test_matmul_X_tile::MatmulTileConfig matmul_config = {
+        .M = M, .K = K, .N = N,
+        .test_init_short = true,
+        .with_dt = true,
+        .reader_kernel = "tests/tt_metal/tt_metal/test_kernels/dataflow/reader_matmul_with_bias_blocked.cpp",
+        .compute_kernel = "tests/tt_metal/tt_metal/test_kernels/compute/matmul_block.cpp",
+        .compute_kernel_args = {
+            1, // block_tile_dim, within block, how many tiles are on the K dim
+            M, // dst_tile_rows
+            N, // dst_tile_cols
+            K, // block_cnt, across blocks, how many tiles are on the K dim
+            M, // in0_block_tile_cnt, M * block_tile_dim
+            N, // in1_block_tile_cnt,  N * block_tile_dim
+            (M * N), // out_block_tile_cnt
+        }
+    };
+
+    SHAPE shape = {1, 1, M * 32, K * 32};
+    tt::deprecated::Tensor<bfloat16> tensor = tt::deprecated::initialize_tensor<bfloat16>(shape, tt::deprecated::Initialize::RANDOM, 100, std::chrono::system_clock::now().time_since_epoch().count());
+    auto activations_tilized = test_utils::tilize(tensor.get_values(), M * 32, K * 32);
+    auto activations_tile_layout = convert_to_tile_layout(activations_tilized);
+    auto activations = pack_bfloat16_vec_into_uint32_vec(activations_tile_layout);
+    auto activations_tile_transposed = transpose_tiles(activations, M, K, 1);
+
+    auto identity = create_identity_matrix(K * 32, N * 32, std::min(K, N) * 32); //bfloat16 32x32 identity
+    auto identity_tilized = test_utils::tilize(identity, K * 32, N * 32);
+    auto weights_tile_layout = convert_to_tile_layout(identity_tilized);
+    auto weights = pack_bfloat16_vec_into_uint32_vec(weights_tile_layout);
+
+    for(unsigned int id = 0; id < devices_.size(); id++){
+        ASSERT_TRUE(unit_tests_common::matmul::test_matmul_X_tile::matmul_tile(this, devices_.at(id), matmul_config, activations_tile_transposed, weights, tensor));
     }
 }


### PR DESCRIPTION
### Ticket
N/A

### Problem description
Not all BH LLK APIs used by OPs are covered by tests.

### What's changed
Expanded BH LLK API Test Coverage:
1. test_copy_block_matmul_partials [new test] - tests block tile copy and pack API
2. test_reconfig [new test] - tests reconfiguration API for unpack, math and pack
3. test_matmul_X_tile [expanded] - tests matmul block and related init API
For testing purposes, new test kernels were added for both compute and data movement.

### Checklist
- [x] Post commit CI passes
- [x] Blackhole Post commit (if applicable)
- [ ] Model regression CI testing passes (if applicable)
- [x] New/Existing tests provide coverage for changes
