### PR TITLE
#12373: Add queue_id and optional output tensors to rsqrt_bw op

### DIFF
--- a/tests/ttnn/unit_tests/operations/backward/test_backward_rsqrt.py
+++ b/tests/ttnn/unit_tests/operations/backward/test_backward_rsqrt.py
@@ -27,3 +27,33 @@ def test_bw_rsqrt(input_shapes, device):
 
     comp_pass = compare_pcc(tt_output_tensor_on_device, golden_tensor)
     assert comp_pass
+
+
+@pytest.mark.parametrize(
+    "input_shapes",
+    (
+        (torch.Size([1, 1, 32, 32])),
+        (torch.Size([1, 1, 320, 384])),
+        (torch.Size([1, 3, 320, 384])),
+    ),
+)
+def test_bw_rsqrt_opt_output(input_shapes, device):
+    grad_data, grad_tensor = data_gen_with_range(input_shapes, -100, 101, device)
+    in_data, input_tensor = data_gen_with_range(input_shapes, -201, 199, device, True)
+
+    input_grad = torch.zeros(input_shapes, dtype=torch.bfloat16)
+    input_grad = ttnn.from_torch(
+        input_grad, ttnn.bfloat16, layout=ttnn.TILE_LAYOUT, device=device, memory_config=ttnn.L1_MEMORY_CONFIG
+    )
+    cq_id = 0
+    pages_before = ttnn._ttnn.reports.get_buffer_pages()
+    ttnn.rsqrt_bw(grad_tensor, input_tensor, input_grad=input_grad, queue_id=cq_id)
+    assert len(pages_before) == len(ttnn._ttnn.reports.get_buffer_pages())
+
+    tt_output_tensor_on_device = [input_grad]
+
+    golden_function = ttnn.get_golden_function(ttnn.rsqrt_bw)
+    golden_tensor = golden_function(grad_data, in_data)
+
+    comp_pass = compare_pcc(tt_output_tensor_on_device, golden_tensor)
+    assert comp_pass

--- a/ttnn/cpp/ttnn/operations/eltwise/unary_backward/device/unary_backward_op.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary_backward/device/unary_backward_op.hpp
@@ -39,7 +39,6 @@ enum class UnaryBackwardOpType {
     I0_BW,
     TAN_BW,
     SIGMOID_BW,
-    RSQRT_BW,
     RELU_BW,
     LOGIT_BW,
     HARDSHRINK_BW,
@@ -96,7 +95,6 @@ std::vector<Tensor> _fill_zero_bw( const Tensor& grad, const Tensor& input, cons
 std::vector<Tensor> _i0_bw( const Tensor& grad, const Tensor& input, const std::optional<MemoryConfig>& output_mem_config);
 std::vector<Tensor> _tan_bw( const Tensor& grad, const Tensor& input, const std::optional<MemoryConfig>& output_mem_config);
 std::vector<Tensor> _sigmoid_bw( const Tensor& grad, const Tensor& input, const std::optional<MemoryConfig>& output_mem_config);
-std::vector<Tensor> _rsqrt_bw( const Tensor& grad, const Tensor& input, const std::optional<MemoryConfig>& output_mem_config);
 std::vector<Tensor> _reciprocal_bw( const Tensor& grad, const Tensor& input, const std::optional<MemoryConfig>& output_mem_config);
 std::vector<Tensor> _ceil_bw(const Tensor& grad, const Tensor& input, const std::optional<MemoryConfig>& output_mem_config);
 std::vector<Tensor> _softsign_bw(const Tensor& grad, const Tensor& input, const std::optional<MemoryConfig>& output_mem_config);
@@ -235,13 +233,6 @@ template <>
 struct OpHandler<UnaryBackwardOpType::SIGMOID_BW> {
     static std::vector<Tensor> handle(const Tensor& grad, const Tensor& input, const std::optional<MemoryConfig>& output_mem_config) {
         return _sigmoid_bw(grad, input, output_mem_config);
-    }
-};
-
-template <>
-struct OpHandler<UnaryBackwardOpType::RSQRT_BW> {
-    static std::vector<Tensor> handle(const Tensor& grad, const Tensor& input, const std::optional<MemoryConfig>& output_mem_config) {
-        return _rsqrt_bw(grad, input, output_mem_config);
     }
 };
 

--- a/ttnn/cpp/ttnn/operations/eltwise/unary_backward/unary_backward.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary_backward/unary_backward.hpp
@@ -106,6 +106,20 @@ struct ExecuteUnaryBackwardOp {
     }
 };
 
+struct ExecuteUnaryBackwardRsqrt {
+    static std::vector<std::optional<Tensor>> invoke(
+        uint8_t queue_id,
+        const Tensor &grad_tensor_arg,
+        const Tensor &input_tensor_arg,
+        const std::optional<MemoryConfig> &memory_config = std::nullopt,
+        std::optional<Tensor> input_grad = std::nullopt);
+
+    static std::vector<std::optional<Tensor>> invoke(
+        const Tensor &grad_tensor_arg,
+        const Tensor &input_tensor_arg,
+        const std::optional<MemoryConfig> &memory_config = std::nullopt);
+};
+
 template <UnaryBackwardOpType unary_backward_op_type>
 struct ExecuteUnaryBackwardOptionalFloatParamsWithDefault {
     static std::vector<Tensor> invoke(
@@ -388,8 +402,7 @@ constexpr auto sigmoid_bw = ttnn::register_operation<
 
 constexpr auto rsqrt_bw = ttnn::register_operation<
     "ttnn::rsqrt_bw",
-    operations::unary_backward::ExecuteUnaryBackwardOp<
-        operations::unary_backward::UnaryBackwardOpType::RSQRT_BW>>();
+    operations::unary_backward::ExecuteUnaryBackwardRsqrt>();
 
 constexpr auto neg_bw = ttnn::register_operation<
     "ttnn::neg_bw",


### PR DESCRIPTION
### Ticket
Link to Github Issue #12373

### What's changed

- Added queue_id and optional output tensors to ttnn.rsqrt_bw

### Checklist

- [x]  [All Post commit CI ](https://github.com/tenstorrent/tt-metal/actions/runs/10786798857)