### PR TITLE
#11559: Replace tt_lib in tests/ttnn files

### DIFF
--- a/models/utility_functions.py
+++ b/models/utility_functions.py
@@ -5,7 +5,6 @@
 from typing import Union
 import time
 import ttnn
-from ttnn import ConcatMeshToTensor
 import torch
 import numpy as np
 from loguru import logger
@@ -212,7 +211,7 @@ def tt_tensors_to_torch_tensors(
         tt_tensors_device = ttnn.untilize(tt_tensors_device, use_multicore=False)
 
     tt_tensors_device = ttnn.to_torch(
-        tt_tensors_device, mesh_composer=ConcatMeshToTensor(device_mesh, dim=concat_dim), device=device_mesh
+        tt_tensors_device, mesh_composer=ttnn.ConcatMeshToTensor(device_mesh, dim=concat_dim), device=device_mesh
     )
 
     return tt_tensors_device

--- a/tests/ttnn/benchmarks/test_benchmark.py
+++ b/tests/ttnn/benchmarks/test_benchmark.py
@@ -7,7 +7,6 @@ import time
 import pytest
 import torch
 import ttnn
-import tt_lib as ttl
 
 
 # fmt: off

--- a/tests/ttnn/profiling/profile_host_overhead.py
+++ b/tests/ttnn/profiling/profile_host_overhead.py
@@ -5,7 +5,6 @@
 import os
 import pytest
 import torch
-import tt_lib
 import ttnn
 import time
 import statistics
@@ -19,17 +18,17 @@ from tracy import signpost
 test_sweep_args = [
     # (
     #     (1, 2, 1024, 1024),
-    #     tt_lib.tensor.DataType.BFLOAT16,
-    #     tt_lib.tensor.Layout.TILE,
-    #     tt_lib.tensor.MemoryConfig(tt_lib.tensor.TensorMemoryLayout.INTERLEAVED, tt_lib.tensor.BufferType.DRAM),
-    #     tt_lib.tensor.MemoryConfig(tt_lib.tensor.TensorMemoryLayout.INTERLEAVED, tt_lib.tensor.BufferType.DRAM),
+    #     ttnn.bfloat16,
+    #     ttnn.TILE_LAYOUT,
+    #     ttnn.DRAM_MEMORY_CONFIG,
+    #     ttnn.DRAM_MEMORY_CONFIG,
     # ),
     (
         (1, 4, 1024, 1024),
-        tt_lib.tensor.DataType.BFLOAT16,
-        tt_lib.tensor.Layout.TILE,
-        tt_lib.tensor.MemoryConfig(tt_lib.tensor.TensorMemoryLayout.INTERLEAVED, tt_lib.tensor.BufferType.DRAM),
-        tt_lib.tensor.MemoryConfig(tt_lib.tensor.TensorMemoryLayout.INTERLEAVED, tt_lib.tensor.BufferType.DRAM),
+        ttnn.bfloat16,
+        ttnn.TILE_LAYOUT,
+        ttnn.DRAM_MEMORY_CONFIG,
+        ttnn.DRAM_MEMORY_CONFIG
     ),
 ]
 
@@ -38,7 +37,7 @@ NUM_REPEATS = 5
 
 
 # def torch2tt_tensor(x, device, dlayout, in_mem_config, dtype):
-#     return tt_lib.tensor.Tensor(x, dtype).pad_to_tile(float("nan")).to(dlayout).to(device, in_mem_config)
+#     return ttnn.Tensor(x, dtype).pad_to_tile(float("nan")).to(dlayout).to(device, in_mem_config)
 
 
 def measure_host_overhead(op_func, op_name, device, num_call_to_stack, is_warmup):
@@ -240,7 +239,7 @@ def run_measure_host_overhead(op, device, text_file, measuring_func):
         logger.info(f"Profiling op {op['name']} for input shape {input_shape}")
 
         if "layout" in op and op["layout"] == "ROW_MAJOR":
-            dlayout = tt_lib.tensor.Layout.ROW_MAJOR
+            dlayout = ttnn.ROW_MAJOR_LAYOUT
 
         num_repeats = op["num_repeats"] if "num_repeats" in op else NUM_REPEATS
         shape_func = None if "shape_func" not in op else op["shape_func"]

--- a/tests/ttnn/profiling/profile_host_overhead.py
+++ b/tests/ttnn/profiling/profile_host_overhead.py
@@ -23,13 +23,7 @@ test_sweep_args = [
     #     ttnn.DRAM_MEMORY_CONFIG,
     #     ttnn.DRAM_MEMORY_CONFIG,
     # ),
-    (
-        (1, 4, 1024, 1024),
-        ttnn.bfloat16,
-        ttnn.TILE_LAYOUT,
-        ttnn.DRAM_MEMORY_CONFIG,
-        ttnn.DRAM_MEMORY_CONFIG
-    ),
+    ((1, 4, 1024, 1024), ttnn.bfloat16, ttnn.TILE_LAYOUT, ttnn.DRAM_MEMORY_CONFIG, ttnn.DRAM_MEMORY_CONFIG),
 ]
 
 all_num_call_to_stack = [20]  # For 10 and more test  execution spills to dispatch

--- a/tests/ttnn/python_api_testing/sweep_tests/ttnn_ops.py
+++ b/tests/ttnn/python_api_testing/sweep_tests/ttnn_ops.py
@@ -4,7 +4,6 @@
 
 import torch
 import ttnn
-import tt_lib
 
 from ttnn.model_preprocessing import preprocess_model, preprocess_model_parameters
 import transformers
@@ -22,57 +21,6 @@ from tests.tt_eager.python_api_testing.sweep_tests.model_tests import (
 )
 
 
-def layout_to_ttnn(layout):
-    if layout == tt_lib.tensor.Layout.TILE:
-        return ttnn.TILE_LAYOUT
-
-    elif layout == tt_lib.tensor.Layout.ROW_MAJOR:
-        return ttnn.ROW_MAJOR_LAYOUT
-
-    else:
-        assert False, "Unknown layout passed"
-
-
-def dtype_to_ttnn(dtype):
-    if dtype == tt_lib.tensor.DataType.BFLOAT16:
-        return ttnn.bfloat16
-
-    elif dtype == tt_lib.tensor.DataType.BFLOAT8_B:
-        return ttnn.bfloat8_b
-
-    elif dtype == tt_lib.tensor.DataType.UINT32:
-        return ttnn.uint32
-
-    elif dtype == tt_lib.tensor.DataType.UINT16:
-        return ttnn.uint16
-
-    elif dtype == tt_lib.tensor.DataType.INT32:
-        return ttnn.int32
-
-    elif dtype == tt_lib.tensor.DataType.FLOAT32:
-        return ttnn.float32
-
-    elif dtype == tt_lib.tensor.DataType.BFLOAT4_B:
-        return ttnn.bfloat4_b
-
-    else:
-        assert False, "Unknown dtype passed"
-
-
-def memory_config_to_ttnn(mem_config):
-    if mem_config is None:
-        return None
-
-    if mem_config.buffer_type == tt_lib.tensor.BufferType.DRAM:
-        return ttnn.DRAM_MEMORY_CONFIG
-
-    elif mem_config.buffer_type == tt_lib.tensor.BufferType.L1:
-        return ttnn.L1_MEMORY_CONFIG
-
-    else:
-        assert False, "Unknown memory passed"
-
-
 def setup_ttnn_tensor(x, device, layout, input_mem_config, dtype):
     # Check if input is scalar -> Then return scalar
     if len(x.shape) == 1 and x.shape[0] == 1:
@@ -80,10 +28,10 @@ def setup_ttnn_tensor(x, device, layout, input_mem_config, dtype):
 
     input_tensor = ttnn.from_torch(
         x,
-        dtype=dtype_to_ttnn(dtype),
-        layout=layout_to_ttnn(layout),
+        dtype=dtype,
+        layout=layout,
         device=device if input_mem_config is not None else None,
-        memory_config=memory_config_to_ttnn(input_mem_config),
+        memory_config=input_mem_config,
     )
 
     return input_tensor
@@ -109,9 +57,9 @@ def ones(
     t0 = ttnn.ones(
         x.shape,
         device=device if input_mem_config[0] is not None else None,
-        dtype=dtype_to_ttnn(dtype[0]),
-        layout=layout_to_ttnn(layout[0]),
-        memory_config=memory_config_to_ttnn(output_mem_config),
+        dtype=dtype[0],
+        layout=layout[0],
+        memory_config=output_mem_config,
     )
 
     return ttnn_tensor_to_torch(t0)
@@ -128,7 +76,7 @@ def ones_like(
     **kwargs,
 ):
     t0 = setup_ttnn_tensor(x, device, layout[0], input_mem_config[0], dtype[0])
-    t1 = ttnn.ones_like(t0, memory_config=memory_config_to_ttnn(output_mem_config))
+    t1 = ttnn.ones_like(t0, memory_config=output_mem_config)
 
     return ttnn_tensor_to_torch(t1)
 
@@ -148,9 +96,9 @@ def full(
         x.shape,
         fill_value=scalar,
         device=device if input_mem_config[0] is not None else None,
-        dtype=dtype_to_ttnn(dtype[0]),
-        layout=layout_to_ttnn(layout[0]),
-        memory_config=memory_config_to_ttnn(output_mem_config),
+        dtype=dtype[0],
+        layout=layout[0],
+        memory_config=output_mem_config,
     )
 
     return ttnn_tensor_to_torch(t0)
@@ -167,7 +115,7 @@ def eltwise_hardswish(
     **kwargs,
 ):
     t0 = setup_ttnn_tensor(x, device, layout[0], input_mem_config[0], dtype[0])
-    t1 = ttnn.hardswish(t0, memory_config=memory_config_to_ttnn(output_mem_config))
+    t1 = ttnn.hardswish(t0, memory_config=output_mem_config)
 
     return ttnn_tensor_to_torch(t1)
 
@@ -183,7 +131,7 @@ def eltwise_hardtanh(
     **kwargs,
 ):
     t0 = setup_ttnn_tensor(x, device, layout[0], input_mem_config[0], dtype[0])
-    t1 = ttnn.hardtanh(t0, memory_config=memory_config_to_ttnn(output_mem_config))
+    t1 = ttnn.hardtanh(t0, memory_config=output_mem_config)
 
     return ttnn_tensor_to_torch(t1)
 
@@ -200,7 +148,7 @@ def eltwise_heaviside(
     **kwargs,
 ):
     t0 = setup_ttnn_tensor(x, device, layout[0], input_mem_config[0], dtype[0])
-    t1 = ttnn.heaviside(t0, scalar, memory_config=memory_config_to_ttnn(output_mem_config))
+    t1 = ttnn.heaviside(t0, scalar, memory_config=output_mem_config)
 
     return ttnn_tensor_to_torch(t1)
 
@@ -218,7 +166,7 @@ def eltwise_hypot(
 ):
     t0 = setup_ttnn_tensor(x, device, layout[0], input_mem_config[0], dtype[0])
     t1 = setup_ttnn_tensor(y, device, layout[1], input_mem_config[1], dtype[1])
-    t2 = ttnn.hypot(t0, t1, memory_config=memory_config_to_ttnn(output_mem_config))
+    t2 = ttnn.hypot(t0, t1, memory_config=output_mem_config)
 
     return ttnn_tensor_to_torch(t2)
 
@@ -234,7 +182,7 @@ def eltwise_i0(
     **kwargs,
 ):
     t0 = setup_ttnn_tensor(x, device, layout[0], input_mem_config[0], dtype[0])
-    t1 = ttnn.i0(t0, memory_config=memory_config_to_ttnn(output_mem_config))
+    t1 = ttnn.i0(t0, memory_config=output_mem_config)
 
     return ttnn_tensor_to_torch(t1)
 
@@ -250,7 +198,7 @@ def eltwise_isfinite(
     **kwargs,
 ):
     t0 = setup_ttnn_tensor(x, device, layout[0], input_mem_config[0], dtype[0])
-    t1 = ttnn.isfinite(t0, memory_config=memory_config_to_ttnn(output_mem_config))
+    t1 = ttnn.isfinite(t0, memory_config=output_mem_config)
 
     return ttnn_tensor_to_torch(t1)
 
@@ -266,7 +214,7 @@ def eltwise_isinf(
     **kwargs,
 ):
     t0 = setup_ttnn_tensor(x, device, layout[0], input_mem_config[0], dtype[0])
-    t1 = ttnn.isinf(t0, memory_config=memory_config_to_ttnn(output_mem_config))
+    t1 = ttnn.isinf(t0, memory_config=output_mem_config)
 
     return ttnn_tensor_to_torch(t1)
 
@@ -282,7 +230,7 @@ def eltwise_isnan(
     **kwargs,
 ):
     t0 = setup_ttnn_tensor(x, device, layout[0], input_mem_config[0], dtype[0])
-    t1 = ttnn.isnan(t0, memory_config=memory_config_to_ttnn(output_mem_config))
+    t1 = ttnn.isnan(t0, memory_config=output_mem_config)
 
     return ttnn_tensor_to_torch(t1)
 
@@ -298,7 +246,7 @@ def eltwise_isneginf(
     **kwargs,
 ):
     t0 = setup_ttnn_tensor(x, device, layout[0], input_mem_config[0], dtype[0])
-    t1 = ttnn.isneginf(t0, memory_config=memory_config_to_ttnn(output_mem_config))
+    t1 = ttnn.isneginf(t0, memory_config=output_mem_config)
 
     return ttnn_tensor_to_torch(t1)
 
@@ -314,7 +262,7 @@ def eltwise_isposinf(
     **kwargs,
 ):
     t0 = setup_ttnn_tensor(x, device, layout[0], input_mem_config[0], dtype[0])
-    t1 = ttnn.isposinf(t0, memory_config=memory_config_to_ttnn(output_mem_config))
+    t1 = ttnn.isposinf(t0, memory_config=output_mem_config)
 
     return ttnn_tensor_to_torch(t1)
 
@@ -331,7 +279,7 @@ def eltwise_leaky_relu(
     **kwargs,
 ):
     t0 = setup_ttnn_tensor(x, device, layout[0], input_mem_config[0], dtype[0])
-    t1 = ttnn.leaky_relu(t0, negative_slope, memory_config=memory_config_to_ttnn(output_mem_config))
+    t1 = ttnn.leaky_relu(t0, negative_slope, memory_config=output_mem_config)
 
     return ttnn_tensor_to_torch(t1)
 
@@ -348,7 +296,7 @@ def activation_glu(
     **kwargs,
 ):
     t0 = setup_ttnn_tensor(x, device, layout[0], input_mem_config[0], dtype[0])
-    t1 = ttnn.glu(t0, dim=dim, memory_config=memory_config_to_ttnn(output_mem_config))
+    t1 = ttnn.glu(t0, dim=dim, memory_config=output_mem_config)
 
     return ttnn_tensor_to_torch(t1)
 
@@ -367,7 +315,7 @@ def eltwise_lerp_binary(
 ):
     t0 = setup_ttnn_tensor(x, device, layout[0], input_mem_config[0], dtype[0])
     t1 = setup_ttnn_tensor(y, device, layout[1], input_mem_config[1], dtype[1])
-    t2 = ttnn.lerp(t0, t1, weight, memory_config=memory_config_to_ttnn(output_mem_config))
+    t2 = ttnn.lerp(t0, t1, weight, memory_config=output_mem_config)
 
     return ttnn_tensor_to_torch(t2)
 
@@ -407,7 +355,7 @@ def eltwise_lerp_ternary(
     t0 = setup_ttnn_tensor(x, device, layout[0], input_mem_config[0], dtype[0])
     t1 = setup_ttnn_tensor(y, device, layout[1], input_mem_config[1], dtype[1])
     t2 = setup_ttnn_tensor(z, device, layout[2], input_mem_config[2], dtype[2])
-    t3 = ttnn.lerp(t0, t1, t2, memory_config=memory_config_to_ttnn(output_mem_config))
+    t3 = ttnn.lerp(t0, t1, t2, memory_config=output_mem_config)
 
     return ttnn_tensor_to_torch(t3)
 
@@ -423,7 +371,7 @@ def eltwise_lgamma(
     **kwargs,
 ):
     t0 = setup_ttnn_tensor(x, device, layout[0], input_mem_config[0], dtype[0])
-    t1 = ttnn.lgamma(t0, memory_config=memory_config_to_ttnn(output_mem_config))
+    t1 = ttnn.lgamma(t0, memory_config=output_mem_config)
 
     return ttnn_tensor_to_torch(t1)
 
@@ -439,7 +387,7 @@ def eltwise_log(
     **kwargs,
 ):
     t0 = setup_ttnn_tensor(x, device, layout[0], input_mem_config[0], dtype[0])
-    t1 = ttnn.log(t0, memory_config=memory_config_to_ttnn(output_mem_config))
+    t1 = ttnn.log(t0, memory_config=output_mem_config)
 
     return ttnn_tensor_to_torch(t1)
 
@@ -455,7 +403,7 @@ def eltwise_log10(
     **kwargs,
 ):
     t0 = setup_ttnn_tensor(x, device, layout[0], input_mem_config[0], dtype[0])
-    t1 = ttnn.log10(t0, memory_config=memory_config_to_ttnn(output_mem_config))
+    t1 = ttnn.log10(t0, memory_config=output_mem_config)
 
     return ttnn_tensor_to_torch(t1)
 
@@ -471,7 +419,7 @@ def eltwise_log1p(
     **kwargs,
 ):
     t0 = setup_ttnn_tensor(x, device, layout[0], input_mem_config[0], dtype[0])
-    t1 = ttnn.log1p(t0, memory_config=memory_config_to_ttnn(output_mem_config))
+    t1 = ttnn.log1p(t0, memory_config=output_mem_config)
 
     return ttnn_tensor_to_torch(t1)
 
@@ -487,7 +435,7 @@ def eltwise_log2(
     **kwargs,
 ):
     t0 = setup_ttnn_tensor(x, device, layout[0], input_mem_config[0], dtype[0])
-    t1 = ttnn.log2(t0, memory_config=memory_config_to_ttnn(output_mem_config))
+    t1 = ttnn.log2(t0, memory_config=output_mem_config)
 
     return ttnn_tensor_to_torch(t1)
 
@@ -503,7 +451,7 @@ def eltwise_log_sigmoid(
     **kwargs,
 ):
     t0 = setup_ttnn_tensor(x, device, layout[0], input_mem_config[0], dtype[0])
-    t1 = ttnn.log_sigmoid(t0, memory_config=memory_config_to_ttnn(output_mem_config))
+    t1 = ttnn.log_sigmoid(t0, memory_config=output_mem_config)
 
     return ttnn_tensor_to_torch(t1)
 
@@ -520,7 +468,7 @@ def eltwise_celu(
     **kwargs,
 ):
     t0 = setup_ttnn_tensor(x, device, layout[0], input_mem_config[0], dtype[0])
-    t1 = ttnn.celu(t0, alpha=alpha, memory_config=memory_config_to_ttnn(output_mem_config))
+    t1 = ttnn.celu(t0, alpha=alpha, memory_config=output_mem_config)
 
     return ttnn_tensor_to_torch(t1)
 
@@ -537,7 +485,7 @@ def eltwise_logit(
     **kwargs,
 ):
     t0 = setup_ttnn_tensor(x, device, layout[0], input_mem_config[0], dtype[0])
-    t1 = ttnn.logit(t0, eps=eps, memory_config=memory_config_to_ttnn(output_mem_config))
+    t1 = ttnn.logit(t0, eps=eps, memory_config=output_mem_config)
 
     return ttnn_tensor_to_torch(t1)
 
@@ -553,7 +501,7 @@ def eltwise_mish(
     **kwargs,
 ):
     t0 = setup_ttnn_tensor(x, device, layout[0], input_mem_config[0], dtype[0])
-    t1 = ttnn.mish(t0, memory_config=memory_config_to_ttnn(output_mem_config))
+    t1 = ttnn.mish(t0, memory_config=output_mem_config)
 
     return ttnn_tensor_to_torch(t1)
 
@@ -569,7 +517,7 @@ def eltwise_multigammaln(
     **kwargs,
 ):
     t0 = setup_ttnn_tensor(x, device, layout[0], input_mem_config[0], dtype[0])
-    t1 = ttnn.multigammaln(t0, memory_config=memory_config_to_ttnn(output_mem_config))
+    t1 = ttnn.multigammaln(t0, memory_config=output_mem_config)
 
     return ttnn_tensor_to_torch(t1)
 
@@ -585,7 +533,7 @@ def eltwise_neg(
     **kwargs,
 ):
     t0 = setup_ttnn_tensor(x, device, layout[0], input_mem_config[0], dtype[0])
-    t1 = ttnn.neg(t0, memory_config=memory_config_to_ttnn(output_mem_config))
+    t1 = ttnn.neg(t0, memory_config=output_mem_config)
 
     return ttnn_tensor_to_torch(t1)
 
@@ -602,7 +550,7 @@ def eltwise_prelu(
     **kwargs,
 ):
     t0 = setup_ttnn_tensor(x, device, layout[0], input_mem_config[0], dtype[0])
-    t1 = ttnn.prelu(t0, scalar, memory_config=memory_config_to_ttnn(output_mem_config))
+    t1 = ttnn.prelu(t0, scalar, memory_config=output_mem_config)
 
     return ttnn_tensor_to_torch(t1)
 
@@ -618,7 +566,7 @@ def eltwise_relu(
     **kwargs,
 ):
     t0 = setup_ttnn_tensor(x, device, layout[0], input_mem_config[0], dtype[0])
-    t1 = ttnn.relu(t0, memory_config=memory_config_to_ttnn(output_mem_config))
+    t1 = ttnn.relu(t0, memory_config=output_mem_config)
 
     return ttnn_tensor_to_torch(t1)
 
@@ -634,7 +582,7 @@ def eltwise_logical_not(
     **kwargs,
 ):
     t0 = setup_ttnn_tensor(x, device, layout[0], input_mem_config[0], dtype[0])
-    t1 = ttnn.logical_not(t0, memory_config=memory_config_to_ttnn(output_mem_config))
+    t1 = ttnn.logical_not(t0, memory_config=output_mem_config)
 
     return ttnn_tensor_to_torch(t1)
 
@@ -652,7 +600,7 @@ def eltwise_xlogy(
 ):
     t0 = setup_ttnn_tensor(x, device, layout[0], input_mem_config[0], dtype[0])
     t1 = setup_ttnn_tensor(y, device, layout[1], input_mem_config[1], dtype[1])
-    t2 = ttnn.xlogy(t0, t1, memory_config=memory_config_to_ttnn(output_mem_config))
+    t2 = ttnn.xlogy(t0, t1, memory_config=output_mem_config)
 
     return ttnn_tensor_to_torch(t2)
 
@@ -670,7 +618,7 @@ def eltwise_squared_difference(
 ):
     t0 = setup_ttnn_tensor(x, device, layout[0], input_mem_config[0], dtype[0])
     t1 = setup_ttnn_tensor(y, device, layout[1], input_mem_config[1], dtype[1])
-    t2 = ttnn.squared_difference(t0, t1, memory_config=memory_config_to_ttnn(output_mem_config))
+    t2 = ttnn.squared_difference(t0, t1, memory_config=output_mem_config)
 
     return ttnn_tensor_to_torch(t2)
 
@@ -694,7 +642,7 @@ def eltwise_add_and_apply_activation(
 
     t0 = setup_ttnn_tensor(x, device, layout[0], input_mem_config[0], dtype[0])
     t1 = setup_ttnn_tensor(y, device, layout[1], input_mem_config[1], dtype[1])
-    t2 = ttnn.add(t0, t1, activations=activations, memory_config=memory_config_to_ttnn(output_mem_config))
+    t2 = ttnn.add(t0, t1, activations=activations, memory_config=output_mem_config)
 
     return ttnn_tensor_to_torch(t2)
 
@@ -734,7 +682,7 @@ def eltwise_gtz(
     **kwargs,
 ):
     t0 = setup_ttnn_tensor(x, device, layout[0], input_mem_config[0], dtype[0])
-    t1 = ttnn.gtz(t0, memory_config=memory_config_to_ttnn(output_mem_config))
+    t1 = ttnn.gtz(t0, memory_config=output_mem_config)
 
     return ttnn_tensor_to_torch(t1)
 
@@ -750,7 +698,7 @@ def eltwise_ltz(
     **kwargs,
 ):
     t0 = setup_ttnn_tensor(x, device, layout[0], input_mem_config[0], dtype[0])
-    t1 = ttnn.ltz(t0, memory_config=memory_config_to_ttnn(output_mem_config))
+    t1 = ttnn.ltz(t0, memory_config=output_mem_config)
 
     return ttnn_tensor_to_torch(t1)
 
@@ -766,7 +714,7 @@ def eltwise_gez(
     **kwargs,
 ):
     t0 = setup_ttnn_tensor(x, device, layout[0], input_mem_config[0], dtype[0])
-    t1 = ttnn.gez(t0, memory_config=memory_config_to_ttnn(output_mem_config))
+    t1 = ttnn.gez(t0, memory_config=output_mem_config)
 
     return ttnn_tensor_to_torch(t1)
 
@@ -782,7 +730,7 @@ def eltwise_lez(
     **kwargs,
 ):
     t0 = setup_ttnn_tensor(x, device, layout[0], input_mem_config[0], dtype[0])
-    t1 = ttnn.lez(t0, memory_config=memory_config_to_ttnn(output_mem_config))
+    t1 = ttnn.lez(t0, memory_config=output_mem_config)
 
     return ttnn_tensor_to_torch(t1)
 
@@ -798,7 +746,7 @@ def eltwise_nez(
     **kwargs,
 ):
     t0 = setup_ttnn_tensor(x, device, layout[0], input_mem_config[0], dtype[0])
-    t1 = ttnn.nez(t0, memory_config=memory_config_to_ttnn(output_mem_config))
+    t1 = ttnn.nez(t0, memory_config=output_mem_config)
 
     return ttnn_tensor_to_torch(t1)
 
@@ -818,7 +766,7 @@ def eltwise_add(
     t0 = setup_ttnn_tensor(x, device, layout[0], input_mem_config[0], dtype[0])
     t1 = setup_ttnn_tensor(y, device, layout[1], input_mem_config[1], dtype[1])
 
-    t2 = ttnn.add(t0, t1, memory_config=memory_config_to_ttnn(output_mem_config))
+    t2 = ttnn.add(t0, t1, memory_config=output_mem_config)
     return ttnn_tensor_to_torch(t2)
 
 
@@ -833,7 +781,7 @@ def eltwise_exp(
     **kwargs,
 ):
     t0 = setup_ttnn_tensor(x, device, layout[0], input_mem_config[0], dtype[0])
-    t1 = ttnn.exp(t0, memory_config=memory_config_to_ttnn(output_mem_config))
+    t1 = ttnn.exp(t0, memory_config=output_mem_config)
     return ttnn_tensor_to_torch(t1)
 
 
@@ -849,7 +797,7 @@ def permute(
     **kwargs,
 ):
     t0 = setup_ttnn_tensor(x, device, layout[0], input_mem_config[0], dtype[0])
-    t1 = ttnn.permute(t0, permute_dims)  # , memory_config=memory_config_to_ttnn(output_mem_config))
+    t1 = ttnn.permute(t0, permute_dims)  # , memory_config=output_mem_config)
     return ttnn_tensor_to_torch(t1)
 
 
@@ -865,7 +813,7 @@ def reshape(
     **kwargs,
 ):
     t0 = setup_ttnn_tensor(x, device, layout[0], input_mem_config[0], dtype[0])
-    t1 = ttnn.reshape(t0, reshape_dims)  # , memory_config=memory_config_to_ttnn(output_mem_config))
+    t1 = ttnn.reshape(t0, reshape_dims)  # , memory_config=output_mem_config)
     return ttnn_tensor_to_torch(t1)
 
 
@@ -880,7 +828,7 @@ def transpose_01(
     **kwargs,
 ):
     t0 = setup_ttnn_tensor(x, device, layout[0], input_mem_config[0], dtype[0])
-    t1 = ttnn.transpose(t0, 0, 1)  # , memory_config=memory_config_to_ttnn(output_mem_config))
+    t1 = ttnn.transpose(t0, 0, 1)  # , memory_config=output_mem_config)
     return ttnn_tensor_to_torch(t1)
 
 
@@ -895,7 +843,7 @@ def transpose_02(
     **kwargs,
 ):
     t0 = setup_ttnn_tensor(x, device, layout[0], input_mem_config[0], dtype[0])
-    t1 = ttnn.transpose(t0, 0, 2)  # , memory_config=memory_config_to_ttnn(output_mem_config))
+    t1 = ttnn.transpose(t0, 0, 2)  # , memory_config=output_mem_config)
     return ttnn_tensor_to_torch(t1)
 
 
@@ -910,7 +858,7 @@ def transpose_03(
     **kwargs,
 ):
     t0 = setup_ttnn_tensor(x, device, layout[0], input_mem_config[0], dtype[0])
-    t1 = ttnn.transpose(t0, 0, 3)  # , memory_config=memory_config_to_ttnn(output_mem_config))
+    t1 = ttnn.transpose(t0, 0, 3)  # , memory_config=output_mem_config)
     return ttnn_tensor_to_torch(t1)
 
 
@@ -925,7 +873,7 @@ def transpose_12(
     **kwargs,
 ):
     t0 = setup_ttnn_tensor(x, device, layout[0], input_mem_config[0], dtype[0])
-    t1 = ttnn.transpose(t0, 1, 2)  # , memory_config=memory_config_to_ttnn(output_mem_config))
+    t1 = ttnn.transpose(t0, 1, 2)  # , memory_config=output_mem_config)
     return ttnn_tensor_to_torch(t1)
 
 
@@ -940,7 +888,7 @@ def transpose_13(
     **kwargs,
 ):
     t0 = setup_ttnn_tensor(x, device, layout[0], input_mem_config[0], dtype[0])
-    t1 = ttnn.transpose(t0, 1, 3)  # , memory_config=memory_config_to_ttnn(output_mem_config))
+    t1 = ttnn.transpose(t0, 1, 3)  # , memory_config=output_mem_config)
     return ttnn_tensor_to_torch(t1)
 
 
@@ -955,7 +903,7 @@ def transpose_23(
     **kwargs,
 ):
     t0 = setup_ttnn_tensor(x, device, layout[0], input_mem_config[0], dtype[0])
-    t1 = ttnn.transpose(t0, 2, 3)  # , memory_config=memory_config_to_ttnn(output_mem_config))
+    t1 = ttnn.transpose(t0, 2, 3)  # , memory_config=output_mem_config)
     return ttnn_tensor_to_torch(t1)
 
 
@@ -971,7 +919,7 @@ def gelu(
 ):
     t0 = setup_ttnn_tensor(x, device, layout[0], input_mem_config[0], dtype[0])
 
-    t1 = ttnn.gelu(t0, memory_config=memory_config_to_ttnn(output_mem_config))
+    t1 = ttnn.gelu(t0, memory_config=output_mem_config)
     return ttnn_tensor_to_torch(t1)
 
 
@@ -988,7 +936,7 @@ def activation_geglu(
 ):
     t0 = setup_ttnn_tensor(x, device, layout[0], input_mem_config[0], dtype[0])
 
-    t1 = ttnn.geglu(t0, dim, memory_config=memory_config_to_ttnn(output_mem_config))
+    t1 = ttnn.geglu(t0, dim, memory_config=output_mem_config)
     return ttnn_tensor_to_torch(t1)
 
 
@@ -1005,7 +953,7 @@ def activation_swiglu(
 ):
     t0 = setup_ttnn_tensor(x, device, layout[0], input_mem_config[0], dtype[0])
 
-    t1 = ttnn.swiglu(t0, dim, memory_config=memory_config_to_ttnn(output_mem_config))
+    t1 = ttnn.swiglu(t0, dim, memory_config=output_mem_config)
     return ttnn_tensor_to_torch(t1)
 
 
@@ -1023,7 +971,7 @@ def eltwise_sub(
     t0 = setup_ttnn_tensor(x, device, layout[0], input_mem_config[0], dtype[0])
     t1 = setup_ttnn_tensor(y, device, layout[1], input_mem_config[1], dtype[1])
 
-    t2 = ttnn.subtract(t0, t1, memory_config=memory_config_to_ttnn(output_mem_config))
+    t2 = ttnn.subtract(t0, t1, memory_config=output_mem_config)
     return ttnn_tensor_to_torch(t2)
 
 
@@ -1034,14 +982,14 @@ def embeddings(x, y, *args, device, dtype, layout, input_mem_config, output_mem_
     t0 = setup_ttnn_tensor(x, device, layout[0], input_mem_config[0], dtype[0])
     t1 = setup_ttnn_tensor(y, device, layout[1], input_mem_config[1], dtype[1])
 
-    t2 = ttnn.embedding(t0, t1, memory_config=memory_config_to_ttnn(output_mem_config))
+    t2 = ttnn.embedding(t0, t1, memory_config=output_mem_config)
     return ttnn_tensor_to_torch(t2)
 
 
 def eltwise_tanh(x, *args, device, dtype, layout, input_mem_config, output_mem_config, **kwargs):
     t0 = setup_ttnn_tensor(x, device, layout[0], input_mem_config[0], dtype[0])
 
-    t1 = ttnn.tanh(t0, memory_config=memory_config_to_ttnn(output_mem_config))
+    t1 = ttnn.tanh(t0, memory_config=output_mem_config)
     return ttnn_tensor_to_torch(t1)
 
 
@@ -1056,7 +1004,7 @@ def softmax(
     **kwargs,
 ):
     t0 = setup_ttnn_tensor(x, device, layout[0], input_mem_config[0], dtype[0])
-    t1 = ttnn.softmax(t0, dim=-1, memory_config=memory_config_to_ttnn(output_mem_config))
+    t1 = ttnn.softmax(t0, dim=-1, memory_config=output_mem_config)
     return ttnn_tensor_to_torch(t1)
 
 
@@ -1073,7 +1021,7 @@ def softplus(
     **kwargs,
 ):
     t0 = setup_ttnn_tensor(x, device, layout[0], input_mem_config[0], dtype[0])
-    t1 = ttnn.softplus(t0, beta=beta, threshold=threshold, memory_config=memory_config_to_ttnn(output_mem_config))
+    t1 = ttnn.softplus(t0, beta=beta, threshold=threshold, memory_config=output_mem_config)
     return ttnn_tensor_to_torch(t1)
 
 
@@ -1091,7 +1039,7 @@ def mul(
     t0 = setup_ttnn_tensor(x, device, layout[0], input_mem_config[0], dtype[0])
     t1 = setup_ttnn_tensor(y, device, layout[1], input_mem_config[1], dtype[1])
 
-    t2 = ttnn.multiply(t0, t1, memory_config=memory_config_to_ttnn(output_mem_config))
+    t2 = ttnn.multiply(t0, t1, memory_config=output_mem_config)
     return ttnn_tensor_to_torch(t2)
 
 
@@ -1113,9 +1061,7 @@ def linear(x, weight, bias=None, *args, device, dtype, layout, input_mem_config,
     else:
         tt_bias = None
 
-    t1 = ttnn.linear(
-        t0, tt_weight, bias=tt_bias, dtype=ttnn.bfloat16, memory_config=memory_config_to_ttnn(output_mem_config)
-    )
+    t1 = ttnn.linear(t0, tt_weight, bias=tt_bias, dtype=ttnn.bfloat16, memory_config=output_mem_config)
 
     return ttnn_tensor_to_torch(t1)
 
@@ -1123,7 +1069,7 @@ def linear(x, weight, bias=None, *args, device, dtype, layout, input_mem_config,
 def eltwise_softmax_in_place(x, *args, device, dtype, layout, input_mem_config, output_mem_config, **kwargs):
     t0 = setup_ttnn_tensor(x, device, layout[0], input_mem_config[0], dtype[0])
 
-    t1 = ttnn.softmax(t0, -1, memory_config=memory_config_to_ttnn(output_mem_config))
+    t1 = ttnn.softmax(t0, -1, memory_config=output_mem_config)
     return ttnn_tensor_to_torch(t1)
 
 
@@ -1148,11 +1094,11 @@ def matmul(
         t2 = ttnn.matmul(
             t0,
             t1,
-            memory_config=memory_config_to_ttnn(output_mem_config),
+            memory_config=output_mem_config,
             core_grid=ttnn.CoreGrid(y=ycoregrid, x=xcoregrid),
         )
     else:
-        t2 = ttnn.matmul(t0, t1, memory_config=memory_config_to_ttnn(output_mem_config))
+        t2 = ttnn.matmul(t0, t1, memory_config=output_mem_config)
 
     return ttnn_tensor_to_torch(t2)
 
@@ -1173,7 +1119,7 @@ def layernorm(
     t1 = setup_ttnn_tensor(y, device, layout[1], input_mem_config[1], dtype[1])
     t2 = setup_ttnn_tensor(z, device, layout[2], input_mem_config[2], dtype[2])
 
-    t3 = ttnn.layer_norm(t0, weight=t1, bias=t2, memory_config=memory_config_to_ttnn(output_mem_config))
+    t3 = ttnn.layer_norm(t0, weight=t1, bias=t2, memory_config=output_mem_config)
 
     return ttnn_tensor_to_torch(t3)
 
@@ -1196,9 +1142,7 @@ def layernorm_residual(
     t2 = setup_ttnn_tensor(z, device, layout[2], input_mem_config[2], dtype[2])
     t3 = setup_ttnn_tensor(w, device, layout[3], input_mem_config[3], dtype[3])
 
-    t4 = ttnn.layer_norm(
-        t0, residual_input_tensor=t1, weight=t2, bias=t3, memory_config=memory_config_to_ttnn(output_mem_config)
-    )
+    t4 = ttnn.layer_norm(t0, residual_input_tensor=t1, weight=t2, bias=t3, memory_config=output_mem_config)
 
     return ttnn_tensor_to_torch(t4)
 
@@ -1214,7 +1158,7 @@ def layernorm_noweights(
     **kwargs,
 ):
     t0 = setup_ttnn_tensor(x, device, layout[0], input_mem_config[0], dtype[0])
-    t1 = ttnn.layer_norm(t0, memory_config=memory_config_to_ttnn(output_mem_config))
+    t1 = ttnn.layer_norm(t0, memory_config=output_mem_config)
 
     return ttnn_tensor_to_torch(t1)
 
@@ -1230,9 +1174,7 @@ def attention_softmax_nomask(
     **kwargs,
 ):
     t0 = setup_ttnn_tensor(x, device, layout[0], input_mem_config[0], dtype[0])
-    t2 = ttnn.transformer.attention_softmax(
-        t0, head_size=None, attention_mask=None, memory_config=memory_config_to_ttnn(output_mem_config)
-    )
+    t2 = ttnn.transformer.attention_softmax(t0, head_size=None, attention_mask=None, memory_config=output_mem_config)
 
     return ttnn_tensor_to_torch(t2)
 
@@ -1258,9 +1200,7 @@ def attention_softmax(
     if scalar < 0:
         scalar = -scalar
 
-    t2 = ttnn.transformer.attention_softmax(
-        t0, head_size=scalar, attention_mask=t1, memory_config=memory_config_to_ttnn(output_mem_config)
-    )
+    t2 = ttnn.transformer.attention_softmax(t0, head_size=scalar, attention_mask=t1, memory_config=output_mem_config)
 
     return ttnn_tensor_to_torch(t2)
 
@@ -1279,7 +1219,7 @@ def rmsnorm(
     t0 = setup_ttnn_tensor(x, device, layout[0], input_mem_config[0], dtype[0])
     t1 = setup_ttnn_tensor(y, device, layout[1], input_mem_config[1], dtype[1])
 
-    t2 = ttnn.rms_norm(t0, residual_input_tensor=t1, memory_config=memory_config_to_ttnn(output_mem_config))
+    t2 = ttnn.rms_norm(t0, residual_input_tensor=t1, memory_config=output_mem_config)
     return ttnn_tensor_to_torch(t2)
 
 
@@ -1294,7 +1234,7 @@ def transformer_concatenate_heads(
     **kwargs,
 ):
     t0 = setup_ttnn_tensor(x, device, layout[0], input_mem_config[0], dtype[0])
-    t1 = ttnn.transformer.concatenate_heads(t0, memory_config=memory_config_to_ttnn(output_mem_config))
+    t1 = ttnn.transformer.concatenate_heads(t0, memory_config=output_mem_config)
 
     return ttnn_tensor_to_torch(t1)
 
@@ -1311,7 +1251,7 @@ def full_like(
     **kwargs,
 ):
     t0 = setup_ttnn_tensor(x, device, layout[0], input_mem_config[0], dtype[0])
-    t1 = ttnn.full_like(t0, fill_value=scalar, memory_config=memory_config_to_ttnn(output_mem_config))
+    t1 = ttnn.full_like(t0, fill_value=scalar, memory_config=output_mem_config)
 
     return ttnn_tensor_to_torch(t1)
 
@@ -1327,7 +1267,7 @@ def eltwise_relu6(
     **kwargs,
 ):
     t0 = setup_ttnn_tensor(x, device, layout[0], input_mem_config[0], dtype[0])
-    t1 = ttnn.relu6(t0, memory_config=memory_config_to_ttnn(output_mem_config))
+    t1 = ttnn.relu6(t0, memory_config=output_mem_config)
 
     return ttnn_tensor_to_torch(t1)
 
@@ -1343,7 +1283,7 @@ def eltwise_rsqrt(
     **kwargs,
 ):
     t0 = setup_ttnn_tensor(x, device, layout[0], input_mem_config[0], dtype[0])
-    t1 = ttnn.rsqrt(t0, memory_config=memory_config_to_ttnn(output_mem_config))
+    t1 = ttnn.rsqrt(t0, memory_config=output_mem_config)
 
     return ttnn_tensor_to_torch(t1)
 
@@ -1359,7 +1299,7 @@ def eltwise_sigmoid(
     **kwargs,
 ):
     t0 = setup_ttnn_tensor(x, device, layout[0], input_mem_config[0], dtype[0])
-    t1 = ttnn.sigmoid(t0, memory_config=memory_config_to_ttnn(output_mem_config))
+    t1 = ttnn.sigmoid(t0, memory_config=output_mem_config)
 
     return ttnn_tensor_to_torch(t1)
 
@@ -1375,7 +1315,7 @@ def eltwise_sign(
     **kwargs,
 ):
     t0 = setup_ttnn_tensor(x, device, layout[0], input_mem_config[0], dtype[0])
-    t1 = ttnn.sign(t0, memory_config=memory_config_to_ttnn(output_mem_config))
+    t1 = ttnn.sign(t0, memory_config=output_mem_config)
 
     return ttnn_tensor_to_torch(t1)
 
@@ -1391,7 +1331,7 @@ def eltwise_silu(
     **kwargs,
 ):
     t0 = setup_ttnn_tensor(x, device, layout[0], input_mem_config[0], dtype[0])
-    t1 = ttnn.silu(t0, memory_config=memory_config_to_ttnn(output_mem_config))
+    t1 = ttnn.silu(t0, memory_config=output_mem_config)
 
     return ttnn_tensor_to_torch(t1)
 
@@ -1407,7 +1347,7 @@ def eltwise_sigmoid_accurate(
     **kwargs,
 ):
     t0 = setup_ttnn_tensor(x, device, layout[0], input_mem_config[0], dtype[0])
-    t1 = ttnn.sigmoid_accurate(t0, memory_config=memory_config_to_ttnn(output_mem_config))
+    t1 = ttnn.sigmoid_accurate(t0, memory_config=output_mem_config)
 
     return ttnn_tensor_to_torch(t1)
 
@@ -1423,7 +1363,7 @@ def eltwise_sin(
     **kwargs,
 ):
     t0 = setup_ttnn_tensor(x, device, layout[0], input_mem_config[0], dtype[0])
-    t1 = ttnn.sin(t0, memory_config=memory_config_to_ttnn(output_mem_config))
+    t1 = ttnn.sin(t0, memory_config=output_mem_config)
 
     return ttnn_tensor_to_torch(t1)
 
@@ -1439,7 +1379,7 @@ def eltwise_sinh(
     **kwargs,
 ):
     t0 = setup_ttnn_tensor(x, device, layout[0], input_mem_config[0], dtype[0])
-    t1 = ttnn.sinh(t0, memory_config=memory_config_to_ttnn(output_mem_config))
+    t1 = ttnn.sinh(t0, memory_config=output_mem_config)
 
     return ttnn_tensor_to_torch(t1)
 
@@ -1456,7 +1396,7 @@ def eltwise_softshrink(
     **kwargs,
 ):
     t0 = setup_ttnn_tensor(x, device, layout[0], input_mem_config[0], dtype[0])
-    t1 = ttnn.softshrink(t0, lambd=_lambda, memory_config=memory_config_to_ttnn(output_mem_config))
+    t1 = ttnn.softshrink(t0, lambd=_lambda, memory_config=output_mem_config)
 
     return ttnn_tensor_to_torch(t1)
 
@@ -1472,7 +1412,7 @@ def eltwise_softsign(
     **kwargs,
 ):
     t0 = setup_ttnn_tensor(x, device, layout[0], input_mem_config[0], dtype[0])
-    t1 = ttnn.softsign(t0, memory_config=memory_config_to_ttnn(output_mem_config))
+    t1 = ttnn.softsign(t0, memory_config=output_mem_config)
 
     return ttnn_tensor_to_torch(t1)
 
@@ -1488,7 +1428,7 @@ def eltwise_tan(
     **kwargs,
 ):
     t0 = setup_ttnn_tensor(x, device, layout[0], input_mem_config[0], dtype[0])
-    t1 = ttnn.tan(t0, memory_config=memory_config_to_ttnn(output_mem_config))
+    t1 = ttnn.tan(t0, memory_config=output_mem_config)
 
     return ttnn_tensor_to_torch(t1)
 
@@ -1504,7 +1444,7 @@ def eltwise_tanh(
     **kwargs,
 ):
     t0 = setup_ttnn_tensor(x, device, layout[0], input_mem_config[0], dtype[0])
-    t1 = ttnn.tanh(t0, memory_config=memory_config_to_ttnn(output_mem_config))
+    t1 = ttnn.tanh(t0, memory_config=output_mem_config)
 
     return ttnn_tensor_to_torch(t1)
 
@@ -1520,7 +1460,7 @@ def eltwise_swish(
     **kwargs,
 ):
     t0 = setup_ttnn_tensor(x, device, layout[0], input_mem_config[0], dtype[0])
-    t1 = ttnn.swish(t0, memory_config=memory_config_to_ttnn(output_mem_config))
+    t1 = ttnn.swish(t0, memory_config=output_mem_config)
 
     return ttnn_tensor_to_torch(t1)
 
@@ -1536,7 +1476,7 @@ def eltwise_signbit(
     **kwargs,
 ):
     t0 = setup_ttnn_tensor(x, device, layout[0], input_mem_config[0], dtype[0])
-    t1 = ttnn.signbit(t0, memory_config=memory_config_to_ttnn(output_mem_config))
+    t1 = ttnn.signbit(t0, memory_config=output_mem_config)
 
     return ttnn_tensor_to_torch(t1)
 
@@ -1552,7 +1492,7 @@ def eltwise_rad2deg(
     **kwargs,
 ):
     t0 = setup_ttnn_tensor(x, device, layout[0], input_mem_config[0], dtype[0])
-    t1 = ttnn.rad2deg(t0, memory_config=memory_config_to_ttnn(output_mem_config))
+    t1 = ttnn.rad2deg(t0, memory_config=output_mem_config)
 
     return ttnn_tensor_to_torch(t1)
 
@@ -1569,7 +1509,7 @@ def eltwise_polygamma(
     **kwargs,
 ):
     t0 = setup_ttnn_tensor(x, device, layout[0], input_mem_config[0], dtype[0])
-    t1 = ttnn.polygamma(t0, k=k, memory_config=memory_config_to_ttnn(output_mem_config))
+    t1 = ttnn.polygamma(t0, k=k, memory_config=output_mem_config)
 
     return ttnn_tensor_to_torch(t1)
 
@@ -1585,7 +1525,7 @@ def eltwise_recip(
     **kwargs,
 ):
     t0 = setup_ttnn_tensor(x, device, layout[0], input_mem_config[0], dtype[0])
-    t1 = ttnn.reciprocal(t0, memory_config=memory_config_to_ttnn(output_mem_config))
+    t1 = ttnn.reciprocal(t0, memory_config=output_mem_config)
 
     return ttnn_tensor_to_torch(t1)
 
@@ -1601,7 +1541,7 @@ def eltwise_sqrt(
     **kwargs,
 ):
     t0 = setup_ttnn_tensor(x, device, layout[0], input_mem_config[0], dtype[0])
-    t1 = ttnn.sqrt(t0, memory_config=memory_config_to_ttnn(output_mem_config))
+    t1 = ttnn.sqrt(t0, memory_config=output_mem_config)
 
     return ttnn_tensor_to_torch(t1)
 
@@ -1617,7 +1557,7 @@ def eltwise_square(
     **kwargs,
 ):
     t0 = setup_ttnn_tensor(x, device, layout[0], input_mem_config[0], dtype[0])
-    t1 = ttnn.square(t0, memory_config=memory_config_to_ttnn(output_mem_config))
+    t1 = ttnn.square(t0, memory_config=output_mem_config)
 
     return ttnn_tensor_to_torch(t1)
 
@@ -1633,7 +1573,7 @@ def tril(
     **kwargs,
 ):
     t0 = setup_ttnn_tensor(x, device, layout[0], input_mem_config[0], dtype[0])
-    t1 = ttnn.tril(t0, memory_config=memory_config_to_ttnn(output_mem_config))
+    t1 = ttnn.tril(t0, memory_config=output_mem_config)
 
     return ttnn_tensor_to_torch(t1)
 
@@ -1649,7 +1589,7 @@ def triu(
     **kwargs,
 ):
     t0 = setup_ttnn_tensor(x, device, layout[0], input_mem_config[0], dtype[0])
-    t1 = ttnn.triu(t0, memory_config=memory_config_to_ttnn(output_mem_config))
+    t1 = ttnn.triu(t0, memory_config=output_mem_config)
 
     return ttnn_tensor_to_torch(t1)
 
@@ -1665,7 +1605,7 @@ def eltwise_tanhshrink(
     **kwargs,
 ):
     t0 = setup_ttnn_tensor(x, device, layout[0], input_mem_config[0], dtype[0])
-    t1 = ttnn.tanhshrink(t0, memory_config=memory_config_to_ttnn(output_mem_config))
+    t1 = ttnn.tanhshrink(t0, memory_config=output_mem_config)
 
     return ttnn_tensor_to_torch(t1)
 
@@ -1683,7 +1623,7 @@ def eltwise_threshold(
     **kwargs,
 ):
     t0 = setup_ttnn_tensor(x, device, layout[0], input_mem_config[0], dtype[0])
-    t1 = ttnn.threshold(t0, threshold, value, memory_config=memory_config_to_ttnn(output_mem_config))
+    t1 = ttnn.threshold(t0, threshold, value, memory_config=output_mem_config)
 
     return ttnn_tensor_to_torch(t1)
 
@@ -1699,7 +1639,7 @@ def eltwise_eqz(
     **kwargs,
 ):
     t0 = setup_ttnn_tensor(x, device, layout[0], input_mem_config[0], dtype[0])
-    t1 = ttnn.eqz(t0, memory_config=memory_config_to_ttnn(output_mem_config))
+    t1 = ttnn.eqz(t0, memory_config=output_mem_config)
 
     return ttnn_tensor_to_torch(t1)
 
@@ -1722,7 +1662,7 @@ def eltwise_gt(
     else:
         t1 = scalar
 
-    t2 = ttnn.gt(t0, t1, memory_config=memory_config_to_ttnn(output_mem_config))
+    t2 = ttnn.gt(t0, t1, memory_config=output_mem_config)
 
     return ttnn_tensor_to_torch(t2)
 
@@ -1745,7 +1685,7 @@ def eltwise_gte(
     else:
         t1 = scalar
 
-    t2 = ttnn.ge(t0, t1, memory_config=memory_config_to_ttnn(output_mem_config))
+    t2 = ttnn.ge(t0, t1, memory_config=output_mem_config)
 
     return ttnn_tensor_to_torch(t2)
 
@@ -1768,7 +1708,7 @@ def eltwise_lt(
     else:
         t1 = scalar
 
-    t2 = ttnn.lt(t0, t1, memory_config=memory_config_to_ttnn(output_mem_config))
+    t2 = ttnn.lt(t0, t1, memory_config=output_mem_config)
 
     return ttnn_tensor_to_torch(t2)
 
@@ -1791,7 +1731,7 @@ def eltwise_lte(
     else:
         t1 = scalar
 
-    t2 = ttnn.le(t0, t1, memory_config=memory_config_to_ttnn(output_mem_config))
+    t2 = ttnn.le(t0, t1, memory_config=output_mem_config)
 
     return ttnn_tensor_to_torch(t2)
 
@@ -1814,7 +1754,7 @@ def eltwise_eq(
     else:
         t1 = scalar
 
-    t2 = ttnn.eq(t0, t1, memory_config=memory_config_to_ttnn(output_mem_config))
+    t2 = ttnn.eq(t0, t1, memory_config=output_mem_config)
 
     return ttnn_tensor_to_torch(t2)
 
@@ -1837,7 +1777,7 @@ def eltwise_ne(
     else:
         t1 = scalar
 
-    t2 = ttnn.ne(t0, t1, memory_config=memory_config_to_ttnn(output_mem_config))
+    t2 = ttnn.ne(t0, t1, memory_config=output_mem_config)
 
     return ttnn_tensor_to_torch(t2)
 
@@ -1858,7 +1798,7 @@ def eltwise_isclose(
     t0 = setup_ttnn_tensor(x, device, layout[0], input_mem_config[0], dtype[0])
     t1 = setup_ttnn_tensor(y, device, layout[1], input_mem_config[1], dtype[1])
 
-    t2 = ttnn.isclose(t0, t1, rtol=rtol, atol=atol, memory_config=memory_config_to_ttnn(output_mem_config))
+    t2 = ttnn.isclose(t0, t1, rtol=rtol, atol=atol, memory_config=output_mem_config)
 
     return ttnn_tensor_to_torch(t2)
 
@@ -1875,7 +1815,7 @@ def eltwise_polyval(
     **kwargs,
 ):
     t0 = setup_ttnn_tensor(x, device, layout[0], input_mem_config[0], dtype[0])
-    t1 = ttnn.polyval(t0, coeffs, memory_config=memory_config_to_ttnn(output_mem_config))
+    t1 = ttnn.polyval(t0, coeffs, memory_config=output_mem_config)
 
     return ttnn_tensor_to_torch(t1)
 
@@ -1891,7 +1831,7 @@ def abs(
     **kwargs,
 ):
     t0 = setup_ttnn_tensor(x, device, layout[0], input_mem_config[0], dtype[0])
-    t1 = ttnn.abs(t0, memory_config=memory_config_to_ttnn(output_mem_config))
+    t1 = ttnn.abs(t0, memory_config=output_mem_config)
 
     return ttnn_tensor_to_torch(t1)
 
@@ -1907,7 +1847,7 @@ def acos(
     **kwargs,
 ):
     t0 = setup_ttnn_tensor(x, device, layout[0], input_mem_config[0], dtype[0])
-    t1 = ttnn.acos(t0, memory_config=memory_config_to_ttnn(output_mem_config))
+    t1 = ttnn.acos(t0, memory_config=output_mem_config)
 
     return ttnn_tensor_to_torch(t1)
 
@@ -1923,7 +1863,7 @@ def acosh(
     **kwargs,
 ):
     t0 = setup_ttnn_tensor(x, device, layout[0], input_mem_config[0], dtype[0])
-    t1 = ttnn.acosh(t0, memory_config=memory_config_to_ttnn(output_mem_config))
+    t1 = ttnn.acosh(t0, memory_config=output_mem_config)
 
     return ttnn_tensor_to_torch(t1)
 
@@ -1939,7 +1879,7 @@ def asin(
     **kwargs,
 ):
     t0 = setup_ttnn_tensor(x, device, layout[0], input_mem_config[0], dtype[0])
-    t1 = ttnn.asin(t0, memory_config=memory_config_to_ttnn(output_mem_config))
+    t1 = ttnn.asin(t0, memory_config=output_mem_config)
 
     return ttnn_tensor_to_torch(t1)
 
@@ -1955,7 +1895,7 @@ def asinh(
     **kwargs,
 ):
     t0 = setup_ttnn_tensor(x, device, layout[0], input_mem_config[0], dtype[0])
-    t1 = ttnn.asinh(t0, memory_config=memory_config_to_ttnn(output_mem_config))
+    t1 = ttnn.asinh(t0, memory_config=output_mem_config)
 
     return ttnn_tensor_to_torch(t1)
 
@@ -1971,7 +1911,7 @@ def atan(
     **kwargs,
 ):
     t0 = setup_ttnn_tensor(x, device, layout[0], input_mem_config[0], dtype[0])
-    t1 = ttnn.atan(t0, memory_config=memory_config_to_ttnn(output_mem_config))
+    t1 = ttnn.atan(t0, memory_config=output_mem_config)
 
     return ttnn_tensor_to_torch(t1)
 
@@ -1990,7 +1930,7 @@ def atan2(
     t0 = setup_ttnn_tensor(x, device, layout[0], input_mem_config[0], dtype[0])
     t1 = setup_ttnn_tensor(y, device, layout[0], input_mem_config[0], dtype[0])
 
-    t2 = ttnn.atan2(t0, t1, memory_config=memory_config_to_ttnn(output_mem_config))
+    t2 = ttnn.atan2(t0, t1, memory_config=output_mem_config)
 
     return ttnn_tensor_to_torch(t2)
 
@@ -2006,7 +1946,7 @@ def atanh(
     **kwargs,
 ):
     t0 = setup_ttnn_tensor(x, device, layout[0], input_mem_config[0], dtype[0])
-    t1 = ttnn.atanh(t0, memory_config=memory_config_to_ttnn(output_mem_config))
+    t1 = ttnn.atanh(t0, memory_config=output_mem_config)
 
     return ttnn_tensor_to_torch(t1)
 
@@ -2022,7 +1962,7 @@ def cos(
     **kwargs,
 ):
     t0 = setup_ttnn_tensor(x, device, layout[0], input_mem_config[0], dtype[0])
-    t1 = ttnn.cos(t0, memory_config=memory_config_to_ttnn(output_mem_config))
+    t1 = ttnn.cos(t0, memory_config=output_mem_config)
 
     return ttnn_tensor_to_torch(t1)
 
@@ -2038,7 +1978,7 @@ def cosh(
     **kwargs,
 ):
     t0 = setup_ttnn_tensor(x, device, layout[0], input_mem_config[0], dtype[0])
-    t1 = ttnn.cosh(t0, memory_config=memory_config_to_ttnn(output_mem_config))
+    t1 = ttnn.cosh(t0, memory_config=output_mem_config)
 
     return ttnn_tensor_to_torch(t1)
 
@@ -2070,7 +2010,7 @@ def exp2(
     **kwargs,
 ):
     t0 = setup_ttnn_tensor(x, device, layout[0], input_mem_config[0], dtype[0])
-    t1 = ttnn.exp2(t0, memory_config=memory_config_to_ttnn(output_mem_config))
+    t1 = ttnn.exp2(t0, memory_config=output_mem_config)
 
     return ttnn_tensor_to_torch(t1)
 
@@ -2086,7 +2026,7 @@ def expm1(
     **kwargs,
 ):
     t0 = setup_ttnn_tensor(x, device, layout[0], input_mem_config[0], dtype[0])
-    t1 = ttnn.expm1(t0, memory_config=memory_config_to_ttnn(output_mem_config))
+    t1 = ttnn.expm1(t0, memory_config=output_mem_config)
 
     return ttnn_tensor_to_torch(t1)
 
@@ -2103,7 +2043,7 @@ def elu(
     **kwargs,
 ):
     t0 = setup_ttnn_tensor(x, device, layout[0], input_mem_config[0], dtype[0])
-    t1 = ttnn.elu(t0, alpha, memory_config=memory_config_to_ttnn(output_mem_config))
+    t1 = ttnn.elu(t0, alpha, memory_config=output_mem_config)
 
     return ttnn_tensor_to_torch(t1)
 
@@ -2119,7 +2059,7 @@ def erf(
     **kwargs,
 ):
     t0 = setup_ttnn_tensor(x, device, layout[0], input_mem_config[0], dtype[0])
-    t1 = ttnn.erf(t0, memory_config=memory_config_to_ttnn(output_mem_config))
+    t1 = ttnn.erf(t0, memory_config=output_mem_config)
 
     return ttnn_tensor_to_torch(t1)
 
@@ -2135,7 +2075,7 @@ def erfc(
     **kwargs,
 ):
     t0 = setup_ttnn_tensor(x, device, layout[0], input_mem_config[0], dtype[0])
-    t1 = ttnn.erfc(t0, memory_config=memory_config_to_ttnn(output_mem_config))
+    t1 = ttnn.erfc(t0, memory_config=output_mem_config)
 
     return ttnn_tensor_to_torch(t1)
 
@@ -2151,7 +2091,7 @@ def erfinv(
     **kwargs,
 ):
     t0 = setup_ttnn_tensor(x, device, layout[0], input_mem_config[0], dtype[0])
-    t1 = ttnn.erfinv(t0, memory_config=memory_config_to_ttnn(output_mem_config))
+    t1 = ttnn.erfinv(t0, memory_config=output_mem_config)
 
     return ttnn_tensor_to_torch(t1)
 
@@ -2167,7 +2107,7 @@ def hardsigmoid(
     **kwargs,
 ):
     t0 = setup_ttnn_tensor(x, device, layout[0], input_mem_config[0], dtype[0])
-    t1 = ttnn.hardsigmoid(t0, memory_config=memory_config_to_ttnn(output_mem_config))
+    t1 = ttnn.hardsigmoid(t0, memory_config=output_mem_config)
 
     return ttnn_tensor_to_torch(t1)
 
@@ -2183,7 +2123,7 @@ def deg2rad(
     **kwargs,
 ):
     t0 = setup_ttnn_tensor(x, device, layout[0], input_mem_config[0], dtype[0])
-    t1 = ttnn.deg2rad(t0, memory_config=memory_config_to_ttnn(output_mem_config))
+    t1 = ttnn.deg2rad(t0, memory_config=output_mem_config)
 
     return ttnn_tensor_to_torch(t1)
 
@@ -2200,7 +2140,7 @@ def hardshrink(
     **kwargs,
 ):
     t0 = setup_ttnn_tensor(x, device, layout[0], input_mem_config[0], dtype[0])
-    t1 = ttnn.hardshrink(t0, lambd=_lambda, memory_config=memory_config_to_ttnn(output_mem_config))
+    t1 = ttnn.hardshrink(t0, lambd=_lambda, memory_config=output_mem_config)
 
     return ttnn_tensor_to_torch(t1)
 
@@ -2216,7 +2156,7 @@ def clone(
     **kwargs,
 ):
     t0 = setup_ttnn_tensor(x, device, layout[0], input_mem_config[0], dtype[0])
-    t1 = ttnn.clone(t0, memory_config_to_ttnn(output_mem_config), dtype=dtype[0])
+    t1 = ttnn.clone(t0, output_mem_config, dtype=dtype[0])
 
     return ttnn_tensor_to_torch(t1)
 
@@ -2232,7 +2172,7 @@ def cbrt(
     **kwargs,
 ):
     t0 = setup_ttnn_tensor(x, device, layout[0], input_mem_config[0], dtype[0])
-    t1 = ttnn.cbrt(t0, memory_config=memory_config_to_ttnn(output_mem_config))
+    t1 = ttnn.cbrt(t0, memory_config=output_mem_config)
 
     return ttnn_tensor_to_torch(t1)
 
@@ -2248,7 +2188,7 @@ def digamma(
     **kwargs,
 ):
     t0 = setup_ttnn_tensor(x, device, layout[0], input_mem_config[0], dtype[0])
-    t1 = ttnn.digamma(t0, memory_config=memory_config_to_ttnn(output_mem_config))
+    t1 = ttnn.digamma(t0, memory_config=output_mem_config)
 
     return ttnn_tensor_to_torch(t1)
 
@@ -2266,7 +2206,7 @@ def clip(
     **kwargs,
 ):
     t0 = setup_ttnn_tensor(x, device, layout[0], input_mem_config[0], dtype[0])
-    t1 = ttnn.clip(t0, low, high, memory_config=memory_config_to_ttnn(output_mem_config))
+    t1 = ttnn.clip(t0, low, high, memory_config=output_mem_config)
 
     return ttnn_tensor_to_torch(t1)
 
@@ -2284,7 +2224,7 @@ def repeat_interleave(
     **kwargs,
 ):
     t0 = setup_ttnn_tensor(x, device, layout[0], input_mem_config[0], dtype[0])
-    t1 = ttnn.repeat_interleave(t0, repeat, dim)  # memory_config=memory_config_to_ttnn(output_mem_config))
+    t1 = ttnn.repeat_interleave(t0, repeat, dim)  # memory_config=output_mem_config)
 
     return ttnn_tensor_to_torch(t1)
 
@@ -2306,7 +2246,7 @@ def addcmul(
     t1 = setup_ttnn_tensor(y, device, layout[1], input_mem_config[1], dtype[1])
     t2 = setup_ttnn_tensor(z, device, layout[2], input_mem_config[2], dtype[2])
 
-    t3 = ttnn.addcmul(t0, t1, t2, value=scalar, memory_config=memory_config_to_ttnn(output_mem_config))
+    t3 = ttnn.addcmul(t0, t1, t2, value=scalar, memory_config=output_mem_config)
 
     return ttnn_tensor_to_torch(t3)
 
@@ -2322,9 +2262,7 @@ def groupnorm_noweights(
     **kwargs,
 ):
     t0 = setup_ttnn_tensor(x, device, layout[0], input_mem_config[0], dtype[0])
-    t1 = ttnn.group_norm(
-        t0, num_groups=1, weight=None, bias=None, memory_config=memory_config_to_ttnn(output_mem_config)
-    )
+    t1 = ttnn.group_norm(t0, num_groups=1, weight=None, bias=None, memory_config=output_mem_config)
 
     return ttnn_tensor_to_torch(t1)
 
@@ -2345,7 +2283,7 @@ def eltwise_addcdiv(
     t0 = setup_ttnn_tensor(x, device, layout[0], input_mem_config[0], dtype[0])
     t1 = setup_ttnn_tensor(y, device, layout[1], input_mem_config[1], dtype[1])
     t2 = setup_ttnn_tensor(z, device, layout[2], input_mem_config[2], dtype[2])
-    t3 = ttnn.addcdiv(t0, t1, t2, value=scalar, memory_config=memory_config_to_ttnn(output_mem_config))
+    t3 = ttnn.addcdiv(t0, t1, t2, value=scalar, memory_config=output_mem_config)
 
     return ttnn_tensor_to_torch(t3)
 
@@ -2354,7 +2292,7 @@ def where(x, y, z, device, dtype, layout, input_mem_config, output_mem_config, *
     t0 = setup_ttnn_tensor(x, device, layout[0], input_mem_config[0], dtype[0])
     t1 = setup_ttnn_tensor(y, device, layout[1], input_mem_config[1], dtype[1])
     t2 = setup_ttnn_tensor(z, device, layout[2], input_mem_config[2], dtype[2])
-    t3 = ttnn.where(t0, t1, t2, memory_config=memory_config_to_ttnn(output_mem_config))
+    t3 = ttnn.where(t0, t1, t2, memory_config=output_mem_config)
 
     return ttnn_tensor_to_torch(t3)
 
@@ -2375,7 +2313,7 @@ def concat(
     t1 = setup_ttnn_tensor(y, device, layout[1], input_mem_config[1], dtype[1])
 
     xtt = (t0, t1)
-    t2 = ttnn.concat(xtt, dim, memory_config=memory_config_to_ttnn(output_mem_config))
+    t2 = ttnn.concat(xtt, dim, memory_config=output_mem_config)
 
     return ttnn_tensor_to_torch(t2)
 
@@ -2413,7 +2351,7 @@ def upsample(
     **kwargs,
 ):
     t0 = setup_ttnn_tensor(x, device, layout[0], input_mem_config[0], dtype[0])
-    t1 = ttnn.upsample(t0, scale_factor=scale_factor, memory_config=memory_config_to_ttnn(output_mem_config))
+    t1 = ttnn.upsample(t0, scale_factor=scale_factor, memory_config=output_mem_config)
 
     return ttnn_tensor_to_torch(t1)
 
@@ -2435,7 +2373,7 @@ def l1_loss_sum(
     t0 = setup_ttnn_tensor(x, device, layout[0], input_mem_config[0], dtype[0])
     t1 = setup_ttnn_tensor(y, device, layout[1], input_mem_config[1], dtype[1])
 
-    t2 = ttnn.l1_loss(t0, t1, loss_mode="sum", memory_config=memory_config_to_ttnn(output_mem_config))
+    t2 = ttnn.l1_loss(t0, t1, loss_mode="sum", memory_config=output_mem_config)
 
     return ttnn_tensor_to_torch(t2)
 
@@ -2457,7 +2395,7 @@ def l1_loss_mean(
     t0 = setup_ttnn_tensor(x, device, layout[0], input_mem_config[0], dtype[0])
     t1 = setup_ttnn_tensor(y, device, layout[1], input_mem_config[1], dtype[1])
 
-    t2 = ttnn.l1_loss(t0, t1, loss_mode="mean", memory_config=memory_config_to_ttnn(output_mem_config))
+    t2 = ttnn.l1_loss(t0, t1, loss_mode="mean", memory_config=output_mem_config)
 
     return ttnn_tensor_to_torch(t2)
 
@@ -2479,7 +2417,7 @@ def l1_loss(
     t0 = setup_ttnn_tensor(x, device, layout[0], input_mem_config[0], dtype[0])
     t1 = setup_ttnn_tensor(y, device, layout[1], input_mem_config[1], dtype[1])
 
-    t2 = ttnn.l1_loss(t0, t1, loss_mode="none", memory_config=memory_config_to_ttnn(output_mem_config))
+    t2 = ttnn.l1_loss(t0, t1, loss_mode="none", memory_config=output_mem_config)
 
     return ttnn_tensor_to_torch(t2)
 
@@ -2501,7 +2439,7 @@ def mse_loss_sum(
     t0 = setup_ttnn_tensor(x, device, layout[0], input_mem_config[0], dtype[0])
     t1 = setup_ttnn_tensor(y, device, layout[1], input_mem_config[1], dtype[1])
 
-    t2 = ttnn.mse_loss(t0, t1, loss_mode="sum", memory_config=memory_config_to_ttnn(output_mem_config))
+    t2 = ttnn.mse_loss(t0, t1, loss_mode="sum", memory_config=output_mem_config)
 
     return ttnn_tensor_to_torch(t2)
 
@@ -2523,7 +2461,7 @@ def mse_loss_mean(
     t0 = setup_ttnn_tensor(x, device, layout[0], input_mem_config[0], dtype[0])
     t1 = setup_ttnn_tensor(y, device, layout[1], input_mem_config[1], dtype[1])
 
-    t2 = ttnn.mse_loss(t0, t1, loss_mode="mean", memory_config=memory_config_to_ttnn(output_mem_config))
+    t2 = ttnn.mse_loss(t0, t1, loss_mode="mean", memory_config=output_mem_config)
 
     return ttnn_tensor_to_torch(t2)
 
@@ -2545,7 +2483,7 @@ def mse_loss(
     t0 = setup_ttnn_tensor(x, device, layout[0], input_mem_config[0], dtype[0])
     t1 = setup_ttnn_tensor(y, device, layout[1], input_mem_config[1], dtype[1])
 
-    t2 = ttnn.mse_loss(t0, t1, loss_mode="none", memory_config=memory_config_to_ttnn(output_mem_config))
+    t2 = ttnn.mse_loss(t0, t1, loss_mode="none", memory_config=output_mem_config)
 
     return ttnn_tensor_to_torch(t2)
 
@@ -2564,7 +2502,7 @@ def ldexp(
     t0 = setup_ttnn_tensor(x, device, layout[0], input_mem_config[0], dtype[0])
     t1 = setup_ttnn_tensor(y, device, layout[1], input_mem_config[1], dtype[1])
 
-    t2 = ttnn.ldexp(t0, t1, memory_config=memory_config_to_ttnn(output_mem_config))
+    t2 = ttnn.ldexp(t0, t1, memory_config=output_mem_config)
 
     return ttnn_tensor_to_torch(t2)
 
@@ -2583,7 +2521,7 @@ def logical_and(
     t0 = setup_ttnn_tensor(x, device, layout[0], input_mem_config[0], dtype[0])
     t1 = setup_ttnn_tensor(y, device, layout[1], input_mem_config[1], dtype[1])
 
-    t2 = ttnn.logical_and(t0, t1, memory_config=memory_config_to_ttnn(output_mem_config))
+    t2 = ttnn.logical_and(t0, t1, memory_config=output_mem_config)
 
     return ttnn_tensor_to_torch(t2)
 
@@ -2602,7 +2540,7 @@ def logical_or(
     t0 = setup_ttnn_tensor(x, device, layout[0], input_mem_config[0], dtype[0])
     t1 = setup_ttnn_tensor(y, device, layout[1], input_mem_config[1], dtype[1])
 
-    t2 = ttnn.logical_or(t0, t1, memory_config=memory_config_to_ttnn(output_mem_config))
+    t2 = ttnn.logical_or(t0, t1, memory_config=output_mem_config)
 
     return ttnn_tensor_to_torch(t2)
 
@@ -2621,7 +2559,7 @@ def logical_xor(
     t0 = setup_ttnn_tensor(x, device, layout[0], input_mem_config[0], dtype[0])
     t1 = setup_ttnn_tensor(y, device, layout[1], input_mem_config[1], dtype[1])
 
-    t2 = ttnn.logical_xor(t0, t1, memory_config=memory_config_to_ttnn(output_mem_config))
+    t2 = ttnn.logical_xor(t0, t1, memory_config=output_mem_config)
 
     return ttnn_tensor_to_torch(t2)
 
@@ -2641,11 +2579,11 @@ def pow(
     t0 = setup_ttnn_tensor(x, device, layout[0], input_mem_config[0], dtype[0])
 
     if exponent is not None:
-        t1 = ttnn.pow(t0, exponent, memory_config=memory_config_to_ttnn(output_mem_config))
+        t1 = ttnn.pow(t0, exponent, memory_config=output_mem_config)
         return ttnn_tensor_to_torch(t1)
     else:
         t1 = setup_ttnn_tensor(y, device, layout[1], input_mem_config[1], dtype[1])
-        t2 = ttnn.pow(t0, t1, memory_config=memory_config_to_ttnn(output_mem_config))
+        t2 = ttnn.pow(t0, t1, memory_config=output_mem_config)
         return ttnn_tensor_to_torch(t2)
 
 
@@ -2663,7 +2601,7 @@ def logaddexp(
     t0 = setup_ttnn_tensor(x, device, layout[0], input_mem_config[0], dtype[0])
     t1 = setup_ttnn_tensor(y, device, layout[1], input_mem_config[1], dtype[1])
 
-    t2 = ttnn.logaddexp(t0, t1, memory_config=memory_config_to_ttnn(output_mem_config))
+    t2 = ttnn.logaddexp(t0, t1, memory_config=output_mem_config)
 
     return ttnn_tensor_to_torch(t2)
 
@@ -2682,7 +2620,7 @@ def logaddexp2(
     t0 = setup_ttnn_tensor(x, device, layout[0], input_mem_config[0], dtype[0])
     t1 = setup_ttnn_tensor(y, device, layout[1], input_mem_config[1], dtype[1])
 
-    t2 = ttnn.logaddexp2(t0, t1, memory_config=memory_config_to_ttnn(output_mem_config))
+    t2 = ttnn.logaddexp2(t0, t1, memory_config=output_mem_config)
 
     return ttnn_tensor_to_torch(t2)
 
@@ -2699,7 +2637,7 @@ def sum(
     **kwargs,
 ):
     t0 = setup_ttnn_tensor(x, device, layout[0], input_mem_config[0], dtype[0])
-    t1 = ttnn.sum(t0, dim=dim, memory_config=memory_config_to_ttnn(output_mem_config))
+    t1 = ttnn.sum(t0, dim=dim, memory_config=output_mem_config)
 
     return ttnn_tensor_to_torch(t1)
 
@@ -2716,7 +2654,7 @@ def max(
     **kwargs,
 ):
     t0 = setup_ttnn_tensor(x, device, layout[0], input_mem_config[0], dtype[0])
-    t1 = ttnn.max(t0, dim=dim, memory_config=memory_config_to_ttnn(output_mem_config))
+    t1 = ttnn.max(t0, dim=dim, memory_config=output_mem_config)
 
     return ttnn_tensor_to_torch(t1)
 
@@ -2733,7 +2671,7 @@ def min(
     **kwargs,
 ):
     t0 = setup_ttnn_tensor(x, device, layout[0], input_mem_config[0], dtype[0])
-    t1 = ttnn.min(t0, dim=dim, memory_config=memory_config_to_ttnn(output_mem_config))
+    t1 = ttnn.min(t0, dim=dim, memory_config=output_mem_config)
 
     return ttnn_tensor_to_torch(t1)
 
@@ -2752,7 +2690,7 @@ def eltwise_max(
     t0 = setup_ttnn_tensor(x, device, layout[0], input_mem_config[0], dtype[0])
     t1 = setup_ttnn_tensor(y, device, layout[1], input_mem_config[1], dtype[1])
 
-    t2 = ttnn.maximum(t0, t1, memory_config=memory_config_to_ttnn(output_mem_config))
+    t2 = ttnn.maximum(t0, t1, memory_config=output_mem_config)
     return ttnn_tensor_to_torch(t2)
 
 
@@ -2770,7 +2708,7 @@ def eltwise_min(
     t0 = setup_ttnn_tensor(x, device, layout[0], input_mem_config[0], dtype[0])
     t1 = setup_ttnn_tensor(y, device, layout[1], input_mem_config[1], dtype[1])
 
-    t2 = ttnn.minimum(t0, t1, memory_config=memory_config_to_ttnn(output_mem_config))
+    t2 = ttnn.minimum(t0, t1, memory_config=output_mem_config)
     return ttnn_tensor_to_torch(t2)
 
 
@@ -2787,8 +2725,8 @@ def rotary_embedding(
     torch.manual_seed(0)
 
     cache_size = 2048
-    input_dtype = tt_lib.tensor.DataType.BFLOAT16
-    sincos_dtype = tt_lib.tensor.DataType.BFLOAT16
+    input_dtype = ttnn.bfloat16
+    sincos_dtype = ttnn.bfloat16
 
     sin_cos_shape = (1, 1, cache_size, 64)
 
@@ -2799,9 +2737,7 @@ def rotary_embedding(
     t0 = setup_ttnn_tensor(x, device, layout[0], input_mem_config[0], dtype[0])
     cost = setup_ttnn_tensor(cos_cached, device, layout[0], input_mem_config[0], dtype[0])
     sint = setup_ttnn_tensor(sin_cached, device, layout[0], input_mem_config[0], dtype[0])
-    t2 = ttnn.experimental.rotary_embedding(
-        t0, cost, sint, None, memory_config=memory_config_to_ttnn(output_mem_config)
-    )
+    t2 = ttnn.experimental.rotary_embedding(t0, cost, sint, None, memory_config=output_mem_config)
 
     return ttnn_tensor_to_torch(t2)
 
@@ -2819,7 +2755,7 @@ def activation_reglu(
 ):
     t0 = setup_ttnn_tensor(x, device, layout[0], input_mem_config[0], dtype[0])
 
-    t1 = ttnn.reglu(t0, dim, memory_config=memory_config_to_ttnn(output_mem_config))
+    t1 = ttnn.reglu(t0, dim, memory_config=output_mem_config)
     return ttnn_tensor_to_torch(t1)
 
 
@@ -2856,7 +2792,7 @@ def nextafter(
     t0 = setup_ttnn_tensor(x, device, layout[0], input_mem_config[0], dtype[0])
     t1 = setup_ttnn_tensor(y, device, layout[1], input_mem_config[1], dtype[1])
 
-    t2 = ttnn.nextafter(t0, t1, memory_config=memory_config_to_ttnn(output_mem_config))
+    t2 = ttnn.nextafter(t0, t1, memory_config=output_mem_config)
 
     return ttnn_tensor_to_torch(t2)
 
@@ -2871,7 +2807,7 @@ def empty(
     output_mem_config,
     **kwargs,
 ):
-    t1 = ttnn.empty(shape=x.shape, memory_config=memory_config_to_ttnn(output_mem_config))
+    t1 = ttnn.empty(shape=x.shape, memory_config=output_mem_config)
 
     result = ttnn_tensor_to_torch(t1)
     return ttnn_tensor_to_torch(t1)
@@ -2944,9 +2880,9 @@ def zeros(
     t1 = ttnn.zeros(
         x.shape,
         device=device,
-        dtype=dtype_to_ttnn(dtype[0]),
-        layout=layout_to_ttnn(layout[0]),
-        memory_config=memory_config_to_ttnn(output_mem_config),
+        dtype=dtype[0],
+        layout=layout[0],
+        memory_config=output_mem_config,
     )
 
     return ttnn_tensor_to_torch(t1)
@@ -2966,7 +2902,7 @@ def zeros_like(
 
     t1 = ttnn.zeros_like(
         t0,
-        memory_config=memory_config_to_ttnn(output_mem_config),
+        memory_config=output_mem_config,
     )
 
     return ttnn_tensor_to_torch(t1)
@@ -3303,7 +3239,7 @@ def eltwise_subtract_and_apply_activation(
 
     t0 = setup_ttnn_tensor(x, device, layout[0], input_mem_config[0], dtype[0])
     t1 = setup_ttnn_tensor(y, device, layout[1], input_mem_config[1], dtype[1])
-    t2 = ttnn.subtract(t0, t1, activations=activations, memory_config=memory_config_to_ttnn(output_mem_config))
+    t2 = ttnn.subtract(t0, t1, activations=activations, memory_config=output_mem_config)
 
     return ttnn_tensor_to_torch(t2)
 
@@ -3351,7 +3287,7 @@ def eltwise_multiply_and_apply_activation(
 
     t0 = setup_ttnn_tensor(x, device, layout[0], input_mem_config[0], dtype[0])
     t1 = setup_ttnn_tensor(y, device, layout[1], input_mem_config[1], dtype[1])
-    t2 = ttnn.multiply(t0, t1, activations=activations, memory_config=memory_config_to_ttnn(output_mem_config))
+    t2 = ttnn.multiply(t0, t1, activations=activations, memory_config=output_mem_config)
 
     return ttnn_tensor_to_torch(t2)
 
@@ -4733,8 +4669,8 @@ def complex_conj_bw(
     output_mem_config,
     **kwargs,
 ):
-    if dtype[0] == tt_lib.tensor.DataType.BFLOAT8_B:
-        dtype[0] = tt_lib.tensor.DataType.BFLOAT16
+    if dtype[0] == ttnn.bfloat8_b:
+        dtype[0] = ttnn.bfloat16
 
     t0 = ttnn.complex_tensor(
         setup_ttnn_tensor(x.real, device, layout[0], input_mem_config[0], dtype[0]),

--- a/tests/ttnn/unit_tests/benchmarks/test_benchmark.py
+++ b/tests/ttnn/unit_tests/benchmarks/test_benchmark.py
@@ -7,15 +7,17 @@ import time
 import pytest
 import torch
 import ttnn
+from models.utility_functions import run_for_wormhole_b0
 
 
+@run_for_wormhole_b0()
 # fmt: off
-@pytest.mark.parametrize("height,width", [
-    (1024, 1024),
+@pytest.mark.parametrize("height,width,average_time", [
+    (1024, 1024, 1),
 ])
 @pytest.mark.parametrize("dtype", [ttnn.bfloat8_b, ttnn.bfloat16])
 # fmt: on
-def test_benchmark_ttnn_add(device, use_program_cache, height, width, dtype):
+def test_benchmark_ttnn_add(device, use_program_cache, height, width, dtype, average_time):
     torch.manual_seed(0)
 
     torch_input_tensor_a = torch.rand((height, width))
@@ -24,22 +26,27 @@ def test_benchmark_ttnn_add(device, use_program_cache, height, width, dtype):
     input_tensor_a = ttnn.from_torch(torch_input_tensor_a, layout=ttnn.TILE_LAYOUT, device=device, dtype=dtype)
     input_tensor_b = ttnn.from_torch(torch_input_tensor_b, layout=ttnn.TILE_LAYOUT, device=device, dtype=dtype)
     ttnn.matmul(input_tensor_a, input_tensor_b)
+    total_time = 0
     for i in range(3):
         start = time.time()
         output = ttnn.add(input_tensor_a, input_tensor_b)
         end = time.time()
         duration = end - start
+        total_time = total_time + duration
         print(f"ttnn.add: {duration} seconds")
         ttnn.to_torch(output)
+    total_time = total_time / 3
+    assert total_time <= average_time
 
 
+@run_for_wormhole_b0()
 # fmt: off
-@pytest.mark.parametrize("m_size,k_size,n_size", [
-    (384, 1024, 1024),
+@pytest.mark.parametrize("m_size,k_size,n_size,average_time", [
+    (384, 1024, 1024, 1),
 ])
 @pytest.mark.parametrize("dtype", [ttnn.bfloat8_b, ttnn.bfloat16])
 # fmt: on
-def test_benchmark_ttnn_matmul(device, use_program_cache, m_size, k_size, n_size, dtype):
+def test_benchmark_ttnn_matmul(device, use_program_cache, m_size, k_size, n_size, dtype, average_time):
     torch.manual_seed(0)
 
     torch_input_tensor_a = torch.rand((m_size, k_size))
@@ -48,10 +55,14 @@ def test_benchmark_ttnn_matmul(device, use_program_cache, m_size, k_size, n_size
     input_tensor_a = ttnn.from_torch(torch_input_tensor_a, layout=ttnn.TILE_LAYOUT, device=device, dtype=dtype)
     input_tensor_b = ttnn.from_torch(torch_input_tensor_b, layout=ttnn.TILE_LAYOUT, device=device, dtype=dtype)
     ttnn.matmul(input_tensor_a, input_tensor_b)
+    total_time = 0
     for i in range(3):
         start = time.time()
         output = ttnn.matmul(input_tensor_a, input_tensor_b)
         end = time.time()
         duration = end - start
+        total_time = total_time + duration
         print(f"ttnn.matmul: {duration} seconds")
         ttnn.to_torch(output)
+    total_time = total_time / 3
+    assert total_time <= average_time


### PR DESCRIPTION
Issue : #11559 , Tracking Issue : https://github.com/tenstorrent/tt-metal/issues/11242 , Master Issue : https://github.com/tenstorrent/tt-metal/issues/10532

### STATUS : PR Review

- Moved `tests for tests/ttnn/benchmarks/test_benchmark.py` to `tests/ttnn/unit_tests/benchmarks/test_benchmark.py` to run the test on CI - PASSED
- For `tests/ttnn/profiling/profile_host_overhead.py` ,we have test `tests/ttnn/profiling/test_host_overhead_ci.py` , which you can run locally with  `pytest tests/ttnn/profiling/test_host_overhead_ci.py`
  - Facing assertion error , which is due to the diff in measured and ref duration , but that's ok as some measured times fail, but system works and thats fine.
- Testing for `tests/ttnn/python_api_testing/sweep_tests/ttnn_ops.py` - `pytest tests/ttnn/python_api_testing/sweep_tests/run_sweep_test.py --input-path tests/ttnn/python_api_testing/sweep_tests/test_configs/ci_sweep_tests_working/grayskull/ttnn_eltwise_add_test.yaml --input-method cli --cli-input results_ttnn_add` - PASSED

https://github.com/tenstorrent/tt-metal/actions/runs/10593629322 - passed

CI :

- [All post-commit tests](https://github.com/tenstorrent/tt-metal/actions/runs/10595439597) - PASSED
- [[post-commit] C++ tests](https://github.com/tenstorrent/tt-metal/actions/runs/10595440682) - PASSED
- [(Single-card) Device perf regressions](https://github.com/tenstorrent/tt-metal/actions/runs/10595441880) - PASSED
- [[post-commit] models tests](https://github.com/tenstorrent/tt-metal/actions/runs/10595443216) - PASSED
- [(Single-card) Model perf tests](https://github.com/tenstorrent/tt-metal/actions/runs/10595444688) - PASSED
- [(T3K) T3000 model perf tests](https://github.com/tenstorrent/tt-metal/actions/runs/10595445755) - PASSED
- [(T3K) T3000 unit tests](https://github.com/tenstorrent/tt-metal/actions/runs/10595447484)
- [(T3K) T3000 demo tests](https://github.com/tenstorrent/tt-metal/actions/runs/10595449117)
- [Nightly fast dispatch tests](https://github.com/tenstorrent/tt-metal/actions/runs/10595450367)
- [(T3K) T3000 frequent tests](https://github.com/tenstorrent/tt-metal/actions/runs/10595451389) - PASSED
- [(Single-card) Demo tests](https://github.com/tenstorrent/tt-metal/actions/runs/10595453091) - PASSED