### PR TITLE
#12196: Use split readers wherever possible in UNet Shallow

### DIFF
--- a/models/experimental/functional_unet/tests/test_unet_model.py
+++ b/models/experimental/functional_unet/tests/test_unet_model.py
@@ -26,7 +26,7 @@ def test_unet_model(batch, groups, device, use_program_cache, reset_seeds):
     ttnn_model = unet_shallow_ttnn.UNet(parameters, device)
 
     torch_output_tensor = model(torch_input)
-    output_tensor = ttnn_model(ttnn_input, list(torch_input.shape))
+    output_tensor = ttnn_model(ttnn_input)
 
     B, C, H, W = torch_output_tensor.shape
     ttnn_tensor = ttnn.to_torch(output_tensor).reshape(B, H, W, -1)[:, :, :, :C].permute(0, 3, 1, 2)

--- a/models/experimental/functional_unet/tests/test_unet_multi_device.py
+++ b/models/experimental/functional_unet/tests/test_unet_multi_device.py
@@ -46,6 +46,6 @@ def test_unet_multi_device_model(batch, groups, mesh_device, use_program_cache, 
     )
 
     torch_output_tensor = model(torch_input)
-    output_tensor = ttnn_model(ttnn_input, list(torch_input.shape))
+    output_tensor = ttnn_model(ttnn_input)
 
     check_pcc_conv(torch_output_tensor, output_tensor, mesh_composer=output_mesh_composer, pcc=0.99)

