### PR TITLE
#10866: Read profiler buffer with `EnqueueReadBuffer` in fast dispatch mode

### DIFF
--- a/tests/tt_metal/tools/profiler/test_device_profiler.py
+++ b/tests/tt_metal/tools/profiler/test_device_profiler.py
@@ -165,12 +165,12 @@ def test_dispatch_cores():
     ZONE_COUNT = 37
     REF_COUNT_DICT = {
         "grayskull": {
-            "Tensix CQ Dispatch": 11,
-            "Tensix CQ Prefetch": 14,
+            "Tensix CQ Dispatch": 16,
+            "Tensix CQ Prefetch": 21,
         },
         "wormhole_b0": {
-            "Tensix CQ Dispatch": 11,
-            "Tensix CQ Prefetch": 14,
+            "Tensix CQ Dispatch": 16,
+            "Tensix CQ Prefetch": 21,
         },
     }
 

--- a/tt_metal/programming_examples/profiler/test_multi_op/test_multi_op.cpp
+++ b/tt_metal/programming_examples/profiler/test_multi_op/test_multi_op.cpp
@@ -58,7 +58,7 @@ int main(int argc, char **argv) {
 
         // Run 2
         RunCustomCycle(device, PROFILER_OP_SUPPORT_COUNT);
-        Finish(device->command_queue());
+        tt_metal::detail::DumpDeviceProfileResults(device);
 
         pass &= tt_metal::CloseDevice(device);
 

--- a/tt_metal/tools/profiler/profiler.hpp
+++ b/tt_metal/tools/profiler/profiler.hpp
@@ -118,7 +118,7 @@ class DeviceProfiler {
         void setOutputDir(const std::string& new_output_dir);
 
         //Traverse all cores on the device and dump the device profile results
-        void dumpResults(Device *device, const vector<CoreCoord> &worker_cores);
+        void dumpResults(Device *device, const vector<CoreCoord> &worker_cores, bool lastDump);
 };
 
 }  // namespace tt_metal

--- a/tt_metal/tools/profiler/tt_metal_profiler.cpp
+++ b/tt_metal/tools/profiler/tt_metal_profiler.cpp
@@ -438,7 +438,7 @@ void DumpDeviceProfileResults(Device *device, std::vector<CoreCoord> &worker_cor
                 syncDeviceHost (device, SYNC_CORE, tt_metal_device_profiler_map.at(device_id).sync_program, false);
             }
             tt_metal_device_profiler_map.at(device_id).setDeviceArchitecture(device->arch());
-            tt_metal_device_profiler_map.at(device_id).dumpResults(device, worker_cores);
+            tt_metal_device_profiler_map.at(device_id).dumpResults(device, worker_cores, lastDump);
             if (lastDump)
             {
                 // Process is ending, no more device dumps are coming, reset your ref on the buffer so deallocate is the last


### PR DESCRIPTION
### Ticket
[Issue](https://github.com/tenstorrent/tt-metal/issues/10866)
 
### Problem description
Host reading DRAM is very slow making device profiler dump take long.

### What's changed
In FD, have device push its results with `EnqueueReadBuffer`

### Checklist
- [x] Post commit CI passes https://github.com/tenstorrent/tt-metal/actions/runs/10514506502
- [x] T3K profiler https://github.com/tenstorrent/tt-metal/actions/runs/10514509657
- [x] Device perf https://github.com/tenstorrent/tt-metal/actions/runs/10514511551
- [x] uBenchmark https://github.com/tenstorrent/tt-metal/actions/runs/10512968964
