### PR TITLE
#0: Update ttnn calls from generate_buffer_page_mapping to get_buffer…

### DIFF
--- a/ttnn/cpp/ttnn/operations/data_movement/sharded/reshard/device/reshard_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/sharded/reshard/device/reshard_program_factory.cpp
@@ -18,8 +18,8 @@ namespace ttnn::operations::data_movement::detail {
 
 std::unordered_map<CoreCoord, std::vector<PageStride>> get_core_page_ranges(
     Buffer* input_buffer, Buffer* output_buffer) {
-    auto output_buffer_page_mapping = generate_buffer_page_mapping(*output_buffer);
-    auto input_buffer_page_mapping = generate_buffer_page_mapping(*input_buffer);
+    const auto& output_buffer_page_mapping = *output_buffer->get_buffer_page_mapping();
+    const auto& input_buffer_page_mapping = *input_buffer->get_buffer_page_mapping();
 
     const auto& output_shard_to_host_mapping = output_buffer_page_mapping.dev_page_to_host_page_mapping_;
     const auto& input_page_to_local_page_mapping = input_buffer_page_mapping.host_page_to_local_shard_page_mapping_;

--- a/ttnn/cpp/ttnn/reports.hpp
+++ b/ttnn/cpp/ttnn/reports.hpp
@@ -83,7 +83,7 @@ std::vector<BufferInfo> get_buffers() {
                 bank_id = (bank_id + 1) % num_banks;
             }
         } else {
-            auto buffer_page_mapping = generate_buffer_page_mapping(*buffer);
+            const auto& buffer_page_mapping = *buffer->get_buffer_page_mapping();
             for (int page_index = 0; page_index < num_pages; page_index++) {
                 auto dev_page_index = buffer_page_mapping.host_page_to_dev_page_mapping_[page_index];
                 auto core = buffer_page_mapping.all_cores_[buffer_page_mapping.dev_page_to_core_mapping_[dev_page_index]];
@@ -158,7 +158,7 @@ std::vector<BufferPageInfo> get_buffer_pages() {
                 bank_id = (bank_id + 1) % num_banks;
             }
         } else {
-            auto buffer_page_mapping = generate_buffer_page_mapping(*buffer);
+            const auto& buffer_page_mapping = *buffer->get_buffer_page_mapping();
             for (int page_index = 0; page_index < num_pages; page_index++) {
                 auto dev_page_index = buffer_page_mapping.host_page_to_dev_page_mapping_[page_index];
                 auto core = buffer_page_mapping.all_cores_[buffer_page_mapping.dev_page_to_core_mapping_[dev_page_index]];

--- a/ttnn/cpp/ttnn/tensor/tensor.cpp
+++ b/ttnn/cpp/ttnn/tensor/tensor.cpp
@@ -394,7 +394,7 @@ Tensor Tensor::cpu_sharded() const {
 
 Tensor Tensor::extract_shard(const CoreCoord& core) const {
     ZoneScoped;
-    auto buffer_page_mapping = generate_buffer_page_mapping(*this->buffer());
+    const auto& buffer_page_mapping = *this->buffer()->get_buffer_page_mapping();
     auto core_id = buffer_page_mapping.core_to_core_id_.at(core);
     return this->extract_shard(core_id);
 }
@@ -458,7 +458,7 @@ bool Tensor::is_allocated() const {
 }
 
 std::vector<uint32_t> Tensor::host_page_ordering() {
-    auto buffer_page_mapping = generate_buffer_page_mapping(*this->buffer());
+    const auto& buffer_page_mapping = *this->buffer()->get_buffer_page_mapping();
     auto cores = buffer_page_mapping.all_cores_;
     auto shard_size = buffer()->shard_spec().size();
     auto num_pages = cores.size() * shard_size;


### PR DESCRIPTION
…_page_mapping to avoid regenerating the page mapping for the same buffer

### Problem description
For sharded operations/fns, we would need to generate a page mapping for a given buffer. We were using a function that would always regenerate the mapping even if we'd computed it before.

### What's changed
Switch to new function that generates or fetches the cached mapping for a given buffer.

### Checklist
- [ ] Post commit CI passes
- [ ] Blackhole Post commit (if applicable)
- [ ] Model regression CI testing passes (if applicable)
- [ ] New/Existing tests provide coverage for changes
