### PR TITLE
#0: Fixed Conv2dConfig in broken tests

### DIFF
--- a/models/demos/wormhole/mamba/tt/mamba_conv.py
+++ b/models/demos/wormhole/mamba/tt/mamba_conv.py
@@ -55,7 +55,7 @@ class MambaConv:
             dtype=self.config.output_dtype,
             weights_dtype=self.config.weights_dtype,
             math_fidelity=self.config.math_fidelity,
-            height_sharding=True,
+            shard_layout=ttnn.TensorMemoryLayout.HEIGHT_SHARDED,
             input_channels_alignment=32,
             deallocate_activation=True,
         )

--- a/models/demos/wormhole/stable_diffusion/tt/ttnn_functional_unet_2d_condition_model_new_conv.py
+++ b/models/demos/wormhole/stable_diffusion/tt/ttnn_functional_unet_2d_condition_model_new_conv.py
@@ -377,7 +377,9 @@ class UNet2DConditionModel:
         # sample = self.conv_in(sample)
         out_channels = self.parameters.conv_in.weight.shape[0]
         in_channels = self.parameters.conv_in.weight.shape[1]
-
+        shard_layout = (
+            ttnn.TensorMemoryLayout.HEIGHT_SHARDED if in_channels < 320 else ttnn.TensorMemoryLayout.BLOCK_SHARDED
+        )
         conv_config = ttnn.Conv2dConfig(
             dtype=ttnn.bfloat8_b,
             weights_dtype=ttnn.bfloat8_b,
@@ -386,9 +388,7 @@ class UNet2DConditionModel:
             math_approx_mode_enabled=True,
             fp32_dest_acc_enabled=True,
             packer_l1_accum_enabled=False,
-            shard_layout=ttnn.TensorMemoryLayout.HEIGHT_SHARDED
-            if self.in_channels < 320
-            else ttnn.TensorMemoryLayout.BLOCK_SHARDED,
+            shard_layout=shard_layout,
             input_channels_alignment=32,
             transpose_shards=False,
             reshard_if_not_optimal=True,

--- a/models/experimental/functional_unet/tt/unet_shallow_ttnn.py
+++ b/models/experimental/functional_unet/tt/unet_shallow_ttnn.py
@@ -136,15 +136,16 @@ class UNetConv2D:
         self.cache = cache
         self.mesh_mapper = mesh_mapper
 
+        shard_layout = (
+            ttnn.TensorMemoryLayout.HEIGHT_SHARDED
+            if self.use_1d_systolic_array
+            else ttnn.TensorMemoryLayout.BLOCK_SHARDED
+        )
         self.conv_config = ttnn.Conv2dConfig(
             dtype=activation_dtype,
             weights_dtype=weights_dtype,
             math_fidelity=ttnn.MathFidelity.LoFi,
-            shard_layout=(
-                ttnn.TensorMemoryLayout.HEIGHT_SHARDED
-                if self.use_1d_systolic_array
-                else ttnn.TensorMemoryLayout.BLOCK_SHARDED
-            ),
+            shard_layout=shard_layout,
             deallocate_activation=self.deallocate_activation,
             fp32_dest_acc_enabled=True,
             packer_l1_accum_enabled=False,

--- a/models/experimental/yolov4/ttnn/common.py
+++ b/models/experimental/yolov4/ttnn/common.py
@@ -56,7 +56,9 @@ class Conv:
         self.out_channels = self.weights.shape[0]
         self.act_block_h = act_block_h
         self.reshard = reshard
-        self.height_sharding = height_sharding
+        self.shard_layout = (
+            ttnn.TensorMemoryLayout.HEIGHT_SHARDED if height_sharding else ttnn.TensorMemoryLayout.BLOCK_SHARDED
+        )
         self.deallocate = deallocate
         self.activation = activation
 
@@ -69,7 +71,7 @@ class Conv:
             weights_dtype=ttnn.bfloat8_b,
             math_fidelity=ttnn.MathFidelity.LoFi,
             activation=self.activation,
-            height_sharding=self.height_sharding,
+            shard_layout=self.shard_layout,
             math_approx_mode_enabled=True,
             fp32_dest_acc_enabled=False,
             packer_l1_accum_enabled=False,


### PR DESCRIPTION
### Problem description
Conv2dConfig not updated in all tests after the `height_sharding` flag was removed. 

### Checklist
- [ ] Post commit CI passes
- [x] Device perf regression [passes](https://github.com/tenstorrent/tt-metal/actions/runs/10617635416)
- [x] Nightly fast dispatch [same as before](https://github.com/tenstorrent/tt-metal/actions/runs/10617622334/job/29436830180)