### PR TITLE
#0: Replaced conv_params with sliding_window_config

### DIFF
--- a/tests/tt_eager/ops/test_sliding_window_ops.cpp
+++ b/tests/tt_eager/ops/test_sliding_window_ops.cpp
@@ -369,7 +369,6 @@ int main() {
             .stride_hw = {tc.stride_h, tc.stride_w},
             .pad_hw = {tc.pad_h, tc.pad_w},
             .dilation_hw = {1, 1},
-            .groups = 1,
             .num_cores_nhw = tc.num_cores_nhw};
         Shape input_tensor_shape = {
             config.batch_size,

--- a/tests/tt_eager/ops/test_sliding_window_ops.cpp
+++ b/tests/tt_eager/ops/test_sliding_window_ops.cpp
@@ -141,15 +141,15 @@ uint32_t validate_generate_functions(
     auto halo_kernel_config = generate_halo_kernel_config_tensors(
         tensor_metadata, shard_boundaries, false, false, remote_read, device);
 
-    auto [filter_h, filter_w] = config.window_hw_;
-    auto [input_h, input_w] = config.input_hw_;
-    auto [stride_h, stride_w] = config.stride_hw_;
+    auto [filter_h, filter_w] = config.window_hw;
+    auto [input_h, input_w] = config.input_hw;
+    auto [stride_h, stride_w] = config.stride_hw;
     auto output_shape = config.get_output_shape();
     uint32_t output_n, output_h, output_w;
     std::tie(output_n, output_h, output_w) = std::forward_as_tuple(output_shape[0], output_shape[1], output_shape[2]);
 
-    uint32_t padded_input_h = input_h + 2 * config.pad_hw_.first;
-    uint32_t padded_input_w = input_w + 2 * config.pad_hw_.second;
+    uint32_t padded_input_h = input_h + 2 * config.pad_hw.first;
+    uint32_t padded_input_w = input_w + 2 * config.pad_hw.second;
 
     auto ref_pad_metadata = pad_metadata_from_tensor_metadata(tensor_metadata);
     if (ref_pad_metadata != pad_metadata) {
@@ -362,26 +362,21 @@ int main() {
 
     log_info(tt::LogTest, "Tests for Sliding window metadata calcations starts");
     for (auto tc : configs) {
-        SlidingWindowConfig config = SlidingWindowConfig(
-            tc.batch_size,
-            tc.input_h,
-            tc.input_w,
-            tc.filter_h,
-            tc.filter_w,
-            tc.stride_h,
-            tc.stride_w,
-            tc.pad_h,
-            tc.pad_w,
-            1,
-            1,
-            1,
-            tc.num_cores_nhw);
+        SlidingWindowConfig config{
+            .batch_size = tc.batch_size,
+            .input_hw = {tc.input_h, tc.input_w},
+            .window_hw = {tc.filter_h, tc.filter_w},
+            .stride_hw = {tc.stride_h, tc.stride_w},
+            .pad_hw = {tc.pad_h, tc.pad_w},
+            .dilation_hw = {1, 1},
+            .groups = 1,
+            .num_cores_nhw = tc.num_cores_nhw};
         Shape input_tensor_shape = {
-            config.batch_size_,
-            config.input_hw_.first + 2 * config.pad_hw_.first,
-            config.input_hw_.second + 2 * config.pad_hw_.second};
+            config.batch_size,
+            config.input_hw.first + 2 * config.pad_hw.first,
+            config.input_hw.second + 2 * config.pad_hw.second};
         Shape output_tensor_shape = config.get_output_shape().value;
-        Shape filter_tensor_shape = {config.window_hw_.first, config.window_hw_.second};
+        Shape filter_tensor_shape = {config.window_hw.first, config.window_hw.second};
 
         Tensor input_padded_tensor =
             tt::numpy::random::random(input_tensor_shape, DataType::BFLOAT16).to(Layout::ROW_MAJOR).cpu();

--- a/tests/tt_eager/ops/test_sliding_window_ops.cpp
+++ b/tests/tt_eager/ops/test_sliding_window_ops.cpp
@@ -374,6 +374,7 @@ int main() {
             tc.pad_w,
             1,
             1,
+            1,
             tc.num_cores_nhw);
         Shape input_tensor_shape = {
             config.batch_size_,

--- a/tests/ttnn/unit_tests/operations/test_new_conv2d.py
+++ b/tests/ttnn/unit_tests/operations/test_new_conv2d.py
@@ -58,6 +58,7 @@ def run_conv(
     pad_w,
     use_1d_systolic_array,
     config_override,
+    dilation=1,
     use_shallow_conv_variant=False,
     transpose_mcast=True,
     enable_auto_formatting=False,
@@ -86,6 +87,7 @@ def run_conv(
         bias=torch_bias_tensor.reshape(-1) if has_bias else None,
         stride=(stride_h, stride_w),
         padding=(pad_h, pad_w),
+        dilation=(dilation, dilation),
         groups=groups,
     )
     output_shape_nhwc = [
@@ -143,6 +145,7 @@ def run_conv(
         kernel_size=(filter_height, filter_width),
         stride=(stride_h, stride_w),
         padding=(pad_h, pad_w),
+        dilation=(dilation, dilation),
         batch_size=batch_size,
         input_height=input_height,
         input_width=input_width,
@@ -1515,6 +1518,79 @@ def test_conv_core_nondivis(
         pad_w,
         use_1d_systolic_array,
         config_override,
+    )
+
+
+# The following test takes various shape sizes from resnet50, unet and stable diffusion and tests for different number of groups - all the way to num_groups = num_in_channels (depthwise conv)
+@skip_for_grayskull()
+@pytest.mark.parametrize("device_params", [{"l1_small_size": 16384}], indirect=True)
+@pytest.mark.parametrize(
+    "batch_size, input_channels, output_channels, input_height, input_width, filter_height, filter_width, stride_h, stride_w, pad_h, pad_w, groups, use_1d_systolic_array, config_override, use_shallow_conv_variant",
+    ((1, 64, 64, 16, 16, 3, 3, 1, 1, 2, 2, 2, True, None, False),),
+)
+@pytest.mark.parametrize(
+    "weights_dtype",
+    [ttnn.bfloat16],
+)
+@pytest.mark.parametrize(
+    "activations_dtype",
+    [ttnn.bfloat8_b, ttnn.bfloat16],
+)
+@pytest.mark.parametrize("math_fidelity", [ttnn.MathFidelity.LoFi])
+@pytest.mark.parametrize("output_layout", [ttnn.TILE_LAYOUT])
+@pytest.mark.parametrize(
+    "dilation",
+    [
+        2,
+    ],
+)
+@pytest.mark.skip("Dilation is WIP")
+def test_conv_dilation(
+    device,
+    use_program_cache,
+    math_fidelity,
+    activations_dtype,
+    weights_dtype,
+    batch_size,
+    output_channels,
+    input_channels,
+    input_height,
+    input_width,
+    filter_height,
+    filter_width,
+    stride_h,
+    stride_w,
+    pad_h,
+    pad_w,
+    use_1d_systolic_array,
+    config_override,
+    use_shallow_conv_variant,
+    groups,
+    output_layout,
+    dilation,
+):
+    run_conv(
+        device,
+        math_fidelity,
+        activations_dtype,
+        weights_dtype,
+        batch_size,
+        output_channels,
+        input_channels,
+        input_height,
+        input_width,
+        filter_height,
+        filter_width,
+        stride_h,
+        stride_w,
+        pad_h,
+        pad_w,
+        use_1d_systolic_array,
+        config_override,
+        use_shallow_conv_variant=use_shallow_conv_variant,
+        groups=groups,
+        output_layout=output_layout,
+        dilation=dilation,
     )
 
 

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/conv2d.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/conv2d.cpp
@@ -731,7 +731,6 @@ std::tuple<ttnn::Tensor, uint32_t, uint32_t, ttnn::Tensor, std::optional<ttnn::T
             .stride_hw = {stride[0], stride[1]},
             .pad_hw = {padding[0], padding[1]},
             .dilation_hw = {dilation[0], dilation[1]},
-            .groups = groups,
             .num_cores_nhw = opt_conv_op_parallel_config.num_cores_nhw,
             .core_range_set = input_tensor_post_tm.memory_config().shard_spec.value().grid,
             .snap_to_tile = true
@@ -750,6 +749,7 @@ std::tuple<ttnn::Tensor, uint32_t, uint32_t, ttnn::Tensor, std::optional<ttnn::T
                 bias_tensor_on_device,
                 sliding_window_config,
                 out_channels,
+                groups,
                 conv_config.output_layout == Layout::ROW_MAJOR,
                 conv_config.activation == "relu",
                 conv_config.math_fidelity,
@@ -796,6 +796,7 @@ std::tuple<ttnn::Tensor, uint32_t, uint32_t, ttnn::Tensor, std::optional<ttnn::T
             bias_tensor_on_device,
             sliding_window_config,
             out_channels,
+            groups,
             conv_config.output_layout == Layout::ROW_MAJOR,
             conv_config.activation == "relu",
             conv_config.math_fidelity,

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/conv2d.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/conv2d.cpp
@@ -724,26 +724,22 @@ std::tuple<ttnn::Tensor, uint32_t, uint32_t, ttnn::Tensor, std::optional<ttnn::T
     }
     if (!use_matmul_for_1x1_conv) {
         // call halo op
-        SlidingWindowConfig sliding_window_config = SlidingWindowConfig(
-            batch_size,
-            input_height,
-            input_width,
-            kernel_size[0],
-            kernel_size[1],
-            stride[0],
-            stride[1],
-            padding[0],
-            padding[1],
-            dilation[0],
-            dilation[1],
-            groups,
-            opt_conv_op_parallel_config.num_cores_nhw,
-            input_tensor_post_tm.memory_config().shard_spec.value().grid,
-            true);
+        SlidingWindowConfig sliding_window_config = SlidingWindowConfig{
+            .batch_size = batch_size,
+            .input_hw = {input_height, input_width},
+            .window_hw = {kernel_size[0], kernel_size[1]},
+            .stride_hw = {stride[0], stride[1]},
+            .pad_hw = {padding[0], padding[1]},
+            .dilation_hw = {dilation[0], dilation[1]},
+            .groups = groups,
+            .num_cores_nhw = opt_conv_op_parallel_config.num_cores_nhw,
+            .core_range_set = input_tensor_post_tm.memory_config().shard_spec.value().grid,
+            .snap_to_tile = true
+        };
 
         bool bypass_halo = (parallel_config.shard_scheme == TensorMemoryLayout::WIDTH_SHARDED &&
-            sliding_window_config.pad_hw_.first==0 &&
-            sliding_window_config.pad_hw_.second==0
+            sliding_window_config.pad_hw.first==0 &&
+            sliding_window_config.pad_hw.second==0
             );
         if(bypass_halo)
         {

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/device/multi_core_optimized_conv_sharded/optimized_conv_op_sharded_v2.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/device/multi_core_optimized_conv_sharded/optimized_conv_op_sharded_v2.cpp
@@ -518,12 +518,12 @@ operation::ProgramWithCallbacks multi_core_optimized_conv_sharded_v2_impl(
     uint32_t conv_act_size_h = ashape_with_channels_padded[1];
     uint32_t conv_act_size_w = ashape_with_channels_padded[2];
     uint32_t conv_act_size_c = ashape_with_channels_padded[3];
-    uint32_t filter_h = (uint32_t)sliding_window_config.window_hw_.first;  // filter_h
-    uint32_t filter_w = (uint32_t)sliding_window_config.window_hw_.second;  // filter_W
-    uint32_t stride_h = (uint32_t)sliding_window_config.stride_hw_.first;
-    uint32_t stride_w = (uint32_t)sliding_window_config.stride_hw_.second;
-    uint32_t pad_h = (uint32_t)sliding_window_config.pad_hw_.first;
-    uint32_t pad_w = (uint32_t)sliding_window_config.pad_hw_.second;
+    uint32_t filter_h = (uint32_t)sliding_window_config.window_hw.first;  // filter_h
+    uint32_t filter_w = (uint32_t)sliding_window_config.window_hw.second;  // filter_W
+    uint32_t stride_h = (uint32_t)sliding_window_config.stride_hw.first;
+    uint32_t stride_w = (uint32_t)sliding_window_config.stride_hw.second;
+    uint32_t pad_h = (uint32_t)sliding_window_config.pad_hw.first;
+    uint32_t pad_w = (uint32_t)sliding_window_config.pad_hw.second;
 
     // Compute the 2d matrix shape
     auto [act_matrix_shape, act_matrix_shape_unpadded] =

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/device/multi_core_optimized_conv_sharded/optimized_conv_op_sharded_v2.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/device/multi_core_optimized_conv_sharded/optimized_conv_op_sharded_v2.cpp
@@ -43,7 +43,7 @@ operation::ProgramWithCallbacks multi_core_optimized_conv_width_sharded_v2_impl(
     const Shape& ashape,
     std::optional<const Tensor> bias,
     const std::optional<const Tensor> conv_reader_indices,
-    vector<int> conv_params,
+    sliding_window::SlidingWindowConfig sliding_window_config,
     uint32_t output_channels,
     bool untilize_out,
     bool has_bias,
@@ -339,7 +339,7 @@ operation::ProgramWithCallbacks multi_core_optimized_conv_sharded_v2_impl(
     const Shape& ashape,
     std::optional<const Tensor> bias,
     const std::optional<const Tensor> conv_reader_indices,
-    vector<int> conv_params,
+    sliding_window::SlidingWindowConfig sliding_window_config,
     uint32_t output_channels,
     bool untilize_out,
     bool has_bias,
@@ -518,17 +518,17 @@ operation::ProgramWithCallbacks multi_core_optimized_conv_sharded_v2_impl(
     uint32_t conv_act_size_h = ashape_with_channels_padded[1];
     uint32_t conv_act_size_w = ashape_with_channels_padded[2];
     uint32_t conv_act_size_c = ashape_with_channels_padded[3];
-    uint32_t weight_size_h = (uint32_t)conv_params[0];  // filter_h
-    uint32_t weight_size_w = (uint32_t)conv_params[1];  // filter_W
-    uint32_t stride_h = (uint32_t)conv_params[2];
-    uint32_t stride_w = (uint32_t)conv_params[3];
-    uint32_t pad_h = (uint32_t)conv_params[4];
-    uint32_t pad_w = (uint32_t)conv_params[5];
+    uint32_t filter_h = (uint32_t)sliding_window_config.window_hw_.first;  // filter_h
+    uint32_t filter_w = (uint32_t)sliding_window_config.window_hw_.second;  // filter_W
+    uint32_t stride_h = (uint32_t)sliding_window_config.stride_hw_.first;
+    uint32_t stride_w = (uint32_t)sliding_window_config.stride_hw_.second;
+    uint32_t pad_h = (uint32_t)sliding_window_config.pad_hw_.first;
+    uint32_t pad_w = (uint32_t)sliding_window_config.pad_hw_.second;
 
     // Compute the 2d matrix shape
     auto [act_matrix_shape, act_matrix_shape_unpadded] =
         optimized_conv_op_utils::compute_opt_conv_activation_as_mm_shape(
-            ashape_with_channels_padded.value, conv_params, out_block_h_ntiles, extra_padding_for_32B_alignment);
+            ashape_with_channels_padded.value, sliding_window_config, out_block_h_ntiles, extra_padding_for_32B_alignment);
     assert(act_matrix_shape.size() == 3);
     assert(act_matrix_shape[0] == 1);
     uint32_t act_matrix_height = (uint32_t)act_matrix_shape[1];
@@ -540,9 +540,8 @@ operation::ProgramWithCallbacks multi_core_optimized_conv_sharded_v2_impl(
 
     uint32_t input_width = ashape[2];
     uint32_t input_channels = ashape[3];
-    uint32_t kernel_width = conv_params[1];
-    uint32_t groups = conv_params[6];
-    bool is_conv1d = kernel_width == 1 && input_width == 1;
+    uint32_t groups = sliding_window_config.groups;
+    bool is_conv1d = filter_w == 1 && input_width == 1;
     bool is_depthwise_conv = groups == input_channels && groups == output_channels;
 
     if (has_bias) {
@@ -617,7 +616,7 @@ operation::ProgramWithCallbacks multi_core_optimized_conv_sharded_v2_impl(
     log_debug(LogOp, "act_block_num_tiles_split_last: {}", act_block_num_tiles_split_last);
 
     TT_FATAL(
-        (act_block_w_datums == round_up(conv_act_size_c * weight_size_w, TILE_WIDTH)) ||
+        (act_block_w_datums == round_up(conv_act_size_c * filter_w, TILE_WIDTH)) ||
         ((act_block_w_datums <= conv_act_size_c) && (conv_act_size_c % act_block_w_datums == 0)));
 
     // weight block info
@@ -687,8 +686,8 @@ operation::ProgramWithCallbacks multi_core_optimized_conv_sharded_v2_impl(
     auto [conv_output_size_h, conv_output_size_w] = optimized_conv_op_utils::compute_opt_conv_output_face_shape(
         conv_act_size_h,
         conv_act_size_w,
-        weight_size_h,
-        weight_size_w,
+        filter_h,
+        filter_w,
         stride_h,
         stride_w,
         pad_h,
@@ -785,12 +784,12 @@ operation::ProgramWithCallbacks multi_core_optimized_conv_sharded_v2_impl(
     uint32_t window_outer;
     uint32_t window_inner;
 
-    if (weight_width_sliced and weight_size_w == 3) {
+    if (weight_width_sliced and filter_w == 3) {
         window_outer = 1;  // window_outer = 1 becasue all of filter window is processed in the inner loop
         window_inner = 3;  // window_inner = 9 / 3, ie. read 3 width coalesced
     } else {
         window_outer = num_blocks_act_w;                                  // window_outer
-        window_inner = weight_size_h * weight_size_w / num_blocks_act_w;  // window_inner
+        window_inner = filter_h * filter_w / num_blocks_act_w;  // window_inner
     }
 
     reader_defines["WINDOW_INNER"] = std::to_string(window_inner);
@@ -941,14 +940,14 @@ operation::ProgramWithCallbacks multi_core_optimized_conv_sharded_v2_impl(
     uint32_t num_act_cb_tiles = act_block_h_ntiles * act_block_w_ntiles / conv_act_c_blocks;
     uint32_t num_act_cb_second_reader_tiles = 0;
     // TODO: This flag should be set in kernel logic but need this for create_CB
-    if (a.memory_config().is_sharded() and ((weight_size_h == 3 and weight_size_w == 3 and
-        (stride_h == 1 or stride_h == 2)) or (weight_size_h == 1 and weight_size_w == 1 and stride_h == 2)) and weight_width_sliced) {
+    if (a.memory_config().is_sharded() and ((filter_h == 3 and filter_w == 3 and
+        (stride_h == 1 or stride_h == 2)) or (filter_h == 1 and filter_w == 1 and stride_h == 2)) and weight_width_sliced) {
         // If conv_act_c_blocks > 1 and we have 2D conv with sharded input, we always read entire 3x3 window before
         // pushing in reader/writer
         // TODO: Generalize this to not make this assumption
         read_window_in_inner_loop = true;
-        num_weight_cb_tiles *= weight_size_h * weight_size_w;
-        num_act_cb_tiles *= weight_size_h * weight_size_w;
+        num_weight_cb_tiles *= filter_h * filter_w;
+        num_act_cb_tiles *= filter_h * filter_w;
     } else if (num_blocks_act_h_per_core > 1) {
         fully_buffer_weights = true;
     }
@@ -992,7 +991,7 @@ operation::ProgramWithCallbacks multi_core_optimized_conv_sharded_v2_impl(
 
     uint32_t conv_act_c_read_bytes = conv_act_size_c * a.element_size() / conv_act_c_blocks;
     uint32_t act_block_w_extra_align_bytes =
-        (round_up(conv_act_size_c * weight_size_w, TILE_WIDTH) - (conv_act_size_c * weight_size_w)) * a.element_size();
+        (round_up(conv_act_size_c * filter_w, TILE_WIDTH) - (conv_act_size_c * filter_w)) * a.element_size();
 
     uint32_t in0_block_w = act_block_w_ntiles / conv_act_c_blocks;
     uint32_t in0_block_num_tiles = act_block_num_tiles / conv_act_c_blocks;
@@ -1075,7 +1074,7 @@ operation::ProgramWithCallbacks multi_core_optimized_conv_sharded_v2_impl(
 
     compute_kernel = "ttnn/cpp/ttnn/operations/conv/conv2d/device/kernels/conv_bmm_tilize_col_major_out_blocks.cpp";
     // Input should always be sharded in this conv; always use reader kernel for input shard with halo and padding
-    if (weight_size_h >= 1 and weight_size_w >= 1) {
+    if (filter_h >= 1 and filter_w >= 1) {
         if (!is_conv1d and weight_width_sliced) {
             // 2D conv
             assert(read_window_in_inner_loop == true);
@@ -1109,7 +1108,7 @@ operation::ProgramWithCallbacks multi_core_optimized_conv_sharded_v2_impl(
         }
         else if (is_conv1d and is_depthwise_conv) {
             // 1D Depthwise Conv
-            TT_FATAL(act_block_w_datums == round_up(conv_act_size_c * weight_size_w, TILE_WIDTH));
+            TT_FATAL(act_block_w_datums == round_up(conv_act_size_c * filter_w, TILE_WIDTH));
             TT_FATAL(split_reader == false, "Split reader not supported for this conv yet!");
 
             compute_kernel = "ttnn/cpp/ttnn/operations/conv/conv2d/device/kernels/compute_depthwise_conv1d.cpp";
@@ -1122,7 +1121,7 @@ operation::ProgramWithCallbacks multi_core_optimized_conv_sharded_v2_impl(
 
         } else {
             // 1D conv
-            TT_FATAL(act_block_w_datums == round_up(conv_act_size_c * weight_size_w, TILE_WIDTH));
+            TT_FATAL(act_block_w_datums == round_up(conv_act_size_c * filter_w, TILE_WIDTH));
 
             reader_kernel =
                 "ttnn/cpp/ttnn/operations/conv/conv2d/device/kernels/reader_conv_activations_padded_with_halo_3x3_weights_v2.cpp";
@@ -1162,7 +1161,7 @@ operation::ProgramWithCallbacks multi_core_optimized_conv_sharded_v2_impl(
     }
 
     if (read_window_in_inner_loop) {
-        const uint32_t window_size = weight_size_h * weight_size_w;
+        const uint32_t window_size = filter_h * filter_w;
         in0_block_w *= window_size;
         in0_block_num_tiles *= window_size;
         in0_subblock_num_tiles *= window_size;
@@ -1183,10 +1182,10 @@ operation::ProgramWithCallbacks multi_core_optimized_conv_sharded_v2_impl(
         (uint32_t)window_inner,
         (uint32_t)reader_arg_act_block_h_datums,
         (uint32_t)(split_reader ? act_block_num_tiles_split / conv_act_c_blocks : act_block_num_tiles / conv_act_c_blocks),
-        (uint32_t)weight_size_w,
+        (uint32_t)filter_w,
         (uint32_t)conv_act_size_w + (2 * pad_w),
         (uint32_t)act_block_w_extra_align_bytes,  // only used for 1d systolic variant
-        (uint32_t)weight_size_h,
+        (uint32_t)filter_h,
         (uint32_t)num_blocks_act_h_per_core,                              // act_num_blocks_h
         (uint32_t)in0_block_num_tiles,                                    // act_block_num_tiles
         (uint32_t)conv_act_c_blocks,                                      // act_w_num_outer
@@ -1279,7 +1278,7 @@ operation::ProgramWithCallbacks multi_core_optimized_conv_sharded_v2_impl(
             // (uint32_t)act_block_num_tiles / conv_act_c_blocks,
             (uint32_t)act_block_num_tiles_split_last / conv_act_c_blocks,
             (uint32_t)conv_act_c_read_bytes,
-            (uint32_t)weight_size_w * conv_act_c_read_bytes,                  // coalesced_read_bytes
+            (uint32_t)filter_w * conv_act_c_read_bytes,                  // coalesced_read_bytes
             (uint32_t)(conv_act_size_w + 2 * pad_w) * conv_act_c_read_bytes,  // window_outer_offset
             (uint32_t)act_block_w_extra_align_bytes,                          // only used for 1d systolic variant
             (uint32_t)act_block_h_datums_split,                          // only used for 1d systolic variant
@@ -1680,7 +1679,7 @@ operation::ProgramWithCallbacks multi_core_optimized_conv_sharded_v2_(
     const Shape& ashape,
     std::optional<const Tensor> bias,
     const std::optional<const Tensor> conv_reader_indices,
-    vector<int> conv_params,
+    sliding_window::SlidingWindowConfig sliding_window_config,
     uint32_t output_channels,
     bool untilize_out,
     bool has_bias,
@@ -1704,7 +1703,7 @@ operation::ProgramWithCallbacks multi_core_optimized_conv_sharded_v2_(
         ashape,
         bias,
         conv_reader_indices,
-        conv_params,
+        sliding_window_config,
         output_channels,
         untilize_out,
         has_bias,
@@ -1727,7 +1726,7 @@ operation::ProgramWithCallbacks multi_core_optimized_conv_sharded_v2_(
         ashape,
         bias,
         conv_reader_indices,
-        conv_params,
+        sliding_window_config,
         output_channels,
         untilize_out,
         has_bias,
@@ -1748,7 +1747,7 @@ operation::ProgramWithCallbacks multi_core_optimized_conv_sharded_v2_new(
     const Tensor& a,
     const Tensor& b,
     std::optional<const Tensor> bias,
-    vector<int> conv_params,
+    sliding_window::SlidingWindowConfig sliding_window_config,
     uint32_t output_channels,
     bool untilize_out,
     bool fuse_relu,
@@ -1771,27 +1770,6 @@ operation::ProgramWithCallbacks multi_core_optimized_conv_sharded_v2_new(
     parallel_config.shard_scheme = a.memory_config().memory_layout;
     parallel_config.shard_orientation = a.shard_spec().value().orientation;
     // TODO: pass sliding window config to the function instead of conv params
-    uint32_t weight_size_h = (uint32_t)conv_params[0];  // filter_h
-    uint32_t weight_size_w = (uint32_t)conv_params[1];  // filter_W
-    uint32_t stride_h = (uint32_t)conv_params[2];
-    uint32_t stride_w = (uint32_t)conv_params[3];
-    uint32_t pad_h = (uint32_t)conv_params[4];
-    uint32_t pad_w = (uint32_t)conv_params[5];
-    auto sliding_window_config = ttnn::operations::sliding_window::SlidingWindowConfig(
-        input_tensor_shape[0],
-        input_tensor_shape[1],
-        input_tensor_shape[2],
-        weight_size_h,
-        weight_size_w,
-        stride_h,
-        stride_w,
-        pad_h,
-        pad_w,
-        1,
-        1,
-        parallelization_config.num_cores_nhw,
-        parallel_config.grid,
-        true);
 
     // create conv config tensors
     auto pad_metadata = ttnn::operations::sliding_window::generate_pad_metadata(sliding_window_config);
@@ -1803,22 +1781,7 @@ operation::ProgramWithCallbacks multi_core_optimized_conv_sharded_v2_new(
     DataType indices_tt_dtype = DataType::UINT16;
     // For 2d convs, each core in a column or row share the same specs
     CoreCoord grid_size = parallel_config.grid.bounding_box().grid_size();
-    // if(parallel_config.shard_scheme == TensorMemoryLayout::BLOCK_SHARDED) {
-    //     uint32_t num_shards_nhw = conv_sharded_input_top_left_indices.size();
-    //     TT_FATAL(sliding_window_config.num_cores_nhw_ == num_shards_nhw);
-    //     uint32_t num_shards_channels = 0;
-    //     if(parallel_config.shard_orientation == ShardOrientation::COL_MAJOR) {
-    //         num_shards_channels = grid_size.y;
-    //     } else {
-    //         num_shards_channels = grid_size.x;
-    //     }
-    //     // replicate across channel shards
-    //     for (uint32_t j = 1; j < num_shards_channels; j++) {
-    //         for (uint32_t i = 0; i < num_shards_nhw; i++) {
-    //             conv_sharded_input_top_left_indices.push_back(conv_sharded_input_top_left_indices[i]);
-    //         }
-    //     }
-    // }
+
     bool is_block_sharded = a.memory_config().memory_layout == TensorMemoryLayout::BLOCK_SHARDED;
     auto conv_reader_indices_tensor = ttnn::operations::sliding_window::construct_on_host_config_tensor(
         conv_sharded_input_top_left_indices, sliding_window_config, parallel_config);
@@ -1835,7 +1798,7 @@ operation::ProgramWithCallbacks multi_core_optimized_conv_sharded_v2_new(
         Shape(input_tensor_shape),
         bias,
         conv_reader_indices_tensor,
-        conv_params,
+        sliding_window_config,
         output_channels,
         untilize_out,
         bias.has_value(),
@@ -1858,7 +1821,7 @@ operation::ProgramWithCallbacks multi_core_optimized_conv_sharded_v2_new(
         Shape(input_tensor_shape),
         bias,
         conv_reader_indices_tensor,
-        conv_params,
+        sliding_window_config,
         output_channels,
         untilize_out,
         bias.has_value(),

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/device/multi_core_optimized_conv_sharded/optimized_conv_op_sharded_v2.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/device/multi_core_optimized_conv_sharded/optimized_conv_op_sharded_v2.cpp
@@ -45,6 +45,7 @@ operation::ProgramWithCallbacks multi_core_optimized_conv_width_sharded_v2_impl(
     const std::optional<const Tensor> conv_reader_indices,
     sliding_window::SlidingWindowConfig sliding_window_config,
     uint32_t output_channels,
+    uint32_t groups,
     bool untilize_out,
     bool has_bias,
     bool fuse_relu,
@@ -341,6 +342,7 @@ operation::ProgramWithCallbacks multi_core_optimized_conv_sharded_v2_impl(
     const std::optional<const Tensor> conv_reader_indices,
     sliding_window::SlidingWindowConfig sliding_window_config,
     uint32_t output_channels,
+    uint32_t groups,
     bool untilize_out,
     bool has_bias,
     bool fuse_relu,
@@ -540,7 +542,6 @@ operation::ProgramWithCallbacks multi_core_optimized_conv_sharded_v2_impl(
 
     uint32_t input_width = ashape[2];
     uint32_t input_channels = ashape[3];
-    uint32_t groups = sliding_window_config.groups;
     bool is_conv1d = filter_w == 1 && input_width == 1;
     bool is_depthwise_conv = groups == input_channels && groups == output_channels;
 
@@ -1681,6 +1682,7 @@ operation::ProgramWithCallbacks multi_core_optimized_conv_sharded_v2_(
     const std::optional<const Tensor> conv_reader_indices,
     sliding_window::SlidingWindowConfig sliding_window_config,
     uint32_t output_channels,
+    uint32_t groups,
     bool untilize_out,
     bool has_bias,
     bool fuse_relu,
@@ -1705,6 +1707,7 @@ operation::ProgramWithCallbacks multi_core_optimized_conv_sharded_v2_(
         conv_reader_indices,
         sliding_window_config,
         output_channels,
+        groups,
         untilize_out,
         has_bias,
         fuse_relu,
@@ -1728,6 +1731,7 @@ operation::ProgramWithCallbacks multi_core_optimized_conv_sharded_v2_(
         conv_reader_indices,
         sliding_window_config,
         output_channels,
+        groups,
         untilize_out,
         has_bias,
         fuse_relu,
@@ -1749,6 +1753,7 @@ operation::ProgramWithCallbacks multi_core_optimized_conv_sharded_v2_new(
     std::optional<const Tensor> bias,
     sliding_window::SlidingWindowConfig sliding_window_config,
     uint32_t output_channels,
+    uint32_t groups,
     bool untilize_out,
     bool fuse_relu,
     MathFidelity math_fidelity,
@@ -1799,6 +1804,7 @@ operation::ProgramWithCallbacks multi_core_optimized_conv_sharded_v2_new(
         conv_reader_indices_tensor,
         sliding_window_config,
         output_channels,
+        groups,
         untilize_out,
         bias.has_value(),
         fuse_relu,
@@ -1822,6 +1828,7 @@ operation::ProgramWithCallbacks multi_core_optimized_conv_sharded_v2_new(
         conv_reader_indices_tensor,
         sliding_window_config,
         output_channels,
+        groups,
         untilize_out,
         bias.has_value(),
         fuse_relu,

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/device/multi_core_optimized_conv_sharded/optimized_conv_op_sharded_v2.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/device/multi_core_optimized_conv_sharded/optimized_conv_op_sharded_v2.cpp
@@ -1764,12 +1764,11 @@ operation::ProgramWithCallbacks multi_core_optimized_conv_sharded_v2_new(
     bool enable_split_reader,
     bool enable_subblock_padding) {
     tt_metal::Program program = tt_metal::CreateProgram();
-    // TODO: conv params need to be cleaned up and replaced with sliding window config
+
     ttnn::operations::sliding_window::ParallelConfig parallel_config;
     parallel_config.grid = a.shard_spec().value().grid;
     parallel_config.shard_scheme = a.memory_config().memory_layout;
     parallel_config.shard_orientation = a.shard_spec().value().orientation;
-    // TODO: pass sliding window config to the function instead of conv params
 
     // create conv config tensors
     auto pad_metadata = ttnn::operations::sliding_window::generate_pad_metadata(sliding_window_config);

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/device/multi_core_optimized_conv_sharded/optimized_conv_op_width_sharded_v2.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/device/multi_core_optimized_conv_sharded/optimized_conv_op_width_sharded_v2.cpp
@@ -43,6 +43,7 @@ operation::ProgramWithCallbacks multi_core_optimized_conv_width_sharded_v2_impl(
     const std::optional<const Tensor> conv_reader_indices,
     sliding_window::SlidingWindowConfig sliding_window_config,
     uint32_t output_channels,
+    uint32_t groups,
     bool untilize_out,
     bool has_bias,
     bool fuse_relu,

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/device/multi_core_optimized_conv_sharded/optimized_conv_op_width_sharded_v2.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/device/multi_core_optimized_conv_sharded/optimized_conv_op_width_sharded_v2.cpp
@@ -214,12 +214,12 @@ operation::ProgramWithCallbacks multi_core_optimized_conv_width_sharded_v2_impl(
     uint32_t conv_act_size_h = ashape_with_channels_padded[1];
     uint32_t conv_act_size_w = ashape_with_channels_padded[2];
     uint32_t conv_act_size_c = ashape_with_channels_padded[3];
-    uint32_t filter_h = (uint32_t)sliding_window_config.window_hw_.first;  // filter_h
-    uint32_t filter_w = (uint32_t)sliding_window_config.window_hw_.second;  // filter_W
-    uint32_t stride_h = (uint32_t)sliding_window_config.stride_hw_.first;
-    uint32_t stride_w = (uint32_t)sliding_window_config.stride_hw_.second;
-    uint32_t pad_h = (uint32_t)sliding_window_config.pad_hw_.first;
-    uint32_t pad_w = (uint32_t)sliding_window_config.pad_hw_.second;
+    uint32_t filter_h = (uint32_t)sliding_window_config.window_hw.first;  // filter_h
+    uint32_t filter_w = (uint32_t)sliding_window_config.window_hw.second;  // filter_W
+    uint32_t stride_h = (uint32_t)sliding_window_config.stride_hw.first;
+    uint32_t stride_w = (uint32_t)sliding_window_config.stride_hw.second;
+    uint32_t pad_h = (uint32_t)sliding_window_config.pad_hw.first;
+    uint32_t pad_w = (uint32_t)sliding_window_config.pad_hw.second;
     uint32_t input_size_h = conv_act_size_h + (pad_h*2);
     uint32_t input_size_w = conv_act_size_w + (pad_w*2);
 

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/device/multi_core_optimized_conv_sharded/optimized_conv_op_width_sharded_v2.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/device/multi_core_optimized_conv_sharded/optimized_conv_op_width_sharded_v2.cpp
@@ -41,7 +41,7 @@ operation::ProgramWithCallbacks multi_core_optimized_conv_width_sharded_v2_impl(
     const Shape& ashape,
     std::optional<const Tensor> bias,
     const std::optional<const Tensor> conv_reader_indices,
-    vector<int> conv_params,
+    sliding_window::SlidingWindowConfig sliding_window_config,
     uint32_t output_channels,
     bool untilize_out,
     bool has_bias,
@@ -214,12 +214,12 @@ operation::ProgramWithCallbacks multi_core_optimized_conv_width_sharded_v2_impl(
     uint32_t conv_act_size_h = ashape_with_channels_padded[1];
     uint32_t conv_act_size_w = ashape_with_channels_padded[2];
     uint32_t conv_act_size_c = ashape_with_channels_padded[3];
-    uint32_t weight_size_h = (uint32_t)conv_params[0];  // filter_h
-    uint32_t weight_size_w = (uint32_t)conv_params[1];  // filter_W
-    uint32_t stride_h = (uint32_t)conv_params[2];
-    uint32_t stride_w = (uint32_t)conv_params[3];
-    uint32_t pad_h = (uint32_t)conv_params[4];
-    uint32_t pad_w = (uint32_t)conv_params[5];
+    uint32_t filter_h = (uint32_t)sliding_window_config.window_hw_.first;  // filter_h
+    uint32_t filter_w = (uint32_t)sliding_window_config.window_hw_.second;  // filter_W
+    uint32_t stride_h = (uint32_t)sliding_window_config.stride_hw_.first;
+    uint32_t stride_w = (uint32_t)sliding_window_config.stride_hw_.second;
+    uint32_t pad_h = (uint32_t)sliding_window_config.pad_hw_.first;
+    uint32_t pad_w = (uint32_t)sliding_window_config.pad_hw_.second;
     uint32_t input_size_h = conv_act_size_h + (pad_h*2);
     uint32_t input_size_w = conv_act_size_w + (pad_w*2);
 
@@ -227,7 +227,7 @@ operation::ProgramWithCallbacks multi_core_optimized_conv_width_sharded_v2_impl(
     // Compute the 2d matrix shape
     auto [act_matrix_shape, act_matrix_shape_unpadded] =
         optimized_conv_op_utils::compute_opt_conv_activation_as_mm_shape(
-            ashape_with_channels_padded.value, conv_params, out_block_h_ntiles, extra_padding_for_32B_alignment);
+            ashape_with_channels_padded.value, sliding_window_config, out_block_h_ntiles, extra_padding_for_32B_alignment);
     TT_FATAL(act_matrix_shape.size() == 3);
     TT_FATAL(act_matrix_shape[0] == 1);
     uint32_t act_matrix_height = (uint32_t)act_matrix_shape[1];
@@ -309,10 +309,10 @@ operation::ProgramWithCallbacks multi_core_optimized_conv_width_sharded_v2_impl(
     log_debug(LogOp, "act_block_num_tiles_split_last: {}", act_block_num_tiles_split_last);
     log_debug(LogOp, "act_block_w_datums: {}", act_block_w_datums);
     log_debug(LogOp, "conv_act_size_c: {}", conv_act_size_c);
-    log_debug(LogOp, "weight_size_w: {}", weight_size_w);
+    log_debug(LogOp, "filter_w: {}", filter_w);
 
     // TT_FATAL(
-    //     (act_block_w_datums == round_up(conv_act_size_c * weight_size_w, TILE_WIDTH)) ||
+    //     (act_block_w_datums == round_up(conv_act_size_c * filter_w, TILE_WIDTH)) ||
     //     ((act_block_w_datums <= conv_act_size_c)
     //      && (conv_act_size_c % act_block_w_datums == 0)
     //      ));
@@ -389,8 +389,8 @@ operation::ProgramWithCallbacks multi_core_optimized_conv_width_sharded_v2_impl(
     auto [conv_output_size_h, conv_output_size_w] = optimized_conv_op_utils::compute_opt_conv_output_face_shape(
         conv_act_size_h,
         conv_act_size_w,
-        weight_size_h,
-        weight_size_w,
+        filter_h,
+        filter_w,
         stride_h,
         stride_w,
         pad_h,
@@ -528,8 +528,8 @@ operation::ProgramWithCallbacks multi_core_optimized_conv_width_sharded_v2_impl(
         (uint32_t)input_size_w,
         (uint32_t)conv_output_size_w,  // conv_output_w_last_index
         (uint32_t)conv_act_c_read_bytes,
-        (uint32_t)weight_size_h, //Input filter window height
-        (uint32_t)weight_size_w, //Input filter window width
+        (uint32_t)filter_h, //Input filter window height
+        (uint32_t)filter_w, //Input filter window width
         (uint32_t)act_block_h_datums,
         (uint32_t)act_block_num_tiles,
         (uint32_t)total_num_cores,
@@ -545,8 +545,8 @@ operation::ProgramWithCallbacks multi_core_optimized_conv_width_sharded_v2_impl(
     };
     weights_kernel_compile_args = {
         weight_cb,                                                  //cb_id_weight
-        act_block_w_ntiles/(weight_size_h*weight_size_w),           //core_in_channels_ntiles
-        weight_size_h*weight_size_w,                                //window_size_hw
+        act_block_w_ntiles/(filter_h*filter_w),           //core_in_channels_ntiles
+        filter_h*filter_w,                                //window_size_hw
         weight_block_w_ntiles,                                      //weight_block_width_ntiles
         weight_block_num_tiles,                                     //weight_block_num_tiles
         weight_matrix_width_ntiles,                                 //weight_matrix_width_ntiles

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/device/optimized_conv_op.hpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/device/optimized_conv_op.hpp
@@ -45,10 +45,11 @@ struct OptimizedConvBlockConfig {
 
 operation::ProgramWithCallbacks multi_core_optimized_conv_(const Tensor& a, const Tensor &b, const Shape& ashape, std::optional<const Tensor> bias, vector<int> conv_params, uint32_t output_channels, bool untilize_out, bool has_bias, bool fuse_relu, const MathFidelity math_fidelity, const OptimizedConvParallelizationConfig& parallelization_config, const OptimizedConvBlockConfig& block_config, uint32_t extra_padding_for_32B_alignment, Tensor &output);
 operation::ProgramWithCallbacks multi_core_optimized_conv_sharded_(const Tensor& a, const Tensor &b, const Shape& ashape, std::optional<const Tensor> bias, vector<int> conv_params, uint32_t output_channels, bool untilize_out, bool has_bias, bool fuse_relu, const MathFidelity math_fidelity, const OptimizedConvParallelizationConfig& parallelization_config, const OptimizedConvBlockConfig& block_config, uint32_t extra_padding_for_32B_alignment, Tensor &output);
-operation::ProgramWithCallbacks multi_core_optimized_conv_sharded_v2_(const Tensor& a, const Tensor &b, const Shape& ashape, std::optional<const Tensor> bias, const std::optional<const Tensor> conv_reader_indices, sliding_window::SlidingWindowConfig sliding_window_config, uint32_t output_channels, bool untilize_out, bool has_bias, bool fuse_relu, const OptimizedConvParallelizationConfig& parallelization_config, const OptimizedConvBlockConfig& block_config, uint32_t extra_padding_for_32B_alignment, bool use_shallow_conv_variant, bool transpose_mcast, Tensor &output, DeviceComputeKernelConfig compute_kernel_config, bool enable_act_double_buffer, bool enable_split_reader, bool enable_subblock_padding);
+operation::ProgramWithCallbacks multi_core_optimized_conv_sharded_v2_(const Tensor& a, const Tensor &b, const Shape& ashape, std::optional<const Tensor> bias, const std::optional<const Tensor> conv_reader_indices, sliding_window::SlidingWindowConfig sliding_window_config, uint32_t output_channels, uint32_t groups, bool untilize_out, bool has_bias, bool fuse_relu, const OptimizedConvParallelizationConfig& parallelization_config, const OptimizedConvBlockConfig& block_config, uint32_t extra_padding_for_32B_alignment, bool use_shallow_conv_variant, bool transpose_mcast, Tensor &output, DeviceComputeKernelConfig compute_kernel_config, bool enable_act_double_buffer, bool enable_split_reader, bool enable_subblock_padding);
 operation::ProgramWithCallbacks multi_core_optimized_conv_sharded_v2_new(const Tensor& a, const Tensor &b, std::optional<const Tensor> bias,
     sliding_window::SlidingWindowConfig sliding_window_config,
     uint32_t output_channels,
+    uint32_t groups,
     bool untilize_out, bool fuse_relu, MathFidelity math_fidelity,
     const OptimizedConvParallelizationConfig& parallelization_config,
     const OptimizedConvBlockConfig& block_config, uint32_t extra_padding_for_32B_alignment,
@@ -170,6 +171,7 @@ struct OptimizedConvNew {
     OptimizedConvBlockConfig block_config;
     const sliding_window::SlidingWindowConfig& sliding_window_config;
     const uint32_t output_channels;
+    const uint32_t groups;
     bool untilize_out, has_bias, fuse_relu;
     MathFidelity math_fidelity;
     uint32_t extra_padding_for_32B_alignment;
@@ -182,7 +184,8 @@ struct OptimizedConvNew {
     bool enable_split_reader;
     bool enable_subblock_padding;
     OptimizedConvNew(const sliding_window::SlidingWindowConfig& sliding_window_config,
-        uint32_t output_channels, bool untile_out,
+        uint32_t output_channels, uint32_t groups,
+        bool untile_out,
         bool has_bias, bool fuse_relu,
         MathFidelity mfidelity, const OptimizedConvParallelizationConfig& p_config,
         const OptimizedConvBlockConfig& b_config,
@@ -191,6 +194,7 @@ struct OptimizedConvNew {
         std::array<std::uint32_t, 4> input_tensor_shape, bool use_shallow_conv_variant,
         const DeviceComputeKernelConfig compute_kernel_config, bool enable_act_double_buffer, bool enable_split_reader, bool enable_subblock_padding) :
             output_channels(output_channels),
+            groups(groups),
             sliding_window_config(sliding_window_config),
             untilize_out(untile_out),
             has_bias(has_bias),
@@ -253,6 +257,7 @@ struct OptimizedConvNew {
 Tensor optimized_conv_new(const Tensor& a, const Tensor &b, std::optional<const Tensor> bias,
     sliding_window::SlidingWindowConfig sliding_window_config,
     uint32_t output_channels,
+    uint32_t groups,
     bool untilize_out, bool fuse_relu, MathFidelity math_fidelity,
     const OptimizedConvParallelizationConfig& parallelization_config,
     const OptimizedConvBlockConfig& block_config, uint32_t extra_padding_for_32B_alignment,

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/device/optimized_conv_op.hpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/device/optimized_conv_op.hpp
@@ -4,6 +4,7 @@
 
 #pragma once
 
+#include "ttnn/operations/sliding_window/sliding_window.hpp"
 #include "ttnn/tensor/tensor.hpp"
 #include "ttnn/run_operation.hpp"
 #include "ttnn/operations/core/compute_kernel/compute_kernel_config.hpp"
@@ -44,9 +45,9 @@ struct OptimizedConvBlockConfig {
 
 operation::ProgramWithCallbacks multi_core_optimized_conv_(const Tensor& a, const Tensor &b, const Shape& ashape, std::optional<const Tensor> bias, vector<int> conv_params, uint32_t output_channels, bool untilize_out, bool has_bias, bool fuse_relu, const MathFidelity math_fidelity, const OptimizedConvParallelizationConfig& parallelization_config, const OptimizedConvBlockConfig& block_config, uint32_t extra_padding_for_32B_alignment, Tensor &output);
 operation::ProgramWithCallbacks multi_core_optimized_conv_sharded_(const Tensor& a, const Tensor &b, const Shape& ashape, std::optional<const Tensor> bias, vector<int> conv_params, uint32_t output_channels, bool untilize_out, bool has_bias, bool fuse_relu, const MathFidelity math_fidelity, const OptimizedConvParallelizationConfig& parallelization_config, const OptimizedConvBlockConfig& block_config, uint32_t extra_padding_for_32B_alignment, Tensor &output);
-operation::ProgramWithCallbacks multi_core_optimized_conv_sharded_v2_(const Tensor& a, const Tensor &b, const Shape& ashape, std::optional<const Tensor> bias, const std::optional<const Tensor> conv_reader_indices, vector<int> conv_params, uint32_t output_channels, bool untilize_out, bool has_bias, bool fuse_relu, const OptimizedConvParallelizationConfig& parallelization_config, const OptimizedConvBlockConfig& block_config, uint32_t extra_padding_for_32B_alignment, bool use_shallow_conv_variant, bool transpose_mcast, Tensor &output, DeviceComputeKernelConfig compute_kernel_config, bool enable_act_double_buffer, bool enable_split_reader, bool enable_subblock_padding);
+operation::ProgramWithCallbacks multi_core_optimized_conv_sharded_v2_(const Tensor& a, const Tensor &b, const Shape& ashape, std::optional<const Tensor> bias, const std::optional<const Tensor> conv_reader_indices, sliding_window::SlidingWindowConfig sliding_window_config, uint32_t output_channels, bool untilize_out, bool has_bias, bool fuse_relu, const OptimizedConvParallelizationConfig& parallelization_config, const OptimizedConvBlockConfig& block_config, uint32_t extra_padding_for_32B_alignment, bool use_shallow_conv_variant, bool transpose_mcast, Tensor &output, DeviceComputeKernelConfig compute_kernel_config, bool enable_act_double_buffer, bool enable_split_reader, bool enable_subblock_padding);
 operation::ProgramWithCallbacks multi_core_optimized_conv_sharded_v2_new(const Tensor& a, const Tensor &b, std::optional<const Tensor> bias,
-    vector<int> conv_params,
+    sliding_window::SlidingWindowConfig sliding_window_config,
     uint32_t output_channels,
     bool untilize_out, bool fuse_relu, MathFidelity math_fidelity,
     const OptimizedConvParallelizationConfig& parallelization_config,
@@ -167,7 +168,7 @@ Tensor optimized_conv(const Tensor& a, const Tensor &b, std::optional<const Tens
 struct OptimizedConvNew {
     OptimizedConvParallelizationConfig parallelization_config;
     OptimizedConvBlockConfig block_config;
-    const std::vector<int> conv_params;
+    const sliding_window::SlidingWindowConfig& sliding_window_config;
     const uint32_t output_channels;
     bool untilize_out, has_bias, fuse_relu;
     MathFidelity math_fidelity;
@@ -180,7 +181,7 @@ struct OptimizedConvNew {
     bool enable_act_double_buffer;
     bool enable_split_reader;
     bool enable_subblock_padding;
-    OptimizedConvNew(const vector<int>& c_params,
+    OptimizedConvNew(const sliding_window::SlidingWindowConfig& sliding_window_config,
         uint32_t output_channels, bool untile_out,
         bool has_bias, bool fuse_relu,
         MathFidelity mfidelity, const OptimizedConvParallelizationConfig& p_config,
@@ -190,7 +191,7 @@ struct OptimizedConvNew {
         std::array<std::uint32_t, 4> input_tensor_shape, bool use_shallow_conv_variant,
         const DeviceComputeKernelConfig compute_kernel_config, bool enable_act_double_buffer, bool enable_split_reader, bool enable_subblock_padding) :
             output_channels(output_channels),
-            conv_params(c_params),
+            sliding_window_config(sliding_window_config),
             untilize_out(untile_out),
             has_bias(has_bias),
             fuse_relu(fuse_relu),
@@ -216,7 +217,7 @@ struct OptimizedConvNew {
     static constexpr auto attribute_names = std::make_tuple(
         "parallelization_config",
         "block_config",
-        "conv_params",
+        "sliding_window_config",
         "output_channels",
         "untilize_out",
         "has_bias",
@@ -233,7 +234,7 @@ struct OptimizedConvNew {
         return std::make_tuple(
             std::cref(this->parallelization_config),
             std::cref(this->block_config),
-            std::cref(this->conv_params),
+            std::cref(this->sliding_window_config),
             std::cref(this->output_channels),
             std::cref(this->untilize_out),
             std::cref(this->has_bias),
@@ -250,7 +251,7 @@ struct OptimizedConvNew {
 };
 
 Tensor optimized_conv_new(const Tensor& a, const Tensor &b, std::optional<const Tensor> bias,
-    const vector<int> conv_params,
+    sliding_window::SlidingWindowConfig sliding_window_config,
     uint32_t output_channels,
     bool untilize_out, bool fuse_relu, MathFidelity math_fidelity,
     const OptimizedConvParallelizationConfig& parallelization_config,
@@ -278,5 +279,6 @@ using namespace tt::tt_metal;
 pair<uint32_t, uint32_t> compute_opt_conv_output_face_shape(uint32_t conv_activation_h, uint32_t conv_activation_w, uint32_t filter_h, uint32_t filter_w, uint32_t stride_h, uint32_t stride_w, uint32_t pad_h, uint32_t pad_w, uint32_t padding_for_32B_alignment=0);
 
 pair<vector<uint32_t>, vector<uint32_t>> compute_opt_conv_activation_as_mm_shape(const Shape& conv_activation_shape, vector<int> conv_params, uint32_t act_block_h_ntiles, uint32_t padding_for_32B_alignment);
+pair<vector<uint32_t>, vector<uint32_t>> compute_opt_conv_activation_as_mm_shape(const Shape& conv_activation_shape, ttnn::operations::sliding_window::SlidingWindowConfig sliding_window_config, uint32_t act_block_h_ntiles, uint32_t padding_for_32B_alignment);
 
 } // optimized_conv_op_utils

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/device/optimized_conv_op_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/device/optimized_conv_op_program_factory.cpp
@@ -230,8 +230,19 @@ operation::ProgramWithCallbacks OptimizedConv::create_program(const std::vector<
     if (input_tensor_a.memory_config().is_sharded()) {
         // If conv_reader_indices is passed in, use v2 where we don't generate indices locally
         if (conv_reader_indices.has_value()) {
-            TT_FATAL(0," Conv Sharded v2 only supported via the new ttnn.conv2d API. ");
-            // return multi_core_optimized_conv_sharded_v2_(input_tensor_a, input_tensor_b, this->input_tensor_shape, input_tensor_bias, conv_reader_indices, sliding_window_config, output_channels, untilize_out, has_bias, fuse_relu, parallelization_config, block_config, extra_padding_for_32B_alignment, this->use_shallow_conv_variant, transpose_mcast, output_tensor, this->compute_kernel_config, this->enable_act_double_buffer, this->enable_split_reader, this->enable_subblock_padding);
+            const auto& input_tensor_a_shape = this->input_tensor_shape;
+            auto sliding_window_config = sliding_window::SlidingWindowConfig(
+                input_tensor_a_shape[0],
+                input_tensor_a_shape[1],
+                input_tensor_a_shape[2],
+                conv_params[0], //filter_h
+                conv_params[1], //filter_w
+                conv_params[2], //stride_h
+                conv_params[3], //stride_w
+                conv_params[4], //pad_h
+                conv_params[5] //pad_w
+            );
+            return multi_core_optimized_conv_sharded_v2_(input_tensor_a, input_tensor_b, this->input_tensor_shape, input_tensor_bias, conv_reader_indices, sliding_window_config, output_channels, untilize_out, has_bias, fuse_relu, parallelization_config, block_config, extra_padding_for_32B_alignment, this->use_shallow_conv_variant, transpose_mcast, output_tensor, this->compute_kernel_config, this->enable_act_double_buffer, this->enable_split_reader, this->enable_subblock_padding);
         } else {
             return multi_core_optimized_conv_sharded_(input_tensor_a, input_tensor_b, this->input_tensor_shape, input_tensor_bias, conv_params, output_channels, untilize_out, has_bias, fuse_relu, math_fidelity, parallelization_config, block_config, extra_padding_for_32B_alignment, output_tensor);
         }

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/device/optimized_conv_op_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/device/optimized_conv_op_program_factory.cpp
@@ -17,6 +17,7 @@
 #include "ttnn/deprecated/tt_dnn/op_library/sharding_utilities.hpp"
 #include "ttnn/operations/experimental/auto_format/auto_format.hpp"
 
+#include "ttnn/operations/sliding_window/sliding_window.hpp"
 #include "ttnn/tensor/tensor_utils.hpp"
 using namespace tt::constants;
 namespace optimized_conv_op_utils {
@@ -35,6 +36,24 @@ pair<vector<uint32_t>, vector<uint32_t>> compute_opt_conv_activation_as_mm_shape
     uint32_t stride_w = (uint32_t) conv_params[3];
     uint32_t pad_h = (uint32_t) conv_params[4];
     uint32_t pad_w = (uint32_t) conv_params[5];
+    auto [conv_output_h, conv_output_w] = compute_opt_conv_output_face_shape(conv_activation_shape[1], conv_activation_shape[2], filter_h, filter_w, stride_h, stride_w, pad_h, pad_w, padding_for_32B_alignment);
+    uint32_t batch_size = conv_activation_shape[0];
+    // pad height
+    uint32_t num_rows = (uint32_t) batch_size * conv_output_h * conv_output_w;
+    uint32_t act_block_h_datums = act_block_h_ntiles * TILE_HEIGHT;
+    uint32_t num_rows_padded = (uint32_t) (std::ceil((double) num_rows / (double) act_block_h_datums ) * act_block_h_datums);
+    uint32_t num_cols = conv_activation_shape[3] * filter_h * filter_w;
+    uint32_t num_cols_padded = round_up(conv_activation_shape[3] * filter_w, TILE_WIDTH) * filter_h;
+    return {{1, num_rows_padded, num_cols_padded}, {1, num_rows, num_cols}};
+}
+
+pair<vector<uint32_t>, vector<uint32_t>> compute_opt_conv_activation_as_mm_shape(const Shape& conv_activation_shape, ttnn::operations::sliding_window::SlidingWindowConfig sliding_window_config, uint32_t act_block_h_ntiles, uint32_t padding_for_32B_alignment) {
+    uint32_t filter_h = (uint32_t)sliding_window_config.window_hw_.first;  // filter_h
+    uint32_t filter_w = (uint32_t)sliding_window_config.window_hw_.second;  // filter_W
+    uint32_t stride_h = (uint32_t)sliding_window_config.stride_hw_.first;
+    uint32_t stride_w = (uint32_t)sliding_window_config.stride_hw_.second;
+    uint32_t pad_h = (uint32_t)sliding_window_config.pad_hw_.first;
+    uint32_t pad_w = (uint32_t)sliding_window_config.pad_hw_.second;
     auto [conv_output_h, conv_output_w] = compute_opt_conv_output_face_shape(conv_activation_shape[1], conv_activation_shape[2], filter_h, filter_w, stride_h, stride_w, pad_h, pad_w, padding_for_32B_alignment);
     uint32_t batch_size = conv_activation_shape[0];
     // pad height
@@ -211,7 +230,8 @@ operation::ProgramWithCallbacks OptimizedConv::create_program(const std::vector<
     if (input_tensor_a.memory_config().is_sharded()) {
         // If conv_reader_indices is passed in, use v2 where we don't generate indices locally
         if (conv_reader_indices.has_value()) {
-            return multi_core_optimized_conv_sharded_v2_(input_tensor_a, input_tensor_b, this->input_tensor_shape, input_tensor_bias, conv_reader_indices, conv_params, output_channels, untilize_out, has_bias, fuse_relu, parallelization_config, block_config, extra_padding_for_32B_alignment, this->use_shallow_conv_variant, transpose_mcast, output_tensor, this->compute_kernel_config, this->enable_act_double_buffer, this->enable_split_reader, this->enable_subblock_padding);
+            TT_FATAL(0," Conv Sharded v2 only supported via the new ttnn.conv2d API. ");
+            // return multi_core_optimized_conv_sharded_v2_(input_tensor_a, input_tensor_b, this->input_tensor_shape, input_tensor_bias, conv_reader_indices, sliding_window_config, output_channels, untilize_out, has_bias, fuse_relu, parallelization_config, block_config, extra_padding_for_32B_alignment, this->use_shallow_conv_variant, transpose_mcast, output_tensor, this->compute_kernel_config, this->enable_act_double_buffer, this->enable_split_reader, this->enable_subblock_padding);
         } else {
             return multi_core_optimized_conv_sharded_(input_tensor_a, input_tensor_b, this->input_tensor_shape, input_tensor_bias, conv_params, output_channels, untilize_out, has_bias, fuse_relu, math_fidelity, parallelization_config, block_config, extra_padding_for_32B_alignment, output_tensor);
         }
@@ -271,7 +291,7 @@ operation::OpPerformanceModel OptimizedConv::create_op_performance_model(const s
 }
 
 Tensor optimized_conv_new(const Tensor& a, const Tensor &b, std::optional<const Tensor> bias,
-    const vector<int> conv_params,
+    sliding_window::SlidingWindowConfig sliding_window_config,
     uint32_t output_channels,
     bool untilize_out, bool fuse_relu, MathFidelity math_fidelity,
     const OptimizedConvParallelizationConfig& parallelization_config,
@@ -287,7 +307,7 @@ Tensor optimized_conv_new(const Tensor& a, const Tensor &b, std::optional<const 
 ) {
     std::vector<Tensor> output_tensors = {Tensor(operation::get_workers_for_op_output({a, b}))};
     operation::launch_op(
-        [conv_params, output_channels, untilize_out, fuse_relu, math_fidelity, parallelization_config, block_config, extra_padding_for_32B_alignment, memory_config, dtype, input_tensor_shape, use_shallow_conv_variant, compute_kernel_config, enable_act_double_buffer, enable_split_reader, enable_subblock_padding]
+        [sliding_window_config, output_channels, untilize_out, fuse_relu, math_fidelity, parallelization_config, block_config, extra_padding_for_32B_alignment, memory_config, dtype, input_tensor_shape, use_shallow_conv_variant, compute_kernel_config, enable_act_double_buffer, enable_split_reader, enable_subblock_padding]
             (const std::vector<Tensor>& input_tensors, const std::vector<std::optional<const Tensor>>& optional_input_tensors, const std::vector<std::optional<Tensor>>& optional_output_tensors) mutable -> std::vector<Tensor> {
                 using ttnn::operations::experimental::auto_format::FormatParams;
                 auto& a = input_tensors.at(0);
@@ -308,7 +328,7 @@ Tensor optimized_conv_new(const Tensor& a, const Tensor &b, std::optional<const 
                 bool fp32_accum = a.device()->arch() == tt::ARCH::WORMHOLE_B0;  // && compute_kernel_config.has_value()) ? compute_kernel_config.value().fp32_dest_acc_en : false;
                 auto kernel_config_val = init_device_compute_kernel_config(arch, compute_kernel_config, MathFidelity::LoFi, true, fp32_accum, false);
                 return operation::run_without_autoformat(
-                    OptimizedConvNew(conv_params, output_channels, untilize_out, bias.has_value(), fuse_relu, math_fidelity, parallelization_config, block_config, extra_padding_for_32B_alignment, memory_config, dtype, input_tensor_shape, use_shallow_conv_variant, kernel_config_val, enable_act_double_buffer, enable_split_reader, enable_subblock_padding
+                    OptimizedConvNew(sliding_window_config, output_channels, untilize_out, bias.has_value(), fuse_relu, math_fidelity, parallelization_config, block_config, extra_padding_for_32B_alignment, memory_config, dtype, input_tensor_shape, use_shallow_conv_variant, kernel_config_val, enable_act_double_buffer, enable_split_reader, enable_subblock_padding
                     ),
                     input_tensors,
                     optional_input_tensors);
@@ -327,7 +347,7 @@ void OptimizedConvNew::validate(const std::vector<Tensor>& input_tensors, const 
     }
     if (this->memory_config.is_sharded()) {
         uint32_t out_block_h_ntiles = parallelization_config.per_core_out_matrix_height_ntiles;
-        auto [act_matrix_shape, act_matrix_shape_unpadded] = optimized_conv_op_utils::compute_opt_conv_activation_as_mm_shape(input_tensor_a.get_legacy_shape(), conv_params, out_block_h_ntiles, extra_padding_for_32B_alignment);
+        auto [act_matrix_shape, act_matrix_shape_unpadded] = optimized_conv_op_utils::compute_opt_conv_activation_as_mm_shape(input_tensor_a.get_legacy_shape(), sliding_window_config, out_block_h_ntiles, extra_padding_for_32B_alignment);
         uint32_t out_width_ntiles = this->compute_output_shapes(input_tensors).at(0)[-1] / TILE_WIDTH;
         if(this->memory_config.memory_layout == TensorMemoryLayout::HEIGHT_SHARDED) {
             TT_FATAL(this->parallelization_config.per_core_out_matrix_width_ntiles == out_width_ntiles);
@@ -351,12 +371,12 @@ std::vector<tt::tt_metal::Shape> OptimizedConvNew::compute_output_shapes(const s
     uint32_t conv_activation_h = input_tensor_a_shape[1];
     uint32_t conv_activation_w = input_tensor_a_shape[2];
     // TODO: clean up here
-    uint32_t filter_h = (uint32_t) conv_params[0];
-    uint32_t filter_w = (uint32_t) conv_params[1];
-    uint32_t stride_h = (uint32_t) conv_params[2];
-    uint32_t stride_w = (uint32_t) conv_params[3];
-    uint32_t pad_h = (uint32_t) conv_params[4];
-    uint32_t pad_w = (uint32_t) conv_params[5];
+    uint32_t filter_h = (uint32_t)sliding_window_config.window_hw_.first;  // filter_h
+    uint32_t filter_w = (uint32_t)sliding_window_config.window_hw_.second;  // filter_W
+    uint32_t stride_h = (uint32_t)sliding_window_config.stride_hw_.first;
+    uint32_t stride_w = (uint32_t)sliding_window_config.stride_hw_.second;
+    uint32_t pad_h = (uint32_t)sliding_window_config.pad_hw_.first;
+    uint32_t pad_w = (uint32_t)sliding_window_config.pad_hw_.second;
     auto [conv_output_h, conv_output_w] = optimized_conv_op_utils::compute_opt_conv_output_face_shape(conv_activation_h, conv_activation_w, filter_h, filter_w, stride_h, stride_w, pad_h, pad_w, extra_padding_for_32B_alignment);
 
     // Tiled output shape is padded shape. Padded to tile shape.
@@ -397,7 +417,7 @@ std::vector<Tensor> OptimizedConvNew::create_output_tensors(const std::vector<Te
             return{create_device_tensor(output_shape, this->dtype, output_layout, input_tensor.device(), mem_config)};
 
         } else if (this->memory_config.memory_layout == TensorMemoryLayout::BLOCK_SHARDED) {
-            auto [act_matrix_shape, act_matrix_shape_unpadded] = optimized_conv_op_utils::compute_opt_conv_activation_as_mm_shape(this->input_tensor_shape, conv_params, this->parallelization_config.per_core_out_matrix_height_ntiles, extra_padding_for_32B_alignment);
+            auto [act_matrix_shape, act_matrix_shape_unpadded] = optimized_conv_op_utils::compute_opt_conv_activation_as_mm_shape(this->input_tensor_shape, sliding_window_config, this->parallelization_config.per_core_out_matrix_height_ntiles, extra_padding_for_32B_alignment);
             uint32_t act_matrix_height = (uint32_t) act_matrix_shape[1];
             uint32_t act_matrix_height_ntiles = act_matrix_height / TILE_HEIGHT;
             uint32_t total_active_num_cores_per_weight_slice = act_matrix_height_ntiles / this->parallelization_config.per_core_out_matrix_height_ntiles;
@@ -434,7 +454,7 @@ operation::ProgramWithCallbacks OptimizedConvNew::create_program(const std::vect
     TT_ASSERT(input_tensor_a.memory_config().is_sharded()); // TODO: move this check to validate_input_tensors
     return multi_core_optimized_conv_sharded_v2_new(
         input_tensor_a, input_tensor_b, input_tensor_bias,
-        conv_params,
+        sliding_window_config,
         output_channels,
         untilize_out, fuse_relu, math_fidelity,
         parallelization_config,
@@ -455,12 +475,12 @@ operation::OpPerformanceModel OptimizedConvNew::create_op_performance_model(cons
     uint32_t conv_activation_h = input_tensor_a_shape[1];
     uint32_t conv_activation_w = input_tensor_a_shape[2];
     uint32_t conv_activation_c = input_tensor_a_shape[3];
-    uint32_t filter_h = (uint32_t) conv_params[0];
-    uint32_t filter_w = (uint32_t) conv_params[1];
-    uint32_t stride_h = (uint32_t) conv_params[2];
-    uint32_t stride_w = (uint32_t) conv_params[3];
-    uint32_t pad_h = (uint32_t) conv_params[4];
-    uint32_t pad_w = (uint32_t) conv_params[5];
+    uint32_t filter_h = (uint32_t)sliding_window_config.window_hw_.first;  // filter_h
+    uint32_t filter_w = (uint32_t)sliding_window_config.window_hw_.second;  // filter_W
+    uint32_t stride_h = (uint32_t)sliding_window_config.stride_hw_.first;
+    uint32_t stride_w = (uint32_t)sliding_window_config.stride_hw_.second;
+    uint32_t pad_h = (uint32_t)sliding_window_config.pad_hw_.first;
+    uint32_t pad_w = (uint32_t)sliding_window_config.pad_hw_.second;
 
     const auto& t = output_tensors.at(0);
     if(t.storage_type() != StorageType::DEVICE) {

--- a/ttnn/cpp/ttnn/operations/pool/maxpool/device/max_pool2d_multi_core_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/pool/maxpool/device/max_pool2d_multi_core_program_factory.cpp
@@ -350,17 +350,17 @@ MaxPoolNew::MultiCore::cached_program_t MaxPoolNew::MultiCore::create(const oper
 
     tt::tt_metal::detail::AddConfigBuffer(program, reader_indices_on_device.device_buffer());
 
-    auto in_n = sliding_window_config.batch_size_;
-    auto in_h = sliding_window_config.input_hw_.first;
-    auto in_w = sliding_window_config.input_hw_.second;
-    auto kernel_size_h = sliding_window_config.window_hw_.first;
-    auto kernel_size_w = sliding_window_config.window_hw_.second;
-    auto stride_h = sliding_window_config.stride_hw_.first;
-    auto stride_w = sliding_window_config.stride_hw_.second;
-    auto pad_h = sliding_window_config.pad_hw_.first;
-    auto pad_w = sliding_window_config.pad_hw_.second;
-    auto dilation_h = sliding_window_config.dilation_hw_.first;
-    auto dilation_w = sliding_window_config.dilation_hw_.second;
+    auto in_n = sliding_window_config.batch_size;
+    auto in_h = sliding_window_config.input_hw.first;
+    auto in_w = sliding_window_config.input_hw.second;
+    auto kernel_size_h = sliding_window_config.window_hw.first;
+    auto kernel_size_w = sliding_window_config.window_hw.second;
+    auto stride_h = sliding_window_config.stride_hw.first;
+    auto stride_w = sliding_window_config.stride_hw.second;
+    auto pad_h = sliding_window_config.pad_hw.first;
+    auto pad_w = sliding_window_config.pad_hw.second;
+    auto dilation_h = sliding_window_config.dilation_hw.first;
+    auto dilation_w = sliding_window_config.dilation_hw.second;
 
     return max_pool_2d_multi_core_sharded_with_halo_v2_impl_new(
         program,

--- a/ttnn/cpp/ttnn/operations/pool/maxpool/max_pool2d.cpp
+++ b/ttnn/cpp/ttnn/operations/pool/maxpool/max_pool2d.cpp
@@ -78,7 +78,6 @@ Tensor MaxPoolNewOp::invoke(uint8_t queue_id, const Tensor& input_tensor, uint32
             .stride_hw = {stride.at(0), stride.at(1)},
             .pad_hw = {padding.at(0), padding.at(1)},
             .dilation_hw = {dilation.at(0), dilation.at(1)},
-            .groups = 1,
             .num_cores_nhw = num_cores_nhw,
             .core_range_set = parallel_config.grid,
             .snap_to_tile = false

--- a/ttnn/cpp/ttnn/operations/pool/maxpool/max_pool2d.cpp
+++ b/ttnn/cpp/ttnn/operations/pool/maxpool/max_pool2d.cpp
@@ -15,13 +15,14 @@ namespace operations::pool {
 template<typename T>
 Tensor MaxPoolNewOp::invoke(uint8_t queue_id, const Tensor& input_tensor, uint32_t batch_size, uint32_t input_h, uint32_t input_w, uint32_t channels, std::array<uint32_t, 2> kernel_size, std::array<uint32_t, 2> stride, std::array<uint32_t, 2> padding, std::array<uint32_t, 2> dilation, T* device) {
 
-    sliding_window::SlidingWindowConfig sliding_window_config = sliding_window::SlidingWindowConfig(
-                                                                    batch_size,
-                                                                    input_h, input_w,
-                                                                    kernel_size.at(0), kernel_size.at(1),
-                                                                    stride.at(0), stride.at(1),
-                                                                    padding.at(0), padding.at(1),
-                                                                    dilation.at(0), dilation.at(1));
+    sliding_window::SlidingWindowConfig sliding_window_config{
+            .batch_size = batch_size,
+            .input_hw = {input_h, input_w},
+            .window_hw = {kernel_size.at(0), kernel_size.at(1)},
+            .stride_hw = {stride.at(0), stride.at(1)},
+            .pad_hw = {padding.at(0), padding.at(1)},
+            .dilation_hw = {dilation.at(0), dilation.at(1)}
+    };
     auto output_shape = sliding_window_config.get_output_shape();
     auto input_tensor_sharded = input_tensor;
 
@@ -70,22 +71,19 @@ Tensor MaxPoolNewOp::invoke(uint8_t queue_id, const Tensor& input_tensor, uint32
     log_debug(tt::LogOp, "output_nhw: {}, output_nhw_padded: {}, output_shard_height_padded: {}, output_shard_width_padded: {}", output_nhw, output_nhw_padded, output_shard_height_padded, output_shard_width_padded);
     memory_config.shard_spec = ShardSpec{shard_spec.grid, {output_shard_height_padded, output_shard_width_padded}, ShardOrientation::ROW_MAJOR, false};
 
-    sliding_window_config = sliding_window::SlidingWindowConfig(
-                                            batch_size,
-                                            input_h,
-                                            input_w,
-                                            kernel_size.at(0),
-                                            kernel_size.at(1),
-                                            stride.at(0),
-                                            stride.at(1),
-                                            padding.at(0),
-                                            padding.at(1),
-                                            dilation.at(0),
-                                            dilation.at(1),
-                                            1, //groups
-                                            num_cores_nhw,
-                                            parallel_config.grid,
-                                            false);
+    sliding_window_config = sliding_window::SlidingWindowConfig{
+            .batch_size = batch_size,
+            .input_hw = {input_h, input_w},
+            .window_hw = {kernel_size.at(0), kernel_size.at(1)},
+            .stride_hw = {stride.at(0), stride.at(1)},
+            .pad_hw = {padding.at(0), padding.at(1)},
+            .dilation_hw = {dilation.at(0), dilation.at(1)},
+            .groups = 1,
+            .num_cores_nhw = num_cores_nhw,
+            .core_range_set = parallel_config.grid,
+            .snap_to_tile = false
+    };
+
     // call the halo uop
     uint32_t neg_inf_pad_val = 0xf7ff;
     auto haloed_tensor = ttnn::halo(

--- a/ttnn/cpp/ttnn/operations/pool/maxpool/max_pool2d.cpp
+++ b/ttnn/cpp/ttnn/operations/pool/maxpool/max_pool2d.cpp
@@ -82,6 +82,7 @@ Tensor MaxPoolNewOp::invoke(uint8_t queue_id, const Tensor& input_tensor, uint32
                                             padding.at(1),
                                             dilation.at(0),
                                             dilation.at(1),
+                                            1, //groups
                                             num_cores_nhw,
                                             parallel_config.grid,
                                             false);

--- a/ttnn/cpp/ttnn/operations/sliding_window/halo/device/halo_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/sliding_window/halo/device/halo_device_operation.cpp
@@ -31,7 +31,7 @@ std::vector<tt::tt_metal::Shape> HaloDeviceOperation::compute_output_shapes(cons
     tt::tt_metal::Shape output_shape = input_shape;
 
     uint32_t nbatch = input_shape[0];
-    uint32_t total_nsticks = config_.num_cores_nhw_ * max_out_nsticks_per_core_;
+    uint32_t total_nsticks = config_.num_cores_nhw * max_out_nsticks_per_core_;
 
     // output_shape[0] remains same
     // output_shape[1] remains same
@@ -41,7 +41,7 @@ std::vector<tt::tt_metal::Shape> HaloDeviceOperation::compute_output_shapes(cons
 
     log_debug(tt::LogOp, "output_shape: [{} {} {} {}]", output_shape[0], output_shape[1], output_shape[2], output_shape[3]);
     log_debug(tt::LogOp, "max_out_nsticks_per_core: {}", max_out_nsticks_per_core_);
-    log_debug(tt::LogOp, "num_cores_nhw: {}", config_.num_cores_nhw_);
+    log_debug(tt::LogOp, "num_cores_nhw: {}", config_.num_cores_nhw);
 
     return {output_shape};
 }
@@ -62,7 +62,7 @@ std::vector<Tensor> HaloDeviceOperation::create_output_tensors(const std::vector
     }
 
     auto out_mem_config = output_memory_config_;
-    out_mem_config.shard_spec->shape[0] = tt::div_up(output_shape[0] * output_shape[2], config_.num_cores_nhw_);
+    out_mem_config.shard_spec->shape[0] = tt::div_up(output_shape[0] * output_shape[2], config_.num_cores_nhw);
     out_mem_config.shard_spec->shape[1] = input_tensor.memory_config().shard_spec->shape[1];
     out_mem_config.shard_spec->halo = true;
     return {create_device_tensor(output_shape, output_dtype, Layout::ROW_MAJOR, input_tensor.device(), out_mem_config)};
@@ -105,7 +105,7 @@ operation::ProgramWithCallbacks HaloDeviceOperation::create_program(const std::v
         program,
         input_tensor,
         pad_val_,
-        config_.num_cores_nhw_,
+        config_.num_cores_nhw,
         max_out_nsticks_per_core_,
         pad_config_device_tensor,
         local_config_device_tensor,

--- a/ttnn/cpp/ttnn/operations/sliding_window/sliding_window.cpp
+++ b/ttnn/cpp/ttnn/operations/sliding_window/sliding_window.cpp
@@ -505,7 +505,7 @@ auto fmt::formatter<ttnn::operations::sliding_window::ParallelConfig>::format(co
 }
 
 auto fmt::formatter<ttnn::operations::sliding_window::SlidingWindowConfig>::format(const ttnn::operations::sliding_window::SlidingWindowConfig& t, format_context& ctx) const -> format_context::iterator {
-        std::string str = fmt::format("SlidingWindowConfig(batch_size_={}, input_hw_=({},{}), window_hw_=({},{}), stride_hw_=({},{}), pad_hw_=({},{}), dilation_hw_=({},{}), num_cores_nhw_={}, core_range_set_={})",
+        std::string str = fmt::format("SlidingWindowConfig(batch_size_={}, input_hw_=({},{}), window_hw_=({},{}), stride_hw_=({},{}), pad_hw_=({},{}), dilation_hw_=({},{}), groups={}, num_cores_nhw_={}, core_range_set_={})",
             t.batch_size_,
             t.input_hw_.first,
             t.input_hw_.second,
@@ -517,6 +517,7 @@ auto fmt::formatter<ttnn::operations::sliding_window::SlidingWindowConfig>::form
             t.pad_hw_.second,
             t.dilation_hw_.first,
             t.dilation_hw_.second,
+            t.groups,
             t.num_cores_nhw_,
             t.core_range_set_.str());
         return fmt::format_to(ctx.out(), "{}", str);

--- a/ttnn/cpp/ttnn/operations/sliding_window/sliding_window.cpp
+++ b/ttnn/cpp/ttnn/operations/sliding_window/sliding_window.cpp
@@ -14,44 +14,47 @@ std::size_t SlidingWindowConfig::get_hash() const {
     * Return the input shape (excluding depth)
     */
 Shape SlidingWindowConfig::get_input_shape() const {
-    return Shape(std::vector<uint32_t>{batch_size_, std::get<0>(input_hw_), std::get<1>(input_hw_)});
+    return Shape(std::vector<uint32_t>{batch_size, std::get<0>(input_hw), std::get<1>(input_hw)});
 }
 
+bool SlidingWindowConfig::has_parallel_config() const {
+    return num_cores_nhw > 0 && !core_range_set.ranges().empty();
+}
 /**
     * Calculate the window op output shape, excludes the channel dimension since this config is independent of the depth.
     */
 Shape SlidingWindowConfig::get_output_shape() const {
-    uint32_t output_h = (input_hw_.first + 2 * pad_hw_.first - dilation_hw_.first * window_hw_.first) / stride_hw_.first + 1;
-    uint32_t output_w = (input_hw_.second + 2 * pad_hw_.second - dilation_hw_.second * window_hw_.second) / stride_hw_.second + 1;
-    // uint32_t output_h = (std::get<0>(input_hw_) + 2 * std::get<0>(pad_hw_) - std::get<0>(dilation_hw_) * std::get<0>(window_hw_)) / std::get<0>(stride_hw_) + 1;
-    // uint32_t output_w = (std::get<1>(input_hw_) + 2 * std::get<1>(pad_hw_) - std::get<1>(dilation_hw_) * std::get<1>(window_hw_)) / std::get<1>(stride_hw_) + 1;
-    log_debug(tt::LogOp, "output_size: {} {} {}", batch_size_, output_h, output_w);
-    return Shape( std::vector<uint32_t>{batch_size_, output_h, output_w, 0});
+    uint32_t output_h = (input_hw.first + 2 * pad_hw.first - dilation_hw.first * window_hw.first) / stride_hw.first + 1;
+    uint32_t output_w = (input_hw.second + 2 * pad_hw.second - dilation_hw.second * window_hw.second) / stride_hw.second + 1;
+    // uint32_t output_h = (std::get<0>(input_hw) + 2 * std::get<0>(pad_hw) - std::get<0>(dilation_hw) * std::get<0>(window_hw)) / std::get<0>(stride_hw) + 1;
+    // uint32_t output_w = (std::get<1>(input_hw) + 2 * std::get<1>(pad_hw) - std::get<1>(dilation_hw) * std::get<1>(window_hw)) / std::get<1>(stride_hw) + 1;
+    log_debug(tt::LogOp, "output_size: {} {} {}", batch_size, output_h, output_w);
+    return Shape( std::vector<uint32_t>{batch_size, output_h, output_w, 0});
 }
 
 /**
     * Calculate output tensor shard height
     */
 uint32_t SlidingWindowConfig::get_output_shard_y(bool snap_to_tile) const {
-    TT_ASSERT(has_parallel_config_, "Parallel config is not set in SlidingWindowConfig");
+    TT_ASSERT(has_parallel_config(), "Parallel config is not set in SlidingWindowConfig");
     Shape output_shape = get_output_shape();
     uint32_t output_nhw = output_shape[0] * output_shape[1] * output_shape[2];
-    uint32_t output_nhw_padded = tt::round_up(output_nhw, num_cores_nhw_ * (snap_to_tile ? tt:: constants::TILE_HEIGHT : 1));
-    log_debug(tt::LogOp, "output_nhw: {} output_nhw_padded: {} num_cores_nhw: {}", output_nhw, output_nhw_padded, num_cores_nhw_);
-    return (output_nhw_padded / num_cores_nhw_);
+    uint32_t output_nhw_padded = tt::round_up(output_nhw, num_cores_nhw * (snap_to_tile ? tt:: constants::TILE_HEIGHT : 1));
+    log_debug(tt::LogOp, "output_nhw: {} output_nhw_padded: {} num_cores_nhw: {}", output_nhw, output_nhw_padded, num_cores_nhw);
+    return (output_nhw_padded / num_cores_nhw);
 }
 
 
 std::vector<bool> generate_pad_metadata(const SlidingWindowConfig& config) {
-    uint32_t padded_input_h = config.input_hw_.first + 2 * config.pad_hw_.first;
-    uint32_t padded_input_w = config.input_hw_.second + 2 * config.pad_hw_.second;
-    std::vector<bool> pad_metadata(config.batch_size_ * padded_input_h * padded_input_w, false);
+    uint32_t padded_input_h = config.input_hw.first + 2 * config.pad_hw.first;
+    uint32_t padded_input_w = config.input_hw.second + 2 * config.pad_hw.second;
+    std::vector<bool> pad_metadata(config.batch_size * padded_input_h * padded_input_w, false);
 
-    for (uint32_t b = 0; b < config.batch_size_; ++b) {
+    for (uint32_t b = 0; b < config.batch_size; ++b) {
         for (uint32_t h = 0; h < padded_input_h; ++h) {
             for (uint32_t w = 0; w < padded_input_w; ++w) {
-                if (h < config.pad_hw_.first || h >= config.pad_hw_.first + config.input_hw_.first ||
-                    w < config.pad_hw_.second || w >= config.pad_hw_.second + config.input_hw_.second) {
+                if (h < config.pad_hw.first || h >= config.pad_hw.first + config.input_hw.first ||
+                    w < config.pad_hw.second || w >= config.pad_hw.second + config.input_hw.second) {
                     pad_metadata[b * padded_input_h * padded_input_w + h * padded_input_w + w] = true;
                 }
             }
@@ -63,14 +66,14 @@ std::vector<bool> generate_pad_metadata(const SlidingWindowConfig& config) {
 std::vector<uint32_t> generate_op_trace_metadata(const SlidingWindowConfig& config) {
     Shape output_shape = config.get_output_shape();
     uint32_t output_nhw = output_shape[0] * output_shape[1] * output_shape[2];
-    uint32_t padded_input_h = config.input_hw_.first + 2 * config.pad_hw_.first;
-    uint32_t padded_input_w = config.input_hw_.second + 2 * config.pad_hw_.second;
+    uint32_t padded_input_h = config.input_hw.first + 2 * config.pad_hw.first;
+    uint32_t padded_input_w = config.input_hw.second + 2 * config.pad_hw.second;
     uint32_t i = 0;
     std::vector<uint32_t> op_trace_metadata(output_nhw, 0);
     for (uint32_t b = 0; b < output_shape[0]; ++b) {
         for (uint32_t h = 0; h < output_shape[1]; ++h) {
             for (uint32_t w = 0; w < output_shape[2]; ++w) {
-                uint32_t input_index = b * padded_input_h * padded_input_w + h * config.stride_hw_.first * padded_input_w + w * config.stride_hw_.second;
+                uint32_t input_index = b * padded_input_h * padded_input_w + h * config.stride_hw.first * padded_input_w + w * config.stride_hw.second;
                 op_trace_metadata[i++] = input_index;
             }
         }
@@ -80,11 +83,11 @@ std::vector<uint32_t> generate_op_trace_metadata(const SlidingWindowConfig& conf
 
 std::vector<std::pair<uint32_pair_t, uint32_pair_t>> generate_shard_boundaries(const SlidingWindowConfig& config, const std::vector<uint32_t>& op_trace_metadata) {
     std::vector<std::pair<uint32_pair_t, uint32_pair_t>> shard_boundaries;
-    uint32_t num_cores = config.num_cores_nhw_;
-    uint32_t output_shard_h = config.get_output_shard_y(config.snap_to_tile_);
-    uint32_t padded_input_w = config.input_hw_.second + 2 * config.pad_hw_.second;
+    uint32_t num_cores = config.num_cores_nhw;
+    uint32_t output_shard_h = config.get_output_shard_y(config.snap_to_tile);
+    uint32_t padded_input_w = config.input_hw.second + 2 * config.pad_hw.second;
     uint32_t max_index = op_trace_metadata.size();
-    uint32_t halo_with_pad_len = (config.window_hw_.first - 1) * padded_input_w + config.window_hw_.second - 1;
+    uint32_t halo_with_pad_len = (config.window_hw.first - 1) * padded_input_w + config.window_hw.second - 1;
     uint32_t output_index_start = 0;
     for (uint32_t core = 0; core < num_cores; ++ core) {
         uint32_t output_index_end = std::min(output_index_start + output_shard_h, max_index) - 1;
@@ -111,11 +114,11 @@ std::vector<std::pair<bool, uint32_pair_t>> generate_tensor_metadata(const std::
     uint32_t input_nhw = input_shape[0] * input_shape[1] * input_shape[2];
     uint32_t input_nhw_padded;
     if (is_in_tiled) {
-        input_nhw_padded = tt::round_up(input_nhw, config.num_cores_nhw_ * tt:: constants::TILE_HEIGHT);
+        input_nhw_padded = tt::round_up(input_nhw, config.num_cores_nhw * tt:: constants::TILE_HEIGHT);
     } else {
-        input_nhw_padded = tt::round_up(input_nhw, config.num_cores_nhw_);
+        input_nhw_padded = tt::round_up(input_nhw, config.num_cores_nhw);
     }
-    uint32_t input_shard_height = input_nhw_padded / config.num_cores_nhw_;
+    uint32_t input_shard_height = input_nhw_padded / config.num_cores_nhw;
     uint32_t input_reshard_height = reshard_num_cores_nhw == 0 ? input_shard_height : tt::round_up(input_nhw, reshard_num_cores_nhw * tt:: constants::TILE_HEIGHT) / reshard_num_cores_nhw;
 
     auto remap = [input_shard_height, input_reshard_height](uint32_t core_id, uint32_t local_idx) -> std::pair<uint32_t, uint32_t> {
@@ -469,13 +472,13 @@ Tensor move_config_tensor_to_device(const Tensor& config_tensor, const ParallelC
 }
 
 std::string SlidingWindowConfig::to_string() const {
-    return std::to_string(batch_size_)
-            + "_" + std::to_string(std::get<0>(input_hw_)) + "_" + std::to_string(std::get<1>(input_hw_))
-            + "_" + std::to_string(std::get<0>(window_hw_)) + "_" + std::to_string(std::get<1>(window_hw_))
-            + "_" + std::to_string(std::get<0>(stride_hw_)) + "_" + std::to_string(std::get<1>(stride_hw_))
-            + "_" + std::to_string(std::get<0>(pad_hw_)) + "_" + std::to_string(std::get<1>(pad_hw_))
-            + "_" + std::to_string(std::get<0>(dilation_hw_)) + "_" + std::to_string(std::get<1>(dilation_hw_))
-            + "_" + std::to_string(num_cores_nhw_) + "_" + core_range_set_.str();
+    return std::to_string(batch_size)
+            + "_" + std::to_string(std::get<0>(input_hw)) + "_" + std::to_string(std::get<1>(input_hw))
+            + "_" + std::to_string(std::get<0>(window_hw)) + "_" + std::to_string(std::get<1>(window_hw))
+            + "_" + std::to_string(std::get<0>(stride_hw)) + "_" + std::to_string(std::get<1>(stride_hw))
+            + "_" + std::to_string(std::get<0>(pad_hw)) + "_" + std::to_string(std::get<1>(pad_hw))
+            + "_" + std::to_string(std::get<0>(dilation_hw)) + "_" + std::to_string(std::get<1>(dilation_hw))
+            + "_" + std::to_string(num_cores_nhw) + "_" + core_range_set.str();
 }
 
 } // namespace ttnn::operations::sliding_window
@@ -505,20 +508,20 @@ auto fmt::formatter<ttnn::operations::sliding_window::ParallelConfig>::format(co
 }
 
 auto fmt::formatter<ttnn::operations::sliding_window::SlidingWindowConfig>::format(const ttnn::operations::sliding_window::SlidingWindowConfig& t, format_context& ctx) const -> format_context::iterator {
-        std::string str = fmt::format("SlidingWindowConfig(batch_size_={}, input_hw_=({},{}), window_hw_=({},{}), stride_hw_=({},{}), pad_hw_=({},{}), dilation_hw_=({},{}), groups={}, num_cores_nhw_={}, core_range_set_={})",
-            t.batch_size_,
-            t.input_hw_.first,
-            t.input_hw_.second,
-            t.window_hw_.first,
-            t.window_hw_.second,
-            t.stride_hw_.first,
-            t.stride_hw_.second,
-            t.pad_hw_.first,
-            t.pad_hw_.second,
-            t.dilation_hw_.first,
-            t.dilation_hw_.second,
+        std::string str = fmt::format("SlidingWindowConfig(batch_size={}, input_hw=({},{}), window_hw=({},{}), stride_hw=({},{}), pad_hw=({},{}), dilation_hw=({},{}), groups={}, num_cores_nhw={}, core_range_set_={})",
+            t.batch_size,
+            t.input_hw.first,
+            t.input_hw.second,
+            t.window_hw.first,
+            t.window_hw.second,
+            t.stride_hw.first,
+            t.stride_hw.second,
+            t.pad_hw.first,
+            t.pad_hw.second,
+            t.dilation_hw.first,
+            t.dilation_hw.second,
             t.groups,
-            t.num_cores_nhw_,
-            t.core_range_set_.str());
+            t.num_cores_nhw,
+            t.core_range_set.str());
         return fmt::format_to(ctx.out(), "{}", str);
 }

--- a/ttnn/cpp/ttnn/operations/sliding_window/sliding_window.cpp
+++ b/ttnn/cpp/ttnn/operations/sliding_window/sliding_window.cpp
@@ -508,7 +508,7 @@ auto fmt::formatter<ttnn::operations::sliding_window::ParallelConfig>::format(co
 }
 
 auto fmt::formatter<ttnn::operations::sliding_window::SlidingWindowConfig>::format(const ttnn::operations::sliding_window::SlidingWindowConfig& t, format_context& ctx) const -> format_context::iterator {
-        std::string str = fmt::format("SlidingWindowConfig(batch_size={}, input_hw=({},{}), window_hw=({},{}), stride_hw=({},{}), pad_hw=({},{}), dilation_hw=({},{}), groups={}, num_cores_nhw={}, core_range_set_={})",
+        std::string str = fmt::format("SlidingWindowConfig(batch_size={}, input_hw=({},{}), window_hw=({},{}), stride_hw=({},{}), pad_hw=({},{}), dilation_hw=({},{}), num_cores_nhw={}, core_range_set_={})",
             t.batch_size,
             t.input_hw.first,
             t.input_hw.second,
@@ -520,7 +520,6 @@ auto fmt::formatter<ttnn::operations::sliding_window::SlidingWindowConfig>::form
             t.pad_hw.second,
             t.dilation_hw.first,
             t.dilation_hw.second,
-            t.groups,
             t.num_cores_nhw,
             t.core_range_set.str());
         return fmt::format_to(ctx.out(), "{}", str);

--- a/ttnn/cpp/ttnn/operations/sliding_window/sliding_window.cpp
+++ b/ttnn/cpp/ttnn/operations/sliding_window/sliding_window.cpp
@@ -26,8 +26,6 @@ bool SlidingWindowConfig::has_parallel_config() const {
 Shape SlidingWindowConfig::get_output_shape() const {
     uint32_t output_h = (input_hw.first + 2 * pad_hw.first - dilation_hw.first * window_hw.first) / stride_hw.first + 1;
     uint32_t output_w = (input_hw.second + 2 * pad_hw.second - dilation_hw.second * window_hw.second) / stride_hw.second + 1;
-    // uint32_t output_h = (std::get<0>(input_hw) + 2 * std::get<0>(pad_hw) - std::get<0>(dilation_hw) * std::get<0>(window_hw)) / std::get<0>(stride_hw) + 1;
-    // uint32_t output_w = (std::get<1>(input_hw) + 2 * std::get<1>(pad_hw) - std::get<1>(dilation_hw) * std::get<1>(window_hw)) / std::get<1>(stride_hw) + 1;
     log_debug(tt::LogOp, "output_size: {} {} {}", batch_size, output_h, output_w);
     return Shape( std::vector<uint32_t>{batch_size, output_h, output_w, 0});
 }

--- a/ttnn/cpp/ttnn/operations/sliding_window/sliding_window.hpp
+++ b/ttnn/cpp/ttnn/operations/sliding_window/sliding_window.hpp
@@ -34,37 +34,25 @@ using uint32_pair_t = std::pair<uint32_t, uint32_t>;
 struct SlidingWindowConfig {
 
     // input tensor shape
-    uint32_t batch_size_;
-    uint32_pair_t input_hw_;
+    uint32_t batch_size = 0;
+    uint32_pair_t input_hw = {0, 0};
 
     // windowing parameters
-    uint32_pair_t window_hw_;
-    uint32_pair_t stride_hw_;
-    uint32_pair_t pad_hw_;
-    uint32_pair_t dilation_hw_;
+    uint32_pair_t window_hw  = {1, 1};
+    uint32_pair_t stride_hw  = {1, 1};
+    uint32_pair_t pad_hw = {0, 0} ;
+    uint32_pair_t dilation_hw = {1, 1};
 
-    uint32_t groups;
+    uint32_t groups = 1;
 
     // parallel configuration
-    bool has_parallel_config_;
-    uint32_t num_cores_nhw_;        // num cores along collapsed height nhw
-    CoreRangeSet core_range_set_;   // active cores
+    uint32_t num_cores_nhw = 1;        // num cores along collapsed height nhw
+    CoreRangeSet core_range_set = std::set{CoreRange({0, 0}, {0, 0})};   // active cores
 
-    bool snap_to_tile_;
-
-    SlidingWindowConfig(uint32_t batch_size, uint32_t input_h, uint32_t input_w, uint32_t window_h, uint32_t window_w, uint32_t stride_h, uint32_t stride_w, uint32_t pad_h, uint32_t pad_w, uint32_t dilation_h = 1, uint32_t dilation_w = 1, uint32_t groups = 1, uint32_t num_cores_nhw = 0, CoreRangeSet core_range = {{}}, bool snap_to_tile = false)
-        : batch_size_(batch_size), input_hw_(input_h, input_w), window_hw_(window_h, window_w), stride_hw_(stride_h, stride_w), pad_hw_(pad_h, pad_w), dilation_hw_(dilation_h, dilation_w), groups(groups), has_parallel_config_(false), num_cores_nhw_(num_cores_nhw), core_range_set_(core_range), snap_to_tile_(snap_to_tile) {
-            has_parallel_config_ = num_cores_nhw_ > 0 && !core_range_set_.ranges().empty();
-        }
-
-    SlidingWindowConfig(const SlidingWindowConfig& other): batch_size_(other.batch_size_), input_hw_(other.input_hw_), window_hw_(other.window_hw_), stride_hw_(other.stride_hw_), pad_hw_(other.pad_hw_), dilation_hw_(other.dilation_hw_), groups(other.groups), has_parallel_config_(other.has_parallel_config_), num_cores_nhw_(other.num_cores_nhw_), core_range_set_(other.core_range_set_), snap_to_tile_(other.snap_to_tile_) {}
-
-    SlidingWindowConfig(): core_range_set_({{{0,0}, {0,0}}}) {}
-
-
+    bool snap_to_tile = false;
 
     std::string to_string() const;
-
+    bool has_parallel_config() const;
     /**
         * Unique hash val for the sliding window configuration.
         */

--- a/ttnn/cpp/ttnn/operations/sliding_window/sliding_window.hpp
+++ b/ttnn/cpp/ttnn/operations/sliding_window/sliding_window.hpp
@@ -43,6 +43,8 @@ struct SlidingWindowConfig {
     uint32_pair_t pad_hw_;
     uint32_pair_t dilation_hw_;
 
+    uint32_t groups;
+
     // parallel configuration
     bool has_parallel_config_;
     uint32_t num_cores_nhw_;        // num cores along collapsed height nhw
@@ -50,12 +52,12 @@ struct SlidingWindowConfig {
 
     bool snap_to_tile_;
 
-    SlidingWindowConfig(uint32_t batch_size, uint32_t input_h, uint32_t input_w, uint32_t window_h, uint32_t window_w, uint32_t stride_h, uint32_t stride_w, uint32_t pad_h, uint32_t pad_w, uint32_t dilation_h = 1, uint32_t dilation_w = 1, uint32_t num_cores_nhw = 0, CoreRangeSet core_range = {{}}, bool snap_to_tile = false)
-        : batch_size_(batch_size), input_hw_(input_h, input_w), window_hw_(window_h, window_w), stride_hw_(stride_h, stride_w), pad_hw_(pad_h, pad_w), dilation_hw_(dilation_h, dilation_w), has_parallel_config_(false), num_cores_nhw_(num_cores_nhw), core_range_set_(core_range), snap_to_tile_(snap_to_tile) {
+    SlidingWindowConfig(uint32_t batch_size, uint32_t input_h, uint32_t input_w, uint32_t window_h, uint32_t window_w, uint32_t stride_h, uint32_t stride_w, uint32_t pad_h, uint32_t pad_w, uint32_t dilation_h = 1, uint32_t dilation_w = 1, uint32_t groups = 1, uint32_t num_cores_nhw = 0, CoreRangeSet core_range = {{}}, bool snap_to_tile = false)
+        : batch_size_(batch_size), input_hw_(input_h, input_w), window_hw_(window_h, window_w), stride_hw_(stride_h, stride_w), pad_hw_(pad_h, pad_w), dilation_hw_(dilation_h, dilation_w), groups(groups), has_parallel_config_(false), num_cores_nhw_(num_cores_nhw), core_range_set_(core_range), snap_to_tile_(snap_to_tile) {
             has_parallel_config_ = num_cores_nhw_ > 0 && !core_range_set_.ranges().empty();
         }
 
-    SlidingWindowConfig(const SlidingWindowConfig& other): batch_size_(other.batch_size_), input_hw_(other.input_hw_), window_hw_(other.window_hw_), stride_hw_(other.stride_hw_), pad_hw_(other.pad_hw_), dilation_hw_(other.dilation_hw_), has_parallel_config_(other.has_parallel_config_), num_cores_nhw_(other.num_cores_nhw_), core_range_set_(other.core_range_set_), snap_to_tile_(other.snap_to_tile_) {}
+    SlidingWindowConfig(const SlidingWindowConfig& other): batch_size_(other.batch_size_), input_hw_(other.input_hw_), window_hw_(other.window_hw_), stride_hw_(other.stride_hw_), pad_hw_(other.pad_hw_), dilation_hw_(other.dilation_hw_), groups(other.groups), has_parallel_config_(other.has_parallel_config_), num_cores_nhw_(other.num_cores_nhw_), core_range_set_(other.core_range_set_), snap_to_tile_(other.snap_to_tile_) {}
 
     SlidingWindowConfig(): core_range_set_({{{0,0}, {0,0}}}) {}
 

--- a/ttnn/cpp/ttnn/operations/sliding_window/sliding_window.hpp
+++ b/ttnn/cpp/ttnn/operations/sliding_window/sliding_window.hpp
@@ -43,8 +43,6 @@ struct SlidingWindowConfig {
     uint32_pair_t pad_hw = {0, 0} ;
     uint32_pair_t dilation_hw = {1, 1};
 
-    uint32_t groups = 1;
-
     // parallel configuration
     uint32_t num_cores_nhw = 1;        // num cores along collapsed height nhw
     CoreRangeSet core_range_set = std::set{CoreRange({0, 0}, {0, 0})};   // active cores


### PR DESCRIPTION
### Problem description
Currently `conv_params`, which is a vector of uint32 that contained information like filter height/width, stride, padding etc. This vector was passed around the conv2d code. Because it was a vector, using an index to access a variable could easily lead to bugs, especially when making changes.

This vector was replaced with the `sliding_window_config` structure. This allows access using the name of the variable instead of the index. 

### What's changed
Replaced conv_params with sliding_window_config in the conv2d cpp code..

### Checklist
- [x] Post commit CI [passes](https://github.com/tenstorrent/tt-metal/actions/runs/10695480499)
- [ ] Blackhole Post commit (if applicable)
- [ ] Model regression CI testing passes (if applicable)

