### PR TITLE
#12436: port `moreh_sum` from `tt_dnn` to `ttnn`

### DIFF
--- a/tests/ttnn/unit_tests/operations/test_moreh_sum.py
+++ b/tests/ttnn/unit_tests/operations/test_moreh_sum.py
@@ -1,0 +1,319 @@
+# SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+
+# SPDX-License-Identifier: Apache-2.0
+
+import pytest
+import torch
+from loguru import logger
+
+
+import ttnn
+from models.utility_functions import (
+    comp_allclose_and_pcc,
+    skip_for_grayskull,
+)
+from tests.tt_eager.python_api_testing.unit_testing.misc.test_utils import (
+    get_compute_kernel_options,
+    compute_kernel_options,
+    compute_kernel_ids,
+    filter_indices,
+    filter_indices_with_last_two,
+    TILE_HEIGHT,
+    TILE_WIDTH,
+)
+
+
+def is_npu_dtype_uint32(data_type):
+    return data_type == ttnn.uint32
+
+
+def is_npu_dtype_float(data_type):
+    return data_type == ttnn.float32 or data_type == ttnn.bfloat16
+
+
+def get_tensors(
+    input_shape,
+    dim,
+    device,
+    *,
+    with_padding=True,
+    use_randint=True,
+    keep_batch_dim=False,
+    npu_dtype=ttnn.bfloat16,
+    cpu_dtype=torch.bfloat16,
+):
+    npu_layout = ttnn.TILE_LAYOUT
+    output_shape = input_shape.copy()
+    if dim is None or dim == []:
+        dim = list(range(len(input_shape)))
+
+    if isinstance(dim, int):
+        dim = [dim]
+
+    for d in dim:
+        output_shape[d] = 1
+
+    if keep_batch_dim:
+        torch_output_shape = output_shape.copy()
+        tt_output_shape = output_shape.copy()
+    else:
+        torch_output_shape = filter_indices(output_shape, dim)
+        tt_output_shape = filter_indices_with_last_two(output_shape, dim)
+
+    if use_randint:
+        int_min = 0 if is_npu_dtype_uint32(npu_dtype) else -2
+        int_max = 10 if is_npu_dtype_uint32(npu_dtype) else 3
+        requires_grad = True if is_npu_dtype_float(npu_dtype) else False
+        torch_input = torch.randint(int_min, int_max, input_shape, dtype=cpu_dtype, requires_grad=requires_grad)
+        torch_output = torch.randint(int_min, int_max, tt_output_shape, dtype=cpu_dtype)
+    else:
+        torch_input = torch.rand(input_shape, dtype=cpu_dtype, requires_grad=True)
+        torch_output = torch.rand(tt_output_shape, dtype=cpu_dtype)
+
+    if with_padding:
+        tt_input = ttnn.Tensor(torch_input, npu_dtype).pad_to_tile(float("nan")).to(npu_layout).to(device)
+        tt_output = ttnn.Tensor(torch_output, npu_dtype).pad_to_tile(float("nan")).to(npu_layout).to(device)
+    else:
+        tt_input = ttnn.Tensor(torch_input, npu_dtype).to(npu_layout).to(device)
+        tt_output = ttnn.Tensor(torch_output, npu_dtype).to(npu_layout).to(device)
+
+    return tt_input, tt_output, tt_output_shape, torch_output_shape, torch_input
+
+
+def moreh_sum(input_shape, dim, keep_batch_dim, use_provide_output, compute_kernel_options, device):
+    (tt_input, tt_output, output_shape, _, torch_input) = get_tensors(
+        input_shape, dim, device, keep_batch_dim=keep_batch_dim
+    )
+    torch_output = torch.sum(torch_input, dim, keep_batch_dim)
+
+    if not use_provide_output:
+        tt_output = None
+
+    compute_kernel_config = get_compute_kernel_options(compute_kernel_options)
+    cpu_layout = ttnn.ROW_MAJOR_LAYOUT
+    tt_output_cpu = (
+        ttnn.operations.moreh.sum(
+            tt_input,
+            dim,
+            keepdim=keep_batch_dim,
+            output=tt_output,
+            compute_kernel_config=compute_kernel_config,
+        )
+        .cpu()
+        .to(cpu_layout)
+        .unpad_from_tile(output_shape)
+        .to_torch()
+    )
+
+    # test for equivalance
+    # TODO(Dongjin) : check while changing rtol after enabling fp32_dest_acc_en
+    rtol = atol = 0.12
+    passing, output_pcc = comp_allclose_and_pcc(
+        torch_output if keep_batch_dim else torch_output.reshape(-1),
+        tt_output_cpu if keep_batch_dim else tt_output_cpu.reshape(-1),
+        pcc=0.999,
+        rtol=rtol,
+        atol=atol,
+    )
+
+    logger.debug(f"input_shape={input_shape}, dim={dim}, tt_output_shape={tt_output_cpu.shape}")
+    logger.debug(f"Out passing={passing}")
+    logger.debug(f"Output pcc={output_pcc}")
+
+    return passing
+
+
+@pytest.mark.parametrize(
+    "input_shape",
+    (([3, 2, TILE_HEIGHT * 10 - 1, TILE_WIDTH * 10 - 1]),),
+    ids=[
+        "3, 2, TILE_HEIGHT * 10 - 1, TILE_WIDTH * 10 - 1",
+    ],
+)
+@pytest.mark.parametrize(
+    "dim",
+    (
+        None,
+        0,
+        1,
+        2,
+        3,
+        [],
+        [0, 1],
+        [0, 1, 2],
+        [0, 1, 2, 3],
+        [0, 1, 3],
+        [0, 2, 3],
+        [1, 2],
+        [1, 2, 3],
+        [1, 3],
+        [2, 3],
+    ),
+    ids=["None", "0", "1", "2", "3", "[]", "0,1", "0,1,2", "0,1,2,3", "0,1,3", "0,2,3", "1,2", "1,2,3", "1,3", "2,3"],
+)
+@pytest.mark.parametrize("compute_kernel_options", compute_kernel_options, ids=compute_kernel_ids)
+@pytest.mark.parametrize("keep_batch_dim", (True, False), ids=["keep_batch_dim-true", "keep_batch_dim-flase"])
+def test_moreh_sum(input_shape, dim, keep_batch_dim, compute_kernel_options, device):
+    torch.manual_seed(2023)
+    passing = moreh_sum(input_shape, dim, keep_batch_dim, True, compute_kernel_options, device)
+    assert passing
+
+
+@pytest.mark.parametrize(
+    "input_shape",
+    (
+        ([TILE_HEIGHT, TILE_WIDTH]),
+        ([TILE_HEIGHT - 1, TILE_WIDTH - 1]),
+        ([2, 3, 2, 4, TILE_HEIGHT * 4, TILE_WIDTH * 4]),
+        ([3, 2, 4, TILE_HEIGHT * 4 - 1, TILE_WIDTH * 4 - 1]),
+    ),
+    ids=[
+        "TILE_HEIGHT, TILE_WIDTH",
+        "TILE_HEIGHT - 1, TILE_WIDTH - 1",
+        "2, 3, 2, 4, TILE_HEIGHT * 4, TILE_WIDTH * 4",
+        "3, 2, 4, TILE_HEIGHT * 4 - 1, TILE_WIDTH * 4 - 1",
+    ],
+)
+@pytest.mark.parametrize(
+    "dim",
+    (0, 1, 2, 3, 4, 5),
+    ids=["0", "1", "2", "3", "4", "5"],
+)
+@pytest.mark.parametrize("use_provide_output", (True, False), ids=["True", "False"])
+@pytest.mark.parametrize("keep_batch_dim", (True, False), ids=["keep_batch_dim-true", "keep_batch_dim-flase"])
+def test_moreh_sum_non_4d(input_shape, dim, keep_batch_dim, use_provide_output, device):
+    torch.manual_seed(2023)
+    input_rank = len(input_shape)
+    if dim >= input_rank:
+        pytest.skip(f"input dim {dim} exceeds the dims of input tensor {len(input_shape)}.")
+
+    passing = moreh_sum(input_shape, dim, keep_batch_dim, use_provide_output, False, device)
+    assert passing
+
+
+@pytest.mark.parametrize(
+    "input_shape",
+    [
+        [4, TILE_HEIGHT * 4, TILE_WIDTH * 4],
+    ],
+    ids=[
+        "4, TILE_HEIGHT * 4, TILE_WIDTH * 4",
+    ],
+)
+@pytest.mark.parametrize(
+    "dim",
+    (0, 1, 2),
+    ids=["0", "1", "2"],
+)
+def test_moreh_sum_enable_cache(input_shape, dim, device, use_program_cache):
+    torch.manual_seed(3072)
+    keep_batch_dim = [True, False]
+    use_provide_output = [True, False]
+    for i in range(2):
+        passing = moreh_sum(input_shape, dim, keep_batch_dim[i], use_provide_output[i], False, device)
+        assert passing
+    assert device.num_program_cache_entries() == 2
+
+
+@pytest.mark.parametrize(
+    "input_shape",
+    (
+        [10, TILE_HEIGHT * 12, TILE_WIDTH * 12],
+        [10, TILE_HEIGHT * 12 - 10, TILE_WIDTH * 12 - 10],
+    ),
+    ids=[
+        "10, TILE_HEIGHT * 12, TILE_WIDTH * 12",
+        "10, TILE_HEIGHT * 12 - 10, TILE_WIDTH * 12 - 10",
+    ],
+)
+@pytest.mark.parametrize(
+    "dim",
+    (0, 1, 2),
+    ids=["dim-n", "dim-h", "dim-w"],
+)
+@pytest.mark.parametrize("compute_kernel_options", compute_kernel_options, ids=compute_kernel_ids)
+def test_moreh_sum_fp32_dest_acc(input_shape, dim, compute_kernel_options, device):
+    torch.manual_seed(3072)
+
+    compute_kernel_config = get_compute_kernel_options(compute_kernel_options)
+
+    (tt_input, tt_output, output_shape, torch_output_shape, torch_input) = get_tensors(
+        input_shape, dim, device, use_randint=False, keep_batch_dim=True
+    )
+    torch_input = torch_input.float()
+    torch_output = torch.sum(torch_input, dim, True)
+
+    cpu_layout = ttnn.ROW_MAJOR_LAYOUT
+    tt_output_cpu = (
+        ttnn.operations.moreh.sum(
+            tt_input, dim, keepdim=True, output=tt_output, compute_kernel_config=compute_kernel_config
+        )
+        .cpu()
+        .to(cpu_layout)
+        .unpad_from_tile(output_shape)
+        .to_torch()
+    )
+
+    rtol = atol = 0.1
+    passing, output_pcc = comp_allclose_and_pcc(torch_output, tt_output_cpu, pcc=0.999, rtol=rtol, atol=atol)
+    logger.debug(f"Out passing={passing}")
+    logger.debug(f"Output pcc={output_pcc}")
+    logger.debug(f"std={torch.std(torch.abs(torch_output - tt_output_cpu))}")
+    logger.debug(f"mean={torch.abs(torch_output - tt_output_cpu).mean()}")
+
+    # TODO: Need to check the accuracy for fp32 mode
+    # assert passing
+
+
+@skip_for_grayskull()
+@pytest.mark.parametrize(
+    "input_shape",
+    [
+        [TILE_HEIGHT, TILE_WIDTH],
+        [3, 1, TILE_HEIGHT - 1, TILE_WIDTH - 1],
+        [2, 2, 3, TILE_HEIGHT * 8, TILE_WIDTH * 8],
+        [3, TILE_HEIGHT * 20 - 2, TILE_WIDTH * 20 - 2],
+        [10, 3, TILE_HEIGHT * 8 - 1, TILE_WIDTH * 8 - 1],
+    ],
+    ids=[
+        "TILE_HEIGHT, TILE_WIDTH",
+        "3, 1, TILE_HEIGHT - 1, TILE_WIDTH - 1",
+        "2, 2, 3, TILE_HEIGHT * 8, TILE_WIDTH * 8",
+        "3, TILE_HEIGHT * 20 - 2, TILE_WIDTH * 20 - 2",
+        "10, 3, TILE_HEIGHT * 8 - 1, TILE_WIDTH * 8 - 1",
+    ],
+)
+@pytest.mark.parametrize(
+    "dim",
+    [-1, -2, 0, 1],
+    ids=["dim-w", "dim-h", "dim-b0", "dim-b1"],
+)
+@pytest.mark.parametrize(
+    "data_type",
+    [ttnn.int32],
+    ids=["int32"],
+)
+def test_moreh_sum_integer(input_shape, dim, data_type, device):
+    if (dim == 0 or dim == 1) and (len(input_shape) - dim <= 2):
+        pytest.skip(f"skip sum for batch-dim with this config. {input_shape} and {dim}")
+
+    torch.manual_seed(3072)
+
+    compute_kernel_config = get_compute_kernel_options(True)
+    (tt_input, tt_output, tt_output_shape, _, torch_input) = get_tensors(
+        input_shape, dim, device, use_randint=True, keep_batch_dim=True, npu_dtype=data_type, cpu_dtype=torch.int64
+    )
+
+    normalized_dim = dim if dim >= 0 else len(input_shape) + dim
+
+    torch_output = torch.sum(torch_input, normalized_dim, True)
+    cpu_layout = ttnn.ROW_MAJOR_LAYOUT
+
+    tt_output = ttnn.operations.moreh.sum(
+        tt_input, dim=normalized_dim, keepdim=True, output=tt_output, compute_kernel_config=compute_kernel_config
+    )
+
+    tt_output_cpu = tt_output.cpu().to(cpu_layout).unpad_from_tile(tt_output_shape).to_torch()
+    logger.debug(f"{torch.equal(torch_output, tt_output_cpu)}")
+
+    assert torch.equal(torch_output, tt_output_cpu)

--- a/ttnn/CMakeLists.txt
+++ b/ttnn/CMakeLists.txt
@@ -348,6 +348,16 @@ set(ALL_TTNN_SRCS
     ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/moreh/moreh_getitem/device/moreh_getitem_rm_factory.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/moreh/moreh_getitem/device/moreh_getitem_tilized_factory.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/moreh/moreh_getitem/device/moreh_getitem_device_operation.cpp
+
+    ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/moreh/moreh_sum/moreh_sum.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/moreh/moreh_sum/moreh_sum_pybind.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/moreh/moreh_sum/device/moreh_sum_device_operation.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/moreh/moreh_sum/device/moreh_int_sum_h_program_factory.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/moreh/moreh_sum/device/moreh_int_sum_nc_program_factory.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/moreh/moreh_sum/device/moreh_int_sum_w_program_factory.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/moreh/moreh_sum/device/moreh_sum_h_program_factory.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/moreh/moreh_sum/device/moreh_sum_nc_program_factory.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/moreh/moreh_sum/device/moreh_sum_w_program_factory.cpp
 )
 
 # Split src and python bindings

--- a/ttnn/cpp/ttnn/deprecated/tt_dnn/op_library/moreh_sum/moreh_sum.hpp
+++ b/ttnn/cpp/ttnn/deprecated/tt_dnn/op_library/moreh_sum/moreh_sum.hpp
@@ -5,7 +5,6 @@
 #pragma once
 
 #include "ttnn/decorators.hpp"
-
 #include "ttnn/operations/core/compute_kernel/compute_kernel_config.hpp"
 
 namespace ttnn {
@@ -33,6 +32,7 @@ struct MorehSumOperation {
 }  // namespace operations::moreh
 
 // TODO: remove launch_op from device operation
-constexpr auto moreh_sum = ttnn::register_operation<"ttnn::moreh_sum", ttnn::operations::moreh::MorehSumOperation>();
+constexpr auto moreh_sum =
+    ttnn::register_operation_with_auto_launch_op<"ttnn::moreh_sum", ttnn::operations::moreh::MorehSumOperation>();
 
 }  // namespace ttnn

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_pybind.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_pybind.cpp
@@ -7,11 +7,13 @@
 #include "ttnn/operations/moreh/moreh_adam/moreh_adam_pybind.hpp"
 #include "ttnn/operations/moreh/moreh_arange/moreh_arange_pybind.hpp"
 #include "ttnn/operations/moreh/moreh_getitem/moreh_getitem_pybind.hpp"
