### PR TITLE
#5337: Fix Mixtral total number of generated tokens in perf benchmark

### DIFF
--- a/models/demos/t3000/mixtral8x7b/demo/demo_with_prefill.py
+++ b/models/demos/t3000/mixtral8x7b/demo/demo_with_prefill.py
@@ -246,7 +246,6 @@ def run_mixtral_demo(user_input, batch_size, device_mesh, instruct_mode, max_pre
     finished_generation = [False] * batch_size
 
     num_tokens_generated_decode = max_generated_tokens
-    log_total_iterations = max_generated_tokens  # In case all users finish early, for logging purposes
     profiler.start("inference_decode")
     # Keep running inference as long as there is a user in the batch still decoding or max tokens per user are decoded
     for iteration in range(max_generated_tokens):
@@ -256,7 +255,9 @@ def run_mixtral_demo(user_input, batch_size, device_mesh, instruct_mode, max_pre
         # Check if all users have finished generating (reached EoS token). If so, stop decoding.
         if all(finished_generation):
             logger.info("All users have finished generating tokens")
-            log_total_iterations = iteration
+            num_tokens_generated_decode = (
+                iteration  # In case all users finish early, update the real number of generated tokens
+            )
             break
 
         iteration_time_start = time()
@@ -387,7 +388,7 @@ def run_mixtral_demo(user_input, batch_size, device_mesh, instruct_mode, max_pre
     compile_decode_time = profiler.get_duration("compile_decode")
     inference_prefill_time = profiler.get_duration("inference_prefill")
     inference_decode_time = profiler.get_duration("inference_decode")
-    log_printing_time = sum(profiler.get_duration(f"log_printing_{i}") for i in range(log_total_iterations))
+    log_printing_time = sum(profiler.get_duration(f"log_printing_{i}") for i in range(num_tokens_generated_decode))
 
     # Correct the inference decode time to remove the time spent on compile (1st iteration) and log_printing (at the end of every iteration)
     inference_decode_time = inference_decode_time - compile_decode_time - log_printing_time
@@ -429,7 +430,7 @@ def run_mixtral_demo(user_input, batch_size, device_mesh, instruct_mode, max_pre
     logger.info(f"Decode compile time: {round(measurements['compile_decode'], 4)}s")
     logger.info(f"Prefill inference time per user: {round(measurements['inference_prefill']/(batch_size-1), 4)}s")
     logger.info(
-        f"Total Decode inference time ({max_generated_tokens-1} iterations): {round(measurements['inference_decode'], 4)}s"
+        f"Total Decode inference time ({num_tokens_generated_decode-1} iterations): {round(measurements['inference_decode'], 4)}s"
     )
     logger.info("---")
     logger.info(f"Time to first token: {round(measurements['prefill_time_to_token'], 4) * 1000}ms")


### PR DESCRIPTION
There was a bug on the Mixtral benchmark code that was not accounting correctly for the case where all users finish before the max_number_iterations.
This would lead to abnormally high tok/s/u.

E.g.:
- Max iterations = 120
- All users finish after 50 iterations.
- final tok/s/u would be 120/inference time, instead of 50/inference time. More than double!
