### PR TITLE
[Falcon7b] Re-enable demo perf-mode tests on galaxy, update targets, prevent multinomial errors (during perf-mode) using nan-to-num

### DIFF
--- a/models/demos/falcon7b_common/demo/demo.py
+++ b/models/demos/falcon7b_common/demo/demo.py
@@ -109,6 +109,7 @@ def top_pk_logits_efficient(logits, p=0.9, k=10, temperature=1.0, return_probs=F
     top_k_values, top_k_indices = torch.topk(logits, k=k)
     top_p_values = top_k_top_p_filtering(top_k_values, top_p=p)
     probs = F.softmax(top_p_values / temperature, dim=-1)
+    probs = torch.nan_to_num(probs)  # convert nan to num to prevent error in multinomial
     top_k_id = torch.multinomial(probs, num_samples=1).squeeze(-1)
     token = top_k_indices.gather(-1, top_k_id.unsqueeze(-1)).squeeze(-1)
     if return_probs:

--- a/models/demos/tg/falcon7b/demo_tg.py
+++ b/models/demos/tg/falcon7b/demo_tg.py
@@ -10,9 +10,9 @@ from models.utility_functions import is_wormhole_b0
 @pytest.mark.parametrize(
     "perf_mode, max_seq_len, expected_perf_metrics, greedy_sampling, expected_greedy_output_path",
     (
-        (True, 128, {"prefill_t/s": 5940, "decode_t/s": 1240, "decode_t/s/u": 1.21}, False, None),
-        (True, 1024, {"prefill_t/s": 12300, "decode_t/s": 1130, "decode_t/s/u": 1.10}, False, None),
-        (True, 2048, {"prefill_t/s": 9340, "decode_t/s": 1130, "decode_t/s/u": 1.10}, False, None),
+        (True, 128, {"prefill_t/s": 12760, "decode_t/s": 3510, "decode_t/s/u": 3.4}, False, None),
+        (True, 1024, {"prefill_t/s": 17200, "decode_t/s": 3560, "decode_t/s/u": 3.5}, False, None),
+        (True, 2048, {"prefill_t/s": 12380, "decode_t/s": 3600, "decode_t/s/u": 3.5}, False, None),
         (True, 128, None, False, None),
         (True, 1024, None, False, None),
         (True, 2048, None, False, None),
@@ -64,8 +64,6 @@ def test_demo_multichip(
             pytest.skip("Skipping test in CI since it provides redundant testing")
         if expected_greedy_output_path:
             pytest.skip("Skipping test in CI due to Issue #11254")
-        elif expected_perf_metrics:
-            pytest.skip("Skipping test in CI due to Issue #11258")
     elif expected_greedy_output_path or expected_perf_metrics:
         assert num_devices == 32, "32 devices are expected for perf and greedy output verification"
 


### PR DESCRIPTION
### Ticket
#5383 
#11258

### Problem description
- Falcon7b galaxy perf-mode demo tests were disabled due to ND ci hangs

### What's changed
- Re-enabled the tests, updated the perf-mode targets
- Fixed rare bug that could occur with perf-mode runs where torch multinomial would crash due to nan inputs

### Checklist
- [x] Post commit CI passes
- [x] Blackhole Post commit (if applicable)
- [x] Model regression CI testing passes (if applicable)
- [x] New/Existing tests provide coverage for changes

TG demo test: https://github.com/tenstorrent/tt-metal/actions/runs/10533656796
T3K demo tests: https://github.com/tenstorrent/tt-metal/actions/runs/10533429783
Single-card demo tests: https://github.com/tenstorrent/tt-metal/actions/runs/10533434902

