### PR TITLE
[Bugfix] Fixed wrong capture counter

### DIFF
--- a/ttnn/cpp/ttnn/graph/graph_processor.cpp
+++ b/ttnn/cpp/ttnn/graph/graph_processor.cpp
@@ -118,8 +118,8 @@ void GraphProcessor::track_allocate(tt::tt_metal::Buffer* buffer, bool bottom_up
 
 void GraphProcessor::track_deallocate(tt::tt_metal::Buffer* buffer) {
     const std::lock_guard<std::mutex> lock(mutex);
-    auto counter = graph.size();
     auto buffer_idx = add_buffer(buffer);
+    auto counter = graph.size();
     std::unordered_map<std::string, std::string> params = {
             {kSize, std::to_string(buffer->size())},
             {kType, buffer->is_dram() ? "DRAM" : "L1"},


### PR DESCRIPTION
### Ticket
None
### Problem description
If allocation out of scope of the graph we are creating a new buffer ID in deallocate.
But we are using a wrong counter for deallocate node.

### What's changed
Just created buffer first then get counter.

### Checklist
- [ ] Post commit CI passes
- [ ] Blackhole Post commit (if applicable)
- [ ] Model regression CI testing passes (if applicable)
- [ ] New/Existing tests provide coverage for changes
