### PR TITLE
[Blackhole Bringup] Fixes for maxpool

### DIFF
--- a/tests/tt_metal/tt_metal/test_kernels/dataflow/writer_unary_8bank.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/dataflow/writer_unary_8bank.cpp
@@ -12,6 +12,7 @@ void kernel_main() {
     constexpr uint32_t cb_id_out0 = 16;
     constexpr uint32_t onetile = 1;
     uint32_t tile_bytes = get_tile_size(cb_id_out0);
+    const DataFormat data_format = get_dataformat(cb_id_out0);
 
     #ifdef KERNEL_COMPILE_TIME_ARG_0
     constexpr bool write_to_dram = get_compile_time_arg_val(0);
@@ -19,7 +20,10 @@ void kernel_main() {
     constexpr bool write_to_dram = true;
     #endif
 
-    const InterleavedPow2AddrGen<write_to_dram> s = { dst_addr, 11 };
+    const InterleavedAddrGenFast<write_to_dram> s = {
+        .bank_base_address = dst_addr,
+        .page_size = tile_bytes,
+        .data_format = data_format};
 
     for (uint32_t i = 0; i<num_tiles; i ++) {
         uint64_t dst_noc_addr = get_noc_addr(i, s);
@@ -27,10 +31,10 @@ void kernel_main() {
         cb_wait_front(cb_id_out0, onetile);
         uint32_t l1_read_addr = get_read_ptr(cb_id_out0);
 
-        noc_async_write(l1_read_addr, dst_noc_addr, tile_bytes);
+        noc_async_write_tile(i, s, l1_read_addr);
 
         noc_async_write_barrier();
 
         cb_pop_front(cb_id_out0, onetile);
-     }
+    }
 }

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_math_reduce_api.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_math_reduce_api.h
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+// SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -16,10 +16,9 @@ template <
     int num_fidelity_phases = 0,
     bool is_fp32_dest_acc_en = false,
     bool is_int_fpu_en = false>
-inline void llk_math_reduce(const uint dst_index, const uint num_faces = 4/*not used*/) {
-    _llk_math_reduce_<type, dim, num_fidelity_phases, is_fp32_dest_acc_en, is_int_fpu_en>(dst_index);
+inline void llk_math_reduce(const uint dst_index, const uint num_faces = 4) {
+    _llk_math_reduce_<type, dim, num_fidelity_phases, is_fp32_dest_acc_en, is_int_fpu_en>(dst_index, false, num_faces);
 }
-
 
 template <PoolType type, ReduceDim dim, int num_fidelity_phases = 0>
 inline void llk_math_reduce_init(

--- a/tt_metal/hw/ckernels/grayskull/metal/llk_api/llk_unpack_tilize_api.h
+++ b/tt_metal/hw/ckernels/grayskull/metal/llk_api/llk_unpack_tilize_api.h
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+// SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -229,13 +229,14 @@ inline void llk_unpack_tilizeA_B(
     DEBUG_STATUS("UPTD");
 }
 
-template <bool reuse_srcB = false>
+template <bool neginf_srcA = false, std::uint32_t reload_srcB = false, bool reuse_srcB = false>
 inline void llk_unpack_tilizeA_B_block(
     std::uint32_t operandA,
     std::uint32_t operandB,
     std::uint32_t block_c_tiles_a,
     std::uint32_t tile_idx_b,
-    std::uint32_t num_faces = 4) {
+    std::uint32_t num_faces = 4,
+    std::uint32_t unpA_face_r_dim = FACE_R_DIM /*unused*/) {
     for (std::uint32_t tile_idx_a = 0; tile_idx_a < block_c_tiles_a; tile_idx_a++) {
         llk_unpack_tilizeA_B<reuse_srcB>(operandA, operandB, tile_idx_a, tile_idx_b, block_c_tiles_a, num_faces);
     }

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_unpack_tilize_api.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_unpack_tilize_api.h
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+// SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -290,13 +290,14 @@ inline void llk_unpack_tilizeA_B(
     DEBUG_STATUS("UPTD");
 }
 
-template <bool zero_srcA = false>
+template <bool neginf_srcA = false, std::uint32_t reload_srcB = false, bool zero_srcA = false>
 inline void llk_unpack_tilizeA_B_block(
     std::uint32_t operandA,
     std::uint32_t operandB,
     std::uint32_t block_c_tiles_a,
     std::uint32_t tile_idx_b,
-    std::uint32_t num_faces = 4) {
+    std::uint32_t num_faces = 4,
+    std::uint32_t unpA_face_r_dim = FACE_R_DIM /*unused*/) {
     for (std::uint32_t tile_idx_a = 0; tile_idx_a < block_c_tiles_a; tile_idx_a++) {
         llk_unpack_tilizeA_B<zero_srcA>(operandA, operandB, tile_idx_a, tile_idx_b, block_c_tiles_a, num_faces);
     }

--- a/tt_metal/include/compute_kernel_api/pack_untilize.h
+++ b/tt_metal/include/compute_kernel_api/pack_untilize.h
@@ -18,7 +18,7 @@ namespace ckernel {
 /**
  * Init function for untilize operations, to be used at the beginning of the kernel.
  */
-template <uint32_t block_ct_dim = 8>
+template <uint32_t block_ct_dim = 8, uint32_t full_ct_dim = block_ct_dim>
 ALWI void pack_untilize_init(uint32_t icb, uint32_t ocb)
 {
     MATH(( llk_math_eltwise_unary_datacopy_init<A2D, BroadcastType::NONE, DST_ACCUM_MODE>(false /*transpose of faces*/, false /*transpose within 16x16 face*/, icb) ));
@@ -26,7 +26,7 @@ ALWI void pack_untilize_init(uint32_t icb, uint32_t ocb)
     MATH(( llk_math_hw_configure_disaggregated<true>() ));
 
     PACK(( llk_pack_hw_configure_disaggregated<false, DST_ACCUM_MODE>(ocb) ));
-    PACK(( llk_pack_untilize_init<block_ct_dim>(ocb) ));
+    PACK(( llk_pack_untilize_init<block_ct_dim, full_ct_dim>(ocb) ));
     PACK(( llk_pack_dest_init<true, DST_ACCUM_MODE>() ));
 
     UNPACK(( llk_unpack_A_hw_configure_disaggregated<DST_ACCUM_MODE>(icb) ));
@@ -36,7 +36,7 @@ ALWI void pack_untilize_init(uint32_t icb, uint32_t ocb)
 /**
  * Perform the untilize operation on a block of tiles. This simply loops over the provided block size.
 */
-template <uint32_t block_ct_dim = 8>
+template <uint32_t block_ct_dim = 8, uint32_t full_ct_dim = block_ct_dim>
 ALWI void pack_untilize_block(uint32_t icb, uint32_t block_rt_dim, uint32_t ocb) {
     for (uint32_t r = 0; r < block_rt_dim; ++r) {
         MATH(( llk_math_wait_for_dest_available() ));
@@ -47,7 +47,7 @@ ALWI void pack_untilize_block(uint32_t icb, uint32_t block_rt_dim, uint32_t ocb)
         MATH(( llk_math_dest_section_done<DST_ACCUM_MODE>() ));
 
         PACK(( llk_packer_wait_for_math_done() ));
-        PACK(( llk_pack_untilize<block_ct_dim>(1 /*num_blocks*/, ocb) ));
+        PACK(( llk_pack_untilize<block_ct_dim, full_ct_dim>(1 /*num_blocks*/, ocb) ));
         PACK(( llk_pack_dest_section_done<DST_ACCUM_MODE>() ));
     }
 }
@@ -69,6 +69,8 @@ ALWI void pack_untilize_dst_init_short(uint32_t ocb, uint32_t face_r_dim = 16, u
 {
     PACK(( llk_pack_untilize_init<block_ct_dim, full_ct_dim, diagonal>(ocb, face_r_dim, num_faces) ));
     PACK(( llk_init_packer_dest_offset_registers<true, diagonal>() ));
+
+    MATH(( llk_math_hw_configure_disaggregated<true>() ));
 }
 
 template <uint32_t block_ct_dim = 8, uint32_t full_ct_dim = block_ct_dim, bool diagonal = false>
@@ -76,13 +78,12 @@ ALWI void pack_untilize_dst(uint32_t ocb, uint32_t block_rt_dim = 1, uint32_t bl
     PACK(( llk_pack_untilize<block_ct_dim, full_ct_dim, diagonal>(block_rt_dim, ocb, face_r_dim, num_faces, block_c_index) ));
 }
 
-template <uint32_t block_ct_dim = 8>
+template <uint32_t block_ct_dim = 8, uint32_t full_ct_dim = block_ct_dim>
 ALWI void pack_untilize_init_short(uint32_t icb, uint32_t ocb)
 {
     UNPACK(( llk_unpack_A_init<BroadcastType::NONE, false, EltwiseBinaryReuseDestType::NONE, UnpackToDestEn>(false, false, icb) )); // init must be after configure
     MATH(( llk_math_eltwise_unary_datacopy_init<A2D, BroadcastType::NONE, DST_ACCUM_MODE>(false /*transpose of faces*/, false /*transpose within 16x16 face*/, icb) ));
-    MATH(( llk_math_hw_configure_disaggregated<true>() ));
-    pack_untilize_dst_init_short<block_ct_dim>(ocb);
+    pack_untilize_dst_init_short<block_ct_dim, full_ct_dim>(ocb);
 }
 
 }

--- a/tt_metal/include/compute_kernel_api/tilize.h
+++ b/tt_metal/include/compute_kernel_api/tilize.h
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+// SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -101,11 +101,6 @@ ALWI void tilize_init_unpack(uint32_t icb, uint32_t block)
     UNPACK(( llk_unpack_tilize_init(icb, block) ));
 }
 
-ALWI void tilizeA_B_init_unpack(uint32_t icb0, uint32_t icb1, uint32_t block)
-{
-    UNPACK(( llk_unpack_tilizeA_B_init(icb0, icb1, block) ));
-}
-
 /**
  * Re-initialize for the tilize operation. This also reconfigure the unpacker with CB data type.
  */
@@ -149,9 +144,9 @@ ALWI void unpack_tilize_block(uint32_t icb, uint32_t block)
     UNPACK(( llk_unpack_tilize_block(icb, block) ));
 }
 
-ALWI void unpack_tilizeA_B_block(uint32_t icb0, uint32_t icb1, uint32_t block, uint32_t tile_idx_b, uint32_t num_faces = 4)
+ALWI void unpack_tilizeA_B_block(uint32_t icb0, uint32_t icb1, uint32_t block, uint32_t tile_idx_b, uint32_t num_faces = 4, uint32_t srca_face_r_dim = 16)
 {
-    UNPACK(( llk_unpack_tilizeA_B_block(icb0, icb1, block, tile_idx_b, num_faces) ));
+    UNPACK(( llk_unpack_tilizeA_B_block<true, true>(icb0, icb1, block, tile_idx_b, num_faces, srca_face_r_dim) ));
 }
 
 /**
@@ -179,7 +174,7 @@ ALWI void unpack_tilizeA_B_block(uint32_t icb0, uint32_t icb1, uint32_t block, u
 
 ALWI void unpack_tilizeA_B_dot_product_block(uint32_t icb0, uint32_t icb1, uint32_t block, uint32_t tile_idx_b, uint32_t num_faces = 4)
 {
-    UNPACK(( llk_unpack_tilizeA_B_block<true>(icb0, icb1, block, tile_idx_b, num_faces) ));
+    UNPACK(( llk_unpack_tilizeA_B_block<false, false, true>(icb0, icb1, block, tile_idx_b, num_faces) ));
 }
 
 /**


### PR DESCRIPTION
### Ticket
#10498

### Problem description
unpack_tilizeA_B and pack_untilize kernels need updates for the maxpool op

### What's changed
Fixed unpack_tilizeA_B to unpack num_faces<4 & r_dim < 16, added missing api changes for reduce & pack_untilize for correct number of faces.

### Checklist
- [x] Post commit CI passes
- [x] Blackhole Post commit (if applicable)
- [ ] Model regression CI testing passes (if applicable)
- [ ] New/Existing tests provide coverage for changes
