### PR TITLE
enable persistent EDM kernels for all-gather

### DIFF
--- a/tests/tt_metal/tt_metal/unit_tests_fast_dispatch/command_queue/test_EnqueueProgram.cpp
+++ b/tests/tt_metal/tt_metal/unit_tests_fast_dispatch/command_queue/test_EnqueueProgram.cpp
@@ -640,9 +640,9 @@ bool test_increment_runtime_args_sanity(Device* device, const DummyProgramConfig
 
 // Create randomly sized pair of unique and common runtime args vectors, with careful not to exceed max between the two.
 // Optionally force the max size for one of the vectors.
-std::pair<std::vector<uint32_t>, std::vector<uint32_t>> create_runtime_args(bool force_max_size = false, uint32_t unique_base = 0, uint32_t common_base = 100){
+std::pair<std::vector<uint32_t>, std::vector<uint32_t>> create_runtime_args(bool force_max_size = false, std::vector<uint32_t> rt_args_unique = {}, uint32_t unique_base = 0, uint32_t common_base = 100){
 
-    constexpr uint32_t MAX_RUNTIME_ARGS = 256;
+    uint32_t MAX_RUNTIME_ARGS = 256 - rt_args_unique.size();
 
     // Generate Unique Runtime Args. Common RT args starting address must be L1 Aligned, so account for that here via padding
     uint32_t num_rt_args_unique = rand() % (MAX_RUNTIME_ARGS + 1);
@@ -663,7 +663,6 @@ std::pair<std::vector<uint32_t>, std::vector<uint32_t>> create_runtime_args(bool
         rt_args_common.push_back(common_base + i);
     }
 
-    vector<uint32_t> rt_args_unique;
     for (uint32_t i = 0; i < num_rt_args_unique; i++) {
         rt_args_unique.push_back(unique_base + i);
     }
@@ -1404,6 +1403,486 @@ TEST_F(CommandQueueFixture, TestRandomizedProgram) {
         std::shuffle(std::begin(programs), std::end(programs), rng);
         if (i % 50 == 0) {
             log_info(tt::LogTest, "Enqueueing {} programs for iter: {}/{} now.", programs.size(), i+1, NUM_ITERATIONS);
+        }
+        for (Program& program: programs) {
+            EnqueueProgram(this->device_->command_queue(), program, false);
+        }
+    }
+
+    log_info(tt::LogTest, "Calling Finish.");
+    Finish(this->device_->command_queue());
+}
+
+
+TEST_F(CommandQueueFixture, TestRandomizedPersistentProgram) {
+    uint32_t NUM_PROGRAMS = 100;
+    uint32_t MAX_LOOP = 100;
+    uint32_t page_size = 1024;
+
+    // Make random
+    auto random_seed = 0; // (unsigned int)time(NULL);
+    uint32_t seed = tt::parse_env("SEED", random_seed);
+    log_info(tt::LogTest, "Using Test Seed: {}", seed);
+    srand(seed);
+
+    CoreCoord worker_grid_size = this->device_->compute_with_storage_grid_size();
+    CoreRange cr({0, 0}, {worker_grid_size.x - 1, worker_grid_size.y - 1});
+    CoreRangeSet cr_set({cr});
+
+    log_info(tt::LogTest, "Starting compile of {} programs now.", NUM_PROGRAMS);
+
+    std::map<string, string> data_movement_defines = {{"DATA_MOVEMENT", "1"}};
+    std::map<string, string> compute_defines = {{"COMPUTE", "1"}};
+
+    vector<uint32_t> brisc_compile_args = {page_size};
+
+    vector<uint32_t> ncrisc_compile_args = {page_size};
+
+    vector<uint32_t> trisc_compile_args = {page_size};
+
+    // Create our persistent program
+    auto persistent_program = CreatePersistentProgram();
+
+    auto persistent_brisc_kernel = CreateKernel(
+        persistent_program, "tests/tt_metal/tt_metal/test_kernels/dataflow/unit_tests/command_queue/random_persistent_program.cpp", cr_set, DataMovementConfig{
+            .processor = DataMovementProcessor::RISCV_0, .noc = NOC::RISCV_0_default, .compile_args = brisc_compile_args, .defines = data_movement_defines});
+
+    auto persistent_ncrisc_kernel = CreateKernel(
+        persistent_program, "tests/tt_metal/tt_metal/test_kernels/dataflow/unit_tests/command_queue/random_persistent_program.cpp", cr_set, DataMovementConfig{
+            .processor = DataMovementProcessor::RISCV_1, .noc = NOC::RISCV_1_default, .compile_args = ncrisc_compile_args, .defines = data_movement_defines});
+
+    auto persistent_trisc_kernel = CreateKernel(
+        persistent_program, "tests/tt_metal/tt_metal/test_kernels/dataflow/unit_tests/command_queue/random_persistent_program.cpp", cr_set, ComputeConfig{
+            .math_approx_mode = false,
+            .compile_args = trisc_compile_args,
+            .defines = compute_defines
+        });
+
+    tt::tt_metal::detail::CompileProgram(this->device_, persistent_program);
+    EnqueueProgram(this->device_->command_queue(), persistent_program, false);
+
+    vector<Program> programs;
+    for (uint32_t i = 0; i < NUM_PROGRAMS; i++) {
+        programs.push_back(Program());
+        Program& program = programs.back();
+
+        // brisc
+        uint32_t BRISC_OUTER_LOOP, BRISC_MIDDLE_LOOP, BRISC_INNER_LOOP, NUM_CBS, NUM_SEMS;
+        bool USE_MAX_RT_ARGS;
+
+        if (i % 10 == 0) {
+            log_info(tt::LogTest, "Compiling program {} of {}", i + 1, NUM_PROGRAMS);
+        }
+
+        if (i == 0) {
+            // Ensures that we get at least one compilation with the max amount to
+            // ensure it compiles and runs
+            BRISC_OUTER_LOOP = MAX_LOOP;
+            BRISC_MIDDLE_LOOP = MAX_LOOP;
+            BRISC_INNER_LOOP = MAX_LOOP;
+            NUM_CBS = NUM_CIRCULAR_BUFFERS;
+            NUM_SEMS = NUM_SEMAPHORES;
+            USE_MAX_RT_ARGS = true;
+        } else {
+            BRISC_OUTER_LOOP = rand() % (MAX_LOOP) + 1;
+            BRISC_MIDDLE_LOOP = rand() % (MAX_LOOP) + 1;
+            BRISC_INNER_LOOP = rand() % (MAX_LOOP) + 1;
+            NUM_CBS = rand() % (NUM_CIRCULAR_BUFFERS) + 1;
+            NUM_SEMS = rand() % (NUM_SEMAPHORES) + 1;
+            USE_MAX_RT_ARGS = false;
+        }
+
+        log_debug(tt::LogTest, "Compiling program {}/{} w/ BRISC_OUTER_LOOP: {} BRISC_MIDDLE_LOOP: {} BRISC_INNER_LOOP: {} NUM_CBS: {} NUM_SEMS: {} USE_MAX_RT_ARGS: {}",
+                 i+1, NUM_PROGRAMS, BRISC_OUTER_LOOP, BRISC_MIDDLE_LOOP, BRISC_INNER_LOOP, NUM_CBS, NUM_SEMS, USE_MAX_RT_ARGS);
+
+        for (uint32_t j = 0; j < NUM_CBS; j++) {
+            CircularBufferConfig cb_config = CircularBufferConfig(page_size * (j + 1), {{j, tt::DataFormat::Float16_b}}).set_page_size(j, page_size * (j + 1));
+            auto cb = CreateCircularBuffer(program, cr_set, cb_config);
+        }
+
+        for (uint32_t j = 0; j < NUM_SEMS; j++) {
+            CreateSemaphore(program, cr_set, j + 1);
+        }
+
+        vector<uint32_t> brisc_unique_rtargs_base = {BRISC_OUTER_LOOP, BRISC_MIDDLE_LOOP, BRISC_INNER_LOOP, NUM_CBS, NUM_SEMS, 0, 0};
+        auto [brisc_unique_rtargs, brisc_common_rtargs] = local_test_functions::create_runtime_args(USE_MAX_RT_ARGS, brisc_unique_rtargs_base);
+        uint32_t num_brisc_unique_rtargs = brisc_unique_rtargs.size();
+        uint32_t num_brisc_common_rtargs = brisc_common_rtargs.size();
+        brisc_unique_rtargs[5] = num_brisc_unique_rtargs - brisc_unique_rtargs_base.size();
+        brisc_unique_rtargs[6] = num_brisc_common_rtargs;
+
+
+        // ncrisc
+        uint32_t NCRISC_OUTER_LOOP, NCRISC_MIDDLE_LOOP, NCRISC_INNER_LOOP;
+        if (i == 0) {
+            NCRISC_OUTER_LOOP = MAX_LOOP;
+            NCRISC_MIDDLE_LOOP = MAX_LOOP;
+            NCRISC_INNER_LOOP = MAX_LOOP;
+        } else {
+            NCRISC_OUTER_LOOP = rand() % (MAX_LOOP) + 1;
+            NCRISC_MIDDLE_LOOP = rand() % (MAX_LOOP) + 1;
+            NCRISC_INNER_LOOP = rand() % (MAX_LOOP) + 1;
+        }
+
+        vector<uint32_t> ncrisc_unique_rtargs_base = {NCRISC_OUTER_LOOP, NCRISC_MIDDLE_LOOP, NCRISC_INNER_LOOP, NUM_CBS, NUM_SEMS, 0, 0};
+        auto [ncrisc_unique_rtargs, ncrisc_common_rtargs] = local_test_functions::create_runtime_args(USE_MAX_RT_ARGS, ncrisc_unique_rtargs_base);
+        uint32_t num_ncrisc_unique_rtargs = ncrisc_unique_rtargs.size();
+        uint32_t num_ncrisc_common_rtargs = ncrisc_common_rtargs.size();
+        ncrisc_unique_rtargs[5] = num_ncrisc_unique_rtargs - ncrisc_unique_rtargs_base.size();
+        ncrisc_unique_rtargs[6] = num_ncrisc_common_rtargs;
+
+
+        // trisc
+        uint32_t TRISC_OUTER_LOOP, TRISC_MIDDLE_LOOP, TRISC_INNER_LOOP;
+        if (i == 0) {
+            TRISC_OUTER_LOOP = MAX_LOOP;
+            TRISC_MIDDLE_LOOP = MAX_LOOP;
+            TRISC_INNER_LOOP = MAX_LOOP;
+        } else {
+            TRISC_OUTER_LOOP = rand() % (MAX_LOOP) + 1;
+            TRISC_MIDDLE_LOOP = rand() % (MAX_LOOP) + 1;
+            TRISC_INNER_LOOP = rand() % (MAX_LOOP) + 1;
+        }
+
+        vector<uint32_t> trisc_unique_rtargs_base = {TRISC_OUTER_LOOP, TRISC_MIDDLE_LOOP, TRISC_INNER_LOOP, NUM_CBS, NUM_SEMS, 0, 0};
+        auto [trisc_unique_rtargs, trisc_common_rtargs] = local_test_functions::create_runtime_args(USE_MAX_RT_ARGS, trisc_unique_rtargs_base);
+        uint32_t num_trisc_unique_rtargs = trisc_unique_rtargs.size();
+        uint32_t num_trisc_common_rtargs = trisc_common_rtargs.size();
+        trisc_unique_rtargs[5] = num_trisc_unique_rtargs - trisc_unique_rtargs_base.size();
+        trisc_unique_rtargs[6] = num_trisc_common_rtargs;
+
+
+        bool at_least_one_kernel = false;
+        if (i == 0 or ((rand() % 2) == 0)) {
+            auto dummy_brisc_kernel = AttachPersistentKernel(
+                program, "tests/tt_metal/tt_metal/test_kernels/dataflow/unit_tests/command_queue/random_persistent_program.cpp", cr_set, DataMovementConfig{
+                    .processor = DataMovementProcessor::RISCV_0, .noc = NOC::RISCV_0_default, .compile_args = brisc_compile_args, .defines = data_movement_defines}, this->device_);
+            SetRuntimeArgs(program, dummy_brisc_kernel, cr_set, brisc_unique_rtargs);
+            SetCommonRuntimeArgs(program, dummy_brisc_kernel, brisc_common_rtargs);
+            at_least_one_kernel = true;
+        }
+
+        if (i == 0 or ((rand() % 2) == 0)) {
+            auto dummy_ncrisc_kernel = AttachPersistentKernel(
+                program, "tests/tt_metal/tt_metal/test_kernels/dataflow/unit_tests/command_queue/random_persistent_program.cpp", cr_set, DataMovementConfig{
+                    .processor = DataMovementProcessor::RISCV_1, .noc = NOC::RISCV_1_default, .compile_args = ncrisc_compile_args, .defines = data_movement_defines}, this->device_);
+            SetRuntimeArgs(program, dummy_ncrisc_kernel, cr_set, ncrisc_unique_rtargs);
+            SetCommonRuntimeArgs(program, dummy_ncrisc_kernel, ncrisc_common_rtargs);
+            at_least_one_kernel = true;
+        }
+
+        if (i == 0 or ((rand() % 2) == 0)) {
+            auto dummy_trisc_kernel = AttachPersistentKernel(
+                program, "tests/tt_metal/tt_metal/test_kernels/dataflow/unit_tests/command_queue/random_persistent_program.cpp", cr_set, ComputeConfig{
+                    .math_approx_mode = false,
+                    .compile_args = trisc_compile_args,
+                    .defines = compute_defines
+                }, this->device_);
+            SetRuntimeArgs(program, dummy_trisc_kernel, cr_set, trisc_unique_rtargs);
+            SetCommonRuntimeArgs(program, dummy_trisc_kernel, trisc_common_rtargs);
+            at_least_one_kernel = true;
+        }
+
+        if (not at_least_one_kernel) {
+            uint32_t random_risc = rand() % 3 + 1;
+            if (random_risc == 1) {
+                auto dummy_brisc_kernel = AttachPersistentKernel(
+                    program, "tests/tt_metal/tt_metal/test_kernels/dataflow/unit_tests/command_queue/random_persistent_program.cpp", cr_set, DataMovementConfig{
+                        .processor = DataMovementProcessor::RISCV_0, .noc = NOC::RISCV_0_default, .compile_args = brisc_compile_args, .defines = data_movement_defines}, this->device_);
+                SetRuntimeArgs(program, dummy_brisc_kernel, cr_set, brisc_unique_rtargs);
+                SetCommonRuntimeArgs(program, dummy_brisc_kernel, brisc_common_rtargs);
+            } else if (random_risc == 2) {
+                auto dummy_ncrisc_kernel = AttachPersistentKernel(
+                    program, "tests/tt_metal/tt_metal/test_kernels/dataflow/unit_tests/command_queue/random_persistent_program.cpp", cr_set, DataMovementConfig{
+                        .processor = DataMovementProcessor::RISCV_1, .noc = NOC::RISCV_1_default, .compile_args = ncrisc_compile_args, .defines = data_movement_defines}, this->device_);
+                SetRuntimeArgs(program, dummy_ncrisc_kernel, cr_set, ncrisc_unique_rtargs);
+                SetCommonRuntimeArgs(program, dummy_ncrisc_kernel, ncrisc_common_rtargs);
+            } else if (random_risc == 3) {
+                auto dummy_trisc_kernel = AttachPersistentKernel(
+                    program, "tests/tt_metal/tt_metal/test_kernels/dataflow/unit_tests/command_queue/random_persistent_program.cpp", cr_set, ComputeConfig{
+                        .math_approx_mode = false,
+                        .compile_args = trisc_compile_args,
+                        .defines = compute_defines
+                    }, this->device_);
+                SetRuntimeArgs(program, dummy_trisc_kernel, cr_set, trisc_unique_rtargs);
+                SetCommonRuntimeArgs(program, dummy_trisc_kernel, trisc_common_rtargs);
+            } else {
+                TT_ASSERT("Invalid");
+            }
+        }
+
+        tt::tt_metal::detail::CompileProgram(this->device_, program);
+    }
+
+    log_info(tt::LogTest, "Running {} programs for cache warmup.", programs.size());
+    // This loop caches program and runs
+    for (Program& program: programs) {
+        EnqueueProgram(this->device_->command_queue(), program, false);
+    }
+
+    // This loops assumes already cached
+    uint32_t NUM_ITERATIONS = 500; // TODO(agrebenisan): Bump this to 5000, saw hangs for very large number of iterations, need to come back to that
+
+    log_info(tt::LogTest, "Running {} programs for {} iterations now.", programs.size(), NUM_ITERATIONS);
+    for (uint32_t i = 0; i < NUM_ITERATIONS; i++) {
+        auto rng = std::default_random_engine {};
+        std::shuffle(std::begin(programs), std::end(programs), rng);
+        if (i % 50 == 0) {
+            log_info(tt::LogTest, "Enqueueing {} programs for iter: {}/{} now.", programs.size(), i+1, NUM_ITERATIONS);
+        }
+        for (Program& program: programs) {
+            EnqueueProgram(this->device_->command_queue(), program, false);
+        }
+    }
+
+    log_info(tt::LogTest, "Calling Finish.");
+    Finish(this->device_->command_queue());
+}
+
+TEST_F(CommandQueueFixture, TestReloadPersistentProgram) {
+    uint32_t NUM_PROGRAMS = 100;
+    uint32_t MAX_LOOP = 100;
+    uint32_t page_size = 1024;
+
+    // Make random
+    auto random_seed = 0; // (unsigned int)time(NULL);
+    uint32_t seed = tt::parse_env("SEED", random_seed);
+    log_info(tt::LogTest, "Using Test Seed: {}", seed);
+    srand(seed);
+
+    CoreCoord worker_grid_size = this->device_->compute_with_storage_grid_size();
+    CoreRange cr({0, 0}, {worker_grid_size.x - 1, worker_grid_size.y - 1});
+    CoreRangeSet cr_set({cr});
+
+    log_info(tt::LogTest, "Starting compile of {} programs now.", NUM_PROGRAMS);
+
+    std::map<string, string> data_movement_defines = {{"DATA_MOVEMENT", "1"}};
+    std::map<string, string> compute_defines = {{"COMPUTE", "1"}};
+
+    vector<uint32_t> brisc_compile_args = {page_size};
+
+    vector<uint32_t> ncrisc_compile_args = {page_size};
+
+    vector<uint32_t> trisc_compile_args = {page_size};
+
+    // Create our persistent program
+
+    auto persistent_program = CreatePersistentProgram();
+
+    auto persistent_brisc_kernel = CreateKernel(
+        persistent_program, "tests/tt_metal/tt_metal/test_kernels/dataflow/unit_tests/command_queue/random_persistent_program.cpp", cr_set, DataMovementConfig{
+            .processor = DataMovementProcessor::RISCV_0, .noc = NOC::RISCV_0_default, .compile_args = brisc_compile_args, .defines = data_movement_defines});
+
+    auto persistent_ncrisc_kernel = CreateKernel(
+        persistent_program, "tests/tt_metal/tt_metal/test_kernels/dataflow/unit_tests/command_queue/random_persistent_program.cpp", cr_set, DataMovementConfig{
+            .processor = DataMovementProcessor::RISCV_1, .noc = NOC::RISCV_1_default, .compile_args = ncrisc_compile_args, .defines = data_movement_defines});
+
+    auto persistent_trisc_kernel = CreateKernel(
+        persistent_program, "tests/tt_metal/tt_metal/test_kernels/dataflow/unit_tests/command_queue/random_persistent_program.cpp", cr_set, ComputeConfig{
+            .math_approx_mode = false,
+            .compile_args = trisc_compile_args,
+            .defines = compute_defines
+        });
+
+    tt::tt_metal::detail::CompileProgram(this->device_, persistent_program);
+    EnqueueProgram(this->device_->command_queue(), persistent_program, false);
+
+    vector<Program> programs;
+    for (uint32_t i = 0; i < NUM_PROGRAMS; i++) {
+        programs.push_back(Program());
+        Program& program = programs.back();
+
+        // brisc
+        uint32_t BRISC_OUTER_LOOP, BRISC_MIDDLE_LOOP, BRISC_INNER_LOOP, NUM_CBS, NUM_SEMS;
+        bool USE_MAX_RT_ARGS;
+
+        if (i % 10 == 0) {
+            log_info(tt::LogTest, "Compiling program {} of {}", i + 1, NUM_PROGRAMS);
+        }
+
+        if (i == 0) {
+            // Ensures that we get at least one compilation with the max amount to
+            // ensure it compiles and runs
+            BRISC_OUTER_LOOP = MAX_LOOP;
+            BRISC_MIDDLE_LOOP = MAX_LOOP;
+            BRISC_INNER_LOOP = MAX_LOOP;
+            NUM_CBS = NUM_CIRCULAR_BUFFERS;
+            NUM_SEMS = NUM_SEMAPHORES;
+            USE_MAX_RT_ARGS = true;
+        } else {
+            BRISC_OUTER_LOOP = rand() % (MAX_LOOP) + 1;
+            BRISC_MIDDLE_LOOP = rand() % (MAX_LOOP) + 1;
+            BRISC_INNER_LOOP = rand() % (MAX_LOOP) + 1;
+            NUM_CBS = rand() % (NUM_CIRCULAR_BUFFERS) + 1;
+            NUM_SEMS = rand() % (NUM_SEMAPHORES) + 1;
+            USE_MAX_RT_ARGS = false;
+        }
+
+        log_debug(tt::LogTest, "Compiling program {}/{} w/ BRISC_OUTER_LOOP: {} BRISC_MIDDLE_LOOP: {} BRISC_INNER_LOOP: {} NUM_CBS: {} NUM_SEMS: {} USE_MAX_RT_ARGS: {}",
+                 i+1, NUM_PROGRAMS, BRISC_OUTER_LOOP, BRISC_MIDDLE_LOOP, BRISC_INNER_LOOP, NUM_CBS, NUM_SEMS, USE_MAX_RT_ARGS);
+
+        for (uint32_t j = 0; j < NUM_CBS; j++) {
+            CircularBufferConfig cb_config = CircularBufferConfig(page_size * (j + 1), {{j, tt::DataFormat::Float16_b}}).set_page_size(j, page_size * (j + 1));
+            auto cb = CreateCircularBuffer(program, cr_set, cb_config);
+        }
+
+        for (uint32_t j = 0; j < NUM_SEMS; j++) {
+            CreateSemaphore(program, cr_set, j + 1);
+        }
+
+        vector<uint32_t> brisc_unique_rtargs_base = {BRISC_OUTER_LOOP, BRISC_MIDDLE_LOOP, BRISC_INNER_LOOP, NUM_CBS, NUM_SEMS, 0, 0};
+        auto [brisc_unique_rtargs, brisc_common_rtargs] = local_test_functions::create_runtime_args(USE_MAX_RT_ARGS, brisc_unique_rtargs_base);
+        uint32_t num_brisc_unique_rtargs = brisc_unique_rtargs.size();
+        uint32_t num_brisc_common_rtargs = brisc_common_rtargs.size();
+        brisc_unique_rtargs[5] = num_brisc_unique_rtargs - brisc_unique_rtargs_base.size();
+        brisc_unique_rtargs[6] = num_brisc_common_rtargs;
+
+
+        // ncrisc
+        uint32_t NCRISC_OUTER_LOOP, NCRISC_MIDDLE_LOOP, NCRISC_INNER_LOOP;
+        if (i == 0) {
+            NCRISC_OUTER_LOOP = MAX_LOOP;
+            NCRISC_MIDDLE_LOOP = MAX_LOOP;
+            NCRISC_INNER_LOOP = MAX_LOOP;
+        } else {
+            NCRISC_OUTER_LOOP = rand() % (MAX_LOOP) + 1;
+            NCRISC_MIDDLE_LOOP = rand() % (MAX_LOOP) + 1;
+            NCRISC_INNER_LOOP = rand() % (MAX_LOOP) + 1;
+        }
+
+        vector<uint32_t> ncrisc_unique_rtargs_base = {NCRISC_OUTER_LOOP, NCRISC_MIDDLE_LOOP, NCRISC_INNER_LOOP, NUM_CBS, NUM_SEMS, 0, 0};
+        auto [ncrisc_unique_rtargs, ncrisc_common_rtargs] = local_test_functions::create_runtime_args(USE_MAX_RT_ARGS, ncrisc_unique_rtargs_base);
+        uint32_t num_ncrisc_unique_rtargs = ncrisc_unique_rtargs.size();
+        uint32_t num_ncrisc_common_rtargs = ncrisc_common_rtargs.size();
+        ncrisc_unique_rtargs[5] = num_ncrisc_unique_rtargs - ncrisc_unique_rtargs_base.size();
+        ncrisc_unique_rtargs[6] = num_ncrisc_common_rtargs;
+
+
+        // trisc
+        uint32_t TRISC_OUTER_LOOP, TRISC_MIDDLE_LOOP, TRISC_INNER_LOOP;
+        if (i == 0) {
+            TRISC_OUTER_LOOP = MAX_LOOP;
+            TRISC_MIDDLE_LOOP = MAX_LOOP;
+            TRISC_INNER_LOOP = MAX_LOOP;
+        } else {
+            TRISC_OUTER_LOOP = rand() % (MAX_LOOP) + 1;
+            TRISC_MIDDLE_LOOP = rand() % (MAX_LOOP) + 1;
+            TRISC_INNER_LOOP = rand() % (MAX_LOOP) + 1;
+        }
+
+        vector<uint32_t> trisc_unique_rtargs_base = {TRISC_OUTER_LOOP, TRISC_MIDDLE_LOOP, TRISC_INNER_LOOP, NUM_CBS, NUM_SEMS, 0, 0};
+        auto [trisc_unique_rtargs, trisc_common_rtargs] = local_test_functions::create_runtime_args(USE_MAX_RT_ARGS, trisc_unique_rtargs_base);
+        uint32_t num_trisc_unique_rtargs = trisc_unique_rtargs.size();
+        uint32_t num_trisc_common_rtargs = trisc_common_rtargs.size();
+        trisc_unique_rtargs[5] = num_trisc_unique_rtargs - trisc_unique_rtargs_base.size();
+        trisc_unique_rtargs[6] = num_trisc_common_rtargs;
+
+        bool attach = i % 2 == 0;
+
+        bool at_least_one_kernel = false;
+        if (i == 0 or ((rand() % 2) == 0)) {
+            auto dummy_brisc_kernel = attach ? AttachPersistentKernel(
+                program, "tests/tt_metal/tt_metal/test_kernels/dataflow/unit_tests/command_queue/random_persistent_program.cpp", cr_set, DataMovementConfig{
+                    .processor = DataMovementProcessor::RISCV_0, .noc = NOC::RISCV_0_default, .compile_args = brisc_compile_args, .defines = data_movement_defines}, this->device_) :
+                CreateKernel(
+                program, "tests/tt_metal/tt_metal/test_kernels/dataflow/unit_tests/command_queue/random_persistent_program.cpp", cr_set, DataMovementConfig{
+                    .processor = DataMovementProcessor::RISCV_0, .noc = NOC::RISCV_0_default, .compile_args = brisc_compile_args, .defines = data_movement_defines});
+            SetRuntimeArgs(program, dummy_brisc_kernel, cr_set, brisc_unique_rtargs);
+            SetCommonRuntimeArgs(program, dummy_brisc_kernel, brisc_common_rtargs);
+            at_least_one_kernel = true;
+        }
+
+        if (i == 0 or ((rand() % 2) == 0)) {
+            auto dummy_ncrisc_kernel = attach ? AttachPersistentKernel(
+                program, "tests/tt_metal/tt_metal/test_kernels/dataflow/unit_tests/command_queue/random_persistent_program.cpp", cr_set, DataMovementConfig{
+                    .processor = DataMovementProcessor::RISCV_1, .noc = NOC::RISCV_1_default, .compile_args = ncrisc_compile_args, .defines = data_movement_defines}, this->device_) :
+                CreateKernel(
+                program, "tests/tt_metal/tt_metal/test_kernels/dataflow/unit_tests/command_queue/random_persistent_program.cpp", cr_set, DataMovementConfig{
+                    .processor = DataMovementProcessor::RISCV_1, .noc = NOC::RISCV_1_default, .compile_args = ncrisc_compile_args, .defines = data_movement_defines});
+            SetRuntimeArgs(program, dummy_ncrisc_kernel, cr_set, ncrisc_unique_rtargs);
+            SetCommonRuntimeArgs(program, dummy_ncrisc_kernel, ncrisc_common_rtargs);
+            at_least_one_kernel = true;
+        }
+
+        if (i == 0 or ((rand() % 2) == 0)) {
+            auto dummy_trisc_kernel = attach ? AttachPersistentKernel(
+                program, "tests/tt_metal/tt_metal/test_kernels/dataflow/unit_tests/command_queue/random_persistent_program.cpp", cr_set, ComputeConfig{
+                    .math_approx_mode = false,
+                    .compile_args = trisc_compile_args,
+                    .defines = compute_defines
+                }, this->device_) :
+                CreateKernel(
+                program, "tests/tt_metal/tt_metal/test_kernels/dataflow/unit_tests/command_queue/random_persistent_program.cpp", cr_set, ComputeConfig{
+                    .math_approx_mode = false,
+                    .compile_args = trisc_compile_args,
+                    .defines = compute_defines
+                });
+            SetRuntimeArgs(program, dummy_trisc_kernel, cr_set, trisc_unique_rtargs);
+            SetCommonRuntimeArgs(program, dummy_trisc_kernel, trisc_common_rtargs);
+            at_least_one_kernel = true;
+        }
+
+        if (not at_least_one_kernel) {
+            uint32_t random_risc = rand() % 3 + 1;
+            if (random_risc == 1) {
+                auto dummy_brisc_kernel = attach ? AttachPersistentKernel(
+                    program, "tests/tt_metal/tt_metal/test_kernels/dataflow/unit_tests/command_queue/random_persistent_program.cpp", cr_set, DataMovementConfig{
+                        .processor = DataMovementProcessor::RISCV_0, .noc = NOC::RISCV_0_default, .compile_args = brisc_compile_args, .defines = data_movement_defines}, this->device_) :
+                    CreateKernel(
+                    program, "tests/tt_metal/tt_metal/test_kernels/dataflow/unit_tests/command_queue/random_persistent_program.cpp", cr_set, DataMovementConfig{
+                        .processor = DataMovementProcessor::RISCV_0, .noc = NOC::RISCV_0_default, .compile_args = brisc_compile_args, .defines = data_movement_defines});
+                SetRuntimeArgs(program, dummy_brisc_kernel, cr_set, brisc_unique_rtargs);
+                SetCommonRuntimeArgs(program, dummy_brisc_kernel, brisc_common_rtargs);
+            } else if (random_risc == 2) {
+                auto dummy_ncrisc_kernel = attach ? AttachPersistentKernel(
+                    program, "tests/tt_metal/tt_metal/test_kernels/dataflow/unit_tests/command_queue/random_persistent_program.cpp", cr_set, DataMovementConfig{
+                        .processor = DataMovementProcessor::RISCV_1, .noc = NOC::RISCV_1_default, .compile_args = ncrisc_compile_args, .defines = data_movement_defines}, this->device_) :
+                    CreateKernel(
+                    program, "tests/tt_metal/tt_metal/test_kernels/dataflow/unit_tests/command_queue/random_persistent_program.cpp", cr_set, DataMovementConfig{
+                        .processor = DataMovementProcessor::RISCV_1, .noc = NOC::RISCV_1_default, .compile_args = ncrisc_compile_args, .defines = data_movement_defines});
+                SetRuntimeArgs(program, dummy_ncrisc_kernel, cr_set, ncrisc_unique_rtargs);
+                SetCommonRuntimeArgs(program, dummy_ncrisc_kernel, ncrisc_common_rtargs);
+            } else if (random_risc == 3) {
+                auto dummy_trisc_kernel = attach ? AttachPersistentKernel(
+                    program, "tests/tt_metal/tt_metal/test_kernels/dataflow/unit_tests/command_queue/random_persistent_program.cpp", cr_set, ComputeConfig{
+                        .math_approx_mode = false,
+                        .compile_args = trisc_compile_args,
+                        .defines = compute_defines
+                    }, this->device_) :
+                    CreateKernel(
+                    program, "tests/tt_metal/tt_metal/test_kernels/dataflow/unit_tests/command_queue/random_persistent_program.cpp", cr_set, ComputeConfig{
+                        .math_approx_mode = false,
+                        .compile_args = trisc_compile_args,
+                        .defines = compute_defines
+                    });
+                SetRuntimeArgs(program, dummy_trisc_kernel, cr_set, trisc_unique_rtargs);
+                SetCommonRuntimeArgs(program, dummy_trisc_kernel, trisc_common_rtargs);
+            } else {
+                TT_ASSERT("Invalid");
+            }
+        }
+
+        tt::tt_metal::detail::CompileProgram(this->device_, program);
+    }
+
+    log_info(tt::LogTest, "Running {} programs for cache warmup.", programs.size());
+    // This loop caches program and runs
+    for (Program& program: programs) {
+        EnqueueProgram(this->device_->command_queue(), program, false);
+    }
+
+    // This loops assumes already cached
+    uint32_t NUM_ITERATIONS = 500; // TODO(agrebenisan): Bump this to 5000, saw hangs for very large number of iterations, need to come back to that
+
+    log_info(tt::LogTest, "Running {} programs for {} iterations now.", programs.size(), NUM_ITERATIONS);
+    for (uint32_t i = 0; i < NUM_ITERATIONS; i++) {
+        auto rng = std::default_random_engine {};
+        std::shuffle(std::begin(programs), std::end(programs), rng);
+        if (i % 50 == 0) {
+            log_info(tt::LogTest, "Enqueueing {} programs for iter: {}/{} now.", programs.size(), i+1, NUM_ITERATIONS);
+        }
+        if (i % 5 == 0) {
+            EnqueueProgram(this->device_->command_queue(), persistent_program, false);
         }
         for (Program& program: programs) {
             EnqueueProgram(this->device_->command_queue(), program, false);

--- a/tests/ttnn/unit_tests/gtests/ccl/test_erisc_data_mover_with_workers.cpp
+++ b/tests/ttnn/unit_tests/gtests/ccl/test_erisc_data_mover_with_workers.cpp
@@ -563,7 +563,8 @@ bool RunWriteBWTest(
         sender_device,
         local_chip_edm_builder,
         eth_sender_core,
-        NOC::NOC_0);
+        NOC::NOC_0,
+        ttnn::ccl::OpBuildMode::NON_PERSISTENT);
     set_edm_runtime_args(
         sender_program,
         local_edm_kernel,
@@ -576,7 +577,8 @@ bool RunWriteBWTest(
         receiver_device,
         remote_chip_edm_builder,
         eth_receiver_core,
-        NOC::NOC_0);
+        NOC::NOC_0,
+        ttnn::ccl::OpBuildMode::NON_PERSISTENT);
     set_edm_runtime_args(
         receiver_program,
         remote_edm_kernel,

--- a/tests/ttnn/unit_tests/operations/test_all_gather.py
+++ b/tests/ttnn/unit_tests/operations/test_all_gather.py
@@ -963,7 +963,13 @@ def run_all_gather_sharded(
     input_tensor_mesh = ttnn.aggregate_as_tensor(tt_input_tensors)
 
     ## Run the actual allgather operation
-    tt_out_tensor = all_gather_operation(input_tensor_mesh, dim, num_links=num_links, memory_config=output_mem_config)
+    tt_out_tensor = all_gather_operation(
+        input_tensor_mesh,
+        dim,
+        num_links=num_links,
+        memory_config=output_mem_config,
+        op_fabric_mode=ttnn.CclFabricMode.EDM,
+    )
     ## Wait for completion
     for d in devices:
         ttnn.synchronize_device(d)

--- a/tt_metal/host_api.hpp
+++ b/tt_metal/host_api.hpp
@@ -109,6 +109,8 @@ bool CloseDevice(Device *device);
  */
 Program CreateProgram();
 
+Program CreatePersistentProgram();
+
 /**
  * Creates a data movement kernel with no compile time arguments and adds it to the program.
  *
@@ -126,6 +128,9 @@ KernelHandle CreateKernel(
     const std::string &file_name,
     const std::variant<CoreCoord, CoreRange, CoreRangeSet> &core_spec,
     const std::variant<DataMovementConfig, ComputeConfig, EthernetConfig> &config);
+
+bool FindPersistentKernel(const std::string &file_name, const std::variant<CoreCoord, CoreRange, CoreRangeSet> &core_spec, const std::variant<DataMovementConfig, ComputeConfig, EthernetConfig> &config);
+KernelHandle AttachPersistentKernel(Program &program, const std::string &file_name, const std::variant<CoreCoord, CoreRange, CoreRangeSet> &core_spec, const std::variant<DataMovementConfig, ComputeConfig, EthernetConfig> &config, Device * device);
 
 // ==================================================
 //                  HOST API: buffers

--- a/tt_metal/host_api.hpp
+++ b/tt_metal/host_api.hpp
@@ -130,7 +130,7 @@ KernelHandle CreateKernel(
     const std::variant<DataMovementConfig, ComputeConfig, EthernetConfig> &config);
 
 bool FindPersistentKernel(const std::string &file_name, const std::variant<CoreCoord, CoreRange, CoreRangeSet> &core_spec, const std::variant<DataMovementConfig, ComputeConfig, EthernetConfig> &config);
-KernelHandle AttachPersistentKernel(Program &program, const std::string &file_name, const std::variant<CoreCoord, CoreRange, CoreRangeSet> &core_spec, const std::variant<DataMovementConfig, ComputeConfig, EthernetConfig> &config, Device * device);
+KernelHandle AttachPersistentKernel(Program &program, const std::string &file_name, const std::variant<CoreCoord, CoreRange, CoreRangeSet> &core_spec, const std::variant<DataMovementConfig, ComputeConfig, EthernetConfig> &config, const Device *const device);
 
 // ==================================================
 //                  HOST API: buffers

--- a/tt_metal/tt_metal.cpp
+++ b/tt_metal/tt_metal.cpp
@@ -938,7 +938,7 @@ bool FindPersistentKernel(const std::string &file_name, const std::variant<CoreC
         config);
 }
 
-KernelHandle AttachPersistentKernel(Program &program, const std::string &file_name, const std::variant<CoreCoord, CoreRange, CoreRangeSet> &core_spec, const Config &config, Device * device) {
+KernelHandle AttachPersistentKernel(Program &program, const std::string &file_name, const std::variant<CoreCoord, CoreRange, CoreRangeSet> &core_spec, const Config &config, const Device *const device) {
 
     auto core_type = detail::get_core_type(config);
     CoreRangeSet core_ranges = GetCoreRangeSet(core_spec);

--- a/ttnn/CMakeLists.txt
+++ b/ttnn/CMakeLists.txt
@@ -28,6 +28,7 @@ set(ALL_TTNN_SRCS
     ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/ccl/reduce_scatter/device/reduce_scatter_op.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/ccl/reduce_scatter/reduce_scatter.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/ccl/reduce_scatter/reduce_scatter_pybind.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/ccl/ccl_pybind.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/core/compute_kernel/compute_kernel_config.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/conv/conv2d/conv2d.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/conv/conv2d/conv2d_pybind.cpp

--- a/ttnn/CMakeLists.txt
+++ b/ttnn/CMakeLists.txt
@@ -20,6 +20,7 @@ set(ALL_TTNN_SRCS
     ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/ccl/ccl_op_fusion.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/ccl/ccl_common.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/ccl/ccl_host_datastructures.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/ccl/erisc_datamover_builder.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/ccl/line_all_gather/device/line_all_gather_op.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/ccl/line_all_gather/line_all_gather.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/ccl/line_all_gather/line_all_gather_pybind.cpp

--- a/ttnn/cpp/pybind11/operations/__init__.hpp
+++ b/ttnn/cpp/pybind11/operations/__init__.hpp
@@ -10,9 +10,7 @@
 #include "pybind11/operations/copy.hpp"
 #include "pybind11/operations/core.hpp"
 #include "pybind11/operations/creation.hpp"
-#include "ttnn/operations/ccl/all_gather/all_gather_pybind.hpp"
-#include "ttnn/operations/ccl/line_all_gather/line_all_gather_pybind.hpp"
-#include "ttnn/operations/ccl/reduce_scatter/reduce_scatter_pybind.hpp"
+#include "ttnn/operations/ccl/ccl_pybind.hpp"
 #include "ttnn/operations/conv/conv2d/conv2d_pybind.hpp"
 #include "ttnn/operations/data_movement/data_movement_pybind.hpp"
 #include "ttnn/operations/eltwise/binary/binary_pybind.hpp"
@@ -70,9 +68,7 @@ void py_module(py::module& module) {
     unary_backward::py_module(m_unary_backward);
 
     auto m_ccl = module.def_submodule("ccl", "collective communication operations");
-    ccl::py_bind_all_gather(m_ccl);
-    ccl::py_bind_line_all_gather(m_ccl);
-    ccl::py_bind_reduce_scatter(m_ccl);
+    ccl::py_module(m_ccl);
 
     auto m_complex = module.def_submodule("complex", "complex tensor creation");
     complex::py_module(m_complex);

--- a/ttnn/cpp/ttnn/operations/ccl/all_gather/all_gather.cpp
+++ b/ttnn/cpp/ttnn/operations/ccl/all_gather/all_gather.cpp
@@ -5,11 +5,12 @@
 #include "ttnn/operations/ccl/all_gather/all_gather.hpp"
 #include "ttnn/operations/ccl/all_gather/device/all_gather_op.hpp"
 #include "ttnn/multi_device.hpp"
+#include "ttnn/operations/ccl/ccl_fabric.hpp"
 
 namespace ttnn::operations::ccl {
 
-ttnn::Tensor ExecuteAllGather::invoke(const ttnn::Tensor& input_tensor, const uint32_t dim, const uint32_t num_links, const std::optional<ttnn::MemoryConfig>& memory_config) {
-    return ttnn::operations::ccl::all_gather(input_tensor, dim, num_links, memory_config);
+ttnn::Tensor ExecuteAllGather::invoke(const ttnn::Tensor& input_tensor, const uint32_t dim, const uint32_t num_links, const std::optional<ttnn::MemoryConfig>& memory_config, ttnn::ccl::OpFabricMode fabric_mode) {
+    return ttnn::operations::ccl::all_gather(input_tensor, dim, num_links, memory_config, fabric_mode);
 }
 
 }  // namespace ttnn::operations::ccl

--- a/ttnn/cpp/ttnn/operations/ccl/all_gather/all_gather.hpp
+++ b/ttnn/cpp/ttnn/operations/ccl/all_gather/all_gather.hpp
@@ -5,6 +5,7 @@
 #pragma once
 
 #include "ttnn/decorators.hpp"
+#include "ttnn/operations/ccl/ccl_fabric.hpp"
 
 namespace ttnn {
 namespace operations {
@@ -15,7 +16,8 @@ struct ExecuteAllGather {
         const ttnn::Tensor& input_tensor,
         const uint32_t dim,
         const uint32_t num_links = 1,
-        const std::optional<ttnn::MemoryConfig>& memory_config = std::nullopt);
+        const std::optional<ttnn::MemoryConfig>& memory_config = std::nullopt,
+        const ttnn::ccl::OpFabricMode op_fabric_mode = ttnn::ccl::OpFabricMode::TEMPORARY_EDM);
 };
 
 }  // namespace ccl

--- a/ttnn/cpp/ttnn/operations/ccl/all_gather/device/all_gather_op.cpp
+++ b/ttnn/cpp/ttnn/operations/ccl/all_gather/device/all_gather_op.cpp
@@ -7,6 +7,7 @@
 
 #include "tt_metal/host_api.hpp"
 
+#include "ttnn/operations/ccl/ccl_host_datastructures.hpp"
 #include "ttnn/tensor/tensor_utils.hpp"
 
 #include "eth_l1_address_map.h"
@@ -172,7 +173,20 @@ std::vector<Tensor> AllGather::create_output_tensors(const std::vector<Tensor> &
 }
 
 operation::ProgramWithCallbacks AllGather::create_program(const std::vector<Tensor> & input_tensors, std::vector<Tensor> &output_tensors) const {
-    return all_gather_multi_core_with_workers(input_tensors[0], output_tensors[0], this->dim, this->num_links, this->ring_size, this->ring_index, this->receiver_device_id, this->sender_device_id, this->topology);
+    return all_gather_multi_core_with_workers(
+        input_tensors[0],
+        output_tensors[0],
+        all_gather_op_builder_args_t {
+            this->dim,
+            this->num_links,
+            this->ring_size,
+            this->ring_index,
+            this->receiver_device_id,
+            this->sender_device_id,
+            this->topology
+        },
+        this->op_build_mode
+    );
 }
 
 namespace operations {

--- a/ttnn/cpp/ttnn/operations/ccl/all_gather/device/all_gather_op.hpp
+++ b/ttnn/cpp/ttnn/operations/ccl/all_gather/device/all_gather_op.hpp
@@ -14,7 +14,7 @@
 #include "ttnn/operations/ccl/ccl_host_datastructures.hpp"
 #include "ttnn/operations/ccl/ccl_common.hpp"
 #include "ttnn/operations/ccl/ccl_op_fusion.hpp"
-
+#include "ttnn/cpp/ttnn/operations/ccl/ccl_fabric.hpp"
 
 #include "ttnn/run_operation.hpp"
 
@@ -148,38 +148,44 @@ AllGather create_all_gather_struct(
 );
 
 // All Gather Variants
-operation::ProgramWithCallbacks all_gather_full_shard_grid(
-    const Tensor& input_tensor,
-    Tensor& output_tensor,
-    const uint32_t dim,
-    const uint32_t num_links,
-    const uint32_t ring_size,
-    const uint32_t ring_index,
-    const std::optional<chip_id_t> receiver_device_id,
-    const std::optional<chip_id_t> sender_device_id,
-    all_gather_op::Topology topology);
+struct all_gather_op_builder_args_t {
+    std::size_t dim;
+    std::size_t num_links;
+    std::size_t ring_size;
+    std::size_t ring_index;
+    std::optional<chip_id_t> receiver_device_id;
+    std::optional<chip_id_t> sender_device_id;
+    ccl::Topology topology;
+};
+
+
 operation::ProgramWithCallbacks all_gather_multi_core_with_workers(
     const Tensor& input_tensor,
     Tensor& output_tensor,
-    const uint32_t dim,
-    const uint32_t num_links,
-    const uint32_t ring_size,
-    const uint32_t ring_index,
-    const std::optional<chip_id_t> receiver_device_id,
-    const std::optional<chip_id_t> sender_device_id,
-    all_gather_op::Topology topology);
+    all_gather_op_builder_args_t const& op_args,
+    ccl::OpBuildMode build_mode
+    // const uint32_t dim,
+    // const uint32_t num_links,
+    // const uint32_t ring_size,
+    // const uint32_t ring_index,
+    // const std::optional<chip_id_t> receiver_device_id,
+    // const std::optional<chip_id_t> sender_device_id,
+    // all_gather_op::Topology topology
+    );
 operation::ProgramWithCallbacks all_gather_multi_core_with_workers_helper(
     tt::tt_metal::Program& program,
     const Tensor& input_tensor,
     Tensor& output_tensor,
-    const uint32_t dim,
-    const uint32_t num_links,
-    const uint32_t ring_size,
-    const uint32_t ring_index,
-    const std::optional<chip_id_t> receiver_device_id,
-    const std::optional<chip_id_t> sender_device_id,
-    all_gather_op::Topology topology,
+    all_gather_op_builder_args_t const& op_args,
+    // const uint32_t dim,
+    // const uint32_t num_links,
+    // const uint32_t ring_size,
+    // const uint32_t ring_index,
+    // const std::optional<chip_id_t> receiver_device_id,
+    // const std::optional<chip_id_t> sender_device_id,
+    // all_gather_op::Topology topology,
     std::optional<experimental::ccl::AllGatherFusedOpSignaler>& fused_op_signaler,
+    ccl::OpBuildMode build_mode,
     const CoreCoord core_grid_offset = CoreCoord(0, 0));
 
 
@@ -191,7 +197,8 @@ Tensor all_gather(
     const Tensor& input_tensor,
     const uint32_t dim,
     const uint32_t num_links = 1,
-    const std::optional<MemoryConfig>& memory_config = std::nullopt);
+    const std::optional<MemoryConfig>& memory_config = std::nullopt,
+    ttnn::ccl::OpFabricMode = ttnn::ccl::OpFabricMode::TEMPORARY_EDM);
 
 } // namespace ccl
 } // namespace operations

--- a/ttnn/cpp/ttnn/operations/ccl/all_gather/device/all_gather_op.hpp
+++ b/ttnn/cpp/ttnn/operations/ccl/all_gather/device/all_gather_op.hpp
@@ -132,6 +132,7 @@ struct AllGather {
     const std::optional<chip_id_t> sender_device_id;
     const MemoryConfig output_mem_config;
     const all_gather_op::Topology topology;
+    const ccl::OpBuildMode op_build_mode;
 
     void validate(const std::vector<Tensor> &input_tensors) const;
     std::vector<tt::tt_metal::Shape> compute_output_shapes(const std::vector<Tensor> &input_tensors) const;
@@ -140,11 +141,14 @@ struct AllGather {
 };
 
 AllGather create_all_gather_struct(
-    const Tensor& input_tensor,
+    const MemoryConfig &input_tensor_memory_config,
+    const Device* input_tensor_device,
     const uint32_t dim,
     const uint32_t num_links,
     const std::optional<MemoryConfig>& memory_config,
-    const std::vector<Device*>& devices
+    const std::vector<Device*>& devices,
+    const ttnn::ccl::Topology topology,
+    const ccl::OpBuildMode op_build_mode
 );
 
 // All Gather Variants

--- a/ttnn/cpp/ttnn/operations/ccl/all_gather/device/multi_core/all_gather_op_multi_core.cpp
+++ b/ttnn/cpp/ttnn/operations/ccl/all_gather/device/multi_core/all_gather_op_multi_core.cpp
@@ -1170,6 +1170,13 @@ operation::ProgramWithCallbacks all_gather_multi_core_with_workers_helper(
         sender_device_id,
         build_mode);
 
+    TT_ASSERT((!build_worker_kernels) ^ worker_sender_reader_kernel_id.has_value());
+    TT_ASSERT((!build_worker_kernels) ^ worker_sender_writer_kernel_id.has_value());
+    TT_ASSERT((!build_worker_kernels) ^ worker_receiver_reader_kernel_id.has_value());
+    TT_ASSERT((!build_worker_kernels) ^ worker_receiver_writer_kernel_id.has_value());
+    TT_ASSERT((!build_worker_kernels) ^ receiver_worker_semaphore_id.has_value());
+    TT_ASSERT((!build_worker_kernels) ^ sender_worker_writer_semaphore_id.has_value());
+    TT_ASSERT((!build_worker_kernels) ^ sender_worker_reader_semaphore_id.has_value());
 
     auto override_runtime_arguments_callback =
         [worker_sender_reader_kernel_id,

--- a/ttnn/cpp/ttnn/operations/ccl/ccl_common.hpp
+++ b/ttnn/cpp/ttnn/operations/ccl/ccl_common.hpp
@@ -13,6 +13,7 @@
 #include "tt_metal/host_api.hpp"
 #include "tt_metal/impl/program/program.hpp"
 #include "ttnn/tensor/types.hpp"
+#include "ttnn/cpp/ttnn/operations/ccl/ccl_fabric.hpp"
 
 namespace ttnn {
 namespace ccl {
@@ -441,7 +442,8 @@ KernelHandle generate_edm_kernel(
     Device const* device,
     ccl::EriscDatamoverBuilder const& edm_builder,
     CoreCoord const& eth_core,
-    NOC noc_id);
+    NOC noc_id,
+    ccl::OpBuildMode build_mode);
 
 void generate_edm_kernels_for_ring_or_linear_topology(
    tt::tt_metal::Program& program,
@@ -450,7 +452,8 @@ void generate_edm_kernels_for_ring_or_linear_topology(
     std::vector<ccl::EriscDatamoverBuilder> const& clockwise_edm_builders,
     std::vector<ccl::EriscDatamoverBuilder> const& counter_clockwise_edm_builders,
     std::optional<uint32_t> receiver_device_id,
-    std::optional<uint32_t> sender_device_id);
+    std::optional<uint32_t> sender_device_id,
+    ccl::OpBuildMode build_mode);
 
 ccl::EriscDatamoverBuilder create_erisc_datamover_builder(
     std::size_t num_channels,

--- a/ttnn/cpp/ttnn/operations/ccl/ccl_fabric.hpp
+++ b/ttnn/cpp/ttnn/operations/ccl/ccl_fabric.hpp
@@ -10,6 +10,9 @@ namespace ccl {
 
 enum class OpFabricMode {
     PERSISTENT_EDM,
+
+    // Dispatch/launch the EDMs per op. They do not live past
+    // the lifetime of the op
     TEMPORARY_EDM
 };
 

--- a/ttnn/cpp/ttnn/operations/ccl/ccl_fabric.hpp
+++ b/ttnn/cpp/ttnn/operations/ccl/ccl_fabric.hpp
@@ -1,0 +1,23 @@
+// SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+///
+
+#pragma once
+
+namespace ttnn {
+namespace ccl {
+
+enum class OpFabricMode {
+    PERSISTENT_EDM,
+    TEMPORARY_EDM
+};
+
+enum class OpBuildMode {
+    NON_PERSISTENT,
+    PERSISTENT_BUILD_PERSISTENT_EDM,
+    PERSISTENT_BUILD_NON_PERSISTENT_WORKERS
+};
+
+} // namespace ccl
+} // namespace ttnn

--- a/ttnn/cpp/ttnn/operations/ccl/ccl_host_datastructures.hpp
+++ b/ttnn/cpp/ttnn/operations/ccl/ccl_host_datastructures.hpp
@@ -79,13 +79,7 @@ class EriscDatamoverBuilder {
             uint32_t channel,
             uint32_t num_buffers,
             std::vector<ccl::WorkerXY> const& worker_coords,
-            uint32_t largest_message_size_bytes = 0) :
-            worker_coords(worker_coords),
-            worker_semaphore_id(worker_semaphore_id),
-            num_eth_messages_to_forward(num_eth_messages_to_forward),
-            channel(channel),
-            largest_message_size_bytes(largest_message_size_bytes),
-            is_sender(is_sender) {}
+            uint32_t largest_message_size_bytes = 0);
 
         std::vector<ccl::WorkerXY> const worker_coords;
         uint32_t worker_semaphore_id;
@@ -96,24 +90,7 @@ class EriscDatamoverBuilder {
         bool is_sender;
     };
 
-    void push_back_channel_args(std::vector<uint32_t>& args, ChannelBufferSpec const& channel) const {
-        args.push_back(this->local_buffer_addresses.at(channel.channel));
-        args.push_back(channel.num_eth_messages_to_forward);
-        if (channel.largest_message_size_bytes > 0) {
-            args.push_back(std::min<uint32_t>(channel.largest_message_size_bytes, this->eth_buffer_size_bytes));
-            if (channel.largest_message_size_bytes < this->eth_buffer_size_bytes) {
-                log_trace(tt::LogOp, "Trimming buffer size for channel {} to {}", channel.channel, args.back());
-            }
-        } else {
-            args.push_back(this->eth_buffer_size_bytes);
-        }
-        args.push_back(this->local_semaphore_addresses.at(channel.channel));
-        args.push_back(channel.worker_semaphore_id);
-        args.push_back(channel.worker_coords.size());
-        for (auto const& worker_coord : channel.worker_coords) {
-            args.push_back(worker_coord.to_uint32());
-        }
-    }
+    void push_back_channel_args(std::vector<uint32_t>& args, ChannelBufferSpec const& channel) const;
 
     std::vector<ChannelBufferSpec> active_channels;
     std::vector<uint32_t> const local_semaphore_addresses;
@@ -146,155 +123,35 @@ class EriscDatamoverBuilder {
         ccl::EriscDataMoverBufferSharingMode buffer_sharing_mode,
         ccl::EriscDataMoverTerminationMode termination_mode = ccl::EriscDataMoverTerminationMode::MESSAGE_COUNT_REACHED,
         std::size_t num_buffers_per_channel = 1,
-        chip_id_t chip_id = -1) :
-        local_semaphore_addresses(local_semaphore_addresses),
-        local_buffer_addresses(local_buffer_addresses),
-        eth_buffer_size_bytes(eth_buffer_size),
-        handshake_addr(handshake_addr),
-        num_channel_buffers(local_buffer_addresses.size()),
-        buffer_sharing_mode(buffer_sharing_mode),
-        num_buffers_per_channel(num_buffers_per_channel),
-        termination_mode(termination_mode),
-        enable_sender(false),
-        enable_receiver(false),
-        num_senders(0),
-        num_receivers(0),
-        chip_id(chip_id) {
-
-        TT_ASSERT(num_buffers_per_channel > 0);
-        TT_ASSERT(local_buffer_addresses.size() == local_semaphore_addresses.size());
-        active_channels.reserve(num_channel_buffers);
-        TT_ASSERT(eth_buffer_size_bytes < 163000);
-        log_trace(tt::LogOp, "EriscDatamoverBuilder:");
-        for (auto const& addr : local_semaphore_addresses) {
-            TT_ASSERT(addr > 0);
-            TT_ASSERT(addr % 16 == 0);
-            log_trace(tt::LogOp, "\tsemaphore_address: {}", addr);
-        }
-        for (auto const& addr : local_buffer_addresses) {
-            TT_ASSERT(addr > 0);
-            TT_ASSERT(addr % 16 == 0);
-            log_trace(tt::LogOp, "\tbuffer_address: {}", addr);
-        }
-    }
+        chip_id_t chip_id = -1);
 
     [[nodiscard]]
     ChannelBufferInterface add_sender_channel(
         uint32_t worker_semaphore_id,
         uint32_t num_eth_messages_to_forward,
         std::vector<ccl::WorkerXY> const& worker_coords,
-        uint32_t expected_message_size_bytes = 0) {
-        this->enable_sender = true;
-        this->num_senders++;
-        auto channel = active_channels.size();
-        active_channels.emplace_back(
-            true, worker_semaphore_id, num_eth_messages_to_forward, channel, this->num_buffers_per_channel, worker_coords, expected_message_size_bytes);
-        log_trace(tt::LogOp, "Adding sender channel:");
-        log_trace(tt::LogOp, "\tworker_semaphore_id: {}", active_channels.back().worker_semaphore_id);
-        log_trace(tt::LogOp, "\tnum_eth_messages_to_forward: {}", active_channels.back().num_eth_messages_to_forward);
-        log_trace(tt::LogOp, "\tchannel: {}", active_channels.back().channel);
-        log_trace(tt::LogOp, "\tis_sender: {}", active_channels.back().is_sender ? 1 : 0);
-        log_trace(tt::LogOp, "\tbuffer_address: {}", local_buffer_addresses.at(channel));
-        log_trace(tt::LogOp, "\tsemaphore_address: {}", local_semaphore_addresses.at(channel));
-        log_trace(tt::LogOp, "\tnum_workers: {}", worker_coords.size());
-
-        return ChannelBufferInterface{channel, local_buffer_addresses.at(channel), local_semaphore_addresses.at(channel)};
-    }
+        uint32_t expected_message_size_bytes = 0);
 
     // This function is used to set the maximum message size for a given channel. If the maximum
     // message size is < EDM channel buffer size, then the buffer size passed to the EDM for this channel
     // will be trimmed be no larger than the largest message to save on unnecessary eth bandwidth.
-    void set_max_message_size_bytes(std::size_t channel, std::size_t max_message_size_bytes) {
-        active_channels.at(channel).largest_message_size_bytes = std::max<uint32_t>(active_channels.at(channel).largest_message_size_bytes, max_message_size_bytes);
-    }
+    void set_max_message_size_bytes(std::size_t channel, std::size_t max_message_size_bytes);
 
     [[nodiscard]]
     ChannelBufferInterface add_receiver_channel(
         uint32_t worker_semaphore_id,
         uint32_t num_eth_messages_to_forward,
         std::vector<ccl::WorkerXY> const& worker_coords,
-        uint32_t expected_message_size_bytes = 0) {
-        this->enable_receiver = true;
-        this->num_receivers++;
-        auto channel = active_channels.size();
-        active_channels.emplace_back(
-            false, worker_semaphore_id, num_eth_messages_to_forward, channel, this->num_buffers_per_channel, worker_coords, expected_message_size_bytes);
-        log_trace(tt::LogOp, "Adding receiver channel:");
-        log_trace(tt::LogOp, "\tworker_semaphore_id: {}", active_channels.back().worker_semaphore_id);
-        log_trace(tt::LogOp, "\tnum_eth_messages_to_forward: {}", active_channels.back().num_eth_messages_to_forward);
-        log_trace(tt::LogOp, "\tchannel: {}", active_channels.back().channel);
-        log_trace(tt::LogOp, "\tnum_workers: {}", worker_coords.size());
-        log_trace(tt::LogOp, "\tis_sender: {}", active_channels.back().is_sender ? 1 : 0);
-        return ChannelBufferInterface{channel, local_buffer_addresses.at(channel), local_semaphore_addresses.at(channel)};
-    }
+        uint32_t expected_message_size_bytes = 0);
 
-    [[nodiscard]]
-    std::vector<uint32_t> emit_compile_time_args() const {
-        return std::vector<uint32_t>{
-            static_cast<uint32_t>(this->enable_sender ? 1 : 0),
-            static_cast<uint32_t>(this->enable_receiver ? 1 : 0),
-            this->num_senders,
-            this->num_receivers,
-            this->buffer_sharing_mode,
-            this->termination_mode,
-            1,
-            static_cast<uint32_t>(this->num_senders > 0 && active_channels.at(0).is_sender),
-            this->num_buffers_per_channel,
-            chip_id
-            };
-    }
+    [[nodiscard]] std::vector<uint32_t> emit_compile_time_args() const;
 
-    [[nodiscard]]
-    std::vector<uint32_t> emit_runtime_args() const {
-        std::vector<uint32_t> args;
-        uint32_t size = 3 + active_channels.size() * 6;
-        for (auto const& channel : active_channels) {
-            size += channel.worker_coords.size();
-        }
-        args.reserve(size);
+    [[nodiscard]] std::vector<uint32_t> emit_runtime_args() const;
 
-        // Handshake address
-        args.push_back(handshake_addr);
+    void dump_to_log() const;
 
-        bool senders_below_receivers = active_channels.size() == 0 || this->active_channels.front().is_sender;
-
-        // Receiver channel args
-        uint32_t receiver_channels_offset = senders_below_receivers ? this->num_senders : 0;
-        args.push_back(receiver_channels_offset);
-        for (auto const& channel : this->active_channels) {
-            if (channel.is_sender) {
-                continue;
-            }
-            push_back_channel_args(args, channel);
-        }
-
-        // Sender channel args
-        uint32_t sender_channels_offset = senders_below_receivers ? 0 : this->num_receivers;
-        args.push_back(sender_channels_offset);
-        for (auto const& channel : this->active_channels) {
-            if (!channel.is_sender) {
-                continue;
-            }
-            push_back_channel_args(args, channel);
-        }
-
-        return args;
-    }
-
-    void dump_to_log() const {
-        auto const& rt_args = this->emit_runtime_args();
-        log_trace(tt::LogOp, "EDM RT Args:");
-        for (auto const& arg : rt_args) {
-            log_trace(tt::LogOp, "\t{}", arg);
-        }
-    };
-
-    [[nodiscard]]
-    uint32_t get_eth_buffer_size_bytes() const {
-        return this->eth_buffer_size_bytes;
-    }
-
-    std::vector<ChannelBufferSpec> const& get_active_channels() const { return this->active_channels; }
+    [[nodiscard]] uint32_t get_eth_buffer_size_bytes() const;
+    std::vector<ChannelBufferSpec> const& get_active_channels() const;
 };
 
 };  // namespace ccl

--- a/ttnn/cpp/ttnn/operations/ccl/ccl_pybind.cpp
+++ b/ttnn/cpp/ttnn/operations/ccl/ccl_pybind.cpp
@@ -1,0 +1,34 @@
+// SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "ttnn/cpp/ttnn/operations/ccl/ccl_pybind.hpp"
+#include "ttnn/operations/ccl/ccl_fabric.hpp"
+#include "ttnn/cpp/pybind11/export_enum.hpp"
+#include "ttnn/operations/ccl/all_gather/all_gather_pybind.hpp"
+#include "ttnn/operations/ccl/line_all_gather/line_all_gather_pybind.hpp"
+#include "ttnn/operations/ccl/reduce_scatter/reduce_scatter_pybind.hpp"
+
+#include <pybind11/pybind11.h>
+#include <pybind11/operators.h>
+#include <pybind11/stl.h>
+
+
+namespace ttnn {
+namespace operations {
+namespace ccl {
+
+void py_module(py::module& module) {
+    py::enum_<ttnn::ccl::OpFabricMode>(module, "FabricMode")
+        .value("EDM", ttnn::ccl::OpFabricMode::TEMPORARY_EDM)
+        .value("PersistentEDM", ttnn::ccl::OpFabricMode::PERSISTENT_EDM);
+
+    ccl::py_bind_all_gather(module);
+    ccl::py_bind_line_all_gather(module);
+    ccl::py_bind_reduce_scatter(module);
+
+}
+
+}  // namespace ccl
+}  // namespace operations
+}  // namespace ttn

--- a/ttnn/cpp/ttnn/operations/ccl/ccl_pybind.hpp
+++ b/ttnn/cpp/ttnn/operations/ccl/ccl_pybind.hpp
@@ -1,0 +1,19 @@
+// SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <pybind11/pybind11.h>
+
+namespace ttnn {
+namespace operations {
+namespace ccl {
+
+namespace py = pybind11;
+
+void py_module(py::module& module);
+
+} // namespace ccl
+} // namespace operations
+} // namespace ttnn

--- a/ttnn/cpp/ttnn/operations/ccl/erisc_datamover_builder.cpp
+++ b/ttnn/cpp/ttnn/operations/ccl/erisc_datamover_builder.cpp
@@ -1,0 +1,194 @@
+#include "ttnn/operations/ccl/ccl_host_datastructures.hpp"
+
+namespace ttnn {
+namespace ccl {
+
+EriscDatamoverBuilder::ChannelBufferSpec::ChannelBufferSpec(
+    bool is_sender,
+    uint32_t worker_semaphore_id,
+    uint32_t num_eth_messages_to_forward,
+    uint32_t channel,
+    uint32_t num_buffers,
+    std::vector<ccl::WorkerXY> const& worker_coords,
+    uint32_t largest_message_size_bytes) :
+    worker_coords(worker_coords),
+    worker_semaphore_id(worker_semaphore_id),
+    num_eth_messages_to_forward(num_eth_messages_to_forward),
+    channel(channel),
+    largest_message_size_bytes(largest_message_size_bytes),
+    is_sender(is_sender) {}
+
+void EriscDatamoverBuilder::push_back_channel_args(std::vector<uint32_t>& args, ChannelBufferSpec const& channel) const {
+    args.push_back(this->local_buffer_addresses.at(channel.channel));
+    args.push_back(channel.num_eth_messages_to_forward);
+    if (channel.largest_message_size_bytes > 0) {
+        args.push_back(std::min<uint32_t>(channel.largest_message_size_bytes, this->eth_buffer_size_bytes));
+        if (channel.largest_message_size_bytes < this->eth_buffer_size_bytes) {
+            log_trace(tt::LogOp, "Trimming buffer size for channel {} to {}", channel.channel, args.back());
+        }
+    } else {
+        args.push_back(this->eth_buffer_size_bytes);
+    }
+    args.push_back(this->local_semaphore_addresses.at(channel.channel));
+    args.push_back(channel.worker_semaphore_id);
+    args.push_back(channel.worker_coords.size());
+    for (auto const& worker_coord : channel.worker_coords) {
+        args.push_back(worker_coord.to_uint32());
+    }
+}
+
+EriscDatamoverBuilder::EriscDatamoverBuilder(
+    uint32_t eth_buffer_size,
+    uint32_t handshake_addr,
+    std::vector<uint32_t> const& local_semaphore_addresses,
+    std::vector<uint32_t> const& local_buffer_addresses,
+    ccl::EriscDataMoverBufferSharingMode buffer_sharing_mode,
+    ccl::EriscDataMoverTerminationMode termination_mode,
+    std::size_t num_buffers_per_channel,
+    chip_id_t chip_id) :
+    local_semaphore_addresses(local_semaphore_addresses),
+    local_buffer_addresses(local_buffer_addresses),
+    eth_buffer_size_bytes(eth_buffer_size),
+    handshake_addr(handshake_addr),
+    num_channel_buffers(local_buffer_addresses.size()),
+    buffer_sharing_mode(buffer_sharing_mode),
+    num_buffers_per_channel(num_buffers_per_channel),
+    termination_mode(termination_mode),
+    enable_sender(false),
+    enable_receiver(false),
+    num_senders(0),
+    num_receivers(0),
+    chip_id(chip_id) {
+
+    TT_ASSERT(num_buffers_per_channel > 0);
+    TT_ASSERT(local_buffer_addresses.size() == local_semaphore_addresses.size());
+    active_channels.reserve(num_channel_buffers);
+    TT_ASSERT(eth_buffer_size_bytes < 163000);
+    log_trace(tt::LogOp, "EriscDatamoverBuilder:");
+    for (auto const& addr : local_semaphore_addresses) {
+        TT_ASSERT(addr > 0);
+        TT_ASSERT(addr % 16 == 0);
+        log_trace(tt::LogOp, "\tsemaphore_address: {}", addr);
+    }
+    for (auto const& addr : local_buffer_addresses) {
+        TT_ASSERT(addr > 0);
+        TT_ASSERT(addr % 16 == 0);
+        log_trace(tt::LogOp, "\tbuffer_address: {}", addr);
+    }
+}
+
+EriscDatamoverBuilder::ChannelBufferInterface EriscDatamoverBuilder::add_sender_channel(
+    uint32_t worker_semaphore_id,
+    uint32_t num_eth_messages_to_forward,
+    std::vector<ccl::WorkerXY> const& worker_coords,
+    uint32_t expected_message_size_bytes) {
+    this->enable_sender = true;
+    this->num_senders++;
+    auto channel = active_channels.size();
+    active_channels.emplace_back(
+        true, worker_semaphore_id, num_eth_messages_to_forward, channel, this->num_buffers_per_channel, worker_coords, expected_message_size_bytes);
+    log_trace(tt::LogOp, "Adding sender channel:");
+    log_trace(tt::LogOp, "\tworker_semaphore_id: {}", active_channels.back().worker_semaphore_id);
+    log_trace(tt::LogOp, "\tnum_eth_messages_to_forward: {}", active_channels.back().num_eth_messages_to_forward);
+    log_trace(tt::LogOp, "\tchannel: {}", active_channels.back().channel);
+    log_trace(tt::LogOp, "\tis_sender: {}", active_channels.back().is_sender ? 1 : 0);
+    log_trace(tt::LogOp, "\tbuffer_address: {}", local_buffer_addresses.at(channel));
+    log_trace(tt::LogOp, "\tsemaphore_address: {}", local_semaphore_addresses.at(channel));
+    log_trace(tt::LogOp, "\tnum_workers: {}", worker_coords.size());
+
+    return ChannelBufferInterface{channel, local_buffer_addresses.at(channel), local_semaphore_addresses.at(channel)};
+}
+
+    // This function is used to set the maximum message size for a given channel. If the maximum
+    // message size is < EDM channel buffer size, then the buffer size passed to the EDM for this channel
+    // will be trimmed be no larger than the largest message to save on unnecessary eth bandwidth.
+void EriscDatamoverBuilder::set_max_message_size_bytes(std::size_t channel, std::size_t max_message_size_bytes) {
+    active_channels.at(channel).largest_message_size_bytes = std::max<uint32_t>(active_channels.at(channel).largest_message_size_bytes, max_message_size_bytes);
+}
+
+EriscDatamoverBuilder::ChannelBufferInterface EriscDatamoverBuilder::add_receiver_channel(
+    uint32_t worker_semaphore_id,
+    uint32_t num_eth_messages_to_forward,
+    std::vector<ccl::WorkerXY> const& worker_coords,
+    uint32_t expected_message_size_bytes) {
+    this->enable_receiver = true;
+    this->num_receivers++;
+    auto channel = active_channels.size();
+    active_channels.emplace_back(
+        false, worker_semaphore_id, num_eth_messages_to_forward, channel, this->num_buffers_per_channel, worker_coords, expected_message_size_bytes);
+    log_trace(tt::LogOp, "Adding receiver channel:");
+    log_trace(tt::LogOp, "\tworker_semaphore_id: {}", active_channels.back().worker_semaphore_id);
+    log_trace(tt::LogOp, "\tnum_eth_messages_to_forward: {}", active_channels.back().num_eth_messages_to_forward);
+    log_trace(tt::LogOp, "\tchannel: {}", active_channels.back().channel);
+    log_trace(tt::LogOp, "\tnum_workers: {}", worker_coords.size());
+    log_trace(tt::LogOp, "\tis_sender: {}", active_channels.back().is_sender ? 1 : 0);
+    return ChannelBufferInterface{channel, local_buffer_addresses.at(channel), local_semaphore_addresses.at(channel)};
+}
+
+std::vector<uint32_t> EriscDatamoverBuilder::emit_compile_time_args() const {
+    return std::vector<uint32_t>{
+        static_cast<uint32_t>(this->enable_sender ? 1 : 0),
+        static_cast<uint32_t>(this->enable_receiver ? 1 : 0),
+        this->num_senders,
+        this->num_receivers,
+        this->buffer_sharing_mode,
+        this->termination_mode,
+        1,
+        static_cast<uint32_t>(this->num_senders > 0 && active_channels.at(0).is_sender),
+        this->num_buffers_per_channel,
+        chip_id
+        };
+}
+
+std::vector<uint32_t> EriscDatamoverBuilder::emit_runtime_args() const {
+    std::vector<uint32_t> args;
+    uint32_t size = 3 + active_channels.size() * 6;
+    for (auto const& channel : active_channels) {
+        size += channel.worker_coords.size();
+    }
+    args.reserve(size);
+
+    // Handshake address
+    args.push_back(handshake_addr);
+
+    bool senders_below_receivers = active_channels.size() == 0 || this->active_channels.front().is_sender;
+
+    // Receiver channel args
+    uint32_t receiver_channels_offset = senders_below_receivers ? this->num_senders : 0;
+    args.push_back(receiver_channels_offset);
+    for (auto const& channel : this->active_channels) {
+        if (channel.is_sender) {
+            continue;
+        }
+        push_back_channel_args(args, channel);
+    }
+
+    // Sender channel args
+    uint32_t sender_channels_offset = senders_below_receivers ? 0 : this->num_receivers;
+    args.push_back(sender_channels_offset);
+    for (auto const& channel : this->active_channels) {
+        if (!channel.is_sender) {
+            continue;
+        }
+        push_back_channel_args(args, channel);
+    }
+
+    return args;
+}
+
+void EriscDatamoverBuilder::dump_to_log() const {
+    auto const& rt_args = this->emit_runtime_args();
+    log_trace(tt::LogOp, "EDM RT Args:");
+    for (auto const& arg : rt_args) {
+        log_trace(tt::LogOp, "\t{}", arg);
+    }
+};
+
+uint32_t EriscDatamoverBuilder::get_eth_buffer_size_bytes() const {
+    return this->eth_buffer_size_bytes;
+}
+
+std::vector<EriscDatamoverBuilder::ChannelBufferSpec> const& EriscDatamoverBuilder::get_active_channels() const { return this->active_channels; }
+
+};  // namespace ccl
+};  // namespace ttnn

--- a/ttnn/cpp/ttnn/operations/ccl/kernel_common/worker_edm_adapters.hpp
+++ b/ttnn/cpp/ttnn/operations/ccl/kernel_common/worker_edm_adapters.hpp
@@ -36,7 +36,9 @@ struct WorkerToEdmReader{
     {}
 
     FORCE_INLINE void wait_for_payload_available() const {
+        DPRINT << "Receive Worker Wait EDM\n";
         noc_semaphore_wait(this->worker_sem_addr, 1);
+        DPRINT << "Receive Worker Wait EDM\n";
         noc_semaphore_set(this->worker_sem_addr, 0);
     }
 
@@ -95,7 +97,9 @@ struct WorkerToEdmSender{
     }
 
     FORCE_INLINE void wait_for_empty_write_slot() const {
+        DPRINT << "Send Worker Wait EDM\n";
         noc_semaphore_wait(this->worker_sem_addr, 1);
+        DPRINT << "Send Worker Got Go from EDM\n";
         noc_semaphore_set(this->worker_sem_addr, 0);
     }
 
@@ -129,6 +133,7 @@ struct WorkerToEdmSender{
     template<ttnn::ccl::EDM_IO_BLOCKING_MODE blocking_mode>
     FORCE_INLINE void send_payload_impl(uint32_t cb_id, uint32_t num_pages, uint32_t page_size) {
         uint64_t buffer_address = this->edm_buffer_addr + (this->buffer_index * (this->buffer_size_bytes + sizeof(eth_channel_sync_t)));
+        DPRINT << "WorkerSender sending to " << buffer_address << " with size " << page_size * num_pages << "\n";
         send_chunk<blocking_mode>(cb_id, num_pages, page_size, buffer_address);
         noc_semaphore_inc(edm_semaphore_addr, 1);
         this->buffer_index = (this->buffer_index == this->last_buffer_index) ? 0 : this->buffer_index + 1;

--- a/ttnn/cpp/ttnn/operations/ccl/line_all_gather/device/line_all_gather_op.hpp
+++ b/ttnn/cpp/ttnn/operations/ccl/line_all_gather/device/line_all_gather_op.hpp
@@ -7,6 +7,7 @@
 #include <cstdint>
 #include "common/core_coord.h"
 #include "impl/buffers/buffer.hpp"
+#include "ttnn/operations/ccl/ccl_fabric.hpp"
 #include "ttnn/tensor/tensor.hpp"
 #include "ttnn/operations/ccl/shared_with_host/hetergeneous_data_structs.hpp"
 #include "tt_metal/common/constants.hpp"
@@ -38,6 +39,7 @@ struct LineAllGather {
     const std::optional<chip_id_t> sender_device_id;
     const MemoryConfig output_mem_config;
     const all_gather_op::Topology topology;
+    const ttnn::ccl::OpBuildMode op_build_mode;
 
     void validate(const std::vector<Tensor> &input_tensors) const;
     std::vector<tt::tt_metal::Shape> compute_output_shapes(const std::vector<Tensor> &input_tensors) const;
@@ -52,7 +54,8 @@ Tensor line_all_gather(
     const Tensor& input_tensor,
     const uint32_t dim,
     const uint32_t num_links = 1,
-    const std::optional<MemoryConfig>& memory_config = std::nullopt);
+    const std::optional<MemoryConfig>& memory_config = std::nullopt,
+        const ttnn::ccl::OpFabricMode op_fabric_mode = ttnn::ccl::OpFabricMode::TEMPORARY_EDM);
 
 Tensor line_all_gather(
     const Tensor& input_tensor,
@@ -60,7 +63,8 @@ Tensor line_all_gather(
     const uint32_t cluster_axis,
     const MeshDevice& mesh_device,
     const uint32_t num_links = 1,
-    const std::optional<MemoryConfig>& memory_config = std::nullopt);
+    const std::optional<MemoryConfig>& memory_config = std::nullopt,
+    ttnn::ccl::OpFabricMode op_fabic_mode = ttnn::ccl::OpFabricMode::TEMPORARY_EDM);
 
 } // namespace ccl
 } // namespace operations

--- a/ttnn/cpp/ttnn/operations/ccl/line_all_gather/line_all_gather.cpp
+++ b/ttnn/cpp/ttnn/operations/ccl/line_all_gather/line_all_gather.cpp
@@ -12,8 +12,9 @@ ttnn::Tensor ExecuteLineAllGather::invoke(
     const ttnn::Tensor& input_tensor,
     const uint32_t dim,
     const uint32_t num_links,
-    const std::optional<ttnn::MemoryConfig>& memory_config) {
-    return ttnn::operations::ccl::line_all_gather(input_tensor, dim, num_links, memory_config);
+    const std::optional<ttnn::MemoryConfig>& memory_config,
+    const ttnn::ccl::OpFabricMode op_fabric_mode) {
+    return ttnn::operations::ccl::line_all_gather(input_tensor, dim, num_links, memory_config, op_fabric_mode);
 }
 
 ttnn::Tensor ExecuteLineAllGather::invoke(
@@ -22,9 +23,10 @@ ttnn::Tensor ExecuteLineAllGather::invoke(
     const uint32_t cluster_axis,
     const MeshDevice& mesh_device,
     const uint32_t num_links,
-    const std::optional<ttnn::MemoryConfig>& memory_config) {
+    const std::optional<ttnn::MemoryConfig>& memory_config,
+        const ttnn::ccl::OpFabricMode op_fabric_mode) {
     return ttnn::operations::ccl::line_all_gather(
-        input_tensor, dim, cluster_axis, mesh_device, num_links, memory_config);
+        input_tensor, dim, cluster_axis, mesh_device, num_links, memory_config, op_fabric_mode);
 }
 
 }  // namespace ttnn::operations::ccl

--- a/ttnn/cpp/ttnn/operations/ccl/line_all_gather/line_all_gather.hpp
+++ b/ttnn/cpp/ttnn/operations/ccl/line_all_gather/line_all_gather.hpp
@@ -5,6 +5,7 @@
 #pragma once
 
 #include "ttnn/decorators.hpp"
+#include "ttnn/operations/ccl/ccl_fabric.hpp"
 
 namespace ttnn {
 namespace operations {
@@ -15,7 +16,8 @@ struct ExecuteLineAllGather {
         const ttnn::Tensor& input_tensor,
         const uint32_t dim,
         const uint32_t num_links = 1,
-        const std::optional<ttnn::MemoryConfig>& memory_config = std::nullopt);
+        const std::optional<ttnn::MemoryConfig>& memory_config = std::nullopt,
+        const ttnn::ccl::OpFabricMode op_fabric_mode = ttnn::ccl::OpFabricMode::TEMPORARY_EDM);
 
     static ttnn::Tensor invoke(
         const ttnn::Tensor& input_tensor,
@@ -23,7 +25,9 @@ struct ExecuteLineAllGather {
         const uint32_t cluster_axis,
         const MeshDevice& mesh_device,
         const uint32_t num_links = 1,
-        const std::optional<ttnn::MemoryConfig>& memory_config = std::nullopt);
+        const std::optional<ttnn::MemoryConfig>& memory_config = std::nullopt,
+        const ttnn::ccl::OpFabricMode op_fabric_mode = ttnn::ccl::OpFabricMode::TEMPORARY_EDM
+        );
 };
 
 }  // namespace ccl

--- a/ttnn/cpp/ttnn/operations/ccl/line_all_gather/line_all_gather_pybind.cpp
+++ b/ttnn/cpp/ttnn/operations/ccl/line_all_gather/line_all_gather_pybind.cpp
@@ -7,6 +7,7 @@
 
 #include "ttnn/cpp/pybind11/decorators.hpp"
 #include "ttnn/operations/ccl/line_all_gather/line_all_gather.hpp"
+#include "ttnn/operations/ccl/ccl_fabric.hpp"
 #include "ttnn/types.hpp"
 
 
@@ -25,14 +26,16 @@ void bind_line_all_gather(pybind11::module& module, const ccl_operation_t& opera
                const ttnn::Tensor& input_tensor,
                const uint32_t dim,
                const uint32_t num_links,
-               const std::optional<ttnn::MemoryConfig>& memory_config) -> ttnn::Tensor {
-                return self(input_tensor, dim, num_links, memory_config);
+               const std::optional<ttnn::MemoryConfig>& memory_config,
+               const ttnn::ccl::OpFabricMode op_fabric_mode) -> ttnn::Tensor {
+                return self(input_tensor, dim, num_links, memory_config, op_fabric_mode);
             },
             py::arg("input_tensor"),
             py::arg("dim"),
             py::kw_only(),
             py::arg("num_links") = 1,
-            py::arg("memory_config") = std::nullopt},
+            py::arg("memory_config") = std::nullopt,
+            py::arg("op_fabric_mode") = ttnn::ccl::OpFabricMode::TEMPORARY_EDM},
         ttnn::pybind_overload_t{
             [](const ccl_operation_t& self,
                const ttnn::Tensor& input_tensor,
@@ -40,8 +43,9 @@ void bind_line_all_gather(pybind11::module& module, const ccl_operation_t& opera
                const uint32_t cluster_axis,
                const MeshDevice& mesh_device,
                const uint32_t num_links,
-               const std::optional<ttnn::MemoryConfig>& memory_config) -> ttnn::Tensor {
-                return self(input_tensor, dim, cluster_axis, mesh_device, num_links, memory_config);
+               const std::optional<ttnn::MemoryConfig>& memory_config,
+               const ttnn::ccl::OpFabricMode op_fabric_mode) -> ttnn::Tensor {
+                return self(input_tensor, dim, cluster_axis, mesh_device, num_links, memory_config, op_fabric_mode);
             },
             py::arg("input_tensor"),
             py::arg("dim"),
@@ -49,7 +53,8 @@ void bind_line_all_gather(pybind11::module& module, const ccl_operation_t& opera
             py::arg("mesh_device"),
             py::kw_only(),
             py::arg("num_links") = 1,
-            py::arg("memory_config") = std::nullopt});
+            py::arg("memory_config") = std::nullopt,
+            py::arg("op_fabric_mode") = ttnn::ccl::OpFabricMode::TEMPORARY_EDM});
 }
 
 }  // namespace detail
@@ -79,6 +84,7 @@ void py_bind_line_all_gather(pybind11::module& module) {
         Keyword Args:
             * :attr:`num_links` (int): Number of links to use for the all-gather operation.
             * :attr:`memory_config` (Optional[ttnn.MemoryConfig]): Memory configuration for the operation.
+            * :attr:`op_fabric_mode` (Optional[ttnn.ccl.FabricMode]): Specifies to the op if it should try to reuse presistent EriscDataMover (EDM) kernels to avoid dispatch/recompile for erisc cores
 
         Example:
 

--- a/ttnn/cpp/ttnn/operations/ccl/reduce_scatter/device/host/reduce_scatter_full_worker_grid.cpp
+++ b/ttnn/cpp/ttnn/operations/ccl/reduce_scatter/device/host/reduce_scatter_full_worker_grid.cpp
@@ -718,6 +718,9 @@ operation::ProgramWithCallbacks reduce_scatter_with_workers(
     const std::optional<chip_id_t> receiver_device_id,
     const std::optional<chip_id_t> sender_device_id,
    ttnn::ccl::Topology topology) {
+    OpBuildMode op_build_mode = OpBuildMode::NON_PERSISTENT;
+    TT_ASSERT(op_build_mode == OpBuildMode::NON_PERSISTENT, "Reduce scatter only supports non-persistent mode EDM mode until support is added in the op");
+
     log_trace(tt::LogOp, "reduce_scatter_with_workers entry");
     TT_ASSERT(
         input_tensor.get_legacy_shape()[scatter_split_dim] ==
@@ -916,7 +919,8 @@ operation::ProgramWithCallbacks reduce_scatter_with_workers(
         cw_per_link_edm_builders,
         ccw_per_link_edm_builders,
         receiver_device_id,
-        sender_device_id);
+        sender_device_id,
+        op_build_mode);
 
     uint32_t total_num_workers = worker_cores.size();
     auto override_runtime_arguments_callback =

--- a/ttnn/cpp/ttnn/operations/ccl/shared_with_host/edm_types.hpp
+++ b/ttnn/cpp/ttnn/operations/ccl/shared_with_host/edm_types.hpp
@@ -1,0 +1,17 @@
+// SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <cstddef>
+
+namespace ttnn {
+namespace ccl {
+namespace edm {
+
+static constexpr std::size_t MAX_NUM_CHANNELS_ALLOWED = 20;
+
+}
+}
+}

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_matmul/device/all_gather_matmul_op.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_matmul/device/all_gather_matmul_op.hpp
@@ -13,6 +13,7 @@
 #include "tt_metal/host_api.hpp"
 #include "ttnn/operations/ccl/ccl_host_datastructures.hpp"
 #include "ttnn/operations/ccl/ccl_common.hpp"
+#include "ttnn/operations/ccl/ccl_fabric.hpp"
 
 #include "ttnn/run_operation.hpp"
 
@@ -67,6 +68,7 @@ operation::ProgramWithCallbacks all_gather_matmul_multi_core_with_workers(
     const std::optional<chip_id_t> sender_device_id,
     all_gather_op::Topology topology,
     const CoreCoord core_grid_offset,
+    ttnn::ccl::OpBuildMode op_build_mode,
 
     /* Matmul Params */
     const std::optional<const Tensor> bias,

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_matmul/device/multi_core/all_gather_matmul_op_multi_core.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_matmul/device/multi_core/all_gather_matmul_op_multi_core.cpp
@@ -211,7 +211,7 @@ operation::ProgramWithCallbacks experimental::all_gather_matmul_multi_core_with_
     const std::optional<chip_id_t> sender_device_id,
     all_gather_op::Topology topology,
     const CoreCoord core_grid_offset,
-
+    ttnn::ccl::OpBuildMode op_build_mode,
 
     /* Matmul Params */
     const std::optional<const Tensor> bias,
@@ -219,7 +219,6 @@ operation::ProgramWithCallbacks experimental::all_gather_matmul_multi_core_with_
     DeviceComputeKernelConfig compute_kernel_config,
     const operations::matmul::MatmulProgramConfig program_config,
     bool untilize_out
-
 ) {
     tt::tt_metal::Program program{};
     bool use_datacopy = false; /* Enable for debugging purposes */
@@ -332,14 +331,16 @@ operation::ProgramWithCallbacks experimental::all_gather_matmul_multi_core_with_
         matmul_program_with_callbacks->program,
         input_tensor,
         all_gather_output_tensor,
+        all_gather_op_builder_args_t {
         dim,
         num_links,
         ring_size,
         ring_index,
         receiver_device_id,
         sender_device_id,
-        topology,
+        topology},
         all_gather_fused_op_signaler,
+        op_build_mode,
         core_grid_offset);
     const auto all_gather_override_runtime_arguments_callback = program_with_callbacks.override_runtime_arguments_callback;
 

--- a/ttnn/ttnn/__init__.py
+++ b/ttnn/ttnn/__init__.py
@@ -273,6 +273,8 @@ ttnn.Tensor.__lt__ = lambda self, *args, **kwargs: ttnn.lt(self, *args, **kwargs
 ttnn.Tensor.__le__ = lambda self, *args, **kwargs: ttnn.le(self, *args, **kwargs)
 ttnn.Tensor.__getitem__ = lambda self, *args, **kwargs: ttnn.operations.core.__getitem__(self, *args, **kwargs)
 
+CclFabricMode = ttnn._ttnn.operations.ccl.FabricMode
+
 from ttnn.operations.matmul import (
     MatmulMultiCoreReuseProgramConfig,
     MatmulMultiCoreReuseMultiCastProgramConfig,

--- a/ttnn/ttnn/operations/__init__.py
+++ b/ttnn/ttnn/operations/__init__.py
@@ -7,6 +7,7 @@ import pkgutil
 __all__ = []
 
 for loader, module_name, is_pkg in pkgutil.walk_packages(__path__):
+    print(f"module_name: {module_name}")
     __all__.append(module_name)
     _module = loader.find_spec(module_name).loader.load_module(module_name)
     globals()[module_name] = _module


### PR DESCRIPTION
### Ticket
[Link to Github Issue](https://github.com/tenstorrent/tt-metal/issues/12103)

### Problem description
Several topics hit with persistent (EDM) kernels:
1) Reduce CCL startup latency:
- It is not possible currently to mcast ethernet binaries to erisc cores. This will become problematic for Galaxy systems where 16 separate ethernet kernels will need to be programmed with ethernet kernels with every CCL op invocation. This will negatively impact performance - especially in latency sensitive scenario.

2) Make incremental progress towards persistent multichip fabric
- All CCL operations make use of the EDM kernel and so can safely reuse the same kernel binary. Future multichip workloads will target a persistent multi-chip fabric

### What's changed
- Updated EDM kernel to migrate some CT args to RT args so that the kernel can be reused across CCL op invocations.
- Update all-gather ops to make use of the persistent program kernel feature. 

### Checklist
- [ ] Post commit CI passes
- [ ] Blackhole Post commit (if applicable)
- [ ] Model regression CI testing passes (if applicable)
- [ ] New/Existing tests provide coverage for changes