--- a/models/experimental/functional_unet/tests/test_unet_perf.py
+++ b/models/experimental/functional_unet/tests/test_unet_perf.py
@@ -1,0 +1,218 @@
+# SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
+
+# SPDX-License-Identifier: Apache-2.0
+
+import ttnn
+import pytest
+
+from loguru import logger
+
+from tests.ttnn.utils_for_testing import assert_with_pcc
+
+from models.experimental.functional_unet.tt.model_preprocessing import (
+    create_unet_input_tensors,
+    create_unet_model_parameters,
+)
+from models.experimental.functional_unet.tt import unet_shallow_torch
+from models.experimental.functional_unet.tt import unet_shallow_ttnn
+from models.experimental.functional_unet.tests.common import (
+    check_pcc_conv,
+    is_n300_with_eth_dispatch_cores,
+)
+
+from models.perf.perf_utils import prep_perf_report
+from models.perf.device_perf_utils import run_device_perf, check_device_perf, prep_device_perf_report
+from models.utility_functions import (
+    profiler,
+    skip_for_grayskull,
+)
+
+
+@skip_for_grayskull("UNet not currently supported on GS")
+@pytest.mark.models_device_performance_bare_metal
+@pytest.mark.parametrize(
+    "batch, groups, expected_device_perf_fps",
+    ((2, 1, 443.0),),
+)
+def test_unet_perf_device(batch: int, groups: int, expected_device_perf_fps: float, reset_seeds):
+    command = f"pytest models/experimental/functional_unet/tests/test_unet_model.py::test_unet_model[device_params0-{groups}-{batch}]"
+    cols = ["DEVICE FW", "DEVICE KERNEL", "DEVICE BRISC KERNEL"]
+
+    inference_time_key = "AVG DEVICE FW SAMPLES/S"
+    post_processed_results = run_device_perf(
+        command, subdir="unet_shallow", num_iterations=1, cols=cols, batch_size=batch
+    )
+    expected_perf_cols = {inference_time_key: expected_device_perf_fps}
+    expected_results = check_device_perf(
+        post_processed_results, margin=0.02, expected_perf_cols=expected_perf_cols, assert_on_fail=True
+    )
+    prep_device_perf_report(
+        model_name=f"unet-shallow_batch-{batch}_groups-{groups}",
+        batch_size=batch,
+        post_processed_results=post_processed_results,
+        expected_results=expected_results,
+        comments="",
+    )
+
+
+@skip_for_grayskull("UNet not currently supported on GS")
+@pytest.mark.models_performance_bare_metal
+@pytest.mark.parametrize("device_params", [{"l1_small_size": 64768}], indirect=True)
+@pytest.mark.parametrize(
+    "batch, groups, iterations, expected_compile_time, expected_inference_time_ms",
+    ((2, 1, 16, 16.0, 39.0),),
+)
+def test_unet_perf_e2e(
+    batch: int,
+    groups: int,
+    iterations: int,
+    expected_compile_time: float,
+    expected_inference_time_ms: float,
+    device,
+    use_program_cache,
+    reset_seeds,
+):
+    profiler.clear()
+
+    torch_input, ttnn_input = create_unet_input_tensors(device, batch, groups, pad_input=True)
+
+    profiler.start(f"initialize_ref_model")
+    model = unet_shallow_torch.UNet.from_random_weights(groups=1)
+    profiler.end(f"initialize_ref_model")
+
+    profiler.start(f"initialize_model")
+    parameters = create_unet_model_parameters(model, torch_input, groups=groups, device=device)
+    ttnn_model = unet_shallow_ttnn.UNet(parameters, device)
+    profiler.end(f"initialize_model")
+
+    torch_output_tensor = model(torch_input)
+
+    logger.info(f"Compiling model with warmup run")
+    profiler.start(f"inference_and_compile_time")
+    output_tensor = ttnn_model(ttnn_input)
+    profiler.end(f"inference_and_compile_time")
+
+    inference_and_compile_time = profiler.get("inference_and_compile_time")
+    logger.info(f"Model compiled with warmup run in {(inference_and_compile_time):.2f} s")
+
+    logger.info(f"Running inference for {iterations} iterations")
+    for idx in range(iterations):
+        profiler.start("inference_time")
+        profiler.start(f"inference_time_{idx}")
+        output_tensor = ttnn_model(ttnn_input)
+        profiler.end(f"inference_time_{idx}")
+        profiler.end("inference_time")
+
+    mean_inference_time = profiler.get("inference_time")
+    inference_time = profiler.get(f"inference_time_{iterations - 1}")
+    compile_time = inference_and_compile_time - inference_time
+    logger.info(f"Model compilation took {compile_time:.1f} s")
+    logger.info(f"Inference time on last iterations was completed in {(inference_time * 1000.0):.2f} ms")
+    logger.info(
+        f"Mean inference time for {batch} (batch) images was {(mean_inference_time * 1000.0):.2f} ms ({batch / mean_inference_time:.2f} fps)"
+    )
+
+    expected_inference_time = expected_inference_time_ms * 1e-3
+    prep_perf_report(
+        model_name=f"unet_shallow",
+        batch_size=batch,
+        inference_and_compile_time=inference_and_compile_time,
+        inference_time=inference_time,
+        expected_compile_time=expected_compile_time,
+        expected_inference_time=expected_inference_time,
+        comments="",
+    )
+
+    logger.info(f"Running sanity check against reference model output")
+    B, C, H, W = torch_output_tensor.shape
+    ttnn_tensor = ttnn.to_torch(output_tensor).reshape(B, H, W, -1)[:, :, :, :C].permute(0, 3, 1, 2)
+    assert_with_pcc(torch_output_tensor, ttnn_tensor, 0.99)
+
+
+@skip_for_grayskull("UNet not currently supported on GS")
+@pytest.mark.models_performance_bare_metal
+@pytest.mark.parametrize("device_params", [{"l1_small_size": 64768}], indirect=True)
+@pytest.mark.parametrize(
+    "batch, groups, iterations, expected_compile_time, expected_inference_time_ms",
+    ((2, 1, 16, 16.0, 39.0),),
+)
+def test_unet_data_parallel_perf_e2e(
+    batch: int,
+    groups: int,
+    iterations: int,
+    expected_compile_time: float,
+    expected_inference_time_ms: float,
+    mesh_device,
+    use_program_cache,
+    reset_seeds,
+):
+    if not is_n300_with_eth_dispatch_cores(mesh_device):
+        pytest.skip("Test is only valid for N300")
+
+    profiler.clear()
+
+    inputs_mesh_mapper = ttnn.ShardTensorToMesh(mesh_device, dim=0)
+    weights_mesh_mapper = ttnn.ReplicateTensorToMesh(mesh_device)
+    output_mesh_composer = ttnn.ConcatMeshToTensor(mesh_device, dim=0)
+
+    torch_input, ttnn_input = create_unet_input_tensors(mesh_device, batch, groups, pad_input=True)
+
+    profiler.start(f"initialize_ref_model")
+    model = unet_shallow_torch.UNet.from_random_weights(groups=groups)
+    profiler.end(f"initialize_ref_model")
+
+    profiler.start(f"initialize_model")
+    parameters = create_unet_model_parameters(model, torch_input, groups=groups, device=mesh_device)
+    ttnn_model = unet_shallow_ttnn.UNet(parameters, device=mesh_device, mesh_mapper=weights_mesh_mapper)
+    profiler.end(f"initialize_model")
+
+    num_devices = len(mesh_device.get_device_ids())
+    total_batch = num_devices * batch
+    torch_input, ttnn_input = create_unet_input_tensors(
+        mesh_device, total_batch, groups, pad_input=True, mesh_mapper=inputs_mesh_mapper
+    )
+    logger.info(f"Created reference input tensors: {list(torch_input.shape)}")
+    logger.info(
+        f"Created multi-device input tensors: shape={list(ttnn_input.shape)} on devices={mesh_device.get_device_ids()}"
+    )
+
+    torch_output_tensor = model(torch_input)
+
+    logger.info(f"Compiling model with warmup run")
+    profiler.start(f"inference_and_compile_time")
+    output_tensor = ttnn_model(ttnn_input)
+    profiler.end(f"inference_and_compile_time")
+
+    inference_and_compile_time = profiler.get("inference_and_compile_time")
+    logger.info(f"Model compiled with warmup run in {(inference_and_compile_time):.2f} s")
+
+    logger.info(f"Running inference for {iterations} iterations")
+    for idx in range(iterations):
+        profiler.start("inference_time")
+        profiler.start(f"inference_time_{idx}")
+        output_tensor = ttnn_model(ttnn_input)
+        profiler.end(f"inference_time_{idx}")
+        profiler.end("inference_time")
+
+    mean_inference_time = profiler.get("inference_time")
+    inference_time = profiler.get(f"inference_time_{iterations - 1}")
+    compile_time = inference_and_compile_time - inference_time
+    logger.info(f"Model compilation took {compile_time:.1f} s")
+    logger.info(f"Inference time on last iterations was completed in {(inference_time * 1000.0):.2f} ms")
+    logger.info(
+        f"Mean inference time for {total_batch} (batch) images was {(mean_inference_time * 1000.0):.2f} ms ({total_batch / mean_inference_time:.2f} fps)"
+    )
+
+    expected_inference_time = expected_inference_time_ms * 1e-3
+    prep_perf_report(
+        model_name=f"unet_shallow-data_parallel",
+        batch_size=total_batch,
+        inference_and_compile_time=inference_and_compile_time,
+        inference_time=inference_time,
+        expected_compile_time=expected_compile_time,
+        expected_inference_time=expected_inference_time,
+        comments="batch_{total_batch}-num_devices_{num_devices}",
+    )
+
+    logger.info(f"Running sanity check against reference model output")
+    check_pcc_conv(torch_output_tensor, output_tensor, mesh_composer=output_mesh_composer, pcc=0.99)

