### PR TITLE
#11640: Include simulation device in tt_cluster

### DIFF
--- a/tt_metal/llrt/tt_cluster.cpp
+++ b/tt_metal/llrt/tt_cluster.cpp
@@ -14,6 +14,7 @@
 #include "hostdevcommon/dprint_common.h"
 #include "rtoptions.hpp"
 #include "third_party/umd/device/tt_silicon_driver_common.hpp"
+#include "third_party/umd/device/simulation/tt_simulation_device.h"
 #include "tools/profiler/profiler.hpp"
 #include "tt_metal/impl/debug/sanitize_noc_host.hpp"
 #include "tt_metal/llrt/rtoptions.hpp"


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/11640

### Problem description
Hide flatbuffers from public header `device_api_metal.h`.

### What's changed
To do so, need to include `tt_simulation_device.h` in `tt_cluster.cpp` and bump UMD for related change.

This is a copy of changes made by @marty1885:
https://github.com/tenstorrent/tt-metal/pull/11641
https://github.com/tenstorrent/tt-umd/pull/34

Related UMD PR: https://github.com/tenstorrent/tt-umd/pull/36

### Checklist
- [x] Post commit CI passes: https://github.com/tenstorrent/tt-metal/actions/runs/10501969870
