### PR TITLE
Add Block Division for Untilizing in Multicore 

### DIFF
--- a/tests/ttnn/unit_tests/test_to_layout.py
+++ b/tests/ttnn/unit_tests/test_to_layout.py
@@ -58,3 +58,38 @@ def test_to_layout_2D(device, height, width, on_device, from_layout, to_layout, 
 
     assert_with_pcc(torch_input_tensor, output_tensor)
     assert torch.allclose(torch_input_tensor, output_tensor)
+
+
+@pytest.mark.parametrize(
+    "shape",
+    [
+        (1, 1, 32, 128 * 1024),
+    ],
+)
+@pytest.mark.parametrize("on_device", [True])
+@pytest.mark.parametrize("from_layout", [ttnn.TILE_LAYOUT])
+@pytest.mark.parametrize("to_layout", [ttnn.ROW_MAJOR_LAYOUT])
+def test_to_layout_llama(device, shape, on_device, from_layout, to_layout):
+    torch.manual_seed(0)
+    torch_input_tensor = torch.rand(shape, dtype=torch.bfloat16)
+    input_tensor = ttnn.from_torch(torch_input_tensor)
+    assert input_tensor.layout == ttnn.ROW_MAJOR_LAYOUT
+    input_tensor = ttnn.to_layout(input_tensor, from_layout)
+    assert input_tensor.layout == from_layout
+
+    if on_device:
+        input_tensor = ttnn.to_device(input_tensor, device)
+        assert ttnn.is_tensor_storage_on_device(input_tensor)
+
+    output_tensor = ttnn.to_layout(input_tensor, to_layout)
+    assert output_tensor.layout == to_layout
+
+    if on_device:
+        assert ttnn.is_tensor_storage_on_device(output_tensor)
+        output_tensor = ttnn.from_device(output_tensor)
+        assert not ttnn.is_tensor_storage_on_device(output_tensor)
+
+    output_tensor = ttnn.to_torch(output_tensor)
+
+    assert_with_pcc(torch_input_tensor, output_tensor)
+    assert torch.allclose(torch_input_tensor, output_tensor)

--- a/ttnn/cpp/ttnn/operations/data_movement/untilize/device/kernels/dataflow/writer_unary_stick_layout_split_rows_interleaved_parallel_columns.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/untilize/device/kernels/dataflow/writer_unary_stick_layout_split_rows_interleaved_parallel_columns.cpp
@@ -1,0 +1,70 @@
+// SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <stdint.h>
+#include "dataflow_api.h"
+
+void kernel_main() {
+
+    // Constexpr
+    constexpr uint32_t cb_id_out0                       = 16;
+    constexpr uint32_t tile_height = 32;
+
+    const uint32_t dst_addr                   = get_arg_val<uint32_t>(0);
+    const uint32_t num_sticks                 = get_arg_val<uint32_t>(1);
+    const uint32_t stick_size                 = get_arg_val<uint32_t>(2);
+    const uint32_t num_tiles_per_core        = get_arg_val<uint32_t>(3);
+    const uint32_t tile_width_size           = get_arg_val<uint32_t>(4);
+    const uint32_t start_stick_id = get_arg_val<uint32_t>(5);
+    uint32_t offset_within_stick    = get_arg_val<uint32_t>(6);
+
+    constexpr bool dst_is_dram          = get_compile_time_arg_val(0) == 1;
+    #define stick_size_is_power_of_two get_compile_time_arg_val(1) == 1
+
+    #if (stick_size_is_power_of_two)
+    constexpr uint32_t log_base_2_of_page_size = get_compile_time_arg_val(2);
+    const InterleavedPow2AddrGen<dst_is_dram> s = {
+        .bank_base_address = dst_addr,
+        .log_base_2_of_page_size = log_base_2_of_page_size // TODO(AP): refactor
+    };
+    #else
+    const InterleavedAddrGen<dst_is_dram> s = {
+        .bank_base_address = dst_addr,
+        .page_size = stick_size
+    };
+    #endif
+
+    uint64_t base_dst_noc_addr[tile_height];
+
+    auto write_tiles = [&] (const uint32_t& num_tiles, const uint32_t& width_size, const uint32_t& stride_size){
+        cb_wait_front(cb_id_out0, num_tiles);
+        uint32_t l1_read_addr = get_read_ptr(cb_id_out0);
+        for (uint32_t k = 0; k < tile_height; k++) {
+            uint64_t dst_noc_addr = base_dst_noc_addr[k];
+            noc_async_write(l1_read_addr, dst_noc_addr, width_size);
+            l1_read_addr += width_size;
+            base_dst_noc_addr[k] += width_size + stride_size;
+
+
+        }
+        noc_async_write_barrier();
+        cb_pop_front(cb_id_out0, num_tiles);
+    };
+
+    uint32_t stick_id = start_stick_id;
+
+
+    uint32_t curr_offset = offset_within_stick;
+    for (uint32_t i = 0; i < num_sticks / tile_height; i++) {
+        for(uint32_t tile_id = 0; tile_id < num_tiles_per_core; tile_id++) {
+            for (uint32_t j = stick_id; j < (tile_height + stick_id); j++) {
+                base_dst_noc_addr[j] = get_noc_addr(j, s, curr_offset);
+            }
+            write_tiles(1, tile_width_size, stick_size - curr_offset - tile_width_size);
+            curr_offset += tile_width_size;
+        }
+
+        stick_id += tile_height;
+    }
+}

--- a/ttnn/cpp/ttnn/operations/data_movement/untilize/device/untilize_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/untilize/device/untilize_program_factory.cpp
@@ -19,6 +19,261 @@ using namespace tt::constants;
 
 namespace ttnn::operations::data_movement::detail {
 
+
+uint32_t get_largest_divisor(uint32_t dividend, uint32_t starting_divisor, uint32_t divisor_factor = 1) {
+    for (uint32_t curr_div = starting_divisor; curr_div > 0; curr_div--) {
+        if (dividend % (curr_div*divisor_factor) == 0) {
+            return curr_div;
+        }
+    }
+    return 1;
+}
+
+operation::ProgramWithCallbacks untilize_multi_core_parallelize_column(
+    const Tensor& a, Tensor& output, bool use_pack_untilize, bool fp32_dest_acc_en) {
+
+    tt::tt_metal::Program program{};
+
+    tt::DataFormat input_cb_data_format = tt::tt_metal::datatype_to_dataformat_converter(a.get_dtype());
+    uint32_t input_single_tile_size = tt::tt_metal::detail::TileSize(input_cb_data_format);
+    tt::DataFormat output_cb_data_format = tt::tt_metal::datatype_to_dataformat_converter(output.get_dtype());
+    uint32_t output_single_tile_size = tt::tt_metal::detail::TileSize(output_cb_data_format);
+
+    Device* device = a.device();
+
+    auto grid_size = device->compute_with_storage_grid_size();
+    uint32_t ntiles = a.volume() / TILE_HW;
+    uint32_t ncores_x = grid_size.x;
+    //uint32_t ncores_x = 2;
+
+    ncores_x = get_largest_divisor(ntiles, ncores_x);
+    uint32_t ncores_y = grid_size.y;
+    //uint32_t ncores_y = 1;
+    ncores_y = get_largest_divisor(ntiles, ncores_y, ncores_x);
+
+    TT_ASSERT(ntiles % (ncores_x * ncores_y) == 0);
+    uint32_t ntiles_per_block = ntiles/(ncores_x * ncores_y);
+
+    //TODO increase block size to increase untilize performance, currently each untilize block is a single tile
+    //uint32_t max_l1_size = a.device()->l1_size_per_core() / 2 - L1_UNRESERVED_BASE;
+    //uint32_t max_tiles = (max_l1_size / (input_single_tile_size + output_single_tile_size))/2;  // 2 CBs, double buffering each
+    uint32_t max_tiles = 1;
+
+
+
+    uint32_t stick_s = a.get_legacy_shape()[-1];
+    uint32_t ntiles_per_row = stick_s / TILE_WIDTH;
+    uint32_t stick_size = stick_s * output.element_size();
+    uint32_t ntiles_per_column = ntiles / ntiles_per_row;
+    uint32_t starting_tile = ntiles_per_block;
+    if (ntiles_per_row > max_tiles) {
+        starting_tile = max_tiles;
+    }
+    ntiles_per_block = get_largest_divisor(ntiles_per_row, starting_tile);
+    TT_ASSERT(ntiles_per_row % ntiles_per_block == 0 and ntiles_per_block >= 1 and ntiles_per_block <= ntiles_per_row and ntiles % ntiles_per_block == 0);
+
+    uint32_t nblocks = (ntiles / ntiles_per_block);
+    uint32_t block_size_nbytes =  input_single_tile_size;
+
+    auto [ncores, all_cores, core_range, core_range_cliff, nblocks_per_core, nblocks_per_core_cliff] =
+        ttnn::split_blocks_for_tilize(CoreCoord(ncores_x, ncores_y), nblocks);
+
+    bool row_major = true;
+    bool src_block_sharded = false;
+    uint32_t num_rows_block = 0, block_row_size = 0, output_row_size = 0, last_block_row_size_unpadded = 0,
+             num_output_rows_unpadded = 0;
+    CoreCoord end_core;
+    std::vector<CoreCoord> cores_with_rtargs;
+
+    uint32_t num_input_tiles = ntiles_per_block * 2;
+    auto [src0_cb_index, cb_src0] = create_cb(
+        tt::CB::c_in0,
+        program,
+        all_cores,
+        input_single_tile_size,
+        num_input_tiles,
+        input_cb_data_format,
+        nullptr);
+
+    uint32_t num_output_tiles =  ntiles_per_block * 2;
+    auto [output_cb_index, cb_output] = create_cb(
+        tt::CB::c_out0,
+        program,
+        all_cores,
+        output_single_tile_size,
+        num_output_tiles,
+        output_cb_data_format,
+         nullptr);
+
+    Buffer* src0_buffer = a.buffer();
+    Buffer* dst_buffer = output.buffer();
+    bool src0_is_dram = src0_buffer->buffer_type() == BufferType::DRAM ? 1 : 0;
+    std::vector<uint32_t> reader_ct_args = {(uint32_t)src0_is_dram};
+
+    auto unary_reader_kernel_id = CreateKernel(
+        program,
+        "ttnn/cpp/ttnn/operations/eltwise/unary/device/kernels/dataflow/reader_unary_interleaved_start_id.cpp",
+        all_cores,
+        ReaderDataMovementConfig(reader_ct_args));
+
+    bool out_is_dram = dst_buffer->buffer_type() == BufferType::DRAM ? 1 : 0;
+    bool stick_size_is_power_of_two = is_power_of_two_at_least_32(stick_size);
+    uint32_t log2_stick_size = stick_size_is_power_of_two ? (std::uint32_t)std::log2(stick_size) : 0;
+    std::vector<uint32_t> writer_ct_args = {
+        (uint32_t)out_is_dram,
+        (uint32_t)stick_size_is_power_of_two,
+        (uint32_t)log2_stick_size,
+    };
+
+    auto unary_writer_kernel_id = CreateKernel(
+        program,
+        "ttnn/cpp/ttnn/operations/data_movement/untilize/device/kernels/dataflow/"
+        "writer_unary_stick_layout_split_rows_interleaved_parallel_columns.cpp",
+        all_cores,
+        WriterDataMovementConfig(writer_ct_args));
+
+
+    /** compute
+     */
+    vector<uint32_t> compute_args = {
+        (uint32_t)nblocks_per_core,  // per_core_block_cnt
+        (uint32_t)ntiles_per_block,  // per_block_ntiles
+    };
+    vector<uint32_t> compute_args_cliff = {
+        (uint32_t)nblocks_per_core_cliff ,
+        (uint32_t)ntiles_per_block,  // per_block_ntiles
+    };
+
+    std::string compute_kernel("ttnn/cpp/ttnn/operations/data_movement/untilize/device/kernels/compute/pack_untilize.cpp");
+    if (ntiles_per_block > MAX_PACK_UNTILIZE_WIDTH || !use_pack_untilize) {
+        log_debug(tt::LogOp, "Using slow untilize.");
+        compute_kernel = std::string("ttnn/cpp/ttnn/operations/data_movement/untilize/device/kernels/compute/untilize.cpp");
+    } else {
+        log_debug(tt::LogOp, "Using fast pack untilize.");
+    }
+
+    if (core_range.ranges().size() > 0) {
+        auto untilize_kernel_id = CreateKernel(
+            program,
+            compute_kernel,
+            core_range,
+            ComputeConfig{.fp32_dest_acc_en = fp32_dest_acc_en, .compile_args = compute_args});
+    }
+    if (core_range_cliff.ranges().size() > 0) {
+        auto untilize_cliff_kernel_id = CreateKernel(
+            program,
+            compute_kernel,
+            core_range_cliff,
+            ComputeConfig{.fp32_dest_acc_en = fp32_dest_acc_en, .compile_args = compute_args_cliff});
+    }
+
+
+
+    uint32_t ncores_full = ncores;
+    auto full_cores = all_cores;
+    if (nblocks_per_core_cliff > 0 && nblocks_per_core_cliff < nblocks_per_core) {
+        // unequal case with cliff
+        ncores_full -= 1;
+        full_cores = core_range;
+    }
+    uint32_t tile_start_id = 0;
+    uint32_t offset_within_stick = 0;
+    auto cores = grid_to_cores(ncores_x * ncores_y, ncores_x, ncores_y, row_major);
+
+    auto nsticks_per_core = ntiles_per_column * TILE_HEIGHT;
+
+    for (uint32_t i = 0; i < cores.size(); i++) {
+        CoreCoord core = cores[i];
+        if (!full_cores.core_coord_in_core_ranges(core)) {
+            continue;
+        }
+        // reader runtime args
+        vector<uint32_t> reader_rt_args;
+        auto ntiles_per_core = ntiles_per_block * nblocks_per_core;
+        reader_rt_args = {
+            src0_buffer->address(),               // src_addr
+            ntiles_per_core,  // ntiles
+            tile_start_id                         // start_id
+        };
+
+        std::vector<uint32_t> writer_rt_args;
+        writer_rt_args = {
+            dst_buffer->address(),           // dst_addr
+            nsticks_per_core,  // nsticks
+            stick_size,               // block_size_nbytes
+            ntiles_per_core,                // ntiles_per_core
+            TILE_WIDTH * output.element_size(),               // tile_width_size
+            0, //start stick id = 0, since parallelizing on height
+            offset_within_stick
+        };
+
+        tt::tt_metal::SetRuntimeArgs(program, unary_reader_kernel_id, core, reader_rt_args);
+        tt::tt_metal::SetRuntimeArgs(program, unary_writer_kernel_id, core, writer_rt_args);
+        cores_with_rtargs.push_back(core);
+        tile_start_id += ntiles_per_core;
+        offset_within_stick += ntiles_per_core * TILE_WIDTH * output.element_size();
+    }
+    if (ncores_full < ncores) {
+        // last core is the cliff core with nblocks_per_core_cliff blocks
+        CoreCoord core = row_major ? CoreCoord{ncores_full % ncores_x, ncores_full / ncores_x}
+                                   : CoreCoord{ncores_full / ncores_y, ncores_full % ncores_y};
+        // reader runtime args
+        std::vector<uint32_t> reader_rt_args;
+        auto ntiles_per_core_cliff = ntiles_per_block * nblocks_per_core_cliff;
+        reader_rt_args = {
+            src0_buffer->address(),               // src_addr
+            ntiles_per_core_cliff,  // ntiles
+            tile_start_id                         // start_id
+        };
+
+        std::vector<uint32_t> writer_rt_args;
+        writer_rt_args = {
+            dst_buffer->address(),           // dst_addr
+            nsticks_per_core,  // nsticks
+            stick_size,               // block_size_nbytes
+            ntiles_per_core_cliff,                // ntiles_per_core
+            TILE_WIDTH * output.element_size(),               // tile_width_size
+            0, //start stick id = 0, since parallelizing on height
+            offset_within_stick
+        };
+        tt::tt_metal::SetRuntimeArgs(program, unary_reader_kernel_id, core, reader_rt_args);
+        tt::tt_metal::SetRuntimeArgs(program, unary_writer_kernel_id, core, writer_rt_args);
+    }
+
+    auto override_runtime_arguments_callback = [reader_kernel_id = unary_reader_kernel_id,
+                                                writer_kernel_id = unary_writer_kernel_id,
+                                                cb_src0 = cb_src0,
+                                                cb_output = cb_output,
+                                                cores_with_rtargs](
+                                                   const void* operation,
+                                                   Program& program,
+                                                   const std::vector<Tensor>& input_tensors,
+                                                   const std::vector<std::optional<const Tensor>>&,
+                                                   const std::vector<Tensor>& output_tensors) {
+        auto src_buffer = input_tensors.at(0).buffer();
+        auto dst_buffer = output_tensors.at(0).buffer();
+        {
+            auto& runtime_args_by_core = GetRuntimeArgs(program, reader_kernel_id);
+            for (const CoreCoord& core : cores_with_rtargs) {
+                auto& runtime_args = runtime_args_by_core[core.x][core.y];
+                runtime_args[0] = src_buffer->address();
+            }
+        }
+
+        {
+            auto& runtime_args_by_core = GetRuntimeArgs(program, writer_kernel_id);
+            for (const CoreCoord& core : cores_with_rtargs) {
+                auto& runtime_args = runtime_args_by_core[core.x][core.y];
+                runtime_args[0] = dst_buffer->address();
+            }
+        }
+    };
+
+    return {.program = std::move(program), .override_runtime_arguments_callback = override_runtime_arguments_callback};
+}
+
+
+
 operation::ProgramWithCallbacks untilize_multi_core(
     const Tensor& a, Tensor& output, bool use_pack_untilize, bool fp32_dest_acc_en) {
     tt::tt_metal::Program program{};
@@ -34,10 +289,18 @@ operation::ProgramWithCallbacks untilize_multi_core(
     Device* device = a.device();
 
     uint32_t ntiles = a.volume() / TILE_HW;
+    uint32_t stick_s = a.get_legacy_shape()[-1];
     uint32_t ntiles_per_block = a.get_legacy_shape()[-1] / TILE_WIDTH;
     uint32_t nblocks = ceil((float)ntiles / ntiles_per_block);
     uint32_t block_size_nbytes = a.get_legacy_shape()[-1] * output.element_size();
 
+    uint32_t max_l1_size = a.device()->l1_size_per_core() / 2 - L1_UNRESERVED_BASE;
+    uint32_t max_tiles = (max_l1_size / (input_single_tile_size + output_single_tile_size));  // 2 CBs, double buffering each
+    if (ntiles_per_block > max_tiles) {
+        if(!src_sharded and !out_sharded) {
+            return untilize_multi_core_parallelize_column(a, output, use_pack_untilize, fp32_dest_acc_en);
+        }
+    }
     auto grid_size = device->compute_with_storage_grid_size();
     auto [ncores, all_cores, core_range, core_range_cliff, nblocks_per_core, nblocks_per_core_cliff] =
         ttnn::split_blocks_for_tilize(grid_size, nblocks);
@@ -498,7 +761,7 @@ operation::ProgramWithCallbacks untilize_single_core(
 
     bool out_is_dram = dst_buffer->buffer_type() == tt::tt_metal::BufferType::DRAM ? 1 : 0;
     bool stick_size_is_power_of_two = is_power_of_two_at_least_32(stick_size);
-    uint32_t log2_stick_size = stick_size_is_power_of_two ? (std::uint32_t)log2(stick_size) : 0;
+    uint32_t log2_stick_size = stick_size_is_power_of_two ? (std::bit_width(stick_size) - 1): 0;
     std::vector<uint32_t> writer_compile_time_args = {
         (std::uint32_t)out_is_dram,
         (std::uint32_t)stick_size_is_power_of_two,


### PR DESCRIPTION
### Ticket
[Link to Github Issue](https://github.com/tenstorrent/tt-metal/issues/11509)

### Problem description
Untilize in multi-core runs out of L1 memory. This greedily makes the entire row a block. Added the same intelligence that is in single core to divide rows into multiple blocks for the untilize core.

### What's changed
Added intelligence in multi-core to break rows into multiple blocks. 

### Checklist
- [x] Post commit CI passes
- [ ] Blackhole Post commit (if applicable)
- [ ] Model regression CI testing passes (if applicable)
- [ ] New/Existing tests provide coverage for changes
