### PR TITLE
#12107: optimize EDM handshaking perf and perf consistency

### DIFF
--- a/tt_metal/hw/inc/ethernet/dataflow_api.h
+++ b/tt_metal/hw/inc/ethernet/dataflow_api.h
@@ -228,15 +228,21 @@ void eth_write_remote_reg(uint32_t reg_addr, uint32_t value) {
  * |-------------------|---------------------------------------------------------|----------|-------------|----------|
  */
 FORCE_INLINE
-void eth_wait_for_receiver_done() {
+void eth_wait_for_receiver_done(uint32_t wait_min = 0) {
     internal_::eth_send_packet(
         0,
 
         ((uint32_t)(&(erisc_info->channels[0].bytes_sent))) >> 4,
         ((uint32_t)(&(erisc_info->channels[0].bytes_sent))) >> 4,
         1);
+    uint32_t count = 0;
     while (erisc_info->channels[0].bytes_sent != 0) {
-        run_routing();
+        if (count == wait_min) {
+            count = 0;
+            run_routing();
+        } else {
+            count++;
+        }
     }
 }
 
@@ -313,9 +319,15 @@ void eth_wait_for_receiver_channel_done(uint32_t channel) {
  * | channel                     | Which transaction channel to block on                   | uint32_t | 0..7        | True     |
  */
 FORCE_INLINE
-void eth_wait_receiver_done() {
+void eth_wait_receiver_done(uint32_t wait_min = 0) {
+    uint32_t count = 0;
     while (erisc_info->channels[0].bytes_sent != 0) {
-        run_routing();
+        if (count == wait_min) {
+            count = 0;
+            run_routing();
+        } else {
+            count++;
+        }
     }
 }
 
@@ -332,9 +344,15 @@ void eth_wait_receiver_done() {
  * | num_bytes         | Size of data transfer in bytes, must be multiple of 16  | uint32_t | 0..256kB | True     |
  */
 FORCE_INLINE
-void eth_wait_for_bytes(uint32_t num_bytes) {
+void eth_wait_for_bytes(uint32_t num_bytes, uint32_t wait_min = 0) {
+    uint32_t count = 0;
     while (erisc_info->channels[0].bytes_sent != num_bytes) {
-        run_routing();
+        if (count == wait_min) {
+            count = 0;
+            run_routing();
+        } else {
+            count++;
+        }
     }
 }
 

--- a/ttnn/cpp/ttnn/operations/ccl/kernels/edm/erisc_async_datamover.hpp
+++ b/ttnn/cpp/ttnn/operations/ccl/kernels/edm/erisc_async_datamover.hpp
@@ -239,6 +239,18 @@ class ChannelBuffer final {
     FORCE_INLINE bool eth_is_receiver_channel_send_acked() const {
         return *(this->channel_bytes_acked_addresses[buffer_index]) != 0; }
     FORCE_INLINE void eth_clear_sender_channel_ack() const { *(this->channel_bytes_acked_addresses[buffer_index]) = 0; }
+
+    /*
+     * As a receiver channel, send a first level ack to the connected sender channel on the other
+     * end of the ethernet link. The first level ack is a signal from the receiver to the sender
+     * to indicate that the last sent message has been received. When the sender receives the first
+     * level ack, it is safe to clear its buffer with new data from producers
+     *
+     * It is crucial that when the receiver channel sends the first level ack, that it does not send from the same
+     * source as the second level ack. Doing so will present a race condition where by the time the
+     * first level ack leaves L1 and the ethernet subsystem, the EDM receiver channel may have overwritten
+     * the L1 memory with the second level ack - resulting in the sender receiving two second level acks.
+     */
     FORCE_INLINE void eth_receiver_channel_ack(uint32_t eth_transaction_ack_word_addr) const {
         ASSERT(reinterpret_cast<volatile uint32_t*>(eth_transaction_ack_word_addr)[0] == 1);
         reinterpret_cast<volatile uint32_t*>(eth_transaction_ack_word_addr)[1] = 1;
@@ -366,6 +378,9 @@ class QueueIndexPointer {
  * channels are initialized. Otherwise we have a race between channel initialization on the receiver side
  * and real payload data (and signals) using those channels.
  *
+ * Note that the master and slave concepts here only apply in the context of handshaking and initialization
+ * of the EDM. They do not apply during the main EDM execution loop.
+ *
  * The basic protocol for the handshake is to use the reserved space at erisc_info[0] where the master writes
  * and sends payload available information to that channel. The receive must acknowledge that message and upon
  * doing so, considers the handshake complete.
@@ -374,6 +389,17 @@ namespace handshake {
 
 static constexpr uint32_t A_LONG_TIMEOUT_BEFORE_CONTEXT_SWITCH = 1000000000;
 
+/*
+ * Initialize base datastructures and values which are common to master and slave EDM cores.
+ * The main memory region initialized here is the channel ack region offset 16B from the
+ * base handshake address.
+ *
+ * This memory region serves a special purpose for flow control between EDM cores. This
+ * 16B region is initialized to a fixed set of values. This region is used by receiver
+ * EDM channels when sending first level acks to its corresponding sender EDM channel.
+ *
+ * See ChannelBuffer::eth_receiver_channel_ack for more information
+ */
 FORCE_INLINE void initialize_edm_common_datastructures(std::uint32_t handshake_register_address) {
     reinterpret_cast<volatile tt_l1_ptr uint32_t *>(handshake_register_address)[4] = 1;
     reinterpret_cast<volatile tt_l1_ptr uint32_t *>(handshake_register_address)[5] = 1;
@@ -388,6 +414,10 @@ FORCE_INLINE void initialize_edm_common_datastructures(std::uint32_t handshake_r
     *(volatile tt_l1_ptr uint32_t *)handshake_register_address = 0;
 }
 
+/*
+ * As the designated master EDM core, initiate a handshake by sending a packet to reserved
+ * memory region.
+ */
 FORCE_INLINE void sender_side_start(std::uint32_t handshake_register_address) {
     initialize_edm_common_datastructures(handshake_register_address);
     eth_wait_receiver_done(A_LONG_TIMEOUT_BEFORE_CONTEXT_SWITCH);
@@ -397,6 +427,9 @@ FORCE_INLINE void sender_side_start(std::uint32_t handshake_register_address) {
     eth_send_bytes(handshake_register_address, handshake_register_address, 16);
 }
 
+/*
+ * As the designated master EDM core, wait for the acknowledgement from the slave EDM core
+ */
 FORCE_INLINE void sender_side_finish(std::uint32_t handshake_register_address) {
     eth_wait_for_receiver_done(A_LONG_TIMEOUT_BEFORE_CONTEXT_SWITCH);
 }
@@ -405,6 +438,11 @@ FORCE_INLINE void receiver_side_start(std::uint32_t handshake_register_address) 
     initialize_edm_common_datastructures(handshake_register_address);
 }
 
+/*
+ * As the designated slave EDM core, send the acknowledgement to the master EDM core.
+ * The slave EDM core shall only acknowledge after receiving the initial handshake packet
+ * from the master EDM core.
+ */
 FORCE_INLINE void receiver_side_finish(std::uint32_t handshake_register_address) {
     eth_wait_for_bytes(16, A_LONG_TIMEOUT_BEFORE_CONTEXT_SWITCH);
     while (eth_txq_reg_read(0, ETH_TXQ_CMD) != 0) {

--- a/ttnn/cpp/ttnn/operations/ccl/kernels/edm/erisc_datamover.cpp
+++ b/ttnn/cpp/ttnn/operations/ccl/kernels/edm/erisc_datamover.cpp
@@ -144,6 +144,13 @@ void kernel_main() {
     uint32_t args_offset = 0;
     uint32_t handshake_addr = get_arg_val<uint32_t>(args_offset++);
 
+    bool is_done_as_rx_handshaker = is_handshake_sender;
+    if constexpr (is_handshake_sender) {
+        erisc::datamover::handshake::sender_side_start(handshake_addr);
+    } else {
+        erisc::datamover::handshake::receiver_side_start(handshake_addr);
+    }
+
     uint8_t const sender_channels_start = get_arg_val<uint32_t>(args_offset++);
     uint32_t const sender_num_channels = num_senders;//get_arg_val<uint32_t>(args_offset++);
     uint8_t num_senders_with_no_work = 0;
@@ -210,12 +217,12 @@ void kernel_main() {
         }
     }
 
-    // Handshake with other erisc to make sure it's safe to start sending/receiving
-    // Chose an arbitrary ordering mechanism to guarantee one of the erisc's will always be "sender" and the other
-    // will always be "receiver" (only for handshake purposes)
-    bool act_as_sender_in_handshake =
-        (sender_channels_start < receiver_channels_start || receiver_num_channels == 0) && sender_num_channels > 0;
-    erisc::datamover::eth_setup_handshake(handshake_addr, act_as_sender_in_handshake);
+    if constexpr (is_handshake_sender) {
+        erisc::datamover::handshake::sender_side_finish(handshake_addr);
+    } else {
+        erisc::datamover::handshake::receiver_side_finish(handshake_addr);
+        is_done_as_rx_handshaker = true;
+    }
     uint32_t eth_transaction_ack_word_addr = handshake_addr + 16;
     uint32_t eth_transaction_complete_addr = handshake_addr + 32;
 


### PR DESCRIPTION
### Ticket
[Link to Github Issue](https://github.com/tenstorrent/tt-metal/issues/12103)

### Problem description
The current handshake scheme will very eagerly perform erisc context switches which can lead to performance degradation. Additionally, handshake is currently performed purely after channel initialization - however it doesn't need to.

### What's changed
- Remove eager context switching during handshaking
- break up handshake into two phases so master/sender initiates handshake as early as possible

For all gather 32x8192, bfp8, 8 chip, 1 link, width sharded (4,8) shard grid, this leads to a 3-4.2k cycle reduction

### Checklist
- [x] Post commit CI passes: https://github.com/tenstorrent/tt-metal/actions/runs/10703002051
- [x] t3000 frequent: https://github.com/tenstorrent/tt-metal/actions/runs/10703348787
  - same mixtral failure as on main (TypeError: prepare_inputs_ttnn() takes 3 positional arguments but 5 were given) 
- [x] t3000 model perf: https://github.com/tenstorrent/tt-metal/actions/runs/10703344844
  - same mixtral failure as on main (DRAM allocator issue)
- [x] Blackhole Post commit (if applicable)
- [x] New/Existing tests provide coverage for changes
