### PR TITLE
#12231: Reduce timeout on matmul and concat sweeps

### DIFF
--- a/tests/sweep_framework/sweeps/data_movement/concat/concat_sharded.py
+++ b/tests/sweep_framework/sweeps/data_movement/concat/concat_sharded.py
@@ -17,7 +17,7 @@ from tests.ttnn.utils_for_testing import (
 from models.utility_functions import torch_random
 
 # Override the default timeout in seconds for hang detection.
-TIMEOUT = 20
+TIMEOUT = 5
 random.seed(0)
 
 

--- a/tests/sweep_framework/sweeps/matmul/full/matmul_default_block_sharded.py
+++ b/tests/sweep_framework/sweeps/matmul/full/matmul_default_block_sharded.py
@@ -20,6 +20,8 @@ from tests.ttnn.utils_for_testing import (
 )
 from models.utility_functions import torch_random
 
+TIMEOUT = 5
+
 
 def get_block_sharded_specs(
     batch_sizes_choices: List[Tuple[int, ...]],

--- a/tests/sweep_framework/sweeps/matmul/full/matmul_default_height_sharded.py
+++ b/tests/sweep_framework/sweeps/matmul/full/matmul_default_height_sharded.py
@@ -20,6 +20,8 @@ from tests.ttnn.utils_for_testing import (
 )
 from models.utility_functions import torch_random
 
+TIMEOUT = 5
+
 
 def get_height_sharded_specs(
     batch_sizes_choices: List[Tuple[int, ...]], m_size_choices: List[int], num_cores_choices: List[int]

--- a/tests/sweep_framework/sweeps/matmul/full/matmul_default_interleaved.py
+++ b/tests/sweep_framework/sweeps/matmul/full/matmul_default_interleaved.py
@@ -12,6 +12,7 @@ import ttnn
 from tests.ttnn.utils_for_testing import check_with_pcc, start_measuring_time, stop_measuring_time
 from models.utility_functions import torch_random
 
+TIMEOUT = 5
 
 parameters = {
     "default": {

--- a/tests/sweep_framework/sweeps/matmul/full/matmul_default_width_sharded.py
+++ b/tests/sweep_framework/sweeps/matmul/full/matmul_default_width_sharded.py
@@ -20,6 +20,9 @@ from tests.ttnn.utils_for_testing import (
 from models.utility_functions import torch_random
 
 
+TIMEOUT = 5
+
+
 def get_width_sharded_specs(k_size_choices: List[int], num_cores_choices: List[int]) -> Tuple[int, int, int]:
     for k_size in k_size_choices:
         for per_core_width, num_cores_width in get_per_core_size_and_num_cores(

--- a/tests/sweep_framework/sweeps/matmul/short/matmul.py
+++ b/tests/sweep_framework/sweeps/matmul/short/matmul.py
@@ -11,6 +11,8 @@ import ttnn
 from tests.ttnn.utils_for_testing import check_with_pcc, start_measuring_time, stop_measuring_time
 from models.utility_functions import torch_random
 
+TIMEOUT = 5
+
 parameters = {
     "default": {
         "batch_sizes": [(1,)],

--- a/tests/sweep_framework/sweeps/matmul/short/matmul_create_program_config.py
+++ b/tests/sweep_framework/sweeps/matmul/short/matmul_create_program_config.py
@@ -12,6 +12,7 @@ import ttnn
 from tests.ttnn.utils_for_testing import check_with_pcc, start_measuring_time, stop_measuring_time
 from models.utility_functions import torch_random
 
+TIMEOUT = 5
 
 # TODO: Consolidate tests for duplicate use cases into sweep with shapes
 # TODO: Missing coverage for Stable Diffusion matmul in: tests/ttnn/unit_tests/operations/test_matmul.py

--- a/tests/sweep_framework/sweeps/matmul/short/matmul_default.py
+++ b/tests/sweep_framework/sweeps/matmul/short/matmul_default.py
@@ -12,6 +12,8 @@ from tests.ttnn.utils_for_testing import check_with_pcc, start_measuring_time, s
 from models.utility_functions import torch_random
 
 
+TIMEOUT = 5
+
 # TODO: Missing coverage for mixed precision; passed in dtype does nothing in current matmul path
 parameters = {
     "default": {

--- a/tests/sweep_framework/sweeps/matmul/short/matmul_default_sharded.py
+++ b/tests/sweep_framework/sweeps/matmul/short/matmul_default_sharded.py
@@ -14,6 +14,9 @@ from tests.ttnn.utils_for_testing import check_with_pcc, start_measuring_time, s
 from models.utility_functions import torch_random
 
 
+TIMEOUT = 5
+
+
 class TensorMemoryConfigs(enum.Enum):
     BLOCK_Y5_X7 = enum.auto()
     BLOCK_Y7_X5_COL = enum.auto()

--- a/tests/sweep_framework/sweeps/matmul/short/matmul_user_program_config.py
+++ b/tests/sweep_framework/sweeps/matmul/short/matmul_user_program_config.py
@@ -13,6 +13,7 @@ import ttnn
 from tests.ttnn.utils_for_testing import check_with_pcc, start_measuring_time, stop_measuring_time
 from models.utility_functions import torch_random
 
+TIMEOUT = 5
 
 # Set up suites and specify batch_sizes, input_shapes, batch_matrix_multiply, program_config, and memory configs
 # TODO: Missing coverage for WH fp32 and compute config tests in: tests/tt_eager/python_api_testing/unit_testing/misc/test_matmul.py

--- a/tests/sweep_framework/sweeps/matmul/short/matmul_user_program_config_mcast_1d.py
+++ b/tests/sweep_framework/sweeps/matmul/short/matmul_user_program_config_mcast_1d.py
@@ -13,6 +13,8 @@ import ttnn
 from tests.ttnn.utils_for_testing import check_with_pcc, start_measuring_time, stop_measuring_time
 from models.utility_functions import torch_random
 
+TIMEOUT = 5
+
 
 class TensorMemoryConfigs(enum.Enum):
     CUSTOM_MEMORY_CONFIG = enum.auto()

--- a/tests/sweep_framework/sweeps/matmul/short/matmul_user_program_config_mcast_2d.py
+++ b/tests/sweep_framework/sweeps/matmul/short/matmul_user_program_config_mcast_2d.py
@@ -13,6 +13,8 @@ import ttnn
 from tests.ttnn.utils_for_testing import check_with_pcc, assert_with_pcc, start_measuring_time, stop_measuring_time
 from models.utility_functions import torch_random
 
+TIMEOUT = 5
+
 
 class TensorMemoryConfigs(enum.Enum):
     CUSTOM_MEMORY_CONFIG = enum.auto()


### PR DESCRIPTION
### Ticket
#12231 
### Problem description
Sweeps pipeline is timing out because of long hang timeouts.

### What's changed
Reduce timeouts on matmuls and concats to a more reasonable number.

### Checklist
- [ ] Post commit CI passes
- [ ] Blackhole Post commit (if applicable)
- [ ] Model regression CI testing passes (if applicable)
- [ ] New/Existing tests provide coverage for changes
