### PR TITLE
#12405: Refactor to use strong types

### DIFF
--- a/tt_metal/common/metal_soc_descriptor.cpp
+++ b/tt_metal/common/metal_soc_descriptor.cpp
@@ -101,7 +101,7 @@ CoreCoord metal_SocDescriptor::get_physical_ethernet_core_from_logical(const Cor
         (eth_chan_map.find(logical_coord) != eth_chan_map.end()),
         "Bounds-Error -- Logical_core={} is outside of ethernet logical grid",
         logical_coord.str());
-    return this->physical_ethernet_cores.at(eth_chan_map.at(logical_coord));
+    return this->physical_ethernet_cores.at(static_cast<int>(eth_chan_map.at(logical_coord)));
 }
 
 CoreCoord metal_SocDescriptor::get_logical_ethernet_core_from_physical(const CoreCoord &physical_coord) const {
@@ -113,7 +113,7 @@ CoreCoord metal_SocDescriptor::get_logical_ethernet_core_from_physical(const Cor
         "Bounds-Error -- Physical_core={} is outside of ethernet physical grid",
         physical_coord.str());
 
-    int chan = it - phys_eth_map.begin();
+    auto chan = tt::umd::ethernet_channel{it - phys_eth_map.begin()};
     return this->chan_to_logical_eth_core_map.at(chan);
 }
 
@@ -327,8 +327,8 @@ void metal_SocDescriptor::generate_logical_eth_coords_mapping() {
     this->physical_ethernet_cores = this->ethernet_cores;
     for (int i = 0; i < this->physical_ethernet_cores.size(); i++) {
         CoreCoord core = {0, static_cast<size_t>(i)};
-        this->logical_eth_core_to_chan_map.insert({core, i});
-        this->chan_to_logical_eth_core_map.insert({i, core});
+        this->logical_eth_core_to_chan_map.insert({core, tt::umd::ethernet_channel{i}});
+        this->chan_to_logical_eth_core_map.insert({tt::umd::ethernet_channel{i}, core});
         this->logical_ethernet_cores.emplace_back(core);
     }
 }

--- a/tt_metal/common/metal_soc_descriptor.h
+++ b/tt_metal/common/metal_soc_descriptor.h
@@ -6,6 +6,7 @@
 
 #include "common/tt_backend_api_types.hpp"
 #include "core_coord.h"
+#include "third_party/umd/device/tt_cluster_descriptor_types.h"
 #include "third_party/umd/device/tt_soc_descriptor.h"
 
 //! tt_SocDescriptor contains information regarding the SOC configuration targetted.
