### PR TITLE
#0: Refactor Python dynamic modules creation

### DIFF
--- a/ttnn/ttnn/__init__.py
+++ b/ttnn/ttnn/__init__.py
@@ -202,15 +202,16 @@ release_trace = ttnn._ttnn.operations.core.release_trace
 
 
 from ttnn.decorators import (
-    register_python_operation,
-    register_cpp_operation,
     attach_golden_function,
-    query_registered_operations,
+    create_module_if_not_exists,
     dump_operations,
-    register_pre_operation_hook,
-    register_post_operation_hook,
     get_golden_function,
     get_fallback_function,
+    query_registered_operations,
+    register_cpp_operation,
+    register_post_operation_hook,
+    register_pre_operation_hook,
+    register_python_operation,
 )
 
 
@@ -218,7 +219,10 @@ def auto_register_ttnn_cpp_operations(module):
     for attribute_name in dir(module):
         attribute = getattr(module, attribute_name)
         if hasattr(attribute, "__ttnn_operation__") and attribute.__ttnn_operation__ is None:
-            setattr(module, attribute_name, ttnn.register_cpp_operation()(attribute))
+            full_name = attribute.python_fully_qualified_name
+            module_path, _, func_name = full_name.rpartition(".")
+            target_module = create_module_if_not_exists(module_path)
+            register_cpp_operation(target_module, func_name, attribute)
         elif isinstance(attribute, ModuleType):
             auto_register_ttnn_cpp_operations(attribute)
 
@@ -285,7 +289,7 @@ from ttnn.operations.reduction import (
 )
 
 from ttnn.operations.conv2d import Conv2d, Conv2dConfig, get_conv_output_dim, get_conv_padded_input_shape_and_mem_config
-from ttnn.operations.pool import TTPyMaxPool, max_pool2d, max_pool2d_legacy, MaxPool2d, global_avg_pool2d, avg_pool2d
+from ttnn.operations.pool import TTPyMaxPool, max_pool2d, max_pool2d_legacy, MaxPool2d, avg_pool2d
 from ttnn.operations.conv1d import Conv1d, Conv1dConfig
 
 from ttnn.operations.transformer import SDPAProgramConfig

--- a/ttnn/ttnn/decorators.py
+++ b/ttnn/ttnn/decorators.py
@@ -2,14 +2,17 @@
 
 # SPDX-License-Identifier: Apache-2.0
 
-from contextlib import contextmanager
 import dataclasses
-from functools import wraps
-import inspect
-import os
+import sys
 import time
 import traceback
 import types
+
+from contextlib import contextmanager
+from functools import wraps
+from importlib.machinery import ModuleSpec
+from importlib.util import module_from_spec
+from typing import Callable
 
 from loguru import logger
 
@@ -303,10 +306,10 @@ def posprocess_global_golden_function_outputs(outputs, golden_outputs):
 @dataclasses.dataclass
 class FastOperation:
     python_fully_qualified_name: str
-    function: callable
-    preprocess_golden_function_inputs: callable
-    golden_function: callable
-    postprocess_golden_function_outputs: callable
+    function: Callable
+    preprocess_golden_function_inputs: Callable
+    golden_function: Callable
+    postprocess_golden_function_outputs: Callable
     is_cpp_operation: bool
     is_experimental: bool
 
@@ -329,10 +332,10 @@ class FastOperation:
 @dataclasses.dataclass
 class Operation:
     python_fully_qualified_name: str
-    function: callable
-    preprocess_golden_function_inputs: callable
-    golden_function: callable
-    postprocess_golden_function_outputs: callable
+    function: Callable
+    preprocess_golden_function_inputs: Callable
+    golden_function: Callable
+    postprocess_golden_function_outputs: Callable
     is_cpp_operation: bool
     is_experimental: bool
 
@@ -607,7 +610,23 @@ class Operation:
     __doc__ = property(lambda self: self.decorated_function.__doc__)
 
 
-REGISTERED_OPERATIONS = set()
+class RegisteredOperations:
+    def __init__(self):
+        self.operations = set()
+
+    def __iter__(self):
+        return iter(self.operations)
+
+    def __contains__(self, operation):
+        return operation in self.operations
+
+    def add(self, operation, name):
+        if operation in self.operations:
+            raise RuntimeError(f'Operation with name "{name}" is already registered')
+        self.operations.add(operation)
+
+
+REGISTERED_OPERATIONS = RegisteredOperations()
 
 
 def query_registered_operations(include_experimental=False):
@@ -690,69 +709,43 @@ def attach_golden_function(
     )
 
 
-def export_operation(python_fully_qualified_name, operation, is_method):
-    """
-    This function is used to export the operation to the ttnn module using the fully qualified name
-    For example, an operation named "ttnn.add" would be exported as ttnn.add.
-    Any level of nesting is possible.
-    """
-    global REGISTERED_OPERATIONS
+def create_module_if_not_exists(module_name):
+    if module_name in sys.modules:
+        return sys.modules[module_name]
 
-    if operation in REGISTERED_OPERATIONS:
-        raise RuntimeError(f'Operation with name "{python_fully_qualified_name}" is already registered')
+    # Recursively create parent modules if they don't exist
+    parent_module_name, _, child_module_name = module_name.rpartition(".")
+    if parent_module_name:
+        parent_module = create_module_if_not_exists(parent_module_name)
+    else:
+        parent_module = None
 
-    REGISTERED_OPERATIONS.add(operation)
+    # Create the module
+    new_module = module_from_spec(ModuleSpec(module_name, None))
 
