### PR TITLE
#0: Add e2e_perf default on test hang

### DIFF
--- a/tests/sweep_framework/runner.py
+++ b/tests/sweep_framework/runner.py
@@ -141,6 +141,7 @@ def execute_suite(test_module, test_vectors, pbar_manager, suite_name):
                 p = None
                 tt_smi_util.run_tt_smi(ARCH)
                 result["status"], result["exception"] = TestStatus.FAIL_CRASH_HANG, "TEST TIMED OUT (CRASH / HANG)"
+                result["e2e_perf"] = None
         result["timestamp"] = datetime.datetime.now().strftime("%Y-%m-%d_%H-%M-%S")
         result["host"] = get_hostname()
         result["user"] = get_username()


### PR DESCRIPTION
### Ticket
Link to Github Issue

### Problem description

Tests that hang won't store default e2e perf data, breaking the query tool upon retrieval. 

### What's changed

Added default e2e perf data on test hang.

### Checklist
- [ ] Post commit CI passes
- [ ] Blackhole Post commit (if applicable)
- [ ] Model regression CI testing passes (if applicable)
- [ ] New/Existing tests provide coverage for changes
