### PR TITLE
#12321: Migrate moreh_bmm, moreh_bmm_backward operations from tt_eager to ttnn

### DIFF
--- a/tests/ttnn/unit_tests/operations/test_moreh_bmm.py
+++ b/tests/ttnn/unit_tests/operations/test_moreh_bmm.py
@@ -1,0 +1,136 @@
+# SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+
+# SPDX-License-Identifier: Apache-2.0
+
+import pytest
+import torch
+import torch.nn.functional as F
+from loguru import logger
+
+import ttnn
+from tests.ttnn.unit_tests.operations.test_moreh_matmul import get_tensors
+from models.utility_functions import comp_allclose_and_pcc
+
+from tests.tt_eager.python_api_testing.unit_testing.misc.test_utils import (
+    get_compute_kernel_options,
+    compute_kernel_options,
+    compute_kernel_ids,
+)
+
+
+@pytest.mark.parametrize(
+    "shape",
+    (
+        # batch, m, k, n
+        [1, 31, 639, 31],
+        [5, 95, 415, 65],
+        [10, 191, 447, 159],
+    ),
+)
+@pytest.mark.parametrize("has_output", [False, True])
+@pytest.mark.parametrize("compute_kernel_options", compute_kernel_options, ids=compute_kernel_ids)
+def test_moreh_bmm(shape, has_output, compute_kernel_options, device):
+    input_shape = [shape[0], shape[1], shape[2]]
+    mat2_shape = [shape[0], shape[2], shape[3]]
+    output_shape = [shape[0], shape[1], shape[3]]
+
+    # get tensors
+    tt_input, tt_mat2, tt_output, _, _, _, input, mat2, _ = get_tensors(
+        input_shape, mat2_shape, output_shape, False, False, False, device
+    )
+
+    compute_kernel_config = get_compute_kernel_options(compute_kernel_options)
+
+    # tt bmm
+    cpu_layout = ttnn.ROW_MAJOR_LAYOUT
+    tt_output = (
+        ttnn.operations.moreh.bmm(
+            tt_input, tt_mat2, output=tt_output if has_output else None, compute_kernel_config=compute_kernel_config
+        )
+        .cpu()
+        .to(cpu_layout)
+        .unpad_from_tile(output_shape)
+        .to_torch()
+    )
+
+    # torch bmm
+    output = torch.bmm(input, mat2)
+
+    # test for equivalance
+    passing, output_pcc = comp_allclose_and_pcc(output, tt_output, pcc=0.999)
+    logger.debug(f"Out passing={passing}")
+    logger.debug(f"Output pcc={output_pcc}")
+
+    assert passing
+
+
+@pytest.mark.parametrize(
+    "shape",
+    (
+        # batch, m, k, n
+        [1, 32, 32, 32],
+        [3, 31, 31, 31],
+        [7, 511, 313, 765],
+    ),
+)
+@pytest.mark.parametrize(
+    "requires_grad",
+    (
+        (True, False),
+        (False, True),
+        (True, True),
+    ),
+)
+@pytest.mark.parametrize("compute_kernel_options", compute_kernel_options, ids=compute_kernel_ids)
+def test_moreh_bmm_backward(shape, requires_grad, compute_kernel_options, device):
+    require_input_grad, require_mat2_grad = requires_grad
+    input_shape = [shape[0], shape[1], shape[2]]
+    mat2_shape = [shape[0], shape[2], shape[3]]
+    output_shape = [shape[0], shape[1], shape[3]]
+
+    compute_kernel_config = get_compute_kernel_options(compute_kernel_options)
+
+    # get tensors
+    (
+        tt_input,
+        tt_mat2,
+        _,
+        tt_output_grad,
+        tt_input_grad,
+        tt_mat2_grad,
+        input,
+        mat2,
+        output_grad,
+    ) = get_tensors(input_shape, mat2_shape, output_shape, require_input_grad, require_mat2_grad, False, device)
+
+    # tt bmm fwd, bwd
+    cpu_layout = ttnn.ROW_MAJOR_LAYOUT
+    ttnn.operations.moreh.bmm_backward(
+        tt_output_grad,
+        tt_input,
+        mat2=tt_mat2,
+        are_required_outputs=(require_input_grad, require_mat2_grad),
+        input_grad=tt_input_grad if require_input_grad else None,
+        mat2_grad=tt_mat2_grad if require_mat2_grad else None,
+        compute_kernel_config=compute_kernel_config,
+    )
+
+    # torch bmm fwd, bwd
+    output = torch.bmm(input.requires_grad_(require_input_grad), mat2.requires_grad_(require_mat2_grad))
+    output.backward(output_grad)
+
+    # test for equivalance
+    rtol = atol = 0.1
+    if require_input_grad:
+        ttcpu_input_grad = tt_input_grad.cpu().to(cpu_layout).unpad_from_tile(input_shape).to_torch()
+        passing, output_pcc = comp_allclose_and_pcc(input.grad, ttcpu_input_grad, pcc=0.999, rtol=rtol, atol=atol)
+        logger.debug(f"input_grad passing={passing}")
+        logger.debug(f"input_grad pcc={output_pcc}")
+        assert passing
+
+    if require_mat2_grad:
+        ttcpu_mat2_grad = tt_mat2_grad.cpu().to(cpu_layout).unpad_from_tile(mat2_shape).to_torch()
+        passing, output_pcc = comp_allclose_and_pcc(mat2.grad, ttcpu_mat2_grad, pcc=0.999, rtol=rtol, atol=atol)
+        logger.debug(f"mat2_grad passing={passing}")
+        logger.debug(f"mat2_grad pcc={output_pcc}")
+        assert passing

