### PR TITLE
Replace assert with fatal in Shape::get_normalized_index

### DIFF
--- a/ttnn/cpp/ttnn/tensor/types.cpp
+++ b/ttnn/cpp/ttnn/tensor/types.cpp
@@ -66,7 +66,7 @@ Padding::Padding(const std::vector<PadDimension>& pad_dimensions, PadValue pad_v
 const uint32_t Padding::get_normalized_index(std::int64_t index) const {
     std::int64_t rank = static_cast<std::int64_t>(this->rank_);
     std::uint64_t normalized_index = index >= 0 ? index : rank + index;
-    TT_ASSERT(
+    TT_FATAL(
         normalized_index >= 0 and normalized_index < rank,
         fmt::format(
             "Index is out of bounds for the rank, should be between 0 and {} however is {}",
@@ -164,7 +164,7 @@ const Shape Shape::without_padding() const {
 const uint32_t Shape::get_normalized_index(std::int64_t index) const {
     std::int64_t rank = static_cast<std::int64_t>(this->rank_);
     std::uint64_t normalized_index = index >= 0 ? index : rank + index;
-    TT_ASSERT(
+    TT_FATAL(
         normalized_index >= 0 and normalized_index < rank,
         fmt::format(
             "Index is out of bounds for the rank, should be between 0 and {} however is {}",


### PR DESCRIPTION
### Ticket
None

### Problem description
Locally I see an error
```
Always | FATAL    | Index is out of bounds for the rank, should be between 0 and -1 however is 0
```

But on CI I don't see an error and only see 
```
Current thread 0x00007fb0ce910740 (most recent call first):
  File "/home/ubuntu/actions-runner/_work/_tool/Python/3.8.18/x64/lib/python3.8/site-packages/ttnn/decorators.py", line 326 in __call__
  File "/home/ubuntu/actions-runner/_work/_tool/Python/3.8.18/x64/lib/python3.8/site-packages/ttnn/operations/core.py", line 253 in from_torch
  File "/home/ubuntu/actions-runner/_work/_tool/Python/3.8.18/x64/lib/python3.8/site-packages/ttnn/decorators.py", line 326 in __call__
  File "<eval_with_key>.169", line 6 in forward
```
and
```
/home/ubuntu/actions-runner/_work/_temp/680c046b-e3ad-4d49-abdb-28acd76629ec.sh: line 2: 927358 Segmentation fault      (core dumped) python3 -m pytest --github-report tests/models/ --splits 40 --group 30 -s
```

This is because we use TT_ASSERT where we should have used TT_FATAL

### What's changed
Change

### Checklist
- [x] Local build passes