### PR TITLE
#12069: Add catch and handling for device initialize exception, typic…

### DIFF
--- a/tests/sweep_framework/runner.py
+++ b/tests/sweep_framework/runner.py
@@ -45,8 +45,12 @@ def get_devices(test_module):
 
 def run(test_module, input_queue, output_queue):
     device_generator = get_devices(test_module)
-    device, device_name = next(device_generator)
-    print(f"SWEEPS: Opened device configuration, {device_name}.")
+    try:
+        device, device_name = next(device_generator)
+        print(f"SWEEPS: Opened device configuration, {device_name}.")
+    except AssertionError as e:
+        output_queue.put([False, "DEVICE EXCEPTION: " + str(e), None])
+        return
     try:
         while True:
             test_vector = input_queue.get(block=True, timeout=1)
@@ -124,6 +128,13 @@ def execute_suite(test_module, test_vectors, pbar_manager, suite_name):
                     result["status"] = TestStatus.PASS
                     result["message"] = message
                 else:
+                    if "DEVICE EXCEPTION" in message:
+                        print(
+                            "SWEEPS: DEVICE EXCEPTION: Device could not be initialized. The following assertion was thrown: ",
+                            message,
+                        )
+                        print("SWEEPS: Skipping test suite because of device error, proceeding...")
+                        return []
                     if "Out of Memory: Not enough space to allocate" in message:
                         result["status"] = TestStatus.FAIL_L1_OUT_OF_MEM
                     elif "Watcher" in message:


### PR DESCRIPTION
…ally when tests are run on unsupported machines

### Ticket
#12069 

### Problem description
See issue.

### What's changed
Add a catch around the device initialization, if there is an assertion, log the output and skip that suite of tests if the machine is incorrect.

### Checklist
- [ ] Post commit CI passes
- [ ] Blackhole Post commit (if applicable)
- [ ] Model regression CI testing passes (if applicable)
- [ ] New/Existing tests provide coverage for changes
