### PR TITLE
#0: Do not use mount-cloud-weka label because we may no longer need it as cloud fixed it

### DIFF
--- a/.github/workflows/fast-dispatch-full-regressions-and-models.yaml
+++ b/.github/workflows/fast-dispatch-full-regressions-and-models.yaml
@@ -22,98 +22,98 @@ jobs:
             {
               name: "Common models GS",
               arch: grayskull,
-              runs-on: ["cloud-virtual-machine", "E150", "in-service", "mount-cloud-weka"],
+              runs-on: ["cloud-virtual-machine", "E150", "in-service"],
               cmd: tests/scripts/single_card/nightly/run_common_models.sh,
               timeout: 40
             },
             {
               name: "Common models N300 WH B0",
               arch: wormhole_b0,
-              runs-on: ["cloud-virtual-machine", "N300", "in-service", "mount-cloud-weka"],
+              runs-on: ["cloud-virtual-machine", "N300", "in-service"],
               cmd: tests/scripts/single_card/nightly/run_common_models.sh,
               timeout: 40,
             },
             {
               name: "Common models N150 WH BO",
               arch: wormhole_b0,
-              runs-on: ["cloud-virtual-machine", "N150", "in-service", "mount-cloud-weka"],
+              runs-on: ["cloud-virtual-machine", "N150", "in-service"],
               cmd: tests/scripts/single_card/nightly/run_common_models.sh,
               timeout: 40,
             },
             {
               name: "GS ttnn nightly",
               arch: grayskull,
-              runs-on: ["cloud-virtual-machine", "E150", "in-service", "mount-cloud-weka"],
+              runs-on: ["cloud-virtual-machine", "E150", "in-service"],
               cmd: tests/scripts/single_card/nightly/run_ttnn.sh,
               timeout: 40
             },
             {
               name: "WH N150 ttnn nightly",
               arch: wormhole_b0,
-              runs-on: ["cloud-virtual-machine", "N150", "in-service", "mount-cloud-weka"],
+              runs-on: ["cloud-virtual-machine", "N150", "in-service"],
               cmd: tests/scripts/single_card/nightly/run_ttnn.sh,
               timeout: 70
             },
             {
               name: "WH N300 ttnn nightly",
               arch: wormhole_b0,
-              runs-on: ["cloud-virtual-machine", "N300", "in-service", "mount-cloud-weka"],
+              runs-on: ["cloud-virtual-machine", "N300", "in-service"],
               cmd: tests/scripts/single_card/nightly/run_ttnn.sh,
               timeout: 70
             },
             {
               name: "GS-only models",
               arch: grayskull,
-              runs-on: ["cloud-virtual-machine", "E150", "in-service", "mount-cloud-weka"],
+              runs-on: ["cloud-virtual-machine", "E150", "in-service"],
               cmd: tests/scripts/single_card/nightly/run_gs_only.sh,
               timeout: 40
             },
             {
               name: "N300 WH-only models",
               arch: wormhole_b0,
-              runs-on: ["cloud-virtual-machine", "N300", "in-service", "mount-cloud-weka"],
+              runs-on: ["cloud-virtual-machine", "N300", "in-service"],
               cmd: tests/scripts/single_card/nightly/run_wh_b0_only.sh,
               timeout: 80
             },
             {
               name: "N150 WH-only models",
               arch: wormhole_b0,
-              runs-on: ["cloud-virtual-machine", "N150", "in-service", "mount-cloud-weka"],
+              runs-on: ["cloud-virtual-machine", "N150", "in-service"],
               cmd: tests/scripts/single_card/nightly/run_wh_b0_only.sh,
               timeout: 80
             },
             {
               name: "API tests GS",
               arch: grayskull,
-              runs-on: ["cloud-virtual-machine", "E150", "in-service", "mount-cloud-weka"],
+              runs-on: ["cloud-virtual-machine", "E150", "in-service"],
               cmd: ./tests/scripts/run_tests.sh --tt-arch grayskull --pipeline-type frequent_api --dispatch-mode fast,
               timeout: 40
             },
             {
               name: "API tests N300 WH B0",
               arch: wormhole_b0,
-              runs-on: ["cloud-virtual-machine", "N300", "in-service", "mount-cloud-weka"],
+              runs-on: ["cloud-virtual-machine", "N300", "in-service"],
               cmd: ./tests/scripts/run_tests.sh --tt-arch wormhole_b0 --pipeline-type frequent_api --dispatch-mode fast,
               timeout: 40
             },
             {
               name: "API tests N150 WH B0",
               arch: wormhole_b0,
-              runs-on: ["cloud-virtual-machine", "N150", "in-service", "mount-cloud-weka"],
+              runs-on: ["cloud-virtual-machine", "N150", "in-service"],
               cmd: ./tests/scripts/run_tests.sh --tt-arch wormhole_b0 --pipeline-type frequent_api --dispatch-mode fast,
               timeout: 40
             },
             {
               name: "[Unstable] N150 models",
               arch: wormhole_b0,
-              runs-on: ["cloud-virtual-machine", "N150", "in-service", "mount-cloud-weka"],
+              runs-on: ["cloud-virtual-machine", "N150", "in-service"],
               cmd: tests/scripts/single_card/nightly/run_wh_b0_unstable.sh,
               timeout: 55
             },
             {
               name: "[Unstable] N300 models",
               arch: wormhole_b0,
-              runs-on: ["cloud-virtual-machine", "N300", "in-service", "mount-cloud-weka"],
+              runs-on: ["cloud-virtual-machine", "N300", "in-service"],
               cmd: tests/scripts/single_card/nightly/run_wh_b0_unstable.sh,
               timeout: 55
             },

