### PR TITLE
#12147: Add queue_id and optional output tensors to ttnn.neg_bw

### DIFF
--- a/tests/ttnn/unit_tests/operations/backward/test_backward_neg.py
+++ b/tests/ttnn/unit_tests/operations/backward/test_backward_neg.py
@@ -41,12 +41,44 @@ def test_bw_neg_opt(input_shapes, device):
     in_data, input_tensor = data_gen_with_range(input_shapes, -100, 100, device, True)
     grad_data, grad_tensor = data_gen_with_range(input_shapes, -100, 100, device)
     _, input_grad = data_gen_with_range(input_shapes, -1, 1, device)
+    input_grad = ttnn.to_memory_config(input_grad, ttnn.L1_MEMORY_CONFIG)
 
     pages_before = ttnn._ttnn.reports.get_buffer_pages()
-    tt_output_tensor_on_device = ttnn.neg_bw(grad_tensor, input_tensor, input_grad=input_grad)
+    ttnn.neg_bw(grad_tensor, input_tensor, input_grad=input_grad)
+    assert len(pages_before) == len(ttnn._ttnn.reports.get_buffer_pages())
 
     golden_function = ttnn.get_golden_function(ttnn.neg_bw)
     golden_tensor = golden_function(grad_data, in_data)
 
+    tt_output_tensor_on_device = [input_grad]
     comp_pass = compare_pcc(tt_output_tensor_on_device, golden_tensor)
+
+    assert comp_pass
+
+
+@pytest.mark.parametrize(
+    "input_shapes",
+    (
+        (torch.Size([1, 1, 32, 32])),
+        (torch.Size([1, 1, 320, 384])),
+        (torch.Size([1, 3, 320, 384])),
+    ),
+)
+def test_bw_neg_opt_id(input_shapes, device):
+    in_data, input_tensor = data_gen_with_range(input_shapes, -100, 100, device, True)
+    grad_data, grad_tensor = data_gen_with_range(input_shapes, -100, 100, device)
+    _, input_grad = data_gen_with_range(input_shapes, -1, 1, device)
+    input_grad = ttnn.to_memory_config(input_grad, ttnn.L1_MEMORY_CONFIG)
+    cq_id = 0
+
+    pages_before = ttnn._ttnn.reports.get_buffer_pages()
+    ttnn.neg_bw(grad_tensor, input_tensor, input_grad=input_grad, queue_id=cq_id)
+    assert len(pages_before) == len(ttnn._ttnn.reports.get_buffer_pages())
+
+    golden_function = ttnn.get_golden_function(ttnn.neg_bw)
+    golden_tensor = golden_function(grad_data, in_data)
+
+    tt_output_tensor_on_device = [input_grad]
+    comp_pass = compare_pcc(tt_output_tensor_on_device, golden_tensor)
+
     assert comp_pass

--- a/tests/ttnn/unit_tests/operations/backward/test_backward_neg.py
+++ b/tests/ttnn/unit_tests/operations/backward/test_backward_neg.py
@@ -27,3 +27,26 @@ def test_bw_neg(input_shapes, device):
 
     comp_pass = compare_pcc(tt_output_tensor_on_device, golden_tensor)
     assert comp_pass
+
+
+@pytest.mark.parametrize(
+    "input_shapes",
+    (
+        (torch.Size([1, 1, 32, 32])),
+        (torch.Size([1, 1, 320, 384])),
+        (torch.Size([1, 3, 320, 384])),
+    ),
+)
+def test_bw_neg_opt(input_shapes, device):
+    in_data, input_tensor = data_gen_with_range(input_shapes, -100, 100, device, True)
+    grad_data, grad_tensor = data_gen_with_range(input_shapes, -100, 100, device)
+    _, input_grad = data_gen_with_range(input_shapes, -1, 1, device)
+
+    pages_before = ttnn._ttnn.reports.get_buffer_pages()
+    tt_output_tensor_on_device = ttnn.neg_bw(grad_tensor, input_tensor, input_grad=input_grad)
+
+    golden_function = ttnn.get_golden_function(ttnn.neg_bw)
+    golden_tensor = golden_function(grad_data, in_data)
+
+    comp_pass = compare_pcc(tt_output_tensor_on_device, golden_tensor)
+    assert comp_pass

