### PR TITLE
Use L1 Input to Resnet Trace

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@
 For the latest model updates and features, please see [MODEL_UPDATES.md](models/MODEL_UPDATES.md)
 
 ## TT-NN Tech Reports
-- [Advanced Performance Optimizations for Models](./tech_reports/AdvancedPerformanceOperationsForModels/AdvancedPerformanceOptimizationsForModels.md) (updated Sept 6th)
+- [Advanced Performance Optimizations for Models](./tech_reports/AdvancedPerformanceOperationsForModels/AdvancedPerformanceOptimizationsForModels.md) (updated Sept 8th)
 - [Programming Mesh of Devices](./tech_reports/Programming%20Mesh%20of%20Devices/Programming%20Mesh%20of%20Devices%20with%20TT-NN.md) (updated Sept 6th)
 ---
 

--- a/models/demos/ttnn_resnet/tests/multi_device/test_perf_ttnn_resnet.py
+++ b/models/demos/ttnn_resnet/tests/multi_device/test_perf_ttnn_resnet.py
@@ -171,32 +171,42 @@ def run_trace_model(
     device, tt_inputs, test_infra, mesh_mapper, mesh_composer, num_warmup_iterations, num_measurement_iterations
 ):
     ops_parallel_config = {}
-    tt_inputs_host, sharded_mem_config_DRAM, input_mem_config = test_infra.setup_dram_sharded_input(
+    tt_inputs_host, input_mem_config = test_infra.setup_l1_sharded_input(
         device,
         mesh_mapper=mesh_mapper,
     )
-    tt_image_res = tt_inputs_host.to(device, sharded_mem_config_DRAM)
     # Compile
     profiler.start("compile")
-    ttnn.copy_host_to_device_tensor(tt_inputs_host, tt_image_res)
-    test_infra.input_tensor = ttnn.to_memory_config(tt_image_res, input_mem_config)
+    test_infra.input_tensor = tt_inputs_host.to(device, input_mem_config)
+    shape = test_infra.input_tensor.shape
+    dtype = test_infra.input_tensor.dtype
+    layout = test_infra.input_tensor.layout
     _ = ttnn.from_device(test_infra.run(), blocking=True)
     profiler.end("compile")
     ttnn.dump_device_profiler(device)
+    test_infra.output_tensor.deallocate(force=True)
 
     profiler.start("cache")
-    ttnn.copy_host_to_device_tensor(tt_inputs_host, tt_image_res)
-    test_infra.input_tensor = ttnn.to_memory_config(tt_image_res, input_mem_config)
+    test_infra.input_tensor = tt_inputs_host.to(device, input_mem_config)
     _ = ttnn.from_device(test_infra.run(), blocking=True)
     profiler.end("cache")
     ttnn.dump_device_profiler(device)
 
     # Capture
-    ttnn.copy_host_to_device_tensor(tt_inputs_host, tt_image_res)
+    test_infra.input_tensor = tt_inputs_host.to(device, input_mem_config)
+    test_infra.output_tensor.deallocate(force=True)
+    trace_input_addr = ttnn.buffer_address(test_infra.input_tensor)
     tid = ttnn.begin_trace_capture(device, cq_id=0)
-    test_infra.input_tensor = ttnn.to_memory_config(tt_image_res, input_mem_config)
     tt_output_res = test_infra.run()
+    tt_image_res = ttnn.allocate_tensor_on_device(
+        shape,
+        dtype,
+        layout,
+        device,
+        input_mem_config,
+    )
     ttnn.end_trace_capture(device, tid, cq_id=0)
+    assert trace_input_addr == ttnn.buffer_address(tt_image_res)
     ttnn.dump_device_profiler(device)
 
     for iter in range(0, num_warmup_iterations):
@@ -272,7 +282,7 @@ def run_trace_2cq_model(
     test_infra.input_tensor = ttnn.to_memory_config(tt_image_res, input_mem_config)
     ttnn.record_event(0, op_event)
     test_infra.output_tensor.deallocate(force=True)
-    first_out_addr = ttnn.buffer_address(test_infra.input_tensor)
+    trace_input_addr = ttnn.buffer_address(test_infra.input_tensor)
 
     tid = ttnn.begin_trace_capture(device, cq_id=0)
     tt_output_res = test_infra.run()
@@ -284,7 +294,7 @@ def run_trace_2cq_model(
         input_mem_config,
     )
     ttnn.end_trace_capture(device, tid, cq_id=0)
-    assert first_out_addr == ttnn.buffer_address(input_tensor)
+    assert trace_input_addr == ttnn.buffer_address(input_tensor)
     ttnn.dump_device_profiler(device)
 
     for iter in range(0, num_warmup_iterations):

--- a/models/demos/ttnn_resnet/tests/multi_device/test_ttnn_resnet50_performant.py
+++ b/models/demos/ttnn_resnet/tests/multi_device/test_ttnn_resnet50_performant.py
@@ -79,9 +79,13 @@ def test_run_resnet50_inference(
     # First run configures convs JIT
     test_infra.input_tensor = tt_inputs_host.to(mesh_device, input_mem_config)
     test_infra.run()
+    test_infra.validate()
+
     # Optimized run
     test_infra.input_tensor = tt_inputs_host.to(mesh_device, input_mem_config)
     test_infra.run()
+    test_infra.validate()
+
     # More optimized run with caching
     if use_signpost:
         signpost(header="start")
@@ -131,28 +135,40 @@ def test_run_resnet50_trace_inference(
         output_mesh_composer=output_mesh_composer,
         model_location_generator=model_location_generator,
     )
-    tt_inputs_host, sharded_mem_config_DRAM, input_mem_config = test_infra.setup_dram_sharded_input(
+    tt_inputs_host, input_mem_config = test_infra.setup_l1_sharded_input(
         mesh_device,
         mesh_mapper=inputs_mesh_mapper,
     )
-    tt_image_res = tt_inputs_host.to(mesh_device, sharded_mem_config_DRAM)
 
     # First run configures convs JIT
-    ttnn.copy_host_to_device_tensor(tt_inputs_host, tt_image_res, 0)
-    test_infra.input_tensor = ttnn.to_memory_config(tt_image_res, input_mem_config)
+    test_infra.input_tensor = tt_inputs_host.to(mesh_device, input_mem_config)
+    shape = test_infra.input_tensor.shape
+    dtype = test_infra.input_tensor.dtype
+    layout = test_infra.input_tensor.layout
     test_infra.run()
+    test_infra.validate()
+    test_infra.output_tensor.deallocate(force=True)
 
     # Optimized run
-    ttnn.copy_host_to_device_tensor(tt_inputs_host, tt_image_res, 0)
-    test_infra.input_tensor = ttnn.to_memory_config(tt_image_res, input_mem_config)
+    test_infra.input_tensor = tt_inputs_host.to(mesh_device, input_mem_config)
     test_infra.run()
+    test_infra.validate()
 
     # Capture
-    ttnn.copy_host_to_device_tensor(tt_inputs_host, tt_image_res, 0)
+    test_infra.input_tensor = tt_inputs_host.to(mesh_device, input_mem_config)
+    test_infra.output_tensor.deallocate(force=True)
+    trace_input_addr = ttnn.buffer_address(test_infra.input_tensor)
     tid = ttnn.begin_trace_capture(mesh_device, cq_id=0)
-    test_infra.input_tensor = ttnn.to_memory_config(tt_image_res, input_mem_config)
     test_infra.run()
+    tt_image_res = ttnn.allocate_tensor_on_device(
+        shape,
+        dtype,
+        layout,
+        mesh_device,
+        input_mem_config,
+    )
     ttnn.end_trace_capture(mesh_device, tid, cq_id=0)
+    assert trace_input_addr == ttnn.buffer_address(tt_image_res)
 
     # More optimized run with caching
     if use_signpost:
@@ -317,6 +333,7 @@ def test_run_resnet50_trace_2cqs_inference(
     ttnn.record_event(0, op_event)
     test_infra.run()
     test_infra.validate()
+    test_infra.output_tensor.deallocate(force=True)
 
     # Optimized run
     ttnn.wait_for_event(1, op_event)
@@ -324,11 +341,7 @@ def test_run_resnet50_trace_2cqs_inference(
     ttnn.record_event(1, write_event)
     ttnn.wait_for_event(0, write_event)
     test_infra.input_tensor = ttnn.to_memory_config(tt_image_res, input_mem_config)
-    first_out_addr = ttnn.buffer_address(test_infra.input_tensor)
     ttnn.record_event(0, op_event)
-    # Deallocate the previous output tensor here to make allocation match capture setup
-    # This allows us to allocate the input tensor after at the same address
-    test_infra.output_tensor.deallocate(force=True)
     test_infra.run()
     test_infra.validate()
 
@@ -340,7 +353,7 @@ def test_run_resnet50_trace_2cqs_inference(
     test_infra.input_tensor = ttnn.to_memory_config(tt_image_res, input_mem_config)
     ttnn.record_event(0, op_event)
     test_infra.output_tensor.deallocate(force=True)
-    first_out_addr = ttnn.buffer_address(test_infra.input_tensor)
+    trace_input_addr = ttnn.buffer_address(test_infra.input_tensor)
     tid = ttnn.begin_trace_capture(mesh_device, cq_id=0)
     test_infra.run()
     input_tensor = ttnn.allocate_tensor_on_device(
@@ -351,8 +364,7 @@ def test_run_resnet50_trace_2cqs_inference(
         input_mem_config,
     )
     ttnn.end_trace_capture(mesh_device, tid, cq_id=0)
-    assert first_out_addr == ttnn.buffer_address(input_tensor)
-    test_infra.validate()
+    assert trace_input_addr == ttnn.buffer_address(input_tensor)
 
     # More optimized run with caching
     if use_signpost:

--- a/models/demos/ttnn_resnet/tests/test_perf_ttnn_resnet.py
+++ b/models/demos/ttnn_resnet/tests/test_perf_ttnn_resnet.py
@@ -142,29 +142,40 @@ def run_2cq_model(device, tt_inputs, test_infra, num_warmup_iterations, num_meas
 
 def run_trace_model(device, tt_inputs, test_infra, num_warmup_iterations, num_measurement_iterations):
     ops_parallel_config = {}
-    tt_inputs_host, sharded_mem_config_DRAM, input_mem_config = test_infra.setup_dram_sharded_input(device)
-    tt_image_res = tt_inputs_host.to(device, sharded_mem_config_DRAM)
+    tt_inputs_host, input_mem_config = test_infra.setup_l1_sharded_input(device)
+
     # Compile
     profiler.start("compile")
-    ttnn.copy_host_to_device_tensor(tt_inputs_host, tt_image_res)
-    test_infra.input_tensor = ttnn.to_memory_config(tt_image_res, input_mem_config)
+    test_infra.input_tensor = tt_inputs_host.to(device, input_mem_config)
+    shape = test_infra.input_tensor.shape
+    dtype = test_infra.input_tensor.dtype
+    layout = test_infra.input_tensor.layout
     _ = ttnn.from_device(test_infra.run(), blocking=True)
     profiler.end("compile")
     ttnn.DumpDeviceProfiler(device)
+    test_infra.output_tensor.deallocate(force=True)
 
     profiler.start("cache")
-    ttnn.copy_host_to_device_tensor(tt_inputs_host, tt_image_res)
-    test_infra.input_tensor = ttnn.to_memory_config(tt_image_res, input_mem_config)
+    test_infra.input_tensor = tt_inputs_host.to(device, input_mem_config)
     _ = ttnn.from_device(test_infra.run(), blocking=True)
     profiler.end("cache")
     ttnn.DumpDeviceProfiler(device)
 
     # Capture
-    ttnn.copy_host_to_device_tensor(tt_inputs_host, tt_image_res)
+    test_infra.input_tensor = tt_inputs_host.to(device, input_mem_config)
+    test_infra.output_tensor.deallocate(force=True)
+    trace_input_addr = test_infra.input_tensor.buffer_address()
     tid = ttnn.begin_trace_capture(device, cq_id=0)
-    test_infra.input_tensor = ttnn.to_memory_config(tt_image_res, input_mem_config)
     tt_output_res = test_infra.run()
+    tt_image_res = ttnn.allocate_tensor_on_device(
+        shape,
+        dtype,
+        layout,
+        device,
+        input_mem_config,
+    )
     ttnn.end_trace_capture(device, tid, cq_id=0)
+    assert trace_input_addr == tt_image_res.buffer_address()
     ttnn.DumpDeviceProfiler(device)
 
     for iter in range(0, num_warmup_iterations):
@@ -236,7 +247,7 @@ def run_trace_2cq_model(device, tt_inputs, test_infra, num_warmup_iterations, nu
     test_infra.input_tensor = ttnn.to_memory_config(tt_image_res, input_mem_config)
     ttnn.record_event(0, op_event)
     test_infra.output_tensor.deallocate(force=True)
-    first_out_addr = test_infra.input_tensor.buffer_address()
+    trace_input_addr = test_infra.input_tensor.buffer_address()
     tid = ttnn.begin_trace_capture(device, cq_id=0)
     tt_output_res = test_infra.run()
     reshard_out = ttnn.allocate_tensor_on_device(
@@ -247,7 +258,7 @@ def run_trace_2cq_model(device, tt_inputs, test_infra, num_warmup_iterations, nu
         input_mem_config,
     )
     ttnn.end_trace_capture(device, tid, cq_id=0)
-    assert first_out_addr == reshard_out.buffer_address()
+    assert trace_input_addr == reshard_out.buffer_address()
     ttnn.DumpDeviceProfiler(device)
 
     for iter in range(0, num_warmup_iterations):

--- a/models/demos/ttnn_resnet/tests/test_ttnn_resnet50_performant.py
+++ b/models/demos/ttnn_resnet/tests/test_ttnn_resnet50_performant.py
@@ -41,9 +41,13 @@ def run_resnet50_inference(
     # First run configures convs JIT
     test_infra.input_tensor = tt_inputs_host.to(device, input_mem_config)
     test_infra.run()
+    test_infra.validate()
+
     # Optimized run
     test_infra.input_tensor = tt_inputs_host.to(device, input_mem_config)
     test_infra.run()
+    test_infra.validate()
+
     # More optimized run with caching
     if use_signpost:
         signpost(header="start")
@@ -78,28 +82,40 @@ def run_resnet50_trace_inference(
         weight_dtype,
         math_fidelity,
         dealloc_input=True,
-        final_output_mem_config=ttnn.DRAM_MEMORY_CONFIG,
+        final_output_mem_config=ttnn.L1_MEMORY_CONFIG,
         model_location_generator=model_location_generator,
     )
-    tt_inputs_host, sharded_mem_config_DRAM, input_mem_config = test_infra.setup_dram_sharded_input(device)
-    tt_image_res = tt_inputs_host.to(device, sharded_mem_config_DRAM)
+    tt_inputs_host, input_mem_config = test_infra.setup_l1_sharded_input(device)
 
     # First run configures convs JIT
-    ttnn.copy_host_to_device_tensor(tt_inputs_host, tt_image_res, 0)
-    test_infra.input_tensor = ttnn.to_memory_config(tt_image_res, input_mem_config)
+    test_infra.input_tensor = tt_inputs_host.to(device, input_mem_config)
+    shape = test_infra.input_tensor.shape
+    dtype = test_infra.input_tensor.dtype
+    layout = test_infra.input_tensor.layout
     test_infra.run()
+    test_infra.validate()
+    test_infra.output_tensor.deallocate(force=True)
 
     # Optimized run
-    ttnn.copy_host_to_device_tensor(tt_inputs_host, tt_image_res, 0)
-    test_infra.input_tensor = ttnn.to_memory_config(tt_image_res, input_mem_config)
+    test_infra.input_tensor = tt_inputs_host.to(device, input_mem_config)
     test_infra.run()
+    test_infra.validate()
 
     # Capture
-    ttnn.copy_host_to_device_tensor(tt_inputs_host, tt_image_res, 0)
+    test_infra.input_tensor = tt_inputs_host.to(device, input_mem_config)
+    test_infra.output_tensor.deallocate(force=True)
+    trace_input_addr = test_infra.input_tensor.buffer_address()
     tid = ttnn.begin_trace_capture(device, cq_id=0)
-    test_infra.input_tensor = ttnn.to_memory_config(tt_image_res, input_mem_config)
     test_infra.run()
+    tt_image_res = ttnn.allocate_tensor_on_device(
+        shape,
+        dtype,
+        layout,
+        device,
+        input_mem_config,
+    )
     ttnn.end_trace_capture(device, tid, cq_id=0)
+    assert trace_input_addr == tt_image_res.buffer_address()
 
     # More optimized run with caching
     if use_signpost:
@@ -198,7 +214,7 @@ def run_resnet50_trace_2cqs_inference(
         weight_dtype,
         math_fidelity,
         dealloc_input=True,
-        final_output_mem_config=ttnn.DRAM_MEMORY_CONFIG,
+        final_output_mem_config=ttnn.L1_MEMORY_CONFIG,
         model_location_generator=model_location_generator,
     )
     tt_inputs_host, sharded_mem_config_DRAM, input_mem_config = test_infra.setup_dram_sharded_input(device)
@@ -220,6 +236,7 @@ def run_resnet50_trace_2cqs_inference(
     ttnn.record_event(0, op_event)
     test_infra.run()
     test_infra.validate()
+    test_infra.output_tensor.deallocate(force=True)
 
     # Optimized run
     ttnn.wait_for_event(1, op_event)
@@ -228,9 +245,6 @@ def run_resnet50_trace_2cqs_inference(
     ttnn.wait_for_event(0, write_event)
     test_infra.input_tensor = ttnn.to_memory_config(tt_image_res, input_mem_config)
     ttnn.record_event(0, op_event)
-    # Deallocate the previous output tensor here to make allocation match capture setup
-    # This allows us to allocate the input tensor after at the same address
-    test_infra.output_tensor.deallocate(force=True)
     test_infra.run()
     test_infra.validate()
 
@@ -242,7 +256,7 @@ def run_resnet50_trace_2cqs_inference(
     test_infra.input_tensor = ttnn.to_memory_config(tt_image_res, input_mem_config)
     ttnn.record_event(0, op_event)
     test_infra.output_tensor.deallocate(force=True)
-    first_out_addr = test_infra.input_tensor.buffer_address()
+    trace_input_addr = test_infra.input_tensor.buffer_address()
     tid = ttnn.begin_trace_capture(device, cq_id=0)
     test_infra.run()
     input_tensor = ttnn.allocate_tensor_on_device(
@@ -253,8 +267,7 @@ def run_resnet50_trace_2cqs_inference(
         input_mem_config,
     )
     ttnn.end_trace_capture(device, tid, cq_id=0)
-    assert first_out_addr == input_tensor.buffer_address()
-    test_infra.validate()
+    assert trace_input_addr == input_tensor.buffer_address()
 
     # More optimized run with caching
     if use_signpost:


### PR DESCRIPTION
### What's changed
Update resnet and trace docs on using L1 input to trace when we can't allocate a persistent l1 tensor

### Checklist
- [x] Model regression CI testing passes (if applicable)
- [x] New/Existing tests provide coverage for changes
