### PR TITLE
Add DISABLE_DI_DT_WORKAROUND and optimize matmuls, untilize on device

### DIFF
--- a/models/demos/wormhole/llama31_8b/README.md
+++ b/models/demos/wormhole/llama31_8b/README.md
@@ -59,7 +59,7 @@ Note that while running the demo you might see the warning: `Op | WARNING  | TIL
 # Run the demo with a pre-written batch of 8 user prompts:
 
 # Prefill & Decode demo
-pytest models/demos/wormhole/llama31_8b/demo/demo_with_prefill.py::test_llama_demo[general_weights]
+pytest models/demos/wormhole/llama31_8b/demo/demo_with_prefill.py::test_llama_demo[general_weights-1_batch]
 
 # Decode-only demo
 pytest models/demos/wormhole/llama31_8b/demo/demo.py::test_llama_demo[general_weights]
@@ -68,7 +68,7 @@ pytest models/demos/wormhole/llama31_8b/demo/demo.py::test_llama_demo[general_we
 We also provide an input file with 32 user question-prompt for instruct weights (don't forget to update your env flags to the correct instruct weights folder):
 ```
 # Prefill & Decode demo
-pytest models/demos/wormhole/llama31_8b/demo/demo_with_prefill.py::test_llama_demo[instruct_weights]
+pytest models/demos/wormhole/llama31_8b/demo/demo_with_prefill.py::test_llama_demo[instruct_weights-1_batch]
 
 # Decode-only demo
 pytest models/demos/wormhole/llama31_8b/demo/demo.py::test_llama_demo[instruct_weights]

--- a/models/demos/wormhole/llama31_8b/demo/demo.py
+++ b/models/demos/wormhole/llama31_8b/demo/demo.py
@@ -167,6 +167,7 @@ def run_llama_demo(user_input, batch_size, device, instruct_mode, is_ci_env):
 
         # Run ttnn llama model
         tt_out = tt_model(decode_input, current_pos, rot_mat=current_rot_mat)
+        tt_out = ttnn.untilize(tt_out, use_multicore=False)  # single core OOMs
         tt_output_torch = (
             ttnn.to_torch(tt_out).permute(2, 1, 0, 3).squeeze(1)[: model_args.max_batch_size, :, :]
         )  # [batch, seq, hidden_dim]

--- a/models/demos/wormhole/llama31_8b/demo/demo.py
+++ b/models/demos/wormhole/llama31_8b/demo/demo.py
@@ -167,7 +167,9 @@ def run_llama_demo(user_input, batch_size, device, instruct_mode, is_ci_env):
 
         # Run ttnn llama model
         tt_out = tt_model(decode_input, current_pos, rot_mat=current_rot_mat)
-        tt_out = ttnn.untilize(tt_out, use_multicore=False)  # single core OOMs
+        tt_out = ttnn.untilize(
+            tt_out, use_multicore=False
+        )  # multi-core OOMs (https://github.com/tenstorrent/tt-metal/issues/9022)
         tt_output_torch = (
             ttnn.to_torch(tt_out).permute(2, 1, 0, 3).squeeze(1)[: model_args.max_batch_size, :, :]
         )  # [batch, seq, hidden_dim]

