### PR TITLE
#10147: migrate bitwise ops to ttnn

### DIFF
--- a/tests/ttnn/python_api_testing/sweep_tests/op_map.py
+++ b/tests/ttnn/python_api_testing/sweep_tests/op_map.py
@@ -1070,4 +1070,20 @@ op_map = {
         "tt_op": ttnn_ops.complex_is_real,
         "pytorch_op": pytorch_ops.complex_is_real,
     },
+    "eltwise-bitwise_xor": {
+        "tt_op": ttnn_ops.eltwise_bitwise_xor,
+        "pytorch_op": pytorch_ops.bitwise_xor,
+    },
+    "eltwise-bitwise_not": {
+        "tt_op": ttnn_ops.eltwise_bitwise_not,
+        "pytorch_op": pytorch_ops.bitwise_not,
+    },
+    "eltwise-right_shift": {
+        "tt_op": ttnn_ops.eltwise_right_shift,
+        "pytorch_op": pytorch_ops.right_shift,
+    },
+    "eltwise-left_shift": {
+        "tt_op": ttnn_ops.eltwise_left_shift,
+        "pytorch_op": pytorch_ops.left_shift,
+    },
 }

--- a/tests/ttnn/python_api_testing/sweep_tests/test_configs/ci_sweep_tests_broken/grayskull/ttnn_bitwise_right_shift_test.yaml
+++ b/tests/ttnn/python_api_testing/sweep_tests/test_configs/ci_sweep_tests_broken/grayskull/ttnn_bitwise_right_shift_test.yaml
@@ -1,12 +1,12 @@
 ---
 test-list:
-  - bitwise-and:
+  - eltwise-right_shift:
       shape:
         start-shape: [1, 1, 32, 32]
         end-shape: [6, 12, 256, 256]
         interval: [1, 1, 32, 32]
         num-dims: [2, 3, 4]
-        num-shapes: 1
+        num-shapes: 2
         num-samples: 128
         args-sampling-strategy: "all"
       env:
@@ -26,4 +26,4 @@ test-list:
         data-type: ["INT32"]
         buffer-type: ["DRAM", "L1"]
         out-buffer-type: ["DRAM", "L1"]
-      output-file: bitwise_and_sweep.csv
+      output-file: bitwise_right_shift_sweep.csv

--- a/tests/ttnn/python_api_testing/sweep_tests/test_configs/ci_sweep_tests_broken/grayskull/ttnn_bitwise_shift_left_test.yaml
+++ b/tests/ttnn/python_api_testing/sweep_tests/test_configs/ci_sweep_tests_broken/grayskull/ttnn_bitwise_shift_left_test.yaml
@@ -1,12 +1,12 @@
 ---
 test-list:
-  - bitwise-and:
+  - eltwise-left_shift:
       shape:
         start-shape: [1, 1, 32, 32]
         end-shape: [6, 12, 256, 256]
         interval: [1, 1, 32, 32]
         num-dims: [2, 3, 4]
-        num-shapes: 1
+        num-shapes: 2
         num-samples: 128
         args-sampling-strategy: "all"
       env:
@@ -26,4 +26,4 @@ test-list:
         data-type: ["INT32"]
         buffer-type: ["DRAM", "L1"]
         out-buffer-type: ["DRAM", "L1"]
-      output-file: bitwise_and_sweep.csv
+      output-file: bitwise_left_shift_sweep.csv

--- a/tests/ttnn/python_api_testing/sweep_tests/test_configs/ci_sweep_tests_broken/wormhole/ttnn_bitwise_right_shift_test.yaml
+++ b/tests/ttnn/python_api_testing/sweep_tests/test_configs/ci_sweep_tests_broken/wormhole/ttnn_bitwise_right_shift_test.yaml
@@ -1,12 +1,12 @@
 ---
 test-list:
-  - bitwise-and:
+  - eltwise-right_shift:
       shape:
         start-shape: [1, 1, 32, 32]
         end-shape: [6, 12, 256, 256]
         interval: [1, 1, 32, 32]
         num-dims: [2, 3, 4]
-        num-shapes: 1
+        num-shapes: 2
         num-samples: 128
         args-sampling-strategy: "all"
       env:
@@ -26,4 +26,4 @@ test-list:
         data-type: ["INT32"]
         buffer-type: ["DRAM", "L1"]
         out-buffer-type: ["DRAM", "L1"]
-      output-file: bitwise_and_sweep.csv
+      output-file: bitwise_right_shift_sweep.csv

