### PR TITLE
#12207: Port moreh_dot to ttnn

### DIFF
--- a/tests/ttnn/unit_tests/operations/test_moreh_dot.py
+++ b/tests/ttnn/unit_tests/operations/test_moreh_dot.py
@@ -1,0 +1,113 @@
+# SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+
+# SPDX-License-Identifier: Apache-2.0
+
+import pytest
+import torch
+from loguru import logger
+
+import ttnn
+from models.utility_functions import comp_allclose_and_pcc
+from tests.tt_eager.python_api_testing.unit_testing.misc.test_utils import (
+    get_compute_kernel_options,
+    compute_kernel_options,
+    compute_kernel_ids,
+)
+
+
+def create_tt_tensor(tensor, layout, dtype):
+    return ttnn.from_torch(tensor, layout=layout, dtype=dtype)
+
+
+def get_tensors(
+    input_shape, other_shape, output_shape, require_input_grad, require_other_grad, is_1d, device, use_randint=True
+):
+    npu_dtype = ttnn.bfloat16
+    cpu_dtype = torch.bfloat16
+    npu_layout = ttnn.TILE_LAYOUT
+    cpu_layout = ttnn.ROW_MAJOR_LAYOUT
+
+    # create tensors for forward
+    if use_randint:
+        input = torch.randint(-2, 3, input_shape, dtype=cpu_dtype)
+        other = torch.randint(-2, 3, other_shape, dtype=cpu_dtype)
+        output = torch.randint(-2, 3, output_shape, dtype=cpu_dtype)
+    else:
+        input = torch.rand(input_shape, dtype=cpu_dtype)
+        other = torch.rand(other_shape, dtype=cpu_dtype)
+        output = torch.rand(output_shape, dtype=cpu_dtype)
+
+    tt_input = create_tt_tensor(input, cpu_layout, npu_dtype).pad_to_tile(float(1)).to(npu_layout).to(device)
+    tt_other = create_tt_tensor(other, cpu_layout, npu_dtype).pad_to_tile(float("nan")).to(npu_layout).to(device)
+    tt_output = create_tt_tensor(output, cpu_layout, npu_dtype).pad_to_tile(float("nan")).to(npu_layout).to(device)
+
+    torch_input = input.reshape(-1) if is_1d else input
+    torch_other = other.reshape(-1) if is_1d else other
+
+    # tensors for backward
+    output_grad = tt_output_grad = torch_output_grad = tt_input_grad = tt_other_grad = None
+    if require_input_grad or require_other_grad:
+        output_grad = torch.randint(-2, 3, output_shape, dtype=cpu_dtype)
+        tt_output_grad = (
+            create_tt_tensor(output_grad, cpu_layout, npu_dtype).pad_to_tile(float(-1)).to(npu_layout).to(device)
+        )
+        torch_output_grad = output_grad[0][0][0][0] if is_1d else output_grad
+
+        if require_input_grad:
+            input_grad = torch.full(input_shape, float("nan"), dtype=cpu_dtype)
+            tt_input_grad = (
+                create_tt_tensor(input_grad, cpu_layout, npu_dtype).pad_to_tile(float("nan")).to(npu_layout).to(device)
+            )
+
+        if require_other_grad:
+            other_grad = torch.full(other_shape, float("nan"), dtype=cpu_dtype)
+            tt_other_grad = (
+                create_tt_tensor(other_grad, cpu_layout, npu_dtype).pad_to_tile(float("nan")).to(npu_layout).to(device)
+            )
+
+    return (
+        tt_input,
+        tt_other,
+        tt_output,
+        tt_output_grad,
+        tt_input_grad,
+        tt_other_grad,
+        torch_input,
+        torch_other,
+        torch_output_grad,
+    )
+
+
+@pytest.mark.parametrize(
+    "input_shape",
+    (
+        [1, 1, 1, 10],  # test not mutiple of 32 case
+        [1, 1, 1, 32],  # test single tile
+        [1, 1, 1, 352],  # test multiple tiles
+        [1, 1, 1, 323],  # test multiple tiles, not a multiple of 32
+    ),
+)
+def test_moreh_matmul_1d(input_shape, device):
+    torch.manual_seed(3072)
+    # get tensors
+    output_shape = [1, 1, 1, 1]
+    tt_input, tt_other, _, _, _, _, torch_input, torch_other, _ = get_tensors(
+        input_shape, input_shape, output_shape, False, False, True, device
+    )
+
+    # tt matmul
+    cpu_layout = ttnn.ROW_MAJOR_LAYOUT
+    tt_out = ttnn.moreh_dot(tt_input, tt_other).cpu().to(cpu_layout).unpad_from_tile(output_shape).to_torch()
+
+    # torch matmul
+    torch_input = torch.reshape(torch_input, (torch_input.shape[-1],))
+    torch_other = torch.reshape(torch_other, (torch_other.shape[-1],))
+    torch_out = torch.matmul(torch_input, torch_other)
+
+    # test for equivalance
+    rtol = atol = 0.1
+    passing, output_pcc = comp_allclose_and_pcc(torch_out, tt_out[0][0][0][0], pcc=0.999, rtol=rtol, atol=atol)
+    logger.debug(f"Out passing={passing}")
+    logger.debug(f"Output pcc={output_pcc}")
+
+    assert passing

