### PR TITLE
#0: Fast dispatch host read/write optimizations for workers

### DIFF
--- a/docs/source/tt-metalium/tt_metal/apis/host_apis/command_queue/EnqueueRecordEvent.rst
+++ b/docs/source/tt-metalium/tt_metal/apis/host_apis/command_queue/EnqueueRecordEvent.rst
@@ -1,4 +1,4 @@
 EnqueueRecordEvent
 ==================
 
-.. doxygenfunction:: EnqueueRecordEvent(CommandQueue& cq, std::shared_ptr<Event> event)
+.. doxygenfunction:: EnqueueRecordEvent

--- a/docs/source/tt-metalium/tt_metal/apis/host_apis/command_queue/EnqueueWaitForEvent.rst
+++ b/docs/source/tt-metalium/tt_metal/apis/host_apis/command_queue/EnqueueWaitForEvent.rst
@@ -1,4 +1,4 @@
 EnqueueWaitForEvent
 ===================
 
-.. doxygenfunction:: EnqueueWaitForEvent(CommandQueue& cq, std::shared_ptr<Event> event)
+.. doxygenfunction:: EnqueueWaitForEvent

--- a/docs/source/tt-metalium/tt_metal/apis/host_apis/command_queue/EventQuery.rst
+++ b/docs/source/tt-metalium/tt_metal/apis/host_apis/command_queue/EventQuery.rst
@@ -1,4 +1,4 @@
 EventQuery
 ==========
 
-.. doxygenfunction:: EventQuery(std::shared_ptr<Event> event)
+.. doxygenfunction:: EventQuery

--- a/docs/source/tt-metalium/tt_metal/apis/host_apis/command_queue/EventSynchronize.rst
+++ b/docs/source/tt-metalium/tt_metal/apis/host_apis/command_queue/EventSynchronize.rst
@@ -1,4 +1,4 @@
 EventSynchronize
 ================
 
-.. doxygenfunction:: EventSynchronize(std::shared_ptr<Event> event)
+.. doxygenfunction:: EventSynchronize