--- a/models/experimental/functional_unet/tt/model_preprocessing.py
+++ b/models/experimental/functional_unet/tt/model_preprocessing.py
@@ -66,34 +66,65 @@ def create_unet_model_parameters(model: unet_shallow_torch.UNet, input_tensor: t
     }
 
     parameters.c1["conv_blocking_and_parallelization_config_override"] = {"act_block_h": 8 * 32}
+    parameters.c1["use_split_reader"] = True
+    parameters.c1["use_activation_double_buffer"] = True
     parameters.c1_2["conv_blocking_and_parallelization_config_override"] = {"act_block_h": 8 * 32}
+    parameters.c1_2["use_split_reader"] = True
+    parameters.c1_2["use_activation_double_buffer"] = True
 
     parameters.c2["conv_blocking_and_parallelization_config_override"] = {"act_block_h": 5 * 32}
     parameters.c2_2["conv_blocking_and_parallelization_config_override"] = {"act_block_h": 5 * 32}
+    parameters.c2_2["use_activation_double_buffer"] = True
+
     parameters.c3["conv_blocking_and_parallelization_config_override"] = None
+    parameters.c3["use_split_reader"] = True
+    parameters.c3["use_activation_double_buffer"] = True
     parameters.c3_2["conv_blocking_and_parallelization_config_override"] = None
