### PR TITLE
Update UNet test CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -160,6 +160,7 @@ tests/python_api_testing/unit_testing/fallback_ops @tt-aho
 tests/ttnn/integration_tests/stable_diffusion @esmalTT @uaydonat @mywoodstock
 tests/device_perf_tests/stable_diffusion/test_perf_stable_diffusion.py @esmalTT @uaydonat @mywoodstock
 tests/ttnn/integration_tests/unet @esmalTT @uaydonat @mywoodstock
+tests/nightly/wh_b0_only_eth/experimental/functional_unet @esmalTT @uaydonat @mywoodstock
 scripts/profiler/ @mo-tenstorrent
 scripts/docker @ttmchiou @TT-billteng @tt-rkim
 


### PR DESCRIPTION
Updating to avoid pulling in a bunch of unnecessary reviewers on UNet tests