--- a/ttnn/cpp/ttnn/operations/eltwise/unary_backward/device/unary_backward_op.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary_backward/device/unary_backward_op.cpp
@@ -424,11 +424,11 @@ std::vector<Tensor> _rsqrt_bw(const Tensor& grad, const Tensor& input, const std
     return grad_tensor;
 }
 
-std::vector<Tensor> _neg_bw(const Tensor& grad, const Tensor& input, const std::optional<MemoryConfig>& output_mem_config) {
-    std::vector<Tensor> grad_tensor;
-    Tensor result = ttnn::neg(grad, output_mem_config);
-    grad_tensor.emplace_back(result);
-    return grad_tensor;
+std::vector<std::optional<Tensor>> ExecuteUnaryBackwardNeg::invoke(uint8_t queue_id, const Tensor& grad, const Tensor& input, const std::optional<MemoryConfig>& output_mem_config, std::optional<Tensor> input_grad) {
+    std::vector<std::optional<Tensor>> result = {std::nullopt};
+    input_grad = input_grad.value_or(ttnn::zeros_like(input));
+    result[0] = ttnn::neg(queue_id, grad, output_mem_config, input_grad);
+    return result;
 }
 
 std::vector<Tensor> _relu_bw(const Tensor& grad, const Tensor& input, const std::optional<MemoryConfig>& output_mem_config) {

--- a/ttnn/cpp/ttnn/operations/eltwise/unary_backward/device/unary_backward_op.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary_backward/device/unary_backward_op.hpp
@@ -46,7 +46,6 @@ enum class UnaryBackwardOpType {
     TAN_BW,
     SIGMOID_BW,
     RSQRT_BW,
-    NEG_BW,
     RELU_BW,
     LOGIT_BW,
     HARDSHRINK_BW,
@@ -106,7 +105,6 @@ std::vector<Tensor> _i0_bw( const Tensor& grad, const Tensor& input, const std::
 std::vector<Tensor> _tan_bw( const Tensor& grad, const Tensor& input, const std::optional<MemoryConfig>& output_mem_config);
 std::vector<Tensor> _sigmoid_bw( const Tensor& grad, const Tensor& input, const std::optional<MemoryConfig>& output_mem_config);
 std::vector<Tensor> _rsqrt_bw( const Tensor& grad, const Tensor& input, const std::optional<MemoryConfig>& output_mem_config);
-std::vector<Tensor> _neg_bw( const Tensor& grad, const Tensor& input, const std::optional<MemoryConfig>& output_mem_config);
 std::vector<Tensor> _reciprocal_bw( const Tensor& grad, const Tensor& input, const std::optional<MemoryConfig>& output_mem_config);
 std::vector<Tensor> _ceil_bw(const Tensor& grad, const Tensor& input, const std::optional<MemoryConfig>& output_mem_config);
 std::vector<Tensor> _softsign_bw(const Tensor& grad, const Tensor& input, const std::optional<MemoryConfig>& output_mem_config);
@@ -263,13 +261,6 @@ template <>
 struct OpHandler<UnaryBackwardOpType::RSQRT_BW> {
     static std::vector<Tensor> handle(const Tensor& grad, const Tensor& input, const std::optional<MemoryConfig>& output_mem_config) {
         return _rsqrt_bw(grad, input, output_mem_config);
-    }
-};
-
-template <>
-struct OpHandler<UnaryBackwardOpType::NEG_BW> {
-    static std::vector<Tensor> handle(const Tensor& grad, const Tensor& input, const std::optional<MemoryConfig>& output_mem_config) {
-        return _neg_bw(grad, input, output_mem_config);
     }
 };
 

--- a/ttnn/cpp/ttnn/operations/eltwise/unary_backward/unary_backward.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary_backward/unary_backward.hpp
@@ -13,6 +13,15 @@ namespace ttnn {
 
 namespace operations::unary_backward {
 
+struct ExecuteUnaryBackwardNeg {
+    static std::vector<std::optional<Tensor>> invoke(
+        uint8_t queue_id,
+        const Tensor &grad_tensor_arg,
+        const Tensor &input_tensor_arg,
+        const std::optional<MemoryConfig> &memory_config = std::nullopt,
+        std::optional<Tensor> input_grad = std::nullopt);
+};
+
 template <UnaryBackwardOpType unary_backward_op_type>
 struct ExecuteUnaryBackwardTwoFloat {
     static std::vector<Tensor> invoke(
@@ -351,8 +360,7 @@ constexpr auto rsqrt_bw = ttnn::register_operation<
 
 constexpr auto neg_bw = ttnn::register_operation<
     "ttnn::neg_bw",
-    operations::unary_backward::ExecuteUnaryBackwardOp<
-        operations::unary_backward::UnaryBackwardOpType::NEG_BW>>();
+    operations::unary_backward::ExecuteUnaryBackwardNeg>();
 
 constexpr auto ceil_bw = ttnn::register_operation<
     "ttnn::ceil_bw",

--- a/ttnn/cpp/ttnn/operations/eltwise/unary_backward/unary_backward_pybind.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary_backward/unary_backward_pybind.hpp
@@ -674,7 +674,7 @@ void bind_unary_backward_shape(
 
 template <typename unary_backward_operation_t>
 void bind_unary_backward_unary_optional(
-    py::module& module, const unary_backward_operation_t& operation, std::string_view description) {
+    py::module& module, const unary_backward_operation_t& operation, std::string_view description, std::string_view supported_dtype = "") {
     auto doc = fmt::format(
         R"doc({0}(grad_tensor: ttnn.Tensor, input_tensor: ttnn.Tensor, *, memory_config: ttnn.MemoryConfig) -> std::vector<std::optional<Tensor>>
 
@@ -686,9 +686,10 @@ void bind_unary_backward_unary_optional(
 
         Keyword args:
             * :attr:`memory_config` (Optional[ttnn.MemoryConfig]): memory config for the output tensor
-            * :attr:`are_required_outputs` (Optional[std::vector<bool>]): List of bool, Default value is [True]
             * :attr:`input_grad` (Optional[ttnn.Tensor]): preallocated output tensor,
             * :attr:`queue_id` (Optional[uint8]): command queue id
+
+        {3}
 
         Example:
 
@@ -698,7 +699,8 @@ void bind_unary_backward_unary_optional(
         )doc",
         operation.base_name(),
         operation.python_fully_qualified_name(),
-        description);
+        description,
+        supported_dtype);
 
     bind_registered_operation(
         module,
@@ -709,16 +711,14 @@ void bind_unary_backward_unary_optional(
                const ttnn::Tensor& grad_tensor,
                const ttnn::Tensor& input_tensor,
                const std::optional<ttnn::MemoryConfig>& memory_config,
-               const std::vector<bool>& are_required_outputs,
                const std::optional<ttnn::Tensor>& input_grad,
                const uint8_t& queue_id) -> std::vector<std::optional<ttnn::Tensor>> {
-                return self(queue_id, grad_tensor, input_tensor, memory_config, are_required_outputs, input_grad);
+                return self(queue_id, grad_tensor, input_tensor, memory_config, input_grad);
             },
             py::arg("grad_tensor"),
             py::arg("input_tensor"),
             py::kw_only(),
             py::arg("memory_config") = std::nullopt,
-            py::arg("are_required_outputs") = std::vector<bool>{true},
             py::arg("input_grad") = std::nullopt,
             py::arg("queue_id") = 0});
 }
@@ -1178,7 +1178,7 @@ void py_module(py::module& module) {
         +----------------------------+---------------------------------+-------------------+)doc",
         R"doc(Performs backward operations for rsqrt on :attr:`input_tensor` with given :attr:`grad_tensor`.)doc");
 
-    detail::bind_unary_backward_op(
+    detail::bind_unary_backward_unary_optional(
         module,
         ttnn::neg_bw,
         R"doc(Supported dtypes, layouts, and ranks:

--- a/ttnn/cpp/ttnn/operations/eltwise/unary_backward/unary_backward_pybind.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary_backward/unary_backward_pybind.hpp
@@ -673,7 +673,7 @@ void bind_unary_backward_shape(
 }
 
 template <typename unary_backward_operation_t>
-void bind_unary_backward_unary_optional(
+void bind_unary_backward_neg(
     py::module& module, const unary_backward_operation_t& operation, std::string_view description, std::string_view supported_dtype = "") {
     auto doc = fmt::format(
         R"doc({0}(grad_tensor: ttnn.Tensor, input_tensor: ttnn.Tensor, *, memory_config: ttnn.MemoryConfig) -> std::vector<std::optional<Tensor>>
@@ -719,6 +719,57 @@ void bind_unary_backward_unary_optional(
             py::arg("input_tensor"),
             py::kw_only(),
             py::arg("memory_config") = std::nullopt,
+            py::arg("input_grad") = std::nullopt,
+            py::arg("queue_id") = 0});
+}
+
+template <typename unary_backward_operation_t>
+void bind_unary_backward_unary_optional(
+    py::module& module, const unary_backward_operation_t& operation, std::string_view description) {
+    auto doc = fmt::format(
+        R"doc({0}(grad_tensor: ttnn.Tensor, input_tensor: ttnn.Tensor, *, memory_config: ttnn.MemoryConfig) -> std::vector<std::optional<Tensor>>
+
+        {2}
+
+        Args:
+            * :attr:`grad_tensor`
+            * :attr:`input_tensor`
+
+        Keyword args:
+            * :attr:`memory_config` (Optional[ttnn.MemoryConfig]): memory config for the output tensor
+            * :attr:`are_required_outputs` (Optional[std::vector<bool>]): List of bool, Default value is [True]
+            * :attr:`input_grad` (Optional[ttnn.Tensor]): preallocated output tensor,
+            * :attr:`queue_id` (Optional[uint8]): command queue id
+
+        Example:
+
+            >>> grad_tensor = ttnn.to_device(ttnn.from_torch(torch.tensor((1, 2), dtype=torch.bfloat16)), device)
+            >>> tensor1 = ttnn.to_device(ttnn.from_torch(torch.tensor((1, 2), dtype=torch.bfloat16)), device)
+            >>> output = {1}(grad_tensor, tensor)
+        )doc",
+        operation.base_name(),
+        operation.python_fully_qualified_name(),
+        description);
+
+    bind_registered_operation(
+        module,
+        operation,
+        doc,
+        ttnn::pybind_overload_t{
+            [](const unary_backward_operation_t& self,
+               const ttnn::Tensor& grad_tensor,
+               const ttnn::Tensor& input_tensor,
+               const std::optional<ttnn::MemoryConfig>& memory_config,
+               const std::vector<bool>& are_required_outputs,
+               const std::optional<ttnn::Tensor>& input_grad,
+               const uint8_t& queue_id) -> std::vector<std::optional<ttnn::Tensor>> {
+                return self(queue_id, grad_tensor, input_tensor, memory_config, are_required_outputs, input_grad);
+            },
+            py::arg("grad_tensor"),
+            py::arg("input_tensor"),
+            py::kw_only(),
+            py::arg("memory_config") = std::nullopt,
+            py::arg("are_required_outputs") = std::vector<bool>{true},
             py::arg("input_grad") = std::nullopt,
             py::arg("queue_id") = 0});
 }
@@ -1178,7 +1229,7 @@ void py_module(py::module& module) {
         +----------------------------+---------------------------------+-------------------+)doc",
         R"doc(Performs backward operations for rsqrt on :attr:`input_tensor` with given :attr:`grad_tensor`.)doc");
 
-    detail::bind_unary_backward_unary_optional(
+    detail::bind_unary_backward_neg(
         module,
         ttnn::neg_bw,
         R"doc(Supported dtypes, layouts, and ranks:


### PR DESCRIPTION
Issue : https://github.com/tenstorrent/tt-metal/issues/12147
https://github.com/tenstorrent/tt-metal/actions/runs/10773054531 - passed

Test File : `tests/ttnn/unit_tests/operations/backward/test_backward_neg.py`
<img width="954" alt="Screenshot 2024-09-09 at 7 26 17 PM" src="https://github.com/user-attachments/assets/9a2b230f-7b48-423e-83a1-8feaa19f82c3">


