### PR TITLE
#11453: Add options to enable compilation with sanitizers

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -96,6 +96,35 @@ message(STATUS "Build shared libs: ${BUILD_SHARED_LIBS}")
 option(ENABLE_ASAN "Enable build with AddressSanitizer" OFF)
 message(STATUS "Build with ASAN: ${ENABLE_ASAN}")
 
+set(SANITIZER_ENABLED ${ENABLE_ASAN})
+
+option(ENABLE_MSAN "Enable build with MemorySanitizer" OFF)
+message(STATUS "Build with MSAN: ${ENABLE_MSAN}")
+
+if(SANITIZER_ENABLED AND ENABLE_MSAN)
+    message(FATAL_ERROR "Multiple sanitizers are not supported")
+elseif(ENABLE_MSAN)
+    set(SANITIZER_ENABLED ${ENABLE_MSAN})
+endif()
+
+option(ENABLE_TSAN "Enable build with ThreadSanitizer" OFF)
+message(STATUS "Build with TSAN: ${ENABLE_TSAN}")
+
+if(SANITIZER_ENABLED AND ENABLE_TSAN)
+    message(FATAL_ERROR "Multiple sanitizers are not supported")
+elseif(ENABLE_TSAN)
+    set(SANITIZER_ENABLED ${ENABLE_TSAN})
+endif()
+
+option(ENABLE_UBSAN "Enable build with UndefinedBehaviorSanitizer" OFF)
+message(STATUS "Build with UBSAN: ${ENABLE_UBSAN}")
+
+if(SANITIZER_ENABLED AND ENABLE_UBSAN)
+    message(FATAL_ERROR "Multiple sanitizers are not supported")
+endif()
+
+unset(SANITIZER_ENABLED)
+
 include(GNUInstallDirs)
 set(CMAKE_INSTALL_PREFIX "${PROJECT_BINARY_DIR}")
 set(CMAKE_INSTALL_LIBDIR "${PROJECT_BINARY_DIR}/lib")
@@ -169,10 +198,19 @@ if(ENABLE_TRACY)
     target_compile_options(compiler_flags INTERFACE -DTRACY_ENABLE -fno-omit-frame-pointer)
     target_link_options(linker_flags INTERFACE -rdynamic)
 endif()
-if(ENABLE_ASAN)
-    target_compile_options(compiler_flags INTERFACE -fsanitize=address)
-    target_link_options(linker_flags INTERFACE -fsanitize=address)
-endif()
+target_compile_options(
+    compiler_flags
+    INTERFACE $<$<BOOL:ENABLE_ASAN>:-fsanitize=address>
+              $<$<BOOL:ENABLE_MSAN>:-fsanitize=memory>
+              $<$<BOOL:ENABLE_TSAN>:-fsanitize=thread>
+              $<$<BOOL:ENABLE_UBSAN>:-fsanitize=undefined>)
+target_link_options(
+    linker_flags
+    INTERFACE
+    $<$<BOOL:ENABLE_ASAN>:-fsanitize=address>
+    $<$<BOOL:ENABLE_MSAN>:-fsanitize=memory>
+    $<$<BOOL:ENABLE_TSAN>:-fsanitize=thread>
+    $<$<BOOL:ENABLE_UBSAN>:-fsanitize=undefined>)
 
 string(TOUPPER $ENV{ARCH_NAME} ARCH_NAME_DEF)
 target_compile_options(compiler_flags INTERFACE -DARCH_${ARCH_NAME_DEF})

--- a/build_metal.sh
+++ b/build_metal.sh
@@ -58,6 +58,9 @@ show_help() {
     echo "  -b  Set the build type. Default is Release. Other options are Debug, RelWithDebInfo, and CI."
     echo "  -t  Enable build time trace (clang only)."
     echo "  -a  Enable AddressSanitizer."
+    echo "  -m  Enable MemorySanitizer."
+    echo "  -s  Enable ThreadSanitizer."
+    echo "  -u  Enable UndefinedBehaviorSanitizer."
 }
 
 # Parse CLI options
@@ -65,9 +68,12 @@ export_compile_commands="OFF"
 enable_ccache="OFF"
 enable_time_trace="OFF"
 enable_asan="OFF"
+enable_msan="OFF"
+enable_tsan="OFF"
+enable_ubsan="OFF"
 build_type="Release"
 
-while getopts "hectab:" opt; do
+while getopts "hectamsub:" opt; do
     case ${opt} in
         h )
             show_help
@@ -84,6 +90,15 @@ while getopts "hectab:" opt; do
             ;;
         a )
             enable_asan="ON"
+            ;;
+        m )
+            enable_msan="ON"
+            ;;
+        s )
+            enable_tsan="ON"
+            ;;
+        u )
+            enable_ubsan="ON"
             ;;
         b )
             build_type="$OPTARG"
@@ -106,6 +121,9 @@ echo "Enable ccache: $enable_ccache"
 echo "Build type: $build_type"
 echo "Enable time trace: $enable_time_trace"
 echo "Enable AddressSanitizer: $enable_asan"
+echo "Enable MemorySanitizer: $enable_msan"
+echo "Enable ThreadSanitizer: $enable_tsan"
+echo "Enable UndefinedBehaviorSanitizer: $enable_ubsan"
 
 # Create and link the build directory
 mkdir -p build_$build_type
@@ -125,6 +143,18 @@ fi
 
 if [ "$enable_asan" = "ON" ]; then
     cmake_args="$cmake_args -DENABLE_ASAN=ON"
+fi
+
+if [ "$enable_msan" = "ON" ]; then
+    cmake_args="$cmake_args -DENABLE_MSAN=ON"
+fi
+
+if [ "$enable_tsan" = "ON" ]; then
+    cmake_args="$cmake_args -DENABLE_TSAN=ON"
+fi
+
+if [ "$enable_ubsan" = "ON" ]; then
+    cmake_args="$cmake_args -DENABLE_UBSAN=ON"
 fi
 
 # Configure cmake


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/11453

### Problem description
We want the ability to compile C++ with sanitizers to verify code's safety

### What's changed
This pull request adds options for MemorySanitizer, ThreadSanitizer, and UndefinedBehaviorSanitizer to CMake and the `build_metal.sh` script, and ensures that they're mutually exclusive during configuration.

### Checklist
- [ ] Post commit CI passes
- [ ] Blackhole Post commit (if applicable)
- [ ] Model regression CI testing passes (if applicable)
- [ ] New/Existing tests provide coverage for changes
