### PR TITLE
#11401: Minor Supplementary Code Changes for Documentation

### DIFF
--- a/tech_reports/Programming Mesh of Devices/Programming Mesh of Devices with TT-NN.md
+++ b/tech_reports/Programming Mesh of Devices/Programming Mesh of Devices with TT-NN.md
@@ -366,7 +366,7 @@ torch_output = model.forward(torch_hidden_states)
 mesh_device = ttnn.open_device_mesh(ttnn.DeviceGrid(y=1, x=4))
 
 # Shard input activations on batch dimension to devices in the mesh
-with ttnn.distribute(mesh_mapper=ttnn.ShardTensorToMesh(mesh_device, dim=0)):
+with ttnn.distribute(ttnn.ShardTensorToMesh(mesh_device, dim=0)):
     hidden_states = ttnn.from_torch(
         torch_hidden_states,
         dtype=ttnn.bfloat16,
@@ -375,7 +375,7 @@ with ttnn.distribute(mesh_mapper=ttnn.ShardTensorToMesh(mesh_device, dim=0)):
     )
 
 # Replicate model parameters to devices in the mesh
-with ttnn.distribute(mesh_mapper=ttnn.ReplicateTensorToMesh(mesh_device)):
+with ttnn.distribute(ttnn.ReplicateTensorToMesh(mesh_device)):
     parameters = ttnn.model_preprocessing.preprocess_model_parameters(
         initialize_model=lambda: model,
         device=mesh_device,
@@ -385,6 +385,6 @@ with ttnn.distribute(mesh_mapper=ttnn.ReplicateTensorToMesh(mesh_device)):
 ttnn_model = TtFalconMLP(parameters)
 ttnn_output = ttnn_model(hidden_states)
 
-with ttnn.distribute(mesh_composer=ttnn.ConcatMeshToTensor(mesh_device, dim=0)):
+with ttnn.distribute(ttnn.ConcatMeshToTensor(mesh_device, dim=0)):
     assert_with_pcc(torch_output, ttnn.to_torch(ttnn_output), 0.98)
 ```

--- a/tests/scripts/tg/run_tg_frequent_tests.sh
+++ b/tests/scripts/tg/run_tg_frequent_tests.sh
@@ -4,6 +4,7 @@ run_tg_tests() {
   # Add tests here
   echo "LOG_METAL: running run_tg_frequent_tests"
 
+  pytest -n auto tests/ttnn/multichip_unit_tests/test_data_parallel_example.py --timeout=900 ; fail+=$?
   pytest -n auto tests/ttnn/multichip_unit_tests/test_multidevice_TG.py --timeout=900 ; fail+=$?
   pytest -n auto models/demos/tg/llama3_70b/tests/test_llama_mlp_galaxy.py --timeout=300 ; fail+=$?
   pytest -n auto models/demos/tg/llama3_70b/tests/test_llama_attention_galaxy.py --timeout=480 ; fail+=$?

--- a/tests/ttnn/multichip_unit_tests/test_data_parallel_example_TG.py
+++ b/tests/ttnn/multichip_unit_tests/test_data_parallel_example_TG.py
@@ -1,0 +1,61 @@
+# SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
+
+# SPDX-License-Identifier: Apache-2.0
+
+
+import ttnn
+import torch
+import transformers
+import pytest
+
+from tests.ttnn.utils_for_testing import assert_with_pcc
+from ttnn.model_preprocessing import preprocess_model_parameters
+
+
+class TtFalconMLP:
+    def __init__(self, parameters):
+        super().__init__()
+        self.dense_h_to_4h_weights = parameters.dense_h_to_4h.weight
+        self.dense_4h_to_h_weights = parameters.dense_4h_to_h.weight
+
+    def __call__(self, x: ttnn.Tensor) -> ttnn.Tensor:
+        ff1_linear: ttnn.Tensor = ttnn.linear(x, self.dense_h_to_4h_weights)
+        gelu = ttnn.gelu(ff1_linear)
+        ff2_linear: ttnn.Tensor = ttnn.linear(gelu, self.dense_4h_to_h_weights)
+
+        return ff2_linear
+
+
+@pytest.mark.parametrize("mesh_device", [pytest.param((1, 4), id="1x4_grid")], indirect=True)
+def test_data_parallel_falcon_mlp(mesh_device):
+    # Load Falcon MLP model from huggingface
+    config = transformers.FalconConfig.from_pretrained("tiiuae/falcon-7b-instruct")
+    model = transformers.models.falcon.modeling_falcon.FalconMLP(config).eval()
+
+    # Initialize hidden states
+    batch_size, sequence_length = 4, 128
+    torch_hidden_states = (torch.rand(batch_size, 1, sequence_length, config.hidden_size, dtype=torch.float32) * 2) - 1
+    torch_output = model.forward(torch_hidden_states)
+
+    # Shard input activations on batch dimension to devices in the mesh
+    with ttnn.distribute(ttnn.ShardTensorToMesh(mesh_device, dim=0)):
+        hidden_states = ttnn.from_torch(
+            torch_hidden_states,
+            dtype=ttnn.bfloat16,
+            layout=ttnn.TILE_LAYOUT,
+            device=mesh_device,
+        )
+
+    # Replicate model parameters to devices in the mesh
+    with ttnn.distribute(ttnn.ReplicateTensorToMesh(mesh_device)):
+        parameters = preprocess_model_parameters(
+            initialize_model=lambda: model,
+            device=mesh_device,
+        )
+
+    # Initialize Model
+    ttnn_model = TtFalconMLP(parameters)
+    ttnn_output = ttnn_model(hidden_states)
+
+    with ttnn.distribute(ttnn.ConcatMeshToTensor(mesh_device, dim=0)):
+        assert_with_pcc(torch_output, ttnn.to_torch(ttnn_output), 0.98)

--- a/tt_metal/impl/device/mesh_device.cpp
+++ b/tt_metal/impl/device/mesh_device.cpp
@@ -164,12 +164,23 @@ void MeshDevice::close_devices() {
     managed_devices.clear();
 }
 
+std::string MeshDevice::to_string() const {
+    return fmt::format("MeshDevice({}x{} grid, {} devices)",
+                       this->num_rows(),
+                       this->num_cols(),
+                       this->num_devices());
+}
+
 std::shared_ptr<const MeshDeviceView> MeshDevice::get_view() const {
     return this->view;
 }
 
 std::shared_ptr<MeshDeviceView> MeshDevice::get_view() {
     return this->view;
+}
+
+std::ostream& operator<<(std::ostream& os, const MeshDevice& mesh_device) {
+    return os << mesh_device.to_string();
 }
 
 bool validate_worker_modes(const std::vector<Device*>& workers) {

--- a/tt_metal/impl/device/mesh_device.hpp
+++ b/tt_metal/impl/device/mesh_device.hpp
@@ -57,10 +57,13 @@ public:
     std::shared_ptr<const MeshDeviceView> get_view() const;
     std::shared_ptr<MeshDeviceView> get_view();
 
+    std::string to_string() const;
+
    private:
     bool is_galaxy_;
 };
 
+std::ostream& operator<<(std::ostream& os, const MeshDevice& mesh_device);
 bool validate_worker_modes(const std::vector<Device*>& workers);
 
 } // namespace tt::tt_metal

--- a/ttnn/cpp/pybind11/multi_device.hpp
+++ b/ttnn/cpp/pybind11/multi_device.hpp
@@ -98,7 +98,8 @@ void py_module(py::module& module) {
 
             Returns:
                 Tuple[int, int]: The shape of the device mesh as (num_rows, num_cols).
-        )doc");
+        )doc")
+        .def("__repr__", &MeshDevice::to_string);
 
     module.def(
         "open_mesh_device",

--- a/ttnn/ttnn/__init__.py
+++ b/ttnn/ttnn/__init__.py
@@ -190,6 +190,7 @@ from ttnn.multi_device import (
     ListMeshToTensor,
     visualize_mesh_device,
     ConcatMesh2dToTensor,
+    distribute,
 )
 
 from ttnn.core import (


### PR DESCRIPTION
### Ticket
Link to Github Issue

### Problem description
There are some minor quality-of-life supplementary api changes for MeshDevice.

### What's changed
- Added the example used in https://github.com/tenstorrent/tt-metal/blob/main/tech_reports/Programming%20Mesh%20of%20Devices/Programming%20Mesh%20of%20Devices%20with%20TT-NN.md#5-programming-mesh-of-devices-using-data-parallel to regression
- Add ctx manager to make distribution strategy easier to specify
- Add simple __repr__ dunder method to display basic information about MeshDevice

### Checklist
- [x] Post commit CI passes
- [x] Blackhole Post commit (if applicable)
- [x] Model regression CI testing passes (if applicable)
- [x] New/Existing tests provide coverage for changes
