### PR TITLE
LICENSE: refine wording

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -204,7 +204,9 @@
 
 Third-Party Dependencies:
 
-The following dependencies are utilized by this project and are included in a distributed build of a Python Wheel:
+The following separate and independent dependencies are utilized by this
+project and are included in a distributed build of a Python Wheel and
+are subject to their own license terms listed as follows:
 
 - sfpi-gcc - [License available here](https://github.com/tenstorrent-metal/sfpi-rel-temp/blob/master/LICENSE) [and here](https://github.com/tenstorrent-metal/sfpi-rel-temp/blob/master/compiler/LICENSE)
 


### PR DESCRIPTION
Clarify that sfpi-gcc is independent.