### PR TITLE
#11591: Fix race by making only unpacker zero out RISCV_DEBUG_REG_DBG_FEATURE_DISABLE at start of kernel

### DIFF
--- a/tt_metal/hw/firmware/src/trisck.cc
+++ b/tt_metal/hw/firmware/src/trisck.cc
@@ -44,8 +44,8 @@ void kernel_launch()
     tt_l1_ptr uint *local_l1_start_addr = (tt_l1_ptr uint *)PREPROCESSOR_EXPAND(MEM_TRISC, COMPILE_FOR_TRISC, _INIT_LOCAL_L1_BASE);
     firmware_kernel_common_init(local_l1_start_addr);
 #if defined(UCK_CHLKC_UNPACK)
-        // Hack workaround for issue #11591
-        for (volatile uint32_t xxx = 0; xxx < 100; xxx++);
+    // Make sure DBG_FEATURE_DISABLE register is cleared before every kernel is executed
+    memory_write(RISCV_DEBUG_REG_DBG_FEATURE_DISABLE, 0);
 #endif
     run_kernel();
 #endif

--- a/tt_metal/hw/inc/firmware_common.h
+++ b/tt_metal/hw/inc/firmware_common.h
@@ -61,10 +61,6 @@ inline void firmware_kernel_common_init(void *init_local_l1_base) {
     for (void (** fptr)() = __init_array_start; fptr < __init_array_end; fptr++) {
         (**fptr)();
     }
-
-    // Make sure DBG_FEATURE_DISABLE register is cleared before every kernel is executed
-    memory_write(RISCV_DEBUG_REG_DBG_FEATURE_DISABLE, 0);
-
 }
 FORCE_INLINE
 uint32_t firmware_config_init(tt_l1_ptr mailboxes_t* const mailboxes, uint32_t core_type_index, uint32_t dispatch_class) {


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/11591

### Problem description
There was a race exposed by removing the duplicate CB initialization from unpacker where some tests produced incorrect PCC. This was caused due to all riscs trying to zero out a register at the start of their kernel, and unpacker needing to set it to a non-zero value. Since there is no ordering, a RISC would zero out the register after unpacker wrote the needed value.

### What's changed
Remove the zeroing out of the register from the common risc init path and only zero out on unpacker.

### Checklist
- [x] Post commit CI passes
- [x] Blackhole Post commit (if applicable)
- [x] Model regression CI testing passes (if applicable)
- [x] New/Existing tests provide coverage for changes
