### PR TITLE
#12195: Use `ttnn.reshard` for all resharding in UNet Shallow

### DIFF
--- a/models/experimental/functional_unet/tt/unet_shallow_ttnn.py
+++ b/models/experimental/functional_unet/tt/unet_shallow_ttnn.py
@@ -484,11 +484,12 @@ class UNet:
 
     def bottleneck(self, x):
         if x.is_sharded():
-            x = ttnn.sharded_to_interleaved(x, ttnn.L1_MEMORY_CONFIG)
-        x = ttnn.interleaved_to_sharded(
-            x,
-            self.bnc_sharded_memory_config,
-        )
+            x = ttnn.reshard(x, self.bnc_sharded_memory_config)
+        else:
+            x = ttnn.interleaved_to_sharded(
+                x,
+                self.bnc_sharded_memory_config,
+            )
         x = self.bnc(x)
         return self.bnc2(x)
 


### PR DESCRIPTION
### Ticket
- #12195 

### What's changed
This change updates UNet Shallow to use `ttnn.reshard` instead of `ttnn.sharded_to_interleaved` + `ttnn.interleaved_to_sharded`. Previously this was not possible due to an issue with `ttnn.reshard`.

### Checklist
- [ ] Post commit CI passes
- [ ] Model regression CI testing passes (if applicable)
