### PR TITLE
#11858 , #11859: Fix Dockerfile 20.04 and 22.04 sequence and requirements

### DIFF
--- a/dockerfile/ubuntu-20.04-amd64.Dockerfile
+++ b/dockerfile/ubuntu-20.04-amd64.Dockerfile
@@ -32,6 +32,11 @@ ENV PYTHON_ENV_DIR=${TT_METAL_INFRA_DIR}/tt-metal/python_env
 # RUN python3 -m venv $PYTHON_ENV_DIR
 # ENV PATH="$PYTHON_ENV_DIR/bin:$PATH"
 
+# Create directories for infra
+RUN mkdir -p ${TT_METAL_INFRA_DIR}/tt-metal/docs/
+RUN mkdir -p ${TT_METAL_INFRA_DIR}/tt-metal/tests/sweep_framework/
+RUN mkdir -p ${TT_METAL_INFRA_DIR}/tt-metal/tt_metal/python_env/
+
 # Copy requirements from tt-metal folders with requirements.txt docs
 COPY /docs/requirements-docs.txt ${TT_METAL_INFRA_DIR}/tt-metal/docs/.
 # Copy requirements from tt-metal folders for sweeps (requirements-sweeps.txt)

--- a/dockerfile/ubuntu-22.04-amd64.Dockerfile
+++ b/dockerfile/ubuntu-22.04-amd64.Dockerfile
@@ -30,6 +30,30 @@ RUN /bin/bash /opt/tt_metal_infra/scripts/docker/install_test_deps.sh ${DOXYGEN_
 COPY /scripts /opt/tt_metal_infra/scripts
 COPY build_metal.sh /scripts/build_metal.sh
 
+# Setup Env variables to setup Python Virtualenv - Install TT-Metal Python deps
+ENV TT_METAL_INFRA_DIR=/opt/tt_metal_infra
+ENV PYTHON_ENV_DIR=${TT_METAL_INFRA_DIR}/tt-metal/python_env
+
+# Disable using venv since this is isolated in a docker container
+# RUN python3 -m venv $PYTHON_ENV_DIR
+# ENV PATH="$PYTHON_ENV_DIR/bin:$PATH"
+
+# Create directories for infra
+RUN mkdir -p ${TT_METAL_INFRA_DIR}/tt-metal/docs/
+RUN mkdir -p ${TT_METAL_INFRA_DIR}/tt-metal/tests/sweep_framework/
+RUN mkdir -p ${TT_METAL_INFRA_DIR}/tt-metal/tt_metal/python_env/
+
+# Copy requirements from tt-metal folders with requirements.txt docs
+COPY /docs/requirements-docs.txt ${TT_METAL_INFRA_DIR}/tt-metal/docs/.
+# Copy requirements from tt-metal folders for sweeps (requirements-sweeps.txt)
+COPY /tests/sweep_framework/requirements-sweeps.txt ${TT_METAL_INFRA_DIR}/tt-metal/tests/sweep_framework/.
+COPY /tt_metal/python_env/* ${TT_METAL_INFRA_DIR}/tt-metal/tt_metal/python_env/.
+RUN python3 -m pip config set global.extra-index-url https://download.pytorch.org/whl/cpu \
+    && python3 -m pip install setuptools wheel
+
+RUN python3 -m pip install -r ${TT_METAL_INFRA_DIR}/tt-metal/tt_metal/python_env/requirements-dev.txt
+RUN python3 -m pip install -r ${TT_METAL_INFRA_DIR}/tt-metal/docs/requirements-docs.txt
+
 # Install Clang-17
 RUN cd $TT_METAL_INFRA_DIR \
     && wget https://apt.llvm.org/llvm.sh \

--- a/scripts/docker/requirements-22.04.txt
+++ b/scripts/docker/requirements-22.04.txt
@@ -18,3 +18,5 @@ python3-dev
 python3-venv
 cargo
 ninja-build
+libxml2-dev
+libxslt-dev


### PR DESCRIPTION
### Ticket
Addresses #11858 and #11859

Contributes to #10469

### Problem description
Docker build issues in Ubuntu 20.04 and 22.04 Dockerfiles:
1. Clang-17 installation fails due to non-existent directory.
2. Ubuntu 22.04 Dockerfile has misplaced environment variable setup and copying steps.
3. Ubuntu 22.04 lacks libxml2 and libxslt, causing errors during virtual environment creation.

### What's changed
- Made sure the right directories are created before Clang-17 is installed
- Moved a chunk of lines in the 22.04 dockerfile to their right place
- Added libxml2 and libxslt to 22.04's requirements file

### Checklist
- [ ] Post commit CI passes
- [ ] Blackhole Post commit (if applicable)
- [ ] Model regression CI testing passes (if applicable)
- [ ] New/Existing tests provide coverage for changes
