### PR TITLE
#11720: Enable ttnn binary to be built using rpath as origin

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -288,3 +288,5 @@ add_custom_target(clean-built
    COMMAND ${CMAKE_COMMAND} -E remove_directory ${PROJECT_SOURCE_DIR}/built
    COMMENT "Cleaning `built` directory"
 )
+
+set_target_properties(ttnn PROPERTIES INSTALL_RPATH "$ORIGIN" BUILD_RPATH "$ORIGIN")


### PR DESCRIPTION
This PR enables ttnn to dynamically link to other libraries starting from the location of where the binary is located. This is very useful for upstream projects that want to build ttnn.so and ship it around. It will also help metal's packaging and releases as it allows the package to be relocatable. 

Hierarchy of linker paths
1. directories specified by link flags (-l)
2. directories in rpath and runpath
3. env variables (LD_LIBRARY_PATH)
4. default system lib paths

built in absolute paths are bypassed by this search