### PR TITLE
#11646: Replace ttnn.experimental.tensor.* in models/demos

### DIFF
--- a/models/demos/falcon7b_common/tests/test_utils.py
+++ b/models/demos/falcon7b_common/tests/test_utils.py
@@ -118,7 +118,7 @@ def get_rand_falcon_inputs(
                 tt_attention_mask = [
                     tt_from_torch(
                         attn_mask,
-                        dtype=ttnn.experimental.tensor.DataType.BFLOAT4_B,
+                        dtype=ttnn.bfloat4_b,
                         device=device_mesh,
                         layout=ttnn.TILE_LAYOUT,
                         mesh_mapper=ShardTensorToMesh(device_mesh, dim=0),

--- a/models/demos/falcon7b_common/tests/unit_tests/test_falcon_attn_matmul.py
+++ b/models/demos/falcon7b_common/tests/unit_tests/test_falcon_attn_matmul.py
@@ -37,7 +37,7 @@ def run_falcon_attn_matmul_test(
         expected_output_shape = [1, q_heads, batch, seq_len]
 
         B = torch.randn(b_shape) - 0.95
-        b_t = ttnn.Tensor(B, in1_dtype).to(ttnn.experimental.tensor.Layout.TILE).to(device, in1_mem_config)
+        b_t = ttnn.Tensor(B, in1_dtype).to(ttnn.TILE_LAYOUT).to(device, in1_mem_config)
 
     elif falcon_op == ttnn.experimental.attn_matmul_from_cache:
         q_len = 1
@@ -60,14 +60,14 @@ def run_falcon_attn_matmul_test(
             B = kv_cache[:, :, :seq_len, :]
             expected_output_shape = [1, q_heads, batch, K]
 
-        b_t = ttnn.Tensor(kv_cache, in1_dtype).to(ttnn.experimental.tensor.Layout.TILE).to(device, in1_mem_config)
+        b_t = ttnn.Tensor(kv_cache, in1_dtype).to(ttnn.TILE_LAYOUT).to(device, in1_mem_config)
 
     else:
         raise NotImplementedError(f"falcon matmul op is undefined!")
 
     A = torch.randn(a_shape)
 
-    a_t = ttnn.Tensor(A, in0_dtype).to(ttnn.experimental.tensor.Layout.TILE).to(device, in0_mem_config)
+    a_t = ttnn.Tensor(A, in0_dtype).to(ttnn.TILE_LAYOUT).to(device, in0_mem_config)
 
     compute_grid_size = device.compute_with_storage_grid_size()
 
@@ -75,7 +75,7 @@ def run_falcon_attn_matmul_test(
         out = falcon_op(
             a_t,
             b_t,
-            compute_with_storage_grid_size=ttnn.experimental.tensor.CoreCoord(compute_grid_size.x, compute_grid_size.y),
+            compute_with_storage_grid_size=ttnn.CoreCoord(compute_grid_size.x, compute_grid_size.y),
             memory_config=out_mem_config,
             dtype=out_dtype,
         )
@@ -86,7 +86,7 @@ def run_falcon_attn_matmul_test(
             b_t,
             num_tokens=seq_len,
             transpose_hw=transpose_hw,
-            compute_with_storage_grid_size=ttnn.experimental.tensor.CoreCoord(compute_grid_size.x, compute_grid_size.y),
+            compute_with_storage_grid_size=ttnn.CoreCoord(compute_grid_size.x, compute_grid_size.y),
             memory_config=out_mem_config,
             dtype=out_dtype,
         )
@@ -119,32 +119,26 @@ def run_falcon_attn_matmul_test(
     "in0_mem_config, in1_mem_config, out_mem_config",
     (
         (
-            ttnn.experimental.tensor.MemoryConfig(
-                ttnn.experimental.tensor.TensorMemoryLayout.INTERLEAVED, ttnn.experimental.tensor.BufferType.DRAM
-            ),
-            ttnn.experimental.tensor.MemoryConfig(
-                ttnn.experimental.tensor.TensorMemoryLayout.INTERLEAVED, ttnn.experimental.tensor.BufferType.DRAM
-            ),
-            ttnn.experimental.tensor.MemoryConfig(
-                ttnn.experimental.tensor.TensorMemoryLayout.INTERLEAVED, ttnn.experimental.tensor.BufferType.DRAM
-            ),
+            ttnn.DRAM_MEMORY_CONFIG,
+            ttnn.DRAM_MEMORY_CONFIG,
+            ttnn.DRAM_MEMORY_CONFIG,
         ),
     ),
     ids=["DRAM"],
 )
 @pytest.mark.parametrize(
     "out_dtype",
-    (ttnn.experimental.tensor.DataType.BFLOAT16,),
+    (ttnn.bfloat16,),
     ids=["out_BFLOAT16"],
 )
 @pytest.mark.parametrize(
     "in1_dtype",
-    (ttnn.experimental.tensor.DataType.BFLOAT16,),
+    (ttnn.bfloat16,),
     ids=["in1_BFLOAT16"],
 )
 @pytest.mark.parametrize(
     "in0_dtype",
-    (ttnn.experimental.tensor.DataType.BFLOAT16,),
+    (ttnn.bfloat16,),
     ids=["in0_BFLOAT16"],
 )
 @pytest.mark.parametrize(

--- a/models/demos/falcon7b_common/tests/unit_tests/test_falcon_lm_head_matmul_2d.py
+++ b/models/demos/falcon7b_common/tests/unit_tests/test_falcon_lm_head_matmul_2d.py
@@ -42,7 +42,7 @@ def run_falcon_lm_head_matmul_2d(
     a_t = torch2tt_tensor(
         A,
         device,
-        ttnn.experimental.tensor.Layout.TILE,
+        ttnn.TILE_LAYOUT,
         in0_mem_config,
         in0_dtype,
     )
@@ -56,7 +56,7 @@ def run_falcon_lm_head_matmul_2d(
             torch2tt_tensor(
                 B_slices[i],
                 device,
-                ttnn.experimental.tensor.Layout.TILE,
+                ttnn.TILE_LAYOUT,
                 in1_mem_config,
                 in1_dtype,
             )
@@ -84,19 +84,13 @@ def test_falcon_lm_head_matmul_2d(
     seq_len,
     device,
 ):
-    in0_mem_config = ttnn.experimental.tensor.MemoryConfig(
-        ttnn.experimental.tensor.TensorMemoryLayout.INTERLEAVED, ttnn.experimental.tensor.BufferType.DRAM
-    )
-    in1_mem_config = ttnn.experimental.tensor.MemoryConfig(
-        ttnn.experimental.tensor.TensorMemoryLayout.INTERLEAVED, ttnn.experimental.tensor.BufferType.DRAM
-    )
-    out_mem_config = ttnn.experimental.tensor.MemoryConfig(
-        ttnn.experimental.tensor.TensorMemoryLayout.INTERLEAVED, ttnn.experimental.tensor.BufferType.DRAM
-    )
+    in0_mem_config = ttnn.DRAM_MEMORY_CONFIG
+    in1_mem_config = ttnn.DRAM_MEMORY_CONFIG
+    out_mem_config = ttnn.DRAM_MEMORY_CONFIG
 
-    in0_dtype = ttnn.experimental.tensor.DataType.BFLOAT16
-    in1_dtype = ttnn.experimental.tensor.DataType.BFLOAT8_B
-    out_dtype = ttnn.experimental.tensor.DataType.BFLOAT16
+    in0_dtype = ttnn.bfloat16
+    in1_dtype = ttnn.bfloat8_b
+    out_dtype = ttnn.bfloat16
 
     run_falcon_lm_head_matmul_2d(
         seq_len, device, in0_mem_config, in1_mem_config, out_mem_config, in0_dtype, in1_dtype, out_dtype

--- a/models/demos/falcon7b_common/tt/falcon_attention.py
+++ b/models/demos/falcon7b_common/tt/falcon_attention.py
@@ -249,9 +249,9 @@ class TtFalconAttentionPrefill(nn.Module):
             memory_config=(
                 self.model_config["K_TRANSPOSED_OUTPUT_MEMCFG"]
                 if llm_mode == "prefill" or self.model_config["l1_sharded"] == False
-                else ttnn.experimental.tensor.MemoryConfig(
-                    ttnn.experimental.tensor.TensorMemoryLayout.HEIGHT_SHARDED,
-                    ttnn.experimental.tensor.BufferType.L1,
+                else ttnn.MemoryConfig(
+                    ttnn.TensorMemoryLayout.HEIGHT_SHARDED,
+                    ttnn.BufferType.L1,
                 )
             ),
         )
@@ -336,7 +336,7 @@ class TtFalconAttentionPrefill(nn.Module):
                 self.query_key_value_weights,
                 program_config=self.model_config["FUSED_QKV_MM_OPTIMIZED_PROGCFG"],
                 memory_config=self.model_config["FUSED_QKV_MM_OPTIMIZED_MEMCFG"],
-                dtype=ttnn.experimental.tensor.DataType.BFLOAT16,
+                dtype=ttnn.bfloat16,
                 compute_kernel_config=self.model_config["FUSED_QKV_MM_OPTIMIZED_KERNEL_CONFIG"],
             )
         else:
@@ -400,8 +400,8 @@ class TtFalconAttentionPrefill(nn.Module):
                 mm_activations_height_shard_spec,
                 num_slices,  # num_slices
                 i,  # slice_index
-                ttnn.experimental.tensor.TensorMemoryLayout.HEIGHT_SHARDED,
-                ttnn.experimental.tensor.ShardOrientation.ROW_MAJOR,
+                ttnn.TensorMemoryLayout.HEIGHT_SHARDED,
+                ttnn.ShardOrientation.ROW_MAJOR,
             )
 
             subblock_h = 1
@@ -417,7 +417,7 @@ class TtFalconAttentionPrefill(nn.Module):
                 key_layer_transposed,
                 program_config=qkt_prg_cfg,
                 memory_config=self.model_config["QKTV_MM_OPTIMIZED_MEMCFG"],
-                dtype=ttnn.experimental.tensor.DataType.BFLOAT16,
+                dtype=ttnn.bfloat16,
                 compute_kernel_config=self.model_config["QKTV_AND_SOFTMAX_OPTIMIZED_KERNEL_CONFIG"],
             )
 
@@ -440,7 +440,7 @@ class TtFalconAttentionPrefill(nn.Module):
                 value_layer,
                 program_config=qktv_prg_cfg,
                 memory_config=self.model_config["QKTV_MM_OPTIMIZED_MEMCFG"],
-                dtype=ttnn.experimental.tensor.DataType.BFLOAT16,
+                dtype=ttnn.bfloat16,
                 compute_kernel_config=self.model_config["QKTV_AND_SOFTMAX_OPTIMIZED_KERNEL_CONFIG"],
             )
 
@@ -663,9 +663,9 @@ class TtFalconAttentionDecode(nn.Module):
             memory_config=(
                 self.model_config["K_TRANSPOSED_OUTPUT_MEMCFG"]
                 if self.model_config["l1_sharded"] == False
-                else ttnn.experimental.tensor.MemoryConfig(
-                    ttnn.experimental.tensor.TensorMemoryLayout.HEIGHT_SHARDED,
-                    ttnn.experimental.tensor.BufferType.L1,
+                else ttnn.MemoryConfig(
+                    ttnn.TensorMemoryLayout.HEIGHT_SHARDED,
+                    ttnn.BufferType.L1,
                 )
             ),
         )

--- a/models/demos/falcon7b_common/tt/falcon_lm_head.py
+++ b/models/demos/falcon7b_common/tt/falcon_lm_head.py
@@ -18,8 +18,8 @@ def falcon_lm_head_matmul_2d(
     weights: List[ttnn.Tensor],
     num_slices: int,
     lm_head_padding: ttnn.Tensor,
-    out_mem_config: ttnn.experimental.tensor.MemoryConfig,
-    out_dtype: ttnn.experimental.tensor.DataType,
+    out_mem_config: ttnn.MemoryConfig,
+    out_dtype: ttnn.DataType,
 ):
     assert (
         hidden_states.device().arch() == ttnn.device.Arch.WORMHOLE_B0
@@ -41,8 +41,8 @@ def falcon_lm_head_matmul_2d(
 
     hidden_states = ttnn.concat([hidden_states, lm_head_padding], -1)
 
-    compute_kernel_config = ttnn.experimental.tensor.WormholeComputeKernelConfig(
-        math_fidelity=ttnn.experimental.tensor.MathFidelity.HiFi2,
+    compute_kernel_config = ttnn.WormholeComputeKernelConfig(
+        math_fidelity=ttnn.MathFidelity.HiFi2,
         math_approx_mode=True,
         fp32_dest_acc_en=False,
         packer_l1_acc=True,

--- a/models/demos/falcon7b_common/tt/falcon_mlp.py
+++ b/models/demos/falcon7b_common/tt/falcon_mlp.py
@@ -203,8 +203,8 @@ class TtFalconMLPPrefill(nn.Module):
                     [self.seq_len // num_slices // grid_size[1], padded_hidden_size // grid_size[0]],
                     num_slices,
                     slice_idx,
-                    ttnn.experimental.tensor.TensorMemoryLayout.BLOCK_SHARDED,
-                    ttnn.experimental.tensor.ShardOrientation.ROW_MAJOR,
+                    ttnn.TensorMemoryLayout.BLOCK_SHARDED,
+                    ttnn.ShardOrientation.ROW_MAJOR,
                 )
 
                 hidden_states = ttnn.matmul(

--- a/models/demos/falcon7b_common/tt/falcon_model.py
+++ b/models/demos/falcon7b_common/tt/falcon_model.py
@@ -55,7 +55,7 @@ class TtFalconModelShared(torch.nn.Module):
             embedding_weights_str,
             weight_config_str="WORD_EMBEDDING_WEIGHTS",
             weights_to_cache=(state_dict[embedding_weights_str] if state_dict else None),
-            tt_layout=ttnn.experimental.tensor.Layout.ROW_MAJOR,
+            tt_layout=ttnn.ROW_MAJOR_LAYOUT,
         )
 
         # stack all decoders
@@ -130,9 +130,9 @@ class TtFalconModelShared(torch.nn.Module):
                 attn_masks_unordered = [
                     tt_from_torch(
                         attention_mask_slice,
-                        dtype=ttnn.experimental.tensor.DataType.BFLOAT16,  # subsequent tilize op excepts bfloat16 inputs
+                        dtype=ttnn.bfloat16,  # subsequent tilize op excepts bfloat16 inputs
                         device=self.device_mesh,
-                        layout=ttnn.experimental.tensor.Layout.ROW_MAJOR,
+                        layout=ttnn.ROW_MAJOR_LAYOUT,
                         memory_config=self.model_config["ATTN_MASK_MEMCFG"],
                         mesh_mapper=ReplicateTensorToMesh(self.device_mesh),
                     )
@@ -152,9 +152,9 @@ class TtFalconModelShared(torch.nn.Module):
                 # Send attn masks to device
                 tt_attention_mask = tt_from_torch(
                     attention_mask_,
-                    dtype=ttnn.experimental.tensor.DataType.BFLOAT16,  # subsequent tilize op excepts bfloat16 inputs
+                    dtype=ttnn.bfloat16,  # subsequent tilize op excepts bfloat16 inputs
                     device=self.device_mesh,
-                    layout=ttnn.experimental.tensor.Layout.ROW_MAJOR,
+                    layout=ttnn.ROW_MAJOR_LAYOUT,
                     memory_config=self.model_config["ATTN_MASK_MEMCFG"],
                     mesh_mapper=ReplicateTensorToMesh(self.device_mesh),
                 )
@@ -206,9 +206,9 @@ class TtFalconModelShared(torch.nn.Module):
             # Send attn masks to device
             tt_attention_mask = tt_from_torch(
                 attention_mask,
-                dtype=ttnn.experimental.tensor.DataType.BFLOAT16,  # subsequent tilize op excepts bfloat16 inputs
+                dtype=ttnn.bfloat16,  # subsequent tilize op excepts bfloat16 inputs
                 device=self.device_mesh,
-                layout=ttnn.experimental.tensor.Layout.ROW_MAJOR,
+                layout=ttnn.ROW_MAJOR_LAYOUT,
                 memory_config=self.model_config["ATTN_MASK_MEMCFG"],
                 mesh_mapper=ReplicateTensorToMesh(self.device_mesh),
             )
@@ -252,7 +252,7 @@ class TtFalconModelShared(torch.nn.Module):
             memory_config=self.model_config["WORD_EMBEDDING_OUTPUT_MEMCFG"],
         )
         input_embeddings = ttnn.unsqueeze_to_4D(input_embeddings)
-        input_embeddings = ttnn.to_layout(input_embeddings, ttnn.experimental.tensor.Layout.TILE)
+        input_embeddings = ttnn.to_layout(input_embeddings, ttnn.TILE_LAYOUT)
 
         layer_output = input_embeddings
         presents = ()

--- a/models/demos/grayskull/vit/demo/demo_vit_ttnn_imagenet_inference.py
+++ b/models/demos/grayskull/vit/demo/demo_vit_ttnn_imagenet_inference.py
@@ -96,30 +96,28 @@ def test_vit(device):
         patch_size = 16
         torch_pixel_values = torch_pixel_values.reshape(batch_size, img_h, img_w // patch_size, 4 * patch_size)
         N, H, W, C = torch_pixel_values.shape
-        shard_grid = ttnn.experimental.tensor.CoreRangeSet(
+        shard_grid = ttnn.CoreRangeSet(
             {
-                ttnn.experimental.tensor.CoreRange(
-                    ttnn.experimental.tensor.CoreCoord(0, 0),
-                    ttnn.experimental.tensor.CoreCoord(7, 0),
+                ttnn.CoreRange(
+                    ttnn.CoreCoord(0, 0),
+                    ttnn.CoreCoord(7, 0),
                 ),
             }
         )
         n_cores = 8
-        shard_spec = ttnn.experimental.tensor.ShardSpec(
-            shard_grid, [N * H * W // n_cores, C], ttnn.experimental.tensor.ShardOrientation.ROW_MAJOR, False
-        )
+        shard_spec = ttnn.ShardSpec(shard_grid, [N * H * W // n_cores, C], ttnn.ShardOrientation.ROW_MAJOR, False)
 
         output = None
         pixel_values = torch2tt_tensor(
             torch_pixel_values,
             device,
-            ttnn.experimental.tensor.Layout.ROW_MAJOR,
-            tt_memory_config=ttnn.experimental.tensor.MemoryConfig(
-                ttnn.experimental.tensor.TensorMemoryLayout.HEIGHT_SHARDED,
-                ttnn.experimental.tensor.BufferType.L1,
+            ttnn.ROW_MAJOR_LAYOUT,
+            tt_memory_config=ttnn.MemoryConfig(
+                ttnn.TensorMemoryLayout.HEIGHT_SHARDED,
+                ttnn.BufferType.L1,
                 shard_spec,
             ),
-            tt_dtype=ttnn.experimental.tensor.DataType.BFLOAT16,
+            tt_dtype=ttnn.bfloat16,
         )
 
         output = ttnn_optimized_sharded_vit.vit(

--- a/models/demos/grayskull/vit/demo/demo_vit_ttnn_inference_device_OPs.py
+++ b/models/demos/grayskull/vit/demo/demo_vit_ttnn_inference_device_OPs.py
@@ -105,30 +105,28 @@ def test_vit(device, use_program_cache):
         patch_size = 16
         torch_pixel_values = torch_pixel_values.reshape(batch_size, img_h, img_w // patch_size, 4 * patch_size)
         N, H, W, C = torch_pixel_values.shape
-        shard_grid = ttnn.experimental.tensor.CoreRangeSet(
+        shard_grid = ttnn.CoreRangeSet(
             {
-                ttnn.experimental.tensor.CoreRange(
-                    ttnn.experimental.tensor.CoreCoord(0, 0),
-                    ttnn.experimental.tensor.CoreCoord(7, 0),
+                ttnn.CoreRange(
+                    ttnn.CoreCoord(0, 0),
+                    ttnn.CoreCoord(7, 0),
                 ),
             }
         )
         n_cores = 8
-        shard_spec = ttnn.experimental.tensor.ShardSpec(
-            shard_grid, [N * H * W // n_cores, C], ttnn.experimental.tensor.ShardOrientation.ROW_MAJOR, False
-        )
+        shard_spec = ttnn.ShardSpec(shard_grid, [N * H * W // n_cores, C], ttnn.ShardOrientation.ROW_MAJOR, False)
 
         output = None
         pixel_values = torch2tt_tensor(
             torch_pixel_values,
             device,
-            ttnn.experimental.tensor.Layout.ROW_MAJOR,
-            tt_memory_config=ttnn.experimental.tensor.MemoryConfig(
-                ttnn.experimental.tensor.TensorMemoryLayout.HEIGHT_SHARDED,
-                ttnn.experimental.tensor.BufferType.L1,
+            ttnn.ROW_MAJOR_LAYOUT,
+            tt_memory_config=ttnn.MemoryConfig(
+                ttnn.TensorMemoryLayout.HEIGHT_SHARDED,
+                ttnn.BufferType.L1,
                 shard_spec,
             ),
-            tt_dtype=ttnn.experimental.tensor.DataType.BFLOAT16,
+            tt_dtype=ttnn.bfloat16,
         )
 
         output = ttnn_optimized_sharded_vit.vit(

--- a/models/demos/grayskull/vit/demo/demo_vit_ttnn_inference_throughput.py
+++ b/models/demos/grayskull/vit/demo/demo_vit_ttnn_inference_throughput.py
@@ -107,30 +107,28 @@ def test_vit(device, use_program_cache):
         patch_size = 16
         torch_pixel_values = torch_pixel_values.reshape(batch_size, img_h, img_w // patch_size, 4 * patch_size)
         N, H, W, C = torch_pixel_values.shape
-        shard_grid = ttnn.experimental.tensor.CoreRangeSet(
+        shard_grid = ttnn.CoreRangeSet(
             {
-                ttnn.experimental.tensor.CoreRange(
-                    ttnn.experimental.tensor.CoreCoord(0, 0),
-                    ttnn.experimental.tensor.CoreCoord(7, 0),
+                ttnn.CoreRange(
+                    ttnn.CoreCoord(0, 0),
+                    ttnn.CoreCoord(7, 0),
                 ),
             }
         )
         n_cores = 8
-        shard_spec = ttnn.experimental.tensor.ShardSpec(
-            shard_grid, [N * H * W // n_cores, C], ttnn.experimental.tensor.ShardOrientation.ROW_MAJOR, False
-        )
+        shard_spec = ttnn.ShardSpec(shard_grid, [N * H * W // n_cores, C], ttnn.ShardOrientation.ROW_MAJOR, False)
 
         output = None
         pixel_values = torch2tt_tensor(
             torch_pixel_values,
             device,
-            ttnn.experimental.tensor.Layout.ROW_MAJOR,
-            tt_memory_config=ttnn.experimental.tensor.MemoryConfig(
-                ttnn.experimental.tensor.TensorMemoryLayout.HEIGHT_SHARDED,
-                ttnn.experimental.tensor.BufferType.L1,
+            ttnn.ROW_MAJOR_LAYOUT,
+            tt_memory_config=ttnn.MemoryConfig(
+                ttnn.TensorMemoryLayout.HEIGHT_SHARDED,
+                ttnn.BufferType.L1,
                 shard_spec,
             ),
-            tt_dtype=ttnn.experimental.tensor.DataType.BFLOAT16,
+            tt_dtype=ttnn.bfloat16,
         )
 
         output = ttnn_optimized_sharded_vit.vit(

--- a/models/demos/resnet/tt/metalResnetBlock50.py
+++ b/models/demos/resnet/tt/metalResnetBlock50.py
@@ -1384,9 +1384,9 @@ class ResNet(nn.Module):
         self.model_config = model_config
         self.reader_patterns_cache = {}
         if self.storage_in_dram:
-            self.memory_config = ttnn.MemoryConfig(ttnn.TensorMemoryLayout.INTERLEAVED, ttnn.BufferType.DRAM)
+            self.memory_config = ttnn.DRAM_MEMORY_CONFIG
         else:
-            self.memory_config = ttnn.MemoryConfig(ttnn.TensorMemoryLayout.INTERLEAVED, ttnn.BufferType.L1)
+            self.memory_config = ttnn.L1_MEMORY_CONFIG
         if sharded:
             self.height_sharded_memory_config = ttnn.MemoryConfig(
                 ttnn.TensorMemoryLayout.HEIGHT_SHARDED, ttnn.BufferType.L1

--- a/models/demos/t3000/falcon40b/demo/demo.py
+++ b/models/demos/t3000/falcon40b/demo/demo.py
@@ -153,7 +153,7 @@ def print_output_prompts(generated_ids, tokenizer, num_users_to_display=None):
 
 def synchronize_devices(devices):
     for device in devices:
-        ttnn.device.synchronize_device(device)
+        ttnn.synchronize_device(device)
 
 
 def top_pk_logits(logits, p=0.9, k=10, temperature=1.0, return_probs=False):

--- a/models/demos/t3000/falcon40b/tests/test_falcon_end_to_end.py
+++ b/models/demos/t3000/falcon40b/tests/test_falcon_end_to_end.py
@@ -131,7 +131,7 @@ def run_test_FalconCausalLM_end_to_end(
         use_global_cos_sin_cache,
     )
     for device in device_mesh.get_devices():
-        ttnn.device.synchronize_device(device)
+        ttnn.synchronize_device(device)
     profiler.end("TtFalcon_model_setup")
     logger.info("Done loading TT Falcon Model")
 
@@ -192,7 +192,7 @@ def run_test_FalconCausalLM_end_to_end(
 
     profiler.end("first_model_run_with_compile", force_enable=True)
     for device in device_mesh.get_devices():
-        ttnn.device.synchronize_device(device)
+        ttnn.synchronize_device(device)
 
     del tt_out
     del tt_inputs
@@ -227,7 +227,7 @@ def run_test_FalconCausalLM_end_to_end(
                     layer_past_len=kv_cache_len,
                     use_cache=use_cache,
                 )
-                if tt_out.get_layout() != ttnn.experimental.tensor.Layout.ROW_MAJOR:
+                if tt_out.get_layout() != ttnn.ROW_MAJOR_LAYOUT:
                     tt_out = ttnn.untilize(tt_out, use_multicore=False)
                 tt_outs.append(tt_out)
 
@@ -248,7 +248,7 @@ def run_test_FalconCausalLM_end_to_end(
             )
             tt_out = ttnn.to_torch(tt_out, device=device_mesh, mesh_composer=ConcatMeshToTensor(device_mesh, dim=-1))
         for device in device_mesh.get_devices():
-            ttnn.device.synchronize_device(device)
+            ttnn.synchronize_device(device)
 
         del tt_out
         del tt_inputs
@@ -272,7 +272,7 @@ def run_test_FalconCausalLM_end_to_end(
             llm_mode, model_input, kv_cache_len, num_input_tokens=kv_len
         )
     for device in device_mesh.get_devices():
-        ttnn.device.synchronize_device(device)
+        ttnn.synchronize_device(device)
     profiler.start(f"model_run_for_inference")
 
     if llm_mode == "prefill":
@@ -300,7 +300,7 @@ def run_test_FalconCausalLM_end_to_end(
         )
     profiler.end(f"model_run_for_inference")
     for device in device_mesh.get_devices():
-        ttnn.device.synchronize_device(device)
+        ttnn.synchronize_device(device)
 
     if llm_mode == "prefill":
         tensors = [

--- a/models/demos/t3000/falcon40b/tests/test_falcon_model.py
+++ b/models/demos/t3000/falcon40b/tests/test_falcon_model.py
@@ -173,7 +173,7 @@ def run_test_FalconModel_inference(
         use_global_cos_sin_cache=use_global_cos_sin_cache,
     )
     for device in device_mesh.get_devices():
-        ttnn.device.synchronize_device(device)
+        ttnn.synchronize_device(device)
 
     # TODO: Generate embeddings and attention_mask on device
     if llm_mode == "prefill":

--- a/models/demos/t3000/falcon40b/tests/test_falcon_model_single_chip.py
+++ b/models/demos/t3000/falcon40b/tests/test_falcon_model_single_chip.py
@@ -12,7 +12,7 @@ from models.utility_functions import comp_pcc, torch2tt_tensor, tt2torch_tensor,
 
 @pytest.mark.parametrize(
     "shard_orientation",
-    (ttnn.experimental.tensor.ShardOrientation.ROW_MAJOR, ttnn.experimental.tensor.ShardOrientation.COL_MAJOR),
+    (ttnn.ShardOrientation.ROW_MAJOR, ttnn.ShardOrientation.COL_MAJOR),
 )
 @pytest.mark.parametrize(
     "output_sharded",
@@ -40,14 +40,12 @@ def test_group_attn_matmul(
 
     compute_grid_size = device.compute_with_storage_grid_size()
 
-    interleaved_mem_config = ttnn.experimental.tensor.MemoryConfig(
-        ttnn.experimental.tensor.TensorMemoryLayout.INTERLEAVED, ttnn.experimental.tensor.BufferType.DRAM
-    )
+    interleaved_mem_config = ttnn.DRAM_MEMORY_CONFIG
 
     # NOTE: Mixed precision is supported as well; but might not have enough space for larger seq_len with BFLOAT16
-    in0_dtype = ttnn.experimental.tensor.DataType.BFLOAT8_B
-    in1_dtype = ttnn.experimental.tensor.DataType.BFLOAT8_B
-    output_dtype = ttnn.experimental.tensor.DataType.BFLOAT8_B
+    in0_dtype = ttnn.bfloat8_b
+    in1_dtype = ttnn.bfloat8_b
+    output_dtype = ttnn.bfloat8_b
 
     q_len = 1
     input_shape_a = [q_len, q_heads, batch, K]
@@ -56,23 +54,15 @@ def test_group_attn_matmul(
     input_tensor_a = torch.randn(input_shape_a).bfloat16()
     input_tensor_b = torch.randn(input_shape_b).bfloat16()
 
-    tt_input_tensor_a = (
-        ttnn.experimental.tensor.Tensor(input_tensor_a, in0_dtype)
-        .to(ttnn.experimental.tensor.Layout.TILE)
-        .to(device, interleaved_mem_config)
-    )
-    tt_input_tensor_b = (
-        ttnn.experimental.tensor.Tensor(input_tensor_b, in1_dtype)
-        .to(ttnn.experimental.tensor.Layout.TILE)
-        .to(device, interleaved_mem_config)
-    )
+    tt_input_tensor_a = ttnn.Tensor(input_tensor_a, in0_dtype).to(ttnn.TILE_LAYOUT).to(device, interleaved_mem_config)
+    tt_input_tensor_b = ttnn.Tensor(input_tensor_b, in1_dtype).to(ttnn.TILE_LAYOUT).to(device, interleaved_mem_config)
 
     if in0_sharded:
         tt_input_tensor_a = ttnn.interleaved_to_sharded(
             tt_input_tensor_a,
             compute_grid_size,
             [q_len * batch, K],
-            ttnn.experimental.tensor.TensorMemoryLayout.HEIGHT_SHARDED,
+            ttnn.TensorMemoryLayout.HEIGHT_SHARDED,
             shard_orientation,
         )
 
@@ -81,14 +71,14 @@ def test_group_attn_matmul(
             tt_input_tensor_b,
             compute_grid_size,
             [kv_heads * K, seq_len],
-            ttnn.experimental.tensor.TensorMemoryLayout.HEIGHT_SHARDED,
+            ttnn.TensorMemoryLayout.HEIGHT_SHARDED,
             shard_orientation,
         )
 
     if output_sharded:
-        output_mem_config = ttnn.experimental.tensor.MemoryConfig(
-            memory_layout=ttnn.experimental.tensor.TensorMemoryLayout.HEIGHT_SHARDED,
-            buffer_type=ttnn.experimental.tensor.BufferType.L1,
+        output_mem_config = ttnn.MemoryConfig(
+            memory_layout=ttnn.TensorMemoryLayout.HEIGHT_SHARDED,
+            buffer_type=ttnn.BufferType.L1,
         )
     else:
         output_mem_config = interleaved_mem_config
@@ -103,7 +93,7 @@ def test_group_attn_matmul(
     if output_sharded:
         tt_output_tensor_on_device = ttnn.sharded_to_interleaved(tt_output_tensor_on_device, interleaved_mem_config)
 
-    tt_output_tensor = tt_output_tensor_on_device.cpu().to(ttnn.experimental.tensor.Layout.ROW_MAJOR).to_torch()
+    tt_output_tensor = tt_output_tensor_on_device.cpu().to(ttnn.ROW_MAJOR_LAYOUT).to_torch()
 
     input_tensor_a = input_tensor_a.to(torch.float)
     input_tensor_b = torch.repeat_interleave(input_tensor_b.to(torch.float), q_heads // kv_heads, dim=1)
@@ -121,8 +111,8 @@ def test_group_attn_matmul(
         [32, 8192, 1152, 8],
     ],
 )
-@pytest.mark.parametrize("activations_dtype", [ttnn.experimental.tensor.DataType.BFLOAT16])
-@pytest.mark.parametrize("weights_dtype", [ttnn.experimental.tensor.DataType.BFLOAT8_B])
+@pytest.mark.parametrize("activations_dtype", [ttnn.bfloat16])
+@pytest.mark.parametrize("weights_dtype", [ttnn.bfloat8_b])
 def test_sharded_matmul_1d_in0(
     device, in0_sharded, out_sharded, M, K, N, num_cores, activations_dtype, weights_dtype, function_level_defaults
 ):
@@ -132,13 +122,10 @@ def test_sharded_matmul_1d_in0(
     in1_shape = [1, 1, K, N]
     bias_shape = [1, 1, 1, N]
 
-    interleaved_mem_config = ttnn.experimental.tensor.MemoryConfig(
-        memory_layout=ttnn.experimental.tensor.TensorMemoryLayout.INTERLEAVED,
-        buffer_type=ttnn.experimental.tensor.BufferType.DRAM,
-    )
-    sharded_mem_config = ttnn.experimental.tensor.MemoryConfig(
-        memory_layout=ttnn.experimental.tensor.TensorMemoryLayout.WIDTH_SHARDED,
-        buffer_type=ttnn.experimental.tensor.BufferType.L1,
+    interleaved_mem_config = ttnn.DRAM_MEMORY_CONFIG
+    sharded_mem_config = ttnn.MemoryConfig(
+        memory_layout=ttnn.TensorMemoryLayout.WIDTH_SHARDED,
+        buffer_type=ttnn.BufferType.L1,
     )
 
     in0 = torch.randn(in0_shape).bfloat16().float()
@@ -156,8 +143,8 @@ def test_sharded_matmul_1d_in0(
             in0_t,
             grid_size,
             [M, K // num_cores],
-            ttnn.experimental.tensor.TensorMemoryLayout.WIDTH_SHARDED,
-            ttnn.experimental.tensor.ShardOrientation.ROW_MAJOR,
+            ttnn.TensorMemoryLayout.WIDTH_SHARDED,
+            ttnn.ShardOrientation.ROW_MAJOR,
         )
 
     program_config = ttnn.MatmulMultiCoreReuseMultiCast1DProgramConfig(
@@ -201,8 +188,8 @@ def test_sharded_matmul_1d_in0(
 )
 @pytest.mark.parametrize("out_sharded", [True], ids=["out_sharded"])
 @pytest.mark.parametrize("in0_sharded", [True], ids=["in0_sharded"])
-@pytest.mark.parametrize("weights_dtype", [ttnn.experimental.tensor.DataType.BFLOAT8_B])
-@pytest.mark.parametrize("activations_dtype", [ttnn.experimental.tensor.DataType.BFLOAT8_B])
+@pytest.mark.parametrize("weights_dtype", [ttnn.bfloat8_b])
+@pytest.mark.parametrize("activations_dtype", [ttnn.bfloat8_b])
 def test_sharded_matmul_1d_in0_multi_chip(
     pcie_devices,
     num_devices,
@@ -225,13 +212,10 @@ def test_sharded_matmul_1d_in0_multi_chip(
     in0_shape = [1, 1, M, K]
     in1_shape = [1, 1, K, N]
 
-    interleaved_mem_config = ttnn.experimental.tensor.MemoryConfig(
-        memory_layout=ttnn.experimental.tensor.TensorMemoryLayout.INTERLEAVED,
-        buffer_type=ttnn.experimental.tensor.BufferType.DRAM,
-    )
-    sharded_mem_config = ttnn.experimental.tensor.MemoryConfig(
-        memory_layout=ttnn.experimental.tensor.TensorMemoryLayout.WIDTH_SHARDED,
-        buffer_type=ttnn.experimental.tensor.BufferType.L1,
+    interleaved_mem_config = ttnn.DRAM_MEMORY_CONFIG
+    sharded_mem_config = ttnn.MemoryConfig(
+        memory_layout=ttnn.TensorMemoryLayout.WIDTH_SHARDED,
+        buffer_type=ttnn.BufferType.L1,
     )
 
     in0 = torch.randn(in0_shape).bfloat16().float()
@@ -250,8 +234,8 @@ def test_sharded_matmul_1d_in0_multi_chip(
                 in0_temp,
                 grid_size,
                 [M, K // num_cores],
-                ttnn.experimental.tensor.TensorMemoryLayout.WIDTH_SHARDED,
-                ttnn.experimental.tensor.ShardOrientation.ROW_MAJOR,
+                ttnn.TensorMemoryLayout.WIDTH_SHARDED,
+                ttnn.ShardOrientation.ROW_MAJOR,
             )
         in0_t.append(in0_temp)
 
@@ -317,8 +301,8 @@ def test_sharded_matmul_1d_in0_multi_chip(
 )
 @pytest.mark.parametrize("out_sharded", [True], ids=["out_sharded"])
 @pytest.mark.parametrize("in0_sharded", [True], ids=["in0_sharded"])
-@pytest.mark.parametrize("weights_dtype", [ttnn.experimental.tensor.DataType.BFLOAT8_B])
-@pytest.mark.parametrize("activations_dtype", [ttnn.experimental.tensor.DataType.BFLOAT8_B])
+@pytest.mark.parametrize("weights_dtype", [ttnn.bfloat8_b])
+@pytest.mark.parametrize("activations_dtype", [ttnn.bfloat8_b])
 def test_sharded_matmul_1d_in0_multi_chip(
     all_devices,
     num_devices,
@@ -338,13 +322,10 @@ def test_sharded_matmul_1d_in0_multi_chip(
     in0_shape = [1, 1, M, K]
     in1_shape = [1, 1, K, N]
 
-    interleaved_mem_config = ttnn.experimental.tensor.MemoryConfig(
-        memory_layout=ttnn.experimental.tensor.TensorMemoryLayout.INTERLEAVED,
-        buffer_type=ttnn.experimental.tensor.BufferType.DRAM,
-    )
-    sharded_mem_config = ttnn.experimental.tensor.MemoryConfig(
-        memory_layout=ttnn.experimental.tensor.TensorMemoryLayout.WIDTH_SHARDED,
-        buffer_type=ttnn.experimental.tensor.BufferType.L1,
+    interleaved_mem_config = ttnn.DRAM_MEMORY_CONFIG
+    sharded_mem_config = ttnn.MemoryConfig(
+        memory_layout=ttnn.TensorMemoryLayout.WIDTH_SHARDED,
+        buffer_type=ttnn.BufferType.L1,
     )
 
     in0 = torch.randn(in0_shape).bfloat16().float()
@@ -363,8 +344,8 @@ def test_sharded_matmul_1d_in0_multi_chip(
                 in0_temp,
                 grid_size,
                 [M, K // num_cores],
-                ttnn.experimental.tensor.TensorMemoryLayout.WIDTH_SHARDED,
-                ttnn.experimental.tensor.ShardOrientation.ROW_MAJOR,
+                ttnn.TensorMemoryLayout.WIDTH_SHARDED,
+                ttnn.ShardOrientation.ROW_MAJOR,
             )
         in0_t.append(in0_temp)
 
@@ -422,7 +403,7 @@ def test_sharded_matmul_1d_in0_multi_chip(
 
 @pytest.mark.parametrize(
     "dtype",
-    (ttnn.experimental.tensor.DataType.BFLOAT8_B, ttnn.experimental.tensor.DataType.BFLOAT16),
+    (ttnn.bfloat8_b, ttnn.bfloat16),
     ids=["BFLOAT8_B", "BFLOAT16"],
 )
 @pytest.mark.parametrize(
@@ -445,7 +426,7 @@ def test_sharded_nlp_create_qkv_heads_test(
     torch.manual_seed(1234)
     compute_grid_size = device.compute_with_storage_grid_size()
     num_cores = num_kv_heads
-    shard_grid = ttnn.experimental.tensor.CoreRangeSet(
+    shard_grid = ttnn.CoreRangeSet(
         ttnn.experimental.tensor.num_cores_to_corerange_set(num_cores, compute_grid_size, True)
     )
     q_shape = [seq_len, 1, batch, num_cores, num_q_heads // num_cores * head_dim]
@@ -459,71 +440,59 @@ def test_sharded_nlp_create_qkv_heads_test(
         B = torch.concat([K.flatten(-2, -1), V.flatten(-2, -1)], -1)
         A_interleaved = torch.concat([Q], -1).flatten(-2, -1)
         B_interleaved = torch.concat([K, V], -1).flatten(-2, -1)
-        in0_shard_spec = ttnn.experimental.tensor.ShardSpec(
+        in0_shard_spec = ttnn.ShardSpec(
             shard_grid,
             [
                 seq_len * batch,
                 A_interleaved.shape[-1] // num_cores,
             ],
-            ttnn.experimental.tensor.ShardOrientation.ROW_MAJOR,
+            ttnn.ShardOrientation.ROW_MAJOR,
             False,
         )
-        in1_shard_spec = ttnn.experimental.tensor.ShardSpec(
+        in1_shard_spec = ttnn.ShardSpec(
             shard_grid,
             [
                 seq_len * batch,
                 B_interleaved.shape[-1] // num_cores,
             ],
-            ttnn.experimental.tensor.ShardOrientation.ROW_MAJOR,
+            ttnn.ShardOrientation.ROW_MAJOR,
             False,
         )
-        in0_mem_config = ttnn.experimental.tensor.MemoryConfig(
-            ttnn.experimental.tensor.TensorMemoryLayout.WIDTH_SHARDED,
-            ttnn.experimental.tensor.BufferType.L1,
+        in0_mem_config = ttnn.MemoryConfig(
+            ttnn.TensorMemoryLayout.WIDTH_SHARDED,
+            ttnn.BufferType.L1,
             in0_shard_spec,
         )
-        in1_mem_config = ttnn.experimental.tensor.MemoryConfig(
-            ttnn.experimental.tensor.TensorMemoryLayout.WIDTH_SHARDED,
-            ttnn.experimental.tensor.BufferType.L1,
+        in1_mem_config = ttnn.MemoryConfig(
+            ttnn.TensorMemoryLayout.WIDTH_SHARDED,
+            ttnn.BufferType.L1,
             in1_shard_spec,
         )
-        in0_t = (
-            ttnn.experimental.tensor.Tensor(A_interleaved, dtype)
-            .to(ttnn.experimental.tensor.Layout.TILE)
-            .to(device, in0_mem_config)
-        )
-        in1_t = (
-            ttnn.experimental.tensor.Tensor(B_interleaved, dtype)
-            .to(ttnn.experimental.tensor.Layout.TILE)
-            .to(device, in1_mem_config)
-        )
+        in0_t = ttnn.Tensor(A_interleaved, dtype).to(ttnn.TILE_LAYOUT).to(device, in0_mem_config)
+        in1_t = ttnn.Tensor(B_interleaved, dtype).to(ttnn.TILE_LAYOUT).to(device, in1_mem_config)
     else:
         A = torch.concat([Q.flatten(-2, -1), K.flatten(-2, -1), V.flatten(-2, -1)], -1)
         A_interleaved = torch.concat([Q, K, V], -1).flatten(-2, -1)
-        in0_shard_spec = ttnn.experimental.tensor.ShardSpec(
+        in0_shard_spec = ttnn.ShardSpec(
             shard_grid,
             [
                 seq_len * batch,
                 A_interleaved.shape[-1] // num_cores,
             ],
-            ttnn.experimental.tensor.ShardOrientation.ROW_MAJOR,
+            ttnn.ShardOrientation.ROW_MAJOR,
             False,
         )
-        in0_mem_config = ttnn.experimental.tensor.MemoryConfig(
-            ttnn.experimental.tensor.TensorMemoryLayout.WIDTH_SHARDED,
-            ttnn.experimental.tensor.BufferType.L1,
+        in0_mem_config = ttnn.MemoryConfig(
+            ttnn.TensorMemoryLayout.WIDTH_SHARDED,
+            ttnn.BufferType.L1,
             in0_shard_spec,
         )
-        in0_t = (
-            ttnn.experimental.tensor.Tensor(A_interleaved, dtype)
-            .to(ttnn.experimental.tensor.Layout.TILE)
-            .to(device, in0_mem_config)
-        )
+        in0_t = ttnn.Tensor(A_interleaved, dtype).to(ttnn.TILE_LAYOUT).to(device, in0_mem_config)
 
     out_shard_spec = in0_shard_spec
-    out_mem_config = ttnn.experimental.tensor.MemoryConfig(
-        ttnn.experimental.tensor.TensorMemoryLayout.HEIGHT_SHARDED,
-        ttnn.experimental.tensor.BufferType.L1,
+    out_mem_config = ttnn.MemoryConfig(
+        ttnn.TensorMemoryLayout.HEIGHT_SHARDED,
+        ttnn.BufferType.L1,
         out_shard_spec,
     )
     q, k, v = ttnn.experimental.nlp_create_qkv_heads(
@@ -556,7 +525,7 @@ def test_sharded_nlp_create_qkv_heads_test(
     ref_k = torch.reshape(ref_k, [seq_len, batch, num_kv_heads, head_dim]).transpose(-3, -2)
     ref_v = torch.reshape(ref_v, [seq_len, batch, num_kv_heads, head_dim]).transpose(-3, -2)
 
-    if dtype == ttnn.experimental.tensor.DataType.BFLOAT8_B:
+    if dtype == ttnn.bfloat8_b:
         pcc = 0.99
     else:
         pcc = 1.0

--- a/models/demos/t3000/falcon40b/tests/test_falcon_prefill_determinism.py
+++ b/models/demos/t3000/falcon40b/tests/test_falcon_prefill_determinism.py
@@ -95,7 +95,7 @@ def run_test_falcon_prefill_end_to_end_determinism(
         use_global_cos_sin_cache,
     )
     for device in device_mesh.get_devices():
-        ttnn.device.synchronize_device(device)
+        ttnn.synchronize_device(device)
     logger.info("Done loading TT Falcon Model")
 
     # Prepare inputs -----------------------------------------------------------------------
@@ -133,7 +133,7 @@ def run_test_falcon_prefill_end_to_end_determinism(
     logger.info("Done running TT Falcon model")
 
     for device in device_mesh.get_devices():
-        ttnn.device.synchronize_device(device)
+        ttnn.synchronize_device(device)
 
     reference_out = torch.vstack(tt_outs)
     reference_kv_cache = []

--- a/models/demos/t3000/falcon40b/tests/test_perf_falcon.py
+++ b/models/demos/t3000/falcon40b/tests/test_perf_falcon.py
@@ -91,7 +91,7 @@ def run_test_FalconCausalLM_end_to_end(
     else:
         raise NotImplementedError(f"Llm mode {llm_mode} is not supported! Must be one of prefill or decode.")
     for device in devices:
-        ttnn.device.synchronize_device(device)
+        ttnn.synchronize_device(device)
 
     # NOTE: Passing in pytorch tensor here instead of ll buda tensor
     # since we don't yet have embedding support on device
@@ -109,7 +109,7 @@ def run_test_FalconCausalLM_end_to_end(
         use_global_cos_sin_cache,
     )
     for device in devices:
-        ttnn.device.synchronize_device(device)
+        ttnn.synchronize_device(device)
     profiler.end("TtFalcon_model_setup")
 
     del state_dict
@@ -175,7 +175,7 @@ def run_test_FalconCausalLM_end_to_end(
 
     profiler.end("first_model_run_with_compile", force_enable=True)
     for device in devices:
-        ttnn.device.synchronize_device(device)
+        ttnn.synchronize_device(device)
 
     del tt_out
     del tt_layer_present
@@ -232,7 +232,7 @@ def run_test_FalconCausalLM_end_to_end(
 
     profiler.end(f"model_warmup_run_for_inference")
     for device in devices:
-        ttnn.device.synchronize_device(device)
+        ttnn.synchronize_device(device)
 
     # Run for perf iteration - profiler enabled
     for device in devices:
@@ -286,7 +286,7 @@ def run_test_FalconCausalLM_end_to_end(
         _ = ttnn.to_torch(tt_FalconCausalLM.perf_e2e_test_tile_tensor)
 
     for device in devices:
-        ttnn.device.synchronize_device(device)
+        ttnn.synchronize_device(device)
 
     profiler.end(f"model_run_for_inference")
 

--- a/models/demos/t3000/falcon40b/tests/test_perplexity_falcon.py
+++ b/models/demos/t3000/falcon40b/tests/test_perplexity_falcon.py
@@ -173,7 +173,7 @@ def run_test_perplexity(
             use_global_cos_sin_cache=True,
         )
         for device in device_mesh.get_devices():
-            ttnn.device.synchronize_device(device)
+            ttnn.synchronize_device(device)
 
         # Initialize kvcache
         logger.info("Initializing kvcache...")

--- a/models/demos/t3000/falcon40b/tests/unit_tests/distributed_layernorm/test_distributed_layernorm.py
+++ b/models/demos/t3000/falcon40b/tests/unit_tests/distributed_layernorm/test_distributed_layernorm.py
@@ -119,7 +119,7 @@ class TtDistributedLayernorm:
 
                 self.ln_gamma.append(ln_gamma_host.to(devices[i], dram_memcfg))
 
-                ttnn.experimental.tensor.dump_tensor(
+                ttnn.dump_tensor(
                     str(ln_weights_path),
                     ln_gamma_host,
                 )
@@ -138,7 +138,7 @@ class TtDistributedLayernorm:
                 )
                 self.ln_beta.append(ln_beta_host.to(devices[i], dram_memcfg))
 
-                ttnn.experimental.tensor.dump_tensor(
+                ttnn.dump_tensor(
                     str(ln_bias_path),
                     ln_beta_host,
                 )

--- a/models/demos/t3000/falcon40b/tests/unit_tests/layernorm/test_falcon_layernorm.py
+++ b/models/demos/t3000/falcon40b/tests/unit_tests/layernorm/test_falcon_layernorm.py
@@ -47,13 +47,13 @@ class TtFalconLayernorm:
         self.model_config = model_config
         self.is_sharded = is_sharded
 
-        gamma_host = ttnn.experimental.tensor.Tensor(
+        gamma_host = ttnn.Tensor(
             gamma.reshape([1, 1, -1, 32]),
             self.model_config["LN_ATTN_WEIGHTS_DTYPE"],
         )
         self.gamma = gamma_host.to(device, self.model_config["LN_ATTN_WEIGHTS_MEMCFG"])
 
-        beta_host = ttnn.experimental.tensor.Tensor(
+        beta_host = ttnn.Tensor(
             beta.reshape([1, 1, -1, 32]),
             self.model_config["LN_ATTN_BIAS_DTYPE"],
         )
@@ -61,15 +61,15 @@ class TtFalconLayernorm:
 
         self.layernorm_eps = config.layer_norm_epsilon
 
-    def __call__(self, x: ttnn.experimental.tensor.Tensor) -> ttnn.experimental.tensor.Tensor:
+    def __call__(self, x: ttnn.Tensor) -> ttnn.Tensor:
         if self.is_sharded:
             row_height = x.get_legacy_shape()[2]
             shard_width_hidden_dim_across_32_cores = x.get_legacy_shape()[3] // 32
-            shard_spec_32_cores_grid = ttnn.experimental.tensor.CoreRangeSet(
+            shard_spec_32_cores_grid = ttnn.CoreRangeSet(
                 {
-                    ttnn.experimental.tensor.CoreRange(
-                        ttnn.experimental.tensor.CoreCoord(0, 0),
-                        ttnn.experimental.tensor.CoreCoord(7, 3),
+                    ttnn.CoreRange(
+                        ttnn.CoreCoord(0, 0),
+                        ttnn.CoreCoord(7, 3),
                     ),
                 }
             )
@@ -79,16 +79,16 @@ class TtFalconLayernorm:
             #     epsilon=self.layernorm_eps,
             #     weight=self.gamma,
             #     bias=self.beta,
-            #     memory_config=ttnn.experimental.tensor.MemoryConfig(
-            #         ttnn.experimental.tensor.TensorMemoryLayout.WIDTH_SHARDED,
-            #         ttnn.experimental.tensor.BufferType.L1,
-            #         ttnn.experimental.tensor.ShardSpec(
+            #     memory_config=ttnn.MemoryConfig(
+            #         ttnn.TensorMemoryLayout.WIDTH_SHARDED,
+            #         ttnn.BufferType.L1,
+            #         ttnn.ShardSpec(
             #             shard_spec_32_cores_grid,
             #             [
             #                 row_height,
             #                 shard_width_hidden_dim_across_32_cores,
             #             ],
-            #             ttnn.experimental.tensor.ShardOrientation.ROW_MAJOR,
+            #             ttnn.ShardOrientation.ROW_MAJOR,
             #             False,
             #         ),
             #     ),
@@ -107,16 +107,16 @@ class TtFalconLayernorm:
                 epsilon=self.layernorm_eps,
                 weight=self.gamma,
                 bias=self.beta,
-                memory_config=ttnn.experimental.tensor.MemoryConfig(
-                    ttnn.experimental.tensor.TensorMemoryLayout.BLOCK_SHARDED,
-                    ttnn.experimental.tensor.BufferType.L1,
-                    ttnn.experimental.tensor.ShardSpec(
+                memory_config=ttnn.MemoryConfig(
+                    ttnn.TensorMemoryLayout.BLOCK_SHARDED,
+                    ttnn.BufferType.L1,
+                    ttnn.ShardSpec(
                         shard_spec_32_cores_grid,
                         [
                             32,
                             1024,
                         ],
-                        ttnn.experimental.tensor.ShardOrientation.ROW_MAJOR,
+                        ttnn.ShardOrientation.ROW_MAJOR,
                         False,
                     ),
                 ),
@@ -172,59 +172,57 @@ def run_test_FalconLayernorm_inference(pcc, device, model_location_generator, ge
     input_shape = [1, 1, seqlen, config.hidden_size]
 
     input_torch = (torch.rand(input_shape) * 2) - 1
-    input = torch2tt_tensor(
-        input_torch, None, tt_dtype=ttnn.experimental.tensor.DataType.BFLOAT8_B
-    )  # ttnn.experimental.tensor.DataType.BFLOAT16 # TODO: should be BF16!!
+    input = torch2tt_tensor(input_torch, None, tt_dtype=ttnn.bfloat8_b)  # ttnn.bfloat16 # TODO: should be BF16!!
     input = input.to(device, model_config["DEFAULT_MEMCFG"])
 
     if is_sharded:
         # # Option1 : width sharded; produces bad PCC
-        # shard_spec_32_cores_grid = ttnn.experimental.tensor.CoreRangeSet(
+        # shard_spec_32_cores_grid = ttnn.CoreRangeSet(
         #     {
-        #         ttnn.experimental.tensor.CoreRange(
-        #             ttnn.experimental.tensor.CoreCoord(0, 0),
-        #             ttnn.experimental.tensor.CoreCoord(7, 3),
+        #         ttnn.CoreRange(
+        #             ttnn.CoreCoord(0, 0),
+        #             ttnn.CoreCoord(7, 3),
         #         ),
         #     }
         # )
         # input = ttnn.interleaved_to_sharded(
         #     input,
-        #     ttnn.experimental.tensor.MemoryConfig(
-        #         ttnn.experimental.tensor.TensorMemoryLayout.WIDTH_SHARDED,
-        #         ttnn.experimental.tensor.BufferType.L1,
-        #         ttnn.experimental.tensor.ShardSpec(
+        #     ttnn.MemoryConfig(
+        #         ttnn.TensorMemoryLayout.WIDTH_SHARDED,
+        #         ttnn.BufferType.L1,
+        #         ttnn.ShardSpec(
         #             shard_spec_32_cores_grid,
         #             [
         #                 seqlen,
         #                 config.hidden_size // 32,
         #             ],
-        #             ttnn.experimental.tensor.ShardOrientation.ROW_MAJOR,
+        #             ttnn.ShardOrientation.ROW_MAJOR,
         #             False,
         #         ),
         #     ),
         # )
 
         # Option 2: block sharded hardcoded for S=128 and 8x4 grid of cores; produces good PCC!
-        shard_spec_32_cores_grid = ttnn.experimental.tensor.CoreRangeSet(
+        shard_spec_32_cores_grid = ttnn.CoreRangeSet(
             {
-                ttnn.experimental.tensor.CoreRange(
-                    ttnn.experimental.tensor.CoreCoord(0, 0),
-                    ttnn.experimental.tensor.CoreCoord(7, 3),
+                ttnn.CoreRange(
+                    ttnn.CoreCoord(0, 0),
+                    ttnn.CoreCoord(7, 3),
                 ),
             }
         )
         input = ttnn.interleaved_to_sharded(
             input,
-            ttnn.experimental.tensor.MemoryConfig(
-                ttnn.experimental.tensor.TensorMemoryLayout.BLOCK_SHARDED,
-                ttnn.experimental.tensor.BufferType.L1,
-                ttnn.experimental.tensor.ShardSpec(
+            ttnn.MemoryConfig(
+                ttnn.TensorMemoryLayout.BLOCK_SHARDED,
+                ttnn.BufferType.L1,
+                ttnn.ShardSpec(
                     shard_spec_32_cores_grid,
                     [
                         32,
                         1024,
                     ],
-                    ttnn.experimental.tensor.ShardOrientation.ROW_MAJOR,
+                    ttnn.ShardOrientation.ROW_MAJOR,
                     False,
                 ),
             ),

--- a/models/demos/t3000/falcon40b/tests/unit_tests/layernorm/test_fused_falcon_layernorm.py
+++ b/models/demos/t3000/falcon40b/tests/unit_tests/layernorm/test_fused_falcon_layernorm.py
@@ -91,7 +91,7 @@ class TtFusedFalconLayernorm:
             ln_attn_beta_host = torch2tt_tensor(
                 ln_attn_beta_torch_padded,
                 None,
-                tt_layout=ttnn.experimental.tensor.Layout.TILE,
+                tt_layout=ttnn.TILE_LAYOUT,
                 tt_memory_config=self.model_config["LN_ATTN_BIAS_MEMCFG"],
                 tt_dtype=self.model_config["LN_ATTN_BIAS_DTYPE"],
             )
@@ -104,7 +104,7 @@ class TtFusedFalconLayernorm:
             ln_mlp_gamma_host = torch2tt_tensor(
                 ln_mlp_gamma_torch_padded,
                 None,
-                tt_layout=ttnn.experimental.tensor.Layout.TILE,
+                tt_layout=ttnn.TILE_LAYOUT,
                 tt_memory_config=self.model_config["LN_MLP_WEIGHTS_MEMCFG"],
                 tt_dtype=self.model_config["LN_MLP_WEIGHTS_DTYPE"],
             )
@@ -117,7 +117,7 @@ class TtFusedFalconLayernorm:
             ln_mlp_beta_host = torch2tt_tensor(
                 ln_mlp_beta_torch_padded,
                 None,
-                tt_layout=ttnn.experimental.tensor.Layout.TILE,
+                tt_layout=ttnn.TILE_LAYOUT,
                 tt_memory_config=self.model_config["LN_MLP_BIAS_MEMCFG"],
                 tt_dtype=self.model_config["LN_MLP_BIAS_DTYPE"],
             )
@@ -125,35 +125,35 @@ class TtFusedFalconLayernorm:
 
         self.layernorm_eps = config.layer_norm_epsilon
 
-        shard_spec_cores_grid = ttnn.experimental.tensor.CoreRangeSet(
+        shard_spec_cores_grid = ttnn.CoreRangeSet(
             {
-                ttnn.experimental.tensor.CoreRange(
-                    ttnn.experimental.tensor.CoreCoord(0, 0),
-                    ttnn.experimental.tensor.CoreCoord(7, 7),
+                ttnn.CoreRange(
+                    ttnn.CoreCoord(0, 0),
+                    ttnn.CoreCoord(7, 7),
                 ),
             }
         )
         H = config.hidden_size  # 8192
-        self.sharded_memconfig = ttnn.experimental.tensor.MemoryConfig(
-            ttnn.experimental.tensor.TensorMemoryLayout.BLOCK_SHARDED,
-            ttnn.experimental.tensor.BufferType.L1,
-            ttnn.experimental.tensor.ShardSpec(
+        self.sharded_memconfig = ttnn.MemoryConfig(
+            ttnn.TensorMemoryLayout.BLOCK_SHARDED,
+            ttnn.BufferType.L1,
+            ttnn.ShardSpec(
                 shard_spec_cores_grid,
                 [self.model_config["SEQ_LEN"] // 8, H // 8],  # 1024
-                ttnn.experimental.tensor.ShardOrientation.ROW_MAJOR,
+                ttnn.ShardOrientation.ROW_MAJOR,
                 False,
             ),
         )
-        # self.width_sharded_memconfig = ttnn.experimental.tensor.MemoryConfig(
-        #     ttnn.experimental.tensor.TensorMemoryLayout.WIDTH_SHARDED,
-        #     ttnn.experimental.tensor.BufferType.L1,
-        #     ttnn.experimental.tensor.ShardSpec(
+        # self.width_sharded_memconfig = ttnn.MemoryConfig(
+        #     ttnn.TensorMemoryLayout.WIDTH_SHARDED,
+        #     ttnn.BufferType.L1,
+        #     ttnn.ShardSpec(
         #         shard_spec_cores_grid,
         #         [
         #             self.model_config["SEQ_LEN"],
         #             H // 64,
         #         ],
-        #         ttnn.experimental.tensor.ShardOrientation.ROW_MAJOR,
+        #         ttnn.ShardOrientation.ROW_MAJOR,
         #         False,
         #     ),
         # )
@@ -166,12 +166,9 @@ class TtFusedFalconLayernorm:
             inplace=False,
         )
 
-        self.interleaved_memconfig = ttnn.experimental.tensor.MemoryConfig(
-            ttnn.experimental.tensor.TensorMemoryLayout.INTERLEAVED,
-            ttnn.experimental.tensor.BufferType.L1,
-        )
+        self.interleaved_memconfig = ttnn.L1_MEMORY_CONFIG
 
-    def __call__(self, x: ttnn.experimental.tensor.Tensor) -> ttnn.experimental.tensor.Tensor:
+    def __call__(self, x: ttnn.Tensor) -> ttnn.Tensor:
         # # OG layernorm
         # out1 = ttnn.layer_norm(
         #     x, epsilon=self.layernorm_eps, weight=self.ln_attn_gamma, bias=self.ln_attn_beta, memory_config=self.sharded_memconfig, program_config=self.prg_config

--- a/models/demos/t3000/falcon40b/tests/unit_tests/test_falcon_create_qkv_heads.py
+++ b/models/demos/t3000/falcon40b/tests/unit_tests/test_falcon_create_qkv_heads.py
@@ -61,13 +61,13 @@ class TtFalconCreateQKVHeads:
         self.num_heads = num_heads
         self.num_kv_heads = num_kv_heads
 
-    def __call__(self, x: ttnn.experimental.tensor.Tensor) -> ttnn.experimental.tensor.Tensor:
+    def __call__(self, x: ttnn.Tensor) -> ttnn.Tensor:
         q_layer, k_layer, v_layer = ttnn.experimental.nlp_create_qkv_heads(
             x,
             num_heads=self.num_heads,
             num_kv_heads=self.num_kv_heads,
             transpose_k_heads=False,
-            memory_config=ttnn.MemoryConfig(ttnn.TensorMemoryLayout.INTERLEAVED, ttnn.BufferType.DRAM),
+            memory_config=ttnn.DRAM_MEMORY_CONFIG,
         )
 
         return q_layer, k_layer, v_layer
@@ -109,12 +109,10 @@ def run_test_FalconMLP_inference(
         num_kv_heads=num_kv_heads,
     )
 
-    input_host = torch2tt_tensor(input, None, tt_dtype=ttnn.experimental.tensor.DataType.BFLOAT16)
+    input_host = torch2tt_tensor(input, None, tt_dtype=ttnn.bfloat16)
     input = input_host.to(
         device,
-        ttnn.experimental.tensor.MemoryConfig(
-            ttnn.experimental.tensor.TensorMemoryLayout.INTERLEAVED, ttnn.experimental.tensor.BufferType.DRAM
-        ),
+        ttnn.DRAM_MEMORY_CONFIG,
     )
 
     q_tt_out, k_tt_out, v_tt_out = tt_Falconcreate_qkv_heads_model(input)

--- a/models/demos/t3000/falcon40b/tests/unit_tests/test_falcon_softmax.py
+++ b/models/demos/t3000/falcon40b/tests/unit_tests/test_falcon_softmax.py
@@ -45,9 +45,7 @@ class TtFalconSoftmax:
         self.seqlen = seqlen
         self.scalar = 1 / math.sqrt(head_dim)
 
-    def __call__(
-        self, x: ttnn.experimental.tensor.Tensor, attention_mask: ttnn.experimental.tensor.Tensor
-    ) -> ttnn.experimental.tensor.Tensor:
+    def __call__(self, x: ttnn.Tensor, attention_mask: ttnn.Tensor) -> ttnn.Tensor:
         out = ttnn.scale_causal_mask_hw_dims_softmax_in_place(
             x,
             self.scalar,
@@ -75,8 +73,8 @@ def run_test_FalconSoftmax_inference(
 
     input_shape = [1, num_attention_heads, seqlen, seqlen]
     input_torch = (torch.rand(input_shape) * 2) - 1
-    input = torch2tt_tensor(input_torch, None, tt_dtype=ttnn.experimental.tensor.DataType.BFLOAT16)
-    input = input.to(device, ttnn.MemoryConfig(ttnn.TensorMemoryLayout.INTERLEAVED, ttnn.BufferType.DRAM))
+    input = torch2tt_tensor(input_torch, None, tt_dtype=ttnn.bfloat16)
+    input = input.to(device, ttnn.DRAM_MEMORY_CONFIG)
 
     attention_mask_bool = torch.ones(1, 1, seqlen, seqlen, dtype=bool).triu(diagonal=1)
 

--- a/models/demos/t3000/falcon40b/tt/falcon_attention.py
+++ b/models/demos/t3000/falcon40b/tt/falcon_attention.py
@@ -98,9 +98,7 @@ class TtFalconRotaryEmbedding:
                 tt_cache_path,
             )
 
-    def __call__(
-        self, layer: ttnn.experimental.tensor.Tensor, token_idx: Optional[int] = None
-    ) -> ttnn.experimental.tensor.Tensor:
+    def __call__(self, layer: ttnn.Tensor, token_idx: Optional[int] = None) -> ttnn.Tensor:
         seq_len = layer.get_legacy_shape()[2]
         assert seq_len <= self.max_seq_len_cached, "seq_len exceeds max_seq_len_cached in RotaryEmbedding!"
         # TODO: Make rotary embedding in place
@@ -248,16 +246,16 @@ class TtFalconAttention:
 
     def __call__(
         self,
-        hidden_states: ttnn.experimental.tensor.Tensor,
+        hidden_states: ttnn.Tensor,
         alibi: torch.Tensor,
-        attention_mask: ttnn.experimental.tensor.Tensor,
+        attention_mask: ttnn.Tensor,
         llm_mode: str,
         user_id: int = 0,
-        layer_past: Optional[Tuple[ttnn.experimental.tensor.Tensor]] = None,
+        layer_past: Optional[Tuple[ttnn.Tensor]] = None,
         layer_past_len: int = 0,
         output_attentions: bool = False,
         use_cache: bool = False,
-    ) -> Tuple[ttnn.experimental.tensor.Tensor, Optional[Tuple[ttnn.experimental.tensor.Tensor]]]:
+    ) -> Tuple[ttnn.Tensor, Optional[Tuple[ttnn.Tensor]]]:
         """
         Prefill input shape: [batch, 1, seq_len, hidden_size]
         Decode input shape: [seq_len, 1, batch, hidden_size]
@@ -291,16 +289,16 @@ class TtFalconAttention:
 
     def fwd_prefill(
         self,
-        hidden_states: ttnn.experimental.tensor.Tensor,
+        hidden_states: ttnn.Tensor,
         alibi: torch.Tensor,
-        attention_mask: ttnn.experimental.tensor.Tensor,
+        attention_mask: ttnn.Tensor,
         llm_mode: str,
         user_id: int = 0,
-        layer_past: Optional[Tuple[ttnn.experimental.tensor.Tensor]] = None,
+        layer_past: Optional[Tuple[ttnn.Tensor]] = None,
         layer_past_len: int = 0,
         output_attentions: bool = False,
         use_cache: bool = False,
-    ) -> Tuple[ttnn.experimental.tensor.Tensor, Optional[Tuple[ttnn.experimental.tensor.Tensor]]]:
+    ) -> Tuple[ttnn.Tensor, Optional[Tuple[ttnn.Tensor]]]:
         """
         Prefill input shape: [batch, 1, seq_len, hidden_size]
         Decode input shape: [seq_len, 1, batch, hidden_size]
@@ -396,16 +394,16 @@ class TtFalconAttention:
 
     def fwd_decode(
         self,
-        hidden_states: ttnn.experimental.tensor.Tensor,
+        hidden_states: ttnn.Tensor,
         alibi: torch.Tensor,
-        attention_mask: ttnn.experimental.tensor.Tensor,
+        attention_mask: ttnn.Tensor,
         llm_mode: str,
         user_id: int = 0,
-        layer_past: Optional[Tuple[ttnn.experimental.tensor.Tensor]] = None,
+        layer_past: Optional[Tuple[ttnn.Tensor]] = None,
         layer_past_len: int = 0,
         output_attentions: bool = False,
         use_cache: bool = False,
-    ) -> Tuple[ttnn.experimental.tensor.Tensor, Optional[Tuple[ttnn.experimental.tensor.Tensor]]]:
+    ) -> Tuple[ttnn.Tensor, Optional[Tuple[ttnn.Tensor]]]:
         """
         Prefill input shape: [batch, 1, seq_len, hidden_size]
         Decode input shape: [seq_len, 1, batch, hidden_size]

--- a/models/demos/t3000/falcon40b/tt/falcon_causallm.py
+++ b/models/demos/t3000/falcon40b/tt/falcon_causallm.py
@@ -60,14 +60,14 @@ class TtFalconCausalLM(TtFalconModelShared):
 
     def __call__(
         self,
-        input_ids: ttnn.experimental.tensor.Tensor,
+        input_ids: ttnn.Tensor,
         llm_mode: str,
-        attention_mask: ttnn.experimental.tensor.Tensor = None,
+        attention_mask: ttnn.Tensor = None,
         user_id: int = 0,
-        layer_past: Optional[Tuple[Tuple[ttnn.experimental.tensor.Tensor]]] = None,
+        layer_past: Optional[Tuple[Tuple[ttnn.Tensor]]] = None,
         layer_past_len: int = 0,
         use_cache: bool = False,
-    ) -> ttnn.experimental.tensor.Tensor:
+    ) -> ttnn.Tensor:
         if llm_mode == "prefill":
             return self.fwd_prefill_causallm(
                 input_ids=input_ids,
@@ -93,14 +93,14 @@ class TtFalconCausalLM(TtFalconModelShared):
 
     def fwd_prefill_causallm(
         self,
-        input_ids: ttnn.experimental.tensor.Tensor,
+        input_ids: ttnn.Tensor,
         llm_mode: str,
-        attention_mask: ttnn.experimental.tensor.Tensor = None,
+        attention_mask: ttnn.Tensor = None,
         user_id: int = 0,
-        layer_past: Optional[Tuple[Tuple[ttnn.experimental.tensor.Tensor]]] = None,
+        layer_past: Optional[Tuple[Tuple[ttnn.Tensor]]] = None,
         layer_past_len: int = 0,
         use_cache: bool = False,
-    ) -> ttnn.experimental.tensor.Tensor:
+    ) -> ttnn.Tensor:
         hidden_states, presents = super().__call__(
             input_ids=input_ids,
             attention_mask=attention_mask,
@@ -143,14 +143,14 @@ class TtFalconCausalLM(TtFalconModelShared):
 
     def fwd_decode_causallm(
         self,
-        input_ids: ttnn.experimental.tensor.Tensor,
+        input_ids: ttnn.Tensor,
         llm_mode: str,
-        attention_mask: ttnn.experimental.tensor.Tensor = None,
+        attention_mask: ttnn.Tensor = None,
         user_id: int = 0,
-        layer_past: Optional[Tuple[Tuple[ttnn.experimental.tensor.Tensor]]] = None,
+        layer_past: Optional[Tuple[Tuple[ttnn.Tensor]]] = None,
         layer_past_len: int = 0,
         use_cache: bool = False,
-    ) -> ttnn.experimental.tensor.Tensor:
+    ) -> ttnn.Tensor:
         hidden_states, presents = super().__call__(
             input_ids=input_ids,
             attention_mask=attention_mask,

--- a/models/demos/t3000/falcon40b/tt/falcon_decoder.py
+++ b/models/demos/t3000/falcon40b/tt/falcon_decoder.py
@@ -138,16 +138,16 @@ class TtFalconDecoderLayer:
 
     def __call__(
         self,
-        hidden_states: ttnn.experimental.tensor.Tensor,
+        hidden_states: ttnn.Tensor,
         alibi: torch.Tensor,
-        attention_mask: ttnn.experimental.tensor.Tensor,
+        attention_mask: ttnn.Tensor,
         llm_mode: str,
         user_id: int = 0,
-        layer_past: Optional[Tuple[ttnn.experimental.tensor.Tensor]] = None,
+        layer_past: Optional[Tuple[ttnn.Tensor]] = None,
         layer_past_len: int = 0,
         output_attentions: Optional[bool] = False,
         use_cache: Optional[bool] = False,
-    ) -> Tuple[ttnn.experimental.tensor.Tensor, Optional[Tuple[torch.FloatTensor, torch.FloatTensor]]]:
+    ) -> Tuple[ttnn.Tensor, Optional[Tuple[torch.FloatTensor, torch.FloatTensor]]]:
         """Input shape: [batch, 1, seq_len, hidden_size]"""
 
         if llm_mode == "prefill":
@@ -179,16 +179,16 @@ class TtFalconDecoderLayer:
 
     def fwd_prefill(
         self,
-        hidden_states: ttnn.experimental.tensor.Tensor,
+        hidden_states: ttnn.Tensor,
         alibi: torch.Tensor,
         attention_mask: torch.Tensor,
         llm_mode: str,
         user_id: int = 0,
-        layer_past: Optional[Tuple[ttnn.experimental.tensor.Tensor]] = None,
+        layer_past: Optional[Tuple[ttnn.Tensor]] = None,
         layer_past_len: int = 0,
         output_attentions: Optional[bool] = False,
         use_cache: Optional[bool] = False,
-    ) -> Tuple[ttnn.experimental.tensor.Tensor, Optional[Tuple[torch.FloatTensor, torch.FloatTensor]]]:
+    ) -> Tuple[ttnn.Tensor, Optional[Tuple[torch.FloatTensor, torch.FloatTensor]]]:
         """Input shape: [batch, 1, seq_len, hidden_size]"""
 
         assert not output_attentions
@@ -288,16 +288,16 @@ class TtFalconDecoderLayer:
 
     def fwd_decode(
         self,
-        hidden_states: ttnn.experimental.tensor.Tensor,
+        hidden_states: ttnn.Tensor,
         alibi: torch.Tensor,
         attention_mask: torch.Tensor,
         llm_mode: str,
         user_id: int = 0,
-        layer_past: Optional[Tuple[ttnn.experimental.tensor.Tensor]] = None,
+        layer_past: Optional[Tuple[ttnn.Tensor]] = None,
         layer_past_len: int = 0,
         output_attentions: Optional[bool] = False,
         use_cache: Optional[bool] = False,
-    ) -> Tuple[ttnn.experimental.tensor.Tensor, Optional[Tuple[torch.FloatTensor, torch.FloatTensor]]]:
+    ) -> Tuple[ttnn.Tensor, Optional[Tuple[torch.FloatTensor, torch.FloatTensor]]]:
         """Input shape: [batch, 1, seq_len, hidden_size]"""
 
         assert not output_attentions

--- a/models/demos/t3000/falcon40b/tt/falcon_mlp.py
+++ b/models/demos/t3000/falcon40b/tt/falcon_mlp.py
@@ -87,9 +87,7 @@ class TtFalconMLP:
                 mesh_mapper=ReplicateTensorToMesh(self.device_mesh),
             )
 
-    def __call__(
-        self, x: List[ttnn.experimental.tensor.Tensor], llm_mode: str
-    ) -> List[ttnn.experimental.tensor.Tensor]:
+    def __call__(self, x: List[ttnn.Tensor], llm_mode: str) -> List[ttnn.Tensor]:
         if llm_mode == "prefill":
             return self.fwd_prefill(x)
         elif llm_mode == "decode":
@@ -97,7 +95,7 @@ class TtFalconMLP:
         else:
             assert False
 
-    def fwd_decode(self, x: List[ttnn.experimental.tensor.Tensor]) -> List[ttnn.experimental.tensor.Tensor]:
+    def fwd_decode(self, x: List[ttnn.Tensor]) -> List[ttnn.Tensor]:
         hidden_states = ttnn.matmul(
             x,
             self.dense_h_to_4h_weights,
@@ -142,7 +140,7 @@ class TtFalconMLP:
         # return TT Tensor
         return hidden_states
 
-    def fwd_prefill(self, x: List[ttnn.experimental.tensor.Tensor]) -> List[ttnn.experimental.tensor.Tensor]:
+    def fwd_prefill(self, x: List[ttnn.Tensor]) -> List[ttnn.Tensor]:
         hidden_states = []
         should_deallocate_ln_tensors = determine_tensor_deallocation(
             self.model_config["layernorm_params"]["slice_size"], x.get_legacy_shape()[2]
@@ -157,7 +155,7 @@ class TtFalconMLP:
                 mlp_num_slices,
                 slice_idx,
                 self.model_config["MLP_INPUT_SHARD_LAYOUT"],
-                ttnn.experimental.tensor.ShardOrientation.ROW_MAJOR,
+                ttnn.ShardOrientation.ROW_MAJOR,
             )
 
             hidden_states_slice = falcon_prefill_matmul(

--- a/models/demos/t3000/falcon40b/tt/falcon_model.py
+++ b/models/demos/t3000/falcon40b/tt/falcon_model.py
@@ -248,14 +248,14 @@ class TtFalconModelShared:
     @abstractmethod
     def __call__(
         self,
-        input_ids: ttnn.experimental.tensor.Tensor,
+        input_ids: ttnn.Tensor,
         llm_mode: str,
-        attention_mask: ttnn.experimental.tensor.Tensor = None,
+        attention_mask: ttnn.Tensor = None,
         user_id: int = 0,
-        layer_past: Optional[Tuple[Tuple[ttnn.experimental.tensor.Tensor]]] = None,
+        layer_past: Optional[Tuple[Tuple[ttnn.Tensor]]] = None,
         layer_past_len: int = 0,
         use_cache: bool = False,
-    ) -> ttnn.experimental.tensor.Tensor:
+    ) -> ttnn.Tensor:
         input_embeddings = self.embeddings(input_ids)
 
         if llm_mode == "prefill":
@@ -283,14 +283,14 @@ class TtFalconModelShared:
 
     def fwd_prefill(
         self,
-        input_embeddings: ttnn.experimental.tensor.Tensor,
+        input_embeddings: ttnn.Tensor,
         llm_mode: str,
-        attention_mask: ttnn.experimental.tensor.Tensor = None,
+        attention_mask: ttnn.Tensor = None,
         user_id: int = 0,
-        layer_past: Optional[Tuple[Tuple[ttnn.experimental.tensor.Tensor]]] = None,
+        layer_past: Optional[Tuple[Tuple[ttnn.Tensor]]] = None,
         layer_past_len: int = 0,
         use_cache: bool = False,
-    ) -> ttnn.experimental.tensor.Tensor:
+    ) -> ttnn.Tensor:
         layer_output = input_embeddings
         presents = ()
         for idx, layer in enumerate(self.layers):
@@ -341,14 +341,14 @@ class TtFalconModelShared:
 
     def fwd_decode(
         self,
-        input_embeddings: ttnn.experimental.tensor.Tensor,
+        input_embeddings: ttnn.Tensor,
         llm_mode: str,
-        attention_mask: ttnn.experimental.tensor.Tensor = None,
+        attention_mask: ttnn.Tensor = None,
         user_id: int = 0,
-        layer_past: Optional[Tuple[Tuple[ttnn.experimental.tensor.Tensor]]] = None,
+        layer_past: Optional[Tuple[Tuple[ttnn.Tensor]]] = None,
         layer_past_len: int = 0,
         use_cache: bool = False,
-    ) -> ttnn.experimental.tensor.Tensor:
+    ) -> ttnn.Tensor:
         layer_output = input_embeddings
         presents = ()
         for idx, layer in enumerate(self.layers):
@@ -420,14 +420,14 @@ class TtFalconModel(TtFalconModelShared):
 
     def __call__(
         self,
-        input_ids: ttnn.experimental.tensor.Tensor,
+        input_ids: ttnn.Tensor,
         llm_mode: str,
-        attention_mask: ttnn.experimental.tensor.Tensor = None,
+        attention_mask: ttnn.Tensor = None,
         user_id: int = 0,
-        layer_past: Optional[Tuple[Tuple[ttnn.experimental.tensor.Tensor]]] = None,
+        layer_past: Optional[Tuple[Tuple[ttnn.Tensor]]] = None,
         layer_past_len: int = 0,
         use_cache: bool = False,
-    ) -> ttnn.experimental.tensor.Tensor:
+    ) -> ttnn.Tensor:
         hidden_states, presents = super().__call__(
             input_ids=input_ids,
             llm_mode=llm_mode,

--- a/models/demos/t3000/falcon40b/tt/model_config.py
+++ b/models/demos/t3000/falcon40b/tt/model_config.py
@@ -158,28 +158,20 @@ def get_decode_model_config(model_config_str, input_shape, num_devices):
     assert len(input_shape) == 2
     assert num_devices == 8, "Decode is currently only supported on 8 devicess"
 
-    DRAM_MEMCFG = ttnn.experimental.tensor.MemoryConfig(
-        ttnn.experimental.tensor.TensorMemoryLayout.INTERLEAVED, ttnn.experimental.tensor.BufferType.DRAM
-    )
-    L1_MEMCFG = ttnn.experimental.tensor.MemoryConfig(
-        ttnn.experimental.tensor.TensorMemoryLayout.INTERLEAVED, ttnn.experimental.tensor.BufferType.L1
-    )
-    WIDTH_SHARDED_MEMCFG = ttnn.experimental.tensor.MemoryConfig(
-        ttnn.experimental.tensor.TensorMemoryLayout.WIDTH_SHARDED, ttnn.experimental.tensor.BufferType.L1
-    )
-    HEIGHT_SHARDED_MEMCFG = ttnn.experimental.tensor.MemoryConfig(
-        ttnn.experimental.tensor.TensorMemoryLayout.HEIGHT_SHARDED, ttnn.experimental.tensor.BufferType.L1
-    )
-    BFLOAT16_DTYPE = ttnn.experimental.tensor.DataType.BFLOAT16
-    BFP8_DTYPE = ttnn.experimental.tensor.DataType.BFLOAT8_B
-    BFP4_DTYPE = ttnn.experimental.tensor.DataType.BFLOAT4_B
+    DRAM_MEMCFG = ttnn.DRAM_MEMORY_CONFIG
+    L1_MEMCFG = ttnn.L1_MEMORY_CONFIG
+    WIDTH_SHARDED_MEMCFG = ttnn.MemoryConfig(ttnn.TensorMemoryLayout.WIDTH_SHARDED, ttnn.BufferType.L1)
+    HEIGHT_SHARDED_MEMCFG = ttnn.MemoryConfig(ttnn.TensorMemoryLayout.HEIGHT_SHARDED, ttnn.BufferType.L1)
+    BFLOAT16_DTYPE = ttnn.bfloat16
+    BFP8_DTYPE = ttnn.bfloat8_b
+    BFP4_DTYPE = ttnn.bfloat4_b
 
     # Set default dtype and mem_config based on model_config_str
     if model_config_str in ACCEPTABLE_DECODE_MODEL_CONFIG_STRS:
         dtype_str, mem_config_str = model_config_str.split("-")
         # TODO: Set default memcfg for BFLOAT16-L1 to L1
         mem_config = DRAM_MEMCFG if mem_config_str == "DRAM" else L1_MEMCFG
-        dtype = getattr(ttnn.experimental.tensor.DataType, dtype_str)
+        dtype = getattr(ttnn.DataType, dtype_str)
     else:
         raise NotImplementedError(f"Model config {model_config_str} is not supported!")
 
@@ -193,14 +185,14 @@ def get_decode_model_config(model_config_str, input_shape, num_devices):
         "MAX_GRID_SIZE": (8, 4),
         "ALL_GATHER_NUM_LINKS": 1,
         "DEFAULT_CACHE_PATH": Path(f"models/demos/t3000/falcon40b/datasets/"),
-        "COMPUTE_KERNEL_CONFIG": ttnn.experimental.tensor.WormholeComputeKernelConfig(
-            math_fidelity=ttnn.experimental.tensor.MathFidelity.LoFi,
+        "COMPUTE_KERNEL_CONFIG": ttnn.WormholeComputeKernelConfig(
+            math_fidelity=ttnn.MathFidelity.LoFi,
             math_approx_mode=True,
             fp32_dest_acc_en=True,
             packer_l1_acc=True,
         ),
-        "COMPUTE_KERNEL_FP16_ACC_CONFIG": ttnn.experimental.tensor.WormholeComputeKernelConfig(
-            math_fidelity=ttnn.experimental.tensor.MathFidelity.LoFi,
+        "COMPUTE_KERNEL_FP16_ACC_CONFIG": ttnn.WormholeComputeKernelConfig(
+            math_fidelity=ttnn.MathFidelity.LoFi,
             math_approx_mode=True,
             fp32_dest_acc_en=False,
             packer_l1_acc=True,
@@ -255,43 +247,43 @@ def get_decode_model_config(model_config_str, input_shape, num_devices):
         model_config["POST_SOFTMAX_MM_OUTPUT_MEMCFG"] = L1_MEMCFG
 
     if mem_config_str == "SHARDED":
-        shard_spec_32_cores_grid = ttnn.experimental.tensor.CoreRangeSet(
+        shard_spec_32_cores_grid = ttnn.CoreRangeSet(
             {
-                ttnn.experimental.tensor.CoreRange(
-                    ttnn.experimental.tensor.CoreCoord(0, 0),
-                    ttnn.experimental.tensor.CoreCoord(7, 3),
+                ttnn.CoreRange(
+                    ttnn.CoreCoord(0, 0),
+                    ttnn.CoreCoord(7, 3),
                 ),
             }
         )
-        shard_spec_16_cores_grid = ttnn.experimental.tensor.CoreRangeSet(
+        shard_spec_16_cores_grid = ttnn.CoreRangeSet(
             {
-                ttnn.experimental.tensor.CoreRange(
-                    ttnn.experimental.tensor.CoreCoord(0, 0),
-                    ttnn.experimental.tensor.CoreCoord(7, 1),
+                ttnn.CoreRange(
+                    ttnn.CoreCoord(0, 0),
+                    ttnn.CoreCoord(7, 1),
                 ),
             }
         )
-        shard_spec_8_cores_grid = ttnn.experimental.tensor.CoreRangeSet(
+        shard_spec_8_cores_grid = ttnn.CoreRangeSet(
             {
-                ttnn.experimental.tensor.CoreRange(
-                    ttnn.experimental.tensor.CoreCoord(0, 0),
-                    ttnn.experimental.tensor.CoreCoord(7, 0),
+                ttnn.CoreRange(
+                    ttnn.CoreCoord(0, 0),
+                    ttnn.CoreCoord(7, 0),
                 ),
             }
         )
-        shard_spec_2_cores_grid = ttnn.experimental.tensor.CoreRangeSet(
+        shard_spec_2_cores_grid = ttnn.CoreRangeSet(
             {
-                ttnn.experimental.tensor.CoreRange(
-                    ttnn.experimental.tensor.CoreCoord(0, 0),
-                    ttnn.experimental.tensor.CoreCoord(1, 0),
+                ttnn.CoreRange(
+                    ttnn.CoreCoord(0, 0),
+                    ttnn.CoreCoord(1, 0),
                 ),
             }
         )
-        shard_spec_1_cores_grid = ttnn.experimental.tensor.CoreRangeSet(
+        shard_spec_1_cores_grid = ttnn.CoreRangeSet(
             {
-                ttnn.experimental.tensor.CoreRange(
-                    ttnn.experimental.tensor.CoreCoord(0, 0),
-                    ttnn.experimental.tensor.CoreCoord(0, 0),
+                ttnn.CoreRange(
+                    ttnn.CoreCoord(0, 0),
+                    ttnn.CoreCoord(0, 0),
                 ),
             }
         )
@@ -312,96 +304,96 @@ def get_decode_model_config(model_config_str, input_shape, num_devices):
         shard_width_qkv_heads_per_device_across_8_cores = total_width_of_qkv_heads_per_device // 8
 
         # Embeddings
-        model_config["WORD_EMBEDDING_OUTPUT_MEMCFG"] = ttnn.experimental.tensor.MemoryConfig(
-            ttnn.experimental.tensor.TensorMemoryLayout.WIDTH_SHARDED,
-            ttnn.experimental.tensor.BufferType.L1,
-            ttnn.experimental.tensor.ShardSpec(
+        model_config["WORD_EMBEDDING_OUTPUT_MEMCFG"] = ttnn.MemoryConfig(
+            ttnn.TensorMemoryLayout.WIDTH_SHARDED,
+            ttnn.BufferType.L1,
+            ttnn.ShardSpec(
                 shard_spec_32_cores_grid,
                 [
                     row_height,
                     shard_width_hidden_dim_per_device_across_32_cores,
                 ],
-                ttnn.experimental.tensor.ShardOrientation.ROW_MAJOR,
+                ttnn.ShardOrientation.ROW_MAJOR,
                 False,
             ),
         )
-        model_config["ATTN_MASK_MEMCFG"] = ttnn.experimental.tensor.MemoryConfig(
-            ttnn.experimental.tensor.TensorMemoryLayout.HEIGHT_SHARDED,
-            ttnn.experimental.tensor.BufferType.L1,
-            ttnn.experimental.tensor.ShardSpec(
+        model_config["ATTN_MASK_MEMCFG"] = ttnn.MemoryConfig(
+            ttnn.TensorMemoryLayout.HEIGHT_SHARDED,
+            ttnn.BufferType.L1,
+            ttnn.ShardSpec(
                 shard_spec_32_cores_grid,
                 [
                     row_height,
                     1,  # Dynamic
                 ],
-                ttnn.experimental.tensor.ShardOrientation.ROW_MAJOR,
+                ttnn.ShardOrientation.ROW_MAJOR,
                 False,
             ),
         )
-        model_config["PARALLEL_ATTN_ADD_OUTPUT_MEMCFG"] = ttnn.experimental.tensor.MemoryConfig(
-            ttnn.experimental.tensor.TensorMemoryLayout.WIDTH_SHARDED,
-            ttnn.experimental.tensor.BufferType.L1,
-            ttnn.experimental.tensor.ShardSpec(
+        model_config["PARALLEL_ATTN_ADD_OUTPUT_MEMCFG"] = ttnn.MemoryConfig(
+            ttnn.TensorMemoryLayout.WIDTH_SHARDED,
+            ttnn.BufferType.L1,
+            ttnn.ShardSpec(
                 shard_spec_32_cores_grid,
                 [
                     row_height,
                     shard_width_hidden_dim_per_device_across_32_cores,
                 ],
-                ttnn.experimental.tensor.ShardOrientation.ROW_MAJOR,
+                ttnn.ShardOrientation.ROW_MAJOR,
                 False,
             ),
         )
-        model_config["DROPOUT_ADD_OUTPUT_MEMCFG"] = ttnn.experimental.tensor.MemoryConfig(
-            ttnn.experimental.tensor.TensorMemoryLayout.WIDTH_SHARDED,
-            ttnn.experimental.tensor.BufferType.L1,
-            ttnn.experimental.tensor.ShardSpec(
+        model_config["DROPOUT_ADD_OUTPUT_MEMCFG"] = ttnn.MemoryConfig(
+            ttnn.TensorMemoryLayout.WIDTH_SHARDED,
+            ttnn.BufferType.L1,
+            ttnn.ShardSpec(
                 shard_spec_32_cores_grid,
                 [
                     row_height,
                     shard_width_hidden_dim_per_device_across_32_cores,
                 ],
-                ttnn.experimental.tensor.ShardOrientation.ROW_MAJOR,
+                ttnn.ShardOrientation.ROW_MAJOR,
                 False,
             ),
         )
 
         # Decoder
-        model_config["DECODER_ALL_GATHER_OUTPUT_MEMCFG"] = ttnn.experimental.tensor.MemoryConfig(
-            ttnn.experimental.tensor.TensorMemoryLayout.WIDTH_SHARDED,
-            ttnn.experimental.tensor.BufferType.L1,
-            ttnn.experimental.tensor.ShardSpec(
+        model_config["DECODER_ALL_GATHER_OUTPUT_MEMCFG"] = ttnn.MemoryConfig(
+            ttnn.TensorMemoryLayout.WIDTH_SHARDED,
+            ttnn.BufferType.L1,
+            ttnn.ShardSpec(
                 shard_spec_32_cores_grid,
                 [
                     row_height,
                     shard_width_hidden_dim_across_32_cores,
                 ],
-                ttnn.experimental.tensor.ShardOrientation.ROW_MAJOR,
+                ttnn.ShardOrientation.ROW_MAJOR,
                 False,
             ),
         )
-        model_config["LN_ATTN_INPUT_MEMCFG"] = ttnn.experimental.tensor.MemoryConfig(
-            ttnn.experimental.tensor.TensorMemoryLayout.WIDTH_SHARDED,
-            ttnn.experimental.tensor.BufferType.L1,
-            ttnn.experimental.tensor.ShardSpec(
+        model_config["LN_ATTN_INPUT_MEMCFG"] = ttnn.MemoryConfig(
+            ttnn.TensorMemoryLayout.WIDTH_SHARDED,
+            ttnn.BufferType.L1,
+            ttnn.ShardSpec(
                 shard_spec_32_cores_grid,
                 [
                     row_height,
                     shard_width_hidden_dim_across_32_cores,
                 ],
-                ttnn.experimental.tensor.ShardOrientation.ROW_MAJOR,
+                ttnn.ShardOrientation.ROW_MAJOR,
                 False,
             ),
         )
-        model_config["LN_ATTN_OUTPUT_MEMCFG"] = ttnn.experimental.tensor.MemoryConfig(
-            ttnn.experimental.tensor.TensorMemoryLayout.WIDTH_SHARDED,
-            ttnn.experimental.tensor.BufferType.L1,
-            ttnn.experimental.tensor.ShardSpec(
+        model_config["LN_ATTN_OUTPUT_MEMCFG"] = ttnn.MemoryConfig(
+            ttnn.TensorMemoryLayout.WIDTH_SHARDED,
+            ttnn.BufferType.L1,
+            ttnn.ShardSpec(
                 shard_spec_32_cores_grid,
                 [
                     row_height,
                     shard_width_hidden_dim_across_32_cores,
                 ],
-                ttnn.experimental.tensor.ShardOrientation.ROW_MAJOR,
+                ttnn.ShardOrientation.ROW_MAJOR,
                 False,
             ),
         )
@@ -419,31 +411,31 @@ def get_decode_model_config(model_config_str, input_shape, num_devices):
             block_w=8,
             inplace=True,
         )
-        model_config["LN_MLP_OUTPUT_MEMCFG"] = ttnn.experimental.tensor.MemoryConfig(
-            ttnn.experimental.tensor.TensorMemoryLayout.WIDTH_SHARDED,
-            ttnn.experimental.tensor.BufferType.L1,
-            ttnn.experimental.tensor.ShardSpec(
+        model_config["LN_MLP_OUTPUT_MEMCFG"] = ttnn.MemoryConfig(
+            ttnn.TensorMemoryLayout.WIDTH_SHARDED,
+            ttnn.BufferType.L1,
+            ttnn.ShardSpec(
                 shard_spec_32_cores_grid,
                 [
                     row_height,
                     shard_width_hidden_dim_across_32_cores,
                 ],
-                ttnn.experimental.tensor.ShardOrientation.ROW_MAJOR,
+                ttnn.ShardOrientation.ROW_MAJOR,
                 False,
             ),
         )
 
         # ATTN
-        model_config["FUSED_QKV_MM_INPUT_MEMCFG"] = ttnn.experimental.tensor.MemoryConfig(
-            ttnn.experimental.tensor.TensorMemoryLayout.WIDTH_SHARDED,
-            ttnn.experimental.tensor.BufferType.L1,
-            ttnn.experimental.tensor.ShardSpec(
+        model_config["FUSED_QKV_MM_INPUT_MEMCFG"] = ttnn.MemoryConfig(
+            ttnn.TensorMemoryLayout.WIDTH_SHARDED,
+            ttnn.BufferType.L1,
+            ttnn.ShardSpec(
                 shard_spec_8_cores_grid,
                 [
                     row_height,
                     shard_width_hidden_dim_across_8_cores,
                 ],
-                ttnn.experimental.tensor.ShardOrientation.ROW_MAJOR,
+                ttnn.ShardOrientation.ROW_MAJOR,
                 False,
             ),
         )
@@ -458,70 +450,70 @@ def get_decode_model_config(model_config_str, input_shape, num_devices):
             fused_activation=None,
             mcast_in0=True,
         )
-        model_config["FUSED_QKV_MM_OUTPUT_MEMCFG"] = ttnn.experimental.tensor.MemoryConfig(
-            ttnn.experimental.tensor.TensorMemoryLayout.WIDTH_SHARDED,
-            ttnn.experimental.tensor.BufferType.L1,
-            ttnn.experimental.tensor.ShardSpec(
+        model_config["FUSED_QKV_MM_OUTPUT_MEMCFG"] = ttnn.MemoryConfig(
+            ttnn.TensorMemoryLayout.WIDTH_SHARDED,
+            ttnn.BufferType.L1,
+            ttnn.ShardSpec(
                 shard_spec_8_cores_grid,
                 [
                     row_height,
                     shard_width_qkv_heads_per_device_across_8_cores,
                 ],
-                ttnn.experimental.tensor.ShardOrientation.ROW_MAJOR,
+                ttnn.ShardOrientation.ROW_MAJOR,
                 False,
             ),
         )
-        model_config["CREATE_QKV_HEADS_INPUT_MEMCFG"] = ttnn.experimental.tensor.MemoryConfig(
-            ttnn.experimental.tensor.TensorMemoryLayout.WIDTH_SHARDED,
-            ttnn.experimental.tensor.BufferType.L1,
-            ttnn.experimental.tensor.ShardSpec(
+        model_config["CREATE_QKV_HEADS_INPUT_MEMCFG"] = ttnn.MemoryConfig(
+            ttnn.TensorMemoryLayout.WIDTH_SHARDED,
+            ttnn.BufferType.L1,
+            ttnn.ShardSpec(
                 shard_spec_1_cores_grid,
                 [
                     row_height,
                     total_width_per_group_of_qkv_heads,  # Must always be minimum a full group
                 ],
-                ttnn.experimental.tensor.ShardOrientation.ROW_MAJOR,
+                ttnn.ShardOrientation.ROW_MAJOR,
                 False,
             ),
         )
         model_config["CREATE_QKV_HEADS_OUTPUT_MEMCFG"] = HEIGHT_SHARDED_MEMCFG
-        model_config["CREATE_Q_HEADS_OUTPUT_MEMCFG"] = ttnn.experimental.tensor.MemoryConfig(
-            ttnn.experimental.tensor.TensorMemoryLayout.HEIGHT_SHARDED,
-            ttnn.experimental.tensor.BufferType.L1,
-            ttnn.experimental.tensor.ShardSpec(
+        model_config["CREATE_Q_HEADS_OUTPUT_MEMCFG"] = ttnn.MemoryConfig(
+            ttnn.TensorMemoryLayout.HEIGHT_SHARDED,
+            ttnn.BufferType.L1,
+            ttnn.ShardSpec(
                 shard_spec_16_cores_grid,
                 [
                     row_height,
                     head_dim,
                 ],
-                ttnn.experimental.tensor.ShardOrientation.ROW_MAJOR,
+                ttnn.ShardOrientation.ROW_MAJOR,
                 False,
             ),
         )
-        model_config["CREATE_KV_HEADS_OUTPUT_MEMCFG"] = ttnn.experimental.tensor.MemoryConfig(
-            ttnn.experimental.tensor.TensorMemoryLayout.HEIGHT_SHARDED,
-            ttnn.experimental.tensor.BufferType.L1,
-            ttnn.experimental.tensor.ShardSpec(
+        model_config["CREATE_KV_HEADS_OUTPUT_MEMCFG"] = ttnn.MemoryConfig(
+            ttnn.TensorMemoryLayout.HEIGHT_SHARDED,
+            ttnn.BufferType.L1,
+            ttnn.ShardSpec(
                 shard_spec_1_cores_grid,
                 [
                     row_height,
                     head_dim,
                 ],
-                ttnn.experimental.tensor.ShardOrientation.ROW_MAJOR,
+                ttnn.ShardOrientation.ROW_MAJOR,
                 False,
             ),
         )
         model_config["ROTARY_EMBEDDING_OUTPUT_MEMCFG"] = HEIGHT_SHARDED_MEMCFG
-        model_config["KV_CACHE_SLICE_OUTPUT_MEMCFG"] = ttnn.experimental.tensor.MemoryConfig(
-            ttnn.experimental.tensor.TensorMemoryLayout.HEIGHT_SHARDED,
-            ttnn.experimental.tensor.BufferType.L1,
-            ttnn.experimental.tensor.ShardSpec(
+        model_config["KV_CACHE_SLICE_OUTPUT_MEMCFG"] = ttnn.MemoryConfig(
+            ttnn.TensorMemoryLayout.HEIGHT_SHARDED,
+            ttnn.BufferType.L1,
+            ttnn.ShardSpec(
                 shard_spec_32_cores_grid,
                 [
                     1,  # Dynamic
                     head_dim,
                 ],
-                ttnn.experimental.tensor.ShardOrientation.ROW_MAJOR,
+                ttnn.ShardOrientation.ROW_MAJOR,
                 False,
             ),
         )
@@ -535,31 +527,31 @@ def get_decode_model_config(model_config_str, input_shape, num_devices):
         )
         model_config["POST_SOFTMAX_MM_OUTPUT_MEMCFG"] = HEIGHT_SHARDED_MEMCFG
         model_config["CONCAT_HEADS_OUTPUT_MEMCFG"] = WIDTH_SHARDED_MEMCFG
-        model_config["ATTN_ALL_GATHER_OUTPUT_MEMCFG"] = ttnn.experimental.tensor.MemoryConfig(
-            ttnn.experimental.tensor.TensorMemoryLayout.WIDTH_SHARDED,
-            ttnn.experimental.tensor.BufferType.L1,
-            ttnn.experimental.tensor.ShardSpec(
+        model_config["ATTN_ALL_GATHER_OUTPUT_MEMCFG"] = ttnn.MemoryConfig(
+            ttnn.TensorMemoryLayout.WIDTH_SHARDED,
+            ttnn.BufferType.L1,
+            ttnn.ShardSpec(
                 shard_spec_32_cores_grid,
                 [
                     row_height,
                     shard_width_hidden_dim_across_32_cores,
                 ],
-                ttnn.experimental.tensor.ShardOrientation.ROW_MAJOR,
+                ttnn.ShardOrientation.ROW_MAJOR,
                 False,
             ),
         )
         model_config["SELFOUT_MM_OUTPUT_MEMCFG"] = WIDTH_SHARDED_MEMCFG
         model_config["DENSE_H_TO_4H_MM_OUTPUT_MEMCFG"] = WIDTH_SHARDED_MEMCFG
-        model_config["MLP_REDUCE_SCATTER_OUTPUT_MEMCFG"] = ttnn.experimental.tensor.MemoryConfig(
-            ttnn.experimental.tensor.TensorMemoryLayout.WIDTH_SHARDED,
-            ttnn.experimental.tensor.BufferType.L1,
-            ttnn.experimental.tensor.ShardSpec(
+        model_config["MLP_REDUCE_SCATTER_OUTPUT_MEMCFG"] = ttnn.MemoryConfig(
+            ttnn.TensorMemoryLayout.WIDTH_SHARDED,
+            ttnn.BufferType.L1,
+            ttnn.ShardSpec(
                 shard_spec_32_cores_grid,
                 [
                     row_height,
                     shard_width_hidden_dim_per_device_across_32_cores,
                 ],
-                ttnn.experimental.tensor.ShardOrientation.ROW_MAJOR,
+                ttnn.ShardOrientation.ROW_MAJOR,
                 False,
             ),
         )
@@ -599,29 +591,29 @@ def get_decode_model_config(model_config_str, input_shape, num_devices):
             mcast_in0=True,
         )
 
-        model_config["FINAL_ALL_GATHER_OUTPUT_MEMCFG"] = ttnn.experimental.tensor.MemoryConfig(
-            ttnn.experimental.tensor.TensorMemoryLayout.WIDTH_SHARDED,
-            ttnn.experimental.tensor.BufferType.L1,
-            ttnn.experimental.tensor.ShardSpec(
+        model_config["FINAL_ALL_GATHER_OUTPUT_MEMCFG"] = ttnn.MemoryConfig(
+            ttnn.TensorMemoryLayout.WIDTH_SHARDED,
+            ttnn.BufferType.L1,
+            ttnn.ShardSpec(
                 shard_spec_32_cores_grid,
                 [
                     row_height,
                     shard_width_hidden_dim_across_32_cores,
                 ],
-                ttnn.experimental.tensor.ShardOrientation.ROW_MAJOR,
+                ttnn.ShardOrientation.ROW_MAJOR,
                 False,
             ),
         )
-        model_config["LN_F_OUTPUT_MEMCFG"] = ttnn.experimental.tensor.MemoryConfig(
-            ttnn.experimental.tensor.TensorMemoryLayout.WIDTH_SHARDED,
-            ttnn.experimental.tensor.BufferType.L1,
-            ttnn.experimental.tensor.ShardSpec(
+        model_config["LN_F_OUTPUT_MEMCFG"] = ttnn.MemoryConfig(
+            ttnn.TensorMemoryLayout.WIDTH_SHARDED,
+            ttnn.BufferType.L1,
+            ttnn.ShardSpec(
                 shard_spec_32_cores_grid,
                 [
                     row_height,
                     shard_width_hidden_dim_across_32_cores,
                 ],
-                ttnn.experimental.tensor.ShardOrientation.ROW_MAJOR,
+                ttnn.ShardOrientation.ROW_MAJOR,
                 False,
             ),
         )
@@ -658,27 +650,19 @@ def get_prefill_model_config(model_config_str, input_shape, num_devices):
     assert len(input_shape) == 2
     assert num_devices == 8, "Prefill is currently only supported on 8 devicess"
 
-    DRAM_MEMCFG = ttnn.experimental.tensor.MemoryConfig(
-        ttnn.experimental.tensor.TensorMemoryLayout.INTERLEAVED, ttnn.experimental.tensor.BufferType.DRAM
-    )
-    L1_MEMCFG = ttnn.experimental.tensor.MemoryConfig(
-        ttnn.experimental.tensor.TensorMemoryLayout.INTERLEAVED, ttnn.experimental.tensor.BufferType.L1
-    )
-    WIDTH_SHARDED_MEMCFG = ttnn.experimental.tensor.MemoryConfig(
-        ttnn.experimental.tensor.TensorMemoryLayout.WIDTH_SHARDED, ttnn.experimental.tensor.BufferType.L1
-    )
-    HEIGHT_SHARDED_MEMCFG = ttnn.experimental.tensor.MemoryConfig(
-        ttnn.experimental.tensor.TensorMemoryLayout.HEIGHT_SHARDED, ttnn.experimental.tensor.BufferType.L1
-    )
-    BFLOAT16_DTYPE = ttnn.experimental.tensor.DataType.BFLOAT16
-    BFP8_DTYPE = ttnn.experimental.tensor.DataType.BFLOAT8_B
-    BFP4_DTYPE = ttnn.experimental.tensor.DataType.BFLOAT4_B
+    DRAM_MEMCFG = ttnn.DRAM_MEMORY_CONFIG
+    L1_MEMCFG = ttnn.L1_MEMORY_CONFIG
+    WIDTH_SHARDED_MEMCFG = ttnn.MemoryConfig(ttnn.TensorMemoryLayout.WIDTH_SHARDED, ttnn.BufferType.L1)
+    HEIGHT_SHARDED_MEMCFG = ttnn.MemoryConfig(ttnn.TensorMemoryLayout.HEIGHT_SHARDED, ttnn.BufferType.L1)
+    BFLOAT16_DTYPE = ttnn.bfloat16
+    BFP8_DTYPE = ttnn.bfloat8_b
+    BFP4_DTYPE = ttnn.bfloat4_b
 
     # Set default dtype and mem_config based on model_config_str
     if model_config_str in ACCEPTABLE_PREFILL_MODEL_CONFIG_STRS:
         dtype_str, mem_config_str = model_config_str.split("-")
         mem_config = DRAM_MEMCFG if mem_config_str == "DRAM" else L1_MEMCFG
-        dtype = getattr(ttnn.experimental.tensor.DataType, dtype_str)
+        dtype = getattr(ttnn.DataType, dtype_str)
     else:
         raise NotImplementedError(f"Model config {model_config_str} is not supported!")
 
@@ -692,14 +676,14 @@ def get_prefill_model_config(model_config_str, input_shape, num_devices):
         "MAX_GRID_SIZE": (8, 4),
         "ALL_GATHER_NUM_LINKS": 2 if num_devices == 4 else 1,
         "DEFAULT_CACHE_PATH": Path(f"models/demos/t3000/falcon40b/datasets/"),
-        "COMPUTE_KERNEL_CONFIG": ttnn.experimental.tensor.WormholeComputeKernelConfig(
-            math_fidelity=ttnn.experimental.tensor.MathFidelity.HiFi2,
+        "COMPUTE_KERNEL_CONFIG": ttnn.WormholeComputeKernelConfig(
+            math_fidelity=ttnn.MathFidelity.HiFi2,
             math_approx_mode=True,
             fp32_dest_acc_en=True,
             packer_l1_acc=True,
         ),
-        "COMPUTE_KERNEL_FP16_ACC_CONFIG": ttnn.experimental.tensor.WormholeComputeKernelConfig(
-            math_fidelity=ttnn.experimental.tensor.MathFidelity.HiFi2,
+        "COMPUTE_KERNEL_FP16_ACC_CONFIG": ttnn.WormholeComputeKernelConfig(
+            math_fidelity=ttnn.MathFidelity.HiFi2,
             math_approx_mode=True,
             fp32_dest_acc_en=False,
             packer_l1_acc=True,
@@ -748,31 +732,31 @@ def get_prefill_model_config(model_config_str, input_shape, num_devices):
         assert num_cores in (16, 32, 64)
         if num_cores == 16:
             attention_mm_grid_size = (8, 2)
-            attn_core_range_set = ttnn.experimental.tensor.CoreRangeSet(
+            attn_core_range_set = ttnn.CoreRangeSet(
                 {
-                    ttnn.experimental.tensor.CoreRange(
-                        ttnn.experimental.tensor.CoreCoord(0, 0),
-                        ttnn.experimental.tensor.CoreCoord(7, 1),
+                    ttnn.CoreRange(
+                        ttnn.CoreCoord(0, 0),
+                        ttnn.CoreCoord(7, 1),
                     ),
                 }
             )
         elif num_cores == 32:
             attention_mm_grid_size = (8, 4)
-            attn_core_range_set = ttnn.experimental.tensor.CoreRangeSet(
+            attn_core_range_set = ttnn.CoreRangeSet(
                 {
-                    ttnn.experimental.tensor.CoreRange(
-                        ttnn.experimental.tensor.CoreCoord(0, 0),
-                        ttnn.experimental.tensor.CoreCoord(7, 3),
+                    ttnn.CoreRange(
+                        ttnn.CoreCoord(0, 0),
+                        ttnn.CoreCoord(7, 3),
                     ),
                 }
             )
         else:
             attention_mm_grid_size = (8, 8)
-            attn_core_range_set = ttnn.experimental.tensor.CoreRangeSet(
+            attn_core_range_set = ttnn.CoreRangeSet(
                 {
-                    ttnn.experimental.tensor.CoreRange(
-                        ttnn.experimental.tensor.CoreCoord(0, 0),
-                        ttnn.experimental.tensor.CoreCoord(7, 7),
+                    ttnn.CoreRange(
+                        ttnn.CoreCoord(0, 0),
+                        ttnn.CoreCoord(7, 7),
                     ),
                 }
             )
@@ -836,31 +820,31 @@ def get_prefill_model_config(model_config_str, input_shape, num_devices):
             hidden_size // mlpn_mm_grid_size[0],
         ]
 
-        model_config["MLP_INPUT_SHARD_LAYOUT"] = ttnn.experimental.tensor.TensorMemoryLayout.BLOCK_SHARDED
+        model_config["MLP_INPUT_SHARD_LAYOUT"] = ttnn.TensorMemoryLayout.BLOCK_SHARDED
 
-        model_config["DENSE_H_TO_4H_MM_OPTIMIZED_OUTPUT_MEMCFG"] = ttnn.experimental.tensor.MemoryConfig(
-            ttnn.experimental.tensor.TensorMemoryLayout.BLOCK_SHARDED,
-            ttnn.experimental.tensor.BufferType.L1,
-            ttnn.experimental.tensor.ShardSpec(
+        model_config["DENSE_H_TO_4H_MM_OPTIMIZED_OUTPUT_MEMCFG"] = ttnn.MemoryConfig(
+            ttnn.TensorMemoryLayout.BLOCK_SHARDED,
+            ttnn.BufferType.L1,
+            ttnn.ShardSpec(
                 mlp_core_range_set,
                 [
                     row_height // mlp_num_slices // mlpn_mm_grid_size[1],
                     hidden_size // 8 // mlpn_mm_grid_size[0],
                 ],
-                ttnn.experimental.tensor.ShardOrientation.ROW_MAJOR,
+                ttnn.ShardOrientation.ROW_MAJOR,
                 False,
             ),
         )
-        model_config["DENSE_4H_TO_H_MM_OPTIMIZED_OUTPUT_MEMCFG"] = ttnn.experimental.tensor.MemoryConfig(
-            ttnn.experimental.tensor.TensorMemoryLayout.BLOCK_SHARDED,
-            ttnn.experimental.tensor.BufferType.L1,
-            ttnn.experimental.tensor.ShardSpec(
+        model_config["DENSE_4H_TO_H_MM_OPTIMIZED_OUTPUT_MEMCFG"] = ttnn.MemoryConfig(
+            ttnn.TensorMemoryLayout.BLOCK_SHARDED,
+            ttnn.BufferType.L1,
+            ttnn.ShardSpec(
                 mlp_core_range_set,
                 [
                     row_height // mlp_num_slices // mlpn_mm_grid_size[1],
                     hidden_size // mlpn_mm_grid_size[0],
                 ],
-                ttnn.experimental.tensor.ShardOrientation.ROW_MAJOR,
+                ttnn.ShardOrientation.ROW_MAJOR,
                 False,
             ),
         )
@@ -870,31 +854,31 @@ def get_prefill_model_config(model_config_str, input_shape, num_devices):
             hidden_size // mlp_num_cores,
         ]
 
-        model_config["MLP_INPUT_SHARD_LAYOUT"] = ttnn.experimental.tensor.TensorMemoryLayout.WIDTH_SHARDED
+        model_config["MLP_INPUT_SHARD_LAYOUT"] = ttnn.TensorMemoryLayout.WIDTH_SHARDED
 
-        model_config["DENSE_H_TO_4H_MM_OPTIMIZED_OUTPUT_MEMCFG"] = ttnn.experimental.tensor.MemoryConfig(
-            ttnn.experimental.tensor.TensorMemoryLayout.WIDTH_SHARDED,
-            ttnn.experimental.tensor.BufferType.L1,
-            ttnn.experimental.tensor.ShardSpec(
+        model_config["DENSE_H_TO_4H_MM_OPTIMIZED_OUTPUT_MEMCFG"] = ttnn.MemoryConfig(
+            ttnn.TensorMemoryLayout.WIDTH_SHARDED,
+            ttnn.BufferType.L1,
+            ttnn.ShardSpec(
                 mlp_core_range_set,
                 [
                     row_height // mlp_num_slices,
                     hidden_size // 8 // mlp_num_cores,
                 ],
-                ttnn.experimental.tensor.ShardOrientation.ROW_MAJOR,
+                ttnn.ShardOrientation.ROW_MAJOR,
                 False,
             ),
         )
-        model_config["DENSE_4H_TO_H_MM_OPTIMIZED_OUTPUT_MEMCFG"] = ttnn.experimental.tensor.MemoryConfig(
-            ttnn.experimental.tensor.TensorMemoryLayout.WIDTH_SHARDED,
-            ttnn.experimental.tensor.BufferType.L1,
-            ttnn.experimental.tensor.ShardSpec(
+        model_config["DENSE_4H_TO_H_MM_OPTIMIZED_OUTPUT_MEMCFG"] = ttnn.MemoryConfig(
+            ttnn.TensorMemoryLayout.WIDTH_SHARDED,
+            ttnn.BufferType.L1,
+            ttnn.ShardSpec(
                 mlp_core_range_set,
                 [
                     row_height // mlp_num_slices,
                     hidden_size // mlp_num_cores,
                 ],
-                ttnn.experimental.tensor.ShardOrientation.ROW_MAJOR,
+                ttnn.ShardOrientation.ROW_MAJOR,
                 False,
             ),
         )
@@ -926,25 +910,25 @@ def get_sharded_layernorm_specs_for_seqlen(
     layernorm_shard_height_hidden_dim = partial_seqlen // layernorm_num_cores_y
     layernorm_shard_width_hidden_dim = hidden_size // layernorm_num_cores_x
 
-    core_range_block_sharded_layernorm = ttnn.experimental.tensor.CoreRangeSet(
+    core_range_block_sharded_layernorm = ttnn.CoreRangeSet(
         {
-            ttnn.experimental.tensor.CoreRange(
-                ttnn.experimental.tensor.CoreCoord(0, 0),
-                ttnn.experimental.tensor.CoreCoord(layernorm_num_cores_x - 1, layernorm_num_cores_y - 1),
+            ttnn.CoreRange(
+                ttnn.CoreCoord(0, 0),
+                ttnn.CoreCoord(layernorm_num_cores_x - 1, layernorm_num_cores_y - 1),
             ),
         }
     )
 
-    layernorm_block_sharded_mem_config = ttnn.experimental.tensor.MemoryConfig(
-        ttnn.experimental.tensor.TensorMemoryLayout.BLOCK_SHARDED,
-        ttnn.experimental.tensor.BufferType.L1,
-        ttnn.experimental.tensor.ShardSpec(
+    layernorm_block_sharded_mem_config = ttnn.MemoryConfig(
+        ttnn.TensorMemoryLayout.BLOCK_SHARDED,
+        ttnn.BufferType.L1,
+        ttnn.ShardSpec(
             core_range_block_sharded_layernorm,
             [
                 layernorm_shard_height_hidden_dim,
                 layernorm_shard_width_hidden_dim,
             ],
-            ttnn.experimental.tensor.ShardOrientation.ROW_MAJOR,
+            ttnn.ShardOrientation.ROW_MAJOR,
             False,
         ),
     )

--- a/models/demos/t3000/llama2_70b/tests/unit_tests/test_rotary_embedding_llama.py
+++ b/models/demos/t3000/llama2_70b/tests/unit_tests/test_rotary_embedding_llama.py
@@ -241,9 +241,9 @@ def test_rotary_embedding_llama(
             inp.reshape(-1).tolist(),
             inp.shape,
             ttnn.bfloat16,
-            ttnn.Layout.ROW_MAJOR,
+            ttnn.ROW_MAJOR_LAYOUT,
         )
-        .to(ttnn.Layout.TILE)
+        .to(ttnn.TILE_LAYOUT)
         .to(devices[0])
     )
 
@@ -299,9 +299,9 @@ def test_rotary_embedding_llama_with_program_cache(
                 inp.reshape(-1).tolist(),
                 inp.shape,
                 ttnn.bfloat16,
-                ttnn.Layout.ROW_MAJOR,
+                ttnn.ROW_MAJOR_LAYOUT,
             )
-            .to(ttnn.Layout.TILE)
+            .to(ttnn.TILE_LAYOUT)
             .to(devices[0])
         )
 

--- a/models/demos/t3000/llama2_70b/tt/llama_decoder_optimized.py
+++ b/models/demos/t3000/llama2_70b/tt/llama_decoder_optimized.py
@@ -264,7 +264,7 @@ class TtLlamaDecoder_optimized:
         # xs_replicated = []
         # for i in range(self.num_devices):
         #     xs_replicated.append(
-        #         ttnn.experimental.tensor.typecast(ttnn.experimental.tensor.clone(xs[i]), dtype=ttnn.bfloat8_b)
+        #         ttnn.experimental.tensor.typecast(ttnn.clone(xs[i]), dtype=ttnn.bfloat8_b)
         #     )
 
         attn_norm_interleaved = self.tt_distributed_rmsnorm(xs, self.norm_eps, self.attn_norm_sharded)

--- a/models/demos/t3000/llama2_70b/tt/llama_mlp_optimized.py
+++ b/models/demos/t3000/llama2_70b/tt/llama_mlp_optimized.py
@@ -72,11 +72,11 @@ class TtLlamaMLP_optimized:
 
         # w1: 8k x 4k. width-sharded on 12 banks, 4224 over 12 banks.
         device = self.device_mesh.get_device(0)
-        weight_grid = ttnn.experimental.tensor.CoreRangeSet(
+        weight_grid = ttnn.CoreRangeSet(
             {
-                ttnn.experimental.tensor.CoreRange(
-                    ttnn.experimental.tensor.CoreCoord(0, 0),
-                    ttnn.experimental.tensor.CoreCoord(device.dram_grid_size().x - 1, device.dram_grid_size().y - 1),
+                ttnn.CoreRange(
+                    ttnn.CoreCoord(0, 0),
+                    ttnn.CoreCoord(device.dram_grid_size().x - 1, device.dram_grid_size().y - 1),
                 )
             }
         )

--- a/models/demos/t3000/mixtral8x7b/demo/demo.py
+++ b/models/demos/t3000/mixtral8x7b/demo/demo.py
@@ -118,8 +118,8 @@ def run_mixtral_demo(user_input, batch_size, device_mesh, instruct_mode, is_ci_e
         decode_input_11BH = ttnn.reshape(decode_input_11BH, ttnn.Shape([1, 1, batch_size, model_args.dim]))
 
         decode_input_11BH = ttnn.to_layout(decode_input_11BH, layout=ttnn.TILE_LAYOUT)
-        # decode_input_11BH = [ttnn.experimental.tensor.tilize(decode_input_11BH[i]) for i in range(len(devices))]
-        # decode_input_11BH = [ttnn.experimental.tensor.tilize_with_val_padding(decode_input_11BH[i], ) for i in range(len(devices))]")
+        # decode_input_11BH = [ttnn.tilize(decode_input_11BH[i]) for i in range(len(devices))]
+        # decode_input_11BH = [ttnn.tilize_with_val_padding(decode_input_11BH[i], ) for i in range(len(devices))]")
 
     # Prepare inputs for decode mode (rotary embeddings, attention mask, padding)
     current_rot_mat, rot_matrix = get_single_rot_mat(

--- a/models/demos/t3000/mixtral8x7b/demo/demo_with_prefill.py
+++ b/models/demos/t3000/mixtral8x7b/demo/demo_with_prefill.py
@@ -232,7 +232,7 @@ def run_mixtral_demo(user_input, batch_size, device_mesh, instruct_mode, max_pre
 
         # Device synchrozization ensures profiler is accurate in end-to-end timing
         for dev in device_mesh.get_devices():
-            ttnn.device.synchronize_device(dev)
+            ttnn.synchronize_device(dev)
 
         profiler.end(f"inference_prefill")
         logger.info(f"Prefill finished [{prefill_seq_len} tokens]")

--- a/models/demos/t3000/mixtral8x7b/tests/test_mixtral_perf.py
+++ b/models/demos/t3000/mixtral8x7b/tests/test_mixtral_perf.py
@@ -342,7 +342,7 @@ def run_inference_prefill(tt_model, model_args, prefill_seq_len, device_mesh, pt
         profiler.start(f"e2e_prefill_inference_sync_{batch_id}")
         devices = device_mesh.get_devices()
         for device in devices:
-            ttnn.device.synchronize_device(device)
+            ttnn.synchronize_device(device)
         profiler.end(f"e2e_prefill_inference_sync_{batch_id}")
 
 

--- a/models/demos/t3000/mixtral8x7b/tests/test_mixtral_perf_benchmark.py
+++ b/models/demos/t3000/mixtral8x7b/tests/test_mixtral_perf_benchmark.py
@@ -360,7 +360,7 @@ def run_inference_prefill(profiler, tt_model, model_args, prefill_seq_len, devic
         profiler.start(f"e2e_prefill_inference_get_output_{batch_id}")
         devices = device_mesh.get_devices()
         for device in devices:
-            ttnn.device.synchronize_device(device)
+            ttnn.synchronize_device(device)
         profiler.end(f"e2e_prefill_inference_get_output_{batch_id}")
 
 

--- a/models/demos/t3000/mixtral8x7b/tt/model_config.py
+++ b/models/demos/t3000/mixtral8x7b/tt/model_config.py
@@ -111,14 +111,14 @@ class TtModelArgs:
         self.model_config.update({f"{key}_TILE": ttnn.TILE_LAYOUT for key in self.OP_KEYS if "LAYOUT" in key})
 
         # Set configurations for sharded type
-        self.model_config["WIDTH_SHARDED_MEMCFG"] = ttnn.experimental.tensor.MemoryConfig(
-            ttnn.experimental.tensor.TensorMemoryLayout.WIDTH_SHARDED, ttnn.experimental.tensor.BufferType.L1
+        self.model_config["WIDTH_SHARDED_MEMCFG"] = ttnn.MemoryConfig(
+            ttnn.TensorMemoryLayout.WIDTH_SHARDED, ttnn.BufferType.L1
         )
-        self.model_config["HEIGHT_SHARDED_MEMCFG"] = ttnn.experimental.tensor.MemoryConfig(
-            ttnn.experimental.tensor.TensorMemoryLayout.HEIGHT_SHARDED, ttnn.experimental.tensor.BufferType.L1
+        self.model_config["HEIGHT_SHARDED_MEMCFG"] = ttnn.MemoryConfig(
+            ttnn.TensorMemoryLayout.HEIGHT_SHARDED, ttnn.BufferType.L1
         )
-        self.model_config["BLOCK_SHARDED_MEMCFG"] = ttnn.experimental.tensor.MemoryConfig(
-            ttnn.experimental.tensor.TensorMemoryLayout.BLOCK_SHARDED, ttnn.experimental.tensor.BufferType.L1
+        self.model_config["BLOCK_SHARDED_MEMCFG"] = ttnn.MemoryConfig(
+            ttnn.TensorMemoryLayout.BLOCK_SHARDED, ttnn.BufferType.L1
         )
 
         # Useful core grid based on batch size
@@ -187,8 +187,8 @@ class TtModelArgs:
             k_chunk_size=32,
         )
 
-        self.model_config["SDPA_DECODE_COMPUTE_PROGCFG"] = ttnn.experimental.tensor.WormholeComputeKernelConfig(
-            math_fidelity=ttnn.experimental.tensor.MathFidelity.HiFi4,
+        self.model_config["SDPA_DECODE_COMPUTE_PROGCFG"] = ttnn.WormholeComputeKernelConfig(
+            math_fidelity=ttnn.MathFidelity.HiFi4,
             math_approx_mode=False,
             fp32_dest_acc_en=False,
             packer_l1_acc=False,
@@ -368,8 +368,8 @@ class TtModelArgs:
             fused_activation=None,
             fuse_batch=False,
         )
-        self.model_config["PREFILL_MLP_COMPUTE_CONFIG"] = ttnn.experimental.tensor.WormholeComputeKernelConfig(
-            math_fidelity=ttnn.experimental.tensor.MathFidelity.LoFi,
+        self.model_config["PREFILL_MLP_COMPUTE_CONFIG"] = ttnn.WormholeComputeKernelConfig(
+            math_fidelity=ttnn.MathFidelity.LoFi,
             math_approx_mode=True,
             fp32_dest_acc_en=False,
             packer_l1_acc=True,
@@ -427,14 +427,14 @@ class TtModelArgs:
             packer_l1_acc=True,
         )
 
-        self.model_config["ROT_MAT_COMPUTE_KERNEL_CONFIG"] = ttnn.experimental.tensor.WormholeComputeKernelConfig(
-            math_fidelity=ttnn.experimental.tensor.MathFidelity.HiFi4,  # Highest fidelity
+        self.model_config["ROT_MAT_COMPUTE_KERNEL_CONFIG"] = ttnn.WormholeComputeKernelConfig(
+            math_fidelity=ttnn.MathFidelity.HiFi4,  # Highest fidelity
             math_approx_mode=False,
             fp32_dest_acc_en=True,
             packer_l1_acc=True,
         )
 
-        self.model_config["GATE_MM_OUTPUT_KERNEL_CONFIG"] = ttnn.experimental.tensor.WormholeComputeKernelConfig(
+        self.model_config["GATE_MM_OUTPUT_KERNEL_CONFIG"] = ttnn.WormholeComputeKernelConfig(
             math_fidelity=ttnn.MathFidelity.HiFi4,
             fp32_dest_acc_en=True,
             packer_l1_acc=True,

--- a/models/demos/tg/llama3_70b/tt/llama_attention_galaxy.py
+++ b/models/demos/tg/llama3_70b/tt/llama_attention_galaxy.py
@@ -593,7 +593,7 @@ class TtLlamaAttention_galaxy:
         single_user_key_layer = self.prefill_prepare_tensor_for_kv_cache(key_layer, user_id)
 
         # Fill cache with multi-device tensor
-        ttnn.experimental.tensor.fill_cache(
+        ttnn.fill_cache(
             keys_reshaped,
             ttnn.experimental.typecast(single_user_key_layer, ttnn.bfloat8_b, memory_config=ttnn.DRAM_MEMORY_CONFIG),
             user_id % self.batch_size_per_device_group,
@@ -608,14 +608,14 @@ class TtLlamaAttention_galaxy:
 
         single_user_value_layer = self.prefill_prepare_tensor_for_kv_cache(value_layer, user_id)
 
-        ttnn.experimental.tensor.fill_cache(
+        ttnn.fill_cache(
             values_reshaped,
             ttnn.experimental.typecast(single_user_value_layer, ttnn.bfloat8_b, memory_config=ttnn.DRAM_MEMORY_CONFIG),
             user_id % self.batch_size_per_device_group,
         )
 
         # SDPA
-        attn_output = ttnn.experimental.operations.primary.transformers.scaled_dot_product_attention(
+        attn_output = ttnn.transformers.scaled_dot_product_attention(
             query_layer,
             key_layer,
             value_layer,

--- a/models/demos/ttnn_falcon7b/tt/falcon_attention.py
+++ b/models/demos/ttnn_falcon7b/tt/falcon_attention.py
@@ -161,9 +161,7 @@ class TtFalconAttention:
                 attn_weights = ttnn.experimental.attn_matmul(
                     query_layer,
                     key_layer_transposed,
-                    compute_with_storage_grid_size=ttnn.experimental.tensor.CoreCoord(
-                        self.core_grid.x, self.core_grid.y
-                    ),
+                    compute_with_storage_grid_size=ttnn.CoreCoord(self.core_grid.x, self.core_grid.y),
                     memory_config=self.model_config["PRE_SOFTMAX_MM_OUTPUT_MEMCFG"],
                     dtype=self.model_config["PRE_SOFTMAX_MM_OUTPUT_DTYPE"],  # Must be BFLOAT16
                 )
@@ -171,9 +169,7 @@ class TtFalconAttention:
                 attn_weights = ttnn.experimental.group_attn_matmul(
                     query_layer,
                     key_layer_transposed,
-                    compute_with_storage_grid_size=ttnn.experimental.tensor.CoreCoord(
-                        self.core_grid.x, self.core_grid.y
-                    ),
+                    compute_with_storage_grid_size=ttnn.CoreCoord(self.core_grid.x, self.core_grid.y),
                     memory_config=self.model_config["PRE_SOFTMAX_MM_OUTPUT_MEMCFG"],
                     dtype=self.model_config["PRE_SOFTMAX_MM_OUTPUT_DTYPE"],  # Must be BFLOAT16
                 )
@@ -228,9 +224,7 @@ class TtFalconAttention:
                 attn_output = ttnn.experimental.attn_matmul(
                     attn_weights,
                     value_layer,
-                    compute_with_storage_grid_size=ttnn.experimental.tensor.CoreCoord(
-                        self.core_grid.x, self.core_grid.y
-                    ),
+                    compute_with_storage_grid_size=ttnn.CoreCoord(self.core_grid.x, self.core_grid.y),
                     memory_config=self.model_config["POST_SOFTMAX_MM_OUTPUT_MEMCFG"],
                     dtype=self.model_config["POST_SOFTMAX_MM_OUTPUT_DTYPE"],  # Must be BFLOAT16
                 )
@@ -238,9 +232,7 @@ class TtFalconAttention:
                 attn_output = ttnn.experimental.group_attn_matmul(
                     attn_weights,
                     value_layer,
-                    compute_with_storage_grid_size=ttnn.experimental.tensor.CoreCoord(
-                        self.core_grid.x, self.core_grid.y
-                    ),
+                    compute_with_storage_grid_size=ttnn.CoreCoord(self.core_grid.x, self.core_grid.y),
                     memory_config=self.model_config["POST_SOFTMAX_MM_OUTPUT_MEMCFG"],
                     dtype=self.model_config["POST_SOFTMAX_MM_OUTPUT_DTYPE"],  # Must be BFLOAT16
                 )

--- a/models/demos/ttnn_falcon7b/tt/model_config.py
+++ b/models/demos/ttnn_falcon7b/tt/model_config.py
@@ -111,7 +111,7 @@ def get_model_config(model_config_str):
         "DEFAULT_DTYPE": dtype,
         "DEFAULT_MEMCFG": mem_config,
         "MOVE_DECODER_OUTPUT_BOOL": False,
-    }  # DEFAULT_MEMCFG also used to determine banking for ttl.device.InitializeDevice
+    }  # DEFAULT_MEMCFG also used to determine banking for ttnn.experimental.device.InitializeDevice
     model_config.update({f"{key}_MEMCFG": mem_config for key in OP_KEYS if key not in NO_MEMCFG})
     model_config.update({f"{key}_DTYPE": dtype for key in OP_KEYS if key not in NO_DTYPE})
 

--- a/models/demos/ttnn_resnet/tt/ttnn_functional_resnet50.py
+++ b/models/demos/ttnn_resnet/tt/ttnn_functional_resnet50.py
@@ -709,11 +709,11 @@ class resnet50:
         )
 
         grid_size = (8, 4)
-        shard_grid = ttnn.experimental.tensor.CoreRangeSet(
+        shard_grid = ttnn.CoreRangeSet(
             {
-                ttnn.experimental.tensor.CoreRange(
-                    ttnn.experimental.tensor.CoreCoord(0, 0),
-                    ttnn.experimental.tensor.CoreCoord(grid_size[0] - 1, grid_size[1] - 1),
+                ttnn.CoreRange(
+                    ttnn.CoreCoord(0, 0),
+                    ttnn.CoreCoord(grid_size[0] - 1, grid_size[1] - 1),
                 )
             }
         )
@@ -721,11 +721,9 @@ class resnet50:
             x.volume() // x.get_legacy_shape()[-1],
             x.get_legacy_shape()[-1] // (grid_size[0] * grid_size[1]),
         ]
-        shard_spec = ttnn.experimental.tensor.ShardSpec(
-            shard_grid, shard_shape, ttnn.experimental.tensor.ShardOrientation.ROW_MAJOR, False
-        )
-        width_sharded_mem_config = ttnn.types.MemoryConfig(
-            ttnn.types.TensorMemoryLayout.WIDTH_SHARDED, ttnn.types.BufferType.L1, shard_spec
+        shard_spec = ttnn.ShardSpec(shard_grid, shard_shape, ttnn.ShardOrientation.ROW_MAJOR, False)
+        width_sharded_mem_config = ttnn.MemoryConfig(
+            ttnn.TensorMemoryLayout.WIDTH_SHARDED, ttnn.BufferType.L1, shard_spec
         )
         x = ttnn.to_memory_config(x, width_sharded_mem_config)
         unpadded_shape = x.get_legacy_shape()

--- a/models/demos/ttnn_resnet/tt/ttnn_functional_resnet50_large_new_conv_api.py
+++ b/models/demos/ttnn_resnet/tt/ttnn_functional_resnet50_large_new_conv_api.py
@@ -733,11 +733,11 @@ class resnet50:
         )
 
         grid_size = (8, 4)
-        shard_grid = ttnn.experimental.tensor.CoreRangeSet(
+        shard_grid = ttnn.CoreRangeSet(
             {
-                ttnn.experimental.tensor.CoreRange(
-                    ttnn.experimental.tensor.CoreCoord(0, 0),
-                    ttnn.experimental.tensor.CoreCoord(grid_size[0] - 1, grid_size[1] - 1),
+                ttnn.CoreRange(
+                    ttnn.CoreCoord(0, 0),
+                    ttnn.CoreCoord(grid_size[0] - 1, grid_size[1] - 1),
                 )
             }
         )
@@ -745,11 +745,9 @@ class resnet50:
             x.volume() // x.get_legacy_shape()[-1],
             x.get_legacy_shape()[-1] // (grid_size[0] * grid_size[1]),
         ]
-        shard_spec = ttnn.experimental.tensor.ShardSpec(
-            shard_grid, shard_shape, ttnn.experimental.tensor.ShardOrientation.ROW_MAJOR, False
-        )
-        width_sharded_mem_config = ttnn.types.MemoryConfig(
-            ttnn.types.TensorMemoryLayout.WIDTH_SHARDED, ttnn.types.BufferType.L1, shard_spec
+        shard_spec = ttnn.ShardSpec(shard_grid, shard_shape, ttnn.ShardOrientation.ROW_MAJOR, False)
+        width_sharded_mem_config = ttnn.MemoryConfig(
+            ttnn.TensorMemoryLayout.WIDTH_SHARDED, ttnn.BufferType.L1, shard_spec
         )
         x = ttnn.to_memory_config(x, width_sharded_mem_config)
         unpadded_shape = x.get_legacy_shape()
@@ -958,11 +956,11 @@ class resnet50:
         )
 
         grid_size = (8, 4)
-        shard_grid = ttnn.experimental.tensor.CoreRangeSet(
+        shard_grid = ttnn.CoreRangeSet(
             {
-                ttnn.experimental.tensor.CoreRange(
-                    ttnn.experimental.tensor.CoreCoord(0, 0),
-                    ttnn.experimental.tensor.CoreCoord(grid_size[0] - 1, grid_size[1] - 1),
+                ttnn.CoreRange(
+                    ttnn.CoreCoord(0, 0),
+                    ttnn.CoreCoord(grid_size[0] - 1, grid_size[1] - 1),
                 )
             }
         )
@@ -970,11 +968,9 @@ class resnet50:
             x.volume() // x.get_legacy_shape()[-1],
             x.get_legacy_shape()[-1] // (grid_size[0] * grid_size[1]),
         ]
-        shard_spec = ttnn.experimental.tensor.ShardSpec(
-            shard_grid, shard_shape, ttnn.experimental.tensor.ShardOrientation.ROW_MAJOR, False
-        )
-        width_sharded_mem_config = ttnn.types.MemoryConfig(
-            ttnn.types.TensorMemoryLayout.WIDTH_SHARDED, ttnn.types.BufferType.L1, shard_spec
+        shard_spec = ttnn.ShardSpec(shard_grid, shard_shape, ttnn.ShardOrientation.ROW_MAJOR, False)
+        width_sharded_mem_config = ttnn.MemoryConfig(
+            ttnn.TensorMemoryLayout.WIDTH_SHARDED, ttnn.BufferType.L1, shard_spec
         )
         x = ttnn.to_memory_config(x, width_sharded_mem_config)
         unpadded_shape = x.get_legacy_shape()

--- a/models/demos/ttnn_resnet/tt/ttnn_functional_resnet50_new_conv_api.py
+++ b/models/demos/ttnn_resnet/tt/ttnn_functional_resnet50_new_conv_api.py
@@ -1074,11 +1074,11 @@ class resnet50:
         )
 
         grid_size = (8, 4)
-        shard_grid = ttnn.experimental.tensor.CoreRangeSet(
+        shard_grid = ttnn.CoreRangeSet(
             {
-                ttnn.experimental.tensor.CoreRange(
-                    ttnn.experimental.tensor.CoreCoord(0, 0),
-                    ttnn.experimental.tensor.CoreCoord(grid_size[0] - 1, grid_size[1] - 1),
+                ttnn.CoreRange(
+                    ttnn.CoreCoord(0, 0),
+                    ttnn.CoreCoord(grid_size[0] - 1, grid_size[1] - 1),
                 )
             }
         )
@@ -1086,11 +1086,9 @@ class resnet50:
             x.volume() // x.get_legacy_shape()[-1],
             x.get_legacy_shape()[-1] // (grid_size[0] * grid_size[1]),
         ]
-        shard_spec = ttnn.experimental.tensor.ShardSpec(
-            shard_grid, shard_shape, ttnn.experimental.tensor.ShardOrientation.ROW_MAJOR, False
-        )
-        width_sharded_mem_config = ttnn.types.MemoryConfig(
-            ttnn.types.TensorMemoryLayout.WIDTH_SHARDED, ttnn.types.BufferType.L1, shard_spec
+        shard_spec = ttnn.ShardSpec(shard_grid, shard_shape, ttnn.ShardOrientation.ROW_MAJOR, False)
+        width_sharded_mem_config = ttnn.MemoryConfig(
+            ttnn.TensorMemoryLayout.WIDTH_SHARDED, ttnn.BufferType.L1, shard_spec
         )
         x = ttnn.to_memory_config(x, width_sharded_mem_config)
 

--- a/models/demos/ttnn_resnet/tt/ttnn_functional_resnet50_xlarge_new_conv_api.py
+++ b/models/demos/ttnn_resnet/tt/ttnn_functional_resnet50_xlarge_new_conv_api.py
@@ -727,11 +727,11 @@ class resnet50:
         )
 
         grid_size = (8, 4)
-        shard_grid = ttnn.experimental.tensor.CoreRangeSet(
+        shard_grid = ttnn.CoreRangeSet(
             {
-                ttnn.experimental.tensor.CoreRange(
-                    ttnn.experimental.tensor.CoreCoord(0, 0),
-                    ttnn.experimental.tensor.CoreCoord(grid_size[0] - 1, grid_size[1] - 1),
+                ttnn.CoreRange(
+                    ttnn.CoreCoord(0, 0),
+                    ttnn.CoreCoord(grid_size[0] - 1, grid_size[1] - 1),
                 )
             }
         )
@@ -739,11 +739,9 @@ class resnet50:
             x.volume() // x.get_legacy_shape()[-1],
             x.get_legacy_shape()[-1] // (grid_size[0] * grid_size[1]),
         ]
-        shard_spec = ttnn.experimental.tensor.ShardSpec(
-            shard_grid, shard_shape, ttnn.experimental.tensor.ShardOrientation.ROW_MAJOR, False
-        )
-        width_sharded_mem_config = ttnn.types.MemoryConfig(
-            ttnn.types.TensorMemoryLayout.WIDTH_SHARDED, ttnn.types.BufferType.L1, shard_spec
+        shard_spec = ttnn.ShardSpec(shard_grid, shard_shape, ttnn.ShardOrientation.ROW_MAJOR, False)
+        width_sharded_mem_config = ttnn.MemoryConfig(
+            ttnn.TensorMemoryLayout.WIDTH_SHARDED, ttnn.BufferType.L1, shard_spec
         )
         x = ttnn.to_memory_config(x, width_sharded_mem_config)
         unpadded_shape = x.get_legacy_shape()
@@ -935,11 +933,11 @@ class resnet50:
         )
 
         grid_size = (8, 4)
-        shard_grid = ttnn.experimental.tensor.CoreRangeSet(
+        shard_grid = ttnn.CoreRangeSet(
             {
-                ttnn.experimental.tensor.CoreRange(
-                    ttnn.experimental.tensor.CoreCoord(0, 0),
-                    ttnn.experimental.tensor.CoreCoord(grid_size[0] - 1, grid_size[1] - 1),
+                ttnn.CoreRange(
+                    ttnn.CoreCoord(0, 0),
+                    ttnn.CoreCoord(grid_size[0] - 1, grid_size[1] - 1),
                 )
             }
         )
@@ -947,11 +945,9 @@ class resnet50:
             x.volume() // x.get_legacy_shape()[-1],
             x.get_legacy_shape()[-1] // (grid_size[0] * grid_size[1]),
         ]
-        shard_spec = ttnn.experimental.tensor.ShardSpec(
-            shard_grid, shard_shape, ttnn.experimental.tensor.ShardOrientation.ROW_MAJOR, False
-        )
-        width_sharded_mem_config = ttnn.types.MemoryConfig(
-            ttnn.types.TensorMemoryLayout.WIDTH_SHARDED, ttnn.types.BufferType.L1, shard_spec
+        shard_spec = ttnn.ShardSpec(shard_grid, shard_shape, ttnn.ShardOrientation.ROW_MAJOR, False)
+        width_sharded_mem_config = ttnn.MemoryConfig(
+            ttnn.TensorMemoryLayout.WIDTH_SHARDED, ttnn.BufferType.L1, shard_spec
         )
         x = ttnn.to_memory_config(x, width_sharded_mem_config)
         unpadded_shape = x.get_legacy_shape()

--- a/models/demos/ttnn_resnet/tt/ttnn_functional_resnet50_xlarge_new_conv_api_24.py
+++ b/models/demos/ttnn_resnet/tt/ttnn_functional_resnet50_xlarge_new_conv_api_24.py
@@ -756,11 +756,11 @@ class resnet50:
         )
 
         grid_size = (8, 4)
-        shard_grid = ttnn.experimental.tensor.CoreRangeSet(
+        shard_grid = ttnn.CoreRangeSet(
             {
-                ttnn.experimental.tensor.CoreRange(
-                    ttnn.experimental.tensor.CoreCoord(0, 0),
-                    ttnn.experimental.tensor.CoreCoord(grid_size[0] - 1, grid_size[1] - 1),
+                ttnn.CoreRange(
+                    ttnn.CoreCoord(0, 0),
+                    ttnn.CoreCoord(grid_size[0] - 1, grid_size[1] - 1),
                 )
             }
         )
@@ -768,11 +768,9 @@ class resnet50:
             x.volume() // x.get_legacy_shape()[-1],
             x.get_legacy_shape()[-1] // (grid_size[0] * grid_size[1]),
         ]
-        shard_spec = ttnn.experimental.tensor.ShardSpec(
-            shard_grid, shard_shape, ttnn.experimental.tensor.ShardOrientation.ROW_MAJOR, False
-        )
-        width_sharded_mem_config = ttnn.types.MemoryConfig(
-            ttnn.types.TensorMemoryLayout.WIDTH_SHARDED, ttnn.types.BufferType.L1, shard_spec
+        shard_spec = ttnn.ShardSpec(shard_grid, shard_shape, ttnn.ShardOrientation.ROW_MAJOR, False)
+        width_sharded_mem_config = ttnn.MemoryConfig(
+            ttnn.TensorMemoryLayout.WIDTH_SHARDED, ttnn.BufferType.L1, shard_spec
         )
         x = ttnn.to_memory_config(x, width_sharded_mem_config)
         unpadded_shape = x.get_legacy_shape()
@@ -960,11 +958,11 @@ class resnet50:
         )
 
         grid_size = (8, 4)
-        shard_grid = ttnn.experimental.tensor.CoreRangeSet(
+        shard_grid = ttnn.CoreRangeSet(
             {
-                ttnn.experimental.tensor.CoreRange(
-                    ttnn.experimental.tensor.CoreCoord(0, 0),
-                    ttnn.experimental.tensor.CoreCoord(grid_size[0] - 1, grid_size[1] - 1),
+                ttnn.CoreRange(
+                    ttnn.CoreCoord(0, 0),
+                    ttnn.CoreCoord(grid_size[0] - 1, grid_size[1] - 1),
                 )
             }
         )
@@ -972,11 +970,9 @@ class resnet50:
             x.volume() // x.get_legacy_shape()[-1],
             x.get_legacy_shape()[-1] // (grid_size[0] * grid_size[1]),
         ]
-        shard_spec = ttnn.experimental.tensor.ShardSpec(
-            shard_grid, shard_shape, ttnn.experimental.tensor.ShardOrientation.ROW_MAJOR, False
-        )
-        width_sharded_mem_config = ttnn.types.MemoryConfig(
-            ttnn.types.TensorMemoryLayout.WIDTH_SHARDED, ttnn.types.BufferType.L1, shard_spec
+        shard_spec = ttnn.ShardSpec(shard_grid, shard_shape, ttnn.ShardOrientation.ROW_MAJOR, False)
+        width_sharded_mem_config = ttnn.MemoryConfig(
+            ttnn.TensorMemoryLayout.WIDTH_SHARDED, ttnn.BufferType.L1, shard_spec
         )
         x = ttnn.to_memory_config(x, width_sharded_mem_config)
         unpadded_shape = x.get_legacy_shape()

--- a/models/demos/ttnn_resnet/tt/ttnn_functional_resnet50_xxlarge_new_conv_api.py
+++ b/models/demos/ttnn_resnet/tt/ttnn_functional_resnet50_xxlarge_new_conv_api.py
@@ -809,11 +809,11 @@ class resnet50:
         )
 
         grid_size = (8, 4)
-        shard_grid = ttnn.experimental.tensor.CoreRangeSet(
+        shard_grid = ttnn.CoreRangeSet(
             {
-                ttnn.experimental.tensor.CoreRange(
-                    ttnn.experimental.tensor.CoreCoord(0, 0),
-                    ttnn.experimental.tensor.CoreCoord(grid_size[0] - 1, grid_size[1] - 1),
+                ttnn.CoreRange(
+                    ttnn.CoreCoord(0, 0),
+                    ttnn.CoreCoord(grid_size[0] - 1, grid_size[1] - 1),
                 )
             }
         )
@@ -821,11 +821,9 @@ class resnet50:
             x.volume() // x.get_legacy_shape()[-1],
             x.get_legacy_shape()[-1] // (grid_size[0] * grid_size[1]),
         ]
-        shard_spec = ttnn.experimental.tensor.ShardSpec(
-            shard_grid, shard_shape, ttnn.experimental.tensor.ShardOrientation.ROW_MAJOR, False
-        )
-        width_sharded_mem_config = ttnn.types.MemoryConfig(
-            ttnn.types.TensorMemoryLayout.WIDTH_SHARDED, ttnn.types.BufferType.L1, shard_spec
+        shard_spec = ttnn.ShardSpec(shard_grid, shard_shape, ttnn.ShardOrientation.ROW_MAJOR, False)
+        width_sharded_mem_config = ttnn.MemoryConfig(
+            ttnn.TensorMemoryLayout.WIDTH_SHARDED, ttnn.BufferType.L1, shard_spec
         )
         x = ttnn.to_memory_config(x, width_sharded_mem_config)
         unpadded_shape = x.get_legacy_shape()
@@ -1029,11 +1027,11 @@ class resnet50:
         )
 
         grid_size = (8, 4)
-        shard_grid = ttnn.experimental.tensor.CoreRangeSet(
+        shard_grid = ttnn.CoreRangeSet(
             {
-                ttnn.experimental.tensor.CoreRange(
-                    ttnn.experimental.tensor.CoreCoord(0, 0),
-                    ttnn.experimental.tensor.CoreCoord(grid_size[0] - 1, grid_size[1] - 1),
+                ttnn.CoreRange(
+                    ttnn.CoreCoord(0, 0),
+                    ttnn.CoreCoord(grid_size[0] - 1, grid_size[1] - 1),
                 )
             }
         )
@@ -1041,11 +1039,9 @@ class resnet50:
             x.volume() // x.get_legacy_shape()[-1],
             x.get_legacy_shape()[-1] // (grid_size[0] * grid_size[1]),
         ]
-        shard_spec = ttnn.experimental.tensor.ShardSpec(
-            shard_grid, shard_shape, ttnn.experimental.tensor.ShardOrientation.ROW_MAJOR, False
-        )
-        width_sharded_mem_config = ttnn.types.MemoryConfig(
-            ttnn.types.TensorMemoryLayout.WIDTH_SHARDED, ttnn.types.BufferType.L1, shard_spec
+        shard_spec = ttnn.ShardSpec(shard_grid, shard_shape, ttnn.ShardOrientation.ROW_MAJOR, False)
+        width_sharded_mem_config = ttnn.MemoryConfig(
+            ttnn.TensorMemoryLayout.WIDTH_SHARDED, ttnn.BufferType.L1, shard_spec
         )
         x = ttnn.to_memory_config(x, width_sharded_mem_config)
         unpadded_shape = x.get_legacy_shape()

--- a/models/demos/wormhole/llama31_8b/demo/demo.py
+++ b/models/demos/wormhole/llama31_8b/demo/demo.py
@@ -179,7 +179,7 @@ def run_llama_demo(user_input, batch_size, device, instruct_mode, is_ci_env):
         # tt_out = ttnn.to_layout(tt_out, ttnn.ROW_MAJOR_LAYOUT)
         # tt_out = ttnn.permute(tt_out, (2, 1, 0, 3))
         # tt_out = ttnn.reshape(tt_out, (tt_out.shape[0], tt_out.shape[2], tt_out.shape[3]))  # Squeeze(1)
-        # tt_out_argmax = ttnn.experimental.tensor.argmax(tt_out, dim=-1)
+        # tt_out_argmax = ttnn.argmax(tt_out, dim=-1)
         # Typecast from bf16 to uint32 for embedding
         # tt_out_tok = ttnn.clone(tt_out_argmax, ttnn.DRAM_MEMORY_CONFIG, dtype=ttnn.uint32)
         # tt_out_tok = ttnn.experimental.tensor.typecast(tt_out_tok, dtype=ttnn.uint32)

--- a/models/demos/wormhole/llama31_8b/demo/demo_with_prefill.py
+++ b/models/demos/wormhole/llama31_8b/demo/demo_with_prefill.py
@@ -309,7 +309,7 @@ def run_llama_demo(user_input, batch_size, device, instruct_mode, is_ci_env, num
                         mode="prefill",
                     )
             # Device synchrozization ensures profiler is accurate in end-to-end timing
-            ttnn.device.synchronize_device(device)
+            ttnn.synchronize_device(device)
             profiler.end(f"inference_prefill", iteration=batch_idx)
             logger.info(f"Prefill finished [{prefill_seq_len} tokens]!")
 
@@ -367,7 +367,7 @@ def run_llama_demo(user_input, batch_size, device, instruct_mode, is_ci_env, num
             # tt_out = ttnn.to_layout(tt_out, ttnn.ROW_MAJOR_LAYOUT)
             # tt_out = ttnn.permute(tt_out, (2, 1, 0, 3))
             # tt_out = ttnn.reshape(tt_out, (tt_out.shape[0], tt_out.shape[2], tt_out.shape[3]))  # Squeeze(1)
-            # tt_out_argmax = ttnn.experimental.tensor.argmax(tt_out, dim=-1)
+            # tt_out_argmax = ttnn.argmax(tt_out, dim=-1)
             # Typecast from bf16 to uint32 for embedding
             # tt_out_tok = ttnn.clone(tt_out_argmax, ttnn.DRAM_MEMORY_CONFIG, dtype=ttnn.uint32)
             # tt_out_tok = ttnn.experimental.tensor.typecast(tt_out_tok, dtype=ttnn.uint32)

--- a/models/demos/wormhole/llama31_8b/tt/llama_attention.py
+++ b/models/demos/wormhole/llama31_8b/tt/llama_attention.py
@@ -140,7 +140,7 @@ class TtLlamaAttention(nn.Module):
             self.layer_past_list.append(layer_past)
 
         self.q_heads_program_config = ttnn.MatmulMultiCoreReuseMultiCastProgramConfig(
-            compute_with_storage_grid_size=ttnn.experimental.tensor.CoreCoord(self.grid_size.x, self.grid_size.y),
+            compute_with_storage_grid_size=ttnn.CoreCoord(self.grid_size.x, self.grid_size.y),
             in0_block_w=4,
             out_subblock_h=4,
             out_subblock_w=1,
@@ -150,7 +150,7 @@ class TtLlamaAttention(nn.Module):
             fused_activation=None,
         )
         self.k_heads_program_config = ttnn.MatmulMultiCoreReuseMultiCastProgramConfig(
-            compute_with_storage_grid_size=ttnn.experimental.tensor.CoreCoord(self.grid_size.x, self.grid_size.y),
+            compute_with_storage_grid_size=ttnn.CoreCoord(self.grid_size.x, self.grid_size.y),
             in0_block_w=4,
             out_subblock_h=1,
             out_subblock_w=1,
@@ -161,7 +161,7 @@ class TtLlamaAttention(nn.Module):
         )
 
         self.expand_program_config = ttnn.MatmulMultiCoreReuseMultiCastProgramConfig(
-            compute_with_storage_grid_size=ttnn.experimental.tensor.CoreCoord(self.grid_size.x, self.grid_size.y),
+            compute_with_storage_grid_size=ttnn.CoreCoord(self.grid_size.x, self.grid_size.y),
             in0_block_w=4,
             out_subblock_h=2,
             out_subblock_w=2,
@@ -172,7 +172,7 @@ class TtLlamaAttention(nn.Module):
         )
 
         self.reduce_program_config = ttnn.MatmulMultiCoreReuseMultiCastProgramConfig(
-            compute_with_storage_grid_size=ttnn.experimental.tensor.CoreCoord(self.grid_size.x, self.grid_size.y),
+            compute_with_storage_grid_size=ttnn.CoreCoord(self.grid_size.x, self.grid_size.y),
             in0_block_w=4,
             out_subblock_h=4,
             out_subblock_w=1,
@@ -183,7 +183,7 @@ class TtLlamaAttention(nn.Module):
         )
 
         self.attn_program_config = ttnn.MatmulMultiCoreReuseProgramConfig(
-            compute_with_storage_grid_size=ttnn.experimental.tensor.CoreCoord(8, 4),
+            compute_with_storage_grid_size=ttnn.CoreCoord(8, 4),
             in0_block_w=1,
             out_subblock_h=1,
             out_subblock_w=4,
@@ -195,7 +195,7 @@ class TtLlamaAttention(nn.Module):
             fp32_dest_acc_en=True,
             packer_l1_acc=True,
         )
-        self.attention_grid = ttnn.experimental.tensor.CoreCoord(8, 4)
+        self.attention_grid = ttnn.CoreCoord(8, 4)
         self.scale = self.head_dim**-0.5
 
     def forward_decode(

--- a/models/demos/wormhole/llama31_8b/tt/model_config.py
+++ b/models/demos/wormhole/llama31_8b/tt/model_config.py
@@ -263,8 +263,8 @@ class TtModelArgs:
                 use_height_and_width_as_shard_shape=True,
             )
 
-            self.model_config["MLP_KERNEL_CONFIG"] = ttnn.experimental.tensor.WormholeComputeKernelConfig(
-                math_fidelity=ttnn.experimental.tensor.MathFidelity.LoFi,
+            self.model_config["MLP_KERNEL_CONFIG"] = ttnn.WormholeComputeKernelConfig(
+                math_fidelity=ttnn.MathFidelity.LoFi,
                 math_approx_mode=True,
                 fp32_dest_acc_en=False,
                 packer_l1_acc=True,
@@ -276,8 +276,8 @@ class TtModelArgs:
                 k_chunk_size=32,
             )
 
-            self.model_config["SDPA_DECODE_COMPUTE_PROGCFG"] = ttnn.experimental.tensor.WormholeComputeKernelConfig(
-                math_fidelity=ttnn.experimental.tensor.MathFidelity.HiFi4,
+            self.model_config["SDPA_DECODE_COMPUTE_PROGCFG"] = ttnn.WormholeComputeKernelConfig(
+                math_fidelity=ttnn.MathFidelity.HiFi4,
                 math_approx_mode=False,
                 fp32_dest_acc_en=False,
                 packer_l1_acc=False,

--- a/models/demos/wormhole/mistral7b/demo/demo.py
+++ b/models/demos/wormhole/mistral7b/demo/demo.py
@@ -219,7 +219,7 @@ def run_mistral_demo(user_input, batch_size, device, instruct_mode, is_ci_env, n
             # tt_out = ttnn.to_layout(tt_out, ttnn.ROW_MAJOR_LAYOUT)
             # tt_out = ttnn.permute(tt_out, (2, 1, 0, 3))
             # tt_out = ttnn.reshape(tt_out, (tt_out.shape[0], tt_out.shape[2], tt_out.shape[3]))  # Squeeze(1)
-            # tt_out_argmax = ttnn.experimental.tensor.argmax(tt_out, dim=-1)
+            # tt_out_argmax = ttnn.argmax(tt_out, dim=-1)
             # Typecast from bf16 to uint32 for embedding
             # tt_out_tok = ttnn.clone(tt_out_argmax, ttnn.DRAM_MEMORY_CONFIG, dtype=ttnn.uint32)
             # tt_out_tok = ttnn.experimental.tensor.typecast(tt_out_tok, dtype=ttnn.uint32)

--- a/models/demos/wormhole/mistral7b/demo/demo_with_prefill.py
+++ b/models/demos/wormhole/mistral7b/demo/demo_with_prefill.py
@@ -308,7 +308,7 @@ def run_mistral_demo(user_input, batch_size, device, instruct_mode, is_ci_env, n
                     profiler.end(f"compile_prefill", iteration=batch_idx)
 
             # Device synchrozization ensures profiler is accurate in end-to-end timing
-            ttnn.device.synchronize_device(device)
+            ttnn.synchronize_device(device)
 
             profiler.end(f"inference_prefill", iteration=batch_idx)
             logger.info(f"Prefill finished [{prefill_seq_len} tokens]!")
@@ -358,7 +358,7 @@ def run_mistral_demo(user_input, batch_size, device, instruct_mode, is_ci_env, n
             # tt_out = ttnn.to_layout(tt_out, ttnn.ROW_MAJOR_LAYOUT)
             # tt_out = ttnn.permute(tt_out, (2, 1, 0, 3))
             # tt_out = ttnn.reshape(tt_out, (tt_out.shape[0], tt_out.shape[2], tt_out.shape[3]))  # Squeeze(1)
-            # tt_out_argmax = ttnn.experimental.tensor.argmax(tt_out, dim=-1)
+            # tt_out_argmax = ttnn.argmax(tt_out, dim=-1)
             # Typecast from bf16 to uint32 for embedding
             # tt_out_tok = ttnn.clone(tt_out_argmax, ttnn.DRAM_MEMORY_CONFIG, dtype=ttnn.uint32)
             # tt_out_tok = ttnn.experimental.tensor.typecast(tt_out_tok, dtype=ttnn.uint32)

--- a/models/demos/wormhole/mistral7b/tt/mistral_attention.py
+++ b/models/demos/wormhole/mistral7b/tt/mistral_attention.py
@@ -152,7 +152,7 @@ class TtMistralAttention(nn.Module):
         ]
 
         self.q_heads_program_config = ttnn.MatmulMultiCoreReuseMultiCastProgramConfig(
-            compute_with_storage_grid_size=ttnn.experimental.tensor.CoreCoord(self.grid_size.x, self.grid_size.y),
+            compute_with_storage_grid_size=ttnn.CoreCoord(self.grid_size.x, self.grid_size.y),
             in0_block_w=4,
             out_subblock_h=4,
             out_subblock_w=1,
@@ -162,7 +162,7 @@ class TtMistralAttention(nn.Module):
             fused_activation=None,
         )
         self.k_heads_program_config = ttnn.MatmulMultiCoreReuseMultiCastProgramConfig(
-            compute_with_storage_grid_size=ttnn.experimental.tensor.CoreCoord(self.grid_size.x, self.grid_size.y),
+            compute_with_storage_grid_size=ttnn.CoreCoord(self.grid_size.x, self.grid_size.y),
             in0_block_w=4,
             out_subblock_h=1,
             out_subblock_w=1,
@@ -206,7 +206,7 @@ class TtMistralAttention(nn.Module):
             for i in range(len(devices))
         ]
         self.expand_program_config = ttnn.MatmulMultiCoreReuseMultiCastProgramConfig(
-            compute_with_storage_grid_size=ttnn.experimental.tensor.CoreCoord(self.grid_size.x, self.grid_size.y),
+            compute_with_storage_grid_size=ttnn.CoreCoord(self.grid_size.x, self.grid_size.y),
             in0_block_w=4,
             out_subblock_h=2,
             out_subblock_w=2,
@@ -217,7 +217,7 @@ class TtMistralAttention(nn.Module):
         )
 
         self.reduce_program_config = ttnn.MatmulMultiCoreReuseMultiCastProgramConfig(
-            compute_with_storage_grid_size=ttnn.experimental.tensor.CoreCoord(self.grid_size.x, self.grid_size.y),
+            compute_with_storage_grid_size=ttnn.CoreCoord(self.grid_size.x, self.grid_size.y),
             in0_block_w=4,
             out_subblock_h=4,
             out_subblock_w=1,
@@ -228,7 +228,7 @@ class TtMistralAttention(nn.Module):
         )
 
         self.attn_program_config = ttnn.MatmulMultiCoreReuseProgramConfig(
-            compute_with_storage_grid_size=ttnn.experimental.tensor.CoreCoord(8, 4),
+            compute_with_storage_grid_size=ttnn.CoreCoord(8, 4),
             in0_block_w=1,
             out_subblock_h=1,
             out_subblock_w=4,
@@ -240,7 +240,7 @@ class TtMistralAttention(nn.Module):
             fp32_dest_acc_en=True,
             packer_l1_acc=True,
         )
-        self.attention_grid = ttnn.experimental.tensor.CoreCoord(8, 4)
+        self.attention_grid = ttnn.CoreCoord(8, 4)
         self.scale = self.head_dim**-0.5
 
     def forward_decode(

--- a/models/demos/wormhole/mistral7b/tt/model_config.py
+++ b/models/demos/wormhole/mistral7b/tt/model_config.py
@@ -237,8 +237,8 @@ class TtModelArgs:
                 use_height_and_width_as_shard_shape=True,
             )
 
-            self.model_config["MLP_KERNEL_CONFIG"] = ttnn.experimental.tensor.WormholeComputeKernelConfig(
-                math_fidelity=ttnn.experimental.tensor.MathFidelity.LoFi,
+            self.model_config["MLP_KERNEL_CONFIG"] = ttnn.WormholeComputeKernelConfig(
+                math_fidelity=ttnn.MathFidelity.LoFi,
                 math_approx_mode=True,
                 fp32_dest_acc_en=False,
                 packer_l1_acc=True,

--- a/models/demos/wormhole/stable_diffusion/tt/ttnn_functional_basic_transformer_block.py
+++ b/models/demos/wormhole/stable_diffusion/tt/ttnn_functional_basic_transformer_block.py
@@ -65,11 +65,11 @@ class basic_transformer_block:
             assert False, "AdaLayerNormZero not supported and not used in stable diffusion"
 
         if hidden_states.memory_config().shard_spec.num_cores() == 64:
-            end_grid = ttnn.experimental.tensor.CoreCoord(7, 7)
+            end_grid = ttnn.CoreCoord(7, 7)
         elif hidden_states.memory_config().shard_spec.num_cores() == 40:
-            end_grid = ttnn.experimental.tensor.CoreCoord(4, 7)
+            end_grid = ttnn.CoreCoord(4, 7)
         elif hidden_states.memory_config().shard_spec.num_cores() == 32:
-            end_grid = ttnn.experimental.tensor.CoreCoord(7, 3)
+            end_grid = ttnn.CoreCoord(7, 3)
 
         sharded_mem_cfg = ttnn.get_memory_config(hidden_states)
         program_config = ttnn.LayerNormShardedMultiCoreProgramConfig(
@@ -174,11 +174,11 @@ class basic_transformer_block:
         hidden_states = ttnn.add(norm_hidden_states, hidden_states, memory_config=hidden_states.memory_config())
 
         if hidden_states.memory_config().shard_spec.num_cores() == 64:
-            end_grid = ttnn.experimental.tensor.CoreCoord(7, 7)
+            end_grid = ttnn.CoreCoord(7, 7)
         elif hidden_states.memory_config().shard_spec.num_cores() == 40:
-            end_grid = ttnn.experimental.tensor.CoreCoord(7, 4)
+            end_grid = ttnn.CoreCoord(7, 4)
         elif hidden_states.memory_config().shard_spec.num_cores() == 32:
-            end_grid = ttnn.experimental.tensor.CoreCoord(3, 7)
+            end_grid = ttnn.CoreCoord(3, 7)
         else:
             assert False, f"Unsupported number of cores: {hidden_states.memory_config().shard_spec.num_cores()}"
 

--- a/models/demos/wormhole/stable_diffusion/tt/ttnn_functional_cross_attention.py
+++ b/models/demos/wormhole/stable_diffusion/tt/ttnn_functional_cross_attention.py
@@ -202,29 +202,23 @@ class cross_attention:
         self.parameters.to_out[0].weight = weight_to_bfp8(self.parameters.to_out[0].weight)
         self.parameters.to_out[0].bias = weight_to_bfp8(self.parameters.to_out[0].bias)
 
-        self.dram_interleaved_memory_config = ttnn.experimental.tensor.MemoryConfig(
-            memory_layout=ttnn.experimental.tensor.TensorMemoryLayout.INTERLEAVED,
-            buffer_type=ttnn.experimental.tensor.BufferType.DRAM,
+        self.dram_interleaved_memory_config = ttnn.DRAM_MEMORY_CONFIG
+        self.l1_interleaved_memory_config = ttnn.L1_MEMORY_CONFIG
+        self.block_sharded_memory_config = ttnn.MemoryConfig(
+            memory_layout=ttnn.TensorMemoryLayout.BLOCK_SHARDED,
+            buffer_type=ttnn.BufferType.L1,
         )
-        self.l1_interleaved_memory_config = ttnn.experimental.tensor.MemoryConfig(
-            memory_layout=ttnn.experimental.tensor.TensorMemoryLayout.INTERLEAVED,
-            buffer_type=ttnn.experimental.tensor.BufferType.L1,
+        self.height_sharded_memory_config = ttnn.MemoryConfig(
+            memory_layout=ttnn.TensorMemoryLayout.HEIGHT_SHARDED,
+            buffer_type=ttnn.BufferType.L1,
         )
-        self.block_sharded_memory_config = ttnn.experimental.tensor.MemoryConfig(
-            memory_layout=ttnn.experimental.tensor.TensorMemoryLayout.BLOCK_SHARDED,
-            buffer_type=ttnn.experimental.tensor.BufferType.L1,
-        )
-        self.height_sharded_memory_config = ttnn.experimental.tensor.MemoryConfig(
-            memory_layout=ttnn.experimental.tensor.TensorMemoryLayout.HEIGHT_SHARDED,
-            buffer_type=ttnn.experimental.tensor.BufferType.L1,
-        )
-        self.width_sharded_memory_config = ttnn.experimental.tensor.MemoryConfig(
-            memory_layout=ttnn.experimental.tensor.TensorMemoryLayout.WIDTH_SHARDED,
-            buffer_type=ttnn.experimental.tensor.BufferType.L1,
+        self.width_sharded_memory_config = ttnn.MemoryConfig(
+            memory_layout=ttnn.TensorMemoryLayout.WIDTH_SHARDED,
+            buffer_type=ttnn.BufferType.L1,
         )
 
-        self.compute_kernel_config = ttnn.experimental.tensor.WormholeComputeKernelConfig(
-            math_fidelity=ttnn.experimental.tensor.MathFidelity.LoFi,
+        self.compute_kernel_config = ttnn.WormholeComputeKernelConfig(
+            math_fidelity=ttnn.MathFidelity.LoFi,
             math_approx_mode=True,
             fp32_dest_acc_en=False,
             packer_l1_acc=False,
@@ -366,8 +360,8 @@ class cross_attention:
                     self.tsa_mm_activations_height_shard_spec,
                     self.num_slices,
                     j * self.num_slices // 2 + i,
-                    ttnn.experimental.tensor.TensorMemoryLayout.HEIGHT_SHARDED,
-                    ttnn.experimental.tensor.ShardOrientation.ROW_MAJOR,
+                    ttnn.TensorMemoryLayout.HEIGHT_SHARDED,
+                    ttnn.ShardOrientation.ROW_MAJOR,
                 )
 
                 k_slice = ttnn.slice(
@@ -382,7 +376,7 @@ class cross_attention:
                     k_slice,
                     program_config=self.program_configs["tsa_qkt"],
                     memory_config=self.height_sharded_memory_config,
-                    dtype=ttnn.experimental.tensor.DataType.BFLOAT8_B,
+                    dtype=ttnn.bfloat8_b,
                     compute_kernel_config=self.compute_kernel_config,
                 )
                 k_slice.deallocate()
@@ -421,7 +415,7 @@ class cross_attention:
                     v_slice,
                     program_config=self.program_configs["tsa_v"],
                     memory_config=self.height_sharded_memory_config,
-                    dtype=ttnn.experimental.tensor.DataType.BFLOAT8_B,
+                    dtype=ttnn.bfloat8_b,
                     compute_kernel_config=self.compute_kernel_config,
                 )
                 v_slice.deallocate()
@@ -437,8 +431,8 @@ class cross_attention:
             self.output_tensor,
             (8, 2),
             self.tsa_output_shard_shape,
-            ttnn.experimental.tensor.TensorMemoryLayout.HEIGHT_SHARDED,
-            ttnn.experimental.tensor.ShardOrientation.ROW_MAJOR,
+            ttnn.TensorMemoryLayout.HEIGHT_SHARDED,
+            ttnn.ShardOrientation.ROW_MAJOR,
         )
         return output
 
@@ -461,8 +455,8 @@ class cross_attention:
                 query,
                 grid_size,
                 [num_heads * seq_len // num_cores, inner],
-                ttnn.experimental.tensor.TensorMemoryLayout.HEIGHT_SHARDED,
-                ttnn.experimental.tensor.ShardOrientation.ROW_MAJOR,
+                ttnn.TensorMemoryLayout.HEIGHT_SHARDED,
+                ttnn.ShardOrientation.ROW_MAJOR,
             )
             query.deallocate()
         else:
@@ -481,37 +475,35 @@ class cross_attention:
             key,
             program_config=program_config,
             memory_config=self.height_sharded_memory_config,
-            dtype=ttnn.experimental.tensor.DataType.BFLOAT8_B,
+            dtype=ttnn.bfloat8_b,
             compute_kernel_config=self.compute_kernel_config,
         )
 
         num_cores_softmax = num_heads * seq_len // 32
         if num_cores_softmax > 64:
             num_cores_softmax = 64
-            end_grid = ttnn.experimental.tensor.CoreCoord(7, 7)
+            end_grid = ttnn.CoreCoord(7, 7)
             compute_with_storage_grid_size = (8, 8)
         elif num_cores_softmax == 48:
-            end_grid = ttnn.experimental.tensor.CoreCoord(7, 5)
+            end_grid = ttnn.CoreCoord(7, 5)
             compute_with_storage_grid_size = (8, 6)
         elif num_cores_softmax == 32:
-            end_grid = ttnn.experimental.tensor.CoreCoord(7, 3)
+            end_grid = ttnn.CoreCoord(7, 3)
             compute_with_storage_grid_size = (8, 4)
 
         height_per_core = num_heads * seq_len // num_cores_softmax
         orig_mem_config = attention_scores.memory_config()
 
-        output_shard_grid = ttnn.experimental.tensor.CoreRangeSet(
-            {ttnn.experimental.tensor.CoreRange(ttnn.experimental.tensor.CoreCoord(0, 0), end_grid)}
-        )
-        output_shard_spec = ttnn.experimental.tensor.ShardSpec(
+        output_shard_grid = ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), end_grid)})
+        output_shard_spec = ttnn.ShardSpec(
             output_shard_grid,
             [height_per_core, key_len],
-            ttnn.experimental.tensor.ShardOrientation.ROW_MAJOR,
+            ttnn.ShardOrientation.ROW_MAJOR,
             False,
         )
-        output_mem_config = ttnn.experimental.tensor.MemoryConfig(
-            ttnn.experimental.tensor.TensorMemoryLayout.HEIGHT_SHARDED,
-            ttnn.experimental.tensor.BufferType.L1,
+        output_mem_config = ttnn.MemoryConfig(
+            ttnn.TensorMemoryLayout.HEIGHT_SHARDED,
+            ttnn.BufferType.L1,
             output_shard_spec,
         )
         attention_scores = ttnn.reshard(
@@ -554,8 +546,8 @@ class cross_attention:
                 value,
                 grid_size,
                 [num_heads * key_len // num_cores, inner],
-                ttnn.experimental.tensor.TensorMemoryLayout.HEIGHT_SHARDED,
-                ttnn.experimental.tensor.ShardOrientation.ROW_MAJOR,
+                ttnn.TensorMemoryLayout.HEIGHT_SHARDED,
+                ttnn.ShardOrientation.ROW_MAJOR,
             )
             value.deallocate()
         else:
@@ -574,12 +566,10 @@ class cross_attention:
             v_sharded,
             program_config=program_config,
             memory_config=self.height_sharded_memory_config,
-            dtype=ttnn.experimental.tensor.DataType.BFLOAT8_B,
+            dtype=ttnn.bfloat8_b,
             compute_kernel_config=self.compute_kernel_config,
         )
-        attention_scores = reshard_to(
-            attention_scores, (8, 2), ttnn.experimental.tensor.TensorMemoryLayout.HEIGHT_SHARDED
-        )
+        attention_scores = reshard_to(attention_scores, (8, 2), ttnn.TensorMemoryLayout.HEIGHT_SHARDED)
         v_sharded.deallocate()
         return ttnn.reshape(attention_scores, (2, 8, attention_scores.shape[-2], attention_scores.shape[-1]))
 
@@ -596,10 +586,10 @@ class cross_attention:
 
         grid_sizes = {4096: (4, 8), 1024: (4, 8), 256: (5, 8), 64: (8, 4)}
         shard_directions = {
-            4096: ttnn.experimental.tensor.TensorMemoryLayout.BLOCK_SHARDED,
-            1024: ttnn.experimental.tensor.TensorMemoryLayout.BLOCK_SHARDED,
-            256: ttnn.experimental.tensor.TensorMemoryLayout.BLOCK_SHARDED,
-            64: ttnn.experimental.tensor.TensorMemoryLayout.BLOCK_SHARDED,
+            4096: ttnn.TensorMemoryLayout.BLOCK_SHARDED,
+            1024: ttnn.TensorMemoryLayout.BLOCK_SHARDED,
+            256: ttnn.TensorMemoryLayout.BLOCK_SHARDED,
+            64: ttnn.TensorMemoryLayout.BLOCK_SHARDED,
         }
         out_subblock_hs = {256: 8, 64: 4}
 
@@ -607,11 +597,9 @@ class cross_attention:
         num_cores = grid_size[0] * grid_size[1]
         B, M, K, N = 1, hidden_states.shape[-2], hidden_states.shape[-1], self.parameters.to_out[0].weight.shape[-1]
 
-        hs = shard_directions[size] == ttnn.experimental.tensor.TensorMemoryLayout.HEIGHT_SHARDED
+        hs = shard_directions[size] == ttnn.TensorMemoryLayout.HEIGHT_SHARDED
         if hs:
-            hidden_states = reshard_to(
-                hidden_states, grid_size, ttnn.experimental.tensor.TensorMemoryLayout.HEIGHT_SHARDED
-            )
+            hidden_states = reshard_to(hidden_states, grid_size, ttnn.TensorMemoryLayout.HEIGHT_SHARDED)
             output_mem_config = self.height_sharded_memory_config
             program_config = ttnn.MatmulMultiCoreReuseMultiCast1DProgramConfig(
                 compute_with_storage_grid_size=grid_size,
@@ -625,9 +613,7 @@ class cross_attention:
                 mcast_in0=False if hs else True,
             )
         else:
-            hidden_states = reshard_to(
-                hidden_states, grid_size, ttnn.experimental.tensor.TensorMemoryLayout.BLOCK_SHARDED
-            )
+            hidden_states = reshard_to(hidden_states, grid_size, ttnn.TensorMemoryLayout.BLOCK_SHARDED)
             output_mem_config = self.block_sharded_memory_config
             in0_block_h, in0_block_w, out_subblock_h, out_subblock_w, out_block_h, out_block_w = determine_blocking(
                 M, K, N, grid_size
@@ -649,7 +635,7 @@ class cross_attention:
             bias=self.parameters.to_out[0].bias,
             program_config=program_config,
             memory_config=output_mem_config,
-            dtype=ttnn.experimental.tensor.DataType.BFLOAT8_B,
+            dtype=ttnn.bfloat8_b,
             compute_kernel_config=self.compute_kernel_config,
         )
 
@@ -677,8 +663,8 @@ class cross_attention:
                 hidden_states,
                 grid_size,
                 [self.hidden_states_shape[-2] // grid_size[1], self.hidden_states_shape[-1] // grid_size[0]],
-                ttnn.experimental.tensor.TensorMemoryLayout.BLOCK_SHARDED,
-                ttnn.experimental.tensor.ShardOrientation.ROW_MAJOR,
+                ttnn.TensorMemoryLayout.BLOCK_SHARDED,
+                ttnn.ShardOrientation.ROW_MAJOR,
             )
         if encoder_hidden_states:
             encoder_hidden_states = ttnn.reshape(
@@ -697,7 +683,7 @@ class cross_attention:
                 memory_config=(
                     self.l1_interleaved_memory_config if interleaved_out else self.block_sharded_memory_config
                 ),
-                dtype=ttnn.experimental.tensor.DataType.BFLOAT8_B,
+                dtype=ttnn.bfloat8_b,
                 compute_kernel_config=self.compute_kernel_config,
             )
             ttnn.deallocate(hidden_states)
@@ -709,15 +695,15 @@ class cross_attention:
                     num_heads=heads,
                 )
             else:
-                qkv_out = reshard_to(qkv_out, (8, 2), ttnn.experimental.tensor.TensorMemoryLayout.BLOCK_SHARDED)
+                qkv_out = reshard_to(qkv_out, (8, 2), ttnn.TensorMemoryLayout.BLOCK_SHARDED)
                 query, key, value = ttnn.transformer.split_query_key_value_and_split_heads(
                     qkv_out,
-                    memory_config=ttnn.ttnn.L1_HEIGHT_SHARDED_MEMORY_CONFIG,
+                    memory_config=ttnn.L1_HEIGHT_SHARDED_MEMORY_CONFIG,
                     num_heads=heads,
                 )
-                query = reshard_to(query, (2, 8), ttnn.experimental.tensor.TensorMemoryLayout.HEIGHT_SHARDED)
-                key = reshard_to(key, (2, 8), ttnn.experimental.tensor.TensorMemoryLayout.HEIGHT_SHARDED)
-                value = reshard_to(value, (2, 8), ttnn.experimental.tensor.TensorMemoryLayout.HEIGHT_SHARDED)
+                query = reshard_to(query, (2, 8), ttnn.TensorMemoryLayout.HEIGHT_SHARDED)
+                key = reshard_to(key, (2, 8), ttnn.TensorMemoryLayout.HEIGHT_SHARDED)
+                value = reshard_to(value, (2, 8), ttnn.TensorMemoryLayout.HEIGHT_SHARDED)
             ttnn.deallocate(qkv_out)
         else:
             if self.seq_len == 4096:
@@ -729,7 +715,7 @@ class cross_attention:
                 self.parameters.to_q.weight,
                 program_config=program_config,
                 memory_config=self.block_sharded_memory_config,
-                dtype=ttnn.experimental.tensor.DataType.BFLOAT8_B,
+                dtype=ttnn.bfloat8_b,
                 compute_kernel_config=self.compute_kernel_config,
             )
             ttnn.deallocate(hidden_states)
@@ -740,28 +726,22 @@ class cross_attention:
                 self.parameters.kv.weight,
                 program_config=program_config,
                 memory_config=self.block_sharded_memory_config,
-                dtype=ttnn.experimental.tensor.DataType.BFLOAT8_B,
+                dtype=ttnn.bfloat8_b,
                 compute_kernel_config=self.compute_kernel_config,
             )
-            end_core = (
-                ttnn.experimental.tensor.CoreCoord(7, 1)
-                if self.seq_len != 64
-                else ttnn.experimental.tensor.CoreCoord(3, 1)
-            )
+            end_core = ttnn.CoreCoord(7, 1) if self.seq_len != 64 else ttnn.CoreCoord(3, 1)
             grid_size = (8, 2) if self.seq_len != 64 else (4, 2)
-            q_proj = reshard_to(q_proj, grid_size, ttnn.experimental.tensor.TensorMemoryLayout.BLOCK_SHARDED)
-            output_shard_grid = ttnn.experimental.tensor.CoreRangeSet(
-                {ttnn.experimental.tensor.CoreRange(ttnn.experimental.tensor.CoreCoord(0, 0), end_core)}
-            )
-            output_shard_spec = ttnn.experimental.tensor.ShardSpec(
+            q_proj = reshard_to(q_proj, grid_size, ttnn.TensorMemoryLayout.BLOCK_SHARDED)
+            output_shard_grid = ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), end_core)})
+            output_shard_spec = ttnn.ShardSpec(
                 output_shard_grid,
                 [self.seq_len, self.q_len // grid_size[0]],
-                ttnn.experimental.tensor.ShardOrientation.ROW_MAJOR,
+                ttnn.ShardOrientation.ROW_MAJOR,
                 False,
             )
-            output_mem_config = ttnn.experimental.tensor.MemoryConfig(
-                ttnn.experimental.tensor.TensorMemoryLayout.BLOCK_SHARDED,
-                ttnn.experimental.tensor.BufferType.L1,
+            output_mem_config = ttnn.MemoryConfig(
+                ttnn.TensorMemoryLayout.BLOCK_SHARDED,
+                ttnn.BufferType.L1,
                 output_shard_spec,
             )
             q_proj = ttnn.reshard(
@@ -769,18 +749,16 @@ class cross_attention:
                 output_mem_config,
             )
 
-            output_shard_grid = ttnn.experimental.tensor.CoreRangeSet(
-                {ttnn.experimental.tensor.CoreRange(ttnn.experimental.tensor.CoreCoord(0, 0), end_core)}
-            )
-            output_shard_spec = ttnn.experimental.tensor.ShardSpec(
+            output_shard_grid = ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), end_core)})
+            output_shard_spec = ttnn.ShardSpec(
                 output_shard_grid,
                 [96, self.kv_len // grid_size[0]],
-                ttnn.experimental.tensor.ShardOrientation.ROW_MAJOR,
+                ttnn.ShardOrientation.ROW_MAJOR,
                 False,
             )
-            output_mem_config = ttnn.experimental.tensor.MemoryConfig(
-                ttnn.experimental.tensor.TensorMemoryLayout.BLOCK_SHARDED,
-                ttnn.experimental.tensor.BufferType.L1,
+            output_mem_config = ttnn.MemoryConfig(
+                ttnn.TensorMemoryLayout.BLOCK_SHARDED,
+                ttnn.BufferType.L1,
                 output_shard_spec,
             )
             kv_proj = ttnn.reshard(
@@ -799,9 +777,9 @@ class cross_attention:
             )
             ttnn.deallocate(kv_proj)
             ttnn.deallocate(q_proj)
-            query = reshard_to(query, (2, 8), ttnn.experimental.tensor.TensorMemoryLayout.HEIGHT_SHARDED)
-            key = reshard_to(key, (2, 8), ttnn.experimental.tensor.TensorMemoryLayout.HEIGHT_SHARDED)
-            value = reshard_to(value, (2, 8), ttnn.experimental.tensor.TensorMemoryLayout.HEIGHT_SHARDED)
+            query = reshard_to(query, (2, 8), ttnn.TensorMemoryLayout.HEIGHT_SHARDED)
+            key = reshard_to(key, (2, 8), ttnn.TensorMemoryLayout.HEIGHT_SHARDED)
+            value = reshard_to(value, (2, 8), ttnn.TensorMemoryLayout.HEIGHT_SHARDED)
 
         hidden_states = self.get_attention_scores_opt(
             query, key, value, dim_head, attn_type="cross" if encoder_hidden_states else "self"

--- a/models/demos/wormhole/stable_diffusion/tt/ttnn_functional_feedforward.py
+++ b/models/demos/wormhole/stable_diffusion/tt/ttnn_functional_feedforward.py
@@ -37,16 +37,13 @@ class feedforward:
         self.parameters.net[2].weight = ttnn.unsqueeze_to_4D(self.parameters.net[2].weight)
         self.parameters.net[2].bias = ttnn.unsqueeze_to_4D(self.parameters.net[2].bias)
         self.geglu = geglu(device, parameters.net[0])
-        self.block_sharded_memory_config = ttnn.experimental.tensor.MemoryConfig(
-            memory_layout=ttnn.experimental.tensor.TensorMemoryLayout.BLOCK_SHARDED,
-            buffer_type=ttnn.experimental.tensor.BufferType.L1,
+        self.block_sharded_memory_config = ttnn.MemoryConfig(
+            memory_layout=ttnn.TensorMemoryLayout.BLOCK_SHARDED,
+            buffer_type=ttnn.BufferType.L1,
         )
-        self.l1_interleaved_memory_config = ttnn.experimental.tensor.MemoryConfig(
-            memory_layout=ttnn.experimental.tensor.TensorMemoryLayout.INTERLEAVED,
-            buffer_type=ttnn.experimental.tensor.BufferType.L1,
-        )
-        self.compute_kernel_config = ttnn.experimental.tensor.WormholeComputeKernelConfig(
-            math_fidelity=ttnn.experimental.tensor.MathFidelity.LoFi,
+        self.l1_interleaved_memory_config = ttnn.L1_MEMORY_CONFIG
+        self.compute_kernel_config = ttnn.WormholeComputeKernelConfig(
+            math_fidelity=ttnn.MathFidelity.LoFi,
             math_approx_mode=True,
             fp32_dest_acc_en=False,
             packer_l1_acc=False,
@@ -88,7 +85,7 @@ class feedforward:
             bias=self.parameters.net[2].bias,
             program_config=program_config,
             memory_config=self.l1_interleaved_memory_config if interleaved_output else self.block_sharded_memory_config,
-            dtype=ttnn.experimental.tensor.DataType.BFLOAT8_B,
+            dtype=ttnn.bfloat8_b,
             compute_kernel_config=self.compute_kernel_config,
         )
         if interleaved_output:
@@ -96,7 +93,7 @@ class feedforward:
                 hidden_states,
                 grid_size,
                 [hidden_states.shape[-2] // grid_size[1], hidden_states.shape[-1] // grid_size[0]],
-                ttnn.experimental.tensor.TensorMemoryLayout.BLOCK_SHARDED,
-                ttnn.experimental.tensor.ShardOrientation.ROW_MAJOR,
+                ttnn.TensorMemoryLayout.BLOCK_SHARDED,
+                ttnn.ShardOrientation.ROW_MAJOR,
             )
         return hidden_states

--- a/models/demos/wormhole/stable_diffusion/tt/ttnn_functional_resnetblock2d.py
+++ b/models/demos/wormhole/stable_diffusion/tt/ttnn_functional_resnetblock2d.py
@@ -244,12 +244,12 @@ class resnetBlock2D:
         if not self.fallback_on_groupnorm:
             if (
                 self.first_gn_expected_input_sharded_memory_config.memory_layout
-                == ttnn.types.TensorMemoryLayout.BLOCK_SHARDED
+                == ttnn.TensorMemoryLayout.BLOCK_SHARDED
             ):
                 num_cores_across_channel = self.first_group_norm_core_grid.y
             elif (
                 self.first_gn_expected_input_sharded_memory_config.memory_layout
-                == ttnn.types.TensorMemoryLayout.HEIGHT_SHARDED
+                == ttnn.TensorMemoryLayout.HEIGHT_SHARDED
             ):
                 num_cores_across_channel = 1
             else:
@@ -268,7 +268,7 @@ class resnetBlock2D:
 
             self.norm1_input_mask = ttnn.from_torch(
                 self.norm1_input_mask_torch_tensor,
-                dtype=ttnn.DataType.BFLOAT8_B,
+                dtype=ttnn.bfloat8_b,
                 layout=ttnn.TILE_LAYOUT,
                 device=device,
                 memory_config=ttnn.DRAM_MEMORY_CONFIG,
@@ -276,26 +276,26 @@ class resnetBlock2D:
 
             self.parameters.norm1.weight = ttnn.from_torch(
                 self.parameters.norm1.weight,
-                dtype=ttnn.DataType.BFLOAT16,
+                dtype=ttnn.bfloat16,
                 layout=ttnn.ROW_MAJOR_LAYOUT,
                 device=device,
                 memory_config=ttnn.DRAM_MEMORY_CONFIG,
             )
             self.parameters.norm1.bias = ttnn.from_torch(
                 self.parameters.norm1.bias,
-                dtype=ttnn.DataType.BFLOAT16,
+                dtype=ttnn.bfloat16,
                 layout=ttnn.ROW_MAJOR_LAYOUT,
                 device=device,
                 memory_config=ttnn.DRAM_MEMORY_CONFIG,
             )
             if (
                 self.second_gn_expected_input_sharded_memory_config.memory_layout
-                == ttnn.types.TensorMemoryLayout.BLOCK_SHARDED
+                == ttnn.TensorMemoryLayout.BLOCK_SHARDED
             ):
                 num_cores_across_channel = self.second_group_norm_core_grid.y
             elif (
                 self.second_gn_expected_input_sharded_memory_config.memory_layout
-                == ttnn.types.TensorMemoryLayout.HEIGHT_SHARDED
+                == ttnn.TensorMemoryLayout.HEIGHT_SHARDED
             ):
                 num_cores_across_channel = 1
             else:
@@ -309,14 +309,14 @@ class resnetBlock2D:
             )
             self.parameters.norm2.weight = ttnn.from_torch(
                 self.parameters.norm2.weight,
-                dtype=ttnn.DataType.BFLOAT16,
+                dtype=ttnn.bfloat16,
                 layout=ttnn.ROW_MAJOR_LAYOUT,
                 device=device,
                 memory_config=ttnn.DRAM_MEMORY_CONFIG,
             )
             self.parameters.norm2.bias = ttnn.from_torch(
                 self.parameters.norm2.bias,
-                dtype=ttnn.DataType.BFLOAT16,
+                dtype=ttnn.bfloat16,
                 layout=ttnn.ROW_MAJOR_LAYOUT,
                 device=device,
                 memory_config=ttnn.DRAM_MEMORY_CONFIG,
@@ -327,7 +327,7 @@ class resnetBlock2D:
             )
             self.norm2_input_mask = ttnn.from_torch(
                 self.norm2_input_mask_torch_tensor,
-                dtype=ttnn.DataType.BFLOAT8_B,
+                dtype=ttnn.bfloat8_b,
                 layout=ttnn.TILE_LAYOUT,
                 device=device,
                 memory_config=ttnn.DRAM_MEMORY_CONFIG,
@@ -336,28 +336,28 @@ class resnetBlock2D:
             self.parameters.time_emb_proj.bias = weight_to_bfp8(self.parameters.time_emb_proj.bias)
 
     def reshard_to(self, tensor, grid_size, layout):
-        if layout == ttnn.experimental.tensor.TensorMemoryLayout.BLOCK_SHARDED:
+        if layout == ttnn.TensorMemoryLayout.BLOCK_SHARDED:
             shard_spec = [tensor.volume() // tensor.shape[-1] // grid_size[0], tensor.shape[-1] // grid_size[1]]
-        elif layout == ttnn.experimental.tensor.TensorMemoryLayout.HEIGHT_SHARDED:
+        elif layout == ttnn.TensorMemoryLayout.HEIGHT_SHARDED:
             num_cores = grid_size[0] * grid_size[1]
             shard_spec = [tensor.volume() // tensor.shape[-1] // num_cores, tensor.shape[-1]]
-        output_shard_grid = ttnn.experimental.tensor.CoreRangeSet(
+        output_shard_grid = ttnn.CoreRangeSet(
             {
-                ttnn.experimental.tensor.CoreRange(
-                    ttnn.experimental.tensor.CoreCoord(0, 0),
-                    ttnn.experimental.tensor.CoreCoord(grid_size[0] - 1, grid_size[1] - 1),
+                ttnn.CoreRange(
+                    ttnn.CoreCoord(0, 0),
+                    ttnn.CoreCoord(grid_size[0] - 1, grid_size[1] - 1),
                 )
             }
         )
-        output_shard_spec = ttnn.experimental.tensor.ShardSpec(
+        output_shard_spec = ttnn.ShardSpec(
             output_shard_grid,
             shard_spec,
-            ttnn.experimental.tensor.ShardOrientation.COL_MAJOR,
+            ttnn.ShardOrientation.COL_MAJOR,
             False,
         )
-        output_mem_config = ttnn.experimental.tensor.MemoryConfig(
+        output_mem_config = ttnn.MemoryConfig(
             layout,
-            ttnn.experimental.tensor.BufferType.L1,
+            ttnn.BufferType.L1,
             output_shard_spec,
         )
         if tensor.is_sharded():
@@ -371,7 +371,7 @@ class resnetBlock2D:
                 grid_size,
                 shard_spec,
                 layout,
-                ttnn.experimental.tensor.ShardOrientation.COL_MAJOR,
+                ttnn.ShardOrientation.COL_MAJOR,
             )
         return tensor
 
@@ -490,7 +490,7 @@ class resnetBlock2D:
             # TODO
             grid_size = (2, self.conv1s[0].conv.grid_size[0])
             # num_cores = grid_size[0] * grid_size[1]
-            # temb = self.reshard_to(temb, grid_size, ttnn.experimental.tensor.TensorMemoryLayout.BLOCK_SHARDED)
+            # temb = self.reshard_to(temb, grid_size, ttnn.TensorMemoryLayout.BLOCK_SHARDED)
             temb = nonlinearity(temb, memory_config=temb.memory_config())
             if temb_channels is not None:
                 if time_embedding_norm == "default":
@@ -509,23 +509,20 @@ class resnetBlock2D:
                     transpose_mcast=True,
                     fused_activation=None,
                 )
-                compute_kernel_config = ttnn.experimental.tensor.WormholeComputeKernelConfig(
-                    math_fidelity=ttnn.experimental.tensor.MathFidelity.LoFi,
+                compute_kernel_config = ttnn.WormholeComputeKernelConfig(
+                    math_fidelity=ttnn.MathFidelity.LoFi,
                     math_approx_mode=True,
                     fp32_dest_acc_en=False,
                     packer_l1_acc=False,
                 )
-                l1_memory_config = ttnn.experimental.tensor.MemoryConfig(
-                    memory_layout=ttnn.experimental.tensor.TensorMemoryLayout.INTERLEAVED,
-                    buffer_type=ttnn.experimental.tensor.BufferType.L1,
-                )
+                l1_memory_config = ttnn.L1_MEMORY_CONFIG
                 temb = ttnn.linear(
                     temb,
                     self.parameters.time_emb_proj.weight,
                     bias=self.parameters.time_emb_proj.bias,
                     program_config=program_config,
                     memory_config=l1_memory_config,
-                    dtype=ttnn.experimental.tensor.DataType.BFLOAT8_B,
+                    dtype=ttnn.bfloat8_b,
                     compute_kernel_config=compute_kernel_config,
                 )
 

--- a/models/demos/wormhole/stable_diffusion/tt/ttnn_functional_resnetblock2d_new_conv.py
+++ b/models/demos/wormhole/stable_diffusion/tt/ttnn_functional_resnetblock2d_new_conv.py
@@ -201,12 +201,12 @@ class resnetBlock2D:
         if not self.fallback_on_groupnorm:
             if (
                 self.first_gn_expected_input_sharded_memory_config.memory_layout
-                == ttnn.types.TensorMemoryLayout.BLOCK_SHARDED
+                == ttnn.TensorMemoryLayout.BLOCK_SHARDED
             ):
                 num_cores_across_channel = self.first_group_norm_core_grid.y
             elif (
                 self.first_gn_expected_input_sharded_memory_config.memory_layout
-                == ttnn.types.TensorMemoryLayout.HEIGHT_SHARDED
+                == ttnn.TensorMemoryLayout.HEIGHT_SHARDED
             ):
                 num_cores_across_channel = 1
             else:
@@ -225,7 +225,7 @@ class resnetBlock2D:
 
             self.norm1_input_mask = ttnn.from_torch(
                 self.norm1_input_mask_torch_tensor,
-                dtype=ttnn.DataType.BFLOAT8_B,
+                dtype=ttnn.bfloat8_b,
                 layout=ttnn.TILE_LAYOUT,
                 device=device,
                 memory_config=ttnn.DRAM_MEMORY_CONFIG,
@@ -233,26 +233,26 @@ class resnetBlock2D:
 
             self.parameters.norm1.weight = ttnn.from_torch(
                 self.parameters.norm1.weight,
-                dtype=ttnn.DataType.BFLOAT16,
+                dtype=ttnn.bfloat16,
                 layout=ttnn.ROW_MAJOR_LAYOUT,
                 device=device,
                 memory_config=ttnn.DRAM_MEMORY_CONFIG,
             )
             self.parameters.norm1.bias = ttnn.from_torch(
                 self.parameters.norm1.bias,
-                dtype=ttnn.DataType.BFLOAT16,
+                dtype=ttnn.bfloat16,
                 layout=ttnn.ROW_MAJOR_LAYOUT,
                 device=device,
                 memory_config=ttnn.DRAM_MEMORY_CONFIG,
             )
             if (
                 self.second_gn_expected_input_sharded_memory_config.memory_layout
-                == ttnn.types.TensorMemoryLayout.BLOCK_SHARDED
+                == ttnn.TensorMemoryLayout.BLOCK_SHARDED
             ):
                 num_cores_across_channel = self.second_group_norm_core_grid.y
             elif (
                 self.second_gn_expected_input_sharded_memory_config.memory_layout
-                == ttnn.types.TensorMemoryLayout.HEIGHT_SHARDED
+                == ttnn.TensorMemoryLayout.HEIGHT_SHARDED
             ):
                 num_cores_across_channel = 1
             else:
@@ -266,14 +266,14 @@ class resnetBlock2D:
             )
             self.parameters.norm2.weight = ttnn.from_torch(
                 self.parameters.norm2.weight,
-                dtype=ttnn.DataType.BFLOAT16,
+                dtype=ttnn.bfloat16,
                 layout=ttnn.ROW_MAJOR_LAYOUT,
                 device=device,
                 memory_config=ttnn.DRAM_MEMORY_CONFIG,
             )
             self.parameters.norm2.bias = ttnn.from_torch(
                 self.parameters.norm2.bias,
-                dtype=ttnn.DataType.BFLOAT16,
+                dtype=ttnn.bfloat16,
                 layout=ttnn.ROW_MAJOR_LAYOUT,
                 device=device,
                 memory_config=ttnn.DRAM_MEMORY_CONFIG,
@@ -284,7 +284,7 @@ class resnetBlock2D:
             )
             self.norm2_input_mask = ttnn.from_torch(
                 self.norm2_input_mask_torch_tensor,
-                dtype=ttnn.DataType.BFLOAT8_B,
+                dtype=ttnn.bfloat8_b,
                 layout=ttnn.TILE_LAYOUT,
                 device=device,
                 memory_config=ttnn.DRAM_MEMORY_CONFIG,
@@ -293,28 +293,28 @@ class resnetBlock2D:
             self.parameters.time_emb_proj.bias = weight_to_bfp8(self.parameters.time_emb_proj.bias)
 
     def reshard_to(self, tensor, grid_size, layout):
-        if layout == ttnn.experimental.tensor.TensorMemoryLayout.BLOCK_SHARDED:
+        if layout == ttnn.TensorMemoryLayout.BLOCK_SHARDED:
             shard_spec = [tensor.volume() // tensor.shape[-1] // grid_size[0], tensor.shape[-1] // grid_size[1]]
-        elif layout == ttnn.experimental.tensor.TensorMemoryLayout.HEIGHT_SHARDED:
+        elif layout == ttnn.TensorMemoryLayout.HEIGHT_SHARDED:
             num_cores = grid_size[0] * grid_size[1]
             shard_spec = [tensor.volume() // tensor.shape[-1] // num_cores, tensor.shape[-1]]
-        output_shard_grid = ttnn.experimental.tensor.CoreRangeSet(
+        output_shard_grid = ttnn.CoreRangeSet(
             {
-                ttnn.experimental.tensor.CoreRange(
-                    ttnn.experimental.tensor.CoreCoord(0, 0),
-                    ttnn.experimental.tensor.CoreCoord(grid_size[0] - 1, grid_size[1] - 1),
+                ttnn.CoreRange(
+                    ttnn.CoreCoord(0, 0),
+                    ttnn.CoreCoord(grid_size[0] - 1, grid_size[1] - 1),
                 )
             }
         )
-        output_shard_spec = ttnn.experimental.tensor.ShardSpec(
+        output_shard_spec = ttnn.ShardSpec(
             output_shard_grid,
             shard_spec,
-            ttnn.experimental.tensor.ShardOrientation.COL_MAJOR,
+            ttnn.ShardOrientation.COL_MAJOR,
             False,
         )
-        output_mem_config = ttnn.experimental.tensor.MemoryConfig(
+        output_mem_config = ttnn.MemoryConfig(
             layout,
-            ttnn.experimental.tensor.BufferType.L1,
+            ttnn.BufferType.L1,
             output_shard_spec,
         )
         if tensor.is_sharded():
@@ -328,7 +328,7 @@ class resnetBlock2D:
                 grid_size,
                 shard_spec,
                 layout,
-                ttnn.experimental.tensor.ShardOrientation.COL_MAJOR,
+                ttnn.ShardOrientation.COL_MAJOR,
             )
         return tensor
 
@@ -524,7 +524,7 @@ class resnetBlock2D:
         if temb is not None:
             grid_size = (2, 5)  # 5 is the Magic Number!
             # num_cores = grid_size[0] * grid_size[1]
-            # temb = self.reshard_to(temb, grid_size, ttnn.experimental.tensor.TensorMemoryLayout.BLOCK_SHARDED)
+            # temb = self.reshard_to(temb, grid_size, ttnn.TensorMemoryLayout.BLOCK_SHARDED)
             temb = nonlinearity(temb, memory_config=temb.memory_config())
             if temb_channels is not None:
                 if time_embedding_norm == "default":
@@ -543,23 +543,20 @@ class resnetBlock2D:
                     transpose_mcast=True,
                     fused_activation=None,
                 )
-                compute_kernel_config = ttnn.experimental.tensor.WormholeComputeKernelConfig(
-                    math_fidelity=ttnn.experimental.tensor.MathFidelity.LoFi,
+                compute_kernel_config = ttnn.WormholeComputeKernelConfig(
+                    math_fidelity=ttnn.MathFidelity.LoFi,
                     math_approx_mode=True,
                     fp32_dest_acc_en=False,
                     packer_l1_acc=False,
                 )
-                l1_memory_config = ttnn.experimental.tensor.MemoryConfig(
-                    memory_layout=ttnn.experimental.tensor.TensorMemoryLayout.INTERLEAVED,
-                    buffer_type=ttnn.experimental.tensor.BufferType.L1,
-                )
+                l1_memory_config = ttnn.L1_MEMORY_CONFIG
                 temb = ttnn.linear(
                     temb,
                     self.parameters.time_emb_proj.weight,
                     bias=self.parameters.time_emb_proj.bias,
                     program_config=program_config,
                     memory_config=l1_memory_config,
-                    dtype=ttnn.experimental.tensor.DataType.BFLOAT8_B,
+                    dtype=ttnn.bfloat8_b,
                     compute_kernel_config=compute_kernel_config,
                 )
 

--- a/models/demos/wormhole/stable_diffusion/tt/ttnn_functional_transformer_2d.py
+++ b/models/demos/wormhole/stable_diffusion/tt/ttnn_functional_transformer_2d.py
@@ -82,15 +82,9 @@ class transformer_2d_model:
         )
 
         if not self.fallback_on_groupnorm:
-            if (
-                self.gn_expected_input_sharded_memory_config.memory_layout
-                == ttnn.types.TensorMemoryLayout.BLOCK_SHARDED
-            ):
+            if self.gn_expected_input_sharded_memory_config.memory_layout == ttnn.TensorMemoryLayout.BLOCK_SHARDED:
                 num_cores_across_channel = self.group_norm_core_grid.y
-            elif (
-                self.gn_expected_input_sharded_memory_config.memory_layout
-                == ttnn.types.TensorMemoryLayout.HEIGHT_SHARDED
-            ):
+            elif self.gn_expected_input_sharded_memory_config.memory_layout == ttnn.TensorMemoryLayout.HEIGHT_SHARDED:
                 num_cores_across_channel = 1
             else:
                 num_cores_across_channel = int(self.group_norm_core_grid.x * self.group_norm_core_grid.y)
@@ -103,14 +97,14 @@ class transformer_2d_model:
             )
             parameters.norm.weight = ttnn.from_torch(
                 parameters.norm.weight,
-                dtype=ttnn.DataType.BFLOAT16,
+                dtype=ttnn.bfloat16,
                 layout=ttnn.ROW_MAJOR_LAYOUT,
                 device=device,
                 memory_config=ttnn.DRAM_MEMORY_CONFIG,
             )
             parameters.norm.bias = ttnn.from_torch(
                 parameters.norm.bias,
-                dtype=ttnn.DataType.BFLOAT16,
+                dtype=ttnn.bfloat16,
                 layout=ttnn.ROW_MAJOR_LAYOUT,
                 device=device,
                 memory_config=ttnn.DRAM_MEMORY_CONFIG,
@@ -121,7 +115,7 @@ class transformer_2d_model:
             )
             self.norm_input_mask = ttnn.from_torch(
                 self.norm_input_mask_torch_tensor,
-                dtype=ttnn.DataType.BFLOAT8_B,
+                dtype=ttnn.bfloat8_b,
                 layout=ttnn.TILE_LAYOUT,
                 device=device,
                 memory_config=ttnn.DRAM_MEMORY_CONFIG,
@@ -285,7 +279,7 @@ class transformer_2d_model:
         hidden_states = ttnn.tilize(
             hidden_states,
             memory_config=hidden_states.memory_config(),
-            dtype=ttnn.experimental.tensor.DataType.BFLOAT8_B,
+            dtype=ttnn.bfloat8_b,
         )
         hidden_states = ttnn.to_memory_config(hidden_states, self.proj_in.conv.input_sharded_memory_config)
 

--- a/models/demos/wormhole/stable_diffusion/tt/ttnn_functional_transformer_2d_new_conv.py
+++ b/models/demos/wormhole/stable_diffusion/tt/ttnn_functional_transformer_2d_new_conv.py
@@ -62,15 +62,9 @@ class transformer_2d_model:
         )
 
         if not self.fallback_on_groupnorm:
-            if (
-                self.gn_expected_input_sharded_memory_config.memory_layout
-                == ttnn.types.TensorMemoryLayout.BLOCK_SHARDED
-            ):
+            if self.gn_expected_input_sharded_memory_config.memory_layout == ttnn.TensorMemoryLayout.BLOCK_SHARDED:
                 num_cores_across_channel = self.group_norm_core_grid.y
-            elif (
-                self.gn_expected_input_sharded_memory_config.memory_layout
-                == ttnn.types.TensorMemoryLayout.HEIGHT_SHARDED
-            ):
+            elif self.gn_expected_input_sharded_memory_config.memory_layout == ttnn.TensorMemoryLayout.HEIGHT_SHARDED:
                 num_cores_across_channel = 1
             else:
                 num_cores_across_channel = int(self.group_norm_core_grid.x * self.group_norm_core_grid.y)
@@ -83,14 +77,14 @@ class transformer_2d_model:
             )
             parameters.norm.weight = ttnn.from_torch(
                 parameters.norm.weight,
-                dtype=ttnn.DataType.BFLOAT16,
+                dtype=ttnn.bfloat16,
                 layout=ttnn.ROW_MAJOR_LAYOUT,
                 device=device,
                 memory_config=ttnn.DRAM_MEMORY_CONFIG,
             )
             parameters.norm.bias = ttnn.from_torch(
                 parameters.norm.bias,
-                dtype=ttnn.DataType.BFLOAT16,
+                dtype=ttnn.bfloat16,
                 layout=ttnn.ROW_MAJOR_LAYOUT,
                 device=device,
                 memory_config=ttnn.DRAM_MEMORY_CONFIG,
@@ -101,7 +95,7 @@ class transformer_2d_model:
             )
             self.norm_input_mask = ttnn.from_torch(
                 self.norm_input_mask_torch_tensor,
-                dtype=ttnn.DataType.BFLOAT8_B,
+                dtype=ttnn.bfloat8_b,
                 layout=ttnn.TILE_LAYOUT,
                 device=device,
                 memory_config=ttnn.DRAM_MEMORY_CONFIG,
@@ -242,7 +236,7 @@ class transformer_2d_model:
         hidden_states = ttnn.tilize(
             hidden_states,
             memory_config=hidden_states.memory_config(),
-            dtype=ttnn.experimental.tensor.DataType.BFLOAT8_B,
+            dtype=ttnn.bfloat8_b,
         )
 
         conv_config = ttnn.Conv2dConfig(

--- a/models/demos/wormhole/stable_diffusion/tt/ttnn_functional_unet_2d_condition_model.py
+++ b/models/demos/wormhole/stable_diffusion/tt/ttnn_functional_unet_2d_condition_model.py
@@ -264,15 +264,9 @@ class UNet2DConditionModel:
         )
 
         if not self.fallback_on_groupnorm:
-            if (
-                self.gn_expected_input_sharded_memory_config.memory_layout
-                == ttnn.types.TensorMemoryLayout.BLOCK_SHARDED
-            ):
+            if self.gn_expected_input_sharded_memory_config.memory_layout == ttnn.TensorMemoryLayout.BLOCK_SHARDED:
                 num_cores_across_channel = self.group_norm_core_grid.y
-            elif (
-                self.gn_expected_input_sharded_memory_config.memory_layout
-                == ttnn.types.TensorMemoryLayout.HEIGHT_SHARDED
-            ):
+            elif self.gn_expected_input_sharded_memory_config.memory_layout == ttnn.TensorMemoryLayout.HEIGHT_SHARDED:
                 num_cores_across_channel = 1
             else:
                 num_cores_across_channel = int(self.group_norm_core_grid.x * self.group_norm_core_grid.y)
@@ -285,14 +279,14 @@ class UNet2DConditionModel:
             )
             self.parameters.conv_norm_out.weight = ttnn.from_torch(
                 self.parameters.conv_norm_out.weight,
-                dtype=ttnn.DataType.BFLOAT16,
+                dtype=ttnn.bfloat16,
                 layout=ttnn.ROW_MAJOR_LAYOUT,
                 device=device,
                 memory_config=ttnn.DRAM_MEMORY_CONFIG,
             )
             self.parameters.conv_norm_out.bias = ttnn.from_torch(
                 self.parameters.conv_norm_out.bias,
-                dtype=ttnn.DataType.BFLOAT16,
+                dtype=ttnn.bfloat16,
                 layout=ttnn.ROW_MAJOR_LAYOUT,
                 device=device,
                 memory_config=ttnn.DRAM_MEMORY_CONFIG,
@@ -302,7 +296,7 @@ class UNet2DConditionModel:
             )
             self.norm_input_mask = ttnn.from_torch(
                 self.norm_input_mask_torch_tensor,
-                dtype=ttnn.DataType.BFLOAT8_B,
+                dtype=ttnn.bfloat8_b,
                 layout=ttnn.TILE_LAYOUT,
                 device=device,
                 memory_config=ttnn.DRAM_MEMORY_CONFIG,

--- a/models/demos/wormhole/stable_diffusion/tt/ttnn_functional_unet_2d_condition_model_new_conv.py
+++ b/models/demos/wormhole/stable_diffusion/tt/ttnn_functional_unet_2d_condition_model_new_conv.py
@@ -231,15 +231,9 @@ class UNet2DConditionModel:
         )
 
         if not self.fallback_on_groupnorm:
-            if (
-                self.gn_expected_input_sharded_memory_config.memory_layout
-                == ttnn.types.TensorMemoryLayout.BLOCK_SHARDED
-            ):
+            if self.gn_expected_input_sharded_memory_config.memory_layout == ttnn.TensorMemoryLayout.BLOCK_SHARDED:
                 num_cores_across_channel = self.group_norm_core_grid.y
-            elif (
-                self.gn_expected_input_sharded_memory_config.memory_layout
-                == ttnn.types.TensorMemoryLayout.HEIGHT_SHARDED
-            ):
+            elif self.gn_expected_input_sharded_memory_config.memory_layout == ttnn.TensorMemoryLayout.HEIGHT_SHARDED:
                 num_cores_across_channel = 1
             else:
                 num_cores_across_channel = int(self.group_norm_core_grid.x * self.group_norm_core_grid.y)
@@ -252,14 +246,14 @@ class UNet2DConditionModel:
             )
             self.parameters.conv_norm_out.weight = ttnn.from_torch(
                 self.parameters.conv_norm_out.weight,
-                dtype=ttnn.DataType.BFLOAT16,
+                dtype=ttnn.bfloat16,
                 layout=ttnn.ROW_MAJOR_LAYOUT,
                 device=device,
                 memory_config=ttnn.DRAM_MEMORY_CONFIG,
             )
             self.parameters.conv_norm_out.bias = ttnn.from_torch(
                 self.parameters.conv_norm_out.bias,
-                dtype=ttnn.DataType.BFLOAT16,
+                dtype=ttnn.bfloat16,
                 layout=ttnn.ROW_MAJOR_LAYOUT,
                 device=device,
                 memory_config=ttnn.DRAM_MEMORY_CONFIG,
@@ -269,7 +263,7 @@ class UNet2DConditionModel:
             )
             self.norm_input_mask = ttnn.from_torch(
                 self.norm_input_mask_torch_tensor,
-                dtype=ttnn.DataType.BFLOAT8_B,
+                dtype=ttnn.bfloat8_b,
                 layout=ttnn.TILE_LAYOUT,
                 device=device,
                 memory_config=ttnn.DRAM_MEMORY_CONFIG,

--- a/models/demos/wormhole/stable_diffusion/tt/ttnn_functional_upsample_nearest_2d.py
+++ b/models/demos/wormhole/stable_diffusion/tt/ttnn_functional_upsample_nearest_2d.py
@@ -43,31 +43,31 @@ class upsample_nearest2d:
         ncores = (nshards_h, nshards_w)
         assert ncores == max_grid_size
 
-        shard_grid = ttnn.experimental.tensor.CoreRangeSet(
+        shard_grid = ttnn.CoreRangeSet(
             {
-                ttnn.experimental.tensor.CoreRange(
-                    ttnn.experimental.tensor.CoreCoord(0, 0),
-                    ttnn.experimental.tensor.CoreCoord(max_grid_size[1] - 1, max_grid_size[0] - 1),
+                ttnn.CoreRange(
+                    ttnn.CoreCoord(0, 0),
+                    ttnn.CoreCoord(max_grid_size[1] - 1, max_grid_size[0] - 1),
                 )
             }
         )
 
-        shard_orientation = ttnn.experimental.tensor.ShardOrientation.ROW_MAJOR
-        tensor_memory_layout = ttnn.types.TensorMemoryLayout.BLOCK_SHARDED
+        shard_orientation = ttnn.ShardOrientation.ROW_MAJOR
+        tensor_memory_layout = ttnn.TensorMemoryLayout.BLOCK_SHARDED
 
         ## input shard
         shard_height = math.ceil(batch_size * input_height * input_width / ncores[0])
         shard_width = math.ceil(in_channels / ncores[1])
 
         shard_shape = (shard_height, shard_width)
-        shard_spec = ttnn.experimental.tensor.ShardSpec(shard_grid, shard_shape, shard_orientation, False)
-        self.in_sharded_mem_config = ttnn.MemoryConfig(tensor_memory_layout, ttnn.types.BufferType.L1, shard_spec)
+        shard_spec = ttnn.ShardSpec(shard_grid, shard_shape, shard_orientation, False)
+        self.in_sharded_mem_config = ttnn.MemoryConfig(tensor_memory_layout, ttnn.BufferType.L1, shard_spec)
 
         ## output shard
         shard_height = shard_height * scale_factor * scale_factor
         shard_shape = (shard_height, shard_width)
-        shard_spec = ttnn.experimental.tensor.ShardSpec(shard_grid, shard_shape, shard_orientation, False)
-        self.out_sharded_mem_config = ttnn.MemoryConfig(tensor_memory_layout, ttnn.types.BufferType.L1, shard_spec)
+        shard_spec = ttnn.ShardSpec(shard_grid, shard_shape, shard_orientation, False)
+        self.out_sharded_mem_config = ttnn.MemoryConfig(tensor_memory_layout, ttnn.BufferType.L1, shard_spec)
 
     def __call__(self, input):
         if input.memory_config() != self.in_sharded_mem_config:

--- a/models/demos/wormhole/stable_diffusion/tt/ttnn_functional_utility_functions.py
+++ b/models/demos/wormhole/stable_diffusion/tt/ttnn_functional_utility_functions.py
@@ -256,7 +256,7 @@ def reshard_to(tensor, grid_size, layout, col_major=False, shape=None):
     else:
         shape = tensor.shape
         volume = tensor.volume()
-    if layout == ttnn.experimental.tensor.TensorMemoryLayout.BLOCK_SHARDED:
+    if layout == ttnn.TensorMemoryLayout.BLOCK_SHARDED:
         logical_grid_size = list(grid_size)
         if col_major:
             logical_grid_size[0], logical_grid_size[1] = grid_size[1], grid_size[0]
@@ -264,30 +264,26 @@ def reshard_to(tensor, grid_size, layout, col_major=False, shape=None):
             volume // shape[-1] // logical_grid_size[1],
             shape[-1] // logical_grid_size[0],
         ]
-    elif layout == ttnn.experimental.tensor.TensorMemoryLayout.HEIGHT_SHARDED:
+    elif layout == ttnn.TensorMemoryLayout.HEIGHT_SHARDED:
         num_cores = grid_size[0] * grid_size[1]
         shard_spec = [volume // shape[-1] // num_cores, shape[-1]]
-    output_shard_grid = ttnn.experimental.tensor.CoreRangeSet(
+    output_shard_grid = ttnn.CoreRangeSet(
         {
-            ttnn.experimental.tensor.CoreRange(
-                ttnn.experimental.tensor.CoreCoord(0, 0),
-                ttnn.experimental.tensor.CoreCoord(grid_size[0] - 1, grid_size[1] - 1),
+            ttnn.CoreRange(
+                ttnn.CoreCoord(0, 0),
+                ttnn.CoreCoord(grid_size[0] - 1, grid_size[1] - 1),
             )
         }
     )
-    output_shard_spec = ttnn.experimental.tensor.ShardSpec(
+    output_shard_spec = ttnn.ShardSpec(
         output_shard_grid,
         shard_spec,
-        (
-            ttnn.experimental.tensor.ShardOrientation.COL_MAJOR
-            if col_major
-            else ttnn.experimental.tensor.ShardOrientation.ROW_MAJOR
-        ),
+        (ttnn.ShardOrientation.COL_MAJOR if col_major else ttnn.ShardOrientation.ROW_MAJOR),
         False,
     )
-    output_mem_config = ttnn.experimental.tensor.MemoryConfig(
+    output_mem_config = ttnn.MemoryConfig(
         layout,
-        ttnn.experimental.tensor.BufferType.L1,
+        ttnn.BufferType.L1,
         output_shard_spec,
     )
     if tensor.is_sharded():
@@ -301,6 +297,6 @@ def reshard_to(tensor, grid_size, layout, col_major=False, shape=None):
             grid_size,
             shard_spec,
             layout,
-            ttnn.experimental.tensor.ShardOrientation.ROW_MAJOR,
+            ttnn.ShardOrientation.ROW_MAJOR,
         )
     return tensor


### PR DESCRIPTION
### Ticket
Link to Github Issue #11646  
Master Issue #11513

### Problem description
Replace ttnn.experimental.tensor.* with ttnn.* APIs in models/demos

### Checklist
- [x] Post commit CI https://github.com/tenstorrent/tt-metal/actions/runs/10611921163
- [x] model perf https://github.com/tenstorrent/tt-metal/actions/runs/10599206598
- [x] demos https://github.com/tenstorrent/tt-metal/actions/runs/10599204526
- [x] t3k model perf https://github.com/tenstorrent/tt-metal/actions/runs/10599211049
- [x] t3k frequent https://github.com/tenstorrent/tt-metal/actions/runs/10600945670
- [ ] nightly fd https://github.com/tenstorrent/tt-metal/actions/runs/10599215089
- [x] tg nightly https://github.com/tenstorrent/tt-metal/actions/runs/10599449495
- [x] device perf https://github.com/tenstorrent/tt-metal/actions/runs/10599234879
- [x] PC model tests https://github.com/tenstorrent/tt-metal/actions/runs/10599555373
- [x] Model regression CI testing passes (if applicable)
- [x] New/Existing tests provide coverage for changes
