### PR TITLE
Add Mamba unit tests to post-commit test suite 

### DIFF
--- a/models/demos/wormhole/mamba/demo/demo.py
+++ b/models/demos/wormhole/mamba/demo/demo.py
@@ -372,8 +372,8 @@ def run_mamba_demo(
     chunk_size_to_prefill_targets_tok_per_s = {32: 135.0, 128: 270.0}  # perf is different for different chunk sizes
     targets = {
         "prefill_t/s": chunk_size_to_prefill_targets_tok_per_s[prefill_chunk_size],
-        "decode_t/s": 236.0,
-        "decode_t/s/u": 7.4,
+        "decode_t/s": 235.0,
+        "decode_t/s/u": 7.3,
     }
     warmup_iterations = {"inference_prefill": 0, "inference_decode": 0}
     benchmark_data = create_benchmark_data(profiler, measurements, warmup_iterations, targets)

--- a/models/demos/wormhole/mamba/reference/prefill_decode_model.py
+++ b/models/demos/wormhole/mamba/reference/prefill_decode_model.py
@@ -186,6 +186,26 @@ class Mamba(nn.Module):
 
         return model
 
+    @staticmethod
+    def from_random(pretrained_model_name: MambaPretrainedModelName, batch_size: int = 1):
+        from transformers.utils import CONFIG_NAME
+        from transformers.utils.hub import cached_file
+
+        def load_config_hf(model_name):
+            resolved_archive_file = cached_file(model_name, CONFIG_NAME, _raise_exceptions_for_missing_entries=False)
+            if not resolved_archive_file:
+                raise RuntimeError("Unable to load Mamba archive file from HF")
+            return json.load(open(resolved_archive_file))
+
+        config_data = load_config_hf(pretrained_model_name)
+        args = ModelArgs(
+            d_model=config_data["d_model"],
+            n_layer=config_data["n_layer"],
+            vocab_size=config_data["vocab_size"],
+            batch_size=batch_size,
+        )
+        return Mamba(args)
+
 
 class ResidualBlock(nn.Module):
     def __init__(self, args: ModelArgs):

--- a/models/demos/wormhole/mamba/tests/test_mamba_block.py
+++ b/models/demos/wormhole/mamba/tests/test_mamba_block.py
@@ -29,6 +29,15 @@ class PytorchMambaBlock(torch.nn.Module):
         return result
 
 
+@pytest.mark.parametrize("layer", [0])
+@pytest.mark.parametrize(
+    "use_pretrained_weights",
+    [True, False],
+    ids=[
+        "pretrained_weight_true",
+        "pretrained_weight_false",
+    ],
+)
 @pytest.mark.parametrize("device_params", [{"l1_small_size": 16384}], indirect=True)
 @pytest.mark.parametrize(
     "model_version, mode, batch, seq_len, pcc",
@@ -38,45 +47,45 @@ class PytorchMambaBlock(torch.nn.Module):
             ModelMode.PREFILL,
             1,
             128,
-            0.98,
+            0.985,
         ),
         (
             "state-spaces/mamba-2.8b",
             ModelMode.DECODE,
             32,
             1,
-            0.97,
+            0.975,
         ),
     ),
 )
 def test_mamba_block_inference(
-    device: ttnn.Device,
-    use_program_cache,
     model_version: MambaPretrainedModelName,
     mode: ModelMode,
     batch: int,
     seq_len: int,
     pcc: float,
+    use_pretrained_weights: bool,
+    layer: int,
+    device: ttnn.Device,
+    use_program_cache,
+    reset_seeds,
 ):
-    torch.manual_seed(0)
-
-    LAYER_NUM = 0
-
-    reference_model = Mamba.from_pretrained(model_version, batch_size=batch)
+    load_reference_model = Mamba.from_pretrained if use_pretrained_weights else Mamba.from_random
+    reference_model = load_reference_model(model_version, batch_size=batch)
     reference_model.args.mode = mode
 
     d_model = reference_model.args.d_model
     input = torch.rand(batch, seq_len, d_model)
 
-    reference_output = PytorchMambaBlock(reference_model, LAYER_NUM)(input)
+    reference_output = PytorchMambaBlock(reference_model, layer)(input)
 
     config = model_config.create_model_config(batch, reference_model.args.d_model, mode=mode, seq_len=seq_len)
 
     loader = TtTensorLoader(reference_model.state_dict(), device)
 
