### PR TITLE
#11881: Add `-Wno-vla-cxx-extension` to CMake to fix build on clang18

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -153,7 +153,7 @@ target_link_libraries(metal_common_libs INTERFACE
 add_library(linker_flags INTERFACE)
 
 add_library(compiler_warnings INTERFACE)
-target_compile_options(compiler_warnings INTERFACE -Werror -Wdelete-non-virtual-dtor -Wreturn-type -Wswitch -Wuninitialized -Wno-unused-parameter -Wno-vla-cxx-extension)
+target_compile_options(compiler_warnings INTERFACE -Werror -Wdelete-non-virtual-dtor -Wreturn-type -Wswitch -Wuninitialized -Wno-unused-parameter)
 
 # add additional compile warning flags depending on the compiler
 ADJUST_COMPILER_WARNINGS()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -153,7 +153,7 @@ target_link_libraries(metal_common_libs INTERFACE
 add_library(linker_flags INTERFACE)
 
 add_library(compiler_warnings INTERFACE)
-target_compile_options(compiler_warnings INTERFACE -Werror -Wdelete-non-virtual-dtor -Wreturn-type -Wswitch -Wuninitialized -Wno-unused-parameter)
+target_compile_options(compiler_warnings INTERFACE -Werror -Wdelete-non-virtual-dtor -Wreturn-type -Wswitch -Wuninitialized -Wno-unused-parameter -Wno-vla-cxx-extension)
 
 # add additional compile warning flags depending on the compiler
 ADJUST_COMPILER_WARNINGS()

--- a/cmake/compilers.cmake
+++ b/cmake/compilers.cmake
@@ -36,6 +36,7 @@ function(ADJUST_COMPILER_WARNINGS)
             -Wsometimes-uninitialized -Wno-c++11-narrowing -Wno-error=local-type-template-args
             -Wno-delete-non-abstract-non-virtual-dtor -Wno-c99-designator -Wno-shift-op-parentheses -Wno-non-c-typedef-for-linkage
             -Wno-deprecated-this-capture -Wno-deprecated-volatile -Wno-deprecated-builtins -Wno-deprecated-declarations
+            -Wno-vla-cxx-extension
         )
     else() # GCC-12 or higher
         target_compile_options(compiler_warnings INTERFACE


### PR DESCRIPTION
### Ticket
[Link to Github Issue](https://github.com/tenstorrent/tt-metal/issues/11881)

### Problem description
tt-metal fails to build on clang-18 due to use of VLA and -Werror is turned on

### What's changed
The flag `-Wno-vla-cxx-extension` is added to suppress the warning from popping up

### Checklist
- [ ] Post commit CI passes
- [ ] Blackhole Post commit (if applicable)
- [ ] Model regression CI testing passes (if applicable)
- [ ] New/Existing tests provide coverage for changes
