### PR TITLE
#0: Add another codeowner for conv2d

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -105,7 +105,7 @@ ttnn/setup.py @ayerofieiev-tt @dmakoviichuk-tt @tt-rkim
 ttnn/**/CMakeLists.txt @ayerofieiev-tt @dmakoviichuk-tt @yan-zaretskiy
 ttnn/cpp/ttnn/operations/ccl/ @SeanNijjar @cfjchu
 ttnn/cpp/ttnn/operations/pool/ @mywoodstock @shwetankTT @sankarmanoj-tt @pavlejosipovic
-ttnn/cpp/ttnn/operations/conv2d/ @mywoodstock @shwetankTT @sankarmanoj-tt @pavlejosipovic
+ttnn/cpp/ttnn/operations/conv2d/ @mywoodstock @shwetankTT @sankarmanoj-tt @pavlejosipovic @bbradelTT
 ttnn/cpp/ttnn/operations/data_movement/ @tarafdarTT @sjameelTT @yan-zaretskiy
 ttnn/cpp/ttnn/operations/matmul/ @TT-BrianLiu @bbradelTT @yugaoTT
 ttnn/cpp/ttnn/operations/eltwise/ @arakhmati @patrickroberts @yan-zaretskiy @eyonland


### PR DESCRIPTION
### Ticket
Link to Github Issue: N/A

### Problem description
- I'll need to start working on conv. It's good to be a codeowner to see relevant PRs

### What's changed
- add myself to conv2d codeowners

### Checklist
- [ ] Post commit CI passes N/A
- [ ] Blackhole Post commit (if applicable) N/A
- [ ] Model regression CI testing passes (if applicable) N/A
- [ ] New/Existing tests provide coverage for changes N/A
