### PR TITLE
#11913: Shard `ttnn.upsample` input in UNet to make it multi-core

### DIFF
--- a/models/experimental/functional_unet/tt/unet_shallow_ttnn.py
+++ b/models/experimental/functional_unet/tt/unet_shallow_ttnn.py
@@ -2,10 +2,9 @@
 
 # SPDX-License-Identifier: Apache-2.0
 
+import math
 import ttnn
 import torch
-
-from loguru import logger
 
 from ttnn.operations.conv2d import determine_parallel_config, create_sharded_memory_config_from_parallel_config
 
@@ -13,35 +12,37 @@ from models.utility_functions import nearest_32
 from ttnn.model_preprocessing import fold_batch_norm2d_into_conv2d, ParameterDict
 
 
-# Unet reshard wrapper
-def unet_reshard(
-    ttnn_tensor,
-    sharded_memory_config,
-    use_reshard=True,
-    interleaved_memory_config=ttnn.L1_MEMORY_CONFIG,
-    dtype=None,
-):
-    if use_reshard:
-        return ttnn.to_memory_config(
-            ttnn_tensor,
-            memory_config=sharded_memory_config,
+def determine_num_cores_for_upsample(nhw: int, width: int, max_cores=64) -> int:
+    gcd_nhw_width = math.gcd(nhw, width)
+    cores = nhw // gcd_nhw_width
+    if cores > max_cores:
+        for divisor in range(max_cores, 0, -1):
+            if nhw % divisor == 0 and (nhw // divisor) % width == 0:
+                cores = divisor
+                break
+    return cores
+
+
+def get_core_grid_from_num_cores(num_cores: int):
+    if num_cores == 44:
+        return ttnn.CoreRangeSet(
+            {
+                ttnn.CoreRange(
+                    ttnn.CoreCoord(0, 0),
+                    ttnn.CoreCoord(7, 4),
+                ),
+                ttnn.CoreRange(
+                    ttnn.CoreCoord(0, 5),
+                    ttnn.CoreCoord(3, 5),
+                ),
+            }
         )
-    else:
-        ttl_tensor = ttnn_tensor
-        ttl_tensor = ttnn.sharded_to_interleaved(ttl_tensor, interleaved_memory_config, dtype)
-        ttl_tensor = ttnn.interleaved_to_sharded(
-            ttl_tensor,
-            sharded_memory_config,
-            dtype,
-        )
-        return ttl_tensor
+    elif num_cores == 48:
+        return ttnn.CoreGrid(x=8, y=6)
+    raise RuntimeError(f"Could not get core grid given num_cores={num_cores}")
 
 
-# Unet concat tensor wrapper
-def unet_concat(ttnn_tensors, dim=-1, use_reshard=True, perf_mode=False):
-    if not perf_mode:
-        return ttnn.concat(ttnn_tensors, dim=3)
-
+def unet_concat(ttnn_tensors, dim=-1):
     assert len(ttnn_tensors) > 0
     assert dim < 0
     ttlib_tensors = ttnn_tensors
@@ -153,6 +154,7 @@ class UNetConv2D:
             enable_split_reader=False,
             enable_subblock_padding=False,
             activation=activation,
+            output_layout=ttnn.TILE_LAYOUT,
         )
         config_override = conv.conv_blocking_and_parallelization_config_override
         if config_override and "act_block_h" in config_override:
@@ -190,19 +192,12 @@ class UNetConv2D:
 
 
 class UNetMaxPool2D:
-    def __init__(self, pool, channels, device=None, reader_patterns_cache={}):
+    def __init__(self, pool, channels, device=None):
         self.pool = pool
         self.channels = channels
         self.device = device
 
     def __call__(self, x):
-        # For some reason the shard widths don't always match - so don't assert on it
-        # assert (
-        # x.memory_config().shard_spec.num_cores()
-        # == self.max_pool.max_pool.input_sharded_memory_config.shard_spec.num_cores()
-        # and x.memory_config().shard_spec.shape[0]
-        # == self.max_pool.max_pool.input_sharded_memory_config.shard_spec.shape[0]
-        # ), "Expected same input shard to match max pool's shard configuration"
         x = ttnn.max_pool2d_new(
             input_tensor=x,
             batch_size=self.pool.batch_size,
@@ -228,13 +223,12 @@ class UNetDownblock:
         pool,
         device,
         conv_cache={},
-        max_pool_cache={},
         should_reshard=False,
         mesh_mapper=None,
     ):
         self.conv1 = UNetConv2D(conv1, bn=bn1, device=device, cache=conv_cache, mesh_mapper=mesh_mapper)
         self.conv2 = UNetConv2D(conv2, bn=bn2, device=device, cache=conv_cache, mesh_mapper=mesh_mapper)
-        self.pool1 = UNetMaxPool2D(pool, conv2.out_channels, device=device, reader_patterns_cache=max_pool_cache)
+        self.pool1 = UNetMaxPool2D(pool, conv2.out_channels, device=device)
 
         self.should_reshard = should_reshard
         if self.should_reshard:
@@ -273,9 +267,7 @@ class UNetDownblock:
             )
         x = self.conv1(x)
         x = self.conv2(x)
-        residual = ttnn.sharded_to_interleaved(
-            x, memory_config=ttnn.DRAM_MEMORY_CONFIG, output_dtype=ttnn.bfloat16
-        )  # pool deletes its activation - spill to DRAM
+        residual = x
         x = self.pool1(x)
         return x, residual
 
