### PR TITLE
#0: Update matmul_multi_core_reuse to support mixed precision

### DIFF
--- a/ttnn/cpp/ttnn/operations/matmul/device/kernels/compute/bmm_large_block_zm.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/kernels/compute/bmm_large_block_zm.cpp
@@ -22,7 +22,7 @@ void MAIN {
     uint32_t out_subblock_num_tiles = get_compile_time_arg_val(10);  // out_subblock_h * out_subblock_w;
     uint32_t batch = get_compile_time_arg_val(11);                   // batch dim
 
-    mm_init();
+    mm_init(tt::CB::c_in0, tt::CB::c_in1, tt::CB::c_intermed0);
 
     for (uint32_t b = 0; b < batch; b++) {
         bool spill = num_blocks > 1;
@@ -41,13 +41,13 @@ void MAIN {
                     acquire_dst(tt::DstMode::Half);
 
                     if (enable_reload) {
-                        copy_tile_to_dst_init_short();
+                        copy_tile_to_dst_init_short_with_dt(tt::CB::c_in1, tt::CB::c_intermed0);
                         cb_wait_front(tt::CB::c_intermed0, out_subblock_num_tiles);
                         for (uint32_t i = 0; i < out_subblock_num_tiles; i++) {
                             copy_tile(tt::CB::c_intermed0, i, i);
                         }
                         cb_pop_front(tt::CB::c_intermed0, out_subblock_num_tiles);
-                        mm_init_short();
+                        mm_init_short_with_dt(tt::CB::c_in0, tt::CB::c_in1, tt::CB::c_intermed0);
                     }
 
                     // Compute output sub-block from in0_subblock x in1_subblock

--- a/ttnn/cpp/ttnn/operations/matmul/device/matmul_op_multi_core_reuse_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/matmul_op_multi_core_reuse_program_factory.cpp
@@ -15,9 +15,10 @@ using tt_metal::Buffer;
 
 tt_metal::operation::ProgramWithCallbacks create_program(
     tt_metal::Device *device,
-    tt::DataFormat cb_data_format,
+    tt::DataFormat in0_cb_data_format,
+    tt::DataFormat in1_cb_data_format,
+    tt::DataFormat out_cb_data_format,
     MathFidelity math_fidelity,
-    uint32_t single_tile_size,
     uint32_t num_cores_x,
     uint32_t B,
     uint32_t M,
@@ -34,15 +35,19 @@ tt_metal::operation::ProgramWithCallbacks create_program(
     tt_metal::Buffer *out_buffer) {
     tt_metal::Program program{};
 
+    uint32_t in0_single_tile_size = tt_metal::detail::TileSize(in0_cb_data_format);
+    uint32_t in1_single_tile_size = tt_metal::detail::TileSize(in1_cb_data_format);
+    uint32_t out_single_tile_size = tt_metal::detail::TileSize(out_cb_data_format);
+
     uint32_t in0_block_tiles = per_core_M * in0_block_w;
     uint32_t in0_CB_tiles = in0_block_tiles * 2;  // double buffer
-    uint32_t in0_CB_size = in0_CB_tiles * single_tile_size;
+    uint32_t in0_CB_size = in0_CB_tiles * in0_single_tile_size;
     uint32_t in1_block_tiles = per_core_N * in0_block_w;
     uint32_t in1_CB_tiles = in1_block_tiles * 2;  // double buffer
-    uint32_t in1_CB_size = in1_CB_tiles * single_tile_size;
+    uint32_t in1_CB_size = in1_CB_tiles * in1_single_tile_size;
     uint32_t out_block_tiles = per_core_M * per_core_N;
     uint32_t out_CB_tiles = out_block_tiles;  // No double buffer
-    uint32_t out_CB_size = out_CB_tiles * single_tile_size;
+    uint32_t out_CB_size = out_CB_tiles * out_single_tile_size;
 
     // Compute kernel compile time args
     uint32_t num_blocks = (K / in0_block_w);
@@ -85,24 +90,24 @@ tt_metal::operation::ProgramWithCallbacks create_program(
     // Create circular buffers
     uint32_t src0_cb_index = 0;
     tt_metal::CircularBufferConfig src0_cb_config =
-        tt_metal::CircularBufferConfig(in0_CB_size, {{src0_cb_index, cb_data_format}})
-            .set_page_size(src0_cb_index, single_tile_size);
+        tt_metal::CircularBufferConfig(in0_CB_size, {{src0_cb_index, in0_cb_data_format}})
+            .set_page_size(src0_cb_index, in0_single_tile_size);
     auto cb_src0 = tt_metal::CreateCircularBuffer(program, all_cores, src0_cb_config);
 
     uint32_t src1_cb_index = 1;
     tt_metal::CircularBufferConfig src1_cb_config =
-        tt_metal::CircularBufferConfig(in1_CB_size, {{src1_cb_index, cb_data_format}})
-            .set_page_size(src1_cb_index, single_tile_size);
+        tt_metal::CircularBufferConfig(in1_CB_size, {{src1_cb_index, in1_cb_data_format}})
+            .set_page_size(src1_cb_index, in1_single_tile_size);
     auto cb_src1 = tt_metal::CreateCircularBuffer(program, all_cores, src1_cb_config);
 
     uint32_t output_cb_index = 16;  // output operands start at index 16
     uint32_t interm0_cb_index = 24;
     std::map<uint8_t, tt::DataFormat> output_cb_data_format_spec{
-        {output_cb_index, cb_data_format}, {interm0_cb_index, cb_data_format}};
+        {output_cb_index, out_cb_data_format}, {interm0_cb_index, out_cb_data_format}};
     tt_metal::CircularBufferConfig output_cb_config =
         tt_metal::CircularBufferConfig(out_CB_size, output_cb_data_format_spec)
-            .set_page_size(output_cb_index, single_tile_size)
-            .set_page_size(interm0_cb_index, single_tile_size);
+            .set_page_size(output_cb_index, out_single_tile_size)
+            .set_page_size(interm0_cb_index, out_single_tile_size);
     auto cb_output = tt_metal::CreateCircularBuffer(program, all_cores, output_cb_config);
 
     bool in0_is_dram = in0_buffer->buffer_type() == tt_metal::BufferType::DRAM ? 1 : 0;
@@ -241,8 +246,9 @@ operation::ProgramWithCallbacks matmul_multi_core_reuse(
     const Tensor &a, const Tensor &b, Tensor &output, bool bcast_batch) {
     const auto &ashape = a.get_legacy_shape(), bshape = b.get_legacy_shape();
 
-    tt::DataFormat cb_data_format = tt_metal::datatype_to_dataformat_converter(a.get_dtype());
-    uint32_t single_tile_size = tt_metal::detail::TileSize(cb_data_format);
+    tt::DataFormat in0_cb_data_format = tt_metal::datatype_to_dataformat_converter(a.get_dtype());
+    tt::DataFormat in1_cb_data_format = tt_metal::datatype_to_dataformat_converter(b.get_dtype());
+    tt::DataFormat out_cb_data_format = tt_metal::datatype_to_dataformat_converter(output.get_dtype());
     MathFidelity math_fidelity = MathFidelity::HiFi4;
 
     tt_metal::Buffer *in0_buffer = a.buffer();
@@ -289,9 +295,10 @@ operation::ProgramWithCallbacks matmul_multi_core_reuse(
 
     return create_program(
         device,
-        cb_data_format,
+        in0_cb_data_format,
+        in1_cb_data_format,
+        out_cb_data_format,
         math_fidelity,
-        single_tile_size,
         num_cores_x,
         B,
         Mt,


### PR DESCRIPTION
### Ticket
Link to Github Issue https://github.com/tenstorrent/tt-metal/issues/10936

### Problem description
- mixed precision matmul does not work for matmul_multi_core_reuse

### What's changed
- add support for mixed precision

### Checklist
- [x] Post commit CI passes https://github.com/tenstorrent/tt-metal/actions/runs/10580712661
- [x] Blackhole Post commit (if applicable) https://github.com/tenstorrent/tt-metal/actions/runs/10580789447
- [x] Model regression CI testing passes (if applicable) https://github.com/tenstorrent/tt-metal/actions/runs/10580755027
- [ ] New/Existing tests provide coverage for changes
