### PR TITLE
#0: Always initialize l1_banking allocator even when size is 0

### DIFF
--- a/tt_metal/impl/allocator/allocator.cpp
+++ b/tt_metal/impl/allocator/allocator.cpp
@@ -211,21 +211,19 @@ void init_one_bank_per_channel(Allocator &allocator, const AllocatorConfig &allo
         allocator.dram_channel_to_bank_ids.insert({bank_id, {bank_id}});
         allocator.logical_core_to_bank_ids[BufferType::DRAM].insert({logical_core, {bank_id}});
     }
-    if (alloc_config.trace_region_size > 0) {
-        // Trace buffers are allocated in this region (top-down). Trace region is offset at dram_bank_size + UNRESERVED
-        // offset
-        allocator.trace_buffer_manager = BankManager(
-            BufferType::TRACE,
-            bank_offsets,
-            alloc_config.trace_region_size,
-            ALLOCATOR_ALIGNMENT,
-            dram_bank_size + DRAM_UNRESERVED_BASE);
-        for (uint32_t bank_id = 0; bank_id < alloc_config.num_dram_channels; bank_id++) {
-            CoreCoord logical_core = CoreCoord{bank_id, 0};
-            allocator.bank_id_to_dram_channel.insert({bank_id, bank_id});
-            allocator.dram_channel_to_bank_ids.insert({bank_id, {bank_id}});
-            allocator.logical_core_to_bank_ids[BufferType::TRACE].insert({logical_core, {bank_id}});
-        }
+    // Trace buffers are allocated in this region (top-down). Trace region is offset at dram_bank_size + UNRESERVED
+    // offset
+    allocator.trace_buffer_manager = BankManager(
+        BufferType::TRACE,
+        bank_offsets,
+        alloc_config.trace_region_size,
+        ALLOCATOR_ALIGNMENT,
+        dram_bank_size + DRAM_UNRESERVED_BASE);
+    for (uint32_t bank_id = 0; bank_id < alloc_config.num_dram_channels; bank_id++) {
+        CoreCoord logical_core = CoreCoord{bank_id, 0};
+        allocator.bank_id_to_dram_channel.insert({bank_id, bank_id});
+        allocator.dram_channel_to_bank_ids.insert({bank_id, {bank_id}});
+        allocator.logical_core_to_bank_ids[BufferType::TRACE].insert({logical_core, {bank_id}});
     }
 }
 

--- a/tt_metal/impl/allocator/l1_banking_allocator.cpp
+++ b/tt_metal/impl/allocator/l1_banking_allocator.cpp
@@ -182,15 +182,13 @@ void init_compute_and_storage_l1_bank_manager(Allocator &allocator, const Alloca
     TT_ASSERT(
         (alloc_offset + alloc_config.l1_small_size) <= alloc_config.worker_l1_size,
         "L1 small region extends past L1 size");
-    if (alloc_config.l1_small_size > 0) {
-        allocator.l1_small_manager = BankManager(
-            BufferType::L1_SMALL,
-            small_bank_id_to_bank_offset,
-            alloc_config.l1_small_size,
-            small_interleaved_address_limit,
-            ALLOCATOR_ALIGNMENT,
-            small_alloc_offset);
-    }
+    allocator.l1_small_manager = BankManager(
+        BufferType::L1_SMALL,
+        small_bank_id_to_bank_offset,
+        alloc_config.l1_small_size,
+        small_interleaved_address_limit,
+        ALLOCATOR_ALIGNMENT,
+        small_alloc_offset);
 }
 
 }   // namespace allocator


### PR DESCRIPTION
### Problem description
We were seeing segmentation faults when running a model that uses L1_SMALL but doesn't initialize the size to non-zero. This is because we only initialize the l1 small allocator when size is non-zero, and we only have a TT_ASSERT for if allocator is initialized in `BankManager::allocate_buffer`, so in release mode we don't assert out and seg fault.
We could flip this to TT_FATAL, but this means that we pay the cost of this check every time we allocate a buffer. Instead, we always initialize the allocator even when size is zero. This means we only pay a cost once during device/allocator init, and not during buffer allocation in runtime.
This also generates a more descriptive assert, ex.
`Always | FATAL    | Out of Memory: Not enough space to allocate 256 B L1_SMALL buffer across 64 banks, where each bank needs to store 32 B`
compared to having the allocator not initialized, ex.
`Always | FATAL    | Allocator not initialized!`

### What's changed
Always initialize the non-default allocators even when size is 0

### Checklist
- [x] Post commit CI passes
- [ ] Blackhole Post commit (if applicable)
- [ ] Model regression CI testing passes (if applicable)
- [x] New/Existing tests provide coverage for changes
