### PR TITLE
#12355: Support vector of optional tensor and example

### DIFF
--- a/tests/ttnn/unit_tests/operations/test_examples.py
+++ b/tests/ttnn/unit_tests/operations/test_examples.py
@@ -39,3 +39,37 @@ def test_composite_example(device, height, width):
     output_tensor = ttnn.to_torch(output_tensor)
 
     assert_with_pcc(torch_output_tensor, output_tensor, 0.99)
+
+
+@pytest.mark.parametrize("height", [64])
+@pytest.mark.parametrize("width", [128])
+def test_example_multiple_return(device, height, width):
+    torch.manual_seed(0)
+
+    torch_input_tensor = torch.rand((height, width), dtype=torch.bfloat16)
+    torch_output_tensor = torch_input_tensor
+
+    input_tensor = ttnn.from_torch(torch_input_tensor, layout=ttnn.TILE_LAYOUT, device=device)
+    output1, output2 = ttnn.prim.example_multiple_return(input_tensor)
+    output_tensor1 = ttnn.to_torch(output1)
+    output_tensor2 = ttnn.to_torch(output2)
+
+    assert_with_pcc(torch_output_tensor, output_tensor1, 0.99)
+    assert_with_pcc(torch_output_tensor, output_tensor2, 0.99)
+
+
+@pytest.mark.parametrize("height", [64])
+@pytest.mark.parametrize("width", [128])
+def test_composite_example_multiple_return(device, height, width):
+    torch.manual_seed(0)
+
+    torch_input_tensor = torch.rand((height, width), dtype=torch.bfloat16)
+    torch_output_tensor = torch_input_tensor
+
+    input_tensor = ttnn.from_torch(torch_input_tensor, layout=ttnn.TILE_LAYOUT, device=device)
+    output1, output2 = ttnn.composite_example_multiple_return(input_tensor)
+    output_tensor1 = ttnn.to_torch(output1)
+    output_tensor2 = ttnn.to_torch(output2)
+
+    assert_with_pcc(torch_output_tensor, output_tensor1, 0.99)
+    assert_with_pcc(torch_output_tensor, output_tensor2, 0.99)

