### PR TITLE
#11938: Refactoring `moreh_bmm`

### DIFF
--- a/tests/tt_eager/python_api_testing/unit_testing/misc/test_moreh_bmm.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/misc/test_moreh_bmm.py
@@ -11,30 +11,42 @@ import ttnn
 from tests.tt_eager.python_api_testing.unit_testing.misc.test_moreh_matmul import get_tensors
 from models.utility_functions import comp_allclose_and_pcc
 
+from tests.tt_eager.python_api_testing.unit_testing.misc.test_utils import (
+    get_compute_kernel_options,
+    compute_kernel_options,
+    compute_kernel_ids,
+)
+
 
 @pytest.mark.parametrize(
     "shape",
     (
+        # batch, m, k, n
         [1, 31, 639, 31],
         [5, 95, 415, 65],
         [10, 191, 447, 159],
-        [20, 287, 479, 255],
     ),
 )
-def test_moreh_bmm(shape, device):
-    input_shape = [1, shape[0], shape[1], shape[2]]
-    mat2_shape = [1, shape[0], shape[2], shape[3]]
-    output_shape = [1, shape[0], shape[1], shape[3]]
+@pytest.mark.parametrize("has_output", [False, True])
+@pytest.mark.parametrize("compute_kernel_options", compute_kernel_options, ids=compute_kernel_ids)
+def test_moreh_bmm(shape, has_output, compute_kernel_options, device):
+    input_shape = [shape[0], shape[1], shape[2]]
+    mat2_shape = [shape[0], shape[2], shape[3]]
+    output_shape = [shape[0], shape[1], shape[3]]
 
     # get tensors
-    tt_input, tt_mat2, _, _, _, _, torch_input, torch_mat2, _ = get_tensors(
+    tt_input, tt_mat2, tt_output, _, _, _, input, mat2, _ = get_tensors(
         input_shape, mat2_shape, output_shape, False, False, False, device
     )
+
+    compute_kernel_config = get_compute_kernel_options(compute_kernel_options)
 
     # tt bmm
     cpu_layout = ttnn.ROW_MAJOR_LAYOUT
     tt_out = (
-        ttnn.experimental.operations.primary.moreh_bmm(tt_input, tt_mat2)
+        ttnn.experimental.operations.primary.moreh_bmm(
+            tt_input, tt_mat2, output=tt_output if has_output else None, compute_kernel_config=compute_kernel_config
+        )
         .cpu()
         .to(cpu_layout)
         .unpad_from_tile(output_shape)
@@ -42,10 +54,7 @@ def test_moreh_bmm(shape, device):
     )
 
     # torch bmm
-    torch_input = torch_input.reshape(-1, input_shape[2], input_shape[3])
-    torch_mat2 = torch_mat2.reshape(-1, mat2_shape[2], mat2_shape[3])
-    torch_out = torch.bmm(torch_input, torch_mat2)
-    torch_out = torch.unsqueeze(torch_out, dim=0)
+    torch_out = torch.bmm(input, mat2)
 
     ## test for equivalance
     passing, output_pcc = comp_allclose_and_pcc(torch_out, tt_out, pcc=0.999)

--- a/tests/tt_eager/python_api_testing/unit_testing/misc/test_moreh_bmm.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/misc/test_moreh_bmm.py
@@ -43,7 +43,7 @@ def test_moreh_bmm(shape, has_output, compute_kernel_options, device):
 
     # tt bmm
     cpu_layout = ttnn.ROW_MAJOR_LAYOUT
-    tt_out = (
+    tt_output = (
         ttnn.experimental.operations.primary.moreh_bmm(
             tt_input, tt_mat2, output=tt_output if has_output else None, compute_kernel_config=compute_kernel_config
         )
@@ -54,10 +54,10 @@ def test_moreh_bmm(shape, has_output, compute_kernel_options, device):
     )
 
     # torch bmm
-    torch_out = torch.bmm(input, mat2)
+    output = torch.bmm(input, mat2)
 
     ## test for equivalance
-    passing, output_pcc = comp_allclose_and_pcc(torch_out, tt_out, pcc=0.999)
+    passing, output_pcc = comp_allclose_and_pcc(output, tt_output, pcc=0.999)
     logger.debug(f"Out passing={passing}")
     logger.debug(f"Output pcc={output_pcc}")
 
@@ -67,9 +67,9 @@ def test_moreh_bmm(shape, has_output, compute_kernel_options, device):
 @pytest.mark.parametrize(
     "shape",
     (
+        # batch, m, k, n
         [1, 32, 32, 32],
         [3, 31, 31, 31],
-        [5, 255, 765, 511],
         [7, 511, 313, 765],
     ),
 )
@@ -81,11 +81,14 @@ def test_moreh_bmm(shape, has_output, compute_kernel_options, device):
         (True, True),
     ),
 )
