### PR TITLE
#11847: Add tt-smi reset command environment variable for sweeps

### DIFF
--- a/tests/sweep_framework/README.md
+++ b/tests/sweep_framework/README.md
@@ -315,6 +315,7 @@ The test runner reads in test vectors from the test vector database and executes
 
 - Hang Detection / Timeout: Default timeout for one single test is 30 seconds. This can be overridden by setting a global `TIMEOUT` variable in the test file. Test processes are killed after this timeout and tt-smi is automatically run to reset the chip after a hang, before continuing the test suite.
 - NOTE ON HANGS: When specifying one test vector to run, hang detection will be disabled. This is because the test is run in the parent process to allow debug tools like gdb/lldb to be used easily.
+- NOTE ON TT-SMI: To ensure the best stability, set the TT-SMI reset command in an environment variable `TT_SMI_RESET_COMMAND`. For example `TT_SMI_RESET_COMMAND="tt-smi -tr 0"`. If this is not set, the system will attempt to find tt-smi and use default flags, but this is not guaranteed to work on every system because of version mismatches of tt-smi.
 - Result Classification: Tests will be assigned one of the following statuses after a run:
     1. PASS: The test met expected criteria. In this case the test message response is stored with the status, typically this is a PCC value.
     2. FAIL: ASSERT / EXCEPTION: The test failed due to an assertion in the op itself, failed PCC assertion, or any other exception that is raised during execution. The exception is stored with the test result.

--- a/tests/sweep_framework/tt_smi_util.py
+++ b/tests/sweep_framework/tt_smi_util.py
@@ -2,14 +2,21 @@
 
 # SPDX-License-Identifier: Apache-2.0
 
+import os
 import shutil
 import subprocess
 
 GRAYSKULL_ARGS = ["-tr", "all"]
 WORMHOLE_ARGS = ["-wr", "all"]
 
+RESET_OVERRIDE = os.getenv("TT_SMI_RESET_COMMAND")
+
 
 def run_tt_smi(arch: str):
+    if RESET_OVERRIDE is not None:
+        subprocess.run(RESET_OVERRIDE, shell=True)
+        return
+
     if arch not in ["grayskull", "wormhole_b0"]:
         raise Exception(f"SWEEPS: Unsupported Architecture for TT-SMI Reset: {arch}")
 


### PR DESCRIPTION
### Ticket
#11847 

### Problem description
TT-SMI reset will sometimes fail when the host's version of tt-smi does not match the default flags expected.
Core SW DevInfra is looking into updating tt-smi on all our machines to be consistent, but until then, there is a temporary flag to override the tt-smi reset command that will be used.

### What's changed
Add the `TT_SMI_RESET_COMMAND` environment variable to be used to override the tt-smi reset command used by sweeping infra. This will be the most stable approach to run the infra, but there is still logic to find and run tt-smi using default flags.

### Checklist
- [ ] Post commit CI passes
- [ ] Blackhole Post commit (if applicable)
- [ ] Model regression CI testing passes (if applicable)
- [ ] New/Existing tests provide coverage for changes