+    parameters.c3_2["use_split_reader"] = True
+    parameters.c3_2["use_activation_double_buffer"] = True
+
     parameters.c4["conv_blocking_and_parallelization_config_override"] = None
+    parameters.c4["use_activation_double_buffer"] = True
     parameters.c4_2["conv_blocking_and_parallelization_config_override"] = None
+    parameters.c4_2["use_activation_double_buffer"] = True
 
     parameters.bnc["conv_blocking_and_parallelization_config_override"] = None
+    parameters.bnc["use_activation_double_buffer"] = True
     parameters.bnc_2["conv_blocking_and_parallelization_config_override"] = None
+    parameters.bnc_2["use_activation_double_buffer"] = True
 
     parameters.c5["conv_blocking_and_parallelization_config_override"] = None
+    parameters.c5["use_activation_double_buffer"] = True
     parameters.c5_2["conv_blocking_and_parallelization_config_override"] = None
+    parameters.c5_2["use_activation_double_buffer"] = True
     parameters.c5_3["conv_blocking_and_parallelization_config_override"] = None
+    parameters.c5_3["use_activation_double_buffer"] = True
 
     parameters.c6["conv_blocking_and_parallelization_config_override"] = None
+    parameters.c6["use_split_reader"] = True
+    parameters.c6["use_activation_double_buffer"] = True
     parameters.c6_2["conv_blocking_and_parallelization_config_override"] = None
+    parameters.c6_2["use_split_reader"] = True
+    parameters.c6_2["use_activation_double_buffer"] = True
     parameters.c6_3["conv_blocking_and_parallelization_config_override"] = None
+    parameters.c6_3["use_split_reader"] = True
+    parameters.c6_3["use_activation_double_buffer"] = True
 
-    parameters.c7["conv_blocking_and_parallelization_config_override"] = {"act_block_h": 32}
+    parameters.c7["conv_blocking_and_parallelization_config_override"] = {"act_block_h": 5 * 32}
+    parameters.c7["use_activation_double_buffer"] = True
     parameters.c7_2["conv_blocking_and_parallelization_config_override"] = None
+    parameters.c7_2["use_split_reader"] = True
+    parameters.c7_2["use_activation_double_buffer"] = True
     parameters.c7_3["conv_blocking_and_parallelization_config_override"] = None
+    parameters.c7_3["use_split_reader"] = True
+    parameters.c7_3["use_activation_double_buffer"] = True
 
-    parameters.c8["conv_blocking_and_parallelization_config_override"] = {"act_block_h": 32}
-    parameters.c8["conv_blocking_and_parallelization_config_override"] = {"act_block_h": 32}
-    parameters.c8_2["conv_blocking_and_parallelization_config_override"] = {"act_block_h": 32}
-    parameters.c8_3["conv_blocking_and_parallelization_config_override"] = {"act_block_h": 32}
+    parameters.c8["conv_blocking_and_parallelization_config_override"] = {"act_block_h": 5 * 32}
+    parameters.c8["use_activation_double_buffer"] = True
+    parameters.c8_2["conv_blocking_and_parallelization_config_override"] = {"act_block_h": 5 * 32}
+    parameters.c8_2["use_activation_double_buffer"] = True
+    parameters.c8_3["conv_blocking_and_parallelization_config_override"] = {"act_block_h": 5 * 32}
+    parameters.c8_3["use_activation_double_buffer"] = True
 
     parameters.output_layer["conv_blocking_and_parallelization_config_override"] = None
 

