### PR TITLE
#10549: Add tiled n-way last-dim split kernels

### DIFF
--- a/ttnn/cpp/ttnn/operations/data_movement/split/device/kernels/dataflow/reader_tm_tile_layout_split_n_chunks.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/split/device/kernels/dataflow/reader_tm_tile_layout_split_n_chunks.cpp
@@ -1,0 +1,69 @@
+// SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <stdint.h>
+
+#include "dataflow_api.h"
+
+#define DEBUG
+#ifdef DEBUG
+#include "debug/dprint.h"
+#endif
+
+void kernel_main() {
+    // READER RUNTIME ARGS
+    uint32_t start_tile = get_arg_val<uint32_t>(0);
+    uint32_t in0_tensor_addr = get_arg_val<uint32_t>(1);
+    uint32_t reader_core_id = get_arg_val<uint32_t>(2);
+
+    // COMPILE TIME ARGS
+    // interleaved accessor args
+    constexpr uint32_t in0_is_dram = get_compile_time_arg_val(1);
+    constexpr uint32_t z = get_compile_time_arg_val(2);
+    constexpr uint32_t z_stride = get_compile_time_arg_val(3);
+    constexpr uint32_t y_stride = get_compile_time_arg_val(4);
+    constexpr uint32_t y_tiles_per_core = get_compile_time_arg_val(5);
+    constexpr uint32_t x_tiles_per_core = get_compile_time_arg_val(6);
+    constexpr uint32_t x_tiles_per_bank = get_compile_time_arg_val(7);
+    constexpr uint32_t num_chunks = get_compile_time_arg_val(8);
+
+    constexpr uint32_t cb_id_in0 = 0;
+    uint32_t single_tile_size_bytes = get_tile_size(cb_id_in0);
+
+    constexpr bool in0_is_dram_bool = in0_is_dram == 1;
+
+    constexpr uint32_t onetile = 1;
+#define tile_dtype_is_bfloat16 get_compile_time_arg_val(0) == 1
+#if (tile_dtype_is_bfloat16)
+    const InterleavedAddrGenFast<in0_is_dram_bool> s0 = {
+        .bank_base_address = in0_tensor_addr, .page_size = single_tile_size_bytes, .data_format = DataFormat::Float16};
+#else
+    const InterleavedAddrGenFast<in0_is_dram_bool> s0 = {
+        .bank_base_address = in0_tensor_addr, .page_size = single_tile_size_bytes, .data_format = DataFormat::Bfp8_b};
+#endif
+    uint32_t tensor_stride = x_tiles_per_bank;
+    uint32_t tensor_stride_cum = 0;
+    for (uint32_t n = 0; n < num_chunks; n++) {
+        uint32_t z_stride_cum = 0;
+        for (uint32_t k = 0; k < z; k++) {
+            uint32_t y_stride_cum = 0;
+            for (uint32_t j = 0; j < y_tiles_per_core; j++) {
+                for (uint32_t i = 0; i < x_tiles_per_bank; i++) {
+                    uint32_t tile_offset = y_stride_cum + z_stride_cum + tensor_stride_cum + i;
+                    cb_reserve_back(cb_id_in0, onetile);
+                    uint32_t l1_write_addr_in0 = get_write_ptr(cb_id_in0);
+                    noc_async_read_tile(start_tile + tile_offset, s0, l1_write_addr_in0);
+                    noc_async_read_barrier();
+                    cb_push_back(cb_id_in0, onetile);
+    #ifdef DEBUG
+                    DPRINT << "[R/" << reader_core_id << "]" << " @ " << s0.bank_base_address << "[" << start_tile+tile_offset << "]" << ENDL();
+    #endif
+                }
+                y_stride_cum += y_stride;
+            }
+            z_stride_cum += z_stride;
+        }
+        tensor_stride_cum += tensor_stride;
+    }
+}

