### PR TITLE
Dump device profiler results in worker cores in async mode

### DIFF
--- a/tests/scripts/run_profiler_regressions.sh
+++ b/tests/scripts/run_profiler_regressions.sh
@@ -56,7 +56,7 @@ run_profiling_test(){
 
     run_additional_T3000_test
 
-    #run_async_mode_T3000_test
+    run_async_mode_T3000_test
 
     TT_METAL_DEVICE_PROFILER=1 pytest $PROFILER_TEST_SCRIPTS_ROOT/test_device_profiler.py
 

--- a/tt_metal/tools/profiler/tt_metal_profiler.cpp
+++ b/tt_metal/tools/profiler/tt_metal_profiler.cpp
@@ -51,6 +51,8 @@ std::map <uint32_t, DeviceProfiler> tt_metal_device_profiler_map;
 std::unordered_map <uint32_t, std::vector <std::pair<uint64_t,uint64_t>>> deviceHostTimePair;
 std::unordered_map <uint32_t, uint64_t> smallestHostime;
 
+std::mutex device_mutex;
+
 constexpr CoreCoord SYNC_CORE = {0,0};
 
 void setControlBuffer(uint32_t device_id, std::vector<uint32_t>& control_buffer)
@@ -324,6 +326,7 @@ void InitDeviceProfiler(Device *device){
 
 void DumpDeviceProfileResults(Device *device, bool lastDump) {
 #if defined(TRACY_ENABLE)
+    ZoneScoped;
     std::vector<CoreCoord> workerCores;
     auto device_id = device->id();
     auto device_num_hw_cqs = device->num_hw_cqs();
@@ -336,7 +339,10 @@ void DumpDeviceProfileResults(Device *device, bool lastDump) {
         auto physicalCore = device->physical_core_from_logical_core(core, CoreType::ETH);
         workerCores.push_back(physicalCore);
     }
-    DumpDeviceProfileResults(device, workerCores, lastDump);
+    device->push_work([device, workerCores, lastDump] () mutable {
+        DumpDeviceProfileResults(device, workerCores, lastDump);
+    });
+
 #endif
 }
 
@@ -345,6 +351,7 @@ void DumpDeviceProfileResults(Device *device, std::vector<CoreCoord> &worker_cor
 #if defined(TRACY_ENABLE)
     ZoneScoped;
 
+    std::scoped_lock<std::mutex> lock(device_mutex);
     auto dispatch_core_type = dispatch_core_manager::instance().get_dispatch_core_type(device->id());
     if (tt::llrt::OptionsG.get_profiler_do_dispatch_cores()) {
         auto device_id = device->id();
@@ -431,6 +438,7 @@ void DumpDeviceProfileResults(Device *device, std::vector<CoreCoord> &worker_cor
         }
 	TT_FATAL(DprintServerIsRunning() == false, "Debug print server is running, cannot dump device profiler data");
         auto device_id = device->id();
+
         if (tt_metal_device_profiler_map.find(device_id) != tt_metal_device_profiler_map.end())
         {
             if (!lastDump)


### PR DESCRIPTION
### Ticket
#12219 
### Problem description
Device profiler is making calls to CQ commands in main thread

### What's changed
Push dump device profiler results to worker cores. Lock over the entire function to make the calls thread safe

### Checklist
- [x] Post commit CI passes https://github.com/tenstorrent/tt-metal/actions/runs/10709120816
- [x] T3K profiler https://github.com/tenstorrent/tt-metal/actions/runs/10709124431
- [x] Device Perf https://github.com/tenstorrent/tt-metal/actions/runs/10709127495
- [x] uBenchmark https://github.com/tenstorrent/tt-metal/actions/runs/10709130084
