### PR TITLE
#10515: For matmul corner case, if CBs don't fit, choose different program config

### DIFF
--- a/ttnn/cpp/ttnn/operations/matmul/device/matmul_op.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/matmul_op.cpp
@@ -19,8 +19,8 @@
 using namespace tt;
 using namespace tt::constants;
 using namespace tt::tt_metal;
-using ttnn::operations::unary::UnaryWithParam;
 using tt::tt_metal::Shape;
+using ttnn::operations::unary::UnaryWithParam;
 
 namespace {
 
@@ -42,7 +42,7 @@ inline bool get_fp32_dest_acc_en(const std::optional<const DeviceComputeKernelCo
     bool fp32_dest_acc_en = false;
     if (compute_kernel_config) {
         std::visit(
-            [&](auto &&compute_kernel_config) {
+            [&](auto&& compute_kernel_config) {
                 using T = std::decay_t<decltype(compute_kernel_config)>;
                 if constexpr (std::is_same_v<T, WormholeComputeKernelConfig>) {
                     fp32_dest_acc_en = compute_kernel_config.fp32_dest_acc_en;
@@ -54,8 +54,8 @@ inline bool get_fp32_dest_acc_en(const std::optional<const DeviceComputeKernelCo
 }
 
 bool get_broadcast_batch(
-    const Tensor &input_tensor_a,
-    const Tensor &input_tensor_b,
+    const Tensor& input_tensor_a,
+    const Tensor& input_tensor_b,
     const std::optional<const MatmulProgramConfig> matmul_program_config) {
     uint32_t batch_size_b = get_batch_size(input_tensor_b.get_legacy_shape());
     bool broadcast_batch = batch_size_b == 1;
@@ -64,7 +64,7 @@ bool get_broadcast_batch(
     }
 
     bool is_multi_core_reuse = std::visit(
-        [](const auto &program_config) -> bool {
+        [](const auto& program_config) -> bool {
             using ProgramConfigType = std::decay_t<decltype(program_config)>;
             if constexpr (std::is_same_v<ProgramConfigType, MatmulMultiCoreReuseProgramConfig>) {
                 return true;
@@ -151,6 +151,82 @@ std::tuple<uint32_t, uint32_t> get_subblock_sizes(
     TT_FATAL(false, "Unable to find subblock sizes");
 }
 
+CoreCoord get_core_range(
+    uint32_t num_blocks_rows, uint32_t num_blocks_cols, uint32_t max_num_rows, uint32_t max_num_cols) {
+    CoreCoord core_range(0, 0);
+    if (!(num_blocks_rows == 1 && num_blocks_cols == 1) && num_blocks_rows <= max_num_rows &&
+        num_blocks_cols <= max_num_cols) {
+        core_range.x = num_blocks_cols;
+        core_range.y = num_blocks_rows;
+    }
+    return core_range;
+}
+
+inline uint32_t get_estimated_size_of_cbs(
+    uint32_t per_core_M,
+    uint32_t per_core_N,
+    uint32_t in0_block_w,
+    uint32_t in0_single_tile_size,
+    uint32_t in1_single_tile_size,
+    uint32_t output_single_tile_size) {
+    // Circular Buffer sizes:
+    // src0 CB: per_core_M * in0_block_w * 2 (for double buffer)
+    // src1 CB: per_core_N * in0_block_w * 2 (for double buffer)
+    // out CB:  per_core_M * per_core_N
+    // Ignore optional intermediate CB because not needed when need to create a program config.
+    uint32_t in0_size = per_core_M * in0_block_w * 2 * in0_single_tile_size;
+    uint32_t in1_size = per_core_M * in0_block_w * 2 * in1_single_tile_size;
+    uint32_t out_size = per_core_M * per_core_N * output_single_tile_size;
+    return in0_size + in1_size + out_size;
+}
+
+inline uint32_t get_max_l1_space(const Tensor& input_tensor_a) {
+    tt::tt_metal::Device* device = input_tensor_a.device();
+    const std::vector<uint32_t>& bank_ids =
+        device->bank_ids_from_logical_core(BufferType::L1, *device->compute_cores_.begin());
+    std::optional<uint64_t> lowest_address = allocator::lowest_occupied_l1_address(*device->allocator_, bank_ids[0]);
+    uint32_t max_l1_space = lowest_address.has_value() ? lowest_address.value() : device->l1_size_per_core();
+    max_l1_space = max_l1_space - L1_UNRESERVED_BASE;
+    return max_l1_space;
+}
+
+inline bool can_cbs_fit_in_l1(
+    const Tensor& input_tensor_a,
+    const Tensor& input_tensor_b,
+    uint32_t per_core_M,
+    uint32_t per_core_N,
+    uint32_t in0_block_w) {
+    uint32_t max_l1_space = get_max_l1_space(input_tensor_a);
+    tt::DataFormat in0_data_format = tt_metal::datatype_to_dataformat_converter(input_tensor_a.get_dtype());
+    tt::DataFormat in1_data_format = tt_metal::datatype_to_dataformat_converter(input_tensor_b.get_dtype());
+    uint32_t in0_single_tile_size = tt_metal::detail::TileSize(in0_data_format);  // use as estimate for output as well
+    uint32_t in1_single_tile_size = tt_metal::detail::TileSize(in1_data_format);
+    uint32_t size = get_estimated_size_of_cbs(
+        per_core_M, per_core_N, in0_block_w, in0_single_tile_size, in1_single_tile_size, in0_single_tile_size);
+    return size < max_l1_space;
+}
+
+inline uint32_t get_per_core_factor(const Tensor& input_tensor_a, const Tensor& input_tensor_b, uint32_t in0_block_w) {
+    uint32_t max_l1_space = get_max_l1_space(input_tensor_a);
+    tt::DataFormat in0_data_format = tt_metal::datatype_to_dataformat_converter(input_tensor_a.get_dtype());
+    tt::DataFormat in1_data_format = tt_metal::datatype_to_dataformat_converter(input_tensor_b.get_dtype());
+    uint32_t in0_single_tile_size = tt_metal::detail::TileSize(in0_data_format);  // use as estimate for output as well
+    uint32_t in1_single_tile_size = tt_metal::detail::TileSize(in1_data_format);
+    for (uint32_t per_core_factor = 16; per_core_factor > 1; per_core_factor /= 2) {
+        uint32_t size = get_estimated_size_of_cbs(
+            per_core_factor,
+            per_core_factor,
+            in0_block_w,
+            in0_single_tile_size,
+            in1_single_tile_size,
+            in0_single_tile_size);
+        if (size < max_l1_space) {
+            return per_core_factor;
+        }
+    }
+    return 1;
+}
+
 MatmulProgramConfig create_matmul_1d_systolic_array_program_config(
     const ttnn::types::Shape& input_shape_a,
     const ttnn::types::Shape& input_shape_b,
@@ -200,8 +276,7 @@ MatmulProgramConfig create_matmul_1d_systolic_array_program_config(
     while (k_tiles % k_tiles_per_core != 0) {
         k_tiles_per_core -= 1;
     }
-    auto matmul_params =
-        get_subblock_sizes(batch_and_m_tiles_per_core, n_tiles_per_core, fp32_dest_acc_en);
+    auto matmul_params = get_subblock_sizes(batch_and_m_tiles_per_core, n_tiles_per_core, fp32_dest_acc_en);
     uint32_t out_subblock_h = std::get<0>(matmul_params);
     uint32_t out_subblock_w = std::get<1>(matmul_params);
     return MatmulMultiCoreReuseMultiCast1DProgramConfig{
@@ -215,6 +290,137 @@ MatmulProgramConfig create_matmul_1d_systolic_array_program_config(
         .fused_activation = fused_activation,
         .mcast_in0 = is_wide,
     };
+}
+
+MatmulMultiCoreReuseMultiCast1DProgramConfig get_mcast_1d_config(
+    const Tensor& input_tensor_a,
+    const Tensor& input_tensor_b,
+    const bool fuse_batch,
+    const std::optional<UnaryWithParam> fused_activation,
+    const bool mcast_in0,
+    const bool out_sharded,
+    const std::optional<const CoreCoord> compute_with_storage_grid_size,
+    const std::optional<const DeviceComputeKernelConfig> compute_kernel_config) {
+    auto device = input_tensor_a.device();
+    auto grid_size = compute_with_storage_grid_size.value_or(device->compute_with_storage_grid_size());
+    uint32_t M = fuse_batch ? input_tensor_a.volume() / input_tensor_a.get_legacy_shape()[-1]
+                            : input_tensor_a.get_legacy_shape()[-2];
+    uint32_t K = input_tensor_a.get_legacy_shape()[-1];
+    uint32_t N = input_tensor_b.get_legacy_shape()[-1];
+    uint32_t per_core_M, per_core_N;
+    if (mcast_in0) {
+        per_core_M = M / TILE_HEIGHT;
+        per_core_N = div_up(div_up(N, grid_size.x * grid_size.y), TILE_WIDTH);
+    } else {
+        per_core_M = div_up(div_up(M, grid_size.x * grid_size.y), TILE_HEIGHT);
+        per_core_N = N / TILE_WIDTH;
+    }
+    uint32_t in0_block_w = K / TILE_WIDTH % 2 == 0 ? 2 : 1;
+    bool per_core_N_equals_subblock_w_constraint = out_sharded && !mcast_in0;
+    bool per_core_M_equals_subblock_h_constraint = out_sharded && mcast_in0;
+    bool fp32_dest_acc_en = get_fp32_dest_acc_en(compute_kernel_config);
+    auto subblock_hw = bmm_op_utils::get_matmul_subblock_params(
+        per_core_M,
+        per_core_N,
+        per_core_M_equals_subblock_h_constraint,
+        per_core_N_equals_subblock_w_constraint,
+        fp32_dest_acc_en);
+    auto out_subblock_h = std::get<0>(subblock_hw);
+    auto out_subblock_w = std::get<1>(subblock_hw);
+
+    return MatmulMultiCoreReuseMultiCast1DProgramConfig{
+        .compute_with_storage_grid_size = grid_size,
+        .in0_block_w = in0_block_w,
+        .out_subblock_h = out_subblock_h,
+        .out_subblock_w = out_subblock_w,
+        .per_core_M = per_core_M,
+        .per_core_N = per_core_N,
+        .fuse_batch = fuse_batch,
+        .fused_activation = fused_activation,
+        .mcast_in0 = mcast_in0};
+}
+
+inline MatmulProgramConfig create_simple_matmul_program_config(
+    const Tensor& input_tensor_a,
+    const Tensor& input_tensor_b,
+    const std::optional<const DeviceComputeKernelConfig> compute_kernel_config,
+    const CoreCoord& compute_with_storage_grid_size) {
+    const auto &ashape = input_tensor_a.get_legacy_shape(), bshape = input_tensor_b.get_legacy_shape();
+    uint32_t batch_size_a = get_batch_size(ashape);
+    uint32_t num_output_tiles = batch_size_a * ashape[-2] * bshape[-1] / TILE_HW;  // Output M x N
+
+    // Parameters for large matmul with reuse
+    uint32_t B = batch_size_a;
+    uint32_t Mt = ashape[-2] / TILE_HEIGHT;
+    uint32_t Kt = ashape[-1] / TILE_WIDTH;
+    uint32_t Nt = bshape[-1] / TILE_WIDTH;
+    uint32_t in0_block_w = 2;
+
+    TT_FATAL(input_tensor_a.storage_type() == StorageType::DEVICE, "input tensor needs to be on device");
+    uint32_t num_cores_x = compute_with_storage_grid_size.x;
+    uint32_t num_cores_y = compute_with_storage_grid_size.y;
+    uint32_t per_core_M, per_core_N, out_subblock_h, out_subblock_w;
+    uint32_t num_blocks_x, num_blocks_y;
+
+    // out_subblock h/w doesn't matter
+    per_core_M = get_per_core_factor(input_tensor_a, input_tensor_b, in0_block_w);
+    per_core_N = per_core_M;
+
+    // Calculate number of blocks along x and y; tensor dims are padded up to 512
+    num_blocks_y = (Mt - 1) / per_core_M + 1;
+    num_blocks_x = (Nt - 1) / per_core_N + 1;
+
+    if (num_blocks_x * num_blocks_y <= num_cores_x * num_cores_y and Kt % in0_block_w == 0) {
+        CoreCoord core_range = get_core_range(num_blocks_y, num_blocks_x, num_cores_y, num_cores_x);
+        if (core_range.y == 1) {
+            return get_mcast_1d_config(
+                input_tensor_a,
+                input_tensor_b,
+                false /* fuse_batch */,
+                std::nullopt /* fused_activation */,
+                true /* mcast_in0 */,
+                false /* out_sharded */,
+                std::nullopt /* compute_with_storage_grid_size */,
+                compute_kernel_config);
+        } else if (core_range.x == 1) {
+            return get_mcast_1d_config(
+                input_tensor_a,
+                input_tensor_b,
+                false /* fuse_batch */,
+                std::nullopt /* fused_activation */,
+                false /* mcast_in0 */,
+                false /* out_sharded */,
+                std::nullopt /* compute_with_storage_grid_size */,
+                compute_kernel_config);
+        } else if (core_range.y > 0 && num_blocks_x <= num_cores_x && num_blocks_y <= num_cores_y) {
+            bool transpose_mcast = input_tensor_a.memory_config().memory_layout == TensorMemoryLayout::BLOCK_SHARDED &&
+                                   input_tensor_a.shard_spec().value().orientation == ShardOrientation::COL_MAJOR;
+            out_subblock_h = 4;
+            out_subblock_w = 2;
+            if (out_subblock_w != per_core_N) {
+                out_subblock_h = 1;
+            }
+            return MatmulMultiCoreReuseMultiCastProgramConfig{
+                .compute_with_storage_grid_size = {num_cores_x, num_cores_y},
+                .in0_block_w = in0_block_w,
+                .out_subblock_h = out_subblock_h,
+                .out_subblock_w = out_subblock_w,
+                .per_core_M = per_core_M,
+                .per_core_N = per_core_N,
+                .transpose_mcast = transpose_mcast,
+                .fused_activation = std::nullopt,
+                .fuse_batch = false,
+            };
+        }
+        // If we don't need padding, use the default multi_core reuse/reuse_mcast
+        else if (Mt % per_core_M == 0 and Nt % per_core_N == 0) {
+            return MatmulMultiCoreNonOptimizedReuseProgramConfig{};
+        } else {
+            return MatmulMultiCoreProgramConfig{};
+        }
+    } else {
+        return MatmulMultiCoreProgramConfig{};
+    }
 }
 
 MatmulProgramConfig create_matmul_program_config(
@@ -266,6 +472,11 @@ MatmulProgramConfig create_matmul_program_config(
             m_tiles_per_core = div_up(m_size, ttnn::TILE_SIZE);
             n_tiles_per_core = div_up(n_size, ttnn::TILE_SIZE);
             k_tiles_per_core = 1;  // TODO(arakhmati): Can it be more than 1 without running out of memory?
+            if (!can_cbs_fit_in_l1(
+                    input_tensor_a, input_tensor_b, m_tiles_per_core, n_tiles_per_core, k_tiles_per_core)) {
+                return create_simple_matmul_program_config(
+                    input_tensor_a, input_tensor_b, compute_kernel_config, core_coord);
+            }
         } else if (a_is_sharded) {
             TT_FATAL(
                 a_layout != TensorMemoryLayout::WIDTH_SHARDED,
@@ -349,65 +560,6 @@ MatmulProgramConfig create_matmul_program_config(
         .transpose_mcast = transpose_mcast,
         .fused_activation = fused_activation,
     };
-}
-
-CoreCoord get_core_range(
-    uint32_t num_blocks_rows, uint32_t num_blocks_cols, uint32_t max_num_rows, uint32_t max_num_cols) {
-    CoreCoord core_range(0, 0);
-    if (!(num_blocks_rows == 1 && num_blocks_cols == 1) && num_blocks_rows <= max_num_rows &&
-        num_blocks_cols <= max_num_cols) {
-        core_range.x = num_blocks_cols;
-        core_range.y = num_blocks_rows;
-    }
-    return core_range;
-}
-
-MatmulMultiCoreReuseMultiCast1DProgramConfig get_mcast_1d_config(
-    const Tensor& input_tensor_a,
-    const Tensor& input_tensor_b,
-    const bool fuse_batch,
-    const std::optional<UnaryWithParam> fused_activation,
-    const bool mcast_in0,
-    const bool out_sharded,
-    const std::optional<const CoreCoord> compute_with_storage_grid_size,
-    const std::optional<const DeviceComputeKernelConfig> compute_kernel_config) {
-    auto device = input_tensor_a.device();
-    auto grid_size = compute_with_storage_grid_size.value_or(device->compute_with_storage_grid_size());
-    uint32_t M = fuse_batch ? input_tensor_a.volume() / input_tensor_a.get_legacy_shape()[-1]
-                            : input_tensor_a.get_legacy_shape()[-2];
-    uint32_t K = input_tensor_a.get_legacy_shape()[-1];
-    uint32_t N = input_tensor_b.get_legacy_shape()[-1];
-    uint32_t per_core_M, per_core_N;
-    if (mcast_in0) {
-        per_core_M = M / TILE_HEIGHT;
-        per_core_N = div_up(div_up(N, grid_size.x * grid_size.y), TILE_WIDTH);
-    } else {
-        per_core_M = div_up(div_up(M, grid_size.x * grid_size.y), TILE_HEIGHT);
-        per_core_N = N / TILE_WIDTH;
-    }
-    uint32_t in0_block_w = K / TILE_WIDTH % 2 == 0 ? 2 : 1;
-    bool per_core_N_equals_subblock_w_constraint = out_sharded && !mcast_in0;
-    bool per_core_M_equals_subblock_h_constraint = out_sharded && mcast_in0;
-    bool fp32_dest_acc_en = get_fp32_dest_acc_en(compute_kernel_config);
-    auto subblock_hw = bmm_op_utils::get_matmul_subblock_params(
-        per_core_M,
-        per_core_N,
-        per_core_M_equals_subblock_h_constraint,
-        per_core_N_equals_subblock_w_constraint,
-        fp32_dest_acc_en);
-    auto out_subblock_h = std::get<0>(subblock_hw);
-    auto out_subblock_w = std::get<1>(subblock_hw);
-
-    return MatmulMultiCoreReuseMultiCast1DProgramConfig{
-        .compute_with_storage_grid_size = grid_size,
-        .in0_block_w = in0_block_w,
-        .out_subblock_h = out_subblock_h,
-        .out_subblock_w = out_subblock_w,
-        .per_core_M = per_core_M,
-        .per_core_N = per_core_N,
-        .fuse_batch = fuse_batch,
-        .fused_activation = fused_activation,
-        .mcast_in0 = mcast_in0};
 }
 
 // TODO: Only supports sharded matmul for now; infer most matmul params from shard spec
@@ -579,134 +731,6 @@ MatmulProgramConfig get_matmul_program_config(
         input_tensor_a, input_tensor_b, user_core_coord, fused_activation, compute_kernel_config);
 }
 
-inline uint32_t get_estimated_size_of_cbs(
-    uint32_t per_core_M,
-    uint32_t per_core_N,
-    uint32_t in0_block_w,
-    uint32_t in0_single_tile_size,
-    uint32_t in1_single_tile_size,
-    uint32_t output_single_tile_size) {
-    // Circular Buffer sizes:
-    // src0 CB: per_core_M * in0_block_w * 2 (for double buffer)
-    // src1 CB: per_core_N * in0_block_w * 2 (for double buffer)
-    // out CB:  per_core_M * per_core_N
-    // Ignore optional intermediate CB because not needed when need to create a program config.
-    uint32_t in0_size = per_core_M * in0_block_w * 2 * in0_single_tile_size;
-    uint32_t in1_size = per_core_M * in0_block_w * 2 * in1_single_tile_size;
-    uint32_t out_size = per_core_M * per_core_N * output_single_tile_size;
-    return in0_size + in1_size + out_size;
-}
-
-inline uint32_t get_per_core_factor(const Tensor& input_tensor_a, const Tensor& input_tensor_b, uint32_t in0_block_w) {
-    tt::tt_metal::Device* device = input_tensor_a.device();
-    const std::vector<uint32_t>& bank_ids =
-        device->bank_ids_from_logical_core(BufferType::L1, *device->compute_cores_.begin());
-    std::optional<uint64_t> lowest_address = allocator::lowest_occupied_l1_address(*device->allocator_, bank_ids[0]);
-    uint32_t max_l1_space = lowest_address.has_value() ? lowest_address.value() : device->l1_size_per_core();
-    max_l1_space = max_l1_space - L1_UNRESERVED_BASE;
-    tt::DataFormat in0_data_format = tt_metal::datatype_to_dataformat_converter(input_tensor_a.get_dtype());
-    tt::DataFormat in1_data_format = tt_metal::datatype_to_dataformat_converter(input_tensor_b.get_dtype());
-    uint32_t in0_single_tile_size = tt_metal::detail::TileSize(in0_data_format);  // use as estimate for output as well
-    uint32_t in1_single_tile_size = tt_metal::detail::TileSize(in1_data_format);
-    for (uint32_t per_core_factor = 16; per_core_factor > 1; per_core_factor /= 2) {
-        uint32_t size = get_estimated_size_of_cbs(
-            per_core_factor,
-            per_core_factor,
-            in0_block_w,
-            in0_single_tile_size,
-            in1_single_tile_size,
-            in0_single_tile_size);
-        if (size < max_l1_space) {
-            return per_core_factor;
-        }
-    }
-    return 1;
-}
-
-inline MatmulProgramConfig create_simple_matmul_program_config(
-    const Tensor& input_tensor_a,
-    const Tensor& input_tensor_b,
-    const std::optional<const DeviceComputeKernelConfig> compute_kernel_config) {
-    const auto &ashape = input_tensor_a.get_legacy_shape(), bshape = input_tensor_b.get_legacy_shape();
-    uint32_t batch_size_a = get_batch_size(ashape);
-    uint32_t num_output_tiles = batch_size_a * ashape[-2] * bshape[-1] / TILE_HW;  // Output M x N
-
-    // Parameters for large matmul with reuse
-    uint32_t B = batch_size_a;
-    uint32_t Mt = ashape[-2] / TILE_HEIGHT;
-    uint32_t Kt = ashape[-1] / TILE_WIDTH;
-    uint32_t Nt = bshape[-1] / TILE_WIDTH;
-    uint32_t in0_block_w = 2;
-
-    TT_FATAL(input_tensor_a.storage_type() == StorageType::DEVICE, "input tensor needs to be on device");
-    tt::tt_metal::Device* device = input_tensor_a.device();
-    auto compute_with_storage_grid_size = device->compute_with_storage_grid_size();
-    uint32_t num_cores_x = compute_with_storage_grid_size.x;
-    uint32_t num_cores_y = compute_with_storage_grid_size.y;
-    uint32_t per_core_M, per_core_N, out_subblock_h, out_subblock_w;
-    uint32_t num_blocks_x, num_blocks_y;
-
-    // out_subblock h/w doesn't matter
-    per_core_M = get_per_core_factor(input_tensor_a, input_tensor_b, in0_block_w);
-    per_core_N = per_core_M;
-
-    // Calculate number of blocks along x and y; tensor dims are padded up to 512
-    num_blocks_y = (Mt - 1) / per_core_M + 1;
-    num_blocks_x = (Nt - 1) / per_core_N + 1;
-
-    if (num_blocks_x * num_blocks_y <= num_cores_x * num_cores_y and Kt % in0_block_w == 0) {
-        CoreCoord core_range = get_core_range(num_blocks_y, num_blocks_x, num_cores_y, num_cores_x);
-        if (core_range.y == 1) {
-            return get_mcast_1d_config(
-                input_tensor_a,
-                input_tensor_b,
-                false /* fuse_batch */,
-                std::nullopt /* fused_activation */,
-                true /* mcast_in0 */,
-                false /* out_sharded */,
-                std::nullopt /* compute_with_storage_grid_size */,
-                compute_kernel_config);
-        } else if (core_range.x == 1) {
-            return get_mcast_1d_config(
-                input_tensor_a,
-                input_tensor_b,
-                false /* fuse_batch */,
-                std::nullopt /* fused_activation */,
-                false /* mcast_in0 */,
-                false /* out_sharded */,
-                std::nullopt /* compute_with_storage_grid_size */,
-                compute_kernel_config);
-        } else if (core_range.y > 0 && num_blocks_x <= num_cores_x && num_blocks_y <= num_cores_y) {
-            bool transpose_mcast = input_tensor_a.memory_config().memory_layout == TensorMemoryLayout::BLOCK_SHARDED &&
-                                   input_tensor_a.shard_spec().value().orientation == ShardOrientation::COL_MAJOR;
-            out_subblock_h = 4;
-            out_subblock_w = 2;
-            if (out_subblock_w != per_core_N) {
-                out_subblock_h = 1;
-            }
-            return MatmulMultiCoreReuseMultiCastProgramConfig{
-                .compute_with_storage_grid_size = {num_cores_x, num_cores_y},
-                .in0_block_w = in0_block_w,
-                .out_subblock_h = out_subblock_h,
-                .out_subblock_w = out_subblock_w,
-                .per_core_M = per_core_M,
-                .per_core_N = per_core_N,
-                .transpose_mcast = transpose_mcast,
-                .fused_activation = std::nullopt,
-                .fuse_batch = false,
-            };
-        }
-        // If we don't need padding, use the default multi_core reuse/reuse_mcast
-        else if (Mt % per_core_M == 0 and Nt % per_core_N == 0) {
-            return MatmulMultiCoreNonOptimizedReuseProgramConfig{};
-        } else {
-            return MatmulMultiCoreProgramConfig{};
-        }
-    } else {
-        return MatmulMultiCoreProgramConfig{};
-    }
-}
-
 inline MatmulProgramConfig generate_matmul_program_config(
     const Tensor& input_tensor_a,
     const Tensor& input_tensor_b,
@@ -723,7 +747,10 @@ inline MatmulProgramConfig generate_matmul_program_config(
             return create_matmul_program_config(
                 input_tensor_a, input_tensor_b, user_core_coord, user_fused_activation, compute_kernel_config);
         } else {
-            return create_simple_matmul_program_config(input_tensor_a, input_tensor_b, compute_kernel_config);
+            tt::tt_metal::Device* device = input_tensor_a.device();
+            auto compute_with_storage_grid_size = device->compute_with_storage_grid_size();
+            return create_simple_matmul_program_config(
+                input_tensor_a, input_tensor_b, compute_kernel_config, compute_with_storage_grid_size);
         }
     } else {
         bool bmm = user_run_batched;
@@ -827,7 +854,8 @@ std::tuple<uint32_t, uint32_t> get_matmul_subblock_params(
     return {1, 1};
 }
 
-void add_stagger_defines_if_needed(const tt::ARCH arch, const int num_cores, std::map<string, string>& mm_kernel_defines) {
+void add_stagger_defines_if_needed(
+    const tt::ARCH arch, const int num_cores, std::map<string, string>& mm_kernel_defines) {
     // Empirically deduced di/dt problems appear for matmuls using more than 48 cores;
     // when there is 48 cores or less, we never enable stagger since the delay impacts op performance
     constexpr uint32_t WH_B0_MM_MAX_CORES_NO_STAGGER = 48;
@@ -851,22 +879,16 @@ namespace operations {
 namespace matmul {
 
 Matmul create_matmul_struct(
-    const Tensor &input_tensor_a,
-    const Tensor &input_tensor_b,
-    const struct Matmul &parameters
-) {
+    const Tensor& input_tensor_a, const Tensor& input_tensor_b, const struct Matmul& parameters) {
     auto arch = input_tensor_a.device()->arch();
     const bool has_user_grid = parameters.user_core_coord.has_value();
     const bool has_program_config = parameters.program_config.has_value();
     const auto increase_fidelity = !has_program_config && !has_user_grid;
     auto math_fidelity = increase_fidelity ? MathFidelity::HiFi2 : MathFidelity::LoFi;
-    auto kernel_config_val =
-        init_device_compute_kernel_config(arch, parameters.compute_kernel_config, math_fidelity);
-    bool broadcast_batch = parameters.bcast_batch.value_or(
-        get_broadcast_batch(input_tensor_a, input_tensor_b, parameters.program_config));
-    TT_FATAL(
-        !(has_user_grid && has_program_config),
-        "Cannot use both user core grid/coordinates and a program config");
+    auto kernel_config_val = init_device_compute_kernel_config(arch, parameters.compute_kernel_config, math_fidelity);
+    bool broadcast_batch =
+        parameters.bcast_batch.value_or(get_broadcast_batch(input_tensor_a, input_tensor_b, parameters.program_config));
+    TT_FATAL(!(has_user_grid && has_program_config), "Cannot use both user core grid/coordinates and a program config");
 
     return Matmul{
         parameters.program_config,
@@ -881,10 +903,10 @@ Matmul create_matmul_struct(
 }
 
 Tensor matmul(
-    const Tensor &input_tensor_a,
-    const Tensor &input_tensor_b,
+    const Tensor& input_tensor_a,
+    const Tensor& input_tensor_b,
     const std::optional<const Tensor> bias,
-    const struct Matmul &parameters,
+    const struct Matmul& parameters,
     const uint8_t queue_id) {
     std::vector<std::optional<const Tensor>> optional_input_tensors = {};
     std::vector<Tensor> output_tensors;
@@ -899,11 +921,11 @@ Tensor matmul(
 
     operation::launch_op(
         [parameters, queue_id](
-            const std::vector<Tensor> &input_tensors,
-            const std::vector<std::optional<const Tensor>> &optional_input_tensors,
-            const std::vector<std::optional<Tensor>> &optional_output_tensors) mutable -> std::vector<Tensor> {
-            const auto &input_tensor_a = input_tensors.at(0);
-            const auto &input_tensor_b = input_tensors.at(1);
+            const std::vector<Tensor>& input_tensors,
+            const std::vector<std::optional<const Tensor>>& optional_input_tensors,
+            const std::vector<std::optional<Tensor>>& optional_output_tensors) mutable -> std::vector<Tensor> {
+            const auto& input_tensor_a = input_tensors.at(0);
+            const auto& input_tensor_b = input_tensors.at(1);
 
             return operation::run(
                 create_matmul_struct(input_tensor_a, input_tensor_b, parameters),
@@ -1462,7 +1484,9 @@ operation::ProgramWithCallbacks Matmul::create_program(
                     program_config.fused_activation,
                     program_config.mcast_in0,
                     this->untilize_out);
-            } else if constexpr (std::is_same_v<ProgramConfigType, MatmulMultiCoreReuseMultiCastDRAMShardedProgramConfig>) {
+            } else if constexpr (std::is_same_v<
+                                     ProgramConfigType,
+                                     MatmulMultiCoreReuseMultiCastDRAMShardedProgramConfig>) {
                 return matmul_multi_core_reuse_dram_sharded_optimized(
                     input_tensor_a,
                     input_tensor_b,


### PR DESCRIPTION
### Ticket
Link to Github Issue https://github.com/tenstorrent/tt-metal/issues/10515

### Problem description
- although the issue was solved by changing parameters to matmul, it would be good to cover the specific corner case in that issue and avoid failing matmul

### What's changed
If
- the user provides a core grid, 
- the inputs are interleaved,
- the inputs are batched, and
- the matmul program config chosen would generate CBs that do not fit in L1,
  - then use the simple matmul program config choosing method to select a different matmul program config

Also
- moved the methods around and factored out some code
- ran clang-format on the edited file

### Checklist
- [x] Post commit CI passes https://github.com/tenstorrent/tt-metal/actions/runs/10562011637
- [x] Blackhole Post commit (if applicable) https://github.com/tenstorrent/tt-metal/actions/runs/10562000916
- [x] Model regression CI testing passes (if applicable) same behaviour https://github.com/tenstorrent/tt-metal/actions/runs/10562222597 as main https://github.com/tenstorrent/tt-metal/actions/runs/10557704799
- [x] New/Existing tests provide coverage for changes