--- a/models/demos/wormhole/llama31_8b/demo/demo_with_prefill.py
+++ b/models/demos/wormhole/llama31_8b/demo/demo_with_prefill.py
@@ -355,7 +355,9 @@ def run_llama_demo(user_input, batch_size, device, instruct_mode, is_ci_env, num
             profiler.start(f"decode_and_argmax", iteration=batch_idx)
             # Run ttnn llama3.1 model
             tt_out = tt_model(decode_input, current_pos, rot_mat=current_rot_mat)
-            tt_out = ttnn.untilize(tt_out, use_multicore=False)  # single core OOMs
+            tt_out = ttnn.untilize(
+                tt_out, use_multicore=False
+            )  # multi-core OOMs (https://github.com/tenstorrent/tt-metal/issues/9022)
             tt_output_torch = (
                 ttnn.to_torch(tt_out).permute(2, 1, 0, 3).squeeze(1)[:batch_size, :, :]
             )  # [batch, seq, hidden_dim]

--- a/models/demos/wormhole/llama31_8b/demo/demo_with_prefill.py
+++ b/models/demos/wormhole/llama31_8b/demo/demo_with_prefill.py
@@ -355,6 +355,7 @@ def run_llama_demo(user_input, batch_size, device, instruct_mode, is_ci_env, num
             profiler.start(f"decode_and_argmax", iteration=batch_idx)
             # Run ttnn llama3.1 model
             tt_out = tt_model(decode_input, current_pos, rot_mat=current_rot_mat)
+            tt_out = ttnn.untilize(tt_out, use_multicore=False)  # single core OOMs
             tt_output_torch = (
                 ttnn.to_torch(tt_out).permute(2, 1, 0, 3).squeeze(1)[:batch_size, :, :]
             )  # [batch, seq, hidden_dim]

--- a/models/demos/wormhole/llama31_8b/tests/test_llama_perf.py
+++ b/models/demos/wormhole/llama31_8b/tests/test_llama_perf.py
@@ -31,9 +31,9 @@ if not os.getenv("CI") == "true":  # Enable tracy signpost support in local runs
 @pytest.mark.parametrize(
     "kv_cache_len, expected_compile_time, expected_inference_time",
     (
-        (32, 6, 0.185),
-        (128, 6, 0.185),
-        (1024, 11, 0.185),
+        (32, 6, 0.09),
+        (128, 6, 0.09),
+        (1024, 11, 0.09),
     ),
 )
 def test_llama_model_perf(
@@ -102,11 +102,11 @@ def test_llama_model_perf(
     compile_and_iter_time = profiler.get("model_run_for_inference_0")
 
     ttnn.DumpDeviceProfiler(device)
+    ttnn.synchronize_device(device)
 
     if not os.getenv("CI") == "true":  # Enable tracy signpost support in local runs only
         signpost("Model perf run")
 
-    profiler.clear()
     profiler.start(f"end_to_end_inference")
     run_inference(tt_model, tt_embd, embd, encoded_prompts, generation_start_pos, generation_length)
     profiler.end(f"end_to_end_inference")
@@ -158,6 +158,9 @@ def run_inference(tt_model, tt_embd, embd, encoded_prompts, generation_start_pos
 
         # Convert ttnn tensor to torch tensor
         profiler.start(f"result_wait_for_inference_{i}")
+        tt_out = ttnn.untilize(
+            tt_out, use_multicore=False
+        )  # multi-core OOMs (https://github.com/tenstorrent/tt-metal/issues/9022)
         tt_output_torch = ttnn.to_torch(tt_out).permute(2, 1, 0, 3).squeeze(1)  # [seq, batch, hidden_dim]
 
         profiler.end(f"model_run_for_inference_{i}")

--- a/models/demos/wormhole/llama31_8b/tt/llama_attention.py
+++ b/models/demos/wormhole/llama31_8b/tt/llama_attention.py
@@ -321,7 +321,8 @@ class TtLlamaAttention(nn.Module):
             dense_out = ttnn.linear(
                 attn_output_cat,
                 wo,
-                memory_config=self.model_config["LM_HEAD_OUTPUT_MEMCFG"],
+                memory_config=self.model_config["ATTN_OUTPUT_MEMCFG"],
+                program_config=self.model_config["ATTN_OUTPUT_PROGCFG"],
                 compute_kernel_config=self.compute_kernel_config,
                 # core_grid=self.grid_size,
             )  # seqlen, 1, batch, hidden_size

--- a/models/demos/wormhole/llama31_8b/tt/llama_mlp.py
+++ b/models/demos/wormhole/llama31_8b/tt/llama_mlp.py
@@ -68,6 +68,7 @@ class TtLlamaMLP(torch.nn.Module):
             dtype=ttnn.bfloat16,
             activation="silu" if not pc_1 else None,
             program_config=pc_1,
+            memory_config=ttnn.L1_MEMORY_CONFIG if seq_len <= 32 else ttnn.DRAM_MEMORY_CONFIG,
         )
 
         w3_out = ttnn.linear(
@@ -77,6 +78,7 @@ class TtLlamaMLP(torch.nn.Module):
             core_grid=ttnn.CoreGrid(y=8, x=8) if not pc_3 else None,
             dtype=ttnn.bfloat16,
             program_config=pc_3,
+            memory_config=ttnn.L1_MEMORY_CONFIG if seq_len <= 32 else ttnn.DRAM_MEMORY_CONFIG,
         )
 
         # x.deallocate(True)
@@ -92,6 +94,7 @@ class TtLlamaMLP(torch.nn.Module):
             core_grid=ttnn.CoreGrid(y=8, x=8) if not pc_2 else None,
             dtype=ttnn.bfloat8_b,
             program_config=pc_2,
+            memory_config=ttnn.L1_MEMORY_CONFIG if seq_len <= 32 else ttnn.DRAM_MEMORY_CONFIG,
         )
 
         w2_in.deallocate(True)

--- a/models/demos/wormhole/llama31_8b/tt/llama_model.py
+++ b/models/demos/wormhole/llama31_8b/tt/llama_model.py
@@ -2,6 +2,7 @@
 
 # SPDX-License-Identifier: Apache-2.0
 
+import os
 import ttnn
 import torch
 import torch.nn as nn
@@ -31,6 +32,7 @@ class TtTransformer(nn.Module):
         self.device = device
         self.dtype = dtype
         self.model_config = args.get_model_config()
+        self.grid_size = self.args.max_grid_size
         assert self.vocab_size > 0
 
         self.layers = torch.nn.ModuleList(
@@ -82,6 +84,7 @@ class TtTransformer(nn.Module):
         if mode == "prefill":
             return x
         x = self.norm(x)
+
         output = ttnn.linear(
             x,
             self.output_weight,

--- a/models/demos/wormhole/llama31_8b/tt/model_config.py
+++ b/models/demos/wormhole/llama31_8b/tt/model_config.py
@@ -57,7 +57,7 @@ class TtModelArgs:
         "QK_MM_OUTPUT",
         "QKV_MM_OUTPUT",
         "CONCAT_HEADS_OUTPUT",
-        "LM_HEAD_OUTPUT",
+        "ATTN_OUTPUT",
         "ATTN_W_LAYOUT",
         # Decoder
         "DEC_SKIP_OUTPUT",
@@ -105,27 +105,29 @@ class TtModelArgs:
         self.model_config.update({f"{key}_TILE": ttnn.TILE_LAYOUT for key in self.OP_KEYS if "LAYOUT" in key})
 
         if device is not None:  # Avoid issue with test_llama_torch.py not having a device
-            grid_size = device.compute_with_storage_grid_size()
-            for i in range(grid_size.y, 0, -1):
-                # Force the number of rows in the grid to be a factor of max_batch_size for a valid sharding
-                if self.max_batch_size % i == 0:
-                    grid_size_y = i
-                    break
-            assert (
-                self.max_batch_size % grid_size_y == 0
-            ), f"Number of rows in the grid should be a factor of max_batch_size ({self.max_batch_size})"
-            self.max_grid_size = ttnn.CoreGrid(y=grid_size_y, x=grid_size.x)  # (y,x)
+            # grid_size = device.compute_with_storage_grid_size()
+            # for i in range(grid_size.y, 0, -1):
+            #     # Force the number of rows in the grid to be a factor of max_batch_size for a valid sharding
+            #     if self.max_batch_size % i == 0:
+            #         grid_size_y = i
+            #         break
+            # assert (
+            #     self.max_batch_size % grid_size_y == 0
+            # ), f"Number of rows in the grid should be a factor of max_batch_size ({self.max_batch_size})"
+            # self.max_grid_size = ttnn.CoreGrid(y=grid_size_y, x=grid_size.x)  # (y,x)
+            grid = device.compute_with_storage_grid_size()
+            self.max_grid_size = ttnn.CoreGrid(x=grid.x, y=grid.y)
 
-            # Add sharded memory config for MLP FF1/FF3
-            mlp_shard_config = ttnn.create_sharded_memory_config(
-                [self.max_batch_size, self.hidden_dim], self.max_grid_size, ttnn.ShardStrategy.WIDTH
-            )
-            self.model_config["FF1_OUTPUT_MEMCFG"] = mlp_shard_config
-            self.model_config["FF3_OUTPUT_MEMCFG"] = mlp_shard_config
+            # # Add sharded memory config for MLP FF1/FF3
+            # mlp_shard_config = ttnn.create_sharded_memory_config(
+            #     [self.max_batch_size, self.hidden_dim], self.max_grid_size, ttnn.ShardStrategy.WIDTH
+            # )
+            # self.model_config["FF1_OUTPUT_MEMCFG"] = mlp_shard_config
+            # self.model_config["FF3_OUTPUT_MEMCFG"] = mlp_shard_config
 
             # Compute kernel shared by attention and MLP. FP32 acc is needed for accuracy
             self.compute_kernel_config = ttnn.WormholeComputeKernelConfig(
-                math_fidelity=ttnn.MathFidelity.HiFi4,
+                math_fidelity=ttnn.MathFidelity.HiFi2,  # DRAM-bound so keep full precision here
                 math_approx_mode=False,
                 fp32_dest_acc_en=True,
                 packer_l1_acc=True,
@@ -135,6 +137,17 @@ class TtModelArgs:
                 compute_with_storage_grid_size=(8, 8),
                 q_chunk_size=256 if seqlen > 8192 * 2 else (128 if seqlen >= 8192 else 64),
                 k_chunk_size=256 if seqlen > 8192 * 2 else (128 if seqlen >= 8192 else 64),
+            )
+            self.model_config["ATTN_OUTPUT_PROGCFG"] = ttnn.MatmulMultiCoreReuseMultiCast1DProgramConfig(
+                compute_with_storage_grid_size=(8, 8),
+                in0_block_w=4,  # how much inner dim you take each time
+                out_subblock_h=1,  # Must be divisible by per_core_M
+                out_subblock_w=2,  # Must be divisible by per_core_N, out_subblock_w * out_subblock_h <= 4
+                per_core_M=1,  # M / TILE_HEIGHT / Grid_Size (dynamic based on seqlen)
+                per_core_N=2,  # N / TILE_WIDTH / Grid_Size
+                mcast_in0=True,
+                fused_activation=None,
+                fuse_batch=True,
             )
 
             self.model_config["PREFILL_MLP_W1_PRG_CONFIG"] = ttnn.MatmulMultiCoreReuseMultiCastProgramConfig(
@@ -172,7 +185,6 @@ class TtModelArgs:
                 fused_activation=None,
                 fuse_batch=False,
             )
-            # FIXME: This configuration avoids di/dt non-deterministic hangs. Issue #11354
             self.model_config[
                 "PREFILL_MLP_W1_PRG_CONFIG_128"
             ] = lambda seq_len: ttnn.MatmulMultiCoreReuseMultiCast1DProgramConfig(
@@ -186,7 +198,6 @@ class TtModelArgs:
                 fused_activation=ttnn.UnaryOpType.SILU,
                 fuse_batch=False,
             )
-            # FIXME: This configuration avoids di/dt non-deterministic hangs. Issue #11354
             self.model_config[
                 "PREFILL_MLP_W3_PRG_CONFIG_128"
             ] = lambda seq_len: ttnn.MatmulMultiCoreReuseMultiCast1DProgramConfig(
@@ -200,20 +211,35 @@ class TtModelArgs:
                 fused_activation=None,
                 fuse_batch=False,
             )
-            # FIXME: This configuration avoids di/dt non-deterministic hangs. Issue #11354
-            self.model_config[
-                "PREFILL_MLP_W2_PRG_CONFIG_128"
-            ] = lambda seq_len: ttnn.MatmulMultiCoreReuseMultiCast1DProgramConfig(
-                compute_with_storage_grid_size=(8, 8),
-                in0_block_w=1,  # how much inner dim you take each time
-                out_subblock_h=1,  # Must be divisible by per_core_M
-                out_subblock_w=1,  # Must be divisible by per_core_N, out_subblock_w * out_subblock_h <= 4
-                per_core_M=seq_len // 32,  # M / TILE_HEIGHT / Grid_Size (dynamic based on seqlen)
-                per_core_N=2,  # 4096 / 32 / 64 cores = 2.86 -> 4 (32 cores) # N / TILE_WIDTH / Grid_Size
-                mcast_in0=True,
-                fused_activation=None,
-                fuse_batch=False,
-            )
+            if os.getenv("DI_DT_WORKAROUND") == "1":
+                self.model_config[
+                    "PREFILL_MLP_W2_PRG_CONFIG_128"
+                ] = lambda seq_len: ttnn.MatmulMultiCoreReuseMultiCast1DProgramConfig(
+                    compute_with_storage_grid_size=(8, 8),
+                    in0_block_w=1,  # how much inner dim you take each time
+                    out_subblock_h=1,  # Must be divisible by per_core_M
+                    out_subblock_w=1,  # Must be divisible by per_core_N, out_subblock_w * out_subblock_h <= 4
+                    per_core_M=seq_len // 32,  # M / TILE_HEIGHT / Grid_Size (dynamic based on seqlen)
+                    per_core_N=2,  # 4096 / 32 / 64 cores = 2.86 -> 4 (32 cores) # N / TILE_WIDTH / Grid_Size
+                    mcast_in0=True,
+                    fused_activation=None,
+                    fuse_batch=False,
+                )
+            else:
+                self.model_config[
+                    "PREFILL_MLP_W2_PRG_CONFIG_128"
+                ] = lambda seq_len: ttnn.MatmulMultiCoreReuseMultiCast1DProgramConfig(
+                    compute_with_storage_grid_size=(8, 8),
+                    in0_block_w=4,  # how much inner dim you take each time
+                    out_subblock_h=1,  # Must be divisible by per_core_M
+                    out_subblock_w=2,  # Must be divisible by per_core_N, out_subblock_w * out_subblock_h <= 4
+                    per_core_M=seq_len // 32,  # M / TILE_HEIGHT / Grid_Size (dynamic based on seqlen)
+                    per_core_N=2,  # 4096 / 32 / 64 cores = 2.86 -> 4 (32 cores) # N / TILE_WIDTH / Grid_Size
+                    mcast_in0=True,
+                    fused_activation=None,
+                    fuse_batch=False,
+                )
+
             self.model_config["WO_PREFILL_PROGCFG"] = lambda seq_len: ttnn.MatmulMultiCoreReuseMultiCastProgramConfig(
                 compute_with_storage_grid_size=(8, 8),
                 in0_block_w=1,  # how much inner dim you take each time
@@ -242,18 +268,30 @@ class TtModelArgs:
                 fuse_batch=seq_len <= 2048,
             )
 
-            # FIXME: This configuration avoids di/dt non-deterministic hangs. Issue #11354
-            self.model_config["OUTPUT_MM_PROGCFG"] = ttnn.MatmulMultiCoreReuseMultiCast1DProgramConfig(
-                compute_with_storage_grid_size=(7, 8),
-                in0_block_w=1,
-                per_core_M=1,
-                per_core_N=72,  # vocab size = 128k = 4008 tiles. 4008/56cores = 72
-                out_subblock_h=1,
-                out_subblock_w=1,
-                fuse_batch=True,
-                fused_activation=None,
-                mcast_in0=True,
-            )
+            if os.getenv("DI_DT_WORKAROUND") == "1":
+                self.model_config["OUTPUT_MM_PROGCFG"] = ttnn.MatmulMultiCoreReuseMultiCast1DProgramConfig(
+                    compute_with_storage_grid_size=(7, 8),
+                    in0_block_w=1,
+                    per_core_M=1,
+                    per_core_N=72,  # vocab size = 128k = 4008 tiles. 4008/56cores = 72
+                    out_subblock_h=1,
+                    out_subblock_w=1,
+                    fuse_batch=True,
+                    fused_activation=None,
+                    mcast_in0=True,
+                )
+            else:
+                self.model_config["OUTPUT_MM_PROGCFG"] = ttnn.MatmulMultiCoreReuseMultiCast1DProgramConfig(
+                    compute_with_storage_grid_size=(8, 8),
+                    in0_block_w=2,
+                    per_core_M=1,
+                    per_core_N=72,  # vocab size = 128k = 4008 tiles. 4008/56cores = 72
+                    out_subblock_h=1,
+                    out_subblock_w=4,
+                    fuse_batch=True,
+                    fused_activation=None,
+                    mcast_in0=True,
+                )
 
             self.model_config["KV_PREFILL_MEM_CFG"] = lambda seq_len: ttnn.create_sharded_memory_config(
                 (seq_len // 8, self.head_dim),
@@ -264,7 +302,7 @@ class TtModelArgs:
             )
 
             self.model_config["MLP_KERNEL_CONFIG"] = ttnn.WormholeComputeKernelConfig(
-                math_fidelity=ttnn.MathFidelity.LoFi,
+                math_fidelity=ttnn.MathFidelity.HiFi2,  # DRAM-bound so keep full precision here
                 math_approx_mode=True,
                 fp32_dest_acc_en=False,
                 packer_l1_acc=True,
@@ -277,7 +315,7 @@ class TtModelArgs:
             )
 
             self.model_config["SDPA_DECODE_COMPUTE_PROGCFG"] = ttnn.WormholeComputeKernelConfig(
-                math_fidelity=ttnn.MathFidelity.HiFi4,
+                math_fidelity=ttnn.MathFidelity.HiFi2,
                 math_approx_mode=False,
                 fp32_dest_acc_en=False,
                 packer_l1_acc=False,

--- a/models/demos/wormhole/llama31_8b/tt/model_config.py
+++ b/models/demos/wormhole/llama31_8b/tt/model_config.py
@@ -5,11 +5,7 @@
 import os
 import ttnn
 from pathlib import Path
-from models.utility_functions import is_wormhole_b0
-from conftest import is_ci_env
 from loguru import logger
-import tarfile
-import urllib.request
 
 
 class TtModelArgs:
@@ -95,8 +91,8 @@ class TtModelArgs:
 
         self.instruct = instruct
 
-        # CI does not set DI_DT_WORKAROUND but we want to apply it there too for now
-        self.di_dt_workaround = os.getenv("DI_DT_WORKAROUND") == "1" or is_ci_env()
+        # Enable workarounds by default until di/dt issues are fixed
+        self.di_dt_workaround = os.getenv("DISABLE_DI_DT_WORKAROUND") != "1"
 
         DRAM_MEMCFG = ttnn.DRAM_MEMORY_CONFIG
         L1_MEMCFG = ttnn.L1_MEMORY_CONFIG


### PR DESCRIPTION
### Ticket
[Link to Github Issue](https://github.com/tenstorrent/tt-metal/issues/12328)

### Problem description
Make llama 3.1 8b great

### What's changed
* Moved dI/dT workarounds and added a DISABLE_DI_DT_WORKAROUND=1 flag to run without them
* Optimized matmul kernels (thanks `models/perf/perf-report.py`!)
* Forced untilize on device
* On-device perf up to 21 t/s/u, e2e perf up to 17 t/s/u

### Checklist
- [x] [Post commit CI passes](https://github.com/tenstorrent/tt-metal/actions/runs/10793538317)
- [x] Blackhole Post commit (not applicable)
- [x] Model regression CI testing passes ([perf](https://github.com/tenstorrent/tt-metal/actions/runs/10793572307) [demo](https://github.com/tenstorrent/tt-metal/actions/runs/10793576678))
- [x] New/Existing tests provide coverage for changes
