### PR TITLE
#11854: Move .umd that houses cluster descriptor to TT_METAL_HOME

### DIFF
--- a/tt_metal/llrt/tt_cluster.cpp
+++ b/tt_metal/llrt/tt_cluster.cpp
@@ -96,10 +96,10 @@ void Cluster::detect_arch_and_target() {
 std::filesystem::path get_cluster_desc_yaml() {
     namespace fs = std::filesystem;
 
-    // RK: We eventually need to take out the create-ethernet-map binary and use it
-    // as a binary in the environment
+    // TODO: The interface into create-ethernet-map should be through an API rather a
+    // subprocess call to the binary
     const fs::path tt_metal_dir = fs::path(tt::llrt::OptionsG.get_root_dir()) / "tt_metal";
-    const fs::path umd_path = tt_metal_dir / ".umd";
+    const fs::path umd_path = fs::path(tt::llrt::OptionsG.get_root_dir()) / ".umd";
     fs::create_directory(umd_path);
     const fs::path cluster_desc_path = umd_path / "cluster_desc.yaml";
     if (!fs::exists(cluster_desc_path)) {


### PR DESCRIPTION
as… in production Python environments with the wheel, we don't want .umd to be generated in the package directories for Python. One problem is sometimes the packages directory is owned by root, but users shouldn't have to be root to use packages

### Ticket

#11854

### Problem description

As part of our effort to cleanup artifacts generated / modified at runtime, we should move `.umd/` to `TT_METAL_HOME`. This is because `tt_metal` is a package that we distribute via the wheel, and users may install it as root into their Python environments. However, non-root users should still be able to use those packages. This means that those users have read-only access to the package directories./

`.umd/` is generated at runtime to keep the cluster descriptor. We should not have to make this folder in `tt_metal/` necessarily, and instead keep it in `TT_METAL_HOME`.

### What's changed

Move `.umd/` to `TT_METAL_HOME`.

### Checklist
- [x] Post commit CI passes
- [x] Blackhole Post commit (if applicable)
- [x] Model regression CI testing passes (if applicable)
- [x] New/Existing tests provide coverage for changes
