### PR TITLE
Remove noinline attribute from sdpa_decode compute kernel

### DIFF
--- a/ttnn/cpp/ttnn/operations/transformer/sdpa_decode/device/kernels/compute/sdpa_flash_decode.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa_decode/device/kernels/compute/sdpa_flash_decode.cpp
@@ -105,7 +105,7 @@ void reduce_c() {
     UNPACK(tensix_sync());
 }
 
-void __attribute((noinline)) recip_block_inplace(uint32_t in_cb, uint32_t num_tiles) {
+void recip_block_inplace(uint32_t in_cb, uint32_t num_tiles) {
     // Precondition: in_cb has num_tiles produced
     // Postcondition: in_cb has num_tiles produced
     copy_tile_to_dst_init_short(in_cb);


### PR DESCRIPTION
### Ticket
Link to Github Issue

### Problem description
forcing no inline leads to 'TRISC0_FIRMWARE_CODE' overflowed by 2024 bytes' error
### What's changed
Remove noinline attribute from sdpa_decode compute kernel

### Checklist
- [ ] Post commit CI passes
- [ ] Blackhole Post commit (if applicable)
- [ ] Model regression CI testing passes (if applicable)
- [ ] New/Existing tests provide coverage for changes
