### PR TITLE
#11952: removed manual invoke methods from device operations

### DIFF
--- a/tests/ttnn/unit_tests/operations/test_add.py
+++ b/tests/ttnn/unit_tests/operations/test_add.py
@@ -259,8 +259,19 @@ def test_prim_add(device, shape):
 
     input_tensor_a = ttnn.from_torch(torch_input_tensor_a, layout=ttnn.TILE_LAYOUT, device=device)
     input_tensor_b = ttnn.from_torch(torch_input_tensor_b, layout=ttnn.TILE_LAYOUT, device=device)
-    ttnn.prim.binary(input_tensor_a, input_tensor_b, ttnn.BinaryOpType.ADD, output_tensor=input_tensor_a)
-    output_tensor = ttnn.to_torch(input_tensor_a)
+    output_tensor = ttnn.prim.binary(
+        input_tensor_a,
+        input_tensor_b,
+        output_tensor=None,
+        binary_op_type=ttnn.BinaryOpType.ADD,
+        activations=None,
+        input_tensor_a_activation=None,
+        memory_config=ttnn.DRAM_MEMORY_CONFIG,
+        dtype=ttnn.bfloat16,
+        compute_kernel_config=None,
+        queue_id=0,
+    )
+    output_tensor = ttnn.to_torch(output_tensor)
 
     assert_with_pcc(torch_output_tensor, output_tensor, 0.99988)
     assert output_tensor.shape == shape

--- a/tests/ttnn/unit_tests/operations/test_examples.py
+++ b/tests/ttnn/unit_tests/operations/test_examples.py
@@ -20,7 +20,7 @@ def test_example(device, height, width):
     torch_output_tensor = torch_input_tensor
 
     input_tensor = ttnn.from_torch(torch_input_tensor, layout=ttnn.TILE_LAYOUT, device=device)
-    output_tensor = ttnn.prim.example(input_tensor)
+    output_tensor = ttnn.prim.example(input_tensor, attribute=True, some_other_attribute=42, queue_id=0)
     output_tensor = ttnn.to_torch(output_tensor)
 
     assert_with_pcc(torch_output_tensor, output_tensor, 0.99)

--- a/ttnn/cpp/ttnn/operations/copy.hpp
+++ b/ttnn/cpp/ttnn/operations/copy.hpp
@@ -34,7 +34,7 @@ inline Tensor copy_impl(
                                                                           // DST directly, fp32 is converted to fp16b
 
     auto output_memory_config = optional_output_tensor.has_value() ? optional_output_tensor.value().memory_config() : memory_config.value_or(input_tensor.memory_config());
-    return prim::unary(queue_id, input_tensor, op_chain, output_dtype, output_memory_config, fp32_dest_acc_en, preserve_fp32_precision, optional_output_tensor);
+    return prim::unary(queue_id, {input_tensor, optional_output_tensor}, {op_chain, output_dtype, output_memory_config, fp32_dest_acc_en, preserve_fp32_precision});
 }
 }  // namespace detail
 

--- a/ttnn/cpp/ttnn/operations/data_movement/fold/device/fold_device_op.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/fold/device/fold_device_op.cpp
@@ -77,19 +77,5 @@ Fold::tensor_return_value_t Fold::create_output_tensors(const operation_attribut
     }
 }
 
-std::tuple<Fold::operation_attributes_t, Fold::tensor_args_t>
- Fold::invoke(
-            const ttnn::Tensor &input_tensor,
-            uint32_t stride_h,
-            uint32_t stride_w,
-            const std::optional<const tt::tt_metal::Shape> &output_shape,
-            uint32_t pad_c,
-            uint32_t pad_h,
-            uint32_t pad_w) {
-    bool is_sharded = input_tensor.is_sharded();
-    Fold::operation_attributes_t op_attr = {.stride_h = stride_h, .stride_w = stride_w, .is_sharded = is_sharded};
-    return {op_attr, Fold::tensor_args_t{.input_tensor = input_tensor}};
-}
-
 
 } // namespace ttnn::operations::data_movement

