### PR TITLE
#11447: Add support for data parallel UNet on T3000

### DIFF
--- a/.github/workflows/t3000-unit-tests.yaml
+++ b/.github/workflows/t3000-unit-tests.yaml
@@ -23,6 +23,7 @@ jobs:
           { name: "t3k falcon40b tests", arch: wormhole_b0, cmd: run_t3000_falcon40b_tests, timeout: 30, owner_id: U053W15B6JF}, #Djordje Ivanovic
           { name: "t3k mixtral tests", arch: wormhole_b0, cmd: run_t3000_mixtral_tests, timeout: 30, owner_id: U03PUAKE719}, #Miguel Tairum Cruz
           { name: "t3k grok tests", arch: wormhole_b0, cmd: run_t3000_grok_tests, timeout: 30, owner_id: U03HY7MK4BT}, #Mark O'Connor
+          { name: "t3k unet shallow tests", arch: wormhole_b0, cmd: run_t3000_unet_shallow_tests, timeout: 30, owner_id: U06ECNVR0EN}, #Evan Smal
         ]
     name: ${{ matrix.test-group.name }}
     env:

--- a/models/experimental/functional_unet/tests/common.py
+++ b/models/experimental/functional_unet/tests/common.py
@@ -13,6 +13,13 @@ def is_n300_with_eth_dispatch_cores(mesh_device) -> bool:
     return all_devices_using_full_grid and (len(mesh_device.get_devices()) == 2)
 
 
+def is_t3k_with_eth_dispatch_cores(mesh_device) -> bool:
+    all_devices_using_full_grid = all(
+        [(8 == device.core_grid.x and 8 == device.core_grid.y) for device in mesh_device.get_devices()]
+    )
+    return all_devices_using_full_grid and (len(mesh_device.get_devices()) == 8)
+
+
 def check_pcc_conv(torch_tensor, ttnn_tensor, pcc=0.999, mesh_composer=None):
     B, C, H, W = torch_tensor.shape
     ttnn_tensor = ttnn.to_torch(ttnn_tensor, mesh_composer=mesh_composer).reshape(B, H, W, C).permute(0, 3, 1, 2)

--- a/tests/scripts/t3000/run_t3000_unit_tests.sh
+++ b/tests/scripts/t3000/run_t3000_unit_tests.sh
@@ -134,6 +134,24 @@ run_t3000_grok_tests() {
   fi
 }
 
+run_t3000_unet_shallow_tests() {
+  # Record the start time
+  fail=0
+  start_time=$(date +%s)
+
+  echo "LOG_METAL: Running run_t3000_unet_shallow_tests"
+
+  WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml pytest -n auto models/experimental/functional_unet/tests/test_unet_multi_device.py; fail+=$?
+
+  # Record the end time
+  end_time=$(date +%s)
+  duration=$((end_time - start_time))
+  echo "LOG_METAL: run_t3000_unet_shallow_tests took $duration seconds to complete"
+  if [[ $fail -ne 0 ]]; then
+    exit 1
+  fi
+}
+
 run_t3000_tests() {
   # Run ttmetal tests
   run_t3000_ttmetal_tests
@@ -152,6 +170,9 @@ run_t3000_tests() {
 
   # Run grok tests
   run_t3000_grok_tests
+
+  # Run unet shallow tests
+  run_t3000_unet_shallow_tests
 }
 
 fail=0


### PR DESCRIPTION
### Ticket
- #11447

### What's changed
- Update the multi device test to run when T3K is being used. No changes were required to the model since everything is already working on N300.
- Add multi device test to T3K unit test pipeline.

### Checklist
- [x] Post commit CI passes
- [x] Model regression CI testing passes (if applicable) - [pipeline](https://github.com/tenstorrent/tt-metal/actions/runs/10742336890/job/29795108409)
