### PR TITLE
#12173: Add tt-smi command override to sweeps ci workflow

### DIFF
--- a/.github/workflows/ttnn-run-sweeps.yaml
+++ b/.github/workflows/ttnn-run-sweeps.yaml
@@ -49,16 +49,19 @@ jobs:
               name: "Grayskull E150 Sweeps",
               arch: grayskull,
               runs-on: ["cloud-virtual-machine", "E150", "in-service"],
+              tt-smi-cmd: "tt-smi-metal -r 0"
             },
             {
               name: "Wormhole N150 Sweeps",
               arch: wormhole_b0,
               runs-on: ["cloud-virtual-machine", "N150", "in-service"],
+              tt-smi-cmd: "tt-smi-metal -r 0"
             },
             {
               name: "Wormhole N300 Sweeps",
               arch: wormhole_b0,
               runs-on: ["cloud-virtual-machine", "N300", "in-service"],
+              tt-smi-cmd: "tt-smi-metal -r 0"
             }
           ]
     env:
@@ -66,6 +69,7 @@ jobs:
       ARCH_NAME: ${{ matrix.test-group.arch }}
       ELASTIC_USERNAME: ${{ secrets.SWEEPS_ELASTIC_USERNAME }}
       ELASTIC_PASSWORD: ${{ secrets.SWEEPS_ELASTIC_PASSWORD }}
+      TT_SMI_RESET_COMMAND: ${{ matrix.test-group.tt-smi-cmd }}
       LD_LIBRARY_PATH: ${{ github.workspace }}/build/lib
     environment: dev
     timeout-minutes: 720

--- a/tests/sweep_framework/tt_smi_util.py
+++ b/tests/sweep_framework/tt_smi_util.py
@@ -14,7 +14,12 @@ RESET_OVERRIDE = os.getenv("TT_SMI_RESET_COMMAND")
 
 def run_tt_smi(arch: str):
     if RESET_OVERRIDE is not None:
-        subprocess.run(RESET_OVERRIDE, shell=True)
+        smi_process = subprocess.run(RESET_OVERRIDE, shell=True)
+        if smi_process.returncode == 0:
+            print("SWEEPS: TT-SMI Reset Complete Successfully")
+            return
+        else:
+            raise Exception(f"SWEEPS: TT-SMI Reset Failed with Exit Code: {smi_process.returncode}")
         return
 
     if arch not in ["grayskull", "wormhole_b0"]:
@@ -27,12 +32,21 @@ def run_tt_smi(arch: str):
     ]
     args = GRAYSKULL_ARGS if arch == "grayskull" else WORMHOLE_ARGS
 
+    # Potential implementation to use the pre-defined reset script on each CI runner. Not in use because of the time and extra functions it has. (hugepages check, etc.)
+    # if os.getenv("CI") == "true":
+    #     smi_process = subprocess.run(f"/opt/tt_metal_infra/scripts/ci/{arch}/reset.sh", shell=True, capture_output=True)
+    #     if smi_process.returncode == 0:
+    #         print("SWEEPS: TT-SMI Reset Complete Successfully")
+    #         return
+    #     else:
+    #         raise Exception(f"SWEEPS: TT-SMI Reset Failed with Exit Code: {smi_process.returncode}")
+
     for smi_option in smi_options:
         executable = shutil.which(smi_option)
         if executable is not None:
-            # Corner case for newer version of tt-smi, -tr and -wr are removed on this version (tt-smi-metal).
+            # Corner case for newer version of tt-smi, -tr and -wr are removed on this version (tt-smi-metal). Default device 0, if needed use TT_SMI_RESET_COMMAND override.
             if smi_option == "tt-smi-metal":
-                args = ["-r", "all"]
+                args = ["-r", "0"]
             smi_process = subprocess.run([executable, *args])
             if smi_process.returncode == 0:
                 print("SWEEPS: TT-SMI Reset Complete Successfully")


### PR DESCRIPTION
### Ticket
#12173 

### Problem description
In CI, we use a newer version of tt-smi than on IRD or some cloud machines. This causes the reset to fail if the tt_smi_util code cannot pickup the correct flags automatically.

### What's changed
Set the `TT_SMI_RESET_COMMAND` env variable to override the tt-smi reset command in the sweeps workflow.

### Checklist
- [ ] Post commit CI passes
- [ ] Blackhole Post commit (if applicable)
- [ ] Model regression CI testing passes (if applicable)
- [ ] New/Existing tests provide coverage for changes
