### PR TITLE
Add missing include to graph_trace_utils.hpp

### DIFF
--- a/ttnn/cpp/ttnn/graph/graph_processor.hpp
+++ b/ttnn/cpp/ttnn/graph/graph_processor.hpp
@@ -6,6 +6,8 @@
 
 #include "tt_metal/graph/graph_tracking.hpp"
 #include "third_party/json/json.hpp"
+#include "ttnn/tensor/tensor.hpp"
+
 #include <mutex>
 #include <stack>
 #include <typeindex>

--- a/ttnn/cpp/ttnn/graph/graph_trace_utils.hpp
+++ b/ttnn/cpp/ttnn/graph/graph_trace_utils.hpp
@@ -5,6 +5,7 @@
 #pragma once
 
 #include "third_party/json/json.hpp"
+#include "ttnn/tensor/types.hpp"
 
 #include <vector>
 


### PR DESCRIPTION
### Ticket
None

### Problem description
Graph_trace_utils.hpp is missing a tensor/types.hpp include for `ttnn::Shape`

### What's changed
Adding it

### Checklist
- [ ] Post commit CI passes
