### PR TITLE
#0: skip yolov4 failing sub_modules

### DIFF
--- a/models/experimental/yolov4/demo/demo.py
+++ b/models/experimental/yolov4/demo/demo.py
@@ -538,6 +538,7 @@ def do_detect(model, img, conf_thresh, nms_thresh, n_classes, device=None, class
 @skip_for_grayskull()
 @pytest.mark.parametrize("device_params", [{"l1_small_size": 16384}], indirect=True)
 def test_yolov4_model(device, model_location_generator, reset_seeds, input_path):
+    pytest.skip("bias_shape.without_padding()[-1] == b_shape[-1] issue for conv")
     model_path = model_location_generator("models", model_subdir="Yolo")
     if model_path == "models":
         pytest.skip(

--- a/tests/ttnn/integration_tests/yolov4/test_ttnn_head.py
+++ b/tests/ttnn/integration_tests/yolov4/test_ttnn_head.py
@@ -14,6 +14,7 @@ from loguru import logger
 
 @pytest.mark.parametrize("device_params", [{"l1_small_size": 16384}], indirect=True)
 def test_head(device, reset_seeds, model_location_generator):
+    pytest.skip("bias_shape.without_padding()[-1] == b_shape[-1] issue for conv")
     model_path = model_location_generator("models", model_subdir="Yolo")
 
     if model_path == "models":

--- a/tests/ttnn/integration_tests/yolov4/test_ttnn_yolov4.py
+++ b/tests/ttnn/integration_tests/yolov4/test_ttnn_yolov4.py
@@ -14,6 +14,7 @@ import pytest
 @skip_for_grayskull()
 @pytest.mark.parametrize("device_params", [{"l1_small_size": 16384}], indirect=True)
 def test_yolov4(device, reset_seeds, model_location_generator):
+    pytest.skip("bias_shape.without_padding()[-1] == b_shape[-1] issue for conv")
     model_path = model_location_generator("models", model_subdir="Yolo")
 
     if model_path == "models":


### PR DESCRIPTION
### Problem description
Temporary fix,skip yolov4 sub_module tests which are failing on main.

### What's changed
Skipped sub_modules which are failing due to **bias_shape.without_padding()[-1] == b_shape[-1]**.

### Checklist
- [ ] Post commit CI passes