--- a/ttnn/CMakeLists.txt
+++ b/ttnn/CMakeLists.txt
@@ -149,6 +149,11 @@ set(ALL_TTNN_SRCS
     ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/examples/example/device/example_device_operation.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/examples/example/device/multi_core_program_factory.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/examples/example/device/single_core_program_factory.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/examples/example_multiple_return/device/example_multiple_return_device_operation.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/examples/example_multiple_return/device/single_core_program_factory.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/examples/example_multiple_return/example_multiple_return.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/examples/example_multiple_return/example_multiple_return_pybind.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/examples/examples_pybind.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/data_movement/bcast/bcast.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/data_movement/bcast/bcast_types.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/data_movement/bcast/bcast_pybind.cpp

--- a/ttnn/cpp/ttnn/decorators.hpp
+++ b/ttnn/cpp/ttnn/decorators.hpp
@@ -113,6 +113,16 @@ auto map_execute_on_worker_thread_return_to_launch_op_return(const T&& value) ->
         return value;
     } else if constexpr (std::is_same_v<std::decay_t<decltype(value)>, Tensor>) {
         return {value};
+    } else if constexpr (std::is_same_v<std::decay_t<decltype(value)>, OptionalTensors>) {
+        Tensors output_tensors;
+        auto size = value.size();
+        output_tensors.reserve(size);
+
+        auto dummy_tensor = Tensor();
+        for (uint32_t i = 0 ; i < size; i++) {
+            output_tensors.push_back(value.at(i).value_or(dummy_tensor));
+        }
+        return output_tensors;
     } else if constexpr (is_homogenous_tuple<T, Tensor>()) {
         Tensors output_tensors;
         output_tensors.reserve(std::tuple_size_v<T>);
@@ -278,6 +288,16 @@ struct registered_operation_t {
             return output_tensors.at(0);
         } else if constexpr (std::is_same_v<execute_on_worker_thread_return_t, Tensors>) {
             return output_tensors;
+        } else if constexpr (std::is_same_v<execute_on_worker_thread_return_t, OptionalTensors>) {
+            // convert tensor to optional tensor
+            std::vector<std::optional<Tensor>> ret;
+
+            auto size = output_tensors.size();
+            ret.reserve(size);
+            for (uint32_t i = 0 ; i < size; i++) {
+                ret.push_back(output_tensors.at(i));
+            }
+            return ret;
         } else if constexpr (detail::is_homogenous_tuple<execute_on_worker_thread_return_t, Tensor>()) {
             return detail::make_tuple_from_vector<execute_on_worker_thread_return_t>(output_tensors);
         } else {

--- a/ttnn/cpp/ttnn/decorators.hpp
+++ b/ttnn/cpp/ttnn/decorators.hpp
@@ -119,8 +119,8 @@ auto map_execute_on_worker_thread_return_to_launch_op_return(const T&& value) ->
         output_tensors.reserve(size);
 
         auto dummy_tensor = Tensor();
-        for (uint32_t i = 0 ; i < size; i++) {
-            output_tensors.push_back(value.at(i).value_or(dummy_tensor));
+        for (auto& val : value) {
+            output_tensors.push_back(val.value_or(dummy_tensor));
         }
         return output_tensors;
     } else if constexpr (is_homogenous_tuple<T, Tensor>()) {

--- a/ttnn/cpp/ttnn/operations/examples/example_multiple_return/device/example_multiple_return_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/examples/example_multiple_return/device/example_multiple_return_device_operation.cpp
@@ -1,0 +1,58 @@
+// SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "example_multiple_return_device_operation.hpp"
+
+namespace ttnn::operations::examples {
+
+ExampleMultipleReturnDeviceOperation::program_factory_t ExampleMultipleReturnDeviceOperation::select_program_factory(
+    const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args) {
+    return SingleCore{};
+}
+
+void ExampleMultipleReturnDeviceOperation::validate_on_program_cache_miss(
+    const operation_attributes_t& attributes, const tensor_args_t& tensor_args) {}
+
+void ExampleMultipleReturnDeviceOperation::validate_on_program_cache_hit(
+    const operation_attributes_t& attributes, const tensor_args_t& tensor_args) {}
+
+ExampleMultipleReturnDeviceOperation::shape_return_value_t ExampleMultipleReturnDeviceOperation::compute_output_shapes(
+    const operation_attributes_t&, const tensor_args_t& tensor_args) {
+    return {tensor_args.input_tensor.tensor_attributes->shape, tensor_args.input_tensor.tensor_attributes->shape};
+}
+
+ExampleMultipleReturnDeviceOperation::tensor_return_value_t ExampleMultipleReturnDeviceOperation::create_output_tensors(
+    const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args) {
+    auto [output1_shape_opt, output2_shape_opt] = compute_output_shapes(operation_attributes, tensor_args);
+
+    auto output1_shape = output1_shape_opt.value();
+    auto output2_shape = output2_shape_opt.value();
+
+    const auto& input_tensor = tensor_args.input_tensor;
+    auto output1 = create_device_tensor(
+        output1_shape,
+        input_tensor.tensor_attributes->dtype,
+        input_tensor.tensor_attributes->layout,
+        input_tensor.device());
+
+    auto output2 = create_device_tensor(
+        output2_shape,
+        input_tensor.tensor_attributes->dtype,
+        input_tensor.tensor_attributes->layout,
+        input_tensor.device());
+
+    return {output1, output2};
+}
+
+
+std::tuple<ExampleMultipleReturnDeviceOperation::operation_attributes_t, ExampleMultipleReturnDeviceOperation::tensor_args_t>
+ExampleMultipleReturnDeviceOperation::invoke(const Tensor& input_tensor) {
+    return {
+        operation_attributes_t{true, 42},
+        tensor_args_t{input_tensor}
+    };
+}
+
+
+}  // namespace ttnn::operations::examples

--- a/ttnn/cpp/ttnn/operations/examples/example_multiple_return/device/example_multiple_return_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/examples/example_multiple_return/device/example_multiple_return_device_operation.hpp
@@ -1,0 +1,134 @@
+// SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <optional>
+#include <variant>
+
+#include "ttnn/tensor/tensor.hpp"
+#include "ttnn/core.hpp"
+#include "ttnn/device_operation.hpp"
+#include "ttnn/types.hpp"
+#include "ttnn/decorators.hpp"
+
+namespace ttnn::operations::examples {
+
+struct ExampleMultipleReturnDeviceOperation {
+    // Define the operation attributes. This is it to store all variables needed by operations that aren't tensors
+    struct operation_attributes_t {
+        bool attribute;
+        int some_other_attribute;
+    };
+
+    // Define the tensor arguments. This is it to store all tensors passed in and/or out of the operation
+    // Tensor arguments don't need to be just input tensors, they can be output tensors, input/output tensors, optional
+    // tensors, etc.
+    struct tensor_args_t {
+        // This example will use a tensor that can only be used as an input
+        const Tensor& input_tensor;
+
+        // However, the following examples show what else can be done with tensor_args_t
+
+        // An example of the tensor that can be used for input/output or just for pre-allocated output
+        // Tensor& io_tensor;
+
+        // An example of an optional tensor
+        // std::optional<Tensor> optional_output_tensor;
+
+        // An example of a vector of tensors
+        // std::vector<Tensor> vector_of_tensors;
+
+        // An example of a tuple of tensors
+        // std::tuple<Tensor, ...> tuple_of_tensors;
+
+        // An example of a vector of optional tensors
+        // std::vector<std::optional<Tensor>> vector_of_optional_tensors;
+
+        // An example of a tuple of tensors
+        // std::tuple<std::vector<std::optional<Tensor>>, std::optional<Tensor>> some_crazy_tuple_of_tensors;
+    };
+
+    // Define the return types for the shape(s) of the operation
+    // Can be a single ttnn::Shape, std::optional<ttnn::Shape>, std::vector<ttnn::Shape>, std::tuple<ttnn::Shape> etc.
+    using shape_return_value_t = std::tuple<std::optional<ttnn::Shape>, std::optional<ttnn::Shape>>;
+
+    // Define the return types for the tensor(s) of the operation
+    // Can be a single Tensor, std::optional<Tensor, ...>, std::vector<Tensor>, std::tuple<Tensor, ...> etc.
+    using tensor_return_value_t = std::vector<std::optional<Tensor>>;
+
+    // Note shape_return_value_t and tensor_return_value_t should follow the same pattern
+    // i.e. if shape_return_value_t is a std::vector<std::optional<ttnn::Shape>> then tensor_return_value_t should be
+    // std::vector<std::optional<Tensor>>
+
+    struct SingleCore {
+        // Shared variables are the variables that are shared between the create and override_runtime_arguments methods
+        struct shared_variables_t {
+            KernelHandle unary_reader_kernel_id;
+            KernelHandle unary_writer_kernel_id;
+        };
+        using cached_program_t = ttnn::device_operation::CachedProgram<shared_variables_t>;
+
+        static cached_program_t create(
+            const operation_attributes_t& operation_attributes,
+            const tensor_args_t& tensor_args,
+            tensor_return_value_t& tensor_return_value);
+
+        static void override_runtime_arguments(
+            cached_program_t& cached_program,
+            const operation_attributes_t& operation_attributes,
+            const tensor_args_t& tensor_args,
+            tensor_return_value_t& tensor_return_value);
+    };
+
+    using program_factory_t = std::variant<SingleCore>;
+
+    // Mandatory methods
+
+    // Select the program factory based on the operation attributes and tensor args
+    static program_factory_t select_program_factory(const operation_attributes_t&, const tensor_args_t&);
+
+    // Validate the operation when it creates a program. Usually will have more checks
+    static void validate_on_program_cache_miss(const operation_attributes_t&, const tensor_args_t&);
+
+    // Validate the operation when it reuses a program. Usually will have less checks
+    static void validate_on_program_cache_hit(const operation_attributes_t&, const tensor_args_t&);
+
+    // Compute the output shapes based on the operation attributes and tensor args
+    static shape_return_value_t compute_output_shapes(const operation_attributes_t&, const tensor_args_t&);
+
+    // Create the output tensors based on the operation attributes and tensor args
+    static tensor_return_value_t create_output_tensors(const operation_attributes_t&, const tensor_args_t&);
+
+    // API call to map user arguments to operation attributes and tensor args.
+    // This is the only method that is called by the user
+    // The user will be able to call the operation using `tensor_return_value_t output = ttnn::prim::example(input_tensor)` after the op is registered
+    // Keep in mind that the the overload with `queue_id` argument will be added automatically for primitive operations
+    // So, the user can also call this operation using `tensor_return_value_t output = ttnn::prim::example(queue_id, input_tensor)`
+    static std::tuple<operation_attributes_t, tensor_args_t> invoke(const Tensor& input_tensor);
+
+    // Optional methods
+
+    // In case the operation need a custom hash function, the following method can be implemented
+    /* static tt::stl::hash::hash_t compute_program_hash(
+        const operation_attributes_t&, const tensor_args_t&);
+    */
+
+    // In case the operation needs a custom create_op_performance_model, this method can be implemented
+    /*
+    static operation::OpPerformanceModel create_op_performance_model(
+        const operation_attributes_t&,
+        const tensor_args_t&,
+        tensor_return_value_t&);
+    */
+};
+
+}  // namespace ttnn::operations::examples
+
+// Register the operation with the ttnn::register_operation API to make it available to the user as ttnn::prim::example
+namespace ttnn::prim {
+constexpr auto example_multiple_return = ttnn::register_operation<
+    "ttnn::prim::example_multiple_return",
+    ttnn::operations::examples::ExampleMultipleReturnDeviceOperation>();
+}  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/examples/example_multiple_return/device/kernels/writer_multiple.cpp
+++ b/ttnn/cpp/ttnn/operations/examples/example_multiple_return/device/kernels/writer_multiple.cpp
@@ -1,0 +1,58 @@
+// SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "dataflow_api.h"
+#include "dprint.h"
+
+void kernel_main() {
+    uint32_t dst_addr1  = get_arg_val<uint32_t>(0);
+    uint32_t dst_addr2  = get_arg_val<uint32_t>(1);
+    uint32_t num_tiles = get_arg_val<uint32_t>(2);
+    uint32_t start_id = get_arg_val<uint32_t>(3);
+
+    constexpr uint32_t cb_id_out = get_compile_time_arg_val(0);
+    constexpr bool dst_is_dram1 = get_compile_time_arg_val(1) == 1;
+    constexpr bool dst_is_dram2 = get_compile_time_arg_val(2) == 1;
+
+    #ifdef OUT_SHARDED
+    cb_wait_front(cb_id_out, num_tiles);
+    #else
+
+    // single-tile ublocks
+    constexpr uint32_t onetile = 1;
+    const uint32_t tile_bytes = get_tile_size(cb_id_out);
+    const DataFormat data_format = get_dataformat(cb_id_out);
+
+    const InterleavedAddrGenFast<dst_is_dram1> s1 = {
+        .bank_base_address = dst_addr1,
+        .page_size = tile_bytes,
+        .data_format = data_format
+    };
+
+    const InterleavedAddrGenFast<dst_is_dram2> s2 = {
+        .bank_base_address = dst_addr2,
+        .page_size = tile_bytes,
+        .data_format = data_format
+    };
+
+    #ifdef BACKWARDS
+    uint32_t end_id = start_id - num_tiles;
+    for (uint32_t i = start_id; i != end_id; -- i) {
+    #else
+    uint32_t end_id = start_id + num_tiles;
+    for (uint32_t i = start_id; i < end_id; ++ i) {
+    #endif
+        cb_wait_front(cb_id_out, onetile);
+
+        uint32_t l1_read_addr = get_read_ptr(cb_id_out);
+        noc_async_write_tile(i, s1, l1_read_addr);
+        noc_async_write_barrier();
+
+        noc_async_write_tile(i, s2, l1_read_addr);
+        noc_async_write_barrier();
+
+        cb_pop_front(cb_id_out, onetile);
+    }
+    #endif
+}

--- a/ttnn/cpp/ttnn/operations/examples/example_multiple_return/device/single_core_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/examples/example_multiple_return/device/single_core_program_factory.cpp
@@ -1,0 +1,160 @@
+// SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "example_multiple_return_device_operation.hpp"
+#include "ttnn/deprecated/tt_dnn/op_library/work_split.hpp"
+
+namespace ttnn::operations::examples {
+ExampleMultipleReturnDeviceOperation::SingleCore::cached_program_t ExampleMultipleReturnDeviceOperation::SingleCore::create(
+    const operation_attributes_t& operation_attributes,
+    const tensor_args_t& tensor_args,
+    tensor_return_value_t& tensor_return_value) {
+    using namespace tt;
+    using namespace tt::tt_metal;
+
+    const auto& input_tensor = tensor_args.input_tensor;
+
+    auto output_tensor1 = tensor_return_value.at(0).value();
+    auto output_tensor2 = tensor_return_value.at(1).value();
+
+    auto src_buffer = input_tensor.buffer();
+    auto dst_buffer1 = output_tensor1.buffer();
+    auto dst_buffer2 = output_tensor2.buffer();
+
+    tt::tt_metal::Program program{};
+
+    tt::DataFormat cb_data_format = tt::tt_metal::datatype_to_dataformat_converter(input_tensor.get_dtype());
+    uint32_t single_tile_size = tt::tt_metal::detail::TileSize(cb_data_format);
+    tt::DataFormat cb_data_format_output = tt::tt_metal::datatype_to_dataformat_converter(output_tensor1.get_dtype());
+    uint32_t single_tile_size_output = tt::tt_metal::detail::TileSize(cb_data_format_output);
+
+    uint32_t num_tiles = input_tensor.volume() / tt::constants::TILE_HW;
+
+    tt::tt_metal::Device* device = input_tensor.device();
+
+    CoreCoord compute_with_storage_grid_size = {1, 1};
+    uint32_t num_cores_x = compute_with_storage_grid_size.x;
+    uint32_t num_cores_y = compute_with_storage_grid_size.y;
+    auto [num_cores, all_cores, core_group_1, core_group_2, num_tiles_per_core_group_1, num_tiles_per_core_group_2] =
+        split_work_to_cores(compute_with_storage_grid_size, num_tiles);
+
+    uint32_t src0_cb_index = 0;
+    uint32_t num_input_tiles = 2;
+    tt::tt_metal::CircularBufferConfig cb_src0_config =
+        tt::tt_metal::CircularBufferConfig(num_input_tiles * single_tile_size, {{src0_cb_index, cb_data_format}})
+            .set_page_size(src0_cb_index, single_tile_size);
+    auto cb_src0 = tt::tt_metal::CreateCircularBuffer(program, all_cores, cb_src0_config);
+
+    uint32_t output_cb_index = 16;  // output_tensor operands start at index 16
+    uint32_t num_output_tiles = 2;
+    tt::tt_metal::CircularBufferConfig cb_output_config =
+        tt::tt_metal::CircularBufferConfig(
+            num_output_tiles * single_tile_size_output, {{output_cb_index, cb_data_format_output}})
+            .set_page_size(output_cb_index, single_tile_size_output);
+    auto cb_output1 = tt::tt_metal::CreateCircularBuffer(program, all_cores, cb_output_config);
+
+    bool src_is_dram = src_buffer->buffer_type() == tt::tt_metal::BufferType::DRAM ? 1 : 0;
+    std::vector<uint32_t> reader_compile_time_args = {(uint32_t)src_is_dram};
+    bool dst_is_dram1 = dst_buffer1->buffer_type() == tt::tt_metal::BufferType::DRAM ? 1 : 0;
+    bool dst_is_dram2 = dst_buffer2->buffer_type() == tt::tt_metal::BufferType::DRAM ? 1 : 0;
+    std::vector<uint32_t> writer_compile_time_args = {(std::uint32_t)output_cb_index, (std::uint32_t)dst_is_dram1, (std::uint32_t)dst_is_dram2};
+
+    tt::tt_metal::KernelHandle unary_reader_kernel_id = tt::tt_metal::CreateKernel(
+        program,
+        "ttnn/cpp/ttnn/operations/eltwise/unary/device/kernels/dataflow/reader_unary_interleaved_start_id.cpp",
+        all_cores,
+        tt::tt_metal::ReaderDataMovementConfig(reader_compile_time_args));
+
+    tt::tt_metal::KernelHandle unary_writer_kernel_id = tt::tt_metal::CreateKernel(
+        program,
+        "ttnn/cpp/ttnn/operations/examples/example_multiple_return/device/kernels/writer_multiple.cpp",
+        all_cores,
+        tt::tt_metal::WriterDataMovementConfig(writer_compile_time_args));
+
+    vector<uint32_t> compute_kernel_args_group_1 = {
+        num_tiles_per_core_group_1,  // per_core_block_cnt
+        1                            // per_core_block_size
+    };
+
+    bool math_approx_mode = false;
+    auto eltwise_unary_kernel_group_1_id = tt::tt_metal::CreateKernel(
+        program,
+        "tt_metal/kernels/compute/eltwise_sfpu.cpp",
+        core_group_1,
+        tt::tt_metal::ComputeConfig{
+            .math_fidelity = MathFidelity::HiFi4,
+            .math_approx_mode = math_approx_mode,
+            .compile_args = compute_kernel_args_group_1});
+
+    if (!core_group_2.ranges().empty()) {
+        vector<uint32_t> compute_kernel_args_group_2 = {
+            num_tiles_per_core_group_2,  // per_core_block_cnt
+            1                            // per_core_block_size
+        };
+
+        auto eltwise_unary_kernel_group_2_id = tt::tt_metal::CreateKernel(
+            program,
+            "tt_metal/kernels/compute/eltwise_sfpu.cpp",
+            core_group_2,
+            tt::tt_metal::ComputeConfig{
+                .math_fidelity = MathFidelity::HiFi4,
+                .math_approx_mode = math_approx_mode,
+                .compile_args = compute_kernel_args_group_2});
+    }
+
+    for (uint32_t i = 0, num_tiles_written = 0; i < num_cores; i++) {
+        CoreCoord core = {i / num_cores_y, i % num_cores_y};
+        uint32_t num_tiles_per_core = 0;
+        if (core_group_1.core_coord_in_core_ranges(core)) {
+            num_tiles_per_core = num_tiles_per_core_group_1;
+        } else if (core_group_2.core_coord_in_core_ranges(core)) {
+            num_tiles_per_core = num_tiles_per_core_group_2;
+        } else {
+            TT_ASSERT(false, "Core not in specified core ranges");
+        }
+
+        tt::tt_metal::SetRuntimeArgs(
+            program, unary_reader_kernel_id, core, {src_buffer->address(), num_tiles_per_core, num_tiles_written});
+
+        tt::tt_metal::SetRuntimeArgs(
+            program, unary_writer_kernel_id, core, {dst_buffer1->address(), dst_buffer2->address(), num_tiles_per_core, num_tiles_written});
+        num_tiles_written += num_tiles_per_core;
+    }
+
+    return {
+        std::move(program),
+        {.unary_reader_kernel_id = unary_reader_kernel_id, .unary_writer_kernel_id = unary_writer_kernel_id}};
+}
+
+void ExampleMultipleReturnDeviceOperation::SingleCore::override_runtime_arguments(
+    cached_program_t& cached_program,
+    const operation_attributes_t& operation_attributes,
+    const tensor_args_t& tensor_args,
+    tensor_return_value_t& tensor_return_value) {
+    auto& program = cached_program.program;
+    auto& unary_reader_kernel_id = cached_program.shared_variables.unary_reader_kernel_id;
+    auto& unary_writer_kernel_id = cached_program.shared_variables.unary_writer_kernel_id;
+
+    const auto& input_tensor = tensor_args.input_tensor;
+    auto output_tensor1 = tensor_return_value.at(0).value();
+    auto output_tensor2 = tensor_return_value.at(0);
+
+    auto src_buffer = input_tensor.buffer();
+    auto dst_buffer = output_tensor1.buffer();
+
+    {
+        auto& runtime_args = tt::tt_metal::GetRuntimeArgs(program, unary_reader_kernel_id, CoreCoord{0, 0});
+        runtime_args[0] = src_buffer->address();
+    }
+
+    {
+        auto& runtime_args = tt::tt_metal::GetRuntimeArgs(program, unary_writer_kernel_id, CoreCoord{0, 0});
+        runtime_args[0] = dst_buffer->address();
+        if (output_tensor2.has_value()) {
+            // do something
+        }
+    }
+}
+
+}  // namespace ttnn::operations::examples

--- a/ttnn/cpp/ttnn/operations/examples/example_multiple_return/device/single_core_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/examples/example_multiple_return/device/single_core_program_factory.cpp
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "example_multiple_return_device_operation.hpp"
-#include "ttnn/deprecated/tt_dnn/op_library/work_split.hpp"
+#include "tt_metal/common/work_split.hpp"
 
 namespace ttnn::operations::examples {
 ExampleMultipleReturnDeviceOperation::SingleCore::cached_program_t ExampleMultipleReturnDeviceOperation::SingleCore::create(

--- a/ttnn/cpp/ttnn/operations/examples/example_multiple_return/example_multiple_return.cpp
+++ b/ttnn/cpp/ttnn/operations/examples/example_multiple_return/example_multiple_return.cpp
@@ -1,0 +1,22 @@
+
+// SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "example_multiple_return.hpp"
+
+namespace ttnn::operations::examples {
+
+std::vector<std::optional<Tensor>> CompositeExampleMutipleReturnOperation::invoke(const Tensor& input_tensor) {
+    return prim::example_multiple_return(input_tensor);
+}
+
+std::vector<Tensor> CompositeExampleMutipleReturnOperation::create_async_output_tensors(
+    const std::vector<Tensor>& input_tensors, const std::vector<std::optional<const Tensor>>& optional_inputs) {
+    const auto& input_tensor = input_tensors.at(0);
+    return {
+        Tensor(operation::get_workers_for_op_output({input_tensor})),
+        Tensor(operation::get_workers_for_op_output({input_tensor}))};
+}
+
+}  // namespace ttnn::operations::examples

--- a/ttnn/cpp/ttnn/operations/examples/example_multiple_return/example_multiple_return.hpp
+++ b/ttnn/cpp/ttnn/operations/examples/example_multiple_return/example_multiple_return.hpp
@@ -1,0 +1,27 @@
+
+// SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include "device/example_multiple_return_device_operation.hpp"
+
+namespace ttnn::operations::examples {
+
+// A composite operation is an operation that calls multiple operations in sequence
+// It is written using invoke and can be used to call multiple primitive and/or composite operations
+struct CompositeExampleMutipleReturnOperation {
+    // The user will be able to call this method as `Tensor output = ttnn::composite_example(input_tensor)` after the op
+    // is registered
+    static std::vector<std::optional<Tensor>> invoke(const Tensor& input_tensor);
+
+    static std::vector<Tensor> create_async_output_tensors(
+        const std::vector<Tensor>& input_tensors, const std::vector<std::optional<const Tensor>>& optional_inputs);
+};
+
+}  // namespace ttnn::operations::examples
+
+namespace ttnn {
+constexpr auto composite_example_multiple_return = ttnn::register_operation_with_auto_launch_op<"ttnn::composite_example_multiple_return",operations::examples::CompositeExampleMutipleReturnOperation>();
+}  // namespace ttnn

--- a/ttnn/cpp/ttnn/operations/examples/example_multiple_return/example_multiple_return_pybind.cpp
+++ b/ttnn/cpp/ttnn/operations/examples/example_multiple_return/example_multiple_return_pybind.cpp
@@ -1,0 +1,28 @@
+// SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "ttnn/operations/examples/example_multiple_return/example_multiple_return_pybind.hpp"
+
+#include "ttnn/cpp/pybind11/decorators.hpp"
+#include "ttnn/operations/examples/example_multiple_return/example_multiple_return.hpp"
+
+namespace py = pybind11;
+
+namespace ttnn::operations::examples {
+
+void bind_example_multiple_return_operation(py::module& module) {
+    bind_registered_operation(
+        module,
+        ttnn::prim::example_multiple_return,
+        R"doc(example_multiple_return(input_tensor: ttnn.Tensor) -> std::vector<std::optional<ttnn.Tensor>>)doc",
+        ttnn::pybind_arguments_t{py::arg("input_tensor")});
+
+    bind_registered_operation(
+        module,
+        ttnn::composite_example_multiple_return,
+        R"doc(composite_example_multiple_return(input_tensor: ttnn.Tensor) -> std::vector<std::optional<Tensor>>)doc",
+        ttnn::pybind_arguments_t{py::arg("input_tensor")});
+}
+
+}  // namespace ttnn::operations::examples

--- a/ttnn/cpp/ttnn/operations/examples/example_multiple_return/example_multiple_return_pybind.hpp
+++ b/ttnn/cpp/ttnn/operations/examples/example_multiple_return/example_multiple_return_pybind.hpp
@@ -7,8 +7,9 @@
 #include <pybind11/pybind11.h>
 
 namespace py = pybind11;
+
 namespace ttnn::operations::examples {
 
-void py_module(py::module& module);
+void bind_example_multiple_return_operation(py::module& module);
 
 }  // namespace ttnn::operations::examples

--- a/ttnn/cpp/ttnn/operations/examples/examples_pybind.cpp
+++ b/ttnn/cpp/ttnn/operations/examples/examples_pybind.cpp
@@ -1,0 +1,17 @@
+// SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "examples_pybind.hpp"
+
+#include "ttnn/operations/examples/example/example_pybind.hpp"
+#include "ttnn/operations/examples/example_multiple_return/example_multiple_return_pybind.hpp"
+
+namespace ttnn::operations::examples {
+
+void py_module(py::module& module) {
+    bind_example_operation(module);
+    bind_example_multiple_return_operation(module);
+}
+
+}  // namespace ttnn::operations::examples


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/12355

### Problem description
There is currently an issue in ttnn where if you create an op that returns a vector of optional tensors and use register_operation_with_auto_launch_op, the build fails.

The problematic part is in decorator.hpp where only cases for tensor, tensors, and tuple are allowed, causing the static_assert to fail.
 - https://github.com/tenstorrent/tt-metal/blob/main/ttnn/cpp/ttnn/decorators.hpp#L284


### What's changed
Add handling for a vector of optional tensors and create an example that returns a vector of optional tensors.

### Checklist
- [ ] Post commit CI passes
- [ ] Blackhole Post commit (if applicable)
- [ ] Model regression CI testing passes (if applicable)
- [ ] New/Existing tests provide coverage for changes