-    # Do not export methods
-    if is_method:
-        return
-
-    module_path = python_fully_qualified_name.split(".")  # "ttnn.add" -> ["ttnn", "add"]
-
-    if len(module_path) < 2:
-        raise RuntimeError("Module path have to have at least 2 tokens!")
-
-    if module_path[0] != "ttnn":
-        raise RuntimeError('Module path must start with "ttnn."')
-
-    module_path = module_path[1:]  # ["ttnn", "add"] -> ["add"]
-
-    def recursive_helper(module, path):
-        submodule_name, *rest = path
-        if not rest:
-            setattr(module, submodule_name, operation)
-            return
-
-        submodule = getattr(module, submodule_name, types.ModuleType(submodule_name))
-        setattr(module, submodule_name, submodule)
-        recursive_helper(submodule, rest)
-
-    recursive_helper(ttnn, module_path)
+    if parent_module:
+        setattr(parent_module, child_module_name, new_module)
+    sys.modules[module_name] = new_module
+    return new_module
 
 
-def register_cpp_operation():
-    def operation_decorator(function: callable):
-        is_cpp_operation = hasattr(function, "__ttnn_operation__")
+def register_cpp_operation(target_module: types.ModuleType, func_name: str, function: Callable):
+    operation_class = FastOperation if ttnn.CONFIG.enable_fast_runtime_mode else Operation
 
-        if not is_cpp_operation:
-            raise RuntimeError(f"{function} is not a C++ operation)")
+    operation = operation_class(
+        python_fully_qualified_name=function.python_fully_qualified_name,
+        function=function,
+        golden_function=None,
+        preprocess_golden_function_inputs=None,
+        postprocess_golden_function_outputs=None,
+        is_cpp_operation=True,
+        is_experimental=False,
+    )
 
-        operation_class = FastOperation if ttnn.CONFIG.enable_fast_runtime_mode else Operation
+    REGISTERED_OPERATIONS.add(operation, func_name)
+    setattr(target_module, func_name, operation)
 
