### PR TITLE
#11581: Restrict numpy version <2 so that we don't run into some numpy cross-version link errors on 22.04

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,7 @@ authors = [
 ]
 dependencies = [
   "pyyaml>=5.4",
-  "numpy>=1.24.4",
+  "numpy>=1.24.4,<2",
   "loguru==0.6.0",
   "toolz==0.12.0",
   "matplotlib==3.7.1",


### PR DESCRIPTION
### Ticket

#11581 

### Problem description

Looks like we run into cross-version link errors with numpy if we use a version `>=2` on Ubuntu 22.04.

### What's changed

Restrict numpy for now.

### Checklist
- [ ] Post commit CI passes
- [ ] Blackhole Post commit (if applicable)
- [ ] Model regression CI testing passes (if applicable)
- [ ] New/Existing tests provide coverage for changes