--- a/ttnn/cpp/ttnn/operations/data_movement/fold/device/fold_device_op.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/fold/device/fold_device_op.hpp
@@ -21,7 +21,7 @@ struct Fold {
     };
 
     struct tensor_args_t {
-        const Tensor& input_tensor;
+        const Tensor input_tensor;
     };
 
     using shape_return_value_t = ttnn::Shape;
@@ -71,19 +71,11 @@ struct Fold {
     static void validate_on_program_cache_hit(const operation_attributes_t&, const tensor_args_t&);
     static shape_return_value_t compute_output_shapes(const operation_attributes_t&, const tensor_args_t&);
     static tensor_return_value_t create_output_tensors(const operation_attributes_t&, const tensor_args_t&);
-
-    static std::tuple<operation_attributes_t, tensor_args_t> invoke(
-        const ttnn::Tensor& input_tensor,
-        uint32_t stride_h,
-        uint32_t stride_w,
-        const std::optional<const tt::tt_metal::Shape>& output_shape,
-        uint32_t pad_c,
-        uint32_t pad_h,
-        uint32_t pad_w);
 };
 
 } // namespace ttnn::operations::data_movement
 
 namespace ttnn::prim {
 constexpr auto fold = ttnn::register_operation<"ttnn::prim::fold", ttnn::operations::data_movement::Fold>();
+
 } // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/data_movement/fold/fold.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/fold/fold.cpp
@@ -299,7 +299,7 @@ Tensor FoldOperation::invoke(uint8_t queue_id,
             return fold_with_transpose_(queue_id, input_tensor, output_shape, stride_h, stride_w, pad_c, pad_h, pad_w).at(0);
         }
     }
-    return ttnn::prim::fold(queue_id, input_tensor, stride_h, stride_w, output_shape, pad_c, pad_h, pad_w);
+    return ttnn::prim::fold(queue_id, {input_tensor}, {stride_h, stride_w, input_tensor.is_sharded()});
 }
 
 Tensor FoldOperation::invoke(const ttnn::Tensor &input_tensor,

--- a/ttnn/cpp/ttnn/operations/eltwise/binary/binary.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary/binary.cpp
@@ -151,14 +151,14 @@ Tensor BinaryOperation<binary_op_type>::invoke(
 
     return ttnn::prim::binary(
         queue_id,
-        input_tensor_a,
-        input_tensor_b,
-        binary_op_type,
-        output_dtype,
-        memory_config,
-        optional_output_tensor,
-        activations,
-        input_tensor_a_activation);
+        {input_tensor_a, input_tensor_b, optional_output_tensor},
+        {
+            binary_op_type,
+            activations,
+            input_tensor_a_activation,
+            memory_config.value_or(input_tensor_a_arg.memory_config()),
+            output_dtype.value_or(input_tensor_a_arg.get_dtype()),
+            std::nullopt});
 }
 
 template <BinaryOpType binary_op_type>
