### PR TITLE
#10718: Fix issue with negative pipeline queue times

### DIFF
--- a/.github/workflows/_produce-data.yaml
+++ b/.github/workflows/_produce-data.yaml
@@ -8,6 +8,10 @@ on:
         description: "Unique GitHub workflow run ID to use for data"
         default: 10066309412
         type: number
+      test_workflow_run_attempt:
+        description: "Run attempt of the workflow run"
+        default: 1
+        type: number
   workflow_run:
     workflows:
       - "All post-commit tests"
@@ -44,7 +48,7 @@ jobs:
           event_name="${{ github.event_name }}"
           if [[ "$event_name" == "workflow_dispatch" ]]; then
             run_id="${{ inputs.test_workflow_run_id }}"
-            attempt_number="1"
+            attempt_number="${{ inputs.test_workflow_run_attempt }}"
           elif [[ "$event_name" == "workflow_run" ]]; then
             run_id="${{ github.event.workflow_run.id }}"
             attempt_number="${{ github.event.workflow_run.run_attempt }}"

--- a/infra/data_collection/github/utils.py
+++ b/infra/data_collection/github/utils.py
@@ -59,6 +59,7 @@ def get_pipeline_row_from_github_info(github_runner_environment, github_pipeline
 
     jobs = github_jobs_json["jobs"]
     jobs_start_times = list(map(lambda job_: get_datetime_from_github_datetime(job_["started_at"]), jobs))
+    # We filter out jobs that started before because that means they're from a previous attempt for that pipeline
     eligible_jobs_start_times = list(
         filter(
             lambda job_start_time_: job_start_time_ >= get_datetime_from_github_datetime(pipeline_submission_ts),

--- a/infra/data_collection/github/utils.py
+++ b/infra/data_collection/github/utils.py
@@ -59,7 +59,16 @@ def get_pipeline_row_from_github_info(github_runner_environment, github_pipeline
 
     jobs = github_jobs_json["jobs"]
     jobs_start_times = list(map(lambda job_: get_datetime_from_github_datetime(job_["started_at"]), jobs))
-    sorted_jobs_start_times = sorted(jobs_start_times)
+    eligible_jobs_start_times = list(
+        filter(
+            lambda job_start_time_: job_start_time_ >= get_datetime_from_github_datetime(pipeline_submission_ts),
+            jobs_start_times,
+        )
+    )
+    sorted_jobs_start_times = sorted(eligible_jobs_start_times)
+    assert (
+        sorted_jobs_start_times
+    ), f"It seems that this pipeline does not have any jobs that started on or after the pipeline was submitted, which should be impossible. Please directly inspect the JSON objects"
     pipeline_start_ts = get_data_pipeline_datetime_from_datetime(sorted_jobs_start_times[0])
 
     pipeline_end_ts = github_pipeline_json["updated_at"]


### PR DESCRIPTION
### Ticket

#10718

### Problem description

We see certain pipelines in the CI/CD dashboard come up with negative queue times. This obviously makes no sense.
The reason why this happens is because we're grabbing a job with a start time that's earlier than the pipeline queue time. How is that possible? This is because workflow re-runs can inherit already-run jobs from a previous attempt, meaning later attempts can have jobs with timestamps that are earlier than the attempt start time.


### What's changed

We just filter out any jobs that have a start time earlier than the pipeline queue time. We can be confident those are jobs that from an earlier attempt.

### Checklist
- [x] Post commit CI passes
- [x] Blackhole Post commit (if applicable)
- [x] Model regression CI testing passes (if applicable)
- [x] New/Existing tests provide coverage for changes
