### PR TITLE
#12117: Refactor DeviceMesh->MeshDevice, DeviceGrid->MeshShape

### DIFF
--- a/models/common/rmsnorm.py
+++ b/models/common/rmsnorm.py
@@ -11,15 +11,15 @@ SHARD_HEIGHT = TILE  # Current ttnn.rms_norm implementation requires shard heigh
 
 class RMSNorm(LightweightModule):
     """
-    RMSNorm supporting replication over a DeviceMesh and sharding within devices.
+    RMSNorm supporting replication over a MeshDevice and sharding within devices.
 
     This class implements a Root Mean Square Normalization (RMSNorm) that can be
     distributed across multiple devices and cores. If the `device` parameter is a
-    DeviceMesh, the weights and computations are replicated across all devices in
+    MeshDevice, the weights and computations are replicated across all devices in
     the mesh. Expects an interleaved input tensor, can optionally output a sharded tensor.
 
     Args:
-        device: The device or DeviceMesh on which to perform the computations.
+        device: The device or MeshDevice on which to perform the computations.
         state_dict: The state dictionary containing the model parameters.
         dim: Input dimension (e.g. model hidden dimension size).
         layer_num: The layer number to determine the weight key in the state dictionary.
@@ -61,7 +61,7 @@ class RMSNorm(LightweightModule):
         torch_weight = state_dict[weight_name].unsqueeze(0).view(1, 1, dim).expand([1, SHARD_HEIGHT, dim])
         cache_name = None if weight_cache_path is None else weight_cache_path / weight_name
 
-        is_device_mesh = device.__class__.__name__ == "DeviceMesh"
+        is_mesh_device = device.__class__.__name__ == "MeshDevice"
         self.weight = ttnn.as_tensor(
             torch_weight,
             device=device,
@@ -69,7 +69,7 @@ class RMSNorm(LightweightModule):
             layout=ttnn.TILE_LAYOUT,
             memory_config=weight_memory_config,
             cache_file_name=cache_name,
-            mesh_mapper=ttnn.ReplicateTensorToMesh(device) if is_device_mesh else None,
+            mesh_mapper=ttnn.ReplicateTensorToMesh(device) if is_mesh_device else None,
         )
 
         if is_sharded:

--- a/models/common/tests/test_rmsnorm.py
+++ b/models/common/tests/test_rmsnorm.py
@@ -108,7 +108,7 @@ def test_rmsnorm_singledevice(device, is_sharded, use_program_cache, reset_seeds
     "is_sharded",
     (True, False),
 )
-def test_rmsnorm_multidevice(t3k_device_mesh, is_sharded, use_program_cache, reset_seeds):
+def test_rmsnorm_multidevice(t3k_mesh_device, is_sharded, use_program_cache, reset_seeds):
     dim = 4096
     dtype = ttnn.bfloat8_b
 
@@ -116,7 +116,7 @@ def test_rmsnorm_multidevice(t3k_device_mesh, is_sharded, use_program_cache, res
     state_dict = reference_model.state_dict()
 
     tt_model = TtRMSNorm(
-        device=t3k_device_mesh,
+        device=t3k_mesh_device,
         dim=dim,
         state_dict=state_dict,
         weight_key="rmsnorm",
@@ -127,14 +127,14 @@ def test_rmsnorm_multidevice(t3k_device_mesh, is_sharded, use_program_cache, res
 
     tt_input = ttnn.from_torch(
         input,
-        device=t3k_device_mesh,
+        device=t3k_mesh_device,
         dtype=dtype,
         layout=ttnn.TILE_LAYOUT,
-        mesh_mapper=ReplicateTensorToMesh(t3k_device_mesh),
+        mesh_mapper=ReplicateTensorToMesh(t3k_mesh_device),
     )
 
     tt_output = tt_model(tt_input)
-    tt_output_torch = ttnn.to_torch(tt_output, mesh_composer=ConcatMeshToTensor(t3k_device_mesh, dim=0))[0]
+    tt_output_torch = ttnn.to_torch(tt_output, mesh_composer=ConcatMeshToTensor(t3k_mesh_device, dim=0))[0]
     passing, pcc_message = comp_pcc(reference_output, tt_output_torch)
 
     logger.info(comp_allclose(reference_output, tt_output_torch))

--- a/models/demos/falcon7b_common/demo/demo.py
+++ b/models/demos/falcon7b_common/demo/demo.py
@@ -125,7 +125,7 @@ def run_falcon_demo_kv(
     model_config_strs_prefill_decode,
     model_location_generator,
     get_tt_cache_path,
-    device_mesh,  # can be ttnn.Device or ttnn.DeviceMesh
+    mesh_device,  # can be ttnn.Device or ttnn.MeshDevice
     model_version="tiiuae/falcon-7b-instruct",
     num_layers=32,
     perf_mode=False,  # Option to measure perf using max seq length (with invalid outputs)
@@ -157,7 +157,7 @@ def run_falcon_demo_kv(
     disable_persistent_kernel_cache()
     disable_compilation_reports()
 
-    num_devices = get_num_devices(device_mesh)
+    num_devices = get_num_devices(mesh_device)
     global_batch = batch_size * num_devices
 
     torch.manual_seed(0)
@@ -197,13 +197,13 @@ def run_falcon_demo_kv(
     logger.info("Loading weights finished!")
     profiler.end(f"loading_weights")
 
-    synchronize_devices(device_mesh)
+    synchronize_devices(mesh_device)
 
     logger.info("Moving weights (single layer) to device...")
     base_url = ""
 
     tt_FalconCausalLM_singlelayer = TtFalconCausalLM(
-        device_mesh,
+        mesh_device,
         state_dict,
         base_url,
         1,
@@ -215,7 +215,7 @@ def run_falcon_demo_kv(
     )  # single layer only used for compile
     logger.info("Moved weights (single layer) to device!")
 
-    synchronize_devices(device_mesh)
+    synchronize_devices(mesh_device)
 
     logger.info("Initializing KV cache...")
     profiler.start(f"initializing_KV_cache")
@@ -224,9 +224,9 @@ def run_falcon_demo_kv(
         1,
         batch_size,
         max_seq_len,
-        device_mesh,
+        mesh_device,
     )  # only used for compile
-    kv_cache = initialize_kv_cache(configuration, num_layers, batch_size, max_seq_len, device_mesh)
+    kv_cache = initialize_kv_cache(configuration, num_layers, batch_size, max_seq_len, mesh_device)
     profiler.end(f"initializing_KV_cache")
 
     ### First prefill run with compile ###
@@ -252,7 +252,7 @@ def run_falcon_demo_kv(
             layer_past_len=0,
             use_cache=use_cache,
         )
-        synchronize_devices(device_mesh)
+        synchronize_devices(mesh_device)
 
         tt_prefill_input_ids.deallocate()
         if tt_prefill_attention_mask is not None:
@@ -267,7 +267,7 @@ def run_falcon_demo_kv(
 
     profiler.end("compile_prefill")
 
-    synchronize_devices(device_mesh)
+    synchronize_devices(mesh_device)
     logger.info("Finished 1st run prefill stage with compile!")
 
     ### First run decode stage with compile ###
@@ -296,7 +296,7 @@ def run_falcon_demo_kv(
             layer_past_len=kv_cache_len,
             use_cache=use_cache,
         )
-        synchronize_devices(device_mesh)
+        synchronize_devices(mesh_device)
 
         tt_decode_input_ids.deallocate()
         if tt_decode_attention_mask is not None:
@@ -306,7 +306,7 @@ def run_falcon_demo_kv(
     profiler.end("compile_decode")
 
     logger.info("Finished 1st run decode stage with compile!")
-    synchronize_devices(device_mesh)
+    synchronize_devices(mesh_device)
 
     del tt_logits
     del tt_prefill_input_ids
@@ -319,7 +319,7 @@ def run_falcon_demo_kv(
     logger.info("Moving weights (all layers) to device; might take some time...")
     profiler.start(f"moving_to_device")
     tt_FalconCausalLM = TtFalconCausalLM(
-        device_mesh,
+        mesh_device,
         state_dict,
         base_url,
         num_layers,
@@ -367,7 +367,7 @@ def run_falcon_demo_kv(
             layer_past_len=0,
             use_cache=use_cache,
         )
-        synchronize_devices(device_mesh)
+        synchronize_devices(mesh_device)
 
         if tt_prefill_attention_mask is not None:
             if isinstance(tt_prefill_attention_mask, ttnn.Tensor):
@@ -378,7 +378,7 @@ def run_falcon_demo_kv(
             else:
                 raise ValueError("Invalid type for tt_attention_mask")
 
-        logits = tt_tensors_to_torch_tensors(tt_logits, device_mesh, concat_dim=0).squeeze(1)
+        logits = tt_tensors_to_torch_tensors(tt_logits, mesh_device, concat_dim=0).squeeze(1)
 
         tt_prefill_input_ids.deallocate()
         tt_logits.deallocate()
@@ -439,9 +439,9 @@ def run_falcon_demo_kv(
             layer_past_len=kv_cache_len,
             use_cache=use_cache,
         )
-        synchronize_devices(device_mesh)
+        synchronize_devices(mesh_device)
 
-        logits = tt_tensors_to_torch_tensors(tt_logits, device_mesh, concat_dim=2).squeeze(1)
+        logits = tt_tensors_to_torch_tensors(tt_logits, mesh_device, concat_dim=2).squeeze(1)
 
         tt_decode_input_ids.deallocate()
         if tt_decode_attention_mask is not None:

--- a/models/demos/falcon7b_common/tests/perplexity/test_perplexity_falcon.py
+++ b/models/demos/falcon7b_common/tests/perplexity/test_perplexity_falcon.py
@@ -27,7 +27,7 @@ from models.utility_functions import is_wormhole_b0
     ],
 )
 @pytest.mark.parametrize("enable_async_mode", (True,), indirect=True)  # Option to run Falcon in Async mode
-@pytest.mark.parametrize("device_mesh", (1,), indirect=True)
+@pytest.mark.parametrize("mesh_device", (1,), indirect=True)
 def test_perplexity(
     llm_mode,
     batch_size,
@@ -40,7 +40,7 @@ def test_perplexity(
     enable_async_mode,
     model_location_generator,
     get_tt_cache_path,
-    device_mesh,
+    mesh_device,
     use_program_cache,
 ):
     assert is_wormhole_b0(), "This test is only for Wormhole B0"
@@ -52,7 +52,7 @@ def test_perplexity(
         model_config_str,
         model_location_generator,
         get_tt_cache_path,
-        device_mesh,
+        mesh_device,
         num_samples,
         {"ppl": expected_ppl, "top1_acc": expected_top1, "top5_acc": expected_top5},
     )

--- a/models/demos/falcon7b_common/tests/test_falcon_device_perf.py
+++ b/models/demos/falcon7b_common/tests/test_falcon_device_perf.py
@@ -39,7 +39,7 @@ from models.utility_functions import disable_compilation_reports, disable_persis
         "decode_seq2047_bfloat16-l1_sharded",
     ],
 )
-@pytest.mark.parametrize("device_mesh", (1,), indirect=True)
+@pytest.mark.parametrize("mesh_device", (1,), indirect=True)
 def test_device_perf_wh_bare_metal(
     model_version,
     llm_mode,
@@ -50,7 +50,7 @@ def test_device_perf_wh_bare_metal(
     model_config_str,
     model_location_generator,
     get_tt_cache_path,
-    device_mesh,
+    mesh_device,
 ):
     model_config = get_model_config(model_config_str, seq_len, batch)
     tt_cache_path = get_tt_cache_path(
@@ -70,7 +70,7 @@ def test_device_perf_wh_bare_metal(
         ][kv_cache_len]
 
     run_test_FalconCausalLM_end_to_end(
-        device_mesh,
+        mesh_device,
         model_version,
         llm_mode,
         batch,

--- a/models/demos/falcon7b_common/tests/test_falcon_model.py
+++ b/models/demos/falcon7b_common/tests/test_falcon_model.py
@@ -40,7 +40,7 @@ class PytorchFalconModel(torch.nn.Module):
 
 
 def run_test_FalconModel_inference(
-    device_mesh,
+    mesh_device,
     model_version,
     llm_mode,
     batch,
@@ -52,7 +52,7 @@ def run_test_FalconModel_inference(
     tt_cache_path,
     model_location_generator,
 ):
-    num_devices = get_num_devices(device_mesh)
+    num_devices = get_num_devices(mesh_device)
     global_batch = batch * num_devices
     hugging_face_reference_model, state_dict = load_hf_model(model_location_generator, model_version)
     configuration = hugging_face_reference_model.config
@@ -80,7 +80,7 @@ def run_test_FalconModel_inference(
         seq_len,
         batch,
         kv_cache_len,
-        device_mesh,
+        mesh_device,
         global_batch,
         head_dim,
         max_position_embeddings,
@@ -97,7 +97,7 @@ def run_test_FalconModel_inference(
     )
 
     tt_FalconModel = TtFalconModel(
-        device_mesh,
+        mesh_device,
         state_dict,
         base_url,
         num_layers,
@@ -129,7 +129,7 @@ def run_test_FalconModel_inference(
                 use_cache=use_cache,
             )
             # Get outputs from all devices
-            tt_outs[user_id::batch] = tt_tensors_to_torch_tensors(tt_out, device_mesh, concat_dim=0).squeeze(1)
+            tt_outs[user_id::batch] = tt_tensors_to_torch_tensors(tt_out, mesh_device, concat_dim=0).squeeze(1)
         tt_out = tt_outs
 
     elif llm_mode == "decode":
@@ -144,7 +144,7 @@ def run_test_FalconModel_inference(
             layer_past_len=kv_cache_len,
             use_cache=use_cache,
         )
-        tt_out = tt_tensors_to_torch_tensors(tt_out, device_mesh, concat_dim=2).squeeze(1).transpose(0, 1)
+        tt_out = tt_tensors_to_torch_tensors(tt_out, mesh_device, concat_dim=2).squeeze(1).transpose(0, 1)
 
     # check outputs ----------------------------------------------------------------------
     does_pass, output_pcc = comp_pcc(pytorch_out, tt_out, pcc)
@@ -153,14 +153,14 @@ def run_test_FalconModel_inference(
     for i in range(num_layers):
         if llm_mode == "prefill":
             pytorch_layer_pres = (pytorch_layer_present[i][0].squeeze(1), pytorch_layer_present[i][1].squeeze(1))
-            tt_layer_pres = concat_device_out_layer_present(device_mesh, tt_layer_present[i], kv_len)
+            tt_layer_pres = concat_device_out_layer_present(mesh_device, tt_layer_present[i], kv_len)
         elif llm_mode == "decode":
             pytorch_layer_pres = (
                 pytorch_layer_present[i][0].squeeze(1)[:, kv_cache_len, :],
                 pytorch_layer_present[i][1].squeeze(1)[:, kv_cache_len, :],
             )
             tt_layer_pres = concat_device_out_layer_present(
-                device_mesh, tt_layer_present[i], kv_cache_len, end_idx_only=True
+                mesh_device, tt_layer_present[i], kv_cache_len, end_idx_only=True
             )
 
         does_pass2, output_pcc = comp_pcc(pytorch_layer_pres[0], tt_layer_pres[0], pcc)
@@ -180,7 +180,7 @@ def run_test_FalconModel_inference(
         assert does_pass, f"PCC value is lower than {pcc}"
 
 
-@pytest.mark.parametrize("device_mesh", (1, 2, 4, (8, 4)), indirect=True, ids=["1chip", "2chip", "4chip", "32chipTG"])
+@pytest.mark.parametrize("mesh_device", (1, 2, 4, (8, 4)), indirect=True, ids=["1chip", "2chip", "4chip", "32chipTG"])
 @pytest.mark.parametrize("enable_async_mode", (False, True), indirect=True)
 @pytest.mark.parametrize(
     "llm_mode, batch, seq_len, kv_cache_len",
@@ -212,7 +212,7 @@ def test_FalconModel_inference(
     model_config_str,
     model_location_generator,
     get_tt_cache_path,
-    device_mesh,
+    mesh_device,
     enable_async_mode,
 ):
     if model_config_str == "BFLOAT16-L1_SHARDED" and llm_mode == "prefill":
@@ -223,7 +223,7 @@ def test_FalconModel_inference(
         model_version, model_subdir="Falcon", default_dir=model_config["DEFAULT_CACHE_PATH"]
     )
     run_test_FalconModel_inference(
-        device_mesh,
+        mesh_device,
         model_version,
         llm_mode,
         batch,

--- a/models/demos/falcon7b_common/tests/test_perf_falcon.py
+++ b/models/demos/falcon7b_common/tests/test_perf_falcon.py
@@ -126,7 +126,7 @@ class TestParametrized:
         model_config_str,
         model_location_generator,
         get_tt_cache_path,
-        device_mesh,
+        mesh_device,
         async_mode,
     ):
         if model_config_str == "BFLOAT16-L1_SHARDED" and llm_mode == "prefill":
@@ -141,7 +141,7 @@ class TestParametrized:
         disable_compilation_reports()
 
         run_test_FalconCausalLM_end_to_end(
-            device_mesh,
+            mesh_device,
             model_version,
             llm_mode,
             batch,
@@ -191,7 +191,7 @@ class TestParametrized:
         ],
     )
     @pytest.mark.parametrize("enable_async_mode", (False, True), indirect=True, ids=["noasync", "async"])
-    @pytest.mark.parametrize("device_mesh", (1,), indirect=True)
+    @pytest.mark.parametrize("mesh_device", (1,), indirect=True)
     @skip_for_grayskull()
     def test_perf_wh_bare_metal(
         self,
@@ -205,7 +205,7 @@ class TestParametrized:
         model_config_str,
         model_location_generator,
         get_tt_cache_path,
-        device_mesh,
+        mesh_device,
         use_program_cache,
         enable_async_mode,
     ):
@@ -236,13 +236,13 @@ class TestParametrized:
             model_config_str,
             model_location_generator,
             get_tt_cache_path,
-            device_mesh,
+            mesh_device,
             enable_async_mode,
         )
 
     @pytest.mark.model_perf_t3000
     @pytest.mark.parametrize(
-        "llm_mode, device_mesh, num_layers, batch, seq_len, kv_cache_len, model_config_str, expected_inference_time, enable_async_mode",
+        "llm_mode, mesh_device, num_layers, batch, seq_len, kv_cache_len, model_config_str, expected_inference_time, enable_async_mode",
         (
             ("prefill", 4, 32, 1, 128, 0, "BFLOAT16-DRAM", 0.071, False),
             ("prefill", 4, 32, 1, 256, 0, "BFLOAT16-DRAM", 0.142, False),
@@ -275,7 +275,7 @@ class TestParametrized:
             "decode_batch32_1024_async",
             "decode_batch32_2047_async",
         ],
-        indirect=["device_mesh", "enable_async_mode"],
+        indirect=["mesh_device", "enable_async_mode"],
     )
     @skip_for_grayskull()
     def test_perf_t3000_bare_metal(
@@ -292,7 +292,7 @@ class TestParametrized:
         model_config_str,
         model_location_generator,
         get_tt_cache_path,
-        device_mesh,
+        mesh_device,
     ):
         if llm_mode == "prefill":
             expected_output_pcc, expected_k_cache_pcc, expected_v_cache_pcc = PREFILL_CONFIG_TO_PCC[DeviceSetup.T3000][
@@ -315,6 +315,6 @@ class TestParametrized:
             model_config_str,
             model_location_generator,
             get_tt_cache_path,
-            device_mesh,
+            mesh_device,
             enable_async_mode,
         )

--- a/models/demos/falcon7b_common/tests/test_utils.py
+++ b/models/demos/falcon7b_common/tests/test_utils.py
@@ -9,7 +9,7 @@ from transformers import FalconForCausalLM
 from models.utility_functions import tt_tensors_to_torch_tensors
 
 
-def initialize_kv_cache(configuration, num_layers, batch_size, max_seq_len, device_mesh):
+def initialize_kv_cache(configuration, num_layers, batch_size, max_seq_len, mesh_device):
     head_dim = configuration.hidden_size // configuration.num_attention_heads
     kv_cache = ()
     for _ in range(num_layers):
@@ -18,16 +18,16 @@ def initialize_kv_cache(configuration, num_layers, batch_size, max_seq_len, devi
         tt_k_cache = tt_from_torch(
             k_cache,
             dtype=ttnn.bfloat16,
-            device=device_mesh,
+            device=mesh_device,
             layout=ttnn.TILE_LAYOUT,
-            mesh_mapper=ReplicateTensorToMesh(device_mesh),
+            mesh_mapper=ReplicateTensorToMesh(mesh_device),
         )
         tt_v_cache = tt_from_torch(
             v_cache,
             dtype=ttnn.bfloat16,
-            device=device_mesh,
+            device=mesh_device,
             layout=ttnn.TILE_LAYOUT,
-            mesh_mapper=ReplicateTensorToMesh(device_mesh),
+            mesh_mapper=ReplicateTensorToMesh(mesh_device),
         )
         kv_cache += ((tt_k_cache, tt_v_cache),)
     return kv_cache
@@ -78,7 +78,7 @@ def get_rand_falcon_inputs(
     seq_len,
     batch,
     kv_cache_len,
-    device_mesh,
+    mesh_device,
     global_batch,
     head_dim,
     max_position_embeddings,
@@ -104,9 +104,9 @@ def get_rand_falcon_inputs(
             tt_attention_input = tt_from_torch(
                 attention_input.unsqueeze(1),
                 dtype=model_config["DEFAULT_DTYPE"],
-                device=device_mesh,
+                device=mesh_device,
                 layout=ttnn.TILE_LAYOUT,
-                mesh_mapper=ShardTensorToMesh(device_mesh, dim=0),
+                mesh_mapper=ShardTensorToMesh(mesh_device, dim=0),
             )
 
             if model_config["PREFILL_OPTIMIZED_MODE"] and seq_len in [2048, 128, 1024]:
@@ -119,9 +119,9 @@ def get_rand_falcon_inputs(
                     tt_from_torch(
                         attn_mask,
                         dtype=ttnn.bfloat4_b,
-                        device=device_mesh,
+                        device=mesh_device,
                         layout=ttnn.TILE_LAYOUT,
-                        mesh_mapper=ShardTensorToMesh(device_mesh, dim=0),
+                        mesh_mapper=ShardTensorToMesh(mesh_device, dim=0),
                     )
                     for attn_mask in attn_masks
                 ]
@@ -129,9 +129,9 @@ def get_rand_falcon_inputs(
                 tt_attention_mask = tt_from_torch(
                     (attention_mask_bool * -100000).expand(-1, configuration.num_attention_heads, -1, -1),
                     dtype=model_config["DEFAULT_DTYPE"],
-                    device=device_mesh,
+                    device=mesh_device,
                     layout=ttnn.TILE_LAYOUT,
-                    mesh_mapper=ShardTensorToMesh(device_mesh, dim=0),
+                    mesh_mapper=ShardTensorToMesh(mesh_device, dim=0),
                 )
 
         # Generate kvcache for each layer
@@ -143,16 +143,16 @@ def get_rand_falcon_inputs(
             tt_k_cache = tt_from_torch(
                 tt_k_cache.unsqueeze(1),
                 dtype=model_config["DEFAULT_DTYPE"],
-                device=device_mesh,
+                device=mesh_device,
                 layout=ttnn.TILE_LAYOUT,
-                mesh_mapper=ShardTensorToMesh(device_mesh, dim=0),
+                mesh_mapper=ShardTensorToMesh(mesh_device, dim=0),
             )
             tt_v_cache = tt_from_torch(
                 tt_v_cache.unsqueeze(1),
                 dtype=model_config["DEFAULT_DTYPE"],
-                device=device_mesh,
+                device=mesh_device,
                 layout=ttnn.TILE_LAYOUT,
-                mesh_mapper=ShardTensorToMesh(device_mesh, dim=0),
+                mesh_mapper=ShardTensorToMesh(mesh_device, dim=0),
             )
             tt_layer_past += ((tt_k_cache, tt_v_cache),)
 
@@ -167,9 +167,9 @@ def get_rand_falcon_inputs(
             tt_attention_input = tt_from_torch(
                 attention_input.unsqueeze(1).transpose(0, 2),
                 dtype=model_config["DEFAULT_DTYPE"],
-                device=device_mesh,
+                device=mesh_device,
                 layout=ttnn.TILE_LAYOUT,
-                mesh_mapper=ShardTensorToMesh(device_mesh, dim=2),
+                mesh_mapper=ShardTensorToMesh(mesh_device, dim=2),
             )
 
             attention_mask_bool = torch.zeros(global_batch, 1, q_len, kv_len, dtype=bool)
@@ -197,10 +197,10 @@ def get_rand_falcon_inputs(
             tt_attention_mask = tt_from_torch(
                 attention_mask_bool_padded,
                 dtype=model_config["DEFAULT_DTYPE"],
-                device=device_mesh,
+                device=mesh_device,
                 layout=ttnn.ROW_MAJOR_LAYOUT,
                 memory_config=model_config["ATTN_MASK_MEMCFG"],
-                mesh_mapper=ShardTensorToMesh(device_mesh, dim=device_shard_dim),
+                mesh_mapper=ShardTensorToMesh(mesh_device, dim=device_shard_dim),
             )
             if not model_config["l1_sharded"]:
                 # Tilize attn masks
@@ -225,16 +225,16 @@ def get_rand_falcon_inputs(
             tt_k_cache = tt_from_torch(
                 tt_k_cache.unsqueeze(1),
                 dtype=model_config["DEFAULT_DTYPE"],
-                device=device_mesh,
+                device=mesh_device,
                 layout=ttnn.TILE_LAYOUT,
-                mesh_mapper=ShardTensorToMesh(device_mesh, dim=0),
+                mesh_mapper=ShardTensorToMesh(mesh_device, dim=0),
             )
             tt_v_cache = tt_from_torch(
                 tt_v_cache.unsqueeze(1),
                 dtype=model_config["DEFAULT_DTYPE"],
-                device=device_mesh,
+                device=mesh_device,
                 layout=ttnn.TILE_LAYOUT,
-                mesh_mapper=ShardTensorToMesh(device_mesh, dim=0),
+                mesh_mapper=ShardTensorToMesh(mesh_device, dim=0),
             )
             tt_layer_past += ((tt_k_cache, tt_v_cache),)
 
@@ -255,10 +255,10 @@ def get_rand_falcon_inputs(
         )
 
 
-def concat_device_out_layer_present(device_mesh, tt_layer_present, seq_end_idx, end_idx_only=False):
+def concat_device_out_layer_present(mesh_device, tt_layer_present, seq_end_idx, end_idx_only=False):
     tt_layer_present = (
-        tt_tensors_to_torch_tensors(tt_layer_present[0], device_mesh, concat_dim=0).squeeze(1),
-        tt_tensors_to_torch_tensors(tt_layer_present[1], device_mesh, concat_dim=0).squeeze(1),
+        tt_tensors_to_torch_tensors(tt_layer_present[0], mesh_device, concat_dim=0).squeeze(1),
+        tt_tensors_to_torch_tensors(tt_layer_present[1], mesh_device, concat_dim=0).squeeze(1),
     )
     if not end_idx_only:
         tt_layer_present = (
@@ -273,18 +273,18 @@ def concat_device_out_layer_present(device_mesh, tt_layer_present, seq_end_idx, 
     return tt_layer_present
 
 
-def concat_device_outputs(device_mesh, tt_out, llm_mode, tt_layer_present, seq_end_idx):
+def concat_device_outputs(mesh_device, tt_out, llm_mode, tt_layer_present, seq_end_idx):
     concat_dim = 2 if llm_mode == "decode" else 0
-    tt_out = tt_tensors_to_torch_tensors(tt_out, device_mesh, concat_dim=concat_dim).squeeze(1)
+    tt_out = tt_tensors_to_torch_tensors(tt_out, mesh_device, concat_dim=concat_dim).squeeze(1)
     if llm_mode == "decode":
         tt_out = tt_out.transpose(0, 1)
-    tt_layer_present = concat_device_out_layer_present(device_mesh, tt_layer_present, seq_end_idx)
+    tt_layer_present = concat_device_out_layer_present(mesh_device, tt_layer_present, seq_end_idx)
     return tt_out, tt_layer_present
 
 
 def get_devices(device):
-    # device is either a ttnn.DeviceMesh or a ttnn.Device
-    if type(device) == ttnn.DeviceMesh:
+    # device is either a ttnn.MeshDevice or a ttnn.Device
+    if type(device) == ttnn.MeshDevice:
         devices = device.get_devices()
     elif type(device) == ttnn.Device:
         devices = [device]
@@ -294,27 +294,27 @@ def get_devices(device):
 
 
 def synchronize_devices(device):
-    # device is either a ttnn.DeviceMesh or a ttnn.Device
+    # device is either a ttnn.MeshDevice or a ttnn.Device
     devices = get_devices(device)
     for device in devices:
         ttnn.synchronize_device(device)
 
 
 def tt_from_torch(torch_tensor, dtype=None, device=None, layout=None, memory_config=None, mesh_mapper=None):
-    # device is either a ttnn.DeviceMesh or a ttnn.Device
+    # device is either a ttnn.MeshDevice or a ttnn.Device
     return ttnn.from_torch(
         torch_tensor,
         dtype=dtype,
         device=device,
         layout=layout,
         memory_config=memory_config,
-        mesh_mapper=mesh_mapper if type(device) == ttnn.DeviceMesh else None,
+        mesh_mapper=mesh_mapper if type(device) == ttnn.MeshDevice else None,
     )
 
 
 def get_num_devices(device):
-    # device is either a ttnn.DeviceMesh or a ttnn.Device
-    if type(device) == ttnn.DeviceMesh:
+    # device is either a ttnn.MeshDevice or a ttnn.Device
+    if type(device) == ttnn.MeshDevice:
         return device.get_num_devices()
     elif type(device) == ttnn.Device:
         return 1
@@ -323,7 +323,7 @@ def get_num_devices(device):
 
 
 def dump_device_profiler(device):
-    # device is either a ttnn.DeviceMesh or a ttnn.Device
+    # device is either a ttnn.MeshDevice or a ttnn.Device
     devices = get_devices(device)
     for device in devices:
         ttnn.DumpDeviceProfiler(device)

--- a/models/demos/falcon7b_common/tt/falcon_attention.py
+++ b/models/demos/falcon7b_common/tt/falcon_attention.py
@@ -23,7 +23,7 @@ from models.demos.falcon7b_common.tests.test_utils import tt_from_torch
 class TtFalconRotaryEmbedding(torch.nn.Module):
     def __init__(
         self,
-        device_mesh,
+        mesh_device,
         dim,
         base_url,
         layer_num,
@@ -52,7 +52,7 @@ class TtFalconRotaryEmbedding(torch.nn.Module):
         sin_str = f"{layer_name}.sin_cached"
 
         self.tt_cos_cached = get_weights_cached(
-            device_mesh,
+            mesh_device,
             model_config,
             tt_cache_path,
             cos_str,
@@ -61,7 +61,7 @@ class TtFalconRotaryEmbedding(torch.nn.Module):
             weights_dict=weights_dict,
         )
         self.tt_sin_cached = get_weights_cached(
-            device_mesh,
+            mesh_device,
             model_config,
             tt_cache_path,
             sin_str,
@@ -89,7 +89,7 @@ class TtFalconAttentionPrefill(nn.Module):
 
     def __init__(
         self,
-        device_mesh,
+        mesh_device,
         state_dict,
         base_url,
         layer_num,
@@ -105,7 +105,7 @@ class TtFalconAttentionPrefill(nn.Module):
         self.num_heads = num_heads
         self.head_dim = hidden_size // num_heads
         self.max_position_embeddings = max_position_embeddings
-        self.device_mesh = device_mesh
+        self.mesh_device = mesh_device
         self.state_dict = state_dict
         self.model_config = model_config
         self.padded_local_heads = nearest_32(num_heads)
@@ -121,7 +121,7 @@ class TtFalconAttentionPrefill(nn.Module):
         selfout_str = f"{layer_name}.dense.weight"
 
         self.query_key_value_weights = get_weights_cached(
-            device_mesh,
+            mesh_device,
             model_config,
             tt_cache_path,
             query_key_value_str,
@@ -130,7 +130,7 @@ class TtFalconAttentionPrefill(nn.Module):
             weights_dict=weights_dict,
         )
         self.dense_weights = get_weights_cached(
-            device_mesh,
+            mesh_device,
             model_config,
             tt_cache_path,
             selfout_str,
@@ -140,7 +140,7 @@ class TtFalconAttentionPrefill(nn.Module):
         )
 
         self.rotary_embedding = TtFalconRotaryEmbedding(
-            device_mesh,
+            mesh_device,
             self.head_dim,
             base_url,
             layer_num,
@@ -153,9 +153,9 @@ class TtFalconAttentionPrefill(nn.Module):
         self.scalar = tt_from_torch(
             torch.tensor(1 / math.sqrt(self.head_dim)).view(1, 1),
             dtype=model_config["DEFAULT_DTYPE"],
-            device=device_mesh,
+            device=mesh_device,
             layout=ttnn.TILE_LAYOUT,
-            mesh_mapper=ReplicateTensorToMesh(device_mesh),
+            mesh_mapper=ReplicateTensorToMesh(mesh_device),
         )
 
         # optimized version can utilize single float value for softmax
@@ -172,10 +172,10 @@ class TtFalconAttentionPrefill(nn.Module):
                 tt_tensors = tt_from_torch(
                     tensor.detach(),
                     ttnn.bfloat16,
-                    device=self.device_mesh,
+                    device=self.mesh_device,
                     layout=ttnn.TILE_LAYOUT,
                     memory_config=self.model_config["ATTN_OPTIMIZED_MEMCFG"],
-                    mesh_mapper=ReplicateTensorToMesh(self.device_mesh),
+                    mesh_mapper=ReplicateTensorToMesh(self.mesh_device),
                 )
                 self.model_config["ATTN_OUTPUT_TENSORS"][seq_len] = tt_tensors
 
@@ -481,7 +481,7 @@ class TtFalconAttentionDecode(nn.Module):
 
     def __init__(
         self,
-        device_mesh,
+        mesh_device,
         state_dict,
         base_url,
         layer_num,
@@ -497,7 +497,7 @@ class TtFalconAttentionDecode(nn.Module):
         self.num_heads = num_heads
         self.head_dim = hidden_size // num_heads
         self.max_position_embeddings = max_position_embeddings
-        self.device_mesh = device_mesh
+        self.mesh_device = mesh_device
         self.state_dict = state_dict
         self.model_config = model_config
         self.padded_local_heads = nearest_32(num_heads)
@@ -513,7 +513,7 @@ class TtFalconAttentionDecode(nn.Module):
         selfout_str = f"{layer_name}.dense.weight"
 
         self.query_key_value_weights = get_weights_cached(
-            device_mesh,
+            mesh_device,
             model_config,
             tt_cache_path,
             query_key_value_str,
@@ -522,7 +522,7 @@ class TtFalconAttentionDecode(nn.Module):
             weights_dict=weights_dict,
         )
         self.dense_weights = get_weights_cached(
-            device_mesh,
+            mesh_device,
             model_config,
             tt_cache_path,
             selfout_str,
@@ -532,7 +532,7 @@ class TtFalconAttentionDecode(nn.Module):
         )
 
         self.rotary_embedding = TtFalconRotaryEmbedding(
-            device_mesh,
+            mesh_device,
             self.head_dim,
             base_url,
             layer_num,
@@ -547,9 +547,9 @@ class TtFalconAttentionDecode(nn.Module):
             self.tt_scalar = tt_from_torch(
                 torch.tensor(self.scalar).view(1, 1),
                 dtype=model_config["DEFAULT_DTYPE"],
-                device=device_mesh,
+                device=mesh_device,
                 layout=ttnn.TILE_LAYOUT,
-                mesh_mapper=ReplicateTensorToMesh(device_mesh),
+                mesh_mapper=ReplicateTensorToMesh(mesh_device),
             )
 
     def forward(
@@ -690,7 +690,7 @@ class TtFalconAttentionDecode(nn.Module):
             attn_weights = ttnn.experimental.attn_matmul(
                 query_layer,
                 key_layer_transposed,
-                compute_with_storage_grid_size=self.device_mesh.compute_with_storage_grid_size(),
+                compute_with_storage_grid_size=self.mesh_device.compute_with_storage_grid_size(),
                 memory_config=self.model_config["PRE_SOFTMAX_MM_OUTPUT_MEMCFG"],
                 dtype=self.model_config["PRE_SOFTMAX_MM_OUTPUT_DTYPE"],  # Must be BFLOAT16
             )
@@ -700,7 +700,7 @@ class TtFalconAttentionDecode(nn.Module):
             attn_weights = ttnn.experimental.group_attn_matmul(
                 query_layer,
                 key_layer_transposed,
-                compute_with_storage_grid_size=self.device_mesh.compute_with_storage_grid_size(),
+                compute_with_storage_grid_size=self.mesh_device.compute_with_storage_grid_size(),
                 memory_config=self.model_config["PRE_SOFTMAX_MM_OUTPUT_MEMCFG"],
                 dtype=self.model_config["PRE_SOFTMAX_MM_OUTPUT_DTYPE"],  # Must be BFLOAT16
             )
@@ -813,7 +813,7 @@ class TtFalconAttentionDecode(nn.Module):
                 attn_output = ttnn.experimental.attn_matmul(
                     attn_weights,
                     value_layer,
-                    compute_with_storage_grid_size=self.device_mesh.compute_with_storage_grid_size(),
+                    compute_with_storage_grid_size=self.mesh_device.compute_with_storage_grid_size(),
                     memory_config=self.model_config["POST_SOFTMAX_MM_OUTPUT_MEMCFG"],
                     dtype=self.model_config["POST_SOFTMAX_MM_OUTPUT_DTYPE"],  # Must be BFLOAT16
                 )
@@ -821,7 +821,7 @@ class TtFalconAttentionDecode(nn.Module):
                 attn_output = ttnn.experimental.group_attn_matmul(
                     attn_weights,
                     value_layer,
-                    compute_with_storage_grid_size=self.device_mesh.compute_with_storage_grid_size(),
+                    compute_with_storage_grid_size=self.mesh_device.compute_with_storage_grid_size(),
                     memory_config=self.model_config["POST_SOFTMAX_MM_OUTPUT_MEMCFG"],
                     dtype=self.model_config["POST_SOFTMAX_MM_OUTPUT_DTYPE"],  # Must be BFLOAT16
                 )

--- a/models/demos/falcon7b_common/tt/falcon_causallm.py
+++ b/models/demos/falcon7b_common/tt/falcon_causallm.py
@@ -57,7 +57,7 @@ def falcon_lm_head_matmul(
 class TtFalconCausalLM(TtFalconModelShared):
     def __init__(
         self,
-        device_mesh,  # can be ttnn.Device or ttnn.DeviceMesh
+        mesh_device,  # can be ttnn.Device or ttnn.MeshDevice
         state_dict,
         base_url,
         num_layers,
@@ -69,7 +69,7 @@ class TtFalconCausalLM(TtFalconModelShared):
     ):
         assert base_url == "", "base_url should be empty at the root of the model!"
         super().__init__(
-            device_mesh=device_mesh,
+            mesh_device=mesh_device,
             state_dict=state_dict,
             base_url=f"transformer",
             num_layers=num_layers,
@@ -96,7 +96,7 @@ class TtFalconCausalLM(TtFalconModelShared):
             # Cache sliced weights for lm_head with different seq_len
             self.lm_head_sliced_weights = [
                 get_weights_cached(
-                    device_mesh,
+                    mesh_device,
                     model_config,
                     tt_cache_path,
                     f"lm_head.weight_slice_{i}_of_{self.num_slices}",
@@ -110,14 +110,14 @@ class TtFalconCausalLM(TtFalconModelShared):
             self.lm_head_padding = tt_from_torch(
                 padding,
                 dtype=self.model_config["LM_HEAD_MM_INPUT_DTYPE"],
-                device=self.device_mesh,
+                device=self.mesh_device,
                 layout=ttnn.TILE_LAYOUT,
                 memory_config=self.model_config["LM_HEAD_MM_INPUT_MEMCFG"],
-                mesh_mapper=ReplicateTensorToMesh(self.device_mesh),
+                mesh_mapper=ReplicateTensorToMesh(self.mesh_device),
             )
 
         self.lm_head_weights = get_weights_cached(
-            device_mesh,
+            mesh_device,
             model_config,
             tt_cache_path,
             f"lm_head.weight",

--- a/models/demos/falcon7b_common/tt/falcon_decoder.py
+++ b/models/demos/falcon7b_common/tt/falcon_decoder.py
@@ -15,7 +15,7 @@ from torch import nn
 class TtFalconDecoderLayer(nn.Module):
     def __init__(
         self,
-        device_mesh,
+        mesh_device,
         state_dict,
         base_url,
         layer_num,
@@ -36,7 +36,7 @@ class TtFalconDecoderLayer(nn.Module):
         assert config.parallel_attn, "Path for config.parallel_attn=False is not implemented in TtFalconDecoderLayer!"
 
         self.self_attn_prefill = TtFalconAttentionPrefill(
-            device_mesh=device_mesh,
+            mesh_device=mesh_device,
             state_dict=state_dict,
             base_url=base_url,
             layer_num=layer_num,
@@ -49,7 +49,7 @@ class TtFalconDecoderLayer(nn.Module):
         )
 
         self.self_attn_decode = TtFalconAttentionDecode(
-            device_mesh=device_mesh,
+            mesh_device=mesh_device,
             state_dict=state_dict,
             base_url=base_url,
             layer_num=layer_num,
@@ -62,7 +62,7 @@ class TtFalconDecoderLayer(nn.Module):
         )
 
         self.mlp_prefill = TtFalconMLPPrefill(
-            device_mesh=device_mesh,
+            mesh_device=mesh_device,
             state_dict=state_dict,
             base_url=base_url,
             layer_num=layer_num,
@@ -74,7 +74,7 @@ class TtFalconDecoderLayer(nn.Module):
         )
 
         self.mlp_decode = TtFalconMLPDecode(
-            device_mesh=device_mesh,
+            mesh_device=mesh_device,
             state_dict=state_dict,
             base_url=base_url,
             layer_num=layer_num,
@@ -91,7 +91,7 @@ class TtFalconDecoderLayer(nn.Module):
         layernorm_bias_str = f"{layer_name}.input_layernorm.bias"
 
         self.layernorm_gamma = get_weights_cached(
-            device_mesh,
+            mesh_device,
             model_config,
             tt_cache_path,
             layernorm_weights_str,
@@ -99,7 +99,7 @@ class TtFalconDecoderLayer(nn.Module):
             weights_to_cache=(self.state_dict[layernorm_weights_str] if self.state_dict else None),
         )
         self.layernorm_beta = get_weights_cached(
-            device_mesh,
+            mesh_device,
             model_config,
             tt_cache_path,
             layernorm_bias_str,

--- a/models/demos/falcon7b_common/tt/falcon_mlp.py
+++ b/models/demos/falcon7b_common/tt/falcon_mlp.py
@@ -89,7 +89,7 @@ def falcon_dense_h_to_4h_matmul(
 class TtFalconMLPPrefill(nn.Module):
     def __init__(
         self,
-        device_mesh,
+        mesh_device,
         state_dict,
         base_url,
         layer_num,
@@ -102,7 +102,7 @@ class TtFalconMLPPrefill(nn.Module):
         super().__init__()
 
         self.state_dict = state_dict
-        self.device_mesh = device_mesh
+        self.mesh_device = mesh_device
         self.hidden_size = hidden_size
         self.model_config = model_config
         self.max_position_embeddings = max_position_embeddings
@@ -127,7 +127,7 @@ class TtFalconMLPPrefill(nn.Module):
         )
 
         self.dense_h_to_4h_weights = get_weights_cached(
-            device_mesh,
+            mesh_device,
             model_config,
             tt_cache_path,
             dense_h_to_4h_str,
@@ -137,7 +137,7 @@ class TtFalconMLPPrefill(nn.Module):
             custom_output_shape=custom_output_shape_h_to_4h,
         )
         self.dense_4h_to_h_weights = get_weights_cached(
-            device_mesh,
+            mesh_device,
             model_config,
             tt_cache_path,
             dense_4h_to_h_str,
@@ -163,10 +163,10 @@ class TtFalconMLPPrefill(nn.Module):
             tt_padding = tt_from_torch(
                 tt_padding,
                 ttnn.bfloat16,
-                device=self.device_mesh,
+                device=self.mesh_device,
                 layout=ttnn.TILE_LAYOUT,
                 memory_config=ttnn.DRAM_MEMORY_CONFIG,
-                mesh_mapper=ReplicateTensorToMesh(self.device_mesh),
+                mesh_mapper=ReplicateTensorToMesh(self.mesh_device),
             )
             mlp_padding_tensors[seq_len] = tt_padding
         self.model_config["MLP_PREFILL_PADDING_TENSORS"] = mlp_padding_tensors
@@ -178,10 +178,10 @@ class TtFalconMLPPrefill(nn.Module):
         out_tt = tt_from_torch(
             out_tensor,
             ttnn.bfloat16,
-            device=self.device_mesh,
+            device=self.mesh_device,
             layout=ttnn.TILE_LAYOUT,
             memory_config=ttnn.DRAM_MEMORY_CONFIG,
-            mesh_mapper=ReplicateTensorToMesh(self.device_mesh),
+            mesh_mapper=ReplicateTensorToMesh(self.mesh_device),
         )
         self.model_config["MLP_OUTPUT_TENSORS"] = out_tt
 
@@ -269,7 +269,7 @@ class TtFalconMLPPrefill(nn.Module):
 class TtFalconMLPDecode(nn.Module):
     def __init__(
         self,
-        device_mesh,
+        mesh_device,
         state_dict,
         base_url,
         layer_num,
@@ -282,7 +282,7 @@ class TtFalconMLPDecode(nn.Module):
         super().__init__()
 
         self.state_dict = state_dict
-        self.device_mesh = device_mesh
+        self.mesh_device = mesh_device
         self.hidden_size = hidden_size
         self.model_config = model_config
         self.padding_value = model_config["MLP_PADDING_VALUE"]
@@ -304,7 +304,7 @@ class TtFalconMLPDecode(nn.Module):
         )
 
         self.dense_h_to_4h_weights = get_weights_cached(
-            device_mesh,
+            mesh_device,
             model_config,
             tt_cache_path,
             dense_h_to_4h_str,
@@ -314,7 +314,7 @@ class TtFalconMLPDecode(nn.Module):
             custom_output_shape=custom_output_shape_h_to_4h,
         )
         self.dense_4h_to_h_weights = get_weights_cached(
-            device_mesh,
+            mesh_device,
             model_config,
             tt_cache_path,
             dense_4h_to_h_str,
@@ -331,10 +331,10 @@ class TtFalconMLPDecode(nn.Module):
         tt_paddings = tt_from_torch(
             tt_padding,
             ttnn.bfloat16,
-            device=self.device_mesh,
+            device=self.mesh_device,
             layout=ttnn.TILE_LAYOUT,
             memory_config=ttnn.DRAM_MEMORY_CONFIG,
-            mesh_mapper=ReplicateTensorToMesh(self.device_mesh),
+            mesh_mapper=ReplicateTensorToMesh(self.mesh_device),
         )
         self.model_config["MLP_DECODE_PADDING_TENSORS"] = tt_paddings
 

--- a/models/demos/falcon7b_common/tt/falcon_model.py
+++ b/models/demos/falcon7b_common/tt/falcon_model.py
@@ -25,7 +25,7 @@ class TtFalconModelShared(torch.nn.Module):
     @abstractmethod
     def __init__(
         self,
-        device_mesh,
+        mesh_device,
         state_dict,
         base_url,
         num_layers,
@@ -38,8 +38,8 @@ class TtFalconModelShared(torch.nn.Module):
 
         # NOTE: Once we make embeddings run on device, pass in state dict
         # instead of model itself
-        self.device_mesh = device_mesh
-        self.num_devices = get_num_devices(device_mesh)
+        self.mesh_device = mesh_device
+        self.num_devices = get_num_devices(mesh_device)
         self.state_dict = state_dict
         self.base_url = base_url
         self.config = config
@@ -49,7 +49,7 @@ class TtFalconModelShared(torch.nn.Module):
         layer_name = f"{base_url}"
         embedding_weights_str = f"{layer_name}.word_embeddings.weight"
         self.embedding_weights = get_weights_cached(
-            device_mesh,
+            mesh_device,
             model_config,
             tt_cache_path,
             embedding_weights_str,
@@ -62,7 +62,7 @@ class TtFalconModelShared(torch.nn.Module):
         self.layers = torch.nn.ModuleList(
             [
                 TtFalconDecoderLayer(
-                    device_mesh=device_mesh,
+                    mesh_device=mesh_device,
                     state_dict=state_dict,
                     base_url=f"{base_url}.h",
                     layer_num=layer_num,
@@ -79,7 +79,7 @@ class TtFalconModelShared(torch.nn.Module):
         layernorm_bias_str = f"{layer_name}.ln_f.bias"
 
         self.layernorm_gamma = get_weights_cached(
-            device_mesh,
+            mesh_device,
             model_config,
             tt_cache_path,
             layernorm_weights_str,
@@ -87,7 +87,7 @@ class TtFalconModelShared(torch.nn.Module):
             weights_to_cache=(self.state_dict[layernorm_weights_str] if self.state_dict else None),
         )
         self.layernorm_beta = get_weights_cached(
-            device_mesh,
+            mesh_device,
             model_config,
             tt_cache_path,
             layernorm_bias_str,
@@ -131,10 +131,10 @@ class TtFalconModelShared(torch.nn.Module):
                     tt_from_torch(
                         attention_mask_slice,
                         dtype=ttnn.bfloat16,  # subsequent tilize op excepts bfloat16 inputs
-                        device=self.device_mesh,
+                        device=self.mesh_device,
                         layout=ttnn.ROW_MAJOR_LAYOUT,
                         memory_config=self.model_config["ATTN_MASK_MEMCFG"],
-                        mesh_mapper=ReplicateTensorToMesh(self.device_mesh),
+                        mesh_mapper=ReplicateTensorToMesh(self.mesh_device),
                     )
                     for attention_mask_slice in attention_mask_
                 ]
@@ -153,10 +153,10 @@ class TtFalconModelShared(torch.nn.Module):
                 tt_attention_mask = tt_from_torch(
                     attention_mask_,
                     dtype=ttnn.bfloat16,  # subsequent tilize op excepts bfloat16 inputs
-                    device=self.device_mesh,
+                    device=self.mesh_device,
                     layout=ttnn.ROW_MAJOR_LAYOUT,
                     memory_config=self.model_config["ATTN_MASK_MEMCFG"],
-                    mesh_mapper=ReplicateTensorToMesh(self.device_mesh),
+                    mesh_mapper=ReplicateTensorToMesh(self.mesh_device),
                 )
                 # Repeat attn masks for all heads
                 tt_attention_mask = ttnn.repeat(
@@ -175,9 +175,9 @@ class TtFalconModelShared(torch.nn.Module):
                 input_ids,
                 dtype=self.model_config["INPUT_DTYPE"],
                 layout=ttnn.ROW_MAJOR_LAYOUT,
-                device=self.device_mesh,
+                device=self.mesh_device,
                 memory_config=self.model_config["INPUT_MEMCFG"],
-                mesh_mapper=ShardTensorToMesh(self.device_mesh, dim=0),
+                mesh_mapper=ShardTensorToMesh(self.mesh_device, dim=0),
             )
         elif llm_mode == "decode":
             assert batch_size % 32 == 0, "For decode, batch_size must be multiple of 32!"
@@ -207,10 +207,10 @@ class TtFalconModelShared(torch.nn.Module):
             tt_attention_mask = tt_from_torch(
                 attention_mask,
                 dtype=ttnn.bfloat16,  # subsequent tilize op excepts bfloat16 inputs
-                device=self.device_mesh,
+                device=self.mesh_device,
                 layout=ttnn.ROW_MAJOR_LAYOUT,
                 memory_config=self.model_config["ATTN_MASK_MEMCFG"],
-                mesh_mapper=ReplicateTensorToMesh(self.device_mesh),
+                mesh_mapper=ReplicateTensorToMesh(self.mesh_device),
             )
             if not self.model_config["l1_sharded"]:
                 # Tilize attn masks
@@ -224,9 +224,9 @@ class TtFalconModelShared(torch.nn.Module):
                 input_ids.transpose(0, 1),
                 dtype=self.model_config["INPUT_DTYPE"],
                 layout=ttnn.ROW_MAJOR_LAYOUT,
-                device=self.device_mesh,
+                device=self.mesh_device,
                 memory_config=self.model_config["INPUT_MEMCFG"],
-                mesh_mapper=ShardTensorToMesh(self.device_mesh, dim=1),
+                mesh_mapper=ShardTensorToMesh(self.mesh_device, dim=1),
             )
         else:
             raise NotImplementedError(f"Llm mode {llm_mode} is not supported! Must be one of prefill or decode.")
@@ -271,7 +271,7 @@ class TtFalconModelShared(torch.nn.Module):
             layer_output = layer_output[0]
 
             if device_perf_run and idx % 8 == 0:
-                dump_device_profiler(self.device_mesh)
+                dump_device_profiler(self.mesh_device)
 
         # apply final norm layer
         layer_output = layernorm(
@@ -288,7 +288,7 @@ class TtFalconModelShared(torch.nn.Module):
 class TtFalconModel(TtFalconModelShared):
     def __init__(
         self,
-        device_mesh,
+        mesh_device,
         state_dict,
         base_url,
         num_layers,
@@ -298,7 +298,7 @@ class TtFalconModel(TtFalconModelShared):
         tt_cache_path,
     ):
         super().__init__(
-            device_mesh=device_mesh,
+            mesh_device=mesh_device,
             state_dict=state_dict,
             base_url=base_url,
             num_layers=num_layers,

--- a/models/demos/falcon7b_common/tt/model_utils.py
+++ b/models/demos/falcon7b_common/tt/model_utils.py
@@ -10,7 +10,7 @@ from models.utility_functions import is_wormhole_b0
 
 
 def get_weights_cached(
-    device_mesh,
+    mesh_device,
     model_config,
     tt_cache_path,
     weight_cache_str,
@@ -48,9 +48,9 @@ def get_weights_cached(
             weights_to_cache,
             dtype=model_config[f"{weight_config_str}_DTYPE"],
             layout=tt_layout,
-            device=device_mesh,
+            device=mesh_device,
             memory_config=model_config[f"{weight_config_str}_MEMCFG"],
-            mesh_mapper=ReplicateTensorToMesh(device_mesh) if type(device_mesh) == ttnn.DeviceMesh else None,
+            mesh_mapper=ReplicateTensorToMesh(mesh_device) if type(mesh_device) == ttnn.MeshDevice else None,
             cache_file_name=str(path),
             preprocess=preprocess_weights,
         )

--- a/models/demos/grayskull/falcon7b/demo_grayskull.py
+++ b/models/demos/grayskull/falcon7b/demo_grayskull.py
@@ -37,7 +37,7 @@ def test_demo(
         model_config_strs_prefill_decode=["BFLOAT16-DRAM", "BFLOAT16-DRAM"],
         model_location_generator=model_location_generator,
         get_tt_cache_path=get_tt_cache_path,
-        device_mesh=device,
+        mesh_device=device,
         perf_mode=perf_mode,
         greedy_sampling=greedy_sampling,
         expected_perf_metrics=expected_perf_metrics,

--- a/models/demos/t3000/falcon40b/demo/demo.py
+++ b/models/demos/t3000/falcon40b/demo/demo.py
@@ -34,14 +34,14 @@ SPACE = 204
 
 
 # Used for debugging non-deterministic outputs of prefill stage
-def save_kv_cache_to_file(device_mesh, kv_cache, kv_cache_path):
+def save_kv_cache_to_file(mesh_device, kv_cache, kv_cache_path):
     # generate tensor of 60 layers and key and value tensors for each layer where there is 60 layers, key and value and tensor shape (32, 1, 128, 64)
     final_tensor = torch.zeros(60, 2, 32, 1, 128, 512)
     for layer in range(60):
         for type in range(len(kv_cache[layer])):
             # get key tensor from device
             tensor = ttnn.to_torch(
-                kv_cache[layer][type], device=device_mesh, mesh_composer=ttnn.ConcatMeshToTensor(device_mesh, dim=-1)
+                kv_cache[layer][type], device=mesh_device, mesh_composer=ttnn.ConcatMeshToTensor(mesh_device, dim=-1)
             )
             # save tensor to file
             final_tensor[layer][type] = tensor
@@ -100,7 +100,7 @@ def preprocess_and_validate_inputs(input_prompts, tokenizer, max_seq_len, perf_m
 
 # TODO: Remove once we have prefill on device
 def initialize_and_fill_kv_cache(
-    pytorch_FalconCausalLM, model_config, configuration, prefill_ids, num_layers, batch_size, max_seq_len, device_mesh
+    pytorch_FalconCausalLM, model_config, configuration, prefill_ids, num_layers, batch_size, max_seq_len, mesh_device
 ):
     logger.info("Generating kv cache on host")
 
@@ -128,17 +128,17 @@ def initialize_and_fill_kv_cache(
             tensor=tt_k_cache_host,
             dtype=model_config["KV_CACHE_DTYPE"],
             layout=ttnn.TILE_LAYOUT,
-            device=device_mesh,
+            device=mesh_device,
             memory_config=model_config["KV_CACHE_MEMCFG"],
-            mesh_mapper=ttnn.ShardTensorToMesh(device_mesh, dim=1),
+            mesh_mapper=ttnn.ShardTensorToMesh(mesh_device, dim=1),
         )
         tt_v_cache = ttnn.as_tensor(
             tensor=tt_v_cache_host,
             dtype=model_config["KV_CACHE_DTYPE"],
             layout=ttnn.TILE_LAYOUT,
-            device=device_mesh,
+            device=mesh_device,
             memory_config=model_config["KV_CACHE_MEMCFG"],
-            mesh_mapper=ttnn.ShardTensorToMesh(device_mesh, dim=1),
+            mesh_mapper=ttnn.ShardTensorToMesh(mesh_device, dim=1),
         )
         kv_cache += ((tt_k_cache, tt_v_cache),)
 
@@ -189,7 +189,7 @@ def run_falcon_demo_kv(
     max_seq_len,
     model_location_generator,
     get_tt_cache_path,
-    device_mesh,
+    mesh_device,
     prefill_on_host,
     perf_mode=False,
     greedy_sampling=False,
@@ -200,7 +200,7 @@ def run_falcon_demo_kv(
         logger.info("Running in performance measurement mode (invalid outputs)!")
 
     configuration = FalconConfig(**model_config_entries)
-    devices = device_mesh.get_devices()
+    devices = mesh_device.get_devices()
 
     profiler.start(f"loading_inputs")
     if len(user_input) == 1:
@@ -243,7 +243,7 @@ def run_falcon_demo_kv(
     base_url = ""
     use_global_cos_sin_cache = True
     tt_FalconCausalLM_singlelayer = TtFalconCausalLM(
-        device_mesh,
+        mesh_device,
         state_dict,
         base_url,
         1,
@@ -346,7 +346,7 @@ def run_falcon_demo_kv(
     logger.info("Moving weights (all layers) to device; might take some time...")
     profiler.start(f"moving_to_device")
     tt_FalconCausalLM = TtFalconCausalLM(
-        device_mesh,
+        mesh_device,
         state_dict,
         base_url,
         num_layers,
@@ -382,7 +382,7 @@ def run_falcon_demo_kv(
             num_layers,
             batch_size,
             max_seq_len,
-            device_mesh,
+            mesh_device,
         )
         profiler.end(f"initializing_KV_cache_on_host")
 
@@ -427,7 +427,7 @@ def run_falcon_demo_kv(
                 tt_logits = ttnn.untilize(tt_logits, use_multicore=False)
 
             logits = ttnn.to_torch(
-                tt_logits, device=device_mesh, mesh_composer=ttnn.ConcatMeshToTensor(device_mesh, dim=-1)
+                tt_logits, device=mesh_device, mesh_composer=ttnn.ConcatMeshToTensor(mesh_device, dim=-1)
             ).squeeze(1)
             del tt_logits
 
@@ -492,7 +492,7 @@ def run_falcon_demo_kv(
             tt_logits = ttnn.untilize(tt_logits, use_multicore=False)
 
         logits = ttnn.to_torch(
-            tt_logits, device=device_mesh, mesh_composer=ttnn.ConcatMeshToTensor(device_mesh, dim=-1)
+            tt_logits, device=mesh_device, mesh_composer=ttnn.ConcatMeshToTensor(mesh_device, dim=-1)
         ).squeeze(1)
 
         del tt_logits
@@ -585,7 +585,7 @@ def test_demo(
     user_input,
     model_location_generator,
     get_tt_cache_path,
-    t3k_device_mesh,
+    t3k_mesh_device,
     use_program_cache,
 ):
     # disable_persistent_kernel_cache()
@@ -601,7 +601,7 @@ def test_demo(
         max_seq_len=max_seq_len,
         model_location_generator=model_location_generator,
         get_tt_cache_path=get_tt_cache_path,
-        device_mesh=t3k_device_mesh,
+        mesh_device=t3k_mesh_device,
         prefill_on_host=False,
         perf_mode=perf_mode,
         greedy_sampling=greedy_sampling,

--- a/models/demos/t3000/falcon40b/tests/ci/test_falcon_end_to_end_1_layer_t3000.py
+++ b/models/demos/t3000/falcon40b/tests/ci/test_falcon_end_to_end_1_layer_t3000.py
@@ -80,7 +80,7 @@ def test_FalconCausalLM_end_to_end_with_program_cache(
     memcfg,
     model_location_generator,
     get_tt_cache_path,
-    t3k_device_mesh,
+    t3k_mesh_device,
     use_program_cache,
     async_mode,
 ):
@@ -97,7 +97,7 @@ def test_FalconCausalLM_end_to_end_with_program_cache(
 
     input_shape = [batch, seq_len]
     model_config = get_model_config(model_config_str, llm_mode, input_shape, num_devices)
-    devices = t3k_device_mesh.get_devices()
+    devices = t3k_mesh_device.get_devices()
     for device in devices:
         device.enable_async(async_mode)
     compute_grid_size = devices[0].compute_with_storage_grid_size()
@@ -112,7 +112,7 @@ def test_FalconCausalLM_end_to_end_with_program_cache(
     disable_compilation_reports()
 
     run_test_FalconCausalLM_end_to_end(
-        t3k_device_mesh,
+        t3k_mesh_device,
         model_version,
         llm_mode,
         batch,

--- a/models/demos/t3000/falcon40b/tests/ci/test_falcon_end_to_end_60_layer_t3000_prefill_10_loops.py
+++ b/models/demos/t3000/falcon40b/tests/ci/test_falcon_end_to_end_60_layer_t3000_prefill_10_loops.py
@@ -72,7 +72,7 @@ def test_FalconCausalLM_prefill_end_to_end_t3000_ci_loops_10(
     num_loops,
     model_location_generator,
     get_tt_cache_path,
-    t3k_device_mesh,
+    t3k_mesh_device,
     use_program_cache,
     async_mode,
 ):
@@ -88,7 +88,7 @@ def test_FalconCausalLM_prefill_end_to_end_t3000_ci_loops_10(
     input_shape = [batch, seq_len]
     model_config_str = f"{data_type}-{memcfg}"
     model_config = get_model_config(model_config_str, llm_mode, input_shape, num_devices)
-    devices = t3k_device_mesh.get_devices()
+    devices = t3k_mesh_device.get_devices()
     for device in devices:
         device.enable_async(async_mode)
     compute_grid_size = devices[0].compute_with_storage_grid_size()
@@ -138,7 +138,7 @@ def test_FalconCausalLM_prefill_end_to_end_t3000_ci_loops_10(
     disable_compilation_reports()
 
     run_test_FalconCausalLM_end_to_end(
-        t3k_device_mesh,
+        t3k_mesh_device,
         model_version,
         llm_mode,
         batch,

--- a/models/demos/t3000/falcon40b/tests/test_demo.py
+++ b/models/demos/t3000/falcon40b/tests/test_demo.py
@@ -11,7 +11,7 @@ from models.demos.t3000.falcon40b.demo.demo import run_falcon_demo_kv
 
 @pytest.mark.parametrize("max_seq_len", (128,))
 def test_demo_generate_reference_output(
-    max_seq_len, model_location_generator, get_tt_cache_path, t3k_device_mesh, use_program_cache, is_ci_env
+    max_seq_len, model_location_generator, get_tt_cache_path, t3k_mesh_device, use_program_cache, is_ci_env
 ):
     if is_ci_env:
         pytest.skip("Skip generating reference output in CI")
@@ -28,7 +28,7 @@ def test_demo_generate_reference_output(
         max_seq_len=max_seq_len,
         model_location_generator=model_location_generator,
         get_tt_cache_path=get_tt_cache_path,
-        device_mesh=t3k_device_mesh,
+        mesh_device=t3k_mesh_device,
         prefill_on_host=False,
         perf_mode=False,
         greedy_sampling=True,
@@ -44,12 +44,12 @@ def test_demo(
     max_seq_len,
     model_location_generator,
     get_tt_cache_path,
-    t3k_device_mesh,
+    t3k_mesh_device,
     use_program_cache,
 ):
     input_file = "models/demos/t3000/falcon40b/demo/input_data.json"
     # Enable async mode
-    for device in t3k_device_mesh.get_devices():
+    for device in t3k_mesh_device.get_devices():
         device.enable_async(True)
 
     generated_text, measurements = run_falcon_demo_kv(
@@ -62,7 +62,7 @@ def test_demo(
         max_seq_len=max_seq_len,
         model_location_generator=model_location_generator,
         get_tt_cache_path=get_tt_cache_path,
-        device_mesh=t3k_device_mesh,
+        mesh_device=t3k_mesh_device,
         prefill_on_host=False,
         perf_mode=False,
         greedy_sampling=True,

--- a/models/demos/t3000/falcon40b/tests/test_falcon_causallm.py
+++ b/models/demos/t3000/falcon40b/tests/test_falcon_causallm.py
@@ -44,7 +44,7 @@ class PytorchFalconCausalLM(torch.nn.Module):
 
 
 def run_test_FalconCausalLM_inference(
-    device_mesh,
+    mesh_device,
     model_version,
     llm_mode,
     batch,
@@ -99,17 +99,17 @@ def run_test_FalconCausalLM_inference(
                 tensor=tt_kv_cache_host,
                 dtype=model_config["KV_CACHE_DTYPE"],
                 layout=ttnn.TILE_LAYOUT,
-                device=device_mesh,
+                device=mesh_device,
                 memory_config=model_config["KV_CACHE_MEMCFG"],
-                mesh_mapper=ShardTensorToMesh(device_mesh, dim=1),
+                mesh_mapper=ShardTensorToMesh(mesh_device, dim=1),
             )
             tt_v_cache = ttnn.as_tensor(
                 tensor=tt_kv_cache_host,
                 dtype=model_config["KV_CACHE_DTYPE"],
                 layout=ttnn.TILE_LAYOUT,
-                device=device_mesh,
+                device=mesh_device,
                 memory_config=model_config["KV_CACHE_MEMCFG"],
-                mesh_mapper=ShardTensorToMesh(device_mesh, dim=1),
+                mesh_mapper=ShardTensorToMesh(mesh_device, dim=1),
             )
             tt_layer_past += ((tt_k_cache, tt_v_cache),)
 
@@ -139,17 +139,17 @@ def run_test_FalconCausalLM_inference(
                 tensor=tt_k_cache_host,
                 dtype=model_config["KV_CACHE_DTYPE"],
                 layout=ttnn.TILE_LAYOUT,
-                device=device_mesh,
+                device=mesh_device,
                 memory_config=model_config["KV_CACHE_MEMCFG"],
-                mesh_mapper=ShardTensorToMesh(device_mesh, dim=1),
+                mesh_mapper=ShardTensorToMesh(mesh_device, dim=1),
             )
             tt_v_cache = ttnn.as_tensor(
                 tensor=tt_v_cache_host,
                 dtype=model_config["KV_CACHE_DTYPE"],
                 layout=ttnn.TILE_LAYOUT,
-                device=device_mesh,
+                device=mesh_device,
                 memory_config=model_config["KV_CACHE_MEMCFG"],
-                mesh_mapper=ShardTensorToMesh(device_mesh, dim=1),
+                mesh_mapper=ShardTensorToMesh(mesh_device, dim=1),
             )
 
             tt_layer_past += ((tt_k_cache, tt_v_cache),)
@@ -166,7 +166,7 @@ def run_test_FalconCausalLM_inference(
     # since we don't yet have embedding support on device
     # device, state_dict, base_url, max_position_embeddings, config, num_decoders
     tt_FalconCausalLM = TtFalconCausalLM(
-        device_mesh,
+        mesh_device,
         state_dict,
         base_url,
         num_layers,
@@ -199,7 +199,7 @@ def run_test_FalconCausalLM_inference(
             )
 
             tt_out_tensor = ttnn.to_torch(
-                tt_out, device=device_mesh, mesh_composer=ConcatMeshToTensor(device_mesh, dim=-1)
+                tt_out, device=mesh_device, mesh_composer=ConcatMeshToTensor(mesh_device, dim=-1)
             )
             tt_outs.append(tt_out_tensor.squeeze(1))
 
@@ -217,7 +217,7 @@ def run_test_FalconCausalLM_inference(
             layer_past_len=kv_cache_len,
             use_cache=use_cache,
         )
-        tt_out = ttnn.to_torch(tt_out, device=device_mesh, mesh_composer=ConcatMeshToTensor(device_mesh, dim=-1))
+        tt_out = ttnn.to_torch(tt_out, device=mesh_device, mesh_composer=ConcatMeshToTensor(mesh_device, dim=-1))
         tt_out = tt_out.squeeze(0)
         tt_out = tt_out.transpose(0, 1)
 
@@ -229,10 +229,10 @@ def run_test_FalconCausalLM_inference(
         pytorch_layer_pres = pytorch_layer_present[i]
         tt_layer_pres = (
             ttnn.to_torch(
-                tt_layer_present[i][0], device=device_mesh, mesh_composer=ConcatMeshToTensor(device_mesh, dim=1)
+                tt_layer_present[i][0], device=mesh_device, mesh_composer=ConcatMeshToTensor(mesh_device, dim=1)
             ),
             ttnn.to_torch(
-                tt_layer_present[i][1], device=device_mesh, mesh_composer=ConcatMeshToTensor(device_mesh, dim=1)
+                tt_layer_present[i][1], device=mesh_device, mesh_composer=ConcatMeshToTensor(mesh_device, dim=1)
             ),
         )
         tt_layer_pres = (
@@ -331,7 +331,7 @@ def test_FalconCausalLM_inference(
     model_config_str,
     model_location_generator,
     get_tt_cache_path,
-    t3k_device_mesh,
+    t3k_mesh_device,
     use_program_cache,
 ):
     if llm_mode == "prefill" and (model_config_str not in ["BFLOAT8_B-DRAM", "BFLOAT16-DRAM"] or num_devices != 8):
@@ -341,7 +341,7 @@ def test_FalconCausalLM_inference(
 
     input_shape = [batch, seq_len]
     model_config = get_model_config(model_config_str, llm_mode, input_shape, num_devices)
-    devices = t3k_device_mesh.get_devices()
+    devices = t3k_mesh_device.get_devices()
     compute_grid_size = devices[0].compute_with_storage_grid_size()
     if compute_grid_size.x < model_config["MAX_GRID_SIZE"][0] or compute_grid_size.y < model_config["MAX_GRID_SIZE"][1]:
         pytest.skip(f"Requires grid size of at least {model_config['MAX_GRID_SIZE']} to run")
@@ -351,7 +351,7 @@ def test_FalconCausalLM_inference(
     )
 
     run_test_FalconCausalLM_inference(
-        t3k_device_mesh,
+        t3k_mesh_device,
         model_version,
         llm_mode,
         batch,

--- a/models/demos/t3000/falcon40b/tests/test_falcon_end_to_end.py
+++ b/models/demos/t3000/falcon40b/tests/test_falcon_end_to_end.py
@@ -33,7 +33,7 @@ from models.utility_functions import (
 
 # TODO: Replace this with actual Falcon application-level tests
 def run_test_FalconCausalLM_end_to_end(
-    device_mesh,
+    mesh_device,
     model_version,
     llm_mode,
     batch,
@@ -120,7 +120,7 @@ def run_test_FalconCausalLM_end_to_end(
     logger.info("Loading TT Falcon Model")
     profiler.start("TtFalcon_model_setup")
     tt_FalconCausalLM = TtFalconCausalLM(
-        device_mesh,
+        mesh_device,
         state_dict,
         base_url,
         num_layers,
@@ -130,7 +130,7 @@ def run_test_FalconCausalLM_end_to_end(
         tt_cache_path,
         use_global_cos_sin_cache,
     )
-    for device in device_mesh.get_devices():
+    for device in mesh_device.get_devices():
         ttnn.synchronize_device(device)
     profiler.end("TtFalcon_model_setup")
     logger.info("Done loading TT Falcon Model")
@@ -174,7 +174,7 @@ def run_test_FalconCausalLM_end_to_end(
             tt_outs.append(tt_out)
 
         tt_outs = [
-            ttnn.to_torch(tt_out, device=device_mesh, mesh_composer=ConcatMeshToTensor(device_mesh, dim=-1))
+            ttnn.to_torch(tt_out, device=mesh_device, mesh_composer=ConcatMeshToTensor(mesh_device, dim=-1))
             for tt_out in tt_outs
         ]
         tt_out = tt_outs
@@ -188,10 +188,10 @@ def run_test_FalconCausalLM_end_to_end(
             layer_past_len=kv_cache_len,
             use_cache=use_cache,
         )
-        tt_out = ttnn.to_torch(tt_out, device=device_mesh, mesh_composer=ConcatMeshToTensor(device_mesh, dim=-1))
+        tt_out = ttnn.to_torch(tt_out, device=mesh_device, mesh_composer=ConcatMeshToTensor(mesh_device, dim=-1))
 
     profiler.end("first_model_run_with_compile", force_enable=True)
-    for device in device_mesh.get_devices():
+    for device in mesh_device.get_devices():
         ttnn.synchronize_device(device)
 
     del tt_out
@@ -232,7 +232,7 @@ def run_test_FalconCausalLM_end_to_end(
                 tt_outs.append(tt_out)
 
             tt_outs = [
-                ttnn.to_torch(tt_out, device=device_mesh, mesh_composer=ConcatMeshToTensor(device_mesh, dim=-1))
+                ttnn.to_torch(tt_out, device=mesh_device, mesh_composer=ConcatMeshToTensor(mesh_device, dim=-1))
                 for tt_out in tt_outs
             ]
             tt_out = tt_outs
@@ -246,8 +246,8 @@ def run_test_FalconCausalLM_end_to_end(
                 layer_past_len=kv_cache_len,
                 use_cache=use_cache,
             )
-            tt_out = ttnn.to_torch(tt_out, device=device_mesh, mesh_composer=ConcatMeshToTensor(device_mesh, dim=-1))
-        for device in device_mesh.get_devices():
+            tt_out = ttnn.to_torch(tt_out, device=mesh_device, mesh_composer=ConcatMeshToTensor(mesh_device, dim=-1))
+        for device in mesh_device.get_devices():
             ttnn.synchronize_device(device)
 
         del tt_out
@@ -271,7 +271,7 @@ def run_test_FalconCausalLM_end_to_end(
         tt_inputs, tt_attention_mask = tt_FalconCausalLM.model_preprocessing(
             llm_mode, model_input, kv_cache_len, num_input_tokens=kv_len
         )
-    for device in device_mesh.get_devices():
+    for device in mesh_device.get_devices():
         ttnn.synchronize_device(device)
     profiler.start(f"model_run_for_inference")
 
@@ -299,17 +299,17 @@ def run_test_FalconCausalLM_end_to_end(
             use_cache=use_cache,
         )
     profiler.end(f"model_run_for_inference")
-    for device in device_mesh.get_devices():
+    for device in mesh_device.get_devices():
         ttnn.synchronize_device(device)
 
     if llm_mode == "prefill":
         tensors = [
-            ttnn.to_torch(tt_out, device=device_mesh, mesh_composer=ConcatMeshToTensor(device_mesh, dim=-1))
+            ttnn.to_torch(tt_out, device=mesh_device, mesh_composer=ConcatMeshToTensor(mesh_device, dim=-1))
             for tt_out in tt_outs
         ]
         tt_out = torch.vstack(tensors)
     elif llm_mode == "decode":
-        tt_out = ttnn.to_torch(tt_out, device=device_mesh, mesh_composer=ConcatMeshToTensor(device_mesh, dim=-1))
+        tt_out = ttnn.to_torch(tt_out, device=mesh_device, mesh_composer=ConcatMeshToTensor(mesh_device, dim=-1))
         tt_out = tt_out.squeeze(1).transpose(0, 1)
     # check outputs ----------------------------------------------------------------------
     does_pass, output_pcc = comp_pcc(pytorch_out, tt_out, out_pcc)
@@ -326,10 +326,10 @@ def run_test_FalconCausalLM_end_to_end(
         pytorch_layer_pres = pytorch_layer_present[i]
         tt_layer_pres = (
             ttnn.to_torch(
-                tt_layer_present[i][0], device=device_mesh, mesh_composer=ConcatMeshToTensor(device_mesh, dim=1)
+                tt_layer_present[i][0], device=mesh_device, mesh_composer=ConcatMeshToTensor(mesh_device, dim=1)
             ),
             ttnn.to_torch(
-                tt_layer_present[i][1], device=device_mesh, mesh_composer=ConcatMeshToTensor(device_mesh, dim=1)
+                tt_layer_present[i][1], device=mesh_device, mesh_composer=ConcatMeshToTensor(mesh_device, dim=1)
             ),
         )
         tt_layer_pres = (
@@ -462,7 +462,7 @@ def test_FalconCausalLM_end_to_end_with_program_cache(
     memcfg,
     model_location_generator,
     get_tt_cache_path,
-    t3k_device_mesh,
+    t3k_mesh_device,
     use_program_cache,
     async_mode,
 ):
@@ -524,7 +524,7 @@ def test_FalconCausalLM_end_to_end_with_program_cache(
 
     input_shape = [batch, seq_len]
     model_config = get_model_config(model_config_str, llm_mode, input_shape, num_devices)
-    devices = t3k_device_mesh.get_devices()
+    devices = t3k_mesh_device.get_devices()
     # Set async mode
     for device in devices:
         device.enable_async(async_mode)
@@ -540,7 +540,7 @@ def test_FalconCausalLM_end_to_end_with_program_cache(
     disable_compilation_reports()
 
     run_test_FalconCausalLM_end_to_end(
-        t3k_device_mesh,
+        t3k_mesh_device,
         model_version,
         llm_mode,
         batch,

--- a/models/demos/t3000/falcon40b/tests/test_falcon_model.py
+++ b/models/demos/t3000/falcon40b/tests/test_falcon_model.py
@@ -39,7 +39,7 @@ class PytorchFalconModel(torch.nn.Module):
 
 
 def run_test_FalconModel_inference(
-    device_mesh,
+    mesh_device,
     model_version,
     llm_mode,
     batch,
@@ -93,17 +93,17 @@ def run_test_FalconModel_inference(
                 tensor=tt_kv_cache_host,
                 dtype=model_config["KV_CACHE_DTYPE"],
                 layout=ttnn.TILE_LAYOUT,
-                device=device_mesh,
+                device=mesh_device,
                 memory_config=model_config["KV_CACHE_MEMCFG"],
-                mesh_mapper=ShardTensorToMesh(device_mesh, dim=1),
+                mesh_mapper=ShardTensorToMesh(mesh_device, dim=1),
             )
             tt_v_cache = ttnn.as_tensor(
                 tensor=tt_kv_cache_host,
                 dtype=model_config["KV_CACHE_DTYPE"],
                 layout=ttnn.TILE_LAYOUT,
-                device=device_mesh,
+                device=mesh_device,
                 memory_config=model_config["KV_CACHE_MEMCFG"],
-                mesh_mapper=ShardTensorToMesh(device_mesh, dim=1),
+                mesh_mapper=ShardTensorToMesh(mesh_device, dim=1),
             )
             tt_layer_past += ((tt_k_cache, tt_v_cache),)
 
@@ -134,17 +134,17 @@ def run_test_FalconModel_inference(
                 tensor=tt_k_cache_host,
                 dtype=model_config["KV_CACHE_DTYPE"],
                 layout=ttnn.TILE_LAYOUT,
-                device=device_mesh,
+                device=mesh_device,
                 memory_config=model_config["KV_CACHE_MEMCFG"],
-                mesh_mapper=ShardTensorToMesh(device_mesh, dim=1),
+                mesh_mapper=ShardTensorToMesh(mesh_device, dim=1),
             )
             tt_v_cache = ttnn.as_tensor(
                 tensor=tt_v_cache_host,
                 dtype=model_config["KV_CACHE_DTYPE"],
                 layout=ttnn.TILE_LAYOUT,
-                device=device_mesh,
+                device=mesh_device,
                 memory_config=model_config["KV_CACHE_MEMCFG"],
-                mesh_mapper=ShardTensorToMesh(device_mesh, dim=1),
+                mesh_mapper=ShardTensorToMesh(mesh_device, dim=1),
             )
 
             tt_layer_past += ((tt_k_cache, tt_v_cache),)
@@ -162,7 +162,7 @@ def run_test_FalconModel_inference(
     # since we don't yet have embedding support on device
     # device, state_dict, base_url, max_position_embeddings, config, num_decoders
     tt_FalconModel = TtFalconModel(
-        device_mesh,
+        mesh_device,
         state_dict,
         base_url,
         num_layers,
@@ -172,7 +172,7 @@ def run_test_FalconModel_inference(
         tt_cache_path,
         use_global_cos_sin_cache=use_global_cos_sin_cache,
     )
-    for device in device_mesh.get_devices():
+    for device in mesh_device.get_devices():
         ttnn.synchronize_device(device)
 
     # TODO: Generate embeddings and attention_mask on device
@@ -196,7 +196,7 @@ def run_test_FalconModel_inference(
                 use_cache=use_cache,
             )
             # output of model is replicated
-            tensors = ttnn.to_torch(tt_out, device=device_mesh, mesh_composer=ListMeshToTensor(device_mesh))
+            tensors = ttnn.to_torch(tt_out, device=mesh_device, mesh_composer=ListMeshToTensor(mesh_device))
             tt_outs.append(tensors[0].squeeze(1))
 
         tt_out = torch.vstack(tt_outs)
@@ -213,7 +213,7 @@ def run_test_FalconModel_inference(
             use_cache=use_cache,
         )
         # Output of model is replicated
-        tensors = ttnn.to_torch(tt_out, device=device_mesh, mesh_composer=ListMeshToTensor(device_mesh))
+        tensors = ttnn.to_torch(tt_out, device=mesh_device, mesh_composer=ListMeshToTensor(mesh_device))
         tt_out = tensors[0].squeeze(1).transpose(0, 1)
 
     # check outputs ----------------------------------------------------------------------
@@ -224,10 +224,10 @@ def run_test_FalconModel_inference(
         pytorch_layer_pres = pytorch_layer_present[i]
         tt_layer_pres = (
             ttnn.to_torch(
-                tt_layer_present[i][0], device=device_mesh, mesh_composer=ConcatMeshToTensor(device_mesh, dim=1)
+                tt_layer_present[i][0], device=mesh_device, mesh_composer=ConcatMeshToTensor(mesh_device, dim=1)
             ),
             ttnn.to_torch(
-                tt_layer_present[i][1], device=device_mesh, mesh_composer=ConcatMeshToTensor(device_mesh, dim=1)
+                tt_layer_present[i][1], device=mesh_device, mesh_composer=ConcatMeshToTensor(mesh_device, dim=1)
             ),
         )
         tt_layer_pres = (
@@ -326,7 +326,7 @@ def test_FalconModel_inference(
     model_config_str,
     model_location_generator,
     get_tt_cache_path,
-    t3k_device_mesh,
+    t3k_mesh_device,
     use_program_cache,
 ):
     if llm_mode == "prefill" and (model_config_str not in ["BFLOAT8_B-DRAM", "BFLOAT16-DRAM"] or num_devices != 8):
@@ -336,7 +336,7 @@ def test_FalconModel_inference(
 
     input_shape = [batch, seq_len]
     model_config = get_model_config(model_config_str, llm_mode, input_shape, num_devices)
-    devices = t3k_device_mesh.get_devices()
+    devices = t3k_mesh_device.get_devices()
     compute_grid_size = devices[0].compute_with_storage_grid_size()
     if compute_grid_size.x < model_config["MAX_GRID_SIZE"][0] or compute_grid_size.y < model_config["MAX_GRID_SIZE"][1]:
         pytest.skip(f"Requires grid size of at least {model_config['MAX_GRID_SIZE']} to run")
@@ -346,7 +346,7 @@ def test_FalconModel_inference(
     )
 
     run_test_FalconModel_inference(
-        t3k_device_mesh,
+        t3k_mesh_device,
         model_version,
         llm_mode,
         batch,

--- a/models/demos/t3000/falcon40b/tests/test_falcon_prefill_determinism.py
+++ b/models/demos/t3000/falcon40b/tests/test_falcon_prefill_determinism.py
@@ -18,7 +18,7 @@ from tests.tt_eager.python_api_testing.sweep_tests.comparison_funcs import (
 
 
 def run_test_falcon_prefill_end_to_end_determinism(
-    device_mesh,
+    mesh_device,
     model_version,
     generate_weights,
     batch,
@@ -66,17 +66,17 @@ def run_test_falcon_prefill_end_to_end_determinism(
             tensor=tt_k_cache_host,
             dtype=model_config["KV_CACHE_DTYPE"],
             layout=ttnn.TILE_LAYOUT,
-            device=device_mesh,
+            device=mesh_device,
             memory_config=model_config["KV_CACHE_MEMCFG"],
-            mesh_mapper=ShardTensorToMesh(device_mesh, dim=1),
+            mesh_mapper=ShardTensorToMesh(mesh_device, dim=1),
         )
         tt_v_cache = ttnn.as_tensor(
             tensor=tt_v_cache_host,
             dtype=model_config["KV_CACHE_DTYPE"],
             layout=ttnn.TILE_LAYOUT,
-            device=device_mesh,
+            device=mesh_device,
             memory_config=model_config["KV_CACHE_MEMCFG"],
-            mesh_mapper=ShardTensorToMesh(device_mesh, dim=1),
+            mesh_mapper=ShardTensorToMesh(mesh_device, dim=1),
         )
         tt_layer_past += ((tt_k_cache, tt_v_cache),)
 
@@ -84,7 +84,7 @@ def run_test_falcon_prefill_end_to_end_determinism(
     # NOTE: Passing in pytorch tensor here instead of tt tensor
     # since we don't yet have embedding support on device
     tt_FalconCausalLM = TtFalconCausalLM(
-        device_mesh,
+        mesh_device,
         state_dict,
         base_url,
         num_layers,
@@ -94,7 +94,7 @@ def run_test_falcon_prefill_end_to_end_determinism(
         tt_cache_path,
         use_global_cos_sin_cache,
     )
-    for device in device_mesh.get_devices():
+    for device in mesh_device.get_devices():
         ttnn.synchronize_device(device)
     logger.info("Done loading TT Falcon Model")
 
@@ -126,13 +126,13 @@ def run_test_falcon_prefill_end_to_end_determinism(
         tt_outs.append(tt_out)
 
     tt_outs = [
-        ttnn.to_torch(tt_out, device=device_mesh, mesh_composer=ConcatMeshToTensor(device_mesh, dim=-1))
+        ttnn.to_torch(tt_out, device=mesh_device, mesh_composer=ConcatMeshToTensor(mesh_device, dim=-1))
         for tt_out in tt_outs
     ]
 
     logger.info("Done running TT Falcon model")
 
-    for device in device_mesh.get_devices():
+    for device in mesh_device.get_devices():
         ttnn.synchronize_device(device)
 
     reference_out = torch.vstack(tt_outs)
@@ -140,10 +140,10 @@ def run_test_falcon_prefill_end_to_end_determinism(
     for i in range(num_layers):
         tt_layer_pres = (
             ttnn.to_torch(
-                tt_layer_present[i][0], device=device_mesh, mesh_composer=ConcatMeshToTensor(device_mesh, dim=1)
+                tt_layer_present[i][0], device=mesh_device, mesh_composer=ConcatMeshToTensor(mesh_device, dim=1)
             ),
             ttnn.to_torch(
-                tt_layer_present[i][1], device=device_mesh, mesh_composer=ConcatMeshToTensor(device_mesh, dim=1)
+                tt_layer_present[i][1], device=mesh_device, mesh_composer=ConcatMeshToTensor(mesh_device, dim=1)
             ),
         )
         reference_kv_cache.append(tt_layer_pres)
@@ -180,7 +180,7 @@ def run_test_falcon_prefill_end_to_end_determinism(
             tt_outs.append(tt_out)
 
         tt_outs = [
-            ttnn.to_torch(tt_out, device=device_mesh, mesh_composer=ConcatMeshToTensor(device_mesh, dim=-1))
+            ttnn.to_torch(tt_out, device=mesh_device, mesh_composer=ConcatMeshToTensor(mesh_device, dim=-1))
             for tt_out in tt_outs
         ]
         tt_out = tt_outs
@@ -196,10 +196,10 @@ def run_test_falcon_prefill_end_to_end_determinism(
             pytorch_layer_pres = reference_kv_cache[i]
             tt_layer_pres = (
                 ttnn.to_torch(
-                    tt_layer_present[i][0], device=device_mesh, mesh_composer=ConcatMeshToTensor(device_mesh, dim=1)
+                    tt_layer_present[i][0], device=mesh_device, mesh_composer=ConcatMeshToTensor(mesh_device, dim=1)
                 ),
                 ttnn.to_torch(
-                    tt_layer_present[i][1], device=device_mesh, mesh_composer=ConcatMeshToTensor(device_mesh, dim=1)
+                    tt_layer_present[i][1], device=mesh_device, mesh_composer=ConcatMeshToTensor(mesh_device, dim=1)
                 ),
             )
 
@@ -270,13 +270,13 @@ def test_falcon_prefill_end_to_end_determinism(
     model_config_str,
     model_location_generator,
     get_tt_cache_path,
-    t3k_device_mesh,
+    t3k_mesh_device,
 ):
     num_devices = 8
 
     input_shape = [batch, seq_len]
     model_config = get_model_config(model_config_str, "prefill", input_shape, num_devices)
-    devices = t3k_device_mesh.get_devices()
+    devices = t3k_mesh_device.get_devices()
     compute_grid_size = devices[0].compute_with_storage_grid_size()
     if compute_grid_size.x < model_config["MAX_GRID_SIZE"][0] or compute_grid_size.y < model_config["MAX_GRID_SIZE"][1]:
         pytest.skip(f"Requires grid size of at least {model_config['MAX_GRID_SIZE']} to run")
@@ -290,7 +290,7 @@ def test_falcon_prefill_end_to_end_determinism(
             device.enable_program_cache()
 
     run_test_falcon_prefill_end_to_end_determinism(
-        t3k_device_mesh,
+        t3k_mesh_device,
         model_version,
         generate_weights,
         batch,

--- a/models/demos/t3000/falcon40b/tests/test_perf_falcon.py
+++ b/models/demos/t3000/falcon40b/tests/test_perf_falcon.py
@@ -31,7 +31,7 @@ from models.perf.perf_utils import prep_perf_report
 
 # TODO: Replace this with actual Falcon application-level tests
 def run_test_FalconCausalLM_end_to_end(
-    device_mesh,
+    mesh_device,
     model_version,
     llm_mode,
     batch,
@@ -52,7 +52,7 @@ def run_test_FalconCausalLM_end_to_end(
 
     # Clear global profiler state before starting measurements
     profiler.clear()
-    devices = device_mesh.get_devices()
+    devices = mesh_device.get_devices()
     model_name = model_location_generator(model_version, model_subdir="Falcon")
 
     profiler.start("hugging_face_model_setup")
@@ -98,7 +98,7 @@ def run_test_FalconCausalLM_end_to_end(
     # device, state_dict, base_url, max_position_embeddings, config, num_decoders
     profiler.start("TtFalcon_model_setup")
     tt_FalconCausalLM = TtFalconCausalLM(
-        device_mesh,
+        mesh_device,
         state_dict,
         base_url,
         num_layers,
@@ -157,7 +157,7 @@ def run_test_FalconCausalLM_end_to_end(
             tt_outs.append(tt_out)
 
         tt_outs = [
-            ttnn.to_torch(tt_out, device=device_mesh, mesh_composer=ConcatMeshToTensor(device_mesh, dim=-1))
+            ttnn.to_torch(tt_out, device=mesh_device, mesh_composer=ConcatMeshToTensor(mesh_device, dim=-1))
             for tt_out in tt_outs
         ]
         tt_out = tt_outs
@@ -171,7 +171,7 @@ def run_test_FalconCausalLM_end_to_end(
             layer_past_len=kv_cache_len,
             use_cache=use_cache,
         )
-        tt_out = ttnn.to_torch(tt_out, device=device_mesh, mesh_composer=ConcatMeshToTensor(device_mesh, dim=-1))
+        tt_out = ttnn.to_torch(tt_out, device=mesh_device, mesh_composer=ConcatMeshToTensor(mesh_device, dim=-1))
 
     profiler.end("first_model_run_with_compile", force_enable=True)
     for device in devices:
@@ -213,7 +213,7 @@ def run_test_FalconCausalLM_end_to_end(
                 tt_outs.append(tt_out)
 
             tt_outs = [
-                ttnn.to_torch(tt_out, device=device_mesh, mesh_composer=ConcatMeshToTensor(device_mesh, dim=-1))
+                ttnn.to_torch(tt_out, device=mesh_device, mesh_composer=ConcatMeshToTensor(mesh_device, dim=-1))
                 for tt_out in tt_outs
             ]
         elif llm_mode == "decode":
@@ -228,7 +228,7 @@ def run_test_FalconCausalLM_end_to_end(
                 layer_past_len=kv_cache_len,
                 use_cache=use_cache,
             )
-            tt_outs = ttnn.to_torch(tt_out, device=device_mesh, mesh_composer=ConcatMeshToTensor(device_mesh, dim=-1))
+            tt_outs = ttnn.to_torch(tt_out, device=mesh_device, mesh_composer=ConcatMeshToTensor(mesh_device, dim=-1))
 
     profiler.end(f"model_warmup_run_for_inference")
     for device in devices:
@@ -370,7 +370,7 @@ def test_perf_bare_metal(
     model_config_str,
     model_location_generator,
     get_tt_cache_path,
-    t3k_device_mesh,
+    t3k_mesh_device,
     use_program_cache,
     is_ci_env,
     async_mode,
@@ -382,7 +382,7 @@ def test_perf_bare_metal(
 
     input_shape = [batch, seq_len]
     model_config = get_model_config(model_config_str, llm_mode, input_shape, num_devices)
-    devices = t3k_device_mesh.get_devices()
+    devices = t3k_mesh_device.get_devices()
     for device in devices:
         device.enable_async(async_mode)
     compute_grid_size = devices[0].compute_with_storage_grid_size()
@@ -397,7 +397,7 @@ def test_perf_bare_metal(
     disable_compilation_reports()
 
     run_test_FalconCausalLM_end_to_end(
-        t3k_device_mesh,
+        t3k_mesh_device,
         model_version,
         llm_mode,
         batch,
@@ -447,7 +447,7 @@ def test_device_perf_bare_metal(
     model_config_str,
     model_location_generator,
     get_tt_cache_path,
-    t3k_device_mesh,
+    t3k_mesh_device,
     use_program_cache,
     is_ci_env,
 ):
@@ -458,7 +458,7 @@ def test_device_perf_bare_metal(
 
     input_shape = [batch, seq_len]
     model_config = get_model_config(model_config_str, llm_mode, input_shape, num_devices)
-    devices = t3k_device_mesh.get_devices()
+    devices = t3k_mesh_device.get_devices()
     compute_grid_size = devices[0].compute_with_storage_grid_size()
     if compute_grid_size.x < model_config["MAX_GRID_SIZE"][0] or compute_grid_size.y < model_config["MAX_GRID_SIZE"][1]:
         pytest.skip(f"Requires grid size of at least {model_config['MAX_GRID_SIZE']} to run")
@@ -471,7 +471,7 @@ def test_device_perf_bare_metal(
     disable_compilation_reports()
 
     run_test_FalconCausalLM_end_to_end(
-        t3k_device_mesh,
+        t3k_mesh_device,
         model_version,
         llm_mode,
         batch,

--- a/models/demos/t3000/falcon40b/tests/test_perplexity_falcon.py
+++ b/models/demos/t3000/falcon40b/tests/test_perplexity_falcon.py
@@ -27,7 +27,7 @@ from models.utility_functions import is_wormhole_b0, tt_tensors_to_torch_tensors
 
 
 def calculate_perplexity(
-    model, dataloader, llm_mode, batch_size, seq_len, kv_cache, configuration, device_mesh, use_hf_model=False
+    model, dataloader, llm_mode, batch_size, seq_len, kv_cache, configuration, mesh_device, use_hf_model=False
 ):
     if llm_mode == "prefill" and not use_hf_model:
         assert batch_size == 1
@@ -55,7 +55,7 @@ def calculate_perplexity(
                     )
                     # Get outputs from all devices
                     logits = ttnn.to_torch(
-                        tt_logits, device=device_mesh, mesh_composer=ConcatMeshToTensor(device_mesh, dim=-1)
+                        tt_logits, device=mesh_device, mesh_composer=ConcatMeshToTensor(mesh_device, dim=-1)
                     )
                     # Deallocate tt tensors
                     tt_prefill_input_ids.deallocate()
@@ -86,7 +86,7 @@ def calculate_perplexity(
                         )
                         # Get outputs from all devices
                         logits_cur = ttnn.to_torch(
-                            tt_logits, device=device_mesh, mesh_composer=ConcatMeshToTensor(device_mesh, dim=-1)
+                            tt_logits, device=mesh_device, mesh_composer=ConcatMeshToTensor(mesh_device, dim=-1)
                         )
                         logits.append(logits_cur.view(-1, 1, configuration.vocab_size))
                         # Deallocate tt tensors
@@ -123,7 +123,7 @@ def run_test_perplexity(
     model_config_str,
     model_location_generator,
     get_tt_cache_path,
-    device_mesh,
+    mesh_device,
     num_samples,
     expected_acc_metrics,
     stride=None,
@@ -153,7 +153,7 @@ def run_test_perplexity(
         # Load tt-metal model config
         input_shape = [batch_size, max_seq_len]
         model_config = get_model_config(
-            model_config_str, llm_mode, input_shape, num_devices=len(device_mesh.get_devices())
+            model_config_str, llm_mode, input_shape, num_devices=len(mesh_device.get_devices())
         )
         tt_cache_path = get_tt_cache_path(
             model_version, model_subdir="Falcon", default_dir=model_config["DEFAULT_CACHE_PATH"]
@@ -162,7 +162,7 @@ def run_test_perplexity(
         # Load tt-metal model
         logger.info("Moving weights (all layers) to device; might take some time...")
         model = TtFalconCausalLM(
-            device_mesh,
+            mesh_device,
             state_dict,
             "",
             num_layers,
@@ -172,7 +172,7 @@ def run_test_perplexity(
             tt_cache_path,
             use_global_cos_sin_cache=True,
         )
-        for device in device_mesh.get_devices():
+        for device in mesh_device.get_devices():
             ttnn.synchronize_device(device)
 
         # Initialize kvcache
@@ -194,7 +194,7 @@ def run_test_perplexity(
         max_seq_len,
         kv_cache,
         configuration,
-        device_mesh,
+        mesh_device,
         use_hf_model=use_hf_model,
     )
     logger.info(f"Perplexity evaluation time: {(time.time() - start):.2f} s")
@@ -285,7 +285,7 @@ def test_perplexity(
     expected_top5,
     model_location_generator,
     get_tt_cache_path,
-    t3k_device_mesh,
+    t3k_mesh_device,
     use_program_cache,
 ):
     assert is_wormhole_b0(), "This test is only for Wormhole B0"
@@ -297,7 +297,7 @@ def test_perplexity(
         model_config_str,
         model_location_generator,
         get_tt_cache_path,
-        t3k_device_mesh,
+        t3k_mesh_device,
         num_samples,
         {"ppl": expected_ppl, "top1_acc": expected_top1, "top5_acc": expected_top5},
     )

--- a/models/demos/t3000/falcon40b/tt/falcon_causallm.py
+++ b/models/demos/t3000/falcon40b/tt/falcon_causallm.py
@@ -15,7 +15,7 @@ from models.demos.t3000.falcon40b.tt.model_utils import falcon_prefill_matmul, d
 class TtFalconCausalLM(TtFalconModelShared):
     def __init__(
         self,
-        device_mesh,
+        mesh_device,
         state_dict,
         base_url,
         num_layers,
@@ -28,7 +28,7 @@ class TtFalconCausalLM(TtFalconModelShared):
         assert base_url == "", "base_url should be empty at the root of the model!"
 
         super().__init__(
-            device_mesh=device_mesh,
+            mesh_device=mesh_device,
             state_dict=state_dict,
             base_url=f"transformer",
             num_layers=num_layers,
@@ -39,7 +39,7 @@ class TtFalconCausalLM(TtFalconModelShared):
             use_global_cos_sin_cache=use_global_cos_sin_cache,
         )
         self.model_config = model_config
-        self.device_mesh = device_mesh
+        self.mesh_device = mesh_device
         lm_head_str = f"lm_head.weight"
 
         lm_head_path = tt_cache_path / f"{lm_head_str}_{self.model_config['LM_HEAD_MM_WEIGHTS_DTYPE'].name}"
@@ -48,14 +48,14 @@ class TtFalconCausalLM(TtFalconModelShared):
             tensor=self.state_dict[f"lm_head.weight"],
             dtype=self.model_config["LM_HEAD_MM_WEIGHTS_DTYPE"],
             layout=ttnn.TILE_LAYOUT,
-            device=device_mesh,
+            device=mesh_device,
             memory_config=self.model_config["LM_HEAD_MM_WEIGHTS_MEMCFG"],
-            mesh_mapper=ShardTensorToMesh(device_mesh, dim=3),
+            mesh_mapper=ShardTensorToMesh(mesh_device, dim=3),
             cache_file_name=lm_head_path,
             preprocess=lambda x: torch.transpose(x.reshape(1, 1, *x.shape), -2, -1),
         )
         self.perf_e2e_test_tile_tensor = ttnn.from_torch(
-            torch.zeros((1, 1, 32, 32)), device=device_mesh.get_devices()[0]
+            torch.zeros((1, 1, 32, 32)), device=mesh_device.get_devices()[0]
         )
 
     def __call__(

--- a/models/demos/t3000/falcon40b/tt/falcon_decoder.py
+++ b/models/demos/t3000/falcon40b/tt/falcon_decoder.py
@@ -18,7 +18,7 @@ from models.demos.t3000.falcon40b.tt.model_utils import fused_partial_layernorm
 class TtFalconDecoderLayer:
     def __init__(
         self,
-        device_mesh,
+        mesh_device,
         state_dict,
         base_url,
         layer_num,
@@ -33,17 +33,17 @@ class TtFalconDecoderLayer:
         self.hidden_size = config.hidden_size
         self.state_dict = state_dict
         self.base_url = base_url
-        self.device_mesh = device_mesh
+        self.mesh_device = mesh_device
         self.layer_num = layer_num
         self.max_position_embeddings = max_position_embeddings
         self.model_config = model_config
-        self.num_devices = len(device_mesh.get_device_ids())
+        self.num_devices = len(mesh_device.get_device_ids())
         self.ln_output_tensors_dict = ln_output_tensors_dict
 
         assert config.parallel_attn, "Path for config.parallel_attn=False is not implemented in TtFalconDecoderLayer!"
 
         self.self_attn = TtFalconAttention(
-            device_mesh=device_mesh,
+            mesh_device=mesh_device,
             state_dict=state_dict,
             base_url=base_url,
             layer_num=layer_num,
@@ -55,7 +55,7 @@ class TtFalconDecoderLayer:
         )
 
         self.mlp = TtFalconMLP(
-            device_mesh=device_mesh,
+            mesh_device=mesh_device,
             state_dict=state_dict,
             base_url=base_url,
             layer_num=layer_num,
@@ -78,9 +78,9 @@ class TtFalconDecoderLayer:
             tensor=self.state_dict[ln_mlp_weights_str],
             dtype=self.model_config["LN_MLP_WEIGHTS_DTYPE"],
             layout=ttnn.TILE_LAYOUT,
-            device=self.device_mesh,
+            device=self.mesh_device,
             memory_config=self.model_config["LN_MLP_WEIGHTS_MEMCFG"],
-            mesh_mapper=ReplicateTensorToMesh(self.device_mesh),
+            mesh_mapper=ReplicateTensorToMesh(self.mesh_device),
             cache_file_name=ln_mlp_weights_path,
             preprocess=pad_ln_params,
         )
@@ -91,9 +91,9 @@ class TtFalconDecoderLayer:
             tensor=self.state_dict[ln_mlp_bias_str],
             dtype=self.model_config["LN_MLP_BIAS_DTYPE"],
             layout=ttnn.TILE_LAYOUT,
-            device=self.device_mesh,
+            device=self.mesh_device,
             memory_config=self.model_config["LN_MLP_BIAS_MEMCFG"],
-            mesh_mapper=ReplicateTensorToMesh(self.device_mesh),
+            mesh_mapper=ReplicateTensorToMesh(self.mesh_device),
             cache_file_name=ln_mlp_bias_path,
             preprocess=pad_ln_params,
         )
@@ -109,9 +109,9 @@ class TtFalconDecoderLayer:
             tensor=self.state_dict[ln_attn_weights_str],
             dtype=self.model_config["LN_ATTN_WEIGHTS_DTYPE"],
             layout=ttnn.TILE_LAYOUT,
-            device=self.device_mesh,
+            device=self.mesh_device,
             memory_config=self.model_config["LN_ATTN_WEIGHTS_MEMCFG"],
-            mesh_mapper=ReplicateTensorToMesh(self.device_mesh),
+            mesh_mapper=ReplicateTensorToMesh(self.mesh_device),
             cache_file_name=ln_attn_weights_path,
             preprocess=pad_ln_params,
         )
@@ -122,9 +122,9 @@ class TtFalconDecoderLayer:
             tensor=self.state_dict[ln_attn_bias_str],
             dtype=self.model_config["LN_ATTN_BIAS_DTYPE"],
             layout=ttnn.TILE_LAYOUT,
-            device=self.device_mesh,
+            device=self.mesh_device,
             memory_config=self.model_config["LN_ATTN_BIAS_MEMCFG"],
-            mesh_mapper=ReplicateTensorToMesh(self.device_mesh),
+            mesh_mapper=ReplicateTensorToMesh(self.mesh_device),
             cache_file_name=ln_attn_bias_path,
             preprocess=pad_ln_params,
         )

--- a/models/demos/t3000/falcon40b/tt/falcon_embeddings.py
+++ b/models/demos/t3000/falcon40b/tt/falcon_embeddings.py
@@ -8,13 +8,13 @@ from ttnn import ShardTensorToMesh
 
 
 class TtFalconEmbeddings(torch.nn.Module):
-    def __init__(self, device_mesh, state_dict, cache_path, model_config):
+    def __init__(self, mesh_device, state_dict, cache_path, model_config):
         super().__init__()
 
         self.state_dict = state_dict
-        self.device_mesh = device_mesh
+        self.mesh_device = mesh_device
         self.model_config = model_config
-        self.num_devices = device_mesh.get_num_devices()
+        self.num_devices = mesh_device.get_num_devices()
 
         base_name = "transformer.word_embeddings.weight"
 
@@ -22,10 +22,10 @@ class TtFalconEmbeddings(torch.nn.Module):
             tensor=self.state_dict[base_name],
             dtype=ttnn.bfloat16,
             layout=ttnn.ROW_MAJOR_LAYOUT,
-            device=self.device_mesh,
+            device=self.mesh_device,
             memory_config=ttnn.DRAM_MEMORY_CONFIG,
             cache_file_name=cache_path / base_name,
-            mesh_mapper=ShardTensorToMesh(device_mesh, dim=-1),
+            mesh_mapper=ShardTensorToMesh(mesh_device, dim=-1),
             preprocess=lambda x: x.reshape(1, 1, *x.shape),
         )
 

--- a/models/demos/t3000/falcon40b/tt/falcon_mlp.py
+++ b/models/demos/t3000/falcon40b/tt/falcon_mlp.py
@@ -14,7 +14,7 @@ from ttnn import ShardTensorToMesh, ReplicateTensorToMesh
 class TtFalconMLP:
     def __init__(
         self,
-        device_mesh,
+        mesh_device,
         state_dict,
         base_url,
         layer_num,
@@ -25,7 +25,7 @@ class TtFalconMLP:
         super().__init__()
 
         self.state_dict = state_dict
-        self.device_mesh = device_mesh
+        self.mesh_device = mesh_device
         self.hidden_size = hidden_size
         self.model_config = model_config
 
@@ -41,9 +41,9 @@ class TtFalconMLP:
             w1_weight,
             dtype=self.model_config["DENSE_H_TO_4H_MM_WEIGHTS_DTYPE"],
             layout=ttnn.TILE_LAYOUT,
-            device=self.device_mesh,
+            device=self.mesh_device,
             memory_config=self.model_config["DENSE_H_TO_4H_MM_WEIGHTS_MEMCFG"],
-            mesh_mapper=ShardTensorToMesh(self.device_mesh, dim=3),
+            mesh_mapper=ShardTensorToMesh(self.mesh_device, dim=3),
             cache_file_name=tt_cache_path / dense_h_to_4h_str,
             preprocess=lambda x: torch.transpose(x.reshape(1, 1, *x.shape), -2, -1),
         )
@@ -52,9 +52,9 @@ class TtFalconMLP:
             w2_weight,
             dtype=self.model_config["DENSE_4H_TO_H_MM_WEIGHTS_DTYPE"],
             layout=ttnn.TILE_LAYOUT,
-            device=self.device_mesh,
+            device=self.mesh_device,
             memory_config=self.model_config["DENSE_4H_TO_H_MM_WEIGHTS_MEMCFG"],
-            mesh_mapper=ShardTensorToMesh(self.device_mesh, dim=2),
+            mesh_mapper=ShardTensorToMesh(self.mesh_device, dim=2),
             cache_file_name=tt_cache_path / f"{dense_4h_to_h_str}_height_fractured",
             preprocess=lambda x: torch.transpose(x.reshape(1, 1, *x.shape), -2, -1),
         )
@@ -82,9 +82,9 @@ class TtFalconMLP:
                 out_tensor,
                 self.model_config["DENSE_4H_TO_H_MM_OUTPUT_DTYPE"],
                 layout=ttnn.TILE_LAYOUT,
-                device=self.device_mesh,
+                device=self.mesh_device,
                 memory_config=self.model_config["DEFAULT_MEMCFG"],
-                mesh_mapper=ReplicateTensorToMesh(self.device_mesh),
+                mesh_mapper=ReplicateTensorToMesh(self.mesh_device),
             )
 
     def __call__(self, x: List[ttnn.Tensor], llm_mode: str) -> List[ttnn.Tensor]:
@@ -119,7 +119,7 @@ class TtFalconMLP:
 
         hidden_states = ttnn.get_device_tensors(
             hidden_states
-        )  # Workaround for reduce_scatter only taking a vector of tensors and not device_mesh
+        )  # Workaround for reduce_scatter only taking a vector of tensors and not mesh_device
 
         hidden_states = ttnn.get_device_tensors(
             ttnn.reduce_scatter(
@@ -195,7 +195,7 @@ class TtFalconMLP:
 
         hidden_states = ttnn.get_device_tensors(
             self.output
-        )  # Workaround for reduce_scatter only taking a vector of tensors and not device_mesh
+        )  # Workaround for reduce_scatter only taking a vector of tensors and not mesh_device
 
         hidden_states = ttnn.get_device_tensors(
             ttnn.reduce_scatter(

--- a/models/demos/t3000/falcon40b/tt/falcon_model.py
+++ b/models/demos/t3000/falcon40b/tt/falcon_model.py
@@ -25,7 +25,7 @@ class TtFalconModelShared:
     @abstractmethod
     def __init__(
         self,
-        device_mesh,
+        mesh_device,
         state_dict,
         base_url,
         num_layers,
@@ -39,7 +39,7 @@ class TtFalconModelShared:
 
         # NOTE: Once we make embeddings run on device, pass in state dict
         # instead of model itself
-        self.device_mesh = device_mesh
+        self.mesh_device = mesh_device
         self.state_dict = state_dict
         self.base_url = base_url
         self.config = config
@@ -47,7 +47,7 @@ class TtFalconModelShared:
         self.model_config = model_config
         self.num_layers = num_layers
         self.hidden_size = config.hidden_size
-        self.num_devices = device_mesh.get_num_devices()
+        self.num_devices = mesh_device.get_num_devices()
         self.ln_output_tensors_dict = {
             "final_layernorm": dict(),
             "mlp_layernorm": dict(),
@@ -56,7 +56,7 @@ class TtFalconModelShared:
 
         # Word Embeddings
         self.embeddings = TtFalconEmbeddings(
-            device_mesh=device_mesh,
+            mesh_device=mesh_device,
             state_dict=state_dict,
             cache_path=tt_cache_path,
             model_config=model_config,
@@ -64,7 +64,7 @@ class TtFalconModelShared:
 
         if use_global_cos_sin_cache:
             global_cos_sin_cache = generate_cos_sin_cache(
-                device_mesh,
+                mesh_device,
                 config.hidden_size // config.num_attention_heads,
                 base_url,
                 max_position_embeddings,
@@ -77,7 +77,7 @@ class TtFalconModelShared:
         # stack all decoders
         self.layers = [
             TtFalconDecoderLayer(
-                device_mesh=device_mesh,
+                mesh_device=mesh_device,
                 state_dict=state_dict,
                 base_url=f"{base_url}.h",
                 layer_num=layer_num,
@@ -105,9 +105,9 @@ class TtFalconModelShared:
             tensor=self.state_dict[layernorm_weights_str],
             dtype=self.model_config["LN_F_WEIGHTS_DTYPE"],
             layout=ttnn.ROW_MAJOR_LAYOUT,
-            device=device_mesh,
+            device=mesh_device,
             memory_config=self.model_config["LN_F_WEIGHTS_MEMCFG"],
-            mesh_mapper=ReplicateTensorToMesh(device_mesh),
+            mesh_mapper=ReplicateTensorToMesh(mesh_device),
             cache_file_name=layernorm_weights_path,
             preprocess=lambda x: x.reshape(1, 1, -1, 32),
         )
@@ -116,9 +116,9 @@ class TtFalconModelShared:
             tensor=self.state_dict[layernorm_bias_str],
             dtype=self.model_config["LN_F_BIAS_DTYPE"],
             layout=ttnn.ROW_MAJOR_LAYOUT,
-            device=device_mesh,
+            device=mesh_device,
             memory_config=self.model_config["LN_F_BIAS_MEMCFG"],
-            mesh_mapper=ReplicateTensorToMesh(device_mesh),
+            mesh_mapper=ReplicateTensorToMesh(mesh_device),
             cache_file_name=layernorm_bias_path,
             preprocess=lambda x: x.reshape(1, 1, -1, 32),
         )
@@ -136,9 +136,9 @@ class TtFalconModelShared:
             tensor=attn_mask_bool,
             dtype=self.model_config["BFLOAT16_DTYPE"],
             layout=ttnn.ROW_MAJOR_LAYOUT,
-            device=self.device_mesh,
+            device=self.mesh_device,
             memory_config=attention_mask_memconfig,
-            mesh_mapper=ReplicateTensorToMesh(self.device_mesh),
+            mesh_mapper=ReplicateTensorToMesh(self.mesh_device),
             preprocess=lambda x: (x * -1e5),
         )
 
@@ -179,9 +179,9 @@ class TtFalconModelShared:
             tensor=input_ids,
             dtype=ttnn.uint32,
             layout=ttnn.ROW_MAJOR_LAYOUT,
-            device=self.device_mesh,
+            device=self.mesh_device,
             memory_config=ttnn.DRAM_MEMORY_CONFIG,
-            mesh_mapper=ReplicateTensorToMesh(self.device_mesh),
+            mesh_mapper=ReplicateTensorToMesh(self.mesh_device),
         )
 
         # Generate input and attention_mask ---------------------------------------------
@@ -202,7 +202,7 @@ class TtFalconModelShared:
                     sequence_size,
                     self.model_config["layernorm_params"]["slice_size"],
                     self.ln_output_tensors_dict,
-                    self.device_mesh,
+                    self.mesh_device,
                     self.hidden_size,
                     self.model_config["LN_MLP_OUTPUT_DTYPE"],
                 )
@@ -228,9 +228,9 @@ class TtFalconModelShared:
                 tensor=attention_mask_bool_padded,
                 dtype=self.model_config["BFLOAT16_DTYPE"],  # subsequent tilize op expects bfloat16 inputs
                 layout=ttnn.ROW_MAJOR_LAYOUT,
-                device=self.device_mesh,
+                device=self.mesh_device,
                 memory_config=self.model_config["DEFAULT_MEMCFG"],
-                mesh_mapper=ReplicateTensorToMesh(self.device_mesh),
+                mesh_mapper=ReplicateTensorToMesh(self.mesh_device),
                 preprocess=lambda x: (x.transpose(0, 2) * -1e5).expand(1, 1, -1, -1),
             )
 
@@ -396,7 +396,7 @@ class TtFalconModelShared:
 class TtFalconModel(TtFalconModelShared):
     def __init__(
         self,
-        device_mesh,
+        mesh_device,
         state_dict,
         base_url,
         num_layers,
@@ -407,7 +407,7 @@ class TtFalconModel(TtFalconModelShared):
         use_global_cos_sin_cache,
     ):
         super().__init__(
-            device_mesh=device_mesh,
+            mesh_device=mesh_device,
             state_dict=state_dict,
             base_url=base_url,
             num_layers=num_layers,

--- a/models/demos/t3000/falcon40b/tt/model_utils.py
+++ b/models/demos/t3000/falcon40b/tt/model_utils.py
@@ -389,7 +389,7 @@ def determine_tensor_deallocation(layernorm_slice_size, seq_len):
     return seq_len <= layernorm_slice_size
 
 
-def generate_layernorm_persistent_tensors(seq_len, slice_size, ln_output_tensors_dict, device_mesh, hidden_size, dtype):
+def generate_layernorm_persistent_tensors(seq_len, slice_size, ln_output_tensors_dict, mesh_device, hidden_size, dtype):
     if seq_len <= slice_size:
         return
 
@@ -399,9 +399,9 @@ def generate_layernorm_persistent_tensors(seq_len, slice_size, ln_output_tensors
             tensor=tensor,
             dtype=dtype,
             layout=ttnn.TILE_LAYOUT,
-            device=device_mesh,
+            device=mesh_device,
             memory_config=ttnn.DRAM_MEMORY_CONFIG,
-            mesh_mapper=ttnn.ReplicateTensorToMesh(device_mesh),
+            mesh_mapper=ttnn.ReplicateTensorToMesh(mesh_device),
         )
         if name in ln_output_tensors_dict and ln_output_tensors_dict[name] is not None:
             ln_output_tensors_dict[name].update({seq_len: output_tensor})

--- a/models/demos/t3000/falcon7b/demo_t3000.py
+++ b/models/demos/t3000/falcon7b/demo_t3000.py
@@ -33,7 +33,7 @@ from models.utility_functions import is_wormhole_b0
     ],
 )
 @pytest.mark.parametrize("enable_async_mode", (True,), indirect=True)  # Option to run Falcon in Async mode
-@pytest.mark.parametrize("device_mesh", (1, 2, 3, 4, 5, 6, 7, 8), indirect=True)
+@pytest.mark.parametrize("mesh_device", (1, 2, 3, 4, 5, 6, 7, 8), indirect=True)
 def test_demo_multichip(
     perf_mode,  # Option to measure perf using max seq length (with invalid outputs) and expected perf (t/s)
     max_seq_len,
@@ -43,12 +43,12 @@ def test_demo_multichip(
     user_input,
     model_location_generator,
     get_tt_cache_path,
-    device_mesh,
+    mesh_device,
     use_program_cache,
     enable_async_mode,
     is_ci_env,
 ):
-    num_devices = device_mesh.get_num_devices()
+    num_devices = mesh_device.get_num_devices()
     if is_ci_env:
         if num_devices != 8 or (not expected_greedy_output_path and not expected_perf_metrics):
             pytest.skip("Skipping test in CI since it provides redundant testing")
@@ -74,7 +74,7 @@ def test_demo_multichip(
         model_config_strs_prefill_decode=["BFLOAT16-DRAM", "BFLOAT16-L1_SHARDED"],
         model_location_generator=model_location_generator,
         get_tt_cache_path=get_tt_cache_path,
-        device_mesh=device_mesh,
+        mesh_device=mesh_device,
         perf_mode=perf_mode,
         greedy_sampling=greedy_sampling,
         expected_perf_metrics=expected_perf_metrics,

--- a/models/demos/t3000/llama2_70b/demo/demo.py
+++ b/models/demos/t3000/llama2_70b/demo/demo.py
@@ -19,7 +19,7 @@ from models.demos.t3000.llama2_70b.tt.llama_common import load_llama_state_dict
 from models.demos.t3000.llama2_70b.reference.llama.llama.tokenizer3 import ChatFormat
 from models.demos.t3000.llama2_70b.tt.llama_common import (
     setup_llama_env,
-    check_device_mesh,
+    check_mesh_device,
     string_similarity_score,
 )
 
@@ -39,7 +39,7 @@ class ModelArgs:
 
 @dataclass
 class TTArgs:
-    device_mesh: object = None
+    mesh_device: object = None
     n_devices: int = 8
     emulated: bool = False
     cache_path: str = None
@@ -406,7 +406,7 @@ def test_LlamaModel_demo(
     temperature,
     chat,
     # TT args
-    t3k_device_mesh,
+    t3k_mesh_device,
     n_devices,
     decode_only,
     llama_version,
@@ -422,10 +422,10 @@ def test_LlamaModel_demo(
         llama_version=llama_version,
     )
 
-    check_device_mesh(t3k_device_mesh, model_config)
+    check_mesh_device(t3k_mesh_device, model_config)
 
-    for i in t3k_device_mesh.get_device_ids():
-        device = t3k_device_mesh.get_device(i)
+    for i in t3k_mesh_device.get_device_ids():
+        device = t3k_mesh_device.get_device(i)
         device.enable_async(True)
 
     args = construct_arg(
@@ -444,7 +444,7 @@ def test_LlamaModel_demo(
         top_k=top_k,
         temperature=temperature,
         chat=chat,
-        device_mesh=t3k_device_mesh,
+        mesh_device=t3k_mesh_device,
         n_devices=n_devices,
         cache_path=cache_path,
         decode_only=decode_only,

--- a/models/demos/t3000/llama2_70b/demo/eval.py
+++ b/models/demos/t3000/llama2_70b/demo/eval.py
@@ -24,7 +24,7 @@ from models.demos.t3000.llama2_70b.demo.demo import (
 from datetime import datetime
 from models.demos.t3000.llama2_70b.tt.llama_common import (
     setup_llama_env,
-    check_device_mesh,
+    check_mesh_device,
 )
 
 
@@ -351,7 +351,7 @@ def test_LlamaModel_demo(
     top_k,
     temperature,
     # TT args
-    t3k_device_mesh,
+    t3k_mesh_device,
     n_devices,
     # Dataset args
     dataset,
@@ -370,10 +370,10 @@ def test_LlamaModel_demo(
         llama_version=llama_version,
     )
 
-    check_device_mesh(t3k_device_mesh, model_config)
+    check_mesh_device(t3k_mesh_device, model_config)
 
-    for i in t3k_device_mesh.get_device_ids():
-        device = t3k_device_mesh.get_device(i)
+    for i in t3k_mesh_device.get_device_ids():
+        device = t3k_mesh_device.get_device(i)
         device.enable_async(True)
 
     args = construct_arg(
@@ -388,7 +388,7 @@ def test_LlamaModel_demo(
         top_k=top_k,
         temperature=temperature,
         chat=False,
-        device_mesh=t3k_device_mesh,
+        mesh_device=t3k_mesh_device,
         n_devices=n_devices,
         cache_path=cache_path,
         decode_only=False,

--- a/models/demos/t3000/llama2_70b/demo/eval_t3000.py
+++ b/models/demos/t3000/llama2_70b/demo/eval_t3000.py
@@ -20,7 +20,7 @@ from models.demos.t3000.llama2_70b.demo.demo import (
 from datetime import datetime
 from models.demos.t3000.llama2_70b.tt.llama_common import (
     setup_llama_env,
-    check_device_mesh,
+    check_mesh_device,
 )
 from models.demos.t3000.llama2_70b.demo.eval import (
     wikitext_detokenizer,
@@ -165,7 +165,7 @@ def test_LlamaModel_demo(
     top_k,
     temperature,
     # TT args
-    t3k_device_mesh,
+    t3k_mesh_device,
     n_devices,
     # Dataset args
     dataset,
@@ -184,10 +184,10 @@ def test_LlamaModel_demo(
         llama_version=llama_version,
     )
 
-    check_device_mesh(t3k_device_mesh, model_config)
+    check_mesh_device(t3k_mesh_device, model_config)
 
-    for i in t3k_device_mesh.get_device_ids():
-        device = t3k_device_mesh.get_device(i)
+    for i in t3k_mesh_device.get_device_ids():
+        device = t3k_mesh_device.get_device(i)
         device.enable_async(True)
 
     args = construct_arg(
@@ -202,7 +202,7 @@ def test_LlamaModel_demo(
         top_k=top_k,
         temperature=temperature,
         chat=False,
-        device_mesh=t3k_device_mesh,
+        mesh_device=t3k_mesh_device,
         n_devices=n_devices,
         cache_path=cache_path,
         decode_only=False,

--- a/models/demos/t3000/llama2_70b/tests/test_llama_attention.py
+++ b/models/demos/t3000/llama2_70b/tests/test_llama_attention.py
@@ -15,7 +15,7 @@ from models.demos.t3000.llama2_70b.reference.llama.llama.model import precompute
 from models.utility_functions import skip_for_grayskull
 from models.demos.t3000.llama2_70b.tt.llama_common import (
     setup_llama_env,
-    check_device_mesh,
+    check_mesh_device,
     extract_pcc_from_log,
     generate_rot_emb,
     get_rotation_mat,
@@ -117,10 +117,10 @@ def tt_llama_attention_prepare_inputs(llama_attention_model, x, start_pos):
             dtype=ttnn.bfloat16,
             layout=ttnn.TILE_LAYOUT,
             memory_config=llama_attention_model.model_config["DRAM_MEMCFG"],
-            mesh_mapper=ReplicateTensorToMesh(llama_attention_model.device_mesh),
-            device=llama_attention_model.device_mesh,
+            mesh_mapper=ReplicateTensorToMesh(llama_attention_model.mesh_device),
+            device=llama_attention_model.mesh_device,
         )
-        xs = ttnn.to_device(xs, llama_attention_model.device_mesh)
+        xs = ttnn.to_device(xs, llama_attention_model.mesh_device)
 
         cos, sin = precompute_freqs(llama_attention_model.head_dim, llama_attention_model.max_seq_len * 2)
         cos_gathered, sin_gathered = gather_cos_sin(torch.arange(start_pos, start_pos + seq_len), cos, sin)
@@ -133,8 +133,8 @@ def tt_llama_attention_prepare_inputs(llama_attention_model, x, start_pos):
             layout=ttnn.TILE_LAYOUT,
             cache_file_name=cache_name(f"cos_gathered_prefill_{seq_len}"),
             memory_config=llama_attention_model.model_config["DRAM_MEMCFG"],
-            device=llama_attention_model.device_mesh,
-            mesh_mapper=ReplicateTensorToMesh(llama_attention_model.device_mesh),
+            device=llama_attention_model.mesh_device,
+            mesh_mapper=ReplicateTensorToMesh(llama_attention_model.mesh_device),
         )
         sin_gathereds = ttnn.as_tensor(
             sin_gathered,
@@ -142,12 +142,12 @@ def tt_llama_attention_prepare_inputs(llama_attention_model, x, start_pos):
             layout=ttnn.TILE_LAYOUT,
             cache_file_name=cache_name(f"sin_gathered_prefill_{seq_len}"),
             memory_config=llama_attention_model.model_config["DRAM_MEMCFG"],
-            device=llama_attention_model.device_mesh,
-            mesh_mapper=ReplicateTensorToMesh(llama_attention_model.device_mesh),
+            device=llama_attention_model.mesh_device,
+            mesh_mapper=ReplicateTensorToMesh(llama_attention_model.mesh_device),
         )
 
-        cos_gathereds = ttnn.to_device(cos_gathereds, llama_attention_model.device_mesh)
-        sin_gathereds = ttnn.to_device(sin_gathereds, llama_attention_model.device_mesh)
+        cos_gathereds = ttnn.to_device(cos_gathereds, llama_attention_model.mesh_device)
+        sin_gathereds = ttnn.to_device(sin_gathereds, llama_attention_model.mesh_device)
         rot_mats = [cos_gathereds, sin_gathereds]
 
         attn_mask = torch.full((seq_len, seq_len), torch.finfo(torch.float32).min)
@@ -158,11 +158,11 @@ def tt_llama_attention_prepare_inputs(llama_attention_model, x, start_pos):
             dtype=ttnn.bfloat16,
             layout=ttnn.TILE_LAYOUT,
             cache_file_name=cache_name(f"attn_mask_prefill_{seq_len}"),
-            mesh_mapper=ReplicateTensorToMesh(llama_attention_model.device_mesh),
+            mesh_mapper=ReplicateTensorToMesh(llama_attention_model.mesh_device),
             memory_config=llama_attention_model.model_config["DRAM_MEMCFG"],
-            device=llama_attention_model.device_mesh,
+            device=llama_attention_model.mesh_device,
         )
-        attn_masks = ttnn.to_device(attn_masks, llama_attention_model.device_mesh)
+        attn_masks = ttnn.to_device(attn_masks, llama_attention_model.mesh_device)
 
     elif llama_attention_model.model_config["LLM_MODE"] == "decode":
         assert seq_len == 1, "Only supporting decode mode"
@@ -178,10 +178,10 @@ def tt_llama_attention_prepare_inputs(llama_attention_model, x, start_pos):
             dtype=ttnn.bfloat16,
             layout=ttnn.TILE_LAYOUT,
             memory_config=llama_attention_model.model_config["DRAM_MEMCFG"],
-            mesh_mapper=ReplicateTensorToMesh(llama_attention_model.device_mesh),
-            device=llama_attention_model.device_mesh,
+            mesh_mapper=ReplicateTensorToMesh(llama_attention_model.mesh_device),
+            device=llama_attention_model.mesh_device,
         )
-        xs = ttnn.to_device(xs, llama_attention_model.device_mesh)
+        xs = ttnn.to_device(xs, llama_attention_model.mesh_device)
         xs = ttnn.interleaved_to_sharded(xs, llama_attention_model.model_config["LN_ATTN_OUTPUT_MEMCFG"])
 
         rot_emb = generate_rot_emb(llama_attention_model.head_dim, llama_attention_model.max_seq_len * 2)
@@ -193,10 +193,10 @@ def tt_llama_attention_prepare_inputs(llama_attention_model, x, start_pos):
             dtype=ttnn.bfloat16,
             layout=ttnn.TILE_LAYOUT,
             memory_config=llama_attention_model.model_config["DRAM_MEMCFG"],
-            mesh_mapper=ReplicateTensorToMesh(llama_attention_model.device_mesh),
-            device=llama_attention_model.device_mesh,
+            mesh_mapper=ReplicateTensorToMesh(llama_attention_model.mesh_device),
+            device=llama_attention_model.mesh_device,
         )
-        rot_mats = ttnn.to_device(rot_mats, llama_attention_model.device_mesh)
+        rot_mats = ttnn.to_device(rot_mats, llama_attention_model.mesh_device)
 
         rot_mats = ttnn.interleaved_to_sharded(rot_mats, llama_attention_model.model_config["ROT_MAT_MM_IN1_MEMCFG"])
 
@@ -211,7 +211,7 @@ def tt_llama_attention_prepare_inputs(llama_attention_model, x, start_pos):
 
 
 def run_test_LlamaAttention_inference(
-    t3k_device_mesh,
+    t3k_mesh_device,
     batch,
     seq_len,
     pcc,
@@ -248,14 +248,14 @@ def run_test_LlamaAttention_inference(
         transformation_mat_torch,
         dtype=ttnn.bfloat16,
         layout=ttnn.TILE_LAYOUT,
-        device=t3k_device_mesh,
+        device=t3k_mesh_device,
         memory_config=model_config["DRAM_MEMCFG"],
-        mesh_mapper=ReplicateTensorToMesh(t3k_device_mesh),
+        mesh_mapper=ReplicateTensorToMesh(t3k_mesh_device),
     )
-    transformation_mats = ttnn.to_device(transformation_mats, t3k_device_mesh)
+    transformation_mats = ttnn.to_device(transformation_mats, t3k_mesh_device)
 
     tt_LlamaAttention_model = TtLlamaAttention_optimized(
-        t3k_device_mesh,
+        t3k_mesh_device,
         state_dict,
         BASE_URL,
         UNIT_TEST_LAYER_NUM,
@@ -310,7 +310,7 @@ def run_test_LlamaAttention_inference(
         )
 
         tt_out = ttnn.from_device(tt_out)
-        tt_out = ttnn.to_torch(tt_out, mesh_composer=ConcatMeshToTensor(t3k_device_mesh, dim=3))
+        tt_out = ttnn.to_torch(tt_out, mesh_composer=ConcatMeshToTensor(t3k_mesh_device, dim=3))
         tt_out = tt_out.permute(2, 1, 0, 3).squeeze(1)  # [batch, seq_len, hidden_dim]
         if model_config["LLM_MODE"] == "decode":
             tt_out = tt_out[:batch]
@@ -345,7 +345,7 @@ def run_test_LlamaAttention_inference(
     # concat the pasts by heads
     tt_layer_present_all = [ttnn.from_device(lp) for lp in tt_LlamaAttention_model.layer_past]
     tt_layer_present_all = [
-        ttnn.to_torch(lp, mesh_composer=ConcatMeshToTensor(t3k_device_mesh, dim=0)).transpose(0, 1)[:batch, ...]
+        ttnn.to_torch(lp, mesh_composer=ConcatMeshToTensor(t3k_mesh_device, dim=0)).transpose(0, 1)[:batch, ...]
         for lp in tt_layer_present_all
     ]
 
@@ -396,7 +396,7 @@ def test_LlamaAttention_inference(
     batch,
     seq_len,
     pcc,
-    t3k_device_mesh,
+    t3k_mesh_device,
     max_batch_size,
     max_context_len,
     llama_version,
@@ -419,9 +419,9 @@ def test_LlamaAttention_inference(
         max_context_len=max_context_len,
     )
 
-    check_device_mesh(t3k_device_mesh, model_config)
+    check_mesh_device(t3k_mesh_device, model_config)
     run_test_LlamaAttention_inference(
-        t3k_device_mesh,
+        t3k_mesh_device,
         batch,
         seq_len,
         pcc,

--- a/models/demos/t3000/llama2_70b/tests/test_llama_attention_t3000.py
+++ b/models/demos/t3000/llama2_70b/tests/test_llama_attention_t3000.py
@@ -5,7 +5,7 @@
 import pytest
 
 from models.utility_functions import skip_for_grayskull, skip_for_wormhole_b0
-from models.demos.t3000.llama2_70b.tt.llama_common import setup_llama_env, check_device_mesh
+from models.demos.t3000.llama2_70b.tt.llama_common import setup_llama_env, check_mesh_device
 from models.demos.t3000.llama2_70b.tests.test_llama_attention import run_test_LlamaAttention_inference
 
 
@@ -34,7 +34,7 @@ def test_LlamaAttention_inference_t3000(
     batch,
     seq_len,
     pcc,
-    t3k_device_mesh,
+    t3k_mesh_device,
     max_batch_size,
     max_context_len,
     llama_version,
@@ -57,9 +57,9 @@ def test_LlamaAttention_inference_t3000(
         max_context_len=max_context_len,
     )
 
-    check_device_mesh(t3k_device_mesh, model_config)
+    check_mesh_device(t3k_mesh_device, model_config)
     run_test_LlamaAttention_inference(
-        t3k_device_mesh,
+        t3k_mesh_device,
         batch,
         seq_len,
         pcc,

--- a/models/demos/t3000/llama2_70b/tests/test_llama_decoder.py
+++ b/models/demos/t3000/llama2_70b/tests/test_llama_decoder.py
@@ -14,7 +14,7 @@ from models.demos.t3000.llama2_70b.reference.llama.llama.model import precompute
 from models.utility_functions import skip_for_grayskull
 from models.demos.t3000.llama2_70b.tt.llama_common import (
     setup_llama_env,
-    check_device_mesh,
+    check_mesh_device,
     extract_pcc_from_log,
     generate_rot_emb,
     get_rotation_mat,
@@ -117,10 +117,10 @@ def tt_llama_decoder_prepare_inputs(llama_decoder_model, x, start_pos):
             dtype=ttnn.bfloat16,
             layout=ttnn.TILE_LAYOUT,
             memory_config=llama_decoder_model.model_config["DRAM_MEMCFG"],
-            mesh_mapper=ttnn.ShardTensorToMesh(llama_decoder_model.device_mesh, dim=3),
-            device=llama_decoder_model.device_mesh,
+            mesh_mapper=ttnn.ShardTensorToMesh(llama_decoder_model.mesh_device, dim=3),
+            device=llama_decoder_model.mesh_device,
         )
-        xs = ttnn.to_device(xs, llama_decoder_model.device_mesh)
+        xs = ttnn.to_device(xs, llama_decoder_model.mesh_device)
 
         cos, sin = precompute_freqs(
             llama_decoder_model.head_dim, llama_decoder_model.max_seq_len * 2, llama_decoder_model.rope_theta
@@ -135,8 +135,8 @@ def tt_llama_decoder_prepare_inputs(llama_decoder_model, x, start_pos):
             layout=ttnn.TILE_LAYOUT,
             cache_file_name=cache_name(f"cos_gathered_prefill_{seq_len}"),
             memory_config=llama_decoder_model.model_config["DRAM_MEMCFG"],
-            device=llama_decoder_model.device_mesh,
-            mesh_mapper=ReplicateTensorToMesh(llama_decoder_model.device_mesh),
+            device=llama_decoder_model.mesh_device,
+            mesh_mapper=ReplicateTensorToMesh(llama_decoder_model.mesh_device),
         )
         sin_gathereds = ttnn.as_tensor(
             sin_gathered,
@@ -144,11 +144,11 @@ def tt_llama_decoder_prepare_inputs(llama_decoder_model, x, start_pos):
             layout=ttnn.TILE_LAYOUT,
             cache_file_name=cache_name(f"sin_gathered_prefill_{seq_len}"),
             memory_config=llama_decoder_model.model_config["DRAM_MEMCFG"],
-            device=llama_decoder_model.device_mesh,
-            mesh_mapper=ReplicateTensorToMesh(llama_decoder_model.device_mesh),
+            device=llama_decoder_model.mesh_device,
+            mesh_mapper=ReplicateTensorToMesh(llama_decoder_model.mesh_device),
         )
-        cos_gathereds = ttnn.to_device(cos_gathereds, llama_decoder_model.device_mesh)
-        sin_gathereds = ttnn.to_device(sin_gathereds, llama_decoder_model.device_mesh)
+        cos_gathereds = ttnn.to_device(cos_gathereds, llama_decoder_model.mesh_device)
+        sin_gathereds = ttnn.to_device(sin_gathereds, llama_decoder_model.mesh_device)
         rot_mats = [cos_gathereds, sin_gathereds]
 
         attn_mask = torch.full((seq_len, seq_len), torch.finfo(torch.float32).min)
@@ -159,11 +159,11 @@ def tt_llama_decoder_prepare_inputs(llama_decoder_model, x, start_pos):
             dtype=ttnn.bfloat16,
             layout=ttnn.TILE_LAYOUT,
             cache_file_name=cache_name(f"attn_mask_prefill_{seq_len}"),
-            mesh_mapper=ReplicateTensorToMesh(llama_decoder_model.device_mesh),
+            mesh_mapper=ReplicateTensorToMesh(llama_decoder_model.mesh_device),
             memory_config=llama_decoder_model.model_config["DRAM_MEMCFG"],
-            device=llama_decoder_model.device_mesh,
+            device=llama_decoder_model.mesh_device,
         )
-        attn_masks = ttnn.to_device(attn_masks, llama_decoder_model.device_mesh)
+        attn_masks = ttnn.to_device(attn_masks, llama_decoder_model.mesh_device)
 
     elif llama_decoder_model.model_config["LLM_MODE"] == "decode":
         assert seq_len == 1, "Only supporting decode mode"
@@ -178,10 +178,10 @@ def tt_llama_decoder_prepare_inputs(llama_decoder_model, x, start_pos):
             dtype=ttnn.bfloat16,
             layout=ttnn.TILE_LAYOUT,
             memory_config=llama_decoder_model.model_config["DRAM_MEMCFG"],
-            mesh_mapper=ttnn.ShardTensorToMesh(llama_decoder_model.device_mesh, dim=3),
-            device=llama_decoder_model.device_mesh,
+            mesh_mapper=ttnn.ShardTensorToMesh(llama_decoder_model.mesh_device, dim=3),
+            device=llama_decoder_model.mesh_device,
         )
-        xs = ttnn.to_device(xs, llama_decoder_model.device_mesh)
+        xs = ttnn.to_device(xs, llama_decoder_model.mesh_device)
         xs = ttnn.interleaved_to_sharded(xs, llama_decoder_model.model_config["WORD_EMBEDDING_OUTPUT_MEMCFG"])
 
         rot_emb = generate_rot_emb(
@@ -194,10 +194,10 @@ def tt_llama_decoder_prepare_inputs(llama_decoder_model, x, start_pos):
             dtype=ttnn.bfloat16,
             layout=ttnn.TILE_LAYOUT,
             memory_config=llama_decoder_model.model_config["DRAM_MEMCFG"],
-            mesh_mapper=ReplicateTensorToMesh(llama_decoder_model.device_mesh),
-            device=llama_decoder_model.device_mesh,
+            mesh_mapper=ReplicateTensorToMesh(llama_decoder_model.mesh_device),
+            device=llama_decoder_model.mesh_device,
         )
-        rot_mats = ttnn.to_device(rot_mats, llama_decoder_model.device_mesh)
+        rot_mats = ttnn.to_device(rot_mats, llama_decoder_model.mesh_device)
 
         rot_mats = ttnn.interleaved_to_sharded(rot_mats, llama_decoder_model.model_config["ROT_MAT_MM_IN1_MEMCFG"])
 
@@ -212,7 +212,7 @@ def tt_llama_decoder_prepare_inputs(llama_decoder_model, x, start_pos):
 
 
 def run_test_LlamaDecoder_inference(
-    t3k_device_mesh,
+    t3k_mesh_device,
     batch,
     seq_len,
     pcc,
@@ -250,14 +250,14 @@ def run_test_LlamaDecoder_inference(
         transformation_mat_torch,
         dtype=ttnn.bfloat16,
         layout=ttnn.TILE_LAYOUT,
-        device=t3k_device_mesh,
+        device=t3k_mesh_device,
         memory_config=model_config["DRAM_MEMCFG"],
-        mesh_mapper=ReplicateTensorToMesh(t3k_device_mesh),
+        mesh_mapper=ReplicateTensorToMesh(t3k_mesh_device),
     )
-    transformation_mats = ttnn.to_device(transformation_mats, t3k_device_mesh)
+    transformation_mats = ttnn.to_device(transformation_mats, t3k_mesh_device)
 
     tt_LlamaDecoder_model = TtLlamaDecoder_optimized(
-        t3k_device_mesh,
+        t3k_mesh_device,
         state_dict,
         BASE_URL,
         UNIT_TEST_LAYER_NUM,
@@ -309,7 +309,7 @@ def run_test_LlamaDecoder_inference(
         )
 
         tt_out = ttnn.from_device(tt_out)
-        tt_out = ttnn.to_torch(tt_out, mesh_composer=ConcatMeshToTensor(t3k_device_mesh, dim=3))
+        tt_out = ttnn.to_torch(tt_out, mesh_composer=ConcatMeshToTensor(t3k_mesh_device, dim=3))
         tt_out = tt_out.permute(2, 1, 0, 3).squeeze(1)  # [batch, seq_len, hidden_dim]
         if model_config["LLM_MODE"] == "decode":
             tt_out = tt_out[:batch]
@@ -342,7 +342,7 @@ def run_test_LlamaDecoder_inference(
 
     tt_layer_present_all = [ttnn.from_device(lp) for lp in tt_LlamaDecoder_model.attention.layer_past]
     tt_layer_present_all = [
-        ttnn.to_torch(lp, mesh_composer=ConcatMeshToTensor(t3k_device_mesh, dim=0)).transpose(0, 1)[:batch, ...]
+        ttnn.to_torch(lp, mesh_composer=ConcatMeshToTensor(t3k_mesh_device, dim=0)).transpose(0, 1)[:batch, ...]
         for lp in tt_layer_present_all
     ]
 
@@ -393,7 +393,7 @@ def test_LlamaDecoder_inference(
     batch,
     seq_len,
     pcc,
-    t3k_device_mesh,
+    t3k_mesh_device,
     max_batch_size,
     max_context_len,
     llama_version,
@@ -416,9 +416,9 @@ def test_LlamaDecoder_inference(
         max_context_len=max_context_len,
     )
 
-    check_device_mesh(t3k_device_mesh, model_config)
+    check_mesh_device(t3k_mesh_device, model_config)
     run_test_LlamaDecoder_inference(
-        t3k_device_mesh,
+        t3k_mesh_device,
         batch,
         seq_len,
         pcc,

--- a/models/demos/t3000/llama2_70b/tests/test_llama_decoder_t3000.py
+++ b/models/demos/t3000/llama2_70b/tests/test_llama_decoder_t3000.py
@@ -5,7 +5,7 @@
 import pytest
 
 from models.utility_functions import skip_for_grayskull, skip_for_wormhole_b0
-from models.demos.t3000.llama2_70b.tt.llama_common import setup_llama_env, check_device_mesh
+from models.demos.t3000.llama2_70b.tt.llama_common import setup_llama_env, check_mesh_device
 from models.demos.t3000.llama2_70b.tests.test_llama_decoder import run_test_LlamaDecoder_inference
 
 
@@ -37,7 +37,7 @@ def test_LlamaDecoder_inference_t3000(
     batch,
     seq_len,
     pcc,
-    t3k_device_mesh,
+    t3k_mesh_device,
     max_batch_size,
     max_context_len,
     llama_version,
@@ -60,10 +60,10 @@ def test_LlamaDecoder_inference_t3000(
         max_context_len=max_context_len,
     )
 
-    check_device_mesh(t3k_device_mesh, model_config)
+    check_mesh_device(t3k_mesh_device, model_config)
 
     run_test_LlamaDecoder_inference(
-        t3k_device_mesh,
+        t3k_mesh_device,
         batch,
         seq_len,
         pcc,

--- a/models/demos/t3000/llama2_70b/tests/test_llama_generation.py
+++ b/models/demos/t3000/llama2_70b/tests/test_llama_generation.py
@@ -20,7 +20,7 @@ from models.demos.t3000.llama2_70b.tt.llama_generation import TtLlamaModelForGen
 from models.utility_functions import torch2tt_tensor, tt2torch_tensor, skip_for_grayskull, get_devices_for_t3000
 from models.demos.t3000.llama2_70b.tt.llama_common import (
     setup_llama_env,
-    check_device_mesh,
+    check_mesh_device,
     extract_pcc_from_log,
     MAX_SEQ_LEN,
     BASE_URL,
@@ -135,7 +135,7 @@ def test_LlamaModel_inference(
     temperature,
     # TT args
     # all_devices,
-    t3k_device_mesh,
+    t3k_mesh_device,
     n_devices,
     llama_version,
     decode_only,
@@ -144,15 +144,15 @@ def test_LlamaModel_inference(
         llama_version=llama_version,
     )
 
-    if t3k_device_mesh.get_num_devices() < n_devices and not emulated:
+    if t3k_mesh_device.get_num_devices() < n_devices and not emulated:
         pytest.skip(f"Requires at {n_devices} devices to run")
 
-    compute_grid_size = t3k_device_mesh.get_device(0).compute_with_storage_grid_size()
+    compute_grid_size = t3k_mesh_device.get_device(0).compute_with_storage_grid_size()
     if compute_grid_size.x < model_config["MAX_GRID_SIZE"][0] or compute_grid_size.y < model_config["MAX_GRID_SIZE"][1]:
         pytest.skip(f"Requires grid size of at least {model_config['MAX_GRID_SIZE']} to run")
 
-    for i in t3k_device_mesh.get_device_ids():
-        device = t3k_device_mesh.get_device(i)
+    for i in t3k_mesh_device.get_device_ids():
+        device = t3k_mesh_device.get_device(i)
         device.enable_program_cache()
 
     args = construct_arg(
@@ -168,7 +168,7 @@ def test_LlamaModel_inference(
         top_p=top_p,
         top_k=top_k,
         temperature=temperature,
-        device_mesh=t3k_device_mesh,
+        mesh_device=t3k_mesh_device,
         n_devices=n_devices,
         cache_path=cache_path,
         decode_only=decode_only,

--- a/models/demos/t3000/llama2_70b/tests/test_llama_mlp_t3000.py
+++ b/models/demos/t3000/llama2_70b/tests/test_llama_mlp_t3000.py
@@ -6,7 +6,7 @@ import pytest
 
 from models.utility_functions import skip_for_grayskull
 from models.demos.t3000.llama2_70b.tests.test_llama_mlp import run_test_LlamaMLP_inference
-from models.demos.t3000.llama2_70b.tt.llama_common import setup_llama_env, check_device_mesh
+from models.demos.t3000.llama2_70b.tt.llama_common import setup_llama_env, check_mesh_device
 
 
 @skip_for_grayskull("Requires eth connected devices to run")
@@ -34,7 +34,7 @@ def test_LlamaMLP_inference_t3000(
     batch,
     seq_len,
     pcc,
-    t3k_device_mesh,
+    t3k_mesh_device,
     max_batch_size,
     max_context_len,
     llama_version,
@@ -57,9 +57,9 @@ def test_LlamaMLP_inference_t3000(
         max_context_len=max_context_len,
     )
 
-    check_device_mesh(t3k_device_mesh, model_config)
+    check_mesh_device(t3k_mesh_device, model_config)
     run_test_LlamaMLP_inference(
-        t3k_device_mesh,
+        t3k_mesh_device,
         batch,
         seq_len,
         pcc,

--- a/models/demos/t3000/llama2_70b/tests/test_llama_model_t3000.py
+++ b/models/demos/t3000/llama2_70b/tests/test_llama_model_t3000.py
@@ -5,7 +5,7 @@
 import pytest
 
 from models.utility_functions import skip_for_grayskull, skip_for_wormhole_b0
-from models.demos.t3000.llama2_70b.tt.llama_common import setup_llama_env, check_device_mesh
+from models.demos.t3000.llama2_70b.tt.llama_common import setup_llama_env, check_mesh_device
 from models.demos.t3000.llama2_70b.tests.test_llama_model import run_test_LlamaModel_inference
 
 
@@ -44,7 +44,7 @@ def test_LlamaModel_inference(
     seq_len,
     pcc,
     n_layers,
-    t3k_device_mesh,
+    t3k_mesh_device,
     max_batch_size,
     max_context_len,
     llama_version,
@@ -67,10 +67,10 @@ def test_LlamaModel_inference(
         max_context_len=max_context_len,
     )
 
-    check_device_mesh(t3k_device_mesh, model_config)
+    check_mesh_device(t3k_mesh_device, model_config)
 
     run_test_LlamaModel_inference(
-        t3k_device_mesh,
+        t3k_mesh_device,
         batch,
         seq_len,
         pcc,

--- a/models/demos/t3000/llama2_70b/tt/llama_attention_optimized.py
+++ b/models/demos/t3000/llama2_70b/tt/llama_attention_optimized.py
@@ -12,7 +12,7 @@ from ttnn import ShardTensorToMesh
 class TtLlamaAttention_optimized:
     def __init__(
         self,
-        device_mesh,
+        mesh_device,
         state_dict,
         base_url,
         layer_num,
@@ -24,8 +24,8 @@ class TtLlamaAttention_optimized:
         read_cache=False,
     ):
         self.state_dict = state_dict
-        self.device_mesh = device_mesh
-        self.num_devices = device_mesh.get_num_devices()
+        self.mesh_device = mesh_device
+        self.num_devices = mesh_device.get_num_devices()
         self.model_config = model_config
         self.read_cache = read_cache
 
@@ -81,14 +81,14 @@ class TtLlamaAttention_optimized:
             ttnn.to_device(
                 ttnn.as_tensor(
                     lp,
-                    device=self.device_mesh,
-                    mesh_mapper=ShardTensorToMesh(self.device_mesh, dim=0),
+                    device=self.mesh_device,
+                    mesh_mapper=ShardTensorToMesh(self.mesh_device, dim=0),
                     layout=ttnn.TILE_LAYOUT,
                     memory_config=self.model_config["DRAM_MEMCFG"],
                     dtype=ttnn.bfloat8_b,
                     cache_file_name=self.cache_path / f"empty_attn_cache{cache_k.shape}",
                 ),
-                self.device_mesh,
+                self.mesh_device,
             )
             for lp in layer_past
         ]
@@ -149,24 +149,24 @@ class TtLlamaAttention_optimized:
             qkv_cat,
             dtype=ttnn.bfloat8_b,
             layout=ttnn.TILE_LAYOUT,
-            device=self.device_mesh,
+            device=self.mesh_device,
             memory_config=self.model_config["DRAM_MEMCFG"],
-            mesh_mapper=ShardTensorToMesh(self.device_mesh, dim=3),
+            mesh_mapper=ShardTensorToMesh(self.mesh_device, dim=3),
             cache_file_name=self.cache_path / wqkv_cache_str,
         )
-        self.qkv = ttnn.to_device(qkv_ttnn, self.device_mesh)
+        self.qkv = ttnn.to_device(qkv_ttnn, self.mesh_device)
 
         wo_ttnn = ttnn.as_tensor(
             pt_wo,
             dtype=ttnn.bfloat8_b,
             layout=ttnn.TILE_LAYOUT,
-            device=self.device_mesh,
+            device=self.mesh_device,
             memory_config=self.model_config["DRAM_MEMCFG"],
-            mesh_mapper=ShardTensorToMesh(self.device_mesh, dim=3),
+            mesh_mapper=ShardTensorToMesh(self.mesh_device, dim=3),
             cache_file_name=self.cache_path / wo_str,
         )
 
-        self.wo = ttnn.to_device(wo_ttnn, self.device_mesh)
+        self.wo = ttnn.to_device(wo_ttnn, self.mesh_device)
 
     def __call__(
         self,

--- a/models/demos/t3000/llama2_70b/tt/llama_common.py
+++ b/models/demos/t3000/llama2_70b/tt/llama_common.py
@@ -35,8 +35,8 @@ from ttnn import (
 
 
 class ShardTensor2dMesh(TensorToMesh):
-    def __init__(self, device_mesh, dims, cluster_shape):
-        super().__init__(device_mesh)
+    def __init__(self, mesh_device, dims, cluster_shape):
+        super().__init__(mesh_device)
         self.dims = dims
         self.cluster_shape = cluster_shape
 
@@ -66,10 +66,10 @@ class ShardTensor2dMesh(TensorToMesh):
 
 
 class ConcatMesh2DToTensor(MeshToTensor):
-    def __init__(self, device_mesh, dims, cluster_shape):
+    def __init__(self, mesh_device, dims, cluster_shape):
         self.dims = dims
         self.cluster_shape = cluster_shape
-        self.device_mesh = device_mesh
+        self.mesh_device = mesh_device
 
     def compose(self, tensor: ttnn.Tensor) -> torch.Tensor:
         tt_shards = [ttnn.to_torch(tt_input_tensor) for tt_input_tensor in ttnn.get_device_tensors(tensor)]
@@ -185,13 +185,13 @@ def setup_llama_env(llama_version="llama3", batch=32, seq_len=1, n_devices=8, ma
     return model_config, ckpt_dir, tokenizer_path, cache_path
 
 
-def check_device_mesh(t3k_device_mesh, model_config):
-    assert t3k_device_mesh.get_num_devices() >= model_config["NUM_DEVICES"], (
+def check_mesh_device(t3k_mesh_device, model_config):
+    assert t3k_mesh_device.get_num_devices() >= model_config["NUM_DEVICES"], (
         "Requires at least %d devices to run",
         model_config["NUM_DEVICES"],
     )
 
-    compute_grid_size = t3k_device_mesh.get_device(0).compute_with_storage_grid_size()
+    compute_grid_size = t3k_mesh_device.get_device(0).compute_with_storage_grid_size()
     assert not (
         compute_grid_size.x < model_config["MAX_GRID_SIZE"][0] or compute_grid_size.y < model_config["MAX_GRID_SIZE"][1]
     ), ("Requires grid size of at least %d to run", model_config["MAX_GRID_SIZE"])

--- a/models/demos/t3000/llama2_70b/tt/llama_decoder_optimized.py
+++ b/models/demos/t3000/llama2_70b/tt/llama_decoder_optimized.py
@@ -15,7 +15,7 @@ from models.demos.t3000.llama2_70b.tt.llama_mlp_optimized import TtLlamaMLP_opti
 class TtLlamaDecoder_optimized:
     def __init__(
         self,
-        device_mesh,
+        mesh_device,
         state_dict,
         base_url,
         layer_num,
@@ -28,8 +28,8 @@ class TtLlamaDecoder_optimized:
         super().__init__()
 
         self.state_dict = state_dict
-        self.device_mesh = device_mesh
-        self.num_devices = device_mesh.get_num_devices()
+        self.mesh_device = mesh_device
+        self.num_devices = mesh_device.get_num_devices()
         self.model_config = model_config
         self.read_cache = read_cache
 
@@ -48,7 +48,7 @@ class TtLlamaDecoder_optimized:
         self.cache_path = cache_path
 
         self.attention = TtLlamaAttention_optimized(
-            device_mesh,
+            mesh_device,
             state_dict,
             base_url,
             layer_num,
@@ -60,7 +60,7 @@ class TtLlamaDecoder_optimized:
         )
 
         self.mlp = TtLlamaMLP_optimized(
-            device_mesh,
+            mesh_device,
             state_dict,
             base_url,
             layer_num,
@@ -100,45 +100,45 @@ class TtLlamaDecoder_optimized:
             pt_attn_norm,
             dtype=ttnn.bfloat16,
             layout=ttnn.ROW_MAJOR_LAYOUT,
-            device=self.device_mesh,
+            device=self.mesh_device,
             memory_config=self.model_config["DRAM_MEMCFG"],
-            mesh_mapper=ReplicateTensorToMesh(self.device_mesh),
+            mesh_mapper=ReplicateTensorToMesh(self.mesh_device),
             cache_file_name=self.cache_path / attn_norm_str,
         )
-        self.attn_norm = ttnn.to_device(attn_norm_ttnn, self.device_mesh)
+        self.attn_norm = ttnn.to_device(attn_norm_ttnn, self.mesh_device)
 
         attn_norm_sharded_ttnn = ttnn.as_tensor(
             pt_attn_norm,
             dtype=ttnn.bfloat16,
             layout=ttnn.ROW_MAJOR_LAYOUT,
-            device=self.device_mesh,
+            device=self.mesh_device,
             memory_config=self.model_config["DRAM_MEMCFG"],
-            mesh_mapper=ShardTensorToMesh(self.device_mesh, dim=2),
+            mesh_mapper=ShardTensorToMesh(self.mesh_device, dim=2),
             cache_file_name=self.cache_path / attn_norm_sharded_str,
         )
-        self.attn_norm_sharded = ttnn.to_device(attn_norm_sharded_ttnn, self.device_mesh)
+        self.attn_norm_sharded = ttnn.to_device(attn_norm_sharded_ttnn, self.mesh_device)
 
         ffn_norm_ttnn = ttnn.as_tensor(
             pt_ffn_norm,
             dtype=ttnn.bfloat16,
             layout=ttnn.ROW_MAJOR_LAYOUT,
-            device=self.device_mesh,
+            device=self.mesh_device,
             memory_config=self.model_config["DRAM_MEMCFG"],
-            mesh_mapper=ReplicateTensorToMesh(self.device_mesh),
+            mesh_mapper=ReplicateTensorToMesh(self.mesh_device),
             cache_file_name=self.cache_path / ffn_norm_str,
         )
-        self.ffn_norm = ttnn.to_device(ffn_norm_ttnn, self.device_mesh)
+        self.ffn_norm = ttnn.to_device(ffn_norm_ttnn, self.mesh_device)
 
         ffn_norm_sharded_ttnn = ttnn.as_tensor(
             pt_ffn_norm,
             dtype=ttnn.bfloat16,
             layout=ttnn.ROW_MAJOR_LAYOUT,
-            device=self.device_mesh,
+            device=self.mesh_device,
             memory_config=self.model_config["DRAM_MEMCFG"],
-            mesh_mapper=ShardTensorToMesh(self.device_mesh, dim=2),
+            mesh_mapper=ShardTensorToMesh(self.mesh_device, dim=2),
             cache_file_name=self.cache_path / ffn_norm_sharded_str,
         )
-        self.ffn_norm_sharded = ttnn.to_device(ffn_norm_sharded_ttnn, self.device_mesh)
+        self.ffn_norm_sharded = ttnn.to_device(ffn_norm_sharded_ttnn, self.mesh_device)
 
     def __call__(
         self,

--- a/models/demos/t3000/llama2_70b/tt/llama_embedding.py
+++ b/models/demos/t3000/llama2_70b/tt/llama_embedding.py
@@ -10,13 +10,13 @@ from ttnn import ShardTensorToMesh
 class TtLlamaEmbedding:
     def __init__(
         self,
-        device_mesh,
+        mesh_device,
         state_dict,
         cache_path,
     ):
         self.state_dict = state_dict
-        self.device_mesh = device_mesh
-        self.num_devices = device_mesh.get_num_devices()
+        self.mesh_device = mesh_device
+        self.num_devices = mesh_device.get_num_devices()
 
         base_name = "tok_embeddings.weight"
         # torch_weights = [
@@ -42,12 +42,12 @@ class TtLlamaEmbedding:
             self.state_dict[base_name].unsqueeze(0).unsqueeze(0),
             dtype=ttnn.bfloat16,  # row_major has to be bfloat16 for now
             layout=ttnn.ROW_MAJOR_LAYOUT,
-            device=device_mesh,
+            device=mesh_device,
             memory_config=ttnn.DRAM_MEMORY_CONFIG,
-            mesh_mapper=ShardTensorToMesh(device_mesh, dim=3),
+            mesh_mapper=ShardTensorToMesh(mesh_device, dim=3),
             cache_file_name=cache_path / base_name,
         )
-        self.emb_weights = ttnn.to_device(embd_weights_ttn, device_mesh)
+        self.emb_weights = ttnn.to_device(embd_weights_ttn, mesh_device)
 
     def __call__(self, x: ttnn.Tensor) -> ttnn.Tensor:
         x = ttnn.embedding(

--- a/models/demos/t3000/llama2_70b/tt/llama_generation.py
+++ b/models/demos/t3000/llama2_70b/tt/llama_generation.py
@@ -27,7 +27,7 @@ class TtLlamaModelForGeneration:
         self.max_batch_size = model_args.max_batch_size
         self.max_kv_context_len = model_args.max_kv_context_len
 
-        self.device_mesh = tt_args.device_mesh
+        self.mesh_device = tt_args.mesh_device
 
         # Initial model_config is set in decode mode
         model_config = get_model_config(
@@ -40,7 +40,7 @@ class TtLlamaModelForGeneration:
 
         # TT model -------------------------------------------------------------
         self.tt_model = TtLlamaModel(
-            self.device_mesh,
+            self.mesh_device,
             state_dict,
             BASE_URL,
             n_layers,
@@ -138,7 +138,7 @@ class TtLlamaModelForGeneration:
 
     def _process_logits(self, tt_logits):
         logits = ttnn.to_torch(
-            tt_logits, device=self.device_mesh, mesh_composer=ConcatMeshToTensor(self.device_mesh, dim=3)
+            tt_logits, device=self.mesh_device, mesh_composer=ConcatMeshToTensor(self.mesh_device, dim=3)
         )
         return logits[..., : self.params.vocab_size].float()
 

--- a/models/demos/t3000/llama2_70b/tt/llama_model_optimized.py
+++ b/models/demos/t3000/llama2_70b/tt/llama_model_optimized.py
@@ -25,7 +25,7 @@ from models.demos.t3000.llama2_70b.tt.llama_common import (
 class TtLlamaModel_optimized:
     def __init__(
         self,
-        device_mesh,
+        mesh_device,
         state_dict,
         base_url,
         n_layers,
@@ -35,8 +35,8 @@ class TtLlamaModel_optimized:
         read_cache=False,
     ):
         self.state_dict = state_dict
-        self.device_mesh = device_mesh
-        self.num_devices = device_mesh.get_num_devices()
+        self.mesh_device = mesh_device
+        self.num_devices = mesh_device.get_num_devices()
         self.model_config = model_config
         self.read_cache = read_cache
 
@@ -59,16 +59,16 @@ class TtLlamaModel_optimized:
             transformation_mat_torch,
             dtype=ttnn.bfloat16,
             layout=ttnn.TILE_LAYOUT,
-            device=device_mesh,
+            device=mesh_device,
             memory_config=model_config["DRAM_MEMCFG"],
-            mesh_mapper=ReplicateTensorToMesh(device_mesh),
+            mesh_mapper=ReplicateTensorToMesh(mesh_device),
         )
-        transformation_mats = ttnn.to_device(transformation_mats, device_mesh)
+        transformation_mats = ttnn.to_device(transformation_mats, mesh_device)
 
         logger.info("Creating Layers")
         self.layers = [
             TtLlamaDecoder_optimized(
-                device_mesh,
+                mesh_device,
                 state_dict,
                 base_url,
                 layer_num,
@@ -89,7 +89,7 @@ class TtLlamaModel_optimized:
         self.rot_emb = freqs_to_rotation_matrix(self.cos, self.sin)  # for decode
         # Embedding
         self.tt_embd = TtLlamaEmbedding(
-            device_mesh,
+            mesh_device,
             state_dict,
             cache_path,
         )
@@ -123,34 +123,34 @@ class TtLlamaModel_optimized:
             padded_lm_head,
             dtype=ttnn.bfloat8_b,
             layout=ttnn.TILE_LAYOUT,
-            device=self.device_mesh,
+            device=self.mesh_device,
             memory_config=self.model_config["DRAM_MEMCFG"],
-            mesh_mapper=ShardTensorToMesh(self.device_mesh, dim=3),
+            mesh_mapper=ShardTensorToMesh(self.mesh_device, dim=3),
             cache_file_name=self.cache_path / lm_head_str,
         )
-        self.lm_head = ttnn.to_device(padded_lm_head_ttnn, self.device_mesh)
+        self.lm_head = ttnn.to_device(padded_lm_head_ttnn, self.mesh_device)
 
         norm_ttnn = ttnn.as_tensor(
             pt_norm_weight,
             dtype=ttnn.bfloat16,
             layout=ttnn.ROW_MAJOR_LAYOUT,
-            device=self.device_mesh,
+            device=self.mesh_device,
             memory_config=self.model_config["DRAM_MEMCFG"],
-            mesh_mapper=ReplicateTensorToMesh(self.device_mesh),
+            mesh_mapper=ReplicateTensorToMesh(self.mesh_device),
             cache_file_name=self.cache_path / norm_str,
         )
-        self.norm = ttnn.to_device(norm_ttnn, self.device_mesh)
+        self.norm = ttnn.to_device(norm_ttnn, self.mesh_device)
 
         norm_sharded_ttnn = ttnn.as_tensor(
             pt_norm_weight,
             dtype=ttnn.bfloat16,
             layout=ttnn.ROW_MAJOR_LAYOUT,
-            device=self.device_mesh,
+            device=self.mesh_device,
             memory_config=self.model_config["DRAM_MEMCFG"],
-            mesh_mapper=ShardTensorToMesh(self.device_mesh, dim=2),
+            mesh_mapper=ShardTensorToMesh(self.mesh_device, dim=2),
             cache_file_name=self.cache_path / norm_sharded_str,
         )
-        self.norm_sharded = ttnn.to_device(norm_sharded_ttnn, self.device_mesh)
+        self.norm_sharded = ttnn.to_device(norm_sharded_ttnn, self.mesh_device)
 
     def prepare_inputs(self, inp_ids, start_pos, valid_seq_len=None):
         """
@@ -184,11 +184,11 @@ class TtLlamaModel_optimized:
             inp_ids,
             dtype=ttnn.uint32,
             layout=ttnn.ROW_MAJOR_LAYOUT,
-            device=self.device_mesh,
+            device=self.mesh_device,
             memory_config=self.model_config["DRAM_MEMCFG"],
-            mesh_mapper=ReplicateTensorToMesh(self.device_mesh),
+            mesh_mapper=ReplicateTensorToMesh(self.mesh_device),
         )
-        x = ttnn.to_device(x, self.device_mesh)
+        x = ttnn.to_device(x, self.mesh_device)
 
         xs = self.tt_embd(x)
 
@@ -211,8 +211,8 @@ class TtLlamaModel_optimized:
                 layout=ttnn.TILE_LAYOUT,
                 cache_file_name=cache_name(f"cos_gathered_prefill_{seq_len}"),
                 memory_config=self.model_config["DRAM_MEMCFG"],
-                device=self.device_mesh,
-                mesh_mapper=ReplicateTensorToMesh(self.device_mesh),
+                device=self.mesh_device,
+                mesh_mapper=ReplicateTensorToMesh(self.mesh_device),
             )
             sin_gathereds = ttnn.as_tensor(
                 sin_gathered,
@@ -220,11 +220,11 @@ class TtLlamaModel_optimized:
                 layout=ttnn.TILE_LAYOUT,
                 cache_file_name=cache_name(f"sin_gathered_prefill_{seq_len}"),
                 memory_config=self.model_config["DRAM_MEMCFG"],
-                device=self.device_mesh,
-                mesh_mapper=ReplicateTensorToMesh(self.device_mesh),
+                device=self.mesh_device,
+                mesh_mapper=ReplicateTensorToMesh(self.mesh_device),
             )
-            cos_gathereds = ttnn.to_device(cos_gathereds, self.device_mesh)
-            sin_gathereds = ttnn.to_device(sin_gathereds, self.device_mesh)
+            cos_gathereds = ttnn.to_device(cos_gathereds, self.mesh_device)
+            sin_gathereds = ttnn.to_device(sin_gathereds, self.mesh_device)
             rot_mats = [cos_gathereds, sin_gathereds]
 
             attn_mask = torch.full((seq_len, seq_len), torch.finfo(torch.float32).min)
@@ -243,11 +243,11 @@ class TtLlamaModel_optimized:
                 dtype=ttnn.bfloat16,
                 layout=ttnn.TILE_LAYOUT,
                 cache_file_name=cache_name(f"attn_masks_prefill_{seq_len}"),
-                mesh_mapper=ReplicateTensorToMesh(self.device_mesh),
+                mesh_mapper=ReplicateTensorToMesh(self.mesh_device),
                 memory_config=self.model_config["DRAM_MEMCFG"],
-                device=self.device_mesh,
+                device=self.mesh_device,
             )
-            attn_masks = ttnn.to_device(attn_masks, self.device_mesh)
+            attn_masks = ttnn.to_device(attn_masks, self.mesh_device)
 
         elif self.model_config["LLM_MODE"] == "decode":
             assert seq_len == 1, "Decode mode only supports seq_len=1"
@@ -267,12 +267,12 @@ class TtLlamaModel_optimized:
                 rot_mat,
                 dtype=ttnn.bfloat16,
                 layout=ttnn.TILE_LAYOUT,
-                device=self.device_mesh,
+                device=self.mesh_device,
                 cache_file_name=cache_name(f"rot_mat_decode_b{batch}_{start_pos}"),
                 memory_config=self.model_config["DRAM_MEMCFG"],
-                mesh_mapper=ReplicateTensorToMesh(self.device_mesh),
+                mesh_mapper=ReplicateTensorToMesh(self.mesh_device),
             )
-            rot_mats = ttnn.to_device(rot_mats, self.device_mesh)
+            rot_mats = ttnn.to_device(rot_mats, self.mesh_device)
 
             rot_mats = ttnn.interleaved_to_sharded(rot_mats, self.model_config["ROT_MAT_MM_IN1_MEMCFG"])
 

--- a/models/demos/t3000/llama3_70b/demo/demo.py
+++ b/models/demos/t3000/llama3_70b/demo/demo.py
@@ -9,7 +9,7 @@ from loguru import logger
 
 from models.demos.t3000.llama2_70b.tt.llama_common import (
     setup_llama_env,
-    check_device_mesh,
+    check_mesh_device,
 )
 from models.demos.t3000.llama2_70b.demo.demo import main, construct_arg
 
@@ -80,7 +80,7 @@ def test_LlamaModel_demo(
     temperature,
     chat,
     # TT args
-    t3k_device_mesh,
+    t3k_mesh_device,
     n_devices,
     decode_only,
     llama_version,
@@ -96,10 +96,10 @@ def test_LlamaModel_demo(
         llama_version=llama_version,
     )
 
-    check_device_mesh(t3k_device_mesh, model_config)
+    check_mesh_device(t3k_mesh_device, model_config)
 
-    for i in t3k_device_mesh.get_device_ids():
-        device = t3k_device_mesh.get_device(i)
+    for i in t3k_mesh_device.get_device_ids():
+        device = t3k_mesh_device.get_device(i)
         device.enable_async(True)
 
     args = construct_arg(
@@ -117,7 +117,7 @@ def test_LlamaModel_demo(
         top_k=top_k,
         temperature=temperature,
         chat=chat,
-        device_mesh=t3k_device_mesh,
+        mesh_device=t3k_mesh_device,
         n_devices=n_devices,
         cache_path=cache_path,
         decode_only=decode_only,

--- a/models/demos/t3000/mixtral8x7b/demo/demo.py
+++ b/models/demos/t3000/mixtral8x7b/demo/demo.py
@@ -36,7 +36,7 @@ class Emb(torch.nn.Module):
 
 
 @torch.no_grad()
-def run_mixtral_demo(user_input, batch_size, device_mesh, instruct_mode, is_ci_env):
+def run_mixtral_demo(user_input, batch_size, mesh_device, instruct_mode, is_ci_env):
     if batch_size == 32:
         max_seq_len = 16384
     elif batch_size in [4, 8, 16]:
@@ -57,7 +57,7 @@ def run_mixtral_demo(user_input, batch_size, device_mesh, instruct_mode, is_ci_e
 
     # Load model args, weights, and tokenizer
     model_args = TtModelArgs(
-        device_mesh.get_device(0), instruct=instruct_mode, max_seq_len=max_seq_len, max_batch_size=batch_size
+        mesh_device.get_device(0), instruct=instruct_mode, max_seq_len=max_seq_len, max_batch_size=batch_size
     )
     tokenizer = Tokenizer(model_args.tokenizer_path)
 
@@ -81,7 +81,7 @@ def run_mixtral_demo(user_input, batch_size, device_mesh, instruct_mode, is_ci_e
 
     # Preprocess initial prompt inputs
     input_tokens_tt, max_prompt_len, input_mask, input_tokens_pt, input_mask_pt = preprocess_inputs(
-        input_prompts, tokenizer, model_args, dtype, instruct_mode, device_mesh
+        input_prompts, tokenizer, model_args, dtype, instruct_mode, mesh_device
     )
 
     if instruct_mode:
@@ -90,7 +90,7 @@ def run_mixtral_demo(user_input, batch_size, device_mesh, instruct_mode, is_ci_e
     # Load TTNN mixtral model
     logger.info("Loading weights to device...")
     tt_model = TtTransformer(
-        device_mesh=device_mesh,
+        mesh_device=mesh_device,
         state_dict=state_dict,
         args=model_args,
         layers=list(range(model_args.n_layers)),
@@ -100,7 +100,7 @@ def run_mixtral_demo(user_input, batch_size, device_mesh, instruct_mode, is_ci_e
 
     if not embed_on_host:
         tt_embds = TtMixtralEmbedding(
-            device_mesh=device_mesh,
+            mesh_device=mesh_device,
             args=model_args,
             weight_cache_path=model_args.weight_cache_path(dtype),
             state_dict=state_dict,
@@ -124,14 +124,14 @@ def run_mixtral_demo(user_input, batch_size, device_mesh, instruct_mode, is_ci_e
     # Prepare inputs for decode mode (rotary embeddings, attention mask, padding)
     current_rot_mat, rot_matrix = get_single_rot_mat(
         model_args.head_dim,
-        tt_model.device_mesh,
+        tt_model.mesh_device,
     )
 
     generation_start_pos = 0
     max_generated_tokens = 50  # max_seq_len-1
 
     cache_attention(
-        device_mesh,
+        mesh_device,
         state_dict,
         model_args,
         current_rot_mat,
@@ -164,7 +164,7 @@ def run_mixtral_demo(user_input, batch_size, device_mesh, instruct_mode, is_ci_e
                 model_args.dim,
                 start_pos,
                 model_args,
-                tt_model.device_mesh,
+                tt_model.mesh_device,
             )
 
         # Run ttnn mixtral model
@@ -173,7 +173,7 @@ def run_mixtral_demo(user_input, batch_size, device_mesh, instruct_mode, is_ci_e
         if embed_on_host:
             # Convert ttnn tensor to torch tensor
             tt_output_torch = (
-                ttnn.to_torch(tt_out_11BH, mesh_composer=ConcatMeshToTensor(device_mesh, dim=0))[0]
+                ttnn.to_torch(tt_out_11BH, mesh_composer=ConcatMeshToTensor(mesh_device, dim=0))[0]
                 .squeeze(1)
                 .view(32, seqlen, -1)
                 .detach()
@@ -192,7 +192,7 @@ def run_mixtral_demo(user_input, batch_size, device_mesh, instruct_mode, is_ci_e
         else:  # Embedding/argmax on device
             # TODO Debug (only device 0 is doing argmax, otherwise it throws an error)
             # Alternatively, send the output back to device: ttnn.Tensor.to()
-            # ttnn.SetDefaultDevice(device_mesh.get_device(0))
+            # ttnn.SetDefaultDevice(mesh_device.get_device(0))
 
             # TODO Update argmax to ttnn when OP becomes available
             tt_out_B11B = ttnn.argmax(tt_out_11BH, dim=-1)
@@ -271,17 +271,17 @@ def run_mixtral_demo(user_input, batch_size, device_mesh, instruct_mode, is_ci_e
     ],
     ids=["general", "instruct"],
 )
-def test_mixtral8x7b_demo(t3k_device_mesh, use_program_cache, input_prompts, instruct_weights, is_ci_env):
+def test_mixtral8x7b_demo(t3k_mesh_device, use_program_cache, input_prompts, instruct_weights, is_ci_env):
     if is_ci_env and instruct_weights == True:
         pytest.skip("CI demo test only runs general weights to reduce CI pipeline load (both are supported)")
 
-    for device in t3k_device_mesh.get_device_ids():
-        t3k_device_mesh.get_device(device).enable_async(True)
+    for device in t3k_mesh_device.get_device_ids():
+        t3k_mesh_device.get_device(device).enable_async(True)
 
     return run_mixtral_demo(
         user_input=input_prompts,
         batch_size=32,
-        device_mesh=t3k_device_mesh,
+        mesh_device=t3k_mesh_device,
         instruct_mode=instruct_weights,
         is_ci_env=is_ci_env,
     )

--- a/models/demos/t3000/mixtral8x7b/tests/test_dummy_weights.py
+++ b/models/demos/t3000/mixtral8x7b/tests/test_dummy_weights.py
@@ -15,7 +15,7 @@ from models.utility_functions import (
 )
 
 
-def test_load_dummy_weights(t3k_device_mesh):
+def test_load_dummy_weights(t3k_mesh_device):
     # Set to incorrect paths to test dummy weight loading
 
     backup_cache_path = TtModelArgs.DEFAULT_CACHE_PATH
@@ -27,11 +27,11 @@ def test_load_dummy_weights(t3k_device_mesh):
         TtModelArgs.DEFAULT_TOKENIZER_PATH = "this/path/does/not/exist"
         TtModelArgs.DEFAULT_CKPT_DIR = "this/path/does/not/exist"
 
-        model_args = TtModelArgs(t3k_device_mesh.get_device(0), dummy_weights=True)
+        model_args = TtModelArgs(t3k_mesh_device.get_device(0), dummy_weights=True)
         model_args.n_layers = 1
         state_dict = model_args.load_state_dict()
         tt_model = TtTransformer(
-            device_mesh=t3k_device_mesh,
+            mesh_device=t3k_mesh_device,
             state_dict=state_dict,
             args=model_args,
             layers=list(range(model_args.n_layers)),

--- a/models/demos/t3000/mixtral8x7b/tests/test_mixtral_attention_prefill.py
+++ b/models/demos/t3000/mixtral8x7b/tests/test_mixtral_attention_prefill.py
@@ -33,13 +33,13 @@ from models.utility_functions import (
     ),
 )
 @torch.no_grad()
-def test_mixtral_attention_inference(t3k_device_mesh, use_program_cache, reset_seeds, seq_len):
-    for device in t3k_device_mesh.get_device_ids():
-        t3k_device_mesh.get_device(device).enable_async(True)
+def test_mixtral_attention_inference(t3k_mesh_device, use_program_cache, reset_seeds, seq_len):
+    for device in t3k_mesh_device.get_device_ids():
+        t3k_mesh_device.get_device(device).enable_async(True)
 
     pcc = 0.99
     dtype = ttnn.bfloat8_b
-    model_args = TtModelArgs(t3k_device_mesh.get_device(0))
+    model_args = TtModelArgs(t3k_mesh_device.get_device(0))
     model_args = set_model_args(model_args, seq_len)
     state_dict = model_args.load_state_dict()
     batch = 1  # Prefill only a single user
@@ -51,20 +51,20 @@ def test_mixtral_attention_inference(t3k_device_mesh, use_program_cache, reset_s
     reference_model.load_state_dict(partial_state_dict)
 
     # Prepare rotation matrices for RoPE
-    rot_mats = get_prefill_rot_mat(model_args.head_dim, model_args.max_seq_len, t3k_device_mesh, seq_len=seq_len)
+    rot_mats = get_prefill_rot_mat(model_args.head_dim, model_args.max_seq_len, t3k_mesh_device, seq_len=seq_len)
     head_dim = model_args.dim // model_args.n_heads
     transformation_mat_torch = get_rot_transformation_mat(head_dim)
     transformation_mats = ttnn.as_tensor(
         transformation_mat_torch,
         dtype=ttnn.bfloat16,
         layout=ttnn.TILE_LAYOUT,
-        device=t3k_device_mesh,
+        device=t3k_mesh_device,
         memory_config=ttnn.DRAM_MEMORY_CONFIG,
-        mesh_mapper=ReplicateTensorToMesh(t3k_device_mesh),
+        mesh_mapper=ReplicateTensorToMesh(t3k_mesh_device),
     )
 
     # Load ttnn model
-    tt_model = TtMixtralAttention(t3k_device_mesh, state_dict, args=model_args, layer_num=0, dtype=dtype)
+    tt_model = TtMixtralAttention(t3k_mesh_device, state_dict, args=model_args, layer_num=0, dtype=dtype)
 
     generation_start_pos = 0
     generation_length = 3
@@ -77,7 +77,7 @@ def test_mixtral_attention_inference(t3k_device_mesh, use_program_cache, reset_s
         start_pos = generation_start_pos + i
         attention_input, attn_mask, attn_mask_torch = prepare_inputs_ttnn_prefill(
             tt_attention_input,
-            t3k_device_mesh,
+            t3k_mesh_device,
         )
 
         current_pos = start_pos % model_args.sliding_window
@@ -93,7 +93,7 @@ def test_mixtral_attention_inference(t3k_device_mesh, use_program_cache, reset_s
             mode="prefill",
         )
 
-        tt_output_torch = ttnn.to_torch(tt_out, mesh_composer=ConcatMeshToTensor(t3k_device_mesh, dim=0))[0].view(
+        tt_output_torch = ttnn.to_torch(tt_out, mesh_composer=ConcatMeshToTensor(t3k_mesh_device, dim=0))[0].view(
             batch, seq_len, -1
         )  # [ batch, seq, hidden_dim]
 
@@ -117,7 +117,7 @@ def test_mixtral_attention_inference(t3k_device_mesh, use_program_cache, reset_s
         # Validate KV-cache
         tt_layer_present_all = [ttnn.from_device(lp) for lp in tt_model.layer_past]
         tt_layer_present_all = [
-            ttnn.to_torch(lp, mesh_composer=ConcatMeshToTensor(t3k_device_mesh, dim=1)) for lp in tt_layer_present_all
+            ttnn.to_torch(lp, mesh_composer=ConcatMeshToTensor(t3k_mesh_device, dim=1)) for lp in tt_layer_present_all
         ]
         pytorch_layer_present = [
             reference_model.cache_k.clone().permute(2, 0, 1, 3),  # [batch, n_kv_heads, seq, head_dim]

--- a/models/demos/t3000/mixtral8x7b/tests/test_mixtral_decoder_prefill.py
+++ b/models/demos/t3000/mixtral8x7b/tests/test_mixtral_decoder_prefill.py
@@ -29,19 +29,19 @@ from ttnn import ReplicateTensorToMesh, ConcatMeshToTensor
         1024 * 32,
     ),
 )
-def test_mixtral_decoder_inference(t3k_device_mesh, use_program_cache, reset_seeds, seq_len):
+def test_mixtral_decoder_inference(t3k_mesh_device, use_program_cache, reset_seeds, seq_len):
     """
     b: batch
     s: sequence length
     h: hidden size
     """
-    for device in t3k_device_mesh.get_device_ids():
-        t3k_device_mesh.get_device(device).enable_async(True)
+    for device in t3k_mesh_device.get_device_ids():
+        t3k_mesh_device.get_device(device).enable_async(True)
 
     pcc = 0.99
     dtype = ttnn.bfloat8_b
 
-    model_args = TtModelArgs(t3k_device_mesh.get_device(0))
+    model_args = TtModelArgs(t3k_mesh_device.get_device(0))
     model_args = set_model_args(model_args, seq_len)
     batch = 1
     state_dict = model_args.load_state_dict()
@@ -49,21 +49,21 @@ def test_mixtral_decoder_inference(t3k_device_mesh, use_program_cache, reset_see
     reference_model = TransformerBlock(args=model_args)
     reference_model.load_state_dict(partial_state_dict)
 
-    rot_mats = get_prefill_rot_mat(model_args.head_dim, model_args.max_seq_len, t3k_device_mesh, seq_len=seq_len)
+    rot_mats = get_prefill_rot_mat(model_args.head_dim, model_args.max_seq_len, t3k_mesh_device, seq_len=seq_len)
     head_dim = model_args.dim // model_args.n_heads
     transformation_mat_torch = get_rot_transformation_mat(head_dim)
     transformation_mats = ttnn.as_tensor(
         transformation_mat_torch,
         dtype=ttnn.bfloat16,
         layout=ttnn.TILE_LAYOUT,
-        device=t3k_device_mesh,
+        device=t3k_mesh_device,
         memory_config=ttnn.DRAM_MEMORY_CONFIG,
-        mesh_mapper=ReplicateTensorToMesh(t3k_device_mesh),
+        mesh_mapper=ReplicateTensorToMesh(t3k_mesh_device),
     )
 
     # Initialize TT model
     tt_model = TtTransformerBlock(
-        device_mesh=t3k_device_mesh,
+        mesh_device=t3k_mesh_device,
         state_dict=state_dict,
         args=model_args,
         layer_num=0,
@@ -86,7 +86,7 @@ def test_mixtral_decoder_inference(t3k_device_mesh, use_program_cache, reset_see
 
         decode_input_b1sh, attn_mask, attn_mask_torch = prepare_inputs_ttnn_prefill(
             pt_decode_input_bsh,
-            tt_model.device_mesh,
+            tt_model.mesh_device,
         )
         # Run TT model
         tt_out_b1sh = tt_model(
@@ -101,7 +101,7 @@ def test_mixtral_decoder_inference(t3k_device_mesh, use_program_cache, reset_see
         )
 
         tt_output_torch_b1h = (
-            ttnn.to_torch(tt_out_b1sh, mesh_composer=ConcatMeshToTensor(t3k_device_mesh, dim=0))[0]
+            ttnn.to_torch(tt_out_b1sh, mesh_composer=ConcatMeshToTensor(t3k_mesh_device, dim=0))[0]
             .squeeze(1)
             .view(batch, seq_len, -1)
         )

--- a/models/demos/t3000/mixtral8x7b/tests/test_mixtral_mlp.py
+++ b/models/demos/t3000/mixtral8x7b/tests/test_mixtral_mlp.py
@@ -18,9 +18,9 @@ from models.utility_functions import (
 )
 
 
-def test_mixtral_mlp_inference(t3k_device_mesh, use_program_cache, reset_seeds):
-    for device in t3k_device_mesh.get_device_ids():
-        t3k_device_mesh.get_device(device).enable_async(True)
+def test_mixtral_mlp_inference(t3k_mesh_device, use_program_cache, reset_seeds):
+    for device in t3k_mesh_device.get_device_ids():
+        t3k_mesh_device.get_device(device).enable_async(True)
 
     # Specify different dtypes for each feedForward weights
     dtypes = {
@@ -29,11 +29,11 @@ def test_mixtral_mlp_inference(t3k_device_mesh, use_program_cache, reset_seeds):
         "w3": ttnn.bfloat4_b,
     }
 
-    model_args = TtModelArgs(t3k_device_mesh.get_device(0))
+    model_args = TtModelArgs(t3k_mesh_device.get_device(0))
     state_dict = model_args.load_state_dict()
 
     tt_model = TtMixtralMLP(
-        device_mesh=t3k_device_mesh,
+        mesh_device=t3k_mesh_device,
         state_dict=state_dict,
         args=model_args,
         layer_num=0,
@@ -59,15 +59,15 @@ def test_mixtral_mlp_inference(t3k_device_mesh, use_program_cache, reset_seeds):
     reference_output = reference_model(torch_input)
     tt_input = ttnn.from_torch(
         torch_input,
-        device=t3k_device_mesh,
+        device=t3k_mesh_device,
         dtype=ttnn.bfloat16,
         memory_config=ttnn.L1_MEMORY_CONFIG,
         layout=ttnn.TILE_LAYOUT,
-        mesh_mapper=ReplicateTensorToMesh(t3k_device_mesh),
+        mesh_mapper=ReplicateTensorToMesh(t3k_mesh_device),
     )
 
     tt_output = tt_model(tt_input)
-    tt_output_torch = ttnn.to_torch(tt_output, mesh_composer=ConcatMeshToTensor(t3k_device_mesh, dim=0))[0]
+    tt_output_torch = ttnn.to_torch(tt_output, mesh_composer=ConcatMeshToTensor(t3k_mesh_device, dim=0))[0]
 
     pcc_required = 0.99
     passing, pcc_message = comp_pcc(reference_output, tt_output_torch, pcc_required)

--- a/models/demos/t3000/mixtral8x7b/tests/test_mixtral_model.py
+++ b/models/demos/t3000/mixtral8x7b/tests/test_mixtral_model.py
@@ -35,9 +35,9 @@ class Emb(torch.nn.Module):
         32,
     ),
 )
-def test_mixtral_model_inference(t3k_device_mesh, use_program_cache, reset_seeds, batch):
-    for device in t3k_device_mesh.get_device_ids():
-        t3k_device_mesh.get_device(device).enable_async(True)
+def test_mixtral_model_inference(t3k_mesh_device, use_program_cache, reset_seeds, batch):
+    for device in t3k_mesh_device.get_device_ids():
+        t3k_mesh_device.get_device(device).enable_async(True)
 
     valid_pcc = 0.97
     dtype = ttnn.bfloat8_b
@@ -52,7 +52,7 @@ def test_mixtral_model_inference(t3k_device_mesh, use_program_cache, reset_seeds
     else:
         raise ValueError(f"Batch size {batch} not supported")
 
-    model_args = TtModelArgs(t3k_device_mesh.get_device(0), max_seq_len=max_seq_len, max_batch_size=batch)
+    model_args = TtModelArgs(t3k_mesh_device.get_device(0), max_seq_len=max_seq_len, max_batch_size=batch)
     state_dict = model_args.load_state_dict()
     tokenizer = Tokenizer(model_args.tokenizer_path)
 
@@ -70,7 +70,7 @@ def test_mixtral_model_inference(t3k_device_mesh, use_program_cache, reset_seeds
 
     # Load TTNN model
     tt_model = TtTransformer(
-        device_mesh=t3k_device_mesh,
+        mesh_device=t3k_mesh_device,
         state_dict=state_dict,
         args=model_args,
         layers=list(range(model_args.n_layers)),
@@ -101,7 +101,7 @@ def test_mixtral_model_inference(t3k_device_mesh, use_program_cache, reset_seeds
             model_args.dim,
             start_pos,
             model_args,
-            tt_model.device_mesh,
+            tt_model.mesh_device,
         )
 
         # Run TT model
@@ -109,7 +109,7 @@ def test_mixtral_model_inference(t3k_device_mesh, use_program_cache, reset_seeds
 
         # Convert ttnn tensor to torch tensor
         tt_output_torch = (
-            ttnn.to_torch(tt_out, mesh_composer=ConcatMeshToTensor(t3k_device_mesh, dim=0))[0]
+            ttnn.to_torch(tt_out, mesh_composer=ConcatMeshToTensor(t3k_mesh_device, dim=0))[0]
             .squeeze(1)
             .view(32, seqlen, -1)
             .detach()

--- a/models/demos/t3000/mixtral8x7b/tests/test_mixtral_model_prefill.py
+++ b/models/demos/t3000/mixtral8x7b/tests/test_mixtral_model_prefill.py
@@ -40,13 +40,13 @@ class Emb(torch.nn.Module):
         1024 * 32,
     ),
 )
-def test_mixtral_model_inference_CI(t3k_device_mesh, use_program_cache, reset_seeds, seq_len, is_ci_env):
+def test_mixtral_model_inference_CI(t3k_mesh_device, use_program_cache, reset_seeds, seq_len, is_ci_env):
     # Set additional Mistral flag for CI
     if is_ci_env:
         os.environ["MIXTRAL_REF_OUTPUT_PATH"] = "/mnt/MLPerf/tt_dnn-models/Mistral/Mixtral-8x7B-v0.1/prefill/"
 
-    for device in t3k_device_mesh.get_device_ids():
-        t3k_device_mesh.get_device(device).enable_async(True)
+    for device in t3k_mesh_device.get_device_ids():
+        t3k_mesh_device.get_device(device).enable_async(True)
 
     n_layers = 32
 
@@ -64,7 +64,7 @@ def test_mixtral_model_inference_CI(t3k_device_mesh, use_program_cache, reset_se
             ref_out_file
         ), f"Reference output file not found: {ref_out_file}. Please set the flag 'MIXTRAL_REF_OUTPUT_PATH' correctly."
 
-    model_args = TtModelArgs(t3k_device_mesh.get_device(0))
+    model_args = TtModelArgs(t3k_mesh_device.get_device(0))
     model_args = set_model_args(model_args, seq_len)
     model_args.n_layers = n_layers
 
@@ -81,20 +81,20 @@ def test_mixtral_model_inference_CI(t3k_device_mesh, use_program_cache, reset_se
     embd.load_state_dict({"emb.weight": state_dict["tok_embeddings.weight"]})
 
     # Prepare rotary matrices
-    rot_mats = get_prefill_rot_mat(model_args.head_dim, model_args.max_seq_len, t3k_device_mesh, seq_len=seq_len)
+    rot_mats = get_prefill_rot_mat(model_args.head_dim, model_args.max_seq_len, t3k_mesh_device, seq_len=seq_len)
     head_dim = model_args.dim // model_args.n_heads
     transformation_mat_torch = get_rot_transformation_mat(head_dim)
     transformation_mats = ttnn.as_tensor(
         transformation_mat_torch,
         dtype=ttnn.bfloat16,
         layout=ttnn.TILE_LAYOUT,
-        device=t3k_device_mesh,
+        device=t3k_mesh_device,
         memory_config=ttnn.DRAM_MEMORY_CONFIG,
-        mesh_mapper=ReplicateTensorToMesh(t3k_device_mesh),
+        mesh_mapper=ReplicateTensorToMesh(t3k_mesh_device),
     )
     # Load TTNN model
     tt_model = TtTransformer(
-        device_mesh=t3k_device_mesh,
+        mesh_device=t3k_mesh_device,
         state_dict=state_dict,
         args=model_args,
         layers=list(range(model_args.n_layers)),
@@ -114,7 +114,7 @@ def test_mixtral_model_inference_CI(t3k_device_mesh, use_program_cache, reset_se
     for iter in range(1):
         decode_input, attn_mask, attn_mask_torch = prepare_inputs_ttnn_prefill(
             tt_decode_input,
-            tt_model.device_mesh,
+            tt_model.mesh_device,
         )
 
         # Run TT model
@@ -124,7 +124,7 @@ def test_mixtral_model_inference_CI(t3k_device_mesh, use_program_cache, reset_se
 
         # Convert ttnn tensor to torch tensor
         tt_output_torch = (
-            ttnn.to_torch(tt_out, mesh_composer=ConcatMeshToTensor(t3k_device_mesh, dim=0))[0]
+            ttnn.to_torch(tt_out, mesh_composer=ConcatMeshToTensor(t3k_mesh_device, dim=0))[0]
             .view(batch, seq_len, -1)
             .detach()
             .float()
@@ -174,13 +174,13 @@ def test_mixtral_model_inference_CI(t3k_device_mesh, use_program_cache, reset_se
             model_args.dim,
             start_pos,
             model_args,
-            tt_model.device_mesh,
+            tt_model.mesh_device,
         )
         tt_out = tt_model(decode_input, start_pos, current_pos, mode="decode")
 
         # Convert ttnn tensor to torch tensor
         tt_output_torch = (
-            ttnn.to_torch(tt_out, mesh_composer=ConcatMeshToTensor(t3k_device_mesh, dim=0))[0]
+            ttnn.to_torch(tt_out, mesh_composer=ConcatMeshToTensor(t3k_mesh_device, dim=0))[0]
             .view(32, seqlen, -1)
             .detach()
             .float()

--- a/models/demos/t3000/mixtral8x7b/tests/test_mixtral_moe_prefill.py
+++ b/models/demos/t3000/mixtral8x7b/tests/test_mixtral_moe_prefill.py
@@ -29,15 +29,15 @@ from models.utility_functions import (
         1024 * 32,
     ),
 )
-def test_mixtral_moe_inference(t3k_device_mesh, use_program_cache, reset_seeds, seq_len):
-    for device in t3k_device_mesh.get_device_ids():
-        t3k_device_mesh.get_device(device).enable_async(True)
+def test_mixtral_moe_inference(t3k_mesh_device, use_program_cache, reset_seeds, seq_len):
+    for device in t3k_mesh_device.get_device_ids():
+        t3k_mesh_device.get_device(device).enable_async(True)
 
     pcc = 0.99
     iterations = 1
     dtype = ttnn.bfloat8_b
 
-    model_args = TtModelArgs(t3k_device_mesh.get_device(0))
+    model_args = TtModelArgs(t3k_mesh_device.get_device(0))
     state_dict = model_args.load_state_dict()
     batch = 1
 
@@ -59,7 +59,7 @@ def test_mixtral_moe_inference(t3k_device_mesh, use_program_cache, reset_seeds, 
 
     # Initialize TT models
     experts = TtMixtralMLP(
-        device_mesh=t3k_device_mesh,
+        mesh_device=t3k_mesh_device,
         state_dict=state_dict,
         args=model_args,
         layer_num=0,
@@ -71,7 +71,7 @@ def test_mixtral_moe_inference(t3k_device_mesh, use_program_cache, reset_seeds, 
     )
 
     tt_model = TtMoeLayer(
-        device_mesh=t3k_device_mesh,
+        mesh_device=t3k_mesh_device,
         state_dict=state_dict,
         experts=experts,
         args=model_args,
@@ -88,16 +88,16 @@ def test_mixtral_moe_inference(t3k_device_mesh, use_program_cache, reset_seeds, 
         pt_decode_input = (torch.rand(batch, seq_len, model_args.dim) * 2) - 1
         tt_decode_input = ttnn.from_torch(
             pt_decode_input.clone().unsqueeze(1).view(1, 1, seq_len, 4096),
-            device=t3k_device_mesh,
+            device=t3k_mesh_device,
             dtype=ttnn.bfloat16,
             memory_config=ttnn.DRAM_MEMORY_CONFIG,
             layout=ttnn.TILE_LAYOUT,
-            mesh_mapper=ReplicateTensorToMesh(t3k_device_mesh),
+            mesh_mapper=ReplicateTensorToMesh(t3k_mesh_device),
         )
 
         # Run TT model
         tt_out = tt_model(tt_decode_input, mode="prefill")
-        tt_output_torch = ttnn.to_torch(tt_out, mesh_composer=ConcatMeshToTensor(t3k_device_mesh, dim=0))[0].view(
+        tt_output_torch = ttnn.to_torch(tt_out, mesh_composer=ConcatMeshToTensor(t3k_mesh_device, dim=0))[0].view(
             batch, seq_len, -1
         )
 

--- a/models/demos/t3000/mixtral8x7b/tests/test_mixtral_perf.py
+++ b/models/demos/t3000/mixtral8x7b/tests/test_mixtral_perf.py
@@ -43,7 +43,7 @@ class Emb(torch.nn.Module):
     ),
 )
 def test_mixtral_model_perf(
-    t3k_device_mesh,
+    t3k_mesh_device,
     generation_start_pos,
     expected_compile_time,
     expected_inference_time,
@@ -51,8 +51,8 @@ def test_mixtral_model_perf(
     reset_seeds,
     is_ci_env,
 ):
-    for device in t3k_device_mesh.get_device_ids():
-        t3k_device_mesh.get_device(device).enable_async(True)
+    for device in t3k_mesh_device.get_device_ids():
+        t3k_mesh_device.get_device(device).enable_async(True)
 
     if not is_ci_env:  # Enable tracy signpost support in local runs only
         from tracy import signpost
@@ -60,7 +60,7 @@ def test_mixtral_model_perf(
     dtype = ttnn.bfloat8_b
 
     # Can use dummy_weights=True correctness is not tested, but it is much slower
-    model_args = TtModelArgs(t3k_device_mesh.get_device(0), dummy_weights=False)
+    model_args = TtModelArgs(t3k_mesh_device.get_device(0), dummy_weights=False)
     model_args.n_layers = 32
 
     # Clear global profiler state before starting measurements
@@ -86,7 +86,7 @@ def test_mixtral_model_perf(
     profiler.start("Mixtral_model_setup")
     # Load TTNN model
     tt_model = TtTransformer(
-        device_mesh=t3k_device_mesh,
+        mesh_device=t3k_mesh_device,
         state_dict=state_dict,
         args=model_args,
         layers=list(range(model_args.n_layers)),
@@ -104,8 +104,8 @@ def test_mixtral_model_perf(
     profiler.print(units="ms")
     compile_and_iter_time = profiler.get("e2e_decode_compile")
 
-    for device_id in t3k_device_mesh.get_device_ids():
-        ttnn.DumpDeviceProfiler(t3k_device_mesh.get_device(device_id))
+    for device_id in t3k_mesh_device.get_device_ids():
+        ttnn.DumpDeviceProfiler(t3k_mesh_device.get_device(device_id))
 
     if not is_ci_env:  # Enable tracy signpost support in local runs only
         signpost("Model perf run")
@@ -153,7 +153,7 @@ def test_mixtral_model_perf(
     ],
 )
 def test_mixtral_model_with_prefill_perf(
-    t3k_device_mesh,
+    t3k_mesh_device,
     prefill_seqlen,
     expected_compile_time,
     expected_inference_time,
@@ -161,8 +161,8 @@ def test_mixtral_model_with_prefill_perf(
     reset_seeds,
     is_ci_env,
 ):
-    for device in t3k_device_mesh.get_device_ids():
-        t3k_device_mesh.get_device(device).enable_async(True)
+    for device in t3k_mesh_device.get_device_ids():
+        t3k_mesh_device.get_device(device).enable_async(True)
 
     if not is_ci_env:  # Enable tracy signpost support in local runs only
         from tracy import signpost
@@ -171,7 +171,7 @@ def test_mixtral_model_with_prefill_perf(
     batch_size = 32
 
     # Can use dummy_weights=True correctness is not tested, but it is much slower
-    model_args = TtModelArgs(t3k_device_mesh.get_device(0), dummy_weights=False)
+    model_args = TtModelArgs(t3k_mesh_device.get_device(0), dummy_weights=False)
     model_args.n_layers = 32
 
     # Clear global profiler state before starting measurements
@@ -204,7 +204,7 @@ def test_mixtral_model_with_prefill_perf(
         input_mask_pt,
         prefill_seq_len,
         encoded_prompts,
-    ) = preprocess_inputs_prefill(prompts, tokenizer, model_args, dtype, False, t3k_device_mesh)
+    ) = preprocess_inputs_prefill(prompts, tokenizer, model_args, dtype, False, t3k_mesh_device)
 
     profiler.end("preprocessing_inputs")
 
@@ -218,7 +218,7 @@ def test_mixtral_model_with_prefill_perf(
     profiler.start("Mixtral_model_setup")
     # Load TTNN model
     tt_model = TtTransformer(
-        device_mesh=t3k_device_mesh,
+        mesh_device=t3k_mesh_device,
         state_dict=state_dict,
         args=model_args,
         layers=list(range(model_args.n_layers)),
@@ -232,28 +232,28 @@ def test_mixtral_model_with_prefill_perf(
         signpost("prefill warmup")
     profiler.clear()
     profiler.start(f"e2e_prefill_warmup")
-    run_inference_prefill(tt_model, model_args, prefill_seq_len, t3k_device_mesh, pt_prefill_input, 1)
+    run_inference_prefill(tt_model, model_args, prefill_seq_len, t3k_mesh_device, pt_prefill_input, 1)
     profiler.end(f"e2e_prefill_warmup")
     profiler.print(units="ms")
     prefill_warmup_time = profiler.get("e2e_prefill_warmup")
 
     # Profiler dump, ready for real run
-    for device_id in t3k_device_mesh.get_device_ids():
-        ttnn.DumpDeviceProfiler(t3k_device_mesh.get_device(device_id))
+    for device_id in t3k_mesh_device.get_device_ids():
+        ttnn.DumpDeviceProfiler(t3k_mesh_device.get_device(device_id))
 
     if not is_ci_env:  # Enable tracy signpost support in local runs only
         signpost("prefill perf run")
     profiler.clear()
     profiler.start(f"e2e_prefill_1_user")
     # Prefill a single user, as this will be the real-world usage
-    prefill_out = run_inference_prefill(tt_model, model_args, prefill_seq_len, t3k_device_mesh, pt_prefill_input, 1)
+    prefill_out = run_inference_prefill(tt_model, model_args, prefill_seq_len, t3k_mesh_device, pt_prefill_input, 1)
     profiler.end(f"e2e_prefill_1_user")
     profiler.print(units="ms")
     prefill_time = profiler.get("e2e_prefill_1_user")
 
     # profile dump
-    for device_id in t3k_device_mesh.get_device_ids():
-        ttnn.DumpDeviceProfiler(t3k_device_mesh.get_device(device_id))
+    for device_id in t3k_mesh_device.get_device_ids():
+        ttnn.DumpDeviceProfiler(t3k_mesh_device.get_device(device_id))
 
     # Decode (Run 1 warmup iteration before running 1 perf iteration)
     generation_start_pos = prefill_seq_len
@@ -269,8 +269,8 @@ def test_mixtral_model_with_prefill_perf(
     decode_warmup_time = profiler.get("e2e_decode_warmup")
 
     # Profiler dump, ready for real run
-    for device_id in t3k_device_mesh.get_device_ids():
-        ttnn.DumpDeviceProfiler(t3k_device_mesh.get_device(device_id))
+    for device_id in t3k_mesh_device.get_device_ids():
+        ttnn.DumpDeviceProfiler(t3k_mesh_device.get_device(device_id))
 
     if not is_ci_env:  # Enable tracy signpost support in local runs only
         signpost("decode perf run")
@@ -297,11 +297,11 @@ def test_mixtral_model_with_prefill_perf(
     )
 
 
-def run_inference_prefill(tt_model, model_args, prefill_seq_len, device_mesh, pt_prefill_input, batch_size):
+def run_inference_prefill(tt_model, model_args, prefill_seq_len, mesh_device, pt_prefill_input, batch_size):
     # Get rotary matrix
     profiler.start("prefill_prepare_rot_matrices")
     rot_mats_prefill = get_prefill_rot_mat(
-        model_args.head_dim, model_args.max_seq_len, device_mesh, seq_len=prefill_seq_len
+        model_args.head_dim, model_args.max_seq_len, mesh_device, seq_len=prefill_seq_len
     )
 
     head_dim = model_args.dim // model_args.n_heads
@@ -310,9 +310,9 @@ def run_inference_prefill(tt_model, model_args, prefill_seq_len, device_mesh, pt
         transformation_mat_torch,
         dtype=ttnn.bfloat16,
         layout=ttnn.TILE_LAYOUT,
-        device=device_mesh,
+        device=mesh_device,
         memory_config=ttnn.DRAM_MEMORY_CONFIG,
-        mesh_mapper=ReplicateTensorToMesh(device_mesh),
+        mesh_mapper=ReplicateTensorToMesh(mesh_device),
     )
     profiler.end("prefill_prepare_rot_matrices")
 
@@ -321,7 +321,7 @@ def run_inference_prefill(tt_model, model_args, prefill_seq_len, device_mesh, pt
         profiler.start(f"e2e_prefill_prepare_inputs_{batch_id}")
         prefill_input, attn_mask, _ = prepare_inputs_ttnn_prefill(
             pt_prefill_input[batch_id],
-            device_mesh,
+            mesh_device,
         )
         profiler.end(f"e2e_prefill_prepare_inputs_{batch_id}")
 
@@ -340,7 +340,7 @@ def run_inference_prefill(tt_model, model_args, prefill_seq_len, device_mesh, pt
 
         # Device sync to get proper e2e timing
         profiler.start(f"e2e_prefill_inference_sync_{batch_id}")
-        devices = device_mesh.get_devices()
+        devices = mesh_device.get_devices()
         for device in devices:
             ttnn.synchronize_device(device)
         profiler.end(f"e2e_prefill_inference_sync_{batch_id}")
@@ -366,7 +366,7 @@ def run_inference_decode(tt_model, embd, encoded_prompts, generation_start_pos, 
             tt_model.args.dim,
             start_pos,
             tt_model.args,
-            tt_model.device_mesh,
+            tt_model.mesh_device,
         )
         profiler.end(f"Decode_prepare_inputs_{i}")
 
@@ -379,7 +379,7 @@ def run_inference_decode(tt_model, embd, encoded_prompts, generation_start_pos, 
         # Convert ttnn tensor to torch tensor
         profiler.start(f"python_wait_for_inference_out_{i}")
         tt_output_torch = (
-            ttnn.to_torch(tt_out, mesh_composer=ConcatMeshToTensor(tt_model.device_mesh, dim=0))[0]
+            ttnn.to_torch(tt_out, mesh_composer=ConcatMeshToTensor(tt_model.mesh_device, dim=0))[0]
             .squeeze(1)
             .view(32, seqlen, -1)
             .detach()

--- a/models/demos/t3000/mixtral8x7b/tests/test_mixtral_perf_benchmark.py
+++ b/models/demos/t3000/mixtral8x7b/tests/test_mixtral_perf_benchmark.py
@@ -46,7 +46,7 @@ class Emb(torch.nn.Module):
     ),
 )
 def test_mixtral_model_perf(
-    t3k_device_mesh,
+    t3k_mesh_device,
     generation_start_pos,
     expected_compile_time,
     expected_inference_time,
@@ -54,8 +54,8 @@ def test_mixtral_model_perf(
     reset_seeds,
     is_ci_env,
 ):
-    for device in t3k_device_mesh.get_device_ids():
-        t3k_device_mesh.get_device(device).enable_async(True)
+    for device in t3k_mesh_device.get_device_ids():
+        t3k_mesh_device.get_device(device).enable_async(True)
 
     if not is_ci_env:  # Enable tracy signpost support in local runs only
         from tracy import signpost
@@ -63,7 +63,7 @@ def test_mixtral_model_perf(
     dtype = ttnn.bfloat8_b
 
     # Can use dummy_weights=True correctness is not tested, but it is much slower
-    model_args = TtModelArgs(t3k_device_mesh.get_device(0), dummy_weights=False)
+    model_args = TtModelArgs(t3k_mesh_device.get_device(0), dummy_weights=False)
     model_args.n_layers = 32
 
     profiler = BenchmarkProfiler()
@@ -88,7 +88,7 @@ def test_mixtral_model_perf(
     profiler.start("Mixtral_model_setup")
     # Load TTNN model
     tt_model = TtTransformer(
-        device_mesh=t3k_device_mesh,
+        mesh_device=t3k_mesh_device,
         state_dict=state_dict,
         args=model_args,
         layers=list(range(model_args.n_layers)),
@@ -149,7 +149,7 @@ def test_mixtral_model_perf(
     ],
 )
 def test_mixtral_model_with_prefill_perf(
-    t3k_device_mesh,
+    t3k_mesh_device,
     prefill_seqlen,
     target_compile_t,
     target_inference_t,
@@ -160,8 +160,8 @@ def test_mixtral_model_with_prefill_perf(
     reset_seeds,
     is_ci_env,
 ):
-    for device in t3k_device_mesh.get_device_ids():
-        t3k_device_mesh.get_device(device).enable_async(True)
+    for device in t3k_mesh_device.get_device_ids():
+        t3k_mesh_device.get_device(device).enable_async(True)
 
     if not is_ci_env:  # Enable tracy signpost support in local runs only
         from tracy import signpost
@@ -170,7 +170,7 @@ def test_mixtral_model_with_prefill_perf(
     batch_size = 32
 
     # Can use dummy_weights=True correctness is not tested, but it is much slower
-    model_args = TtModelArgs(t3k_device_mesh.get_device(0), dummy_weights=False)
+    model_args = TtModelArgs(t3k_mesh_device.get_device(0), dummy_weights=False)
     model_args.n_layers = 32
 
     profiler = BenchmarkProfiler()
@@ -202,7 +202,7 @@ def test_mixtral_model_with_prefill_perf(
         input_mask_pt,
         prefill_seq_len,
         encoded_prompts,
-    ) = preprocess_inputs_prefill(prompts, tokenizer, model_args, dtype, False, t3k_device_mesh)
+    ) = preprocess_inputs_prefill(prompts, tokenizer, model_args, dtype, False, t3k_mesh_device)
     profiler.end("preprocessing_inputs")
 
     assert (
@@ -215,7 +215,7 @@ def test_mixtral_model_with_prefill_perf(
     profiler.start("Mixtral_model_setup")
     # Load TTNN model
     tt_model = TtTransformer(
-        device_mesh=t3k_device_mesh,
+        mesh_device=t3k_mesh_device,
         state_dict=state_dict,
         args=model_args,
         layers=list(range(model_args.n_layers)),
@@ -228,7 +228,7 @@ def test_mixtral_model_with_prefill_perf(
     if not is_ci_env:  # Enable tracy signpost support in local runs only
         signpost("prefill warmup")
     profiler.start(f"compile_prefill")
-    run_inference_prefill(profiler, tt_model, model_args, prefill_seq_len, t3k_device_mesh, pt_prefill_input, 1)
+    run_inference_prefill(profiler, tt_model, model_args, prefill_seq_len, t3k_mesh_device, pt_prefill_input, 1)
     profiler.end(f"compile_prefill")
     prefill_warmup_time = profiler.get_duration("compile_prefill")
 
@@ -237,7 +237,7 @@ def test_mixtral_model_with_prefill_perf(
     profiler.start(f"inference_prefill")
     # Prefill a single user, as this will be the real-world usage
     prefill_out = run_inference_prefill(
-        profiler, tt_model, model_args, prefill_seq_len, t3k_device_mesh, pt_prefill_input, 1
+        profiler, tt_model, model_args, prefill_seq_len, t3k_mesh_device, pt_prefill_input, 1
     )
     profiler.end(f"inference_prefill")
     prefill_time = profiler.get_duration("inference_prefill")
@@ -315,11 +315,11 @@ def test_mixtral_model_with_prefill_perf(
     )
 
 
-def run_inference_prefill(profiler, tt_model, model_args, prefill_seq_len, device_mesh, pt_prefill_input, batch_size):
+def run_inference_prefill(profiler, tt_model, model_args, prefill_seq_len, mesh_device, pt_prefill_input, batch_size):
     # Get rotary matrix
     profiler.start("prefill_prepare_rot_matrices")
     rot_mats_prefill = get_prefill_rot_mat(
-        model_args.head_dim, model_args.max_seq_len, device_mesh, seq_len=prefill_seq_len
+        model_args.head_dim, model_args.max_seq_len, mesh_device, seq_len=prefill_seq_len
     )
 
     head_dim = model_args.dim // model_args.n_heads
@@ -328,9 +328,9 @@ def run_inference_prefill(profiler, tt_model, model_args, prefill_seq_len, devic
         transformation_mat_torch,
         dtype=ttnn.bfloat16,
         layout=ttnn.TILE_LAYOUT,
-        device=device_mesh,
+        device=mesh_device,
         memory_config=ttnn.DRAM_MEMORY_CONFIG,
-        mesh_mapper=ReplicateTensorToMesh(device_mesh),
+        mesh_mapper=ReplicateTensorToMesh(mesh_device),
     )
     profiler.end("prefill_prepare_rot_matrices")
 
@@ -339,7 +339,7 @@ def run_inference_prefill(profiler, tt_model, model_args, prefill_seq_len, devic
         profiler.start(f"e2e_prefill_prepare_inputs_{batch_id}")
         prefill_input, attn_mask, _ = prepare_inputs_ttnn_prefill(
             pt_prefill_input[batch_id],
-            device_mesh,
+            mesh_device,
         )
         profiler.end(f"e2e_prefill_prepare_inputs_{batch_id}")
 
@@ -358,7 +358,7 @@ def run_inference_prefill(profiler, tt_model, model_args, prefill_seq_len, devic
 
         # Device sync to get proper e2e timing
         profiler.start(f"e2e_prefill_inference_get_output_{batch_id}")
-        devices = device_mesh.get_devices()
+        devices = mesh_device.get_devices()
         for device in devices:
             ttnn.synchronize_device(device)
         profiler.end(f"e2e_prefill_inference_get_output_{batch_id}")
@@ -384,7 +384,7 @@ def run_inference_decode(profiler, tt_model, embd, encoded_prompts, generation_s
             tt_model.args.dim,
             start_pos,
             tt_model.args,
-            tt_model.device_mesh,
+            tt_model.mesh_device,
         )
         profiler.end(f"Decode_prepare_inputs_{i}")
 
@@ -397,7 +397,7 @@ def run_inference_decode(profiler, tt_model, embd, encoded_prompts, generation_s
         # Convert ttnn tensor to torch tensor
         profiler.start(f"python_wait_for_inference_out_{i}")
         tt_output_torch = (
-            ttnn.to_torch(tt_out, mesh_composer=ConcatMeshToTensor(tt_model.device_mesh, dim=0))[0]
+            ttnn.to_torch(tt_out, mesh_composer=ConcatMeshToTensor(tt_model.mesh_device, dim=0))[0]
             .squeeze(1)
             .view(32, seqlen, -1)
             .detach()

--- a/models/demos/t3000/mixtral8x7b/tests/test_mixtral_perplexity.py
+++ b/models/demos/t3000/mixtral8x7b/tests/test_mixtral_perplexity.py
@@ -43,7 +43,7 @@ class Emb(torch.nn.Module):
 
 @torch.no_grad()
 def run_test_perplexity(
-    device_mesh,
+    mesh_device,
     batch_size,
     llm_mode,
     max_seq_len,
@@ -70,7 +70,7 @@ def run_test_perplexity(
         ref_running_nll, ref_running_top1_acc, ref_running_top5_acc = 0.0, 0.0, 0.0
 
     # Load model args, weights, and tokenizer
-    model_args = TtModelArgs(device_mesh.get_device(0), instruct=instruct_mode)
+    model_args = TtModelArgs(mesh_device.get_device(0), instruct=instruct_mode)
     tokenizer = Tokenizer(model_args.tokenizer_path)
     if instruct_mode:
         tokenizer._model.pad_id = tokenizer._model.eos_id
@@ -104,7 +104,7 @@ def run_test_perplexity(
     # Load TTNN mixtral model
     logger.info("Loading weights to device...")
     tt_model = TtTransformer(
-        device_mesh=device_mesh,
+        mesh_device=mesh_device,
         state_dict=state_dict,
         args=model_args,
         layers=list(range(model_args.n_layers)),
@@ -119,7 +119,7 @@ def run_test_perplexity(
 
     if not embed_on_host:
         tt_embds = TtMixtralEmbedding(
-            device_mesh=device_mesh,
+            mesh_device=mesh_device,
             args=model_args,
             weight_cache_path=model_args.weight_cache_path(dtype),
             state_dict=state_dict,
@@ -131,13 +131,13 @@ def run_test_perplexity(
     # Prepare inputs for decode mode (rotary embeddings, attention mask, padding)
     current_rot_mat, rot_matrix = get_single_rot_mat(
         model_args.head_dim,
-        tt_model.device_mesh,
+        tt_model.mesh_device,
     )
 
     generation_start_pos = 0
 
     cache_attention(
-        device_mesh,
+        mesh_device,
         state_dict,
         model_args,
         current_rot_mat,
@@ -168,7 +168,7 @@ def run_test_perplexity(
                         model_args.dim,
                         start_pos,
                         model_args,
-                        tt_model.device_mesh,
+                        tt_model.mesh_device,
                     )
                 else:
                     assert "Only embedding on host is supported for now!"
@@ -179,7 +179,7 @@ def run_test_perplexity(
                 if embed_on_host:
                     # Convert ttnn tensor to torch tensor
                     pt_logits = (
-                        ttnn.to_torch(tt_logits, mesh_composer=ConcatMeshToTensor(device_mesh, dim=0))[0]
+                        ttnn.to_torch(tt_logits, mesh_composer=ConcatMeshToTensor(mesh_device, dim=0))[0]
                         .squeeze(1)
                         .view(32, seqlen, -1)
                         .detach()
@@ -269,7 +269,7 @@ def run_test_perplexity(
     ],
 )
 def test_mixtral_perplexity(
-    t3k_device_mesh,
+    t3k_mesh_device,
     use_program_cache,
     reset_seeds,
     llm_mode,
@@ -283,11 +283,11 @@ def test_mixtral_perplexity(
         llm_mode == "decode"
     ), "Only decode mode is supported for now"  # TODO Add prefill support when it reaches main
 
-    for device in t3k_device_mesh.get_device_ids():
-        t3k_device_mesh.get_device(device).enable_async(True)
+    for device in t3k_mesh_device.get_device_ids():
+        t3k_mesh_device.get_device(device).enable_async(True)
 
     return run_test_perplexity(
-        device_mesh=t3k_device_mesh,
+        mesh_device=t3k_mesh_device,
         batch_size=32,
         llm_mode=llm_mode,
         max_seq_len=max_seq_len,

--- a/models/demos/t3000/mixtral8x7b/tests/test_mixtral_topk.py
+++ b/models/demos/t3000/mixtral8x7b/tests/test_mixtral_topk.py
@@ -40,10 +40,10 @@ class Emb(torch.nn.Module):
     ),
 )
 def test_mixtral_model_inference(
-    t3k_device_mesh, use_program_cache, reset_seeds, iterations, expected_top1, expected_top5
+    t3k_mesh_device, use_program_cache, reset_seeds, iterations, expected_top1, expected_top5
 ):
-    for device in t3k_device_mesh.get_device_ids():
-        t3k_device_mesh.get_device(device).enable_async(True)
+    for device in t3k_mesh_device.get_device_ids():
+        t3k_mesh_device.get_device(device).enable_async(True)
 
     dtype = ttnn.bfloat8_b
     seqlen = 1  # Generating one token per user at a time
@@ -53,14 +53,14 @@ def test_mixtral_model_inference(
     running_top5 = 0
     inputs_file = "models/demos/t3000/mixtral8x7b/demo/input_data.json"
 
-    model_args = TtModelArgs(t3k_device_mesh.get_device(0))
+    model_args = TtModelArgs(t3k_mesh_device.get_device(0))
     state_dict = model_args.load_state_dict()
     tokenizer = Tokenizer(model_args.tokenizer_path)
 
     # Prepare inputs
     input_prompts = load_inputs(inputs_file, 32)
     input_tokens_tt, max_prompt_len, input_mask, input_tokens_pt, input_mask_pt = preprocess_inputs(
-        input_prompts, tokenizer, model_args, dtype, False, t3k_device_mesh
+        input_prompts, tokenizer, model_args, dtype, False, t3k_mesh_device
     )
 
     # Load reference model
@@ -74,7 +74,7 @@ def test_mixtral_model_inference(
 
     # Load TTNN model
     tt_model = TtTransformer(
-        device_mesh=t3k_device_mesh,
+        mesh_device=t3k_mesh_device,
         state_dict=state_dict,
         args=model_args,
         layers=list(range(model_args.n_layers)),
@@ -96,14 +96,14 @@ def test_mixtral_model_inference(
             model_args.dim,
             start_pos,
             model_args,
-            tt_model.device_mesh,
+            tt_model.mesh_device,
         )
 
         # Run TT model
         tt_out = tt_model(decode_input, start_pos, current_pos)
         # Convert ttnn tensor to torch tensor
         tt_output_torch = (
-            ttnn.to_torch(tt_out, mesh_composer=ttnn.ConcatMeshToTensor(t3k_device_mesh, dim=0))[0]
+            ttnn.to_torch(tt_out, mesh_composer=ttnn.ConcatMeshToTensor(t3k_mesh_device, dim=0))[0]
             .squeeze(1)
             .view(32, seqlen, -1)
             .detach()

--- a/models/demos/t3000/mixtral8x7b/tt/mixtral_attention.py
+++ b/models/demos/t3000/mixtral8x7b/tt/mixtral_attention.py
@@ -10,12 +10,12 @@ from models.common.lightweightmodule import LightweightModule
 
 
 class TtMixtralAttention(LightweightModule):
-    def __init__(self, device_mesh, state_dict, args, layer_num, dtype):
+    def __init__(self, mesh_device, state_dict, args, layer_num, dtype):
         super().__init__()
         self.num_devices = 8
         self.tile_size = 32
         self.state_dict = state_dict
-        self.device_mesh = device_mesh
+        self.mesh_device = mesh_device
         self.model_args = args
 
         self.hidden_size = args.dim
@@ -73,8 +73,8 @@ class TtMixtralAttention(LightweightModule):
             )
             .unsqueeze(0)
             .unsqueeze(0),
-            device=self.device_mesh,
-            mesh_mapper=ShardTensorToMesh(self.device_mesh, dim=-1),
+            device=self.mesh_device,
+            mesh_mapper=ShardTensorToMesh(self.mesh_device, dim=-1),
             dtype=self.dtype,
             memory_config=self.model_config["ATTN_WEIGHTS_MEMCFG"],
             layout=self.model_config["ATTN_W_LAYOUT_TILE"],
@@ -89,8 +89,8 @@ class TtMixtralAttention(LightweightModule):
             )
             .unsqueeze(0)
             .unsqueeze(0),
-            device=self.device_mesh,
-            mesh_mapper=ShardTensorToMesh(self.device_mesh, dim=-2),
+            device=self.mesh_device,
+            mesh_mapper=ShardTensorToMesh(self.mesh_device, dim=-2),
             dtype=self.dtype,
             memory_config=self.model_config["ATTN_WEIGHTS_MEMCFG"],
             layout=self.model_config["ATTN_W_LAYOUT_TILE"],
@@ -117,8 +117,8 @@ class TtMixtralAttention(LightweightModule):
         self.layer_past = [
             ttnn.as_tensor(
                 lp,
-                device=self.device_mesh,
-                mesh_mapper=ShardTensorToMesh(self.device_mesh, dim=0),
+                device=self.mesh_device,
+                mesh_mapper=ShardTensorToMesh(self.mesh_device, dim=0),
                 dtype=ttnn.bfloat8_b,
                 layout=self.model_config["ATTN_W_LAYOUT_TILE"],
                 memory_config=self.model_config["ATTN_CACHE_WEIGHTS_MEMCFG"],
@@ -134,8 +134,8 @@ class TtMixtralAttention(LightweightModule):
             reduce_mask_torch[:, :, i, range(i, self.tile_size * 8, self.tile_size)] = 1
         self.reduce_mask = ttnn.from_torch(
             reduce_mask_torch,
-            device=self.device_mesh,
-            mesh_mapper=ReplicateTensorToMesh(self.device_mesh),
+            device=self.mesh_device,
+            mesh_mapper=ReplicateTensorToMesh(self.mesh_device),
             dtype=ttnn.bfloat8_b,
             layout=ttnn.TILE_LAYOUT,
         )

--- a/models/demos/t3000/mixtral8x7b/tt/mixtral_decoder.py
+++ b/models/demos/t3000/mixtral8x7b/tt/mixtral_decoder.py
@@ -12,7 +12,7 @@ from models.common.lightweightmodule import LightweightModule
 class TtTransformerBlock(LightweightModule):
     def __init__(
         self,
-        device_mesh,
+        mesh_device,
         state_dict,
         args,
         layer_num,
@@ -21,13 +21,13 @@ class TtTransformerBlock(LightweightModule):
         super().__init__()
 
         self.state_dict = state_dict
-        self.device_mesh = device_mesh
+        self.mesh_device = mesh_device
 
         self.args = args
 
         self.layer_num = layer_num
         self.attention = TtMixtralAttention(
-            device_mesh=device_mesh,
+            mesh_device=mesh_device,
             state_dict=state_dict,
             args=args,
             layer_num=layer_num,
@@ -35,10 +35,10 @@ class TtTransformerBlock(LightweightModule):
         )
 
         self.feed_forward = TtMoeLayer(
-            device_mesh=device_mesh,
+            mesh_device=mesh_device,
             state_dict=state_dict,
             experts=TtMixtralMLP(
-                device_mesh=device_mesh,
+                mesh_device=mesh_device,
                 state_dict=state_dict,
                 args=args,
                 layer_num=layer_num,
@@ -53,7 +53,7 @@ class TtTransformerBlock(LightweightModule):
             dtype=dtype,
         )
         self.attention_norm = RMSNorm(
-            device=device_mesh,
+            device=mesh_device,
             dim=args.dim,
             state_dict=state_dict,
             layer_num=layer_num,
@@ -62,7 +62,7 @@ class TtTransformerBlock(LightweightModule):
         )
 
         self.ffn_norm = RMSNorm(
-            device=device_mesh,
+            device=mesh_device,
             dim=args.dim,
             state_dict=state_dict,
             layer_num=layer_num,

--- a/models/demos/t3000/mixtral8x7b/tt/mixtral_mlp.py
+++ b/models/demos/t3000/mixtral8x7b/tt/mixtral_mlp.py
@@ -9,11 +9,11 @@ from models.common.lightweightmodule import LightweightModule
 
 
 class TtMixtralMLP(LightweightModule):
-    def __init__(self, device_mesh, state_dict, args, layer_num, dtypes):
+    def __init__(self, mesh_device, state_dict, args, layer_num, dtypes):
         super().__init__()
 
         self.state_dict = state_dict
-        self.device_mesh = device_mesh
+        self.mesh_device = mesh_device
         self.dtypes = dtypes
         self.model_args = args
         self.model_config = args.get_model_config()
@@ -35,8 +35,8 @@ class TtMixtralMLP(LightweightModule):
         as_tensor = lambda name: ttnn.as_tensor(
             torch_weight(name),
             dtype=dtypes[name],
-            device=self.device_mesh,
-            mesh_mapper=ShardTensorToMesh(self.device_mesh, dim=0),
+            device=self.mesh_device,
+            mesh_mapper=ShardTensorToMesh(self.mesh_device, dim=0),
             layout=self.model_config["MLP_W_LAYOUT_TILE"],
             memory_config=self.model_config["MLP_WEIGHTS_MEMCFG"],
             cache_file_name=cache_name(name),

--- a/models/demos/t3000/mixtral8x7b/tt/mixtral_model.py
+++ b/models/demos/t3000/mixtral8x7b/tt/mixtral_model.py
@@ -12,19 +12,19 @@ import torch
 
 
 class TtTransformer(LightweightModule):
-    def __init__(self, device_mesh, state_dict, args, dtype, layers, start_pos=0, rotary_on_host=False):
+    def __init__(self, mesh_device, state_dict, args, dtype, layers, start_pos=0, rotary_on_host=False):
         super().__init__()
         self.args = args
         self.vocab_size = args.vocab_size
         self.n_layers = args.n_layers
-        self.device_mesh = device_mesh
+        self.mesh_device = mesh_device
         self.model_config = args.get_model_config()
         self.rotary_on_host = rotary_on_host
         assert self.vocab_size > 0
 
         self.layers = [
             TtTransformerBlock(
-                device_mesh=device_mesh,
+                mesh_device=mesh_device,
                 state_dict=state_dict,
                 args=args,
                 dtype=dtype,
@@ -33,7 +33,7 @@ class TtTransformer(LightweightModule):
             for i in layers
         ]
         self.norm = RMSNorm(
-            device=device_mesh,
+            device=mesh_device,
             dim=args.dim,
             state_dict=state_dict,
             layer_num=None,
@@ -50,12 +50,12 @@ class TtTransformer(LightweightModule):
 
         self.output_weight = ttnn.as_tensor(
             self.state_dict["output.weight"].permute(1, 0).unsqueeze(0).unsqueeze(0),
-            device=device_mesh,
+            device=mesh_device,
             layout=self.model_config["OUTPUT_W_LAYOUT_TILE"],
             dtype=dtype,
             memory_config=self.model_config["OUTPUT_WEIGHTS_MEMCFG"],
             cache_file_name=output_cache_name,
-            mesh_mapper=ttnn.ReplicateTensorToMesh(device_mesh),
+            mesh_mapper=ttnn.ReplicateTensorToMesh(mesh_device),
         )
 
         self.compute_kernel = self.args.get_compute_kernel_config()
@@ -63,7 +63,7 @@ class TtTransformer(LightweightModule):
         if self.rotary_on_host:
             self.current_rot_mat, self.rot_matrix = get_single_rot_mat_torch(self.args.head_dim, start_pos)
         else:
-            self.current_rot_mat, self.rot_matrix = get_single_rot_mat(self.args.head_dim, device_mesh, start_pos)
+            self.current_rot_mat, self.rot_matrix = get_single_rot_mat(self.args.head_dim, mesh_device, start_pos)
 
     def forward(
         self,
@@ -81,10 +81,10 @@ class TtTransformer(LightweightModule):
                 if self.rotary_on_host:
                     rot_mats = ttnn.from_torch(
                         self.current_rot_mat,  # 1,1,head_dim,head_dim
-                        device=self.device_mesh,
+                        device=self.mesh_device,
                         dtype=ttnn.bfloat16,
                         layout=ttnn.TILE_LAYOUT,
-                        mesh_mapper=ttnn.ReplicateTensorToMesh(self.device_mesh),
+                        mesh_mapper=ttnn.ReplicateTensorToMesh(self.mesh_device),
                     )
                 else:
                     rot_mats = self.current_rot_mat
@@ -113,7 +113,7 @@ class TtTransformer(LightweightModule):
             if (start_pos + 1) % 32 == 0:
                 # generate new rotmat to avoid numerical instability every 32 tokens
                 self.current_rot_mat, self.rot_matrix = get_single_rot_mat(
-                    self.args.head_dim, self.device_mesh, start_pos + 1
+                    self.args.head_dim, self.mesh_device, start_pos + 1
                 )
             else:
                 # assigning to a new variable to explictly deallocate since matmul creates a new buffer for the output

--- a/models/demos/t3000/mixtral8x7b/tt/mixtral_moe.py
+++ b/models/demos/t3000/mixtral8x7b/tt/mixtral_moe.py
@@ -9,9 +9,9 @@ from models.common.lightweightmodule import LightweightModule
 
 
 class TtMoeLayer(LightweightModule):
-    def __init__(self, device_mesh, state_dict, experts, args, layer_num, dtype):
+    def __init__(self, mesh_device, state_dict, experts, args, layer_num, dtype):
         super().__init__()
-        self.device_mesh = device_mesh
+        self.mesh_device = mesh_device
         self.experts = experts
         self.args = args
         self.dtype = dtype
@@ -43,8 +43,8 @@ class TtMoeLayer(LightweightModule):
             layout=self.model_config["GATE_W_LAYOUT_TILE"],
             memory_config=self.model_config["GATE_WEIGHTS_MEMCFG"],
             cache_file_name=cache_name,
-            device=self.device_mesh,
-            mesh_mapper=ShardTensorToMesh(device_mesh, dim=1),
+            device=self.mesh_device,
+            mesh_mapper=ShardTensorToMesh(mesh_device, dim=1),
         )
 
         self.tile_size = 32
@@ -56,8 +56,8 @@ class TtMoeLayer(LightweightModule):
             top8_mask,
             dtype=ttnn.bfloat16,
             layout=ttnn.TILE_LAYOUT,
-            device=device_mesh,
-            mesh_mapper=ReplicateTensorToMesh(device_mesh),
+            device=mesh_device,
+            mesh_mapper=ReplicateTensorToMesh(mesh_device),
         )
         self.top8_mask_11B_64 = ttnn.sum(self.top8_mask_11B_64, dim=2)
 
@@ -67,8 +67,8 @@ class TtMoeLayer(LightweightModule):
             top2_mask,
             dtype=ttnn.bfloat16,
             layout=ttnn.TILE_LAYOUT,
-            device=device_mesh,
-            mesh_mapper=ReplicateTensorToMesh(device_mesh),
+            device=mesh_device,
+            mesh_mapper=ReplicateTensorToMesh(mesh_device),
         )
         self.top2_mask_11BB = ttnn.sum(self.top2_mask_11BB, dim=2)
 
@@ -79,8 +79,8 @@ class TtMoeLayer(LightweightModule):
             reduce_mask_torch,
             dtype=ttnn.bfloat8_b,
             layout=ttnn.TILE_LAYOUT,
-            device=self.device_mesh,
-            mesh_mapper=ReplicateTensorToMesh(device_mesh),
+            device=self.mesh_device,
+            mesh_mapper=ReplicateTensorToMesh(mesh_device),
         )
 
     def forward(self, inputs, mode="decode"):

--- a/models/demos/tg/falcon7b/demo_tg.py
+++ b/models/demos/tg/falcon7b/demo_tg.py
@@ -34,7 +34,7 @@ from models.utility_functions import is_wormhole_b0
 )
 @pytest.mark.parametrize("enable_async_mode", (True,), indirect=True)  # Option to run Falcon in Async mode
 @pytest.mark.parametrize(
-    "device_mesh",
+    "mesh_device",
     (
         (4, 4),
         (8, 4),
@@ -51,13 +51,13 @@ def test_demo_multichip(
     user_input,
     model_location_generator,
     get_tt_cache_path,
-    device_mesh,
+    mesh_device,
     use_program_cache,
     enable_async_mode,
     is_ci_env,
 ):
     assert is_wormhole_b0(), "Multi-chip is only supported for Wormhole B0"
-    num_devices = device_mesh.get_num_devices()
+    num_devices = mesh_device.get_num_devices()
 
     if is_ci_env:
         if num_devices != 32 or (not expected_greedy_output_path and not expected_perf_metrics):
@@ -84,7 +84,7 @@ def test_demo_multichip(
         model_config_strs_prefill_decode=["BFLOAT16-DRAM", "BFLOAT16-L1_SHARDED"],
         model_location_generator=model_location_generator,
         get_tt_cache_path=get_tt_cache_path,
-        device_mesh=device_mesh,
+        mesh_device=mesh_device,
         perf_mode=perf_mode,
         greedy_sampling=greedy_sampling,
         expected_perf_metrics=expected_perf_metrics,

--- a/models/demos/tg/llama3_70b/demo/demo.py
+++ b/models/demos/tg/llama3_70b/demo/demo.py
@@ -19,7 +19,7 @@ from models.demos.t3000.llama2_70b.tt.llama_common import load_llama_state_dict
 from models.demos.t3000.llama2_70b.reference.llama.llama.tokenizer3 import ChatFormat
 from models.demos.t3000.llama2_70b.tt.llama_common import (
     setup_llama_env,
-    check_device_mesh,
+    check_mesh_device,
     string_similarity_score,
 )
 
@@ -39,7 +39,7 @@ class ModelArgs:
 
 @dataclass
 class TTArgs:
-    device_mesh: object = None
+    mesh_device: object = None
     cluster_shape: tuple = (4, 8)
     n_devices: int = 32
     emulated: bool = False
@@ -350,7 +350,7 @@ def top_pk_logits_efficient(logits, p=0.9, k=10, temperature=1.0, return_probs=F
 @pytest.mark.timeout(240000)
 @skip_for_grayskull("Requires eth connected devices to run")
 @pytest.mark.parametrize(
-    "cluster_shape, device_mesh", [pytest.param((4, 8), (8, 4), id="4x8_grid")], indirect=["device_mesh"]
+    "cluster_shape, mesh_device", [pytest.param((4, 8), (8, 4), id="4x8_grid")], indirect=["mesh_device"]
 )
 @pytest.mark.parametrize(
     "llama_version",
@@ -417,7 +417,7 @@ def test_LlamaModel_demo(
     temperature,
     chat,
     # TT args
-    device_mesh,
+    mesh_device,
     cluster_shape,
     n_devices,
     decode_only,
@@ -434,10 +434,10 @@ def test_LlamaModel_demo(
         llama_version=llama_version,
     )
 
-    check_device_mesh(device_mesh, model_config)
+    check_mesh_device(mesh_device, model_config)
 
-    for i in device_mesh.get_device_ids():
-        device = device_mesh.get_device(i)
+    for i in mesh_device.get_device_ids():
+        device = mesh_device.get_device(i)
         device.enable_async(True)
 
     args = construct_arg(
@@ -456,7 +456,7 @@ def test_LlamaModel_demo(
         top_k=top_k,
         temperature=temperature,
         chat=chat,
-        device_mesh=device_mesh,
+        mesh_device=mesh_device,
         cluster_shape=cluster_shape,
         n_devices=n_devices,
         cache_path=cache_path,

--- a/models/demos/tg/llama3_70b/tests/test_llama_demo_nightly.py
+++ b/models/demos/tg/llama3_70b/tests/test_llama_demo_nightly.py
@@ -14,7 +14,7 @@ from loguru import logger
 from models.utility_functions import skip_for_grayskull
 from models.demos.t3000.llama2_70b.tt.llama_common import (
     setup_llama_env,
-    check_device_mesh,
+    check_mesh_device,
 )
 from models.demos.tg.llama3_70b.demo.demo import run_demo, construct_arg
 
@@ -22,7 +22,7 @@ from models.demos.tg.llama3_70b.demo.demo import run_demo, construct_arg
 @pytest.mark.timeout(240000)
 @skip_for_grayskull("Requires eth connected devices to run")
 @pytest.mark.parametrize(
-    "cluster_shape, device_mesh", [pytest.param((4, 8), (8, 4), id="4x8_grid")], indirect=["device_mesh"]
+    "cluster_shape, mesh_device", [pytest.param((4, 8), (8, 4), id="4x8_grid")], indirect=["mesh_device"]
 )
 @pytest.mark.parametrize(
     "llama_version",
@@ -75,7 +75,7 @@ def test_llama3_tg_nightly_demo(
     temperature,
     chat,
     # TT args
-    device_mesh,
+    mesh_device,
     cluster_shape,
     n_devices,
     decode_only,
@@ -92,11 +92,11 @@ def test_llama3_tg_nightly_demo(
         llama_version=llama_version,
     )
 
-    check_device_mesh(device_mesh, model_config)
+    check_mesh_device(mesh_device, model_config)
 
     # TODO: Renable when issue #11089 is resolved
-    for i in device_mesh.get_device_ids():
-        device = device_mesh.get_device(i)
+    for i in mesh_device.get_device_ids():
+        device = mesh_device.get_device(i)
         device.enable_async(True)
 
     args = construct_arg(
@@ -115,7 +115,7 @@ def test_llama3_tg_nightly_demo(
         top_k=top_k,
         temperature=temperature,
         chat=chat,
-        device_mesh=device_mesh,
+        mesh_device=mesh_device,
         cluster_shape=cluster_shape,
         n_devices=n_devices,
         cache_path=cache_path,

--- a/models/demos/tg/llama3_70b/tests/test_llama_mlp_galaxy.py
+++ b/models/demos/tg/llama3_70b/tests/test_llama_mlp_galaxy.py
@@ -13,7 +13,7 @@ from models.demos.tg.llama3_70b.tt.llama_mlp_galaxy import TtLlamaMLP_galaxy
 from models.utility_functions import skip_for_grayskull
 from models.demos.t3000.llama2_70b.tt.llama_common import (
     setup_llama_env,
-    check_device_mesh,
+    check_mesh_device,
     MAX_SEQ_LEN,
     BASE_URL,
     UNIT_TEST_N_LAYER,
@@ -57,10 +57,10 @@ def tt_llama_mlp_prepare_inputs(llama_mlp_model, x):
             x,
             dtype=ttnn.bfloat16,
             layout=ttnn.TILE_LAYOUT,
-            device=llama_mlp_model.device_mesh,
+            device=llama_mlp_model.mesh_device,
             memory_config=act_mem_config,
             mesh_mapper=ShardTensor2dMesh(
-                llama_mlp_model.device_mesh, dims=(3, None), cluster_shape=llama_mlp_model.cluster_shape
+                llama_mlp_model.mesh_device, dims=(3, None), cluster_shape=llama_mlp_model.cluster_shape
             ),
         )
     elif llama_mlp_model.model_config["LLM_MODE"] == "prefill":
@@ -68,10 +68,10 @@ def tt_llama_mlp_prepare_inputs(llama_mlp_model, x):
             x,
             dtype=ttnn.bfloat16,
             layout=ttnn.TILE_LAYOUT,
-            device=llama_mlp_model.device_mesh,
+            device=llama_mlp_model.mesh_device,
             memory_config=ttnn.DRAM_MEMORY_CONFIG,
             mesh_mapper=ShardTensor2dMesh(
-                llama_mlp_model.device_mesh, dims=(3, None), cluster_shape=llama_mlp_model.cluster_shape
+                llama_mlp_model.mesh_device, dims=(3, None), cluster_shape=llama_mlp_model.cluster_shape
             ),
         )
 
@@ -79,7 +79,7 @@ def tt_llama_mlp_prepare_inputs(llama_mlp_model, x):
 
 
 def run_test_LlamaMLP_inference(
-    device_mesh,
+    mesh_device,
     cluster_shape,
     batch,
     seq_len,
@@ -126,7 +126,7 @@ def run_test_LlamaMLP_inference(
 
     # TT hardware execution -------------------------------------------------------------
     tt_LlamaMLP_model = TtLlamaMLP_galaxy(
-        device_mesh,
+        mesh_device,
         cluster_shape,
         state_dict,
         BASE_URL,
@@ -141,7 +141,7 @@ def run_test_LlamaMLP_inference(
     tt_out = tt_LlamaMLP_model(tt_mlp_input)
 
     tt_out = ttnn.to_torch(
-        tt_out, mesh_composer=ConcatMesh2DToTensor(device_mesh, dims=(3, 1), cluster_shape=cluster_shape)
+        tt_out, mesh_composer=ConcatMesh2DToTensor(mesh_device, dims=(3, 1), cluster_shape=cluster_shape)
     )
     tt_out = tt_out[:, 0:1, :, :]
 
@@ -158,7 +158,7 @@ def run_test_LlamaMLP_inference(
 
 @skip_for_grayskull("Requires eth connected devices to run")
 @pytest.mark.parametrize(
-    "cluster_shape, device_mesh", [pytest.param((4, 8), (8, 4), id="4x8_grid")], indirect=["device_mesh"]
+    "cluster_shape, mesh_device", [pytest.param((4, 8), (8, 4), id="4x8_grid")], indirect=["mesh_device"]
 )
 @pytest.mark.parametrize(
     "llama_version",
@@ -184,7 +184,7 @@ def test_LlamaMLP_inference(
     batch,
     seq_len,
     pcc,
-    device_mesh,
+    mesh_device,
     max_batch_size,
     max_context_len,
     llama_version,
@@ -208,9 +208,9 @@ def test_LlamaMLP_inference(
         max_context_len=max_context_len,
     )
 
-    check_device_mesh(device_mesh, model_config)
+    check_mesh_device(mesh_device, model_config)
     run_test_LlamaMLP_inference(
-        device_mesh,
+        mesh_device,
         cluster_shape,
         batch,
         seq_len,

--- a/models/demos/tg/llama3_70b/tests/test_llama_model_galaxy_ci.py
+++ b/models/demos/tg/llama3_70b/tests/test_llama_model_galaxy_ci.py
@@ -5,13 +5,13 @@
 import pytest
 
 from models.utility_functions import skip_for_grayskull
-from models.demos.t3000.llama2_70b.tt.llama_common import setup_llama_env, check_device_mesh
+from models.demos.t3000.llama2_70b.tt.llama_common import setup_llama_env, check_mesh_device
 from models.demos.tg.llama3_70b.tests.test_llama_model_galaxy import run_test_LlamaModel_inference
 
 
 @skip_for_grayskull("Requires eth connected devices to run")
 @pytest.mark.parametrize(
-    "cluster_shape, device_mesh", [pytest.param((4, 8), (8, 4), id="4x8_grid")], indirect=["device_mesh"]
+    "cluster_shape, mesh_device", [pytest.param((4, 8), (8, 4), id="4x8_grid")], indirect=["mesh_device"]
 )
 @pytest.mark.parametrize(
     "llama_version",
@@ -37,7 +37,7 @@ def test_LlamaModel_inference(
     seq_len,
     pcc,
     n_layers,
-    device_mesh,
+    mesh_device,
     max_batch_size,
     max_context_len,
     llama_version,
@@ -61,10 +61,10 @@ def test_LlamaModel_inference(
         max_context_len=max_context_len,
     )
 
-    check_device_mesh(device_mesh, model_config)
+    check_mesh_device(mesh_device, model_config)
 
     run_test_LlamaModel_inference(
-        device_mesh,
+        mesh_device,
         cluster_shape,
         batch,
         seq_len,

--- a/models/demos/tg/llama3_70b/tt/llama_common.py
+++ b/models/demos/tg/llama3_70b/tt/llama_common.py
@@ -5,12 +5,12 @@
 import ttnn
 
 
-def tt_all_reduce(input_tensor, device_mesh, cluster_axis, dim=0, num_links=2, memory_config=None):
+def tt_all_reduce(input_tensor, mesh_device, cluster_axis, dim=0, num_links=2, memory_config=None):
     # Ensure the input tensor is in the correct memory configuration
     input_tensor = ttnn.to_memory_config(input_tensor, ttnn.DRAM_MEMORY_CONFIG)
 
     gathered_tensor = ttnn.line_all_gather(
-        input_tensor, dim, num_links=num_links, cluster_axis=cluster_axis, device_mesh=device_mesh
+        input_tensor, dim, num_links=num_links, cluster_axis=cluster_axis, mesh_device=mesh_device
     )
     reduced_tensors = ttnn.experimental.fast_reduce_nc(
         gathered_tensor, dims=[dim], output=None, compute_kernel_config=None
@@ -19,10 +19,10 @@ def tt_all_reduce(input_tensor, device_mesh, cluster_axis, dim=0, num_links=2, m
     return reduced_tensors
 
 
-def tt_all_gather(input_tensor, device_mesh, cluster_axis, dim, num_links=2, memory_config=None):
+def tt_all_gather(input_tensor, mesh_device, cluster_axis, dim, num_links=2, memory_config=None):
     # Ensure the input tensor is in the correct memory configuration
     input_tensor = ttnn.to_memory_config(input_tensor, ttnn.DRAM_MEMORY_CONFIG)
 
     return ttnn.line_all_gather(
-        input_tensor, dim, num_links=num_links, cluster_axis=cluster_axis, device_mesh=device_mesh
+        input_tensor, dim, num_links=num_links, cluster_axis=cluster_axis, mesh_device=mesh_device
     )

--- a/models/demos/tg/llama3_70b/tt/llama_decoder_galaxy.py
+++ b/models/demos/tg/llama3_70b/tt/llama_decoder_galaxy.py
@@ -20,7 +20,7 @@ from models.demos.tg.llama3_70b.tt.llama_common import tt_all_gather
 class TtLlamaDecoder_galaxy:
     def __init__(
         self,
-        device_mesh,
+        mesh_device,
         cluster_shape,
         state_dict,
         base_url,
@@ -34,8 +34,8 @@ class TtLlamaDecoder_galaxy:
         super().__init__()
 
         self.state_dict = state_dict
-        self.device_mesh = device_mesh
-        self.num_devices = device_mesh.get_num_devices()
+        self.mesh_device = mesh_device
+        self.num_devices = mesh_device.get_num_devices()
         self.model_config = model_config
         self.read_cache = read_cache
         self.cluster_shape = cluster_shape
@@ -55,7 +55,7 @@ class TtLlamaDecoder_galaxy:
         self.cache_path = cache_path
 
         self.attention = TtLlamaAttention_galaxy(
-            device_mesh,
+            mesh_device,
             cluster_shape,
             state_dict,
             base_url,
@@ -68,7 +68,7 @@ class TtLlamaDecoder_galaxy:
         )
 
         self.mlp = TtLlamaMLP_galaxy(
-            device_mesh,
+            mesh_device,
             cluster_shape,
             state_dict,
             base_url,
@@ -166,9 +166,9 @@ class TtLlamaDecoder_galaxy:
         #     pt_attn_norm,
         #     dtype=ttnn.bfloat16,
         #     layout=ttnn.ROW_MAJOR_LAYOUT,
-        #     device=self.device_mesh,
+        #     device=self.mesh_device,
         #     memory_config=ttnn.DRAM_MEMORY_CONFIG,
-        #     mesh_mapper=ReplicateTensorToMesh(self.device_mesh),
+        #     mesh_mapper=ReplicateTensorToMesh(self.mesh_device),
         #     cache_file_name=self.cache_path / attn_norm_cache_str,
         # )
 
@@ -176,9 +176,9 @@ class TtLlamaDecoder_galaxy:
             pt_attn_norm,
             dtype=ttnn.bfloat16,
             layout=ttnn.ROW_MAJOR_LAYOUT,
-            device=self.device_mesh,
+            device=self.mesh_device,
             memory_config=ttnn.DRAM_MEMORY_CONFIG,
-            mesh_mapper=ShardTensor2dMesh(self.device_mesh, (2, None), self.cluster_shape),
+            mesh_mapper=ShardTensor2dMesh(self.mesh_device, (2, None), self.cluster_shape),
             cache_file_name=self.cache_path / attn_norm_sharded_str,
         )
 
@@ -186,9 +186,9 @@ class TtLlamaDecoder_galaxy:
         #     pt_ffn_norm,
         #     dtype=ttnn.bfloat16,
         #     layout=ttnn.ROW_MAJOR_LAYOUT,
-        #     device=self.device_mesh,
+        #     device=self.mesh_device,
         #     memory_config=ttnn.DRAM_MEMORY_CONFIG,
-        #     mesh_mapper=ReplicateTensorToMesh(self.device_mesh),
+        #     mesh_mapper=ReplicateTensorToMesh(self.mesh_device),
         #     cache_file_name=self.cache_path / ffn_norm_cache_str,
         # )
 
@@ -196,9 +196,9 @@ class TtLlamaDecoder_galaxy:
             pt_ffn_norm,
             dtype=ttnn.bfloat16,
             layout=ttnn.ROW_MAJOR_LAYOUT,
-            device=self.device_mesh,
+            device=self.mesh_device,
             memory_config=ttnn.DRAM_MEMORY_CONFIG,
-            mesh_mapper=ShardTensor2dMesh(self.device_mesh, (2, None), self.cluster_shape),
+            mesh_mapper=ShardTensor2dMesh(self.mesh_device, (2, None), self.cluster_shape),
             cache_file_name=self.cache_path / ffn_norm_sharded_str,
         )
 
@@ -227,7 +227,7 @@ class TtLlamaDecoder_galaxy:
 
         tt_stats = tt_all_gather(
             tt_stats,
-            device_mesh=self.device_mesh,
+            mesh_device=self.mesh_device,
             dim=3,
             cluster_axis=1,
             num_links=1,

--- a/models/demos/tg/llama3_70b/tt/llama_embedding_galaxy.py
+++ b/models/demos/tg/llama3_70b/tt/llama_embedding_galaxy.py
@@ -9,14 +9,14 @@ from models.demos.t3000.llama2_70b.tt.llama_common import ShardTensor2dMesh
 class TtLlamaEmbedding_galaxy:
     def __init__(
         self,
-        device_mesh,
+        mesh_device,
         cluster_shape,
         state_dict,
         cache_path,
     ):
         self.state_dict = state_dict
-        self.device_mesh = device_mesh
-        self.num_devices = device_mesh.get_num_devices()
+        self.mesh_device = mesh_device
+        self.num_devices = mesh_device.get_num_devices()
         self.cluster_shape = cluster_shape
 
         base_name = "tok_embeddings.weight"
@@ -26,9 +26,9 @@ class TtLlamaEmbedding_galaxy:
             self.state_dict[base_name].unsqueeze(0).unsqueeze(0),
             dtype=ttnn.bfloat16,  # row_major has to be bfloat16 for now
             layout=ttnn.ROW_MAJOR_LAYOUT,
-            device=device_mesh,
+            device=mesh_device,
             memory_config=ttnn.DRAM_MEMORY_CONFIG,
-            mesh_mapper=ShardTensor2dMesh(self.device_mesh, dims=(3, None), cluster_shape=self.cluster_shape),
+            mesh_mapper=ShardTensor2dMesh(self.mesh_device, dims=(3, None), cluster_shape=self.cluster_shape),
             cache_file_name=cache_path / embedding_cache_name,
         )
 

--- a/models/demos/tg/llama3_70b/tt/llama_generation_galaxy.py
+++ b/models/demos/tg/llama3_70b/tt/llama_generation_galaxy.py
@@ -25,7 +25,7 @@ class TtLlamaModelForGeneration:
         self.max_batch_size = model_args.max_batch_size
         self.max_kv_context_len = model_args.max_kv_context_len
 
-        self.device_mesh = tt_args.device_mesh
+        self.mesh_device = tt_args.mesh_device
         self.cluster_shape = tt_args.cluster_shape
 
         # Initial model_config is set in decode mode
@@ -39,7 +39,7 @@ class TtLlamaModelForGeneration:
 
         # TT model -------------------------------------------------------------
         self.tt_model = TtLlamaModel(
-            self.device_mesh,
+            self.mesh_device,
             self.cluster_shape,
             state_dict,
             BASE_URL,
@@ -84,7 +84,7 @@ class TtLlamaModelForGeneration:
     def _process_logits(self, tt_logits):
         logits = ttnn.to_torch(
             tt_logits,
-            mesh_composer=ConcatMesh2DToTensor(self.device_mesh, dims=(1, 3), cluster_shape=self.cluster_shape),
+            mesh_composer=ConcatMesh2DToTensor(self.mesh_device, dims=(1, 3), cluster_shape=self.cluster_shape),
         )
         return logits[:, 0:1, :, : self.params.vocab_size].float()
 

--- a/models/demos/ttnn_falcon7b/tests/multi_chip/test_falcon_decoder.py
+++ b/models/demos/ttnn_falcon7b/tests/multi_chip/test_falcon_decoder.py
@@ -59,7 +59,7 @@ def torch_model():
 )
 @pytest.mark.parametrize("model_config_str", ("BFLOAT16-DRAM", "BFLOAT16-L1"))
 @pytest.mark.parametrize(
-    "device_mesh",
+    "mesh_device",
     [
         2,
     ],
@@ -70,7 +70,7 @@ def torch_model():
     [True, False],
 )
 def test_falcon_decoder(
-    device_mesh,
+    mesh_device,
     model_name,
     llm_mode,
     device_batch_size,
@@ -81,11 +81,11 @@ def test_falcon_decoder(
     torch_model,
     enable_async,
 ):
-    for device in device_mesh.get_device_ids():
-        device_mesh.get_device(device).enable_async(enable_async)
+    for device in mesh_device.get_device_ids():
+        mesh_device.get_device(device).enable_async(enable_async)
 
     torch.manual_seed(0)
-    batch = device_batch_size * device_mesh.get_num_devices()
+    batch = device_batch_size * mesh_device.get_num_devices()
     if llm_mode == "decode":
         shard_dim = 2
     else:
@@ -102,8 +102,8 @@ def test_falcon_decoder(
         batch,
         seq_len,
         configuration.hidden_size,
-        device_mesh,
-        mesh_mapper=ShardTensorToMesh(device_mesh, dim=shard_dim),
+        mesh_device,
+        mesh_mapper=ShardTensorToMesh(mesh_device, dim=shard_dim),
     )
     position_ids = create_position_ids(llm_mode, kv_cache_len)
     attention_mask, tt_attention_mask = create_attention_mask(
@@ -114,8 +114,8 @@ def test_falcon_decoder(
         seq_len,
         configuration.num_attention_heads,
         kv_cache_len,
-        device_mesh,
-        mesh_mapper=ShardTensorToMesh(device_mesh, dim=shard_dim),
+        mesh_device,
+        mesh_mapper=ShardTensorToMesh(mesh_device, dim=shard_dim),
     )
     layer_past, tt_layer_past = create_kv_cache(
         llm_mode,
@@ -123,8 +123,8 @@ def test_falcon_decoder(
         batch,
         kv_cache_len,
         configuration,
-        device_mesh,
-        mesh_mapper=ShardTensorToMesh(device_mesh, dim=0),
+        mesh_device,
+        mesh_mapper=ShardTensorToMesh(mesh_device, dim=0),
     )
 
     pytorch_out, pytorch_layer_present = torch_model(
@@ -137,17 +137,17 @@ def test_falcon_decoder(
     )
     parameters = preprocess_model_parameters(
         initialize_model=lambda: torch_model,
-        device=device_mesh,
+        device=mesh_device,
         custom_preprocessor=create_custom_preprocessor(
             model_config,
             tt_cache_path=get_tt_cache_path(f"{model_name}"),
-            device=device_mesh,
+            device=mesh_device,
             base_file_name=get_model_prefix(),
-            weights_mesh_mapper=ReplicateTensorToMesh(device_mesh),
+            weights_mesh_mapper=ReplicateTensorToMesh(mesh_device),
         ),
     )
     tt_FalconDecoder_model = TtFalconDecoderLayer(
-        device_mesh,
+        mesh_device,
         configuration,
         model_config,
         parameters,
@@ -163,11 +163,11 @@ def test_falcon_decoder(
         layer_past_len=kv_cache_len,
         use_cache=True,
     )
-    tt_out = ttnn.to_torch(tt_out, mesh_composer=ConcatMeshToTensor(device_mesh, dim=shard_dim)).squeeze(1)
+    tt_out = ttnn.to_torch(tt_out, mesh_composer=ConcatMeshToTensor(mesh_device, dim=shard_dim)).squeeze(1)
 
     tt_layer_present = (
-        ttnn.to_torch(tt_layer_present[0], mesh_composer=ConcatMeshToTensor(device_mesh, dim=0)).squeeze(1),
-        ttnn.to_torch(tt_layer_present[1], mesh_composer=ConcatMeshToTensor(device_mesh, dim=0)).squeeze(1),
+        ttnn.to_torch(tt_layer_present[0], mesh_composer=ConcatMeshToTensor(mesh_device, dim=0)).squeeze(1),
+        ttnn.to_torch(tt_layer_present[1], mesh_composer=ConcatMeshToTensor(mesh_device, dim=0)).squeeze(1),
     )
     if llm_mode == "decode":
         tt_out = tt_out.transpose(0, 1)
@@ -185,5 +185,5 @@ def test_falcon_decoder(
         pytorch_layer_present[1].squeeze(1), tt_layer_present[1].to(pytorch_layer_present[1].dtype), expected_pcc
     )
 
-    for device in device_mesh.get_device_ids():
-        device_mesh.get_device(device).enable_async(False)
+    for device in mesh_device.get_device_ids():
+        mesh_device.get_device(device).enable_async(False)

--- a/models/demos/ttnn_falcon7b/tests/multi_chip/test_falcon_mlp.py
+++ b/models/demos/ttnn_falcon7b/tests/multi_chip/test_falcon_mlp.py
@@ -50,7 +50,7 @@ def torch_model():
 )
 @pytest.mark.parametrize("model_config_str", ("BFLOAT16-DRAM", "BFLOAT16-L1"))
 @pytest.mark.parametrize(
-    "device_mesh",
+    "mesh_device",
     [
         1,
         2,
@@ -62,7 +62,7 @@ def torch_model():
     [True, False],
 )
 def test_falcon_mlp(
-    device_mesh,
+    mesh_device,
     model_name,
     batch,
     seq_len,
@@ -71,25 +71,25 @@ def test_falcon_mlp(
     torch_model,
     enable_async,
 ):
-    for device in device_mesh.get_device_ids():
-        device_mesh.get_device(device).enable_async(enable_async)
+    for device in mesh_device.get_device_ids():
+        mesh_device.get_device(device).enable_async(enable_async)
 
     torch.manual_seed(0)
 
     configuration = transformers.FalconConfig.from_pretrained(PRETRAINED_MODEL_NAME)
-    torch_input = (torch.rand(batch * device_mesh.get_num_devices(), 1, seq_len, configuration.hidden_size) * 2) - 1
+    torch_input = (torch.rand(batch * mesh_device.get_num_devices(), 1, seq_len, configuration.hidden_size) * 2) - 1
     torch_output = torch_model(torch_input)
 
     model_config = get_model_config(model_config_str)
     parameters = preprocess_model_parameters(
         initialize_model=lambda: torch_model,
-        device=device_mesh,
+        device=mesh_device,
         custom_preprocessor=create_custom_preprocessor(
             model_config,
             tt_cache_path=get_tt_cache_path(f"{model_name}"),
-            device=device_mesh,
+            device=mesh_device,
             base_file_name=get_model_prefix(),
-            weights_mesh_mapper=ReplicateTensorToMesh(device_mesh),
+            weights_mesh_mapper=ReplicateTensorToMesh(mesh_device),
         ),
     )
 
@@ -97,20 +97,20 @@ def test_falcon_mlp(
     ttnn_input = ttnn.from_torch(
         torch_input,
         dtype=model_config["DEFAULT_DTYPE"],
-        device=device_mesh,
+        device=mesh_device,
         layout=ttnn.TILE_LAYOUT,
-        mesh_mapper=ShardTensorToMesh(device_mesh, dim=0),
+        mesh_mapper=ShardTensorToMesh(mesh_device, dim=0),
     )
     ttnn_output = ttnn_model(ttnn_input)
 
     passed, pcc = assert_with_pcc(
         torch_output,
-        ttnn.to_torch(ttnn_output, mesh_composer=ConcatMeshToTensor(device_mesh, dim=0), device=device_mesh).to(
+        ttnn.to_torch(ttnn_output, mesh_composer=ConcatMeshToTensor(mesh_device, dim=0), device=mesh_device).to(
             torch_output.dtype
         ),
         expected_pcc,
     )
     logger.success(f"Passed: pcc: {pcc}, expected: {expected_pcc}")
 
-    for device in device_mesh.get_device_ids():
-        device_mesh.get_device(device).enable_async(False)
+    for device in mesh_device.get_device_ids():
+        mesh_device.get_device(device).enable_async(False)

--- a/models/demos/ttnn_resnet/tests/multi_device/test_perf_ttnn_resnet.py
+++ b/models/demos/ttnn_resnet/tests/multi_device/test_perf_ttnn_resnet.py
@@ -455,7 +455,7 @@ def run_perf_resnet(
     indirect=["enable_async_mode"],
 )
 def test_perf_t3000(
-    device_mesh,
+    mesh_device,
     use_program_cache,
     device_batch_size,
     expected_inference_time,
@@ -470,7 +470,7 @@ def test_perf_t3000(
         expected_inference_time,
         expected_compile_time,
         hf_cat_image_sample_input,
-        device_mesh,
+        mesh_device,
         f"resnet50_{mode}",
         model_location_generator,
     )
@@ -485,7 +485,7 @@ def test_perf_t3000(
     indirect=["enable_async_mode"],
 )
 def test_perf_trace_t3000(
-    device_mesh,
+    mesh_device,
     use_program_cache,
     device_batch_size,
     expected_inference_time,
@@ -500,7 +500,7 @@ def test_perf_trace_t3000(
         expected_inference_time,
         expected_compile_time,
         hf_cat_image_sample_input,
-        device_mesh,
+        mesh_device,
         f"resnet50_trace_{mode}",
         model_location_generator,
     )
@@ -515,7 +515,7 @@ def test_perf_trace_t3000(
     indirect=["enable_async_mode"],
 )
 def test_perf_2cqs_t3000(
-    device_mesh,
+    mesh_device,
     use_program_cache,
     device_batch_size,
     expected_inference_time,
@@ -530,7 +530,7 @@ def test_perf_2cqs_t3000(
         expected_inference_time,
         expected_compile_time,
         hf_cat_image_sample_input,
-        device_mesh,
+        mesh_device,
         f"resnet50_2cqs_{mode}",
         model_location_generator,
     )
@@ -547,7 +547,7 @@ def test_perf_2cqs_t3000(
     indirect=["enable_async_mode"],
 )
 def test_perf_trace_2cqs_t3000(
-    device_mesh,
+    mesh_device,
     use_program_cache,
     device_batch_size,
     expected_inference_time,
@@ -562,7 +562,7 @@ def test_perf_trace_2cqs_t3000(
         expected_inference_time,
         expected_compile_time,
         hf_cat_image_sample_input,
-        device_mesh,
+        mesh_device,
         f"resnet50_trace_2cqs_{mode}",
         model_location_generator,
     )

--- a/models/demos/wormhole/falcon7b/demo_wormhole.py
+++ b/models/demos/wormhole/falcon7b/demo_wormhole.py
@@ -32,7 +32,7 @@ from models.utility_functions import is_wormhole_b0
         "default_mode_1024_stochastic",
     ],
 )
-@pytest.mark.parametrize("device_mesh", (1,), indirect=True)
+@pytest.mark.parametrize("mesh_device", (1,), indirect=True)
 def test_demo(
     perf_mode,  # Option to measure perf using max seq length (with invalid outputs) and expected perf (t/s)
     max_seq_len,
@@ -42,7 +42,7 @@ def test_demo(
     user_input,
     model_location_generator,
     get_tt_cache_path,
-    device_mesh,
+    mesh_device,
     use_program_cache,
     is_ci_env,
 ):
@@ -69,7 +69,7 @@ def test_demo(
         model_config_strs_prefill_decode=["BFLOAT16-DRAM", "BFLOAT16-L1_SHARDED"],
         model_location_generator=model_location_generator,
         get_tt_cache_path=get_tt_cache_path,
-        device_mesh=device_mesh,
+        mesh_device=mesh_device,
         perf_mode=perf_mode,
         greedy_sampling=greedy_sampling,
         expected_perf_metrics=expected_perf_metrics,

--- a/models/experimental/functional_unet/tests/common.py
+++ b/models/experimental/functional_unet/tests/common.py
@@ -6,11 +6,11 @@ import ttnn
 from tests.ttnn.utils_for_testing import assert_with_pcc
 
 
-def is_n300_with_eth_dispatch_cores(device_mesh) -> bool:
+def is_n300_with_eth_dispatch_cores(mesh_device) -> bool:
     all_devices_using_full_grid = all(
-        [(8 == device.core_grid.x and 8 == device.core_grid.y) for device in device_mesh.get_devices()]
+        [(8 == device.core_grid.x and 8 == device.core_grid.y) for device in mesh_device.get_devices()]
     )
-    return all_devices_using_full_grid and (len(device_mesh.get_devices()) == 2)
+    return all_devices_using_full_grid and (len(mesh_device.get_devices()) == 2)
 
 
 def check_pcc_conv(torch_tensor, ttnn_tensor, pcc=0.999, mesh_composer=None):

--- a/models/experimental/functional_unet/tests/test_unet_bottleneck.py
+++ b/models/experimental/functional_unet/tests/test_unet_bottleneck.py
@@ -42,23 +42,23 @@ def test_unet_bottleneck(batch, groups, device, reset_seeds):
 @pytest.mark.parametrize("batch", [2])
 @pytest.mark.parametrize("groups", [1])
 @pytest.mark.parametrize("device_params", [{"l1_small_size": 32768}], indirect=True)
-def test_unet_bottleneck_multi_device(batch, groups, device_mesh, reset_seeds):
-    if not is_n300_with_eth_dispatch_cores(device_mesh):
+def test_unet_bottleneck_multi_device(batch, groups, mesh_device, reset_seeds):
+    if not is_n300_with_eth_dispatch_cores(mesh_device):
         pytest.skip("Test is only valid for N300")
 
-    inputs_mesh_mapper = ttnn.ShardTensorToMesh(device_mesh, dim=0)
-    weights_mesh_mapper = ttnn.ReplicateTensorToMesh(device_mesh)
-    output_mesh_composer = ttnn.ConcatMeshToTensor(device_mesh, dim=0)
+    inputs_mesh_mapper = ttnn.ShardTensorToMesh(mesh_device, dim=0)
+    weights_mesh_mapper = ttnn.ReplicateTensorToMesh(mesh_device)
+    output_mesh_composer = ttnn.ConcatMeshToTensor(mesh_device, dim=0)
 
-    torch_input, ttnn_input = create_unet_input_tensors(device_mesh, batch, groups, pad_input=False)
+    torch_input, ttnn_input = create_unet_input_tensors(mesh_device, batch, groups, pad_input=False)
     model = unet_shallow_torch.UNet.from_random_weights(groups=1)
 
-    parameters = create_unet_model_parameters(model, torch_input, groups=groups, device=device_mesh)
-    ttnn_model = unet_shallow_ttnn.UNet(parameters, device_mesh, mesh_mapper=weights_mesh_mapper)
+    parameters = create_unet_model_parameters(model, torch_input, groups=groups, device=mesh_device)
+    ttnn_model = unet_shallow_ttnn.UNet(parameters, mesh_device, mesh_mapper=weights_mesh_mapper)
 
-    num_devices = len(device_mesh.get_device_ids())
+    num_devices = len(mesh_device.get_device_ids())
     torch_input, ttnn_input = create_unet_input_tensors(
-        device_mesh,
+        mesh_device,
         num_devices * batch,
         groups,
         pad_input=True,
@@ -69,11 +69,11 @@ def test_unet_bottleneck_multi_device(batch, groups, device_mesh, reset_seeds):
     )
     logger.info(f"Created reference input tensors: {list(torch_input.shape)}")
     logger.info(
-        f"Created multi-device input tensors: shape={list(ttnn_input.shape)} on devices={device_mesh.get_device_ids()}"
+        f"Created multi-device input tensors: shape={list(ttnn_input.shape)} on devices={mesh_device.get_device_ids()}"
     )
     torch_output = model.bottleneck(torch_input)
 
-    ttnn_input = ttnn_input.to(device_mesh)
+    ttnn_input = ttnn_input.to(mesh_device)
     ttnn_output = ttnn_model.bottleneck(ttnn_input)
 
     assert len(ttnn_output.devices()) == 2, "Expected output tensor to be sharded across 2 devices"

--- a/models/experimental/functional_unet/tests/test_unet_downblock.py
+++ b/models/experimental/functional_unet/tests/test_unet_downblock.py
@@ -67,24 +67,24 @@ def test_unet_downblock(batch, groups, block_name, input_channels, input_height,
 )
 @pytest.mark.parametrize("device_params", [{"l1_small_size": 32768}], indirect=True)
 def test_unet_downblock_multi_device(
-    batch, groups, block_name, input_channels, input_height, input_width, device_mesh, reset_seeds
+    batch, groups, block_name, input_channels, input_height, input_width, mesh_device, reset_seeds
 ):
-    if not is_n300_with_eth_dispatch_cores(device_mesh):
+    if not is_n300_with_eth_dispatch_cores(mesh_device):
         pytest.skip("Test is only valid for N300")
 
-    inputs_mesh_mapper = ttnn.ShardTensorToMesh(device_mesh, dim=0)
-    weights_mesh_mapper = ttnn.ReplicateTensorToMesh(device_mesh)
-    output_mesh_composer = ttnn.ConcatMeshToTensor(device_mesh, dim=0)
+    inputs_mesh_mapper = ttnn.ShardTensorToMesh(mesh_device, dim=0)
+    weights_mesh_mapper = ttnn.ReplicateTensorToMesh(mesh_device)
+    output_mesh_composer = ttnn.ConcatMeshToTensor(mesh_device, dim=0)
 
-    torch_input, ttnn_input = create_unet_input_tensors(device_mesh, batch, groups, pad_input=False)
+    torch_input, ttnn_input = create_unet_input_tensors(mesh_device, batch, groups, pad_input=False)
     model = unet_shallow_torch.UNet.from_random_weights(groups=1)
 
-    parameters = create_unet_model_parameters(model, torch_input, groups=groups, device=device_mesh)
-    ttnn_model = unet_shallow_ttnn.UNet(parameters, device_mesh, mesh_mapper=weights_mesh_mapper)
+    parameters = create_unet_model_parameters(model, torch_input, groups=groups, device=mesh_device)
+    ttnn_model = unet_shallow_ttnn.UNet(parameters, mesh_device, mesh_mapper=weights_mesh_mapper)
 
-    num_devices = len(device_mesh.get_device_ids())
+    num_devices = len(mesh_device.get_device_ids())
     torch_input, ttnn_input = create_unet_input_tensors(
-        device_mesh,
+        mesh_device,
         num_devices * batch,
         groups,
         pad_input=True,
@@ -95,12 +95,12 @@ def test_unet_downblock_multi_device(
     )
     logger.info(f"Created reference input tensors: {list(torch_input.shape)}")
     logger.info(
-        f"Created multi-device input tensors: shape={list(ttnn_input.shape)} on devices={device_mesh.get_device_ids()}"
+        f"Created multi-device input tensors: shape={list(ttnn_input.shape)} on devices={mesh_device.get_device_ids()}"
     )
 
     torch_output, torch_residual = getattr(model, block_name)(torch_input)
 
-    ttnn_input = ttnn_input.to(device_mesh)
+    ttnn_input = ttnn_input.to(mesh_device)
     ttnn_output, ttnn_residual = getattr(ttnn_model, block_name)(ttnn_input)
 
     assert len(ttnn_output.devices()) == 2, "Expected output tensor to be sharded across 2 devices"

--- a/models/experimental/functional_unet/tests/test_unet_multi_device.py
+++ b/models/experimental/functional_unet/tests/test_unet_multi_device.py
@@ -22,27 +22,27 @@ from models.experimental.functional_unet.tests.common import (
 @pytest.mark.parametrize("batch", [2])
 @pytest.mark.parametrize("groups", [1])
 @pytest.mark.parametrize("device_params", [{"l1_small_size": 64768}], indirect=True)
-def test_unet_multi_device_model(batch, groups, device_mesh, use_program_cache, reset_seeds):
-    if not is_n300_with_eth_dispatch_cores(device_mesh):
+def test_unet_multi_device_model(batch, groups, mesh_device, use_program_cache, reset_seeds):
+    if not is_n300_with_eth_dispatch_cores(mesh_device):
         pytest.skip("Test is only valid for N300")
 
-    inputs_mesh_mapper = ttnn.ShardTensorToMesh(device_mesh, dim=0)
-    weights_mesh_mapper = ttnn.ReplicateTensorToMesh(device_mesh)
-    output_mesh_composer = ttnn.ConcatMeshToTensor(device_mesh, dim=0)
+    inputs_mesh_mapper = ttnn.ShardTensorToMesh(mesh_device, dim=0)
+    weights_mesh_mapper = ttnn.ReplicateTensorToMesh(mesh_device)
+    output_mesh_composer = ttnn.ConcatMeshToTensor(mesh_device, dim=0)
 
-    torch_input, ttnn_input = create_unet_input_tensors(device_mesh, batch, groups, pad_input=True)
+    torch_input, ttnn_input = create_unet_input_tensors(mesh_device, batch, groups, pad_input=True)
     model = unet_shallow_torch.UNet.from_random_weights(groups=groups)
 
-    parameters = create_unet_model_parameters(model, torch_input, groups=groups, device=device_mesh)
-    ttnn_model = unet_shallow_ttnn.UNet(parameters, device=device_mesh, mesh_mapper=weights_mesh_mapper)
+    parameters = create_unet_model_parameters(model, torch_input, groups=groups, device=mesh_device)
+    ttnn_model = unet_shallow_ttnn.UNet(parameters, device=mesh_device, mesh_mapper=weights_mesh_mapper)
 
-    num_devices = len(device_mesh.get_device_ids())
+    num_devices = len(mesh_device.get_device_ids())
     torch_input, ttnn_input = create_unet_input_tensors(
-        device_mesh, num_devices * batch, groups, pad_input=True, mesh_mapper=inputs_mesh_mapper
+        mesh_device, num_devices * batch, groups, pad_input=True, mesh_mapper=inputs_mesh_mapper
     )
     logger.info(f"Created reference input tensors: {list(torch_input.shape)}")
     logger.info(
-        f"Created multi-device input tensors: shape={list(ttnn_input.shape)} on devices={device_mesh.get_device_ids()}"
+        f"Created multi-device input tensors: shape={list(ttnn_input.shape)} on devices={mesh_device.get_device_ids()}"
     )
 
     torch_output_tensor = model(torch_input)

--- a/models/experimental/functional_unet/tests/test_unet_upblock.py
+++ b/models/experimental/functional_unet/tests/test_unet_upblock.py
@@ -79,24 +79,24 @@ def test_unet_upblock(
 )
 @pytest.mark.parametrize("device_params", [{"l1_small_size": 32768}], indirect=True)
 def test_unet_upblock_multi_device(
-    batch, groups, block_name, input_channels, input_height, input_width, residual_channels, device_mesh, reset_seeds
+    batch, groups, block_name, input_channels, input_height, input_width, residual_channels, mesh_device, reset_seeds
 ):
-    if not is_n300_with_eth_dispatch_cores(device_mesh):
+    if not is_n300_with_eth_dispatch_cores(mesh_device):
         pytest.skip("Test is only valid for N300")
 
-    inputs_mesh_mapper = ttnn.ShardTensorToMesh(device_mesh, dim=0)
-    weights_mesh_mapper = ttnn.ReplicateTensorToMesh(device_mesh)
-    output_mesh_composer = ttnn.ConcatMeshToTensor(device_mesh, dim=0)
+    inputs_mesh_mapper = ttnn.ShardTensorToMesh(mesh_device, dim=0)
+    weights_mesh_mapper = ttnn.ReplicateTensorToMesh(mesh_device)
+    output_mesh_composer = ttnn.ConcatMeshToTensor(mesh_device, dim=0)
 
-    torch_input, ttnn_input = create_unet_input_tensors(device_mesh, batch, groups, pad_input=False)
+    torch_input, ttnn_input = create_unet_input_tensors(mesh_device, batch, groups, pad_input=False)
     model = unet_shallow_torch.UNet.from_random_weights(groups=groups)
 
-    parameters = create_unet_model_parameters(model, torch_input, groups=groups, device=device_mesh)
-    ttnn_model = unet_shallow_ttnn.UNet(parameters, device_mesh, mesh_mapper=weights_mesh_mapper)
+    parameters = create_unet_model_parameters(model, torch_input, groups=groups, device=mesh_device)
+    ttnn_model = unet_shallow_ttnn.UNet(parameters, mesh_device, mesh_mapper=weights_mesh_mapper)
 
-    num_devices = len(device_mesh.get_device_ids())
+    num_devices = len(mesh_device.get_device_ids())
     torch_input, ttnn_input = create_unet_input_tensors(
-        device_mesh,
+        mesh_device,
         num_devices * batch,
         groups,
         pad_input=False,
@@ -107,10 +107,10 @@ def test_unet_upblock_multi_device(
     )
     logger.info(f"Created reference input tensors: {list(torch_input.shape)}")
     logger.info(
-        f"Created multi-device input tensors: shape={list(ttnn_input.shape)} on devices={device_mesh.get_device_ids()}"
+        f"Created multi-device input tensors: shape={list(ttnn_input.shape)} on devices={mesh_device.get_device_ids()}"
     )
     torch_residual, ttnn_residual = create_unet_input_tensors(
-        device_mesh,
+        mesh_device,
         num_devices * batch,
         groups,
         pad_input=False,
@@ -121,11 +121,11 @@ def test_unet_upblock_multi_device(
     )
     logger.info(f"Created reference residual input tensors: {list(torch_residual.shape)}")
     logger.info(
-        f"Created multi-device residual input tensors: shape={list(ttnn_residual.shape)} on devices={device_mesh.get_device_ids()}"
+        f"Created multi-device residual input tensors: shape={list(ttnn_residual.shape)} on devices={mesh_device.get_device_ids()}"
     )
     torch_output = getattr(model, block_name)(torch_input, torch_residual)
 
-    ttnn_input, ttnn_residual = ttnn_input.to(device_mesh), ttnn_residual.to(device_mesh)
+    ttnn_input, ttnn_residual = ttnn_input.to(mesh_device), ttnn_residual.to(mesh_device)
     ttnn_output = getattr(ttnn_model, block_name)(ttnn_input, ttnn_residual)
 
     assert len(ttnn_output.devices()) == 2, "Expected output tensor to be sharded across 2 devices"

--- a/models/experimental/grok/demo/demo.py
+++ b/models/experimental/grok/demo/demo.py
@@ -53,7 +53,7 @@ def load_inputs(user_input, batch):
     return in_prompt
 
 
-def preprocess_inputs(input_prompts, tokenizer, model_args, dtype, instruct, device_mesh):
+def preprocess_inputs(input_prompts, tokenizer, model_args, dtype, instruct, mesh_device):
     """
     Run tokenizer on inputs, and create embeddings for the first token of each input
     """
@@ -82,20 +82,20 @@ def preprocess_inputs(input_prompts, tokenizer, model_args, dtype, instruct, dev
     input_tokens_tt = [
         ttnn.from_torch(
             input_tokens[:, i].unsqueeze(0),
-            device=device_mesh,
+            device=mesh_device,
             dtype=ttnn.uint32,
             layout=ttnn.ROW_MAJOR_LAYOUT,
-            mesh_mapper=ReplicateTensorToMesh(device_mesh),
+            mesh_mapper=ReplicateTensorToMesh(mesh_device),
         )
         for i in range(max_prompt_len)
     ]
     input_mask_tt = [
         ttnn.from_torch(
             input_mask[:, i].unsqueeze(0),
-            device=device_mesh,
+            device=mesh_device,
             dtype=ttnn.bfloat16,
             layout=ttnn.ROW_MAJOR_LAYOUT,
-            mesh_mapper=ReplicateTensorToMesh(device_mesh),
+            mesh_mapper=ReplicateTensorToMesh(mesh_device),
         )
         for i in range(max_prompt_len)
     ]
@@ -103,7 +103,7 @@ def preprocess_inputs(input_prompts, tokenizer, model_args, dtype, instruct, dev
 
 
 @torch.no_grad()
-def run_grok_demo(user_input, batch_size, device_mesh, instruct_mode):
+def run_grok_demo(user_input, batch_size, mesh_device, instruct_mode):
     assert batch_size == 32, "Batch size must be 32"
 
     dtype = ttnn.bfloat8_b
@@ -118,7 +118,7 @@ def run_grok_demo(user_input, batch_size, device_mesh, instruct_mode):
         input_prompts = load_inputs(user_input, 32)
 
     # Load model args, weights, and tokenizer
-    model_args = TtModelArgs(device_mesh.get_device(0), instruct=instruct_mode)
+    model_args = TtModelArgs(mesh_device.get_device(0), instruct=instruct_mode)
     tokenizer = Tokenizer(model_args.tokenizer_path)
 
     model_args.n_layers = 32  # Full model
@@ -141,7 +141,7 @@ def run_grok_demo(user_input, batch_size, device_mesh, instruct_mode):
 
     # Preprocess initial prompt inputs
     input_tokens_tt, max_prompt_len, input_mask, input_tokens_pt, input_mask_pt = preprocess_inputs(
-        input_prompts, tokenizer, model_args, dtype, instruct_mode, device_mesh
+        input_prompts, tokenizer, model_args, dtype, instruct_mode, mesh_device
     )
 
     # TODO should we just change the pad after initial pad of the inputs?
@@ -151,7 +151,7 @@ def run_grok_demo(user_input, batch_size, device_mesh, instruct_mode):
     # Load TTNN grok model
     logger.info("Loading weights to device...")
     tt_model = TtTransformer(
-        device_mesh=device_mesh,
+        mesh_device=mesh_device,
         state_dict=state_dict,
         args=model_args,
         layers=list(range(model_args.n_layers)),
@@ -160,7 +160,7 @@ def run_grok_demo(user_input, batch_size, device_mesh, instruct_mode):
 
     if not embed_on_host:
         tt_embds = TtGrokEmbedding(
-            device_mesh=device_mesh,
+            mesh_device=mesh_device,
             args=model_args,
             weight_cache_path=model_args.weight_cache_path(dtype),
             state_dict=state_dict,
@@ -183,13 +183,13 @@ def run_grok_demo(user_input, batch_size, device_mesh, instruct_mode):
     rot_mats = prepare_rotation_mat_ttnn(
         model_args.head_dim,
         model_args.max_seq_len,
-        tt_model.device_mesh,
+        tt_model.mesh_device,
     )
 
     generation_start_pos = 0
     max_generated_tokens = 50
 
-    cache_attention(device_mesh, state_dict, model_args, rot_mats, generation_start_pos, max_generated_tokens, dtype)
+    cache_attention(mesh_device, state_dict, model_args, rot_mats, generation_start_pos, max_generated_tokens, dtype)
 
     logger.info("Starting inference...")
 
@@ -201,7 +201,7 @@ def run_grok_demo(user_input, batch_size, device_mesh, instruct_mode):
 
     # TODO Debug (only device 0 is doing argmax, otherwise it throws an error)
     # Alternatively, send the output back to device: ttnn.Tensor.to()
-    ttnn.SetDefaultDevice(device_mesh.get_device(0))
+    ttnn.SetDefaultDevice(mesh_device.get_device(0))
 
     # Keep running inference as long as there is a user in the batch still decoding or max tokens per user are decoded
     for iteration in range(max_generated_tokens):
@@ -220,7 +220,7 @@ def run_grok_demo(user_input, batch_size, device_mesh, instruct_mode):
                 model_args.dim,
                 start_pos,
                 model_args.sliding_window,
-                tt_model.device_mesh,
+                tt_model.mesh_device,
             )
 
         # Run ttnn grok model
@@ -230,7 +230,7 @@ def run_grok_demo(user_input, batch_size, device_mesh, instruct_mode):
         if embed_on_host:
             # Convert ttnn tensor to torch tensor
             tt_output_torch = (
-                ttnn.to_torch(tt_out_11BH, mesh_composer=ConcatMeshToTensor(device_mesh, dim=0))[0]
+                ttnn.to_torch(tt_out_11BH, mesh_composer=ConcatMeshToTensor(mesh_device, dim=0))[0]
                 .squeeze(1)
                 .view(batch_size, seqlen, -1)
                 .detach()
@@ -306,7 +306,7 @@ def run_grok_demo(user_input, batch_size, device_mesh, instruct_mode):
     ],
     ids=["general_weights", "instruct_weights"],
 )
-def test_grok8x7b_demo(t3k_device_mesh, use_program_cache, input_prompts, instruct_weights):
+def test_grok8x7b_demo(t3k_mesh_device, use_program_cache, input_prompts, instruct_weights):
     return run_grok_demo(
-        user_input=input_prompts, batch_size=32, device_mesh=t3k_device_mesh, instruct_mode=instruct_weights
+        user_input=input_prompts, batch_size=32, mesh_device=t3k_mesh_device, instruct_mode=instruct_weights
     )

--- a/models/experimental/grok/scripts/tlog.py
+++ b/models/experimental/grok/scripts/tlog.py
@@ -5,15 +5,15 @@ import torch
 import ttnn
 
 log = []
-tlog_device_mesh = None
+tlog_mesh_device = None
 
 
 def tlog(name, tensor, gather_dim=0, log_filename="tlog.pt"):
     if isinstance(tensor, ttnn.Tensor):
         if gather_dim is None:
-            tensor = ttnn.to_torch(tensor, mesh_composer=ttnn.ConcatMeshToTensor(tlog_device_mesh, dim=0))[0]
+            tensor = ttnn.to_torch(tensor, mesh_composer=ttnn.ConcatMeshToTensor(tlog_mesh_device, dim=0))[0]
         else:
-            tensor = ttnn.to_torch(tensor, mesh_composer=ttnn.ConcatMeshToTensor(tlog_device_mesh, dim=gather_dim))
+            tensor = ttnn.to_torch(tensor, mesh_composer=ttnn.ConcatMeshToTensor(tlog_mesh_device, dim=gather_dim))
     log.append((name, tensor.detach()))
     torch.save(log, log_filename)
 

--- a/models/experimental/grok/tests/test_dummy_weights.py
+++ b/models/experimental/grok/tests/test_dummy_weights.py
@@ -15,7 +15,7 @@ from models.utility_functions import (
 )
 
 
-def test_load_dummy_weights(t3k_device_mesh):
+def test_load_dummy_weights(t3k_mesh_device):
     # Set to incorrect paths to test dummy weight loading
 
     backup_cache_path = TtModelArgs.DEFAULT_CACHE_PATH
@@ -27,11 +27,11 @@ def test_load_dummy_weights(t3k_device_mesh):
         TtModelArgs.DEFAULT_TOKENIZER_PATH = "this/path/does/not/exist"
         TtModelArgs.DEFAULT_CKPT_DIR = "this/path/does/not/exist"
 
-        model_args = TtModelArgs(t3k_device_mesh.get_device(0), dummy_weights=True)
+        model_args = TtModelArgs(t3k_mesh_device.get_device(0), dummy_weights=True)
         model_args.n_layers = 1
         state_dict = model_args.load_state_dict()
         tt_model = TtTransformer(
-            device_mesh=t3k_device_mesh,
+            mesh_device=t3k_mesh_device,
             state_dict=state_dict,
             args=model_args,
             layers=list(range(model_args.n_layers)),

--- a/models/experimental/grok/tests/test_grok_embedding.py
+++ b/models/experimental/grok/tests/test_grok_embedding.py
@@ -32,8 +32,8 @@ class Emb(torch.nn.Module):
 
 
 def test_grok_embedding(device, use_program_cache, reset_seeds):
-    for device in t3k_device_mesh.get_device_ids():
-        t3k_device_mesh.get_device(device).enable_async(True)
+    for device in t3k_mesh_device.get_device_ids():
+        t3k_mesh_device.get_device(device).enable_async(True)
     dtype = ttnn.bfloat16
 
     model_args = TtModelArgs(device, dummy_weights=os.getenv("CI") == "true")

--- a/models/experimental/grok/tests/test_grok_moe.py
+++ b/models/experimental/grok/tests/test_grok_moe.py
@@ -26,14 +26,14 @@ from models.utility_functions import (
 
 
 @pytest.mark.timeout(600)
-def test_grok_moe_inference(t3k_device_mesh, use_program_cache, reset_seeds):
-    for device in t3k_device_mesh.get_device_ids():
-        t3k_device_mesh.get_device(device).enable_async(True)
+def test_grok_moe_inference(t3k_mesh_device, use_program_cache, reset_seeds):
+    for device in t3k_mesh_device.get_device_ids():
+        t3k_mesh_device.get_device(device).enable_async(True)
     pcc = 0.87  # real weights = 0.99
     iterations = 1
     dtype = ttnn.bfloat8_b
 
-    model_args = TtModelArgs(t3k_device_mesh.get_device(0), dummy_weights=os.getenv("CI") == "true")
+    model_args = TtModelArgs(t3k_mesh_device.get_device(0), dummy_weights=os.getenv("CI") == "true")
     model_args.n_layers = 1
     state_dict = model_args.load_state_dict()
 
@@ -50,7 +50,7 @@ def test_grok_moe_inference(t3k_device_mesh, use_program_cache, reset_seeds):
 
     # Initialize TT models
     experts = TtGrokMLP(
-        device_mesh=t3k_device_mesh,
+        mesh_device=t3k_mesh_device,
         state_dict=state_dict,
         args=model_args,
         layer_num=0,
@@ -62,7 +62,7 @@ def test_grok_moe_inference(t3k_device_mesh, use_program_cache, reset_seeds):
     )
 
     tt_model = TtMoeLayer(
-        device_mesh=t3k_device_mesh,
+        mesh_device=t3k_mesh_device,
         state_dict=state_dict,
         experts=experts,
         args=model_args,
@@ -83,16 +83,16 @@ def test_grok_moe_inference(t3k_device_mesh, use_program_cache, reset_seeds):
         pt_decode_input = (torch.rand(batch, seqlen, model_args.hidden_size) * 2) - 1
         tt_decode_input = ttnn.from_torch(
             pt_decode_input.clone().unsqueeze(1).view(1, 1, 32, model_args.hidden_size),
-            device=t3k_device_mesh,
+            device=t3k_mesh_device,
             dtype=ttnn.bfloat16,
             memory_config=ttnn.L1_MEMORY_CONFIG,
             layout=ttnn.TILE_LAYOUT,
-            mesh_mapper=ReplicateTensorToMesh(t3k_device_mesh),
+            mesh_mapper=ReplicateTensorToMesh(t3k_mesh_device),
         )
         # Run TT model
         tt_out = tt_model(tt_decode_input)
         tt_output_torch = (
-            ttnn.to_torch(tt_out, mesh_composer=ConcatMeshToTensor(t3k_device_mesh, dim=0))[0]
+            ttnn.to_torch(tt_out, mesh_composer=ConcatMeshToTensor(t3k_mesh_device, dim=0))[0]
             .squeeze(2)
             .view(batch, 1, -1)
         )

--- a/models/experimental/grok/tt/grok_decoder.py
+++ b/models/experimental/grok/tt/grok_decoder.py
@@ -7,13 +7,13 @@ from models.experimental.grok.tt.grok_mlp import TtGrokMLP
 from models.experimental.grok.tt.grok_rms_norm import TtRMSNormSharded, TtRMSNorm
 from models.experimental.grok.tt.grok_moe import TtMoeLayer
 from models.experimental.grok.tt.grok_common import LightweightModule
-from models.experimental.grok.scripts.tlog import tlog, tlog_device_mesh
+from models.experimental.grok.scripts.tlog import tlog, tlog_mesh_device
 
 
 class TtTransformerBlock(LightweightModule):
     def __init__(
         self,
-        device_mesh,
+        mesh_device,
         state_dict,
         args,
         layer_num,
@@ -22,14 +22,14 @@ class TtTransformerBlock(LightweightModule):
         super().__init__()
 
         self.state_dict = state_dict
-        self.device_mesh = device_mesh
-        tlog_device_mesh = device_mesh
+        self.mesh_device = mesh_device
+        tlog_mesh_device = mesh_device
 
         self.args = args
 
         self.layer_num = layer_num
         self.attention = TtGrokAttention(
-            device_mesh=device_mesh,
+            mesh_device=mesh_device,
             state_dict=state_dict,
             args=args,
             layer_num=layer_num,
@@ -37,10 +37,10 @@ class TtTransformerBlock(LightweightModule):
         )
 
         self.feed_forward = TtMoeLayer(
-            device_mesh=device_mesh,
+            mesh_device=mesh_device,
             state_dict=state_dict,
             experts=TtGrokMLP(
-                device_mesh=device_mesh,
+                mesh_device=mesh_device,
                 state_dict=state_dict,
                 args=args,
                 layer_num=layer_num,
@@ -55,7 +55,7 @@ class TtTransformerBlock(LightweightModule):
             dtype=dtype,
         )
         make_norm = lambda name: TtRMSNormSharded(
-            device_mesh=device_mesh,
+            mesh_device=mesh_device,
             state_dict=state_dict,
             args=args,
             dtype=ttnn.bfloat16,

--- a/models/experimental/grok/tt/grok_mlp.py
+++ b/models/experimental/grok/tt/grok_mlp.py
@@ -9,11 +9,11 @@ from models.experimental.grok.tt.grok_common import LightweightModule
 
 
 class TtGrokMLP(LightweightModule):
-    def __init__(self, device_mesh, state_dict, args, layer_num, dtypes):
+    def __init__(self, mesh_device, state_dict, args, layer_num, dtypes):
         super().__init__()
 
         self.state_dict = state_dict
-        self.device_mesh = device_mesh
+        self.mesh_device = mesh_device
         self.dtypes = dtypes
         self.model_args = args
         self.model_config = args.get_model_config()
@@ -35,8 +35,8 @@ class TtGrokMLP(LightweightModule):
         as_tensor = lambda name: ttnn.as_tensor(
             torch_weight(name),
             dtype=dtypes[name],
-            device=self.device_mesh,
-            mesh_mapper=ShardTensorToMesh(self.device_mesh, dim=0),
+            device=self.mesh_device,
+            mesh_mapper=ShardTensorToMesh(self.mesh_device, dim=0),
             layout=self.model_config["MLP_W_LAYOUT_TILE"],
             memory_config=self.model_config["MLP_WEIGHTS_MEMCFG"],
             cache_file_name=cache_name(name),

--- a/models/experimental/grok/tt/grok_rms_norm.py
+++ b/models/experimental/grok/tt/grok_rms_norm.py
@@ -10,7 +10,7 @@ from models.experimental.grok.tt.grok_common import LightweightModule
 class TtRMSNorm(LightweightModule):
     def __init__(
         self,
-        device_mesh,
+        mesh_device,
         state_dict,
         args,
         dtype,
@@ -19,7 +19,7 @@ class TtRMSNorm(LightweightModule):
         eps: float = 1e-05,
     ):
         super().__init__()
-        self.device_mesh = device_mesh
+        self.mesh_device = mesh_device
         self.eps = eps
         self.state_dict = state_dict
         self.model_config = args.get_model_config()
@@ -38,12 +38,12 @@ class TtRMSNorm(LightweightModule):
 
         self.weight = ttnn.as_tensor(
             torch_weight,
-            device=self.device_mesh,
+            device=self.mesh_device,
             dtype=dtype,
             layout=self.model_config["NORM_W_LAYOUT_TILE"],
             memory_config=self.model_config["NORM_WEIGHTS_MEMCFG"],
             cache_file_name=cache_name,
-            mesh_mapper=ReplicateTensorToMesh(device_mesh),
+            mesh_mapper=ReplicateTensorToMesh(mesh_device),
         )
 
     def forward(self, x: ttnn.Tensor) -> ttnn.Tensor:
@@ -54,7 +54,7 @@ class TtRMSNorm(LightweightModule):
 class TtRMSNormSharded(LightweightModule):
     def __init__(
         self,
-        device_mesh,
+        mesh_device,
         state_dict,
         args,
         dtype,
@@ -63,7 +63,7 @@ class TtRMSNormSharded(LightweightModule):
         eps: float = 1e-05,
     ):
         super().__init__()
-        self.device_mesh = device_mesh
+        self.mesh_device = mesh_device
         self.eps = eps
         self.state_dict = state_dict
         self.model_config = args.get_model_config()
@@ -83,12 +83,12 @@ class TtRMSNormSharded(LightweightModule):
 
         self.weight = ttnn.as_tensor(
             torch_weight,
-            device=self.device_mesh,
+            device=self.mesh_device,
             dtype=dtype,
             layout=ttnn.TILE_LAYOUT,
             memory_config=self.model_config["NORM_WEIGHTS_MEMCFG"],
             cache_file_name=cache_name,
-            mesh_mapper=ReplicateTensorToMesh(device_mesh),
+            mesh_mapper=ReplicateTensorToMesh(mesh_device),
         )
 
     def forward(self, x: ttnn.Tensor, out_sharded=False) -> ttnn.Tensor:

--- a/models/utility_functions.py
+++ b/models/utility_functions.py
@@ -194,7 +194,7 @@ def torch2tt_tensor(
 
 
 def tt_tensors_to_torch_tensors(
-    tt_tensors_device: ttnn.Tensor, device_mesh: Union[ttnn.DeviceMesh, ttnn.Device], concat_dim: int = 0
+    tt_tensors_device: ttnn.Tensor, mesh_device: Union[ttnn.MeshDevice, ttnn.Device], concat_dim: int = 0
 ):
     # Convert tensors to interleaved
     if tt_tensors_device.is_sharded():
@@ -211,7 +211,7 @@ def tt_tensors_to_torch_tensors(
         tt_tensors_device = ttnn.untilize(tt_tensors_device, use_multicore=False)
 
     tt_tensors_device = ttnn.to_torch(
-        tt_tensors_device, mesh_composer=ttnn.ConcatMeshToTensor(device_mesh, dim=concat_dim), device=device_mesh
+        tt_tensors_device, mesh_composer=ttnn.ConcatMeshToTensor(mesh_device, dim=concat_dim), device=mesh_device
     )
 
     return tt_tensors_device

--- a/tests/sweep_framework/README.md
+++ b/tests/sweep_framework/README.md
@@ -173,7 +173,7 @@ def invalidate_vector(test_vector) -> Tuple[bool, Optional[str]]:
 Vectors marked invalid will not be run by the test runner, but it will be recorded that it was skipped due to its invalidity.
 
 ### Device Fixture
-Each op test file can optionally have a `device_mesh_fixture` generator which will be picked up by the infra for when a developer wants to use a custom (multi-chip, mesh, or otherwise) device configuration.
+Each op test file can optionally have a `mesh_device_fixture` generator which will be picked up by the infra for when a developer wants to use a custom (multi-chip, mesh, or otherwise) device configuration.
 
 This function should have two stages, setup and teardown of the device. These stages will be executed before, and after the test suite is executed. They are separated by the yield statement.
 
@@ -184,7 +184,7 @@ The `yield` statement must give a tuple of your device object, and a label for t
 #### Example
 
 ```
-def device_mesh_fixture():
+def mesh_device_fixture():
     # SETUP (called before test suite is executed)
     import tt_lib as ttl
 
@@ -193,24 +193,24 @@ def device_mesh_fixture():
     device_ids = [0, 4, 5, 1, 2, 6, 7, 3]
     num_devices_requested = len(device_ids)
 
-    device_mesh = ttnn.open_device_mesh(
-        ttnn.DeviceGrid(1, num_devices_requested), device_ids[:num_devices_requested]
+    mesh_device = ttnn.open_mesh_device(
+        ttnn.MeshShape(1, num_devices_requested), device_ids[:num_devices_requested]
     )
 
     print("ADD: Opened device mesh")
     # YIELD to test infrastructure
     # IMPORTANT: Whatever device object(s) you want to pass to your run function need to be ONE object here, as this generator will only be referenced once before executing the tests.
     # i.e. If you have four separate devices to use in your test, use 'yield ([device1, device2, device3, device4], "4 Device Setup")' inside of a list.
-    yield (device_mesh, "T3000 Mesh")
+    yield (mesh_device, "T3000 Mesh")
 
     # TEARDOWN (called after test suite is finished executing)
     print("ADD: Closing device mesh")
 
-    for device in device_mesh.get_devices():
+    for device in mesh_device.get_devices():
         ttnn.DumpDeviceProfiler(device)
 
-    ttnn.close_device_mesh(device_mesh)
-    del device_mesh
+    ttnn.close_mesh_device(mesh_device)
+    del mesh_device
 ```
 
 ### Run Function
@@ -219,7 +219,7 @@ The run function will be called by the test runner with all defined parameters p
 
 This is where to define the test case itself including setup and teardown and golden comparison.
 
-If you defined a `device_mesh_fixture` generator, the object you yielded will be passed into this function as `device`. Otherwise, `device` will be the default ttnn device opened by the infra.
+If you defined a `mesh_device_fixture` generator, the object you yielded will be passed into this function as `device`. Otherwise, `device` will be the default ttnn device opened by the infra.
 
 The runner expects one of two returns from the run function:
 

--- a/tests/sweep_framework/runner.py
+++ b/tests/sweep_framework/runner.py
@@ -38,7 +38,7 @@ def get_username():
 
 def get_devices(test_module):
     try:
-        return test_module.device_mesh_fixture()
+        return test_module.mesh_device_fixture()
     except:
         return default_device()
 
@@ -69,7 +69,7 @@ def run(test_module, input_queue, output_queue):
             output_queue.put([status, message, e2e_perf])
     except Empty as e:
         try:
-            # Run teardown in device_mesh_fixture
+            # Run teardown in mesh_device_fixture
             next(device_generator)
         except StopIteration:
             print(f"SWEEPS: Closed device configuration, {device_name}.")

--- a/tests/sweep_framework/sweeps/add.py
+++ b/tests/sweep_framework/sweeps/add.py
@@ -76,7 +76,7 @@ def invalidate_vector(test_vector) -> Tuple[bool, Optional[str]]:
 # This is the run instructions for the test, defined by the developer.
 # The run function must take the above-defined parameters as inputs.
 # The runner will call this run function with each test vector, and the returned results from this function will be stored.
-# If you defined a device_mesh_fixture above, the object you yielded will be passed into this function as 'device'. Otherwise, it will be the default ttnn device opened by the infra.
+# If you defined a mesh_device_fixture above, the object you yielded will be passed into this function as 'device'. Otherwise, it will be the default ttnn device opened by the infra.
 def run(
     batch_sizes,
     height,

--- a/tests/ttnn/multichip_unit_tests/test_multidevice_TG.py
+++ b/tests/ttnn/multichip_unit_tests/test_multidevice_TG.py
@@ -24,28 +24,28 @@ from models.utility_functions import nearest_32
 
 @pytest.mark.skip("1D device mesh not supported")
 @pytest.mark.parametrize(
-    "device_mesh",
+    "mesh_device",
     [
         32,
     ],
     indirect=True,
 )
-def test_galaxy_matmul_1d_fracture(device_mesh):
+def test_galaxy_matmul_1d_fracture(mesh_device):
     act_pt = torch.randn(1, 1, 32, 8192)
     weights_pt = torch.randn(1, 1, 8192, 32768)
     act = ttnn.from_torch(
         act_pt,
         dtype=ttnn.bfloat16,
         layout=ttnn.TILE_LAYOUT,
-        device=device_mesh,
-        mesh_mapper=ReplicateTensorToMesh(device_mesh),
+        device=mesh_device,
+        mesh_mapper=ReplicateTensorToMesh(mesh_device),
     )
     weights = ttnn.from_torch(
         weights_pt,
         dtype=ttnn.bfloat16,
         layout=ttnn.TILE_LAYOUT,
-        device=device_mesh,
-        mesh_mapper=ShardTensorToMesh(device_mesh, dim=3),
+        device=mesh_device,
+        mesh_mapper=ShardTensorToMesh(mesh_device, dim=3),
     )
 
     gt = act_pt @ weights_pt
@@ -62,7 +62,7 @@ def test_galaxy_matmul_1d_fracture(device_mesh):
         core_grid=ttnn.CoreGrid(y=4, x=8),
         compute_kernel_config=compute_kernel_attn,
     )
-    out = ttnn.to_torch(out, mesh_composer=ConcatMeshToTensor(device_mesh, dim=3))
+    out = ttnn.to_torch(out, mesh_composer=ConcatMeshToTensor(mesh_device, dim=3))
 
     out_pass, out_pcc = comp_pcc(gt, out, pcc=0.99)
     logger.info(f"PCC value: {out_pcc}")
@@ -70,7 +70,7 @@ def test_galaxy_matmul_1d_fracture(device_mesh):
 
 
 @pytest.mark.parametrize(
-    "mesh_shape, device_mesh", [pytest.param((8, 4), (8, 4), id="8x4_grid")], indirect=["device_mesh"]
+    "mesh_shape, mesh_device", [pytest.param((8, 4), (8, 4), id="8x4_grid")], indirect=["mesh_device"]
 )
 @pytest.mark.parametrize(
     "M, K, N, weights_dtype",
@@ -96,7 +96,7 @@ def test_galaxy_matmul_1d_fracture(device_mesh):
     ],
 )
 # Llama FF1, FF2, FF3 in MLP with dram interleaved weights
-def test_galaxy_matmul_2d_fracture(M, K, N, weights_dtype, mesh_shape, device_mesh):
+def test_galaxy_matmul_2d_fracture(M, K, N, weights_dtype, mesh_shape, mesh_device):
     act_pt = torch.randn(1, 1, M, K)
     weights_pt = torch.randn(1, 1, K, N)
 
@@ -122,15 +122,15 @@ def test_galaxy_matmul_2d_fracture(M, K, N, weights_dtype, mesh_shape, device_me
         dtype=ttnn.bfloat16,
         layout=ttnn.TILE_LAYOUT,
         memory_config=act_mem_config if M == 32 else ttnn.DRAM_MEMORY_CONFIG,
-        device=device_mesh,
-        mesh_mapper=ShardTensor2dMesh(device_mesh, mesh_shape=mesh_shape, dims=act_shard_dim),
+        device=mesh_device,
+        mesh_mapper=ShardTensor2dMesh(mesh_device, mesh_shape=mesh_shape, dims=act_shard_dim),
     )
     weights = ttnn.from_torch(
         weights_pt,
         dtype=weights_dtype,
         layout=ttnn.TILE_LAYOUT,
-        device=device_mesh,
-        mesh_mapper=ShardTensor2dMesh(device_mesh, mesh_shape=mesh_shape, dims=weight_shard_dim),
+        device=mesh_device,
+        mesh_mapper=ShardTensor2dMesh(mesh_device, mesh_shape=mesh_shape, dims=weight_shard_dim),
     )
 
     gt = act_pt @ weights_pt
@@ -150,7 +150,7 @@ def test_galaxy_matmul_2d_fracture(M, K, N, weights_dtype, mesh_shape, device_me
         memory_config=ttnn.L1_WIDTH_SHARDED_MEMORY_CONFIG if M == 32 else ttnn.DRAM_MEMORY_CONFIG,
     )
 
-    out = ttnn.to_torch(out, mesh_composer=ConcatMesh2dToTensor(device_mesh, mesh_shape=mesh_shape, dims=concat_dim))
+    out = ttnn.to_torch(out, mesh_composer=ConcatMesh2dToTensor(mesh_device, mesh_shape=mesh_shape, dims=concat_dim))
     out = torch.sum(out, dim=1, keepdim=True)
 
     out_pass, out_pcc = comp_pcc(gt, out, pcc=0.99)
@@ -160,7 +160,7 @@ def test_galaxy_matmul_2d_fracture(M, K, N, weights_dtype, mesh_shape, device_me
 
 @pytest.mark.skip("See GH #10673: DRAM-SHARDED Matmuls gives ND PCC on TG")
 @pytest.mark.parametrize(
-    "mesh_shape, device_mesh", [pytest.param((8, 4), (8, 4), id="8x4_grid")], indirect=["device_mesh"]
+    "mesh_shape, mesh_device", [pytest.param((8, 4), (8, 4), id="8x4_grid")], indirect=["mesh_device"]
 )
 @pytest.mark.parametrize(
     "M, K, N, weights_dtype",
@@ -170,7 +170,7 @@ def test_galaxy_matmul_2d_fracture(M, K, N, weights_dtype, mesh_shape, device_me
     ],
 )
 # Llama FF1, FF2, FF3 in MLP with dram sharded weights
-def test_galaxy_matmul_2d_fracture_dram_sharded(M, K, N, weights_dtype, mesh_shape, device_mesh):
+def test_galaxy_matmul_2d_fracture_dram_sharded(M, K, N, weights_dtype, mesh_shape, mesh_device):
     act_pt = torch.randn(1, 1, M, K)
     weights_pt = torch.randn(1, 1, K, N)
 
@@ -194,9 +194,9 @@ def test_galaxy_matmul_2d_fracture_dram_sharded(M, K, N, weights_dtype, mesh_sha
         act_pt,
         dtype=ttnn.bfloat16,
         layout=ttnn.TILE_LAYOUT,
-        device=device_mesh,
+        device=mesh_device,
         memory_config=act_mem_config,
-        mesh_mapper=ShardTensor2dMesh(device_mesh, dims=act_shard_dim, mesh_shape=mesh_shape),
+        mesh_mapper=ShardTensor2dMesh(mesh_device, dims=act_shard_dim, mesh_shape=mesh_shape),
     )
 
     compute_kernel_lofi = ttnn.WormholeComputeKernelConfig(
@@ -211,7 +211,7 @@ def test_galaxy_matmul_2d_fracture_dram_sharded(M, K, N, weights_dtype, mesh_sha
             ttnn.CoreRange(
                 ttnn.CoreCoord(0, 0),
                 ttnn.CoreCoord(
-                    device_mesh.get_device(0).dram_grid_size().x - 1, device_mesh.get_device(0).dram_grid_size().y - 1
+                    mesh_device.get_device(0).dram_grid_size().x - 1, mesh_device.get_device(0).dram_grid_size().y - 1
                 ),
             )
         }
@@ -224,9 +224,9 @@ def test_galaxy_matmul_2d_fracture_dram_sharded(M, K, N, weights_dtype, mesh_sha
         weights_pt,
         dtype=weights_dtype,
         layout=ttnn.TILE_LAYOUT,
-        device=device_mesh,
+        device=mesh_device,
         memory_config=weight_mem_config,
-        mesh_mapper=ShardTensor2dMesh(device_mesh, dims=weight_shard_dim, mesh_shape=mesh_shape),
+        mesh_mapper=ShardTensor2dMesh(mesh_device, dims=weight_shard_dim, mesh_shape=mesh_shape),
     )
 
     DRAM_SHARDED_PROGCFG = ttnn.MatmulMultiCoreReuseMultiCastDRAMShardedProgramConfig(
@@ -245,7 +245,7 @@ def test_galaxy_matmul_2d_fracture_dram_sharded(M, K, N, weights_dtype, mesh_sha
         memory_config=ttnn.L1_WIDTH_SHARDED_MEMORY_CONFIG,
     )
 
-    out = ttnn.to_torch(out, mesh_composer=ConcatMesh2dToTensor(device_mesh, dims=concat_dim, mesh_shape=mesh_shape))
+    out = ttnn.to_torch(out, mesh_composer=ConcatMesh2dToTensor(mesh_device, dims=concat_dim, mesh_shape=mesh_shape))
     out = torch.sum(out, dim=1, keepdim=True)
 
     out_pass, out_pcc = comp_pcc(gt, out, pcc=0.99)
@@ -254,7 +254,7 @@ def test_galaxy_matmul_2d_fracture_dram_sharded(M, K, N, weights_dtype, mesh_sha
 
 
 @pytest.mark.parametrize(
-    "mesh_shape, device_mesh", [pytest.param((8, 4), (8, 4), id="8x4_grid")], indirect=["device_mesh"]
+    "mesh_shape, mesh_device", [pytest.param((8, 4), (8, 4), id="8x4_grid")], indirect=["mesh_device"]
 )
 @pytest.mark.parametrize(
     "M, N",
@@ -267,7 +267,7 @@ def test_galaxy_matmul_2d_fracture_dram_sharded(M, K, N, weights_dtype, mesh_sha
     ],
 )
 # Llama FF1 * FF3 in MLP
-def test_galaxy_eltwise_mul_2d_fracture(M, N, mesh_shape, device_mesh):
+def test_galaxy_eltwise_mul_2d_fracture(M, N, mesh_shape, mesh_device):
     FF1_pt = torch.randn(1, 1, M, N)
     FF3_pt = torch.randn(1, 1, M, N)
 
@@ -275,16 +275,16 @@ def test_galaxy_eltwise_mul_2d_fracture(M, N, mesh_shape, device_mesh):
         FF1_pt,
         dtype=ttnn.bfloat16,
         layout=ttnn.TILE_LAYOUT,
-        device=device_mesh,
-        mesh_mapper=ShardTensor2dMesh(device_mesh, dims=(3, None), mesh_shape=mesh_shape),
+        device=mesh_device,
+        mesh_mapper=ShardTensor2dMesh(mesh_device, dims=(3, None), mesh_shape=mesh_shape),
     )
 
     FF3 = ttnn.from_torch(
         FF3_pt,
         dtype=ttnn.bfloat16,
         layout=ttnn.TILE_LAYOUT,
-        device=device_mesh,
-        mesh_mapper=ShardTensor2dMesh(device_mesh, dims=(3, None), mesh_shape=mesh_shape),
+        device=mesh_device,
+        mesh_mapper=ShardTensor2dMesh(mesh_device, dims=(3, None), mesh_shape=mesh_shape),
     )
 
     gt = FF1_pt * FF3_pt
@@ -295,7 +295,7 @@ def test_galaxy_eltwise_mul_2d_fracture(M, N, mesh_shape, device_mesh):
         dtype=ttnn.bfloat16,
     )
 
-    out = ttnn.to_torch(out, mesh_composer=ConcatMesh2dToTensor(device_mesh, dims=(3, 1), mesh_shape=mesh_shape))
+    out = ttnn.to_torch(out, mesh_composer=ConcatMesh2dToTensor(mesh_device, dims=(3, 1), mesh_shape=mesh_shape))
     out = out[:, 0:1, :, :]  # select the first column
 
     out_pass, out_pcc = comp_pcc(gt, out, pcc=0.99999)
@@ -303,7 +303,7 @@ def test_galaxy_eltwise_mul_2d_fracture(M, N, mesh_shape, device_mesh):
     assert out_pass
 
 
-@pytest.mark.parametrize("device_mesh", [pytest.param((8, 4), id="8x4_grid")], indirect=True)
+@pytest.mark.parametrize("mesh_device", [pytest.param((8, 4), id="8x4_grid")], indirect=True)
 @pytest.mark.parametrize(
     "M, N",
     [
@@ -315,7 +315,7 @@ def test_galaxy_eltwise_mul_2d_fracture(M, N, mesh_shape, device_mesh):
     ],
 )
 # Llama residual add
-def test_galaxy_eltwise_add(M, N, device_mesh):
+def test_galaxy_eltwise_add(M, N, mesh_device):
     residual_pt = torch.randn(1, 1, M, N)
     attn_output_pt = torch.randn(1, 1, M, N)
 
@@ -346,18 +346,18 @@ def test_galaxy_eltwise_add(M, N, device_mesh):
         residual_pt,
         dtype=ttnn.bfloat16,
         layout=ttnn.TILE_LAYOUT,
-        device=device_mesh,
+        device=mesh_device,
         memory_config=LN_OUTPUT_MEMCFG,
-        mesh_mapper=ReplicateTensorToMesh(device_mesh),
+        mesh_mapper=ReplicateTensorToMesh(mesh_device),
     )
 
     attn_output = ttnn.from_torch(
         attn_output_pt,
         dtype=ttnn.bfloat16,
         layout=ttnn.TILE_LAYOUT,
-        device=device_mesh,
+        device=mesh_device,
         memory_config=LN_OUTPUT_MEMCFG,
-        mesh_mapper=ReplicateTensorToMesh(device_mesh),
+        mesh_mapper=ReplicateTensorToMesh(mesh_device),
     )
 
     gt = residual_pt + attn_output_pt
@@ -369,7 +369,7 @@ def test_galaxy_eltwise_add(M, N, device_mesh):
         memory_config=LN_OUTPUT_MEMCFG,
     )
 
-    out = ttnn.to_torch(out, mesh_composer=ListMeshToTensor(device_mesh))[0]
+    out = ttnn.to_torch(out, mesh_composer=ListMeshToTensor(mesh_device))[0]
 
     out_pass, out_pcc = comp_pcc(gt, out, pcc=0.99999)
     logger.info(f"PCC value: {out_pcc}")
@@ -377,7 +377,7 @@ def test_galaxy_eltwise_add(M, N, device_mesh):
 
 
 @pytest.mark.parametrize(
-    "mesh_shape, device_mesh", [pytest.param((8, 4), (8, 4), id="8x4_grid")], indirect=["device_mesh"]
+    "mesh_shape, mesh_device", [pytest.param((8, 4), (8, 4), id="8x4_grid")], indirect=["mesh_device"]
 )
 @pytest.mark.parametrize(
     "M, N, head_dim, num_heads",
@@ -395,7 +395,7 @@ def test_galaxy_eltwise_add(M, N, device_mesh):
     ],
 )
 # Llama attention matmuls
-def test_galaxy_attn_matmul(M, N, head_dim, num_heads, mesh_shape, device_mesh):
+def test_galaxy_attn_matmul(M, N, head_dim, num_heads, mesh_shape, mesh_device):
     act_pt = torch.randn(1, 1, M, N)
     weights_pt = torch.randn(1, 1, N, head_dim * num_heads)
 
@@ -403,16 +403,16 @@ def test_galaxy_attn_matmul(M, N, head_dim, num_heads, mesh_shape, device_mesh):
         act_pt,
         dtype=ttnn.bfloat16,
         layout=ttnn.TILE_LAYOUT,
-        device=device_mesh,
-        mesh_mapper=ReplicateTensorToMesh(device_mesh),
+        device=mesh_device,
+        mesh_mapper=ReplicateTensorToMesh(mesh_device),
     )
 
     weights = ttnn.from_torch(
         weights_pt,
         dtype=ttnn.bfloat8_b,
         layout=ttnn.TILE_LAYOUT,
-        device=device_mesh,
-        mesh_mapper=ShardTensor2dMesh(device_mesh, dims=(None, 3), mesh_shape=mesh_shape),
+        device=mesh_device,
+        mesh_mapper=ShardTensor2dMesh(mesh_device, dims=(None, 3), mesh_shape=mesh_shape),
     )
 
     compute_kernel_attn = ttnn.WormholeComputeKernelConfig(
@@ -443,7 +443,7 @@ def test_galaxy_attn_matmul(M, N, head_dim, num_heads, mesh_shape, device_mesh):
 
     gt = act_pt @ weights_pt
 
-    out = ttnn.to_torch(out, mesh_composer=ConcatMesh2dToTensor(device_mesh, dims=(1, 3), mesh_shape=mesh_shape))
+    out = ttnn.to_torch(out, mesh_composer=ConcatMesh2dToTensor(mesh_device, dims=(1, 3), mesh_shape=mesh_shape))
     out = out[:, 0:1, :, :]  # select the first column
 
     out_pass, out_pcc = comp_pcc(gt, out, pcc=0.99)
@@ -465,7 +465,7 @@ def num_to_corerange(total_max_cores):
 
 
 @pytest.mark.parametrize(
-    "device_mesh",
+    "mesh_device",
     [
         pytest.param((8, 4), id="8x4_grid"),
     ],
@@ -489,7 +489,7 @@ def num_to_corerange(total_max_cores):
 # users are fractured over 4 devices along the rows (batch of 8)
 # Note: interleaved inputs are not supported
 def test_galaxy_nlp_create_heads_decode(
-    batch, seq_len, head_dim, n_local_heads, n_local_kv_heads, is_multicore, device_mesh
+    batch, seq_len, head_dim, n_local_heads, n_local_kv_heads, is_multicore, mesh_device
 ):
     total_heads = n_local_heads + n_local_kv_heads * 2
     qkv_heads_pt = torch.rand(1, seq_len, batch, head_dim * total_heads)
@@ -518,8 +518,8 @@ def test_galaxy_nlp_create_heads_decode(
         dtype=ttnn.bfloat16,
         layout=ttnn.TILE_LAYOUT,
         memory_config=CREATE_HEAD_INPUT_MEMCFG,
-        device=device_mesh,
-        mesh_mapper=ReplicateTensorToMesh(device_mesh),
+        device=mesh_device,
+        mesh_mapper=ReplicateTensorToMesh(mesh_device),
     )
 
     # tt operation
@@ -546,17 +546,17 @@ def test_galaxy_nlp_create_heads_decode(
     )
 
     # compare
-    q_heads_tt_cpu = ttnn.to_torch(q_heads_tt, mesh_composer=ListMeshToTensor(device_mesh))[0][..., :n_local_heads, :]
+    q_heads_tt_cpu = ttnn.to_torch(q_heads_tt, mesh_composer=ListMeshToTensor(mesh_device))[0][..., :n_local_heads, :]
     out_pass_q, output_pcc_q = comp_pcc(q_heads_tt_cpu, q_heads_pt, pcc=0.9999)
     logger.info(f"PCC value: {output_pcc_q}")
 
-    k_heads_tt_cpu = ttnn.to_torch(k_heads_tt, mesh_composer=ListMeshToTensor(device_mesh))[0][
+    k_heads_tt_cpu = ttnn.to_torch(k_heads_tt, mesh_composer=ListMeshToTensor(mesh_device))[0][
         ..., :n_local_kv_heads, :
     ]
     out_pass_k, output_pcc_k = comp_pcc(k_heads_tt_cpu, k_heads_pt, pcc=0.9999)
     logger.info(f"PCC value: {output_pcc_k}")
 
-    v_heads_tt_cpu = ttnn.to_torch(v_heads_tt, mesh_composer=ListMeshToTensor(device_mesh))[0][
+    v_heads_tt_cpu = ttnn.to_torch(v_heads_tt, mesh_composer=ListMeshToTensor(mesh_device))[0][
         ..., :n_local_kv_heads, :
     ]
     out_pass_v, output_pcc_v = comp_pcc(v_heads_tt_cpu, v_heads_pt, pcc=0.9999)
@@ -565,7 +565,7 @@ def test_galaxy_nlp_create_heads_decode(
     assert out_pass_q and out_pass_k and out_pass_v
 
 
-@pytest.mark.parametrize("device_mesh", [pytest.param((8, 4), id="8x4_grid")], indirect=True)
+@pytest.mark.parametrize("mesh_device", [pytest.param((8, 4), id="8x4_grid")], indirect=True)
 @pytest.mark.parametrize(
     "batch, seq_len, head_dim, n_local_heads, n_local_kv_heads",
     [
@@ -575,7 +575,7 @@ def test_galaxy_nlp_create_heads_decode(
     ids=["Llama3-70B-decode", "Llama3-405B-decode"],
 )
 # Llama rotary matmul (decode only)
-def test_galaxy_rotary_matmul(batch, seq_len, head_dim, n_local_heads, n_local_kv_heads, device_mesh):
+def test_galaxy_rotary_matmul(batch, seq_len, head_dim, n_local_heads, n_local_kv_heads, mesh_device):
     q_heads_pt = torch.rand(
         seq_len, batch, max(n_local_heads, 32), head_dim
     )  # Unpad batch=32 to 8 for each column group
@@ -615,27 +615,27 @@ def test_galaxy_rotary_matmul(batch, seq_len, head_dim, n_local_heads, n_local_k
         q_heads_pt,
         dtype=ttnn.bfloat16,
         layout=ttnn.TILE_LAYOUT,
-        device=device_mesh,
+        device=mesh_device,
         memory_config=ROTARY_INPUT_MEMCFG,
-        mesh_mapper=ReplicateTensorToMesh(device_mesh),
+        mesh_mapper=ReplicateTensorToMesh(mesh_device),
     )
 
     key_layer = ttnn.from_torch(
         k_heads_pt,
         dtype=ttnn.bfloat16,
         layout=ttnn.TILE_LAYOUT,
-        device=device_mesh,
+        device=mesh_device,
         memory_config=ROTARY_INPUT_MEMCFG,
-        mesh_mapper=ReplicateTensorToMesh(device_mesh),
+        mesh_mapper=ReplicateTensorToMesh(mesh_device),
     )
 
     rot_mats = ttnn.from_torch(
         rot_mat_pt,
         dtype=ttnn.bfloat16,
         layout=ttnn.TILE_LAYOUT,
-        device=device_mesh,
+        device=mesh_device,
         memory_config=ROT_MAT_MEMCFG,
-        mesh_mapper=ReplicateTensorToMesh(device_mesh),
+        mesh_mapper=ReplicateTensorToMesh(mesh_device),
     )
 
     compute_kernel_rotary = ttnn.WormholeComputeKernelConfig(
@@ -672,8 +672,8 @@ def test_galaxy_rotary_matmul(batch, seq_len, head_dim, n_local_heads, n_local_k
     query_layer_gt = q_heads_pt @ rot_mat_pt
     key_layer_gt = k_heads_pt @ rot_mat_pt
 
-    query_layer_cpu = ttnn.to_torch(query_layer, mesh_composer=ListMeshToTensor(device_mesh))[0]
-    key_layer_cpu = ttnn.to_torch(key_layer, mesh_composer=ListMeshToTensor(device_mesh))[0]
+    query_layer_cpu = ttnn.to_torch(query_layer, mesh_composer=ListMeshToTensor(mesh_device))[0]
+    key_layer_cpu = ttnn.to_torch(key_layer, mesh_composer=ListMeshToTensor(mesh_device))[0]
 
     out_pass_q, out_pcc_q = comp_pcc(query_layer_cpu, query_layer_gt, pcc=0.999)
     logger.info(f"PCC value: {out_pcc_q}")
@@ -683,7 +683,7 @@ def test_galaxy_rotary_matmul(batch, seq_len, head_dim, n_local_heads, n_local_k
     assert out_pass_q and out_pass_k
 
 
-@pytest.mark.parametrize("device_mesh", [pytest.param((8, 4), id="8x4_grid")], indirect=True)
+@pytest.mark.parametrize("mesh_device", [pytest.param((8, 4), id="8x4_grid")], indirect=True)
 @pytest.mark.parametrize("head_dim", [128])
 @pytest.mark.parametrize("max_seq_len", [2048])
 @pytest.mark.parametrize("num_users", [8])
@@ -692,7 +692,7 @@ def test_galaxy_rotary_matmul(batch, seq_len, head_dim, n_local_heads, n_local_k
 class TestUpdateCache:
     @pytest.mark.parametrize("seq_len", [128, 2048])
     def test_fill_cache(
-        self, seq_len, head_dim, max_seq_len, num_users, num_heads, input_dtype, device_mesh, use_program_cache
+        self, seq_len, head_dim, max_seq_len, num_users, num_heads, input_dtype, mesh_device, use_program_cache
     ):
         cache_dtype = input_dtype
         input_shape = [1, num_heads, seq_len, head_dim]
@@ -703,15 +703,15 @@ class TestUpdateCache:
             cache,
             dtype=cache_dtype,
             layout=ttnn.TILE_LAYOUT,
-            device=device_mesh,
-            mesh_mapper=ReplicateTensorToMesh(device_mesh),
+            device=mesh_device,
+            mesh_mapper=ReplicateTensorToMesh(mesh_device),
         )
         for i in range(num_users):
             x = torch.randn(input_shape).bfloat16().float()
 
             xt = x
 
-            compute_grid_size = device_mesh.get_device(0).compute_with_storage_grid_size()
+            compute_grid_size = mesh_device.get_device(0).compute_with_storage_grid_size()
             num_cores = min(seq_len // 32 * num_heads, 32)  # Always use max 32 cores for testing
             mesh_shape = ttnn.CoreRangeSet(
                 ttnn.experimental.tensor.num_cores_to_corerange_set(num_cores, compute_grid_size, True)
@@ -733,15 +733,15 @@ class TestUpdateCache:
                 xt,
                 dtype=input_dtype,
                 layout=ttnn.TILE_LAYOUT,
-                device=device_mesh,
+                device=mesh_device,
                 memory_config=input_mem_config,
-                mesh_mapper=ReplicateTensorToMesh(device_mesh),
+                mesh_mapper=ReplicateTensorToMesh(mesh_device),
             )
 
             cachett = ttnn.fill_cache(cachett, xt, i)
             cache[i : i + 1, :, : x.shape[-2], :] = x
 
-        tt_got_back = ttnn.to_torch(cachett, mesh_composer=ListMeshToTensor(device_mesh))[0]
+        tt_got_back = ttnn.to_torch(cachett, mesh_composer=ListMeshToTensor(mesh_device))[0]
         eq, output = comp_pcc(cache, tt_got_back)
         logger.info(output)
         assert eq
@@ -759,7 +759,7 @@ class TestUpdateCache:
         num_heads,
         input_dtype,
         cache_dtype,
-        device_mesh,
+        mesh_device,
         use_program_cache,
     ):
         if num_users > 32 or (num_users + batch_offset) > 32:
@@ -773,8 +773,8 @@ class TestUpdateCache:
             cache,
             dtype=cache_dtype,
             layout=ttnn.TILE_LAYOUT,
-            device=device_mesh,
-            mesh_mapper=ReplicateTensorToMesh(device_mesh),
+            device=mesh_device,
+            mesh_mapper=ReplicateTensorToMesh(mesh_device),
         )
 
         x = torch.randn(input_shape).bfloat16().float()
@@ -785,7 +785,7 @@ class TestUpdateCache:
             x_new = torch.cat((x_new, torch.zeros(32 - num_users - batch_offset, num_heads, 1, head_dim)), dim=0)
             assert x_new.shape[0] == 32, f"Expected x.shape[0] to be 32, got {x_new.shape[0]}"
         xt = x_new.permute(2, 1, 0, 3)
-        compute_grid_size = device_mesh.get_device(0).compute_with_storage_grid_size()
+        compute_grid_size = mesh_device.get_device(0).compute_with_storage_grid_size()
         num_cores = min(max(num_users, 32) // 32 * num_heads, compute_grid_size.x * compute_grid_size.y)
         mesh_shape = ttnn.CoreRangeSet(
             ttnn.experimental.tensor.num_cores_to_corerange_set(num_cores, compute_grid_size, True)
@@ -809,15 +809,15 @@ class TestUpdateCache:
             xt,
             dtype=input_dtype,
             layout=ttnn.TILE_LAYOUT,
-            device=device_mesh,
+            device=mesh_device,
             memory_config=input_mem_config,
-            mesh_mapper=ReplicateTensorToMesh(device_mesh),
+            mesh_mapper=ReplicateTensorToMesh(mesh_device),
         )
 
         cachett = ttnn.update_cache(cachett, xt, cache_idx, batch_offset=batch_offset)
         cache[0:num_users, 0:num_heads, cache_idx : cache_idx + x.shape[-2], 0 : x.shape[-1]] = x
 
-        tt_got_back = ttnn.to_torch(cachett, mesh_composer=ListMeshToTensor(device_mesh))[0]
+        tt_got_back = ttnn.to_torch(cachett, mesh_composer=ListMeshToTensor(mesh_device))[0]
 
         eq_cache, output_cache = comp_pcc(cache, tt_got_back)  # checks the entire kv cache
         eq_update, output_update = comp_pcc(
@@ -856,7 +856,7 @@ def get_chunk_size(s):
 
 
 def run_test_sdpa_decode_single_iter(
-    device_mesh,
+    mesh_device,
     b,
     nh,
     nkv,
@@ -869,7 +869,7 @@ def run_test_sdpa_decode_single_iter(
     sharded_in=False,
     sharded_out=False,
 ):
-    compute_grid_size = device_mesh.get_device(0).compute_with_storage_grid_size()
+    compute_grid_size = mesh_device.get_device(0).compute_with_storage_grid_size()
     if grid_size[0] > compute_grid_size.x or grid_size[1] > compute_grid_size.y:
         pytest.skip(f"Need {grid_size} grid size to run this test but core grid is {compute_grid_size}")
 
@@ -903,20 +903,20 @@ def run_test_sdpa_decode_single_iter(
 
     tt_K = ttnn.from_torch(
         K,
-        device=device_mesh,
+        device=mesh_device,
         dtype=dtype,
         layout=ttnn.TILE_LAYOUT,
         memory_config=dram_memcfg,
-        mesh_mapper=ReplicateTensorToMesh(device_mesh),
+        mesh_mapper=ReplicateTensorToMesh(mesh_device),
     )
 
     tt_V = ttnn.from_torch(
         V,
-        device=device_mesh,
+        device=mesh_device,
         dtype=dtype,
         layout=ttnn.TILE_LAYOUT,
         memory_config=dram_memcfg,
-        mesh_mapper=ReplicateTensorToMesh(device_mesh),
+        mesh_mapper=ReplicateTensorToMesh(mesh_device),
     )
     start_idx = s // 2
     scale = d**-0.5
@@ -944,11 +944,11 @@ def run_test_sdpa_decode_single_iter(
 
     tt_Q = ttnn.from_torch(
         Q,
-        device=device_mesh,
+        device=mesh_device,
         dtype=dtype,
         layout=ttnn.TILE_LAYOUT,
         memory_config=dram_memcfg,
-        mesh_mapper=ReplicateTensorToMesh(device_mesh),
+        mesh_mapper=ReplicateTensorToMesh(mesh_device),
     )
 
     tt_back = ttnn.transformer.scaled_dot_product_attention_decode(
@@ -962,7 +962,7 @@ def run_test_sdpa_decode_single_iter(
         memory_config=height_sharded_memcfg if sharded_out else dram_memcfg,
     )
 
-    tt_back = ttnn.to_torch(tt_back, mesh_composer=ListMeshToTensor(device_mesh))[0]
+    tt_back = ttnn.to_torch(tt_back, mesh_composer=ListMeshToTensor(mesh_device))[0]
     tt_back = tt_back[:, :, :nh, :]
 
     Q_slice = Q[:, :, :nh, :].permute(1, 2, 0, 3)  # b, nh, 1, d
@@ -980,7 +980,7 @@ def run_test_sdpa_decode_single_iter(
     assert out_pass
 
 
-@pytest.mark.parametrize("device_mesh", [pytest.param((8, 4), id="8x4_grid")], indirect=True)
+@pytest.mark.parametrize("mesh_device", [pytest.param((8, 4), id="8x4_grid")], indirect=True)
 @pytest.mark.parametrize(
     "dtype, q_dtype, mask_dtype",
     [
@@ -1002,16 +1002,16 @@ def run_test_sdpa_decode_single_iter(
     ),
     ids=["Llama3-70B-decode", "Llama3-405B-decode"],
 )
-def test_sdpa_decode_sharded(device_mesh, b, nh, nkv, s, d, dtype, grid_size, q_dtype, mask_dtype):
+def test_sdpa_decode_sharded(mesh_device, b, nh, nkv, s, d, dtype, grid_size, q_dtype, mask_dtype):
     run_test_sdpa_decode_single_iter(
-        device_mesh, b, nh, nkv, s, d, dtype, grid_size, q_dtype, mask_dtype, sharded_in=True, sharded_out=False
+        mesh_device, b, nh, nkv, s, d, dtype, grid_size, q_dtype, mask_dtype, sharded_in=True, sharded_out=False
     )
     run_test_sdpa_decode_single_iter(
-        device_mesh, b, nh, nkv, s, d, dtype, grid_size, q_dtype, mask_dtype, sharded_in=True, sharded_out=True
+        mesh_device, b, nh, nkv, s, d, dtype, grid_size, q_dtype, mask_dtype, sharded_in=True, sharded_out=True
     )
 
 
-@pytest.mark.parametrize("device_mesh", [pytest.param((8, 4), id="8x4_grid")], indirect=True)
+@pytest.mark.parametrize("mesh_device", [pytest.param((8, 4), id="8x4_grid")], indirect=True)
 @pytest.mark.parametrize(
     "batch, seq_len, head_dim, n_local_heads, n_local_kv_heads, padded_local_heads",
     [
@@ -1021,7 +1021,7 @@ def test_sdpa_decode_sharded(device_mesh, b, nh, nkv, s, d, dtype, grid_size, q_
     ids=["Llama3-70B-decode", "Llama3-405B-decode"],
 )
 def test_galaxy_nlp_concat_heads_decode(
-    batch, seq_len, head_dim, n_local_heads, n_local_kv_heads, padded_local_heads, device_mesh
+    batch, seq_len, head_dim, n_local_heads, n_local_kv_heads, padded_local_heads, mesh_device
 ):
     concat_head_input = torch.rand(seq_len, batch, padded_local_heads, head_dim)
 
@@ -1045,8 +1045,8 @@ def test_galaxy_nlp_concat_heads_decode(
         dtype=ttnn.bfloat16,
         layout=ttnn.TILE_LAYOUT,
         memory_config=CONCAT_HEADS_INPUT_MEMCFG,
-        device=device_mesh,
-        mesh_mapper=ReplicateTensorToMesh(device_mesh),
+        device=mesh_device,
+        mesh_mapper=ReplicateTensorToMesh(mesh_device),
     )
 
     concat_head_output = ttnn.experimental.nlp_concat_heads_decode(
@@ -1061,7 +1061,7 @@ def test_galaxy_nlp_concat_heads_decode(
     concat_head_output_pt = concat_head_input[:, :, :n_local_heads].reshape(1, 1, batch, head_dim * n_local_heads)
 
     # Compare
-    concat_head_output_tt_cpu = ttnn.to_torch(concat_head_output, mesh_composer=ListMeshToTensor(device_mesh))[0]
+    concat_head_output_tt_cpu = ttnn.to_torch(concat_head_output, mesh_composer=ListMeshToTensor(mesh_device))[0]
     concat_head_output_tt_unpadded = concat_head_output_tt_cpu[:, :, :batch, :]
     out_pass, output_pcc = comp_pcc(concat_head_output_tt_unpadded, concat_head_output_pt, pcc=0.9999)
     logger.info(f"PCC value: {output_pcc}")
@@ -1073,7 +1073,7 @@ def rmsnorm(x, gamma, beta, eps):
     return x * torch.rsqrt(x.pow(2).mean(-1, keepdim=True) + eps) * gamma + beta
 
 
-@pytest.mark.parametrize("device_mesh", [pytest.param((8, 4), id="8x4_grid")], indirect=True)
+@pytest.mark.parametrize("mesh_device", [pytest.param((8, 4), id="8x4_grid")], indirect=True)
 @pytest.mark.parametrize(
     "M, N",
     [
@@ -1082,7 +1082,7 @@ def rmsnorm(x, gamma, beta, eps):
     ],
     ids=["Llama3-70B-decode", "Llama3-405B-decode"],
 )
-def test_galaxy_layernorm(M, N, device_mesh):
+def test_galaxy_layernorm(M, N, mesh_device):
     layernorm_input = torch.rand(1, 1, M, N) * 2 - 0.95
     norm_weights = torch.rand(1, 1, N // 32, 32) * 2 - 1
     norm_eps = 1e-05
@@ -1131,16 +1131,16 @@ def test_galaxy_layernorm(M, N, device_mesh):
         dtype=ttnn.bfloat16,
         layout=ttnn.TILE_LAYOUT,
         memory_config=LN_OUTPUT_MEMCFG,
-        device=device_mesh,
-        mesh_mapper=ReplicateTensorToMesh(device_mesh),
+        device=mesh_device,
+        mesh_mapper=ReplicateTensorToMesh(mesh_device),
     )
 
     norm_weights_tt = ttnn.from_torch(
         norm_weights,
         dtype=ttnn.bfloat16,
         layout=ttnn.ROW_MAJOR_LAYOUT,
-        device=device_mesh,
-        mesh_mapper=ReplicateTensorToMesh(device_mesh),
+        device=mesh_device,
+        mesh_mapper=ReplicateTensorToMesh(mesh_device),
     )
 
     norm_output = ttnn.rms_norm(
@@ -1154,7 +1154,7 @@ def test_galaxy_layernorm(M, N, device_mesh):
 
     # Compare
     beta = torch.zeros(1, 1, N // 32, 32)
-    norm_output_tt_cpu = ttnn.to_torch(norm_output, mesh_composer=ListMeshToTensor(device_mesh))[0]
+    norm_output_tt_cpu = ttnn.to_torch(norm_output, mesh_composer=ListMeshToTensor(mesh_device))[0]
     ref_rmsnorm = rmsnorm(layernorm_input, norm_weights.flatten(), beta.flatten(), norm_eps)
 
     out_pass, output_pcc = comp_pcc(norm_output_tt_cpu, ref_rmsnorm, pcc=0.999)
@@ -1163,15 +1163,15 @@ def test_galaxy_layernorm(M, N, device_mesh):
     assert out_pass
 
 
-@pytest.mark.parametrize("device_mesh", [pytest.param((8, 4), id="8x4_grid")], indirect=True)
-def test_device_submesh(device_mesh):
+@pytest.mark.parametrize("mesh_device", [pytest.param((8, 4), id="8x4_grid")], indirect=True)
+def test_device_submesh(mesh_device):
     rows, cols, tile_size = 8, 4, 32
     full_tensor = torch.rand((1, 1, tile_size * rows, tile_size * cols), dtype=torch.bfloat16)
 
     ttnn_tensor = ttnn.from_torch(
-        full_tensor, mesh_mapper=ShardTensor2dMesh(device_mesh, mesh_shape=(rows, cols), dims=(-2, -1))
+        full_tensor, mesh_mapper=ShardTensor2dMesh(mesh_device, mesh_shape=(rows, cols), dims=(-2, -1))
     )
-    ttnn_tensor = ttnn.to_device(ttnn_tensor, device_mesh)
+    ttnn_tensor = ttnn.to_device(ttnn_tensor, mesh_device)
 
     device_tensors: typing.List[ttnn.Tensor] = ttnn.get_device_tensors(ttnn_tensor)
     for index, device_tensor in enumerate(device_tensors):
@@ -1184,15 +1184,15 @@ def test_device_submesh(device_mesh):
         assert torch.all(device_tensor_torch == full_tensor[0, 0, row_start:row_end, col_start:col_end])
 
 
-@pytest.mark.parametrize("device_mesh", [pytest.param((1, 4), id="1x4_grid")], indirect=True)
-def test_device_line_all_gather_1x4(device_mesh):
+@pytest.mark.parametrize("mesh_device", [pytest.param((1, 4), id="1x4_grid")], indirect=True)
+def test_device_line_all_gather_1x4(mesh_device):
     rows, cols, tile_size = 1, 4, 32
     full_tensor = torch.rand((1, 1, tile_size * rows, tile_size * cols), dtype=torch.bfloat16)
 
     ttnn_tensor = ttnn.from_torch(
-        full_tensor, mesh_mapper=ShardTensor2dMesh(device_mesh, mesh_shape=(rows, cols), dims=(-2, -1))
+        full_tensor, mesh_mapper=ShardTensor2dMesh(mesh_device, mesh_shape=(rows, cols), dims=(-2, -1))
     )
-    ttnn_tensor = ttnn.to_device(ttnn_tensor, device_mesh)
+    ttnn_tensor = ttnn.to_device(ttnn_tensor, mesh_device)
     ttnn_tensor = ttnn.line_all_gather(ttnn_tensor, dim=3, num_links=1)
 
     device_tensors: typing.List[ttnn.Tensor] = ttnn.get_device_tensors(ttnn_tensor)
@@ -1202,16 +1202,16 @@ def test_device_line_all_gather_1x4(device_mesh):
         assert torch.all(device_tensor_torch == full_tensor)
 
 
-@pytest.mark.parametrize("device_mesh", [pytest.param((8, 1), id="8x1_grid")], indirect=True)
-def test_device_line_all_gather_8x1(device_mesh):
+@pytest.mark.parametrize("mesh_device", [pytest.param((8, 1), id="8x1_grid")], indirect=True)
+def test_device_line_all_gather_8x1(mesh_device):
     rows, cols, tile_size = 8, 1, 32
     full_tensor = torch.rand((1, 1, tile_size * rows, tile_size * cols), dtype=torch.bfloat16)
 
     ttnn_tensor = ttnn.from_torch(
-        full_tensor, mesh_mapper=ShardTensor2dMesh(device_mesh, mesh_shape=(rows, cols), dims=(-2, -1))
+        full_tensor, mesh_mapper=ShardTensor2dMesh(mesh_device, mesh_shape=(rows, cols), dims=(-2, -1))
     )
-    ttnn_tensor = ttnn.to_device(ttnn_tensor, device_mesh)
-    ttnn_tensor = ttnn.line_all_gather(ttnn_tensor, dim=2, cluster_axis=0, device_mesh=device_mesh, num_links=1)
+    ttnn_tensor = ttnn.to_device(ttnn_tensor, mesh_device)
+    ttnn_tensor = ttnn.line_all_gather(ttnn_tensor, dim=2, cluster_axis=0, mesh_device=mesh_device, num_links=1)
 
     device_tensors: typing.List[ttnn.Tensor] = ttnn.get_device_tensors(ttnn_tensor)
     for index, device_tensor in enumerate(device_tensors):
@@ -1219,14 +1219,14 @@ def test_device_line_all_gather_8x1(device_mesh):
         assert torch.all(device_tensor_torch == full_tensor)
 
 
-@pytest.mark.parametrize("device_mesh", [pytest.param((8, 4), id="8x4_grid")], indirect=True)
+@pytest.mark.parametrize("mesh_device", [pytest.param((8, 4), id="8x4_grid")], indirect=True)
 @pytest.mark.parametrize("cluster_axis", (0, 1))
 @pytest.mark.parametrize("dim", (2, 3))
-def test_device_line_all_gather_8x4_data(device_mesh, cluster_axis: int, dim: int):
+def test_device_line_all_gather_8x4_data(mesh_device, cluster_axis: int, dim: int):
     """
     Test the line-all-gather operation on a 8x4 mesh.
 
-    Data Pattern for initial sharding [TILE_SIZE*DEVICE_MESH_ROWS, TILE_SIZE*DEVICE_MESH_COLS]:
+    Data Pattern for initial sharding [TILE_SIZE*mesh_device_ROWS, TILE_SIZE*mesh_device_COLS]:
     [1, 1, 1, 1, 1, 1, 1, 1]
     [2, 2, 2, 2, 2, 2, 2, 2]
     [3, 3, 3, 3, 3, 3, 3, 3]
@@ -1238,21 +1238,21 @@ def test_device_line_all_gather_8x4_data(device_mesh, cluster_axis: int, dim: in
 
     Expected data-pattern per-device after line-all-gather:
     - Every device along the column contains the whole column tensor
-    - output: [[1],[2],[3],[4],[5],[6],[7],[8]], shape: [1, 1, TILE_SIZE * DEVICE_MESH_ROWS, 32]
+    - output: [[1],[2],[3],[4],[5],[6],[7],[8]], shape: [1, 1, TILE_SIZE * mesh_device_ROWS, 32]
     """
 
-    (rows, cols), tile_size = device_mesh.shape, 32
+    (rows, cols), tile_size = mesh_device.shape, 32
     full_tensor = torch.zeros((1, 1, tile_size * rows, tile_size * cols), dtype=torch.bfloat16)
 
     for i in range(rows):
         full_tensor[0, 0, i * tile_size : (i + 1) * tile_size, :] = torch.full((tile_size, tile_size * cols), i + 1.0)
 
     ttnn_tensor = ttnn.from_torch(
-        full_tensor, mesh_mapper=ShardTensor2dMesh(device_mesh, mesh_shape=(rows, cols), dims=(-2, -1))
+        full_tensor, mesh_mapper=ShardTensor2dMesh(mesh_device, mesh_shape=(rows, cols), dims=(-2, -1))
     )
-    ttnn_tensor = ttnn.to_device(ttnn_tensor, device_mesh)
+    ttnn_tensor = ttnn.to_device(ttnn_tensor, mesh_device)
     ttnn_tensor = ttnn.line_all_gather(
-        ttnn_tensor, dim=dim, cluster_axis=cluster_axis, device_mesh=device_mesh, num_links=1
+        ttnn_tensor, dim=dim, cluster_axis=cluster_axis, mesh_device=mesh_device, num_links=1
     )
 
     device_tensors: typing.List[ttnn.Tensor] = ttnn.get_device_tensors(ttnn_tensor)
@@ -1280,26 +1280,26 @@ def test_device_line_all_gather_8x4_data(device_mesh, cluster_axis: int, dim: in
         assert torch.allclose(device_tensor_torch, expected, atol=1e-3)
 
 
-@pytest.mark.parametrize("device_mesh", [pytest.param((8, 4), id="8x4_grid")], indirect=True)
-def test_visualize_device_mesh(device_mesh):
-    ttnn.visualize_device_mesh(device_mesh)
+@pytest.mark.parametrize("mesh_device", [pytest.param((8, 4), id="8x4_grid")], indirect=True)
+def test_visualize_mesh_device(mesh_device):
+    ttnn.visualize_mesh_device(mesh_device)
 
 
-@pytest.mark.parametrize("device_mesh", [pytest.param((8, 4), id="8x4_grid")], indirect=True)
-def test_concat_device_mesh_2d(device_mesh):
-    (rows, cols), tile_size = device_mesh.shape, 32
+@pytest.mark.parametrize("mesh_device", [pytest.param((8, 4), id="8x4_grid")], indirect=True)
+def test_concat_mesh_device_2d(mesh_device):
+    (rows, cols), tile_size = mesh_device.shape, 32
     full_tensor = torch.rand((1, 1, tile_size * rows, tile_size * cols), dtype=torch.bfloat16)
     ttnn_tensor = ttnn.from_torch(
-        full_tensor, mesh_mapper=ShardTensor2dMesh(device_mesh, mesh_shape=(rows, cols), dims=(-2, -1))
+        full_tensor, mesh_mapper=ShardTensor2dMesh(mesh_device, mesh_shape=(rows, cols), dims=(-2, -1))
     )
-    ttnn_tensor = ttnn.to_device(ttnn_tensor, device_mesh)
+    ttnn_tensor = ttnn.to_device(ttnn_tensor, mesh_device)
     read_back_tensor = ttnn.to_torch(
-        ttnn_tensor, mesh_composer=ConcatMesh2dToTensor(device_mesh, mesh_shape=(rows, cols), dims=(-2, -1))
+        ttnn_tensor, mesh_composer=ConcatMesh2dToTensor(mesh_device, mesh_shape=(rows, cols), dims=(-2, -1))
     )
     assert torch.allclose(read_back_tensor, full_tensor, atol=1e-3)
 
 
-@pytest.mark.parametrize("device_mesh", [pytest.param((8, 4), id="8x4_grid")], indirect=True)
+@pytest.mark.parametrize("mesh_device", [pytest.param((8, 4), id="8x4_grid")], indirect=True)
 @pytest.mark.parametrize(
     "dims",
     [
@@ -1307,24 +1307,24 @@ def test_concat_device_mesh_2d(device_mesh):
         pytest.param((2, 3), id="shard_height_and_width"),  # TODO(jchu):per device shards can be less than 32?
     ],
 )
-def test_shard_and_concat_2d_various_dims(device_mesh, dims):
-    rows, cols = device_mesh.shape
+def test_shard_and_concat_2d_various_dims(mesh_device, dims):
+    rows, cols = mesh_device.shape
     batch, channels, height, width = 16, 64, 128, 128
     full_tensor = torch.rand((batch, channels, height, width), dtype=torch.float32)
 
     ttnn_tensor = ttnn.from_torch(
-        full_tensor, mesh_mapper=ShardTensor2dMesh(device_mesh, mesh_shape=(rows, cols), dims=dims)
+        full_tensor, mesh_mapper=ShardTensor2dMesh(mesh_device, mesh_shape=(rows, cols), dims=dims)
     )
-    ttnn_tensor = ttnn.to_device(ttnn_tensor, device_mesh)
+    ttnn_tensor = ttnn.to_device(ttnn_tensor, mesh_device)
 
     read_back_tensor = ttnn.to_torch(
-        ttnn_tensor, mesh_composer=ConcatMesh2dToTensor(device_mesh, mesh_shape=(rows, cols), dims=dims)
+        ttnn_tensor, mesh_composer=ConcatMesh2dToTensor(mesh_device, mesh_shape=(rows, cols), dims=dims)
     )
 
     assert torch.allclose(read_back_tensor, full_tensor, atol=1e-6)
 
 
-@pytest.mark.parametrize("device_mesh", [pytest.param((8, 4), id="8x4_grid")], indirect=True)
+@pytest.mark.parametrize("mesh_device", [pytest.param((8, 4), id="8x4_grid")], indirect=True)
 @pytest.mark.parametrize(
     "tensor_shape",
     [
@@ -1333,42 +1333,42 @@ def test_shard_and_concat_2d_various_dims(device_mesh, dims):
         pytest.param((64, 3, 224, 224), id="imagenet_like"),
     ],
 )
-def test_shard_and_concat_2d_various_shapes(device_mesh, tensor_shape):
-    rows, cols = device_mesh.shape
+def test_shard_and_concat_2d_various_shapes(mesh_device, tensor_shape):
+    rows, cols = mesh_device.shape
     full_tensor = torch.rand(tensor_shape, dtype=torch.float32)
 
     ttnn_tensor = ttnn.from_torch(
-        full_tensor, mesh_mapper=ShardTensor2dMesh(device_mesh, mesh_shape=(rows, cols), dims=(2, 3))
+        full_tensor, mesh_mapper=ShardTensor2dMesh(mesh_device, mesh_shape=(rows, cols), dims=(2, 3))
     )
-    ttnn_tensor = ttnn.to_device(ttnn_tensor, device_mesh)
+    ttnn_tensor = ttnn.to_device(ttnn_tensor, mesh_device)
 
     read_back_tensor = ttnn.to_torch(
-        ttnn_tensor, mesh_composer=ConcatMesh2dToTensor(device_mesh, mesh_shape=(rows, cols), dims=(2, 3))
+        ttnn_tensor, mesh_composer=ConcatMesh2dToTensor(mesh_device, mesh_shape=(rows, cols), dims=(2, 3))
     )
 
     assert torch.allclose(read_back_tensor, full_tensor, atol=1e-6)
 
 
-@pytest.mark.parametrize("device_mesh", [pytest.param((8, 4), id="8x4_grid")], indirect=True)
-def test_shard_and_concat_2d_non_divisible(device_mesh):
-    rows, cols = device_mesh.shape
+@pytest.mark.parametrize("mesh_device", [pytest.param((8, 4), id="8x4_grid")], indirect=True)
+def test_shard_and_concat_2d_non_divisible(mesh_device):
+    rows, cols = mesh_device.shape
     # Create a tensor with dimensions not perfectly divisible by the mesh shape
     full_tensor = torch.rand((30, 62, 130, 126), dtype=torch.float32)
 
     ttnn_tensor = ttnn.from_torch(
-        full_tensor, mesh_mapper=ShardTensor2dMesh(device_mesh, mesh_shape=(rows, cols), dims=(2, 3))
+        full_tensor, mesh_mapper=ShardTensor2dMesh(mesh_device, mesh_shape=(rows, cols), dims=(2, 3))
     )
-    ttnn_tensor = ttnn.to_device(ttnn_tensor, device_mesh)
+    ttnn_tensor = ttnn.to_device(ttnn_tensor, mesh_device)
 
     read_back_tensor = ttnn.to_torch(
-        ttnn_tensor, mesh_composer=ConcatMesh2dToTensor(device_mesh, mesh_shape=(rows, cols), dims=(2, 3))
+        ttnn_tensor, mesh_composer=ConcatMesh2dToTensor(mesh_device, mesh_shape=(rows, cols), dims=(2, 3))
     )
 
     assert torch.allclose(read_back_tensor, full_tensor, atol=1e-6)
 
 
-@pytest.mark.parametrize("device_mesh", [pytest.param((8, 1), id="8x1_grid")], indirect=True)
-def test_line_all_gather_column_major(device_mesh):
+@pytest.mark.parametrize("mesh_device", [pytest.param((8, 1), id="8x1_grid")], indirect=True)
+def test_line_all_gather_column_major(mesh_device):
     """
     The input tensor is size [1, 1, 32, 32*8] and it will get sharded onto an 8-row (8x1) device-mesh as follows:
 
@@ -1388,25 +1388,25 @@ def test_line_all_gather_column_major(device_mesh):
     full_tensor = torch.rand((1, 1, tile_size, tile_size * rows), dtype=torch.bfloat16)
 
     ttnn_tensor = ttnn.from_torch(
-        full_tensor, mesh_mapper=ShardTensor2dMesh(device_mesh, mesh_shape=(rows, cols), dims=(-1, -2))
+        full_tensor, mesh_mapper=ShardTensor2dMesh(mesh_device, mesh_shape=(rows, cols), dims=(-1, -2))
     )
-    ttnn_tensor = ttnn.to_device(ttnn_tensor, device_mesh)
-    ttnn.visualize_device_mesh(device_mesh, tensor=ttnn_tensor)
-    ttnn_tensor = ttnn.line_all_gather(ttnn_tensor, dim=3, cluster_axis=0, device_mesh=device_mesh, num_links=1)
-    tt_outputs = ttnn.to_torch(ttnn_tensor, mesh_composer=ListMeshToTensor(device_mesh))
+    ttnn_tensor = ttnn.to_device(ttnn_tensor, mesh_device)
+    ttnn.visualize_mesh_device(mesh_device, tensor=ttnn_tensor)
+    ttnn_tensor = ttnn.line_all_gather(ttnn_tensor, dim=3, cluster_axis=0, mesh_device=mesh_device, num_links=1)
+    tt_outputs = ttnn.to_torch(ttnn_tensor, mesh_composer=ListMeshToTensor(mesh_device))
     for output in tt_outputs[1:]:
         assert output.shape == (1, 1, 32, 32 * 8)
         assert torch.allclose(output, tt_outputs[0])
 
 
-@pytest.mark.parametrize("device_mesh", [pytest.param((8, 4), id="8x4_grid")], indirect=True)
+@pytest.mark.parametrize("mesh_device", [pytest.param((8, 4), id="8x4_grid")], indirect=True)
 @pytest.mark.parametrize("cluster_axis", (1,))
 @pytest.mark.parametrize("dim", (0,))
 @pytest.mark.parametrize("async_mode", (False, True))
-def test_device_line_all_gather_8x4_data(device_mesh, cluster_axis: int, dim: int, async_mode: bool):
+def test_device_line_all_gather_8x4_data(mesh_device, cluster_axis: int, dim: int, async_mode: bool):
     """
     Test the line-all-gather operation on a 8x4 mesh.
-    Data Pattern for initial sharding [TILE_SIZE*DEVICE_MESH_ROWS, TILE_SIZE*DEVICE_MESH_COLS]:
+    Data Pattern for initial sharding [TILE_SIZE*mesh_device_ROWS, TILE_SIZE*mesh_device_COLS]:
     Input:
         [1, 1, 1, 1]
         [2, 2, 2, 2]
@@ -1420,42 +1420,42 @@ def test_device_line_all_gather_8x4_data(device_mesh, cluster_axis: int, dim: in
     - Every device will have the shape: [4, 1, 32, 32]
     """
     if async_mode:
-        for i in device_mesh.get_device_ids():
-            device = device_mesh.get_device(i)
+        for i in mesh_device.get_device_ids():
+            device = mesh_device.get_device(i)
             device.enable_async(True)
 
-    (rows, cols), tile_size = device_mesh.shape, 32
+    (rows, cols), tile_size = mesh_device.shape, 32
     full_tensor = torch.zeros((1, 1, tile_size * rows, tile_size * cols), dtype=torch.bfloat16)
     for i in range(rows):
         full_tensor[0, 0, i * tile_size : (i + 1) * tile_size, :] = torch.full((tile_size, tile_size * cols), i + 1.0)
     ttnn_tensor = ttnn.from_torch(
-        full_tensor, mesh_mapper=ShardTensor2dMesh(device_mesh, mesh_shape=(rows, cols), dims=(-2, -1))
+        full_tensor, mesh_mapper=ShardTensor2dMesh(mesh_device, mesh_shape=(rows, cols), dims=(-2, -1))
     )
-    ttnn_tensor = ttnn.to_device(ttnn_tensor, device_mesh)
+    ttnn_tensor = ttnn.to_device(ttnn_tensor, mesh_device)
     ttnn_tensor = ttnn.line_all_gather(
-        ttnn_tensor, dim=dim, cluster_axis=cluster_axis, device_mesh=device_mesh, num_links=1
+        ttnn_tensor, dim=dim, cluster_axis=cluster_axis, mesh_device=mesh_device, num_links=1
     )
 
 
-@pytest.mark.parametrize("device_mesh", [pytest.param((8, 4), id="8x4_grid")], indirect=True)
-def test_visualize_device_mesh_with_tensor_row_major(device_mesh):
+@pytest.mark.parametrize("mesh_device", [pytest.param((8, 4), id="8x4_grid")], indirect=True)
+def test_visualize_mesh_device_with_tensor_row_major(mesh_device):
     rows, cols, tile_size = 4, 4, 32
     full_tensor = torch.rand((1, 1, tile_size * rows, tile_size * cols), dtype=torch.bfloat16)
 
     ttnn_tensor = ttnn.from_torch(
-        full_tensor, mesh_mapper=ShardTensor2dMesh(device_mesh, mesh_shape=(rows, cols), dims=(-2, -1))
+        full_tensor, mesh_mapper=ShardTensor2dMesh(mesh_device, mesh_shape=(rows, cols), dims=(-2, -1))
     )
-    ttnn_tensor = ttnn.to_device(ttnn_tensor, device_mesh)
-    ttnn.visualize_device_mesh(device_mesh, tensor=ttnn_tensor)
+    ttnn_tensor = ttnn.to_device(ttnn_tensor, mesh_device)
+    ttnn.visualize_mesh_device(mesh_device, tensor=ttnn_tensor)
 
 
-@pytest.mark.parametrize("device_mesh", [pytest.param((8, 4), id="8x4_grid")], indirect=True)
-def test_visualize_device_mesh_with_tensor_col_major(device_mesh):
+@pytest.mark.parametrize("mesh_device", [pytest.param((8, 4), id="8x4_grid")], indirect=True)
+def test_visualize_mesh_device_with_tensor_col_major(mesh_device):
     rows, cols, tile_size = 8, 2, 32
     full_tensor = torch.rand((1, 1, tile_size * rows, tile_size * cols), dtype=torch.bfloat16)
 
     ttnn_tensor = ttnn.from_torch(
-        full_tensor, mesh_mapper=ShardTensor2dMesh(device_mesh, mesh_shape=(rows, cols), dims=(-2, -1))
+        full_tensor, mesh_mapper=ShardTensor2dMesh(mesh_device, mesh_shape=(rows, cols), dims=(-2, -1))
     )
-    ttnn_tensor = ttnn.to_device(ttnn_tensor, device_mesh)
-    ttnn.visualize_device_mesh(device_mesh, tensor=ttnn_tensor)
+    ttnn_tensor = ttnn.to_device(ttnn_tensor, mesh_device)
+    ttnn.visualize_mesh_device(mesh_device, tensor=ttnn_tensor)

--- a/tests/ttnn/unit_tests/gtests/test_ccl_on_tg.cpp
+++ b/tests/ttnn/unit_tests/gtests/test_ccl_on_tg.cpp
@@ -65,7 +65,7 @@ TEST(TGTests, TestAllGatherDeadlock) {
     }
 
     // Create the device mesh: Grid size is <num_tunnels, tunnel_depth>.
-    auto mesh = ttnn::multi_device::open_device_mesh({cluster_tunnel_count * num_mmio_devices, num_devices_in_tunnel}, all_device_ids, 0, 0, 1, DispatchCoreType::WORKER);
+    auto mesh = ttnn::multi_device::open_mesh_device({cluster_tunnel_count * num_mmio_devices, num_devices_in_tunnel}, all_device_ids, 0, 0, 1, DispatchCoreType::WORKER);
 
     // Setup input data and output data containers
     MemoryConfig mem_cfg = MemoryConfig{
@@ -131,7 +131,7 @@ TEST(TGTests, TestAllGatherDeadlock) {
             }
         }
     }
-    ttnn::multi_device::close_device_mesh(mesh);
+    ttnn::multi_device::close_mesh_device(mesh);
 }
 
 TEST(TGTests, TestReduceScatterDeadlock) {
@@ -156,7 +156,7 @@ TEST(TGTests, TestReduceScatterDeadlock) {
     }
 
     // Create the device mesh: Grid size is <num_tunnels, tunnel_depth>.
-    auto mesh = ttnn::multi_device::open_device_mesh({cluster_tunnel_count * num_mmio_devices, num_devices_in_tunnel}, all_device_ids, 0, 0, 1, DispatchCoreType::WORKER);
+    auto mesh = ttnn::multi_device::open_mesh_device({cluster_tunnel_count * num_mmio_devices, num_devices_in_tunnel}, all_device_ids, 0, 0, 1, DispatchCoreType::WORKER);
     // Create the outer ring on which Reduce Scatter will be run. This allows us to verify that there are no deadlocks when we send CCLs to the
     // first tunnel (forward path).
     std::vector<Device*> ring_devices = mesh.get_devices_on_row(0); // Tunnel 0
@@ -241,5 +241,5 @@ TEST(TGTests, TestReduceScatterDeadlock) {
             }
         }
     }
-    ttnn::multi_device::close_device_mesh(mesh);
+    ttnn::multi_device::close_mesh_device(mesh);
 }

--- a/tests/ttnn/unit_tests/gtests/test_multi_device.cpp
+++ b/tests/ttnn/unit_tests/gtests/test_multi_device.cpp
@@ -28,7 +28,7 @@ Tensor create_host_multi_device_tensor(const Tensor& tensor, const ReplicateTens
 }
 
 TEST_F(T3kMultiDeviceFixture, TestGetTensorsFromMultiDeviceStorage) {
-    DeviceMesh* device_mesh = this->device_mesh_.get();
+    MeshDevice* mesh_device = this->mesh_device_.get();
     const auto input_tensor = ttnn::ones(ttnn::Shape(std::array<uint32_t, 2>{32, 32}), ttnn::bfloat16);
     const auto replicated_tensor = create_host_multi_device_tensor(input_tensor, ReplicateTensor(8));
     const auto device_tensors = get_tensors_from_multi_device_storage(replicated_tensor);
@@ -37,7 +37,7 @@ TEST_F(T3kMultiDeviceFixture, TestGetTensorsFromMultiDeviceStorage) {
 }
 
 TEST_F(T3kMultiDeviceFixture, TestGetDistributedTensorConfigFromMultiDeviceStorage) {
-    DeviceMesh* device_mesh = this->device_mesh_.get();
+    MeshDevice* mesh_device = this->mesh_device_.get();
     const auto input_tensor = ttnn::ones(ttnn::Shape(std::array<uint32_t, 2>{32, 32}), ttnn::bfloat16);
     const auto replicated_tensor = create_host_multi_device_tensor(input_tensor, ReplicateTensor(8));
     const auto distributed_tensor_config = get_distributed_tensor_config_from_tensor(replicated_tensor);

--- a/tests/ttnn/unit_tests/gtests/ttnn_test_fixtures.hpp
+++ b/tests/ttnn/unit_tests/gtests/ttnn_test_fixtures.hpp
@@ -15,7 +15,7 @@
 #include "tests/tt_metal/test_utils/env_vars.hpp"
 #include "tt_metal/host_api.hpp"
 #include "tt_metal/hostdevcommon/common_values.hpp"
-#include "tt_metal/impl/device/device_mesh.hpp"
+#include "tt_metal/impl/device/mesh_device.hpp"
 
 namespace ttnn {
 
@@ -69,8 +69,8 @@ class T3kMultiDeviceFixture : public ::testing::Test {
         }
         const auto T3K_DEVICE_IDS = DeviceIds{0, 4, 5, 1, 2, 6, 7, 3};
         constexpr auto DEFAULT_NUM_COMMAND_QUEUES = 1;
-        device_mesh_ = std::make_unique<DeviceMesh>(
-            DeviceGrid{1, num_devices},
+        mesh_device_ = std::make_unique<MeshDevice>(
+            MeshShape{1, num_devices},
             T3K_DEVICE_IDS,
             DEFAULT_L1_SMALL_SIZE,
             DEFAULT_TRACE_REGION_SIZE,
@@ -78,8 +78,8 @@ class T3kMultiDeviceFixture : public ::testing::Test {
             DispatchCoreType::WORKER);
     }
 
-    void TearDown() override { device_mesh_.reset(); }
-    std::unique_ptr<DeviceMesh> device_mesh_;
+    void TearDown() override { mesh_device_.reset(); }
+    std::unique_ptr<MeshDevice> mesh_device_;
 };
 
 }  // namespace ttnn::multi_device::test

--- a/tests/ttnn/unit_tests/operations/test_all_gather.py
+++ b/tests/ttnn/unit_tests/operations/test_all_gather.py
@@ -367,7 +367,7 @@ def test_all_gather_on_t3000_post_commit(
 
 
 def run_line_all_gather(
-    t3k_device_mesh,
+    t3k_mesh_device,
     num_devices,
     input_shape,
     dim,
@@ -380,10 +380,10 @@ def run_line_all_gather(
     enable_async,
     num_iters=1,
 ):
-    if t3k_device_mesh.get_num_devices() != 8:
+    if t3k_mesh_device.get_num_devices() != 8:
         pytest.skip("Not T3000!")
 
-    for device in t3k_device_mesh.get_devices():
+    for device in t3k_mesh_device.get_devices():
         device.enable_async(enable_async)
 
     logger.info(f"Input shape: {input_shape}")
@@ -400,8 +400,8 @@ def run_line_all_gather(
 
     input_tensor = torch.rand(input_shape).bfloat16()
 
-    ttnn_tensor = ttnn.from_torch(input_tensor, mesh_mapper=ShardTensorToMesh(t3k_device_mesh, dim=dim))
-    input_tensor_mesh = ttnn.to_device(ttnn_tensor, t3k_device_mesh)
+    ttnn_tensor = ttnn.from_torch(input_tensor, mesh_mapper=ShardTensorToMesh(t3k_mesh_device, dim=dim))
+    input_tensor_mesh = ttnn.to_device(ttnn_tensor, t3k_mesh_device)
 
     for i in range(num_iters):
         tt_out_tensor = ttnn.line_all_gather(input_tensor_mesh, dim, num_links=num_links, memory_config=mem_config)
@@ -517,7 +517,7 @@ def run_line_all_gather_deprecated(
 )
 @pytest.mark.parametrize("enable_async", [True, False])
 def test_line_all_gather_on_t3000_post_commit(
-    t3k_device_mesh,
+    t3k_mesh_device,
     num_devices,
     input_shape,
     dim,
@@ -531,7 +531,7 @@ def test_line_all_gather_on_t3000_post_commit(
     num_iters=1,
 ):
     run_line_all_gather(
-        t3k_device_mesh,
+        t3k_mesh_device,
         num_devices,
         input_shape,
         dim,
@@ -638,7 +638,7 @@ def test_line_all_gather_on_t3000_post_commit_two_link(
 )
 @pytest.mark.parametrize("enable_async", [True, False])
 def test_line_all_gather_on_t3000_nightly(
-    t3k_device_mesh,
+    t3k_mesh_device,
     num_devices,
     input_shape,
     dim,
@@ -652,7 +652,7 @@ def test_line_all_gather_on_t3000_nightly(
     num_iters=1,
 ):
     run_line_all_gather(
-        t3k_device_mesh,
+        t3k_mesh_device,
         num_devices,
         input_shape,
         dim,

--- a/tests/ttnn/unit_tests/operations/test_all_gather_matmul.py
+++ b/tests/ttnn/unit_tests/operations/test_all_gather_matmul.py
@@ -15,7 +15,7 @@ from tests.ttnn.unit_tests.operations.test_all_gather import is_unsupported_case
 
 
 def run_all_gather_matmul_on_t3000_impl(
-    t3k_device_mesh,
+    t3k_mesh_device,
     num_devices,
     input_shape,
     dim,
@@ -34,7 +34,7 @@ def run_all_gather_matmul_on_t3000_impl(
     if is_known_failure:
         pytest.skip(f"Skipping unsupported case {message}.")
 
-    devices = t3k_device_mesh.get_devices()
+    devices = t3k_mesh_device.get_devices()
 
     logger.info(f"Input shape: {input_shape}")
     logger.info(f"dim: {dim}")
@@ -54,9 +54,9 @@ def run_all_gather_matmul_on_t3000_impl(
         weights_tensor,
         dtype=input_dtype,
         layout=ttnn.TILE_LAYOUT,
-        device=t3k_device_mesh,
+        device=t3k_mesh_device,
         memory_config=mem_config,
-        mesh_mapper=ShardTensorToMesh(t3k_device_mesh, dim=3),
+        mesh_mapper=ShardTensorToMesh(t3k_mesh_device, dim=3),
     )
 
     # torch matmul output
@@ -204,7 +204,7 @@ def run_all_gather_matmul_on_t3000_impl(
 )
 @pytest.mark.parametrize("enable_async", [True, False])
 def test_all_gather_matmul_on_t3000_post_commit(
-    t3k_device_mesh,
+    t3k_mesh_device,
     num_devices,
     input_shape,
     dim,
@@ -218,7 +218,7 @@ def test_all_gather_matmul_on_t3000_post_commit(
     enable_async,
 ):
     run_all_gather_matmul_on_t3000_impl(
-        t3k_device_mesh,
+        t3k_mesh_device,
         num_devices,
         input_shape,
         dim,

--- a/tests/ttnn/unit_tests/operations/test_all_gather_nightly.py
+++ b/tests/ttnn/unit_tests/operations/test_all_gather_nightly.py
@@ -50,7 +50,7 @@ from ttnn import ShardTensorToMesh
 )
 @pytest.mark.parametrize("enable_async", [True, False])
 def test_line_all_gather_on_t3000_nightly(
-    t3k_device_mesh,
+    t3k_mesh_device,
     num_devices,
     input_shape,
     dim,
@@ -64,7 +64,7 @@ def test_line_all_gather_on_t3000_nightly(
     num_iters=1,
 ):
     run_line_all_gather(
-        t3k_device_mesh,
+        t3k_mesh_device,
         num_devices,
         input_shape,
         dim,
@@ -138,7 +138,7 @@ def test_line_all_gather_on_t3000_nightly_two_link(
 
 
 def run_line_all_gather_instances(
-    t3k_device_mesh,
+    t3k_mesh_device,
     num_devices,
     num_instances,
     input_shape,
@@ -152,10 +152,10 @@ def run_line_all_gather_instances(
     enable_async,
     num_iters=1,
 ):
-    if t3k_device_mesh.get_num_devices() != 8:
+    if t3k_mesh_device.get_num_devices() != 8:
         pytest.skip("Not T3000!")
 
-    for device in t3k_device_mesh.get_devices():
+    for device in t3k_mesh_device.get_devices():
         device.enable_async(enable_async)
 
     logger.info(f"Input shape: {input_shape}")
@@ -169,7 +169,7 @@ def run_line_all_gather_instances(
 
     t3k_device = []
 
-    for device in t3k_device_mesh.get_devices():
+    for device in t3k_mesh_device.get_devices():
         t3k_device.append(device)
 
     t3000_device_rows = [
@@ -181,8 +181,8 @@ def run_line_all_gather_instances(
 
     input_tensor = torch.rand(input_shape).bfloat16()
 
-    ttnn_tensor = ttnn.from_torch(input_tensor, mesh_mapper=ShardTensorToMesh(t3k_device_mesh, dim=dim))
-    input_tensor_mesh = ttnn.to_device(ttnn_tensor, t3k_device_mesh)
+    ttnn_tensor = ttnn.from_torch(input_tensor, mesh_mapper=ShardTensorToMesh(t3k_mesh_device, dim=dim))
+    input_tensor_mesh = ttnn.to_device(ttnn_tensor, t3k_mesh_device)
 
     result_mesh_tensors = []
     for loop in range(num_iters):
@@ -236,7 +236,7 @@ def run_line_all_gather_instances(
 )
 @pytest.mark.parametrize("enable_async", [True, False])
 def test_line_all_gather_on_t3000_nightly_instances(
-    t3k_device_mesh,
+    t3k_mesh_device,
     num_devices,
     num_instances,
     input_shape,
@@ -251,7 +251,7 @@ def test_line_all_gather_on_t3000_nightly_instances(
     num_iters=1,
 ):
     run_line_all_gather_instances(
-        t3k_device_mesh,
+        t3k_mesh_device,
         num_devices,
         num_instances,
         input_shape,

--- a/tests/ttnn/unit_tests/operations/test_reduce_scatter_nightly.py
+++ b/tests/ttnn/unit_tests/operations/test_reduce_scatter_nightly.py
@@ -63,7 +63,7 @@ import itertools
 @pytest.mark.parametrize("math_op", [ttnn.ReduceType.Sum])
 @pytest.mark.parametrize("enable_async", [True, False])
 def test_reduce_scatter_nightly(
-    t3k_device_mesh,
+    t3k_mesh_device,
     num_devices,
     per_chip_output_shape,
     scatter_dim,
@@ -78,7 +78,7 @@ def test_reduce_scatter_nightly(
     num_iters=1,
 ):
     run_reduce_scatter_test(
-        t3k_device_mesh,
+        t3k_mesh_device,
         num_devices,
         per_chip_output_shape,
         scatter_dim,

--- a/tests/ttnn/unit_tests/operations/test_reduce_scatter_post_commit.py
+++ b/tests/ttnn/unit_tests/operations/test_reduce_scatter_post_commit.py
@@ -29,7 +29,7 @@ def is_unsupported_case(input_shape, scatter_dim, math_op, mem_config, num_devic
 
 
 def run_reduce_scatter_test(
-    t3k_device_mesh,
+    t3k_mesh_device,
     num_devices,
     per_chip_output_shape,
     scatter_dim,
@@ -43,7 +43,7 @@ def run_reduce_scatter_test(
     enable_async=True,
     num_iters=1,
 ):
-    if len(t3k_device_mesh.get_device_ids()) != 8:
+    if len(t3k_mesh_device.get_device_ids()) != 8:
         pytest.skip("Not T3000!")
 
     debug = False
@@ -54,8 +54,8 @@ def run_reduce_scatter_test(
     if is_known_failure:
         pytest.skip(f"Skipping unsupported case {message}.")
 
-    for device_id in t3k_device_mesh.get_device_ids():
-        t3k_device_mesh.get_device(device_id).enable_async(enable_async)
+    for device_id in t3k_mesh_device.get_device_ids():
+        t3k_mesh_device.get_device(device_id).enable_async(enable_async)
     if enable_async:
         logger.info(f"Using Async Mode for Reduce Scatter Op Dispatch")
 
@@ -76,7 +76,7 @@ def run_reduce_scatter_test(
         tt_input_tensors.append(
             ttnn.Tensor(canonical_input_tensor, input_dtype)
             .to(layout)
-            .to(t3k_device_mesh.get_device(t3k_device_mesh.get_device_ids()[i]), mem_config)
+            .to(t3k_mesh_device.get_device(t3k_mesh_device.get_device_ids()[i]), mem_config)
         )
 
     assert len(tt_input_tensors) == num_devices
@@ -92,8 +92,8 @@ def run_reduce_scatter_test(
             memory_config=mem_config,
         )
 
-        for device_id in t3k_device_mesh.get_device_ids():
-            ttnn.synchronize_device(t3k_device_mesh.get_device(device_id))
+        for device_id in t3k_mesh_device.get_device_ids():
+            ttnn.synchronize_device(t3k_mesh_device.get_device(device_id))
         logger.info(f"Done iteration {i}")
 
     # Compute golden
@@ -167,7 +167,7 @@ def run_reduce_scatter_test(
 @pytest.mark.parametrize("math_op", [ttnn.ReduceType.Sum])
 @pytest.mark.parametrize("enable_async", [True])
 def test_reduce_scatter_post_commit(
-    t3k_device_mesh,
+    t3k_mesh_device,
     num_devices,
     per_chip_output_shape,
     scatter_dim,
@@ -182,7 +182,7 @@ def test_reduce_scatter_post_commit(
     num_iters=1,
 ):
     run_reduce_scatter_test(
-        t3k_device_mesh,
+        t3k_mesh_device,
         num_devices,
         per_chip_output_shape,
         scatter_dim,
@@ -199,7 +199,7 @@ def test_reduce_scatter_post_commit(
 
 
 def run_reduce_scatter_sharded_test(
-    t3k_device_mesh,
+    t3k_mesh_device,
     num_devices,
     per_chip_output_shape,
     output_shard_shape,
@@ -216,13 +216,13 @@ def run_reduce_scatter_sharded_test(
     enable_async=True,
     num_iters=1,
 ):
-    if len(t3k_device_mesh.get_device_ids()) != 8:
+    if len(t3k_mesh_device.get_device_ids()) != 8:
         pytest.skip("Not T3000!")
 
     debug = False
 
-    for device_id in t3k_device_mesh.get_device_ids():
-        t3k_device_mesh.get_device(device_id).enable_async(enable_async)
+    for device_id in t3k_mesh_device.get_device_ids():
+        t3k_mesh_device.get_device(device_id).enable_async(enable_async)
 
     # Generate input tensors
     input_shard_shape = list(output_shard_shape)
@@ -265,7 +265,7 @@ def run_reduce_scatter_sharded_test(
         tt_input_tensors.append(
             ttnn.Tensor(canonical_input_tensor, input_dtype)
             .to(tensor_layout)
-            .to(t3k_device_mesh.get_device(t3k_device_mesh.get_device_ids()[i]), input_mem_config)
+            .to(t3k_mesh_device.get_device(t3k_mesh_device.get_device_ids()[i]), input_mem_config)
         )
 
     input_tensor_mesh = ttnn.aggregate_as_tensor(tt_input_tensors)
@@ -279,8 +279,8 @@ def run_reduce_scatter_sharded_test(
             memory_config=output_mem_config,
         )
 
-        for device_id in t3k_device_mesh.get_device_ids():
-            ttnn.synchronize_device(t3k_device_mesh.get_device(device_id))
+        for device_id in t3k_mesh_device.get_device_ids():
+            ttnn.synchronize_device(t3k_mesh_device.get_device(device_id))
         logger.info(f"Done iteration {i}")
 
     # Compute golden
@@ -362,7 +362,7 @@ def run_reduce_scatter_sharded_test(
 @pytest.mark.parametrize("math_op", [ttnn.ReduceType.Sum])
 @pytest.mark.parametrize("enable_async", [True])
 def test_width_sharded_reduce_scatter_post_commit(
-    t3k_device_mesh,
+    t3k_mesh_device,
     num_devices,
     per_chip_output_shape,
     output_shard_shape,
@@ -380,7 +380,7 @@ def test_width_sharded_reduce_scatter_post_commit(
     num_iters=1,
 ):
     run_reduce_scatter_sharded_test(
-        t3k_device_mesh,
+        t3k_mesh_device,
         num_devices,
         per_chip_output_shape,
         output_shard_shape,
@@ -436,7 +436,7 @@ def test_width_sharded_reduce_scatter_post_commit(
 @pytest.mark.parametrize("math_op", [ttnn.ReduceType.Sum])
 @pytest.mark.parametrize("enable_async", [True])
 def test_height_sharded_reduce_scatter_post_commit(
-    t3k_device_mesh,
+    t3k_mesh_device,
     num_devices,
     per_chip_output_shape,
     output_shard_shape,
@@ -454,7 +454,7 @@ def test_height_sharded_reduce_scatter_post_commit(
     num_iters=1,
 ):
     run_reduce_scatter_sharded_test(
-        t3k_device_mesh,
+        t3k_mesh_device,
         num_devices,
         per_chip_output_shape,
         output_shard_shape,
@@ -509,7 +509,7 @@ def test_height_sharded_reduce_scatter_post_commit(
 @pytest.mark.parametrize("math_op", [ttnn.ReduceType.Sum])
 @pytest.mark.parametrize("enable_async", [True])
 def test_block_sharded_reduce_scatter_post_commit(
-    t3k_device_mesh,
+    t3k_mesh_device,
     num_devices,
     per_chip_output_shape,
     output_shard_shape,
@@ -527,7 +527,7 @@ def test_block_sharded_reduce_scatter_post_commit(
     num_iters=1,
 ):
     run_reduce_scatter_sharded_test(
-        t3k_device_mesh,
+        t3k_mesh_device,
         num_devices,
         per_chip_output_shape,
         output_shard_shape,

--- a/tests/ttnn/unit_tests/test_multi_device.py
+++ b/tests/ttnn/unit_tests/test_multi_device.py
@@ -17,15 +17,15 @@ from ttnn import ShardTensorToMesh, ReplicateTensorToMesh, ConcatMeshToTensor, L
 #######
 # Test MultiDevice Initialization, Open/Close
 #######
-def test_device_mesh_open_close_explicit(silicon_arch_name, silicon_arch_wormhole_b0):
+def test_mesh_device_open_close_explicit(silicon_arch_name, silicon_arch_wormhole_b0):
     """Manually open and close multi-device"""
     num_pcie_devices = ttnn.get_num_pcie_devices()
     if num_pcie_devices <= 1:
         pytest.skip("Requires multiple devices to run")
 
-    device_grid, device_ids = ttnn.DeviceGrid(2, 2), ttnn.get_pcie_device_ids()
-    multi_device = ttnn.open_device_mesh(device_grid, device_ids)
-    ttnn.close_device_mesh(multi_device)
+    mesh_shape, device_ids = ttnn.MeshShape(2, 2), ttnn.get_pcie_device_ids()
+    multi_device = ttnn.open_mesh_device(mesh_shape, device_ids)
+    ttnn.close_mesh_device(multi_device)
 
 
 def test_multi_device_subset_mesh(silicon_arch_name, silicon_arch_wormhole_b0):
@@ -34,33 +34,33 @@ def test_multi_device_subset_mesh(silicon_arch_name, silicon_arch_wormhole_b0):
     if num_pcie_devices <= 1:
         pytest.skip("Requires multiple devices to run")
 
-    device_grid, device_ids = ttnn.DeviceGrid(1, 2), ttnn.get_pcie_device_ids()
-    multi_device = ttnn.open_device_mesh(device_grid, device_ids)
+    mesh_shape, device_ids = ttnn.MeshShape(1, 2), ttnn.get_pcie_device_ids()
+    multi_device = ttnn.open_mesh_device(mesh_shape, device_ids)
     assert multi_device.get_num_devices() == 2
-    ttnn.close_device_mesh(multi_device)
+    ttnn.close_mesh_device(multi_device)
 
-    multi_device = ttnn.open_device_mesh(device_grid, device_ids)
+    multi_device = ttnn.open_mesh_device(mesh_shape, device_ids)
     assert multi_device.get_num_devices() == 2
-    ttnn.close_device_mesh(multi_device)
+    ttnn.close_mesh_device(multi_device)
 
 
-def test_multi_device_open_close_full_device_mesh_fixture(device_mesh):
-    """Using `device_mesh` pytest fixture defined in conftest.py"""
+def test_multi_device_open_close_full_mesh_device_fixture(mesh_device):
+    """Using `mesh_device` pytest fixture defined in conftest.py"""
     pass
 
 
-def test_multi_device_open_close_full_device_mesh_fixture(device_mesh):
-    """Using `device_mesh` pytest fixture defined in conftest.py"""
+def test_multi_device_open_close_full_mesh_device_fixture(mesh_device):
+    """Using `mesh_device` pytest fixture defined in conftest.py"""
     pass
 
 
 def test_multi_device_open_close_using_context_manager(silicon_arch_name, silicon_arch_wormhole_b0):
     """Using context manager to open and close multi-device"""
     pytest.skip("Issue #6983")
-    device_grid, device_ids = ttnn.DeviceGrid(2, 2), ttnn.get_device_ids()
+    mesh_shape, device_ids = ttnn.MeshShape(2, 2), ttnn.get_device_ids()
     if len(device_ids) <= 1:
         pytest.skip()
-    with ttnn.create_device_mesh(device_grid, device_ids) as device_mesh:
+    with ttnn.create_mesh_device(mesh_shape, device_ids) as mesh_device:
         # Do something with multi_device
         pass
 
@@ -70,25 +70,25 @@ def test_multi_device_open_close_galaxy_mesh(silicon_arch_name, silicon_arch_wor
         pytest.skip("Test is only valid on Galaxy")
 
     """Manually open and close multi-device"""
-    device_grid, device_ids = ttnn.DeviceGrid(1, 4), ttnn.get_device_ids()
-    multi_device = ttnn.open_device_mesh(device_grid, device_ids)
+    mesh_shape, device_ids = ttnn.MeshShape(1, 4), ttnn.get_device_ids()
+    multi_device = ttnn.open_mesh_device(mesh_shape, device_ids)
     assert multi_device.get_num_devices() == 4
-    ttnn.close_device_mesh(multi_device)
+    ttnn.close_mesh_device(multi_device)
 
-    device_grid, device_ids = ttnn.DeviceGrid(8, 1), ttnn.get_device_ids()
-    multi_device = ttnn.open_device_mesh(device_grid, device_ids)
+    mesh_shape, device_ids = ttnn.MeshShape(8, 1), ttnn.get_device_ids()
+    multi_device = ttnn.open_mesh_device(mesh_shape, device_ids)
     assert multi_device.get_num_devices() == 8
-    ttnn.close_device_mesh(multi_device)
+    ttnn.close_mesh_device(multi_device)
 
-    device_grid, device_ids = ttnn.DeviceGrid(8, 4), ttnn.get_device_ids()
-    multi_device = ttnn.open_device_mesh(device_grid, device_ids)
+    mesh_shape, device_ids = ttnn.MeshShape(8, 4), ttnn.get_device_ids()
+    multi_device = ttnn.open_mesh_device(mesh_shape, device_ids)
     assert multi_device.get_num_devices() == 32
-    ttnn.close_device_mesh(multi_device)
+    ttnn.close_mesh_device(multi_device)
 
-    device_grid = ttnn.DeviceGrid(3, 2)
-    multi_device = ttnn.open_device_mesh(device_grid, device_ids)
+    mesh_shape = ttnn.MeshShape(3, 2)
+    multi_device = ttnn.open_mesh_device(mesh_shape, device_ids)
     assert multi_device.get_num_devices() == 6
-    ttnn.close_device_mesh(multi_device)
+    ttnn.close_mesh_device(multi_device)
 
 
 #######
@@ -99,20 +99,20 @@ def test_multi_device_open_close_galaxy_mesh(silicon_arch_name, silicon_arch_wor
 @pytest.mark.parametrize("layout", [ttnn.TILE_LAYOUT])
 @pytest.mark.parametrize("memory_config", [ttnn.DRAM_MEMORY_CONFIG])
 @pytest.mark.parametrize("dtype", [ttnn.bfloat8_b])
-def test_ttnn_to_multi_device_multiple_times(device_mesh, layout, memory_config, dtype):
+def test_ttnn_to_multi_device_multiple_times(mesh_device, layout, memory_config, dtype):
     """Test ttnn.to_device(..) works when the tensor is already on device"""
     if dtype == ttnn.bfloat8_b and layout == ttnn.ROW_MAJOR_LAYOUT:
         pytest.skip("Unsupported test permutation: bfloat8_b with ROW_MAJOR_LAYOUT")
 
-    torch_tensor = torch.rand((1, 1, 32, 32 * device_mesh.get_num_devices()), dtype=torch.bfloat16)
+    torch_tensor = torch.rand((1, 1, 32, 32 * mesh_device.get_num_devices()), dtype=torch.bfloat16)
 
     ttnn_tensor = ttnn.from_torch(
-        torch_tensor, dtype=dtype, layout=layout, mesh_mapper=ShardTensorToMesh(device_mesh, dim=3)
+        torch_tensor, dtype=dtype, layout=layout, mesh_mapper=ShardTensorToMesh(mesh_device, dim=3)
     )
-    ttnn_tensor = ttnn.to_device(ttnn_tensor, device_mesh, memory_config=memory_config)
-    ttnn_tensor = ttnn.to_device(ttnn_tensor, device_mesh, memory_config=memory_config)
+    ttnn_tensor = ttnn.to_device(ttnn_tensor, mesh_device, memory_config=memory_config)
+    ttnn_tensor = ttnn.to_device(ttnn_tensor, mesh_device, memory_config=memory_config)
     ttnn_loop_back_tensor = ttnn.from_device(ttnn_tensor)
-    torch_loop_back_tensor = ttnn.to_torch(ttnn_loop_back_tensor, mesh_composer=ConcatMeshToTensor(device_mesh, dim=3))
+    torch_loop_back_tensor = ttnn.to_torch(ttnn_loop_back_tensor, mesh_composer=ConcatMeshToTensor(mesh_device, dim=3))
 
     assert_with_pcc(torch_tensor, torch_loop_back_tensor, pcc=0.9999)
 
@@ -120,19 +120,19 @@ def test_ttnn_to_multi_device_multiple_times(device_mesh, layout, memory_config,
 @pytest.mark.parametrize("layout", [ttnn.TILE_LAYOUT, ttnn.ROW_MAJOR_LAYOUT])
 @pytest.mark.parametrize("memory_config", [ttnn.DRAM_MEMORY_CONFIG, ttnn.L1_MEMORY_CONFIG])
 @pytest.mark.parametrize("dtype", [ttnn.bfloat16, ttnn.bfloat8_b])
-def test_ttnn_to_and_from_multi_device_shard(device_mesh, layout, memory_config, dtype):
+def test_ttnn_to_and_from_multi_device_shard(mesh_device, layout, memory_config, dtype):
     """Shard a tensor across devices, compose it back and verify loopback tensor is same as the original tensor"""
     if dtype == ttnn.bfloat8_b and layout == ttnn.ROW_MAJOR_LAYOUT:
         pytest.skip("Unsupported test permutation: bfloat8_b with ROW_MAJOR_LAYOUT")
 
-    torch_tensor = torch.rand((1, 1, 32, 32 * device_mesh.get_num_devices()), dtype=torch.bfloat16)
+    torch_tensor = torch.rand((1, 1, 32, 32 * mesh_device.get_num_devices()), dtype=torch.bfloat16)
 
     ttnn_tensor = ttnn.from_torch(
-        torch_tensor, dtype=dtype, layout=layout, mesh_mapper=ShardTensorToMesh(device_mesh, dim=3)
+        torch_tensor, dtype=dtype, layout=layout, mesh_mapper=ShardTensorToMesh(mesh_device, dim=3)
     )
-    ttnn_tensor = ttnn.to_device(ttnn_tensor, device_mesh, memory_config=memory_config)
+    ttnn_tensor = ttnn.to_device(ttnn_tensor, mesh_device, memory_config=memory_config)
     ttnn_loop_back_tensor = ttnn.from_device(ttnn_tensor)
-    torch_loop_back_tensor = ttnn.to_torch(ttnn_loop_back_tensor, mesh_composer=ConcatMeshToTensor(device_mesh, dim=3))
+    torch_loop_back_tensor = ttnn.to_torch(ttnn_loop_back_tensor, mesh_composer=ConcatMeshToTensor(mesh_device, dim=3))
 
     assert_with_pcc(torch_tensor, torch_loop_back_tensor, pcc=0.9999)
 
@@ -140,17 +140,17 @@ def test_ttnn_to_and_from_multi_device_shard(device_mesh, layout, memory_config,
 @pytest.mark.parametrize("layout", [ttnn.TILE_LAYOUT, ttnn.ROW_MAJOR_LAYOUT])
 @pytest.mark.parametrize("memory_config", [ttnn.DRAM_MEMORY_CONFIG, ttnn.L1_MEMORY_CONFIG])
 @pytest.mark.parametrize("dtype", [ttnn.bfloat16, ttnn.bfloat8_b])
-def test_multi_device_check_per_device_shard(device_mesh, layout, memory_config, dtype):
+def test_multi_device_check_per_device_shard(mesh_device, layout, memory_config, dtype):
     """This test checks if the tensor is correctly sharded across devices"""
     if dtype == ttnn.bfloat8_b and layout == ttnn.ROW_MAJOR_LAYOUT:
         pytest.skip("Unsupported test permutation: bfloat8_b with ROW_MAJOR_LAYOUT")
 
-    torch_tensor = torch.rand((1, 1, 32, 64 * device_mesh.get_num_devices()), dtype=torch.bfloat16)
+    torch_tensor = torch.rand((1, 1, 32, 64 * mesh_device.get_num_devices()), dtype=torch.bfloat16)
 
     ttnn_tensor = ttnn.from_torch(
-        torch_tensor, dtype=dtype, mesh_mapper=ShardTensorToMesh(device_mesh, dim=3), layout=layout
+        torch_tensor, dtype=dtype, mesh_mapper=ShardTensorToMesh(mesh_device, dim=3), layout=layout
     )
-    ttnn_tensor = ttnn.to_device(ttnn_tensor, device_mesh, memory_config=memory_config)
+    ttnn_tensor = ttnn.to_device(ttnn_tensor, mesh_device, memory_config=memory_config)
     ttnn_loop_back_tensor = ttnn.from_device(ttnn_tensor)
 
     shard_offset, shard_size = 0, 64
@@ -163,7 +163,7 @@ def test_multi_device_check_per_device_shard(device_mesh, layout, memory_config,
 @pytest.mark.parametrize("shape", [(1, 1, 32, 128), (1, 1, 16, 32)])
 @pytest.mark.parametrize("layout", [ttnn.TILE_LAYOUT, ttnn.ROW_MAJOR_LAYOUT])
 @pytest.mark.parametrize("memory_config", [ttnn.DRAM_MEMORY_CONFIG, ttnn.L1_MEMORY_CONFIG])
-def test_multi_device_replicate(device_mesh, shape, layout, memory_config):
+def test_multi_device_replicate(mesh_device, shape, layout, memory_config):
     """Test ReplicateTensorToMesh to broadcast a tensor across multiple devices"""
     from ttnn import ReplicateTensorToMesh, ListMeshToTensor
 
@@ -171,26 +171,26 @@ def test_multi_device_replicate(device_mesh, shape, layout, memory_config):
 
     ttnn_tensor = ttnn.from_torch(
         full_tensor,
-        mesh_mapper=ReplicateTensorToMesh(device_mesh),
+        mesh_mapper=ReplicateTensorToMesh(mesh_device),
         layout=layout,
         memory_config=memory_config,
-        device=device_mesh,
+        device=mesh_device,
     )
-    ttnn_tensor = ttnn.to_device(ttnn_tensor, device_mesh)
+    ttnn_tensor = ttnn.to_device(ttnn_tensor, mesh_device)
     ttnn_loop_back_tensor = ttnn.from_device(ttnn_tensor)
-    loopback_replicated_tensors = ttnn.to_torch(ttnn_loop_back_tensor, mesh_composer=ListMeshToTensor(device_mesh))
+    loopback_replicated_tensors = ttnn.to_torch(ttnn_loop_back_tensor, mesh_composer=ListMeshToTensor(mesh_device))
     for loopback_replicated_tensor in loopback_replicated_tensors:
         assert torch.all(full_tensor == loopback_replicated_tensor)
 
 
-def test_ttnn_multi_device_all_gather(pcie_device_mesh):
+def test_ttnn_multi_device_all_gather(pcie_mesh_device):
     """Multidevice API test for ttnn.all_gather CCL operation"""
-    if pcie_device_mesh.get_num_devices() <= 1:
+    if pcie_mesh_device.get_num_devices() <= 1:
         pytest.skip("Requires multiple devices to run")
-    full_tensor = torch.rand((1, 1, 32, 32 * pcie_device_mesh.get_num_devices()), dtype=torch.bfloat16)
+    full_tensor = torch.rand((1, 1, 32, 32 * pcie_mesh_device.get_num_devices()), dtype=torch.bfloat16)
 
-    ttnn_tensor = ttnn.from_torch(full_tensor, mesh_mapper=ShardTensorToMesh(pcie_device_mesh, dim=3))
-    ttnn_tensor = ttnn.to_device(ttnn_tensor, pcie_device_mesh)
+    ttnn_tensor = ttnn.from_torch(full_tensor, mesh_mapper=ShardTensorToMesh(pcie_mesh_device, dim=3))
+    ttnn_tensor = ttnn.to_device(ttnn_tensor, pcie_mesh_device)
     ttnn_tensor = ttnn.all_gather(ttnn_tensor, dim=3, num_links=1)
 
     device_tensors: typing.List[ttnn.Tensor] = ttnn.get_device_tensors(ttnn_tensor)
@@ -199,97 +199,97 @@ def test_ttnn_multi_device_all_gather(pcie_device_mesh):
         assert torch.all(device_tensor_torch == full_tensor)
 
 
-def test_multi_device_single_op_unary(device_mesh):
+def test_multi_device_single_op_unary(mesh_device):
     """Multidevice API test: Running tensor-parallel multi-device single-op unary"""
-    torch_input_tensor = torch.rand((1, 1, 32, 32 * device_mesh.get_num_devices()), dtype=torch.bfloat16)
+    torch_input_tensor = torch.rand((1, 1, 32, 32 * mesh_device.get_num_devices()), dtype=torch.bfloat16)
     torch_output_golden = torch.nn.functional.gelu(torch_input_tensor)
 
     ttnn_input_tensor = ttnn.from_torch(
         torch_input_tensor,
         layout=ttnn.TILE_LAYOUT,
-        mesh_mapper=ShardTensorToMesh(device_mesh, dim=3),
-        device=device_mesh,
+        mesh_mapper=ShardTensorToMesh(mesh_device, dim=3),
+        device=mesh_device,
     )
     ttnn_output_tensor = ttnn.gelu(ttnn_input_tensor)
 
-    ttnn_torch_output_tensor = ttnn.to_torch(ttnn_output_tensor, mesh_composer=ConcatMeshToTensor(device_mesh, dim=3))
+    ttnn_torch_output_tensor = ttnn.to_torch(ttnn_output_tensor, mesh_composer=ConcatMeshToTensor(mesh_device, dim=3))
     assert_with_pcc(ttnn_torch_output_tensor, torch_output_golden, pcc=0.999)
 
 
-def test_multi_device_single_op_binary(device_mesh):
+def test_multi_device_single_op_binary(mesh_device):
     """Multidevice API test: Running tensor-parallel multi-device single-op binary"""
-    torch_input_a_tensor = torch.rand((1, 1, 32, 32 * device_mesh.get_num_devices()), dtype=torch.bfloat16)
-    torch_input_b_tensor = torch.rand((1, 1, 32, 32 * device_mesh.get_num_devices()), dtype=torch.bfloat16)
+    torch_input_a_tensor = torch.rand((1, 1, 32, 32 * mesh_device.get_num_devices()), dtype=torch.bfloat16)
+    torch_input_b_tensor = torch.rand((1, 1, 32, 32 * mesh_device.get_num_devices()), dtype=torch.bfloat16)
     torch_output_golden = torch_input_a_tensor + torch_input_b_tensor
 
     ttnn_input_a_tensor = ttnn.from_torch(
         torch_input_a_tensor,
         layout=ttnn.TILE_LAYOUT,
-        device=device_mesh,
-        mesh_mapper=ShardTensorToMesh(device_mesh, dim=3),
+        device=mesh_device,
+        mesh_mapper=ShardTensorToMesh(mesh_device, dim=3),
     )
     ttnn_input_b_tensor = ttnn.from_torch(
         torch_input_b_tensor,
         layout=ttnn.TILE_LAYOUT,
-        device=device_mesh,
-        mesh_mapper=ShardTensorToMesh(device_mesh, dim=3),
+        device=mesh_device,
+        mesh_mapper=ShardTensorToMesh(mesh_device, dim=3),
     )
     ttnn_output_tensor = ttnn.add(ttnn_input_a_tensor, ttnn_input_b_tensor)
 
-    ttnn_torch_output_tensor = ttnn.to_torch(ttnn_output_tensor, mesh_composer=ConcatMeshToTensor(device_mesh, dim=3))
+    ttnn_torch_output_tensor = ttnn.to_torch(ttnn_output_tensor, mesh_composer=ConcatMeshToTensor(mesh_device, dim=3))
     assert_with_pcc(ttnn_torch_output_tensor, torch_output_golden, pcc=0.999)
 
 
-def test_multi_device_multi_op(device_mesh):
+def test_multi_device_multi_op(mesh_device):
     """Multidevice API test: Running tensor-parallel multi-device multi-op"""
-    torch_input_tensor = torch.rand((1, 1, 32, 32 * device_mesh.get_num_devices()), dtype=torch.bfloat16)
+    torch_input_tensor = torch.rand((1, 1, 32, 32 * mesh_device.get_num_devices()), dtype=torch.bfloat16)
     torch_output_golden = torch.nn.functional.gelu(torch_input_tensor)
     torch_output_golden = torch.exp(torch_output_golden)
 
     ttnn_input_tensor = ttnn.from_torch(
         torch_input_tensor,
         layout=ttnn.TILE_LAYOUT,
-        mesh_mapper=ShardTensorToMesh(device_mesh, dim=3),
-        device=device_mesh,
+        mesh_mapper=ShardTensorToMesh(mesh_device, dim=3),
+        device=mesh_device,
     )
     ttnn_gelu_output = ttnn.gelu(ttnn_input_tensor)
     ttnn_output_tensor = ttnn.exp(ttnn_gelu_output)
 
-    ttnn_torch_output_tensor = ttnn.to_torch(ttnn_output_tensor, mesh_composer=ConcatMeshToTensor(device_mesh, dim=3))
+    ttnn_torch_output_tensor = ttnn.to_torch(ttnn_output_tensor, mesh_composer=ConcatMeshToTensor(mesh_device, dim=3))
     assert_with_pcc(ttnn_torch_output_tensor, torch_output_golden, pcc=0.999)
 
 
-def test_multi_device_data_parallel_matmul_op(device_mesh):
+def test_multi_device_data_parallel_matmul_op(mesh_device):
     """Multidevice API: Data Parallel on matmul"""
-    torch_input_a_tensor = torch.rand((device_mesh.get_num_devices(), 1, 32, 32), dtype=torch.bfloat16)
+    torch_input_a_tensor = torch.rand((mesh_device.get_num_devices(), 1, 32, 32), dtype=torch.bfloat16)
     torch_input_b_tensor = torch.rand((1, 1, 32, 32), dtype=torch.bfloat16)
     torch_output_golden = torch_input_a_tensor @ torch_input_b_tensor
 
     ttnn_input_a_tensor = ttnn.from_torch(
         torch_input_a_tensor,
         layout=ttnn.TILE_LAYOUT,
-        device=device_mesh,
-        mesh_mapper=ShardTensorToMesh(device_mesh, dim=0),
+        device=mesh_device,
+        mesh_mapper=ShardTensorToMesh(mesh_device, dim=0),
     )
     ttnn_input_b_tensor = ttnn.from_torch(
         torch_input_b_tensor,
         layout=ttnn.TILE_LAYOUT,
-        device=device_mesh,
-        mesh_mapper=ReplicateTensorToMesh(device_mesh),
+        device=mesh_device,
+        mesh_mapper=ReplicateTensorToMesh(mesh_device),
     )
     ttnn_output_tensor = ttnn_input_a_tensor @ ttnn_input_b_tensor
 
-    ttnn_torch_output_tensor = ttnn.to_torch(ttnn_output_tensor, mesh_composer=ConcatMeshToTensor(device_mesh, dim=0))
+    ttnn_torch_output_tensor = ttnn.to_torch(ttnn_output_tensor, mesh_composer=ConcatMeshToTensor(mesh_device, dim=0))
     assert_with_pcc(ttnn_torch_output_tensor, torch_output_golden, pcc=0.993)
 
 
 @pytest.mark.parametrize("layout", [ttnn.TILE_LAYOUT])
 @pytest.mark.parametrize("memory_config", [ttnn.DRAM_MEMORY_CONFIG])
 @pytest.mark.parametrize("dtype", [ttnn.bfloat8_b, ttnn.bfloat4_b])
-def test_multi_device_as_tensor_api(device_mesh, layout, memory_config, dtype):
+def test_multi_device_as_tensor_api(mesh_device, layout, memory_config, dtype):
     """Multidevice API: Data Parallel on matmul using cached tensor"""
     torch.manual_seed(0)
-    torch_input_a_tensor = torch.rand((device_mesh.get_num_devices(), 1, 32, 32), dtype=torch.bfloat16)
+    torch_input_a_tensor = torch.rand((mesh_device.get_num_devices(), 1, 32, 32), dtype=torch.bfloat16)
     torch_input_b_tensor = torch.rand((1, 1, 32, 32), dtype=torch.bfloat16)
     torch_output_golden = torch_input_a_tensor @ torch_input_b_tensor
 
@@ -298,8 +298,8 @@ def test_multi_device_as_tensor_api(device_mesh, layout, memory_config, dtype):
         dtype=dtype,
         layout=layout,
         memory_config=memory_config,
-        device=device_mesh,
-        mesh_mapper=ShardTensorToMesh(device_mesh, dim=0),
+        device=mesh_device,
+        mesh_mapper=ShardTensorToMesh(mesh_device, dim=0),
     )
 
     with tempfile.NamedTemporaryFile() as temp_file:
@@ -307,26 +307,26 @@ def test_multi_device_as_tensor_api(device_mesh, layout, memory_config, dtype):
             torch_input_b_tensor,
             dtype=dtype,
             layout=layout,
-            device=device_mesh,
+            device=mesh_device,
             memory_config=memory_config,
             cache_file_name=f"{temp_file.name}.weight",
-            mesh_mapper=ReplicateTensorToMesh(device_mesh),
+            mesh_mapper=ReplicateTensorToMesh(mesh_device),
         )
 
         ttnn_input_b_tensor = ttnn.as_tensor(
             torch_input_b_tensor,
             dtype=dtype,
             layout=layout,
-            device=device_mesh,
+            device=mesh_device,
             memory_config=memory_config,
             cache_file_name=f"{temp_file.name}.weight",
-            mesh_mapper=ReplicateTensorToMesh(device_mesh),
+            mesh_mapper=ReplicateTensorToMesh(mesh_device),
         )
 
         ttnn_output_tensor = ttnn_input_a_tensor @ ttnn_input_b_tensor
 
         ttnn_torch_output_tensor = ttnn.to_torch(
-            ttnn_output_tensor, mesh_composer=ConcatMeshToTensor(device_mesh, dim=0)
+            ttnn_output_tensor, mesh_composer=ConcatMeshToTensor(mesh_device, dim=0)
         )
         if dtype == ttnn.bfloat4_b:
             assert_with_pcc(ttnn_torch_output_tensor, torch_output_golden, pcc=0.87)
@@ -337,30 +337,30 @@ def test_multi_device_as_tensor_api(device_mesh, layout, memory_config, dtype):
 @pytest.mark.parametrize("layout", [ttnn.TILE_LAYOUT])
 @pytest.mark.parametrize("memory_config", [ttnn.DRAM_MEMORY_CONFIG])
 @pytest.mark.parametrize("dtype", [ttnn.bfloat8_b, ttnn.bfloat4_b])
-def test_multi_device_as_tensor_api_sharded_tensor(device_mesh, layout, memory_config, dtype):
+def test_multi_device_as_tensor_api_sharded_tensor(mesh_device, layout, memory_config, dtype):
     """Multidevice API: Data Parallel on matmul using cached tensor"""
-    input_tensor = torch.rand((device_mesh.get_num_devices(), 1, 32, 32), dtype=torch.bfloat16)
+    input_tensor = torch.rand((mesh_device.get_num_devices(), 1, 32, 32), dtype=torch.bfloat16)
 
     with tempfile.NamedTemporaryFile() as temp_file:
         save_tensor = ttnn.as_tensor(
             input_tensor,
             dtype=dtype,
             layout=layout,
-            device=device_mesh,
+            device=mesh_device,
             memory_config=memory_config,
             cache_file_name=f"{temp_file.name}.weight",
-            mesh_mapper=ShardTensorToMesh(device_mesh, dim=0),
+            mesh_mapper=ShardTensorToMesh(mesh_device, dim=0),
         )
         load_tensor = ttnn.as_tensor(
             input_tensor,
             dtype=dtype,
             layout=layout,
-            device=device_mesh,
+            device=mesh_device,
             memory_config=memory_config,
             cache_file_name=f"{temp_file.name}.weight",
-            mesh_mapper=ShardTensorToMesh(device_mesh, dim=0),
+            mesh_mapper=ShardTensorToMesh(mesh_device, dim=0),
         )
-        torch_loaded_tensor = ttnn.to_torch(load_tensor, mesh_composer=ConcatMeshToTensor(device_mesh, dim=0))
+        torch_loaded_tensor = ttnn.to_torch(load_tensor, mesh_composer=ConcatMeshToTensor(mesh_device, dim=0))
         expected_pcc = 0.98 if dtype == ttnn.bfloat4_b else 0.99
         assert_with_pcc(input_tensor, torch_loaded_tensor, pcc=expected_pcc)
 
@@ -368,48 +368,48 @@ def test_multi_device_as_tensor_api_sharded_tensor(device_mesh, layout, memory_c
 @pytest.mark.parametrize("layout", [ttnn.TILE_LAYOUT])
 @pytest.mark.parametrize("memory_config", [ttnn.DRAM_MEMORY_CONFIG])
 @pytest.mark.parametrize("dtype", [ttnn.bfloat8_b])
-def test_multi_device_permute(device_mesh, layout, memory_config, dtype):
+def test_multi_device_permute(mesh_device, layout, memory_config, dtype):
     if dtype == ttnn.bfloat8_b and layout == ttnn.ROW_MAJOR_LAYOUT:
         pytest.skip("Unsupported test permutation: bfloat8_b with ROW_MAJOR_LAYOUT")
 
-    torch_tensor = torch.rand((32, 1, 160, 64 * device_mesh.get_num_devices()), dtype=torch.bfloat16)
+    torch_tensor = torch.rand((32, 1, 160, 64 * mesh_device.get_num_devices()), dtype=torch.bfloat16)
     torch_golden = torch.permute(torch_tensor, (0, 1, 3, 2))
 
     ttnn_tensor = ttnn.from_torch(
-        torch_tensor, dtype=dtype, layout=layout, mesh_mapper=ShardTensorToMesh(device_mesh, dim=3)
+        torch_tensor, dtype=dtype, layout=layout, mesh_mapper=ShardTensorToMesh(mesh_device, dim=3)
     )
-    ttnn_tensor = ttnn.to_device(ttnn_tensor, device_mesh, memory_config=memory_config)
+    ttnn_tensor = ttnn.to_device(ttnn_tensor, mesh_device, memory_config=memory_config)
     ttnn_permute = ttnn.permute(ttnn_tensor, (0, 1, 3, 2))
     ttnn_loop_back_tensor = ttnn.from_device(ttnn_permute)
-    torch_loop_back_tensor = ttnn.to_torch(ttnn_loop_back_tensor, mesh_composer=ConcatMeshToTensor(device_mesh, dim=2))
+    torch_loop_back_tensor = ttnn.to_torch(ttnn_loop_back_tensor, mesh_composer=ConcatMeshToTensor(mesh_device, dim=2))
 
     assert_with_pcc(torch_golden, torch_loop_back_tensor, pcc=0.9999)
 
 
-def test_max(device_mesh):
+def test_max(mesh_device):
     gate_logits_1SB8 = ttnn.from_torch(
         torch.randn(1, 1, 32, 8),
         dtype=ttnn.bfloat16,
         layout=ttnn.TILE_LAYOUT,
-        device=device_mesh,
-        mesh_mapper=ReplicateTensorToMesh(device_mesh),
+        device=mesh_device,
+        mesh_mapper=ReplicateTensorToMesh(mesh_device),
     )
-    gate_logits_1SB8 = ttnn.to_device(gate_logits_1SB8, device_mesh)
+    gate_logits_1SB8 = ttnn.to_device(gate_logits_1SB8, mesh_device)
     weights_ex0_1SB1 = ttnn.max(gate_logits_1SB8, dim=3)
     print(weights_ex0_1SB1)
 
 
-def test_ttnn_multi_device_all_gather_all_devices(t3k_device_mesh):
+def test_ttnn_multi_device_all_gather_all_devices(t3k_mesh_device):
     """Multidevice API test for ttnn.all_gather CCL operation for full 8-device T3K"""
-    if t3k_device_mesh.get_num_devices() < 8:
+    if t3k_mesh_device.get_num_devices() < 8:
         pytest.skip()
 
-    full_tensor = torch.ones((1, 1, 32, 32 * t3k_device_mesh.get_num_devices()), dtype=torch.bfloat16)
-    for i in range(t3k_device_mesh.get_num_devices()):
+    full_tensor = torch.ones((1, 1, 32, 32 * t3k_mesh_device.get_num_devices()), dtype=torch.bfloat16)
+    for i in range(t3k_mesh_device.get_num_devices()):
         full_tensor[..., i * 32 : (i + 1) * 32] = i
 
-    ttnn_tensor = ttnn.from_torch(full_tensor, mesh_mapper=ShardTensorToMesh(t3k_device_mesh, dim=3))
-    ttnn_tensor = ttnn.to_device(ttnn_tensor, t3k_device_mesh)
+    ttnn_tensor = ttnn.from_torch(full_tensor, mesh_mapper=ShardTensorToMesh(t3k_mesh_device, dim=3))
+    ttnn_tensor = ttnn.to_device(ttnn_tensor, t3k_mesh_device)
     ttnn_tensor = ttnn.all_gather(ttnn_tensor, dim=3, num_links=1)
 
     device_tensors: typing.List[ttnn.Tensor] = ttnn.get_device_tensors(ttnn_tensor)
@@ -418,24 +418,24 @@ def test_ttnn_multi_device_all_gather_all_devices(t3k_device_mesh):
         assert torch.all(device_tensor_torch == full_tensor)
 
 
-def test_sharded_matmul(t3k_device_mesh):
+def test_sharded_matmul(t3k_mesh_device):
     q_heads_1B4D = ttnn.from_torch(
         torch.randn(1, 32, 32, 128),
         dtype=ttnn.bfloat16,
         layout=ttnn.TILE_LAYOUT,
-        device=t3k_device_mesh,
-        mesh_mapper=ReplicateTensorToMesh(t3k_device_mesh),
+        device=t3k_mesh_device,
+        mesh_mapper=ReplicateTensorToMesh(t3k_mesh_device),
     )
     keys_1BDP = ttnn.from_torch(
         torch.randn(1, 32, 128, 32),
         dtype=ttnn.bfloat16,
         layout=ttnn.TILE_LAYOUT,
-        device=t3k_device_mesh,
-        mesh_mapper=ReplicateTensorToMesh(t3k_device_mesh),
+        device=t3k_mesh_device,
+        mesh_mapper=ReplicateTensorToMesh(t3k_mesh_device),
     )
 
-    q_heads_1B4D = ttnn.to_device(q_heads_1B4D, t3k_device_mesh)
-    keys_1BDP = ttnn.to_device(keys_1BDP, t3k_device_mesh)
+    q_heads_1B4D = ttnn.to_device(q_heads_1B4D, t3k_mesh_device)
+    keys_1BDP = ttnn.to_device(keys_1BDP, t3k_mesh_device)
 
     q_heads_1B4D = ttnn.to_memory_config(
         q_heads_1B4D,
@@ -475,23 +475,23 @@ def test_sharded_matmul(t3k_device_mesh):
     print(attn_1B4P)
 
 
-def test_4b_tensor(device_mesh):
+def test_4b_tensor(mesh_device):
     tensor = ttnn.from_torch(
         torch.randn(1, 1, 32, 32),
         dtype=ttnn.bfloat4_b,
         layout=ttnn.TILE_LAYOUT,
-        device=device_mesh,
-        mesh_mapper=ReplicateTensorToMesh(device_mesh),
+        device=mesh_device,
+        mesh_mapper=ReplicateTensorToMesh(mesh_device),
     )
-    tensor = ttnn.to_device(tensor, device_mesh)
+    tensor = ttnn.to_device(tensor, mesh_device)
     x = ttnn.from_torch(
         torch.randn(1, 1, 32, 32),
         dtype=ttnn.bfloat16,
         layout=ttnn.TILE_LAYOUT,
-        device=device_mesh,
-        mesh_mapper=ReplicateTensorToMesh(device_mesh),
+        device=mesh_device,
+        mesh_mapper=ReplicateTensorToMesh(mesh_device),
     )
-    x = ttnn.to_device(x, device_mesh)
+    x = ttnn.to_device(x, mesh_device)
     tensor = ttnn.matmul(
         x,
         tensor,
@@ -502,50 +502,50 @@ def test_4b_tensor(device_mesh):
     )
 
 
-def test_slicing(device_mesh):
+def test_slicing(mesh_device):
     tensor = ttnn.from_torch(
         torch.randn(1, 32, 32, 32),
         dtype=ttnn.bfloat16,
         layout=ttnn.TILE_LAYOUT,
-        device=device_mesh,
-        mesh_mapper=ReplicateTensorToMesh(device_mesh),
+        device=mesh_device,
+        mesh_mapper=ReplicateTensorToMesh(mesh_device),
     )
-    tensor = ttnn.to_device(tensor, device_mesh)
+    tensor = ttnn.to_device(tensor, mesh_device)
     tensor = tensor[:, :, :, :1]
     assert all([device_tensor.shape == tensor.shape for device_tensor in ttnn.get_device_tensors(tensor)])
 
 
-def test_clone(device_mesh):
+def test_clone(mesh_device):
     results_11BH = ttnn.from_torch(
         torch.randn(1, 1, 32, 128),
         dtype=ttnn.bfloat16,
         layout=ttnn.TILE_LAYOUT,
-        device=device_mesh,
-        mesh_mapper=ReplicateTensorToMesh(device_mesh),
+        device=mesh_device,
+        mesh_mapper=ReplicateTensorToMesh(mesh_device),
     )
-    results_11BH = ttnn.to_device(results_11BH, device_mesh)
+    results_11BH = ttnn.to_device(results_11BH, mesh_device)
     results_11BH = ttnn.clone(results_11BH, dtype=ttnn.bfloat8_b, memory_config=ttnn.L1_MEMORY_CONFIG)
     print(results_11BH)
 
 
-def test_device_shard_to_torch(device_mesh):
+def test_device_shard_to_torch(mesh_device):
     """Test `ttnn.get_device_tensor(..) API"""
-    torch_input_tensor = torch.rand((1, 1, 32, 32 * device_mesh.get_num_devices()), dtype=torch.bfloat16)
+    torch_input_tensor = torch.rand((1, 1, 32, 32 * mesh_device.get_num_devices()), dtype=torch.bfloat16)
     torch_output_golden = torch.nn.functional.gelu(torch_input_tensor)
     torch_output_golden = torch.exp(torch_output_golden)
 
     ttnn_input_tensor = ttnn.from_torch(
         torch_input_tensor,
         layout=ttnn.TILE_LAYOUT,
-        mesh_mapper=ShardTensorToMesh(device_mesh, dim=3),
-        device=device_mesh,
+        mesh_mapper=ShardTensorToMesh(mesh_device, dim=3),
+        device=mesh_device,
     )
 
     ttnn_gelu_output = ttnn.gelu(ttnn_input_tensor)
     ttnn_output_tensor = ttnn.exp(ttnn_gelu_output)
 
     # Skip the compose/torch.cat call entirely
-    for i, device in enumerate(device_mesh.get_devices()):
+    for i, device in enumerate(mesh_device.get_devices()):
         device_tensor = ttnn.get_device_tensor(ttnn_output_tensor, device)
         torch_device_tensor = ttnn.to_torch(device_tensor)
         assert_with_pcc(torch_device_tensor, torch_output_golden[..., i * 32 : (i + 1) * 32], pcc=0.999)
@@ -553,7 +553,7 @@ def test_device_shard_to_torch(device_mesh):
 
 @pytest.mark.parametrize("height", [7])
 @pytest.mark.parametrize("width", [3])
-def test_validate_as_tensor(tmp_path, device_mesh, height, width):
+def test_validate_as_tensor(tmp_path, mesh_device, height, width):
     torch_input_tensor = torch.rand((height, width), dtype=torch.float32)
 
     memory_config = ttnn.L1_MEMORY_CONFIG
@@ -561,13 +561,13 @@ def test_validate_as_tensor(tmp_path, device_mesh, height, width):
         torch_input_tensor,
         dtype=ttnn.float32,
         layout=ttnn.TILE_LAYOUT,
-        device=device_mesh,
+        device=mesh_device,
         memory_config=memory_config,
-        mesh_mapper=ttnn.ReplicateTensorToMesh(device_mesh),
+        mesh_mapper=ttnn.ReplicateTensorToMesh(mesh_device),
         cache_file_name=tmp_path / "cache_file",
     )
     assert tensor.dtype == ttnn.float32
-    assert tensor.devices() == device_mesh.get_devices()
+    assert tensor.devices() == mesh_device.get_devices()
     assert tensor.layout == ttnn.TILE_LAYOUT
     assert ttnn.get_memory_config(tensor) == memory_config
 
@@ -575,16 +575,16 @@ def test_validate_as_tensor(tmp_path, device_mesh, height, width):
         torch_input_tensor,
         dtype=ttnn.float32,
         layout=ttnn.TILE_LAYOUT,
-        device=device_mesh,
+        device=mesh_device,
         memory_config=memory_config,
-        mesh_mapper=ttnn.ReplicateTensorToMesh(device_mesh),
+        mesh_mapper=ttnn.ReplicateTensorToMesh(mesh_device),
         cache_file_name=tmp_path / "cache_file",
     )
     assert tensor.dtype == ttnn.float32
-    assert tensor.devices() == device_mesh.get_devices()
+    assert tensor.devices() == mesh_device.get_devices()
     assert tensor.layout == ttnn.TILE_LAYOUT
     assert ttnn.get_memory_config(tensor) == memory_config
 
-    for device in device_mesh.get_devices():
+    for device in mesh_device.get_devices():
         device_tensor = ttnn.get_device_tensor(tensor, device)
         assert torch.allclose(ttnn.to_torch(device_tensor), torch_input_tensor)

--- a/tests/ttnn/unit_tests/test_multi_device_async.py
+++ b/tests/ttnn/unit_tests/test_multi_device_async.py
@@ -19,44 +19,44 @@ import transformers
 @pytest.mark.parametrize("layout", [ttnn.TILE_LAYOUT, ttnn.ROW_MAJOR_LAYOUT])
 @pytest.mark.parametrize("memory_config", [ttnn.DRAM_MEMORY_CONFIG, ttnn.L1_MEMORY_CONFIG])
 @pytest.mark.parametrize("dtype", [ttnn.bfloat16, ttnn.bfloat8_b])
-def test_ttnn_to_and_from_multi_device_shard(pcie_device_mesh, layout, memory_config, dtype):
+def test_ttnn_to_and_from_multi_device_shard(pcie_mesh_device, layout, memory_config, dtype):
     """Shard a tensor across devices, compose it back and verify loopback tensor is same as the original tensor"""
     from ttnn import ShardTensorToMesh, ConcatMeshToTensor
 
     if dtype == ttnn.bfloat8_b and layout == ttnn.ROW_MAJOR_LAYOUT:
         pytest.skip("Unsupported test permutation: bfloat8_b with ROW_MAJOR_LAYOUT")
 
-    for device in pcie_device_mesh.get_device_ids():
-        pcie_device_mesh.get_device(device).enable_async(True)
+    for device in pcie_mesh_device.get_device_ids():
+        pcie_mesh_device.get_device(device).enable_async(True)
 
     for i in range(100):
         torch_tensor = torch.rand((1, 1, 256, 512), dtype=torch.bfloat16)
         ttnn_tensor = ttnn.from_torch(
-            torch_tensor, dtype=dtype, layout=layout, mesh_mapper=ShardTensorToMesh(pcie_device_mesh, dim=3)
+            torch_tensor, dtype=dtype, layout=layout, mesh_mapper=ShardTensorToMesh(pcie_mesh_device, dim=3)
         )
-        ttnn_tensor = ttnn.to_device(ttnn_tensor, pcie_device_mesh, memory_config=memory_config)
+        ttnn_tensor = ttnn.to_device(ttnn_tensor, pcie_mesh_device, memory_config=memory_config)
         ttnn_loop_back_tensor = ttnn.from_device(ttnn_tensor)
         torch_loop_back_tensor = ttnn.to_torch(
-            ttnn_loop_back_tensor, mesh_composer=ConcatMeshToTensor(pcie_device_mesh, dim=3)
+            ttnn_loop_back_tensor, mesh_composer=ConcatMeshToTensor(pcie_mesh_device, dim=3)
         )
         assert_with_pcc(torch_tensor, torch_loop_back_tensor, pcc=0.9999)
 
-    for device in pcie_device_mesh.get_device_ids():
-        pcie_device_mesh.get_device(device).enable_async(False)
+    for device in pcie_mesh_device.get_device_ids():
+        pcie_mesh_device.get_device(device).enable_async(False)
 
 
 @pytest.mark.parametrize("layout", [ttnn.TILE_LAYOUT, ttnn.ROW_MAJOR_LAYOUT])
 @pytest.mark.parametrize("memory_config", [ttnn.DRAM_MEMORY_CONFIG, ttnn.L1_MEMORY_CONFIG])
 @pytest.mark.parametrize("dtype", [ttnn.bfloat16, ttnn.bfloat8_b])
-def test_multi_device_check_per_device_shard(pcie_device_mesh, layout, memory_config, dtype):
+def test_multi_device_check_per_device_shard(pcie_mesh_device, layout, memory_config, dtype):
     """This test checks if the tensor is correctly sharded across devices"""
     from ttnn import ShardTensorToMesh, ConcatMeshToTensor
 
     if dtype == ttnn.bfloat8_b and layout == ttnn.ROW_MAJOR_LAYOUT:
         pytest.skip("Unsupported test permutation: bfloat8_b with ROW_MAJOR_LAYOUT")
 
-    for device in pcie_device_mesh.get_device_ids():
-        pcie_device_mesh.get_device(device).enable_async(True)
+    for device in pcie_mesh_device.get_device_ids():
+        pcie_mesh_device.get_device(device).enable_async(True)
 
     num_loops = 50
     if dtype == ttnn.bfloat8_b:
@@ -66,12 +66,12 @@ def test_multi_device_check_per_device_shard(pcie_device_mesh, layout, memory_co
         torch_tensor = torch.rand((8, 1, 1024, 1024), dtype=torch.bfloat16)
 
         ttnn_tensor = ttnn.from_torch(
-            torch_tensor, dtype=dtype, layout=layout, mesh_mapper=ShardTensorToMesh(pcie_device_mesh, dim=3)
+            torch_tensor, dtype=dtype, layout=layout, mesh_mapper=ShardTensorToMesh(pcie_mesh_device, dim=3)
         )
-        ttnn_tensor = ttnn.to_device(ttnn_tensor, pcie_device_mesh, memory_config=memory_config)
+        ttnn_tensor = ttnn.to_device(ttnn_tensor, pcie_mesh_device, memory_config=memory_config)
         ttnn_loop_back_tensor = ttnn.from_device(ttnn_tensor)
 
-        shard_offset, shard_size = 0, int(1024 / len(pcie_device_mesh.get_device_ids()))
+        shard_offset, shard_size = 0, int(1024 / len(pcie_mesh_device.get_device_ids()))
         for device_tensor in ttnn.get_device_tensors(ttnn_loop_back_tensor):
             device_tensor_torch = ttnn.to_torch(device_tensor)
             assert_with_pcc(
@@ -79,87 +79,87 @@ def test_multi_device_check_per_device_shard(pcie_device_mesh, layout, memory_co
             )
             shard_offset += shard_size
 
-    for device in pcie_device_mesh.get_device_ids():
-        pcie_device_mesh.get_device(device).enable_async(False)
+    for device in pcie_mesh_device.get_device_ids():
+        pcie_mesh_device.get_device(device).enable_async(False)
 
 
 @pytest.mark.parametrize("shape", [(1, 1, 512, 512), (1, 1, 1040, 1040)])
 @pytest.mark.parametrize("layout", [ttnn.TILE_LAYOUT, ttnn.ROW_MAJOR_LAYOUT])
 @pytest.mark.parametrize("memory_config", [ttnn.DRAM_MEMORY_CONFIG, ttnn.L1_MEMORY_CONFIG])
-def test_multi_device_replicate(pcie_device_mesh, shape, layout, memory_config):
+def test_multi_device_replicate(pcie_mesh_device, shape, layout, memory_config):
     """Test ReplicateTensorToMesh to broadcast a tensor across multiple devices"""
     from ttnn import ReplicateTensorToMesh, ListMeshToTensor
 
-    for device in pcie_device_mesh.get_device_ids():
-        pcie_device_mesh.get_device(device).enable_async(True)
+    for device in pcie_mesh_device.get_device_ids():
+        pcie_mesh_device.get_device(device).enable_async(True)
 
     for i in range(100):
         full_tensor = torch.rand(shape, dtype=torch.bfloat16)
 
         ttnn_tensor = ttnn.from_torch(
             full_tensor,
-            mesh_mapper=ReplicateTensorToMesh(pcie_device_mesh),
+            mesh_mapper=ReplicateTensorToMesh(pcie_mesh_device),
             layout=layout,
             memory_config=memory_config,
-            device=pcie_device_mesh,
+            device=pcie_mesh_device,
         )
-        ttnn_tensor = ttnn.to_device(ttnn_tensor, pcie_device_mesh)
+        ttnn_tensor = ttnn.to_device(ttnn_tensor, pcie_mesh_device)
         ttnn_loop_back_tensor = ttnn.from_device(ttnn_tensor)
         loopback_replicated_tensors = ttnn.to_torch(
-            ttnn_loop_back_tensor, mesh_composer=ListMeshToTensor(pcie_device_mesh)
+            ttnn_loop_back_tensor, mesh_composer=ListMeshToTensor(pcie_mesh_device)
         )
         for loopback_replicated_tensor in loopback_replicated_tensors:
             assert torch.all(full_tensor == loopback_replicated_tensor)
 
-    for device in pcie_device_mesh.get_device_ids():
-        pcie_device_mesh.get_device(device).enable_async(False)
+    for device in pcie_mesh_device.get_device_ids():
+        pcie_mesh_device.get_device(device).enable_async(False)
 
 
 @pytest.mark.parametrize("layout", [ttnn.TILE_LAYOUT])
 @pytest.mark.parametrize("memory_config", [ttnn.DRAM_MEMORY_CONFIG])
 @pytest.mark.parametrize("dtype", [ttnn.bfloat8_b])
-def test_ttnn_to_multi_device_tilized_parallel(pcie_device_mesh, layout, memory_config, dtype):
+def test_ttnn_to_multi_device_tilized_parallel(pcie_mesh_device, layout, memory_config, dtype):
     """Test multi chip layout conversions on worker threads"""
     from ttnn import ShardTensorToMesh, ConcatMeshToTensor, ListMeshToTensor
 
     shard_dim = 3
-    for device in pcie_device_mesh.get_device_ids():
-        pcie_device_mesh.get_device(device).enable_async(True)
+    for device in pcie_mesh_device.get_device_ids():
+        pcie_mesh_device.get_device(device).enable_async(True)
     for loop in range(20):
         torch_tensor = torch.rand((8, 1, 1024, 1024), dtype=torch.bfloat16)
         ttnn_tensor = ttnn.from_torch(
             torch_tensor,
-            mesh_mapper=ShardTensorToMesh(pcie_device_mesh, dim=shard_dim),
+            mesh_mapper=ShardTensorToMesh(pcie_mesh_device, dim=shard_dim),
             layout=layout,
             memory_config=memory_config,
-            device=pcie_device_mesh,
+            device=pcie_mesh_device,
         )
         if loop < 10:
             # Test Concat Composer
             readback_tensor = ttnn.to_torch(
-                ttnn_tensor, mesh_composer=ConcatMeshToTensor(pcie_device_mesh, dim=shard_dim), device=pcie_device_mesh
+                ttnn_tensor, mesh_composer=ConcatMeshToTensor(pcie_mesh_device, dim=shard_dim), device=pcie_mesh_device
             )
         else:
             # Test Mesh Composer
             readback_tensors = ttnn.to_torch(
-                ttnn_tensor, mesh_composer=ListMeshToTensor(pcie_device_mesh), device=pcie_device_mesh
+                ttnn_tensor, mesh_composer=ListMeshToTensor(pcie_mesh_device), device=pcie_mesh_device
             )
             readback_tensor = torch.cat(readback_tensors, dim=shard_dim)
         assert torch.all(readback_tensor == torch_tensor)
-    for device in pcie_device_mesh.get_device_ids():
-        pcie_device_mesh.get_device(device).enable_async(False)
+    for device in pcie_mesh_device.get_device_ids():
+        pcie_mesh_device.get_device(device).enable_async(False)
 
 
 @pytest.mark.parametrize("program_cache", [False, True])
 @pytest.mark.parametrize("shape", [(1, 1, 512, 512), (1, 3, 1024, 1024)])
-def test_multi_device_unary_binary_op_chain(pcie_device_mesh, program_cache, shape):
+def test_multi_device_unary_binary_op_chain(pcie_mesh_device, program_cache, shape):
     """Multidevice API test: Running tensor-parallel multi-device chain of eltwise ops"""
     from ttnn import ShardTensorToMesh, ConcatMeshToTensor
 
-    for device in pcie_device_mesh.get_device_ids():
-        pcie_device_mesh.get_device(device).enable_async(True)
+    for device in pcie_mesh_device.get_device_ids():
+        pcie_mesh_device.get_device(device).enable_async(True)
         if program_cache:
-            pcie_device_mesh.get_device(device).enable_program_cache()
+            pcie_mesh_device.get_device(device).enable_program_cache()
 
     torch_silu = torch.nn.SiLU()
     for i in range(50):
@@ -175,8 +175,8 @@ def test_multi_device_unary_binary_op_chain(pcie_device_mesh, program_cache, sha
         ttnn_input_tensor = ttnn.from_torch(
             torch_input_tensor,
             layout=ttnn.TILE_LAYOUT,
-            mesh_mapper=ShardTensorToMesh(pcie_device_mesh, dim=3),
-            device=pcie_device_mesh,
+            mesh_mapper=ShardTensorToMesh(pcie_mesh_device, dim=3),
+            device=pcie_mesh_device,
         )
         ttnn_output_tensor = ttnn.add(
             ttnn.sub(ttnn.exp(ttnn.relu(ttnn.gelu(ttnn_input_tensor))), ttnn.exp(ttnn_input_tensor)),
@@ -184,24 +184,24 @@ def test_multi_device_unary_binary_op_chain(pcie_device_mesh, program_cache, sha
         )
         ttnn_output_tensor = ttnn.from_device(ttnn_output_tensor)
         ttnn_torch_output_tensor = ttnn.to_torch(
-            ttnn_output_tensor, mesh_composer=ConcatMeshToTensor(pcie_device_mesh, dim=3)
+            ttnn_output_tensor, mesh_composer=ConcatMeshToTensor(pcie_mesh_device, dim=3)
         )
         assert_with_pcc(ttnn_torch_output_tensor, torch_output_golden, pcc=0.98)
 
-    for device in pcie_device_mesh.get_device_ids():
-        pcie_device_mesh.get_device(device).enable_async(False)
+    for device in pcie_mesh_device.get_device_ids():
+        pcie_mesh_device.get_device(device).enable_async(False)
 
 
 @pytest.mark.parametrize("program_cache", [False, True])
 @pytest.mark.parametrize("input_a_shape", [(4, 1, 512, 512), (16, 1, 512, 512)])
-def test_multi_device_data_parallel_op_chain(pcie_device_mesh, program_cache, input_a_shape):
+def test_multi_device_data_parallel_op_chain(pcie_mesh_device, program_cache, input_a_shape):
     """Multidevice API: Running data-parallel chain of ops with matmul"""
     from ttnn import ShardTensorToMesh, ConcatMeshToTensor, ReplicateTensorToMesh
 
-    for device in pcie_device_mesh.get_device_ids():
-        pcie_device_mesh.get_device(device).enable_async(True)
+    for device in pcie_mesh_device.get_device_ids():
+        pcie_mesh_device.get_device(device).enable_async(True)
         if program_cache:
-            pcie_device_mesh.get_device(device).enable_program_cache()
+            pcie_mesh_device.get_device(device).enable_program_cache()
 
     torch_silu = torch.nn.SiLU()
     torch_mish = torch.nn.Mish()
@@ -218,14 +218,14 @@ def test_multi_device_data_parallel_op_chain(pcie_device_mesh, program_cache, in
         ttnn_input_a_tensor = ttnn.from_torch(
             torch_input_a_tensor,
             layout=ttnn.TILE_LAYOUT,
-            device=pcie_device_mesh,
-            mesh_mapper=ShardTensorToMesh(pcie_device_mesh, dim=0),
+            device=pcie_mesh_device,
+            mesh_mapper=ShardTensorToMesh(pcie_mesh_device, dim=0),
         )
         ttnn_input_b_tensor = ttnn.from_torch(
             torch_input_b_tensor,
             layout=ttnn.TILE_LAYOUT,
-            device=pcie_device_mesh,
-            mesh_mapper=ReplicateTensorToMesh(pcie_device_mesh),
+            device=pcie_mesh_device,
+            mesh_mapper=ReplicateTensorToMesh(pcie_mesh_device),
         )
         ttnn_output_tensor = ttnn.from_device(
             ttnn.mish(
@@ -235,20 +235,20 @@ def test_multi_device_data_parallel_op_chain(pcie_device_mesh, program_cache, in
             )
         )
         ttnn_torch_output_tensor = ttnn.to_torch(
-            ttnn_output_tensor, mesh_composer=ConcatMeshToTensor(pcie_device_mesh, dim=0)
+            ttnn_output_tensor, mesh_composer=ConcatMeshToTensor(pcie_mesh_device, dim=0)
         )
         assert_with_pcc(ttnn_torch_output_tensor, torch_output_golden, pcc=0.97)
 
-    for device in pcie_device_mesh.get_device_ids():
-        pcie_device_mesh.get_device(device).enable_async(False)
+    for device in pcie_mesh_device.get_device_ids():
+        pcie_mesh_device.get_device(device).enable_async(False)
 
 
 @pytest.mark.parametrize("layout", [ttnn.TILE_LAYOUT, ttnn.ROW_MAJOR_LAYOUT])
 @pytest.mark.parametrize("mem_config", [ttnn.DRAM_MEMORY_CONFIG, ttnn.L1_MEMORY_CONFIG])
-def test_multi_device_argmax(pcie_device_mesh, layout, mem_config):
+def test_multi_device_argmax(pcie_mesh_device, layout, mem_config):
     pytest.skip("Segfault on CI")
-    for device in pcie_device_mesh.get_device_ids():
-        pcie_device_mesh.get_device(device).enable_async(True)
+    for device in pcie_mesh_device.get_device_ids():
+        pcie_mesh_device.get_device(device).enable_async(True)
 
     torch.manual_seed(0)
     torch_input = torch.randn(1, 1, 32, 4096)
@@ -258,27 +258,27 @@ def test_multi_device_argmax(pcie_device_mesh, layout, mem_config):
         torch_input,
         dtype=ttnn.bfloat16,
         layout=layout,
-        device=pcie_device_mesh,
+        device=pcie_mesh_device,
         memory_config=mem_config,
-        mesh_mapper=ttnn.ReplicateTensorToMesh(pcie_device_mesh),
+        mesh_mapper=ttnn.ReplicateTensorToMesh(pcie_mesh_device),
     )
 
     tt_out_11BH = ttnn.argmax(tt_out_11BH, dim=-1)
     tt_out_1B = ttnn.reshape(tt_out_11BH[:1, :, :, :], ttnn.Shape([1, 32]))
-    tt_out_1B = ttnn.to_torch(tt_out_1B, mesh_composer=ttnn.ConcatMeshToTensor(pcie_device_mesh, dim=0))[0]
+    tt_out_1B = ttnn.to_torch(tt_out_1B, mesh_composer=ttnn.ConcatMeshToTensor(pcie_mesh_device, dim=0))[0]
 
     assert_with_pcc(tt_out_1B, reference_output, pcc=0.97)
 
-    for device in pcie_device_mesh.get_device_ids():
-        pcie_device_mesh.get_device(device).enable_async(False)
+    for device in pcie_mesh_device.get_device_ids():
+        pcie_mesh_device.get_device(device).enable_async(False)
 
 
-@pytest.mark.parametrize("pcie_device_mesh", [2], indirect=True)
-def test_multi_device_explicit_dealloc(pcie_device_mesh):
+@pytest.mark.parametrize("pcie_mesh_device", [2], indirect=True)
+def test_multi_device_explicit_dealloc(pcie_mesh_device):
     """Multidevice API: Ensure that deallocating multi-device tensors works as expected"""
     from ttnn import ShardTensorToMesh, ConcatMeshToTensor, ReplicateTensorToMesh
 
-    if pcie_device_mesh.get_num_devices() <= 1:
+    if pcie_mesh_device.get_num_devices() <= 1:
         pytest.skip("Requires multiple devices to run")
 
     # Create input tensors that cause OOM during op execution
@@ -289,14 +289,14 @@ def test_multi_device_explicit_dealloc(pcie_device_mesh):
     ttnn_input_a_tensor = ttnn.from_torch(
         torch_input_a_tensor,
         layout=ttnn.TILE_LAYOUT,
-        device=pcie_device_mesh,
-        mesh_mapper=ShardTensorToMesh(pcie_device_mesh, dim=0),
+        device=pcie_mesh_device,
+        mesh_mapper=ShardTensorToMesh(pcie_mesh_device, dim=0),
     )
     ttnn_input_b_tensor = ttnn.from_torch(
         torch_input_b_tensor,
         layout=ttnn.TILE_LAYOUT,
-        device=pcie_device_mesh,
-        mesh_mapper=ReplicateTensorToMesh(pcie_device_mesh),
+        device=pcie_mesh_device,
+        mesh_mapper=ReplicateTensorToMesh(pcie_mesh_device),
     )
     ttnn_output_tensor_1 = ttnn_input_a_tensor @ ttnn_input_b_tensor
     ttnn_output_tensor_2 = ttnn.gelu(ttnn_output_tensor_1)
@@ -308,18 +308,18 @@ def test_multi_device_explicit_dealloc(pcie_device_mesh):
     ttnn_output_tensor_3.deallocate()
     ttnn_output_tensor = ttnn.from_device(ttnn_output_tensor_4)
     ttnn_torch_output_tensor = ttnn.to_torch(
-        ttnn_output_tensor, mesh_composer=ConcatMeshToTensor(pcie_device_mesh, dim=0)
+        ttnn_output_tensor, mesh_composer=ConcatMeshToTensor(pcie_mesh_device, dim=0)
     )
 
 
 @pytest.mark.parametrize("scalar", [3])
 @pytest.mark.parametrize("size", [64])
-@pytest.mark.parametrize("pcie_device_mesh", [2], indirect=True)
-def test_add_1D_tensor_and_scalar(pcie_device_mesh, scalar, size):
+@pytest.mark.parametrize("pcie_mesh_device", [2], indirect=True)
+def test_add_1D_tensor_and_scalar(pcie_mesh_device, scalar, size):
     torch.manual_seed(0)
 
-    for device in pcie_device_mesh.get_device_ids():
-        pcie_device_mesh.get_device(device).enable_async(True)
+    for device in pcie_mesh_device.get_device_ids():
+        pcie_mesh_device.get_device(device).enable_async(True)
 
     torch_input_tensor = torch.rand((size,), dtype=torch.bfloat16)
     torch_output_tensor = torch_input_tensor + scalar
@@ -327,11 +327,11 @@ def test_add_1D_tensor_and_scalar(pcie_device_mesh, scalar, size):
     input_tensor = ttnn.from_torch(
         torch_input_tensor,
         layout=ttnn.TILE_LAYOUT,
-        device=pcie_device_mesh,
-        mesh_mapper=ttnn.ReplicateTensorToMesh(pcie_device_mesh),
+        device=pcie_mesh_device,
+        mesh_mapper=ttnn.ReplicateTensorToMesh(pcie_mesh_device),
     )
     output_tensor = input_tensor + scalar
-    output_tensors = ttnn.to_torch(output_tensor, mesh_composer=ttnn.ListMeshToTensor(pcie_device_mesh))
+    output_tensors = ttnn.to_torch(output_tensor, mesh_composer=ttnn.ListMeshToTensor(pcie_mesh_device))
     for output_tensor in output_tensors:
         assert ttnn.pearson_correlation_coefficient(torch_output_tensor, output_tensor) >= 0.99988
         assert output_tensor.shape == (1, size)

--- a/tt_metal/impl/CMakeLists.txt
+++ b/tt_metal/impl/CMakeLists.txt
@@ -2,8 +2,8 @@
 set(IMPL_SRC
     ${CMAKE_CURRENT_SOURCE_DIR}/device/device.cpp
 	${CMAKE_CURRENT_SOURCE_DIR}/device/device_pool.cpp
-	${CMAKE_CURRENT_SOURCE_DIR}/device/device_mesh.cpp
-	${CMAKE_CURRENT_SOURCE_DIR}/device/device_mesh_view.cpp
+	${CMAKE_CURRENT_SOURCE_DIR}/device/mesh_device.cpp
+	${CMAKE_CURRENT_SOURCE_DIR}/device/mesh_device_view.cpp
 	${CMAKE_CURRENT_SOURCE_DIR}/buffers/buffer.cpp
 	${CMAKE_CURRENT_SOURCE_DIR}/buffers/circular_buffer.cpp
 	${CMAKE_CURRENT_SOURCE_DIR}/buffers/semaphore.cpp

--- a/tt_metal/impl/device/mesh_device.hpp
+++ b/tt_metal/impl/device/mesh_device.hpp
@@ -10,29 +10,29 @@
 #include <optional>
 
 #include "tt_metal/impl/device/device.hpp"
-#include "tt_metal/impl/device/device_mesh_view.hpp"
+#include "tt_metal/impl/device/mesh_device_view.hpp"
 
 namespace tt::tt_metal {
 
 using DeviceIds = std::vector<int>;
-class DeviceMeshView;
+class MeshDeviceView;
 
-class DeviceMesh
+class MeshDevice
 {
 public:
-    DeviceGrid device_grid;
+    MeshShape mesh_shape;
     std::map<chip_id_t, Device *> managed_devices;
     std::vector<std::pair<int, Device *>> mesh_devices;
-    std::shared_ptr<DeviceMeshView> view;
+    std::shared_ptr<MeshDeviceView> view;
 
-    DeviceMesh(const DeviceGrid &device_grid, const DeviceIds &device_ids, size_t l1_small_size, size_t trace_region_size, size_t num_command_queues, DispatchCoreType dispatch_core_type);
-    ~DeviceMesh();
+    MeshDevice(const MeshShape &mesh_shape, const DeviceIds &device_ids, size_t l1_small_size, size_t trace_region_size, size_t num_command_queues, DispatchCoreType dispatch_core_type);
+    ~MeshDevice();
 
-    DeviceMesh(const DeviceMesh &) = delete;
-    DeviceMesh &operator=(const DeviceMesh &) = delete;
+    MeshDevice(const MeshDevice &) = delete;
+    MeshDevice &operator=(const MeshDevice &) = delete;
 
-    DeviceMesh(DeviceMesh &&) = delete;
-    DeviceMesh &operator=(DeviceMesh &&) = delete;
+    MeshDevice(MeshDevice &&) = delete;
+    MeshDevice &operator=(MeshDevice &&) = delete;
 
     std::vector<Device*> get_devices() const;
     Device *get_device(int logical_device_id) const;
@@ -45,7 +45,7 @@ public:
     int num_devices() const;
     int num_rows() const;
     int num_cols() const;
-    DeviceGrid shape() const;
+    MeshShape shape() const;
 
     CoreCoord compute_with_storage_grid_size() const;
 
@@ -54,8 +54,8 @@ public:
     tt::ARCH arch() const;
 
     void close_devices();
-    std::shared_ptr<const DeviceMeshView> get_view() const;
-    std::shared_ptr<DeviceMeshView> get_view();
+    std::shared_ptr<const MeshDeviceView> get_view() const;
+    std::shared_ptr<MeshDeviceView> get_view();
 
    private:
     bool is_galaxy_;

--- a/tt_metal/impl/device/mesh_device_view.hpp
+++ b/tt_metal/impl/device/mesh_device_view.hpp
@@ -15,9 +15,9 @@
 
 namespace tt::tt_metal {
 
-// Forward declaration of DeviceMesh
-class DeviceMesh;
-using DeviceGrid = std::pair<size_t, size_t>;
+// Forward declaration of MeshDevice
+class MeshDevice;
+using MeshShape = std::pair<size_t, size_t>;
 
 struct Coordinate {
     std::size_t row;
@@ -38,22 +38,22 @@ struct Coordinate {
 };
 
 /**
- * @brief The DeviceMeshView class provides a view of a specific sub-region within the DeviceMesh.
+ * @brief The MeshDeviceView class provides a view of a specific sub-region within the MeshDevice.
  *
- * Once a DeviceMesh is initialized, DeviceMeshView allows the creation of multiple "views" on the
- * DeviceMesh, enabling more granular control over a cluster of initialized devices. This approach
- * differs from simply creating a new DeviceMesh on a subset of devices.
+ * Once a MeshDevice is initialized, MeshDeviceView allows the creation of multiple "views" on the
+ * MeshDevice, enabling more granular control over a cluster of initialized devices. This approach
+ * differs from simply creating a new MeshDevice on a subset of devices.
  *
- * DeviceMeshView serves two primary purposes:
+ * MeshDeviceView serves two primary purposes:
  *
  * 1. It facilitates the creation of abstractions that define parallelization strategies, such as
- *    tensor-parallel or pipeline-parallel, by assigning views of the DeviceMesh.
+ *    tensor-parallel or pipeline-parallel, by assigning views of the MeshDevice.
  *
- * 2. It acts as a query interface for the DeviceMesh, allowing the retrieval of devices based on
+ * 2. It acts as a query interface for the MeshDevice, allowing the retrieval of devices based on
  *    specific sub-regions. This is particularly useful for collective communication operations
  *    (CCL-ops), such as line all-gather, which require column or row views of the device mesh.
  */
-class DeviceMeshView {
+class MeshDeviceView {
 public:
     using device_pointer = Device*;
     using const_device_pointer = const Device*;
@@ -61,9 +61,9 @@ public:
     using DeviceViews = std::vector<std::vector<device_pointer>>;
     using CoordinateMapper = std::function<std::optional<Coordinate>(int device_id)>;
 
-    DeviceMeshView(const DeviceMesh& mesh);
-    DeviceMeshView(const DeviceMesh& mesh, Coordinate top_left, Coordinate bottom_right);
-    DeviceMeshView(std::vector<device_pointer> devices, CoordinateMapper mapper);
+    MeshDeviceView(const MeshDevice& mesh);
+    MeshDeviceView(const MeshDevice& mesh, Coordinate top_left, Coordinate bottom_right);
+    MeshDeviceView(std::vector<device_pointer> devices, CoordinateMapper mapper);
 
     [[nodiscard]] device_pointer get_device(size_t row, size_t col);
     [[nodiscard]] const_device_pointer get_device(size_t row, size_t col) const;
@@ -73,7 +73,7 @@ public:
     // Get devices spanning the rectangular region defined by the top-left and bottom-right coordinates
     // devices are returned in row-major order with start/end coordinates inclusive
     [[nodiscard]] DeviceView get_devices(const Coordinate& start, const Coordinate& end);
-    [[nodiscard]] DeviceView get_devices(const DeviceGrid& shape);
+    [[nodiscard]] DeviceView get_devices(const MeshShape& shape);
 
     [[nodiscard]] DeviceView get_devices_on_row(size_t row) const;
     [[nodiscard]] DeviceView get_devices_on_column(size_t col) const;
@@ -82,7 +82,7 @@ public:
     [[nodiscard]] DeviceViews get_column_views() const;
 
     template<typename Pred>
-    [[nodiscard]] DeviceMeshView subview(Pred&& predicate) const;
+    [[nodiscard]] MeshDeviceView subview(Pred&& predicate) const;
 
     [[nodiscard]] bool empty() const noexcept;
     [[nodiscard]] size_t size() const noexcept;
@@ -90,7 +90,7 @@ public:
     [[nodiscard]] bool contains(const Coordinate& coord) const noexcept;
     [[nodiscard]] const_device_pointer at(const Coordinate& coord) const noexcept;
 
-    bool operator==(const DeviceMeshView& other) const;
+    bool operator==(const MeshDeviceView& other) const;
 
     auto begin() const { return devices_.begin(); }
     auto end() const { return devices_.end(); }
@@ -112,9 +112,9 @@ private:
     void validate_coordinates() const;
 };
 
-// Helper function to create a DeviceMeshView
-inline DeviceMeshView make_device_mesh_view(std::vector<Device*> devices, DeviceMeshView::CoordinateMapper mapper) {
-    return DeviceMeshView(std::move(devices), std::move(mapper));
+// Helper function to create a MeshDeviceView
+inline MeshDeviceView make_mesh_device_view(std::vector<Device*> devices, MeshDeviceView::CoordinateMapper mapper) {
+    return MeshDeviceView(std::move(devices), std::move(mapper));
 }
 
 } // namespace tt::tt_metal

--- a/tt_metal/impl/module.mk
+++ b/tt_metal/impl/module.mk
@@ -6,8 +6,8 @@ TT_METAL_IMPL_CFLAGS = $(CFLAGS) -Werror -Wno-int-to-pointer-cast
 TT_METAL_IMPL_SRCS = \
 	tt_metal/impl/device/device.cpp \
 	tt_metal/impl/device/device_pool.cpp \
-	tt_metal/impl/device/device_mesh.cpp \
-	tt_metal/impl/device/device_mesh_view.cpp \
+	tt_metal/impl/device/mesh_device.cpp \
+	tt_metal/impl/device/mesh_device_view.cpp \
 	tt_metal/impl/buffers/buffer.cpp \
 	tt_metal/impl/buffers/circular_buffer.cpp \
 	tt_metal/impl/buffers/semaphore.cpp \

--- a/ttnn/cpp/pybind11/events.cpp
+++ b/ttnn/cpp/pybind11/events.cpp
@@ -54,13 +54,13 @@ void py_module(py::module& module) {
     // Multi Device APIs
     module.def(
         "create_event",
-        py::overload_cast<DeviceMesh*>(&create_event),
-        py::arg("device_mesh"),
+        py::overload_cast<MeshDevice*>(&create_event),
+        py::arg("mesh_device"),
         R"doc(
             Create an Event Object on a mesh of devices.
 
             Args:
-                device_mesh (DeviceMesh): The mesh on which this event will be used for synchronization.
+                mesh_device (MeshDevice): The mesh on which this event will be used for synchronization.
             )doc");
 
     module.def(

--- a/ttnn/cpp/pybind11/multi_device.hpp
+++ b/ttnn/cpp/pybind11/multi_device.hpp
@@ -16,31 +16,31 @@ namespace ttnn {
 
 namespace multi_device {
 
-void py_module_types(py::module& module) { py::class_<DeviceMesh>(module, "DeviceMesh"); }
+void py_module_types(py::module& module) { py::class_<MeshDevice>(module, "MeshDevice"); }
 
 void py_module(py::module& module) {
-    auto py_device_mesh = static_cast<py::class_<DeviceMesh>>(module.attr("DeviceMesh"));
-    py_device_mesh
+    auto py_mesh_device = static_cast<py::class_<MeshDevice>>(module.attr("MeshDevice"));
+    py_mesh_device
         .def(
-            py::init<DeviceGrid, std::vector<int>, size_t, size_t, size_t, DispatchCoreType>(),
+            py::init<MeshShape, std::vector<int>, size_t, size_t, size_t, DispatchCoreType>(),
             py::kw_only(),
-            py::arg("device_grid"),
+            py::arg("mesh_shape"),
             py::arg("device_ids"),
             py::arg("l1_small_size"),
             py::arg("trace_region_size"),
             py::arg("num_command_queues"),
             py::arg("dispatch_core_type"))
-        .def("get_num_devices", &DeviceMesh::num_devices)
-        .def("get_device_ids", &DeviceMesh::get_device_ids)
+        .def("get_num_devices", &MeshDevice::num_devices)
+        .def("get_device_ids", &MeshDevice::get_device_ids)
         .def(
             "get_device",
-            py::overload_cast<int>(&DeviceMesh::get_device, py::const_),
+            py::overload_cast<int>(&MeshDevice::get_device, py::const_),
             py::return_value_policy::reference)
         .def(
             "get_device",
-            py::overload_cast<int, int>(&DeviceMesh::get_device, py::const_),
+            py::overload_cast<int, int>(&MeshDevice::get_device, py::const_),
             py::return_value_policy::reference)
-        .def("get_devices", &DeviceMesh::get_devices, py::return_value_policy::reference, R"doc(
+        .def("get_devices", &MeshDevice::get_devices, py::return_value_policy::reference, R"doc(
             Get the devices in the device mesh.
 
             Returns:
@@ -48,7 +48,7 @@ void py_module(py::module& module) {
         )doc")
         .def(
             "get_devices_on_row",
-            &DeviceMesh::get_devices_on_row,
+            &MeshDevice::get_devices_on_row,
             py::return_value_policy::reference,
             R"doc(
             Get the devices in a row of the device mesh.
@@ -58,7 +58,7 @@ void py_module(py::module& module) {
         )doc")
         .def(
             "get_devices_on_column",
-            &DeviceMesh::get_devices_on_column,
+            &MeshDevice::get_devices_on_column,
             py::return_value_policy::reference,
             R"doc(
             Get the devices in a row of the device mesh.
@@ -68,7 +68,7 @@ void py_module(py::module& module) {
         )doc")
         .def(
             "compute_with_storage_grid_size",
-            &DeviceMesh::compute_with_storage_grid_size,
+            &MeshDevice::compute_with_storage_grid_size,
             R"doc(
             Get the compute grid size (x, y) of the first device in the device mesh denoting region that can be targeted by ops.
 
@@ -77,7 +77,7 @@ void py_module(py::module& module) {
         )doc")
         .def(
             "dram_grid_size",
-            &DeviceMesh::dram_grid_size,
+            &MeshDevice::dram_grid_size,
             R"doc(
             Get the dram grid size (x, y) of the first device in the device mesh.
 
@@ -86,14 +86,14 @@ void py_module(py::module& module) {
         )doc")
         .def(
             "arch",
-            &DeviceMesh::arch,
+            &MeshDevice::arch,
             R"doc(
             Get the arch of the first device in the device mesh.
 
             Returns:
                 Arch: The arch of the first device in the device mesh.
         )doc")
-        .def_property_readonly("shape", &DeviceMesh::shape, R"doc(
+        .def_property_readonly("shape", &MeshDevice::shape, R"doc(
             Get the shape of the device mesh.
 
             Returns:
@@ -101,17 +101,17 @@ void py_module(py::module& module) {
         )doc");
 
     module.def(
-        "open_device_mesh",
-        &open_device_mesh,
+        "open_mesh_device",
+        &open_mesh_device,
         py::kw_only(),
-        py::arg("device_grid"),
+        py::arg("mesh_shape"),
         py::arg("device_ids"),
         py::arg("l1_small_size"),
         py::arg("trace_region_size"),
         py::arg("num_command_queues"),
         py::arg("dispatch_core_type"));
 
-    module.def("close_device_mesh", &close_device_mesh, py::arg("device_mesh"), py::kw_only());
+    module.def("close_mesh_device", &close_mesh_device, py::arg("mesh_device"), py::kw_only());
     module.def(
         "get_device_tensor",
         py::overload_cast<const Tensor&, int>(&tt::tt_metal::get_device_tensor),

--- a/ttnn/cpp/pybind11/operations/core.hpp
+++ b/ttnn/cpp/pybind11/operations/core.hpp
@@ -104,7 +104,7 @@ void py_module(py::module& module) {
 
     module.def(
         "to_device",
-        py::overload_cast<const ttnn::Tensor&, DeviceMesh*, const std::optional<MemoryConfig>&>(
+        py::overload_cast<const ttnn::Tensor&, MeshDevice*, const std::optional<MemoryConfig>&>(
             &ttnn::operations::core::to_device),
         py::arg("tensor"),
         py::arg("device"),
@@ -186,12 +186,12 @@ void py_module(py::module& module) {
             const ttnn::Shape&,
             ttnn::DataType,
             ttnn::Layout,
-            DeviceMesh*,
+            MeshDevice*,
             const std::optional<ttnn::MemoryConfig>&>(&ttnn::operations::core::allocate_tensor_on_device),
         py::arg("shape"),
         py::arg("dtype"),
         py::arg("layout"),
-        py::arg("device_mesh"),
+        py::arg("mesh_device"),
         py::arg("memory_config") = std::nullopt);
 
     module.def(
@@ -233,23 +233,23 @@ void py_module(py::module& module) {
 
     module.def(
         "begin_trace_capture",
-        py::overload_cast<DeviceMesh*, const uint8_t>(&ttnn::operations::core::begin_trace_capture),
-        py::arg("device_mesh"),
+        py::overload_cast<MeshDevice*, const uint8_t>(&ttnn::operations::core::begin_trace_capture),
+        py::arg("mesh_device"),
         py::kw_only(),
         py::arg("cq_id") = ttnn::DefaultQueueId);
 
     module.def(
         "end_trace_capture",
-        py::overload_cast<DeviceMesh*, const uint32_t, const uint8_t>(&ttnn::operations::core::end_trace_capture),
-        py::arg("device_mesh"),
+        py::overload_cast<MeshDevice*, const uint32_t, const uint8_t>(&ttnn::operations::core::end_trace_capture),
+        py::arg("mesh_device"),
         py::arg("trace_id"),
         py::kw_only(),
         py::arg("cq_id") = ttnn::DefaultQueueId);
 
     module.def(
         "execute_trace",
-        py::overload_cast<DeviceMesh*, const uint32_t, const uint8_t, bool>(&ttnn::operations::core::execute_trace),
-        py::arg("device_mesh"),
+        py::overload_cast<MeshDevice*, const uint32_t, const uint8_t, bool>(&ttnn::operations::core::execute_trace),
+        py::arg("mesh_device"),
         py::arg("trace_id"),
         py::kw_only(),
         py::arg("cq_id") = ttnn::DefaultQueueId,
@@ -257,8 +257,8 @@ void py_module(py::module& module) {
 
     module.def(
         "release_trace",
-        py::overload_cast<DeviceMesh*, const uint32_t>(&ttnn::operations::core::release_trace),
-        py::arg("device_mesh"),
+        py::overload_cast<MeshDevice*, const uint32_t>(&ttnn::operations::core::release_trace),
+        py::arg("mesh_device"),
         py::arg("trace_id"));
 
     bind_registered_operation(
@@ -276,7 +276,7 @@ void py_module(py::module& module) {
         * :attr:`layout`: the layout of either ttnn.ROW_MAJOR_LAYOUT or ttnn.TILE_LAYOUT.
         * :attr:`dtype`: the optional output data type.
         * :attr:`memory_config`: the optional output memory configuration.
-        * :attr:`device`: Device/DeviceMesh whose worker thread on host should be used for the layout conversion
+        * :attr:`device`: Device/MeshDevice whose worker thread on host should be used for the layout conversion
 
     Example:
         >>> device_id = 0
@@ -303,7 +303,7 @@ void py_module(py::module& module) {
                const ttnn::Layout layout,
                const std::optional<ttnn::DataType>& dtype,
                const std::optional<ttnn::MemoryConfig>& memory_config,
-               DeviceMesh* device) -> ttnn::Tensor { return self(tensor, layout, dtype, memory_config, device); },
+               MeshDevice* device) -> ttnn::Tensor { return self(tensor, layout, dtype, memory_config, device); },
             py::arg("tensor"),
             py::arg("layout"),
             py::arg("dtype") = std::nullopt,

--- a/ttnn/cpp/ttnn/deprecated/tt_lib/csrc/tt_lib_bindings_tensor.cpp
+++ b/ttnn/cpp/ttnn/deprecated/tt_lib/csrc/tt_lib_bindings_tensor.cpp
@@ -334,7 +334,7 @@ void TensorModule(py::module& m_tensor) {
         R"doc(Load tensor to file)doc");
     m_tensor.def(
         "load_tensor",
-        static_cast<Tensor (*)(const std::string&, DeviceMesh*)>(&load_tensor<DeviceMesh*>),
+        static_cast<Tensor (*)(const std::string&, MeshDevice*)>(&load_tensor<MeshDevice*>),
         py::arg("file_name"),
         py::arg("device") = nullptr,
         R"doc(Load tensor to file)doc");
@@ -361,7 +361,7 @@ void TensorModule(py::module& m_tensor) {
 
     m_tensor.def(
         "allocate_tensor_on_device",
-        py::overload_cast<const ttnn::Shape&, DataType, Layout, DeviceMesh*, const MemoryConfig&>(
+        py::overload_cast<const ttnn::Shape&, DataType, Layout, MeshDevice*, const MemoryConfig&>(
             &allocate_tensor_on_device),
         py::arg("shape"),
         py::arg("dtype"),

--- a/ttnn/cpp/ttnn/deprecated/tt_lib/csrc/tt_lib_bindings_tensor_pytensor.cpp
+++ b/ttnn/cpp/ttnn/deprecated/tt_lib/csrc/tt_lib_bindings_tensor_pytensor.cpp
@@ -952,8 +952,8 @@ Tensor convert_python_tensors_to_tt_tensors(py::list tensor_shards, std::optiona
                 )doc")
             .def(
                 "to",
-                py::overload_cast<DeviceMesh *, const MemoryConfig &>(&Tensor::to, py::const_),
-                py::arg("device_mesh").noconvert(),
+                py::overload_cast<MeshDevice *, const MemoryConfig &>(&Tensor::to, py::const_),
+                py::arg("mesh_device").noconvert(),
                 py::arg("mem_config").noconvert() = MemoryConfig{.memory_layout = TensorMemoryLayout::INTERLEAVED},
                 py::keep_alive<0, 2>(),
                 R"doc(
@@ -966,7 +966,7 @@ Tensor convert_python_tensors_to_tt_tensors(py::list tensor_shards, std::optiona
                 +-----------+-------------------------------------------------+----------------------------+-----------------------+----------+
                 | Argument  | Description                                     | Data type                  | Valid range           | Required |
                 +===========+=================================================+============================+=======================+==========+
-                | arg0      | DeviceMesh to which tensor will be moved        | tt_lib.device.DeviceMesh   | TT accelerator device | Yes      |
+                | arg0      | MeshDevice to which tensor will be moved        | tt_lib.device.MeshDevice   | TT accelerator device | Yes      |
                 +-----------+-------------------------------------------------+----------------------------+-----------------------+----------+
                 | arg1      | MemoryConfig of tensor of TT accelerator device | tt_lib.tensor.MemoryConfig |                       | No       |
                 +-----------+-------------------------------------------------+----------------------------+-----------------------+----------+
@@ -1066,9 +1066,9 @@ Tensor convert_python_tensors_to_tt_tensors(py::list tensor_shards, std::optiona
             )doc")
             .def(
                 "to",
-                py::overload_cast<Layout, DeviceMesh*>(&Tensor::to, py::const_),
+                py::overload_cast<Layout, MeshDevice*>(&Tensor::to, py::const_),
                 py::arg("target_layout").noconvert(),
-                py::arg("device_mesh") = nullptr,
+                py::arg("mesh_device") = nullptr,
                 R"doc(
                 Convert TT Tensor to provided memory layout. Available layouts conversions are:
                 * ROW_MAJOR to TILE
@@ -1084,7 +1084,7 @@ Tensor convert_python_tensors_to_tt_tensors(py::list tensor_shards, std::optiona
 
                 .. code-block:: python
 
-                    tt_tensor = tt_tensor.to(tt_lib.tensor.Layout.TILE, device_mesh)
+                    tt_tensor = tt_tensor.to(tt_lib.tensor.Layout.TILE, mesh_device)
             )doc")
             .def(
                 "pad",

--- a/ttnn/cpp/ttnn/events.cpp
+++ b/ttnn/cpp/ttnn/events.cpp
@@ -9,9 +9,9 @@
 
 namespace ttnn::events {
 
-MultiDeviceEvent::MultiDeviceEvent(DeviceMesh* device_mesh) {
-    TT_ASSERT(device_mesh != nullptr, "Must provide a valid device_mesh when initializing an event on multiple devices.");
-    auto& devices = device_mesh->mesh_devices;
+MultiDeviceEvent::MultiDeviceEvent(MeshDevice* mesh_device) {
+    TT_ASSERT(mesh_device != nullptr, "Must provide a valid mesh_device when initializing an event on multiple devices.");
+    auto& devices = mesh_device->mesh_devices;
     this->events = std::vector<std::shared_ptr<Event>>(devices.size());
     for (int event_idx = 0; event_idx < devices.size(); event_idx++) {
         this->events[event_idx] = std::make_shared<Event>();
@@ -39,8 +39,8 @@ void wait_for_event(uint8_t cq_id, const std::shared_ptr<Event>& event) {
     });
 }
 
-MultiDeviceEvent create_event(DeviceMesh* device_mesh) {
-    return MultiDeviceEvent(device_mesh);
+MultiDeviceEvent create_event(MeshDevice* mesh_device) {
+    return MultiDeviceEvent(mesh_device);
 }
 
 void record_event(uint8_t cq_id, const MultiDeviceEvent& multi_device_event) {

--- a/ttnn/cpp/ttnn/events.hpp
+++ b/ttnn/cpp/ttnn/events.hpp
@@ -6,13 +6,13 @@
 
 #include <memory>
 
-#include "tt_metal/impl/device/device_mesh.hpp"
+#include "tt_metal/impl/device/mesh_device.hpp"
 
 namespace ttnn::events {
 
 struct MultiDeviceEvent
 {
-    MultiDeviceEvent(DeviceMesh* device_mesh);
+    MultiDeviceEvent(MeshDevice* mesh_device);
     std::vector<std::shared_ptr<Event>> events;
 };
 // Single Device APIs
@@ -20,7 +20,7 @@ std::shared_ptr<Event> create_event(Device* device);
 void record_event(uint8_t cq_id, const std::shared_ptr<Event>& event);
 void wait_for_event(uint8_t cq_id, const std::shared_ptr<Event>& event);
 // Multi Device APIs
-MultiDeviceEvent create_event(DeviceMesh* device_mesh);
+MultiDeviceEvent create_event(MeshDevice* mesh_device);
 void record_event(uint8_t cq_id, const MultiDeviceEvent& event);
 void wait_for_event(uint8_t cq_id, const MultiDeviceEvent& event);
 

--- a/ttnn/cpp/ttnn/multi_device.cpp
+++ b/ttnn/cpp/ttnn/multi_device.cpp
@@ -8,15 +8,15 @@
 
 #include "ttnn/tensor/tensor.hpp"
 #include "ttnn/tensor/tensor_utils.hpp"
-#include "tt_metal/impl/device/device_mesh.hpp"
+#include "tt_metal/impl/device/mesh_device.hpp"
 
 namespace ttnn::multi_device {
 
-DeviceMesh open_device_mesh(const DeviceGrid& device_grid, const DeviceIds& device_ids, size_t l1_small_size, size_t trace_region_size, size_t num_command_queues, DispatchCoreType dispatch_core_type) {
-    return DeviceMesh(device_grid, device_ids, l1_small_size, trace_region_size, num_command_queues, dispatch_core_type);
+MeshDevice open_mesh_device(const MeshShape& mesh_shape, const DeviceIds& device_ids, size_t l1_small_size, size_t trace_region_size, size_t num_command_queues, DispatchCoreType dispatch_core_type) {
+    return MeshDevice(mesh_shape, device_ids, l1_small_size, trace_region_size, num_command_queues, dispatch_core_type);
 }
 
-void close_device_mesh(DeviceMesh &multi_device) {
+void close_mesh_device(MeshDevice &multi_device) {
     multi_device.close_devices();
 }
 

--- a/ttnn/cpp/ttnn/multi_device.hpp
+++ b/ttnn/cpp/ttnn/multi_device.hpp
@@ -8,15 +8,15 @@
 
 #include "ttnn/types.hpp"
 #include "ttnn/tensor/tensor.hpp"
-#include "tt_metal/impl/device/device_mesh.hpp"
+#include "tt_metal/impl/device/mesh_device.hpp"
 
 using Device = ttnn::Device;
 
 namespace ttnn {
 namespace multi_device {
 
-DeviceMesh open_device_mesh(const DeviceGrid& device_grid, const DeviceIds& device_ids, size_t l1_small_size, size_t trace_region_size, size_t num_command_queues, DispatchCoreType dispatch_core_type);
-void close_device_mesh(DeviceMesh &multi_device);
+MeshDevice open_mesh_device(const MeshShape& mesh_shape, const DeviceIds& device_ids, size_t l1_small_size, size_t trace_region_size, size_t num_command_queues, DispatchCoreType dispatch_core_type);
+void close_mesh_device(MeshDevice &multi_device);
 
 std::vector<ttnn::Tensor> get_device_tensors(const ttnn::Tensor& tensor);
 

--- a/ttnn/cpp/ttnn/operations/ccl/line_all_gather/device/line_all_gather_op.cpp
+++ b/ttnn/cpp/ttnn/operations/ccl/line_all_gather/device/line_all_gather_op.cpp
@@ -4,7 +4,7 @@
 
 #include "ttnn/operations/ccl/line_all_gather/device/line_all_gather_op.hpp"
 #include "ttnn/operations/ccl/all_gather/device/all_gather_op.hpp"
-#include "tt_metal/impl/device/device_mesh_view.hpp"
+#include "tt_metal/impl/device/mesh_device_view.hpp"
 #include "tt_dnn/op_library/math.hpp"
 
 #include "tt_metal/host_api.hpp"
@@ -126,11 +126,11 @@ Tensor line_all_gather(
     const Tensor& input_tensor,
     const uint32_t dim,
     const uint32_t cluster_axis,
-    const DeviceMesh& device_mesh,
+    const MeshDevice& mesh_device,
     const uint32_t num_links,
     const std::optional<MemoryConfig>& memory_config) {
 
-    const auto mesh_view = device_mesh.get_view();
+    const auto mesh_view = mesh_device.get_view();
     std::size_t num_devices = (cluster_axis == 0) ? mesh_view->num_rows() : mesh_view->num_cols();
 
     std::vector<Tensor> output_tensors = {Tensor(operation::get_workers_for_op_output({input_tensor}))};

--- a/ttnn/cpp/ttnn/operations/ccl/line_all_gather/device/line_all_gather_op.hpp
+++ b/ttnn/cpp/ttnn/operations/ccl/line_all_gather/device/line_all_gather_op.hpp
@@ -58,7 +58,7 @@ Tensor line_all_gather(
     const Tensor& input_tensor,
     const uint32_t dim,
     const uint32_t cluster_axis,
-    const DeviceMesh& device_mesh,
+    const MeshDevice& mesh_device,
     const uint32_t num_links = 1,
     const std::optional<MemoryConfig>& memory_config = std::nullopt);
 

--- a/ttnn/cpp/ttnn/operations/ccl/line_all_gather/line_all_gather.cpp
+++ b/ttnn/cpp/ttnn/operations/ccl/line_all_gather/line_all_gather.cpp
@@ -20,11 +20,11 @@ ttnn::Tensor ExecuteLineAllGather::invoke(
     const ttnn::Tensor& input_tensor,
     const uint32_t dim,
     const uint32_t cluster_axis,
-    const DeviceMesh& device_mesh,
+    const MeshDevice& mesh_device,
     const uint32_t num_links,
     const std::optional<ttnn::MemoryConfig>& memory_config) {
     return ttnn::operations::ccl::line_all_gather(
-        input_tensor, dim, cluster_axis, device_mesh, num_links, memory_config);
+        input_tensor, dim, cluster_axis, mesh_device, num_links, memory_config);
 }
 
 }  // namespace ttnn::operations::ccl

--- a/ttnn/cpp/ttnn/operations/ccl/line_all_gather/line_all_gather.hpp
+++ b/ttnn/cpp/ttnn/operations/ccl/line_all_gather/line_all_gather.hpp
@@ -21,7 +21,7 @@ struct ExecuteLineAllGather {
         const ttnn::Tensor& input_tensor,
         const uint32_t dim,
         const uint32_t cluster_axis,
-        const DeviceMesh& device_mesh,
+        const MeshDevice& mesh_device,
         const uint32_t num_links = 1,
         const std::optional<ttnn::MemoryConfig>& memory_config = std::nullopt);
 };

--- a/ttnn/cpp/ttnn/operations/ccl/line_all_gather/line_all_gather_pybind.cpp
+++ b/ttnn/cpp/ttnn/operations/ccl/line_all_gather/line_all_gather_pybind.cpp
@@ -38,15 +38,15 @@ void bind_line_all_gather(pybind11::module& module, const ccl_operation_t& opera
                const ttnn::Tensor& input_tensor,
                const uint32_t dim,
                const uint32_t cluster_axis,
-               const DeviceMesh& device_mesh,
+               const MeshDevice& mesh_device,
                const uint32_t num_links,
                const std::optional<ttnn::MemoryConfig>& memory_config) -> ttnn::Tensor {
-                return self(input_tensor, dim, cluster_axis, device_mesh, num_links, memory_config);
+                return self(input_tensor, dim, cluster_axis, mesh_device, num_links, memory_config);
             },
             py::arg("input_tensor"),
             py::arg("dim"),
             py::arg("cluster_axis"),
-            py::arg("device_mesh"),
+            py::arg("mesh_device"),
             py::kw_only(),
             py::arg("num_links") = 1,
             py::arg("memory_config") = std::nullopt});
@@ -71,9 +71,9 @@ void py_bind_line_all_gather(pybind11::module& module) {
                 After the all-gather operation, the size of the :attr:`dim`
                 dimension will larger by number of devices in the line.
             * :attr:`cluster_axis` (int):
-                Provided a MeshTensor, the axis corresponding to DeviceMesh
+                Provided a MeshTensor, the axis corresponding to MeshDevice
                 to perform the line-all-gather operation on.
-            * :attr:`device_mesh` (DeviceMesh):
+            * :attr:`mesh_device` (MeshDevice):
                 Device mesh to perform the line-all-gather operation on.
 
         Keyword Args:

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/conv2d.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/conv2d.cpp
@@ -866,14 +866,14 @@ template ParallelConfig determine_parallel_config<Device>(
     ShardOrientation block_shard_orientation,
     bool is_out_tiled);
 
-template ParallelConfig determine_parallel_config<DeviceMesh>(
+template ParallelConfig determine_parallel_config<MeshDevice>(
     const TensorMemoryLayout shard_layout,
     uint32_t batch_size,
     uint32_t input_channels,
     uint32_t output_height,
     uint32_t output_width,
     uint32_t output_channels,
-    DeviceMesh * device,
+    MeshDevice * device,
     ShardOrientation block_shard_orientation,
     bool is_out_tiled);
 
@@ -887,8 +887,8 @@ template std::tuple<ttnn::Shape, ttnn::MemoryConfig, bool> get_conv_padded_input
     uint32_t in_channels,
     uint32_t out_channels);
 
-template std::tuple<ttnn::Shape, ttnn::MemoryConfig, bool> get_conv_padded_input_shape_and_mem_config<DeviceMesh>(
-    DeviceMesh * device,
+template std::tuple<ttnn::Shape, ttnn::MemoryConfig, bool> get_conv_padded_input_shape_and_mem_config<MeshDevice>(
+    MeshDevice * device,
     const ttnn::Tensor& input_tensor_,
     const Conv2dConfig& conv_config,
     uint32_t batch_size,
@@ -907,8 +907,8 @@ template std::tuple<ttnn::Tensor, ParallelConfig, bool> shard_or_reshard_tensor_
     uint32_t in_channels,
     uint32_t out_channels);
 
-template std::tuple<ttnn::Tensor, ParallelConfig, bool> shard_or_reshard_tensor_if_required<DeviceMesh>(
-    DeviceMesh * device,
+template std::tuple<ttnn::Tensor, ParallelConfig, bool> shard_or_reshard_tensor_if_required<MeshDevice>(
+    MeshDevice * device,
     const ttnn::Tensor& input_tensor_,
     const Conv2dConfig& conv_config,
     uint32_t batch_size,
@@ -928,7 +928,7 @@ template std::pair<ttnn::Tensor, std::optional<ttnn::Tensor>> prepare_conv_weigh
     Device * device,
     uint32_t groups, uint32_t act_block_h_ntiles, uint32_t input_width);
 
-template std::pair<ttnn::Tensor, std::optional<ttnn::Tensor>> prepare_conv_weights_biases_and_move_to_device<DeviceMesh>(
+template std::pair<ttnn::Tensor, std::optional<ttnn::Tensor>> prepare_conv_weights_biases_and_move_to_device<MeshDevice>(
     const ttnn::Tensor& weight_tensor,
     std::optional<const ttnn::Tensor>& bias_tensor,
     uint32_t input_channels_alignment,
@@ -936,7 +936,7 @@ template std::pair<ttnn::Tensor, std::optional<ttnn::Tensor>> prepare_conv_weigh
     uint32_t weight_block_h_ntiles,
     uint32_t weight_block_w_ntiles,
     const ParallelConfig& parallel_config,
-    DeviceMesh * device,
+    MeshDevice * device,
     uint32_t groups, uint32_t act_block_h_ntiles, uint32_t input_width);
 
 template std::tuple<ttnn::Tensor, uint32_t, uint32_t, ttnn::Tensor, std::optional<ttnn::Tensor>> conv2d<Device>(
@@ -956,10 +956,10 @@ template std::tuple<ttnn::Tensor, uint32_t, uint32_t, ttnn::Tensor, std::optiona
     std::optional<const ttnn::Tensor> bias_tensor,
     std::optional<const Conv2dConfig> conv_config_);
 
-template std::tuple<ttnn::Tensor, uint32_t, uint32_t, ttnn::Tensor, std::optional<ttnn::Tensor>> conv2d<DeviceMesh>(
+template std::tuple<ttnn::Tensor, uint32_t, uint32_t, ttnn::Tensor, std::optional<ttnn::Tensor>> conv2d<MeshDevice>(
     const ttnn::Tensor& input_tensor,
     const ttnn::Tensor& weight_tensor,
-    DeviceMesh * device,
+    MeshDevice * device,
     uint32_t in_channels,
     uint32_t out_channels,
     uint32_t batch_size,

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/conv2d.hpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/conv2d.hpp
@@ -197,7 +197,7 @@ struct Conv2dOperation{
         uint8_t queue_id,
         const ttnn::Tensor& input_tensor,
         const ttnn::Tensor& weight_tensor,
-        DeviceMesh * device,
+        MeshDevice * device,
         uint32_t in_channels,
         uint32_t out_channels,
         uint32_t batch_size,

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/conv2d_pybind.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/conv2d_pybind.cpp
@@ -94,7 +94,7 @@ void py_bind_conv2d(py::module& module) {
         ttnn::pybind_overload_t{
             [](const decltype(ttnn::conv2d)& self, const ttnn::Tensor& input_tensor,
                 const ttnn::Tensor& weight_tensor,
-                ttnn::DeviceMesh* device,
+                ttnn::MeshDevice* device,
                 uint32_t in_channels,
                 uint32_t out_channels,
                 uint32_t batch_size,
@@ -195,7 +195,7 @@ void py_bind_conv2d(py::module& module) {
 
     module.def(
         "get_conv_padded_input_shape_and_mem_config",
-        [](DeviceMesh * device,
+        [](MeshDevice * device,
             const ttnn::Tensor& input_tensor,
             const Conv2dConfig& conv_config,
             uint32_t batch_size,
@@ -203,7 +203,7 @@ void py_bind_conv2d(py::module& module) {
             uint32_t width,
             uint32_t in_channels,
             uint32_t out_channels) -> std::tuple<ttnn::Shape, ttnn::MemoryConfig, bool> {
-            return ttnn::operations::conv::conv2d::get_conv_padded_input_shape_and_mem_config<DeviceMesh>(
+            return ttnn::operations::conv::conv2d::get_conv_padded_input_shape_and_mem_config<MeshDevice>(
                 device, input_tensor, conv_config, batch_size, height, width, in_channels, out_channels);
         },
         py::kw_only(),

--- a/ttnn/cpp/ttnn/operations/core/core.hpp
+++ b/ttnn/cpp/ttnn/operations/core/core.hpp
@@ -51,7 +51,7 @@ ttnn::Tensor squeeze_from_4D(const ttnn::Tensor& tensor, const int rank);
 ttnn::Tensor to_device(const ttnn::Tensor& tensor, Device* device, const std::optional<MemoryConfig>& memory_config);
 
 ttnn::Tensor to_device(
-    const ttnn::Tensor& tensor, DeviceMesh* device_mesh, const std::optional<MemoryConfig>& memory_config);
+    const ttnn::Tensor& tensor, MeshDevice* mesh_device, const std::optional<MemoryConfig>& memory_config);
 
 ttnn::Tensor allocate_tensor_on_device(
     const Shape& shape,
@@ -64,7 +64,7 @@ ttnn::Tensor allocate_tensor_on_device(
     const Shape& shape,
     DataType data_type,
     Layout layout,
-    DeviceMesh* device_mesh,
+    MeshDevice* mesh_device,
     const std::optional<MemoryConfig>& memory_config);
 
 void copy_host_to_device_tensor(ttnn::Tensor host_tensor, ttnn::Tensor device_tensor, uint8_t cq_id = ttnn::DefaultQueueId);
@@ -85,13 +85,13 @@ void execute_trace(Device* device, const uint32_t tid, const uint8_t cq_id, bool
 void release_trace(Device* device, const uint32_t tid);
 
 // Trace APIs - Multi Device
-uint32_t begin_trace_capture(DeviceMesh* device, const uint8_t cq_id = ttnn::DefaultQueueId);
+uint32_t begin_trace_capture(MeshDevice* device, const uint8_t cq_id = ttnn::DefaultQueueId);
 
-void end_trace_capture(DeviceMesh* device, const uint32_t tid, const uint8_t cq_id = ttnn::DefaultQueueId);
+void end_trace_capture(MeshDevice* device, const uint32_t tid, const uint8_t cq_id = ttnn::DefaultQueueId);
 
-void execute_trace(DeviceMesh* device, const uint32_t tid, const uint8_t cq_id = ttnn::DefaultQueueId, bool blocking = true);
+void execute_trace(MeshDevice* device, const uint32_t tid, const uint8_t cq_id = ttnn::DefaultQueueId, bool blocking = true);
 
-void release_trace(DeviceMesh* device, const uint32_t tid);
+void release_trace(MeshDevice* device, const uint32_t tid);
 
 }  // namespace core
 }  // namespace operations

--- a/ttnn/cpp/ttnn/operations/core/to_layout/to_layout_op.cpp
+++ b/ttnn/cpp/ttnn/operations/core/to_layout/to_layout_op.cpp
@@ -210,7 +210,7 @@ Tensor to_layout_impl(
     const ttnn::Layout layout,
     const std::optional<ttnn::DataType>& dtype,
     const std::optional<ttnn::MemoryConfig>& memory_config,
-    DeviceMesh* device) {
+    MeshDevice* device) {
     return detail::to_layout_impl(tensor_arg, layout, dtype, memory_config, device);
 }
 

--- a/ttnn/cpp/ttnn/operations/core/to_layout/to_layout_op.hpp
+++ b/ttnn/cpp/ttnn/operations/core/to_layout/to_layout_op.hpp
@@ -37,7 +37,7 @@ struct ToLayout {
         const ttnn::Layout layout,
         const std::optional<ttnn::DataType>& dtype = std::nullopt,
         const std::optional<ttnn::MemoryConfig>& memory_config = std::nullopt,
-        DeviceMesh* device = nullptr);
+        MeshDevice* device = nullptr);
 };
 
 }  // namespace core

--- a/ttnn/cpp/ttnn/operations/pool/maxpool/max_pool2d.cpp
+++ b/ttnn/cpp/ttnn/operations/pool/maxpool/max_pool2d.cpp
@@ -108,7 +108,7 @@ Tensor MaxPoolNewOp::invoke(uint8_t queue_id, const Tensor& input_tensor, uint32
 
 // device template specializations
 template Tensor MaxPoolNewOp::invoke<Device>(uint8_t queue_id, const Tensor& input_tensor, uint32_t batch_size, uint32_t input_h, uint32_t input_w, uint32_t channels, std::array<uint32_t, 2> kernel_size, std::array<uint32_t, 2> stride, std::array<uint32_t, 2> padding, std::array<uint32_t, 2> dilation, Device* device);
-template Tensor MaxPoolNewOp::invoke<DeviceMesh>(uint8_t queue_id, const Tensor& input_tensor, uint32_t batch_size, uint32_t input_h, uint32_t input_w, uint32_t channels, std::array<uint32_t, 2> kernel_size, std::array<uint32_t, 2> stride, std::array<uint32_t, 2> padding, std::array<uint32_t, 2> dilation, DeviceMesh* device);
+template Tensor MaxPoolNewOp::invoke<MeshDevice>(uint8_t queue_id, const Tensor& input_tensor, uint32_t batch_size, uint32_t input_h, uint32_t input_w, uint32_t channels, std::array<uint32_t, 2> kernel_size, std::array<uint32_t, 2> stride, std::array<uint32_t, 2> padding, std::array<uint32_t, 2> dilation, MeshDevice* device);
 
 }  // namespace operations::pool
 }  // namespace ttnn

--- a/ttnn/cpp/ttnn/operations/pool/maxpool/max_pool2d_pybind.cpp
+++ b/ttnn/cpp/ttnn/operations/pool/maxpool/max_pool2d_pybind.cpp
@@ -83,7 +83,7 @@ void bind_max_pool2d_operation(py::module& module) {
                 std::array<uint32_t, 2> stride,
                 std::array<uint32_t, 2> padding,
                 std::array<uint32_t, 2> dilation,
-                DeviceMesh* device,
+                MeshDevice* device,
                 const uint8_t& queue_id)
                 -> ttnn::Tensor { return self(queue_id,
                                             input_tensor,

--- a/ttnn/cpp/ttnn/tensor/serialization.cpp
+++ b/ttnn/cpp/ttnn/tensor/serialization.cpp
@@ -92,7 +92,7 @@ OwnedStorage load_owned_storage(std::ifstream& input_stream) {
 }
 
 template<typename T>
-MultiDeviceHostStorage load_multi_device_host_storage(std::ifstream& input_stream, DeviceMesh* device_mesh) {
+MultiDeviceHostStorage load_multi_device_host_storage(std::ifstream& input_stream, MeshDevice* mesh_device) {
     std::size_t num_buffers = 0;
     DistributedTensorConfig strategy;
     input_stream.read(reinterpret_cast<char*>(&num_buffers), sizeof(std::size_t));
@@ -110,7 +110,7 @@ MultiDeviceHostStorage load_multi_device_host_storage(std::ifstream& input_strea
         buffers.push_back(buffer);
         shapes.push_back(shape);
 
-        for (std::size_t i = 1; i < device_mesh->num_devices(); ++i) {
+        for (std::size_t i = 1; i < mesh_device->num_devices(); ++i) {
             buffers.push_back(owned_buffer::Buffer<T>{buffer.get_ptr()});
             shapes.push_back(shape);
         }
@@ -161,19 +161,19 @@ OwnedStorage load_owned_storage(std::ifstream& input_stream, DataType data_type)
 }
 
 
-MultiDeviceHostStorage load_multi_device_host_storage(std::ifstream& input_stream, DataType data_type, DeviceMesh *device_mesh) {
+MultiDeviceHostStorage load_multi_device_host_storage(std::ifstream& input_stream, DataType data_type, MeshDevice *mesh_device) {
     if (data_type == DataType::UINT32 or data_type == DataType::BFLOAT8_B or data_type == DataType::BFLOAT4_B) {
         using T = std::uint32_t;
-        return load_multi_device_host_storage<T>(input_stream, device_mesh);
+        return load_multi_device_host_storage<T>(input_stream, mesh_device);
     } else if (data_type == DataType::UINT16) {
         using T = std::uint16_t;
-        return load_multi_device_host_storage<T>(input_stream, device_mesh);
+        return load_multi_device_host_storage<T>(input_stream, mesh_device);
     } else if (data_type == DataType::FLOAT32) {
         using T = float;
-        return load_multi_device_host_storage<T>(input_stream, device_mesh);
+        return load_multi_device_host_storage<T>(input_stream, mesh_device);
     } else if (data_type == DataType::BFLOAT16) {
         using T = bfloat16;
-        return load_multi_device_host_storage<T>(input_stream, device_mesh);
+        return load_multi_device_host_storage<T>(input_stream, mesh_device);
     } else {
         TT_THROW("Unsupported DataType");
     }
@@ -182,10 +182,10 @@ MultiDeviceHostStorage load_multi_device_host_storage(std::ifstream& input_strea
 template <typename T>
 Storage load_storage(std::ifstream& input_stream, DataType data_type, StorageType storage_type, T device) {
     if (storage_type == StorageType::MULTI_DEVICE_HOST or storage_type == StorageType::MULTI_DEVICE) {
-        if constexpr (std::is_same_v<T, DeviceMesh*>) {
+        if constexpr (std::is_same_v<T, MeshDevice*>) {
             return load_multi_device_host_storage(input_stream, data_type, device);
         } else {
-            TT_THROW("DeviceMesh is required for MULTI_DEVICE_HOST storage");
+            TT_THROW("MeshDevice is required for MULTI_DEVICE_HOST storage");
         }
     } else {
         return load_owned_storage(input_stream, data_type);
@@ -321,7 +321,7 @@ Tensor load_tensor(const std::string& file_name, T device) {
 
 // Explicit instantiations
 template Tensor load_tensor<Device*>(const std::string&, Device*);
-template Tensor load_tensor<DeviceMesh*>(const std::string&, DeviceMesh*);
+template Tensor load_tensor<MeshDevice*>(const std::string&, MeshDevice*);
 
 }  // namespace tt_metal
 

--- a/ttnn/cpp/ttnn/tensor/tensor.cpp
+++ b/ttnn/cpp/ttnn/tensor/tensor.cpp
@@ -374,8 +374,8 @@ Tensor Tensor::to(Device* target_device, const MemoryConfig& mem_config) const {
     return tensor_ops::tensor_to(*this, target_device, mem_config);
 }
 
-Tensor Tensor::to(DeviceMesh* device_mesh, const MemoryConfig& mem_config) const {
-    std::vector<Device*> workers_to_use = distribute_tensor_to_mesh(*this, *device_mesh);
+Tensor Tensor::to(MeshDevice* mesh_device, const MemoryConfig& mem_config) const {
+    std::vector<Device*> workers_to_use = distribute_tensor_to_mesh(*this, *mesh_device);
     return tensor_ops::tensor_to(*this, workers_to_use, mem_config);
 }
 
@@ -406,8 +406,8 @@ Tensor Tensor::to(Layout target_layout, Device* worker) const {
     return tensor_ops::tensor_to(*this, target_layout, worker);
 }
 
-Tensor Tensor::to(Layout target_layout, DeviceMesh* device_mesh) const {
-    return tensor_ops::tensor_to(*this, target_layout, device_mesh);
+Tensor Tensor::to(Layout target_layout, MeshDevice* mesh_device) const {
+    return tensor_ops::tensor_to(*this, target_layout, mesh_device);
 }
 
 const std::string Tensor::write_to_string() const { return tensor_impl::to_string_wrapper(*this); }
@@ -712,10 +712,10 @@ Tensor allocate_tensor_on_device(
     const ttnn::Shape& shape,
     DataType data_type,
     Layout layout,
-    DeviceMesh* device_mesh,
+    MeshDevice* mesh_device,
     const MemoryConfig& memory_config) {
     // Top level wrapper to asynchronously create a device tensor (multi-device)
-    Tensor device_tensor = Tensor(device_mesh->get_devices());
+    Tensor device_tensor = Tensor(mesh_device->get_devices());
     uint32_t device_tensor_ref_count = device_tensor.tensor_attributes->record_main_thread_ref_count();
     const auto& workers = device_tensor.get_workers();
     uint32_t num_workers = workers.size();
@@ -795,7 +795,7 @@ void write_tensor(Tensor host_tensor, Tensor device_tensor, uint8_t cq_id) {
 }
 
 
-std::vector<Device*> distribute_tensor_to_mesh(const Tensor& tensor, DeviceMesh& device_mesh) {
+std::vector<Device*> distribute_tensor_to_mesh(const Tensor& tensor, MeshDevice& mesh_device) {
     auto get_multi_device_workers = [&](const std::vector<Device*>& workers) {
         if (std::holds_alternative<MultiDeviceStorage>(tensor.get_storage()) or
             std::holds_alternative<MultiDeviceHostStorage>(tensor.get_storage())) {
@@ -804,22 +804,22 @@ std::vector<Device*> distribute_tensor_to_mesh(const Tensor& tensor, DeviceMesh&
         return workers;
     };
 
-    if (device_mesh.get_view() != nullptr and std::holds_alternative<MultiDeviceHostStorage>(tensor.get_storage())) {
+    if (mesh_device.get_view() != nullptr and std::holds_alternative<MultiDeviceHostStorage>(tensor.get_storage())) {
         const auto& host_storage = std::get<tt::tt_metal::MultiDeviceHostStorage>(tensor.get_storage());
 
         return std::visit([&](const auto& strategy) {
             using StrategyType = std::decay_t<decltype(strategy)>;
             if constexpr (std::is_same_v<StrategyType, ShardTensor2D>) {
-                auto mesh_view = device_mesh.get_view();
+                auto mesh_view = mesh_device.get_view();
                 return mesh_view->get_devices(strategy.shard_mesh);
             } else {
-                return get_multi_device_workers(device_mesh.get_devices());
+                return get_multi_device_workers(mesh_device.get_devices());
             }
         }, host_storage.strategy);
     } else if (std::holds_alternative<MultiDeviceStorage>(tensor.get_storage())) {
         return tensor.workers;
     } else {
-        return get_multi_device_workers(device_mesh.get_devices());
+        return get_multi_device_workers(mesh_device.get_devices());
     }
 }
 

--- a/ttnn/cpp/ttnn/tensor/tensor.hpp
+++ b/ttnn/cpp/ttnn/tensor/tensor.hpp
@@ -19,7 +19,7 @@
 #include "ttnn/tensor/types.hpp"
 #include "tt_metal/impl/buffers/buffer.hpp"
 #include "tt_metal/impl/device/device.hpp"
-#include "tt_metal/impl/device/device_mesh.hpp"
+#include "tt_metal/impl/device/mesh_device.hpp"
 #include "tt_metal/tt_stl/reflection.hpp"
 
 namespace tt {
@@ -245,7 +245,7 @@ struct Tensor {
         const MemoryConfig &mem_config = {.memory_layout = tt::tt_metal::TensorMemoryLayout::INTERLEAVED}) const;
 
     Tensor to(
-        DeviceMesh *device_mesh,
+        MeshDevice *mesh_device,
         const MemoryConfig &mem_config = {.memory_layout = tt::tt_metal::TensorMemoryLayout::INTERLEAVED}) const;
 
     Tensor to(
@@ -258,7 +258,7 @@ struct Tensor {
 
     Tensor to(Layout target_layout, Device *worker = nullptr) const;
 
-    Tensor to(Layout target_layout, DeviceMesh *device_mesh) const;
+    Tensor to(Layout target_layout, MeshDevice *mesh_device) const;
 
     Tensor pad(const Shape &output_tensor_shape, const Shape &input_tensor_start, float pad_value) const;
 
@@ -437,12 +437,12 @@ Tensor allocate_tensor_on_device(
     const ttnn::Shape &shape,
     DataType data_type,
     Layout layout,
-    DeviceMesh *device_mesh,
+    MeshDevice *mesh_device,
     const MemoryConfig &memory_config = {.memory_layout = tt::tt_metal::TensorMemoryLayout::INTERLEAVED});
 void write_tensor(Tensor host_tensor, Tensor device_tensor, uint8_t cq_id = ttnn::DefaultQueueId);
 
 // Maps a tensor to the set of devices in the device-mesh that the shards will be distributed across.
-std::vector<Device*> distribute_tensor_to_mesh(const Tensor& tensor, DeviceMesh& device_mesh);
+std::vector<Device*> distribute_tensor_to_mesh(const Tensor& tensor, MeshDevice& mesh_device);
 
 Tensor set_tensor_id(const Tensor &tensor);
 

--- a/ttnn/cpp/ttnn/tensor/tensor_ops.cpp
+++ b/ttnn/cpp/ttnn/tensor/tensor_ops.cpp
@@ -193,11 +193,11 @@ Tensor tensor_to(const Tensor& input_tensor, Layout target_layout, Device* worke
     return output;
 }
 
-Tensor tensor_to(const Tensor& input_tensor, Layout target_layout, DeviceMesh* device_mesh) {
+Tensor tensor_to(const Tensor& input_tensor, Layout target_layout, MeshDevice* mesh_device) {
     ZoneScoped;
-    GraphTracker::instance().track_function_start("Tensor::to", input_tensor, target_layout, device_mesh);
-    if (device_mesh) {
-        auto workers = distribute_tensor_to_mesh(input_tensor, *device_mesh);
+    GraphTracker::instance().track_function_start("Tensor::to", input_tensor, target_layout, mesh_device);
+    if (mesh_device) {
+        auto workers = distribute_tensor_to_mesh(input_tensor, *mesh_device);
         TT_FATAL(
             validate_worker_modes(workers),
             "All device threads/workers must be running in the same mode (ASYNC or SYNC)");

--- a/ttnn/cpp/ttnn/tensor/tensor_ops.hpp
+++ b/ttnn/cpp/ttnn/tensor/tensor_ops.hpp
@@ -10,7 +10,7 @@ struct Tensor;
 class CommandQueue;
 struct MemoryConfig;
 class Device;
-class DeviceMesh;
+class MeshDevice;
 }
 
 namespace tt::tt_metal::tensor_ops {
@@ -21,7 +21,7 @@ Tensor tensor_to(const Tensor& input_tensor, const std::vector<Device*>& workers
 
 Tensor tensor_to(const Tensor& input_tensor, Layout target_layout, Device* worker);
 
-Tensor tensor_to(const Tensor& input_tensor, Layout target_layout, DeviceMesh* device_mesh);
+Tensor tensor_to(const Tensor& input_tensor, Layout target_layout, MeshDevice* mesh_device);
 
 Tensor tensor_cpu(const Tensor& input_tensor, bool blocking, uint8_t cq_id);
 

--- a/ttnn/cpp/ttnn/types.hpp
+++ b/ttnn/cpp/ttnn/types.hpp
@@ -14,10 +14,10 @@ namespace ttnn {
 namespace types {
 
 using Device = tt::tt_metal::Device;
-using DeviceGrid = tt::tt_metal::DeviceGrid;
+using MeshShape = tt::tt_metal::MeshShape;
 using DeviceIds = tt::tt_metal::DeviceIds;
-using DeviceMesh = tt::tt_metal::DeviceMesh;
-using DeviceMeshView = tt::tt_metal::DeviceMeshView;
+using MeshDevice = tt::tt_metal::MeshDevice;
+using MeshDeviceView = tt::tt_metal::MeshDeviceView;
 
 constexpr auto TILE_SIZE = 32;
 

--- a/ttnn/ttnn/__init__.py
+++ b/ttnn/ttnn/__init__.py
@@ -135,7 +135,7 @@ from ttnn.types import (
     DeviceComputeKernelConfig,
     WormholeComputeKernelConfig,
     GrayskullComputeKernelConfig,
-    DeviceGrid,
+    MeshShape,
     UnaryWithParam,
     UnaryOpType,
     BinaryOpType,
@@ -169,15 +169,15 @@ from ttnn.device import (
 )
 
 from ttnn.multi_device import (
-    DeviceMesh,
+    MeshDevice,
     DispatchCoreType,
-    open_device_mesh,
-    close_device_mesh,
+    open_mesh_device,
+    close_mesh_device,
     get_num_pcie_devices,
     get_num_devices,
     get_pcie_device_ids,
     get_device_ids,
-    create_device_mesh,
+    create_mesh_device,
     synchronize_devices,
     TensorToMesh,
     ShardTensorToMesh,
@@ -186,7 +186,7 @@ from ttnn.multi_device import (
     MeshToTensor,
     ConcatMeshToTensor,
     ListMeshToTensor,
-    visualize_device_mesh,
+    visualize_mesh_device,
     ConcatMesh2dToTensor,
 )
 

--- a/ttnn/ttnn/multi_device.py
+++ b/ttnn/ttnn/multi_device.py
@@ -9,18 +9,18 @@ from typing import List, Dict, Optional, Callable, Tuple, Optional, Callable, Un
 import ttnn
 
 
-def get_device_mesh_core_grid(device_mesh):
-    compute_with_storage_grid_size = device_mesh.compute_with_storage_grid_size()
+def get_mesh_device_core_grid(mesh_device):
+    compute_with_storage_grid_size = mesh_device.compute_with_storage_grid_size()
     return ttnn.CoreGrid(y=compute_with_storage_grid_size.y, x=compute_with_storage_grid_size.x)
 
 
-DeviceMesh = ttnn._ttnn.multi_device.DeviceMesh
-DeviceMesh.core_grid = property(get_device_mesh_core_grid)
+MeshDevice = ttnn._ttnn.multi_device.MeshDevice
+MeshDevice.core_grid = property(get_mesh_device_core_grid)
 DispatchCoreType = ttnn._ttnn.device.DispatchCoreType
 
 
 def _get_rich_table(
-    device_mesh: "ttnn.DeviceMesh", style_cell: Optional[Callable] = None, annotate_cell: Optional[Callable] = None
+    mesh_device: "ttnn.MeshDevice", style_cell: Optional[Callable] = None, annotate_cell: Optional[Callable] = None
 ):
     from rich import box, padding
     from rich.align import Align
@@ -32,13 +32,13 @@ def _get_rich_table(
 
     # Setup rich table
     try:
-        rows, cols = device_mesh.shape
+        rows, cols = mesh_device.shape
     except AttributeError as e:
         logger.error("Error getting device mesh shape: {}.", e)
         rows, cols = 0, 0
 
     mesh_table = Table(
-        title=f"DeviceMesh(rows={rows}, cols={cols}):",
+        title=f"MeshDevice(rows={rows}, cols={cols}):",
         show_header=False,
         show_footer=False,
         box=box.SQUARE,
@@ -55,9 +55,9 @@ def _get_rich_table(
         row_cells = []
         for col_idx in range(cols):
             try:
-                device = device_mesh.get_device(row_idx, col_idx)
+                device = mesh_device.get_device(row_idx, col_idx)
             except Exception as e:
-                logger.error("Error fetching device from DeviceMesh at row {}, col {}: {}.", row_idx, col_idx, e)
+                logger.error("Error fetching device from MeshDevice at row {}, col {}: {}.", row_idx, col_idx, e)
                 device = None
 
             try:
@@ -80,7 +80,7 @@ def _get_rich_table(
     return mesh_table
 
 
-def visualize_device_mesh(device_mesh: "ttnn.DeviceMesh", tensor: "ttnn.Tensor" = None):
+def visualize_mesh_device(mesh_device: "ttnn.MeshDevice", tensor: "ttnn.Tensor" = None):
     """
     Visualize the device mesh and the given tensor (if specified).
     """
@@ -109,7 +109,7 @@ def visualize_device_mesh(device_mesh: "ttnn.DeviceMesh", tensor: "ttnn.Tensor" 
         style_cell = color_mapped_devices
         annotate_cell = annotate_with_tensor_shape
 
-    mesh_table = _get_rich_table(device_mesh, style_cell=style_cell, annotate_cell=annotate_cell)
+    mesh_table = _get_rich_table(mesh_device, style_cell=style_cell, annotate_cell=annotate_cell)
     Console().print(mesh_table)
 
 
@@ -131,8 +131,8 @@ def get_device_ids() -> List[int]:
     return list(range(num_devices))
 
 
-def open_device_mesh(
-    device_grid: ttnn.DeviceGrid,
+def open_mesh_device(
+    mesh_shape: ttnn.MeshShape,
     device_ids: List[int],
     l1_small_size: int = ttnn._ttnn.device.DEFAULT_L1_SMALL_SIZE,
     trace_region_size: int = ttnn._ttnn.device.DEFAULT_TRACE_REGION_SIZE,
@@ -140,14 +140,14 @@ def open_device_mesh(
     dispatch_core_type: int = DispatchCoreType.WORKER,
 ):
     """
-    open_device_mesh(device_grid: ttnn.DeviceGrid, device_ids: int) -> ttnn.DeviceMesh:
+    open_mesh_device(mesh_shape: ttnn.MeshShape, device_ids: int) -> ttnn.MeshDevice:
 
     Open a device with the given device_id. If the device is already open, return the existing device.
     """
     assert len(device_ids) > 0
 
-    return ttnn._ttnn.multi_device.DeviceMesh(
-        device_grid=device_grid.as_tuple(),
+    return ttnn._ttnn.multi_device.MeshDevice(
+        mesh_shape=mesh_shape.as_tuple(),
         device_ids=device_ids,
         l1_small_size=l1_small_size,
         trace_region_size=trace_region_size,
@@ -156,18 +156,18 @@ def open_device_mesh(
     )
 
 
-def close_device_mesh(device_mesh):
+def close_mesh_device(mesh_device):
     """
-    close_device_mesh(multi_device: ttnn.Multi) -> None:
+    close_mesh_device(multi_device: ttnn.Multi) -> None:
 
     Close the device and remove it from the device cache.
     """
-    return ttnn._ttnn.multi_device.close_device_mesh(device_mesh)
+    return ttnn._ttnn.multi_device.close_mesh_device(mesh_device)
 
 
 @contextlib.contextmanager
-def create_device_mesh(
-    device_grid: ttnn.DeviceGrid,
+def create_mesh_device(
+    mesh_shape: ttnn.MeshShape,
     device_ids: List[int],
     l1_small_size: int = ttnn._ttnn.device.DEFAULT_L1_SMALL_SIZE,
     trace_region_size: int = ttnn._ttnn.device.DEFAULT_TRACE_REGION_SIZE,
@@ -175,12 +175,12 @@ def create_device_mesh(
     dispatch_core_type: int = DispatchCoreType.WORKER,
 ):
     """
-    create_device_mesh(device_grid: ttnn.DeviceGrid, device_ids: List[int]) -> ttnn.DeviceMesh
+    create_mesh_device(mesh_shape: ttnn.MeshShape, device_ids: List[int]) -> ttnn.MeshDevice
 
     Context manager for opening and closing a device.
     """
-    device_mesh = open_device_mesh(
-        device_grid=device_grid,
+    mesh_device = open_mesh_device(
+        mesh_shape=mesh_shape,
         device_ids=device_ids,
         l1_small_size=l1_small_size,
         trace_region_size=trace_region_size,
@@ -188,14 +188,14 @@ def create_device_mesh(
         dispatch_core_type=dispatch_core_type,
     )
     try:
-        yield device_mesh
+        yield mesh_device
     finally:
-        close_device_mesh(device_mesh)
+        close_mesh_device(mesh_device)
 
 
-def synchronize_devices(devices: Union["ttnn.Device", "ttnn.DeviceMesh"], queue_id: Optional[int] = None) -> None:
+def synchronize_devices(devices: Union["ttnn.Device", "ttnn.MeshDevice"], queue_id: Optional[int] = None) -> None:
     """
-    synchronize_devices(devices: Union[ttnn.Device, ttnn.DeviceMesh], queue_id: Optional[int] = None) -> None:
+    synchronize_devices(devices: Union[ttnn.Device, ttnn.MeshDevice], queue_id: Optional[int] = None) -> None:
 
     Synchronize the devices with host by waiting for all operations to complete.
     If queue_id is provided then only the operations associated with that queue_id are waited for,
@@ -214,8 +214,8 @@ class TensorToMesh:
     You can also "Bring your own TensorToMesh" based on your custom mapping.
     """
 
-    def __init__(self, device_mesh):
-        self.device_mesh = device_mesh
+    def __init__(self, mesh_device):
+        self.mesh_device = mesh_device
 
     def map(self, tensor: "torch.Tensor"):
         raise NotImplementedError("Subclasses must implement this method")
@@ -238,14 +238,14 @@ class MeshToTensor:
 
 
 class ShardTensorToMesh(TensorToMesh):
-    def __init__(self, device_mesh, dim):
-        super().__init__(device_mesh)
+    def __init__(self, mesh_device, dim):
+        super().__init__(mesh_device)
         self.shard_dim = dim
 
     def map(self, tensor: "torch.Tensor") -> Dict[int, ttnn.Tensor]:
         import torch
 
-        sliced_tensors = torch.chunk(tensor, self.device_mesh.get_num_devices(), dim=self.shard_dim)
+        sliced_tensors = torch.chunk(tensor, self.mesh_device.get_num_devices(), dim=self.shard_dim)
         return list(sliced_tensors)
 
     def config(self):
@@ -263,12 +263,12 @@ class ShardTensor2dMesh(TensorToMesh):
     allowing for efficient parallel processing in distributed computing environments.
     """
 
-    def __init__(self, device_mesh: DeviceMesh, mesh_shape: Tuple[int, int], dims: Tuple[Optional[int], Optional[int]]):
+    def __init__(self, mesh_device: MeshDevice, mesh_shape: Tuple[int, int], dims: Tuple[Optional[int], Optional[int]]):
         """
         Initialize the ShardTensor2dMesh.
 
         Args:
-            device_mesh: The target device mesh for distributing the tensor.
+            mesh_device: The target device mesh for distributing the tensor.
             mesh_shape: The shape of the 2D mesh as (rows, cols).
             dims: The dimensions to shard along, specified as (row_dim, col_dim).
 
@@ -288,12 +288,12 @@ class ShardTensor2dMesh(TensorToMesh):
         3. dims=(None, None):
            - Fully replicate the tensor across all devices
         """
-        super().__init__(device_mesh)
+        super().__init__(mesh_device)
         self.mesh_shape: Tuple[int, int] = mesh_shape
         self.dims: Tuple[Optional[int], Optional[int]] = dims
 
-        device_mesh_rows, device_mesh_cols = self.device_mesh.shape
-        if mesh_shape[0] > device_mesh_rows or mesh_shape[1] > device_mesh_cols:
+        mesh_device_rows, mesh_device_cols = self.mesh_device.shape
+        if mesh_shape[0] > mesh_device_rows or mesh_shape[1] > mesh_device_cols:
             raise ValueError("ShardTensor2dMesh: Device mesh shape does not match the provided mesh shape.")
 
     def map(self, tensor: "torch.Tensor") -> List["torch.Tensor"]:
@@ -356,12 +356,12 @@ class ConcatMesh2dToTensor(MeshToTensor):
     sharded tensors from a 2D device mesh back into a single tensor.
     """
 
-    def __init__(self, device_mesh: DeviceMesh, mesh_shape: Tuple[int, int], dims: Tuple[int, int]):
+    def __init__(self, mesh_device: MeshDevice, mesh_shape: Tuple[int, int], dims: Tuple[int, int]):
         """
         Initialize the ConcatMesh2dToTensor.
 
         Args:
-            device_mesh: The source device mesh containing the sharded tensors.
+            mesh_device: The source device mesh containing the sharded tensors.
             mesh_shape: The shape of the 2D mesh as (rows, cols).
             dims: A tuple of two integers specifying the dimensions along which to concatenate the tensors.
                   The first element (row_dim) indicates the dimension for concatenating tensors from different rows.
@@ -374,7 +374,7 @@ class ConcatMesh2dToTensor(MeshToTensor):
         Raises:
             ValueError: If either dimension in 'dims' is None or if both dimensions are the same.
         """
-        self.device_mesh = device_mesh
+        self.mesh_device = mesh_device
         self.mesh_shape = mesh_shape
         self.dims = dims
         if self.dims[0] == self.dims[1]:
@@ -401,33 +401,33 @@ class ConcatMesh2dToTensor(MeshToTensor):
         row_dim, col_dim = self.dims
 
         # Reshape the list of shards into a 2D list representing the device mesh
-        device_grid = [device_shards[i : i + cols] for i in range(0, len(device_shards), cols)]
+        mesh_shape = [device_shards[i : i + cols] for i in range(0, len(device_shards), cols)]
 
         # Concatenate along columns first (within each row)
-        row_concatenated = [torch.cat(row, dim=col_dim) for row in device_grid]
+        row_concatenated = [torch.cat(row, dim=col_dim) for row in mesh_shape]
 
         # Then concatenate the resulting tensors along rows
         return torch.cat(row_concatenated, dim=row_dim)
 
 
 class ReplicateTensorToMesh(TensorToMesh):
-    def __init__(self, device_mesh: DeviceMesh):
-        super().__init__(device_mesh)
+    def __init__(self, mesh_device: MeshDevice):
+        super().__init__(mesh_device)
 
     def map(self, tensor: "torch.Tensor"):
-        return [tensor for i in range(self.device_mesh.get_num_devices())]
+        return [tensor for i in range(self.mesh_device.get_num_devices())]
 
     def config(self):
         return {
             "strategy": "replicate",
-            "replication_factor": str(self.device_mesh.get_num_devices()),
+            "replication_factor": str(self.mesh_device.get_num_devices()),
         }
 
 
 class ConcatMeshToTensor(MeshToTensor):
-    def __init__(self, device_mesh: DeviceMesh, dim: int):
+    def __init__(self, mesh_device: MeshDevice, dim: int):
         self.concat_dim = dim
-        self.device_mesh = device_mesh
+        self.mesh_device = mesh_device
 
     def compose(self, tensor: ttnn.Tensor) -> "torch.Tensor":
         import torch
@@ -439,8 +439,8 @@ class ConcatMeshToTensor(MeshToTensor):
 
 
 class ListMeshToTensor(MeshToTensor):
-    def __init__(self, device_mesh: DeviceMesh):
-        self.device_mesh = device_mesh
+    def __init__(self, mesh_device: MeshDevice):
+        self.mesh_device = mesh_device
 
     def compose(self, tensor: ttnn.Tensor) -> List["torch.Tensor"]:
         return [ttnn.to_torch(tt_input_tensor) for tt_input_tensor in ttnn.get_device_tensors(tensor)]

--- a/ttnn/ttnn/types.py
+++ b/ttnn/ttnn/types.py
@@ -57,7 +57,7 @@ class CoreRange:
 
 
 @dataclasses.dataclass
-class DeviceGrid:
+class MeshShape:
     y: int
     x: int
 


### PR DESCRIPTION
### Ticket
[Link to Github Issue
](https://github.com/tenstorrent/tt-metal/issues/12117)

### Problem description
Purpose is to align on named types as we push MeshDevice down into tt-metal and start creating MeshTensor, MeshProgram, MeshOp concepts. We also need this done to standardize on documentation which will soon be updated as well.

### What's changed
Refactoring:
- `DeviceMesh->MeshDevice`
- `DeviceGrid->MeshShape`
- `device_mesh->mesh_device`

### Checklist
- [ ] Post commit CI passes
- [ ] Blackhole Post commit (if applicable)
- [ ] Model regression CI testing passes (if applicable)
- [ ] New/Existing tests provide coverage for changes
