### PR TITLE
#11972: Add parameter generation step to sweeps CI workflow, use new tagging feature, and schedule nightly

### DIFF
--- a/.github/workflows/all-static-checks.yaml
+++ b/.github/workflows/all-static-checks.yaml
@@ -49,3 +49,12 @@ jobs:
         run: |
           if (( $(grep -Rnw 'tests/tt_metal' -e 'tt_lib' | wc -l ) > 0 )); then exit 1; fi
           if (( $(grep -Rnw 'tests/tt_metal' -e 'tt_eager' | wc -l ) > 10 )); then exit 1; fi
+  check-sweeps-workflow:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5.0.0
+      - name: Check sweeps workflow option count against sweep file count
+        run: |
+          pip install pyyaml
+          python tests/sweep_framework/sweeps_workflow_verification.py

--- a/.github/workflows/ttnn-run-sweeps.yaml
+++ b/.github/workflows/ttnn-run-sweeps.yaml
@@ -2,29 +2,25 @@ name: "ttnn - Run sweeps"
 
 on:
   workflow_dispatch:
+  schedule:
+    - cron: "0 21 * * *" # This cron schedule runs the workflow at 9:00pm UTC nightly
 
 jobs:
   build-artifact:
     uses: ./.github/workflows/build-artifact.yaml
     secrets: inherit
 
-  ttnn-sweeps:
+  ttnn-generate-sweeps:
     needs: build-artifact
-    strategy:
-      # Do not fail-fast because we need to ensure all tests go to completion
-      # so we try not to get hanging machines
-      fail-fast: false
-      matrix:
-        arch: [grayskull, wormhole_b0]
     env:
       TT_METAL_ENV: ${{ vars.TT_METAL_ENV }}
-      ARCH_NAME: ${{ matrix.arch }}
+      ARCH_NAME: wormhole_b0
       ELASTIC_USERNAME: ${{ secrets.SWEEPS_ELASTIC_USERNAME }}
       ELASTIC_PASSWORD: ${{ secrets.SWEEPS_ELASTIC_PASSWORD }}
       LD_LIBRARY_PATH: ${{ github.workspace }}/build/lib
     environment: dev
-    timeout-minutes: 720
-    runs-on: ${{ matrix.arch }}
+    timeout-minutes: 30
+    runs-on: [build, in-service]
     steps:
       - uses: tenstorrent-metal/metal-workflows/.github/actions/checkout-with-submodule-lfs@v2.0.0
       - name: Set up dynamic env vars for build
@@ -32,10 +28,63 @@ jobs:
           echo "TT_METAL_HOME=$(pwd)" >> $GITHUB_ENV
       - uses: ./.github/actions/prepare-metal-run
         with:
-          arch: ${{ matrix.arch }}
-      - name: Run ttnn sweeps
+          arch: wormhole_b0
+      - name: Run ttnn sweeps generation
         run: |
           source ${{ github.workspace }}/python_env/bin/activate
           cd $TT_METAL_HOME
           export PYTHONPATH=$TT_METAL_HOME
-          python tests/sweep_framework/runner.py --elastic cloud
+          python tests/sweep_framework/parameter_generator.py --elastic cloud --tag ci-main --explicit
+
+  ttnn-run-sweeps:
+    needs: ttnn-generate-sweeps
+    strategy:
+      # Do not fail-fast because we need to ensure all tests go to completion
+      # so we try not to get hanging machines
+      fail-fast: false
+      matrix:
+        test-group:
+          [
+            {
+              name: "Grayskull E150 Sweeps",
+              arch: grayskull,
+              runs-on: ["cloud-virtual-machine", "E150", "in-service"],
+              tt-smi-cmd: "tt-smi-metal -r 0"
+            },
+            {
+              name: "Wormhole N150 Sweeps",
+              arch: wormhole_b0,
+              runs-on: ["cloud-virtual-machine", "N150", "in-service"],
+              tt-smi-cmd: "tt-smi-metal -r 0"
+            },
+            {
+              name: "Wormhole N300 Sweeps",
+              arch: wormhole_b0,
+              runs-on: ["cloud-virtual-machine", "N300", "in-service"],
+              tt-smi-cmd: "tt-smi-metal -r 0"
+            }
+          ]
+    env:
+      TT_METAL_ENV: ${{ vars.TT_METAL_ENV }}
+      ARCH_NAME: ${{ matrix.test-group.arch }}
+      ELASTIC_USERNAME: ${{ secrets.SWEEPS_ELASTIC_USERNAME }}
+      ELASTIC_PASSWORD: ${{ secrets.SWEEPS_ELASTIC_PASSWORD }}
+      TT_SMI_RESET_COMMAND: ${{ matrix.test-group.tt-smi-cmd }}
+      LD_LIBRARY_PATH: ${{ github.workspace }}/build/lib
+    environment: dev
+    timeout-minutes: 720
+    runs-on: ${{ matrix.test-group.runs-on }}
+    steps:
+      - uses: tenstorrent-metal/metal-workflows/.github/actions/checkout-with-submodule-lfs@v2.0.0
+      - name: Set up dynamic env vars for build
+        run: |
+          echo "TT_METAL_HOME=$(pwd)" >> $GITHUB_ENV
+      - uses: ./.github/actions/prepare-metal-run
+        with:
+          arch: ${{ matrix.test-group.arch }}
+      - name: Run ttnn sweeps runner
+        run: |
+          source ${{ github.workspace }}/python_env/bin/activate
+          cd $TT_METAL_HOME
+          export PYTHONPATH=$TT_METAL_HOME
+          python tests/sweep_framework/runner.py --elastic cloud --tag ci-main

