### PR TITLE
#0: Fix TT-NN wheel update issue by making sure rpath is updated when…

### DIFF
--- a/ttnn/ttnn/library_tweaks.py
+++ b/ttnn/ttnn/library_tweaks.py
@@ -19,9 +19,6 @@ def _has_not_found(target_so):
 
 def _setup_so_rpath(site_pkgs_ttnn, so_name, new_rpath):
     directory = site_pkgs_ttnn
-    check_f = directory / f".rpath_checked_{so_name}"
-    if os.path.exists(check_f):
-        return
 
     target_so = None
     for f in os.listdir(directory):
@@ -35,17 +32,14 @@ def _setup_so_rpath(site_pkgs_ttnn, so_name, new_rpath):
 
     if _has_not_found(target_so):
         subprocess.check_call(f"patchelf --set-rpath {new_rpath} {target_so}", shell=True)
-    subprocess.check_call(f"touch {check_f}", shell=True)
 
 
 def _setup_so_rpath_in_build_lib(site_pkgs_ttnn):
     directory = site_pkgs_ttnn / "build/lib"
-    check_f = directory / ".rpath_checked"
     if not os.path.exists(directory):
         logger.trace(f"Directory {directory} does not exists")
         return
-    if os.path.exists(check_f):
-        return
+
     import subprocess
 
     metal_so = directory / "libtt_metal.so"
@@ -53,7 +47,6 @@ def _setup_so_rpath_in_build_lib(site_pkgs_ttnn):
     new_rpath = directory
     if _has_not_found(metal_so):
         subprocess.check_call(f"patchelf --set-rpath {new_rpath} {metal_so}", shell=True)
-    subprocess.check_call(f"touch {check_f}", shell=True)
 
 
 def _setup_env(site_pkgs_ttnn):


### PR DESCRIPTION
### Ticket
None

### Problem description
TT-NN Wheel does not work on a user machine after an update (or uninstall/install sequence)

Wheel is shipped with some broken rpath links.
See ldd results
```
        linux-vdso.so.1 (0x00007fff3c576000)
  ->    libtt_metal.so => not found
        libpython3.8.so.1.0 => /lib/x86_64-linux-gnu/libpython3.8.so.1.0 (0x00007f392f6f7000)
        libz.so.1 => /lib/x86_64-linux-gnu/libz.so.1 (0x00007f392f6db000)
        libatomic.so.1 => /lib/x86_64-linux-gnu/libatomic.so.1 (0x00007f392f6d1000)
        libhwloc.so.15 => /lib/x86_64-linux-gnu/libhwloc.so.15 (0x00007f392f680000)
        libnuma.so.1 => /lib/x86_64-linux-gnu/libnuma.so.1 (0x00007f392f673000)
  ->    libdevice.so => not found
        libc++.so.1 => /lib/x86_64-linux-gnu/libc++.so.1 (0x00007f392f575000)
        libc++abi.so.1 => /lib/x86_64-linux-gnu/libc++abi.so.1 (0x00007f392f53e000)
        libunwind.so.1 => /lib/x86_64-linux-gnu/libunwind.so.1 (0x00007f392f530000)
  ->    libnng.so.1 => not found
        libuv.so.1 => /lib/x86_64-linux-gnu/libuv.so.1 (0x00007f392f4ff000)
        libdl.so.2 => /lib/x86_64-linux-gnu/libdl.so.2 (0x00007f392f4f7000)
        libpthread.so.0 => /lib/x86_64-linux-gnu/libpthread.so.0 (0x00007f392f4d4000)
        librt.so.1 => /lib/x86_64-linux-gnu/librt.so.1 (0x00007f392f4ca000)
        libstdc++.so.6 => /lib/x86_64-linux-gnu/libstdc++.so.6 (0x00007f392f2e8000)
        libm.so.6 => /lib/x86_64-linux-gnu/libm.so.6 (0x00007f392f199000)
        libgcc_s.so.1 => /lib/x86_64-linux-gnu/libgcc_s.so.1 (0x00007f392f17e000)
        libc.so.6 => /lib/x86_64-linux-gnu/libc.so.6 (0x00007f392ef8a000)
        /lib64/ld-linux-x86-64.so.2 (0x00007f3931e8b000)
        libexpat.so.1 => /lib/x86_64-linux-gnu/libexpat.so.1 (0x00007f392ef5c000)
        libutil.so.1 => /lib/x86_64-linux-gnu/libutil.so.1 (0x00007f392ef57000)
        libudev.so.1 => /lib/x86_64-linux-gnu/libudev.so.1 (0x00007f392ef2a000)
        libltdl.so.7 => /lib/x86_64-linux-gnu/libltdl.so.7 (0x00007f392ef1f000) 
```

This is known and we run autocorrection during the ttnn module import.
To not check rpath on every load we generate `.rpath_check` file.

The problem is that pip does not remove this file during package uninstall.
It means after package update (uninstall/intall) rpath links are not corrected in the new ttnn and tt-metal libs.
Leaving a user with an error like this
```
ImportError while loading conftest '/home/ubuntu/actions-runner/_work/pytorch2.0_ttnn/pytorch2.0_ttnn/tests/conftest.py'.
tests/conftest.py:2: in <module>
    import ttnn
../../_tool/Python/3.8.18/x64/lib/python3.8/site-packages/ttnn/__init__.py:[20](https://github.com/tenstorrent/pytorch2.0_ttnn/actions/runs/10739347247/job/29784885008#step:4:21): in <module>
    import ttnn._ttnn
E   ImportError: libtt_metal.so: cannot open shared object file: No such file or directory
```

### What's changed
I did not find a way to make sure that pip uninstalls generated files.
I remove the file check for now to resolve an issue.
This cost is payed on each ttnn import and I see it as negligible / tolerable price for the problem it resolves
```
cost = time-to-check-rpath - time-to-check-file-existence
```

Alternatively we can get the hash of the binary and write it to the file. And then get a hash of the binary on load and check if file has that hash. The cost here is higher.

Ideally we should find a way for `pip` to remove the check file.

### Checklist
- [ ] Post commit CI [passes](https://github.com/tenstorrent/tt-metal/actions/runs/10743219408)