### PR TITLE
#0: Revert "#11720: Enable ttnn binary to be built using rpath as origin"

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -288,5 +288,3 @@ add_custom_target(clean-built
    COMMAND ${CMAKE_COMMAND} -E remove_directory ${PROJECT_SOURCE_DIR}/built
    COMMENT "Cleaning `built` directory"
 )
-
-set_target_properties(ttnn PROPERTIES INSTALL_RPATH "$ORIGIN" BUILD_RPATH "$ORIGIN")


### PR DESCRIPTION
…

This reverts commit 62a9289cd8e8e9d826f80382483d326832341370.

### Ticket

This broke local developer workflows. Need to investigate why

### Problem description

This broke local developer workflows. Need to investigate why

### What's changed

Looks like we completely overwrote the RPATH.

### Checklist
- [ ] Post commit CI passes
- [ ] Blackhole Post commit (if applicable)
- [ ] Model regression CI testing passes (if applicable)
- [ ] New/Existing tests provide coverage for changes