--- a/.github/workflows/ttnn-run-sweeps.yaml
+++ b/.github/workflows/ttnn-run-sweeps.yaml
@@ -2,6 +2,29 @@ name: "ttnn - Run sweeps"
 
 on:
   workflow_dispatch:
+    inputs:
+      sweep_name:
+        type: choice
+        description: Which sweep to run?
+        required: true
+        options:
+          - ALL SWEEPS
+          - add
+          - line_all_gather
+          - matmul.full.matmul_default_block_sharded
+          - matmul.full.matmul_default_height_sharded
+          - matmul.full.matmul_default_interleaved
+          - matmul.full.matmul_default_width_sharded
+          - matmul.short.matmul_create_program_config
+          - matmul.short.matmul_default_sharded
+          - matmul.short.matmul_default
+          - matmul.short.matmul_user_program_config_mcast_1d
+          - matmul.short.matmul_user_program_config_mcast_2d
+          - matmul.short.matmul_user_program_config
+          - matmul.short.matmul
+          - data_movement.concat.concat_interleaved_n_tensors
+          - data_movement.concat.concat_interleaved
+          - data_movement.concat.concat_sharded
   schedule:
     - cron: "0 21 * * *" # This cron schedule runs the workflow at 9:00pm UTC nightly
 
@@ -29,11 +52,18 @@ jobs:
       - uses: ./.github/actions/prepare-metal-run
         with:
           arch: wormhole_b0
-      - name: Run ttnn sweeps generation
+      - name: Setup ttnn sweeps generation environment
         run: |
           source ${{ github.workspace }}/python_env/bin/activate
           cd $TT_METAL_HOME
           export PYTHONPATH=$TT_METAL_HOME
+      - name: Run ttnn sweeps generation (single sweep)
+        if: ${{ github.event.inputs.sweep_name != '' && github.event.inputs.sweep_name != 'ALL SWEEPS' }}
+        run: |
+          python tests/sweep_framework/parameter_generator.py --module-name ${{ github.event.inputs.sweep_name }} --elastic cloud --tag ci-main --explicit
+      - name: Run ttnn sweeps generation (all sweeps)
+        if: ${{ github.event.inputs.sweep_name == '' || github.event.inputs.sweep_name == 'ALL SWEEPS' }}
+        run: |
           python tests/sweep_framework/parameter_generator.py --elastic cloud --tag ci-main --explicit
 
   ttnn-run-sweeps:
@@ -82,9 +112,16 @@ jobs:
       - uses: ./.github/actions/prepare-metal-run
         with:
           arch: ${{ matrix.test-group.arch }}
-      - name: Run ttnn sweeps runner
+      - name: Setup ttnn sweeps runner environment
         run: |
           source ${{ github.workspace }}/python_env/bin/activate
           cd $TT_METAL_HOME
           export PYTHONPATH=$TT_METAL_HOME
