### PR TITLE
Fix markdown in LICENSE amendment

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -206,7 +206,7 @@ Third-Party Dependencies:
 
 The following dependencies are utilized by this project and are included in a distributed build of a Python Wheel:
 
-- sfpi-gcc - [License available here](https://github.com/tenstorrent-metal/sfpi-rel-temp/blob/master/LICENSE)[and here](https://github.com/tenstorrent-metal/sfpi-rel-temp/blob/master/compiler/LICENSE)
+- sfpi-gcc - [License available here](https://github.com/tenstorrent-metal/sfpi-rel-temp/blob/master/LICENSE) [and here](https://github.com/tenstorrent-metal/sfpi-rel-temp/blob/master/compiler/LICENSE)
 
 The following dependencies are utilized by this project but are not explicitly
 distributed as part of the software:


### PR DESCRIPTION
Didn't notice the rendering miss until after merge. :( Fixed now.