### PR TITLE
#11704: Add git_branch_name to ci/cd info

### DIFF
--- a/infra/data_collection/github/utils.py
+++ b/infra/data_collection/github/utils.py
@@ -19,6 +19,7 @@ PIPELINE_CSV_FIELDS = (
     "project",
     "trigger",
     "vcs_platform",
+    "git_branch_name",
     "git_commit_hash",
     "git_author",
     "orchestrator",
@@ -104,6 +105,8 @@ def get_pipeline_row_from_github_info(github_runner_environment, github_pipeline
     logger.warning("Using hardcoded value github for vcs_platform value")
     vcs_platform = "github"
 
+    git_branch_name = github_pipeline_json["head_branch"]
+
     git_commit_hash = github_pipeline_json["head_sha"]
 
     git_author = github_pipeline_json["head_commit"]["author"]["name"]
@@ -121,6 +124,7 @@ def get_pipeline_row_from_github_info(github_runner_environment, github_pipeline
         "project": project,
         "trigger": trigger,
         "vcs_platform": vcs_platform,
+        "git_branch_name": git_branch_name,
         "git_commit_hash": git_commit_hash,
         "git_author": git_author,
         "orchestrator": orchestrator,

--- a/infra/data_collection/pydantic_models.py
+++ b/infra/data_collection/pydantic_models.py
@@ -95,6 +95,7 @@ class Pipeline(BaseModel):
         description="Version control software used for the code tested in the pipeline.",
     )
     repository_url: str = Field(description="URL of the code repository.")
+    git_branch_name: Optional[str] = Field(description="Name of the Git branch tested by the pipeline.")
     git_commit_hash: str = Field(description="Git commit that triggered the execution of the pipeline.")
     git_author: str = Field(description="Author of the Git commit.")
     orchestrator: Optional[str] = Field(None, description="CI/CD pipeline orchestration platform.")


### PR DESCRIPTION
### Ticket

#11704


### Problem description

Add `branch_info` to ci/cd info so that we can delineate by branch

### What's changed

Get branch info from workflow context

### Checklist
- [ ] Post commit CI passes
- [ ] Blackhole Post commit (if applicable)
- [ ] Model regression CI testing passes (if applicable)
- [ ] New/Existing tests provide coverage for changes