--- a/tt_metal/detail/tt_metal.hpp
+++ b/tt_metal/detail/tt_metal.hpp
@@ -39,11 +39,11 @@ namespace tt::tt_metal {
         *
         * | Argument    | Description                                     | Data type               | Valid range                                      | Required |
         * |-------------|-------------------------------------------------|-------------------------|--------------------------------------------------|----------|
-        * | buffer      | Buffer to send data to                          | const Buffer &          |                                                  | Yes      |
+        * | buffer      | Buffer to send data to                          | Buffer &                |                                                  | Yes      |
         * | host_buffer | Buffer on host to copy data from                | std::vector<uint32_t> & | Host buffer size must match buffer               | Yes      |
         */
-        void WriteToBuffer(const Buffer &buffer, const std::vector<uint32_t> &host_buffer);
-        void WriteToBuffer( std::shared_ptr<const Buffer> buffer, const std::vector<uint32_t> &host_buffer);
+        void WriteToBuffer(Buffer &buffer, const std::vector<uint32_t> &host_buffer);
+        void WriteToBuffer( std::shared_ptr<Buffer> buffer, const std::vector<uint32_t> &host_buffer);
         /**
         * Copies data from a buffer into a host buffer
         *
@@ -51,12 +51,12 @@ namespace tt::tt_metal {
         *
         * | Argument    | Description                                     | Data type               | Valid range                                      | Required |
         * |-------------|-------------------------------------------------|-------------------------|--------------------------------------------------|----------|
-        * | buffer      | Buffer to read data from                        | const Buffer &          |                                                  | Yes      |
+        * | buffer      | Buffer to read data from                        | Buffer &                |                                                  | Yes      |
         * | host_buffer | Buffer on host to copy data into                | std::vector<uint32_t> & |                                                  | Yes      |
         * | shard_order | For a sharded buffer we can read in shard order | bool                    |                                                  | No       |
         */
-        void ReadFromBuffer(const Buffer &buffer, std::vector<uint32_t> &host_buffer, bool shard_order = false);
-        void ReadFromBuffer(std::shared_ptr<const Buffer> buffer, std::vector<uint32_t> &host_buffer, bool shard_order = false);
+        void ReadFromBuffer(Buffer &buffer, std::vector<uint32_t> &host_buffer, bool shard_order = false);
+        void ReadFromBuffer(std::shared_ptr<Buffer> buffer, std::vector<uint32_t> &host_buffer, bool shard_order = false);
 
         /**
         * Copies data from a buffer into a host buffer
@@ -65,11 +65,11 @@ namespace tt::tt_metal {
         *
         * | Argument    | Description                                     | Data type               | Valid range                                      | Required |
         * |-------------|-------------------------------------------------|-------------------------|--------------------------------------------------|----------|
-        * | buffer      | Buffer to read data from                        | const Buffer &          |                                                  | Yes      |
+        * | buffer      | Buffer to read data from                        | Buffer &                |                                                  | Yes      |
         * | host_buffer | Buffer on host to copy data into                | std::vector<uint32_t> & |                                                  | Yes      |
         * | core_id     | ID of core                                      | const uint32_t &        |                                                  | Yes      |
         */
-        void ReadShard(const Buffer &buffer, std::vector<uint32_t> &host_buffer, const uint32_t & core_id);
+        void ReadShard(Buffer &buffer, std::vector<uint32_t> &host_buffer, const uint32_t & core_id);
 
 
 

--- a/tt_metal/host_api.hpp
+++ b/tt_metal/host_api.hpp
@@ -6,9 +6,10 @@
 
 #include <variant>
 #include <vector>
+
 #include "tt_metal/impl/dispatch/dispatch_core_manager.hpp"
-#include "tt_metal/impl/program/program.hpp"
 #include "tt_metal/impl/kernels/runtime_args_data.hpp"
+#include "tt_metal/impl/program/program.hpp"
 
 /** @file */
 
@@ -84,10 +85,7 @@ Device *CreateDevice(
  * | device_id  | ID of the device to target| chip_id_t (int) | 0 to (GetNumAvailableDevices - 1) | Yes      |
  * */
 Device *CreateDeviceMinimal(
-    chip_id_t device_id,
-    const uint8_t num_hw_cqs = 1,
-    DispatchCoreType dispatch_core_type = DispatchCoreType::WORKER
-    );
+    chip_id_t device_id, const uint8_t num_hw_cqs = 1, DispatchCoreType dispatch_core_type = DispatchCoreType::WORKER);
 
 /**
  * Resets device and closes device
@@ -148,7 +146,10 @@ KernelHandle CreateKernel(
  * | core_spec | Either a single logical core, a range of logical cores or a set of logical core ranges that indicate where the circular buffer will be configured | const std::variant<CoreCoord, CoreRange, CoreRangeSet> & |             | Yes      |
  * | config    | Config for circular buffer                                                                                                                        | const CircularBufferConfig &                             |             | Yes      |
  */
-CBHandle CreateCircularBuffer(Program &program, const std::variant<CoreCoord, CoreRange, CoreRangeSet> &core_spec, const CircularBufferConfig &config);
+CBHandle CreateCircularBuffer(
+    Program &program,
+    const std::variant<CoreCoord, CoreRange, CoreRangeSet> &core_spec,
+    const CircularBufferConfig &config);
 
 /**
  * Gets a reference to the config owned by circular buffer at the given circular buffer ID.
@@ -214,7 +215,11 @@ void UpdateDynamicCircularBufferAddress(Program &program, CBHandle cb_handle, co
  * | initial_value | Initial value of the semaphore                       | uint32_t                                                  |              | Yes      |
  * | core_type     | Tensix or Ethernet core to create semaphore on.      | CoreType                                                  |              | Yes      |
  */
-uint32_t CreateSemaphore(Program &program, const std::variant<CoreRange,CoreRangeSet> &core_spec, uint32_t initial_value, CoreType core_type=CoreType::WORKER);
+uint32_t CreateSemaphore(
+    Program &program,
+    const std::variant<CoreRange, CoreRangeSet> &core_spec,
+    uint32_t initial_value,
+    CoreType core_type = CoreType::WORKER);
 
 /**
 *  Allocates an interleaved DRAM or L1 buffer on device
@@ -259,12 +264,13 @@ void DeallocateBuffer(Buffer &buffer);
 *  | buffer   | The buffer that will be owned by the program | std::shared_ptr<Buffer> buffer |             | Yes      |
 *  | program  | The program getting ownership of the buffer  | std::shared_ptr<Buffer> buffer |             | Yes      |
 */
-void AssignGlobalBufferToProgram(std::shared_ptr<Buffer> buffer, std::variant<std::reference_wrapper<Program>, std::shared_ptr<Program>> program);
+void AssignGlobalBufferToProgram(
+    std::shared_ptr<Buffer> buffer, std::variant<std::reference_wrapper<Program>, std::shared_ptr<Program>> program);
 
 // ==================================================
 //           COMPILE & EXECUTE KENRNELS
 // ==================================================
-using RuntimeArgs = std::vector<std::variant<Buffer*, uint32_t>>;
+using RuntimeArgs = std::vector<std::variant<Buffer *, uint32_t>>;
 /**
  * Set runtime args for a kernel that are sent to the core during runtime. This API needs to be called to update the runtime args for the kernel.
  * Maximum of 255 allowed runtime args per core (unique and common runtime args count toward same limit).
@@ -278,7 +284,11 @@ using RuntimeArgs = std::vector<std::variant<Buffer*, uint32_t>>;
  * | core_spec    | Location of Tensix core(s) where the runtime args will be written      | const std::variant<CoreCoord,CoreRange,CoreRangeSet> & | Any logical Tensix core coordinate(s) on which the kernel is placed | Yes      |
  * | runtime_args | The runtime args to be written                                         | const std::vector<uint32_t> &                          |                                                                     | Yes      |
  */
-void SetRuntimeArgs(const Program &program, KernelHandle kernel, const std::variant<CoreCoord, CoreRange, CoreRangeSet> &core_spec, const std::vector<uint32_t> &runtime_args);
+void SetRuntimeArgs(
+    const Program &program,
+    KernelHandle kernel,
+    const std::variant<CoreCoord, CoreRange, CoreRangeSet> &core_spec,
+    const std::vector<uint32_t> &runtime_args);
 
 /**
  * Set multiple runtime arguments of a kernel at once during runtime, each mapping to a specific core. The runtime args for each core may be unique.
@@ -293,7 +303,11 @@ void SetRuntimeArgs(const Program &program, KernelHandle kernel, const std::vari
  * | core_spec    | Location of Tensix core(s) where the runtime args will be written      | const std::vector<CoreCoord> &                         | Any set of logical Tensix core coordinates on which the kernel is placed   | Yes      |
  * | runtime_args | The runtime args to be written                                         | const std::vector< vector<uint32_t> > &                | Outer vector size must be equal to size of core_spec vector                | Yes      |
  */
-void SetRuntimeArgs(const Program &program, KernelHandle kernel, const std::vector< CoreCoord > & core_spec, const std::vector< std::vector<uint32_t> > &runtime_args);
+void SetRuntimeArgs(
+    const Program &program,
+    KernelHandle kernel,
+    const std::vector<CoreCoord> &core_spec,
+    const std::vector<std::vector<uint32_t>> &runtime_args);
 
 /**
  * Set runtime args for a kernel that are sent to the specified cores using the command queue. This API must be used when Asynchronous Command Queue Mode is enabled.
@@ -308,7 +322,11 @@ void SetRuntimeArgs(const Program &program, KernelHandle kernel, const std::vect
  * | core_spec    | Location of Tensix core(s) where the runtime args will be written      | const std::variant<CoreCoord,CoreRange,CoreRangeSet> & | Any set of logical Tensix core coordinates on which the kernel is placed   | Yes      |
  * | runtime_args | The runtime args to be written                                         | std::shared_ptr<RuntimeArgs>                           |                                                                            | Yes      |
 */
-void SetRuntimeArgs(Device* device, const std::shared_ptr<Kernel> kernel, const std::variant<CoreCoord, CoreRange, CoreRangeSet> &core_spec, std::shared_ptr<RuntimeArgs> runtime_args);
+void SetRuntimeArgs(
+    Device *device,
+    const std::shared_ptr<Kernel> kernel,
+    const std::variant<CoreCoord, CoreRange, CoreRangeSet> &core_spec,
+    std::shared_ptr<RuntimeArgs> runtime_args);
 
 /**
  * Set multiple runtime arguments of a kernel using the command queue. Each core can have distinct arguments. This API must be used when Asynchronous Command Queue Mode is enabled.
@@ -322,8 +340,11 @@ void SetRuntimeArgs(Device* device, const std::shared_ptr<Kernel> kernel, const 
  * | core_spec    | Location of Tensix core(s) where the runtime args will be written      | const std::vector< CoreCoord > &                       | Any set of logical Tensix core coordinates on which the kernel is placed   | Yes      |
  * | runtime_args | The runtime args to be written                                         | const std::vector<std::shared_ptr<RuntimeArgs>>        | Outer vector size must be equal to size of core_spec vector                | Yes      |
  */
-void SetRuntimeArgs(Device* device, const std::shared_ptr<Kernel> kernel, const std::vector< CoreCoord > & core_spec, const std::vector<std::shared_ptr<RuntimeArgs>> runtime_args);
-
+void SetRuntimeArgs(
+    Device *device,
+    const std::shared_ptr<Kernel> kernel,
+    const std::vector<CoreCoord> &core_spec,
+    const std::vector<std::shared_ptr<RuntimeArgs>> runtime_args);
 
 /**
  * Set common (shared by all cores) runtime args for a kernel that are sent to all cores during runtime. This API needs to be called to update the common runtime args for the kernel.
@@ -339,7 +360,6 @@ void SetRuntimeArgs(Device* device, const std::shared_ptr<Kernel> kernel, const 
  */
 void SetCommonRuntimeArgs(const Program &program, KernelHandle kernel_id, const std::vector<uint32_t> &runtime_args);
 
-
 /**
  * Get the runtime args for a kernel.
  *
@@ -351,7 +371,7 @@ void SetCommonRuntimeArgs(const Program &program, KernelHandle kernel_id, const 
  * | kernel_id    | ID of the kernel that will receive the runtime args                    | KernelHandle (uint64_t)       |                                    | Yes      |
  * | logical_core | The location of the Tensix core where the runtime args will be written | const CoreCoord &             | Any logical Tensix core coordinate | Yes      |
  */
-RuntimeArgsData & GetRuntimeArgs(const Program &program, KernelHandle kernel_id, const CoreCoord &logical_core);
+RuntimeArgsData &GetRuntimeArgs(const Program &program, KernelHandle kernel_id, const CoreCoord &logical_core);
 
 /**
  * Get the runtime args for a kernel.
@@ -363,7 +383,7 @@ RuntimeArgsData & GetRuntimeArgs(const Program &program, KernelHandle kernel_id,
  * | program      | The program containing kernels, circular buffers, semaphores           | const Program &               |                                    | Yes      |
  * | kernel_id    | ID of the kernel that will receive the runtime args                    | KernelHandle (uint64_t)       |                                    | Yes      |
  */
-std::vector< std::vector< RuntimeArgsData > > & GetRuntimeArgs(const Program &program, KernelHandle kernel_id);
+std::vector<std::vector<RuntimeArgsData>> &GetRuntimeArgs(const Program &program, KernelHandle kernel_id);
 
 /**
  * Get the common runtime args for a kernel.
@@ -375,7 +395,7 @@ std::vector< std::vector< RuntimeArgsData > > & GetRuntimeArgs(const Program &pr
  * | program      | The program containing kernels, circular buffers, semaphores           | const Program &               |                                    | Yes      |
  * | kernel_id    | ID of the kernel that will receive the runtime args                    | KernelHandle (uint64_t)       |                                    | Yes      |
  */
-RuntimeArgsData & GetCommonRuntimeArgs(const Program &program, KernelHandle kernel_id);
+RuntimeArgsData &GetCommonRuntimeArgs(const Program &program, KernelHandle kernel_id);
 
 /**
  * Reads a buffer from the device
@@ -389,7 +409,11 @@ RuntimeArgsData & GetCommonRuntimeArgs(const Program &program, KernelHandle kern
  * | dst          | The vector where the results that are read will be stored              | vector<uint32_t> &                  |                                        | Yes      |
  * | blocking     | Whether or not this is a blocking operation                            | bool                                | Only blocking mode supported currently | Yes      |
  */
-void EnqueueReadBuffer(CommandQueue& cq, std::variant<std::reference_wrapper<Buffer>, std::shared_ptr<Buffer> > buffer, std::vector<uint32_t>& dst, bool blocking);
+void EnqueueReadBuffer(
+    CommandQueue &cq,
+    std::variant<std::reference_wrapper<Buffer>, std::shared_ptr<Buffer>> buffer,
+    std::vector<uint32_t> &dst,
+    bool blocking);
 
 /**
  * Reads a buffer from the device
@@ -403,7 +427,11 @@ void EnqueueReadBuffer(CommandQueue& cq, std::variant<std::reference_wrapper<Buf
  * | dst          | The memory where the result will be stored                             | void*                               |                                        | Yes      |
  * | blocking     | Whether or not this is a blocking operation                            | bool                                | Only blocking mode supported currently | Yes      |
  */
-void EnqueueReadBuffer(CommandQueue& cq, std::variant<std::reference_wrapper<Buffer>, std::shared_ptr<Buffer> > buffer, void * dst, bool blocking);
+void EnqueueReadBuffer(
+    CommandQueue &cq,
+    std::variant<std::reference_wrapper<Buffer>, std::shared_ptr<Buffer>> buffer,
+    void *dst,
+    bool blocking);
 
 /**
  * Writes a buffer to the device
@@ -417,7 +445,11 @@ void EnqueueReadBuffer(CommandQueue& cq, std::variant<std::reference_wrapper<Buf
  * | src          | The vector we are writing to the device                                | vector<uint32_t> &                  |                                    | Yes      |
  * | blocking     | Whether or not this is a blocking operation                            | bool                                |                                    | Yes      |
  */
-void EnqueueWriteBuffer(CommandQueue& cq, std::variant<std::reference_wrapper<Buffer>, std::shared_ptr<Buffer> > buffer, std::vector<uint32_t>& src, bool blocking);
+void EnqueueWriteBuffer(
+    CommandQueue &cq,
+    std::variant<std::reference_wrapper<Buffer>, std::shared_ptr<Buffer>> buffer,
+    std::vector<uint32_t> &src,
+    bool blocking);
 
 /**
  * Writes a buffer to the device
@@ -431,7 +463,11 @@ void EnqueueWriteBuffer(CommandQueue& cq, std::variant<std::reference_wrapper<Bu
  * | src          | The memory we are writing to the device                                | HostDataType                        |                                    | Yes      |
  * | blocking     | Whether or not this is a blocking operation                            | bool                                |                                    | Yes      |
  */
-void EnqueueWriteBuffer(CommandQueue& cq, std::variant<std::reference_wrapper<Buffer>, std::shared_ptr<Buffer> > buffer, HostDataType src, bool blocking);
+void EnqueueWriteBuffer(
+    CommandQueue &cq,
+    std::variant<std::reference_wrapper<Buffer>, std::shared_ptr<Buffer>> buffer,
+    HostDataType src,
+    bool blocking);
 
 /**
  * Writes a program to the device and launches it
@@ -444,7 +480,8 @@ void EnqueueWriteBuffer(CommandQueue& cq, std::variant<std::reference_wrapper<Bu
  * | program      | The program that will be executed on the device that cq is bound to    | Program &                          |                                    | Yes      |
  * | blocking     | Whether or not this is a blocking operation                            | bool                               |                                    | Yes      |
  */
-void EnqueueProgram(CommandQueue& cq, std::variant<std::reference_wrapper<Program>, std::shared_ptr<Program> > program, bool blocking);
+void EnqueueProgram(
+    CommandQueue &cq, std::variant<std::reference_wrapper<Program>, std::shared_ptr<Program>> program, bool blocking);
 
 /**
  * Blocks until all previously dispatched commands on the device have completed
@@ -455,7 +492,7 @@ void EnqueueProgram(CommandQueue& cq, std::variant<std::reference_wrapper<Progra
  * |--------------|------------------------------------------------------------------------|-------------------------------|------------------------------------|----------|
  * | cq           | The command queue object which dispatches the command to the hardware  | CommandQueue &                |                                    | Yes      |
  */
-void Finish(CommandQueue& cq);
+void Finish(CommandQueue &cq);
 
 /**
  * Begins capture on a trace, when the trace is in capture mode all programs pushed into the trace queue will have their execution delayed until the trace is instantiated and enqueued.
@@ -551,7 +588,7 @@ void DumpDeviceProfileResults(Device *device, const Program &program);
  * | cq           | The command queue object which dispatches the command to the hardware  | CommandQueue &                |                                    | Yes      |
  * | event        | An event that will be populated by this function, and inserted in CQ   | std::shared_ptr<Event>        |                                    | Yes      |
  */
-void EnqueueRecordEvent(CommandQueue& cq, std::shared_ptr<Event> event);
+void EnqueueRecordEvent(CommandQueue &cq, const std::shared_ptr<Event> &event);
 
 /**
  * Enqueues a command on the device for a given CQ (non-blocking). The command on device will block and wait for completion of the specified event (which may be in another CQ).
@@ -562,7 +599,7 @@ void EnqueueRecordEvent(CommandQueue& cq, std::shared_ptr<Event> event);
  * |              | and waits for the event to complete.                                   |                               |                                    |          |
  * | event        | The event object that this CQ will wait on for completion.             | std::shared_ptr<Event>        |                                    | Yes      |
  */
-void EnqueueWaitForEvent(CommandQueue& cq, std::shared_ptr<Event> event);
+void EnqueueWaitForEvent(CommandQueue &cq, const std::shared_ptr<Event> &event);
 
 /**
  * Blocking function for host to synchronize (wait) on an event completion on device.
@@ -571,7 +608,7 @@ void EnqueueWaitForEvent(CommandQueue& cq, std::shared_ptr<Event> event);
  * |--------------|------------------------------------------------------------------------|-------------------------------|------------------------------------|----------|
  * | event        | The event object that host will wait on for completion.                | std::shared_ptr<Event>        |                                    | Yes      |
  */
-void EventSynchronize(std::shared_ptr<Event> event);
+void EventSynchronize(const std::shared_ptr<Event> &event);
 
 /**
  * Host will query an event for completion status on device.
@@ -580,7 +617,7 @@ void EventSynchronize(std::shared_ptr<Event> event);
  * |--------------|------------------------------------------------------------------------|-------------------------------|------------------------------------|----------|
  * | event        | The event object that host will query for completion.                  | std::shared_ptr<Event>        |                                    | Yes      |
  */
-bool EventQuery(std::shared_ptr<Event> event);
+bool EventQuery(const std::shared_ptr<Event> &event);
 
 /**
  * Synchronize the device with host by waiting for all operations to complete.

--- a/tt_metal/impl/buffers/buffer.hpp
+++ b/tt_metal/impl/buffers/buffer.hpp
@@ -175,7 +175,7 @@ class Buffer {
 
     uint32_t size() const { return static_cast<uint32_t>(size_); }
 
-    void set_size(uint64_t size) { size_ = size; }
+    void set_size(uint64_t size) { size_ = size; this->buffer_page_mapping_ = nullptr; }
     // Returns address of buffer in the first bank
     uint32_t address() const { return static_cast<uint32_t>(address_); }
 
@@ -188,6 +188,7 @@ class Buffer {
     void set_page_size(uint64_t page_size) {
         TT_FATAL(size_ % page_size == 0, "buffer size must be divisible by new page size");
         page_size_ = page_size;
+        this->buffer_page_mapping_ = nullptr;
     }
 
     uint32_t num_dev_pages() const {
@@ -247,6 +248,7 @@ class Buffer {
 
     void set_shard_spec(const ShardSpecBuffer& shard_spec) {
         this->shard_parameters_ = shard_spec;
+        this->buffer_page_mapping_ = nullptr;
     }
 
     uint32_t num_cores() const {
@@ -256,6 +258,8 @@ class Buffer {
             return this->shard_spec().tensor_shard_spec.grid.num_cores();
         }
     }
+
+    const std::shared_ptr<const BufferPageMapping>& get_buffer_page_mapping();
 
    private:
     virtual void allocate();
@@ -272,6 +276,7 @@ class Buffer {
     BufferType buffer_type_;
     TensorMemoryLayout buffer_layout_;
     std::optional<ShardSpecBuffer> shard_parameters_;
+    std::shared_ptr<const BufferPageMapping> buffer_page_mapping_;
    protected:
     std::optional<bool> bottom_up_;
 };

--- a/tt_metal/impl/dispatch/command_queue.cpp
+++ b/tt_metal/impl/dispatch/command_queue.cpp
@@ -240,8 +240,8 @@ void EnqueueWriteShardedBufferCommand::add_dispatch_write(HugepageDeviceCommand&
 
 void EnqueueWriteShardedBufferCommand::add_buffer_data(HugepageDeviceCommand& command_sequence) {
     uint32_t data_size_bytes = this->pages_to_write * this->padded_page_size;
-    if (this->buffer_page_mapping.has_value()) {
-        const auto& page_mapping = this->buffer_page_mapping.value();
+    if (this->buffer_page_mapping) {
+        const auto& page_mapping = *this->buffer_page_mapping;
         uint8_t* dst = command_sequence.reserve_space<uint8_t*, true>(data_size_bytes);
         // TODO: Expose getter for cmd_write_offsetB?
         uint32_t dst_offset = dst - (uint8_t*)command_sequence.data();
@@ -1147,7 +1147,8 @@ void EnqueueProgramCommand::assemble_device_commands(
         }
 
         // All Previous Cmds Up to This Point Go Into the Kernel Config Buffer
-        cached_program_command_sequence.program_config_buffer_data_size_bytes = program_command_sequence.write_offset_bytes();
+        cached_program_command_sequence.program_config_buffer_data_size_bytes =
+            program_command_sequence.write_offset_bytes();
 
         // Program Binaries
         for (const auto& kernel_bins_unicast_cmd : kernel_bins_unicast_cmds) {
@@ -1329,7 +1330,8 @@ void EnqueueProgramCommand::process() {
 
     uint32_t program_fetch_size_bytes = cached_program_command_sequence.program_command_sequence.size_bytes();
 
-    uint32_t program_config_buffer_data_size_bytes = cached_program_command_sequence.program_config_buffer_data_size_bytes;
+    uint32_t program_config_buffer_data_size_bytes =
+        cached_program_command_sequence.program_config_buffer_data_size_bytes;
 
     uint32_t program_rem_fetch_size_bytes = program_fetch_size_bytes - program_config_buffer_data_size_bytes;
 
@@ -1758,7 +1760,7 @@ void HWCommandQueue::enqueue_command(T& command, bool blocking) {
     }
 }
 
-void HWCommandQueue::enqueue_read_buffer(std::shared_ptr<Buffer> buffer, void* dst, bool blocking) {
+void HWCommandQueue::enqueue_read_buffer(std::shared_ptr<Buffer>& buffer, void* dst, bool blocking) {
     this->enqueue_read_buffer(*buffer, dst, blocking);
 }
 
@@ -1778,26 +1780,23 @@ void HWCommandQueue::enqueue_read_buffer(Buffer& buffer, void* dst, bool blockin
     uint32_t src_page_index = 0;
 
     if (is_sharded(buffer.buffer_layout())) {
-        bool width_split = buffer.shard_spec().shape_in_pages()[1] != buffer.shard_spec().tensor2d_shape[1];
-        std::optional<BufferPageMapping> buffer_page_mapping = std::nullopt;
-        if (width_split) {
-            buffer_page_mapping = generate_buffer_page_mapping(buffer);
-        }
+        const bool width_split = buffer.shard_spec().shape_in_pages()[1] != buffer.shard_spec().tensor2d_shape[1];
+        const auto& buffer_page_mapping = width_split ? buffer.get_buffer_page_mapping() : nullptr;
+
         // Note that the src_page_index is the device page idx, not the host page idx
         // Since we read core by core we are reading the device pages sequentially
-        const auto& cores = width_split ? buffer_page_mapping.value().all_cores_
+        const auto& cores = width_split ? buffer_page_mapping->all_cores_
                                         : corerange_to_cores(
                                               buffer.shard_spec().grid(),
                                               buffer.num_cores(),
                                               buffer.shard_spec().orientation() == ShardOrientation::ROW_MAJOR);
         uint32_t num_total_pages = buffer.num_pages();
         uint32_t max_pages_per_shard = buffer.shard_spec().size();
-        bool linear_page_copy = true;
         for (uint32_t core_id = 0; core_id < buffer.num_cores(); ++core_id) {
             uint32_t num_pages_to_read;
             if (width_split) {
                 num_pages_to_read =
-                    buffer_page_mapping.value().core_shard_shape_[core_id][0] * buffer.shard_spec().shape_in_pages()[1];
+                    buffer_page_mapping->core_shard_shape_[core_id][0] * buffer.shard_spec().shape_in_pages()[1];
             } else {
                 num_pages_to_read = std::min(num_total_pages, max_pages_per_shard);
                 num_total_pages -= num_pages_to_read;
@@ -1809,8 +1808,8 @@ void HWCommandQueue::enqueue_read_buffer(Buffer& buffer, void* dst, bool blockin
             }
             if (num_pages_to_read > 0) {
                 if (width_split) {
-                    uint32_t host_page = buffer_page_mapping.value().core_host_page_indices_[core_id][0];
-                    src_page_index = buffer_page_mapping.value().host_page_to_dev_page_mapping_[host_page];
+                    uint32_t host_page = buffer_page_mapping->core_host_page_indices_[core_id][0];
+                    src_page_index = buffer_page_mapping->host_page_to_dev_page_mapping_[host_page];
                     unpadded_dst_offset = host_page * buffer.page_size();
                 } else {
                     unpadded_dst_offset = src_page_index * buffer.page_size();
@@ -1829,7 +1828,7 @@ void HWCommandQueue::enqueue_read_buffer(Buffer& buffer, void* dst, bool blockin
                     src_page_index,
                     num_pages_to_read);
 
-                this->issued_completion_q_reads.push(detail::CompletionReaderVariant(
+                this->issued_completion_q_reads.push(std::make_shared<detail::CompletionReaderVariant>(
                     std::in_place_type<detail::ReadBufferDescriptor>,
                     buffer.buffer_layout(),
                     buffer.page_size(),
@@ -1838,8 +1837,7 @@ void HWCommandQueue::enqueue_read_buffer(Buffer& buffer, void* dst, bool blockin
                     unpadded_dst_offset,
                     num_pages_to_read,
                     src_page_index,
-                    width_split ? (*buffer_page_mapping).dev_page_to_host_page_mapping_
-                                : vector<std::optional<uint32_t>>()));
+                    buffer_page_mapping));
 
                 src_page_index += num_pages_to_read;
                 this->enqueue_command(command, false);
@@ -1862,7 +1860,7 @@ void HWCommandQueue::enqueue_read_buffer(Buffer& buffer, void* dst, bool blockin
             src_page_index,
             pages_to_read);
 
-        this->issued_completion_q_reads.push(detail::CompletionReaderVariant(
+        this->issued_completion_q_reads.push(std::make_shared<detail::CompletionReaderVariant>(
             std::in_place_type<detail::ReadBufferDescriptor>,
             buffer.buffer_layout(),
             buffer.page_size(),
@@ -1877,9 +1875,7 @@ void HWCommandQueue::enqueue_read_buffer(Buffer& buffer, void* dst, bool blockin
 }
 
 void HWCommandQueue::enqueue_write_buffer(
-    std::variant<std::reference_wrapper<Buffer>, std::shared_ptr<const Buffer>> buffer,
-    HostDataType src,
-    bool blocking) {
+    std::variant<std::reference_wrapper<Buffer>, std::shared_ptr<Buffer>> buffer, HostDataType src, bool blocking) {
     // Top level API to accept different variants for buffer and src
     // For shared pointer variants, object lifetime is guaranteed at least till the end of this function
     std::visit(
@@ -1889,13 +1885,13 @@ void HWCommandQueue::enqueue_write_buffer(
                 [this, &buffer, &blocking, &data](auto&& b) {
                     using type_buf = std::decay_t<decltype(b)>;
                     if constexpr (std::is_same_v<T, const void*>) {
-                        if constexpr (std::is_same_v<type_buf, std::shared_ptr<const Buffer>>) {
+                        if constexpr (std::is_same_v<type_buf, std::shared_ptr<Buffer>>) {
                             this->enqueue_write_buffer(*b, data, blocking);
                         } else if constexpr (std::is_same_v<type_buf, std::reference_wrapper<Buffer>>) {
                             this->enqueue_write_buffer(b.get(), data, blocking);
                         }
                     } else {
-                        if constexpr (std::is_same_v<type_buf, std::shared_ptr<const Buffer>>) {
+                        if constexpr (std::is_same_v<type_buf, std::shared_ptr<Buffer>>) {
                             this->enqueue_write_buffer(*b, data.get()->data(), blocking);
                         } else if constexpr (std::is_same_v<type_buf, std::reference_wrapper<Buffer>>) {
                             this->enqueue_write_buffer(b.get(), data.get()->data(), blocking);
@@ -1911,7 +1907,7 @@ CoreType HWCommandQueue::get_dispatch_core_type() {
     return dispatch_core_manager::instance().get_dispatch_core_type(device->id());
 }
 
-void HWCommandQueue::enqueue_write_buffer(const Buffer& buffer, const void* src, bool blocking) {
+void HWCommandQueue::enqueue_write_buffer(Buffer& buffer, const void* src, bool blocking) {
     ZoneScopedN("HWCommandQueue_write_buffer");
     TT_FATAL(!this->manager.get_bypass_mode(), "Enqueue Write Buffer cannot be used with tracing");
 
@@ -1927,11 +1923,9 @@ void HWCommandQueue::enqueue_write_buffer(const Buffer& buffer, const void* src,
 
     if (is_sharded(buffer.buffer_layout())) {
         const bool width_split = buffer.shard_spec().shape_in_pages()[1] != buffer.shard_spec().tensor2d_shape[1];
-        std::optional<BufferPageMapping> buffer_page_mapping = std::nullopt;
-        if (width_split) {
-            buffer_page_mapping = generate_buffer_page_mapping(buffer);
-        }
-        const auto& cores = width_split ? buffer_page_mapping.value().all_cores_
+        const auto& buffer_page_mapping = width_split ? buffer.get_buffer_page_mapping() : nullptr;
+
+        const auto& cores = width_split ? buffer_page_mapping->all_cores_
                                         : corerange_to_cores(
                                               buffer.shard_spec().grid(),
                                               buffer.num_cores(),
@@ -1951,12 +1945,12 @@ void HWCommandQueue::enqueue_write_buffer(const Buffer& buffer, const void* src,
             uint32_t num_pages;
             if (width_split) {
                 num_pages =
-                    buffer_page_mapping.value().core_shard_shape_[core_id][0] * buffer.shard_spec().shape_in_pages()[1];
+                    buffer_page_mapping->core_shard_shape_[core_id][0] * buffer.shard_spec().shape_in_pages()[1];
                 if (num_pages == 0) {
                     continue;
                 }
-                dst_page_index = buffer_page_mapping.value().host_page_to_dev_page_mapping_
-                                     [buffer_page_mapping.value().core_host_page_indices_[core_id][0]];
+                dst_page_index =
+                    buffer_page_mapping->host_page_to_dev_page_mapping_[buffer_page_mapping->core_host_page_indices_[core_id][0]];
             } else {
                 num_pages = std::min(num_total_pages, max_pages_per_shard);
                 num_total_pages -= num_pages;
@@ -2041,7 +2035,8 @@ void HWCommandQueue::enqueue_write_buffer(const Buffer& buffer, const void* src,
 
         uint32_t num_full_pages_written = 0;
         while (total_pages_to_write > 0) {
-            uint32_t data_offsetB = CQ_PREFETCH_CMD_BARE_MIN_SIZE; // data appended after CQ_PREFETCH_CMD_RELAY_INLINE + CQ_DISPATCH_CMD_WRITE_PAGED
+            uint32_t data_offsetB = CQ_PREFETCH_CMD_BARE_MIN_SIZE;  // data appended after CQ_PREFETCH_CMD_RELAY_INLINE
+                                                                    // + CQ_DISPATCH_CMD_WRITE_PAGED
             bool issue_wait =
                 (dst_page_index == 0 and
                  bank_base_address == buffer.address());  // only stall for the first write of the buffer
@@ -2186,7 +2181,7 @@ void HWCommandQueue::enqueue_program(Program& program, bool blocking) {
         expected_workers_completed);
 }
 
-void HWCommandQueue::enqueue_record_event(std::shared_ptr<Event> event, bool clear_count) {
+void HWCommandQueue::enqueue_record_event(const std::shared_ptr<Event>& event, bool clear_count) {
     ZoneScopedN("HWCommandQueue_enqueue_record_event");
 
     TT_FATAL(!this->manager.get_bypass_mode(), "Enqueue Record Event cannot be used with tracing");
@@ -2214,11 +2209,11 @@ void HWCommandQueue::enqueue_record_event(std::shared_ptr<Event> event, bool cle
         this->expected_num_workers_completed = 0;
     }
     this->issued_completion_q_reads.push(
-        detail::CompletionReaderVariant(std::in_place_type<detail::ReadEventDescriptor>, event->event_id));
+        std::make_shared<detail::CompletionReaderVariant>(std::in_place_type<detail::ReadEventDescriptor>, event->event_id));
     this->increment_num_entries_in_completion_q();
 }
 
-void HWCommandQueue::enqueue_wait_for_event(std::shared_ptr<Event> sync_event, bool clear_count) {
+void HWCommandQueue::enqueue_wait_for_event(const std::shared_ptr<Event>& sync_event, bool clear_count) {
     ZoneScopedN("HWCommandQueue_enqueue_wait_for_event");
 
     auto command = EnqueueWaitForEventCommand(this->id, this->device, this->manager, *sync_event, clear_count);
@@ -2248,9 +2243,8 @@ void HWCommandQueue::enqueue_trace(const uint32_t trace_id, bool blocking) {
 
 void HWCommandQueue::copy_into_user_space(
     const detail::ReadBufferDescriptor& read_buffer_descriptor, chip_id_t mmio_device_id, uint16_t channel) {
-    const auto& [buffer_layout, page_size, padded_page_size, dev_page_to_host_page_mapping, dst, dst_offset, num_pages_read, cur_dev_page_id] =
+    const auto& [buffer_layout, page_size, padded_page_size, buffer_page_mapping, dst, dst_offset, num_pages_read, cur_dev_page_id] =
         read_buffer_descriptor;
-
     uint32_t padded_num_bytes = (num_pages_read * padded_page_size) + sizeof(CQDispatchCmd);
     uint32_t contig_dst_offset = dst_offset;
     uint32_t remaining_bytes_to_read = padded_num_bytes;
@@ -2264,14 +2258,12 @@ void HWCommandQueue::copy_into_user_space(
     uint32_t pad_size_bytes = padded_page_size - page_size;
 
     while (remaining_bytes_to_read != 0) {
-        this->manager.completion_queue_wait_front(this->id, this->exit_condition);
+        uint32_t completion_queue_write_ptr_and_toggle = this->manager.completion_queue_wait_front(this->id, this->exit_condition);
 
         if (this->exit_condition) {
             break;
         }
 
-        uint32_t completion_queue_write_ptr_and_toggle =
-            get_cq_completion_wr_ptr<true>(this->device->id(), this->id, this->manager.get_cq_size());
         uint32_t completion_q_write_ptr = (completion_queue_write_ptr_and_toggle & 0x7fffffff) << 4;
         uint32_t completion_q_write_toggle = completion_queue_write_ptr_and_toggle >> (31);
         uint32_t completion_q_read_ptr = this->manager.get_completion_queue_read_ptr(this->id);
@@ -2289,12 +2281,11 @@ void HWCommandQueue::copy_into_user_space(
 
         // completion queue write ptr on device could have wrapped but our read ptr is lagging behind
         uint32_t bytes_xfered = std::min(remaining_bytes_to_read, bytes_avail_in_completion_queue);
-        uint32_t num_pages_xfered =
-            (bytes_xfered + dispatch_constants::TRANSFER_PAGE_SIZE - 1) / dispatch_constants::TRANSFER_PAGE_SIZE;
+        uint32_t num_pages_xfered = div_up(bytes_xfered, dispatch_constants::TRANSFER_PAGE_SIZE);
 
         remaining_bytes_to_read -= bytes_xfered;
 
-        if (dev_page_to_host_page_mapping.empty()) {
+        if (buffer_page_mapping == nullptr) {
             void* contiguous_dst = (void*)(uint64_t(dst) + contig_dst_offset);
             if (page_size == padded_page_size) {
                 uint32_t data_bytes_xfered = bytes_xfered - offset_in_completion_q_data;
@@ -2391,7 +2382,7 @@ void HWCommandQueue::copy_into_user_space(
                 } else if (src_offset_bytes + padded_page_size >= bytes_xfered) {
                     // Case 2: Last page of data that was popped off the completion queue
                     // Don't need to compute src_offset_increment since this is end of loop
-                    host_page_id = dev_page_to_host_page_mapping[dev_page_id];
+                    host_page_id = buffer_page_mapping->dev_page_to_host_page_mapping_[dev_page_id];
                     uint32_t num_bytes_remaining = bytes_xfered - src_offset_bytes;
                     num_bytes_to_copy = std::min(num_bytes_remaining, page_size);
                     remaining_bytes_of_nonaligned_page = page_size - num_bytes_to_copy;
@@ -2401,17 +2392,17 @@ void HWCommandQueue::copy_into_user_space(
                         dev_page_id++;
                     }
                     if (host_page_id.has_value()) {
-                        dst_offset_bytes = host_page_id.value() * page_size;
+                        dst_offset_bytes = *host_page_id * page_size;
                     } else {
                         src_offset_bytes += src_offset_increment;
                         continue;
                     }
                 } else {
                     num_bytes_to_copy = page_size;
-                    host_page_id = dev_page_to_host_page_mapping[dev_page_id];
+                    host_page_id = buffer_page_mapping->dev_page_to_host_page_mapping_[dev_page_id];
                     dev_page_id++;
                     if (host_page_id.has_value()) {
-                        dst_offset_bytes = host_page_id.value() * page_size;
+                        dst_offset_bytes = *host_page_id * page_size;
                     } else {
                         src_offset_bytes += src_offset_increment;
                         continue;
@@ -2478,7 +2469,7 @@ void HWCommandQueue::read_completion_queue() {
                                 mmio_device_id,
                                 channel);
                             uint32_t event_completed =
-                                dispatch_cmd_and_event.at(sizeof(CQDispatchCmd) / sizeof(uint32_t));
+                                dispatch_cmd_and_event[sizeof(CQDispatchCmd) / sizeof(uint32_t)];
 
                             TT_ASSERT(
                                 event_completed == read_descriptor.event_id,
@@ -2718,6 +2709,8 @@ void EnqueueReadBuffer(
                 dst.resize(b.get().page_size() * b.get().num_pages() / sizeof(uint32_t));
             } else if constexpr (std::is_same_v<T, std::shared_ptr<Buffer>>) {
                 dst.resize(b->page_size() * b->num_pages() / sizeof(uint32_t));
+            } else {
+                TT_THROW("Invalid buffer type");
             }
         },
         buffer);
@@ -2776,15 +2769,7 @@ void EnqueueWriteBufferImpl(
     std::variant<std::reference_wrapper<Buffer>, std::shared_ptr<Buffer>> buffer,
     HostDataType src,
     bool blocking) {
-    std::visit(
-        [&cq, src, blocking](auto&& b) {
-            using T = std::decay_t<decltype(b)>;
-            if constexpr (
-                std::is_same_v<T, std::reference_wrapper<Buffer>> || std::is_same_v<T, std::shared_ptr<Buffer>>) {
-                cq.hw_command_queue().enqueue_write_buffer(b, src, blocking);
-            }
-        },
-        buffer);
+    cq.hw_command_queue().enqueue_write_buffer(buffer, src, blocking);
 }
 
 void EnqueueProgram(
@@ -2823,7 +2808,7 @@ void EnqueueProgramImpl(
         program);
 }
 
-void EnqueueRecordEvent(CommandQueue& cq, std::shared_ptr<Event> event) {
+void EnqueueRecordEvent(CommandQueue& cq, const std::shared_ptr<Event>& event) {
     detail::DispatchStateCheck(true);
     cq.run_command(CommandInterface{
         .type = EnqueueCommandType::ENQUEUE_RECORD_EVENT,
@@ -2832,11 +2817,11 @@ void EnqueueRecordEvent(CommandQueue& cq, std::shared_ptr<Event> event) {
     });
 }
 
-void EnqueueRecordEventImpl(CommandQueue& cq, std::shared_ptr<Event> event) {
+void EnqueueRecordEventImpl(CommandQueue& cq, const std::shared_ptr<Event>& event) {
     cq.hw_command_queue().enqueue_record_event(event);
 }
 
-void EnqueueWaitForEvent(CommandQueue& cq, std::shared_ptr<Event> event) {
+void EnqueueWaitForEvent(CommandQueue& cq, const std::shared_ptr<Event>& event) {
     detail::DispatchStateCheck(true);
     cq.run_command(CommandInterface{
         .type = EnqueueCommandType::ENQUEUE_WAIT_FOR_EVENT,
@@ -2845,7 +2830,7 @@ void EnqueueWaitForEvent(CommandQueue& cq, std::shared_ptr<Event> event) {
     });
 }
 
-void EnqueueWaitForEventImpl(CommandQueue& cq, std::shared_ptr<Event> event) {
+void EnqueueWaitForEventImpl(CommandQueue& cq, const std::shared_ptr<Event>& event) {
     event->wait_until_ready();  // Block until event populated. Worker thread.
     log_trace(
         tt::LogMetal,
@@ -2858,7 +2843,7 @@ void EnqueueWaitForEventImpl(CommandQueue& cq, std::shared_ptr<Event> event) {
     cq.hw_command_queue().enqueue_wait_for_event(event);
 }
 
-void EventSynchronize(std::shared_ptr<Event> event) {
+void EventSynchronize(const std::shared_ptr<Event>& event) {
     detail::DispatchStateCheck(true);
     event->wait_until_ready();  // Block until event populated. Parent thread.
     log_trace(
@@ -2880,7 +2865,7 @@ void EventSynchronize(std::shared_ptr<Event> event) {
     }
 }
 
-bool EventQuery(std::shared_ptr<Event> event) {
+bool EventQuery(const std::shared_ptr<Event>& event) {
     detail::DispatchStateCheck(true);
     event->wait_until_ready();  // Block until event populated. Parent thread.
     bool event_completed = event->device->sysmem_manager().get_last_completed_event(event->cq_id) >= event->event_id;

--- a/tt_metal/impl/dispatch/command_queue.hpp
+++ b/tt_metal/impl/dispatch/command_queue.hpp
@@ -241,7 +241,7 @@ class EnqueueWriteShardedBufferCommand : public EnqueueWriteBufferCommand {
     void add_dispatch_write(HugepageDeviceCommand& command) override;
     void add_buffer_data(HugepageDeviceCommand& command) override;
 
-    const std::optional<BufferPageMapping>& buffer_page_mapping;
+    const std::shared_ptr<const BufferPageMapping>& buffer_page_mapping;
     const CoreCoord core;
 
    public:
@@ -255,7 +255,7 @@ class EnqueueWriteShardedBufferCommand : public EnqueueWriteBufferCommand {
         bool issue_wait,
         uint32_t expected_num_workers_completed,
         uint32_t bank_base_address,
-        const std::optional<BufferPageMapping>& buffer_page_mapping,
+        const std::shared_ptr<const BufferPageMapping>& buffer_page_mapping,
         const CoreCoord& core,
         uint32_t padded_page_size,
         uint32_t dst_page_index = 0,
@@ -429,7 +429,7 @@ struct ReadBufferDescriptor {
     TensorMemoryLayout buffer_layout;
     uint32_t page_size;
     uint32_t padded_page_size;
-    std::vector<std::optional<uint32_t>> dev_page_to_host_page_mapping;
+    std::shared_ptr<const BufferPageMapping> buffer_page_mapping;
     void* dst;
     uint32_t dst_offset;
     uint32_t num_pages_read;
@@ -443,11 +443,11 @@ struct ReadBufferDescriptor {
         uint32_t dst_offset,
         uint32_t num_pages_read,
         uint32_t cur_dev_page_id,
-        const std::vector<std::optional<uint32_t>>& dev_page_to_host_page_mapping = {}) :
+        const std::shared_ptr<const BufferPageMapping>& buffer_page_mapping = nullptr) :
         buffer_layout(buffer_layout),
         page_size(page_size),
         padded_page_size(padded_page_size),
-        dev_page_to_host_page_mapping(dev_page_to_host_page_mapping),
+        buffer_page_mapping(buffer_page_mapping),
         dst(dst),
         dst_offset(dst_offset),
         num_pages_read(num_pages_read),
@@ -538,16 +538,14 @@ class HWCommandQueue {
     template <typename T>
     void enqueue_command(T& command, bool blocking);
 
-    void enqueue_read_buffer(std::shared_ptr<Buffer> buffer, void* dst, bool blocking);
+    void enqueue_read_buffer(std::shared_ptr<Buffer>& buffer, void* dst, bool blocking);
     void enqueue_read_buffer(Buffer& buffer, void* dst, bool blocking);
     void enqueue_write_buffer(
-        std::variant<std::reference_wrapper<Buffer>, std::shared_ptr<const Buffer>> buffer,
-        HostDataType src,
-        bool blocking);
-    void enqueue_write_buffer(const Buffer& buffer, const void* src, bool blocking);
+        std::variant<std::reference_wrapper<Buffer>, std::shared_ptr<Buffer>> buffer, HostDataType src, bool blocking);
+    void enqueue_write_buffer(Buffer& buffer, const void* src, bool blocking);
     void enqueue_program(Program& program, bool blocking);
-    void enqueue_record_event(std::shared_ptr<Event> event, bool clear_count = false);
-    void enqueue_wait_for_event(std::shared_ptr<Event> sync_event, bool clear_count = false);
+    void enqueue_record_event(const std::shared_ptr<Event>& event, bool clear_count = false);
+    void enqueue_wait_for_event(const std::shared_ptr<Event>& sync_event, bool clear_count = false);
     void enqueue_trace(const uint32_t trace_id, bool blocking);
     void finish();
     void terminate();
@@ -571,10 +569,10 @@ class HWCommandQueue {
     friend void EnqueueAllocateBufferImpl(AllocBufferMetadata alloc_md);
     friend void EnqueueDeallocateBufferImpl(AllocBufferMetadata alloc_md);
     friend void EnqueueGetBufferAddrImpl(void* dst_buf_addr, const Buffer* buffer);
-    friend void EnqueueRecordEventImpl(CommandQueue& cq, std::shared_ptr<Event> event);
-    friend void EnqueueWaitForEventImpl(CommandQueue& cq, std::shared_ptr<Event> event);
+    friend void EnqueueRecordEventImpl(CommandQueue& cq, const std::shared_ptr<Event>& event);
+    friend void EnqueueWaitForEventImpl(CommandQueue& cq, const std::shared_ptr<Event>& event);
     friend void FinishImpl(CommandQueue& cq);
-    friend void EnqueueRecordEvent(CommandQueue& cq, std::shared_ptr<Event> event);
+    friend void EnqueueRecordEvent(CommandQueue& cq, const std::shared_ptr<Event>& event);
     friend class CommandQueue;
     friend class Device;
 };

--- a/tt_metal/impl/dispatch/command_queue_interface.hpp
+++ b/tt_metal/impl/dispatch/command_queue_interface.hpp
@@ -613,7 +613,7 @@ class SystemMemoryManager {
         );
     }
 
-    void completion_queue_wait_front(const uint8_t cq_id, volatile bool &exit_condition) const {
+    uint32_t completion_queue_wait_front(const uint8_t cq_id, volatile bool &exit_condition) const {
         uint32_t write_ptr_and_toggle;
         uint32_t write_ptr;
         uint32_t write_toggle;
@@ -625,6 +625,7 @@ class SystemMemoryManager {
             write_toggle = write_ptr_and_toggle >> 31;
         } while (cq_interface.completion_fifo_rd_ptr == write_ptr and
                  cq_interface.completion_fifo_rd_toggle == write_toggle and not exit_condition);
+        return write_ptr_and_toggle;
     }
 
     void send_completion_queue_read_ptr(const uint8_t cq_id) const {


### PR DESCRIPTION
Cache buffer_page_mapping in buffer object after generating for the first time to minimize regeneration
Use shared ptr/references to reduce copies

### Problem description
When reusing sharded tensors for R/W, we constantly regenerate the buffer_page_mapping object, which is expensive. 

### What's changed
Cache the generated buffer_page_mapping into the tensor's buffer to minimize regeneration on host. We store as a shared_ptr so that we can do a cheaper copy of the ptr when passing this to the completion reader thread, as opposed to copying needed vectors/members. Updating ttnn usages of the old generation fn to the get fn will happen in a separate PR so that reshard of the input will also use the cached object. Also update some shared ptrs to be passed by reference to minimize atomics that occur when passing by value/copying, still quite a few places that can be updated to pass by reference left.

### Checklist
- [x] Post commit CI passes
- [x] Blackhole Post commit (if applicable)
- [x] Model regression CI testing passes (if applicable)
- [x] New/Existing tests provide coverage for changes
