### PR TITLE
Fix CPU matmul bug from example

### DIFF
--- a/tt_metal/programming_examples/matmul_multi_core/matmul_multi_core.cpp
+++ b/tt_metal/programming_examples/matmul_multi_core/matmul_multi_core.cpp
@@ -39,7 +39,7 @@ void golden_matmul(std::vector<bfloat16>& a, std::vector<bfloat16>& b, std::vect
                 float_tmp = a[idx_a].to_float() * b[idx_b].to_float();
                 c_f += float_tmp;
                 idx_a += 1;
-                idx_b += K;
+                idx_b += N;
             }
             output.at(idx_c) = bfloat16(c_f);
         }

--- a/tt_metal/programming_examples/matmul_multicore_reuse/matmul_multicore_reuse.cpp
+++ b/tt_metal/programming_examples/matmul_multicore_reuse/matmul_multicore_reuse.cpp
@@ -39,7 +39,7 @@ void golden_matmul(vector<bfloat16>& a, vector<bfloat16>& b, vector<bfloat16>& o
                 float_tmp = a[idx_a].to_float() * b[idx_b].to_float();
                 c_f += float_tmp;
                 idx_a += 1;
-                idx_b += K;
+                idx_b += N;
             }
             output.at(idx_c) = bfloat16(c_f);
         }

--- a/tt_metal/programming_examples/matmul_multicore_reuse_mcast/matmul_multicore_reuse_mcast.cpp
+++ b/tt_metal/programming_examples/matmul_multicore_reuse_mcast/matmul_multicore_reuse_mcast.cpp
@@ -40,7 +40,7 @@ void golden_matmul(std::vector<bfloat16>& a, std::vector<bfloat16>& b, std::vect
                 float_tmp = a[idx_a].to_float() * b[idx_b].to_float();
                 c_f += float_tmp;
                 idx_a += 1;
-                idx_b += K;
+                idx_b += N;
             }
             output.at(idx_c) = bfloat16(c_f);
         }

--- a/tt_metal/programming_examples/matmul_single_core/matmul_single_core.cpp
+++ b/tt_metal/programming_examples/matmul_single_core/matmul_single_core.cpp
@@ -38,7 +38,7 @@ void golden_matmul(std::vector<bfloat16>& a, std::vector<bfloat16>& b, std::vect
                 float_tmp = a[idx_a].to_float() * b[idx_b].to_float();
                 c_f += float_tmp;
                 idx_a += 1;
-                idx_b += K;
+                idx_b += N;
             }
             output.at(idx_c) = bfloat16(c_f);
         }


### PR DESCRIPTION
When we have two matrices A whose dimension is M by K and B whose dimension is K by N, we have to dot-product i-th row of A and j-th column of B to get (i, j) of the output matrix. To iterate j-th column of B, we have to access {j, j + N, j + 2 * N, ..., j + (K - 1) * N}. However, `golden_matmul(..)` function in the matmul example (CPU matmul code) iterates {j, j + K, j + 2 * K, ..., j + (K - 1) * K} for j-th column of B.

As a coincidence, all the given examples use the same number for M, N, K, which makes the example correct. However, when we change M, N, K e.g., 1024, 512, 256. They have incorrect results.

This commit fixes the issue by iterating `j+k*N` instead of `j+k*K`.
