### PR TITLE
All gather dispatch time optimization 

### DIFF
--- a/ttnn/cpp/ttnn/operations/ccl/all_gather/device/kernels/dataflow/worker_interleaved_ring_gather_receive_reader.cpp
+++ b/ttnn/cpp/ttnn/operations/ccl/all_gather/device/kernels/dataflow/worker_interleaved_ring_gather_receive_reader.cpp
@@ -9,20 +9,25 @@
 
 
 void kernel_main() {
-    constexpr uint32_t num_transfers = get_compile_time_arg_val(0);
-    constexpr uint32_t num_full_chunks = get_compile_time_arg_val(1);
-    constexpr uint32_t page_size = get_compile_time_arg_val(2);
-    constexpr uint32_t num_pages_per_full_chunk = get_compile_time_arg_val(3);
-    constexpr uint32_t rem_num_pages = get_compile_time_arg_val(4);
-    constexpr uint32_t eth_receiver_noc_x = get_compile_time_arg_val(5);
-    constexpr uint32_t eth_receiver_noc_y = get_compile_time_arg_val(6);
-    constexpr uint32_t eth_receiver_l1_semaphore_addr = get_compile_time_arg_val(7);
-    volatile uint32_t *receiver_read_sem_addr = reinterpret_cast<volatile uint32_t *>(get_semaphore(get_compile_time_arg_val(8)));
-    constexpr uint32_t half_cb_n_pages = get_compile_time_arg_val(9);
-    constexpr uint32_t num_buffers_per_channel = get_compile_time_arg_val(10);
-    static_assert (half_cb_n_pages > rem_num_pages, "half_cb_n_pages must be greater than 0");
+    constexpr uint32_t page_size = get_compile_time_arg_val(0);
+    volatile uint32_t *receiver_read_sem_addr = reinterpret_cast<volatile uint32_t *>(get_semaphore(get_compile_time_arg_val(1)));
+    constexpr uint32_t half_cb_n_pages = get_compile_time_arg_val(2);
+    constexpr uint32_t num_buffers_per_channel = get_compile_time_arg_val(3);
+    // static_assert (half_cb_n_pages > rem_num_pages, "half_cb_n_pages must be greater than 0");
 
-    const uint32_t eth_receiver_l1_base_addr = get_arg_val<uint32_t>(0);
+    uint32_t arg_idx = 0;
+    const uint32_t eth_receiver_l1_base_addr = get_arg_val<uint32_t>(arg_idx++);
+    const bool receiver_enabled = get_arg_val<uint32_t>(arg_idx++) == 1;
+    if (!receiver_enabled) {
+        return;
+    }
+    const uint32_t num_transfers = get_arg_val<uint32_t>(arg_idx++);
+    const uint32_t num_full_chunks = get_arg_val<uint32_t>(arg_idx++);
+    const uint32_t num_pages_per_full_chunk = get_arg_val<uint32_t>(arg_idx++);
+    const uint32_t rem_num_pages = get_arg_val<uint32_t>(arg_idx++);
+    const uint32_t eth_receiver_noc_x = get_arg_val<uint32_t>(arg_idx++);
+    const uint32_t eth_receiver_noc_y = get_arg_val<uint32_t>(arg_idx++);
+    const uint32_t eth_receiver_l1_semaphore_addr = get_arg_val<uint32_t>(arg_idx++);
 
     constexpr uint32_t cb_id_in0 = tt::CB::c_in0;
 
@@ -35,13 +40,13 @@ void kernel_main() {
         receiver_read_sem_addr);
 
     for (uint32_t i = 0; i < num_transfers; ++i) {
-        if constexpr (num_full_chunks > 0) {
+        if (num_full_chunks > 0) {
             for (uint32_t c = 0; c < num_full_chunks; ++c) {
                 reader.wait_for_payload_available();
                 reader.fetch_payload_blocking(cb_id_in0, num_pages_per_full_chunk, page_size, false);
             }
         }
-        if constexpr (rem_num_pages > 0) {
+        if (rem_num_pages > 0) {
             reader.wait_for_payload_available();
             reader.fetch_payload_blocking(cb_id_in0, rem_num_pages, page_size, false);
             ASSERT(num_pages_per_full_chunk == 0 || num_pages_per_full_chunk > rem_num_pages);

--- a/ttnn/cpp/ttnn/operations/ccl/all_gather/device/kernels/dataflow/worker_interleaved_ring_gather_receive_reader.cpp
+++ b/ttnn/cpp/ttnn/operations/ccl/all_gather/device/kernels/dataflow/worker_interleaved_ring_gather_receive_reader.cpp
@@ -13,14 +13,9 @@ void kernel_main() {
     volatile uint32_t *receiver_read_sem_addr = reinterpret_cast<volatile uint32_t *>(get_semaphore(get_compile_time_arg_val(1)));
     constexpr uint32_t half_cb_n_pages = get_compile_time_arg_val(2);
     constexpr uint32_t num_buffers_per_channel = get_compile_time_arg_val(3);
-    // static_assert (half_cb_n_pages > rem_num_pages, "half_cb_n_pages must be greater than 0");
 
     uint32_t arg_idx = 0;
     const uint32_t eth_receiver_l1_base_addr = get_arg_val<uint32_t>(arg_idx++);
-    const bool receiver_enabled = get_arg_val<uint32_t>(arg_idx++) == 1;
-    if (!receiver_enabled) {
-        return;
-    }
     const uint32_t num_transfers = get_arg_val<uint32_t>(arg_idx++);
     const uint32_t num_full_chunks = get_arg_val<uint32_t>(arg_idx++);
     const uint32_t num_pages_per_full_chunk = get_arg_val<uint32_t>(arg_idx++);
@@ -28,6 +23,8 @@ void kernel_main() {
     const uint32_t eth_receiver_noc_x = get_arg_val<uint32_t>(arg_idx++);
     const uint32_t eth_receiver_noc_y = get_arg_val<uint32_t>(arg_idx++);
     const uint32_t eth_receiver_l1_semaphore_addr = get_arg_val<uint32_t>(arg_idx++);
+
+    ASSERT(half_cb_n_pages > rem_num_pages);
 
     constexpr uint32_t cb_id_in0 = tt::CB::c_in0;
 

--- a/ttnn/cpp/ttnn/operations/ccl/all_gather/device/kernels/dataflow/worker_interleaved_ring_gather_send_reader.cpp
+++ b/ttnn/cpp/ttnn/operations/ccl/all_gather/device/kernels/dataflow/worker_interleaved_ring_gather_send_reader.cpp
@@ -12,6 +12,30 @@ void kernel_main() {
     uint32_t arg_idx = 0;
     const uint32_t src_addr = get_arg_val<uint32_t>(arg_idx++);
     const uint32_t dst_addr = get_arg_val<uint32_t>(arg_idx++);
+    const bool sender_enabled = get_arg_val<uint32_t>(arg_idx++) == 1;
+
+    if (!sender_enabled) {
+        return;
+    }
+
+    const uint32_t num_transfers = get_arg_val<uint32_t>(arg_idx++);
+    const uint32_t num_full_chunks = get_arg_val<uint32_t>(arg_idx++);
+    const uint32_t num_pages = get_arg_val<uint32_t>(arg_idx++);
+    const uint32_t rem_num_pages = get_arg_val<uint32_t>(arg_idx++);
+    const uint32_t input_start_idx = get_arg_val<uint32_t>(arg_idx++);
+    const uint32_t output_start_idx = get_arg_val<uint32_t>(arg_idx++);
+    const uint32_t output_start_addr_offset = get_arg_val<uint32_t>(arg_idx++);
+    const uint32_t row_start_idx = get_arg_val<uint32_t>(arg_idx++);
+    const uint32_t col_start_idx = get_arg_val<uint32_t>(arg_idx++);
+    const uint32_t row_offset = get_arg_val<uint32_t>(arg_idx++);
+    const uint32_t col_offset = get_arg_val<uint32_t>(arg_idx++);
+    const uint32_t num_rows = get_arg_val<uint32_t>(arg_idx++);
+    const uint32_t num_cols = get_arg_val<uint32_t>(arg_idx++);
+    const uint32_t last_output_page_offset = get_arg_val<uint32_t>(arg_idx++);
+    const uint32_t output_page_offset = get_arg_val<uint32_t>(arg_idx++);
+    const uint32_t last_output_addr_offset = get_arg_val<uint32_t>(arg_idx++);
+    const uint32_t output_addr_offset = get_arg_val<uint32_t>(arg_idx++);
+    const bool is_clockwise_direction = get_arg_val<uint32_t>(arg_idx++) == 1;
 
     #ifdef SHARDED_MEM_LAYOUT
     uint32_t input_shard_grid_nrows = get_arg_val<uint32_t>(arg_idx++);
@@ -31,51 +55,33 @@ void kernel_main() {
 
     constexpr bool src_is_dram = get_compile_time_arg_val(0) == 1;
     constexpr bool dst_is_dram = get_compile_time_arg_val(1) == 1;
-    constexpr uint32_t num_transfers = get_compile_time_arg_val(2);
-    constexpr uint32_t num_full_chunks = get_compile_time_arg_val(3);
-    constexpr uint32_t page_size = get_compile_time_arg_val(4);
-    constexpr uint32_t output_page_size = get_compile_time_arg_val(5);
-    constexpr uint32_t num_pages = get_compile_time_arg_val(6);
-    constexpr uint32_t rem_num_pages = get_compile_time_arg_val(7);
-    constexpr uint32_t input_start_idx = get_compile_time_arg_val(8);
-    constexpr uint32_t output_start_idx = get_compile_time_arg_val(9);
-    constexpr uint32_t output_start_addr_offset = get_compile_time_arg_val(10);
-    constexpr uint32_t row_start_idx = get_compile_time_arg_val(11);
-    constexpr uint32_t col_start_idx = get_compile_time_arg_val(12);
-    constexpr uint32_t row_offset = get_compile_time_arg_val(13);
-    constexpr uint32_t col_offset = get_compile_time_arg_val(14);
-    constexpr uint32_t num_rows = get_compile_time_arg_val(15);
-    constexpr uint32_t num_cols = get_compile_time_arg_val(16);
-    constexpr uint32_t last_output_page_offset = get_compile_time_arg_val(17);
-    constexpr uint32_t output_page_offset = get_compile_time_arg_val(18);
-    constexpr uint32_t last_output_addr_offset = get_compile_time_arg_val(19);
-    constexpr uint32_t output_addr_offset = get_compile_time_arg_val(20);
-    constexpr uint32_t input_start_ring_idx = get_compile_time_arg_val(21);
-    uint32_t sem_addr = get_semaphore(get_compile_time_arg_val(22));
-    constexpr bool is_clockwise_direction = get_compile_time_arg_val(23) == 1;
-    constexpr uint32_t half_cb_n_pages = get_compile_time_arg_val(24);
-    constexpr uint32_t ring_size = get_compile_time_arg_val(25);
+    constexpr uint32_t page_size = get_compile_time_arg_val(2);
+    constexpr uint32_t output_page_size = get_compile_time_arg_val(3);
+    constexpr uint32_t input_start_ring_idx = get_compile_time_arg_val(4);
+    uint32_t sem_addr = get_semaphore(get_compile_time_arg_val(5));
+    constexpr uint32_t half_cb_n_pages = get_compile_time_arg_val(6);
+    constexpr uint32_t ring_size = get_compile_time_arg_val(7);
     #ifdef SHARDED_MEM_LAYOUT
 
-    constexpr tt::tt_metal::TensorMemoryLayout input_tensor_memory_layout = static_cast<tt::tt_metal::TensorMemoryLayout>(get_compile_time_arg_val(26));
-    constexpr uint32_t input_tensor_shard_grid_height = get_compile_time_arg_val(27);
-    constexpr uint32_t input_tensor_shard_grid_width = get_compile_time_arg_val(28);
-    constexpr uint32_t input_tensor_shard_grid_start_y_logical = get_compile_time_arg_val(29);
-    constexpr uint32_t input_tensor_shard_grid_start_x_logical = get_compile_time_arg_val(30);
-    constexpr uint32_t input_tensor_shard_pages_per_shard_y = get_compile_time_arg_val(31);
-    constexpr uint32_t input_tensor_shard_pages_per_shard_x = get_compile_time_arg_val(32);
-    constexpr bool input_tensor_shard_grid_transposed = get_compile_time_arg_val(33) != 0;
+    constexpr tt::tt_metal::TensorMemoryLayout input_tensor_memory_layout = static_cast<tt::tt_metal::TensorMemoryLayout>(get_compile_time_arg_val(8));
+    constexpr uint32_t input_tensor_shard_grid_height = get_compile_time_arg_val(9);
+    constexpr uint32_t input_tensor_shard_grid_width = get_compile_time_arg_val(10);
+    constexpr uint32_t input_tensor_shard_grid_start_y_logical = get_compile_time_arg_val(11);
+    constexpr uint32_t input_tensor_shard_grid_start_x_logical = get_compile_time_arg_val(12);
+    constexpr uint32_t input_tensor_shard_pages_per_shard_y = get_compile_time_arg_val(13);
+    constexpr uint32_t input_tensor_shard_pages_per_shard_x = get_compile_time_arg_val(14);
+    constexpr bool input_tensor_shard_grid_transposed = get_compile_time_arg_val(15) != 0;
 
-    constexpr tt::tt_metal::TensorMemoryLayout output_tensor_memory_layout = static_cast<tt::tt_metal::TensorMemoryLayout>(get_compile_time_arg_val(34));
-    constexpr uint32_t output_tensor_shard_grid_height = get_compile_time_arg_val(35);
-    constexpr uint32_t output_tensor_shard_grid_width = get_compile_time_arg_val(36);
-    constexpr uint32_t output_tensor_shard_grid_start_y_logical = get_compile_time_arg_val(37);
-    constexpr uint32_t output_tensor_shard_grid_start_x_logical = get_compile_time_arg_val(38);
-    constexpr uint32_t output_tensor_shard_pages_per_shard_y = get_compile_time_arg_val(39);
-    constexpr uint32_t output_tensor_shard_pages_per_shard_x = get_compile_time_arg_val(40);
-    constexpr bool output_tensor_shard_grid_transposed = get_compile_time_arg_val(41) != 0;
+    constexpr tt::tt_metal::TensorMemoryLayout output_tensor_memory_layout = static_cast<tt::tt_metal::TensorMemoryLayout>(get_compile_time_arg_val(16));
+    constexpr uint32_t output_tensor_shard_grid_height = get_compile_time_arg_val(17);
+    constexpr uint32_t output_tensor_shard_grid_width = get_compile_time_arg_val(18);
+    constexpr uint32_t output_tensor_shard_grid_start_y_logical = get_compile_time_arg_val(19);
+    constexpr uint32_t output_tensor_shard_grid_start_x_logical = get_compile_time_arg_val(20);
+    constexpr uint32_t output_tensor_shard_pages_per_shard_y = get_compile_time_arg_val(21);
+    constexpr uint32_t output_tensor_shard_pages_per_shard_x = get_compile_time_arg_val(22);
+    constexpr bool output_tensor_shard_grid_transposed = get_compile_time_arg_val(23) != 0;
     #endif
-    static_assert(half_cb_n_pages > rem_num_pages, "half_cb_n_pages must be greater than or equal to rem_num_pages");
+    // static_assert(half_cb_n_pages > rem_num_pages, "half_cb_n_pages must be greater than or equal to rem_num_pages");
 
     constexpr uint32_t cb_id_in0 = tt::CB::c_in0;
 
@@ -172,12 +178,12 @@ void kernel_main() {
     uint32_t col_idx = col_start_idx;
     uint32_t row_idx = row_start_idx;
 
-    if constexpr(num_full_chunks > 0) {
+    if (num_full_chunks > 0) {
         for (uint32_t c = 0; c < num_full_chunks; ++c) {
             read_chunk_from_input_tensor(input_page_idx, cb_id_in0, s, num_pages, page_size);
         }
     }
-    if constexpr(rem_num_pages > 0) {
+    if (rem_num_pages > 0) {
         read_chunk_from_input_tensor(input_page_idx, cb_id_in0, s, rem_num_pages, page_size);
         ASSERT(num_pages == 0 || num_pages > rem_num_pages);
         ASSERT(half_cb_n_pages > rem_num_pages);
@@ -191,38 +197,38 @@ void kernel_main() {
         if (is_clockwise_direction) {
             if (input_ring_idx == 0) {
                 input_ring_idx = ring_size - 1;
-                if constexpr(output_addr_offset != 0) {
+                if (output_addr_offset != 0) {
                     d.bank_base_address += last_output_addr_offset;
                 }
-                if constexpr(output_page_offset != 0) {
+                if (output_page_offset != 0) {
                     output_base_page_idx += last_output_page_offset;
                 }
             } else {
                 input_ring_idx--;
-                if constexpr(output_addr_offset != 0) {
+                if (output_addr_offset != 0) {
                     d.bank_base_address -= output_addr_offset;
                 }
-                if constexpr(output_page_offset != 0) {
+                if (output_page_offset != 0) {
                     output_base_page_idx -= output_page_offset;
                 }
             }
         } else {
             if (input_ring_idx == ring_size - 1) {//0) {
                 input_ring_idx = 0;
-                if constexpr(output_addr_offset != 0) {
+                if (output_addr_offset != 0) {
                     d.bank_base_address -= last_output_addr_offset;
                     // d.bank_base_address = last_output_addr_offset;
                 }
-                if constexpr(output_page_offset != 0) {
+                if (output_page_offset != 0) {
                     output_base_page_idx -= last_output_page_offset;
                     // output_base_page_idx = last_output_page_offset;
                 }
             } else {
                 input_ring_idx++;
-                if constexpr(output_addr_offset != 0) {
+                if (output_addr_offset != 0) {
                     d.bank_base_address += output_addr_offset;
                 }
-                if constexpr(output_page_offset != 0) {
+                if (output_page_offset != 0) {
                     output_base_page_idx += output_page_offset;
                 }
             }
@@ -230,14 +236,14 @@ void kernel_main() {
         output_page_idx = output_base_page_idx;
         col_idx = col_start_idx;
         row_idx = row_start_idx;
-        if constexpr(num_full_chunks > 0) {
+        if (num_full_chunks > 0) {
             for (uint32_t c = 0; c < num_full_chunks; ++c) {
                 noc_semaphore_wait_min(sender_semaphore_addr_ptr, sem_idx);
                 sem_idx++;
                 read_chunk_from_output_tensor(output_page_idx, col_idx, row_idx, cb_id_in0, d, num_cols, num_rows, col_offset, row_offset, num_pages, page_size);
             }
         }
-        if constexpr(rem_num_pages > 0) {
+        if (rem_num_pages > 0) {
             noc_semaphore_wait_min(sender_semaphore_addr_ptr, sem_idx);
             sem_idx++;
             read_chunk_from_output_tensor(output_page_idx, col_idx, row_idx, cb_id_in0, d, num_cols, num_rows, col_offset, row_offset, rem_num_pages, page_size);

--- a/ttnn/cpp/ttnn/operations/ccl/all_gather/device/kernels/dataflow/worker_interleaved_ring_gather_send_reader.cpp
+++ b/ttnn/cpp/ttnn/operations/ccl/all_gather/device/kernels/dataflow/worker_interleaved_ring_gather_send_reader.cpp
@@ -12,12 +12,6 @@ void kernel_main() {
     uint32_t arg_idx = 0;
     const uint32_t src_addr = get_arg_val<uint32_t>(arg_idx++);
     const uint32_t dst_addr = get_arg_val<uint32_t>(arg_idx++);
-    const bool sender_enabled = get_arg_val<uint32_t>(arg_idx++) == 1;
-
-    if (!sender_enabled) {
-        return;
-    }
-
     const uint32_t num_transfers = get_arg_val<uint32_t>(arg_idx++);
     const uint32_t num_full_chunks = get_arg_val<uint32_t>(arg_idx++);
     const uint32_t num_pages = get_arg_val<uint32_t>(arg_idx++);
@@ -81,7 +75,8 @@ void kernel_main() {
     constexpr uint32_t output_tensor_shard_pages_per_shard_x = get_compile_time_arg_val(22);
     constexpr bool output_tensor_shard_grid_transposed = get_compile_time_arg_val(23) != 0;
     #endif
-    // static_assert(half_cb_n_pages > rem_num_pages, "half_cb_n_pages must be greater than or equal to rem_num_pages");
+
+    ASSERT(half_cb_n_pages > rem_num_pages);
 
     constexpr uint32_t cb_id_in0 = tt::CB::c_in0;
 

--- a/ttnn/cpp/ttnn/operations/ccl/all_gather/device/kernels/dataflow/worker_interleaved_ring_gather_send_writer.cpp
+++ b/ttnn/cpp/ttnn/operations/ccl/all_gather/device/kernels/dataflow/worker_interleaved_ring_gather_send_writer.cpp
@@ -13,10 +13,6 @@
 void kernel_main() {
     uint32_t arg_idx = 0;
     const uint32_t dst_addr = get_arg_val<uint32_t>(arg_idx++);
-    const bool sender_enabled = get_arg_val<uint32_t>(arg_idx++) == 1;
-    if (!sender_enabled) {
-        return;
-    }
     const uint32_t eth_sender_l1_base_addr = get_arg_val<uint32_t>(arg_idx++);
     const uint32_t eth_sender_l1_sem_addr = get_arg_val<uint32_t>(arg_idx++);
     const uint32_t num_transfers = get_arg_val<uint32_t>(arg_idx++);
@@ -60,7 +56,7 @@ void kernel_main() {
     constexpr uint32_t half_cb_n_pages = get_compile_time_arg_val(5);
     constexpr uint32_t num_buffers_per_channel = get_compile_time_arg_val(6);
 
-    // static_assert(half_cb_n_pages > rem_num_pages, "half_cb_n_pages must be greater than or equal to rem_num_pages");
+    ASSERT(half_cb_n_pages > rem_num_pages);
 
     #ifdef SHARDED_MEM_LAYOUT
     constexpr tt::tt_metal::TensorMemoryLayout output_tensor_memory_layout = static_cast<tt::tt_metal::TensorMemoryLayout>(get_compile_time_arg_val(7));

--- a/ttnn/cpp/ttnn/operations/ccl/all_gather/device/multi_core/all_gather_op_multi_core.cpp
+++ b/ttnn/cpp/ttnn/operations/ccl/all_gather/device/multi_core/all_gather_op_multi_core.cpp
@@ -29,69 +29,69 @@ namespace ttnn {
 
 using namespace ccl;
 
-static std::tuple<CoreRangeSet,CoreRangeSet> get_all_worker_cores(AllGatherConfig const& all_gather_config, uint32_t num_links, uint32_t num_full_send_directions, CoreCoord const& core_grid_offset) {
+static std::tuple<CoreRangeSet, CoreRangeSet, std::map<std::pair<uint32_t, uint32_t>, std::vector<CoreRangeSet>>>
+get_all_worker_cores(AllGatherConfig const& all_gather_config, uint32_t num_links, uint32_t num_full_send_directions, CoreCoord const& core_grid_offset, bool is_linear, uint32_t ring_size, uint32_t ring_index) {
     constexpr uint32_t worker_grid_width = 8;
     const bool fit_sender_and_receiver_workers_on_same_row = (worker_grid_width / 2) >= all_gather_config.get_num_workers_per_link();
-    std::set<CoreRange> receiver_worker_cores = {};
-    std::set<CoreRange> sender_worker_cores = {};
 
-    for (uint32_t full_send_direction = 0; full_send_direction < num_full_send_directions; full_send_direction++) {
+    std::set<CoreRange> receiver_worker_cores;
+    std::set<CoreRange> sender_worker_cores;
+    std::map<std::pair<uint32_t, uint32_t>, std::vector<CoreRangeSet>> worker_core_map;
+
+    for (uint32_t full_send_direction = 0; full_send_direction < num_full_send_directions; ++full_send_direction) {
+
+        // If linear topology, the first chip in the chain will not have a "receiver" eth core (or more correctly,
+        // it doesn't have an input clockwise our output counter-clockwise connection)
+        bool is_first_chip_in_chain = is_linear && (full_send_direction == 0 ? ring_index == 0 : ring_index == ring_size - 1);
+        // If linear topology, the last chip in the chain will not have a "sender" eth core (or more correctly,
+        // it doesn't have an output clockwise our input counter-clockwise connection)
+        bool is_last_chip_in_chain = is_linear && (full_send_direction == 0 ? ring_index == ring_size - 1 : ring_index == 0);
+
+        bool sender_enabled = (!is_linear || !is_last_chip_in_chain);
+        bool receiver_enabled = (!is_linear || !is_first_chip_in_chain);
+
         for (uint32_t link = 0; link < num_links; ++link) {
             uint32_t max_cols = 8;
             uint32_t curr_row = link * (((all_gather_config.get_num_workers_per_link()  * 2 - 1) / max_cols) + 1) +
                 (full_send_direction * num_links * (((all_gather_config.get_num_workers_per_link() * 2 - 1) / max_cols) + 1)) + core_grid_offset.y;
             uint32_t curr_col = core_grid_offset.x;
-            for (uint32_t r = 0; r < all_gather_config.get_num_workers_per_link(); r++) {
-                receiver_worker_cores.insert(CoreRange(CoreCoord(curr_col, curr_row)));
-                curr_col ++;
-                if (curr_col == max_cols) {
-                    curr_col = 0;
-                    curr_row++;
+
+            std::set<CoreRange> local_receiver_worker_cores;
+            std::set<CoreRange> local_sender_worker_cores;
+
+            if (receiver_enabled) {
+                for (uint32_t r = 0; r < all_gather_config.get_num_workers_per_link(); r++) {
+                    CoreCoord receiver_coord(curr_col, curr_row);
+                    receiver_worker_cores.insert(CoreRange(receiver_coord));
+                    local_receiver_worker_cores.insert(CoreRange(receiver_coord)); // Local receiver cores
+                    curr_col++;
+                    if (curr_col == max_cols) {
+                        curr_col = 0;
+                        curr_row++;
+                    }
                 }
             }
-            for (uint32_t s = 0; s < all_gather_config.get_num_workers_per_link(); s++) {
-                sender_worker_cores.insert(CoreRange(CoreCoord(curr_col, curr_row)));
-                curr_col ++;
-                if (curr_col == max_cols) {
-                    curr_col = 0;
-                    curr_row++;
+
+            if (sender_enabled) {
+                for (uint32_t s = 0; s < all_gather_config.get_num_workers_per_link(); s++) {
+                    CoreCoord sender_coord(curr_col, curr_row);
+                    sender_worker_cores.insert(CoreRange(sender_coord));
+                    local_sender_worker_cores.insert(CoreRange(sender_coord)); // Local sender cores
+                    curr_col++;
+                    if (curr_col == max_cols) {
+                        curr_col = 0;
+                        curr_row++;
+                    }
                 }
             }
+
+            // Insert into map for (link, full_send_direction) as key
+            worker_core_map[std::make_pair(link, full_send_direction)] = {CoreRangeSet(local_receiver_worker_cores), CoreRangeSet(local_sender_worker_cores)};
         }
     }
 
-    return {CoreRangeSet(receiver_worker_cores), CoreRangeSet(sender_worker_cores)};
+    return {CoreRangeSet(receiver_worker_cores), CoreRangeSet(sender_worker_cores), worker_core_map};
 }
-
-
-static std::tuple<CoreRangeSet,CoreRangeSet> select_worker_cores(AllGatherConfig const& all_gather_config, uint32_t num_links, uint32_t link, uint32_t full_send_direction, CoreCoord const& core_grid_offset) {
-    constexpr uint32_t worker_grid_width = 8;
-    const bool fit_sender_and_receiver_workers_on_same_row = (worker_grid_width / 2) >= all_gather_config.get_num_workers_per_link();
-    std::set<CoreRange> receiver_worker_cores = {};
-    std::set<CoreRange> sender_worker_cores = {};
-    uint32_t max_cols = 8;
-    uint32_t curr_row = link * (((all_gather_config.get_num_workers_per_link()  * 2 - 1) / max_cols) + 1) +
-        (full_send_direction * num_links * (((all_gather_config.get_num_workers_per_link() * 2 - 1) / max_cols) + 1)) + core_grid_offset.y;
-    uint32_t curr_col = core_grid_offset.x;
-    for (uint32_t r = 0; r < all_gather_config.get_num_workers_per_link(); r++) {
-        receiver_worker_cores.insert(CoreRange(CoreCoord(curr_col, curr_row)));
-        curr_col ++;
-        if (curr_col == max_cols) {
-            curr_col = 0;
-            curr_row++;
-        }
-    }
-    for (uint32_t s = 0; s < all_gather_config.get_num_workers_per_link(); s++) {
-        sender_worker_cores.insert(CoreRange(CoreCoord(curr_col, curr_row)));
-        curr_col ++;
-        if (curr_col == max_cols) {
-            curr_col = 0;
-            curr_row++;
-        }
-    }
-    return {CoreRangeSet(receiver_worker_cores), CoreRangeSet(sender_worker_cores)};
-}
-
 
 static std::vector<std::vector<uint32_t>> compute_worker_sender_num_transfers(
     AllGatherConfig const& all_gather_config, uint32_t num_links, uint32_t ring_size, uint32_t ring_index, all_gather_op::Topology topology, uint32_t direction
@@ -353,7 +353,7 @@ operation::ProgramWithCallbacks all_gather_multi_core_with_workers_helper(
     }
 
     // KERNEL CREATION
-    auto const& [all_receiver_workers, all_sender_workers] = get_all_worker_cores(all_gather_config, num_links, num_full_send_directions, core_grid_offset);
+    auto const& [all_receiver_workers, all_sender_workers, worker_core_map] = get_all_worker_cores(all_gather_config, num_links, num_full_send_directions, core_grid_offset, is_linear, ring_size, ring_index);
     auto all_sender_worker_cores = corerange_to_cores(all_sender_workers, std::nullopt, true);
     auto all_receiver_worker_cores = corerange_to_cores(all_receiver_workers, std::nullopt, true);
 
@@ -601,7 +601,10 @@ operation::ProgramWithCallbacks all_gather_multi_core_with_workers_helper(
         for (uint32_t i = 0; i < num_links; ++i) {
             // We can't have overlap between the mcast grid for worker cores for different links since mcasting the semaphore in receiver would corrupt other link semaphores
             // We can have overlap between a link's sender and receiver worker grids if we have the semaphores at different addresses
-            auto const& [receiver_workers, sender_workers] = select_worker_cores(all_gather_config, num_links, i, direction, core_grid_offset);
+            // Get receiver and sender CoreRangeSets
+            const auto& worker_core_vector = worker_core_map.at(std::make_pair(i, direction));
+            const auto& receiver_workers = worker_core_vector[0];  // Receiver cores
+            const auto& sender_workers = worker_core_vector[1];    // Sender cores
 
             // Rename this the _channel
             std::vector<uint32_t> pages_per_buffer;
@@ -726,19 +729,13 @@ operation::ProgramWithCallbacks all_gather_multi_core_with_workers_helper(
             std::vector<uint32_t> receiver_eth_sem_addrs; receiver_eth_sem_addrs.reserve(all_gather_config.get_num_workers_per_link());
             std::vector<uint32_t> receiver_eth_buffer_addrs; receiver_eth_buffer_addrs.reserve(all_gather_config.get_num_workers_per_link());
             for (uint32_t b = 0; b < all_gather_config.get_num_workers_per_link(); ++b) {
-                std::vector<ccl::WorkerXY> sender_worker_coords;
-                std::vector<ccl::WorkerXY> receiver_worker_coords;
-                sender_worker_coords.push_back(
-                    ttnn::ccl::WorkerXY(
-                        device->worker_core_from_logical_core(sender_worker_cores.at(b)).x,
-                        device->worker_core_from_logical_core(sender_worker_cores.at(b)).y));
-                receiver_worker_coords.push_back(
-                    ttnn::ccl::WorkerXY(
-                        device->worker_core_from_logical_core(receiver_worker_cores.at(b)).x,
-                        device->worker_core_from_logical_core(receiver_worker_cores.at(b)).y));
-
                 bool sender_enabled = (!is_linear || !is_last_chip_in_chain);
                 if (sender_enabled) {
+                    std::vector<ccl::WorkerXY> sender_worker_coords;
+                    sender_worker_coords.push_back(
+                        ttnn::ccl::WorkerXY(
+                            device->worker_core_from_logical_core(sender_worker_cores.at(b)).x,
+                            device->worker_core_from_logical_core(sender_worker_cores.at(b)).y));
                     auto &sender_edm_builder = is_buffer_in_clockwise_direction(b) ? clockwise_edm_builders.at(i) : counter_clockwise_edm_builders.at(i);
                     log_trace(tt::LogOp, "Adding sender EDM channel");
                     EriscDatamoverBuilder::ChannelBufferInterface const& sender_channel_buffer_info =
@@ -754,6 +751,11 @@ operation::ProgramWithCallbacks all_gather_multi_core_with_workers_helper(
 
                 bool receiver_enabled = (!is_linear || !is_first_chip_in_chain);
                 if (receiver_enabled) {
+                    std::vector<ccl::WorkerXY> receiver_worker_coords;
+                    receiver_worker_coords.push_back(
+                        ttnn::ccl::WorkerXY(
+                            device->worker_core_from_logical_core(receiver_worker_cores.at(b)).x,
+                            device->worker_core_from_logical_core(receiver_worker_cores.at(b)).y));
                     auto &receiver_edm_builder = is_buffer_in_clockwise_direction(b) ? counter_clockwise_edm_builders.at(i) : clockwise_edm_builders.at(i);
                     log_trace(tt::LogOp, "Adding receiver EDM channel");
                     EriscDatamoverBuilder::ChannelBufferInterface const& receiver_channel_buffer_info =
@@ -784,22 +786,7 @@ operation::ProgramWithCallbacks all_gather_multi_core_with_workers_helper(
                 bool receiver_enabled = (!is_linear || !is_first_chip_in_chain);
 
                 // SEND WORKERS
-                if (!sender_enabled) {
-                    tt::tt_metal::SetRuntimeArgs(
-                        program,
-                        worker_sender_reader_kernel_id,
-                        sender_worker_cores.at(b),
-                        {0, 0, sender_enabled});
-
-                    tt::tt_metal::SetRuntimeArgs(
-                        program,
-                        worker_sender_writer_kernel_id,
-                        sender_worker_cores.at(b),
-                        {0, sender_enabled});
-
-                    log_trace(tt::LogOp, "Skipping sender workers for linear chain");
-                }
-                else {
+                if (sender_enabled) {
                     //// Send Reader
                     auto build_worker_send_reader_rt_args = [&]() {
                         bool is_clockwise = is_buffer_in_clockwise_direction(b);
@@ -807,7 +794,6 @@ operation::ProgramWithCallbacks all_gather_multi_core_with_workers_helper(
                         std::vector<uint32_t> args = {
                             static_cast<uint32_t>(input_buffer->address()),
                             static_cast<uint32_t>(output_buffer->address()),
-                            static_cast<uint32_t>(sender_enabled),
                             static_cast<uint32_t>(sender_worker_num_transfers.at(i).at(b)), // move to rt
                             static_cast<uint32_t>(num_full_chunks_per_worker.at(b)), // move to rt
                             static_cast<uint32_t>(pages_per_eth_l1_buffer.at(b)), // move to rt
@@ -869,7 +855,6 @@ operation::ProgramWithCallbacks all_gather_multi_core_with_workers_helper(
 
                         std::vector<uint32_t> worker_writer_sender_rt_args = {
                             static_cast<uint32_t>(output_buffer->address()),
-                            static_cast<uint32_t>(sender_enabled),
                             static_cast<uint32_t>(sender_eth_buffer_addrs.at(b)),
                             static_cast<uint32_t>(sender_eth_sem_addrs.at(b)),
                             static_cast<uint32_t>(sender_worker_num_transfers.at(i).at(b)),
@@ -939,22 +924,8 @@ operation::ProgramWithCallbacks all_gather_multi_core_with_workers_helper(
                 }
 
                 // RECEIVER WORKERS
-                if (!receiver_enabled){
-                    tt::tt_metal::SetRuntimeArgs(
-                        program,
-                        worker_receiver_reader_kernel_id,
-                        receiver_worker_cores.at(b),
-                        {0, receiver_enabled});
+                if (receiver_enabled) {
 
-                    tt::tt_metal::SetRuntimeArgs(
-                        program,
-                        worker_receiver_writer_kernel_id,
-                        receiver_worker_cores.at(b),
-                        {0,0,0, receiver_enabled});
-
-                    log_trace(tt::LogOp, "Skipping receiver workers for linear chain");
-                }
-                else {
                     TT_ASSERT(!is_linear ||
                         ((is_clockwise_direction && (ring_index != 0)) || (!is_clockwise_direction && ring_index != ring_size - 1))
                     );
@@ -995,12 +966,11 @@ operation::ProgramWithCallbacks all_gather_multi_core_with_workers_helper(
                     log_trace(tt::LogOp,"\treceiver_output_start_page_idx={}", receiver_output_start_page_idx);
                     log_trace(tt::LogOp,"\treceiver_ring_index={}", receiver_ring_index);
 
-                    //// Receive Reader
+                   //// Receive Reader
                     auto build_worker_receiver_reader_rt_args = [&]() {
                         CoreCoord const& worker_eth_receiver_core = is_clockwise_direction ? eth_receiver_cores.at(i) : eth_sender_cores.at(i);
                         std::vector<uint32_t> worker_reader_receiver_rt_args = {
                             static_cast<uint32_t>(receiver_eth_buffer_addrs.at(b)),
-                            static_cast<uint32_t>(receiver_enabled),
                             static_cast<uint32_t>(receiver_worker_num_transfers.at(i).at(b)),
                             static_cast<uint32_t>(num_full_chunks_per_worker.at(b)),
                             static_cast<uint32_t>(pages_per_chunk),
@@ -1031,12 +1001,17 @@ operation::ProgramWithCallbacks all_gather_multi_core_with_workers_helper(
 
                     //// Receive Writer
                     auto build_worker_receive_writer_rt_args = [&]() {
-                        auto worker_sender_reader = device->worker_core_from_logical_core(sender_worker_cores.at(b));
+                        uint32_t sender_core_x = -1, sender_core_y = -1;
+                        if (sender_enabled) {
+                            auto worker_sender_reader = device->worker_core_from_logical_core(sender_worker_cores.at(b));
+                            sender_core_x = worker_sender_reader.x;
+                            sender_core_y = worker_sender_reader.y;
+                        }
                         std::vector<uint32_t> worker_writer_receiver_rt_args = {
                             static_cast<uint32_t>(output_buffer->address()),
-                            static_cast<uint32_t>(worker_sender_reader.x),
-                            static_cast<uint32_t>(worker_sender_reader.y),
-                            static_cast<uint32_t>(receiver_enabled),
+                            static_cast<uint32_t>(sender_core_x),
+                            static_cast<uint32_t>(sender_core_y),
+                            static_cast<uint32_t>(sender_enabled),
                             static_cast<uint32_t>(receiver_worker_num_transfers.at(i).at(b)),
                             static_cast<uint32_t>(num_full_chunks_per_worker.at(b)),
                             static_cast<uint32_t>(pages_per_eth_l1_buffer.at(b)),

--- a/ttnn/cpp/ttnn/operations/ccl/all_gather/device/multi_core/all_gather_op_multi_core.cpp
+++ b/ttnn/cpp/ttnn/operations/ccl/all_gather/device/multi_core/all_gather_op_multi_core.cpp
@@ -603,6 +603,8 @@ operation::ProgramWithCallbacks all_gather_multi_core_with_workers_helper(
             // We can have overlap between a link's sender and receiver worker grids if we have the semaphores at different addresses
             // Get receiver and sender CoreRangeSets
             const auto& worker_core_vector = worker_core_map.at(std::make_pair(i, direction));
+            // ensure the vector is size of 2
+            TT_FATAL(worker_core_vector.size() == 2, "Worker core vector should contain receiver and sender cores sets only");
             const auto& receiver_workers = worker_core_vector[0];  // Receiver cores
             const auto& sender_workers = worker_core_vector[1];    // Sender cores
 
@@ -1038,8 +1040,8 @@ operation::ProgramWithCallbacks all_gather_multi_core_with_workers_helper(
 
                         log_trace(tt::LogOp, "Worker {} RW rt args", b);
                         log_trace(tt::LogOp, "\toutput_buffer->address(): {}", output_buffer->address());
-                        log_trace(tt::LogOp, "\tworker_sender_reader.x: {}", worker_sender_reader.x);
-                        log_trace(tt::LogOp, "\tworker_sender_reader.y: {}", worker_sender_reader.y);
+                        log_trace(tt::LogOp, "\tworker_sender_reader.x: {}", sender_core_x);
+                        log_trace(tt::LogOp, "\tworker_sender_reader.y: {}", sender_core_y);
                         log_trace(tt::LogOp, "\treceiver_num_transfers: {}", receiver_worker_num_transfers.at(i).at(b));
                         log_trace(tt::LogOp, "\tnum_full_chunks_per_worker.at(b): {}", num_full_chunks_per_worker.at(b));
                         log_trace(tt::LogOp, "\tpages_per_eth_l1_buffer.at(b): {}", pages_per_eth_l1_buffer.at(b));

--- a/ttnn/cpp/ttnn/operations/ccl/all_gather/device/multi_core/all_gather_op_multi_core.cpp
+++ b/ttnn/cpp/ttnn/operations/ccl/all_gather/device/multi_core/all_gather_op_multi_core.cpp
@@ -29,6 +29,41 @@ namespace ttnn {
 
 using namespace ccl;
 
+static std::tuple<CoreRangeSet,CoreRangeSet> get_all_worker_cores(AllGatherConfig const& all_gather_config, uint32_t num_links, uint32_t num_full_send_directions, CoreCoord const& core_grid_offset) {
+    constexpr uint32_t worker_grid_width = 8;
+    const bool fit_sender_and_receiver_workers_on_same_row = (worker_grid_width / 2) >= all_gather_config.get_num_workers_per_link();
+    std::set<CoreRange> receiver_worker_cores = {};
+    std::set<CoreRange> sender_worker_cores = {};
+
+    for (uint32_t full_send_direction = 0; full_send_direction < num_full_send_directions; full_send_direction++) {
+        for (uint32_t link = 0; link < num_links; ++link) {
+            uint32_t max_cols = 8;
+            uint32_t curr_row = link * (((all_gather_config.get_num_workers_per_link()  * 2 - 1) / max_cols) + 1) +
+                (full_send_direction * num_links * (((all_gather_config.get_num_workers_per_link() * 2 - 1) / max_cols) + 1)) + core_grid_offset.y;
+            uint32_t curr_col = core_grid_offset.x;
+            for (uint32_t r = 0; r < all_gather_config.get_num_workers_per_link(); r++) {
+                receiver_worker_cores.insert(CoreRange(CoreCoord(curr_col, curr_row)));
+                curr_col ++;
+                if (curr_col == max_cols) {
+                    curr_col = 0;
+                    curr_row++;
+                }
+            }
+            for (uint32_t s = 0; s < all_gather_config.get_num_workers_per_link(); s++) {
+                sender_worker_cores.insert(CoreRange(CoreCoord(curr_col, curr_row)));
+                curr_col ++;
+                if (curr_col == max_cols) {
+                    curr_col = 0;
+                    curr_row++;
+                }
+            }
+        }
+    }
+
+    return {CoreRangeSet(receiver_worker_cores), CoreRangeSet(sender_worker_cores)};
+}
+
+
 static std::tuple<CoreRangeSet,CoreRangeSet> select_worker_cores(AllGatherConfig const& all_gather_config, uint32_t num_links, uint32_t link, uint32_t full_send_direction, CoreCoord const& core_grid_offset) {
     constexpr uint32_t worker_grid_width = 8;
     const bool fit_sender_and_receiver_workers_on_same_row = (worker_grid_width / 2) >= all_gather_config.get_num_workers_per_link();
@@ -276,15 +311,6 @@ operation::ProgramWithCallbacks all_gather_multi_core_with_workers_helper(
     std::vector<EriscDatamoverBuilder> counter_clockwise_edm_builders;
     TT_ASSERT(num_full_send_directions > 0);
 
-    std::vector<std::pair<KernelHandle, CoreCoord>> receive_reader_kernel_core_list;
-    std::vector<std::pair<KernelHandle, CoreCoord>> receive_writer_kernel_core_list;
-    std::vector<std::pair<KernelHandle, CoreCoord>> send_reader_kernel_core_list;
-    std::vector<std::pair<KernelHandle, CoreCoord>> send_writer_kernel_core_list;
-    receive_reader_kernel_core_list.reserve(total_worker_core_pairs_used);
-    receive_writer_kernel_core_list.reserve(total_worker_core_pairs_used);
-    send_reader_kernel_core_list.reserve(total_worker_core_pairs_used);
-    send_writer_kernel_core_list.reserve(total_worker_core_pairs_used);
-
     // TODO: move to all-gather config
     auto edm_sem_addrs_per_link = std::vector<std::vector<uint32_t>>(num_links);
     auto edm_buffer_addrs_per_link = std::vector<std::vector<uint32_t>>(num_links);
@@ -325,6 +351,177 @@ operation::ProgramWithCallbacks all_gather_multi_core_with_workers_helper(
             all_gather_config.get_num_buffers_per_channel(),
             input_tensor.device()->id());
     }
+
+    // KERNEL CREATION
+    auto const& [all_receiver_workers, all_sender_workers] = get_all_worker_cores(all_gather_config, num_links, num_full_send_directions, core_grid_offset);
+    auto all_sender_worker_cores = corerange_to_cores(all_sender_workers, std::nullopt, true);
+    auto all_receiver_worker_cores = corerange_to_cores(all_receiver_workers, std::nullopt, true);
+
+    // Circular Buffer Setup
+    uint32_t cb_page_size = input_page_size;
+    log_trace(tt::LogOp, "input_page_size: {}", input_page_size);
+    uint32_t cb_num_pages = 2 * max_pages_per_chunk;
+    log_trace(tt::LogOp, "cb_num_pages: {}", cb_num_pages);
+    uint32_t src0_cb_index = tt::CB::c_in0;
+    CircularBufferConfig cb_src0_config = CircularBufferConfig(cb_num_pages * cb_page_size, {{src0_cb_index, df}})
+    .set_page_size(src0_cb_index, cb_page_size);
+    CBHandle cb_src0_sender_workers = CreateCircularBuffer(program, all_sender_workers, cb_src0_config);
+    CBHandle cb_src0_receiver_workers = CreateCircularBuffer(program, all_receiver_workers, cb_src0_config);
+
+    // This semaphore is used by the receiver core to tell workers that data is available to read
+    auto receiver_worker_semaphore_id = CreateSemaphore(program, all_receiver_workers, 0);
+    // This semaphore is used by the receiver core to tell the worker sender writer that sender buffer is available to write to
+    auto sender_worker_writer_semaphore_id = CreateSemaphore(program, all_sender_workers, 0);
+    // This semaphore is used by the worker receiver writer to tell the worker sender reader that data has been committed to memory
+    // This is currently a running counter of how many chunks were committed since the sender worker never decrements this buffer
+    // Potentially avoid overflow by having it actually decrement (using noc atomic inc with value of -1)
+    auto sender_worker_reader_semaphore_id = CreateSemaphore(program, all_sender_workers, 0);
+
+    // Sender Reader
+    auto build_worker_send_reader_ct_args = [&]() {
+        std::vector<uint32_t> worker_reader_sender_ct_args = {
+            static_cast<uint32_t>(all_gather_config.is_input_dram()),
+            static_cast<uint32_t>(all_gather_config.is_output_dram()),
+            static_cast<uint32_t>(input_page_size),
+            static_cast<uint32_t>(output_page_size),
+            static_cast<uint32_t>(ring_index),
+            static_cast<uint32_t>(sender_worker_reader_semaphore_id),
+            static_cast<uint32_t>(cb_num_pages / 2),
+            static_cast<uint32_t>(ring_size)
+        };
+        if (is_sharded) {
+            emit_sharded_tensor_kernel_ct_args(device, input_tensor, worker_reader_sender_ct_args, input_pages_per_shard_y, input_pages_per_shard_x);
+            emit_sharded_tensor_kernel_ct_args(device, output_tensor, worker_reader_sender_ct_args, output_pages_per_shard_y, output_pages_per_shard_x);
+        };
+
+        log_trace(tt::LogOp, "Worker SR CT args");
+        log_trace(tt::LogOp, "\tall_gather_config.is_input_dram(): {}", all_gather_config.is_input_dram());
+        log_trace(tt::LogOp, "\tall_gather_config.is_output_dram(): {}", all_gather_config.is_output_dram());
+        log_trace(tt::LogOp, "\tinput_page_size: {}", input_page_size);
+        log_trace(tt::LogOp, "\toutput_page_size: {}", output_page_size);
+        log_trace(tt::LogOp, "\tring_index: {}", ring_index);
+        log_trace(tt::LogOp, "\tsender_worker_reader_semaphore_id: {}", sender_worker_reader_semaphore_id);
+
+        if (is_sharded) {
+            log_sharded_tensor_kernel_args(input_tensor, input_pages_per_shard_y, input_pages_per_shard_x, "input");
+            log_sharded_tensor_kernel_args(output_tensor, output_pages_per_shard_y, output_pages_per_shard_x, "output");
+        }
+
+        return worker_reader_sender_ct_args;
+    };
+
+    std::vector<uint32_t> const& worker_send_reader_ct_args = build_worker_send_reader_ct_args();
+
+    std::string const& send_reader_kernel_path = "ttnn/cpp/ttnn/operations/ccl/all_gather/device/kernels/dataflow/worker_interleaved_ring_gather_send_reader.cpp";
+    KernelHandle worker_sender_reader_kernel_id = tt::tt_metal::CreateKernel(
+        program,
+        send_reader_kernel_path,
+        all_sender_workers,
+        tt::tt_metal::ReaderDataMovementConfig(worker_send_reader_ct_args, worker_defines));
+
+    // Sender Writer
+    auto build_worker_sender_writer_ct_args = [&]() {
+        std::vector<uint32_t> worker_writer_sender_ct_args = {
+            static_cast<uint32_t>(all_gather_config.is_output_dram()),
+            static_cast<uint32_t>(input_page_size),
+            static_cast<uint32_t>(output_page_size),
+            static_cast<uint32_t>(ring_index),
+
+            // worker local L1 address of semaphore
+            static_cast<uint32_t>(sender_worker_writer_semaphore_id),
+            static_cast<uint32_t>(cb_num_pages / 2),
+            static_cast<uint32_t>(num_edm_buffers_per_channel),
+        };
+
+        if (is_sharded) {
+            emit_sharded_tensor_kernel_ct_args(device, output_tensor, worker_writer_sender_ct_args, output_pages_per_shard_y, output_pages_per_shard_x);
+        }
+        log_trace(tt::LogOp, "Worker SW CT args");
+        log_trace(tt::LogOp, "\tall_gather_config.is_output_dram(): {}", all_gather_config.is_output_dram());
+        log_trace(tt::LogOp, "\tinput_page_size: {}", input_page_size);
+        log_trace(tt::LogOp, "\toutput_page_size: {}", output_page_size);
+        log_trace(tt::LogOp, "\tring_index: {}", ring_index);
+        log_trace(tt::LogOp, "\tsender_worker_writer_semaphore_id: {}", sender_worker_writer_semaphore_id);
+        log_trace(tt::LogOp, "\thalf_cb_num_pages: {}", cb_num_pages / 2);
+
+        if (is_sharded) {
+            log_sharded_tensor_kernel_args(output_tensor, output_pages_per_shard_y, output_pages_per_shard_x, "output");
+        }
+        return worker_writer_sender_ct_args;
+    };
+
+    std::vector<uint32_t> const& worker_sender_writer_ct_args = build_worker_sender_writer_ct_args();
+
+    std::string const& sender_writer_kernel_path = "ttnn/cpp/ttnn/operations/ccl/all_gather/device/kernels/dataflow/worker_interleaved_ring_gather_send_writer.cpp";
+    KernelHandle worker_sender_writer_kernel_id = tt::tt_metal::CreateKernel(
+        program,
+        sender_writer_kernel_path,
+        all_sender_workers,
+        tt::tt_metal::WriterDataMovementConfig(worker_sender_writer_ct_args, worker_defines));
+
+    // Receiver Reader
+    auto build_worker_receiver_reader_ct_args = [&]() {
+        std::vector<uint32_t> worker_receiver_reader_ct_args = {
+            static_cast<uint32_t>(input_page_size),
+            static_cast<uint32_t>(receiver_worker_semaphore_id),
+            static_cast<uint32_t>(cb_num_pages / 2),
+            static_cast<uint32_t>(num_edm_buffers_per_channel)
+        };
+
+        log_trace(tt::LogOp, "Worker RR ct args");
+        log_trace(tt::LogOp, "\tinput_page_size: {}", input_page_size);
+        log_trace(tt::LogOp, "\treceiver_worker_semaphore_id: {}", receiver_worker_semaphore_id);
+        log_trace(tt::LogOp, "\thalf_cb_num_pages : {}", cb_num_pages / 2);
+        return worker_receiver_reader_ct_args;
+    };
+    std::vector<uint32_t> const& worker_receiver_reader_ct_args = build_worker_receiver_reader_ct_args();
+
+    std::string const& receiver_reader_kernel_path = "ttnn/cpp/ttnn/operations/ccl/all_gather/device/kernels/dataflow/worker_interleaved_ring_gather_receive_reader.cpp";
+    KernelHandle worker_receiver_reader_kernel_id = tt::tt_metal::CreateKernel(
+        program,
+        receiver_reader_kernel_path,
+        all_receiver_workers,
+        tt::tt_metal::ReaderDataMovementConfig(worker_receiver_reader_ct_args, worker_defines));
+
+    // Receiver Writer
+    auto build_worker_receive_writer_ct_args = [&]() {
+        std::vector<uint32_t> worker_writer_receiver_ct_args = {
+            static_cast<uint32_t>(all_gather_config.is_output_dram()),
+            static_cast<uint32_t>(input_page_size),
+            static_cast<uint32_t>(output_page_size),
+            static_cast<uint32_t>(sender_worker_reader_semaphore_id),
+            static_cast<uint32_t>(cb_num_pages / 2),
+            static_cast<uint32_t>(ring_size),
+            static_cast<bool>(fuse_op)
+        };
+
+        if (is_sharded) {
+            emit_sharded_tensor_kernel_ct_args(device, output_tensor, worker_writer_receiver_ct_args, output_pages_per_shard_y, output_pages_per_shard_x);
+        }
+
+        log_trace(tt::LogOp, "Worker RW ct args");
+        log_trace(tt::LogOp, "\tall_gather_config.is_output_dram(): {}", all_gather_config.is_output_dram());
+        log_trace(tt::LogOp, "\tinput_page_size: {}", input_page_size);
+        log_trace(tt::LogOp, "\toutput_page_size: {}", output_page_size);
+        log_trace(tt::LogOp, "\tsender_worker_reader_semaphore_id: {}", sender_worker_reader_semaphore_id);
+        log_trace(tt::LogOp, "\thalf_cb_num_pages: {}", cb_num_pages / 2);
+        log_trace(tt::LogOp, "\tring_size: {}", ring_size);
+        log_trace(tt::LogOp, "\tfuse_op: {}", fuse_op);
+
+        if (is_sharded) {
+            log_sharded_tensor_kernel_args(output_tensor, output_pages_per_shard_y, output_pages_per_shard_x, "output");
+        }
+
+        return worker_writer_receiver_ct_args;
+    };
+    std::vector<uint32_t> const& worker_receive_writer_ct_args = build_worker_receive_writer_ct_args();
+
+    std::string const& receiver_writer_kernel_path = "ttnn/cpp/ttnn/operations/ccl/all_gather/device/kernels/dataflow/worker_interleaved_ring_gather_receive_writer.cpp";
+    KernelHandle worker_receiver_writer_kernel_id = tt::tt_metal::CreateKernel(
+        program,
+        receiver_writer_kernel_path,
+        all_receiver_workers,
+        tt::tt_metal::WriterDataMovementConfig(worker_receive_writer_ct_args, worker_defines));
 
     for (uint32_t direction = 0; direction < num_full_send_directions; direction++) {
         // if we're in ring topology, we'll always need to transfer all ring indices (except the last one)
@@ -405,26 +602,6 @@ operation::ProgramWithCallbacks all_gather_multi_core_with_workers_helper(
             // We can't have overlap between the mcast grid for worker cores for different links since mcasting the semaphore in receiver would corrupt other link semaphores
             // We can have overlap between a link's sender and receiver worker grids if we have the semaphores at different addresses
             auto const& [receiver_workers, sender_workers] = select_worker_cores(all_gather_config, num_links, i, direction, core_grid_offset);
-
-            // Circular Buffer Setup
-            uint32_t cb_page_size = input_page_size;
-            log_trace(tt::LogOp, "input_page_size: {}", input_page_size);
-            uint32_t cb_num_pages = 2 * max_pages_per_chunk;
-            log_trace(tt::LogOp, "cb_num_pages: {}", cb_num_pages);
-            uint32_t src0_cb_index = tt::CB::c_in0;
-            CircularBufferConfig cb_src0_config = CircularBufferConfig(cb_num_pages * cb_page_size, {{src0_cb_index, df}})
-            .set_page_size(src0_cb_index, cb_page_size);
-            CBHandle cb_src0_sender_workers = CreateCircularBuffer(program, sender_workers, cb_src0_config);
-            CBHandle cb_src0_receiver_workers = CreateCircularBuffer(program, receiver_workers, cb_src0_config);
-
-            // This semaphore is used by the receiver core to tell workers that data is available to read
-            auto receiver_worker_semaphore_id = CreateSemaphore(program, receiver_workers, 0);
-            // This semaphore is used by the receiver core to tell the worker sender writer that sender buffer is available to write to
-            auto sender_worker_writer_semaphore_id = CreateSemaphore(program, sender_workers, 0);
-            // This semaphore is used by the worker receiver writer to tell the worker sender reader that data has been committed to memory
-            // This is currently a running counter of how many chunks were committed since the sender worker never decrements this buffer
-            // Potentially avoid overflow by having it actually decrement (using noc atomic inc with value of -1)
-            auto sender_worker_reader_semaphore_id = CreateSemaphore(program, sender_workers, 0);
 
             // Rename this the _channel
             std::vector<uint32_t> pages_per_buffer;
@@ -591,7 +768,6 @@ operation::ProgramWithCallbacks all_gather_multi_core_with_workers_helper(
                 }
             }
 
-
             for (uint32_t b = 0; b < all_gather_config.get_num_workers_per_link(); ++b) {
                 uint32_t global_worker_index = all_gather_config.get_num_workers_per_link() * i + b;
 
@@ -604,18 +780,38 @@ operation::ProgramWithCallbacks all_gather_multi_core_with_workers_helper(
                 log_trace(tt::LogOp,"\tlast_output_page_offset={}", last_output_page_offset);
                 log_trace(tt::LogOp,"\tlast_output_addr_offset={}", last_output_addr_offset);
 
-                if (!is_linear || !is_last_chip_in_chain) {
+                bool sender_enabled = (!is_linear || !is_last_chip_in_chain);
+                bool receiver_enabled = (!is_linear || !is_first_chip_in_chain);
+
+                // SEND WORKERS
+                if (!sender_enabled) {
+                    tt::tt_metal::SetRuntimeArgs(
+                        program,
+                        worker_sender_reader_kernel_id,
+                        sender_worker_cores.at(b),
+                        {0, 0, sender_enabled});
+
+                    tt::tt_metal::SetRuntimeArgs(
+                        program,
+                        worker_sender_writer_kernel_id,
+                        sender_worker_cores.at(b),
+                        {0, sender_enabled});
+
+                    log_trace(tt::LogOp, "Skipping sender workers for linear chain");
+                }
+                else {
                     //// Send Reader
-                    auto build_worker_send_reader_ct_args = [&]() {
-                        std::vector<uint32_t> worker_reader_sender_ct_args = {
-                            static_cast<uint32_t>(all_gather_config.is_input_dram()),
-                            static_cast<uint32_t>(all_gather_config.is_output_dram()),
-                            static_cast<uint32_t>(sender_worker_num_transfers.at(i).at(b)),
-                            static_cast<uint32_t>(num_full_chunks_per_worker.at(b)),
-                            static_cast<uint32_t>(input_page_size),
-                            static_cast<uint32_t>(output_page_size),
-                            static_cast<uint32_t>(pages_per_eth_l1_buffer.at(b)),
-                            static_cast<uint32_t>(rem_pages_per_worker.at(b)),
+                    auto build_worker_send_reader_rt_args = [&]() {
+                        bool is_clockwise = is_buffer_in_clockwise_direction(b);
+
+                        std::vector<uint32_t> args = {
+                            static_cast<uint32_t>(input_buffer->address()),
+                            static_cast<uint32_t>(output_buffer->address()),
+                            static_cast<uint32_t>(sender_enabled),
+                            static_cast<uint32_t>(sender_worker_num_transfers.at(i).at(b)), // move to rt
+                            static_cast<uint32_t>(num_full_chunks_per_worker.at(b)), // move to rt
+                            static_cast<uint32_t>(pages_per_eth_l1_buffer.at(b)), // move to rt
+                            static_cast<uint32_t>(rem_pages_per_worker.at(b)), // move to rt
                             static_cast<uint32_t>(tensor_slicer.input_start_page_idx),
                             static_cast<uint32_t>(tensor_slicer.output_start_page_idx),
                             static_cast<uint32_t>(tensor_slicer.output_start_addr_offset),
@@ -629,24 +825,16 @@ operation::ProgramWithCallbacks all_gather_multi_core_with_workers_helper(
                             static_cast<uint32_t>(tensor_slicer.output_page_offset),
                             static_cast<uint32_t>(last_output_addr_offset),
                             static_cast<uint32_t>(tensor_slicer.output_addr_offset),
-                            static_cast<uint32_t>(ring_index),
-                            static_cast<uint32_t>(sender_worker_reader_semaphore_id),
                             static_cast<uint32_t>(is_clockwise_direction ? 1 : 0),
-                            static_cast<uint32_t>(cb_num_pages / 2),
-                            static_cast<uint32_t>(ring_size)
                         };
                         if (is_sharded) {
-                            emit_sharded_tensor_kernel_ct_args(device, input_tensor, worker_reader_sender_ct_args, input_pages_per_shard_y, input_pages_per_shard_x);
-                            emit_sharded_tensor_kernel_ct_args(device, output_tensor, worker_reader_sender_ct_args, output_pages_per_shard_y, output_pages_per_shard_x);
-                        };
+                            emit_sharded_tensor_kernel_rt_args(device, input_tensor, args);
+                            emit_sharded_tensor_kernel_rt_args(device, output_tensor, args);
+                        }
 
-                        log_trace(tt::LogOp, "Worker {} SR args", b);
-                        log_trace(tt::LogOp, "\tall_gather_config.is_input_dram(): {}", all_gather_config.is_input_dram());
-                        log_trace(tt::LogOp, "\tall_gather_config.is_output_dram(): {}", all_gather_config.is_output_dram());
+                        log_trace(tt::LogOp, "Worker {} SR RT args", b);
                         log_trace(tt::LogOp, "\tsender_num_transfers: {}", sender_worker_num_transfers.at(i).at(b));
                         log_trace(tt::LogOp, "\tnum_full_chunks_per_worker.at(b): {}", num_full_chunks_per_worker.at(b));
-                        log_trace(tt::LogOp, "\tinput_page_size: {}", input_page_size);
-                        log_trace(tt::LogOp, "\toutput_page_size: {}", output_page_size);
                         log_trace(tt::LogOp, "\tpages_per_eth_l1_buffer.at(b): {}", pages_per_eth_l1_buffer.at(b));
                         log_trace(tt::LogOp, "\trem_pages_per_worker.at(b): {}", rem_pages_per_worker.at(b));
                         log_trace(tt::LogOp, "\tinput_start_page_idx: {}", tensor_slicer.input_start_page_idx);
@@ -662,59 +850,30 @@ operation::ProgramWithCallbacks all_gather_multi_core_with_workers_helper(
                         log_trace(tt::LogOp, "\toutput_page_offset: {}", tensor_slicer.output_page_offset);
                         log_trace(tt::LogOp, "\tlast_output_addr_offset: {}", last_output_addr_offset);
                         log_trace(tt::LogOp, "\toutput_addr_offset: {}", tensor_slicer.output_addr_offset);
-                        log_trace(tt::LogOp, "\tring_index: {}", ring_index);
-                        log_trace(tt::LogOp, "\tsender_worker_reader_semaphore_id: {}", sender_worker_reader_semaphore_id);
                         log_trace(tt::LogOp, "\tis_clockwise_direction: {}", is_clockwise_direction ? 1 : 0);
 
-                        if (is_sharded) {
-                            log_sharded_tensor_kernel_args(input_tensor, input_pages_per_shard_y, input_pages_per_shard_x, "input");
-                            log_sharded_tensor_kernel_args(output_tensor, output_pages_per_shard_y, output_pages_per_shard_x, "output");
-                        }
-
-                        return worker_reader_sender_ct_args;
-                    };
-
-                    std::vector<uint32_t> const& worker_send_reader_ct_args = build_worker_send_reader_ct_args();
-
-                    auto build_worker_send_reader_rt_args = [&]() {
-                        bool is_clockwise = is_buffer_in_clockwise_direction(b);
-
-                        std::vector<uint32_t> args = {
-                            static_cast<uint32_t>(input_buffer->address()),
-                            static_cast<uint32_t>(output_buffer->address())
-                        };
-                        if (is_sharded) {
-                            emit_sharded_tensor_kernel_rt_args(device, input_tensor, args);
-                            emit_sharded_tensor_kernel_rt_args(device, output_tensor, args);
-                        }
                         return args;
                     };
                     std::vector<uint32_t> const& worker_send_reader_rt_args = build_worker_send_reader_rt_args();
 
-                    std::string const& send_reader_kernel_path = "ttnn/cpp/ttnn/operations/ccl/all_gather/device/kernels/dataflow/worker_interleaved_ring_gather_send_reader.cpp";
-                    KernelHandle worker_reader_sender_kernel_id = tt::tt_metal::CreateKernel(
-                        program,
-                        send_reader_kernel_path,
-                        sender_worker_cores.at(b),
-                        tt::tt_metal::ReaderDataMovementConfig(worker_send_reader_ct_args, worker_defines));
-                    send_reader_kernel_core_list.push_back({worker_reader_sender_kernel_id, sender_worker_cores.at(b)});
-
                     tt::tt_metal::SetRuntimeArgs(
                         program,
-                        worker_reader_sender_kernel_id,
+                        worker_sender_reader_kernel_id,
                         sender_worker_cores.at(b),
                         worker_send_reader_rt_args);
 
 
                     //// Send Writer
-                    auto build_worker_sender_writer_ct_args = [&]() {
+                    auto build_worker_sender_writer_rt_args = [&]() {
                         CoreCoord const& worker_eth_sender_core = is_clockwise_direction ? eth_sender_cores.at(i) : eth_receiver_cores.at(i);
-                        std::vector<uint32_t> worker_writer_sender_ct_args = {
-                            static_cast<uint32_t>(all_gather_config.is_output_dram()),
+
+                        std::vector<uint32_t> worker_writer_sender_rt_args = {
+                            static_cast<uint32_t>(output_buffer->address()),
+                            static_cast<uint32_t>(sender_enabled),
+                            static_cast<uint32_t>(sender_eth_buffer_addrs.at(b)),
+                            static_cast<uint32_t>(sender_eth_sem_addrs.at(b)),
                             static_cast<uint32_t>(sender_worker_num_transfers.at(i).at(b)),
                             static_cast<uint32_t>(num_full_chunks_per_worker.at(b)),
-                            static_cast<uint32_t>(input_page_size),
-                            static_cast<uint32_t>(output_page_size),
                             static_cast<uint32_t>(pages_per_eth_l1_buffer.at(b)),
                             static_cast<uint32_t>(rem_pages_per_worker.at(b)),
                             static_cast<uint32_t>(tensor_slicer.input_start_page_idx),
@@ -726,28 +885,21 @@ operation::ProgramWithCallbacks all_gather_multi_core_with_workers_helper(
                             static_cast<uint32_t>(tensor_slicer.col_offset),
                             static_cast<uint32_t>(tensor_slicer.num_rows),
                             static_cast<uint32_t>(tensor_slicer.num_cols),
-                            static_cast<uint32_t>(ring_index),
-
-                            // worker local L1 address of semaphore
-                            static_cast<uint32_t>(sender_worker_writer_semaphore_id),
                             static_cast<uint32_t>(device->ethernet_core_from_logical_core(worker_eth_sender_core).x),
                             static_cast<uint32_t>(device->ethernet_core_from_logical_core(worker_eth_sender_core).y),
-                            static_cast<uint32_t>(cb_num_pages / 2),
-                            static_cast<uint32_t>(num_edm_buffers_per_channel),
-
                             static_cast<bool>(fuse_op && direction == 1)
                         };
 
                         if (is_sharded) {
-                            emit_sharded_tensor_kernel_ct_args(device, output_tensor, worker_writer_sender_ct_args, output_pages_per_shard_y, output_pages_per_shard_x);
+                            emit_sharded_tensor_kernel_rt_args(device, output_tensor, worker_writer_sender_rt_args);
                         }
 
-                        log_trace(tt::LogOp, "Worker {} SW CT args", b);
-                        log_trace(tt::LogOp, "\tall_gather_config.is_output_dram(): {}", all_gather_config.is_output_dram());
+                        log_trace(tt::LogOp, "Worker {} SW rt args", b);
+                        log_trace(tt::LogOp, "\toutput_buffer->address(): {}", output_buffer->address());
+                        log_trace(tt::LogOp, "\tsender_eth_buffer_addrs: {}", sender_eth_buffer_addrs.at(b));
+                        log_trace(tt::LogOp, "\tsender_eth_sem_addrs: {}", sender_eth_sem_addrs.at(b));
                         log_trace(tt::LogOp, "\tsender_num_transfers: {}", sender_worker_num_transfers.at(i).at(b));
                         log_trace(tt::LogOp, "\tnum_full_chunks_per_worker: {}", num_full_chunks_per_worker.at(b));
-                        log_trace(tt::LogOp, "\tinput_page_size: {}", input_page_size);
-                        log_trace(tt::LogOp, "\toutput_page_size: {}", output_page_size);
                         log_trace(tt::LogOp, "\tpages_per_eth_l1_buffer: {}", pages_per_eth_l1_buffer.at(b));
                         log_trace(tt::LogOp, "\trem_pages_per_worker: {}", rem_pages_per_worker.at(b));
                         log_trace(tt::LogOp, "\tinput_start_page_idx: {}", tensor_slicer.input_start_page_idx);
@@ -759,30 +911,8 @@ operation::ProgramWithCallbacks all_gather_multi_core_with_workers_helper(
                         log_trace(tt::LogOp, "\tcol_offset: {}", tensor_slicer.col_offset);
                         log_trace(tt::LogOp, "\tnum_rows: {}", tensor_slicer.num_rows);
                         log_trace(tt::LogOp, "\tnum_cols: {}", tensor_slicer.num_cols);
-                        log_trace(tt::LogOp, "\tring_index: {}", ring_index);
-                        log_trace(tt::LogOp, "\tsender_worker_writer_semaphore_id: {}", sender_worker_writer_semaphore_id);
                         log_trace(tt::LogOp, "\tethernet_core_x: {}", device->ethernet_core_from_logical_core(worker_eth_sender_core).x);
                         log_trace(tt::LogOp, "\tethernet_core_y: {}", device->ethernet_core_from_logical_core(worker_eth_sender_core).y);
-                        log_trace(tt::LogOp, "\thalf_cb_num_pages: {}", cb_num_pages / 2);
-
-                        if (is_sharded) {
-                            log_sharded_tensor_kernel_args(output_tensor, output_pages_per_shard_y, output_pages_per_shard_x, "output");
-                        }
-                        return worker_writer_sender_ct_args;
-                    };
-
-                    std::vector<uint32_t> const& worker_sender_writer_ct_args = build_worker_sender_writer_ct_args();
-
-                    auto build_worker_sender_writer_rt_args = [&]() {
-                        std::vector<uint32_t> worker_writer_sender_rt_args = {
-                            static_cast<uint32_t>(output_buffer->address()),
-                            static_cast<uint32_t>(sender_eth_buffer_addrs.at(b)),
-                            static_cast<uint32_t>(sender_eth_sem_addrs.at(b))
-                        };
-
-                        if (is_sharded) {
-                            emit_sharded_tensor_kernel_rt_args(device, output_tensor, worker_writer_sender_rt_args);
-                        }
 
                         if (fuse_op && direction == 1) {
                             fused_op_signaler_sender_workers->push_all_gather_fused_op_rt_args(
@@ -797,36 +927,34 @@ operation::ProgramWithCallbacks all_gather_multi_core_with_workers_helper(
                             );
                         }
 
-                        log_trace(tt::LogOp, "Worker {} SW rt args", b);
-                        log_trace(tt::LogOp, "\toutput_buffer->address(): {}", output_buffer->address());
-                        log_trace(tt::LogOp, "\tsender_eth_buffer_addrs: {}", sender_eth_buffer_addrs.at(b));
-                        log_trace(tt::LogOp, "\tsender_eth_sem_addrs: {}", sender_eth_sem_addrs.at(b));
                         return worker_writer_sender_rt_args;
                     };
                     std::vector<uint32_t> const& worker_sender_writer_rt_args = build_worker_sender_writer_rt_args();
-
-                    std::string const& sender_writer_kernel_path = "ttnn/cpp/ttnn/operations/ccl/all_gather/device/kernels/dataflow/worker_interleaved_ring_gather_send_writer.cpp";
-                    KernelHandle worker_sender_writer_kernel_id = tt::tt_metal::CreateKernel(
-                        program,
-                        sender_writer_kernel_path,
-                        sender_worker_cores.at(b),
-                        tt::tt_metal::WriterDataMovementConfig(worker_sender_writer_ct_args, worker_defines));
-
-                    send_writer_kernel_core_list.push_back({worker_sender_writer_kernel_id, sender_worker_cores.at(b)});
 
                     tt::tt_metal::SetRuntimeArgs(
                         program,
                         worker_sender_writer_kernel_id,
                         sender_worker_cores.at(b),
                         worker_sender_writer_rt_args);
-
-                } // (!is_linear || !is_last_chip_in_chain)
-                else {
-                    log_trace(tt::LogOp, "Skipping sender workers for linear chain");
                 }
 
                 // RECEIVER WORKERS
-                if (!is_linear || !is_first_chip_in_chain) {
+                if (!receiver_enabled){
+                    tt::tt_metal::SetRuntimeArgs(
+                        program,
+                        worker_receiver_reader_kernel_id,
+                        receiver_worker_cores.at(b),
+                        {0, receiver_enabled});
+
+                    tt::tt_metal::SetRuntimeArgs(
+                        program,
+                        worker_receiver_writer_kernel_id,
+                        receiver_worker_cores.at(b),
+                        {0,0,0, receiver_enabled});
+
+                    log_trace(tt::LogOp, "Skipping receiver workers for linear chain");
+                }
+                else {
                     TT_ASSERT(!is_linear ||
                         ((is_clockwise_direction && (ring_index != 0)) || (!is_clockwise_direction && ring_index != ring_size - 1))
                     );
@@ -868,56 +996,32 @@ operation::ProgramWithCallbacks all_gather_multi_core_with_workers_helper(
                     log_trace(tt::LogOp,"\treceiver_ring_index={}", receiver_ring_index);
 
                     //// Receive Reader
-                    auto build_worker_receiver_reader_ct_args = [&]() {
+                    auto build_worker_receiver_reader_rt_args = [&]() {
                         CoreCoord const& worker_eth_receiver_core = is_clockwise_direction ? eth_receiver_cores.at(i) : eth_sender_cores.at(i);
-                        std::vector<uint32_t> worker_receiver_reader_ct_args = {
+                        std::vector<uint32_t> worker_reader_receiver_rt_args = {
+                            static_cast<uint32_t>(receiver_eth_buffer_addrs.at(b)),
+                            static_cast<uint32_t>(receiver_enabled),
                             static_cast<uint32_t>(receiver_worker_num_transfers.at(i).at(b)),
                             static_cast<uint32_t>(num_full_chunks_per_worker.at(b)),
-                            static_cast<uint32_t>(input_page_size),
                             static_cast<uint32_t>(pages_per_chunk),
                             static_cast<uint32_t>(rem_pages_per_worker.at(b)),
                             static_cast<uint32_t>(device->ethernet_core_from_logical_core(worker_eth_receiver_core).x),
                             static_cast<uint32_t>(device->ethernet_core_from_logical_core(worker_eth_receiver_core).y),
                             static_cast<uint32_t>(receiver_eth_sem_addrs.at(b)),
-                            static_cast<uint32_t>(receiver_worker_semaphore_id),
-                            static_cast<uint32_t>(cb_num_pages / 2),
-                            static_cast<uint32_t>(num_edm_buffers_per_channel)
                         };
 
-                        log_trace(tt::LogOp, "Worker {} RR ct args", b);
+                        log_trace(tt::LogOp, "Worker {} RR rt args", b);
+                        log_trace(tt::LogOp, "\treceiver_eth_buffer_addrs: {}", receiver_eth_buffer_addrs.at(b));
                         log_trace(tt::LogOp, "\treceiver_num_transfers: {}", receiver_worker_num_transfers.at(i).at(b));
                         log_trace(tt::LogOp, "\tnum_full_chunks_per_worker: {}", num_full_chunks_per_worker.at(b));
-                        log_trace(tt::LogOp, "\tinput_page_size: {}", input_page_size);
                         log_trace(tt::LogOp, "\tpages_per_chunk: {}", pages_per_chunk);
                         log_trace(tt::LogOp, "\trem_pages_per_worker: {}", rem_pages_per_worker.at(b));
                         log_trace(tt::LogOp, "\tethernet_core_x: {}", device->ethernet_core_from_logical_core(worker_eth_receiver_core).x);
                         log_trace(tt::LogOp, "\tethernet_core_y: {}", device->ethernet_core_from_logical_core(worker_eth_receiver_core).y);
                         log_trace(tt::LogOp, "\treceiver_eth_sem_addrs: {}", receiver_eth_sem_addrs.at(b));
-                        log_trace(tt::LogOp, "\treceiver_worker_semaphore_id: {}", receiver_worker_semaphore_id);
-                        log_trace(tt::LogOp, "\thalf_cb_num_pages : {}", cb_num_pages / 2);
-                        return worker_receiver_reader_ct_args;
-                    };
-                    std::vector<uint32_t> const& worker_receiver_reader_ct_args = build_worker_receiver_reader_ct_args();
-
-                    auto build_worker_receiver_reader_rt_args = [&]() {
-                        std::vector<uint32_t> worker_reader_receiver_rt_args = {
-                            static_cast<uint32_t>(receiver_eth_buffer_addrs.at(b))
-                        };
-
-                        log_trace(tt::LogOp, "Worker {} RR rt args", b);
-                        log_trace(tt::LogOp, "\treceiver_eth_buffer_addrs: {}", receiver_eth_buffer_addrs.at(b));
                         return worker_reader_receiver_rt_args;
                     };
                     std::vector<uint32_t> worker_receiver_reader_rt_args = build_worker_receiver_reader_rt_args();
-
-                    std::string const& receiver_reader_kernel_path = "ttnn/cpp/ttnn/operations/ccl/all_gather/device/kernels/dataflow/worker_interleaved_ring_gather_receive_reader.cpp";
-                    KernelHandle worker_receiver_reader_kernel_id = tt::tt_metal::CreateKernel(
-                        program,
-                        receiver_reader_kernel_path,
-                        receiver_worker_cores.at(b),
-                        tt::tt_metal::ReaderDataMovementConfig(worker_receiver_reader_ct_args, worker_defines));
-
-                    receive_reader_kernel_core_list.push_back({worker_receiver_reader_kernel_id, receiver_worker_cores.at(b)});
 
                     tt::tt_metal::SetRuntimeArgs(
                         program,
@@ -926,13 +1030,15 @@ operation::ProgramWithCallbacks all_gather_multi_core_with_workers_helper(
                         worker_receiver_reader_rt_args);
 
                     //// Receive Writer
-                    auto build_worker_receive_writer_ct_args = [&]() {
-                        std::vector<uint32_t> worker_writer_receiver_ct_args = {
-                            static_cast<uint32_t>(all_gather_config.is_output_dram()),
+                    auto build_worker_receive_writer_rt_args = [&]() {
+                        auto worker_sender_reader = device->worker_core_from_logical_core(sender_worker_cores.at(b));
+                        std::vector<uint32_t> worker_writer_receiver_rt_args = {
+                            static_cast<uint32_t>(output_buffer->address()),
+                            static_cast<uint32_t>(worker_sender_reader.x),
+                            static_cast<uint32_t>(worker_sender_reader.y),
+                            static_cast<uint32_t>(receiver_enabled),
                             static_cast<uint32_t>(receiver_worker_num_transfers.at(i).at(b)),
                             static_cast<uint32_t>(num_full_chunks_per_worker.at(b)),
-                            static_cast<uint32_t>(input_page_size),
-                            static_cast<uint32_t>(output_page_size),
                             static_cast<uint32_t>(pages_per_eth_l1_buffer.at(b)),
                             static_cast<uint32_t>(rem_pages_per_worker.at(b)),
                             static_cast<uint32_t>(receiver_output_start_page_idx),
@@ -948,23 +1054,19 @@ operation::ProgramWithCallbacks all_gather_multi_core_with_workers_helper(
                             static_cast<uint32_t>(last_output_addr_offset),
                             static_cast<uint32_t>(tensor_slicer.output_addr_offset),
                             static_cast<uint32_t>(receiver_ring_index),
-                            static_cast<uint32_t>(sender_worker_reader_semaphore_id),
                             static_cast<uint32_t>(is_clockwise_direction ? 1 : 0),
-                            static_cast<uint32_t>(cb_num_pages / 2),
-                            static_cast<uint32_t>(ring_size),
-                            static_cast<bool>(fuse_op)
                         };
 
                         if (is_sharded) {
-                            emit_sharded_tensor_kernel_ct_args(device, output_tensor, worker_writer_receiver_ct_args, output_pages_per_shard_y, output_pages_per_shard_x);
+                            emit_sharded_tensor_kernel_rt_args(device, output_tensor, worker_writer_receiver_rt_args);
                         }
 
-                        log_trace(tt::LogOp, "Worker {} RW ct args", b);
-                        log_trace(tt::LogOp, "\tall_gather_config.is_output_dram(): {}", all_gather_config.is_output_dram());
+                        log_trace(tt::LogOp, "Worker {} RW rt args", b);
+                        log_trace(tt::LogOp, "\toutput_buffer->address(): {}", output_buffer->address());
+                        log_trace(tt::LogOp, "\tworker_sender_reader.x: {}", worker_sender_reader.x);
+                        log_trace(tt::LogOp, "\tworker_sender_reader.y: {}", worker_sender_reader.y);
                         log_trace(tt::LogOp, "\treceiver_num_transfers: {}", receiver_worker_num_transfers.at(i).at(b));
                         log_trace(tt::LogOp, "\tnum_full_chunks_per_worker.at(b): {}", num_full_chunks_per_worker.at(b));
-                        log_trace(tt::LogOp, "\tinput_page_size: {}", input_page_size);
-                        log_trace(tt::LogOp, "\toutput_page_size: {}", output_page_size);
                         log_trace(tt::LogOp, "\tpages_per_eth_l1_buffer.at(b): {}", pages_per_eth_l1_buffer.at(b));
                         log_trace(tt::LogOp, "\trem_pages_per_worker.at(b): {}", rem_pages_per_worker.at(b));
                         log_trace(tt::LogOp, "\treceiver_output_start_page_idx: {}", receiver_output_start_page_idx);
@@ -980,30 +1082,7 @@ operation::ProgramWithCallbacks all_gather_multi_core_with_workers_helper(
                         log_trace(tt::LogOp, "\tlast_output_addr_offset: {}", last_output_addr_offset);
                         log_trace(tt::LogOp, "\toutput_addr_offset: {}", tensor_slicer.output_addr_offset);
                         log_trace(tt::LogOp, "\treceiver_ring_index: {}", receiver_ring_index);
-                        log_trace(tt::LogOp, "\tsender_worker_reader_semaphore_id: {}", sender_worker_reader_semaphore_id);
                         log_trace(tt::LogOp, "\tis_clockwise_direction ? 1 : 0: {}", is_clockwise_direction ? 1 : 0);
-                        log_trace(tt::LogOp, "\thalf_cb_num_pages: {}", cb_num_pages / 2);
-                        log_trace(tt::LogOp, "\tring_size: {}", ring_size);
-
-                        if (is_sharded) {
-                            log_sharded_tensor_kernel_args(output_tensor, output_pages_per_shard_y, output_pages_per_shard_x, "output");
-                        }
-
-                        return worker_writer_receiver_ct_args;
-                    };
-                    std::vector<uint32_t> const& worker_receive_writer_ct_args = build_worker_receive_writer_ct_args();
-
-                    auto build_worker_receive_writer_rt_args = [&]() {
-                        auto worker_sender_reader = device->worker_core_from_logical_core(sender_worker_cores.at(b));
-                        std::vector<uint32_t> worker_writer_receiver_rt_args = {
-                            static_cast<uint32_t>(output_buffer->address()),
-                            static_cast<uint32_t>(worker_sender_reader.x),
-                            static_cast<uint32_t>(worker_sender_reader.y),
-                        };
-
-                        if (is_sharded) {
-                            emit_sharded_tensor_kernel_rt_args(device, output_tensor, worker_writer_receiver_rt_args);
-                        }
 
                         /* All Gather fusion */
                         if (fuse_op) {
@@ -1015,30 +1094,15 @@ operation::ProgramWithCallbacks all_gather_multi_core_with_workers_helper(
                             );
                         }
 
-                        log_trace(tt::LogOp, "Worker {} RW rt args", b);
-                        log_trace(tt::LogOp, "\toutput_buffer->address(): {}", output_buffer->address());
-                        log_trace(tt::LogOp, "\tworker_sender_reader.x: {}", worker_sender_reader.x);
-                        log_trace(tt::LogOp, "\tworker_sender_reader.y: {}", worker_sender_reader.y);
                         return worker_writer_receiver_rt_args;
                     };
                     std::vector<uint32_t> worker_receive_writer_rt_args = build_worker_receive_writer_rt_args();
 
-                    std::string const& receiver_writer_kernel_path = "ttnn/cpp/ttnn/operations/ccl/all_gather/device/kernels/dataflow/worker_interleaved_ring_gather_receive_writer.cpp";
-                    KernelHandle worker_receive_writer_kernel_id = tt::tt_metal::CreateKernel(
-                        program,
-                        receiver_writer_kernel_path,
-                        receiver_worker_cores.at(b),
-                        tt::tt_metal::WriterDataMovementConfig(worker_receive_writer_ct_args, worker_defines));
-
-                    receive_writer_kernel_core_list.push_back({worker_receive_writer_kernel_id, receiver_worker_cores.at(b)});
                     tt::tt_metal::SetRuntimeArgs(
                         program,
-                        worker_receive_writer_kernel_id,
+                        worker_receiver_writer_kernel_id,
                         receiver_worker_cores.at(b),
                         worker_receive_writer_rt_args);
-                } // (!is_linear || !is_first_chip_in_chain)
-                else {
-                    log_trace(tt::LogOp, "Skipping receiver workers for linear chain");
                 }
 
                 uint32_t pages_per_worker = num_full_chunks_per_worker.at(b) * pages_per_chunk + rem_pages_per_worker.at(b);
@@ -1065,7 +1129,14 @@ operation::ProgramWithCallbacks all_gather_multi_core_with_workers_helper(
         receiver_device_id,
         sender_device_id);
 
-    auto override_runtime_arguments_callback = [num_links, receive_reader_kernel_core_list, receive_writer_kernel_core_list, send_reader_kernel_core_list, send_writer_kernel_core_list] (
+    auto override_runtime_arguments_callback =
+        [worker_sender_reader_kernel_id,
+         worker_sender_writer_kernel_id,
+         worker_receiver_reader_kernel_id,
+         worker_receiver_writer_kernel_id,
+         num_links,
+         all_sender_worker_cores,
+         all_receiver_worker_cores] (
         const void* operation,
         Program& program,
         const std::vector<Tensor>& input_tensors,
@@ -1074,17 +1145,25 @@ operation::ProgramWithCallbacks all_gather_multi_core_with_workers_helper(
     ) {
         const auto& input = input_tensors[0];
         const auto& output = output_tensors[0];
-        for (auto const& [kernel_id, core] : receive_writer_kernel_core_list) {
-            auto &worker_writer_receiver_runtime_args = GetRuntimeArgs(program, kernel_id, core);
+
+        // update receivers
+        auto &worker_writer_receiver_runtime_args_by_core = GetRuntimeArgs(program, worker_receiver_writer_kernel_id);
+        for (auto const& core : all_receiver_worker_cores) {
+            //writer
+            auto &worker_writer_receiver_runtime_args = worker_writer_receiver_runtime_args_by_core[core.x][core.y];
             worker_writer_receiver_runtime_args.at(0) = output.buffer()->address();
         }
-        for (auto const& [kernel_id, core] : send_reader_kernel_core_list) {
-            auto &worker_reader_sender_runtime_args = GetRuntimeArgs(program, kernel_id, core);
+
+        // update senders
+        auto &worker_reader_sender_runtime_args_by_core = GetRuntimeArgs(program, worker_sender_reader_kernel_id);
+        auto &worker_writer_sender_runtime_args_by_core = GetRuntimeArgs(program, worker_sender_writer_kernel_id);
+        for (auto const& core : all_sender_worker_cores) {
+            // reader
+            auto& worker_reader_sender_runtime_args = worker_reader_sender_runtime_args_by_core[core.x][core.y];
             worker_reader_sender_runtime_args.at(0) = input.buffer()->address();
             worker_reader_sender_runtime_args.at(1) = output.buffer()->address();
-        }
-        for (auto const& [kernel_id, core] : send_writer_kernel_core_list) {
-            auto &worker_writer_sender_runtime_args = GetRuntimeArgs(program, kernel_id, core);
+            // writer
+            auto& worker_writer_sender_runtime_args = worker_writer_sender_runtime_args_by_core[core.x][core.y];
             worker_writer_sender_runtime_args.at(0) = output.buffer()->address();
         }
     };


### PR DESCRIPTION
### Ticket
#11398 #11857

### Problem description
All gather has fairly high dispatch time compared to other ops, sitting at ~20 us for Llama decode with tracing.

### Result
After optimization, llama decode dispatch latency has reduced to 8.5 us.

### What's changed:
- merged sender and receiver into the same kernel and uses rt arg to differentiate between modes
- all worker cores now launched at the same time with same ct args
- optimized set runtime args on host by getting the address of the runtime arg vector for all cores