@@ -34,8 +35,8 @@ struct metal_SocDescriptor : public tt_SocDescriptor {
     std::unordered_map<int, int> physical_routing_to_virtual_routing_x;
     std::unordered_map<int, int> physical_routing_to_virtual_routing_y;
 
-    std::map<CoreCoord, int> logical_eth_core_to_chan_map;
-    std::map<int, CoreCoord> chan_to_logical_eth_core_map;
+    std::map<CoreCoord, tt::umd::ethernet_channel> logical_eth_core_to_chan_map;
+    std::map<tt::umd::ethernet_channel, CoreCoord> chan_to_logical_eth_core_map;
 
     metal_SocDescriptor(const tt_SocDescriptor& other, uint32_t harvesting_mask);
     metal_SocDescriptor() = default;

--- a/tt_metal/impl/buffers/buffer.hpp
+++ b/tt_metal/impl/buffers/buffer.hpp
@@ -289,7 +289,7 @@ BufferPageMapping generate_buffer_page_mapping(const Buffer &buffer);
 
 namespace detail {
 using PageAddress = uint32_t;
-using Deviceid = uint32_t;
+using Deviceid = umd::chip_id;
 
 class buffer_map_t {
    public:

--- a/tt_metal/impl/debug/watcher_server.cpp
+++ b/tt_metal/impl/debug/watcher_server.cpp
@@ -969,9 +969,9 @@ void watcher_init(Device *device) {
     for (tt::llrt::RunTimeDebugFeatures delay_feature = tt::llrt::RunTimeDebugFeatureReadDebugDelay;
          (int)delay_feature <= tt::llrt::RunTimeDebugFeatureAtomicDebugDelay;
          delay_feature = (tt::llrt::RunTimeDebugFeatures)((int)delay_feature + 1)) {
-        vector<chip_id_t> chip_ids = tt::llrt::OptionsG.get_feature_chip_ids(delay_feature);
+        auto chip_ids = tt::llrt::OptionsG.get_feature_chip_ids(delay_feature);
         bool this_chip_enabled = tt::llrt::OptionsG.get_feature_all_chips(delay_feature) ||
-                                 std::find(chip_ids.begin(), chip_ids.end(), device->id()) != chip_ids.end();
+                                 std::find(chip_ids.begin(), chip_ids.end(), static_cast<int>(device->id())) != chip_ids.end();
         if (this_chip_enabled) {
             static_assert(sizeof(debug_sanitize_noc_addr_msg_t) % sizeof(uint32_t) == 0);
             debug_insert_delays_msg_t delay_setup;
@@ -1106,7 +1106,7 @@ void watcher_attach(Device *device) {
     }
 
     if (watcher::logfile != nullptr) {
-        fprintf(watcher::logfile, "At %.3lfs attach device %d\n", watcher::get_elapsed_secs(), device->id());
+        fprintf(watcher::logfile, "At %.3lfs attach device %d\n", watcher::get_elapsed_secs(), static_cast<int>(device->id()));
     }
 
     if (watcher::enabled) {
@@ -1125,7 +1125,7 @@ void watcher_detach(Device *old) {
         TT_ASSERT(watcher::devices.find(old) != watcher::devices.end());
         if (watcher::enabled && watcher::logfile != nullptr) {
             log_info(LogLLRuntime, "Watcher detached device {}", old->id());
-            fprintf(watcher::logfile, "At %.3lfs detach device %d\n", watcher::get_elapsed_secs(), old->id());
+            fprintf(watcher::logfile, "At %.3lfs detach device %d\n", watcher::get_elapsed_secs(), static_cast<int>(old->id()));
         }
         watcher::devices.erase(old);
         if (watcher::enabled && watcher::devices.empty()) {

--- a/tt_metal/impl/device/device.cpp
+++ b/tt_metal/impl/device/device.cpp
@@ -574,7 +574,7 @@ void Device::update_workers_build_settings(std::vector<std::vector<std::tuple<tt
                 for (auto&[core, settings] : device_worker_variants[DispatchWorkerType::PREFETCH]) {
                     auto dispatch_core_type = settings.dispatch_core_type;
                     uint32_t downstream_cb_base = mux_settings.cb_start_address + mux_settings.cb_size_bytes * mux_sem;
-                    settings.upstream_cores.push_back(tt_cxy_pair(0, 0, 0));
+                    settings.upstream_cores.emplace_back();
                     settings.downstream_cores.push_back(mux_settings.worker_physical_core);
                     settings.compile_args.resize(23);
                     auto& compile_args = settings.compile_args;
@@ -772,7 +772,7 @@ void Device::update_workers_build_settings(std::vector<std::vector<std::tuple<tt
                     auto prefetch_physical_core = prefetch_h_settings.worker_physical_core;
                     auto dispatch_core_type = settings.dispatch_core_type;
                     settings.upstream_cores.push_back(demux_settings.worker_physical_core);
-                    settings.downstream_cores.push_back(tt_cxy_pair(0, 0, 0));
+                    settings.downstream_cores.emplace_back();
                     settings.compile_args.resize(22);
                     auto& compile_args = settings.compile_args;
                     compile_args[0] = settings.cb_start_address;

--- a/tt_metal/impl/device/mesh_device.hpp
+++ b/tt_metal/impl/device/mesh_device.hpp
@@ -14,7 +14,7 @@
 
 namespace tt::tt_metal {
 
-using DeviceIds = std::vector<int>;
+using DeviceIds = std::vector<umd::chip_id>;
 class MeshDeviceView;
 
 class MeshDevice
@@ -22,7 +22,7 @@ class MeshDevice
 public:
     MeshShape mesh_shape;
     std::map<chip_id_t, Device *> managed_devices;
-    std::vector<std::pair<int, Device *>> mesh_devices;
+    std::vector<std::pair<umd::chip_id, Device *>> mesh_devices;
     std::shared_ptr<MeshDeviceView> view;
 
     MeshDevice(const MeshShape &mesh_shape, const DeviceIds &device_ids, size_t l1_small_size, size_t trace_region_size, size_t num_command_queues, DispatchCoreType dispatch_core_type);
@@ -35,7 +35,7 @@ public:
     MeshDevice &operator=(MeshDevice &&) = delete;
 
     std::vector<Device*> get_devices() const;
-    Device *get_device(int logical_device_id) const;
+    Device *get_device(umd::chip_id logical_device_id) const;
     Device *get_device(int row_idx, int col_idx) const;
     std::vector<Device *> get_devices_on_row(int row_idx) const;
     std::vector<Device *> get_devices_on_column(int col_idx) const;

--- a/tt_metal/impl/device/mesh_device_view.cpp
+++ b/tt_metal/impl/device/mesh_device_view.cpp
@@ -121,7 +121,7 @@ template<typename Pred>
 MeshDeviceView MeshDeviceView::subview(Pred&& predicate) const {
     std::vector<device_pointer> filtered_devices;
     std::copy_if(devices_.begin(), devices_.end(), std::back_inserter(filtered_devices), std::forward<Pred>(predicate));
-    return MeshDeviceView(filtered_devices, [this](int device_id) {
+    return MeshDeviceView(filtered_devices, [this](auto device_id) {
         auto it = device_coordinates_.find(device_id);
         return it != device_coordinates_.end() ? std::optional<Coordinate>(it->second) : std::nullopt;
     });

--- a/tt_metal/impl/device/mesh_device_view.hpp
+++ b/tt_metal/impl/device/mesh_device_view.hpp
@@ -59,7 +59,7 @@ public:
     using const_device_pointer = const Device*;
     using DeviceView = std::vector<device_pointer>;
     using DeviceViews = std::vector<std::vector<device_pointer>>;
-    using CoordinateMapper = std::function<std::optional<Coordinate>(int device_id)>;
+    using CoordinateMapper = std::function<std::optional<Coordinate>(umd::chip_id device_id)>;
 
     MeshDeviceView(const MeshDevice& mesh);
     MeshDeviceView(const MeshDevice& mesh, Coordinate top_left, Coordinate bottom_right);

--- a/tt_metal/impl/dispatch/dispatch_core_manager.hpp
+++ b/tt_metal/impl/dispatch/dispatch_core_manager.hpp
@@ -103,7 +103,7 @@ class dispatch_core_manager {
         if (_inst == nullptr) {
             static dispatch_core_manager dispatch_core_manager(internal_core_type);
             _inst = &dispatch_core_manager;
-        } else if (_inst->dispatch_core_type_by_device[0] != internal_core_type) {
+        } else if (_inst->dispatch_core_type_by_device[{}] != internal_core_type) {
             _inst->reset_dispatch_core_manager(internal_core_type);
         }
     }
@@ -279,7 +279,7 @@ class dispatch_core_manager {
             return assignment.tunneler_d.value();
         }
         TT_ASSERT(false, "Device {} has no allocation for Local Upstream Tunneler Core.", device_id);
-        assignment.tunneler_d = tt_cxy_pair(0, 0, 0);
+        assignment.tunneler_d = tt_cxy_pair{};
         return assignment.tunneler_d.value();
     }
 
@@ -386,7 +386,8 @@ class dispatch_core_manager {
         this->dispatch_core_assignments.clear();
         this->available_dispatch_cores_by_device.clear();
         this->dispatch_core_type_by_device.clear();
-        for (chip_id_t device_id = 0; device_id < tt::Cluster::instance().number_of_devices(); device_id++) {
+        for (std::size_t device_index = 0; device_index < tt::Cluster::instance().number_of_devices(); device_index++) {
+            const umd::chip_id device_id{device_index};
             std::list<CoreCoord> &logical_dispatch_cores = this->available_dispatch_cores_by_device[device_id];
             for (const CoreCoord &logical_dispatch_core :
                  tt::get_logical_dispatch_cores(device_id, MAX_NUM_HW_CQS, dispatch_core_type)) {

--- a/tt_metal/impl/dispatch/work_executor.hpp
+++ b/tt_metal/impl/dispatch/work_executor.hpp
@@ -17,6 +17,7 @@
 #include "lock_free_queue.hpp"
 #include "tt_metal/third_party/tracy/public/common/TracySystem.hpp"
 #include "tt_metal/third_party/tracy/public/tracy/Tracy.hpp"
+#include "tt_metal/third_party/umd/device/tt_cluster_descriptor_types.h"
 
 #if defined(TRACY_ENABLE)
 #define TracyTTThreadName(name, id)                     \
@@ -79,11 +80,11 @@ class WorkExecutor {
    public:
     LockFreeQueue<std::function<void()>> worker_queue;
 
-    WorkExecutor(int cpu_core, int device_id) : cpu_core_for_worker(cpu_core), managed_device_id(device_id) {}
+    WorkExecutor(int cpu_core, umd::chip_id device_id) : cpu_core_for_worker(cpu_core), managed_device_id(device_id) {}
 
     WorkExecutor(WorkExecutor&& other) {
         worker_state = std::move(other.worker_state);
-        cpu_core_for_worker = std::move(other.managed_device_id);
+        cpu_core_for_worker = std::move(other.cpu_core_for_worker);
         managed_device_id = std::move(other.managed_device_id);
     }
 
@@ -230,7 +231,7 @@ class WorkExecutor {
     std::thread worker_thread;
     WorkerState worker_state;
     int cpu_core_for_worker;
-    int managed_device_id;
+    umd::chip_id managed_device_id;
     std::condition_variable cv;
     std::mutex cv_mutex;
 

--- a/tt_metal/impl/kernels/kernel.cpp
+++ b/tt_metal/impl/kernels/kernel.cpp
@@ -132,13 +132,14 @@ uint8_t ComputeKernel::expected_num_binaries() const {
 
 std::vector<ll_api::memory> const &Kernel::binaries(uint32_t build_key) const {
     int expected_num_binaries = this->expected_num_binaries();
-    if (this->binaries_.find(build_key) != this->binaries_.end() and
-        this->binaries_.at(build_key).size() != expected_num_binaries) {
+    const umd::chip_id device_id{build_key};
+    if (this->binaries_.find(device_id) != this->binaries_.end() and
+        this->binaries_.at(device_id).size() != expected_num_binaries) {
         TT_THROW(
             "Expected " + std::to_string(expected_num_binaries) + " binaries but have " +
-            std::to_string(this->binaries_.at(build_key).size()) + " for kernel " + this->name());
+            std::to_string(this->binaries_.at(device_id).size()) + " for kernel " + this->name());
     }
-    return this->binaries_.at(build_key);
+    return this->binaries_.at(device_id);
 }
 
 std::string DataMovementKernel::config_hash() const {
@@ -335,10 +336,11 @@ void ComputeKernel::generate_binaries(Device *device, JitBuildOptions &build_opt
 }
 
 void Kernel::set_binaries(uint32_t build_key, std::vector<ll_api::memory> &&binaries) {
-    if (this->binaries_.find(build_key) != this->binaries_.end()) {
-        TT_ASSERT(this->binaries_.at(build_key) == binaries);
+    const umd::chip_id device_id{build_key};
+    if (this->binaries_.find(device_id) != this->binaries_.end()) {
+        TT_ASSERT(this->binaries_.at(device_id) == binaries);
     } else {
-        this->binaries_[build_key] = std::move(binaries);
+        this->binaries_[device_id] = std::move(binaries);
     }
 }
 

--- a/tt_metal/llrt/llrt.hpp
+++ b/tt_metal/llrt/llrt.hpp
@@ -76,7 +76,7 @@ void write_launch_msg_to_core(chip_id_t chip, CoreCoord core, launch_msg_t *msg,
 
 void launch_erisc_app_fw_on_core(chip_id_t chip, CoreCoord core);
 
-void print_worker_cores(chip_id_t chip_id = 0);
+void print_worker_cores(chip_id_t chip_id = {});
 
 inline bool is_worker_core(const CoreCoord &core, chip_id_t chip_id) {
     const metal_SocDescriptor &soc_desc = tt::Cluster::instance().get_soc_desc(chip_id);
@@ -98,7 +98,7 @@ bool test_load_write_read_risc_binary(ll_api::memory &mem, chip_id_t chip_id, co
 bool test_load_write_read_trisc_binary(ll_api::memory &mem, chip_id_t chip_id, const CoreCoord &core, int triscv_id);
 
 // subchannel hard-coded to 0 for now
-CoreCoord get_core_for_dram_channel(int dram_channel_id, chip_id_t chip_id = 0);
+CoreCoord get_core_for_dram_channel(int dram_channel_id, chip_id_t chip_id = {});
 
 namespace internal_ {
 

--- a/tt_metal/llrt/tt_cluster.hpp
+++ b/tt_metal/llrt/tt_cluster.hpp
@@ -11,6 +11,7 @@
 #include "common/metal_soc_descriptor.h"
 #include "common/test_common.hpp"
 #include "common/tt_backend_api_types.hpp"
+#include "device/tt_cluster_descriptor_types.h"
 #include "host_mem_address_map.h"
 #include "hostdevcommon/common_runtime_address_map.h"
 #include "third_party/umd/device/device_api_metal.h"
@@ -25,7 +26,7 @@
 
 static constexpr std::uint32_t SW_VERSION = 0x00020000;
 
-using tt_target_dram = std::tuple<int, int, int>;
+using tt_target_dram = std::tuple<tt::umd::chip_id, int, int>;
 using tt::TargetDevice;
 
 enum EthRouterMode : uint32_t {
@@ -71,7 +72,7 @@ class Cluster {
 
     //! device driver and misc apis
     void verify_eth_fw() const;
-    void verify_sw_fw_versions(int device_id, std::uint32_t sw_version, std::vector<std::uint32_t> &fw_versions) const;
+    void verify_sw_fw_versions(umd::chip_id device_id, std::uint32_t sw_version, std::vector<std::uint32_t> &fw_versions) const;
 
     void deassert_risc_reset_at_core(const tt_cxy_pair &physical_chip_coord) const;
     void assert_risc_reset_at_core(const tt_cxy_pair &physical_chip_coord) const;
@@ -109,7 +110,7 @@ class Cluster {
     }
 
     std::function<void(uint32_t, uint32_t, const uint8_t *)> get_fast_pcie_static_tlb_write_callable(
-        int chip_id) const {
+        umd::chip_id chip_id) const {
         chip_id_t mmio_device_id = device_to_mmio_device_.at(chip_id);
         tt_SiliconDevice *device =
             dynamic_cast<tt_SiliconDevice *>(this->mmio_device_id_to_driver_.at(mmio_device_id).get());
@@ -126,8 +127,8 @@ class Cluster {
         return device->get_static_tlb_writer(virtual_target);
     }
 
-    std::uint32_t get_numa_node_for_device(uint32_t device_id) const {
-        uint32_t associated_mmio_device_id = this->get_associated_mmio_device(device_id);
+    std::uint32_t get_numa_node_for_device(umd::chip_id device_id) const {
+        auto associated_mmio_device_id = this->get_associated_mmio_device(device_id);
         tt_SiliconDevice* driver = dynamic_cast<tt_SiliconDevice*>(this->mmio_device_id_to_driver_.at(associated_mmio_device_id).get());
         return driver->get_numa_node_for_pcie_device(associated_mmio_device_id);
     }

--- a/tt_metal/tools/memset.cpp
+++ b/tt_metal/tools/memset.cpp
@@ -7,7 +7,7 @@
 
 #include <unistd.h>
 
-void memset_l1(vector<uint32_t> mem_vec, uint32_t chip_id, uint32_t start_addr) {
+void memset_l1(vector<uint32_t> mem_vec, tt::umd::chip_id chip_id, uint32_t start_addr) {
     // Utility function that writes a memory vector to L1 for all cores at a specific start address.
     const metal_SocDescriptor &sdesc = tt::Cluster::instance().get_soc_desc(chip_id);
     for (auto &worker_core : sdesc.physical_workers) {
@@ -15,7 +15,7 @@ void memset_l1(vector<uint32_t> mem_vec, uint32_t chip_id, uint32_t start_addr) 
     }
 }
 
-void memset_dram(vector<uint32_t> mem_vec, uint32_t chip_id, uint32_t start_addr) {
+void memset_dram(vector<uint32_t> mem_vec, tt::umd::chip_id chip_id, uint32_t start_addr) {
     // Utility function that writes a memory to all channels and subchannels at a specific start address.
     const metal_SocDescriptor &sdesc = tt::Cluster::instance().get_soc_desc(chip_id);
     for (uint32_t dram_src_channel_id = 0; dram_src_channel_id < sdesc.dram_cores.size(); dram_src_channel_id++) {
@@ -41,7 +41,7 @@ int main(int argc, char *argv[]) {
 
 
     string mem_type     = argv[1];
-    uint32_t chip_id    = std::stoi(argv[2]);
+    tt::umd::chip_id chip_id{std::stoi(argv[2])};
     uint32_t start_addr = std::stoi(argv[3]);
     uint32_t size       = std::stoi(argv[4]);
     uint32_t val        = std::stoi(argv[5]);

--- a/tt_metal/tools/profiler/profiler.cpp
+++ b/tt_metal/tools/profiler/profiler.cpp
@@ -31,7 +31,7 @@ void DeviceProfiler::readRiscProfilerResults(
 
     std::pair<uint32_t, CoreCoord> deviceCore = {device_id,worker_core};
 
-    const metal_SocDescriptor& soc_d = tt::Cluster::instance().get_soc_desc(device_id);
+    const metal_SocDescriptor& soc_d = tt::Cluster::instance().get_soc_desc(umd::chip_id{device_id});
     uint32_t coreFlatID = soc_d.physical_routing_to_profiler_flat_id.at(worker_core);
     uint32_t startIndex = coreFlatID * PROFILER_RISC_COUNT * PROFILER_FULL_HOST_VECTOR_SIZE_PER_RISC;
 
@@ -44,7 +44,7 @@ void DeviceProfiler::readRiscProfilerResults(
     if (std::find(ethCores.begin(), ethCores.end(), worker_core) == ethCores.end())
     {
         control_buffer = tt::llrt::read_hex_vec_from_core(
-            device_id,
+            umd::chip_id{device_id},
             worker_core,
             PROFILER_L1_BUFFER_CONTROL,
             PROFILER_L1_CONTROL_BUFFER_SIZE);
@@ -58,7 +58,7 @@ void DeviceProfiler::readRiscProfilerResults(
     else
     {
         control_buffer = tt::llrt::read_hex_vec_from_core(
-            device_id,
+            umd::chip_id{device_id},
             worker_core,
             eth_l1_mem::address_map::PROFILER_L1_BUFFER_CONTROL,
             PROFILER_L1_CONTROL_BUFFER_SIZE);
@@ -190,7 +190,7 @@ void DeviceProfiler::readRiscProfilerResults(
     control_buffer_reset[kernel_profiler::DRAM_PROFILER_ADDRESS] = output_dram_buffer->address();
 
     tt::llrt::write_hex_vec_to_core(
-            device_id,
+            umd::chip_id{device_id},
             worker_core,
             control_buffer_reset,
             PROFILER_L1_BUFFER_CONTROL);

--- a/tt_metal/tools/profiler/tt_metal_profiler.cpp
+++ b/tt_metal/tools/profiler/tt_metal_profiler.cpp
@@ -46,16 +46,16 @@ void DumpDeviceProfileResults(Device* device, const Program& program) {
 
 namespace detail {
 
-std::map <uint32_t, DeviceProfiler> tt_metal_device_profiler_map;
+std::map <umd::chip_id, DeviceProfiler> tt_metal_device_profiler_map;
 
-std::unordered_map <uint32_t, std::vector <std::pair<uint64_t,uint64_t>>> deviceHostTimePair;
-std::unordered_map <uint32_t, uint64_t> smallestHostime;
+std::unordered_map <umd::chip_id, std::vector <std::pair<uint64_t,uint64_t>>> deviceHostTimePair;
+std::unordered_map <umd::chip_id, uint64_t> smallestHostime;
 
 std::mutex device_mutex;
 
 constexpr CoreCoord SYNC_CORE = {0,0};
 
-void setControlBuffer(uint32_t device_id, std::vector<uint32_t>& control_buffer)
+void setControlBuffer(umd::chip_id device_id, std::vector<uint32_t>& control_buffer)
 {
 #if defined(TRACY_ENABLE)
     const metal_SocDescriptor& soc_d = tt::Cluster::instance().get_soc_desc(device_id);

--- a/tt_metal/tools/watcher_dump/watcher_dump.cpp
+++ b/tt_metal/tools/watcher_dump/watcher_dump.cpp
@@ -38,11 +38,12 @@ void dump_data(vector<unsigned>& device_ids, bool dump_watcher, bool dump_cqs, b
         std::ofstream cq_file = std::ofstream(cq_fname);
         string iq_fname = cq_dir.string() + fmt::format("device_{}_issue_q.txt", id);
         std::ofstream iq_file = std::ofstream(iq_fname);
+        const auto device_id = umd::chip_id{id};
         // Minimal setup, since we'll be attaching to a potentially hanging chip.
-        auto* device = tt::tt_metal::CreateDeviceMinimal(id, num_hw_cqs, DispatchCoreType::WORKER);
+        auto* device = tt::tt_metal::CreateDeviceMinimal(device_id, num_hw_cqs, DispatchCoreType::WORKER);
         if (dump_cqs) {
             std::unique_ptr<SystemMemoryManager> sysmem_manager =
-                std::make_unique<SystemMemoryManager>(id, num_hw_cqs);
+                std::make_unique<SystemMemoryManager>(device_id, num_hw_cqs);
             internal::dump_cqs(cq_file, iq_file, *sysmem_manager, dump_cqs_raw_data);
         }
         // Watcher attach wthout watcher init - to avoid clearing mailboxes.

--- a/ttnn/cpp/pybind11/device.cpp
+++ b/ttnn/cpp/pybind11/device.cpp
@@ -70,10 +70,12 @@ void py_device_module_types(py::module &m_device) {
 
 void device_module(py::module &m_device) {
 
+    py::enum_<tt::umd::chip_id> chip_id(m_device, "chip_id", py::arithmetic());
+
     auto pyDevice = static_cast<py::class_<Device, std::unique_ptr<Device, py::nodelete>>>(m_device.attr("Device"));
     pyDevice
         .def(
-            py::init<>([](int device_id, size_t l1_small_size, size_t trace_region_size) { return Device(device_id, 1, l1_small_size, trace_region_size); }),
+            py::init<>([](tt::umd::chip_id device_id, size_t l1_small_size, size_t trace_region_size) { return Device(device_id, 1, l1_small_size, trace_region_size); }),
             "Create device.",
             py::arg("device_id"),
             py::arg("l1_small_size") = DEFAULT_L1_SMALL_SIZE,
@@ -132,7 +134,7 @@ void device_module(py::module &m_device) {
 
     m_device.def(
         "CreateDevice",
-        [](int device_id, uint8_t num_hw_cqs, size_t l1_small_size, size_t trace_region_size, tt::tt_metal::DispatchCoreType dispatch_core_type) { return tt::tt_metal::CreateDevice(device_id, num_hw_cqs, l1_small_size, trace_region_size, dispatch_core_type); },
+        [](tt::umd::chip_id device_id, uint8_t num_hw_cqs, size_t l1_small_size, size_t trace_region_size, tt::tt_metal::DispatchCoreType dispatch_core_type) { return tt::tt_metal::CreateDevice(device_id, num_hw_cqs, l1_small_size, trace_region_size, dispatch_core_type); },
         R"doc(
         Creates an instance of TT device.
 
@@ -149,7 +151,7 @@ void device_module(py::module &m_device) {
         py::arg("dispatch_core_type") = tt::tt_metal::DispatchCoreType::WORKER);
     m_device.def(
         "CreateDevices",
-        [](std::vector<int> device_ids, uint8_t num_hw_cqs, size_t l1_small_size, size_t trace_region_size, tt::tt_metal::DispatchCoreType dispatch_core_type) {
+        [](std::vector<tt::umd::chip_id> device_ids, uint8_t num_hw_cqs, size_t l1_small_size, size_t trace_region_size, tt::tt_metal::DispatchCoreType dispatch_core_type) {
             return tt::tt_metal::detail::CreateDevices(device_ids, num_hw_cqs, l1_small_size, trace_region_size, dispatch_core_type);
         },
         R"doc(

--- a/ttnn/cpp/pybind11/multi_device.hpp
+++ b/ttnn/cpp/pybind11/multi_device.hpp
@@ -22,7 +22,7 @@ void py_module(py::module& module) {
     auto py_mesh_device = static_cast<py::class_<MeshDevice>>(module.attr("MeshDevice"));
     py_mesh_device
         .def(
-            py::init<MeshShape, std::vector<int>, size_t, size_t, size_t, DispatchCoreType>(),
+            py::init<MeshShape, std::vector<tt::umd::chip_id>, size_t, size_t, size_t, DispatchCoreType>(),
             py::kw_only(),
             py::arg("mesh_shape"),
             py::arg("device_ids"),
@@ -34,7 +34,7 @@ void py_module(py::module& module) {
         .def("get_device_ids", &MeshDevice::get_device_ids)
         .def(
             "get_device",
-            py::overload_cast<int>(&MeshDevice::get_device, py::const_),
+            py::overload_cast<tt::umd::chip_id>(&MeshDevice::get_device, py::const_),
             py::return_value_policy::reference)
         .def(
             "get_device",

--- a/ttnn/cpp/ttnn/async_runtime.cpp
+++ b/ttnn/cpp/ttnn/async_runtime.cpp
@@ -74,7 +74,7 @@ void write_buffer(
     const std::optional<std::size_t> transfer_size) {
     uint32_t dst_ref_count = dst.tensor_attributes->record_main_thread_ref_count();
     for (const auto worker : dst.get_workers()) {
-        auto src_for_device = (src.size() == 1) ? src.at(0) : src.at(worker->id());
+        auto src_for_device = (src.size() == 1) ? src.at(0) : src.at(static_cast<int>(worker->id()));
         worker->push_work([worker, src_for_device, dst, cq_id, transfer_size]() {
             auto shard = tt::tt_metal::get_shard_for_device(dst, worker);
             tt::tt_metal::memcpy(worker->command_queue(cq_id), shard, src_for_device.get(), transfer_size);
@@ -93,7 +93,7 @@ void read_buffer(
     TT_ASSERT(src_offset == 0, "src_offset is not supported");
     uint32_t src_ref_count = src.tensor_attributes->record_main_thread_ref_count();
     for (const auto worker : src.get_workers()) {
-        auto dst_for_device = (dst.size() == 1) ? dst.at(0) : dst.at(worker->id());
+        auto dst_for_device = (dst.size() == 1) ? dst.at(0) : dst.at(static_cast<int>(worker->id()));
         worker->push_work([worker, dst_for_device, src, cq_id, transfer_size, src_offset, blocking]() {
             const auto& shard = tt::tt_metal::get_shard_for_device(src, worker);
             tt::tt_metal::memcpy(worker->command_queue(cq_id), dst_for_device.get(), shard, transfer_size, blocking);

--- a/ttnn/cpp/ttnn/device.cpp
+++ b/ttnn/cpp/ttnn/device.cpp
@@ -9,13 +9,14 @@ namespace ttnn {
 
 namespace device {
 
-Device &open_device(int device_id, size_t l1_small_size, size_t trace_region_size, tt::tt_metal::DispatchCoreType dispatch_core_type) {
+Device &open_device(int id, size_t l1_small_size, size_t trace_region_size, tt::tt_metal::DispatchCoreType dispatch_core_type) {
+    const tt::umd::chip_id device_id{id};
     tt::DevicePool::initialize({device_id}, 1, l1_small_size, trace_region_size, dispatch_core_type, {});
     return *(tt::DevicePool::instance().get_active_device(device_id));
 }
 
 bool is_device_open(int device_id){
-    return tt::DevicePool::instance().is_device_active(device_id);
+    return tt::DevicePool::instance().is_device_active(tt::umd::chip_id{device_id});
 }
 
 void enable_program_cache(Device &device) {

--- a/ttnn/cpp/ttnn/device_operation.hpp
+++ b/ttnn/cpp/ttnn/device_operation.hpp
@@ -202,7 +202,7 @@ auto get_operation_name(const typename device_operation_t::operation_attributes_
 template <typename device_operation_t>
 inline void log_operation(
     std::size_t device_operation_id,
-    std::size_t device_id,
+    tt::umd::chip_id device_id,
     const typename device_operation_t::operation_attributes_t& operation_attributes,
     const typename device_operation_t::tensor_args_t& tensor_args,
     tt::stl::hash::hash_t program_hash,
@@ -237,7 +237,7 @@ inline void log_operation(
 template <typename device_operation_t>
 inline void log_operation(
     std::size_t device_operation_id,
-    std::size_t device_id,
+    tt::umd::chip_id device_id,
     const typename device_operation_t::operation_attributes_t& operation_attributes,
     const typename device_operation_t::tensor_args_t& tensor_args,
     tt::stl::hash::hash_t program_hash,

--- a/ttnn/cpp/ttnn/multi_device.cpp
+++ b/ttnn/cpp/ttnn/multi_device.cpp
@@ -71,10 +71,10 @@ Tensor aggregate_as_tensor(std::vector<Tensor>& tensor_shards)
         std::unordered_map<int, DeviceBuffer> device_buffers;
         for (const auto &shard : tensor_shards) {
             Device* device = std::get<DeviceStorage>(shard.get_storage()).buffer->device();
-            auto device_id = device->id();
+            auto device_id = static_cast<int>(device->id());
             ordered_device_ids.push_back(device_id);
-            device_buffers.insert({device->id(), std::get<DeviceStorage>(shard.get_storage()).buffer});
-            shapes.insert({device->id(), shard.get_legacy_shape()});
+            device_buffers.insert({device_id, std::get<DeviceStorage>(shard.get_storage()).buffer});
+            shapes.insert({device_id, shard.get_legacy_shape()});
         }
         auto storage = MultiDeviceStorage{AllGatherTensor(), ordered_device_ids, std::move(device_buffers), shapes};
         return Tensor(std::move(storage), tensor_shards.at(0).get_legacy_shape(), tensor_shards.at(0).get_dtype(),  tensor_shards.at(0).get_layout());

--- a/ttnn/cpp/ttnn/operations/ccl/all_gather/device/all_gather_op.cpp
+++ b/ttnn/cpp/ttnn/operations/ccl/all_gather/device/all_gather_op.cpp
@@ -23,8 +23,8 @@ AllGather create_all_gather_struct(
     uint32_t num_devices = devices.size();
 
     uint32_t device_index = 0; // Initialize device index
-    uint32_t receiver_device_id = 0; // Initialize receiver device ID
-    uint32_t sender_device_id = 0; // Initialize sender device ID
+    tt::umd::chip_id receiver_device_id{}; // Initialize receiver device ID
+    tt::umd::chip_id sender_device_id{}; // Initialize sender device ID
 
     for (uint32_t i = 0; i < num_devices; ++i) {
         if (devices[i] == input_tensor.device()) {

--- a/ttnn/cpp/ttnn/operations/ccl/ccl_common.cpp
+++ b/ttnn/cpp/ttnn/operations/ccl/ccl_common.cpp
@@ -15,8 +15,8 @@ namespace ccl {
 RingTopology::RingTopology(
     Device const* device,
     Topology topology,
-    std::optional<uint32_t> sender_device_id,
-    std::optional<uint32_t> receiver_device_id,
+    std::optional<tt::umd::chip_id> sender_device_id,
+    std::optional<tt::umd::chip_id> receiver_device_id,
     uint32_t num_links,
     uint32_t ring_size,
     uint32_t ring_index) :
@@ -37,7 +37,7 @@ RingTopology::RingTopology(
     for (uint32_t l = 0; l < num_links; ++l) {
         // Get the cores for the sender and receiver worker cores
         if (!is_linear || ring_index != ring_size - 1) {
-            uint32_t receiver_device = receiver_device_id.value();
+            auto receiver_device = receiver_device_id.value();
             auto const& sockets = device->get_ethernet_sockets(receiver_device);
             auto eth_sender_core = sockets.at(sender_socket_idx);
             eth_sender_cores.push_back(eth_sender_core);
@@ -45,7 +45,7 @@ RingTopology::RingTopology(
                 tt::LogOp, "\teth_sender_core on link {}: (x={},y={})", l, eth_sender_core.x, eth_sender_core.y);
         }
         if (!is_linear || ring_index != 0) {
-            uint32_t sender_device = sender_device_id.value();
+            auto sender_device = sender_device_id.value();
             auto const& sockets = device->get_ethernet_sockets(sender_device);
             auto eth_receiver_core = sockets.at(receiver_socket_idx);
             eth_receiver_cores.push_back(eth_receiver_core);
@@ -209,8 +209,8 @@ void generate_edm_kernels_for_ring_or_linear_topology(
     RingTopology const& topology_config,
     std::vector<ccl::EriscDatamoverBuilder> const& clockwise_edm_builders,
     std::vector<ccl::EriscDatamoverBuilder> const& counter_clockwise_edm_builders,
-    std::optional<uint32_t> receiver_device_id,
-    std::optional<uint32_t> sender_device_id) {
+    std::optional<tt::umd::chip_id> receiver_device_id,
+    std::optional<tt::umd::chip_id> sender_device_id) {
     auto sender_noc = detail::GetPreferredNOCForDRAMRead(tt::Cluster::instance().arch());
     auto receiver_noc = detail::GetPreferredNOCForDRAMWrite(tt::Cluster::instance().arch());
     uint32_t sender_socket_idx = 0;

--- a/ttnn/cpp/ttnn/operations/ccl/ccl_common.hpp
+++ b/ttnn/cpp/ttnn/operations/ccl/ccl_common.hpp
@@ -22,8 +22,8 @@ struct RingTopology {
     RingTopology(
         Device const* device,
         Topology topology,
-        std::optional<uint32_t> sender_device_id,
-        std::optional<uint32_t> receiver_device_id,
+        std::optional<tt::umd::chip_id> sender_device_id,
+        std::optional<tt::umd::chip_id> receiver_device_id,
         uint32_t num_links,
         uint32_t ring_size,
         uint32_t ring_index);
@@ -449,8 +449,8 @@ void generate_edm_kernels_for_ring_or_linear_topology(
     RingTopology const& topology_config,
     std::vector<ccl::EriscDatamoverBuilder> const& clockwise_edm_builders,
     std::vector<ccl::EriscDatamoverBuilder> const& counter_clockwise_edm_builders,
-    std::optional<uint32_t> receiver_device_id,
-    std::optional<uint32_t> sender_device_id);
+    std::optional<tt::umd::chip_id> receiver_device_id,
+    std::optional<tt::umd::chip_id> sender_device_id);
 
 ccl::EriscDatamoverBuilder create_erisc_datamover_builder(
     std::size_t num_channels,

--- a/ttnn/cpp/ttnn/operations/ccl/ccl_host_datastructures.hpp
+++ b/ttnn/cpp/ttnn/operations/ccl/ccl_host_datastructures.hpp
@@ -146,7 +146,7 @@ class EriscDatamoverBuilder {
         ccl::EriscDataMoverBufferSharingMode buffer_sharing_mode,
         ccl::EriscDataMoverTerminationMode termination_mode = ccl::EriscDataMoverTerminationMode::MESSAGE_COUNT_REACHED,
         std::size_t num_buffers_per_channel = 1,
-        chip_id_t chip_id = -1) :
+        chip_id_t chip_id = tt::umd::chip_id::none) :
         local_semaphore_addresses(local_semaphore_addresses),
         local_buffer_addresses(local_buffer_addresses),
         eth_buffer_size_bytes(eth_buffer_size),
@@ -240,7 +240,7 @@ class EriscDatamoverBuilder {
             1,
             static_cast<uint32_t>(this->num_senders > 0 && active_channels.at(0).is_sender),
             this->num_buffers_per_channel,
-            chip_id
+            static_cast<int>(chip_id)
             };
     }
 

--- a/ttnn/cpp/ttnn/operations/ccl/line_all_gather/device/line_all_gather_op.cpp
+++ b/ttnn/cpp/ttnn/operations/ccl/line_all_gather/device/line_all_gather_op.cpp
@@ -94,8 +94,8 @@ Tensor line_all_gather(
             uint32_t num_devices = devices.size();
 
             uint32_t device_index = 0; // Initialize device index
-            std::optional<uint32_t> receiver_device_id = std::nullopt; // Initialize receiver device ID
-            std::optional<uint32_t> sender_device_id = std::nullopt; // Initialize sender device ID
+            std::optional<tt::umd::chip_id> receiver_device_id = std::nullopt; // Initialize receiver device ID
+            std::optional<tt::umd::chip_id> sender_device_id = std::nullopt; // Initialize sender device ID
 
             for (uint32_t i = 0; i < num_devices; ++i) {
                 if (devices[i] == input_tensor.device()) {

--- a/ttnn/cpp/ttnn/reports.hpp
+++ b/ttnn/cpp/ttnn/reports.hpp
@@ -56,7 +56,7 @@ DeviceInfo get_device_info(const Device &device) {
 }
 
 struct BufferInfo {
-    uint32_t device_id;
+    tt::umd::chip_id device_id;
     uint32_t address;
     uint32_t max_size_per_bank;
     BufferType buffer_type;
@@ -112,7 +112,7 @@ std::vector<BufferInfo> get_buffers() {
 }
 
 struct BufferPageInfo {
-    uint32_t device_id;
+    tt::umd::chip_id device_id;
     uint32_t address;
     uint32_t core_y;
     uint32_t core_x;

--- a/ttnn/cpp/ttnn/tensor/tensor.cpp
+++ b/ttnn/cpp/ttnn/tensor/tensor.cpp
@@ -58,7 +58,7 @@ Tensor::Tensor(const Storage storage, const ttnn::Shape shape, DataType dtype, L
                     auto device_id = storage.ordered_device_ids[i];
                     auto buffer = storage.get_buffer_for_device_id(device_id);
                     TT_ASSERT(buffer->device() != nullptr);
-                    TT_ASSERT(buffer->device()->id() == device_id);
+                    TT_ASSERT(static_cast<int>(buffer->device()->id()) == device_id);
                     tensor_impl::validate_on_device_dtype_and_layout(buffer->device(), shape.value, dtype, layout);
                     workers.push_back(buffer->device());
                 }

--- a/ttnn/cpp/ttnn/tensor/tensor.hpp
+++ b/ttnn/cpp/ttnn/tensor/tensor.hpp
@@ -159,7 +159,7 @@ struct Tensor {
                     workers.cend(),
                     std::back_inserter(
                         std::get<MultiDeviceStorage>(this->tensor_attributes->storage).ordered_device_ids),
-                    [](const Device *worker) { return worker->id(); });
+                    [](const Device *worker) { return static_cast<int>(worker->id()); });
             }
             this->tensor_attributes->num_shards_to_be_populated = workers.size();
         } else if (num_buffers) {

--- a/ttnn/cpp/ttnn/tensor/tensor_impl.cpp
+++ b/ttnn/cpp/ttnn/tensor/tensor_impl.cpp
@@ -609,7 +609,7 @@ std::string to_string(const Tensor& tensor, std::optional<DataType> original_dty
                 auto device_index = 0;
                 std::stringstream ss;
                 apply(host_tensor, [&](const Tensor& device_tensor) {
-                    ss << "device_id:" << devices.at(device_index++)->id() << std::endl;
+                    ss << "device_id:" << static_cast<int>(devices.at(device_index++)->id()) << std::endl;
                     ss << to_string<T>(device_tensor) << std::endl;
                 });
                 return ss.str();

--- a/ttnn/cpp/ttnn/tensor/tensor_utils.cpp
+++ b/ttnn/cpp/ttnn/tensor/tensor_utils.cpp
@@ -521,7 +521,7 @@ Tensor get_device_tensor(const Tensor& multi_device_tensor, const int device_id)
 }
 
 Tensor get_device_tensor(const Tensor& multi_device_tensor, const Device* device) {
-    return get_device_tensor(multi_device_tensor, device->id());
+    return get_device_tensor(multi_device_tensor, static_cast<int>(device->id()));
 }
 
 bool is_multi_device_tensor(const Tensor& tensor) {
@@ -586,7 +586,7 @@ Tensor create_multi_device_tensor(
         for (const auto& tensor : tensors) {
             TT_ASSERT(std::holds_alternative<DeviceStorage>(tensor.get_storage()), fmt::format("Unexpected type {} in {}:{} ",tt::stl::get_active_type_name_in_variant(tensor.get_storage()),__FILE__, __LINE__));
             Device* device = std::get<DeviceStorage>(tensor.get_storage()).buffer->device();
-            auto device_id = device->id();
+            auto device_id = static_cast<int>(device->id());
             ordered_device_ids.push_back(device_id);
             device_buffers.insert({device_id, std::get<DeviceStorage>(tensor.get_storage()).buffer});
             shapes.insert({device_id, tensor.get_legacy_shape()});

--- a/ttnn/cpp/ttnn/tensor/types.hpp
+++ b/ttnn/cpp/ttnn/tensor/types.hpp
@@ -568,6 +568,12 @@ struct MultiDeviceStorage {
     static constexpr auto attribute_names = std::forward_as_tuple();
     const auto attribute_values() const { return std::forward_as_tuple(); }
 
+  private:
+    static inline auto get_id(Device *device) {
+        return static_cast<int>(device->id());
+    }
+
+  public:
     // Helper Functions - Getters and setters to get/modify storage attributes. These are needed to
     // preinitialize empty tensor handles and use/populate them in the worker threads.
 
@@ -576,28 +582,28 @@ struct MultiDeviceStorage {
         TT_ASSERT(
             device == buffer->device(),
             "Mismatch between device derived from buffer and device derived from MultiDeviceStorage.");
-        buffers.insert({device->id(), buffer});
-        shapes.insert({device->id(), shape});
+        buffers.insert({get_id(device), buffer});
+        shapes.insert({get_id(device), shape});
     }
 
     inline DeviceBuffer get_buffer_for_device(Device *device) const {
         std::lock_guard<std::mutex> lock(buffer_mtx);
         TT_ASSERT(
-            buffers.find(device->id()) != buffers.end(), "Buffer not found for device " + std::to_string(device->id()));
+            buffers.find(get_id(device)) != buffers.end(), "Buffer not found for device " + std::to_string(get_id(device)));
         TT_ASSERT(
-            buffers.at(device->id())->device() == device,
+            buffers.at(get_id(device))->device() == device,
             "Mismatch between device derived from buffer and device derived from MultiDeviceStorage.");
-        return buffers.at(device->id());
+        return buffers.at(get_id(device));
     }
 
     inline DeviceBuffer &get_buffer_for_device(Device *device) {
         std::lock_guard<std::mutex> lock(buffer_mtx);
         TT_ASSERT(
-            buffers.find(device->id()) != buffers.end(), "Buffer not found for device " + std::to_string(device->id()));
+            buffers.find(get_id(device)) != buffers.end(), "Buffer not found for device " + std::to_string(get_id(device)));
         TT_ASSERT(
-            buffers.at(device->id())->device() == device,
+            buffers.at(get_id(device))->device() == device,
             "Mismatch between device derived from buffer and device derived from MultiDeviceStorage.");
-        return buffers.at(device->id());
+        return buffers.at(get_id(device));
     }
 
     inline DeviceBuffer get_buffer_for_device_id(uint32_t device_id) const {
@@ -608,8 +614,8 @@ struct MultiDeviceStorage {
     inline Shape get_tensor_shape_for_device(Device *device) const {
         std::lock_guard<std::mutex> lock(shape_mtx);
         TT_ASSERT(
-            shapes.find(device->id()) != shapes.end(), "Shape not found for device " + std::to_string(device->id()));
-        return shapes.at(device->id());
+            shapes.find(get_id(device)) != shapes.end(), "Shape not found for device " + std::to_string(get_id(device)));
+        return shapes.at(get_id(device));
     }
 
     inline uint32_t num_buffers() const {
@@ -619,7 +625,7 @@ struct MultiDeviceStorage {
 
     inline bool has_buffer_for_device(Device *device) const {
         std::lock_guard<std::mutex> lock(buffer_mtx);
-        return buffers.find(device->id()) != buffers.end();
+        return buffers.find(get_id(device)) != buffers.end();
     }
 
     inline bool has_buffer_for_device_id(uint32_t device_id) const {


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/12405

### Problem description
Aliases of integral types are being used interchangeably with the integral types, allowing for erroneous implicit conversions.

### What's changed
Refactor to use enum class and make any intentional conversions explicit. Fixes bug in WorkExecutor move constructor where moved-to cpu core was overwritten with device id, potentially causing thread pinning to wrong core.

### Checklist
- [ ] Post commit CI passes
- [ ] Blackhole Post commit (if applicable)
- [ ] Model regression CI testing passes (if applicable)
- [ ] New/Existing tests provide coverage for changes
