### PR TITLE
#12221: Run telemetry on more runs than just passing ones

### DIFF
--- a/.github/actions/prepare-metal-run/action.yml
+++ b/.github/actions/prepare-metal-run/action.yml
@@ -26,4 +26,5 @@ runs:
       run: tar -xvf ttm_${{ inputs.arch }}.tar
     - uses: ./.github/actions/install-python-deps
     - name: Collect Workflow Telemetry
-      uses: catchpoint/workflow-telemetry-action@v2  
+      if: ${{ !cancelled() }}
+      uses: catchpoint/workflow-telemetry-action@v2


### PR DESCRIPTION
### Ticket

#12221 

### Problem description

Telemetry only collected on passing runs.

### What's changed

Use `!cancelled()` trick to run on failing runs as well.

### Checklist
- [ ] Post commit CI passes
- [ ] Blackhole Post commit (if applicable)
- [ ] Model regression CI testing passes (if applicable)
- [ ] New/Existing tests provide coverage for changes