-    logger.info(f"Initalizing Mamba block from layer {LAYER_NUM}")
+    logger.info(f"Initalizing Mamba block from layer {layer}")
     start = time.time()
-    model = TtMambaBlock(reference_model.args, device, config, loader.get_tensor_loader(LAYER_NUM))
+    model = TtMambaBlock(reference_model.args, device, config, loader.get_tensor_loader(layer))
     logger.info(f"Finished initializing Mamba block (took {time.time() - start:.3f} sec)")
 
     tt_input = input.view(1, 1, config["outer_dim"], d_model)

--- a/models/demos/wormhole/mamba/tests/test_mamba_demo.py
+++ b/models/demos/wormhole/mamba/tests/test_mamba_demo.py
@@ -28,7 +28,7 @@ from difflib import SequenceMatcher
             [
                 "The city of Sarnia is located on the eastern shore of Lake Huron at its extreme southern point where it flows into the St. Clair River . Most of the surrounding area is flat , and the elevation ranges from 169 metres ( 554 ft ) and 281 metres ( 922 ft ) above sea level . The soil mostly comprises clay . Despite this high percentage of clay , the soil is remarkably rich for cultivation . Prior to the Ice Age , glaciers covered most of the area , as can be seen not only by the existence of the Great Lakes themselves but also of alluvial sand deposits, terminal moraines, and rich oil reserves."
             ],
-            ["The Great Lakes are the largest freshwater system in"],
+            ["The area was settled by the Huron Indians"],
             "state-spaces/mamba-2.8b-slimpj",
             10,
             128,

--- a/models/demos/wormhole/mamba/tests/test_mamba_model.py
+++ b/models/demos/wormhole/mamba/tests/test_mamba_model.py
@@ -117,7 +117,7 @@ buildings, agriculture and land use are among the main sectors causing greenhous
             32,
             64,
             1,
-            0.975,
+            0.9865,
         ),
         (
             "state-spaces/mamba-2.8b",
@@ -126,7 +126,7 @@ buildings, agriculture and land use are among the main sectors causing greenhous
             128,
             64,
             1,
-            0.9575,
+            0.9730,
         ),
         (
             "state-spaces/mamba-2.8b",
@@ -135,7 +135,7 @@ buildings, agriculture and land use are among the main sectors causing greenhous
             1,
             64,
             1,
-            0.96,
+            0.9700,
         ),
         (
             "state-spaces/mamba-2.8b",
@@ -144,7 +144,7 @@ buildings, agriculture and land use are among the main sectors causing greenhous
             1,
             1,
             1,
-            0.995,
+            0.9990,
         ),
     ),
 )

--- a/models/demos/wormhole/mamba/tests/test_mamba_perplexity.py
+++ b/models/demos/wormhole/mamba/tests/test_mamba_perplexity.py
@@ -72,6 +72,7 @@ def test_mamba_reference_perplexity(
     expected_top1: int,
     expected_top5: int,
     is_ci_env,
+    reset_seeds,
 ):
     torch.manual_seed(0)
 
