### PR TITLE
#0: Skip python tests on BH if they are skipped on WH

### DIFF
--- a/models/demos/bert/tests/test_ttnn_optimized_bert.py
+++ b/models/demos/bert/tests/test_ttnn_optimized_bert.py
@@ -14,10 +14,10 @@ import ttnn
 from ttnn.model_preprocessing import preprocess_model_parameters
 
 from tests.ttnn.utils_for_testing import assert_with_pcc
-from models.utility_functions import skip_for_wormhole_b0
+from models.utility_functions import is_wormhole_b0, is_blackhole
 
 
-@skip_for_wormhole_b0()
+@pytest.mark.skipif(is_wormhole_b0() or is_blackhole(), reason="Unsupported on WH and BH")
 @pytest.mark.parametrize("model_name", ["phiyodr/bert-large-finetuned-squad2"])
 @pytest.mark.parametrize("batch_size", [8])
 @pytest.mark.parametrize("sequence_size", [384])

--- a/models/demos/falcon7b_common/tests/test_perf_falcon.py
+++ b/models/demos/falcon7b_common/tests/test_perf_falcon.py
@@ -19,7 +19,8 @@ from models.utility_functions import (
     disable_persistent_kernel_cache,
     is_e75,
     skip_for_grayskull,
-    skip_for_wormhole_b0,
+    is_wormhole_b0,
+    is_blackhole,
 )
 
 
@@ -57,7 +58,7 @@ class TestParametrized:
             "decode_batch32_2047_bf16_l1",
         ],
     )