--- a/models/experimental/functional_unet/tt/unet_shallow_ttnn.py
+++ b/models/experimental/functional_unet/tt/unet_shallow_ttnn.py
@@ -2,10 +2,9 @@
 
 # SPDX-License-Identifier: Apache-2.0
 
+import math
 import ttnn
 import torch
-
-from loguru import logger
 
 from ttnn.operations.conv2d import determine_parallel_config, create_sharded_memory_config_from_parallel_config
 
@@ -13,35 +12,37 @@ from models.utility_functions import nearest_32
 from ttnn.model_preprocessing import fold_batch_norm2d_into_conv2d, ParameterDict
 
 
-# Unet reshard wrapper
-def unet_reshard(
-    ttnn_tensor,
-    sharded_memory_config,
-    use_reshard=True,
-    interleaved_memory_config=ttnn.L1_MEMORY_CONFIG,
-    dtype=None,
-):
-    if use_reshard:
-        return ttnn.to_memory_config(
-            ttnn_tensor,
-            memory_config=sharded_memory_config,
+def determine_num_cores_for_upsample(nhw: int, width: int, max_cores=64) -> int:
+    gcd_nhw_width = math.gcd(nhw, width)
+    cores = nhw // gcd_nhw_width
+    if cores > max_cores:
+        for divisor in range(max_cores, 0, -1):
+            if nhw % divisor == 0 and (nhw // divisor) % width == 0:
+                cores = divisor
+                break
+    return cores
+
+
+def get_core_grid_from_num_cores(num_cores: int):
+    if num_cores == 44:
+        return ttnn.CoreRangeSet(
+            {
+                ttnn.CoreRange(
+                    ttnn.CoreCoord(0, 0),
+                    ttnn.CoreCoord(7, 4),
+                ),
+                ttnn.CoreRange(
+                    ttnn.CoreCoord(0, 5),
+                    ttnn.CoreCoord(3, 5),
+                ),
+            }
         )
-    else:
-        ttl_tensor = ttnn_tensor
-        ttl_tensor = ttnn.sharded_to_interleaved(ttl_tensor, interleaved_memory_config, dtype)
-        ttl_tensor = ttnn.interleaved_to_sharded(
-            ttl_tensor,
-            sharded_memory_config,
-            dtype,
-        )
-        return ttl_tensor
+    elif num_cores == 48:
+        return ttnn.CoreGrid(x=8, y=6)
+    raise RuntimeError(f"Could not get core grid given num_cores={num_cores}")
 
 
-# Unet concat tensor wrapper
-def unet_concat(ttnn_tensors, dim=-1, use_reshard=True, perf_mode=False):
-    if not perf_mode:
-        return ttnn.concat(ttnn_tensors, dim=3)
-
+def unet_concat(ttnn_tensors, dim=-1):
     assert len(ttnn_tensors) > 0
     assert dim < 0
     ttlib_tensors = ttnn_tensors
@@ -153,6 +154,7 @@ class UNetConv2D:
             enable_split_reader=False,
             enable_subblock_padding=False,
             activation=activation,
+            output_layout=ttnn.TILE_LAYOUT,
         )
         config_override = conv.conv_blocking_and_parallelization_config_override
         if config_override and "act_block_h" in config_override:
@@ -190,19 +192,12 @@ class UNetConv2D:
 
 
 class UNetMaxPool2D:
-    def __init__(self, pool, channels, device=None, reader_patterns_cache={}):
+    def __init__(self, pool, channels, device=None):
         self.pool = pool
         self.channels = channels
         self.device = device
 
     def __call__(self, x):
-        # For some reason the shard widths don't always match - so don't assert on it
-        # assert (
-        # x.memory_config().shard_spec.num_cores()
-        # == self.max_pool.max_pool.input_sharded_memory_config.shard_spec.num_cores()
-        # and x.memory_config().shard_spec.shape[0]
-        # == self.max_pool.max_pool.input_sharded_memory_config.shard_spec.shape[0]
-        # ), "Expected same input shard to match max pool's shard configuration"
         x = ttnn.max_pool2d_new(
             input_tensor=x,
             batch_size=self.pool.batch_size,
@@ -228,13 +223,12 @@ class UNetDownblock:
         pool,
         device,
         conv_cache={},
-        max_pool_cache={},
         should_reshard=False,
         mesh_mapper=None,
     ):
         self.conv1 = UNetConv2D(conv1, bn=bn1, device=device, cache=conv_cache, mesh_mapper=mesh_mapper)
         self.conv2 = UNetConv2D(conv2, bn=bn2, device=device, cache=conv_cache, mesh_mapper=mesh_mapper)
-        self.pool1 = UNetMaxPool2D(pool, conv2.out_channels, device=device, reader_patterns_cache=max_pool_cache)
+        self.pool1 = UNetMaxPool2D(pool, conv2.out_channels, device=device)
 
         self.should_reshard = should_reshard
         if self.should_reshard:
@@ -273,9 +267,7 @@ class UNetDownblock:
             )
         x = self.conv1(x)
         x = self.conv2(x)