--- a/ttnn/CMakeLists.txt
+++ b/ttnn/CMakeLists.txt
@@ -235,6 +235,11 @@ set(ALL_TTNN_SRCS
     ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/loss/loss.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/loss/loss_pybind.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/matmul/device/matmul_op.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/moreh/moreh_dot_op/device/moreh_dot_program_factory.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/moreh/moreh_dot_op/device/moreh_dot_device_operation.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/moreh/moreh_dot_op/moreh_dot.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/moreh/moreh_dot_op/moreh_dot_pybind.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/moreh/moreh_pybind.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/matmul/device/matmul_op_multi_core_program_factory.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/matmul/device/matmul_op_multi_core_reuse_mcast_1d_program_factory.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/matmul/device/matmul_op_multi_core_reuse_mcast_2d_program_factory.cpp

--- a/ttnn/cpp/pybind11/operations/__init__.hpp
+++ b/ttnn/cpp/pybind11/operations/__init__.hpp
@@ -39,6 +39,7 @@
 #include "ttnn/operations/pool/upsample/upsample_pybind.hpp"
 #include "ttnn/operations/reduction/reduction_pybind.hpp"
 #include "ttnn/operations/transformer/transformer_pybind.hpp"
+#include "ttnn/operations/moreh/moreh_pybind.hpp"
 
 namespace py = pybind11;
 

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_dot_op/device/kernels/moreh_dot.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_dot_op/device/kernels/moreh_dot.cpp
@@ -1,0 +1,68 @@
+// SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <cstdint>
+
+#include "compute_kernel_api/eltwise_binary.h"
+#include "compute_kernel_api/reduce.h"
+#include "compute_kernel_api/tile_move_copy.h"
+
+ALWI void ACQ() { acquire_dst(tt::DstMode::Half); }
+ALWI void REL() { release_dst(tt::DstMode::Half); }
+
+namespace NAMESPACE {
+void MAIN {
+    constexpr int onetile = 1;
+    uint32_t per_core_block_cnt = get_arg_val<uint32_t>(0);
+    binary_op_init_common(tt::CB::c_in0, tt::CB::c_in1);
+    bool enable_reload = false;
+    for (uint32_t block = 0; block < per_core_block_cnt; ++block) {
+        bool last_out = block == (per_core_block_cnt - 1);
+
+        // elemwise-mul
+        ACQ();
+        cb_wait_front(tt::CB::c_in0, onetile);
+        cb_wait_front(tt::CB::c_in1, onetile);
+
+        cb_reserve_back(tt::CB::c_intermed0, onetile);
+        mul_tiles_init();
+        // dst0 = c_in0 x c_in1
+        mul_tiles(tt::CB::c_in0, tt::CB::c_in1, 0, 0, 0);
+        // c_intermed0 = pack(dst0)
+        pack_tile(0, tt::CB::c_intermed0);
+        cb_push_back(tt::CB::c_intermed0, onetile);
+
+        cb_pop_front(tt::CB::c_in0, onetile);
+        cb_pop_front(tt::CB::c_in1, onetile);
+        REL();
+
+        // reduce-w
+        ACQ();
+        if (enable_reload) {
+            cb_wait_front(tt::CB::c_intermed1, onetile);
+            copy_tile_to_dst_init_short();
+            copy_tile(tt::CB::c_intermed1, 0, 0);
+            cb_pop_front(tt::CB::c_intermed1, onetile);
+        }
+
+        cb_wait_front(tt::CB::c_intermed0, onetile);
+        reduce_init_delta<false>();
+        reduce_tile(tt::CB::c_intermed0, tt::CB::c_in2, 0, 0, 0);
+        cb_pop_front(tt::CB::c_intermed0, onetile);
+        reduce_revert_delta();
+
+        if (last_out) {
+            cb_reserve_back(tt::CB::c_out0, onetile);
+            pack_tile(0, tt::CB::c_out0);
+            cb_push_back(tt::CB::c_out0, onetile);
+        } else {
+            cb_reserve_back(tt::CB::c_intermed1, onetile);
+            pack_tile(0, tt::CB::c_intermed1);
+            cb_push_back(tt::CB::c_intermed1, onetile);
+        }
+        REL();
+        enable_reload = true;
+    }
+}
+}  // namespace NAMESPACE

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_dot_op/device/kernels/reader_moreh_dot.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_dot_op/device/kernels/reader_moreh_dot.cpp
@@ -1,0 +1,114 @@
+// SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <stdint.h>
+
+#include "dataflow_api.h"
+
+void mask_tile_in_reader(uint32_t l1_addr, uint32_t mask_w = 32, uint32_t mask_h = 32) {
+    union {
+        float f;
+        uint32_t u;
+    } zero;
+    zero.f = 0.0f;
+    auto ptr = reinterpret_cast<uint16_t *>(l1_addr);
+    for (uint32_t h = 0; h < 16; h++) {
+        // sub tile 0
+        {
+            uint32_t mask_w_0 = (mask_w >= 16) ? 16 : mask_w;
+            uint32_t mask_h_0 = (mask_h >= 16) ? 16 : mask_h;
+            uint32_t w = (h >= mask_h_0) ? 0 : mask_w_0;
+            for (; w < 16; w++) {
+                ptr[h * 16 + w] = uint16_t(zero.u >> 16);
+            }
+        }
+        // sub tile 1
+        {
+            uint32_t mask_w_1 = (mask_w < 16) ? 0 : mask_w - 16;
+            uint32_t mask_h_0 = (mask_h >= 16) ? 16 : mask_h;
+            uint32_t w = (h >= mask_h_0) ? 0 : mask_w_1;
+            for (; w < 16; w++) {
+                ptr[h * 16 + w + 256] = uint16_t(zero.u >> 16);
+            }
+        }
+        // sub tile 2
+        {
+            uint32_t mask_w_0 = (mask_w >= 16) ? 16 : mask_w;
+            uint32_t mask_h_1 = (mask_h < 16) ? 0 : mask_h - 16;
+            uint32_t w = (h >= mask_h_1) ? 0 : mask_w_0;
+            for (; w < 16; w++) {
+                ptr[h * 16 + w + 512] = uint16_t(zero.u >> 16);
+            }
+        }
+        // sub tile 3
+        {
+            uint32_t mask_w_1 = (mask_w < 16) ? 0 : mask_w - 16;
+            uint32_t mask_h_1 = (mask_h < 16) ? 0 : mask_h - 16;
+            uint32_t w = (h >= mask_h_1) ? 0 : mask_w_1;
+            for (; w < 16; w++) {
+                ptr[h * 16 + w + 768] = uint16_t(zero.u >> 16);
+            }
+        }
+    }
+}
+
+void kernel_main() {
+    // same arg indices as in reader_binary_diff_lenghts for compat
+    uint32_t src0_addr = get_arg_val<uint32_t>(0);
+    uint32_t src1_addr = get_arg_val<uint32_t>(1);
+    uint32_t num_tiles = get_arg_val<uint32_t>(2);
+    uint32_t start_id = get_arg_val<uint32_t>(3);
+    uint32_t mask_h = get_arg_val<uint32_t>(4);
+    uint32_t mask_w = get_arg_val<uint32_t>(5);
+
+    constexpr bool src0_is_dram = get_compile_time_arg_val(0) == 1;
+    constexpr bool src1_is_dram = get_compile_time_arg_val(1) == 1;
+    constexpr uint32_t scaler = get_compile_time_arg_val(2);
+
+    constexpr uint32_t cb_id_in0 = 0;
+    constexpr uint32_t cb_id_in1 = 1;
+    constexpr uint32_t cb_id_in2 = 2;
+    cb_reserve_back(cb_id_in2, 1);
+    if (scaler != 0) {
+        auto ptr = reinterpret_cast<uint16_t *>(get_write_ptr(cb_id_in2));
+        for (int j = 0; j < 1024; j++) ptr[j] = uint16_t(0);
+
+        for (int k = 0; k < 4; k++)
+            for (int j = 0; j < 16; j++) ptr[k * 256 + j] = uint16_t(scaler >> 16);
+    }
+    cb_push_back(cb_id_in2, 1);
+
+    uint32_t l1_write_addr_in0;
+    uint32_t src0_tile_bytes = get_tile_size(cb_id_in0);
+    DataFormat src0_data_format = get_dataformat(cb_id_in0);
+    const InterleavedAddrGenFast<src0_is_dram> s0 = {
+        .bank_base_address = src0_addr, .page_size = src0_tile_bytes, .data_format = src0_data_format};
+    uint32_t l1_write_addr_in1;
+    uint32_t src1_tile_bytes = get_tile_size(cb_id_in1);
+    DataFormat src1_data_format = get_dataformat(cb_id_in1);
+    const InterleavedAddrGenFast<src1_is_dram> s1 = {
+        .bank_base_address = src1_addr, .page_size = src1_tile_bytes, .data_format = src1_data_format};
+
+    constexpr uint32_t onetile = 1;
+    for (uint32_t i = start_id; i < start_id + num_tiles; i++) {
+        bool last_tile = i == (start_id + num_tiles - 1);
+        cb_reserve_back(cb_id_in0, onetile);
+        l1_write_addr_in0 = get_write_ptr(cb_id_in0);
+        noc_async_read_tile(i, s0, l1_write_addr_in0);
+
+        cb_reserve_back(cb_id_in1, onetile);
+        l1_write_addr_in1 = get_write_ptr(cb_id_in1);
+        noc_async_read_tile(i, s1, l1_write_addr_in1);
+
+        noc_async_read_barrier();
+
+        if (last_tile) {
+            mask_tile_in_reader(l1_write_addr_in0, mask_w, mask_h);
+            mask_tile_in_reader(l1_write_addr_in1, mask_w, mask_h);
+        }
+
+        cb_push_back(cb_id_in0, onetile);
+        cb_push_back(cb_id_in1, onetile);
+    }
+}

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_dot_op/device/kernels/writer_moreh_dot.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_dot_op/device/kernels/writer_moreh_dot.cpp
@@ -1,0 +1,31 @@
+// SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "dataflow_api.h"
+
+void kernel_main() {
+    uint32_t dst_addr = get_arg_val<uint32_t>(0);
+    uint32_t num_tiles = get_arg_val<uint32_t>(1);
+    uint32_t start_id = get_arg_val<uint32_t>(2);
+
+    constexpr uint32_t cb_id_out = get_compile_time_arg_val(0);
+    constexpr bool dst_is_dram = get_compile_time_arg_val(1) == 1;
+
+    // single-tile ublocks
+    constexpr uint32_t onetile = 1;
+    const uint32_t tile_bytes = get_tile_size(cb_id_out);
+    const DataFormat data_format = get_dataformat(cb_id_out);
+
+    const InterleavedAddrGenFast<dst_is_dram> s = {
+        .bank_base_address = dst_addr, .page_size = tile_bytes, .data_format = data_format};
+
+    uint32_t end_id = start_id + num_tiles;
+    for (uint32_t i = start_id; i < end_id; i++) {
+        cb_wait_front(cb_id_out, onetile);
+        uint32_t l1_read_addr = get_read_ptr(cb_id_out);
+        noc_async_write_tile(i, s, l1_read_addr);
+        noc_async_write_barrier();
+        cb_pop_front(cb_id_out, onetile);
+    }
+}

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_dot_op/device/moreh_dot_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_dot_op/device/moreh_dot_device_operation.cpp
@@ -1,0 +1,88 @@
+// SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "moreh_dot_device_operation.hpp"
+
+#include "ttnn/tensor/tensor.hpp"
+#include "ttnn/deprecated/tt_dnn/op_library/moreh_helper_functions.hpp"
+
+namespace ttnn::operations::moreh::moreh_dot_op {
+MorehDotOperation::program_factory_t MorehDotOperation::select_program_factory(
+    const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args) {
+    // For now we litteraly don't care and return a single factory. Whatever
+    return SingleCore{};
+}
+
+void MorehDotOperation::validate(
+    const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args) {
+    const auto& input_tensor_a = tensor_args.input_tensor_a;
+    const auto& input_tensor_b = tensor_args.input_tensor_b;
+
+    TT_FATAL(tt::operations::primary::is_1d_tensor(input_tensor_a), "Invalid input tensor dimensions.");
+    TT_FATAL(tt::operations::primary::is_1d_tensor(input_tensor_b), "Invalid input tensor dimensions.");
+
+    const auto& a_shape_wo_padding = input_tensor_a.get_legacy_shape().without_padding();
+    const auto& b_shape_wo_padding = input_tensor_b.get_legacy_shape().without_padding();
+    TT_FATAL(a_shape_wo_padding[3] == b_shape_wo_padding[3], "Shape without padding must be the same.");
+
+    TT_FATAL(
+        input_tensor_a.get_dtype() == DataType::BFLOAT16 || input_tensor_a.get_dtype() == DataType::BFLOAT8_B,
+        "Unsupported data format");
+    TT_FATAL(
+        input_tensor_a.storage_type() == StorageType::DEVICE and input_tensor_b.storage_type() == StorageType::DEVICE,
+        "Operands to matmul need to be on device!");
+    TT_FATAL(input_tensor_a.device() == input_tensor_b.device(), "Operands to matmul need to be on the same device!");
+    TT_FATAL(
+        input_tensor_a.buffer() != nullptr and input_tensor_b.buffer() != nullptr,
+        "Operands to matmul need to be allocated in buffers on device!");
+}
+
+void MorehDotOperation::validate_on_program_cache_miss(
+    const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args) {
+    validate(operation_attributes, tensor_args);
+}
+
+void MorehDotOperation::validate_on_program_cache_hit(
+    const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args) {
+    validate(operation_attributes, tensor_args);
+}
+
+MorehDotOperation::shape_return_value_t MorehDotOperation::compute_output_shapes(
+    const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args) {
+
+    const auto& input_tensor = tensor_args.input_tensor_a;
+    auto output_shape = input_tensor.get_shape().value;
+    auto padding = output_shape.padding();
+    output_shape[3] = tt::constants::TILE_WIDTH;
+    padding[3] = Padding::PadDimension{0, 31};
+    return ttnn::Shape{tt::tt_metal::Shape(output_shape, padding)};
+}
+
+
+MorehDotOperation::tensor_return_value_t MorehDotOperation::create_output_tensors(
+    const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args) {
+    std::vector<Tensor> input_tensors = {tensor_args.input_tensor_a, tensor_args.input_tensor_b};
+    const auto output_shape = compute_output_shapes(operation_attributes, tensor_args);
+    const auto& input_tensor = tensor_args.input_tensor_a;
+    return create_device_tensor(
+        output_shape,
+        input_tensor.tensor_attributes->dtype,
+        input_tensor.tensor_attributes->layout,
+        input_tensor.device(),
+        operation_attributes.output_memory_config);
+}
+
+std::tuple<MorehDotOperation::operation_attributes_t, MorehDotOperation::tensor_args_t>
+MorehDotOperation::invoke(
+        const Tensor &input_tensor_a,
+        const Tensor &input_tensor_b,
+        const std::optional<DataType> dtype,
+        const std::optional<MemoryConfig> &output_memory_config) {
+    return {
+        operation_attributes_t{dtype.value_or(input_tensor_a.dtype()), output_memory_config.value_or(input_tensor_a.memory_config())},
+        tensor_args_t{input_tensor_a, input_tensor_b}
+    };
+}
+
+}

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_dot_op/device/moreh_dot_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_dot_op/device/moreh_dot_device_operation.hpp
@@ -1,0 +1,70 @@
+// SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+
+#include <optional>
+#include <variant>
+
+#include "ttnn/tensor/tensor.hpp"
+#include "ttnn/device_operation.hpp"
+#include "ttnn/types.hpp"
+#include "ttnn/decorators.hpp"
+
+
+namespace ttnn::operations::moreh::moreh_dot_op {
+
+struct MorehDotOperation {
+    struct operation_attributes_t {
+        const DataType output_dtype;
+        const MemoryConfig output_memory_config;
+    };
+
+    struct tensor_args_t {
+        const Tensor &input_tensor_a;
+        const Tensor &input_tensor_b;
+    };
+
+    using shape_return_value_t = ttnn::Shape;
+    using tensor_return_value_t = Tensor;
+
+    struct SingleCore {
+        struct shared_variables_t {
+            KernelHandle unary_reader_kernel_id;
+            KernelHandle unary_writer_kernel_id;
+        };
+        using cached_program_t = ttnn::device_operation::CachedProgram<shared_variables_t>;
+
+        static cached_program_t create(
+            const operation_attributes_t& operation_attributes,
+            const tensor_args_t& tensor_args,
+            tensor_return_value_t& tensor_return_value);
+
+        static void override_runtime_arguments(
+            cached_program_t& cached_program,
+            const operation_attributes_t& operation_attributes,
+            const tensor_args_t& tensor_args,
+            tensor_return_value_t& tensor_return_value);
+    };
+
+    using program_factory_t = std::variant<SingleCore>;
+
+    static program_factory_t select_program_factory(const operation_attributes_t&, const tensor_args_t&);
+    static void validate_on_program_cache_miss(const operation_attributes_t&, const tensor_args_t&);
+    static void validate_on_program_cache_hit(const operation_attributes_t&, const tensor_args_t&);
+    static void validate(const operation_attributes_t&, const tensor_args_t&);
+    static shape_return_value_t compute_output_shapes(const operation_attributes_t&, const tensor_args_t&);
+    static tensor_return_value_t create_output_tensors(const operation_attributes_t&, const tensor_args_t&);
+
+    static std::tuple<operation_attributes_t, tensor_args_t> invoke(
+        const Tensor &input_tensor_a,
+        const Tensor &input_tensor_b,
+        const std::optional<DataType> output_dtype,
+        const std::optional<MemoryConfig> &output_memory_config);
+    };
+}
+
+namespace ttnn::prim {
+constexpr auto moreh_dot =
+    ttnn::register_operation<"ttnn::prim::moreh_dot", ttnn::operations::moreh::moreh_dot_op::MorehDotOperation>();
+}

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_dot_op/device/moreh_dot_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_dot_op/device/moreh_dot_program_factory.cpp
@@ -1,0 +1,133 @@
+// SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "moreh_dot_device_operation.hpp"
+#include "tt_dnn/op_library/moreh_helper_functions.hpp"
+#include "tt_metal/common/constants.hpp"
+#include "tt_metal/tt_metal.cpp"
+
+
+namespace ttnn::operations::moreh::moreh_dot_op {
+MorehDotOperation::SingleCore::cached_program_t MorehDotOperation::SingleCore::create(
+    const operation_attributes_t& operation_attributes,
+    const tensor_args_t& tensor_args,
+    tensor_return_value_t& tensor_return_value) {
+    using namespace tt;
+    using namespace tt::tt_metal;
+
+    const auto& input_tensor_a = tensor_args.input_tensor_a;
+    const auto& input_tensor_b = tensor_args.input_tensor_b;
+    auto& output_tensor = tensor_return_value;
+
+    auto src0_buffer = input_tensor_a.buffer();
+    auto src1_buffer = input_tensor_b.buffer();
+    auto dst_buffer = output_tensor.buffer();
+    float scaler = 1.0f;
+
+    Program program{};
+
+    tt::DataFormat cb_data_format = tt::tt_metal::datatype_to_dataformat_converter(input_tensor_a.get_dtype());
+    uint32_t single_tile_size = tt::tt_metal::detail::TileSize(cb_data_format);
+    tt::DataFormat cb_data_format_output = tt::tt_metal::datatype_to_dataformat_converter(output_tensor.get_dtype());
+    uint32_t single_tile_size_output = tt::tt_metal::detail::TileSize(cb_data_format_output);
+
+    uint32_t num_tiles = input_tensor_a.volume() / tt::constants::TILE_HW;
+    const auto &a_shape_wo_padding = input_tensor_a.get_shape().value.without_padding();
+    uint32_t pad_h = a_shape_wo_padding[2] % tt::constants::TILE_HEIGHT;
+    uint32_t pad_w = a_shape_wo_padding[3] % tt::constants::TILE_WIDTH;
+    uint32_t mask_h = (pad_h == 0) ? (tt::constants::TILE_HEIGHT) : (pad_h);
+    uint32_t mask_w = (pad_w == 0) ? (tt::constants::TILE_WIDTH) : (pad_w);
+
+    tt::tt_metal::Device *device = input_tensor_a.device();
+
+    const uint32_t in0_t = 2;   // a
+    const uint32_t in1_t = 2;   // b
+    const uint32_t in2_t = 1;   // scaler
+    const uint32_t out0_t = 2;  // out
+    const uint32_t im0_t = 1;
+    const uint32_t im1_t = 1;
+
+    CoreCoord core = {0, 0};
+
+
+    tt::operations::primary::CreateCircularBuffer(
+        program,
+        std::set<CoreRange>{CoreRange(core, core)},
+        cb_data_format,
+        {
+            {CB::c_in0, in0_t},
+            {CB::c_in1, in1_t},
+            {CB::c_in2, in2_t},
+            {CB::c_out0, out0_t},
+            {CB::c_intermed0, im0_t},
+            {CB::c_intermed1, im1_t},
+        });
+
+    std::vector<uint32_t> reader_compile_time_args = {
+        (std::uint32_t)tt::operations::primary::is_dram(src0_buffer),
+        (std::uint32_t)tt::operations::primary::is_dram(src1_buffer),
+        *reinterpret_cast<uint32_t *>(&scaler)};
+
+    std::vector<uint32_t> writer_compile_time_args = {(std::uint32_t)CB::c_out0, (std::uint32_t)tt::operations::primary::is_dram(dst_buffer)};
+    const auto reader_kernel_file = "ttnn/cpp/ttnn/operations/moreh/moreh_dot_op/device/kernels/reader_moreh_dot.cpp";
+    const auto writer_kernel_file = "ttnn/cpp/ttnn/operations/moreh/moreh_dot_op/device/kernels/writer_moreh_dot.cpp";
+
+    const auto reader_kernel_id = tt::operations::primary::CreateReadKernel(program, reader_kernel_file, core, reader_compile_time_args);
+    const auto writer_kernel_id = tt::operations::primary::CreateWriteKernel(program, writer_kernel_file, core, writer_compile_time_args);
+
+    vector<uint32_t> compute_kernel_args = {};
+    std::map<string, string> compute_defines;
+    compute_defines["REDUCE_OP"] = "PoolType::SUM";
+    compute_defines["REDUCE_DIM"] = "ReduceDim::REDUCE_ROW";
+
+    const uint32_t core_num = 1;
+    const auto compute_kernel_file = "ttnn/cpp/ttnn/operations/moreh/moreh_dot_op/device/kernels/moreh_dot.cpp";
+    const auto compute_kernel_id =
+        tt::operations::primary::CreateComputeKernel(program, compute_kernel_file, {core, core_num, compute_kernel_args}, compute_defines);
+
+    SetRuntimeArgs(
+        program,
+        reader_kernel_id,
+        core,
+        {src0_buffer->address(), src1_buffer->address(), num_tiles, 0, mask_h, mask_w});
+    SetRuntimeArgs(program, compute_kernel_id, core, {num_tiles, 1});
+    SetRuntimeArgs(program, writer_kernel_id, core, {output_tensor.buffer()->address(), 1, 0});
+
+    const std::vector<Tensor> input_tensors = {input_tensor_a, input_tensor_b};
+
+    return {
+        std::move(program),
+        {.unary_reader_kernel_id = reader_kernel_id, .unary_writer_kernel_id = writer_kernel_id}};
+}
+
+void MorehDotOperation::SingleCore::override_runtime_arguments(
+    cached_program_t& cached_program,
+    const operation_attributes_t& operation_attributes,
+    const tensor_args_t& tensor_args,
+    tensor_return_value_t& tensor_return_value) {
+    auto& program = cached_program.program;
+    auto& unary_reader_kernel_id = cached_program.shared_variables.unary_reader_kernel_id;
+    auto& unary_writer_kernel_id = cached_program.shared_variables.unary_writer_kernel_id;
+
+    const auto& input_tensor_a = tensor_args.input_tensor_a;
+    const auto& input_tensor_b = tensor_args.input_tensor_b;
+    auto& output_tensor = tensor_return_value;
+
+    auto src_buffer_a = input_tensor_a.buffer();
+    auto src_buffer_b = input_tensor_b.buffer();
+    auto dst_buffer = output_tensor.buffer();
+
+    {
+        auto& runtime_args = tt::tt_metal::GetRuntimeArgs(program, unary_reader_kernel_id, CoreCoord{0, 0});
+        runtime_args[0] = src_buffer_a->address();
+        runtime_args[1] = src_buffer_b->address();
+    }
+
+    {
+        auto& runtime_args = tt::tt_metal::GetRuntimeArgs(program, unary_writer_kernel_id, CoreCoord{0, 0});
+        runtime_args[0] = dst_buffer->address();
+    }
+}
+
+}  // namespace ttnn::operations::examples

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_dot_op/moreh_dot.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_dot_op/moreh_dot.cpp
@@ -1,0 +1,18 @@
+// SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "moreh_dot.hpp"
+#include "ttnn/operations/moreh/moreh_dot_op/device/moreh_dot_device_operation.hpp"
+
+namespace ttnn::operations::moreh::moreh_dot {
+
+    Tensor MorehDot::invoke(
+        const ttnn::Tensor& input_tensor_a,
+        const ttnn::Tensor& input_tensor_b,
+        const std::optional<DataType> dtype,
+        const std::optional<MemoryConfig> &memory_config) {
+            return ttnn::prim::moreh_dot(
+                input_tensor_a, input_tensor_b, dtype, memory_config);
+        }
+}

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_dot_op/moreh_dot.hpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_dot_op/moreh_dot.hpp
@@ -1,0 +1,23 @@
+
+// SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+#include "ttnn/decorators.hpp"
+namespace ttnn::operations::moreh::moreh_dot {
+
+struct MorehDot {
+
+    static Tensor invoke(
+        const ttnn::Tensor& input_tensor_a,
+        const ttnn::Tensor& input_tensor_b,
+        const std::optional<DataType> dtype,
+        const std::optional<MemoryConfig> &memory_config);
+};
+}
+
+namespace ttnn {
+constexpr auto moreh_dot =
+    ttnn::register_operation_with_auto_launch_op<"ttnn::moreh_dot", ttnn::operations::moreh::moreh_dot::MorehDot>();
+}

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_dot_op/moreh_dot_pybind.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_dot_op/moreh_dot_pybind.cpp
@@ -1,0 +1,34 @@
+// SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <pybind11/pybind11.h>
+#include <pybind11/stl.h>
+
+#include "moreh_dot_pybind.hpp"
+#include "ttnn/cpp/pybind11/decorators.hpp"
+#include "ttnn/operation.hpp"
+#include "ttnn/types.hpp"
+#include "ttnn/operations/moreh/moreh_dot_op/device/moreh_dot_device_operation.hpp"
+#include "moreh_dot.hpp"
+
+namespace py = pybind11;
+
+namespace ttnn::operations::moreh::moreh_dot {
+
+void bind_moreh_dot_operation(py::module& module) {
+
+bind_registered_operation(
+    module,
+    ttnn::moreh_dot,
+    "Moreh moreh_dot Operation",
+    ttnn::pybind_arguments_t{
+
+        py::arg("input_tensor_a"),
+        py::arg("input_tensor_b"),
+        py::kw_only(),
+        py::arg("dtype") = std::nullopt,
+        py::arg("memory_config") = std::nullopt});
+}
+
+}

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_dot_op/moreh_dot_pybind.hpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_dot_op/moreh_dot_pybind.hpp
@@ -1,0 +1,13 @@
+// SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include "pybind11/pybind_fwd.hpp"
+
+namespace py = pybind11;
+
+namespace ttnn::operations::moreh::moreh_dot {
+void bind_moreh_dot_operation(py::module& module);
+}

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_pybind.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_pybind.cpp
@@ -10,6 +10,7 @@
 #include "ttnn/operations/moreh/moreh_sum/moreh_sum_pybind.hpp"
 #include "ttnn/operations/moreh/moreh_mean/moreh_mean_pybind.hpp"
 #include "ttnn/operations/moreh/moreh_mean_backward/moreh_mean_backward_pybind.hpp"
+#include "ttnn/operations/moreh/moreh_dot_op/moreh_dot_pybind.hpp"
 
 namespace ttnn::operations::moreh {
 void bind_moreh_operations(py::module &module) {
@@ -19,5 +20,6 @@ void bind_moreh_operations(py::module &module) {
     moreh_sum::bind_moreh_sum_operation(module);
     moreh_mean::bind_moreh_mean_operation(module);
     moreh_mean_backward::bind_moreh_mean_backward_operation(module);
+    moreh_dot::bind_moreh_dot_operation(module);
 }
 }  // namespace ttnn::operations::moreh


### PR DESCRIPTION
### Ticket
[12207](https://github.com/tenstorrent/tt-metal/issues/12207)

### Problem description
moreh_dot was deprecated alongside tt_dnn. This PR ports it to ttnn using its operation format.

### What's changed
Move device code to ttnn
Create new wrapper code for ttnn with new modules

### Checklist
- [x] Post commit CI passes
- [x] Blackhole Post commit (if applicable) - NA
- [x] Model regression CI testing passes (if applicable) - NA
- [x] New/Existing tests provide coverage for changes
