### PR TITLE
#11768: Fix watcher pause feature

### DIFF
--- a/tests/tt_metal/tt_metal/unit_tests_common/watcher/test_pause.cpp
+++ b/tests/tt_metal/tt_metal/unit_tests_common/watcher/test_pause.cpp
@@ -123,11 +123,11 @@ static void RunTest(WatcherFixture* fixture, Device* device) {
             expected_strings.push_back(expected);
         }
     }
-    EXPECT_TRUE(FileContainsAllStrings(fixture->log_file_name, expected_strings));
+    // See #10527
+    // EXPECT_TRUE(FileContainsAllStrings(fixture->log_file_name, expected_strings));
 }
 
-// See #10527
-TEST_F(WatcherFixture, DISABLED_TestWatcherPause) {
+TEST_F(WatcherFixture, TestWatcherPause) {
     for (Device* device : this->devices_) {
         this->RunTestOnDevice(RunTest, device);
     }

--- a/tt_metal/hw/inc/debug/pause.h
+++ b/tt_metal/hw/inc/debug/pause.h
@@ -6,12 +6,13 @@
 
 #include "watcher_common.h"
 #include "status.h"
+#include "debug/pause.h"
 
 #if defined(WATCHER_ENABLED) && !defined(WATCHER_DISABLE_PAUSE)
 
 void watcher_pause() {
     // Write the pause flag for this core into the memory mailbox for host to read.
-    debug_pause_msg_t tt_l1_ptr *pause_msg = GET_MAILBOX_ADDRESS_DEV(pause_status);
+    debug_pause_msg_t tt_l1_ptr *pause_msg = GET_MAILBOX_ADDRESS_DEV(watcher.pause_status);
     pause_msg->flags[debug_get_which_riscv()] = 1;
 
     // Wait for the pause flag to be cleared.


### PR DESCRIPTION
Watcher pause test was disabled due to instability, and so it didn't get picked up in the latest round of mailbox changes. Fix the bug and re-enable the test (without log checking, due to #10527).

CI running: https://github.com/tenstorrent/tt-metal/actions/runs/10512775563
