### PR TITLE
Enabling BH L1 data cache

### DIFF
--- a/tt_metal/hw/firmware/src/brisc.cc
+++ b/tt_metal/hw/firmware/src/brisc.cc
@@ -338,8 +338,6 @@ int main() {
     DIRTY_STACK_MEMORY();
     DEBUG_STATUS("I");
 
-    disable_lowcache();
-
     int32_t num_words = ((uint)__ldm_data_end - (uint)__ldm_data_start) >> 2;
     l1_to_local_mem_copy((uint*)__ldm_data_start, (uint tt_l1_ptr*)MEM_BRISC_INIT_LOCAL_L1_BASE, num_words);
 

--- a/tt_metal/hw/firmware/src/brisc.cc
+++ b/tt_metal/hw/firmware/src/brisc.cc
@@ -335,6 +335,7 @@ inline void wait_ncrisc_trisc() {
 }
 
 int main() {
+    conditionally_disable_l1_cache();
     DIRTY_STACK_MEMORY();
     DEBUG_STATUS("I");
 

--- a/tt_metal/hw/firmware/src/idle_erisc.cc
+++ b/tt_metal/hw/firmware/src/idle_erisc.cc
@@ -91,7 +91,6 @@ void flush_icache() {
 }
 
 int main() {
-    disable_lowcache();
     DIRTY_STACK_MEMORY();
     DEBUG_STATUS("I");
     int32_t num_words = ((uint)__ldm_data_end - (uint)__ldm_data_start) >> 2;

--- a/tt_metal/hw/firmware/src/idle_erisc.cc
+++ b/tt_metal/hw/firmware/src/idle_erisc.cc
@@ -91,6 +91,7 @@ void flush_icache() {
 }
 
 int main() {
+    conditionally_disable_l1_cache();
     DIRTY_STACK_MEMORY();
     DEBUG_STATUS("I");
     int32_t num_words = ((uint)__ldm_data_end - (uint)__ldm_data_start) >> 2;

--- a/tt_metal/hw/firmware/src/ncrisc.cc
+++ b/tt_metal/hw/firmware/src/ncrisc.cc
@@ -76,6 +76,7 @@ inline __attribute__((always_inline)) void signal_ncrisc_completion() {
 }
 
 int main(int argc, char *argv[]) {
+    conditionally_disable_l1_cache();
     DIRTY_STACK_MEMORY();
     DEBUG_STATUS("I");
 

--- a/tt_metal/hw/firmware/src/ncrisc.cc
+++ b/tt_metal/hw/firmware/src/ncrisc.cc
@@ -79,8 +79,6 @@ int main(int argc, char *argv[]) {
     DIRTY_STACK_MEMORY();
     DEBUG_STATUS("I");
 
-    disable_lowcache();
-
     int32_t num_words = ((uint)__ldm_data_end - (uint)__ldm_data_start) >> 2;
     l1_to_local_mem_copy((uint *)__ldm_data_start, (uint tt_l1_ptr *)MEM_NCRISC_INIT_LOCAL_L1_BASE, num_words);
 

--- a/tt_metal/hw/firmware/src/trisc.cc
+++ b/tt_metal/hw/firmware/src/trisc.cc
@@ -79,8 +79,6 @@ int main(int argc, char *argv[]) {
     DIRTY_STACK_MEMORY();
     DEBUG_STATUS("I");
 
-    disable_lowcache();
-
     uint tt_l1_ptr *local_l1_start_addr =
         (uint tt_l1_ptr *)PREPROCESSOR_EXPAND(MEM_TRISC, COMPILE_FOR_TRISC, _INIT_LOCAL_L1_BASE);
     int32_t num_words = ((uint)__ldm_data_end - (uint)__ldm_data_start) >> 2;

--- a/tt_metal/hw/firmware/src/trisc.cc
+++ b/tt_metal/hw/firmware/src/trisc.cc
@@ -76,6 +76,7 @@ constexpr bool cb_init_write = false;
 using namespace ckernel;
 
 int main(int argc, char *argv[]) {
+    conditionally_disable_l1_cache();
     DIRTY_STACK_MEMORY();
     DEBUG_STATUS("I");
 

--- a/tt_metal/hw/inc/risc_common.h
+++ b/tt_metal/hw/inc/risc_common.h
@@ -169,14 +169,16 @@ inline void riscv_wait(uint32_t cycles) {
 //  Writing an address on one core and reading it from another core only requires the reader to invalidate.
 //  Need to invalidate any address written by noc that may have been previously read
 inline __attribute__((always_inline)) void invalidate_l1_cache() {
-#ifdef ARCH_BLACKHOLE
+#if defined(ARCH_BLACKHOLE) && !defined(DISABLE_L1_DATA_CACHE)
     asm("fence");
 #endif
 }
 
 // Disables Blackhole's L1 cache. Grayskull and Wormhole do not have L1 cache
-inline __attribute__((always_inline)) void disable_lowcache() {
-#ifdef ARCH_BLACKHOLE
+// L1 cache can be disabled by setting `TT_METAL_DISABLE_L1_DATA_CACHE_RISCVS` env var
+// export TT_METAL_DISABLE_L1_DATA_CACHE_RISCVS=<BR,NC,TR,ER>
+inline __attribute__((always_inline)) void conditionally_disable_l1_cache() {
+#if defined(ARCH_BLACKHOLE) && defined(DISABLE_L1_DATA_CACHE)
     // asm(R"ASM(
     //         csrrsi zero, 0x7c0, 0x8
     //       )ASM");

--- a/tt_metal/hw/inc/risc_common.h
+++ b/tt_metal/hw/inc/risc_common.h
@@ -164,6 +164,16 @@ inline void riscv_wait(uint32_t cycles) {
     } while (wall_clock < (wall_clock_timestamp + cycles));
 }
 
+// Invalidates Blackhole's entire L1 cache
+// Blackhole L1 cache is a small write-through cache (4x16B L1 lines). If cache is enabled, the entire L1 is cached (no MMU).
+//  Writing an address on one core and reading it from another core only requires the reader to invalidate.
+//  Need to invalidate any address written by noc that may have been previously read
+inline __attribute__((always_inline)) void invalidate_l1_cache() {
+#ifdef ARCH_BLACKHOLE
+    asm("fence");
+#endif
+}
+
 // Disables Blackhole's L1 cache. Grayskull and Wormhole do not have L1 cache
 inline __attribute__((always_inline)) void disable_lowcache() {
 #ifdef ARCH_BLACKHOLE

--- a/tt_metal/impl/debug/dprint_server.cpp
+++ b/tt_metal/impl/debug/dprint_server.cpp
@@ -198,7 +198,7 @@ private:
 static void PrintTileSlice(ostream& stream, uint8_t* ptr, int hart_id) {
     // Since MATH RISCV doesn't have access to CBs, we can't print tiles from it. If the user still
     // tries to do this print a relevant message.
-    if ((1 << hart_id) == DPRINT_RISCV_TR1) {
+    if ((1 << hart_id) == tt::llrt::RISCV_TR1) {
         stream << "Warning: MATH core does not support TileSlice printing, omitting print..."
             << endl << std::flush;
         return;

--- a/tt_metal/impl/debug/dprint_server.hpp
+++ b/tt_metal/impl/debug/dprint_server.hpp
@@ -10,14 +10,6 @@
 
 namespace tt {
 
-enum DebugPrintHartFlags : unsigned int {
-    DPRINT_RISCV_NC  = 1,
-    DPRINT_RISCV_TR0 = 2,
-    DPRINT_RISCV_TR1 = 4,
-    DPRINT_RISCV_TR2 = 8,
-    DPRINT_RISCV_BR  = 16,
-};
-
 constexpr int DPRINT_NRISCVS = 5;
 constexpr int DPRINT_NRISCVS_ETH = 1;
 

--- a/tt_metal/impl/dispatch/kernels/cq_common.hpp
+++ b/tt_metal/impl/dispatch/kernels/cq_common.hpp
@@ -262,14 +262,15 @@ void cb_wait_all_pages(uint32_t n) {
     volatile tt_l1_ptr uint32_t* sem_addr =
         reinterpret_cast<volatile tt_l1_ptr uint32_t*>(get_semaphore<fd_core_type>(sem_id));
     DEBUG_STATUS("TAPW");
-    while ((*sem_addr) != n);
+    do {
+        invalidate_l1_cache();
+    } while ((*sem_addr) != n);
     DEBUG_STATUS("TAPD");
 }
 
 template<uint32_t noc_xy, uint32_t sem_id>
 FORCE_INLINE
 void cb_acquire_pages(uint32_t n) {
-
     volatile tt_l1_ptr uint32_t* sem_addr =
         reinterpret_cast<volatile tt_l1_ptr uint32_t*>(get_semaphore<fd_core_type>(sem_id));
 
@@ -280,9 +281,10 @@ void cb_acquire_pages(uint32_t n) {
     // Use a wrapping compare here to compare distance
     // Required for trace which steals downstream credits and may make the value negative
     uint32_t heartbeat = 0;
-    while (wrap_gt(n, *sem_addr)) {
+    do {
+        invalidate_l1_cache();
         IDLE_ERISC_HEARTBEAT_AND_RETURN(heartbeat);
-    }
+    } while (wrap_gt(n, *sem_addr));
     DEBUG_STATUS("DAPD");
     noc_semaphore_inc(get_noc_addr_helper(noc_xy, (uint32_t)sem_addr), -n);
 }
@@ -301,7 +303,6 @@ uint32_t cb_acquire_pages(uint32_t cb_fence,
                           uint32_t block_next_start_addr[],
                           uint32_t rd_block_idx,
                           uint32_t& local_count) {
-
     volatile tt_l1_ptr uint32_t* sem_addr =
         reinterpret_cast<volatile tt_l1_ptr uint32_t*>(get_semaphore<fd_core_type>(sem_id));
 
@@ -310,9 +311,10 @@ uint32_t cb_acquire_pages(uint32_t cb_fence,
     if (local_count == upstream_count) {
         DEBUG_STATUS("UAPW");
         uint32_t heartbeat = 0;
-        while ((upstream_count = *sem_addr) == local_count) {
+        do {
+            invalidate_l1_cache();
             IDLE_ERISC_HEARTBEAT_AND_RETURN(heartbeat, 0);
-        }
+        } while ((upstream_count = *sem_addr) == local_count);
         DEBUG_STATUS("UAPD");
     }
 

--- a/tt_metal/impl/dispatch/kernels/packet_queue.hpp
+++ b/tt_metal/impl/dispatch/kernels/packet_queue.hpp
@@ -334,6 +334,7 @@ public:
         if (!this->cb_mode) {
             return 0;
         }
+        invalidate_l1_cache();
         volatile tt_l1_ptr uint32_t* local_sem_addr =
             reinterpret_cast<volatile tt_l1_ptr uint32_t*>(get_semaphore<fd_core_type>(this->cb_mode_local_sem_id));
         // semaphore underflow is currently used to signal path teardown with minimal prefetcher changes
@@ -349,6 +350,7 @@ public:
         if (!this->cb_mode) {
             return false;
         }
+        invalidate_l1_cache();
         volatile tt_l1_ptr uint32_t* local_sem_addr =
             reinterpret_cast<volatile tt_l1_ptr uint32_t*>(get_semaphore<fd_core_type>(this->cb_mode_local_sem_id));
         // semaphore underflow is currently used to signal path teardown with minimal prefetcher changes

--- a/tt_metal/jit_build/build.cpp
+++ b/tt_metal/jit_build/build.cpp
@@ -196,6 +196,8 @@ JitBuildDataMovement::JitBuildDataMovement(const JitBuildEnv& env, int which, bo
 
     this->defines_ = env_.defines_;
 
+    uint32_t l1_cache_disable_mask = tt::llrt::OptionsG.get_feature_riscv_mask(tt::llrt::RunTimeDebugFeatureDisableL1DataCache);
+
     // TODO(pgk): build these once at init into built/libs!
     this->srcs_.push_back("tt_metal/hw/toolchain/substitutes.cpp");
 
@@ -206,6 +208,9 @@ JitBuildDataMovement::JitBuildDataMovement(const JitBuildEnv& env, int which, bo
             this->target_name_ = "brisc";
 
             this->defines_ += "-DCOMPILE_FOR_BRISC ";
+            if ((l1_cache_disable_mask & tt::llrt::DebugHartFlags::RISCV_BR) == tt::llrt::DebugHartFlags::RISCV_BR) {
+                this->defines_ += "-DDISABLE_L1_DATA_CACHE ";
+            }
 
             this->srcs_.push_back("tt_metal/hw/firmware/src/tdma_xmov.c");
             this->srcs_.push_back("tt_metal/hw/firmware/src/" + env_.aliased_arch_name_ + "/noc.c");
@@ -223,6 +228,9 @@ JitBuildDataMovement::JitBuildDataMovement(const JitBuildEnv& env, int which, bo
             this->target_name_ = "ncrisc";
 
             this->defines_ += "-DCOMPILE_FOR_NCRISC ";
+            if ((l1_cache_disable_mask & tt::llrt::DebugHartFlags::RISCV_NC) == tt::llrt::DebugHartFlags::RISCV_NC) {
+                this->defines_ += "-DDISABLE_L1_DATA_CACHE ";
+            }
 
             if (this->is_fw_) {
                 this->srcs_.push_back("tt_metal/hw/firmware/src/ncrisc.cc");
@@ -248,6 +256,11 @@ JitBuildCompute::JitBuildCompute(const JitBuildEnv& env, int which, bool is_fw) 
     this->cflags_ = env_.cflags_ + "-O3 ";
 
     this->defines_ = env_.defines_;
+    uint32_t l1_cache_disable_mask = tt::llrt::OptionsG.get_feature_riscv_mask(tt::llrt::RunTimeDebugFeatureDisableL1DataCache);
+    uint32_t debug_compute_mask = (tt::llrt::DebugHartFlags::RISCV_TR0 | tt::llrt::DebugHartFlags::RISCV_TR1 | tt::llrt::DebugHartFlags::RISCV_TR2);
+    if ((l1_cache_disable_mask & debug_compute_mask) == debug_compute_mask) {
+        this->defines_ += "-DDISABLE_L1_DATA_CACHE ";
+    }
 
     this->includes_ = env_.includes_ + "-I" + env_.root_ + "tt_metal/hw/ckernels/" + env.arch_name_ + "/inc " + "-I" +
                       env_.root_ + "tt_metal/hw/ckernels/" + env.arch_name_ + "/metal/common " + "-I" + env_.root_ +
@@ -315,6 +328,10 @@ JitBuildEthernet::JitBuildEthernet(const JitBuildEnv& env, int which, bool is_fw
                       "/metal/llk_io ";
 
     this->defines_ = env_.defines_;
+    uint32_t l1_cache_disable_mask = tt::llrt::OptionsG.get_feature_riscv_mask(tt::llrt::RunTimeDebugFeatureDisableL1DataCache);
+    if ((l1_cache_disable_mask & tt::llrt::DebugHartFlags::RISCV_ER) == tt::llrt::DebugHartFlags::RISCV_ER) {
+        this->defines_ += "-DDISABLE_L1_DATA_CACHE ";
+    }
 
     switch (this->core_id_) {
         case 0: {

--- a/tt_metal/llrt/rtoptions.cpp
+++ b/tt_metal/llrt/rtoptions.cpp
@@ -23,6 +23,7 @@ const char *RunTimeDebugFeatureNames[RunTimeDebugFeatureCount] = {
     "READ_DEBUG_DELAY",
     "WRITE_DEBUG_DELAY",
     "ATOMIC_DEBUG_DELAY",
+    "DISABLE_L1_DATA_CACHE",
 };
 
 const char *RunTimeDebugClassNames[RunTimeDebugClassCount] = {
@@ -284,24 +285,37 @@ void RunTimeOptions::ParseFeatureChipIds(RunTimeDebugFeatures feature, const std
 }
 
 void RunTimeOptions::ParseFeatureRiscvMask(RunTimeDebugFeatures feature, const std::string &env_var) {
-    // Default is all RISCVs enabled for printing.
-    uint32_t riscv_mask = DPRINT_RISCV_BR | DPRINT_RISCV_TR0 | DPRINT_RISCV_TR1 | DPRINT_RISCV_TR2 | DPRINT_RISCV_NC;
+    uint32_t riscv_mask = 0;
     char *env_var_str = std::getenv(env_var.c_str());
+
     if (env_var_str != nullptr) {
-        if (strcmp(env_var_str, "BR") == 0) {
-            riscv_mask = DPRINT_RISCV_BR;
-        } else if (strcmp(env_var_str, "NC") == 0) {
-            riscv_mask = DPRINT_RISCV_NC;
-        } else if (strcmp(env_var_str, "TR0") == 0) {
-            riscv_mask = DPRINT_RISCV_TR0;
-        } else if (strcmp(env_var_str, "TR1") == 0) {
-            riscv_mask = DPRINT_RISCV_TR1;
-        } else if (strcmp(env_var_str, "TR2") == 0) {
-            riscv_mask = DPRINT_RISCV_TR2;
-        } else {
-            TT_THROW("Invalid TT_DEBUG_PRINT_RISCV");
+        if (strstr(env_var_str, "BR")) {
+            riscv_mask |= RISCV_BR;
         }
+        if (strstr(env_var_str, "NC")) {
+            riscv_mask |= RISCV_NC;
+        }
+        if (strstr(env_var_str, "TR0")) {
+            riscv_mask |= RISCV_TR0;
+        }
+        if (strstr(env_var_str, "TR1")) {
+            riscv_mask |= RISCV_TR1;
+        }
+        if (strstr(env_var_str, "TR2")) {
+            riscv_mask |= RISCV_TR2;
+        }
+        if (strstr(env_var_str, "TR")) {
+            riscv_mask |= (RISCV_TR0 | RISCV_TR1 | RISCV_TR2);
+        }
+        if (strstr(env_var_str, "ER")) {
+            riscv_mask |= RISCV_ER;
+        }
+    } else {
+        // Default is all RISCVs enabled.
+        bool default_disabled = (feature == RunTimeDebugFeatures::RunTimeDebugFeatureDisableL1DataCache);
+        riscv_mask = default_disabled ? 0 : (RISCV_ER | RISCV_BR | RISCV_TR0 | RISCV_TR1 | RISCV_TR2 | RISCV_NC);
     }
+
     feature_targets[feature].riscv_mask = riscv_mask;
 }
 

--- a/tt_metal/llrt/rtoptions.hpp
+++ b/tt_metal/llrt/rtoptions.hpp
@@ -43,6 +43,16 @@ static inline const char *get_core_type_name(CoreType ct) {
     }
 }
 
+// TODO: This should come from the HAL
+enum DebugHartFlags : unsigned int {
+    RISCV_NC  = 1,
+    RISCV_TR0 = 2,
+    RISCV_TR1 = 4,
+    RISCV_TR2 = 8,
+    RISCV_BR  = 16,
+    RISCV_ER  = 32
+};
+
 // Enumerates the debug features that can be enabled at runtime. These features allow for
 // fine-grained control over targeted cores, chips, harts, etc.
 enum RunTimeDebugFeatures {
@@ -50,6 +60,7 @@ enum RunTimeDebugFeatures {
     RunTimeDebugFeatureReadDebugDelay,
     RunTimeDebugFeatureWriteDebugDelay,
     RunTimeDebugFeatureAtomicDebugDelay,
+    RunTimeDebugFeatureDisableL1DataCache,
     // NOTE: Update RunTimeDebugFeatureNames if adding new features
     RunTimeDebugFeatureCount
 };
@@ -218,6 +229,7 @@ class RunTimeOptions {
                 } else {
                     return "false";
                 }
+            case RunTimeDebugFeatureDisableL1DataCache: return std::to_string(get_feature_enabled(feature));
             default: return "";
         }
     }


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/10865

### Problem description
L1 cache was default disabled on BH

### What's changed
- Enabling L1 cache and adding api to invalidate cache. Added invalidation to apis that poll a L1 locations
- Added debug env var `TT_METAL_DISABLE_L1_DATA_CACHE_RISCVS` that can be set to one or more of <BR,NC,TR,ER> to disable the cache

### Checklist
- [x] [Post commit CI passes](https://github.com/tenstorrent/tt-metal/actions/runs/10565994280)
- [x] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/runs/10566009712)
