### PR TITLE
#0: Remove test include from packet_demux

### DIFF
--- a/tt_metal/impl/dispatch/kernels/packet_demux.cpp
+++ b/tt_metal/impl/dispatch/kernels/packet_demux.cpp
@@ -6,7 +6,6 @@
 #include "debug/dprint.h"
 #include "tt_metal/impl/dispatch/kernels/packet_queue.hpp"
 #include "tt_metal/impl/dispatch/kernels/cq_helpers.hpp"
-#include "tests/tt_metal/tt_metal/perf_microbenchmark/routing/kernels/traffic_gen.hpp"
 
 packet_input_queue_state_t input_queue;
 packet_output_queue_state_t output_queues[MAX_SWITCH_FAN_OUT];

--- a/tt_metal/impl/dispatch/kernels/packet_queue_ctrl.hpp
+++ b/tt_metal/impl/dispatch/kernels/packet_queue_ctrl.hpp
@@ -4,8 +4,6 @@
 
 #pragma once
 
-#include <vector>
-
 constexpr uint32_t PACKET_WORD_SIZE_BYTES = 16;
 constexpr uint32_t MAX_SWITCH_FAN_IN = 4;
 constexpr uint32_t MAX_SWITCH_FAN_OUT = 4;


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/10959

### Problem description
FD kernel was including a header from test dir

### What's changed
Remove include of header from test dir

### Checklist
- [x] Post commit CI passes
- [ ] Blackhole Post commit (if applicable)
- [x] Model regression CI testing passes (if applicable)
- [x] New/Existing tests provide coverage for changes
