### PR TITLE
#11972: CI Sweeps workflow update

### DIFF
--- a/.github/workflows/ttnn-run-sweeps.yaml
+++ b/.github/workflows/ttnn-run-sweeps.yaml
@@ -2,6 +2,9 @@ name: "ttnn - Run sweeps"
 
 on:
   workflow_dispatch:
+  push:
+    branches:
+      - jdesousa/sweeps-ci-tagging
 
 jobs:
   build-artifact:
@@ -27,13 +30,11 @@ jobs:
       - uses: ./.github/actions/prepare-metal-run
         with:
           arch: wormhole_b0
-      - name: Setup ttnn sweeps generation environment
+      - name: Run ttnn sweeps generation
         run: |
           source ${{ github.workspace }}/python_env/bin/activate
           cd $TT_METAL_HOME
           export PYTHONPATH=$TT_METAL_HOME
-      - name: Run ttnn sweeps generation
-        run: |
           python tests/sweep_framework/parameter_generator.py --elastic cloud --tag ci-main --explicit
 
   ttnn-run-sweeps:
@@ -49,16 +50,19 @@ jobs:
               name: "Grayskull E150 Sweeps",
               arch: grayskull,
               runs-on: ["cloud-virtual-machine", "E150", "in-service"],
+              tt-smi-cmd: "tt-smi-metal -r 0"
             },
             {
               name: "Wormhole N150 Sweeps",
               arch: wormhole_b0,
               runs-on: ["cloud-virtual-machine", "N150", "in-service"],
+              tt-smi-cmd: "tt-smi-metal -r 0"
             },
             {
               name: "Wormhole N300 Sweeps",
               arch: wormhole_b0,
               runs-on: ["cloud-virtual-machine", "N300", "in-service"],
+              tt-smi-cmd: "tt-smi-metal -r 0"
             }
           ]
     env:
@@ -66,6 +70,7 @@ jobs:
       ARCH_NAME: ${{ matrix.test-group.arch }}
       ELASTIC_USERNAME: ${{ secrets.SWEEPS_ELASTIC_USERNAME }}
       ELASTIC_PASSWORD: ${{ secrets.SWEEPS_ELASTIC_PASSWORD }}
+      TT_SMI_RESET_COMMAND: ${{ matrix.test-group.tt-smi-cmd }}
       LD_LIBRARY_PATH: ${{ github.workspace }}/build/lib
     environment: dev
     timeout-minutes: 720

--- a/.github/workflows/ttnn-run-sweeps.yaml
+++ b/.github/workflows/ttnn-run-sweeps.yaml
@@ -2,9 +2,6 @@ name: "ttnn - Run sweeps"
 
 on:
   workflow_dispatch:
-  push:
-    branches:
-      - jdesousa/sweeps-ci-tagging
 
 jobs:
   build-artifact:
@@ -88,4 +85,4 @@ jobs:
           source ${{ github.workspace }}/python_env/bin/activate
           cd $TT_METAL_HOME
           export PYTHONPATH=$TT_METAL_HOME
-          python tests/sweep_framework/runner.py --elastic cloud --tag ci-main
+          python tests/sweep_framework/runner.py --elastic cloud --tag ci-main --suite-name nightly

--- a/.github/workflows/ttnn-run-sweeps.yaml
+++ b/.github/workflows/ttnn-run-sweeps.yaml
@@ -8,23 +8,17 @@ jobs:
     uses: ./.github/workflows/build-artifact.yaml
     secrets: inherit
 
-  ttnn-sweeps:
+  ttnn-generate-sweeps:
     needs: build-artifact
-    strategy:
-      # Do not fail-fast because we need to ensure all tests go to completion
-      # so we try not to get hanging machines
-      fail-fast: false
-      matrix:
-        arch: [grayskull, wormhole_b0]
     env:
       TT_METAL_ENV: ${{ vars.TT_METAL_ENV }}
-      ARCH_NAME: ${{ matrix.arch }}
+      ARCH_NAME: wormhole_b0
       ELASTIC_USERNAME: ${{ secrets.SWEEPS_ELASTIC_USERNAME }}
       ELASTIC_PASSWORD: ${{ secrets.SWEEPS_ELASTIC_PASSWORD }}
       LD_LIBRARY_PATH: ${{ github.workspace }}/build/lib
     environment: dev
-    timeout-minutes: 720
-    runs-on: ${{ matrix.arch }}
+    timeout-minutes: 30
+    runs-on: [build, in-service]
     steps:
       - uses: tenstorrent-metal/metal-workflows/.github/actions/checkout-with-submodule-lfs@v2.0.0
       - name: Set up dynamic env vars for build
@@ -32,10 +26,61 @@ jobs:
           echo "TT_METAL_HOME=$(pwd)" >> $GITHUB_ENV
       - uses: ./.github/actions/prepare-metal-run
         with:
-          arch: ${{ matrix.arch }}
+          arch: wormhole_b0
+      - name: Setup ttnn sweeps generation environment
+        run: |
+          source ${{ github.workspace }}/python_env/bin/activate
+          cd $TT_METAL_HOME
+          export PYTHONPATH=$TT_METAL_HOME
+      - name: Run ttnn sweeps generation
+        run: |
+          python tests/sweep_framework/parameter_generator.py --elastic cloud --tag ci-main --explicit
+
+  ttnn-run-sweeps:
+    needs: ttnn-generate-sweeps
+    strategy:
+      # Do not fail-fast because we need to ensure all tests go to completion
+      # so we try not to get hanging machines
+      fail-fast: false
+      matrix:
+        test-group:
+          [
+            {
+              name: "Grayskull E150 Sweeps",
+              arch: grayskull,
+              runs-on: ["cloud-virtual-machine", "E150", "in-service"],
+            },
+            {
+              name: "Wormhole N150 Sweeps",
+              arch: wormhole_b0,
+              runs-on: ["cloud-virtual-machine", "N150", "in-service"],
+            },
+            {
+              name: "Wormhole N300 Sweeps",
+              arch: wormhole_b0,
+              runs-on: ["cloud-virtual-machine", "N300", "in-service"],
+            }
+          ]
+    env:
+      TT_METAL_ENV: ${{ vars.TT_METAL_ENV }}
+      ARCH_NAME: ${{ matrix.test-group.arch }}
+      ELASTIC_USERNAME: ${{ secrets.SWEEPS_ELASTIC_USERNAME }}
+      ELASTIC_PASSWORD: ${{ secrets.SWEEPS_ELASTIC_PASSWORD }}
+      LD_LIBRARY_PATH: ${{ github.workspace }}/build/lib
+    environment: dev
+    timeout-minutes: 720
+    runs-on: ${{ matrix.test-group.runs-on }}
+    steps:
+      - uses: tenstorrent-metal/metal-workflows/.github/actions/checkout-with-submodule-lfs@v2.0.0
+      - name: Set up dynamic env vars for build
+        run: |
+          echo "TT_METAL_HOME=$(pwd)" >> $GITHUB_ENV
+      - uses: ./.github/actions/prepare-metal-run
+        with:
+          arch: ${{ matrix.test-group.arch }}
       - name: Run ttnn sweeps
         run: |
           source ${{ github.workspace }}/python_env/bin/activate
           cd $TT_METAL_HOME
           export PYTHONPATH=$TT_METAL_HOME
-          python tests/sweep_framework/runner.py --elastic cloud
+          python tests/sweep_framework/runner.py --elastic cloud --tag ci-main

--- a/tests/sweep_framework/tt_smi_util.py
+++ b/tests/sweep_framework/tt_smi_util.py
@@ -14,7 +14,12 @@ RESET_OVERRIDE = os.getenv("TT_SMI_RESET_COMMAND")
 
 def run_tt_smi(arch: str):
     if RESET_OVERRIDE is not None:
-        subprocess.run(RESET_OVERRIDE, shell=True)
+        smi_process = subprocess.run(RESET_OVERRIDE, shell=True)
+        if smi_process.returncode == 0:
+            print("SWEEPS: TT-SMI Reset Complete Successfully")
+            return
+        else:
+            raise Exception(f"SWEEPS: TT-SMI Reset Failed with Exit Code: {smi_process.returncode}")
         return
 
     if arch not in ["grayskull", "wormhole_b0"]:
@@ -27,12 +32,21 @@ def run_tt_smi(arch: str):
     ]
     args = GRAYSKULL_ARGS if arch == "grayskull" else WORMHOLE_ARGS
 
+    # Potential implementation to use the pre-defined reset script on each CI runner. Not in use because of the time and extra functions it has. (hugepages check, etc.)
+    # if os.getenv("CI") == "true":
+    #     smi_process = subprocess.run(f"/opt/tt_metal_infra/scripts/ci/{arch}/reset.sh", shell=True, capture_output=True)
+    #     if smi_process.returncode == 0:
+    #         print("SWEEPS: TT-SMI Reset Complete Successfully")
+    #         return
+    #     else:
+    #         raise Exception(f"SWEEPS: TT-SMI Reset Failed with Exit Code: {smi_process.returncode}")
+
     for smi_option in smi_options:
         executable = shutil.which(smi_option)
         if executable is not None:
-            # Corner case for newer version of tt-smi, -tr and -wr are removed on this version (tt-smi-metal).
+            # Corner case for newer version of tt-smi, -tr and -wr are removed on this version (tt-smi-metal). Default device 0, if needed use TT_SMI_RESET_COMMAND override.
             if smi_option == "tt-smi-metal":
-                args = ["-r", "all"]
+                args = ["-r", "0"]
             smi_process = subprocess.run([executable, *args])
             if smi_process.returncode == 0:
                 print("SWEEPS: TT-SMI Reset Complete Successfully")


### PR DESCRIPTION
### Ticket
#11972 

### Problem description
See issue

### What's changed
1. Change matrix to use the newer tags for silicon runners
2. Add a test generation job before the running of the tests (on self-hosted CPU machines)
3. Use the new tagging function on both generation and running steps of the workflow
4. Add tt-smi command override to prevent workflow from crashing on hangs when it cannot find tt-smi binary and/or has wrong parameters
5. Add nightly suite filter to limit the amount of tests we run at night. This gives control back to the developers to choose which tests to run on nightly. 

### Checklist
- [ ] Post commit CI passes
- [ ] Blackhole Post commit (if applicable)
- [ ] Model regression CI testing passes (if applicable)
- [ ] New/Existing tests provide coverage for changes