@@ -251,7 +251,6 @@ Tensor RelationalBinary<binary_op_type>::invoke(
 
     auto [input_tensor_a, input_tensor_b] = detail::preprocess_inputs<binary_op_type>(input_tensor_a_arg, input_tensor_b_arg);
 
-    auto output_memory_config = memory_config.value_or(input_tensor_a.memory_config());
     DataType dtype = output_dtype.value_or(input_tensor_a.get_dtype());
     if (optional_output_tensor.has_value()) {
         dtype = optional_output_tensor.value().get_dtype();
@@ -259,14 +258,14 @@ Tensor RelationalBinary<binary_op_type>::invoke(
 
     return ttnn::prim::binary(
         queue_id,
-        input_tensor_a,
-        input_tensor_b,
-        binary_op_type,
-        dtype,
-        output_memory_config,
-        optional_output_tensor,
-        activations,
-        input_tensor_a_activation);
+        {input_tensor_a, input_tensor_b, optional_output_tensor},
+        {
+            binary_op_type,
+            activations,
+            input_tensor_a_activation,
+             memory_config.value_or(input_tensor_a.memory_config()),
+            dtype,
+            std::nullopt});
 }
 
 template <BinaryOpType binary_op_type>

--- a/ttnn/cpp/ttnn/operations/eltwise/binary/binary_pybind.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary/binary_pybind.hpp
@@ -24,64 +24,6 @@ namespace detail {
 
 
 template <typename binary_operation_t>
-void bind_primitive_binary_operation(py::module& module, const binary_operation_t& operation, const std::string& description) {
-    auto doc = fmt::format(
-        R"doc({0}(input_tensor_a: ttnn.Tensor, input_tensor_b: ttnn.Tensor, *, memory_config: Optional[ttnn.MemoryConfig] = None, dtype: Optional[ttnn.DataType] = None, activations: Optional[List[str]] = None) -> ttnn.Tensor
-
-        {2}
-
-        Supports broadcasting (except with scalar)
-
-        Args:
-            * :attr:`input_tensor_a`
-            * :attr:`input_tensor_b` (ttnn.Tensor or Number): the tensor or number to add to :attr:`input_tensor_a`.
-
-        Keyword args:
-            * :attr:`memory_config` (Optional[ttnn.MemoryConfig]): memory config for the output tensor
-            * :attr:`dtype` (Optional[ttnn.DataType]): data type for the output tensor
-            * :attr:`output_tensor` (Optional[ttnn.Tensor]): preallocated output tensor
-            * :attr:`activations` (Optional[List[str]]): list of activation functions to apply to the output tensor
-            * :attr:`queue_id` (Optional[uint8]): command queue id
-
-        Example:
-
-            >>> tensor1 = ttnn.to_device(ttnn.from_torch(torch.tensor((1, 2), dtype=torch.bfloat16)), device)
-            >>> tensor2 = ttnn.to_device(ttnn.from_torch(torch.tensor((0, 1), dtype=torch.bfloat16)), device)
-            >>> output = {1}(tensor1, tensor2)
-        )doc",
-        operation.base_name(),
-        operation.python_fully_qualified_name(),
-        description);
-
-    bind_registered_operation(
-        module,
-        operation,
-        doc,
-        ttnn::pybind_overload_t{
-            [](const binary_operation_t& self,
-               const ttnn::Tensor& input_tensor_a,
-               const ttnn::Tensor& input_tensor_b,
-               BinaryOpType binary_op_type,
-               const std::optional<const DataType>& dtype,
-               const std::optional<ttnn::MemoryConfig>& memory_config,
-               const std::optional<ttnn::Tensor>& output_tensor,
-               const std::optional<unary::FusedActivations>& activations,
-               const std::optional<unary::UnaryWithParam>& input_tensor_a_activation) -> ttnn::Tensor {
-                return self(input_tensor_a, input_tensor_b, binary_op_type, dtype, memory_config, output_tensor, activations, input_tensor_a_activation);
-            },
-            py::arg("input_tensor_a"),
-            py::arg("input_tensor_b"),
-            py::arg("binary_op_type"),
-            py::kw_only(),
-            py::arg("dtype") = std::nullopt,
-            py::arg("memory_config") = std::nullopt,
-            py::arg("output_tensor") = std::nullopt,
-            py::arg("activations") = std::nullopt,
-            py::arg("input_tensor_a_activation") = std::nullopt});
-}
-
-
-template <typename binary_operation_t>
 void bind_binary_operation(py::module& module, const binary_operation_t& operation, const std::string& description) {
     auto doc = fmt::format(
         R"doc({0}(input_tensor_a: ttnn.Tensor, input_tensor_b: Union[ttnn.Tensor, int, float], *, memory_config: Optional[ttnn.MemoryConfig] = None, dtype: Optional[ttnn.DataType] = None, activations: Optional[List[str]] = None) -> ttnn.Tensor
@@ -749,10 +691,9 @@ void py_module(py::module& module) {
 
     auto prim_module = module.def_submodule("prim", "Primitive binary operations");
 
-    detail::bind_primitive_binary_operation(
+    bind_primitive_registered_operation(
         prim_module,
-        ttnn::prim::binary,
-        R"doc(Applied binary operation on :attr:`input_tensor_a` to :attr:`input_tensor_b` and returns the tensor with the same layout as :attr:`input_tensor_a`)doc");
+        ttnn::prim::binary);
 
     // new imported
     detail::bind_binary_composite(

--- a/ttnn/cpp/ttnn/operations/eltwise/binary/device/binary_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary/device/binary_device_operation.cpp
@@ -285,32 +285,4 @@ operation::OpPerformanceModel BinaryDeviceOperation::create_op_performance_model
     return result;
 }
 
-
-
-std::tuple<BinaryDeviceOperation::operation_attributes_t, BinaryDeviceOperation::tensor_args_t> BinaryDeviceOperation::invoke(
-    const Tensor &input_tensor_a_arg,
-    const Tensor &input_tensor_b_arg,
-    BinaryOpType binary_op_type,
-    const std::optional<const DataType> &output_dtype,
-    const std::optional<MemoryConfig> &memory_config,
-    std::optional<Tensor> optional_output_tensor,
-    std::optional<unary::FusedActivations> activations,
-    std::optional<unary::UnaryWithParam> input_tensor_a_activation) {
-    if (output_dtype.has_value() && optional_output_tensor.has_value()) {
-        TT_FATAL(
-            output_dtype.value() == optional_output_tensor.value().get_dtype(),
-            "If both output dtype and output tensor provided dtype should match");
-    }
-
-    return {
-        operation_attributes_t{
-            binary_op_type,
-            activations,
-            input_tensor_a_activation,
-            memory_config.value_or(input_tensor_a_arg.memory_config()),
-            output_dtype.value_or(input_tensor_a_arg.get_dtype()),
-            std::nullopt},
-        tensor_args_t{input_tensor_a_arg, input_tensor_b_arg, optional_output_tensor}};
-    }
-
 }  // namespace ttnn::operations::binary

--- a/ttnn/cpp/ttnn/operations/eltwise/binary/device/binary_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary/device/binary_device_operation.hpp
@@ -37,9 +37,9 @@ struct BinaryDeviceOperation {
         std::optional<DeviceComputeKernelConfig> compute_kernel_config;
     };
     struct tensor_args_t {
-        const Tensor& input_tensor_a;
-        const Tensor& input_tensor_b;
-        std::optional<Tensor> output_tensor;
+        const Tensor input_tensor_a{};
+        const Tensor input_tensor_b{};
+        std::optional<Tensor> output_tensor = std::nullopt;
     };
     using shape_return_value_t = ttnn::Shape;
     using tensor_return_value_t = Tensor;
@@ -210,16 +210,6 @@ struct BinaryDeviceOperation {
         const operation_attributes_t& attributes,
         const tensor_args_t& tensor_args,
         tensor_return_value_t& tensor_return_value);
-
-    static std::tuple<operation_attributes_t, tensor_args_t> invoke(
-        const Tensor& input_tensor_a_arg,
-        const Tensor& input_tensor_b_arg,
-        BinaryOpType binary_op_type,
-        const std::optional<const DataType>& output_dtype,
-        const std::optional<MemoryConfig>& memory_config,
-        std::optional<Tensor> optional_output_tensor,
-        std::optional<unary::FusedActivations> activations,
-        std::optional<unary::UnaryWithParam> input_tensor_a_activation);
 };
 
 }  // namespace ttnn::operations::binary

--- a/ttnn/cpp/ttnn/operations/eltwise/unary/device/unary_device_operation_types.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary/device/unary_device_operation_types.hpp
@@ -21,7 +21,7 @@ struct operation_attributes_t {
 };
 
 struct tensor_args_t {
-    const Tensor& input;
+    const Tensor input{};
     std::optional<Tensor> preallocated_output;
 };
 

--- a/ttnn/cpp/ttnn/operations/eltwise/unary/unary.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary/unary.cpp
@@ -33,7 +33,7 @@ inline Tensor unary_impl(
                                                                           // DST directly, fp32 is converted to fp16b
 
     auto output_memory_config = optional_output_tensor.has_value() ? optional_output_tensor.value().memory_config() : memory_config.value_or(input_tensor.memory_config());
-    return prim::unary(queue_id, input_tensor, op_chain, output_dtype, output_memory_config, fp32_dest_acc_en, preserve_fp32_precision, optional_output_tensor);
+    return prim::unary(queue_id, {input_tensor, optional_output_tensor}, {op_chain, output_dtype, output_memory_config, fp32_dest_acc_en, preserve_fp32_precision});
 }
 
 }  // namespace detail

