### PR TITLE
LLama selfout specific optimizations for fused all_gather_matmul op

### DIFF
--- a/tests/ttnn/unit_tests/operations/test_all_gather_matmul.py
+++ b/tests/ttnn/unit_tests/operations/test_all_gather_matmul.py
@@ -133,7 +133,7 @@ def run_all_gather_matmul_on_t3000_impl(
             )
             return tt_all_gather_out_tensor, tt_matmul_out_tensor, None
         else:
-            return ttl.all_gather_matmul(
+            return ttnn.experimental.all_gather_matmul(
                 input_tensor_mesh,
                 weight_tt,
                 dim,
@@ -191,8 +191,8 @@ def run_all_gather_matmul_on_t3000_impl(
     if USE_DATACOPY:
         print("Checking outputs for All Gather Matmul (Datacopy)")
         for i, t in enumerate(ttnn.get_device_tensors(tt_datacopy_out_tensor)):
-            tt_output_tensor = t.cpu().to(ttl.tensor.Layout.ROW_MAJOR).to_torch()
-            if ag_input_dtype == ttl.tensor.DataType.BFLOAT16:
+            tt_output_tensor = t.cpu().to(ttnn.experimental.tensor.Layout.ROW_MAJOR).to_torch()
+            if ag_input_dtype == ttnn.experimental.tensor.DataType.BFLOAT16:
                 eq, output = comp_equal(tt_output_tensor, input_tensor)
             else:
                 eq, output = comp_pcc(tt_output_tensor, input_tensor)

--- a/tests/ttnn/unit_tests/operations/test_all_gather_matmul.py
+++ b/tests/ttnn/unit_tests/operations/test_all_gather_matmul.py
@@ -161,6 +161,10 @@ def run_all_gather_matmul_on_t3000_impl(
         # Execute trace
         ttnn.execute_trace(t3k_mesh_device, trace_id, cq_id=0, blocking=False)
         logger.info(f"Done executing trace")
+
+        # Synchronize the devices
+        for d in devices:
+            ttnn.synchronize_device(d)
     else:
         for i in range(num_iters):
             tt_all_gather_out_tensor, tt_matmul_out_tensor, tt_datacopy_out_tensor = run_op()

--- a/ttnn/cpp/ttnn/operations/ccl/all_gather/device/kernels/dataflow/worker_interleaved_ring_gather_receive_writer.cpp
+++ b/ttnn/cpp/ttnn/operations/ccl/all_gather/device/kernels/dataflow/worker_interleaved_ring_gather_receive_writer.cpp
@@ -166,6 +166,11 @@ void kernel_main() {
             pop_filler_pages_from_cb(cb_id_in0, half_cb_n_pages - rem_num_pages);
         }
 
+        // Synchronize if all gather fusion is enabled
+        if constexpr(fuse_op) {
+            op_signaler.synchronize_workers_and_signal_op(input_ring_idx);
+        }
+
         if (is_clockwise_direction) {
             if (input_ring_idx == 0) {
                 input_ring_idx = ring_size - 1;
@@ -203,11 +208,6 @@ void kernel_main() {
                 }
             }
 
-        }
-
-        // Synchronize if all gather fusion is enabled
-        if constexpr(fuse_op) {
-            op_signaler.synchronize_workers_and_signal_op();
         }
 
         output_page_idx = output_base_page_idx;

--- a/ttnn/cpp/ttnn/operations/ccl/all_gather/device/kernels/dataflow/worker_interleaved_ring_gather_send_writer.cpp
+++ b/ttnn/cpp/ttnn/operations/ccl/all_gather/device/kernels/dataflow/worker_interleaved_ring_gather_send_writer.cpp
@@ -150,7 +150,7 @@ void kernel_main() {
 
     if (fuse_op) {
         // Synchronize and signal that the local tensor slice is available
-        op_signaler.synchronize_workers_and_signal_op();
+        op_signaler.synchronize_workers_and_signal_op(input_start_ring_idx);
     }
 
     // num_transfers = num_devices - 1

--- a/ttnn/cpp/ttnn/operations/ccl/all_gather/device/multi_core/all_gather_op_multi_core.cpp
+++ b/ttnn/cpp/ttnn/operations/ccl/all_gather/device/multi_core/all_gather_op_multi_core.cpp
@@ -907,11 +907,7 @@ operation::ProgramWithCallbacks all_gather_multi_core_with_workers_helper(
                                 worker_writer_sender_rt_args,
                                 global_num_workers_per_direction,
                                 b,
-                                is_clockwise_direction ? 0 : 1,
-                                std::make_optional<experimental::ccl::CoreSemPair>(
-                                    {fused_op_signaler->all_gather_worker_cores_noc[0],
-                                    fused_op_signaler->all_gather_worker_sync_semaphore}
-                                )
+                                is_clockwise_direction ? 0 : 1
                             );
                         }
 

--- a/ttnn/cpp/ttnn/operations/ccl/ccl_op_fusion.cpp
+++ b/ttnn/cpp/ttnn/operations/ccl/ccl_op_fusion.cpp
@@ -13,12 +13,12 @@ namespace ccl {
 void AllGatherFusedOpSignaler::init_fused_op(
     const std::vector<CoreCoord>& fused_op_receiver_cores_noc,
     const std::vector<uint32_t>& fused_op_receiver_signal_semaphores,
-    bool mcast_fused_op_cores
+    FusedOpSignalerMode fused_op_signaler_mode
 ) {
     this->fused_op_receiver_cores_noc = fused_op_receiver_cores_noc;
     this->fused_op_receiver_signal_semaphores = fused_op_receiver_signal_semaphores;
     this->num_fused_op_cores_to_signal = fused_op_receiver_cores_noc.size();
-    this->mcast_fused_op_cores = mcast_fused_op_cores;
+    this->fused_op_signaler_mode = fused_op_signaler_mode;
 
     initialized_fused_op = true;
 }
@@ -74,7 +74,7 @@ void AllGatherFusedOpSignaler::push_all_gather_fused_op_rt_args(
         static_cast<uint32_t>(this->fused_op_receiver_signal_semaphores[all_gather_direction])
     );
 
-    out_rt_args.push_back(static_cast<uint32_t>(this->mcast_fused_op_cores));
+    out_rt_args.push_back(static_cast<uint32_t>(this->fused_op_signaler_mode == FusedOpSignalerMode::SINGLE ? 0 : 1));
 }
 
 
@@ -105,9 +105,9 @@ void MatmulFusedOpSignaler::init_fused_op(
     Program& program,
     Device const* device,
     const std::variant<CoreRange, CoreRangeSet>& core_range_to_signal,
-    bool mcast_fused_op_cores
+    FusedOpSignalerMode fused_op_signaler_mode
 ) {
-    this->mcast_fused_op_cores = mcast_fused_op_cores;
+    this->fused_op_signaler_mode = fused_op_signaler_mode;
 
     // Clear the existing receiver cores
     this->fused_op_receiver_cores_noc.clear();

--- a/ttnn/cpp/ttnn/operations/ccl/ccl_op_fusion.hpp
+++ b/ttnn/cpp/ttnn/operations/ccl/ccl_op_fusion.hpp
@@ -23,7 +23,7 @@ struct AllGatherFusedOpSignaler {
     uint32_t num_fused_op_cores_to_signal;
     std::vector<CoreCoord> fused_op_receiver_cores_noc;
     std::vector<uint32_t> fused_op_receiver_signal_semaphores;
-    bool mcast_fused_op_cores;
+    bool mcast_fused_op_cores = true;
 
     /* All Gather specific */
     std::vector<CoreCoord> all_gather_worker_cores_noc;
@@ -37,7 +37,7 @@ struct AllGatherFusedOpSignaler {
     void init_fused_op(
         const std::vector<CoreCoord>& fused_op_receiver_cores_noc,
         const std::vector<uint32_t>& fused_op_receiver_signal_semaphores,
-        bool mcast_fused_op_cores = true
+        const bool mcast_fused_op_cores = true
     );
 
     void init_all_gather(
@@ -63,7 +63,7 @@ struct MatmulFusedOpSignaler {
     uint32_t num_fused_op_cores_to_signal;
     std::vector<CoreCoord> fused_op_receiver_cores_noc;
     std::vector<uint32_t> fused_op_receiver_signal_semaphores; // [dir0, dir1]
-    bool mcast_fused_op_cores;
+    bool mcast_fused_op_cores = true;
 
     /* All Gather specs */
     uint32_t num_transfers;

--- a/ttnn/cpp/ttnn/operations/ccl/ccl_op_fusion.hpp
+++ b/ttnn/cpp/ttnn/operations/ccl/ccl_op_fusion.hpp
@@ -29,14 +29,14 @@ enum class FusedOpSignalerMode {
 };
 
 struct AllGatherFusedOpSignaler {
-    uint32_t num_fused_op_cores_to_signal;
-    std::vector<CoreCoord> fused_op_receiver_cores_noc;
-    std::vector<uint32_t> fused_op_receiver_signal_semaphores;
+    uint32_t num_fused_op_cores_to_signal = 0;
+    std::vector<CoreCoord> fused_op_receiver_cores_noc = {};
+    std::vector<uint32_t> fused_op_receiver_signal_semaphores = {};
     FusedOpSignalerMode fused_op_signaler_mode = FusedOpSignalerMode::MULTI;
 
     /* All Gather specific */
-    std::vector<CoreCoord> all_gather_worker_cores_noc;
-    uint32_t all_gather_worker_sync_semaphore;
+    std::vector<CoreCoord> all_gather_worker_cores_noc = {};
+    uint32_t all_gather_worker_sync_semaphore = 0;
 
     bool initialized_fused_op = false;
     bool initialized_all_gather = false;
@@ -69,21 +69,21 @@ struct AllGatherFusedOpSignaler {
 
 // Used to propagate semaphore information from matmul to all_gather in all_gather_matmul op
 struct MatmulFusedOpSignaler {
-    uint32_t num_fused_op_cores_to_signal;
-    std::vector<CoreCoord> fused_op_receiver_cores_noc;
-    std::vector<uint32_t> fused_op_receiver_signal_semaphores; // [dir0, dir1]
+    uint32_t num_fused_op_cores_to_signal = 0;
+    std::vector<CoreCoord> fused_op_receiver_cores_noc = {};
+    std::vector<uint32_t> fused_op_receiver_signal_semaphores = {}; // [dir0, dir1]
     FusedOpSignalerMode fused_op_signaler_mode = FusedOpSignalerMode::MULTI;
 
     /* All Gather specs */
-    uint32_t num_transfers;
-    uint32_t ring_size;
-    uint32_t start_ring_index;
-    uint32_t tensor_slice_shape_width;
-    uint32_t output_page_offset;
-    uint32_t last_output_page_offset;
-    bool is_clockwise_dir;
+    uint32_t num_transfers = 0;
+    uint32_t ring_size = 0;
+    uint32_t start_ring_index = 0;
+    uint32_t tensor_slice_shape_width = 0;
+    uint32_t output_page_offset = 0;
+    uint32_t last_output_page_offset = 0;
+    bool is_clockwise_dir = true;
 
-    uint32_t weight_output_page_offset;
+    uint32_t weight_output_page_offset = 0;
 
     bool initialized_all_gather = false;
     bool initialized_fused_op = false;

--- a/ttnn/cpp/ttnn/operations/ccl/ccl_op_fusion.hpp
+++ b/ttnn/cpp/ttnn/operations/ccl/ccl_op_fusion.hpp
@@ -23,6 +23,7 @@ struct AllGatherFusedOpSignaler {
     uint32_t num_fused_op_cores_to_signal;
     std::vector<CoreCoord> fused_op_receiver_cores_noc;
     std::vector<uint32_t> fused_op_receiver_signal_semaphores;
+    bool mcast_fused_op_cores;
 
     /* All Gather specific */
     std::vector<CoreCoord> all_gather_worker_cores_noc;
@@ -35,7 +36,8 @@ struct AllGatherFusedOpSignaler {
 
     void init_fused_op(
         const std::vector<CoreCoord>& fused_op_receiver_cores_noc,
-        const std::vector<uint32_t>& fused_op_receiver_signal_semaphores
+        const std::vector<uint32_t>& fused_op_receiver_signal_semaphores,
+        bool mcast_fused_op_cores = true
     );
 
     void init_all_gather(
@@ -51,8 +53,7 @@ struct AllGatherFusedOpSignaler {
 
         uint32_t num_workers_to_sync,
         uint32_t curr_worker_index,
-        uint32_t all_gather_direction,
-        std::optional<CoreSemPair> start_signal_core_sem_pair = {}
+        uint32_t all_gather_direction
     );
 
 };
@@ -62,6 +63,7 @@ struct MatmulFusedOpSignaler {
     uint32_t num_fused_op_cores_to_signal;
     std::vector<CoreCoord> fused_op_receiver_cores_noc;
     std::vector<uint32_t> fused_op_receiver_signal_semaphores; // [dir0, dir1]
+    bool mcast_fused_op_cores;
 
     /* All Gather specs */
     uint32_t num_transfers;
@@ -91,7 +93,8 @@ struct MatmulFusedOpSignaler {
     void init_fused_op(
         Program& program,
         Device const* device,
-        const std::variant<CoreRange, CoreRangeSet>& core_range_to_signal
+        const std::variant<CoreRange, CoreRangeSet>& core_range_to_signal,
+        bool mcast_fused_op_cores = true
     );
 
     void push_matmul_fused_op_rt_args(

--- a/ttnn/cpp/ttnn/operations/ccl/kernel_common/worker_sync_utils.hpp
+++ b/ttnn/cpp/ttnn/operations/ccl/kernel_common/worker_sync_utils.hpp
@@ -22,17 +22,22 @@ FORCE_INLINE void master_sync_slaves(
     const uint32_t num_fused_op_cores_to_signal,
     const uint32_t* fused_op_cores_noc_coords,
     const uint32_t fused_op_sem_addr,
+    const bool mcast_signal_op_cores,
 
-    bool wait_for_start_signal) {
-
+    uint32_t fused_op_core_idx) {
     // Wait for all the slaves to finish their work
     volatile tt_l1_ptr uint32_t* master_l1_semaphore_addr = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(worker_sync_sem_addr);
-    noc_semaphore_wait(master_l1_semaphore_addr,  num_workers_to_sync - 1 + (uint32_t)wait_for_start_signal);
+    noc_semaphore_wait(master_l1_semaphore_addr,  num_workers_to_sync - 1);
     // DPRINT << "MASTER SYNCED WITH SLAVES" << ENDL();
 
     // Send signal to op
-    for (uint32_t i = 0; i < num_fused_op_cores_to_signal; i++) {
-        uint64_t remote_fused_op_l1_semaphore_addr = get_noc_addr(fused_op_cores_noc_coords[i * 2], fused_op_cores_noc_coords[i * 2 + 1], fused_op_sem_addr);
+    if (mcast_signal_op_cores) {
+        for (uint32_t i = 0; i < num_fused_op_cores_to_signal; i++) {
+            uint64_t remote_fused_op_l1_semaphore_addr = get_noc_addr(fused_op_cores_noc_coords[i * 2], fused_op_cores_noc_coords[i * 2 + 1], fused_op_sem_addr);
+            noc_semaphore_inc(remote_fused_op_l1_semaphore_addr, 1);
+        }
+    } else {
+        uint64_t remote_fused_op_l1_semaphore_addr = get_noc_addr(fused_op_cores_noc_coords[fused_op_core_idx * 2], fused_op_cores_noc_coords[fused_op_core_idx * 2 + 1], fused_op_sem_addr);
         noc_semaphore_inc(remote_fused_op_l1_semaphore_addr, 1);
     }
     // DPRINT << "MASTER SIGNALED REMOTE OP" << ENDL();
@@ -88,13 +93,8 @@ struct OpSignaler {
     uint32_t num_fused_op_cores_to_signal;
     uint32_t* signal_op_cores_noc_coords;
     uint32_t signal_op_sem_addr;
+    bool mcast_signal_op_cores;
     uint32_t curr_worker_is_master;
-
-    // Params for start signal
-    bool wait_for_start_signal;
-    bool send_start_signal;
-    uint32_t* start_signal_receiver_core_noc;
-    uint32_t start_signal_receiver_sem_addr;
 
     bool initialized = false;
 
@@ -111,14 +111,7 @@ struct OpSignaler {
         this->num_fused_op_cores_to_signal = get_arg_val<uint32_t>(rt_args_idx++);
         this->signal_op_cores_noc_coords = (uint32_t*)get_arg_addr(increment_arg_idx(rt_args_idx, this->num_fused_op_cores_to_signal * 2));
         this->signal_op_sem_addr = get_semaphore(get_arg_val<uint32_t>(rt_args_idx++));
-
-
-        this->wait_for_start_signal = get_arg_val<uint32_t>(rt_args_idx++);
-        this->send_start_signal = get_arg_val<uint32_t>(rt_args_idx++);
-        if (this->send_start_signal) {
-            this->start_signal_receiver_core_noc = (uint32_t*)get_arg_addr(increment_arg_idx(rt_args_idx, 2));
-            this->start_signal_receiver_sem_addr = get_semaphore(get_arg_val<uint32_t>(rt_args_idx++));
-        }
+        this->mcast_signal_op_cores = get_arg_val<uint32_t>(rt_args_idx++) == 1;
 
         uint32_t master_worker_noc_x = this->workers_noc_coords[0];
         uint32_t master_worker_noc_y = this->workers_noc_coords[1];
@@ -129,7 +122,7 @@ struct OpSignaler {
         this->initialized = true;
     }
 
-    void synchronize_workers_and_signal_op() {
+    void synchronize_workers_and_signal_op(uint32_t fused_op_core_idx) {
         ASSERT(this->initialized);
 
         if (this->curr_worker_is_master) {
@@ -141,24 +134,10 @@ struct OpSignaler {
                 this->num_fused_op_cores_to_signal,
                 this->signal_op_cores_noc_coords,
                 this->signal_op_sem_addr,
+                this->mcast_signal_op_cores,
 
-                this->wait_for_start_signal
+                fused_op_core_idx
             );
-
-            // Once start signal is received, no need to wait for it again
-            this->wait_for_start_signal = false;
-
-            if (this->send_start_signal) {
-                uint64_t remote_master_l1_semaphore_addr = get_noc_addr(
-                    this->start_signal_receiver_core_noc[0],
-                    this->start_signal_receiver_core_noc[1],
-                    this->start_signal_receiver_sem_addr
-                );
-                noc_semaphore_inc(remote_master_l1_semaphore_addr, 1);
-
-                // Once start signal is sent, no need to send it again
-                this->send_start_signal = false;
-            }
         } else {
             slave_sync_master(this->workers_noc_coords, this->worker_sync_sem_addr);
         }
@@ -342,7 +321,7 @@ struct MatmulOpReceiver {
             // Wait for a sempaphore signal to start processing the tensor slice
             if (this->wait_for_op_signal && block_id == sender_id) {
                 uint32_t tensor_slice_cnt = (this->curr_transfer_idx) / this->num_directions;
-                noc_semaphore_wait_min(this->signal_op_semaphore_addr_ptrs[this->curr_dir], tensor_slice_cnt + 1);
+                noc_semaphore_wait_min(this->signal_op_semaphore_addr_ptrs[this->curr_dir], 1);
             }
 
             this->curr_transfer_idx++;

--- a/ttnn/cpp/ttnn/operations/ccl/kernel_common/worker_sync_utils.hpp
+++ b/ttnn/cpp/ttnn/operations/ccl/kernel_common/worker_sync_utils.hpp
@@ -86,15 +86,15 @@ uint32_t increment_arg_idx(uint32_t& arg_idx, uint32_t num_args=1) {
 
 // Used to signal an operation that it can start processing data, resulting in overlapping
 struct OpSignaler {
-    uint32_t num_workers_to_sync;
-    uint32_t* workers_noc_coords; // Worker NOC coordinates [x1, y1, x2, y2...], first one is for master
-    uint32_t worker_sync_sem_addr;
+    uint32_t num_workers_to_sync = 0;
+    uint32_t* workers_noc_coords = nullptr; // Worker NOC coordinates [x1, y1, x2, y2...], first one is for master
+    uint32_t worker_sync_sem_addr = 0;
 
-    uint32_t num_fused_op_cores_to_signal;
-    uint32_t* signal_op_cores_noc_coords;
-    uint32_t signal_op_sem_addr;
-    bool mcast_signal_op_cores;
-    uint32_t curr_worker_is_master;
+    uint32_t num_fused_op_cores_to_signal = 0;
+    uint32_t* signal_op_cores_noc_coords = nullptr;
+    uint32_t signal_op_sem_addr = 0;
+    bool mcast_signal_op_cores = true;
+    uint32_t curr_worker_is_master = 0;
 
     bool initialized = false;
 
@@ -180,25 +180,25 @@ FORCE_INLINE void advance_start_page_idx(
 
 struct MatmulOpReceiver {
     static constexpr uint32_t num_directions = 2; // ASSUMPTION: Always 2 directions
-    uint32_t num_tensor_slices;
+    uint32_t num_tensor_slices = 0;
 
-    bool wait_for_op_signal;
-    uint32_t num_transfers;
-    uint32_t ring_size;
-    uint32_t tensor_slice_shape_width; // In tiles
-    uint32_t output_page_offset;
-    uint32_t last_output_page_offset;
+    bool wait_for_op_signal = 0;
+    uint32_t num_transfers = 0;
+    uint32_t ring_size = 0;
+    uint32_t tensor_slice_shape_width = 0; // In tiles
+    uint32_t output_page_offset = 0;
+    uint32_t last_output_page_offset = 0;
 
-    uint32_t num_blocks;
-    uint32_t num_blocks_per_slice;
+    uint32_t num_blocks = 0;
+    uint32_t num_blocks_per_slice = 0;
 
     // Used to track internal state
-    std::array<uint32_t, num_directions> ring_idxs;
-    std::array<uint32_t, num_directions> start_page_idxs;
-    std::array<bool, num_directions> is_clockwise_dirs;
-    std::array<volatile tt_l1_ptr uint32_t*, num_directions> signal_op_semaphore_addr_ptrs;
-    uint32_t curr_dir;
-    uint32_t curr_transfer_idx;
+    std::array<uint32_t, num_directions> ring_idxs = {};
+    std::array<uint32_t, num_directions> start_page_idxs = {};
+    std::array<bool, num_directions> is_clockwise_dirs = {};
+    std::array<volatile tt_l1_ptr uint32_t*, num_directions> signal_op_semaphore_addr_ptrs = {};
+    uint32_t curr_dir = 0;
+    uint32_t curr_transfer_idx = 0;
 
 
     bool initialized = false;

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_matmul/device/multi_core/all_gather_matmul_op_multi_core.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_matmul/device/multi_core/all_gather_matmul_op_multi_core.cpp
@@ -324,7 +324,7 @@ operation::ProgramWithCallbacks experimental::all_gather_matmul_multi_core_with_
         all_gather_fused_op_signaler->init_fused_op(
             matmul_fused_op_signaler->fused_op_receiver_cores_noc,
             matmul_fused_op_signaler->fused_op_receiver_signal_semaphores,
-            matmul_fused_op_signaler->mcast_fused_op_cores
+            matmul_fused_op_signaler->fused_op_signaler_mode
         );
     }
 

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_matmul/device/multi_core/all_gather_matmul_op_multi_core.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_matmul/device/multi_core/all_gather_matmul_op_multi_core.cpp
@@ -323,7 +323,8 @@ operation::ProgramWithCallbacks experimental::all_gather_matmul_multi_core_with_
     } else {
         all_gather_fused_op_signaler->init_fused_op(
             matmul_fused_op_signaler->fused_op_receiver_cores_noc,
-            matmul_fused_op_signaler->fused_op_receiver_signal_semaphores
+            matmul_fused_op_signaler->fused_op_receiver_signal_semaphores,
+            matmul_fused_op_signaler->mcast_fused_op_cores
         );
     }
 

--- a/ttnn/cpp/ttnn/operations/matmul/device/matmul_op_multi_core_reuse_mcast_1d_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/matmul_op_multi_core_reuse_mcast_1d_program_factory.cpp
@@ -368,7 +368,7 @@ operation::ProgramWithCallbacks create_program_mcast_in0(
 
     if (fuse_op) {
         // Create semaphores
-        fused_op_signaler->init_fused_op(program, device, in0_mcast_cores_with_work_and_in_receiver_grid);
+        fused_op_signaler->init_fused_op(program, device, in0_mcast_sender_cores, in0_is_sharded == false /* mcast_fused_op_cores */);
     }
 
     auto mm_kernel_in0_mcast_cores_with_work_and_in_receiver_grid_id = tt_metal::CreateKernel(
@@ -639,10 +639,11 @@ operation::ProgramWithCallbacks create_program_mcast_in0(
             mm_in0_sender_args.insert(mm_in0_sender_args.end(), in0_mcast_noc_x.begin(), in0_mcast_noc_x.end());
             mm_in0_sender_args.insert(mm_in0_sender_args.end(), in0_mcast_noc_y.begin(), in0_mcast_noc_y.end());
 
+            if (fuse_op) {
+                fused_op_signaler->push_matmul_fused_op_rt_args(mm_in0_sender_args, false);
+            }
+
             if (i < num_cores_with_work) {
-                if (fuse_op) {
-                    fused_op_signaler->push_matmul_fused_op_rt_args(mm_in0_sender_args, false);
-                }
 
                 tt_metal::SetRuntimeArgs(
                     program,

--- a/ttnn/cpp/ttnn/operations/matmul/device/matmul_op_multi_core_reuse_mcast_1d_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/matmul_op_multi_core_reuse_mcast_1d_program_factory.cpp
@@ -368,7 +368,8 @@ operation::ProgramWithCallbacks create_program_mcast_in0(
 
     if (fuse_op) {
         // Create semaphores
-        fused_op_signaler->init_fused_op(program, device, in0_mcast_sender_cores, in0_is_sharded == false /* mcast_fused_op_cores */);
+        fused_op_signaler->init_fused_op(program, device, in0_mcast_sender_cores,
+            in0_is_sharded ? ttnn::experimental::ccl::FusedOpSignalerMode::SINGLE : ttnn::experimental::ccl::FusedOpSignalerMode::MULTI);
     }
 
     auto mm_kernel_in0_mcast_cores_with_work_and_in_receiver_grid_id = tt_metal::CreateKernel(


### PR DESCRIPTION
### Ticket
- #12103 
- #10415 

### Problem description
This PR adds optimizations for the fused all_gather_matmul op, specifically targeted towards llama selfout shapes where matmul1d is used with `in0_sharded=True` and `mcast_in0=True`.

As a result, the fused op for the llama selfout case has a device kernel runtime of ~56us (on device 3 from perf table).

### What's changed
Here are the optimizations that are integrated:
- Adding in a toggle called `fused_op_signaler_mode` which reduces the number of matmul cores that are being signaled by the all gather. For `fused_op_signaler_mode=FusedOpSignalerMode::MULTI`, the all gather would signal a group of matmul cores, to make sure that the matmul cores are synchronized when processing a tensor slice. However, due to `mcast_in0=True` in the llama selfout case, the matmul cores are already blocked by each other, ensuring that the cores are synchronized when processing a tensor slice. As such, all gather is only required to signal one matmul core (`fused_op_signaler_mode=FusedOpSignalerMode::SINGLE`) at a time. This reduces the number of `noc_semaphore_inc` from 32 to 1, every time all gather needs to signal the matmul.
  - **Note:** The current implementation is not general and works only for the case when the number of shards in in0 equal the number of devices (the op currently checks for this with a TT_FATAL). This is because it uses the tensor slice's current `ring_idx` to select which matmul core to signal to. For more info, see the comment [here](https://github.com/tenstorrent/tt-metal/pull/11760#discussion_r1737637586).

Before: 
<img width="962" alt="image" src="https://github.com/user-attachments/assets/d7931e77-6f2f-4916-a68e-b7e81158fb5c">

After:
![image](https://github.com/user-attachments/assets/b02fad39-0e1c-4213-826e-216df51d67b8)



- Removing synchronization signaling between sender worker in all gather (which handles the local tensor slice), and the first receiver worker in all gather (which handles the tensor slice right after the local tensor slice)
  - **Note:** Due to `mcast_fused_op_core =False` in the llama selfout case, this does not result in a race, because each core is only waiting on a single semaphore increment from a single source. However, for other scenarios (shapes, matmul configs), this optimizations should NOT be enabled, because the semaphore is reused, and a race would cause a mismatch in the order of the signal received.
  
- Using trace mode
- Changing `in0_block_w` from 8 to 32.
 

### Checklist
- [x] post-commit: https://github.com/tenstorrent/tt-metal/actions/runs/10800603239
- [x] t3k frequent: https://github.com/tenstorrent/tt-metal/actions/runs/10800612568
