### PR TITLE
#11915: Add sweep vector tagging and related infra changes

### DIFF
--- a/tests/sweep_framework/README.md
+++ b/tests/sweep_framework/README.md
@@ -307,6 +307,8 @@ Options:
 
 `--clean` OPTIONAL: This setting is used to recover from mistakes in parameter generation, or if you have removed some test suites. If set, this flag will mark ALL vectors in the sweep as "archived", and regenerate all suites based on the current parameters in the sweep file.
 
+`--tag <tag>` OPTIONAL: This setting is used to assign a custom tag that will be assigned to your test vectors. This is to keep copies of vectors seperate from other developers / CI. By default, this will be your username. You are able to specify a tag when running tests using the runner.
+
 ## Test Runner
 
 The test runner reads in test vectors from the test vector database and executes the tests sequentially by calling the op test's run function with the specified vectors.
@@ -350,6 +352,8 @@ Options:
 `--perf` OPTIONAL: This will enable e2e perf testing on the op tests that are written to support it. Each test will be run twice and the second result will be kept to avoid measuring compile time.
 
 `--dry-run` EXPERIMENTAL: This flag will print all the test vectors that would be run without the flag. This is best used piping stdout to a text file to avoid flooding the terminal.
+
+`--tag <tag>` OPTIONAL: This setting is used to assign a custom tag that will be used to search for test vectors. This is to keep copies of vectors seperate from other developers / CI. By default, this will be your username. You are able to specify a tag when generating tests using the generator. To run the CI suites of tests locally, use the `ci-main` tag.
 
 ## Query Tool
 

--- a/tests/sweep_framework/parameter_generator.py
+++ b/tests/sweep_framework/parameter_generator.py
@@ -64,6 +64,7 @@ def export_suite_vectors(module_name, suite_name, vectors):
             query={
                 "bool": {
                     "must": [
+                        {"match": {"tag.keyword": SWEEPS_TAG}},
                         {"match": {"status.keyword": str(VectorStatus.CURRENT)}},
                         {"match": {"suite_name.keyword": suite_name}},
                     ]
@@ -72,36 +73,40 @@ def export_suite_vectors(module_name, suite_name, vectors):
             size=10000,
         )["hits"]["hits"]
         old_vector_ids = set(vector["_id"] for vector in response)
+        old_vector_hashes = set(vector["_source"]["input_hash"] for vector in response)
     except NotFoundError as e:
         old_vector_ids = set()
+        old_vector_hashes = set()
         pass
 
     current_time = datetime.datetime.now().strftime("%Y-%m-%d_%H-%M-%S")
 
-    new_vector_ids = set()
+    new_vector_hashes = set()
     serialized_vectors = dict()
     for i in range(len(vectors)):
         vector = dict()
         for elem in vectors[i].keys():
             vector[elem] = serialize(vectors[i][elem], warnings)
-        id = hashlib.sha224(str(vectors[i]).encode("utf-8")).hexdigest()
-        new_vector_ids.add(id)
+        input_hash = hashlib.sha224(str(vectors[i]).encode("utf-8")).hexdigest()
+        new_vector_hashes.add(input_hash)
         vector["timestamp"] = current_time
-        serialized_vectors[id] = vector
+        vector["input_hash"] = input_hash
+        vector["tag"] = SWEEPS_TAG
+        serialized_vectors[input_hash] = vector
 
-    if old_vector_ids == new_vector_ids:
+    if old_vector_hashes == new_vector_hashes:
         print(
-            f"SWEEPS: Vectors generated for module {module_name}, suite {suite_name} already exist, and have not changed. Skipping..."
+            f"SWEEPS: Vectors generated for module {module_name}, suite {suite_name} already exist with tag {SWEEPS_TAG}, and have not changed. Skipping..."
         )
         return
     else:
         print(
-            f"SWEEPS: New vectors found for module {module_name}, suite {suite_name}. Archiving old vectors and saving new suite. This step may take several minutes."
+            f"SWEEPS: New vectors found for module {module_name}, suite {suite_name}, with tag {SWEEPS_TAG}. Archiving old vectors and saving new suite. This step may take several minutes."
         )
         for old_vector_id in old_vector_ids:
             client.update(index=index_name, id=old_vector_id, doc={"status": str(VectorStatus.ARCHIVED)})
-        for new_vector_id in serialized_vectors.keys():
-            client.index(index=index_name, id=new_vector_id, body=serialized_vectors[new_vector_id])
+        for new_vector_hash in serialized_vectors.keys():
+            client.index(index=index_name, body=serialized_vectors[new_vector_hash])
         print(f"SWEEPS: Generated {len(serialized_vectors)} test vectors for suite {suite_name}.")
 
 
@@ -127,8 +132,12 @@ def clean_module(module_name):
         exit(1)
 
     update_script = {"source": f"ctx._source.status = '{str(VectorStatus.ARCHIVED)}'", "lang": "painless"}
-    client.update_by_query(index=vector_index, query={"match_all": {}}, script=update_script, refresh=True)
-    print(f"SWEEPS: Marked all vectors in index {vector_index} as archived. Proceeding with generation...")
+    client.update_by_query(
+        index=vector_index, query={"match_all": {"tag.keyword": SWEEPS_TAG}}, script=update_script, refresh=True
+    )
+    print(
+        f"SWEEPS: Marked all vectors with tag {SWEEPS_TAG} in index {vector_index} as archived. Proceeding with generation..."
+    )
 
     client.close()
 
@@ -153,11 +162,27 @@ if __name__ == "__main__":
         default="corp",
         help="Elastic Connection String for vector database. Available presets are ['corp', 'cloud']",
     )
+    parser.add_argument(
+        "--tag",
+        required=False,
+        default=os.getenv("USER"),
+        help="Custom tag for the vectors you are generating. This is to keep copies seperate from other people's test vectors. By default, this will be your username. You are able to specify a tag when running tests using the runner.",
+    )
+    parser.add_argument("--explicit", required=False, action="store_true")
 
     args = parser.parse_args(sys.argv[1:])
 
     global ELASTIC_CONNECTION_STRING
     ELASTIC_CONNECTION_STRING = get_elastic_url(args.elastic)
+
+    global SWEEPS_TAG
+    SWEEPS_TAG = args.tag
+
+    if args.tag == "ci-main" and not args.explicit:
+        print("SWEEPS: The ci-main tag is reserved for CI only.")
+        exit(1)
+
+    print(f"SWEEPS: Running current generation with tag: {SWEEPS_TAG}.")
 
     if args.clean and not args.module_name:
         print("SWEEPS: The clean flag must be set in conjunction with a module name.")


### PR DESCRIPTION
### Ticket
#11915 

### Problem description
Currently, we will have concurrency issues with test vectors when multiple developers are working on the same tests, or if CI is running and updating test data when a developer is trying to work.

### What's changed
Add the concept of tagging test vectors, by default with the developer's username, to separate instances of the test vectors. This will ensure that developers have more control over their tests while they work, and they don't run into conflicts with other devs or CI. 

### Checklist
- [ ] Post commit CI passes
- [ ] Blackhole Post commit (if applicable)
- [ ] Model regression CI testing passes (if applicable)
- [ ] New/Existing tests provide coverage for changes
