### PR TITLE
Point metal to new UMD main branch

### DIFF
--- a/tt_metal/impl/dispatch/command_queue_interface.hpp
+++ b/tt_metal/impl/dispatch/command_queue_interface.hpp
@@ -331,8 +331,7 @@ class SystemMemoryManager {
    private:
     chip_id_t device_id;
     uint8_t num_hw_cqs;
-    const uint32_t m_dma_buf_size;
-    const std::function<void(uint32_t, uint32_t, const uint8_t *, uint32_t)> fast_write_callable;
+    const std::function<void(uint32_t, uint32_t, const uint8_t *)> fast_write_callable;
     vector<uint32_t> completion_byte_addrs;
     char *cq_sysmem_start;
     vector<SystemMemoryCQInterface> cq_interfaces;
@@ -356,7 +355,6 @@ class SystemMemoryManager {
     SystemMemoryManager(chip_id_t device_id, uint8_t num_hw_cqs) :
         device_id(device_id),
         num_hw_cqs(num_hw_cqs),
-        m_dma_buf_size(tt::Cluster::instance().get_m_dma_buf_size(device_id)),
         fast_write_callable(tt::Cluster::instance().get_fast_pcie_static_tlb_write_callable(device_id)),
         bypass_enable(false),
         bypass_buffer_write_offset(0),
@@ -635,7 +633,7 @@ class SystemMemoryManager {
         uint32_t read_ptr_and_toggle =
             cq_interface.completion_fifo_rd_ptr | (cq_interface.completion_fifo_rd_toggle << 31);
         this->fast_write_callable(
-            this->completion_byte_addrs[cq_id], 4, (uint8_t *)&read_ptr_and_toggle, this->m_dma_buf_size);
+            this->completion_byte_addrs[cq_id], 4, (uint8_t *)&read_ptr_and_toggle);
 
         // Also store this data in hugepages in case we hang and can't get it from the device.
         chip_id_t mmio_device_id = tt::Cluster::instance().get_associated_mmio_device(this->device_id);

--- a/tt_metal/llrt/tlb_config.cpp
+++ b/tt_metal/llrt/tlb_config.cpp
@@ -4,9 +4,9 @@
 
 #include "tlb_config.hpp"
 
-#include "third_party/umd/device/blackhole_implementation.h"
-#include "third_party/umd/device/grayskull_implementation.h"
-#include "third_party/umd/device/wormhole_implementation.h"
+#include "third_party/umd/device/blackhole/blackhole_implementation.h"
+#include "third_party/umd/device/grayskull/grayskull_implementation.h"
+#include "third_party/umd/device/wormhole/wormhole_implementation.h"
 
 namespace ll_api {
 

--- a/tt_metal/llrt/tt_cluster.hpp
+++ b/tt_metal/llrt/tt_cluster.hpp
@@ -105,10 +105,10 @@ class Cluster {
         chip_id_t mmio_device_id = device_to_mmio_device_.at(chip_id);
         tt_SiliconDevice *device =
             dynamic_cast<tt_SiliconDevice *>(this->mmio_device_id_to_driver_.at(mmio_device_id).get());
-        return device->get_m_dma_buf_size();
+        return 0;
     }
 
-    std::function<void(uint32_t, uint32_t, const uint8_t *, uint32_t)> get_fast_pcie_static_tlb_write_callable(
+    std::function<void(uint32_t, uint32_t, const uint8_t *)> get_fast_pcie_static_tlb_write_callable(
         int chip_id) const {
         chip_id_t mmio_device_id = device_to_mmio_device_.at(chip_id);
         tt_SiliconDevice *device =


### PR DESCRIPTION
### Ticket
Link to Github Issue

### Problem description
We will be making changes to UMD that will break BBE. So TT-Metal will now point to `metal-main` branch on UMD.

### What's changed
Initial changes on `metal-main` will have deleted all dead code, related necessary metal changes and UMD bump made in this PR

UMD changes: https://github.com/tenstorrent/tt-umd/pull/41

### Checklist
- [x] Post commit CI passes: https://github.com/tenstorrent/tt-metal/actions/runs/10633595782
- [x] Blackhole Post commit (if applicable): https://github.com/tenstorrent/tt-metal/actions/runs/10633999572
