### PR TITLE
#10147: migrate bitwise left and right shift to ttnn

### DIFF
--- a/tests/ttnn/python_api_testing/sweep_tests/op_map.py
+++ b/tests/ttnn/python_api_testing/sweep_tests/op_map.py
@@ -1042,4 +1042,12 @@ op_map = {
         "tt_op": ttnn_ops.argmax,
         "pytorch_op": pytorch_ops.argmax,
     },
+    "eltwise-right_shift": {
+        "tt_op": ttnn_ops.eltwise_right_shift,
+        "pytorch_op": pytorch_ops.right_shift,
+    },
+    "eltwise-left_shift": {
+        "tt_op": ttnn_ops.eltwise_left_shift,
+        "pytorch_op": pytorch_ops.left_shift,
+    },
 }

--- a/tests/ttnn/python_api_testing/sweep_tests/test_configs/ci_sweep_tests_broken/grayskull/ttnn_bitwise_right_shift_test.yaml
+++ b/tests/ttnn/python_api_testing/sweep_tests/test_configs/ci_sweep_tests_broken/grayskull/ttnn_bitwise_right_shift_test.yaml
@@ -1,0 +1,29 @@
+---
+test-list:
+  - eltwise-right_shift:
+      shape:
+        start-shape: [1, 1, 32, 32]
+        end-shape: [6, 12, 256, 256]
+        interval: [1, 1, 32, 32]
+        num-dims: [2, 3, 4]
+        num-shapes: 2
+        num-samples: 128
+        args-sampling-strategy: "all"
+      env:
+        # TT_PCI_DMA_BUF_SIZE: "1048576"
+      datagen:
+        function: gen_rand
+        dtype: int32
+        args:
+          low: 0
+          high: 100
+      comparison:
+        function: comp_pcc
+      args-gen: gen_bitwise_args
+      sanitize-args: False
+      args:
+        data-layout: ["TILE"]
+        data-type: ["INT32"]
+        buffer-type: ["DRAM", "L1"]
+        out-buffer-type: ["DRAM", "L1"]
+      output-file: bitwise_right_shift_sweep.csv

--- a/tests/ttnn/python_api_testing/sweep_tests/test_configs/ci_sweep_tests_broken/grayskull/ttnn_bitwise_shift_left_test.yaml
+++ b/tests/ttnn/python_api_testing/sweep_tests/test_configs/ci_sweep_tests_broken/grayskull/ttnn_bitwise_shift_left_test.yaml
@@ -1,0 +1,29 @@
+---
+test-list:
+  - eltwise-left_shift:
+      shape:
+        start-shape: [1, 1, 32, 32]
+        end-shape: [6, 12, 256, 256]
+        interval: [1, 1, 32, 32]
+        num-dims: [2, 3, 4]
+        num-shapes: 2
+        num-samples: 128
+        args-sampling-strategy: "all"
+      env:
+        # TT_PCI_DMA_BUF_SIZE: "1048576"
+      datagen:
+        function: gen_rand
+        dtype: int32
+        args:
+          low: 0
+          high: 100
+      comparison:
+        function: comp_pcc
+      args-gen: gen_bitwise_args
+      sanitize-args: False
+      args:
+        data-layout: ["TILE"]
+        data-type: ["INT32"]
+        buffer-type: ["DRAM", "L1"]
+        out-buffer-type: ["DRAM", "L1"]
+      output-file: bitwise_left_shift_sweep.csv

--- a/tests/ttnn/python_api_testing/sweep_tests/test_configs/ci_sweep_tests_broken/wormhole/ttnn_bitwise_right_shift_test.yaml
+++ b/tests/ttnn/python_api_testing/sweep_tests/test_configs/ci_sweep_tests_broken/wormhole/ttnn_bitwise_right_shift_test.yaml
@@ -1,0 +1,29 @@
+---
+test-list:
+  - eltwise-right_shift:
+      shape:
+        start-shape: [1, 1, 32, 32]
+        end-shape: [6, 12, 256, 256]
+        interval: [1, 1, 32, 32]
+        num-dims: [2, 3, 4]
+        num-shapes: 2
+        num-samples: 128
+        args-sampling-strategy: "all"
+      env:
+        # TT_PCI_DMA_BUF_SIZE: "1048576"
+      datagen:
+        function: gen_rand
+        dtype: int32
+        args:
+          low: 0
+          high: 100
+      comparison:
+        function: comp_pcc
+      args-gen: gen_bitwise_args
+      sanitize-args: False
+      args:
+        data-layout: ["TILE"]
+        data-type: ["INT32"]
+        buffer-type: ["DRAM", "L1"]
+        out-buffer-type: ["DRAM", "L1"]
+      output-file: bitwise_right_shift_sweep.csv

--- a/tests/ttnn/python_api_testing/sweep_tests/test_configs/ci_sweep_tests_broken/wormhole/ttnn_bitwise_shift_left_test.yaml
+++ b/tests/ttnn/python_api_testing/sweep_tests/test_configs/ci_sweep_tests_broken/wormhole/ttnn_bitwise_shift_left_test.yaml
@@ -1,0 +1,29 @@
+---
+test-list:
+  - eltwise-left_shift:
+      shape:
+        start-shape: [1, 1, 32, 32]
+        end-shape: [6, 12, 256, 256]
+        interval: [1, 1, 32, 32]
+        num-dims: [2, 3, 4]
+        num-shapes: 2
+        num-samples: 128
+        args-sampling-strategy: "all"
+      env:
+        # TT_PCI_DMA_BUF_SIZE: "1048576"
+      datagen:
+        function: gen_rand
+        dtype: int32
+        args:
+          low: 0
+          high: 100
+      comparison:
+        function: comp_pcc
+      args-gen: gen_bitwise_args
+      sanitize-args: False
+      args:
+        data-layout: ["TILE"]
+        data-type: ["INT32"]
+        buffer-type: ["DRAM", "L1"]
+        out-buffer-type: ["DRAM", "L1"]
+      output-file: bitwise_left_shift_sweep.csv

--- a/tests/ttnn/python_api_testing/sweep_tests/ttnn_ops.py
+++ b/tests/ttnn/python_api_testing/sweep_tests/ttnn_ops.py
@@ -4882,3 +4882,37 @@ def eltwise_ceil(
     t1 = ttnn.ceil(t0, memory_config=output_mem_config)
 
     return ttnn_tensor_to_torch(t1)
+
+
+def eltwise_right_shift(
+    x,
+    *args,
+    value,
+    device,
+    dtype,
+    layout,
+    input_mem_config,
+    output_mem_config,
+    **kwargs,
+):
+    t0 = setup_ttnn_tensor(x, device, layout[0], input_mem_config[0], dtype[0])
+    t1 = ttnn.bitwise_right_shift(t0, value, memory_config=output_mem_config, queue_id=0)
+
+    return ttnn_tensor_to_torch(t1)
+
+
+def eltwise_left_shift(
+    x,
+    *args,
+    value,
+    device,
+    dtype,
+    layout,
+    input_mem_config,
+    output_mem_config,
+    **kwargs,
+):
+    t0 = setup_ttnn_tensor(x, device, layout[0], input_mem_config[0], dtype[0])
+    t1 = ttnn.bitwise_left_shift(t0, value, memory_config=output_mem_config, queue_id=0)
+
+    return ttnn_tensor_to_torch(t1)


### PR DESCRIPTION
### Ticket
[Link to Github Issue](https://github.com/tenstorrent/tt-metal/issues/10147)

### Problem description
Migrating eltwise-bitwise-right-shift and eltwise-bitwise-left-shift to ttnn.

