### PR TITLE
Updated to handle int overflow in create_device_tensor

### DIFF
--- a/tests/ttnn/unit_tests/test_as_tensor.py
+++ b/tests/ttnn/unit_tests/test_as_tensor.py
@@ -21,6 +21,20 @@ def test_as_tensor(device, height, width):
     assert torch.allclose(torch_input_tensor, torch_output_tensor)
 
 
+@pytest.mark.parametrize("height", [2**15])
+@pytest.mark.parametrize("width", [2**16])
+def test_allocate_large_tensor(device, height, width):
+    memory_config = ttnn.DRAM_MEMORY_CONFIG
+
+    reshard_out = ttnn.allocate_tensor_on_device(
+        ttnn.Shape([1, 1, height, width]),
+        ttnn.bfloat16,
+        ttnn.TILE_LAYOUT,
+        device,
+        memory_config,
+    )
+
+
 @pytest.mark.parametrize("height", [32])
 @pytest.mark.parametrize("width", [32])
 def test_as_tensor_with_device_tilizer(device, height, width):

--- a/tt_metal/detail/util.hpp
+++ b/tt_metal/detail/util.hpp
@@ -7,6 +7,7 @@
 #include "tt_metal/common/tt_backend_api_types.hpp"
 #include "tt_metal/hostdevcommon/common_values.hpp"
 #include "tt_metal/impl/kernels/data_types.hpp"