@@ -317,7 +309,19 @@ class UNetUpblock:
         x = ttnn.reshape(
             x, (self.conv1.batch_size, self.conv1.input_height // 2, self.conv1.input_width // 2, x.shape[-1])
         )
-        x = ttnn.upsample(x, (2, 2, 1))
+
+        nhw = x.shape[0] * x.shape[1] * x.shape[2]
+        num_cores = determine_num_cores_for_upsample(nhw, x.shape[2])
+        core_grid = get_core_grid_from_num_cores(num_cores)
+        shardspec = ttnn.create_sharded_memory_config_(
+            x.shape, core_grid, ttnn.ShardStrategy.HEIGHT, orientation=ttnn.ShardOrientation.ROW_MAJOR
+        )
+        if x.is_sharded():
+            x = ttnn.reshard(x, shardspec)
+        else:
+            x = ttnn.interleaved_to_sharded(x, shardspec)
+
+        x = ttnn.upsample(x, (2, 2, 1), memory_config=x.memory_config())
         x = ttnn.reshape(
             x, (1, 1, self.conv1.batch_size * self.conv1.input_height * self.conv1.input_width, x.shape[-1])
         )
@@ -327,32 +331,31 @@ class UNetUpblock:
         assert list(x.shape)[:2] == [
             1,
             1,
-        ], f"Expected downblock input to flattened into [1, 1, BHW, C] but was {list(x.shape)}"
+        ], f"Expected upblock input to flattened into [1, 1, BHW, C] but was {list(x.shape)}"
 
+        residual = ttnn.to_layout(residual, ttnn.ROW_MAJOR_LAYOUT)
         x = ttnn.to_layout(x, layout=ttnn.ROW_MAJOR_LAYOUT)
-        x = ttnn.to_memory_config(x, memory_config=ttnn.DRAM_MEMORY_CONFIG)
 
         x = self.upsample(x)
 
-        residual = ttnn.to_layout(residual, ttnn.ROW_MAJOR_LAYOUT)
-        x = unet_concat([x, residual], dim=-1, perf_mode=True)
+        y = unet_concat([x, residual], dim=-1)
+        ttnn.deallocate(x)
         ttnn.deallocate(residual)
 
         if self.should_reshard:
-            x = ttnn.to_memory_config(x, self.sharded_memory_config)
+            y = ttnn.to_memory_config(y, self.sharded_memory_config)
 
-        x = self.conv1(x)
-        x = self.conv2(x)
-        x = self.conv3(x)
+        y = self.conv1(y)
+        y = self.conv2(y)
+        y = self.conv3(y)
 
-        return x
+        return y
 
 
 class UNet:
     def __init__(self, parameters: ParameterDict, device, mesh_mapper=None) -> None:
         self.device = device
         self.conv_cache = {}
-        self.max_pool_cache = {}
         self.downblock1 = UNetDownblock(
             parameters.c1,
             parameters.b1,
@@ -361,7 +364,6 @@ class UNet:
             parameters.p1,
             device,
             conv_cache=self.conv_cache,
-            max_pool_cache=self.max_pool_cache,
             should_reshard=True,
             mesh_mapper=mesh_mapper,
         )
@@ -373,7 +375,6 @@ class UNet:
             parameters.p2,
             device,
             conv_cache=self.conv_cache,
-            max_pool_cache=self.max_pool_cache,
             should_reshard=True,
             mesh_mapper=mesh_mapper,
         )
@@ -385,7 +386,6 @@ class UNet:
             parameters.p3,
             device,
             conv_cache=self.conv_cache,
-            max_pool_cache=self.max_pool_cache,
             should_reshard=True,
             mesh_mapper=mesh_mapper,
         )
@@ -397,7 +397,6 @@ class UNet:
             parameters.p4,
             device,
             conv_cache=self.conv_cache,
-            max_pool_cache=self.max_pool_cache,
             should_reshard=True,
             mesh_mapper=mesh_mapper,
         )
@@ -505,9 +504,13 @@ class UNet:
         x = self.bottleneck(x)
 
         x = self.upblock1(x, c4_residual)
+        ttnn.deallocate(c4_residual)
         x = self.upblock2(x, c3_residual)
+        ttnn.deallocate(c3_residual)
         x = self.upblock3(x, c2_residual)
+        ttnn.deallocate(c2_residual)
         x = self.upblock4(x, c1_residual)
+        ttnn.deallocate(c1_residual)
 
         x = self.output_layer(x)
 

--- a/tests/nightly/wh_b0_only_eth/experimental/functional_unet/tests/test_unet_multi_device.py
+++ b/tests/nightly/wh_b0_only_eth/experimental/functional_unet/tests/test_unet_multi_device.py
@@ -1,0 +1,1 @@
+../../../../../../models/experimental/functional_unet/tests/test_unet_multi_device.py


### PR DESCRIPTION
### Ticket
- #11913 
- #12194

### What's changed
- Reshard inputs to `ttnn.upsample` to improve performance.
- Downstream `ttnn.concat` is now sharded which improves performance.
- Device performance is now 326 fps (up from 22 fps).
- Added missing symlink to one of the unit tests that should be running on the nightly pipeline.

### Checklist
- [x] Post commit CI passes
- [x] Model regression CI testing passes (if applicable)
