### PR TITLE
Migrate CB configs into kernel config ring buffer

### DIFF
--- a/tests/tt_metal/tt_metal/test_kernels/compute/3T/matmul_large_block_zm/zm_3m_pack.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/compute/3T/matmul_large_block_zm/zm_3m_pack.cpp
@@ -86,7 +86,6 @@ void pack_main()
 {
 uint32_t in0_block_w = get_compile_time_arg_val(0);
 llk_pack_init();
-llk_setup_outputs();
 llk_pack_dest_init<DstTileFaceLayout::RowMajor, false>();
 llk_init_packer_dest_offset_registers<DstTileFaceLayout::RowMajor,false>();
 llk_pack_hw_configure_disaggregated<false>(16);

--- a/tests/tt_metal/tt_metal/test_kernels/compute/3T/matmul_large_block_zm/zm_3m_unpack.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/compute/3T/matmul_large_block_zm/zm_3m_unpack.cpp
@@ -122,7 +122,6 @@ inline void unpack_for_matmul_output_row(
 void unpack_main()
 {
 uint32_t in0_block_w = get_compile_time_arg_val(0);
-llk_setup_operands();
 llk_unpack_AB_matmul_init(0);
 // inner block size in tiles
 uint32_t in0_num_subblocks = get_compile_time_arg_val(1);

--- a/tests/tt_metal/tt_metal/test_kernels/compute/3T/untilize_A_and_eltwise_binary/chlkc_pack.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/compute/3T/untilize_A_and_eltwise_binary/chlkc_pack.cpp
@@ -15,7 +15,6 @@ uint32_t per_core_block_r_tiles = get_compile_time_arg_val(1);
 uint32_t per_core_block_c_tiles = get_compile_time_arg_val(2);
 llk_pack_init();
 llk_pack_hw_configure_disaggregated<false>(16);
-llk_setup_outputs();
 llk_pack_dest_init<DstTileFaceLayout::RowMajor, false>();
 
 for (uint32_t block = 0; block < per_core_num_blocks; block++) {

--- a/tests/tt_metal/tt_metal/test_kernels/compute/3T/untilize_A_and_eltwise_binary/chlkc_unpack.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/compute/3T/untilize_A_and_eltwise_binary/chlkc_unpack.cpp
@@ -16,7 +16,6 @@ uint32_t per_core_num_blocks = get_compile_time_arg_val(0);
 uint32_t per_core_block_r_tiles = get_compile_time_arg_val(1);
 uint32_t per_core_block_c_tiles = get_compile_time_arg_val(2);
 
-llk_setup_operands();
 llk_unpack_AB_hw_configure_disaggregated<BroadcastType::NONE>(0,1);
 // llk_unpack_untilize_hw_configure_disaggregated(0);
 

--- a/tests/tt_metal/tt_metal/test_kernels/compute/eltwise_copy_3m.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/compute/eltwise_copy_3m.cpp
@@ -39,7 +39,6 @@ void pack_main()
     int __outer_loop_iter;
     llk_pack_init();
     llk_pack_hw_configure_disaggregated<false>(16);
-    llk_setup_outputs();
     llk_pack_dest_init<DstTileFaceLayout::RowMajor, false>();
     constexpr uint32_t per_core_tile_cnt = get_compile_time_arg_val(0);
     for (uint32_t b = 0; b < per_core_tile_cnt; ++b) {
@@ -56,7 +55,6 @@ void pack_main()
 void unpack_main()
 {
     int __outer_loop_iter;
-    llk_setup_operands();
     UNPACK(( llk_unpack_A_init<BroadcastType::NONE, false, EltwiseBinaryReuseDestType::NONE>()  ));
     UNPACK(( llk_unpack_A_hw_configure_disaggregated<BroadcastType::NONE>(0) ));
     constexpr uint32_t per_core_tile_cnt = get_compile_time_arg_val(0);

--- a/tests/tt_metal/tt_metal/test_kernels/compute/unpack_tilizeA_B.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/compute/unpack_tilizeA_B.cpp
@@ -10,7 +10,6 @@
 
 //#include "debug/dprint.h"
 inline void tilizeA_B_binary_init(uint32_t icb0, uint32_t icb1, uint32_t block, uint32_t ocb = 16, uint32_t num_faces = 4, uint32_t face_r_dim = 16) {
-    UNPACK(( llk_setup_operands() ));
     UNPACK(( llk_unpack_tilizeA_B_hw_configure_disaggregated<DST_ACCUM_MODE>(icb0, icb1) ));
     UNPACK(( llk_unpack_tilizeA_B_init<true, true>(icb0, icb1, block, num_faces, face_r_dim, face_r_dim) ));
 
@@ -20,7 +19,6 @@ inline void tilizeA_B_binary_init(uint32_t icb0, uint32_t icb1, uint32_t block, 
 
     PACK(( llk_pack_hw_configure_disaggregated<false, DST_ACCUM_MODE>(ocb) ));
     PACK(( llk_pack_init(ocb) ));
-    PACK(( llk_setup_outputs() ));
     PACK(( llk_pack_dest_init<false, DST_ACCUM_MODE>(ocb) ));
 }
 

--- a/tests/tt_metal/tt_metal/test_kernels/compute/untilA_elwbin_3m.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/compute/untilA_elwbin_3m.cpp
@@ -59,7 +59,6 @@ uint32_t per_core_num_blocks = get_compile_time_arg_val(0);
 uint32_t per_core_block_r_tiles = get_compile_time_arg_val(1);
 uint32_t per_core_block_c_tiles = get_compile_time_arg_val(2);
 
-llk_setup_operands();
 llk_unpack_AB_hw_configure_disaggregated<BroadcastType::NONE>(0,1);
 // llk_unpack_untilize_hw_configure_disaggregated(0);
 
@@ -99,7 +98,6 @@ void pack_main()
     uint32_t per_core_block_c_tiles = get_compile_time_arg_val(2);
     llk_pack_init();
     llk_pack_hw_configure_disaggregated<false>(16);
-    llk_setup_outputs();
     llk_pack_dest_init<DstTileFaceLayout::RowMajor, false>();
 
     for (uint32_t block = 0; block < per_core_num_blocks; block++) {

--- a/tests/tt_metal/tt_metal/test_kernels/dataflow/unit_tests/command_queue/random_program.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/dataflow/unit_tests/command_queue/random_program.cpp
@@ -39,7 +39,11 @@ void MAIN  {
     constexpr volatile uint32_t page_size = get_compile_time_arg_val(7);
 
     for (uint32_t i = 0; i < num_cbs; i++) {
-        uint32_t cb_val = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(CIRCULAR_BUFFER_CONFIG_BASE + i * 16)[3];
+        tt_l1_ptr mailboxes_t* const mailboxes = (tt_l1_ptr mailboxes_t*)(MEM_MAILBOX_BASE);
+        uint32_t kernel_config_base = mailboxes->launch.kernel_config.kernel_config_base[ProgrammableCoreType::TENSIX];
+        uint32_t tt_l1_ptr *cb_l1_base = (uint32_t tt_l1_ptr *)(kernel_config_base +
+            mailboxes->launch.kernel_config.cb_offset);
+        uint32_t cb_val = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(cb_l1_base + i * 4)[3];
         uint32_t expected = ((i + 1) * page_size) >> 4;
         if (cb_val != expected) {
             DPRINT << "Problem with CB idx: " << i << " Expected: " << expected << " Got: " << cb_val << ENDL();

--- a/tests/tt_metal/tt_metal/unit_tests/circular_buffer/test_CircularBuffer_allocation.cpp
+++ b/tests/tt_metal/tt_metal/unit_tests/circular_buffer/test_CircularBuffer_allocation.cpp
@@ -25,7 +25,7 @@ void validate_cb_address(Program &program, Device *device, const CoreRangeSet &c
             for (auto y = core_range.start_coord.y; y <= core_range.end_coord.y; y++) {
                 CoreCoord core_coord(x, y);
                 tt::tt_metal::detail::ReadFromDeviceL1(
-                    device, core_coord, CIRCULAR_BUFFER_CONFIG_BASE, cb_config_buffer_size, cb_config_vector);
+                    device, core_coord, program.get_cb_base_addr(device, core_coord, CoreType::WORKER), cb_config_buffer_size, cb_config_vector);
 
                 std::map<uint8_t, uint32_t> address_per_buffer_index = core_to_address_per_buffer_index.at(core_coord);
 
@@ -284,6 +284,7 @@ TEST_F(DeviceFixture, TestUpdateCircularBufferAddress) {
 
 TEST_F(DeviceFixture, TestUpdateCircularBufferPageSize) {
   for (unsigned int id = 0; id < num_devices_; id++) {
+    Device *device = this->devices_.at(id);
     Program program;
     CBConfig cb_config;
     CoreCoord core0(0, 0);
@@ -306,7 +307,7 @@ TEST_F(DeviceFixture, TestUpdateCircularBufferPageSize) {
         expected_cb_addr += cb_config.page_size;
     }
 
-    detail::LaunchProgram(this->devices_.at(id), program);
+    detail::LaunchProgram(device, program);
 
     vector<uint32_t> cb_config_vector;
     uint32_t cb_config_buffer_size = NUM_CIRCULAR_BUFFERS * UINT32_WORDS_PER_CIRCULAR_BUFFER_CONFIG * sizeof(uint32_t);
@@ -316,7 +317,7 @@ TEST_F(DeviceFixture, TestUpdateCircularBufferPageSize) {
             for (auto y = core_range.start_coord.y; y <= core_range.end_coord.y; y++) {
                 CoreCoord core_coord(x, y);
                 tt::tt_metal::detail::ReadFromDeviceL1(
-                    this->devices_.at(id), core_coord, CIRCULAR_BUFFER_CONFIG_BASE, cb_config_buffer_size, cb_config_vector);
+                    device, core_coord, program.get_cb_base_addr(device, core_coord, CoreType::WORKER), cb_config_buffer_size, cb_config_vector);
 
                 std::map<uint8_t, uint32_t> address_per_buffer_index = golden_addresses_per_core.at(core_coord);
                 std::map<uint8_t, uint32_t> num_pages_per_buffer_index = golden_num_pages_per_core.at(core_coord);
@@ -333,7 +334,7 @@ TEST_F(DeviceFixture, TestUpdateCircularBufferPageSize) {
     UpdateCircularBufferPageSize(program, cb_ids[1], 1, cb_config.page_size / 2);
     golden_num_pages_per_core[core0][1] = 2;
 
-    detail::LaunchProgram(this->devices_.at(id), program);
+    detail::LaunchProgram(device, program);
 
     // addresses should not be changed
     for (const CoreRange &core_range : cr_set.ranges()) {
@@ -341,7 +342,7 @@ TEST_F(DeviceFixture, TestUpdateCircularBufferPageSize) {
             for (auto y = core_range.start_coord.y; y <= core_range.end_coord.y; y++) {
                 CoreCoord core_coord(x, y);
                 tt::tt_metal::detail::ReadFromDeviceL1(
-                    this->devices_.at(id), core_coord, CIRCULAR_BUFFER_CONFIG_BASE, cb_config_buffer_size, cb_config_vector);
+                    device, core_coord, program.get_cb_base_addr(device, core_coord, CoreType::WORKER), cb_config_buffer_size, cb_config_vector);
 
                 std::map<uint8_t, uint32_t> address_per_buffer_index = golden_addresses_per_core.at(core_coord);
                 std::map<uint8_t, uint32_t> num_pages_per_buffer_index = golden_num_pages_per_core.at(core_coord);

--- a/tests/tt_metal/tt_metal/unit_tests/circular_buffer/test_CircularBuffer_creation.cpp
+++ b/tests/tt_metal/tt_metal/unit_tests/circular_buffer/test_CircularBuffer_creation.cpp
@@ -28,7 +28,7 @@ bool test_cb_config_written_to_core(Program &program, Device *device, const Core
                 for (auto y = core_range.start_coord.y; y <= core_range.end_coord.y; y++) {
                     CoreCoord core_coord(x, y);
                     tt::tt_metal::detail::ReadFromDeviceL1(
-                        device, core_coord, CIRCULAR_BUFFER_CONFIG_BASE, cb_config_buffer_size, cb_config_vector);
+                        device, core_coord, program.get_sem_base_addr(device, core_coord, CoreType::WORKER), cb_config_buffer_size, cb_config_vector);
 
                     for (const auto &[buffer_index, golden_cb_config] : cb_config_per_buffer_index) {
                         auto base_index = UINT32_WORDS_PER_CIRCULAR_BUFFER_CONFIG * buffer_index;

--- a/tests/tt_metal/tt_metal/unit_tests_fast_dispatch/command_queue/test_EnqueueProgram.cpp
+++ b/tests/tt_metal/tt_metal/unit_tests_fast_dispatch/command_queue/test_EnqueueProgram.cpp
@@ -76,7 +76,7 @@ std::vector<CBHandle> initialize_dummy_circular_buffers(Program& program, const 
     return cb_handles;
 }
 
-bool cb_config_successful(Device* device, const DummyProgramMultiCBConfig & program_config){
+bool cb_config_successful(Device* device, Program &program, const DummyProgramMultiCBConfig & program_config){
     bool pass = true;
 
     // Need to use old APIs to read since we cannot allocate a buffer in the reserved space we're trying
@@ -86,7 +86,9 @@ bool cb_config_successful(Device* device, const DummyProgramMultiCBConfig & prog
 
     for (const CoreRange& core_range : program_config.cr_set.ranges()) {
         for (const CoreCoord& core_coord : core_range) {
-            tt::tt_metal::detail::ReadFromDeviceL1(device, core_coord, CIRCULAR_BUFFER_CONFIG_BASE, cb_config_buffer_size, cb_config_vector);
+            tt::tt_metal::detail::ReadFromDeviceL1(device, core_coord,
+                program.get_sem_base_addr(device, core_coord, CoreType::WORKER),
+                cb_config_buffer_size, cb_config_vector);
 
             uint32_t cb_addr = L1_UNRESERVED_BASE;
             for (uint32_t i = 0; i < program_config.cb_config_vector.size(); i++) {
@@ -115,7 +117,7 @@ bool test_dummy_EnqueueProgram_with_cbs(Device* device, CommandQueue& cq, DummyP
     EnqueueProgram(cq, program, is_blocking_op);
     Finish(cq);
 
-    return cb_config_successful(device, program_config);
+    return cb_config_successful(device, program, program_config);
 }
 
 bool test_dummy_EnqueueProgram_with_cbs_update_size(Device* device, CommandQueue& cq, const DummyProgramMultiCBConfig& program_config) {
@@ -126,7 +128,7 @@ bool test_dummy_EnqueueProgram_with_cbs_update_size(Device* device, CommandQueue
     EnqueueProgram(cq, program, false);
     Finish(cq);
 
-    const bool is_cb_config_before_update_successful = cb_config_successful(device, program_config);
+    const bool is_cb_config_before_update_successful = cb_config_successful(device, program, program_config);
 
     DummyProgramMultiCBConfig program_config_2 = program_config;
     for (uint32_t cb_id = 0; cb_id < program_config.cb_config_vector.size(); cb_id++) {
@@ -139,7 +141,7 @@ bool test_dummy_EnqueueProgram_with_cbs_update_size(Device* device, CommandQueue
     EnqueueProgram(cq, program, false);
     Finish(cq);
 
-    const bool is_cb_config_after_update_successful = cb_config_successful(device, program_config_2);
+    const bool is_cb_config_after_update_successful = cb_config_successful(device, program, program_config_2);
     return is_cb_config_before_update_successful && is_cb_config_after_update_successful;
 }
 
@@ -776,7 +778,8 @@ TEST_F(CommandQueueSingleCardFixture, TestMultiCBSharedAddressSpaceSentSingleCor
         vector<uint32_t> cb_config_vector;
 
         tt::tt_metal::detail::ReadFromDeviceL1(
-            device, core_coord, CIRCULAR_BUFFER_CONFIG_BASE, cb_config_buffer_size, cb_config_vector);
+            device, core_coord,
+            program.get_cb_base_addr(device, core_coord, CoreType::WORKER), cb_config_buffer_size, cb_config_vector);
         uint32_t cb_addr = L1_UNRESERVED_BASE;
         uint32_t intermediate_index = intermediate_cb * sizeof(uint32_t);
 

--- a/tt_metal/hostdevcommon/common_runtime_address_map.h
+++ b/tt_metal/hostdevcommon/common_runtime_address_map.h
@@ -57,26 +57,19 @@ constexpr static std::uint32_t PROFILER_RISC_COUNT = 5;
 static_assert (PROFILER_FULL_HOST_BUFFER_SIZE_PER_RISC > PROFILER_L1_BUFFER_SIZE);
 
 // Kernel config buffer is WIP
-// Will eventually move CBs/Sems and likely kernel bins into this buffer
-// Size is presently based on the old size of the RTAs (large enough to hold 1 set)
+// Size is presently based on the old sizes of the RTAs + CB config + Sems
 // plus some extra space freed up in the mem map
 constexpr static std::uint32_t L1_KERNEL_CONFIG_BASE = PROFILER_L1_END_ADDRESS;
-constexpr static std::uint32_t L1_KERNEL_CONFIG_SIZE = 4 * 1024 + 256 + 128;
+constexpr static std::uint32_t L1_KERNEL_CONFIG_SIZE = 4 * 1024 + 256 + 128 + 512;
 
 constexpr static std::uint32_t IDLE_ERISC_L1_KERNEL_CONFIG_BASE = 32 * 1024;
 
-// config for 32 L1 buffers is at addr BUFFER_CONFIG_BASE
-// 12 bytes for each buffer: (addr, size, size_in_tiles)
-// addr and size are in 16B words (byte address >> 4)
-// this is a total of 32 * 3 * 4 = 384B
-constexpr static std::uint32_t CIRCULAR_BUFFER_CONFIG_BASE = L1_KERNEL_CONFIG_BASE + L1_KERNEL_CONFIG_SIZE;
 constexpr static std::uint32_t NUM_CIRCULAR_BUFFERS = 32;
 constexpr static std::uint32_t UINT32_WORDS_PER_CIRCULAR_BUFFER_CONFIG = 4;
-constexpr static std::uint32_t CIRCULAR_BUFFER_CONFIG_SIZE = NUM_CIRCULAR_BUFFERS * UINT32_WORDS_PER_CIRCULAR_BUFFER_CONFIG * sizeof(uint32_t);
 
 constexpr static std::uint32_t PROFILER_L1_CONTROL_VECTOR_SIZE = 32;
 constexpr static std::uint32_t PROFILER_L1_CONTROL_BUFFER_SIZE = PROFILER_L1_CONTROL_VECTOR_SIZE * sizeof(uint32_t);
-constexpr static std::uint32_t PROFILER_L1_BUFFER_CONTROL = CIRCULAR_BUFFER_CONFIG_BASE + CIRCULAR_BUFFER_CONFIG_SIZE;
+constexpr static std::uint32_t PROFILER_L1_BUFFER_CONTROL = L1_KERNEL_CONFIG_BASE + L1_KERNEL_CONFIG_SIZE;
 
 constexpr static std::uint32_t L1_UNRESERVED_BASE = ((PROFILER_L1_BUFFER_CONTROL + PROFILER_L1_CONTROL_BUFFER_SIZE - 1) | (DRAM_ALIGNMENT - 1)) + 1;
 

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_io/llk_io_pack.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_io/llk_io_pack.h
@@ -15,31 +15,6 @@
 
 using namespace ckernel;
 
-// "llk_setup_outputs" is the old function name that HLKC emits
-inline void llk_setup_outputs() {
-    volatile tt_l1_ptr std::uint32_t* circular_buffer_config_addr = (volatile uint32_t*)(CIRCULAR_BUFFER_CONFIG_BASE);
-
-    for (std::uint32_t cb_id = 0; cb_id < NUM_CIRCULAR_BUFFERS; cb_id++) {
-        uint32_t fifo_addr = circular_buffer_config_addr[0];
-        uint32_t fifo_size = circular_buffer_config_addr[1];
-        uint32_t fifo_num_pages = circular_buffer_config_addr[2];
-        uint32_t fifo_page_size = circular_buffer_config_addr[3];
-
-        cb_interface[cb_id].fifo_wr_ptr = fifo_addr;
-        cb_interface[cb_id].fifo_limit = fifo_addr + fifo_size;  // Check if there is overflow
-        cb_interface[cb_id].fifo_size = fifo_size;
-        cb_interface[cb_id].fifo_num_pages = fifo_num_pages;
-        cb_interface[cb_id].fifo_page_size = fifo_page_size;
-
-        // local copy used by the packer
-        cb_interface[cb_id].tiles_received = 0;
-        // this is currently used for in-order packing (the default mode)
-        cb_interface[cb_id].fifo_wr_tile_ptr = 0;
-
-        circular_buffer_config_addr += UINT32_WORDS_PER_CIRCULAR_BUFFER_CONFIG;  // move by 3 uint32's
-    }
-}
-
 // Blocking call to wait for free space needed to pack N tiles
 template <bool skip_sync = false, bool wait_for_blocks = false, bool brisc_pack = false>
 inline void llk_wait_for_free_tiles(const std::int32_t operand, const std::int32_t num_tiles) {

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_io/llk_io_unpack.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_io/llk_io_unpack.h
@@ -14,27 +14,6 @@
 
 using namespace ckernel;
 
-// "llk_setup_operands" is the old function name that HLKC emits
-inline void llk_setup_operands() {
-    volatile tt_l1_ptr std::uint32_t* circular_buffer_config_addr = (volatile uint32_t*)(CIRCULAR_BUFFER_CONFIG_BASE);
-
-    for (uint32_t cb_id = 0; cb_id < NUM_CIRCULAR_BUFFERS; cb_id++) {
-        // NOTE: fifo_addr, fifo_size and fifo_limit in 16B words!
-        uint32_t fifo_addr = circular_buffer_config_addr[0];
-        uint32_t fifo_size = circular_buffer_config_addr[1];
-        uint32_t fifo_num_pages = circular_buffer_config_addr[2];  // not used atm
-        uint32_t fifo_page_size = circular_buffer_config_addr[3];
-
-        cb_interface[cb_id].fifo_rd_ptr = fifo_addr;
-        cb_interface[cb_id].fifo_size = fifo_size;
-        cb_interface[cb_id].fifo_limit = fifo_addr + fifo_size;  // Check if there is overflow
-        cb_interface[cb_id].tiles_acked = 0;
-        cb_interface[cb_id].fifo_page_size = fifo_page_size;
-
-        circular_buffer_config_addr += UINT32_WORDS_PER_CIRCULAR_BUFFER_CONFIG;  // move by 3 uint32's
-    }
-}
-
 // Wait for N tiles available in the incoming stream
 inline void llk_wait_tiles(int operand, std::int32_t num_tiles) {
     // TODO(MO): Manually uncomment until issue #6619 is resolved

--- a/tt_metal/hw/ckernels/grayskull/metal/llk_io/llk_io.cc
+++ b/tt_metal/hw/ckernels/grayskull/metal/llk_io/llk_io.cc
@@ -1,3 +1,0 @@
-#include "llk_io.h"
-
-CBInterface cb_interface[NUM_CIRCULAR_BUFFERS] = {0};

--- a/tt_metal/hw/ckernels/grayskull/metal/llk_io/llk_io.h
+++ b/tt_metal/hw/ckernels/grayskull/metal/llk_io/llk_io.h
@@ -6,5 +6,3 @@
 #include <cstdint>
 
 #include "circular_buffer.h"
-
-extern CBInterface cb_interface[NUM_CIRCULAR_BUFFERS];

--- a/tt_metal/hw/ckernels/grayskull/metal/llk_io/llk_io_pack.h
+++ b/tt_metal/hw/ckernels/grayskull/metal/llk_io/llk_io_pack.h
@@ -17,10 +17,6 @@
 
 using namespace ckernel;
 
-// "llk_setup_outputs" is the old function name that HLKC emits
-inline void llk_setup_outputs() {
-}
-
 // Blocking call to wait for free space needed to pack N tiles
 template <bool skip_sync = false, bool wait_for_blocks = false, bool brisc_pack = false>
 inline void llk_wait_for_free_tiles(const std::int32_t operand, const std::int32_t num_tiles) {

--- a/tt_metal/hw/ckernels/grayskull/metal/llk_io/llk_io_unpack.h
+++ b/tt_metal/hw/ckernels/grayskull/metal/llk_io/llk_io_unpack.h
@@ -13,28 +13,6 @@
 #include "tools/profiler/kernel_profiler.hpp"
 using namespace ckernel;
 
-// "llk_setup_operands" is the old function name that HLKC emits
-inline void llk_setup_operands() {
-    volatile tt_l1_ptr std::uint32_t* circular_buffer_config_addr = (volatile uint32_t*)(CIRCULAR_BUFFER_CONFIG_BASE);
-
-    for (uint32_t cb_id = 0; cb_id < NUM_CIRCULAR_BUFFERS; cb_id++) {
-
-        // NOTE: fifo_addr, fifo_size and fifo_limit in 16B words!
-        uint32_t fifo_addr = circular_buffer_config_addr[0];
-        uint32_t fifo_size = circular_buffer_config_addr[1];
-        uint32_t fifo_num_pages = circular_buffer_config_addr[2]; // not used atm
-        uint32_t fifo_page_size = circular_buffer_config_addr[3];
-
-        cb_interface[cb_id].fifo_rd_ptr = fifo_addr;
-        cb_interface[cb_id].fifo_size = fifo_size;
-        cb_interface[cb_id].fifo_limit = fifo_addr + fifo_size;  // Check if there is overflow
-        cb_interface[cb_id].tiles_acked = 0;
-        cb_interface[cb_id].fifo_page_size = fifo_page_size;
-
-        circular_buffer_config_addr += UINT32_WORDS_PER_CIRCULAR_BUFFER_CONFIG; // move by 3 uint32's
-    }
-}
-
 // Wait for N tiles available in the incoming stream
 inline void llk_wait_tiles(int operand, std::int32_t num_tiles) {
     // TODO(MO): Manually uncomment until issue #6619 is resolved

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_io/llk_io_pack.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_io/llk_io_pack.h
@@ -15,32 +15,6 @@
 
 using namespace ckernel;
 
-// "llk_setup_outputs" is the old function name that HLKC emits
-inline void llk_setup_outputs() {
-    volatile tt_l1_ptr std::uint32_t* circular_buffer_config_addr = (volatile uint32_t*)(CIRCULAR_BUFFER_CONFIG_BASE);
-
-    for (std::uint32_t cb_id = 0; cb_id < NUM_CIRCULAR_BUFFERS; cb_id++) {
-
-        uint32_t fifo_addr = circular_buffer_config_addr[0];
-        uint32_t fifo_size = circular_buffer_config_addr[1];
-        uint32_t fifo_num_pages = circular_buffer_config_addr[2];
-        uint32_t fifo_page_size = circular_buffer_config_addr[3];
-
-        cb_interface[cb_id].fifo_wr_ptr = fifo_addr;
-        cb_interface[cb_id].fifo_limit = fifo_addr + fifo_size;  // Check if there is overflow
-        cb_interface[cb_id].fifo_size = fifo_size;
-        cb_interface[cb_id].fifo_num_pages = fifo_num_pages;
-        cb_interface[cb_id].fifo_page_size = fifo_page_size;
-
-        // local copy used by the packer
-        cb_interface[cb_id].tiles_received = 0;
-        // this is currently used for in-order packing (the default mode)
-        cb_interface[cb_id].fifo_wr_tile_ptr = 0;
-
-        circular_buffer_config_addr += UINT32_WORDS_PER_CIRCULAR_BUFFER_CONFIG; // move by 3 uint32's
-    }
-}
-
 // Blocking call to wait for free space needed to pack N tiles
 template <bool skip_sync = false, bool wait_for_blocks = false, bool brisc_pack = false>
 inline void llk_wait_for_free_tiles(const std::int32_t operand, const std::int32_t num_tiles) {

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_io/llk_io_unpack.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_io/llk_io_unpack.h
@@ -15,28 +15,6 @@
 
 using namespace ckernel;
 
-// "llk_setup_operands" is the old function name that HLKC emits
-inline void llk_setup_operands() {
-    volatile tt_l1_ptr std::uint32_t* circular_buffer_config_addr = (volatile uint32_t*)(CIRCULAR_BUFFER_CONFIG_BASE);
-
-    for (uint32_t cb_id = 0; cb_id < NUM_CIRCULAR_BUFFERS; cb_id++) {
-
-        // NOTE: fifo_addr, fifo_size and fifo_limit in 16B words!
-        uint32_t fifo_addr = circular_buffer_config_addr[0];
-        uint32_t fifo_size = circular_buffer_config_addr[1];
-        uint32_t fifo_num_pages = circular_buffer_config_addr[2]; // not used atm
-        uint32_t fifo_page_size = circular_buffer_config_addr[3];
-
-        cb_interface[cb_id].fifo_rd_ptr = fifo_addr;
-        cb_interface[cb_id].fifo_size = fifo_size;
-        cb_interface[cb_id].fifo_limit = fifo_addr + fifo_size;  // Check if there is overflow
-        cb_interface[cb_id].tiles_acked = 0;
-        cb_interface[cb_id].fifo_page_size = fifo_page_size;
-
-        circular_buffer_config_addr += UINT32_WORDS_PER_CIRCULAR_BUFFER_CONFIG; // move by 3 uint32's
-    }
-}
-
 // Apply delay on odd rows of tensix cores in case of matmul.
 // We do this so that not all cores start at once, therefore reducing the chance of di/dt problems.
 // MM_STAGGER_ODD_ROWS is an externally controlled define, set up in program compilation.

--- a/tt_metal/hw/firmware/src/brisc.cc
+++ b/tt_metal/hw/firmware/src/brisc.cc
@@ -384,7 +384,7 @@ int main() {
 
             noc_index = mailboxes->launch.kernel_config.brisc_noc_id;
 
-            setup_cb_read_write_interfaces(0, num_cbs_to_early_init, true, true);
+            setup_cb_read_write_interfaces(0, num_cbs_to_early_init, true, true, false);
             finish_ncrisc_copy_and_run(enables);
 
             firmware_config_init(mailboxes, ProgrammableCoreType::TENSIX, DISPATCH_CLASS_TENSIX_DM0);
@@ -392,7 +392,7 @@ int main() {
             // Run the BRISC kernel
             DEBUG_STATUS("R");
             if (enables & DISPATCH_CLASS_MASK_TENSIX_ENABLE_DM0) {
-                setup_cb_read_write_interfaces(num_cbs_to_early_init, mailboxes->launch.kernel_config.max_cb_index, true, true);
+                setup_cb_read_write_interfaces(num_cbs_to_early_init, mailboxes->launch.kernel_config.max_cb_index, true, true, false);
                 kernel_init();
                 RECORD_STACK_USAGE();
             } else {

--- a/tt_metal/hw/firmware/src/brisc.cc
+++ b/tt_metal/hw/firmware/src/brisc.cc
@@ -384,15 +384,17 @@ int main() {
 
             noc_index = mailboxes->launch.kernel_config.brisc_noc_id;
 
-            setup_cb_read_write_interfaces(0, num_cbs_to_early_init, true, true, false);
-            finish_ncrisc_copy_and_run(enables);
+            uint32_t kernel_config_base = firmware_config_init(mailboxes, ProgrammableCoreType::TENSIX, DISPATCH_CLASS_TENSIX_DM0);
+            uint32_t tt_l1_ptr *cb_l1_base = (uint32_t tt_l1_ptr *)(kernel_config_base +
+                mailboxes->launch.kernel_config.cb_offset);
+            setup_cb_read_write_interfaces(cb_l1_base, 0, num_cbs_to_early_init, true, true, false);
 
-            firmware_config_init(mailboxes, ProgrammableCoreType::TENSIX, DISPATCH_CLASS_TENSIX_DM0);
+            finish_ncrisc_copy_and_run(enables);
 
             // Run the BRISC kernel
             DEBUG_STATUS("R");
             if (enables & DISPATCH_CLASS_MASK_TENSIX_ENABLE_DM0) {
-                setup_cb_read_write_interfaces(num_cbs_to_early_init, mailboxes->launch.kernel_config.max_cb_index, true, true, false);
+                setup_cb_read_write_interfaces(cb_l1_base, num_cbs_to_early_init, mailboxes->launch.kernel_config.max_cb_index, true, true, false);
                 kernel_init();
                 RECORD_STACK_USAGE();
             } else {

--- a/tt_metal/hw/firmware/src/idle_erisc.cc
+++ b/tt_metal/hw/firmware/src/idle_erisc.cc
@@ -49,8 +49,6 @@ uint8_t my_y[NUM_NOCS] __attribute__((used));
 
 tt_l1_ptr mailboxes_t * const mailboxes = (tt_l1_ptr mailboxes_t *)(MEM_IERISC_MAILBOX_BASE);
 
-constexpr uint32_t num_cbs_to_early_init = 4;  // safe small number to overlap w/ ncrisc copy
-
 CBInterface cb_interface[NUM_CIRCULAR_BUFFERS] __attribute__((used));
 
 #if defined(PROFILE_KERNEL)
@@ -128,24 +126,17 @@ int main() {
 
             noc_index = mailboxes->launch.kernel_config.brisc_noc_id;
 
-            //UC FIXME: do i need this?
-            setup_cb_read_write_interfaces(0, num_cbs_to_early_init, true, true);
-
-            //if (mailboxes->launch.enable_brisc) {
-                //UC FIXME: do i need this?
-            setup_cb_read_write_interfaces(num_cbs_to_early_init, mailboxes->launch.kernel_config.max_cb_index, true, true);
+            setup_cb_read_write_interfaces(0, mailboxes->launch.kernel_config.max_cb_index, true, true, false);
 
             firmware_config_init(mailboxes, ProgrammableCoreType::IDLE_ETH, DISPATCH_CLASS_ETH_DM0);
 
             flush_icache();
+
             // Run the ERISC kernel
             DEBUG_STATUS("R");
             kernel_init();
             RECORD_STACK_USAGE();
-            //} else {
-                // This was not initialized in kernel_init
-            //    noc_local_state_init(noc_index);
-            //}
+
             DEBUG_STATUS("D");
 
             mailboxes->launch.go.run = RUN_MSG_DONE;

--- a/tt_metal/hw/firmware/src/idle_erisc.cc
+++ b/tt_metal/hw/firmware/src/idle_erisc.cc
@@ -126,9 +126,10 @@ int main() {
 
             noc_index = mailboxes->launch.kernel_config.brisc_noc_id;
 
-            setup_cb_read_write_interfaces(0, mailboxes->launch.kernel_config.max_cb_index, true, true, false);
-
-            firmware_config_init(mailboxes, ProgrammableCoreType::IDLE_ETH, DISPATCH_CLASS_ETH_DM0);
+            uint32_t kernel_config_base = firmware_config_init(mailboxes, ProgrammableCoreType::IDLE_ETH, DISPATCH_CLASS_ETH_DM0);
+            uint32_t tt_l1_ptr *cb_l1_base = (uint32_t tt_l1_ptr *)(kernel_config_base +
+                mailboxes->launch.kernel_config.cb_offset);
+            setup_cb_read_write_interfaces(cb_l1_base, 0, mailboxes->launch.kernel_config.max_cb_index, true, true, false);
 
             flush_icache();
 
@@ -136,7 +137,6 @@ int main() {
             DEBUG_STATUS("R");
             kernel_init();
             RECORD_STACK_USAGE();
-
             DEBUG_STATUS("D");
 
             mailboxes->launch.go.run = RUN_MSG_DONE;

--- a/tt_metal/hw/firmware/src/ncrisc.cc
+++ b/tt_metal/hw/firmware/src/ncrisc.cc
@@ -96,9 +96,10 @@ int main(int argc, char *argv[]) {
         notify_brisc_and_wait();
         DeviceZoneScopedMainN("NCRISC-FW");
 
-        setup_cb_read_write_interfaces(0, mailboxes->launch.kernel_config.max_cb_index, true, true, false);
-
-        firmware_config_init(mailboxes, ProgrammableCoreType::TENSIX, DISPATCH_CLASS_TENSIX_DM1);
+        uint32_t kernel_config_base = firmware_config_init(mailboxes, ProgrammableCoreType::TENSIX, DISPATCH_CLASS_TENSIX_DM1);
+        uint32_t tt_l1_ptr *cb_l1_base = (uint32_t tt_l1_ptr *)(kernel_config_base +
+            mailboxes->launch.kernel_config.cb_offset);
+        setup_cb_read_write_interfaces(cb_l1_base, 0, mailboxes->launch.kernel_config.max_cb_index, true, true, false);
 
         DEBUG_STATUS("R");
         kernel_init();

--- a/tt_metal/hw/firmware/src/ncrisc.cc
+++ b/tt_metal/hw/firmware/src/ncrisc.cc
@@ -96,7 +96,7 @@ int main(int argc, char *argv[]) {
         notify_brisc_and_wait();
         DeviceZoneScopedMainN("NCRISC-FW");
 
-        setup_cb_read_write_interfaces(0, mailboxes->launch.kernel_config.max_cb_index, true, true);
+        setup_cb_read_write_interfaces(0, mailboxes->launch.kernel_config.max_cb_index, true, true, false);
 
         firmware_config_init(mailboxes, ProgrammableCoreType::TENSIX, DISPATCH_CLASS_TENSIX_DM1);
 

--- a/tt_metal/hw/firmware/src/trisc.cc
+++ b/tt_metal/hw/firmware/src/trisc.cc
@@ -109,6 +109,10 @@ int main(int argc, char *argv[]) {
 
 #if !defined(UCK_CHLKC_MATH)
         setup_cb_read_write_interfaces(0, mailboxes->launch.kernel_config.max_cb_index, cb_init_read, cb_init_write);
+#if defined(UCK_CHLKC_UNPACK)
+        // Hack workaround for issue #11591
+        for (volatile uint32_t xxx = 0; xxx < 100; xxx++);
+#endif
 #endif
 
         uint32_t kernel_config_base = mailboxes->launch.kernel_config.kernel_config_base[ProgrammableCoreType::TENSIX];

--- a/tt_metal/hw/firmware/src/trisc.cc
+++ b/tt_metal/hw/firmware/src/trisc.cc
@@ -58,6 +58,7 @@ volatile tt_l1_ptr uint32_t l1_buffer[16] __attribute__((section("l1_data"))) __
 __attribute__((used));
 
 #if !defined(UCK_CHLKC_MATH)
+uint32_t tt_l1_ptr *cb_l1_base __attribute__((used));
 CBInterface cb_interface[NUM_CIRCULAR_BUFFERS] __attribute__((used));
 #endif
 
@@ -107,15 +108,18 @@ int main(int argc, char *argv[]) {
         while (*trisc_run != RUN_SYNC_MSG_GO);
         DeviceZoneScopedMainN("TRISC-FW");
 
+        uint32_t kernel_config_base = mailboxes->launch.kernel_config.kernel_config_base[ProgrammableCoreType::TENSIX];
+
 #if !defined(UCK_CHLKC_MATH)
-        setup_cb_read_write_interfaces(0, mailboxes->launch.kernel_config.max_cb_index, cb_init_read, cb_init_write, cb_init_write);
+        uint32_t tt_l1_ptr *cb_l1_base = (uint32_t tt_l1_ptr *)(kernel_config_base +
+            mailboxes->launch.kernel_config.cb_offset);
+        setup_cb_read_write_interfaces(cb_l1_base, 0, mailboxes->launch.kernel_config.max_cb_index, cb_init_read, cb_init_write, cb_init_write);
 #if defined(UCK_CHLKC_UNPACK)
         // Hack workaround for issue #11591
         for (volatile uint32_t xxx = 0; xxx < 100; xxx++);
 #endif
 #endif
 
-        uint32_t kernel_config_base = mailboxes->launch.kernel_config.kernel_config_base[ProgrammableCoreType::TENSIX];
         rta_l1_base = (uint32_t tt_l1_ptr *)(kernel_config_base +
             mailboxes->launch.kernel_config.mem_map[DISPATCH_CLASS_TENSIX_COMPUTE].rta_offset);
         crta_l1_base = (uint32_t tt_l1_ptr *)(kernel_config_base +

--- a/tt_metal/hw/firmware/src/trisc.cc
+++ b/tt_metal/hw/firmware/src/trisc.cc
@@ -108,7 +108,7 @@ int main(int argc, char *argv[]) {
         DeviceZoneScopedMainN("TRISC-FW");
 
 #if !defined(UCK_CHLKC_MATH)
-        setup_cb_read_write_interfaces(0, mailboxes->launch.kernel_config.max_cb_index, cb_init_read, cb_init_write);
+        setup_cb_read_write_interfaces(0, mailboxes->launch.kernel_config.max_cb_index, cb_init_read, cb_init_write, cb_init_write);
 #if defined(UCK_CHLKC_UNPACK)
         // Hack workaround for issue #11591
         for (volatile uint32_t xxx = 0; xxx < 100; xxx++);

--- a/tt_metal/hw/inc/blackhole/dev_mem_map.h
+++ b/tt_metal/hw/inc/blackhole/dev_mem_map.h
@@ -52,6 +52,7 @@
 #define MEM_BOOT_CODE_BASE 0
 #define MEM_L1_BARRIER 12
 #define MEM_MAILBOX_BASE 16
+// Magic size must be big enough to hold dev_msgs_t.  static_asserts will fire if this is too small
 #define MEM_MAILBOX_END (MEM_MAILBOX_BASE + 1356)
 #define MEM_IERISC_MAILBOX_BASE 1024
 #define MEM_IERISC_MAILBOX_END (MEM_IERISC_MAILBOX_BASE + 128)

--- a/tt_metal/hw/inc/blackhole/eth_l1_address_map.h
+++ b/tt_metal/hw/inc/blackhole/eth_l1_address_map.h
@@ -28,7 +28,9 @@ struct address_map {
   static constexpr std::int32_t DATA_BUFFER_SIZE_ETH = 4 * 1024;
   static constexpr std::int32_t DATA_BUFFER_SIZE_NOC = 16 * 1024;
   static constexpr std::int32_t DATA_BUFFER_SIZE = 24 * 1024;
-  static constexpr std::int32_t ERISC_L1_KERNEL_CONFIG_SIZE = 96 * 4;
+  // Kernel config buffer is WIP
+  // Size is presently based on the old sizes of the RTAs + CB config + Sems
+  static constexpr std::int32_t ERISC_L1_KERNEL_CONFIG_SIZE = 96 * 4 + 8 * 16;
 
   // Base addresses
   static constexpr std::int32_t FIRMWARE_BASE = 0x9040;
@@ -58,6 +60,8 @@ struct address_map {
   // erisc early exit functionality re-uses mailboxes_t::ncrisc_halt_msg_t::stack_save memory
   static constexpr std::int32_t ERISC_MEM_MAILBOX_STACK_SAVE = ERISC_MEM_MAILBOX_BASE + 4;
 
+  // Kernel config buffer is WIP
+  // Size is presently based on the old sizes of the RTAs + CB config + Sems
   static constexpr std::uint32_t PROFILER_L1_BUFFER_ER = ERISC_MEM_MAILBOX_BASE + 288 + 256 + 16;
   static constexpr std::uint32_t PROFILER_L1_BUFFER_CONTROL = PROFILER_L1_BUFFER_ER + PROFILER_L1_BUFFER_SIZE;
 

--- a/tt_metal/hw/inc/circular_buffer.h
+++ b/tt_metal/hw/inc/circular_buffer.h
@@ -51,7 +51,7 @@ extern CBInterface cb_interface[NUM_CIRCULAR_BUFFERS];
 
 // NCRISC and BRISC setup read and write
 // TRISC sets up read or write
-inline void setup_cb_read_write_interfaces(uint32_t start_cb_index, uint32_t max_cb_index, bool read, bool write) {
+inline void setup_cb_read_write_interfaces(uint32_t start_cb_index, uint32_t max_cb_index, bool read, bool write, bool init_wr_tile_ptr) {
     volatile tt_l1_ptr uint32_t* circular_buffer_config_addr = (volatile tt_l1_ptr uint32_t*)(CIRCULAR_BUFFER_CONFIG_BASE) + start_cb_index * UINT32_WORDS_PER_CIRCULAR_BUFFER_CONFIG;
 
     for (uint32_t cb_id = start_cb_index; cb_id < max_cb_index; cb_id++) {
@@ -76,6 +76,10 @@ inline void setup_cb_read_write_interfaces(uint32_t start_cb_index, uint32_t max
             cb_interface[cb_id].fifo_num_pages = fifo_num_pages;
         }
         cb_interface[cb_id].fifo_page_size = fifo_page_size;
+
+        if (init_wr_tile_ptr) {
+            cb_interface[cb_id].fifo_wr_tile_ptr = 0;
+        }
 
         circular_buffer_config_addr += UINT32_WORDS_PER_CIRCULAR_BUFFER_CONFIG;
     }

--- a/tt_metal/hw/inc/circular_buffer.h
+++ b/tt_metal/hw/inc/circular_buffer.h
@@ -51,8 +51,11 @@ extern CBInterface cb_interface[NUM_CIRCULAR_BUFFERS];
 
 // NCRISC and BRISC setup read and write
 // TRISC sets up read or write
-inline void setup_cb_read_write_interfaces(uint32_t start_cb_index, uint32_t max_cb_index, bool read, bool write, bool init_wr_tile_ptr) {
-    volatile tt_l1_ptr uint32_t* circular_buffer_config_addr = (volatile tt_l1_ptr uint32_t*)(CIRCULAR_BUFFER_CONFIG_BASE) + start_cb_index * UINT32_WORDS_PER_CIRCULAR_BUFFER_CONFIG;
+inline void setup_cb_read_write_interfaces(uint32_t tt_l1_ptr *cb_l1_base, uint32_t start_cb_index, uint32_t max_cb_index, bool read, bool write, bool init_wr_tile_ptr) {
+
+    constexpr uint32_t WORDS_PER_CIRCULAR_BUFFER_CONFIG = 4;
+
+    volatile tt_l1_ptr uint32_t* circular_buffer_config_addr = cb_l1_base + start_cb_index * WORDS_PER_CIRCULAR_BUFFER_CONFIG;
 
     for (uint32_t cb_id = start_cb_index; cb_id < max_cb_index; cb_id++) {
 
@@ -81,6 +84,6 @@ inline void setup_cb_read_write_interfaces(uint32_t start_cb_index, uint32_t max
             cb_interface[cb_id].fifo_wr_tile_ptr = 0;
         }
 
-        circular_buffer_config_addr += UINT32_WORDS_PER_CIRCULAR_BUFFER_CONFIG;
+        circular_buffer_config_addr += WORDS_PER_CIRCULAR_BUFFER_CONFIG;
     }
 }

--- a/tt_metal/hw/inc/dev_msgs.h
+++ b/tt_metal/hw/inc/dev_msgs.h
@@ -83,6 +83,7 @@ struct kernel_config_msg_t {
     // Ring buffer of kernel configuration data
     volatile uint32_t kernel_config_base[static_cast<int>(ProgrammableCoreType::COUNT)];
     volatile uint16_t sem_offset[static_cast<int>(ProgrammableCoreType::COUNT)];
+    volatile uint16_t cb_offset;
     dyn_mem_map_t mem_map[DISPATCH_CLASS_MAX];
 
     volatile uint8_t mode;                   // dispatch mode host/dev
@@ -93,6 +94,7 @@ struct kernel_config_msg_t {
     volatile uint8_t dispatch_core_y;
     volatile uint8_t exit_erisc_kernel;
     volatile uint8_t pad1;
+    volatile uint16_t pad2;
 } __attribute__((packed));
 
 struct go_msg_t {

--- a/tt_metal/hw/inc/firmware_common.h
+++ b/tt_metal/hw/inc/firmware_common.h
@@ -67,7 +67,7 @@ inline void firmware_kernel_common_init(void *init_local_l1_base) {
 
 }
 FORCE_INLINE
-void firmware_config_init(tt_l1_ptr mailboxes_t* const mailboxes, uint32_t core_type_index, uint32_t dispatch_class) {
+uint32_t firmware_config_init(tt_l1_ptr mailboxes_t* const mailboxes, uint32_t core_type_index, uint32_t dispatch_class) {
 
     extern uint32_t tt_l1_ptr *rta_l1_base;
     extern uint32_t tt_l1_ptr *crta_l1_base;
@@ -86,4 +86,6 @@ void firmware_config_init(tt_l1_ptr mailboxes_t* const mailboxes, uint32_t core_
         mailboxes->launch.kernel_config.mem_map[dispatch_class].rta_offset);
     crta_l1_base = (uint32_t tt_l1_ptr *)(kernel_config_base[core_type_index] +
         mailboxes->launch.kernel_config.mem_map[dispatch_class].crta_offset);
+
+    return kernel_config_base[core_type_index];
 }

--- a/tt_metal/hw/inc/grayskull/dev_mem_map.h
+++ b/tt_metal/hw/inc/grayskull/dev_mem_map.h
@@ -54,6 +54,7 @@
 #define MEM_BOOT_CODE_BASE 0
 #define MEM_L1_BARRIER 12
 #define MEM_MAILBOX_BASE 16
+// Magic size must be big enough to hold dev_msgs_t.  static_asserts will fire if this is too small
 #define MEM_MAILBOX_END (MEM_MAILBOX_BASE + 1356)
 #define MEM_IERISC_MAILBOX_BASE 0
 #define MEM_IERISC_MAILBOX_END 0

--- a/tt_metal/hw/inc/wormhole/dev_mem_map.h
+++ b/tt_metal/hw/inc/wormhole/dev_mem_map.h
@@ -56,6 +56,7 @@
 #define MEM_BOOT_CODE_BASE 0
 #define MEM_L1_BARRIER 12
 #define MEM_MAILBOX_BASE 16
+// Magic size must be big enough to hold dev_msgs_t.  static_asserts will fire if this is too small
 #define MEM_MAILBOX_END (MEM_MAILBOX_BASE + 1356)
 #define MEM_IERISC_MAILBOX_BASE 1024
 #define MEM_IERISC_MAILBOX_END (MEM_IERISC_MAILBOX_BASE + 128)

--- a/tt_metal/hw/inc/wormhole/eth_l1_address_map.h
+++ b/tt_metal/hw/inc/wormhole/eth_l1_address_map.h
@@ -28,6 +28,8 @@ struct address_map {
   static constexpr std::int32_t DATA_BUFFER_SIZE_ETH = 4 * 1024;
   static constexpr std::int32_t DATA_BUFFER_SIZE_NOC = 16 * 1024;
   static constexpr std::int32_t DATA_BUFFER_SIZE = 24 * 1024;
+  // Kernel config buffer is WIP
+  // Size is presently based on the old sizes of the RTAs + CB config + Sems
   static constexpr std::int32_t ERISC_L1_KERNEL_CONFIG_SIZE = 96 * 4 + 8 * 16;
 
   // Base addresses

--- a/tt_metal/impl/dispatch/command_queue.cpp
+++ b/tt_metal/impl/dispatch/command_queue.cpp
@@ -1110,6 +1110,7 @@ void EnqueueProgramCommand::assemble_device_commands(
         }
 
         // CB Configs commands
+        index = hal.get_programmable_core_type_index(HalProgrammableCoreType::TENSIX);
         if (num_multicast_cb_sub_cmds > 0) {
             uint32_t curr_sub_cmd_idx = 0;
             cached_program_command_sequence.cb_configs_payloads.reserve(num_multicast_cb_sub_cmds);
@@ -1118,13 +1119,15 @@ void EnqueueProgramCommand::assemble_device_commands(
                 uint32_t write_offset_bytes = program_command_sequence.write_offset_bytes();
                 program_command_sequence.add_dispatch_write_packed<CQDispatchWritePackedMulticastSubCmd>(
                     num_sub_cmds_in_cmd,
-                    CIRCULAR_BUFFER_CONFIG_BASE,
+                    program.get_program_config(index).cb_offset,
                     cb_config_size_bytes,
                     mcast_cb_payload_sizeB,
                     multicast_cb_config_sub_cmds,
                     multicast_cb_config_data,
                     this->packed_write_max_unicast_sub_cmds,
-                    curr_sub_cmd_idx);
+                    curr_sub_cmd_idx,
+                    false,
+                    DISPATCH_WRITE_OFFSET_TENSIX_L1_CONFIG_BASE);
                 for (auto &data_and_size : multicast_cb_config_data) {
                     RecordDispatchData(program, DISPATCH_DATA_CB_CONFIG, data_and_size.second);
                 }

--- a/tt_metal/impl/program/program.cpp
+++ b/tt_metal/impl/program/program.cpp
@@ -901,9 +901,31 @@ void Program::set_launch_msg_sem_offsets() {
     }
 }
 
+uint32_t Program::finalize_cbs(uint32_t programmable_core_type_index, uint32_t base_offset) {
+
+    int max_id = -1;
+
+    // TODO: has to be better way to do this and don't read from volatile
+    for (auto& kg : this->get_kernel_groups(programmable_core_type_index)) {
+        int32_t id = kg.launch_msg.kernel_config.max_cb_index;
+        if (id > max_id) {
+            max_id = id;
+        }
+
+        kg.launch_msg.kernel_config.cb_offset = base_offset;
+    }
+
+    uint32_t cb_size = (max_id + 1) * UINT32_WORDS_PER_CIRCULAR_BUFFER_CONFIG * sizeof(uint32_t);
+
+    this->program_configs_[programmable_core_type_index].cb_offset = base_offset;
+    this->program_configs_[programmable_core_type_index].cb_size = cb_size;
+
+    return base_offset + cb_size;
+}
+
 uint32_t& Program::get_program_config_size(uint32_t programmable_core_type_index) {
     return this->program_config_sizes_[programmable_core_type_index];
- }
+}
 
 void Program::finalize() {
     // Store the number of tensix "go signals" for use by CQ
@@ -921,15 +943,16 @@ void Program::finalize() {
 
     for (uint32_t index = 0; index < hal.get_programmable_core_type_count(); index++) {
         uint32_t offset = 0;
-        offset = this->finalize_rt_args(index, offset);
+        offset = finalize_rt_args(index, offset);
         TT_ASSERT(offset == align(offset, L1_ALIGNMENT));
-        offset = this->finalize_sems(index, offset);
+        offset = finalize_sems(index, offset);
         TT_ASSERT(offset == align(offset, L1_ALIGNMENT));
-
+        offset = finalize_cbs(index, offset);
+        TT_ASSERT(offset == align(offset, L1_ALIGNMENT));
         this->get_program_config_size(index) = offset;
     }
 
-    // The sem offsets cross programmable_core_types so must be set outside the loop above
+    // The sem offsets cross programmable_core_types so must be set after the loop above
     this->set_launch_msg_sem_offsets();
 
     finalized_ = true;
@@ -1061,6 +1084,19 @@ uint32_t Program::get_sem_base_addr(Device *device, CoreCoord logical_core, Core
     return base_addr + this->program_configs_[index].sem_offset;
 }
 
+uint32_t Program::get_cb_base_addr(Device *device, CoreCoord logical_core, CoreType core_type) const {
+
+    CoreCoord phys_core = device->physical_core_from_logical_core(logical_core, core_type);
+    HalProgrammableCoreType programmable_core_type = device->get_programmable_core_type(phys_core);
+    uint32_t index = hal.get_programmable_core_type_index(programmable_core_type);
+
+    uint32_t base_addr = device->using_fast_dispatch ?
+        device->sysmem_manager().get_config_buffer_mgr().get_last_slot_addr(programmable_core_type) :
+        hal.get_dev_addr(programmable_core_type, HalMemAddrType::KERNEL_CONFIG);
+
+    return base_addr + this->program_configs_[index].cb_offset;
+}
+
 uint32_t Program::get_sem_size(Device *device, CoreCoord logical_core, CoreType core_type) const {
 
     CoreCoord phys_core = device->physical_core_from_logical_core(logical_core, core_type);
@@ -1068,6 +1104,15 @@ uint32_t Program::get_sem_size(Device *device, CoreCoord logical_core, CoreType 
     uint32_t index = hal.get_programmable_core_type_index(programmable_core_type);
 
     return this->program_configs_[index].sem_size;
+}
+
+uint32_t Program::get_cb_size(Device *device, CoreCoord logical_core, CoreType core_type) const {
+
+    CoreCoord phys_core = device->physical_core_from_logical_core(logical_core, core_type);
+    HalProgrammableCoreType programmable_core_type = device->get_programmable_core_type(phys_core);
+    uint32_t index = hal.get_programmable_core_type_index(programmable_core_type);
+
+    return this->program_configs_[index].cb_size;
 }
 
 Program::~Program() {}

--- a/tt_metal/impl/program/program.hpp
+++ b/tt_metal/impl/program/program.hpp
@@ -65,6 +65,8 @@ struct ProgramConfig {
     std::array<uint32_t, DISPATCH_CLASS_MAX> crta_sizes;
     uint32_t sem_offset;
     uint32_t sem_size;
+    uint32_t cb_offset;
+    uint32_t cb_size;
 };
 
 class Program {
@@ -142,6 +144,8 @@ class Program {
 
     void capture_multi_device_dependencies() { capture_multi_device_dependencies_ = true; }
     bool has_multi_device_dependencies() { return capture_multi_device_dependencies_; }
+
+    ProgramConfig& get_program_config(uint32_t programmable_core_type_index);
 
     // debug/test
     uint32_t get_sem_base_addr(Device *device, CoreCoord logical_core, CoreType core_type) const;
@@ -241,7 +245,6 @@ class Program {
 
     void update_kernel_groups(uint32_t programmable_core_type_index);
 
-    ProgramConfig& get_program_config(uint32_t programmable_core_type_index);
     uint32_t& get_program_config_size(uint32_t programmable_core_type_index);
 
     uint32_t finalize_rt_args(uint32_t programmable_core_type_index, uint32_t base_offset);

--- a/tt_metal/include/compute_kernel_api/bcast.h
+++ b/tt_metal/include/compute_kernel_api/bcast.h
@@ -107,19 +107,16 @@ void init_bcast(uint32_t icb0, uint32_t icb1, uint32_t ocb = 16)
     else
         MATH(( llk_math_eltwise_binary_init<tBcastOp, tBcastDim>() ));
 
-    UNPACK(( llk_setup_operands() ));
     UNPACK(( llk_unpack_AB_hw_configure_disaggregated<DST_ACCUM_MODE>(icb0, icb1) ));
     UNPACK(( llk_unpack_AB_init<tBcastDim>(icb0, icb1) ));
     // TODO(AP): running this specific init after common AB init causes a hang
 
     // clone of general init for AB TODO(AP): commonize
-    //UNPACK(( llk_setup_operands() ));
     //UNPACK(( llk_unpack_AB_init<BroadcastType::NONE>() ));
     //UNPACK(( llk_unpack_AB_hw_configure_disaggregated<BroadcastType::NONE>(icb0, icb1) ));
 
     PACK(( llk_pack_hw_configure_disaggregated<false, DST_ACCUM_MODE>(ocb) ));
     PACK(( llk_pack_init(ocb) ));
-    PACK(( llk_setup_outputs() ));
     PACK(( llk_pack_dest_init<false, DST_ACCUM_MODE>() ));
 
     MATH(( llk_math_pack_sync_init<DST_ACCUM_MODE>() ));

--- a/tt_metal/include/compute_kernel_api/eltwise_binary.h
+++ b/tt_metal/include/compute_kernel_api/eltwise_binary.h
@@ -29,7 +29,6 @@ namespace ckernel {
  */
 ALWI void binary_op_init_common(uint32_t icb0, uint32_t icb1, uint32_t ocb=16)
 {
-    UNPACK(( llk_setup_operands() ));
     UNPACK(( llk_unpack_AB_hw_configure_disaggregated<DST_ACCUM_MODE>(icb0, icb1) ));
     UNPACK(( llk_unpack_AB_init<BroadcastType::NONE>(icb0, icb1) ));
 
@@ -38,7 +37,6 @@ ALWI void binary_op_init_common(uint32_t icb0, uint32_t icb1, uint32_t ocb=16)
 
     PACK(( llk_pack_hw_configure_disaggregated<false, DST_ACCUM_MODE>(ocb) ));
     PACK(( llk_pack_init(ocb) ));
-    PACK(( llk_setup_outputs() ));
     PACK(( llk_pack_dest_init<false, DST_ACCUM_MODE>() ));
 }
 

--- a/tt_metal/include/compute_kernel_api/eltwise_unary/eltwise_unary.h
+++ b/tt_metal/include/compute_kernel_api/eltwise_unary/eltwise_unary.h
@@ -19,13 +19,11 @@ namespace ckernel {
 
 ALWI void unary_op_init_common(uint32_t icb, uint32_t ocb = 16)
 {
-    UNPACK(( llk_setup_operands() ));
     UNPACK(( llk_unpack_A_hw_configure_disaggregated<DST_ACCUM_MODE>(icb) ));
     UNPACK(( llk_unpack_A_init<BroadcastType::NONE, false, EltwiseBinaryReuseDestType::NONE, UnpackToDestEn>(false /*transpose of faces*/, false /*transpose within 16x16 face*/, icb)  ));
 
     PACK(( llk_pack_hw_configure_disaggregated<false, DST_ACCUM_MODE>(ocb) ));
     PACK(( llk_pack_init<false>(ocb) ));
-    PACK(( llk_setup_outputs() ));
     PACK(( llk_pack_dest_init<false, DST_ACCUM_MODE>() ));
 
     MATH(( llk_math_eltwise_unary_datacopy_init<A2D, BroadcastType::NONE, DST_ACCUM_MODE>(false /*transpose of faces*/, false /*transpose within 16x16 face*/, icb) ));

--- a/tt_metal/include/compute_kernel_api/matmul.h
+++ b/tt_metal/include/compute_kernel_api/matmul.h
@@ -28,7 +28,6 @@ namespace ckernel {
  * | transpose      | The transpose flag for performing transpose operation on B    | uint32_t |  Any positive value will indicate tranpose is set   | False    |
  */
 ALWI void mm_init(uint32_t in0_cb_id = 0, uint32_t in1_cb_id = 1, uint32_t out_cb_id = 16, const uint32_t transpose=0) {
-    UNPACK(( llk_setup_operands() ));
     UNPACK(( llk_unpack_AB_matmul_hw_configure_disaggregated<DST_ACCUM_MODE>(in0_cb_id, in1_cb_id) ));
     UNPACK(( llk_unpack_AB_matmul_init(in0_cb_id, in1_cb_id, transpose) ));
 
@@ -38,7 +37,6 @@ ALWI void mm_init(uint32_t in0_cb_id = 0, uint32_t in1_cb_id = 1, uint32_t out_c
 
     PACK(( llk_pack_hw_configure_disaggregated<false, DST_ACCUM_MODE>(out_cb_id) ));
     PACK(( llk_pack_init(out_cb_id)  ));
-    PACK(( llk_setup_outputs()  ));
     PACK(( llk_pack_dest_init<false, DST_ACCUM_MODE>()  ));
 }
 
@@ -130,7 +128,6 @@ ALWI void mm_init_short_with_dt(uint32_t in0_cb_id = 0, uint32_t in1_cb_id = 1, 
  * | kt_dim         | the inner dim of the input matrices in tiles                  | uint32_t | 1 to 2^32-1                                         | False    |
  */
 ALWI void mm_block_init(uint32_t in0_cb_id = 0, uint32_t in1_cb_id = 1, uint32_t out_cb_id = 16, const uint32_t transpose = 0, uint32_t ct_dim = 1, uint32_t rt_dim = 1, uint32_t kt_dim = 1) {
-    UNPACK(( llk_setup_operands() ));
     UNPACK(( llk_unpack_AB_matmul_hw_configure_disaggregated<DST_ACCUM_MODE>(in0_cb_id, in1_cb_id) ));
     UNPACK(( llk_unpack_AB_matmul_init(in0_cb_id, in1_cb_id, transpose, ct_dim, rt_dim, kt_dim) ));
 
@@ -139,7 +136,6 @@ ALWI void mm_block_init(uint32_t in0_cb_id = 0, uint32_t in1_cb_id = 1, uint32_t
 
     PACK(( llk_pack_hw_configure_disaggregated<false, DST_ACCUM_MODE>(out_cb_id) ));
     PACK(( llk_pack_init<false, false>(out_cb_id)  ));
-    PACK(( llk_setup_outputs()  ));
     PACK(( llk_pack_dest_init<false, DST_ACCUM_MODE>()  ));
 }
 

--- a/tt_metal/include/compute_kernel_api/pack_untilize.h
+++ b/tt_metal/include/compute_kernel_api/pack_untilize.h
@@ -27,10 +27,8 @@ ALWI void pack_untilize_init(uint32_t icb, uint32_t ocb)
 
     PACK(( llk_pack_hw_configure_disaggregated<false, DST_ACCUM_MODE>(ocb) ));
     PACK(( llk_pack_untilize_init<block_ct_dim>(ocb) ));
-    PACK(( llk_setup_outputs() ));
     PACK(( llk_pack_dest_init<true, DST_ACCUM_MODE>() ));
 
-    UNPACK(( llk_setup_operands() ));
     UNPACK(( llk_unpack_A_hw_configure_disaggregated<DST_ACCUM_MODE>(icb) ));
     UNPACK(( llk_unpack_A_init<BroadcastType::NONE, false, EltwiseBinaryReuseDestType::NONE, UnpackToDestEn>(false, false, icb) )); // init must be after configure
 }

--- a/tt_metal/include/compute_kernel_api/reduce.h
+++ b/tt_metal/include/compute_kernel_api/reduce.h
@@ -20,7 +20,6 @@ namespace ckernel {
 template<bool at_start, PoolType reduce_type = REDUCE_OP, ReduceDim reduce_dim = REDUCE_DIM>
 ALWI void reduce_init(uint32_t icb, uint32_t icb_scaler, uint32_t ocb = 16)
 {
-    UNPACK(( llk_setup_operands() ));
     UNPACK(( llk_unpack_AB_hw_configure_disaggregated<DST_ACCUM_MODE>(icb, icb_scaler) ));
     UNPACK(( llk_unpack_AB_reduce_init<reduce_dim>(icb, icb_scaler) ));
 
@@ -30,7 +29,6 @@ ALWI void reduce_init(uint32_t icb, uint32_t icb_scaler, uint32_t ocb = 16)
 
     PACK(( llk_pack_init() ));
     PACK(( llk_pack_reduce_config_v2<reduce_dim, at_start, false, DST_ACCUM_MODE>(ocb) ));
-    PACK(( llk_setup_outputs() ));
     PACK(( llk_pack_dest_init<false, DST_ACCUM_MODE>() ));
 }
 

--- a/tt_metal/include/compute_kernel_api/tilize.h
+++ b/tt_metal/include/compute_kernel_api/tilize.h
@@ -30,10 +30,8 @@ ALWI void tilize_init(uint32_t icb, uint32_t block, uint32_t ocb = 16)
 
     PACK(( llk_pack_hw_configure_disaggregated<false, DST_ACCUM_MODE, ReluType::NO_RELU, 0, true/*tilize en*/>(ocb) ));
     PACK(( llk_pack_init<false, false, true/*tilize en*/>(ocb) ));
-    PACK(( llk_setup_outputs() ));
     PACK(( llk_pack_dest_init<false, DST_ACCUM_MODE>(ocb) ));
 
-    UNPACK(( llk_setup_operands() ));
     UNPACK(( llk_unpack_tilize_hw_configure_disaggregated<DST_ACCUM_MODE>(icb) ));
     UNPACK(( llk_unpack_tilize_init(icb, block) ));
 }
@@ -44,7 +42,6 @@ ALWI void tilize_init(uint32_t icb, uint32_t block, uint32_t ocb = 16)
  */
 ALWI void tilizeA_B_reduce_init(uint32_t icb0, uint32_t icb1_scaler, uint32_t block, uint32_t ocb = 16, uint32_t num_faces = 4, uint32_t face_r_dim = 16)
 {
-    UNPACK(( llk_setup_operands() ));
     UNPACK(( llk_unpack_tilizeA_B_hw_configure_disaggregated<DST_ACCUM_MODE>(icb0, icb1_scaler) ));
     UNPACK(( llk_unpack_tilizeA_B_init<true, true>(icb0, icb1_scaler, block, num_faces, face_r_dim, 1) ));
 
@@ -53,7 +50,6 @@ ALWI void tilizeA_B_reduce_init(uint32_t icb0, uint32_t icb1_scaler, uint32_t bl
 
     PACK(( llk_pack_hw_configure_disaggregated<false, DST_ACCUM_MODE>(ocb) ));
     PACK(( llk_pack_init(ocb) ));
-    PACK(( llk_setup_outputs() ));
     PACK(( llk_pack_dest_init<false, DST_ACCUM_MODE>(ocb) ));
 }
 #endif
@@ -76,7 +72,6 @@ ALWI void tilizeA_B_reduce_init(uint32_t icb0, uint32_t icb1_scaler, uint32_t bl
 
 ALWI void tilizeA_B_dot_product_init(uint32_t icb0, uint32_t icb1, uint32_t block, uint32_t ocb = 16, uint32_t num_faces = 4, uint32_t face_r_dim = 16)
 {
-    UNPACK(( llk_setup_operands() ));
     UNPACK(( llk_unpack_tilizeA_B_hw_configure_disaggregated<DST_ACCUM_MODE>(icb0, icb1) ));
     UNPACK(( llk_unpack_tilizeA_B_init<false, false, true>(icb0, icb1, block, num_faces, face_r_dim, face_r_dim) ));
 
@@ -85,7 +80,6 @@ ALWI void tilizeA_B_dot_product_init(uint32_t icb0, uint32_t icb1, uint32_t bloc
 
     PACK(( llk_pack_hw_configure_disaggregated<false, DST_ACCUM_MODE>(ocb) ));
     PACK(( llk_pack_init(ocb) ));
-    PACK(( llk_setup_outputs() ));
     PACK(( llk_pack_dest_init<false, DST_ACCUM_MODE>(ocb) ));
 }
 

--- a/tt_metal/include/compute_kernel_api/transpose_wh.h
+++ b/tt_metal/include/compute_kernel_api/transpose_wh.h
@@ -32,10 +32,8 @@ ALWI void transpose_wh_init(uint32_t icb, uint32_t ocb = 16)
 
     PACK(( llk_pack_hw_configure_disaggregated<false, DST_ACCUM_MODE>(ocb) ));
     PACK(( llk_pack_init(ocb) ));
-    PACK(( llk_setup_outputs() ));
     PACK(( llk_pack_dest_init<false, DST_ACCUM_MODE>() ));
 
-    UNPACK(( llk_setup_operands() ));
     UNPACK(( llk_unpack_A_hw_configure_disaggregated<DST_ACCUM_MODE>(0, true) ));
     UNPACK(( llk_unpack_A_init<BroadcastType::NONE, true, EltwiseBinaryReuseDestType::NONE>(true, true)  ));
 }

--- a/tt_metal/include/compute_kernel_api/untilize.h
+++ b/tt_metal/include/compute_kernel_api/untilize.h
@@ -26,10 +26,8 @@ ALWI void untilize_init(uint32_t icb, uint32_t ocb = 16)
 
     PACK(( llk_pack_hw_configure_disaggregated<false, DST_ACCUM_MODE>(ocb) ));
     PACK(( llk_pack_init(ocb) ));
-    PACK(( llk_setup_outputs() ));
     PACK(( llk_pack_dest_init<false, DST_ACCUM_MODE>() ));
 
-    UNPACK(( llk_setup_operands() ));
     UNPACK(( llk_unpack_untilize_hw_configure_disaggregated<DST_ACCUM_MODE>(icb) ));
     UNPACK(( llk_unpack_untilize_init(icb) )); // init must be after configure
 }

--- a/tt_metal/llrt/llrt.cpp
+++ b/tt_metal/llrt/llrt.cpp
@@ -174,32 +174,6 @@ void print_worker_cores(chip_id_t chip_id) {
     std::cout << std::endl << std::endl;
 }
 
-CircularBufferConfigVec create_circular_buffer_config_vector() {
-    CircularBufferConfigVec circular_buffer_config_vec(
-        NUM_CIRCULAR_BUFFERS * UINT32_WORDS_PER_CIRCULAR_BUFFER_CONFIG, 0);  // init to 0's
-    return circular_buffer_config_vec;
-}
-
-void set_config_for_circular_buffer(
-    CircularBufferConfigVec &circular_buffer_config_vec,
-    uint32_t circular_buffer_index,
-    uint32_t addr_in_bytes,
-    uint32_t size_in_bytes,
-    uint32_t num_pages) {
-
-    uint32_t page_size = size_in_bytes / num_pages;
-    circular_buffer_config_vec.at(UINT32_WORDS_PER_CIRCULAR_BUFFER_CONFIG * circular_buffer_index) =
-        addr_in_bytes >> 4;  // convert to addr in 16B words
-    circular_buffer_config_vec.at(UINT32_WORDS_PER_CIRCULAR_BUFFER_CONFIG * circular_buffer_index + 1) =
-        size_in_bytes >> 4;  // convert to addr in 16B words
-    circular_buffer_config_vec.at(UINT32_WORDS_PER_CIRCULAR_BUFFER_CONFIG * circular_buffer_index + 2) = num_pages;
-    circular_buffer_config_vec.at(UINT32_WORDS_PER_CIRCULAR_BUFFER_CONFIG * circular_buffer_index + 3) = page_size >> 4;
-}
-
-void write_circular_buffer_config_vector_to_core(chip_id_t chip, const CoreCoord &core, CircularBufferConfigVec circular_buffer_config_vec) {
-    write_hex_vec_to_core(chip, core, circular_buffer_config_vec, CIRCULAR_BUFFER_CONFIG_BASE);
-}
-
 ll_api::memory read_mem_from_core(chip_id_t chip, const CoreCoord &core, const ll_api::memory& mem, uint64_t local_init_addr) {
 
     ll_api::memory read_mem;

--- a/tt_metal/llrt/llrt.hpp
+++ b/tt_metal/llrt/llrt.hpp
@@ -52,7 +52,6 @@ using NUM_REPETITIONS = std::uint32_t;
 
 using WorkerCore = tt_cxy_pair;
 using WorkerCores = std::vector<WorkerCore>;
-using CircularBufferConfigVec = std::vector<uint32_t>;
 
 ll_api::memory get_risc_binary(string path);
 uint16_t get_binary_code_size16(const ll_api::memory &mem, int riscv_id);
@@ -90,18 +89,6 @@ inline bool is_ethernet_core(const CoreCoord &core, chip_id_t chip_id) {
     return std::find(soc_desc.physical_ethernet_cores.begin(), soc_desc.physical_ethernet_cores.end(), core) !=
            soc_desc.physical_ethernet_cores.end();
 }
-
-CircularBufferConfigVec create_circular_buffer_config_vector();
-
-void set_config_for_circular_buffer(
-    CircularBufferConfigVec &circular_buffer_config_vec,
-    uint32_t circular_buffer_index,
-    uint32_t addr_in_bytes,
-    uint32_t size_in_bytes,
-    uint32_t num_pages);
-
-void write_circular_buffer_config_vector_to_core(
-    chip_id_t chip, const CoreCoord &core, CircularBufferConfigVec circular_buffer_config_vec);
 
 uint32_t generate_risc_startup_addr(bool is_eth_core);
 void program_risc_startup_addr(chip_id_t chip_id, const CoreCoord &core);

--- a/tt_metal/tt_metal.cpp
+++ b/tt_metal/tt_metal.cpp
@@ -719,23 +719,28 @@ bool ConfigureDeviceWithProgram(Device *device, Program &program, bool fd_bootlo
             // TODO: add support for CB for ethernet cores
             if (core_type == CoreType::WORKER) {
                 // CircularBufferConfigVec -- common across all kernels, so written once to the core
-                llrt::CircularBufferConfigVec circular_buffer_config_vec = llrt::create_circular_buffer_config_vector();
+                std::vector<uint32_t> circular_buffer_config_vec(NUM_CIRCULAR_BUFFERS * UINT32_WORDS_PER_CIRCULAR_BUFFER_CONFIG, 0);
 
                 auto cbs_on_core = program.circular_buffers_on_core(logical_core);
                 for (auto circular_buffer : cbs_on_core) {
                     for (uint32_t buffer_index : circular_buffer->buffer_indices()) {
-                        llrt::set_config_for_circular_buffer(
-                            circular_buffer_config_vec,
-                            buffer_index,
-                            circular_buffer->address(),
-                            circular_buffer->size(),
-                            circular_buffer->num_pages(buffer_index));
+                        uint32_t addr_in_bytes = circular_buffer->address();
+                        uint32_t size_in_bytes = circular_buffer->size();
+                        uint32_t num_pages = circular_buffer->num_pages(buffer_index);
+                        uint32_t page_size = size_in_bytes / num_pages;
+                        circular_buffer_config_vec.at(UINT32_WORDS_PER_CIRCULAR_BUFFER_CONFIG * buffer_index) =
+                            addr_in_bytes >> 4;  // convert to addr in 16B words
+                        circular_buffer_config_vec.at(UINT32_WORDS_PER_CIRCULAR_BUFFER_CONFIG * buffer_index + 1) =
+                            size_in_bytes >> 4;  // convert to addr in 16B words
+                        circular_buffer_config_vec.at(UINT32_WORDS_PER_CIRCULAR_BUFFER_CONFIG * buffer_index + 2) = num_pages;
+                        circular_buffer_config_vec.at(UINT32_WORDS_PER_CIRCULAR_BUFFER_CONFIG * buffer_index + 3) = page_size >> 4;
                     }
                 }  // PROF_END("CBS")
 
                 if (cbs_on_core.size()) {
-                    llrt::write_circular_buffer_config_vector_to_core(
-                        device_id, physical_core, circular_buffer_config_vec);
+                    uint64_t kernel_config_base = hal.get_dev_addr(index, HalMemAddrType::KERNEL_CONFIG);
+                    uint64_t addr = kernel_config_base + program.get_program_config(index).cb_offset;
+                    llrt::write_hex_vec_to_core(device_id, physical_core, circular_buffer_config_vec, addr);
                 }
             }
             program.init_semaphores(*device, logical_core, index);


### PR DESCRIPTION
### Ticket
#4984 

### Problem description
Feature: move CB configs to ring buffer

### What's changed
CB configs are no longer statically allocated

### Checklist
- [ ] Post commit CI passes
- [ ] Blackhole Post commit (if applicable)
- [ ] Model regression CI testing passes (if applicable)
- [ ] New/Existing tests provide coverage for changes
