### PR TITLE
[Blackhole Bringup] Add pack_untilize tests & fixes

### DIFF
--- a/tests/tt_metal/tt_metal/test_kernels/compute/dst_untilize.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/compute/dst_untilize.cpp
@@ -14,23 +14,25 @@ void MAIN {
 
     constexpr uint32_t per_core_block_cnt = get_compile_time_arg_val(0);
     constexpr uint32_t per_core_block_tile_cnt = get_compile_time_arg_val(1);
+    constexpr uint32_t num_faces = get_compile_time_arg_val(2);
+    constexpr uint32_t num_rows_per_face = get_compile_time_arg_val(3);
 
     unary_op_init_common(tt::CB::c_in0, tt::CB::c_out0);
+    copy_tile_to_dst_init_short(tt::CB::c_in0);
+    pack_untilize_dst_init_short<per_core_block_tile_cnt>(tt::CB::c_out0, num_rows_per_face, num_faces);
 
     for(uint32_t b = 0; b < per_core_block_cnt; ++ b) {
         cb_wait_front(tt::CB::c_in0, per_core_block_tile_cnt);
         cb_reserve_back(tt::CB::c_out0, per_core_block_tile_cnt);
 
         tile_regs_acquire();
-        copy_tile_init();
         for (uint32_t i = 0; i < per_core_block_tile_cnt; ++i) {
             copy_tile(tt::CB::c_in0, i, i);
         }
         tile_regs_commit();
 
         tile_regs_wait();
-        pack_untilize_dst_init_short<per_core_block_tile_cnt>(tt::CB::c_out0);
-        pack_untilize_dst<per_core_block_tile_cnt>(tt::CB::c_out0);
+        pack_untilize_dst<per_core_block_tile_cnt>(tt::CB::c_out0, 1, 0, num_rows_per_face, num_faces);
         tile_regs_release();
 
         cb_push_back(tt::CB::c_out0, per_core_block_tile_cnt);

--- a/tests/tt_metal/tt_metal/test_kernels/compute/pack_untilize.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/compute/pack_untilize.cpp
@@ -13,11 +13,12 @@ void MAIN {
 
     constexpr uint32_t per_core_block_cnt = get_compile_time_arg_val(0);
     constexpr uint32_t per_core_block_tile_cnt = get_compile_time_arg_val(1);
-#ifndef SHORT_INIT
-    pack_untilize_init<per_core_block_tile_cnt>(tt::CB::c_in0, tt::CB::c_out0);
-#else
+
+#ifdef SHORT_INIT
     unary_op_init_common(tt::CB::c_in0, tt::CB::c_out0);
     pack_untilize_init_short<per_core_block_tile_cnt>(tt::CB::c_in0, tt::CB::c_out0);
+#else
+    pack_untilize_init<per_core_block_tile_cnt>(tt::CB::c_in0, tt::CB::c_out0);
 #endif
 
     for(uint32_t b = 0; b < per_core_block_cnt; ++ b) {

--- a/tests/tt_metal/tt_metal/test_kernels/compute/unpack_tilizeA_B.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/compute/unpack_tilizeA_B.cpp
@@ -14,7 +14,7 @@ inline void tilizeA_B_binary_init(uint32_t icb0, uint32_t icb1, uint32_t block, 
     UNPACK(( llk_unpack_tilizeA_B_init<true, true>(icb0, icb1, block, num_faces, face_r_dim, face_r_dim) ));
 
     MATH(( llk_math_pack_sync_init<DST_ACCUM_MODE>() ));
-    MATH(( llk_math_hw_configure_disaggregated<false>() ));
+    MATH(( llk_math_hw_configure_disaggregated() ));
     MATH(( llk_math_eltwise_binary_init<ELWADD, NONE>(0/*transpose*/, 0/*acc_to_dest*/) ));
 
     PACK(( llk_pack_hw_configure_disaggregated<false, DST_ACCUM_MODE>(ocb) ));

--- a/tests/tt_metal/tt_metal/unit_tests/compute/test_golden_impls.cpp
+++ b/tests/tt_metal/tt_metal/unit_tests/compute/test_golden_impls.cpp
@@ -15,15 +15,20 @@
 
 namespace unit_tests::compute {
 
-std::vector<uint32_t> gold_standard_untilize(const std::vector<uint32_t> &src_vec, const std::vector<uint32_t> &shape) {
+std::vector<uint32_t> gold_standard_untilize(const std::vector<uint32_t> &src_vec, const GoldenConfig &config) {
     vector<uint32_t> dst_vec;
 
-    int num_rows = shape.at(0);
-    int num_cols = shape.at(1) / 2;
+    int num_rows = config.num_tiles_r_dim * config.face_r_dim * (config.num_faces > 2 ? 2: 1);
+    //Due to each element being 32 bits, for bfloat16 thats 2 elements
+    int num_cols = (config.num_tiles_c_dim * config.face_c_dim *  (config.num_faces >= 2 ? 2: 1)) / 2;
 
-    int num_tile_rows = num_rows / 32;
-    int num_tile_cols = num_cols / 16;
+    int num_tile_rows = config.num_tiles_r_dim;
+    int num_tile_cols = config.num_tiles_c_dim;
 
+    //Due to each element being 32 bits, for bfloat16 thats 2 elements
+    int num_c_dim = config.face_c_dim / 2;
+    //Untilize outputs correct number of r_dim & num_faces
+    //But assumes increments are still default 16x16 faces
     int face_size = 16 * 8;
     int tile_size = face_size * 4;
 
@@ -37,23 +42,26 @@ std::vector<uint32_t> gold_standard_untilize(const std::vector<uint32_t> &src_ve
         int physical_start_for_tile_row = tile_start_index * 32 * 16;
 
         // Iterate over tile columns 32 times (naive, but simple for validation)
-        for (int x = 0; x < 2; x++) {
-            for (int i = 0; i < 16; i++) { // num rows in a face
+        uint32_t num_iterations = (config.num_faces > 2) ? 2 : 1;
+        for (int x = 0; x < num_iterations; x++) {
+            for (int i = 0; i < config.face_r_dim; i++) { // num rows in a face
                 for (int j = 0; j < num_tile_cols; j++) { // num columns top two faces
                     // Left face row copy
-                    for (int k = 0; k < 8; k++) {
-                        int idx = physical_start_for_tile_row + i * 8 + k + j * tile_size;
+                    for (int k = 0; k < num_c_dim; k++) {
+                        int idx = physical_start_for_tile_row + i * num_c_dim + k + j * tile_size;
                         TT_FATAL(ind.find(idx) == ind.end(), t);
                         ind.insert(idx);
                         dst_vec.push_back(src_vec.at(idx));
                     }
 
-                    // Right face row copy
-                    for (int k = 0; k < 8; k++) {
-                        int idx = physical_start_for_tile_row + i * 8 + k + face_size + j * tile_size;
-                        TT_FATAL(ind.find(idx) == ind.end(), t);
-                        ind.insert(idx);
-                        dst_vec.push_back(src_vec.at(idx));
+                    if(config.num_faces > 1) {
+                        // Right face row copy
+                        for (int k = 0; k < num_c_dim; k++) {
+                            int idx = physical_start_for_tile_row + i * num_c_dim + k + face_size + j * tile_size;
+                            TT_FATAL(ind.find(idx) == ind.end(), t);
+                            ind.insert(idx);
+                            dst_vec.push_back(src_vec.at(idx));
+                        }
                     }
                 }
             }
@@ -65,11 +73,13 @@ std::vector<uint32_t> gold_standard_untilize(const std::vector<uint32_t> &src_ve
     return dst_vec;
 }
 
-std::vector<uint32_t> gold_standard_tilize(const std::vector<uint32_t> &src_vec, const std::vector<uint32_t> &shape) {
+std::vector<uint32_t> gold_standard_tilize(const std::vector<uint32_t> &src_vec, const GoldenConfig &config) {
     vector<uint32_t> dst_vec;
 
-    int num_rows = shape.at(0);
-    int num_cols = shape.at(1) / 2;
+    //TODO: RT update this one to use variable tile sizes
+    int num_rows = config.num_tiles_r_dim * config.face_r_dim * (config.num_faces > 2 ? 2: 1);
+    //Due to each element being 32 bits, for bfloat16 thats 2 elements
+    int num_cols = (config.num_tiles_c_dim * config.face_c_dim *  (config.num_faces >= 2 ? 2: 1)) / 2;
     for (int x = 0; x < num_rows; x += 32) {
         for (int y = 0; y < num_cols; y += 16) {
             int start = x * num_cols + y;
@@ -213,9 +223,9 @@ std::vector<uint16_t> gold_reduce_hw(const std::vector<uint16_t> &src_vec, const
     return reduced;
 }
 
-std::vector<uint32_t> gold_standard_tilize_w_elwadd(const std::vector<uint32_t> &src0_vec, const std::vector<uint32_t> &src1_vec, const std::vector<uint32_t> &shape) {
+std::vector<uint32_t> gold_standard_tilize_w_elwadd(const std::vector<uint32_t> &src0_vec, const std::vector<uint32_t> &src1_vec, const GoldenConfig &config) {
 
-    std::vector<bfloat16> unpacked_tilize_src0_vec = tt::test_utils::unpack_vector<bfloat16, uint32_t>(gold_standard_tilize(src0_vec, shape));
+    std::vector<bfloat16> unpacked_tilize_src0_vec = tt::test_utils::unpack_vector<bfloat16, uint32_t>(gold_standard_tilize(src0_vec, config));
     std::vector<bfloat16> unpacked_src1_vec = tt::test_utils::unpack_vector<bfloat16, uint32_t>(src1_vec);
 
     std::vector<bfloat16> result_vec(unpacked_tilize_src0_vec.size());

--- a/tests/tt_metal/tt_metal/unit_tests/compute/test_golden_impls.hpp
+++ b/tests/tt_metal/tt_metal/unit_tests/compute/test_golden_impls.hpp
@@ -13,9 +13,18 @@
 //TODO: RT these functions should be templated for different data formats
 namespace unit_tests::compute {
 
-std::vector<uint32_t> gold_standard_untilize(const std::vector<uint32_t> &src_vec, const std::vector<uint32_t> &shape);
+//Used if golden function needs tile details
+struct GoldenConfig {
+    int num_tiles_r_dim;
+    int num_tiles_c_dim;
+    int face_r_dim = 16;
+    int face_c_dim = 16;
+    int num_faces = 4;
+};
 
-std::vector<uint32_t> gold_standard_tilize(const std::vector<uint32_t> &src_vec, const std::vector<uint32_t> &shape);
+std::vector<uint32_t> gold_standard_untilize(const std::vector<uint32_t> &src_vec, const GoldenConfig &config);
+
+std::vector<uint32_t> gold_standard_tilize(const std::vector<uint32_t> &src_vec,  const GoldenConfig &config);
 
 // input shape.x is assumed to have the full number of elements in bfloat16
 // src_vec is expected to be untilized
@@ -40,6 +49,6 @@ std::vector<uint16_t> gold_reduce_hw(const std::vector<uint16_t> &src_vec, const
 // Takes untilized src0_vec and tilized src1_vec
 // returns tilized result of eltwise addition
 // Assumes all elements in bfloat16
-std::vector<uint32_t> gold_standard_tilize_w_elwadd(const std::vector<uint32_t> &src0_vec, const std::vector<uint32_t> &src1_vec, const std::vector<uint32_t> &shape);
+std::vector<uint32_t> gold_standard_tilize_w_elwadd(const std::vector<uint32_t> &src0_vec, const std::vector<uint32_t> &src1_vec, const GoldenConfig &config);
 
 }   // unit_tests::compute

--- a/tt_metal/hw/inc/debug/dprint_tensix.h
+++ b/tt_metal/hw/inc/debug/dprint_tensix.h
@@ -25,6 +25,7 @@
 #define READ_THREAD_2_CFG_REG_FIELD(reg_field_name) READ_CFG_REG_FIELD(ckernel::dbg_cfgreg::THREAD_2_CFG, reg_field_name)
 
 // Print the contents of tile with index tile_id within the destination register
+template<bool print_by_face=false>
 void dprint_tensix_dest_reg(int tile_id = 0) {
     dbg_halt();
     MATH({
@@ -41,26 +42,39 @@ void dprint_tensix_dest_reg(int tile_id = 0) {
         // Print the contents
         DPRINT << FIXED() << SETPRECISION(2);
         uint32_t rd_data[8+1]; // data + array_type
+        DPRINT << "Tile ID = " << tile_id << ENDL();
 
         // print faces 0 & 1
         int face_r_dim = 16;
         for (int row = 0; row < face_r_dim; row++) {
             // face 0
             dbg_read_dest_acc_row(row + 64 * tile_id, rd_data);
-            DPRINT << SETW(6) << TYPED_U32_ARRAY(TypedU32_ARRAY_Format_Tensix_Config_Register_Data_Format_Type, data_format_reg_field_value, rd_data, 8);
-            // face 1
-            dbg_read_dest_acc_row(row + face_r_dim + 64 * tile_id, rd_data);
-            DPRINT << SETW(6) << TYPED_U32_ARRAY(TypedU32_ARRAY_Format_Tensix_Config_Register_Data_Format_Type, data_format_reg_field_value, rd_data, 8) << ENDL();
+            DPRINT << SETW(6) << " " << TYPED_U32_ARRAY(TypedU32_ARRAY_Format_Tensix_Config_Register_Data_Format_Type, data_format_reg_field_value, rd_data, 8);
+        }
+        if constexpr (print_by_face) {
+            DPRINT << ENDL();
         }
 
-        // print faces 2 & 3
+        for (int row = 0; row < face_r_dim; row++) {
+            // face 1
+            dbg_read_dest_acc_row(row + face_r_dim + 64 * tile_id, rd_data);
+            DPRINT << SETW(6) << " " << TYPED_U32_ARRAY(TypedU32_ARRAY_Format_Tensix_Config_Register_Data_Format_Type, data_format_reg_field_value, rd_data, 8) << ENDL();
+        }
+
         for (int row = 0; row < face_r_dim; row++) {
             // face 2
             dbg_read_dest_acc_row(row + 2*face_r_dim + 64 * tile_id, rd_data);
-            DPRINT << SETW(6) << TYPED_U32_ARRAY(TypedU32_ARRAY_Format_Tensix_Config_Register_Data_Format_Type, data_format_reg_field_value, rd_data, 8);
+            DPRINT << SETW(6) << " " << TYPED_U32_ARRAY(TypedU32_ARRAY_Format_Tensix_Config_Register_Data_Format_Type, data_format_reg_field_value, rd_data, 8);
+        }
+
+        if constexpr (print_by_face) {
+            DPRINT << ENDL();
+        }
+
+        for (int row = 0; row < face_r_dim; row++) {
             // face 3
             dbg_read_dest_acc_row(row + 3*face_r_dim + 64 * tile_id, rd_data);
-            DPRINT << SETW(6) << TYPED_U32_ARRAY(TypedU32_ARRAY_Format_Tensix_Config_Register_Data_Format_Type, data_format_reg_field_value, rd_data, 8) << ENDL();
+            DPRINT << SETW(6) << " " << TYPED_U32_ARRAY(TypedU32_ARRAY_Format_Tensix_Config_Register_Data_Format_Type, data_format_reg_field_value, rd_data, 8) << ENDL();
         }
     })
     dbg_unhalt();


### PR DESCRIPTION
### Ticket
#10052

### Problem description
Pack_untilize missing/failing tests

### What's changed
Kept the dst remap bits on since it does not affect other operations according to HW spec, and also toggling that bit for pack_untilize causes failures no matter how many stalls or wait for csr bits is done.

Added more pack_untilize tests.

### Checklist
- [x] Post commit CI passes
- [x] Blackhole Post commit (if applicable)
- [ ] Model regression CI testing passes (if applicable)
- [ ] New/Existing tests provide coverage for changes
