### PR TITLE
#11430: Refactoring moreh_mean

### DIFF
--- a/tests/tt_eager/python_api_testing/unit_testing/misc/test_moreh_mean.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/misc/test_moreh_mean.py
@@ -6,116 +6,87 @@ import pytest
 import torch
 from loguru import logger
 
+import tt_lib as ttl
 import ttnn
-from models.utility_functions import comp_allclose_and_pcc, comp_pcc
+from models.utility_functions import comp_allclose
 
-from tests.tt_eager.python_api_testing.unit_testing.misc.test_utils import TILE_HEIGHT, TILE_WIDTH
+from tests.tt_eager.python_api_testing.unit_testing.misc.test_utils import (
+    get_compute_kernel_options,
+    compute_kernel_options,
+    compute_kernel_ids,
+    to_cpu,
+    to_npu,
+    TILE_HEIGHT,
+    TILE_WIDTH,
+    check_dim,
+)
 
 
-def get_tensors(input_shape, output_shape, use_randint, device):
-    npu_dtype = ttnn.bfloat16
-    npu_layout = ttnn.TILE_LAYOUT
-    cpu_dtype = torch.float
+def get_torch_tensors(input_shape, use_randint=False):
+    cpu_dtype = torch.bfloat16
 
     if use_randint:
         torch_input = torch.randint(-2, 3, input_shape, dtype=cpu_dtype)
-        torch_output = torch.randint(-2, 3, output_shape, dtype=cpu_dtype)
     else:
-        torch_input = torch.rand(input_shape, dtype=cpu_dtype) * 200 - 100
-        torch_output = torch.rand(output_shape, dtype=cpu_dtype) * 200 - 100
+        torch_input = torch.rand(input_shape, dtype=cpu_dtype)
 
-    torch_input = torch_input.bfloat16().requires_grad_()
-    torch_output = torch_output.bfloat16()
-    tt_input = ttnn.Tensor(torch_input, npu_dtype).pad_to_tile(float("nan")).to(npu_layout).to(device)
-    tt_output = ttnn.Tensor(torch_output, npu_dtype).pad_to_tile(float("nan")).to(npu_layout).to(device)
-    return tt_input, tt_output, torch_input
+    torch_input.requires_grad_()
+    return torch_input
 
 
-def get_backward_tensors(output_grad_shape, input_grad_shape, use_randint, device):
-    npu_dtype = ttnn.bfloat16
-    npu_layout = ttnn.TILE_LAYOUT
-    cpu_dtype = torch.float
+def get_tt_tensors(torch_input, output_shape, device):
+    torch_input = torch_input.bfloat16()
+    torch_output = torch.empty(output_shape, dtype=torch.bfloat16)
+
+    tt_input = to_npu(torch_input, device)
+    tt_output = to_npu(torch_output, device)
+    return tt_input, tt_output
+
+
+def get_torch_backward_tensors(output_grad_shape, use_randint=False):
+    cpu_dtype = torch.bfloat16
 
     if use_randint:
-        torch_input_grad = torch.randint(-2, 3, input_grad_shape, dtype=cpu_dtype)
         torch_output_grad = torch.randint(-2, 3, output_grad_shape, dtype=cpu_dtype)
     else:
-        torch_input_grad = torch.rand(input_grad_shape, dtype=cpu_dtype) * 200 - 100
-        torch_output_grad = torch.rand(output_grad_shape, dtype=cpu_dtype) * 200 - 100
+        torch_output_grad = torch.rand(output_grad_shape, dtype=cpu_dtype)
 
-    torch_input_grad = torch_input_grad.bfloat16()
-    torch_output_grad = torch_output_grad.bfloat16()
-    tt_output_grad = ttnn.Tensor(torch_output_grad, npu_dtype).pad_to_tile(float("nan")).to(npu_layout).to(device)
-    tt_input_grad = ttnn.Tensor(torch_input_grad, npu_dtype).pad_to_tile(float("nan")).to(npu_layout).to(device)
-
-    return tt_output_grad, tt_input_grad, torch_output_grad
+    return torch_output_grad
 
 
-@pytest.mark.parametrize(
-    "input_shape",
-    (
-        ([1, 1, TILE_HEIGHT - 1, TILE_WIDTH - 1]),
-        ([4, 4, TILE_HEIGHT * 12 - 1, TILE_WIDTH * 30 - 1]),
-        ([4, 4, TILE_HEIGHT * 30 - 1, TILE_WIDTH * 12 - 1]),
-        ([8, 8, TILE_HEIGHT * 4 - 1, TILE_WIDTH * 4 - 1]),
-    ),
-    ids=[
-        "1, 1, TILE_HEIGHT-1,TILE_WIDTH - 1",
-        "4, 4, TILE_HEIGHT * 12 - 1, TILE_WIDTH * 30 - 1",
-        "4, 4, TILE_HEIGHT * 30 - 1, TILE_WIDTH * 12 - 1",
-        "8, 8, TILE_HEIGHT * 4 - 1, TILE_WIDTH * 4 - 1",
-    ],
-)
-@pytest.mark.parametrize(
-    "dims",
-    (
-        [0],
-        [0, 1],
-        [0, 1, 2],
-        [0, 1, 2, 3],
-        [0, 1, 3],
-        [0, 2, 3],
-        [1],
-        [1, 2],
-        [1, 2, 3],
-        [1, 3],
-        [2],
-        [2, 3],
-        [3],
-    ),
-    ids=["0", "0,1", "0,1,2", "0,1,2,3", "0,1,3", "0,2,3", "1", "1,2", "1,2,3", "1,3", "2", "2,3", "3"],
-)
-@pytest.mark.parametrize(
-    "use_randint",
-    (True, False),
-    ids=["True", "False"],
-)
-def test_moreh_mean_dims(input_shape, dims, use_randint, device):
-    torch.manual_seed(2023)
-    output_shape = input_shape.copy()
+def get_tt_backward_tensors(torch_output_grad, input_grad_shape, device):
+    cpu_dtype = torch.bfloat16
 
-    for dim in dims:
-        output_shape[dim] = 1
+    torch_input_grad = torch.empty(input_grad_shape, dtype=cpu_dtype)
 
-    (tt_input, tt_output, torch_input) = get_tensors(input_shape, output_shape, use_randint, device)
+    tt_input_grad = to_npu(torch_input_grad, device)
+    tt_output_grad = to_npu(torch_output_grad, device)
 
-    torch_output = torch.mean(torch_input, dims, True)
+    return tt_output_grad, tt_input_grad
 
