### PR TITLE
Collection of small dprint/watcer changes

### DIFF
--- a/docs/source/tt-metalium/tools/kernel_print.rst
+++ b/docs/source/tt-metalium/tools/kernel_print.rst
@@ -21,8 +21,8 @@ Note that the core coordinates are logical coordinates, so worker cores and ethe
 
 .. code-block::
 
-    export TT_METAL_DPRINT_CORES=0,0     # required, x,y OR (x1,y1),(x2,y2),(x3,y3) OR (x1,y1)-(x2,y2) OR all
-    export TT_METAL_DPRINT_ETH_CORES=0,0 # optional, x,y OR (x1,y1),(x2,y2),(x3,y3) OR (x1,y1)-(x2,y2) OR all
+    export TT_METAL_DPRINT_CORES=0,0     # required, x,y OR (x1,y1),(x2,y2),(x3,y3) OR (x1,y1)-(x2,y2) OR all OR worker OR dispatch
+    export TT_METAL_DPRINT_ETH_CORES=0,0 # optional, x,y OR (x1,y1),(x2,y2),(x3,y3) OR (x1,y1)-(x2,y2) OR all OR worker OR dispatch
     export TT_METAL_DPRINT_CHIPS=0       # optional, comma separated list of chips
     export TT_METAL_DPRINT_RISCVS=BR     # optional, default is all RISCs.  Use a subset of BR,NC,TR0,TR1,TR2
     export TT_METAL_DPRINT_FILE=log.txt  # optional, default is to print to the screen

--- a/tests/scripts/run_tools_tests.sh
+++ b/tests/scripts/run_tools_tests.sh
@@ -32,7 +32,7 @@ if [[ -z "$TT_METAL_SLOW_DISPATCH_MODE" ]] ; then
     # Check that stack dumping is working
     ./build/test/tt_metal/unit_tests_fast_dispatch --gtest_filter=*TestWatcherRingBufferBrisc
     ./build/tools/watcher_dump -d=0 -w
-    grep "brisc stack usage:" generated/watcher/watcher.log > /dev/null || { echo "Error: couldn't find stack usage in watcher log after dump." ; exit 1; }
+    grep "brisc highest stack usage:" generated/watcher/watcher.log > /dev/null || { echo "Error: couldn't find stack usage in watcher log after dump." ; exit 1; }
     echo "Watcher stack usage test - Pass"
 
     # Remove created files.

