### PR TITLE
#11845: fix worker ring direction assignment in reduce scatter

### DIFF
--- a/ttnn/cpp/ttnn/operations/ccl/reduce_scatter/device/host/reduce_scatter_full_worker_grid.cpp
+++ b/ttnn/cpp/ttnn/operations/ccl/reduce_scatter/device/host/reduce_scatter_full_worker_grid.cpp
@@ -802,7 +802,8 @@ operation::ProgramWithCallbacks reduce_scatter_with_workers(
 
     // Configure the EDM builders
     std::function<bool(uint32_t)> is_worker_in_clockwise_direction_fn = [enable_bidirectional, num_edm_channels](uint32_t x) {
-                return enable_bidirectional ? (x % num_edm_channels == 0) : true;
+                static constexpr bidirectional_directions = 2;
+                return enable_bidirectional ? (x % bidirectional_directions == 0) : true;
             };
     EdmInterfaceAddresses edm_interface_addresses;
     for (std::size_t link = 0; link < num_links; link++) {

--- a/ttnn/cpp/ttnn/operations/ccl/reduce_scatter/device/host/reduce_scatter_full_worker_grid.cpp
+++ b/ttnn/cpp/ttnn/operations/ccl/reduce_scatter/device/host/reduce_scatter_full_worker_grid.cpp
@@ -802,7 +802,7 @@ operation::ProgramWithCallbacks reduce_scatter_with_workers(
 
     // Configure the EDM builders
     std::function<bool(uint32_t)> is_worker_in_clockwise_direction_fn = [enable_bidirectional, num_edm_channels](uint32_t x) {
-                static constexpr bidirectional_directions = 2;
+                static constexpr bool bidirectional_directions = 2;
                 return enable_bidirectional ? (x % bidirectional_directions == 0) : true;
             };
     EdmInterfaceAddresses edm_interface_addresses;


### PR DESCRIPTION
### Ticket
#11845 


### Problem description
Too many workers were accidentally sent in the same ring direction instead of evenly distributed for bidirectional ring reduce scatter.

I thought this  was included in an earlier PR but I must have missed it.

### What's changed
Split workers evenly across both ring directions.

With this change we are in the same performance bracket as allgather was before we enabled double buffered channels for all-gather. (e.g. we are seeing up to 17GBps for some larger reduce scatters and around 8-10 for some smaller ones). 

Once double/triple buffering is enabled, we should be roughly at parity with all-gather

### Checklist
- [x] Post commit CI passes: https://github.com/tenstorrent/tt-metal/actions/runs/10528070242
- [x] t3000 frequent: https://github.com/tenstorrent/tt-metal/actions/runs/10528062488
- [x] t3000 model perf: https://github.com/tenstorrent/tt-metal/actions/runs/10528060568
- [x] Blackhole Post commit (if applicable)
- [x] Model regression CI testing passes (if applicable)
- [x] New/Existing tests provide coverage for changes


# Perf delta
![image](https://github.com/user-attachments/assets/829fd5c3-b1f3-48d8-b941-a9fbea7088f5)