--- a/ttnn/cpp/ttnn/operations/data_movement/split/device/kernels/dataflow/writer_tm_tile_layout_split_n_chunks.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/split/device/kernels/dataflow/writer_tm_tile_layout_split_n_chunks.cpp
@@ -1,0 +1,88 @@
+// SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <stdint.h>
+#include <algorithm>
+#include <array>
+#include "dataflow_api.h"
+
+// #define DEBUG
+#ifdef DEBUG
+#include "debug/dprint.h"
+#endif
+
+void kernel_main() {
+    // COMPILE TIME ARGS
+    // interleaved accessor args
+    constexpr uint32_t out_is_dram = get_compile_time_arg_val(1);
+    // WRITER COMPILE TIME ARGS
+    //constexpr uint32_t out_num_tiles_per_tensor = get_compile_time_arg_val(2);
+    constexpr uint32_t y_tiles_per_core = get_compile_time_arg_val(2);
+    constexpr uint32_t x_tiles_per_bank = get_compile_time_arg_val(3);
+    constexpr uint32_t z = get_compile_time_arg_val(4);
+    constexpr uint32_t z_stride = get_compile_time_arg_val(5);
+    constexpr uint32_t y_stride = get_compile_time_arg_val(6);
+    constexpr uint32_t num_chunks = get_compile_time_arg_val(7);
+
+    // WRITER RUNTIME ARGS
+    std::array<uint32_t, num_chunks> out_addrs;
+
+    for (uint32_t i = 0; i < num_chunks; i++) {
+        out_addrs[i] = get_arg_val<uint32_t>(i);
+    }
+
+    uint32_t writer_core_id = get_arg_val<uint32_t>(num_chunks+0);
+    uint32_t start_tile = get_arg_val<uint32_t>(num_chunks+1);
+
+    constexpr uint32_t cb_id_out0 = 0;  // same as cb_id_in0
+    uint32_t single_tile_size_bytes = get_tile_size(cb_id_out0);
+
+    constexpr bool out_is_dram_bool = out_is_dram == 1;
+    constexpr uint32_t onetile = 1;
+
+    DataFormat df;
+
+#define tile_dtype_is_bfloat16 get_compile_time_arg_val(0) == 1
+#if (tile_dtype_is_bfloat16)
+    df = DataFormat::Float16;
+#else
+    df = DataFormat::Bfp8_b;
+#endif
+    std::array<InterleavedAddrGenFast<out_is_dram_bool>, num_chunks> output_banks;
+    std::transform(out_addrs.begin(),
+                   out_addrs.end(),
+                   output_banks.begin(),
+                   [&](uint32_t &addr) -> InterleavedAddrGenFast<out_is_dram_bool> {
+                        return { .bank_base_address = addr,
+                                 .page_size = single_tile_size_bytes,
+                                 .data_format = df };
+                   });
+
+    uint32_t out_split_tensor_tile_id;
+    uint32_t bank_id = 0;
+    uint32_t tile_id = 0;
+
+    for (const auto& s : output_banks) {
+        uint32_t z_stride_cum = 0;
+        for (uint32_t k = 0; k < z; k++) {
+            uint32_t y_stride_cum = 0;
+            for (uint32_t j = 0; j < y_tiles_per_core; j++) {
+                for (uint32_t i = 0; i < x_tiles_per_bank; i++) {
+                    uint32_t tile_id = start_tile + y_stride_cum + z_stride_cum + i;
+                    cb_wait_front(cb_id_out0, onetile);
+                    uint32_t l1_read_addr = get_read_ptr(cb_id_out0);
+                    noc_async_write_tile(tile_id, s, l1_read_addr);
+                    noc_async_write_barrier();
+                    cb_pop_front(cb_id_out0, onetile);
+#ifdef DEBUG
+                    DPRINT << "[W/" << writer_core_id <<"] B" << bank_id << "@" << s.bank_base_address << "[" << tile_id << "]" << ENDL();
+#endif
+                }
+                y_stride_cum += y_stride;
+            }
+            z_stride_cum += z_stride;
+        }
+        bank_id++;
+    }
+}

--- a/ttnn/cpp/ttnn/operations/data_movement/split/device/split_op.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/split/device/split_op.cpp
@@ -51,8 +51,10 @@ std::vector<Tensor> SplitDeviceOperation::create_output_tensors(const std::vecto
 
 operation::ProgramWithCallbacks SplitDeviceOperation::create_program(const std::vector<Tensor>& input_tensors, std::vector<Tensor> &output_tensors) const {
     const auto& input_tensor = input_tensors.at(0);
-    return detail::split_last_dim_two_chunks_tiled(input_tensor, output_tensors, this->output_mem_config);
+    if (output_tensors.size() == 2) {
+        return detail::split_last_dim_two_chunks_tiled(input_tensor, output_tensors, this->output_mem_config);
+    } else {
+        return detail::split_last_dim_n_chunks_tiled(input_tensor, output_tensors, this->output_mem_config);
+    }
 }
-
-
 }