--- a/tests/tt_metal/tt_metal/test_kernels/misc/watcher_waypoints.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/misc/watcher_waypoints.cpp
@@ -34,9 +34,6 @@ void MAIN {
     uint32_t sync_wait_cycles = get_arg_val<uint32_t>(0);
     uint32_t sync_address     = get_arg_val<uint32_t>(1);
     WATCHER_RING_BUFFER_PUSH(sync_wait_cycles);
-#if defined(COMPILE_FOR_IDLE_ERISC)
-    sync_wait_cycles = 0x5f5e1000U;
-#endif
 
     // Post a new waypoint with a delay after (to let the watcher poll it)
     hacky_sync(1, sync_wait_cycles, sync_address);

--- a/tests/tt_metal/tt_metal/unit_tests_common/common/dprint_fixture.hpp
+++ b/tests/tt_metal/tt_metal/unit_tests_common/common/dprint_fixture.hpp
@@ -28,30 +28,16 @@ protected:
         // used by all tests using this fixture, so set dprint enabled for
         // all cores and all devices
         tt::llrt::OptionsG.set_feature_enabled(tt::llrt::RunTimeDebugFeatureDprint, true);
-        tt::llrt::OptionsG.set_feature_all_cores(tt::llrt::RunTimeDebugFeatureDprint, CoreType::WORKER, true);
-        tt::llrt::OptionsG.set_feature_all_cores(tt::llrt::RunTimeDebugFeatureDprint, CoreType::ETH, true);
+        tt::llrt::OptionsG.set_feature_all_cores(
+            tt::llrt::RunTimeDebugFeatureDprint, CoreType::WORKER, tt::llrt::RunTimeDebugClassWorker);
+        tt::llrt::OptionsG.set_feature_all_cores(
+            tt::llrt::RunTimeDebugFeatureDprint, CoreType::ETH, tt::llrt::RunTimeDebugClassWorker);
         tt::llrt::OptionsG.set_feature_all_chips(tt::llrt::RunTimeDebugFeatureDprint, true);
         // Send output to a file so the test can check after program is run.
         tt::llrt::OptionsG.set_feature_file_name(tt::llrt::RunTimeDebugFeatureDprint, dprint_file_name);
         tt::llrt::OptionsG.set_test_mode_enabled(true);
         watcher_previous_enabled = tt::llrt::OptionsG.get_watcher_enabled();
         tt::llrt::OptionsG.set_watcher_enabled(false);
-
-        // Setup dispatch core manager to get dispatch cores that need to be excluded from printing
-        const auto &dispatch_core_type = tt::llrt::OptionsG.get_dispatch_core_type();
-        tt::tt_metal::dispatch_core_manager::initialize(dispatch_core_type);
-
-        // By default, exclude dispatch cores from printing
-        unsigned num_cqs = tt::llrt::OptionsG.get_num_hw_cqs();
-        std::map<CoreType, std::unordered_set<CoreCoord>> disabled;
-        for (unsigned int id = 0; id < tt::tt_metal::GetNumAvailableDevices(); id++) {
-            CoreType internal_core_type = dispatch_core_manager::instance().get_dispatch_core_type(id);
-            for (auto core : tt::get_logical_dispatch_cores(id, num_cqs, internal_core_type)) {
-                log_info(tt::LogTest, "Disable dprint on Device {}: {}", id, core);
-                disabled[internal_core_type].insert(core);
-            }
-        }
-        tt::llrt::OptionsG.set_feature_disabled_cores(tt::llrt::RunTimeDebugFeatureDprint, disabled);
 
         ExtraSetUp();
 
@@ -69,8 +55,10 @@ protected:
         // Reset DPrint settings
         tt::llrt::OptionsG.set_feature_cores(tt::llrt::RunTimeDebugFeatureDprint, {});
         tt::llrt::OptionsG.set_feature_enabled(tt::llrt::RunTimeDebugFeatureDprint, false);
-        tt::llrt::OptionsG.set_feature_all_cores(tt::llrt::RunTimeDebugFeatureDprint, CoreType::WORKER, false);
-        tt::llrt::OptionsG.set_feature_all_cores(tt::llrt::RunTimeDebugFeatureDprint, CoreType::ETH, false);
+        tt::llrt::OptionsG.set_feature_all_cores(
+            tt::llrt::RunTimeDebugFeatureDprint, CoreType::WORKER, tt::llrt::RunTimeDebugClassNoneSpecified);
+        tt::llrt::OptionsG.set_feature_all_cores(
+            tt::llrt::RunTimeDebugFeatureDprint, CoreType::ETH, tt::llrt::RunTimeDebugClassNoneSpecified);
         tt::llrt::OptionsG.set_feature_all_chips(tt::llrt::RunTimeDebugFeatureDprint, false);
         tt::llrt::OptionsG.set_feature_file_name(tt::llrt::RunTimeDebugFeatureDprint, "");
         tt::llrt::OptionsG.set_test_mode_enabled(false);

--- a/tests/tt_metal/tt_metal/unit_tests_common/dprint/test_eth_cores.cpp
+++ b/tests/tt_metal/tt_metal/unit_tests_common/dprint/test_eth_cores.cpp
@@ -94,7 +94,7 @@ TEST_F(DPrintFixture, TestPrintEthCores) {
 }
 TEST_F(DPrintFixture, TestPrintIEthCores) {
     if (!this->IsSlowDispatch()) {
-        log_info(tt::LogTest, "Skip due to #7771");
+        log_info(tt::LogTest, "FD-on-idle-eth not supported.");
         GTEST_SKIP();
     }
     for (Device* device : this->devices_) {

--- a/tests/tt_metal/tt_metal/unit_tests_common/watcher/test_assert.cpp
+++ b/tests/tt_metal/tt_metal/unit_tests_common/watcher/test_assert.cpp
@@ -235,7 +235,7 @@ TEST_F(WatcherFixture, TestWatcherAssertErisc) {
 
 TEST_F(WatcherFixture, TestWatcherAssertIErisc) {
     if (!this->IsSlowDispatch()) {
-        log_info(tt::LogTest, "Skip due to #7771");
+        log_info(tt::LogTest, "FD-on-idle-eth not supported.");
         GTEST_SKIP();
     }
     if (this->slow_dispatch_)

--- a/tests/tt_metal/tt_metal/unit_tests_common/watcher/test_noc_sanitize.cpp
+++ b/tests/tt_metal/tt_metal/unit_tests_common/watcher/test_noc_sanitize.cpp
@@ -286,7 +286,7 @@ TEST_F(WatcherFixture, TestWatcherSanitizeEth) {
 
 TEST_F(WatcherFixture, TestWatcherSanitizeIEth) {
     if (!this->IsSlowDispatch()) {
-        log_info(tt::LogTest, "Skip due to #7771");
+        log_info(tt::LogTest, "FD-on-idle-eth not supported.");
         GTEST_SKIP();
     }
     if (this->slow_dispatch_)

--- a/tests/tt_metal/tt_metal/unit_tests_common/watcher/test_pause.cpp
+++ b/tests/tt_metal/tt_metal/unit_tests_common/watcher/test_pause.cpp
@@ -53,9 +53,11 @@ static void RunTest(WatcherFixture* fixture, Device* device) {
     bool has_eth_cores = !device->get_active_ethernet_cores(true).empty();
     //bool has_eth_cores = false;
     bool has_ieth_cores = !device->get_inactive_ethernet_cores().empty();
-    // TODO: revert this when #7771 is fixed.
+
+    // TODO: Enable this when FD-on-idle-eth is supported.
     if (!fixture->IsSlowDispatch())
         has_ieth_cores = false;
+
     if (has_eth_cores) {
         KernelHandle erisc_kid;
         std::set<CoreRange> eth_core_ranges;

--- a/tests/tt_metal/tt_metal/unit_tests_common/watcher/test_ringbuf.cpp
+++ b/tests/tt_metal/tt_metal/unit_tests_common/watcher/test_ringbuf.cpp
@@ -192,7 +192,7 @@ TEST_F(WatcherFixture, TestWatcherRingBufferErisc) {
 }
 TEST_F(WatcherFixture, TestWatcherRingBufferIErisc) {
     if (!this->IsSlowDispatch()) {
-        log_info(tt::LogTest, "Skip due to #7771");
+        log_info(tt::LogTest, "FD-on-idle-eth not supported.");
         GTEST_SKIP();
     }
     for (Device* device : this->devices_) {

--- a/tests/tt_metal/tt_metal/unit_tests_common/watcher/test_waypoint.cpp
+++ b/tests/tt_metal/tt_metal/unit_tests_common/watcher/test_waypoint.cpp
@@ -78,9 +78,11 @@ static void RunTest(WatcherFixture* fixture, Device* device) {
     // Also run on ethernet cores if they're present
     bool has_eth_cores = !device->get_active_ethernet_cores(true).empty();
     bool has_idle_eth_cores = !device->get_inactive_ethernet_cores().empty();
-    // TODO: revert this when #7771 is fixed.
+
+    // TODO: Enable this when FD-on-idle-eth is supported.
     if (!fixture->IsSlowDispatch())
         has_idle_eth_cores = false;
+
     if (has_eth_cores) {
         KernelHandle erisc_kid;
         std::set<CoreRange> eth_core_ranges;

--- a/tests/tt_metal/tt_metal/unit_tests_fast_dispatch/command_queue/test_EnqueueProgram.cpp
+++ b/tests/tt_metal/tt_metal/unit_tests_fast_dispatch/command_queue/test_EnqueueProgram.cpp
@@ -863,8 +863,7 @@ TEST_F(CommandQueueSingleCardFixture, IncrementRuntimeArgsSanitySingleCoreDataMo
 }
 
 // Sanity test for setting and verifying common and unique runtime args to single cores via ERISC(IDLE). Some arch may return 0 active eth cores, that's okay.
-// FIXME - Disabled due to #7771 kernels not running on idle eth cores. At one point this was passing, but then before merging same day
-// it started hanging just like below inactive-idle-eth test.
+// FIXME - Re-enable when FD-on-idle-eth is supported
 TEST_F(CommandQueueSingleCardFixture, DISABLED_IncrementRuntimeArgsSanitySingleCoreDataMovementEriscIdle) {
     for (Device *device : devices_) {
         for (const auto &eth_core : device->get_active_ethernet_cores(true)) {
@@ -878,7 +877,7 @@ TEST_F(CommandQueueSingleCardFixture, DISABLED_IncrementRuntimeArgsSanitySingleC
 }
 
 // Sanity test for setting and verifying common and unique runtime args to single cores via inactive ERISC cores. Some arch may return 0 active eth cores, that's okay.
-// FIXME - Disabled due to #7771 kernels not running on idle eth cores.
+// FIXME - Re-enable when FD-on-idle-eth is supported
 TEST_F(CommandQueueSingleCardFixture, DISABLED_IncrementRuntimeArgsSanitySingleCoreDataMovementEriscInactive) {
     for (Device *device : devices_) {
         for (const auto &eth_core : device->get_inactive_ethernet_cores()) {

--- a/tt_metal/impl/debug/dprint_server.cpp
+++ b/tt_metal/impl/debug/dprint_server.cpp
@@ -82,6 +82,21 @@ static map<CoreType, set<CoreCoord>> get_all_physical_printable_cores(Device *de
     return all_physical_printable_cores;
 }
 
+// Helper function to get all physical printable cores that are used for dispatch. Should be a subset of
+// get_all_physical_printable_cores().
+static map<CoreType, set<CoreCoord>> get_dispatch_physical_printable_cores(Device* device) {
+    map<CoreType, set<CoreCoord>> physical_printable_dispatch_cores;
+    unsigned num_cqs = tt::llrt::OptionsG.get_num_hw_cqs();
+    for (unsigned int id = 0; id < tt::Cluster::instance().number_of_user_devices(); id++) {
+        CoreType dispatch_core_type = dispatch_core_manager::instance().get_dispatch_core_type(id);
+        for (auto logical_core : tt::get_logical_dispatch_cores(id, num_cqs, dispatch_core_type)) {
+            CoreCoord physical_core = device->physical_core_from_logical_core(logical_core, dispatch_core_type);
+            physical_printable_dispatch_cores[dispatch_core_type].insert(physical_core);
+        }
+    }
+    return physical_printable_dispatch_cores;
+}
+
 // A null stream for when the print server is muted.
 class NullBuffer : public std::streambuf {
 public:
@@ -412,6 +427,7 @@ void DebugPrintServerContext::AttachDevice(Device* device) {
     // A set of all valid printable cores, used for checking the user input. Note that the coords
     // here are physical.
     map<CoreType, set<CoreCoord>> all_physical_printable_cores = get_all_physical_printable_cores(device);
+    map<CoreType, set<CoreCoord>> dispatch_physical_printable_cores = get_dispatch_physical_printable_cores(device);
 
     // Initialize all print buffers on all cores on the device to have print disabled magic. We
     // will then write print enabled magic for only the cores the user has specified to monitor.
@@ -434,34 +450,48 @@ void DebugPrintServerContext::AttachDevice(Device* device) {
         if (std::find(chip_ids.begin(), chip_ids.end(), device->id()) == chip_ids.end())
             return;
 
-    // Handle specifically disabled cores
-    std::unordered_set<CoreCoord> disabled_phys_cores;
-    for (auto &type_and_cores : tt::llrt::OptionsG.get_feature_disabled_cores(tt::llrt::RunTimeDebugFeatureDprint)) {
-        for (auto &core : type_and_cores.second) {
-            CoreCoord physical_core = device->physical_core_from_logical_core(core, type_and_cores.first);
-            disabled_phys_cores.insert(physical_core);
-        }
-    }
-
     // Core range depends on whether dprint_all_cores flag is set.
     vector<CoreCoord> print_cores_sanitized;
     for (CoreType core_type : {CoreType::WORKER, CoreType::ETH}) {
-        if (tt::llrt::OptionsG.get_feature_all_cores(tt::llrt::RunTimeDebugFeatureDprint, core_type)) {
+        if (tt::llrt::OptionsG.get_feature_all_cores(tt::llrt::RunTimeDebugFeatureDprint, core_type) ==
+            tt::llrt::RunTimeDebugClassAll) {
             // Print from all cores of the given type, cores returned here are guaranteed to be valid.
             for (CoreCoord phys_core: all_physical_printable_cores[core_type]) {
-                // Don't print on specifically disabled cores.
-                if (disabled_phys_cores.find(phys_core) != disabled_phys_cores.end())
-                    continue;
                 print_cores_sanitized.push_back(phys_core);
             }
             log_info(
                 tt::LogMetal,
                 "DPRINT enabled on device {}, all {} cores.",
                 device->id(),
-                tt::llrt::get_core_type_name(core_type)
-            );
+                tt::llrt::get_core_type_name(core_type));
+        } else if (
+            tt::llrt::OptionsG.get_feature_all_cores(tt::llrt::RunTimeDebugFeatureDprint, core_type) ==
+            tt::llrt::RunTimeDebugClassDispatch) {
+            for (CoreCoord phys_core : dispatch_physical_printable_cores[core_type]) {
+                print_cores_sanitized.push_back(phys_core);
+            }
+            log_info(
+                tt::LogMetal,
+                "DPRINT enabled on device {}, {} dispatch cores.",
+                device->id(),
+                tt::llrt::get_core_type_name(core_type));
+        } else if (
+            tt::llrt::OptionsG.get_feature_all_cores(tt::llrt::RunTimeDebugFeatureDprint, core_type) ==
+            tt::llrt::RunTimeDebugClassWorker) {
+            // For worker cores, take all cores and remove dispatch cores.
+            for (CoreCoord phys_core: all_physical_printable_cores[core_type]) {
+                if (dispatch_physical_printable_cores[core_type].find(phys_core) ==
+                    dispatch_physical_printable_cores[core_type].end()) {
+                    print_cores_sanitized.push_back(phys_core);
+                }
+            }
+            log_info(
+                tt::LogMetal,
+                "DPRINT enabled on device {}, {} worker cores.",
+                device->id(),
+                tt::llrt::get_core_type_name(core_type));
         } else {
-            // Only print from the cores specified by the user
+            // No "all cores" option provided, which means print from the cores specified by the user
             vector<CoreCoord> print_cores = tt::llrt::OptionsG.get_feature_cores(tt::llrt::RunTimeDebugFeatureDprint)[core_type];
 
             // We should also validate that the cores the user specified are valid worker cores.
@@ -476,9 +506,6 @@ void DebugPrintServerContext::AttachDevice(Device* device) {
                     valid_logical_core = false;
                 }
                 if (valid_logical_core && all_physical_printable_cores[core_type].count(phys_core) > 0) {
-                    // Don't print on specifically disabled cores.
-                    if (disabled_phys_cores.find(phys_core) != disabled_phys_cores.end())
-                        continue;
                     print_cores_sanitized.push_back(phys_core);
                     log_info(
                         tt::LogMetal,

--- a/tt_metal/llrt/rtoptions.cpp
+++ b/tt_metal/llrt/rtoptions.cpp
@@ -25,6 +25,13 @@ const char *RunTimeDebugFeatureNames[RunTimeDebugFeatureCount] = {
     "ATOMIC_DEBUG_DELAY",
 };
 
+const char *RunTimeDebugClassNames[RunTimeDebugClassCount] = {
+    "N/A",
+    "worker",
+    "dispatch",
+    "all"
+};
+
 // Note: global initialization order is non-deterministic
 // This is ok so long as this gets initialized before decisions are based on
 // env state
@@ -181,7 +188,7 @@ void RunTimeOptions::ParseFeatureEnv(RunTimeDebugFeatures feature) {
     // Set feature enabled if the user asked for any feature cores
     feature_targets[feature].enabled = false;
     for (auto &core_type_and_all_flag : feature_targets[feature].all_cores)
-        if (core_type_and_all_flag.second)
+        if (core_type_and_all_flag.second != RunTimeDebugClassNoneSpecified)
             feature_targets[feature].enabled = true;
     for (auto &core_type_and_cores : feature_targets[feature].cores)
         if (core_type_and_cores.second.size() > 0)
@@ -198,9 +205,14 @@ void RunTimeOptions::ParseFeatureCoreRange(
     vector<CoreCoord> cores;
 
     // Check if "all" is specified, rather than a range of cores.
-    if (str != nullptr && strcmp(str, "all") == 0) {
-        feature_targets[feature].all_cores[core_type] = true;
-        return;
+    feature_targets[feature].all_cores[core_type] = RunTimeDebugClassNoneSpecified;
+    if (str != nullptr) {
+        for (int idx = 0; idx < RunTimeDebugClassCount; idx++) {
+            if (strcmp(str, RunTimeDebugClassNames[idx]) == 0) {
+                feature_targets[feature].all_cores[core_type] = idx;
+                return;
+            }
+        }
     }
     if (str != nullptr) {
         if (isdigit(str[0])) {

--- a/tt_metal/llrt/rtoptions.hpp
+++ b/tt_metal/llrt/rtoptions.hpp
@@ -54,14 +54,23 @@ enum RunTimeDebugFeatures {
     RunTimeDebugFeatureCount
 };
 
+// Enumerates a class of cores to enable features on at runtime.
+enum RunTimeDebugClass {
+    RunTimeDebugClassNoneSpecified,
+    RunTimeDebugClassWorker,
+    RunTimeDebugClassDispatch,
+    RunTimeDebugClassAll,
+    RunTimeDebugClassCount
+};
+
 extern const char *RunTimeDebugFeatureNames[RunTimeDebugFeatureCount];
+extern const char *RunTimeDebugClassNames[RunTimeDebugClassCount];
 
 // TargetSelection stores the targets for a given debug feature. I.e. for which chips, cores, harts
 // to enable the feature.
 struct TargetSelection {
     std::map<CoreType, std::vector<CoreCoord>> cores;
-    std::map<CoreType, bool> all_cores;
-    std::map<CoreType, std::unordered_set<CoreCoord>> disabled_cores;
+    std::map<CoreType, int> all_cores;
     bool enabled;
     std::vector<int> chip_ids;
     bool all_chips = false;
@@ -148,18 +157,11 @@ class RunTimeOptions {
     inline void set_feature_cores(RunTimeDebugFeatures feature, std::map<CoreType, std::vector<CoreCoord>> cores) {
         feature_targets[feature].cores = cores;
     }
-    inline std::map<CoreType, std::unordered_set<CoreCoord>> &get_feature_disabled_cores(RunTimeDebugFeatures feature) {
-        return feature_targets[feature].disabled_cores;
-    }
-    inline void set_feature_disabled_cores(
-        RunTimeDebugFeatures feature, std::map<CoreType, std::unordered_set<CoreCoord>> disabled_cores) {
-        feature_targets[feature].disabled_cores = disabled_cores;
-    }
     // An alternative to setting cores by range, a flag to enable all.
-    inline void set_feature_all_cores(RunTimeDebugFeatures feature, CoreType core_type, bool all_cores) {
+    inline void set_feature_all_cores(RunTimeDebugFeatures feature, CoreType core_type, int all_cores) {
         feature_targets[feature].all_cores[core_type] = all_cores;
     }
-    inline bool get_feature_all_cores(RunTimeDebugFeatures feature, CoreType core_type) {
+    inline int get_feature_all_cores(RunTimeDebugFeatures feature, CoreType core_type) {
         return feature_targets[feature].all_cores[core_type];
     }
     // Note: core range is inclusive


### PR DESCRIPTION
### Ticket
Address a bunch of small dprint/watcher issues:
#11521, #10494, #11579, #7771

### What's changed
* Re-enable some rpeviously failing tests
* Change watcher stack reporting to be a summary at the end of each dump, instead of for each core (to clean up the log). Example (instead of these lines being printed for all cores):
```
354 k_id[0]: blank
355 k_id[1]: tests/tt_metal/tt_metal/test_kernels/misc/watcher_waypoints.cpp
356 k_id[2]: tests/tt_metal/tt_metal/test_kernels/misc/watcher_waypoints.cpp
357 k_id[3]: tests/tt_metal/tt_metal/test_kernels/misc/watcher_waypoints.cpp
358 k_id[4]: tests/tt_metal/tt_metal/test_kernels/misc/watcher_waypoints.cpp
359 k_id[5]: tests/tt_metal/tt_metal/test_kernels/misc/watcher_waypoints.cpp
360 Stack usage summary:
361     brisc highest stack usage: 192/768, on core (x=1,y=1), running kernel tests/tt_metal/tt_metal/test_kernels/misc/watcher_waypoints.cpp
362     ncrisc highest stack usage: 192/768, on core (x=1,y=1), running kernel tests/tt_metal/tt_metal/test_kernels/misc/watcher_waypoints.cpp
363     trisc0 highest stack usage: 92/320, on core (x=1,y=1), running kernel tests/tt_metal/tt_metal/test_kernels/misc/watcher_waypoints.cpp
364     trisc1 highest stack usage: 92/256, on core (x=1,y=1), running kernel tests/tt_metal/tt_metal/test_kernels/misc/watcher_waypoints.cpp
365     trisc2 highest stack usage: 192/768, on core (x=1,y=1), running kernel tests/tt_metal/tt_metal/test_kernels/misc/watcher_waypoints.cpp
366     ierisc highest stack usage: 256/768, on core (x=9,y=0), running kernel tests/tt_metal/tt_metal/test_kernels/misc/watcher_waypoints.cpp
```
* Add a couple more options for specifying classes of cores to enable dprint on (specifically, `dispatch` and `workers` separately)

### Checklist
- [X] Post commit CI passes - [Running: https://github.com/tenstorrent/tt-metal/actions/runs/10563579540](https://github.com/tenstorrent/tt-metal/actions/runs/10563579540)
- [X] Blackhole Post commit (if applicable) - Small global tools changes, post-commit should be sufficient
- [X] Model regression CI testing passes (if applicable) - Small global tools changes, post-commit should be sufficient
- [X] New/Existing tests provide coverage for changes - Existing tests updated to match
