### PR TITLE
[Falcon7b] Re-enable decode perplexity test with seq len 2048

### DIFF
--- a/models/demos/falcon7b_common/tests/perplexity/test_perplexity_falcon.py
+++ b/models/demos/falcon7b_common/tests/perplexity/test_perplexity_falcon.py
@@ -43,9 +43,6 @@ def test_perplexity(
     device_mesh,
     use_program_cache,
 ):
-    if llm_mode == "decode" and max_seq_len == 2048:
-        pytest.skip("Skipping decode-seq2048 due to Issue #10365")
-
     assert is_wormhole_b0(), "This test is only for Wormhole B0"
 
     run_test_perplexity(


### PR DESCRIPTION
### Ticket
#10365

### Problem description
N/A

### What's changed
- Re-enabling the Falcon7b decode perplexity test with sequence length 2048 as it no longer seg faults at the end of the test.

### Checklist
- [x] Post commit CI passes
- [x] Blackhole Post commit (if applicable)
- [x] Model regression CI testing passes (if applicable)
- [x] New/Existing tests provide coverage for changes

Perplexity tests (Falcon7b): https://github.com/tenstorrent/tt-metal/actions/runs/10531054674/job/29182633431
