### PR TITLE
Fix binary L1 interface to properly account for internal repeat buffers

### DIFF
--- a/ttnn/cpp/ttnn/operations/eltwise/binary/binary_l1_interface.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary/binary_l1_interface.hpp
@@ -4,6 +4,8 @@
 #include <optional>
 #include <tuple>
 #include <vector>
+#include "impl/buffers/buffer.hpp"
+#include "ttnn/tensor/types.hpp"
 
 // forward declarations
 namespace tt {
@@ -30,10 +32,9 @@ uint32_t calculate_circular_buffer_l1_allocation_size_per_core(
     const tt::tt_metal::DataType data_type,
     const tt::tt_metal::Layout& layout,
     const tt::tt_metal::MemoryConfig& memory_config,
-    const int max_block_size = 1);
+    const uint32_t max_block_size);
 
-inline uint32_t calculate_circular_buffer_l1_allocation_size_per_core(
-    const EltwiseOpParams& input, int max_block_size = 1) {
+inline uint32_t calculate_circular_buffer_l1_allocation_size_per_core(EltwiseOpParams input, uint32_t max_block_size) {
     return calculate_circular_buffer_l1_allocation_size_per_core(
         std::get<ttnn::types::Shape>(input),
         std::get<tt::tt_metal::DataType>(input),

--- a/ttnn/cpp/ttnn/operations/eltwise/binary/binary_l1_interface.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary/binary_l1_interface.hpp
@@ -1,7 +1,6 @@
 #pragma once
 
 #include <cstdint>
-#include <iostream>
 #include <optional>
 #include <tuple>
 #include <vector>
@@ -30,14 +29,17 @@ uint32_t calculate_circular_buffer_l1_allocation_size_per_core(
     const ttnn::types::Shape& shape,
     const tt::tt_metal::DataType data_type,
     const tt::tt_metal::Layout& layout,
-    const tt::tt_metal::MemoryConfig& memory_config);
+    const tt::tt_metal::MemoryConfig& memory_config,
+    const int max_block_size = 1);
 
-inline uint32_t calculate_circular_buffer_l1_allocation_size_per_core(EltwiseOpParams input) {
+inline uint32_t calculate_circular_buffer_l1_allocation_size_per_core(
+    const EltwiseOpParams& input, int max_block_size = 1) {
     return calculate_circular_buffer_l1_allocation_size_per_core(
         std::get<ttnn::types::Shape>(input),
         std::get<tt::tt_metal::DataType>(input),
         std::get<tt::tt_metal::Layout>(input),
-        std::get<tt::tt_metal::MemoryConfig>(input));
+        std::get<tt::tt_metal::MemoryConfig>(input),
+        max_block_size);
 }
 
 uint32_t calculate_tensor_l1_allocation_size_per_core(
@@ -56,6 +58,12 @@ inline uint32_t calculate_tensor_l1_allocation_size_per_core(EltwiseOpParams inp
 
 uint32_t get_num_of_cores(const std::optional<tt::tt_metal::ShardSpec>& shard_spec);
 
+uint32_t get_num_pages(const tt::tt_metal::ShardSpec& shard_spec);
+
+uint32_t calculate_repeat_circular_buffer_size(tt::tt_metal::DataType data_type);
+
+uint32_t calculate_max_block_size(const std::optional<tt::tt_metal::ShardSpec>& shard_spec);
+
 class EltwiseOpL1Usage {
    public:
     EltwiseOpL1Usage(const EltwiseOpParams& input_a, const EltwiseOpParams& input_b, const EltwiseOpParams& output);
@@ -65,39 +73,35 @@ class EltwiseOpL1Usage {
     virtual std::vector<std::tuple<uint32_t, uint32_t>> get_tensor_l1_allocations_per_core() const = 0;
 
    protected:
+    std::optional<EltwiseOpParams> calculate_repeat_buffer_impl(
+        const EltwiseOpParams& input_a, const EltwiseOpParams& input_b);
+
+    std::optional<ShardSpec> get_op_shard_spec() const;
+
     EltwiseOpParams input_a;
     EltwiseOpParams input_b;
     EltwiseOpParams output;
+    std::optional<EltwiseOpParams> repeat;
 };
 
 class ElementWiseMultiCoreOpL1Usage : public EltwiseOpL1Usage {
    public:
     ElementWiseMultiCoreOpL1Usage(
-        const EltwiseOpParams& input_a, const EltwiseOpParams& input_b, const std::optional<EltwiseOpParams>& output);
+        const EltwiseOpParams& input_a, const EltwiseOpParams& input_b, const EltwiseOpParams& output);
     virtual ~ElementWiseMultiCoreOpL1Usage() = default;
 
     virtual std::vector<std::tuple<uint32_t, uint32_t>> get_circular_buffer_l1_allocations_per_core() const override;
     virtual std::vector<std::tuple<uint32_t, uint32_t>> get_tensor_l1_allocations_per_core() const override;
-
-   protected:
-    std::optional<EltwiseOpParams> intermediate;
-    std::optional<EltwiseOpParams> calculate_intermediate_buffer_impl(
-        const EltwiseOpParams& input_a, const EltwiseOpParams& input_b);
 };
 
 class BroadcastWidthMultiCoreOpL1Usage : public EltwiseOpL1Usage {
    public:
     BroadcastWidthMultiCoreOpL1Usage(
-        const EltwiseOpParams& input_a, const EltwiseOpParams& input_b, const std::optional<EltwiseOpParams>& output);
+        const EltwiseOpParams& input_a, const EltwiseOpParams& input_b, const EltwiseOpParams& output);
     virtual ~BroadcastWidthMultiCoreOpL1Usage() = default;
 
     virtual std::vector<std::tuple<uint32_t, uint32_t>> get_circular_buffer_l1_allocations_per_core() const override;
     virtual std::vector<std::tuple<uint32_t, uint32_t>> get_tensor_l1_allocations_per_core() const override;
-
-   protected:
-    std::optional<EltwiseOpParams> intermediate;
-    std::optional<EltwiseOpParams> calculate_intermediate_buffer_impl(
-        const EltwiseOpParams& input_a, const EltwiseOpParams& input_b);
 };
 
 class EltwiseOpL1UsageFactory {


### PR DESCRIPTION
No review required from the code owners, this is our internal branch that we are working on TTNN <-> optimiser interface, sorry for spam 😄 

Fixed L1 binary interface to properly account for:
-  internal repeat CB being allocated when performing a batch broadcast for all binary eltwise op implementations
- output buffer being allocated by the internal call to repeat

Fixed broken UT with invalid sharding spec - all UTs now passing (or being skipped due to lack of implementation of all eltwise binary op implementations).

Applied clang format to all the files.