### PR TITLE
#11993: Fix offset calculation for uneven shard in reshard fast path

### DIFF
--- a/tests/tt_eager/python_api_testing/unit_testing/misc/test_reshard.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/misc/test_reshard.py
@@ -4,16 +4,13 @@
 
 import pytest
 import torch
-import math
 import ttnn
 from tests.tt_eager.python_api_testing.sweep_tests.comparison_funcs import (
     comp_equal,
     comp_pcc,
 )
 
-from enum import Enum
-
-from models.utility_functions import skip_for_wormhole_b0, skip_for_grayskull
+from models.utility_functions import skip_for_grayskull
 
 
 def run_reshard_test(
@@ -30,10 +27,13 @@ def run_reshard_test(
     output_sharding_scheme,
     tt_dtype,
 ):
+    grid_size = device.compute_with_storage_grid_size()
     input_shard_grid_set = set()
     for _input_shard_grid in input_shard_grid:
         compute_grid_start = ttnn.CoreCoord(_input_shard_grid[0][0], _input_shard_grid[0][1])
         compute_grid_end = ttnn.CoreCoord(_input_shard_grid[1][0], _input_shard_grid[1][1])
+        if compute_grid_end.x > grid_size.x - 1 or compute_grid_end.y > grid_size.y - 1:
+            pytest.skip("Shard Grid exceeds device grid size")
         input_shard_grid_set.add(ttnn.CoreRange(compute_grid_start, compute_grid_end))
 
     input_shard_grid = ttnn.CoreRangeSet(input_shard_grid_set)
@@ -42,6 +42,8 @@ def run_reshard_test(
     for _output_shard_grid in output_shard_grid:
         compute_grid_start = ttnn.CoreCoord(_output_shard_grid[0][0], _output_shard_grid[0][1])
         compute_grid_end = ttnn.CoreCoord(_output_shard_grid[1][0], _output_shard_grid[1][1])
+        if compute_grid_end.x > grid_size.x - 1 or compute_grid_end.y > grid_size.y - 1:
+            pytest.skip("Shard Grid exceeds device grid size")
         output_shard_grid_set.add(ttnn.CoreRange(compute_grid_start, compute_grid_end))
 
     output_shard_grid = ttnn.CoreRangeSet(output_shard_grid_set)
@@ -80,7 +82,6 @@ def run_reshard_test(
     return torch_tensor, torch_tensor_after_round_trip
 
 
-@skip_for_wormhole_b0()
 @pytest.mark.parametrize(
     "input_shape, input_layout, input_shard_grid,  input_shard_shape, input_shard_orientation, input_sharding_scheme, output_shard_grid, output_shard_shape, output_shard_orientation, output_sharding_scheme",
     [
@@ -155,6 +156,18 @@ def run_reshard_test(
             (32, 1024),
             ttnn.ShardOrientation.COL_MAJOR,
             ttnn.TensorMemoryLayout.BLOCK_SHARDED,
+        ),
+        (
+            [1, 1, 1320, 32],
+            ttnn.ROW_MAJOR_LAYOUT,
+            [[(0, 0), (7, 5)], [(0, 6), (6, 6)]],
+            (24, 32),
+            ttnn.ShardOrientation.ROW_MAJOR,
+            ttnn.TensorMemoryLayout.HEIGHT_SHARDED,
+            [[(0, 0), (7, 4)], [(0, 5), (1, 5)]],
+            (32, 32),
+            ttnn.ShardOrientation.ROW_MAJOR,
+            ttnn.TensorMemoryLayout.HEIGHT_SHARDED,
         ),
     ],
 )

--- a/ttnn/cpp/ttnn/operations/data_movement/sharded/reshard/device/reshard_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/sharded/reshard/device/reshard_program_factory.cpp
@@ -363,12 +363,14 @@ operation::ProgramWithCallbacks reshard_multi_core_same_width(const Tensor& inpu
         uint32_t output_units_per_core = std::min(output_units_left, output_units_per_shard);
         output_units_left -= output_units_per_core;
         uint32_t output_units_per_kernel = tt::div_up(output_units_per_core, kernels.size());
+        uint32_t output_start_offset = 0;
         for (const auto& kernel_id : kernels) {
             std::vector<uint32_t> kernel_args = {input_address, 0, 0};
             uint32_t output_units_to_get = std::min(output_units_per_core, output_units_per_kernel);
             if (output_units_to_get != 0) {
                 uint32_t num_reads = 0;
-                kernel_args[1] = (output_units_per_shard - output_units_per_core) * unit_size;
+                kernel_args[1] = output_start_offset;
+                output_start_offset += output_units_to_get * unit_size;
                 while (output_units_to_get > 0) {
                     if (input_core_units_rem == 0) {
                         input_core_idx++;


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/11993

### Problem description
Mismatch for uneven last shard for reshard fast path (height -> height sharding)

### What's changed
Fixed offset calculation

### Checklist
- [x] Post commit CI passes
- [ ] Blackhole Post commit (if applicable)
- [x] Model regression CI testing passes (if applicable)
- [x] New/Existing tests provide coverage for changes
