### PR TITLE
#11711: Attempt to use qooman/actions--context to see if we can get job ID easily

### DIFF
--- a/.github/workflows/fast-dispatch-build-and-unit-tests.yaml
+++ b/.github/workflows/fast-dispatch-build-and-unit-tests.yaml
@@ -89,3 +89,16 @@ jobs:
           path: |
             generated/test_reports/
           prefix: "test_reports_"
+      - uses: qoomon/actions--context@v2.0.2
+        if: ${{ !cancelled() }}
+        id: job-context
+      - name: Output qooman outputs
+        if: ${{ !cancelled() }}
+        run: |
+          echo "Current Environment: ${{ steps.job-context.outputs.environment }}"
+          echo "Current Job ID: ${{ steps.job-context.outputs.job_id }}"
+      - uses: actions/upload-artifact@v4
+        if: ${{ !cancelled() }}
+        with:
+          name: "test_reports_jobid_${{ steps.job-context.outputs.job_id }}"
+          path: generated/test_reports/


### PR DESCRIPTION
…

### Ticket

#11711

### Problem description

We currently have some horrible solution where use `uuid`s to get the job ID of artifacts and logs.

### What's changed

Try using this new action to see if it helps.

### Checklist
- [ ] Post commit CI passes
- [ ] Blackhole Post commit (if applicable)
- [ ] Model regression CI testing passes (if applicable)
- [ ] New/Existing tests provide coverage for changes