--- a/.github/workflows/single-card-demo-tests-impl.yaml
+++ b/.github/workflows/single-card-demo-tests-impl.yaml
@@ -12,13 +12,13 @@ jobs:
           {
             name: "N150",
             arch: wormhole_b0,
-            runs-on: ["cloud-virtual-machine", "N150", "in-service", "mount-cloud-weka"],
+            runs-on: ["cloud-virtual-machine", "N150", "in-service"],
             cmd: './tests/scripts/run_tests.sh --tt-arch wormhole_b0 --pipeline-type demos_single_card_n150 --dispatch-mode ""'
           },
           {
             name: "N300",
             arch: wormhole_b0,
-            runs-on: ["cloud-virtual-machine", "N300", "in-service", "mount-cloud-weka"],
+            runs-on: ["cloud-virtual-machine", "N300", "in-service"],
             cmd: './tests/scripts/run_tests.sh --tt-arch wormhole_b0 --pipeline-type demos_single_card_n300 --dispatch-mode ""'
           }
         ]

--- a/.github/workflows/tg-nightly-tests.yaml
+++ b/.github/workflows/tg-nightly-tests.yaml
@@ -26,7 +26,7 @@ jobs:
       LOGURU_LEVEL: INFO
       LD_LIBRARY_PATH: ${{ github.workspace }}/build/lib
     environment: dev
-    runs-on: ["arch-wormhole_b0", "config-tg", "in-service", "pipeline-functional", "mount-cloud-weka"]
+    runs-on: ["arch-wormhole_b0", "config-tg", "in-service", "pipeline-functional"]
     steps:
       - uses: tenstorrent-metal/metal-workflows/.github/actions/checkout-with-submodule-lfs@v2.0.0
       - uses: ./.github/actions/retry-command


### PR DESCRIPTION
…

### Ticket

#10944

### Problem description

We had to select certain VMs which could connect to Weka, as certain ones couldn't. Now cloud should have fixed things.

### What's changed

Remove `mount-cloud-weka` label requirement for runner.

### Checklist
- [ ] Post commit CI passes
- [ ] Blackhole Post commit (if applicable)
- [ ] Model regression CI testing passes (if applicable)
- [ ] New/Existing tests provide coverage for changes
