### PR TITLE
update slack notification include workflow run

### DIFF
--- a/.github/actions/slack-report/action.yaml
+++ b/.github/actions/slack-report/action.yaml
@@ -4,7 +4,8 @@ inputs:
   owner:
     description: "The Slack ID of the person to be tagged."
     default: "U014XCQ9CF8" # @Raymond Kim
-  slack_webhook_url: 
+  slack_webhook_url:
+    description: "Webhook URL for the Slack channel to be posted to. Generated via slack app!"
     required: true
 runs:
   using: "composite"
@@ -15,7 +16,7 @@ runs:
       with:
         payload: |
           {
-            "text": "just so you know `${{ github.event.sender.login }}` broke ${{ github.workflow }} with https://github.com/tenstorrent/tt-metal/commit/${{ github.sha }}",
+            "text": "just so you know `${{ github.event.sender.login }}` broke ${{ github.workflow }} with https://github.com/tenstorrent/tt-metal/commit/${{ github.sha }} at ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}",
             "owner": "${{ inputs.owner }}"
           }
       env:


### PR DESCRIPTION
### Ticket
Add workflow link to slack notifications instead of just commit.

### Problem description
Confusing to find failed GH runs


### What's changed
old format
[@Michael Chiou](https://tenstorrent.slack.com/team/U06CXU895AP), just so you know `ttmchiou` broke Build tt-metal artifacts with https://github.com/tenstorrent/tt-metal/commit/0393725641824e8b1a558a333a11b77098449706

new format
[@Michael Chiou](https://tenstorrent.slack.com/team/U06CXU895AP), just so you know `ttmchiou` broke Build tt-metal artifacts with https://github.com/tenstorrent/tt-metal/commit/0393725641824e8b1a558a333a11b77098449706 at https://github.com/tenstorrent/tt-metal/actions/runs/10608545695


### Checklist
- [ ] Post commit CI passes
- [ ] Blackhole Post commit (if applicable)
- [ ] Model regression CI testing passes (if applicable)
- [ ] New/Existing tests provide coverage for changes