--- a/ttnn/cpp/ttnn/operations/examples/example/device/example_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/examples/example/device/example_device_operation.cpp
@@ -38,13 +38,4 @@ ExampleDeviceOperation::tensor_return_value_t ExampleDeviceOperation::create_out
 }
 
 
-std::tuple<ExampleDeviceOperation::operation_attributes_t, ExampleDeviceOperation::tensor_args_t>
-ExampleDeviceOperation::invoke(const Tensor& input_tensor) {
-    return {
-        operation_attributes_t{true, 42},
-        tensor_args_t{input_tensor}
-    };
-}
-
-
 }  // namespace ttnn::operations::examples

--- a/ttnn/cpp/ttnn/operations/examples/example/device/example_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/examples/example/device/example_device_operation.hpp
@@ -27,12 +27,12 @@ struct ExampleDeviceOperation {
     // tensors, etc.
     struct tensor_args_t {
         // This example will use a tensor that can only be used as an input
-        const Tensor& input_tensor;
+        const Tensor input_tensor{};
 
         // However, the following examples show what else can be done with tensor_args_t
 
         // An example of the tensor that can be used for input/output or just for pre-allocated output
-        // Tensor& io_tensor;
+        // Tensor io_tensor;
 
         // An example of an optional tensor
         // std::optional<Tensor> optional_output_tensor;
@@ -123,13 +123,6 @@ struct ExampleDeviceOperation {
     // Create the output tensors based on the operation attributes and tensor args
     static tensor_return_value_t create_output_tensors(const operation_attributes_t&, const tensor_args_t&);
 
-    // API call to map user arguments to operation attributes and tensor args.
-    // This is the only method that is called by the user
-    // The user will be able to call the operation using `tensor_return_value_t output = ttnn::prim::example(input_tensor)` after the op is registered
-    // Keep in mind that the the overload with `queue_id` argument will be added automatically for primitive operations
-    // So, the user can also call this operation using `tensor_return_value_t output = ttnn::prim::example(queue_id, input_tensor)`
-    static std::tuple<operation_attributes_t, tensor_args_t> invoke(const Tensor& input_tensor);
-
     // Optional methods
 
     // In case the operation need a custom hash function, the following method can be implemented
@@ -149,6 +142,9 @@ struct ExampleDeviceOperation {
 }  // namespace ttnn::operations::examples
 
 // Register the operation with the ttnn::register_operation API to make it available to the user as ttnn::prim::example
+// The user will be able to call the operation using `tensor_return_value_t output = ttnn::prim::example({.input_tensor=input_tensor}, {.attribute=true, .some_other_attribute=42})` after the op is registered
+// Keep in mind that the the overload with `queue_id` argument will be added automatically for primitive operations
+// So, the user can also call this operation using `tensor_return_value_t output = ttnn::prim::example(queue_id, {.input_tensor=input_tensor}, {.attribute=true, .some_other_attribute=42})`
 namespace ttnn::prim {
 constexpr auto example = ttnn::register_operation<
     "ttnn::prim::example",

--- a/ttnn/cpp/ttnn/operations/examples/example/example.hpp
+++ b/ttnn/cpp/ttnn/operations/examples/example/example.hpp
@@ -16,8 +16,8 @@ struct CompositeExampleOperation {
 
     // The user will be able to call this method as `Tensor output = ttnn::composite_example(input_tensor)` after the op is registered
     static Tensor invoke(const Tensor& input_tensor) {
-        auto copy = prim::example(input_tensor);
-        auto another_copy = prim::example(copy);
+        auto copy = prim::example({.input_tensor=input_tensor});
+        auto another_copy = prim::example({.input_tensor=copy});
         return another_copy;
     }
 };

--- a/ttnn/cpp/ttnn/operations/examples/example/example_pybind.hpp
+++ b/ttnn/cpp/ttnn/operations/examples/example/example_pybind.hpp
@@ -17,19 +17,14 @@ namespace ttnn::operations::examples {
 
 void bind_example_operation(py::module& module) {
 
-    bind_registered_operation(
-        module,
-        ttnn::prim::example,
-        R"doc(example(input_tensor: ttnn.Tensor) -> ttnn.Tensor)doc",
 
-        // Add pybind overloads for the C++ APIs that should be exposed to python
-        // There should be no logic here, just a call to `self` with the correct arguments
-        // The overload with `queue_id` argument will be added automatically for primitive operations
-        // This specific function can be called from python as `ttnn.prim.example(input_tensor)` or `ttnn.prim.example(input_tensor, queue_id=queue_id)`
-        ttnn::pybind_overload_t{
-            [](const decltype(ttnn::prim::example)& self, const ttnn::Tensor& input_tensor)
-                -> ttnn::Tensor { return self(input_tensor); },
-            py::arg("input_tensor")});
+    // Add pybind overloads for the C++ APIs that should be exposed to python
+    // There should be no logic here, just a call to `self` with the correct arguments
+    // The overload with `queue_id` argument will be added automatically for primitive operations
+    // This specific function can be called from python as `ttnn.prim.example(input_tensor, attribute=True, some_other_attribute=42, queue_id=0)`
+    bind_primitive_registered_operation(
+        module,
+        ttnn::prim::example);
 
     bind_registered_operation(
         module,

--- a/ttnn/cpp/ttnn/operations/experimental/transformer/nlp_create_qkv_heads/device/nlp_create_qkv_heads_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/nlp_create_qkv_heads/device/nlp_create_qkv_heads_device_operation.cpp
@@ -136,26 +136,4 @@ NlpCreateHeadsDeviceOperation::program_factory_t NlpCreateHeadsDeviceOperation::
     }
 }
 
-
-std::tuple<NlpCreateHeadsDeviceOperation::operation_attributes_t, NlpCreateHeadsDeviceOperation::tensor_args_t>
-NlpCreateHeadsDeviceOperation::invoke(
-        const Tensor& input_tensor_q,
-        const std::optional<Tensor>& input_tensor_kv,
-        const uint32_t num_q_heads,
-        const std::optional<uint32_t> num_kv_heads,
-        uint32_t head_dim,
-        const bool transpose_k_heads,
-        const std::optional<MemoryConfig>& memory_config,
-        std::optional<std::vector<std::optional<Tensor>>> optional_output_tensors) {
-
-    return {operation_attributes_t{.num_q_heads = num_q_heads,
-                                   .num_kv_heads = num_kv_heads.value_or(num_q_heads),
-                                   .head_dim = head_dim,
-                                   .transpose_k_heads = transpose_k_heads,
-                                   .output_mem_config = memory_config.value_or(input_tensor_q.memory_config())},
-            tensor_args_t{.input_tensor_q = input_tensor_q,
-                          .input_tensor_kv = input_tensor_kv,
-                          .optional_output_tensors = optional_output_tensors.value_or(std::vector<std::optional<Tensor>>{})}};
-}
-
 }  // namespace ttnn::operations::experimental::transformer

--- a/ttnn/cpp/ttnn/operations/experimental/transformer/nlp_create_qkv_heads/device/nlp_create_qkv_heads_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/nlp_create_qkv_heads/device/nlp_create_qkv_heads_device_operation.hpp
@@ -27,8 +27,8 @@ struct NlpCreateHeadsDeviceOperation {
     };
 
     struct tensor_args_t {
-        const Tensor& input_tensor_q;
-        const std::optional<Tensor> &input_tensor_kv;
+        const Tensor input_tensor_q{};
+        const std::optional<Tensor> input_tensor_kv;
         std::vector<std::optional<Tensor>> optional_output_tensors;
     };
 
@@ -112,16 +112,6 @@ struct NlpCreateHeadsDeviceOperation {
 
     // Create the output tensors based on the operation attributes and tensor args
     static tensor_return_value_t create_output_tensors(const operation_attributes_t&, const tensor_args_t&);
-
-    static std::tuple<operation_attributes_t, tensor_args_t> invoke(
-        const Tensor& input_tensor_q,
-        const std::optional<Tensor>& input_tensor_kv,
-        const uint32_t num_q_heads,
-        const std::optional<uint32_t> num_kv_heads,
-        uint32_t head_dim,
-        const bool transpose_k_heads,
-        const std::optional<MemoryConfig>& memory_config,
-        std::optional<std::vector<std::optional<Tensor>>> optional_output_tensors);
 };
 
 } // namespace ttnn::operations::experimental::transformer

--- a/ttnn/cpp/ttnn/operations/experimental/transformer/nlp_create_qkv_heads/nlp_create_qkv_heads.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/nlp_create_qkv_heads/nlp_create_qkv_heads.cpp
@@ -27,7 +27,10 @@ namespace ttnn::operations::experimental::transformer {
                 head_dim = input_tensor_q.get_legacy_shape()[3] / (num_q_heads + 2 * num_kv_heads_val);
             }
 
-            return ttnn::prim::nlp_create_qkv_heads(queue_id, input_tensor_q, input_tensor_kv, num_q_heads, num_kv_heads, head_dim, transpose_k_heads, memory_config, optional_output_tensors);
+            return ttnn::prim::nlp_create_qkv_heads(
+                queue_id,
+                {input_tensor_q, input_tensor_kv, optional_output_tensors.value_or(std::vector<std::optional<Tensor>>{})},
+                {num_q_heads, num_kv_heads.value_or(num_q_heads), head_dim, transpose_k_heads, memory_config.value_or(input_tensor_q.memory_config())});
     };
 
     std::tuple<ttnn::Tensor, ttnn::Tensor, ttnn::Tensor> NlpCreateHeadsOperation::invoke (

--- a/ttnn/cpp/ttnn/operations/pool/maxpool/device/max_pool2d_device_op.cpp
+++ b/ttnn/cpp/ttnn/operations/pool/maxpool/device/max_pool2d_device_op.cpp
@@ -140,16 +140,4 @@ operation::OpPerformanceModel MaxPoolNew::create_op_performance_model(const oper
     return result;
 }
 
-
-std::tuple<MaxPoolNew::operation_attributes_t, MaxPoolNew::tensor_args_t> MaxPoolNew::invoke(
-    const Tensor& input_tensor,
-    const sliding_window::SlidingWindowConfig& sliding_window_config,
-    DataType output_dtype,
-    MemoryConfig memory_config) {
-    return {
-        operation_attributes_t{sliding_window_config, output_dtype, memory_config},
-        tensor_args_t{input_tensor}
-    };
-}
-
 } // namespace ttnn::operations::pool

--- a/ttnn/cpp/ttnn/operations/pool/maxpool/device/max_pool2d_device_op.hpp
+++ b/ttnn/cpp/ttnn/operations/pool/maxpool/device/max_pool2d_device_op.hpp
@@ -32,7 +32,7 @@ struct MaxPoolNew {
     };
 
     struct tensor_args_t {
-        const Tensor& input_tensor_;
+        const Tensor input_tensor_{};
     };
 
     using shape_return_value_t = ttnn::Shape;
@@ -68,12 +68,6 @@ struct MaxPoolNew {
     static Tensor create_output_tensors(const operation_attributes_t&, const tensor_args_t&);
     static tt::stl::hash::hash_t compute_program_hash(const operation_attributes_t&, const tensor_args_t&);
     static operation::OpPerformanceModel create_op_performance_model(const operation_attributes_t&, const tensor_args_t&, const Tensor&);
-
-    static std::tuple<operation_attributes_t, tensor_args_t> invoke(
-        const Tensor& input_tensor,
-        const sliding_window::SlidingWindowConfig& sliding_window_config,
-        DataType output_dtype,
-        MemoryConfig memory_config);
 
 };
 

--- a/ttnn/cpp/ttnn/operations/pool/maxpool/max_pool2d.cpp
+++ b/ttnn/cpp/ttnn/operations/pool/maxpool/max_pool2d.cpp
@@ -100,10 +100,11 @@ Tensor MaxPoolNewOp::invoke(uint8_t queue_id, const Tensor& input_tensor, uint32
 
     return ttnn::prim::max_pool_new(
         queue_id,
-        haloed_tensor,
-        sliding_window_config,
-        DataType::BFLOAT16,      // input_tensor.dtype(), // currently only bfp16 output is supported
-        memory_config);
+        {haloed_tensor},
+        {
+            sliding_window_config,
+            DataType::BFLOAT16,      // input_tensor.dtype(), // currently only bfp16 output is supported
+            memory_config});
 }
 
 // device template specializations

--- a/ttnn/cpp/ttnn/run_operation.cpp
+++ b/ttnn/cpp/ttnn/run_operation.cpp
@@ -199,18 +199,6 @@ struct OldInfraDeviceOperation {
     static std::string get_type_name(const operation_attributes_t& attributes) {
         return attributes.get_type_name();
     }
-
-    static std::tuple<operation_attributes_t, tensor_args_t> invoke(
-        operation_attributes_t&& operation_attributes,
-        const operation::Tensors& input_tensors,
-        const operation::OptionalConstTensors& optional_input_tensors,
-        const operation::OptionalTensors& optional_output_tensors
-    ) {
-        return std::make_tuple(
-            std::move(operation_attributes),
-            tensor_args_t{input_tensors, optional_input_tensors, optional_output_tensors}
-        );
-    }
 };
 
 
@@ -236,9 +224,15 @@ OutputTensors run(
     uint8_t cq_id) {
 
     if constexpr (std::is_same_v<OutputTensors, Tensors>) {
-        return ttnn::prim::old_infra_device_operation(cq_id, std::move(operation), input_tensors, optional_input_tensors, optional_output_tensors);
+        return ttnn::prim::old_infra_device_operation(
+            cq_id,
+            {input_tensors, optional_input_tensors, optional_output_tensors},
+            {std::move(operation)});
     } else {
-        return ttnn::prim::old_infra_device_operation_with_optional_output_tensors(cq_id, std::move(operation), input_tensors, optional_input_tensors, optional_output_tensors);
+        return ttnn::prim::old_infra_device_operation_with_optional_output_tensors(
+            cq_id,
+             {input_tensors, optional_input_tensors, optional_output_tensors},
+             {std::move(operation)});
     }
 }
 


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/11952

### Problem description
Removed manual `invoke` methods from device operations and replace with automated calls

### What's changed
- Updated `decorators.hpp` to invoke device operations using `ttnn::prim::device_operation(queue_id, tensor_args_tuple, operation_attributes_tuple)`
- `prim` ops are meant to be called by compilers and not users. So, it might be okay to leave this change as is and pass in tuples for `tensor_args` and `operation_attributes`. Alternatively, more time can be spent to make the function accept `tensor_args_t` and `operation_attributes_t` directly.


### What does API look like now?

C++
```cpp
auto output = ttnn::prim::binary(queue_id, {input_tensor_a, input_tensor_b}, {BinaryOpType::Add, in_place});
```

Python
```python
output = ttnn.prim.binary((input_tensor_a, input_tensor_b), (BinaryOpType.Add, in_place), queue_id=queue_id)
```