-def test_moreh_bmm_backward(shape, requires_grad, device):
+@pytest.mark.parametrize("compute_kernel_options", compute_kernel_options, ids=compute_kernel_ids)
+def test_moreh_bmm_backward(shape, requires_grad, compute_kernel_options, device):
     require_input_grad, require_mat2_grad = requires_grad
-    input_shape = [1, shape[0], shape[1], shape[2]]
-    mat2_shape = [1, shape[0], shape[2], shape[3]]
-    output_shape = [1, shape[0], shape[1], shape[3]]
+    input_shape = [shape[0], shape[1], shape[2]]
+    mat2_shape = [shape[0], shape[2], shape[3]]
+    output_shape = [shape[0], shape[1], shape[3]]
+
+    compute_kernel_config = get_compute_kernel_options(compute_kernel_options)
 
     # get tensors
     (
@@ -95,40 +98,39 @@ def test_moreh_bmm_backward(shape, requires_grad, device):
         tt_output_grad,
         tt_input_grad,
         tt_mat2_grad,
-        torch_input,
-        torch_mat2,
-        torch_output_grad,
+        input,
+        mat2,
+        output_grad,
     ) = get_tensors(input_shape, mat2_shape, output_shape, require_input_grad, require_mat2_grad, False, device)
 
     # tt bmm fwd, bwd
     cpu_layout = ttnn.ROW_MAJOR_LAYOUT
     ttnn.experimental.operations.primary.moreh_bmm_backward(
-        tt_output_grad, tt_input, tt_mat2, tt_input_grad, tt_mat2_grad
+        tt_output_grad,
+        tt_input,
+        tt_mat2,
+        are_required_outputs=(require_input_grad, require_mat2_grad),
+        input_grad=tt_input_grad if require_input_grad else None,
+        mat2_grad=tt_mat2_grad if require_mat2_grad else None,
+        compute_kernel_config=compute_kernel_config,
     )
 
     # torch bmm fwd, bwd
-    torch_input = torch_input.reshape(-1, input_shape[2], input_shape[3])
-    torch_mat2 = torch_mat2.reshape(-1, mat2_shape[2], mat2_shape[3])
-    torch_output_grad = torch_output_grad.reshape(-1, output_shape[2], output_shape[3])
-    torch_out = torch.bmm(torch_input.requires_grad_(require_input_grad), torch_mat2.requires_grad_(require_mat2_grad))
-    torch_out.backward(torch_output_grad)
+    output = torch.bmm(input.requires_grad_(require_input_grad), mat2.requires_grad_(require_mat2_grad))
+    output.backward(output_grad)
 
     # test for equivalance
     rtol = atol = 0.1
     if require_input_grad:
         ttcpu_input_grad = tt_input_grad.cpu().to(cpu_layout).unpad_from_tile(input_shape).to_torch()
-
-        torch_input_grad = torch.unsqueeze(torch_input.grad, dim=0)
-        passing, output_pcc = comp_allclose_and_pcc(torch_input_grad, ttcpu_input_grad, pcc=0.999, rtol=rtol, atol=atol)
+        passing, output_pcc = comp_allclose_and_pcc(input.grad, ttcpu_input_grad, pcc=0.999, rtol=rtol, atol=atol)
         logger.debug(f"input_grad passing={passing}")
         logger.debug(f"input_grad pcc={output_pcc}")
         assert passing
 
     if require_mat2_grad:
         ttcpu_mat2_grad = tt_mat2_grad.cpu().to(cpu_layout).unpad_from_tile(mat2_shape).to_torch()
