### PR TITLE
#11989: Code clean up

### DIFF
--- a/tests/tt_eager/ops/test_average_pool.cpp
+++ b/tests/tt_eager/ops/test_average_pool.cpp
@@ -34,7 +34,7 @@ int main () {
     Shape resnet18_shape = {1, 1, 7 * 7, 2048};
     auto result = run_avg_pool_2d_resnet(resnet18_shape, device);
 
-    TT_FATAL(result.get_legacy_shape() == Shape({1, 1, TILE_HEIGHT, 2048}));
+    TT_FATAL(result.get_legacy_shape() == Shape({1, 1, tt::constants::TILE_HEIGHT, 2048}));
     TT_FATAL(result.get_legacy_shape().without_padding() == Shape({1, 1, 1, 2048}));
 
     TT_FATAL(tt::tt_metal::CloseDevice(device));

--- a/tests/tt_eager/ops/test_eltwise_unary_op.cpp
+++ b/tests/tt_eager/ops/test_eltwise_unary_op.cpp
@@ -101,6 +101,7 @@ bool run_test(Device* device, const Shape& shape, float low, float high, Args...
 }
 
 void test_operation_infrastructure() {
+    using namespace tt::constants;
     tt::log_info(tt::LogTest, "Running {}", __func__);
 
     using ttnn::operations::unary::UnaryWithParam;
@@ -126,6 +127,7 @@ void test_operation_infrastructure() {
 }
 
 void test_shape_padding() {
+    using namespace tt::constants;
     tt::log_info(tt::LogTest, "Running {}", __func__);
 
     using ttnn::operations::unary::UnaryWithParam;

--- a/ttnn/cpp/ttnn/deprecated/tt_dnn/op_library/moreh_adam/moreh_adam.cpp
+++ b/ttnn/cpp/ttnn/deprecated/tt_dnn/op_library/moreh_adam/moreh_adam.cpp
@@ -40,7 +40,7 @@ operation::ProgramWithCallbacks moreh_adam_(
     const Tensor& exp_avg_sq_out,
     const std::optional<const Tensor> max_exp_avg_sq_out,
     const ttnn::DeviceComputeKernelConfig compute_kernel_config) {
-    uint32_t num_tiles = param_in.volume() / TILE_HW;
+    uint32_t num_tiles = param_in.volume() / tt::constants::TILE_HW;
 
     Program program{};
 

--- a/ttnn/cpp/ttnn/deprecated/tt_dnn/op_library/moreh_adamw/moreh_adamw.cpp
+++ b/ttnn/cpp/ttnn/deprecated/tt_dnn/op_library/moreh_adamw/moreh_adamw.cpp
@@ -42,7 +42,7 @@ operation::ProgramWithCallbacks moreh_adamw_(
     const std::optional<const Tensor> max_exp_avg_sq_out,
     const CoreRange core_range,
     const ttnn::DeviceComputeKernelConfig compute_kernel_config) {
-    uint32_t num_units = param_in.volume() / TILE_HW;
+    uint32_t num_units = param_in.volume() / tt::constants::TILE_HW;
 
     Program program{};
 

--- a/ttnn/cpp/ttnn/deprecated/tt_dnn/op_library/moreh_clip_grad_norm/moreh_clip_grad_norm_op.cpp
+++ b/ttnn/cpp/ttnn/deprecated/tt_dnn/op_library/moreh_clip_grad_norm/moreh_clip_grad_norm_op.cpp
@@ -237,6 +237,7 @@ Tensor moreh_clip_grad_norm_impl(
     bool error_if_nonfinite,
     const std::optional<std::reference_wrapper<const Tensor>> total_norm,
     const MemoryConfig &output_mem_config) {
+    using namespace tt::constants;
     // Create tmp_pow_sum[1, 1, TILE_HEIGHT, TILE_WIDTH * total_num_inputs]
     const auto total_num_inputs = static_cast<uint32_t>(inputs.size());
     Shape tmp_pow_sum_shape{1, 1, TILE_HEIGHT, TILE_WIDTH * total_num_inputs};

--- a/ttnn/cpp/ttnn/deprecated/tt_dnn/op_library/moreh_clip_grad_norm/moreh_clip_grad_norm_step1/moreh_clip_grad_norm_step1.cpp
+++ b/ttnn/cpp/ttnn/deprecated/tt_dnn/op_library/moreh_clip_grad_norm/moreh_clip_grad_norm_step1/moreh_clip_grad_norm_step1.cpp
@@ -140,7 +140,7 @@ operation::ProgramWithCallbacks moreh_clip_grad_norm_step1_impl(
 
         const auto& input = inputs.at(i);
         const auto input_addr = input.buffer()->address();
-        const auto num_tiles = input.volume() / TILE_HW;
+        const auto num_tiles = input.volume() / tt::constants::TILE_HW;
         const auto [origin_h, origin_w] = origin_hw_vec.at(i);
 
         // reader

--- a/ttnn/cpp/ttnn/deprecated/tt_dnn/op_library/moreh_clip_grad_norm/moreh_clip_grad_norm_step2/moreh_clip_grad_norm_step2.cpp
+++ b/ttnn/cpp/ttnn/deprecated/tt_dnn/op_library/moreh_clip_grad_norm/moreh_clip_grad_norm_step2/moreh_clip_grad_norm_step2.cpp
@@ -33,7 +33,7 @@ operation::ProgramWithCallbacks moreh_clip_grad_norm_step2_impl(
     ////////////////////////////////////////////////////////////////////////////
     //                         Parameters Setup
     ////////////////////////////////////////////////////////////////////////////
-    const auto num_tiles = tmp_pow_sum.volume() / TILE_HW;
+    const auto num_tiles = tmp_pow_sum.volume() / tt::constants::TILE_HW;
 
     auto [p, decimal, p_is_negative] = get_p_decimal_p_is_negative(1.0f / norm_type);
 

--- a/ttnn/cpp/ttnn/deprecated/tt_dnn/op_library/moreh_clip_grad_norm/moreh_clip_grad_norm_step3/moreh_clip_grad_norm_step3.cpp
+++ b/ttnn/cpp/ttnn/deprecated/tt_dnn/op_library/moreh_clip_grad_norm/moreh_clip_grad_norm_step3/moreh_clip_grad_norm_step3.cpp
@@ -104,7 +104,7 @@ operation::ProgramWithCallbacks moreh_clip_grad_norm_step3_impl(
 
         const auto& input = inputs.at(i);
         const auto input_addr = input.buffer()->address();
-        const auto num_tiles = input.volume() / TILE_HW;
+        const auto num_tiles = input.volume() / tt::constants::TILE_HW;
 
         // reader
         const std::vector<uint32_t> reader_runtime_args{

--- a/ttnn/cpp/ttnn/deprecated/tt_dnn/op_library/moreh_groupnorm/moreh_groupnorm.cpp
+++ b/ttnn/cpp/ttnn/deprecated/tt_dnn/op_library/moreh_groupnorm/moreh_groupnorm.cpp
@@ -48,6 +48,7 @@ operation::ProgramWithCallbacks moreh_groupnorm_impl(
     Tensor &output,
     const std::optional<const Tensor> mean,
     const std::optional<const Tensor> rstd) {
+    using namespace tt::constants;
     ////////////////////////////////////////////////////////////////////////////
     //                      Device Setup
     ////////////////////////////////////////////////////////////////////////////

--- a/ttnn/cpp/ttnn/deprecated/tt_dnn/op_library/moreh_groupnorm/moreh_groupnorm_op.cpp
+++ b/ttnn/cpp/ttnn/deprecated/tt_dnn/op_library/moreh_groupnorm/moreh_groupnorm_op.cpp
@@ -72,6 +72,7 @@ void MorehGroupNorm::validate_with_output_tensors(
 }
 
 std::vector<Shape> MorehGroupNorm::compute_output_shapes(const std::vector<Tensor> &input_tensors) const {
+    using namespace tt::constants;
     // mean, rstd (1, 1, N, num_groups)
     const auto output_shape = input_tensors.at(0).get_legacy_shape();
     const auto N = output_shape[0];

--- a/ttnn/cpp/ttnn/deprecated/tt_dnn/op_library/moreh_groupnorm_backward/gamma_beta_grad/moreh_groupnorm_backward_gamma_beta_grad.cpp
+++ b/ttnn/cpp/ttnn/deprecated/tt_dnn/op_library/moreh_groupnorm_backward/gamma_beta_grad/moreh_groupnorm_backward_gamma_beta_grad.cpp
@@ -32,6 +32,7 @@ operation::ProgramWithOptionalOutputTensors moreh_groupnorm_backward_gamma_beta_
     uint32_t num_groups,
     const std::optional<const Tensor> gamma_grad,
     const std::optional<const Tensor> beta_grad) {
+    using namespace tt::constants;
     ////////////////////////////////////////////////////////////////////////////
     //                      Device Setup
     ////////////////////////////////////////////////////////////////////////////

--- a/ttnn/cpp/ttnn/deprecated/tt_dnn/op_library/moreh_groupnorm_backward/input_grad/moreh_groupnorm_backward_input_grad.cpp
+++ b/ttnn/cpp/ttnn/deprecated/tt_dnn/op_library/moreh_groupnorm_backward/input_grad/moreh_groupnorm_backward_input_grad.cpp
@@ -32,6 +32,7 @@ operation::ProgramWithCallbacks moreh_groupnorm_backward_input_grad_impl(
     uint32_t num_groups,
     Tensor &input_grad,
     const std::optional<const Tensor> gamma) {
+    using namespace tt::constants;
     ////////////////////////////////////////////////////////////////////////////
     //                      Device Setup
     ////////////////////////////////////////////////////////////////////////////

--- a/ttnn/cpp/ttnn/deprecated/tt_dnn/op_library/moreh_groupnorm_backward/moreh_groupnorm_backward_op.cpp
+++ b/ttnn/cpp/ttnn/deprecated/tt_dnn/op_library/moreh_groupnorm_backward/moreh_groupnorm_backward_op.cpp
@@ -172,6 +172,7 @@ void MorehGroupNormBackwardGammaBetaGrad::validate_with_output_tensors(
 
 std::vector<Shape> MorehGroupNormBackwardGammaBetaGrad::compute_output_shapes(
     const std::vector<Tensor> &input_tensors) const {
+    using namespace tt::constants;
     const auto &output_grad = input_tensors.at(0);
     // output_grad (N, C, H, W)
     const auto &output_grad_shape = output_grad.get_legacy_shape();

--- a/ttnn/cpp/ttnn/deprecated/tt_dnn/op_library/moreh_layernorm/moreh_layernorm_op.cpp
+++ b/ttnn/cpp/ttnn/deprecated/tt_dnn/op_library/moreh_layernorm/moreh_layernorm_op.cpp
@@ -56,6 +56,7 @@ operation::ProgramWithCallbacks moreh_layernorm_impl(
     const std::optional<const Tensor> mean,
     const std::optional<const Tensor> rstd,
     const ttnn::DeviceComputeKernelConfig compute_kernel_config) {
+    using namespace tt::constants;
     ////////////////////////////////////////////////////////////////////////////
     //                      Device Setup
     ////////////////////////////////////////////////////////////////////////////

--- a/ttnn/cpp/ttnn/deprecated/tt_dnn/op_library/moreh_layernorm_backward/gamma_beta_grad/moreh_layernorm_backward_gamma_beta_grad.cpp
+++ b/ttnn/cpp/ttnn/deprecated/tt_dnn/op_library/moreh_layernorm_backward/gamma_beta_grad/moreh_layernorm_backward_gamma_beta_grad.cpp
@@ -32,6 +32,7 @@ operation::ProgramWithCallbacks moreh_layernorm_backward_gamma_beta_grad_impl(
     const ttnn::DeviceComputeKernelConfig compute_kernel_config,
     const std::optional<const Tensor> gamma_grad,
     const std::optional<const Tensor> beta_grad) {
+    using namespace tt::constants;
     ////////////////////////////////////////////////////////////////////////////
     //                      Device Setup
     ////////////////////////////////////////////////////////////////////////////

--- a/ttnn/cpp/ttnn/deprecated/tt_dnn/op_library/moreh_layernorm_backward/input_grad/moreh_layernorm_backward_input_grad.cpp
+++ b/ttnn/cpp/ttnn/deprecated/tt_dnn/op_library/moreh_layernorm_backward/input_grad/moreh_layernorm_backward_input_grad.cpp
@@ -33,6 +33,7 @@ operation::ProgramWithCallbacks moreh_layernorm_backward_input_grad_impl(
     const tt_metal::Tensor& input_grad,
     const ttnn::DeviceComputeKernelConfig compute_kernel_config,
     const std::optional<const Tensor> gamma) {
+    using namespace tt::constants;
     ////////////////////////////////////////////////////////////////////////////
     //                      Device Setup
     ////////////////////////////////////////////////////////////////////////////

--- a/ttnn/cpp/ttnn/deprecated/tt_dnn/op_library/moreh_norm/moreh_norm_h/moreh_norm_h.cpp
+++ b/ttnn/cpp/ttnn/deprecated/tt_dnn/op_library/moreh_norm/moreh_norm_h/moreh_norm_h.cpp
@@ -39,8 +39,8 @@ operation::ProgramWithCallbacks moreh_norm_h_impl(const Tensor &input, float p, 
     const auto H = input_shape[-2];
     const auto W = input_shape[-1];
 
-    const auto Ht = H / TILE_HEIGHT;
-    const auto Wt = W / TILE_WIDTH;
+    const auto Ht = H / tt::constants::TILE_HEIGHT;
+    const auto Wt = W / tt::constants::TILE_WIDTH;
 
     const auto num_units = input.volume() / H / W * Wt;
 

--- a/ttnn/cpp/ttnn/deprecated/tt_dnn/op_library/moreh_norm/moreh_norm_op.cpp
+++ b/ttnn/cpp/ttnn/deprecated/tt_dnn/op_library/moreh_norm/moreh_norm_op.cpp
@@ -58,7 +58,7 @@ inline void validate_output_tensor_with_keepdim(const Tensor& input, const Tenso
 
     if (keepdim) {
         bool ranks_are_equal = (input_rank == output_rank);
-        input_shape[dim] = (is_tile_dim) ? (TILE_HEIGHT) : (1);
+        input_shape[dim] = (is_tile_dim) ? (tt::constants::TILE_HEIGHT) : (1);
         input_shape_wo_padding[dim] = 1;
 
         if (!ranks_are_equal) {
@@ -138,6 +138,7 @@ void MorehNorm::validate_with_output_tensors(
 }
 
 std::vector<Shape> MorehNorm::compute_output_shapes(const std::vector<Tensor> &input_tensors) const {
+    using namespace tt::constants;
     const auto& input = input_tensors.at(0);
     const auto& input_shape = input.get_legacy_shape();
     const auto input_rank = input_shape.rank();

--- a/ttnn/cpp/ttnn/deprecated/tt_dnn/op_library/moreh_norm/moreh_norm_other/moreh_norm_other.cpp
+++ b/ttnn/cpp/ttnn/deprecated/tt_dnn/op_library/moreh_norm/moreh_norm_other/moreh_norm_other.cpp
@@ -24,7 +24,8 @@ namespace operations {
 namespace primary {
 
 operation::ProgramWithCallbacks moreh_norm_other_impl(const Tensor &input, float p, int64_t dim, const Tensor &output, const ttnn::DeviceComputeKernelConfig compute_kernel_config) {
-    ////////////////////////////////////////////////////////////////////////////
+    using namespace tt::constants;
+   ////////////////////////////////////////////////////////////////////////////
     //                      Device Setup
     ////////////////////////////////////////////////////////////////////////////
     auto device = input.device();

--- a/ttnn/cpp/ttnn/deprecated/tt_dnn/op_library/moreh_norm/moreh_norm_w/moreh_norm_w.cpp
+++ b/ttnn/cpp/ttnn/deprecated/tt_dnn/op_library/moreh_norm/moreh_norm_w/moreh_norm_w.cpp
@@ -39,8 +39,8 @@ operation::ProgramWithCallbacks moreh_norm_w_impl(const Tensor &input, float p, 
     const auto H = input_shape[-2];
     const auto W = input_shape[-1];
 
-    const auto Ht = H / TILE_HEIGHT;
-    const auto Wt = W / TILE_WIDTH;
+    const auto Ht = H / tt::constants::TILE_HEIGHT;
+    const auto Wt = W / tt::constants::TILE_WIDTH;
 
     const auto num_units = input.volume() / H / W * Ht;
 

--- a/ttnn/cpp/ttnn/deprecated/tt_dnn/op_library/moreh_norm_backward/moreh_norm_backward.cpp
+++ b/ttnn/cpp/ttnn/deprecated/tt_dnn/op_library/moreh_norm_backward/moreh_norm_backward.cpp
@@ -43,7 +43,7 @@ void get_tensor_dim(std::vector<uint32_t> &dim, const Shape& shape) {
 
         // last 2-dim
         if (idx == rank - 1 || idx == rank - 2) {
-            dim[i] = shape[idx] / TILE_HEIGHT;
+            dim[i] = shape[idx] / tt::constants::TILE_HEIGHT;
         }
         else {
             dim[i] = shape[idx];
@@ -68,7 +68,7 @@ Shape get_output_grad_shape(const Tensor &output_grad, const Tensor &input_grad,
         TT_FATAL(dim < rank, "dim {} < rank {}", dim, rank);
         bool is_tile_dim = (dim == rank - 1 || dim == rank - 2);
         if (is_tile_dim) {
-            shape[dim] = TILE_HEIGHT;
+            shape[dim] = tt::constants::TILE_HEIGHT;
             padding[dim] = Padding::PadDimension{0, 31};
         } else {
             shape[dim] = 1;
@@ -117,7 +117,7 @@ operation::ProgramWithCallbacks moreh_norm_backward_(
         }
     }
 
-    const auto num_input_grad_tiles = input_grad.volume() / TILE_HW;
+    const auto num_input_grad_tiles = input_grad.volume() / tt::constants::TILE_HW;
     auto [math_fidelity, math_approx_mode, fp32_dest_acc_en, packer_l1_acc] = get_compute_kernel_config_args(output_grad.device()->arch(), compute_kernel_config);
 
     auto [floored_p, decimal, p_is_negative] = get_floored_p_and_decimal_and_p_is_negative(p);

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/conv2d.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/conv2d.cpp
@@ -94,7 +94,7 @@ ParallelConfig determine_parallel_config(
 
         } else if(shard_layout == TensorMemoryLayout::WIDTH_SHARDED) {
             uint32_t num_cores_channels = find_closest_common_largest_divisor(
-                conv_out_2d_matrix_width_ntiles, std::ceil((double)input_channels / (double)TILE_WIDTH), max_num_cores);
+                conv_out_2d_matrix_width_ntiles, std::ceil((double)input_channels / (double)tt::constants::TILE_WIDTH), max_num_cores);
              log_debug(LogOp, "Num cores for Width Sharding : {}", num_cores_channels);
             CoreRangeSet grid = num_cores_to_core_range_set(num_cores_channels, device_grid_size_coord, true);
             return grid;
@@ -103,7 +103,7 @@ ParallelConfig determine_parallel_config(
             uint32_t total_cores_for_channels =
                 block_shard_orientation == ShardOrientation::COL_MAJOR ? device_grid_size[1] : device_grid_size[0];
             uint32_t num_cores_channels = find_closest_common_largest_divisor(
-                conv_out_2d_matrix_width_ntiles, std::ceil((double)input_channels / (double)TILE_WIDTH), total_cores_for_channels);
+                conv_out_2d_matrix_width_ntiles, std::ceil((double)input_channels / (double)tt::constants::TILE_WIDTH), total_cores_for_channels);
             uint32_t cores_x =
                 block_shard_orientation == ShardOrientation::COL_MAJOR ? num_cores_nhw : num_cores_channels;
             uint32_t cores_y =

--- a/ttnn/cpp/ttnn/operations/core/to_layout/to_layout_op.cpp
+++ b/ttnn/cpp/ttnn/operations/core/to_layout/to_layout_op.cpp
@@ -8,7 +8,7 @@
 #include "ttnn/operations/data_movement/tilize_with_val_padding/tilize_with_val_padding.hpp"
 #include "ttnn/operations/data_movement/untilize/untilize.hpp"
 #include "ttnn/operations/data_movement/untilize_with_unpadding/untilize_with_unpadding.hpp"
-
+#include "tt_metal/common/constants.hpp"
 #include "ttnn/operations/core/core.hpp"
 
 namespace ttnn {
@@ -30,7 +30,7 @@ inline bool use_multicore_device_tilize(
             ? tt::tt_metal::detail::TileSize(tt::tt_metal::datatype_to_dataformat_converter(output_dtype.value()))
             : input_single_tile_size;
 
-    uint32_t num_tiles_in_row = input.get_shape()[-1] / TILE_WIDTH;
+    uint32_t num_tiles_in_row = input.get_shape()[-1] / tt::constants::TILE_WIDTH;
     uint32_t max_l1_size = input.device()->l1_size_per_core() / 2 - L1_UNRESERVED_BASE;
     uint32_t max_tiles = max_l1_size / (input_single_tile_size + output_single_tile_size);  // 2 CBs
 

--- a/ttnn/cpp/ttnn/operations/creation.hpp
+++ b/ttnn/cpp/ttnn/operations/creation.hpp
@@ -19,6 +19,7 @@ namespace creation {
 
 template <typename T, std::size_t rank=4>
 Tensor create_scalar(T scalar, DataType data_type, Layout layout, Device* device){
+    using namespace tt::constants;
     static_assert(rank >=2, "Rank must be at least 2 when creating a tensor with TILE_LAYOUT");
     std::array<std::uint32_t, rank> intended_shape = {};
     intended_shape.fill(1);

--- a/ttnn/cpp/ttnn/operations/data_movement/bcast/device/bcast_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/bcast/device/bcast_device_operation.cpp
@@ -31,6 +31,7 @@ operation::ProgramWithCallbacks bcast_multi_core_hw(
 
 
 void EltwiseBinaryBroadcast::validate_with_output_tensors(const std::vector<Tensor>& input_tensors, const std::vector<std::optional<Tensor>>& output_tensors) const {
+    using namespace tt::constants;
     const auto& input_tensor_a = input_tensors.at(0);
     const auto& input_tensor_b = input_tensors.at(1);
 
@@ -174,6 +175,7 @@ const operation::Hash EltwiseBinaryBroadcast::compute_program_hash(
 }
 
 BcastOpParallelizationStrategy EltwiseBinaryBroadcast::get_parallelization_strategy(const std::vector<Tensor> &input_tensors) const {
+    using namespace tt::constants;
     const auto& input_tensor_a = input_tensors.at(0);
     const auto& input_tensor_b = input_tensors.at(1);
 

--- a/ttnn/cpp/ttnn/operations/data_movement/fold/fold.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/fold/fold.cpp
@@ -11,6 +11,7 @@
 #include "ttnn/cpp/ttnn/operations/data_movement/slice/slice.hpp"
 #include "ttnn/cpp/ttnn/operations/data_movement/reshape/reshape.hpp"
 #include "ttnn/cpp/ttnn/operations/data_movement/pad/pad.hpp"
+#include "tt_metal/common/constants.hpp"
 
 #include "fold.hpp"
 
@@ -20,6 +21,7 @@ namespace ttnn::operations::data_movement {
 std::vector<Tensor> fold_with_transpose_(
     uint8_t queue_id, const Tensor& input, const std::optional<const tt::tt_metal::Shape>& output_shape, uint32_t stride_h, uint32_t stride_w, uint32_t pad_c, uint32_t pad_h, uint32_t pad_w) {
 
+    using namespace tt::constants;
     Device * device;
 
     // Get the device
@@ -131,6 +133,7 @@ ttnn::MemoryConfig create_sharded_memory_config(ttnn::Shape tensor_shape, CoreCo
 std::vector<Tensor> fold_with_transpose_sharded_(
     uint8_t queue_id, const Tensor& input, const std::optional<const tt::tt_metal::Shape>& output_shape, uint32_t stride_h, uint32_t stride_w, uint32_t pad_c, uint32_t pad_h, uint32_t pad_w, CoreCoord grid_size, const std::optional<MemoryConfig> override_memory_config) {
 
+    using namespace tt::constants;
     Device * device;
 
     // Get the device

--- a/ttnn/cpp/ttnn/operations/data_movement/pad/device/pad_op.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/pad/device/pad_op.cpp
@@ -2,14 +2,15 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
+#include "tt_metal/common/constants.hpp"
 #include "pad_op.hpp"
 #include "pad_program_factory.hpp"
-
 
 namespace ttnn::operations::data_movement {
 
 void Pad::validate_with_output_tensors(
     const std::vector<Tensor> &input_tensors, const std::vector<std::optional<Tensor>> &output_tensors) const {
+    using namespace tt::constants;
     const auto& input_tensor = input_tensors.at(0);
     TT_FATAL(input_tensor.storage_type() == StorageType::DEVICE, "Operand to pad needs to be on device!");
     TT_FATAL(input_tensor.buffer() != nullptr, "Operand to pad needs to be allocated in a buffer on device!");

--- a/ttnn/cpp/ttnn/operations/data_movement/reshape/reshape.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/reshape/reshape.cpp
@@ -6,7 +6,7 @@
 #include "ttnn/common/constants.hpp"
 #include "ttnn/run_operation.hpp"
 #include "reshape.hpp"
-
+#include "tt_metal/common/constants.hpp"
 #include <ttnn/deprecated/tt_numpy/functions.hpp>
 #include "ttnn/operations/experimental/auto_format/auto_format.hpp"
 #include "ttnn/tensor/tensor_utils.hpp"
@@ -56,7 +56,7 @@ ttnn::Tensor ReshapeOperation::invoke(
     int H,
     int W,
     const std::optional<MemoryConfig>& memory_config_arg) {
-
+    using namespace tt::constants;
     auto output_mem_config = memory_config_arg.value_or(input_tensor.memory_config());
     // No-op (Will do a tensor copy)
     tt::tt_metal::Shape output_shape = tt::tt_metal::infer_dims_for_reshape(N, C, H, W, input_tensor.volume());

--- a/ttnn/cpp/ttnn/operations/data_movement/slice/device/slice_op.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/slice/device/slice_op.cpp
@@ -2,6 +2,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
+#include "tt_metal/common/constants.hpp"
 #include "slice_op.hpp"
 #include "slice_program_factory.hpp"
 
@@ -18,7 +19,7 @@ inline __attribute__((always_inline)) uint32_t get_upper_start_offset(const Tens
 
     uint32_t num_pages = tensor.volume();
     if (tensor.get_layout() == Layout::TILE) {
-        num_pages /= TILE_HW;
+        num_pages /= tt::constants::TILE_HW;
     } else {
         uint32_t page_width = shape[-1];
         num_pages /= page_width;
@@ -35,6 +36,7 @@ inline __attribute__((always_inline)) uint32_t get_upper_start_offset(const Tens
 }
 
 uint32_t get_tiled_start_offset(const Tensor &input_tensor, const Shape &slice_start) {
+    using namespace tt::constants;
     uint32_t num_input_pages = input_tensor.volume() / (TILE_HW);
     const auto& shape = input_tensor.get_legacy_shape();
     uint32_t upper_dims_compressed = get_upper_dims_compressed(shape);
@@ -66,6 +68,7 @@ uint32_t get_rm_start_offset(const Tensor &tensor, const Shape &slice_start) {
 
 void SliceDeviceOperation::validate_with_output_tensors(
     const std::vector<Tensor> &input_tensors, const std::vector<std::optional<Tensor>> &output_tensors) const {
+    using namespace tt::constants;
     const auto &input_tensor_a = input_tensors.at(0);
     TT_FATAL(input_tensor_a.storage_type() == StorageType::DEVICE, "Operands to unpad need to be on device!");
     TT_FATAL(input_tensor_a.buffer() != nullptr, "Operands to unpad need to be allocated in buffers on device!");

--- a/ttnn/cpp/ttnn/operations/data_movement/tilize/device/tilize_op.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/tilize/device/tilize_op.cpp
@@ -5,7 +5,7 @@
 #include "tilize_op.hpp"
 #include "tilize_program_factory.hpp"
 #include "ttnn/run_operation.hpp"
-
+#include "tt_metal/common/constants.hpp"
 namespace ttnn::operations::data_movement {
 void Tilize::validate(const std::vector<Tensor>& input_tensors) const {
     const auto& input_tensor_a = input_tensors.at(0);
@@ -13,7 +13,7 @@ void Tilize::validate(const std::vector<Tensor>& input_tensors) const {
     TT_FATAL(input_tensor_a.buffer() != nullptr, "Operands to tilize need to be allocated in buffers on device!");
     TT_FATAL(input_tensor_a.get_layout() == Layout::ROW_MAJOR, "Can only tilize row major data");
 
-    TT_FATAL(input_tensor_a.volume() % TILE_HW == 0);
+    TT_FATAL(input_tensor_a.volume() % tt::constants::TILE_HW == 0);
 
     auto width = input_tensor_a.get_legacy_shape()[-1];
     uint32_t stick_s = width;

--- a/ttnn/cpp/ttnn/operations/data_movement/tilize_with_val_padding/tilize_with_val_padding.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/tilize_with_val_padding/tilize_with_val_padding.cpp
@@ -49,6 +49,7 @@ ttnn::Tensor ExecuteTilizeWithZeroPadding::invoke(
     const std::optional<MemoryConfig> &memory_config,
     std::optional<DataType> output_dtype,
     bool use_multicore) {
+    using namespace tt::constants;
     auto shape = input_tensor.get_legacy_shape();
 
     shape[2] = tt::round_up(shape[2], TILE_HEIGHT);

--- a/ttnn/cpp/ttnn/operations/data_movement/untilize/device/untilize_op.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/untilize/device/untilize_op.cpp
@@ -26,6 +26,7 @@ uint32_t get_num_cores(CoreCoord grid_size, uint32_t nblocks) {
 }  // namespace untilize_helpers
 
 void Untilize::validate(const std::vector<Tensor>& input_tensors) const {
+    using namespace tt::constants;
     const auto& input_tensor_a = input_tensors.at(0);
     TT_FATAL(input_tensor_a.storage_type() == StorageType::DEVICE, "Operands to untilize need to be on device!");
     TT_FATAL(input_tensor_a.buffer() != nullptr, "Operands to untilize need to be allocated in buffers on device!");
@@ -64,6 +65,7 @@ std::vector<tt::tt_metal::Shape> Untilize::compute_output_shapes(const std::vect
 
 std::vector<Tensor> Untilize::create_output_tensors(
     const std::vector<Tensor>& input_tensors, const std::vector<std::optional<Tensor>>& output_tensors) const {
+    using namespace tt::constants;
     const auto& input_tensor = input_tensors.at(0);
     DataType output_dtype =
         input_tensor.get_dtype() == DataType::BFLOAT8_B ? DataType::BFLOAT16 : input_tensor.get_dtype();

--- a/ttnn/cpp/ttnn/operations/data_movement/untilize_with_halo_v2/device/untilize_with_halo_v2_op.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/untilize_with_halo_v2/device/untilize_with_halo_v2_op.cpp
@@ -11,6 +11,7 @@
 namespace ttnn::operations::data_movement {
 
 void UntilizeWithHaloV2::validate(const std::vector<Tensor>& input_tensors) const {
+    using namespace tt::constants;
     const auto& input_tensor = input_tensors.at(0);
 
     // validate input data tensor

--- a/ttnn/cpp/ttnn/operations/data_movement/untilize_with_unpadding/device/untilize_with_unpadding_op.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/untilize_with_unpadding/device/untilize_with_unpadding_op.cpp
@@ -16,7 +16,7 @@ void UntilizeWithUnpadding::validate(const std::vector<Tensor>& input_tensors) c
     TT_FATAL(input_tensor_a.buffer() != nullptr, "Operands need to be allocated in buffers on device!");
     TT_FATAL(input_tensor_a.get_layout() == Layout::TILE, "Can only untilize tile major data");
 
-    TT_FATAL(input_tensor_a.volume() % TILE_HW == 0);
+    TT_FATAL(input_tensor_a.volume() % tt::constants::TILE_HW == 0);
     for (uint32_t i = 0; i < input_tensor_a.get_legacy_shape().rank(); i++) {
         TT_FATAL(input_tensor_a.get_legacy_shape()[i] > 0);
         TT_FATAL(this->output_tensor_end[i] < input_tensor_a.get_legacy_shape()[i]);

--- a/ttnn/cpp/ttnn/operations/eltwise/binary/binary.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary/binary.cpp
@@ -213,6 +213,7 @@ Tensor BinaryOperation<binary_op_type>::invoke(
     const std::optional<Tensor> &optional_output_tensor,
     std::optional<unary::FusedActivations> activations,
     std::optional<unary::UnaryWithParam> input_tensor_a_activation) {
+    using namespace tt::constants;
     // Cast Float Scalar to a device tensor
     auto host_buffer = owned_buffer::create<::bfloat16>(static_cast<std::size_t>(TILE_HEIGHT * TILE_WIDTH));
     host_buffer[0] = scalar;

--- a/ttnn/cpp/ttnn/operations/eltwise/binary/device/binary_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary/device/binary_device_operation.cpp
@@ -48,6 +48,7 @@ BinaryDeviceOperation::program_factory_t BinaryDeviceOperation::select_program_f
 
 void BinaryDeviceOperation::validate_on_program_cache_miss(
     const operation_attributes_t& attributes, const tensor_args_t& tensor_args) {
+    using namespace tt::constants;
     const auto& input_tensor_a = tensor_args.input_tensor_a;
     const auto& input_tensor_b = tensor_args.input_tensor_b;
     const auto& output_tensor = tensor_args.output_tensor;
@@ -174,6 +175,7 @@ BinaryDeviceOperation::shape_return_value_t BinaryDeviceOperation::compute_outpu
 
 BinaryDeviceOperation::tensor_return_value_t BinaryDeviceOperation::create_output_tensors(
     const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args) {
+    using namespace tt::constants;
     auto output_shape = compute_output_shapes(operation_attributes, tensor_args);
     const auto& input_tensor_a = tensor_args.input_tensor_a;
     const auto& input_tensor_b = tensor_args.input_tensor_b;

--- a/ttnn/cpp/ttnn/operations/eltwise/binary/device/broadcast_height_and_width_multi_core_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary/device/broadcast_height_and_width_multi_core_program_factory.cpp
@@ -13,7 +13,7 @@
 #include "tt_metal/detail/util.hpp"
 #include "tt_metal/host_api.hpp"
 #include "ttnn/device_operation.hpp"
-
+#include "tt_metal/common/constants.hpp"
 
 
 namespace ttnn::operations::binary {
@@ -34,6 +34,7 @@ BinaryDeviceOperation::BroadcastHeightAndWidthMultiCore::create(
     tensor_return_value_t& tensor_return_value) {
     using namespace tt;
     using namespace tt::tt_metal;
+    using namespace tt::constants;
 
     const auto& a = tensor_args.input_tensor_a;
     const auto& b = tensor_args.input_tensor_b;
@@ -246,6 +247,7 @@ void BinaryDeviceOperation::BroadcastHeightAndWidthMultiCore::override_runtime_a
     tensor_return_value_t& tensor_return_value) {
     using namespace tt;
     using namespace tt::tt_metal;
+    using namespace tt::constants;
 
     const auto& input_tensor_a = tensor_args.input_tensor_a;
     const auto& input_tensor_b = tensor_args.input_tensor_b;

--- a/ttnn/cpp/ttnn/operations/eltwise/binary/device/broadcast_height_multi_core_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary/device/broadcast_height_multi_core_program_factory.cpp
@@ -31,6 +31,7 @@ BinaryDeviceOperation ::BroadcastHeightMultiCore::create(
     tensor_return_value_t& tensor_return_value) {
     using namespace tt;
     using namespace tt::tt_metal;
+    using namespace tt::constants;
 
     const auto& a = tensor_args.input_tensor_a;
     const auto& b = tensor_args.input_tensor_b;
@@ -214,6 +215,7 @@ void BinaryDeviceOperation ::BroadcastHeightMultiCore::override_runtime_argument
     tensor_return_value_t& tensor_return_value) {
     using namespace tt;
     using namespace tt::tt_metal;
+    using namespace tt::constants;
 
     const auto& input_tensor_a = tensor_args.input_tensor_a;
     const auto& input_tensor_b = tensor_args.input_tensor_b;

--- a/ttnn/cpp/ttnn/operations/eltwise/binary/device/broadcast_height_multi_core_sharded_optimized_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary/device/broadcast_height_multi_core_sharded_optimized_program_factory.cpp
@@ -31,6 +31,7 @@ BinaryDeviceOperation::BroadcastHeightMultiCoreShardedOptimized::create(
     tensor_return_value_t& tensor_return_value) {
     using namespace tt;
     using namespace tt::tt_metal;
+    using namespace tt::constants;
 
     const auto& a = tensor_args.input_tensor_a;
     const auto& b = tensor_args.input_tensor_b;
@@ -252,6 +253,7 @@ void BinaryDeviceOperation ::BroadcastHeightMultiCoreShardedOptimized::override_
     tensor_return_value_t& tensor_return_value) {
     using namespace tt;
     using namespace tt::tt_metal;
+    using namespace tt::constants;
 
     const auto& input_tensor_a = tensor_args.input_tensor_a;
     const auto& input_tensor_b = tensor_args.input_tensor_b;

--- a/ttnn/cpp/ttnn/operations/eltwise/binary/device/broadcast_height_multi_core_sharded_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary/device/broadcast_height_multi_core_sharded_program_factory.cpp
@@ -31,6 +31,7 @@ BinaryDeviceOperation::BroadcastHeightMultiCoreSharded::create(
     tensor_return_value_t& tensor_return_value) {
     using namespace tt;
     using namespace tt::tt_metal;
+    using namespace tt::constants;
 
     const auto& a = tensor_args.input_tensor_a;
     const auto& b = tensor_args.input_tensor_b;
@@ -218,6 +219,7 @@ void BinaryDeviceOperation ::BroadcastHeightMultiCoreSharded::override_runtime_a
     tensor_return_value_t& tensor_return_value) {
     using namespace tt;
     using namespace tt::tt_metal;
+    using namespace tt::constants;
 
     const auto& input_tensor_a = tensor_args.input_tensor_a;
     const auto& input_tensor_b = tensor_args.input_tensor_b;

--- a/ttnn/cpp/ttnn/operations/eltwise/binary/device/broadcast_width_multi_core_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary/device/broadcast_width_multi_core_program_factory.cpp
@@ -30,6 +30,7 @@ BinaryDeviceOperation::BroadcastWidthMultiCore::cached_program_t BinaryDeviceOpe
     tensor_return_value_t& tensor_return_value) {
     using namespace tt;
     using namespace tt::tt_metal;
+    using namespace tt::constants;
 
     const auto& a = tensor_args.input_tensor_a;
     const auto& b = tensor_args.input_tensor_b;
@@ -212,6 +213,7 @@ void BinaryDeviceOperation::BroadcastWidthMultiCore::override_runtime_arguments(
     tensor_return_value_t& tensor_return_value) {
     using namespace tt;
     using namespace tt::tt_metal;
+    using namespace tt::constants;
 
     const auto& input_tensor_a = tensor_args.input_tensor_a;
     const auto& input_tensor_b = tensor_args.input_tensor_b;

--- a/ttnn/cpp/ttnn/operations/eltwise/binary/device/element_wise_multi_core_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary/device/element_wise_multi_core_program_factory.cpp
@@ -33,6 +33,7 @@ inline __attribute__((always_inline)) void set_eltwise_binary_runtime_args(
     const uint32_t dst_single_tile_size) {
     using namespace tt;
     using namespace tt::tt_metal;
+    using namespace tt::constants;
 
     auto src_buffer_a = a.buffer();
     auto src_buffer_b = b.buffer();
@@ -254,6 +255,7 @@ BinaryDeviceOperation::ElementWiseMultiCore::cached_program_t BinaryDeviceOperat
     using namespace tt;
     using namespace tt::tt_metal;
     using ttnn::operations::unary::UnaryWithParam;
+    using namespace tt::constants;
 
     const auto& a = tensor_args.input_tensor_a;
     const auto& b = tensor_args.input_tensor_b;

--- a/ttnn/cpp/ttnn/operations/eltwise/unary/device/unary_composite_op.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary/device/unary_composite_op.cpp
@@ -525,7 +525,7 @@ Tensor _threshold(const Tensor& input_tensor, float threshold, float value, cons
 std::vector<Tensor> split_tensor_for_glu(const Tensor& input_a, int32_t dim, const std::optional<MemoryConfig>& output_mem_config) {
     std::vector<Tensor> t_split;
     Shape inshape(input_a.get_legacy_shape());
-    TT_FATAL(((inshape[dim] / 2) % TILE_WIDTH == 0), "Split tensor dimension should be in full tile");
+    TT_FATAL(((inshape[dim] / 2) % tt::constants::TILE_WIDTH == 0), "Split tensor dimension should be in full tile");
     std::vector<uint32_t> s_a = {0, 0, 0, 0};
     std::vector<uint32_t> e_a = {input_a.get_legacy_shape()[0] - 1, inshape[1] - 1, inshape[2] - 1, inshape[3] / 2 - 1};
 

--- a/ttnn/cpp/ttnn/operations/experimental/auto_format/auto_format.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/auto_format/auto_format.cpp
@@ -15,7 +15,6 @@
 #include "tt_metal/common/constants.hpp"
 #include "tt_metal/host_api.hpp"
 
-using namespace tt::constants;
 
 namespace ttnn::operations::experimental::auto_format{
 
@@ -42,6 +41,7 @@ Tensor AutoFormat::move_tensor_to_mem_config(const Tensor& input, const MemoryCo
 // Used in backward_ops.cpp
 // See: Remove auto format within permute_op.cpp #9404
 Tensor AutoFormat::move_tensor_to_device_and_pad(const Tensor& input, Device *device, Layout target_layout, std::optional<MemoryConfig> target_mem_config){
+    using namespace tt::constants;
     const auto intended_shape = input.get_shape();
     const auto device_shape = input.get_legacy_shape();
     const auto new_intended_shape = std::array<std::uint32_t, 4>{intended_shape[0], intended_shape[1], intended_shape[-2], intended_shape[-1]};

--- a/ttnn/cpp/ttnn/operations/experimental/auto_format/auto_format.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/auto_format/auto_format.hpp
@@ -13,8 +13,6 @@
 
 #include "tt_metal/common/math.hpp"
 
-using namespace tt::constants;
-
 namespace ttnn::operations::experimental::auto_format{
 
 struct FormatParams {
@@ -34,6 +32,7 @@ class AutoFormat {
 
 
         static tt::tt_metal::Shape pad_to_tile_shape(const tt::tt_metal::Shape& unpadded_shape, bool pad_c=false, bool pad_n=false, bool pad_h=true, bool pad_w=true) {
+            using namespace tt::constants;
             auto n = pad_n ? tt::round_up(unpadded_shape.rank() >= 4 ? unpadded_shape[-4] : 1, TILE_HEIGHT) : unpadded_shape.rank() >= 4 ? unpadded_shape[-4] : 1;
             auto c = pad_c ? tt::round_up(unpadded_shape.rank() >= 3 ? unpadded_shape[-3] : 1, TILE_WIDTH) : unpadded_shape.rank() >= 3 ? unpadded_shape[-3] : 1;
             auto h = pad_h ? tt::round_up(unpadded_shape[-2], TILE_HEIGHT) : unpadded_shape[-2];
@@ -60,7 +59,7 @@ class AutoFormat {
 
         // TODO: These legal checks should probably be somewhere else like tensor class, since it is common logic not just for autoformat
         static bool legal_tile_shape(const tt::tt_metal::Shape& shape) {
-            return (shape[2] % TILE_HEIGHT == 0 && shape[3] % TILE_WIDTH == 0);
+            return (shape[2] % tt::constants::TILE_HEIGHT == 0 && shape[3] % tt::constants::TILE_WIDTH == 0);
         }
 
         static bool legal_rm_shape(const tt::tt_metal::Shape& shape) {

--- a/ttnn/cpp/ttnn/operations/experimental/matmul/group_attn_matmul/group_attn_matmul.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/matmul/group_attn_matmul/group_attn_matmul.cpp
@@ -36,7 +36,7 @@ namespace ttnn::operations::experimental::matmul {
         auto kernel_config_val = init_device_compute_kernel_config(arch, compute_kernel_config);
 
         // Need to cache on out_subblock_w because it must be a compile time arg for optimal use of templated pack_untilize APIs
-        const uint32_t Nt = input_tensor_b.get_legacy_shape()[-1] / TILE_WIDTH;
+        const uint32_t Nt = input_tensor_b.get_legacy_shape()[-1] / tt::constants::TILE_WIDTH;
         constexpr uint32_t HALF_DST_MAX = 8; // 8 is the max number of tiles for half DST (assuming out_subblock_h == 1)
         constexpr uint32_t HALF_DST_MAX_FP32 = 4; // max dst tiles are 4 for fp32
         uint32_t out_subblock_w;

--- a/ttnn/cpp/ttnn/operations/experimental/ssm/hc_sum_reduce/device/hc_sum_reduce_op.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ssm/hc_sum_reduce/device/hc_sum_reduce_op.cpp
@@ -9,6 +9,7 @@
 namespace ttnn::operations::experimental::ssm {
 
 void HCSumReduce::validate(const std::vector<Tensor>& input_tensors) const {
+    using namespace tt::constants;
     TT_FATAL(input_tensors.size() == 1);
     const auto& input_tensor_a = input_tensors.at(0);
     TT_FATAL((input_tensor_a.get_layout() == Layout::TILE), "Inputs to ssm_1d_sum_reduce must be tilized");

--- a/ttnn/cpp/ttnn/operations/experimental/ssm/prefix_scan/device/prefix_scan_op.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ssm/prefix_scan/device/prefix_scan_op.cpp
@@ -3,12 +3,13 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "prefix_scan_op.hpp"
-
+#include "tt_metal/common/constants.hpp"
 #include "prefix_scan_program_factory.hpp"
 
 namespace ttnn::operations::experimental::ssm {
 
 void PrefixScan::validate(const std::vector<Tensor>& input_tensors) const {
+    using namespace tt::constants;
     TT_FATAL(input_tensors.size() == 3, "Expected 3 input tensors (A, Bx, H)");
 
     const auto& a = input_tensors[0];
@@ -20,7 +21,7 @@ void PrefixScan::validate(const std::vector<Tensor>& input_tensors) const {
     const auto& shape = a.get_legacy_shape();
     TT_FATAL(shape.rank() == 4, "Expected input tensors to be rank 4");
     TT_FATAL(shape[0] == 1 && shape[1] == 1, "Dimension 0 and 1 should be size 1");
-    TT_FATAL(shape[2] >= TILE_HEIGHT && shape[2] % TILE_HEIGHT == 0, "Sequence length should be a multiple of 32");
+    TT_FATAL(shape[2] >= tt::constants::TILE_HEIGHT && shape[2] % tt::constants::TILE_HEIGHT == 0, "Sequence length should be a multiple of 32");
 
     const auto& h = input_tensors.at(2);
     TT_FATAL(h.dtype() == DataType::BFLOAT16, "Expected initial hidden state to be bfloat16");

--- a/ttnn/cpp/ttnn/operations/experimental/ssm/repeat_and_interleave_eltwise_mul/device/repeat_and_interleave_eltwise_mul_op.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ssm/repeat_and_interleave_eltwise_mul/device/repeat_and_interleave_eltwise_mul_op.cpp
@@ -5,10 +5,12 @@
 #include "repeat_and_interleave_eltwise_mul_op.hpp"
 
 #include "repeat_and_interleave_eltwise_mul_program_factory.hpp"
+#include "tt_metal/common/constants.hpp"
 
 namespace ttnn::operations::experimental::ssm {
 
 void RepeatAndInterleaveEltwiseMul::validate(const std::vector<Tensor>& input_tensors) const {
+    using namespace tt::constants;
     TT_FATAL(input_tensors.size() == 2);
     const auto& input_tensor_a = input_tensors.at(0);
     const auto& input_tensor_b = input_tensors.at(1);
@@ -68,7 +70,7 @@ std::vector<tt::tt_metal::Shape> RepeatAndInterleaveEltwiseMul::compute_output_s
     const auto& input_tensor_b = input_tensors.at(1);
     const auto shape_a = input_tensor_a.get_legacy_shape();
     const auto shape_b = input_tensor_b.get_legacy_shape();
-    return {{shape_a[0], shape_a[1], shape_a[2], TILE_WIDTH * HIDDEN_SIZE}};
+    return {{shape_a[0], shape_a[1], shape_a[2], tt::constants::TILE_WIDTH * HIDDEN_SIZE}};
 }
 
 std::vector<Tensor> RepeatAndInterleaveEltwiseMul::create_output_tensors(

--- a/ttnn/cpp/ttnn/operations/experimental/transformer/create_qkv_heads/device/create_qkv_heads_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/create_qkv_heads/device/create_qkv_heads_device_operation.cpp
@@ -28,7 +28,7 @@ void CreateQKVHeadsDeviceOperation::validate(const std::vector<Tensor> &input_te
     uint32_t num_w_cores = rm ? bbox.end_coord.x + 1 : bbox.end_coord.y + 1;
 
     TT_FATAL(this->num_q_heads % this->num_kv_heads == 0, fmt::format("Number of q heads {} must fit evenly into number of kv heads {}", this->num_q_heads, this->num_kv_heads));
-    TT_FATAL(input_shape[3] % (num_w_cores * TILE_WIDTH) == 0, fmt::format("Flattened hidden dimension {} must be a multiple of width cores {} * tile width {} to ensure that each core gets an even amount of tiles", input_shape[3], num_w_cores, TILE_WIDTH));
+    TT_FATAL(input_shape[3] % (num_w_cores * tt::constants::TILE_WIDTH) == 0, fmt::format("Flattened hidden dimension {} must be a multiple of width cores {} * tile width {} to ensure that each core gets an even amount of tiles", input_shape[3], num_w_cores, tt::constants::TILE_WIDTH));
 
     TT_FATAL(this->output_mem_config.memory_layout == TensorMemoryLayout::HEIGHT_SHARDED);
     TT_FATAL(input_shape[0] == num_h_cores, fmt::format("Batch size  {} must be equal to num cores {}", input_shape[0], num_h_cores));

--- a/ttnn/cpp/ttnn/operations/experimental/transformer/create_qkv_heads_from_separate_tensors/device/create_qkv_heads_from_separate_tensors_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/create_qkv_heads_from_separate_tensors/device/create_qkv_heads_from_separate_tensors_device_operation.cpp
@@ -10,6 +10,7 @@
 namespace ttnn::operations::experimental::transformer {
 
 void CreateQKVHeadsSeparateTensorsDeviceOperation::validate(const std::vector<Tensor> &input_tensors) const {
+    using namespace tt::constants;
     const auto& q_input_tensor = input_tensors.at(0);
     const auto& kv_input_tensor = input_tensors.at(1);
 

--- a/ttnn/cpp/ttnn/operations/experimental/transformer/nlp_create_qkv_heads/device/nlp_create_qkv_heads_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/nlp_create_qkv_heads/device/nlp_create_qkv_heads_device_operation.cpp
@@ -10,6 +10,7 @@ namespace ttnn::operations::experimental::transformer {
 
 // Generic NLP CreateHeads op
 void NlpCreateHeadsDeviceOperation::validate_on_program_cache_miss(const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args) {
+    using namespace tt::constants;
     const auto& input_tensor = tensor_args.input_tensor_q;
     const auto input_shape = input_tensor.get_legacy_shape();
 
@@ -73,6 +74,7 @@ void NlpCreateHeadsDeviceOperation::validate_on_program_cache_hit(const operatio
 }
 
 NlpCreateHeadsDeviceOperation::shape_return_value_t NlpCreateHeadsDeviceOperation::compute_output_shapes(const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args) {
+    using namespace tt::constants;
     const auto& input_tensor = tensor_args.input_tensor_q;
     const auto input_shape = input_tensor.get_legacy_shape();
 
@@ -95,6 +97,7 @@ NlpCreateHeadsDeviceOperation::shape_return_value_t NlpCreateHeadsDeviceOperatio
 }
 
 NlpCreateHeadsDeviceOperation::tensor_return_value_t NlpCreateHeadsDeviceOperation::create_output_tensors(const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args) {
+    using namespace tt::constants;
     const auto& input_tensor = tensor_args.input_tensor_q;
     if (tensor_args.optional_output_tensors.size() == 3) {
         const auto& output_tensors = tensor_args.optional_output_tensors;

--- a/ttnn/cpp/ttnn/operations/experimental/transformer/nlp_create_qkv_heads_decode/device/nlp_create_qkv_heads_decode_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/nlp_create_qkv_heads_decode/device/nlp_create_qkv_heads_decode_device_operation.cpp
@@ -11,6 +11,7 @@ namespace ttnn::operations::experimental::transformer {
 
 // Generic NLP CreateHeads op for decode
 void NLPCreateHeadsDecodeDeviceOperation::validate(const std::vector<Tensor>& input_tensors) const {
+    using namespace tt::constants;
     const auto& input_tensor = input_tensors.at(0);
     const auto input_shape = input_tensor.get_legacy_shape();
     // TODO: Rewrite validation for this decode case
@@ -43,6 +44,7 @@ void NLPCreateHeadsDecodeDeviceOperation::validate(const std::vector<Tensor>& in
 }
 
 std::vector<tt::tt_metal::Shape> NLPCreateHeadsDecodeDeviceOperation::compute_output_shapes(const std::vector<Tensor>& input_tensors) const {
+    using namespace tt::constants;
     std::vector<Shape> output_shape_vec;
     const auto& input_tensor = input_tensors.at(0);
     const auto input_shape = input_tensor.get_legacy_shape();
@@ -62,6 +64,7 @@ std::vector<tt::tt_metal::Shape> NLPCreateHeadsDecodeDeviceOperation::compute_ou
 }
 
 std::vector<Tensor> NLPCreateHeadsDecodeDeviceOperation::create_output_tensors(const std::vector<Tensor>& input_tensors) const {
+    using namespace tt::constants;
     const auto& input_tensor = input_tensors.at(0);
     const auto input_shape = input_tensor.get_legacy_shape();
     auto output_shapes = this->compute_output_shapes(input_tensors);

--- a/ttnn/cpp/ttnn/operations/experimental/transformer/nlp_create_qkv_heads_falcon7b/device/nlp_create_qkv_heads_falcon7b_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/nlp_create_qkv_heads_falcon7b/device/nlp_create_qkv_heads_falcon7b_device_operation.cpp
@@ -18,7 +18,7 @@ void NlpCreateHeadsFalcon7BDeviceOperation::validate(const std::vector<Tensor>& 
     TT_FATAL(input_tensor.get_dtype() == tt::tt_metal::DataType::FLOAT32 || input_tensor.get_dtype() == tt::tt_metal::DataType::BFLOAT16 || input_tensor.get_dtype() == tt::tt_metal::DataType::BFLOAT8_B, "Unsupported data format");
     TT_FATAL(input_tensor.get_layout() == Layout::TILE);
 
-    TT_FATAL(input_shape[2] % TILE_HEIGHT == 0);
+    TT_FATAL(input_shape[2] % tt::constants::TILE_HEIGHT == 0);
     TT_FATAL((input_shape == tt::tt_metal::Shape({input_shape[0], 1, input_shape[2], 4672})), "Unsupported input shape");
     TT_FATAL(this->output_mem_config.memory_layout == TensorMemoryLayout::INTERLEAVED);
 }

--- a/ttnn/cpp/ttnn/operations/experimental/transformer/nlp_kv_cache_load_slice/device/nlp_kv_cache_load_slice_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/nlp_kv_cache_load_slice/device/nlp_kv_cache_load_slice_device_operation.cpp
@@ -9,6 +9,7 @@ namespace ttnn::operations::experimental::transformer {
 
 // NLP KV Cache Unpad To Sharded op
 void NlpKVCacheLoadSliceDeviceOperation::validate(const std::vector<Tensor> &input_tensors) const {
+    using namespace tt::constants;
     const auto& input_tensor_a = input_tensors.at(0);
     TT_FATAL(input_tensor_a.storage_type() == StorageType::DEVICE, "Operands to unpad need to be on device!");
     TT_FATAL(input_tensor_a.buffer() != nullptr , "Operands to unpad need to be allocated in buffers on device!");

--- a/ttnn/cpp/ttnn/operations/experimental/transformer/rotary_embedding/rotary_embedding.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/rotary_embedding/rotary_embedding.cpp
@@ -19,9 +19,9 @@ ttnn::Tensor RotaryEmbeddingOperation::invoke(
     const std::optional<MemoryConfig>& memory_config,
     const std::optional<const ttnn::DeviceComputeKernelConfig> compute_kernel_config) {
 
-    TT_FATAL(input_tensor.get_legacy_shape()[-1] % (TILE_WIDTH * 2) == 0,
+    TT_FATAL(input_tensor.get_legacy_shape()[-1] % (tt::constants::TILE_WIDTH * 2) == 0,
             fmt::format("Input X dimension ({}) must be divisible by {} for tiling.",
-            input_tensor.get_legacy_shape()[-1], TILE_WIDTH * 2));
+            input_tensor.get_legacy_shape()[-1], tt::constants::TILE_WIDTH * 2));
 
     uint32_t seq_len = input_tensor.get_legacy_shape()[-2];
     uint32_t B = input_tensor.get_legacy_shape()[0];

--- a/ttnn/cpp/ttnn/operations/experimental/transformer/rotate_half/rotate_half.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/rotate_half/rotate_half.cpp
@@ -14,10 +14,10 @@ Tensor RotateHalfOperation::invoke(const Tensor& input_tensor, const std::option
             fmt::format("Input tensor must be on device. Current storage type: {}.",
                         static_cast<int>(input_tensor.storage_type())));
 
-    TT_FATAL(input_tensor.get_legacy_shape()[-1] % (TILE_WIDTH * 2) == 0,
+    TT_FATAL(input_tensor.get_legacy_shape()[-1] % (tt::constants::TILE_WIDTH * 2) == 0,
             fmt::format("Input X dimension ({}) must be divisible by {} for tiling.",
                         input_tensor.get_legacy_shape()[-1],
-                        TILE_WIDTH * 2));
+                        tt::constants::TILE_WIDTH * 2));
 
     tt::tt_metal::Shape pad_shape = ttnn::operations::experimental::auto_format::AutoFormat::pad_to_tile_shape(input_tensor.get_legacy_shape());
     ttnn::operations::experimental::auto_format::FormatParams input_format_params = {.pad_shape=pad_shape, .pad_value=0.0, .target_layout=Layout::TILE};

--- a/ttnn/cpp/ttnn/operations/pool/maxpool/device/max_pool_multi_core.cpp
+++ b/ttnn/cpp/ttnn/operations/pool/maxpool/device/max_pool_multi_core.cpp
@@ -66,6 +66,7 @@ std::tuple<CoreRange, CoreRangeSet, CoreRangeSet, uint32_t, uint32_t> get_decomp
 
 // uint32_t get_num_cores(CoreCoord grid_size, uint32_t out_nhw, uint32_t nbatch) {
 uint32_t get_num_cores(const Device* device, uint32_t out_nhw, uint32_t nbatch) {
+    using namespace tt::constants;
     auto grid_size = device->compute_with_storage_grid_size();
     uint32_t avail_ncores = grid_size.x * grid_size.y;
     uint32_t ncores = 0;

--- a/ttnn/cpp/ttnn/operations/reduction/topk/device/topk_op.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/topk/device/topk_op.cpp
@@ -13,7 +13,7 @@ static inline bool verify_available_cores(uint16_t width, uint16_t min_dim, uint
         uint16_t rem = width % split_size;
         uint16_t num_cores = width / split_size + (rem > 0);
         uint32_t memory_cost_gather = 2*num_cores * (value_tile_size + index_tile_size); // gathering one index and one value tile from each local core, allocating two CBs for each
-        uint32_t memory_cost_local = (split_size / TILE_WIDTH) * (value_tile_size + index_tile_size); // we divide the width into split_size chunks and each chunk, as well as a matching set of indices, is processed by a core
+        uint32_t memory_cost_local = (split_size / tt::constants::TILE_WIDTH) * (value_tile_size + index_tile_size); // we divide the width into split_size chunks and each chunk, as well as a matching set of indices, is processed by a core
         if (num_cores <= max_cores && (memory_cost_gather + memory_cost_local) < L1_SIZE && num_cores > 1) {
             return true;
         }

--- a/ttnn/cpp/ttnn/operations/reduction/topk/device/topk_program_factory.hpp
+++ b/ttnn/cpp/ttnn/operations/reduction/topk/device/topk_program_factory.hpp
@@ -11,6 +11,7 @@
 namespace ttnn::operations::reduction::detail {
 
 operation::ProgramWithCallbacks topk_single_core_interleaved(const Tensor &input_tensor, const uint16_t k, const int8_t dim, Tensor &value_tensor, Tensor &index_tensor) {
+    using namespace tt::constants;
     tt::tt_metal::Program program{};
     CoreRange core({0, 0}, {0, 0});
     tt::DataFormat input_cb_data_format = tt::tt_metal::datatype_to_dataformat_converter(input_tensor.get_dtype());
@@ -191,7 +192,7 @@ static inline std::tuple<uint16_t, uint16_t, uint16_t, uint16_t> cores_utilized(
         uint16_t rem = width % split_size;
         uint16_t num_cores = width / split_size + (rem > 0);
         uint32_t memory_cost_gather = 2*num_cores * (value_tile_size + index_tile_size); // gathering one index and one value tile from each local core, allocating two CBs for each
-        uint32_t memory_cost_local = (split_size / TILE_WIDTH) * (value_tile_size + index_tile_size); // we divide the width into split_size chunks and each chunk, as well as a matching set of indices, is processed by a core
+        uint32_t memory_cost_local = (split_size / tt::constants::TILE_WIDTH) * (value_tile_size + index_tile_size); // we divide the width into split_size chunks and each chunk, as well as a matching set of indices, is processed by a core
         if (num_cores <= max_cores && (memory_cost_gather + memory_cost_local) < L1_SIZE && num_cores > 1) {
             return {num_cores + 1, split_size, rem, num_cores * k};
         }
@@ -204,6 +205,7 @@ static inline std::tuple<uint16_t, uint16_t, uint16_t, uint16_t> cores_utilized(
  *
 */
 operation::ProgramWithCallbacks topk_multicore_interleaved(const Tensor &input_tensor, const uint16_t k, const int8_t dim, Tensor &value_tensor, Tensor &index_tensor) {
+    using namespace tt::constants;
     tt::tt_metal::Program program{};
 
 

--- a/ttnn/cpp/ttnn/operations/sliding_window/halo/device/halo_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/sliding_window/halo/device/halo_device_operation.cpp
@@ -19,7 +19,7 @@ void HaloDeviceOperation::validate(const std::vector<Tensor> &input_tensors) con
         // skip the untilize, only do halo
         log_debug(tt::LogOp, "Input is ROW_MAJOR, no need to untilize.");
     } else {
-        TT_FATAL(input_tensor.volume() % TILE_HW == 0);
+        TT_FATAL(input_tensor.volume() % tt::constants::TILE_HW == 0);
     }
     TT_FATAL(input_tensor.memory_config().memory_layout == TensorMemoryLayout::HEIGHT_SHARDED || input_tensor.memory_config().memory_layout == TensorMemoryLayout::BLOCK_SHARDED || input_tensor.memory_config().memory_layout == TensorMemoryLayout::WIDTH_SHARDED, "Only height, width or block sharded tensors are supported.");
     TT_FATAL(input_tensor.shard_spec().has_value(), "Shard spec should not be empty");

--- a/ttnn/cpp/ttnn/operations/transformer/split_query_key_value_and_split_heads/split_query_key_value_and_split_heads.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/split_query_key_value_and_split_heads/split_query_key_value_and_split_heads.cpp
@@ -132,9 +132,9 @@ std::tuple<Tensor, Tensor, Tensor> SplitQueryKeyValueAndSplitHeadsOperation::inv
 
     uint32_t head_size = hidden_dim / num_heads;
     uint32_t padded_head_size = hidden_dim_padded / num_heads;
-    TT_FATAL(head_size % TILE_WIDTH == 0,
+    TT_FATAL(head_size % tt::constants::TILE_WIDTH == 0,
             fmt::format("Invalid head size: {}. The head size must be a multiple of the tile width ({}). Please adjust the dimensions accordingly.",
-                        head_size, TILE_WIDTH));
+                        head_size, tt::constants::TILE_WIDTH));
 
     TT_FATAL(padded_head_size == head_size,
             fmt::format("Padding error: Head size {} should not include additional tile padding, but padded head size was found to be {}. Ensure that no extra padding is applied.",


### PR DESCRIPTION
### Ticket
Link to Github Issue #11989 

### Work Done

- Removed the global namespace usage for tt::constants in auto_format.hpp.
- Added it within the respective functions instead.

### Checklist
- [x] [All Post commit CI ](https://github.com/tenstorrent/tt-metal/actions/runs/10610462284)
- [x]  [(Single-card) Model perf tests](https://github.com/tenstorrent/tt-metal/actions/runs/10695265584)
- [x] [(Single-card) Demo tests](https://github.com/tenstorrent/tt-metal/actions/runs/10610493762)
- [x] [(Single-card) Device perf regressions](https://github.com/tenstorrent/tt-metal/actions/runs/10610500709)
- [x] [Nightly fast dispatch tests](https://github.com/tenstorrent/tt-metal/actions/runs/10611947087)
- [x] [[post-commit] models tests](https://github.com/tenstorrent/tt-metal/actions/runs/10610515856)
- [x] [(T3K) T3000 model perf tests](https://github.com/tenstorrent/tt-metal/actions/runs/10610529104)
- [x] [(T3K) T3000 frequent tests](https://github.com/tenstorrent/tt-metal/actions/runs/10610547051)
- [x] [(T3K) T3000 nightly tests](https://github.com/tenstorrent/tt-metal/actions/runs/10610541703)