--- a/ttnn/CMakeLists.txt
+++ b/ttnn/CMakeLists.txt
@@ -353,6 +353,10 @@ set(ALL_TTNN_SRCS
     ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/moreh/moreh_arange/device/moreh_arange_program_factory.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/moreh/moreh_arange/moreh_arange.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/moreh/moreh_arange/moreh_arange_pybind.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/moreh/moreh_bmm/moreh_bmm.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/moreh/moreh_bmm/moreh_bmm_pybind.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/moreh/moreh_bmm_backward/moreh_bmm_backward.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/moreh/moreh_bmm_backward/moreh_bmm_backward_pybind.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/moreh/moreh_dot_op/device/moreh_dot_device_operation.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/moreh/moreh_dot_op/device/moreh_dot_program_factory.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/moreh/moreh_dot_op/moreh_dot.cpp

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_bmm/moreh_bmm.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_bmm/moreh_bmm.cpp
@@ -1,0 +1,18 @@
+// SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "moreh_bmm.hpp"
+
+#include "ttnn/cpp/ttnn/operations/moreh/moreh_matmul/moreh_matmul.hpp"
+
+namespace ttnn::operations::moreh::moreh_bmm {
+Tensor MorehBmm::invoke(
+    const Tensor& input,
+    const Tensor& mat2,
+    const std::optional<Tensor>& output,
+    const std::optional<MemoryConfig>& memory_config,
+    const std::optional<DeviceComputeKernelConfig>& compute_kernel_config) {
+    return ttnn::moreh_matmul(input, mat2, false, false, output, std::nullopt, memory_config, compute_kernel_config);
+}
+}  // namespace ttnn::operations::moreh::moreh_bmm

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_bmm/moreh_bmm.hpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_bmm/moreh_bmm.hpp
@@ -1,0 +1,24 @@
+// SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include "ttnn/cpp/ttnn/operations/core/compute_kernel/compute_kernel_config.hpp"
+#include "ttnn/decorators.hpp"
+
+namespace ttnn::operations::moreh::moreh_bmm {
+struct MorehBmm {
+    static Tensor invoke(
+        const Tensor& input,
+        const Tensor& mat2,
+        const std::optional<Tensor>& output,
+        const std::optional<MemoryConfig>& memory_config,
+        const std::optional<DeviceComputeKernelConfig>& compute_kernel_config);
+};
+}  // namespace ttnn::operations::moreh::moreh_bmm
+
+namespace ttnn {
+constexpr auto moreh_bmm =
+    ttnn::register_operation_with_auto_launch_op<"ttnn::moreh_bmm", ttnn::operations::moreh::moreh_bmm::MorehBmm>();
+}

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_bmm/moreh_bmm_pybind.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_bmm/moreh_bmm_pybind.cpp
@@ -1,0 +1,24 @@
+// SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "moreh_bmm_pybind.hpp"
+
+#include "moreh_bmm.hpp"
+#include "pybind11/decorators.hpp"
+
+namespace ttnn::operations::moreh::moreh_bmm {
+void bind_moreh_bmm_operation(py::module& module) {
+    bind_registered_operation(
+        module,
+        ttnn::moreh_bmm,
+        "Moreh BMM Operation",
+        ttnn::pybind_arguments_t{
+            py::arg("input"),
+            py::arg("mat2"),
+            py::kw_only(),
+            py::arg("output") = std::nullopt,
+            py::arg("memory_config") = std::nullopt,
+            py::arg("compute_kernel_config") = std::nullopt});
+}
+}  // namespace ttnn::operations::moreh::moreh_bmm

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_bmm/moreh_bmm_pybind.hpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_bmm/moreh_bmm_pybind.hpp
@@ -1,0 +1,13 @@
+// SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include "pybind11/pybind_fwd.hpp"
+
+namespace py = pybind11;
+
+namespace ttnn::operations::moreh::moreh_bmm {
+void bind_moreh_bmm_operation(py::module& module);
+}  // namespace ttnn::operations::moreh::moreh_bmm

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_bmm_backward/moreh_bmm_backward.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_bmm_backward/moreh_bmm_backward.cpp
@@ -1,0 +1,47 @@
+// SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "moreh_bmm_backward.hpp"
+
+#include "ttnn/cpp/ttnn/operations/moreh/moreh_matmul/moreh_matmul.hpp"
+
+namespace ttnn::operations::moreh::moreh_bmm_backward {
+std::vector<std::optional<Tensor>> MorehBmmBackward::invoke(
+    const Tensor& output_grad,
+    const Tensor& input,
+    const Tensor& mat2,
+    const std::vector<bool>& are_required_outputs,
+    const std::optional<Tensor>& input_grad,
+    const std::optional<Tensor>& mat2_grad,
+    const std::optional<MemoryConfig>& input_grad_memory_config,
+    const std::optional<MemoryConfig>& mat2_grad_memory_config,
+    const std::optional<DeviceComputeKernelConfig>& compute_kernel_config) {
+    std::vector<std::optional<Tensor>> outputs(2);
+    if (are_required_outputs.at(0)) {
+        TT_FATAL(input_grad.has_value(), "input_grad needs to have a value when input_requires_grad is True.");
+        outputs[0] = ttnn::moreh_matmul(
+            output_grad,
+            mat2,
+            false,
+            true,
+            input_grad.value(),
+            std::nullopt,
+            input_grad_memory_config,
+            compute_kernel_config);
+    }
+    if (are_required_outputs.at(1)) {
+        TT_FATAL(mat2_grad.has_value(), "mat2_grad needs to have a value when mat2_requires_grad is True.");
+        outputs[1] = ttnn::moreh_matmul(
+            input,
+            output_grad,
+            true,
+            false,
+            mat2_grad.value(),
+            std::nullopt,
+            mat2_grad_memory_config,
+            compute_kernel_config);
+    }
+    return outputs;
+}
+}  // namespace ttnn::operations::moreh::moreh_bmm_backward

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_bmm_backward/moreh_bmm_backward.hpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_bmm_backward/moreh_bmm_backward.hpp
@@ -1,0 +1,28 @@
+// SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include "ttnn/cpp/ttnn/operations/core/compute_kernel/compute_kernel_config.hpp"
+#include "ttnn/decorators.hpp"
+
+namespace ttnn::operations::moreh::moreh_bmm_backward {
+struct MorehBmmBackward {
+    static std::vector<std::optional<Tensor>> invoke(
+        const Tensor& output_grad,
+        const Tensor& input,
+        const Tensor& mat2,
+        const std::vector<bool>& are_required_outputs,
+        const std::optional<Tensor>& input_grad,
+        const std::optional<Tensor>& mat2_grad,
+        const std::optional<MemoryConfig>& input_grad_memory_config,
+        const std::optional<MemoryConfig>& mat2_grad_memory_config,
+        const std::optional<DeviceComputeKernelConfig>& compute_kernel_config);
+};
+}  // namespace ttnn::operations::moreh::moreh_bmm_backward
+
+namespace ttnn {
+constexpr auto moreh_bmm_backward = ttnn::
+    register_operation<"ttnn::moreh_bmm_backward", ttnn::operations::moreh::moreh_bmm_backward::MorehBmmBackward>();
+}

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_bmm_backward/moreh_bmm_backward_pybind.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_bmm_backward/moreh_bmm_backward_pybind.cpp
@@ -1,0 +1,28 @@
+// SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "moreh_bmm_backward_pybind.hpp"
+
+#include "pybind11/decorators.hpp"
+#include "ttnn/operations/moreh/moreh_bmm_backward/moreh_bmm_backward.hpp"
+
+namespace ttnn::operations::moreh::moreh_bmm_backward {
+void bind_moreh_bmm_backward_operation(py::module& module) {
+    bind_registered_operation(
+        module,
+        ttnn::moreh_bmm_backward,
+        "Moreh Bmm Backward Operation",
+        ttnn::pybind_arguments_t{
+            py::arg("output_grad"),
+            py::arg("input"),
+            py::arg("mat2"),
+            py::kw_only(),
+            py::arg("are_required_outputs") = std::vector<bool>{true, true},
+            py::arg("input_grad") = std::nullopt,
+            py::arg("mat2_grad") = std::nullopt,
+            py::arg("input_grad_memory_config") = std::nullopt,
+            py::arg("mat2_grad_memory_config") = std::nullopt,
+            py::arg("compute_kernel_config") = std::nullopt});
+}
+}  // namespace ttnn::operations::moreh::moreh_bmm_backward

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_bmm_backward/moreh_bmm_backward_pybind.hpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_bmm_backward/moreh_bmm_backward_pybind.hpp
@@ -1,0 +1,13 @@
+// SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include "pybind11/pybind_fwd.hpp"
+
+namespace py = pybind11;
+
+namespace ttnn::operations::moreh::moreh_bmm_backward {
+void bind_moreh_bmm_backward_operation(py::module& module);
+}  // namespace ttnn::operations::moreh::moreh_bmm_backward

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_pybind.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_pybind.cpp
@@ -6,6 +6,8 @@
 
 #include "ttnn/operations/moreh/moreh_adam/moreh_adam_pybind.hpp"
 #include "ttnn/operations/moreh/moreh_arange/moreh_arange_pybind.hpp"
+#include "ttnn/operations/moreh/moreh_bmm/moreh_bmm_pybind.hpp"
+#include "ttnn/operations/moreh/moreh_bmm_backward/moreh_bmm_backward_pybind.hpp"
 #include "ttnn/operations/moreh/moreh_dot_op/moreh_dot_pybind.hpp"
 #include "ttnn/operations/moreh/moreh_dot_op_backward/moreh_dot_backward_pybind.hpp"
 #include "ttnn/operations/moreh/moreh_getitem/moreh_getitem_pybind.hpp"
@@ -22,6 +24,8 @@ namespace ttnn::operations::moreh {
 void bind_moreh_operations(py::module &module) {
     moreh_adam::bind_moreh_adam_operation(module);
     moreh_arange::bind_moreh_arange_operation(module);
+    moreh_bmm::bind_moreh_bmm_operation(module);
+    moreh_bmm_backward::bind_moreh_bmm_backward_operation(module);
     moreh_dot::bind_moreh_dot_operation(module);
     moreh_dot_backward::bind_moreh_dot_backward_operation(module);
     moreh_getitem::bind_moreh_getitem_operation(module);

--- a/ttnn/ttnn/operations/moreh.py
+++ b/ttnn/ttnn/operations/moreh.py
@@ -6,6 +6,8 @@ import ttnn
 
 adam = ttnn._ttnn.operations.moreh.moreh_adam
 arange = ttnn._ttnn.operations.moreh.moreh_arange
+bmm = ttnn._ttnn.operations.moreh.moreh_bmm
+bmm_backward = ttnn._ttnn.operations.moreh.moreh_bmm_backward
 getitem = ttnn._ttnn.operations.moreh.moreh_getitem
 matmul = ttnn._ttnn.operations.moreh.moreh_matmul
 mean = ttnn._ttnn.operations.moreh.moreh_mean


### PR DESCRIPTION
### Ticket
Link to Github Issue: [#12321](https://github.com/tenstorrent/tt-metal/issues/12321)
Dependency: [PR: #12250: port moreh_matmul from tt_dnn to ttnn #12251](https://github.com/tenstorrent/tt-metal/pull/12251)

### Problem description
`moreh_bmm`, `moreh_bmm_backward` were deprecated alongside `tt_dnn`. This PR ports them to `ttnn` using its operation format.

### What's changed
- Move device code to `ttnn`
- Create new wrapper code for `ttnn` with new modules

### What's not changed
- Removed `moreh_bmm`, `moreh_bmm_backward`'s `tt_dnn` implementations (Reason: Deprecated `moreh_bmm`, `moreh_bmm_backward` is being called by others operations)

### Checklist
- [x] Post commit CI passes:
+ [All post-commit tests #15227](https://github.com/tenstorrent/tt-metal/actions/runs/10768312315)
+ [All post-commit tests #15621](https://github.com/tenstorrent/tt-metal/actions/runs/10843014842)
+ [All post-commit tests #15705](https://github.com/tenstorrent/tt-metal/actions/runs/10861605599/)
+ [All post-commit tests #16292](https://github.com/tenstorrent/tt-metal/actions/runs/10988993611)
+ [All post-commit tests #16313](https://github.com/tenstorrent/tt-metal/actions/runs/10995548042)
- [x] Blackhole Post commit (if applicable): Not available.
- [x] Model regression CI testing passes (if applicable): Not available.
- [x] New/Existing tests provide coverage for changes: 30/30 test cases passed.