### PR TITLE
#0: Further optimize EDM handshake

### DIFF
--- a/ttnn/cpp/ttnn/operations/ccl/ccl_host_datastructures.hpp
+++ b/ttnn/cpp/ttnn/operations/ccl/ccl_host_datastructures.hpp
@@ -258,21 +258,21 @@ class EriscDatamoverBuilder {
 
         bool senders_below_receivers = active_channels.size() == 0 || this->active_channels.front().is_sender;
 
-        // Sender channel args
-        uint32_t sender_channels_offset = senders_below_receivers ? 0 : this->num_receivers;
-        args.push_back(sender_channels_offset);
-        for (auto const& channel : this->active_channels) {
-            if (!channel.is_sender) {
-                continue;
-            }
-            push_back_channel_args(args, channel);
-        }
-
         // Receiver channel args
         uint32_t receiver_channels_offset = senders_below_receivers ? this->num_senders : 0;
         args.push_back(receiver_channels_offset);
         for (auto const& channel : this->active_channels) {
             if (channel.is_sender) {
+                continue;
+            }
+            push_back_channel_args(args, channel);
+        }
+
+        // Sender channel args
+        uint32_t sender_channels_offset = senders_below_receivers ? 0 : this->num_receivers;
+        args.push_back(sender_channels_offset);
+        for (auto const& channel : this->active_channels) {
+            if (!channel.is_sender) {
                 continue;
             }
             push_back_channel_args(args, channel);

--- a/ttnn/cpp/ttnn/operations/ccl/kernels/edm/erisc_async_datamover.hpp
+++ b/ttnn/cpp/ttnn/operations/ccl/kernels/edm/erisc_async_datamover.hpp
@@ -439,6 +439,14 @@ FORCE_INLINE void receiver_side_start(std::uint32_t handshake_register_address) 
 }
 
 /*
+ * Return: true if slave EDM handshake core is able to complete the handshake with
+ * an ack.
+ */
+FORCE_INLINE bool receiver_side_can_finish() {
+    return eth_bytes_are_available_on_channel(0);
+}
+
+/*
  * As the designated slave EDM core, send the acknowledgement to the master EDM core.
  * The slave EDM core shall only acknowledge after receiving the initial handshake packet
  * from the master EDM core.

--- a/ttnn/cpp/ttnn/operations/ccl/kernels/edm/erisc_datamover.cpp
+++ b/ttnn/cpp/ttnn/operations/ccl/kernels/edm/erisc_datamover.cpp
@@ -151,39 +151,6 @@ void kernel_main() {
         erisc::datamover::handshake::receiver_side_start(handshake_addr);
     }
 
-    uint8_t const sender_channels_start = get_arg_val<uint32_t>(args_offset++);
-    uint32_t const sender_num_channels = num_senders;//get_arg_val<uint32_t>(args_offset++);
-    uint8_t num_senders_with_no_work = 0;
-    for (uint32_t channel = 0; channel < sender_num_channels; channel++) {
-        uint32_t const sender_buffer_address = get_arg_val<uint32_t>(args_offset++);
-        uint32_t const sender_num_messages_to_send = get_arg_val<uint32_t>(args_offset++);
-        // Each channel buffer is at buffer_base + (channel_id * sender_channel_size)
-        // Each channel currently constrained to the same buffer size
-        uint32_t const sender_channel_size = get_arg_val<uint32_t>(args_offset++);
-        // The erisc's local l1 copy of the semaphore workers remotely increment
-        uint32_t const sender_semaphores_base_address = get_arg_val<uint32_t>(args_offset++);
-        // worker's semaphore L1 address
-        const uint32_t worker_semaphore_address = get_semaphore(get_arg_val<uint32_t>(args_offset++));
-        const uint32_t sender_num_workers = get_arg_val<uint32_t>(args_offset++);
-        const uint32_t workers_xy_list_addr = get_arg_addr(args_offset);
-        args_offset += sender_num_workers;
-        new (&buffer_channels[sender_channels_start + channel]) ChannelBufferT(
-            sender_channels_start + channel,
-            sender_buffer_address,
-            sender_channel_size,
-            worker_semaphore_address,
-            sender_num_workers,
-            sender_num_messages_to_send,
-            (volatile tt_l1_ptr uint32_t *const)sender_semaphores_base_address,
-            (const WorkerXY *)workers_xy_list_addr,
-            true);
-        if constexpr (terminate_on_worker_signal == EriscDataMoverTerminationMode::MESSAGE_COUNT_REACHED) {
-            if (sender_num_messages_to_send == 0) {
-                num_senders_with_no_work++;
-            }
-        }
-    }
-
     // Receiver args
     uint8_t const receiver_channels_start = get_arg_val<uint32_t>(args_offset++);
     uint32_t const receiver_num_channels = num_receivers;//get_arg_val<uint32_t>(args_offset++);
@@ -217,11 +184,54 @@ void kernel_main() {
         }
     }
 
+    if (!is_handshake_sender) {
+        if (!is_done_as_rx_handshaker && erisc::datamover::handshake::receiver_side_can_finish()) {
+            is_done_as_rx_handshaker = true;
+            erisc::datamover::handshake::receiver_side_finish(handshake_addr);
+        }
+    }
+
+
+    uint8_t const sender_channels_start = get_arg_val<uint32_t>(args_offset++);
+    uint32_t const sender_num_channels = num_senders;//get_arg_val<uint32_t>(args_offset++);
+    uint8_t num_senders_with_no_work = 0;
+    for (uint32_t channel = 0; channel < sender_num_channels; channel++) {
+        uint32_t const sender_buffer_address = get_arg_val<uint32_t>(args_offset++);
+        uint32_t const sender_num_messages_to_send = get_arg_val<uint32_t>(args_offset++);
+        // Each channel buffer is at buffer_base + (channel_id * sender_channel_size)
+        // Each channel currently constrained to the same buffer size
+        uint32_t const sender_channel_size = get_arg_val<uint32_t>(args_offset++);
+        // The erisc's local l1 copy of the semaphore workers remotely increment
+        uint32_t const sender_semaphores_base_address = get_arg_val<uint32_t>(args_offset++);
+        // worker's semaphore L1 address
+        const uint32_t worker_semaphore_address = get_semaphore(get_arg_val<uint32_t>(args_offset++));
+        const uint32_t sender_num_workers = get_arg_val<uint32_t>(args_offset++);
+        const uint32_t workers_xy_list_addr = get_arg_addr(args_offset);
+        args_offset += sender_num_workers;
+        new (&buffer_channels[sender_channels_start + channel]) ChannelBufferT(
+            sender_channels_start + channel,
+            sender_buffer_address,
+            sender_channel_size,
+            worker_semaphore_address,
+            sender_num_workers,
+            sender_num_messages_to_send,
+            (volatile tt_l1_ptr uint32_t *const)sender_semaphores_base_address,
+            (const WorkerXY *)workers_xy_list_addr,
+            true);
+        if constexpr (terminate_on_worker_signal == EriscDataMoverTerminationMode::MESSAGE_COUNT_REACHED) {
+            if (sender_num_messages_to_send == 0) {
+                num_senders_with_no_work++;
+            }
+        }
+    }
+
     if constexpr (is_handshake_sender) {
         erisc::datamover::handshake::sender_side_finish(handshake_addr);
     } else {
-        erisc::datamover::handshake::receiver_side_finish(handshake_addr);
-        is_done_as_rx_handshaker = true;
+        if (!is_done_as_rx_handshaker) {
+            erisc::datamover::handshake::receiver_side_finish(handshake_addr);
+            is_done_as_rx_handshaker = true;
+        }
     }
     uint32_t eth_transaction_ack_word_addr = handshake_addr + 16;
     uint32_t eth_transaction_complete_addr = handshake_addr + 32;


### PR DESCRIPTION
### Ticket
[#12103](https://github.com/tenstorrent/tt-metal/issues/12103)

### Problem description
Improve performance of CCLs. EDM handshake has room for improvement

### What's changed
- Swap receiver and sender channel arg order so EDM handshake slave can send handshake response earlier
- Also allow for slave handshaking EDM core to send ack after receiver channels are initialized

Net improvements are as follows:
- In best case, cycle count reduction of of 2-3k cycles
- All-gather maximum times similarly long but minimum times are noticeably faster

### Checklist
- [x] Post commit CI passes: https://github.com/tenstorrent/tt-metal/actions/runs/10729948830
- [x] t3000 nightly: https://github.com/tenstorrent/tt-metal/actions/runs/10729949513
- [x] t3000 model perf: https://github.com/tenstorrent/tt-metal/actions/runs/10729950537
  - same failure on main
- [x] t3000 frequent: https://github.com/tenstorrent/tt-metal/actions/runs/10729951461
  - same failure on main
- [x] Blackhole Post commit (if applicable)
- [x] Model regression CI testing passes (if applicable)
- [x] New/Existing tests provide coverage for changes