@@ -124,16 +125,16 @@ def test_mamba_reference_perplexity(
     verify_acc_metrics(calculated_acc_metrics, expected_acc_metrics)
 
 
-@pytest.mark.timeout(1000)
+@pytest.mark.timeout(1200)
 @skip_for_grayskull("Mamba not supported on Grayskull")
 @pytest.mark.parametrize("device_params", [{"l1_small_size": 16384}], indirect=True)
 @pytest.mark.parametrize(
     "model_version, mode, batch_size, max_seq_len, num_samples, expected_ppl, expected_top1, expected_top5",
     (
-        ("state-spaces/mamba-2.8b", ModelMode.DECODE, 32, 64, 64, 28.8, 0.365, 0.605),
-        ("state-spaces/mamba-2.8b", ModelMode.DECODE, 32, 128, 64, 20.7, 0.395, 0.655),
-        ("state-spaces/mamba-2.8b", ModelMode.PREFILL, 1, 64, 64, 27.1, 0.355, 0.615),
-        ("state-spaces/mamba-2.8b", ModelMode.PREFILL, 1, 128, 64, 20.5, 0.395, 0.645),
+        ("state-spaces/mamba-2.8b", ModelMode.DECODE, 32, 64, 64, 27.2, 0.378, 0.620),
+        ("state-spaces/mamba-2.8b", ModelMode.DECODE, 32, 128, 64, 19.5, 0.410, 0.667),
+        ("state-spaces/mamba-2.8b", ModelMode.PREFILL, 1, 64, 64, 24.7, 0.375, 0.632),
+        ("state-spaces/mamba-2.8b", ModelMode.PREFILL, 1, 128, 64, 18.6, 0.415, 0.670),
     ),
 )
 def test_mamba_perplexity(
@@ -148,6 +149,7 @@ def test_mamba_perplexity(
     expected_top5: int,
     use_program_cache,
     get_tt_cache_path,
+    reset_seeds,
 ):
     torch.manual_seed(0)
 

--- a/models/demos/wormhole/mamba/tests/test_residual_block.py
+++ b/models/demos/wormhole/mamba/tests/test_residual_block.py
@@ -30,6 +30,15 @@ class PytorchResidualBlock(torch.nn.Module):
 
 
 @skip_for_grayskull("Grayskull not supported")
+@pytest.mark.parametrize("layer", [0])
+@pytest.mark.parametrize(
+    "use_pretrained_weights",
+    [True, False],
+    ids=[
+        "pretrained_weight_true",
+        "pretrained_weight_false",
+    ],
+)
 @pytest.mark.parametrize("device_params", [{"l1_small_size": 16384}], indirect=True)
 @pytest.mark.parametrize(
     "model_version, mode, batch, seq_len, pcc",
@@ -39,43 +48,43 @@ class PytorchResidualBlock(torch.nn.Module):
             ModelMode.PREFILL,
             1,
             128,
-            0.99,
+            0.9980,
         ),
         (
             "state-spaces/mamba-2.8b",
             ModelMode.DECODE,
             32,
             1,
-            0.99,
+            0.9998,
         ),
     ),
 )
 def test_residual_block(
-    device: ttnn.Device,
-    use_program_cache,
     model_version: MambaPretrainedModelName,
     mode: ModelMode,
     batch: int,
     seq_len: int,
     pcc: float,
+    use_pretrained_weights: bool,
+    layer: int,
+    device: ttnn.Device,
+    use_program_cache,
+    reset_seeds,
 ):
-    torch.manual_seed(0)
-
-    LAYER_NUM = 0
-
-    reference_model = Mamba.from_pretrained(model_version, batch_size=batch)
+    load_reference_model = Mamba.from_pretrained if use_pretrained_weights else Mamba.from_random
+    reference_model = load_reference_model(model_version, batch_size=batch)
     reference_model.args.mode = mode
 
     d_model = reference_model.args.d_model
     input = torch.rand(batch, seq_len, d_model)
 
-    reference_output = PytorchResidualBlock(reference_model, LAYER_NUM)(input)
+    reference_output = PytorchResidualBlock(reference_model, layer)(input)
 
     config = model_config.create_model_config(batch, reference_model.args.d_model, mode=mode, seq_len=seq_len)
 
     loader = TtTensorLoader(reference_model.state_dict(), device)
 
-    model = TtResidualBlock(reference_model.args, device, config, loader.get_tensor_loader(LAYER_NUM))
+    model = TtResidualBlock(reference_model.args, device, config, loader.get_tensor_loader(layer))
 
     tt_input = input.view(1, 1, config["outer_dim"], d_model)
     tt_input = ttnn.to_device(

--- a/tests/scripts/run_python_model_tests.sh
+++ b/tests/scripts/run_python_model_tests.sh
@@ -39,6 +39,9 @@ run_python_model_tests_wormhole_b0() {
     # Unet Shallow
     WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml pytest -svv models/experimental/functional_unet/tests/test_unet_model.py
 
+    # Mamba
+    WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml pytest -svv models/demos/wormhole/mamba/tests/test_residual_block.py -k "pretrained_weight_false"
+
     # Llama 3.1 8B single-layer dummy weights tight PCC check
     WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml pytest models/demos/wormhole/llama31_8b/tests/test_llama_model.py -k "quick"
 }


### PR DESCRIPTION
### Summary
Adds Mamba unit tests to post-commit pipeline. To speed these tests up, I added an option to use random weights which will mean we skip downloading them. Each test file adds 30 seconds of time to post commit (adding 1.5 mins total time).

Overall Mamba accuracy was improved with fc5e09669d336e045eb2f65f719e2e35116b5bea. This change updates the expected tokens and PCC values in our tests.

### Checklist
- [x] Post commit CI passes
- [x] Model regression CI testing passes (if applicable)
