### PR TITLE
#0: remove extra arch-wormhole labels for single-card workflows

### DIFF
--- a/.github/workflows/fast-dispatch-full-regressions-and-models.yaml
+++ b/.github/workflows/fast-dispatch-full-regressions-and-models.yaml
@@ -106,7 +106,7 @@ jobs:
             {
               name: "[Unstable] N150 models",
               arch: wormhole_b0,
-              runs-on: ["cloud-virtual-machine", "arch-wormhole_b0", "N150", "in-service", "mount-cloud-weka"],
+              runs-on: ["cloud-virtual-machine", "N150", "in-service", "mount-cloud-weka"],
               cmd: tests/scripts/single_card/nightly/run_wh_b0_unstable.sh,
               timeout: 55
             },

--- a/.github/workflows/perf-device-models-impl.yaml
+++ b/.github/workflows/perf-device-models-impl.yaml
@@ -11,8 +11,8 @@ jobs:
       fail-fast: false
       matrix:
         test-info: [
-          {name: "GS", arch: grayskull, runs-on: ["perf-no-reset-grayskull", "bare-metal"], machine-type: "bare_metal", timeout: 40},
-          {name: "N300 WH B0", arch: wormhole_b0, runs-on: ["arch-wormhole_b0", "N300", "pipeline-perf", "bare-metal", "in-service"], machine-type: "bare_metal", timeout: 30},
+          {name: "GS", arch: grayskull, runs-on: ["perf-no-reset-grayskull", "bare-metal", "in-service"], machine-type: "bare_metal", timeout: 40},
+          {name: "N300 WH B0", arch: wormhole_b0, runs-on: ["N300", "pipeline-perf", "bare-metal", "in-service"], machine-type: "bare_metal", timeout: 30},
         ]
     name: "${{ matrix.test-info.name }} device perf"
     env:

--- a/.github/workflows/single-card-demo-tests-impl.yaml
+++ b/.github/workflows/single-card-demo-tests-impl.yaml
@@ -12,13 +12,13 @@ jobs:
           {
             name: "N150",
             arch: wormhole_b0,
-            runs-on: ["cloud-virtual-machine", "arch-wormhole_b0", "N150", "in-service", "mount-cloud-weka"],
+            runs-on: ["cloud-virtual-machine", "N150", "in-service", "mount-cloud-weka"],
             cmd: './tests/scripts/run_tests.sh --tt-arch wormhole_b0 --pipeline-type demos_single_card_n150 --dispatch-mode ""'
           },
           {
             name: "N300",
             arch: wormhole_b0,
-            runs-on: ["cloud-virtual-machine", "arch-wormhole_b0", "N300", "in-service", "mount-cloud-weka"],
+            runs-on: ["cloud-virtual-machine", "N300", "in-service", "mount-cloud-weka"],
             cmd: './tests/scripts/run_tests.sh --tt-arch wormhole_b0 --pipeline-type demos_single_card_n300 --dispatch-mode ""'
           }
         ]

--- a/.github/workflows/tg-unit-tests.yaml
+++ b/.github/workflows/tg-unit-tests.yaml
@@ -19,7 +19,7 @@ jobs:
           {
             name: "TG UMD unit tests",
             arch: wormhole_b0,
-            runs-on: ["arch-wormhole_b0", "config-tg", "in-service", "runner-test", "bare-metal", "pipeline-functional"],
+            runs-on: ["arch-wormhole_b0", "config-tg", "in-service", "bare-metal", "pipeline-functional"],
             cmd: "./build/test/umd/galaxy/unit_tests_glx"
           },
         ]

--- a/.github/workflows/umd-unit-tests.yaml
+++ b/.github/workflows/umd-unit-tests.yaml
@@ -40,6 +40,7 @@ jobs:
     name: ${{ inputs.arch }} ${{ inputs.runner-label }}
     runs-on:
       - ${{ inputs.runner-label }}
+      - cloud-virtual-machines
       - "in-service"
     env:
       TT_METAL_ENV: ${{ vars.TT_METAL_ENV }}


### PR DESCRIPTION
### Ticket
Link to Github Issue https://github.com/tenstorrent/tt-metal/issues/11038

### Problem description
New workflows merged recently didn't capture new runner-label PR

### What's changed
Describe the approach used to solve the problem.
Summarize the changes made and its impact.

### Checklist
- [ ] Post commit CI passes
- [ ] Blackhole Post commit (if applicable)
- [ ] Model regression CI testing passes (if applicable)
- [ ] New/Existing tests provide coverage for changes