-        residual = ttnn.sharded_to_interleaved(
-            x, memory_config=ttnn.DRAM_MEMORY_CONFIG, output_dtype=ttnn.bfloat16
-        )  # pool deletes its activation - spill to DRAM
+        residual = x
         x = self.pool1(x)
         return x, residual
 
@@ -317,7 +309,19 @@ class UNetUpblock:
         x = ttnn.reshape(
             x, (self.conv1.batch_size, self.conv1.input_height // 2, self.conv1.input_width // 2, x.shape[-1])
         )
-        x = ttnn.upsample(x, (2, 2, 1))
+
+        nhw = x.shape[0] * x.shape[1] * x.shape[2]
+        num_cores = determine_num_cores_for_upsample(nhw, x.shape[2])
+        core_grid = get_core_grid_from_num_cores(num_cores)
+        shardspec = ttnn.create_sharded_memory_config_(
+            x.shape, core_grid, ttnn.ShardStrategy.HEIGHT, orientation=ttnn.ShardOrientation.ROW_MAJOR
+        )
+        if x.is_sharded():
+            x = ttnn.reshard(x, shardspec)
+        else:
+            x = ttnn.interleaved_to_sharded(x, shardspec)
+
+        x = ttnn.upsample(x, (2, 2, 1), memory_config=x.memory_config())
         x = ttnn.reshape(
             x, (1, 1, self.conv1.batch_size * self.conv1.input_height * self.conv1.input_width, x.shape[-1])
         )
@@ -327,32 +331,31 @@ class UNetUpblock:
         assert list(x.shape)[:2] == [
             1,
             1,
-        ], f"Expected downblock input to flattened into [1, 1, BHW, C] but was {list(x.shape)}"
+        ], f"Expected upblock input to flattened into [1, 1, BHW, C] but was {list(x.shape)}"
 
+        residual = ttnn.to_layout(residual, ttnn.ROW_MAJOR_LAYOUT)
         x = ttnn.to_layout(x, layout=ttnn.ROW_MAJOR_LAYOUT)
-        x = ttnn.to_memory_config(x, memory_config=ttnn.DRAM_MEMORY_CONFIG)
 
         x = self.upsample(x)
 
-        residual = ttnn.to_layout(residual, ttnn.ROW_MAJOR_LAYOUT)
-        x = unet_concat([x, residual], dim=-1, perf_mode=True)
+        y = unet_concat([x, residual], dim=-1)
+        ttnn.deallocate(x)
         ttnn.deallocate(residual)
 
         if self.should_reshard:
-            x = ttnn.to_memory_config(x, self.sharded_memory_config)
+            y = ttnn.to_memory_config(y, self.sharded_memory_config)
 