+#include "ttnn/operations/moreh/moreh_sum/moreh_sum_pybind.hpp"
 
 namespace ttnn::operations::moreh {
 void bind_moreh_operations(py::module &module) {
     moreh_arange::bind_moreh_arange_operation(module);
     moreh_adam::bind_moreh_adam_operation(module);
     moreh_getitem::bind_moreh_getitem_operation(module);
+    moreh_sum::bind_moreh_sum_operation(module);
 }
 }  // namespace ttnn::operations::moreh

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_sum/device/moreh_int_sum_h_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_sum/device/moreh_int_sum_h_program_factory.cpp
@@ -1,0 +1,220 @@
+// SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <vector>
+
+#include "moreh_sum_device_operation.hpp"
+#include "ttnn/deprecated/tt_dnn/op_library/moreh_helper_functions.hpp"
+#include "tt_metal/common/work_split.hpp"
+#include "ttnn/operations/core/compute_kernel/compute_kernel_config.hpp"
+
+namespace ttnn::operations::moreh::moreh_sum {
+MorehSumOperation::MorehSumHIntFactory::cached_program_t MorehSumOperation::MorehSumHIntFactory::create(
+    const operation_attributes_t& operation_attributes,
+    const tensor_args_t& tensor_args,
+    tensor_return_value_t& output_tensor) {
+    auto input = tensor_args.input;
+    auto output = output_tensor;
+
+    auto output_mem_config = operation_attributes.output_mem_config;
+    const DeviceComputeKernelConfig& compute_kernel_config = init_device_compute_kernel_config(
+        input.device()->arch(), operation_attributes.compute_kernel_config, MathFidelity::HiFi4);
+    ;
+
+    tt::tt_metal::Device* device{input.device()};
+    tt::tt_metal::Program program{tt::tt_metal::CreateProgram()};
+
+    const auto cb_data_format{datatype_to_dataformat_converter(output.get_dtype())};
+    const auto shape{input.get_legacy_shape()};
+
+    const auto [W, H, other_dims_product] = tt::operations::primary::extract_spatial_dims(shape);
+    uint32_t Wt{W / tt::constants::TILE_WIDTH};
+    uint32_t Ht{H / tt::constants::TILE_HEIGHT};
+    uint32_t HtWt{Ht * Wt};
+    uint32_t num_tiles = input.volume() / tt::constants::TILE_HW;
+    auto num_cols{other_dims_product * Wt};
+
+    // check mask for h-dim
+    const auto input_shape_without_padding{shape.without_padding()};
+    const auto origin_H{input_shape_without_padding[-2]};
+    const bool do_mask_h{(origin_H % tt::constants::TILE_HEIGHT) != 0};
+    const auto mask_h{do_mask_h ? origin_H % tt::constants::TILE_HEIGHT : tt::constants::TILE_HEIGHT};
+
+    auto [math_fidelity, math_approx_mode, fp32_dest_acc_en, packer_l1_acc] =
+        get_compute_kernel_config_args(input.device()->arch(), compute_kernel_config);
+    log_debug(
+        tt::LogOp,
+        "math_fidelity {} math_approx_mode {} fp32_dest_acc_en {} packer_l1_acc {}",
+        math_fidelity,
+        math_approx_mode,
+        fp32_dest_acc_en,
+        packer_l1_acc);
+
+    if (!fp32_dest_acc_en) {
+        log_warning(tt::LogOp, "fp32_dest_acc_en should be set for integer sum");
+        fp32_dest_acc_en = true;
+    }
+    log_debug(tt::LogOp, "do_mask_h {} mask_h {}", do_mask_h, mask_h);
+
+    ////////////////////////////////////////////////////////////////////////////
+    //                         Core Setup
+    ////////////////////////////////////////////////////////////////////////////
+    auto grid{device->compute_with_storage_grid_size()};
+    const auto num_cores_y{grid.y};
+
+    const uint32_t in0_t{2};        // input
+    const uint32_t in1_t{1};        // mask
+    const uint32_t intermed0_t{1};  // accumalated sum
+    const uint32_t out0_t{2};       // output
+    const auto
+        [num_cores, all_cores, core_group_1, core_group_2, num_cols_per_core_group_1, num_cols_per_core_group_2] =
+            tt::tt_metal::split_work_to_cores(grid, num_cols);
+
+    log_debug(
+        tt::LogOp,
+        "num_tiles {}, num_cols {}, num_cols_per_core_group_1 {}, num_cols_per_core_group_2 {}",
+        num_tiles,
+        num_cols,
+        num_cols_per_core_group_1,
+        num_cols_per_core_group_2);
+
+    ////////////////////////////////////////////////////////////////////////////
+    //                         CircularBuffer Setup
+    ////////////////////////////////////////////////////////////////////////////
+    tt::operations::primary::CreateCircularBuffer(
+        program,
+        all_cores,
+        cb_data_format,
+        {
+            {tt::CB::c_in0, in0_t},              // input
+            {tt::CB::c_in1, in1_t},              // mask
+            {tt::CB::c_intermed0, intermed0_t},  // accumalated sum
+            {tt::CB::c_out0, out0_t},            // output
+        });
+    ////////////////////////////////////////////////////////////////////////////
+    //                      DataMovementKernel SetUp
+    ////////////////////////////////////////////////////////////////////////////
+    std::vector<uint32_t> reader_compile_time_args = {
+        static_cast<uint32_t>(tt::operations::primary::is_dram(input)), Ht, Wt};
+    std::map<string, string> reader_defines{};
+    if (do_mask_h) {
+        reader_defines["DO_MASK_H"] = "1";
+    }
+    std::vector<uint32_t> writer_compile_time_args = {static_cast<uint32_t>(tt::operations::primary::is_dram(output))};
+    const auto reader_kernel_file{
+        "ttnn/cpp/ttnn/operations/moreh/moreh_sum/device/moreh_sum_h_impl_kernels/reader_moreh_int_sum_h.cpp"};
+    const auto writer_kernel_file{
+        "ttnn/cpp/ttnn/operations/moreh/moreh_sum/device/moreh_sum_h_impl_kernels/writer_moreh_int_sum_h.cpp"};
+    const auto reader_kernel_id{tt::operations::primary::CreateReadKernel(
+        program, reader_kernel_file, all_cores, reader_compile_time_args, reader_defines)};
+    const auto writer_kernel_id{
+        tt::operations::primary::CreateWriteKernel(program, writer_kernel_file, all_cores, writer_compile_time_args)};
+
+    ////////////////////////////////////////////////////////////////////////////
+    //                      ComputeKernel SetUp
+    ////////////////////////////////////////////////////////////////////////////
+    const std::vector<uint32_t> compute_args_group_1{
+        num_cols_per_core_group_1,  // num_cols
+        Ht,                         // Ht
+        origin_H};
+
+    std::map<string, string> compute_defines;
+    if (fp32_dest_acc_en) {
+        compute_defines["FP32_DEST_ACC_EN"] = "1";
+    }
+    const auto compute_kernel_file{
+        "ttnn/cpp/ttnn/operations/moreh/moreh_sum/device/moreh_sum_h_impl_kernels/moreh_int_sum_h.cpp"};
+    const auto compute_kernel_1_id = tt::operations::primary::CreateComputeKernel(
+        program,
+        compute_kernel_file,
+        {core_group_1, num_cols_per_core_group_1, compute_args_group_1},
+        compute_defines,
+        math_fidelity,
+        fp32_dest_acc_en,
+        math_approx_mode);
+
+    std::optional<KernelHandle> compute_kernel_2_id{std::nullopt};
+    if (!core_group_2.ranges().empty()) {
+        const std::vector<uint32_t> compute_args_group_2{
+            num_cols_per_core_group_2,  // num_cols
+            Ht,                         // Ht
+            origin_H};
+        compute_kernel_2_id = tt::operations::primary::CreateComputeKernel(
+            program,
+            compute_kernel_file,
+            {core_group_2, num_cols_per_core_group_2, compute_args_group_2},
+            compute_defines,
+            math_fidelity,
+            fp32_dest_acc_en,
+            math_approx_mode);
+    }
+    uint32_t out_dim_divider{Wt};
+    for (uint32_t i = 0, num_cols_read = 0; i < num_cores; ++i) {
+        CoreCoord core = {i / num_cores_y, i % num_cores_y};
+
+        uint32_t num_cols_per_core{0};
+        if (core_group_1.core_coord_in_core_ranges(core)) {
+            num_cols_per_core = num_cols_per_core_group_1;
+        } else if (core_group_2.core_coord_in_core_ranges(core)) {
+            num_cols_per_core = num_cols_per_core_group_2;
+        } else {
+            TT_THROW("Core not in specified core ranges.");
+        }
+
+        SetRuntimeArgs(
+            program,
+            reader_kernel_id,
+            core,
+            {input.buffer()->address(),
+             num_cols_read / Wt * HtWt + num_cols_read % Wt,
+             num_cols_read % Wt,
+             num_cols_per_core,
+             mask_h});
+
+        SetRuntimeArgs(
+            program,
+            writer_kernel_id,
+            core,
+            {
+                output.buffer()->address(),
+                num_cols_per_core,  // number of tiles to write
+                num_cols_read       // output tile start index
+            });
+
+        num_cols_read += num_cols_per_core;
+    }
+
+    return {std::move(program), {reader_kernel_id, writer_kernel_id, num_cores, num_cores_y}};
+}
+
+void MorehSumOperation::MorehSumHIntFactory::override_runtime_arguments(
+    cached_program_t& cached_program,
+    const operation_attributes_t& operation_attributes,
+    const tensor_args_t& tensor_args,
+    tensor_return_value_t& tensor_return_value) {
+    auto& program = cached_program.program;
+    auto& reader_kernel_id = cached_program.shared_variables.unary_reader_kernel_id;
+    auto& writer_kernel_id = cached_program.shared_variables.unary_writer_kernel_id;
+    auto num_cores = cached_program.shared_variables.num_cores;
+    auto num_cores_y = cached_program.shared_variables.num_cores_y;
+
+    log_debug(tt::LogOp, "{}:{} args_callback ", __func__, __LINE__);
+    auto src_dram_buffer = tensor_args.input.buffer();
+    auto dst_dram_buffer = tensor_return_value.buffer();
+
+    for (uint32_t i = 0, num_tiles_read = 0; i < num_cores; i++) {
+        CoreCoord core = {i / num_cores_y, i % num_cores_y};
+
+        {
+            auto& runtime_args = GetRuntimeArgs(program, reader_kernel_id, core);
+            runtime_args[0] = src_dram_buffer->address();
+        }
+
+        {
+            auto& runtime_args = GetRuntimeArgs(program, writer_kernel_id, core);
+            runtime_args[0] = dst_dram_buffer->address();
+        }
+    }
+}
+}  // namespace ttnn::operations::moreh::moreh_sum

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_sum/device/moreh_int_sum_nc_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_sum/device/moreh_int_sum_nc_program_factory.cpp
@@ -1,0 +1,191 @@
+// SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <vector>
+
+#include "moreh_sum_device_operation.hpp"
+#include "tt_metal/common/work_split.hpp"
+#include "tt_metal/detail/util.hpp"
+#include "ttnn/deprecated/tt_dnn/op_library/moreh_helper_functions.hpp"
+#include "ttnn/operations/core/compute_kernel/compute_kernel_config.hpp"
+
+namespace ttnn::operations::moreh::moreh_sum {
+MorehSumOperation::MorehSumNCIntFactory::cached_program_t MorehSumOperation::MorehSumNCIntFactory::create(
+    const operation_attributes_t &operation_attributes,
+    const tensor_args_t &tensor_args,
+    tensor_return_value_t &output_tensor) {
+    auto input = tensor_args.input;
+    auto output = output_tensor;
+    auto dim = operation_attributes.dim;
+
+    auto output_mem_config = operation_attributes.output_mem_config;
+    const DeviceComputeKernelConfig &compute_kernel_config = init_device_compute_kernel_config(
+        input.device()->arch(), operation_attributes.compute_kernel_config, MathFidelity::HiFi4);
+    ;
+
+    tt::tt_metal::Device *device{input.device()};
+    tt::tt_metal::Program program{tt::tt_metal::CreateProgram()};
+
+    const auto cb_data_format{datatype_to_dataformat_converter(output.get_dtype())};
+    const auto single_tile_size{tt::tt_metal::detail::TileSize(cb_data_format)};
+
+    const auto &input_shape = input.get_legacy_shape();
+    const auto &input_shape_without_padding = input_shape.without_padding();
+    const auto [Wt, Ht, inner_tile_size, reduce_tile_size] =
+        tt::operations::primary::extract_and_scale_spatial_dims(input_shape, static_cast<uint32_t>(dim));
+    const auto num_reduce_input_tile{input_shape[dim]};
+    const auto num_output_tiles{output.volume() / tt::constants::TILE_HW};
+    auto [math_fidelity, math_approx_mode, fp32_dest_acc_en, packer_l1_acc] =
+        get_compute_kernel_config_args(input.device()->arch(), compute_kernel_config);
+
+    log_debug(
+        tt::LogOp, "reduce_tile_size {} inner_tile_size {} Ht {} Wt {}", reduce_tile_size, inner_tile_size, Ht, Wt);
+    log_debug(
+        tt::LogOp, "dim {} num_reduce_input_tile {} num_output_tiles {}", dim, num_reduce_input_tile, num_output_tiles);
+    log_debug(
+        tt::LogOp,
+        "math_fidelity {} math_approx_mode {} fp32_dest_acc_en {} packer_l1_acc {}",
+        math_fidelity,
+        math_approx_mode,
+        fp32_dest_acc_en,
+        packer_l1_acc);
+
+    if (!fp32_dest_acc_en) {
+        log_warning(tt::LogOp, "fp32_dest_acc_en should be set for integer sum");
+        fp32_dest_acc_en = true;
+    }
+
+    ////////////////////////////////////////////////////////////////////////////
+    //                         Core Setup
+    ////////////////////////////////////////////////////////////////////////////
+    auto grid = device->compute_with_storage_grid_size();
+    const auto num_cores_y = grid.y;
+
+    const uint32_t in0_t = 2;        // input
+    const uint32_t intermed0_t = 1;  // accumulated sum
+    const uint32_t out0_t = 2;       // output
+    const auto
+        [num_cores_to_be_used,
+         all_cores,
+         core_group_1,
+         core_group_2,
+         num_cols_per_core_group_1,
+         num_cols_per_core_group_2] = tt::tt_metal::split_work_to_cores(grid, num_output_tiles);
+
+    tt::operations::primary::CreateCircularBuffer(
+        program,
+        all_cores,
+        cb_data_format,
+        {
+            {tt::CB::c_in0, in0_t},              // input
+            {tt::CB::c_intermed0, intermed0_t},  // accumulated sum
+            {tt::CB::c_out0, out0_t},            // output
+        });
+
+    std::vector<uint32_t> reader_compile_time_args = {static_cast<uint32_t>(tt::operations::primary::is_dram(input))};
+    std::vector<uint32_t> writer_compile_time_args = {static_cast<uint32_t>(tt::operations::primary::is_dram(output))};
+    const auto reader_kernel_file =
+        "ttnn/cpp/ttnn/operations/moreh/moreh_sum/device/moreh_sum_nc_impl_kernels/reader_moreh_sum_nc.cpp";
+    const auto writer_kernel_file =
+        "ttnn/cpp/ttnn/operations/moreh/moreh_sum/device/moreh_sum_nc_impl_kernels/writer_moreh_sum_nc.cpp";
+    const auto reader_kernel_id =
+        tt::operations::primary::CreateReadKernel(program, reader_kernel_file, all_cores, reader_compile_time_args);
+    const auto writer_kernel_id =
+        tt::operations::primary::CreateWriteKernel(program, writer_kernel_file, all_cores, writer_compile_time_args);
+
+    ////////////////////////////////////////////////////////////////////////////
+    //                      ComputeKernel SetUp
+    ////////////////////////////////////////////////////////////////////////////
+    const std::vector<uint32_t> compute_args_group_1{num_cols_per_core_group_1, num_reduce_input_tile};
+    std::map<string, string> compute_defines;
+    if (fp32_dest_acc_en) {
+        compute_defines["FP32_DEST_ACC_EN"] = "1";
+    }
+    const auto compute_kernel_file =
+        "ttnn/cpp/ttnn/operations/moreh/moreh_sum/device/moreh_sum_nc_impl_kernels/moreh_int_sum_nc.cpp";
+    const auto compute_kernel_1_id = tt::operations::primary::CreateComputeKernel(
+        program,
+        compute_kernel_file,
+        {core_group_1, num_cols_per_core_group_1, compute_args_group_1},
+        compute_defines,
+        math_fidelity,
+        fp32_dest_acc_en,
+        math_approx_mode);
+
+    std::optional<KernelHandle> compute_kernel_2_id = std::nullopt;
+    if (!core_group_2.ranges().empty()) {
+        const std::vector<uint32_t> compute_args_group_2{num_cols_per_core_group_2, num_reduce_input_tile};
+        compute_kernel_2_id = tt::operations::primary::CreateComputeKernel(
+            program,
+            compute_kernel_file,
+            {core_group_2, num_cols_per_core_group_2, compute_args_group_2},
+            compute_defines,
+            math_fidelity,
+            fp32_dest_acc_en,
+            math_approx_mode);
+    }
+
+    ////////////////////////////////////////////////////////////////////////////
+    //                      RuntimeArgs SetUp
+    ////////////////////////////////////////////////////////////////////////////
+    for (uint32_t i = 0, tile_offset = 0; i < num_cores_to_be_used; ++i) {
+        CoreCoord core = {i / num_cores_y, i % num_cores_y};
+
+        uint32_t num_tiles_per_core;
+        if (core_group_1.core_coord_in_core_ranges(core)) {
+            num_tiles_per_core = num_cols_per_core_group_1;
+        } else if (core_group_2.core_coord_in_core_ranges(core)) {
+            num_tiles_per_core = num_cols_per_core_group_2;
+        } else {
+            TT_THROW("Core not in specified core ranges.");
+        }
+
+        SetRuntimeArgs(
+            program,
+            reader_kernel_id,
+            core,
+            {input.buffer()->address(),
+             num_reduce_input_tile,
+             num_tiles_per_core,
+             tile_offset,
+             static_cast<uint32_t>(dim),
+             reduce_tile_size,
+             inner_tile_size});
+
+        SetRuntimeArgs(program, writer_kernel_id, core, {output.buffer()->address(), num_tiles_per_core, tile_offset});
+
+        tile_offset += num_tiles_per_core;
+    }
+
+    return {std::move(program), {reader_kernel_id, writer_kernel_id, num_cores_to_be_used, num_cores_y}};
+}
+
+void MorehSumOperation::MorehSumNCIntFactory::override_runtime_arguments(
+    cached_program_t &cached_program,
+    const operation_attributes_t &operation_attributes,
+    const tensor_args_t &tensor_args,
+    tensor_return_value_t &tensor_return_value) {
+    auto &program = cached_program.program;
+    auto &reader_kernel_id = cached_program.shared_variables.unary_reader_kernel_id;
+    auto &writer_kernel_id = cached_program.shared_variables.unary_writer_kernel_id;
+    auto num_cores = cached_program.shared_variables.num_cores;
+    auto num_cores_y = cached_program.shared_variables.num_cores_y;
+
+    log_debug(tt::LogOp, "{}:{} args_callback ", __func__, __LINE__);
+    const auto *input_buffer{tensor_args.input.buffer()};
+    const auto *output_buffer{tensor_return_value.buffer()};
+    for (uint32_t i = 0; i < num_cores; ++i) {
+        CoreCoord core = {i / num_cores_y, i % num_cores_y};
+        {
+            auto &runtime_args = GetRuntimeArgs(program, reader_kernel_id, core);
+            runtime_args[0] = input_buffer->address();
+        }
+
+        {
+            auto &runtime_args = GetRuntimeArgs(program, writer_kernel_id, core);
+            runtime_args[0] = output_buffer->address();
+        }
+    }
+}
+}  // namespace ttnn::operations::moreh::moreh_sum

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_sum/device/moreh_int_sum_w_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_sum/device/moreh_int_sum_w_program_factory.cpp
@@ -1,0 +1,225 @@
+// SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <vector>
+
+#include "moreh_sum_device_operation.hpp"
+#include "ttnn/deprecated/tt_dnn/op_library/moreh_helper_functions.hpp"
+#include "tt_metal/common/work_split.hpp"
+#include "ttnn/operations/core/compute_kernel/compute_kernel_config.hpp"
+
+namespace ttnn::operations::moreh::moreh_sum {
+MorehSumOperation::MorehSumWIntFactory::cached_program_t MorehSumOperation::MorehSumWIntFactory::create(
+    const operation_attributes_t& operation_attributes,
+    const tensor_args_t& tensor_args,
+    tensor_return_value_t& output_tensor) {
+    auto input = tensor_args.input;
+    auto output = output_tensor;
+
+    auto output_mem_config = operation_attributes.output_mem_config;
+    const DeviceComputeKernelConfig& compute_kernel_config = init_device_compute_kernel_config(
+        input.device()->arch(), operation_attributes.compute_kernel_config, MathFidelity::HiFi4);
+    ;
+
+    tt::tt_metal::Device* device{input.device()};
+    tt::tt_metal::Program program{tt::tt_metal::CreateProgram()};
+
+    ////////////////////////////////////////////////////////////////////////////
+    //                         Parameters Setup
+    ////////////////////////////////////////////////////////////////////////////
+    const auto cb_data_format{datatype_to_dataformat_converter(output.get_dtype())};
+    const auto shape{input.get_legacy_shape()};
+
+    const auto [W, H, other_dims_product] = tt::operations::primary::extract_spatial_dims(shape);
+    uint32_t Wt{W / tt::constants::TILE_WIDTH};
+    uint32_t Ht{H / tt::constants::TILE_HEIGHT};
+    uint32_t num_tiles = input.volume() / tt::constants::TILE_HW;
+    auto num_rows{other_dims_product * Ht};
+
+    // check mask for w-dim
+    const auto input_shape_without_padding{shape.without_padding()};
+    const auto origin_W{input_shape_without_padding[-1]};
+    const bool do_mask_w{(origin_W % tt::constants::TILE_WIDTH) != 0};
+    const auto mask_w{do_mask_w ? origin_W % tt::constants::TILE_WIDTH : tt::constants::TILE_WIDTH};
+
+    auto [math_fidelity, math_approx_mode, fp32_dest_acc_en, packer_l1_acc] =
+        get_compute_kernel_config_args(input.device()->arch(), compute_kernel_config);
+    log_debug(
+        tt::LogOp,
+        "math_fidelity {} math_approx_mode {} fp32_dest_acc_en {} packer_l1_acc {}",
+        math_fidelity,
+        math_approx_mode,
+        fp32_dest_acc_en,
+        packer_l1_acc);
+
+    if (!fp32_dest_acc_en) {
+        log_warning(tt::LogOp, "fp32_dest_acc_en should be set for integer sum");
+        fp32_dest_acc_en = true;
+    }
+    log_debug(tt::LogOp, "do_mask_w {} mask_w {}", do_mask_w, mask_w);
+
+    ////////////////////////////////////////////////////////////////////////////
+    //                         Core Setup
+    ////////////////////////////////////////////////////////////////////////////
+    auto grid{device->compute_with_storage_grid_size()};
+    const auto num_cores_y{grid.y};
+
+    const uint32_t in0_t{2};        // input
+    const uint32_t in1_t{1};        // mask
+    const uint32_t intermed0_t{1};  // accumalated sum
+    const uint32_t out0_t{2};       // output
+    const auto
+        [num_cores, all_cores, core_group_1, core_group_2, num_rows_per_core_group_1, num_rows_per_core_group_2] =
+            tt::tt_metal::split_work_to_cores(grid, num_rows);
+
+    log_debug(
+        tt::LogOp,
+        "num_tiles {}, num_rows {}, num_rows_per_core_group_1 {}, num_rows_per_core_group_2 {}",
+        num_tiles,
+        num_rows,
+        num_rows_per_core_group_1,
+        num_rows_per_core_group_2);
+
+    ////////////////////////////////////////////////////////////////////////////
+    //                         CircularBuffer Setup
+    ////////////////////////////////////////////////////////////////////////////
+    tt::operations::primary::CreateCircularBuffer(
+        program,
+        all_cores,
+        cb_data_format,
+        {
+            {tt::CB::c_in0, in0_t},              // input
+            {tt::CB::c_in1, in1_t},              // mask
+            {tt::CB::c_intermed0, intermed0_t},  // accumalated sum
+            {tt::CB::c_out0, out0_t},            // output
+        });
+    ////////////////////////////////////////////////////////////////////////////
+    //                      DataMovementKernel SetUp
+    ////////////////////////////////////////////////////////////////////////////
+    std::vector<uint32_t> reader_compile_time_args = {static_cast<uint32_t>(tt::operations::primary::is_dram(input))};
+    std::map<string, string> reader_defines{};
+    if (do_mask_w) {
+        reader_defines["DO_MASK_W"] = "1";
+    }
+    std::vector<uint32_t> writer_compile_time_args = {static_cast<uint32_t>(tt::operations::primary::is_dram(output))};
+    const auto reader_kernel_file{
+        "ttnn/cpp/ttnn/operations/moreh/moreh_sum/device/moreh_sum_w_impl_kernels/reader_moreh_int_sum_w.cpp"};
+    const auto writer_kernel_file{
+        "ttnn/cpp/ttnn/operations/moreh/moreh_sum/device/moreh_sum_w_impl_kernels/writer_moreh_int_sum_w.cpp"};
+    const auto reader_kernel_id{tt::operations::primary::CreateReadKernel(
+        program, reader_kernel_file, all_cores, reader_compile_time_args, reader_defines)};
+    const auto writer_kernel_id{
+        tt::operations::primary::CreateWriteKernel(program, writer_kernel_file, all_cores, writer_compile_time_args)};
+
+    ////////////////////////////////////////////////////////////////////////////
+    //                      ComputeKernel SetUp
+    ////////////////////////////////////////////////////////////////////////////
+    const std::vector<uint32_t> compute_args_group_1{
+        num_rows_per_core_group_1,  // num_rows
+        Wt,                         // Wt
+        origin_W};
+
+    std::map<string, string> compute_defines;
+    if (fp32_dest_acc_en) {
+        compute_defines["FP32_DEST_ACC_EN"] = "1";
+    }
+    const auto compute_kernel_file{
+        "ttnn/cpp/ttnn/operations/moreh/moreh_sum/device/moreh_sum_w_impl_kernels/moreh_int_sum_w.cpp"};
+    const auto compute_kernel_1_id = tt::operations::primary::CreateComputeKernel(
+        program,
+        compute_kernel_file,
+        {core_group_1, num_rows_per_core_group_1, compute_args_group_1},
+        compute_defines,
+        math_fidelity,
+        fp32_dest_acc_en,
+        math_approx_mode);
+
+    std::optional<KernelHandle> compute_kernel_2_id{std::nullopt};
+    if (!core_group_2.ranges().empty()) {
+        const std::vector<uint32_t> compute_args_group_2{
+            num_rows_per_core_group_2,  // num_rows
+            Wt,                         // Wt
+            origin_W};
+        compute_kernel_2_id = tt::operations::primary::CreateComputeKernel(
+            program,
+            compute_kernel_file,
+            {core_group_2, num_rows_per_core_group_2, compute_args_group_2},
+            compute_defines,
+            math_fidelity,
+            fp32_dest_acc_en,
+            math_approx_mode);
+    }
+
+    ////////////////////////////////////////////////////////////////////////////
+    //                      RuntimeArgs SetUp
+    ////////////////////////////////////////////////////////////////////////////
+    uint32_t out_dim_divider{Wt};
+    for (uint32_t i = 0, tile_offset = 0; i < num_cores; ++i) {
+        CoreCoord core = {i / num_cores_y, i % num_cores_y};
+
+        uint32_t num_rows_per_core{0};
+        if (core_group_1.core_coord_in_core_ranges(core)) {
+            num_rows_per_core = num_rows_per_core_group_1;
+        } else if (core_group_2.core_coord_in_core_ranges(core)) {
+            num_rows_per_core = num_rows_per_core_group_2;
+        } else {
+            TT_THROW("Core not in specified core ranges.");
+        }
+
+        uint32_t num_tensor_tiles_per_core{num_rows_per_core * Wt};
+        SetRuntimeArgs(
+            program,
+            reader_kernel_id,
+            core,
+            {input.buffer()->address(),
+             num_tensor_tiles_per_core,
+             tile_offset,  // tile index of row to start reading from
+             mask_w});
+
+        SetRuntimeArgs(
+            program,
+            writer_kernel_id,
+            core,
+            {
+                output.buffer()->address(),
+                num_tensor_tiles_per_core / out_dim_divider,  // number of tiles to write
+                tile_offset / out_dim_divider                 // output tile start index
+            });
+
+        tile_offset += num_tensor_tiles_per_core;
+    }
+
+    return {std::move(program), {reader_kernel_id, writer_kernel_id, num_cores, num_cores_y}};
+}
+
+void MorehSumOperation::MorehSumWIntFactory::override_runtime_arguments(
+    cached_program_t& cached_program,
+    const operation_attributes_t& operation_attributes,
+    const tensor_args_t& tensor_args,
+    tensor_return_value_t& tensor_return_value) {
+    auto& program = cached_program.program;
+    auto& reader_kernel_id = cached_program.shared_variables.unary_reader_kernel_id;
+    auto& writer_kernel_id = cached_program.shared_variables.unary_writer_kernel_id;
+    auto num_cores = cached_program.shared_variables.num_cores;
+    auto num_cores_y = cached_program.shared_variables.num_cores_y;
+
+    log_debug(tt::LogOp, "{}:{} args_callback ", __func__, __LINE__);
+    auto src_dram_buffer{tensor_args.input.buffer()};
+    auto dst_dram_buffer{tensor_return_value.buffer()};
+
+    for (uint32_t i = 0, num_tiles_read = 0; i < num_cores; i++) {
+        CoreCoord core = {i / num_cores_y, i % num_cores_y};
+
+        {
+            auto& runtime_args = GetRuntimeArgs(program, reader_kernel_id, core);
+            runtime_args[0] = src_dram_buffer->address();
+        }
+
+        {
+            auto& runtime_args = GetRuntimeArgs(program, writer_kernel_id, core);
+            runtime_args[0] = dst_dram_buffer->address();
+        }
+    }
+}
+}  // namespace ttnn::operations::moreh::moreh_sum

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_sum/device/moreh_sum_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_sum/device/moreh_sum_device_operation.cpp
@@ -1,0 +1,147 @@
+// SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "moreh_sum_device_operation.hpp"
+
+#include <cstdint>
+
+#include "tt_dnn/op_library/moreh_helper_functions.hpp"
+#include "ttnn/tensor/tensor.hpp"
+#include "ttnn/tensor/types.hpp"
+
+namespace ttnn::operations::moreh::moreh_sum {
+MorehSumOperation::program_factory_t MorehSumOperation::select_program_factory(
+    const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args) {
+    // Case for int32
+    const auto input_rank = tensor_args.input.get_shape().value.rank();
+
+    if (tensor_args.input.dtype() == DataType::INT32) {
+        if (operation_attributes.dim == input_rank - 1) {
+            return MorehSumWIntFactory{};
+        } else if (operation_attributes.dim == input_rank - 2) {
+            return MorehSumHIntFactory{};
+        } else {
+            return MorehSumNCIntFactory{};
+        }
+    }
+
+    if (operation_attributes.dim == input_rank - 1) {
+        return MorehSumWFactory{};
+    } else if (operation_attributes.dim == input_rank - 2) {
+        return MorehSumHFactory{};
+    } else {
+        return MorehSumNCFactory{};
+    }
+}
+
+void validate_tensors(
+    const MorehSumOperation::operation_attributes_t& operation_attributes,
+    const MorehSumOperation::tensor_args_t& tensor_args) {
+    const auto& input = tensor_args.input;
+    auto& output = tensor_args.output;
+
+    tt::operations::primary::check_tensor(input, "moreh_sum", "input", {DataType::BFLOAT16, DataType::INT32});
+    tt::operations::primary::check_tensor(output, "moreh_sum", "output", {DataType::BFLOAT16, DataType::INT32});
+
+    tt::operations::primary::validate_input_with_dim(input, operation_attributes.dim);
+
+    if (output.has_value()) {
+        tt::operations::primary::validate_output_with_keepdim(
+            input, output.value(), operation_attributes.dim, operation_attributes.keep_batch_dim);
+    }
+}
+
+void MorehSumOperation::validate_on_program_cache_miss(
+    const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args) {
+    validate_tensors(operation_attributes, tensor_args);
+};
+
+void MorehSumOperation::validate_on_program_cache_hit(
+    const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args) {
+    validate_tensors(operation_attributes, tensor_args);
+};
+
+MorehSumOperation::shape_return_value_t MorehSumOperation::compute_output_shapes(
+    const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args) {
+    const auto& input = tensor_args.input;
+    const auto& input_shape = input.get_shape();
+    const auto input_rank = input_shape.rank();
+    const bool is_tile_dim = (operation_attributes.dim == input_rank - 1 || operation_attributes.dim == input_rank - 2);
+    log_debug(
+        tt::LogOp,
+        "{}:{} dim {}, keep_batch_dim {}",
+        __func__,
+        __LINE__,
+        operation_attributes.dim,
+        operation_attributes.keep_batch_dim);
+
+    Shape output_shape = input_shape;
+    if (operation_attributes.keep_batch_dim) {
+        auto shape = input_shape.value;
+        auto padding = shape.padding();
+
+        if (is_tile_dim) {
+            // e.g. (2, 64, 64) with dim 1 to be (2, 1[32], 64)
+            shape[operation_attributes.dim] = tt::constants::TILE_HEIGHT;
+            padding[operation_attributes.dim] = Padding::PadDimension{0, 31};
+        } else {
+            // e.g. (2, 64, 64) with dim 0 to be (1, 64, 64)
+            shape[operation_attributes.dim] = 1;
+        }
+
+        output_shape = Shape{tt::tt_metal::Shape(shape, padding)};
+    } else {
+        std::vector<uint32_t> shape;
+        std::vector<Padding::PadDimension> pad_dimensions;
+        const std::size_t output_rank = (is_tile_dim) ? (input_rank) : (input_rank - 1);
+        auto input_padding = input_shape.value.padding();
+
+        // e.g. (2, 64, 64) with dim 1 to be (2, 1[32], 64)
+        // e.g. (2, 64, 64) with dim 0 to be (64, 64)
+        for (int i = 0; i < input_rank; ++i) {
+            bool is_reduced_dim = (i == operation_attributes.dim);
+            if (is_reduced_dim && !is_tile_dim)
+                continue;
+
+            shape.push_back((is_reduced_dim && is_tile_dim) ? (tt::constants::TILE_HEIGHT) : (input_shape.value[i]));
+            pad_dimensions.push_back(
+                (is_reduced_dim && is_tile_dim) ? (Padding::PadDimension{0, 31}) : (input_padding[i]));
+        }
+
+        auto padding = Padding(pad_dimensions, input_padding.pad_value());
+        output_shape = Shape{tt::tt_metal::Shape(shape, padding)};
+    }
+
+    log_debug(tt::LogOp, "{}:{} output_shape {}", __func__, __LINE__, output_shape);
+    return {output_shape};
+};
+
+MorehSumOperation::tensor_return_value_t MorehSumOperation::create_output_tensors(
+    const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args) {
+    if (tensor_args.output.has_value()) {
+        log_debug(tt::LogOp, "{}:{} use output tensor", __func__, __LINE__);
+        return {tensor_args.output.value()};
+    }
+
+    log_debug(tt::LogOp, "{}:{} create output tensor", __func__, __LINE__);
+    return create_device_tensor(
+        compute_output_shapes(operation_attributes, tensor_args),
+        tensor_args.input.get_dtype(),
+        tensor_args.input.get_layout(),
+        tensor_args.input.device(),
+        operation_attributes.output_mem_config);
+}
+
+std::tuple<MorehSumOperation::operation_attributes_t, MorehSumOperation::tensor_args_t> MorehSumOperation::invoke(
+    const Tensor& input,
+    const int64_t dim,
+    const bool keep_batch_dim,
+    const std::optional<Tensor>& output,
+    const std::optional<MemoryConfig>& output_mem_config,
+    const std::optional<DeviceComputeKernelConfig>& compute_kernel_config) {
+    return {
+        {dim, keep_batch_dim, output_mem_config.value_or(input.memory_config()), compute_kernel_config},
+        {input, output}};
+}
+}  // namespace ttnn::operations::moreh::moreh_sum

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_sum/device/moreh_sum_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_sum/device/moreh_sum_device_operation.hpp
@@ -1,0 +1,86 @@
+// SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <variant>
+
+#include "ttnn/decorators.hpp"
+#include "ttnn/operations/core/compute_kernel/compute_kernel_config.hpp"
+#include "ttnn/tensor/types.hpp"
+
+#define MOREH_SUM_FACTORY_H(name)                                                           \
+    struct name {                                                                           \
+        struct shared_variables_t {                                                         \
+            KernelHandle unary_reader_kernel_id;                                            \
+            KernelHandle unary_writer_kernel_id;                                            \
+            std::size_t num_cores;                                                          \
+            std::size_t num_cores_y;                                                        \
+        };                                                                                  \
+                                                                                            \
+        using cached_program_t = ttnn::device_operation::CachedProgram<shared_variables_t>; \
+                                                                                            \
+        static cached_program_t create(                                                     \
+            const operation_attributes_t& operation_attributes,                             \
+            const tensor_args_t& tensor_args,                                               \
+            tensor_return_value_t& output_tensor);                                          \
+                                                                                            \
+        static void override_runtime_arguments(                                             \
+            cached_program_t& cached_program,                                               \
+            const operation_attributes_t& operation_attributes,                             \
+            const tensor_args_t& tensor_args,                                               \
+            tensor_return_value_t& output_tensor);                                          \
+    };
+
+namespace ttnn::operations::moreh::moreh_sum {
+struct MorehSumOperation {
+    struct operation_attributes_t {
+        const int64_t dim;
+        const bool keep_batch_dim;
+
+        const MemoryConfig output_mem_config;
+        const std::optional<DeviceComputeKernelConfig> compute_kernel_config;
+    };
+
+    struct tensor_args_t {
+        const Tensor& input;
+        const std::optional<Tensor>& output;
+    };
+
+    using shape_return_value_t = Shape;
+    using tensor_return_value_t = Tensor;
+
+    MOREH_SUM_FACTORY_H(MorehSumHFactory)
+    MOREH_SUM_FACTORY_H(MorehSumNCFactory)
+    MOREH_SUM_FACTORY_H(MorehSumWFactory)
+    MOREH_SUM_FACTORY_H(MorehSumHIntFactory)
+    MOREH_SUM_FACTORY_H(MorehSumNCIntFactory)
+    MOREH_SUM_FACTORY_H(MorehSumWIntFactory)
+
+    using program_factory_t = std::variant<
+        MorehSumHFactory,
+        MorehSumNCFactory,
+        MorehSumWFactory,
+        MorehSumHIntFactory,
+        MorehSumNCIntFactory,
+        MorehSumWIntFactory>;
+
+    static program_factory_t select_program_factory(const operation_attributes_t&, const tensor_args_t&);
+    static void validate_on_program_cache_miss(const operation_attributes_t&, const tensor_args_t&);
+    static void validate_on_program_cache_hit(const operation_attributes_t&, const tensor_args_t&);
+    static shape_return_value_t compute_output_shapes(const operation_attributes_t&, const tensor_args_t&);
+    static tensor_return_value_t create_output_tensors(const operation_attributes_t&, const tensor_args_t&);
+    static std::tuple<operation_attributes_t, tensor_args_t> invoke(
+        const Tensor& input,
+        const int64_t dim,
+        const bool keep_batch_dim,
+        const std::optional<Tensor>& output,
+        const std::optional<MemoryConfig>& output_mem_config,
+        const std::optional<DeviceComputeKernelConfig>& compute_kernel_config);
+};
+
+}  // namespace ttnn::operations::moreh::moreh_sum
+
+namespace ttnn::prim {
+constexpr auto moreh_sum =
+    ttnn::register_operation<"ttnn::prim::moreh_sum", ttnn::operations::moreh::moreh_sum::MorehSumOperation>();
+}

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_sum/device/moreh_sum_h_impl_kernels/moreh_int_sum_h.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_sum/device/moreh_sum_h_impl_kernels/moreh_int_sum_h.cpp
@@ -1,0 +1,94 @@
+// SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "compute_kernel_api/eltwise_unary/sfpu_int_sum.h"
+#include "ttnn/cpp/ttnn/deprecated/tt_dnn/kernels/compute/moreh_common.hpp"
+
+namespace NAMESPACE {
+void MAIN {
+    constexpr uint32_t num_cols = get_compile_time_arg_val(0);
+    constexpr uint32_t Ht = get_compile_time_arg_val(1);
+    constexpr uint32_t origin_H = get_compile_time_arg_val(2);
+
+    auto cb_in0 = tt::CB::c_in0;
+    constexpr auto cb_mask_h = tt::CB::c_in1;
+    constexpr auto cb_out0 = tt::CB::c_out0;
+    constexpr auto cb_intermed0 = tt::CB::c_intermed0;
+    constexpr uint32_t TILE_H = 32;
+    constexpr bool do_mask_h = (origin_H % TILE_H) != 0;
+
+    unary_op_init_common(cb_in0, cb_out0);
+
+    constexpr int onetile = 1;
+    constexpr int idx0 = 0;
+    constexpr int dst0 = 0;
+    constexpr int dst1 = 1;
+
+    if (do_mask_h) {
+        cb_wait_front(cb_mask_h, onetile);
+    }
+
+    for (uint32_t col = 0; col < num_cols; ++col) {
+        constexpr bool is_single_ht = (Ht == 1);
+        if (is_single_ht) {
+            tile_regs_acquire();
+            copy_tile_to_dst(cb_in0, idx0, dst0);
+
+            if (do_mask_h) {
+                copy_tile_to_dst(cb_mask_h, idx0, dst1, false);
+                mask_tile_init();
+                mask_tile(dst0, dst1, DataFormat::Int32);
+            }
+
+            sfpu_sum_int_init();
+            sfpu_sum_int_col(dst0);
+            tile_regs_commit();
+
+            tile_regs_wait();
+            pack_tile_from_dst(cb_out0, dst0);
+            tile_regs_release();
+        } else {
+            for (uint32_t ht = 0; ht < Ht; ++ht) {
+                if (ht == 0) {
+                    tile_regs_acquire();
+                    copy_tile_to_dst(cb_in0, idx0, dst0);
+                    tile_regs_commit();
+
+                    tile_regs_wait();
+                    pack_tile_from_dst(cb_intermed0, dst0);
+                    tile_regs_release();
+                } else {
+                    tile_regs_acquire();
+                    copy_tile_to_dst(cb_in0, idx0, dst0);
+
+                    if (ht == Ht - 1 && do_mask_h) {
+                        copy_tile_to_dst(cb_mask_h, idx0, dst1, false);
+                        mask_tile_init();
+                        mask_tile(dst0, dst1, DataFormat::Int32);
+                    }
+
+                    copy_tile_to_dst(cb_intermed0, idx0, dst1);
+                    sfpu_sum_int_init();
+                    sfpu_add_int(dst0, dst1);
+                    tile_regs_commit();
+
+                    tile_regs_wait();
+                    pack_tile_from_dst(cb_intermed0, dst0);
+                    tile_regs_release();
+                }
+            }
+
+            tile_regs_acquire();
+            copy_tile_to_dst(cb_intermed0, idx0, dst0);
+            sfpu_sum_int_init();
+            sfpu_sum_int_col(dst0);
+            tile_regs_commit();
+
+            tile_regs_wait();
+            pack_tile_from_dst(cb_out0, dst0);
+            tile_regs_release();
+        }
+    }
+}
+}  // namespace NAMESPACE

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_sum/device/moreh_sum_h_impl_kernels/moreh_sum_h.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_sum/device/moreh_sum_h_impl_kernels/moreh_sum_h.cpp
@@ -1,0 +1,134 @@
+// SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "ttnn/cpp/ttnn/deprecated/tt_dnn/kernels/compute/moreh_common.hpp"
+
+namespace NAMESPACE {
+void MAIN {
+
+    uint32_t Ht = get_compile_time_arg_val(0);
+    uint32_t Wt = get_compile_time_arg_val(1);
+    uint32_t NC = get_compile_time_arg_val(2);
+    constexpr uint32_t origin_H = get_compile_time_arg_val(3);
+
+    auto cb_input = tt::CB::c_in0;
+    constexpr auto cb_scaler = tt::CB::c_in2;
+    constexpr auto cb_mask_h = tt::CB::c_in3;
+    constexpr auto cb_accum_dst = tt::CB::c_intermed0;
+    constexpr auto cb_masked_input = tt::CB::c_intermed1;
+    constexpr auto cb_out = tt::CB::c_out0;
+    constexpr uint32_t TILE_H = 32;
+    constexpr bool do_mask_h = (origin_H % TILE_H) != 0;
+
+    binary_op_init_common(cb_input, cb_input, cb_out);
+
+    cb_wait_front(cb_scaler, 1);  // scaler tile from the reader
+
+    constexpr int onetile = 1;
+    int reduce_dst_idx = 0;
+    const uint32_t mask_dst_idx = reduce_dst_idx + 1;
+
+    if (do_mask_h) {
+        cb_wait_front(cb_mask_h, onetile);
+    }
+
+    for (uint32_t nc = 0; nc < NC; nc++) {
+        for (uint32_t wt = 0; wt < Wt; ++wt) {
+            // tiles are expected to be coming in in NCWH order (H-contiguous)
+            // reducing in W means out[0][w] = sum(h=0..H-1, in[h][w])
+            // in this case we just sequentially add to accumulator all the H-tiles in a column
+            cb_input = tt::CB::c_in0;
+            bool is_h_single_tile = (Ht == 1);
+            if (!is_h_single_tile) {
+                tile_regs_acquire();
+                for (uint32_t ht = 0; ht < Ht - 1; ++ht) {
+                    cb_wait_front(cb_input, onetile);
+
+                    #if defined FP32_DEST_ACC_EN
+                        unpack_reconfig_data_format(cb_input, cb_scaler);
+                    #endif
+                    reduce_init_delta<false>();
+                    reduce_tile(cb_input, cb_scaler, 0, 0, reduce_dst_idx);
+                    reduce_revert_delta();
+
+                    cb_pop_front(cb_input, onetile);
+                }
+                tile_regs_commit();
+                cb_reserve_back(cb_accum_dst, onetile);
+                tile_regs_wait();
+                #if defined FP32_DEST_ACC_EN
+                    pack_reconfig_data_format(cb_accum_dst);
+                #endif
+                pack_tile(reduce_dst_idx, cb_accum_dst);
+                tile_regs_release();
+                cb_push_back(cb_accum_dst, onetile);
+            }
+
+            if (do_mask_h) {
+                tile_regs_acquire();
+                cb_wait_front(cb_input, onetile);
+                #if defined FP32_DEST_ACC_EN
+                    unpack_reconfig_data_format_srca(cb_input);
+                #endif
+                copy_tile_to_dst_init_short(cb_input);
+                copy_tile(cb_input, 0, reduce_dst_idx);
+                copy_tile(cb_mask_h, 0, mask_dst_idx);
+                mask_tile_init();
+                mask_tile(reduce_dst_idx, mask_dst_idx);
+                tile_regs_commit();
+
+                cb_reserve_back(cb_masked_input, onetile);
+                tile_regs_wait();
+                #if defined FP32_DEST_ACC_EN
+                    pack_reconfig_data_format(cb_masked_input);
+                #endif
+                pack_tile(reduce_dst_idx, cb_masked_input);
+                tile_regs_release();
+                cb_push_back(cb_masked_input, onetile);
+
+                cb_pop_front(cb_input, onetile);
+                cb_input = cb_masked_input;
+            }
+
+            tile_regs_acquire();
+            cb_wait_front(cb_input, onetile);
+            if (!is_h_single_tile) {
+                #if defined FP32_DEST_ACC_EN
+                    unpack_reconfig_data_format_srca(cb_accum_dst);
+                #endif
+                cb_wait_front(cb_accum_dst, onetile);
+                copy_tile_to_dst_init_short(cb_accum_dst);
+                copy_tile(cb_accum_dst, 0, reduce_dst_idx);
+            }
+
+            #if defined FP32_DEST_ACC_EN
+                unpack_reconfig_data_format(cb_input, cb_scaler);
+            #endif
+            reduce_init_delta<false>();
+            reduce_tile(cb_input, cb_scaler, 0, 0, reduce_dst_idx);
+            reduce_revert_delta();
+            tile_regs_commit();
+
+            cb_reserve_back(cb_out, onetile);
+            tile_regs_wait();
+            #if defined FP32_DEST_ACC_EN
+                pack_reconfig_data_format(cb_out);
+            #endif
+            pack_tile(reduce_dst_idx, cb_out);
+            tile_regs_release();
+            cb_push_back(cb_out, onetile);
+
+            cb_pop_front(cb_input, onetile);
+            if (!is_h_single_tile) {
+                cb_pop_front(cb_accum_dst, onetile);
+            }
+        }
+    }
+
+    if (do_mask_h) {
+        cb_pop_front(cb_mask_h, onetile);
+    }
+    cb_pop_front(cb_scaler, onetile);
+}
+}  // namespace NAMESPACE

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_sum/device/moreh_sum_h_impl_kernels/reader_moreh_int_sum_h.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_sum/device/moreh_sum_h_impl_kernels/reader_moreh_int_sum_h.cpp
@@ -1,0 +1,58 @@
+// SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "ttnn/cpp/ttnn/deprecated/tt_dnn/kernels/dataflow/moreh_common.hpp"
+
+void kernel_main() {
+    constexpr bool src_is_dram = get_compile_time_arg_val(0) == 1;
+    constexpr uint32_t Ht  = get_compile_time_arg_val(1);
+    constexpr uint32_t Wt  = get_compile_time_arg_val(2);
+
+    uint32_t src_addr  = get_arg_val<uint32_t>(0);
+    uint32_t col_start_tile_id = get_arg_val<uint32_t>(1); // Start id in column major order. This should be the start of a column
+    uint32_t curr_col_in_batch = get_arg_val<uint32_t>(2);
+    uint32_t num_cols = get_arg_val<uint32_t>(3); // number of cols to read
+    uint32_t mask_h = get_arg_val<uint32_t>(4);
+
+
+    constexpr uint32_t cb_id_in0 = 0;
+
+    // ublocks size defined in tiles
+    constexpr uint32_t onetile = 1;
+    const uint32_t tile_bytes = get_tile_size(cb_id_in0);
+    const DataFormat data_format = get_dataformat(cb_id_in0);
+
+#ifdef DO_MASK_H
+    constexpr uint32_t cb_id_mask_h = 1;
+    generate_int_mask_h(cb_id_mask_h, mask_h);
+#endif
+
+    const InterleavedAddrGenFast<src_is_dram> s = {
+        .bank_base_address = src_addr,
+        .page_size = tile_bytes,
+        .data_format = data_format
+    };
+
+    uint32_t w = curr_col_in_batch;
+
+    // this reader will read a NHW tensor in NWH order
+    for (uint32_t i = 0; i < num_cols; i++) {
+        uint32_t curr_id = col_start_tile_id;
+        for (uint32_t j = 0; j < Ht; j++) {
+            cb_reserve_back(cb_id_in0, onetile);
+            uint32_t l1_write_addr = get_write_ptr(cb_id_in0);
+            noc_async_read_tile(curr_id, s, l1_write_addr);
+            noc_async_read_barrier();
+            cb_push_back(cb_id_in0, onetile);
+            curr_id += Wt; // stride in H
+        }
+        w++;
+        if (w == Wt) {
+            col_start_tile_id = curr_id - Wt + 1;
+            w = 0;
+        } else {
+            col_start_tile_id++;
+        }
+    }
+}

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_sum/device/moreh_sum_h_impl_kernels/reader_moreh_sum_h.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_sum/device/moreh_sum_h_impl_kernels/reader_moreh_sum_h.cpp
@@ -1,0 +1,65 @@
+// SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "ttnn/cpp/ttnn/deprecated/tt_dnn/kernels/dataflow/moreh_common.hpp"
+#include "ttnn/cpp/ttnn/deprecated/tt_dnn/kernels/dataflow/generate_reduce_scaler.hpp"
+
+void kernel_main() {
+    uint32_t src_addr  = get_arg_val<uint32_t>(0);
+    uint32_t col_start_tile_id = get_arg_val<uint32_t>(1); // Start id in column major order. This should be the start of a column
+    uint32_t curr_col_in_batch = get_arg_val<uint32_t>(2);
+    uint32_t num_cols = get_arg_val<uint32_t>(3); // number of cols to read
+    uint32_t mask_h = get_arg_val<uint32_t>(4);
+
+    constexpr bool src_is_dram = get_compile_time_arg_val(0) == 1;
+    constexpr uint32_t Ht  = get_compile_time_arg_val(1);
+    constexpr uint32_t Wt  = get_compile_time_arg_val(2);
+    constexpr uint32_t HtWt  = get_compile_time_arg_val(3);
+
+    constexpr uint32_t cb_id_in0 = 0;
+
+    // ublocks size defined in tiles
+    constexpr uint32_t onetile = 1;
+    const uint32_t tile_bytes = get_tile_size(cb_id_in0);
+    const DataFormat data_format = get_dataformat(cb_id_in0);
+
+    #ifdef REDUCE_SCALER
+    constexpr uint32_t cb_id_in2 = 2;
+    constexpr uint32_t scaler = get_compile_time_arg_val(4);
+    generate_reduce_scaler(cb_id_in2, scaler);
+    #endif
+
+    constexpr uint32_t cb_id_mask_h = 3;
+#ifdef DO_MASK_H
+    generate_mask_h(cb_id_mask_h, mask_h);
+#endif
+
+    const InterleavedAddrGenFast<src_is_dram> s = {
+        .bank_base_address = src_addr,
+        .page_size = tile_bytes,
+        .data_format = data_format
+    };
+
+    uint32_t w = curr_col_in_batch;
+
+    // this reader will read a NHW tensor in NWH order
+    for (uint32_t i = 0; i < num_cols; i++) {
+        uint32_t curr_id = col_start_tile_id;
+        for (uint32_t j = 0; j < Ht; j++) {
+            cb_reserve_back(cb_id_in0, onetile);
+            uint32_t l1_write_addr = get_write_ptr(cb_id_in0);
+            noc_async_read_tile(curr_id, s, l1_write_addr);
+            noc_async_read_barrier();
+            cb_push_back(cb_id_in0, onetile);
+            curr_id += Wt; // stride in H
+        }
+        w++;
+        if (w == Wt) {
+            col_start_tile_id = curr_id - Wt + 1;
+            w = 0;
+        } else {
+            col_start_tile_id++;
+        }
+    }
+}

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_sum/device/moreh_sum_h_impl_kernels/writer_moreh_int_sum_h.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_sum/device/moreh_sum_h_impl_kernels/writer_moreh_int_sum_h.cpp
@@ -1,0 +1,45 @@
+// SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "dataflow_api.h"
+
+void kernel_main() {
+    constexpr bool dst_is_dram = get_compile_time_arg_val(0) == 1;
+
+    uint32_t dst_addr  = get_arg_val<uint32_t>(0);
+    uint32_t num_tiles = get_arg_val<uint32_t>(1);
+    uint32_t start_id = get_arg_val<uint32_t>(2);
+
+    constexpr uint32_t cb_id_out = 16;
+
+    // single-tile ublocks
+    constexpr uint32_t onetile = 1;
+    const uint32_t tile_bytes = get_tile_size(cb_id_out);
+    const DataFormat data_format = get_dataformat(cb_id_out);
+
+    const InterleavedAddrGenFast<dst_is_dram> s = {
+        .bank_base_address = dst_addr,
+        .page_size = tile_bytes,
+        .data_format = data_format
+    };
+
+    uint32_t end_id = start_id + num_tiles;
+    for (uint32_t i = start_id; i < end_id; ++ i) {
+        cb_wait_front(cb_id_out, onetile);
+
+        uint32_t l1_read_addr = get_read_ptr(cb_id_out);
+        volatile tt_l1_ptr int32_t* out_l1_ptr = reinterpret_cast<volatile tt_l1_ptr int32_t*>(l1_read_addr);
+
+        for (uint32_t w = 0; w < 16; w++) {
+            for (uint32_t subh = 1; subh < 4; ++subh) {
+                out_l1_ptr[w] += out_l1_ptr[w + (16 * subh)];
+                out_l1_ptr[w + 256] += out_l1_ptr[w + 256 + (16 * subh)];
+            }
+        }
+
+        noc_async_write_tile(i, s, l1_read_addr);
+        noc_async_write_barrier();
+        cb_pop_front(cb_id_out, onetile);
+    }
+}

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_sum/device/moreh_sum_h_impl_kernels/writer_moreh_sum_h.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_sum/device/moreh_sum_h_impl_kernels/writer_moreh_sum_h.cpp
@@ -1,0 +1,34 @@
+// SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "dataflow_api.h"
+
+void kernel_main() {
+    uint32_t dst_addr  = get_arg_val<uint32_t>(0);
+    uint32_t num_tiles = get_arg_val<uint32_t>(1);
+    uint32_t start_id = get_arg_val<uint32_t>(2);
+
+    constexpr uint32_t cb_id_out = get_compile_time_arg_val(0);
+    constexpr bool dst_is_dram = get_compile_time_arg_val(1) == 1;
+
+    // single-tile ublocks
+    constexpr uint32_t onetile = 1;
+    const uint32_t tile_bytes = get_tile_size(cb_id_out);
+    const DataFormat data_format = get_dataformat(cb_id_out);
+
+    const InterleavedAddrGenFast<dst_is_dram> s = {
+        .bank_base_address = dst_addr,
+        .page_size = tile_bytes,
+        .data_format = data_format
+    };
+
+    uint32_t end_id = start_id + num_tiles;
+    for (uint32_t i = start_id; i < end_id; ++ i) {
+        cb_wait_front(cb_id_out, onetile);
+        uint32_t l1_read_addr = get_read_ptr(cb_id_out);
+        noc_async_write_tile(i, s, l1_read_addr);
+        noc_async_write_barrier();
+        cb_pop_front(cb_id_out, onetile);
+    }
+}

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_sum/device/moreh_sum_h_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_sum/device/moreh_sum_h_program_factory.cpp
@@ -1,0 +1,263 @@
+// SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <vector>
+
+#include "common/bfloat16.hpp"
+#include "moreh_sum_device_operation.hpp"
+#include "ttnn/deprecated/tt_dnn/op_library/moreh_helper_functions.hpp"
+#include "ttnn/operations/core/compute_kernel/compute_kernel_config.hpp"
+#include "ttnn/operations/reduction/generic/device/common.hpp"
+#include "ttnn/operations/reduction/generic/device/reduce_op.hpp"
+
+namespace ttnn::operations::moreh::moreh_sum {
+MorehSumOperation::MorehSumHFactory::cached_program_t MorehSumOperation::MorehSumHFactory::create(
+    const operation_attributes_t& operation_attributes,
+    const tensor_args_t& tensor_args,
+    tensor_return_value_t& output_tensor) {
+    auto input = tensor_args.input;
+    auto output = output_tensor;
+
+    auto output_mem_config = operation_attributes.output_mem_config;
+    const DeviceComputeKernelConfig &compute_kernel_config = init_device_compute_kernel_config(
+        input.device()->arch(), operation_attributes.compute_kernel_config, MathFidelity::HiFi4);
+    ;
+
+    tt::tt_metal::ReduceOpMath reduce_op = tt::tt_metal::ReduceOpMath::SUM;
+    tt::tt_metal::ReduceOpDim reduce_dim = tt::tt_metal::ReduceOpDim::H;
+    float scaler = 1.0f;
+
+    const auto shape = input.get_shape().value;
+    const auto [W, H, other_dims_product] = tt::operations::primary::extract_spatial_dims(shape);
+
+    uint32_t Wt = W / tt::constants::TILE_WIDTH;
+    uint32_t Ht = H / tt::constants::TILE_HEIGHT;
+    uint32_t HtWt = Ht * Wt;
+
+    // check mask for h-dim
+    const auto input_shape_without_padding = shape.without_padding();
+    const auto origin_H = input_shape_without_padding[-2];
+    const bool do_mask_h = (origin_H % tt::constants::TILE_HEIGHT) != 0;
+    const auto mask_h = do_mask_h ? origin_H % tt::constants::TILE_HEIGHT : tt::constants::TILE_HEIGHT;
+
+    auto [math_fidelity, math_approx_mode, fp32_dest_acc_en, packer_l1_acc] =
+        get_compute_kernel_config_args(input.device()->arch(), compute_kernel_config);
+    log_debug(
+        tt::LogOp,
+        "math_fidelity {} math_approx_mode {} fp32_dest_acc_en {} packer_l1_acc {}",
+        math_fidelity,
+        math_approx_mode,
+        fp32_dest_acc_en,
+        packer_l1_acc);
+
+    tt::tt_metal::Program program = tt::tt_metal::CreateProgram();
+
+    tt::DataFormat src0_cb_data_format = tt::tt_metal::datatype_to_dataformat_converter(input.get_dtype());
+    uint32_t src0_single_tile_size = tt::tt_metal::detail::TileSize(src0_cb_data_format);
+    tt::DataFormat scaler_cb_data_format = tt::DataFormat::Float16_b;
+    uint32_t scaler_single_tile_size = tt::tt_metal::detail::TileSize(src0_cb_data_format);
+    tt::DataFormat mask_h_cb_data_format = tt::DataFormat::Float16_b;
+    uint32_t mask_h_single_tile_size = tt::tt_metal::detail::TileSize(mask_h_cb_data_format);
+    tt::DataFormat intermed_cb_data_format = (fp32_dest_acc_en) ? tt::DataFormat::Float32 : tt::DataFormat::Float16_b;
+    tt::DataFormat intermed1_cb_data_format = tt::DataFormat::Float16_b;
+    uint32_t intermed_single_tile_size = tt::tt_metal::detail::TileSize(intermed_cb_data_format);
+    tt::DataFormat dst_cb_data_format = tt::tt_metal::datatype_to_dataformat_converter(output.get_dtype());
+    uint32_t dst_single_tile_size = tt::tt_metal::detail::TileSize(dst_cb_data_format);
+
+    uint32_t num_tiles = input.volume() / tt::constants::TILE_HW;
+
+    tt::tt_metal::Device* device = input.device();
+
+    auto compute_with_storage_grid_size = device->compute_with_storage_grid_size();
+    uint32_t num_cores_y = compute_with_storage_grid_size.y;
+    auto num_cols = other_dims_product * Wt;
+
+    const CoreRange all_core_range(
+        {0, 0}, {compute_with_storage_grid_size.x - 1, compute_with_storage_grid_size.y - 1});
+
+    auto [num_cores, all_cores, core_group_1, core_group_2, num_cols_per_core_group_1, num_cols_per_core_group_2] =
+        tt::operations::primary::split_work_to_cores(all_core_range, num_cols);
+
+    string compute_kernel_name =
+        "ttnn/cpp/ttnn/operations/moreh/moreh_sum/device/moreh_sum_h_impl_kernels/moreh_sum_h.cpp";
+
+    uint32_t src0_cb_index = tt::CB::c_in0;
+    CBHandle cb_src0;
+    uint32_t src1_cb_index = tt::CB::c_in1;
+    CBHandle cb_src1 = 0;
+    uint32_t num_input_tiles = 2;
+    tt::tt_metal::CircularBufferConfig cb_src0_config =
+        tt::tt_metal::CircularBufferConfig(
+            num_input_tiles * src0_single_tile_size, {{src0_cb_index, src0_cb_data_format}})
+            .set_page_size(src0_cb_index, src0_single_tile_size);
+    cb_src0 = tt::tt_metal::CreateCircularBuffer(program, all_cores, cb_src0_config);
+
+    uint32_t scaler_cb_index = tt::CB::c_in2;
+    tt::tt_metal::CircularBufferConfig cb_scaler_config =
+        tt::tt_metal::CircularBufferConfig(1 * scaler_single_tile_size, {{scaler_cb_index, scaler_cb_data_format}})
+            .set_page_size(scaler_cb_index, scaler_single_tile_size);
+    auto cb_scaler = tt::tt_metal::CreateCircularBuffer(program, all_cores, cb_scaler_config);
+
+    tt::tt_metal::CircularBufferConfig cb_mask_h_config =
+        tt::tt_metal::CircularBufferConfig(mask_h_single_tile_size, {{tt::CB::c_in3, mask_h_cb_data_format}})
+            .set_page_size(tt::CB::c_in3, mask_h_single_tile_size);
+    auto cb_mask_h = tt::tt_metal::CreateCircularBuffer(program, all_cores, cb_mask_h_config);
+
+    tt::tt_metal::CircularBufferConfig cb_intermed0_config =
+        tt::tt_metal::CircularBufferConfig(intermed_single_tile_size, {{tt::CB::c_intermed0, intermed_cb_data_format}})
+            .set_page_size(tt::CB::c_intermed0, intermed_single_tile_size);
+    auto cb_intermed0 = tt::tt_metal::CreateCircularBuffer(program, all_cores, cb_intermed0_config);
+
+    tt::tt_metal::CircularBufferConfig cb_intermed1_config =
+        tt::tt_metal::CircularBufferConfig(intermed_single_tile_size, {{tt::CB::c_intermed1, intermed1_cb_data_format}})
+            .set_page_size(tt::CB::c_intermed1, intermed_single_tile_size);
+    auto cb_intermed1 = tt::tt_metal::CreateCircularBuffer(program, all_cores, cb_intermed1_config);
+
+    uint32_t output_cb_index = tt::CB::c_out0;  // output operands start at index 16
+    CBHandle cb_output;
+    uint32_t num_output_tiles = 2;
+    tt::tt_metal::CircularBufferConfig cb_output_config =
+        tt::tt_metal::CircularBufferConfig(
+            num_output_tiles * dst_single_tile_size, {{output_cb_index, dst_cb_data_format}})
+            .set_page_size(output_cb_index, dst_single_tile_size);
+    cb_output = tt::tt_metal::CreateCircularBuffer(program, all_cores, cb_output_config);
+    tt::tt_metal::Buffer* src0_buffer = input.buffer();
+    tt::tt_metal::KernelHandle reader_kernel_id;
+    auto bfloat_scaler_value = *(new class bfloat16(scaler));
+    uint32_t packed_scaler_value = pack_two_bfloat16_into_uint32({bfloat_scaler_value, bfloat_scaler_value});
+    bool src0_is_dram = src0_buffer->buffer_type() == tt::tt_metal::BufferType::DRAM ? 1 : 0;
+    std::vector<uint32_t> reader_compile_time_args = {(std::uint32_t)src0_is_dram, Ht, Wt, HtWt, packed_scaler_value};
+
+    std::map<string, string> reader_defines;
+    reader_defines["REDUCE_SCALER"] = "1";
+    if (do_mask_h) {
+        reader_defines["DO_MASK_H"] = "1";
+    }
+    reader_kernel_id = tt::tt_metal::CreateKernel(
+        program,
+        "ttnn/cpp/ttnn/operations/moreh/moreh_sum/device/moreh_sum_h_impl_kernels/reader_moreh_sum_h.cpp",
+        all_cores,
+        tt::tt_metal::ReaderDataMovementConfig(reader_compile_time_args, reader_defines));
+
+    tt::tt_metal::Buffer* dst_buffer = output.buffer();
+    tt::tt_metal::KernelHandle writer_kernel_id;
+
+    bool dst_is_dram = dst_buffer->buffer_type() == tt::tt_metal::BufferType::DRAM ? 1 : 0;
+    std::vector<uint32_t> writer_compile_time_args = {(std::uint32_t)output_cb_index, (std::uint32_t)dst_is_dram};
+
+    writer_kernel_id = tt::tt_metal::CreateKernel(
+        program,
+        "ttnn/cpp/ttnn/operations/moreh/moreh_sum/device/moreh_sum_h_impl_kernels/writer_moreh_sum_h.cpp",
+        all_cores,
+        tt::tt_metal::WriterDataMovementConfig(writer_compile_time_args));
+    std::map<string, string> reduce_defines = reduce_op_utils::get_defines(reduce_op, reduce_dim);
+    if (fp32_dest_acc_en) {
+        reduce_defines["FP32_DEST_ACC_EN"] = "1";
+    }
+
+    vector<uint32_t> compute_kernel_args_group_1 = {
+        Ht,                         // Ht
+        num_cols_per_core_group_1,  // Wt
+        1,                          // NC
+        origin_H};
+
+    // set preserve_fp32_precision to the same value as fp32_dest_acc_en
+    bool preserve_fp32_precision = fp32_dest_acc_en;
+    auto reduce_compute_kernel_group_1_id = tt::tt_metal::CreateKernel(
+        program,
+        compute_kernel_name,
+        core_group_1,
+        tt::tt_metal::ComputeConfig{
+            .math_fidelity = math_fidelity,
+            .fp32_dest_acc_en = fp32_dest_acc_en,
+            .preserve_fp32_precision = preserve_fp32_precision,
+            .math_approx_mode = math_approx_mode,
+            .compile_args = compute_kernel_args_group_1,
+            .defines = reduce_defines});
+
+    if (!core_group_2.ranges().empty()) {
+        vector<uint32_t> compute_kernel_args_group_2 = {
+            Ht,                         // Ht
+            num_cols_per_core_group_2,  // Wt
+            1,                          // NC
+            origin_H};
+
+        auto reduce_compute_kernel_group_2_id = tt::tt_metal::CreateKernel(
+            program,
+            compute_kernel_name,
+            core_group_2,
+            tt::tt_metal::ComputeConfig{
+                .math_fidelity = math_fidelity,
+                .fp32_dest_acc_en = fp32_dest_acc_en,
+                .preserve_fp32_precision = preserve_fp32_precision,
+                .math_approx_mode = math_approx_mode,
+                .compile_args = compute_kernel_args_group_2,
+                .defines = reduce_defines});
+    }
+
+    for (uint32_t i = 0, num_cols_read = 0; i < num_cores; i++) {
+        CoreCoord core = {i / num_cores_y, i % num_cores_y};
+        uint32_t num_cols_per_core = 0;
+        if (core_group_1.core_coord_in_core_ranges(core)) {
+            num_cols_per_core = num_cols_per_core_group_1;
+        } else if (core_group_2.core_coord_in_core_ranges(core)) {
+            num_cols_per_core = num_cols_per_core_group_2;
+        } else {
+            TT_ASSERT(false, "Core not in specified core ranges");
+        }
+        tt::tt_metal::SetRuntimeArgs(
+            program,
+            reader_kernel_id,
+            core,
+            {input.buffer()->address(),
+             num_cols_read / Wt * HtWt + num_cols_read % Wt,
+             num_cols_read % Wt,
+             num_cols_per_core,
+             mask_h});
+
+        tt::tt_metal::SetRuntimeArgs(
+            program,
+            writer_kernel_id,
+            core,
+            {
+                output.buffer()->address(),
+                num_cols_per_core,  // number of tiles to write
+                num_cols_read       // output tile start index
+            });
+        num_cols_read += num_cols_per_core;
+    }
+
+    return {std::move(program), {reader_kernel_id, writer_kernel_id, num_cores, num_cores_y}};
+}
+
+void MorehSumOperation::MorehSumHFactory::override_runtime_arguments(
+    cached_program_t& cached_program,
+    const operation_attributes_t& operation_attributes,
+    const tensor_args_t& tensor_args,
+    tensor_return_value_t& tensor_return_value) {
+    auto& program = cached_program.program;
+    auto& reader_kernel_id = cached_program.shared_variables.unary_reader_kernel_id;
+    auto& writer_kernel_id = cached_program.shared_variables.unary_writer_kernel_id;
+    auto num_cores = cached_program.shared_variables.num_cores;
+    auto num_cores_y = cached_program.shared_variables.num_cores_y;
+
+    log_debug(tt::LogOp, "{}:{} args_callback ", __func__, __LINE__);
+    auto src_buffer = tensor_args.input.buffer();
+    auto dst_buffer = tensor_return_value.buffer();
+
+    for (uint32_t i = 0, num_tiles_read = 0; i < num_cores; i++) {
+        CoreCoord core = {i / num_cores_y, i % num_cores_y};
+
+        {
+            auto& runtime_args = GetRuntimeArgs(program, reader_kernel_id, core);
+            runtime_args[0] = src_buffer->address();
+        }
+
+        {
+            auto& runtime_args = GetRuntimeArgs(program, writer_kernel_id, core);
+            runtime_args[0] = dst_buffer->address();
+        }
+    }
+}
+}  // namespace ttnn::operations::moreh::moreh_sum

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_sum/device/moreh_sum_nc_impl_kernels/moreh_int_sum_nc.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_sum/device/moreh_sum_nc_impl_kernels/moreh_int_sum_nc.cpp
@@ -1,0 +1,44 @@
+// SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "compute_kernel_api/eltwise_unary/sfpu_int_sum.h"
+#include "ttnn/cpp/ttnn/deprecated/tt_dnn/kernels/compute/moreh_common.hpp"
+
+namespace NAMESPACE {
+void MAIN {
+    // compile-time args
+    constexpr uint32_t num_output_tiles = get_compile_time_arg_val(0);
+    constexpr uint32_t num_input_tiles = get_compile_time_arg_val(1);
+
+    constexpr auto cb_in0 = tt::CB::c_in0;
+    constexpr auto cb_out0 = tt::CB::c_out0;
+    constexpr auto cb_intermed0 = tt::CB::c_intermed0;
+    constexpr int onetile = 1;
+    constexpr int idx0 = 0;
+    constexpr int dst0 = 0;
+    constexpr int dst1 = 1;
+
+    unary_op_init_common(cb_in0, cb_out0);
+    for (uint32_t i = 0; i < num_output_tiles; i++) {
+        bool enable_reload = false;
+        for (uint32_t j = 0; j < num_input_tiles; ++j) {
+            bool last_out = (j == num_input_tiles - 1);
+            tile_regs_acquire();
+            copy_tile_to_dst(cb_in0, idx0, dst0);
+            if (enable_reload) {
+                copy_tile_to_dst(cb_intermed0, idx0, dst1);
+                sfpu_sum_int_init();
+                sfpu_add_int(dst0, dst1);
+            }
+            tile_regs_commit();
+
+            tile_regs_wait();
+            uint32_t cb_out = (last_out) ? (cb_out0) : (cb_intermed0);
+            pack_tile_from_dst(cb_out, dst0);
+            tile_regs_release();
+            enable_reload = true;
+        }
+    }
+}
+}  // namespace NAMESPACE

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_sum/device/moreh_sum_nc_impl_kernels/moreh_sum_nc.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_sum/device/moreh_sum_nc_impl_kernels/moreh_sum_nc.cpp
@@ -1,0 +1,48 @@
+// SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "ttnn/cpp/ttnn/deprecated/tt_dnn/kernels/compute/moreh_common.hpp"
+
+namespace NAMESPACE {
+void MAIN {
+    // compile-time args
+    constexpr uint32_t num_output_tiles = get_compile_time_arg_val(0);
+    constexpr uint32_t num_input_tiles = get_compile_time_arg_val(1);
+
+    constexpr auto cb_in0 = tt::CB::c_in0;
+    constexpr auto cb_in1 = tt::CB::c_in1;
+    constexpr auto cb_out0 = tt::CB::c_out0;
+    constexpr uint32_t onetile = 1;
+    constexpr uint32_t dst0 = 0;
+    constexpr uint32_t dst1 = 1;
+    constexpr uint32_t idx0 = 0;
+    constexpr bool acc_to_dest = true;
+
+    binary_op_init_common(cb_in0, cb_in1, cb_out0);
+    cb_wait_front(cb_in1, onetile);
+
+    for (uint32_t i = 0; i < num_output_tiles; i++) {
+        tile_regs_acquire();
+        add_tiles_init(cb_in0, cb_in1, acc_to_dest);
+        for (uint32_t j = 0; j < num_input_tiles; ++j) {
+            cb_wait_front(cb_in0, onetile);
+            #if defined FP32_DEST_ACC_EN
+                unpack_reconfig_data_format(cb_in0, cb_in1);
+            #endif
+            add_tiles(cb_in0, cb_in1, idx0, idx0, dst0);
+            cb_pop_front(cb_in0, onetile);
+        }
+        tile_regs_commit();
+
+        cb_reserve_back(cb_out0, onetile);
+        tile_regs_wait();
+        #if defined FP32_DEST_ACC_EN
+            pack_reconfig_data_format(cb_out0);
+        #endif
+        pack_tile(dst0, cb_out0);
+        tile_regs_release();
+        cb_push_back(cb_out0, onetile);
+    }
+}
+}  // namespace NAMESPACE

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_sum/device/moreh_sum_nc_impl_kernels/moreh_sum_nc_gs.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_sum/device/moreh_sum_nc_impl_kernels/moreh_sum_nc_gs.cpp
@@ -1,0 +1,62 @@
+// SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "ttnn/cpp/ttnn/deprecated/tt_dnn/kernels/compute/moreh_common.hpp"
+
+namespace NAMESPACE {
+void MAIN {
+    // compile-time args
+    constexpr uint32_t num_output_tiles = get_compile_time_arg_val(0);
+    constexpr uint32_t num_input_tiles = get_compile_time_arg_val(1);
+
+    constexpr auto cb_in0 = tt::CB::c_in0;
+    constexpr auto cb_in1 = tt::CB::c_in1;
+    constexpr auto cb_out0 = tt::CB::c_out0;
+    constexpr auto cb_intermed0 = tt::CB::c_intermed0;
+    constexpr uint32_t onetile = 1;
+    constexpr uint32_t dst0 = 0;
+    constexpr uint32_t dst1 = 1;
+    constexpr uint32_t first_tile = 0;
+
+    binary_op_init_common(cb_in0, cb_in1, cb_out0);
+    cb_wait_front(cb_in1, onetile);
+
+    for (uint32_t i = 0; i < num_output_tiles; i++) {
+        bool enable_reload = false;
+        for (uint32_t j = 0; j < num_input_tiles; ++j) {
+            bool last_out = (j == num_input_tiles - 1);
+            uint32_t cb_add  = (enable_reload) ? (cb_intermed0) : (cb_in1);
+
+            cb_wait_front(cb_in0, onetile);
+            if (enable_reload) {
+                cb_wait_front(cb_intermed0, onetile);
+            }
+
+            tile_regs_acquire();
+            #if defined FP32_DEST_ACC_EN
+                unpack_reconfig_data_format(cb_in0, cb_add);
+            #endif
+            add_tiles_init(cb_in0, cb_add);
+            add_tiles(cb_in0, cb_add, first_tile, first_tile, dst0);
+            tile_regs_commit();
+
+            cb_pop_front(cb_in0, onetile);
+            if (enable_reload) {
+                cb_pop_front(cb_intermed0, onetile);
+            }
+
+            uint32_t cb_out = (last_out) ? (cb_out0) : (cb_intermed0);
+            cb_reserve_back(cb_out, onetile);
+            tile_regs_wait();
+            #if defined FP32_DEST_ACC_EN
+                pack_reconfig_data_format(cb_out);
+            #endif
+            pack_tile(dst0, cb_out);
+            tile_regs_release();
+            cb_push_back(cb_out, onetile);
+            enable_reload = true;
+        }
+    }
+}
+}  // namespace NAMESPACE

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_sum/device/moreh_sum_nc_impl_kernels/reader_moreh_sum_nc.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_sum/device/moreh_sum_nc_impl_kernels/reader_moreh_sum_nc.cpp
@@ -1,0 +1,52 @@
+// SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "ttnn/cpp/ttnn/deprecated/tt_dnn/kernels/dataflow/moreh_common.hpp"
+#include "ttnn/cpp/ttnn/deprecated/tt_dnn/kernels/dataflow/generate_reduce_scaler.hpp"
+
+inline uint32_t get_read_tile_id(uint32_t output_tile_id, uint32_t reduce_tile_size, uint32_t inner_tile_size) {
+    return ((output_tile_id / inner_tile_size) * reduce_tile_size) + (output_tile_id % inner_tile_size);
+}
+
+void kernel_main() {
+    // compile-time args
+    constexpr bool input_is_dram = (get_compile_time_arg_val(0) == 1);
+
+    // runtime args
+    ArgFetcher arg_fetcher;
+    const auto input_addr = arg_fetcher.get_next_arg_val<uint32_t>();
+    const auto num_input_tiles = arg_fetcher.get_next_arg_val<uint32_t>();
+    const auto num_output_tiles = arg_fetcher.get_next_arg_val<uint32_t>();
+    const auto start_id = arg_fetcher.get_next_arg_val<uint32_t>();
+    const auto dim = arg_fetcher.get_next_arg_val<uint32_t>();
+    const auto reduce_tile_size = arg_fetcher.get_next_arg_val<uint32_t>();
+    const auto inner_tile_size = arg_fetcher.get_next_arg_val<uint32_t>();
+
+    constexpr uint32_t onetile = 1;
+    constexpr uint32_t cb_id_in0 = 0;
+
+    #ifdef USE_FPU
+    constexpr uint32_t cb_id_in1 = 1;
+    constexpr uint32_t scaler = 0;
+    generate_reduce_scaler(cb_id_in1, scaler);
+    #endif
+
+    uint32_t l1_write_addr_in0;
+    uint32_t input_tile_bytes = get_tile_size(cb_id_in0);
+    const auto input_data_format = get_dataformat(cb_id_in0);
+    const InterleavedAddrGenFast<input_is_dram> input_addrg = {
+        .bank_base_address = input_addr, .page_size = input_tile_bytes, .data_format = input_data_format};
+
+    for (uint32_t i = start_id; i < start_id + num_output_tiles; i++) {
+        auto read_tile_id = (dim == 0) ? (i) : (get_read_tile_id(i, reduce_tile_size, inner_tile_size));
+        for (uint32_t j = 0; j < num_input_tiles; ++j) {
+            cb_reserve_back(cb_id_in0, onetile);
+            l1_write_addr_in0 = get_write_ptr(cb_id_in0);
+            noc_async_read_tile(read_tile_id, input_addrg, l1_write_addr_in0);
+            noc_async_read_barrier();
+            cb_push_back(cb_id_in0, onetile);
+            read_tile_id += inner_tile_size;
+        }
+    }
+}

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_sum/device/moreh_sum_nc_impl_kernels/writer_moreh_sum_nc.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_sum/device/moreh_sum_nc_impl_kernels/writer_moreh_sum_nc.cpp
@@ -1,0 +1,35 @@
+// SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "ttnn/cpp/ttnn/deprecated/tt_dnn/kernels/dataflow/moreh_common.hpp"
+
+void kernel_main() {
+    // compile-time args
+    constexpr bool output_is_dram = (get_compile_time_arg_val(0) == 1);
+
+    // runtime args
+    ArgFetcher arg_fetcher;
+    const auto output_addr = arg_fetcher.get_next_arg_val<uint32_t>();
+    const auto num_tiles = arg_fetcher.get_next_arg_val<uint32_t>();
+    const auto start_id = arg_fetcher.get_next_arg_val<uint32_t>();
+
+    constexpr uint32_t cb_id_out = 16;
+    constexpr uint32_t onetile = 1;
+
+    uint32_t output_tile_bytes = get_tile_size(cb_id_out);
+    const auto output_data_format = get_dataformat(cb_id_out);
+
+    const InterleavedAddrGenFast<output_is_dram> output_addrg = {
+        .bank_base_address = output_addr, .page_size = output_tile_bytes, .data_format = output_data_format};
+
+    for (uint32_t i = start_id; i < start_id + num_tiles; i++) {
+        uint32_t write_tile_id = i;
+        cb_wait_front(cb_id_out, onetile);
+
+        uint32_t l1_read_addr = get_read_ptr(cb_id_out);
+        noc_async_write_tile(write_tile_id, output_addrg, l1_read_addr);
+        noc_async_write_barrier();
+        cb_pop_front(cb_id_out, onetile);
+    }
+}

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_sum/device/moreh_sum_nc_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_sum/device/moreh_sum_nc_program_factory.cpp
@@ -1,0 +1,202 @@
+// SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <vector>
+
+#include "moreh_sum_device_operation.hpp"
+#include "ttnn/deprecated/tt_dnn/op_library/moreh_helper_functions.hpp"
+#include "tt_metal/common/work_split.hpp"
+#include "ttnn/operations/core/compute_kernel/compute_kernel_config.hpp"
+
+namespace ttnn::operations::moreh::moreh_sum {
+MorehSumOperation::MorehSumNCFactory::cached_program_t MorehSumOperation::MorehSumNCFactory::create(
+    const operation_attributes_t& operation_attributes,
+    const tensor_args_t& tensor_args,
+    tensor_return_value_t& output_tensor) {
+    auto input = tensor_args.input;
+    auto output = output_tensor;
+    auto dim = operation_attributes.dim;
+
+    auto output_mem_config = operation_attributes.output_mem_config;
+    const DeviceComputeKernelConfig &compute_kernel_config = init_device_compute_kernel_config(
+        input.device()->arch(), operation_attributes.compute_kernel_config, MathFidelity::HiFi4);
+    ;
+
+    auto* device = input.device();
+    auto program = Program();
+
+    const auto cb_data_format = datatype_to_dataformat_converter(output.get_dtype());
+    const auto single_tile_size = tt::tt_metal::detail::TileSize(cb_data_format);
+
+    const auto& input_shape = input.get_legacy_shape();
+    const auto& input_shape_without_padding = input_shape.without_padding();
+    const auto [Wt, Ht, inner_tile_size, reduce_tile_size] =
+        tt::operations::primary::extract_and_scale_spatial_dims(input_shape, static_cast<uint32_t>(dim));
+    const auto num_reduce_input_tile = input_shape[dim];
+    const auto num_output_tiles = output.volume() / tt::constants::TILE_HW;
+    auto [math_fidelity, math_approx_mode, fp32_dest_acc_en, packer_l1_acc] =
+        get_compute_kernel_config_args(input.device()->arch(), compute_kernel_config);
+
+    log_debug(
+        tt::LogOp, "reduce_tile_size {} inner_tile_size {} Ht {} Wt {}", reduce_tile_size, inner_tile_size, Ht, Wt);
+    log_debug(
+        tt::LogOp, "dim {} num_reduce_input_tile {} num_output_tiles {}", dim, num_reduce_input_tile, num_output_tiles);
+    log_debug(
+        tt::LogOp,
+        "math_fidelity {} math_approx_mode {} fp32_dest_acc_en {} packer_l1_acc {}",
+        math_fidelity,
+        math_approx_mode,
+        fp32_dest_acc_en,
+        packer_l1_acc);
+
+    ////////////////////////////////////////////////////////////////////////////
+    //                         Core Setup
+    ////////////////////////////////////////////////////////////////////////////
+    auto grid = device->compute_with_storage_grid_size();
+    const auto num_cores_y = grid.y;
+
+    const uint32_t in0_t = 2;        // input
+    const uint32_t in1_t = 1;        // zero
+    const uint32_t intermed0_t = 1;  // accumulated sum
+    const uint32_t out0_t = 2;       // output
+    const auto
+        [num_cores_to_be_used,
+         all_cores,
+         core_group_1,
+         core_group_2,
+         num_cols_per_core_group_1,
+         num_cols_per_core_group_2] = tt::tt_metal::split_work_to_cores(grid, num_output_tiles);
+
+    ////////////////////////////////////////////////////////////////////////////
+    //                         CircularBuffer Setup
+    ////////////////////////////////////////////////////////////////////////////
+    tt::operations::primary::CreateCircularBuffer(
+        program,
+        all_cores,
+        cb_data_format,
+        {
+            {tt::CB::c_in0, in0_t},  // input
+            {tt::CB::c_in1, in1_t},  // zero
+            {tt::CB::c_intermed0, intermed0_t, (fp32_dest_acc_en) ? tt::DataFormat::Float32 : cb_data_format},
+            {tt::CB::c_out0, out0_t},  // output
+        });
+    ////////////////////////////////////////////////////////////////////////////
+    //                      DataMovementKernel SetUp
+    ////////////////////////////////////////////////////////////////////////////
+    std::vector<uint32_t> reader_compile_time_args = {static_cast<uint32_t>(tt::operations::primary::is_dram(input))};
+    std::map<string, string> reader_defines;
+    reader_defines["USE_FPU"] = "1";
+    std::vector<uint32_t> writer_compile_time_args = {static_cast<uint32_t>(tt::operations::primary::is_dram(output))};
+    const auto reader_kernel_file =
+        "ttnn/cpp/ttnn/operations/moreh/moreh_sum/device/moreh_sum_nc_impl_kernels/reader_moreh_sum_nc.cpp";
+    const auto writer_kernel_file =
+        "ttnn/cpp/ttnn/operations/moreh/moreh_sum/device/moreh_sum_nc_impl_kernels/writer_moreh_sum_nc.cpp";
+    const auto reader_kernel_id = tt::operations::primary::CreateReadKernel(
+        program, reader_kernel_file, all_cores, reader_compile_time_args, reader_defines);
+    const auto writer_kernel_id =
+        tt::operations::primary::CreateWriteKernel(program, writer_kernel_file, all_cores, writer_compile_time_args);
+
+    ////////////////////////////////////////////////////////////////////////////
+    //                      ComputeKernel SetUp
+    ////////////////////////////////////////////////////////////////////////////
+    const std::vector<uint32_t> compute_args_group_1{num_cols_per_core_group_1, num_reduce_input_tile};
+    std::map<string, string> compute_defines;
+    if (fp32_dest_acc_en) {
+        compute_defines["FP32_DEST_ACC_EN"] = "1";
+    }
+    // set preserve_fp32_precision to the same value as fp32_dest_acc_en
+    bool preserve_fp32_precision = fp32_dest_acc_en;
+    auto compute_kernel_file =
+        "ttnn/cpp/ttnn/operations/moreh/moreh_sum/device/moreh_sum_nc_impl_kernels/moreh_sum_nc.cpp";
+    if (device->arch() == tt::ARCH::GRAYSKULL) {
+        compute_kernel_file =
+            "ttnn/cpp/ttnn/operations/moreh/moreh_sum/device/moreh_sum_nc_impl_kernels/moreh_sum_nc_gs.cpp";
+    }
+    const auto compute_kernel_1_id = tt::operations::primary::CreateComputeKernel(
+        program,
+        compute_kernel_file,
+        {core_group_1, num_cols_per_core_group_1, compute_args_group_1},
+        compute_defines,
+        math_fidelity,
+        fp32_dest_acc_en,
+        math_approx_mode,
+        preserve_fp32_precision);
+
+    std::optional<KernelHandle> compute_kernel_2_id = std::nullopt;
+    if (!core_group_2.ranges().empty()) {
+        const std::vector<uint32_t> compute_args_group_2{num_cols_per_core_group_2, num_reduce_input_tile};
+        compute_kernel_2_id = tt::operations::primary::CreateComputeKernel(
+            program,
+            compute_kernel_file,
+            {core_group_2, num_cols_per_core_group_2, compute_args_group_2},
+            compute_defines,
+            math_fidelity,
+            fp32_dest_acc_en,
+            math_approx_mode,
+            preserve_fp32_precision);
+    }
+
+    ////////////////////////////////////////////////////////////////////////////
+    //                      RuntimeArgs SetUp
+    ////////////////////////////////////////////////////////////////////////////
+    for (uint32_t i = 0, tile_offset = 0; i < num_cores_to_be_used; ++i) {
+        CoreCoord core = {i / num_cores_y, i % num_cores_y};
+
+        uint32_t num_tiles_per_core;
+        if (core_group_1.core_coord_in_core_ranges(core)) {
+            num_tiles_per_core = num_cols_per_core_group_1;
+        } else if (core_group_2.core_coord_in_core_ranges(core)) {
+            num_tiles_per_core = num_cols_per_core_group_2;
+        } else {
+            TT_THROW("Core not in specified core ranges.");
+        }
+
+        SetRuntimeArgs(
+            program,
+            reader_kernel_id,
+            core,
+            {input.buffer()->address(),
+             num_reduce_input_tile,
+             num_tiles_per_core,
+             tile_offset,
+             static_cast<uint32_t>(dim),
+             reduce_tile_size,
+             inner_tile_size});
+
+        SetRuntimeArgs(program, writer_kernel_id, core, {output.buffer()->address(), num_tiles_per_core, tile_offset});
+
+        tile_offset += num_tiles_per_core;
+    }
+
+    return {std::move(program), {reader_kernel_id, writer_kernel_id, num_cores_to_be_used, num_cores_y}};
+}
+
+void MorehSumOperation::MorehSumNCFactory::override_runtime_arguments(
+    cached_program_t& cached_program,
+    const operation_attributes_t& operation_attributes,
+    const tensor_args_t& tensor_args,
+    tensor_return_value_t& tensor_return_value) {
+    auto& program = cached_program.program;
+    auto& reader_kernel_id = cached_program.shared_variables.unary_reader_kernel_id;
+    auto& writer_kernel_id = cached_program.shared_variables.unary_writer_kernel_id;
+    auto num_cores = cached_program.shared_variables.num_cores;
+    auto num_cores_y = cached_program.shared_variables.num_cores_y;
+
+    log_debug(tt::LogOp, "{}:{} args_callback ", __func__, __LINE__);
+    const auto* input_buffer = tensor_args.input.buffer();
+    const auto* output_buffer = tensor_return_value.buffer();
+    for (uint32_t i = 0; i < num_cores; ++i) {
+        CoreCoord core = {i / num_cores_y, i % num_cores_y};
+        {
+            auto& runtime_args = GetRuntimeArgs(program, reader_kernel_id, core);
+            runtime_args[0] = input_buffer->address();
+        }
+
+        {
+            auto& runtime_args = GetRuntimeArgs(program, writer_kernel_id, core);
+            runtime_args[0] = output_buffer->address();
+        }
+    }
+}
+}  // namespace ttnn::operations::moreh::moreh_sum

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_sum/device/moreh_sum_w_impl_kernels/moreh_int_sum_w.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_sum/device/moreh_sum_w_impl_kernels/moreh_int_sum_w.cpp
@@ -1,0 +1,93 @@
+// SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "compute_kernel_api/eltwise_unary/sfpu_int_sum.h"
+#include "ttnn/cpp/ttnn/deprecated/tt_dnn/kernels/compute/moreh_common.hpp"
+
+namespace NAMESPACE {
+
+void MAIN {
+    constexpr uint32_t num_rows = get_compile_time_arg_val(0);
+    constexpr uint32_t Wt = get_compile_time_arg_val(1);
+    constexpr uint32_t origin_W = get_compile_time_arg_val(2);
+
+    constexpr auto cb_in0 = tt::CB::c_in0;
+    constexpr auto cb_mask_w = tt::CB::c_in1;
+    constexpr auto cb_intermed0 = tt::CB::c_intermed0;
+    constexpr auto cb_out0 = tt::CB::c_out0;
+    constexpr uint32_t TILE_W = 32;
+    constexpr bool do_mask_w = (origin_W % TILE_W) != 0;
+    constexpr int onetile = 1;
+    constexpr int idx0 = 0;
+    constexpr int dst0 = 0;
+    constexpr int dst1 = 1;
+
+    unary_op_init_common(cb_in0, cb_out0);
+
+    if (do_mask_w) {
+        cb_wait_front(cb_mask_w, onetile);
+    }
+
+    for (uint32_t row = 0; row < num_rows; ++row) {
+        constexpr bool is_single_wt = (Wt == 1);
+        if (is_single_wt) {
+            tile_regs_acquire();
+            copy_tile_to_dst(cb_in0, idx0, dst0);
+
+            if (do_mask_w) {
+                copy_tile_to_dst(cb_mask_w, idx0, dst1, false);
+                mask_tile_init();
+                mask_tile(dst0, dst1, DataFormat::Int32);
+            }
+
+            sfpu_sum_int_init();
+            sfpu_sum_int_row(dst0);
+            tile_regs_commit();
+
+            tile_regs_wait();
+            pack_tile_from_dst(cb_out0, dst0);
+            tile_regs_release();
+        } else {
+            for (uint32_t wt = 0; wt < Wt; ++wt) {
+                if (wt == 0) {
+                    tile_regs_acquire();
+                    copy_tile_to_dst(cb_in0, idx0, dst0);
+                    tile_regs_commit();
+
+                    tile_regs_wait();
+                    pack_tile_from_dst(cb_intermed0, dst0);
+                    tile_regs_release();
+                } else {
+                    tile_regs_acquire();
+                    copy_tile_to_dst(cb_in0, idx0, dst0);
+                    if (wt == Wt - 1 && do_mask_w) {
+                        copy_tile_to_dst(cb_mask_w, idx0, dst1, false);
+                        mask_tile_init();
+                        mask_tile(dst0, dst1, DataFormat::Int32);
+                    }
+
+                    copy_tile_to_dst(cb_intermed0, idx0, dst1);
+                    sfpu_sum_int_init();
+                    sfpu_add_int(dst0, dst1);
+                    tile_regs_commit();
+
+                    tile_regs_wait();
+                    pack_tile_from_dst(cb_intermed0, dst0);
+                    tile_regs_release();
+                }
+            }
+
+            tile_regs_acquire();
+            copy_tile_to_dst(cb_intermed0, idx0, dst0);
+            sfpu_sum_int_init();
+            sfpu_sum_int_row(dst0);
+            tile_regs_commit();
+
+            tile_regs_wait();
+            pack_tile_from_dst(cb_out0, dst0);
+            tile_regs_release();
+        }
+    }
+}
+}  // namespace NAMESPACE

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_sum/device/moreh_sum_w_impl_kernels/moreh_sum_w.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_sum/device/moreh_sum_w_impl_kernels/moreh_sum_w.cpp
@@ -1,0 +1,134 @@
+// SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "ttnn/cpp/ttnn/deprecated/tt_dnn/kernels/compute/moreh_common.hpp"
+
+namespace NAMESPACE {
+void MAIN {
+    uint32_t Ht = get_compile_time_arg_val(0);
+    uint32_t Wt = get_compile_time_arg_val(1);
+    uint32_t NC = get_compile_time_arg_val(2);
+    constexpr uint32_t origin_W = get_compile_time_arg_val(3);
+
+
+    auto cb_input = tt::CB::c_in0;
+    constexpr auto cb_scaler = tt::CB::c_in2;
+    constexpr auto cb_mask_w = tt::CB::c_in3;
+    constexpr auto cb_accum_dst = tt::CB::c_intermed0;
+    constexpr auto cb_masked_input = tt::CB::c_intermed1;
+    constexpr auto cb_out = tt::CB::c_out0;
+    constexpr uint32_t TILE_W = 32;
+    constexpr bool do_mask_w = (origin_W % TILE_W) != 0;
+
+    binary_op_init_common(cb_input, cb_scaler, cb_out);
+
+    cb_wait_front(cb_scaler, 1);  // scaler tile from the reader
+
+    constexpr int onetile = 1;
+    int reduce_dst_idx = 0;
+    const uint32_t mask_dst_idx = reduce_dst_idx + 1;
+
+    if (do_mask_w) {
+        cb_wait_front(cb_mask_w, onetile);
+    }
+
+    for (uint32_t nc = 0; nc < NC; nc++) {
+        for (uint32_t ht = 0; ht < Ht; ++ht) {
+            // tiles are expected to be coming in in NCHW order (W-contiguous)
+            // reducing in W means out[h][0] = sum(w=0..W-1, in[h][w])
+            // in this case we just sequentially add to accumulator all the W-tiles in a row
+            cb_input = tt::CB::c_in0;
+            bool is_w_single_tile = (Wt == 1);
+            if (!is_w_single_tile) {
+                tile_regs_acquire();
+                for (uint32_t wt = 0; wt < Wt - 1; ++wt) {
+                    cb_wait_front(cb_input, onetile);
+
+                    #if defined FP32_DEST_ACC_EN
+                        unpack_reconfig_data_format(cb_input, cb_scaler);
+                    #endif
+                    reduce_init_delta<false>();
+                    reduce_tile(cb_input, cb_scaler, 0, 0, reduce_dst_idx);
+                    reduce_revert_delta();
+
+                    cb_pop_front(cb_input, onetile);
+                }
+                tile_regs_commit();
+                cb_reserve_back(cb_accum_dst, onetile);
+                tile_regs_wait();
+                #if defined FP32_DEST_ACC_EN
+                    pack_reconfig_data_format(cb_accum_dst);
+                #endif
+                pack_tile(reduce_dst_idx, cb_accum_dst);
+                tile_regs_release();
+                cb_push_back(cb_accum_dst, onetile);
+            }
+
+            if (do_mask_w) {
+                tile_regs_acquire();
+                cb_wait_front(cb_input, onetile);
+                #if defined FP32_DEST_ACC_EN
+                    unpack_reconfig_data_format_srca(cb_input);
+                #endif
+                copy_tile_to_dst_init_short(cb_input);
+                copy_tile(cb_input, 0, reduce_dst_idx);
+                copy_tile(cb_mask_w, 0, mask_dst_idx);
+                mask_tile_init();
+                mask_tile(reduce_dst_idx, mask_dst_idx);
+                tile_regs_commit();
+
+                cb_reserve_back(cb_masked_input, onetile);
+                tile_regs_wait();
+                #if defined FP32_DEST_ACC_EN
+                    pack_reconfig_data_format(cb_masked_input);
+                #endif
+                pack_tile(reduce_dst_idx, cb_masked_input);
+                tile_regs_release();
+                cb_push_back(cb_masked_input, onetile);
+
+                cb_pop_front(cb_input, onetile);
+                cb_input = cb_masked_input;
+            }
+
+            tile_regs_acquire();
+            cb_wait_front(cb_input, onetile);
+            if (!is_w_single_tile) {
+                #if defined FP32_DEST_ACC_EN
+                    unpack_reconfig_data_format_srca(cb_accum_dst);
+                #endif
+                cb_wait_front(cb_accum_dst, onetile);
+                copy_tile_to_dst_init_short(cb_accum_dst);
+                copy_tile(cb_accum_dst, 0, reduce_dst_idx);
+            }
+
+            #if defined FP32_DEST_ACC_EN
+                unpack_reconfig_data_format(cb_input, cb_scaler);
+            #endif
+            reduce_init_delta<false>();
+            reduce_tile(cb_input, cb_scaler, 0, 0, reduce_dst_idx);
+            reduce_revert_delta();
+            tile_regs_commit();
+
+            cb_reserve_back(cb_out, onetile);
+            tile_regs_wait();
+            #if defined FP32_DEST_ACC_EN
+                pack_reconfig_data_format(cb_out);
+            #endif
+            pack_tile(reduce_dst_idx, cb_out);
+            tile_regs_release();
+            cb_push_back(cb_out, onetile);
+
+            cb_pop_front(cb_input, onetile);
+            if (!is_w_single_tile) {
+                cb_pop_front(cb_accum_dst, onetile);
+            }
+        }
+    }
+
+    if (do_mask_w) {
+        cb_pop_front(cb_mask_w, onetile);
+    }
+    cb_pop_front(cb_scaler, onetile);
+}
+}  // namespace NAMESPACE

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_sum/device/moreh_sum_w_impl_kernels/reader_moreh_int_sum_w.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_sum/device/moreh_sum_w_impl_kernels/reader_moreh_int_sum_w.cpp
@@ -1,0 +1,36 @@
+// SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "ttnn/cpp/ttnn/deprecated/tt_dnn/kernels/dataflow/moreh_common.hpp"
+
+void kernel_main() {
+    constexpr bool src_is_dram = get_compile_time_arg_val(0) == 1;
+
+    uint32_t src_addr = get_arg_val<uint32_t>(0);
+    uint32_t num_tiles = get_arg_val<uint32_t>(1);
+    uint32_t start_id = get_arg_val<uint32_t>(2);
+    uint32_t mask_w = get_arg_val<uint32_t>(3);
+
+    constexpr uint32_t cb_id_in0 = 0;
+    constexpr uint32_t cb_id_mask_w = 1;
+#ifdef DO_MASK_W
+    generate_int_mask_w(cb_id_mask_w, mask_w);
+#endif
+
+    // ublocks size defined in tiles
+    constexpr uint32_t onetile = 1;
+    uint32_t tile_bytes = get_tile_size(cb_id_in0);
+    const DataFormat data_format = get_dataformat(cb_id_in0);
+    const InterleavedAddrGenFast<src_is_dram> s = {
+        .bank_base_address = src_addr, .page_size = tile_bytes, .data_format = data_format};
+
+    // read a ublock of tiles from src to CB, and then push the ublock to unpacker
+    for (uint32_t i = start_id; i < start_id + num_tiles; i++) {
+        cb_reserve_back(cb_id_in0, onetile);
+        uint32_t l1_write_addr = get_write_ptr(cb_id_in0);
+        noc_async_read_tile(i, s, l1_write_addr);
+        noc_async_read_barrier();
+        cb_push_back(cb_id_in0, onetile);
+    }
+}

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_sum/device/moreh_sum_w_impl_kernels/reader_moreh_sum_w.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_sum/device/moreh_sum_w_impl_kernels/reader_moreh_sum_w.cpp
@@ -1,0 +1,42 @@
+// SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "ttnn/cpp/ttnn/deprecated/tt_dnn/kernels/dataflow/moreh_common.hpp"
+#include "ttnn/cpp/ttnn/deprecated/tt_dnn/kernels/dataflow/generate_reduce_scaler.hpp"
+
+void kernel_main() {
+    uint32_t src_addr = get_arg_val<uint32_t>(0);
+    uint32_t num_tiles = get_arg_val<uint32_t>(1);
+    uint32_t start_id = get_arg_val<uint32_t>(2);
+    uint32_t mask_w = get_arg_val<uint32_t>(3);
+    constexpr bool src_is_dram = get_compile_time_arg_val(0) == 1;
+    constexpr uint32_t scaler = get_compile_time_arg_val(1);
+
+    constexpr uint32_t cb_id_in2 = 2;
+    generate_reduce_scaler(cb_id_in2, scaler);
+
+    constexpr uint32_t cb_id_mask_w = 3;
+#ifdef DO_MASK_W
+    generate_mask_w(cb_id_mask_w, mask_w);
+#endif
+
+    constexpr uint32_t cb_id_in0 = 0;
+
+    // ublocks size defined in tiles
+    constexpr uint32_t onetile = 1;
+    uint32_t tile_bytes = get_tile_size(cb_id_in0);
+    const DataFormat data_format = get_dataformat(cb_id_in0);
+
+    const InterleavedAddrGenFast<src_is_dram> s = {
+        .bank_base_address = src_addr, .page_size = tile_bytes, .data_format = data_format};
+
+    // read a ublock of tiles from src to CB, and then push the ublock to unpacker
+    for (uint32_t i = start_id; i < start_id + num_tiles; i++) {
+        cb_reserve_back(cb_id_in0, onetile);
+        uint32_t l1_write_addr = get_write_ptr(cb_id_in0);
+        noc_async_read_tile(i, s, l1_write_addr);
+        noc_async_read_barrier();
+        cb_push_back(cb_id_in0, onetile);
+    }
+}

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_sum/device/moreh_sum_w_impl_kernels/writer_moreh_int_sum_w.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_sum/device/moreh_sum_w_impl_kernels/writer_moreh_int_sum_w.cpp
@@ -1,0 +1,44 @@
+// SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "dataflow_api.h"
+
+void kernel_main() {
+    constexpr bool dst_is_dram = get_compile_time_arg_val(0) == 1;
+
+    uint32_t dst_addr  = get_arg_val<uint32_t>(0);
+    uint32_t num_tiles = get_arg_val<uint32_t>(1);
+    uint32_t start_id = get_arg_val<uint32_t>(2);
+
+    constexpr uint32_t cb_id_out = 16;
+
+    // single-tile ublocks
+    constexpr uint32_t onetile = 1;
+    const uint32_t tile_bytes = get_tile_size(cb_id_out);
+    const DataFormat data_format = get_dataformat(cb_id_out);
+
+    const InterleavedAddrGenFast<dst_is_dram> s = {
+        .bank_base_address = dst_addr,
+        .page_size = tile_bytes,
+        .data_format = data_format
+    };
+
+    uint32_t end_id = start_id + num_tiles;
+    for (uint32_t i = start_id; i < end_id; ++ i) {
+        cb_wait_front(cb_id_out, onetile);
+        uint32_t l1_read_addr = get_read_ptr(cb_id_out);
+
+        volatile tt_l1_ptr int32_t* out_l1_ptr = reinterpret_cast<volatile tt_l1_ptr int32_t*>(l1_read_addr);
+        for (uint32_t h = 0; h < 16; h++) {
+            for (uint32_t subw = 1; subw < 8; ++subw) {
+                out_l1_ptr[h * 16] += out_l1_ptr[h * 16 + (2 * subw)];
+                out_l1_ptr[(h * 16) + 512] += out_l1_ptr[(h * 16) + 512 + (2 * subw)];
+            }
+        }
+
+        noc_async_write_tile(i, s, l1_read_addr);
+        noc_async_write_barrier();
+        cb_pop_front(cb_id_out, onetile);
+    }
+}

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_sum/device/moreh_sum_w_impl_kernels/writer_moreh_sum_w.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_sum/device/moreh_sum_w_impl_kernels/writer_moreh_sum_w.cpp
@@ -1,0 +1,34 @@
+// SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "dataflow_api.h"
+
+void kernel_main() {
+    uint32_t dst_addr  = get_arg_val<uint32_t>(0);
+    uint32_t num_tiles = get_arg_val<uint32_t>(1);
+    uint32_t start_id = get_arg_val<uint32_t>(2);
+
+    constexpr uint32_t cb_id_out = get_compile_time_arg_val(0);
+    constexpr bool dst_is_dram = get_compile_time_arg_val(1) == 1;
+
+    // single-tile ublocks
+    constexpr uint32_t onetile = 1;
+    const uint32_t tile_bytes = get_tile_size(cb_id_out);
+    const DataFormat data_format = get_dataformat(cb_id_out);
+
+    const InterleavedAddrGenFast<dst_is_dram> s = {
+        .bank_base_address = dst_addr,
+        .page_size = tile_bytes,
+        .data_format = data_format
+    };
+
+    uint32_t end_id = start_id + num_tiles;
+    for (uint32_t i = start_id; i < end_id; ++ i) {
+        cb_wait_front(cb_id_out, onetile);
+        uint32_t l1_read_addr = get_read_ptr(cb_id_out);
+        noc_async_write_tile(i, s, l1_read_addr);
+        noc_async_write_barrier();
+        cb_pop_front(cb_id_out, onetile);
+    }
+}

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_sum/device/moreh_sum_w_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_sum/device/moreh_sum_w_program_factory.cpp
@@ -1,0 +1,258 @@
+// SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <vector>
+
+#include "moreh_sum_device_operation.hpp"
+#include "ttnn/deprecated/tt_dnn/op_library/moreh_helper_functions.hpp"
+#include "ttnn/operations/core/compute_kernel/compute_kernel_config.hpp"
+#include "ttnn/operations/reduction/generic/device/common.hpp"
+#include "ttnn/operations/reduction/generic/device/reduce_op.hpp"
+
+namespace ttnn::operations::moreh::moreh_sum {
+MorehSumOperation::MorehSumWFactory::cached_program_t MorehSumOperation::MorehSumWFactory::create(
+    const operation_attributes_t &operation_attributes,
+    const tensor_args_t &tensor_args,
+    tensor_return_value_t &output_tensor) {
+    auto input = tensor_args.input;
+    auto output = output_tensor;
+
+    auto output_mem_config = operation_attributes.output_mem_config;
+    const DeviceComputeKernelConfig &compute_kernel_config = init_device_compute_kernel_config(
+        input.device()->arch(), operation_attributes.compute_kernel_config, MathFidelity::HiFi4);
+    ;
+
+    tt::tt_metal::ReduceOpMath reduce_op = tt::tt_metal::ReduceOpMath::SUM;
+    tt::tt_metal::ReduceOpDim reduce_dim = tt::tt_metal::ReduceOpDim::W;
+    float scaler = 1.0f;
+
+    const auto shape = input.get_shape();
+    const auto [W, H, other_dims_product] = tt::operations::primary::extract_spatial_dims(shape.value);
+
+    uint32_t HW = H * W;
+    uint32_t Wt = W / tt::constants::TILE_WIDTH;
+    uint32_t Ht = H / tt::constants::TILE_HEIGHT;
+
+    // check mask for w-dim
+    const auto input_shape_without_padding = shape.value.without_padding();
+    const auto origin_W = input_shape_without_padding[-1];
+    const bool do_mask_w = (origin_W % tt::constants::TILE_WIDTH) != 0;
+    const auto mask_w = do_mask_w ? origin_W % tt::constants::TILE_WIDTH : tt::constants::TILE_WIDTH;
+
+    auto [math_fidelity, math_approx_mode, fp32_dest_acc_en, packer_l1_acc] =
+        get_compute_kernel_config_args(input.device()->arch(), compute_kernel_config);
+    log_debug(
+        tt::LogOp,
+        "math_fidelity {} math_approx_mode {} fp32_dest_acc_en {} packer_l1_acc {}",
+        math_fidelity,
+        math_approx_mode,
+        fp32_dest_acc_en,
+        packer_l1_acc);
+
+    tt::tt_metal::Program program = tt::tt_metal::CreateProgram();
+
+    tt::DataFormat src0_cb_data_format = tt::tt_metal::datatype_to_dataformat_converter(input.get_dtype());
+    uint32_t src0_single_tile_size = tt::tt_metal::detail::TileSize(src0_cb_data_format);
+    // Scaler datatype is hardcoded bfloat16 due to tile creation in reader
+    tt::DataFormat scaler_cb_data_format = tt::DataFormat::Float16_b;
+    uint32_t scaler_single_tile_size = tt::tt_metal::detail::TileSize(scaler_cb_data_format);
+    tt::DataFormat mask_w_cb_data_format = tt::DataFormat::Float16_b;
+    uint32_t mask_w_single_tile_size = tt::tt_metal::detail::TileSize(mask_w_cb_data_format);
+    tt::DataFormat intermed_cb_data_format = (fp32_dest_acc_en) ? tt::DataFormat::Float32 : tt::DataFormat::Float16_b;
+    tt::DataFormat intermed1_cb_data_format = tt::DataFormat::Float16_b;
+    uint32_t intermed_single_tile_size = tt::tt_metal::detail::TileSize(intermed_cb_data_format);
+    tt::DataFormat dst_cb_data_format = tt::tt_metal::datatype_to_dataformat_converter(output.get_dtype());
+    uint32_t dst_single_tile_size = tt::tt_metal::detail::TileSize(dst_cb_data_format);
+
+    uint32_t num_tiles = input.volume() / tt::constants::TILE_HW;
+
+    tt::tt_metal::Device *device = input.device();
+
+    auto compute_with_storage_grid_size = device->compute_with_storage_grid_size();
+    uint32_t num_cores_y = compute_with_storage_grid_size.y;
+    auto num_rows = other_dims_product * Ht;
+
+    const CoreRange all_core_range(
+        {0, 0}, {compute_with_storage_grid_size.x - 1, compute_with_storage_grid_size.y - 1});
+
+    auto [num_cores, all_cores, core_group_1, core_group_2, num_rows_per_core_group_1, num_rows_per_core_group_2] =
+        tt::operations::primary::split_work_to_cores(all_core_range, num_rows);
+
+    string compute_kernel_name =
+        "ttnn/cpp/ttnn/operations/moreh/moreh_sum/device/moreh_sum_w_impl_kernels/moreh_sum_w.cpp";
+
+    uint32_t src0_cb_index = 0;
+    uint32_t num_input_tiles = 2;
+    tt::tt_metal::CircularBufferConfig cb_src0_config =
+        tt::tt_metal::CircularBufferConfig(
+            num_input_tiles * src0_single_tile_size, {{src0_cb_index, src0_cb_data_format}})
+            .set_page_size(src0_cb_index, src0_single_tile_size);
+    auto cb_src0 = tt::tt_metal::CreateCircularBuffer(program, all_cores, cb_src0_config);
+
+    tt::tt_metal::CircularBufferConfig cb_scaler_config =
+        tt::tt_metal::CircularBufferConfig(
+            num_input_tiles * scaler_single_tile_size, {{tt::CB::c_in2, scaler_cb_data_format}})
+            .set_page_size(tt::CB::c_in2, scaler_single_tile_size);
+    auto cb_scaler = tt::tt_metal::CreateCircularBuffer(program, all_cores, cb_scaler_config);
+
+    tt::tt_metal::CircularBufferConfig cb_mask_w_config =
+        tt::tt_metal::CircularBufferConfig(mask_w_single_tile_size, {{tt::CB::c_in3, mask_w_cb_data_format}})
+            .set_page_size(tt::CB::c_in3, mask_w_single_tile_size);
+    auto cb_mask_w = tt::tt_metal::CreateCircularBuffer(program, all_cores, cb_mask_w_config);
+
+    tt::tt_metal::CircularBufferConfig cb_intermed0_config =
+        tt::tt_metal::CircularBufferConfig(intermed_single_tile_size, {{tt::CB::c_intermed0, intermed_cb_data_format}})
+            .set_page_size(tt::CB::c_intermed0, intermed_single_tile_size);
+    auto cb_intermed0 = tt::tt_metal::CreateCircularBuffer(program, all_cores, cb_intermed0_config);
+
+    tt::tt_metal::CircularBufferConfig cb_intermed1_config =
+        tt::tt_metal::CircularBufferConfig(intermed_single_tile_size, {{tt::CB::c_intermed1, intermed1_cb_data_format}})
+            .set_page_size(tt::CB::c_intermed1, intermed_single_tile_size);
+    auto cb_intermed1 = tt::tt_metal::CreateCircularBuffer(program, all_cores, cb_intermed1_config);
+
+    uint32_t output_cb_index = 16;  // output operands start at index 16
+    uint32_t num_output_tiles = 2;
+    tt::tt_metal::CircularBufferConfig cb_output_config =
+        tt::tt_metal::CircularBufferConfig(
+            num_output_tiles * dst_single_tile_size, {{output_cb_index, dst_cb_data_format}})
+            .set_page_size(output_cb_index, dst_single_tile_size);
+    auto cb_output = tt::tt_metal::CreateCircularBuffer(program, all_cores, cb_output_config);
+
+    class bfloat16 bfloat_scaler_value = *(new class bfloat16(scaler));
+    uint32_t packed_scaler_value = pack_two_bfloat16_into_uint32({bfloat_scaler_value, bfloat_scaler_value});
+    tt::tt_metal::Buffer *src_buffer = input.buffer();
+    bool src_is_dram = src_buffer->buffer_type() == tt::tt_metal::BufferType::DRAM ? 1 : 0;
+    std::vector<uint32_t> reader_compile_time_args = {(uint32_t)src_is_dram, packed_scaler_value};
+    tt::tt_metal::Buffer *dst_buffer = output.buffer();
+    bool dst_is_dram = dst_buffer->buffer_type() == tt::tt_metal::BufferType::DRAM ? 1 : 0;
+    std::vector<uint32_t> writer_compile_time_args = {(std::uint32_t)output_cb_index, (std::uint32_t)dst_is_dram};
+
+    std::map<string, string> reader_defines{};
+    if (do_mask_w) {
+        reader_defines["DO_MASK_W"] = "1";
+    }
+    tt::tt_metal::KernelHandle reader_kernel_id = tt::tt_metal::CreateKernel(
+        program,
+        "ttnn/cpp/ttnn/operations/moreh/moreh_sum/device/moreh_sum_w_impl_kernels/reader_moreh_sum_w.cpp",
+        all_cores,
+        tt::tt_metal::ReaderDataMovementConfig(reader_compile_time_args, reader_defines));
+
+    tt::tt_metal::KernelHandle writer_kernel_id = tt::tt_metal::CreateKernel(
+        program,
+        "ttnn/cpp/ttnn/operations/moreh/moreh_sum/device/moreh_sum_w_impl_kernels/writer_moreh_sum_w.cpp",
+        all_cores,
+        tt::tt_metal::WriterDataMovementConfig(writer_compile_time_args));
+
+    std::map<string, string> reduce_defines = reduce_op_utils::get_defines(reduce_op, reduce_dim);
+    if (fp32_dest_acc_en) {
+        reduce_defines["FP32_DEST_ACC_EN"] = "1";
+    }
+    vector<uint32_t> compute_kernel_args_group_1 = {
+        num_rows_per_core_group_1,  // Ht
+        Wt,                         // Wt
+        1,                          // NC
+        origin_W,
+    };
+
+    // set preserve_fp32_precision to the same value as fp32_dest_acc_en
+    bool preserve_fp32_precision = fp32_dest_acc_en;
+    auto reduce_compute_kernel_group_1_id = tt::tt_metal::CreateKernel(
+        program,
+        compute_kernel_name,
+        core_group_1,
+        tt::tt_metal::ComputeConfig{
+            .math_fidelity = math_fidelity,
+            .fp32_dest_acc_en = fp32_dest_acc_en,
+            .preserve_fp32_precision = preserve_fp32_precision,
+            .math_approx_mode = math_approx_mode,
+            .compile_args = compute_kernel_args_group_1,
+            .defines = reduce_defines});
+
+    if (!core_group_2.ranges().empty()) {
+        vector<uint32_t> compute_kernel_args_group_2 = {
+            num_rows_per_core_group_2,  // Ht
+            Wt,                         // Wt
+            1,                          // NC
+            origin_W,
+        };
+
+        auto reduce_compute_kernel_group_2_id = tt::tt_metal::CreateKernel(
+            program,
+            compute_kernel_name,
+            core_group_2,
+            tt::tt_metal::ComputeConfig{
+                .math_fidelity = math_fidelity,
+                .fp32_dest_acc_en = fp32_dest_acc_en,
+                .preserve_fp32_precision = preserve_fp32_precision,
+                .math_approx_mode = math_approx_mode,
+                .compile_args = compute_kernel_args_group_2,
+                .defines = reduce_defines});
+    }
+
+    uint32_t out_dim_divider = Wt;
+    for (uint32_t i = 0, num_tiles_read = 0; i < num_cores; i++) {
+        CoreCoord core = {i / num_cores_y, i % num_cores_y};
+        uint32_t num_rows_per_core = 0;
+        if (core_group_1.core_coord_in_core_ranges(core)) {
+            num_rows_per_core = num_rows_per_core_group_1;
+        } else if (core_group_2.core_coord_in_core_ranges(core)) {
+            num_rows_per_core = num_rows_per_core_group_2;
+        } else {
+            TT_ASSERT(false, "Core not in specified core ranges");
+        }
+        uint32_t num_tensor_tiles_per_core = num_rows_per_core * Wt;
+        tt::tt_metal::SetRuntimeArgs(
+            program,
+            reader_kernel_id,
+            core,
+            {input.buffer()->address(),
+             num_tensor_tiles_per_core,
+             num_tiles_read,  // tile index of row to start reading from
+             mask_w});
+
+        tt::tt_metal::SetRuntimeArgs(
+            program,
+            writer_kernel_id,
+            core,
+            {
+                output.buffer()->address(),
+                num_tensor_tiles_per_core / out_dim_divider,  // number of tiles to write
+                num_tiles_read / out_dim_divider              // output tile start index
+            });
+        num_tiles_read += num_tensor_tiles_per_core;
+    }
+
+    return {std::move(program), {reader_kernel_id, writer_kernel_id, num_cores, num_cores_y}};
+}
+
+void MorehSumOperation::MorehSumWFactory::override_runtime_arguments(
+    cached_program_t &cached_program,
+    const operation_attributes_t &operation_attributes,
+    const tensor_args_t &tensor_args,
+    tensor_return_value_t &tensor_return_value) {
+    auto &program = cached_program.program;
+    auto &reader_kernel_id = cached_program.shared_variables.unary_reader_kernel_id;
+    auto &writer_kernel_id = cached_program.shared_variables.unary_writer_kernel_id;
+    auto num_cores = cached_program.shared_variables.num_cores;
+    auto num_cores_y = cached_program.shared_variables.num_cores_y;
+
+    log_debug(tt::LogOp, "{}:{} args_callback ", __func__, __LINE__);
+    auto src_dram_buffer = tensor_args.input.buffer();
+    auto dst_dram_buffer = tensor_return_value.buffer();
+
+    for (uint32_t i = 0, num_tiles_read = 0; i < num_cores; i++) {
+        CoreCoord core = {i / num_cores_y, i % num_cores_y};
+
+        {
+            auto &runtime_args = GetRuntimeArgs(program, reader_kernel_id, core);
+            runtime_args[0] = src_dram_buffer->address();
+        }
+
+        {
+            auto &runtime_args = GetRuntimeArgs(program, writer_kernel_id, core);
+            runtime_args[0] = dst_dram_buffer->address();
+        }
+    }
+}
+}  // namespace ttnn::operations::moreh::moreh_sum

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_sum/moreh_sum.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_sum/moreh_sum.cpp
@@ -1,0 +1,32 @@
+// SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "moreh_sum.hpp"
+
+#include "ttnn/deprecated/tt_dnn/op_library/moreh_helper_functions.hpp"
+#include "ttnn/operations/moreh/moreh_sum/device/moreh_sum_device_operation.hpp"
+
+namespace ttnn::operations::moreh::moreh_sum {
+Tensor MorehSum::invoke(
+    const Tensor& input,
+    std::optional<std::variant<int64_t, std::vector<int64_t>>> dim,
+    const bool keep_batch_dim,
+    const std::optional<Tensor>& output,
+    const std::optional<MemoryConfig>& output_mem_config,
+    const std::optional<DeviceComputeKernelConfig>& compute_kernel_config) {
+    std::vector<int64_t> dims = tt::operations::primary::get_dim(dim, input.get_legacy_shape().rank());
+    std::sort(dims.begin(), dims.end());
+
+    auto temp_input = input;
+    for (uint32_t i = dims.size() - 1; i > 0; i--) {
+        log_debug(tt::LogOp, "{}:{} dim {} keep_batch_dim {}", __func__, __LINE__, dims[i], keep_batch_dim);
+        auto temp_output = ttnn::prim::moreh_sum(
+            temp_input, dims[i], keep_batch_dim, std::nullopt, output_mem_config, compute_kernel_config);
+        temp_input = temp_output;
+    }
+    log_debug(tt::LogOp, "{}:{} dim {} keep_batch_dim {}", __func__, __LINE__, dims.front(), keep_batch_dim);
+    return ttnn::prim::moreh_sum(
+        temp_input, dims.front(), keep_batch_dim, output, output_mem_config, compute_kernel_config);
+}
+}  // namespace ttnn::operations::moreh::moreh_sum

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_sum/moreh_sum.hpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_sum/moreh_sum.hpp
@@ -1,0 +1,22 @@
+// SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+#include "ttnn/decorators.hpp"
+#include "ttnn/operations/core/compute_kernel/compute_kernel_config.hpp"
+namespace ttnn::operations::moreh::moreh_sum {
+struct MorehSum {
+    static Tensor invoke(
+        const Tensor& input,
+        std::optional<std::variant<int64_t, std::vector<int64_t>>> dims,
+        const bool keep_batch_dim,
+        const std::optional<Tensor>& output,
+        const std::optional<MemoryConfig>& output_mem_config,
+        const std::optional<DeviceComputeKernelConfig>& compute_kernel_config);
+};
+}  // namespace ttnn::operations::moreh::moreh_sum
+
+namespace ttnn {
+constexpr auto moreh_sum = ttnn::register_operation<"ttnn::moreh_sum", ttnn::operations::moreh::moreh_sum::MorehSum>();
+}

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_sum/moreh_sum_pybind.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_sum/moreh_sum_pybind.cpp
@@ -1,0 +1,25 @@
+// SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "moreh_sum_pybind.hpp"
+
+#include "pybind11/decorators.hpp"
+#include "ttnn/operations/moreh/moreh_sum/moreh_sum.hpp"
+
+namespace ttnn::operations::moreh::moreh_sum {
+void bind_moreh_sum_operation(py::module& module) {
+    bind_registered_operation(
+        module,
+        ttnn::moreh_sum,
+        "Moreh moreh_sum Operation",
+        ttnn::pybind_arguments_t{
+            py::arg("input"),
+            py::arg("dim"),
+            py::kw_only(),
+            py::arg("keepdim") = false,
+            py::arg("output") = std::nullopt,
+            py::arg("memory_config") = std::nullopt,
+            py::arg("compute_kernel_config") = std::nullopt});
+}
+}  // namespace ttnn::operations::moreh::moreh_sum

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_sum/moreh_sum_pybind.hpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_sum/moreh_sum_pybind.hpp
@@ -1,0 +1,13 @@
+// SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include "pybind11/pybind_fwd.hpp"
+
+namespace py = pybind11;
+
+namespace ttnn::operations::moreh::moreh_sum {
+void bind_moreh_sum_operation(py::module& module);
+}  // namespace ttnn::operations::moreh::moreh_sum

--- a/ttnn/ttnn/operations/moreh.py
+++ b/ttnn/ttnn/operations/moreh.py
@@ -7,3 +7,4 @@ import ttnn
 arange = ttnn._ttnn.operations.moreh.moreh_arange
 adam = ttnn._ttnn.operations.moreh.moreh_adam
 getitem = ttnn._ttnn.operations.moreh.moreh_getitem
+sum = ttnn._ttnn.operations.moreh.moreh_sum


### PR DESCRIPTION
### Ticket
#12436 

### Problem description
`moreh_sum` was deprecated alongside `tt_dnn`. This PR ports it to `ttnn` using its operation format.

### What's changed
 - Moved device code to `ttnn`
 - Created new wrapper code for `ttnn` with new modules
 - Ported unit tests to `ttnn`

### Checklist
- [ ] Post commit CI passes
- [ ] Blackhole Post commit (if applicable)
- [ ] Model regression CI testing passes (if applicable)
- [ ] New/Existing tests provide coverage for changes

### Additional Notes
- Previous implementation of `moreh_sum` has not been removed due to a dependancy by `moreh_matmul_backward`. Doing so would cause the mentioned `tt_dnn` unit test to fail.