-    cpu_layout = ttnn.ROW_MAJOR_LAYOUT
-    tt_output_cpu = (
-        ttnn.experimental.operations.primary.moreh_mean(tt_input, tt_output, dims=dims)
-        .cpu()
-        .to(cpu_layout)
-        .unpad_from_tile(output_shape)
-        .to_torch()
+
+def run_moreh_mean(input_shape_dim, device, keepdim=False, compute_kernel_options=None):
+    input_shape, dim = input_shape_dim
+
+    check_dim(input_shape, dim, keepdim)
+
+    compute_kernel_config = get_compute_kernel_options(compute_kernel_options)
+
+    # run torch
+    torch_input = get_torch_tensors(input_shape)
+    torch_output = torch.mean(torch_input, dim=dim, keepdim=keepdim)
+
+    # run tt
+    (tt_input, tt_output) = get_tt_tensors(torch_input, torch_output.shape, device)
+
+    ttnn.experimental.operations.primary.moreh_mean(
+        tt_input, dim=dim, keepdim=keepdim, output=tt_output, compute_kernel_config=compute_kernel_config
     )
+    tt_output_cpu = to_cpu(tt_output, torch_output.shape)
 
     # test for equivalance
     rtol = atol = 0.1
-    if use_randint:
-        passing, output_pcc = comp_allclose_and_pcc(torch_output, tt_output_cpu, pcc=0.999, rtol=rtol, atol=atol)
-    else:
-        passing, output_pcc = comp_pcc(torch_output, tt_output_cpu, pcc=0.999)
+    passing, output_pcc = comp_allclose(torch_output, tt_output_cpu, rtol=rtol, atol=atol)
 
     logger.debug(f"Out passing={passing}")
     logger.debug(f"Output pcc={output_pcc}")
@@ -123,79 +94,202 @@ def test_moreh_mean_dims(input_shape, dims, use_randint, device):
     assert passing
 
 
-@pytest.mark.parametrize(
-    "input_shape",
-    (
-        ([1, 1, TILE_HEIGHT - 1, TILE_WIDTH - 1]),
-        ([4, 4, TILE_HEIGHT * 12 - 1, TILE_WIDTH * 30 - 1]),
-        ([4, 4, TILE_HEIGHT * 30 - 1, TILE_WIDTH * 12 - 1]),
-        ([8, 8, TILE_HEIGHT * 20 - 1, TILE_WIDTH * 20 - 1]),
-    ),
-    ids=[
-        "1, 1, TILE_HEIGHT-1,TILE_WIDTH - 1",
-        "4, 4, TILE_HEIGHT * 12 - 1, TILE_WIDTH * 30 - 1",
-        "4, 4, TILE_HEIGHT * 30 - 1, TILE_WIDTH * 12 - 1",
-        "8, 8, TILE_HEIGHT * 20 - 1, TILE_WIDTH * 20 - 1",
-    ],
-)
-@pytest.mark.parametrize(
-    "dims",
-    (
-        [0],
-        [0, 1],
-        [0, 1, 2],
-        [0, 1, 2, 3],
-        [0, 1, 3],
-        [0, 2, 3],
-        [1],
-        [1, 2],
-        [1, 2, 3],
-        [1, 3],
-        [2],
-        [2, 3],
-        [3],
-    ),
-    ids=["0", "0,1", "0,1,2", "0,1,2,3", "0,1,3", "0,2,3", "1", "1,2", "1,2,3", "1,3", "2", "2,3", "3"],
-)
-@pytest.mark.parametrize(
-    "use_randint",
-    (True, False),
-    ids=["True", "False"],
-)
-def test_moreh_mean_backward(input_shape, dims, use_randint, device):
-    torch.manual_seed(2023)
-    output_shape = input_shape.copy()
+def run_moreh_mean_backward(input_shape_dim, device, keepdim=False, compute_kernel_options=None, create_output=False):
+    input_shape, dim = input_shape_dim
 
-    for dim in dims:
-        output_shape[dim] = 1
+    check_dim(input_shape, dim, keepdim)
 
-    (_, _, torch_input) = get_tensors(input_shape, output_shape, use_randint, device)
-    (tt_output_grad, tt_input_grad, torch_output_grad) = get_backward_tensors(
-        output_shape, input_shape, use_randint, device
-    )
+    compute_kernel_config = get_compute_kernel_options(compute_kernel_options)
 
-    torch_output = torch.mean(torch_input, dims, True)
+    # run torch
+    torch_input = get_torch_tensors(input_shape)
+    torch_output = torch.mean(torch_input, dim=dim, keepdim=keepdim)
+
+    torch_output_grad = get_torch_backward_tensors(torch_output.shape)
+
     torch_output.backward(torch_output_grad)
 
-    cpu_layout = ttnn.ROW_MAJOR_LAYOUT
-    tt_input_grad_cpu = (
-        ttnn.experimental.operations.primary.moreh_mean_backward(tt_output_grad, tt_input_grad)
-        .cpu()
-        .to(cpu_layout)
-        .unpad_from_tile(input_shape)
-        .to_torch()
-    )
+    # run_tt
+    tt_output_grad, tt_input_grad = get_tt_backward_tensors(torch_output_grad, torch_input.shape, device)
+
+    if create_output:
+        input_grad_shape = ttnn._ttnn.deprecated.tensor.Shape(torch_input.shape)
+        tt_input_grad = ttnn.experimental.operations.primary.moreh_mean_backward(
+            tt_output_grad,
+            dim=dim,
+            keepdim=keepdim,
+            input_grad_shape=input_grad_shape,
+            compute_kernel_config=compute_kernel_config,
+        )
+    else:
+        ttnn.experimental.operations.primary.moreh_mean_backward(
+            tt_output_grad,
+            dim=dim,
+            keepdim=keepdim,
+            input_grad=tt_input_grad,
+            compute_kernel_config=compute_kernel_config,
+        )
+
+    tt_input_grad_cpu = to_cpu(tt_input_grad, torch_input.grad.shape)
 
     # test for equivalance
     rtol = atol = 0.1
-    if use_randint:
-        passing, output_pcc = comp_allclose_and_pcc(
-            torch_input.grad, tt_input_grad_cpu, pcc=0.999, rtol=rtol, atol=atol
-        )
-    else:
-        passing, output_pcc = comp_pcc(torch_input.grad, tt_input_grad_cpu, pcc=0.999)
+    passing, output_pcc = comp_allclose(torch_input.grad, tt_input_grad_cpu, rtol=rtol, atol=atol)
 
     logger.debug(f"Out passing={passing}")
     logger.debug(f"Output pcc={output_pcc}")
 
     assert passing
+
+
+@pytest.mark.parametrize(
+    "input_shape_dim",
+    [
+        # hw single tile
+        [[TILE_HEIGHT - 15, TILE_WIDTH - 10], [0]],  # h
+        [[TILE_HEIGHT - 15, TILE_WIDTH - 10], [1]],  # w
+        # hw multiple tiles
+        [[TILE_HEIGHT * 4, TILE_WIDTH * 5], [0]],  # h
+        [[TILE_HEIGHT * 4, TILE_WIDTH * 5], [1]],  # w
+        # ncd single tile
+        [[3, 4, 5, TILE_HEIGHT - 15, TILE_WIDTH - 10], [0]],  # n
+        [[3, 4, 5, TILE_HEIGHT - 15, TILE_WIDTH - 10], [1]],  # c
+        [[3, 4, 5, TILE_HEIGHT - 15, TILE_WIDTH - 10], [2]],  # d
+        # ncd multiple tile
+        [[3, 4, 5, TILE_HEIGHT * 3 - 15, TILE_WIDTH * 4 - 10], [0]],  # n
+        [[3, 4, 5, TILE_HEIGHT * 3 - 15, TILE_WIDTH * 4 - 10], [1]],  # c
+        [[3, 4, 5, TILE_HEIGHT * 3 - 15, TILE_WIDTH * 4 - 10], [2]],  # d
+        # multiple dims
+        [[3, 4, 5, TILE_HEIGHT * 3 - 15, TILE_WIDTH * 4 - 10], [0, 1, 2]],
+        [[3, 4, 5, TILE_HEIGHT * 3 - 15, TILE_WIDTH * 4 - 10], [1, 2]],
+        [[3, 4, 5, TILE_HEIGHT * 3 - 15, TILE_WIDTH * 4 - 10], [0, 2, 4]],
+        # all dims
+        [[3, 4, 5, TILE_HEIGHT * 3 - 15, TILE_WIDTH * 4 - 10], None],
+    ],
+)
+@pytest.mark.parametrize("keepdim", [True, False])
+def test_moreh_mean(input_shape_dim, keepdim, device):
+    torch.manual_seed(2023)
+
+    run_moreh_mean(input_shape_dim, device, keepdim)
+
+
+@pytest.mark.parametrize(
+    "input_shape_dim",
+    [
+        # hw multiple tiles
+        [[TILE_HEIGHT * 4, TILE_WIDTH * 5], [0]],  # h
+        [[TILE_HEIGHT * 4, TILE_WIDTH * 5], [1]],  # w
+        # ncd multiple tile
+        [[3, 4, 5, TILE_HEIGHT * 3 - 15, TILE_WIDTH * 4 - 10], [1]],  # c
+    ],
+)
+@pytest.mark.parametrize("compute_kernel_options", compute_kernel_options, ids=compute_kernel_ids)
+def test_moreh_mean_compute_kernel_options(input_shape_dim, compute_kernel_options, device):
+    torch.manual_seed(2023)
+
+    run_moreh_mean(input_shape_dim, device, keepdim=True, compute_kernel_options=compute_kernel_options)
+
+
+@pytest.mark.parametrize(
+    "input_shape_dim",
+    [
+        # hw multiple tiles
+        [[TILE_HEIGHT * 4, TILE_WIDTH * 5], [0]],  # h
+        [[TILE_HEIGHT * 4, TILE_WIDTH * 5], [1]],  # w
+        # ncd multiple tile
+        [[3, 4, 5, TILE_HEIGHT * 3 - 15, TILE_WIDTH * 4 - 10], [1]],  # c
+    ],
+)
+def test_moreh_mean_callback(input_shape_dim, device, use_program_cache):
+    torch.manual_seed(2023)
+
+    for _ in range(2):
+        run_moreh_mean(input_shape_dim, device, keepdim=True)
+        torch_dummy = torch.randn([32, 32])
+        tt_dummy = to_npu(torch_dummy, device)
+
+
+@pytest.mark.parametrize(
+    "input_shape_dim",
+    [
+        # hw single tile
+        [[TILE_HEIGHT - 15, TILE_WIDTH - 10], [1]],  # h
+        [[TILE_HEIGHT - 15, TILE_WIDTH - 10], [1]],  # w
+        # hw multiple tiles
+        [[TILE_HEIGHT * 4, TILE_WIDTH * 5], [0]],  # h
+        [[TILE_HEIGHT * 4, TILE_WIDTH * 5], [1]],  # w
+        # # ncd single tile
+        [[3, 4, 5, TILE_HEIGHT - 15, TILE_WIDTH - 10], [0]],  # n
+        [[3, 4, 5, TILE_HEIGHT - 15, TILE_WIDTH - 10], [1]],  # c
+        [[3, 4, 5, TILE_HEIGHT - 15, TILE_WIDTH - 10], [2]],  # d
+        # ncd multiple tile
+        [[3, 4, 5, TILE_HEIGHT * 3 - 15, TILE_WIDTH * 4 - 10], [0]],  # n
+        [[3, 4, 5, TILE_HEIGHT * 3 - 15, TILE_WIDTH * 4 - 10], [1]],  # c
+        [[3, 4, 5, TILE_HEIGHT * 3 - 15, TILE_WIDTH * 4 - 10], [2]],  # d
+        # multiple dims
+        [[3, 4, 5, TILE_HEIGHT * 3 - 15, TILE_WIDTH * 4 - 10], [0, 1, 2]],
+        [[3, 4, 5, TILE_HEIGHT * 3 - 15, TILE_WIDTH * 4 - 10], [1, 2]],
+        [[3, 4, 5, TILE_HEIGHT * 3 - 15, TILE_WIDTH * 4 - 10], [0, 2, 4]],
+        # all dims
+        [[3, 4, 5, TILE_HEIGHT * 3 - 15, TILE_WIDTH * 4 - 10], None],
+    ],
+)
+@pytest.mark.parametrize("keepdim", [True, False])
+def test_moreh_mean_backward(input_shape_dim, keepdim, device):
+    torch.manual_seed(2023)
+
+    run_moreh_mean_backward(input_shape_dim, device, keepdim=keepdim)
+
+
+@pytest.mark.parametrize(
+    "input_shape_dim",
+    [
+        # hw multiple tiles
+        [[TILE_HEIGHT * 4, TILE_WIDTH * 5], [0]],  # h
+        [[TILE_HEIGHT * 4, TILE_WIDTH * 5], [1]],  # w
+        # ncd multiple tile
+        [[3, 4, 5, TILE_HEIGHT * 3 - 15, TILE_WIDTH * 4 - 10], [1]],  # c
+    ],
+)
+@pytest.mark.parametrize("compute_kernel_options", compute_kernel_options, ids=compute_kernel_ids)
+def test_moreh_mean_backward_compute_kernel_options(input_shape_dim, compute_kernel_options, device):
+    torch.manual_seed(2023)
+
+    run_moreh_mean_backward(input_shape_dim, device, keepdim=True, compute_kernel_options=compute_kernel_options)
+
+
+@pytest.mark.parametrize(
+    "input_shape_dim",
+    [
+        # hw multiple tiles
+        [[TILE_HEIGHT * 4, TILE_WIDTH * 5], [0]],  # h
+        [[TILE_HEIGHT * 4, TILE_WIDTH * 5], [1]],  # w
+        # ncd multiple tile
+        [[3, 4, 5, TILE_HEIGHT * 3 - 15, TILE_WIDTH * 4 - 10], [1]],  # c
+    ],
+)
+def test_moreh_mean_backward_callback(input_shape_dim, device, use_program_cache):
+    torch.manual_seed(2023)
+
+    for _ in range(2):
+        run_moreh_mean_backward(input_shape_dim, device, keepdim=True)
+        torch_dummy = torch.randn([32, 32])
+        tt_dummy = to_npu(torch_dummy, device)
+
+
+@pytest.mark.parametrize(
+    "input_shape_dim",
+    [
+        # hw multiple tiles
+        [[TILE_HEIGHT * 4 - 10, TILE_WIDTH * 5 - 20], [0]],  # h
+        [[TILE_HEIGHT * 4 - 10, TILE_WIDTH * 5 - 20], [1]],  # h
+        # ncd multiple tile
+        [[3, 4, 5, TILE_HEIGHT * 3 - 15, TILE_WIDTH * 4 - 10], [0, 2]],  # c
+    ],
+)
+@pytest.mark.parametrize("keepdim", [True, False])
+def test_moreh_mean_backward_create_output(input_shape_dim, keepdim, device):
+    torch.manual_seed(2023)
+
+    run_moreh_mean_backward(input_shape_dim, device, keepdim=keepdim, create_output=True)

--- a/tests/tt_eager/python_api_testing/unit_testing/misc/test_moreh_nll_loss.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/misc/test_moreh_nll_loss.py
@@ -35,8 +35,6 @@ def get_torch_tensors(shape):
 
 
 def get_tt_tensors(torch_input, torch_target, torch_weight, torch_divisor, torch_output, device):
-    C = torch_input.shape[1]
-
     npu_index_dtype = ttnn.int32
 
     tt_input = to_npu(torch_input, device)

--- a/tests/tt_eager/python_api_testing/unit_testing/misc/test_moreh_norm.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/misc/test_moreh_norm.py
@@ -18,29 +18,8 @@ from tests.tt_eager.python_api_testing.unit_testing.misc.test_utils import (
     compute_output_shape,
     TILE_HEIGHT,
     TILE_WIDTH,
+    check_dim,
 )
-
-
-def check_dim(input_shape, dim, keepdim):
-    if type(dim) == int and dim >= len(input_shape):
-        pytest.skip("dim bigger than input rank")
-
-    if type(dim) == list:
-        for i in dim:
-            if i >= len(input_shape):
-                pytest.skip("dim bigger than input rank")
-
-    if keepdim == False:
-        if dim in [None, []]:
-            pytest.skip("`keepdim == false` don't support last 2-dim")
-
-        if type(dim) == int and len(input_shape) - 2 <= dim:
-            pytest.skip("`keepdim == false` don't support last 2-dim")
-
-        if type(dim) == list:
-            for i in dim:
-                if len(input_shape) - 2 <= i:
-                    pytest.skip("`keepdim == false` don't support last 2-dim")
 
 
 def make_cpu_tensors(input_shape, dim, keepdim=False):
@@ -68,7 +47,6 @@ def torch_norm(cpu_x, cpu_dy, *, p=2.0, dim=None, keepdim=False, do_backward=Fal
 
 def tt_norm(
     cpu_x,
-    expected_y,
     cpu_dy,
     *,
     p=2.0,
@@ -129,7 +107,6 @@ def run_moreh_norm(input_shape, p, dim, rtol, atol, device, keepdim=False, compu
     # actual
     actual_y, _ = tt_norm(
         cpu_x,
-        expected_y,
         cpu_dy,
         p=p,
         dim=dim,
@@ -157,7 +134,6 @@ def run_moreh_norm_backward(input_shape, p, dim, rtol, atol, device, keepdim=Fal
     # actual
     _, actual_dx = tt_norm(
         cpu_x,
-        expected_dx,
         cpu_dy,
         p=p,
         dim=dim,

--- a/tests/tt_eager/python_api_testing/unit_testing/misc/test_utils.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/misc/test_utils.py
@@ -5,6 +5,7 @@
 import ttnn
 from models.utility_functions import is_wormhole_b0
 import copy
+import pytest
 
 
 TILE_HEIGHT = 32
@@ -132,3 +133,25 @@ def compute_output_shape(input_shape, dim, keepdim=False):
         tt_output_shape = filter_indices_with_last_two(output_shape, dim)
 
     return torch_output_shape, tt_output_shape
+
+
+def check_dim(input_shape, dim, keepdim):
+    if type(dim) == int and dim >= len(input_shape):
+        pytest.skip("dim bigger than input rank")
+
+    if type(dim) == list:
+        for i in dim:
+            if i >= len(input_shape):
+                pytest.skip("dim bigger than input rank")
+
+    if keepdim == False:
+        if dim in [None, []]:
+            pytest.skip("`keepdim == false` don't support last 2-dim")
+
+        if type(dim) == int and len(input_shape) - 2 <= dim:
+            pytest.skip("`keepdim == false` don't support last 2-dim")
+
+        if type(dim) == list:
+            for i in dim:
+                if len(input_shape) - 2 <= i:
+                    pytest.skip("`keepdim == false` don't support last 2-dim")

--- a/ttnn/cpp/ttnn/deprecated/tt_dnn/op_library/moreh_helper_functions.cpp
+++ b/ttnn/cpp/ttnn/deprecated/tt_dnn/op_library/moreh_helper_functions.cpp
@@ -4,15 +4,16 @@
 
 #include "ttnn/deprecated/tt_dnn/op_library/moreh_helper_functions.hpp"
 
-#include "ttnn/deprecated/tt_dnn/op_library/work_split.hpp"
-#include "tt_metal/detail/util.hpp"
 #include "common/constants.hpp"
-
 #include "third_party/magic_enum/magic_enum.hpp"
+#include "tt_metal/detail/util.hpp"
+#include "ttnn/deprecated/tt_dnn/op_library/work_split.hpp"
 
 namespace tt {
 namespace operations {
 namespace primary {
+
+using namespace constants;
 
 std::tuple<CoreRangeSet, CoreRangeSet, CoreRangeSet> add_core_offset(
     CoreRangeSet all_cores,
@@ -132,8 +133,15 @@ std::tuple<uint32_t, CoreRangeSet, CoreRangeSet, CoreRangeSet, uint32_t, uint32_
     std::vector<KernelHandle> compute_kernel_ids{};
     KernelHandle compute_kernel_id{};
     for (auto arg : args) {
-        compute_kernel_id =
-            CreateComputeKernel(program, file_name, arg, defines, math_fidelity, fp32_dest_acc_en, math_approx_mode, preserve_fp32_precision);
+        compute_kernel_id = CreateComputeKernel(
+            program,
+            file_name,
+            arg,
+            defines,
+            math_fidelity,
+            fp32_dest_acc_en,
+            math_approx_mode,
+            preserve_fp32_precision);
         compute_kernel_ids.push_back(compute_kernel_id);
     }
     return compute_kernel_ids;
@@ -161,6 +169,36 @@ std::tuple<uint32_t, CoreRangeSet, CoreRangeSet, CoreRangeSet, uint32_t, uint32_
                 .math_approx_mode = math_approx_mode,
                 .compile_args = arg.compile_args,
                 .defines = defines});
+    }
+    return compute_kernel_id;
+}
+
+[[maybe_unused]] std::vector<KernelHandle> CreateComputeKernel(
+    Program &program, const std::string &file_name, std::vector<ComputeKernelArg> args, ComputeKernelConfig config) {
+    std::vector<KernelHandle> compute_kernel_ids{};
+    KernelHandle compute_kernel_id{};
+    for (auto arg : args) {
+        compute_kernel_id = CreateComputeKernel(program, file_name, arg, config);
+        compute_kernel_ids.push_back(compute_kernel_id);
+    }
+    return compute_kernel_ids;
+}
+
+[[maybe_unused]] KernelHandle CreateComputeKernel(
+    Program &program, const std::string &file_name, ComputeKernelArg arg, ComputeKernelConfig config) {
+    KernelHandle compute_kernel_id{0};
+    if (arg.num_tile_per_core_group > 0) {
+        compute_kernel_id = CreateKernel(
+            program,
+            file_name,
+            arg.core_spec,
+            tt_metal::ComputeConfig{
+                .math_fidelity = config.math_fidelity,
+                .fp32_dest_acc_en = config.fp32_dest_acc_en,
+                .preserve_fp32_precision = config.preserve_fp32_precision,
+                .math_approx_mode = config.math_approx_mode,
+                .compile_args = arg.compile_args,
+                .defines = config.defines});
     }
     return compute_kernel_id;
 }
@@ -202,22 +240,27 @@ std::tuple<uint32_t, CoreRangeSet, CoreRangeSet, CoreRangeSet, uint32_t, uint32_
 }
 
 void check_tensor(
-    const Tensor& tensor,
-    const std::string& op_name,
-    const std::string& tensor_name,
+    const Tensor &tensor,
+    const std::string &op_name,
+    const std::string &tensor_name,
     const std::initializer_list<DataType> &data_types,
     Layout layout,
     bool check_dtype,
     bool check_layout) {
     if (check_layout) {
-        TT_FATAL(tensor.get_layout() == layout, "{} {} only supports {} layout.", op_name, tensor_name, magic_enum::enum_name(layout));
+        TT_FATAL(
+            tensor.get_layout() == layout,
+            "{} {} only supports {} layout.",
+            op_name,
+            tensor_name,
+            magic_enum::enum_name(layout));
     }
     TT_FATAL(tensor.storage_type() == StorageType::DEVICE, "{} {} need to be on device!", op_name, tensor_name);
     TT_FATAL(tensor.buffer() != nullptr, "{} {} need to be allocated in buffers on device!", op_name, tensor_name);
 
     if (check_dtype) {
         bool dtype_supported = false;
-        for (const auto& data_type : data_types) {
+        for (const auto &data_type : data_types) {
             if (tensor.get_dtype() == data_type) {
                 dtype_supported = true;
                 break;
@@ -226,7 +269,7 @@ void check_tensor(
         if (!dtype_supported) {
             std::string dtype_string = "[";
             bool is_first = true;
-            for (const auto& data_type : data_types) {
+            for (const auto &data_type : data_types) {
                 if (!is_first) {
                     dtype_string += ", ";
                 }
@@ -235,15 +278,16 @@ void check_tensor(
             }
             dtype_string += "]";
 
-            TT_FATAL(dtype_supported, "{} {} only supports specific data types. {} ", op_name, tensor_name, dtype_string);
+            TT_FATAL(
+                dtype_supported, "{} {} only supports specific data types. {} ", op_name, tensor_name, dtype_string);
         }
     }
 }
 
 void check_tensor(
     std::optional<Tensor> tensor,
-    const std::string& op_name,
-    const std::string& tensor_name,
+    const std::string &op_name,
+    const std::string &tensor_name,
     const std::initializer_list<DataType> &data_types,
     Layout layout,
     bool check_dtype,
@@ -255,15 +299,7 @@ void check_tensor(
 }
 
 bool is_hw_dim(uint32_t dim, uint32_t rank) {
-    if (rank == 1 || rank == 2) {
-        return true;
-    }
-    if (rank >= 3) {
-        if (dim >= rank - 2) {
-            return true;
-        }
-    }
-    return false;
+    return (dim >= rank - 2);
 }
 
 uint32_t compute_inner(Shape shape, uint32_t dim) {
@@ -295,7 +331,7 @@ uint32_t compute_outer(Shape shape, uint32_t dim) {
     return num_outer;
 }
 
-void expand_to_max_dim(std::vector<uint32_t> &dim, const Shape& shape) {
+void expand_to_max_dim(std::vector<uint32_t> &dim, const Shape &shape) {
     const auto rank = shape.rank();
     for (auto i = 0; i < rank; ++i) {
         auto idx = rank - 1 - i;
@@ -303,6 +339,140 @@ void expand_to_max_dim(std::vector<uint32_t> &dim, const Shape& shape) {
     }
 }
 
+void validate_input_with_dim(const Tensor &input, const int64_t &dim) {
+    auto input_shape = input.get_legacy_shape();
+    auto input_shape_wo_padding = input.get_legacy_shape().without_padding();
+    const auto input_rank = input_shape.rank();
+    log_debug(LogOp, "{}:{} input_rank {}", __func__, __LINE__, input_rank);
+    TT_FATAL(
+        (dim >= 0 && dim <= tt::tt_metal::MAX_NUM_DIMENSIONS),
+        "dim must be between 0 and {}.",
+        tt::tt_metal::MAX_NUM_DIMENSIONS);
+    TT_FATAL((dim < input_rank), "dim must be smaller than input tensor rank {}.", input_rank);
+}
+
+void validate_output_with_keepdim(const Tensor &input, const Tensor &output, const int64_t &dim, const bool &keep_dim) {
+    auto input_shape = input.get_legacy_shape();
+    auto input_shape_wo_padding = input_shape.without_padding();
+    const auto input_rank = input_shape.rank();
+
+    const auto &output_shape = output.get_legacy_shape();
+    const auto &output_shape_wo_padding = output_shape.without_padding();
+    const auto output_rank = output_shape.rank();
+
+    const bool is_tile_dim = (dim == input_rank - 1 || dim == input_rank - 2);
+
+    log_debug(LogOp, "{}:{} keep_dim {} dim {}", __func__, __LINE__, keep_dim, dim);
+    log_debug(LogOp, "{}:{} input_shape {} wo_padding {}", __func__, __LINE__, input_shape, input_shape_wo_padding);
+    log_debug(LogOp, "{}:{} output_shape {} wo_paddoutg {}", __func__, __LINE__, output_shape, output_shape_wo_padding);
+
+    if (keep_dim) {
+        bool ranks_are_equal = (input_rank == output_rank);
+        input_shape[dim] = (is_tile_dim) ? (TILE_HEIGHT) : (1);
+        input_shape_wo_padding[dim] = 1;
+
+        if (!ranks_are_equal) {
+            log_warning(
+                LogOp,
+                "{}:{} input_rank {} and output_rank {} are not the same in keep_dim mode",
+                __func__,
+                __LINE__,
+                input_rank,
+                output_rank);
+        }
+
+        std::vector<uint32_t> input_dim(tt::tt_metal::MAX_NUM_DIMENSIONS, 1);
+        std::vector<uint32_t> output_dim(tt::tt_metal::MAX_NUM_DIMENSIONS, 1);
+        std::vector<uint32_t> input_dim_wo_padding(tt::tt_metal::MAX_NUM_DIMENSIONS, 1);
+        std::vector<uint32_t> output_dim_wo_padding(tt::tt_metal::MAX_NUM_DIMENSIONS, 1);
+        expand_to_max_dim(input_dim, input_shape);
+        expand_to_max_dim(output_dim, output_shape);
+        expand_to_max_dim(input_dim_wo_padding, input_shape_wo_padding);
+        expand_to_max_dim(output_dim_wo_padding, output_shape_wo_padding);
+
+        for (int i = 0; i < input_rank; ++i) {
+            TT_FATAL(input_dim[i] == output_dim[i]);
+            TT_FATAL(input_dim_wo_padding[i] == output_dim_wo_padding[i]);
+        }
+    } else {
+        std::vector<uint32_t> expected_output_shape;
+        std::vector<uint32_t> expected_output_shape_wo_padding;
+        for (int i = 0; i < output_shape.rank(); ++i) {
+            if (i == dim && !is_tile_dim) {
+                expected_output_shape.push_back(1);
+                expected_output_shape_wo_padding.push_back(1);
+            }
+            expected_output_shape.push_back(output_shape[i]);
+            expected_output_shape_wo_padding.push_back(output_shape_wo_padding[i]);
+        }
+
+        log_debug(LogOp, "{}:{} expected_output_shape {}", __func__, __LINE__, expected_output_shape);
+        log_debug(
+            LogOp, "{}:{} expected_output_shape_wo_padding {}", __func__, __LINE__, expected_output_shape_wo_padding);
+        for (int i = 0; i < input_rank; ++i) {
+            if (i == dim)
+                continue;
+            TT_FATAL(input_shape[i] == expected_output_shape[i]);
+            TT_FATAL(input_shape_wo_padding[i] == expected_output_shape_wo_padding[i]);
+        }
+    }
+}
+
+void initialize_dims_with_range(std::vector<int64_t> &dims, uint32_t input_rank) {
+    dims.resize(input_rank);
+    std::iota(dims.begin(), dims.end(), 0);
+}
+
+std::vector<int64_t> get_dim(
+    const std::optional<std::variant<int64_t, std::vector<int64_t>>> &dim, uint32_t input_rank) {
+    std::vector<int64_t> dims;
+    if (!dim.has_value()) {
+        initialize_dims_with_range(dims, input_rank);
+    } else if (std::holds_alternative<int64_t>(dim.value())) {
+        auto d = std::get<int64_t>(dim.value());
+        dims.push_back(d);
+    } else {
+        dims = std::get<std::vector<int64_t>>(dim.value());
+        if (dims.empty()) {
+            initialize_dims_with_range(dims, input_rank);
+        }
+    }
+    return dims;
+}
+
+std::tuple<uint32_t, uint32_t, uint32_t> extract_spatial_dims(const Shape& shape) {
+    const auto rank = shape.rank();
+
+    TT_FATAL(rank >= 2, "Shape must have at least two dims.");
+    uint32_t W = shape[-1];
+    uint32_t H = shape[-2];
+
+    uint32_t other_dims_product = 1;
+    for (auto i = 0; i < rank - 2; ++i) {
+        other_dims_product *= shape[i];
+    }
+
+    return { W, H, other_dims_product};
+}
+
+std::tuple<uint32_t, uint32_t, uint32_t, uint32_t> extract_and_scale_spatial_dims(const Shape& shape, uint32_t dim) {
+    const auto rank = shape.rank();
+
+    TT_FATAL(rank >= 2, "Shape must have at least two dims.");
+    uint32_t Wt = shape[-1] / TILE_WIDTH;
+    uint32_t Ht = shape[-2] / TILE_HEIGHT;
+
+    uint32_t reduce_dim = shape[dim];
+    uint32_t inner_dims_product = 1;
+    for (auto i = dim + 1; i < rank - 2; ++i) {
+        inner_dims_product *= shape[i];
+    }
+
+    uint32_t inner_tile_size = inner_dims_product * Ht * Wt;
+    uint32_t reduce_tile_size = reduce_dim * inner_tile_size;
+
+    return { Wt, Ht, inner_tile_size, reduce_tile_size};
+}
 
 }  // namespace primary
 }  // namespace operations

--- a/ttnn/cpp/ttnn/deprecated/tt_dnn/op_library/moreh_mean/kernels/moreh_mean_w.cpp
+++ b/ttnn/cpp/ttnn/deprecated/tt_dnn/op_library/moreh_mean/kernels/moreh_mean_w.cpp
@@ -8,9 +8,7 @@
 #include "compute_kernel_api/mask.h"
 #include "compute_kernel_api/reduce.h"
 #include "compute_kernel_api/tile_move_copy.h"
-
-ALWI void ACQ() { acquire_dst(tt::DstMode::Half); }
-ALWI void REL() { release_dst(tt::DstMode::Half); }
+#include "ttnn/cpp/ttnn/deprecated/tt_dnn/kernels/compute/moreh_common.hpp"
 
 namespace NAMESPACE {
 void MAIN {
@@ -19,15 +17,13 @@ void MAIN {
     uint32_t NC = get_compile_time_arg_val(2);
     constexpr uint32_t origin_W = get_compile_time_arg_val(3);
 
-
     auto cb_input = tt::CB::c_in0;
     constexpr auto cb_scaler = tt::CB::c_in2;
     constexpr auto cb_mask_w = tt::CB::c_in3;
     constexpr auto cb_accum_dst = tt::CB::c_intermed0;
     constexpr auto cb_masked_input = tt::CB::c_intermed1;
     constexpr auto cb_out = tt::CB::c_out0;
-    constexpr uint32_t TILE_W = 32;
-    constexpr bool do_mask_w = (origin_W % TILE_W) != 0;
+    constexpr bool do_mask_w = (origin_W % TILE_WIDTH) != 0;
 
     binary_op_init_common(cb_input, cb_input);
 
@@ -49,61 +45,72 @@ void MAIN {
             cb_input = tt::CB::c_in0;
             bool is_w_single_tile = (Wt == 1);
             if (!is_w_single_tile) {
-                ACQ();
+                tile_regs_acquire();
+
+                reduce_init_delta_with_dt<false, REDUCE_OP, REDUCE_DIM>(cb_accum_dst, cb_input, cb_scaler);
                 for (uint32_t wt = 0; wt < Wt - 1; ++wt) {
                     cb_wait_front(cb_input, onetile);
-
-                    reduce_init_delta<false>();
                     reduce_tile(cb_input, cb_scaler, 0, 0, reduce_dst_idx);
-                    reduce_revert_delta();
-
                     cb_pop_front(cb_input, onetile);
                 }
+                reduce_revert_delta(cb_accum_dst);
+                tile_regs_commit();
+
                 cb_reserve_back(cb_accum_dst, onetile);
-                pack_tile(reduce_dst_idx, cb_accum_dst);
+                tile_regs_wait();
+                pack_tile_with_dt(reduce_dst_idx, cb_accum_dst);
+                tile_regs_release();
                 cb_push_back(cb_accum_dst, onetile);
-                REL();
             }
 
             if (do_mask_w) {
-                ACQ();
+                tile_regs_acquire();
                 cb_wait_front(cb_input, onetile);
-                copy_tile_init();
+
+                copy_tile_init_with_dt(cb_input);
                 copy_tile(cb_input, 0, reduce_dst_idx);
+
+                copy_tile_init_with_dt(cb_mask_w);
                 copy_tile(cb_mask_w, 0, mask_dst_idx);
+
                 mask_tile_init();
                 mask_tile(reduce_dst_idx, mask_dst_idx);
+                tile_regs_commit();
 
                 cb_reserve_back(cb_masked_input, onetile);
-                pack_tile(reduce_dst_idx, cb_masked_input);
+                tile_regs_wait();
+                pack_tile_with_dt(reduce_dst_idx, cb_masked_input);
+                tile_regs_release();
                 cb_push_back(cb_masked_input, onetile);
 
                 cb_pop_front(cb_input, onetile);
                 cb_input = cb_masked_input;
-                REL();
             }
 
-            ACQ();
+            tile_regs_acquire();
             cb_wait_front(cb_input, onetile);
             if (!is_w_single_tile) {
                 cb_wait_front(cb_accum_dst, onetile);
-                copy_tile_init();
+
+                copy_tile_init_with_dt(cb_accum_dst);
                 copy_tile(cb_accum_dst, 0, reduce_dst_idx);
             }
 
-            reduce_init_delta<false>();
+            reduce_init_delta_with_dt<false, REDUCE_OP, REDUCE_DIM>(cb_out, cb_input, cb_scaler);
             reduce_tile(cb_input, cb_scaler, 0, 0, reduce_dst_idx);
-            reduce_revert_delta();
+            reduce_revert_delta(cb_out);
+            tile_regs_commit();
 
             cb_reserve_back(cb_out, onetile);
-            pack_tile(reduce_dst_idx, cb_out);
+            tile_regs_wait();
+            pack_tile_with_dt(reduce_dst_idx, cb_out);
+            tile_regs_release();
             cb_push_back(cb_out, onetile);
 
             cb_pop_front(cb_input, onetile);
             if (!is_w_single_tile) {
                 cb_pop_front(cb_accum_dst, onetile);
             }
-            REL();
         }
     }
 

--- a/ttnn/cpp/ttnn/deprecated/tt_dnn/op_library/moreh_mean/kernels/reader_moreh_mean_h.cpp
+++ b/ttnn/cpp/ttnn/deprecated/tt_dnn/op_library/moreh_mean/kernels/reader_moreh_mean_h.cpp
@@ -5,26 +5,27 @@
 #include "ttnn/cpp/ttnn/deprecated/tt_dnn/kernels/dataflow/moreh_common.hpp"
 
 void kernel_main() {
-    uint32_t src_addr  = get_arg_val<uint32_t>(0);
-    uint32_t col_start_tile_id = get_arg_val<uint32_t>(1); // Start id in column major order. This should be the start of a column
+    uint32_t src_addr = get_arg_val<uint32_t>(0);
+    uint32_t col_start_tile_id =
+        get_arg_val<uint32_t>(1);  // Start id in column major order. This should be the start of a column
     uint32_t curr_col_in_batch = get_arg_val<uint32_t>(2);
-    uint32_t num_cols = get_arg_val<uint32_t>(3); // number of cols to read
+    uint32_t num_cols = get_arg_val<uint32_t>(3);  // number of cols to read
     uint32_t mask_h = get_arg_val<uint32_t>(4);
 
     constexpr bool src_is_dram = get_compile_time_arg_val(0) == 1;
-    constexpr uint32_t Ht  = get_compile_time_arg_val(1);
-    constexpr uint32_t Wt  = get_compile_time_arg_val(2);
-    constexpr uint32_t HtWt  = get_compile_time_arg_val(3);
+    constexpr uint32_t Ht = get_compile_time_arg_val(1);
+    constexpr uint32_t Wt = get_compile_time_arg_val(2);
+    constexpr uint32_t HtWt = get_compile_time_arg_val(3);
 
-    constexpr uint32_t cb_id_in0 = 0;
+    constexpr uint32_t cb_id_in0 = tt::CB::c_in0;
 
     // ublocks size defined in tiles
     constexpr uint32_t onetile = 1;
     const uint32_t tile_bytes = get_tile_size(cb_id_in0);
     const DataFormat data_format = get_dataformat(cb_id_in0);
 
-    #ifdef REDUCE_SCALER
-    constexpr uint32_t cb_id_in2 = 2;
+#ifdef REDUCE_SCALER
+    constexpr uint32_t cb_id_in2 = tt::CB::c_in2;
     constexpr uint32_t scaler = get_compile_time_arg_val(4);
     cb_reserve_back(cb_id_in2, 1);
     constexpr uint32_t num_zeros_reads = 2048 / MEM_ZEROS_SIZE;
@@ -49,18 +50,15 @@ void kernel_main() {
         }
     }
     cb_push_back(cb_id_in2, 1);
-    #endif
+#endif
 
-    constexpr uint32_t cb_id_mask_h = 3;
+    constexpr uint32_t cb_id_mask_h = tt::CB::c_in3;
 #ifdef DO_MASK_H
     generate_mask_h(cb_id_mask_h, mask_h);
 #endif
 
     const InterleavedAddrGenFast<src_is_dram> s = {
-        .bank_base_address = src_addr,
-        .page_size = tile_bytes,
-        .data_format = data_format
-    };
+        .bank_base_address = src_addr, .page_size = tile_bytes, .data_format = data_format};
 
     uint32_t w = curr_col_in_batch;
 
@@ -73,7 +71,7 @@ void kernel_main() {
             noc_async_read_tile(curr_id, s, l1_write_addr);
             noc_async_read_barrier();
             cb_push_back(cb_id_in0, onetile);
-            curr_id += Wt; // stride in H
+            curr_id += Wt;  // stride in H
         }
         w++;
         if (w == Wt) {

--- a/ttnn/cpp/ttnn/deprecated/tt_dnn/op_library/moreh_mean/kernels/reader_moreh_mean_w.cpp
+++ b/ttnn/cpp/ttnn/deprecated/tt_dnn/op_library/moreh_mean/kernels/reader_moreh_mean_w.cpp
@@ -12,7 +12,7 @@ void kernel_main() {
     constexpr bool src_is_dram = get_compile_time_arg_val(0) == 1;
     constexpr uint32_t scaler = get_compile_time_arg_val(1);
 
-    constexpr uint32_t cb_id_in2 = 2;
+    constexpr uint32_t cb_id_in2 = tt::CB::c_in2;
     cb_reserve_back(cb_id_in2, 1);
     constexpr uint32_t num_zeros_reads = 2048 / MEM_ZEROS_SIZE;
     uint64_t zeros_noc_addr = get_noc_addr(MEM_ZEROS_BASE);
@@ -37,12 +37,12 @@ void kernel_main() {
     }
     cb_push_back(cb_id_in2, 1);
 
-    constexpr uint32_t cb_id_mask_w = 3;
+    constexpr uint32_t cb_id_mask_w = tt::CB::c_in3;
 #ifdef DO_MASK_W
     generate_mask_w(cb_id_mask_w, mask_w);
 #endif
 
-    constexpr uint32_t cb_id_in0 = 0;
+    constexpr uint32_t cb_id_in0 = tt::CB::c_in0;
 
     // ublocks size defined in tiles
     constexpr uint32_t onetile = 1;

--- a/ttnn/cpp/ttnn/deprecated/tt_dnn/op_library/moreh_mean/moreh_mean_h/moreh_mean_h.cpp
+++ b/ttnn/cpp/ttnn/deprecated/tt_dnn/op_library/moreh_mean/moreh_mean_h/moreh_mean_h.cpp
@@ -4,12 +4,13 @@
 
 #include <algorithm>
 
-#include "ttnn/deprecated/tt_dnn/op_library/moreh_mean/moreh_mean_op.hpp"
-#include "ttnn/operations/reduction/generic/device/reduce_op.hpp"
-#include "ttnn/deprecated/tt_dnn/op_library/work_split.hpp"
 #include "tt_metal/common/constants.hpp"
 #include "tt_metal/detail/util.hpp"
 #include "tt_metal/host_api.hpp"
+#include "ttnn/deprecated/tt_dnn/op_library/moreh_helper_functions.hpp"
+#include "ttnn/deprecated/tt_dnn/op_library/moreh_mean/moreh_mean_op.hpp"
+#include "ttnn/deprecated/tt_dnn/op_library/work_split.hpp"
+#include "ttnn/operations/reduction/generic/device/reduce_op.hpp"
 
 namespace tt {
 using namespace constants;
@@ -17,13 +18,13 @@ namespace operations {
 
 namespace primary {
 
-// TODO: Consolidate into moreh_sum_h
-operation::ProgramWithCallbacks moreh_mean_h(const Tensor &a, const Tensor &output) {
-    tt_metal::ReduceOpMath reduce_op = tt_metal::ReduceOpMath::SUM;
-    tt_metal::ReduceOpDim reduce_dim = tt_metal::ReduceOpDim::H;
-
-    const auto shape = a.get_legacy_shape();
-    uint32_t W = shape[3], H = shape[2], NC = shape[1] * shape[0];
+operation::ProgramWithCallbacks moreh_mean_h(
+    const Tensor &input,
+    const Tensor &output,
+    const CoreRange core_range,
+    const DeviceComputeKernelConfig compute_kernel_config) {
+    const auto shape = input.get_legacy_shape();
+    uint32_t W = shape[-1], H = shape[-2];
 
     uint32_t Wt = W / TILE_WIDTH;
     uint32_t Ht = H / TILE_HEIGHT;
@@ -31,154 +32,128 @@ operation::ProgramWithCallbacks moreh_mean_h(const Tensor &a, const Tensor &outp
 
     // check mask for h-dim
     const auto input_shape_without_padding = shape.without_padding();
-    const auto origin_H = input_shape_without_padding[2];
+    const auto origin_H = input_shape_without_padding[-2];
     const bool do_mask_h = (origin_H % TILE_HEIGHT) != 0;
     const auto mask_h = do_mask_h ? origin_H % TILE_HEIGHT : TILE_HEIGHT;
 
-    float scaler = 1.0f / origin_H;
+    auto program = tt_metal::CreateProgram();
 
-    tt_metal::Program program = tt_metal::CreateProgram();
+    auto units_to_divide = input.volume() / W / H * Wt;
 
-    tt::DataFormat src0_cb_data_format = tt_metal::datatype_to_dataformat_converter(a.get_dtype());
-    uint32_t src0_single_tile_size = tt_metal::detail::TileSize(src0_cb_data_format);
-    tt::DataFormat scaler_cb_data_format = DataFormat::Float16_b;
-    uint32_t scaler_single_tile_size = tt_metal::detail::TileSize(src0_cb_data_format);
-    tt::DataFormat mask_h_cb_data_format = tt::DataFormat::Float16_b;
-    uint32_t mask_h_single_tile_size = tt_metal::detail::TileSize(mask_h_cb_data_format);
-    tt::DataFormat intermed_cb_data_format = tt::DataFormat::Float16_b;
-    uint32_t intermed_single_tile_size= tt_metal::detail::TileSize(intermed_cb_data_format);
-    tt::DataFormat dst_cb_data_format = tt_metal::datatype_to_dataformat_converter(output.get_dtype());
-    uint32_t dst_single_tile_size = tt_metal::detail::TileSize(dst_cb_data_format);
+    uint32_t core_h = core_range.end_coord.y - core_range.start_coord.y + 1;
 
-    uint32_t num_tiles = a.volume() / TILE_HW;
+    auto [num_cores, all_cores, core_group_1, core_group_2, units_per_core_group_1, units_per_core_group_2] =
+        split_work_to_cores(core_range, units_to_divide);
 
-    tt_metal::Device *device = a.device();
+    auto arch = input.device()->arch();
+    auto [math_fidelity, math_approx_mode, fp32_dest_acc_en, packer_l1_acc] =
+        get_compute_kernel_config_args(arch, compute_kernel_config);
 
-    auto compute_with_storage_grid_size = device->compute_with_storage_grid_size();
-    uint32_t num_cores_x = compute_with_storage_grid_size.x;
-    uint32_t num_cores_y = compute_with_storage_grid_size.y;
-    auto num_cols = NC * Wt;
-    auto [num_cores, all_cores, core_group_1, core_group_2, num_cols_per_core_group_1, num_cols_per_core_group_2] =
-        split_work_to_cores(compute_with_storage_grid_size, num_cols);
+    // create circular buffers
+    tt::DataFormat data_format = tt_metal::datatype_to_dataformat_converter(input.get_dtype());
 
-    string compute_kernel_name = "ttnn/cpp/ttnn/deprecated/tt_dnn/op_library/moreh_mean/kernels/moreh_mean_h.cpp";
+    auto fp32_dest_acc_en_data_format = fp32_dest_acc_en ? tt::DataFormat::Float32 : data_format;
 
-    uint32_t src0_cb_index = CB::c_in0;
-    CBHandle cb_src0;
-    uint32_t src1_cb_index = CB::c_in1;
-    CBHandle cb_src1 = 0;
     uint32_t num_input_tiles = 2;
-    tt_metal::CircularBufferConfig cb_src0_config =
-        tt_metal::CircularBufferConfig(num_input_tiles * src0_single_tile_size, {{src0_cb_index, src0_cb_data_format}})
-            .set_page_size(src0_cb_index, src0_single_tile_size);
-    cb_src0 = tt_metal::CreateCircularBuffer(program, all_cores, cb_src0_config);
-
-    uint32_t scaler_cb_index = CB::c_in2;
-    tt_metal::CircularBufferConfig cb_scaler_config =
-        tt_metal::CircularBufferConfig(1 * scaler_single_tile_size, {{scaler_cb_index, scaler_cb_data_format}})
-            .set_page_size(scaler_cb_index, scaler_single_tile_size);
-    auto cb_scaler = tt_metal::CreateCircularBuffer(program, all_cores, cb_scaler_config);
-
-    tt_metal::CircularBufferConfig cb_mask_h_config =
-        tt_metal::CircularBufferConfig(mask_h_single_tile_size, {{CB::c_in3, mask_h_cb_data_format}})
-            .set_page_size(CB::c_in3, mask_h_single_tile_size);
-    auto cb_mask_h = tt_metal::CreateCircularBuffer(program, all_cores, cb_mask_h_config);
-
-    tt_metal::CircularBufferConfig cb_intermed0_config =
-        tt_metal::CircularBufferConfig(intermed_single_tile_size, {{CB::c_intermed0, intermed_cb_data_format}})
-            .set_page_size(CB::c_intermed0, intermed_single_tile_size);
-    auto cb_intermed0 = tt_metal::CreateCircularBuffer(program, all_cores, cb_intermed0_config);
-
-    tt_metal::CircularBufferConfig cb_intermed1_config =
-        tt_metal::CircularBufferConfig(intermed_single_tile_size, {{CB::c_intermed1, intermed_cb_data_format}})
-            .set_page_size(CB::c_intermed1, intermed_single_tile_size);
-    auto cb_intermed1 = tt_metal::CreateCircularBuffer(program, all_cores, cb_intermed1_config);
-
-    uint32_t output_cb_index = CB::c_out0;  // output operands start at index 16
-    CBHandle cb_output;
     uint32_t num_output_tiles = 2;
-    tt_metal::CircularBufferConfig cb_output_config =
-        tt_metal::CircularBufferConfig(num_output_tiles * dst_single_tile_size, {{output_cb_index, dst_cb_data_format}})
-            .set_page_size(output_cb_index, dst_single_tile_size);
-    cb_output = tt_metal::CreateCircularBuffer(program, all_cores, cb_output_config);
-    tt_metal::Buffer *src0_buffer = a.buffer();
-    tt_metal::KernelHandle reader_kernel_id;
+    CreateCircularBuffer(
+        program,
+        all_cores,
+        data_format,
+        {
+            {CB::c_in0, num_input_tiles},                        // input
+            {CB::c_in2, 1},                                      // scaler
+            {CB::c_in3, 1},                                      // mask
+            {CB::c_intermed0, 1, fp32_dest_acc_en_data_format},  //
+            {CB::c_intermed1, 1},                                //
+            {CB::c_out0, 1},                                     // output
+        });
+
+    float scaler = 1.0f / origin_H;
     bfloat16 bfloat_scaler_value = bfloat16(scaler);
-    uint32_t packed_scaler_value = pack_two_bfloat16_into_uint32({bfloat_scaler_value, bfloat_scaler_value});
-    bool src0_is_dram = src0_buffer->buffer_type() == tt_metal::BufferType::DRAM ? 1 : 0;
-    std::vector<uint32_t> reader_compile_time_args = {(std::uint32_t)src0_is_dram, Ht, Wt, HtWt, packed_scaler_value};
+    auto packed_scaler_value = pack_two_bfloat16_into_uint32({bfloat_scaler_value, bfloat_scaler_value});
+    std::vector<uint32_t> reader_compile_time_args = {
+        static_cast<uint32_t>(is_dram(input)), Ht, Wt, HtWt, packed_scaler_value};
 
     std::map<string, string> reader_defines;
     reader_defines["REDUCE_SCALER"] = "1";
     if (do_mask_h) {
         reader_defines["DO_MASK_H"] = "1";
     }
-    reader_kernel_id = tt_metal::CreateKernel(
+    const auto reader_kernel_id = CreateReadKernel(
         program,
         "ttnn/cpp/ttnn/deprecated/tt_dnn/op_library/moreh_mean/kernels/reader_moreh_mean_h.cpp",
         all_cores,
-        tt_metal::ReaderDataMovementConfig(reader_compile_time_args, reader_defines));
+        reader_compile_time_args,
+        reader_defines);
 
-    tt_metal::Buffer *dst_buffer = output.buffer();
-    tt_metal::KernelHandle writer_kernel_id;
+    std::vector<uint32_t> writer_compile_time_args = {
+        static_cast<uint32_t>(CB::c_out0), static_cast<uint32_t>(is_dram(output))};
 
-    bool dst_is_dram = dst_buffer->buffer_type() == tt_metal::BufferType::DRAM ? 1 : 0;
-    std::vector<uint32_t> writer_compile_time_args = {(std::uint32_t)output_cb_index, (std::uint32_t)dst_is_dram};
-
-    writer_kernel_id = tt_metal::CreateKernel(
+    const auto writer_kernel_id = CreateWriteKernel(
         program,
-        "ttnn/cpp/ttnn/deprecated/tt_dnn/op_library/moreh_mean/kernels/writer_moreh_mean_unary_interleaved_start_id.cpp",
+        "ttnn/cpp/ttnn/deprecated/tt_dnn/op_library/moreh_mean/kernels/"
+        "writer_moreh_mean_unary_interleaved_start_id.cpp",
         all_cores,
-        tt_metal::WriterDataMovementConfig(writer_compile_time_args));
-    std::map<string, string> reduce_defines = reduce_op_utils::get_defines(reduce_op, reduce_dim);
-    vector<uint32_t> compute_kernel_args_group_1 = {
-        Ht,                         // Ht
-        num_cols_per_core_group_1,  // Wt
-        1,                          // NC
-        origin_H
-    };
+        writer_compile_time_args);
 
-    auto reduce_compute_kernel_group_1_id = tt_metal::CreateKernel(
+    ////////////////////////////////////////////////////////////////////////////
+    //                      ComputeKernel SetUp
+    ///////////////////////////////////////////////////////////////////////////
+    string compute_kernel_name = "ttnn/cpp/ttnn/deprecated/tt_dnn/op_library/moreh_mean/kernels/moreh_mean_h.cpp";
+    auto reduce_op = tt_metal::ReduceOpMath::SUM;
+    auto reduce_dim = tt_metal::ReduceOpDim::H;
+    std::map<string, string> compute_defines = reduce_op_utils::get_defines(reduce_op, reduce_dim);
+    if (fp32_dest_acc_en) {
+        compute_defines["FP32_DEST_ACC_EN"] = 1;
+    }
+    vector<uint32_t> compute_kernel_args_group_1 = {
+        Ht,                      // Ht
+        units_per_core_group_1,  // Wt
+        1,                       // NC
+        origin_H};
+    vector<uint32_t> compute_kernel_args_group_2 = {
+        Ht,                      // Ht
+        units_per_core_group_2,  // Wt
+        1,                       // NC
+        origin_H};
+
+    auto compute_kernel_ids = CreateComputeKernel(
         program,
         compute_kernel_name,
-        core_group_1,
-        tt_metal::ComputeConfig{.compile_args = compute_kernel_args_group_1, .defines = reduce_defines});
+        {
+            {core_group_1, units_per_core_group_1, compute_kernel_args_group_1},
+            {core_group_2, units_per_core_group_2, compute_kernel_args_group_2},
+        },
+        ComputeKernelConfig{
+            .math_fidelity = math_fidelity,
+            .fp32_dest_acc_en = fp32_dest_acc_en,
+            // TODO(hyungsuk): change preserve_fp32_precision from false to fp32_dest_acc_en after fix #10337
+            // .preserve_fp32_precision = fp32_dest_acc_en,
+            .preserve_fp32_precision = false,
+            .math_approx_mode = math_approx_mode,
+            .defines = compute_defines});
 
-    if (!core_group_2.ranges().empty()) {
-        vector<uint32_t> compute_kernel_args_group_2 = {
-            Ht,                         // Ht
-            num_cols_per_core_group_2,  // Wt
-            1,                          // NC
-            origin_H
-        };
-
-        auto reduce_compute_kernel_group_2_id = tt_metal::CreateKernel(
-            program,
-            compute_kernel_name,
-            core_group_2,
-            tt_metal::ComputeConfig{.compile_args = compute_kernel_args_group_2, .defines = reduce_defines});
-    }
-
-    for (uint32_t i = 0, num_cols_read = 0; i < num_cores; i++) {
-        CoreCoord core = {i / num_cores_y, i % num_cores_y};
-        uint32_t num_cols_per_core = 0;
+    for (uint32_t i = 0, tile_offset = 0; i < num_cores; i++) {
+        CoreCoord core = {i / core_h, i % core_h};
+        uint32_t units_per_core = 0;
         if (core_group_1.core_coord_in_core_ranges(core)) {
-            num_cols_per_core = num_cols_per_core_group_1;
+            units_per_core = units_per_core_group_1;
         } else if (core_group_2.core_coord_in_core_ranges(core)) {
-            num_cols_per_core = num_cols_per_core_group_2;
+            units_per_core = units_per_core_group_2;
         } else {
+            std::cout << "i " << i << "\n";
             TT_ASSERT(false, "Core not in specified core ranges");
         }
         tt_metal::SetRuntimeArgs(
             program,
             reader_kernel_id,
             core,
-            {a.buffer()->address(),
-             num_cols_read / Wt * HtWt + num_cols_read % Wt,
-             num_cols_read % Wt,
-             num_cols_per_core,
-             mask_h
-             });
+            {input.buffer()->address(),
+             tile_offset / Wt * HtWt + tile_offset % Wt,
+             tile_offset % Wt,
+             units_per_core,
+             mask_h});
 
         tt_metal::SetRuntimeArgs(
             program,
@@ -186,40 +161,36 @@ operation::ProgramWithCallbacks moreh_mean_h(const Tensor &a, const Tensor &outp
             core,
             {
                 output.buffer()->address(),
-                num_cols_per_core,  // number of tiles to write
-                num_cols_read       // output tile start index
+                units_per_core,  // number of tiles to write
+                tile_offset      // output tile start index
             });
-        num_cols_read += num_cols_per_core;
+        tile_offset += units_per_core;
     }
 
-    auto override_runtime_arguments_callback = [reader_kernel_id = reader_kernel_id,
-                                                writer_kernel_id = writer_kernel_id,
-                                                cb_src1 = cb_src1,
-                                                cb_output = cb_output,
-                                                num_cores = num_cores,
-                                                num_cores_y = num_cores_y](
-                                                   const void *operation,
-                                                   Program &program,
-                                                   const std::vector<Tensor> &input_tensors,
-                                                   const std::vector<std::optional<const Tensor>> &,
-                                                   const std::vector<Tensor> &output_tensors) {
-        auto src_buffer = input_tensors.at(0).buffer();
-        auto dst_buffer = output_tensors.at(0).buffer();
+    auto override_runtime_arguments_callback =
+        [reader_kernel_id = reader_kernel_id, writer_kernel_id = writer_kernel_id, num_cores, core_h](
+            const void *operation,
+            Program &program,
+            const std::vector<Tensor> &input_tensors,
+            const std::vector<std::optional<const Tensor>> &,
+            const std::vector<Tensor> &output_tensors) {
+            auto src_buffer = input_tensors.at(0).buffer();
+            auto dst_buffer = output_tensors.at(0).buffer();
 
-        for (uint32_t i = 0, num_tiles_read = 0; i < num_cores; i++) {
-            CoreCoord core = {i / num_cores_y, i % num_cores_y};
+            for (uint32_t i = 0; i < num_cores; i++) {
+                CoreCoord core = {i / core_h, i % core_h};
 
-            {
-                auto &runtime_args = GetRuntimeArgs(program, reader_kernel_id, core);
-                runtime_args[0] = src_buffer->address();
+                {
+                    auto &runtime_args = GetRuntimeArgs(program, reader_kernel_id, core);
+                    runtime_args[0] = src_buffer->address();
+                }
+
+                {
+                    auto &runtime_args = GetRuntimeArgs(program, writer_kernel_id, core);
+                    runtime_args[0] = dst_buffer->address();
+                }
             }
-
-            {
-                auto &runtime_args = GetRuntimeArgs(program, writer_kernel_id, core);
-                runtime_args[0] = dst_buffer->address();
-            }
-        }
-    };
+        };
 
     return {.program = std::move(program), .override_runtime_arguments_callback = override_runtime_arguments_callback};
 }

--- a/ttnn/cpp/ttnn/deprecated/tt_dnn/op_library/moreh_mean/moreh_mean_nc/moreh_mean_nc.cpp
+++ b/ttnn/cpp/ttnn/deprecated/tt_dnn/op_library/moreh_mean/moreh_mean_nc/moreh_mean_nc.cpp
@@ -2,13 +2,13 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-#include "ttnn/deprecated/tt_dnn/op_library/moreh_mean/moreh_mean_op.hpp"
-#include "ttnn/operations/data_movement/bcast/bcast.hpp"
-#include "ttnn/deprecated/tt_dnn/op_library/moreh_helper_functions.hpp"
-#include "ttnn/deprecated/tt_dnn/op_library/work_split.hpp"
 #include "tt_metal/common/constants.hpp"
 #include "tt_metal/detail/util.hpp"
 #include "tt_metal/host_api.hpp"
+#include "ttnn/deprecated/tt_dnn/op_library/moreh_helper_functions.hpp"
+#include "ttnn/deprecated/tt_dnn/op_library/moreh_mean/moreh_mean_op.hpp"
+#include "ttnn/deprecated/tt_dnn/op_library/work_split.hpp"
+#include "ttnn/operations/data_movement/bcast/bcast.hpp"
 
 namespace tt {
 using namespace constants;
@@ -16,9 +16,12 @@ namespace operations {
 
 namespace primary {
 
-operation::ProgramWithCallbacks moreh_mean_nc(const Tensor &input, const Tensor &output, int64_t dim) {
-    TT_ASSERT(dim == 0 || dim == 1);
-
+operation::ProgramWithCallbacks moreh_mean_nc(
+    const Tensor &input,
+    const Tensor &output,
+    int64_t dim,
+    const CoreRange core_range,
+    const DeviceComputeKernelConfig compute_kernel_config) {
     ////////////////////////////////////////////////////////////////////////////
     //                      Device Setup
     ////////////////////////////////////////////////////////////////////////////
@@ -34,57 +37,60 @@ operation::ProgramWithCallbacks moreh_mean_nc(const Tensor &input, const Tensor 
     const auto &input_shape = input.get_legacy_shape();
     const auto &input_shape_without_padding = input_shape.without_padding();
 
-    const auto N = input_shape[0];
-    const auto C = input_shape[1];
-    const auto Ht = input_shape[2] / TILE_HEIGHT;
-    const auto Wt = input_shape[3] / TILE_WIDTH;
+    const auto Ht = input_shape[-2] / TILE_HEIGHT;
+    const auto Wt = input_shape[-1] / TILE_WIDTH;
     const auto HtWt = Ht * Wt;
-    const auto CHtWt = C * Ht * Wt;
     const auto num_reduce_input_tile = input_shape[dim];
-    const auto input_tile_offset = (dim == 0) ? (CHtWt) : (HtWt);
-    const auto num_output_tiles = output.volume() / TILE_HW;
 
-    log_debug(LogTest, "N {} C {} Ht {} Wt {}", N, C, Ht, Wt);
+    const auto rank = input_shape.rank();
+    auto input_tile_stride = HtWt;
+    for (int i = dim + 1; i < rank - 2; i++) {
+        input_tile_stride *= input_shape[i];
+    }
+
+    uint32_t inner_size = 1;
+    for (int i = dim + 1; i < rank - 2; i++) {
+        inner_size *= input_shape[i];
+    }
+
+    const auto units_to_divide = output.volume() / TILE_HW;
+
     log_debug(
         LogTest,
-        "dim {} num_reduce_input_tile {} input_tile_offset {}, num_output_tiles {}",
+        "dim {} num_reduce_input_tile {} input_tile_offset {}, units_to_divide {}",
         dim,
         num_reduce_input_tile,
-        input_tile_offset,
-        num_output_tiles);
+        input_tile_stride,
+        units_to_divide);
 
     ////////////////////////////////////////////////////////////////////////////
     //                         Core Setup
     ////////////////////////////////////////////////////////////////////////////
-    auto grid = device->compute_with_storage_grid_size();
-    const auto num_cores_y = grid.y;
+    uint32_t core_h = core_range.end_coord.y - core_range.start_coord.y + 1;
 
-    const uint32_t in0_t = 2;        // input
-    const uint32_t in1_t = 1;        // zero
-    const uint32_t in2_t = 1;        // scalar
-    const uint32_t intermed0_t = 1;  // accumulated mean
-    const uint32_t out0_t = 2;       // output
-    const auto
-        [num_cores_to_be_used,
-         all_cores,
-         core_group_1,
-         core_group_2,
-         num_cols_per_core_group_1,
-         num_cols_per_core_group_2] = tt_metal::split_work_to_cores(grid, num_output_tiles);
+    auto [num_cores, all_cores, core_group_1, core_group_2, units_per_core_group_1, units_per_core_group_2] =
+        split_work_to_cores(core_range, units_to_divide);
+
+    auto arch = input.device()->arch();
+    auto [math_fidelity, math_approx_mode, fp32_dest_acc_en, packer_l1_acc] =
+        get_compute_kernel_config_args(arch, compute_kernel_config);
 
     ////////////////////////////////////////////////////////////////////////////
     //                         CircularBuffer Setup
     ////////////////////////////////////////////////////////////////////////////
+    tt::DataFormat data_format = tt_metal::datatype_to_dataformat_converter(input.get_dtype());
+
+    auto fp32_dest_acc_en_data_format = fp32_dest_acc_en ? tt::DataFormat::Float32 : data_format;
     CreateCircularBuffer(
         program,
         all_cores,
         cb_data_format,
         {
-            {CB::c_in0, in0_t},              // input
-            {CB::c_in1, in1_t},              // zero
-            {CB::c_in2, in2_t},              // scalar
-            {CB::c_intermed0, intermed0_t},  // accumulated mean
-            {CB::c_out0, out0_t},            // output
+            {CB::c_in0, 2},        // input
+            {CB::c_in1, 1},        // zero
+            {CB::c_in2, 1},        // scaler
+            {CB::c_intermed0, 1},  // accumulated mean
+            {CB::c_out0, 2},       // output
         });
 
     ////////////////////////////////////////////////////////////////////////////
@@ -92,41 +98,53 @@ operation::ProgramWithCallbacks moreh_mean_nc(const Tensor &input, const Tensor 
     ////////////////////////////////////////////////////////////////////////////
     std::vector<uint32_t> reader_compile_time_args;
     std::vector<uint32_t> writer_compile_time_args;
-    const auto reader_kernel_file = "ttnn/cpp/ttnn/deprecated/tt_dnn/op_library/moreh_mean/kernels/reader_moreh_mean_nc.cpp";
-    const auto writer_kernel_file = "ttnn/cpp/ttnn/deprecated/tt_dnn/op_library/moreh_mean/kernels/writer_moreh_mean_nc.cpp";
+    const auto reader_kernel_file =
+        "ttnn/cpp/ttnn/deprecated/tt_dnn/op_library/moreh_mean/kernels/reader_moreh_mean_nc.cpp";
+    const auto writer_kernel_file =
+        "ttnn/cpp/ttnn/deprecated/tt_dnn/op_library/moreh_mean/kernels/writer_moreh_mean_nc.cpp";
     const auto reader_kernel_id = CreateReadKernel(program, reader_kernel_file, all_cores, reader_compile_time_args);
     const auto writer_kernel_id = CreateWriteKernel(program, writer_kernel_file, all_cores, writer_compile_time_args);
 
     ////////////////////////////////////////////////////////////////////////////
     //                      ComputeKernel SetUp
     ////////////////////////////////////////////////////////////////////////////
-    const std::vector<uint32_t> compute_args_group_1{num_cols_per_core_group_1};
-    std::map<string, string> compute_defines;
     const auto compute_kernel_file = "ttnn/cpp/ttnn/deprecated/tt_dnn/op_library/moreh_mean/kernels/moreh_mean_nc.cpp";
-    const auto compute_kernel_1_id = CreateComputeKernel(
-        program, compute_kernel_file, {core_group_1, num_cols_per_core_group_1, compute_args_group_1}, compute_defines);
+    std::map<string, string> compute_defines;
+    const std::vector<uint32_t> compute_args_group_1{units_per_core_group_1};
+    const std::vector<uint32_t> compute_args_group_2{units_per_core_group_2};
 
-    std::optional<KernelHandle> compute_kernel_2_id = std::nullopt;
-    if (!core_group_2.ranges().empty()) {
-        const std::vector<uint32_t> compute_args_group_2{num_cols_per_core_group_2};
-        compute_kernel_2_id = CreateComputeKernel(
-            program,
-            compute_kernel_file,
-            {core_group_2, num_cols_per_core_group_2, compute_args_group_2},
-            compute_defines);
+    if (fp32_dest_acc_en) {
+        compute_defines["FP32_DEST_ACC_EN"] = 1;
     }
+    auto compute_kernel_ids = CreateComputeKernel(
+        program,
+        compute_kernel_file,
+        {
+            {core_group_1, units_per_core_group_1, compute_args_group_1},
+            {core_group_2, units_per_core_group_2, compute_args_group_2},
+        },
+        ComputeKernelConfig{
+            .math_fidelity = math_fidelity,
+            // TODO(hyungsuk): change preserve_fp32_precision from false to fp32_dest_acc_en after fix #10337
+            // .preserve_fp32_precision = fp32_dest_acc_en,
+            .fp32_dest_acc_en = fp32_dest_acc_en,
+            .preserve_fp32_precision = fp32_dest_acc_en,
+            .math_approx_mode = math_approx_mode,
+            .defines = compute_defines});
 
     ////////////////////////////////////////////////////////////////////////////
     //                      RuntimeArgs SetUp
     ////////////////////////////////////////////////////////////////////////////
-    for (uint32_t i = 0, tile_offset = 0; i < num_cores_to_be_used; ++i) {
-        CoreCoord core = {i / num_cores_y, i % num_cores_y};
+    for (uint32_t i = 0, tile_offset = 0; i < num_cores; ++i) {
+        CoreCoord core = {i / core_h, i % core_h};
 
-        uint32_t num_tiles_per_core;
+        uint32_t units_per_core;
         if (core_group_1.core_coord_in_core_ranges(core)) {
-            num_tiles_per_core = num_cols_per_core_group_1;
+            units_per_core = units_per_core_group_1;
+            SetRuntimeArgs(program, compute_kernel_ids[0], core, {num_reduce_input_tile, units_per_core});
         } else if (core_group_2.core_coord_in_core_ranges(core)) {
-            num_tiles_per_core = num_cols_per_core_group_2;
+            units_per_core = units_per_core_group_2;
+            SetRuntimeArgs(program, compute_kernel_ids[1], core, {num_reduce_input_tile, units_per_core});
         } else {
             TT_THROW("Core not in specified core ranges.");
         }
@@ -137,49 +155,39 @@ operation::ProgramWithCallbacks moreh_mean_nc(const Tensor &input, const Tensor 
             core,
             {input.buffer()->address(),
              num_reduce_input_tile,
-             num_tiles_per_core,
-             input_tile_offset,
+             units_per_core,
+             input_tile_stride,
              tile_offset,
              static_cast<uint32_t>(is_dram(input)),
              HtWt,
-             CHtWt,
-             static_cast<uint32_t>(dim)
-             });
+             inner_size});
 
         SetRuntimeArgs(
             program,
             writer_kernel_id,
             core,
-            {output.buffer()->address(), num_tiles_per_core, tile_offset, static_cast<uint32_t>(is_dram(output))});
+            {output.buffer()->address(), units_per_core, tile_offset, static_cast<uint32_t>(is_dram(output))});
 
-        if (core_group_1.core_coord_in_core_ranges(core)) {
-            SetRuntimeArgs(program, compute_kernel_1_id, core, {num_reduce_input_tile, num_tiles_per_core});
-        } else if (core_group_2.core_coord_in_core_ranges(core)) {
-            TT_ASSERT(compute_kernel_2_id.has_value());
-            SetRuntimeArgs(program, compute_kernel_2_id.value(), core, {num_reduce_input_tile, num_tiles_per_core});
-        } else {
-            TT_ASSERT(false, "Core not in specified core ranges.");
-        }
-        tile_offset += num_tiles_per_core;
+        tile_offset += units_per_core;
     }
 
-    auto override_runtime_arguments_callback = [reader_kernel_id, writer_kernel_id, num_cores_to_be_used, num_cores_y](
+    auto override_runtime_arguments_callback = [reader_kernel_id, writer_kernel_id, num_cores, core_h](
                                                    const void *operation,
                                                    const Program &program,
                                                    const std::vector<Tensor> &input_tensors,
                                                    const std::vector<std::optional<const Tensor>> &,
                                                    const std::vector<Tensor> &output_tensors) {
         const auto *input_buffer = input_tensors.at(0).buffer();
-        const auto *output_buffer = input_tensors.at(1).buffer();
-        for (uint32_t i = 0; i < num_cores_to_be_used; ++i) {
-            CoreCoord core = {i / num_cores_y, i % num_cores_y};
+        const auto *output_buffer = output_tensors.at(0).buffer();
+        for (uint32_t i = 0; i < num_cores; ++i) {
+            CoreCoord core = {i / core_h, i % core_h};
             {
-                auto& runtime_args = GetRuntimeArgs(program, reader_kernel_id, core);
+                auto &runtime_args = GetRuntimeArgs(program, reader_kernel_id, core);
                 runtime_args[0] = input_buffer->address();
             }
 
             {
-                auto& runtime_args = GetRuntimeArgs(program, writer_kernel_id, core);
+                auto &runtime_args = GetRuntimeArgs(program, writer_kernel_id, core);
                 runtime_args[0] = output_buffer->address();
             }
         }

--- a/ttnn/cpp/ttnn/deprecated/tt_dnn/op_library/moreh_mean/moreh_mean_op.cpp
+++ b/ttnn/cpp/ttnn/deprecated/tt_dnn/op_library/moreh_mean/moreh_mean_op.cpp
@@ -3,9 +3,10 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "ttnn/deprecated/tt_dnn/op_library/moreh_mean/moreh_mean_op.hpp"
-#include "ttnn/deprecated/tt_dnn/op_library/moreh_helper_functions.hpp"
+
 #include "tt_metal/common/constants.hpp"
 #include "tt_metal/host_api.hpp"
+#include "ttnn/deprecated/tt_dnn/op_library/moreh_helper_functions.hpp"
 
 namespace tt {
 using namespace constants;
@@ -15,139 +16,160 @@ namespace primary {
 ////////////////////////////////////////////////////////////////////////////
 //                         MorehMean
 ////////////////////////////////////////////////////////////////////////////
-void MorehMean::validate(const std::vector<Tensor>& inputs) const {
-    TT_ASSERT((dim >= 0 && dim <= 3), "dim should be 0 - 3");
-    const auto& input = inputs.at(0);
-    const auto& output = inputs.at(1);
+void MorehMean::validate_with_output_tensors(
+    const std::vector<Tensor>& input_tensors, const std::vector<std::optional<Tensor>>& output_tensors) const {
+    TT_FATAL((dim >= 0 && dim <= 7), "dim should be 0 - 7");
+    TT_FATAL(input_tensors.size() == 1);
+    TT_FATAL(this->divisor.has_value() == false, "divisor not supported yet.");
 
-    auto input_shape = input.get_legacy_shape();
-    const auto& output_shape = output.get_legacy_shape();
-    auto input_shape_wo_padding = input.get_legacy_shape().without_padding();
-    const auto& output_shape_wo_padding = output.get_legacy_shape().without_padding();
+    const auto& input = input_tensors.at(0);
+    auto& output = output_tensors.at(0);
 
-    if (dim == 0 || dim == 1) {
-        input_shape[dim] = 1;
-        input_shape_wo_padding[dim] = 1;
-    } else {
-        input_shape[dim] = TILE_HEIGHT;
-        input_shape_wo_padding[dim] = 1;
-    }
+    check_tensor(input, "moreh_mean", "input", {DataType::BFLOAT16});
+    check_tensor(output, "moreh_mean", "output", {DataType::BFLOAT16});
 
-    for (int i = 0; i < input_shape.rank(); ++i) {
-        TT_ASSERT(input_shape[i] == output_shape[i]);
-        TT_ASSERT(input_shape_wo_padding[i] == output_shape_wo_padding[i]);
+    validate_input_with_dim(input, this->dim);
+
+    if (output.has_value()) {
+        validate_output_with_keepdim(input, output.value(), this->dim, this->keepdim);
     }
 }
 
-std::vector<Tensor> MorehMean::create_output_tensors(const std::vector<Tensor>& inputs) const {
-    // Inplace
-    return {};
+std::vector<Shape> MorehMean::compute_output_shapes(const std::vector<Tensor>& input_tensors) const {
+    auto input_shape = input_tensors[0].get_legacy_shape();
+    auto output_shape = input_shape;
+    auto input_rank = input_shape.rank();
+
+    if (this->keepdim) {
+        auto padding = output_shape.padding();
+        if (dim + 1 == input_rank) {
+            output_shape[dim] = TILE_WIDTH;
+            padding[dim] = Padding::PadDimension{0, 31};
+        } else if (dim + 2 == input_rank) {
+            output_shape[dim] = TILE_HEIGHT;
+            padding[dim] = Padding::PadDimension{0, 31};
+        } else {
+            output_shape[dim] = 1;
+        }
+
+        return {Shape(output_shape, padding)};
+    }
+
+    std::vector<uint32_t> shape;
+    std::vector<Padding::PadDimension> pad_dimensions;
+    const bool is_tile_dim = (this->dim == input_rank - 1 || this->dim == input_rank - 2);
+    const std::size_t output_rank = (is_tile_dim) ? (input_rank) : (input_rank - 1);
+    auto input_padding = input_shape.padding();
+
+    // e.g. (2, 64, 64) with dim 1 to be (2, 1[32], 64)
+    // e.g. (2, 64, 64) with dim 0 to be (64, 64)
+    for (int i = 0; i < input_rank; ++i) {
+        bool is_reduced_dim = (i == this->dim);
+        if (is_reduced_dim && !is_tile_dim)
+            continue;
+
+        shape.push_back((is_reduced_dim && is_tile_dim) ? (TILE_HEIGHT) : (input_shape[i]));
+        pad_dimensions.push_back((is_reduced_dim && is_tile_dim) ? (Padding::PadDimension{0, 31}) : (input_padding[i]));
+    }
+
+    auto padding = Padding(pad_dimensions, input_padding.pad_value());
+    return {Shape(shape, padding)};
 }
 
-std::vector<Shape> MorehMean::compute_output_shapes(const std::vector<Tensor>& inputs) const {
-    // Inplace
-    return {};
+std::vector<Tensor> MorehMean::create_output_tensors(
+    const std::vector<Tensor>& input_tensors, const std::vector<std::optional<Tensor>>& output_tensors) const {
+    if (output_tensors[0].has_value()) {
+        return {output_tensors[0].value()};
+    }
+
+    return operation::generic_create_output_tensors(
+        *this, input_tensors, input_tensors[0].get_dtype(), Layout::TILE, this->memory_config);
 }
 
 operation::ProgramWithCallbacks MorehMean::create_program(
     const std::vector<Tensor>& inputs, std::vector<Tensor>& outputs) const {
-    TT_ASSERT((dim >= 0 && dim <= 3), "dim should be 0 - 3");
-    auto& input = inputs.at(0);
-    auto& output = inputs.at(1);
+    auto& input = inputs[0];
+    auto& output = outputs[0];
 
-    if (dim == 0 || dim == 1) {
-        return moreh_mean_nc(input, output, dim);
-    } else if (dim == 2) {
-        return moreh_mean_h(input, output);
-    } else {
-        return moreh_mean_w(input, output);
-    }
-}
+    auto rank = input.get_legacy_shape().rank();
 
-inline Shape compute_output_shape(const Shape& input_shape, const int64_t& dim) {
-    auto output_shape = input_shape;
-    auto padding = output_shape.padding();
-    switch (dim) {
-        case 0:
-        case 1: output_shape[dim] = 1; break;
-        case 2:
-            output_shape[dim] = TILE_HEIGHT;
-            padding[dim] = Padding::PadDimension{0, 31};
-            break;
-        case 3:
-            output_shape[dim] = TILE_WIDTH;
-            padding[dim] = Padding::PadDimension{0, 31};
-            break;
+    if (dim + 1 == rank) {
+        return moreh_mean_w(input, output, this->core_range, this->compute_kernel_config);
+    } else if (dim + 2 == rank) {
+        return moreh_mean_h(input, output, this->core_range, this->compute_kernel_config);
     }
 
-    return {Shape(output_shape, padding)};
-}
-
-inline Tensor create_output_tensor(
-    const Tensor& input_tensor, const Shape& output_shape, const MemoryConfig& mem_config) {
-    TT_ASSERT(input_tensor.storage_type() == StorageType::DEVICE);
-    return create_device_tensor(
-        output_shape, input_tensor.get_dtype(), Layout::TILE, input_tensor.device(), mem_config);
-}
-
-// output as arg
-Tensor moreh_mean_(const Tensor& input, const Tensor& output, const int64_t& dim) {
-    std::vector<Tensor> dummy_output_tensors = {Tensor(operation::get_workers_for_op_output({input, output}))};
-
-    operation::launch_op(
-        [dim](
-            const std::vector<Tensor>& input_tensors,
-            const std::vector<std::optional<const Tensor>>& optional_input_tensors,
-            const std::vector<std::optional<Tensor>>& optional_output_tensors) mutable -> std::vector<Tensor> {
-            return operation::run(
-                MorehMean{.dim = dim}, input_tensors, optional_input_tensors, optional_output_tensors);
-        },
-        {input, output},
-        dummy_output_tensors);
-
-    return output;
+    return moreh_mean_nc(input, output, dim, this->core_range, this->compute_kernel_config);
 }
 
 // output creation inside
-Tensor moreh_mean_(const Tensor& input, const int64_t& dim, const MemoryConfig& mem_config) {
-    const auto& input_shape = input.get_legacy_shape();
-    const auto& output_shape = compute_output_shape(input_shape, dim);
-    auto output = create_output_tensor(input, output_shape, mem_config);
+Tensor moreh_mean_(
+    const Tensor& input,
+    const int64_t& dim,
+    const bool keepdim,
+    const std::optional<uint32_t> divisor,
+    const std::optional<const Tensor> output,
+    const std::optional<MemoryConfig> memory_config,
+    std::optional<const DeviceComputeKernelConfig> compute_kernel_config) {
+    std::vector<Tensor> output_tensors = {Tensor(operation::get_workers_for_op_output({input}))};
 
-    std::vector<Tensor> dummy_output_tensors = {Tensor(operation::get_workers_for_op_output({input, output}))};
+    auto device = input.device();
+    auto kernel_config_val =
+        init_device_compute_kernel_config(device->arch(), compute_kernel_config, MathFidelity::HiFi4);
+
+    auto grid_coord = device->compute_with_storage_grid_size();
+    const CoreRange all_cores({0, 0}, {grid_coord.x - 1, grid_coord.y - 1});
 
     operation::launch_op(
-        [dim](
+        [dim, keepdim, divisor, memory_config, all_cores, kernel_config_val](
             const std::vector<Tensor>& input_tensors,
             const std::vector<std::optional<const Tensor>>& optional_input_tensors,
             const std::vector<std::optional<Tensor>>& optional_output_tensors) mutable -> std::vector<Tensor> {
             return operation::run(
-                MorehMean{.dim = dim}, input_tensors, optional_input_tensors, optional_output_tensors);
+                MorehMean{
+                    .dim = dim,
+                    .keepdim = keepdim,
+                    .divisor = divisor,
+                    .memory_config = memory_config.value_or(input_tensors.at(0).memory_config()),
+                    .core_range = all_cores,
+                    .compute_kernel_config = kernel_config_val},
+                input_tensors,
+                optional_input_tensors,
+                optional_output_tensors);
         },
-        {input, output},
-        dummy_output_tensors);
+        {input},
+        output_tensors,
+        {},
+        {output});
 
-    return output;
-}
-
-Tensor moreh_mean(
-    const Tensor& input, const Tensor& output, std::vector<int64_t>& dims, const MemoryConfig& mem_config) {
-    // reduce for all dims
-    if (dims.empty()) {
-        dims = {0, 1, 2, 3};
+    if (output.has_value()) {
+        return output.value();
     }
 
-    std::vector<int64_t> sorted_dims = dims;
-    std::sort(sorted_dims.begin(), sorted_dims.end());
+    return output_tensors[0];
+}
+
+std::optional<Tensor> moreh_mean(
+    const Tensor& input,
+    std::optional<std::variant<int64_t, std::vector<int64_t>>> dim,
+    const bool keepdim,
+    const std::optional<uint32_t> divisor,
+    const std::optional<const Tensor> output,
+    const std::optional<MemoryConfig> memory_config,
+    std::optional<const DeviceComputeKernelConfig> compute_kernel_config) {
+    auto rank = input.get_legacy_shape().rank();
+    std::vector<int64_t> dims = get_dim(dim, rank);
+    std::sort(dims.begin(), dims.end());
 
     auto temp_input = input;
     for (uint32_t i = dims.size() - 1; i > 0; i--) {
-        log_debug(LogTest, "{}:{} dim {}", __func__, __LINE__, sorted_dims[i]);
-        auto temp_output = moreh_mean_(temp_input, sorted_dims[i], mem_config);
+        log_debug(LogTest, "{}:{} dim {}", __func__, __LINE__, dims[i]);
+        auto temp_output =
+            moreh_mean_(temp_input, dims[i], keepdim, divisor, std::nullopt, memory_config, compute_kernel_config);
         temp_input = temp_output;
     }
-    log_debug(LogTest, "{}:{} dim {}", __func__, __LINE__, sorted_dims.front());
-    moreh_mean_(temp_input, output, sorted_dims.front());
+    log_debug(LogTest, "{}:{} dim {}", __func__, __LINE__, dims.front());
+    moreh_mean_(temp_input, dims.front(), keepdim, divisor, output, memory_config, compute_kernel_config);
 
     return output;
 }

--- a/ttnn/cpp/ttnn/deprecated/tt_dnn/op_library/moreh_mean/moreh_mean_w/moreh_mean_w.cpp
+++ b/ttnn/cpp/ttnn/deprecated/tt_dnn/op_library/moreh_mean/moreh_mean_w/moreh_mean_w.cpp
@@ -5,12 +5,13 @@
 
 #include <algorithm>
 
-#include "ttnn/deprecated/tt_dnn/op_library/moreh_mean/moreh_mean_op.hpp"
-#include "ttnn/operations/reduction/generic/device/reduce_op.hpp"
-#include "ttnn/deprecated/tt_dnn/op_library/work_split.hpp"
 #include "tt_metal/common/constants.hpp"
 #include "tt_metal/detail/util.hpp"
 #include "tt_metal/host_api.hpp"
+#include "ttnn/deprecated/tt_dnn/op_library/moreh_helper_functions.hpp"
+#include "ttnn/deprecated/tt_dnn/op_library/moreh_mean/moreh_mean_op.hpp"
+#include "ttnn/deprecated/tt_dnn/op_library/work_split.hpp"
+#include "ttnn/operations/reduction/generic/device/reduce_op.hpp"
 
 namespace tt {
 using namespace constants;
@@ -18,13 +19,13 @@ namespace operations {
 
 namespace primary {
 
-// TODO: Consolidate into moreh_sum_w
-operation::ProgramWithCallbacks moreh_mean_w(const Tensor &a, const Tensor &output) {
-    tt_metal::ReduceOpMath reduce_op = tt_metal::ReduceOpMath::SUM;
-    tt_metal::ReduceOpDim reduce_dim = tt_metal::ReduceOpDim::W;
-
-    const auto shape = a.get_legacy_shape();
-    uint32_t W = shape[3], H = shape[2], NC = shape[1] * shape[0];
+operation::ProgramWithCallbacks moreh_mean_w(
+    const Tensor &input,
+    const Tensor &output,
+    const CoreRange core_range,
+    const DeviceComputeKernelConfig compute_kernel_config) {
+    const auto shape = input.get_legacy_shape();
+    uint32_t W = shape[-1], H = shape[-2];
     uint32_t HW = H * W;
 
     uint32_t Wt = W / TILE_WIDTH;
@@ -32,151 +33,128 @@ operation::ProgramWithCallbacks moreh_mean_w(const Tensor &a, const Tensor &outp
 
     // check mask for w-dim
     const auto input_shape_without_padding = shape.without_padding();
-    const auto origin_W = input_shape_without_padding[3];
+    const auto origin_W = input_shape_without_padding[-1];
     const bool do_mask_w = (origin_W % TILE_WIDTH) != 0;
     const auto mask_w = do_mask_w ? origin_W % TILE_WIDTH : TILE_WIDTH;
 
-    float scaler = 1.0f / origin_W;
+    auto program = tt_metal::CreateProgram();
 
-    tt_metal::Program program = tt_metal::CreateProgram();
+    uint32_t core_h = core_range.end_coord.y - core_range.start_coord.y + 1;
 
-    tt::DataFormat src0_cb_data_format = tt_metal::datatype_to_dataformat_converter(a.get_dtype());
-    uint32_t src0_single_tile_size = tt_metal::detail::TileSize(src0_cb_data_format);
-    // Scaler datatype is hardcoded bfloat16 due to tile creation in reader
-    tt::DataFormat scaler_cb_data_format = tt::DataFormat::Float16_b;
-    uint32_t scaler_single_tile_size = tt_metal::detail::TileSize(scaler_cb_data_format);
-    tt::DataFormat mask_w_cb_data_format = tt::DataFormat::Float16_b;
-    uint32_t mask_w_single_tile_size = tt_metal::detail::TileSize(mask_w_cb_data_format);
-    tt::DataFormat intermed_cb_data_format = tt::DataFormat::Float16_b;
-    uint32_t intermed_single_tile_size= tt_metal::detail::TileSize(intermed_cb_data_format);
-    tt::DataFormat dst_cb_data_format = tt_metal::datatype_to_dataformat_converter(output.get_dtype());
-    uint32_t dst_single_tile_size = tt_metal::detail::TileSize(dst_cb_data_format);
+    auto units_to_divide = input.volume() / W / H * Ht;
+    auto [num_cores, all_cores, core_group_1, core_group_2, units_per_core_group_1, units_per_core_group_2] =
+        split_work_to_cores(core_range, units_to_divide);
 
-    uint32_t num_tiles = a.volume() / TILE_HW;
+    auto arch = input.device()->arch();
+    auto [math_fidelity, math_approx_mode, fp32_dest_acc_en, packer_l1_acc] =
+        get_compute_kernel_config_args(arch, compute_kernel_config);
 
-    tt_metal::Device *device = a.device();
+    // create circular buffers
+    tt::DataFormat data_format = tt_metal::datatype_to_dataformat_converter(input.get_dtype());
 
-    auto compute_with_storage_grid_size = device->compute_with_storage_grid_size();
-    uint32_t num_cores_x = compute_with_storage_grid_size.x;
-    uint32_t num_cores_y = compute_with_storage_grid_size.y;
-    auto num_rows = NC * Ht;
+    auto fp32_dest_acc_en_data_format = fp32_dest_acc_en ? tt::DataFormat::Float32 : data_format;
 
-    auto [num_cores, all_cores, core_group_1, core_group_2, num_rows_per_core_group_1, num_rows_per_core_group_2] =
-        split_work_to_cores(compute_with_storage_grid_size, num_rows);
-
-    string compute_kernel_name = "ttnn/cpp/ttnn/deprecated/tt_dnn/op_library/moreh_mean/kernels/moreh_mean_w.cpp";
-
-    uint32_t src0_cb_index = 0;
     uint32_t num_input_tiles = 2;
-    tt_metal::CircularBufferConfig cb_src0_config =
-        tt_metal::CircularBufferConfig(num_input_tiles * src0_single_tile_size, {{src0_cb_index, src0_cb_data_format}})
-            .set_page_size(src0_cb_index, src0_single_tile_size);
-    auto cb_src0 = tt_metal::CreateCircularBuffer(program, all_cores, cb_src0_config);
-
-    tt_metal::CircularBufferConfig cb_scaler_config =
-        tt_metal::CircularBufferConfig(num_input_tiles * scaler_single_tile_size, {{CB::c_in2, scaler_cb_data_format}})
-            .set_page_size(CB::c_in2, scaler_single_tile_size);
-    auto cb_scaler = tt_metal::CreateCircularBuffer(program, all_cores, cb_scaler_config);
-
-    tt_metal::CircularBufferConfig cb_mask_w_config =
-        tt_metal::CircularBufferConfig(mask_w_single_tile_size, {{CB::c_in3, mask_w_cb_data_format}})
-            .set_page_size(CB::c_in3, mask_w_single_tile_size);
-    auto cb_mask_w = tt_metal::CreateCircularBuffer(program, all_cores, cb_mask_w_config);
-
-    tt_metal::CircularBufferConfig cb_intermed0_config =
-        tt_metal::CircularBufferConfig(intermed_single_tile_size, {{CB::c_intermed0, intermed_cb_data_format}})
-            .set_page_size(CB::c_intermed0, intermed_single_tile_size);
-    auto cb_intermed0 = tt_metal::CreateCircularBuffer(program, all_cores, cb_intermed0_config);
-
-    tt_metal::CircularBufferConfig cb_intermed1_config =
-        tt_metal::CircularBufferConfig(intermed_single_tile_size, {{CB::c_intermed1, intermed_cb_data_format}})
-            .set_page_size(CB::c_intermed1, intermed_single_tile_size);
-    auto cb_intermed1 = tt_metal::CreateCircularBuffer(program, all_cores, cb_intermed1_config);
-
-    uint32_t output_cb_index = 16;  // output operands start at index 16
     uint32_t num_output_tiles = 2;
-    tt_metal::CircularBufferConfig cb_output_config =
-        tt_metal::CircularBufferConfig(num_output_tiles * dst_single_tile_size, {{output_cb_index, dst_cb_data_format}})
-            .set_page_size(output_cb_index, dst_single_tile_size);
-    auto cb_output = tt_metal::CreateCircularBuffer(program, all_cores, cb_output_config);
+    CreateCircularBuffer(
+        program,
+        all_cores,
+        data_format,
+        {
+            {CB::c_in0, num_input_tiles},                        // input
+            {CB::c_in2, 1},                                      // scalar
+            {CB::c_in3, 1},                                      // mask
+            {CB::c_intermed0, 1, fp32_dest_acc_en_data_format},  //
+            {CB::c_intermed1, 1},                                //
+            {CB::c_out0, 1},                                     // output
+        });
 
+    float scaler = 1.0f / origin_W;
     bfloat16 bfloat_scaler_value = bfloat16(scaler);
-    uint32_t packed_scaler_value = pack_two_bfloat16_into_uint32({bfloat_scaler_value, bfloat_scaler_value});
-    tt_metal::Buffer *src_buffer = a.buffer();
-    bool src_is_dram = src_buffer->buffer_type() == tt_metal::BufferType::DRAM ? 1 : 0;
-    std::vector<uint32_t> reader_compile_time_args = {(uint32_t)src_is_dram, packed_scaler_value};
-    tt_metal::Buffer *dst_buffer = output.buffer();
-    bool dst_is_dram = dst_buffer->buffer_type() == tt_metal::BufferType::DRAM ? 1 : 0;
-    std::vector<uint32_t> writer_compile_time_args = {(std::uint32_t)output_cb_index, (std::uint32_t)dst_is_dram};
+    auto packed_scaler_value = pack_two_bfloat16_into_uint32({bfloat_scaler_value, bfloat_scaler_value});
 
+    std::vector<uint32_t> reader_compile_time_args = {static_cast<uint32_t>(is_dram(input)), packed_scaler_value};
+
+    std::vector<uint32_t> writer_compile_time_args = {
+        static_cast<uint32_t>(CB::c_out0), static_cast<uint32_t>(is_dram(output))};
 
     std::map<string, string> reader_defines{};
     if (do_mask_w) {
         reader_defines["DO_MASK_W"] = "1";
     }
-    tt_metal::KernelHandle reader_kernel_id = tt_metal::CreateKernel(
+    const auto reader_kernel_id = CreateReadKernel(
         program,
         "ttnn/cpp/ttnn/deprecated/tt_dnn/op_library/moreh_mean/kernels/reader_moreh_mean_w.cpp",
         all_cores,
-        tt_metal::ReaderDataMovementConfig(reader_compile_time_args, reader_defines));
+        reader_compile_time_args,
+        reader_defines);
 
-    tt_metal::KernelHandle writer_kernel_id = tt_metal::CreateKernel(
+    const auto writer_kernel_id = CreateWriteKernel(
         program,
-        "ttnn/cpp/ttnn/deprecated/tt_dnn/op_library/moreh_mean/kernels/writer_moreh_mean_unary_interleaved_start_id.cpp",
+        "ttnn/cpp/ttnn/deprecated/tt_dnn/op_library/moreh_mean/kernels/"
+        "writer_moreh_mean_unary_interleaved_start_id.cpp",
         all_cores,
-        tt_metal::WriterDataMovementConfig(writer_compile_time_args));
+        writer_compile_time_args);
 
-    std::map<string, string> reduce_defines = reduce_op_utils::get_defines(reduce_op, reduce_dim);
+    ////////////////////////////////////////////////////////////////////////////
+    //                      ComputeKernel SetUp
+    ///////////////////////////////////////////////////////////////////////////
+    string compute_kernel_name = "ttnn/cpp/ttnn/deprecated/tt_dnn/op_library/moreh_mean/kernels/moreh_mean_w.cpp";
+    auto reduce_op = tt_metal::ReduceOpMath::SUM;
+    auto reduce_dim = tt_metal::ReduceOpDim::W;
+    std::map<string, string> compute_defines = reduce_op_utils::get_defines(reduce_op, reduce_dim);
+    if (fp32_dest_acc_en) {
+        compute_defines["FP32_DEST_ACC_EN"] = 1;
+    }
     vector<uint32_t> compute_kernel_args_group_1 = {
-        num_rows_per_core_group_1,  // Ht
-        Wt,                         // Wt
-        1,                          // NC
+        units_per_core_group_1,  // Ht
+        Wt,                      // Wt
+        1,                       // NC
+        origin_W,
+    };
+    vector<uint32_t> compute_kernel_args_group_2 = {
+        units_per_core_group_2,  // Ht
+        Wt,                      // Wt
+        1,                       // NC
         origin_W,
     };
 
-    auto reduce_compute_kernel_group_1_id = tt_metal::CreateKernel(
+    auto compute_kernel_ids = CreateComputeKernel(
         program,
         compute_kernel_name,
-        core_group_1,
-        tt_metal::ComputeConfig{.compile_args = compute_kernel_args_group_1, .defines = reduce_defines});
-
-    if (!core_group_2.ranges().empty()) {
-        vector<uint32_t> compute_kernel_args_group_2 = {
-            num_rows_per_core_group_2,  // Ht
-            Wt,                         // Wt
-            1,                          // NC
-            origin_W,
-        };
-
-        auto reduce_compute_kernel_group_2_id = tt_metal::CreateKernel(
-            program,
-            compute_kernel_name,
-            core_group_2,
-            tt_metal::ComputeConfig{.compile_args = compute_kernel_args_group_2, .defines = reduce_defines});
-    }
+        {
+            {core_group_1, units_per_core_group_1, compute_kernel_args_group_1},
+            {core_group_2, units_per_core_group_2, compute_kernel_args_group_2},
+        },
+        ComputeKernelConfig{
+            .math_fidelity = math_fidelity,
+            .fp32_dest_acc_en = fp32_dest_acc_en,
+            // TODO(hyungsuk): change preserve_fp32_precision from false to fp32_dest_acc_en after fix #10337
+            // .preserve_fp32_precision = fp32_dest_acc_en,
+            .preserve_fp32_precision = false,
+            .math_approx_mode = math_approx_mode,
+            .defines = compute_defines});
 
     uint32_t out_dim_divider = Wt;
-    for (uint32_t i = 0, num_tiles_read = 0; i < num_cores; i++) {
-        CoreCoord core = {i / num_cores_y, i % num_cores_y};
-        uint32_t num_rows_per_core = 0;
+    for (uint32_t i = 0, tile_offset = 0; i < num_cores; i++) {
+        CoreCoord core = {i / core_h, i % core_h};
+        uint32_t units_per_core = 0;
         if (core_group_1.core_coord_in_core_ranges(core)) {
-            num_rows_per_core = num_rows_per_core_group_1;
+            units_per_core = units_per_core_group_1;
         } else if (core_group_2.core_coord_in_core_ranges(core)) {
-            num_rows_per_core = num_rows_per_core_group_2;
+            units_per_core = units_per_core_group_2;
         } else {
             TT_ASSERT(false, "Core not in specified core ranges");
         }
-        uint32_t num_tensor_tiles_per_core = num_rows_per_core * Wt;
+        uint32_t num_tensor_tiles_per_core = units_per_core * Wt;
         tt_metal::SetRuntimeArgs(
             program,
             reader_kernel_id,
             core,
-            {
-                a.buffer()->address(),
-                num_tensor_tiles_per_core,
-                num_tiles_read,  // tile index of row to start reading from
-                mask_w
-            });
+            {input.buffer()->address(),
+             num_tensor_tiles_per_core,
+             tile_offset,  // tile index of row to start reading from
+             mask_w});
 
         tt_metal::SetRuntimeArgs(
             program,
@@ -185,12 +163,12 @@ operation::ProgramWithCallbacks moreh_mean_w(const Tensor &a, const Tensor &outp
             {
                 output.buffer()->address(),
                 num_tensor_tiles_per_core / out_dim_divider,  // number of tiles to write
-                num_tiles_read / out_dim_divider              // output tile start index
+                tile_offset / out_dim_divider                 // output tile start index
             });
-        num_tiles_read += num_tensor_tiles_per_core;
+        tile_offset += num_tensor_tiles_per_core;
     }
 
-    auto override_runtime_args_callback = [reader_kernel_id, writer_kernel_id, num_cores, num_cores_y](
+    auto override_runtime_args_callback = [reader_kernel_id, writer_kernel_id, num_cores, core_h](
                                               const Program &program,
                                               const std::vector<Buffer *> &input_buffers,
                                               const std::vector<Buffer *> &output_buffers) {
@@ -198,8 +176,8 @@ operation::ProgramWithCallbacks moreh_mean_w(const Tensor &a, const Tensor &outp
 
         auto dst_dram_buffer = output_buffers.at(0);
 
-        for (uint32_t i = 0, num_tiles_read = 0; i < num_cores; i++) {
-            CoreCoord core = {i / num_cores_y, i % num_cores_y};
+        for (uint32_t i = 0; i < num_cores; i++) {
+            CoreCoord core = {i / core_h, i % core_h};
 
             {
                 auto &runtime_args = GetRuntimeArgs(program, reader_kernel_id, core);

--- a/ttnn/cpp/ttnn/deprecated/tt_dnn/op_library/moreh_mean_backward/kernels/reader_moreh_mean_backward.cpp
+++ b/ttnn/cpp/ttnn/deprecated/tt_dnn/op_library/moreh_mean_backward/kernels/reader_moreh_mean_backward.cpp
@@ -3,40 +3,74 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "ttnn/cpp/ttnn/deprecated/tt_dnn/kernels/dataflow/moreh_common.hpp"
+static constexpr int32_t MAX_NUM_DIMENSIONS = 8;
+
+inline uint32_t get_output_grad_tile(
+    uint32_t idx,
+    uint32_t rank,
+    uint32_t* output_grad_dim,
+    uint32_t* output_grad_stride,
+    uint32_t* input_grad_dim,
+    uint32_t* input_grad_stride,
+    bool* need_bcast_dim) {
+    uint32_t cur_idx[MAX_NUM_DIMENSIONS];
+
+    for (uint32_t i = 0; i < rank; ++i) {
+        cur_idx[i] = (need_bcast_dim[i]) ? (0) : ((idx / input_grad_stride[i]) % input_grad_dim[i]);
+    }
+
+    uint32_t read_tile_id = 0;
+    for (uint32_t i = 0; i < rank; ++i) {
+        read_tile_id += (cur_idx[i] * output_grad_stride[i]);
+    }
+
+    return read_tile_id;
+}
 
 void kernel_main() {
+    // compile-time args
+    constexpr bool output_grad_is_dram = (get_compile_time_arg_val(0) == 1);
+    constexpr uint32_t input_grad_rank = get_compile_time_arg_val(1);
+
+    // runtime args
     ArgFetcher arg_fetcher;
+
     const auto output_grad_addr = arg_fetcher.get_next_arg_val<uint32_t>();
     const auto num_output_tiles = arg_fetcher.get_next_arg_val<uint32_t>();
     const auto start_id = arg_fetcher.get_next_arg_val<uint32_t>();
-    const auto output_grad_is_dram = (arg_fetcher.get_next_arg_val<uint32_t>() == 1);
-
-    const auto output_grad_n = arg_fetcher.get_next_arg_val<uint32_t>();
-    const auto output_grad_c = arg_fetcher.get_next_arg_val<uint32_t>();
-    const auto output_grad_ht = arg_fetcher.get_next_arg_val<uint32_t>();
-    const auto output_grad_wt = arg_fetcher.get_next_arg_val<uint32_t>();
-
-    const auto input_grad_n = arg_fetcher.get_next_arg_val<uint32_t>();
-    const auto input_grad_c = arg_fetcher.get_next_arg_val<uint32_t>();
-    const auto input_grad_ht = arg_fetcher.get_next_arg_val<uint32_t>();
-    const auto input_grad_wt = arg_fetcher.get_next_arg_val<uint32_t>();
-
-    const auto n_need_bcast = arg_fetcher.get_next_arg_val<uint32_t>();
-    const auto c_need_bcast = arg_fetcher.get_next_arg_val<uint32_t>();
-    const auto ht_need_bcast = arg_fetcher.get_next_arg_val<uint32_t>();
-    const auto wt_need_bcast = arg_fetcher.get_next_arg_val<uint32_t>();
     const auto num_dim = arg_fetcher.get_next_arg_val<uint32_t>();
 
-    const auto output_grad_HtWt = output_grad_ht * output_grad_wt;
-    const auto output_grad_CHtWt = output_grad_c * output_grad_HtWt;
+    uint32_t output_grad_dim[MAX_NUM_DIMENSIONS];
+    for (uint32_t i = 0; i < input_grad_rank; ++i) {
+        output_grad_dim[i] = arg_fetcher.get_next_arg_val<uint32_t>();
+    }
 
-    const auto input_grad_HtWt = input_grad_ht * input_grad_wt;
-    const auto input_grad_CHtWt = input_grad_c * input_grad_HtWt;
+    uint32_t input_grad_dim[MAX_NUM_DIMENSIONS];
+    for (uint32_t i = 0; i < input_grad_rank; ++i) {
+        input_grad_dim[i] = arg_fetcher.get_next_arg_val<uint32_t>();
+    }
+
+    bool need_bcast_dim[MAX_NUM_DIMENSIONS];
+    for (uint32_t i = 0; i < input_grad_rank; ++i) {
+        need_bcast_dim[i] = (arg_fetcher.get_next_arg_val<uint32_t>() == 1);
+    }
+
+    uint32_t output_grad_stride[MAX_NUM_DIMENSIONS];
+    output_grad_stride[0] = 1;
+    for (uint32_t i = 1; i < input_grad_rank; ++i) {
+        output_grad_stride[i] = output_grad_stride[i - 1] * output_grad_dim[i - 1];
+    }
+
+    uint32_t input_grad_stride[MAX_NUM_DIMENSIONS];
+    input_grad_stride[0] = 1;
+    for (uint32_t i = 1; i < input_grad_rank; ++i) {
+        input_grad_stride[i] = input_grad_stride[i - 1] * input_grad_dim[i - 1];
+    }
 
     constexpr uint32_t onetile = 1;
-    constexpr uint32_t cb_id_in0 = 0;
-    constexpr uint32_t cb_id_in1 = 1;
-    constexpr uint32_t cb_id_in2 = 2;
+    constexpr uint32_t cb_id_in0 = tt::CB::c_in0;
+    constexpr uint32_t cb_id_in1 = tt::CB::c_in1;
+    constexpr uint32_t cb_id_in2 = tt::CB::c_in2;
 
     // zero tile
     union {
@@ -52,36 +86,18 @@ void kernel_main() {
     uint32_t l1_write_addr_in0;
     uint32_t output_grad_tile_bytes = get_tile_size(cb_id_in0);
     const auto output_grad_data_format = get_dataformat(cb_id_in0);
-    const InterleavedAddrGenFast<true> dram_output_grad_addrg = {
-        .bank_base_address = output_grad_addr,
-        .page_size = output_grad_tile_bytes,
-        .data_format = output_grad_data_format};
-    const InterleavedAddrGenFast<false> l1_output_grad_addrg = {
+    const InterleavedAddrGenFast<output_grad_is_dram> output_grad_addrg = {
         .bank_base_address = output_grad_addr,
         .page_size = output_grad_tile_bytes,
         .data_format = output_grad_data_format};
 
     for (uint32_t i = start_id; i < start_id + num_output_tiles; i++) {
-        const auto cur_n = i / input_grad_CHtWt;
-        const auto cur_c = (i / input_grad_HtWt) % input_grad_c;
-        const auto cur_ht = (i / input_grad_wt) % input_grad_ht;
-        const auto cur_wt = i % input_grad_wt;
-
-        const auto target_n = (n_need_bcast) ? (0) : (cur_n);
-        const auto target_c = (c_need_bcast) ? (0) : (cur_c);
-        const auto target_ht = (ht_need_bcast) ? (0) : (cur_ht);
-        const auto target_wt = (wt_need_bcast) ? (0) : (cur_wt);
-
-        auto read_tile_id =
-            target_n * output_grad_CHtWt + target_c * output_grad_HtWt + target_ht * output_grad_wt + target_wt;
+        auto read_tile_id = get_output_grad_tile(
+            i, input_grad_rank, output_grad_dim, output_grad_stride, input_grad_dim, input_grad_stride, need_bcast_dim);
 
         cb_reserve_back(cb_id_in0, onetile);
         l1_write_addr_in0 = get_write_ptr(cb_id_in0);
-        if (output_grad_is_dram) {
-            noc_async_read_tile(read_tile_id, dram_output_grad_addrg, l1_write_addr_in0);
-        } else {
-            noc_async_read_tile(read_tile_id, l1_output_grad_addrg, l1_write_addr_in0);
-        }
+        noc_async_read_tile(read_tile_id, output_grad_addrg, l1_write_addr_in0);
         noc_async_read_barrier();
         cb_push_back(cb_id_in0, onetile);
     }

--- a/ttnn/cpp/ttnn/deprecated/tt_dnn/op_library/moreh_mean_backward/kernels/writer_moreh_mean_backward.cpp
+++ b/ttnn/cpp/ttnn/deprecated/tt_dnn/op_library/moreh_mean_backward/kernels/writer_moreh_mean_backward.cpp
@@ -2,37 +2,35 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-#include <cstdint>
-
-#include "dataflow_api.h"
+#include "ttnn/cpp/ttnn/deprecated/tt_dnn/kernels/dataflow/moreh_common.hpp"
 
 void kernel_main() {
-    const auto output_addr = get_arg_val<uint32_t>(0);
-    const auto num_tiles = get_arg_val<uint32_t>(1);
-    const auto start_id = get_arg_val<uint32_t>(2);
-    const auto output_is_dram = (get_arg_val<uint32_t>(3) == 1);
+    // compile-time args
+    constexpr bool input_grad_is_dram = (get_compile_time_arg_val(0) == 1);
 
-    constexpr uint32_t cb_id_out = 16;
+    // runtime args
+    ArgFetcher arg_fetcher;
+    const auto input_grad_addr = arg_fetcher.get_next_arg_val<uint32_t>();
+    const auto num_tiles = arg_fetcher.get_next_arg_val<uint32_t>();
+    const auto start_id = arg_fetcher.get_next_arg_val<uint32_t>();
+
+    constexpr uint32_t cb_id_out = tt::CB::c_out0;
     constexpr uint32_t onetile = 1;
 
-    uint32_t output_tile_bytes = get_tile_size(cb_id_out);
-    const auto output_data_format = get_dataformat(cb_id_out);
+    uint32_t input_grad_tile_bytes = get_tile_size(cb_id_out);
+    const auto input_grad_data_format = get_dataformat(cb_id_out);
 
-    const InterleavedAddrGenFast<true> dram_output_addrg = {
-        .bank_base_address = output_addr, .page_size = output_tile_bytes, .data_format = output_data_format};
-    const InterleavedAddrGenFast<false> l1_output_addrg = {
-        .bank_base_address = output_addr, .page_size = output_tile_bytes, .data_format = output_data_format};
+    const InterleavedAddrGenFast<input_grad_is_dram> input_grad_addrg = {
+        .bank_base_address = input_grad_addr,
+        .page_size = input_grad_tile_bytes,
+        .data_format = input_grad_data_format};
 
     for (uint32_t i = start_id; i < start_id + num_tiles; i++) {
         uint32_t write_tile_id = i;
         cb_wait_front(cb_id_out, onetile);
 
         uint32_t l1_read_addr = get_read_ptr(cb_id_out);
-        if (output_is_dram) {
-            noc_async_write_tile(write_tile_id, dram_output_addrg, l1_read_addr);
-        } else {
-            noc_async_write_tile(write_tile_id, l1_output_addrg, l1_read_addr);
-        }
+        noc_async_write_tile(write_tile_id, input_grad_addrg, l1_read_addr);
         noc_async_write_barrier();
         cb_pop_front(cb_id_out, onetile);
     }

--- a/ttnn/cpp/ttnn/deprecated/tt_dnn/op_library/moreh_mean_backward/moreh_mean_backward.cpp
+++ b/ttnn/cpp/ttnn/deprecated/tt_dnn/op_library/moreh_mean_backward/moreh_mean_backward.cpp
@@ -2,12 +2,12 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-#include "ttnn/deprecated/tt_dnn/op_library/moreh_mean_backward/moreh_mean_backward_op.hpp"
-#include "ttnn/deprecated/tt_dnn/op_library/moreh_helper_functions.hpp"
-#include "ttnn/deprecated/tt_dnn/op_library/work_split.hpp"
 #include "tt_metal/common/constants.hpp"
 #include "tt_metal/detail/util.hpp"
 #include "tt_metal/host_api.hpp"
+#include "ttnn/deprecated/tt_dnn/op_library/moreh_helper_functions.hpp"
+#include "ttnn/deprecated/tt_dnn/op_library/moreh_mean_backward/moreh_mean_backward_op.hpp"
+#include "ttnn/deprecated/tt_dnn/op_library/work_split.hpp"
 
 namespace tt {
 using namespace constants;
@@ -15,7 +15,57 @@ namespace operations {
 
 namespace primary {
 
-operation::ProgramWithCallbacks moreh_mean_backward_program(const Tensor &output_grad, const Tensor &input_grad) {
+namespace {
+
+void get_tensor_dim(std::vector<uint32_t> &dim, const Shape &shape) {
+    const auto rank = shape.rank();
+    for (auto i = 0; i < rank; ++i) {
+        auto idx = rank - 1 - i;
+
+        // last 2-dim
+        if (idx == rank - 1 || idx == rank - 2) {
+            dim[i] = shape[idx] / TILE_HEIGHT;
+        } else {
+            dim[i] = shape[idx];
+        }
+    }
+
+    log_debug(LogOp, "rank {}", rank);
+    for (auto i = 0; i < rank; ++i) {
+        log_debug(LogOp, "dim[{}] = {}", i, dim[i]);
+    }
+}
+
+Shape get_output_grad_shape(
+    const Tensor &output_grad, const Tensor &input_grad, const std::vector<int64_t> &dims, const bool &keepdim) {
+    if (keepdim) {
+        return output_grad.get_legacy_shape();
+    }
+
+    auto shape = input_grad.get_legacy_shape();
+    auto rank = shape.rank();
+    auto padding = shape.padding();
+    for (auto dim : dims) {
+        TT_FATAL(dim < rank, "dim {} < rank {}", dim, rank);
+        bool is_tile_dim = (dim == rank - 1 || dim == rank - 2);
+        if (is_tile_dim) {
+            shape[dim] = TILE_HEIGHT;
+            padding[dim] = Padding::PadDimension{0, 31};
+        } else {
+            shape[dim] = 1;
+        }
+    }
+
+    return Shape(shape, padding);
+}
+}  // namespace
+
+operation::ProgramWithCallbacks moreh_mean_backward_impl(
+    const Tensor &output_grad,
+    const Tensor &input_grad,
+    const std::vector<int64_t> &dims,
+    const bool keepdim,
+    const DeviceComputeKernelConfig &compute_kernel_config) {
     ////////////////////////////////////////////////////////////////////////////
     //                      Device Setup
     ////////////////////////////////////////////////////////////////////////////
@@ -28,49 +78,54 @@ operation::ProgramWithCallbacks moreh_mean_backward_program(const Tensor &output
     const auto cb_data_format = datatype_to_dataformat_converter(output_grad.get_dtype());
     const auto single_tile_size = detail::TileSize(cb_data_format);
 
-    const auto &output_grad_shape = output_grad.get_legacy_shape();
-    const auto &output_grad_shape_wo_padding = output_grad_shape.without_padding();
-    const auto output_grad_n = output_grad_shape[0];
-    const auto output_grad_c = output_grad_shape[1];
-    const auto output_grad_ht = output_grad_shape[2] / TILE_HEIGHT;
-    const auto output_grad_wt = output_grad_shape[3] / TILE_WIDTH;
-    const auto output_grad_origin_h = output_grad_shape_wo_padding[2];
-    const auto output_grad_origin_w = output_grad_shape_wo_padding[3];
-
     const auto &input_grad_shape = input_grad.get_legacy_shape();
     const auto &input_grad_shape_wo_padding = input_grad_shape.without_padding();
-    const auto input_grad_n = input_grad_shape[0];
-    const auto input_grad_c = input_grad_shape[1];
-    const auto input_grad_ht = input_grad_shape[2] / TILE_HEIGHT;
-    const auto input_grad_wt = input_grad_shape[3] / TILE_WIDTH;
-    const auto input_grad_origin_h = input_grad_shape_wo_padding[2];
-    const auto input_grad_origin_w = input_grad_shape_wo_padding[3];
+    const uint32_t input_grad_rank = input_grad_shape.rank();
 
-    const auto n_need_bcast = (output_grad_n != input_grad_n);
-    const auto c_need_bcast = (output_grad_c != input_grad_c);
-    const auto ht_need_bcast = (output_grad_origin_h != input_grad_origin_h);
-    const auto wt_need_bcast = (output_grad_origin_w != input_grad_origin_w);
+    std::vector<uint32_t> input_grad_dim(input_grad_rank, 1);
+    log_debug(LogOp, "input_grad");
+    get_tensor_dim(input_grad_dim, input_grad_shape);
+    const auto &output_grad_shape = get_output_grad_shape(output_grad, input_grad, dims, keepdim);
+    const auto &output_grad_shape_wo_padding = output_grad_shape.without_padding();
+
+    std::vector<uint32_t> output_grad_dim(input_grad_rank, 1);
+    log_debug(LogOp, "output_grad");
+    get_tensor_dim(output_grad_dim, output_grad_shape);
+
+    std::vector<uint32_t> need_bcast_dim(input_grad_rank, 0);
+    for (auto i = 0; i < input_grad_rank; ++i) {
+        auto idx = input_grad_rank - 1 - i;
+        bool is_tile_dim = (idx == input_grad_rank - 1 || idx == input_grad_rank - 2);
+
+        if (is_tile_dim) {
+            need_bcast_dim[i] = (output_grad_shape_wo_padding[idx] != input_grad_shape_wo_padding[idx]);
+        } else {
+            need_bcast_dim[i] = (output_grad_shape[idx] != input_grad_shape[idx]);
+        }
+    }
     const auto num_input_grad_tiles = input_grad.volume() / TILE_HW;
+    auto [math_fidelity, math_approx_mode, fp32_dest_acc_en, packer_l1_acc] =
+        get_compute_kernel_config_args(output_grad.device()->arch(), compute_kernel_config);
 
-    uint32_t num_dim = 1;
-    if (n_need_bcast) num_dim *= input_grad_n;
-    if (c_need_bcast) num_dim *= input_grad_c;
-    if (ht_need_bcast) num_dim *= input_grad_origin_h;
-    if (wt_need_bcast) num_dim *= input_grad_origin_w;
-
-    log_debug(LogOp, "num_dim {}", num_dim);
+    for (auto i = 0; i < input_grad_rank; ++i) {
+        log_debug(LogOp, "need_bcast_dim [{}] = {}", i, need_bcast_dim[i]);
+    }
+    log_debug(LogOp, "num_input_grad_tiles {}", num_input_grad_tiles);
+    log_debug(
+        LogOp,
+        "math_fidelity {} math_approx_mode {} fp32_dest_acc_en {} packer_l1_acc {}",
+        math_fidelity,
+        math_approx_mode,
+        fp32_dest_acc_en,
+        packer_l1_acc);
 
     ////////////////////////////////////////////////////////////////////////////
     //                         Core Setup
     ////////////////////////////////////////////////////////////////////////////
+
     auto grid = device->compute_with_storage_grid_size();
     const auto num_cores_y = grid.y;
 
-    const uint32_t in0_t = 2;        // input
-    const uint32_t in1_t = 1;        // zero
-    const uint32_t in2_t = 1;        // scalar
-    const uint32_t intermed0_t = 1;  // accumulated mean
-    const uint32_t out0_t = 2;       // output
     const auto
         [num_cores_to_be_used,
          all_cores,
@@ -87,45 +142,61 @@ operation::ProgramWithCallbacks moreh_mean_backward_program(const Tensor &output
         all_cores,
         cb_data_format,
         {
-            {CB::c_in0, in0_t},              // input
-            {CB::c_in1, in1_t},              // zero
-            {CB::c_in2, in2_t},              // scalar
-            {CB::c_intermed0, intermed0_t},  // temp
-            {CB::c_out0, out0_t},            // output
+            {CB::c_in0, 2},  // input
+            {CB::c_in1, 1},  // zero
+            {CB::c_in2, 1},  // scalar
+            {CB::c_intermed0, 1},
+            {CB::c_out0, 2},  // output
         });
 
     ////////////////////////////////////////////////////////////////////////////
     //                      DataMovementKernel SetUp
     ////////////////////////////////////////////////////////////////////////////
-    std::vector<uint32_t> reader_compile_time_args;
-    std::vector<uint32_t> writer_compile_time_args;
-    const auto reader_kernel_file = "ttnn/cpp/ttnn/deprecated/tt_dnn/op_library/moreh_mean_backward/kernels/reader_moreh_mean_backward.cpp";
-    const auto writer_kernel_file = "ttnn/cpp/ttnn/deprecated/tt_dnn/op_library/moreh_mean_backward/kernels/writer_moreh_mean_backward.cpp";
+    std::vector<uint32_t> reader_compile_time_args = {static_cast<uint32_t>(is_dram(output_grad)), input_grad_rank};
+    std::vector<uint32_t> writer_compile_time_args = {static_cast<uint32_t>(is_dram(input_grad))};
+    const auto reader_kernel_file =
+        "ttnn/cpp/ttnn/deprecated/tt_dnn/op_library/moreh_mean_backward/kernels/reader_moreh_mean_backward.cpp";
+    const auto writer_kernel_file =
+        "ttnn/cpp/ttnn/deprecated/tt_dnn/op_library/moreh_mean_backward/kernels/writer_moreh_mean_backward.cpp";
     const auto reader_kernel_id = CreateReadKernel(program, reader_kernel_file, all_cores, reader_compile_time_args);
     const auto writer_kernel_id = CreateWriteKernel(program, writer_kernel_file, all_cores, writer_compile_time_args);
 
     ////////////////////////////////////////////////////////////////////////////
     //                      ComputeKernel SetUp
     ////////////////////////////////////////////////////////////////////////////
-    const std::vector<uint32_t> compute_args_group_1{num_cols_per_core_group_1};
     std::map<string, string> compute_defines;
-    const auto compute_kernel_file = "ttnn/cpp/ttnn/deprecated/tt_dnn/op_library/moreh_mean_backward/kernels/moreh_mean_backward.cpp";
-    const auto compute_kernel_1_id = CreateComputeKernel(
-        program, compute_kernel_file, {core_group_1, num_cols_per_core_group_1, compute_args_group_1}, compute_defines);
-
-    std::optional<KernelHandle> compute_kernel_2_id = std::nullopt;
-    if (!core_group_2.ranges().empty()) {
-        const std::vector<uint32_t> compute_args_group_2{num_cols_per_core_group_2};
-        compute_kernel_2_id = CreateComputeKernel(
-            program,
-            compute_kernel_file,
-            {core_group_2, num_cols_per_core_group_2, compute_args_group_2},
-            compute_defines);
+    if (fp32_dest_acc_en) {
+        compute_defines["FP32_DEST_ACC_EN"] = "1";
     }
+
+    const auto compute_kernel_file =
+        "ttnn/cpp/ttnn/deprecated/tt_dnn/op_library/moreh_mean_backward/kernels/moreh_mean_backward.cpp";
+    const std::vector<uint32_t> compute_args_group_1{num_cols_per_core_group_1, need_bcast_dim[0], need_bcast_dim[1]};
+    const std::vector<uint32_t> compute_args_group_2{num_cols_per_core_group_2, need_bcast_dim[0], need_bcast_dim[1]};
+    auto compute_kernel_ids = CreateComputeKernel(
+        program,
+        compute_kernel_file,
+        {
+            {core_group_1, num_cols_per_core_group_1, compute_args_group_1},
+            {core_group_2, num_cols_per_core_group_2, compute_args_group_2},
+        },
+        ComputeKernelConfig{
+            .math_fidelity = math_fidelity,
+            .fp32_dest_acc_en = fp32_dest_acc_en,
+            // TODO(hyungsuk): change preserve_fp32_precision from false to fp32_dest_acc_en after fix #10337
+            // .preserve_fp32_precision = fp32_dest_acc_en,
+            .preserve_fp32_precision = false,
+            .math_approx_mode = math_approx_mode,
+            .defines = compute_defines});
 
     ////////////////////////////////////////////////////////////////////////////
     //                      RuntimeArgs SetUp
     ////////////////////////////////////////////////////////////////////////////
+    uint32_t num_dim = 1;
+    for (auto dim : dims) {
+        num_dim *= input_grad_shape_wo_padding[dim];
+    }
+
     for (uint32_t i = 0, tile_offset = 0; i < num_cores_to_be_used; ++i) {
         CoreCoord core = {i / num_cores_y, i % num_cores_y};
 
@@ -138,53 +209,20 @@ operation::ProgramWithCallbacks moreh_mean_backward_program(const Tensor &output
             TT_THROW("Core not in specified core ranges.");
         }
 
-        SetRuntimeArgs(
-            program,
-            reader_kernel_id,
-            core,
-            {output_grad.buffer()->address(),
-             num_tiles_per_core,
-             tile_offset,
-             static_cast<uint32_t>(is_dram(output_grad)),
-             output_grad_n,
-             output_grad_c,
-             output_grad_ht,
-             output_grad_wt,
-             input_grad_n,
-             input_grad_c,
-             input_grad_ht,
-             input_grad_wt,
-             n_need_bcast,
-             c_need_bcast,
-             ht_need_bcast,
-             wt_need_bcast,
-             num_dim});
+        std::vector<uint32_t> reader_rt_args;
+        reader_rt_args.push_back(output_grad.buffer()->address());
+        reader_rt_args.push_back(num_tiles_per_core);
+        reader_rt_args.push_back(tile_offset);
+        reader_rt_args.push_back(num_dim);
+        reader_rt_args.insert(reader_rt_args.end(), output_grad_dim.begin(), output_grad_dim.end());
+        reader_rt_args.insert(reader_rt_args.end(), input_grad_dim.begin(), input_grad_dim.end());
+        reader_rt_args.insert(reader_rt_args.end(), need_bcast_dim.begin(), need_bcast_dim.end());
+
+        SetRuntimeArgs(program, reader_kernel_id, core, reader_rt_args);
 
         SetRuntimeArgs(
-            program,
-            writer_kernel_id,
-            core,
-            {input_grad.buffer()->address(),
-             num_tiles_per_core,
-             tile_offset,
-             static_cast<uint32_t>(is_dram(input_grad))});
+            program, writer_kernel_id, core, {input_grad.buffer()->address(), num_tiles_per_core, tile_offset});
 
-        if (core_group_1.core_coord_in_core_ranges(core)) {
-            SetRuntimeArgs(
-                program,
-                compute_kernel_1_id,
-                core,
-                {num_tiles_per_core, n_need_bcast, c_need_bcast, ht_need_bcast, wt_need_bcast});
-        } else if (core_group_2.core_coord_in_core_ranges(core)) {
-            TT_ASSERT(compute_kernel_2_id.has_value());
-            SetRuntimeArgs(
-                program,
-                compute_kernel_2_id.value(),
-                core,
-                {num_tiles_per_core, n_need_bcast, c_need_bcast, ht_need_bcast, wt_need_bcast});
-        } else {
-            TT_ASSERT(false, "Core not in specified core ranges.");
-        }
         tile_offset += num_tiles_per_core;
     }
 
@@ -195,7 +233,7 @@ operation::ProgramWithCallbacks moreh_mean_backward_program(const Tensor &output
                                                    const std::vector<std::optional<const Tensor>> &,
                                                    const std::vector<Tensor> &output_tensors) {
         const auto *output_grad_buffer = input_tensors.at(0).buffer();
-        const auto *input_grad_buffer = input_tensors.at(1).buffer();
+        const auto *input_grad_buffer = output_tensors.at(0).buffer();
         for (uint32_t i = 0; i < num_cores_to_be_used; ++i) {
             CoreCoord core = {i / num_cores_y, i % num_cores_y};
             {

--- a/ttnn/cpp/ttnn/deprecated/tt_dnn/op_library/moreh_mean_backward/moreh_mean_backward_op.hpp
+++ b/ttnn/cpp/ttnn/deprecated/tt_dnn/op_library/moreh_mean_backward/moreh_mean_backward_op.hpp
@@ -7,8 +7,9 @@
 #pragma once
 #include <vector>
 
-#include "ttnn/tensor/tensor.hpp"
+#include "ttnn/deprecated/tt_dnn/op_library/compute_kernel_config.hpp"
 #include "ttnn/run_operation.hpp"
+#include "ttnn/tensor/tensor.hpp"
 
 namespace tt {
 
@@ -19,16 +20,57 @@ namespace primary {
 using namespace tt_metal;
 
 struct MorehMeanBackward {
-    void validate(const std::vector<Tensor> &inputs) const;
-    std::vector<Shape> compute_output_shapes(const std::vector<Tensor> &inputs) const;
-    std::vector<Tensor> create_output_tensors(const std::vector<Tensor> &inputs) const;
+    std::vector<int64_t> dims;
+    bool keepdim;
+    std::optional<Shape> input_grad_shape;
+    MemoryConfig memory_config;
+    const CoreRange core_range;  // unused for now
+    const DeviceComputeKernelConfig compute_kernel_config;
+
+    void validate_with_output_tensors(
+        const std::vector<Tensor> &input_tensors, const std::vector<std::optional<Tensor>> &output_tensors) const;
+    std::vector<Shape> compute_output_shapes(const std::vector<Tensor> &input_tensors) const;
+    std::vector<Tensor> create_output_tensors(
+        const std::vector<Tensor> &input_tensors, const std::vector<std::optional<Tensor>> &output_tensors) const;
     operation::ProgramWithCallbacks create_program(
-        const std::vector<Tensor> &inputs, std::vector<Tensor> &outputs) const;
+        const std::vector<Tensor> &input_tensors, std::vector<Tensor> &output_tensors) const;
+
+    static constexpr auto attribute_names =
+        std::make_tuple("dims", "keepdim", "input_grad_shape", "memory_config", "compute_kernel_config");
+    const auto attribute_values() const {
+        return std::make_tuple(
+            std::cref(this->dims),
+            std::cref(this->keepdim),
+            std::cref(this->input_grad_shape),
+            std::cref(this->memory_config),
+            std::cref(this->compute_kernel_config));
+    }
 };
 
-operation::ProgramWithCallbacks moreh_mean_backward_program(const Tensor &output_grad, const Tensor &input_grad);
+operation::ProgramWithCallbacks moreh_mean_backward_impl(
+    const Tensor &output_grad,
+    const Tensor &input_grad,
+    const std::vector<int64_t> &dims,
+    const bool keepdim,
+    const DeviceComputeKernelConfig &compute_kernel_config);
 
-Tensor moreh_mean_backward(const Tensor &output_grad, const Tensor &input_grad);
+Tensor moreh_mean_backward_(
+    const Tensor& output_grad,
+    std::optional<std::variant<int64_t, std::vector<int64_t>>> dim,
+    const bool keepdim,
+    std::optional<Shape> input_grad_shape,
+    const std::optional<const Tensor> input_grad,
+    const std::optional<MemoryConfig> memory_config,
+    std::optional<const DeviceComputeKernelConfig> compute_kernel_config);
+
+Tensor moreh_mean_backward(
+    const Tensor &output_grad,
+    std::optional<std::variant<int64_t, std::vector<int64_t>>> dim = std::nullopt,
+    const bool keepdim = false,
+    std::optional<Shape> input_grad_shape = std::nullopt,
+    const std::optional<const Tensor> input_grad = std::nullopt,
+    const std::optional<MemoryConfig> memory_config = std::nullopt,
+    std::optional<const DeviceComputeKernelConfig> compute_kernel_config = std::nullopt);
 
 }  // namespace primary
 

--- a/ttnn/cpp/ttnn/deprecated/tt_dnn/op_library/moreh_nll_loss/moreh_nll_loss_op.cpp
+++ b/ttnn/cpp/ttnn/deprecated/tt_dnn/op_library/moreh_nll_loss/moreh_nll_loss_op.cpp
@@ -134,8 +134,8 @@ std::vector<Shape> MorehNllLossStep2::compute_output_shapes(const std::vector<Te
 
     // Need extend 1d output to 2d, because TT not support 1d tensor
     if (input_rank == 2) {
-        output_shape_vec.push_back(32);
-        dimensions_pads.push_back(Padding::PadDimension{.front = 0, .back = 31});
+        output_shape_vec.push_back(1);
+        dimensions_pads.push_back(Padding::PadDimension{.front = 0, .back = 0});
     }
 
     for (uint32_t dim = 0; dim < input_rank; dim++) {
@@ -144,15 +144,19 @@ std::vector<Shape> MorehNllLossStep2::compute_output_shapes(const std::vector<Te
             continue;
         }
 
-        // padding if output is w, h dim
-        if (is_hw_dim(dim, input_rank)) {
-            uint32_t up32_shape = round_up(input_shape[dim], 32);
-            uint32_t padding_back = up32_shape - input_shape_without_padding[dim];
-            output_shape_vec.push_back(up32_shape);
-            dimensions_pads.push_back(Padding::PadDimension{.front = 0, .back = padding_back});
-        } else {
-            output_shape_vec.push_back(input_shape_without_padding[dim]);
-            dimensions_pads.push_back(Padding::PadDimension{.front = 0, .back = 0});
+        output_shape_vec.push_back(input_shape_without_padding[dim]);
+        dimensions_pads.push_back(Padding::PadDimension{.front = 0, .back = 0});
+    }
+
+    // padding output
+    {
+        uint32_t output_rank = output_shape_vec.size();
+        for (uint32_t dim = output_rank - 2; dim < output_rank; dim++) {
+            uint32_t up32_shape = round_up(output_shape_vec[dim], 32);
+            uint32_t padding_back = up32_shape - output_shape_vec[dim];
+
+            output_shape_vec[dim] = up32_shape;
+            dimensions_pads[dim].back = padding_back;
         }
     }
 

--- a/ttnn/cpp/ttnn/deprecated/tt_dnn/op_library/moreh_nll_loss/moreh_nll_loss_op.cpp
+++ b/ttnn/cpp/ttnn/deprecated/tt_dnn/op_library/moreh_nll_loss/moreh_nll_loss_op.cpp
@@ -19,20 +19,6 @@ namespace tt {
 namespace operations {
 namespace primary {
 
-namespace {
-bool is_output_wh_dim(uint32_t input_dim, uint32_t input_rank) {
-    if (input_rank == 2 || input_rank == 3) {
-        return true;
-    }
-    if (input_rank >= 4) {
-        if (input_dim >= input_rank - 2) {
-            return true;
-        }
-    }
-    return false;
-}
-}  // namespace
-
 void MorehNllLossStep1::validate(
     const std::vector<Tensor>& input_tensors,
     const std::vector<std::optional<const Tensor>>& optional_input_tensors) const {
@@ -159,7 +145,7 @@ std::vector<Shape> MorehNllLossStep2::compute_output_shapes(const std::vector<Te
         }
 
         // padding if output is w, h dim
-        if (is_output_wh_dim(dim, input_rank)) {
+        if (is_hw_dim(dim, input_rank)) {
             uint32_t up32_shape = round_up(input_shape[dim], 32);
             uint32_t padding_back = up32_shape - input_shape_without_padding[dim];
             output_shape_vec.push_back(up32_shape);

--- a/ttnn/cpp/ttnn/deprecated/tt_dnn/op_library/moreh_norm_backward/moreh_norm_backward_op.cpp
+++ b/ttnn/cpp/ttnn/deprecated/tt_dnn/op_library/moreh_norm_backward/moreh_norm_backward_op.cpp
@@ -24,69 +24,6 @@ namespace operations {
 
 namespace primary {
 
-
-inline
-std::tuple<uint32_t, uint32_t, uint32_t> extract_spatial_dims(const Shape& shape) {
-    const auto rank = shape.rank();
-
-    TT_FATAL(rank >= 2, "Shape must have at least two dims.");
-    uint32_t W = shape[-1];
-    uint32_t H = shape[-2];
-
-    uint32_t other_dims_product = 1;
-    for (auto i = 0; i < rank - 2; ++i) {
-        other_dims_product *= shape[i];
-    }
-
-    return { W, H, other_dims_product};
-}
-
-inline void initialize_dims_with_range(std::vector<int64_t>& dims, uint32_t input_rank) {
-    dims.resize(input_rank);
-    std::iota(dims.begin(), dims.end(), 0);
-}
-
-inline std::vector<int64_t> get_dim(
-    const std::optional<std::variant<int64_t, std::vector<int64_t>>>& dim,
-    uint32_t input_rank
-) {
-    std::vector<int64_t> dims;
-    if (!dim.has_value()) {
-        initialize_dims_with_range(dims, input_rank);
-    }
-    else if (std::holds_alternative<int64_t>(dim.value())) {
-        auto d = std::get<int64_t>(dim.value());
-        dims.push_back(d);
-    }
-    else {
-        dims = std::get<std::vector<int64_t>>(dim.value());
-        if (dims.empty()) {
-            initialize_dims_with_range(dims, input_rank);
-        }
-    }
-    return dims;
-}
-
-inline
-std::tuple<uint32_t, uint32_t, uint32_t, uint32_t> extract_and_scale_spatial_dims(const Shape& shape, uint32_t dim) {
-    const auto rank = shape.rank();
-
-    TT_FATAL(rank >= 2, "Shape must have at least two dims.");
-    uint32_t Wt = shape[-1] / TILE_WIDTH;
-    uint32_t Ht = shape[-2] / TILE_HEIGHT;
-
-    uint32_t reduce_dim = shape[dim];
-    uint32_t inner_dims_product = 1;
-    for (auto i = dim + 1; i < rank - 2; ++i) {
-        inner_dims_product *= shape[i];
-    }
-
-    uint32_t inner_tile_size = inner_dims_product * Ht * Wt;
-    uint32_t reduce_tile_size = reduce_dim * inner_tile_size;
-
-    return { Wt, Ht, inner_tile_size, reduce_tile_size};
-}
-
 void MorehNormBackward::validate_with_output_tensors(
     const std::vector<Tensor> &input_tensors,
     const std::vector<std::optional<Tensor>> &output_tensors) const {

--- a/ttnn/cpp/ttnn/deprecated/tt_dnn/op_library/moreh_sum/moreh_sum_h_impl/moreh_sum_h_impl.cpp
+++ b/ttnn/cpp/ttnn/deprecated/tt_dnn/op_library/moreh_sum/moreh_sum_h_impl/moreh_sum_h_impl.cpp
@@ -4,6 +4,7 @@
 
 #include <algorithm>
 
+#include "ttnn/deprecated/tt_dnn/op_library/moreh_helper_functions.hpp"
 #include "ttnn/deprecated/tt_dnn/op_library/moreh_sum/moreh_sum_op.hpp"
 #include "ttnn/operations/reduction/generic/device/reduce_op.hpp"
 #include "ttnn/deprecated/tt_dnn/op_library/work_split.hpp"
@@ -64,11 +65,13 @@ operation::ProgramWithCallbacks moreh_sum_h_impl(const Tensor &a, const Tensor &
     tt_metal::Device *device = a.device();
 
     auto compute_with_storage_grid_size = device->compute_with_storage_grid_size();
-    uint32_t num_cores_x = compute_with_storage_grid_size.x;
     uint32_t num_cores_y = compute_with_storage_grid_size.y;
     auto num_cols = other_dims_product * Wt;
+
+    const CoreRange all_core_range({0, 0}, {compute_with_storage_grid_size.x - 1, compute_with_storage_grid_size.y - 1});
+
     auto [num_cores, all_cores, core_group_1, core_group_2, num_cols_per_core_group_1, num_cols_per_core_group_2] =
-        split_work_to_cores(compute_with_storage_grid_size, num_cols);
+        split_work_to_cores(all_core_range, num_cols);
 
     string compute_kernel_name = "ttnn/cpp/ttnn/deprecated/tt_dnn/op_library/moreh_sum/moreh_sum_h_impl/kernels/moreh_sum_h.cpp";
 

--- a/ttnn/cpp/ttnn/deprecated/tt_dnn/op_library/moreh_sum/moreh_sum_op.cpp
+++ b/ttnn/cpp/ttnn/deprecated/tt_dnn/op_library/moreh_sum/moreh_sum_op.cpp
@@ -7,9 +7,9 @@
 #include <cstdint>
 #include <numeric>
 
-#include "ttnn/deprecated/tt_dnn/op_library/moreh_helper_functions.hpp"
 #include "tt_metal/common/constants.hpp"
 #include "tt_metal/host_api.hpp"
+#include "ttnn/deprecated/tt_dnn/op_library/moreh_helper_functions.hpp"
 
 namespace tt {
 using namespace constants;
@@ -20,86 +20,6 @@ namespace primary {
 //                         MorehSum
 ////////////////////////////////////////////////////////////////////////////
 namespace {
-
-
-inline void validate_input_tensor_with_dim(const Tensor& input, const int64_t &dim) {
-    auto input_shape = input.get_legacy_shape();
-    auto input_shape_wo_padding = input.get_legacy_shape().without_padding();
-    const auto input_rank = input_shape.rank();
-    log_debug(LogOp, "{}:{} input_rank {}", __func__, __LINE__, input_rank);
-    TT_FATAL(
-        (dim >= 0 && dim <= tt::tt_metal::MAX_NUM_DIMENSIONS),
-        "dim must be between 0 and {}.",
-        tt::tt_metal::MAX_NUM_DIMENSIONS);
-    TT_FATAL((dim < input_rank), "dim must be smaller than input tensor rank {}.", input_rank);
-}
-
-inline void validate_output_tensor_with_keep_batch_dim(const Tensor& input, const Tensor& output, const int64_t &dim, const bool &keep_batch_dim) {
-    auto input_shape = input.get_legacy_shape();
-    auto input_shape_wo_padding = input_shape.without_padding();
-    const auto input_rank = input_shape.rank();
-
-    const auto& output_shape = output.get_legacy_shape();
-    const auto& output_shape_wo_padding = output_shape.without_padding();
-    const auto output_rank = output_shape.rank();
-
-    const bool is_tile_dim = (dim == input_rank - 1 || dim == input_rank - 2);
-
-    log_debug(LogOp, "{}:{} keep_batch_dim {} dim {}", __func__, __LINE__, keep_batch_dim, dim);
-    log_debug(LogOp, "{}:{} input_shape {} wo_padding {}", __func__, __LINE__, input_shape, input_shape_wo_padding);
-    log_debug(LogOp, "{}:{} output_shape {} wo_paddoutg {}", __func__, __LINE__, output_shape, output_shape_wo_padding);
-
-    if (keep_batch_dim) {
-        bool ranks_are_equal = (input_rank == output_rank);
-        input_shape[dim] = (is_tile_dim) ? (TILE_HEIGHT) : (1);
-        input_shape_wo_padding[dim] = 1;
-
-        if (!ranks_are_equal) {
-            log_warning(
-                LogOp,
-                "{}:{} input_rank {} and output_rank {} are not the same in keep_batch_dim mode",
-                __func__,
-                __LINE__,
-                input_rank,
-                output_rank);
-        }
-
-        std::vector<uint32_t> input_dim(tt::tt_metal::MAX_NUM_DIMENSIONS, 1);
-        std::vector<uint32_t> output_dim(tt::tt_metal::MAX_NUM_DIMENSIONS, 1);
-        std::vector<uint32_t> input_dim_wo_padding(tt::tt_metal::MAX_NUM_DIMENSIONS, 1);
-        std::vector<uint32_t> output_dim_wo_padding(tt::tt_metal::MAX_NUM_DIMENSIONS, 1);
-        expand_to_max_dim(input_dim, input_shape);
-        expand_to_max_dim(output_dim, output_shape);
-        expand_to_max_dim(input_dim_wo_padding, input_shape_wo_padding);
-        expand_to_max_dim(output_dim_wo_padding, output_shape_wo_padding);
-
-        for (int i = 0; i < input_rank; ++i) {
-            TT_FATAL(input_dim[i] == output_dim[i]);
-            TT_FATAL(input_dim_wo_padding[i] == output_dim_wo_padding[i]);
-        }
-    } else {
-        std::vector<uint32_t> expected_output_shape;
-        std::vector<uint32_t> expected_output_shape_wo_padding;
-        for (int i = 0; i < output_shape.rank(); ++i) {
-            if (i == dim && !is_tile_dim) {
-                expected_output_shape.push_back(1);
-                expected_output_shape_wo_padding.push_back(1);
-            }
-            expected_output_shape.push_back(output_shape[i]);
-            expected_output_shape_wo_padding.push_back(output_shape_wo_padding[i]);
-        }
-
-        log_debug(LogOp, "{}:{} expected_output_shape {}", __func__, __LINE__, expected_output_shape);
-        log_debug(
-            LogOp, "{}:{} expected_output_shape_wo_padding {}", __func__, __LINE__, expected_output_shape_wo_padding);
-        for (int i = 0; i < input_rank; ++i) {
-            if (i == dim)
-                continue;
-            TT_FATAL(input_shape[i] == expected_output_shape[i]);
-            TT_FATAL(input_shape_wo_padding[i] == expected_output_shape_wo_padding[i]);
-        }
-    }
-}
 
 Tensor _moreh_sum(
     const Tensor& input,
@@ -112,7 +32,8 @@ Tensor _moreh_sum(
     std::vector<Tensor> output_tensors = {Tensor(operation::get_workers_for_op_output({input}))};
 
     TT_FATAL(input.storage_type() == StorageType::DEVICE || input.storage_type() == StorageType::MULTI_DEVICE);
-    auto kernel_config_val = init_device_compute_kernel_config(input.device()->arch(), compute_kernel_config, MathFidelity::HiFi4);
+    auto kernel_config_val =
+        init_device_compute_kernel_config(input.device()->arch(), compute_kernel_config, MathFidelity::HiFi4);
 
     operation::launch_op(
         [dim, keep_batch_dim, output_mem_config, kernel_config_val, queue_id](
@@ -147,10 +68,10 @@ void MorehSum::validate_with_output_tensors(
     check_tensor(input, "moreh_sum", "input", {DataType::BFLOAT16, DataType::INT32});
     check_tensor(output, "moreh_sum", "output", {DataType::BFLOAT16, DataType::INT32});
 
-    validate_input_tensor_with_dim(input, this->dim);
+    validate_input_with_dim(input, this->dim);
 
     if (output.has_value()) {
-        validate_output_tensor_with_keep_batch_dim(input, output.value(), this->dim, this->keep_batch_dim);
+        validate_output_with_keepdim(input, output.value(), this->dim, this->keep_batch_dim);
     }
 }
 

--- a/ttnn/cpp/ttnn/deprecated/tt_dnn/op_library/moreh_sum/moreh_sum_op.hpp
+++ b/ttnn/cpp/ttnn/deprecated/tt_dnn/op_library/moreh_sum/moreh_sum_op.hpp
@@ -25,69 +25,6 @@ namespace primary {
 
 using namespace tt_metal;
 
-inline
-std::tuple<uint32_t, uint32_t, uint32_t> extract_spatial_dims(const Shape& shape) {
-    const auto rank = shape.rank();
-
-    TT_FATAL(rank >= 2, "Shape must have at least two dims.");
-    uint32_t W = shape[-1];
-    uint32_t H = shape[-2];
-
-    uint32_t other_dims_product = 1;
-    for (auto i = 0; i < rank - 2; ++i) {
-        other_dims_product *= shape[i];
-    }
-
-    return { W, H, other_dims_product};
-}
-
-inline void initialize_dims_with_range(std::vector<int64_t>& dims, uint32_t input_rank) {
-    dims.resize(input_rank);
-    std::iota(dims.begin(), dims.end(), 0);
-}
-
-inline std::vector<int64_t> get_dim(
-    const std::optional<std::variant<int64_t, std::vector<int64_t>>>& dim,
-    uint32_t input_rank
-) {
-    std::vector<int64_t> dims;
-    if (!dim.has_value()) {
-        initialize_dims_with_range(dims, input_rank);
-    }
-    else if (std::holds_alternative<int64_t>(dim.value())) {
-        auto d = std::get<int64_t>(dim.value());
-        dims.push_back(d);
-    }
-    else {
-        dims = std::get<std::vector<int64_t>>(dim.value());
-        if (dims.empty()) {
-            initialize_dims_with_range(dims, input_rank);
-        }
-    }
-    return dims;
-}
-
-inline
-std::tuple<uint32_t, uint32_t, uint32_t, uint32_t> extract_and_scale_spatial_dims(const Shape& shape, uint32_t dim) {
-    const auto rank = shape.rank();
-
-    TT_FATAL(rank >= 2, "Shape must have at least two dims.");
-    uint32_t Wt = shape[-1] / TILE_WIDTH;
-    uint32_t Ht = shape[-2] / TILE_HEIGHT;
-
-    uint32_t reduce_dim = shape[dim];
-    uint32_t inner_dims_product = 1;
-    for (auto i = dim + 1; i < rank - 2; ++i) {
-        inner_dims_product *= shape[i];
-    }
-
-    uint32_t inner_tile_size = inner_dims_product * Ht * Wt;
-    uint32_t reduce_tile_size = reduce_dim * inner_tile_size;
-
-    return { Wt, Ht, inner_tile_size, reduce_tile_size};
-}
-
-
 struct MorehSum {
     int64_t dim;
     bool keep_batch_dim;

--- a/ttnn/cpp/ttnn/deprecated/tt_dnn/op_library/moreh_sum/moreh_sum_w_impl/moreh_sum_w_impl.cpp
+++ b/ttnn/cpp/ttnn/deprecated/tt_dnn/op_library/moreh_sum/moreh_sum_w_impl/moreh_sum_w_impl.cpp
@@ -11,6 +11,7 @@
 #include "tt_metal/common/constants.hpp"
 #include "tt_metal/detail/util.hpp"
 #include "tt_metal/host_api.hpp"
+#include "ttnn/deprecated/tt_dnn/op_library/moreh_helper_functions.hpp"
 
 namespace tt {
 using namespace constants;
@@ -65,12 +66,13 @@ operation::ProgramWithCallbacks moreh_sum_w_impl(const Tensor &a, const Tensor &
     tt_metal::Device *device = a.device();
 
     auto compute_with_storage_grid_size = device->compute_with_storage_grid_size();
-    uint32_t num_cores_x = compute_with_storage_grid_size.x;
     uint32_t num_cores_y = compute_with_storage_grid_size.y;
     auto num_rows = other_dims_product * Ht;
 
+    const CoreRange all_core_range({0, 0}, {compute_with_storage_grid_size.x - 1, compute_with_storage_grid_size.y - 1});
+
     auto [num_cores, all_cores, core_group_1, core_group_2, num_rows_per_core_group_1, num_rows_per_core_group_2] =
-        split_work_to_cores(compute_with_storage_grid_size, num_rows);
+        split_work_to_cores(all_core_range, num_rows);
 
     string compute_kernel_name = "ttnn/cpp/ttnn/deprecated/tt_dnn/op_library/moreh_sum/moreh_sum_w_impl/kernels/moreh_sum_w.cpp";
 

--- a/ttnn/cpp/ttnn/deprecated/tt_dnn/op_library/moreh_sum_backward/moreh_sum_backward_impl/kernels/writer_moreh_sum_backward.cpp
+++ b/ttnn/cpp/ttnn/deprecated/tt_dnn/op_library/moreh_sum_backward/moreh_sum_backward_impl/kernels/writer_moreh_sum_backward.cpp
@@ -14,14 +14,16 @@ void kernel_main() {
     const auto num_tiles = arg_fetcher.get_next_arg_val<uint32_t>();
     const auto start_id = arg_fetcher.get_next_arg_val<uint32_t>();
 
-    constexpr uint32_t cb_id_out = 16;
+    constexpr uint32_t cb_id_out = tt::CB::c_out0;
     constexpr uint32_t onetile = 1;
 
     uint32_t input_grad_tile_bytes = get_tile_size(cb_id_out);
     const auto input_grad_data_format = get_dataformat(cb_id_out);
 
     const InterleavedAddrGenFast<input_grad_is_dram> input_grad_addrg = {
-        .bank_base_address = input_grad_addr, .page_size = input_grad_tile_bytes, .data_format = input_grad_data_format};
+        .bank_base_address = input_grad_addr,
+        .page_size = input_grad_tile_bytes,
+        .data_format = input_grad_data_format};
 
     for (uint32_t i = start_id; i < start_id + num_tiles; i++) {
         uint32_t write_tile_id = i;

--- a/ttnn/cpp/ttnn/deprecated/tt_lib/csrc/operations/primary/module.hpp
+++ b/ttnn/cpp/ttnn/deprecated/tt_lib/csrc/operations/primary/module.hpp
@@ -26,8 +26,8 @@
 #include "ttnn/deprecated/tt_dnn/op_library/moreh_mean/moreh_mean_op.hpp"
 #include "ttnn/deprecated/tt_dnn/op_library/moreh_mean_backward/moreh_mean_backward_op.hpp"
 #include "ttnn/deprecated/tt_dnn/op_library/moreh_nll_loss/moreh_nll_loss_op.hpp"
-#include "ttnn/deprecated/tt_dnn/op_library/moreh_nll_loss_unreduced/moreh_nll_loss_unreduced_op.hpp"
 #include "ttnn/deprecated/tt_dnn/op_library/moreh_nll_loss_backward/moreh_nll_loss_backward_op.hpp"
+#include "ttnn/deprecated/tt_dnn/op_library/moreh_nll_loss_unreduced/moreh_nll_loss_unreduced_op.hpp"
 #include "ttnn/deprecated/tt_dnn/op_library/moreh_nll_loss_unreduced_backward/moreh_nll_loss_unreduced_backward_op.hpp"
 #include "ttnn/deprecated/tt_dnn/op_library/moreh_norm/moreh_norm_op.hpp"
 #include "ttnn/deprecated/tt_dnn/op_library/moreh_norm_backward/moreh_norm_backward_op.hpp"
@@ -519,16 +519,26 @@ void py_module(py::module& m_primary) {
         "moreh_mean",
         &moreh_mean,
         py::arg("input").noconvert(),
-        py::arg("output").noconvert(),
         py::kw_only(),
-        py::arg("dims").noconvert() = std::vector<int64_t>(),
-        py::arg("output_mem_config").noconvert() = operation::DEFAULT_OUTPUT_MEMORY_CONFIG,
+        py::arg("dim").noconvert() = std::nullopt,
+        py::arg("keepdim").noconvert() = false,
+        py::arg("divisor").noconvert() = std::nullopt,
+        py::arg("output").noconvert() = std::nullopt,
+        py::arg("memory_config").noconvert() = std::nullopt,
+        py::arg("compute_kernel_config").noconvert() = std::nullopt,
         "Performs mean operation. Returns an output tensor.");
+
     m_primary.def(
         "moreh_mean_backward",
         &moreh_mean_backward,
         py::arg("output_grad").noconvert(),
-        py::arg("input_grad").noconvert(),
+        py::kw_only(),
+        py::arg("dim").noconvert() = std::nullopt,
+        py::arg("keepdim").noconvert() = false,
+        py::arg("input_grad_shape").noconvert() = std::nullopt,
+        py::arg("input_grad").noconvert() = std::nullopt,
+        py::arg("memory_config").noconvert() = std::nullopt,
+        py::arg("compute_kernel_config").noconvert() = std::nullopt,
         "Performs mean backward operation. Returns an input_grad tensor.");
 
     m_primary.def(

--- a/ttnn/cpp/ttnn/operations/experimental/reduction/fast_reduce_nc/device/fast_reduce_nc_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/reduction/fast_reduce_nc/device/fast_reduce_nc_program_factory.cpp
@@ -17,6 +17,8 @@ using namespace tt;
 using namespace tt::constants;
 using namespace tt::tt_metal;
 
+namespace {
+
 std::tuple<uint32_t, uint32_t, uint32_t, uint32_t> extract_and_scale_spatial_dims(const tt::tt_metal::Shape& shape, uint32_t dim) {
     const auto rank = shape.rank();
 
@@ -34,6 +36,8 @@ std::tuple<uint32_t, uint32_t, uint32_t, uint32_t> extract_and_scale_spatial_dim
     uint32_t reduce_tile_size = reduce_dim * inner_tile_size;
 
     return { Wt, Ht, inner_tile_size, reduce_tile_size};
+}
+
 }
 
 operation::ProgramWithCallbacks reduce_nc_factory(const ttnn::Tensor &input, const ttnn::Tensor &output, int64_t dim,const DeviceComputeKernelConfig &compute_kernel_config) {


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/11430

### Problem description
moreh_mean needs refactoring as it currently does not support n-dimensional tensors and optional output, among other missing functionalities.

### What's changed
refactoring moreh_norm
- add fp32_dest_acc_en support
- support non 4d tensor
- support optional output tensor
- add keepdim


### Checklist
- [x] Post commit CI passes
- [ ] Blackhole Post commit (if applicable)
- [x] Model regression CI testing passes (if applicable)
- [x] New/Existing tests provide coverage for changes
