### PR TITLE
#12175: Add schedule for ttnn-run-sweeps workflow nightly

### DIFF
--- a/.github/workflows/ttnn-run-sweeps.yaml
+++ b/.github/workflows/ttnn-run-sweeps.yaml
@@ -2,6 +2,8 @@ name: "ttnn - Run sweeps"
 
 on:
   workflow_dispatch:
+    schedule:
+     - cron: "0 21 * * *" # This cron schedule runs the workflow at 9:00pm UTC nightly
 
 jobs:
   build-artifact:


### PR DESCRIPTION
### Ticket
#12175 

### Problem description
Sweeps need to run on a regular basis.

### What's changed
Added a nightly schedule to the ttnn-run-sweeps workflow

### Checklist
- [ ] Post commit CI passes
- [ ] Blackhole Post commit (if applicable)
- [ ] Model regression CI testing passes (if applicable)
- [ ] New/Existing tests provide coverage for changes
