### PR TITLE
#12073: assert out on block and width sharded concat

### DIFF
--- a/tests/sweep_framework/sweeps/data_movement/concat/concat_interleaved_n_tensors.py
+++ b/tests/sweep_framework/sweeps/data_movement/concat/concat_interleaved_n_tensors.py
@@ -12,7 +12,7 @@ from tests.ttnn.utils_for_testing import check_with_pcc, start_measuring_time, s
 from models.utility_functions import torch_random
 
 # Override the default timeout in seconds for hang detection.
-TIMEOUT = 20
+TIMEOUT = 30  # formatting on host and torch CPU call are slow
 random.seed(0)
 tiled_dim_unpadded = [32, 64, 96]
 tiled_dim_padded = [7, 16]
@@ -57,10 +57,10 @@ def generate_concat_config(tensor_counts, ranks, variable_dim, other_dims):
 parameter_tiled_interleaved = {
     f"tiled_interleaved_suite_{n}_tensors": {
         "concat_specs": list(
-            generate_concat_config(n, [4, 3, 2], tiled_dim_unpadded, tiled_dim_unpadded + tiled_dim_padded)
+            generate_concat_config(n, [4, 3], tiled_dim_unpadded, tiled_dim_unpadded + tiled_dim_padded)
         )
         + list(
-            generate_concat_config(n, [4, 3, 2], tiled_dim_padded, [32, 33])
+            generate_concat_config(n, [4, 3], tiled_dim_padded, [32, 33])
         ),  # variable dim doesn't support padding, other dims can be anything
         "dtype": [ttnn.bfloat16, ttnn.bfloat8_b],
         "layout": [ttnn.TILE_LAYOUT],
@@ -78,10 +78,10 @@ parameter_tiled_interleaved = {
 
 parameters_row_major_interleaved = {
     f"row_major_interleaved_suite_{n}_tensors": {
-        "concat_specs": list(generate_concat_config(n, [4, 3, 2], rm_dim_even, rm_dim_even))
-        + list(generate_concat_config(n, [4, 3, 2], rm_dim_even, rm_dim_odd))
+        "concat_specs": list(generate_concat_config(n, [4, 3], rm_dim_even, rm_dim_even))
+        + list(generate_concat_config(n, [4, 3], rm_dim_even, rm_dim_odd))
         + list(
-            generate_concat_config(n, [4, 3, 2], rm_dim_odd, rm_dim_even)
+            generate_concat_config(n, [4, 3], rm_dim_odd, rm_dim_even)
         ),  # variable dim doesn't support padding, other dims can be anything
         "dtype": [ttnn.bfloat16],
         "layout": [ttnn.ROW_MAJOR_LAYOUT],

--- a/ttnn/cpp/ttnn/operations/data_movement/concat/device/concat_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/concat/device/concat_device_operation.cpp
@@ -50,6 +50,9 @@ void ConcatDeviceOperation::validate(const std::vector<Tensor> &input_tensors) c
         TT_FATAL(in_ref.is_sharded() == shard_first, "All tensors must be sharded or all must be interleaved");
         if (shard_first) {
             TT_FATAL((in_ref.get_layout() == Layout::ROW_MAJOR), "Only row major supported for sharded concat.");
+            TT_FATAL(in_ref.shard_spec().has_value(), "Sharded tensors must have a shard spec.");
+            TT_FATAL(in_ref.memory_config().memory_layout != TensorMemoryLayout::BLOCK_SHARDED, "Block sharded inputs are not supported");
+            TT_FATAL(in_ref.memory_config().memory_layout != TensorMemoryLayout::WIDTH_SHARDED, "Width sharded inputs are not supported");
         }
     }
     if (shard_first) {


### PR DESCRIPTION
- Assert out block and width sharded concat
- Sweep output_mem_config on sharding as both sharded to interleaved and sharded to sharded is supported
- Swap x and y on coregrid for sharding formation to correct shard formation

### Ticket
Link to Github Issue

### Problem description
Provide context for the problem.

### What's changed
Describe the approach used to solve the problem.
Summarize the changes made and its impact.

### Checklist
- [ ] Post commit CI passes
- [ ] Blackhole Post commit (if applicable)
- [ ] Model regression CI testing passes (if applicable)
- [ ] New/Existing tests provide coverage for changes
