### PR TITLE
#12323: delete ctor of AllGatherFusedOpSignaler

### DIFF
--- a/ttnn/cpp/ttnn/operations/ccl/ccl_op_fusion.hpp
+++ b/ttnn/cpp/ttnn/operations/ccl/ccl_op_fusion.hpp
@@ -77,8 +77,6 @@ struct MatmulFusedOpSignaler {
     bool initialized_all_gather = false;
     bool initialized_fused_op = false;
 
-    MatmulFusedOpSignaler() {}
-
     void init_all_gather(
         uint32_t num_transfers,
         uint32_t ring_size,


### PR DESCRIPTION
### Ticket
[Link to Github Issue](https://github.com/tenstorrent/tt-metal/issues/12323)

### Problem description
Due to the ctor of `AllGatherFusedOpSignaler` is essentially the default constructor. The expression `std::optional<AllGatherFusedOpSignaler> all_gather_fused_op_signaler = AllGatherFusedOpSignaler();` triggers GCC14's uninitialized variable detection.

### What's changed
Delete the default constructor.

### Checklist
- [ ] Post commit CI passes
- [ ] Blackhole Post commit (if applicable)
- [ ] Model regression CI testing passes (if applicable)
- [ ] New/Existing tests provide coverage for changes