+#include "llrt/hal.hpp"
 
 namespace tt::tt_metal::detail{
 
@@ -24,10 +25,10 @@ namespace tt::tt_metal::detail{
         return tt::tile_size(data_format);
     }
 
-    inline uint32_t SizeBytesPerBank(uint32_t size_bytes, uint32_t page_size_bytes, uint32_t num_banks, uint32_t alignment_bytes) {
+    inline DeviceAddr SizeBytesPerBank(DeviceAddr size_bytes, DeviceAddr page_size_bytes, uint32_t num_banks, uint32_t alignment_bytes) {
         TT_ASSERT(page_size_bytes > 0 and size_bytes % page_size_bytes == 0, "Page size {} should be divisible by buffer size {}", page_size_bytes, size_bytes);
-        uint32_t num_pages = size_bytes / page_size_bytes;
-        int num_equally_distributed_pages = num_pages == 1 ? 1 : 1 + ((num_pages - 1) / num_banks);
+        DeviceAddr num_pages = size_bytes / page_size_bytes;
+        DeviceAddr num_equally_distributed_pages = num_pages == 1 ? 1 : 1 + ((num_pages - 1) / num_banks);
         return num_equally_distributed_pages * round_up(page_size_bytes, alignment_bytes);
     }
 

--- a/tt_metal/impl/allocator/algorithms/allocator_algorithm.hpp
+++ b/tt_metal/impl/allocator/algorithms/allocator_algorithm.hpp
@@ -10,6 +10,7 @@
 #include "hostdevcommon/common_values.hpp"
 
 #include "tt_metal/impl/allocator/allocator_types.hpp"
+#include "llrt/hal.hpp"
 
 namespace tt {
 
@@ -19,21 +20,21 @@ namespace allocator {
 
 class Algorithm {
    public:
-    Algorithm(uint64_t max_size_bytes, uint64_t offset_bytes, uint64_t min_allocation_size, uint64_t alignment)
+    Algorithm(DeviceAddr max_size_bytes, DeviceAddr offset_bytes, DeviceAddr min_allocation_size, DeviceAddr alignment)
         : max_size_bytes_(max_size_bytes), offset_bytes_(offset_bytes), min_allocation_size_(min_allocation_size), alignment_(alignment), lowest_occupied_address_(std::nullopt) {
         TT_ASSERT(offset_bytes % this->alignment_ == 0, "Offset {} should be {} B aligned", offset_bytes, this->alignment_);
     }
 
     virtual ~Algorithm() {}
 
-    uint64_t align(uint64_t address) const {
-        uint64_t factor = (address + alignment_ - 1) / alignment_;
+    DeviceAddr align(DeviceAddr address) const {
+        DeviceAddr factor = (address + alignment_ - 1) / alignment_;
         return factor * alignment_;
     }
 
-    uint64_t max_size_bytes() const { return max_size_bytes_; }
+    DeviceAddr max_size_bytes() const { return max_size_bytes_; }
 
-    std::optional<uint64_t> lowest_occupied_address() const {
+    std::optional<DeviceAddr> lowest_occupied_address() const {
         if (not this->lowest_occupied_address_.has_value()) {
             return this->lowest_occupied_address_;
         }
@@ -42,14 +43,14 @@ class Algorithm {
 
     virtual void init() = 0;
 
-    virtual std::vector<std::pair<uint64_t, uint64_t>> available_addresses(uint64_t size_bytes) const = 0;
+    virtual std::vector<std::pair<DeviceAddr, DeviceAddr>> available_addresses(DeviceAddr size_bytes) const = 0;
 
     // bottom_up=true indicates that allocation grows from address 0
-    virtual std::optional<uint64_t> allocate(uint64_t size_bytes, bool bottom_up=true, uint64_t address_limit=0) = 0;
+    virtual std::optional<DeviceAddr> allocate(DeviceAddr size_bytes, bool bottom_up=true, DeviceAddr address_limit=0) = 0;
 
-    virtual std::optional<uint64_t> allocate_at_address(uint64_t absolute_start_address, uint64_t size_bytes) = 0;
+    virtual std::optional<DeviceAddr> allocate_at_address(DeviceAddr absolute_start_address, DeviceAddr size_bytes) = 0;
 
-    virtual void deallocate(uint64_t absolute_address) = 0;
+    virtual void deallocate(DeviceAddr absolute_address) = 0;
 
     virtual void clear() = 0;
 
@@ -58,11 +59,11 @@ class Algorithm {
     virtual void dump_blocks(std::ofstream &out) const = 0;
 
    protected:
-    uint64_t max_size_bytes_;
-    uint64_t offset_bytes_;
-    uint64_t min_allocation_size_;
-    uint64_t alignment_;
-    std::optional<uint64_t> lowest_occupied_address_;
+    DeviceAddr max_size_bytes_;
+    DeviceAddr offset_bytes_;
+    DeviceAddr min_allocation_size_;
+    DeviceAddr alignment_;
+    std::optional<DeviceAddr> lowest_occupied_address_;
 };
 
 }  // namespace allocator

--- a/tt_metal/impl/allocator/algorithms/free_list.cpp
+++ b/tt_metal/impl/allocator/algorithms/free_list.cpp
@@ -15,7 +15,7 @@ namespace tt_metal {
 
 namespace allocator {
 
-FreeList::FreeList(uint64_t max_size_bytes, uint64_t offset_bytes, uint64_t min_allocation_size, uint64_t alignment, FreeList::SearchPolicy search_policy)
+FreeList::FreeList(DeviceAddr max_size_bytes, DeviceAddr offset_bytes, DeviceAddr min_allocation_size, DeviceAddr alignment, FreeList::SearchPolicy search_policy)
     : search_policy_(search_policy), Algorithm(max_size_bytes, offset_bytes, min_allocation_size, alignment) {
     this->init();
 }
@@ -32,14 +32,14 @@ bool FreeList::is_allocated(const boost::local_shared_ptr<Block> block) const {
     return block->prev_free == nullptr and block->next_free == nullptr and block != this->free_block_head_ and block != this->free_block_tail_;
 }
 
-std::vector<std::pair<uint64_t, uint64_t>> FreeList::available_addresses(uint64_t size_bytes) const {
-    uint64_t alloc_size = size_bytes < this->min_allocation_size_ ? this->min_allocation_size_ : size_bytes;
+std::vector<std::pair<DeviceAddr, DeviceAddr>> FreeList::available_addresses(DeviceAddr size_bytes) const {
+    DeviceAddr alloc_size = size_bytes < this->min_allocation_size_ ? this->min_allocation_size_ : size_bytes;
     alloc_size = this->align(alloc_size);
-    std::vector<std::pair<uint64_t, uint64_t>> addresses;
+    std::vector<std::pair<DeviceAddr, DeviceAddr>> addresses;
     boost::local_shared_ptr<FreeList::Block> curr_block = this->free_block_head_;
     while (curr_block != nullptr) {
         if (curr_block->size >= alloc_size) {
-            uint64_t end_range = (curr_block->address + curr_block->size) - alloc_size;
+            DeviceAddr end_range = (curr_block->address + curr_block->size) - alloc_size;
             addresses.push_back({curr_block->address, end_range});
         }
         curr_block = curr_block->next_free;
@@ -47,7 +47,7 @@ std::vector<std::pair<uint64_t, uint64_t>> FreeList::available_addresses(uint64_
     return addresses;
 }
 
-boost::local_shared_ptr<FreeList::Block> FreeList::search_best(uint64_t size_bytes, bool bottom_up) {
+boost::local_shared_ptr<FreeList::Block> FreeList::search_best(DeviceAddr size_bytes, bool bottom_up) {
     boost::local_shared_ptr<FreeList::Block> best_block = nullptr;
     boost::local_shared_ptr<FreeList::Block> curr_block = bottom_up ? this->free_block_head_ : this->free_block_tail_;
     while (curr_block != nullptr) {
@@ -65,7 +65,7 @@ boost::local_shared_ptr<FreeList::Block> FreeList::search_best(uint64_t size_byt
     return best_block;
 }
 
-boost::local_shared_ptr<FreeList::Block> FreeList::search_first(uint64_t size_bytes, bool bottom_up) {
+boost::local_shared_ptr<FreeList::Block> FreeList::search_first(DeviceAddr size_bytes, bool bottom_up) {
     boost::local_shared_ptr<FreeList::Block> curr_block = bottom_up ? this->free_block_head_ : this->free_block_tail_;
     boost::local_shared_ptr<FreeList::Block> first_fit_block = nullptr;
     while (curr_block != nullptr) {
@@ -79,7 +79,7 @@ boost::local_shared_ptr<FreeList::Block> FreeList::search_first(uint64_t size_by
     return first_fit_block;
 }
 
-boost::local_shared_ptr<FreeList::Block> FreeList::search(uint64_t size_bytes, bool bottom_up) {
+boost::local_shared_ptr<FreeList::Block> FreeList::search(DeviceAddr size_bytes, bool bottom_up) {
     switch (this->search_policy_) {
         case FreeList::SearchPolicy::BEST:
             return search_best(size_bytes, bottom_up);
@@ -153,7 +153,7 @@ void FreeList::update_right_aligned_allocated_block_connections(boost::local_sha
 }
 
 // Offset marks the start of the allocated block
-boost::local_shared_ptr<FreeList::Block> FreeList::allocate_slice_of_free_block(boost::local_shared_ptr<FreeList::Block> free_block, uint64_t offset, uint64_t size_bytes) {
+boost::local_shared_ptr<FreeList::Block> FreeList::allocate_slice_of_free_block(boost::local_shared_ptr<FreeList::Block> free_block, DeviceAddr offset, DeviceAddr size_bytes) {
     TT_ASSERT(free_block->address + offset + size_bytes <= free_block->address + free_block->size);
 
     // Allocated slice spans the entire space of free_block
@@ -181,8 +181,8 @@ boost::local_shared_ptr<FreeList::Block> FreeList::allocate_slice_of_free_block(
         TT_ASSERT(case_three);
         // Original: | .................... free_block ....................|
         // Result:   | free_block_mod | allocated_block | next_free_block  |
-        uint64_t next_free_block_addr = free_block->address + offset + size_bytes;
-        uint64_t next_free_block_size = (free_block->address + free_block->size) - next_free_block_addr;
+        DeviceAddr next_free_block_addr = free_block->address + offset + size_bytes;
+        DeviceAddr next_free_block_size = (free_block->address + free_block->size) - next_free_block_addr;
         auto next_free_block = boost::make_local_shared<FreeList::Block>(
             next_free_block_addr,
             next_free_block_size,
@@ -215,7 +215,7 @@ boost::local_shared_ptr<FreeList::Block> FreeList::allocate_slice_of_free_block(
     return allocated_block;
 }
 
-void FreeList::update_lowest_occupied_address(uint64_t address) {
+void FreeList::update_lowest_occupied_address(DeviceAddr address) {
     if (not this->lowest_occupied_address_.has_value()) {
         this->lowest_occupied_address_ = address;
     } else {
@@ -223,8 +223,8 @@ void FreeList::update_lowest_occupied_address(uint64_t address) {
     }
 }
 
-std::optional<uint64_t> FreeList::allocate(uint64_t size_bytes, bool bottom_up, uint64_t address_limit) {
-    uint64_t alloc_size = size_bytes < this->min_allocation_size_ ? this->min_allocation_size_ : size_bytes;
+std::optional<DeviceAddr> FreeList::allocate(DeviceAddr size_bytes, bool bottom_up, DeviceAddr address_limit) {
+    DeviceAddr alloc_size = size_bytes < this->min_allocation_size_ ? this->min_allocation_size_ : size_bytes;
     alloc_size = this->align(alloc_size);
     auto free_block = search(alloc_size, bottom_up);
 
@@ -233,7 +233,7 @@ std::optional<uint64_t> FreeList::allocate(uint64_t size_bytes, bool bottom_up, 
     }
 
     // offset denotes where allocation starts relative to free_block start
-    uint64_t offset = bottom_up ? 0 : (((free_block->address + free_block->size) - alloc_size) - free_block->address);
+    DeviceAddr offset = bottom_up ? 0 : (((free_block->address + free_block->size) - alloc_size) - free_block->address);
     auto allocated_block = allocate_slice_of_free_block(free_block, offset, alloc_size);
 
     this->update_lowest_occupied_address(allocated_block->address);
@@ -243,11 +243,11 @@ std::optional<uint64_t> FreeList::allocate(uint64_t size_bytes, bool bottom_up, 
     return allocated_block->address + this->offset_bytes_;
 }
 
-std::optional<uint64_t> FreeList::allocate_at_address(uint64_t absolute_start_address, uint64_t size_bytes) {
+std::optional<DeviceAddr> FreeList::allocate_at_address(DeviceAddr absolute_start_address, DeviceAddr size_bytes) {
     TT_ASSERT(absolute_start_address % this->alignment_ == 0, "Requested address " + std::to_string(absolute_start_address) + " should be " + std::to_string(this->alignment_) + "B aligned");
     auto start_address = absolute_start_address - this->offset_bytes_;
     boost::local_shared_ptr<FreeList::Block> curr_block = this->free_block_head_;
-    uint64_t alloc_size = size_bytes < this->min_allocation_size_ ? this->min_allocation_size_ : size_bytes;
+    DeviceAddr alloc_size = size_bytes < this->min_allocation_size_ ? this->min_allocation_size_ : size_bytes;
     alloc_size = this->align(alloc_size);
     // Look for a free block of size at least size_bytes that encompasses start_address
     while (curr_block != nullptr) {
@@ -256,7 +256,7 @@ std::optional<uint64_t> FreeList::allocate_at_address(uint64_t absolute_start_ad
                 allocate_slice_of_free_block(curr_block, /*offset=*/0, alloc_size);
                 break;
             } else if ((start_address > curr_block->address) and ((start_address + alloc_size) <= (curr_block->address + curr_block->size))) {
-                uint64_t start_offset = start_address - curr_block->address;
+                DeviceAddr start_offset = start_address - curr_block->address;
                 allocate_slice_of_free_block(curr_block, start_offset, alloc_size);
                 break;
             }
@@ -271,7 +271,7 @@ std::optional<uint64_t> FreeList::allocate_at_address(uint64_t absolute_start_ad
     return absolute_start_address;
 }
 
-boost::local_shared_ptr<FreeList::Block> FreeList::find_block(uint64_t address) {
+boost::local_shared_ptr<FreeList::Block> FreeList::find_block(DeviceAddr address) {
     boost::local_shared_ptr<Block> block = nullptr;
     boost::local_shared_ptr<Block> curr_block = this->block_head_;
     while (curr_block != nullptr) {
@@ -298,8 +298,8 @@ void FreeList::update_lowest_occupied_address() {
     }
 }
 
-void FreeList::deallocate(uint64_t absolute_address) {
-    uint64_t address = absolute_address - this->offset_bytes_;
+void FreeList::deallocate(DeviceAddr absolute_address) {
+    DeviceAddr address = absolute_address - this->offset_bytes_;
     boost::local_shared_ptr<Block> block_to_free = find_block(address);
     if (block_to_free == nullptr or not this->is_allocated(block_to_free)) {
         return;

--- a/tt_metal/impl/allocator/algorithms/free_list.hpp
+++ b/tt_metal/impl/allocator/algorithms/free_list.hpp
@@ -18,16 +18,16 @@ class FreeList : public Algorithm {
         FIRST = 1
     };
 
-    FreeList(uint64_t max_size_bytes, uint64_t offset_bytes, uint64_t min_allocation_size, uint64_t alignment, SearchPolicy search_policy);
+    FreeList(DeviceAddr max_size_bytes, DeviceAddr offset_bytes, DeviceAddr min_allocation_size, DeviceAddr alignment, SearchPolicy search_policy);
     void init();
 
-    std::vector<std::pair<uint64_t, uint64_t>> available_addresses(uint64_t size_bytes) const;
+    std::vector<std::pair<DeviceAddr, DeviceAddr>> available_addresses(DeviceAddr size_bytes) const;
 
-    std::optional<uint64_t> allocate(uint64_t size_bytes, bool bottom_up=true, uint64_t address_limit=0);
+    std::optional<DeviceAddr> allocate(DeviceAddr size_bytes, bool bottom_up=true, DeviceAddr address_limit=0);
 
-    std::optional<uint64_t> allocate_at_address(uint64_t absolute_start_address, uint64_t size_bytes);
+    std::optional<DeviceAddr> allocate_at_address(DeviceAddr absolute_start_address, DeviceAddr size_bytes);
 
-    void deallocate(uint64_t absolute_address);
+    void deallocate(DeviceAddr absolute_address);
 
     void clear();
 
@@ -37,11 +37,11 @@ class FreeList : public Algorithm {
 
    private:
     struct Block {
-        Block(uint64_t address, uint64_t size) : address(address), size(size) {}
-        Block(uint64_t address, uint64_t size, boost::local_shared_ptr<Block> prev_block, boost::local_shared_ptr<Block> next_block, boost::local_shared_ptr<Block> prev_free, boost::local_shared_ptr<Block> next_free)
+        Block(DeviceAddr address, DeviceAddr size) : address(address), size(size) {}
+        Block(DeviceAddr address, DeviceAddr size, boost::local_shared_ptr<Block> prev_block, boost::local_shared_ptr<Block> next_block, boost::local_shared_ptr<Block> prev_free, boost::local_shared_ptr<Block> next_free)
               : address(address), size(size), prev_block(prev_block), next_block(next_block), prev_free(prev_free), next_free(next_free) {}
-        uint64_t address;
-        uint64_t size;
+        DeviceAddr address;
+        DeviceAddr size;
         boost::local_shared_ptr<Block> prev_block = nullptr;
         boost::local_shared_ptr<Block> next_block = nullptr;
         boost::local_shared_ptr<Block> prev_free = nullptr;
@@ -52,11 +52,11 @@ class FreeList : public Algorithm {
 
     bool is_allocated(const boost::local_shared_ptr<Block> block) const;
 
-    boost::local_shared_ptr<Block> search_best(uint64_t size_bytes, bool bottom_up);
+    boost::local_shared_ptr<Block> search_best(DeviceAddr size_bytes, bool bottom_up);
 
-    boost::local_shared_ptr<Block> search_first(uint64_t size_bytes, bool bottom_up);
+    boost::local_shared_ptr<Block> search_first(DeviceAddr size_bytes, bool bottom_up);
 
-    boost::local_shared_ptr<Block> search(uint64_t size_bytes, bool bottom_up);
+    boost::local_shared_ptr<Block> search(DeviceAddr size_bytes, bool bottom_up);
 
     void allocate_entire_free_block(boost::local_shared_ptr<Block> free_block_to_allocate);
 
@@ -64,13 +64,13 @@ class FreeList : public Algorithm {
 
     void update_right_aligned_allocated_block_connections(boost::local_shared_ptr<Block> free_block, boost::local_shared_ptr<Block> allocated_block);
 
-    boost::local_shared_ptr<Block> allocate_slice_of_free_block(boost::local_shared_ptr<Block> free_block, uint64_t offset, uint64_t size_bytes);
+    boost::local_shared_ptr<Block> allocate_slice_of_free_block(boost::local_shared_ptr<Block> free_block, DeviceAddr offset, DeviceAddr size_bytes);
 
-    boost::local_shared_ptr<Block> find_block(uint64_t address);
+    boost::local_shared_ptr<Block> find_block(DeviceAddr address);
 
     void update_lowest_occupied_address();
 
-    void update_lowest_occupied_address(uint64_t address);
+    void update_lowest_occupied_address(DeviceAddr address);
 
     SearchPolicy search_policy_;
     boost::local_shared_ptr<Block> block_head_;

--- a/tt_metal/impl/allocator/allocator.cpp
+++ b/tt_metal/impl/allocator/allocator.cpp
@@ -27,7 +27,7 @@ static char const *get_memory_pool_name(BufferType buffer_type) {
 }
 #endif
 
-void BankManager::init_allocator(uint64_t size_bytes, uint32_t alignment_bytes, uint64_t offset) {
+void BankManager::init_allocator(DeviceAddr size_bytes, uint32_t alignment_bytes, DeviceAddr offset) {
     this->allocator_ =
         std::make_unique<FreeList>(size_bytes, offset, alignment_bytes, alignment_bytes, FreeList::SearchPolicy::FIRST);
 }
@@ -53,9 +53,9 @@ void validate_num_banks(uint32_t num_banks, const BufferType &buffer_type) {
 BankManager::BankManager(
     const BufferType &buffer_type,
     const std::vector<int64_t> &bank_offsets,
-    uint64_t size_bytes,
+    DeviceAddr size_bytes,
     uint32_t alignment_bytes,
-    uint64_t alloc_offset) :
+    DeviceAddr alloc_offset) :
     buffer_type_(buffer_type), alignment_bytes_(alignment_bytes) {
     unsigned int bank_id = 0;
     for (const auto bank_offset : bank_offsets) {
@@ -70,10 +70,10 @@ BankManager::BankManager(
 BankManager::BankManager(
     const BufferType &buffer_type,
     const std::unordered_map<uint32_t, int64_t> &bank_id_to_bank_offset,
-    uint64_t size_bytes,
-    uint64_t interleaved_address_limit,
+    DeviceAddr size_bytes,
+    DeviceAddr interleaved_address_limit,
     uint32_t alignment_bytes,
-    uint64_t alloc_offset) :
+    DeviceAddr alloc_offset) :
     buffer_type_(buffer_type),
     bank_id_to_bank_offset_(bank_id_to_bank_offset),
     interleaved_address_limit_(interleaved_address_limit),
@@ -84,13 +84,13 @@ BankManager::BankManager(
 
 uint32_t BankManager::num_banks() const { return this->bank_id_to_bank_offset_.size(); }
 
-uint32_t BankManager::bank_size() const {
+DeviceAddr BankManager::bank_size() const {
     TT_ASSERT(bool(this->allocator_), "Allocator not initialized!");
-    uint64_t max_size_bytes_u64 = this->allocator_->max_size_bytes();
-    if (max_size_bytes_u64 > std::numeric_limits<uint32_t>::max()) {
-        TT_THROW("Bank size {} overflows uint32_t", max_size_bytes_u64);
+    DeviceAddr max_size_bytes_u64 = this->allocator_->max_size_bytes();
+    if (max_size_bytes_u64 > std::numeric_limits<DeviceAddr>::max()) {
+        TT_THROW("Bank size {} overflows DeviceAddr", max_size_bytes_u64);
     }
-    uint32_t max_size_bytes = (uint32_t)max_size_bytes_u64;
+    DeviceAddr max_size_bytes = (DeviceAddr)max_size_bytes_u64;
     return max_size_bytes;
 }
 
@@ -108,8 +108,8 @@ void BankManager::validate_bank_id(uint32_t bank_id) const {
 }
 
 uint64_t BankManager::allocate_buffer(
-    uint32_t size,
-    uint32_t page_size,
+    DeviceAddr size,
+    DeviceAddr page_size,
     bool bottom_up,
     CoreCoord compute_grid_size,
     std::optional<uint32_t> num_shards) {
@@ -123,8 +123,8 @@ uint64_t BankManager::allocate_buffer(
             fmt::format("Expected number of shards {} to be less than or equal to total number of L1 banks {} in compute cores", num_shards.value(), num_compute_banks));
         num_banks = num_shards.value();
     }
-    uint32_t size_per_bank = tt::tt_metal::detail::SizeBytesPerBank(size, page_size, num_banks, this->alignment_bytes_);
-    uint64_t address_limit = 0;
+    DeviceAddr size_per_bank = tt::tt_metal::detail::SizeBytesPerBank(size, page_size, num_banks, this->alignment_bytes_);
+    DeviceAddr address_limit = 0;
     if (!is_sharded and this->buffer_type_ == BufferType::L1) {
         address_limit = this->interleaved_address_limit_;
         TT_FATAL(address_limit > 0);
@@ -144,10 +144,10 @@ uint64_t BankManager::allocate_buffer(
     return address.value();
 }
 
-void BankManager::deallocate_buffer(uint64_t address) { this->allocator_->deallocate(address); }
+void BankManager::deallocate_buffer(DeviceAddr address) { this->allocator_->deallocate(address); }
 
 void BankManager::deallocate_all() {
-    for (uint64_t addr : this->allocated_buffers_) {
+    for (DeviceAddr addr : this->allocated_buffers_) {
         this->allocator_->deallocate(addr);
     }
 }
@@ -174,14 +174,14 @@ BankManager &&BankManager::operator=(BankManager &&that) {
     return std::move(*this);
 }
 
-std::optional<uint64_t> BankManager::lowest_occupied_address(uint32_t bank_id) const {
+std::optional<DeviceAddr> BankManager::lowest_occupied_address(uint32_t bank_id) const {
     if (not this->allocator_)
         return std::nullopt;
     auto lowest_address = this->allocator_->lowest_occupied_address();
     if (not lowest_address.has_value()) {
         return lowest_address;
     }
-    auto adjusted_abs_addr = lowest_address.value() + this->bank_offset(bank_id);
+    DeviceAddr adjusted_abs_addr = lowest_address.value() + this->bank_offset(bank_id);
     return adjusted_abs_addr;
 }
 
@@ -196,9 +196,9 @@ void BankManager::dump_blocks(std::ofstream &out) const {
 
 void init_one_bank_per_channel(Allocator &allocator, const AllocatorConfig &alloc_config) {
     // Space up to DRAM_UNRESERVED_BASE is reserved for DRAM write barrier
-    uint64_t offset_bytes = static_cast<uint64_t>(DRAM_UNRESERVED_BASE);
+    DeviceAddr offset_bytes = static_cast<DeviceAddr>(DRAM_UNRESERVED_BASE);
     // DRAM bank is between unreserved start and trace_region start: UNRESERVED | DRAM BANK | TRACE REGION
-    uint32_t dram_bank_size = alloc_config.dram_bank_size - DRAM_UNRESERVED_BASE - alloc_config.trace_region_size;
+    DeviceAddr dram_bank_size = alloc_config.dram_bank_size - DRAM_UNRESERVED_BASE - alloc_config.trace_region_size;
     std::vector<int64_t> bank_offsets(alloc_config.num_dram_channels);
     for (uint32_t channel_id = 0; channel_id < alloc_config.num_dram_channels; channel_id++) {
         bank_offsets.at(channel_id) = static_cast<int32_t>(alloc_config.dram_bank_offsets.at(channel_id));
@@ -231,8 +231,8 @@ void init_one_bank_per_l1(Allocator &allocator, const AllocatorConfig &alloc_con
     TT_ASSERT(alloc_config.l1_small_size == 0);
     uint32_t num_l1_banks = alloc_config.worker_grid_size.y * alloc_config.worker_grid_size.x;
     // Space up to L1_UNRESERVED_BASE is reserved for risc binaries, kernel args, debug and perf monitoring tools
-    uint64_t offset_bytes = static_cast<uint64_t>(L1_UNRESERVED_BASE);
-    uint32_t l1_bank_size = alloc_config.worker_l1_size - L1_UNRESERVED_BASE;
+    DeviceAddr offset_bytes = static_cast<DeviceAddr>(L1_UNRESERVED_BASE);
+    DeviceAddr l1_bank_size = alloc_config.worker_l1_size - L1_UNRESERVED_BASE;
     std::vector<int64_t> bank_offsets(num_l1_banks, 0);
     allocator.l1_manager = BankManager(BufferType::L1, bank_offsets, l1_bank_size, ALLOCATOR_ALIGNMENT, offset_bytes);
 
@@ -260,7 +260,7 @@ uint32_t num_banks(const Allocator &allocator, const BufferType &buffer_type) {
     return 0;
 }
 
-uint32_t bank_size(const Allocator &allocator, const BufferType &buffer_type) {
+DeviceAddr bank_size(const Allocator &allocator, const BufferType &buffer_type) {
     switch (buffer_type) {
         case BufferType::DRAM: return allocator.dram_manager.bank_size();
         case BufferType::L1: return allocator.l1_manager.bank_size();
@@ -337,16 +337,16 @@ void dump_memory_blocks(const Allocator &allocator, const BufferType &buffer_typ
     }
 }
 
-std::optional<uint64_t> lowest_occupied_l1_address(const Allocator &allocator, uint32_t bank_id) {
+std::optional<DeviceAddr> lowest_occupied_l1_address(const Allocator &allocator, uint32_t bank_id) {
     // l1_manager always sits below l1_small_manager in the address space, so there is no need to check l1_small_manager
     return allocator.l1_manager.lowest_occupied_address(bank_id);
 }
 
-uint64_t base_alloc(
+DeviceAddr base_alloc(
     const AllocatorConfig &config,
     BankManager &bank_manager,
-    uint64_t size,
-    uint64_t page_size,
+    DeviceAddr size,
+    DeviceAddr page_size,
     bool bottom_up,
     std::optional<uint32_t> num_shards) {
     return bank_manager.allocate_buffer(size, page_size, bottom_up, config.compute_grid_size, num_shards);
@@ -358,8 +358,8 @@ void enable_allocs(Allocator &allocator) { allocator.disabled_allocs = false; }
 
 uint64_t allocate_buffer(
     Allocator &allocator,
-    uint32_t size,
-    uint32_t page_size,
+    DeviceAddr size,
+    DeviceAddr page_size,
     const BufferType &buffer_type,
     bool bottom_up,
     std::optional<uint32_t> num_shards) {
@@ -387,7 +387,7 @@ uint64_t allocate_buffer(
     return address;
 }
 
-void deallocate_buffer(Allocator &allocator, uint64_t address, const BufferType &buffer_type) {
+void deallocate_buffer(Allocator &allocator, DeviceAddr address, const BufferType &buffer_type) {
     switch (buffer_type) {
         case BufferType::DRAM: allocator.dram_manager.deallocate_buffer(address); break;
         case BufferType::L1: allocator.l1_manager.deallocate_buffer(address); break;

--- a/tt_metal/impl/allocator/allocator.hpp
+++ b/tt_metal/impl/allocator/allocator.hpp
@@ -13,6 +13,7 @@
 #include "tt_metal/common/assert.hpp"
 #include "tt_metal/common/core_coord.h"
 #include "tt_metal/impl/allocator/algorithms/allocator_algorithm.hpp"
+#include "llrt/hal.hpp"
 
 namespace tt {
 
@@ -28,44 +29,44 @@ class BankManager {
    public:
     BankManager() {}
 
-    BankManager(const BufferType &buffer_type, const std::vector<int64_t> &bank_descriptors, uint64_t size_bytes, uint32_t alignment_bytes, uint64_t alloc_offset=0);
-    BankManager(const BufferType &buffer_type, const std::unordered_map<uint32_t, int64_t> &bank_id_to_descriptor, uint64_t size_bytes, uint64_t interleaved_address_limit, uint32_t alignment_bytes, uint64_t alloc_offset=0);
+    BankManager(const BufferType &buffer_type, const std::vector<int64_t> &bank_descriptors, DeviceAddr size_bytes, uint32_t alignment_bytes, DeviceAddr alloc_offset=0);
+    BankManager(const BufferType &buffer_type, const std::unordered_map<uint32_t, int64_t> &bank_id_to_descriptor, DeviceAddr size_bytes, DeviceAddr interleaved_address_limit, uint32_t alignment_bytes, DeviceAddr alloc_offset=0);
     BankManager&& operator=(BankManager&& that);
     ~BankManager();
     uint32_t num_banks() const;
 
-    uint32_t bank_size() const;
+    DeviceAddr bank_size() const;
 
     int64_t bank_offset(uint32_t bank_id) const;
 
-    uint64_t allocate_buffer(uint32_t size, uint32_t page_size, bool bottom_up, CoreCoord compute_grid_size, std::optional<uint32_t> num_shards);
+    DeviceAddr allocate_buffer(DeviceAddr size, DeviceAddr page_size, bool bottom_up, CoreCoord compute_grid_size, std::optional<uint32_t> num_shards);
 
-    void deallocate_buffer(uint64_t address);
+    void deallocate_buffer(DeviceAddr address);
     void deallocate_all();
 
     void clear();
 
-    std::optional<uint64_t> lowest_occupied_address(uint32_t bank_id) const;
+    std::optional<DeviceAddr> lowest_occupied_address(uint32_t bank_id) const;
 
     Statistics get_statistics() const;
 
     void dump_blocks(std::ofstream &out) const;
 
    private:
-    void deallocate_buffer_(uint64_t address);
+    void deallocate_buffer_(DeviceAddr address);
 
     // Types of buffers allocated in the banks
     BufferType buffer_type_;
-    std::unordered_set<uint64_t> allocated_buffers_;
+    std::unordered_set<DeviceAddr> allocated_buffers_;
     // This is to store offsets for any banks that share a core or node (dram in wh/storage core), so we can view all banks using only bank_id
     // Set to 0 for cores/nodes with only 1 bank
     std::unordered_map<uint32_t, int64_t> bank_id_to_bank_offset_;
     std::unique_ptr<Algorithm> allocator_;
-    uint64_t interleaved_address_limit_;
+    DeviceAddr interleaved_address_limit_;
     uint32_t alignment_bytes_;
     void validate_bank_id(uint32_t bank_id) const;
 
-    void init_allocator(uint64_t size_bytes, uint32_t alignment_bytes, uint64_t offset);
+    void init_allocator(DeviceAddr size_bytes, uint32_t alignment_bytes, DeviceAddr offset);
 };
 
 // Functions used to initiate allocator and allocate buffers
@@ -75,7 +76,7 @@ void init_one_bank_per_l1(Allocator &allocator, const AllocatorConfig &alloc_con
 
 uint32_t num_banks(const Allocator &allocator, const BufferType &buffer_type);
 
-uint32_t bank_size(const Allocator &allocator, const BufferType &buffer_type);
+DeviceAddr bank_size(const Allocator &allocator, const BufferType &buffer_type);
 
 uint32_t dram_channel_from_bank_id(const Allocator &allocator, uint32_t bank_id);
 
@@ -92,17 +93,17 @@ Statistics get_statistics(const Allocator &allocator, const BufferType &buffer_t
 
 void dump_memory_blocks(const Allocator &allocator, const BufferType &buffer_type, std::ofstream &out);
 
-std::optional<uint64_t> lowest_occupied_l1_address(const Allocator &allocator, uint32_t bank_id);
+std::optional<DeviceAddr> lowest_occupied_l1_address(const Allocator &allocator, uint32_t bank_id);
 
-uint64_t base_alloc(const AllocatorConfig & config, BankManager &bank_manager, uint64_t size, uint64_t page_size, bool bottom_up, std::optional<uint32_t> num_shards);
+DeviceAddr base_alloc(const AllocatorConfig & config, BankManager &bank_manager, DeviceAddr size, DeviceAddr page_size, bool bottom_up, std::optional<uint32_t> num_shards);
 
-uint64_t allocate_buffer(Allocator &allocator, uint32_t size, uint32_t page_size, const BufferType &buffer_type, bool bottom_up, std::optional<uint32_t> num_shards = std::nullopt);
+DeviceAddr allocate_buffer(Allocator &allocator, DeviceAddr size, DeviceAddr page_size, const BufferType &buffer_type, bool bottom_up, std::optional<uint32_t> num_shards = std::nullopt);
 
 void disable_allocs(Allocator &allocator);
 
 void enable_allocs(Allocator &allocator);
 
-void deallocate_buffer(Allocator &allocator, uint64_t address, const BufferType &buffer_type);
+void deallocate_buffer(Allocator &allocator, DeviceAddr address, const BufferType &buffer_type);
 void deallocate_buffers(Allocator &allocator);
 
 void clear(Allocator &allocatator);

--- a/tt_metal/impl/buffers/buffer.cpp
+++ b/tt_metal/impl/buffers/buffer.cpp
@@ -23,8 +23,8 @@ bool is_sharded(const TensorMemoryLayout &layout) {
 }
 
 void validate_buffer_size_and_page_size(
-    uint64_t size,
-    uint64_t page_size,
+    DeviceAddr size,
+    DeviceAddr page_size,
     const BufferType &buffer_type,
     const TensorMemoryLayout &buffer_layout,
     const std::optional<ShardSpecBuffer>& shard_parameters) {
@@ -115,8 +115,8 @@ inline std::tuple<std::vector<std::vector<uint32_t>>, std::vector<std::array<uin
 
 Buffer::Buffer(
     Device *device,
-    uint64_t size,
-    uint64_t page_size,
+    DeviceAddr size,
+    DeviceAddr page_size,
     const BufferType buffer_type,
     const TensorMemoryLayout buffer_layout,
     const std::optional<ShardSpecBuffer>& shard_parameters,
@@ -305,7 +305,7 @@ CoreCoord Buffer::noc_coordinates(uint32_t bank_id) const {
 
 CoreCoord Buffer::noc_coordinates() const { return this->noc_coordinates(0); }
 
-uint64_t Buffer::page_address(uint32_t bank_id, uint32_t page_index) const {
+DeviceAddr Buffer::page_address(uint32_t bank_id, uint32_t page_index) const {
     auto num_banks = this->device_->num_banks(this->buffer_type_);
     TT_ASSERT(bank_id < num_banks, "Invalid Bank ID: {} exceeds total numbers of banks ({})!", bank_id, num_banks);
     int pages_offset_within_bank = (int)page_index / num_banks;
@@ -313,15 +313,15 @@ uint64_t Buffer::page_address(uint32_t bank_id, uint32_t page_index) const {
     return translate_page_address(offset, bank_id);
 }
 
-uint64_t Buffer::sharded_page_address(uint32_t bank_id, uint32_t page_index) const {
+DeviceAddr Buffer::sharded_page_address(uint32_t bank_id, uint32_t page_index) const {
     TT_ASSERT(is_sharded(this->buffer_layout()));
     int pages_offset_within_bank = page_index % shard_spec().size();
     auto offset = (round_up(this->page_size_, this->alignment()) * pages_offset_within_bank);
     return translate_page_address(offset, bank_id);
 }
 
-uint64_t Buffer::translate_page_address(uint64_t offset, uint32_t bank_id) const {
-    uint64_t base_page_address = this->address_ + this->device_->bank_offset(this->buffer_type_, bank_id);
+DeviceAddr Buffer::translate_page_address(uint64_t offset, uint32_t bank_id) const {
+    DeviceAddr base_page_address = this->address_ + this->device_->bank_offset(this->buffer_type_, bank_id);
     return base_page_address + offset;
 }
 

--- a/tt_metal/impl/buffers/buffer.hpp
+++ b/tt_metal/impl/buffers/buffer.hpp
@@ -20,6 +20,7 @@
 #include "tt_metal/third_party/umd/device/tt_soc_descriptor.h" // For CoreType
 #include "tt_metal/tt_stl/concepts.hpp"
 #include "tt_metal/tt_stl/reflection.hpp"
+#include "llrt/hal.hpp"
 
 namespace tt {
 
@@ -102,7 +103,7 @@ struct ShardSpecBuffer {
         auto height_in_pages = tensor_shard_spec.shape[1] / page_shape[1];
         return {width_in_pages, height_in_pages};
     }
-    uint32_t size() const {
+    DeviceAddr size() const {
         auto shape_in_pages_ = this->shape_in_pages();
         return shape_in_pages_[0] * shape_in_pages_[1];
     }
@@ -110,8 +111,8 @@ struct ShardSpecBuffer {
 
 struct BufferConfig {
     Device *device;
-    uint64_t size;       // Size in bytes
-    uint64_t page_size;  // Size of unit being interleaved. For non-interleaved buffers: size == page_size
+    DeviceAddr size;       // Size in bytes
+    DeviceAddr page_size;  // Size of unit being interleaved. For non-interleaved buffers: size == page_size
     BufferType buffer_type;
     TensorMemoryLayout buffer_layout = TensorMemoryLayout::INTERLEAVED;
     bool allocate = true;
@@ -123,8 +124,8 @@ typedef BufferConfig InterleavedBufferConfig;
 // designator constructor
 struct ShardedBufferConfig {
     Device *device;
-    uint64_t size;       // Size in bytes
-    uint64_t page_size;  // Size of unit being interleaved. For non-interleaved buffers: size == page_size
+    DeviceAddr size;       // Size in bytes
+    DeviceAddr page_size;  // Size of unit being interleaved. For non-interleaved buffers: size == page_size
     BufferType buffer_type = BufferType::L1;
     TensorMemoryLayout buffer_layout = TensorMemoryLayout::HEIGHT_SHARDED;
     ShardSpecBuffer shard_parameters;
@@ -159,8 +160,8 @@ class Buffer {
 
     Buffer(
         Device *device,
-        uint64_t size,
-        uint64_t page_size,
+        DeviceAddr size,
+        DeviceAddr page_size,
         const BufferType buffer_type,
         const TensorMemoryLayout buffer_layout = TensorMemoryLayout::INTERLEAVED,
         const std::optional<ShardSpecBuffer>& shard_parameter = std::nullopt,
@@ -176,19 +177,19 @@ class Buffer {
     virtual ~Buffer();
     Device *device() const { return device_; }
 
-    uint32_t size() const { return static_cast<uint32_t>(size_); }
+    DeviceAddr size() const { return static_cast<DeviceAddr>(size_); }
 
-    void set_size(uint64_t size) { size_ = size; this->buffer_page_mapping_ = nullptr; }
+    void set_size(DeviceAddr size) { size_ = size; this->buffer_page_mapping_ = nullptr; }
     // Returns address of buffer in the first bank
     uint32_t address() const { return static_cast<uint32_t>(address_); }
 
     void set_address(uint64_t addr) { address_ = addr; }
 
-    uint32_t page_size() const { return page_size_; }
+    DeviceAddr page_size() const { return page_size_; }
 
     uint32_t num_pages() const { return this->size() / this->page_size(); }
 
-    void set_page_size(uint64_t page_size) {
+    void set_page_size(DeviceAddr page_size) {
         TT_FATAL(size_ % page_size == 0, "buffer size must be divisible by new page size");
         page_size_ = page_size;
         this->buffer_page_mapping_ = nullptr;
@@ -230,18 +231,18 @@ class Buffer {
     // returns NoC coordinates of first bank buffer is in
     CoreCoord noc_coordinates() const;
 
-    uint64_t page_address(uint32_t bank_id, uint32_t page_index) const;
+    DeviceAddr page_address(uint32_t bank_id, uint32_t page_index) const;
 
     uint32_t alignment() const { return ALLOCATOR_ALIGNMENT; }
 
-    uint32_t aligned_page_size() const { return align(page_size_, this->alignment());}
+    DeviceAddr aligned_page_size() const { return align(page_size_, this->alignment());}
 
-    uint32_t aligned_size() const { return this->num_dev_pages() * this->aligned_page_size(); }
+    DeviceAddr aligned_size() const { return this->num_dev_pages() * this->aligned_page_size(); }
 
     // SHARDED API STARTS HERE
     // TODO: WILL SEPARATE INTO SHARDED BUFFER CLASS
 
-    uint64_t sharded_page_address(uint32_t bank_id, uint32_t page_index) const;
+    DeviceAddr sharded_page_address(uint32_t bank_id, uint32_t page_index) const;
 
     ShardSpecBuffer shard_spec() const {
         TT_ASSERT(is_sharded(this->buffer_layout_), "Buffer not sharded");
@@ -270,12 +271,12 @@ class Buffer {
     virtual void deallocate();
     friend void DeallocateBuffer(Buffer &buffer);
 
-    uint64_t translate_page_address(uint64_t offset, uint32_t bank_id) const;
+    DeviceAddr translate_page_address(uint64_t offset, uint32_t bank_id) const;
 
     Device *device_;
-    uint64_t size_;       // Size in bytes
-    uint64_t address_;    // Address of buffer
-    uint64_t page_size_;  // Size of unit being interleaved. For non-interleaved buffers: size == page_size
+    DeviceAddr size_;       // Size in bytes
+    DeviceAddr address_;    // Address of buffer
+    DeviceAddr page_size_;  // Size of unit being interleaved. For non-interleaved buffers: size == page_size
     BufferType buffer_type_;
     TensorMemoryLayout buffer_layout_;
     std::optional<ShardSpecBuffer> shard_parameters_;
@@ -288,22 +289,21 @@ class Buffer {
 BufferPageMapping generate_buffer_page_mapping(const Buffer &buffer);
 
 namespace detail {
-using PageAddress = uint32_t;
 using Deviceid = uint32_t;
 
 class buffer_map_t {
    public:
-    void insert(std::tuple<Deviceid, PageAddress> buf_attr, Buffer *buffer) {
+    void insert(std::tuple<Deviceid, DeviceAddr> buf_attr, Buffer *buffer) {
         std::scoped_lock<std::mutex> lock(this->map_mutex);
         this->map.insert({buf_attr, buffer});
     }
 
-    void erase(std::tuple<Deviceid, PageAddress> buf_attr) {
+    void erase(std::tuple<Deviceid, DeviceAddr> buf_attr) {
         std::scoped_lock<std::mutex> lock(this->map_mutex);
         this->map.erase(buf_attr);
     }
 
-    std::map<std::tuple<Deviceid, PageAddress>, Buffer *> value() {
+    std::map<std::tuple<Deviceid, DeviceAddr>, Buffer *> value() {
         std::scoped_lock<std::mutex> lock(this->map_mutex);
         return this->map;
     }
@@ -312,7 +312,7 @@ class buffer_map_t {
 
    private:
     std::mutex map_mutex;
-    std::map<std::tuple<Deviceid, PageAddress>, Buffer *> map = {};
+    std::map<std::tuple<Deviceid, DeviceAddr>, Buffer *> map = {};
 };
 
 extern buffer_map_t BUFFER_MAP;

--- a/tt_metal/impl/dispatch/command_queue.cpp
+++ b/tt_metal/impl/dispatch/command_queue.cpp
@@ -2639,7 +2639,8 @@ void EnqueueAllocateBufferImpl(AllocBufferMetadata alloc_md) {
             alloc_md.bottom_up,
             std::nullopt);
     }
-    buffer->set_address(static_cast<uint64_t>(allocated_addr));
+    TT_ASSERT(allocated_addr <= std::numeric_limits<uint32_t>::max());
+    buffer->set_address(static_cast<DeviceAddr>(allocated_addr));
 }
 
 void EnqueueAllocateBuffer(CommandQueue& cq, Buffer* buffer, bool bottom_up, bool blocking) {

--- a/tt_metal/impl/program/program.cpp
+++ b/tt_metal/impl/program/program.cpp
@@ -496,7 +496,7 @@ void Program::validate_circular_buffer_region(const Device *device) const {
     // Only compute with storage cores can have CBs and all compute with storage cores will have the same bank offset
     const std::vector<uint32_t> &bank_ids =
         device->bank_ids_from_logical_core(BufferType::L1, *device->compute_cores_.begin());
-    std::optional<uint64_t> lowest_address = allocator::lowest_occupied_l1_address(*device->allocator_, bank_ids[0]);
+    std::optional<DeviceAddr> lowest_address = allocator::lowest_occupied_l1_address(*device->allocator_, bank_ids[0]);
     uint32_t max_l1_size = device->l1_size_per_core();
 
     for (const CircularBufferAllocator &cb_allocator : this->cb_allocators_) {

--- a/ttnn/cpp/ttnn/async_runtime.cpp
+++ b/ttnn/cpp/ttnn/async_runtime.cpp
@@ -12,7 +12,7 @@ using DeviceBuffer = std::shared_ptr<Buffer>;
 using queue_id = uint8_t;
 
 DeviceBuffer allocate_interleaved_buffer_on_device(
-    uint32_t buffer_size_bytes,
+    size_t buffer_size_bytes,
     Device* device,
     const Shape& shape,
     DataType data_type,
@@ -23,12 +23,12 @@ DeviceBuffer allocate_interleaved_buffer_on_device(
 }
 
 DeviceBuffer allocate_contiguous_buffer_on_device(
-    uint32_t buffer_size_bytes, Device* device, const MemoryConfig& memory_config) {
+    size_t buffer_size_bytes, Device* device, const MemoryConfig& memory_config) {
     return std::make_shared<Buffer>(device, buffer_size_bytes, buffer_size_bytes, memory_config.buffer_type);
 }
 
 DeviceBuffer allocate_sharded_buffer_on_device(
-    uint32_t buffer_size_bytes,
+    size_t buffer_size_bytes,
     Device* device,
     const Shape& shape,
     DataType data_type,
@@ -49,13 +49,14 @@ DeviceBuffer allocate_sharded_buffer_on_device(
 }
 
 DeviceBuffer allocate_buffer_on_device(
-    uint32_t buffer_size_bytes,
+    size_t buffer_size_bytes,
     types::Device* device,
     const Shape& shape,
     DataType data_type,
     Layout layout,
     const MemoryConfig& memory_config,
     const std::optional<ShardSpecBuffer>& shard_spec) {
+    std::cout << "buffer_size_bytes " << buffer_size_bytes << std::endl;
     if (memory_config.memory_layout == tt::tt_metal::TensorMemoryLayout::INTERLEAVED) {
         return allocate_interleaved_buffer_on_device(
             buffer_size_bytes, device, shape, data_type, layout, memory_config);

--- a/ttnn/cpp/ttnn/async_runtime.hpp
+++ b/ttnn/cpp/ttnn/async_runtime.hpp
@@ -12,7 +12,7 @@ namespace ttnn {
     using DeviceBuffer = std::shared_ptr<Buffer>;
     using queue_id = uint8_t;
 
-    DeviceBuffer allocate_buffer_on_device(uint32_t buffer_size_bytes, types::Device* device, const Shape& shape, DataType data_type, Layout layout, const MemoryConfig& memory_config, const std::optional<ShardSpecBuffer>& shard_spec = std::nullopt);
+    DeviceBuffer allocate_buffer_on_device(size_t buffer_size_bytes, types::Device* device, const Shape& shape, DataType data_type, Layout layout, const MemoryConfig& memory_config, const std::optional<ShardSpecBuffer>& shard_spec = std::nullopt);
 
     void write_buffer(queue_id cq_id, Tensor& dst, std::vector<std::shared_ptr<void>> src, const std::optional<std::size_t> transfer_size = std::nullopt);
 

--- a/ttnn/cpp/ttnn/tensor/tensor.cpp
+++ b/ttnn/cpp/ttnn/tensor/tensor.cpp
@@ -520,7 +520,7 @@ Tensor create_device_tensor(
         auto page_shape = tensor_impl::get_sharded_page_shape(layout, data_type, shard_spec.shape);
         std::array<uint32_t, 2> tensor2d_size = {other_dims / page_shape[0], width / page_shape[1]};
         ShardSpecBuffer shard_spec_buffer(shard_spec, page_shape, tensor2d_size);
-        uint32_t packed_size_in_bytes =
+        size_t packed_size_in_bytes =
             tensor_impl::packed_buffer_size_bytes_wrapper(data_type, compute_buffer_size(shape, data_type));
         auto device_buffer = tensor_impl::allocate_buffer_on_device(
             packed_size_in_bytes, device, shape, data_type, layout, memory_config, shard_spec_buffer);
@@ -530,7 +530,7 @@ Tensor create_device_tensor(
         GraphTracker::instance().track_function_end(output);
         return output;
     } else {
-        uint32_t packed_size_in_bytes =
+        size_t packed_size_in_bytes =
             tensor_impl::packed_buffer_size_bytes_wrapper(data_type, compute_buffer_size(shape, data_type));
         auto device_buffer = tensor_impl::allocate_buffer_on_device(
             packed_size_in_bytes, device, shape, data_type, layout, memory_config);

--- a/ttnn/cpp/ttnn/tensor/tensor_impl.cpp
+++ b/ttnn/cpp/ttnn/tensor/tensor_impl.cpp
@@ -179,7 +179,7 @@ void validate_sharded_buffer_allocation(
 namespace detail {
 
 DeviceBuffer allocate_interleaved_buffer_on_device(
-    uint32_t buffer_size_bytes,
+    size_t buffer_size_bytes,
     Device* device,
     const Shape& shape,
     DataType data_type,
@@ -190,12 +190,12 @@ DeviceBuffer allocate_interleaved_buffer_on_device(
 }
 
 DeviceBuffer allocate_contiguous_buffer_on_device(
-    uint32_t buffer_size_bytes, Device* device, const MemoryConfig& memory_config) {
+    size_t buffer_size_bytes, Device* device, const MemoryConfig& memory_config) {
     return std::make_shared<Buffer>(device, buffer_size_bytes, buffer_size_bytes, memory_config.buffer_type);
 }
 
 DeviceBuffer allocate_sharded_buffer_on_device(
-    uint32_t buffer_size_bytes,
+    size_t buffer_size_bytes,
     Device* device,
     const Shape& shape,
     DataType data_type,
@@ -213,7 +213,7 @@ DeviceBuffer allocate_sharded_buffer_on_device(
 }  // namespace detail
 
 DeviceBuffer allocate_buffer_on_device(
-    uint32_t buffer_size_bytes,
+    size_t buffer_size_bytes,
     Device* device,
     const Shape& shape,
     DataType data_type,

--- a/ttnn/cpp/ttnn/tensor/tensor_impl.hpp
+++ b/ttnn/cpp/ttnn/tensor/tensor_impl.hpp
@@ -161,25 +161,25 @@ std::vector<DataType> unpack_uint32_vec(std::vector<uint32_t>& data_to_unpack) {
 uint32_t element_size_bytes(DataType dtype);
 
 template <typename T>
-constexpr inline uint32_t packed_buffer_size_bytes(uint32_t volume_unpacked_data) {
+constexpr inline size_t packed_buffer_size_bytes(size_t volume_unpacked_data) {
     auto num_type_in_u32 = sizeof(uint32_t) / sizeof(T);
     return (volume_unpacked_data / num_type_in_u32) * sizeof(uint32_t);
 }
 
 // Specialization for float because it gets converted to bfloat16 before being packed
 template <>
-constexpr inline uint32_t packed_buffer_size_bytes<float>(uint32_t volume_unpacked_data) {
+constexpr inline size_t packed_buffer_size_bytes<float>(size_t volume_unpacked_data) {
     auto num_type_in_u32 = sizeof(uint32_t) / sizeof(float);
     return (volume_unpacked_data / num_type_in_u32) * sizeof(uint32_t);
 }
 
 template <>
-constexpr inline uint32_t packed_buffer_size_bytes<bfloat8_b>(uint32_t volume_unpacked_data) {
+constexpr inline size_t packed_buffer_size_bytes<bfloat8_b>(size_t volume_unpacked_data) {
     return packed_buffer_size_bytes<uint32_t>(volume_unpacked_data);
 }
 
 template <>
-constexpr inline uint32_t packed_buffer_size_bytes<bfloat4_b>(uint32_t volume_unpacked_data) {
+constexpr inline size_t packed_buffer_size_bytes<bfloat4_b>(size_t volume_unpacked_data) {
     return packed_buffer_size_bytes<uint32_t>(volume_unpacked_data);
 }
 
@@ -249,7 +249,7 @@ void validate_sharded_buffer_allocation(
 uint32_t get_page_size(DataType dtype, Layout layout, uint32_t total_size_bytes, const Shape& shape);
 
 DeviceBuffer allocate_buffer_on_device(
-    uint32_t buffer_size_bytes,
+    size_t buffer_size_bytes,
     Device* device,
     const Shape& shape,
     DataType data_type,

--- a/ttnn/cpp/ttnn/tensor/tensor_impl_wrapper.hpp
+++ b/ttnn/cpp/ttnn/tensor/tensor_impl_wrapper.hpp
@@ -33,7 +33,7 @@ auto dispatch(DataType dtype, Func &&func, Args &&...args) {
             std::get<0>(std::forward_as_tuple(args...)).get_dtype(), AS_LAMBDA(func), std::forward<Args>(args)...); \
     }
 
-inline uint32_t packed_buffer_size_bytes_wrapper(DataType dtype, uint32_t volume_unpacked_data) {
+inline size_t packed_buffer_size_bytes_wrapper(DataType dtype, size_t volume_unpacked_data) {
     return dispatch(dtype, AS_LAMBDA(packed_buffer_size_bytes), volume_unpacked_data);
 }
 

--- a/ttnn/cpp/ttnn/tensor/tensor_utils.hpp
+++ b/ttnn/cpp/ttnn/tensor/tensor_utils.hpp
@@ -39,7 +39,7 @@ const Shape infer_dims_for_reshape_RM(int N, int C, int H, int W, uint32_t old_v
 
 template <typename T>
 static std::size_t compute_volume(const T& shape) {
-    auto volume = 1;
+    size_t volume = 1;
     for (auto index = 0; index < shape.size(); index++) {
         volume *= shape[index];
     }
@@ -75,7 +75,7 @@ static int compute_flat_indices(const vector<int>& indices, const vector<std::ui
 
 template <typename T>
 static std::size_t compute_buffer_size(const T& shape, DataType data_type) {
-    const auto volume = compute_volume(shape);
+    const size_t volume = compute_volume(shape);
     if (data_type == DataType::BFLOAT8_B) {
         TT_ASSERT(volume % constants::TILE_HW == 0);
         const auto bfloat8_b_volume = volume / constants::TILE_HW * constants::BFLOAT8_B_TILE_HW;


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/12096

### Problem description
Using combination of size_t and uint32_t in tensor -> buffer creation was causing overflow for 4GB tensor

### What's changed
Use DeviceAddr at buffer/allocator level in metal runtime and commonize tensor level to use size_t

### Checklist
- [x] [Post commit CI](https://github.com/tenstorrent/tt-metal/actions/runs/10741884808)
- [x] [Blackhole Post Commit](https://github.com/tenstorrent/tt-metal/actions/runs/10741889201)
- [x] New/Existing tests provide coverage for changes
