### PR TITLE
Proposal :: constraints & l1 api

### DIFF
--- a/tests/ttnn/unit_tests/gtests/CMakeLists.txt
+++ b/tests/ttnn/unit_tests/gtests/CMakeLists.txt
@@ -2,6 +2,7 @@
 set(TTNN_UNIT_TESTS_SRC
     ${CMAKE_CURRENT_SOURCE_DIR}/test_add.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/test_graph_add.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/test_mlir_interface.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/test_repeat_interleave.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/test_async_runtime.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/test_multiprod_queue.cpp

--- a/tests/ttnn/unit_tests/gtests/test_mlir_interface.cpp
+++ b/tests/ttnn/unit_tests/gtests/test_mlir_interface.cpp
@@ -1,0 +1,235 @@
+// SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "common/constants.hpp"
+#include "gtest/gtest.h"
+#include "impl/event/event.hpp"
+#include "impl/program/program.hpp"
+#include "tt_metal/common/logger.hpp"
+#include "tests/tt_metal/tt_metal/unit_tests_common/common/common_fixture.hpp"
+#include "ttnn/device.hpp"
+#include "ttnn/operations/eltwise/binary/binary.hpp"
+#include "ttnn/operations/eltwise/binary/binary_constraints.hpp"
+#include "ttnn/operations/eltwise/binary/binary_l1_interface.hpp"
+#include "ttnn/operations/core/core.hpp"
+#include "ttnn/operations/creation.hpp"
+#include "ttnn/operations/normalization/softmax/softmax.hpp"
+#include "ttnn/operations/reduction/generic/generic_reductions.hpp"
+#include "ttnn/tensor/tensor.hpp"
+#include "ttnn/types.hpp"
+#include "ttnn_test_fixtures.hpp"
+
+#include "ttnn/tensor/types.hpp"
+
+#include "ttnn/graph/graph_processor.hpp"
+#include "ttnn/graph/graph_trace_utils.hpp"
+#include "ttnn/graph/graph_operation_queries.hpp"
+
+#include "ttnn/tensor/types.hpp"
+
+#include <cstdint>
+#include <functional>
+#include <optional>
+#include <string>
+#include <tuple>
+#include <variant>
+#include <vector>
+
+namespace ttnn {
+namespace operations {
+namespace binary {
+namespace test {
+
+struct InputShapeTestParam {
+    ttnn::types::Shape shape;
+    tt::tt_metal::MemoryConfig memory_config;
+    tt::tt_metal::DataType data_type = tt::tt_metal::DataType::BFLOAT16;
+    tt::tt_metal::Layout layout = tt::tt_metal::Layout::TILE;
+};
+
+class MlirInterfaceTestFixture : public TTNNFixtureWithDevice,
+                              public testing::WithParamInterface<std::tuple<InputShapeTestParam, InputShapeTestParam, tt::tt_metal::IGraphProcessor::RunMode>> {};
+
+
+TEST_P(MlirInterfaceTestFixture, MlirInterfaceTest) {
+    auto param_combination = GetParam();
+    auto input_a = std::get<0>(param_combination);
+    auto input_b = std::get<1>(param_combination);
+    auto run_mode = std::get<2>(param_combination);
+
+    // pad input shapes (this isn't happening automagically)
+    auto pad_shape_to_tile = [] (const ttnn::Shape& shape) {
+        std::vector<uint32_t> shape_og;
+        std::vector<uint32_t> shape_padded;
+
+        auto rank = shape.rank();
+        for (auto i = 0; i < rank; i++) {
+            shape_og.push_back(shape[i]);
+
+            if (i >= rank - 2)
+            {
+                shape_padded.push_back((shape[i] + 31) / 32 * 32);
+            } else {
+                shape_padded.push_back(shape[i]);
+            }
+        }
+        return ttnn::Shape(shape_og, shape_padded);
+    };
+    input_a.shape = pad_shape_to_tile(input_a.shape);
+    input_b.shape = pad_shape_to_tile(input_b.shape);
+
+    // Check input params against op constraints
+    try {
+        std::unique_ptr<EltwiseOpConstraintsBuilder> builder = EltwiseOpConstraintsFactory::Make(input_a.shape, input_a.memory_config, input_b.shape, input_b.memory_config);
+        if (builder)
+        {
+            const auto op_constraints = (*builder)
+                .setBufferTypeA(input_a.memory_config.buffer_type)
+                .setBufferTypeB(input_b.memory_config.buffer_type)
+                .setBufferTypeO(input_a.memory_config.buffer_type) // assuming output buffer type is the same as input_a
+                .setDataTypeA(input_b.data_type)
+                .setDataTypeB(input_b.data_type)
+                .setDataTypeO(input_a.data_type) // assuming output data type is the same as input_a
+                .setIsShardedA(input_a.memory_config.is_sharded())
+                .setIsShardedB(input_b.memory_config.is_sharded())
+                .setIsShardedO(input_a.memory_config.is_sharded()) // assuming output is sharded if input_a is sharded
+                .build_constraints();
+            std::cout << "size(op_contraints) =  " << op_constraints.size() << std::endl;
+
+            if (op_constraints.size() == 0)
+            {
+                std::cout << "op_constraints is empty" << std::endl;
+                GTEST_SKIP();
+            }
+        }
+        else {
+            std::cout << "builder is nullptr" << std::endl;
+            GTEST_SKIP();
+        }
+    }
+    catch (const std::exception& e) {
+        std::cout << e.what() << std::endl;
+        GTEST_FAIL();
+    }
+
+    // Run the test
+    {
+        auto input_tensor_a = ttnn::zeros(input_a.shape, input_a.data_type, input_a.layout, this->getDevice(), input_a.memory_config);
+        auto input_tensor_b = ttnn::zeros(input_b.shape, input_b.data_type, input_b.layout, this->getDevice(), input_b.memory_config);
+        std::cout << "OP = " << input_a.shape << " + " << input_b.shape << std::endl;
+
+        auto call = [&] {
+            const auto output_tensor = ttnn::add(input_tensor_a, input_tensor_b);
+            return output_tensor;
+        };
+
+        // // get graph trace for ground truth
+        auto json_trace = graph::query_trace(call);
+        tt::log_info("Trace: {}", json_trace.dump(4));
+
+
+        // L1 interface calls and checks against graph trace
+        {
+            auto l1_input_a = std::make_tuple(input_a.shape, input_a.data_type, input_a.layout, input_a.memory_config);
+            auto l1_input_b = std::make_tuple(input_b.shape, input_b.data_type, input_b.layout, input_b.memory_config);
+
+            auto l1_usage = EltwiseOpL1UsageFactory::Make(l1_input_a, l1_input_b);
+
+            auto l1_cb_usage = l1_usage->get_circular_buffer_l1_allocations_per_core();
+            auto graph_circular_buffer_allocations = graph::extract_circular_buffer_allocations_per_core(json_trace);
+            EXPECT_EQ(l1_cb_usage.size(), graph_circular_buffer_allocations.size());
+            for (int i = 0; i < l1_cb_usage.size(); i++) {
+                std::cout << "DBG cb[" << i << "]" << std::get<0>(l1_cb_usage[i]) << std::endl; // << " " << graph_circular_buffer_allocations[i] << std::endl;
+                EXPECT_EQ(std::get<0>(l1_cb_usage[i]), graph_circular_buffer_allocations[i]);
+            }
+
+            auto l1_tensor_usage = l1_usage->get_tensor_l1_allocations_per_core(); // what about output tensor allocation?
+            auto graph_l1_buffer_allocations = graph::extract_l1_buffer_allocations(json_trace); // total
+            EXPECT_EQ(l1_tensor_usage.size(), graph_l1_buffer_allocations.size());
+            for (int i = 0; i < l1_tensor_usage.size(); i++) {
+                std::cout << "DBG l1[" << i << "]" << std::get<0>(l1_tensor_usage[i]) << std::endl; // << " " << graph_l1_buffer_allocations[i] << std::endl;
+                EXPECT_EQ(std::get<0>(l1_tensor_usage[i]) * std::get<1>(l1_tensor_usage[i]), graph_l1_buffer_allocations[i]);
+            }
+        }
+    }
+}
+
+INSTANTIATE_TEST_SUITE_P(
+    MlirInterfaceTests, // Prefix for the instantiated test suite
+    MlirInterfaceTestFixture, // Test suite name
+    ::testing::Combine(
+        ::testing::Values(
+            InputShapeTestParam{
+                .shape = ttnn::Shape(tt::tt_metal::Array4D{1, 5, 32*64, 32}),
+                .memory_config =
+                {
+                    .memory_layout = tt::tt_metal::TensorMemoryLayout::HEIGHT_SHARDED,
+                    .buffer_type = tt::tt_metal::BufferType::L1,
+                    .shard_spec = tt::tt_metal::ShardSpec{
+                        CoreRangeSet{std::set<CoreRange>{CoreRange{CoreCoord{0, 0}, CoreCoord{7, 7}}}},
+                        {160, 32},
+                        ShardOrientation::COL_MAJOR
+                        }
+                },
+            },
+            InputShapeTestParam{
+                .shape = ttnn::Shape(tt::tt_metal::Array4D{1, 1, 32, 32}),
+                .memory_config = ttnn::L1_MEMORY_CONFIG,
+            }
+        ),
+
+        ::testing::Values(
+            InputShapeTestParam{
+                .shape = ttnn::Shape(tt::tt_metal::Array4D{1, 5, 32*64, 32}),
+                .memory_config =
+                {
+                    .memory_layout = tt::tt_metal::TensorMemoryLayout::HEIGHT_SHARDED,
+                    .buffer_type = tt::tt_metal::BufferType::L1,
+                    .shard_spec = tt::tt_metal::ShardSpec{
+                        CoreRangeSet{std::set<CoreRange>{CoreRange{CoreCoord{0, 0}, CoreCoord{7, 7}}}},
+                        {160, 32},
+                        ShardOrientation::COL_MAJOR
+                        }
+                },
+            },
+            InputShapeTestParam{
+                .shape = ttnn::Shape(tt::tt_metal::Array4D{1, 1, 32, 32}),
+                .memory_config = ttnn::L1_MEMORY_CONFIG,
+            },
+            InputShapeTestParam{
+                .shape = ttnn::Shape(tt::tt_metal::Array4D{1, 4, 32, 32}),
+                .memory_config = ttnn::L1_MEMORY_CONFIG,
+            },
+            InputShapeTestParam{
+                .shape = ttnn::Shape(tt::tt_metal::Array4D{3, 1, 32, 32}),
+                .memory_config = ttnn::L1_MEMORY_CONFIG,
+            },
+            InputShapeTestParam{
+                .shape = ttnn::Shape(tt::tt_metal::Array4D{3, 4, 32, 32}),
+                .memory_config = ttnn::L1_MEMORY_CONFIG,
+            },
+            InputShapeTestParam{
+                .shape = ttnn::Shape(tt::tt_metal::Array4D{1, 1, 1, 32}),
+                .memory_config = ttnn::L1_MEMORY_CONFIG,
+            },
+            InputShapeTestParam{
+                .shape = ttnn::Shape(tt::tt_metal::Array4D{1, 1, 32, 1}),
+                .memory_config = ttnn::L1_MEMORY_CONFIG,
+            },
+            InputShapeTestParam{
+                .shape = ttnn::Shape(tt::tt_metal::Array4D{1, 1, 1, 1}),
+                .memory_config = ttnn::L1_MEMORY_CONFIG,
+            }
+        ),
+
+        // ::testing::Values(tt::tt_metal::IGraphProcessor::RunMode::NO_DISPATCH, tt::tt_metal::IGraphProcessor::RunMode::NORMAL)
+        ::testing::Values(tt::tt_metal::IGraphProcessor::RunMode::NO_DISPATCH)
+    )
+);
+
+
+}  // namespace test
+}  // namespace binary
+}  // namespace operations
+}  // namespace ttnn

--- a/ttnn/CMakeLists.txt
+++ b/ttnn/CMakeLists.txt
@@ -116,6 +116,7 @@ set(ALL_TTNN_SRCS
     ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/data_movement/untilize_with_unpadding/device/untilize_with_unpadding_program_factory.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/data_movement/untilize_with_unpadding/untilize_with_unpadding.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/eltwise/binary/binary.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/eltwise/binary/binary_l1_interface.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/eltwise/binary/common/binary_op_utils.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/eltwise/binary/device/binary_composite_op.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/eltwise/binary/device/binary_device_operation.cpp

--- a/ttnn/cpp/ttnn/graph/graph_trace_utils.hpp
+++ b/ttnn/cpp/ttnn/graph/graph_trace_utils.hpp
@@ -11,6 +11,9 @@
 
 namespace ttnn::graph {
 
+std::vector<uint32_t> extract_circular_buffer_allocations_per_core(const nlohmann::json& trace);
+std::vector<uint32_t> extract_l1_buffer_allocations(const nlohmann::json& trace);
+
 uint32_t extract_peak_L1_memory_usage(const nlohmann::json& trace);
 
 // Returns count of intermediate and output tensors
@@ -28,10 +31,7 @@ struct TensorInfo {
     bool operator==(const TensorInfo& other) const = default;
 };
 
-std::ostream &operator<<(std::ostream &os, const TensorInfo &info) {
-    os << "TensorInfo{shape: " << info.shape << ", size: " << info.size << ", type: " << static_cast<int>(info.type) << "}";
-    return os;
-}
+std::ostream &operator<<(std::ostream &os, const TensorInfo &info);
 
 std::vector<TensorInfo> extract_output_info(const nlohmann::json& trace);
 

--- a/ttnn/cpp/ttnn/operations/eltwise/binary/binary_constraints.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary/binary_constraints.hpp
@@ -562,11 +562,46 @@ class EltwiseOpConstraintsFactory
         const ttnn::Shape& input_shape_b,
         const tt::tt_metal::MemoryConfig& memory_config_b)
     {
+        // void BinaryDeviceOperation::validate_on_program_cache_hit(
+        auto batch_size_0_a = input_shape_a.rank() >= 4 ? input_shape_a[-4] : 1;
+        auto batch_size_1_a = input_shape_a.rank() >= 3 ? input_shape_a[-3] : 1;
         auto height_a = input_shape_a[-2];
         auto width_a = input_shape_a[-1];
 
+        auto batch_size_0_b = input_shape_b.rank() >= 4 ? input_shape_b[-4] : 1;
+        auto batch_size_1_b = input_shape_b.rank() >= 3 ? input_shape_b[-3] : 1;
         auto height_b = input_shape_b[-2];
         auto width_b = input_shape_b[-1];
+
+        // Input shape b must be the same as or broadcastable to input shape a
+        if (batch_size_0_a != batch_size_0_b) {
+            if (! (batch_size_0_a > batch_size_0_b and batch_size_0_b == 1))
+            {
+                // "ttnn::operations::binary::BinaryDeviceOperation: batch size mismatch");
+                return EltwiseOpTypes::NotSupported;
+            }
+        }
+        if (batch_size_1_a != batch_size_1_b) {
+            if (! (batch_size_1_a > batch_size_1_b and batch_size_1_b == 1))
+            {
+                // "ttnn::operations::binary::BinaryDeviceOperation: batch size mismatch");
+                return EltwiseOpTypes::NotSupported;
+            }
+        }
+        if (height_a != height_b) {
+            if (! (height_a > height_b and height_b == 1))
+            {
+                // "ttnn::operations::binary::BinaryDeviceOperation: height mismatch");
+                return EltwiseOpTypes::NotSupported;
+            }
+        }
+        if (width_a != width_b) {
+            if (! (width_a > width_b and width_b == 1))
+            {
+                // "ttnn::operations::binary::BinaryDeviceOperation: width mismatch");
+                return EltwiseOpTypes::NotSupported;
+            }
+        }
 
         if (ElementWiseMultiCoreConstraintsBuilder::check_input_parameters(input_shape_a, memory_config_a, input_shape_b, memory_config_b)) {
             return EltwiseOpTypes::ElementWiseMultiCore;

--- a/ttnn/cpp/ttnn/operations/eltwise/binary/binary_constraints.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary/binary_constraints.hpp
@@ -1,0 +1,722 @@
+#pragma once
+
+#include <algorithm>
+#include <memory>
+#include <optional>
+#include "impl/buffers/buffer_constants.hpp"
+#include "ttnn/tensor/tensor.hpp"
+#include "ttnn/tensor/types.hpp"
+
+namespace detail { // constexpr combinations
+template <typename Array, std::size_t... I>
+constexpr auto array_to_tuple_impl(const Array& a, std::index_sequence<I...>)
+{
+    return std::make_tuple(a[I]...);
+}
+
+template <typename T, std::size_t N, typename Indx = std::make_index_sequence<N>>
+constexpr auto array_to_tuple(const std::array<T, N>& a)
+{
+    return array_to_tuple_impl(a, Indx{});
+}
+
+template<typename Tuple, typename NewElement>
+constexpr auto extendTupleDirect(const Tuple& t, NewElement&& newElem) {
+    return std::tuple_cat(t, std::make_tuple(std::forward<NewElement>(newElem)));
+}
+
+template <typename Array1, typename Array2, std::size_t... I, std::size_t... J, std::size_t... E>
+constexpr auto combine_array_x_array_impl(const Array1& a1, const Array2& a2, std::index_sequence<I...>, std::index_sequence<J...>, std::index_sequence<E...>)
+// template <typename Array1, typename Array2, std::size_t... I, std::size_t... J>
+// constexpr auto arrays_to_tuple_cartesian_impl(const Array1& a1, const Array2& a2, std::index_sequence<I...>, std::index_sequence<J...>)
+{
+    // there is probably a better way to achieve this
+    size_t i = 0;
+    size_t j = 0;
+    return std::array<std::tuple<typename Array1::value_type, typename Array2::value_type>, sizeof...(I) * sizeof...(J)> {
+        [&i, &j, a1, a2](auto...) {
+            if (i * j >= sizeof...(I) * sizeof...(J)) {
+                return std::tuple<typename Array1::value_type, typename Array2::value_type>{};
+            }
+
+            auto value = std::make_tuple(a1[i], a2[j]);
+            if (++j >= sizeof...(J)) {
+                j = 0;
+                ++i;
+            }
+            return value;
+        }(std::integral_constant<std::size_t, E>{})...};
+}
+
+template <typename T, std::size_t N, typename U, std::size_t M, typename Indx1 = std::make_index_sequence<N>, typename Indx2 = std::make_index_sequence<M>>
+constexpr auto combine_array_x_array(const std::array<T, N>& a1, const std::array<U, M>& a2)
+{
+    return combine_array_x_array_impl(a1, a2, Indx1{}, Indx2{}, std::make_index_sequence<N * M>{});
+}
+
+template <typename... TupleArgs, typename U, std::size_t... I, std::size_t... J, std::size_t... E>
+constexpr auto combine_tuple_x_array_impl(
+    const std::array<std::tuple<TupleArgs...>, sizeof...(I)> & a1,
+    const std::array<U, sizeof...(J)>& a2,
+    std::index_sequence<I...>,
+    std::index_sequence<J...>,
+    std::index_sequence<E...>)
+{
+    // there is probably a better way to achieve this
+    size_t i = 0;
+    size_t j = 0;
+    return std::array<std::tuple<TupleArgs..., U>, sizeof...(I) * sizeof...(J)> {
+        [&i, &j, a1, a2](auto...) {
+            if (i * j >= sizeof...(I) * sizeof...(J)) {
+                return std::tuple<TupleArgs..., U>{};
+            }
+            auto value = extendTupleDirect(a1[i], a2[j]);
+            if (++j >= sizeof...(J)) {
+                j = 0;
+                ++i;
+            }
+            return value;
+        }(std::integral_constant<std::size_t, E>{})...};
+}
+
+template <typename... TupleArgs, std::size_t N, typename U, std::size_t M, typename Indx1 = std::make_index_sequence<N>, typename Indx2 = std::make_index_sequence<M>>
+constexpr auto combine_tuple_x_array(const std::array<std::tuple<TupleArgs...>, N>& a1, const std::array<U, M>& a2)
+{
+    return combine_tuple_x_array_impl(a1, a2, Indx1{}, Indx2{}, std::make_index_sequence<N * M>{});
+}
+}
+
+// input shapes and shard shapes are runtime thing, we cannot return arbitrary count of shapes
+
+using EltwiseOpConstraint = std::tuple<
+    // a
+    tt::tt_metal::DataType,
+    tt::tt_metal::BufferType,
+    bool,
+    tt::tt_metal::Layout,
+    tt::tt_metal::TensorMemoryLayout,
+    tt::tt_metal::ShardOrientation,
+    // b
+    tt::tt_metal::DataType,
+    tt::tt_metal::BufferType,
+    bool,
+    tt::tt_metal::Layout,
+    tt::tt_metal::TensorMemoryLayout,
+    tt::tt_metal::ShardOrientation,
+    // output
+    tt::tt_metal::DataType,
+    tt::tt_metal::BufferType,
+    bool,
+    tt::tt_metal::Layout,
+    tt::tt_metal::TensorMemoryLayout,
+    tt::tt_metal::ShardOrientation
+>;
+
+class EltwiseOpConstraintsBuilder {
+    protected:
+        std::optional<tt::tt_metal::DataType> data_type_a;  // required
+        std::optional<tt::tt_metal::BufferType> buffer_type_a; // required
+        std::optional<bool> is_sharded_a; // required
+        std::optional<tt::tt_metal::Layout> tile_layout_a;
+        std::optional<tt::tt_metal::TensorMemoryLayout> tensor_memory_layout_a;
+        std::optional<tt::tt_metal::ShardOrientation> shard_orientation_a;
+
+        std::optional<tt::tt_metal::DataType> data_type_b;  // required
+        std::optional<tt::tt_metal::BufferType> buffer_type_b; // required
+        std::optional<bool> is_sharded_b; // required
+        std::optional<tt::tt_metal::Layout> tile_layout_b;
+        std::optional<tt::tt_metal::TensorMemoryLayout> tensor_memory_layout_b;
+        std::optional<tt::tt_metal::ShardOrientation> shard_orientation_b;
+
+        std::optional<tt::tt_metal::DataType> data_type_o;  // required
+        std::optional<tt::tt_metal::BufferType> buffer_type_o; // required
+        std::optional<bool> is_sharded_o; // required
+        std::optional<tt::tt_metal::Layout> tile_layout_o;
+        std::optional<tt::tt_metal::TensorMemoryLayout> tensor_memory_layout_o;
+        std::optional<tt::tt_metal::ShardOrientation> shard_orientation_o;
+
+        // check if required parameters are set
+        bool can_build_constraints() const
+        {
+            return data_type_a.has_value() && buffer_type_a.has_value() && is_sharded_a.has_value() &&
+                data_type_b.has_value() && buffer_type_b.has_value() && is_sharded_b.has_value() &&
+                data_type_o.has_value() && buffer_type_o.has_value() && is_sharded_o.has_value();
+        }
+
+        // check if it is possible to build constraints with all set parameters
+        bool is_valid_external_constraint(const EltwiseOpConstraint& constraint) const {
+            if (data_type_a.has_value() && std::get<0>(constraint) != data_type_a.value()) {
+                return false;
+            }
+            if (buffer_type_a.has_value() && std::get<1>(constraint) != buffer_type_a.value()) {
+                return false;
+            }
+            if (is_sharded_a.has_value() && std::get<2>(constraint) != is_sharded_a.value()) {
+                return false;
+            }
+            if (tile_layout_a.has_value() && std::get<3>(constraint) != tile_layout_a.value()) {
+                return false;
+            }
+            if (tensor_memory_layout_a.has_value() && std::get<4>(constraint) != tensor_memory_layout_a.value()) {
+                return false;
+            }
+            if (shard_orientation_a.has_value() && std::get<5>(constraint) != shard_orientation_a.value()) {
+                return false;
+            }
+            if (data_type_b.has_value() && std::get<6>(constraint) != data_type_b.value()) {
+                return false;
+            }
+            if (buffer_type_b.has_value() && std::get<7>(constraint) != buffer_type_b.value()) {
+                return false;
+            }
+            if (is_sharded_b.has_value() && std::get<8>(constraint) != is_sharded_b.value()) {
+                return false;
+            }
+            if (tile_layout_b.has_value() && std::get<9>(constraint) != tile_layout_b.value()) {
+                return false;
+            }
+            if (tensor_memory_layout_b.has_value() && std::get<10>(constraint) != tensor_memory_layout_b.value()) {
+                return false;
+            }
+            if (shard_orientation_b.has_value() && std::get<11>(constraint) != shard_orientation_b.value()) {
+                return false;
+            }
+            if (data_type_o.has_value() && std::get<12>(constraint) != data_type_o.value()) {
+                return false;
+            }
+            if (buffer_type_o.has_value() && std::get<13>(constraint) != buffer_type_o.value()) {
+                return false;
+            }
+            if (is_sharded_o.has_value() && std::get<14>(constraint) != is_sharded_o.value()) {
+                return false;
+            }
+            if (tile_layout_o.has_value() && std::get<15>(constraint) != tile_layout_o.value()) {
+                return false;
+            }
+            if (tensor_memory_layout_o.has_value() && std::get<16>(constraint) != tensor_memory_layout_o.value()) {
+                return false;
+            }
+            if (shard_orientation_o.has_value() && std::get<17>(constraint) != shard_orientation_o.value()) {
+                return false;
+            }
+            return true;
+        }
+
+        // op specific constraints
+        virtual bool is_valid_op_constraint(const EltwiseOpConstraint& constraint) const = 0;
+
+    public:
+        EltwiseOpConstraintsBuilder() = default;
+        virtual ~EltwiseOpConstraintsBuilder() = default;
+
+        virtual std::string get_op_name() const = 0;
+
+        std::vector<EltwiseOpConstraint> build_constraints()
+        {
+            if (can_build_constraints() == false)
+            {
+                throw std::runtime_error("Cannot build constraints, missing required parameters");
+            }
+
+            // reducing search space
+            // data types are required
+            // buffer types are required
+            // is sharded is required
+            std::vector<TensorMemoryLayout> sweep_tensor_memory_layout_a;
+            if (is_sharded_a.value()) {
+                sweep_tensor_memory_layout_a = {TensorMemoryLayout::HEIGHT_SHARDED, TensorMemoryLayout::WIDTH_SHARDED, TensorMemoryLayout::BLOCK_SHARDED};
+            }
+            else
+            {
+                sweep_tensor_memory_layout_a = {TensorMemoryLayout::INTERLEAVED};
+            }
+            std::vector<TensorMemoryLayout> sweep_tensor_memory_layout_b;
+            if (is_sharded_b.value()) {
+                sweep_tensor_memory_layout_b = {TensorMemoryLayout::HEIGHT_SHARDED, TensorMemoryLayout::WIDTH_SHARDED, TensorMemoryLayout::BLOCK_SHARDED};
+            }
+            else
+            {
+                sweep_tensor_memory_layout_b = {TensorMemoryLayout::INTERLEAVED};
+            }
+            std::vector<TensorMemoryLayout> sweep_tensor_memory_layout_o;
+            if (is_sharded_o.value()) {
+                sweep_tensor_memory_layout_o = {TensorMemoryLayout::HEIGHT_SHARDED, TensorMemoryLayout::WIDTH_SHARDED, TensorMemoryLayout::BLOCK_SHARDED};
+            }
+            else
+            {
+                sweep_tensor_memory_layout_o = {TensorMemoryLayout::INTERLEAVED};
+            }
+            static constexpr std::array<ShardOrientation, 2> shard_shapes = {ShardOrientation::ROW_MAJOR, ShardOrientation::COL_MAJOR};
+            static constexpr std::array<Layout, 2> tile_layouts = {Layout::ROW_MAJOR, Layout::TILE};
+
+            std::vector<EltwiseOpConstraint> constraints;
+            for (const auto& tml_a : sweep_tensor_memory_layout_a)
+            {
+                for (const auto& tml_b : sweep_tensor_memory_layout_b)
+                {
+                    for (const auto& tml_o : sweep_tensor_memory_layout_o)
+                    {
+                        for (const auto& shard_shape_a : shard_shapes)
+                        {
+                            for (const auto& shard_shape_b : shard_shapes)
+                            {
+                                for (const auto& shard_shape_o : shard_shapes)
+                                {
+                                    for (const auto& tile_layout_a : tile_layouts)
+                                    {
+                                        for (const auto& tile_layout_b : tile_layouts)
+                                        {
+                                            for (const auto& tile_layout_o : tile_layouts)
+                                            {
+                                                const auto constraint = std::make_tuple(
+                                                    data_type_a.value(),
+                                                    buffer_type_a.value(),
+                                                    is_sharded_a.value(),
+                                                    tile_layout_a,
+                                                    tml_a,
+                                                    shard_shape_a,
+                                                    data_type_b.value(),
+                                                    buffer_type_b.value(),
+                                                    is_sharded_b.value(),
+                                                    tile_layout_b,
+                                                    tml_b,
+                                                    shard_shape_b,
+                                                    data_type_o.value(),
+                                                    buffer_type_o.value(),
+                                                    is_sharded_o.value(),
+                                                    tile_layout_o,
+                                                    tml_o,
+                                                    shard_shape_o
+                                                );
+                                                if (is_valid_external_constraint(constraint)
+                                                    && is_valid_op_constraint(constraint))
+                                                {
+                                                    constraints.emplace_back(constraint);
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+
+            return std::move(constraints);
+        }
+
+        // Setters for parameter a
+        EltwiseOpConstraintsBuilder& setDataTypeA(tt::tt_metal::DataType dataType) {
+            data_type_a = dataType;
+            return *this;
+        }
+
+        EltwiseOpConstraintsBuilder& setBufferTypeA(tt::tt_metal::BufferType bufferType) {
+            buffer_type_a = bufferType;
+            return *this;
+        }
+
+        EltwiseOpConstraintsBuilder& setIsShardedA(bool isSharded) {
+            is_sharded_a = isSharded;
+            return *this;
+        }
+
+        EltwiseOpConstraintsBuilder& setTileLayoutA(tt::tt_metal::Layout tileLayout) {
+            tile_layout_a = tileLayout;
+            return *this;
+        }
+
+        EltwiseOpConstraintsBuilder& setTensorMemoryLayoutA(tt::tt_metal::TensorMemoryLayout tensorMemoryLayout) {
+            tensor_memory_layout_a = tensorMemoryLayout;
+            return *this;
+        }
+
+        EltwiseOpConstraintsBuilder& setShardOrientationA(tt::tt_metal::ShardOrientation shardOrientation) {
+            shard_orientation_a = shardOrientation;
+            return *this;
+        }
+
+        // Setters for parameter b
+        EltwiseOpConstraintsBuilder& setDataTypeB(tt::tt_metal::DataType dataType) {
+            data_type_b = dataType;
+            return *this;
+        }
+
+        EltwiseOpConstraintsBuilder& setBufferTypeB(tt::tt_metal::BufferType bufferType) {
+            buffer_type_b = bufferType;
+            return *this;
+        }
+
+        EltwiseOpConstraintsBuilder& setIsShardedB(bool isSharded) {
+            is_sharded_b = isSharded;
+            return *this;
+        }
+
+        EltwiseOpConstraintsBuilder& setTileLayoutB(tt::tt_metal::Layout tileLayout) {
+            tile_layout_b = tileLayout;
+            return *this;
+        }
+
+        EltwiseOpConstraintsBuilder& setTensorMemoryLayoutB(tt::tt_metal::TensorMemoryLayout tensorMemoryLayout) {
+            tensor_memory_layout_b = tensorMemoryLayout;
+            return *this;
+        }
+
+        EltwiseOpConstraintsBuilder& setShardOrientationB(tt::tt_metal::ShardOrientation shardOrientation) {
+            shard_orientation_b = shardOrientation;
+            return *this;
+        }
+
+        // Setters for parameter output
+        EltwiseOpConstraintsBuilder& setDataTypeO(tt::tt_metal::DataType dataType) {
+            data_type_o = dataType;
+            return *this;
+        }
+
+        EltwiseOpConstraintsBuilder& setBufferTypeO(tt::tt_metal::BufferType bufferType) {
+            buffer_type_o = bufferType;
+            return *this;
+        }
+
+        EltwiseOpConstraintsBuilder& setIsShardedO(bool isSharded) {
+            is_sharded_o = isSharded;
+            return *this;
+        }
+
+        EltwiseOpConstraintsBuilder& setTileLayoutO(tt::tt_metal::Layout tileLayout) {
+            tile_layout_o = tileLayout;
+            return *this;
+        }
+
+        EltwiseOpConstraintsBuilder& setTensorMemoryLayoutO(tt::tt_metal::TensorMemoryLayout tensorMemoryLayout) {
+            tensor_memory_layout_o = tensorMemoryLayout;
+            return *this;
+        }
+
+        EltwiseOpConstraintsBuilder& setShardOrientationO(tt::tt_metal::ShardOrientation shardOrientation) {
+            shard_orientation_o = shardOrientation;
+            return *this;
+        }
+};
+
+enum class EltwiseOpTypes
+{
+    ElementWiseMultiCore,
+    BroadcastWidthMultiCore,
+    BroadcastHeightMultiCore,
+    BroadcastHeightAndWidthMultiCore,
+    BroadcastHeightMultiCoreSharded,
+    BroadcastHeightMultiCoreShardedOptimized,
+    NotSupported
+};
+
+class ElementWiseMultiCoreConstraintsBuilder : public EltwiseOpConstraintsBuilder
+{
+public:
+    // ElementWiseMultiCoreConstraintsBuilder() = default;
+    ElementWiseMultiCoreConstraintsBuilder() {
+        std::cout << "ElementWiseMultiCoreConstraintsBuilder" << std::endl;
+    }
+    virtual ~ElementWiseMultiCoreConstraintsBuilder() = default;
+
+    virtual std::string get_op_name() const override {
+        return "ElementWiseMultiCore";
+    }
+
+    static bool check_input_parameters(const ttnn::Shape& input_shape_a,
+        const tt::tt_metal::MemoryConfig& memory_config_a,
+        const ttnn::Shape& input_shape_b,
+        const tt::tt_metal::MemoryConfig& memory_config_b)
+    {
+        auto height_a = input_shape_a[-2];
+        auto width_a = input_shape_a[-1];
+
+        auto height_b = input_shape_b[-2];
+        auto width_b = input_shape_b[-1];
+
+        if (height_a == height_b and width_a == width_b) {
+            return true;
+        }
+        return false;
+    }
+protected:
+    virtual bool is_valid_op_constraint(const EltwiseOpConstraint& constraint) const override {
+        const tt::tt_metal::Layout c_tile_layout_a = std::get<3>(constraint);
+        const tt::tt_metal::Layout c_tile_layout_b = std::get<9>(constraint);
+        const tt::tt_metal::Layout c_tile_layout_o = std::get<15>(constraint);
+
+        // made-up constraint - tiles only
+        if (c_tile_layout_a != tt::tt_metal::Layout::TILE)
+        {
+            return false;
+        }
+        if (c_tile_layout_b != tt::tt_metal::Layout::TILE)
+        {
+            return false;
+        }
+        if (c_tile_layout_o != tt::tt_metal::Layout::TILE)
+        {
+            return false;
+        }
+
+        return true;
+    }
+};
+
+class BroadcastWidthMultiCoreConstraintsBuilder : public EltwiseOpConstraintsBuilder
+{
+public:
+    // BroadcastWidthMultiCoreConstraintsBuilder() = default;
+    BroadcastWidthMultiCoreConstraintsBuilder() {
+        std::cout << "BroadcastWidthMultiCoreConstraintsBuilder" << std::endl;
+    }
+    virtual ~BroadcastWidthMultiCoreConstraintsBuilder() = default;
+
+    virtual std::string get_op_name() const override {
+        return "BroadcastWidthMultiCoreConstraintsBuilder";
+    }
+
+    static bool check_input_parameters(const ttnn::Shape& input_shape_a,
+        const tt::tt_metal::MemoryConfig& memory_config_a,
+        const ttnn::Shape& input_shape_b,
+        const tt::tt_metal::MemoryConfig& memory_config_b)
+    {
+        auto height_a = input_shape_a[-2];
+        auto width_a = input_shape_a[-1];
+
+        auto height_b = input_shape_b[-2];
+        auto width_b = input_shape_b[-1];
+
+        if (width_b == 1 && height_b > 1) {
+            return true;
+        }
+        return false;
+    }
+protected:
+    virtual bool is_valid_op_constraint(const EltwiseOpConstraint& constraint) const override {
+        const bool c_is_sharded_a = std::get<2>(constraint);
+        const bool c_is_sharded_b = std::get<8>(constraint);
+        const bool c_is_sharded_o = std::get<14>(constraint);
+
+        const tt::tt_metal::TensorMemoryLayout c_tensor_memory_layout_a = std::get<4>(constraint);
+        const tt::tt_metal::TensorMemoryLayout c_tensor_memory_layout_b = std::get<10>(constraint);
+        const tt::tt_metal::TensorMemoryLayout c_tensor_memory_layout_c = std::get<16>(constraint);
+
+        // BroadcastWidthMultiCoreConstraintsBuilder doesn't support sharding
+        if (c_is_sharded_a)
+        {
+            return false;
+        }
+        if (c_is_sharded_b)
+        {
+            return false;
+        }
+        if (c_is_sharded_o)
+        {
+            return false;
+        }
+        if (c_tensor_memory_layout_a != tt::tt_metal::TensorMemoryLayout::INTERLEAVED)
+        {
+            return false;
+        }
+        if (c_tensor_memory_layout_b != tt::tt_metal::TensorMemoryLayout::INTERLEAVED)
+        {
+            return false;
+        }
+        if (c_tensor_memory_layout_c != tt::tt_metal::TensorMemoryLayout::INTERLEAVED)
+        {
+            return false;
+        }
+
+        return true;
+    }
+};
+
+class EltwiseOpConstraintsFactory
+{
+    public:
+    EltwiseOpConstraintsFactory() = delete;
+    static std::unique_ptr<EltwiseOpConstraintsBuilder> Make(const ttnn::Shape& input_shape_a,
+        const tt::tt_metal::MemoryConfig& memory_config_a,
+        const ttnn::Shape& input_shape_b,
+        tt::tt_metal::MemoryConfig& memory_config_b)
+    {
+        auto eltwise_op_type = GetEltwiseOpType(input_shape_a, memory_config_a, input_shape_b, memory_config_b);
+        switch (eltwise_op_type) {
+            case EltwiseOpTypes::ElementWiseMultiCore:
+                return std::make_unique<ElementWiseMultiCoreConstraintsBuilder>();
+            case EltwiseOpTypes::BroadcastWidthMultiCore:
+                return std::make_unique<BroadcastWidthMultiCoreConstraintsBuilder>();
+            case EltwiseOpTypes::BroadcastHeightMultiCore: // not implemented yet
+            case EltwiseOpTypes::BroadcastHeightAndWidthMultiCore: // not implemented yet
+            case EltwiseOpTypes::BroadcastHeightMultiCoreSharded: // not implemented yet
+            case EltwiseOpTypes::BroadcastHeightMultiCoreShardedOptimized: // not implemented yet
+            default:
+                return nullptr;
+        }
+    };
+
+    static EltwiseOpTypes GetEltwiseOpType(const ttnn::Shape& input_shape_a,
+        const tt::tt_metal::MemoryConfig& memory_config_a,
+        const ttnn::Shape& input_shape_b,
+        const tt::tt_metal::MemoryConfig& memory_config_b)
+    {
+        auto height_a = input_shape_a[-2];
+        auto width_a = input_shape_a[-1];
+
+        auto height_b = input_shape_b[-2];
+        auto width_b = input_shape_b[-1];
+
+        if (ElementWiseMultiCoreConstraintsBuilder::check_input_parameters(input_shape_a, memory_config_a, input_shape_b, memory_config_b)) {
+            return EltwiseOpTypes::ElementWiseMultiCore;
+        } else if (BroadcastWidthMultiCoreConstraintsBuilder::check_input_parameters(input_shape_a, memory_config_a, input_shape_b, memory_config_b)) {
+            return EltwiseOpTypes::BroadcastWidthMultiCore;
+        }
+        std::cout << "EltwiseOpTypes::NotSupported" << std::endl;
+        // todo other op flavors
+
+        return EltwiseOpTypes::NotSupported;
+    }
+};
+
+
+// constexpr EltwiseOpConstraintsBuilder constraints_builder = EltwiseOpConstraintsBuilder();
+
+// constexpr ttnn::Shape a = ttnn::Shape(tt::tt_metal::Array4D{1, 1, 32, 32});
+
+// constexpr tt::tt_metal::MemoryConfig memory_config_a = {
+//     .memory_layout = tt::tt_metal::TensorMemoryLayout::HEIGHT_SHARDED,
+//     .buffer_type = tt::tt_metal::BufferType::L1,
+//     .shard_spec = tt::tt_metal::ShardSpec{
+//         CoreRangeSet{std::set<CoreRange>{CoreRange{CoreCoord{0, 0}, CoreCoord{7, 7}}}},
+//         {160, 32},
+//         ShardOrientation::COL_MAJOR
+//     }
+// };
+
+// constexpr tt::tt_metal::ShardSpec ss = {
+//         CoreRangeSet{std::set<CoreRange>{CoreRange{CoreCoord{0, 0}, CoreCoord{7, 7}}}},
+//         {160, 32},
+//         ShardOrientation::COL_MAJOR
+//     };
+// ../ttnn/cpp/ttnn/operations/eltwise/binary/binary_constraints.hpp:20:35: error: constexpr variable cannot have non-literal type 'const tt::tt_metal::ShardSpec'
+//    20 | constexpr tt::tt_metal::ShardSpec ss = {
+//       |                                   ^
+// ../tt_metal/impl/buffers/buffer.hpp:38:8: note: 'ShardSpec' is not literal because it is not an aggregate and has no constexpr constructors other than copy or move constructors
+//    38 | struct ShardSpec {
+
+// bool is_binary_op_valid(
+//         const ttnn::Shape& input_shape_a,
+//         const tt::tt_metal::MemoryConfig& memory_config_a,
+//         const ttnn::Shape& input_shape_b,
+//         tt::tt_metal::MemoryConfig& memory_config_b) {
+
+//         auto height_a = input_shape_a[-2];
+//         auto width_a = input_shape_a[-1];
+
+//         auto height_b = input_shape_b[-2];
+//         auto width_b = input_shape_b[-1];
+
+//     if (height_a == height_b and width_a == width_b) {
+//         std::cout << "ElementWiseMultiCore" << std::endl;
+//         // return ElementWiseMultiCore{};
+//         return true;
+//     } else if (height_b == 1 or width_b == 1) {
+//         if (height_b == 1 and width_b == 1) {
+//             std::cout << "BroadcastHeightAndWidthMultiCore" << std::endl;
+//             // return BroadcastHeightAndWidthMultiCore{};
+//             // no additional constraints at
+//             // BinaryDeviceOperation::ElementWiseMultiCore::cached_program_t BinaryDeviceOperation::ElementWiseMultiCore::create(
+//             return true;
+//         } else if (height_b == 1) {
+//             if(memory_config_a.is_sharded()){
+//                 if (input_shape_a.value[0] == input_shape_b.value[0]
+//                         || input_shape_a.value[0] > 1
+//                         and input_shape_b.value[0] == 1){
+//                             std::cout << "BroadcastHeightMultiCoreShardedOptimized" << std::endl;
+
+//                             //  "Output tensor should have same number of cores {} as input tensor {}",
+//                             // TODO needs output
+
+//                             //  "Input and output tile size should be same"
+//                             // TODO needs output
+
+//                             //  "Input tile size should be less than shard size"
+//                             // TODO needs data format
+
+//                             if (memory_config_a.memory_layout == TensorMemoryLayout::BLOCK_SHARDED) {
+//                             //     ncores_x = all_cores.ranges().begin()->end_coord.y + 1;
+//                             //     Wt = shard_spec.shape[1] / TILE_WIDTH;
+//                             //     Ht = shard_spec.shape[0] / TILE_HEIGHT;
+//                             } else if (memory_config_a.memory_layout == TensorMemoryLayout::WIDTH_SHARDED) {
+//                                 uint32_t bN = input_shape_b.rank() >= 4 ? input_shape_b[-4] : 1;
+//                                 if (memory_config_a.shard_spec.value().shape[0] % (bN * tt::constants::TILE_HEIGHT) != 0)
+//                                 {
+//                                     return false;
+//                                 }
+//                             //     Wt = shard_spec.shape[1] / TILE_WIDTH;
+//                             //     Ht = shard_spec.shape[0] / TILE_HEIGHT;
+//                             //     TT_ASSERT(
+//                             //         (shard_spec.shape[0] % (bN * TILE_HEIGHT) == 0),
+//                             //         "Shard height per batch must be divisible by TILE_HEIGHT {} {} {} ",
+//                             //         shard_spec.shape[0],
+//                             //         bN,
+//                             //         TILE_HEIGHT);
+//                             } else {
+//                             //     TT_FATAL(false, "1 Unsupported memory layout");
+//                                 return false;
+//                             }
+
+//                             if (memory_config_a.shard_spec.value().shape[0] % tt::constants::TILE_HEIGHT != 0)
+//                             {
+//                                 return false;
+//                             }
+//                             if (memory_config_a.shard_spec.value().shape[0] % tt::constants::TILE_WIDTH != 0)
+//                             {
+//                                 return false;
+//                             }
+//                             // TT_ASSERT(
+//                                 // (shard_spec.shape[0] % TILE_HEIGHT == 0) && (shard_spec.shape[0] % TILE_WIDTH == 0),
+//                                 // "Shard shapes must be multiple of TILE_HEIGHT ");
+
+//                             uint32_t N = input_shape_a.rank() >= 4 ? input_shape_a[-4] : 1;
+//                             uint32_t C = input_shape_a.rank() >= 3 ? input_shape_a[-3] : 1;
+//                             uint32_t H = input_shape_a[-2];
+//                             uint32_t W = input_shape_a[-1];
+//                             uint32_t bN = input_shape_b.rank() >= 4 ? input_shape_b[-4] : 1;
+//                             uint32_t bC = input_shape_b.rank() >= 3 ? input_shape_b[-3] : 1;
+//                             uint32_t bH = input_shape_b[-2];
+//                             uint32_t bW = input_shape_b[-1];
+//                             uint32_t NC = N * C;
+//                             uint32_t HW = H * W;
+//                             if ((NC * H / tt::constants::TILE_HEIGHT) % bN != 0)
+//                             {
+//                                 return false;
+//                             }
+//                             //     TT_FATAL((NC * H / TILE_HEIGHT) % bN == 0, "N*C*H of input0 must be devisible by batch size of input1");
+
+//                         // return BroadcastHeightMultiCoreShardedOptimized{};
+//                         return true;
+//                 } else {
+//                     std::cout << "BroadcastHeightMultiCoreSharded" << std::endl;
+//                         // return BroadcastHeightMultiCoreSharded{};
+//                         return true;
+//                 }
+//             }
+//             std::cout << "BroadcastHeightMultiCore" << std::endl;
+//             // return BroadcastHeightMultiCore{};
+//             return true;
+//         } else if (width_b == 1) {
+//             std::cout << "BroadcastWidthMultiCore" << std::endl;
+//             // return BroadcastWidthMultiCore{};
+//             // this is obivous only if you look at BroadcastWidthMultiCore::create
+//             if (memory_config_a.is_sharded() || memory_config_b.is_sharded())
+//             {
+//                 return false;
+//             }
+//             return true;
+//         }
+//     }
+//         return false;
+//     };

--- a/ttnn/cpp/ttnn/operations/eltwise/binary/binary_l1_interface.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary/binary_l1_interface.cpp
@@ -1,0 +1,282 @@
+#include "binary_l1_interface.hpp"
+#include <optional>
+#include <tuple>
+#include <memory>
+
+#include "tt_metal/common/constants.hpp"
+#include "ttnn/cpp/ttnn/tensor/types.hpp"
+#include "ttnn/cpp/ttnn/tensor/tensor.hpp"
+#include "ttnn/cpp/ttnn/tensor/tensor_impl.hpp"
+
+
+uint32_t get_num_of_cores(const std::optional<tt::tt_metal::ShardSpec>& shard_spec) {
+    if (shard_spec.has_value()) {
+        return shard_spec.value().grid.num_cores();
+    }
+    return (uint32_t)64; // Nebula_x1
+};
+
+ttnn::types::Shape get_larger_shape_by_volume(const ttnn::types::Shape& a, const ttnn::types::Shape& b) {
+    if (a.volume() > b.volume()) {
+        return a;
+    }
+    else {
+        return b;
+    }
+};
+
+EltwiseOpParams get_larger_eltwise_op_params_by_volume(const EltwiseOpParams& a, const EltwiseOpParams& b) {
+    if (std::get<ttnn::types::Shape>(a).volume() > std::get<ttnn::types::Shape>(b).volume()) {
+        return a;
+    }
+    else {
+        return b;
+    }
+};
+
+// these should go to a common tensor_l1_interface header or something
+uint32_t calculate_circular_buffer_l1_allocation_size_per_core(
+    const ttnn::types::Shape& shape,
+    const tt::tt_metal::DataType data_type,
+    const tt::tt_metal::Layout& layout,
+    const tt::tt_metal::MemoryConfig& memory_config)
+{
+    auto total_size_bytes = shape.with_tile_padding().volume() * tt::tt_metal::tensor_impl::element_size_bytes(data_type);
+    auto page_size = tt::tt_metal::tensor_impl::get_page_size(data_type, layout, total_size_bytes, shape.value);
+    auto num_pages = 2; /// default value for interleaved
+    if (memory_config.is_sharded())
+    {
+        num_pages = memory_config.shard_spec.value().shape[0] * memory_config.shard_spec.value().shape[1] / tt::constants::TILE_HEIGHT / tt::constants::TILE_WIDTH;
+    };
+
+    return page_size * num_pages;
+}
+
+uint32_t calculate_tensor_l1_allocation_size_per_core(
+    const ttnn::types::Shape& shape,
+    const tt::tt_metal::DataType data_type,
+    const tt::tt_metal::Layout& layout,
+    const tt::tt_metal::MemoryConfig& memory_config)
+{
+    if (memory_config.is_l1())
+    {
+        if (memory_config.is_sharded()) {
+            tt::tt_metal::ShardSpecBuffer shard_spec_buffer( // this structure is not used inside validate_sharded_buffer_allocation
+                                                             // assembling it with data from memory_config
+                memory_config.shard_spec.value().grid,
+                memory_config.shard_spec.value().shape,
+                memory_config.shard_spec.value().orientation,
+                memory_config.shard_spec.value().halo,
+                {32, 32}, //
+                {32, 32}  //
+            );
+            tt::tt_metal::tensor_impl::validate_sharded_buffer_allocation(shape.value, layout, data_type, shard_spec_buffer, memory_config);
+
+            auto total_size_bytes = shape.with_tile_padding().volume() * tt::tt_metal::tensor_impl::element_size_bytes(data_type);
+            auto num_of_cores = memory_config.shard_spec.value().grid.num_cores();
+            return total_size_bytes / num_of_cores;
+        } else {
+            //          Banks are ½ size of L1 (732KB)
+            auto total_size_bytes = shape.with_tile_padding().volume() * tt::tt_metal::tensor_impl::element_size_bytes(data_type);
+            auto num_of_cores = 64; // Nebula_x1
+            return total_size_bytes / num_of_cores;
+        }
+    }
+    return (uint32_t)0; // dram not implemented yet
+}
+
+#include "binary_constraints.hpp" // for EltwiseOpConstraintsDirector::GetEltwiseOpType(..)
+std::unique_ptr<EltwiseOpL1Usage> EltwiseOpL1UsageFactory::Make(const EltwiseOpParams& input_a, const EltwiseOpParams& input_b, const std::optional<EltwiseOpParams>& output)
+{
+    const auto input_shape_a = std::get<ttnn::types::Shape>(input_a);
+    const auto memory_config_a = std::get<tt::tt_metal::MemoryConfig>(input_a);
+    const auto input_shape_b = std::get<ttnn::types::Shape>(input_b);
+    const auto memory_config_b = std::get<tt::tt_metal::MemoryConfig>(input_b);
+
+    auto eltwise_op_type = EltwiseOpConstraintsFactory::GetEltwiseOpType(input_shape_a, memory_config_a, input_shape_b, memory_config_b);
+
+    switch (eltwise_op_type) {
+        case EltwiseOpTypes::ElementWiseMultiCore:
+            return std::make_unique<ElementWiseMultiCoreOpL1Usage>(input_a, input_b, output);
+        case EltwiseOpTypes::BroadcastWidthMultiCore:
+            return std::make_unique<BroadcastWidthMultiCoreOpL1Usage>(input_a, input_b, output);
+        case EltwiseOpTypes::BroadcastHeightMultiCore: // not implemented yet
+        case EltwiseOpTypes::BroadcastHeightAndWidthMultiCore: // not implemented yet
+        case EltwiseOpTypes::BroadcastHeightMultiCoreSharded: // not implemented yet
+        case EltwiseOpTypes::BroadcastHeightMultiCoreShardedOptimized: // not implemented yet
+        default:
+            return nullptr;
+    }
+};
+
+EltwiseOpL1Usage::EltwiseOpL1Usage(const EltwiseOpParams& input_a, const EltwiseOpParams& input_b, const EltwiseOpParams& output) :
+    input_a(input_a),
+    input_b(input_b),
+    output(output) {};
+
+ElementWiseMultiCoreOpL1Usage::ElementWiseMultiCoreOpL1Usage(const EltwiseOpParams& input_a, const EltwiseOpParams& input_b, const std::optional<EltwiseOpParams>& output)
+:   EltwiseOpL1Usage(input_a, input_b, output.has_value() ? output.value() : get_larger_eltwise_op_params_by_volume(input_a, input_b))
+,   intermediate(calculate_intermediate_buffer_impl(input_a, input_b))
+{
+}
+
+std::vector<std::tuple<uint32_t, uint32_t>> ElementWiseMultiCoreOpL1Usage::ElementWiseMultiCoreOpL1Usage::get_circular_buffer_l1_allocations_per_core() const
+{
+    std::vector<std::tuple<uint32_t, uint32_t>> sizes;
+    sizes.emplace_back(
+        std::make_tuple(
+            calculate_circular_buffer_l1_allocation_size_per_core(input_a),
+            get_num_of_cores(std::get<tt::tt_metal::MemoryConfig>(input_a).shard_spec)));
+    sizes.emplace_back(
+        std::make_tuple(
+            calculate_circular_buffer_l1_allocation_size_per_core(input_b),
+            get_num_of_cores(std::get<tt::tt_metal::MemoryConfig>(input_b).shard_spec)));
+    if (intermediate.has_value())
+    {
+        sizes.emplace_back(
+            std::make_tuple(
+                calculate_circular_buffer_l1_allocation_size_per_core(intermediate.value()),
+                get_num_of_cores(std::get<tt::tt_metal::MemoryConfig>(intermediate.value()).shard_spec)));
+    }
+    sizes.emplace_back(
+        std::make_tuple(
+            calculate_circular_buffer_l1_allocation_size_per_core(output),
+            get_num_of_cores(std::get<tt::tt_metal::MemoryConfig>(output).shard_spec)));
+
+    return std::move(sizes);
+}
+
+std::vector<std::tuple<uint32_t, uint32_t>> ElementWiseMultiCoreOpL1Usage::ElementWiseMultiCoreOpL1Usage::get_tensor_l1_allocations_per_core() const
+{
+    std::vector<std::tuple<uint32_t, uint32_t>> sizes;
+
+    if (intermediate.has_value())
+    {
+        sizes.emplace_back(
+            std::make_tuple(
+                calculate_tensor_l1_allocation_size_per_core(intermediate.value()),
+                get_num_of_cores(std::get<tt::tt_metal::MemoryConfig>(intermediate.value()).shard_spec)));
+    }
+
+    sizes.emplace_back(
+        std::make_tuple(
+            calculate_tensor_l1_allocation_size_per_core(output),
+            get_num_of_cores(std::get<tt::tt_metal::MemoryConfig>(output).shard_spec)));
+
+    return std::move(sizes);
+}
+
+
+std::optional<EltwiseOpParams> ElementWiseMultiCoreOpL1Usage::calculate_intermediate_buffer_impl(const EltwiseOpParams& input_a, const EltwiseOpParams& input_b)
+{
+    const auto shape_a = std::get<ttnn::types::Shape>(input_a);
+    const auto shape_b = std::get<ttnn::types::Shape>(input_b);
+
+    // internal buffer at ElementWiseMultiCore is used for ONLY batch broadcasts
+    bool is_batch_broadcast = false;
+    if ((shape_a.rank() == 4) && (shape_a.rank() == 4)) {
+        if (shape_a[0] != shape_b[0]) {
+            is_batch_broadcast = true;
+        }
+    }
+    if (!is_batch_broadcast)
+    {
+        return std::nullopt;
+    }
+
+    auto intermediate = (shape_a[0] > shape_b[0]) ? input_b : input_a;
+    assert(std::get<ttnn::types::Shape>(intermediate).rank() == 4); // my implementation limitation
+
+    auto batch_size = (shape_a[0] > shape_b[0]) ? shape_a[0] : shape_b[0];;
+    vector<uint32_t> new_shape;
+    new_shape.push_back(batch_size);
+    for (int i = 1; i < 4; i++) {
+        new_shape.push_back(std::get<ttnn::types::Shape>(intermediate)[i]);
+    }
+
+    std::get<ttnn::types::Shape>(intermediate) = ttnn::Shape{tt::tt_metal::Shape{new_shape, tt::tt_metal::Padding{std::get<ttnn::types::Shape>(intermediate).rank()}}};
+
+    return std::make_optional(intermediate);
+}
+
+BroadcastWidthMultiCoreOpL1Usage::BroadcastWidthMultiCoreOpL1Usage(const EltwiseOpParams& input_a, const EltwiseOpParams& input_b, const std::optional<EltwiseOpParams>& output)
+:   EltwiseOpL1Usage(input_a, input_b, output.has_value() ? output.value() : get_larger_eltwise_op_params_by_volume(input_a, input_b))
+,   intermediate(calculate_intermediate_buffer_impl(input_a, input_b))
+{
+}
+
+std::vector<std::tuple<uint32_t, uint32_t>> BroadcastWidthMultiCoreOpL1Usage::get_circular_buffer_l1_allocations_per_core() const
+{
+    std::vector<std::tuple<uint32_t, uint32_t>> sizes;
+
+    sizes.emplace_back(
+        std::make_tuple(
+            calculate_circular_buffer_l1_allocation_size_per_core(input_a),
+            get_num_of_cores(std::get<tt::tt_metal::MemoryConfig>(input_a).shard_spec)));
+    sizes.emplace_back(
+        std::make_tuple(
+            calculate_circular_buffer_l1_allocation_size_per_core(input_b),
+            get_num_of_cores(std::get<tt::tt_metal::MemoryConfig>(input_b).shard_spec)));
+    if (intermediate.has_value()) {
+        sizes.emplace_back(
+            std::make_tuple(
+                calculate_circular_buffer_l1_allocation_size_per_core(intermediate.value()),
+                get_num_of_cores(std::get<tt::tt_metal::MemoryConfig>(intermediate.value()).shard_spec)));
+    }
+    sizes.emplace_back(
+        std::make_tuple(
+            calculate_circular_buffer_l1_allocation_size_per_core(output),
+            get_num_of_cores(std::get<tt::tt_metal::MemoryConfig>(output).shard_spec)));
+
+    return std::move(sizes);
+}
+
+std::vector<std::tuple<uint32_t, uint32_t>> BroadcastWidthMultiCoreOpL1Usage::get_tensor_l1_allocations_per_core() const
+{
+    std::vector<std::tuple<uint32_t, uint32_t>> sizes;
+
+    if (intermediate.has_value()) {
+        sizes.emplace_back(
+            std::make_tuple(
+                calculate_tensor_l1_allocation_size_per_core(intermediate.value()),
+                get_num_of_cores(std::get<tt::tt_metal::MemoryConfig>(intermediate.value()).shard_spec)));
+    }
+    sizes.emplace_back(
+        std::make_tuple(
+            calculate_tensor_l1_allocation_size_per_core(output),
+            get_num_of_cores(std::get<tt::tt_metal::MemoryConfig>(output).shard_spec)));
+
+    return std::move(sizes);
+}
+
+std::optional<EltwiseOpParams> BroadcastWidthMultiCoreOpL1Usage::calculate_intermediate_buffer_impl(const EltwiseOpParams& input_a, const EltwiseOpParams& input_b)
+{
+    const auto shape_a = std::get<ttnn::types::Shape>(input_a);
+    const auto shape_b = std::get<ttnn::types::Shape>(input_b);
+
+    // internal buffer used for batch broadcasts
+    bool is_batch_broadcast = false;
+    if ((shape_a.rank() == 4) && (shape_a.rank() == 4)) {
+        if (shape_a[0] != shape_b[0]) {
+            is_batch_broadcast = true;
+        }
+    }
+    if (!is_batch_broadcast)
+    {
+        return std::nullopt;
+    }
+
+    auto intermediate = (shape_a[0] > shape_b[0]) ? input_b : input_a;
+    assert(std::get<ttnn::types::Shape>(intermediate).rank() == 4); // my implementation limitation
+
+    auto batch_size = (shape_a[0] > shape_b[0]) ? shape_a[0] : shape_b[0];;
+    vector<uint32_t> new_shape;
+    new_shape.push_back(batch_size);
+    for (int i = 1; i < 4; i++) {
+        new_shape.push_back(std::get<ttnn::types::Shape>(intermediate)[i]);
+    }
+
+    std::get<ttnn::types::Shape>(intermediate) = ttnn::Shape{tt::tt_metal::Shape{new_shape, tt::tt_metal::Padding{std::get<ttnn::types::Shape>(intermediate).rank()}}};
+
+    return std::make_optional(intermediate);
+}

--- a/ttnn/cpp/ttnn/operations/eltwise/binary/binary_l1_interface.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary/binary_l1_interface.hpp
@@ -1,0 +1,100 @@
+#pragma once
+
+#include <cstdint>
+#include <iostream>
+#include <optional>
+#include <vector>
+#include <tuple>
+
+// forward declarations
+namespace tt
+{
+namespace tt_metal
+{
+enum class DataType;
+enum class Layout;
+struct MemoryConfig;
+struct ShardSpec;
+} // namespace tt_metal
+} // namespace tt
+
+namespace ttnn {
+    namespace types {
+        struct Shape;
+    }
+} // namespace ttnn
+
+using EltwiseOpParams = std::tuple<ttnn::types::Shape, tt::tt_metal::DataType, tt::tt_metal::Layout, tt::tt_metal::MemoryConfig>;
+
+
+// these should go to a common tensor_l1_interface header or something
+uint32_t calculate_circular_buffer_l1_allocation_size_per_core(
+    const ttnn::types::Shape& shape,
+    const tt::tt_metal::DataType data_type,
+    const tt::tt_metal::Layout& layout,
+    const tt::tt_metal::MemoryConfig& memory_config);
+
+inline uint32_t calculate_circular_buffer_l1_allocation_size_per_core(EltwiseOpParams input)
+{
+    return calculate_circular_buffer_l1_allocation_size_per_core(std::get<ttnn::types::Shape>(input), std::get<tt::tt_metal::DataType>(input), std::get<tt::tt_metal::Layout>(input), std::get<tt::tt_metal::MemoryConfig>(input));
+}
+
+uint32_t calculate_tensor_l1_allocation_size_per_core(
+    const ttnn::types::Shape& shape,
+    const tt::tt_metal::DataType data_type,
+    const tt::tt_metal::Layout& layout,
+    const tt::tt_metal::MemoryConfig& memory_config);
+
+inline uint32_t calculate_tensor_l1_allocation_size_per_core(EltwiseOpParams input)
+{
+    return calculate_tensor_l1_allocation_size_per_core(std::get<ttnn::types::Shape>(input), std::get<tt::tt_metal::DataType>(input), std::get<tt::tt_metal::Layout>(input), std::get<tt::tt_metal::MemoryConfig>(input));
+}
+
+uint32_t get_num_of_cores(const std::optional<tt::tt_metal::ShardSpec>& shard_spec);
+
+class EltwiseOpL1Usage {
+public:
+    EltwiseOpL1Usage(const EltwiseOpParams& input_a, const EltwiseOpParams& input_b, const EltwiseOpParams& output);
+    virtual ~EltwiseOpL1Usage() = default;
+
+    virtual std::vector<std::tuple<uint32_t, uint32_t>> get_circular_buffer_l1_allocations_per_core() const = 0;
+    virtual std::vector<std::tuple<uint32_t, uint32_t>> get_tensor_l1_allocations_per_core() const = 0;
+
+protected:
+    EltwiseOpParams input_a;
+    EltwiseOpParams input_b;
+    EltwiseOpParams output;
+};
+
+class ElementWiseMultiCoreOpL1Usage : public EltwiseOpL1Usage {
+public:
+    ElementWiseMultiCoreOpL1Usage(const EltwiseOpParams& input_a, const EltwiseOpParams& input_b, const std::optional<EltwiseOpParams>& output);
+    virtual ~ElementWiseMultiCoreOpL1Usage() = default;
+
+    virtual std::vector<std::tuple<uint32_t, uint32_t>> get_circular_buffer_l1_allocations_per_core() const override;
+    virtual std::vector<std::tuple<uint32_t, uint32_t>> get_tensor_l1_allocations_per_core() const override;
+
+protected:
+    std::optional<EltwiseOpParams> intermediate;
+    std::optional<EltwiseOpParams> calculate_intermediate_buffer_impl(const EltwiseOpParams& input_a, const EltwiseOpParams& input_b);
+};
+
+class BroadcastWidthMultiCoreOpL1Usage : public EltwiseOpL1Usage {
+public:
+    BroadcastWidthMultiCoreOpL1Usage(const EltwiseOpParams& input_a, const EltwiseOpParams& input_b, const std::optional<EltwiseOpParams>& output);
+    virtual ~BroadcastWidthMultiCoreOpL1Usage() = default;
+
+    virtual std::vector<std::tuple<uint32_t, uint32_t>> get_circular_buffer_l1_allocations_per_core() const override;
+    virtual std::vector<std::tuple<uint32_t, uint32_t>> get_tensor_l1_allocations_per_core() const override;
+
+protected:
+    std::optional<EltwiseOpParams> intermediate;
+    std::optional<EltwiseOpParams> calculate_intermediate_buffer_impl(const EltwiseOpParams& input_a, const EltwiseOpParams& input_b);
+};
+
+class EltwiseOpL1UsageFactory
+{
+    public:
+    EltwiseOpL1UsageFactory() = delete;
+    static std::unique_ptr<EltwiseOpL1Usage> Make(const EltwiseOpParams& input_a, const EltwiseOpParams& input_b, const std::optional<EltwiseOpParams>& output = std::nullopt);
+};


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-mlir/issues/303
https://github.com/tenstorrent/tt-mlir/issues/304

### Problem description
Compiler TTNN API to expose valid op constraints and l1 usage for selected constraint and input/output shapes. 

### What's changed
This is a proposal approach to implement API to compiler/optimizer. 
Constraints would be tested against silicon; l1 usage would be tested against graph capture. 

There is a good amount of copied code that has been pulled out op implementation, feels like this code could be leveraged in the op as well. In case we want to take this direction. 

### Checklist
- [ ] Post commit CI passes
- [ ] Blackhole Post commit (if applicable)
- [ ] Model regression CI testing passes (if applicable)
- [ ] New/Existing tests provide coverage for changes
