### PR TITLE
#12245: Add queue_id and optional output tensor addalpha_bw

### DIFF
--- a/tests/ttnn/unit_tests/operations/backward/test_backward_addalpha.py
+++ b/tests/ttnn/unit_tests/operations/backward/test_backward_addalpha.py
@@ -62,7 +62,7 @@ def test_bw_addalpha_wo_alpha(input_shapes, device):
     ),
 )
 @pytest.mark.parametrize("alpha", [0.05, 2.0, 1.5, 0.12])
-@pytest.mark.parametrize("are_required_outputs", [[True, True], [True, False], [False, True], [False, False]])
+@pytest.mark.parametrize("are_required_outputs", [[True, True], [True, False], [False, True]])
 def test_bw_addalpha_with_opt_output(input_shapes, alpha, device, are_required_outputs):
     in_data, input_tensor = data_gen_with_range(input_shapes, -100, 100, device, True)
     other_data, other_tensor = data_gen_with_range(input_shapes, -90, 100, device, True)
@@ -76,7 +76,9 @@ def test_bw_addalpha_with_opt_output(input_shapes, alpha, device, are_required_o
         _, other_grad = data_gen_with_range(input_shapes, -1, 1, device)
 
     cq_id = 0
-    tt_output_tensor_on_device = ttnn.addalpha_bw(
+
+    pages_before = ttnn._ttnn.reports.get_buffer_pages()
+    ttnn.addalpha_bw(
         grad_tensor,
         input_tensor,
         other_tensor,
@@ -86,6 +88,9 @@ def test_bw_addalpha_with_opt_output(input_shapes, alpha, device, are_required_o
         input_b_grad=other_grad,
         queue_id=cq_id,
     )
+    assert len(pages_before) == len(ttnn._ttnn.reports.get_buffer_pages())
+
+    tt_output_tensor_on_device = [input_grad, other_grad]
 
     golden_function = ttnn.get_golden_function(ttnn.addalpha_bw)
     golden_tensor = golden_function(grad_data, in_data, other_data, alpha)
@@ -105,7 +110,7 @@ def test_bw_addalpha_with_opt_output(input_shapes, alpha, device, are_required_o
         (torch.Size([1, 3, 320, 384])),
     ),
 )
-@pytest.mark.parametrize("are_required_outputs", [[True, True], [True, False], [False, True], [False, False]])
+@pytest.mark.parametrize("are_required_outputs", [[True, True], [True, False], [False, True]])
 def test_bw_addalpha_with_opt_output_wo_alpha(input_shapes, device, are_required_outputs):
     in_data, input_tensor = data_gen_with_range(input_shapes, -100, 100, device, True)
     other_data, other_tensor = data_gen_with_range(input_shapes, -90, 100, device, True)

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_backward/binary_backward.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_backward/binary_backward.hpp
@@ -28,36 +28,6 @@ struct ExecuteBinaryBackwardTensor {
 };
 
 template <BinaryBackwardOpType binary_backward_op_type>
-struct ExecuteBinaryBackwardOptionalFloatDefault {
-    static std::vector<std::optional<Tensor>> invoke(
-        uint8_t queue_id,
-        const Tensor &grad_tensor_arg,
-        const Tensor &input_tensor_a_arg,
-        const Tensor &input_tensor_b_arg,
-        float parameter,
-        const std::optional<MemoryConfig> &memory_config = std::nullopt,
-        const std::vector<bool> &are_required_outputs = std::vector<bool>{true, true},
-        std::optional<Tensor> input_a_grad = std::nullopt,
-        std::optional<Tensor> input_b_grad = std::nullopt) {
-        auto output_memory_config = memory_config.value_or(input_tensor_a_arg.memory_config());
-        return OpHandler<binary_backward_op_type>::handle(queue_id, grad_tensor_arg, input_tensor_a_arg, input_tensor_b_arg, parameter, output_memory_config, are_required_outputs, input_a_grad, input_b_grad);
-    }
-
-    static std::vector<std::optional<Tensor>> invoke(
-        const Tensor &grad_tensor_arg,
-        const Tensor &input_tensor_a_arg,
-        const Tensor &input_tensor_b_arg,
-        float parameter,
-        const std::optional<MemoryConfig> &memory_config = std::nullopt,
-        const std::vector<bool> &are_required_outputs = std::vector<bool>{true, true},
-        std::optional<Tensor> input_a_grad = std::nullopt,
-        std::optional<Tensor> input_b_grad = std::nullopt) {
-        auto output_memory_config = memory_config.value_or(input_tensor_a_arg.memory_config());
-        return OpHandler<binary_backward_op_type>::handle(DefaultQueueId, grad_tensor_arg, input_tensor_a_arg, input_tensor_b_arg, parameter, output_memory_config, are_required_outputs, input_a_grad, input_b_grad);
-    }
-};
-
-template <BinaryBackwardOpType binary_backward_op_type>
 struct ExecuteBinaryBackwardFloatDefault {
     static std::vector<Tensor> invoke(
         const Tensor &grad_tensor_arg,
@@ -235,6 +205,28 @@ struct ExecuteBackwardFmod {
 
 };
 
+struct ExecuteAddalphaBW {
+    static std::vector<std::optional<Tensor>> invoke(
+        uint8_t queue_id,
+        const Tensor &grad_tensor_arg,
+        const Tensor &input_tensor_a_arg,
+        const Tensor &input_tensor_b_arg,
+        float parameter,
+        const std::optional<MemoryConfig> &memory_config = std::nullopt,
+        const std::vector<bool> &are_required_outputs = std::vector<bool>{true, true},
+        std::optional<Tensor> input_a_grad = std::nullopt,
+        std::optional<Tensor> input_b_grad = std::nullopt);
+
+    static std::vector<std::optional<Tensor>> invoke(
+        const Tensor &grad_tensor_arg,
+        const Tensor &input_tensor_a_arg,
+        const Tensor &input_tensor_b_arg,
+        float parameter,
+        const std::optional<MemoryConfig> &memory_config = std::nullopt,
+        const std::vector<bool> &are_required_outputs = std::vector<bool>{true, true},
+        std::optional<Tensor> input_a_grad = std::nullopt,
+        std::optional<Tensor> input_b_grad = std::nullopt);
+};
 
 }  // operations::binary
 
@@ -249,7 +241,6 @@ constexpr auto squared_difference_bw = ttnn::register_operation<"ttnn::squared_d
 constexpr auto min_bw = ttnn::register_operation<"ttnn::min_bw", operations::binary_backward::ExecuteBinaryBackwardTensor<operations::binary_backward::BinaryBackwardOpType::MIN_BW>>();
 constexpr auto max_bw = ttnn::register_operation<"ttnn::max_bw", operations::binary_backward::ExecuteBinaryBackwardTensor<operations::binary_backward::BinaryBackwardOpType::MAX_BW>>();
 
-constexpr auto addalpha_bw = ttnn::register_operation<"ttnn::addalpha_bw", operations::binary_backward::ExecuteBinaryBackwardOptionalFloatDefault<operations::binary_backward::BinaryBackwardOpType::ADDALPHA_BW>>();
 
 constexpr auto subalpha_bw = ttnn::register_operation<"ttnn::subalpha_bw", operations::binary_backward::ExecuteBinaryBackwardFloatDefault<operations::binary_backward::BinaryBackwardOpType::SUBALPHA_BW>>();
 
@@ -260,6 +251,10 @@ constexpr auto mul_bw = ttnn::register_operation<"ttnn::mul_bw", operations::bin
 constexpr auto bias_gelu_bw = ttnn::register_operation<
     "ttnn::bias_gelu_bw",
     operations::binary_backward::ExecuteBackwardBiasGelu>();
+
+constexpr auto addalpha_bw = ttnn::register_operation<
+    "ttnn::addalpha_bw",
+    operations::binary_backward::ExecuteAddalphaBW>();
 
 constexpr auto add_bw = ttnn::register_operation<
     "ttnn::add_bw",

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_backward/device/binary_backward_op.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_backward/device/binary_backward_op.cpp
@@ -25,7 +25,7 @@
 #include "tt_metal/tools/profiler/op_profiler.hpp"
 #include "ttnn/operations/eltwise/ternary/where.hpp"
 #include "ttnn/operations/creation.hpp"
-
+#include "ttnn/common/constants.hpp"
 #include "ttnn/operations/eltwise/binary_backward/binary_backward.hpp"
 #include "third_party/magic_enum/magic_enum.hpp"
 
@@ -54,7 +54,20 @@ std::vector<ttnn::Tensor> _atan2_bw(
     return grad_tensor;
 }
 
-std::vector<std::optional<ttnn::Tensor>> _addalpha_bw(
+// to be used for all binary backward ops to create a zeros tensor when there's no preallocated output_tensor
+void preallocated_tensors_check(std::optional<Tensor>& input_grad, std::optional<Tensor>& other_grad, const Tensor& input, const Tensor& other,  const std::array<bool, 2>& required_outputs){
+
+    TT_FATAL(required_outputs[0] || required_outputs[1], "Atleast one gradient is expected to be calculated.");
+
+    if(required_outputs[0] && !input_grad.has_value()){
+        input_grad = ttnn::zeros_like(input);
+    }
+    if(required_outputs[1] && !other_grad.has_value()){
+        other_grad = ttnn::zeros_like(other);
+    }
+}
+
+std::vector<std::optional<ttnn::Tensor>> ExecuteAddalphaBW::invoke(
     uint8_t queue_id,
     const Tensor& grad,
     const Tensor& input,
@@ -64,31 +77,31 @@ std::vector<std::optional<ttnn::Tensor>> _addalpha_bw(
     const std::vector<bool>& are_required_outputs,
     std::optional<Tensor> input_grad,
     std::optional<Tensor> other_grad) {
-    std::vector<std::optional<Tensor>> result;
+    std::vector<std::optional<Tensor>> result = {std::nullopt, std::nullopt};
 
-    if (are_required_outputs.at(0)) {
-        if(input_grad.has_value()){
-            ttnn::assign(queue_id, grad, input_grad.value());
-        } else {
-            input_grad = grad;
-        }
-        result.emplace_back(input_grad);
-    } else {
-        result.emplace_back(std::nullopt);
+    preallocated_tensors_check(input_grad, other_grad, input, other, {are_required_outputs[0], are_required_outputs[1]});
+
+    if (are_required_outputs[0]) {
+        ttnn::assign(queue_id, grad, input_grad.value());
+        result[0] = input_grad;
     }
-    if (are_required_outputs.at(1)) {
-        if(other_grad.has_value()){
-            ttnn::multiply(queue_id, grad, ttnn::operations::creation::full_like(grad, alpha, grad.get_dtype(), grad.get_layout(), std::nullopt, output_mem_config), std::nullopt, operation::DEFAULT_OUTPUT_MEMORY_CONFIG, other_grad);
-        } else {
-            other_grad = ttnn::multiply(queue_id, grad, alpha, std::nullopt, output_mem_config);
-        }
-        result.emplace_back(other_grad);
-    } else {
-        result.emplace_back(std::nullopt);
+    if (are_required_outputs[1]) {
+        ttnn::multiply(queue_id, grad, alpha, std::nullopt, output_mem_config, other_grad);
+        result[1] = other_grad;
     }
+    return result;
+}
 
-    return std::move(result);
-
+std::vector<std::optional<ttnn::Tensor>> ExecuteAddalphaBW::invoke(
+    const Tensor& grad,
+    const Tensor& input,
+    const Tensor& other,
+    float alpha,
+    const std::optional<MemoryConfig>& output_mem_config,
+    const std::vector<bool>& are_required_outputs,
+    std::optional<Tensor> input_grad,
+    std::optional<Tensor> other_grad) {
+       return ExecuteAddalphaBW::invoke(ttnn::DefaultQueueId, grad, input, other, alpha, output_mem_config, are_required_outputs, input_grad, other_grad);
 }
 
 std::vector<ttnn::Tensor> _subalpha_bw(
@@ -103,18 +116,6 @@ std::vector<ttnn::Tensor> _subalpha_bw(
 std::vector<ttnn::Tensor> _sub_bw(
     const Tensor& grad, const Tensor& input, const Tensor& other, const std::optional<MemoryConfig>& output_mem_config) {
     return _subalpha_bw(grad, input, other, 1.0, output_mem_config);
-}
-
-std::vector<std::optional<Tensor>> _add_bw(
-    uint8_t queue_id,
-    const Tensor& grad,
-    const Tensor& input,
-    const Tensor& other,
-    const MemoryConfig& output_mem_config,
-    const std::vector<bool>& are_required_outputs,
-    std::optional<Tensor> input_grad,
-    std::optional<Tensor> other_grad) {
-    return _addalpha_bw(queue_id, grad, input, other, 1.0f, output_mem_config, are_required_outputs, input_grad, other_grad);
 }
 
 std::vector<Tensor> ExecuteBackwardAdd::invoke(

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_backward/device/binary_backward_op.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_backward/device/binary_backward_op.hpp
@@ -56,9 +56,6 @@ std::vector<ttnn::Tensor> _div_bw( const Tensor& grad, const Tensor& input, cons
 
 std::vector<ttnn::Tensor> _concat_bw( const Tensor& grad, const Tensor& input, const Tensor& other, int dim = 0, const std::optional<MemoryConfig>& output_mem_config = std::nullopt);
 
-std::vector<std::optional<ttnn::Tensor>> _addalpha_bw( uint8_t queue_id, const Tensor& grad, const Tensor& input, const Tensor& other, float alpha = 1.0f, const std::optional<MemoryConfig>& output_mem_config = std::nullopt, const std::vector<bool>& are_required_outputs = std::vector<bool>{true, true}, std::optional<Tensor> input_grad = std::nullopt, std::optional<Tensor> other_grad = std::nullopt);
-
-std::vector<std::optional<ttnn::Tensor>> _add_bw(uint8_t queue_id, const Tensor& grad, const Tensor& input, const Tensor& other, const MemoryConfig& output_mem_config, const std::vector<bool>& are_required_outputs, std::optional<Tensor> input_grad, std::optional<Tensor> other_grad);
 std::vector<std::optional<ttnn::Tensor>> _eq_bw(uint8_t queue_id, const Tensor& grad, const Tensor& input, const Tensor& other, const MemoryConfig& output_mem_config, const std::vector<bool>& are_required_outputs, std::optional<Tensor> input_grad, std::optional<Tensor> other_grad);
 
 // OpHandler struct template
@@ -151,13 +148,6 @@ struct OpHandler<BinaryBackwardOpType::MAX_BW> {
 };
 
 template <>
-struct OpHandler<BinaryBackwardOpType::ADDALPHA_BW> {
-    static std::vector<std::optional<ttnn::Tensor>> handle( uint8_t queue_id, const Tensor& grad, const Tensor& input, const Tensor& other, float alpha, const MemoryConfig& output_mem_config, const std::vector<bool>& are_required_outputs, std::optional<Tensor> input_grad, std::optional<Tensor> other_grad ) {
-        return _addalpha_bw( queue_id, grad, input, other, alpha, output_mem_config, are_required_outputs, input_grad, other_grad);
-    }
-};
-
-template <>
 struct OpHandler<BinaryBackwardOpType::SUBALPHA_BW> {
     static std::vector<Tensor> handle( const Tensor& grad, const Tensor& input, const Tensor& other, float alpha, const std::optional<MemoryConfig>& output_mem_config ) {
         return _subalpha_bw(grad, input, other, alpha, output_mem_config);
@@ -178,11 +168,5 @@ struct OpHandler<BinaryBackwardOpType::CONCAT_BW> {
     }
 };
 
-template <>
-struct OpHandler<BinaryBackwardOpType::ADD_BW> {
-    static std::vector<std::optional<Tensor>> handle(uint8_t queue_id, const Tensor& grad, const Tensor& input, const Tensor& other, const MemoryConfig& output_mem_config, const std::vector<bool>& are_required_outputs, std::optional<Tensor> input_grad, std::optional<Tensor> other_grad) {
-        return _add_bw(queue_id, grad, input, other, output_mem_config, are_required_outputs, input_grad, other_grad);
-    }
-};
 
 }  // namespace ttnn::operations::binary_backward


### PR DESCRIPTION
### Ticket
Link to Github Issue #12245

### Problem description
 To add queue_id and optional output tensor addalpha_bw

### What's changed

-  Add queue_id and optional output tensor addalpha_bw
-  Removed OpHandler usage
-  Added a common function `preallocated_tensors_check` for binary_bw ops

### Checklist
- [x] Post commit CI passes https://github.com/tenstorrent/tt-metal/actions/runs/10807479911
- [ ] Blackhole Post commit (if applicable)
- [ ] Model regression CI testing passes (if applicable)
- [x] New/Existing tests provide coverage for changes