-        x = self.conv1(x)
-        x = self.conv2(x)
-        x = self.conv3(x)
+        y = self.conv1(y)
+        y = self.conv2(y)
+        y = self.conv3(y)
 
-        return x
+        return y
 
 
 class UNet:
     def __init__(self, parameters: ParameterDict, device, mesh_mapper=None) -> None:
         self.device = device
         self.conv_cache = {}
-        self.max_pool_cache = {}
         self.downblock1 = UNetDownblock(
             parameters.c1,
             parameters.b1,
@@ -361,7 +364,6 @@ class UNet:
             parameters.p1,
             device,
             conv_cache=self.conv_cache,
-            max_pool_cache=self.max_pool_cache,
             should_reshard=True,
             mesh_mapper=mesh_mapper,
         )
@@ -373,7 +375,6 @@ class UNet:
             parameters.p2,
             device,
             conv_cache=self.conv_cache,
-            max_pool_cache=self.max_pool_cache,
             should_reshard=True,
             mesh_mapper=mesh_mapper,
         )
@@ -385,7 +386,6 @@ class UNet:
             parameters.p3,
             device,
             conv_cache=self.conv_cache,
-            max_pool_cache=self.max_pool_cache,
             should_reshard=True,
             mesh_mapper=mesh_mapper,
         )
@@ -397,7 +397,6 @@ class UNet:
             parameters.p4,
             device,
             conv_cache=self.conv_cache,
-            max_pool_cache=self.max_pool_cache,
             should_reshard=True,
             mesh_mapper=mesh_mapper,
         )
@@ -505,9 +504,13 @@ class UNet:
         x = self.bottleneck(x)
 
         x = self.upblock1(x, c4_residual)
+        ttnn.deallocate(c4_residual)
         x = self.upblock2(x, c3_residual)
+        ttnn.deallocate(c3_residual)
         x = self.upblock3(x, c2_residual)
+        ttnn.deallocate(c2_residual)
         x = self.upblock4(x, c1_residual)
+        ttnn.deallocate(c1_residual)
 
         x = self.output_layer(x)
 

--- a/tests/nightly/wh_b0_only_eth/experimental/functional_unet/tests/test_unet_multi_device.py
+++ b/tests/nightly/wh_b0_only_eth/experimental/functional_unet/tests/test_unet_multi_device.py
@@ -1,0 +1,1 @@
+../../../../../../models/experimental/functional_unet/tests/test_unet_multi_device.py

--- a/tests/scripts/run_performance.sh
+++ b/tests/scripts/run_performance.sh
@@ -53,6 +53,7 @@ run_perf_models_cnn_javelin() {
     local test_marker=$2
 
     # Run tests
+    env WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml pytest models/experimental/functional_unet/tests/test_unet_perf.py -m $test_marker
     env WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml pytest -n auto tests/device_perf_tests/stable_diffusion -m $test_marker --timeout=480
 
     ## Merge all the generated reports
@@ -83,6 +84,8 @@ run_device_perf_models() {
 
     if [ "$tt_arch" == "wormhole_b0" ]; then
         env WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml pytest models/demos/ttnn_resnet/tests -m $test_marker
+
+        env WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml pytest models/experimental/functional_unet/tests/test_unet_perf.py -m $test_marker
 
         env WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml pytest models/demos/wormhole/mamba/tests -m $test_marker
 


### PR DESCRIPTION
### Ticket
Addresses all of the following:
- #12196
- #12195

### What's changed
- Enable split reader and activation double buffering on some convolutions
- Fuse output layer bias with `matmul`
- Use `ttnn.reshard` instead of `ttnn.sharded_to_interleaved` + `ttnn.interleaved_to_sharded` in bottleneck layer
- Device performance is now 440 fps (including initial input sharding)
- Adds device and end-to-end performance tests to CI

### Checklist
- [ ] Post commit CI passes
- [ ] Model regression CI testing passes (if applicable)