-
-        torch_mat2_grad = torch.unsqueeze(torch_mat2.grad, dim=0)
-        passing, output_pcc = comp_allclose_and_pcc(torch_mat2_grad, ttcpu_mat2_grad, pcc=0.999, rtol=rtol, atol=atol)
+        passing, output_pcc = comp_allclose_and_pcc(mat2.grad, ttcpu_mat2_grad, pcc=0.999, rtol=rtol, atol=atol)
         logger.debug(f"mat2_grad passing={passing}")
         logger.debug(f"mat2_grad pcc={output_pcc}")
         assert passing

--- a/ttnn/cpp/ttnn/deprecated/tt_dnn/op_library/moreh_bmm/moreh_bmm_op.cpp
+++ b/ttnn/cpp/ttnn/deprecated/tt_dnn/op_library/moreh_bmm/moreh_bmm_op.cpp
@@ -11,25 +11,37 @@ namespace tt {
 namespace operations {
 namespace primary {
 
+namespace {
 inline void moreh_bmm_validate(const Tensor& input, const Tensor& mat2) {
-    const auto& a_shape = input.get_legacy_shape();
-    const auto& b_shape = mat2.get_legacy_shape();
+    const auto& input_shape = input.get_legacy_shape();
+    const auto& mat2_shape = mat2.get_legacy_shape();
 
-    TT_ASSERT(a_shape[0] == 1, "input must be a 3D tensor");
-    TT_ASSERT(b_shape[0] == 1, "mat2 must be a 3D tensor");
-}
-
-Tensor moreh_bmm_(const Tensor& input, const Tensor& mat2, const MemoryConfig& mem_config) {
-    moreh_bmm_validate(input, mat2);
-    return moreh_matmul(input, mat2, false, false, std::nullopt, std::nullopt, mem_config);
-}
-
-Tensor moreh_bmm(const Tensor& input, const Tensor& mat2, const MemoryConfig& output_mem_config) {
     TT_ASSERT(
         input.storage_type() == StorageType::DEVICE && mat2.storage_type() == StorageType::DEVICE,
         "input tensors need to be on device");
+    TT_ASSERT(input_shape.rank() == 3, "input must be a 3D tensor");
+    TT_ASSERT(mat2_shape.rank() == 3, "mat2 must be a 3D tensor");
+}
 
-    return moreh_bmm_(input, mat2, output_mem_config);
+Tensor moreh_bmm_(
+    const Tensor& input,
+    const Tensor& mat2,
+    const std::optional<const Tensor>& output,
+    const MemoryConfig& mem_config,
+    const std::optional<const DeviceComputeKernelConfig> &compute_kernel_config) {
+    moreh_bmm_validate(input, mat2);
+    return moreh_matmul(input, mat2, false, false, output, std::nullopt, mem_config, compute_kernel_config);
+}
+}  // namespace
+
+Tensor moreh_bmm(
+    const Tensor& input,
+    const Tensor& mat2,
+    const std::optional<const Tensor> output,
+    const MemoryConfig& output_mem_config,
+    std::optional<const DeviceComputeKernelConfig> compute_kernel_config) {
+
+    return moreh_bmm_(input, mat2, output, output_mem_config, compute_kernel_config);
 }
 
 }  // namespace primary

--- a/ttnn/cpp/ttnn/deprecated/tt_dnn/op_library/moreh_bmm/moreh_bmm_op.hpp
+++ b/ttnn/cpp/ttnn/deprecated/tt_dnn/op_library/moreh_bmm/moreh_bmm_op.hpp
@@ -6,7 +6,10 @@
 
 #pragma once
 
+#include <optional>
+
 #include "ttnn/tensor/tensor.hpp"
+#include "ttnn/deprecated/tt_dnn/op_library/compute_kernel_config.hpp"
 #include "ttnn/operation.hpp"
 
 namespace tt {
@@ -18,7 +21,9 @@ using namespace tt_metal;
 Tensor moreh_bmm(
     const Tensor& input,
     const Tensor& mat2,
-    const MemoryConfig& output_mem_config = operation::DEFAULT_OUTPUT_MEMORY_CONFIG);
+    std::optional<const Tensor> output = std::nullopt,
+    const MemoryConfig& output_mem_config = operation::DEFAULT_OUTPUT_MEMORY_CONFIG,
+    std::optional<const DeviceComputeKernelConfig> compute_kernel_config = std::nullopt);
 
 }  // namespace primary
 

--- a/ttnn/cpp/ttnn/deprecated/tt_dnn/op_library/moreh_bmm_backward/moreh_bmm_backward_op.cpp
+++ b/ttnn/cpp/ttnn/deprecated/tt_dnn/op_library/moreh_bmm_backward/moreh_bmm_backward_op.cpp
@@ -11,71 +11,81 @@ namespace tt {
 namespace operations {
 namespace primary {
 
+namespace {
 inline void moreh_bmm_backward_validate(
     const Tensor &output_grad,
     const Tensor &input,
     const Tensor &mat2,
-    std::optional<std::reference_wrapper<const Tensor>> input_grad,
-    std::optional<std::reference_wrapper<const Tensor>> mat2_grad) {
-    const auto &input_shape = input.get_legacy_shape().without_padding();
-    const auto &mat2_shape = mat2.get_legacy_shape().without_padding();
-    const auto &output_grad_shape = output_grad.get_legacy_shape().without_padding();
+    std::optional<const Tensor> &input_grad,
+    std::optional<const Tensor> &mat2_grad) {
     TT_ASSERT(
         output_grad.storage_type() == StorageType::DEVICE && input.storage_type() == StorageType::DEVICE &&
             mat2.storage_type() == StorageType::DEVICE,
         "input tensors need to be on device");
 
-    TT_ASSERT(input_shape[0] == 1, "input must be a 3D tensor");
-    TT_ASSERT(mat2_shape[0] == 1, "mat2 must be a 3D tensor");
-    TT_ASSERT(output_grad_shape[0] == 1, "output_grad must be a 3D tensor");
-    TT_ASSERT(
-        output_grad_shape[1] == input_shape[1] && output_grad_shape[2] == input_shape[2] &&
-            output_grad_shape[3] == mat2_shape[3],
-        "check output_grad shape");
+    const auto &output_grad_shape = output_grad.get_legacy_shape();
+    const auto &input_shape = input.get_legacy_shape();
+    const auto &mat2_shape = mat2.get_legacy_shape();
+    TT_ASSERT(output_grad_shape.rank() == 3, "output_grad must be a 3D tensor");
+    TT_ASSERT(input_shape.rank() == 3, "input must be a 3D tensor");
+    TT_ASSERT(mat2_shape.rank() == 3, "mat2 must be a 3D tensor");
 
-    if (input_grad) {
-        const auto &input_grad_tensor = input_grad->get();
-        TT_ASSERT(
-            input_grad_tensor.get_legacy_shape().without_padding() == input_shape,
-            "shape of input_grad should be the same as shape of input");
+    if (input_grad.has_value()) {
+        const auto &input_grad_shape = input_grad.value().get_legacy_shape();
+        TT_ASSERT(input_grad_shape.rank() == 3, "input_grad must be a 3D tensor");
     }
 
-    if (mat2_grad) {
-        const auto &mat2_grad_tensor = mat2_grad->get();
-        TT_ASSERT(
-            mat2_grad_tensor.get_legacy_shape().without_padding() == mat2_shape,
-            "shape of mat2_grad should be the same as shape of mat2");
+    if (mat2_grad.has_value()) {
+        const auto &mat2_grad_shape = mat2_grad.value().get_legacy_shape();
+        TT_ASSERT(mat2_grad_shape.rank() == 3, "mat2_grad must be a 3D tensor");
     }
 }
+}
 
-[[maybe_unused]] std::vector<std::variant<std::monostate, Tensor, char *>> moreh_bmm_backward(
+std::vector<std::optional<Tensor>> moreh_bmm_backward(
     const Tensor &output_grad,
     const Tensor &input,
     const Tensor &mat2,
-    std::optional<std::reference_wrapper<const Tensor>> input_grad,
-    std::optional<std::reference_wrapper<const Tensor>> mat2_grad,
-    const MemoryConfig &output_mem_config) {
-    using TensorVariant = std::variant<std::monostate, Tensor, char *>;
-    std::vector<TensorVariant> outputs;
+    const std::vector<bool> &are_required_outputs,
+    std::optional<const Tensor> input_grad,
+    std::optional<const Tensor> mat2_grad,
+    const MemoryConfig &input_grad_mem_config,
+    const MemoryConfig &mat2_grad_mem_config,
+    std::optional<const DeviceComputeKernelConfig> compute_kernel_config) {
+    std::vector<std::optional<Tensor>> outputs(2);
     outputs.reserve(2);
 
-    moreh_bmm_backward_validate(output_grad, input, mat2, input_grad, mat2_grad);
+    const bool input_requires_grad = are_required_outputs.at(0);
+    const bool mat2_requires_grad = are_required_outputs.at(1);
 
-    if (input_grad) {
-        auto res = tt::operations::primary::moreh_matmul(
-            output_grad, mat2, false, true, input_grad->get(), std::nullopt, output_mem_config);
-        outputs.push_back(TensorVariant(std::in_place_type<Tensor>, std::move(res)));
-    } else {
-        outputs.push_back(TensorVariant(std::in_place_type<char *>, nullptr));
+    if (input_requires_grad) {
+        TT_ASSERT(input_grad.has_value());
+        const auto &input_grad_tensor = input_grad.value();
+        outputs[0] = moreh_matmul(
+            output_grad,
+            mat2,
+            false,
+            true,
+            input_grad_tensor,
+            std::nullopt,
+            input_grad_mem_config,
+            compute_kernel_config);
     }
 
-    if (mat2_grad) {
-        auto res = tt::operations::primary::moreh_matmul(
-            input, output_grad, true, false, mat2_grad->get(), std::nullopt, output_mem_config);
-        outputs.push_back(TensorVariant(std::in_place_type<Tensor>, std::move(res)));
-    } else {
-        outputs.push_back(TensorVariant(std::in_place_type<char *>, nullptr));
+    if (mat2_requires_grad) {
+        TT_ASSERT(mat2_grad.has_value());
+        const auto &mat2_grad_tensor = mat2_grad.value();
+        outputs[1] = moreh_matmul(
+            input,
+            output_grad,
+            true,
+            false,
+            mat2_grad_tensor,
+            std::nullopt,
+            mat2_grad_mem_config,
+            compute_kernel_config);
     }
+
     return outputs;
 }
 

--- a/ttnn/cpp/ttnn/deprecated/tt_dnn/op_library/moreh_bmm_backward/moreh_bmm_backward_op.hpp
+++ b/ttnn/cpp/ttnn/deprecated/tt_dnn/op_library/moreh_bmm_backward/moreh_bmm_backward_op.hpp
@@ -6,8 +6,9 @@
 
 #pragma once
 
-#include "ttnn/tensor/tensor.hpp"
+#include "ttnn/deprecated/tt_dnn/op_library/compute_kernel_config.hpp"
 #include "ttnn/operation.hpp"
+#include "ttnn/tensor/tensor.hpp"
 
 namespace tt {
 namespace operations {
@@ -15,13 +16,16 @@ namespace primary {
 
 using namespace tt_metal;
 
-[[maybe_unused]] std::vector<std::variant<std::monostate, Tensor, char *>> moreh_bmm_backward(
+std::vector<std::optional<Tensor>> moreh_bmm_backward(
     const Tensor &output_grad,
     const Tensor &input,
     const Tensor &mat2,
-    std::optional<std::reference_wrapper<const Tensor>> input_grad = std::nullopt,
-    std::optional<std::reference_wrapper<const Tensor>> mat2_grad = std::nullopt,
-    const MemoryConfig &output_mem_config = operation::DEFAULT_OUTPUT_MEMORY_CONFIG);
+    const std::vector<bool> &are_required_outputs = std::vector<bool>{true, true},
+    std::optional<const Tensor> input_grad = std::nullopt,
+    std::optional<const Tensor> mat2_grad = std::nullopt,
+    const MemoryConfig &input_grad_mem_config = operation::DEFAULT_OUTPUT_MEMORY_CONFIG,
+    const MemoryConfig &mat2_grad_mem_config = operation::DEFAULT_OUTPUT_MEMORY_CONFIG,
+    std::optional<const DeviceComputeKernelConfig> compute_kernel_config = std::nullopt);
 
 }  // namespace primary
 

--- a/ttnn/cpp/ttnn/deprecated/tt_dnn/op_library/moreh_matmul_backward/moreh_matmul_backward_op.hpp
+++ b/ttnn/cpp/ttnn/deprecated/tt_dnn/op_library/moreh_matmul_backward/moreh_matmul_backward_op.hpp
@@ -5,9 +5,9 @@
  */
 
 #pragma once
-#include "ttnn/tensor/tensor.hpp"
 #include "ttnn/deprecated/tt_dnn/op_library/compute_kernel_config.hpp"
 #include "ttnn/run_operation.hpp"
+#include "ttnn/tensor/tensor.hpp"
 
 namespace tt {
 

--- a/ttnn/cpp/ttnn/deprecated/tt_lib/csrc/operations/primary/module.hpp
+++ b/ttnn/cpp/ttnn/deprecated/tt_lib/csrc/operations/primary/module.hpp
@@ -117,7 +117,10 @@ void py_module(py::module& m_primary) {
         &moreh_bmm,
         py::arg("input").noconvert(),
         py::arg("mat2").noconvert(),
+        py::kw_only(),
+        py::arg("output").noconvert() = std::nullopt,
         py::arg("output_mem_config").noconvert() = operation::DEFAULT_OUTPUT_MEMORY_CONFIG,
+        py::arg("compute_kernel_config").noconvert() = std::nullopt,
         R"doc(
         "Performs a moreh_bmm operation.
     )doc");

--- a/ttnn/cpp/ttnn/deprecated/tt_lib/csrc/operations/primary/module.hpp
+++ b/ttnn/cpp/ttnn/deprecated/tt_lib/csrc/operations/primary/module.hpp
@@ -130,9 +130,13 @@ void py_module(py::module& m_primary) {
         py::arg("output_grad").noconvert(),
         py::arg("input").noconvert(),
         py::arg("mat2").noconvert(),
+        py::kw_only(),
+        py::arg("are_required_outputs").noconvert() = std::vector<bool>{true, true},
         py::arg("input_grad").noconvert() = std::nullopt,
         py::arg("mat2_grad").noconvert() = std::nullopt,
-        py::arg("output_mem_config").noconvert() = operation::DEFAULT_OUTPUT_MEMORY_CONFIG,
+        py::arg("input_grad_mem_config").noconvert() = operation::DEFAULT_OUTPUT_MEMORY_CONFIG,
+        py::arg("mat2_grad_mem_config").noconvert() = operation::DEFAULT_OUTPUT_MEMORY_CONFIG,
+        py::arg("compute_kernel_config").noconvert() = std::nullopt,
         R"doc(
         "Performs a moreh_bmm_backward operation.
     )doc");


### PR DESCRIPTION
### Ticket
[Link to Github Issue 11938
](https://github.com/tenstorrent/tt-metal/issues/11938)
### Problem description
`moreh_bmm`needs refactoring as it currently does not support n-dimensional tensors and optional output, among other missing functionalities.

### What's changed
Refactoring `moreh_bmm`, `moreh_bmm_backward`.

### Note
TTNN OP migration will be carried out after that PR.

### Checklist
- [x] [Post commit CI passes](https://github.com/tenstorrent/tt-metal/actions/runs/10598892644)
- [ ] Blackhole Post commit (if applicable)
- [ ] Model regression CI testing passes (if applicable)
- [x] New/Existing tests provide coverage for changes
