### PR TITLE
#10808: use sharded concat in yolov4

### DIFF
--- a/models/experimental/yolov4/ttnn/downsample1.py
+++ b/models/experimental/yolov4/ttnn/downsample1.py
@@ -45,15 +45,11 @@ class Down1:
         output_tensor = self.conv7(device, output_tensor)
         output_tensor = ttnn.mish(output_tensor)
 
-        # output_tensor = ttnn.experimental.tensor.sharded_to_interleaved(output_tensor, ttnn.L1_MEMORY_CONFIG)
-        # output_tensor_left = ttnn.experimental.tensor.sharded_to_interleaved(output_tensor_left, ttnn.L1_MEMORY_CONFIG)
         output_tensor = ttnn.to_layout(output_tensor, layout=ttnn.ROW_MAJOR_LAYOUT)
         output_tensor_left = ttnn.to_layout(output_tensor_left, layout=ttnn.ROW_MAJOR_LAYOUT)
-        print("output_tensor_left", output_tensor_left.memory_config())
-        print("output_tensor", output_tensor.memory_config())
         output_sharded_memory_config = ttnn.create_sharded_memory_config(
-            [1024, 64],
-            core_grid=ttnn.CoreGrid(y=8, x=8),
+            [512, 128],
+            core_grid=output_tensor_left.memory_config().shard_spec.grid,
             strategy=ttnn.ShardStrategy.HEIGHT,
             use_height_and_width_as_shard_shape=True,
         )

--- a/tests/ttnn/unit_tests/operations/test_concat.py
+++ b/tests/ttnn/unit_tests/operations/test_concat.py
@@ -60,10 +60,22 @@ def test_concat(device, height, width, dim, async_mode):
             (80, 48),
             ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(0, 1))}),
         ),
+        (
+            (1, 1, 25600, 64),
+            (512, 64),
+            (1, 1, 25600, 64),
+            (512, 64),
+            (512, 128),
+            ttnn.CoreRangeSet(
+                {
+                    ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(7, 5)),
+                    ttnn.CoreRange(ttnn.CoreCoord(0, 6), ttnn.CoreCoord(1, 6)),
+                }
+            ),
+        ),
     ),
 )
 @pytest.mark.parametrize("async_mode", [True, False], ids=["async_on", "async_off"])
-@pytest.mark.skip(reason="Issue #8426: Add validation for ttnn.concat for sharded inputs")
 def test_sharded_concat(
     device, input_shape_a, shard_shape_a, input_shape_b, shard_shape_b, output_shard_shape, shard_grid, async_mode
 ):

--- a/tt_metal/impl/allocator/allocator.cpp
+++ b/tt_metal/impl/allocator/allocator.cpp
@@ -120,7 +120,7 @@ uint64_t BankManager::allocate_buffer(
         is_sharded = true;
         TT_FATAL(
             num_shards.value() <= num_compute_banks,
-            "Expected number of shards to be less than or equal to total number of L1 banks in compute cores");
+            fmt::format("Expected number of shards {} to be less than or equal to total number of L1 banks {} in compute cores", num_shards.value(), num_compute_banks));
         num_banks = num_shards.value();
     }
     uint32_t size_per_bank = tt::tt_metal::detail::SizeBytesPerBank(size, page_size, num_banks, this->alignment_bytes_);


### PR DESCRIPTION
### Ticket
#10808

### Problem description
Sharded implementation is more performant. Use that instead when the input is height sharded. Enable ttnn sharded concat tests as well.

### What's changed
Describe the approach used to solve the problem.
Summarize the changes made and its impact.

### Checklist
- [x] Post commit CI passes
- [ ] Blackhole Post commit (if applicable)
- [ ] Model regression CI testing passes (if applicable)
- [ ] New/Existing tests provide coverage for changes
