### PR TITLE
#11814: Propagate test script status to CI job status

### DIFF
--- a/tests/scripts/t3000/run_t3000_demo_tests.sh
+++ b/tests/scripts/t3000/run_t3000_demo_tests.sh
@@ -26,18 +26,22 @@ run_t3000_falcon40b_tests() {
 
 run_t3000_llama3_70b_tests() {
   # Record the start time
+  fail=0
   start_time=$(date +%s)
 
   echo "LOG_METAL: Running run_t3000_llama3_70b_tests"
 
   # Llama3 70B demo (output verification)
-  env WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml pytest models/demos/t3000/llama3_70b/demo/demo.py::test_LlamaModel_demo[wormhole_b0-True-short_context-check_enabled-greedy-tt-70b-T3000-80L-decode_only-text_completion-llama3] --timeout=900
+  env WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml pytest models/demos/t3000/llama3_70b/demo/demo.py::test_LlamaModel_demo[wormhole_b0-True-short_context-check_enabled-greedy-tt-70b-T3000-80L-decode_only-text_completion-llama3] --timeout=900 ; fail+=$?
 
 
   # Record the end time
   end_time=$(date +%s)
   duration=$((end_time - start_time))
   echo "LOG_METAL: run_t3000_llama3_70b_tests $duration seconds to complete"
+  if [[ $fail -ne 0 ]]; then
+    exit 1
+  fi
 }
 
 run_t3000_falcon7b_tests(){


### PR DESCRIPTION
### Ticket
(https://github.com/tenstorrent/tt-metal/issues/11814)

### Problem description
Failing test does not propagate status to CI job

### What's changed
It's added in bash script collecting output value from script

### Checklist
- [x] Demo test failing as observed in log: https://github.com/tenstorrent/tt-metal/actions/runs/10523890618 