-        operation = operation_class(
-            python_fully_qualified_name=function.python_fully_qualified_name,
-            function=function,
-            golden_function=None,
-            preprocess_golden_function_inputs=None,
-            postprocess_golden_function_outputs=None,
-            is_cpp_operation=True,
-            is_experimental=False,
-        )
-
-        export_operation(function.python_fully_qualified_name, operation, is_method=False)
-        return operation
-
-    return operation_decorator
+    return operation
 
 
 def register_python_operation(
@@ -767,7 +760,7 @@ def register_python_operation(
 ):
     python_fully_qualified_name = name
 
-    def operation_decorator(function: callable):
+    def operation_decorator(function: Callable):
         is_cpp_operation = hasattr(function, "__ttnn_operation__")
 
         if is_cpp_operation:
@@ -807,7 +800,18 @@ def register_python_operation(
             preprocess_golden_function_inputs=preprocess_golden_function_inputs,
             postprocess_golden_function_outputs=postprocess_golden_function_outputs,
         )
-        export_operation(python_fully_qualified_name, operation, is_method)
+
+        if not is_method:  # Do not export methods
+            module_path, _, func_name = python_fully_qualified_name.rpartition(".")
+            if not module_path:
+                raise RuntimeError("Module path have to have at least 2 tokens!")
+            if not module_path.startswith("ttnn"):
+                raise RuntimeError('Module path must start with "ttnn."')
+
+            target_module = create_module_if_not_exists(module_path)
+
+            REGISTERED_OPERATIONS.add(operation, python_fully_qualified_name)
+            setattr(target_module, func_name, operation)
 
         # Wrap method appropriately in order to avoid errors
         if is_method:

--- a/ttnn/ttnn/experimental_loader/__init__.py
+++ b/ttnn/ttnn/experimental_loader/__init__.py
@@ -8,6 +8,8 @@ import ttnn._ttnn
 import ttnn
 import types
 
+from ttnn.decorators import create_module_if_not_exists
+
 
 def register_tt_lib_operations_as_ttnn_operations(module):
     module_name = module.__name__
@@ -35,14 +37,8 @@ def register_tt_lib_operations_as_ttnn_operations(module):
         elif isinstance(attribute, types.ModuleType):
             register_tt_lib_operations_as_ttnn_operations(attribute)
         else:
-            ttnn_module = ttnn
-            ttnn_module_path = ttnn_module_name.split(".")[1:]
-            while ttnn_module_path:
-                ttnn_submodule_name = ttnn_module_path.pop(0)
-                ttnn_submodule = getattr(ttnn_module, ttnn_submodule_name, types.ModuleType(ttnn_submodule_name))
-                setattr(ttnn_module, ttnn_submodule_name, ttnn_submodule)
-                ttnn_module = ttnn_submodule
-            setattr(ttnn_module, attribute_name, attribute)
+            target_module = create_module_if_not_exists(ttnn_module_name)
+            setattr(target_module, attribute_name, attribute)
 
 
 register_tt_lib_operations_as_ttnn_operations(ttnn._ttnn.deprecated.tensor)

--- a/ttnn/ttnn/operations/binary.py
+++ b/ttnn/ttnn/operations/binary.py
@@ -197,7 +197,7 @@ def _golden_function_addalpha(input_tensor_a, input_tensor_b, alpha, *args, **kw
     return torch.add(input_tensor_a, input_tensor_b, alpha=alpha)
 
 
-ttnn.attach_golden_function(ttnn._ttnn.operations.binary.addalpha, golden_function=_golden_function_addalpha)
+ttnn.attach_golden_function(ttnn.addalpha, golden_function=_golden_function_addalpha)
 
 
 def _golden_function_subalpha(input_tensor_a, input_tensor_b, alpha, *args, **kwargs):
@@ -206,7 +206,7 @@ def _golden_function_subalpha(input_tensor_a, input_tensor_b, alpha, *args, **kw
     return torch.sub(input_tensor_a, input_tensor_b, alpha=alpha)
 
 
-ttnn.attach_golden_function(ttnn._ttnn.operations.binary.subalpha, golden_function=_golden_function_subalpha)
+ttnn.attach_golden_function(ttnn.subalpha, golden_function=_golden_function_subalpha)
 
 
 def _golden_function_xlogy(input_tensor_a, input_tensor_b, *args, **kwargs):
@@ -215,7 +215,7 @@ def _golden_function_xlogy(input_tensor_a, input_tensor_b, *args, **kwargs):
     return torch.xlogy(input_tensor_a, input_tensor_b)
 
 
-ttnn.attach_golden_function(ttnn._ttnn.operations.binary.xlogy, golden_function=_golden_function_xlogy)
+ttnn.attach_golden_function(ttnn.xlogy, golden_function=_golden_function_xlogy)
 
 
 def _golden_function_hypot(input_tensor_a, input_tensor_b, *args, **kwargs):
@@ -224,7 +224,7 @@ def _golden_function_hypot(input_tensor_a, input_tensor_b, *args, **kwargs):
     return torch.hypot(input_tensor_a, input_tensor_b)
 
 
-ttnn.attach_golden_function(ttnn._ttnn.operations.binary.hypot, golden_function=_golden_function_hypot)
+ttnn.attach_golden_function(ttnn.hypot, golden_function=_golden_function_hypot)
 
 
 def _golden_function_maximum(input_tensor_a, input_tensor_b, *args, **kwargs):
@@ -233,7 +233,7 @@ def _golden_function_maximum(input_tensor_a, input_tensor_b, *args, **kwargs):
     return torch.maximum(input_tensor_a, input_tensor_b)
 
 
-ttnn.attach_golden_function(ttnn._ttnn.operations.binary.maximum, golden_function=_golden_function_maximum)
+ttnn.attach_golden_function(ttnn.maximum, golden_function=_golden_function_maximum)
 
 
 def _golden_function_minimum(input_tensor_a, input_tensor_b, *args, **kwargs):
@@ -242,7 +242,7 @@ def _golden_function_minimum(input_tensor_a, input_tensor_b, *args, **kwargs):
     return torch.minimum(input_tensor_a, input_tensor_b)
 
 
-ttnn.attach_golden_function(ttnn._ttnn.operations.binary.minimum, golden_function=_golden_function_minimum)
+ttnn.attach_golden_function(ttnn.minimum, golden_function=_golden_function_minimum)
 
 
 def _golden_function_logical_xor(input_tensor_a, input_tensor_b, *args, **kwargs):
@@ -251,7 +251,7 @@ def _golden_function_logical_xor(input_tensor_a, input_tensor_b, *args, **kwargs
     return torch.logical_xor(input_tensor_a, input_tensor_b)
 
 
-ttnn.attach_golden_function(ttnn._ttnn.operations.binary.logical_xor, golden_function=_golden_function_logical_xor)
+ttnn.attach_golden_function(ttnn.logical_xor, golden_function=_golden_function_logical_xor)
 
 
 def _golden_function_logical_and(input_tensor_a, input_tensor_b, *args, **kwargs):
@@ -260,7 +260,7 @@ def _golden_function_logical_and(input_tensor_a, input_tensor_b, *args, **kwargs
     return torch.logical_and(input_tensor_a, input_tensor_b)
 
 
-ttnn.attach_golden_function(ttnn._ttnn.operations.binary.logical_and, golden_function=_golden_function_logical_and)
+ttnn.attach_golden_function(ttnn.logical_and, golden_function=_golden_function_logical_and)
 
 
 def _golden_function_logical_or(input_tensor_a, input_tensor_b, *args, **kwargs):
@@ -269,7 +269,7 @@ def _golden_function_logical_or(input_tensor_a, input_tensor_b, *args, **kwargs)
     return torch.logical_or(input_tensor_a, input_tensor_b)
 
 
-ttnn.attach_golden_function(ttnn._ttnn.operations.binary.logical_or, golden_function=_golden_function_logical_or)
+ttnn.attach_golden_function(ttnn.logical_or, golden_function=_golden_function_logical_or)
 
 
 def _golden_function_atan2(input_tensor_a, input_tensor_b, *args, **kwargs):
@@ -278,7 +278,7 @@ def _golden_function_atan2(input_tensor_a, input_tensor_b, *args, **kwargs):
     return torch.atan2(input_tensor_a, input_tensor_b)
 
 
-ttnn.attach_golden_function(ttnn._ttnn.operations.binary.atan2, golden_function=_golden_function_atan2)
+ttnn.attach_golden_function(ttnn.atan2, golden_function=_golden_function_atan2)
 
 
 def _golden_function_nextafter(input_tensor_a, input_tensor_b, *args, **kwargs):
@@ -287,7 +287,7 @@ def _golden_function_nextafter(input_tensor_a, input_tensor_b, *args, **kwargs):
     return torch.nextafter(input_tensor_a, input_tensor_b)
 
 
-ttnn.attach_golden_function(ttnn._ttnn.operations.binary.nextafter, golden_function=_golden_function_nextafter)
+ttnn.attach_golden_function(ttnn.nextafter, golden_function=_golden_function_nextafter)
 
 
 def _golden_function_isclose(input_tensor_a, input_tensor_b, *args, rtol=1e-05, atol=1e-08, equal_nan=False, **kwargs):
@@ -296,7 +296,7 @@ def _golden_function_isclose(input_tensor_a, input_tensor_b, *args, rtol=1e-05, 
     return torch.isclose(input_tensor_a, input_tensor_b, rtol=rtol, atol=atol, equal_nan=equal_nan)
 
 
-ttnn.attach_golden_function(ttnn._ttnn.operations.binary.isclose, golden_function=_golden_function_isclose)
+ttnn.attach_golden_function(ttnn.isclose, golden_function=_golden_function_isclose)
 
 
 def _golden_function_div(input_tensor_a, input_tensor_b, round_mode, *args, **kwargs):
@@ -307,7 +307,7 @@ def _golden_function_div(input_tensor_a, input_tensor_b, round_mode, *args, **kw
     return torch.div(input_tensor_a, input_tensor_b, rounding_mode=round_mode)
 
 
-ttnn.attach_golden_function(ttnn._ttnn.operations.binary.div, golden_function=_golden_function_div)
+ttnn.attach_golden_function(ttnn.div, golden_function=_golden_function_div)
 
 
 def _golden_function_div_no_nan(input_tensor_a, input_tensor_b, *args, **kwargs):
@@ -322,7 +322,7 @@ def _golden_function_div_no_nan(input_tensor_a, input_tensor_b, *args, **kwargs)
         return torch.where(input_tensor_b == 0, 0, input_tensor_a / input_tensor_b)
 
 
-ttnn.attach_golden_function(ttnn._ttnn.operations.binary.div_no_nan, golden_function=_golden_function_div_no_nan)
+ttnn.attach_golden_function(ttnn.div_no_nan, golden_function=_golden_function_div_no_nan)
 
 
 def _golden_function_floor_div(input_tensor_a, input_tensor_b, *args, **kwargs):
@@ -331,7 +331,7 @@ def _golden_function_floor_div(input_tensor_a, input_tensor_b, *args, **kwargs):
     return torch.floor_divide(input_tensor_a, input_tensor_b)
 
 
-ttnn.attach_golden_function(ttnn._ttnn.operations.binary.floor_div, golden_function=_golden_function_floor_div)
+ttnn.attach_golden_function(ttnn.floor_div, golden_function=_golden_function_floor_div)
 
 
 def _golden_function_remainder(input_tensor_a, input_tensor_b, *args, **kwargs):
@@ -340,7 +340,7 @@ def _golden_function_remainder(input_tensor_a, input_tensor_b, *args, **kwargs):
     return torch.remainder(input_tensor_a, input_tensor_b)
 
 
-ttnn.attach_golden_function(ttnn._ttnn.operations.binary.remainder, golden_function=_golden_function_remainder)
+ttnn.attach_golden_function(ttnn.remainder, golden_function=_golden_function_remainder)
 
 
 def _golden_function_fmod(input_tensor_a, input_tensor_b, *args, **kwargs):
@@ -349,7 +349,7 @@ def _golden_function_fmod(input_tensor_a, input_tensor_b, *args, **kwargs):
     return torch.fmod(input_tensor_a, input_tensor_b)
 
 
-ttnn.attach_golden_function(ttnn._ttnn.operations.binary.fmod, golden_function=_golden_function_fmod)
+ttnn.attach_golden_function(ttnn.fmod, golden_function=_golden_function_fmod)
 
 
 def torch_squared_difference(x, y, *args, **kwargs):
@@ -363,7 +363,7 @@ def _golden_function_scatter(input_tensor_a, input_tensor_b, *args, **kwargs):
     return input_tensor_b
 
 
-ttnn.attach_golden_function(ttnn._ttnn.operations.binary.scatter, golden_function=_golden_function_scatter)
+ttnn.attach_golden_function(ttnn.scatter, golden_function=_golden_function_scatter)
 
 
 def _golden_function_outer(input_tensor_a, input_tensor_b, *args, **kwargs):
@@ -372,7 +372,7 @@ def _golden_function_outer(input_tensor_a, input_tensor_b, *args, **kwargs):
     return torch.outer(input_tensor_a.squeeze(), input_tensor_b.squeeze())
 
 
-ttnn.attach_golden_function(ttnn._ttnn.operations.binary.outer, golden_function=_golden_function_outer)
+ttnn.attach_golden_function(ttnn.outer, golden_function=_golden_function_outer)
 
 
 def _golden_function_polyval(input_tensor_a, coeffs, *args, **kwargs):
@@ -382,7 +382,7 @@ def _golden_function_polyval(input_tensor_a, coeffs, *args, **kwargs):
     return result
 
 
-ttnn.attach_golden_function(ttnn._ttnn.operations.binary.polyval, golden_function=_golden_function_polyval)
+ttnn.attach_golden_function(ttnn.polyval, golden_function=_golden_function_polyval)
 
 
 def _golden_function_gt_(input_tensor_a, input_tensor_b, *args, **kwargs):
@@ -391,7 +391,7 @@ def _golden_function_gt_(input_tensor_a, input_tensor_b, *args, **kwargs):
     return input_tensor_a.gt_(input_tensor_b)
 
 
-ttnn.attach_golden_function(ttnn._ttnn.operations.binary.gt_, golden_function=_golden_function_gt_)
+ttnn.attach_golden_function(ttnn.gt_, golden_function=_golden_function_gt_)
 
 
 def _golden_function_le_(input_tensor_a, input_tensor_b, *args, **kwargs):
@@ -400,7 +400,7 @@ def _golden_function_le_(input_tensor_a, input_tensor_b, *args, **kwargs):
     return input_tensor_a.le_(input_tensor_b)
 
 
-ttnn.attach_golden_function(ttnn._ttnn.operations.binary.le_, golden_function=_golden_function_le_)
+ttnn.attach_golden_function(ttnn.le_, golden_function=_golden_function_le_)
 
 
 def _golden_function_lt_(input_tensor_a, input_tensor_b, *args, **kwargs):
@@ -409,7 +409,7 @@ def _golden_function_lt_(input_tensor_a, input_tensor_b, *args, **kwargs):
     return input_tensor_a.lt_(input_tensor_b)
 
 
-ttnn.attach_golden_function(ttnn._ttnn.operations.binary.lt_, golden_function=_golden_function_lt_)
+ttnn.attach_golden_function(ttnn.lt_, golden_function=_golden_function_lt_)
 
 
 def _golden_function_ge_(input_tensor_a, input_tensor_b, *args, **kwargs):
@@ -418,7 +418,7 @@ def _golden_function_ge_(input_tensor_a, input_tensor_b, *args, **kwargs):
     return input_tensor_a.ge_(input_tensor_b)
 
 
-ttnn.attach_golden_function(ttnn._ttnn.operations.binary.ge_, golden_function=_golden_function_ge_)
+ttnn.attach_golden_function(ttnn.ge_, golden_function=_golden_function_ge_)
 
 
 def _golden_function_eq_(input_tensor_a, input_tensor_b, *args, **kwargs):
@@ -427,7 +427,7 @@ def _golden_function_eq_(input_tensor_a, input_tensor_b, *args, **kwargs):
     return input_tensor_a.eq_(input_tensor_b)
 
 
-ttnn.attach_golden_function(ttnn._ttnn.operations.binary.eq_, golden_function=_golden_function_eq_)
+ttnn.attach_golden_function(ttnn.eq_, golden_function=_golden_function_eq_)
 
 
 def _golden_function_ne_(input_tensor_a, input_tensor_b, *args, **kwargs):
@@ -436,7 +436,7 @@ def _golden_function_ne_(input_tensor_a, input_tensor_b, *args, **kwargs):
     return input_tensor_a.ne_(input_tensor_b)
 
 
-ttnn.attach_golden_function(ttnn._ttnn.operations.binary.ne_, golden_function=_golden_function_ne_)
+ttnn.attach_golden_function(ttnn.ne_, golden_function=_golden_function_ne_)
 
 
 __all__ = []

--- a/ttnn/ttnn/operations/data_movement.py
+++ b/ttnn/ttnn/operations/data_movement.py
@@ -82,7 +82,7 @@ def _golden_function(input_tensor, dims, **_):
     return torch.permute(input_tensor, dims)
 
 
-ttnn.attach_golden_function(ttnn._ttnn.operations.data_movement.permute, golden_function=_golden_function)
+ttnn.attach_golden_function(ttnn.permute, golden_function=_golden_function)
 
 
 def _golden_function(tensors, dim=0, **_):

--- a/ttnn/ttnn/operations/normalization.py
+++ b/ttnn/ttnn/operations/normalization.py
@@ -24,7 +24,7 @@ ttnn.attach_golden_function(
 )
 
 ttnn.attach_golden_function(
-    ttnn._ttnn.operations.normalization.softmax_in_place,
+    ttnn.softmax_in_place,
     golden_function=_golden_function,
 )
 
@@ -40,17 +40,17 @@ def _golden_function(input_tensor: ttnn.Tensor, scalar: float, attention_mask=No
 
 
 ttnn.attach_golden_function(
-    ttnn._ttnn.operations.normalization.scale_mask_softmax_in_place,
+    ttnn.scale_mask_softmax_in_place,
     golden_function=_golden_function,
 )
 
 ttnn.attach_golden_function(
-    ttnn._ttnn.operations.normalization.scale_mask_softmax,
+    ttnn.scale_mask_softmax,
     golden_function=_golden_function,
 )
 
 ttnn.attach_golden_function(
-    ttnn._ttnn.operations.normalization.scale_causal_mask_hw_dims_softmax_in_place,
+    ttnn.scale_causal_mask_hw_dims_softmax_in_place,
     golden_function=_golden_function,
 )
 
@@ -61,7 +61,13 @@ SoftmaxShardedMultiCoreProgramConfig = ttnn._ttnn.operations.normalization.Softm
 
 
 def _golden_function(
-    input_tensor: ttnn.Tensor, *, epsilon=1e-12, residual_input_tensor=None, weight=None, bias=None, **_
+    input_tensor: ttnn.Tensor,
+    *,
+    epsilon=1e-12,
+    residual_input_tensor=None,
+    weight=None,
+    bias=None,
+    **_,
 ):
     import torch
 

--- a/ttnn/ttnn/operations/pool.py
+++ b/ttnn/ttnn/operations/pool.py
@@ -431,9 +431,7 @@ def golden_global_avg_pool2d(input_tensor: ttnn.Tensor):
     return torch.nn.functional.global_avg_pool2d(input_tensor, output_size)
 
 
-global_avg_pool2d = ttnn.register_python_operation(
-    name="ttnn.global_avg_pool2d", golden_function=golden_global_avg_pool2d
-)(ttnn._ttnn.operations.pool.global_avg_pool2d)
+ttnn.attach_golden_function(ttnn.global_avg_pool2d, golden_global_avg_pool2d)
 
 avg_pool2d = ttnn.register_python_operation(name="ttnn.avg_pool2d", golden_function=golden_global_avg_pool2d)(
     ttnn._ttnn.operations.pool.avg_pool2d

--- a/ttnn/ttnn/operations/unary.py
+++ b/ttnn/ttnn/operations/unary.py
@@ -199,7 +199,7 @@ def _golden_function_pow(input_tensor_a, exponent, *args, **kwargs):
     return torch.pow(input_tensor_a, exponent)
 
 
-ttnn.attach_golden_function(ttnn._ttnn.operations.unary.pow, golden_function=_golden_function_pow)
+ttnn.attach_golden_function(ttnn.pow, golden_function=_golden_function_pow)
 
 
 def _golden_function_relu_min(input_tensor_a, *args, lower_limit, **kwargs):
@@ -208,7 +208,7 @@ def _golden_function_relu_min(input_tensor_a, *args, lower_limit, **kwargs):
     return torch.max(input_tensor_a, torch.tensor(lower_limit))
 
 
-ttnn.attach_golden_function(ttnn._ttnn.operations.unary.relu_min, golden_function=_golden_function_relu_min)
+ttnn.attach_golden_function(ttnn.relu_min, golden_function=_golden_function_relu_min)
 
 
 def _golden_function_relu_max(input_tensor_a, *args, upper_limit, **kwargs):
@@ -217,7 +217,7 @@ def _golden_function_relu_max(input_tensor_a, *args, upper_limit, **kwargs):
     return torch.relu(torch.min(input_tensor_a, torch.tensor(upper_limit)))
 
 
-ttnn.attach_golden_function(ttnn._ttnn.operations.unary.relu_max, golden_function=_golden_function_relu_max)
+ttnn.attach_golden_function(ttnn.relu_max, golden_function=_golden_function_relu_max)
 
 
 def _golden_function_heaviside(input_tensor_a, *args, value, **kwargs):
@@ -226,7 +226,7 @@ def _golden_function_heaviside(input_tensor_a, *args, value, **kwargs):
     return torch.heaviside(input_tensor_a, torch.tensor(value, dtype=input_tensor_a.dtype))
 
 
-ttnn.attach_golden_function(ttnn._ttnn.operations.unary.heaviside, golden_function=_golden_function_heaviside)
+ttnn.attach_golden_function(ttnn.heaviside, golden_function=_golden_function_heaviside)
 
 
 def _golden_function_polygamma(input_tensor_a, k, *args, **kwargs):
@@ -235,7 +235,7 @@ def _golden_function_polygamma(input_tensor_a, k, *args, **kwargs):
     return torch.special.polygamma(n=k, input=input_tensor_a)
 
 
-ttnn.attach_golden_function(ttnn._ttnn.operations.unary.polygamma, golden_function=_golden_function_polygamma)
+ttnn.attach_golden_function(ttnn.polygamma, golden_function=_golden_function_polygamma)
 
 
 def _golden_function_clamp(input_tensor_a, min, max, *args, **kwargs):
@@ -244,7 +244,7 @@ def _golden_function_clamp(input_tensor_a, min, max, *args, **kwargs):
     return torch.clamp(input=input_tensor_a, min=min, max=max)
 
 
-ttnn.attach_golden_function(ttnn._ttnn.operations.unary.clamp, golden_function=_golden_function_clamp)
+ttnn.attach_golden_function(ttnn.clamp, golden_function=_golden_function_clamp)
 
 
 def _golden_function_clip(input_tensor_a, min, max, *args, **kwargs):
@@ -253,7 +253,7 @@ def _golden_function_clip(input_tensor_a, min, max, *args, **kwargs):
     return torch.clip(input=input_tensor_a, min=min, max=max)
 
 
-ttnn.attach_golden_function(ttnn._ttnn.operations.unary.clip, golden_function=_golden_function_clip)
+ttnn.attach_golden_function(ttnn.clip, golden_function=_golden_function_clip)
 
 
 def _golden_function_round(input_tensor_a, decimal, *args, **kwargs):
@@ -262,7 +262,7 @@ def _golden_function_round(input_tensor_a, decimal, *args, **kwargs):
     return torch.round(input=input_tensor_a, decimals=decimal)
 
 
-ttnn.attach_golden_function(ttnn._ttnn.operations.unary.round, golden_function=_golden_function_round)
+ttnn.attach_golden_function(ttnn.round, golden_function=_golden_function_round)
 
 
 def _golden_function_selu(input_tensor_a, *args, **kwargs):
@@ -271,7 +271,7 @@ def _golden_function_selu(input_tensor_a, *args, **kwargs):
     return torch.nn.functional.selu(input_tensor_a)
 
 
-ttnn.attach_golden_function(ttnn._ttnn.operations.unary.selu, golden_function=_golden_function_selu)
+ttnn.attach_golden_function(ttnn.selu, golden_function=_golden_function_selu)
 
 
 def _golden_function_tanhshrink(input_tensor_a, *args, **kwargs):
@@ -280,7 +280,7 @@ def _golden_function_tanhshrink(input_tensor_a, *args, **kwargs):
     return torch.nn.functional.tanhshrink(input=input_tensor_a)
 
 
-ttnn.attach_golden_function(ttnn._ttnn.operations.unary.tanhshrink, golden_function=_golden_function_tanhshrink)
+ttnn.attach_golden_function(ttnn.tanhshrink, golden_function=_golden_function_tanhshrink)
 
 
 def _golden_function_threshold(input_tensor_a, threshold, value, *args, **kwargs):
@@ -289,7 +289,7 @@ def _golden_function_threshold(input_tensor_a, threshold, value, *args, **kwargs
     return torch.threshold(input_tensor_a, threshold, value)
 
 
-ttnn.attach_golden_function(ttnn._ttnn.operations.unary.threshold, golden_function=_golden_function_threshold)
+ttnn.attach_golden_function(ttnn.threshold, golden_function=_golden_function_threshold)
 
 
 def _golden_function_trunc(input_tensor_a, *args, **kwargs):
@@ -298,7 +298,7 @@ def _golden_function_trunc(input_tensor_a, *args, **kwargs):
     return torch.trunc(input=input_tensor_a)
 
 
-ttnn.attach_golden_function(ttnn._ttnn.operations.unary.trunc, golden_function=_golden_function_trunc)
+ttnn.attach_golden_function(ttnn.trunc, golden_function=_golden_function_trunc)
 
 
 def _golden_function_rsub(input_tensor_a, value, *args, **kwargs):
@@ -307,7 +307,7 @@ def _golden_function_rsub(input_tensor_a, value, *args, **kwargs):
     return torch.sub(value, input_tensor_a)
 
 
-ttnn.attach_golden_function(ttnn._ttnn.operations.unary.rsub, golden_function=_golden_function_rsub)
+ttnn.attach_golden_function(ttnn.rsub, golden_function=_golden_function_rsub)
 
 
 def _golden_function_rdiv(input_tensor_a, value, *args, **kwargs):
@@ -316,7 +316,7 @@ def _golden_function_rdiv(input_tensor_a, value, *args, **kwargs):
     return torch.div(torch.tensor(value, dtype=input_tensor_a.dtype), input_tensor_a)
 
 
-ttnn.attach_golden_function(ttnn._ttnn.operations.unary.rdiv, golden_function=_golden_function_rdiv)
+ttnn.attach_golden_function(ttnn.rdiv, golden_function=_golden_function_rdiv)
 
 
 def _golden_function_bitwise_left_shift(input_tensor_a, shift_amt, *args, **kwargs):
@@ -325,9 +325,7 @@ def _golden_function_bitwise_left_shift(input_tensor_a, shift_amt, *args, **kwar
     return torch.bitwise_left_shift(input_tensor_a, shift_amt)
 
 
-ttnn.attach_golden_function(
-    ttnn._ttnn.operations.unary.bitwise_left_shift, golden_function=_golden_function_bitwise_left_shift
-)
+ttnn.attach_golden_function(ttnn.bitwise_left_shift, golden_function=_golden_function_bitwise_left_shift)
 
 
 def _golden_function_bitwise_right_shift(input_tensor_a, shift_amt, *args, **kwargs):
@@ -336,9 +334,7 @@ def _golden_function_bitwise_right_shift(input_tensor_a, shift_amt, *args, **kwa
     return torch.bitwise_right_shift(input_tensor_a, shift_amt)
 
 
-ttnn.attach_golden_function(
-    ttnn._ttnn.operations.unary.bitwise_right_shift, golden_function=_golden_function_bitwise_right_shift
-)
+ttnn.attach_golden_function(ttnn.bitwise_right_shift, golden_function=_golden_function_bitwise_right_shift)
 
 
 def _golden_function_bitwise_and(input_tensor_a, value, *args, **kwargs):
@@ -347,7 +343,7 @@ def _golden_function_bitwise_and(input_tensor_a, value, *args, **kwargs):
     return torch.bitwise_and(input_tensor_a, value)
 
 
-ttnn.attach_golden_function(ttnn._ttnn.operations.unary.bitwise_and, golden_function=_golden_function_bitwise_and)
+ttnn.attach_golden_function(ttnn.bitwise_and, golden_function=_golden_function_bitwise_and)
 
 
 def _golden_function_bitwise_or(input_tensor_a, value, *args, **kwargs):
@@ -356,7 +352,7 @@ def _golden_function_bitwise_or(input_tensor_a, value, *args, **kwargs):
     return torch.bitwise_or(input_tensor_a, value)
 
 
-ttnn.attach_golden_function(ttnn._ttnn.operations.unary.bitwise_or, golden_function=_golden_function_bitwise_or)
+ttnn.attach_golden_function(ttnn.bitwise_or, golden_function=_golden_function_bitwise_or)
 
 
 def _golden_function_bitwise_xor(input_tensor_a, value, *args, **kwargs):
@@ -365,7 +361,7 @@ def _golden_function_bitwise_xor(input_tensor_a, value, *args, **kwargs):
     return torch.bitwise_xor(input_tensor_a, value)
 
 
-ttnn.attach_golden_function(ttnn._ttnn.operations.unary.bitwise_xor, golden_function=_golden_function_bitwise_xor)
+ttnn.attach_golden_function(ttnn.bitwise_xor, golden_function=_golden_function_bitwise_xor)
 
 
 def _golden_function_bitwise_not(input_tensor_a, value, *args, **kwargs):
@@ -374,7 +370,7 @@ def _golden_function_bitwise_not(input_tensor_a, value, *args, **kwargs):
     return torch.bitwise_not(input_tensor_a, value)
 
 
-ttnn.attach_golden_function(ttnn._ttnn.operations.unary.bitwise_not, golden_function=_golden_function_bitwise_not)
+ttnn.attach_golden_function(ttnn.bitwise_not, golden_function=_golden_function_bitwise_not)
 
 
 def _golden_function_glu(input_tensor_a, dim, *args, **kwargs):
@@ -383,7 +379,7 @@ def _golden_function_glu(input_tensor_a, dim, *args, **kwargs):
     return torch.nn.functional.glu(input_tensor_a, dim)
 
 
-ttnn.attach_golden_function(ttnn._ttnn.operations.unary.glu, golden_function=_golden_function_glu)
+ttnn.attach_golden_function(ttnn.glu, golden_function=_golden_function_glu)
 
 
 def _golden_function_reglu(input_tensor_a, dim, *args, **kwargs):
@@ -397,7 +393,7 @@ def _golden_function_reglu(input_tensor_a, dim, *args, **kwargs):
     return tensA * torch.nn.functional.relu(tensB)
 
 
-ttnn.attach_golden_function(ttnn._ttnn.operations.unary.reglu, golden_function=_golden_function_reglu)
+ttnn.attach_golden_function(ttnn.reglu, golden_function=_golden_function_reglu)
 
 
 def _golden_function_geglu(input_tensor_a, dim, *args, **kwargs):
@@ -411,7 +407,7 @@ def _golden_function_geglu(input_tensor_a, dim, *args, **kwargs):
     return tensA * torch.nn.functional.gelu(tensB)
 
 
-ttnn.attach_golden_function(ttnn._ttnn.operations.unary.geglu, golden_function=_golden_function_geglu)
+ttnn.attach_golden_function(ttnn.geglu, golden_function=_golden_function_geglu)
 
 
 def _golden_function_swiglu(input_tensor_a, dim, *args, **kwargs):
@@ -425,7 +421,7 @@ def _golden_function_swiglu(input_tensor_a, dim, *args, **kwargs):
     return tensA * torch.nn.functional.silu(tensB)
 
 
-ttnn.attach_golden_function(ttnn._ttnn.operations.unary.swiglu, golden_function=_golden_function_swiglu)
+ttnn.attach_golden_function(ttnn.swiglu, golden_function=_golden_function_swiglu)
 
 
 def _golden_function_logical_not_(input_tensor_a, *args, **kwargs):
@@ -434,7 +430,7 @@ def _golden_function_logical_not_(input_tensor_a, *args, **kwargs):
     return input_tensor_a.logical_not_()
 
 
-ttnn.attach_golden_function(ttnn._ttnn.operations.unary.logical_not_, golden_function=_golden_function_logical_not_)
+ttnn.attach_golden_function(ttnn.logical_not_, golden_function=_golden_function_logical_not_)
 
 
 def _golden_function_hardshrink(input_tensor_a, *args, lambd=0.5, **kwargs):
@@ -443,7 +439,7 @@ def _golden_function_hardshrink(input_tensor_a, *args, lambd=0.5, **kwargs):
     return torch.nn.functional.hardshrink(input_tensor_a, lambd=lambd)
 
 
-ttnn.attach_golden_function(ttnn._ttnn.operations.unary.hardshrink, golden_function=_golden_function_hardshrink)
+ttnn.attach_golden_function(ttnn.hardshrink, golden_function=_golden_function_hardshrink)
 
 
 def _golden_function_softshrink(input_tensor_a, *args, lambd=0.5, **kwargs):
@@ -452,7 +448,7 @@ def _golden_function_softshrink(input_tensor_a, *args, lambd=0.5, **kwargs):
     return torch.nn.functional.softshrink(input_tensor_a, lambd=lambd)
 
 
-ttnn.attach_golden_function(ttnn._ttnn.operations.unary.softshrink, golden_function=_golden_function_softshrink)
+ttnn.attach_golden_function(ttnn.softshrink, golden_function=_golden_function_softshrink)
 
 
 def _golden_function_logit(input_tensor_a, *args, eps=None, **kwargs):
@@ -461,7 +457,7 @@ def _golden_function_logit(input_tensor_a, *args, eps=None, **kwargs):
     return torch.special.logit(input_tensor_a, eps=eps)
 
 
-ttnn.attach_golden_function(ttnn._ttnn.operations.unary.logit, golden_function=_golden_function_logit)
+ttnn.attach_golden_function(ttnn.logit, golden_function=_golden_function_logit)
 
 
 def _golden_function_celu(input_tensor_a, *args, alpha=1.0, **kwargs):
@@ -470,7 +466,7 @@ def _golden_function_celu(input_tensor_a, *args, alpha=1.0, **kwargs):
     return torch.celu(input_tensor_a, alpha=alpha)
 
 
-ttnn.attach_golden_function(ttnn._ttnn.operations.unary.celu, golden_function=_golden_function_celu)
+ttnn.attach_golden_function(ttnn.celu, golden_function=_golden_function_celu)
 
 
 def torch_reglu(input_tensor, *args, **kwargs):
@@ -564,7 +560,7 @@ def _golden_function_glu(input_tensor_a, dim, *args, **kwargs):
     return torch.nn.functional.glu(input_tensor_a, dim)
 
 
-ttnn.attach_golden_function(ttnn._ttnn.operations.unary.glu, golden_function=_golden_function_glu)
+ttnn.attach_golden_function(ttnn.glu, golden_function=_golden_function_glu)
 
 
 def _golden_function_reglu(input_tensor_a, dim, *args, **kwargs):
@@ -579,7 +575,7 @@ def _golden_function_reglu(input_tensor_a, dim, *args, **kwargs):
     return tensA * torch.nn.functional.relu(tensB)
 
 
-ttnn.attach_golden_function(ttnn._ttnn.operations.unary.reglu, golden_function=_golden_function_reglu)
+ttnn.attach_golden_function(ttnn.reglu, golden_function=_golden_function_reglu)
 
 
 def _golden_function_geglu(input_tensor_a, dim, *args, **kwargs):
@@ -595,7 +591,7 @@ def _golden_function_geglu(input_tensor_a, dim, *args, **kwargs):
     return tensA * torch.nn.functional.gelu(tensB)
 
 
-ttnn.attach_golden_function(ttnn._ttnn.operations.unary.geglu, golden_function=_golden_function_geglu)
+ttnn.attach_golden_function(ttnn.geglu, golden_function=_golden_function_geglu)
 
 
 def _golden_function_swiglu(input_tensor_a, dim, *args, **kwargs):
@@ -611,7 +607,7 @@ def _golden_function_swiglu(input_tensor_a, dim, *args, **kwargs):
     return tensA * torch.nn.functional.silu(tensB)
 
 
-ttnn.attach_golden_function(ttnn._ttnn.operations.unary.swiglu, golden_function=_golden_function_swiglu)
+ttnn.attach_golden_function(ttnn.swiglu, golden_function=_golden_function_swiglu)
 
 
 def _golden_function_normalize_global(input_tensor_a, *args, **kwargs):
@@ -624,9 +620,7 @@ def _golden_function_normalize_global(input_tensor_a, *args, **kwargs):
     return input_tensor_a
 
 
-ttnn.attach_golden_function(
-    ttnn._ttnn.operations.unary.normalize_global, golden_function=_golden_function_normalize_global
-)
+ttnn.attach_golden_function(ttnn.normalize_global, golden_function=_golden_function_normalize_global)
 
 
 def _golden_function_rpow(input_tensor_a, dim, *args, **kwargs):
@@ -635,7 +629,7 @@ def _golden_function_rpow(input_tensor_a, dim, *args, **kwargs):
     return torch.pow(dim, input_tensor_a)
 
 
-ttnn.attach_golden_function(ttnn._ttnn.operations.unary.rpow, golden_function=_golden_function_rpow)
+ttnn.attach_golden_function(ttnn.rpow, golden_function=_golden_function_rpow)
 
 
 def _golden_function_frac(input_tensor_a, *args, **kwargs):
@@ -644,7 +638,7 @@ def _golden_function_frac(input_tensor_a, *args, **kwargs):
     return torch.frac(input_tensor_a)
 
 
-ttnn.attach_golden_function(ttnn._ttnn.operations.unary.frac, golden_function=_golden_function_frac)
+ttnn.attach_golden_function(ttnn.frac, golden_function=_golden_function_frac)
 
 
 def _golden_function_rdiv(input_tensor_a, value, *args, round_mode=None, **kwargs):
@@ -656,5 +650,5 @@ def _golden_function_rdiv(input_tensor_a, value, *args, round_mode=None, **kwarg
     return torch.div(torch.full_like(input_tensor_a, value), input_tensor_a, rounding_mode=round_mode)
 
 
-ttnn.attach_golden_function(ttnn._ttnn.operations.unary.rdiv, golden_function=_golden_function_rdiv)
+ttnn.attach_golden_function(ttnn.rdiv, golden_function=_golden_function_rdiv)
 __all__ = []


### PR DESCRIPTION
### Problem description
We dynamically create in-memory modules in Python code based on the value of the `python_fully_qualified_name` attribute of the ops classes. When we do that, we use `types.ModuleType` instances instead of the recommended methods from the `importlib`. In addition, we don't register the new modules in the `sys.modules` dictionary.

### What's changed
- Refactored the op registration code to make it clearer that we create dynamic modules as needed. 
- Fixed the problems above. With these fixes the docs can be built locally again (local builds currently fail on the main branch, even though they work in CI.
- Fixed lots of import inconsistencies.

### Checklist
- [x] Post commit CI passes
