### PR TITLE
Use product codes for cards instead of arch for eager-package-main

### DIFF
--- a/.github/workflows/eager-package-main.yaml
+++ b/.github/workflows/eager-package-main.yaml
@@ -47,10 +47,11 @@ jobs:
       matrix:
         os: [ubuntu-20.04]
         runner-hw-info: [
-          {arch: grayskull},
-          {arch: wormhole_b0},
+          {arch: grayskull, type: E150},
+          {arch: wormhole_b0, type: N150},
+          {arch: wormhole_b0, type: N300}
         ]
-    runs-on: ["Linux", "${{ matrix.runner-hw-info.arch }}"]
+    runs-on: ["cloud-virtual-machine", "${{ matrix.runner-hw-info.type }}", "in-service"]
     environment: production
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
### Ticket
eager-package-main workflow still uses arch in workflow.
Removed reference to arch so that we can remove grayskull/wormhole_b0 label


### Checklist
- [ ] Post commit CI passes 
- [ ] Blackhole Post commit (if applicable)
- [ ] Model regression CI testing passes (if applicable)
- [ ] New/Existing tests provide coverage for changes

https://github.com/tenstorrent/tt-metal/actions/runs/10588331933