### PR TITLE
#12046: Populate/use Buffer ctor "allocate" field in CreateBuffer() & deallocate()

### DIFF
--- a/tt_metal/impl/buffers/buffer.hpp
+++ b/tt_metal/impl/buffers/buffer.hpp
@@ -114,6 +114,7 @@ struct BufferConfig {
     uint64_t page_size;  // Size of unit being interleaved. For non-interleaved buffers: size == page_size
     BufferType buffer_type;
     TensorMemoryLayout buffer_layout = TensorMemoryLayout::INTERLEAVED;
+    bool allocate = true;
 };
 
 typedef BufferConfig InterleavedBufferConfig;
@@ -127,6 +128,7 @@ struct ShardedBufferConfig {
     BufferType buffer_type = BufferType::L1;
     TensorMemoryLayout buffer_layout = TensorMemoryLayout::HEIGHT_SHARDED;
     ShardSpecBuffer shard_parameters;
+    bool allocate = true;
 };
 
 bool is_sharded(const TensorMemoryLayout &layout);
@@ -152,7 +154,8 @@ class Buffer {
         buffer_type_(BufferType::DRAM),
         buffer_layout_(TensorMemoryLayout::INTERLEAVED),
         shard_parameters_(std::nullopt),
-        bottom_up_(std::nullopt) {}
+        bottom_up_(std::nullopt),
+        allocate_(true) {}
 
     Buffer(
         Device *device,
@@ -277,6 +280,7 @@ class Buffer {
     TensorMemoryLayout buffer_layout_;
     std::optional<ShardSpecBuffer> shard_parameters_;
     std::shared_ptr<const BufferPageMapping> buffer_page_mapping_;
+    bool allocate_ = true;
    protected:
     std::optional<bool> bottom_up_;
 };

--- a/tt_metal/tt_metal.cpp
+++ b/tt_metal/tt_metal.cpp
@@ -976,7 +976,7 @@ uint32_t CreateSemaphore(
 
 std::shared_ptr<Buffer> CreateBuffer(const InterleavedBufferConfig &config) {
     return std::make_shared<Buffer>(
-        config.device, config.size, config.page_size, config.buffer_type, config.buffer_layout);
+        config.device, config.size, config.page_size, config.buffer_type, config.buffer_layout, std::nullopt, std::nullopt, config.allocate);
 }
 
 std::shared_ptr<Buffer> CreateBuffer(const ShardedBufferConfig &config) {
@@ -986,7 +986,9 @@ std::shared_ptr<Buffer> CreateBuffer(const ShardedBufferConfig &config) {
         config.page_size,
         config.buffer_type,
         config.buffer_layout,
-        config.shard_parameters);
+        config.shard_parameters,
+        std::nullopt,
+        config.allocate);
 }
 
 void DeallocateBuffer(Buffer &buffer) { buffer.deallocate(); }


### PR DESCRIPTION
Hello, tt-mlir developer here, putting up a PR for a change we'd (@kmabeeTT / @nsmithtt ) like with passing post-commit

### Ticket
Closes #12046 - see ticket for details

### Problem description
tt-mlir/tt-forge project wants to create `Buffer` objects with existing constructor flag `allocate=false` as view of existing memory that they allocate/deallocate, and have `Buffer::deallocate()` do nothing if buffer was created with `allocate=false`. Solves segfault during `Device:close()` which would loop over all Buffers in `detail::BUFFER_MAP` and deallocate these buffers again that tt-mlir had already deallocated/destroyed.

### What's changed

Kind of a simple change, hopefully not too controversial. 

 - Buffer constructor already had "allocate" field which protected against Buffer::allocate() from being called, and BUFFER_MAP insert.
 - Now, it's driven by CreateBuffer, added to Shard/Interleave configs, stored as state in Buffer class, and respected by Buffer::deallocate() to early exit if !allocate.
 - Solves segfault on metal Device::close() in tt-mlir where Buffer is created as view over memory and lifetime (alloc/dealloc) is managed by tt-mlir, but attempted to be deallocated again during teardown, so will be created with allocate=false now.

Not sure how this change impacts ttnn/async if at all (probably not at all), but I get the impression the `allocate=false` on Buffer constructor was originally used by them.  The only thing I think that would impact that is:

1. A few more calls to `this->allocate()` gaurded by (`if this->allocate_`) in Buffer constructors, similiar to main constructor
2. `Buffer::deallocate()` early exit now include the term to early exist if Buffer was created with `allocate=false`


### Checklist
- [x] Post commit CI passes : https://github.com/tenstorrent/tt-metal/actions/runs/10649195297
- [ ] Blackhole Post commit (if applicable)
- [ ] Model regression CI testing passes (if applicable)
- [ ] New/Existing tests provide coverage for changes

Not sure about other 3 bullets here, don't think they are applicable for this change, others please let me know.

