### PR TITLE
#12275: Always build the container for every push

### DIFF
--- a/.github/actions/docker-run/action.yml
+++ b/.github/actions/docker-run/action.yml
@@ -34,11 +34,11 @@ runs:
     - name: Determine Docker Tag to use
       shell: bash
       run: |
-        # if [[ "${GITHUB_REF_NAME}" == "main" ]]; then
-        echo "IMAGE_TAG=latest" >> $GITHUB_ENV
-        # else
-        #   echo "IMAGE_TAG=dev-${GITHUB_REF_NAME//\//-}" >> $GITHUB_ENV
-        # fi
+        if [[ "${GITHUB_REF_NAME}" == "main" ]]; then
+          echo "IMAGE_TAG=latest" >> $GITHUB_ENV
+        else
+          echo "IMAGE_TAG=dev-${GITHUB_REF_NAME//\//-}" >> $GITHUB_ENV
+        fi
     - name: Docker login
       uses: docker/login-action@v3
       with:

--- a/.github/workflows/build-docker-artifact.yaml
+++ b/.github/workflows/build-docker-artifact.yaml
@@ -3,14 +3,6 @@ name: "Build tt-metal docker artifact"
 on:
   workflow_dispatch:
   push:
-    branches:
-      - main
-    paths:
-      - dockerfile/ubuntu-20.04-amd64.Dockerfile
-      - scripts/docker/requirements*
-      - pyproject.toml
-      - scripts/docker/install_test_deps.sh
-      - tt_metal/python_env/requirements-dev.txt
 jobs:
   build-docker-image:
     env:


### PR DESCRIPTION
### Ticket
#12275 

### Problem description

When the PR #12165 was merged, there was a bug where feature branches that did not modify the Docker container still tried to look up the branch-specific container. However, the branch-specific container would only be built upon the changes to the `Dockerfile` or `requirements.txt` files. 

### What's changed

This PR changes the process to always build Docker container on every push. This will fix the problem of the jobs in specific branches looking for the branch-specific containers.

The speed of Docker build job that does not modify anything is 38 seconds - https://github.com/tenstorrent/tt-metal/actions/runs/10722267013

The disk-size requirements should not be changing since all the layers of the Docker images should already be present.

We should monitor the usability of applying so many labels to the same image since most branches make no Docker-related changes.

### Alternative Approach

In order to avoid building a container for every branch, we can check if any of the relevant to Docker environment files have changed between the feature branch and the main branch using the technique described here  - https://stackoverflow.com/a/77153325

If we identify a change, we can construct the image tag to the branch-specific image.

### Checklist
- [ ] Post commit CI passes
- [ ] Blackhole Post commit (if applicable)
- [ ] Model regression CI testing passes (if applicable)
- [ ] New/Existing tests provide coverage for changes