--- a/ttnn/cpp/ttnn/operations/data_movement/split/device/split_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/split/device/split_program_factory.cpp
@@ -2,12 +2,227 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-#include "tt_metal/common/work_split.hpp"
+#include <cstdint>
+#include <iterator>
+#include <ranges>
+#include <vector>
+#include "ttnn/deprecated/tt_dnn/op_library/work_split.hpp"
 #include "tt_metal/host_api.hpp"
 #include "tt_metal/common/constants.hpp"
+#include "ttnn/tensor/tensor.hpp"
+#include "ttnn/cpp/ttnn/operation.hpp"
+namespace   ttnn::operations::data_movement::detail {
 
-namespace ttnn::operations::data_movement::detail {
+// operation for generic n-way splits where n != 2
+operation::ProgramWithCallbacks split_last_dim_n_chunks_tiled(
+    const Tensor &input_tensor, std::vector<Tensor> &output_tensors, const MemoryConfig &mem_config) {
+    uint32_t dim = 3; // this op always splits on dim 3 for now.
+    uint32_t num_chunks = output_tensors.size();
 
+    auto input_shape = input_tensor.get_legacy_shape();
+
+    Program program{};
+    tt::tt_metal::Device *device = input_tensor.device();
+    tt::DataFormat input_data_format = tt::tt_metal::datatype_to_dataformat_converter(input_tensor.get_dtype());
+
+    ////////////////////////////////////////////////////////////////////////////
+    //                 Buffer Setup
+    ////////////////////////////////////////////////////////////////////////////
+
+    uint32_t single_tile_size = tt::tt_metal::detail::TileSize(input_data_format);
+    tt::tt_metal::Buffer *in0_buffer = input_tensor.buffer();
+
+    // Output buffers
+    TT_FATAL(std::all_of(output_tensors.begin(),
+                        output_tensors.end(),
+                        [](tt::tt_metal::Tensor &t) {return t.buffer() != nullptr;}),
+            "Output tensor buffers should be allocated on device!"); // FIXME?: could make this more specific
+
+    ////////////////////////////////////////////////////////////////////////////
+    //                      Application Setup
+    ////////////////////////////////////////////////////////////////////////////
+
+    uint32_t z = input_shape[1]; // channels
+    uint32_t num_tiles_y_dim = input_shape[2] / tt::constants::TILE_HEIGHT; // how many tiles along height axis of the input tensor
+    uint32_t num_tiles_x_dim = input_shape[3] / tt::constants::TILE_WIDTH; // how many tiles along width axis of the input tensor
+    uint32_t num_cores_x_limit = device->compute_with_storage_grid_size().x;
+    uint32_t num_cores_y_limit = device->compute_with_storage_grid_size().y;
+
+    // We are splitting along the width (last dim/dim 3) of the tensor so we
+    // parallelize along height (dim 2) and depth (dim 1).
+
+    uint32_t num_cores = (num_cores_x_limit * num_cores_y_limit);
+
+    auto [num_cores_used, y_tiles_per_core] = get_max_cores_divisible_by_tiles_per_core_tiles(num_tiles_y_dim, num_cores);
+
+    uint32_t x_tiles_per_core = num_tiles_x_dim;
+    uint32_t xy_tiles_per_core = y_tiles_per_core * x_tiles_per_core;
+    uint32_t tiles_per_core = xy_tiles_per_core * z;
+
+    uint32_t start_core_x = 0;
+    uint32_t start_core_y = 0;
+
+    uint32_t num_cores_c = std::gcd(num_cores_used, num_cores_x_limit);
+    uint32_t num_cores_r = num_cores_used / num_cores_c;
+
+    CoreRange all_cores(
+        {(std::size_t)start_core_x, (std::size_t)start_core_y},
+        {(std::size_t)start_core_x + num_cores_r - 1, (std::size_t)start_core_y + num_cores_c - 1}
+    );
+
+    bool tile_dtype_is_bfloat16 = input_tensor.get_dtype() == tt::tt_metal::DataType::BFLOAT16;
+    bool in0_is_dram = in0_buffer->buffer_type() == tt::tt_metal::BufferType::DRAM ? 1 : 0;
+
+    std::vector<tt::tt_metal::Buffer*> output_buffers(output_tensors.size());
+    std::transform(output_tensors.begin(),
+                   output_tensors.end(),
+                   output_buffers.begin(),
+                   [](Tensor &t) { return t.buffer(); });
+
+    TT_FATAL(std::all_of(output_tensors.begin(),
+                         output_tensors.end(),
+                         [&](tt::tt_metal::Tensor &t)
+                           {return t.buffer()->buffer_type() == output_tensors[0].buffer()->buffer_type();}),
+             "Output buffers should be the same type");
+
+    bool out_is_dram = output_buffers[0]->buffer_type() == tt::tt_metal::BufferType::DRAM ? 1 : 0;
+
+    uint32_t x_tiles_per_bank = num_tiles_x_dim / num_chunks;
+
+    uint32_t z_stride_read = num_tiles_x_dim * num_tiles_y_dim; // increase z by going through an x-y plane.
+    uint32_t y_stride_read = num_tiles_x_dim; // advance by the width to go down in height
+
+    std::vector<uint32_t> reader_compile_time_args = {// interleaved accessor args
+                                                      (std::uint32_t)tile_dtype_is_bfloat16,
+                                                      // by default in dram
+                                                      (std::uint32_t)in0_is_dram,
+
+                                                      // READER COMPILE TIME ARGS
+                                                      (std::uint32_t)z,
+                                                      (std::uint32_t)z_stride_read,
+                                                      (std::uint32_t)y_stride_read,
+                                                      (std::uint32_t)y_tiles_per_core,
+                                                      (std::uint32_t)x_tiles_per_core,
+                                                      (std::uint32_t)x_tiles_per_bank,
+                                                      (std::uint32_t)num_chunks
+                                                    };
+
+    uint32_t z_stride_write = (num_tiles_x_dim * num_tiles_y_dim) / num_chunks;
+    uint32_t y_stride_write = num_tiles_x_dim / num_chunks;
+
+    std::vector<uint32_t> writer_compile_time_args = {// interleaved accessor args
+                                                      (std::uint32_t)tile_dtype_is_bfloat16,
+                                                      (std::uint32_t)out_is_dram,
+                                                      (std::uint32_t)y_tiles_per_core,
+                                                      (std::uint32_t)x_tiles_per_bank,
+                                                      (std::uint32_t)z,
+                                                      (std::uint32_t)z_stride_write,
+                                                      (std::uint32_t)y_stride_write,
+                                                      (std::uint32_t)num_chunks};
+
+    auto reader_kernel_id = tt::tt_metal::CreateKernel(
+        program,
+        "ttnn/cpp/ttnn/operations/data_movement/split/device/kernels/dataflow/reader_tm_tile_layout_split_n_chunks.cpp",
+        all_cores,
+	tt::tt_metal::ReaderDataMovementConfig(reader_compile_time_args));
+
+    auto writer_kernel_id = tt::tt_metal::CreateKernel(
+        program,
+        "ttnn/cpp/ttnn/operations/data_movement/split/device/kernels/dataflow/writer_tm_tile_layout_split_n_chunks.cpp",
+        all_cores,
+        tt::tt_metal::WriterDataMovementConfig(writer_compile_time_args));
+
+    uint32_t src0_cb_index = 0;
+    uint32_t num_input_tiles = 2;
+    auto cb_src0_config =
+        tt::tt_metal::CircularBufferConfig(num_input_tiles * single_tile_size, {{src0_cb_index, input_data_format}})
+            .set_page_size(src0_cb_index, single_tile_size);
+    auto cb_src0 = tt::tt_metal::CreateCircularBuffer(program, all_cores, cb_src0_config);
+
+    auto setup_reader_runtime_args =
+        [xy_tiles_per_core,
+         num_cores_r,
+         num_chunks,
+         &program,
+         reader_kernel_id
+         ](const CoreCoord &core, Buffer* in0_buffer) {
+            uint32_t reader_core_id = core.y * num_cores_r + core.x;
+            uint32_t start_tile = xy_tiles_per_core * reader_core_id; // start tile within the input tensor
+            std::vector<uint32_t> reader_runtime_args = {
+                (std::uint32_t)start_tile,
+                (std::uint32_t)(in0_buffer->address()),  // in0_tensor_addr
+                (std::uint32_t)reader_core_id,
+            };
+
+            tt::tt_metal::SetRuntimeArgs(program,
+                                         reader_kernel_id,
+                                         core,
+                                         reader_runtime_args);
+        };
+
+    auto setup_writer_runtime_args =
+        [xy_tiles_per_core,
+         num_cores_r,
+         num_chunks,
+         &program,
+         writer_kernel_id](const CoreCoord &core, const std::vector<Buffer*> &output_buffers) {
+            std::vector<uint32_t> output_addrs;
+            output_addrs.reserve(output_buffers.size());
+            std::transform(output_buffers.begin(),
+                           output_buffers.end(),
+                           std::back_inserter(output_addrs),
+                           [](tt::tt_metal::Buffer *buf) { return buf->address(); });
+
+            uint32_t writer_core_id = core.y * num_cores_r + core.x;
+            uint32_t writer_start_tile = (xy_tiles_per_core / num_chunks) * writer_core_id; // start tile within each output bank
+
+            std::vector<uint32_t> control_args = {writer_core_id, writer_start_tile};
+            std::vector<uint32_t> writer_runtime_args;
+            writer_runtime_args.reserve(output_addrs.size()+control_args.size());
+
+            writer_runtime_args.insert(writer_runtime_args.end(),
+                                       output_addrs.begin(),
+                                       output_addrs.end());
+
+            // add writer_core_id and start_tile to the end of the writer_runtime_args
+            writer_runtime_args.insert(writer_runtime_args.end(),
+                                       control_args.begin(),
+                                       control_args.end());
+
+            tt::tt_metal::SetRuntimeArgs(program, writer_kernel_id, core, writer_runtime_args);
+        };
+
+    auto setup_runtime_args =
+        [setup_reader_runtime_args,
+         setup_writer_runtime_args]
+        (const CoreCoord &core,
+         Buffer* in0_buffer,
+         const std::vector<Buffer*> &output_buffers) {
+            setup_reader_runtime_args(core, in0_buffer);
+            setup_writer_runtime_args(core, output_buffers);
+        };
+
+    for (auto core : all_cores) {
+        setup_reader_runtime_args(core, in0_buffer);
+        setup_writer_runtime_args(core, output_buffers);
+    };
+
+    auto override_runtime_args_callback =
+        [all_cores,
+         setup_runtime_args](const Program &program,
+                             const std::vector<Buffer *> &input_buffers,
+                             const std::vector<Buffer *> &output_buffers) {
+                                 const auto in0_buffer = input_buffers[0];
+                                 for (auto core : all_cores) {
+                                     setup_runtime_args(core, in0_buffer, output_buffers);
+                                 }
+                                 return;
+                             };
+
+    return {std::move(program), override_runtime_args_callback};
+}
+
+// operation for the special case of two-way splits
 void setup_runtime(
     const Program &program,
     const uint32_t &core_offset,
@@ -122,11 +337,11 @@ operation::ProgramWithCallbacks split_last_dim_two_chunks_tiled(
 
     // parallelize y
     auto [num_cores_y, per_core_tiles_y] =
-        tt::tt_metal::get_max_cores_divisible_by_tiles_per_core_tiles(num_tiles_dim_3, num_cores_y_limit, /*request_even=*/true);
+        get_max_cores_divisible_by_tiles_per_core_tiles(num_tiles_dim_3, num_cores_y_limit, /*request_even=*/true);
 
     // parallelize x
     auto [num_cores_x, per_core_tiles_x] =
-        tt::tt_metal::get_max_cores_divisible_by_tiles_per_core_tiles(num_tiles_dim_2, num_cores_x_limit / num_cores_z);
+        get_max_cores_divisible_by_tiles_per_core_tiles(num_tiles_dim_2, num_cores_x_limit / num_cores_z);
 
     uint32_t per_core_tiles = per_core_tiles_x * per_core_tiles_y * (z / num_cores_z);
 

--- a/ttnn/cpp/ttnn/operations/data_movement/split/device/split_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/split/device/split_program_factory.cpp
@@ -6,7 +6,7 @@
 #include <iterator>
 #include <ranges>
 #include <vector>
-#include "ttnn/deprecated/tt_dnn/op_library/work_split.hpp"
+#include "tt_metal/common/work_split.hpp"
 #include "tt_metal/host_api.hpp"
 #include "tt_metal/common/constants.hpp"
 #include "ttnn/tensor/tensor.hpp"

--- a/ttnn/cpp/ttnn/operations/data_movement/split/device/split_program_factory.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/split/device/split_program_factory.hpp
@@ -6,9 +6,10 @@
 
 namespace ttnn::operations::data_movement::detail {
 
+    operation::ProgramWithCallbacks split_last_dim_n_chunks_tiled(
+        const Tensor &input_tensor, std::vector<Tensor> &output_tensors, const MemoryConfig &mem_config);
 
-operation::ProgramWithCallbacks split_last_dim_two_chunks_tiled(
-    const Tensor &input_tensor, std::vector<Tensor> &output_tensors, const MemoryConfig &mem_config);
-
+    operation::ProgramWithCallbacks split_last_dim_two_chunks_tiled(
+        const Tensor &input_tensor, std::vector<Tensor> &output_tensors, const MemoryConfig &mem_config);
 
 }

--- a/ttnn/cpp/ttnn/operations/data_movement/split/split.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/split/split.cpp
@@ -18,8 +18,8 @@ namespace detail {
 
     std::vector<Tensor> impl_split_last_dim_n_chunks_tiled(const Tensor &input_tensor, const MemoryConfig &mem_config, const int64_t &num_chunks) {
         auto input_shape = input_tensor.get_legacy_shape();
-        auto padded_input_shape = AutoFormat::pad_to_tile_shape(input_shape);
-        FormatParams input_format_params = {.pad_shape = padded_input_shape, .pad_value = 0.0, .target_layout = Layout::TILE};
+        auto padded_input_shape = ttnn::operations::experimental::auto_format::AutoFormat::pad_to_tile_shape(input_shape);
+        ttnn::operations::experimental::auto_format::FormatParams input_format_params = {.pad_shape = padded_input_shape, .pad_value = 0.0, .target_layout = Layout::TILE};
         return operation::run_with_autoformat(SplitDeviceOperation{num_chunks, 3, mem_config}, {input_tensor}, {input_format_params}, {Layout::TILE, Layout::TILE});
     }
 

--- a/ttnn/cpp/ttnn/operations/data_movement/split/split.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/split/split.cpp
@@ -16,26 +16,25 @@ namespace ttnn::operations::data_movement {
 
 namespace detail {
 
-    std::vector<Tensor> impl_split_last_dim_two_chunks_tiled(const Tensor &input_tensor, const MemoryConfig &mem_config) {
-
+    std::vector<Tensor> impl_split_last_dim_n_chunks_tiled(const Tensor &input_tensor, const MemoryConfig &mem_config, const int64_t &num_chunks) {
         auto input_shape = input_tensor.get_legacy_shape();
-        auto padded_input_shape = ttnn::operations::experimental::auto_format::AutoFormat::pad_to_tile_shape(input_shape);
-        ttnn::operations::experimental::auto_format::FormatParams input_format_params = {.pad_shape = padded_input_shape, .pad_value = 0.0, .target_layout = Layout::TILE};
-        return operation::run_with_autoformat(SplitDeviceOperation{2, 3, mem_config}, {input_tensor}, {input_format_params}, {Layout::TILE, Layout::TILE});
+        auto padded_input_shape = AutoFormat::pad_to_tile_shape(input_shape);
+        FormatParams input_format_params = {.pad_shape = padded_input_shape, .pad_value = 0.0, .target_layout = Layout::TILE};
+        return operation::run_with_autoformat(SplitDeviceOperation{num_chunks, 3, mem_config}, {input_tensor}, {input_format_params}, {Layout::TILE, Layout::TILE});
     }
 
-    std::vector<Tensor> split_last_dim_two_chunks_tiled(const Tensor &input_tensor, const MemoryConfig &mem_config) {
+    std::vector<Tensor> split_last_dim_n_chunks_tiled(const Tensor &input_tensor, const MemoryConfig &mem_config, const int64_t &num_chunks) {
         const auto shape = input_tensor.get_legacy_shape();
         const bool pre_post_reshape = shape[0] > 1;
 
         if (!pre_post_reshape) {
-            return impl_split_last_dim_two_chunks_tiled(input_tensor, mem_config);
+            return impl_split_last_dim_n_chunks_tiled(input_tensor, mem_config, num_chunks);
         }
 
         const int W = 1, Z = shape[0] * shape[1], Y = shape[2], X = shape[3];
         const Tensor &reshaped_tensor = ttnn::reshape_on_device(input_tensor, 1, -1, Y, X, mem_config);
 
-        auto part_reshaped = impl_split_last_dim_two_chunks_tiled(reshaped_tensor, mem_config);
+        auto part_reshaped = impl_split_last_dim_n_chunks_tiled(reshaped_tensor, mem_config, num_chunks);
 
         std::vector<Tensor> results;
         results.reserve(part_reshaped.size());
@@ -45,13 +44,13 @@ namespace detail {
     }
 
 
-std::vector<Tensor> split_dim_two_chunks_tiled(
-    const Tensor &input_tensor, int dim /* = 3 */, const MemoryConfig &mem_config /* = default */) {
+std::vector<Tensor> split_dim_n_chunks_tiled(
+    const Tensor &input_tensor, int dim /* = 3 */, const MemoryConfig &mem_config /* = default */, const int64_t &num_chunks /* = 2 */) {
     if (dim == 3) {
-        return split_last_dim_two_chunks_tiled(input_tensor, mem_config);
+        return split_last_dim_n_chunks_tiled(input_tensor, mem_config, num_chunks);
     }
     Tensor ref_input_tensor = ttnn::transpose(input_tensor, dim, 3, mem_config);
-    auto transposed_result = split_last_dim_two_chunks_tiled(ref_input_tensor, mem_config);
+    auto transposed_result = split_last_dim_n_chunks_tiled(ref_input_tensor, mem_config, num_chunks);
     std::vector<Tensor> results;
     results.reserve(transposed_result.size());
     for (Tensor &t : transposed_result) {
@@ -69,11 +68,8 @@ std::vector<ttnn::Tensor> SplitOperation::invoke(
     int64_t& num_splits,
     int64_t& dim,
     const std::optional<MemoryConfig>& memory_config_arg) {
-
-    auto memory_config = memory_config_arg.value_or(input_tensor.memory_config());
-    TT_FATAL(num_splits == 2, "Currently only supporting split in 2");
-    return detail::split_dim_two_chunks_tiled(input_tensor, dim, memory_config);
-
+        auto memory_config = memory_config_arg.value_or(input_tensor.memory_config());
+        return detail::split_dim_n_chunks_tiled(input_tensor, dim, memory_config, num_splits);
 }
 
 std::vector<ttnn::Tensor> SplitOperation::invoke(
@@ -81,10 +77,10 @@ std::vector<ttnn::Tensor> SplitOperation::invoke(
     int64_t& num_splits,
     int64_t& dim,
     const std::optional<MemoryConfig>& memory_config) {
-    return invoke(DefaultQueueId, input_tensor, num_splits, dim, memory_config);
+        return invoke(DefaultQueueId, input_tensor, num_splits, dim, memory_config);
 }
 
-std::vector<ttnn::Tensor> SplitOperation::invoke(const ttnn::Tensor& input_tensor, int64_t& num_splits,  int64_t& dim) {
+std::vector<ttnn::Tensor> SplitOperation::invoke(const ttnn::Tensor& input_tensor, int64_t& num_splits, int64_t& dim) {
     return invoke(DefaultQueueId, input_tensor, num_splits, dim, std::nullopt);
 }
 

--- a/ttnn/cpp/ttnn/operations/data_movement/split/split_pybind.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/split/split_pybind.hpp
@@ -30,7 +30,7 @@ void bind_split(py::module& module) {
             Args:
                 * :attr:`input_tensor`: Input Tensor.
                 * :attr:`num_splits`: Number of ways to split.
-                * :attr:`dim2`: Dim to split. Defaults to 0.
+                * :attr:`dim`: Dim to split. Defaults to 0.
 
             Keyword Args:
                 * :attr:`memory_config`: Memory Config of the output tensor


### PR DESCRIPTION
### Ticket
#10549 

### Problem description
Split currently only supports splitting on device for tiled tensors split into two chunks; we need to support splitting tensors into n chunks for arbitrary n.

### What's changed
This PR adds new kernels to support splitting n-ways (still only supporting tiled tensors), devolving to the existing kernel for more efficient handling of the 2-way special case. It also adds new tests for the n-way split functionality.

### Checklist
- [ ] Post commit CI passes
- [ ] Blackhole Post commit (if applicable)
- [ ] Model regression CI testing passes (if applicable)
- [ ] New/Existing tests provide coverage for changes