--- a/tests/ttnn/python_api_testing/sweep_tests/test_configs/ci_sweep_tests_broken/wormhole/ttnn_bitwise_shift_left_test.yaml
+++ b/tests/ttnn/python_api_testing/sweep_tests/test_configs/ci_sweep_tests_broken/wormhole/ttnn_bitwise_shift_left_test.yaml
@@ -1,12 +1,12 @@
 ---
 test-list:
-  - bitwise-and:
+  - eltwise-left_shift:
       shape:
         start-shape: [1, 1, 32, 32]
         end-shape: [6, 12, 256, 256]
         interval: [1, 1, 32, 32]
         num-dims: [2, 3, 4]
-        num-shapes: 1
+        num-shapes: 2
         num-samples: 128
         args-sampling-strategy: "all"
       env:
@@ -26,4 +26,4 @@ test-list:
         data-type: ["INT32"]
         buffer-type: ["DRAM", "L1"]
         out-buffer-type: ["DRAM", "L1"]
-      output-file: bitwise_and_sweep.csv
+      output-file: bitwise_left_shift_sweep.csv

--- a/tests/ttnn/python_api_testing/sweep_tests/test_configs/ci_sweep_tests_working/grayskull/ttnn_bitwise_not_test.yaml
+++ b/tests/ttnn/python_api_testing/sweep_tests/test_configs/ci_sweep_tests_working/grayskull/ttnn_bitwise_not_test.yaml
@@ -1,12 +1,12 @@
 ---
 test-list:
-  - bitwise-and:
+  - eltwise-bitwise_not:
       shape:
         start-shape: [1, 1, 32, 32]
         end-shape: [6, 12, 256, 256]
         interval: [1, 1, 32, 32]
         num-dims: [2, 3, 4]
-        num-shapes: 1
+        num-shapes: 2
         num-samples: 128
         args-sampling-strategy: "all"
       env:
@@ -26,4 +26,4 @@ test-list:
         data-type: ["INT32"]
         buffer-type: ["DRAM", "L1"]
         out-buffer-type: ["DRAM", "L1"]
-      output-file: bitwise_and_sweep.csv
+      output-file: bitwise_not_sweep.csv

--- a/tests/ttnn/python_api_testing/sweep_tests/test_configs/ci_sweep_tests_working/grayskull/ttnn_bitwise_or_test.yaml
+++ b/tests/ttnn/python_api_testing/sweep_tests/test_configs/ci_sweep_tests_working/grayskull/ttnn_bitwise_or_test.yaml
@@ -1,12 +1,12 @@
 ---
 test-list:
-  - bitwise-and:
+  - bitwise-or:
       shape:
         start-shape: [1, 1, 32, 32]
         end-shape: [6, 12, 256, 256]
         interval: [1, 1, 32, 32]
         num-dims: [2, 3, 4]
-        num-shapes: 1
+        num-shapes: 2
         num-samples: 128
         args-sampling-strategy: "all"
       env:
@@ -26,4 +26,4 @@ test-list:
         data-type: ["INT32"]
         buffer-type: ["DRAM", "L1"]
         out-buffer-type: ["DRAM", "L1"]
-      output-file: bitwise_and_sweep.csv
+      output-file: bitwise_or_sweep.csv

--- a/tests/ttnn/python_api_testing/sweep_tests/test_configs/ci_sweep_tests_working/grayskull/ttnn_bitwise_xor_test.yaml
+++ b/tests/ttnn/python_api_testing/sweep_tests/test_configs/ci_sweep_tests_working/grayskull/ttnn_bitwise_xor_test.yaml
@@ -1,12 +1,12 @@
 ---
 test-list:
-  - bitwise-and:
+  - eltwise-bitwise_xor:
       shape:
         start-shape: [1, 1, 32, 32]
         end-shape: [6, 12, 256, 256]
         interval: [1, 1, 32, 32]
         num-dims: [2, 3, 4]
-        num-shapes: 1
+        num-shapes: 2
         num-samples: 128
         args-sampling-strategy: "all"
       env:
@@ -26,4 +26,4 @@ test-list:
         data-type: ["INT32"]
         buffer-type: ["DRAM", "L1"]
         out-buffer-type: ["DRAM", "L1"]
-      output-file: bitwise_and_sweep.csv
+      output-file: bitwise_xor_sweep.csv

--- a/tests/ttnn/python_api_testing/sweep_tests/test_configs/ci_sweep_tests_working/wormhole/ttnn_bitwise_not_test.yaml
+++ b/tests/ttnn/python_api_testing/sweep_tests/test_configs/ci_sweep_tests_working/wormhole/ttnn_bitwise_not_test.yaml
@@ -1,12 +1,12 @@
 ---
 test-list:
-  - bitwise-and:
+  - eltwise-bitwise_not:
       shape:
         start-shape: [1, 1, 32, 32]
         end-shape: [6, 12, 256, 256]
         interval: [1, 1, 32, 32]
         num-dims: [2, 3, 4]
-        num-shapes: 1
+        num-shapes: 2
         num-samples: 128
         args-sampling-strategy: "all"
       env:
@@ -26,4 +26,4 @@ test-list:
         data-type: ["INT32"]
         buffer-type: ["DRAM", "L1"]
         out-buffer-type: ["DRAM", "L1"]
-      output-file: bitwise_and_sweep.csv
+      output-file: bitwise_not_sweep.csv

--- a/tests/ttnn/python_api_testing/sweep_tests/test_configs/ci_sweep_tests_working/wormhole/ttnn_bitwise_xor_test.yaml
+++ b/tests/ttnn/python_api_testing/sweep_tests/test_configs/ci_sweep_tests_working/wormhole/ttnn_bitwise_xor_test.yaml
@@ -1,12 +1,12 @@
 ---
 test-list:
-  - bitwise-and:
+  - eltwise-bitwise_xor:
       shape:
         start-shape: [1, 1, 32, 32]
         end-shape: [6, 12, 256, 256]
         interval: [1, 1, 32, 32]
         num-dims: [2, 3, 4]
-        num-shapes: 1
+        num-shapes: 2
         num-samples: 128
         args-sampling-strategy: "all"
       env:
@@ -26,4 +26,4 @@ test-list:
         data-type: ["INT32"]
         buffer-type: ["DRAM", "L1"]
         out-buffer-type: ["DRAM", "L1"]
-      output-file: bitwise_and_sweep.csv
+      output-file: bitwise_xor_sweep.csv

--- a/tests/ttnn/python_api_testing/sweep_tests/ttnn_ops.py
+++ b/tests/ttnn/python_api_testing/sweep_tests/ttnn_ops.py
@@ -5010,3 +5010,71 @@ def complex_is_imag(x, *args, device, dtype, layout, input_mem_config, output_me
     t1 = ttnn.is_imag(t0, memory_config=output_mem_config)
 
     return ttnn_tensor_to_torch(t1)
+
+
+def eltwise_bitwise_xor(
+    x,
+    *args,
+    value,
+    device,
+    dtype,
+    layout,
+    input_mem_config,
+    output_mem_config,
+    **kwargs,
+):
+    t0 = setup_ttnn_tensor(x, device, layout[0], input_mem_config[0], dtype[0])
+    t1 = ttnn.bitwise_xor(t0, value, memory_config=output_mem_config, queue_id=0)
+
+    return ttnn_tensor_to_torch(t1)
+
+
+def eltwise_bitwise_not(
+    x,
+    *args,
+    value,
+    device,
+    dtype,
+    layout,
+    input_mem_config,
+    output_mem_config,
+    **kwargs,
+):
+    t0 = setup_ttnn_tensor(x, device, layout[0], input_mem_config[0], dtype[0])
+    t1 = ttnn.bitwise_not(t0, value, memory_config=output_mem_config, queue_id=0)
+
+    return ttnn_tensor_to_torch(t1)
+
+
+def eltwise_right_shift(
+    x,
+    *args,
+    value,
+    device,
+    dtype,
+    layout,
+    input_mem_config,
+    output_mem_config,
+    **kwargs,
+):
+    t0 = setup_ttnn_tensor(x, device, layout[0], input_mem_config[0], dtype[0])
+    t1 = ttnn.bitwise_right_shift(t0, value, memory_config=output_mem_config, queue_id=0)
+
+    return ttnn_tensor_to_torch(t1)
+
+
+def eltwise_left_shift(
+    x,
+    *args,
+    value,
+    device,
+    dtype,
+    layout,
+    input_mem_config,
+    output_mem_config,
+    **kwargs,
+):
+    t0 = setup_ttnn_tensor(x, device, layout[0], input_mem_config[0], dtype[0])
+    t1 = ttnn.bitwise_left_shift(t0, value, memory_config=output_mem_config, queue_id=0)
+
+    return ttnn_tensor_to_torch(t1)


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/10147

### Problem description
Migrating bitwise ops to ttnn.
Ops included:
-bitwise_xor
-bitwise_or
-bitwise_not
-bitwise_and (fixed yaml file)
-bitwise_left_shit
-bitwise_right_shift

### What's changed
Implemented coresponding API cals in ttnn_ops and added yaml files