-    @skip_for_wormhole_b0()
+    @pytest.mark.skipif(is_wormhole_b0() or is_blackhole(), reason="Unsupported on WH and BH")
     def test_perf_gs_bare_metal(
         self,
         model_version,

--- a/models/demos/falcon7b_common/tests/unit_tests/test_falcon_matmuls_and_bmms_with_mixed_precision.py
+++ b/models/demos/falcon7b_common/tests/unit_tests/test_falcon_matmuls_and_bmms_with_mixed_precision.py
@@ -10,7 +10,7 @@ import ttnn
 from models.demos.falcon7b_common.tt.falcon_causallm import falcon_lm_head_matmul
 from models.demos.falcon7b_common.tt.falcon_mlp import falcon_dense_4h_to_h_matmul, falcon_dense_h_to_4h_matmul
 from models.demos.falcon7b_common.tt.model_utils import get_falcon_default_core_grid
-from models.utility_functions import comp_pcc, tt2torch_tensor, torch2tt_tensor, skip_for_wormhole_b0
+from models.utility_functions import comp_pcc, tt2torch_tensor, torch2tt_tensor, is_wormhole_b0, is_blackhole
 import torch
 import math
 
@@ -157,7 +157,7 @@ def run_falcon_matmul_test(
 
 
 # TODO: We could parametrize these separately for comprehensive testing
-@skip_for_wormhole_b0("non-determinstic hang, see issue #5882")
+@pytest.mark.skipif(is_wormhole_b0() or is_blackhole(), reason="non-determinstic hang, see issue #5882")
 @pytest.mark.parametrize(
     "in0_mem_config, in1_mem_config, out_mem_config",
     (
@@ -231,7 +231,7 @@ def test_falcon_matmul(
 
 
 # Test matmul attention sequence with InterleavedToShardedPartialOp
-@skip_for_wormhole_b0("non-determinstic hang, see issue #5882")
+@pytest.mark.skipif(is_wormhole_b0() or is_blackhole(), reason="non-determinstic hang, see issue #5882")
 @pytest.mark.parametrize("seq_len", [128, 1024, 2048], ids=["seq_len_128", "seq_len_1024", "seq_len_2048"])
 @pytest.mark.parametrize("num_cores", [64])
 def test_falcon7b_attnention_sliced(
@@ -483,7 +483,7 @@ def test_falcon7b_attnention_sliced(
 
 @pytest.mark.parametrize("seq_len", [128, 1024, 2048], ids=["seq_len_128", "seq_len_1024", "seq_len_2048"])
 @pytest.mark.parametrize("num_cores", [64])
-@skip_for_wormhole_b0("non-determinstic hang, see issue #5882")
+@pytest.mark.skipif(is_wormhole_b0() or is_blackhole(), reason="non-determinstic hang, see issue #5882")
 @pytest.mark.parametrize("async_mode", [True, False], ids=["async_on", "async_off"])
 def test_falcon7b_attention_softmax_sequence(
     device,

--- a/models/demos/grayskull/vit/demo/demo_vit_ttnn_imagenet_inference.py
+++ b/models/demos/grayskull/vit/demo/demo_vit_ttnn_imagenet_inference.py
@@ -14,7 +14,7 @@ import ttnn
 from ttnn.model_preprocessing import preprocess_model_parameters
 
 from models.experimental.functional_vit.tt import ttnn_optimized_sharded_vit
-from models.utility_functions import skip_for_wormhole_b0, torch2tt_tensor
+from models.utility_functions import is_wormhole_b0, torch2tt_tensor, is_blackhole
 from models.experimental.vit.vit_helper_funcs import get_data_loader, get_batch
 
 import ast
@@ -27,7 +27,7 @@ def get_imagenet_label_dict():
     return class_labels
 
 
-@skip_for_wormhole_b0()
+@pytest.mark.skipif(is_wormhole_b0() or is_blackhole(), reason="Unsupported on WH and BH")
 def test_vit(device):
     torch.manual_seed(0)
 

--- a/models/demos/grayskull/vit/demo/demo_vit_ttnn_inference_device_OPs.py
+++ b/models/demos/grayskull/vit/demo/demo_vit_ttnn_inference_device_OPs.py
@@ -15,11 +15,11 @@ import ttnn
 from ttnn.model_preprocessing import preprocess_model_parameters
 
 from models.experimental.functional_vit.tt import ttnn_optimized_sharded_vit
-from models.utility_functions import skip_for_wormhole_b0, torch2tt_tensor
+from models.utility_functions import is_wormhole_b0, torch2tt_tensor, is_blackhole
 from models.experimental.vit.vit_helper_funcs import get_data_loader, get_batch
 
 from models.utility_functions import (
-    skip_for_wormhole_b0,
+    is_wormhole_b0,
     enable_persistent_kernel_cache,
     disable_persistent_kernel_cache,
     torch_random,
@@ -38,7 +38,7 @@ import os
 os.environ["TTNN_CONFIG_OVERRIDES"] = '{"enable_fast_runtime_mode": true}'
 
 
-@skip_for_wormhole_b0()
+@pytest.mark.skipif(is_wormhole_b0() or is_blackhole(), reason="Unsupported on WH and BH")
 @pytest.mark.models_performance_bare_metal
 @pytest.mark.models_performance_virtual_machine
 def test_vit(device, use_program_cache):

--- a/models/demos/grayskull/vit/demo/demo_vit_ttnn_inference_throughput.py
+++ b/models/demos/grayskull/vit/demo/demo_vit_ttnn_inference_throughput.py
@@ -15,11 +15,11 @@ import ttnn
 from ttnn.model_preprocessing import preprocess_model_parameters
 
 from models.experimental.functional_vit.tt import ttnn_optimized_sharded_vit
-from models.utility_functions import skip_for_wormhole_b0, torch2tt_tensor
+from models.utility_functions import is_wormhole_b0, torch2tt_tensor, is_blackhole
 from models.experimental.vit.vit_helper_funcs import get_data_loader, get_batch
 
 from models.utility_functions import (
-    skip_for_wormhole_b0,
+    is_wormhole_b0,
     enable_persistent_kernel_cache,
     disable_persistent_kernel_cache,
     torch_random,
@@ -38,7 +38,7 @@ import os
 os.environ["TTNN_CONFIG_OVERRIDES"] = '{"enable_fast_runtime_mode": true}'
 
 
-@skip_for_wormhole_b0()
+@pytest.mark.skipif(is_wormhole_b0() or is_blackhole(), reason="Unsupported on WH and BH")
 @pytest.mark.models_performance_bare_metal
 @pytest.mark.models_performance_virtual_machine
 def test_vit(device, use_program_cache):

--- a/models/demos/metal_BERT_large_11/tests/test_demo.py
+++ b/models/demos/metal_BERT_large_11/tests/test_demo.py
@@ -6,7 +6,7 @@ from models.demos.metal_BERT_large_11.demo.demo import test_demo as demo_json
 from models.demos.metal_BERT_large_11.demo.demo import test_demo_squadv2 as demo_squadv2
 import pytest
 from loguru import logger
-from models.utility_functions import is_e75, skip_for_wormhole_b0, skip_for_grayskull
+from models.utility_functions import is_e75, is_wormhole_b0, skip_for_grayskull, is_blackhole
 
 
 @skip_for_grayskull()
@@ -16,7 +16,7 @@ from models.utility_functions import is_e75, skip_for_wormhole_b0, skip_for_gray
     (("models/demos/metal_BERT_large_11/demo/input_data.json"),),
     ids=["default_input"],
 )
-@skip_for_wormhole_b0(reason_str="#7525: hangs on wh b0")
+@pytest.mark.skipif(is_wormhole_b0() or is_blackhole(), reason="#7525: hangs on wh b0")
 def test_demo_batch_7(batch, input_path, model_location_generator, device, use_program_cache):
     if is_e75(device):
         pytest.skip(f"Bert large 11 is not supported on E75")
@@ -51,7 +51,7 @@ def test_demo_batch_7(batch, input_path, model_location_generator, device, use_p
     (("models/demos/metal_BERT_large_11/demo/input_data.json"),),
     ids=["default_input"],
 )
-@skip_for_wormhole_b0(reason_str="#7525: hangs on wh b0")
+@pytest.mark.skipif(is_wormhole_b0() or is_blackhole(), reason="#7525: hangs on wh b0")
 def test_demo_batch_12(batch, input_path, model_location_generator, device, use_program_cache):
     if is_e75(device):
         pytest.skip(f"Bert large 11 is not supported on E75")
@@ -81,7 +81,7 @@ def test_demo_batch_12(batch, input_path, model_location_generator, device, use_
 
 
 @skip_for_grayskull()
-@skip_for_wormhole_b0(reason_str="#7525: hangs on wh b0")
+@pytest.mark.skipif(is_wormhole_b0() or is_blackhole(), reason="#7525: hangs on wh b0")
 @pytest.mark.parametrize(
     "batch, exact, f1",
     (
@@ -112,7 +112,7 @@ def test_demo_squadv2_batch_7(batch, exact, f1, model_location_generator, device
     ),
     ids=["batch_12"],
 )
-@skip_for_wormhole_b0(reason_str="#7525: hangs on wh b0")
+@pytest.mark.skipif(is_wormhole_b0() or is_blackhole(), reason="#7525: hangs on wh b0")
 def test_demo_squadv2_batch_12(batch, exact, f1, model_location_generator, device, use_program_cache):
     loop_count = 10
     evals = demo_squadv2(model_location_generator, device, use_program_cache, batch, loop_count)

--- a/models/demos/metal_BERT_large_11/tests/test_perf_bert11.py
+++ b/models/demos/metal_BERT_large_11/tests/test_perf_bert11.py
@@ -22,7 +22,8 @@ from models.utility_functions import (
     profiler,
     run_for_grayskull,
     run_for_wormhole_b0,
-    skip_for_wormhole_b0,
+    is_wormhole_b0,
+    is_blackhole,
 )
 from models.perf.perf_utils import prep_perf_report
 
@@ -150,7 +151,7 @@ def run_perf_bert11(
     logger.info(f"bert11 compile time: {compile_time}")
 
 
-@skip_for_wormhole_b0(reason_str="Didn't test on WH yet")
+@pytest.mark.skipif(is_wormhole_b0() or is_blackhole(), reason="Didn't test on WH yet")
 @run_for_wormhole_b0(reason_str="WH specific batch size")
 @pytest.mark.models_performance_bare_metal
 @pytest.mark.parametrize(

--- a/models/demos/metal_BERT_large_11/tests/test_perf_device_bert.py
+++ b/models/demos/metal_BERT_large_11/tests/test_perf_device_bert.py
@@ -5,7 +5,7 @@
 import pytest
 
 from models.perf.device_perf_utils import run_device_perf, check_device_perf, prep_device_perf_report
-from models.utility_functions import skip_for_grayskull, skip_for_wormhole_b0
+from models.utility_functions import skip_for_grayskull, is_wormhole_b0, is_blackhole
 
 
 def run_bert_perf(batch_size, test, expected_perf):
@@ -29,7 +29,7 @@ def run_bert_perf(batch_size, test, expected_perf):
     )
 
 
-@skip_for_wormhole_b0("Incorrect device metrics for wormhole b0")
+@pytest.mark.skipif(is_wormhole_b0() or is_blackhole(), reason="Incorrect device metrics for wormhole b0")
 @pytest.mark.models_device_performance_bare_metal
 @pytest.mark.parametrize(
     "batch_size, test, expected_perf",

--- a/models/demos/t3000/llama2_70b/tests/test_llama_model_t3000.py
+++ b/models/demos/t3000/llama2_70b/tests/test_llama_model_t3000.py
@@ -4,13 +4,13 @@
 
 import pytest
 
-from models.utility_functions import skip_for_grayskull, skip_for_wormhole_b0
+from models.utility_functions import skip_for_grayskull, is_wormhole_b0, is_blackhole
 from models.demos.t3000.llama2_70b.tt.llama_common import setup_llama_env, check_mesh_device
 from models.demos.t3000.llama2_70b.tests.test_llama_model import run_test_LlamaModel_inference
 
 
 @skip_for_grayskull("Requires eth connected devices to run")
-# @skip_for_wormhole_b0("See GH Issue #10317")
+# @pytest.mark.skipif(is_wormhole_b0() or is_blackhole(), reason="See GH Issue #10317")
 @pytest.mark.parametrize(
     "llama_version",
     (

--- a/models/demos/t3000/llama2_70b/tests/test_llama_perf_decode.py
+++ b/models/demos/t3000/llama2_70b/tests/test_llama_perf_decode.py
@@ -23,7 +23,7 @@ from models.utility_functions import (
     profiler,
     disable_compilation_reports,
     skip_for_grayskull,
-    skip_for_wormhole_b0,
+    is_wormhole_b0,
 )
 from models.perf.perf_utils import prep_perf_report
 

--- a/models/demos/t3000/mixtral8x7b/tests/test_mixtral_attention.py
+++ b/models/demos/t3000/mixtral8x7b/tests/test_mixtral_attention.py
@@ -15,7 +15,7 @@ from models.demos.t3000.mixtral8x7b.tt.model_config import TtModelArgs
 from models.utility_functions import (
     comp_pcc,
     comp_allclose,
-    skip_for_wormhole_b0,
+    is_wormhole_b0,
 )
 
 

--- a/models/demos/t3000/mixtral8x7b/tests/test_mixtral_mlp.py
+++ b/models/demos/t3000/mixtral8x7b/tests/test_mixtral_mlp.py
@@ -14,7 +14,7 @@ from models.demos.t3000.mixtral8x7b.tt.model_config import TtModelArgs
 from models.utility_functions import (
     comp_pcc,
     comp_allclose,
-    skip_for_wormhole_b0,
+    is_wormhole_b0,
 )
 
 

--- a/models/demos/t3000/mixtral8x7b/tests/test_mixtral_rms_norm.py
+++ b/models/demos/t3000/mixtral8x7b/tests/test_mixtral_rms_norm.py
@@ -15,7 +15,7 @@ from models.demos.t3000.mixtral8x7b.tt.model_config import TtModelArgs
 from models.utility_functions import (
     comp_pcc,
     comp_allclose,
-    skip_for_wormhole_b0,
+    is_wormhole_b0,
 )
 
 

--- a/models/demos/ttnn_falcon7b/tests/test_perf_falcon.py
+++ b/models/demos/ttnn_falcon7b/tests/test_perf_falcon.py
@@ -34,7 +34,8 @@ from models.utility_functions import (
     disable_compilation_reports,
     is_e75,
     is_wormhole_b0,
-    skip_for_wormhole_b0,
+    is_wormhole_b0,
+    is_blackhole,
 )
 from models.perf.perf_utils import prep_perf_report
 import ttnn
@@ -354,7 +355,7 @@ def run_test_FalconCausalLM_end_to_end(
             assert does_pass, f"PCC value is lower than {pcc}"
 
 
-@skip_for_wormhole_b0(reason_str="Does not run on single WH")
+@pytest.mark.skipif(is_wormhole_b0() or is_blackhole(), reason="Does not run on single WH")
 @pytest.mark.models_performance_bare_metal
 @pytest.mark.parametrize(
     "llm_mode, batch, seq_len, kv_cache_len, expected_inference_time",

--- a/models/experimental/bloom/tests/test_bloom_block.py
+++ b/models/experimental/bloom/tests/test_bloom_block.py
@@ -12,7 +12,7 @@ from tests.tt_eager.python_api_testing.sweep_tests.comparison_funcs import (
 from loguru import logger
 import models.experimental.bloom.bloom_utils as bloom_utils
 import models.experimental.bloom.tt.bloom_block as bloom_block
-from models.utility_functions import skip_for_wormhole_b0
+from models.utility_functions import is_wormhole_b0, is_blackhole
 
 
 def run_bloom_block_test(device):
@@ -61,6 +61,6 @@ def run_bloom_block_test(device):
     assert do_all_blocks_pass
 
 
-@skip_for_wormhole_b0()
+@pytest.mark.skipif(is_wormhole_b0() or is_blackhole(), reason="Unsupported on WH and BH")
 def test_bloom_block(device):
     run_bloom_block_test(device)

--- a/models/experimental/bloom/tests/test_bloom_causal_lm.py
+++ b/models/experimental/bloom/tests/test_bloom_causal_lm.py
@@ -12,10 +12,10 @@ from tests.tt_eager.python_api_testing.sweep_tests.comparison_funcs import (
 
 from loguru import logger
 import models.experimental.bloom.tt.bloom_causal_lm as bloom_causal_lm
-from models.utility_functions import skip_for_wormhole_b0
+from models.utility_functions import is_wormhole_b0, is_blackhole
 
 
-@skip_for_wormhole_b0()
+@pytest.mark.skipif(is_wormhole_b0() or is_blackhole(), reason="Unsupported on WH and BH")
 def test_bloom_causal_lm(device):
     hugging_bloom_reference_model = BloomForCausalLM.from_pretrained("bigscience/bloom-560m", torchscript=False)
     hugging_bloom_reference_model.eval()

--- a/models/experimental/bloom/tests/test_bloom_model.py
+++ b/models/experimental/bloom/tests/test_bloom_model.py
@@ -14,7 +14,7 @@ from loguru import logger
 
 import models.experimental.bloom.bloom_utils as bloom_utils
 import models.experimental.bloom.tt.bloom_model as bloom_model
-from models.utility_functions import skip_for_wormhole_b0
+from models.utility_functions import is_wormhole_b0, is_blackhole
 
 
 def run_bloom_model_test(device):
@@ -54,6 +54,6 @@ def run_bloom_model_test(device):
     assert does_pass
 
 
-@skip_for_wormhole_b0()
+@pytest.mark.skipif(is_wormhole_b0() or is_blackhole(), reason="Unsupported on WH and BH")
 def test_bloom_model(device):
     run_bloom_model_test(device)

--- a/models/experimental/mnist/tests/test_mnist.py
+++ b/models/experimental/mnist/tests/test_mnist.py
@@ -12,12 +12,13 @@ from models.utility_functions import (
     torch2tt_tensor,
     tt2torch_tensor,
     comp_pcc,
-    skip_for_wormhole_b0,
+    is_wormhole_b0,
+    is_blackhole,
 )
 from models.experimental.mnist.tt.mnist_model import mnist_model
 
 
-@skip_for_wormhole_b0()
+@pytest.mark.skipif(is_wormhole_b0() or is_blackhole(), reason="Unsupported on WH and BH")
 def test_mnist_inference(device, model_location_generator):
     # Data preprocessing/loading
     transform = transforms.Compose([transforms.ToTensor()])

--- a/models/experimental/nanogpt/tests/test_nanogpt_attention.py
+++ b/models/experimental/nanogpt/tests/test_nanogpt_attention.py
@@ -19,11 +19,12 @@ from models.utility_functions import (
     torch_to_tt_tensor_rm,
     comp_allclose,
     comp_pcc,
-    skip_for_wormhole_b0,
+    is_wormhole_b0,
+    is_blackhole,
 )
 
 
-@skip_for_wormhole_b0()
+@pytest.mark.skipif(is_wormhole_b0() or is_blackhole(), reason="Unsupported on WH and BH")
 @pytest.mark.skip(reason="Test is hanging gs, see issue #7534")
 @pytest.mark.parametrize(
     "dtype",

--- a/models/experimental/nanogpt/tests/test_nanogpt_block.py
+++ b/models/experimental/nanogpt/tests/test_nanogpt_block.py
@@ -19,11 +19,12 @@ from models.utility_functions import (
     torch_to_tt_tensor_rm,
     comp_allclose,
     comp_pcc,
-    skip_for_wormhole_b0,
+    is_wormhole_b0,
+    is_blackhole,
 )
 
 
-@skip_for_wormhole_b0()
+@pytest.mark.skipif(is_wormhole_b0() or is_blackhole(), reason="Unsupported on WH and BH")
 @pytest.mark.skip(reason="Test is hanging gs, see issue #7534")
 @pytest.mark.parametrize(
     "dtype",

--- a/models/experimental/nanogpt/tests/test_nanogpt_mlp.py
+++ b/models/experimental/nanogpt/tests/test_nanogpt_mlp.py
@@ -20,7 +20,8 @@ from models.utility_functions import (
     torch_to_tt_tensor_rm,
     comp_allclose,
     comp_pcc,
-    skip_for_wormhole_b0,
+    is_wormhole_b0,
+    is_blackhole,
 )
 
 
@@ -32,7 +33,7 @@ from models.utility_functions import (
     "pcc",
     ((0.99,),),
 )
-@skip_for_wormhole_b0()
+@pytest.mark.skipif(is_wormhole_b0() or is_blackhole(), reason="Unsupported on WH and BH")
 def test_nanogpt_mlp(device, pcc, dtype, reset_seeds):
     model_hf = GPT2LMHeadModel.from_pretrained("gpt2")
     config = model_hf.config

--- a/models/experimental/nanogpt/tests/test_nanogpt_model.py
+++ b/models/experimental/nanogpt/tests/test_nanogpt_model.py
@@ -13,10 +13,10 @@ import os
 from loguru import logger
 import models.experimental.nanogpt.tt.nanogpt_model as nanogpt_model
 
-from models.utility_functions import tt_to_torch_tensor, comp_allclose, comp_pcc, skip_for_wormhole_b0
+from models.utility_functions import tt_to_torch_tensor, comp_allclose, comp_pcc, is_wormhole_b0, is_blackhole
 
 
-@skip_for_wormhole_b0()
+@pytest.mark.skipif(is_wormhole_b0() or is_blackhole(), reason="Unsupported on WH and BH")
 @pytest.mark.skip(reason="Test is failing gs, see issue #7534")
 @pytest.mark.parametrize(
     "dtype",

--- a/models/experimental/roberta/tests/test_roberta_encoder.py
+++ b/models/experimental/roberta/tests/test_roberta_encoder.py
@@ -10,11 +10,11 @@ from transformers import RobertaModel
 import pytest
 
 from models.experimental.roberta.tt.roberta_encoder import TtRobertaEncoder
-from models.utility_functions import tt2torch_tensor, comp_allclose, comp_pcc, skip_for_wormhole_b0
+from models.utility_functions import tt2torch_tensor, comp_allclose, comp_pcc, is_wormhole_b0, is_blackhole
 from models.experimental.roberta.roberta_common import torch2tt_tensor
 
 
-@skip_for_wormhole_b0()
+@pytest.mark.skipif(is_wormhole_b0() or is_blackhole(), reason="Unsupported on WH and BH")
 def test_roberta_encoder_inference(device):
     torch.manual_seed(1234)
     base_address = f"encoder"

--- a/models/experimental/roberta/tests/test_roberta_for_masked_lm.py
+++ b/models/experimental/roberta/tests/test_roberta_for_masked_lm.py
@@ -14,12 +14,13 @@ from models.utility_functions import (
     tt2torch_tensor,
     comp_allclose,
     comp_pcc,
-    skip_for_wormhole_b0,
+    is_wormhole_b0,
+    is_blackhole,
 )
 from models.experimental.roberta.roberta_common import torch2tt_tensor
 
 
-@skip_for_wormhole_b0()
+@pytest.mark.skipif(is_wormhole_b0() or is_blackhole(), reason="Unsupported on WH and BH")
 def test_roberta_masked_lm_inference(device):
     torch.manual_seed(1234)
     base_address = f""

--- a/models/experimental/roberta/tests/test_roberta_for_multiple_choice.py
+++ b/models/experimental/roberta/tests/test_roberta_for_multiple_choice.py
@@ -14,12 +14,13 @@ from models.utility_functions import (
     tt2torch_tensor,
     comp_allclose,
     comp_pcc,
-    skip_for_wormhole_b0,
+    is_wormhole_b0,
+    is_blackhole,
 )
 from models.experimental.roberta.roberta_common import torch2tt_tensor
 
 
-@skip_for_wormhole_b0()
+@pytest.mark.skipif(is_wormhole_b0() or is_blackhole(), reason="Unsupported on WH and BH")
 @pytest.mark.skip(reason="Mismatch happening on GS, issue #5943")
 def test_roberta_for_multiple_choice(device):
     """

--- a/models/experimental/roberta/tests/test_roberta_for_qa.py
+++ b/models/experimental/roberta/tests/test_roberta_for_qa.py
@@ -10,11 +10,11 @@ from transformers import AutoTokenizer, RobertaForQuestionAnswering
 import pytest
 
 from models.experimental.roberta.tt.roberta_for_question_answering import TtRobertaForQuestionAnswering
-from models.utility_functions import comp_allclose, comp_pcc, skip_for_wormhole_b0
+from models.utility_functions import comp_allclose, comp_pcc, is_wormhole_b0, is_blackhole
 from models.experimental.roberta.roberta_common import torch2tt_tensor
 
 
-@skip_for_wormhole_b0()
+@pytest.mark.skipif(is_wormhole_b0() or is_blackhole(), reason="Unsupported on WH and BH")
 def test_roberta_qa_inference(device):
     torch.manual_seed(1234)
 

--- a/models/experimental/roberta/tests/test_roberta_for_sequence_classification.py
+++ b/models/experimental/roberta/tests/test_roberta_for_sequence_classification.py
@@ -14,12 +14,13 @@ from models.utility_functions import (
     tt2torch_tensor,
     comp_allclose,
     comp_pcc,
-    skip_for_wormhole_b0,
+    is_wormhole_b0,
+    is_blackhole,
 )
 from models.experimental.roberta.roberta_common import torch2tt_tensor
 
 
-@skip_for_wormhole_b0()
+@pytest.mark.skipif(is_wormhole_b0() or is_blackhole(), reason="Unsupported on WH and BH")
 def test_roberta_for_sequence_classification(device):
     torch.manual_seed(1234)
     base_address = ""

--- a/models/experimental/roberta/tests/test_roberta_for_token_classification.py
+++ b/models/experimental/roberta/tests/test_roberta_for_token_classification.py
@@ -14,12 +14,13 @@ from models.utility_functions import (
     tt2torch_tensor,
     comp_allclose,
     comp_pcc,
-    skip_for_wormhole_b0,
+    is_wormhole_b0,
+    is_blackhole,
 )
 from models.experimental.roberta.roberta_common import torch2tt_tensor
 
 
-@skip_for_wormhole_b0()
+@pytest.mark.skipif(is_wormhole_b0() or is_blackhole(), reason="Unsupported on WH and BH")
 @pytest.mark.skip(reason="Test is failing. see issue #7533")
 def test_roberta_for_token_classification(device):
     torch.manual_seed(1234)

--- a/models/experimental/roberta/tests/test_roberta_layer.py
+++ b/models/experimental/roberta/tests/test_roberta_layer.py
@@ -14,12 +14,13 @@ from models.utility_functions import (
     tt2torch_tensor,
     comp_allclose,
     comp_pcc,
-    skip_for_wormhole_b0,
+    is_wormhole_b0,
+    is_blackhole,
 )
 from models.experimental.roberta.roberta_common import torch2tt_tensor
 
 
-@skip_for_wormhole_b0()
+@pytest.mark.skipif(is_wormhole_b0() or is_blackhole(), reason="Unsupported on WH and BH")
 def test_roberta_layer_inference(device):
     torch.manual_seed(1234)
 

--- a/models/experimental/roberta/tests/test_roberta_model.py
+++ b/models/experimental/roberta/tests/test_roberta_model.py
@@ -14,12 +14,13 @@ from models.utility_functions import (
     tt2torch_tensor,
     comp_allclose,
     comp_pcc,
-    skip_for_wormhole_b0,
+    is_wormhole_b0,
+    is_blackhole,
 )
 from models.experimental.roberta.roberta_common import torch2tt_tensor
 
 
-@skip_for_wormhole_b0()
+@pytest.mark.skipif(is_wormhole_b0() or is_blackhole(), reason="Unsupported on WH and BH")
 def test_roberta_model_inference(device):
     torch.manual_seed(1234)
 

--- a/models/experimental/stable_diffusion/tests/test_cross_attn_down_block.py
+++ b/models/experimental/stable_diffusion/tests/test_cross_attn_down_block.py
@@ -21,13 +21,14 @@ from models.utility_functions import (
 from models.utility_functions import (
     comp_pcc,
     comp_allclose_and_pcc,
-    skip_for_wormhole_b0,
+    is_wormhole_b0,
+    is_blackhole,
 )
 from models.experimental.stable_diffusion.tt.unet_2d_blocks import TtCrossAttnDownBlock2D
 from models.experimental.stable_diffusion.tt.experimental_ops import UseDeviceConv
 
 
-@skip_for_wormhole_b0()
+@pytest.mark.skipif(is_wormhole_b0() or is_blackhole(), reason="Unsupported on WH and BH")
 @pytest.mark.skip(reason="Test is failing, see issue #7536")
 @pytest.mark.parametrize("index", [1])  # FIXME: failing 0, 2 with L1 error.
 def test_run_cross_attn_down_block_real_input_inference(device, index, model_location_generator):

--- a/models/experimental/stable_diffusion/tests/test_cross_attn_up_block.py
+++ b/models/experimental/stable_diffusion/tests/test_cross_attn_up_block.py
@@ -16,7 +16,8 @@ from models.utility_functions import (
     torch_to_tt_tensor,
     tt_to_torch_tensor,
     torch_to_tt_tensor_rm,
-    skip_for_wormhole_b0,
+    is_wormhole_b0,
+    is_blackhole,
 )
 from models.utility_functions import comp_pcc, comp_allclose_and_pcc
 from models.experimental.stable_diffusion.tt.unet_2d_blocks import TtCrossAttnUpBlock2D
@@ -24,7 +25,7 @@ from models.experimental.stable_diffusion.tt.experimental_ops import UseDeviceCo
 
 
 # low PCC for value 2, 3: 0.9851282356324425 etc.
-@skip_for_wormhole_b0()
+@pytest.mark.skipif(is_wormhole_b0() or is_blackhole(), reason="Unsupported on WH and BH")
 @pytest.mark.skip(reason="Test is failing, see issue #7536")
 @pytest.mark.parametrize("index", [1, 2, 3])
 def test_run_cross_attn_up_block_real_input_inference(device, index, model_location_generator):

--- a/models/experimental/stable_diffusion/tests/test_downblock_2d.py
+++ b/models/experimental/stable_diffusion/tests/test_downblock_2d.py
@@ -17,13 +17,14 @@ from models.utility_functions import (
     torch_to_tt_tensor,
     tt_to_torch_tensor,
     torch_to_tt_tensor_rm,
-    skip_for_wormhole_b0,
+    is_wormhole_b0,
+    is_blackhole,
 )
 from models.utility_functions import comp_pcc, comp_allclose_and_pcc
 from models.experimental.stable_diffusion.tt.downblock_2d import TtDownBlock2D
 
 
-@skip_for_wormhole_b0()
+@pytest.mark.skipif(is_wormhole_b0() or is_blackhole(), reason="Unsupported on WH and BH")
 def test_run_downblock_real_input_inference(device, model_location_generator):
     # setup pytorch model
     pipe = StableDiffusionPipeline.from_pretrained("CompVis/stable-diffusion-v1-4", torch_dtype=torch.float32)

--- a/models/experimental/stable_diffusion/tests/test_unbatched_stable_diffusion.py
+++ b/models/experimental/stable_diffusion/tests/test_unbatched_stable_diffusion.py
@@ -18,7 +18,8 @@ from models.utility_functions import (
     disable_persistent_kernel_cache,
     torch_to_tt_tensor_rm,
     tt_to_torch_tensor,
-    skip_for_wormhole_b0,
+    is_wormhole_b0,
+    is_blackhole,
 )
 import ttnn
 from models.experimental.stable_diffusion.tt.unet_2d_condition import (
@@ -93,7 +94,7 @@ def make_tt_unet(state_dict, device):
     return tt_unet
 
 
-@skip_for_wormhole_b0()
+@pytest.mark.skipif(is_wormhole_b0() or is_blackhole(), reason="Unsupported on WH and BH")
 @pytest.mark.skip(reason="Test is failing., see issue #7536")
 def test_unbatched_stable_diffusion(device):
     # 1. Load the autoencoder model which will be used to decode the latents into image space.

--- a/models/experimental/stable_diffusion/tests/test_unet_mid_block.py
+++ b/models/experimental/stable_diffusion/tests/test_unet_mid_block.py
@@ -10,7 +10,8 @@ from models.utility_functions import (
     torch_to_tt_tensor,
     tt_to_torch_tensor,
     torch_to_tt_tensor_rm,
-    skip_for_wormhole_b0,
+    is_wormhole_b0,
+    is_blackhole,
 )
 from models.utility_functions import comp_pcc, comp_allclose_and_pcc
 from models.experimental.stable_diffusion.tt.unet_2d_blocks import TtUNetMidBlock2DCrossAttn
@@ -18,7 +19,7 @@ from loguru import logger
 import pytest
 
 
-@skip_for_wormhole_b0()
+@pytest.mark.skipif(is_wormhole_b0() or is_blackhole(), reason="Unsupported on WH and BH")
 @pytest.mark.skip(reason="Test is failing, see issue #7536")
 def test_run_unet_mid_block_real_input_inference(device, model_location_generator):
     # setup pytorch model

--- a/models/experimental/stable_diffusion/tests/test_upblock_2d.py
+++ b/models/experimental/stable_diffusion/tests/test_upblock_2d.py
@@ -12,14 +12,15 @@ from models.utility_functions import (
     torch_to_tt_tensor,
     tt_to_torch_tensor,
     torch_to_tt_tensor_rm,
-    skip_for_wormhole_b0,
+    is_wormhole_b0,
+    is_blackhole,
 )
 from models.utility_functions import comp_pcc, comp_allclose_and_pcc
 from models.experimental.stable_diffusion.tt.upblock_2d import TtUpBlock2D
 import pytest
 
 
-@skip_for_wormhole_b0()
+@pytest.mark.skipif(is_wormhole_b0() or is_blackhole(), reason="Unsupported on WH and BH")
 def test_run_upblock_real_input_inference(device, model_location_generator):
     # setup pytorch model
     pipe = StableDiffusionPipeline.from_pretrained("CompVis/stable-diffusion-v1-4", torch_dtype=torch.float32)

--- a/models/experimental/whisper/tests/test_whisper_decoder.py
+++ b/models/experimental/whisper/tests/test_whisper_decoder.py
@@ -14,7 +14,8 @@ from models.utility_functions import (
     torch2tt_tensor,
     tt2torch_tensor,
     comp_pcc,
-    skip_for_wormhole_b0,
+    is_wormhole_b0,
+    is_blackhole,
 )
 
 
@@ -91,7 +92,7 @@ def run_whisper_decoder(device):
     assert does_pass
 
 
-@skip_for_wormhole_b0()
+@pytest.mark.skipif(is_wormhole_b0() or is_blackhole(), reason="Unsupported on WH and BH")
 def test_WhipserDecoder_inference(device):
     torch.manual_seed(1234)
     run_whisper_decoder(device=device)

--- a/models/experimental/whisper/tests/test_whisper_encoder.py
+++ b/models/experimental/whisper/tests/test_whisper_encoder.py
@@ -14,7 +14,7 @@ from transformers import (
 
 import ttnn
 import pytest
-from models.utility_functions import skip_for_wormhole_b0
+from models.utility_functions import is_wormhole_b0, is_blackhole
 
 from models.utility_functions import (
     torch2tt_tensor,
@@ -111,7 +111,7 @@ def run_whisper_encoder(device, for_audio_classification=False, encoder_layers=1
         assert does_pass
 
 
-@skip_for_wormhole_b0()
+@pytest.mark.skipif(is_wormhole_b0() or is_blackhole(), reason="Unsupported on WH and BH")
 def test_WhipserEncoder_inference(device):
     torch.manual_seed(1234)
     run_whisper_encoder(device=device, for_audio_classification=False)

--- a/models/experimental/whisper/tests/test_whisper_for_audio_classification.py
+++ b/models/experimental/whisper/tests/test_whisper_for_audio_classification.py
@@ -18,7 +18,8 @@ from models.utility_functions import (
     torch2tt_tensor,
     tt2torch_tensor,
     comp_pcc,
-    skip_for_wormhole_b0,
+    is_wormhole_b0,
+    is_blackhole,
 )
 
 
@@ -86,7 +87,7 @@ def run_whisper_for_audio_classification(device):
         assert does_pass
 
 
-@skip_for_wormhole_b0()
+@pytest.mark.skipif(is_wormhole_b0() or is_blackhole(), reason="Unsupported on WH and BH")
 def test_WhipserForAudioClassification_inference(device):
     torch.manual_seed(1234)
     run_whisper_for_audio_classification(device=device)

--- a/models/experimental/whisper/tests/test_whisper_for_conditional_generation.py
+++ b/models/experimental/whisper/tests/test_whisper_for_conditional_generation.py
@@ -46,7 +46,8 @@ from models.utility_functions import (
     comp_pcc,
     torch2tt_tensor,
     tt2torch_tensor,
-    skip_for_wormhole_b0,
+    is_wormhole_b0,
+    is_blackhole,
 )
 
 
@@ -441,7 +442,7 @@ def run_generate(sample, device):
         return tt_transcription
 
 
-@skip_for_wormhole_b0()
+@pytest.mark.skipif(is_wormhole_b0() or is_blackhole(), reason="Unsupported on WH and BH")
 def test_WhipserForConditionalGeneration_inference(device):
     torch.manual_seed(1234)
 

--- a/models/experimental/whisper/tests/test_whisper_model.py
+++ b/models/experimental/whisper/tests/test_whisper_model.py
@@ -16,7 +16,8 @@ from models.utility_functions import (
     comp_pcc,
     torch2tt_tensor,
     tt2torch_tensor,
-    skip_for_wormhole_b0,
+    is_wormhole_b0,
+    is_blackhole,
 )
 
 
@@ -94,7 +95,7 @@ def run_whisper_model(device):
     assert does_pass
 
 
-@skip_for_wormhole_b0()
+@pytest.mark.skipif(is_wormhole_b0() or is_blackhole(), reason="Unsupported on WH and BH")
 def test_WhipserModel_inference(device):
     torch.manual_seed(1234)
     run_whisper_model(device=device)

--- a/models/utility_functions.py
+++ b/models/utility_functions.py
@@ -940,6 +940,10 @@ def is_grayskull():
     return "grayskull" in ARCH_NAME
 
 
+def skip_for_blackhole(reason_str="not working for Blackhole"):
+    return pytest.mark.skipif(is_blackhole(), reason=reason_str)
+
+
 def skip_for_wormhole_b0(reason_str="not working for Wormhole B0"):
     return pytest.mark.skipif(is_wormhole_b0(), reason=reason_str)
 

--- a/tests/tt_eager/ops_device_perf/run_op_profiling.py
+++ b/tests/tt_eager/ops_device_perf/run_op_profiling.py
@@ -10,7 +10,7 @@ import pytest
 
 from tt_metal.tools.profiler.process_model_log import run_device_profiler, post_process_ops_log
 
-from models.utility_functions import skip_for_wormhole_b0
+from models.utility_functions import is_wormhole_b0, is_blackhole
 
 from tt_metal.tools.profiler.common import PROFILER_LOGS_DIR, PROFILER_DEVICE_SIDE_LOG
 
@@ -135,7 +135,7 @@ def run_op_test():
         assert is_within_range
 
 
-@skip_for_wormhole_b0()
+@pytest.mark.skipif(is_wormhole_b0() or is_blackhole(), reason="Unsupported on WH and BH")
 @pytest.mark.models_device_performance_bare_metal
 def test_run_op_test():
     run_op_test()

--- a/tests/tt_eager/python_api_testing/sweep_tests/pytests/tt_dnn/test_layernorm_sharded.py
+++ b/tests/tt_eager/python_api_testing/sweep_tests/pytests/tt_dnn/test_layernorm_sharded.py
@@ -20,7 +20,7 @@ from tests.tt_eager.python_api_testing.sweep_tests.comparison_funcs import (
     comp_equal,
     comp_pcc,
 )
-from models.utility_functions import is_wormhole_b0, skip_for_wormhole_b0, skip_for_grayskull
+from models.utility_functions import is_wormhole_b0, is_wormhole_b0, skip_for_grayskull, is_blackhole
 from models.utility_functions import torch2tt_tensor, tt2torch_tensor, pad_by_zero
 
 
@@ -36,7 +36,7 @@ seq_lens = [32, 256, 384]
 per_core_ks = [32, 64, 128]
 
 
-@skip_for_wormhole_b0()
+@pytest.mark.skipif(is_wormhole_b0() or is_blackhole(), reason="Unsupported on WH and BH")
 @pytest.mark.parametrize(
     "grid_size",
     grid_sizes,
@@ -186,7 +186,7 @@ seq_lens = [32, 256, 384]
 per_core_ks = [32, 64, 128]
 
 
-@skip_for_wormhole_b0()
+@pytest.mark.skipif(is_wormhole_b0() or is_blackhole(), reason="Unsupported on WH and BH")
 @pytest.mark.parametrize(
     "grid_size",
     grid_sizes,

--- a/tests/tt_eager/python_api_testing/sweep_tests/pytests/tt_dnn/test_softmax_sharded.py
+++ b/tests/tt_eager/python_api_testing/sweep_tests/pytests/tt_dnn/test_softmax_sharded.py
@@ -18,7 +18,7 @@ from tt_lib.utils import (
 )
 from models.utility_functions import print_diff_argmax, comp_pcc
 from models.utility_functions import torch2tt_tensor, tt2torch_tensor, pad_by_zero
-from models.utility_functions import skip_for_wormhole_b0
+from models.utility_functions import is_wormhole_b0, is_blackhole
 
 # only use certain tests for CI to reduce run time
 # grid_sizes = [(i, j) for i in range(1, 13) for j in range(1, 9)] # (1,1) to (12,8)
@@ -27,7 +27,7 @@ grid_sizes = [[1, 1], [1, 8], [12, 1], [12, 8]]
 seq_lens = [32, 64, 256, 384, 512]
 
 
-@skip_for_wormhole_b0()
+@pytest.mark.skipif(is_wormhole_b0() or is_blackhole(), reason="Unsupported on WH and BH")
 @pytest.mark.parametrize(
     "scale_mask",
     [True, False],

--- a/tests/tt_eager/python_api_testing/trace_testing/misc/test_bert_ops.py
+++ b/tests/tt_eager/python_api_testing/trace_testing/misc/test_bert_ops.py
@@ -11,12 +11,12 @@ import ttnn
 from tests.tt_eager.python_api_testing.sweep_tests.comparison_funcs import (
     comp_pcc,
 )
-from models.utility_functions import is_wormhole_b0, is_grayskull, skip_for_wormhole_b0
+from models.utility_functions import is_wormhole_b0, is_grayskull, is_wormhole_b0, is_blackhole
 from loguru import logger
 from models.utility_functions import torch2tt_tensor, tt2torch_tensor, pad_by_zero
 
 
-@pytest.mark.skipif(is_wormhole_b0(), reason="Unsupported parallelizations for WH B0")
+@pytest.mark.skipif(is_wormhole_b0() or is_blackhole(), reason="Unsupported parallelizations for WH B0 and BH")
 @pytest.mark.parametrize("fidelity", [ttnn.MathFidelity.LoFi, ttnn.MathFidelity.HiFi2], ids=["LoFi", "HiFi2"])
 @pytest.mark.parametrize(
     "in1_in_dram, out_sharded, in0_sharded, M, K, N, activation",

--- a/tests/tt_eager/python_api_testing/unit_testing/misc/test_bert_ops.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/misc/test_bert_ops.py
@@ -15,12 +15,12 @@ from tests.tt_eager.python_api_testing.sweep_tests.comparison_funcs import (
     comp_equal,
     comp_pcc,
 )
-from models.utility_functions import is_wormhole_b0, is_grayskull, skip_for_wormhole_b0
+from models.utility_functions import is_wormhole_b0, is_grayskull, is_wormhole_b0, is_blackhole, is_blackhole
 from loguru import logger
 from models.utility_functions import torch2tt_tensor, tt2torch_tensor, pad_by_zero
 
 
-@pytest.mark.skipif(is_wormhole_b0(), reason="Unsupported parallelizations for WH B0")
+@pytest.mark.skipif(is_wormhole_b0() or is_blackhole(), reason="Unsupported parallelizations for WH B0 or BH")
 @pytest.mark.parametrize("fidelity", [ttnn.MathFidelity.LoFi, ttnn.MathFidelity.HiFi2], ids=["LoFi", "HiFi2"])
 @pytest.mark.parametrize("has_bias", [True, False], ids=["bias", "no_bias"])
 @pytest.mark.parametrize(
@@ -270,7 +270,7 @@ def test_bert_linear(
         (True, False, False, 2688, 4096, 1024, None),
     ],
 )
-@skip_for_wormhole_b0("WH ND hang, see issue #4392")
+@pytest.mark.skipif(is_wormhole_b0() or is_blackhole(), reason="WH ND hang, see issue #4392")
 def test_bert_linear_batch7(
     device,
     fidelity,

--- a/tests/tt_eager/python_api_testing/unit_testing/misc/test_layernorm_sharded.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/misc/test_layernorm_sharded.py
@@ -13,14 +13,14 @@ import math
 from tests.tt_eager.python_api_testing.sweep_tests.comparison_funcs import (
     comp_pcc,
 )
-from models.utility_functions import torch2tt_tensor, skip_for_wormhole_b0, is_grayskull
+from models.utility_functions import torch2tt_tensor, is_wormhole_b0, is_grayskull
 
 
 def rms_norm(x, dim, gamma, beta, eps):
     return x * torch.rsqrt(x.pow(2).mean([-i for i in range(1, len(dim) + 1)], keepdim=True) + eps) * gamma + beta
 
 
-# @skip_for_wormhole_b0()
+# @pytest.mark.skipif(is_wormhole_b0() or is_blackhole(), reason="Unsupported on WH and BH")
 @pytest.mark.parametrize(
     "out_mem_config",
     (ttnn.MemoryConfig(ttnn.TensorMemoryLayout.BLOCK_SHARDED, ttnn.BufferType.L1),),

--- a/tests/tt_eager/python_api_testing/unit_testing/misc/test_matmul_1d_2d.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/misc/test_matmul_1d_2d.py
@@ -32,10 +32,10 @@ def find_max_subblock(out_block_h, out_block_w):
     return best_h, best_w, max_product
 
 
-from models.utility_functions import is_wormhole_b0, is_grayskull, skip_for_wormhole_b0
+from models.utility_functions import is_wormhole_b0, is_grayskull, is_wormhole_b0, is_blackhole
 
 
-@skip_for_wormhole_b0()
+@pytest.mark.skipif(is_wormhole_b0() or is_blackhole(), reason="Unsupported on WH and BH")
 @pytest.mark.skipif(is_grayskull(), reason="no llama2 test on GS")
 @pytest.mark.parametrize(
     "packer_l1_acc",
@@ -172,7 +172,7 @@ def test_llama2_matmul(
     assert passing
 
 
-@skip_for_wormhole_b0()
+@pytest.mark.skipif(is_wormhole_b0() or is_blackhole(), reason="Unsupported on WH and BH")
 @pytest.mark.skipif(is_grayskull(), reason="GS does not support fp32")
 @pytest.mark.parametrize("has_bias", [False], ids=["no_bias"])
 @pytest.mark.parametrize(
@@ -502,7 +502,7 @@ def test_multi_core_matmul_2d_wh(
     assert passing
 
 
-@skip_for_wormhole_b0()
+@pytest.mark.skipif(is_wormhole_b0() or is_blackhole(), reason="Unsupported on WH and BH")
 @pytest.mark.skipif(is_grayskull(), reason="GS does not support fp32")
 @pytest.mark.parametrize("has_bias", [False], ids=["no_bias"])
 @pytest.mark.parametrize(
@@ -824,7 +824,7 @@ def test_multi_core_matmul_1d_wh(
     assert passing
 
 
-@skip_for_wormhole_b0()
+@pytest.mark.skipif(is_wormhole_b0() or is_blackhole(), reason="Unsupported on WH and BH")
 @pytest.mark.parametrize("has_bias", [False], ids=["no_bias"])
 @pytest.mark.parametrize(
     "in1_in_dram, out_sharded, in0_sharded, M, K, N, activation, dtype, fidelity",
@@ -1040,7 +1040,7 @@ def test_multi_core_matmul_2d_gs(
     assert passing
 
 
-@skip_for_wormhole_b0()
+@pytest.mark.skipif(is_wormhole_b0() or is_blackhole(), reason="Unsupported on WH and BH")
 @pytest.mark.parametrize("has_bias", [False], ids=["no_bias"])
 @pytest.mark.parametrize(
     "in1_in_dram, out_sharded, in0_sharded, M, K, N, activation, dtype, fidelity",

--- a/tests/tt_eager/python_api_testing/unit_testing/misc/test_moreh_adam.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/misc/test_moreh_adam.py
@@ -8,7 +8,7 @@ import torch.optim as optim
 
 import ttnn
 import pytest
-from models.utility_functions import skip_for_wormhole_b0, comp_allclose_and_pcc, comp_pcc, is_wormhole_b0
+from models.utility_functions import is_wormhole_b0, comp_allclose_and_pcc, comp_pcc, is_wormhole_b0
 from loguru import logger
 from tests.tt_eager.python_api_testing.unit_testing.misc.test_utils import (
     get_compute_kernel_options,

--- a/tests/tt_eager/python_api_testing/unit_testing/misc/test_moreh_adamw.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/misc/test_moreh_adamw.py
@@ -10,7 +10,7 @@ import ttnn
 import ttnn
 import pytest
 from models.utility_functions import (
-    skip_for_wormhole_b0,
+    is_wormhole_b0,
     comp_allclose_and_pcc,
     comp_pcc,
     comp_allclose,

--- a/tests/tt_eager/python_api_testing/unit_testing/misc/test_moreh_clip_grad_norm.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/misc/test_moreh_clip_grad_norm.py
@@ -114,7 +114,7 @@ def test_moreh_clip_grad_norm(
             assert pass_input_i
 
 
-# @skip_for_wormhole_b0()
+# @pytest.mark.skipif(is_wormhole_b0() or is_blackhole(), reason="Unsupported on WH and BH")
 # @pytest.mark.parametrize("error_if_nonfinite", [True, False])
 # def test_moreh_clip_grad_norm_with_error_if_nonfinite(error_if_nonfinite, device):
 #     torch.manual_seed(2023)

--- a/tests/tt_eager/python_api_testing/unit_testing/misc/test_move_sharded.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/misc/test_move_sharded.py
@@ -7,7 +7,7 @@ from loguru import logger
 
 
 import ttnn
-from models.utility_functions import comp_pcc, skip_for_wormhole_b0
+from models.utility_functions import comp_pcc, is_wormhole_b0, is_blackhole
 import torch
 import ttnn
 
@@ -16,7 +16,7 @@ shapes = [
 ]
 
 
-@skip_for_wormhole_b0("disabled due to watcher error, see issue #5863")
+@pytest.mark.skipif(is_wormhole_b0() or is_blackhole(), reason="disabled due to watcher error, see issue #5863")
 @pytest.mark.parametrize("shape", shapes)
 def test_move_op(shape, device):
     run_move_op(shape, device)

--- a/tests/tt_eager/python_api_testing/unit_testing/misc/test_sharded.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/misc/test_sharded.py
@@ -11,7 +11,7 @@ from tests.tt_eager.python_api_testing.sweep_tests.comparison_funcs import (
     comp_equal,
     comp_pcc,
 )
-from models.utility_functions import is_wormhole_b0, skip_for_wormhole_b0
+from models.utility_functions import is_wormhole_b0, is_wormhole_b0, is_blackhole
 from loguru import logger
 from models.utility_functions import torch2tt_tensor, tt2torch_tensor, pad_by_zero, roundup32
 
@@ -319,7 +319,7 @@ def test_sharded_tilize(H, num_cores, output_dtype, device, function_level_defau
     assert passing
 
 
-@skip_for_wormhole_b0("WH ND hang, see issue #4392")
+@pytest.mark.skipif(is_wormhole_b0() or is_blackhole(), reason="WH ND hang, see issue #4392")
 @pytest.mark.parametrize("M", [127 * 32])
 @pytest.mark.parametrize("K", [1 * 32])
 @pytest.mark.parametrize("N", [1 * 32])
@@ -387,7 +387,7 @@ def test_height_sharded_matmul_1d_padding(device, M, K, N, num_cores):
     assert passing
 
 
-@skip_for_wormhole_b0("WH ND hang, see issue #4392")
+@pytest.mark.skipif(is_wormhole_b0() or is_blackhole(), reason="WH ND hang, see issue #4392")
 @pytest.mark.parametrize("in0_sharded", [True, False], ids=["in0_sharded", "in0_unsharded"])
 @pytest.mark.parametrize("out_sharded", [True, False], ids=["out_sharded", "out_unsharded"])
 @pytest.mark.parametrize("M, num_cores", [[25088, 98], [50176, 98]])

--- a/tests/tt_eager/python_api_testing/unit_testing/misc/test_untilize_with_halo_and_max_pool_v2.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/misc/test_untilize_with_halo_and_max_pool_v2.py
@@ -19,7 +19,7 @@ from ttnn.operations.pool import max_pool2d_legacy as ttnn_max_pool2d_legacy
 
 from tt_lib.utils import _nearest_32
 from tests.tt_eager.python_api_testing.sweep_tests.comparison_funcs import comp_pcc
-from models.utility_functions import is_wormhole_b0, skip_for_wormhole_b0, skip_for_grayskull
+from models.utility_functions import is_wormhole_b0, is_wormhole_b0, skip_for_grayskull
 
 
 def volume(shape):

--- a/tests/ttnn/integration_tests/bert/test_performance.py
+++ b/tests/ttnn/integration_tests/bert/test_performance.py
@@ -21,9 +21,10 @@ from models.experimental.functional_common.attention_mask_functions import get_e
 from ttnn.model_preprocessing import preprocess_model_parameters
 
 from models.utility_functions import (
-    skip_for_wormhole_b0,
+    is_wormhole_b0,
     enable_persistent_kernel_cache,
     disable_persistent_kernel_cache,
+    is_blackhole,
 )
 from models.perf.perf_utils import prep_perf_report
 
@@ -63,7 +64,7 @@ def get_expected_times(bert):
     }[bert]
 
 
-@skip_for_wormhole_b0()
+@pytest.mark.skipif(is_wormhole_b0() or is_blackhole(), reason="Unsupported on WH and BH")
 @pytest.mark.models_performance_bare_metal
 @pytest.mark.models_performance_virtual_machine
 @pytest.mark.parametrize("model_name", ["phiyodr/bert-large-finetuned-squad2"])

--- a/tests/ttnn/integration_tests/bert/test_torch_bert.py
+++ b/tests/ttnn/integration_tests/bert/test_torch_bert.py
@@ -10,12 +10,12 @@ import transformers
 from ttnn.model_preprocessing import preprocess_model_parameters
 
 from models.demos.bert.reference import torch_bert
-from models.utility_functions import torch_random, skip_for_wormhole_b0
+from models.utility_functions import torch_random, is_wormhole_b0, is_blackhole
 
 from tests.ttnn.utils_for_testing import assert_with_pcc
 
 
-@skip_for_wormhole_b0()
+@pytest.mark.skipif(is_wormhole_b0() or is_blackhole(), reason="Unsupported on WH and BH")
 @pytest.mark.parametrize("model_name", ["phiyodr/bert-large-finetuned-squad2"])
 @pytest.mark.parametrize("batch_size", [1])
 @pytest.mark.parametrize("sequence_size", [384])
@@ -44,7 +44,7 @@ def test_bert_attention(model_name, batch_size, sequence_size):
     assert_with_pcc(torch_output, output, 0.9999)
 
 
-@skip_for_wormhole_b0()
+@pytest.mark.skipif(is_wormhole_b0() or is_blackhole(), reason="Unsupported on WH and BH")
 @pytest.mark.parametrize("model_name", ["phiyodr/bert-large-finetuned-squad2"])
 @pytest.mark.parametrize("batch_size", [1])
 @pytest.mark.parametrize("sequence_size", [384])
@@ -70,7 +70,7 @@ def test_bert_intermediate(model_name, batch_size, sequence_size):
     assert_with_pcc(torch_output, output, 0.9999)
 
 
-@skip_for_wormhole_b0()
+@pytest.mark.skipif(is_wormhole_b0() or is_blackhole(), reason="Unsupported on WH and BH")
 @pytest.mark.parametrize("model_name", ["phiyodr/bert-large-finetuned-squad2"])
 @pytest.mark.parametrize("batch_size", [1])
 @pytest.mark.parametrize("sequence_size", [384])
@@ -113,7 +113,7 @@ class BertFeedForward(torch.nn.Module):
         return hidden_states
 
 
-@skip_for_wormhole_b0()
+@pytest.mark.skipif(is_wormhole_b0() or is_blackhole(), reason="Unsupported on WH and BH")
 @pytest.mark.parametrize("model_name", ["phiyodr/bert-large-finetuned-squad2"])
 @pytest.mark.parametrize("batch_size", [1])
 @pytest.mark.parametrize("sequence_size", [384])
@@ -140,7 +140,7 @@ def test_bert_feedforward(model_name, batch_size, sequence_size):
     assert_with_pcc(torch_output, output, 0.9999)
 
 
-@skip_for_wormhole_b0()
+@pytest.mark.skipif(is_wormhole_b0() or is_blackhole(), reason="Unsupported on WH and BH")
 @pytest.mark.parametrize("model_name", ["phiyodr/bert-large-finetuned-squad2"])
 @pytest.mark.parametrize("batch_size", [1])
 @pytest.mark.parametrize("sequence_size", [384])
@@ -169,7 +169,7 @@ def test_bert_layer(model_name, batch_size, sequence_size):
     assert_with_pcc(torch_output, output, 0.9999)
 
 
-@skip_for_wormhole_b0()
+@pytest.mark.skipif(is_wormhole_b0() or is_blackhole(), reason="Unsupported on WH and BH")
 @pytest.mark.parametrize("model_name", ["phiyodr/bert-large-finetuned-squad2"])
 @pytest.mark.parametrize("batch_size", [1])
 @pytest.mark.parametrize("sequence_size", [384])
@@ -198,7 +198,7 @@ def test_bert_encoder(model_name, batch_size, sequence_size):
     assert_with_pcc(torch_output, output, 0.9999)
 
 
-@skip_for_wormhole_b0()
+@pytest.mark.skipif(is_wormhole_b0() or is_blackhole(), reason="Unsupported on WH and BH")
 @pytest.mark.parametrize("model_name", ["phiyodr/bert-large-finetuned-squad2"])
 @pytest.mark.parametrize("batch_size", [1])
 @pytest.mark.parametrize("sequence_size", [384])
@@ -236,7 +236,7 @@ def test_bert(model_name, batch_size, sequence_size):
     assert_with_pcc(torch_output, output, 0.9999)
 
 
-@skip_for_wormhole_b0()
+@pytest.mark.skipif(is_wormhole_b0() or is_blackhole(), reason="Unsupported on WH and BH")
 @pytest.mark.parametrize("model_name", ["phiyodr/bert-large-finetuned-squad2"])
 @pytest.mark.parametrize("batch_size", [1])
 @pytest.mark.parametrize("sequence_size", [384])

--- a/tests/ttnn/integration_tests/bert/test_ttnn_bert.py
+++ b/tests/ttnn/integration_tests/bert/test_ttnn_bert.py
@@ -11,12 +11,12 @@ import ttnn
 from ttnn.model_preprocessing import preprocess_model_parameters
 
 from models.demos.bert.tt import ttnn_bert
-from models.utility_functions import torch_random, skip_for_wormhole_b0
+from models.utility_functions import torch_random, is_wormhole_b0, is_blackhole
 
 from tests.ttnn.utils_for_testing import assert_with_pcc
 
 
-@skip_for_wormhole_b0()
+@pytest.mark.skipif(is_wormhole_b0() or is_blackhole(), reason="Unsupported on WH and BH")
 @pytest.mark.parametrize("model_name", ["phiyodr/bert-large-finetuned-squad2"])
 @pytest.mark.parametrize("batch_size", [1])
 @pytest.mark.parametrize("sequence_size", [384])
@@ -49,7 +49,7 @@ def test_bert_attention(device, model_name, batch_size, sequence_size):
     assert_with_pcc(torch_output, output, 0.9999)
 
 
-@skip_for_wormhole_b0()
+@pytest.mark.skipif(is_wormhole_b0() or is_blackhole(), reason="Unsupported on WH and BH")
 @pytest.mark.parametrize("model_name", ["phiyodr/bert-large-finetuned-squad2"])
 @pytest.mark.parametrize("batch_size", [1])
 @pytest.mark.parametrize("sequence_size", [384])
@@ -79,7 +79,7 @@ def test_bert_intermediate(device, model_name, batch_size, sequence_size, torch_
     assert_with_pcc(torch_output, output.to(torch_output.dtype), 0.9997)
 
 
-@skip_for_wormhole_b0()
+@pytest.mark.skipif(is_wormhole_b0() or is_blackhole(), reason="Unsupported on WH and BH")
 @pytest.mark.parametrize("model_name", ["phiyodr/bert-large-finetuned-squad2"])
 @pytest.mark.parametrize("batch_size", [1])
 @pytest.mark.parametrize("sequence_size", [384])
@@ -125,7 +125,7 @@ class BertFeedForward(torch.nn.Module):
         return hidden_states
 
 
-@skip_for_wormhole_b0()
+@pytest.mark.skipif(is_wormhole_b0() or is_blackhole(), reason="Unsupported on WH and BH")
 @pytest.mark.parametrize("model_name", ["phiyodr/bert-large-finetuned-squad2"])
 @pytest.mark.parametrize("batch_size", [1])
 @pytest.mark.parametrize("sequence_size", [384])
@@ -155,7 +155,7 @@ def test_bert_feedforward(device, model_name, batch_size, sequence_size):
     assert_with_pcc(torch_output, output, 0.99979)
 
 
-@skip_for_wormhole_b0()
+@pytest.mark.skipif(is_wormhole_b0() or is_blackhole(), reason="Unsupported on WH and BH")
 @pytest.mark.parametrize("model_name", ["phiyodr/bert-large-finetuned-squad2"])
 @pytest.mark.parametrize("batch_size", [1])
 @pytest.mark.parametrize("sequence_size", [384])
@@ -188,7 +188,7 @@ def test_bert_layer(device, model_name, batch_size, sequence_size):
     assert_with_pcc(torch_output, output, 0.99964)
 
 
-@skip_for_wormhole_b0()
+@pytest.mark.skipif(is_wormhole_b0() or is_blackhole(), reason="Unsupported on WH and BH")
 @pytest.mark.parametrize("model_name", ["phiyodr/bert-large-finetuned-squad2"])
 @pytest.mark.parametrize("batch_size", [1])
 @pytest.mark.parametrize("sequence_size", [384])
@@ -225,7 +225,7 @@ def test_bert_encoder(device, model_name, batch_size, sequence_size):
 
 
 @pytest.mark.skip(reason="Mismatch in output")
-@skip_for_wormhole_b0()
+@pytest.mark.skipif(is_wormhole_b0() or is_blackhole(), reason="Unsupported on WH and BH")
 @pytest.mark.parametrize("model_name", ["phiyodr/bert-large-finetuned-squad2"])
 @pytest.mark.parametrize("batch_size", [1])
 @pytest.mark.parametrize("sequence_size", [384])
@@ -269,7 +269,7 @@ def test_bert(device, model_name, batch_size, sequence_size):
     assert_with_pcc(torch_output, output, 0.9999)
 
 
-@skip_for_wormhole_b0()
+@pytest.mark.skipif(is_wormhole_b0() or is_blackhole(), reason="Unsupported on WH and BH")
 @pytest.mark.parametrize("model_name", ["phiyodr/bert-large-finetuned-squad2"])
 @pytest.mark.parametrize("batch_size", [1])
 @pytest.mark.parametrize("sequence_size", [384])

--- a/tests/ttnn/integration_tests/bert/test_ttnn_optimized_bert.py
+++ b/tests/ttnn/integration_tests/bert/test_ttnn_optimized_bert.py
@@ -14,10 +14,10 @@ import ttnn
 from ttnn.model_preprocessing import preprocess_model_parameters
 
 from tests.ttnn.utils_for_testing import assert_with_pcc
-from models.utility_functions import skip_for_wormhole_b0
+from models.utility_functions import is_wormhole_b0, is_blackhole
 
 
-@skip_for_wormhole_b0()
+@pytest.mark.skipif(is_wormhole_b0() or is_blackhole(), reason="Unsupported on WH and BH")
 @pytest.mark.parametrize("model_name", ["phiyodr/bert-large-finetuned-squad2"])
 @pytest.mark.parametrize("batch_size", [8])
 @pytest.mark.parametrize("sequence_size", [384])

--- a/tests/ttnn/integration_tests/bert/test_ttnn_optimized_sharded_bert.py
+++ b/tests/ttnn/integration_tests/bert/test_ttnn_optimized_sharded_bert.py
@@ -14,10 +14,10 @@ import ttnn
 from ttnn.model_preprocessing import preprocess_model_parameters
 
 from tests.ttnn.utils_for_testing import assert_with_pcc
-from models.utility_functions import skip_for_wormhole_b0
+from models.utility_functions import is_wormhole_b0, is_blackhole
 
 
-@skip_for_wormhole_b0()
+@pytest.mark.skipif(is_wormhole_b0() or is_blackhole(), reason="Unsupported on WH and BH")
 @pytest.mark.parametrize("model_name", ["phiyodr/bert-large-finetuned-squad2"])
 @pytest.mark.parametrize("batch_size", [8])
 @pytest.mark.parametrize("sequence_size", [384])

--- a/tests/ttnn/integration_tests/bloom/test_bloom_for_causal_lm.py
+++ b/tests/ttnn/integration_tests/bloom/test_bloom_for_causal_lm.py
@@ -11,7 +11,7 @@ from transformers import BloomConfig, BloomForCausalLM, BloomTokenizerFast
 from models import generation_utils
 from models.demos.grayskull.functional_bloom.reference import torch_functional_bloom
 from models.demos.grayskull.functional_bloom.tt import ttnn_optimized_functional_bloom
-from models.utility_functions import skip_for_wormhole_b0, skip_for_grayskull
+from models.utility_functions import is_wormhole_b0, skip_for_grayskull, is_blackhole
 
 from ttnn.model_preprocessing import preprocess_model_parameters
 
@@ -99,7 +99,7 @@ def test_torch_bloom_for_causal_lm():
     assert expected_generated_text == generated_text
 
 
-@skip_for_wormhole_b0()
+@pytest.mark.skipif(is_wormhole_b0() or is_blackhole(), reason="Unsupported on WH and BH")
 @skip_for_grayskull(reason_str="#10797: OOM")
 def test_ttnn_bloom_for_causal_lm(device, batch_size=8):
     model_name = "bigscience/bloom-560m"

--- a/tests/ttnn/integration_tests/bloom/test_bloom_for_question_answering.py
+++ b/tests/ttnn/integration_tests/bloom/test_bloom_for_question_answering.py
@@ -8,7 +8,7 @@ from transformers import BloomConfig, BloomForQuestionAnswering, BloomTokenizerF
 
 from models.demos.grayskull.functional_bloom.tt import ttnn_functional_bloom
 from models.demos.grayskull.functional_bloom.tt import ttnn_optimized_functional_bloom
-from models.utility_functions import skip_for_wormhole_b0, skip_for_grayskull
+from models.utility_functions import is_wormhole_b0, skip_for_grayskull, is_blackhole
 
 import ttnn
 from ttnn.model_preprocessing import preprocess_model_parameters
@@ -16,7 +16,7 @@ from ttnn.model_preprocessing import preprocess_model_parameters
 from tests.ttnn.utils_for_testing import assert_with_pcc
 
 
-@skip_for_wormhole_b0()
+@pytest.mark.skipif(is_wormhole_b0() or is_blackhole(), reason="Unsupported on WH and BH")
 @skip_for_grayskull(reason_str="#10797: OOM")
 @pytest.mark.parametrize("ttnn_model", [ttnn_functional_bloom, ttnn_optimized_functional_bloom])
 def test_bloom_for_question_answering(device, use_program_cache, ttnn_model, batch_size=8, max_length=384):

--- a/tests/ttnn/integration_tests/bloom/test_demo.py
+++ b/tests/ttnn/integration_tests/bloom/test_demo.py
@@ -4,7 +4,7 @@
 
 import pytest
 from loguru import logger
-from models.utility_functions import skip_for_wormhole_b0, skip_for_grayskull
+from models.utility_functions import is_wormhole_b0, skip_for_grayskull, is_blackhole
 from models.demos.grayskull.functional_bloom.tt import ttnn_optimized_functional_bloom
 from models.demos.grayskull.functional_bloom.demo.demo_causal_lm import test_demo as demo_cg_json
 from models.demos.grayskull.functional_bloom.demo.demo_causal_lm import test_demo_hellaswag as demo_cg_hellaswag
@@ -23,7 +23,7 @@ from models.demos.grayskull.functional_bloom.demo.demo_qa import test_demo_squad
     ids=["batch_7"],
 )
 @skip_for_grayskull(reason_str="#10797: OOM")
-@skip_for_wormhole_b0()
+@pytest.mark.skipif(is_wormhole_b0() or is_blackhole(), reason="Unsupported on WH and BH")
 def test_demo_batch_7_cg(
     input_path, ttnn_model, model_location_generator, device, use_program_cache, batch_size, reset_seeds
 ):
@@ -53,7 +53,7 @@ def test_demo_batch_7_cg(
     ((ttnn_optimized_functional_bloom, 7, 0.5),),
     ids=["batch_7"],
 )
-@skip_for_wormhole_b0()
+@pytest.mark.skipif(is_wormhole_b0() or is_blackhole(), reason="Unsupported on WH and BH")
 @skip_for_grayskull(reason_str="#10797: OOM")
 def test_demo_squadv2_batch_7_cg(
     model_location_generator, ttnn_model, device, use_program_cache, batch_size, ref_accuracy, reset_seeds
@@ -77,7 +77,7 @@ def test_demo_squadv2_batch_7_cg(
     ids=["batch_7"],
 )
 @skip_for_grayskull(reason_str="#10797: OOM")
-@skip_for_wormhole_b0()
+@pytest.mark.skipif(is_wormhole_b0() or is_blackhole(), reason="Unsupported on WH and BH")
 def test_demo_batch_7_qa(
     input_path, ttnn_model, model_location_generator, device, use_program_cache, reset_seeds, batch_size
 ):
@@ -107,7 +107,7 @@ def test_demo_batch_7_qa(
     ids=["batch_6"],
 )
 @skip_for_grayskull(reason_str="#10797: OOM")
-@skip_for_wormhole_b0()
+@pytest.mark.skipif(is_wormhole_b0() or is_blackhole(), reason="Unsupported on WH and BH")
 def test_demo_squadv2_batch_6_qa(ttnn_model, device, use_program_cache, reset_seeds, batch_size, f1):
     loop_count = 5
     eval_score = demo_qa_squadv2(

--- a/tests/ttnn/integration_tests/bloom/test_performance.py
+++ b/tests/ttnn/integration_tests/bloom/test_performance.py
@@ -11,7 +11,8 @@ from transformers import BloomConfig, BloomForCausalLM, BloomForQuestionAnswerin
 from models.demos.grayskull.functional_bloom.tt import ttnn_functional_bloom
 from models.demos.grayskull.functional_bloom.tt import ttnn_optimized_functional_bloom
 from models.utility_functions import (
-    skip_for_wormhole_b0,
+    is_wormhole_b0,
+    is_blackhole,
     enable_persistent_kernel_cache,
     disable_persistent_kernel_cache,
 )
@@ -35,7 +36,7 @@ def get_expected_times_causal_lm(functional_bloom):
     }[functional_bloom]
 
 
-@skip_for_wormhole_b0()
+@pytest.mark.skipif(is_wormhole_b0() or is_blackhole(), reason="Unsupported on WH and BH")
 @pytest.mark.models_performance_bare_metal
 @pytest.mark.models_performance_virtual_machine
 @pytest.mark.parametrize("functional_bloom", [ttnn_functional_bloom, ttnn_optimized_functional_bloom])
@@ -116,7 +117,7 @@ def test_performance_of_bloom_for_question_answering(
     ttnn_optimized_functional_bloom.ASSUME_FUSED_SOFTMAX = False
 
 
-@skip_for_wormhole_b0()
+@pytest.mark.skipif(is_wormhole_b0() or is_blackhole(), reason="Unsupported on WH and BH")
 @pytest.mark.models_performance_bare_metal
 @pytest.mark.models_performance_virtual_machine
 @pytest.mark.parametrize("functional_bloom", [ttnn_functional_bloom, ttnn_optimized_functional_bloom])

--- a/tests/ttnn/integration_tests/bloom/test_torch_functional_bloom.py
+++ b/tests/ttnn/integration_tests/bloom/test_torch_functional_bloom.py
@@ -8,7 +8,7 @@ import torch
 from transformers.models import bloom
 
 from models.demos.grayskull.functional_bloom.reference import torch_functional_bloom
-from models.utility_functions import skip_for_wormhole_b0
+from models.utility_functions import is_wormhole_b0, is_blackhole
 from ttnn.model_preprocessing import preprocess_model_parameters
 
 from tests.ttnn.utils_for_testing import assert_with_pcc
@@ -20,7 +20,7 @@ def torch_random(shape, low, high, dtype):
     return torch.zeros(shape, dtype=dtype).uniform_(low, high)
 
 
-@skip_for_wormhole_b0()
+@pytest.mark.skipif(is_wormhole_b0() or is_blackhole(), reason="Unsupported on WH and BH")
 def test_bloom_gelu():
     torch.manual_seed(0)
 
@@ -33,7 +33,7 @@ def test_bloom_gelu():
     assert_with_pcc(torch_output, output, pcc=0.9999)
 
 
-@skip_for_wormhole_b0()
+@pytest.mark.skipif(is_wormhole_b0() or is_blackhole(), reason="Unsupported on WH and BH")
 @pytest.mark.parametrize("model_name", ["bigscience/bloom-560m"])
 @pytest.mark.parametrize("batch_size", [1])
 @pytest.mark.parametrize("sequence_size", [384])
@@ -79,7 +79,7 @@ def test_bloom_attention(model_name, batch_size, sequence_size):
     assert_with_pcc(torch_output, output, pcc=0.9999)
 
 
-@skip_for_wormhole_b0()
+@pytest.mark.skipif(is_wormhole_b0() or is_blackhole(), reason="Unsupported on WH and BH")
 @pytest.mark.parametrize("model_name", ["bigscience/bloom-560m"])
 @pytest.mark.parametrize("batch_size", [1])
 @pytest.mark.parametrize("sequence_size", [384])
@@ -108,7 +108,7 @@ def test_bloom_mlp(model_name, batch_size, sequence_size):
     assert_with_pcc(torch_output, output, pcc=0.9999)
 
 
-@skip_for_wormhole_b0()
+@pytest.mark.skipif(is_wormhole_b0() or is_blackhole(), reason="Unsupported on WH and BH")
 @pytest.mark.parametrize("model_name", ["bigscience/bloom-560m"])
 @pytest.mark.parametrize("batch_size", [1])
 @pytest.mark.parametrize("sequence_size", [384])
@@ -151,7 +151,7 @@ def test_bloom_block(model_name, batch_size, sequence_size):
     assert_with_pcc(torch_output, output, pcc=0.9999)
 
 
-@skip_for_wormhole_b0()
+@pytest.mark.skipif(is_wormhole_b0() or is_blackhole(), reason="Unsupported on WH and BH")
 @pytest.mark.parametrize("model_name", ["bigscience/bloom-560m"])
 @pytest.mark.parametrize("batch_size", [1])
 @pytest.mark.parametrize("sequence_size", [384])
@@ -185,7 +185,7 @@ def test_bloom(model_name, batch_size, sequence_size):
     assert_with_pcc(torch_output, output, pcc=0.994)
 
 
-@skip_for_wormhole_b0()
+@pytest.mark.skipif(is_wormhole_b0() or is_blackhole(), reason="Unsupported on WH and BH")
 @pytest.mark.parametrize("model_name", ["bigscience/bloom-560m"])
 @pytest.mark.parametrize("batch_size", [1])
 @pytest.mark.parametrize("sequence_size", [384])

--- a/tests/ttnn/integration_tests/bloom/test_ttnn_functional_bloom.py
+++ b/tests/ttnn/integration_tests/bloom/test_ttnn_functional_bloom.py
@@ -9,7 +9,7 @@ import ttnn
 from transformers.models import bloom
 
 from models.demos.grayskull.functional_bloom.tt import ttnn_functional_bloom
-from models.utility_functions import skip_for_wormhole_b0
+from models.utility_functions import is_wormhole_b0, is_blackhole
 from ttnn.model_preprocessing import preprocess_model_parameters
 
 from tests.ttnn.utils_for_testing import assert_with_pcc
@@ -21,7 +21,7 @@ def torch_random(shape, low, high, dtype):
     return torch.zeros(shape, dtype=dtype).uniform_(low, high)
 
 
-@skip_for_wormhole_b0()
+@pytest.mark.skipif(is_wormhole_b0() or is_blackhole(), reason="Unsupported on WH and BH")
 @pytest.mark.parametrize("model_name", ["bigscience/bloom-560m"])
 @pytest.mark.parametrize("batch_size", [1])
 @pytest.mark.parametrize("sequence_size", [384])
@@ -69,7 +69,7 @@ def test_bloom_attention(device, model_name, batch_size, sequence_size):
     assert_with_pcc(torch_output, output, pcc=0.9999)
 
 
-@skip_for_wormhole_b0()
+@pytest.mark.skipif(is_wormhole_b0() or is_blackhole(), reason="Unsupported on WH and BH")
 @pytest.mark.parametrize("model_name", ["bigscience/bloom-560m"])
 @pytest.mark.parametrize("batch_size", [1])
 @pytest.mark.parametrize("sequence_size", [384])
@@ -99,7 +99,7 @@ def test_bloom_mlp(device, model_name, batch_size, sequence_size):
     assert_with_pcc(torch_output, output, pcc=0.9998)
 
 
-@skip_for_wormhole_b0()
+@pytest.mark.skipif(is_wormhole_b0() or is_blackhole(), reason="Unsupported on WH and BH")
 @pytest.mark.parametrize("model_name", ["bigscience/bloom-560m"])
 @pytest.mark.parametrize("batch_size", [1])
 @pytest.mark.parametrize("sequence_size", [384])
@@ -144,7 +144,7 @@ def test_bloom_block(device, model_name, batch_size, sequence_size):
 
 
 @pytest.mark.skip(reason="Issue #8648.")
-@skip_for_wormhole_b0()
+@pytest.mark.skipif(is_wormhole_b0() or is_blackhole(), reason="Unsupported on WH and BH")
 @pytest.mark.parametrize("model_name", ["bigscience/bloom-560m"])
 @pytest.mark.parametrize("batch_size", [1])
 @pytest.mark.parametrize("sequence_size", [384])
@@ -184,7 +184,7 @@ def test_bloom(device, model_name, batch_size, sequence_size):
 
 
 @pytest.mark.skip(reason="Issue #8648.")
-@skip_for_wormhole_b0()
+@pytest.mark.skipif(is_wormhole_b0() or is_blackhole(), reason="Unsupported on WH and BH")
 @pytest.mark.parametrize("model_name", ["bigscience/bloom-560m"])
 @pytest.mark.parametrize("batch_size", [1])
 @pytest.mark.parametrize("sequence_size", [384])

--- a/tests/ttnn/integration_tests/bloom/test_ttnn_optimized_functional_bloom.py
+++ b/tests/ttnn/integration_tests/bloom/test_ttnn_optimized_functional_bloom.py
@@ -9,7 +9,7 @@ import ttnn
 from transformers.models import bloom
 
 from models.demos.grayskull.functional_bloom.tt import ttnn_optimized_functional_bloom
-from models.utility_functions import skip_for_wormhole_b0, skip_for_grayskull
+from models.utility_functions import is_wormhole_b0, skip_for_grayskull, is_blackhole
 from ttnn.model_preprocessing import preprocess_model_parameters
 
 from tests.ttnn.utils_for_testing import assert_with_pcc
@@ -21,7 +21,7 @@ def torch_random(shape, low, high, dtype):
     return torch.zeros(shape, dtype=dtype).uniform_(low, high)
 
 
-@skip_for_wormhole_b0()
+@pytest.mark.skipif(is_wormhole_b0() or is_blackhole(), reason="Unsupported on WH and BH")
 @skip_for_grayskull(reason_str="#10797: OOM")
 @pytest.mark.parametrize("model_name", ["bigscience/bloom-560m"])
 @pytest.mark.parametrize("batch_size", [8])

--- a/tests/ttnn/integration_tests/resnet/test_ttnn_functional_resnet50_large_new.py
+++ b/tests/ttnn/integration_tests/resnet/test_ttnn_functional_resnet50_large_new.py
@@ -20,7 +20,8 @@ from models.utility_functions import (
     pad_and_fold_conv_filters_for_unity_stride,
     enable_memory_reports,
     skip_for_grayskull,
-    skip_for_wormhole_b0,
+    is_wormhole_b0,
+    is_blackhole,
 )
 
 from models.demos.ttnn_resnet.tt.ttnn_functional_resnet50_large_new_conv_api import resnet50
@@ -263,7 +264,7 @@ def create_test_infra(device, batch_size, act_dtype, weight_dtype, math_fidelity
     return ResNet50TestInfra(device, batch_size, act_dtype, weight_dtype, math_fidelity)
 
 
-@skip_for_wormhole_b0("Only works with Grayskull")
+@pytest.mark.skipif(is_wormhole_b0() or is_blackhole(), reason="Only works with Grayskull")
 @pytest.mark.parametrize("device_params", [{"l1_small_size": 24576}], indirect=True)
 @pytest.mark.parametrize(
     "batch_size, act_dtype, weight_dtype, math_fidelity",

--- a/tests/ttnn/integration_tests/resnet/test_ttnn_functional_resnet50_xlarge_new.py
+++ b/tests/ttnn/integration_tests/resnet/test_ttnn_functional_resnet50_xlarge_new.py
@@ -20,7 +20,8 @@ from models.utility_functions import (
     pad_and_fold_conv_filters_for_unity_stride,
     enable_memory_reports,
     skip_for_grayskull,
-    skip_for_wormhole_b0,
+    is_wormhole_b0,
+    is_blackhole,
 )
 
 # from models.demos.ttnn_resnet.tt.ttnn_functional_resnet50_xlarge_new_conv_api import resnet50
@@ -262,7 +263,7 @@ def create_test_infra(device, batch_size, act_dtype, weight_dtype, math_fidelity
     return ResNet50TestInfra(device, batch_size, act_dtype, weight_dtype, math_fidelity)
 
 
-@skip_for_wormhole_b0("Only works for Grayskull.")
+@pytest.mark.skipif(is_wormhole_b0() or is_blackhole(), reason="Only works for Grayskull.")
 @pytest.mark.parametrize("device_params", [{"l1_small_size": 24576}], indirect=True)
 @pytest.mark.parametrize(
     "batch_size, act_dtype, weight_dtype, math_fidelity",

--- a/tests/ttnn/integration_tests/resnet/test_ttnn_functional_resnet50_xxlarge_new.py
+++ b/tests/ttnn/integration_tests/resnet/test_ttnn_functional_resnet50_xxlarge_new.py
@@ -20,7 +20,7 @@ from models.utility_functions import (
     pad_and_fold_conv_filters_for_unity_stride,
     enable_memory_reports,
     skip_for_grayskull,
-    skip_for_wormhole_b0,
+    is_wormhole_b0,
 )
 
 from models.demos.ttnn_resnet.tests.ttnn_resnet_test_infra import load_resnet50_model

--- a/tests/ttnn/integration_tests/roberta/test_performance.py
+++ b/tests/ttnn/integration_tests/roberta/test_performance.py
@@ -19,7 +19,8 @@ from models.demos.bert.tt import ttnn_optimized_bert
 from ttnn.model_preprocessing import preprocess_model_parameters
 
 from models.utility_functions import (
-    skip_for_wormhole_b0,
+    is_wormhole_b0,
+    is_blackhole,
     enable_persistent_kernel_cache,
     disable_persistent_kernel_cache,
 )
@@ -33,7 +34,7 @@ def get_expected_times(bert):
     }[bert]
 
 
-@skip_for_wormhole_b0()
+@pytest.mark.skipif(is_wormhole_b0() or is_blackhole(), reason="Unsupported on WH and BH")
 @pytest.mark.models_performance_bare_metal
 @pytest.mark.models_performance_virtual_machine
 @pytest.mark.parametrize("model_name", ["deepset/roberta-large-squad2"])

--- a/tests/ttnn/integration_tests/stable_diffusion/test_sharded_attention.py
+++ b/tests/ttnn/integration_tests/stable_diffusion/test_sharded_attention.py
@@ -12,7 +12,7 @@ from models.utility_functions import (
     comp_pcc,
     tt2torch_tensor,
     torch2tt_tensor,
-    skip_for_wormhole_b0,
+    is_wormhole_b0,
     skip_for_grayskull,
 )
 from models.demos.wormhole.stable_diffusion.tt.ttnn_functional_utility_functions import (

--- a/tests/ttnn/integration_tests/stable_diffusion/test_unet_2d_condition_model_new_conv.py
+++ b/tests/ttnn/integration_tests/stable_diffusion/test_unet_2d_condition_model_new_conv.py
@@ -11,8 +11,9 @@ import time
 
 from models.utility_functions import (
     skip_for_grayskull,
-    skip_for_wormhole_b0,
+    is_wormhole_b0,
     comp_pcc,
+    is_blackhole,
 )
 from diffusers import LMSDiscreteScheduler
 import ttnn
@@ -62,7 +63,7 @@ def unsqueeze_all_params_to_4d(params):
 
 
 @skip_for_grayskull()
-@skip_for_wormhole_b0(reason_str="#10923: CB / L1 buffer clash")
+@pytest.mark.skipif(is_wormhole_b0() or is_blackhole(), reason="#10923: CB / L1 buffer clash")
 @pytest.mark.parametrize(
     "device_params", [{"l1_small_size": 32768}], ids=["device_params=l1_small_size_24576"], indirect=True
 )

--- a/tests/ttnn/integration_tests/t5/test_performance.py
+++ b/tests/ttnn/integration_tests/t5/test_performance.py
@@ -13,7 +13,8 @@ from models.demos.grayskull.t5.tt import ttnn_functional_t5
 from models.demos.grayskull.t5.tt import ttnn_optimized_functional_t5
 from models.utility_functions import (
     torch_random,
-    skip_for_wormhole_b0,
+    is_wormhole_b0,
+    is_blackhole,
     enable_persistent_kernel_cache,
     disable_persistent_kernel_cache,
 )
@@ -36,7 +37,7 @@ def get_expected_times(model_name, functional_t5):
     }[model_name][functional_t5]
 
 
-@skip_for_wormhole_b0()
+@pytest.mark.skipif(is_wormhole_b0() or is_blackhole(), reason="Unsupported on WH and BH")
 @pytest.mark.skip(reason="#7619: Perf regression on both")
 @pytest.mark.models_performance_bare_metal
 @pytest.mark.models_performance_virtual_machine

--- a/tests/ttnn/integration_tests/t5/test_ttnn_functional_t5.py
+++ b/tests/ttnn/integration_tests/t5/test_ttnn_functional_t5.py
@@ -8,7 +8,7 @@ import torch
 import transformers
 
 from models.demos.grayskull.t5.tt import ttnn_functional_t5 as functional_t5
-from models.utility_functions import torch_random, skip_for_wormhole_b0
+from models.utility_functions import torch_random, is_wormhole_b0, is_blackhole
 import ttnn
 from ttnn.model_preprocessing import preprocess_model_parameters
 
@@ -36,7 +36,7 @@ def test_t5_layer_norm(device, model_name, batch_size, sequence_size):
     assert ttnn.pearson_correlation_coefficient(torch_output, output) >= 0.9999
 
 
-@skip_for_wormhole_b0()
+@pytest.mark.skipif(is_wormhole_b0() or is_blackhole(), reason="Unsupported on WH and BH")
 @pytest.mark.parametrize("model_name", ["t5-small", "google/flan-t5-small"])
 @pytest.mark.parametrize("batch_size", [1])
 @pytest.mark.parametrize("sequence_size", [128])
@@ -60,7 +60,7 @@ def test_t5_dense_act_dense(device, model_name, batch_size, sequence_size):
     assert ttnn.pearson_correlation_coefficient(torch_output, output) >= 0.99917
 
 
-@skip_for_wormhole_b0()
+@pytest.mark.skipif(is_wormhole_b0() or is_blackhole(), reason="Unsupported on WH and BH")
 @pytest.mark.parametrize("model_name", ["t5-small", "google/flan-t5-small"])
 @pytest.mark.parametrize("batch_size", [1])
 @pytest.mark.parametrize("sequence_size", [128])
@@ -84,7 +84,7 @@ def test_t5_dense_gated_act_dense(device, model_name, batch_size, sequence_size)
     assert ttnn.pearson_correlation_coefficient(torch_output, output) >= 0.99907
 
 
-@skip_for_wormhole_b0()
+@pytest.mark.skipif(is_wormhole_b0() or is_blackhole(), reason="Unsupported on WH and BH")
 @pytest.mark.parametrize("model_name", ["t5-small", "google/flan-t5-small"])
 @pytest.mark.parametrize("batch_size", [1])
 @pytest.mark.parametrize("sequence_size", [128])
@@ -108,7 +108,7 @@ def test_t5_layer_ff(device, model_name, batch_size, sequence_size):
     assert ttnn.pearson_correlation_coefficient(torch_output, output) >= 0.99910
 
 
-@skip_for_wormhole_b0()
+@pytest.mark.skipif(is_wormhole_b0() or is_blackhole(), reason="Unsupported on WH and BH")
 @pytest.mark.parametrize("model_name", ["t5-small", "google/flan-t5-small"])
 @pytest.mark.parametrize("batch_size", [1])
 @pytest.mark.parametrize("sequence_size", [128])
@@ -132,7 +132,7 @@ def test_t5_attention(device, model_name, batch_size, sequence_size):
     assert ttnn.pearson_correlation_coefficient(torch_output, output) >= 0.99901
 
 
-@skip_for_wormhole_b0()
+@pytest.mark.skipif(is_wormhole_b0() or is_blackhole(), reason="Unsupported on WH and BH")
 @pytest.mark.parametrize("model_name", ["t5-small", "google/flan-t5-small"])
 @pytest.mark.parametrize("batch_size", [1])
 @pytest.mark.parametrize("sequence_size", [128])
@@ -156,7 +156,7 @@ def test_t5_layer_self_attention(device, model_name, batch_size, sequence_size):
     assert ttnn.pearson_correlation_coefficient(torch_output, output) >= 0.9983
 
 
-@skip_for_wormhole_b0()
+@pytest.mark.skipif(is_wormhole_b0() or is_blackhole(), reason="Unsupported on WH and BH")
 @pytest.mark.parametrize("model_name", ["t5-small", "google/flan-t5-small"])
 @pytest.mark.parametrize("batch_size", [1])
 @pytest.mark.parametrize("sequence_size", [128])
@@ -186,7 +186,7 @@ def test_t5_layer_cross_attention(device, model_name, batch_size, sequence_size)
     assert ttnn.pearson_correlation_coefficient(torch_output, output) >= 0.9999
 
 
-@skip_for_wormhole_b0()
+@pytest.mark.skipif(is_wormhole_b0() or is_blackhole(), reason="Unsupported on WH and BH")
 @pytest.mark.parametrize("model_name", ["t5-small", "google/flan-t5-small"])
 @pytest.mark.parametrize("batch_size", [1])
 @pytest.mark.parametrize("sequence_size", [128])
@@ -210,7 +210,7 @@ def test_t5_block_encoder(device, model_name, batch_size, sequence_size):
     assert ttnn.pearson_correlation_coefficient(torch_output, output) >= 0.99734
 
 
-@skip_for_wormhole_b0()
+@pytest.mark.skipif(is_wormhole_b0() or is_blackhole(), reason="Unsupported on WH and BH")
 @pytest.mark.parametrize("model_name", ["t5-small", "google/flan-t5-small"])
 @pytest.mark.parametrize("batch_size", [1])
 @pytest.mark.parametrize("sequence_size", [128])
@@ -247,7 +247,7 @@ def test_t5_block_decoder(device, model_name, batch_size, sequence_size):
     assert ttnn.pearson_correlation_coefficient(torch_output, output) >= 0.99749
 
 
-@skip_for_wormhole_b0()
+@pytest.mark.skipif(is_wormhole_b0() or is_blackhole(), reason="Unsupported on WH and BH")
 @pytest.mark.parametrize("model_name", ["t5-small", "google/flan-t5-small"])
 @pytest.mark.parametrize("batch_size", [1])
 @pytest.mark.parametrize("sequence_size", [128])
@@ -282,7 +282,7 @@ def test_t5_stack_encoder(device, model_name, batch_size, sequence_size):
     assert ttnn.pearson_correlation_coefficient(torch_output, output) >= 0.9962
 
 
-@skip_for_wormhole_b0()
+@pytest.mark.skipif(is_wormhole_b0() or is_blackhole(), reason="Unsupported on WH and BH")
 @pytest.mark.parametrize("model_name", ["t5-small", "google/flan-t5-small"])
 @pytest.mark.parametrize("batch_size", [1])
 @pytest.mark.parametrize("sequence_size", [128])
@@ -324,7 +324,7 @@ def test_t5_stack_decoder(device, model_name, batch_size, sequence_size):
     assert ttnn.pearson_correlation_coefficient(torch_output, output) >= 0.9963
 
 
-@skip_for_wormhole_b0()
+@pytest.mark.skipif(is_wormhole_b0() or is_blackhole(), reason="Unsupported on WH and BH")
 @pytest.mark.parametrize("model_name", ["t5-small", "google/flan-t5-small"])
 @pytest.mark.parametrize("batch_size", [1])
 @pytest.mark.parametrize("sequence_size", [128])

--- a/tests/ttnn/integration_tests/t5/test_ttnn_optimized_functional_t5.py
+++ b/tests/ttnn/integration_tests/t5/test_ttnn_optimized_functional_t5.py
@@ -8,7 +8,7 @@ import torch
 import transformers
 
 from models.demos.grayskull.t5.tt import ttnn_optimized_functional_t5 as functional_t5
-from models.utility_functions import torch_random, skip_for_wormhole_b0
+from models.utility_functions import torch_random, is_wormhole_b0, is_blackhole
 import ttnn
 from ttnn.model_preprocessing import preprocess_model_parameters
 
@@ -36,7 +36,7 @@ def test_t5_layer_norm(device, model_name, batch_size, sequence_size):
     assert ttnn.pearson_correlation_coefficient(torch_output, output) >= 0.9999
 
 
-@skip_for_wormhole_b0()
+@pytest.mark.skipif(is_wormhole_b0() or is_blackhole(), reason="Unsupported on WH and BH")
 @pytest.mark.parametrize("model_name", ["t5-small", "google/flan-t5-small"])
 @pytest.mark.parametrize("batch_size", [1])
 @pytest.mark.parametrize("sequence_size", [128])
@@ -60,7 +60,7 @@ def test_t5_dense_act_dense(device, model_name, batch_size, sequence_size):
     assert ttnn.pearson_correlation_coefficient(torch_output, output) >= 0.99811
 
 
-@skip_for_wormhole_b0()
+@pytest.mark.skipif(is_wormhole_b0() or is_blackhole(), reason="Unsupported on WH and BH")
 @pytest.mark.parametrize("model_name", ["t5-small", "google/flan-t5-small"])
 @pytest.mark.parametrize("batch_size", [1])
 @pytest.mark.parametrize("sequence_size", [128])
@@ -84,7 +84,7 @@ def test_t5_dense_gated_act_dense(device, model_name, batch_size, sequence_size)
     assert ttnn.pearson_correlation_coefficient(torch_output, output) >= 0.99907
 
 
-@skip_for_wormhole_b0()
+@pytest.mark.skipif(is_wormhole_b0() or is_blackhole(), reason="Unsupported on WH and BH")
 @pytest.mark.parametrize("model_name", ["t5-small", "google/flan-t5-small"])
 @pytest.mark.parametrize("batch_size", [1])
 @pytest.mark.parametrize("sequence_size", [128])
@@ -108,7 +108,7 @@ def test_t5_layer_ff(device, model_name, batch_size, sequence_size):
     assert ttnn.pearson_correlation_coefficient(torch_output, output) >= 0.9979
 
 
-@skip_for_wormhole_b0()
+@pytest.mark.skipif(is_wormhole_b0() or is_blackhole(), reason="Unsupported on WH and BH")
 @pytest.mark.parametrize("model_name", ["t5-small", "google/flan-t5-small"])
 @pytest.mark.parametrize("batch_size", [8])
 @pytest.mark.parametrize("sequence_size", [128])
@@ -134,7 +134,7 @@ def test_t5_attention(device, model_name, batch_size, sequence_size):
     assert ttnn.pearson_correlation_coefficient(torch_output, output) >= 0.9990
 
 
-@skip_for_wormhole_b0()
+@pytest.mark.skipif(is_wormhole_b0() or is_blackhole(), reason="Unsupported on WH and BH")
 @pytest.mark.parametrize("model_name", ["t5-small", "google/flan-t5-small"])
 @pytest.mark.parametrize("batch_size", [8])
 @pytest.mark.parametrize("sequence_size", [128])
@@ -163,7 +163,7 @@ def test_t5_layer_self_attention(device, model_name, batch_size, sequence_size):
     assert ttnn.pearson_correlation_coefficient(torch_output, output) >= 0.997
 
 
-@skip_for_wormhole_b0()
+@pytest.mark.skipif(is_wormhole_b0() or is_blackhole(), reason="Unsupported on WH and BH")
 @pytest.mark.parametrize("model_name", ["t5-small", "google/flan-t5-small"])
 @pytest.mark.parametrize("batch_size", [8])
 @pytest.mark.parametrize("sequence_size", [128])
@@ -200,7 +200,7 @@ def test_t5_layer_cross_attention(device, model_name, batch_size, sequence_size)
     assert ttnn.pearson_correlation_coefficient(torch_output, output) >= 0.9999
 
 
-@skip_for_wormhole_b0()
+@pytest.mark.skipif(is_wormhole_b0() or is_blackhole(), reason="Unsupported on WH and BH")
 @pytest.mark.parametrize("model_name", ["t5-small", "google/flan-t5-small"])
 @pytest.mark.parametrize("batch_size", [8])
 @pytest.mark.parametrize("sequence_size", [128])
@@ -229,7 +229,7 @@ def test_t5_block_encoder(device, model_name, batch_size, sequence_size):
     assert ttnn.pearson_correlation_coefficient(torch_output, output) >= 0.9935
 
 
-@skip_for_wormhole_b0()
+@pytest.mark.skipif(is_wormhole_b0() or is_blackhole(), reason="Unsupported on WH and BH")
 @pytest.mark.parametrize("model_name", ["t5-small", "google/flan-t5-small"])
 @pytest.mark.parametrize("batch_size", [8])
 @pytest.mark.parametrize("sequence_size", [128])
@@ -266,7 +266,7 @@ def test_t5_block_decoder(device, model_name, batch_size, sequence_size):
     assert ttnn.pearson_correlation_coefficient(torch_output, output) >= 0.9936
 
 
-@skip_for_wormhole_b0()
+@pytest.mark.skipif(is_wormhole_b0() or is_blackhole(), reason="Unsupported on WH and BH")
 @pytest.mark.parametrize("model_name", ["t5-small", "google/flan-t5-small"])
 @pytest.mark.parametrize("batch_size", [8])
 @pytest.mark.parametrize("sequence_size", [128])
@@ -298,7 +298,7 @@ def test_t5_stack_encoder(device, model_name, batch_size, sequence_size):
     assert ttnn.pearson_correlation_coefficient(torch_output, output) >= 0.9944
 
 
-@skip_for_wormhole_b0()
+@pytest.mark.skipif(is_wormhole_b0() or is_blackhole(), reason="Unsupported on WH and BH")
 @pytest.mark.parametrize("model_name", ["t5-small", "google/flan-t5-small"])
 @pytest.mark.parametrize("batch_size", [8])
 @pytest.mark.parametrize("sequence_size", [128])
@@ -337,7 +337,7 @@ def test_t5_stack_decoder(device, model_name, batch_size, sequence_size):
     assert ttnn.pearson_correlation_coefficient(torch_output, output) >= 0.993
 
 
-@skip_for_wormhole_b0()
+@pytest.mark.skipif(is_wormhole_b0() or is_blackhole(), reason="Unsupported on WH and BH")
 @pytest.mark.parametrize("model_name", ["t5-small", "google/flan-t5-small"])
 @pytest.mark.parametrize("batch_size", [8])
 @pytest.mark.parametrize("sequence_size", [128])

--- a/tests/ttnn/integration_tests/vit/test_accuracy_ttnn_functional_vit.py
+++ b/tests/ttnn/integration_tests/vit/test_accuracy_ttnn_functional_vit.py
@@ -21,7 +21,8 @@ from models.experimental.vit.vit_helper_funcs import get_data_loader, get_batch
 from ttnn.model_preprocessing import preprocess_model_parameters
 
 from models.utility_functions import (
-    skip_for_wormhole_b0,
+    is_wormhole_b0,
+    is_blackhole,
     enable_persistent_kernel_cache,
     disable_persistent_kernel_cache,
 )
@@ -44,7 +45,7 @@ def get_imagenet_label_dict():
 
 
 @pytest.mark.skip(reason="#7527: Test and PCC threshold needs review")
-@skip_for_wormhole_b0()
+@pytest.mark.skipif(is_wormhole_b0() or is_blackhole(), reason="Unsupported on WH and BH")
 @pytest.mark.models_performance_bare_metal
 @pytest.mark.models_performance_virtual_machine
 @pytest.mark.parametrize("model_name", ["google/vit-base-patch16-224"])

--- a/tests/ttnn/integration_tests/vit/test_accuracy_ttnn_optim_interleaved_vit.py
+++ b/tests/ttnn/integration_tests/vit/test_accuracy_ttnn_optim_interleaved_vit.py
@@ -21,7 +21,8 @@ from models.experimental.vit.vit_helper_funcs import get_data_loader, get_batch
 from ttnn.model_preprocessing import preprocess_model_parameters
 
 from models.utility_functions import (
-    skip_for_wormhole_b0,
+    is_wormhole_b0,
+    is_blackhole,
     enable_persistent_kernel_cache,
     disable_persistent_kernel_cache,
     torch2tt_tensor,
@@ -45,7 +46,7 @@ def get_imagenet_label_dict():
 
 
 @pytest.mark.skip(reason="#7527: Test and PCC threshold needs review")
-@skip_for_wormhole_b0()
+@pytest.mark.skipif(is_wormhole_b0() or is_blackhole(), reason="Unsupported on WH and BH")
 @pytest.mark.models_performance_bare_metal
 @pytest.mark.models_performance_virtual_machine
 @pytest.mark.parametrize("model_name", ["google/vit-base-patch16-224"])

--- a/tests/ttnn/integration_tests/vit/test_accuracy_ttnn_optim_sharded_vit.py
+++ b/tests/ttnn/integration_tests/vit/test_accuracy_ttnn_optim_sharded_vit.py
@@ -21,7 +21,8 @@ from models.experimental.vit.vit_helper_funcs import get_data_loader, get_batch
 from ttnn.model_preprocessing import preprocess_model_parameters
 
 from models.utility_functions import (
-    skip_for_wormhole_b0,
+    is_wormhole_b0,
+    is_blackhole,
     enable_persistent_kernel_cache,
     disable_persistent_kernel_cache,
 )
@@ -44,7 +45,7 @@ def get_imagenet_label_dict():
 
 
 @pytest.mark.skip(reason="#7527: Test and PCC threshold needs review")
-@skip_for_wormhole_b0()
+@pytest.mark.skipif(is_wormhole_b0() or is_blackhole(), reason="Unsupported on WH and BH")
 @pytest.mark.models_performance_bare_metal
 @pytest.mark.models_performance_virtual_machine
 @pytest.mark.parametrize("model_name", ["google/vit-base-patch16-224"])

--- a/tests/ttnn/integration_tests/vit/test_performance_deviceOPs_ttnn_functional_vit.py
+++ b/tests/ttnn/integration_tests/vit/test_performance_deviceOPs_ttnn_functional_vit.py
@@ -20,7 +20,8 @@ from models.experimental.functional_vit.tt import ttnn_functional_vit
 from ttnn.model_preprocessing import preprocess_model_parameters
 
 from models.utility_functions import (
-    skip_for_wormhole_b0,
+    is_wormhole_b0,
+    is_blackhole,
     enable_persistent_kernel_cache,
     disable_persistent_kernel_cache,
     torch_random,
@@ -35,7 +36,7 @@ def get_expected_times(functional_vit):
 
 
 @pytest.mark.skip(reason="#7527: Test and PCC threshold needs review")
-@skip_for_wormhole_b0()
+@pytest.mark.skipif(is_wormhole_b0() or is_blackhole(), reason="Unsupported on WH and BH")
 @pytest.mark.models_performance_bare_metal
 @pytest.mark.models_performance_virtual_machine
 @pytest.mark.parametrize("model_name", ["google/vit-base-patch16-224"])
@@ -88,7 +89,7 @@ def test_performance_vit_encoder(device, use_program_cache, model_name, batch_si
 
 
 @pytest.mark.skip(reason="#7527: Test and PCC threshold needs review")
-@skip_for_wormhole_b0()
+@pytest.mark.skipif(is_wormhole_b0() or is_blackhole(), reason="Unsupported on WH and BH")
 @pytest.mark.models_performance_bare_metal
 @pytest.mark.models_performance_virtual_machine
 @pytest.mark.parametrize("model_name", ["google/vit-base-patch16-224"])

--- a/tests/ttnn/integration_tests/vit/test_performance_deviceOPs_ttnn_optim_interleaved_vit.py
+++ b/tests/ttnn/integration_tests/vit/test_performance_deviceOPs_ttnn_optim_interleaved_vit.py
@@ -20,7 +20,8 @@ from models.experimental.functional_vit.tt import ttnn_optimized_interleaved_vit
 from ttnn.model_preprocessing import preprocess_model_parameters
 
 from models.utility_functions import (
-    skip_for_wormhole_b0,
+    is_blackhole,
+    is_wormhole_b0,
     enable_persistent_kernel_cache,
     disable_persistent_kernel_cache,
     torch_random,
@@ -36,7 +37,7 @@ def get_expected_times(functional_vit):
 
 
 @pytest.mark.skip(reason="#7527: Test and PCC threshold needs review")
-@skip_for_wormhole_b0()
+@pytest.mark.skipif(is_wormhole_b0() or is_blackhole(), reason="Unsupported on WH and BH")
 @pytest.mark.models_performance_bare_metal
 @pytest.mark.models_performance_virtual_machine
 @pytest.mark.parametrize("model_name", ["google/vit-base-patch16-224"])
@@ -105,7 +106,7 @@ def test_performance_vit_encoder(device, use_program_cache, model_name, batch_si
 
 
 @pytest.mark.skip(reason="#7527: Test and PCC threshold needs review")
-@skip_for_wormhole_b0()
+@pytest.mark.skipif(is_wormhole_b0() or is_blackhole(), reason="Unsupported on WH and BH")
 @pytest.mark.models_performance_bare_metal
 @pytest.mark.models_performance_virtual_machine
 @pytest.mark.parametrize("model_name", ["google/vit-base-patch16-224"])

--- a/tests/ttnn/integration_tests/vit/test_performance_deviceOPs_ttnn_optim_sharded_vit.py
+++ b/tests/ttnn/integration_tests/vit/test_performance_deviceOPs_ttnn_optim_sharded_vit.py
@@ -15,11 +15,12 @@ from transformers import AutoImageProcessor
 
 import ttnn
 from models.experimental.functional_vit.tt import ttnn_optimized_sharded_vit
-from models.utility_functions import torch_random, skip_for_wormhole_b0, torch2tt_tensor
+from models.utility_functions import torch_random, is_wormhole_b0, torch2tt_tensor
 from ttnn.model_preprocessing import preprocess_model_parameters
 
 from models.utility_functions import (
-    skip_for_wormhole_b0,
+    is_wormhole_b0,
+    is_blackhole,
     enable_persistent_kernel_cache,
     disable_persistent_kernel_cache,
     torch_random,
@@ -35,7 +36,7 @@ def get_expected_times(functional_vit):
 
 
 @pytest.mark.skip(reason="#7527: Test and PCC threshold needs review")
-@skip_for_wormhole_b0()
+@pytest.mark.skipif(is_wormhole_b0() or is_blackhole(), reason="Unsupported on WH and BH")
 @pytest.mark.parametrize("model_name", ["google/vit-base-patch16-224"])
 @pytest.mark.parametrize("batch_size", [8])
 @pytest.mark.parametrize("image_size", [224])
@@ -121,7 +122,7 @@ def test_performance_vit_embeddings(device, model_name, batch_size, image_size, 
 
 
 @pytest.mark.skip(reason="#7527: Test and PCC threshold needs review")
-@skip_for_wormhole_b0()
+@pytest.mark.skipif(is_wormhole_b0() or is_blackhole(), reason="Unsupported on WH and BH")
 @pytest.mark.models_performance_bare_metal
 @pytest.mark.models_performance_virtual_machine
 @pytest.mark.parametrize("model_name", ["google/vit-base-patch16-224"])
@@ -192,7 +193,7 @@ def test_performance_vit_encoder(device, use_program_cache, model_name, batch_si
 
 
 @pytest.mark.skip(reason="#7527: Test and PCC threshold needs review")
-@skip_for_wormhole_b0()
+@pytest.mark.skipif(is_wormhole_b0() or is_blackhole(), reason="Unsupported on WH and BH")
 @pytest.mark.models_performance_bare_metal
 @pytest.mark.models_performance_virtual_machine
 @pytest.mark.parametrize("model_name", ["google/vit-base-patch16-224"])

--- a/tests/ttnn/integration_tests/vit/test_performance_highres.py
+++ b/tests/ttnn/integration_tests/vit/test_performance_highres.py
@@ -21,7 +21,8 @@ from models.experimental.functional_vit.tt import ttnn_optimized_vit_highres
 from ttnn.model_preprocessing import preprocess_model_parameters
 
 from models.utility_functions import (
-    skip_for_wormhole_b0,
+    is_wormhole_b0,
+    is_blackhole,
     enable_persistent_kernel_cache,
     disable_persistent_kernel_cache,
     torch_random,
@@ -73,7 +74,7 @@ def interpolate_pos_encoding(
 
 
 @pytest.mark.skip(reason="#7527: Test and PCC threshold needs review")
-@skip_for_wormhole_b0()
+@pytest.mark.skipif(is_wormhole_b0() or is_blackhole(), reason="Unsupported on WH and BH")
 @pytest.mark.models_performance_bare_metal
 @pytest.mark.models_performance_virtual_machine
 @pytest.mark.parametrize("model_name", ["google/vit-base-patch16-224"])
@@ -172,7 +173,7 @@ def test_performance_vit_encoder(device, use_program_cache, model_name, batch_si
 
 
 @pytest.mark.skip(reason="#7527: Test and PCC threshold needs review")
-@skip_for_wormhole_b0()
+@pytest.mark.skipif(is_wormhole_b0() or is_blackhole(), reason="Unsupported on WH and BH")
 @pytest.mark.models_performance_bare_metal
 @pytest.mark.models_performance_virtual_machine
 @pytest.mark.parametrize("model_name", ["google/vit-base-patch16-224"])

--- a/tests/ttnn/integration_tests/vit/test_performance_highres_deviceOPs.py
+++ b/tests/ttnn/integration_tests/vit/test_performance_highres_deviceOPs.py
@@ -21,7 +21,8 @@ from models.experimental.functional_vit.tt import ttnn_optimized_vit_highres
 from ttnn.model_preprocessing import preprocess_model_parameters
 
 from models.utility_functions import (
-    skip_for_wormhole_b0,
+    is_wormhole_b0,
+    is_blackhole,
     enable_persistent_kernel_cache,
     disable_persistent_kernel_cache,
     torch_random,
@@ -73,7 +74,7 @@ def interpolate_pos_encoding(
 
 
 @pytest.mark.skip(reason="#7527: Test and PCC threshold needs review")
-@skip_for_wormhole_b0()
+@pytest.mark.skipif(is_wormhole_b0() or is_blackhole(), reason="Unsupported on WH and BH")
 @pytest.mark.models_performance_bare_metal
 @pytest.mark.models_performance_virtual_machine
 @pytest.mark.parametrize("model_name", ["google/vit-base-patch16-224"])
@@ -175,7 +176,7 @@ def test_performance_vit_encoder(device, use_program_cache, model_name, batch_si
 
 
 @pytest.mark.skip(reason="#7527: Test and PCC threshold needs review")
-@skip_for_wormhole_b0()
+@pytest.mark.skipif(is_wormhole_b0() or is_blackhole(), reason="Unsupported on WH and BH")
 @pytest.mark.models_performance_bare_metal
 @pytest.mark.models_performance_virtual_machine
 @pytest.mark.parametrize("model_name", ["google/vit-base-patch16-224"])

--- a/tests/ttnn/integration_tests/vit/test_performance_ttnn_functional_vit.py
+++ b/tests/ttnn/integration_tests/vit/test_performance_ttnn_functional_vit.py
@@ -20,7 +20,8 @@ from models.experimental.functional_vit.tt import ttnn_functional_vit
 from ttnn.model_preprocessing import preprocess_model_parameters
 
 from models.utility_functions import (
-    skip_for_wormhole_b0,
+    is_blackhole,
+    is_wormhole_b0,
     enable_persistent_kernel_cache,
     disable_persistent_kernel_cache,
     torch_random,
@@ -35,7 +36,7 @@ def get_expected_times(functional_vit):
 
 
 @pytest.mark.skip(reason="#7527: Test and PCC threshold needs review")
-@skip_for_wormhole_b0()
+@pytest.mark.skipif(is_wormhole_b0() or is_blackhole(), reason="Unsupported on WH and BH")
 @pytest.mark.models_performance_bare_metal
 @pytest.mark.models_performance_virtual_machine
 @pytest.mark.parametrize("model_name", ["google/vit-base-patch16-224"])
@@ -106,7 +107,7 @@ def test_performance_vit_encoder(device, use_program_cache, model_name, batch_si
 
 
 @pytest.mark.skip(reason="#7527: Test and PCC threshold needs review")
-@skip_for_wormhole_b0()
+@pytest.mark.skipif(is_wormhole_b0() or is_blackhole(), reason="Unsupported on WH and BH")
 @pytest.mark.models_performance_bare_metal
 @pytest.mark.models_performance_virtual_machine
 @pytest.mark.parametrize("model_name", ["google/vit-base-patch16-224"])

--- a/tests/ttnn/integration_tests/vit/test_performance_ttnn_optim_interleaved_vit.py
+++ b/tests/ttnn/integration_tests/vit/test_performance_ttnn_optim_interleaved_vit.py
@@ -20,7 +20,8 @@ from models.experimental.functional_vit.tt import ttnn_optimized_interleaved_vit
 from ttnn.model_preprocessing import preprocess_model_parameters
 
 from models.utility_functions import (
-    skip_for_wormhole_b0,
+    is_wormhole_b0,
+    is_blackhole,
     enable_persistent_kernel_cache,
     disable_persistent_kernel_cache,
     torch_random,
@@ -35,7 +36,7 @@ def get_expected_times(functional_vit):
 
 
 @pytest.mark.skip(reason="#7527: Test and PCC threshold needs review")
-@skip_for_wormhole_b0()
+@pytest.mark.skipif(is_wormhole_b0() or is_blackhole(), reason="Unsupported on WH and BH")
 @pytest.mark.models_performance_bare_metal
 @pytest.mark.models_performance_virtual_machine
 @pytest.mark.parametrize("model_name", ["google/vit-base-patch16-224"])
@@ -120,7 +121,7 @@ def test_performance_vit_encoder(device, use_program_cache, model_name, batch_si
 
 
 @pytest.mark.skip(reason="#7527: Test and PCC threshold needs review")
-@skip_for_wormhole_b0()
+@pytest.mark.skipif(is_wormhole_b0() or is_blackhole(), reason="Unsupported on WH and BH")
 @pytest.mark.models_performance_bare_metal
 @pytest.mark.models_performance_virtual_machine
 @pytest.mark.parametrize("model_name", ["google/vit-base-patch16-224"])

--- a/tests/ttnn/integration_tests/vit/test_performance_ttnn_optim_sharded_vit.py
+++ b/tests/ttnn/integration_tests/vit/test_performance_ttnn_optim_sharded_vit.py
@@ -15,12 +15,12 @@ from transformers import AutoImageProcessor
 
 import ttnn
 from models.experimental.functional_vit.tt import ttnn_optimized_sharded_vit
-from models.utility_functions import torch_random, skip_for_wormhole_b0
+from models.utility_functions import torch_random, is_wormhole_b0, is_blackhole
 
 from ttnn.model_preprocessing import preprocess_model_parameters
 
 from models.utility_functions import (
-    skip_for_wormhole_b0,
+    is_wormhole_b0,
     torch_random,
 )
 from models.perf.perf_utils import prep_perf_report
@@ -32,7 +32,7 @@ def get_expected_times(functional_vit):
     }[functional_vit]
 
 
-@skip_for_wormhole_b0()
+@pytest.mark.skipif(is_wormhole_b0() or is_blackhole(), reason="Unsupported on WH and BH")
 @pytest.mark.models_performance_bare_metal
 @pytest.mark.models_performance_virtual_machine
 @pytest.mark.parametrize("model_name", ["google/vit-base-patch16-224"])
@@ -112,7 +112,7 @@ def test_performance_vit_encoder(device, use_program_cache, model_name, batch_si
     logger.info(f"Samples per second: {1 / inference_time * batch_size}")
 
 
-@skip_for_wormhole_b0()
+@pytest.mark.skipif(is_wormhole_b0() or is_blackhole(), reason="Unsupported on WH and BH")
 @pytest.mark.models_performance_bare_metal
 @pytest.mark.models_performance_virtual_machine
 @pytest.mark.parametrize("model_name", ["google/vit-base-patch16-224"])

--- a/tests/ttnn/integration_tests/vit/test_torch_functional_vit.py
+++ b/tests/ttnn/integration_tests/vit/test_torch_functional_vit.py
@@ -10,7 +10,7 @@ import transformers
 from ttnn.model_preprocessing import preprocess_model_parameters
 
 from models.experimental.functional_vit.reference import torch_functional_vit
-from models.utility_functions import torch_random, skip_for_wormhole_b0
+from models.utility_functions import torch_random, is_blackhole, is_wormhole_b0
 
 from tests.ttnn.utils_for_testing import assert_with_pcc
 
@@ -18,7 +18,7 @@ from tests.ttnn.utils_for_testing import assert_with_pcc
 
 
 @pytest.mark.skip(reason="#7527: Test and PCC threshold needs review")
-@skip_for_wormhole_b0()
+@pytest.mark.skipif(is_wormhole_b0() or is_blackhole(), reason="Unsupported on WH and BH")
 @pytest.mark.parametrize("model_name", ["google/vit-base-patch16-224"])
 @pytest.mark.parametrize("batch_size", [8])
 @pytest.mark.parametrize("image_size", [224])
@@ -46,7 +46,7 @@ def test_vit_patch_embeddings(model_name, batch_size, image_size, image_channels
 
 
 @pytest.mark.skip(reason="#7527: Test and PCC threshold needs review")
-@skip_for_wormhole_b0()
+@pytest.mark.skipif(is_wormhole_b0() or is_blackhole(), reason="Unsupported on WH and BH")
 @pytest.mark.parametrize("model_name", ["google/vit-base-patch16-224"])
 @pytest.mark.parametrize("batch_size", [8])
 @pytest.mark.parametrize("image_size", [224])
@@ -82,7 +82,7 @@ def test_vit_embeddings(model_name, batch_size, image_size, image_channels):
 
 
 @pytest.mark.skip(reason="#7527: Test and PCC threshold needs review")
-@skip_for_wormhole_b0()
+@pytest.mark.skipif(is_wormhole_b0() or is_blackhole(), reason="Unsupported on WH and BH")
 @pytest.mark.parametrize("model_name", ["google/vit-base-patch16-224"])
 @pytest.mark.parametrize("batch_size", [1])
 @pytest.mark.parametrize("sequence_size", [196])
@@ -113,7 +113,7 @@ def test_vit_attention(model_name, batch_size, sequence_size):
 
 
 @pytest.mark.skip(reason="#7527: Test and PCC threshold needs review")
-@skip_for_wormhole_b0()
+@pytest.mark.skipif(is_wormhole_b0() or is_blackhole(), reason="Unsupported on WH and BH")
 @pytest.mark.parametrize("model_name", ["google/vit-base-patch16-224"])
 @pytest.mark.parametrize("batch_size", [1])
 @pytest.mark.parametrize("sequence_size", [196])
@@ -140,7 +140,7 @@ def test_vit_intermediate(model_name, batch_size, sequence_size):
 
 
 @pytest.mark.skip(reason="#7527: Test and PCC threshold needs review")
-@skip_for_wormhole_b0()
+@pytest.mark.skipif(is_wormhole_b0() or is_blackhole(), reason="Unsupported on WH and BH")
 @pytest.mark.parametrize("model_name", ["google/vit-base-patch16-224"])
 @pytest.mark.parametrize("batch_size", [1])
 @pytest.mark.parametrize("sequence_size", [196])
@@ -172,7 +172,7 @@ def test_vit_output(model_name, batch_size, sequence_size):
 
 
 @pytest.mark.skip(reason="#7527: Test and PCC threshold needs review")
-@skip_for_wormhole_b0()
+@pytest.mark.skipif(is_wormhole_b0() or is_blackhole(), reason="Unsupported on WH and BH")
 @pytest.mark.parametrize("model_name", ["google/vit-base-patch16-224"])
 @pytest.mark.parametrize("batch_size", [1])
 @pytest.mark.parametrize("sequence_size", [196])
@@ -202,7 +202,7 @@ def test_vit_layer(model_name, batch_size, sequence_size):
 
 
 @pytest.mark.skip(reason="#7527: Test and PCC threshold needs review")
-@skip_for_wormhole_b0()
+@pytest.mark.skipif(is_wormhole_b0() or is_blackhole(), reason="Unsupported on WH and BH")
 @pytest.mark.parametrize("model_name", ["google/vit-base-patch16-224"])
 @pytest.mark.parametrize("batch_size", [1])
 @pytest.mark.parametrize("sequence_size", [198])
@@ -231,7 +231,7 @@ def test_vit_encoder(model_name, batch_size, sequence_size):
 
 
 @pytest.mark.skip(reason="#7527: Test and PCC threshold needs review")
-@skip_for_wormhole_b0()
+@pytest.mark.skipif(is_wormhole_b0() or is_blackhole(), reason="Unsupported on WH and BH")
 @pytest.mark.parametrize("model_name", ["google/vit-base-patch16-224"])
 @pytest.mark.parametrize("batch_size", [1])
 @pytest.mark.parametrize("image_size", [224])

--- a/tests/ttnn/integration_tests/vit/test_torch_functional_vit_highres.py
+++ b/tests/ttnn/integration_tests/vit/test_torch_functional_vit_highres.py
@@ -11,7 +11,7 @@ import transformers
 from ttnn.model_preprocessing import preprocess_model_parameters
 
 from models.experimental.functional_vit.reference import torch_functional_vit
-from models.utility_functions import torch_random, skip_for_wormhole_b0
+from models.utility_functions import torch_random, is_blackhole, is_wormhole_b0
 
 from tests.ttnn.utils_for_testing import assert_with_pcc
 
@@ -55,7 +55,7 @@ def interpolate_pos_encoding(
 
 
 @pytest.mark.skip(reason="#7527: Test and PCC threshold needs review")
-@skip_for_wormhole_b0()
+@pytest.mark.skipif(is_wormhole_b0() or is_blackhole(), reason="Unsupported on WH and BH")
 @pytest.mark.parametrize("model_name", ["google/vit-base-patch16-224"])
 @pytest.mark.parametrize("batch_size", [1])
 @pytest.mark.parametrize("image_size", [1280])
@@ -83,7 +83,7 @@ def test_vit_patch_embeddings(model_name, batch_size, image_size, image_channels
 
 
 @pytest.mark.skip(reason="#7527: Test and PCC threshold needs review")
-@skip_for_wormhole_b0()
+@pytest.mark.skipif(is_wormhole_b0() or is_blackhole(), reason="Unsupported on WH and BH")
 @pytest.mark.parametrize("model_name", ["google/vit-base-patch16-224"])
 @pytest.mark.parametrize("batch_size", [1])
 @pytest.mark.parametrize("image_size", [1280])
@@ -124,7 +124,7 @@ def test_vit_embeddings(model_name, batch_size, image_size, image_channels):
 
 
 @pytest.mark.skip(reason="#7527: Test and PCC threshold needs review")
-@skip_for_wormhole_b0()
+@pytest.mark.skipif(is_wormhole_b0() or is_blackhole(), reason="Unsupported on WH and BH")
 @pytest.mark.parametrize("model_name", ["google/vit-base-patch16-224"])
 @pytest.mark.parametrize("batch_size", [1])
 @pytest.mark.parametrize("sequence_size", [198])
@@ -154,7 +154,7 @@ def test_vit_layernorm_before(model_name, batch_size, sequence_size):
 
 
 @pytest.mark.skip(reason="#7527: Test and PCC threshold needs review")
-@skip_for_wormhole_b0()
+@pytest.mark.skipif(is_wormhole_b0() or is_blackhole(), reason="Unsupported on WH and BH")
 @pytest.mark.parametrize("model_name", ["google/vit-base-patch16-224"])
 @pytest.mark.parametrize("batch_size", [1])
 @pytest.mark.parametrize("sequence_size", [196])
@@ -185,7 +185,7 @@ def test_vit_attention(model_name, batch_size, sequence_size):
 
 
 @pytest.mark.skip(reason="#7527: Test and PCC threshold needs review")
-@skip_for_wormhole_b0()
+@pytest.mark.skipif(is_wormhole_b0() or is_blackhole(), reason="Unsupported on WH and BH")
 @pytest.mark.parametrize("model_name", ["google/vit-base-patch16-224"])
 @pytest.mark.parametrize("batch_size", [1])
 @pytest.mark.parametrize("sequence_size", [196])
@@ -212,7 +212,7 @@ def test_vit_intermediate(model_name, batch_size, sequence_size):
 
 
 @pytest.mark.skip(reason="#7527: Test and PCC threshold needs review")
-@skip_for_wormhole_b0()
+@pytest.mark.skipif(is_wormhole_b0() or is_blackhole(), reason="Unsupported on WH and BH")
 @pytest.mark.parametrize("model_name", ["google/vit-base-patch16-224"])
 @pytest.mark.parametrize("batch_size", [1])
 @pytest.mark.parametrize("sequence_size", [196])
@@ -244,7 +244,7 @@ def test_vit_output(model_name, batch_size, sequence_size):
 
 
 @pytest.mark.skip(reason="#7527: Test and PCC threshold needs review")
-@skip_for_wormhole_b0()
+@pytest.mark.skipif(is_wormhole_b0() or is_blackhole(), reason="Unsupported on WH and BH")
 @pytest.mark.parametrize("model_name", ["google/vit-base-patch16-224"])
 @pytest.mark.parametrize("batch_size", [1])
 @pytest.mark.parametrize("sequence_size", [196])
@@ -274,7 +274,7 @@ def test_vit_layer(model_name, batch_size, sequence_size):
 
 
 @pytest.mark.skip(reason="#7527: Test and PCC threshold needs review")
-@skip_for_wormhole_b0()
+@pytest.mark.skipif(is_wormhole_b0() or is_blackhole(), reason="Unsupported on WH and BH")
 @pytest.mark.parametrize("model_name", ["google/vit-base-patch16-224"])
 @pytest.mark.parametrize("batch_size", [1])
 @pytest.mark.parametrize("sequence_size", [198])
@@ -303,7 +303,7 @@ def test_vit_encoder(model_name, batch_size, sequence_size):
 
 
 @pytest.mark.skip(reason="#7527: Test and PCC threshold needs review")
-@skip_for_wormhole_b0()
+@pytest.mark.skipif(is_wormhole_b0() or is_blackhole(), reason="Unsupported on WH and BH")
 @pytest.mark.parametrize("model_name", ["google/vit-base-patch16-224"])
 @pytest.mark.parametrize("batch_size", [1])
 @pytest.mark.parametrize("image_size", [1280])

--- a/tests/ttnn/integration_tests/vit/test_ttnn_functional_vit.py
+++ b/tests/ttnn/integration_tests/vit/test_ttnn_functional_vit.py
@@ -14,13 +14,13 @@ import ttnn
 from ttnn.model_preprocessing import preprocess_model_parameters
 
 from models.experimental.functional_vit.tt import ttnn_functional_vit
-from models.utility_functions import torch_random, skip_for_wormhole_b0
+from models.utility_functions import torch_random, skip_for_wormhole_b0, is_wormhole_b0, is_blackhole
 
 from tests.ttnn.utils_for_testing import assert_with_pcc
 
 
 @pytest.mark.skip(reason="#7527: Test and PCC threshold needs review")
-@skip_for_wormhole_b0()
+@pytest.mark.skipif(is_wormhole_b0() or is_blackhole(), reason="Unsupported on WH and BH")
 @pytest.mark.parametrize("model_name", ["google/vit-base-patch16-224"])
 @pytest.mark.parametrize("batch_size", [8])
 @pytest.mark.parametrize("image_size", [224])
@@ -55,7 +55,7 @@ def test_vit_patch_embeddings(device, model_name, batch_size, image_size, image_
 
 
 @pytest.mark.skip(reason="#7527: Test and PCC threshold needs review")
-@skip_for_wormhole_b0()
+@pytest.mark.skipif(is_wormhole_b0() or is_blackhole(), reason="Unsupported on WH and BH")
 @pytest.mark.parametrize("model_name", ["google/vit-base-patch16-224"])
 @pytest.mark.parametrize("batch_size", [8])
 @pytest.mark.parametrize("image_size", [224])
@@ -116,7 +116,7 @@ def test_vit_embeddings(device, model_name, batch_size, image_size, image_channe
 
 
 @pytest.mark.skip(reason="#7527: Test and PCC threshold needs review")
-@skip_for_wormhole_b0()
+@pytest.mark.skipif(is_wormhole_b0() or is_blackhole(), reason="Unsupported on WH and BH")
 @pytest.mark.parametrize("model_name", ["google/vit-base-patch16-224"])
 @pytest.mark.parametrize("batch_size", [8])
 @pytest.mark.parametrize("sequence_size", [224])
@@ -152,7 +152,7 @@ def test_vit_attention(device, model_name, batch_size, sequence_size):
 
 
 @pytest.mark.skip(reason="#7527: Test and PCC threshold needs review")
-@skip_for_wormhole_b0()
+@pytest.mark.skipif(is_wormhole_b0() or is_blackhole(), reason="Unsupported on WH and BH")
 @pytest.mark.parametrize("model_name", ["google/vit-base-patch16-224"])
 @pytest.mark.parametrize("batch_size", [8])
 @pytest.mark.parametrize("sequence_size", [224])
@@ -185,7 +185,7 @@ def test_vit_intermediate(device, model_name, batch_size, sequence_size, torch_d
 
 
 @pytest.mark.skip(reason="#7527: Test and PCC threshold needs review")
-@skip_for_wormhole_b0()
+@pytest.mark.skipif(is_wormhole_b0() or is_blackhole(), reason="Unsupported on WH and BH")
 @pytest.mark.parametrize("model_name", ["google/vit-base-patch16-224"])
 @pytest.mark.parametrize("batch_size", [8])
 @pytest.mark.parametrize("sequence_size", [224])
@@ -223,7 +223,7 @@ def test_vit_output(device, model_name, batch_size, sequence_size):
 
 
 @pytest.mark.skip(reason="#7527: Test and PCC threshold needs review")
-@skip_for_wormhole_b0()
+@pytest.mark.skipif(is_wormhole_b0() or is_blackhole(), reason="Unsupported on WH and BH")
 @pytest.mark.parametrize("model_name", ["google/vit-base-patch16-224"])
 @pytest.mark.parametrize("batch_size", [8])
 @pytest.mark.parametrize("sequence_size", [224])
@@ -259,7 +259,7 @@ def test_vit_layer(device, model_name, batch_size, sequence_size):
 
 
 @pytest.mark.skip(reason="#7527: Test and PCC threshold needs review")
-@skip_for_wormhole_b0()
+@pytest.mark.skipif(is_wormhole_b0() or is_blackhole(), reason="Unsupported on WH and BH")
 @pytest.mark.parametrize("model_name", ["google/vit-base-patch16-224"])
 @pytest.mark.parametrize("batch_size", [8])
 @pytest.mark.parametrize("sequence_size", [224])
@@ -301,7 +301,7 @@ def test_vit_encoder(device, model_name, batch_size, sequence_size):
 
 
 @pytest.mark.skip(reason="#7527: Test and PCC threshold needs review")
-@skip_for_wormhole_b0()
+@pytest.mark.skipif(is_wormhole_b0() or is_blackhole(), reason="Unsupported on WH and BH")
 @pytest.mark.parametrize("model_name", ["google/vit-base-patch16-224"])
 @pytest.mark.parametrize("batch_size", [8])
 @pytest.mark.parametrize("image_size", [224])

--- a/tests/ttnn/integration_tests/vit/test_ttnn_functional_vit_highres.py
+++ b/tests/ttnn/integration_tests/vit/test_ttnn_functional_vit_highres.py
@@ -14,7 +14,7 @@ import ttnn
 from ttnn.model_preprocessing import preprocess_model_parameters
 
 from models.experimental.functional_vit.tt import ttnn_functional_vit_highres
-from models.utility_functions import torch_random, skip_for_wormhole_b0
+from models.utility_functions import torch_random, is_blackhole, is_wormhole_b0
 
 from tests.ttnn.utils_for_testing import assert_with_pcc
 
@@ -55,7 +55,7 @@ def interpolate_pos_encoding(
 
 
 @pytest.mark.skip(reason="#7527: Test and PCC threshold needs review")
-@skip_for_wormhole_b0()
+@pytest.mark.skipif(is_wormhole_b0() or is_blackhole(), reason="Unsupported on WH and BH")
 @pytest.mark.parametrize("model_name", ["google/vit-base-patch16-224"])
 @pytest.mark.parametrize("image_size_h", [1024])
 @pytest.mark.parametrize("image_size_w", [1024])
@@ -98,7 +98,7 @@ def test_vit_patch_embeddings(device, model_name, image_size_h, image_size_w, im
 
 
 @pytest.mark.skip(reason="#7527: Test and PCC threshold needs review")
-@skip_for_wormhole_b0()
+@pytest.mark.skipif(is_wormhole_b0() or is_blackhole(), reason="Unsupported on WH and BH")
 @pytest.mark.parametrize("model_name", ["google/vit-base-patch16-224"])
 @pytest.mark.parametrize("image_size_h", [1024])
 @pytest.mark.parametrize("image_size_w", [1024])
@@ -151,7 +151,7 @@ def test_vit_embeddings(device, model_name, image_size_h, image_size_w):
 
 
 @pytest.mark.skip(reason="#7527: Test and PCC threshold needs review")
-@skip_for_wormhole_b0()
+@pytest.mark.skipif(is_wormhole_b0() or is_blackhole(), reason="Unsupported on WH and BH")
 @pytest.mark.parametrize("model_name", ["google/vit-base-patch16-224"])
 @pytest.mark.parametrize("sequence_size", [224])
 def test_vit_attention(device, model_name, sequence_size):
@@ -185,7 +185,7 @@ def test_vit_attention(device, model_name, sequence_size):
 
 
 @pytest.mark.skip(reason="#7527: Test and PCC threshold needs review")
-@skip_for_wormhole_b0()
+@pytest.mark.skipif(is_wormhole_b0() or is_blackhole(), reason="Unsupported on WH and BH")
 @pytest.mark.parametrize("model_name", ["google/vit-base-patch16-224"])
 @pytest.mark.parametrize("sequence_size", [4096])
 def test_vit_intermediate(device, model_name, sequence_size):
@@ -215,7 +215,7 @@ def test_vit_intermediate(device, model_name, sequence_size):
 
 
 @pytest.mark.skip(reason="#7527: Test and PCC threshold needs review")
-@skip_for_wormhole_b0()
+@pytest.mark.skipif(is_wormhole_b0() or is_blackhole(), reason="Unsupported on WH and BH")
 @pytest.mark.parametrize("model_name", ["google/vit-base-patch16-224"])
 @pytest.mark.parametrize("sequence_size", [4096])
 def test_vit_output(device, model_name, sequence_size):
@@ -249,7 +249,7 @@ def test_vit_output(device, model_name, sequence_size):
 
 
 @pytest.mark.skip(reason="#7527: Test and PCC threshold needs review")
-@skip_for_wormhole_b0()
+@pytest.mark.skipif(is_wormhole_b0() or is_blackhole(), reason="Unsupported on WH and BH")
 @pytest.mark.parametrize("model_name", ["google/vit-base-patch16-224"])
 @pytest.mark.parametrize("sequence_size", [4096])
 def test_vit_layer(device, model_name, sequence_size):
@@ -283,7 +283,7 @@ def test_vit_layer(device, model_name, sequence_size):
 
 
 @pytest.mark.skip(reason="#7527: Test and PCC threshold needs review")
-@skip_for_wormhole_b0()
+@pytest.mark.skipif(is_wormhole_b0() or is_blackhole(), reason="Unsupported on WH and BH")
 @pytest.mark.parametrize("model_name", ["google/vit-base-patch16-224"])
 @pytest.mark.parametrize("sequence_size", [4096])
 def test_vit_encoder(device, model_name, sequence_size):
@@ -323,7 +323,7 @@ def test_vit_encoder(device, model_name, sequence_size):
 
 
 @pytest.mark.skip(reason="#7527: Test and PCC threshold needs review")
-@skip_for_wormhole_b0()
+@pytest.mark.skipif(is_wormhole_b0() or is_blackhole(), reason="Unsupported on WH and BH")
 @pytest.mark.parametrize("model_name", ["google/vit-base-patch16-224"])
 @pytest.mark.parametrize("image_size_h", [1024])
 @pytest.mark.parametrize("image_size_w", [1024])

--- a/tests/ttnn/integration_tests/vit/test_ttnn_optimized_interleaved_vit.py
+++ b/tests/ttnn/integration_tests/vit/test_ttnn_optimized_interleaved_vit.py
@@ -14,14 +14,14 @@ import ttnn
 from ttnn.model_preprocessing import preprocess_model_parameters
 
 from models.experimental.functional_vit.tt import ttnn_optimized_interleaved_vit
-from models.utility_functions import torch_random, skip_for_wormhole_b0, torch2tt_tensor
+from models.utility_functions import torch_random, is_wormhole_b0, torch2tt_tensor, is_blackhole
 
 from tests.ttnn.utils_for_testing import assert_with_pcc
 from models.experimental.functional_vit.reference import torch_functional_vit
 
 
 @pytest.mark.skip(reason="#7527: Test and PCC threshold needs review")
-@skip_for_wormhole_b0()
+@pytest.mark.skipif(is_wormhole_b0() or is_blackhole(), reason="Unsupported on WH and BH")
 @pytest.mark.parametrize("model_name", ["google/vit-base-patch16-224"])
 @pytest.mark.parametrize("batch_size", [8])
 @pytest.mark.parametrize("image_size", [224])
@@ -80,7 +80,7 @@ def test_vit_patch_embeddings(device, model_name, batch_size, image_size, image_
 
 
 @pytest.mark.skip(reason="#7527: Test and PCC threshold needs review")
-@skip_for_wormhole_b0()
+@pytest.mark.skipif(is_wormhole_b0() or is_blackhole(), reason="Unsupported on WH and BH")
 @pytest.mark.parametrize("model_name", ["google/vit-base-patch16-224"])
 @pytest.mark.parametrize("batch_size", [8])
 @pytest.mark.parametrize("image_size", [224])
@@ -162,7 +162,7 @@ def test_vit_embeddings(device, model_name, batch_size, image_size, image_channe
 
 
 @pytest.mark.skip(reason="#7527: Test and PCC threshold needs review")
-@skip_for_wormhole_b0()
+@pytest.mark.skipif(is_wormhole_b0() or is_blackhole(), reason="Unsupported on WH and BH")
 @pytest.mark.parametrize("model_name", ["google/vit-base-patch16-224"])
 @pytest.mark.parametrize("batch_size", [8])
 @pytest.mark.parametrize("sequence_size", [224])  # padded from 197 to 224
@@ -209,7 +209,7 @@ def test_vit_attention(device, model_name, batch_size, sequence_size):
 
 
 @pytest.mark.skip(reason="#7527: Test and PCC threshold needs review")
-@skip_for_wormhole_b0()
+@pytest.mark.skipif(is_wormhole_b0() or is_blackhole(), reason="Unsupported on WH and BH")
 @pytest.mark.parametrize("model_name", ["google/vit-base-patch16-224"])
 @pytest.mark.parametrize("batch_size", [8])
 @pytest.mark.parametrize("sequence_size", [224])  # padded from 197 to 224
@@ -239,7 +239,7 @@ def test_vit_intermediate(device, model_name, batch_size, sequence_size):
 
 
 @pytest.mark.skip(reason="#7527: Test and PCC threshold needs review")
-@skip_for_wormhole_b0()
+@pytest.mark.skipif(is_wormhole_b0() or is_blackhole(), reason="Unsupported on WH and BH")
 @pytest.mark.parametrize("model_name", ["google/vit-base-patch16-224"])
 @pytest.mark.parametrize("batch_size", [8])
 @pytest.mark.parametrize("sequence_size", [224])  # padded from 197 to 224
@@ -273,7 +273,7 @@ def test_vit_output(device, model_name, batch_size, sequence_size):
 
 
 @pytest.mark.skip(reason="#7527: Test and PCC threshold needs review")
-@skip_for_wormhole_b0()
+@pytest.mark.skipif(is_wormhole_b0() or is_blackhole(), reason="Unsupported on WH and BH")
 @pytest.mark.parametrize("model_name", ["google/vit-base-patch16-224"])
 @pytest.mark.parametrize("batch_size", [8])
 @pytest.mark.parametrize("sequence_size", [224])  # padded from 197 to 224
@@ -334,7 +334,7 @@ def test_vit_layer(device, model_name, batch_size, sequence_size):
 
 
 @pytest.mark.skip(reason="#7527: Test and PCC threshold needs review")
-@skip_for_wormhole_b0()
+@pytest.mark.skipif(is_wormhole_b0() or is_blackhole(), reason="Unsupported on WH and BH")
 @pytest.mark.parametrize("model_name", ["google/vit-base-patch16-224"])
 @pytest.mark.parametrize("batch_size", [8])
 @pytest.mark.parametrize("sequence_size", [224])  ## padded from 197 to 224
@@ -390,7 +390,7 @@ def test_vit_encoder(device, model_name, batch_size, sequence_size):
 
 
 @pytest.mark.skip(reason="#7527: Test and PCC threshold needs review")
-@skip_for_wormhole_b0()
+@pytest.mark.skipif(is_wormhole_b0() or is_blackhole(), reason="Unsupported on WH and BH")
 @pytest.mark.parametrize("model_name", ["google/vit-base-patch16-224"])
 @pytest.mark.parametrize("batch_size", [8])
 @pytest.mark.parametrize("image_size", [224])

--- a/tests/ttnn/integration_tests/vit/test_ttnn_optimized_sharded_vit.py
+++ b/tests/ttnn/integration_tests/vit/test_ttnn_optimized_sharded_vit.py
@@ -15,13 +15,13 @@ from ttnn.model_preprocessing import preprocess_model_parameters
 
 from models.experimental.functional_vit.tt import ttnn_optimized_sharded_vit
 from models.experimental.functional_vit.reference import torch_functional_vit
-from models.utility_functions import torch_random, skip_for_wormhole_b0
+from models.utility_functions import torch_random, is_wormhole_b0, is_blackhole
 
 from tests.ttnn.utils_for_testing import assert_with_pcc
 
 
 @pytest.mark.skip(reason="#7527: Test and PCC threshold needs review")
-@skip_for_wormhole_b0()
+@pytest.mark.skipif(is_wormhole_b0() or is_blackhole(), reason="Unsupported on WH and BH")
 @pytest.mark.parametrize("model_name", ["google/vit-base-patch16-224"])
 @pytest.mark.parametrize("batch_size", [8])
 @pytest.mark.parametrize("image_size", [224])
@@ -83,7 +83,7 @@ def test_vit_patch_embeddings(device, model_name, batch_size, image_size, image_
 
 
 @pytest.mark.skip(reason="#7527: Test and PCC threshold needs review")
-@skip_for_wormhole_b0()
+@pytest.mark.skipif(is_wormhole_b0() or is_blackhole(), reason="Unsupported on WH and BH")
 @pytest.mark.parametrize("model_name", ["google/vit-base-patch16-224"])
 @pytest.mark.parametrize("batch_size", [8])
 @pytest.mark.parametrize("image_size", [224])
@@ -171,7 +171,7 @@ def test_vit_embeddings(device, model_name, batch_size, image_size, image_channe
 
 
 @pytest.mark.skip(reason="#7527: Test and PCC threshold needs review")
-@skip_for_wormhole_b0()
+@pytest.mark.skipif(is_wormhole_b0() or is_blackhole(), reason="Unsupported on WH and BH")
 @pytest.mark.parametrize("model_name", ["google/vit-base-patch16-224"])
 @pytest.mark.parametrize("batch_size", [8])
 @pytest.mark.parametrize("sequence_size", [224])  # padded from 197 to 224
@@ -233,7 +233,7 @@ def test_vit_attention(device, model_name, batch_size, sequence_size):
 
 
 @pytest.mark.skip(reason="#7527: Test and PCC threshold needs review")
-@skip_for_wormhole_b0()
+@pytest.mark.skipif(is_wormhole_b0() or is_blackhole(), reason="Unsupported on WH and BH")
 @pytest.mark.parametrize("model_name", ["google/vit-base-patch16-224"])
 @pytest.mark.parametrize("batch_size", [8])
 @pytest.mark.parametrize("sequence_size", [224])  # padded from 197 to 224
@@ -265,7 +265,7 @@ def test_vit_intermediate(device, model_name, batch_size, sequence_size):
 
 
 @pytest.mark.skip(reason="#7527: Test and PCC threshold needs review")
-@skip_for_wormhole_b0()
+@pytest.mark.skipif(is_wormhole_b0() or is_blackhole(), reason="Unsupported on WH and BH")
 @pytest.mark.parametrize("model_name", ["google/vit-base-patch16-224"])
 @pytest.mark.parametrize("batch_size", [8])
 @pytest.mark.parametrize("sequence_size", [224])  # padded from 197 to 224
@@ -313,7 +313,7 @@ def test_vit_output(device, model_name, batch_size, sequence_size):
 
 
 @pytest.mark.skip(reason="#7527: Test and PCC threshold needs review")
-@skip_for_wormhole_b0()
+@pytest.mark.skipif(is_wormhole_b0() or is_blackhole(), reason="Unsupported on WH and BH")
 @pytest.mark.parametrize("model_name", ["google/vit-base-patch16-224"])
 @pytest.mark.parametrize("batch_size", [8])
 @pytest.mark.parametrize("sequence_size", [224])  # padded from 197 to 224
@@ -375,7 +375,7 @@ def test_vit_layer(device, model_name, batch_size, sequence_size):
 
 
 @pytest.mark.skip(reason="#7527: Test and PCC threshold needs review")
-@skip_for_wormhole_b0()
+@pytest.mark.skipif(is_wormhole_b0() or is_blackhole(), reason="Unsupported on WH and BH")
 @pytest.mark.parametrize("model_name", ["google/vit-base-patch16-224"])
 @pytest.mark.parametrize("batch_size", [8])
 @pytest.mark.parametrize("sequence_size", [224])  ## padded from 197 to 224
@@ -431,7 +431,7 @@ def test_vit_encoder(device, model_name, batch_size, sequence_size):
     assert_with_pcc(torch_output, output, 0.9999)
 
 
-@skip_for_wormhole_b0()
+@pytest.mark.skipif(is_wormhole_b0() or is_blackhole(), reason="Unsupported on WH and BH")
 @pytest.mark.parametrize("model_name", ["google/vit-base-patch16-224"])
 @pytest.mark.parametrize("batch_size", [8])
 @pytest.mark.parametrize("image_size", [224])

--- a/tests/ttnn/integration_tests/vit/test_ttnn_optimized_vit_highres.py
+++ b/tests/ttnn/integration_tests/vit/test_ttnn_optimized_vit_highres.py
@@ -14,7 +14,7 @@ import ttnn
 from ttnn.model_preprocessing import preprocess_model_parameters
 
 from models.experimental.functional_vit.tt import ttnn_optimized_vit_highres
-from models.utility_functions import torch_random, skip_for_wormhole_b0
+from models.utility_functions import torch_random, is_wormhole_b0, is_blackhole
 
 from tests.ttnn.utils_for_testing import assert_with_pcc
 
@@ -55,7 +55,7 @@ def interpolate_pos_encoding(
 
 
 @pytest.mark.skip(reason="#7527: Test and PCC threshold needs review")
-@skip_for_wormhole_b0()
+@pytest.mark.skipif(is_wormhole_b0() or is_blackhole(), reason="Unsupported on WH and BH")
 @pytest.mark.parametrize("model_name", ["google/vit-base-patch16-224"])
 @pytest.mark.parametrize("image_size_h", [1024])
 @pytest.mark.parametrize("image_size_w", [1024])
@@ -101,7 +101,7 @@ def test_vit_patch_embeddings(device, model_name, image_size_h, image_size_w, im
 
 
 @pytest.mark.skip(reason="#7527: Test and PCC threshold needs review")
-@skip_for_wormhole_b0()
+@pytest.mark.skipif(is_wormhole_b0() or is_blackhole(), reason="Unsupported on WH and BH")
 @pytest.mark.parametrize("model_name", ["google/vit-base-patch16-224"])
 @pytest.mark.parametrize("image_size_h", [1024])
 @pytest.mark.parametrize("image_size_w", [1024])
@@ -159,7 +159,7 @@ def test_vit_embeddings(device, model_name, image_size_h, image_size_w):
 
 
 @pytest.mark.skip(reason="#7527: Test and PCC threshold needs review")
-@skip_for_wormhole_b0()
+@pytest.mark.skipif(is_wormhole_b0() or is_blackhole(), reason="Unsupported on WH and BH")
 @pytest.mark.parametrize("model_name", ["google/vit-base-patch16-224"])
 @pytest.mark.parametrize("sequence_size", [640])
 def test_vit_attention_experimental(device, model_name, sequence_size):
@@ -193,7 +193,7 @@ def test_vit_attention_experimental(device, model_name, sequence_size):
 
 
 @pytest.mark.skip(reason="#7527: Test and PCC threshold needs review")
-@skip_for_wormhole_b0()
+@pytest.mark.skipif(is_wormhole_b0() or is_blackhole(), reason="Unsupported on WH and BH")
 @pytest.mark.parametrize("model_name", ["google/vit-base-patch16-224"])
 @pytest.mark.parametrize("sequence_size", [640])
 def test_vit_attention(device, model_name, sequence_size):
@@ -227,7 +227,7 @@ def test_vit_attention(device, model_name, sequence_size):
 
 
 @pytest.mark.skip(reason="#7527: Test and PCC threshold needs review")
-@skip_for_wormhole_b0()
+@pytest.mark.skipif(is_wormhole_b0() or is_blackhole(), reason="Unsupported on WH and BH")
 @pytest.mark.parametrize("model_name", ["google/vit-base-patch16-224"])
 @pytest.mark.parametrize("sequence_size", [4032])
 def test_vit_intermediate(device, model_name, sequence_size):
@@ -256,7 +256,7 @@ def test_vit_intermediate(device, model_name, sequence_size):
 
 
 @pytest.mark.skip(reason="#7527: Test and PCC threshold needs review")
-@skip_for_wormhole_b0()
+@pytest.mark.skipif(is_wormhole_b0() or is_blackhole(), reason="Unsupported on WH and BH")
 @pytest.mark.parametrize("model_name", ["google/vit-base-patch16-224"])
 @pytest.mark.parametrize("sequence_size", [4032])
 def test_vit_output(device, model_name, sequence_size):
@@ -289,7 +289,7 @@ def test_vit_output(device, model_name, sequence_size):
 
 
 @pytest.mark.skip(reason="#7527: Test and PCC threshold needs review")
-@skip_for_wormhole_b0()
+@pytest.mark.skipif(is_wormhole_b0() or is_blackhole(), reason="Unsupported on WH and BH")
 @pytest.mark.parametrize("model_name", ["google/vit-base-patch16-224"])
 @pytest.mark.parametrize("sequence_size", [4032])
 def test_vit_layer(device, model_name, batch_size, sequence_size):
@@ -337,7 +337,7 @@ def test_vit_layer(device, model_name, batch_size, sequence_size):
 
 
 @pytest.mark.skip(reason="#7527: Test and PCC threshold needs review")
-@skip_for_wormhole_b0()
+@pytest.mark.skipif(is_wormhole_b0() or is_blackhole(), reason="Unsupported on WH and BH")
 @pytest.mark.parametrize("model_name", ["google/vit-base-patch16-224"])
 @pytest.mark.parametrize("sequence_size", [640])  #
 def test_vit_encoder(device, model_name, sequence_size):
@@ -399,7 +399,7 @@ def test_vit_encoder(device, model_name, sequence_size):
 
 
 @pytest.mark.skip(reason="#7527: Test and PCC threshold needs review")
-@skip_for_wormhole_b0()
+@pytest.mark.skipif(is_wormhole_b0() or is_blackhole(), reason="Unsupported on WH and BH")
 @pytest.mark.parametrize("model_name", ["google/vit-base-patch16-224"])
 @pytest.mark.parametrize("image_size_h", [1024])
 @pytest.mark.parametrize("image_size_w", [1024])

--- a/tests/ttnn/integration_tests/whisper/test_performance.py
+++ b/tests/ttnn/integration_tests/whisper/test_performance.py
@@ -9,7 +9,7 @@ from datasets import load_dataset
 import torch
 from ttnn.model_preprocessing import preprocess_model_parameters
 from loguru import logger
-from models.utility_functions import skip_for_wormhole_b0
+from models.utility_functions import is_wormhole_b0, is_blackhole
 from models.perf.perf_utils import prep_perf_report
 import time
 import ttnn
@@ -22,7 +22,7 @@ def get_expected_times(functional_whisper):
     }[functional_whisper]
 
 
-@skip_for_wormhole_b0(reason_str="Not tested on single WH")
+@pytest.mark.skipif(is_wormhole_b0() or is_blackhole(), reason="Not tested on single WH")
 @pytest.mark.models_performance_bare_metal
 @pytest.mark.models_performance_virtual_machine
 @pytest.mark.parametrize("model_name", ["openai/whisper-base"])

--- a/tests/ttnn/integration_tests/whisper/test_ttnn_functional_whisper.py
+++ b/tests/ttnn/integration_tests/whisper/test_ttnn_functional_whisper.py
@@ -13,13 +13,13 @@ import ttnn
 from tests.ttnn.utils_for_testing import assert_with_pcc
 from models.utility_functions import torch_random
 from ttnn.model_preprocessing import preprocess_model_parameters
-from models.utility_functions import skip_for_wormhole_b0
+from models.utility_functions import is_blackhole, is_wormhole_b0
 from loguru import logger
 
 MODEL_NAME = "openai/whisper-base"
 
 
-@skip_for_wormhole_b0()
+@pytest.mark.skipif(is_wormhole_b0() or is_blackhole(), reason="Unsupported on WH and BH")
 @pytest.mark.parametrize("ttnn_model", [ttnn_functional_whisper])
 @pytest.mark.parametrize("model_name", [MODEL_NAME])
 @pytest.mark.parametrize("batch_size", [1])
@@ -84,7 +84,7 @@ def test_whisper_attention(device, ttnn_model, model_name, batch_size, sequence_
     assert_with_pcc(torch_output, output, 0.98)
 
 
-@skip_for_wormhole_b0()
+@pytest.mark.skipif(is_wormhole_b0() or is_blackhole(), reason="Unsupported on WH and BH")
 @pytest.mark.parametrize("ttnn_model", [ttnn_functional_whisper])
 @pytest.mark.parametrize("model_name", [MODEL_NAME])
 @pytest.mark.parametrize("batch_size", [1])
@@ -120,7 +120,7 @@ def test_encoder_layer(device, ttnn_model, model_name, batch_size, sequence_size
     assert_with_pcc(torch_output, output, pcc=0.99)
 
 
-@skip_for_wormhole_b0()
+@pytest.mark.skipif(is_wormhole_b0() or is_blackhole(), reason="Unsupported on WH and BH")
 @pytest.mark.parametrize("ttnn_model", [ttnn_functional_whisper])
 @pytest.mark.parametrize("model_name", [MODEL_NAME])
 @pytest.mark.parametrize("batch_size", [1])
@@ -174,7 +174,7 @@ def test_encoder(device, ttnn_model, model_name, batch_size, feature_size, seque
     assert_with_pcc(torch_output, output, 0.97)
 
 
-@skip_for_wormhole_b0()
+@pytest.mark.skipif(is_wormhole_b0() or is_blackhole(), reason="Unsupported on WH and BH")
 @pytest.mark.parametrize("ttnn_model", [ttnn_functional_whisper])
 @pytest.mark.parametrize("model_name", [MODEL_NAME])
 @pytest.mark.parametrize("batch_size", [1])
@@ -233,7 +233,7 @@ def test_decoder_layer(device, ttnn_model, model_name, batch_size, sequence_size
     assert_with_pcc(torch_output, output, 0.97)
 
 
-@skip_for_wormhole_b0()
+@pytest.mark.skipif(is_wormhole_b0() or is_blackhole(), reason="Unsupported on WH and BH")
 @pytest.mark.parametrize("ttnn_model", [ttnn_functional_whisper])
 @pytest.mark.parametrize("model_name", [MODEL_NAME])
 @pytest.mark.parametrize("batch_size", [1])
@@ -305,7 +305,7 @@ def test_decoder(device, ttnn_model, model_name, batch_size, sequence_size):
     assert_with_pcc(torch_output, output, pcc=0.99)
 
 
-@skip_for_wormhole_b0()
+@pytest.mark.skipif(is_wormhole_b0() or is_blackhole(), reason="Unsupported on WH and BH")
 @pytest.mark.parametrize("ttnn_model", [ttnn_functional_whisper])
 def test_ttnn_whisper(device, ttnn_model):
     torch.manual_seed(0)

--- a/tests/ttnn/integration_tests/whisper/test_ttnn_optimized_functional_whisper.py
+++ b/tests/ttnn/integration_tests/whisper/test_ttnn_optimized_functional_whisper.py
@@ -13,12 +13,12 @@ import ttnn
 from tests.ttnn.utils_for_testing import assert_with_pcc
 from models.utility_functions import torch_random
 from ttnn.model_preprocessing import preprocess_model_parameters
-from models.utility_functions import skip_for_wormhole_b0
+from models.utility_functions import is_wormhole_b0, is_blackhole
 
 MODEL_NAME = "openai/whisper-base"
 
 
-@skip_for_wormhole_b0()
+@pytest.mark.skipif(is_wormhole_b0() or is_blackhole(), reason="Unsupported on WH and BH")
 @pytest.mark.parametrize("ttnn_model", [ttnn_optimized_functional_whisper])
 @pytest.mark.parametrize("model_name", [MODEL_NAME])
 @pytest.mark.parametrize("batch_size", [1])
@@ -82,7 +82,7 @@ def test_whisper_attention(device, ttnn_model, model_name, batch_size, sequence_
     assert_with_pcc(torch_output, output, 0.98)
 
 
-@skip_for_wormhole_b0()
+@pytest.mark.skipif(is_wormhole_b0() or is_blackhole(), reason="Unsupported on WH and BH")
 @pytest.mark.parametrize("ttnn_model", [ttnn_optimized_functional_whisper])
 @pytest.mark.parametrize("model_name", [MODEL_NAME])
 @pytest.mark.parametrize("batch_size", [1])
@@ -119,7 +119,7 @@ def test_encoder_layer(device, ttnn_model, model_name, batch_size, sequence_size
     assert_with_pcc(torch_output, output, pcc=0.99)
 
 
-@skip_for_wormhole_b0()
+@pytest.mark.skipif(is_wormhole_b0() or is_blackhole(), reason="Unsupported on WH and BH")
 @pytest.mark.parametrize("ttnn_model", [ttnn_optimized_functional_whisper])
 @pytest.mark.parametrize("model_name", [MODEL_NAME])
 @pytest.mark.parametrize("batch_size", [1])
@@ -172,7 +172,7 @@ def test_encoder(device, ttnn_model, model_name, batch_size, feature_size, seque
     assert_with_pcc(torch_output, output, 0.968)
 
 
-@skip_for_wormhole_b0()
+@pytest.mark.skipif(is_wormhole_b0() or is_blackhole(), reason="Unsupported on WH and BH")
 @pytest.mark.parametrize("ttnn_model", [ttnn_optimized_functional_whisper])
 @pytest.mark.parametrize("model_name", [MODEL_NAME])
 @pytest.mark.parametrize("batch_size", [1])
@@ -229,7 +229,7 @@ def test_decoder_layer(device, ttnn_model, model_name, batch_size, sequence_size
     assert_with_pcc(torch_output, output, 0.97)
 
 
-@skip_for_wormhole_b0()
+@pytest.mark.skipif(is_wormhole_b0() or is_blackhole(), reason="Unsupported on WH and BH")
 @pytest.mark.parametrize("ttnn_model", [ttnn_optimized_functional_whisper])
 @pytest.mark.parametrize("model_name", [MODEL_NAME])
 @pytest.mark.parametrize("batch_size", [1])
@@ -301,7 +301,7 @@ def test_decoder(device, ttnn_model, model_name, batch_size, sequence_size):
     assert_with_pcc(torch_output, output, pcc=0.99)
 
 
-@skip_for_wormhole_b0()
+@pytest.mark.skipif(is_wormhole_b0() or is_blackhole(), reason="Unsupported on WH and BH")
 @pytest.mark.requires_fast_runtime_mode_off
 @pytest.mark.parametrize("ttnn_model", [ttnn_optimized_functional_whisper])
 def test_ttnn_whisper(tmp_path, device, ttnn_model):

--- a/tests/ttnn/unit_tests/operations/backward/complex_ops/test_backward_complex_div.py
+++ b/tests/ttnn/unit_tests/operations/backward/complex_ops/test_backward_complex_div.py
@@ -16,9 +16,9 @@ from loguru import logger
 from tests.tt_eager.python_api_testing.sweep_tests.comparison_funcs import comp_pcc, comp_equal, comp_allclose
 
 from models.utility_functions import (
-    skip_for_wormhole_b0,
+    is_wormhole_b0,
+    is_blackhole,
 )
-from models.utility_functions import is_wormhole_b0
 from tests.ttnn.unit_tests.operations.backward.complex_ops.backward_complex_utility_funcs import (
     Complex,
     convert_to_torch_tensor,
@@ -86,7 +86,7 @@ def test_level2_complex_div_bw(bs, hw, memcfg, dtype, device, function_level_def
 @pytest.mark.parametrize("dtype", ((ttnn.bfloat16,)))
 @pytest.mark.parametrize("bs", ((1, 1), (1, 2)))
 @pytest.mark.parametrize("hw", ((32, 64), (320, 384)))
-@skip_for_wormhole_b0()
+@pytest.mark.skipif(is_wormhole_b0() or is_blackhole(), reason="Unsupported on WH and BH")
 def test_level2_complex_div_bw_other_zero(bs, hw, memcfg, dtype, device, function_level_defaults):
     input_shape = torch.Size([bs[0], bs[1], hw[0], hw[1]])
 

--- a/tests/ttnn/unit_tests/operations/backward/complex_ops/test_backward_recip.py
+++ b/tests/ttnn/unit_tests/operations/backward/complex_ops/test_backward_recip.py
@@ -14,7 +14,7 @@ from loguru import logger
 from tests.ttnn.unit_tests.operations.backward.utility_funcs import data_gen_with_range
 from tests.tt_eager.python_api_testing.sweep_tests.comparison_funcs import comp_pcc, comp_equal, comp_allclose
 
-from models.utility_functions import is_wormhole_b0, skip_for_wormhole_b0
+from models.utility_functions import is_wormhole_b0, skip_for_wormhole_b0, is_blackhole
 from tests.ttnn.unit_tests.operations.backward.complex_ops.backward_complex_utility_funcs import (
     Complex,
     convert_to_torch_tensor,
@@ -83,7 +83,7 @@ def test_level2_recip_bw(bs, hw, memcfg, dtype, device, function_level_defaults)
 @pytest.mark.parametrize("dtype", ((ttnn.bfloat16,)))
 @pytest.mark.parametrize("bs", ((1, 1), (1, 2)))
 @pytest.mark.parametrize("hw", ((32, 64), (320, 384)))
-@skip_for_wormhole_b0()
+@pytest.mark.skipif(is_wormhole_b0() or is_blackhole(), reason="Unsupported on WH and BH")
 def test_level2_recip_bw_inp_zero(bs, hw, memcfg, dtype, device, function_level_defaults):
     input_shape = torch.Size([bs[0], bs[1], hw[0], hw[1]])
 

--- a/tests/ttnn/unit_tests/operations/backward/test_backward_cosh.py
+++ b/tests/ttnn/unit_tests/operations/backward/test_backward_cosh.py
@@ -10,7 +10,8 @@ from tests.ttnn.unit_tests.operations.backward.utility_funcs import (
     compare_pcc,
 )
 from models.utility_functions import (
-    skip_for_wormhole_b0,
+    is_wormhole_b0,
+    is_blackhole,
 )
 
 
@@ -81,7 +82,7 @@ def test_bw_cosh_neg_inf(input_shapes, device):
     "input_shapes",
     ((torch.Size([1, 1, 32, 32])),),
 )
-@skip_for_wormhole_b0()
+@pytest.mark.skipif(is_wormhole_b0() or is_blackhole(), reason="Unsupported on WH and BH")
 def test_bw_cosh_nan_test1(input_shapes, device):
     in_data, input_tensor = data_gen_with_range(input_shapes, 86, 89, device, True)
     grad_data, grad_tensor = data_gen_with_range(input_shapes, 35, 50, device)
@@ -99,7 +100,7 @@ def test_bw_cosh_nan_test1(input_shapes, device):
     "input_shapes",
     ((torch.Size([1, 1, 32, 32])),),
 )
-@skip_for_wormhole_b0()
+@pytest.mark.skipif(is_wormhole_b0() or is_blackhole(), reason="Unsupported on WH and BH")
 def test_bw_cosh_nan_test2(input_shapes, device):
     in_data, input_tensor = data_gen_with_range(input_shapes, 86, 89, device, True)
     grad_data, grad_tensor = data_gen_with_range(input_shapes, -50, -35, device)

--- a/tests/ttnn/unit_tests/operations/backward/test_backward_div.py
+++ b/tests/ttnn/unit_tests/operations/backward/test_backward_div.py
@@ -7,7 +7,8 @@ import pytest
 import ttnn
 from tests.ttnn.unit_tests.operations.backward.utility_funcs import data_gen_with_range, data_gen_with_val, compare_pcc
 from models.utility_functions import (
-    skip_for_wormhole_b0,
+    is_wormhole_b0,
+    is_blackhole,
 )
 
 
@@ -81,7 +82,7 @@ def test_bw_div_binary_default(input_shapes, device):
     ),
 )
 @pytest.mark.parametrize("scalar", [0.0])
-@skip_for_wormhole_b0()
+@pytest.mark.skipif(is_wormhole_b0() or is_blackhole(), reason="Unsupported on WH and BH")
 def test_bw_unary_div_0(input_shapes, scalar, round_mode, device):
     in_data, input_tensor = data_gen_with_range(input_shapes, -100, 100, device, True)
     grad_data, grad_tensor = data_gen_with_val(input_shapes, device, False, val=0)
@@ -140,7 +141,7 @@ def test_bw_unary_div(input_shapes, scalar, round_mode, device):
     ),
 )
 @pytest.mark.parametrize("scalar", [0.0])
-@skip_for_wormhole_b0()
+@pytest.mark.skipif(is_wormhole_b0() or is_blackhole(), reason="Unsupported on WH and BH")
 def test_bw_unary_div_0_default(input_shapes, scalar, device):
     in_data, input_tensor = data_gen_with_range(input_shapes, -100, 100, device, True)
     grad_data, grad_tensor = data_gen_with_val(input_shapes, device, False, val=0)

--- a/tests/ttnn/unit_tests/operations/backward/test_backward_fill.py
+++ b/tests/ttnn/unit_tests/operations/backward/test_backward_fill.py
@@ -5,7 +5,7 @@
 import torch
 import pytest
 import ttnn
-from models.utility_functions import skip_for_wormhole_b0
+from models.utility_functions import is_wormhole_b0, is_blackhole
 from tests.ttnn.unit_tests.operations.backward.utility_funcs import (
     data_gen_with_range,
     compare_all_close,
@@ -25,7 +25,7 @@ from tests.ttnn.unit_tests.operations.backward.utility_funcs import (
 #   self: zeros_like(grad)
 #   value: grad.sum()
 #   result: at::fill(self_t, value_t)
-@skip_for_wormhole_b0()
+@pytest.mark.skipif(is_wormhole_b0() or is_blackhole(), reason="Unsupported on WH and BH")
 def test_bw_fill(input_shapes, device):
     grad_data, grad_tensor = data_gen_with_range(input_shapes, -1, 1, device)
     in_data, input_tensor = data_gen_with_range(input_shapes, -10, 10, device, True)

--- a/tests/ttnn/unit_tests/operations/backward/test_backward_polygamma.py
+++ b/tests/ttnn/unit_tests/operations/backward/test_backward_polygamma.py
@@ -7,7 +7,8 @@ import pytest
 import ttnn
 from tests.ttnn.unit_tests.operations.backward.utility_funcs import compare_pcc, data_gen_with_range, data_gen_with_val
 from models.utility_functions import (
-    skip_for_wormhole_b0,
+    is_wormhole_b0,
+    is_blackhole,
 )
 
 
@@ -68,7 +69,7 @@ def test_bw_polygamma_range_pos(input_shapes, order, device):
     "order",
     [2, 5],
 )
-@skip_for_wormhole_b0()
+@pytest.mark.skipif(is_wormhole_b0() or is_blackhole(), reason="Unsupported on WH and BH")
 def test_bw_polygamma_zero(input_shapes, order, device):
     in_data, input_tensor = data_gen_with_val(input_shapes, device, True, 0)
     grad_data, grad_tensor = data_gen_with_val(input_shapes, device, True, 0)

--- a/tests/ttnn/unit_tests/operations/backward/test_backward_sinh.py
+++ b/tests/ttnn/unit_tests/operations/backward/test_backward_sinh.py
@@ -8,7 +8,8 @@ import ttnn
 from tests.ttnn.unit_tests.operations.backward.utility_funcs import data_gen_with_range, compare_pcc
 
 from models.utility_functions import (
-    skip_for_wormhole_b0,
+    is_wormhole_b0,
+    is_blackhole,
 )
 
 
@@ -79,7 +80,7 @@ def test_bw_sinh_neg_inf(input_shapes, device):
     "input_shapes",
     ((torch.Size([1, 1, 32, 32])),),
 )
-@skip_for_wormhole_b0()
+@pytest.mark.skipif(is_wormhole_b0() or is_blackhole(), reason="Unsupported on WH and BH")
 def test_bw_sinh_nan_test1(input_shapes, device):
     in_data, input_tensor = data_gen_with_range(input_shapes, 86, 89, device, True)
     grad_data, grad_tensor = data_gen_with_range(input_shapes, 35, 50, device)
@@ -97,7 +98,7 @@ def test_bw_sinh_nan_test1(input_shapes, device):
     "input_shapes",
     ((torch.Size([1, 1, 32, 32])),),
 )
-@skip_for_wormhole_b0()
+@pytest.mark.skipif(is_wormhole_b0() or is_blackhole(), reason="Unsupported on WH and BH")
 def test_bw_sinh_nan_test2(input_shapes, device):
     in_data, input_tensor = data_gen_with_range(input_shapes, 86, 89, device, True)
     grad_data, grad_tensor = data_gen_with_range(input_shapes, -50, -35, device)

--- a/tests/ttnn/unit_tests/operations/test_backward.py
+++ b/tests/ttnn/unit_tests/operations/test_backward.py
@@ -8,7 +8,7 @@ import torch
 
 import ttnn
 
-from models.utility_functions import skip_for_wormhole_b0
+from models.utility_functions import is_wormhole_b0, is_blackhole
 from tests.ttnn.unit_tests.operations.backward.utility_funcs import (
     data_gen_with_val,
     compare_all_close,
@@ -56,7 +56,7 @@ def test_atanh(device, h, w, in_val, grad_val):
 @pytest.mark.parametrize("w", [128])
 @pytest.mark.parametrize("in_val", [-1, 0, 1])
 @pytest.mark.parametrize("grad_val", [-1, 0, 1])
-@skip_for_wormhole_b0("Skipped due to hardware restriction in storing nan")
+@pytest.mark.skipif(is_wormhole_b0() or is_blackhole(), reason="Skipped due to hardware restriction in storing nan")
 def test_atanh_nan(device, h, w, in_val, grad_val):
     run_backward_unary_test(device, h, w, in_val, grad_val, ttnn.atanh_bw, torch.atanh)
 
@@ -98,7 +98,7 @@ def test_atan2(device, h, w, in_val, grad_val, other_val):
 @pytest.mark.parametrize("in_val", [0])
 @pytest.mark.parametrize("grad_val", [-1, 0, 1])
 @pytest.mark.parametrize("other_val", [0])
-@skip_for_wormhole_b0("Skipped due to hardware restriction in storing nan")
+@pytest.mark.skipif(is_wormhole_b0() or is_blackhole(), reason="Skipped due to hardware restriction in storing nan")
 def test_atan2_zero(device, h, w, in_val, grad_val, other_val):
     run_backward_binary_test(device, h, w, in_val, grad_val, other_val, ttnn.atan2_bw, torch.atan2)
 
@@ -108,7 +108,7 @@ def test_atan2_zero(device, h, w, in_val, grad_val, other_val):
 @pytest.mark.parametrize("in_val", [-1, 1])
 @pytest.mark.parametrize("grad_val", [-1, 0, 1])
 @pytest.mark.parametrize("other_val", [-1, 1])
-@skip_for_wormhole_b0("Skipped due to hardware restriction in storing nan")
+@pytest.mark.skipif(is_wormhole_b0() or is_blackhole(), reason="Skipped due to hardware restriction in storing nan")
 def test_xlogy(device, h, w, in_val, grad_val, other_val):
     run_backward_binary_test(device, h, w, in_val, grad_val, other_val, ttnn.xlogy_bw, torch.xlogy)
 

--- a/tests/ttnn/unit_tests/operations/test_composite.py
+++ b/tests/ttnn/unit_tests/operations/test_composite.py
@@ -7,7 +7,7 @@ import pytest
 import random
 import ttnn
 from tests.ttnn.unit_tests.operations.backward.utility_funcs import data_gen_with_range, compare_pcc
-from models.utility_functions import skip_for_grayskull, skip_for_wormhole_b0
+from models.utility_functions import skip_for_grayskull, is_wormhole_b0, is_blackhole
 
 
 @pytest.mark.parametrize(
@@ -721,7 +721,7 @@ def test_unary_softshrink(input_shapes, param, device):
     assert comp_pass
 
 
-@skip_for_wormhole_b0()
+@pytest.mark.skipif(is_wormhole_b0() or is_blackhole(), reason="Unsupported on WH and BH")
 @pytest.mark.parametrize(
     "input_shapes",
     (

--- a/tests/ttnn/unit_tests/operations/test_conv1d.py
+++ b/tests/ttnn/unit_tests/operations/test_conv1d.py
@@ -7,7 +7,7 @@ from loguru import logger
 import torch
 import pytest
 from models.utility_functions import (
-    skip_for_wormhole_b0,
+    is_wormhole_b0,
     skip_for_grayskull,
     is_grayskull,
     is_wormhole_b0,

--- a/tests/ttnn/unit_tests/operations/test_experimental.py
+++ b/tests/ttnn/unit_tests/operations/test_experimental.py
@@ -7,11 +7,11 @@ import pytest
 import torch
 
 import ttnn
-from models.utility_functions import skip_for_wormhole_b0, torch_random, is_wormhole_b0, is_grayskull
+from models.utility_functions import is_wormhole_b0, torch_random, is_wormhole_b0, is_grayskull, is_blackhole
 from tests.ttnn.utils_for_testing import assert_with_pcc
 
 
-@skip_for_wormhole_b0()
+@pytest.mark.skipif(is_wormhole_b0() or is_blackhole(), reason="Unsupported on WH and BH")
 @pytest.mark.requires_fast_runtime_mode_off
 @pytest.mark.parametrize("height", [32])
 @pytest.mark.parametrize("width", [32])
@@ -31,7 +31,7 @@ def test_ttnn_experimental_tensor_exp(device, height, width):
     assert_with_pcc(torch_output_tensor, output_tensor)
 
 
-@skip_for_wormhole_b0()
+@pytest.mark.skipif(is_wormhole_b0() or is_blackhole(), reason="Unsupported on WH and BH")
 @pytest.mark.parametrize("m_size", [32])
 @pytest.mark.parametrize("k_size", [32])
 @pytest.mark.parametrize("n_size", [32])
@@ -51,7 +51,7 @@ def test_ttnn_matmul(device, m_size, k_size, n_size):
     assert_with_pcc(torch_output_tensor, output_tensor)
 
 
-@skip_for_wormhole_b0()
+@pytest.mark.skipif(is_wormhole_b0() or is_blackhole(), reason="Unsupported on WH and BH")
 @pytest.mark.parametrize("m_size", [32])
 @pytest.mark.parametrize("k_size", [32])
 @pytest.mark.parametrize("n_size", [32])

--- a/tests/ttnn/unit_tests/operations/test_fold_op.py
+++ b/tests/ttnn/unit_tests/operations/test_fold_op.py
@@ -14,9 +14,10 @@ from models.utility_functions import (
     pad_and_fold_conv_activation_for_unity_stride,
     pad_and_fold_conv_filters_for_unity_stride,
     _nearest_y,
-    skip_for_wormhole_b0,
+    is_wormhole_b0,
     torch2tt_tensor,
     tt2torch_tensor,
+    is_blackhole,
 )
 from tests.ttnn.utils_for_testing import assert_with_pcc
 from models.utility_functions import skip_for_grayskull
@@ -331,7 +332,7 @@ def test_fold_with_permute_reshape_on_device(device, n, c, h, w, pad_h, pad_w, s
     assert_with_pcc(torch_output_tensor, tt_output_tensor, 1)
 
 
-# @skip_for_wormhole_b0()
+# @pytest.mark.skipif(is_wormhole_b0() or is_blackhole(), reason="Unsupported on WH and BH")
 @pytest.mark.parametrize(
     "act_shape,stride_h,stride_w",
     [
@@ -366,7 +367,7 @@ def test_fold(act_shape, stride_h, stride_w, device):
     torch.testing.assert_allclose(actual, expected)
 
 
-@skip_for_wormhole_b0()
+@pytest.mark.skipif(is_wormhole_b0() or is_blackhole(), reason="Unsupported on WH and BH")
 def test_fold_sharded(device):
     torch.manual_seed(0)
 

--- a/tests/ttnn/unit_tests/operations/test_matmul.py
+++ b/tests/ttnn/unit_tests/operations/test_matmul.py
@@ -7,11 +7,11 @@ import torch
 import ttnn
 
 from tests.ttnn.utils_for_testing import assert_with_pcc
-from models.utility_functions import skip_for_grayskull, skip_for_wormhole_b0, is_grayskull
+from models.utility_functions import skip_for_grayskull, is_wormhole_b0, is_grayskull, is_blackhole
 
 
 # fmt: off
-@skip_for_wormhole_b0()
+@pytest.mark.skipif(is_wormhole_b0() or is_blackhole(), reason="Unsupported on WH and BH")
 @pytest.mark.parametrize("m_size,k_size,n_size", [
     (1, 2, 2),
     (1, 2, 4),
@@ -41,7 +41,7 @@ def test_matmul_with_matched_width_height(device, m_size, k_size, n_size):
 
 
 # fmt: off
-@skip_for_wormhole_b0()
+@pytest.mark.skipif(is_wormhole_b0() or is_blackhole(), reason="Unsupported on WH and BH")
 @pytest.mark.parametrize("k_size, n_size", [
     (2, 4),
     (4, 2),
@@ -69,7 +69,7 @@ def test_matmul_with_matched_width_height_from_1D(device, k_size, n_size):
     assert_with_pcc(torch_output_tensor, output, 0.9999)
 
 
-@skip_for_wormhole_b0()
+@pytest.mark.skipif(is_wormhole_b0() or is_blackhole(), reason="Unsupported on WH and BH")
 @pytest.mark.skip(reason="ttnn.reshape doesn't support reshaping the input tensors used in this test")
 @pytest.mark.parametrize("w", [(4), (2)])
 def test_matmul_does_dot_product(device, w):
@@ -94,7 +94,7 @@ def test_matmul_does_dot_product(device, w):
 
 
 # fmt: off
-@skip_for_wormhole_b0()
+@pytest.mark.skipif(is_wormhole_b0() or is_blackhole(), reason="Unsupported on WH and BH")
 @pytest.mark.parametrize("n_size,c,h,w", [
     (1, 1, 2, 4),
     (1, 1, 4, 2),
@@ -120,7 +120,7 @@ def test_matmul_with_matched_width_height_4D(device, n_size, c, h, w):
 
 
 # fmt: off
-@skip_for_wormhole_b0()
+@pytest.mark.skipif(is_wormhole_b0() or is_blackhole(), reason="Unsupported on WH and BH")
 @pytest.mark.parametrize("n_size,c,h,w", [
     (1, 1, 2, 2),
     (1, 1, 4, 4),
@@ -145,7 +145,7 @@ def test_matmul_same_shape_and_valid(device, n_size, c, h, w):
 
 
 # fmt: off
-@skip_for_wormhole_b0()
+@pytest.mark.skipif(is_wormhole_b0() or is_blackhole(), reason="Unsupported on WH and BH")
 @pytest.mark.parametrize("input_a,input_b", [
         ([1.0,2.0,3.0],[3.0,4.0,5.0])
     ])
@@ -172,7 +172,7 @@ def test_matmul_same_shape_but_invalid(device, input_a, input_b):
     assert "The width of the first tensor must be equal to the height of the second tensor" in str(exception.value)
 
 
-@skip_for_wormhole_b0()
+@pytest.mark.skipif(is_wormhole_b0() or is_blackhole(), reason="Unsupported on WH and BH")
 def test_tutorial_matmul(device):
     torch.manual_seed(0)
 
@@ -193,7 +193,7 @@ def test_tutorial_matmul(device):
     assert_with_pcc(torch_output_tensor, output, pcc=0.999)
 
 
-@skip_for_wormhole_b0()
+@pytest.mark.skipif(is_wormhole_b0() or is_blackhole(), reason="Unsupported on WH and BH")
 def test_tutorial_matmul_inputs_and_output_in_l1_memory(device):
     torch.manual_seed(0)
 
@@ -218,7 +218,7 @@ def test_tutorial_matmul_inputs_and_output_in_l1_memory(device):
     assert_with_pcc(torch_output_tensor, output, pcc=0.999)
 
 
-@skip_for_wormhole_b0()
+@pytest.mark.skipif(is_wormhole_b0() or is_blackhole(), reason="Unsupported on WH and BH")
 def test_tutorial_matmul_with_inputs_and_output_in_l1_memory_and_user_specified_core_grid(device):
     torch.manual_seed(0)
 
@@ -246,7 +246,7 @@ def test_tutorial_matmul_with_inputs_and_output_in_l1_memory_and_user_specified_
     assert_with_pcc(torch_output_tensor, output, pcc=0.999)
 
 
-@skip_for_wormhole_b0()
+@pytest.mark.skipif(is_wormhole_b0() or is_blackhole(), reason="Unsupported on WH and BH")
 @pytest.mark.parametrize(
     "batch_size_0, batch_size_1, m_size, k_size, n_size, bcast_batch, input_a_sharded_memory_config_args, input_b_sharded_memory_config_args",
     [
@@ -382,7 +382,7 @@ def test_sharded_matmul(
     assert_with_pcc(torch_output_tensor, output, pcc=0.999)
 
 
-@skip_for_wormhole_b0()
+@pytest.mark.skipif(is_wormhole_b0() or is_blackhole(), reason="Unsupported on WH and BH")
 @pytest.mark.parametrize("batch_size", [1, 7])
 def test_matmul_with_core_grid(device, batch_size):
     torch.manual_seed(0)
@@ -408,7 +408,7 @@ def test_matmul_with_core_grid(device, batch_size):
     assert_with_pcc(torch_output_tensor, output_tensor, 0.999)
 
 
-@skip_for_wormhole_b0()
+@pytest.mark.skipif(is_wormhole_b0() or is_blackhole(), reason="Unsupported on WH and BH")
 @pytest.mark.parametrize("batch_size", [1, 8])
 @pytest.mark.parametrize("m_size", [30, 61])
 @pytest.mark.parametrize("k_size", [1023, 2048])
@@ -433,7 +433,7 @@ def test_wide_matmul_with_argument_for_core_grid_set_to_device_grid(device, batc
     assert_with_pcc(torch_output_tensor, output_tensor, 0.997)
 
 
-@skip_for_wormhole_b0()
+@pytest.mark.skipif(is_wormhole_b0() or is_blackhole(), reason="Unsupported on WH and BH")
 @pytest.mark.parametrize("batch_size", [1, 8])
 @pytest.mark.parametrize("m_size", [1024, 2048])
 @pytest.mark.parametrize("k_size", [1023, 2048])
@@ -458,7 +458,7 @@ def test_tall_matmul_with_argument_for_core_grid_set_to_device_grid(device, batc
     assert_with_pcc(torch_output_tensor, output_tensor, pcc=0.997)
 
 
-@skip_for_wormhole_b0()
+@pytest.mark.skipif(is_wormhole_b0() or is_blackhole(), reason="Unsupported on WH and BH")
 @pytest.mark.parametrize("batch_size", [1, 8])
 @pytest.mark.parametrize("m_size", [31, 63])
 @pytest.mark.parametrize("k_size", [1024, 2048])
@@ -517,7 +517,7 @@ def test_matmul_with_transpose_a_or_b(device, n_size, c, m, k, n, transpose_a, t
 ##########################
 # MODEL SPECIFIC MATMULS #
 ##########################
-@skip_for_wormhole_b0()
+@pytest.mark.skipif(is_wormhole_b0() or is_blackhole(), reason="Unsupported on WH and BH")
 @pytest.mark.parametrize("batch_size", [1])
 @pytest.mark.parametrize("m_size", [128])
 @pytest.mark.parametrize("k_size", [4544])
@@ -544,7 +544,7 @@ def test_falcon_query_key_value_matmul(device, batch_size, m_size, k_size, n_siz
 
 
 # @skip_for_grayskull()
-@skip_for_wormhole_b0()
+@pytest.mark.skipif(is_wormhole_b0() or is_blackhole(), reason="Unsupported on WH and BH")
 @pytest.mark.parametrize(
     "batch_size, channel_a, channel_b, m_size, k_size, n_size, has_bias",
     [

--- a/tests/ttnn/unit_tests/operations/test_max_pool2d.py
+++ b/tests/ttnn/unit_tests/operations/test_max_pool2d.py
@@ -7,12 +7,12 @@ from loguru import logger
 import torch
 import pytest
 import math
-from models.utility_functions import is_wormhole_b0
+from models.utility_functions import is_wormhole_b0, is_blackhole
 from tests.ttnn.utils_for_testing import assert_with_pcc
 import ttnn
 
 
-# @skip_for_wormhole_b0()
+# @pytest.mark.skipif(is_wormhole_b0() or is_blackhole(), reason="Unsupported on WH and BH")
 ## max-pool params:
 ## kernel_h, kernel_w
 ## stride_h, stride_w

--- a/tests/ttnn/unit_tests/operations/test_mean.py
+++ b/tests/ttnn/unit_tests/operations/test_mean.py
@@ -8,7 +8,7 @@ import torch
 
 import ttnn
 from tests.ttnn.utils_for_testing import assert_with_pcc
-from models.utility_functions import torch_random, skip_for_wormhole_b0, is_wormhole_b0
+from models.utility_functions import torch_random, is_wormhole_b0, is_wormhole_b0
 
 
 @pytest.mark.parametrize("batch_size", [1, 16])

--- a/tests/ttnn/unit_tests/operations/test_new_conv2d.py
+++ b/tests/ttnn/unit_tests/operations/test_new_conv2d.py
@@ -7,11 +7,13 @@ from loguru import logger
 import torch
 import pytest
 from models.utility_functions import (
-    skip_for_wormhole_b0,
+    is_wormhole_b0,
     skip_for_grayskull,
     is_grayskull,
     is_wormhole_b0,
     is_x2_harvested,
+    is_blackhole,
+    skip_for_blackhole,
     is_blackhole,
 )
 from tests.ttnn.utils_for_testing import assert_with_pcc, check_with_pcc, check_with_pcc_without_tensor_printout
@@ -541,7 +543,7 @@ def test_conv_for_segformer_512x512(
     )
 
 
-@skip_for_wormhole_b0("This is test is for Grayskull only. Skipping")
+@pytest.mark.skipif(is_wormhole_b0() or is_blackhole(), reason="This is test is for Grayskull only. Skipping")
 @pytest.mark.parametrize("device_params", [{"l1_small_size": 16384}], indirect=True)
 @pytest.mark.parametrize(
     "output_channels, input_channels, input_height, input_width, filter_height, filter_width, stride_h, stride_w, pad_h, pad_w, use_1d_systolic_array, config_override",
@@ -644,6 +646,7 @@ def test_resnet50_conv_gs(
 
 
 @skip_for_grayskull()
+@skip_for_blackhole()
 @pytest.mark.parametrize("device_params", [{"l1_small_size": 16384}], indirect=True)
 @pytest.mark.parametrize(
     "batch_size, output_channels, input_channels, input_height, input_width, filter_height, filter_width, stride_h, stride_w, pad_h, pad_w, use_1d_systolic_array, config_override",
@@ -1028,6 +1031,7 @@ def test_sd_conv(
 
 
 @skip_for_grayskull()
+@skip_for_blackhole()
 @pytest.mark.parametrize("device_params", [{"l1_small_size": 16384}], indirect=True)
 @pytest.mark.parametrize(
     "batch_size, output_channels, input_channels, input_height, input_width, filter_height, filter_width, stride_h, stride_w, pad_h, pad_w, use_1d_systolic_array, config_override",
@@ -1190,7 +1194,7 @@ def test_sd_conv_wh(
         )
 
 
-@skip_for_wormhole_b0()
+@pytest.mark.skipif(is_wormhole_b0() or is_blackhole(), reason="Unsupported on WH and BH")
 @pytest.mark.parametrize("device_params", [{"l1_small_size": 16384}], indirect=True)
 @pytest.mark.parametrize(
     "batch_size, output_channels, input_channels, input_height, input_width, filter_height, filter_width, stride_h, stride_w, pad_h, pad_w, use_1d_systolic_array, config_override, use_shallow_conv_variant",
@@ -1295,6 +1299,7 @@ def test_unet_conv(
 
 
 @skip_for_grayskull()
+@skip_for_blackhole()
 @pytest.mark.parametrize("device_params", [{"l1_small_size": 16384}], indirect=True)
 @pytest.mark.parametrize(
     "batch_size, output_channels, input_channels, input_height, input_width, filter_height, filter_width, stride_h, stride_w, pad_h, pad_w, use_1d_systolic_array, config_override, use_shallow_conv_variant",

--- a/tests/ttnn/unit_tests/operations/test_reallocate.py
+++ b/tests/ttnn/unit_tests/operations/test_reallocate.py
@@ -9,10 +9,10 @@ import ttnn
 from tests.ttnn.utils_for_testing import assert_with_pcc
 
 
-from models.utility_functions import skip_for_wormhole_b0
+from models.utility_functions import is_wormhole_b0, is_blackhole
 
 
-@skip_for_wormhole_b0("#7733: fix for sharding on whb0")
+@pytest.mark.skipif(is_wormhole_b0() or is_blackhole(), reason="#7733: fix for sharding on whb0")
 @pytest.mark.parametrize(
     "mem_config", [ttnn.DRAM_MEMORY_CONFIG, ttnn.L1_MEMORY_CONFIG, ttnn.L1_BLOCK_SHARDED_MEMORY_CONFIG]
 )

--- a/tests/ttnn/unit_tests/operations/test_silu.py
+++ b/tests/ttnn/unit_tests/operations/test_silu.py
@@ -14,7 +14,7 @@ import ttnn
 
 from tests.ttnn.utils_for_testing import check_with_pcc_without_tensor_printout
 from tests.ttnn.ttnn_utility_fuction import get_shard_grid_from_num_cores
-from models.utility_functions import skip_for_wormhole_b0, skip_for_grayskull
+from models.utility_functions import is_wormhole_b0, skip_for_grayskull, is_blackhole
 from tt_lib.utils import (
     _nearest_y,
 )
@@ -117,7 +117,7 @@ def run_elt_silu_relu(
     assert passing
 
 
-@skip_for_wormhole_b0()
+@pytest.mark.skipif(is_wormhole_b0() or is_blackhole(), reason="Unsupported on WH and BH")
 @pytest.mark.parametrize(
     "batch_size, input_channels, input_height, input_width, ncores, grid_size, shard_strategy, shard_orientation",
     (

--- a/tests/ttnn/unit_tests/operations/test_transformer.py
+++ b/tests/ttnn/unit_tests/operations/test_transformer.py
@@ -9,7 +9,7 @@ import torch
 import ttnn
 
 from tests.ttnn.utils_for_testing import assert_with_pcc
-from models.utility_functions import torch_random, skip_for_wormhole_b0
+from models.utility_functions import torch_random, is_blackhole, is_wormhole_b0
 
 
 @pytest.mark.parametrize("batch_size", [1])
@@ -328,7 +328,7 @@ def test_vit_split_query_key_value_and_split_heads(
     assert ttnn.pearson_correlation_coefficient(torch_value_tensor, value_tensor) > 0.999
 
 
-@skip_for_wormhole_b0()
+@pytest.mark.skipif(is_wormhole_b0() or is_blackhole(), reason="Unsupported on WH and BH")
 @pytest.mark.parametrize("sequence_size", [224, 384])
 @pytest.mark.parametrize("input_dtype", [ttnn.bfloat8_b])
 @pytest.mark.parametrize("head_size", [64])

--- a/tests/ttnn/unit_tests/operations/test_unary.py
+++ b/tests/ttnn/unit_tests/operations/test_unary.py
@@ -10,7 +10,7 @@ import ttnn
 
 from tests.ttnn.utils_for_testing import assert_with_pcc, assert_equal
 from tests.ttnn.unit_tests.operations.backward.utility_funcs import data_gen_with_range, compare_pcc
-from models.utility_functions import torch_random, skip_for_grayskull, skip_for_wormhole_b0
+from models.utility_functions import torch_random, skip_for_grayskull, is_wormhole_b0, is_blackhole
 
 
 def run_unary_test(device, h, w, ttnn_function, pcc=0.9999):

--- a/tests/ttnn/unit_tests/test_model_preprocessing.py
+++ b/tests/ttnn/unit_tests/test_model_preprocessing.py
@@ -19,7 +19,7 @@ from ttnn.model_preprocessing import (
 )
 
 from tests.ttnn.utils_for_testing import assert_with_pcc
-from models.utility_functions import skip_for_wormhole_b0, skip_for_grayskull
+from models.utility_functions import is_wormhole_b0, skip_for_grayskull, is_blackhole
 
 
 @contextlib.contextmanager
@@ -29,7 +29,7 @@ def use_ttnn_model_cache():
     ttnn.CONFIG.enable_model_cache = False
 
 
-@skip_for_wormhole_b0()
+@pytest.mark.skipif(is_wormhole_b0() or is_blackhole(), reason="Unsupported on WH and BH")
 @pytest.mark.parametrize("model_name", [None, "linear"])
 @pytest.mark.parametrize("batch_size", [1])
 @pytest.mark.parametrize("m_size", [64])
@@ -57,7 +57,7 @@ def test_linear(device, model_name, batch_size, m_size, k_size, n_size):
     assert_with_pcc(torch_output_tensor, output_tensor, pcc=0.9997)
 
 
-@skip_for_wormhole_b0()
+@pytest.mark.skipif(is_wormhole_b0() or is_blackhole(), reason="Unsupported on WH and BH")
 @pytest.mark.parametrize("batch_size", [1])
 @pytest.mark.parametrize("m_size", [64])
 @pytest.mark.parametrize("k_size", [128])

--- a/tests/ttnn/unit_tests/test_pre_and_post_operation_hook.py
+++ b/tests/ttnn/unit_tests/test_pre_and_post_operation_hook.py
@@ -8,11 +8,11 @@ import torch
 
 import ttnn
 from tests.ttnn.utils_for_testing import assert_with_pcc
-from models.utility_functions import skip_for_wormhole_b0
+from models.utility_functions import is_wormhole_b0, is_blackhole
 from models.utility_functions import torch_random
 
 
-@skip_for_wormhole_b0()
+@pytest.mark.skipif(is_wormhole_b0() or is_blackhole(), reason="Unsupported on WH and BH")
 @pytest.mark.parametrize("batch_size", [1])
 @pytest.mark.parametrize("h", [32])
 @pytest.mark.parametrize("w", [32])
@@ -35,7 +35,7 @@ def test_pre_and_post_operation_hooks_for_printing(device, batch_size, h, w, dim
         ttnn.exp(input_tensor) * 2 + 1
 
 
-@skip_for_wormhole_b0()
+@pytest.mark.skipif(is_wormhole_b0() or is_blackhole(), reason="Unsupported on WH and BH")
 @pytest.mark.requires_fast_runtime_mode_off
 @pytest.mark.parametrize("batch_size", [1])
 @pytest.mark.parametrize("h", [32])

--- a/tests/ttnn/unit_tests/test_tracer.py
+++ b/tests/ttnn/unit_tests/test_tracer.py
@@ -11,14 +11,14 @@ import transformers
 import ttnn
 from ttnn.tracer import trace, visualize, get_graph
 
-from models.utility_functions import skip_for_wormhole_b0
+from models.utility_functions import is_wormhole_b0, is_blackhole
 
 from models.demos.bert.tt import ttnn_bert
 from models.demos.bert.tt import ttnn_optimized_bert
 from ttnn.model_preprocessing import preprocess_model_parameters
 
 
-@skip_for_wormhole_b0()
+@pytest.mark.skipif(is_wormhole_b0() or is_blackhole(), reason="Unsupported on WH and BH")
 @pytest.mark.requires_fast_runtime_mode_off
 def test_exp():
     with trace():
@@ -28,7 +28,7 @@ def test_exp():
     visualize(tensor)
 
 
-@skip_for_wormhole_b0()
+@pytest.mark.skipif(is_wormhole_b0() or is_blackhole(), reason="Unsupported on WH and BH")
 @pytest.mark.requires_fast_runtime_mode_off
 def test_reshape():
     with trace():
@@ -41,7 +41,7 @@ def test_reshape():
     visualize(tensor)
 
 
-@skip_for_wormhole_b0()
+@pytest.mark.skipif(is_wormhole_b0() or is_blackhole(), reason="Unsupported on WH and BH")
 @pytest.mark.requires_fast_runtime_mode_off
 @pytest.mark.parametrize("show_modules", [True, False])
 def test_torch_bert(show_modules):
@@ -58,7 +58,7 @@ def test_torch_bert(show_modules):
     visualize(last_hidden_state, show_modules=show_modules)
 
 
-@skip_for_wormhole_b0()
+@pytest.mark.skipif(is_wormhole_b0() or is_blackhole(), reason="Unsupported on WH and BH")
 @pytest.mark.requires_fast_runtime_mode_off
 @pytest.mark.parametrize("show_modules", [True, False])
 def test_bloom(show_modules):
@@ -78,7 +78,7 @@ def test_bloom(show_modules):
         visualize(last_hidden_state, show_modules=show_modules)
 
 
-@skip_for_wormhole_b0()
+@pytest.mark.skipif(is_wormhole_b0() or is_blackhole(), reason="Unsupported on WH and BH")
 @pytest.mark.requires_fast_runtime_mode_off
 @pytest.mark.models_performance_bare_metal
 @pytest.mark.models_performance_virtual_machine


### PR DESCRIPTION
### Problem description
We want to start enabling ttnn/python tests on BH and run the full post commit suite and are trying to achieve single chip WH - BH parity

### What's changed
Skip tests on BH if they are skipped on BH 

### Checklist
- [x] [Post commit CI passes](https://github.com/tenstorrent/tt-metal/actions/runs/10691828050)
- [x] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/runs/10623120314)
- [x] [Model regression CI testing passes](https://github.com/tenstorrent/tt-metal/actions/runs/10690932084)