+      - name: Run ttnn sweeps (single sweep)
+        if: ${{ github.event.inputs.sweep_name != '' && github.event.inputs.sweep_name != 'ALL SWEEPS' }}
+        run: |
+          python tests/sweep_framework/runner.py --module-name ${{ github.event.inputs.sweep_name }} --elastic cloud --tag ci-main
+      - name: Run ttnn sweeps (all sweeps)
+        if: ${{ github.event.inputs.sweep_name == '' || github.event.inputs.sweep_name == 'ALL SWEEPS' }}
+        run: |
           python tests/sweep_framework/runner.py --elastic cloud --tag ci-main

--- a/tests/sweep_framework/sweeps_workflow_verification.py
+++ b/tests/sweep_framework/sweeps_workflow_verification.py
@@ -1,0 +1,17 @@
+# SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
+
+# SPDX-License-Identifier: Apache-2.0
+
+from yaml import load, Loader
+import pathlib
+
+with open(".github/workflows/ttnn-run-sweeps.yaml") as file:
+    workflow = load(file, Loader)
+    workflow_count = len(workflow[True]["workflow_dispatch"]["inputs"]["sweep_name"]["options"])
+
+    sweeps_path = pathlib.Path(__file__).parent / "sweeps"
+    file_count = len(list(sweeps_path.glob("**/*.py")))
+    assert (
+        file_count + 1 == workflow_count
+    ), f"Sweeps workflow options does not match expected number of sweep files ({workflow_count} exist, expected {file_count + 1}). If you added a new sweep file, please add it to the options in the .github/workflows/ttnn-run-sweeps.yaml workflow file."
+    print("Sweeps workflow options match expected number of sweep files.")

--- a/tests/sweep_framework/tt_smi_util.py
+++ b/tests/sweep_framework/tt_smi_util.py
@@ -14,7 +14,12 @@ RESET_OVERRIDE = os.getenv("TT_SMI_RESET_COMMAND")
 
 def run_tt_smi(arch: str):
     if RESET_OVERRIDE is not None:
-        subprocess.run(RESET_OVERRIDE, shell=True)
+        smi_process = subprocess.run(RESET_OVERRIDE, shell=True)
+        if smi_process.returncode == 0:
+            print("SWEEPS: TT-SMI Reset Complete Successfully")
+            return
+        else:
+            raise Exception(f"SWEEPS: TT-SMI Reset Failed with Exit Code: {smi_process.returncode}")
         return
 
     if arch not in ["grayskull", "wormhole_b0"]:
@@ -27,12 +32,21 @@ def run_tt_smi(arch: str):
     ]
     args = GRAYSKULL_ARGS if arch == "grayskull" else WORMHOLE_ARGS
 
+    # Potential implementation to use the pre-defined reset script on each CI runner. Not in use because of the time and extra functions it has. (hugepages check, etc.)
+    # if os.getenv("CI") == "true":
+    #     smi_process = subprocess.run(f"/opt/tt_metal_infra/scripts/ci/{arch}/reset.sh", shell=True, capture_output=True)
+    #     if smi_process.returncode == 0:
+    #         print("SWEEPS: TT-SMI Reset Complete Successfully")
+    #         return
+    #     else:
+    #         raise Exception(f"SWEEPS: TT-SMI Reset Failed with Exit Code: {smi_process.returncode}")
+
     for smi_option in smi_options:
         executable = shutil.which(smi_option)
         if executable is not None:
-            # Corner case for newer version of tt-smi, -tr and -wr are removed on this version (tt-smi-metal).
+            # Corner case for newer version of tt-smi, -tr and -wr are removed on this version (tt-smi-metal). Default device 0, if needed use TT_SMI_RESET_COMMAND override.
             if smi_option == "tt-smi-metal":
-                args = ["-r", "all"]
+                args = ["-r", "0"]
             smi_process = subprocess.run([executable, *args])
             if smi_process.returncode == 0:
                 print("SWEEPS: TT-SMI Reset Complete Successfully")


### PR DESCRIPTION
### Ticket
#11972 

### Problem description
It was possible for vectors to become out of date with the files in main, meaning some tests could possibly break on CI runs if developers were concurrently working on changes.

### What's changed
Added parameter generation step to CI sweeps workflow using the new tagging functionality introduced in #11970.
Schedule this new run nightly.

### Checklist
- [ ] Post commit CI passes
- [ ] Blackhole Post commit (if applicable)
- [ ] Model regression CI testing passes (if applicable)
- [ ] New/Existing tests provide coverage for changes
