### PR TITLE
#11591: Move hack delay from trisc.cc to trisck.cc before run_kernel

### DIFF
--- a/tt_metal/hw/firmware/src/trisc.cc
+++ b/tt_metal/hw/firmware/src/trisc.cc
@@ -113,10 +113,6 @@ int main(int argc, char *argv[]) {
         uint32_t tt_l1_ptr *cb_l1_base = (uint32_t tt_l1_ptr *)(kernel_config_base +
             mailboxes->launch.kernel_config.cb_offset);
         setup_cb_read_write_interfaces(cb_l1_base, 0, mailboxes->launch.kernel_config.max_cb_index, cb_init_read, cb_init_write, cb_init_write);
-#if defined(UCK_CHLKC_UNPACK)
-        // Hack workaround for issue #11591
-        for (volatile uint32_t xxx = 0; xxx < 100; xxx++);
-#endif
 #endif
 
         rta_l1_base = (uint32_t tt_l1_ptr *)(kernel_config_base +

--- a/tt_metal/hw/firmware/src/trisck.cc
+++ b/tt_metal/hw/firmware/src/trisck.cc
@@ -43,7 +43,10 @@ void kernel_launch()
 #else
     tt_l1_ptr uint *local_l1_start_addr = (tt_l1_ptr uint *)PREPROCESSOR_EXPAND(MEM_TRISC, COMPILE_FOR_TRISC, _INIT_LOCAL_L1_BASE);
     firmware_kernel_common_init(local_l1_start_addr);
-
+#if defined(UCK_CHLKC_UNPACK)
+        // Hack workaround for issue #11591
+        for (volatile uint32_t xxx = 0; xxx < 100; xxx++);
+#endif
     run_kernel();
 #endif
 }


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/11591

### Problem description
Paul originally found what seems like a race in unpacker after removing the duplicate CB initialization from llks, so that we only init once in trisc.cc. A hack delay loop was added to trisc.cc after the cb init for unpacker, as this seemed to resolve the PCC failures on CI, but looks like this was not sufficient for all tests and some tests now produce ND output.

### What's changed
Moved the hack delay from trisc.cc to trisck.cc before run_kernel. This seems to have resolved the ND PCC issues the other tests were seeing. Looking to merge this workaround for now while debugging the root cause of why we need this hack to pass.

### Checklist
- [x] Post commit CI passes
- [x] Blackhole Post commit (if applicable)
- [x] Model regression CI testing passes (if applicable)
- [x] New/Existing tests provide coverage for changes
