### PR TITLE
#0: Call op validation when program cache is disabled

### DIFF
--- a/ttnn/cpp/ttnn/device_operation.hpp
+++ b/ttnn/cpp/ttnn/device_operation.hpp
@@ -326,6 +326,8 @@ void launch_on_worker_thread(auto cq_id, auto operation_id, const auto& operatio
     } else {
         auto program_hash = 0;
         bool program_cache_hit = false;
+        device_operation_t::validate_on_program_cache_miss(operation_attributes, tensor_args);
+
         log_operation<device_operation_t>(operation_attributes, tensor_args, program_hash, program_cache_hit);
 
         tt::stl::reflection::visit_object_of_type<Tensor>(CheckDeviceBufferIsAllocated{}, tensor_args);


### PR DESCRIPTION
### Problem description
When the program cache is disabled, we don't run op validation logic at all.

### What's changed
Added the call to `validate_on_program_cache_miss` for this case to the `launch_on_worker_thread` function.

### Checklist
- [ ] Post commit CI passes
