### PR TITLE
BH LLK API Math Fidelity Test Coverage

### DIFF
--- a/tests/tt_metal/tt_metal/unit_tests/compute/test_broadcast.cpp
+++ b/tests/tt_metal/tt_metal/unit_tests/compute/test_broadcast.cpp
@@ -65,6 +65,7 @@ struct BroadcastConfig {
     ApiConvention api_convention;
     EltwiseOp eltwise_op;
     BroadcastDim broadcast_dim;
+    MathFidelity math_fidelity = MathFidelity::HiFi4;
 };
 
 void mask_src_b_for_broadcast(std::vector<tt::test_utils::df::bfloat16>& tile, const std::vector<uint32_t> &shape, BroadcastDim dim) {
@@ -81,11 +82,22 @@ void mask_src_b_for_broadcast(std::vector<tt::test_utils::df::bfloat16>& tile, c
     }
 }
 
-std::vector<tt::test_utils::df::bfloat16> gold_broadcast(std::vector<tt::test_utils::df::bfloat16>& src_a, std::vector<tt::test_utils::df::bfloat16>& src_b, const std::vector<uint32_t> &shape, EltwiseOp op, BroadcastDim dim) {
+std::vector<tt::test_utils::df::bfloat16> gold_broadcast(std::vector<tt::test_utils::df::bfloat16>& src_a, std::vector<tt::test_utils::df::bfloat16>& src_b, const std::vector<uint32_t> &shape, EltwiseOp op, BroadcastDim dim, MathFidelity math_fidelity = MathFidelity::HiFi4) {
     int num_rows = shape.at(0);
     int num_cols = shape.at(1);
 
+    uint16_t srca_fid_mask = 0xFFFF;
+    uint16_t srcb_fid_mask = 0xFFFF;
+
     std::vector<tt::test_utils::df::bfloat16> golden(num_cols * num_rows);
+
+    switch (math_fidelity) {
+        case MathFidelity::HiFi4:
+        case MathFidelity::HiFi3: { break; }
+        case MathFidelity::HiFi2: { srcb_fid_mask = 0xFFFE; break; }
+        case MathFidelity::LoFi: { srca_fid_mask = 0xFFF8; srcb_fid_mask = 0xFFFE; break; }
+        default: { TT_THROW("Unsupported MathFidelity={}", math_fidelity); break; }
+    }
 
     for (int i = 0; i < num_rows; i++) {
         for (int j = 0; j < num_cols; j++) {
@@ -102,7 +114,12 @@ std::vector<tt::test_utils::df::bfloat16> gold_broadcast(std::vector<tt::test_ut
             {
             case EltwiseOp::ADD: { golden[i * num_cols + j] = src_a[i * num_cols + j].to_float() + broadcast_value.to_float(); break; }
             case EltwiseOp::SUB: { golden[i * num_cols + j] = src_a[i * num_cols + j].to_float() - broadcast_value.to_float(); break; }
-            case EltwiseOp::MUL: { golden[i * num_cols + j] = src_a[i * num_cols + j].to_float() * broadcast_value.to_float(); break; }
+            case EltwiseOp::MUL: {
+                golden[i * num_cols + j] =
+                    tt::test_utils::df::bfloat16(std::bit_cast<uint32_t>(src_a[i * num_cols + j].to_packed() & srca_fid_mask)).to_float() *
+                    tt::test_utils::df::bfloat16(std::bit_cast<uint32_t>(broadcast_value.to_packed() & srcb_fid_mask)).to_float();
+                break;
+            }
             default: { TT_THROW("Unsupported EltwiseOp={}", op); break; }
             }
         }
@@ -198,7 +215,7 @@ void run_single_core_broadcast(tt_metal::Device* device, const BroadcastConfig& 
         program,
         "tests/tt_metal/tt_metal/test_kernels/compute/broadcast.cpp",
         core,
-        tt_metal::ComputeConfig{.compile_args = {}, .defines = defines});
+        tt_metal::ComputeConfig{.math_fidelity = test_config.math_fidelity, .compile_args = {}, .defines = defines});
 
     tt_metal::SetRuntimeArgs(
         program,
@@ -239,7 +256,7 @@ void run_single_core_broadcast(tt_metal::Device* device, const BroadcastConfig& 
 
     mask_src_b_for_broadcast(input1, {tile_width, tile_height}, test_config.broadcast_dim);
 
-    std::vector<tt::test_utils::df::bfloat16> golden = gold_broadcast(input0, input1, {tile_width, tile_height}, test_config.eltwise_op, test_config.broadcast_dim);
+    std::vector<tt::test_utils::df::bfloat16> golden = gold_broadcast(input0, input1, {tile_width, tile_height}, test_config.eltwise_op, test_config.broadcast_dim, test_config.math_fidelity);
 
     auto packed_input0 = pack_vector<uint32_t, tt::test_utils::df::bfloat16>(input0);
     auto packed_input1 = pack_vector<uint32_t, tt::test_utils::df::bfloat16>(input1);
@@ -264,7 +281,7 @@ void run_single_core_broadcast(tt_metal::Device* device, const BroadcastConfig& 
         dest_buffer_data_untilized,
         packed_golden,
         [&](const tt::test_utils::df::bfloat16& a, const tt::test_utils::df::bfloat16& b) {
-            return is_close(a, b, 0.0155f);
+            return is_close(a, b, 0.0155);
         });
     ASSERT_TRUE(result);
 }
@@ -275,7 +292,13 @@ class BroadcastParametrizedDeviceFixture : public DeviceFixture,
 };
 
 TEST_P(BroadcastParametrizedDeviceFixture, ComputeSingleTileBroadcast) {
-    unit_tests::compute::broadcast::run_single_core_broadcast(this->devices_.at(0), GetParam());
+    unit_tests::compute::broadcast::BroadcastConfig test_config = GetParam();
+    for (uint8_t i = uint8_t(MathFidelity::LoFi); i <= uint8_t(MathFidelity::HiFi4); i++) {
+        if (i == 1) continue;
+        log_info("Math Fidelity = {}", i);
+        test_config.math_fidelity = MathFidelity(i);
+        unit_tests::compute::broadcast::run_single_core_broadcast(this->devices_.at(0), test_config);
+    }
 }
 
 using namespace unit_tests::compute::broadcast;

--- a/tests/tt_metal/tt_metal/unit_tests/compute/test_broadcast.cpp
+++ b/tests/tt_metal/tt_metal/unit_tests/compute/test_broadcast.cpp
@@ -90,12 +90,13 @@ std::vector<tt::test_utils::df::bfloat16> gold_broadcast(std::vector<tt::test_ut
     uint16_t srcb_fid_mask = 0xFFFF;
 
     std::vector<tt::test_utils::df::bfloat16> golden(num_cols * num_rows);
+    auto arch = get_arch_from_string(get_env_arch_name());
 
     switch (math_fidelity) {
         case MathFidelity::HiFi4:
         case MathFidelity::HiFi3: { break; }
-        case MathFidelity::HiFi2: { srcb_fid_mask = 0xFFFE; break; }
-        case MathFidelity::LoFi: { srca_fid_mask = 0xFFF8; srcb_fid_mask = 0xFFFE; break; }
+        case MathFidelity::HiFi2: { srcb_fid_mask = (arch == tt::ARCH::GRAYSKULL) ? 0xFFF8 : 0xFFFE; break; }
+        case MathFidelity::LoFi: { srca_fid_mask = 0xFFF8; srcb_fid_mask = (arch == tt::ARCH::GRAYSKULL) ? 0xFFF8 : 0xFFFE; break; }
         default: { TT_THROW("Unsupported MathFidelity={}", math_fidelity); break; }
     }
 

--- a/tests/tt_metal/tt_metal/unit_tests_common/compute/matmul/test_matmul_X_tile.cpp
+++ b/tests/tt_metal/tt_metal/unit_tests_common/compute/matmul/test_matmul_X_tile.cpp
@@ -5,11 +5,13 @@
 #include <algorithm>
 #include <functional>
 #include <random>
+#include <chrono>
 
 #include "tests/tt_metal/tt_metal/unit_tests_common/common/common_fixture.hpp"
 #include "tt_metal/host_api.hpp"
 #include "tt_metal/detail/tt_metal.hpp"
 #include "common/bfloat16.hpp"
+#include "tt_metal/test_utils/comparison.hpp"
 #include "tt_metal/test_utils/deprecated/tensor.hpp"
 #include "test_tiles.hpp"
 #include "tests/tt_metal/test_utils/tilization.hpp"
@@ -28,7 +30,18 @@ struct MatmulTileConfig {
     string reader_kernel;
     string compute_kernel;
     vector<uint32_t> compute_kernel_args;
+    MathFidelity math_fidelity = MathFidelity::HiFi4;
 };
+
+void set_math_fid_masks(uint16_t &math_fid_mask, MathFidelity math_fidelity = MathFidelity::HiFi4) {
+    switch (math_fidelity) {
+        case MathFidelity::HiFi4:
+        case MathFidelity::HiFi3: { break; }
+        case MathFidelity::HiFi2:
+        case MathFidelity::LoFi: { math_fid_mask = 0xFFFE; break; }
+        default: { TT_THROW("Unsupported MathFidelity={}", math_fidelity); break; }
+    }
+}
 
 bool matmul_tile(CommonFixture *fixture, tt_metal::Device *device, const MatmulTileConfig &cfg, vector<uint32_t> activations, vector<std::seed_seq::result_type> weights, deprecated::Tensor<bfloat16> tensor){
     bool pass = true;
@@ -200,7 +213,9 @@ bool matmul_tile(CommonFixture *fixture, tt_metal::Device *device, const MatmulT
         program,
         cfg.compute_kernel,
         core,
-        tt_metal::ComputeConfig{.compile_args = cfg.compute_kernel_args, .defines = compute_defines}
+        tt_metal::ComputeConfig{.math_fidelity = cfg.math_fidelity,
+                                .compile_args = cfg.compute_kernel_args,
+                                .defines = compute_defines}
     );
 
     fixture->WriteBuffer(device, src0_dram_buffer, activations);
@@ -246,13 +261,22 @@ bool matmul_tile(CommonFixture *fixture, tt_metal::Device *device, const MatmulT
 
     auto result_bfp16 = unpack_uint32_vec_into_bfloat16_vec(result_vec);
     auto result_flat_layout = convert_to_flat_layout(result_bfp16);
+    auto golden = tensor.get_values();
+    auto result_untilized = test_utils::untilize(result_flat_layout, M*32, N*32);
 
-    if (cfg.M > 1 || cfg.N > 1 || cfg.K > 1){
-        auto result_untilized = test_utils::untilize(result_flat_layout, M*32, N*32);
-        pass &= (tensor.get_values() == result_untilized);
-    }else {
-        pass &= (tensor.get_values() == result_flat_layout); // src1 is all 0's
+    uint16_t math_fid_mask = 0xFFFF;
+    set_math_fid_masks(math_fid_mask, cfg.math_fidelity);
+    // If we're testing LoFi/HiFi2 we generate matching golden (trunc LSB).
+    // Note that this will work only for multiplying with identity matrix
+    for (auto i = 0; i < golden.size(); i++) {
+        golden[i] = bfloat16(golden[i].to_uint16() & math_fid_mask);
     }
+    if (cfg.M > 1 || cfg.N > 1 || cfg.K > 1){
+        pass &= (golden == result_untilized);
+    } else {
+        pass &= (golden == result_flat_layout); // src1 is all 0's
+    }
+
     DeallocateBuffer(*src0_dram_buffer);
     DeallocateBuffer(*src1_dram_buffer);
     if (cfg.with_bias || cfg.test_init_short) {
@@ -267,185 +291,256 @@ bool matmul_tile(CommonFixture *fixture, tt_metal::Device *device, const MatmulT
 } // namespace unit_tests_common::matmul::test_matmul_X_tile
 
 TEST_F(CommonFixture, MatmulSingleTile){
-    unit_tests_common::matmul::test_matmul_X_tile::MatmulTileConfig matmul_config = {
-        .M = 1, .K = 1, .N = 1,
-        .reader_kernel = "tests/tt_metal/tt_metal/test_kernels/dataflow/reader_matmul_blocked.cpp",
-        .compute_kernel = "tests/tt_metal/tt_metal/test_kernels/compute/matmul.cpp",
-        .compute_kernel_args = {
-            1, // block_tile_dim
-            1, // dst_tile_rows
-            1, // dst_tile_cols
-            1, // block_cnt
-            1, // in0_block_tile_cnt
-            1, // in1_block_tile_cnt
-            1 // out_block_tile_cnt
+    for (uint8_t i = uint8_t(MathFidelity::LoFi); i <= uint8_t(MathFidelity::HiFi4); i++) {
+        if (i == 1) continue;
+        unit_tests_common::matmul::test_matmul_X_tile::MatmulTileConfig matmul_config = {
+            .M = 1, .K = 1, .N = 1,
+            .reader_kernel = "tests/tt_metal/tt_metal/test_kernels/dataflow/reader_matmul_blocked.cpp",
+            .compute_kernel = "tests/tt_metal/tt_metal/test_kernels/compute/matmul.cpp",
+            .compute_kernel_args = {
+                1, // block_tile_dim
+                1, // dst_tile_rows
+                1, // dst_tile_cols
+                1, // block_cnt
+                1, // in0_block_tile_cnt
+                1, // in1_block_tile_cnt
+                1 // out_block_tile_cnt
+            },
+            .math_fidelity = MathFidelity(i)
+        };
+        SHAPE shape = {1, 1, 32, 32};
+        tt::log_info(tt::LogTest, "Math Fidelity = {}", i);
+        tt::deprecated::Tensor<bfloat16> tensor = tt::deprecated::initialize_tensor<bfloat16>(shape, tt::deprecated::Initialize::RANDOM, 100, std::chrono::system_clock::now().time_since_epoch().count());
+        auto activations_tile_layout = convert_to_tile_layout(tensor.get_values());
+        auto activations = pack_bfloat16_vec_into_uint32_vec(activations_tile_layout);
+
+        auto identity = create_identity_matrix(32, 32, 32); //bfloat16 32x32 identity
+        auto weights_tile_layout = convert_to_tile_layout(identity);
+        auto weights = pack_bfloat16_vec_into_uint32_vec(weights_tile_layout);
+
+        for(unsigned int id = 0; id < devices_.size(); id++){
+            ASSERT_TRUE(unit_tests_common::matmul::test_matmul_X_tile::matmul_tile(this, devices_.at(id), matmul_config, activations, weights, tensor));
         }
-    };
-    SHAPE shape = {1, 1, 32, 32};
-    tt::deprecated::Tensor<bfloat16> tensor = tt::deprecated::initialize_tensor<bfloat16>(shape, tt::deprecated::Initialize::RANDOM, 100, std::chrono::system_clock::now().time_since_epoch().count());
-    auto activations_tile_layout = convert_to_tile_layout(tensor.get_values());
-    auto activations = pack_bfloat16_vec_into_uint32_vec(activations_tile_layout);
-
-    auto identity = create_identity_matrix(32, 32, 32); //bfloat16 32x32 identity
-    auto weights_tile_layout = convert_to_tile_layout(identity);
-    auto weights = pack_bfloat16_vec_into_uint32_vec(weights_tile_layout);
-
-    for(unsigned int id = 0; id < devices_.size(); id++){
-        ASSERT_TRUE(unit_tests_common::matmul::test_matmul_X_tile::matmul_tile(this, devices_.at(id), matmul_config, activations, weights, tensor));
     }
 }
 
 TEST_F(CommonFixture, MatmulMultiTile){
-    uint32_t M = 4;
-    uint32_t N = 4;
-    uint32_t K = 4;
-    unit_tests_common::matmul::test_matmul_X_tile::MatmulTileConfig matmul_config = {
-        .M = M, .K = K, .N = N,
-        .reader_kernel = "tests/tt_metal/tt_metal/test_kernels/dataflow/reader_matmul_with_bias_blocked.cpp",
-        .compute_kernel = "tests/tt_metal/tt_metal/test_kernels/compute/matmul_with_bias.cpp",
-        .compute_kernel_args = {
-            1, // block_tile_dim, within block, how many tiles are on the K dim
-            M, // dst_tile_rows
-            N, // dst_tile_cols
-            K, // block_cnt, across blocks, how many tiles are on the K dim
-            M, // in0_block_tile_cnt, M * block_tile_dim
-            N, // in1_block_tile_cnt,  N * block_tile_dim
-            (M * N), // out_block_tile_cnt
-            matmul_config.with_bias // whether or not to use bias
+    for (uint8_t i = uint8_t(MathFidelity::LoFi); i <= uint8_t(MathFidelity::HiFi4); i++) {
+        if (i == 1) continue;
+        uint32_t M = 4;
+        uint32_t N = 4;
+        uint32_t K = 4;
+        unit_tests_common::matmul::test_matmul_X_tile::MatmulTileConfig matmul_config = {
+            .M = M, .K = K, .N = N,
+            .reader_kernel = "tests/tt_metal/tt_metal/test_kernels/dataflow/reader_matmul_with_bias_blocked.cpp",
+            .compute_kernel = "tests/tt_metal/tt_metal/test_kernels/compute/matmul_with_bias.cpp",
+            .compute_kernel_args = {
+                1, // block_tile_dim, within block, how many tiles are on the K dim
+                M, // dst_tile_rows
+                N, // dst_tile_cols
+                K, // block_cnt, across blocks, how many tiles are on the K dim
+                M, // in0_block_tile_cnt, M * block_tile_dim
+                N, // in1_block_tile_cnt,  N * block_tile_dim
+                (M * N), // out_block_tile_cnt
+                matmul_config.with_bias // whether or not to use bias
+            },
+            .math_fidelity = MathFidelity(i)
+        };
+        tt::log_info(tt::LogTest, "Math Fidelity = {}", i);
+        SHAPE shape = {1, 1, M * 32, K * 32};
+        tt::deprecated::Tensor<bfloat16> tensor = tt::deprecated::initialize_tensor<bfloat16>(shape, tt::deprecated::Initialize::RANDOM, 100, std::chrono::system_clock::now().time_since_epoch().count());
+        auto activations_tilized = test_utils::tilize(tensor.get_values(), M * 32, K * 32);
+        auto activations_tile_layout = convert_to_tile_layout(activations_tilized);
+        auto activations = pack_bfloat16_vec_into_uint32_vec(activations_tile_layout);
+        auto activations_tile_transposed = transpose_tiles(activations, M, K, 1);
+
+        auto identity = create_identity_matrix(K * 32, N * 32, std::min(K, N) * 32); //bfloat16 32x32 identity
+        auto identity_tilized = test_utils::tilize(identity, K * 32, N * 32);
+        auto weights_tile_layout = convert_to_tile_layout(identity_tilized);
+        auto weights = pack_bfloat16_vec_into_uint32_vec(weights_tile_layout);
+
+        for(unsigned int id = 0; id < devices_.size(); id++){
+            ASSERT_TRUE(unit_tests_common::matmul::test_matmul_X_tile::matmul_tile(this, devices_.at(id), matmul_config, activations_tile_transposed, weights, tensor));
+            log_info(LogTest, "Multi tile with no bias passed");
+            matmul_config.with_bias = true;
+            ASSERT_TRUE(unit_tests_common::matmul::test_matmul_X_tile::matmul_tile(this, devices_.at(id), matmul_config, activations_tile_transposed, weights, tensor));
+            log_info(LogTest, "Multi tile with bias passed");
         }
-    };
-
-    SHAPE shape = {1, 1, M * 32, K * 32};
-    tt::deprecated::Tensor<bfloat16> tensor = tt::deprecated::initialize_tensor<bfloat16>(shape, tt::deprecated::Initialize::RANDOM, 100, std::chrono::system_clock::now().time_since_epoch().count());
-    auto activations_tilized = test_utils::tilize(tensor.get_values(), M * 32, K * 32);
-    auto activations_tile_layout = convert_to_tile_layout(activations_tilized);
-    auto activations = pack_bfloat16_vec_into_uint32_vec(activations_tile_layout);
-    auto activations_tile_transposed = transpose_tiles(activations, M, K, 1);
-
-    auto identity = create_identity_matrix(K * 32, N * 32, std::min(K, N) * 32); //bfloat16 32x32 identity
-    auto identity_tilized = test_utils::tilize(identity, K * 32, N * 32);
-    auto weights_tile_layout = convert_to_tile_layout(identity_tilized);
-    auto weights = pack_bfloat16_vec_into_uint32_vec(weights_tile_layout);
-
-    for(unsigned int id = 0; id < devices_.size(); id++){
-        ASSERT_TRUE(unit_tests_common::matmul::test_matmul_X_tile::matmul_tile(this, devices_.at(id), matmul_config, activations_tile_transposed, weights, tensor));
-        log_info(LogTest, "Multi tile with no bias passed");
-        matmul_config.with_bias = true;
-        ASSERT_TRUE(unit_tests_common::matmul::test_matmul_X_tile::matmul_tile(this, devices_.at(id), matmul_config, activations_tile_transposed, weights, tensor));
-        log_info(LogTest, "Multi tile with bias passed");
     }
 }
 
 TEST_F(CommonFixture, MatmulBlock){
-    uint32_t M = 4;
-    uint32_t N = 4;
-    uint32_t K = 4;
-    unit_tests_common::matmul::test_matmul_X_tile::MatmulTileConfig matmul_config = {
-        .M = M, .K = K, .N = N,
-        .test_init_short = false,
-        .with_dt = false,
-        .reader_kernel = "tests/tt_metal/tt_metal/test_kernels/dataflow/reader_matmul_with_bias_blocked.cpp",
-        .compute_kernel = "tests/tt_metal/tt_metal/test_kernels/compute/matmul_block.cpp",
-        .compute_kernel_args = {
-            1, // block_tile_dim, within block, how many tiles are on the K dim
-            M, // dst_tile_rows
-            N, // dst_tile_cols
-            K, // block_cnt, across blocks, how many tiles are on the K dim
-            M, // in0_block_tile_cnt, M * block_tile_dim
-            N, // in1_block_tile_cnt,  N * block_tile_dim
-            (M * N), // out_block_tile_cnt
+    for (uint8_t i = uint8_t(MathFidelity::LoFi); i <= uint8_t(MathFidelity::HiFi4); i++) {
+        if (i == 1) continue;
+        uint32_t M = 4;
+        uint32_t N = 4;
+        uint32_t K = 4;
+        unit_tests_common::matmul::test_matmul_X_tile::MatmulTileConfig matmul_config = {
+            .M = M, .K = K, .N = N,
+            .test_init_short = false,
+            .with_dt = false,
+            .reader_kernel = "tests/tt_metal/tt_metal/test_kernels/dataflow/reader_matmul_with_bias_blocked.cpp",
+            .compute_kernel = "tests/tt_metal/tt_metal/test_kernels/compute/matmul_block.cpp",
+            .compute_kernel_args = {
+                1, // block_tile_dim, within block, how many tiles are on the K dim
+                M, // dst_tile_rows
+                N, // dst_tile_cols
+                K, // block_cnt, across blocks, how many tiles are on the K dim
+                M, // in0_block_tile_cnt, M * block_tile_dim
+                N, // in1_block_tile_cnt,  N * block_tile_dim
+                (M * N), // out_block_tile_cnt
+            },
+            .math_fidelity = MathFidelity(i)
+        };
+        tt::log_info(tt::LogTest, "Math Fidelity = {}", i);
+        SHAPE shape = {1, 1, M * 32, K * 32};
+        tt::deprecated::Tensor<bfloat16> tensor = tt::deprecated::initialize_tensor<bfloat16>(shape, tt::deprecated::Initialize::RANDOM, 100, std::chrono::system_clock::now().time_since_epoch().count());
+        auto activations_tilized = test_utils::tilize(tensor.get_values(), M * 32, K * 32);
+        auto activations_tile_layout = convert_to_tile_layout(activations_tilized);
+        auto activations = pack_bfloat16_vec_into_uint32_vec(activations_tile_layout);
+        auto activations_tile_transposed = transpose_tiles(activations, M, K, 1);
+
+        auto identity = create_identity_matrix(K * 32, N * 32, std::min(K, N) * 32); //bfloat16 32x32 identity
+        auto identity_tilized = test_utils::tilize(identity, K * 32, N * 32);
+        auto weights_tile_layout = convert_to_tile_layout(identity_tilized);
+        auto weights = pack_bfloat16_vec_into_uint32_vec(weights_tile_layout);
+
+        for(unsigned int id = 0; id < devices_.size(); id++){
+            ASSERT_TRUE(unit_tests_common::matmul::test_matmul_X_tile::matmul_tile(this, devices_.at(id), matmul_config, activations_tile_transposed, weights, tensor));
         }
-    };
-
-    SHAPE shape = {1, 1, M * 32, K * 32};
-    tt::deprecated::Tensor<bfloat16> tensor = tt::deprecated::initialize_tensor<bfloat16>(shape, tt::deprecated::Initialize::RANDOM, 100, std::chrono::system_clock::now().time_since_epoch().count());
-    auto activations_tilized = test_utils::tilize(tensor.get_values(), M * 32, K * 32);
-    auto activations_tile_layout = convert_to_tile_layout(activations_tilized);
-    auto activations = pack_bfloat16_vec_into_uint32_vec(activations_tile_layout);
-    auto activations_tile_transposed = transpose_tiles(activations, M, K, 1);
-
-    auto identity = create_identity_matrix(K * 32, N * 32, std::min(K, N) * 32); //bfloat16 32x32 identity
-    auto identity_tilized = test_utils::tilize(identity, K * 32, N * 32);
-    auto weights_tile_layout = convert_to_tile_layout(identity_tilized);
-    auto weights = pack_bfloat16_vec_into_uint32_vec(weights_tile_layout);
-
-    for(unsigned int id = 0; id < devices_.size(); id++){
-        ASSERT_TRUE(unit_tests_common::matmul::test_matmul_X_tile::matmul_tile(this, devices_.at(id), matmul_config, activations_tile_transposed, weights, tensor));
     }
 }
 
 TEST_F(CommonFixture, MatmulBlockInitShort){
-    uint32_t M = 4;
-    uint32_t N = 4;
-    uint32_t K = 4;
-    unit_tests_common::matmul::test_matmul_X_tile::MatmulTileConfig matmul_config = {
-        .M = M, .K = K, .N = N,
-        .test_init_short = true,
-        .with_dt = false,
-        .reader_kernel = "tests/tt_metal/tt_metal/test_kernels/dataflow/reader_matmul_with_bias_blocked.cpp",
-        .compute_kernel = "tests/tt_metal/tt_metal/test_kernels/compute/matmul_block.cpp",
-        .compute_kernel_args = {
-            1, // block_tile_dim, within block, how many tiles are on the K dim
-            M, // dst_tile_rows
-            N, // dst_tile_cols
-            K, // block_cnt, across blocks, how many tiles are on the K dim
-            M, // in0_block_tile_cnt, M * block_tile_dim
-            N, // in1_block_tile_cnt,  N * block_tile_dim
-            (M * N), // out_block_tile_cnt
+    for (uint8_t i = uint8_t(MathFidelity::LoFi); i <= uint8_t(MathFidelity::HiFi4); i++) {
+        if (i == 1) continue;
+        uint32_t M = 4;
+        uint32_t N = 4;
+        uint32_t K = 4;
+        unit_tests_common::matmul::test_matmul_X_tile::MatmulTileConfig matmul_config = {
+            .M = M, .K = K, .N = N,
+            .test_init_short = true,
+            .with_dt = false,
+            .reader_kernel = "tests/tt_metal/tt_metal/test_kernels/dataflow/reader_matmul_with_bias_blocked.cpp",
+            .compute_kernel = "tests/tt_metal/tt_metal/test_kernels/compute/matmul_block.cpp",
+            .compute_kernel_args = {
+                1, // block_tile_dim, within block, how many tiles are on the K dim
+                M, // dst_tile_rows
+                N, // dst_tile_cols
+                K, // block_cnt, across blocks, how many tiles are on the K dim
+                M, // in0_block_tile_cnt, M * block_tile_dim
+                N, // in1_block_tile_cnt,  N * block_tile_dim
+                (M * N), // out_block_tile_cnt
+            },
+            .math_fidelity = MathFidelity(i)
+        };
+        tt::log_info(tt::LogTest, "Math Fidelity = {}", i);
+        SHAPE shape = {1, 1, M * 32, K * 32};
+        tt::deprecated::Tensor<bfloat16> tensor = tt::deprecated::initialize_tensor<bfloat16>(shape, tt::deprecated::Initialize::RANDOM, 100, std::chrono::system_clock::now().time_since_epoch().count());
+        auto activations_tilized = test_utils::tilize(tensor.get_values(), M * 32, K * 32);
+        auto activations_tile_layout = convert_to_tile_layout(activations_tilized);
+        auto activations = pack_bfloat16_vec_into_uint32_vec(activations_tile_layout);
+        auto activations_tile_transposed = transpose_tiles(activations, M, K, 1);
+
+        auto identity = create_identity_matrix(K * 32, N * 32, std::min(K, N) * 32); //bfloat16 32x32 identity
+        auto identity_tilized = test_utils::tilize(identity, K * 32, N * 32);
+        auto weights_tile_layout = convert_to_tile_layout(identity_tilized);
+        auto weights = pack_bfloat16_vec_into_uint32_vec(weights_tile_layout);
+
+        for(unsigned int id = 0; id < devices_.size(); id++){
+            ASSERT_TRUE(unit_tests_common::matmul::test_matmul_X_tile::matmul_tile(this, devices_.at(id), matmul_config, activations_tile_transposed, weights, tensor));
         }
-    };
-
-    SHAPE shape = {1, 1, M * 32, K * 32};
-    tt::deprecated::Tensor<bfloat16> tensor = tt::deprecated::initialize_tensor<bfloat16>(shape, tt::deprecated::Initialize::RANDOM, 100, std::chrono::system_clock::now().time_since_epoch().count());
-    auto activations_tilized = test_utils::tilize(tensor.get_values(), M * 32, K * 32);
-    auto activations_tile_layout = convert_to_tile_layout(activations_tilized);
-    auto activations = pack_bfloat16_vec_into_uint32_vec(activations_tile_layout);
-    auto activations_tile_transposed = transpose_tiles(activations, M, K, 1);
-
-    auto identity = create_identity_matrix(K * 32, N * 32, std::min(K, N) * 32); //bfloat16 32x32 identity
-    auto identity_tilized = test_utils::tilize(identity, K * 32, N * 32);
-    auto weights_tile_layout = convert_to_tile_layout(identity_tilized);
-    auto weights = pack_bfloat16_vec_into_uint32_vec(weights_tile_layout);
-
-    for(unsigned int id = 0; id < devices_.size(); id++){
-        ASSERT_TRUE(unit_tests_common::matmul::test_matmul_X_tile::matmul_tile(this, devices_.at(id), matmul_config, activations_tile_transposed, weights, tensor));
     }
 }
 
 TEST_F(CommonFixture, MatmulBlockInitShortWithDt){
-    uint32_t M = 4;
-    uint32_t N = 4;
-    uint32_t K = 4;
-    unit_tests_common::matmul::test_matmul_X_tile::MatmulTileConfig matmul_config = {
-        .M = M, .K = K, .N = N,
-        .test_init_short = true,
-        .with_dt = true,
-        .reader_kernel = "tests/tt_metal/tt_metal/test_kernels/dataflow/reader_matmul_with_bias_blocked.cpp",
-        .compute_kernel = "tests/tt_metal/tt_metal/test_kernels/compute/matmul_block.cpp",
-        .compute_kernel_args = {
-            1, // block_tile_dim, within block, how many tiles are on the K dim
-            M, // dst_tile_rows
-            N, // dst_tile_cols
-            K, // block_cnt, across blocks, how many tiles are on the K dim
-            M, // in0_block_tile_cnt, M * block_tile_dim
-            N, // in1_block_tile_cnt,  N * block_tile_dim
-            (M * N), // out_block_tile_cnt
+    for (uint8_t i = uint8_t(MathFidelity::LoFi); i <= uint8_t(MathFidelity::HiFi4); i++) {
+        if (i == 1) continue;
+        uint32_t M = 4;
+        uint32_t N = 4;
+        uint32_t K = 4;
+        unit_tests_common::matmul::test_matmul_X_tile::MatmulTileConfig matmul_config = {
+            .M = M, .K = K, .N = N,
+            .test_init_short = true,
+            .with_dt = true,
+            .reader_kernel = "tests/tt_metal/tt_metal/test_kernels/dataflow/reader_matmul_with_bias_blocked.cpp",
+            .compute_kernel = "tests/tt_metal/tt_metal/test_kernels/compute/matmul_block.cpp",
+            .compute_kernel_args = {
+                1, // block_tile_dim, within block, how many tiles are on the K dim
+                M, // dst_tile_rows
+                N, // dst_tile_cols
+                K, // block_cnt, across blocks, how many tiles are on the K dim
+                M, // in0_block_tile_cnt, M * block_tile_dim
+                N, // in1_block_tile_cnt,  N * block_tile_dim
+                (M * N), // out_block_tile_cnt
+            },
+            .math_fidelity = MathFidelity(i)
+        };
+        tt::log_info(tt::LogTest, "Math Fidelity = {}", i);
+        SHAPE shape = {1, 1, M * 32, K * 32};
+        tt::deprecated::Tensor<bfloat16> tensor = tt::deprecated::initialize_tensor<bfloat16>(shape, tt::deprecated::Initialize::RANDOM, 100, std::chrono::system_clock::now().time_since_epoch().count());
+        auto activations_tilized = test_utils::tilize(tensor.get_values(), M * 32, K * 32);
+        auto activations_tile_layout = convert_to_tile_layout(activations_tilized);
+        auto activations = pack_bfloat16_vec_into_uint32_vec(activations_tile_layout);
+        auto activations_tile_transposed = transpose_tiles(activations, M, K, 1);
+
+        auto identity = create_identity_matrix(K * 32, N * 32, std::min(K, N) * 32); //bfloat16 32x32 identity
+        auto identity_tilized = test_utils::tilize(identity, K * 32, N * 32);
+        auto weights_tile_layout = convert_to_tile_layout(identity_tilized);
+        auto weights = pack_bfloat16_vec_into_uint32_vec(weights_tile_layout);
+
+        for(unsigned int id = 0; id < devices_.size(); id++){
+            ASSERT_TRUE(unit_tests_common::matmul::test_matmul_X_tile::matmul_tile(this, devices_.at(id), matmul_config, activations_tile_transposed, weights, tensor));
         }
-    };
+    }
+}
 
-    SHAPE shape = {1, 1, M * 32, K * 32};
-    tt::deprecated::Tensor<bfloat16> tensor = tt::deprecated::initialize_tensor<bfloat16>(shape, tt::deprecated::Initialize::RANDOM, 100, std::chrono::system_clock::now().time_since_epoch().count());
-    auto activations_tilized = test_utils::tilize(tensor.get_values(), M * 32, K * 32);
-    auto activations_tile_layout = convert_to_tile_layout(activations_tilized);
-    auto activations = pack_bfloat16_vec_into_uint32_vec(activations_tile_layout);
-    auto activations_tile_transposed = transpose_tiles(activations, M, K, 1);
+TEST_F(CommonFixture, MatmulMultiTileMathFid){
+    for (uint8_t i = uint8_t(MathFidelity::LoFi); i <= uint8_t(MathFidelity::HiFi4); i++) {
+        if (i == 1) continue;
+        auto elapsed = std::chrono::nanoseconds(0);
+        uint32_t M = 4;
+        uint32_t N = 4;
+        uint32_t K = 4;
+        unit_tests_common::matmul::test_matmul_X_tile::MatmulTileConfig matmul_config = {
+            .M = M, .K = K, .N = N,
+            .reader_kernel = "tests/tt_metal/tt_metal/test_kernels/dataflow/reader_matmul_with_bias_blocked.cpp",
+            .compute_kernel = "tests/tt_metal/tt_metal/test_kernels/compute/matmul_with_bias.cpp",
+            .compute_kernel_args = {
+                1, // block_tile_dim, within block, how many tiles are on the K dim
+                M, // dst_tile_rows
+                N, // dst_tile_cols
+                K, // block_cnt, across blocks, how many tiles are on the K dim
+                M, // in0_block_tile_cnt, M * block_tile_dim
+                N, // in1_block_tile_cnt,  N * block_tile_dim
+                (M * N), // out_block_tile_cnt
+                matmul_config.with_bias // whether or not to use bias
+            },
+            .math_fidelity = MathFidelity(i)
+        };
+        tt::log_info(tt::LogTest, "Math Fidelity = {}", i);
+        SHAPE shape = {1, 1, M * 32, K * 32};
+        tt::deprecated::Tensor<bfloat16> tensor = tt::deprecated::initialize_tensor<bfloat16>(shape, tt::deprecated::Initialize::RANDOM, 100, std::chrono::system_clock::now().time_since_epoch().count());
 
-    auto identity = create_identity_matrix(K * 32, N * 32, std::min(K, N) * 32); //bfloat16 32x32 identity
-    auto identity_tilized = test_utils::tilize(identity, K * 32, N * 32);
-    auto weights_tile_layout = convert_to_tile_layout(identity_tilized);
-    auto weights = pack_bfloat16_vec_into_uint32_vec(weights_tile_layout);
+        auto activations_tilized = test_utils::tilize(tensor.get_values(), M * 32, K * 32);
+        auto activations_tile_layout = convert_to_tile_layout(activations_tilized);
+        auto activations = pack_bfloat16_vec_into_uint32_vec(activations_tile_layout);
+        auto activations_tile_transposed = transpose_tiles(activations, M, K, 1);
 
-    for(unsigned int id = 0; id < devices_.size(); id++){
-        ASSERT_TRUE(unit_tests_common::matmul::test_matmul_X_tile::matmul_tile(this, devices_.at(id), matmul_config, activations_tile_transposed, weights, tensor));
+        auto identity = create_identity_matrix(K * 32, N * 32, std::min(K, N) * 32); //bfloat16 32x32 identity
+        auto identity_tilized = test_utils::tilize(identity, K * 32, N * 32);
+        auto weights_tile_layout = convert_to_tile_layout(identity_tilized);
+        auto weights = pack_bfloat16_vec_into_uint32_vec(weights_tile_layout);
+        for (uint8_t j = 0; j <  10; j++) {
+            for(unsigned int id = 0; id < devices_.size(); id++){
+                auto begin = std::chrono::high_resolution_clock::now();
+                ASSERT_TRUE(unit_tests_common::matmul::test_matmul_X_tile::matmul_tile(this, devices_.at(id), matmul_config, activations_tile_transposed, weights, tensor));
+                matmul_config.with_bias = true;
+                ASSERT_TRUE(unit_tests_common::matmul::test_matmul_X_tile::matmul_tile(this, devices_.at(id), matmul_config, activations_tile_transposed, weights, tensor));
+                auto end = std::chrono::high_resolution_clock::now();
+                elapsed += std::chrono::duration_cast<std::chrono::nanoseconds>(end - begin);
+            }
+        }
+        tt::log_info(tt::LogTest, "This kernel call lasted for {:.5f}s on average.", elapsed.count()*1e-10);
     }
 }

--- a/tests/tt_metal/tt_metal/unit_tests_common/compute/matmul/test_matmul_large_block.cpp
+++ b/tests/tt_metal/tt_metal/unit_tests_common/compute/matmul/test_matmul_large_block.cpp
@@ -17,15 +17,17 @@
 #include "tests/tt_metal/tt_metal/unit_tests_common/compute/matmul/matmul_utils.hpp"
 
 using namespace tt;
+using namespace tt::test_utils;
 
 namespace unit_tests_common::matmul::test_matmul_large_block {
 
 void set_math_fid_masks(uint16_t &math_fid_mask, MathFidelity math_fidelity = MathFidelity::HiFi4) {
+    auto arch = get_arch_from_string(get_env_arch_name());
     switch (math_fidelity) {
         case MathFidelity::HiFi4:
         case MathFidelity::HiFi3: { break; }
         case MathFidelity::HiFi2:
-        case MathFidelity::LoFi: { math_fid_mask = 0xFFFE; break; }
+        case MathFidelity::LoFi: { math_fid_mask = (arch == tt::ARCH::GRAYSKULL) ? 0xFFF8 : 0xFFFE; break; }
         default: { TT_THROW("Unsupported MathFidelity={}", math_fidelity); break; }
     }
 }

--- a/tt_metal/jit_build/genfiles.cpp
+++ b/tt_metal/jit_build/genfiles.cpp
@@ -358,6 +358,7 @@ static void generate_math_fidelity_descriptor(JitBuildOptions& options) {
 
     file_stream.open(math_fidelity_descriptor);
     file_stream << "constexpr std::int32_t MATH_FIDELITY = " << (int)desc.get_hlk_math_fidelity() << ";" << endl;
+    // file_stream << "constexpr std::int32_t MATH_FIDELITY = " << "1" << ";" << endl;
     file_stream.close();
 }
 

--- a/tt_metal/jit_build/genfiles.cpp
+++ b/tt_metal/jit_build/genfiles.cpp
@@ -358,7 +358,6 @@ static void generate_math_fidelity_descriptor(JitBuildOptions& options) {
 
     file_stream.open(math_fidelity_descriptor);
     file_stream << "constexpr std::int32_t MATH_FIDELITY = " << (int)desc.get_hlk_math_fidelity() << ";" << endl;
-    // file_stream << "constexpr std::int32_t MATH_FIDELITY = " << "1" << ";" << endl;
     file_stream.close();
 }
 

--- a/tt_metal/kernels/compute/eltwise_binary.cpp
+++ b/tt_metal/kernels/compute/eltwise_binary.cpp
@@ -5,13 +5,9 @@
 #include "compute_kernel_api/eltwise_binary.h"
 
 #include <cstdint>
-#include "debug/dprint.h"
 
 #include "compute_kernel_api/eltwise_unary/sfpu_split_includes.h"
 #include "compute_kernel_api/tile_move_copy.h"
-
-#define STRINGIFY(x) #x
-#define TOSTRING(x) STRINGIFY(x)
 namespace NAMESPACE {
 void MAIN {
     uint32_t per_core_block_cnt = get_arg_val<uint32_t>(0);

--- a/tt_metal/kernels/compute/eltwise_binary.cpp
+++ b/tt_metal/kernels/compute/eltwise_binary.cpp
@@ -5,10 +5,13 @@
 #include "compute_kernel_api/eltwise_binary.h"
 
 #include <cstdint>
+#include "debug/dprint.h"
 
 #include "compute_kernel_api/eltwise_unary/sfpu_split_includes.h"
 #include "compute_kernel_api/tile_move_copy.h"
 
+#define STRINGIFY(x) #x
+#define TOSTRING(x) STRINGIFY(x)
 namespace NAMESPACE {
 void MAIN {
     uint32_t per_core_block_cnt = get_arg_val<uint32_t>(0);
@@ -26,7 +29,11 @@ void MAIN {
     binary_op_init_common(cb_inp0, cb_inp1, cb_out0);
 
 #if not defined ELTWISE_DEST_REUSE_TYPE
+#ifdef FULL_INIT
+    binary_op_specific_init<true, ELTWISE_OP_TYPE>();
+#else
     binary_op_specific_init<false, ELTWISE_OP_TYPE>();
+#endif
 #endif
 
 #ifdef PACK_RELU
@@ -51,7 +58,12 @@ void MAIN {
 #endif
 
 #ifdef DST_ACCUM_MODE
-        ELTWISE_OP_INIT(cb_inp0, cb_inp1, true);
+// The following define is needed if mul_tiles/_init is used
+#ifdef MUL_TILES_WITH_DST_ACCUM
+    ELTWISE_OP_INIT(cb_inp0, cb_inp1);
+#else
+    ELTWISE_OP_INIT(cb_inp0, cb_inp1, true);
+#endif
 #endif
 
 #ifdef ELTWISE_DEST_REUSE_TYPE


### PR DESCRIPTION
### Ticket
N/A

### Problem description
Blackhole LLK API tests do not cover all possible LLK template argument combinations. 

### What's changed
This PR introduces MATH_FIDELITY parameter sweep for most API calls tested so far:
1. Added math_fid test coverage for broadcasts and appropriate inits.
2. Added math_fid test coverage for eltwise ops and appropriate inits.
3. Added math_fid test coverage for matmuls and appropriate inits.
4. Added dst_acc test coverage where convenient.

reduce* calls will be addressed in a separate PR. 

### Checklist
- [x] Post commit CI passes
- [x] Blackhole Post commit (if applicable)
- [ ] Model regression CI testing passes (if applicable)
- [x] New/Existing tests provide coverage for changes
