### PR TITLE
#11964: Only write branch is if the repo is not detached

### DIFF
--- a/models/perf/perf_utils.py
+++ b/models/perf/perf_utils.py
@@ -24,7 +24,8 @@ def merge_perf_files(fname, perf_fname, expected_cols):
     repo = git.Repo(search_parent_directories=True)
 
     merge_res = open(fname, "w")
-    merge_res.write(f"branch: {repo.active_branch} \n")
+    if not repo.head.is_detached():
+        merge_res.write(f"branch: {repo.active_branch} \n")
     merge_res.write(f"hash: {repo.head.object.hexsha} \n")
     cols = ", ".join(expected_cols)
     merge_res.write(f"{cols} \n")

--- a/models/perf/perf_utils.py
+++ b/models/perf/perf_utils.py
@@ -24,7 +24,7 @@ def merge_perf_files(fname, perf_fname, expected_cols):
     repo = git.Repo(search_parent_directories=True)
 
     merge_res = open(fname, "w")
-    if not repo.head.is_detached():
+    if not repo.head.is_detached:
         merge_res.write(f"branch: {repo.active_branch} \n")
     merge_res.write(f"hash: {repo.head.object.hexsha} \n")
     cols = ", ".join(expected_cols)

--- a/tests/scripts/run_performance.sh
+++ b/tests/scripts/run_performance.sh
@@ -50,7 +50,6 @@ run_perf_models_cnn_javelin() {
 
     # Run tests
     env WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml pytest -n auto tests/device_perf_tests/stable_diffusion -m $test_marker --timeout=480
-    env WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml pytest models/experimental/functional_unet/tests -m $test_marker
 
     ## Merge all the generated reports
     env python models/perf/merge_perf_results.py
@@ -82,7 +81,6 @@ run_device_perf_models() {
         env WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml pytest models/demos/wormhole/mamba/tests -m $test_marker
 
         env WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml pytest models/demos/metal_BERT_large_11/tests -m $test_marker
-        env WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml pytest models/experimental/functional_unet/tests -m $test_marker
 
         env WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml pytest models/demos/falcon7b_common/tests -m $test_marker
     fi


### PR DESCRIPTION
 because when	run on a tag, it's detached and the head_branch property does
	not exist

### Ticket

#11964 

### Problem description

The package and release pipeline broke when running on a tag. This is because `GitPython`'s `head_branch` property for a `repo` object does not work for detached repos - which in this case is what happens when we check out a tag and not a branch ref.

The quick fix is to only record the branch ref if the repo is not detached.

### What's changed

Add condition to only record branch if it's not detached.

### Checklist
- [ ] Post commit CI passes
- [ ] Blackhole Post commit (if applicable)
- [ ] Model regression CI testing passes (if applicable)
- [ ] New/Existing tests provide coverage for changes
