### PR TITLE
#12440: Fix fatals that would never be triggered

### DIFF
--- a/tests/tt_eager/integration_tests/test_bert.cpp
+++ b/tests/tt_eager/integration_tests/test_bert.cpp
@@ -285,7 +285,7 @@ void test_bert() {
     run_loop();
     device->disable_and_clear_program_cache();
 
-    TT_FATAL(tt::tt_metal::CloseDevice(device));
+    TT_FATAL(tt::tt_metal::CloseDevice(device), "Error");
 }
 
 int main(int argc, char** argv) {

--- a/tests/tt_eager/ops/test_average_pool.cpp
+++ b/tests/tt_eager/ops/test_average_pool.cpp
@@ -34,9 +34,9 @@ int main () {
     Shape resnet18_shape = {1, 1, 7 * 7, 2048};
     auto result = run_avg_pool_2d_resnet(resnet18_shape, device);
 
-    TT_FATAL(result.get_legacy_shape() == Shape({1, 1, tt::constants::TILE_HEIGHT, 2048}));
-    TT_FATAL(result.get_legacy_shape().without_padding() == Shape({1, 1, 1, 2048}));
+    TT_FATAL(result.get_legacy_shape() == Shape({1, 1, tt::constants::TILE_HEIGHT, 2048}), "Incorrect shape {}.", result.get_legacy_shape());
+    TT_FATAL(result.get_legacy_shape().without_padding() == Shape({1, 1, 1, 2048}), "Incorrect shape {}.", result.get_legacy_shape().without_padding());
 
-    TT_FATAL(tt::tt_metal::CloseDevice(device));
+    TT_FATAL(tt::tt_metal::CloseDevice(device), "Error");
     return 0;
 }

--- a/tests/tt_eager/ops/test_bcast_op.cpp
+++ b/tests/tt_eager/ops/test_bcast_op.cpp
@@ -124,7 +124,7 @@ int main(int argc, char **argv) {
         TT_THROW("Test Failed");
     }
 
-    TT_FATAL(pass);
+    TT_FATAL(pass, "Error");
 
     return 0;
 }

--- a/tests/tt_eager/ops/test_bmm_op.cpp
+++ b/tests/tt_eager/ops/test_bmm_op.cpp
@@ -75,7 +75,7 @@ int main(int argc, char **argv) {
         TT_THROW("Test Failed");
     }
 
-    TT_FATAL(pass);
+    TT_FATAL(pass, "Error");
 
     return 0;
 }

--- a/tests/tt_eager/ops/test_eltwise_binary_op.cpp
+++ b/tests/tt_eager/ops/test_eltwise_binary_op.cpp
@@ -53,51 +53,51 @@ int main() {
     {
         Shape shape = {1, 1, tt::constants::TILE_HEIGHT, tt::constants::TILE_WIDTH};
         auto allclose = run_test<host_function<std::plus<float>>>(shape, ttnn::add, device);
-        TT_FATAL(allclose);
+        TT_FATAL(allclose, "Error");
     }
 
     {
         Shape shape = {1, 1, tt::constants::TILE_HEIGHT, tt::constants::TILE_WIDTH};
         auto allclose = run_test<host_function<std::minus<float>>>(shape, ttnn::subtract, device);
-        TT_FATAL(allclose);
+        TT_FATAL(allclose, "Error");
     }
 
     {
         Shape shape = {1, 1, tt::constants::TILE_HEIGHT, tt::constants::TILE_WIDTH};
         auto allclose = run_test<host_function<std::multiplies<float>>>(shape, ttnn::multiply, device, 1e-2f, 1e-3f);
-        TT_FATAL(allclose);
+        TT_FATAL(allclose, "Error");
     }
 
     auto run_binary_ops = [&] {
         {
             Shape shape = {1, 1, tt::constants::TILE_HEIGHT, tt::constants::TILE_WIDTH};
             auto allclose = run_test<host_function<std::plus<float>>>(shape, ttnn::add, device);
-            TT_FATAL(allclose);
+            TT_FATAL(allclose, "Error");
         }
 
         {
             Shape shape = {1, 1, tt::constants::TILE_HEIGHT, tt::constants::TILE_WIDTH};
             auto allclose = run_test<host_function<std::minus<float>>>(shape, ttnn::subtract, device);
-            TT_FATAL(allclose);
+            TT_FATAL(allclose, "Error");
         }
 
         {
             Shape shape = {1, 1, tt::constants::TILE_HEIGHT * 2, tt::constants::TILE_WIDTH * 2};
             auto allclose = run_test<host_function<std::plus<float>>>(shape, ttnn::add, device);
-            TT_FATAL(allclose);
+            TT_FATAL(allclose, "Error");
         }
 
         {
             Shape shape = {1, 1, tt::constants::TILE_HEIGHT, tt::constants::TILE_WIDTH};
             auto allclose =
                 run_test<host_function<std::multiplies<float>>>(shape, ttnn::multiply, device, 1e-2f, 1e-3f);
-            TT_FATAL(allclose);
+            TT_FATAL(allclose, "Error");
         }
 
         {
             Shape shape = {1, 1, tt::constants::TILE_HEIGHT * 4, tt::constants::TILE_WIDTH * 4};
             auto allclose = run_test<host_function<std::plus<float>>>(shape, ttnn::add, device);
-            TT_FATAL(allclose);
+            TT_FATAL(allclose, "Error");
         }
     };
 
@@ -118,9 +118,9 @@ int main() {
 
     device->disable_and_clear_program_cache();
 
-    TT_FATAL(device->num_program_cache_entries()== 0);
+    TT_FATAL(device->num_program_cache_entries()== 0, "Error");
 
-    TT_FATAL(tt::tt_metal::CloseDevice(device));
+    TT_FATAL(tt::tt_metal::CloseDevice(device), "Error");
 
     return 0;
 }

--- a/tests/tt_eager/ops/test_eltwise_unary_op.cpp
+++ b/tests/tt_eager/ops/test_eltwise_unary_op.cpp
@@ -123,7 +123,7 @@ void test_operation_infrastructure() {
     auto program_hash = ttnn::operations::unary::UnaryDeviceOperation::compute_program_hash(op_args, tensor_args);
     TT_FATAL(program_hash == 3018574135764717736ULL, fmt::format("Actual value is {}", program_hash));
 
-    TT_FATAL(tt::tt_metal::CloseDevice(device));
+    TT_FATAL(tt::tt_metal::CloseDevice(device), "Error");
 }
 
 void test_shape_padding() {
@@ -149,10 +149,10 @@ void test_shape_padding() {
     output_tensor = output_tensor.cpu();
 
     auto output_shape = output_tensor.get_legacy_shape();
-    TT_FATAL(output_shape == tt::tt_metal::Shape(padded_input_shape));
-    TT_FATAL(output_shape.without_padding() == tt::tt_metal::Shape(input_shape));
+    TT_FATAL(output_shape == tt::tt_metal::Shape(padded_input_shape), "Error");
+    TT_FATAL(output_shape.without_padding() == tt::tt_metal::Shape(input_shape), "Error");
 
-    TT_FATAL(tt::tt_metal::CloseDevice(device));
+    TT_FATAL(tt::tt_metal::CloseDevice(device), "Error");
 }
 
 namespace tt {
@@ -180,47 +180,47 @@ void test_numerically() {
     auto shape = Shape{1, 1, TILE_HEIGHT, TILE_WIDTH};
     {
         auto allclose = run_test<UnaryOpType::SQRT>(device, shape, 0.0f, 1.0f, 1e-1f, 1e-5f);
-        TT_FATAL(allclose);
+        TT_FATAL(allclose, "Error");
     }
     {
         auto allclose = run_test<UnaryOpType::EXP>(device, shape, -1.0f, 1.0f, 1e-1f, 1e-5f);
-        TT_FATAL(allclose);
+        TT_FATAL(allclose, "Error");
     }
     {
         auto allclose = run_test<UnaryOpType::EXP>(device, shape, -1.0f, 1.0f, 1e-1f, 1e-5f);
-        TT_FATAL(allclose);
+        TT_FATAL(allclose, "Error");
     }
     {
         auto allclose = run_test<UnaryOpType::RECIP>(device, shape, 1.0f, 10.0f, 1e-1f, 1e-5f);
-        TT_FATAL(allclose);
+        TT_FATAL(allclose, "Error");
     }
     {
         auto allclose = run_test<UnaryOpType::GELU>(device, shape, 1.0f, 10.0f, 1e-1f, 1e-3f);
-        TT_FATAL(allclose);
+        TT_FATAL(allclose, "Error");
     }
     {
         auto allclose = run_test<UnaryOpType::GELU>(device, shape, 1.0f, 10.0f, 1e-1f, 1e-3f);
-        TT_FATAL(allclose);
+        TT_FATAL(allclose, "Error");
     }
 
     {
         auto allclose = run_test<UnaryOpType::RELU>(device, shape, -1.0f, 1.0f, 1e-1f, 1e-5f);
-        TT_FATAL(allclose);
+        TT_FATAL(allclose, "Error");
     }
     {
         auto allclose = run_test<UnaryOpType::SIGMOID>(device, shape, -1.0f, 1.0f, 1e-1f, 1e-5f);
-        TT_FATAL(allclose);
+        TT_FATAL(allclose, "Error");
     }
     {
         auto allclose = run_test<UnaryOpType::LOG>(device, shape, 0.0f, 1.0f, 1e-1f, 1e-2f);
-        TT_FATAL(allclose);
+        TT_FATAL(allclose, "Error");
     }
     {
         auto allclose = run_test<UnaryOpType::TANH>(device, shape, -1.0f, 1.0f, 1e-1f, 1e-5f);
-        TT_FATAL(allclose);
+        TT_FATAL(allclose, "Error");
     }
 
-    TT_FATAL(tt::tt_metal::CloseDevice(device));
+    TT_FATAL(tt::tt_metal::CloseDevice(device), "Error");
 }
 
 void test_program_cache() {
@@ -276,8 +276,8 @@ void test_program_cache() {
     TT_FATAL(device->num_program_cache_entries() == 4, "There are {} entries", device->num_program_cache_entries());
 
     device->disable_and_clear_program_cache();
-    TT_FATAL(device->num_program_cache_entries() == 0);
-    TT_FATAL(tt::tt_metal::CloseDevice(device));
+    TT_FATAL(device->num_program_cache_entries() == 0, "Error");
+    TT_FATAL(tt::tt_metal::CloseDevice(device), "Error");
 }
 
 int main(int argc, char** argv) {

--- a/tests/tt_eager/ops/test_fold_op.cpp
+++ b/tests/tt_eager/ops/test_fold_op.cpp
@@ -37,7 +37,7 @@ int main(int argc, char **argv) {
         TT_THROW("Test Failed");
     }
 
-    TT_FATAL(pass);
+    TT_FATAL(pass, "Error");
 
     return 0;
 }

--- a/tests/tt_eager/ops/test_layernorm_op.cpp
+++ b/tests/tt_eager/ops/test_layernorm_op.cpp
@@ -47,7 +47,7 @@ int main(int argc, char **argv) {
         TT_THROW("Test Failed");
     }
 
-    TT_FATAL(pass);
+    TT_FATAL(pass, "Error");
 
     return 0;
 }

--- a/tests/tt_eager/ops/test_pad_op.cpp
+++ b/tests/tt_eager/ops/test_pad_op.cpp
@@ -32,8 +32,8 @@ void test_operation_infrastructure() {
     auto output_tensor = ttnn::pad(input_tensor, padded_shape, tt::tt_metal::Array4D({0, 0, 0, 0}), 0);
 
     auto output_shape = output_tensor.get_legacy_shape();
-    TT_FATAL(output_shape == tt::tt_metal::Shape(padded_shape));
-    TT_FATAL(output_shape.without_padding() == tt::tt_metal::Shape(input_shape));
+    TT_FATAL(output_shape == tt::tt_metal::Shape(padded_shape), "Error");
+    TT_FATAL(output_shape.without_padding() == tt::tt_metal::Shape(input_shape), "Error");
 }
 
 int main(int argc, char** argv) {

--- a/tests/tt_eager/ops/test_sliding_window_ops.cpp
+++ b/tests/tt_eager/ops/test_sliding_window_ops.cpp
@@ -425,6 +425,6 @@ int main() {
         }
     }
     log_info(tt::LogTest, "Tests for Sliding window metadata calcations ends");
-    TT_FATAL(tt::tt_metal::CloseDevice(device));
+    TT_FATAL(tt::tt_metal::CloseDevice(device), "Error");
     return 0;
 }

--- a/tests/tt_eager/ops/test_softmax_op.cpp
+++ b/tests/tt_eager/ops/test_softmax_op.cpp
@@ -44,7 +44,7 @@ int main(int argc, char **argv) {
         TT_THROW("Test Failed");
     }
 
-    TT_FATAL(pass);
+    TT_FATAL(pass, "Error");
 
     return 0;
 }

--- a/tests/tt_eager/ops/test_tilize_op.cpp
+++ b/tests/tt_eager/ops/test_tilize_op.cpp
@@ -70,7 +70,7 @@ int main(int argc, char **argv) {
         TT_THROW("Test Failed");
     }
 
-    TT_FATAL(pass);
+    TT_FATAL(pass, "Error");
 
     return 0;
 }

--- a/tests/tt_eager/ops/test_tilize_op_channels_last.cpp
+++ b/tests/tt_eager/ops/test_tilize_op_channels_last.cpp
@@ -70,7 +70,7 @@ int main(int argc, char **argv) {
         TT_THROW("Test Failed");
     }
 
-    TT_FATAL(pass);
+    TT_FATAL(pass, "Error");
 
     return 0;
 }

--- a/tests/tt_eager/ops/test_tilize_zero_padding.cpp
+++ b/tests/tt_eager/ops/test_tilize_zero_padding.cpp
@@ -83,7 +83,7 @@ int main(int argc, char **argv) {
         TT_THROW("Test Failed");
     }
 
-    TT_FATAL(pass);
+    TT_FATAL(pass, "Error");
 
     return 0;
 }

--- a/tests/tt_eager/ops/test_tilize_zero_padding_channels_last.cpp
+++ b/tests/tt_eager/ops/test_tilize_zero_padding_channels_last.cpp
@@ -84,7 +84,7 @@ int main(int argc, char **argv) {
         TT_THROW("Test Failed");
     }
 
-    TT_FATAL(pass);
+    TT_FATAL(pass, "Error");
 
     return 0;
 }

--- a/tests/tt_eager/ops/test_transpose_op.cpp
+++ b/tests/tt_eager/ops/test_transpose_op.cpp
@@ -64,7 +64,7 @@ int main(int argc, char **argv) {
         TT_THROW("Test Failed");
     }
 
-    TT_FATAL(pass);
+    TT_FATAL(pass, "Error");
 
     return 0;
 }

--- a/tests/tt_eager/ops/test_transpose_wh_multi_core.cpp
+++ b/tests/tt_eager/ops/test_transpose_wh_multi_core.cpp
@@ -22,9 +22,9 @@ using namespace constants;
 //////////////////////////////////////////////////////////////////////////////////////////
 
 Tensor perform_transpose_wh(Tensor& input_tensor) {
-    TT_FATAL(input_tensor.storage_type() == StorageType::OWNED);
+    TT_FATAL(input_tensor.storage_type() == StorageType::OWNED, "Error");
     auto ashape = input_tensor.get_legacy_shape();
-    TT_FATAL(ashape.rank() == 4);
+    TT_FATAL(ashape.rank() == 4, "Error");
     auto bshape = ashape;
     bshape[2] = ashape[3];
     bshape[3] = ashape[2];
@@ -119,7 +119,7 @@ int main(int argc, char **argv) {
         TT_THROW("Test Failed");
     }
 
-    TT_FATAL(pass);
+    TT_FATAL(pass, "Error");
 
     return 0;
 }

--- a/tests/tt_eager/ops/test_transpose_wh_single_core.cpp
+++ b/tests/tt_eager/ops/test_transpose_wh_single_core.cpp
@@ -22,9 +22,9 @@ using namespace constants;
 //////////////////////////////////////////////////////////////////////////////////////////
 
 Tensor perform_transpose_wh(Tensor& input_tensor) {
-    TT_FATAL(input_tensor.storage_type() == StorageType::OWNED);
+    TT_FATAL(input_tensor.storage_type() == StorageType::OWNED, "Error");
     auto ashape = input_tensor.get_legacy_shape();
-    TT_FATAL(ashape.rank() == 4);
+    TT_FATAL(ashape.rank() == 4, "Error");
     auto bshape = ashape;
     bshape[2] = ashape[3];
     bshape[3] = ashape[2];
@@ -119,7 +119,7 @@ int main(int argc, char **argv) {
         TT_THROW("Test Failed");
     }
 
-    TT_FATAL(pass);
+    TT_FATAL(pass, "Error");
 
     return 0;
 }

--- a/tests/tt_eager/tensors/test_copy_and_move.cpp
+++ b/tests/tt_eager/tensors/test_copy_and_move.cpp
@@ -238,7 +238,7 @@ int main(int argc, char **argv) {
         TT_THROW("Test Failed");
     }
 
-    TT_FATAL(pass);
+    TT_FATAL(pass, "Error");
 
     return 0;
 }

--- a/tests/tt_eager/tensors/test_host_device_loopback.cpp
+++ b/tests/tt_eager/tensors/test_host_device_loopback.cpp
@@ -78,7 +78,7 @@ int main(int argc, char **argv) {
         TT_THROW("Test Failed");
     }
 
-    TT_FATAL(pass);
+    TT_FATAL(pass, "Error");
 
     return 0;
 }

--- a/tests/tt_eager/tensors/test_ranks.cpp
+++ b/tests/tt_eager/tensors/test_ranks.cpp
@@ -146,7 +146,7 @@ int main(int argc, char **argv) {
         TT_THROW("Test Failed");
     }
 
-    TT_FATAL(pass);
+    TT_FATAL(pass, "Error");
 
     return 0;
 }

--- a/tests/tt_eager/tensors/test_raw_host_memory_pointer.cpp
+++ b/tests/tt_eager/tensors/test_raw_host_memory_pointer.cpp
@@ -180,7 +180,7 @@ void test_raw_host_memory_pointer() {
         TT_ASSERT(element == bfloat16(10.0f));
     }
 
-    TT_FATAL(tt::tt_metal::CloseDevice(device));
+    TT_FATAL(tt::tt_metal::CloseDevice(device), "Error");
 }
 
 int main() {

--- a/tests/tt_metal/llrt/test_libs/conv_pattern.hpp
+++ b/tests/tt_metal/llrt/test_libs/conv_pattern.hpp
@@ -18,9 +18,9 @@ class ConvParameters {
         uint32_t PadW = 0;
         ConvParameters(uint32_t r, uint32_t s,  uint32_t u,  uint32_t v,  uint32_t padH,  uint32_t padW) :
         R(r), S(s), U(u), V(v), PadH(padH), PadW(padW) {
-            TT_FATAL(U > 0 and V > 0);
-            TT_FATAL(R > 0 and S > 0);
-            TT_FATAL(PadH >= 0 and PadW >= 0);
+            TT_FATAL(U > 0 and V > 0, "Error");
+            TT_FATAL(R > 0 and S > 0, "Error");
+            TT_FATAL(PadH >= 0 and PadW >= 0, "Error");
         }
         void print() {
             std::cout << "Printing conv params" << std::endl;
@@ -82,8 +82,8 @@ template <typename T>
 std::vector<T> untilize_act(std::vector<T> tilized_act,
                                             std::uint32_t output_rows,
                                             std::uint32_t output_cols) {
-    TT_FATAL(output_rows % TILE_HEIGHT == 0);
-    TT_FATAL(output_cols % TILE_WIDTH == 0);
+    TT_FATAL(output_rows % TILE_HEIGHT == 0, "Error");
+    TT_FATAL(output_cols % TILE_WIDTH == 0, "Error");
     uint32_t num_tiles_c = output_cols / TILE_WIDTH;
     uint32_t num_tiles_r = output_rows / TILE_HEIGHT;
     std::vector<T> untilized_act;
@@ -144,8 +144,8 @@ std::vector<std::vector<T>> untilize_weights(std::vector<T> tilized_weights,
 // transform it back to row major full tensor. (This function inverts the tilize() function)
 template <typename T>
 std::vector<T> untilize(std::vector<T> data, int rows, int cols) {
-    TT_FATAL(rows % TILE_HEIGHT == 0);
-    TT_FATAL(cols % TILE_WIDTH == 0);
+    TT_FATAL(rows % TILE_HEIGHT == 0, "Error");
+    TT_FATAL(cols % TILE_WIDTH == 0, "Error");
     int num_tiles_r = rows / TILE_HEIGHT;
     int num_tiles_c = cols / TILE_WIDTH;
     std::vector<T> result;
@@ -169,8 +169,8 @@ std::vector<T> untilize(std::vector<T> data, int rows, int cols) {
 
 template <typename T>
 std::vector<T> tilize_2d_matrix(std::vector<std::vector<T>> row_major_matrix) {
-    TT_FATAL(row_major_matrix.size() % TILE_HEIGHT == 0);
-    TT_FATAL(row_major_matrix.at(0).size() % TILE_WIDTH == 0);
+    TT_FATAL(row_major_matrix.size() % TILE_HEIGHT == 0, "Error");
+    TT_FATAL(row_major_matrix.at(0).size() % TILE_WIDTH == 0, "Error");
     int num_tiles_r = row_major_matrix.size() / TILE_HEIGHT;
     int num_tiles_c = row_major_matrix.at(0).size() / TILE_WIDTH;
     std::vector<T> result;
@@ -248,8 +248,8 @@ std::vector<std::vector<T>> move_weights_dram_to_l1_mm(tt::deprecated::Tensor<T>
 // is contiguous
 template <typename T>
 std::vector<T> tilize(std::vector<T> data, int rows, int cols) {
-    TT_FATAL(rows % TILE_HEIGHT == 0);
-    TT_FATAL(cols % TILE_WIDTH == 0);
+    TT_FATAL(rows % TILE_HEIGHT == 0, "Error");
+    TT_FATAL(cols % TILE_WIDTH == 0, "Error");
     int num_tiles_r = rows / TILE_HEIGHT;
     int num_tiles_c = cols / TILE_WIDTH;
     std::vector<T> result;

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/8_dram_adjacent_core_read/test_dram_read.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/8_dram_adjacent_core_read/test_dram_read.cpp
@@ -598,7 +598,7 @@ int main(int argc, char **argv) {
             input_size = k * n * 2;
             tile_format = tt::DataFormat::Float16_b;
         } else {
-            TT_FATAL("input data format invalid");
+            TT_FATAL(false, "Input data format {} is invalid. Please change.", df);
         }
         uint32_t kt = k / 32;
         uint32_t nt = n / 32;

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/8_dram_adjacent_core_read/test_dram_read.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/8_dram_adjacent_core_read/test_dram_read.cpp
@@ -598,7 +598,7 @@ int main(int argc, char **argv) {
             input_size = k * n * 2;
             tile_format = tt::DataFormat::Float16_b;
         } else {
-            TT_FATAL(false, "Input data format {} is invalid. Please change.", df);
+            TT_THROW("Input data format {} is invalid. Please change.", df);
         }
         uint32_t kt = k / 32;
         uint32_t nt = n / 32;

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/common.h
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/common.h
@@ -813,7 +813,7 @@ inline void gen_bare_dispatcher_unicast_write_cmd(Device *device,
     cmd.write_linear.length = length;
     cmd.write_linear.num_mcast_dests = 0;
 
-    TT_FATAL((cmd.write_linear.addr & (L1_ALIGNMENT - 1)) == 0);
+    TT_FATAL((cmd.write_linear.addr & (L1_ALIGNMENT - 1)) == 0, "Error");
 
     add_bare_dispatcher_cmd(cmds, cmd);
 }
@@ -930,7 +930,7 @@ inline void gen_dispatcher_packed_write_cmd(Device *device,
     cmd.write_packed.size = size_words * sizeof(uint32_t);
 
     uint32_t sub_cmds_size = padded_size(worker_cores.size() * sizeof(CQDispatchWritePackedUnicastSubCmd), sizeof(CQDispatchCmd));
-    TT_FATAL(repeat == false || size_words * sizeof(uint32_t) + sizeof(CQDispatchCmd) + sub_cmds_size <= dispatch_buffer_page_size_g);
+    TT_FATAL(repeat == false || size_words * sizeof(uint32_t) + sizeof(CQDispatchCmd) + sub_cmds_size <= dispatch_buffer_page_size_g, "Error");
 
     add_dispatcher_packed_cmd(device, cmds, worker_cores, device_data, cmd, size_words, repeat);
 }

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/test_dispatcher.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/test_dispatcher.cpp
@@ -539,7 +539,8 @@ int main(int argc, char **argv) {
             log_info(LogTest, "Running packed write unicast");
             break;
         case 5:
-            TT_FATAL(false, "Unknown test type {}", test_type_g);
+            log_info(LogTest, "Running alternate packed write unicast");
+            break;
         }
 
         log_info(LogTest, "Worker grid {}", all_workers_g.str());

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/test_dispatcher.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/test_dispatcher.cpp
@@ -539,7 +539,7 @@ int main(int argc, char **argv) {
             log_info(LogTest, "Running packed write unicast");
             break;
         case 5:
-            TT_FATAL("Unknown test type {}", test_type_g);
+            TT_FATAL(false, "Unknown test type {}", test_type_g);
         }
 
         log_info(LogTest, "Worker grid {}", all_workers_g.str());

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/old/matmul/matmul_global_l1.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/old/matmul/matmul_global_l1.cpp
@@ -930,8 +930,8 @@ tt_metal::Program create_program_mcast_in0_in1(
 // is contiguous
 template <typename T>
 std::vector<T> tilize(std::vector<T> data, int rows, int cols) {
-  TT_FATAL(rows % 32 == 0);
-  TT_FATAL(cols % 32 == 0);
+  TT_FATAL(rows % 32 == 0, "Error");
+  TT_FATAL(cols % 32 == 0, "Error");
   int num_tiles_r = rows / 32;
   int num_tiles_c = cols / 32;
   std::vector<T> result;
@@ -957,8 +957,8 @@ std::vector<T> tilize(std::vector<T> data, int rows, int cols) {
 // tilize() function)
 template <typename T>
 std::vector<T> untilize(std::vector<T> data, int rows, int cols) {
-  TT_FATAL(rows % 32 == 0);
-  TT_FATAL(cols % 32 == 0);
+  TT_FATAL(rows % 32 == 0, "Error");
+  TT_FATAL(cols % 32 == 0, "Error");
   int num_tiles_r = rows / 32;
   int num_tiles_c = cols / 32;
   std::vector<T> result;
@@ -1174,20 +1174,20 @@ int main(int argc, char** argv) {
     //                      Matmul Parameters Setup
     ////////////////////////////////////////////////////////////////////////////
     uint32_t B = 1;
-    TT_FATAL(Kt % in0_block_w == 0);
+    TT_FATAL(Kt % in0_block_w == 0, "Error");
 
     uint32_t num_blocks_y = (Mt - 1) / per_core_Mt + 1;
     uint32_t num_blocks_x = (Nt - 1) / per_core_Nt + 1;
     uint32_t num_blocks_total = num_blocks_y * num_blocks_x;
-    TT_FATAL(num_blocks_total <= num_cores_x * num_cores_y);
+    TT_FATAL(num_blocks_total <= num_cores_x * num_cores_y, "Error");
     CoreCoord core_range =
         get_core_range(num_blocks_y, num_blocks_x, num_cores_y, num_cores_x);
-    TT_FATAL(num_cores_y == core_range.y && num_cores_x == core_range.x);
+    TT_FATAL(num_cores_y == core_range.y && num_cores_x == core_range.x, "Error");
 
     ////////////////////////////////////////////////////////////////////////////
     //                      Application Setup
     ////////////////////////////////////////////////////////////////////////////
-    TT_FATAL(core_range.x > 1 && core_range.y > 1);
+    TT_FATAL(core_range.x > 1 && core_range.y > 1, "Error");
     MathFidelity math_fidelity = MathFidelity::HiFi4;
 
     auto program = create_program_mcast_in0_in1(
@@ -1246,7 +1246,7 @@ int main(int argc, char** argv) {
     TT_THROW("Test Failed");
   }
 
-  TT_FATAL(pass);
+  TT_FATAL(pass, "Error");
 
   return 0;
 }

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/old/matmul/matmul_local_l1.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/old/matmul/matmul_local_l1.cpp
@@ -25,8 +25,8 @@ using namespace tt;
 // is contiguous
 template <typename T>
 std::vector<T> tilize(std::vector<T> data, int rows, int cols) {
-    TT_FATAL(rows % 32 == 0);
-    TT_FATAL(cols % 32 == 0);
+    TT_FATAL(rows % 32 == 0, "Error");
+    TT_FATAL(cols % 32 == 0, "Error");
     int num_tiles_r = rows / 32;
     int num_tiles_c = cols / 32;
     std::vector<T> result;
@@ -52,8 +52,8 @@ std::vector<T> tilize(std::vector<T> data, int rows, int cols) {
 // tilize() function)
 template <typename T>
 std::vector<T> untilize(std::vector<T> data, int rows, int cols) {
-    TT_FATAL(rows % 32 == 0);
-    TT_FATAL(cols % 32 == 0);
+    TT_FATAL(rows % 32 == 0, "Error");
+    TT_FATAL(cols % 32 == 0, "Error");
     int num_tiles_r = rows / 32;
     int num_tiles_c = cols / 32;
     std::vector<T> result;
@@ -245,13 +245,13 @@ int main(int argc, char **argv) {
     if (Mt % num_cores_r != 0) {
       TT_THROW("Mt {} must be a multiple of num_cores_r {}", Mt,
                 num_cores_r);
-      TT_FATAL(false);
+      TT_FATAL(false, "Error");
     }
 
     if (Nt % num_cores_c != 0) {
       TT_THROW("Nt {} must be a multiple of num_cores_c {}", Nt,
                 num_cores_c);
-      TT_FATAL(false);
+      TT_FATAL(false, "Error");
     }
 
     tt::DataFormat data_format = tt::DataFormat::Float16_b;
@@ -285,7 +285,7 @@ int main(int argc, char **argv) {
     if (output_addr + (per_core_output_tiles * single_tile_size) >
         1024 * 1024) {
       log_error(LogTest, "inputs and output CBs don't fit in L1");
-      TT_FATAL(false);
+      TT_FATAL(false, "Error");
     }
 
     SHAPE shape = {1, 1, Mt * 32, Kt * 32};
@@ -319,7 +319,7 @@ int main(int argc, char **argv) {
             pack_bfloat16_vec_into_uint32_vec(activations_tile_layout);
         pass &= tt_metal::detail::WriteToDeviceL1(
             device, core, activations_addr, activations);
-        TT_FATAL(pass);
+        TT_FATAL(pass, "Error");
 
         auto identity_tilized =
             tilize(weights_slice, Kt * 32, per_core_Nt * 32);
@@ -329,7 +329,7 @@ int main(int argc, char **argv) {
             transpose_tiles(weights, Kt, per_core_Nt, 1);
         pass &= tt_metal::detail::WriteToDeviceL1(device, core, weights_addr,
                                                   weights_tile_transposed);
-        TT_FATAL(pass);
+        TT_FATAL(pass, "Error");
       }
     }
 
@@ -456,7 +456,7 @@ int main(int argc, char **argv) {
     TT_THROW("Test Failed");
   }
 
-  TT_FATAL(pass);
+  TT_FATAL(pass, "Error");
 
   return 0;
 }

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/old/noc/test_noc_read_global_l1.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/old/noc/test_noc_read_global_l1.cpp
@@ -101,7 +101,7 @@ int main(int argc, char **argv) {
         // for convenience
         if (Nt % cb_n != 0) {
             log_error(LogTest, "activations({} tiles) should be divided cb buffer ({} tiles)", Nt, cb_n);
-            TT_FATAL(false);
+            TT_FATAL(false, "Error");
         }
 
         tt::DataFormat data_format = tt::DataFormat::Float16_b;
@@ -349,7 +349,7 @@ int main(int argc, char **argv) {
         TT_THROW("Test Failed");
     }
 
-    TT_FATAL(pass);
+    TT_FATAL(pass, "Error");
 
     return 0;
 }

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/old/noc/test_noc_read_local_l1.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/old/noc/test_noc_read_local_l1.cpp
@@ -93,7 +93,7 @@ int main(int argc, char **argv) {
         // for convenience
         if (Nt % cb_n != 0) {
             log_error(LogTest, "activations({} tiles) should be divided cb buffer ({} tiles)", Nt, cb_n);
-            TT_FATAL(false);
+            TT_FATAL(false, "Error");
         }
 
         tt::DataFormat data_format = tt::DataFormat::Float16_b;
@@ -165,7 +165,7 @@ int main(int argc, char **argv) {
 
         if (activations_addr + total_tiles_size_bytes > 1024 * 1024) {
             log_error(LogTest, "cb and activations buffer exceeds local L1 size");
-            TT_FATAL(false);
+            TT_FATAL(false, "Error");
         }
 
         // copy activation to l1 buffer
@@ -283,7 +283,7 @@ int main(int argc, char **argv) {
         TT_THROW("Test Failed");
     }
 
-    TT_FATAL(pass);
+    TT_FATAL(pass, "Error");
 
     return 0;
 }

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/old/pcie/test_enqueue_rw_buffer.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/old/pcie/test_enqueue_rw_buffer.cpp
@@ -131,7 +131,7 @@ int main(int argc, char** argv) {
     TT_THROW("Test Failed");
   }
 
-  TT_FATAL(pass);
+  TT_FATAL(pass, "Error");
 
   return 0;
 }

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/old/pcie/test_rw_buffer.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/old/pcie/test_rw_buffer.cpp
@@ -128,6 +128,6 @@ int main(int argc, char** argv) {
     TT_THROW("Test Failed");
   }
 
-  TT_FATAL(pass);
+  TT_FATAL(pass, "Error");
   return 0;
 }

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/old/pcie/test_rw_device_dram.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/old/pcie/test_rw_device_dram.cpp
@@ -113,6 +113,6 @@ int main(int argc, char** argv) {
     TT_THROW("Test Failed");
   }
 
-  TT_FATAL(pass);
+  TT_FATAL(pass, "Error");
   return 0;
 }

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/old/pcie/test_rw_device_l1.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/old/pcie/test_rw_device_l1.cpp
@@ -97,6 +97,6 @@ int main(int argc, char** argv) {
     TT_THROW("Test Failed");
   }
 
-  TT_FATAL(pass);
+  TT_FATAL(pass, "Error");
   return 0;
 }

--- a/tests/tt_metal/tt_metal/test_add_two_ints.cpp
+++ b/tests/tt_metal/tt_metal/test_add_two_ints.cpp
@@ -90,7 +90,7 @@ int main(int argc, char **argv) {
         TT_THROW("Test Failed");
     }
 
-    TT_FATAL(pass);
+    TT_FATAL(pass, "Error");
 
 
     return 0;

--- a/tests/tt_metal/tt_metal/test_bcast.cpp
+++ b/tests/tt_metal/tt_metal/test_bcast.cpp
@@ -26,7 +26,7 @@ using std::vector;
 
 namespace {
 const char* get_reader_name(bool multibank, BcastDim::Enum bcast_dim) {
-    TT_FATAL(multibank && "Only multibank is supported correctly.");
+    TT_FATAL(multibank && "Only multibank is supported correctly.", "Error");
     if (bcast_dim == BcastDim::H) {
         return multibank ?
             "tests/tt_metal/tt_metal/test_kernels/dataflow/reader_bcast_h_8bank.cpp" :
@@ -40,7 +40,7 @@ const char* get_reader_name(bool multibank, BcastDim::Enum bcast_dim) {
             "tests/tt_metal/tt_metal/test_kernels/dataflow/reader_bcast_hw_8bank.cpp" :
             "tt_metal/kernels/dataflow/reader_binary_diff_lengths.cpp";
     }
-    TT_FATAL(false && "Unexpected bcast_dim!");
+    TT_FATAL(false && "Unexpected bcast_dim!", "Error");
     return "";
 }
 
@@ -49,7 +49,7 @@ const char* get_compute_name(BcastDim::Enum bcast_dim) {
         case BcastDim::H:  return "tests/tt_metal/tt_metal/test_kernels/compute/bcast_h.cpp";
         case BcastDim::W:  return "tests/tt_metal/tt_metal/test_kernels/compute/bcast_w.cpp";
         case BcastDim::HW: return "tests/tt_metal/tt_metal/test_kernels/compute/bcast_hw.cpp";
-        default:           TT_FATAL(false && "Unexpected bcast_dim!");
+        default:           TT_FATAL(false && "Unexpected bcast_dim!", "Error");
     }
     return "";
 }
@@ -101,8 +101,8 @@ int main(int argc, char **argv) {
         vector<uint32_t> shape = {2, 4, 2*TILE_HEIGHT, 3*TILE_WIDTH};
         uint32_t W = shape[3], H = shape[2], NC = shape[1]*shape[0], N = shape[0], C = shape[1];
         uint32_t HW = H*W;
-        TT_FATAL(W % TILE_WIDTH == 0 && H % TILE_HEIGHT == 0);
-        TT_FATAL(H > 0 && W > 0 && NC > 0);
+        TT_FATAL(W % TILE_WIDTH == 0 && H % TILE_HEIGHT == 0, "Error");
+        TT_FATAL(H > 0 && W > 0 && NC > 0, "Error");
         uint32_t Wt = W/TILE_WIDTH;
         uint32_t Ht = H/TILE_HEIGHT;
         uint32_t num_tensor_tiles = NC*H*W / (32*32);
@@ -164,7 +164,7 @@ int main(int argc, char **argv) {
             // convert the reference broadcast tensor to tiled format
             tiled_bcast_values = convert_layout<uint16_t>(
                 ref_bcast_values, ref_bcast_shape, TensorLayout::LIN_ROW_MAJOR, TensorLayout::TILED32_4FACES);
-            TT_FATAL(tiled_bcast_values[0] == bcast_1value16);
+            TT_FATAL(tiled_bcast_values[0] == bcast_1value16, "Error");
             // restore ref values and shape to 1
             ref_bcast_shape[3] = 1;
             ref_bcast_shape[4] = 1;
@@ -173,7 +173,7 @@ int main(int argc, char **argv) {
             // At least that's the behavior i've seen from a single tile bcast-H
             // So this is why here we create a W-sized vector
             // Same for the if branch for BCAST_W below
-            TT_FATAL(W%32 == 0);
+            TT_FATAL(W%32 == 0, "Error");
             // pad values and shape with extra 32 values because the reader kernel expects it
             // generate broadcast values along the W axis with one extra tile (needed by the kernel I believe)
             // TODO(AP): need to figure out why the extra tile in broadcast inputs is expected by the kernel
@@ -346,7 +346,7 @@ int main(int argc, char **argv) {
         TT_THROW("Test Failed");
     }
 
-    TT_FATAL(pass);
+    TT_FATAL(pass, "Error");
 
     return 0;
 }

--- a/tests/tt_metal/tt_metal/test_bfp4_conversion.cpp
+++ b/tests/tt_metal/tt_metal/test_bfp4_conversion.cpp
@@ -50,7 +50,7 @@ int main(int argc, char **argv) {
         // Ensure that passing in row_major_input=true and row_major_output=true are inverses of row_major_input=false and row_major_output=false yield the same result
         pass &= (packed_bfp4b_tile_vec_rm_in == packed_bfp4b_tile_vec_tile_in);
 
-        TT_FATAL(unpacked_bfp4b_tile_vec_rm_out.size() == fp32_vec.size());
+        TT_FATAL(unpacked_bfp4b_tile_vec_rm_out.size() == fp32_vec.size(), "Error");
         for (int rm_idx = 0; rm_idx < fp32_vec.size(); rm_idx++) {
             float golden = fp32_vec.at(rm_idx);
             float converted = unpacked_bfp4b_tile_vec_rm_out.at(rm_idx);
@@ -60,7 +60,7 @@ int main(int argc, char **argv) {
             pass &= comp;
         }
 
-        TT_FATAL(unpacked_bfp4b_tile_vec_tile_out.size() == tiled_fp32_vec.size());
+        TT_FATAL(unpacked_bfp4b_tile_vec_tile_out.size() == tiled_fp32_vec.size(), "Error");
         for (int rm_idx = 0; rm_idx < fp32_vec.size(); rm_idx++) {
             float golden = tiled_fp32_vec.at(rm_idx);
             float converted = unpacked_bfp4b_tile_vec_tile_out.at(rm_idx);
@@ -87,7 +87,7 @@ int main(int argc, char **argv) {
         TT_THROW("Test Failed");
     }
 
-    TT_FATAL(pass);
+    TT_FATAL(pass, "Error");
 
     return 0;
 }

--- a/tests/tt_metal/tt_metal/test_bfp8_conversion.cpp
+++ b/tests/tt_metal/tt_metal/test_bfp8_conversion.cpp
@@ -50,7 +50,7 @@ int main(int argc, char **argv) {
         // Ensure that passing in row_major_input=true and row_major_output=true are inverses of row_major_input=false and row_major_output=false yield the same result
         pass &= (packed_bfp8b_tile_vec_rm_in == packed_bfp8b_tile_vec_tile_in);
 
-        TT_FATAL(unpacked_bfp8b_tile_vec_rm_out.size() == fp32_vec.size());
+        TT_FATAL(unpacked_bfp8b_tile_vec_rm_out.size() == fp32_vec.size(), "Error");
         for (int rm_idx = 0; rm_idx < fp32_vec.size(); rm_idx++) {
             float golden = fp32_vec.at(rm_idx);
             float converted = unpacked_bfp8b_tile_vec_rm_out.at(rm_idx);
@@ -60,7 +60,7 @@ int main(int argc, char **argv) {
             pass &= comp;
         }
 
-        TT_FATAL(unpacked_bfp8b_tile_vec_tile_out.size() == tiled_fp32_vec.size());
+        TT_FATAL(unpacked_bfp8b_tile_vec_tile_out.size() == tiled_fp32_vec.size(), "Error");
         for (int rm_idx = 0; rm_idx < fp32_vec.size(); rm_idx++) {
             float golden = tiled_fp32_vec.at(rm_idx);
             float converted = unpacked_bfp8b_tile_vec_tile_out.at(rm_idx);
@@ -87,7 +87,7 @@ int main(int argc, char **argv) {
         TT_THROW("Test Failed");
     }
 
-    TT_FATAL(pass);
+    TT_FATAL(pass, "Error");
 
     return 0;
 }

--- a/tests/tt_metal/tt_metal/test_bmm.cpp
+++ b/tests/tt_metal/tt_metal/test_bmm.cpp
@@ -194,7 +194,7 @@ int main(int argc, char **argv) {
         TT_THROW("Test Failed");
     }
 
-    TT_FATAL(pass);
+    TT_FATAL(pass, "Error");
 
     return 0;
 }

--- a/tests/tt_metal/tt_metal/test_clean_init.cpp
+++ b/tests/tt_metal/tt_metal/test_clean_init.cpp
@@ -150,7 +150,7 @@ int main(int argc, char **argv) {
     }
 
     // Error out with non-zero return code if we don't detect a pass
-    TT_FATAL(pass);
+    TT_FATAL(pass, "Error");
 
     return 0;
 }

--- a/tests/tt_metal/tt_metal/test_compile_args.cpp
+++ b/tests/tt_metal/tt_metal/test_compile_args.cpp
@@ -114,7 +114,7 @@ int main(int argc, char **argv) {
         TT_THROW("Test Failed");
     }
 
-    TT_FATAL(pass);
+    TT_FATAL(pass, "Error");
 
     return 0;
 }

--- a/tests/tt_metal/tt_metal/test_compile_program.cpp
+++ b/tests/tt_metal/tt_metal/test_compile_program.cpp
@@ -50,7 +50,7 @@ std::unordered_map<std::string, std::string> get_last_program_binary_path(const 
                 latest_hash = dir_entry.path().filename().string();
             }
         }
-        TT_FATAL(not latest_hash.empty());
+        TT_FATAL(not latest_hash.empty(), "Error");
         kernel_name_to_last_compiled_dir.insert({kernel->name(), latest_hash});
     }
     return kernel_name_to_last_compiled_dir;
@@ -371,7 +371,7 @@ int main(int argc, char **argv) {
         TT_THROW("Test Failed");
     }
 
-    TT_FATAL(pass);
+    TT_FATAL(pass, "Error");
     return 0;
 
 }

--- a/tests/tt_metal/tt_metal/test_compile_sets_kernel_binaries.cpp
+++ b/tests/tt_metal/tt_metal/test_compile_sets_kernel_binaries.cpp
@@ -23,8 +23,8 @@ using namespace tt;
 
 std::string get_latest_kernel_binary_path(uint32_t mask, const std::shared_ptr<Kernel> kernel) {
     auto root_dir = jit_build_get_kernel_compile_outpath(mask);
-    TT_FATAL(kernel != nullptr);
-    TT_FATAL(std::filesystem::exists(root_dir + kernel->name()));
+    TT_FATAL(kernel != nullptr, "Error");
+    TT_FATAL(std::filesystem::exists(root_dir + kernel->name()), "Error");
 
     std::filesystem::path kernel_path{root_dir + kernel->name()};
     std::filesystem::file_time_type ftime = std::filesystem::last_write_time(*kernel_path.begin());
@@ -36,7 +36,7 @@ std::string get_latest_kernel_binary_path(uint32_t mask, const std::shared_ptr<K
             latest_hash = dir_entry.path().filename().string();
         }
     }
-    TT_FATAL(not latest_hash.empty());
+    TT_FATAL(not latest_hash.empty(), "Error");
     return kernel->name() + "/" + latest_hash;
 }
 
@@ -140,7 +140,8 @@ int main(int argc, char **argv) {
             const KernelGroup* kernel_group = program.kernels_on_core(core, programmable_core_index);
             TT_FATAL(
                 kernel_group != nullptr && kernel_group->kernel_ids[DISPATCH_CLASS_TENSIX_COMPUTE].has_value() and
-                kernel_group->kernel_ids[DISPATCH_CLASS_TENSIX_DM0].has_value() and kernel_group->kernel_ids[DISPATCH_CLASS_TENSIX_DM1].has_value());
+                kernel_group->kernel_ids[DISPATCH_CLASS_TENSIX_DM0].has_value() and kernel_group->kernel_ids[DISPATCH_CLASS_TENSIX_DM1].has_value(),
+                "Error");
             auto compute_kernel = tt_metal::detail::GetKernel(program, kernel_group->kernel_ids[DISPATCH_CLASS_TENSIX_COMPUTE].value());
             auto riscv0_kernel = tt_metal::detail::GetKernel(program, kernel_group->kernel_ids[DISPATCH_CLASS_TENSIX_DM0].value());
             auto riscv1_kernel = tt_metal::detail::GetKernel(program, kernel_group->kernel_ids[DISPATCH_CLASS_TENSIX_DM1].value());
@@ -182,9 +183,9 @@ int main(int argc, char **argv) {
                         auto compute_kernel = tt_metal::detail::GetKernel(program, kernel_group->kernel_ids[DISPATCH_CLASS_TENSIX_COMPUTE].value());
                         auto riscv0_kernel = tt_metal::detail::GetKernel(program, kernel_group->kernel_ids[DISPATCH_CLASS_TENSIX_DM0].value());
                         auto riscv1_kernel = tt_metal::detail::GetKernel(program, kernel_group->kernel_ids[DISPATCH_CLASS_TENSIX_DM1].value());
-                        TT_FATAL(compute_kernel->binaries(mask) == compute_binaries.at(mask));
-                        TT_FATAL(riscv0_kernel->binaries(mask) == brisc_binaries.at(mask));
-                        TT_FATAL(riscv1_kernel->binaries(mask) == ncrisc_binaries.at(mask));
+                        TT_FATAL(compute_kernel->binaries(mask) == compute_binaries.at(mask), "Error");
+                        TT_FATAL(riscv0_kernel->binaries(mask) == brisc_binaries.at(mask), "Error");
+                        TT_FATAL(riscv1_kernel->binaries(mask) == ncrisc_binaries.at(mask), "Error");
 
                         std::string brisc_hex_path = device->build_kernel_target_path(
                             JitBuildProcessorType::DATA_MOVEMENT,
@@ -239,7 +240,7 @@ int main(int argc, char **argv) {
         TT_THROW("Test Failed");
     }
 
-    TT_FATAL(pass);
+    TT_FATAL(pass, "Error");
 
     return 0;
 }

--- a/tests/tt_metal/tt_metal/test_core_range_set.cpp
+++ b/tests/tt_metal/tt_metal/test_core_range_set.cpp
@@ -28,18 +28,18 @@ void check_program_is_mapped_to_correct_cores(const tt_metal::Program &program, 
                 auto logical_core = CoreCoord{x, y};
                 for (size_t kernel_id = 0; kernel_id < program.num_kernels(); kernel_id++) {
                     auto kernel = tt_metal::detail::GetKernel(program, kernel_id);
-                    TT_FATAL(kernel->is_on_logical_core(logical_core));
+                    TT_FATAL(kernel->is_on_logical_core(logical_core), "Error");
                     // Check that compute kernel compile time args are mapped to the correct cores
                     if (kernel->processor() == tt::RISCV::COMPUTE) {
                         auto kernel_compile_time_args = kernel->compile_time_args();
-                        TT_FATAL(kernel_compile_time_args == compute_kernel_args);
+                        TT_FATAL(kernel_compile_time_args == compute_kernel_args, "Error");
                     }
                 }
                 for (auto cb : program.circular_buffers()) {
-                    TT_FATAL(cb->is_on_logical_core(logical_core));
+                    TT_FATAL(cb->is_on_logical_core(logical_core), "Error");
                 }
                 for (auto semaphore : program.semaphores() ){
-                    TT_FATAL(semaphore.initialized_on_logical_core(logical_core));
+                    TT_FATAL(semaphore.initialized_on_logical_core(logical_core), "Error");
                 }
             }
         }
@@ -62,7 +62,7 @@ void check_semaphores_are_initialized(tt_metal::Device *device, tt_metal::Progra
                     filtered_res.push_back(res.at(i));
                 }
 
-                TT_FATAL(filtered_res == golden_sem_values);
+                TT_FATAL(filtered_res == golden_sem_values, "Error");
             }
         }
     }
@@ -196,7 +196,7 @@ bool test_program_specified_with_core_range_set(tt_metal::Device *device, tt_met
         std::vector<uint32_t> result_vec;
         tt_metal::detail::ReadFromBuffer(dst_l1_buffer, result_vec);
         bool copied_data_correctly = src_vec == result_vec;
-        TT_FATAL(copied_data_correctly);
+        TT_FATAL(copied_data_correctly, "Error");
         pass &= copied_data_correctly;
     }
 
@@ -246,7 +246,7 @@ int main(int argc, char **argv) {
         TT_THROW("Test Failed");
     }
 
-    TT_FATAL(pass);
+    TT_FATAL(pass, "Error");
 
     return 0;
 }

--- a/tests/tt_metal/tt_metal/test_datacopy.cpp
+++ b/tests/tt_metal/tt_metal/test_datacopy.cpp
@@ -159,7 +159,7 @@ int main(int argc, char **argv) {
         TT_THROW("Test Failed");
     }
 
-    TT_FATAL(pass);
+    TT_FATAL(pass, "Error");
 
     return 0;
 }

--- a/tests/tt_metal/tt_metal/test_datacopy_bfp8b.cpp
+++ b/tests/tt_metal/tt_metal/test_datacopy_bfp8b.cpp
@@ -44,7 +44,7 @@ int main(int argc, char **argv) {
         CoreCoord core = {0, 0};
 
         uint32_t single_tile_size = tt_metal::detail::TileSize(tt::DataFormat::Bfp8_b);
-        TT_FATAL(single_tile_size == (256 * 4) + (16 *4));
+        TT_FATAL(single_tile_size == (256 * 4) + (16 *4), "Error");
         uint32_t num_tiles = 2048;
         uint32_t dram_buffer_size = single_tile_size * num_tiles; // num_tiles of BFP8_B
 
@@ -159,7 +159,7 @@ int main(int argc, char **argv) {
         TT_THROW("Test Failed");
     }
 
-    TT_FATAL(pass);
+    TT_FATAL(pass, "Error");
 
     return 0;
 }

--- a/tests/tt_metal/tt_metal/test_datacopy_multi_core_multi_dram.cpp
+++ b/tests/tt_metal/tt_metal/test_datacopy_multi_core_multi_dram.cpp
@@ -22,8 +22,8 @@ using namespace tt;
 // is contiguous
 template <typename T>
 std::vector<T> tilize(std::vector<T> data, int rows, int cols) {
-    TT_FATAL(rows % 32 == 0);
-    TT_FATAL(cols % 32 == 0);
+    TT_FATAL(rows % 32 == 0, "Error");
+    TT_FATAL(cols % 32 == 0, "Error");
     int num_tiles_r = rows / 32;
     int num_tiles_c = cols / 32;
     std::vector<T> result;
@@ -95,11 +95,11 @@ std::tuple<tt_metal::Program, tt_metal::KernelHandle, tt_metal::KernelHandle> cr
 
     int num_cores = num_cores_r * num_cores_c;
 
-    TT_FATAL("Error: tensor's tiles don't even distributed across cores." && tensor_num_tiles % num_cores == 0);
+    TT_FATAL("Error: tensor's tiles don't even distributed across cores." && tensor_num_tiles % num_cores == 0, "Error");
     int num_tiles_per_core = tensor_num_tiles / num_cores;
 
-    TT_FATAL("Error: block must fit to half-dst" && block_num_tiles <= 8); // half-dst in GS
-    TT_FATAL("Error: num tiles per core needs to be divisible by block size." && num_tiles_per_core % block_num_tiles == 0);
+    TT_FATAL("Error: block must fit to half-dst" && block_num_tiles <= 8, "Error"); // half-dst in GS
+    TT_FATAL("Error: num tiles per core needs to be divisible by block size." && num_tiles_per_core % block_num_tiles == 0, "Error");
     int num_blocks_per_core = num_tiles_per_core / block_num_tiles;
 
     uint32_t single_tile_size = 2 * 1024; // bfloat16
@@ -111,8 +111,8 @@ std::tuple<tt_metal::Program, tt_metal::KernelHandle, tt_metal::KernelHandle> cr
     uint32_t out_CB_size = out_CB_tiles * single_tile_size;
     uint32_t out_CB_index = 16;
 
-    TT_FATAL(in0_CB_size <= 130*1024);
-    TT_FATAL(out_CB_size <= 540*1024);
+    TT_FATAL(in0_CB_size <= 130*1024, "Error");
+    TT_FATAL(out_CB_size <= 540*1024, "Error");
 
     CoreCoord start_core{0, 0};
     CoreCoord end_core{(std::size_t)num_cores_c - 1, (std::size_t)num_cores_r - 1};
@@ -135,7 +135,7 @@ std::tuple<tt_metal::Program, tt_metal::KernelHandle, tt_metal::KernelHandle> cr
                 .set_page_size(out_CB_index, single_tile_size);
             auto cb_output = tt_metal::CreateCircularBuffer(program, core, cb_output_config);
 
-            TT_FATAL(l1_valid_address < 1024 * 1024);
+            TT_FATAL(l1_valid_address < 1024 * 1024, "Error");
         }
     }
 
@@ -191,8 +191,8 @@ bool write_runtime_args_to_device(
 
     uint dram_channel_size = 1024 * 1024 * 1024;
 
-    TT_FATAL(src0_dram_addr + dram_buffer_size_act < dram_channel_size);
-    TT_FATAL(dst_dram_addr + dram_buffer_size_out < dram_channel_size);
+    TT_FATAL(src0_dram_addr + dram_buffer_size_act < dram_channel_size, "Error");
+    TT_FATAL(dst_dram_addr + dram_buffer_size_out < dram_channel_size, "Error");
     */
 
     for(int core_idx_y = 0; core_idx_y < num_cores_r; core_idx_y++) {
@@ -439,7 +439,7 @@ int main(int argc, char **argv) {
         TT_THROW("Test Failed");
     }
 
-    TT_FATAL(pass);
+    TT_FATAL(pass, "Error");
 
     return 0;
 }

--- a/tests/tt_metal/tt_metal/test_datacopy_output_in_l1.cpp
+++ b/tests/tt_metal/tt_metal/test_datacopy_output_in_l1.cpp
@@ -172,7 +172,7 @@ int main(int argc, char **argv) {
         TT_THROW("Test Failed");
     }
 
-    TT_FATAL(pass);
+    TT_FATAL(pass, "Did not pass test");
 
     return 0;
 }

--- a/tests/tt_metal/tt_metal/test_dataflow_cb.cpp
+++ b/tests/tt_metal/tt_metal/test_dataflow_cb.cpp
@@ -153,7 +153,7 @@ int main(int argc, char **argv) {
         TT_THROW("Test Failed");
     }
 
-    TT_FATAL(pass);
+    TT_FATAL(pass, "Error");
 
     return 0;
 }

--- a/tests/tt_metal/tt_metal/test_dram_copy_sticks_multi_core.cpp
+++ b/tests/tt_metal/tt_metal/test_dram_copy_sticks_multi_core.cpp
@@ -149,7 +149,7 @@ int main(int argc, char **argv) {
         TT_THROW("Test Failed");
     }
 
-    TT_FATAL(pass);
+    TT_FATAL(pass, "Error");
 
     return 0;
 }

--- a/tests/tt_metal/tt_metal/test_dram_loopback_multi_core.cpp
+++ b/tests/tt_metal/tt_metal/test_dram_loopback_multi_core.cpp
@@ -71,7 +71,7 @@ int main(int argc, char **argv) {
         uint32_t transient_buffer_size_bytes = transient_buffer_size_tiles * single_tile_size;
         std::uint32_t stream_register_address = STREAM_REG_ADDR(0, 12);
 
-        TT_FATAL(num_output_tiles % transient_buffer_size_tiles == 0);
+        TT_FATAL(num_output_tiles % transient_buffer_size_tiles == 0, "Error");
 
         tt_metal::InterleavedBufferConfig dram_config{
                                 .device=device,
@@ -174,6 +174,6 @@ int main(int argc, char **argv) {
         TT_THROW("Test Failed");
     }
 
-    TT_FATAL(pass);
+    TT_FATAL(pass, "Error");
     return 0;
 }

--- a/tests/tt_metal/tt_metal/test_dram_loopback_multi_core_db.cpp
+++ b/tests/tt_metal/tt_metal/test_dram_loopback_multi_core_db.cpp
@@ -76,7 +76,7 @@ int main(int argc, char **argv) {
         uint32_t stream_register_address1 = STREAM_REG_ADDR(0, 12);
         uint32_t stream_register_address2 = STREAM_REG_ADDR(0, 24);
 
-        TT_FATAL(num_output_tiles % transient_buffer_size_tiles == 0);
+        TT_FATAL(num_output_tiles % transient_buffer_size_tiles == 0, "Error");
 
         tt_metal::InterleavedBufferConfig buff_config{
                                 .device=device,
@@ -197,7 +197,7 @@ int main(int argc, char **argv) {
         TT_THROW("Test Failed");
     }
 
-    TT_FATAL(pass);
+    TT_FATAL(pass, "Error");
 
     return 0;
 }

--- a/tests/tt_metal/tt_metal/test_dram_loopback_single_core.cpp
+++ b/tests/tt_metal/tt_metal/test_dram_loopback_single_core.cpp
@@ -123,7 +123,7 @@ int main(int argc, char **argv) {
         TT_THROW("Test Failed");
     }
 
-    TT_FATAL(pass);
+    TT_FATAL(pass, "Error");
 
     return 0;
 }

--- a/tests/tt_metal/tt_metal/test_dram_loopback_single_core_db.cpp
+++ b/tests/tt_metal/tt_metal/test_dram_loopback_single_core_db.cpp
@@ -46,7 +46,7 @@ int main(int argc, char **argv) {
         // We read and write total_l1_buffer_size_tiles / 2 tiles from and to DRAM
         uint32_t l1_buffer_addr = 400 * 1024;
         uint32_t total_l1_buffer_size_tiles = num_tiles / 2;
-        TT_FATAL(total_l1_buffer_size_tiles % 2 == 0);
+        TT_FATAL(total_l1_buffer_size_tiles % 2 == 0, "Error");
         uint32_t total_l1_buffer_size_bytes = total_l1_buffer_size_tiles * single_tile_size;
 
         tt_metal::InterleavedBufferConfig dram_config{
@@ -128,7 +128,7 @@ int main(int argc, char **argv) {
         TT_THROW("Test Failed");
     }
 
-    TT_FATAL(pass);
+    TT_FATAL(pass, "Error");
 
     return 0;
 }

--- a/tests/tt_metal/tt_metal/test_dram_to_l1_multicast.cpp
+++ b/tests/tt_metal/tt_metal/test_dram_to_l1_multicast.cpp
@@ -142,7 +142,7 @@ int main(int argc, char **argv) {
         TT_THROW("Test Failed");
     }
 
-    TT_FATAL(pass);
+    TT_FATAL(pass, "Error");
 
     return 0;
 }

--- a/tests/tt_metal/tt_metal/test_dram_to_l1_multicast_loopback_src.cpp
+++ b/tests/tt_metal/tt_metal/test_dram_to_l1_multicast_loopback_src.cpp
@@ -138,7 +138,7 @@ int main(int argc, char **argv) {
         TT_THROW("Test Failed");
     }
 
-    TT_FATAL(pass);
+    TT_FATAL(pass, "Error");
 
     return 0;
 }

--- a/tests/tt_metal/tt_metal/test_eltwise_binary.cpp
+++ b/tests/tt_metal/tt_metal/test_eltwise_binary.cpp
@@ -204,7 +204,7 @@ int main(int argc, char** argv) {
         TT_THROW("Test Failed");
     }
 
-    TT_FATAL(pass);
+    TT_FATAL(pass, "Error");
 
     return 0;
 }

--- a/tests/tt_metal/tt_metal/test_flatten.cpp
+++ b/tests/tt_metal/tt_metal/test_flatten.cpp
@@ -61,7 +61,7 @@ inline std::vector<uint32_t> gold_standard_flatten(std::vector<uint32_t> src_vec
         start_dram_addr_offset_for_tensor_row += num_tile_cols * 16;
     }
 
-    TT_FATAL(expected_dst_vec.size() == (num_tile_rows * 32) * (num_tile_cols * 16) * 32);
+    TT_FATAL(expected_dst_vec.size() == (num_tile_rows * 32) * (num_tile_cols * 16) * 32, "Error");
     return expected_dst_vec;
 }
 
@@ -196,7 +196,7 @@ int main(int argc, char **argv) {
         //                      Validation & Teardown
         ////////////////////////////////////////////////////////////////////////////
 
-        TT_FATAL(golden.size() == result_vec.size());
+        TT_FATAL(golden.size() == result_vec.size(), "Error");
         pass &= (golden == result_vec);
 
         if (not pass) {
@@ -223,7 +223,7 @@ int main(int argc, char **argv) {
         TT_THROW("Test Failed");
     }
 
-    TT_FATAL(pass);
+    TT_FATAL(pass, "Error");
 
     return 0;
 }

--- a/tests/tt_metal/tt_metal/test_generic_binary_reader_matmul_large_block.cpp
+++ b/tests/tt_metal/tt_metal/test_generic_binary_reader_matmul_large_block.cpp
@@ -23,8 +23,8 @@ using namespace tt;
 // is contiguous
 template <typename T>
 std::vector<T> tilize(std::vector<T> data, int rows, int cols) {
-    TT_FATAL(rows % 32 == 0);
-    TT_FATAL(cols % 32 == 0);
+    TT_FATAL(rows % 32 == 0, "Error");
+    TT_FATAL(cols % 32 == 0, "Error");
     int num_tiles_r = rows / 32;
     int num_tiles_c = cols / 32;
     std::vector<T> result;
@@ -50,8 +50,8 @@ std::vector<T> tilize(std::vector<T> data, int rows, int cols) {
 // transform it back to row major full tensor. (This function inverts the tilize() function)
 template <typename T>
 std::vector<T> untilize(std::vector<T> data, int rows, int cols) {
-    TT_FATAL(rows % 32 == 0);
-    TT_FATAL(cols % 32 == 0);
+    TT_FATAL(rows % 32 == 0, "Error");
+    TT_FATAL(cols % 32 == 0, "Error");
     int num_tiles_r = rows / 32;
     int num_tiles_c = cols / 32;
     std::vector<T> result;
@@ -157,9 +157,9 @@ int main(int argc, char **argv) {
         int in0_block_w = 1;
 
         uint32_t single_tile_size = 2 * 1024;
-        TT_FATAL(M * in0_block_w * single_tile_size * 2 <= 100*1024);
-        TT_FATAL(N * in0_block_w * single_tile_size * 2 <= 100*1024);
-        TT_FATAL(M * N * single_tile_size <= 600*1024);
+        TT_FATAL(M * in0_block_w * single_tile_size * 2 <= 100*1024, "Error");
+        TT_FATAL(N * in0_block_w * single_tile_size * 2 <= 100*1024, "Error");
+        TT_FATAL(M * N * single_tile_size <= 600*1024, "Error");
         uint32_t dram_buffer_size_act = single_tile_size * M * K; // num_tiles of FP16_B, hard-coded in the reader/writer kernels
         uint32_t dram_buffer_size_weights = single_tile_size * K * N; // num_tiles of FP16_B, hard-coded in the reader/writer kernels
         uint32_t dram_buffer_size_out = single_tile_size * M * N; // num_tiles of FP16_B, hard-coded in the reader/writer kernels
@@ -236,7 +236,7 @@ int main(int argc, char **argv) {
         uint32_t src0_num_reads_per_block = src0_num_tiles_per_block * num_addresses_per_tile;
         uint32_t src0_num_bytes_per_block = src0_num_tiles_per_block * single_tile_size;
         uint32_t src1_num_bytes_per_block = src1_num_tiles_per_block * single_tile_size;
-        TT_FATAL(source_addresses.size() == num_blocks * src0_num_reads_per_block);
+        TT_FATAL(source_addresses.size() == num_blocks * src0_num_reads_per_block, "Error");
 
         tt_metal::InterleavedBufferConfig l1_config{
                     .device=device,
@@ -395,7 +395,7 @@ int main(int argc, char **argv) {
         TT_THROW("Test Failed");
     }
 
-    TT_FATAL(pass);
+    TT_FATAL(pass, "Error");
 
     return 0;
 }

--- a/tests/tt_metal/tt_metal/test_gold_impls.hpp
+++ b/tests/tt_metal/tt_metal/test_gold_impls.hpp
@@ -34,7 +34,7 @@ inline std::vector<uint16_t> gold_transpose_hc(std::vector<uint16_t> src_vec, st
     for (int w = 0; w < shape[3]; w++) {
         auto toffs = addrt.offs(n, h, c, w);
         auto offs = addr.offs(n, c, h, w);
-        TT_FATAL(toffs < transposed.size() && offs < src_vec.size());
+        TT_FATAL(toffs < transposed.size() && offs < src_vec.size(), "Error");
         transposed[toffs] = src_vec[offs];
     }
     //log_info(tt::LogVerif, "Prior size = {}", transposed.size());
@@ -78,9 +78,9 @@ inline std::vector<uint16_t> gold_bcast_op(
     BcastOp::Enum bcast_op
 ) {
     uint32_t N = shape[0], C = shape[1], H = shape[2], W = shape[3];
-    TT_FATAL(bcast_dim == BcastDim::W ? bcast_vals.size() == N*C*H : true);
-    TT_FATAL(bcast_dim == BcastDim::H ? bcast_vals.size() == N*C*W : true);
-    TT_FATAL(bcast_dim == BcastDim::HW ? bcast_vals.size() == N*C : true);
+    TT_FATAL(bcast_dim == BcastDim::W ? bcast_vals.size() == N*C*H : true, "Error");
+    TT_FATAL(bcast_dim == BcastDim::H ? bcast_vals.size() == N*C*W : true, "Error");
+    TT_FATAL(bcast_dim == BcastDim::HW ? bcast_vals.size() == N*C : true, "Error");
 
     std::vector<uint32_t> shape_dst{N, C, H, W};
     TensAddr addr(shape);
@@ -97,7 +97,7 @@ inline std::vector<uint16_t> gold_bcast_op(
             case BcastDim::W:  b_index = h + c*H + n*C*H; break; // bcast tensor is nch
             case BcastDim::HW: b_index = c + n*C; break; // bcast tensor is nc
             default:
-            TT_FATAL(false && "Unexpected broadcast mode in gold_bcast_op");
+            TT_FATAL(false && "Unexpected broadcast mode in gold_bcast_op", "Error");
         }
         float bval = bfloat16(bcast_vals[b_index]).to_float();
         float result1 = 0.0f;
@@ -106,7 +106,7 @@ inline std::vector<uint16_t> gold_bcast_op(
             case BcastOp::SUB: result1 = bfloat16(src_vec[offs]).to_float() - bval; break;
             case BcastOp::MUL: result1 = bfloat16(src_vec[offs]).to_float() * bval; break;
             default:
-                TT_FATAL(false && "Unexpected bcast_op");
+                TT_FATAL(false && "Unexpected bcast_op", "Error");
         }
         result[offs] = bfloat16(result1).to_uint16();
     }
@@ -126,10 +126,10 @@ inline std::vector<uint16_t> gold_bmm(
     bool acc16 = false
     )
 {
-    TT_FATAL(shapeB[0] == 1 && shapeA[0] == 1);
-    uint32_t nb = shapeA[1]; TT_FATAL(shapeB[1] == nb);
+    TT_FATAL(shapeB[0] == 1 && shapeA[0] == 1, "Error");
+    uint32_t nb = shapeA[1]; TT_FATAL(shapeB[1] == nb, "Error");
     uint32_t M = shapeA[2];
-    uint32_t K = shapeA[3]; TT_FATAL(shapeB[2] == K);
+    uint32_t K = shapeA[3]; TT_FATAL(shapeB[2] == K, "Error");
     uint32_t N = shapeB[3];
 
     vector<uint32_t> shapeC{1, nb, M, N};

--- a/tests/tt_metal/tt_metal/test_interleaved_l1_buffer.cpp
+++ b/tests/tt_metal/tt_metal/test_interleaved_l1_buffer.cpp
@@ -105,7 +105,7 @@ int main(int argc, char **argv) {
         TT_THROW("Test Failed");
     }
 
-    TT_FATAL(pass);
+    TT_FATAL(pass, "Error");
 
     return 0;
 }

--- a/tests/tt_metal/tt_metal/test_interleaved_layouts.cpp
+++ b/tests/tt_metal/tt_metal/test_interleaved_layouts.cpp
@@ -477,7 +477,7 @@ bool test_interleaved_l1_datacopy(const tt::ARCH& arch) {
 
     std::shared_ptr<tt_metal::Buffer> src, dst;
     if constexpr (src_is_in_l1) {
-        TT_FATAL((buffer_size % num_l1_banks) == 0);
+        TT_FATAL((buffer_size % num_l1_banks) == 0, "Error");
 
 
 
@@ -491,7 +491,7 @@ bool test_interleaved_l1_datacopy(const tt::ARCH& arch) {
             {src->address(), 0, 0, num_pages});
 
     } else {
-        TT_FATAL((buffer_size % num_dram_banks) == 0);
+        TT_FATAL((buffer_size % num_dram_banks) == 0, "Error");
 
 
 
@@ -545,7 +545,7 @@ bool test_interleaved_l1_datacopy(const tt::ARCH& arch) {
 
     pass &= tt_metal::CloseDevice(device);
 
-    TT_FATAL(pass);
+    TT_FATAL(pass, "Error");
 
     return pass;
 }

--- a/tests/tt_metal/tt_metal/test_l1_to_l1_multi_core.cpp
+++ b/tests/tt_metal/tt_metal/test_l1_to_l1_multi_core.cpp
@@ -158,7 +158,7 @@ int main(int argc, char **argv) {
         TT_THROW("Test Failed");
     }
 
-    TT_FATAL(pass);
+    TT_FATAL(pass, "Error");
 
     return 0;
 }

--- a/tests/tt_metal/tt_metal/test_matmul_large_block.cpp
+++ b/tests/tt_metal/tt_metal/test_matmul_large_block.cpp
@@ -22,8 +22,8 @@ using namespace tt;
 // is contiguous
 template <typename T>
 std::vector<T> tilize(std::vector<T> data, int rows, int cols) {
-    TT_FATAL(rows % 32 == 0);
-    TT_FATAL(cols % 32 == 0);
+    TT_FATAL(rows % 32 == 0, "Error");
+    TT_FATAL(cols % 32 == 0, "Error");
     int num_tiles_r = rows / 32;
     int num_tiles_c = cols / 32;
     std::vector<T> result;
@@ -49,8 +49,8 @@ std::vector<T> tilize(std::vector<T> data, int rows, int cols) {
 // transform it back to row major full tensor. (This function inverts the tilize() function)
 template <typename T>
 std::vector<T> untilize(std::vector<T> data, int rows, int cols) {
-    TT_FATAL(rows % 32 == 0);
-    TT_FATAL(cols % 32 == 0);
+    TT_FATAL(rows % 32 == 0, "Error");
+    TT_FATAL(cols % 32 == 0, "Error");
     int num_tiles_r = rows / 32;
     int num_tiles_c = cols / 32;
     std::vector<T> result;
@@ -220,9 +220,9 @@ bool test_matmul_large_block(tt_metal::Device *device, bool activations_rm, bool
         int in0_block_w = K;
 
         uint32_t single_tile_size = 2 * 1024;
-        TT_FATAL(M * in0_block_w * single_tile_size * 2 <= 150*1024);
-        TT_FATAL(N * in0_block_w * single_tile_size * 2 <= 100*1024);
-        TT_FATAL(M * N * single_tile_size <= 600*1024);
+        TT_FATAL(M * in0_block_w * single_tile_size * 2 <= 150*1024, "Error");
+        TT_FATAL(N * in0_block_w * single_tile_size * 2 <= 100*1024, "Error");
+        TT_FATAL(M * N * single_tile_size <= 600*1024, "Error");
         uint32_t dram_buffer_size_act = single_tile_size * M * K; // num_tiles of FP16_B, hard-coded in the reader/writer kernels
         uint32_t dram_buffer_size_weights = single_tile_size * K * N; // num_tiles of FP16_B, hard-coded in the reader/writer kernels
         uint32_t dram_buffer_size_out = single_tile_size * M * N; // num_tiles of FP16_B, hard-coded in the reader/writer kernels
@@ -322,8 +322,8 @@ bool test_matmul_large_block(tt_metal::Device *device, bool activations_rm, bool
 
         create_CBs_for_fused_matmul(program, device, core, activations_rm, output_rm, M, N, in0_block_w, out_subblock_h);
 
-        TT_FATAL(in0_subblock_h * in0_block_w * in0_num_subblocks == in0_block_num_tiles);
-        TT_FATAL(in0_block_w == K);
+        TT_FATAL(in0_subblock_h * in0_block_w * in0_num_subblocks == in0_block_num_tiles, "Error");
+        TT_FATAL(in0_block_w == K, "Error");
 
         vector<uint32_t> compute_kernel_args = {
             uint(in0_block_w),
@@ -494,5 +494,5 @@ int main(int argc, char **argv) {
         TT_THROW("Test Failed");
     }
 
-    TT_FATAL(pass);
+    TT_FATAL(pass, "Error");
 }

--- a/tests/tt_metal/tt_metal/test_matmul_multi_core_multi_dram.cpp
+++ b/tests/tt_metal/tt_metal/test_matmul_multi_core_multi_dram.cpp
@@ -24,8 +24,8 @@ using namespace tt::tt_metal;
 // is contiguous
 template <typename T>
 std::vector<T> tilize(std::vector<T> data, int rows, int cols) {
-    TT_FATAL(rows % 32 == 0);
-    TT_FATAL(cols % 32 == 0);
+    TT_FATAL(rows % 32 == 0, "Error");
+    TT_FATAL(cols % 32 == 0, "Error");
     int num_tiles_r = rows / 32;
     int num_tiles_c = cols / 32;
     std::vector<T> result;
@@ -107,9 +107,9 @@ std::tuple<tt_metal::Program, tt_metal::KernelHandle, tt_metal::KernelHandle> cr
     uint32_t in1_CB_size = in1_block_tiles * 2 * single_tile_size;  // double buffer
     uint32_t out_CB_tiles = per_core_M * per_core_N;
     uint32_t out_CB_size = out_CB_tiles * single_tile_size;
-    TT_FATAL(in0_CB_size <= 130 * 1024);
-    TT_FATAL(in1_CB_size <= 130 * 1024);
-    TT_FATAL(out_CB_size <= 540 * 1024);
+    TT_FATAL(in0_CB_size <= 130 * 1024, "Error");
+    TT_FATAL(in1_CB_size <= 130 * 1024, "Error");
+    TT_FATAL(out_CB_size <= 540 * 1024, "Error");
 
     CoreCoord start_core = {0, 0};
     CoreCoord end_core = {(std::size_t)num_cores_c - 1, (std::size_t)num_cores_r - 1};
@@ -216,9 +216,9 @@ bool assign_runtime_args_to_program(
     uint32_t dram_buffer_size_out =
         single_tile_size * M * N;  // num_tiles of FP16_B, hard-coded in the reader/writer kernels
 
-    TT_FATAL(in0_dram_addr + dram_buffer_size_act < 1024 * 1024 * 1024);
-    TT_FATAL(in1_dram_addr + dram_buffer_size_weights < 1024 * 1024 * 1024);
-    TT_FATAL(out_dram_addr + dram_buffer_size_out < 1024 * 1024 * 1024);
+    TT_FATAL(in0_dram_addr + dram_buffer_size_act < 1024 * 1024 * 1024, "Error");
+    TT_FATAL(in1_dram_addr + dram_buffer_size_weights < 1024 * 1024 * 1024, "Error");
+    TT_FATAL(out_dram_addr + dram_buffer_size_out < 1024 * 1024 * 1024, "Error");
 
     for (int core_idx_y = 0; core_idx_y < num_cores_r; core_idx_y++) {
         for (int core_idx_x = 0; core_idx_x < num_cores_c; core_idx_x++) {
@@ -492,7 +492,7 @@ int main(int argc, char **argv) {
         TT_THROW("Test Failed");
     }
 
-    TT_FATAL(pass);
+    TT_FATAL(pass, "Error");
 
     return 0;
 }

--- a/tests/tt_metal/tt_metal/test_matmul_multi_core_multi_dram_in0_mcast.cpp
+++ b/tests/tt_metal/tt_metal/test_matmul_multi_core_multi_dram_in0_mcast.cpp
@@ -24,8 +24,8 @@ using namespace tt;
 // is contiguous
 template <typename T>
 std::vector<T> tilize(std::vector<T> data, int rows, int cols) {
-    TT_FATAL(rows % 32 == 0);
-    TT_FATAL(cols % 32 == 0);
+    TT_FATAL(rows % 32 == 0, "Error");
+    TT_FATAL(cols % 32 == 0, "Error");
     int num_tiles_r = rows / 32;
     int num_tiles_c = cols / 32;
     std::vector<T> result;
@@ -107,9 +107,9 @@ std::tuple<tt_metal::Program, tt_metal::KernelHandle, tt_metal::KernelHandle, tt
     uint32_t in1_CB_size = in1_block_tiles * 2 * single_tile_size; // double buffer
     uint32_t out_CB_tiles = per_core_M * per_core_N;
     uint32_t out_CB_size = out_CB_tiles * single_tile_size;
-    TT_FATAL(in0_CB_size <= 130*1024);
-    TT_FATAL(in1_CB_size <= 130*1024);
-    TT_FATAL(out_CB_size <= 540*1024);
+    TT_FATAL(in0_CB_size <= 130*1024, "Error");
+    TT_FATAL(in1_CB_size <= 130*1024, "Error");
+    TT_FATAL(out_CB_size <= 540*1024, "Error");
 
     CoreRange all_cores(
         {(std::size_t)start_core_x, (std::size_t)start_core_y},
@@ -240,9 +240,9 @@ bool write_runtime_args_to_device(
     uint32_t dram_buffer_size_weights = single_tile_size * K * N; // num_tiles of FP16_B, hard-coded in the reader/writer kernels
     uint32_t dram_buffer_size_out = single_tile_size * M * N; // num_tiles of FP16_B, hard-coded in the reader/writer kernels
 
-    TT_FATAL(in0_dram_addr + dram_buffer_size_act < 1024 * 1024 * 1024);
-    TT_FATAL(in1_dram_addr + dram_buffer_size_weights < 1024 * 1024 * 1024);
-    TT_FATAL(out_dram_addr + dram_buffer_size_out < 1024 * 1024 * 1024);
+    TT_FATAL(in0_dram_addr + dram_buffer_size_act < 1024 * 1024 * 1024, "Error");
+    TT_FATAL(in1_dram_addr + dram_buffer_size_weights < 1024 * 1024 * 1024, "Error");
+    TT_FATAL(out_dram_addr + dram_buffer_size_out < 1024 * 1024 * 1024, "Error");
 
     for(int core_idx_y = 0; core_idx_y < num_cores_r; core_idx_y++) {
         for(int core_idx_x = 0; core_idx_x < num_cores_c; core_idx_x++) {
@@ -498,7 +498,7 @@ int main(int argc, char **argv) {
         TT_THROW("Test Failed");
     }
 
-    TT_FATAL(pass);
+    TT_FATAL(pass, "Error");
 
     return 0;
 }

--- a/tests/tt_metal/tt_metal/test_matmul_multi_core_multi_dram_in0_mcast_in1_mcast.cpp
+++ b/tests/tt_metal/tt_metal/test_matmul_multi_core_multi_dram_in0_mcast_in1_mcast.cpp
@@ -23,8 +23,8 @@ using namespace tt;
 // is contiguous
 template <typename T>
 std::vector<T> tilize(std::vector<T> data, int rows, int cols) {
-    TT_FATAL(rows % 32 == 0);
-    TT_FATAL(cols % 32 == 0);
+    TT_FATAL(rows % 32 == 0, "Error");
+    TT_FATAL(cols % 32 == 0, "Error");
     int num_tiles_r = rows / 32;
     int num_tiles_c = cols / 32;
     std::vector<T> result;
@@ -106,9 +106,9 @@ std::tuple<tt_metal::Program, tt_metal::KernelHandle, tt_metal::KernelHandle, tt
     uint32_t in1_CB_size = in1_block_tiles * 2 * single_tile_size; // double buffer
     uint32_t out_CB_tiles = per_core_M * per_core_N;
     uint32_t out_CB_size = out_CB_tiles * single_tile_size;
-    TT_FATAL(in0_CB_size <= 130*1024);
-    TT_FATAL(in1_CB_size <= 130*1024);
-    TT_FATAL(out_CB_size <= 540*1024);
+    TT_FATAL(in0_CB_size <= 130*1024, "Error");
+    TT_FATAL(in1_CB_size <= 130*1024, "Error");
+    TT_FATAL(out_CB_size <= 540*1024, "Error");
 
     CoreRange all_cores(
         {(std::size_t)start_core_x, (std::size_t)start_core_y},
@@ -278,9 +278,9 @@ bool write_runtime_args_to_device(
     uint32_t dram_buffer_size_weights = single_tile_size * K * N; // num_tiles of FP16_B, hard-coded in the reader/writer kernels
     uint32_t dram_buffer_size_out = single_tile_size * M * N; // num_tiles of FP16_B, hard-coded in the reader/writer kernels
 
-    TT_FATAL(in0_dram_addr + dram_buffer_size_act < 1024 * 1024 * 1024);
-    TT_FATAL(in1_dram_addr + dram_buffer_size_weights < 1024 * 1024 * 1024);
-    TT_FATAL(out_dram_addr + dram_buffer_size_out < 1024 * 1024 * 1024);
+    TT_FATAL(in0_dram_addr + dram_buffer_size_act < 1024 * 1024 * 1024, "Error");
+    TT_FATAL(in1_dram_addr + dram_buffer_size_weights < 1024 * 1024 * 1024, "Error");
+    TT_FATAL(out_dram_addr + dram_buffer_size_out < 1024 * 1024 * 1024, "Error");
 
     for(int core_idx_y = 0; core_idx_y < num_cores_r; core_idx_y++) {
         for(int core_idx_x = 0; core_idx_x < num_cores_c; core_idx_x++) {
@@ -564,7 +564,7 @@ int main(int argc, char **argv) {
         TT_THROW("Test Failed");
     }
 
-    TT_FATAL(pass);
+    TT_FATAL(pass, "Error");
 
     return 0;
 }

--- a/tests/tt_metal/tt_metal/test_matmul_multi_core_multi_dram_in1_mcast.cpp
+++ b/tests/tt_metal/tt_metal/test_matmul_multi_core_multi_dram_in1_mcast.cpp
@@ -23,8 +23,8 @@ using namespace tt;
 // is contiguous
 template <typename T>
 std::vector<T> tilize(std::vector<T> data, int rows, int cols) {
-    TT_FATAL(rows % 32 == 0);
-    TT_FATAL(cols % 32 == 0);
+    TT_FATAL(rows % 32 == 0, "Error");
+    TT_FATAL(cols % 32 == 0, "Error");
     int num_tiles_r = rows / 32;
     int num_tiles_c = cols / 32;
     std::vector<T> result;
@@ -106,9 +106,9 @@ std::tuple<tt_metal::Program, tt_metal::KernelHandle, tt_metal::KernelHandle, tt
     uint32_t in1_CB_size = in1_block_tiles * 2 * single_tile_size; // double buffer
     uint32_t out_CB_tiles = per_core_M * per_core_N;
     uint32_t out_CB_size = out_CB_tiles * single_tile_size;
-    TT_FATAL(in0_CB_size <= 130*1024);
-    TT_FATAL(in1_CB_size <= 130*1024);
-    TT_FATAL(out_CB_size <= 540*1024);
+    TT_FATAL(in0_CB_size <= 130*1024, "Error");
+    TT_FATAL(in1_CB_size <= 130*1024, "Error");
+    TT_FATAL(out_CB_size <= 540*1024, "Error");
 
     CoreRange all_cores(
         {(std::size_t)start_core_x, (std::size_t)start_core_y},
@@ -240,9 +240,9 @@ bool write_runtime_args_to_device(
     uint32_t dram_buffer_size_weights = single_tile_size * K * N; // num_tiles of FP16_B, hard-coded in the reader/writer kernels
     uint32_t dram_buffer_size_out = single_tile_size * M * N; // num_tiles of FP16_B, hard-coded in the reader/writer kernels
 
-    TT_FATAL(in0_dram_addr + dram_buffer_size_act < 1024 * 1024 * 1024);
-    TT_FATAL(in1_dram_addr + dram_buffer_size_weights < 1024 * 1024 * 1024);
-    TT_FATAL(out_dram_addr + dram_buffer_size_out < 1024 * 1024 * 1024);
+    TT_FATAL(in0_dram_addr + dram_buffer_size_act < 1024 * 1024 * 1024, "Error");
+    TT_FATAL(in1_dram_addr + dram_buffer_size_weights < 1024 * 1024 * 1024, "Error");
+    TT_FATAL(out_dram_addr + dram_buffer_size_out < 1024 * 1024 * 1024, "Error");
 
     for(int core_idx_y = 0; core_idx_y < num_cores_r; core_idx_y++) {
         for(int core_idx_x = 0; core_idx_x < num_cores_c; core_idx_x++) {
@@ -491,7 +491,7 @@ int main(int argc, char **argv) {
         TT_THROW("Test Failed");
     }
 
-    TT_FATAL(pass);
+    TT_FATAL(pass, "Error");
 
     return 0;
 }

--- a/tests/tt_metal/tt_metal/test_matmul_multi_core_single_dram.cpp
+++ b/tests/tt_metal/tt_metal/test_matmul_multi_core_single_dram.cpp
@@ -22,8 +22,8 @@ using namespace tt;
 // is contiguous
 template <typename T>
 std::vector<T> tilize(std::vector<T> data, int rows, int cols) {
-    TT_FATAL(rows % 32 == 0);
-    TT_FATAL(cols % 32 == 0);
+    TT_FATAL(rows % 32 == 0, "Error");
+    TT_FATAL(cols % 32 == 0, "Error");
     int num_tiles_r = rows / 32;
     int num_tiles_c = cols / 32;
     std::vector<T> result;
@@ -49,8 +49,8 @@ std::vector<T> tilize(std::vector<T> data, int rows, int cols) {
 // transform it back to row major full tensor. (This function inverts the tilize() function)
 template <typename T>
 std::vector<T> untilize(std::vector<T> data, int rows, int cols) {
-    TT_FATAL(rows % 32 == 0);
-    TT_FATAL(cols % 32 == 0);
+    TT_FATAL(rows % 32 == 0, "Error");
+    TT_FATAL(cols % 32 == 0, "Error");
     int num_tiles_r = rows / 32;
     int num_tiles_c = cols / 32;
     std::vector<T> result;
@@ -161,9 +161,9 @@ std::tuple<tt_metal::Program, tt_metal::KernelHandle , tt_metal::KernelHandle> c
     uint32_t in1_CB_size = in1_block_tiles * 2 * single_tile_size; // double buffer
     uint32_t out_CB_tiles = per_core_M * per_core_N;
     uint32_t out_CB_size = out_CB_tiles * single_tile_size;
-    TT_FATAL(in0_CB_size <= 130*1024);
-    TT_FATAL(in1_CB_size <= 130*1024);
-    TT_FATAL(out_CB_size <= 540*1024);
+    TT_FATAL(in0_CB_size <= 130*1024, "Error");
+    TT_FATAL(in1_CB_size <= 130*1024, "Error");
+    TT_FATAL(out_CB_size <= 540*1024, "Error");
 
     CoreCoord start_core = {0, 0};
     CoreCoord end_core = {(std::size_t)num_cores_c - 1, (std::size_t)num_cores_r - 1};
@@ -341,9 +341,9 @@ int main(int argc, char **argv) {
                 uint32_t dram_buffer_size_weights = single_tile_size * K * per_core_N; // num_tiles of FP16_B, hard-coded in the reader/writer kernels
                 uint32_t dram_buffer_size_out = single_tile_size * per_core_M * per_core_N; // num_tiles of FP16_B, hard-coded in the reader/writer kernels
 
-                TT_FATAL(dram_buffer_src0_addr + dram_buffer_size_act < 1024 * 1024 * 1024);
-                TT_FATAL(dram_buffer_src1_addr + dram_buffer_size_weights < 1024 * 1024 * 1024);
-                TT_FATAL(dram_buffer_dst_addr + dram_buffer_size_out < 1024 * 1024 * 1024);
+                TT_FATAL(dram_buffer_src0_addr + dram_buffer_size_act < 1024 * 1024 * 1024, "Error");
+                TT_FATAL(dram_buffer_src1_addr + dram_buffer_size_weights < 1024 * 1024 * 1024, "Error");
+                TT_FATAL(dram_buffer_dst_addr + dram_buffer_size_out < 1024 * 1024 * 1024, "Error");
 
                 auto dram_src0_noc_xy = device->dram_core_from_dram_channel(dram_src0_channel_id);
                 auto dram_src1_noc_xy = device->dram_core_from_dram_channel(dram_src1_channel_id);
@@ -432,7 +432,7 @@ int main(int argc, char **argv) {
         TT_THROW("Test Failed");
     }
 
-    TT_FATAL(pass);
+    TT_FATAL(pass, "Error");
 
     return 0;
 }

--- a/tests/tt_metal/tt_metal/test_matmul_multi_tile.cpp
+++ b/tests/tt_metal/tt_metal/test_matmul_multi_tile.cpp
@@ -22,8 +22,8 @@ using namespace tt;
 // is contiguous
 template <typename T>
 std::vector<T> tilize(std::vector<T> data, int rows, int cols) {
-    TT_FATAL(rows % 32 == 0);
-    TT_FATAL(cols % 32 == 0);
+    TT_FATAL(rows % 32 == 0, "Error");
+    TT_FATAL(cols % 32 == 0, "Error");
     int num_tiles_r = rows / 32;
     int num_tiles_c = cols / 32;
     std::vector<T> result;
@@ -49,8 +49,8 @@ std::vector<T> tilize(std::vector<T> data, int rows, int cols) {
 // transform it back to row major full tensor. (This function inverts the tilize() function)
 template <typename T>
 std::vector<T> untilize(std::vector<T> data, int rows, int cols) {
-    TT_FATAL(rows % 32 == 0);
-    TT_FATAL(cols % 32 == 0);
+    TT_FATAL(rows % 32 == 0, "Error");
+    TT_FATAL(cols % 32 == 0, "Error");
     int num_tiles_r = rows / 32;
     int num_tiles_c = cols / 32;
     std::vector<T> result;
@@ -110,7 +110,7 @@ bool run_matmul(const tt::ARCH& arch, const bool with_bias) {
         uint32_t M = 4;
         uint32_t K = 4;
         uint32_t N = K;
-        TT_FATAL(M * K * 32 * 32 <= (64 * 16 * 16));
+        TT_FATAL(M * K * 32 * 32 <= (64 * 16 * 16), "Error");
         uint32_t single_tile_size = 2 * 1024;
         uint32_t dram_buffer_size_act = single_tile_size * M * K; // num_tiles of FP16_B, hard-coded in the reader/writer kernels
         uint32_t dram_buffer_size_weights = single_tile_size * K * N; // num_tiles of FP16_B, hard-coded in the reader/writer kernels
@@ -358,7 +358,7 @@ int main(int argc, char **argv) {
     pass &= run_matmul(arch, false);
     pass &= run_matmul(arch, true);
 
-    TT_FATAL(pass);
+    TT_FATAL(pass, "Error");
 
     return 0;
 }

--- a/tests/tt_metal/tt_metal/test_matmul_single_core.cpp
+++ b/tests/tt_metal/tt_metal/test_matmul_single_core.cpp
@@ -22,8 +22,8 @@ using namespace tt;
 // is contiguous
 template <typename T>
 std::vector<T> tilize(std::vector<T> data, int rows, int cols) {
-    TT_FATAL(rows % 32 == 0);
-    TT_FATAL(cols % 32 == 0);
+    TT_FATAL(rows % 32 == 0, "Error");
+    TT_FATAL(cols % 32 == 0, "Error");
     int num_tiles_r = rows / 32;
     int num_tiles_c = cols / 32;
     std::vector<T> result;
@@ -49,8 +49,8 @@ std::vector<T> tilize(std::vector<T> data, int rows, int cols) {
 // transform it back to row major full tensor. (This function inverts the tilize() function)
 template <typename T>
 std::vector<T> untilize(std::vector<T> data, int rows, int cols) {
-    TT_FATAL(rows % 32 == 0);
-    TT_FATAL(cols % 32 == 0);
+    TT_FATAL(rows % 32 == 0, "Error");
+    TT_FATAL(cols % 32 == 0, "Error");
     int num_tiles_r = rows / 32;
     int num_tiles_c = cols / 32;
     std::vector<T> result;
@@ -130,7 +130,7 @@ std::vector<bfloat16> select_columns(std::vector<bfloat16> data, int M, int K, i
         return data;
     }
     if(min_K_N > K) {
-        TT_FATAL(false);
+        TT_FATAL(false, "Error");
     }
     std::vector<bfloat16> result;
     for(int i = 0; i < M * 32; i++) {
@@ -178,9 +178,9 @@ int main(int argc, char **argv) {
         log_info(LogTest, "Weights block = {}x{}, #blocks = {}, #sub-blocks = {}", out_subblock_w, in0_block_w, K / in0_block_w, N / out_subblock_w);
 
         uint32_t single_tile_size = 2 * 1024;
-        TT_FATAL(M * in0_block_w * single_tile_size * 2 <= 130*1024);
-        TT_FATAL(N * in0_block_w * single_tile_size * 2 <= 130*1024);
-        TT_FATAL(M * N * single_tile_size <= 540*1024);
+        TT_FATAL(M * in0_block_w * single_tile_size * 2 <= 130*1024, "Error");
+        TT_FATAL(N * in0_block_w * single_tile_size * 2 <= 130*1024, "Error");
+        TT_FATAL(M * N * single_tile_size <= 540*1024, "Error");
         uint32_t dram_buffer_size_act = single_tile_size * M * K; // num_tiles of FP16_B, hard-coded in the reader/writer kernels
         uint32_t dram_buffer_size_weights = single_tile_size * K * N; // num_tiles of FP16_B, hard-coded in the reader/writer kernels
         uint32_t dram_buffer_size_out = single_tile_size * M * N; // num_tiles of FP16_B, hard-coded in the reader/writer kernels
@@ -387,7 +387,7 @@ int main(int argc, char **argv) {
         TT_THROW("Test Failed");
     }
 
-    TT_FATAL(pass);
+    TT_FATAL(pass, "Error");
 
     return 0;
 }

--- a/tests/tt_metal/tt_metal/test_matmul_single_core_small.cpp
+++ b/tests/tt_metal/tt_metal/test_matmul_single_core_small.cpp
@@ -23,8 +23,8 @@ using namespace tt;
 // is contiguous
 template <typename T>
 std::vector<T> tilize(std::vector<T> data, int rows, int cols) {
-    TT_FATAL(rows % 32 == 0);
-    TT_FATAL(cols % 32 == 0);
+    TT_FATAL(rows % 32 == 0, "Error");
+    TT_FATAL(cols % 32 == 0, "Error");
     int num_tiles_r = rows / 32;
     int num_tiles_c = cols / 32;
     std::vector<T> result;
@@ -50,8 +50,8 @@ std::vector<T> tilize(std::vector<T> data, int rows, int cols) {
 // transform it back to row major full tensor. (This function inverts the tilize() function)
 template <typename T>
 std::vector<T> untilize(std::vector<T> data, int rows, int cols) {
-    TT_FATAL(rows % 32 == 0);
-    TT_FATAL(cols % 32 == 0);
+    TT_FATAL(rows % 32 == 0, "Error");
+    TT_FATAL(cols % 32 == 0, "Error");
     int num_tiles_r = rows / 32;
     int num_tiles_c = cols / 32;
     std::vector<T> result;
@@ -131,7 +131,7 @@ std::vector<bfloat16> select_columns(std::vector<bfloat16> data, int M, int K, i
         return data;
     }
     if(min_K_N > K) {
-        TT_FATAL(false);
+        TT_FATAL(false, "Error");
     }
     std::vector<bfloat16> result;
     for(int i = 0; i < M * 32; i++) {
@@ -179,9 +179,9 @@ int main(int argc, char **argv) {
         log_info(LogTest, "Weights block = {}x{}, #blocks = {}, #sub-blocks = {}", out_subblock_w, in0_block_w, K / in0_block_w, N / out_subblock_w);
 
         uint32_t single_tile_size = 2 * 1024;
-        TT_FATAL(M * in0_block_w * single_tile_size * 2 <= 130*1024);
-        TT_FATAL(N * in0_block_w * single_tile_size * 2 <= 130*1024);
-        TT_FATAL(M * N * single_tile_size <= 540*1024);
+        TT_FATAL(M * in0_block_w * single_tile_size * 2 <= 130*1024, "Error");
+        TT_FATAL(N * in0_block_w * single_tile_size * 2 <= 130*1024, "Error");
+        TT_FATAL(M * N * single_tile_size <= 540*1024, "Error");
         uint32_t dram_buffer_size_act = single_tile_size * M * K; // num_tiles of FP16_B, hard-coded in the reader/writer kernels
         uint32_t dram_buffer_size_weights = single_tile_size * K * N; // num_tiles of FP16_B, hard-coded in the reader/writer kernels
         uint32_t dram_buffer_size_out = single_tile_size * M * N; // num_tiles of FP16_B, hard-coded in the reader/writer kernels
@@ -393,7 +393,7 @@ int main(int argc, char **argv) {
         TT_THROW("Test Failed");
     }
 
-    TT_FATAL(pass);
+    TT_FATAL(pass, "Error");
 
     return 0;
 }

--- a/tests/tt_metal/tt_metal/test_matmul_single_tile.cpp
+++ b/tests/tt_metal/tt_metal/test_matmul_single_tile.cpp
@@ -179,7 +179,7 @@ int main(int argc, char **argv) {
         TT_THROW("Test Failed");
     }
 
-    TT_FATAL(pass);
+    TT_FATAL(pass, "Error");
 
     return 0;
 }

--- a/tests/tt_metal/tt_metal/test_matmul_single_tile_bfp8b.cpp
+++ b/tests/tt_metal/tt_metal/test_matmul_single_tile_bfp8b.cpp
@@ -41,7 +41,7 @@ int main(int argc, char **argv) {
         CoreCoord core = {0, 0};
 
         uint32_t single_tile_size = tt_metal::detail::TileSize(tt::DataFormat::Bfp8_b);
-        TT_FATAL(single_tile_size == (256 * 4) + (16 *4));
+        TT_FATAL(single_tile_size == (256 * 4) + (16 *4), "Error");
         uint32_t num_tiles = 1;
         uint32_t dram_buffer_size = single_tile_size * num_tiles; // num_tiles of BFP8_B
 
@@ -185,7 +185,7 @@ int main(int argc, char **argv) {
         TT_THROW("Test Failed");
     }
 
-    TT_FATAL(pass);
+    TT_FATAL(pass, "Error");
 
     return 0;
 }

--- a/tests/tt_metal/tt_metal/test_matmul_single_tile_output_in_l1.cpp
+++ b/tests/tt_metal/tt_metal/test_matmul_single_tile_output_in_l1.cpp
@@ -189,7 +189,7 @@ int main(int argc, char **argv) {
         TT_THROW("Test Failed");
     }
 
-    TT_FATAL(pass);
+    TT_FATAL(pass, "Error");
 
     return 0;
 }

--- a/tests/tt_metal/tt_metal/test_multi_core_kernel.cpp
+++ b/tests/tt_metal/tt_metal/test_multi_core_kernel.cpp
@@ -361,7 +361,7 @@ int main(int argc, char **argv) {
         TT_THROW("Test Failed");
     }
 
-    TT_FATAL(pass);
+    TT_FATAL(pass, "Error");
 
     return 0;
 }

--- a/tests/tt_metal/tt_metal/test_multiple_programs.cpp
+++ b/tests/tt_metal/tt_metal/test_multiple_programs.cpp
@@ -27,7 +27,7 @@ std::map<string, string> get_defines(BinaryOpType::Enum op_type){
         case BinaryOpType::ADD: op_name = "add_tiles"; op_binary_type = "EltwiseBinaryType::ELWADD"; break;
         case BinaryOpType::SUB: op_name = "sub_tiles"; op_binary_type = "EltwiseBinaryType::ELWSUB"; break;
         case BinaryOpType::MUL: op_name = "mul_tiles"; op_binary_type = "EltwiseBinaryType::ELWMUL"; break;
-        default: TT_FATAL(false && "Undefined op type");
+        default: TT_FATAL(false && "Undefined op type", "Error");
     }
     defines["ELTWISE_OP"] = op_name.c_str();
     defines["ELTWISE_OP_TYPE"] = op_binary_type.c_str();
@@ -305,7 +305,7 @@ int main(int argc, char **argv) {
         TT_THROW("Test Failed");
     }
 
-    TT_FATAL(pass);
+    TT_FATAL(pass, "Error");
 
     return 0;
 }

--- a/tests/tt_metal/tt_metal/test_transpose_hc.cpp
+++ b/tests/tt_metal/tt_metal/test_transpose_hc.cpp
@@ -213,7 +213,7 @@ int main(int argc, char **argv) {
         TT_THROW("Test Failed");
     }
 
-    TT_FATAL(pass);
+    TT_FATAL(pass, "Error");
 
     return 0;
 }

--- a/tests/tt_metal/tt_metal/test_untilize_eltwise_binary.cpp
+++ b/tests/tt_metal/tt_metal/test_untilize_eltwise_binary.cpp
@@ -256,7 +256,7 @@ int main(int argc, char **argv) {
         TT_THROW("Test Failed");
     }
 
-    TT_FATAL(pass);
+    TT_FATAL(pass, "Error");
 
     return 0;
 }

--- a/tests/tt_metal/tt_metal/tt_dispatch/test_enqueue_program.cpp
+++ b/tests/tt_metal/tt_metal/tt_dispatch/test_enqueue_program.cpp
@@ -112,7 +112,7 @@ void test_enqueue_program(std::function<tt_metal::Program(tt_metal::Device *devi
         EnqueueReadBuffer(cq, std::ref(out), out_vec, true);
     }
 
-    TT_FATAL(out_vec == inp);
+    TT_FATAL(out_vec == inp, "Error");
     tt_metal::CloseDevice(device);
 }
 

--- a/tests/tt_metal/tt_metal/unit_tests/buffer/test_banked.cpp
+++ b/tests/tt_metal/tt_metal/unit_tests/buffer/test_banked.cpp
@@ -86,7 +86,7 @@ bool reader_cb_writer(Device* device, const BankedConfig& cfg, const bool banked
     tt::log_debug(tt::LogTest, "Input buffer: [address: {} B, size: {} B] at noc coord {}", input_buffer->address(), input_buffer->size(), input_buffer->noc_coordinates().str());
     tt::log_debug(tt::LogTest, "Output buffer: [address: {} B, size: {} B] at noc coord {}", output_buffer->address(), output_buffer->size(), output_buffer->noc_coordinates().str());
 
-    TT_FATAL(cfg.num_tiles * cfg.page_size_bytes == cfg.size_bytes);
+    TT_FATAL(cfg.num_tiles * cfg.page_size_bytes == cfg.size_bytes, "Error");
     constexpr uint32_t num_pages_cb = 1;
     CircularBufferConfig input_buffer_cb_config = CircularBufferConfig(cfg.page_size_bytes, {{cb_id, cfg.l1_data_format}})
         .set_page_size(cb_id, cfg.page_size_bytes);
@@ -183,7 +183,7 @@ bool reader_datacopy_writer(Device* device, const BankedConfig& cfg) {
     auto input_buffer = CreateBuffer(in_config);
     auto output_buffer = CreateBuffer(out_config);
 
-    TT_FATAL(cfg.num_tiles * cfg.page_size_bytes == cfg.size_bytes);
+    TT_FATAL(cfg.num_tiles * cfg.page_size_bytes == cfg.size_bytes, "Error");
     constexpr uint32_t num_pages_cb = 1;
     CircularBufferConfig l1_input_cb_config = CircularBufferConfig(cfg.page_size_bytes, {{input0_cb_index, cfg.l1_data_format}})
         .set_page_size(input0_cb_index, cfg.page_size_bytes);
@@ -273,7 +273,7 @@ TEST_F(DeviceFixture, TestSingleCoreSingleTileBankedL1ReaderOnly) {
 TEST_F(DeviceFixture, TestSingleCoreMultiTileBankedL1ReaderOnly) {
     for (unsigned int id = 0; id < num_devices_; id++) {
         BankedConfig test_config;
-        TT_FATAL(this->devices_.at(id)->num_banks(BufferType::L1) % 2 == 0);
+        TT_FATAL(this->devices_.at(id)->num_banks(BufferType::L1) % 2 == 0, "Error");
         size_t num_tiles = this->devices_.at(id)->num_banks(BufferType::L1) / 2;
         size_t tile_increment = num_tiles;
         uint32_t num_iterations = 3;
@@ -300,7 +300,7 @@ TEST_F(DeviceFixture, TestSingleCoreSingleTileBankedDramReaderOnly) {
 TEST_F(DeviceFixture, TestSingleCoreMultiTileBankedDramReaderOnly) {
     for (unsigned int id = 0; id < num_devices_; id++) {
         BankedConfig test_config;
-        TT_FATAL(this->devices_.at(id)->num_banks(BufferType::DRAM) % 2 == 0);
+        TT_FATAL(this->devices_.at(id)->num_banks(BufferType::DRAM) % 2 == 0, "Error");
         size_t num_tiles = this->devices_.at(id)->num_banks(BufferType::DRAM) / 2;
         size_t tile_increment = num_tiles;
         uint32_t num_iterations = 6;
@@ -327,7 +327,7 @@ TEST_F(DeviceFixture, TestSingleCoreSingleTileBankedL1WriterOnly) {
 TEST_F(DeviceFixture, TestSingleCoreMultiTileBankedL1WriterOnly) {
     for (unsigned int id = 0; id < num_devices_; id++) {
         BankedConfig test_config;
-        TT_FATAL(this->devices_.at(id)->num_banks(BufferType::L1) % 2 == 0);
+        TT_FATAL(this->devices_.at(id)->num_banks(BufferType::L1) % 2 == 0, "Error");
         size_t num_tiles = this->devices_.at(id)->num_banks(BufferType::L1) / 2;
         size_t tile_increment = num_tiles;
         uint32_t num_iterations = 3;
@@ -354,7 +354,7 @@ TEST_F(DeviceFixture, TestSingleCoreSingleTileBankedDramWriterOnly) {
 TEST_F(DeviceFixture, TestSingleCoreMultiTileBankedDramWriterOnly) {
     for (unsigned int id = 0; id < num_devices_; id++) {
         BankedConfig test_config;
-        TT_FATAL(this->devices_.at(id)->num_banks(BufferType::DRAM) % 2 == 0);
+        TT_FATAL(this->devices_.at(id)->num_banks(BufferType::DRAM) % 2 == 0, "Error");
         size_t num_tiles = this->devices_.at(id)->num_banks(BufferType::DRAM) / 2;
         size_t tile_increment = num_tiles;
         uint32_t num_iterations = 6;
@@ -382,7 +382,7 @@ TEST_F(DeviceFixture, TestSingleCoreMultiTileBankedL1ReaderAndWriter) {
     for (unsigned int id = 0; id < num_devices_; id++) {
         BankedConfig test_config;
         size_t num_tiles = this->devices_.at(id)->num_banks(BufferType::L1);
-        TT_FATAL(num_tiles % 2 == 0);
+        TT_FATAL(num_tiles % 2 == 0, "Error");
         size_t tile_increment = num_tiles / 2;
         uint32_t num_iterations = 6;
         uint32_t index = 0;
@@ -409,7 +409,7 @@ TEST_F(DeviceFixture, TestSingleCoreMultiTileBankedDramReaderAndWriter) {
     for (unsigned int id = 0; id < num_devices_; id++) {
         BankedConfig test_config;
         size_t num_tiles = this->devices_.at(id)->num_banks(BufferType::L1);
-        TT_FATAL(num_tiles % 2 == 0);
+        TT_FATAL(num_tiles % 2 == 0, "Error");
         size_t tile_increment = num_tiles / 2;
         uint32_t num_iterations = 6;
         uint32_t index = 0;
@@ -439,7 +439,7 @@ TEST_F(DeviceFixture, TestSingleCoreMultiTileBankedDramReaderAndL1Writer) {
         test_config.input_buffer_type = BufferType::DRAM;
 
         size_t num_tiles = this->devices_.at(id)->num_banks(BufferType::L1);
-        TT_FATAL(num_tiles % 2 == 0);
+        TT_FATAL(num_tiles % 2 == 0, "Error");
         size_t tile_increment = num_tiles / 2;
         uint32_t num_iterations = 6;
         uint32_t index = 0;
@@ -467,7 +467,7 @@ TEST_F(DeviceFixture, TestSingleCoreMultiTileBankedL1ReaderAndDramWriter) {
         test_config.output_buffer_type = BufferType::DRAM;
 
         size_t num_tiles = this->devices_.at(id)->num_banks(BufferType::L1);
-        TT_FATAL(num_tiles % 2 == 0);
+        TT_FATAL(num_tiles % 2 == 0, "Error");
         size_t tile_increment = num_tiles / 2;
         uint32_t num_iterations = 6;
         uint32_t index = 0;
@@ -485,7 +485,7 @@ TEST_F(DeviceFixture, TestSingleCoreMultiTileBankedL1ReaderDataCopyL1Writer) {
     for (unsigned int id = 0; id < num_devices_; id++) {
         BankedConfig test_config;
         size_t num_tiles = this->devices_.at(id)->num_banks(BufferType::L1);
-        TT_FATAL(num_tiles % 2 == 0);
+        TT_FATAL(num_tiles % 2 == 0, "Error");
         size_t tile_increment = num_tiles / 2;
         uint32_t num_iterations = 6;
         uint32_t index = 0;
@@ -504,7 +504,7 @@ TEST_F(DeviceFixture, TestSingleCoreMultiTileBankedDramReaderDataCopyDramWriter)
     for (unsigned int id = 0; id < num_devices_; id++) {
         BankedConfig test_config;
         size_t num_tiles = this->devices_.at(id)->num_banks(BufferType::DRAM);
-        TT_FATAL(num_tiles % 2 == 0);
+        TT_FATAL(num_tiles % 2 == 0, "Error");
         size_t tile_increment = num_tiles / 2;
         uint32_t num_iterations = 6;
         uint32_t index = 0;
@@ -524,7 +524,7 @@ TEST_F(DeviceFixture, TestSingleCoreMultiTileBankedL1ReaderDataCopyDramWriter) {
     for (unsigned int id = 0; id < num_devices_; id++) {
         BankedConfig test_config;
         size_t num_tiles = this->devices_.at(id)->num_banks(BufferType::L1);
-        TT_FATAL(num_tiles % 2 == 0);
+        TT_FATAL(num_tiles % 2 == 0, "Error");
         size_t tile_increment = num_tiles / 2;
         uint32_t num_iterations = 6;
         uint32_t index = 0;
@@ -545,7 +545,7 @@ TEST_F(DeviceFixture, TestSingleCoreMultiTileBankedDramReaderDataCopyL1Writer) {
     for (unsigned int id = 0; id < num_devices_; id++) {
         BankedConfig test_config;
         size_t num_tiles = this->devices_.at(id)->num_banks(BufferType::L1);
-        TT_FATAL(num_tiles % 2 == 0);
+        TT_FATAL(num_tiles % 2 == 0, "Error");
         size_t tile_increment = num_tiles / 2;
         uint32_t num_iterations = 6;
         uint32_t index = 0;

--- a/tests/tt_metal/tt_metal/unit_tests/compute/test_golden_impls.cpp
+++ b/tests/tt_metal/tt_metal/unit_tests/compute/test_golden_impls.cpp
@@ -127,7 +127,7 @@ std::vector<uint16_t> gold_transpose_wh(const std::vector<uint16_t> &src_vec, co
     for (int w = 0; w < shape[3]; w++) {
         auto toffs = addrt.offs(n, c, w, h);
         auto offs = addr.offs(n, c, h, w);
-        TT_FATAL(toffs < transposed.size() && offs < src_vec.size());
+        TT_FATAL(toffs < transposed.size() && offs < src_vec.size(), "Error");
         transposed[toffs] = src_vec[offs];
     }
 
@@ -139,7 +139,7 @@ std::vector<uint16_t> gold_transpose_wh(const std::vector<uint16_t> &src_vec, co
 // result is also untilized
 std::vector<uint16_t> gold_reduce_h(const std::vector<uint16_t> &src_vec, const std::vector<uint32_t> &shape, float scaler, bool red_max, bool zeropad) {
     vector<uint32_t> shape_dst{shape[0], shape[1], 1, shape[3]};
-    TT_FATAL(shape[2] > 0);
+    TT_FATAL(shape[2] > 0, "Error");
     if (zeropad)
         shape_dst[2] = 32;
     TensAddr addr(shape);

--- a/tests/tt_metal/tt_metal/unit_tests/compute/test_reduce.cpp
+++ b/tests/tt_metal/tt_metal/unit_tests/compute/test_reduce.cpp
@@ -179,8 +179,8 @@ void run_single_core_reduce_program(tt_metal::Device* device, const ReduceConfig
     uint32_t W = test_config.shape[3], H = test_config.shape[2], NC = test_config.shape[1]*test_config.shape[0];
     uint32_t HW = H*W;
     uint32_t N = test_config.shape[0]*test_config.shape[1];
-    TT_FATAL(W % TILE_WIDTH == 0 && H % TILE_HEIGHT == 0);
-    TT_FATAL(H > 0 && W > 0 && NC > 0);
+    TT_FATAL(W % TILE_WIDTH == 0 && H % TILE_HEIGHT == 0, "Error");
+    TT_FATAL(H > 0 && W > 0 && NC > 0, "Error");
     uint32_t Wt = W/TILE_WIDTH;
     uint32_t Ht = H/TILE_HEIGHT;
 
@@ -196,7 +196,7 @@ void run_single_core_reduce_program(tt_metal::Device* device, const ReduceConfig
     float scaler = (test_config.do_max or test_config.reduce_dim == ReduceDim::HW) ? 1.0f : (test_config.reduce_dim == ReduceDim::H ? 1.0f/H : 1.0f/W);
     uint32_t num_tensor_tiles = NC*H*W / (TILE_WIDTH*TILE_HEIGHT);
     uint32_t divisor = test_config.reduce_dim == ReduceDim::W ? Wt : Ht;
-    TT_FATAL(num_tensor_tiles%divisor == 0);
+    TT_FATAL(num_tensor_tiles%divisor == 0, "Error");
 
     uint32_t single_tile_bytes = 2 * 1024;
     uint32_t dram_buffer_size = single_tile_bytes * num_tensor_tiles;
@@ -264,7 +264,7 @@ void run_single_core_reduce_program(tt_metal::Device* device, const ReduceConfig
     {
         reduce_defines["SHORT_INIT"] = "1";
     }
-  
+
     if (test_config.math_only_reduce) {
         reduce_defines["MATH_ONLY"] = "1";
     } else {

--- a/tests/tt_metal/tt_metal/unit_tests/compute/test_transpose.cpp
+++ b/tests/tt_metal/tt_metal/unit_tests/compute/test_transpose.cpp
@@ -56,7 +56,7 @@ void validate_transpose_wh(const std::vector<uint32_t> &src_vec, const std::vect
     vector<uint16_t> gold_reduced = gold_transpose_wh(src_linear, shape); // result is uint16_t untilized
 
     // Tilize from row major and convert to pairs (uint32_t)
-    TT_FATAL(shape.size() == 4);
+    TT_FATAL(shape.size() == 4, "Error");
     vector<uint32_t> shapeR{shape[0], shape[1], shape[3], shape[2]};
     auto gold_4f_u32 = u32_from_u16_vector(convert_layout<uint16_t>(gold_reduced, shapeR, TensorLayout::LIN_ROW_MAJOR, TensorLayout::TILED32_4FACES));
 
@@ -68,7 +68,7 @@ void validate_transpose_wh(const std::vector<uint32_t> &src_vec, const std::vect
 }
 
 void run_single_core_transpose(tt_metal::Device* device, const TransposeConfig& test_config) {
-    TT_FATAL(test_config.shape.size() == 4);
+    TT_FATAL(test_config.shape.size() == 4, "Error");
 
     Program program = tt_metal::CreateProgram();
 
@@ -76,11 +76,11 @@ void run_single_core_transpose(tt_metal::Device* device, const TransposeConfig& 
 
     uint32_t W = test_config.shape[3], H = test_config.shape[2], NC = test_config.shape[1]*test_config.shape[0];
     uint32_t HW = H*W;
-    TT_FATAL(W % 32 == 0 && H % 32 == 0);
-    TT_FATAL(H > 0 && W > 0 && NC > 0);
+    TT_FATAL(W % 32 == 0 && H % 32 == 0, "Error");
+    TT_FATAL(H > 0 && W > 0 && NC > 0, "Error");
     uint32_t Wt = W/32;
     // size of DST register, with unary r/w this currently only works if the entire Wt fits into DST for reduce
-    TT_FATAL(Wt <= 16);
+    TT_FATAL(Wt <= 16, "Error");
     uint32_t Ht = H/32;
     float scaler = 1.0f/W;
     uint32_t num_tensor_tiles = NC*H*W / (32*32);

--- a/tests/tt_metal/tt_metal/unit_tests/multichip/buffer_movement_kernels.cpp
+++ b/tests/tt_metal/tt_metal/unit_tests/multichip/buffer_movement_kernels.cpp
@@ -177,7 +177,7 @@ bool chip_to_chip_interleaved_buffer_transfer(
     const uint32_t input0_cb_index = 0;
     const uint32_t output_cb_index = 16;
 
-    TT_FATAL(cfg.num_pages * cfg.page_size_bytes == cfg.size_bytes);
+    TT_FATAL(cfg.num_pages * cfg.page_size_bytes == cfg.size_bytes, "Error");
     constexpr uint32_t num_pages_cb = 1;
 
     ////////////////////////////////////////////////////////////////////////////

--- a/tests/tt_metal/tt_metal/unit_tests_common/compute/matmul/test_matmul_large_block.cpp
+++ b/tests/tt_metal/tt_metal/unit_tests_common/compute/matmul/test_matmul_large_block.cpp
@@ -150,9 +150,9 @@ bool matmul_large_block(CommonFixture *fixture, tt_metal::Device *device, bool a
     int in0_block_w = K;
 
     uint32_t single_tile_size = 2 * 1024;
-    TT_FATAL(M * in0_block_w * single_tile_size * 2 <= 150*1024);
-    TT_FATAL(N * in0_block_w * single_tile_size * 2 <= 100*1024);
-    TT_FATAL(M * N * single_tile_size <= 600*1024);
+    TT_FATAL(M * in0_block_w * single_tile_size * 2 <= 150*1024, "Parameter mismatch {} {} {}", M, in0_block_w, single_tile_size);
+    TT_FATAL(N * in0_block_w * single_tile_size * 2 <= 100*1024, "Parameter mismatch {} {} {}", N, in0_block_w, single_tile_size);
+    TT_FATAL(M * N * single_tile_size <= 600*1024, "Parameter mismatch {} {} {}", M, N, single_tile_size);
     uint32_t dram_buffer_size_act = single_tile_size * M * K; // num_tiles of FP16_B, hard-coded in the reader/writer kernels
     uint32_t dram_buffer_size_weights = single_tile_size * K * N; // num_tiles of FP16_B, hard-coded in the reader/writer kernels
     uint32_t dram_buffer_size_out = single_tile_size * M * N; // num_tiles of FP16_B, hard-coded in the reader/writer kernels
@@ -252,8 +252,8 @@ bool matmul_large_block(CommonFixture *fixture, tt_metal::Device *device, bool a
 
     create_CBs_for_fused_matmul(program, device, core, activations_rm, output_rm, M, N, in0_block_w, out_subblock_h);
 
-    TT_FATAL(in0_subblock_h * in0_block_w * in0_num_subblocks == in0_block_num_tiles);
-    TT_FATAL(in0_block_w == K);
+    TT_FATAL(in0_subblock_h * in0_block_w * in0_num_subblocks == in0_block_num_tiles, "Parameter mismatch {} {} {} {}", in0_subblock_h, in0_block_w, in0_num_subblocks, in0_block_num_tiles);
+    TT_FATAL(in0_block_w == K, "Parameter mismatch {} {}", in0_block_w, K);
 
     vector<uint32_t> compute_kernel_args = {
         uint(in0_block_w),

--- a/tests/tt_metal/tt_metal/unit_tests_common/compute/matmul/test_matmul_multi_core_X_dram.cpp
+++ b/tests/tt_metal/tt_metal/unit_tests_common/compute/matmul/test_matmul_multi_core_X_dram.cpp
@@ -41,9 +41,9 @@ std::tuple<tt_metal::Program, tt_metal::KernelHandle , tt_metal::KernelHandle> c
     uint32_t in1_CB_size = in1_block_tiles * 2 * single_tile_size;  // double buffer
     uint32_t out_CB_tiles = per_core_M * per_core_N;
     uint32_t out_CB_size = out_CB_tiles * single_tile_size;
-    TT_FATAL(in0_CB_size <= 130 * 1024);
-    TT_FATAL(in1_CB_size <= 130 * 1024);
-    TT_FATAL(out_CB_size <= 540 * 1024);
+    TT_FATAL(in0_CB_size <= 130*1024, "in0_CB_size {} too large", in0_CB_size);
+    TT_FATAL(in1_CB_size <= 130*1024, "in1_CB_size {} too large", in1_CB_size);
+    TT_FATAL(out_CB_size <= 540*1024, "out_CB_size {} too large", out_CB_size);
 
     CoreCoord start_core = {0, 0};
     CoreCoord end_core = {(std::size_t)num_cores_c - 1, (std::size_t)num_cores_r - 1};
@@ -197,9 +197,9 @@ bool matmul_multi_core_single_dram(tt_metal::Device *device){
             uint32_t dram_buffer_size_weights = single_tile_size * K * per_core_N; // num_tiles of FP16_B, hard-coded in the reader/writer kernels
             uint32_t dram_buffer_size_out = single_tile_size * per_core_M * per_core_N; // num_tiles of FP16_B, hard-coded in the reader/writer kernels
 
-            TT_FATAL(dram_buffer_src0_addr + dram_buffer_size_act < 1024 * 1024 * 1024);
-            TT_FATAL(dram_buffer_src1_addr + dram_buffer_size_weights < 1024 * 1024 * 1024);
-            TT_FATAL(dram_buffer_dst_addr + dram_buffer_size_out < 1024 * 1024 * 1024);
+            TT_FATAL(dram_buffer_src0_addr + dram_buffer_size_act < 1024 * 1024 * 1024, "addr {} + size {} too large", dram_buffer_src0_addr, dram_buffer_size_act);
+            TT_FATAL(dram_buffer_src1_addr + dram_buffer_size_weights < 1024 * 1024 * 1024, dram_buffer_src1_addr, dram_buffer_size_weights);
+            TT_FATAL(dram_buffer_dst_addr + dram_buffer_size_out < 1024 * 1024 * 1024, dram_buffer_dst_addr, dram_buffer_size_out);
 
             auto dram_src0_noc_xy = device->dram_core_from_dram_channel(dram_src0_channel_id);
             auto dram_src1_noc_xy = device->dram_core_from_dram_channel(dram_src1_channel_id);
@@ -300,9 +300,9 @@ bool assign_runtime_args_to_program(
     uint32_t dram_buffer_size_out =
         single_tile_size * M * N;  // num_tiles of FP16_B, hard-coded in the reader/writer kernels
 
-    TT_FATAL(in0_dram_addr + dram_buffer_size_act < 1024 * 1024 * 1024);
-    TT_FATAL(in1_dram_addr + dram_buffer_size_weights < 1024 * 1024 * 1024);
-    TT_FATAL(out_dram_addr + dram_buffer_size_out < 1024 * 1024 * 1024);
+    TT_FATAL(in0_dram_addr + dram_buffer_size_act < 1024 * 1024 * 1024, "addr {} + size {} too large", in0_dram_addr, dram_buffer_size_act);
+    TT_FATAL(in1_dram_addr + dram_buffer_size_weights < 1024 * 1024 * 1024, "addr {} + size {} too large", in1_dram_addr, dram_buffer_size_weights);
+    TT_FATAL(out_dram_addr + dram_buffer_size_out < 1024 * 1024 * 1024, "addr {} + size {} too large", out_dram_addr, dram_buffer_size_out);
 
     for (int core_idx_y = 0; core_idx_y < num_cores_r; core_idx_y++) {
         for (int core_idx_x = 0; core_idx_x < num_cores_c; core_idx_x++) {

--- a/tests/tt_metal/tt_metal/unit_tests_common/compute/matmul/test_matmul_multi_core_multi_dram_in0_mcast_in1_mcast.cpp
+++ b/tests/tt_metal/tt_metal/unit_tests_common/compute/matmul/test_matmul_multi_core_multi_dram_in0_mcast_in1_mcast.cpp
@@ -54,9 +54,9 @@ create_program(
     uint32_t in1_CB_size = in1_block_tiles * 2 * single_tile_size; // double buffer
     uint32_t out_CB_tiles = per_core_M * per_core_N;
     uint32_t out_CB_size = out_CB_tiles * single_tile_size;
-    TT_FATAL(in0_CB_size <= 130*1024);
-    TT_FATAL(in1_CB_size <= 130*1024);
-    TT_FATAL(out_CB_size <= 540*1024);
+    TT_FATAL(in0_CB_size <= 130*1024, "in0_CB_size {} too large", in0_CB_size);
+    TT_FATAL(in1_CB_size <= 130*1024, "in1_CB_size {} too large", in1_CB_size);
+    TT_FATAL(out_CB_size <= 540*1024, "out_CB_size {} too large", out_CB_size);
 
     CoreRange all_cores(
         {(std::size_t)start_core_x, (std::size_t)start_core_y},
@@ -241,9 +241,9 @@ bool write_runtime_args_to_device(
     uint32_t dram_buffer_size_weights = single_tile_size * K * N; // num_tiles of FP16_B, hard-coded in the reader/writer kernels
     uint32_t dram_buffer_size_out = single_tile_size * M * N; // num_tiles of FP16_B, hard-coded in the reader/writer kernels
 
-    TT_FATAL(in0_dram_addr + dram_buffer_size_act < 1024 * 1024 * 1024);
-    TT_FATAL(in1_dram_addr + dram_buffer_size_weights < 1024 * 1024 * 1024);
-    TT_FATAL(out_dram_addr + dram_buffer_size_out < 1024 * 1024 * 1024);
+    TT_FATAL(in0_dram_addr + dram_buffer_size_act < 1024 * 1024 * 1024, "addr {} + size {} too large", in0_dram_addr, dram_buffer_size_act);
+    TT_FATAL(in1_dram_addr + dram_buffer_size_weights < 1024 * 1024 * 1024, "addr {} + size {} too large", in1_dram_addr, dram_buffer_size_weights);
+    TT_FATAL(out_dram_addr + dram_buffer_size_out < 1024 * 1024 * 1024, "addr {} + size {} too large", out_dram_addr, dram_buffer_size_out);
 
     for(int core_idx_y = 0; core_idx_y < num_cores_r; core_idx_y++) {
         for(int core_idx_x = 0; core_idx_x < num_cores_c; core_idx_x++) {

--- a/tests/tt_metal/tt_metal/unit_tests_common/compute/matmul/test_matmul_multi_core_multi_dram_inX_mcast.cpp
+++ b/tests/tt_metal/tt_metal/unit_tests_common/compute/matmul/test_matmul_multi_core_multi_dram_inX_mcast.cpp
@@ -47,9 +47,9 @@ std::
     uint32_t in1_CB_size = in1_block_tiles * 2 * single_tile_size; // double buffer
     uint32_t out_CB_tiles = per_core_M * per_core_N;
     uint32_t out_CB_size = out_CB_tiles * single_tile_size;
-    TT_FATAL(in0_CB_size <= 130*1024);
-    TT_FATAL(in1_CB_size <= 130*1024);
-    TT_FATAL(out_CB_size <= 540*1024);
+    TT_FATAL(in0_CB_size <= 130*1024, "in0_CB_size {} too large", in0_CB_size);
+    TT_FATAL(in1_CB_size <= 130*1024, "in1_CB_size {} too large", in1_CB_size);
+    TT_FATAL(out_CB_size <= 540*1024, "out_CB_size {} too large", out_CB_size);
 
     CoreRange all_cores(
         {(std::size_t)start_core_x, (std::size_t)start_core_y},
@@ -192,9 +192,9 @@ bool write_runtime_args_to_device(
     uint32_t dram_buffer_size_weights = single_tile_size * K * N; // num_tiles of FP16_B, hard-coded in the reader/writer kernels
     uint32_t dram_buffer_size_out = single_tile_size * M * N; // num_tiles of FP16_B, hard-coded in the reader/writer kernels
 
-    TT_FATAL(in0_dram_addr + dram_buffer_size_act < 1024 * 1024 * 1024);
-    TT_FATAL(in1_dram_addr + dram_buffer_size_weights < 1024 * 1024 * 1024);
-    TT_FATAL(out_dram_addr + dram_buffer_size_out < 1024 * 1024 * 1024);
+    TT_FATAL(in0_dram_addr + dram_buffer_size_act < 1024 * 1024 * 1024, "addr {} + size {} too large", in0_dram_addr, dram_buffer_size_act);
+    TT_FATAL(in1_dram_addr + dram_buffer_size_weights < 1024 * 1024 * 1024, "addr {} + size {} too large", in1_dram_addr, dram_buffer_size_weights);
+    TT_FATAL(out_dram_addr + dram_buffer_size_out < 1024 * 1024 * 1024, "addr {} + size {} too large", out_dram_addr, dram_buffer_size_out);
 
     for(int core_idx_y = 0; core_idx_y < num_cores_r; core_idx_y++) {
         for(int core_idx_x = 0; core_idx_x < num_cores_c; core_idx_x++) {

--- a/tests/tt_metal/tt_metal/unit_tests_common/compute/matmul/test_matmul_single_core.cpp
+++ b/tests/tt_metal/tt_metal/unit_tests_common/compute/matmul/test_matmul_single_core.cpp
@@ -35,9 +35,9 @@ bool matmul_single_core(CommonFixture *fixture, tt_metal::Device *device, int M,
     log_info(LogTest, "Weights block = {}x{}, #blocks = {}, #sub-blocks = {}", out_subblock_w, in0_block_w, K / in0_block_w, N / out_subblock_w);
 
     uint32_t single_tile_size = 2 * 1024;
-    TT_FATAL(M * in0_block_w * single_tile_size * 2 <= 130*1024);
-    TT_FATAL(N * in0_block_w * single_tile_size * 2 <= 130*1024);
-    TT_FATAL(M * N * single_tile_size <= 540*1024);
+    TT_FATAL(M * in0_block_w * single_tile_size * 2 <= 130*1024, "Parameter mismatch {} {} {}", M, in0_block_w, single_tile_size);
+    TT_FATAL(N * in0_block_w * single_tile_size * 2 <= 130*1024, "Parameter mismatch {} {} {}", N, in0_block_w, single_tile_size);
+    TT_FATAL(M * N * single_tile_size <= 540*1024, "Parameter mismatch {} {} {}", M, N, single_tile_size);
     uint32_t dram_buffer_size_act = single_tile_size * M * K; // num_tiles of FP16_B, hard-coded in the reader/writer kernels
     uint32_t dram_buffer_size_weights = single_tile_size * K * N; // num_tiles of FP16_B, hard-coded in the reader/writer kernels
     uint32_t dram_buffer_size_out = single_tile_size * M * N; // num_tiles of FP16_B, hard-coded in the reader/writer kernels

--- a/tests/tt_metal/tt_metal/unit_tests_common/compute/test_flatten.cpp
+++ b/tests/tt_metal/tt_metal/unit_tests_common/compute/test_flatten.cpp
@@ -61,7 +61,7 @@ inline std::vector<uint32_t> gold_standard_flatten(std::vector<uint32_t> src_vec
         start_dram_addr_offset_for_tensor_row += num_tile_cols * 16;
     }
 
-    TT_FATAL(expected_dst_vec.size() == (num_tile_rows * 32) * (num_tile_cols * 16) * 32);
+    TT_FATAL(expected_dst_vec.size() == (num_tile_rows * 32) * (num_tile_cols * 16) * 32, "Unexpected dst vec size {}.", expected_dst_vec.size());
     return expected_dst_vec;
 }
 
@@ -175,7 +175,7 @@ bool flatten(CommonFixture *fixture, tt_metal::Device *device, uint32_t num_tile
     //                      Validation & Teardown
     ////////////////////////////////////////////////////////////////////////////
 
-    TT_FATAL(golden.size() == result_vec.size());
+    TT_FATAL(golden.size() == result_vec.size(), "Size mismatch between golden {} and result vec {}.", golden.size(), result_vec.size());
     pass &= (golden == result_vec);
 
     if (not pass) {

--- a/tests/tt_metal/tt_metal/unit_tests_common/dram/test_dram.cpp
+++ b/tests/tt_metal/tt_metal/unit_tests_common/dram/test_dram.cpp
@@ -37,7 +37,7 @@ bool dram_single_core_db (CommonFixture* fixture, tt_metal::Device *device){
     // We read and write total_l1_buffer_size_tiles / 2 tiles from and to DRAM
     uint32_t l1_buffer_addr = 400 * 1024;
     uint32_t total_l1_buffer_size_tiles = num_tiles / 2;
-    TT_FATAL(total_l1_buffer_size_tiles % 2 == 0);
+    TT_FATAL(total_l1_buffer_size_tiles % 2 == 0, "Error");
     uint32_t total_l1_buffer_size_bytes = total_l1_buffer_size_tiles * single_tile_size;
 
     tt_metal::InterleavedBufferConfig dram_config{

--- a/tests/tt_metal/tt_metal/unit_tests_fast_dispatch/command_queue/test_EnqueueWriteBuffer_and_EnqueueReadBuffer.cpp
+++ b/tests/tt_metal/tt_metal/unit_tests_fast_dispatch/command_queue/test_EnqueueWriteBuffer_and_EnqueueReadBuffer.cpp
@@ -81,7 +81,7 @@ class BufferStressTestConfigSharded {
 namespace local_test_functions {
 
 vector<uint32_t> generate_arange_vector(uint32_t size_bytes) {
-    TT_FATAL(size_bytes % sizeof(uint32_t) == 0);
+    TT_FATAL(size_bytes % sizeof(uint32_t) == 0, "Error");
     vector<uint32_t> src(size_bytes / sizeof(uint32_t), 0);
 
     for (uint32_t i = 0; i < src.size(); i++) {

--- a/tests/tt_metal/tt_metal/unit_tests_fast_dispatch/command_queue/test_HostAsyncCQ.cpp
+++ b/tests/tt_metal/tt_metal/unit_tests_fast_dispatch/command_queue/test_HostAsyncCQ.cpp
@@ -64,7 +64,7 @@ inline std::vector<uint32_t> gold_standard_flatten(std::vector<uint32_t> src_vec
         start_dram_addr_offset_for_tensor_row += num_tile_cols * 16;
     }
 
-    TT_FATAL(expected_dst_vec.size() == (num_tile_rows * 32) * (num_tile_cols * 16) * 32);
+    TT_FATAL(expected_dst_vec.size() == (num_tile_rows * 32) * (num_tile_cols * 16) * 32, "Error");
     return expected_dst_vec;
 }
 
@@ -182,7 +182,7 @@ bool flatten(Device *device, uint32_t num_tiles_r = 5, uint32_t num_tiles_c = 5)
         EnqueueReadBuffer(device->command_queue(), dst_dram_buffer, result_vec, true);
 
         // Validation of data
-        TT_FATAL(golden.size() == result_vec.size());
+        TT_FATAL(golden.size() == result_vec.size(), "Error");
         pass &= (golden == result_vec);
 
         if (not pass) {

--- a/tests/tt_metal/tt_metal/unit_tests_fast_dispatch/multichip/test_eth_EnqueueProgram.cpp
+++ b/tests/tt_metal/tt_metal/unit_tests_fast_dispatch/multichip/test_eth_EnqueueProgram.cpp
@@ -451,7 +451,7 @@ bool chip_to_chip_interleaved_buffer_transfer(
     const uint32_t input0_cb_index = 0;
     const uint32_t output_cb_index = 16;
 
-    TT_FATAL(cfg.num_pages * cfg.page_size_bytes == cfg.size_bytes);
+    TT_FATAL(cfg.num_pages * cfg.page_size_bytes == cfg.size_bytes, "Error");
     constexpr uint32_t num_pages_cb = 1;
 
     ////////////////////////////////////////////////////////////////////////////

--- a/tests/tt_metal/tt_metal/unit_tests_fast_dispatch/pipelining/basic_pipeline.cpp
+++ b/tests/tt_metal/tt_metal/unit_tests_fast_dispatch/pipelining/basic_pipeline.cpp
@@ -53,8 +53,8 @@ void create_and_run_row_pipeline(tt_metal::Device* device, const PipelineRowConf
     uint32_t num_blocks_in_CB = (uint32_t)test_config.num_blocks_in_CB;
     uint32_t num_repetitions = (uint32_t)test_config.num_repetitions;
 
-    TT_FATAL(num_cores >= 2 && num_cores <= 12);  // grayskull
-    TT_FATAL(num_tiles % block_size_tiles == 0);
+    TT_FATAL(num_cores >= 2 && num_cores <= 12, "Error");  // grayskull
+    TT_FATAL(num_tiles % block_size_tiles == 0, "Error");
 
     std::vector<CoreCoord> cores;
     for (uint32_t i = 0; i < num_cores; i++) {

--- a/tests/tt_metal/tt_metal/unit_tests_fast_dispatch_single_chip_multi_queue/common/command_queue_test_utils.hpp
+++ b/tests/tt_metal/tt_metal/unit_tests_fast_dispatch_single_chip_multi_queue/common/command_queue_test_utils.hpp
@@ -28,7 +28,7 @@ struct BufferStressTestConfig {
 
 
 inline std::vector<uint32_t> generate_arange_vector(uint32_t size_bytes, uint32_t start = 0) {
-    TT_FATAL(size_bytes % sizeof(uint32_t) == 0);
+    TT_FATAL(size_bytes % sizeof(uint32_t) == 0, "Error");
     vector<uint32_t> src(size_bytes / sizeof(uint32_t), 0);
 
     for (uint32_t i = 0; i < src.size(); i++) {

--- a/tests/ttnn/unit_tests/gtests/ccl/test_erisc_data_mover_with_workers.cpp
+++ b/tests/ttnn/unit_tests/gtests/ccl/test_erisc_data_mover_with_workers.cpp
@@ -704,7 +704,7 @@ int TestEntrypoint(
     bool initialized = false;
     tt_xy_pair eth_sender_core;
     do {
-        TT_FATAL(eth_sender_core_iter != eth_sender_core_iter_end);
+        TT_FATAL(eth_sender_core_iter != eth_sender_core_iter_end, "Error");
         std::tie(device_id, eth_receiver_core) = device_0->get_connected_ethernet_core(*eth_sender_core_iter);
         eth_sender_core = *eth_sender_core_iter;
         eth_sender_core_iter++;

--- a/tests/ttnn/unit_tests/gtests/test_add.cpp
+++ b/tests/ttnn/unit_tests/gtests/test_add.cpp
@@ -35,7 +35,7 @@ TEST_P(Add1DTensorAndScalarFixture, AddsScalarCorrectly) {
         const auto output_tensor = input_tensor + param.scalar;
         const auto expected_tensor =
             ttnn::operations::creation::full(shape, param.scalar, ttnn::bfloat16, ttnn::TILE_LAYOUT, device);
-        TT_FATAL(tt::numpy::allclose<::bfloat16>(ttnn::from_device(expected_tensor), ttnn::from_device(output_tensor)));
+        TT_FATAL(tt::numpy::allclose<::bfloat16>(ttnn::from_device(expected_tensor), ttnn::from_device(output_tensor)), "Error");
     }
     ttnn::close_device(device);
 }

--- a/tt_metal/common/assert.hpp
+++ b/tt_metal/common/assert.hpp
@@ -185,11 +185,11 @@ void tt_assert(char const* file, int line, const std::string& assert_type, bool 
 #endif
 
 #ifndef TT_FATAL
-#define TT_FATAL(condition, ...)                                                             \
-    do {                                                                                     \
-        if (not(condition)) {                                                                \
-            tt::assert::tt_throw(__FILE__, __LINE__, "TT_FATAL", #condition, ##__VA_ARGS__); \
-            __builtin_unreachable();                                                         \
-        }                                                                                    \
+#define TT_FATAL(condition, message, ...)                                                             \
+    do {                                                                                              \
+        if (not(condition)) {                                                                         \
+            tt::assert::tt_throw(__FILE__, __LINE__, "TT_FATAL", #condition, message, ##__VA_ARGS__); \
+            __builtin_unreachable();                                                                  \
+        }                                                                                             \
     } while (0)
 #endif

--- a/tt_metal/common/math.hpp
+++ b/tt_metal/common/math.hpp
@@ -13,7 +13,7 @@
 namespace tt {
 
 inline uint32_t div_up(uint32_t a, uint32_t b) {
-    TT_FATAL(b > 0);
+    TT_FATAL(b > 0, "Divide by 0 error");
     return static_cast<uint32_t>((a + b - 1) / b);
 }
 
@@ -22,7 +22,7 @@ inline uint32_t round_up(uint32_t a, uint32_t b) { return b * div_up(a, b); }
 inline constexpr std::uint32_t round_down(std::uint32_t a, std::uint32_t b) { return a / b * b; }
 
 inline uint32_t positive_pow_of_2(uint32_t exponent) {
-    TT_FATAL(exponent >= 0 && exponent < 32);
+    TT_FATAL(exponent >= 0 && exponent < 32, "Exponent {} out of bounds.", exponent);
     uint32_t result = 1;
     return (result << exponent);
 }

--- a/tt_metal/impl/allocator/allocator.cpp
+++ b/tt_metal/impl/allocator/allocator.cpp
@@ -127,7 +127,7 @@ uint64_t BankManager::allocate_buffer(
     DeviceAddr address_limit = 0;
     if (!is_sharded and this->buffer_type_ == BufferType::L1) {
         address_limit = this->interleaved_address_limit_;
-        TT_FATAL(address_limit > 0);
+        TT_FATAL(address_limit > 0, "Address limit {} needs to be larger than zero.", address_limit);
     }
     TT_ASSERT(bool(this->allocator_), "Allocator not initialized!");
     auto address = this->allocator_->allocate(size_per_bank, bottom_up, address_limit);

--- a/tt_metal/impl/buffers/buffer.cpp
+++ b/tt_metal/impl/buffers/buffer.cpp
@@ -131,7 +131,7 @@ Buffer::Buffer(
     bottom_up_(bottom_up),
     buffer_page_mapping_(nullptr),
     allocate_(allocate) {
-    TT_FATAL(this->device_ != nullptr and this->device_->allocator_ != nullptr);
+    TT_FATAL(this->device_ != nullptr and this->device_->allocator_ != nullptr, "Device and allocator need to not be null.");
     validate_buffer_size_and_page_size(size, page_size, buffer_type, buffer_layout, shard_parameters);
     if (allocate) {
         this->allocate();

--- a/tt_metal/impl/debug/dprint_server.cpp
+++ b/tt_metal/impl/debug/dprint_server.cpp
@@ -384,7 +384,7 @@ DebugPrintServerContext::~DebugPrintServerContext() {
     // Wait for the thread to end, with a timeout
     auto future = std::async(std::launch::async, &std::thread::join, print_server_thread_);
     if (future.wait_for(std::chrono::seconds(2)) == std::future_status::timeout) {
-        TT_FATAL(false && "Timed out waiting on debug print thread to terminate.");
+        TT_THROW("Timed out waiting on debug print thread to terminate.");
     }
     delete print_server_thread_;
     print_server_thread_ = nullptr;
@@ -884,7 +884,7 @@ bool DebugPrintServerContext::PeekOneHartNonBlocking(
                     }
                 break;
                 default:
-                    TT_FATAL("Unexpected debug print type code" && false);
+                    TT_THROW("Unexpected debug print type code");
             }
 
             // TODO(AP): this is slow but leaving here for now for debugging the debug prints themselves
@@ -1048,7 +1048,7 @@ void DprintServerAwait() {
             DebugPrintServerContext::inst
         );
         if (future.wait_for(std::chrono::seconds(1)) == std::future_status::timeout) {
-            TT_FATAL(false && "Timed out waiting on debug print server to read data.");
+            TT_THROW("Timed out waiting on debug print server to read data.");
         }
     }
 }

--- a/tt_metal/impl/dispatch/command_queue.cpp
+++ b/tt_metal/impl/dispatch/command_queue.cpp
@@ -468,7 +468,7 @@ void generate_runtime_args_cmds(
     if (no_stride) {
         TT_FATAL(
             max_packed_cmds >= num_packed_cmds_in_seq,
-            "num_packed_cmds_in_seq {} cannot exceed max_packed_cmds {}",
+            "num_packed_cmds_in_seq {} cannot exceed max_packed_cmds {} when no_stride is true",
             num_packed_cmds_in_seq,
             max_packed_cmds);
     }

--- a/tt_metal/impl/dispatch/command_queue.cpp
+++ b/tt_metal/impl/dispatch/command_queue.cpp
@@ -466,7 +466,11 @@ void generate_runtime_args_cmds(
         max_runtime_args_len, max_prefetch_command_size, packed_write_max_unicast_sub_cmds, no_stride);
     uint32_t offset_idx = 0;
     if (no_stride) {
-        TT_FATAL(max_packed_cmds >= num_packed_cmds_in_seq);
+        TT_FATAL(
+            max_packed_cmds >= num_packed_cmds_in_seq,
+            "num_packed_cmds_in_seq {} cannot exceed max_packed_cmds {}",
+            num_packed_cmds_in_seq,
+            max_packed_cmds);
     }
     while (num_packed_cmds_in_seq != 0) {
         // Generate the device command

--- a/tt_metal/impl/dispatch/command_queue_interface.hpp
+++ b/tt_metal/impl/dispatch/command_queue_interface.hpp
@@ -414,6 +414,9 @@ class SystemMemoryManager {
             TT_FATAL(
                 dispatch_constants::get(core_type).max_prefetch_command_size() *
                     (dispatch_constants::get(core_type).prefetch_q_entries() + 2) <=
+                this->get_issue_queue_size(cq_id),
+                "Issue queue for cq_id {} has size of {} which is too small",
+                cq_id,
                 this->get_issue_queue_size(cq_id));
             this->cq_to_event.push_back(0);
             this->cq_to_last_completed_event.push_back(0);

--- a/tt_metal/impl/dispatch/data_collection.cpp
+++ b/tt_metal/impl/dispatch/data_collection.cpp
@@ -178,7 +178,7 @@ string DispatchClassToString(enum dispatch_core_processor_classes proc_class, Co
             else
                 return "";
         default:
-            TT_FATAL(false, "Incompatible core type: {}", core_type);
+            TT_THROW("Incompatible core type: {}", core_type);
     }
     return "";
 }

--- a/tt_metal/impl/dispatch/data_collection.cpp
+++ b/tt_metal/impl/dispatch/data_collection.cpp
@@ -178,7 +178,7 @@ string DispatchClassToString(enum dispatch_core_processor_classes proc_class, Co
             else
                 return "";
         default:
-            TT_FATAL("Incompatible core type: {}", core_type);
+            TT_FATAL(false, "Incompatible core type: {}", core_type);
     }
     return "";
 }

--- a/tt_metal/impl/dispatch/debug_tools.cpp
+++ b/tt_metal/impl/dispatch/debug_tools.cpp
@@ -185,7 +185,7 @@ uint32_t dump_dispatch_cmd(CQDispatchCmd *cmd, uint32_t cmd_addr, std::ofstream 
             case CQ_DISPATCH_CMD_EXEC_BUF_END: break;
             case CQ_DISPATCH_CMD_REMOTE_WRITE: break;
             case CQ_DISPATCH_CMD_TERMINATE: break;
-            default: TT_FATAL("Unrecognized dispatch command: {}", cmd_id); break;
+            default: TT_FATAL(false, "Unrecognized dispatch command: {}", cmd_id); break;
         }
     }
     return stride;
@@ -542,7 +542,7 @@ void dump_command_queue_raw_data(
         base_addr = cq_interface.offset + CQ_START;
         queue_type_name = "Issue";
     } else {
-        TT_FATAL("Unrecognized CQ type: {}", queue_type);
+        TT_FATAL(false, "Unrecognized CQ type: {}", queue_type);
     }
 
     // Read out in pages

--- a/tt_metal/impl/dispatch/debug_tools.cpp
+++ b/tt_metal/impl/dispatch/debug_tools.cpp
@@ -185,7 +185,8 @@ uint32_t dump_dispatch_cmd(CQDispatchCmd *cmd, uint32_t cmd_addr, std::ofstream 
             case CQ_DISPATCH_CMD_EXEC_BUF_END: break;
             case CQ_DISPATCH_CMD_REMOTE_WRITE: break;
             case CQ_DISPATCH_CMD_TERMINATE: break;
-            default: TT_FATAL(false, "Unrecognized dispatch command: {}", cmd_id); break;
+            case CQ_DISPATCH_CMD_SET_WRITE_OFFSET: break;
+            default: TT_THROW("Unrecognized dispatch command: {}", cmd_id); break;
         }
     }
     return stride;
@@ -542,7 +543,7 @@ void dump_command_queue_raw_data(
         base_addr = cq_interface.offset + CQ_START;
         queue_type_name = "Issue";
     } else {
-        TT_FATAL(false, "Unrecognized CQ type: {}", queue_type);
+        TT_THROW("Unrecognized CQ type: {}", queue_type);
     }
 
     // Read out in pages

--- a/tt_metal/impl/program/program.cpp
+++ b/tt_metal/impl/program/program.cpp
@@ -862,7 +862,7 @@ uint32_t Program::finalize_rt_args(uint32_t programmable_core_type_index, uint32
 
     // TODO: this is asserted here as the leveling above can break the limits enforced by the API
     // Once we use a ring buffer, memory space will be dynamic and this assert won't matter
-    TT_FATAL(offset <= L1_KERNEL_CONFIG_SIZE);
+    TT_FATAL(offset <= L1_KERNEL_CONFIG_SIZE, "offset {} cannot exceed config size {}", offset, L1_KERNEL_CONFIG_SIZE);
 
     return max_unique_rta_size + total_crta_size;
 }

--- a/tt_metal/impl/trace/trace.cpp
+++ b/tt_metal/impl/trace/trace.cpp
@@ -29,7 +29,7 @@ static constexpr uint32_t kExecBufPageMax = 4096;
 size_t interleaved_page_size(
     const uint32_t buf_size, const uint32_t num_banks, const uint32_t min_size, const uint32_t max_size) {
     // Populate power of 2 numbers within min and max as candidates
-    TT_FATAL(min_size > 0 and min_size <= max_size);
+    TT_FATAL(min_size > 0 and min_size <= max_size, "min_size {} not positive and less than or equal to max_size {}.", min_size, max_size);
     vector<uint32_t> candidates;
     candidates.reserve(__builtin_clz(min_size) - __builtin_clz(max_size) + 1);
     for (uint32_t size = 1; size <= max_size; size <<= 1) {
@@ -50,7 +50,7 @@ size_t interleaved_page_size(
             pick = size;
         }
     }
-    TT_FATAL(pick >= min_size and pick <= max_size);
+    TT_FATAL(pick >= min_size and pick <= max_size, "pick {} not between min_size {} and max_size {}", pick, min_size, max_size);
     return pick;
 }
 }  // namespace

--- a/tt_metal/jit_build/genfiles.cpp
+++ b/tt_metal/jit_build/genfiles.cpp
@@ -37,9 +37,7 @@ static string get_absolute_path(const string& file_path_string) {
     // If the path doesn't exist as a absolute/relative path, then it must be relative to TT_METAL_HOME.
     if (!fs::exists(file_path)) {
         file_path = fs::path(llrt::OptionsG.get_root_dir() + file_path_string);
-        if (!fs::exists(file_path)) {
-            TT_FATAL("Kernel file {} doesn't exist!", file_path_string);
-        }
+        TT_FATAL(fs::exists(file_path), "Kernel file {} doesn't exist!", file_path_string);
     }
 
     // Convert to absolute path and return

--- a/tt_metal/llrt/llrt.cpp
+++ b/tt_metal/llrt/llrt.cpp
@@ -294,7 +294,9 @@ static bool check_if_riscs_on_specified_core_done(chip_id_t chip_id, const CoreC
                 run,
                 run_state,
                 RUN_MSG_DONE);
-            TT_FATAL(run_mailbox_read_val[0] == run_state || run_mailbox_read_val[0] == RUN_MSG_DONE);
+            TT_FATAL(
+                run_mailbox_read_val[0] == run_state || run_mailbox_read_val[0] == RUN_MSG_DONE,
+                "Read unexpected run_mailbox value");
         }
 
         return run == RUN_MSG_DONE;

--- a/tt_metal/llrt/tt_cluster.cpp
+++ b/tt_metal/llrt/tt_cluster.cpp
@@ -90,7 +90,10 @@ void Cluster::detect_arch_and_target() {
         get_string(this->arch_));
 #endif
 
-    TT_FATAL(this->target_type_ == TargetDevice::Silicon or this->target_type_ == TargetDevice::Simulator);
+    TT_FATAL(
+        this->target_type_ == TargetDevice::Silicon or this->target_type_ == TargetDevice::Simulator,
+        "Target type={} is not supported",
+        this->target_type_);
 }
 
 std::filesystem::path get_cluster_desc_yaml() {
@@ -277,7 +280,7 @@ void Cluster::open_driver(
 
         // Adding this check is a workaround for current UMD bug that only uses this getter to populate private metadata
         // that is later expected to be populated by unrelated APIs
-        TT_FATAL(device_driver->get_target_mmio_device_ids().size() == 1);
+        TT_FATAL(device_driver->get_target_mmio_device_ids().size() == 1, "Only one target mmio device id allowed.");
     } else if (this->target_type_ == TargetDevice::Simulator) {
         device_driver = std::make_unique<tt_SimulationDevice>(sdesc_path);
     }

--- a/tt_metal/programming_examples/eltwise_binary/eltwise_binary.cpp
+++ b/tt_metal/programming_examples/eltwise_binary/eltwise_binary.cpp
@@ -351,7 +351,7 @@ int main(int argc, char **argv) {
         TT_THROW("Test Failed");
     }
 
-    TT_FATAL(pass);
+    TT_FATAL(pass, "Error");
 
     return 0;
 }

--- a/tt_metal/programming_examples/eltwise_binary/eltwise_binary.cpp
+++ b/tt_metal/programming_examples/eltwise_binary/eltwise_binary.cpp
@@ -351,7 +351,5 @@ int main(int argc, char **argv) {
         TT_THROW("Test Failed");
     }
 
-    TT_FATAL(pass, "Error");
-
     return 0;
 }

--- a/tt_metal/programming_examples/eltwise_sfpu/eltwise_sfpu.cpp
+++ b/tt_metal/programming_examples/eltwise_sfpu/eltwise_sfpu.cpp
@@ -190,7 +190,7 @@ int main(int argc, char **argv) {
         TT_THROW("Test Failed");
     }
 
-    TT_FATAL(pass);
+    TT_FATAL(pass, "Error");
 
     return 0;
 }

--- a/tt_metal/programming_examples/eltwise_sfpu/eltwise_sfpu.cpp
+++ b/tt_metal/programming_examples/eltwise_sfpu/eltwise_sfpu.cpp
@@ -190,7 +190,5 @@ int main(int argc, char **argv) {
         TT_THROW("Test Failed");
     }
 
-    TT_FATAL(pass, "Error");
-
     return 0;
 }

--- a/tt_metal/programming_examples/loopback/loopback.cpp
+++ b/tt_metal/programming_examples/loopback/loopback.cpp
@@ -122,8 +122,5 @@ int main(int argc, char **argv) {
         TT_THROW("Test Failed");
     }
 
-    // Error out with non-zero return code if we don't detect a pass
-    TT_FATAL(pass, "Error");
-
     return 0;
 }

--- a/tt_metal/programming_examples/loopback/loopback.cpp
+++ b/tt_metal/programming_examples/loopback/loopback.cpp
@@ -123,7 +123,7 @@ int main(int argc, char **argv) {
     }
 
     // Error out with non-zero return code if we don't detect a pass
-    TT_FATAL(pass);
+    TT_FATAL(pass, "Error");
 
     return 0;
 }

--- a/tt_metal/programming_examples/profiler/test_custom_cycle_count/test_custom_cycle_count.cpp
+++ b/tt_metal/programming_examples/profiler/test_custom_cycle_count/test_custom_cycle_count.cpp
@@ -79,7 +79,7 @@ int main(int argc, char **argv) {
         TT_THROW("Test Failed");
     }
 
-    TT_FATAL(pass);
+    TT_FATAL(pass, "Error");
 
     return 0;
 }

--- a/tt_metal/programming_examples/profiler/test_custom_cycle_count/test_custom_cycle_count.cpp
+++ b/tt_metal/programming_examples/profiler/test_custom_cycle_count/test_custom_cycle_count.cpp
@@ -79,7 +79,5 @@ int main(int argc, char **argv) {
         TT_THROW("Test Failed");
     }
 
-    TT_FATAL(pass, "Error");
-
     return 0;
 }

--- a/tt_metal/programming_examples/profiler/test_custom_cycle_count_slow_dispatch/test_custom_cycle_count_slow_dispatch.cpp
+++ b/tt_metal/programming_examples/profiler/test_custom_cycle_count_slow_dispatch/test_custom_cycle_count_slow_dispatch.cpp
@@ -78,7 +78,5 @@ int main(int argc, char **argv) {
         TT_THROW("Test Failed");
     }
 
-    TT_FATAL(pass, "Error");
-
     return 0;
 }

--- a/tt_metal/programming_examples/profiler/test_custom_cycle_count_slow_dispatch/test_custom_cycle_count_slow_dispatch.cpp
+++ b/tt_metal/programming_examples/profiler/test_custom_cycle_count_slow_dispatch/test_custom_cycle_count_slow_dispatch.cpp
@@ -78,7 +78,7 @@ int main(int argc, char **argv) {
         TT_THROW("Test Failed");
     }
 
-    TT_FATAL(pass);
+    TT_FATAL(pass, "Error");
 
     return 0;
 }

--- a/tt_metal/programming_examples/profiler/test_dispatch_cores/test_dispatch_cores.cpp
+++ b/tt_metal/programming_examples/profiler/test_dispatch_cores/test_dispatch_cores.cpp
@@ -75,7 +75,7 @@ int main(int argc, char **argv) {
         TT_THROW("Test Failed");
     }
 
-    TT_FATAL(pass);
+    TT_FATAL(pass, "Error");
 
     return 0;
 }

--- a/tt_metal/programming_examples/profiler/test_dispatch_cores/test_dispatch_cores.cpp
+++ b/tt_metal/programming_examples/profiler/test_dispatch_cores/test_dispatch_cores.cpp
@@ -75,7 +75,5 @@ int main(int argc, char **argv) {
         TT_THROW("Test Failed");
     }
 
-    TT_FATAL(pass, "Error");
-
     return 0;
 }

--- a/tt_metal/programming_examples/profiler/test_full_buffer/test_full_buffer.cpp
+++ b/tt_metal/programming_examples/profiler/test_full_buffer/test_full_buffer.cpp
@@ -94,7 +94,5 @@ int main(int argc, char **argv) {
         TT_THROW("Test Failed");
     }
 
-    TT_FATAL(pass, "Error");
-
     return 0;
 }

--- a/tt_metal/programming_examples/profiler/test_full_buffer/test_full_buffer.cpp
+++ b/tt_metal/programming_examples/profiler/test_full_buffer/test_full_buffer.cpp
@@ -94,7 +94,7 @@ int main(int argc, char **argv) {
         TT_THROW("Test Failed");
     }
 
-    TT_FATAL(pass);
+    TT_FATAL(pass, "Error");
 
     return 0;
 }

--- a/tt_metal/programming_examples/profiler/test_multi_op/test_multi_op.cpp
+++ b/tt_metal/programming_examples/profiler/test_multi_op/test_multi_op.cpp
@@ -76,7 +76,7 @@ int main(int argc, char **argv) {
         TT_THROW("Test Failed");
     }
 
-    TT_FATAL(pass);
+    TT_FATAL(pass, "Error");
 
     return 0;
 }

--- a/tt_metal/programming_examples/profiler/test_multi_op/test_multi_op.cpp
+++ b/tt_metal/programming_examples/profiler/test_multi_op/test_multi_op.cpp
@@ -76,7 +76,5 @@ int main(int argc, char **argv) {
         TT_THROW("Test Failed");
     }
 
-    TT_FATAL(pass, "Error");
-
     return 0;
 }

--- a/tt_metal/tt_metal.cpp
+++ b/tt_metal/tt_metal.cpp
@@ -423,11 +423,11 @@ void WriteToDeviceInterleavedContiguous(const Buffer &buffer, const std::vector<
         buffer.size());
 
     uint32_t page_size = buffer.page_size();
-    TT_FATAL(buffer.size() % page_size == 0);
+    TT_FATAL(buffer.size() % page_size == 0, "Buffer size {} mod page_size {} needs to be 0.", buffer.size(), page_size);
     uint32_t num_pages = buffer.size() / page_size;
 
     static constexpr uint32_t bytes_per_page_entry = sizeof(uint32_t);
-    TT_FATAL(page_size % bytes_per_page_entry == 0);
+    TT_FATAL(page_size % bytes_per_page_entry == 0, "Page size {} mod bytes per page entry needs to be 0", page_size, bytes_per_page_entry);
     uint32_t num_entries_per_page = page_size / bytes_per_page_entry;
 
     auto device = buffer.device();
@@ -446,7 +446,7 @@ void WriteToDeviceInterleavedContiguous(const Buffer &buffer, const std::vector<
                 auto noc_coordinates = buffer.noc_coordinates(bank_index);
                 llrt::write_hex_vec_to_core(device->id(), noc_coordinates, page, absolute_address);
             } break;
-            default: TT_FATAL(false && "Unsupported buffer type to write to device!");
+            default: TT_THROW("Unsupported buffer type to write to device!");
         }
 
         bank_index = (bank_index + 1) % num_banks;
@@ -478,16 +478,16 @@ void WriteToBuffer(Buffer &buffer, const std::vector<uint32_t> &host_buffer) {
             WriteToDevice(buffer, host_buffer);
         } break;
         case BufferType::SYSTEM_MEMORY: {
-            TT_FATAL(false && "Writing to host memory is unsupported!");
+            TT_THROW("Writing to host memory is unsupported!");
         } break;
-        default: TT_FATAL(false && "Unsupported buffer type!");
+        default: TT_THROW("Unsupported buffer type!");
     }
 }
 
 void ReadFromDeviceInterleavedContiguous(const Buffer &buffer, std::vector<uint32_t> &host_buffer) {
     host_buffer.clear();  // overwrite the data
     uint32_t page_size = buffer.page_size();
-    TT_FATAL(buffer.size() % page_size == 0);
+    TT_FATAL(buffer.size() % page_size == 0, "Buffer size {} mod page_size {} needs to be 0.", buffer.size(), page_size);
     uint32_t num_pages = buffer.size() / page_size;
 
     auto device = buffer.device();
@@ -505,7 +505,7 @@ void ReadFromDeviceInterleavedContiguous(const Buffer &buffer, std::vector<uint3
                 auto noc_coordinates = buffer.noc_coordinates(bank_index);
                 page = llrt::read_hex_vec_from_core(device->id(), noc_coordinates, absolute_address, page_size);
             } break;
-            default: TT_FATAL(false && "Unsupported buffer type to read from device!");
+            default: TT_THROW("Unsupported buffer type to read from device!");
         }
 
         // Copy page into host buffer
@@ -596,9 +596,9 @@ void ReadFromBuffer(Buffer &buffer, std::vector<uint32_t> &host_buffer, bool sha
             ReadFromDevice(buffer, host_buffer, shard_order);
         } break;
         case BufferType::SYSTEM_MEMORY: {
-            TT_FATAL(false && "Reading from host memory is unsupported!");
+            TT_THROW("Reading from host memory is unsupported!");
         } break;
-        default: TT_FATAL(false && "Unsupported buffer type!");
+        default: TT_THROW("Unsupported buffer type!");
     }
 }
 

--- a/tt_metal/tt_metal.cpp
+++ b/tt_metal/tt_metal.cpp
@@ -423,11 +423,16 @@ void WriteToDeviceInterleavedContiguous(const Buffer &buffer, const std::vector<
         buffer.size());
 
     uint32_t page_size = buffer.page_size();
-    TT_FATAL(buffer.size() % page_size == 0, "Buffer size {} mod page_size {} needs to be 0.", buffer.size(), page_size);
+    TT_FATAL(
+        buffer.size() % page_size == 0,
+        "Invalid buffer size: {}. Buffer size must be a multiple of page size {}.",
+        buffer.size(),
+        page_size);
     uint32_t num_pages = buffer.size() / page_size;
 
     static constexpr uint32_t bytes_per_page_entry = sizeof(uint32_t);
-    TT_FATAL(page_size % bytes_per_page_entry == 0, "Page size {} mod bytes per page entry needs to be 0", page_size, bytes_per_page_entry);
+    TT_FATAL(page_size % bytes_per_page_entry == 0,
+        "Invalid page size: {}. Page size  must be a multiple of bytes per page entry {}.", page_size, bytes_per_page_entry);
     uint32_t num_entries_per_page = page_size / bytes_per_page_entry;
 
     auto device = buffer.device();
@@ -487,7 +492,11 @@ void WriteToBuffer(Buffer &buffer, const std::vector<uint32_t> &host_buffer) {
 void ReadFromDeviceInterleavedContiguous(const Buffer &buffer, std::vector<uint32_t> &host_buffer) {
     host_buffer.clear();  // overwrite the data
     uint32_t page_size = buffer.page_size();
-    TT_FATAL(buffer.size() % page_size == 0, "Buffer size {} mod page_size {} needs to be 0.", buffer.size(), page_size);
+    TT_FATAL(
+        buffer.size() % page_size == 0,
+        "Invalid buffer size: {}. Buffer size must be a multiple of page size {}.",
+        buffer.size(),
+        page_size);
     uint32_t num_pages = buffer.size() / page_size;
 
     auto device = buffer.device();

--- a/ttnn/cpp/ttnn/deprecated/tt_dnn/op_library/moreh_getitem/moreh_getitem_op.cpp
+++ b/ttnn/cpp/ttnn/deprecated/tt_dnn/op_library/moreh_getitem/moreh_getitem_op.cpp
@@ -26,7 +26,7 @@ void MorehGetitem::validate_with_output_tensors(
     TT_FATAL(input_tensor.storage_type() == StorageType::DEVICE, "Operands to getitem need to be on device!");
     TT_FATAL(input_tensor.buffer() != nullptr, "Operands to getitem need to be allocated in buffers on device!");
     auto dtype = input_tensor.get_dtype();
-    TT_FATAL(dtype == DataType::INT32 || dtype == DataType::BFLOAT16);
+    TT_FATAL(dtype == DataType::INT32 || dtype == DataType::BFLOAT16, "Error");
 
     // validate index tensors
     uint32_t index_size = input_tensors.at(1).get_legacy_shape()[-1];
@@ -34,14 +34,14 @@ void MorehGetitem::validate_with_output_tensors(
         auto& index_tensor = input_tensors.at(i);
         TT_FATAL(index_tensor.storage_type() == StorageType::DEVICE, "Operands to getitem need to be on device!");
         TT_FATAL(index_tensor.buffer() != nullptr, "Operands to getitem need to be allocated in buffers on device!");
-        TT_FATAL(index_tensor.get_dtype() == DataType::INT32);
+        TT_FATAL(index_tensor.get_dtype() == DataType::INT32, "Error");
 
         auto index_shape = index_tensor.get_legacy_shape();
         auto index_layout = index_tensor.get_layout();
         if (index_layout == Layout::ROW_MAJOR) {
-            TT_FATAL(index_shape.rank() == 1);
+            TT_FATAL(index_shape.rank() == 1, "Error");
         } else if (index_layout == Layout::TILE) {
-            TT_FATAL(index_shape.rank() == 5);
+            TT_FATAL(index_shape.rank() == 5, "Error");
         }
         TT_FATAL(
             !(input_layout == Layout::ROW_MAJOR && index_layout == Layout::TILE),
@@ -69,7 +69,7 @@ void MorehGetitem::validate_with_output_tensors(
         return;
     }
     TT_FATAL(output_tensors.size() == 1, "Must have 1 output tensor");
-    TT_FATAL(dtype == output_tensors.front().value().get_dtype());
+    TT_FATAL(dtype == output_tensors.front().value().get_dtype(), "Error");
 }
 
 std::vector<Shape> MorehGetitem::compute_output_shapes(const std::vector<Tensor>& input_tensors) const {

--- a/ttnn/cpp/ttnn/deprecated/tt_dnn/op_library/moreh_helper_functions.cpp
+++ b/ttnn/cpp/ttnn/deprecated/tt_dnn/op_library/moreh_helper_functions.cpp
@@ -391,8 +391,8 @@ void validate_output_with_keepdim(const Tensor &input, const Tensor &output, con
         expand_to_max_dim(output_dim_wo_padding, output_shape_wo_padding);
 
         for (int i = 0; i < input_rank; ++i) {
-            TT_FATAL(input_dim[i] == output_dim[i]);
-            TT_FATAL(input_dim_wo_padding[i] == output_dim_wo_padding[i]);
+            TT_FATAL(input_dim[i] == output_dim[i], "Error");
+            TT_FATAL(input_dim_wo_padding[i] == output_dim_wo_padding[i], "Error");
         }
     } else {
         std::vector<uint32_t> expected_output_shape;
@@ -412,8 +412,8 @@ void validate_output_with_keepdim(const Tensor &input, const Tensor &output, con
         for (int i = 0; i < input_rank; ++i) {
             if (i == dim)
                 continue;
-            TT_FATAL(input_shape[i] == expected_output_shape[i]);
-            TT_FATAL(input_shape_wo_padding[i] == expected_output_shape_wo_padding[i]);
+            TT_FATAL(input_shape[i] == expected_output_shape[i], "Error");
+            TT_FATAL(input_shape_wo_padding[i] == expected_output_shape_wo_padding[i], "Error");
         }
     }
 }

--- a/ttnn/cpp/ttnn/deprecated/tt_dnn/op_library/moreh_linear_backward/moreh_linear_backward_op.cpp
+++ b/ttnn/cpp/ttnn/deprecated/tt_dnn/op_library/moreh_linear_backward/moreh_linear_backward_op.cpp
@@ -52,7 +52,7 @@ std::vector<Tensor> MorehBiasAddBackward::create_output_tensors(
         return {output_tensors.at(0).value()};
     }
 
-    TT_FATAL(input_tensors.size() == 2);
+    TT_FATAL(input_tensors.size() == 2, "Error");
     return operation::generic_create_output_tensors(
         *this, input_tensors, input_tensors.at(1).get_dtype(), Layout::TILE, this->bias_grad_mem_config);
 }
@@ -111,7 +111,7 @@ std::vector<std::optional<Tensor>> moreh_linear_backward(
             weight.storage_type() == StorageType::DEVICE,
         "input and weight tensors need to be on device");
 
-    TT_FATAL(output_grad.storage_type() == StorageType::DEVICE);
+    TT_FATAL(output_grad.storage_type() == StorageType::DEVICE, "Error");
     auto kernel_config_val = init_device_compute_kernel_config(output_grad.device()->arch(), compute_kernel_config, MathFidelity::HiFi4);
 
     moreh_linear_backward_validate(output_grad, input, weight, input_grad, weight_grad, bias_grad);

--- a/ttnn/cpp/ttnn/deprecated/tt_dnn/op_library/moreh_matmul/moreh_matmul_op.cpp
+++ b/ttnn/cpp/ttnn/deprecated/tt_dnn/op_library/moreh_matmul/moreh_matmul_op.cpp
@@ -250,7 +250,7 @@ Tensor moreh_matmul_(
     std::optional<const ttnn::DeviceComputeKernelConfig> compute_kernel_config) {
     log_debug(LogOp, "{}:{} run matmul {} {}", __func__, __LINE__, transpose_input, transpose_other);
 
-    TT_FATAL(input.storage_type() == StorageType::DEVICE);
+    TT_FATAL(input.storage_type() == StorageType::DEVICE, "Error");
     auto kernel_config_val = init_device_compute_kernel_config(input.device()->arch(), compute_kernel_config, MathFidelity::HiFi4);
 
     std::vector<Tensor> output_tensors = {Tensor(operation::get_workers_for_op_output({input, other}, {bias}))};

--- a/ttnn/cpp/ttnn/deprecated/tt_dnn/op_library/moreh_matmul/multi_core/moreh_matmul_op_multi_core.cpp
+++ b/ttnn/cpp/ttnn/deprecated/tt_dnn/op_library/moreh_matmul/multi_core/moreh_matmul_op_multi_core.cpp
@@ -345,7 +345,7 @@ operation::ProgramWithCallbacks moreh_matmul_multi_core(
                 compute_rt_args
             );
         } else if (core_group_2.core_coord_in_core_ranges(core)) {
-            TT_FATAL(compute_kernel_2_id.has_value());
+            TT_FATAL(compute_kernel_2_id.has_value(), "Error");
             num_output_tiles_per_core = num_output_tiles_per_core_group_2;
             std::vector<uint32_t> compute_rt_args;
             compute_rt_args.push_back(num_tiles_written);

--- a/ttnn/cpp/ttnn/deprecated/tt_dnn/op_library/moreh_mean/moreh_mean_op.cpp
+++ b/ttnn/cpp/ttnn/deprecated/tt_dnn/op_library/moreh_mean/moreh_mean_op.cpp
@@ -19,7 +19,7 @@ namespace primary {
 void MorehMean::validate_with_output_tensors(
     const std::vector<Tensor>& input_tensors, const std::vector<std::optional<Tensor>>& output_tensors) const {
     TT_FATAL((dim >= 0 && dim <= 7), "dim should be 0 - 7");
-    TT_FATAL(input_tensors.size() == 1);
+    TT_FATAL(input_tensors.size() == 1, "Error");
     TT_FATAL(this->divisor.has_value() == false, "divisor not supported yet.");
 
     const auto& input = input_tensors.at(0);

--- a/ttnn/cpp/ttnn/deprecated/tt_dnn/op_library/moreh_nll_loss_unreduced_backward/moreh_nll_loss_unreduced_backward_op.cpp
+++ b/ttnn/cpp/ttnn/deprecated/tt_dnn/op_library/moreh_nll_loss_unreduced_backward/moreh_nll_loss_unreduced_backward_op.cpp
@@ -56,13 +56,13 @@ void MorehNllLossUnreducedBackward::validate_with_output_tensors(
     TT_FATAL(target_tensor.storage_type() == StorageType::DEVICE, "Operands to nll_loss_unreduced need to be on device!");
     TT_FATAL(target_tensor.buffer() != nullptr, "Operands to nll_loss_unreduced need to be allocated in buffers on device!");
     TT_FATAL((target_tensor.get_layout() == Layout::TILE), "target_tensor to nll_loss_unreduced must be tilized");
-    TT_FATAL(target_tensor.get_dtype() == DataType::INT32);
+    TT_FATAL(target_tensor.get_dtype() == DataType::INT32, "Error");
 
     TT_FATAL(output_grad_tensor.storage_type() == StorageType::DEVICE, "Operands to nll_loss_unreduced need to be on device!");
     TT_FATAL(
         output_grad_tensor.buffer() != nullptr, "Operands to nll_loss_unreduced need to be allocated in buffers on device!");
     TT_FATAL((output_grad_tensor.get_layout() == Layout::TILE), "target_tensor to nll_loss_unreduced must be tilized");
-    TT_FATAL(output_grad_tensor.get_dtype() == DataType::BFLOAT16);
+    TT_FATAL(output_grad_tensor.get_dtype() == DataType::BFLOAT16, "Error");
 
     if (input_grad_tensor.has_value()) {
         TT_FATAL(
@@ -73,7 +73,7 @@ void MorehNllLossUnreducedBackward::validate_with_output_tensors(
             "Operands to nll_loss need to be allocated in buffers on device!");
         TT_FATAL(
             (input_grad_tensor.value().get_layout() == Layout::TILE), "target_tensor to nll_loss_unreduced must be tilized");
-        TT_FATAL(input_grad_tensor.value().get_dtype() == DataType::BFLOAT16);
+        TT_FATAL(input_grad_tensor.value().get_dtype() == DataType::BFLOAT16, "Error");
     }
 
     if (weight_tensor.has_value()) {
@@ -84,7 +84,7 @@ void MorehNllLossUnreducedBackward::validate_with_output_tensors(
             weight_tensor.value().buffer() != nullptr,
             "weight_tensor to nll_loss need to be allocated in buffers on device!");
         TT_FATAL((weight_tensor.value().get_layout() == Layout::TILE), "weight_tensor to nll_loss_unreduced must be in tilized");
-        TT_FATAL(weight_tensor.value().get_dtype() == DataType::BFLOAT16);
+        TT_FATAL(weight_tensor.value().get_dtype() == DataType::BFLOAT16, "Error");
     }
 }
 

--- a/ttnn/cpp/ttnn/deprecated/tt_dnn/op_library/moreh_norm/moreh_norm_op.cpp
+++ b/ttnn/cpp/ttnn/deprecated/tt_dnn/op_library/moreh_norm/moreh_norm_op.cpp
@@ -81,11 +81,11 @@ inline void validate_output_tensor_with_keepdim(const Tensor& input, const Tenso
         expand_to_max_dim(output_dim_wo_padding, output_shape_wo_padding);
 
         for (int i = 0; i < input_rank; ++i) {
-            TT_FATAL(input_dim[i] == output_dim[i]);
-            TT_FATAL(input_dim_wo_padding[i] == output_dim_wo_padding[i]);
+            TT_FATAL(input_dim[i] == output_dim[i], "Error");
+            TT_FATAL(input_dim_wo_padding[i] == output_dim_wo_padding[i], "Error");
         }
     } else {
-        TT_FATAL(!is_tile_dim);
+        TT_FATAL(!is_tile_dim, "Error");
         std::vector<uint32_t> expected_output_shape;
         std::vector<uint32_t> expected_output_shape_wo_padding;
         for (int i = 0; i < output_shape.rank(); ++i) {
@@ -103,8 +103,8 @@ inline void validate_output_tensor_with_keepdim(const Tensor& input, const Tenso
         for (int i = 0; i < input_rank; ++i) {
             if (i == dim)
                 continue;
-            TT_FATAL(input_shape[i] == expected_output_shape[i]);
-            TT_FATAL(input_shape_wo_padding[i] == expected_output_shape_wo_padding[i]);
+            TT_FATAL(input_shape[i] == expected_output_shape[i], "Error");
+            TT_FATAL(input_shape_wo_padding[i] == expected_output_shape_wo_padding[i], "Error");
         }
     }
 }

--- a/ttnn/cpp/ttnn/deprecated/tt_dnn/op_library/moreh_sum/moreh_sum_op.cpp
+++ b/ttnn/cpp/ttnn/deprecated/tt_dnn/op_library/moreh_sum/moreh_sum_op.cpp
@@ -31,7 +31,7 @@ Tensor _moreh_sum(
     uint8_t queue_id = ttnn::DefaultQueueId) {
     std::vector<Tensor> output_tensors = {Tensor(operation::get_workers_for_op_output({input}))};
 
-    TT_FATAL(input.storage_type() == StorageType::DEVICE || input.storage_type() == StorageType::MULTI_DEVICE);
+    TT_FATAL(input.storage_type() == StorageType::DEVICE || input.storage_type() == StorageType::MULTI_DEVICE, "Error");
     auto kernel_config_val =
         init_device_compute_kernel_config(input.device()->arch(), compute_kernel_config, MathFidelity::HiFi4);
 

--- a/ttnn/cpp/ttnn/deprecated/tt_dnn/op_library/moreh_sum_backward/moreh_sum_backward_op.cpp
+++ b/ttnn/cpp/ttnn/deprecated/tt_dnn/op_library/moreh_sum_backward/moreh_sum_backward_op.cpp
@@ -40,7 +40,7 @@ void MorehSumBackward::validate_with_output_tensors(
     // validate output_grad shape
     if (this->keep_batch_dim) {
         for (int i = 0; i < input_rank; ++i) {
-            TT_FATAL(input_shape_wo_padding[i] >= output_grad_shape_wo_padding[i]);
+            TT_FATAL(input_shape_wo_padding[i] >= output_grad_shape_wo_padding[i], "Error");
         }
     } else {
         std::vector<uint32_t> expected_output_grad_shape;
@@ -69,7 +69,7 @@ void MorehSumBackward::validate_with_output_tensors(
         uint32_t rank = output_grad_shape_wo_padding.rank();
         TT_FATAL(expected_rank == rank, "expected_rank {} == rank {}", expected_rank, rank);
         for (int i = 0; i < rank; ++i) {
-            TT_FATAL(expected_output_grad_shape[i] >= output_grad_shape_wo_padding[i]);
+            TT_FATAL(expected_output_grad_shape[i] >= output_grad_shape_wo_padding[i], "Error");
             log_debug(LogOp, "rank {} expected_output_grad_shape {}, output_grad_shape_wo_padding {}", i, expected_output_grad_shape[i], output_grad_shape_wo_padding[i]);
         }
     }
@@ -91,7 +91,7 @@ std::vector<Tensor> MorehSumBackward::create_output_tensors(
         return {output_tensors.at(0).value()};
     }
 
-    TT_FATAL(input_tensors.size() == 2);
+    TT_FATAL(input_tensors.size() == 2, "Error");
     return operation::generic_create_output_tensors(
         *this, input_tensors, input_tensors.at(1).get_dtype(), Layout::TILE, this->input_grad_mem_config);
 }

--- a/ttnn/cpp/ttnn/operation.hpp
+++ b/ttnn/cpp/ttnn/operation.hpp
@@ -523,18 +523,18 @@ struct DeviceOperation final {
                 }
 
                 if constexpr (detail::implements_validate<T>()) {
-                    TT_FATAL(optional_input_tensors.empty());
+                    TT_FATAL(optional_input_tensors.empty(), "Optional input tensors not allowed");
                     operation.validate(input_tensors);
                 } else if constexpr (detail::implements_validate_with_optional_input_tensors<T>()) {
-                    TT_FATAL(not optional_input_tensors.empty());
+                    TT_FATAL(not optional_input_tensors.empty(), "Optional input tensors are expected");
                     operation.validate(input_tensors, optional_input_tensors);
                 } else if constexpr (detail::implements_validate_with_output_tensors<T>()) {
-                    TT_FATAL(optional_input_tensors.empty());
-                    // TT_FATAL(not optional_output_tensors.empty());
+                    TT_FATAL(optional_input_tensors.empty(), "Optional input tensors not allowed");
+                    // TT_FATAL(not optional_output_tensors.empty(), "Error");
                     operation.validate_with_output_tensors(input_tensors, optional_output_tensors);
                 } else if constexpr (detail::implements_validate_with_output_tensors_and_optional_input_tensors<T>()) {
-                    TT_FATAL(not optional_input_tensors.empty());
-                    TT_FATAL(not optional_output_tensors.empty());
+                    TT_FATAL(not optional_input_tensors.empty(), "Optional input tensors are expected");
+                    TT_FATAL(not optional_output_tensors.empty(), "Optional output tensors are expected");
                     operation.validate_with_output_tensors(
                         input_tensors, optional_input_tensors, optional_output_tensors);
                 } else {

--- a/ttnn/cpp/ttnn/operations/ccl/all_gather/device/multi_core/all_gather_op_multi_core.cpp
+++ b/ttnn/cpp/ttnn/operations/ccl/all_gather/device/multi_core/all_gather_op_multi_core.cpp
@@ -120,12 +120,12 @@ static std::vector<std::vector<uint32_t>> compute_worker_sender_num_transfers(
                             break;
 
                         default:
-                            TT_FATAL("Unsupported bidirectional mode");
+                            TT_FATAL(false, "Unsupported bidirectional mode {}. Please change.", all_gather_config.get_bidirectional_mode());
                     };
                     break;
 
                 default:
-                    TT_FATAL("Unsupported topology");
+                    TT_FATAL(false, "Unsupported topology {}. Please change.", topology);
             };
         }
     }
@@ -158,12 +158,12 @@ static std::vector<std::vector<uint32_t>> compute_worker_receiver_num_transfers(
                             break;
 
                         default:
-                            TT_FATAL("Unsupported bidirectional mode");
+                            TT_FATAL(false, "Unsupported bidirectional mode {}. Please change.", all_gather_config.get_bidirectional_mode());
                     };
                     break;
 
                 default:
-                    TT_FATAL("Unsupported topology");
+                    TT_FATAL(false, "Unsupported topology {}. Please change.", topology);
             };
         }
     }

--- a/ttnn/cpp/ttnn/operations/ccl/all_gather/device/multi_core/all_gather_op_multi_core.cpp
+++ b/ttnn/cpp/ttnn/operations/ccl/all_gather/device/multi_core/all_gather_op_multi_core.cpp
@@ -120,12 +120,12 @@ static std::vector<std::vector<uint32_t>> compute_worker_sender_num_transfers(
                             break;
 
                         default:
-                            TT_FATAL(false, "Unsupported bidirectional mode {}. Please change.", all_gather_config.get_bidirectional_mode());
+                            TT_THROW("Unsupported bidirectional mode {}. Please change.", all_gather_config.get_bidirectional_mode());
                     };
                     break;
 
                 default:
-                    TT_FATAL(false, "Unsupported topology {}. Please change.", topology);
+                    TT_THROW("Unsupported topology {}. Please change.", topology);
             };
         }
     }
@@ -158,12 +158,12 @@ static std::vector<std::vector<uint32_t>> compute_worker_receiver_num_transfers(
                             break;
 
                         default:
-                            TT_FATAL(false, "Unsupported bidirectional mode {}. Please change.", all_gather_config.get_bidirectional_mode());
+                            TT_THROW("Unsupported bidirectional mode {}. Please change.", all_gather_config.get_bidirectional_mode());
                     };
                     break;
 
                 default:
-                    TT_FATAL(false, "Unsupported topology {}. Please change.", topology);
+                    TT_THROW("Unsupported topology {}. Please change.", topology);
             };
         }
     }
@@ -183,7 +183,8 @@ static bool shard_grid_is_transposed(Tensor const& t) {
     TT_FATAL(
         t.memory_config().memory_layout == TensorMemoryLayout::BLOCK_SHARDED ||
         t.memory_config().memory_layout == TensorMemoryLayout::HEIGHT_SHARDED ||
-        t.memory_config().memory_layout == TensorMemoryLayout::WIDTH_SHARDED
+        t.memory_config().memory_layout == TensorMemoryLayout::WIDTH_SHARDED,
+        "Unsupported memory layout {}.", t.memory_config().memory_layout
     );
     bool shard_grid_transposed =
         ((t.memory_config().memory_layout == TensorMemoryLayout::HEIGHT_SHARDED &&

--- a/ttnn/cpp/ttnn/operations/ccl/ccl_common.cpp
+++ b/ttnn/cpp/ttnn/operations/ccl/ccl_common.cpp
@@ -116,7 +116,8 @@ std::vector<uint32_t> ShardedAddrGenArgBuilder::emit_ct_args(Tensor const& t) {
     TT_FATAL(
         t.memory_config().memory_layout == TensorMemoryLayout::BLOCK_SHARDED ||
         t.memory_config().memory_layout == TensorMemoryLayout::HEIGHT_SHARDED ||
-        t.memory_config().memory_layout == TensorMemoryLayout::WIDTH_SHARDED
+        t.memory_config().memory_layout == TensorMemoryLayout::WIDTH_SHARDED,
+        "Unsupported memory layout {}.", t.memory_config().memory_layout
     );
     args.push_back(static_cast<uint32_t>(t.memory_config().memory_layout));
     // shard_grid_height (cores)
@@ -141,7 +142,8 @@ bool ShardedAddrGenArgBuilder::shard_grid_is_transposed(Tensor const& t) {
     TT_FATAL(
         t.memory_config().memory_layout == TensorMemoryLayout::BLOCK_SHARDED ||
         t.memory_config().memory_layout == TensorMemoryLayout::HEIGHT_SHARDED ||
-        t.memory_config().memory_layout == TensorMemoryLayout::WIDTH_SHARDED
+        t.memory_config().memory_layout == TensorMemoryLayout::WIDTH_SHARDED,
+        "Unsupported memory layout {}.", t.memory_config().memory_layout
     );
     bool shard_grid_transposed =
         ((t.memory_config().memory_layout == TensorMemoryLayout::HEIGHT_SHARDED &&

--- a/ttnn/cpp/ttnn/operations/ccl/ccl_common.hpp
+++ b/ttnn/cpp/ttnn/operations/ccl/ccl_common.hpp
@@ -266,7 +266,7 @@ class RingReduceScatterBaseTensorSlicer : public LegacyCclTensorSlicer {
     }
 
     void create_worker_slice_shape_for_row_major_layout(tt_xy_pair const& tensor_slice_shape, uint32_t num_workers) {
-        TT_FATAL(false, "Row major interleaved not supported by Reduce Scatter");
+        TT_THROW("Row major interleaved not supported by Reduce Scatter");
     }
 
     // Static methods

--- a/ttnn/cpp/ttnn/operations/ccl/ccl_common.hpp
+++ b/ttnn/cpp/ttnn/operations/ccl/ccl_common.hpp
@@ -266,7 +266,7 @@ class RingReduceScatterBaseTensorSlicer : public LegacyCclTensorSlicer {
     }
 
     void create_worker_slice_shape_for_row_major_layout(tt_xy_pair const& tensor_slice_shape, uint32_t num_workers) {
-        TT_FATAL("Row major interleaved not supported by Reduce Scatter");
+        TT_FATAL(false, "Row major interleaved not supported by Reduce Scatter");
     }
 
     // Static methods

--- a/ttnn/cpp/ttnn/operations/ccl/line_all_gather/device/line_all_gather_op.cpp
+++ b/ttnn/cpp/ttnn/operations/ccl/line_all_gather/device/line_all_gather_op.cpp
@@ -16,7 +16,7 @@
 namespace ttnn {
 
 void LineAllGather::validate(const std::vector<Tensor> &input_tensors) const {
-    TT_FATAL(input_tensors.size() == 1);
+    TT_FATAL(input_tensors.size() == 1, "Error");
     const auto& input_tensor = input_tensors[0];
     const auto& layout = input_tensors[0].get_layout();
     const auto& dtype = input_tensors[0].get_dtype();
@@ -28,9 +28,9 @@ void LineAllGather::validate(const std::vector<Tensor> &input_tensors) const {
     // TODO: Validate ring
     TT_FATAL(input_tensor.storage_type() == StorageType::DEVICE, "Operands to all_gather need to be on device!");
     TT_FATAL(input_tensor.buffer() != nullptr , "Operands to all_gather need to be allocated in buffers on device!");
-    TT_FATAL(this->num_links > 0);
+    TT_FATAL(this->num_links > 0, "Error");
     TT_FATAL(this->num_links <= input_tensor.device()->compute_with_storage_grid_size().y, "Worker cores used by links are parallelizaed over rows");
-    TT_FATAL(this->receiver_device_id.has_value() || this->sender_device_id.has_value());
+    TT_FATAL(this->receiver_device_id.has_value() || this->sender_device_id.has_value(), "Error");
     if (this->receiver_device_id == this->sender_device_id) {
         TT_FATAL(input_tensor.device()->get_ethernet_sockets(this->receiver_device_id.value()).size() >= 2 * this->num_links, "2 Device all gather requires at least 2 eth connections per link");
     } else {
@@ -40,7 +40,8 @@ void LineAllGather::validate(const std::vector<Tensor> &input_tensors) const {
 
     TT_FATAL(input_tensor.memory_config().memory_layout == TensorMemoryLayout::INTERLEAVED ||
         input_tensor.memory_config().memory_layout == TensorMemoryLayout::WIDTH_SHARDED ||
-        input_tensor.memory_config().memory_layout == TensorMemoryLayout::HEIGHT_SHARDED);
+        input_tensor.memory_config().memory_layout == TensorMemoryLayout::HEIGHT_SHARDED,
+        "Unsupported memory layout {}.", input_tensor.memory_config().memory_layout);
 
     // Sharding Config checks
     bool input_sharded = input_tensor.is_sharded();

--- a/ttnn/cpp/ttnn/operations/ccl/reduce_scatter/device/host/reduce_scatter_full_worker_grid.cpp
+++ b/ttnn/cpp/ttnn/operations/ccl/reduce_scatter/device/host/reduce_scatter_full_worker_grid.cpp
@@ -914,7 +914,7 @@ operation::ProgramWithCallbacks reduce_scatter_with_workers(
                 cb_num_pages,
                 cb_num_pages,
                 cw_per_link_edm_builders.at(0).get_eth_buffer_size_bytes(),
-                op_config.get_page_size()));
+                op_config.get_page_size()), "Error");
         }
     }
 

--- a/ttnn/cpp/ttnn/operations/ccl/reduce_scatter/device/reduce_scatter_op.cpp
+++ b/ttnn/cpp/ttnn/operations/ccl/reduce_scatter/device/reduce_scatter_op.cpp
@@ -60,7 +60,7 @@ static ttnn::operations::binary::BinaryOpType convert_reduce_type_to_eltwise_typ
         case ttnn::operations::reduction::ReduceType::Sum:
             return ttnn::operations::binary::BinaryOpType::ADD;
         default:
-            tt::log_warning(tt::LogOp, "Reduce scatter only supports reduce_type Sum. Ignoring type of {} and acting as if that were passed in.", reduce_op);
+            TT_THROW("Reduce scatter only supports reduce_type Sum. Op type {} not supported.", reduce_op);
             return ttnn::operations::binary::BinaryOpType::ADD;
     }
 }

--- a/ttnn/cpp/ttnn/operations/ccl/reduce_scatter/device/reduce_scatter_op.cpp
+++ b/ttnn/cpp/ttnn/operations/ccl/reduce_scatter/device/reduce_scatter_op.cpp
@@ -60,7 +60,7 @@ static ttnn::operations::binary::BinaryOpType convert_reduce_type_to_eltwise_typ
         case ttnn::operations::reduction::ReduceType::Sum:
             return ttnn::operations::binary::BinaryOpType::ADD;
         default:
-            tt::log_info(tt::LogOp, "Reduce scatter only supports reduce_type Sum. Ignoring type of {} and acting as if that were passed in.", reduce_op);
+            tt::log_warning(tt::LogOp, "Reduce scatter only supports reduce_type Sum. Ignoring type of {} and acting as if that were passed in.", reduce_op);
             return ttnn::operations::binary::BinaryOpType::ADD;
     }
 }

--- a/ttnn/cpp/ttnn/operations/ccl/reduce_scatter/device/reduce_scatter_op.cpp
+++ b/ttnn/cpp/ttnn/operations/ccl/reduce_scatter/device/reduce_scatter_op.cpp
@@ -55,10 +55,13 @@ operation::ProgramWithCallbacks ReduceScatter::create_program(
 }
 
 static ttnn::operations::binary::BinaryOpType convert_reduce_type_to_eltwise_type(ttnn::operations::reduction::ReduceType reduce_op) {
+    // Leaving switch statement for future support of additional types.
     switch (reduce_op) {
-        case ttnn::operations::reduction::ReduceType::Sum: return ttnn::operations::binary::BinaryOpType::ADD;
-
-        default: TT_FATAL("Reduce scatter only support reduce_type Sum"); return ttnn::operations::binary::BinaryOpType::ADD;
+        case ttnn::operations::reduction::ReduceType::Sum:
+            return ttnn::operations::binary::BinaryOpType::ADD;
+        default:
+            tt::log_info(tt::LogOp, "Reduce scatter only supports reduce_type Sum. Ignoring type of {} and acting as if that were passed in.", reduce_op);
+            return ttnn::operations::binary::BinaryOpType::ADD;
     }
 }
 

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/conv2d.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/conv2d.cpp
@@ -356,7 +356,7 @@ std::tuple<ttnn::Shape, ttnn::MemoryConfig, bool> get_conv_padded_input_shape_an
                 needs_shard_or_reshard = true;
             }
             if (conv_config.override_sharding_config) {
-                TT_FATAL(conv_config.core_grid.has_value());
+                TT_FATAL(conv_config.core_grid.has_value(), "Error");
                 if (conv_config.core_grid.value() != input_shard_grid) {
                     needs_shard_or_reshard = true;
                 }
@@ -385,7 +385,7 @@ std::tuple<ttnn::Shape, ttnn::MemoryConfig, bool> get_conv_padded_input_shape_an
             block_shard_orientation);
 
         if (conv_config.override_sharding_config) {
-            TT_FATAL(conv_config.core_grid.has_value());
+            TT_FATAL(conv_config.core_grid.has_value(), "Error");
             // override parallel config
             auto shard_orientation =
                 conv_config.shard_layout==TensorMemoryLayout::BLOCK_SHARDED ? block_shard_orientation:  ShardOrientation::ROW_MAJOR;

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/device/multi_core_optimized_conv_sharded/optimized_conv_op_sharded_v2.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/device/multi_core_optimized_conv_sharded/optimized_conv_op_sharded_v2.cpp
@@ -404,7 +404,7 @@ operation::ProgramWithCallbacks multi_core_optimized_conv_sharded_v2_impl(
                 fp32_dest_acc_en = compute_kernel_config.fp32_dest_acc_en;
                 packer_l1_acc = compute_kernel_config.packer_l1_acc;
             } else {
-                TT_FATAL(false, "arch not supported");
+                TT_THROW("arch not supported");
             }
         },
         compute_kernel_config);
@@ -552,8 +552,8 @@ operation::ProgramWithCallbacks multi_core_optimized_conv_sharded_v2_impl(
             TT_THROW("Bias is not supported for depthwise conv1d");
         }
         // Tensor bias is of shape {output_channels}
-        TT_FATAL(bias.has_value());
-        TT_FATAL(bias.value().buffer() != nullptr);
+        TT_FATAL(bias.has_value(), "Error");
+        TT_FATAL(bias.value().buffer() != nullptr, "Error");
         auto bias_shape_without_padding = bias.value().get_legacy_shape().without_padding();
         TT_FATAL(bias_shape_without_padding[0] == 1, "Bias should have batch == 1");
     }
@@ -570,7 +570,7 @@ operation::ProgramWithCallbacks multi_core_optimized_conv_sharded_v2_impl(
 
     // Device compatibility checks
     TT_FATAL(
-        a.storage_type() == StorageType::DEVICE && b.storage_type() == StorageType::DEVICE &&
+        a.storage_type() == StorageType::DEVICE && b.storage_type() == StorageType::DEVICE,
         "Operands to large matmul need to be on device!");
     TT_FATAL(a.device() == b.device(), "Operands to conv need to be on the same device!");
     TT_FATAL(
@@ -620,7 +620,7 @@ operation::ProgramWithCallbacks multi_core_optimized_conv_sharded_v2_impl(
 
     TT_FATAL(
         (act_block_w_datums == round_up(conv_act_size_c * filter_w, TILE_WIDTH)) ||
-        ((act_block_w_datums <= conv_act_size_c) && (conv_act_size_c % act_block_w_datums == 0)));
+        ((act_block_w_datums <= conv_act_size_c) && (conv_act_size_c % act_block_w_datums == 0)), "Error");
 
     // weight block info
     uint32_t weight_block_w_datums = weight_matrix_width / num_blocks_weight_w;
@@ -839,9 +839,9 @@ operation::ProgramWithCallbacks multi_core_optimized_conv_sharded_v2_impl(
     uint32_t num_blocks_out_h_per_core = (per_core_out_matrix_height_ntiles + out_block_h_ntiles-1) / out_block_h_ntiles;
     bool act_height_sliced = per_core_out_matrix_height_ntiles < act_matrix_height_ntiles;
     if (not act_height_sliced) {
-        TT_FATAL(num_blocks_act_h_per_core == num_blocks_act_h);
-        TT_FATAL(num_blocks_out_h_per_core == num_blocks_out_h);
-        TT_FATAL(num_cores_x == 1);
+        TT_FATAL(num_blocks_act_h_per_core == num_blocks_act_h, "Error");
+        TT_FATAL(num_blocks_out_h_per_core == num_blocks_out_h, "Error");
+        TT_FATAL(num_cores_x == 1, "Error");
     }
     uint32_t act_block_h_datums_last_block = (per_core_out_matrix_height_ntiles - (num_blocks_act_h_per_core - 1) * act_block_h_ntiles) * TILE_HEIGHT;
 
@@ -849,28 +849,28 @@ operation::ProgramWithCallbacks multi_core_optimized_conv_sharded_v2_impl(
     log_debug(LogOp, "num_blocks_act_h_per_core: {}", num_blocks_act_h_per_core);
     log_debug(LogOp, "num_blocks_out_h_per_core: {}", num_blocks_out_h_per_core);
 
-    TT_FATAL(act_matrix_height_ntiles % per_core_out_matrix_height_ntiles == 0);
+    TT_FATAL(act_matrix_height_ntiles % per_core_out_matrix_height_ntiles == 0, "Error");
     uint32_t total_active_num_cores_per_weight_slice = act_matrix_height_ntiles / per_core_out_matrix_height_ntiles;
-    TT_FATAL(total_active_num_cores_per_weight_slice <= total_num_cores_per_weight_slice);
+    TT_FATAL(total_active_num_cores_per_weight_slice <= total_num_cores_per_weight_slice, "Error");
     uint32_t total_noop_cores = total_num_cores_per_weight_slice - total_active_num_cores_per_weight_slice;
     uint32_t total_active_num_cores = total_active_num_cores_per_weight_slice * num_weight_slices_width;
     if (weight_width_sliced) {
-        TT_FATAL(total_noop_cores == 0);
-        TT_FATAL(total_active_num_cores == total_num_cores);
+        TT_FATAL(total_noop_cores == 0, "Error");
+        TT_FATAL(total_active_num_cores == total_num_cores, "Error");
     }
 
     if (has_bias) {
-        TT_FATAL(bias_ntiles % num_weight_slices_width == 0);
-        TT_FATAL(bias_ntiles == weight_matrix_width_ntiles);
+        TT_FATAL(bias_ntiles % num_weight_slices_width == 0, "Error");
+        TT_FATAL(bias_ntiles == weight_matrix_width_ntiles, "Error");
     }
     uint32_t bias_ntiles_per_core = bias_ntiles / num_weight_slices_width;
 
     CoreRange all_cores(CoreCoord(0, 0), CoreCoord(num_cores_x - 1, num_cores_y - 1));
-    TT_FATAL(total_active_num_cores >= num_cores_x);
+    TT_FATAL(total_active_num_cores >= num_cores_x, "Error");
     uint32_t num_active_cores_x = num_cores_x;
     uint32_t num_active_cores_y_with_full_x = total_active_num_cores / num_cores_x;
     uint32_t num_active_cores_x_last_y = total_active_num_cores % num_cores_x;
-    TT_FATAL((num_active_cores_x * num_active_cores_y_with_full_x) + num_active_cores_x_last_y == total_active_num_cores);
+    TT_FATAL((num_active_cores_x * num_active_cores_y_with_full_x) + num_active_cores_x_last_y == total_active_num_cores, "Error");
 
     std::set<CoreRange> all_active_cores_set;
     all_active_cores_set.insert(
@@ -1115,7 +1115,7 @@ operation::ProgramWithCallbacks multi_core_optimized_conv_sharded_v2_impl(
         }
         else if (is_conv1d and is_depthwise_conv) {
             // 1D Depthwise Conv
-            TT_FATAL(act_block_w_datums == round_up(conv_act_size_c * filter_w, TILE_WIDTH));
+            TT_FATAL(act_block_w_datums == round_up(conv_act_size_c * filter_w, TILE_WIDTH), "Error");
             TT_FATAL(split_reader == false, "Split reader not supported for this conv yet!");
 
             compute_kernel = "ttnn/cpp/ttnn/operations/conv/conv2d/device/kernels/compute_depthwise_conv1d.cpp";
@@ -1128,7 +1128,7 @@ operation::ProgramWithCallbacks multi_core_optimized_conv_sharded_v2_impl(
 
         } else {
             // 1D conv
-            TT_FATAL(act_block_w_datums == round_up(conv_act_size_c * filter_w, TILE_WIDTH));
+            TT_FATAL(act_block_w_datums == round_up(conv_act_size_c * filter_w, TILE_WIDTH), "Error");
 
             reader_kernel =
                 "ttnn/cpp/ttnn/operations/conv/conv2d/device/kernels/reader_conv_activations_padded_with_halo_3x3_weights_v2.cpp";
@@ -1399,7 +1399,7 @@ operation::ProgramWithCallbacks multi_core_optimized_conv_sharded_v2_impl(
 
             bool reader_is_noc_0 = reader_noc == NOC::NOC_0;
 
-            TT_FATAL(!reader_is_noc_0);
+            TT_FATAL(!reader_is_noc_0, "Error");
 
             if (transpose_mcast) {
                 CoreCoord bottom_core = {(std::size_t)core_x_i, (std::size_t)num_cores_y - 1};
@@ -1536,7 +1536,7 @@ operation::ProgramWithCallbacks multi_core_optimized_conv_sharded_v2_impl(
             } else {
                 CoreCoord top_core = {(std::size_t)core_x_i, 0};
                 auto top_core_physical = device->worker_core_from_logical_core(top_core);
-                TT_FATAL(writer_mcast_noc == NOC::NOC_0);
+                TT_FATAL(writer_mcast_noc == NOC::NOC_0, "Error");
                 if (core_y_i == 0) {
                     // sender
                     if (writer_mcast_noc == NOC::NOC_0) {
@@ -1624,7 +1624,7 @@ operation::ProgramWithCallbacks multi_core_optimized_conv_sharded_v2_impl(
             const std::vector<std::optional<const Tensor>>& optional_input_tensors,
             const std::vector<Tensor>& output_tensors) {
             // Reader config indices is an optional static sharded tensor, so no need to update address
-            TT_FATAL(output_tensors.size() == 1);
+            TT_FATAL(output_tensors.size() == 1, "Error");
 
             auto src_buffer_a = input_tensors.at(0).buffer();
             auto src_buffer_b = input_tensors.at(1).buffer();
@@ -1633,7 +1633,7 @@ operation::ProgramWithCallbacks multi_core_optimized_conv_sharded_v2_impl(
             std::optional<tt_metal::Buffer*> src_buffer_c = std::nullopt;
             if (has_bias) {
                 src_buffer_c = optional_input_tensors.at(0).value().buffer();
-                TT_FATAL(src_buffer_c.value() != nullptr);
+                TT_FATAL(src_buffer_c.value() != nullptr, "Error");
             }
 
             auto dst_buffer = output_tensors.at(0).buffer();

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/device/multi_core_optimized_conv_sharded/optimized_conv_op_sharded_v2.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/device/multi_core_optimized_conv_sharded/optimized_conv_op_sharded_v2.cpp
@@ -404,7 +404,7 @@ operation::ProgramWithCallbacks multi_core_optimized_conv_sharded_v2_impl(
                 fp32_dest_acc_en = compute_kernel_config.fp32_dest_acc_en;
                 packer_l1_acc = compute_kernel_config.packer_l1_acc;
             } else {
-                TT_FATAL("arch not supported");
+                TT_FATAL(false, "arch not supported");
             }
         },
         compute_kernel_config);

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/device/multi_core_optimized_conv_sharded/optimized_conv_op_width_sharded_v2.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/device/multi_core_optimized_conv_sharded/optimized_conv_op_width_sharded_v2.cpp
@@ -107,7 +107,7 @@ operation::ProgramWithCallbacks multi_core_optimized_conv_width_sharded_v2_impl(
                 fp32_dest_acc_en = compute_kernel_config.fp32_dest_acc_en;
                 packer_l1_acc = compute_kernel_config.packer_l1_acc;
             } else {
-                TT_FATAL(false, "arch not supported");
+                TT_THROW("arch not supported");
             }
         },
         compute_kernel_config);
@@ -154,7 +154,7 @@ operation::ProgramWithCallbacks multi_core_optimized_conv_width_sharded_v2_impl(
         }
     }
 
-    // TT_FATAL(out_block_h_ntiles == act_block_h_ntiles); // TODO: fix output block sizing
+    // TT_FATAL(out_block_h_ntiles == act_block_h_ntiles, "Error"); // TODO: fix output block sizing
     TT_FATAL(
         out_block_h_ntiles >= act_block_h_ntiles,
         "Output block height (in # of tiles) ({}) should be greater than or equal to activation block height (in # of "
@@ -181,8 +181,8 @@ operation::ProgramWithCallbacks multi_core_optimized_conv_width_sharded_v2_impl(
     uint32_t num_cores_x = p_config.grid_size.x;
     uint32_t num_cores_y = p_config.grid_size.y;
     uint32_t total_num_cores = p_config.num_cores_c;
-    TT_FATAL(num_cores_x < 13);
-    TT_FATAL(num_cores_y < 10);
+    TT_FATAL(num_cores_x < 13, "Error");
+    TT_FATAL(num_cores_y < 10, "Error");
     uint32_t per_core_out_matrix_height_ntiles = p_config.per_core_out_matrix_height_ntiles;
     uint32_t per_core_out_matrix_width_ntiles = p_config.per_core_out_matrix_width_ntiles;
 
@@ -190,7 +190,7 @@ operation::ProgramWithCallbacks multi_core_optimized_conv_width_sharded_v2_impl(
     bool weight_width_sliced = per_core_out_matrix_width_ntiles < weight_matrix_width_ntiles;
     // uint32_t conv_act_c_blocks = weight_matrix_width_ntiles / per_core_out_matrix_width_ntiles;
     uint32_t input_channels_padded = shard_shape[1] * total_num_cores;
-    // TT_FATAL(conv_act_c_blocks == p_config.num_cores_c);
+    // TT_FATAL(conv_act_c_blocks == p_config.num_cores_c, "Error");
     TT_FATAL(input_channels_padded >= ashape[3], "Incorrect padding of input channels!");
     // check is for 16-byte alignment
     TT_FATAL(
@@ -235,8 +235,8 @@ operation::ProgramWithCallbacks multi_core_optimized_conv_width_sharded_v2_impl(
     auto [act_matrix_shape, act_matrix_shape_unpadded] =
         optimized_conv_op_utils::compute_opt_conv_activation_as_mm_shape(
             ashape_with_channels_padded.value, sliding_window_config, out_block_h_ntiles, extra_padding_for_32B_alignment);
-    TT_FATAL(act_matrix_shape.size() == 3);
-    TT_FATAL(act_matrix_shape[0] == 1);
+    TT_FATAL(act_matrix_shape.size() == 3, "Error");
+    TT_FATAL(act_matrix_shape[0] == 1, "Error");
     uint32_t act_matrix_height = (uint32_t)act_matrix_shape[1];
     uint32_t act_matrix_width = (uint32_t)act_matrix_shape[2];
     uint32_t act_matrix_height_unpadded = (uint32_t)act_matrix_shape_unpadded[1];
@@ -246,8 +246,8 @@ operation::ProgramWithCallbacks multi_core_optimized_conv_width_sharded_v2_impl(
 
     if (has_bias) {
         // Tensor bias is of shape {output_channels}
-        TT_FATAL(bias.has_value());
-        TT_FATAL(bias.value().buffer() != nullptr);
+        TT_FATAL(bias.has_value(), "Error");
+        TT_FATAL(bias.value().buffer() != nullptr, "Error");
         auto bias_shape_without_padding = bias.value().get_legacy_shape().without_padding();
         TT_FATAL(bias_shape_without_padding[0] == 1, "Bias should have batch == 1");
     }
@@ -263,7 +263,7 @@ operation::ProgramWithCallbacks multi_core_optimized_conv_width_sharded_v2_impl(
 
     // Device compatibility checks
     TT_FATAL(
-        a.storage_type() == StorageType::DEVICE && b.storage_type() == StorageType::DEVICE &&
+        a.storage_type() == StorageType::DEVICE && b.storage_type() == StorageType::DEVICE,
         "Operands to large matmul need to be on device!");
     TT_FATAL(a.device() == b.device(), "Operands to conv need to be on the same device!");
     TT_FATAL(
@@ -277,10 +277,10 @@ operation::ProgramWithCallbacks multi_core_optimized_conv_width_sharded_v2_impl(
     uint32_t act_matrix_height_ntiles = act_matrix_height / TILE_HEIGHT;
     uint32_t act_matrix_width_ntiles = act_matrix_width / TILE_WIDTH;
 
-    TT_FATAL(act_matrix_height_ntiles % act_block_h_ntiles == 0);
-    TT_FATAL(act_matrix_width_ntiles % act_block_w_ntiles == 0);
-    TT_FATAL(weight_matrix_width_ntiles % weight_block_w_ntiles == 0);
-    TT_FATAL(act_matrix_height_ntiles % out_block_h_ntiles == 0);
+    TT_FATAL(act_matrix_height_ntiles % act_block_h_ntiles == 0, "Error");
+    TT_FATAL(act_matrix_width_ntiles % act_block_w_ntiles == 0, "Error");
+    TT_FATAL(weight_matrix_width_ntiles % weight_block_w_ntiles == 0, "Error");
+    TT_FATAL(act_matrix_height_ntiles % out_block_h_ntiles == 0, "Error");
 
     uint32_t num_blocks_act_h = act_matrix_height_ntiles / act_block_h_ntiles;
     uint32_t num_blocks_out_h = act_matrix_height_ntiles / out_block_h_ntiles;
@@ -331,29 +331,29 @@ operation::ProgramWithCallbacks multi_core_optimized_conv_width_sharded_v2_impl(
 
     // weight block info
     uint32_t weight_block_w_datums = weight_matrix_width / num_blocks_weight_w;
-    TT_FATAL(weight_block_w_ntiles % out_subblock_w_ntiles == 0);
+    TT_FATAL(weight_block_w_ntiles % out_subblock_w_ntiles == 0, "Error");
     uint32_t weight_num_subblocks = weight_block_w_ntiles / out_subblock_w_ntiles;
     uint32_t weight_block_h_ntiles = act_block_w_ntiles;
     uint32_t weight_block_num_tiles = weight_block_w_ntiles * weight_block_h_ntiles;
     uint32_t weight_block_in_channels_ntiles = input_channels_padded/(32*total_num_cores*per_core_num_blocks_act_w);
-    TT_FATAL(input_channels_padded>=(TILE_HEIGHT*total_num_cores));
-    TT_FATAL(input_channels_padded%(TILE_HEIGHT*total_num_cores)==0);
+    TT_FATAL(input_channels_padded>=(TILE_HEIGHT*total_num_cores), "Error");
+    TT_FATAL(input_channels_padded%(TILE_HEIGHT*total_num_cores)==0, "Error");
 
     uint32_t num_groups = num_blocks_act_h * num_blocks_act_w * num_blocks_weight_w;
     // writer of conv op partially removes padding on the width
     // it removes the padding done for block width but it doesn't remove padding done for tiled width
     uint32_t output_channels_padded_to_tile_width = round_up(output_channels, TILE_WIDTH);
-    TT_FATAL(output_channels_padded_to_tile_width <= weight_matrix_width);
+    TT_FATAL(output_channels_padded_to_tile_width <= weight_matrix_width, "Error");
     uint32_t output_width_num_tiles = output_channels_padded_to_tile_width / TILE_WIDTH;
     uint32_t num_blocks_output_w =
         (uint32_t) std::ceil((double)output_channels_padded_to_tile_width / (double)weight_block_w_datums);
     uint32_t last_block_width_datums = (output_channels_padded_to_tile_width % weight_block_w_datums == 0)
                                            ? weight_block_w_datums
                                            : (output_channels_padded_to_tile_width % weight_block_w_datums);
-    TT_FATAL(last_block_width_datums % TILE_WIDTH == 0);
+    TT_FATAL(last_block_width_datums % TILE_WIDTH == 0, "Error");
 
     // sanity check
-    TT_FATAL(num_blocks_output_w == num_blocks_weight_w);
+    TT_FATAL(num_blocks_output_w == num_blocks_weight_w, "Error");
 
     uint32_t out_block_h_datums = out_block_h_ntiles * TILE_HEIGHT;
 
@@ -374,9 +374,9 @@ operation::ProgramWithCallbacks multi_core_optimized_conv_width_sharded_v2_impl(
     uint32_t act_noc_x = act_dram_noc_xy.x;
     uint32_t act_noc_y = act_dram_noc_xy.y;
 
-    TT_FATAL(act_matrix_width_ntiles % act_block_w_ntiles == 0);
-    TT_FATAL(act_block_h_ntiles % out_subblock_h_ntiles == 0);
-    // TT_FATAL(out_block_h_ntiles % out_subblock_h_ntiles == 0);
+    TT_FATAL(act_matrix_width_ntiles % act_block_w_ntiles == 0, "Error");
+    TT_FATAL(act_block_h_ntiles % out_subblock_h_ntiles == 0, "Error");
+    // TT_FATAL(out_block_h_ntiles % out_subblock_h_ntiles == 0, "Error");
     uint32_t act_num_subblocks = act_block_h_ntiles / out_subblock_h_ntiles;
     uint32_t act_block_num_tiles = act_block_h_ntiles * act_block_w_ntiles;
     uint32_t act_subblock_h_ntiles = out_subblock_h_ntiles;
@@ -421,7 +421,7 @@ operation::ProgramWithCallbacks multi_core_optimized_conv_width_sharded_v2_impl(
 
     uint32_t output_height_padded_to_tile_height = round_up(act_matrix_height_unpadded, TILE_HEIGHT);
     uint32_t output_height_num_tiles = output_height_padded_to_tile_height / TILE_HEIGHT;
-    TT_FATAL(output_height_num_tiles <= act_matrix_height_ntiles);
+    TT_FATAL(output_height_num_tiles <= act_matrix_height_ntiles, "Error");
 
     uint32_t src_dram_act_buffer_size_bytes = src0_dram_buffer->size();
     uint32_t src_dram_weight_buffer_size_bytes = src1_dram_buffer->size();

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/device/multi_core_optimized_conv_sharded/optimized_conv_op_width_sharded_v2.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/device/multi_core_optimized_conv_sharded/optimized_conv_op_width_sharded_v2.cpp
@@ -107,7 +107,7 @@ operation::ProgramWithCallbacks multi_core_optimized_conv_width_sharded_v2_impl(
                 fp32_dest_acc_en = compute_kernel_config.fp32_dest_acc_en;
                 packer_l1_acc = compute_kernel_config.packer_l1_acc;
             } else {
-                TT_FATAL("arch not supported");
+                TT_FATAL(false, "arch not supported");
             }
         },
         compute_kernel_config);

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/device/optimized_conv_op_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/device/optimized_conv_op_program_factory.cpp
@@ -122,17 +122,17 @@ void OptimizedConvNew::validate(const std::vector<Tensor>& input_tensors, const 
     const auto& input_tensor_a = input_tensors.at(0);
     const auto& input_tensor_b = input_tensors.at(1);
     // TODO: ...
-    TT_FATAL(!input_tensor_b.memory_config().is_sharded());
+    TT_FATAL(!input_tensor_b.memory_config().is_sharded(), "Error");
     if (this->untilize_out) {
-        TT_FATAL((this->dtype == DataType::BFLOAT16) || (this->dtype == DataType::FLOAT32));
+        TT_FATAL((this->dtype == DataType::BFLOAT16) || (this->dtype == DataType::FLOAT32), "Error");
     }
     if (this->memory_config.is_sharded()) {
         uint32_t out_block_h_ntiles = parallelization_config.per_core_out_matrix_height_ntiles;
         auto [act_matrix_shape, act_matrix_shape_unpadded] = optimized_conv_op_utils::compute_opt_conv_activation_as_mm_shape(input_tensor_a.get_legacy_shape(), sliding_window_config, out_block_h_ntiles, extra_padding_for_32B_alignment);
         uint32_t out_width_ntiles = this->compute_output_shapes(input_tensors).at(0)[-1] / TILE_WIDTH;
         if(this->memory_config.memory_layout == TensorMemoryLayout::HEIGHT_SHARDED) {
-            TT_FATAL(this->parallelization_config.per_core_out_matrix_width_ntiles == out_width_ntiles);
-            TT_FATAL(this->block_config.out_subblock_w_ntiles == out_width_ntiles || this->block_config.out_subblock_h_ntiles == 1);
+            TT_FATAL(this->parallelization_config.per_core_out_matrix_width_ntiles == out_width_ntiles, "Error");
+            TT_FATAL(this->block_config.out_subblock_w_ntiles == out_width_ntiles || this->block_config.out_subblock_h_ntiles == 1, "Error");
         } else if (this->memory_config.memory_layout == TensorMemoryLayout::BLOCK_SHARDED) {
             // For block sharded, out_width per core is shard width, and this is split along row
             // TODO: We should clean this up and relax constraints on out_subblock h and w
@@ -141,7 +141,7 @@ void OptimizedConvNew::validate(const std::vector<Tensor>& input_tensors, const 
             } else {
                 out_width_ntiles /= this->parallelization_config.grid_size.x;
             }
-            TT_FATAL(this->block_config.out_subblock_w_ntiles == out_width_ntiles || this->block_config.out_subblock_h_ntiles == 1);
+            TT_FATAL(this->block_config.out_subblock_w_ntiles == out_width_ntiles || this->block_config.out_subblock_h_ntiles == 1, "Error");
         }
     }
 }

--- a/ttnn/cpp/ttnn/operations/core/compute_kernel/compute_kernel_config.cpp
+++ b/ttnn/cpp/ttnn/operations/core/compute_kernel/compute_kernel_config.cpp
@@ -38,7 +38,7 @@ DeviceComputeKernelConfig init_device_compute_kernel_config(
                         .fp32_dest_acc_en = fp32_dest_acc_en,
                         .packer_l1_acc = packer_l1_acc};
                 } else {
-                    TT_FATAL(false, "arch not supported");
+                    TT_THROW("arch not supported");
                 }
             },
             compute_kernel_config);
@@ -99,7 +99,7 @@ std::tuple<MathFidelity, bool, bool, bool> get_compute_kernel_config_args(
                 fp32_dest_acc_en = compute_kernel_config.fp32_dest_acc_en;
                 packer_l1_acc = compute_kernel_config.packer_l1_acc;
             } else {
-                TT_FATAL(false, "arch not supported");
+                TT_THROW("arch not supported");
             }
         },
         compute_kernel_config);

--- a/ttnn/cpp/ttnn/operations/core/compute_kernel/compute_kernel_config.cpp
+++ b/ttnn/cpp/ttnn/operations/core/compute_kernel/compute_kernel_config.cpp
@@ -38,7 +38,7 @@ DeviceComputeKernelConfig init_device_compute_kernel_config(
                         .fp32_dest_acc_en = fp32_dest_acc_en,
                         .packer_l1_acc = packer_l1_acc};
                 } else {
-                    TT_FATAL("arch not supported");
+                    TT_FATAL(false, "arch not supported");
                 }
             },
             compute_kernel_config);
@@ -99,7 +99,7 @@ std::tuple<MathFidelity, bool, bool, bool> get_compute_kernel_config_args(
                 fp32_dest_acc_en = compute_kernel_config.fp32_dest_acc_en;
                 packer_l1_acc = compute_kernel_config.packer_l1_acc;
             } else {
-                TT_FATAL("arch not supported");
+                TT_FATAL(false, "arch not supported");
             }
         },
         compute_kernel_config);

--- a/ttnn/cpp/ttnn/operations/core/to_memory_config/to_memory_config_op.hpp
+++ b/ttnn/cpp/ttnn/operations/core/to_memory_config/to_memory_config_op.hpp
@@ -55,7 +55,7 @@ struct ToMemoryConfig {
                 } else {
                     // for row-major tensors where shard-spec[1] is different for input shard and output shard
 
-                    TT_FATAL(memory_config.is_sharded());
+                    TT_FATAL(memory_config.is_sharded(), "Error");
                     Tensor temp = operation::run(
                                       data_movement::ShardedToInterleavedDeviceOperation{
                                           .output_mem_config = ttnn::DRAM_MEMORY_CONFIG,

--- a/ttnn/cpp/ttnn/operations/core/work_split/work_split_tilize.hpp
+++ b/ttnn/cpp/ttnn/operations/core/work_split/work_split_tilize.hpp
@@ -155,7 +155,7 @@ struct FullRep {
         rep{n_rows / 32, n_rows % 32, n_pads / 32, times},
         pad{0, 0, (n_rows + n_pads) * pads_mul, 1},
         times_total(times_total) {
-        TT_FATAL((n_rows + n_pads) % 32 == 0 && "total rows must be divisible by 32");
+        TT_FATAL((n_rows + n_pads) % 32 == 0 && "total rows must be divisible by 32", "Error");
     }
 
     std::vector<BlockRep> to_block_reps() const {

--- a/ttnn/cpp/ttnn/operations/data_movement/bcast/bcast.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/bcast/bcast.cpp
@@ -32,24 +32,24 @@ Tensor BcastOperation::invoke(
             auto &input_tensor_a = input_tensors.at(0);
             auto &input_tensor_b = input_tensors.at(1);
             if (bcast_dim == BcastOpDim::W) {
-                TT_FATAL(input_tensor_a.get_legacy_shape()[-2] == input_tensor_b.get_legacy_shape()[-2]);
+                TT_FATAL(input_tensor_a.get_legacy_shape()[-2] == input_tensor_b.get_legacy_shape()[-2], "Error");
                 if (input_tensor_b.get_layout() == Layout::TILE) {
-                    TT_FATAL(input_tensor_b.get_legacy_shape()[-1] == TILE_WIDTH);
+                    TT_FATAL(input_tensor_b.get_legacy_shape()[-1] == TILE_WIDTH, "Error");
                 } else if (input_tensor_b.get_layout() == Layout::ROW_MAJOR) {
                     TT_FATAL(
                         input_tensor_b.get_legacy_shape()[-1] == 1 ||
-                        input_tensor_b.get_legacy_shape()[-1] == TILE_WIDTH);
+                        input_tensor_b.get_legacy_shape()[-1] == TILE_WIDTH, "Error");
                 } else {
                     TT_FATAL(false, "Unsupported layout");
                 }
             } else if (bcast_dim == BcastOpDim::H) {
-                TT_FATAL(input_tensor_a.get_legacy_shape()[-1] == input_tensor_b.get_legacy_shape()[-1]);
+                TT_FATAL(input_tensor_a.get_legacy_shape()[-1] == input_tensor_b.get_legacy_shape()[-1], "Error");
                 if (input_tensor_b.get_layout() == Layout::TILE) {
-                    TT_FATAL(input_tensor_b.get_legacy_shape()[-2] == TILE_HEIGHT);
+                    TT_FATAL(input_tensor_b.get_legacy_shape()[-2] == TILE_HEIGHT, "Error");
                 } else if (input_tensor_b.get_layout() == Layout::ROW_MAJOR) {
                     TT_FATAL(
                         input_tensor_b.get_legacy_shape()[-2] == 1 ||
-                        input_tensor_b.get_legacy_shape()[-2] == TILE_HEIGHT);
+                        input_tensor_b.get_legacy_shape()[-2] == TILE_HEIGHT, "Error");
                 } else {
                     TT_FATAL(false, "Unsupported layout");
                 }
@@ -57,12 +57,12 @@ Tensor BcastOperation::invoke(
                 if (input_tensor_b.get_layout() == Layout::TILE) {
                     TT_FATAL(
                         input_tensor_b.get_legacy_shape()[-2] == TILE_HEIGHT &&
-                        input_tensor_b.get_legacy_shape()[-1] == TILE_WIDTH);
+                        input_tensor_b.get_legacy_shape()[-1] == TILE_WIDTH, "Error");
                 } else if (input_tensor_b.get_layout() == Layout::ROW_MAJOR) {
                     TT_FATAL(
                         (input_tensor_b.get_legacy_shape()[-2] == 1 && input_tensor_b.get_legacy_shape()[-1] == 1) ||
                         (input_tensor_b.get_legacy_shape()[-2] == TILE_HEIGHT &&
-                         input_tensor_b.get_legacy_shape()[-1] == TILE_WIDTH));
+                         input_tensor_b.get_legacy_shape()[-1] == TILE_WIDTH), "Error");
                 }
             }
             return operation::run_with_autoformat(

--- a/ttnn/cpp/ttnn/operations/data_movement/bcast/device/bcast_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/bcast/device/bcast_device_operation.cpp
@@ -42,8 +42,8 @@ void EltwiseBinaryBroadcast::validate_with_output_tensors(const std::vector<Tens
     const auto input_shape_a = input_tensor_a.get_legacy_shape();
     const auto input_shape_b = input_tensor_b.get_legacy_shape();
 
-    TT_FATAL(input_tensor_a.get_layout() == Layout::TILE);
-    TT_FATAL(input_tensor_b.get_layout() == Layout::TILE);
+    TT_FATAL(input_tensor_a.get_layout() == Layout::TILE, "Error");
+    TT_FATAL(input_tensor_b.get_layout() == Layout::TILE, "Error");
     TT_FATAL(is_floating_point(input_tensor_a.get_dtype()), "Unsupported data format");
     if(!output_tensors.empty() && output_tensors.at(0).has_value()){
         TT_FATAL(is_floating_point(output_tensors.at(0).value().get_dtype()), "Unsupported data format");
@@ -52,8 +52,8 @@ void EltwiseBinaryBroadcast::validate_with_output_tensors(const std::vector<Tens
         TT_FATAL(out_tensor.get_legacy_shape() == output_shape_required.at(0), fmt::format("The input tensors need a shape of {}, however the output tensor is only {}", output_shape_required,  out_tensor.get_legacy_shape()));
     }
     if (this->in_place) {
-        TT_FATAL(input_tensor_a.memory_config().memory_layout == this->output_mem_config.memory_layout);
-        TT_FATAL(input_tensor_a.memory_config().buffer_type == this->output_mem_config.buffer_type);
+        TT_FATAL(input_tensor_a.memory_config().memory_layout == this->output_mem_config.memory_layout, "Error");
+        TT_FATAL(input_tensor_a.memory_config().buffer_type == this->output_mem_config.buffer_type, "Error");
     }
     auto out_mem_config = (!output_tensors.empty() && output_tensors.at(0).has_value()) ? output_tensors.at(0).value().memory_config() : this->output_mem_config;
     if (this->dim == BcastOpDim::W){
@@ -90,10 +90,10 @@ void EltwiseBinaryBroadcast::validate_with_output_tensors(const std::vector<Tens
 
         uint32_t batch_size_b = get_batch_size(input_shape_b);
         if (batch_size_b != 1) {
-            TT_FATAL(input_shape_a.rank() == input_shape_b.rank() && "Broadcast with batch is currently only supported when input tensor ranks are the same");
+            TT_FATAL(input_shape_a.rank() == input_shape_b.rank(), "Broadcast with batch is currently only supported when input tensor ranks are the same", "Error");
             for (auto i = 0; i < input_shape_a.rank() - 2; i++) {
                 TT_FATAL(
-                        input_shape_a[i] == input_shape_b[i] &&
+                        input_shape_a[i] == input_shape_b[i],
                         "Broadcast with batch is currently only supported when bN*bC=1 or N & C match or equivalent"); // for H multi-batch weight is supported
             }
         }
@@ -101,11 +101,11 @@ void EltwiseBinaryBroadcast::validate_with_output_tensors(const std::vector<Tens
 
     // validate input dimensions
     if (this->dim == BcastOpDim::W)
-        TT_FATAL(height_a == height_b && width_b == TILE_WIDTH);
+        TT_FATAL(height_a == height_b && width_b == TILE_WIDTH, "Error");
     if (this->dim == BcastOpDim::H)
-        TT_FATAL(width_a == width_b && height_b == TILE_HEIGHT);
+        TT_FATAL(width_a == width_b && height_b == TILE_HEIGHT, "Error");
     if (this->dim == BcastOpDim::HW)
-        TT_FATAL(width_b == TILE_WIDTH && height_b == TILE_HEIGHT);
+        TT_FATAL(width_b == TILE_WIDTH && height_b == TILE_HEIGHT, "Error");
 }
 
 

--- a/ttnn/cpp/ttnn/operations/data_movement/copy/device/copy_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/copy/device/copy_device_operation.cpp
@@ -21,13 +21,13 @@ void CopyDeviceOperation::validate(const std::vector<Tensor> &input_tensors) con
         "Typecast operation is only supported on Grayskull for float/bfloat outputs");
     TT_FATAL(input_tensor_a.storage_type() == StorageType::DEVICE, "Operands to copy need to be on device!");
     TT_FATAL(input_tensor_a.buffer() != nullptr , "Operands to copy need to be allocated in buffers on device!");
-    TT_FATAL(input_tensor_a.memory_config().memory_layout == TensorMemoryLayout::INTERLEAVED);
+    TT_FATAL(input_tensor_a.memory_config().memory_layout == TensorMemoryLayout::INTERLEAVED, "Error");
     TT_FATAL(input_tensor_a.memory_config().memory_layout == TensorMemoryLayout::INTERLEAVED, "Copy does not currently support sharding");
     if (input_tensors.size() == 2) {
         const auto& dst_tensor = input_tensors[1];
-        TT_FATAL(input_tensor_a.get_legacy_shape() == dst_tensor.get_legacy_shape());
-        TT_FATAL(input_tensor_a.get_layout() == dst_tensor.get_layout());
-        TT_FATAL(input_tensor_a.memory_config().memory_layout == dst_tensor.memory_config().memory_layout);
+        TT_FATAL(input_tensor_a.get_legacy_shape() == dst_tensor.get_legacy_shape(), "Error");
+        TT_FATAL(input_tensor_a.get_layout() == dst_tensor.get_layout(), "Error");
+        TT_FATAL(input_tensor_a.memory_config().memory_layout == dst_tensor.memory_config().memory_layout, "Error");
         TT_FATAL(dst_tensor.memory_config().memory_layout == TensorMemoryLayout::INTERLEAVED, "Copy does not currently support sharding");
     }
     if (this->output_dtype != input_tensor_a.get_dtype()) {

--- a/ttnn/cpp/ttnn/operations/data_movement/data_transfer/data_transfer.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/data_transfer/data_transfer.cpp
@@ -17,10 +17,10 @@ Tensor DataTransferToHostOperation::invoke(const Tensor &input_tensor) {
 
 
 Tensor DataTransferToDeviceOperation::invoke(const Tensor &input_tensor, Device* device, const MemoryConfig& memory_config) {
-    TT_FATAL(device != nullptr);
+    TT_FATAL(device != nullptr, "Error");
 
     if(input_tensor.get_layout() == Layout::ROW_MAJOR) {
-        TT_FATAL(input_tensor.get_legacy_shape()[-1] * input_tensor.element_size() % sizeof(uint32_t) == 0);
+        TT_FATAL(input_tensor.get_legacy_shape()[-1] * input_tensor.element_size() % sizeof(uint32_t) == 0, "Error");
     }
 
     if (input_tensor.storage_type() == StorageType::DEVICE && input_tensor.device() == device) {

--- a/ttnn/cpp/ttnn/operations/data_movement/fill_rm/device/fill_rm_op.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/fill_rm/device/fill_rm_op.cpp
@@ -71,9 +71,9 @@ operation::ProgramWithCallbacks fill_rm_single_core(const Tensor& any, Tensor &o
 
 void FillRM::validate(const std::vector<Tensor> &input_tensors) const {
     const auto& input_tensor_a = input_tensors.at(0);
-    TT_FATAL((this->N > 0 && this->C > 0 && this-> H > 0 && this-> W > 0));
-    TT_FATAL((this->hFill <= this->H && this->wFill <= this->W));
-    TT_FATAL(input_tensor_a.get_dtype() == DataType::BFLOAT16);
+    TT_FATAL((this->N > 0 && this->C > 0 && this-> H > 0 && this-> W > 0), "Error");
+    TT_FATAL((this->hFill <= this->H && this->wFill <= this->W), "Error");
+    TT_FATAL(input_tensor_a.get_dtype() == DataType::BFLOAT16, "Error");
     TT_FATAL(input_tensor_a.memory_config().memory_layout == TensorMemoryLayout::INTERLEAVED, "FillRM does not currently support sharding");
     TT_FATAL(this->output_mem_config.memory_layout == TensorMemoryLayout::INTERLEAVED, "FillRM does not currently support sharding");
 }

--- a/ttnn/cpp/ttnn/operations/data_movement/fold/device/fold_device_op.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/fold/device/fold_device_op.cpp
@@ -28,10 +28,10 @@ void validate_fold(const std::vector<Tensor> &input_tensors, bool is_sharded, ui
             "Fold: Only height-sharded input tensors are supported.");
 
         auto shard_shape = input_tensor.shard_spec().value().shape;
-        TT_FATAL(shard_shape[0] % (input_shape[2] * stride_h * stride_w) == 0);
+        TT_FATAL(shard_shape[0] % (input_shape[2] * stride_h * stride_w) == 0, "Error");
     } else {
-        TT_FATAL(input_shape[1] % stride_h == 0);
-        TT_FATAL(input_shape[2] % stride_w == 0);
+        TT_FATAL(input_shape[1] % stride_h == 0, "Error");
+        TT_FATAL(input_shape[2] % stride_w == 0, "Error");
     }
     TT_FATAL(
         (input_shape[-1] * input_tensor.element_size()) % 16 == 0,

--- a/ttnn/cpp/ttnn/operations/data_movement/fold/fold.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/fold/fold.cpp
@@ -296,7 +296,7 @@ Tensor FoldOperation::invoke(uint8_t queue_id,
             if (input_tensor.memory_config().memory_layout == TensorMemoryLayout::HEIGHT_SHARDED) {
                 return fold_with_transpose_sharded_(queue_id, input_tensor, output_shape, stride_h, stride_w, pad_c, pad_h, pad_w, grid_size.value_or(CoreCoord(1,1)), override_memory_config).at(0);
             } else {
-                TT_FATAL("fold op does not support non height-sharding!");
+                TT_FATAL(false, "fold op does not support non height-sharding!");
             }
         } else {
             return fold_with_transpose_(queue_id, input_tensor, output_shape, stride_h, stride_w, pad_c, pad_h, pad_w).at(0);

--- a/ttnn/cpp/ttnn/operations/data_movement/fold/fold.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/fold/fold.cpp
@@ -296,7 +296,7 @@ Tensor FoldOperation::invoke(uint8_t queue_id,
             if (input_tensor.memory_config().memory_layout == TensorMemoryLayout::HEIGHT_SHARDED) {
                 return fold_with_transpose_sharded_(queue_id, input_tensor, output_shape, stride_h, stride_w, pad_c, pad_h, pad_w, grid_size.value_or(CoreCoord(1,1)), override_memory_config).at(0);
             } else {
-                TT_FATAL(false, "fold op does not support non height-sharding!");
+                TT_THROW("fold op does not support non height-sharding!");
             }
         } else {
             return fold_with_transpose_(queue_id, input_tensor, output_shape, stride_h, stride_w, pad_c, pad_h, pad_w).at(0);

--- a/ttnn/cpp/ttnn/operations/data_movement/indexed_fill/device/indexed_fill_op.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/indexed_fill/device/indexed_fill_op.cpp
@@ -24,7 +24,7 @@ void IndexedFill::validate(const std::vector<Tensor> &input_tensors) const {
     TT_FATAL(this->dim == 0, "Currently only supporting batch dimension");
     TT_FATAL(input_tensor_a.storage_type() == StorageType::DEVICE, "Operands to Index Fill need to be on device!");
     TT_FATAL(input_tensor_a.buffer() != nullptr , "Operands to Index Fill need to be allocated in buffers on device!");
-    TT_FATAL(input_tensor_a.memory_config().memory_layout == TensorMemoryLayout::INTERLEAVED);
+    TT_FATAL(input_tensor_a.memory_config().memory_layout == TensorMemoryLayout::INTERLEAVED, "Error");
     TT_FATAL(input_tensor_a.memory_config().memory_layout == TensorMemoryLayout::INTERLEAVED, "Index Fill does not currently support sharding");
 }
 

--- a/ttnn/cpp/ttnn/operations/data_movement/move/device/move_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/move/device/move_program_factory.cpp
@@ -199,7 +199,7 @@ operation::ProgramWithCallbacks move_multi_core_sharded(const Tensor& input, Ten
     auto input_layout = input.get_layout();
     TT_FATAL(
         input_layout == output.get_layout() && input_dtype == output.get_dtype() &&
-        shard_shape == output.shard_spec().value().shape && input_shape == output.get_legacy_shape());
+        shard_shape == output.shard_spec().value().shape && input_shape == output.get_legacy_shape(), "Error");
     const uint32_t src_cb_sharded = tt::CB::c_in0;
     const uint32_t dst_cb_sharded = tt::CB::c_in1;
     uint32_t tile_size_bytes = tile_size(cb_data_format);

--- a/ttnn/cpp/ttnn/operations/data_movement/pad/device/pad_op.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/pad/device/pad_op.cpp
@@ -14,7 +14,7 @@ void Pad::validate_with_output_tensors(
     const auto& input_tensor = input_tensors.at(0);
     TT_FATAL(input_tensor.storage_type() == StorageType::DEVICE, "Operand to pad needs to be on device!");
     TT_FATAL(input_tensor.buffer() != nullptr, "Operand to pad needs to be allocated in a buffer on device!");
-    TT_FATAL(input_tensor.get_layout() == Layout::TILE || input_tensor.get_layout() == Layout::ROW_MAJOR);
+    TT_FATAL(input_tensor.get_layout() == Layout::TILE || input_tensor.get_layout() == Layout::ROW_MAJOR, "Error");
     if (input_tensor.get_layout() == Layout::TILE) {
         TT_FATAL(
             (this->input_tensor_start[0] == 0 && this->input_tensor_start[1] == 0 && this->input_tensor_start[2] == 0 && this->input_tensor_start[3] == 0),
@@ -36,11 +36,11 @@ void Pad::validate_with_output_tensors(
     }
 
     if (input_tensor.is_sharded()) {
-        TT_FATAL(input_tensor.memory_config().memory_layout == TensorMemoryLayout::HEIGHT_SHARDED);
-        TT_FATAL(input_tensor.get_layout() == Layout::ROW_MAJOR);
+        TT_FATAL(input_tensor.memory_config().memory_layout == TensorMemoryLayout::HEIGHT_SHARDED, "Error");
+        TT_FATAL(input_tensor.get_layout() == Layout::ROW_MAJOR, "Error");
 
-        TT_FATAL(this->output_mem_config.is_sharded());
-        TT_FATAL(this->output_mem_config.memory_layout == TensorMemoryLayout::HEIGHT_SHARDED);
+        TT_FATAL(this->output_mem_config.is_sharded(), "Error");
+        TT_FATAL(this->output_mem_config.memory_layout == TensorMemoryLayout::HEIGHT_SHARDED, "Error");
     }
 }
 
@@ -83,7 +83,7 @@ operation::ProgramWithCallbacks Pad::create_program(const std::vector<Tensor>& i
         }
         return detail::pad_tile(input_tensor, output_tensor, this->output_tensor_shape, this->input_tensor_start, this->pad_value);
     } else {
-        TT_FATAL(false and "Unsupported layout for pad");
+        TT_FATAL(false and "Unsupported layout for pad", "Error");
         return {};
     }
 

--- a/ttnn/cpp/ttnn/operations/data_movement/pad/pad.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/pad/pad.cpp
@@ -38,9 +38,7 @@ static ttnn::Tensor pad_impl(
         const auto input_tensor_shape = input_tensor.get_shape();
         const auto rank = input_tensor_shape.rank();
 
-        if (rank != 4) {
-            TT_FATAL("Tensor rank is not 4");
-        }
+        TT_FATAL(rank == 4, "Tensor rank is not 4");
 
         auto memory_config = memory_config_arg.value_or(input_tensor.memory_config());
         auto output_tensor = operation::run(
@@ -135,7 +133,7 @@ ttnn::Tensor ExecutePad::invoke(
             case 6: output_tensor = pad_impl<tt::tt_metal::Array6D>(queue_id, input_tensor, padding, value, use_multicore, memory_config_arg); break;
             case 7: output_tensor = pad_impl<tt::tt_metal::Array7D>(queue_id, input_tensor, padding, value, use_multicore, memory_config_arg); break;
             case 8: output_tensor = pad_impl<tt::tt_metal::Array8D>(queue_id, input_tensor, padding, value, use_multicore, memory_config_arg); break;
-            default: TT_FATAL("Unsupported tensor rank");
+            default: TT_FATAL(false, "Unsupported tensor rank of {}. Needs to be between 1 and 8 inclusively.", original_rank);
         }
     }
     else {

--- a/ttnn/cpp/ttnn/operations/data_movement/pad/pad.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/pad/pad.cpp
@@ -133,7 +133,7 @@ ttnn::Tensor ExecutePad::invoke(
             case 6: output_tensor = pad_impl<tt::tt_metal::Array6D>(queue_id, input_tensor, padding, value, use_multicore, memory_config_arg); break;
             case 7: output_tensor = pad_impl<tt::tt_metal::Array7D>(queue_id, input_tensor, padding, value, use_multicore, memory_config_arg); break;
             case 8: output_tensor = pad_impl<tt::tt_metal::Array8D>(queue_id, input_tensor, padding, value, use_multicore, memory_config_arg); break;
-            default: TT_FATAL(false, "Unsupported tensor rank of {}. Needs to be between 1 and 8 inclusively.", original_rank);
+            default: TT_THROW("Unsupported tensor rank of {}. Needs to be between 1 and 8 inclusively.", original_rank);
         }
     }
     else {

--- a/ttnn/cpp/ttnn/operations/data_movement/permute/permute.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/permute/permute.cpp
@@ -159,14 +159,14 @@ ttnn::Tensor ExecutePermute::invoke(
     const auto input_layout = input_tensor.get_layout();
     const auto input_rank = input_tensor.get_shape().rank();
 
-    TT_FATAL(input_rank <= 4);
+    TT_FATAL(input_rank <= 4, "Error");
     TT_FATAL(
         input_rank == dims.size(),
         "The number of dimensions in the tensor input does not match the length of the desired ordering");
 
     auto adjust_order = [](const std::vector<int64_t>& dims) {
         std::vector<std::int64_t> new_order;
-        TT_FATAL(dims.size() <= 4);
+        TT_FATAL(dims.size() <= 4, "Error");
         int additional_ranks = 4 - dims.size();
         for (int i = 0; i < additional_ranks; i++) {
             new_order.push_back(i);
@@ -183,7 +183,7 @@ ttnn::Tensor ExecutePermute::invoke(
         itensor = ttnn::to_layout(itensor, ttnn::ROW_MAJOR_LAYOUT, std::nullopt, std::nullopt, (Device*)nullptr);
     }
 
-    TT_FATAL(detail::is_on_device(itensor) and itensor.get_shape().rank() == 4);
+    TT_FATAL(detail::is_on_device(itensor) and itensor.get_shape().rank() == 4, "Error");
     auto output_tensor = detail::permute_launch(itensor, iorder, memory_config.value_or(input_tensor.memory_config()));
     output_tensor = ttnn::to_layout(output_tensor, input_layout, std::nullopt, std::nullopt, (Device*)nullptr);
 

--- a/ttnn/cpp/ttnn/operations/data_movement/reshape/device/reshape_op.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/reshape/device/reshape_op.cpp
@@ -17,7 +17,7 @@ void ReshapeDeviceOperation::validate(const std::vector<Tensor> &input_tensors) 
     const auto& input_tensor_a = input_tensors.at(0);
     TT_FATAL(input_tensor_a.storage_type() == StorageType::DEVICE, "Operands to reshape need to be on device!");
     TT_FATAL(input_tensor_a.buffer() != nullptr , "Operands to reshape need to be allocated in buffers on device!");
-    TT_FATAL(input_tensor_a.get_dtype() == DataType::BFLOAT16);
+    TT_FATAL(input_tensor_a.get_dtype() == DataType::BFLOAT16, "Error");
 
     TT_FATAL(input_tensor_a.get_layout() == Layout::TILE || input_tensor_a.get_layout() == Layout::ROW_MAJOR, "Only tile and row major reshape supported!");
 
@@ -28,8 +28,8 @@ void ReshapeDeviceOperation::validate(const std::vector<Tensor> &input_tensors) 
     TT_FATAL(this->output_mem_config.memory_layout == TensorMemoryLayout::INTERLEAVED, "Reshape does not currently support sharding");
 
     if (input_tensor_a.get_layout() == Layout::TILE) {
-        TT_FATAL(input_tensor_a.volume() % TILE_HW == 0);
-        TT_FATAL(output_shape[2] % TILE_HEIGHT == 0 && output_shape[3] % TILE_WIDTH == 0 && "Expected a multiple of 32 for H, W (or -1 evaluating to such) for reshape!");
+        TT_FATAL(input_tensor_a.volume() % TILE_HW == 0, "Error");
+        TT_FATAL(output_shape[2] % TILE_HEIGHT == 0 && output_shape[3] % TILE_WIDTH == 0, "Expected a multiple of 32 for H, W (or -1 evaluating to such) for reshape!");
     } else if (input_tensor_a.get_layout() == Layout::ROW_MAJOR) {
         uint32_t ROW_MAJOR_WIDTH = 8;
         TT_FATAL(input_tensor_a.get_legacy_shape()[3] % ROW_MAJOR_WIDTH == 0 && output_shape[3] % ROW_MAJOR_WIDTH == 0, "Operand/target width must be a multiple of 8");

--- a/ttnn/cpp/ttnn/operations/data_movement/reshape/device/reshape_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/reshape/device/reshape_program_factory.cpp
@@ -359,7 +359,7 @@ std::vector<std::pair<std::vector<uint32_t>, std::vector<uint32_t> > > get_runti
 
 operation::ProgramWithCallbacks reshape_rm_multi_core(const Tensor &a, Tensor& output, int N, int C, int H, int W) {
 
-    TT_FATAL(a.get_dtype() == output.get_dtype());
+    TT_FATAL(a.get_dtype() == output.get_dtype(), "Error");
 
     tt::tt_metal::Program program = tt::tt_metal::CreateProgram();
 
@@ -378,9 +378,9 @@ operation::ProgramWithCallbacks reshape_rm_multi_core(const Tensor &a, Tensor& o
     uint32_t new_stick_size = output_shape[3] * output.element_size();
 
     if (old_stick_size > new_stick_size) {
-        TT_FATAL(old_stick_size % new_stick_size == 0);
+        TT_FATAL(old_stick_size % new_stick_size == 0, "Error");
     } else {
-        TT_FATAL(new_stick_size % old_stick_size == 0);
+        TT_FATAL(new_stick_size % old_stick_size == 0, "Error");
     }
 
     auto compute_with_storage_grid_size = device->compute_with_storage_grid_size();

--- a/ttnn/cpp/ttnn/operations/data_movement/reshape/reshape.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/reshape/reshape.cpp
@@ -78,7 +78,7 @@ ttnn::Tensor ReshapeOperation::invoke(
         || output_shape[-1] % TILE_WIDTH != 0
         || input_tensor.get_legacy_shape()[-1] % TILE_WIDTH != 0
         || (input_tensor.volume() / input_tensor.get_legacy_shape()[-1]) % TILE_HEIGHT != 0)) {
-        TT_FATAL(input_tensor.get_dtype()==DataType::BFLOAT16);
+        TT_FATAL(input_tensor.get_dtype()==DataType::BFLOAT16, "Error");
 
         return detail::manual_insertion((tt::tt_metal::Tensor)input_tensor, output_shape, input_tensor.device(), output_mem_config);
     }

--- a/ttnn/cpp/ttnn/operations/data_movement/sharded/interleaved_to_sharded/device/interleaved_to_sharded_op.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/sharded/interleaved_to_sharded/device/interleaved_to_sharded_op.cpp
@@ -16,14 +16,14 @@ void InterleavedToShardedDeviceOperation::validate(const std::vector<Tensor>& in
     TT_FATAL(input_tensor.storage_type() == StorageType::DEVICE, "Operands to shard need to be on device!");
     TT_FATAL(input_tensor.buffer() != nullptr, "Operands to shard need to be allocated in buffers on device!");
 
-    TT_FATAL(input_tensor.memory_config().memory_layout == TensorMemoryLayout::INTERLEAVED);
-    TT_FATAL(this->output_mem_config.is_sharded());
-    TT_FATAL(this->output_mem_config.buffer_type == BufferType::L1);
+    TT_FATAL(input_tensor.memory_config().memory_layout == TensorMemoryLayout::INTERLEAVED, "Error");
+    TT_FATAL(this->output_mem_config.is_sharded(), "Error");
+    TT_FATAL(this->output_mem_config.buffer_type == BufferType::L1, "Error");
     if (input_tensor.get_layout() == Layout::ROW_MAJOR) {
         TT_FATAL((*this->output_mem_config.shard_spec).shape[1] * input_tensor.element_size() % L1_ALIGNMENT == 0, "Shard page size must currently have L1 aligned page size");
     }
     if (input_tensor.get_dtype() != this->output_dtype) {
-        TT_FATAL(input_tensor.get_layout() == Layout::TILE);
+        TT_FATAL(input_tensor.get_layout() == Layout::TILE, "Error");
     }
 }
 

--- a/ttnn/cpp/ttnn/operations/data_movement/sharded/reshard/device/reshard_op.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/sharded/reshard/device/reshard_op.cpp
@@ -23,13 +23,13 @@ void ReshardDeviceOperation::validate_with_output_tensors(const std::vector<Tens
     bool has_output_tensor = output_tensors.size() == 1 && output_tensors[0].has_value();
     if (has_output_tensor) {
         const auto& output_tensor = output_tensors[0].value();
-        TT_FATAL(input_tensor.get_shape() == output_tensor.get_shape());
-        TT_FATAL(input_tensor.get_dtype() == output_tensor.get_dtype());
-        TT_FATAL(input_tensor.get_layout() == output_tensor.get_layout());
+        TT_FATAL(input_tensor.get_shape() == output_tensor.get_shape(), "Error");
+        TT_FATAL(input_tensor.get_dtype() == output_tensor.get_dtype(), "Error");
+        TT_FATAL(input_tensor.get_layout() == output_tensor.get_layout(), "Error");
     }
     const auto& out_mem_config = has_output_tensor ? output_tensors[0].value().memory_config() : this->output_mem_config;
     TT_FATAL(out_mem_config.is_sharded(), "output must be sharded");
-    TT_FATAL(out_mem_config.buffer_type == BufferType::L1);
+    TT_FATAL(out_mem_config.buffer_type == BufferType::L1, "Error");
     if(input_tensor.get_layout() == Layout::ROW_MAJOR) {
         bool same_row_size = input_tensor.memory_config().shard_spec.value().shape[1] == out_mem_config.shard_spec.value().shape[1];
         TT_FATAL(same_row_size, "row major must have shard_spec[1] be the same on both input and output");

--- a/ttnn/cpp/ttnn/operations/data_movement/sharded/sharded_to_interleaved/sharded_to_interleaved.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/sharded/sharded_to_interleaved/sharded_to_interleaved.cpp
@@ -20,7 +20,7 @@ ttnn::Tensor ShardedToInterleavedOperation::invoke(
     std::vector<Tensor> output_tensors = {Tensor(operation::get_workers_for_op_output({input_tensor}))};
 
     auto shard_spec = input_tensor.shard_spec().value();
-    TT_FATAL(input_tensor.shard_spec().has_value());
+    TT_FATAL(input_tensor.shard_spec().has_value(), "Error");
     return operation::run(
             ShardedToInterleavedDeviceOperation{
                 .output_mem_config = memory_config,

--- a/ttnn/cpp/ttnn/operations/data_movement/sharded_partial/interleaved_to_sharded_partial/device/interleaved_to_sharded_partial_op.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/sharded_partial/interleaved_to_sharded_partial/device/interleaved_to_sharded_partial_op.cpp
@@ -24,7 +24,7 @@ void InterleavedToShardedPartialDeviceOperation::validate(const std::vector<Tens
 
     TT_FATAL(input_tensor.memory_config().memory_layout == TensorMemoryLayout::INTERLEAVED, "Input tensor must be Interleaved");
     if (input_tensor.get_dtype() != this->output_dtype) {
-        TT_FATAL(input_tensor.get_layout() == Layout::TILE);
+        TT_FATAL(input_tensor.get_layout() == Layout::TILE, "Error");
     }
     auto device_grid = input_tensor.device()->compute_with_storage_grid_size();
     TT_FATAL(this->grid_size.x <= device_grid.x && this->grid_size.y <= device_grid.y, "Grid size for sharding must be less than or equal to total grid available");

--- a/ttnn/cpp/ttnn/operations/data_movement/sharded_partial/interleaved_to_sharded_partial/interleaved_to_sharded_partial.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/sharded_partial/interleaved_to_sharded_partial/interleaved_to_sharded_partial.cpp
@@ -50,7 +50,7 @@ ttnn::Tensor InterleavedToShardedPartialOperation::invoke(
                 }
                 grid_set = tt::tt_metal::num_cores_to_corerange_set(num_cores, grid_size, row_wise);
             } else if constexpr (std::is_same_v<GridType, CoreRangeSet>) {
-                TT_FATAL("Unsupported type for grid.");
+                TT_FATAL(false, "Unsupported type for grid. CoreRangeSet not supported. Switch to a different type.");
             }
         },
         grid);

--- a/ttnn/cpp/ttnn/operations/data_movement/sharded_partial/interleaved_to_sharded_partial/interleaved_to_sharded_partial.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/sharded_partial/interleaved_to_sharded_partial/interleaved_to_sharded_partial.cpp
@@ -50,7 +50,7 @@ ttnn::Tensor InterleavedToShardedPartialOperation::invoke(
                 }
                 grid_set = tt::tt_metal::num_cores_to_corerange_set(num_cores, grid_size, row_wise);
             } else if constexpr (std::is_same_v<GridType, CoreRangeSet>) {
-                TT_FATAL(false, "Unsupported type for grid. CoreRangeSet not supported. Switch to a different type.");
+                TT_THROW("Unsupported type for grid. CoreRangeSet not supported. Switch to a different type.");
             }
         },
         grid);

--- a/ttnn/cpp/ttnn/operations/data_movement/sharded_partial/sharded_to_interleaved_partial/device/sharded_to_interleaved_partial_op.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/sharded_partial/sharded_to_interleaved_partial/device/sharded_to_interleaved_partial_op.cpp
@@ -23,15 +23,15 @@ void ShardedToInterleavedPartialDeviceOperation::validate(const std::vector<Tens
     TT_FATAL(input_tensor.storage_type() == StorageType::DEVICE, "Operands to shard need to be on device!");
     TT_FATAL(input_tensor.buffer() != nullptr, "Operands to shard need to be allocated in buffers on device!");
 
-    TT_FATAL(input_tensor.memory_config().is_sharded());
+    TT_FATAL(input_tensor.memory_config().is_sharded(), "Error");
     if (input_tensor.memory_config().memory_layout != TensorMemoryLayout::HEIGHT_SHARDED) {
         if (input_tensor.get_legacy_shape()[-1] % shard_spec.shape[1] != 0 ||
             ((input_tensor.volume() / input_tensor.get_legacy_shape()[-1]) % shard_spec.shape[0]) != 0) {
-            TT_FATAL(input_tensor.shard_spec().value().grid.ranges().size() == 1);
+            TT_FATAL(input_tensor.shard_spec().value().grid.ranges().size() == 1, "Error");
         }
     }
     if (input_tensor.get_dtype() != this->output_dtype) {
-        TT_FATAL(input_tensor.get_layout() == Layout::TILE);
+        TT_FATAL(input_tensor.get_layout() == Layout::TILE, "Error");
     }
     // Divisibility of num_cores and shard size with tensor shape is done in tensor creation, so no need to assert here
 }

--- a/ttnn/cpp/ttnn/operations/data_movement/sharded_partial/sharded_to_interleaved_partial/sharded_to_interleaved_partial.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/sharded_partial/sharded_to_interleaved_partial/sharded_to_interleaved_partial.cpp
@@ -24,7 +24,7 @@ ttnn::Tensor ShardedToInterleavedPartialOperation::invoke(
 
     auto memory_config = memory_config_arg.value_or(input_tensor.memory_config());
     auto shard_spec = input_tensor.shard_spec().value();
-    TT_FATAL(input_tensor.shard_spec().has_value());
+    TT_FATAL(input_tensor.shard_spec().has_value(), "Error");
     operation::run(
             ShardedToInterleavedPartialDeviceOperation{
                 .num_slices = num_slices,

--- a/ttnn/cpp/ttnn/operations/data_movement/slice/device/slice_op.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/slice/device/slice_op.cpp
@@ -72,14 +72,14 @@ void SliceDeviceOperation::validate_with_output_tensors(
     const auto &input_tensor_a = input_tensors.at(0);
     TT_FATAL(input_tensor_a.storage_type() == StorageType::DEVICE, "Operands to unpad need to be on device!");
     TT_FATAL(input_tensor_a.buffer() != nullptr, "Operands to unpad need to be allocated in buffers on device!");
-    TT_FATAL(input_tensor_a.get_layout() == Layout::TILE || input_tensor_a.get_layout() == Layout::ROW_MAJOR);
-    TT_FATAL(input_tensor_a.get_legacy_shape().rank() == this->slice_start.rank() && this->slice_start.rank() == this->slice_end.rank());
+    TT_FATAL(input_tensor_a.get_layout() == Layout::TILE || input_tensor_a.get_layout() == Layout::ROW_MAJOR, "Error");
+    TT_FATAL(input_tensor_a.get_legacy_shape().rank() == this->slice_start.rank() && this->slice_start.rank() == this->slice_end.rank(), "Error");
     for (uint32_t i = 0; i < input_tensor_a.get_legacy_shape().rank(); i++) {
-        TT_FATAL(this->slice_start[i] < input_tensor_a.get_legacy_shape()[i]);
-        TT_FATAL(this->slice_end[i] < input_tensor_a.get_legacy_shape()[i]);
+        TT_FATAL(this->slice_start[i] < input_tensor_a.get_legacy_shape()[i], "Error");
+        TT_FATAL(this->slice_end[i] < input_tensor_a.get_legacy_shape()[i], "Error");
 
         // Check if start shape is <= end shape
-        TT_FATAL(this->slice_start[i] <= this->slice_end[i]);
+        TT_FATAL(this->slice_start[i] <= this->slice_end[i], "Error");
     }
 
     auto output_tensor_shape = this->compute_output_shapes(input_tensors)[0];
@@ -89,7 +89,7 @@ void SliceDeviceOperation::validate_with_output_tensors(
         TT_FATAL(input_tensor_a.get_dtype() == DataType::BFLOAT16, "Strided slice is only supported for BFLOAT16");
     }
     if (input_tensor_a.get_layout() == Layout::TILE) {
-        TT_FATAL(input_tensor_a.volume() % TILE_HW == 0);
+        TT_FATAL(input_tensor_a.volume() % TILE_HW == 0, "Error");
         TT_FATAL(
             (output_tensor_shape[-2] % TILE_HEIGHT == 0) && (this->slice_start[-2] % TILE_HEIGHT == 0),
             "Can only unpad tilized tensor with full tiles");

--- a/ttnn/cpp/ttnn/operations/data_movement/split/device/split_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/split/device/split_program_factory.cpp
@@ -98,7 +98,7 @@ operation::ProgramWithCallbacks split_last_dim_two_chunks_tiled(
     tt::tt_metal::Buffer *in0_buffer = input_tensor.buffer();
 
     // Output buffers
-    TT_FATAL(output_tensors.size() == num_chunks);
+    TT_FATAL(output_tensors.size() == num_chunks, "Error");
     tt::tt_metal::Tensor &out0 = output_tensors[0];
     tt::tt_metal::Tensor &out1 = output_tensors[1];
 

--- a/ttnn/cpp/ttnn/operations/data_movement/tilize/device/tilize_op.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/tilize/device/tilize_op.cpp
@@ -13,25 +13,25 @@ void Tilize::validate(const std::vector<Tensor>& input_tensors) const {
     TT_FATAL(input_tensor_a.buffer() != nullptr, "Operands to tilize need to be allocated in buffers on device!");
     TT_FATAL(input_tensor_a.get_layout() == Layout::ROW_MAJOR, "Can only tilize row major data");
 
-    TT_FATAL(input_tensor_a.volume() % tt::constants::TILE_HW == 0);
+    TT_FATAL(input_tensor_a.volume() % tt::constants::TILE_HW == 0, "Error");
 
     auto width = input_tensor_a.get_legacy_shape()[-1];
     uint32_t stick_s = width;
     uint32_t num_sticks = input_tensor_a.volume() / width;
-    TT_FATAL(input_tensor_a.get_dtype() == DataType::BFLOAT16);
+    TT_FATAL(input_tensor_a.get_dtype() == DataType::BFLOAT16, "Error");
 
     uint32_t stick_size = stick_s * input_tensor_a.element_size();  // Assuming bfloat16 dataformat
 
     TT_FATAL((stick_size % 2) == 0, "Stick size must be divisible by 2");
 
     if (input_tensor_a.memory_config().is_sharded()) {
-        TT_FATAL(input_tensor_a.memory_config().memory_layout == TensorMemoryLayout::HEIGHT_SHARDED);
-        TT_FATAL(this->output_mem_config.memory_layout == input_tensor_a.memory_config().memory_layout);
-        TT_FATAL(this->use_multicore == true);
-        TT_FATAL(input_tensor_a.shard_spec().value().orientation == ShardOrientation::ROW_MAJOR);
+        TT_FATAL(input_tensor_a.memory_config().memory_layout == TensorMemoryLayout::HEIGHT_SHARDED, "Error");
+        TT_FATAL(this->output_mem_config.memory_layout == input_tensor_a.memory_config().memory_layout, "Error");
+        TT_FATAL(this->use_multicore == true, "Error");
+        TT_FATAL(input_tensor_a.shard_spec().value().orientation == ShardOrientation::ROW_MAJOR, "Error");
     } else {
-        TT_FATAL(input_tensor_a.memory_config().memory_layout == TensorMemoryLayout::INTERLEAVED);
-        TT_FATAL(this->output_mem_config.memory_layout == TensorMemoryLayout::INTERLEAVED);
+        TT_FATAL(input_tensor_a.memory_config().memory_layout == TensorMemoryLayout::INTERLEAVED, "Error");
+        TT_FATAL(this->output_mem_config.memory_layout == TensorMemoryLayout::INTERLEAVED, "Error");
     }
 }
 

--- a/ttnn/cpp/ttnn/operations/data_movement/tilize_with_val_padding/device/tilize_with_val_padding_op.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/tilize_with_val_padding/device/tilize_with_val_padding_op.cpp
@@ -38,7 +38,7 @@ void TilizeWithValPadding::validate(const std::vector<Tensor>& input_tensors) co
         TT_FATAL(this->output_mem_config.memory_layout == input_tensor_a.memory_config().memory_layout, "Output tensor must have the same memory layout as input tensor");
         for (uint32_t i = 0; i < input_tensor_a.get_legacy_shape().rank(); i++) {
             if (i != input_shape.rank() - 2) {
-                TT_FATAL(input_shape[i] == this->output_tensor_shape[i]);
+                TT_FATAL(input_shape[i] == this->output_tensor_shape[i], "Error");
             }
         }
     }

--- a/ttnn/cpp/ttnn/operations/data_movement/transpose/device/transpose_op.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/transpose/device/transpose_op.cpp
@@ -23,51 +23,51 @@ void Transpose::validate(const std::vector<Tensor> &input_tensors) const {
     uint32_t W = shape[3], H = shape[2], C = shape[1], N = shape[0];
     uint32_t HW = H*W;
     if (not row_major) {
-        TT_FATAL(W % TILE_WIDTH == 0 && H % TILE_HEIGHT == 0);
-        TT_FATAL(input_tensor.volume() % TILE_HW == 0);
+        TT_FATAL(W % TILE_WIDTH == 0 && H % TILE_HEIGHT == 0, "Error");
+        TT_FATAL(input_tensor.volume() % TILE_HW == 0, "Error");
     }
     uint32_t ROW_MAJOR_STICK_WIDTH = 16;
     if (this->dim == TransposeOpDim::WH) {
         if (row_major) {
-            TT_FATAL((W * input_tensor.element_size()) % ROW_MAJOR_STICK_WIDTH == 0 && (H * input_tensor.element_size()) % ROW_MAJOR_STICK_WIDTH == 0);
+            TT_FATAL((W * input_tensor.element_size()) % ROW_MAJOR_STICK_WIDTH == 0 && (H * input_tensor.element_size()) % ROW_MAJOR_STICK_WIDTH == 0, "Error");
         }
         if (input_tensor.is_sharded()) {
-            TT_FATAL(input_tensor.memory_config().memory_layout != TensorMemoryLayout::WIDTH_SHARDED);
+            TT_FATAL(input_tensor.memory_config().memory_layout != TensorMemoryLayout::WIDTH_SHARDED, "Error");
             const auto shard_spec = input_tensor.shard_spec().value();
-            TT_FATAL(shard_spec.shape[1] == W);
-            TT_FATAL(shard_spec.shape[0] % H == 0);
-            TT_FATAL(this->output_mem_config.is_sharded());
-            TT_FATAL(this->output_mem_config.memory_layout != TensorMemoryLayout::WIDTH_SHARDED);
+            TT_FATAL(shard_spec.shape[1] == W, "Error");
+            TT_FATAL(shard_spec.shape[0] % H == 0, "Error");
+            TT_FATAL(this->output_mem_config.is_sharded(), "Error");
+            TT_FATAL(this->output_mem_config.memory_layout != TensorMemoryLayout::WIDTH_SHARDED, "Error");
         } else {
-            TT_FATAL(!this->output_mem_config.is_sharded());
+            TT_FATAL(!this->output_mem_config.is_sharded(), "Error");
         }
     } else {
         if (input_tensor.is_sharded()) {
-            TT_FATAL(input_tensor.memory_config().memory_layout == TensorMemoryLayout::HEIGHT_SHARDED);
+            TT_FATAL(input_tensor.memory_config().memory_layout == TensorMemoryLayout::HEIGHT_SHARDED, "Error");
             const auto shard_spec = input_tensor.shard_spec().value();
-            TT_FATAL(shard_spec.shape[1] == W);
-            TT_FATAL(this->output_mem_config.is_sharded());
-            TT_FATAL(this->output_mem_config.memory_layout == TensorMemoryLayout::HEIGHT_SHARDED);
+            TT_FATAL(shard_spec.shape[1] == W, "Error");
+            TT_FATAL(this->output_mem_config.is_sharded(), "Error");
+            TT_FATAL(this->output_mem_config.memory_layout == TensorMemoryLayout::HEIGHT_SHARDED, "Error");
         } else {
-            TT_FATAL(!this->output_mem_config.is_sharded());
+            TT_FATAL(!this->output_mem_config.is_sharded(), "Error");
         }
     }
     if (this->dim == TransposeOpDim::HC) {
         if (row_major) {
-            TT_FATAL((W * input_tensor.element_size()) % ROW_MAJOR_STICK_WIDTH == 0);
+            TT_FATAL((W * input_tensor.element_size()) % ROW_MAJOR_STICK_WIDTH == 0, "Error");
         } else {
-            TT_FATAL(C % TILE_HEIGHT == 0);
+            TT_FATAL(C % TILE_HEIGHT == 0, "Error");
         }
-        TT_FATAL(input_tensor.get_dtype() == DataType::BFLOAT16 || input_tensor.get_dtype() == DataType::FLOAT32);
+        TT_FATAL(input_tensor.get_dtype() == DataType::BFLOAT16 || input_tensor.get_dtype() == DataType::FLOAT32, "Error");
     } else if (this->dim == TransposeOpDim::CW) {
-        TT_FATAL(C % TILE_WIDTH == 0);
-        TT_FATAL(input_tensor.get_dtype() == DataType::BFLOAT16 || input_tensor.get_dtype() == DataType::FLOAT32);
+        TT_FATAL(C % TILE_WIDTH == 0, "Error");
+        TT_FATAL(input_tensor.get_dtype() == DataType::BFLOAT16 || input_tensor.get_dtype() == DataType::FLOAT32, "Error");
     } else if (this->dim == TransposeOpDim::NH) {
-        TT_FATAL(N % TILE_HEIGHT == 0);
-        TT_FATAL(input_tensor.get_dtype() == DataType::BFLOAT16 || input_tensor.get_dtype() == DataType::FLOAT32);
+        TT_FATAL(N % TILE_HEIGHT == 0, "Error");
+        TT_FATAL(input_tensor.get_dtype() == DataType::BFLOAT16 || input_tensor.get_dtype() == DataType::FLOAT32, "Error");
     } else if (this->dim == TransposeOpDim::NW) {
-        TT_FATAL(N % TILE_WIDTH == 0);
-        TT_FATAL(input_tensor.get_dtype() == DataType::BFLOAT16 || input_tensor.get_dtype() == DataType::FLOAT32);
+        TT_FATAL(N % TILE_WIDTH == 0, "Error");
+        TT_FATAL(input_tensor.get_dtype() == DataType::BFLOAT16 || input_tensor.get_dtype() == DataType::FLOAT32, "Error");
     }
 }
 

--- a/ttnn/cpp/ttnn/operations/data_movement/untilize/device/untilize_op.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/untilize/device/untilize_op.cpp
@@ -32,29 +32,29 @@ void Untilize::validate(const std::vector<Tensor>& input_tensors) const {
     TT_FATAL(input_tensor_a.buffer() != nullptr, "Operands to untilize need to be allocated in buffers on device!");
     TT_FATAL(input_tensor_a.get_layout() == Layout::TILE, "Can only untilize tile major data");
 
-    TT_FATAL(input_tensor_a.volume() % TILE_HW == 0);
+    TT_FATAL(input_tensor_a.volume() % TILE_HW == 0, "Error");
 
     if (input_tensor_a.memory_config().is_sharded()) {
         if (this->output_mem_config.is_sharded()) {
-            TT_FATAL(this->output_mem_config.memory_layout == input_tensor_a.memory_config().memory_layout);
+            TT_FATAL(this->output_mem_config.memory_layout == input_tensor_a.memory_config().memory_layout, "Error");
         }
         if (input_tensor_a.memory_config().memory_layout != TensorMemoryLayout::HEIGHT_SHARDED) {
-            TT_FATAL(input_tensor_a.shard_spec().value().grid.ranges().size() == 1);
+            TT_FATAL(input_tensor_a.shard_spec().value().grid.ranges().size() == 1, "Error");
         }
-        TT_FATAL(this->use_multicore == true);
+        TT_FATAL(this->use_multicore == true, "Error");
     } else if (this->output_mem_config.is_sharded()) {
-        TT_FATAL(this->use_multicore == true);
-        TT_FATAL(this->output_mem_config.memory_layout == TensorMemoryLayout::HEIGHT_SHARDED);
+        TT_FATAL(this->use_multicore == true, "Error");
+        TT_FATAL(this->output_mem_config.memory_layout == TensorMemoryLayout::HEIGHT_SHARDED, "Error");
         uint32_t ntiles = input_tensor_a.volume() / TILE_HW;
         uint32_t ntiles_per_block = input_tensor_a.get_legacy_shape()[-1] / TILE_WIDTH;
         uint32_t nblocks = ceil((float)ntiles / ntiles_per_block);
         auto num_cores =
             untilize_helpers::get_num_cores(input_tensor_a.device()->compute_with_storage_grid_size(), nblocks);
         uint32_t fused_height = input_tensor_a.volume() / input_tensor_a.get_legacy_shape()[-1];
-        TT_FATAL(fused_height % num_cores == 0);
+        TT_FATAL(fused_height % num_cores == 0, "Error");
     } else {
-        TT_FATAL(input_tensor_a.memory_config().memory_layout == TensorMemoryLayout::INTERLEAVED);
-        TT_FATAL(this->output_mem_config.memory_layout == TensorMemoryLayout::INTERLEAVED);
+        TT_FATAL(input_tensor_a.memory_config().memory_layout == TensorMemoryLayout::INTERLEAVED, "Error");
+        TT_FATAL(this->output_mem_config.memory_layout == TensorMemoryLayout::INTERLEAVED, "Error");
     }
 }
 

--- a/ttnn/cpp/ttnn/operations/data_movement/untilize_with_halo_v2/device/untilize_with_halo_v2_op.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/untilize_with_halo_v2/device/untilize_with_halo_v2_op.cpp
@@ -19,12 +19,13 @@ void UntilizeWithHaloV2::validate(const std::vector<Tensor>& input_tensors) cons
         // skip the untilize, only do halo
         log_debug(tt::LogOp, "Input is ROW_MAJOR, no need to untilize.");
     } else {
-        TT_FATAL(input_tensor.volume() % TILE_HW == 0);
+        TT_FATAL(input_tensor.volume() % TILE_HW == 0, "Error");
     }
     TT_FATAL(
         input_tensor.memory_config().memory_layout == TensorMemoryLayout::HEIGHT_SHARDED ||
-        input_tensor.memory_config().memory_layout == TensorMemoryLayout::BLOCK_SHARDED);
-    TT_FATAL(input_tensor.shard_spec().has_value());
+        input_tensor.memory_config().memory_layout == TensorMemoryLayout::BLOCK_SHARDED,
+        "Unsupported memory layout {}.", input_tensor.memory_config().memory_layout);
+    TT_FATAL(input_tensor.shard_spec().has_value(), "Error");
 }
 
 std::vector<tt::tt_metal::Shape> UntilizeWithHaloV2::compute_output_shapes(
@@ -66,7 +67,7 @@ std::vector<Tensor> UntilizeWithHaloV2::create_output_tensors(
         auto output_core_range = *(out_mem_config_.shard_spec->grid.ranges().begin());
         auto input_core_w = input_core_range.end_coord.y - input_core_range.start_coord.y + 1;
         auto output_core_w = output_core_range.end_coord.y - output_core_range.start_coord.y + 1;
-        TT_FATAL(input_core_w == output_core_w);
+        TT_FATAL(input_core_w == output_core_w, "Error");
     }
 
     auto out_mem_config = out_mem_config_;

--- a/ttnn/cpp/ttnn/operations/data_movement/untilize_with_unpadding/device/untilize_with_unpadding_op.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/untilize_with_unpadding/device/untilize_with_unpadding_op.cpp
@@ -16,18 +16,18 @@ void UntilizeWithUnpadding::validate(const std::vector<Tensor>& input_tensors) c
     TT_FATAL(input_tensor_a.buffer() != nullptr, "Operands need to be allocated in buffers on device!");
     TT_FATAL(input_tensor_a.get_layout() == Layout::TILE, "Can only untilize tile major data");
 
-    TT_FATAL(input_tensor_a.volume() % tt::constants::TILE_HW == 0);
+    TT_FATAL(input_tensor_a.volume() % tt::constants::TILE_HW == 0, "Error");
     for (uint32_t i = 0; i < input_tensor_a.get_legacy_shape().rank(); i++) {
-        TT_FATAL(input_tensor_a.get_legacy_shape()[i] > 0);
-        TT_FATAL(this->output_tensor_end[i] < input_tensor_a.get_legacy_shape()[i]);
+        TT_FATAL(input_tensor_a.get_legacy_shape()[i] > 0, "Error");
+        TT_FATAL(this->output_tensor_end[i] < input_tensor_a.get_legacy_shape()[i], "Error");
     }
 
     TT_FATAL(((this->output_tensor_end[-1] + 1) % 2 == 0), "Can only unpad to row major tensor of even width");
 
     if (input_tensor_a.memory_config().is_sharded()) {
         if (input_tensor_a.memory_config().memory_layout == TensorMemoryLayout::BLOCK_SHARDED) {
-            TT_FATAL(input_tensor_a.shard_spec().value().grid.ranges().size() == 1);
-            TT_FATAL(this->output_mem_config.memory_layout == TensorMemoryLayout::INTERLEAVED);
+            TT_FATAL(input_tensor_a.shard_spec().value().grid.ranges().size() == 1, "Error");
+            TT_FATAL(this->output_mem_config.memory_layout == TensorMemoryLayout::INTERLEAVED, "Error");
             TT_FATAL(
                 input_tensor_a.volume() /
                         (input_tensor_a.get_legacy_shape()[-2] * input_tensor_a.get_legacy_shape()[-1]) ==
@@ -35,24 +35,24 @@ void UntilizeWithUnpadding::validate(const std::vector<Tensor>& input_tensors) c
                 "Can only write unbatched output interleaved");
         } else if (input_tensor_a.memory_config().memory_layout == TensorMemoryLayout::HEIGHT_SHARDED) {
             if (output_mem_config.is_sharded()) {
-                TT_FATAL(this->output_mem_config.memory_layout == TensorMemoryLayout::HEIGHT_SHARDED);
+                TT_FATAL(this->output_mem_config.memory_layout == TensorMemoryLayout::HEIGHT_SHARDED, "Error");
             }
             // What else?
         } else if (input_tensor_a.memory_config().memory_layout == TensorMemoryLayout::WIDTH_SHARDED) {
             auto output_shape = this->compute_output_shapes(input_tensors).at(0);
             // Minor host code changes required to remove this restriction
-            TT_FATAL(input_tensor_a.shard_spec().value().grid.ranges().size() == 1);
+            TT_FATAL(input_tensor_a.shard_spec().value().grid.ranges().size() == 1, "Error");
             for (uint32_t i = 0; i < output_shape.rank() - 2; i++) {
-                TT_FATAL(input_tensor_a.get_legacy_shape()[i] == output_shape[i]);
+                TT_FATAL(input_tensor_a.get_legacy_shape()[i] == output_shape[i], "Error");
             }
             if (output_mem_config.is_sharded()) {
-                TT_FATAL(this->output_mem_config.memory_layout == input_tensor_a.memory_config().memory_layout);
+                TT_FATAL(this->output_mem_config.memory_layout == input_tensor_a.memory_config().memory_layout, "Error");
                 TT_FATAL(
                     input_tensor_a.get_legacy_shape()[-1] == output_shape[-1] ||
                     (tt::div_up(output_shape[-1], input_tensor_a.shard_spec().value().shape[1]) ==
-                     input_tensor_a.shard_spec().value().grid.num_cores()));
+                     input_tensor_a.shard_spec().value().grid.num_cores()), "Error");
             } else {
-                TT_FATAL(this->output_mem_config.memory_layout == TensorMemoryLayout::INTERLEAVED);
+                TT_FATAL(this->output_mem_config.memory_layout == TensorMemoryLayout::INTERLEAVED, "Error");
                 TT_FATAL(
                     input_tensor_a.volume() /
                             (input_tensor_a.get_legacy_shape()[-2] * input_tensor_a.get_legacy_shape()[-1]) ==
@@ -60,14 +60,14 @@ void UntilizeWithUnpadding::validate(const std::vector<Tensor>& input_tensors) c
                     "Can only write unbatched output interleaved");
                 TT_FATAL(
                     input_tensor_a.get_legacy_shape()[-1] - output_shape[-1] <
-                    input_tensor_a.shard_spec().value().shape[1]);
+                    input_tensor_a.shard_spec().value().shape[1], "Error");
             }
         } else {
             TT_FATAL(false, "Unsupported sharding scheme");
         }
     } else {
-        TT_FATAL(input_tensor_a.memory_config().memory_layout == TensorMemoryLayout::INTERLEAVED);
-        TT_FATAL(this->output_mem_config.memory_layout == TensorMemoryLayout::INTERLEAVED);
+        TT_FATAL(input_tensor_a.memory_config().memory_layout == TensorMemoryLayout::INTERLEAVED, "Error");
+        TT_FATAL(this->output_mem_config.memory_layout == TensorMemoryLayout::INTERLEAVED, "Error");
     }
 }
 

--- a/ttnn/cpp/ttnn/operations/eltwise/binary/device/binary_composite_op.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary/device/binary_composite_op.cpp
@@ -159,7 +159,7 @@ Tensor _logical_xor(const Tensor& input_a, const Tensor& input_b, const std::opt
 }
 
 Tensor _div_overload(const Tensor& input_a, float value, bool accurate_mode, const std::string& round_mode, const std::optional<MemoryConfig>& output_mem_config) {
-    TT_FATAL((round_mode == "None" || round_mode == "trunc" || round_mode == "floor") && "Incorrect rounding mode (expected 'None', 'trunc', or 'floor')");
+    TT_FATAL((round_mode == "None" || round_mode == "trunc" || round_mode == "floor"), "Incorrect rounding mode (expected 'None', 'trunc', or 'floor')");
     Tensor result = ttnn::multiply(input_a, (1.0f/value), std::nullopt, output_mem_config);
     if(round_mode == "trunc"){
         result = ttnn::trunc(result);
@@ -171,7 +171,7 @@ Tensor _div_overload(const Tensor& input_a, float value, bool accurate_mode, con
 }
 
 Tensor _div(const Tensor& input_a, const Tensor& input_b, bool accurate_mode, const std::string& round_mode, const std::optional<MemoryConfig>& output_mem_config) {
-    TT_FATAL((round_mode == "None" || round_mode == "trunc" || round_mode == "floor") && "Incorrect rounding mode (expected 'None', 'trunc', or 'floor')");
+    TT_FATAL((round_mode == "None" || round_mode == "trunc" || round_mode == "floor"), "Incorrect rounding mode (expected 'None', 'trunc', or 'floor')");
     auto arch = input_a.device()->arch();
     if (arch == tt::ARCH::WORMHOLE_B0) {
         DataType input_dtype = input_a.get_dtype();

--- a/ttnn/cpp/ttnn/operations/eltwise/binary/device/binary_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary/device/binary_device_operation.cpp
@@ -65,38 +65,38 @@ void BinaryDeviceOperation::validate_on_program_cache_miss(
         if (input_tensor_a.memory_config().memory_layout != TensorMemoryLayout::HEIGHT_SHARDED) {
             // If we aren't height sharded, we require all sharding schemes to match until we add blocked
             // reader/writers for width and block sharding
-            TT_FATAL((input_tensor_b.memory_config().is_sharded()));
-            TT_FATAL(input_tensor_a.shard_spec().value().grid.ranges().size() == 1);
+            TT_FATAL((input_tensor_b.memory_config().is_sharded()), "Error");
+            TT_FATAL(input_tensor_a.shard_spec().value().grid.ranges().size() == 1, "Error");
         }
         if (input_tensor_b.memory_config().is_sharded()) {
-            TT_FATAL(input_tensor_a.memory_config().memory_layout == input_tensor_b.memory_config().memory_layout);
-            TT_FATAL(input_tensor_a.shard_spec().value() == input_tensor_b.shard_spec().value());
+            TT_FATAL(input_tensor_a.memory_config().memory_layout == input_tensor_b.memory_config().memory_layout, "Error");
+            TT_FATAL(input_tensor_a.shard_spec().value() == input_tensor_b.shard_spec().value(), "Error");
         }
         if (attributes.memory_config.is_sharded()) {
-            TT_FATAL(input_tensor_a.memory_config().memory_layout == attributes.memory_config.memory_layout);
+            TT_FATAL(input_tensor_a.memory_config().memory_layout == attributes.memory_config.memory_layout, "Error");
         } else {
-            TT_FATAL(attributes.memory_config.memory_layout == TensorMemoryLayout::INTERLEAVED);
+            TT_FATAL(attributes.memory_config.memory_layout == TensorMemoryLayout::INTERLEAVED, "Error");
         }
     } else if (input_tensor_b.memory_config().is_sharded()) {
-        TT_FATAL(input_tensor_b.memory_config().memory_layout == TensorMemoryLayout::HEIGHT_SHARDED);
-        TT_FATAL(input_tensor_a.memory_config().memory_layout == TensorMemoryLayout::INTERLEAVED);
+        TT_FATAL(input_tensor_b.memory_config().memory_layout == TensorMemoryLayout::HEIGHT_SHARDED, "Error");
+        TT_FATAL(input_tensor_a.memory_config().memory_layout == TensorMemoryLayout::INTERLEAVED, "Error");
         if (attributes.memory_config.is_sharded()) {
-            TT_FATAL(input_tensor_b.memory_config().memory_layout == attributes.memory_config.memory_layout);
+            TT_FATAL(input_tensor_b.memory_config().memory_layout == attributes.memory_config.memory_layout, "Error");
         } else {
-            TT_FATAL(attributes.memory_config.memory_layout == TensorMemoryLayout::INTERLEAVED);
+            TT_FATAL(attributes.memory_config.memory_layout == TensorMemoryLayout::INTERLEAVED, "Error");
         }
     } else {
-        TT_FATAL(input_tensor_a.memory_config().memory_layout == TensorMemoryLayout::INTERLEAVED);
-        TT_FATAL(input_tensor_b.memory_config().memory_layout == TensorMemoryLayout::INTERLEAVED);
+        TT_FATAL(input_tensor_a.memory_config().memory_layout == TensorMemoryLayout::INTERLEAVED, "Error");
+        TT_FATAL(input_tensor_b.memory_config().memory_layout == TensorMemoryLayout::INTERLEAVED, "Error");
         if (attributes.memory_config.is_sharded()) {
-            TT_FATAL(attributes.memory_config.memory_layout == TensorMemoryLayout::HEIGHT_SHARDED);
+            TT_FATAL(attributes.memory_config.memory_layout == TensorMemoryLayout::HEIGHT_SHARDED, "Error");
             uint32_t num_blocks = input_tensor_a.volume() / input_tensor_a.get_legacy_shape()[-1] / TILE_HEIGHT;
             auto core_grid = input_tensor_a.device()->compute_with_storage_grid_size();
             uint32_t num_cores = core_grid.x * core_grid.y;
-            TT_FATAL(num_blocks < num_cores or num_blocks % num_cores == 0);
+            TT_FATAL(num_blocks < num_cores or num_blocks % num_cores == 0, "Error");
 
         } else {
-            TT_FATAL(attributes.memory_config.memory_layout == TensorMemoryLayout::INTERLEAVED);
+            TT_FATAL(attributes.memory_config.memory_layout == TensorMemoryLayout::INTERLEAVED, "Error");
         }
     }
 
@@ -104,7 +104,7 @@ void BinaryDeviceOperation::validate_on_program_cache_miss(
     std::visit(
         [&attributes](auto&& program_factory) {
             if constexpr (std::is_same_v<decltype(program_factory), ElementWiseMultiCore>) {
-                TT_FATAL(not attributes.activations.has_value());
+                TT_FATAL(not attributes.activations.has_value(), "Error");
             }
         },
         program_factory);

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_backward/device/binary_backward_op.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_backward/device/binary_backward_op.cpp
@@ -435,7 +435,7 @@ std::vector<Tensor> _rsub_bw( const Tensor& grad, const Tensor& input, const Ten
 
 std::vector<Tensor> ExecuteBackwardBiasGelu::invoke(
     const Tensor& grad, const Tensor& input_a, const Tensor& input_b, string approximate, const std::optional<MemoryConfig>& output_mem_config) {
-    TT_FATAL((approximate == "none" || approximate == "tanh") && "Incorrect approximation type (expected 'none', 'tanh')");
+    TT_FATAL((approximate == "none" || approximate == "tanh"), "Incorrect approximation type (expected 'none', 'tanh')");
     std::vector<Tensor> grad_tensor;
     Tensor input = ttnn::add(input_a, input_b);
     grad_tensor = ttnn::gelu_bw(grad, input, approximate = approximate, output_mem_config);
@@ -446,7 +446,7 @@ std::vector<Tensor> ExecuteBackwardBiasGelu::invoke(
 std::vector<Tensor> ExecuteBackwardBiasGelu::invoke(
     const Tensor& grad, const Tensor& input_tensor, float bias, string approximate, const std::optional<MemoryConfig>& output_mem_config) {
     std::vector<Tensor> grad_tensor;
-    TT_FATAL((approximate == "none" || approximate == "tanh") && "Incorrect rounding mode (expected 'none' or 'tanh')");
+    TT_FATAL((approximate == "none" || approximate == "tanh"), "Incorrect rounding mode (expected 'none' or 'tanh')", "Error");
     Tensor input = ttnn::add(input_tensor, bias);
     grad_tensor = ttnn::gelu_bw(grad, input, approximate = approximate);
     return grad_tensor;
@@ -508,7 +508,7 @@ template std::vector<Tensor> _min_or_max_bw<false>(
 std::vector<Tensor> ExecuteBackwardDiv::invoke(
     const Tensor& grad, const Tensor& input, float scalar, std::string round_mode, const std::optional<MemoryConfig>& output_mem_config) {
     std::vector<Tensor> grad_tensor;
-    TT_FATAL((round_mode == "None" || round_mode == "trunc" || round_mode == "floor") && "Incorrect rounding mode (expected 'None', 'trunc', or 'floor')");
+    TT_FATAL((round_mode == "None" || round_mode == "trunc" || round_mode == "floor"), "Incorrect rounding mode (expected 'None', 'trunc', or 'floor')");
     float inv_scalar = 1.0f / scalar;
     if (round_mode == "None") {
         Tensor t_inf = ttnn::operations::creation::full_like(input, std::numeric_limits<float>::infinity());

--- a/ttnn/cpp/ttnn/operations/eltwise/unary/common/unary_op_utils.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary/common/unary_op_utils.cpp
@@ -77,7 +77,7 @@ void update_macro_defines(UnaryOpType op_type, std::map<std::string, std::string
 std::pair<std::string, std::string> get_op_init_and_func_parameterized(
     UnaryOpType op_type, const std::vector<float>& params, const std::string& idst) {
     std::pair<std::string, std::string> op_init_and_name;
-    TT_FATAL(is_parametrized_type(op_type) && "operator should support at least one parameter");
+    TT_FATAL(is_parametrized_type(op_type) && "operator should support at least one parameter", "Error");
     float param0 = params[0];
     switch (op_type) {
         case UnaryOpType::RELU_MAX:

--- a/ttnn/cpp/ttnn/operations/eltwise/unary_backward/device/unary_backward_op.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary_backward/device/unary_backward_op.cpp
@@ -31,7 +31,7 @@ std::vector<Tensor> _clamp_bw(
     const Tensor& grad, const Tensor& input, std::optional<float> min, std::optional<float> max, const std::optional<MemoryConfig>& output_mem_config) {
     std::vector<Tensor> grad_tensor;
     auto output_memory_config = output_mem_config.value_or(input.memory_config()); //TODO: Remove after ternary forward ops migration is completed
-    TT_FATAL((max.has_value() || min.has_value()) && "Only one of 'min' or 'max' can be None. Please provide atleast one value");
+    TT_FATAL((max.has_value() || min.has_value()) && "Only one of 'min' or 'max' can be None. Please provide atleast one value", "Error");
     if (!max.has_value()) {
         Tensor minT = ttnn::ge(input, min.value(), std::nullopt, output_mem_config);
         Tensor result = ttnn::multiply(grad, minT, std::nullopt, output_mem_config);
@@ -103,7 +103,7 @@ std::vector<Tensor> _softplus_bw(
 std::vector<Tensor> _rdiv_bw(
     const Tensor& grad, const Tensor& input, float scalar, string round_mode, const std::optional<MemoryConfig>& output_mem_config) {
     std::vector<Tensor> grad_tensor;
-    TT_FATAL((round_mode == "None" || round_mode == "trunc" || round_mode == "floor") && "Incorrect rounding mode (expected 'None', 'trunc', or 'floor')");
+    TT_FATAL((round_mode == "None" || round_mode == "trunc" || round_mode == "floor"), "Incorrect rounding mode (expected 'None', 'trunc', or 'floor')");
     float t_nan = std::nanf("");
     float t_inf = std::numeric_limits<float>::infinity();
     if (round_mode == "None") {
@@ -1327,7 +1327,7 @@ std::vector<Tensor> _gelu_bw(
     const Tensor& grad, const Tensor& input, string approximate, const std::optional<MemoryConfig>& output_mem_config) {
     std::vector<Tensor> grad_tensor;
     auto output_memory_config = output_mem_config.value_or(input.memory_config()); //TODO: Remove after ternary forward ops migration is completed
-    TT_FATAL((approximate == "none" || approximate == "tanh") && "Incorrect approximate mode (expected 'None', 'tanh')");
+    TT_FATAL((approximate == "none" || approximate == "tanh"), "Incorrect approximate mode (expected 'None', 'tanh')");
 
     if (approximate == "tanh") {
         float kBeta = M_SQRT2 * M_2_SQRTPI * 0.5;
@@ -1375,7 +1375,7 @@ std::vector<Tensor> _repeat_bw(
     auto output_memory_config = output_mem_config.value_or(input.memory_config()); //TODO: Remove after ternary forward ops migration is completed
 
     auto shape_wh = input.get_legacy_shape();
-    TT_FATAL(shape_wh[0] == 1 && "input shape[0] should be 1");
+    TT_FATAL(shape_wh[0] == 1 && "input shape[0] should be 1", "Error");
     auto ttnn_device = input.device();
     // input.get_legacy_shape()[0]
     // If repeat shape has 0's, it returns zeros of given input
@@ -1385,7 +1385,7 @@ std::vector<Tensor> _repeat_bw(
         return grad_tensor;
     } else if (shape[0] > 1) {
         std::vector<int64_t> dim = {0};
-        TT_FATAL(shape[1] == 1 && shape[2] == 1 && shape[3] == 1 && "repeat[1], [2], [3] should be 1");
+        TT_FATAL(shape[1] == 1 && shape[2] == 1 && shape[3] == 1, "repeat[1], [2], [3] should be 1");
         std::array<std::uint32_t, 4> intended_shape_array = {1, shape_wh[1], shape_wh[2], shape_wh[3]};
         const ttnn::Shape required = ttnn::Shape(intended_shape_array);
         Tensor result = tt::operations::primary::moreh_sum(
@@ -1398,7 +1398,7 @@ std::vector<Tensor> _repeat_bw(
         return grad_tensor;
     } else if (shape[1] > 1) {
         std::vector<int64_t> dim = {1};
-        TT_FATAL(shape[0] == 1 && shape[2] == 1 && shape[3] == 1 && "repeat[0], [2], [3] should be 1");
+        TT_FATAL(shape[0] == 1 && shape[2] == 1 && shape[3] == 1, "repeat[0], [2], [3] should be 1");
         std::array<std::uint32_t, 4> intended_shape_array = {shape_wh[0], 1, shape_wh[2], shape_wh[3]};
         const ttnn::Shape required = ttnn::Shape(intended_shape_array);
         Tensor result = tt::operations::primary::moreh_sum(

--- a/ttnn/cpp/ttnn/operations/embedding/device/embedding_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/embedding/device/embedding_device_operation.cpp
@@ -22,26 +22,26 @@ void Embeddings::validate(const std::vector<Tensor> &input_tensors) const {
     TT_FATAL(input_tensors.size() == 2, "Must have between 2 input tensors");
     auto &a = input_tensors.at(0);
     const auto &weights = input_tensors.at(1);
-    TT_FATAL(a.get_layout() == Layout::ROW_MAJOR);
-    TT_FATAL(weights.get_layout() == Layout::ROW_MAJOR);
+    TT_FATAL(a.get_layout() == Layout::ROW_MAJOR, "Error");
+    TT_FATAL(weights.get_layout() == Layout::ROW_MAJOR, "Error");
     TT_FATAL(a.get_dtype() == DataType::UINT32 or a.get_dtype() == DataType::BFLOAT16, "Input must be UINT32 or BFLOAT16");
-    TT_FATAL(weights.get_dtype() == DataType::BFLOAT16);
+    TT_FATAL(weights.get_dtype() == DataType::BFLOAT16, "Error");
     TT_FATAL(a.memory_config().memory_layout == TensorMemoryLayout::INTERLEAVED, "Embedding does not currently support sharding");
     TT_FATAL(weights.memory_config().memory_layout == TensorMemoryLayout::INTERLEAVED, "Embedding does not currently support sharding");
     TT_FATAL(this->output_mem_config.memory_layout == TensorMemoryLayout::INTERLEAVED, "Embedding does not currently support sharding");
 
     TT_FATAL(weights.get_legacy_shape()[0] == 1 && weights.get_legacy_shape()[1] == 1, "First two dimensions for the weights must be 1");
     if (this->tilized) {
-        TT_FATAL(a.get_legacy_shape()[-1] % TILE_HEIGHT == 0);
+        TT_FATAL(a.get_legacy_shape()[-1] % TILE_HEIGHT == 0, "Error");
         TT_FATAL(weights.get_legacy_shape()[-1] % TILE_WIDTH == 0, "Number of columns in table must be factor of tile width");
     } else {
-        TT_FATAL(this->output_dtype != DataType::BFLOAT8_B);
+        TT_FATAL(this->output_dtype != DataType::BFLOAT8_B, "Error");
     }
     TT_FATAL(a.get_legacy_shape()[1] == 1 && a.get_legacy_shape()[2] == 1, "Only dim 0 && 3 for the input can be non 1");
     switch (this->embeddings_type) {
-        case EmbeddingsType::PADDED: TT_FATAL(this->pad_token.has_value()); break;
-        case EmbeddingsType::BINARY: TT_FATAL(weights.get_legacy_shape()[-2] == 2);
-        default: TT_FATAL(!this->pad_token.has_value());
+        case EmbeddingsType::PADDED: TT_FATAL(this->pad_token.has_value(), "Error"); break;
+        case EmbeddingsType::BINARY: TT_FATAL(weights.get_legacy_shape()[-2] == 2, "Error");
+        default: TT_FATAL(!this->pad_token.has_value(), "Error");
     }
 }
 

--- a/ttnn/cpp/ttnn/operations/embedding_backward/device/embedding_backward_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/embedding_backward/device/embedding_backward_device_operation.cpp
@@ -25,7 +25,7 @@ void EmbeddingBackward::validate(const std::vector<Tensor> &input_tensors) const
         index_tensor.device()->arch() == tt::ARCH::WORMHOLE_B0,
         "Embedding backwards is only implemented for Wormhole!");
 
-    TT_FATAL(index_tensor.get_layout() == Layout::ROW_MAJOR);
+    TT_FATAL(index_tensor.get_layout() == Layout::ROW_MAJOR, "Error");
     TT_FATAL(
         index_tensor.get_dtype() == DataType::UINT32 or index_tensor.get_dtype() == DataType::BFLOAT16,
         "Index tensor must be UINT32 or BFLOAT16");
@@ -41,7 +41,7 @@ void EmbeddingBackward::validate(const std::vector<Tensor> &input_tensors) const
         index_tensor_shape[-1] % TILE_WIDTH == 0,
         "Number of columns in the index tensor must be divisible by tile width");
 
-    TT_FATAL(grad_tensor.get_layout() == Layout::TILE);
+    TT_FATAL(grad_tensor.get_layout() == Layout::TILE, "Error");
     TT_FATAL(
         grad_tensor.get_dtype() == DataType::BFLOAT16 or grad_tensor.get_dtype() == DataType::BFLOAT8_B,
         "Output gradient tensor must be BFLOAT16 or BFLOAT8_B");

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_matmul/device/all_gather_matmul_op.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_matmul/device/all_gather_matmul_op.cpp
@@ -38,7 +38,7 @@ void AllGatherMatmul::validate(const std::vector<Tensor> &input_tensors, const s
     std::visit([&] (const auto& config) {
         using ProgramConfigType = std::decay_t<decltype(config)>;
         if (not (std::is_same_v<ProgramConfigType, operations::matmul::MatmulMultiCoreReuseMultiCast1DProgramConfig> || std::is_same_v<ProgramConfigType, operations::matmul::MatmulMultiCoreReuseMultiCastProgramConfig>)) {
-            TT_FATAL(false, "Unsupported MatmulProgramConfig type for AllGatherMatmul. Needs to be 1D or 2D Multicast.");
+            TT_THROW("Unsupported MatmulProgramConfig type for AllGatherMatmul. Needs to be 1D or 2D Multicast.");
         }
     }, this->matmul_struct.program_config.value());
 

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_matmul/device/all_gather_matmul_op.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_matmul/device/all_gather_matmul_op.cpp
@@ -38,7 +38,7 @@ void AllGatherMatmul::validate(const std::vector<Tensor> &input_tensors, const s
     std::visit([&] (const auto& config) {
         using ProgramConfigType = std::decay_t<decltype(config)>;
         if (not (std::is_same_v<ProgramConfigType, operations::matmul::MatmulMultiCoreReuseMultiCast1DProgramConfig> || std::is_same_v<ProgramConfigType, operations::matmul::MatmulMultiCoreReuseMultiCastProgramConfig>)) {
-            TT_FATAL("Unsupported MatmulProgramConfig type for AllGatherMatmul.");
+            TT_FATAL(false, "Unsupported MatmulProgramConfig type for AllGatherMatmul. Needs to be 1D or 2D Multicast.");
         }
     }, this->matmul_struct.program_config.value());
 

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_matmul/device/multi_core/all_gather_matmul_op_multi_core.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_matmul/device/multi_core/all_gather_matmul_op_multi_core.cpp
@@ -285,12 +285,12 @@ operation::ProgramWithCallbacks experimental::all_gather_matmul_multi_core_with_
             );
             matmul_override_runtime_arguments_callback = matmul_program_with_callbacks->override_runtime_arguments_callback;
         } else {
-            TT_FATAL(false, "Unsupported MatmulProgramConfig type. Needs to be 1D or 2D Multicast.");
+            TT_THROW("Unsupported MatmulProgramConfig type. Needs to be 1D or 2D Multicast.");
         }
     }, program_config);
 
     if (!matmul_program_with_callbacks.has_value()) {
-        TT_FATAL(false, "Matmul program with callbacks not created");
+        TT_THROW("Matmul program with callbacks not created");
     }
 
 

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_matmul/device/multi_core/all_gather_matmul_op_multi_core.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_matmul/device/multi_core/all_gather_matmul_op_multi_core.cpp
@@ -285,12 +285,12 @@ operation::ProgramWithCallbacks experimental::all_gather_matmul_multi_core_with_
             );
             matmul_override_runtime_arguments_callback = matmul_program_with_callbacks->override_runtime_arguments_callback;
         } else {
-            TT_FATAL("Unsupported MatmulProgramConfig type");
+            TT_FATAL(false, "Unsupported MatmulProgramConfig type. Needs to be 1D or 2D Multicast.");
         }
     }, program_config);
 
     if (!matmul_program_with_callbacks.has_value()) {
-        TT_FATAL("Matmul program with callbacks not created");
+        TT_FATAL(false, "Matmul program with callbacks not created");
     }
 
 

--- a/ttnn/cpp/ttnn/operations/experimental/matmul/attn_matmul/device/attn_matmul_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/matmul/attn_matmul/device/attn_matmul_device_operation.cpp
@@ -14,7 +14,7 @@ void AttnMatmulDeviceOperation::validate(const std::vector<Tensor>& input_tensor
     // intermediate: [q_heads, batch, batch, kv_len]
     // output: [q_len, q_heads, batch, kv_len]
 
-    TT_FATAL(input_tensors.size() == 2);
+    TT_FATAL(input_tensors.size() == 2, "Error");
     const auto& input_tensor_a = input_tensors.at(0);
     const auto& input_tensor_b = input_tensors.at(1);
     TT_FATAL(
@@ -48,17 +48,17 @@ void AttnMatmulDeviceOperation::validate(const std::vector<Tensor>& input_tensor
     if (read_from_kv_cache) {
         if (this->transpose_hw.value()) {
             TT_FATAL(
-                ashape[3] == bshape[3] &&
+                ashape[3] == bshape[3],
                 "For pre-attention matmul, dimension K for B is in B.shape[3], so A.shape[3] must match B.shape[3]");  // A.K == B.K
         } else {
             TT_FATAL(
-                ashape[3] == this->num_tokens &&
+                ashape[3] == this->num_tokens,
                 "For post-attention matmul, dimension K (A.shape[3]) is the kv_seq_len in this case and must match the "
                 "length of the cache we read");  // A.K == B.K
         }
     } else {
         TT_FATAL(
-            ashape[3] == bshape[2] &&
+            ashape[3] == bshape[2],
             "Dimension K (A.shape[3] and B.shape[2]) must match for A and B in attn_matmul op");  // A.K == B.K
     }
 }

--- a/ttnn/cpp/ttnn/operations/experimental/matmul/attn_matmul/device/attn_matmul_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/matmul/attn_matmul/device/attn_matmul_program_factory.cpp
@@ -43,7 +43,7 @@ operation::ProgramWithCallbacks multi_core_attn_matmul(const Tensor &a, const Te
             fp32_dest_acc_en = compute_kernel_config.fp32_dest_acc_en;
             packer_l1_acc = compute_kernel_config.packer_l1_acc;
         } else {
-            TT_FATAL("arch not supported");
+            TT_FATAL(false, "arch not supported");
         }
 
     }, compute_kernel_config);

--- a/ttnn/cpp/ttnn/operations/experimental/matmul/attn_matmul/device/attn_matmul_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/matmul/attn_matmul/device/attn_matmul_program_factory.cpp
@@ -43,7 +43,7 @@ operation::ProgramWithCallbacks multi_core_attn_matmul(const Tensor &a, const Te
             fp32_dest_acc_en = compute_kernel_config.fp32_dest_acc_en;
             packer_l1_acc = compute_kernel_config.packer_l1_acc;
         } else {
-            TT_FATAL(false, "arch not supported");
+            TT_THROW("arch not supported");
         }
 
     }, compute_kernel_config);

--- a/ttnn/cpp/ttnn/operations/experimental/matmul/group_attn_matmul/device/group_attn_matmul_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/matmul/group_attn_matmul/device/group_attn_matmul_device_operation.cpp
@@ -14,7 +14,7 @@ void GroupAttnMatmulDeviceOperation::validate(const std::vector<Tensor>& input_t
     // intermediate: [q_heads, batch, batch, kv_len]
     // output: [q_len, q_heads, batch, kv_len]
 
-    TT_FATAL(input_tensors.size() == 2);
+    TT_FATAL(input_tensors.size() == 2, "Error");
     const auto& input_tensor_a = input_tensors.at(0);
     const auto& input_tensor_b = input_tensors.at(1);
     TT_FATAL(
@@ -45,7 +45,7 @@ void GroupAttnMatmulDeviceOperation::validate(const std::vector<Tensor>& input_t
     // Any sharded memory configs must be HEIGHT_SHARDED and have the same orientation
     ShardOrientation shard_orientation = this->row_major ? ShardOrientation::ROW_MAJOR : ShardOrientation::COL_MAJOR;
     if (input_tensor_a.is_sharded()) {
-        TT_FATAL(input_tensor_a.memory_config().memory_layout == TensorMemoryLayout::HEIGHT_SHARDED);
+        TT_FATAL(input_tensor_a.memory_config().memory_layout == TensorMemoryLayout::HEIGHT_SHARDED, "Error");
         TT_FATAL(
             input_tensor_a.shard_spec().value().orientation == shard_orientation,
             "Any sharded memory configs must have the same shard orientation as one another!");
@@ -53,21 +53,21 @@ void GroupAttnMatmulDeviceOperation::validate(const std::vector<Tensor>& input_t
             input_tensor_a.shard_spec().value().num_cores() == ashape[1],
             "Q heads must be sharded on number of q heads!");
         auto shard_shape = input_tensor_a.shard_spec().value().shape;
-        TT_FATAL(shard_shape[0] == ashape[2]);
-        TT_FATAL(shard_shape[1] == ashape[3]);
+        TT_FATAL(shard_shape[0] == ashape[2], "Error");
+        TT_FATAL(shard_shape[1] == ashape[3], "Error");
     }
     if (input_tensor_b.is_sharded()) {
-        TT_FATAL(input_tensor_b.memory_config().memory_layout == TensorMemoryLayout::HEIGHT_SHARDED);
+        TT_FATAL(input_tensor_b.memory_config().memory_layout == TensorMemoryLayout::HEIGHT_SHARDED, "Error");
         TT_FATAL(
             input_tensor_b.shard_spec().value().orientation == shard_orientation,
             "Any sharded memory configs must have the same shard orientation as one another!");
         TT_FATAL(input_tensor_b.shard_spec().value().num_cores() == bshape[0], "KV heads must be sharded on batch!");
         auto shard_shape = input_tensor_b.shard_spec().value().shape;
-        TT_FATAL(shard_shape[0] == bshape[1] * bshape[2]);
-        TT_FATAL(shard_shape[1] == bshape[3]);
+        TT_FATAL(shard_shape[0] == bshape[1] * bshape[2], "Error");
+        TT_FATAL(shard_shape[1] == bshape[3], "Error");
     }
     if (this->output_mem_config.is_sharded()) {
-        TT_FATAL(this->output_mem_config.memory_layout == TensorMemoryLayout::HEIGHT_SHARDED);
+        TT_FATAL(this->output_mem_config.memory_layout == TensorMemoryLayout::HEIGHT_SHARDED, "Error");
 
         // If user passes in output_mem_config with shard_spec, assert that it is the same as the one calculated in
         // GroupAttnMatmulDeviceOperation::create_output_tensors
@@ -85,8 +85,8 @@ void GroupAttnMatmulDeviceOperation::validate(const std::vector<Tensor>& input_t
             TT_FATAL(
                 this->output_mem_config.shard_spec.value().orientation == shard_orientation,
                 "Any sharded memory configs must have the same shard orientation as one another!");
-            TT_FATAL(shard_shape[0] == output_shape[2]);
-            TT_FATAL(shard_shape[1] == output_shape[3]);
+            TT_FATAL(shard_shape[0] == output_shape[2], "Error");
+            TT_FATAL(shard_shape[1] == output_shape[3], "Error");
         }
     }
 
@@ -102,17 +102,17 @@ void GroupAttnMatmulDeviceOperation::validate(const std::vector<Tensor>& input_t
     if (read_from_kv_cache) {
         if (this->transpose_hw.value()) {
             TT_FATAL(
-                ashape[3] == bshape[3] &&
+                ashape[3] == bshape[3],
                 "For pre-attention matmul, dimension K for B is in B.shape[3], so A.shape[3] must match B.shape[3]");  // A.K == B.K
         } else {
             TT_FATAL(
-                ashape[3] == this->num_tokens &&
+                ashape[3] == this->num_tokens,
                 "For post-attention matmul, dimension K (A.shape[3]) is the kv_seq_len in this case and must match the "
                 "length of the cache we read");  // A.K == B.K
         }
     } else {
         TT_FATAL(
-            ashape[3] == bshape[2] &&
+            ashape[3] == bshape[2],
             "Dimension K (A.shape[3] and B.shape[2]) must match for A and B in attn_matmul op");  // A.K == B.K
     }
 }

--- a/ttnn/cpp/ttnn/operations/experimental/matmul/group_attn_matmul/device/group_attn_matmul_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/matmul/group_attn_matmul/device/group_attn_matmul_program_factory.cpp
@@ -43,7 +43,7 @@ operation::ProgramWithCallbacks multi_core_group_attn_matmul(const Tensor &a, co
             fp32_dest_acc_en = compute_kernel_config.fp32_dest_acc_en;
             packer_l1_acc = compute_kernel_config.packer_l1_acc;
         } else {
-            TT_FATAL("arch not supported");
+            TT_FATAL(false, "arch not supported");
         }
 
     }, compute_kernel_config);

--- a/ttnn/cpp/ttnn/operations/experimental/matmul/group_attn_matmul/device/group_attn_matmul_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/matmul/group_attn_matmul/device/group_attn_matmul_program_factory.cpp
@@ -43,7 +43,7 @@ operation::ProgramWithCallbacks multi_core_group_attn_matmul(const Tensor &a, co
             fp32_dest_acc_en = compute_kernel_config.fp32_dest_acc_en;
             packer_l1_acc = compute_kernel_config.packer_l1_acc;
         } else {
-            TT_FATAL(false, "arch not supported");
+            TT_THROW("arch not supported");
         }
 
     }, compute_kernel_config);

--- a/ttnn/cpp/ttnn/operations/experimental/paged_cache/device/paged_cache_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/paged_cache/device/paged_cache_operation.cpp
@@ -17,14 +17,14 @@ void PagedUpdateCacheDeviceOperation::validate(const std::vector<Tensor>& input_
     TT_FATAL(input_tensor.device() == cache_tensor.device(), "Operands to update_cache need to be on the same device!");
     TT_FATAL(input_tensor.buffer() != nullptr and cache_tensor.buffer() != nullptr, "Operands to update_cache need to be allocated in buffers on device!");
     TT_FATAL((input_tensor.get_layout() == Layout::TILE && cache_tensor.get_layout() == Layout::TILE), "Inputs to update_cache must be tilized");
-    TT_FATAL(input_tensor.get_dtype() == DataType::FLOAT32 || input_tensor.get_dtype() == DataType::BFLOAT16 || input_tensor.get_dtype() == DataType::BFLOAT8_B);
-    TT_FATAL(cache_tensor.get_dtype() == DataType::FLOAT32 || cache_tensor.get_dtype() == DataType::BFLOAT16 || cache_tensor.get_dtype() == DataType::BFLOAT8_B);
+    TT_FATAL(input_tensor.get_dtype() == DataType::FLOAT32 || input_tensor.get_dtype() == DataType::BFLOAT16 || input_tensor.get_dtype() == DataType::BFLOAT8_B, "Error");
+    TT_FATAL(cache_tensor.get_dtype() == DataType::FLOAT32 || cache_tensor.get_dtype() == DataType::BFLOAT16 || cache_tensor.get_dtype() == DataType::BFLOAT8_B, "Error");
 
     // input_tensor: [1, b, padded_heads, head_dim]
     // cache_tensor: [b, 1, kv_len, head_dim]
-    TT_FATAL(input_tensor.get_legacy_shape()[0] == 1);
-    TT_FATAL(cache_tensor.memory_config().memory_layout == TensorMemoryLayout::INTERLEAVED);
-    TT_FATAL(input_tensor.get_legacy_shape()[-1] == cache_tensor.get_legacy_shape()[-1]);
+    TT_FATAL(input_tensor.get_legacy_shape()[0] == 1, "Error");
+    TT_FATAL(cache_tensor.memory_config().memory_layout == TensorMemoryLayout::INTERLEAVED, "Error");
+    TT_FATAL(input_tensor.get_legacy_shape()[-1] == cache_tensor.get_legacy_shape()[-1], "Error");
 
     if (this->op_type == PagedUpdateCacheOpType::UPDATE) {
 
@@ -32,13 +32,13 @@ void PagedUpdateCacheDeviceOperation::validate(const std::vector<Tensor>& input_
         uint32_t batch_size;
         if (!paged_cache) {
             TT_FATAL(cache_tensor.get_legacy_shape()[1] == 1, "Only supports 1 head now.");
-            TT_FATAL(input_tensor.get_legacy_shape()[1] == cache_tensor.get_legacy_shape()[0]);
+            TT_FATAL(input_tensor.get_legacy_shape()[1] == cache_tensor.get_legacy_shape()[0], "Error");
         } else {
             TT_FATAL(optional_input_tensors.at(0).has_value(), "Paged cache requires update_idxs tensor");
             // TODO: How to validate page_table and paged_cache?
             auto page_table = optional_input_tensors.at(1).value();
-            TT_FATAL(page_table.get_dtype() == DataType::INT32);
-            TT_FATAL(page_table.get_layout() == Layout::ROW_MAJOR);
+            TT_FATAL(page_table.get_dtype() == DataType::INT32, "Error");
+            TT_FATAL(page_table.get_layout() == Layout::ROW_MAJOR, "Error");
             TT_FATAL(page_table.get_legacy_shape()[0] == input_tensor.get_legacy_shape()[1], "Batch size between page_table and input_tensor must match");
             TT_FATAL(page_table.get_legacy_shape()[1] <= cache_tensor.get_legacy_shape()[0], "max_num_blocks_per_seq must be less than max_num_blocks");
         }
@@ -49,51 +49,51 @@ void PagedUpdateCacheDeviceOperation::validate(const std::vector<Tensor>& input_
         uint32_t num_indices;
         if (optional_input_tensors.at(0).has_value()) {
             const auto& update_idxs_tensor = optional_input_tensors.at(0).value();
-            TT_FATAL(update_idxs_tensor.get_dtype() == DataType::INT32);
-            TT_FATAL(update_idxs_tensor.get_layout() == Layout::ROW_MAJOR);
+            TT_FATAL(update_idxs_tensor.get_dtype() == DataType::INT32, "Error");
+            TT_FATAL(update_idxs_tensor.get_layout() == Layout::ROW_MAJOR, "Error");
             // update_idxs_tensor: [num_indices]
             num_indices = update_idxs_tensor.get_legacy_shape()[0];
 
             // must be iterleaved
-            TT_FATAL(update_idxs_tensor.memory_config().memory_layout == TensorMemoryLayout::INTERLEAVED);
+            TT_FATAL(update_idxs_tensor.memory_config().memory_layout == TensorMemoryLayout::INTERLEAVED, "Error");
             // must be in dram
-            TT_FATAL(update_idxs_tensor.buffer()->buffer_type() == tt::tt_metal::BufferType::DRAM);
+            TT_FATAL(update_idxs_tensor.buffer()->buffer_type() == tt::tt_metal::BufferType::DRAM, "Error");
         } else {
             num_indices = this->update_idxs.size();
         }
 
         TT_FATAL(input_tensor.get_legacy_shape()[1] == num_indices, "Number of update_idxs should match batch size");
 
-        TT_FATAL(input_tensor.is_sharded());
+        TT_FATAL(input_tensor.is_sharded(), "Error");
         if (input_tensor.is_sharded()) {
-            TT_FATAL(input_tensor.memory_config().memory_layout != TensorMemoryLayout::WIDTH_SHARDED);
-            TT_FATAL(input_tensor.shard_spec().value().shape[1] == input_tensor.get_legacy_shape()[-1]);
+            TT_FATAL(input_tensor.memory_config().memory_layout != TensorMemoryLayout::WIDTH_SHARDED, "Error");
+            TT_FATAL(input_tensor.shard_spec().value().shape[1] == input_tensor.get_legacy_shape()[-1], "Error");
             // Require even work division for now
             // TT_FATAL(input_tensor.shard_spec().value().grid.num_cores() == cache_tensor.get_legacy_shape()[0], "Input must be sharded on batch num cores");
-            TT_FATAL((input_tensor.volume() / input_tensor.get_legacy_shape()[-1]) % input_tensor.shard_spec().value().shape[0] == 0);
+            TT_FATAL((input_tensor.volume() / input_tensor.get_legacy_shape()[-1]) % input_tensor.shard_spec().value().shape[0] == 0, "Error");
             TT_FATAL(input_tensor.shard_spec().value().orientation == ShardOrientation::ROW_MAJOR, "Only ROW_MAJOR sharding is supported");
         }
-        // TT_FATAL(cache_tensor.get_legacy_shape()[0] <= input_tensor.get_legacy_shape()[-1]);
+        // TT_FATAL(cache_tensor.get_legacy_shape()[0] <= input_tensor.get_legacy_shape()[-1], "Error");
         // batch offset is only valid if num_user less than 32 and batch_offset + num_user <= 32
-        // if (cache_tensor.get_legacy_shape()[0] < 32) TT_FATAL(this->batch_offset + cache_tensor.get_legacy_shape()[0] <= 32);
-        // else TT_FATAL(this->batch_offset == 0);
-        TT_FATAL(this->batch_offset == 0);
+        // if (cache_tensor.get_legacy_shape()[0] < 32) TT_FATAL(this->batch_offset + cache_tensor.get_legacy_shape()[0] <= 32, "Error");
+        // else TT_FATAL(this->batch_offset == 0, "Error");
+        TT_FATAL(this->batch_offset == 0, "Error");
     } else {
 
-        TT_FATAL(this->op_type == PagedUpdateCacheOpType::FILL);
+        TT_FATAL(this->op_type == PagedUpdateCacheOpType::FILL, "Error");
         const auto& page_table_tensor = input_tensors.at(2);
 
-        TT_FATAL(input_tensor.memory_config().memory_layout == TensorMemoryLayout::INTERLEAVED);
-        TT_FATAL(page_table_tensor.memory_config().memory_layout == TensorMemoryLayout::INTERLEAVED);
+        TT_FATAL(input_tensor.memory_config().memory_layout == TensorMemoryLayout::INTERLEAVED, "Error");
+        TT_FATAL(page_table_tensor.memory_config().memory_layout == TensorMemoryLayout::INTERLEAVED, "Error");
 
-        TT_FATAL(page_table_tensor.get_dtype() == DataType::INT32);
+        TT_FATAL(page_table_tensor.get_dtype() == DataType::INT32, "Error");
 
         auto cache_shape = cache_tensor.get_legacy_shape();
         auto input_shape = input_tensor.get_legacy_shape();
         auto page_table_shape = page_table_tensor.get_legacy_shape();
 
-        TT_FATAL(cache_shape[1] == 1);
-        TT_FATAL(this->batch_idx <= cache_shape[0]);
+        TT_FATAL(cache_shape[1] == 1, "Error");
+        TT_FATAL(this->batch_idx <= cache_shape[0], "Error");
         TT_FATAL(input_shape[2] <= cache_shape[2] * page_table_shape[1], "Input seq_len must fit in max_num_blocks_per_seq");
     }
 }

--- a/ttnn/cpp/ttnn/operations/experimental/paged_cache/device/paged_update_cache_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/paged_cache/device/paged_update_cache_program_factory.cpp
@@ -26,7 +26,7 @@ bool enable_fp32_dest(const tt_metal::Device * device, const ttnn::DeviceCompute
             TT_ASSERT(device->arch() == ARCH::WORMHOLE_B0, "kernel config is not for wormhole_b0");
             fp32_dest_acc_en = input_cb_data_format == tt::DataFormat::Float32 ? true : compute_kernel_config.fp32_dest_acc_en;
         } else {
-            TT_FATAL(false, "arch not supported");
+            TT_THROW("arch not supported");
         }
 
     }, compute_kernel_config);
@@ -67,7 +67,7 @@ operation::ProgramWithCallbacks paged_update_cache_multi_core(const Tensor& cach
         index_stick_size = update_idxs_tensor.value().buffer()->aligned_page_size();
 
         log2_page_size = std::log2(index_stick_size);
-        TT_FATAL(1 << log2_page_size == index_stick_size);
+        TT_FATAL(1 << log2_page_size == index_stick_size, "Error");
     }
 
     // Pagetable-specific parameters
@@ -89,7 +89,7 @@ operation::ProgramWithCallbacks paged_update_cache_multi_core(const Tensor& cach
         max_blocks_per_seq = page_table_tensor.get_legacy_shape()[1];
         page_table_stick_size = page_table_tensor.get_legacy_shape()[-1] * page_table_tensor.element_size();
         log2_page_table_stick_size = std::log2(page_table_stick_size);
-        TT_FATAL(1 << log2_page_table_stick_size == page_table_stick_size);
+        TT_FATAL(1 << log2_page_table_stick_size == page_table_stick_size, "Error");
 
         page_table_data_format = tt_metal::datatype_to_dataformat_converter(page_table_tensor.get_dtype());
 

--- a/ttnn/cpp/ttnn/operations/experimental/paged_cache/device/paged_update_cache_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/paged_cache/device/paged_update_cache_program_factory.cpp
@@ -26,7 +26,7 @@ bool enable_fp32_dest(const tt_metal::Device * device, const ttnn::DeviceCompute
             TT_ASSERT(device->arch() == ARCH::WORMHOLE_B0, "kernel config is not for wormhole_b0");
             fp32_dest_acc_en = input_cb_data_format == tt::DataFormat::Float32 ? true : compute_kernel_config.fp32_dest_acc_en;
         } else {
-            TT_FATAL("arch not supported");
+            TT_FATAL(false, "arch not supported");
         }
 
     }, compute_kernel_config);

--- a/ttnn/cpp/ttnn/operations/experimental/reduction/fast_reduce_nc/device/fast_reduce_nc_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/reduction/fast_reduce_nc/device/fast_reduce_nc_device_operation.cpp
@@ -21,7 +21,7 @@ Tensor _fast_reduce_nc(
     std::optional<const ttnn::DeviceComputeKernelConfig> compute_kernel_config) {
     std::vector<Tensor> output_tensors = {Tensor(operation::get_workers_for_op_output({input}))};
 
-    TT_FATAL(input.storage_type() == StorageType::DEVICE || input.storage_type() == StorageType::MULTI_DEVICE);
+    TT_FATAL(input.storage_type() == StorageType::DEVICE || input.storage_type() == StorageType::MULTI_DEVICE, "Error");
     auto kernel_config_val = init_device_compute_kernel_config(input.device()->arch(), compute_kernel_config, MathFidelity::HiFi4);
 
     operation::launch_op(

--- a/ttnn/cpp/ttnn/operations/experimental/ssm/hc_sum_reduce/device/hc_sum_reduce_op.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ssm/hc_sum_reduce/device/hc_sum_reduce_op.cpp
@@ -10,7 +10,7 @@ namespace ttnn::operations::experimental::ssm {
 
 void HCSumReduce::validate(const std::vector<Tensor>& input_tensors) const {
     using namespace tt::constants;
-    TT_FATAL(input_tensors.size() == 1);
+    TT_FATAL(input_tensors.size() == 1, "Error");
     const auto& input_tensor_a = input_tensors.at(0);
     TT_FATAL((input_tensor_a.get_layout() == Layout::TILE), "Inputs to ssm_1d_sum_reduce must be tilized");
 

--- a/ttnn/cpp/ttnn/operations/experimental/ssm/repeat_and_interleave_eltwise_mul/device/repeat_and_interleave_eltwise_mul_op.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ssm/repeat_and_interleave_eltwise_mul/device/repeat_and_interleave_eltwise_mul_op.cpp
@@ -11,7 +11,7 @@ namespace ttnn::operations::experimental::ssm {
 
 void RepeatAndInterleaveEltwiseMul::validate(const std::vector<Tensor>& input_tensors) const {
     using namespace tt::constants;
-    TT_FATAL(input_tensors.size() == 2);
+    TT_FATAL(input_tensors.size() == 2, "Error");
     const auto& input_tensor_a = input_tensors.at(0);
     const auto& input_tensor_b = input_tensors.at(1);
     TT_FATAL(

--- a/ttnn/cpp/ttnn/operations/experimental/transformer/create_qkv_heads/device/create_qkv_heads_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/create_qkv_heads/device/create_qkv_heads_device_operation.cpp
@@ -14,14 +14,14 @@ void CreateQKVHeadsDeviceOperation::validate(const std::vector<Tensor> &input_te
     TT_FATAL(input_tensor.storage_type() == StorageType::DEVICE, "Operands to TM need to be on device!");
     TT_FATAL(input_tensor.buffer() != nullptr, "Operands to TM need to be allocated in buffers on device!");
     TT_FATAL(input_tensor.get_dtype() == tt::tt_metal::DataType::FLOAT32 || input_tensor.get_dtype() == tt::tt_metal::DataType::BFLOAT16 || input_tensor.get_dtype() == tt::tt_metal::DataType::BFLOAT8_B, "Unsupported data format");
-    TT_FATAL(input_tensor.get_layout() == Layout::TILE);
+    TT_FATAL(input_tensor.get_layout() == Layout::TILE, "Error");
     TT_FATAL(input_tensor.is_sharded(), "Operands to TM must be sharded");
     const auto input_shape = input_tensor.get_legacy_shape();
     TT_FATAL(input_shape[1] == 1, "Unsupported input shape");
 
     auto bbox = input_tensor.shard_spec().value().grid.bounding_box();
-    TT_FATAL((bbox.end_coord.x < input_tensor.device()->compute_with_storage_grid_size().x && bbox.end_coord.y < input_tensor.device()->compute_with_storage_grid_size().y));
-    TT_FATAL(input_tensor.memory_config().memory_layout == TensorMemoryLayout::BLOCK_SHARDED);
+    TT_FATAL((bbox.end_coord.x < input_tensor.device()->compute_with_storage_grid_size().x && bbox.end_coord.y < input_tensor.device()->compute_with_storage_grid_size().y), "Error");
+    TT_FATAL(input_tensor.memory_config().memory_layout == TensorMemoryLayout::BLOCK_SHARDED, "Error");
     ShardOrientation shard_orientation = input_tensor.shard_spec().value().orientation;
     bool rm = shard_orientation == ShardOrientation::ROW_MAJOR;
     uint32_t num_h_cores = rm ? bbox.end_coord.y + 1 : bbox.end_coord.x + 1;
@@ -30,7 +30,7 @@ void CreateQKVHeadsDeviceOperation::validate(const std::vector<Tensor> &input_te
     TT_FATAL(this->num_q_heads % this->num_kv_heads == 0, fmt::format("Number of q heads {} must fit evenly into number of kv heads {}", this->num_q_heads, this->num_kv_heads));
     TT_FATAL(input_shape[3] % (num_w_cores * tt::constants::TILE_WIDTH) == 0, fmt::format("Flattened hidden dimension {} must be a multiple of width cores {} * tile width {} to ensure that each core gets an even amount of tiles", input_shape[3], num_w_cores, tt::constants::TILE_WIDTH));
 
-    TT_FATAL(this->output_mem_config.memory_layout == TensorMemoryLayout::HEIGHT_SHARDED);
+    TT_FATAL(this->output_mem_config.memory_layout == TensorMemoryLayout::HEIGHT_SHARDED, "Error");
     TT_FATAL(input_shape[0] == num_h_cores, fmt::format("Batch size  {} must be equal to num cores {}", input_shape[0], num_h_cores));
 }
 

--- a/ttnn/cpp/ttnn/operations/experimental/transformer/create_qkv_heads/device/create_qkv_heads_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/create_qkv_heads/device/create_qkv_heads_program_factory.cpp
@@ -16,7 +16,7 @@ namespace ttnn::operations::experimental::transformer {
         // groups = kv_heads usually
         // heads_per_group = [x 1 1] if qkv since q_heads >= kv_heads and k=v heads but this should be generic
         TT_FATAL(head_dim % TILE_WIDTH == 0, fmt::format("head dim {} needs to be a multiple of tile width {}", head_dim, TILE_WIDTH));
-        TT_FATAL(heads_per_group.size() == output.size() && output.size() == 3);
+        TT_FATAL(heads_per_group.size() == output.size() && output.size() == 3, "Error");
 
         const uint32_t total_heads_per_group = std::accumulate(heads_per_group.begin(), heads_per_group.end(), 0); // num q heads + 2 * num_kv_heads
         const uint32_t elements_per_group = head_dim * total_heads_per_group; // head_dim * (num q heads + 2 * num kv heads)

--- a/ttnn/cpp/ttnn/operations/experimental/transformer/create_qkv_heads_from_separate_tensors/device/create_qkv_heads_from_separate_tensors_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/create_qkv_heads_from_separate_tensors/device/create_qkv_heads_from_separate_tensors_device_operation.cpp
@@ -18,15 +18,15 @@ void CreateQKVHeadsSeparateTensorsDeviceOperation::validate(const std::vector<Te
     TT_FATAL(q_input_tensor.buffer() != nullptr && kv_input_tensor.buffer() != nullptr, "Operands to TM need to be allocated in buffers on device!");
     TT_FATAL(q_input_tensor.get_dtype() == tt::tt_metal::DataType::FLOAT32 || q_input_tensor.get_dtype() == tt::tt_metal::DataType::BFLOAT16 || q_input_tensor.get_dtype() == tt::tt_metal::DataType::BFLOAT8_B, "Unsupported data format");
     TT_FATAL(kv_input_tensor.get_dtype() == q_input_tensor.get_dtype(), "Unsupported data format");
-    TT_FATAL(q_input_tensor.get_layout() == Layout::TILE && kv_input_tensor.get_layout() == Layout::TILE);
+    TT_FATAL(q_input_tensor.get_layout() == Layout::TILE && kv_input_tensor.get_layout() == Layout::TILE, "Error");
     TT_FATAL(q_input_tensor.is_sharded() && kv_input_tensor.is_sharded(), "Operands to TM must be sharded");
 
 
     auto bbox = q_input_tensor.shard_spec().value().grid.bounding_box();
-    TT_FATAL((bbox.end_coord.x < q_input_tensor.device()->compute_with_storage_grid_size().x && bbox.end_coord.y < q_input_tensor.device()->compute_with_storage_grid_size().y));
+    TT_FATAL((bbox.end_coord.x < q_input_tensor.device()->compute_with_storage_grid_size().x && bbox.end_coord.y < q_input_tensor.device()->compute_with_storage_grid_size().y), "Error");
 
-    TT_FATAL(q_input_tensor.memory_config().memory_layout == TensorMemoryLayout::BLOCK_SHARDED);
-    TT_FATAL(kv_input_tensor.memory_config().memory_layout == TensorMemoryLayout::BLOCK_SHARDED);
+    TT_FATAL(q_input_tensor.memory_config().memory_layout == TensorMemoryLayout::BLOCK_SHARDED, "Error");
+    TT_FATAL(kv_input_tensor.memory_config().memory_layout == TensorMemoryLayout::BLOCK_SHARDED, "Error");
 
     ShardOrientation shard_orientation = q_input_tensor.shard_spec().value().orientation;
     bool rm = shard_orientation == ShardOrientation::ROW_MAJOR;
@@ -66,7 +66,7 @@ void CreateQKVHeadsSeparateTensorsDeviceOperation::validate(const std::vector<Te
     TT_FATAL(L1_SIZE >= 2 * (per_core_q_tiles + 2*per_core_k_tiles) * single_tile_size, fmt::format("Workload exceeds L1 capacity"));
 
     // TODO: Add this back when output is HEIGHT sharded only!
-    // TT_FATAL(this->output_mem_config.memory_layout == TensorMemoryLayout::HEIGHT_SHARDED);
+    // TT_FATAL(this->output_mem_config.memory_layout == TensorMemoryLayout::HEIGHT_SHARDED, "Error");
     TT_FATAL(q_input_shape[0] == num_h_cores, fmt::format("Batch size {} must be equal to num cores {}", q_input_shape[0], num_h_cores));
 }
 

--- a/ttnn/cpp/ttnn/operations/experimental/transformer/nlp_concat_heads/device/nlp_concat_heads_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/nlp_concat_heads/device/nlp_concat_heads_device_operation.cpp
@@ -14,17 +14,17 @@ void NLPConcatHeadsDeviceOperation::validate(const std::vector<Tensor>& input_te
     TT_FATAL(input_tensor.storage_type() == StorageType::DEVICE, "Operands to TM need to be on device!");
     TT_FATAL(input_tensor.buffer() != nullptr, "Operands to TM need to be allocated in buffers on device!");
     TT_FATAL(input_tensor.get_dtype() == tt::tt_metal::DataType::FLOAT32 || input_tensor.get_dtype() == tt::tt_metal::DataType::BFLOAT16 || input_tensor.get_dtype() == tt::tt_metal::DataType::BFLOAT8_B, "Unsupported data format");
-    TT_FATAL(input_tensor.get_layout() == Layout::TILE);
+    TT_FATAL(input_tensor.get_layout() == Layout::TILE, "Error");
 
     if (input_tensor.is_sharded()) {
-        TT_FATAL(input_tensor.memory_config().memory_layout != TensorMemoryLayout::WIDTH_SHARDED);
+        TT_FATAL(input_tensor.memory_config().memory_layout != TensorMemoryLayout::WIDTH_SHARDED, "Error");
         auto shard_spec = input_tensor.shard_spec().value();
-        TT_FATAL(shard_spec.shape[1] == input_tensor.get_legacy_shape()[-1]);
-        TT_FATAL(shard_spec.shape[0] % input_tensor.get_legacy_shape()[-2] == 0);
-        TT_FATAL(input_tensor.get_legacy_shape()[1] % (shard_spec.shape[0] / input_tensor.get_legacy_shape()[-2]) == 0);
-        TT_FATAL(this->output_mem_config.memory_layout != TensorMemoryLayout::HEIGHT_SHARDED);
+        TT_FATAL(shard_spec.shape[1] == input_tensor.get_legacy_shape()[-1], "Error");
+        TT_FATAL(shard_spec.shape[0] % input_tensor.get_legacy_shape()[-2] == 0, "Error");
+        TT_FATAL(input_tensor.get_legacy_shape()[1] % (shard_spec.shape[0] / input_tensor.get_legacy_shape()[-2]) == 0, "Error");
+        TT_FATAL(this->output_mem_config.memory_layout != TensorMemoryLayout::HEIGHT_SHARDED, "Error");
     } else {
-        TT_FATAL(this->output_mem_config.memory_layout == TensorMemoryLayout::INTERLEAVED);
+        TT_FATAL(this->output_mem_config.memory_layout == TensorMemoryLayout::INTERLEAVED, "Error");
     }
 }
 

--- a/ttnn/cpp/ttnn/operations/experimental/transformer/nlp_concat_heads_decode/device/nlp_concat_heads_decode_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/nlp_concat_heads_decode/device/nlp_concat_heads_decode_device_operation.cpp
@@ -16,18 +16,18 @@ void NLPConcatHeadsDecodeDeviceOperation::validate(const std::vector<Tensor>& in
     TT_FATAL(input_tensor.storage_type() == StorageType::DEVICE, "Operands to TM need to be on device!");
     TT_FATAL(input_tensor.buffer() != nullptr, "Operands to TM need to be allocated in buffers on device!");
     TT_FATAL(input_tensor.get_dtype() == tt::tt_metal::DataType::FLOAT32 || input_tensor.get_dtype() == tt::tt_metal::DataType::BFLOAT16, "Unsupported data format");
-    TT_FATAL(input_tensor.get_layout() == Layout::TILE);
+    TT_FATAL(input_tensor.get_layout() == Layout::TILE, "Error");
     TT_FATAL(input_shape[0] == 1, "seqlen=1 for decode");
     TT_FATAL(input_shape[1] <= 32, "currently only support less than 32 users");
     TT_FATAL(input_shape[2] == 32, "currently only support 32 padded heads");
     TT_FATAL(input_shape[2] >= this->num_heads, "head_dim must be multiple of TILE_WIDTH");
 
     // input tensor shard spec
-    TT_FATAL(input_tensor.is_sharded());
-    TT_FATAL(input_tensor.memory_config().memory_layout == TensorMemoryLayout::HEIGHT_SHARDED);
+    TT_FATAL(input_tensor.is_sharded(), "Error");
+    TT_FATAL(input_tensor.memory_config().memory_layout == TensorMemoryLayout::HEIGHT_SHARDED, "Error");
     auto shard_spec = input_tensor.shard_spec().value();
-    TT_FATAL(shard_spec.shape[1] == input_tensor.get_legacy_shape()[-1]);
-    TT_FATAL(shard_spec.shape[0] == input_tensor.get_legacy_shape()[-2]);
+    TT_FATAL(shard_spec.shape[1] == input_tensor.get_legacy_shape()[-1], "Error");
+    TT_FATAL(shard_spec.shape[0] == input_tensor.get_legacy_shape()[-2], "Error");
     auto shard_grid = shard_spec.grid.bounding_box().grid_size();
     auto num_cores = shard_grid.x * shard_grid.y;
     TT_FATAL(num_cores == input_shape[1], "num_cores must be equal to num users");

--- a/ttnn/cpp/ttnn/operations/experimental/transformer/nlp_create_qkv_heads/device/nlp_create_qkv_heads_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/nlp_create_qkv_heads/device/nlp_create_qkv_heads_device_operation.cpp
@@ -18,33 +18,33 @@ void NlpCreateHeadsDeviceOperation::validate_on_program_cache_miss(const operati
     TT_FATAL(input_tensor.storage_type() == StorageType::DEVICE, fmt::format("Operands to TM need to be on device! {}", input_tensor.storage_type()));
     TT_FATAL(input_tensor.buffer() != nullptr, "Operands to TM need to be allocated in buffers on device!");
     TT_FATAL(input_tensor.get_dtype() == tt::tt_metal::DataType::FLOAT32 || input_tensor.get_dtype() == tt::tt_metal::DataType::BFLOAT16 || input_tensor.get_dtype() == tt::tt_metal::DataType::BFLOAT8_B, "Unsupported data format");
-    TT_FATAL(input_tensor.get_layout() == Layout::TILE);
+    TT_FATAL(input_tensor.get_layout() == Layout::TILE, "Error");
 
     TT_FATAL(input_shape[2] % TILE_HEIGHT == 0, fmt::format("Unsupported input height {} is not tile aligned", input_shape[2]));
     TT_FATAL(input_shape[1] == 1, fmt::format("Unsupported input sequence length {} is not equal to 1", input_shape[1]));
     if (input_tensor.is_sharded()) {
-        TT_FATAL(input_tensor.shard_spec().value().shape[0] == input_tensor.volume() / input_tensor.get_legacy_shape()[-1]);
-        TT_FATAL(operation_attributes.output_mem_config.is_sharded() && operation_attributes.output_mem_config.memory_layout != TensorMemoryLayout::WIDTH_SHARDED);
-        TT_FATAL(input_tensor.shard_spec().value().orientation == ShardOrientation::ROW_MAJOR);
+        TT_FATAL(input_tensor.shard_spec().value().shape[0] == input_tensor.volume() / input_tensor.get_legacy_shape()[-1], "Error");
+        TT_FATAL(operation_attributes.output_mem_config.is_sharded() && operation_attributes.output_mem_config.memory_layout != TensorMemoryLayout::WIDTH_SHARDED, "Error");
+        TT_FATAL(input_tensor.shard_spec().value().orientation == ShardOrientation::ROW_MAJOR, "Error");
         auto core_grid = input_tensor.device()->compute_with_storage_grid_size();
         uint32_t num_cores = core_grid.x * core_grid.y;
         // 1 Head Per Core Max for now
-        TT_FATAL(operation_attributes.num_q_heads <= num_cores);
-        TT_FATAL(operation_attributes.num_kv_heads <= num_cores);
-        TT_FATAL(operation_attributes.num_q_heads >= operation_attributes.num_kv_heads);
-        TT_FATAL(operation_attributes.num_q_heads % input_tensor.shard_spec().value().num_cores() == 0);
+        TT_FATAL(operation_attributes.num_q_heads <= num_cores, "Error");
+        TT_FATAL(operation_attributes.num_kv_heads <= num_cores, "Error");
+        TT_FATAL(operation_attributes.num_q_heads >= operation_attributes.num_kv_heads, "Error");
+        TT_FATAL(operation_attributes.num_q_heads % input_tensor.shard_spec().value().num_cores() == 0, "Error");
         if (tensor_args.input_tensor_kv.has_value()) {
-            TT_FATAL(tensor_args.input_tensor_kv.value().is_sharded());
-            TT_FATAL(input_tensor.shard_spec().value().grid == tensor_args.input_tensor_kv.value().shard_spec().value().grid);
-            TT_FATAL(input_tensor.shard_spec().value().orientation == tensor_args.input_tensor_kv.value().shard_spec().value().orientation);
-            TT_FATAL(input_tensor.shard_spec().value().shape[1] == (operation_attributes.num_q_heads / operation_attributes.num_kv_heads) * operation_attributes.head_dim);
+            TT_FATAL(tensor_args.input_tensor_kv.value().is_sharded(), "Error");
+            TT_FATAL(input_tensor.shard_spec().value().grid == tensor_args.input_tensor_kv.value().shard_spec().value().grid, "Error");
+            TT_FATAL(input_tensor.shard_spec().value().orientation == tensor_args.input_tensor_kv.value().shard_spec().value().orientation, "Error");
+            TT_FATAL(input_tensor.shard_spec().value().shape[1] == (operation_attributes.num_q_heads / operation_attributes.num_kv_heads) * operation_attributes.head_dim, "Error");
         } else {
-            TT_FATAL(operation_attributes.num_kv_heads % input_tensor.shard_spec().value().num_cores() == 0);
-            TT_FATAL(input_tensor.shard_spec().value().shape[1] == (operation_attributes.num_q_heads / operation_attributes.num_kv_heads + 2) * operation_attributes.head_dim);
+            TT_FATAL(operation_attributes.num_kv_heads % input_tensor.shard_spec().value().num_cores() == 0, "Error");
+            TT_FATAL(input_tensor.shard_spec().value().shape[1] == (operation_attributes.num_q_heads / operation_attributes.num_kv_heads + 2) * operation_attributes.head_dim, "Error");
         }
-        TT_FATAL(!operation_attributes.transpose_k_heads);
+        TT_FATAL(!operation_attributes.transpose_k_heads, "Error");
     } else {
-        TT_FATAL(operation_attributes.output_mem_config.memory_layout == TensorMemoryLayout::INTERLEAVED);
+        TT_FATAL(operation_attributes.output_mem_config.memory_layout == TensorMemoryLayout::INTERLEAVED, "Error");
     }
 
     if (tensor_args.input_tensor_kv.has_value()) {
@@ -54,17 +54,17 @@ void NlpCreateHeadsDeviceOperation::validate_on_program_cache_miss(const operati
         TT_FATAL(input_tensor_kv.storage_type() == StorageType::DEVICE, "Operands to TM need to be on device!");
         TT_FATAL(input_tensor_kv.buffer() != nullptr, "Operands to TM need to be allocated in buffers on device!");
         TT_FATAL(input_tensor_kv.get_dtype() == input_tensor.get_dtype(), "KV tensor dtype must be same as Q tensor dtype!");
-        TT_FATAL(input_tensor_kv.get_layout() == Layout::TILE);
+        TT_FATAL(input_tensor_kv.get_layout() == Layout::TILE, "Error");
 
         TT_FATAL(input_shape_kv[0] == input_shape[0], "KV tensor batch dim must be same as Q tensor batch!");
         TT_FATAL(input_shape_kv[1] == 1, fmt::format("Unsupported input shape {} is not equal to 1", input_shape_kv[1]));
         TT_FATAL(input_shape_kv[2] == input_shape[2], "KV tensor seq_len dim must be same as Q tensor seq_len!");
         if (input_tensor_kv.is_sharded()) {
-            TT_FATAL(input_tensor.is_sharded());
-            TT_FATAL(input_tensor_kv.shard_spec().value().shape[0] == input_tensor_kv.volume() / input_tensor_kv.get_legacy_shape()[-1]);
-            TT_FATAL(input_tensor_kv.shard_spec().value().orientation == ShardOrientation::ROW_MAJOR);
-            TT_FATAL(input_tensor_kv.shard_spec().value().shape[1] == 2 * operation_attributes.head_dim);
-            TT_FATAL(operation_attributes.num_kv_heads % input_tensor_kv.shard_spec().value().num_cores() == 0);
+            TT_FATAL(input_tensor.is_sharded(), "Error");
+            TT_FATAL(input_tensor_kv.shard_spec().value().shape[0] == input_tensor_kv.volume() / input_tensor_kv.get_legacy_shape()[-1], "Error");
+            TT_FATAL(input_tensor_kv.shard_spec().value().orientation == ShardOrientation::ROW_MAJOR, "Error");
+            TT_FATAL(input_tensor_kv.shard_spec().value().shape[1] == 2 * operation_attributes.head_dim, "Error");
+            TT_FATAL(operation_attributes.num_kv_heads % input_tensor_kv.shard_spec().value().num_cores() == 0, "Error");
         }
     }
 }

--- a/ttnn/cpp/ttnn/operations/experimental/transformer/nlp_create_qkv_heads_falcon7b/device/nlp_create_qkv_heads_falcon7b_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/nlp_create_qkv_heads_falcon7b/device/nlp_create_qkv_heads_falcon7b_device_operation.cpp
@@ -16,11 +16,11 @@ void NlpCreateHeadsFalcon7BDeviceOperation::validate(const std::vector<Tensor>& 
     TT_FATAL(input_tensor.storage_type() == StorageType::DEVICE, "Operands to TM need to be on device!");
     TT_FATAL(input_tensor.buffer() != nullptr, "Operands to TM need to be allocated in buffers on device!");
     TT_FATAL(input_tensor.get_dtype() == tt::tt_metal::DataType::FLOAT32 || input_tensor.get_dtype() == tt::tt_metal::DataType::BFLOAT16 || input_tensor.get_dtype() == tt::tt_metal::DataType::BFLOAT8_B, "Unsupported data format");
-    TT_FATAL(input_tensor.get_layout() == Layout::TILE);
+    TT_FATAL(input_tensor.get_layout() == Layout::TILE, "Error");
 
-    TT_FATAL(input_shape[2] % tt::constants::TILE_HEIGHT == 0);
+    TT_FATAL(input_shape[2] % tt::constants::TILE_HEIGHT == 0, "Error");
     TT_FATAL((input_shape == tt::tt_metal::Shape({input_shape[0], 1, input_shape[2], 4672})), "Unsupported input shape");
-    TT_FATAL(this->output_mem_config.memory_layout == TensorMemoryLayout::INTERLEAVED);
+    TT_FATAL(this->output_mem_config.memory_layout == TensorMemoryLayout::INTERLEAVED, "Error");
 }
 
 std::vector<tt::tt_metal::Shape> NlpCreateHeadsFalcon7BDeviceOperation::compute_output_shapes(const std::vector<Tensor>& input_tensors) const {

--- a/ttnn/cpp/ttnn/operations/experimental/transformer/nlp_kv_cache_load_slice/device/nlp_kv_cache_load_slice_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/nlp_kv_cache_load_slice/device/nlp_kv_cache_load_slice_device_operation.cpp
@@ -13,14 +13,14 @@ void NlpKVCacheLoadSliceDeviceOperation::validate(const std::vector<Tensor> &inp
     const auto& input_tensor_a = input_tensors.at(0);
     TT_FATAL(input_tensor_a.storage_type() == StorageType::DEVICE, "Operands to unpad need to be on device!");
     TT_FATAL(input_tensor_a.buffer() != nullptr , "Operands to unpad need to be allocated in buffers on device!");
-    TT_FATAL(input_tensor_a.get_layout() == Layout::TILE);
+    TT_FATAL(input_tensor_a.get_layout() == Layout::TILE, "Error");
 
     for (uint32_t i = 0; i < input_tensor_a.get_legacy_shape().rank(); i++) {
-        TT_FATAL(this->output_tensor_start[i] < input_tensor_a.get_legacy_shape()[i]);
-        TT_FATAL(this->output_tensor_end[i] < input_tensor_a.get_legacy_shape()[i]);
+        TT_FATAL(this->output_tensor_start[i] < input_tensor_a.get_legacy_shape()[i], "Error");
+        TT_FATAL(this->output_tensor_end[i] < input_tensor_a.get_legacy_shape()[i], "Error");
 
         // Check if start shape is <= end shape
-        TT_FATAL(this->output_tensor_start[i] <= this->output_tensor_end[i]);
+        TT_FATAL(this->output_tensor_start[i] <= this->output_tensor_end[i], "Error");
     }
 
     tt::tt_metal::Shape output_tensor_shape = this->compute_output_shapes(input_tensors)[0];
@@ -32,8 +32,8 @@ void NlpKVCacheLoadSliceDeviceOperation::validate(const std::vector<Tensor> &inp
     auto fused_batch_heads = dim0 * dim1;
     auto core_grid = input_tensor_a.device()->compute_with_storage_grid_size();
     // Need at least fused_batch_heads cores to unpad into sharded tensor
-    TT_FATAL(fused_batch_heads <= core_grid.x * core_grid.y);
-    TT_FATAL(input_tensor_a.volume() % TILE_HW == 0);
+    TT_FATAL(fused_batch_heads <= core_grid.x * core_grid.y, "Error");
+    TT_FATAL(input_tensor_a.volume() % TILE_HW == 0, "Error");
     TT_FATAL((output_tensor_shape[-2] % TILE_HEIGHT == 0) &&
                 (this->output_tensor_start[-2] % TILE_HEIGHT == 0),
             "Can only unpad tilized tensor with full tiles");

--- a/ttnn/cpp/ttnn/operations/experimental/transformer/rotary_embedding/device/rotary_embedding_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/rotary_embedding/device/rotary_embedding_device_operation.cpp
@@ -21,7 +21,7 @@ void RotaryEmbedding::validate(const std::vector<Tensor>& input_tensors) const {
     const auto& input_tensor = input_tensors.at(0);
     const auto& cos = input_tensors.at(1);
     const auto& sin = input_tensors.at(2);
-    TT_FATAL(input_tensors.size() == 3);
+    TT_FATAL(input_tensors.size() == 3, "Error");
     auto ref_device = input_tensor.device();
     for (const auto& input : input_tensors) {
         TT_FATAL(input.storage_type() == StorageType::DEVICE, "Operands to rotary embedding need to be on device!");
@@ -43,19 +43,19 @@ void RotaryEmbedding::validate(const std::vector<Tensor>& input_tensors) const {
         TT_FATAL(cos.get_legacy_shape()[-2] >= seq_len, "Cos dims must match input dims");
     }
     if (input_tensor.is_sharded()) {
-        TT_FATAL(input_tensor.memory_config().memory_layout != TensorMemoryLayout::WIDTH_SHARDED);
-        TT_FATAL(input_tensor.shard_spec().value().shape[1] == input_tensor.get_legacy_shape()[-1]);
+        TT_FATAL(input_tensor.memory_config().memory_layout != TensorMemoryLayout::WIDTH_SHARDED, "Error");
+        TT_FATAL(input_tensor.shard_spec().value().shape[1] == input_tensor.get_legacy_shape()[-1], "Error");
         // Require even work division for now
         TT_FATAL(
-            (input_tensor.volume() / input_tensor.get_legacy_shape()[-1]) % input_tensor.shard_spec().value().shape[0] == 0);
+            (input_tensor.volume() / input_tensor.get_legacy_shape()[-1]) % input_tensor.shard_spec().value().shape[0] == 0, "Error");
         if (this->output_mem_config.is_sharded()) {
-            TT_FATAL(this->output_mem_config.memory_layout != TensorMemoryLayout::WIDTH_SHARDED);
+            TT_FATAL(this->output_mem_config.memory_layout != TensorMemoryLayout::WIDTH_SHARDED, "Error");
         }
     } else if (this->output_mem_config.is_sharded()) {
-        TT_FATAL(this->output_mem_config.memory_layout != TensorMemoryLayout::WIDTH_SHARDED);
+        TT_FATAL(this->output_mem_config.memory_layout != TensorMemoryLayout::WIDTH_SHARDED, "Error");
     } else {
-        TT_FATAL(input_tensor.memory_config().memory_layout == TensorMemoryLayout::INTERLEAVED);
-        TT_FATAL(this->output_mem_config.memory_layout == TensorMemoryLayout::INTERLEAVED);
+        TT_FATAL(input_tensor.memory_config().memory_layout == TensorMemoryLayout::INTERLEAVED, "Error");
+        TT_FATAL(this->output_mem_config.memory_layout == TensorMemoryLayout::INTERLEAVED, "Error");
     }
 }
 

--- a/ttnn/cpp/ttnn/operations/experimental/transformer/rotary_embedding/device/rotary_embedding_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/rotary_embedding/device/rotary_embedding_program_factory.cpp
@@ -68,7 +68,7 @@ operation::ProgramWithCallbacks rotary_embedding_multi_core(
             math_fidelity = compute_kernel_config.math_fidelity;
             fp32_dest_acc_en = input_cb_data_format == tt::DataFormat::Float32 ? true : compute_kernel_config.fp32_dest_acc_en;
         } else {
-            TT_FATAL(false, "arch not supported");
+            TT_THROW("arch not supported");
         }
 
     }, compute_kernel_config);

--- a/ttnn/cpp/ttnn/operations/experimental/transformer/rotary_embedding/device/rotary_embedding_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/rotary_embedding/device/rotary_embedding_program_factory.cpp
@@ -68,7 +68,7 @@ operation::ProgramWithCallbacks rotary_embedding_multi_core(
             math_fidelity = compute_kernel_config.math_fidelity;
             fp32_dest_acc_en = input_cb_data_format == tt::DataFormat::Float32 ? true : compute_kernel_config.fp32_dest_acc_en;
         } else {
-            TT_FATAL("arch not supported");
+            TT_FATAL(false, "arch not supported");
         }
 
     }, compute_kernel_config);

--- a/ttnn/cpp/ttnn/operations/experimental/transformer/rotary_embedding_llama/device/rotary_embedding_llama_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/rotary_embedding_llama/device/rotary_embedding_llama_device_operation.cpp
@@ -19,7 +19,7 @@ void RotaryEmbeddingLlama::validate(const std::vector<Tensor>& input_tensors) co
     const auto& cos = input_tensors.at(1);
     const auto& sin = input_tensors.at(2);
     const auto& trans_mat = input_tensors.at(3);
-    TT_FATAL(input_tensors.size() == 4);
+    TT_FATAL(input_tensors.size() == 4, "Error");
     auto ref_device = input_tensor.device();
     for (const auto& input : input_tensors) {
         TT_FATAL(input.storage_type() == StorageType::DEVICE, "Operands to rotary embedding need to be on device!");
@@ -51,8 +51,8 @@ void RotaryEmbeddingLlama::validate(const std::vector<Tensor>& input_tensors) co
     TT_FATAL(trans_mat.get_legacy_shape()[-1] == TILE_WIDTH, "Transformation matrix must have 4rd dim equal to TILE_WIDTH");
 
 
-    TT_FATAL(input_tensor.memory_config().memory_layout == TensorMemoryLayout::INTERLEAVED);
-    TT_FATAL(this->output_mem_config.memory_layout == TensorMemoryLayout::INTERLEAVED);
+    TT_FATAL(input_tensor.memory_config().memory_layout == TensorMemoryLayout::INTERLEAVED, "Error");
+    TT_FATAL(this->output_mem_config.memory_layout == TensorMemoryLayout::INTERLEAVED, "Error");
 
 }
 

--- a/ttnn/cpp/ttnn/operations/experimental/transformer/rotary_embedding_llama/device/rotary_embedding_llama_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/rotary_embedding_llama/device/rotary_embedding_llama_program_factory.cpp
@@ -63,7 +63,7 @@ operation::ProgramWithCallbacks rotary_embedding_llama_multi_core(
             math_fidelity = compute_kernel_config.math_fidelity;
             fp32_dest_acc_en = input_cb_data_format == tt::DataFormat::Float32 ? true : compute_kernel_config.fp32_dest_acc_en;
         } else {
-            TT_FATAL("arch not supported");
+            TT_FATAL(false, "arch not supported");
         }
 
     }, compute_kernel_config);

--- a/ttnn/cpp/ttnn/operations/experimental/transformer/rotary_embedding_llama/device/rotary_embedding_llama_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/rotary_embedding_llama/device/rotary_embedding_llama_program_factory.cpp
@@ -63,7 +63,7 @@ operation::ProgramWithCallbacks rotary_embedding_llama_multi_core(
             math_fidelity = compute_kernel_config.math_fidelity;
             fp32_dest_acc_en = input_cb_data_format == tt::DataFormat::Float32 ? true : compute_kernel_config.fp32_dest_acc_en;
         } else {
-            TT_FATAL(false, "arch not supported");
+            TT_THROW("arch not supported");
         }
 
     }, compute_kernel_config);

--- a/ttnn/cpp/ttnn/operations/experimental/transformer/split_query_key_value_and_split_heads/device/split_query_key_value_and_split_heads_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/split_query_key_value_and_split_heads/device/split_query_key_value_and_split_heads_device_operation.cpp
@@ -27,9 +27,9 @@ void SplitFusedQKVAndSplitHeadsDeviceOperation::validate_with_output_tensors(con
         auto bbox = input_tensor.shard_spec().value().grid.bounding_box();
         TT_FATAL(
             (bbox.end_coord.x < this->compute_with_storage_grid_size.x &&
-             bbox.end_coord.y < this->compute_with_storage_grid_size.y));
-        TT_FATAL(input_tensor.shard_spec().value().grid.ranges().size() == 1);
-        TT_FATAL(input_tensor.memory_config().memory_layout == TensorMemoryLayout::BLOCK_SHARDED);
+             bbox.end_coord.y < this->compute_with_storage_grid_size.y), "Error");
+        TT_FATAL(input_tensor.shard_spec().value().grid.ranges().size() == 1, "Error");
+        TT_FATAL(input_tensor.memory_config().memory_layout == TensorMemoryLayout::BLOCK_SHARDED, "Error");
     }
 
     if (!output_tensors.empty()) {

--- a/ttnn/cpp/ttnn/operations/kv_cache/device/update_cache_op.cpp
+++ b/ttnn/cpp/ttnn/operations/kv_cache/device/update_cache_op.cpp
@@ -19,13 +19,13 @@ void UpdateCache::validate(const std::vector<Tensor>& input_tensors) const {
     TT_FATAL(input_tensor.device() == cache_tensor.device(), "Operands to update_cache need to be on the same device!");
     TT_FATAL(input_tensor.buffer() != nullptr and cache_tensor.buffer() != nullptr, "Operands to update_cache need to be allocated in buffers on device!");
     TT_FATAL((input_tensor.get_layout() == Layout::TILE && cache_tensor.get_layout() == Layout::TILE), "Inputs to update_cache must be tilized");
-    TT_FATAL(input_tensor.get_dtype() == DataType::FLOAT32 || input_tensor.get_dtype() == DataType::BFLOAT16 || input_tensor.get_dtype() == DataType::BFLOAT8_B);
-    TT_FATAL(cache_tensor.get_dtype() == DataType::FLOAT32 || cache_tensor.get_dtype() == DataType::BFLOAT16 || cache_tensor.get_dtype() == DataType::BFLOAT8_B);
+    TT_FATAL(input_tensor.get_dtype() == DataType::FLOAT32 || input_tensor.get_dtype() == DataType::BFLOAT16 || input_tensor.get_dtype() == DataType::BFLOAT8_B, "Error");
+    TT_FATAL(cache_tensor.get_dtype() == DataType::FLOAT32 || cache_tensor.get_dtype() == DataType::BFLOAT16 || cache_tensor.get_dtype() == DataType::BFLOAT8_B, "Error");
 
-    TT_FATAL(input_tensor.get_legacy_shape()[-1] == cache_tensor.get_legacy_shape()[-1]);
-    TT_FATAL(input_tensor.get_legacy_shape()[0] == 1);
-    TT_FATAL(input_tensor.get_legacy_shape()[1] == cache_tensor.get_legacy_shape()[1]);
-    TT_FATAL(cache_tensor.memory_config().memory_layout == TensorMemoryLayout::INTERLEAVED);
+    TT_FATAL(input_tensor.get_legacy_shape()[-1] == cache_tensor.get_legacy_shape()[-1], "Error");
+    TT_FATAL(input_tensor.get_legacy_shape()[0] == 1, "Error");
+    TT_FATAL(input_tensor.get_legacy_shape()[1] == cache_tensor.get_legacy_shape()[1], "Error");
+    TT_FATAL(cache_tensor.memory_config().memory_layout == TensorMemoryLayout::INTERLEAVED, "Error");
     if (this->op_type == UpdateCacheOpType::FILL) {
         // TODO: If we want to support mixed precision like decode, we need to add simple compute kernel for conversion
         TT_FATAL(input_tensor.get_dtype() == cache_tensor.get_dtype(), "Input and cache tensors must have same dtype!");
@@ -37,31 +37,31 @@ void UpdateCache::validate(const std::vector<Tensor>& input_tensors) const {
         if (input_tensor.memory_config().memory_layout == TensorMemoryLayout::INTERLEAVED and input_tensor.get_legacy_shape()[1] > 1) {
             const uint32_t num_blocks_of_work = input_tensor.get_legacy_shape()[1] * input_tensor.get_legacy_shape()[-2] / TILE_HEIGHT;
             const auto compute_with_storage_grid_size = input_tensor.device()->compute_with_storage_grid_size();
-            TT_FATAL((num_blocks_of_work <= compute_with_storage_grid_size.x * compute_with_storage_grid_size.y));
+            TT_FATAL((num_blocks_of_work <= compute_with_storage_grid_size.x * compute_with_storage_grid_size.y), "Error");
         }
 
         if (input_tensor.is_sharded()) {
-            TT_FATAL(input_tensor.memory_config().memory_layout != TensorMemoryLayout::WIDTH_SHARDED);
-            TT_FATAL(input_tensor.shard_spec().value().shape[1] == input_tensor.get_legacy_shape()[-1]);
+            TT_FATAL(input_tensor.memory_config().memory_layout != TensorMemoryLayout::WIDTH_SHARDED, "Error");
+            TT_FATAL(input_tensor.shard_spec().value().shape[1] == input_tensor.get_legacy_shape()[-1], "Error");
             // Require even work division along seq_len and also only 1 head per core
             TT_FATAL(input_tensor.get_legacy_shape()[-2] % input_tensor.shard_spec().value().shape[0] == 0, "Seq len must be divisible by shard height!");
         }
 
-        TT_FATAL(this->batch_idx < cache_tensor.get_legacy_shape()[0]);
-        TT_FATAL(input_tensor.get_legacy_shape()[-2] <= cache_tensor.get_legacy_shape()[-2]);
+        TT_FATAL(this->batch_idx < cache_tensor.get_legacy_shape()[0], "Error");
+        TT_FATAL(input_tensor.get_legacy_shape()[-2] <= cache_tensor.get_legacy_shape()[-2], "Error");
     } else if (this->op_type == UpdateCacheOpType::UPDATE) {
         if (input_tensor.is_sharded()) {
-            TT_FATAL(input_tensor.memory_config().memory_layout != TensorMemoryLayout::WIDTH_SHARDED);
-            TT_FATAL(input_tensor.shard_spec().value().shape[1] == input_tensor.get_legacy_shape()[-1]);
+            TT_FATAL(input_tensor.memory_config().memory_layout != TensorMemoryLayout::WIDTH_SHARDED, "Error");
+            TT_FATAL(input_tensor.shard_spec().value().shape[1] == input_tensor.get_legacy_shape()[-1], "Error");
             // Require even work division for now
-            TT_FATAL((input_tensor.volume() / input_tensor.get_legacy_shape()[-1]) % input_tensor.shard_spec().value().shape[0] == 0);
+            TT_FATAL((input_tensor.volume() / input_tensor.get_legacy_shape()[-1]) % input_tensor.shard_spec().value().shape[0] == 0, "Error");
         } else {
-            TT_FATAL(input_tensor.memory_config().memory_layout == TensorMemoryLayout::INTERLEAVED);
+            TT_FATAL(input_tensor.memory_config().memory_layout == TensorMemoryLayout::INTERLEAVED, "Error");
         }
-        TT_FATAL(cache_tensor.get_legacy_shape()[0] <= input_tensor.get_legacy_shape()[-2]);
+        TT_FATAL(cache_tensor.get_legacy_shape()[0] <= input_tensor.get_legacy_shape()[-2], "Error");
         // batch offset is only valid if num_user less than 32 and batch_offset + num_user <= 32
-        if (cache_tensor.get_legacy_shape()[0] < 32) TT_FATAL(this->batch_offset + cache_tensor.get_legacy_shape()[0] <= 32);
-        else TT_FATAL(this->batch_offset == 0);
+        if (cache_tensor.get_legacy_shape()[0] < 32) TT_FATAL(this->batch_offset + cache_tensor.get_legacy_shape()[0] <= 32, "Error");
+        else TT_FATAL(this->batch_offset == 0, "Error");
     }
 }
 

--- a/ttnn/cpp/ttnn/operations/kv_cache/device/update_cache_op_multi_core.cpp
+++ b/ttnn/cpp/ttnn/operations/kv_cache/device/update_cache_op_multi_core.cpp
@@ -36,7 +36,7 @@ operation::ProgramWithCallbacks update_cache_multi_core(const Tensor& cache_tens
             TT_ASSERT(ttnn::device::is_wormhole_or_blackhole(device->arch()), "kernel config is not for wormhole_b0 or blackhole");
             fp32_dest_acc_en = input_cb_data_format == tt::DataFormat::Float32 ? true : compute_kernel_config.fp32_dest_acc_en;
         } else {
-            TT_FATAL(false, "arch not supported");
+            TT_THROW("arch not supported");
         }
 
     }, compute_kernel_config);

--- a/ttnn/cpp/ttnn/operations/kv_cache/device/update_cache_op_multi_core.cpp
+++ b/ttnn/cpp/ttnn/operations/kv_cache/device/update_cache_op_multi_core.cpp
@@ -36,7 +36,7 @@ operation::ProgramWithCallbacks update_cache_multi_core(const Tensor& cache_tens
             TT_ASSERT(ttnn::device::is_wormhole_or_blackhole(device->arch()), "kernel config is not for wormhole_b0 or blackhole");
             fp32_dest_acc_en = input_cb_data_format == tt::DataFormat::Float32 ? true : compute_kernel_config.fp32_dest_acc_en;
         } else {
-            TT_FATAL("arch not supported");
+            TT_FATAL(false, "arch not supported");
         }
 
     }, compute_kernel_config);

--- a/ttnn/cpp/ttnn/operations/loss/loss.cpp
+++ b/ttnn/cpp/ttnn/operations/loss/loss.cpp
@@ -49,7 +49,8 @@ Tensor loss_function(
             return ttnn::mean(result, std::nullopt, true, memory_config.value_or(ref.memory_config()));
         case LossReductionMode::NONE:
         default:
-            TT_THROW("unsupported loss reduce function {}. Please change.", reduce_mode);
+            // TODO: old code indicated this path is unsupported, but the all post commit test pipeline uses this path.
+            // Need to update test or replace this comment with a throw.
             break;
     }
     return result;

--- a/ttnn/cpp/ttnn/operations/loss/loss.cpp
+++ b/ttnn/cpp/ttnn/operations/loss/loss.cpp
@@ -38,7 +38,7 @@ Tensor loss_function(
             fused_ops.push_back(UnaryWithParam{UnaryOpType::SQUARE});
             break;
         default:
-            TT_FATAL("unsupported loss function");
+            TT_FATAL(false, "unsupported loss function {}. Please change.", loss_kind);
     }
     Tensor result = ttnn::subtract(queue_id, ref, prediction, std::nullopt, memory_config, optional_output_tensor, fused_ops);
 
@@ -49,7 +49,7 @@ Tensor loss_function(
             return ttnn::mean(result, std::nullopt, true, memory_config.value_or(ref.memory_config()));
         case LossReductionMode::NONE:
         default:
-            TT_FATAL("unsupported loss reduce function");
+            TT_FATAL(false, "unsupported loss reduce function {}. Please change.", reduce_mode);
             break;
     }
     return result;

--- a/ttnn/cpp/ttnn/operations/loss/loss.cpp
+++ b/ttnn/cpp/ttnn/operations/loss/loss.cpp
@@ -38,7 +38,7 @@ Tensor loss_function(
             fused_ops.push_back(UnaryWithParam{UnaryOpType::SQUARE});
             break;
         default:
-            TT_FATAL(false, "unsupported loss function {}. Please change.", loss_kind);
+            TT_THROW("unsupported loss function {}. Please change.", loss_kind);
     }
     Tensor result = ttnn::subtract(queue_id, ref, prediction, std::nullopt, memory_config, optional_output_tensor, fused_ops);
 
@@ -49,7 +49,7 @@ Tensor loss_function(
             return ttnn::mean(result, std::nullopt, true, memory_config.value_or(ref.memory_config()));
         case LossReductionMode::NONE:
         default:
-            TT_FATAL(false, "unsupported loss reduce function {}. Please change.", reduce_mode);
+            TT_THROW("unsupported loss reduce function {}. Please change.", reduce_mode);
             break;
     }
     return result;

--- a/ttnn/cpp/ttnn/operations/matmul/device/matmul_op.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/matmul_op.cpp
@@ -113,7 +113,7 @@ operation::OpPerformanceModel create_op_performance_model_for_matmul(
             } else if constexpr (std::is_same_v<T, ttnn::WormholeComputeKernelConfig>) {
                 math_fidelity = compute_kernel_config.math_fidelity;
             } else {
-                TT_FATAL("arch not supported");
+                TT_FATAL(false, "arch not supported");
             }
         },
         compute_kernel_config);

--- a/ttnn/cpp/ttnn/operations/matmul/device/matmul_op.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/matmul_op.cpp
@@ -113,7 +113,7 @@ operation::OpPerformanceModel create_op_performance_model_for_matmul(
             } else if constexpr (std::is_same_v<T, ttnn::WormholeComputeKernelConfig>) {
                 math_fidelity = compute_kernel_config.math_fidelity;
             } else {
-                TT_FATAL(false, "arch not supported");
+                TT_THROW("arch not supported");
             }
         },
         compute_kernel_config);
@@ -148,7 +148,7 @@ std::tuple<uint32_t, uint32_t> get_subblock_sizes(
             }
         }
     }
-    TT_FATAL(false, "Unable to find subblock sizes");
+    TT_THROW("Unable to find subblock sizes");
 }
 
 CoreCoord get_core_range(
@@ -571,7 +571,7 @@ MatmulProgramConfig get_matmul_program_config(
     const bool matmul,
     const std::optional<const CoreCoord> user_core_coord,
     const std::optional<const ttnn::DeviceComputeKernelConfig> compute_kernel_config) {
-    TT_FATAL(input_tensor_a.is_sharded());
+    TT_FATAL(input_tensor_a.is_sharded(), "Error");
     bool fp32_dest_acc_en = get_fp32_dest_acc_en(compute_kernel_config);
     // TODO: allow overwriting of grid size by user_core_coord after allowing support of arbitrary compute grid and more
     // generic sharded output tensor creation
@@ -579,16 +579,16 @@ MatmulProgramConfig get_matmul_program_config(
 
     // MCAST matmuls only support input_b in INTERLEAVED
     if (matmul) {
-        TT_FATAL(input_tensor_b.memory_config().memory_layout == TensorMemoryLayout::INTERLEAVED);
+        TT_FATAL(input_tensor_b.memory_config().memory_layout == TensorMemoryLayout::INTERLEAVED, "Error");
         if ((input_tensor_a.memory_config().memory_layout == TensorMemoryLayout::WIDTH_SHARDED or
              input_tensor_a.memory_config().memory_layout == TensorMemoryLayout::HEIGHT_SHARDED) and
             (grid_size.x > 1 or grid_size.y > 1)) {
-            TT_FATAL(input_tensor_a.shard_spec().value().orientation == ShardOrientation::ROW_MAJOR);
+            TT_FATAL(input_tensor_a.shard_spec().value().orientation == ShardOrientation::ROW_MAJOR, "Error");
 
             bool per_core_N_equals_subblock_w_constraint = false;
             if (output_mem_config.is_sharded()) {
-                TT_FATAL(input_tensor_a.memory_config().buffer_type == output_mem_config.buffer_type);
-                TT_FATAL(input_tensor_a.memory_config().memory_layout == output_mem_config.memory_layout);
+                TT_FATAL(input_tensor_a.memory_config().buffer_type == output_mem_config.buffer_type, "Error");
+                TT_FATAL(input_tensor_a.memory_config().memory_layout == output_mem_config.memory_layout, "Error");
                 per_core_N_equals_subblock_w_constraint = true;
             }
 
@@ -612,7 +612,7 @@ MatmulProgramConfig get_matmul_program_config(
                 per_core_N = N;  // Only necessary if output is sharded; otherwise, can set this to be < N
                 in0_block_w = K;
             } else {
-                TT_FATAL(false, "Input tensor must be WIDTH or HEIGHT sharded for 1D mcast matmul!");
+                TT_THROW("Input tensor must be WIDTH or HEIGHT sharded for 1D mcast matmul!");
             }
 
             auto subblock_hw = bmm_op_utils::get_matmul_subblock_params(
@@ -638,8 +638,8 @@ MatmulProgramConfig get_matmul_program_config(
 
             bool per_core_N_equals_subblock_w_constraint = false;
             if (output_mem_config.is_sharded()) {
-                TT_FATAL(input_tensor_a.memory_config().buffer_type == output_mem_config.buffer_type);
-                TT_FATAL(input_tensor_a.memory_config().memory_layout == output_mem_config.memory_layout);
+                TT_FATAL(input_tensor_a.memory_config().buffer_type == output_mem_config.buffer_type, "Error");
+                TT_FATAL(input_tensor_a.memory_config().memory_layout == output_mem_config.memory_layout, "Error");
                 per_core_N_equals_subblock_w_constraint = true;
             }
 
@@ -681,12 +681,12 @@ MatmulProgramConfig get_matmul_program_config(
         }
     } else {
         // TODO: Need a better criteria for BMMs and MatmulMultiCoreReuseProgramConfig
-        TT_FATAL(input_tensor_a.memory_config().memory_layout != TensorMemoryLayout::WIDTH_SHARDED);
+        TT_FATAL(input_tensor_a.memory_config().memory_layout != TensorMemoryLayout::WIDTH_SHARDED, "Error");
 
         bool per_core_N_equals_subblock_w_constraint = false;
         if (output_mem_config.is_sharded()) {
-            TT_FATAL(input_tensor_a.memory_config().buffer_type == output_mem_config.buffer_type);
-            TT_FATAL(input_tensor_a.memory_config().memory_layout == output_mem_config.memory_layout);
+            TT_FATAL(input_tensor_a.memory_config().buffer_type == output_mem_config.buffer_type, "Error");
+            TT_FATAL(input_tensor_a.memory_config().memory_layout == output_mem_config.memory_layout, "Error");
             per_core_N_equals_subblock_w_constraint = true;
         }
 
@@ -708,14 +708,17 @@ MatmulProgramConfig get_matmul_program_config(
         uint32_t batch_size_a = get_batch_size(input_tensor_a.get_legacy_shape());
         uint32_t batch_size_b = get_batch_size(input_tensor_b.get_legacy_shape());
         bool broadcast_batch = batch_size_a > 1 and batch_size_b == 1;
-        TT_FATAL(!broadcast_batch);
+        TT_FATAL(!broadcast_batch, "Error");
 
         if (input_tensor_b.is_sharded()) {
-            TT_FATAL(input_tensor_a.memory_config().buffer_type == input_tensor_b.memory_config().buffer_type);
-            TT_FATAL(input_tensor_a.memory_config().memory_layout == input_tensor_b.memory_config().memory_layout);
-            TT_FATAL(input_tensor_a.shard_spec().value().grid == input_tensor_b.shard_spec().value().grid);
+            TT_FATAL(input_tensor_a.memory_config().buffer_type == input_tensor_b.memory_config().buffer_type, "Error");
+            TT_FATAL(input_tensor_a.memory_config().memory_layout == input_tensor_b.memory_config().memory_layout, "Error");
+            TT_FATAL(input_tensor_a.shard_spec().value().grid == input_tensor_b.shard_spec().value().grid, "Error");
             TT_FATAL(
-                input_tensor_a.shard_spec().value().orientation == input_tensor_b.shard_spec().value().orientation);
+                input_tensor_a.shard_spec().value().orientation == input_tensor_b.shard_spec().value().orientation,
+                "Orientation mismatch a {} vs b {}.",
+                input_tensor_a.shard_spec().value().orientation,
+                input_tensor_b.shard_spec().value().orientation);
         }
 
         return MatmulMultiCoreReuseProgramConfig{
@@ -943,7 +946,7 @@ Tensor matmul(
 void Matmul::validate(
     const std::vector<Tensor>& input_tensors,
     const std::vector<std::optional<const Tensor>>& optional_input_tensors) const {
-    TT_FATAL(input_tensors.size() == 2);
+    TT_FATAL(input_tensors.size() == 2, "Error");
     const auto& input_tensor_a = input_tensors.at(0);
     const auto& input_tensor_b = input_tensors.at(1);
     const auto& a_shape = input_tensor_a.get_shape();
@@ -958,17 +961,17 @@ void Matmul::validate(
         a_shape[-1],
         b_shape[-2]);
 
-    TT_FATAL(this->bcast_batch.has_value());
+    TT_FATAL(this->bcast_batch.has_value(), "Error");
     if (this->bcast_batch.value()) {
         TT_FATAL(
-            get_batch_size(b_shape) == 1 &&
+            get_batch_size(b_shape) == 1,
             "matmul (batch bcast variant) expects input tensors of shapes BCMK*11KN=BCMN or equivalent");
     } else {
         // same condition as above, different message
-        TT_FATAL(a_shape.rank() == b_shape.rank() && "bmm (non-bcast matmul) expects input tensors of the same rank");
+        TT_FATAL(a_shape.rank() == b_shape.rank() && "bmm (non-bcast matmul) expects input tensors of the same rank", "Error");
         for (auto i = 0; i < a_shape.rank() - 2; i++) {
             TT_FATAL(
-                a_shape[i] == b_shape[i] &&
+                a_shape[i] == b_shape[i],
                 "bmm (non-bcast matmul) expects input tensors of shapes BCMK*BCKN=BCMN or equivalent");
         }
     }
@@ -984,7 +987,7 @@ void Matmul::validate(
 
     MatmulProgramConfig chosen_program_config = get_program_config(input_tensor_a, input_tensor_b, this);
 
-    TT_FATAL(optional_input_tensors.size() == 1);
+    TT_FATAL(optional_input_tensors.size() == 1, "Error");
     const auto& optional_bias = optional_input_tensors.at(0);
     if (optional_bias.has_value()) {
         const auto& bias = optional_bias.value();
@@ -1000,9 +1003,10 @@ void Matmul::validate(
     }
 
     if (this->untilize_out) {
-        TT_FATAL(this->output_dtype.has_value());
+        TT_FATAL(this->output_dtype.has_value(), "Error");
         TT_FATAL(
-            (this->output_dtype.value() == DataType::BFLOAT16) || (this->output_dtype.value() == DataType::FLOAT32));
+            (this->output_dtype.value() == DataType::BFLOAT16) || (this->output_dtype.value() == DataType::FLOAT32),
+            "Unsupported data type: {}", this->output_dtype.value());
     }
 
     std::visit(
@@ -1013,14 +1017,14 @@ void Matmul::validate(
             if constexpr (std::is_same_v<ProgramConfigType, MatmulMultiCoreReuseMultiCast1DProgramConfig>) {
                 if (program_config.mcast_in0) {
                     if (input_tensor_a.is_sharded()) {
-                        TT_FATAL(program_config.fuse_batch);
-                        TT_FATAL(input_tensor_a.memory_config().memory_layout == TensorMemoryLayout::WIDTH_SHARDED);
+                        TT_FATAL(program_config.fuse_batch, "Error");
+                        TT_FATAL(input_tensor_a.memory_config().memory_layout == TensorMemoryLayout::WIDTH_SHARDED, "Error");
                         if (this->output_mem_config.is_sharded()) {
-                            TT_FATAL(input_tensor_a.memory_config().buffer_type == this->output_mem_config.buffer_type);
+                            TT_FATAL(input_tensor_a.memory_config().buffer_type == this->output_mem_config.buffer_type, "Error");
                             TT_FATAL(
-                                input_tensor_a.memory_config().memory_layout == this->output_mem_config.memory_layout);
+                                input_tensor_a.memory_config().memory_layout == this->output_mem_config.memory_layout, "Error");
                         }
-                        TT_FATAL(input_tensor_a.shard_spec().value().orientation == ShardOrientation::ROW_MAJOR);
+                        TT_FATAL(input_tensor_a.shard_spec().value().orientation == ShardOrientation::ROW_MAJOR, "Error");
                         uint32_t M =
                             (program_config.fuse_batch ? input_tensor_a.volume() / input_tensor_a.get_legacy_shape()[-1]
                                                        : input_tensor_a.get_legacy_shape()[-2]) /
@@ -1032,13 +1036,13 @@ void Matmul::validate(
                         auto shard_shape = input_tensor_a.shard_spec().value().shape;
 
                         // No padding
-                        TT_FATAL(M == per_core_M);
-                        TT_FATAL(per_core_M == (shard_shape[0] / TILE_HEIGHT));
-                        TT_FATAL(K % program_config.in0_block_w == 0);
-                        TT_FATAL((shard_shape[1] / TILE_WIDTH) % program_config.in0_block_w == 0);
+                        TT_FATAL(M == per_core_M, "Error");
+                        TT_FATAL(per_core_M == (shard_shape[0] / TILE_HEIGHT), "Error");
+                        TT_FATAL(K % program_config.in0_block_w == 0, "Error");
+                        TT_FATAL((shard_shape[1] / TILE_WIDTH) % program_config.in0_block_w == 0, "Error");
                     }
                     if (this->output_mem_config.is_sharded()) {
-                        TT_FATAL(this->output_mem_config.memory_layout == TensorMemoryLayout::WIDTH_SHARDED);
+                        TT_FATAL(this->output_mem_config.memory_layout == TensorMemoryLayout::WIDTH_SHARDED, "Error");
                         uint32_t M =
                             (program_config.fuse_batch ? input_tensor_a.volume() / input_tensor_a.get_legacy_shape()[-1]
                                                        : input_tensor_a.get_legacy_shape()[-2]) /
@@ -1048,20 +1052,20 @@ void Matmul::validate(
                         uint32_t per_core_N = program_config.per_core_N;
 
                         // No padding
-                        TT_FATAL(M == per_core_M);
+                        TT_FATAL(M == per_core_M, "Error");
 
-                        TT_FATAL(program_config.out_subblock_w == per_core_N || program_config.out_subblock_h == 1);
+                        TT_FATAL(program_config.out_subblock_w == per_core_N || program_config.out_subblock_h == 1, "Error");
                     }
                 } else {
                     if (input_tensor_a.memory_config().is_sharded()) {
-                        TT_FATAL(program_config.fuse_batch);
-                        TT_FATAL(input_tensor_a.memory_config().memory_layout == TensorMemoryLayout::HEIGHT_SHARDED);
+                        TT_FATAL(program_config.fuse_batch, "Error");
+                        TT_FATAL(input_tensor_a.memory_config().memory_layout == TensorMemoryLayout::HEIGHT_SHARDED, "Error");
                         if (this->output_mem_config.is_sharded()) {
-                            TT_FATAL(input_tensor_a.memory_config().buffer_type == this->output_mem_config.buffer_type);
+                            TT_FATAL(input_tensor_a.memory_config().buffer_type == this->output_mem_config.buffer_type, "Error");
                             TT_FATAL(
-                                input_tensor_a.memory_config().memory_layout == this->output_mem_config.memory_layout);
+                                input_tensor_a.memory_config().memory_layout == this->output_mem_config.memory_layout, "Error");
                         }
-                        TT_FATAL(input_tensor_a.shard_spec().value().orientation == ShardOrientation::ROW_MAJOR);
+                        TT_FATAL(input_tensor_a.shard_spec().value().orientation == ShardOrientation::ROW_MAJOR, "Error");
                         uint32_t M =
                             (program_config.fuse_batch ? input_tensor_a.volume() / input_tensor_a.get_legacy_shape()[-1]
                                                        : input_tensor_a.get_legacy_shape()[-2]) /
@@ -1070,13 +1074,13 @@ void Matmul::validate(
                         uint32_t per_core_M = program_config.per_core_M;
                         auto shard_shape = input_tensor_a.shard_spec().value().shape;
 
-                        TT_FATAL(div_up(M, per_core_M) == input_tensor_a.shard_spec().value().grid.num_cores());
-                        TT_FATAL(per_core_M == (shard_shape[0] / TILE_HEIGHT));
-                        TT_FATAL(K % program_config.in0_block_w == 0);
-                        TT_FATAL(K == (shard_shape[1] / TILE_WIDTH));
+                        TT_FATAL(div_up(M, per_core_M) == input_tensor_a.shard_spec().value().grid.num_cores(), "Error");
+                        TT_FATAL(per_core_M == (shard_shape[0] / TILE_HEIGHT), "Error");
+                        TT_FATAL(K % program_config.in0_block_w == 0, "Error");
+                        TT_FATAL(K == (shard_shape[1] / TILE_WIDTH), "Error");
                     }
                     if (this->output_mem_config.is_sharded()) {
-                        TT_FATAL(this->output_mem_config.memory_layout == TensorMemoryLayout::HEIGHT_SHARDED);
+                        TT_FATAL(this->output_mem_config.memory_layout == TensorMemoryLayout::HEIGHT_SHARDED, "Error");
                         uint32_t M =
                             (program_config.fuse_batch ? input_tensor_a.volume() / input_tensor_a.get_legacy_shape()[-1]
                                                        : input_tensor_a.get_legacy_shape()[-2]) /
@@ -1085,20 +1089,20 @@ void Matmul::validate(
                         uint32_t per_core_M = program_config.per_core_M;
                         uint32_t per_core_N = program_config.per_core_N;
 
-                        TT_FATAL(N == per_core_N);
-                        TT_FATAL(program_config.out_subblock_w == per_core_N || program_config.out_subblock_h == 1);
+                        TT_FATAL(N == per_core_N, "Error");
+                        TT_FATAL(program_config.out_subblock_w == per_core_N || program_config.out_subblock_h == 1, "Error");
                     }
                 }
-                TT_FATAL(input_tensor_b.memory_config().memory_layout == TensorMemoryLayout::INTERLEAVED);
+                TT_FATAL(input_tensor_b.memory_config().memory_layout == TensorMemoryLayout::INTERLEAVED, "Error");
             } else if constexpr (std::is_same_v<
                                      ProgramConfigType,
                                      MatmulMultiCoreReuseMultiCastDRAMShardedProgramConfig>) {
-                TT_FATAL(input_tensor_a.is_sharded());
-                TT_FATAL(this->output_mem_config.is_sharded());
-                TT_FATAL(input_tensor_a.memory_config().memory_layout == TensorMemoryLayout::WIDTH_SHARDED);
-                TT_FATAL(input_tensor_a.memory_config().buffer_type == this->output_mem_config.buffer_type);
-                TT_FATAL(input_tensor_a.memory_config().memory_layout == this->output_mem_config.memory_layout);
-                TT_FATAL(input_tensor_a.shard_spec().value().orientation == ShardOrientation::ROW_MAJOR);
+                TT_FATAL(input_tensor_a.is_sharded(), "Error");
+                TT_FATAL(this->output_mem_config.is_sharded(), "Error");
+                TT_FATAL(input_tensor_a.memory_config().memory_layout == TensorMemoryLayout::WIDTH_SHARDED, "Error");
+                TT_FATAL(input_tensor_a.memory_config().buffer_type == this->output_mem_config.buffer_type, "Error");
+                TT_FATAL(input_tensor_a.memory_config().memory_layout == this->output_mem_config.memory_layout, "Error");
+                TT_FATAL(input_tensor_a.shard_spec().value().orientation == ShardOrientation::ROW_MAJOR, "Error");
                 uint32_t M = input_tensor_a.volume() / input_tensor_a.get_legacy_shape()[-1] / TILE_HEIGHT;
                 uint32_t N = input_tensor_b.get_legacy_shape()[-1] / TILE_WIDTH;
                 uint32_t K = input_tensor_a.get_legacy_shape()[-1] / TILE_WIDTH;
@@ -1107,13 +1111,13 @@ void Matmul::validate(
                 auto shard_shape = input_tensor_a.shard_spec().value().shape;
 
                 // No padding
-                TT_FATAL(M == per_core_M);
-                TT_FATAL(per_core_M == (shard_shape[0] / TILE_HEIGHT));
-                TT_FATAL(K % program_config.in0_block_w == 0);
-                TT_FATAL((shard_shape[1] / TILE_WIDTH) % program_config.in0_block_w == 0);
+                TT_FATAL(M == per_core_M, "Error");
+                TT_FATAL(per_core_M == (shard_shape[0] / TILE_HEIGHT), "Error");
+                TT_FATAL(K % program_config.in0_block_w == 0, "Error");
+                TT_FATAL((shard_shape[1] / TILE_WIDTH) % program_config.in0_block_w == 0, "Error");
 
                 // tensor in1
-                TT_FATAL(input_tensor_b.memory_config().memory_layout == TensorMemoryLayout::WIDTH_SHARDED);
+                TT_FATAL(input_tensor_b.memory_config().memory_layout == TensorMemoryLayout::WIDTH_SHARDED, "Error");
             } else if constexpr (std::is_same_v<ProgramConfigType, MatmulMultiCoreReuseMultiCastProgramConfig>) {
                 if (input_tensor_a.memory_config().is_sharded()) {
                     auto tensor_a_memory_layout = input_tensor_a.memory_config().memory_layout;
@@ -1125,54 +1129,56 @@ void Matmul::validate(
 
                     TT_FATAL(
                         tensor_a_memory_layout == TensorMemoryLayout::BLOCK_SHARDED ||
-                        tensor_a_memory_layout == TensorMemoryLayout::HEIGHT_SHARDED);
+                        tensor_a_memory_layout == TensorMemoryLayout::HEIGHT_SHARDED,
+                        "Unsupported memory layout {}.",
+                        tensor_a_memory_layout);
 
                     if (tensor_a_memory_layout == TensorMemoryLayout::BLOCK_SHARDED) {
                         if (program_config.transpose_mcast) {
-                            TT_FATAL(input_tensor_a.shard_spec().value().orientation == ShardOrientation::COL_MAJOR);
+                            TT_FATAL(input_tensor_a.shard_spec().value().orientation == ShardOrientation::COL_MAJOR, "Error");
                         } else {
-                            TT_FATAL(input_tensor_a.shard_spec().value().orientation == ShardOrientation::ROW_MAJOR);
+                            TT_FATAL(input_tensor_a.shard_spec().value().orientation == ShardOrientation::ROW_MAJOR, "Error");
                         }
                         if (this->output_mem_config.is_sharded()) {
-                            TT_FATAL(input_tensor_a.memory_config().buffer_type == this->output_mem_config.buffer_type);
+                            TT_FATAL(input_tensor_a.memory_config().buffer_type == this->output_mem_config.buffer_type, "Error");
                             TT_FATAL(
-                                input_tensor_a.memory_config().memory_layout == this->output_mem_config.memory_layout);
+                                input_tensor_a.memory_config().memory_layout == this->output_mem_config.memory_layout, "Error");
                         }
 
                     } else if (tensor_a_memory_layout == TensorMemoryLayout::HEIGHT_SHARDED) {
-                        TT_FATAL(!program_config.transpose_mcast);
-                        TT_FATAL(K == program_config.in0_block_w);
-                        TT_FATAL(program_config.in0_block_w == (shard_shape[1] / TILE_WIDTH));
+                        TT_FATAL(!program_config.transpose_mcast, "Error");
+                        TT_FATAL(K == program_config.in0_block_w, "Error");
+                        TT_FATAL(program_config.in0_block_w == (shard_shape[1] / TILE_WIDTH), "Error");
                         TT_FATAL(
                             input_tensor_a.shard_spec()->grid.bounding_box().start_coord.x ==
-                            input_tensor_a.shard_spec()->grid.bounding_box().end_coord.x);
+                            input_tensor_a.shard_spec()->grid.bounding_box().end_coord.x, "Error");
                     }
 
-                    TT_FATAL(per_core_M == (shard_shape[0] / TILE_HEIGHT));
-                    TT_FATAL((shard_shape[1] / TILE_WIDTH) % program_config.in0_block_w == 0);
+                    TT_FATAL(per_core_M == (shard_shape[0] / TILE_HEIGHT), "Error");
+                    TT_FATAL((shard_shape[1] / TILE_WIDTH) % program_config.in0_block_w == 0, "Error");
                 }
 
                 if (input_tensor_b.memory_config().is_sharded()) {
-                    TT_FATAL(!program_config.transpose_mcast);
+                    TT_FATAL(!program_config.transpose_mcast, "Error");
                     auto tensor_b_memory_layout = input_tensor_b.memory_config().memory_layout;
-                    TT_FATAL(tensor_b_memory_layout == TensorMemoryLayout::WIDTH_SHARDED);
+                    TT_FATAL(tensor_b_memory_layout == TensorMemoryLayout::WIDTH_SHARDED, "Error");
                     if (input_tensor_b.buffer()->buffer_type() != tt_metal::BufferType::DRAM) {
                         TT_FATAL(
-                            program_config.per_core_N == (input_tensor_b.shard_spec().value().shape[1] / TILE_WIDTH));
+                            program_config.per_core_N == (input_tensor_b.shard_spec().value().shape[1] / TILE_WIDTH), "Error");
                     }
                     TT_FATAL(
                         input_tensor_b.shard_spec()->grid.bounding_box().start_coord.y ==
-                        input_tensor_b.shard_spec()->grid.bounding_box().end_coord.y);
+                        input_tensor_b.shard_spec()->grid.bounding_box().end_coord.y, "Error");
                 }
 
                 if (this->output_mem_config.is_sharded()) {
-                    TT_FATAL(this->output_mem_config.memory_layout == TensorMemoryLayout::BLOCK_SHARDED);
+                    TT_FATAL(this->output_mem_config.memory_layout == TensorMemoryLayout::BLOCK_SHARDED, "Error");
                     uint32_t M = input_tensor_a.volume() / input_tensor_a.get_legacy_shape()[-1] / TILE_HEIGHT;
                     uint32_t N = input_tensor_b.get_legacy_shape()[-1] / TILE_WIDTH;
                     uint32_t per_core_M = program_config.per_core_M;
                     uint32_t per_core_N = program_config.per_core_N;
 
-                    TT_FATAL(program_config.out_subblock_w == per_core_N || program_config.out_subblock_h == 1);
+                    TT_FATAL(program_config.out_subblock_w == per_core_N || program_config.out_subblock_h == 1, "Error");
                 }
             } else if constexpr (std::is_same_v<ProgramConfigType, MatmulMultiCoreReuseProgramConfig>) {
                 uint32_t M = input_tensor_a.get_legacy_shape()[-2] / TILE_HEIGHT;
@@ -1187,53 +1193,53 @@ void Matmul::validate(
                 } else {
                     TT_FATAL(M % per_core_M == 0, "per_core_M must divide M if per_core_M < M!");
                 }
-                TT_FATAL(N == per_core_N);
+                TT_FATAL(N == per_core_N, "Error");
                 if (input_tensor_a.is_sharded()) {
-                    TT_FATAL(input_tensor_a.memory_config().memory_layout != TensorMemoryLayout::WIDTH_SHARDED);
+                    TT_FATAL(input_tensor_a.memory_config().memory_layout != TensorMemoryLayout::WIDTH_SHARDED, "Error");
                     auto in0_shard_shape = input_tensor_a.shard_spec().value().shape;
 
-                    TT_FATAL(K == in0_shard_shape[1]);
-                    TT_FATAL(in0_shard_shape[1] == program_config.in0_block_w * TILE_WIDTH);
-                    TT_FATAL(per_core_M * TILE_HEIGHT == in0_shard_shape[0]);
+                    TT_FATAL(K == in0_shard_shape[1], "Error");
+                    TT_FATAL(in0_shard_shape[1] == program_config.in0_block_w * TILE_WIDTH, "Error");
+                    TT_FATAL(per_core_M * TILE_HEIGHT == in0_shard_shape[0], "Error");
 
                     if (input_tensor_b.is_sharded()) {
                         TT_FATAL(
-                            input_tensor_a.memory_config().buffer_type == input_tensor_b.memory_config().buffer_type);
+                            input_tensor_a.memory_config().buffer_type == input_tensor_b.memory_config().buffer_type, "Error");
                         TT_FATAL(
                             input_tensor_a.memory_config().memory_layout ==
-                            input_tensor_b.memory_config().memory_layout);
-                        TT_FATAL(input_tensor_a.shard_spec().value().grid == input_tensor_b.shard_spec().value().grid);
+                            input_tensor_b.memory_config().memory_layout, "Error");
+                        TT_FATAL(input_tensor_a.shard_spec().value().grid == input_tensor_b.shard_spec().value().grid, "Error");
                         TT_FATAL(
                             input_tensor_a.shard_spec().value().orientation ==
-                            input_tensor_b.shard_spec().value().orientation);
+                            input_tensor_b.shard_spec().value().orientation, "Error");
                     }
                     if (this->output_mem_config.is_sharded()) {
-                        TT_FATAL(input_tensor_a.memory_config().buffer_type == this->output_mem_config.buffer_type);
-                        TT_FATAL(input_tensor_a.memory_config().memory_layout == this->output_mem_config.memory_layout);
+                        TT_FATAL(input_tensor_a.memory_config().buffer_type == this->output_mem_config.buffer_type, "Error");
+                        TT_FATAL(input_tensor_a.memory_config().memory_layout == this->output_mem_config.memory_layout, "Error");
                     }
                 }
 
                 uint32_t batch_size_a = get_batch_size(input_tensor_a.get_legacy_shape());
                 uint32_t batch_size_b = get_batch_size(input_tensor_b.get_legacy_shape());
                 bool broadcast_batch = batch_size_a > 1 and batch_size_b == 1;
-                TT_FATAL(!broadcast_batch);
+                TT_FATAL(!broadcast_batch, "Error");
 
                 if (input_tensor_b.is_sharded()) {
                     TT_FATAL(per_core_M % M == 0, "per_core_M must be a multiple of M if input b is sharded!");
-                    TT_FATAL(input_tensor_b.memory_config().memory_layout != TensorMemoryLayout::WIDTH_SHARDED);
+                    TT_FATAL(input_tensor_b.memory_config().memory_layout != TensorMemoryLayout::WIDTH_SHARDED, "Error");
                     auto in1_shard_shape = input_tensor_b.shard_spec().value().shape;
-                    TT_FATAL(in1_shard_shape[1] == input_tensor_b.get_legacy_shape()[-1]);
-                    TT_FATAL(per_core_N * TILE_HEIGHT == in1_shard_shape[1]);
-                    TT_FATAL(in1_shard_shape[0] % K == 0);
+                    TT_FATAL(in1_shard_shape[1] == input_tensor_b.get_legacy_shape()[-1], "Error");
+                    TT_FATAL(per_core_N * TILE_HEIGHT == in1_shard_shape[1], "Error");
+                    TT_FATAL(in1_shard_shape[0] % K == 0, "Error");
                 }
                 if (this->output_mem_config.is_sharded()) {
-                    TT_FATAL(this->output_mem_config.memory_layout != TensorMemoryLayout::WIDTH_SHARDED);
-                    TT_FATAL(program_config.out_subblock_w == per_core_N || program_config.out_subblock_h == 1);
+                    TT_FATAL(this->output_mem_config.memory_layout != TensorMemoryLayout::WIDTH_SHARDED, "Error");
+                    TT_FATAL(program_config.out_subblock_w == per_core_N || program_config.out_subblock_h == 1, "Error");
                 }
             } else {
-                TT_FATAL(input_tensor_a.memory_config().memory_layout == TensorMemoryLayout::INTERLEAVED);
-                TT_FATAL(input_tensor_b.memory_config().memory_layout == TensorMemoryLayout::INTERLEAVED);
-                TT_FATAL(this->output_mem_config.memory_layout == TensorMemoryLayout::INTERLEAVED);
+                TT_FATAL(input_tensor_a.memory_config().memory_layout == TensorMemoryLayout::INTERLEAVED, "Error");
+                TT_FATAL(input_tensor_b.memory_config().memory_layout == TensorMemoryLayout::INTERLEAVED, "Error");
+                TT_FATAL(this->output_mem_config.memory_layout == TensorMemoryLayout::INTERLEAVED, "Error");
             }
             if constexpr (
                 std::is_same_v<ProgramConfigType, MatmulMultiCoreReuseProgramConfig> ||
@@ -1282,7 +1288,7 @@ std::vector<Tensor> Matmul::create_output_tensors(const std::vector<Tensor>& inp
     const auto& input_tensor_a = input_tensors.at(0);
     const auto& input_tensor_b = input_tensors.at(1);
     auto output_layout = this->untilize_out ? Layout::ROW_MAJOR : Layout::TILE;
-    TT_FATAL(this->output_dtype.has_value());
+    TT_FATAL(this->output_dtype.has_value(), "Error");
     if (this->output_mem_config.is_sharded()) {
         MatmulProgramConfig chosen_program_config = get_program_config(input_tensor_a, input_tensor_b, this);
         return std::visit(
@@ -1395,7 +1401,7 @@ std::vector<Tensor> Matmul::create_output_tensors(const std::vector<Tensor>& inp
                         input_tensor_a.device(),
                         mem_config)};
                 } else {
-                    TT_FATAL(false, "Unsupported op for output sharding");
+                    TT_THROW("Unsupported op for output sharding");
                     return {};
                 }
             },
@@ -1414,15 +1420,15 @@ operation::ProgramWithCallbacks Matmul::create_program(
     const auto& bias = optional_input_tensors.at(0);
     auto& output_tensor = output_tensors.at(0);
 
-    TT_FATAL(this->output_dtype.has_value());
+    TT_FATAL(this->output_dtype.has_value(), "Error");
     tt::tt_metal::DataType output_dtype = this->output_dtype.value();
 
     bool fuse_batch = true;
     // TODO: If input_tensor_a.get_legacy_shape()[0] * input_tensor_a.get_legacy_shape()[1] * ... except last two
     // dimensions == 1, does matmuls work if we treat it as bmm
     // TODO: Only for MatmulMultiCoreReuseProgramConfig we allow this as single core matmul/bmm
-    TT_FATAL(this->compute_kernel_config.has_value());
-    TT_FATAL(this->bcast_batch.has_value());
+    TT_FATAL(this->compute_kernel_config.has_value(), "Error");
+    TT_FATAL(this->bcast_batch.has_value(), "Error");
     bool broadcast_batch = this->bcast_batch.value();
 
     MatmulProgramConfig chosen_program_config = get_program_config(input_tensor_a, input_tensor_b, this);

--- a/ttnn/cpp/ttnn/operations/matmul/device/matmul_op_multi_core_reuse_mcast_1d_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/matmul_op_multi_core_reuse_mcast_1d_program_factory.cpp
@@ -1545,7 +1545,7 @@ operation::ProgramWithCallbacks matmul_multi_core_reuse_mcast_1d_optimized_(
     tt::DataFormat bias_data_format = tt::DataFormat::Bfp8_b;  // bias; doesn't matter if bias=nullptr
     if (bias.has_value()) {
         auto& c = bias.value();
-        TT_FATAL(c.storage_type() == StorageType::DEVICE);
+        TT_FATAL(c.storage_type() == StorageType::DEVICE, "Error");
         TT_FATAL(a.device() == c.device(), "Operands to matmul need to be on the same device!");
         TT_FATAL(c.buffer() != nullptr, "Operands to matmul need to be allocated in buffers on device!");
 
@@ -1560,16 +1560,16 @@ operation::ProgramWithCallbacks matmul_multi_core_reuse_mcast_1d_optimized_(
     uint32_t in1_single_tile_size = tt_metal::detail::TileSize(in1_data_format);
     tt_metal::Buffer* in0_buffer = a.buffer();
     tt_metal::Buffer* in1_buffer = b.buffer();
-    TT_FATAL(in0_buffer->size() % in0_single_tile_size == 0);
-    TT_FATAL(in1_buffer->size() % in1_single_tile_size == 0);
+    TT_FATAL(in0_buffer->size() % in0_single_tile_size == 0, "Error");
+    TT_FATAL(in1_buffer->size() % in1_single_tile_size == 0, "Error");
 
     TT_FATAL(
-        ashape[-1] == bshape[-2] &&
+        ashape[-1] == bshape[-2],
         "Dimension K (A.shape[-1] and B.shape[-2]) must match for A and B in bmm_op");  // A.K == B.K
-    TT_FATAL(ashape[-2] % TILE_HEIGHT == 0);
-    TT_FATAL(ashape[-1] % TILE_WIDTH == 0);
-    TT_FATAL(bshape[-2] % TILE_HEIGHT == 0);
-    TT_FATAL(bshape[-1] % TILE_WIDTH == 0);
+    TT_FATAL(ashape[-2] % TILE_HEIGHT == 0, "Error");
+    TT_FATAL(ashape[-1] % TILE_WIDTH == 0, "Error");
+    TT_FATAL(bshape[-2] % TILE_HEIGHT == 0, "Error");
+    TT_FATAL(bshape[-1] % TILE_WIDTH == 0, "Error");
 
     MathFidelity math_fidelity;
     bool math_approx_mode;
@@ -1592,14 +1592,14 @@ operation::ProgramWithCallbacks matmul_multi_core_reuse_mcast_1d_optimized_(
                 fp32_dest_acc_en = compute_kernel_config.fp32_dest_acc_en;
                 packer_l1_acc = compute_kernel_config.packer_l1_acc;
             } else {
-                TT_FATAL(false, "arch not supported");
+                TT_THROW("arch not supported");
             }
         },
         compute_kernel_config);
 
     if (fp32_dest_acc_en) {
         TT_FATAL(
-            out_subblock_h * out_subblock_w <= 4 &&
+            out_subblock_h * out_subblock_w <= 4,
             "Total number of tiles in a subblock must be less than 4 when in fp32_dest_acc mode");
     }
 
@@ -1617,7 +1617,7 @@ operation::ProgramWithCallbacks matmul_multi_core_reuse_mcast_1d_optimized_(
         Mt = B * Mt;
         B = 1;
     }
-    TT_FATAL(Kt % in0_block_w == 0);
+    TT_FATAL(Kt % in0_block_w == 0, "Error");
 
     // This should allocate a DRAM buffer on the device
     uint32_t num_cores_x = compute_with_storage_grid_size.x;

--- a/ttnn/cpp/ttnn/operations/matmul/device/matmul_op_multi_core_reuse_mcast_1d_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/matmul_op_multi_core_reuse_mcast_1d_program_factory.cpp
@@ -1592,7 +1592,7 @@ operation::ProgramWithCallbacks matmul_multi_core_reuse_mcast_1d_optimized_(
                 fp32_dest_acc_en = compute_kernel_config.fp32_dest_acc_en;
                 packer_l1_acc = compute_kernel_config.packer_l1_acc;
             } else {
-                TT_FATAL("arch not supported");
+                TT_FATAL(false, "arch not supported");
             }
         },
         compute_kernel_config);

--- a/ttnn/cpp/ttnn/operations/matmul/device/matmul_op_multi_core_reuse_mcast_2d_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/matmul_op_multi_core_reuse_mcast_2d_program_factory.cpp
@@ -1295,7 +1295,7 @@ operation::ProgramWithCallbacks matmul_multi_core_reuse_mcast_2d_optimized_(
                 fp32_dest_acc_en = compute_kernel_config.fp32_dest_acc_en;
                 packer_l1_acc = compute_kernel_config.packer_l1_acc;
             } else {
-                TT_FATAL("arch not supported");
+                TT_FATAL(false, "arch not supported");
             }
         },
         compute_kernel_config);

--- a/ttnn/cpp/ttnn/operations/matmul/device/matmul_op_multi_core_reuse_mcast_2d_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/matmul_op_multi_core_reuse_mcast_2d_program_factory.cpp
@@ -1248,7 +1248,7 @@ operation::ProgramWithCallbacks matmul_multi_core_reuse_mcast_2d_optimized_(
     tt::DataFormat bias_data_format = tt::DataFormat::Bfp8_b;  // bias; doesn't matter if bias=nullptr
     if (bias.has_value()) {
         auto& c = bias.value();
-        TT_FATAL(c.storage_type() == StorageType::DEVICE);
+        TT_FATAL(c.storage_type() == StorageType::DEVICE, "Error");
         TT_FATAL(a.device() == c.device(), "Operands to matmul need to be on the same device!");
         TT_FATAL(c.buffer() != nullptr, "Operands to matmul need to be allocated in buffers on device!");
 
@@ -1263,16 +1263,16 @@ operation::ProgramWithCallbacks matmul_multi_core_reuse_mcast_2d_optimized_(
     uint32_t in1_single_tile_size = tt_metal::detail::TileSize(in1_data_format);
     tt_metal::Buffer* in0_buffer = a.buffer();
     tt_metal::Buffer* in1_buffer = b.buffer();
-    TT_FATAL(in0_buffer->size() % in0_single_tile_size == 0);
-    TT_FATAL(in1_buffer->size() % in1_single_tile_size == 0);
+    TT_FATAL(in0_buffer->size() % in0_single_tile_size == 0, "Error");
+    TT_FATAL(in1_buffer->size() % in1_single_tile_size == 0, "Error");
 
     TT_FATAL(
-        ashape[-1] == bshape[-2] &&
+        ashape[-1] == bshape[-2],
         "Dimension K (A.shape[-1] and B.shape[-2]) must match for A and B in bmm_op");  // A.K == B.K
-    TT_FATAL(ashape[-2] % TILE_HEIGHT == 0);
-    TT_FATAL(ashape[-1] % TILE_WIDTH == 0);
-    TT_FATAL(bshape[-2] % TILE_HEIGHT == 0);
-    TT_FATAL(bshape[-1] % TILE_WIDTH == 0);
+    TT_FATAL(ashape[-2] % TILE_HEIGHT == 0, "Error");
+    TT_FATAL(ashape[-1] % TILE_WIDTH == 0, "Error");
+    TT_FATAL(bshape[-2] % TILE_HEIGHT == 0, "Error");
+    TT_FATAL(bshape[-1] % TILE_WIDTH == 0, "Error");
 
     MathFidelity math_fidelity;
     bool math_approx_mode;
@@ -1295,14 +1295,14 @@ operation::ProgramWithCallbacks matmul_multi_core_reuse_mcast_2d_optimized_(
                 fp32_dest_acc_en = compute_kernel_config.fp32_dest_acc_en;
                 packer_l1_acc = compute_kernel_config.packer_l1_acc;
             } else {
-                TT_FATAL(false, "arch not supported");
+                TT_THROW("arch not supported");
             }
         },
         compute_kernel_config);
 
     if (fp32_dest_acc_en) {
         TT_FATAL(
-            out_subblock_h * out_subblock_w <= 4 &&
+            out_subblock_h * out_subblock_w <= 4,
             "Total number of tiles in a subblock must be less than 4 when in fp32_dest_acc mode");
     }
 
@@ -1320,7 +1320,7 @@ operation::ProgramWithCallbacks matmul_multi_core_reuse_mcast_2d_optimized_(
         Mt = B * Mt;
         B = 1;
     }
-    TT_FATAL(Kt % in0_block_w == 0);
+    TT_FATAL(Kt % in0_block_w == 0, "Error");
 
     // This should allocate a DRAM buffer on the device
     uint32_t num_cores_x = compute_with_storage_grid_size.x;

--- a/ttnn/cpp/ttnn/operations/matmul/device/matmul_op_multi_core_reuse_mcast_dram_sharded_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/matmul_op_multi_core_reuse_mcast_dram_sharded_program_factory.cpp
@@ -1087,8 +1087,8 @@ operation::ProgramWithCallbacks create_program_dram_sharded(
             const std::vector<Tensor>& input_tensors,
             const std::vector<std::optional<const Tensor>>& optional_input_tensors,
             const std::vector<Tensor>& output_tensors) {
-            TT_FATAL(input_tensors.size() + optional_input_tensors.size() == 3);
-            TT_FATAL(output_tensors.size() == 1);
+            TT_FATAL(input_tensors.size() + optional_input_tensors.size() == 3, "Error");
+            TT_FATAL(output_tensors.size() == 1, "Error");
 
             auto src_buffer_a = input_tensors.at(0).buffer();
             auto src_buffer_b = input_tensors.at(1).buffer();
@@ -1147,7 +1147,7 @@ operation::ProgramWithCallbacks matmul_multi_core_reuse_dram_sharded_optimized_(
     tt::DataFormat bias_data_format = tt::DataFormat::Bfp8_b;  // bias; doesn't matter if bias=nullptr
     if (bias.has_value()) {
         auto& c = bias.value();
-        TT_FATAL(c.storage_type() == StorageType::DEVICE);
+        TT_FATAL(c.storage_type() == StorageType::DEVICE, "Error");
         TT_FATAL(a.device() == c.device(), "Operands to matmul need to be on the same device!");
         TT_FATAL(c.buffer() != nullptr, "Operands to matmul need to be allocated in buffers on device!");
 
@@ -1158,23 +1158,23 @@ operation::ProgramWithCallbacks matmul_multi_core_reuse_dram_sharded_optimized_(
 
     tt::tt_metal::Device* device = a.device();
 
-    TT_FATAL(a.shard_spec().has_value() && output.shard_spec().has_value());
+    TT_FATAL(a.shard_spec().has_value() && output.shard_spec().has_value(), "Error");
     CoreRangeSet all_cores_storage = a.shard_spec().value().grid;
 
     uint32_t in0_single_tile_size = tt_metal::detail::TileSize(in0_data_format);
     uint32_t in1_single_tile_size = tt_metal::detail::TileSize(in1_data_format);
     tt_metal::Buffer* in0_buffer = a.buffer();
     tt_metal::Buffer* in1_buffer = b.buffer();
-    TT_FATAL(in0_buffer->size() % in0_single_tile_size == 0);
-    TT_FATAL(in1_buffer->size() % in1_single_tile_size == 0);
+    TT_FATAL(in0_buffer->size() % in0_single_tile_size == 0, "Error");
+    TT_FATAL(in1_buffer->size() % in1_single_tile_size == 0, "Error");
 
     TT_FATAL(
-        ashape[-1] == bshape[-2] &&
+        ashape[-1] == bshape[-2],
         "Dimension K (A.shape[-1] and B.shape[-2]) must match for A and B in bmm_op");  // A.K == B.K
-    TT_FATAL(ashape[-2] % TILE_HEIGHT == 0);
-    TT_FATAL(ashape[-1] % TILE_WIDTH == 0);
-    TT_FATAL(bshape[-2] % TILE_HEIGHT == 0);
-    TT_FATAL(bshape[-1] % TILE_WIDTH == 0);
+    TT_FATAL(ashape[-2] % TILE_HEIGHT == 0, "Error");
+    TT_FATAL(ashape[-1] % TILE_WIDTH == 0, "Error");
+    TT_FATAL(bshape[-2] % TILE_HEIGHT == 0, "Error");
+    TT_FATAL(bshape[-1] % TILE_WIDTH == 0, "Error");
 
     MathFidelity math_fidelity;
     bool math_approx_mode;
@@ -1197,7 +1197,7 @@ operation::ProgramWithCallbacks matmul_multi_core_reuse_dram_sharded_optimized_(
                 fp32_dest_acc_en = compute_kernel_config.fp32_dest_acc_en;
                 packer_l1_acc = compute_kernel_config.packer_l1_acc;
             } else {
-                TT_FATAL(false, "arch not supported");
+                TT_THROW("arch not supported");
             }
         },
         compute_kernel_config);
@@ -1212,7 +1212,7 @@ operation::ProgramWithCallbacks matmul_multi_core_reuse_dram_sharded_optimized_(
     uint32_t Kt = ashape[-1] / TILE_WIDTH;
     uint32_t Nt = bshape[-1] / TILE_WIDTH;
 
-    TT_FATAL(Kt % in0_block_w == 0);
+    TT_FATAL(Kt % in0_block_w == 0, "Error");
 
     ////////////////////////////////////////////////////////////////////////////
     //                      Grayskull Device Setup

--- a/ttnn/cpp/ttnn/operations/matmul/device/matmul_op_multi_core_reuse_mcast_dram_sharded_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/matmul_op_multi_core_reuse_mcast_dram_sharded_program_factory.cpp
@@ -376,7 +376,6 @@ operation::ProgramWithCallbacks create_program_dram_sharded(
         get_dram_reader_core_coords_wormhole_b0(device, all_worker_cores, all_worker_cores_ordered);
     } else {
         get_dram_reader_core_coords_grayskull(device, all_worker_cores, all_worker_cores_ordered);
-        // TT_FATAL("not implemeted except for wormhole_b0 yet!");
     }
 
     // dram banks
@@ -1198,7 +1197,7 @@ operation::ProgramWithCallbacks matmul_multi_core_reuse_dram_sharded_optimized_(
                 fp32_dest_acc_en = compute_kernel_config.fp32_dest_acc_en;
                 packer_l1_acc = compute_kernel_config.packer_l1_acc;
             } else {
-                TT_FATAL("arch not supported");
+                TT_FATAL(false, "arch not supported");
             }
         },
         compute_kernel_config);

--- a/ttnn/cpp/ttnn/operations/matmul/device/matmul_op_multi_core_reuse_optimized_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/matmul_op_multi_core_reuse_optimized_program_factory.cpp
@@ -512,7 +512,7 @@ operation::ProgramWithCallbacks matmul_multi_core_reuse_optimized_(
                 fp32_dest_acc_en = compute_kernel_config.fp32_dest_acc_en;
                 packer_l1_acc = compute_kernel_config.packer_l1_acc;
             } else {
-                TT_FATAL("arch not supported");
+                TT_FATAL(false, "arch not supported");
             }
         },
         compute_kernel_config);

--- a/ttnn/cpp/ttnn/operations/matmul/device/matmul_op_multi_core_reuse_optimized_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/matmul_op_multi_core_reuse_optimized_program_factory.cpp
@@ -512,14 +512,14 @@ operation::ProgramWithCallbacks matmul_multi_core_reuse_optimized_(
                 fp32_dest_acc_en = compute_kernel_config.fp32_dest_acc_en;
                 packer_l1_acc = compute_kernel_config.packer_l1_acc;
             } else {
-                TT_FATAL(false, "arch not supported");
+                TT_THROW("arch not supported");
             }
         },
         compute_kernel_config);
 
     if (fp32_dest_acc_en) {
         TT_FATAL(
-            out_subblock_h * out_subblock_w <= 4 &&
+            out_subblock_h * out_subblock_w <= 4,
             "Total number of tiles in a subblock must be less than 4 when in fp32_dest_acc mode");
     }
 

--- a/ttnn/cpp/ttnn/operations/matmul/device/matmul_op_multi_core_reuse_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/matmul_op_multi_core_reuse_program_factory.cpp
@@ -269,9 +269,9 @@ operation::ProgramWithCallbacks matmul_multi_core_reuse(
     uint32_t per_core_M = 16;
     uint32_t per_core_N = 16;
 
-    TT_FATAL(Mt % per_core_M == 0);
-    TT_FATAL(Nt % per_core_N == 0);
-    TT_FATAL(Kt % in0_block_w == 0);
+    TT_FATAL(Mt % per_core_M == 0, "Error");
+    TT_FATAL(Nt % per_core_N == 0, "Error");
+    TT_FATAL(Kt % in0_block_w == 0, "Error");
 
     // This should allocate a DRAM buffer on the device
     tt_metal::Device *device = a.device();
@@ -280,7 +280,7 @@ operation::ProgramWithCallbacks matmul_multi_core_reuse(
     uint32_t num_cores_y = compute_with_storage_grid_size.y;
 
     uint32_t num_blocks_total = (Mt / per_core_M) * (Nt / per_core_N);
-    TT_FATAL(num_blocks_total <= num_cores_x * num_cores_y);
+    TT_FATAL(num_blocks_total <= num_cores_x * num_cores_y, "Error");
 
     ////////////////////////////////////////////////////////////////////////////
     //                      Grayskull Device Setup

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_arange/device/moreh_arange_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_arange/device/moreh_arange_device_operation.cpp
@@ -28,13 +28,13 @@ void MorehArangeOperation::validate_inputs(
     TT_FATAL(
         output_dtype == output_tensor->get_dtype(),
         "If output_tensor is provided as input, its dtype should match the output_dtype parameter.");
-    TT_FATAL(output_tensor->memory_config().memory_layout == TensorMemoryLayout::INTERLEAVED);
+    TT_FATAL(output_tensor->memory_config().memory_layout == TensorMemoryLayout::INTERLEAVED, "Error");
 
     auto output_layout = output_tensor->get_layout();
     if (operation_attributes.untilize_out) {
-        TT_FATAL(output_layout == Layout::ROW_MAJOR);
+        TT_FATAL(output_layout == Layout::ROW_MAJOR, "Error");
     } else {
-        TT_FATAL(output_layout == Layout::TILE);
+        TT_FATAL(output_layout == Layout::TILE, "Error");
     }
 }
 

--- a/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/groupnorm_op.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/groupnorm_op.cpp
@@ -22,7 +22,7 @@ void GroupNorm::validate(const std::vector<Tensor> &input_tensors, const std::ve
     const auto& gamma = optional_input_tensors.at(0);
     const auto& beta = optional_input_tensors.at(1);
     const auto& input_mask = optional_input_tensors.at(2);
-    TT_FATAL(a.get_dtype() == DataType::BFLOAT16);
+    TT_FATAL(a.get_dtype() == DataType::BFLOAT16, "Error");
     TT_FATAL(a.storage_type() == StorageType::DEVICE, "Operands to layernorm need to be on device!");
     TT_FATAL(a.buffer() != nullptr, "Operands to layernorm need to be allocated in buffers on device!");
     TT_FATAL(a.get_legacy_shape()[3] % this->num_groups == 0,  "channel must be divisible by num_groups!");
@@ -31,41 +31,41 @@ void GroupNorm::validate(const std::vector<Tensor> &input_tensors, const std::ve
     if (gamma.has_value()) {
         if (gamma.value().get_layout() == Layout::TILE) {
             TT_FATAL(a.get_legacy_shape()[3] == gamma.value().get_legacy_shape()[3], fmt::format("{} != {}", a.get_legacy_shape()[3], gamma.value().get_legacy_shape()[3]));
-            TT_FATAL(a.device() == gamma.value().device());
+            TT_FATAL(a.device() == gamma.value().device(), "Error");
             TT_FATAL(gamma.value().buffer() != nullptr, "Operands to layernorm need to be allocated in buffers on device!");
-            TT_FATAL(gamma.value().get_legacy_shape()[2] == TILE_HEIGHT);
+            TT_FATAL(gamma.value().get_legacy_shape()[2] == TILE_HEIGHT, "Error");
         } else {
-            TT_FATAL(gamma.value().get_layout() == Layout::ROW_MAJOR);
-            TT_FATAL((gamma.value().get_legacy_shape()[3] == TILE_WIDTH));
-            TT_FATAL(a.device() == gamma.value().device());
+            TT_FATAL(gamma.value().get_layout() == Layout::ROW_MAJOR, "Error");
+            TT_FATAL((gamma.value().get_legacy_shape()[3] == TILE_WIDTH), "Error");
+            TT_FATAL(a.device() == gamma.value().device(), "Error");
             TT_FATAL(gamma.value().buffer() != nullptr, "Operands to layernorm need to be allocated in buffers on device!");
-            TT_FATAL(gamma.value().get_dtype() == DataType::BFLOAT16);
+            TT_FATAL(gamma.value().get_dtype() == DataType::BFLOAT16, "Error");
         }
         if (beta.has_value()) {
-            TT_FATAL(gamma.value().get_layout() == beta.value().get_layout());
+            TT_FATAL(gamma.value().get_layout() == beta.value().get_layout(), "Error");
         }
     }
 
     if (beta.has_value()) {
         if (beta.value().get_layout() == Layout::TILE) {
-            TT_FATAL(a.get_legacy_shape()[3] == beta.value().get_legacy_shape()[3]);
-            TT_FATAL(a.device() == beta.value().device());
+            TT_FATAL(a.get_legacy_shape()[3] == beta.value().get_legacy_shape()[3], "Error");
+            TT_FATAL(a.device() == beta.value().device(), "Error");
             TT_FATAL(beta.value().buffer() != nullptr, "Operands to layernorm need to be allocated in buffers on device!");
-            TT_FATAL(beta.value().get_legacy_shape()[2] == TILE_HEIGHT);
+            TT_FATAL(beta.value().get_legacy_shape()[2] == TILE_HEIGHT, "Error");
         } else {
-            TT_FATAL(beta.value().get_layout() == Layout::ROW_MAJOR);
-            TT_FATAL(beta.value().get_legacy_shape()[3] == TILE_WIDTH);
-            TT_FATAL(a.device() == beta.value().device());
+            TT_FATAL(beta.value().get_layout() == Layout::ROW_MAJOR, "Error");
+            TT_FATAL(beta.value().get_legacy_shape()[3] == TILE_WIDTH, "Error");
+            TT_FATAL(a.device() == beta.value().device(), "Error");
             TT_FATAL(beta.value().buffer() != nullptr, "Operands to layernorm need to be allocated in buffers on device!");
-            TT_FATAL(beta.value().get_dtype() == DataType::BFLOAT16);
+            TT_FATAL(beta.value().get_dtype() == DataType::BFLOAT16, "Error");
         }
     }
 
     if (input_mask.has_value()) {
-        TT_FATAL(input_mask.value().get_layout() == Layout::TILE);
-        TT_FATAL(input_mask.value().get_legacy_shape()[1] == this->num_groups);
-        TT_FATAL(input_mask.value().get_legacy_shape()[2] == TILE_HEIGHT);
-        TT_FATAL(input_mask.value().get_legacy_shape()[3] % TILE_WIDTH == 0);
+        TT_FATAL(input_mask.value().get_layout() == Layout::TILE, "Error");
+        TT_FATAL(input_mask.value().get_legacy_shape()[1] == this->num_groups, "Error");
+        TT_FATAL(input_mask.value().get_legacy_shape()[2] == TILE_HEIGHT, "Error");
+        TT_FATAL(input_mask.value().get_legacy_shape()[3] % TILE_WIDTH == 0, "Error");
     }
 }
 std::vector<tt::tt_metal::Shape> GroupNorm::compute_output_shapes(const std::vector<Tensor> &input_tensors) const {

--- a/ttnn/cpp/ttnn/operations/normalization/layernorm/device/layernorm_op.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/layernorm/device/layernorm_op.cpp
@@ -21,8 +21,8 @@ void LayerNorm::validate(const std::vector<Tensor> &input_tensors, const std::ve
     const auto& b = optional_input_tensors.at(0);
     const auto& gamma = optional_input_tensors.at(1);
     const auto& beta = optional_input_tensors.at(2);
-    TT_FATAL(a.get_layout() == Layout::TILE);
-    TT_FATAL(a.get_dtype() == DataType::FLOAT32 or a.get_dtype() == DataType::BFLOAT16 or a.get_dtype() == DataType::BFLOAT8_B);
+    TT_FATAL(a.get_layout() == Layout::TILE, "Error");
+    TT_FATAL(a.get_dtype() == DataType::FLOAT32 or a.get_dtype() == DataType::BFLOAT16 or a.get_dtype() == DataType::BFLOAT8_B, "Error");
     TT_FATAL(a.storage_type() == StorageType::DEVICE, "Operands to layernorm need to be on device!");
     TT_FATAL(a.buffer() != nullptr, "Operands to layernorm need to be allocated in buffers on device!");
 
@@ -37,14 +37,14 @@ void LayerNorm::validate(const std::vector<Tensor> &input_tensors, const std::ve
         if (gamma.value().get_layout() == Layout::TILE) {
             TT_FATAL(a.get_legacy_shape()[-1] == gamma.value().get_legacy_shape()[-1], fmt::format("{} != {}", a.get_legacy_shape()[-1], gamma.value().get_legacy_shape()[-1]));
             TT_FATAL(gamma.value().buffer() != nullptr, "Operands to layernorm need to be allocated in buffers on device!");
-            TT_FATAL(a.device() == gamma.value().device());
-            TT_FATAL(gamma.value().get_legacy_shape()[-2] == TILE_HEIGHT);
+            TT_FATAL(a.device() == gamma.value().device(), "Error");
+            TT_FATAL(gamma.value().get_legacy_shape()[-2] == TILE_HEIGHT, "Error");
         } else {
-            TT_FATAL(gamma.value().get_layout() == Layout::ROW_MAJOR);
-            TT_FATAL((gamma.value().get_legacy_shape()[-1] == TILE_WIDTH && gamma.value().volume() / TILE_WIDTH == a.get_legacy_shape()[-1] / TILE_WIDTH));
+            TT_FATAL(gamma.value().get_layout() == Layout::ROW_MAJOR, "Error");
+            TT_FATAL((gamma.value().get_legacy_shape()[-1] == TILE_WIDTH && gamma.value().volume() / TILE_WIDTH == a.get_legacy_shape()[-1] / TILE_WIDTH), "Error");
             TT_FATAL(gamma.value().buffer() != nullptr, "Operands to layernorm need to be allocated in buffers on device!");
-            TT_FATAL(a.device() == gamma.value().device());
-            TT_FATAL(gamma.value().get_dtype() == DataType::FLOAT32 or gamma.value().get_dtype() == DataType::BFLOAT16);
+            TT_FATAL(a.device() == gamma.value().device(), "Error");
+            TT_FATAL(gamma.value().get_dtype() == DataType::FLOAT32 or gamma.value().get_dtype() == DataType::BFLOAT16, "Error");
         }
         if (beta.has_value()) {
             TT_FATAL(gamma.value().get_layout() == beta.value().get_layout(), "Gamma and beta must have the same layout!");
@@ -53,22 +53,22 @@ void LayerNorm::validate(const std::vector<Tensor> &input_tensors, const std::ve
 
     if (beta.has_value()) {
         if (beta.value().get_layout() == Layout::TILE) {
-            TT_FATAL(a.get_legacy_shape()[-1] == beta.value().get_legacy_shape()[-1]);
+            TT_FATAL(a.get_legacy_shape()[-1] == beta.value().get_legacy_shape()[-1], "Error");
             TT_FATAL(beta.value().buffer() != nullptr, "Operands to layernorm need to be allocated in buffers on device!");
-            TT_FATAL(a.device() == beta.value().device());
-            TT_FATAL(beta.value().get_legacy_shape()[-2] == TILE_HEIGHT);
+            TT_FATAL(a.device() == beta.value().device(), "Error");
+            TT_FATAL(beta.value().get_legacy_shape()[-2] == TILE_HEIGHT, "Error");
         } else {
-            TT_FATAL(beta.value().get_layout() == Layout::ROW_MAJOR);
-            TT_FATAL((beta.value().get_legacy_shape()[-1] == TILE_WIDTH && beta.value().volume() / TILE_WIDTH == a.get_legacy_shape()[-1] / TILE_WIDTH));
+            TT_FATAL(beta.value().get_layout() == Layout::ROW_MAJOR, "Error");
+            TT_FATAL((beta.value().get_legacy_shape()[-1] == TILE_WIDTH && beta.value().volume() / TILE_WIDTH == a.get_legacy_shape()[-1] / TILE_WIDTH), "Error");
             TT_FATAL(beta.value().buffer() != nullptr, "Operands to layernorm need to be allocated in buffers on device!");
-            TT_FATAL(a.device() == beta.value().device());
-            TT_FATAL(beta.value().get_dtype() == DataType::FLOAT32 or beta.value().get_dtype() == DataType::BFLOAT16);
+            TT_FATAL(a.device() == beta.value().device(), "Error");
+            TT_FATAL(beta.value().get_dtype() == DataType::FLOAT32 or beta.value().get_dtype() == DataType::BFLOAT16, "Error");
         }
     }
     if (a.is_sharded()) {
         // TODO: Add support for this (should be similar to interleaved)
-        TT_FATAL(a.memory_config().memory_layout != TensorMemoryLayout::HEIGHT_SHARDED);
-        TT_FATAL(this->output_mem_config.is_sharded() && this->output_mem_config.memory_layout != TensorMemoryLayout::HEIGHT_SHARDED);
+        TT_FATAL(a.memory_config().memory_layout != TensorMemoryLayout::HEIGHT_SHARDED, "Error");
+        TT_FATAL(this->output_mem_config.is_sharded() && this->output_mem_config.memory_layout != TensorMemoryLayout::HEIGHT_SHARDED, "Error");
     }
     std::visit(
         [&](const auto& program_config) {
@@ -77,10 +77,10 @@ void LayerNorm::validate(const std::vector<Tensor> &input_tensors, const std::ve
                 std::is_same_v<ProgramConfigType, LayerNormShardedMultiCoreProgramConfig>
             ) {
                 if (program_config.inplace) {
-                    TT_FATAL(this->output_mem_config.is_sharded());
+                    TT_FATAL(this->output_mem_config.is_sharded(), "Error");
                 }
-                TT_FATAL(a.memory_config().buffer_type == this->output_mem_config.buffer_type);
-                TT_FATAL(a.memory_config().memory_layout == this->output_mem_config.memory_layout);
+                TT_FATAL(a.memory_config().buffer_type == this->output_mem_config.buffer_type, "Error");
+                TT_FATAL(a.memory_config().memory_layout == this->output_mem_config.memory_layout, "Error");
 
                 // tensor shape
                 const auto shape = a.get_legacy_shape();
@@ -98,14 +98,14 @@ void LayerNorm::validate(const std::vector<Tensor> &input_tensors, const std::ve
                 TT_FATAL(M % TILE_HEIGHT == 0, "M must be divisible by tile height.");
                 TT_FATAL(K % TILE_WIDTH == 0, "K must be divisible by tile width.");
                 const auto bbox = shard_spec.grid.bounding_box();
-                TT_FATAL(bbox.end_coord.x < program_config.compute_with_storage_grid_size.x && bbox.end_coord.y < program_config.compute_with_storage_grid_size.y);
+                TT_FATAL(bbox.end_coord.x < program_config.compute_with_storage_grid_size.x && bbox.end_coord.y < program_config.compute_with_storage_grid_size.y, "Error");
 
                 bool mcast_1d = M == block_h;
                 bool row_wise = shard_spec.orientation == ShardOrientation::ROW_MAJOR;
                 if (mcast_1d) {
                     TT_FATAL(tt::div_up(Kt, shard_spec.num_cores()) == program_config.block_w, "block_w must equal to K / num_cores.");
                     TT_FATAL(Mt == program_config.block_h, "block_h must equal to M.");
-                    TT_FATAL(a.memory_config().memory_layout != TensorMemoryLayout::HEIGHT_SHARDED);
+                    TT_FATAL(a.memory_config().memory_layout != TensorMemoryLayout::HEIGHT_SHARDED, "Error");
                 } else {
                     if (row_wise) {
                         TT_FATAL(tt::div_up(Kt, (bbox.end_coord.x + 1)) == program_config.block_w, "block_w must equal to K / num_cores_c.");
@@ -116,11 +116,11 @@ void LayerNorm::validate(const std::vector<Tensor> &input_tensors, const std::ve
                     }
                 }
                 if (b.has_value()) {
-                    TT_FATAL(b.value().is_sharded());
-                    TT_FATAL(b.value().shard_spec() == shard_spec);
+                    TT_FATAL(b.value().is_sharded(), "Error");
+                    TT_FATAL(b.value().shard_spec() == shard_spec, "Error");
                 }
-                TT_FATAL(program_config.block_h * TILE_HEIGHT == shard_spec.shape[0]);
-                TT_FATAL(program_config.block_w * TILE_WIDTH == shard_spec.shape[1]);
+                TT_FATAL(program_config.block_h * TILE_HEIGHT == shard_spec.shape[0], "Error");
+                TT_FATAL(program_config.block_w * TILE_WIDTH == shard_spec.shape[1], "Error");
                 TT_FATAL(program_config.block_w % program_config.subblock_w == 0, "block_w must be divisible by subblock_w.");
             }
         },

--- a/ttnn/cpp/ttnn/operations/normalization/layernorm/device/multi_core/layernorm_op_multi_core.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/layernorm/device/multi_core/layernorm_op_multi_core.cpp
@@ -95,7 +95,7 @@ operation::ProgramWithCallbacks layernorm_multi_core(
             math_approx_mode = compute_kernel_config.math_approx_mode;
             fp32_dest_acc_en = tt::tt_metal::datatype_to_dataformat_converter(a.get_dtype()) == tt::DataFormat::Float32 ? true : compute_kernel_config.fp32_dest_acc_en;
         } else {
-            TT_FATAL("arch not supported");
+            TT_FATAL(false, "arch not supported");
         }
 
     }, compute_kernel_config);
@@ -451,7 +451,7 @@ operation::ProgramWithCallbacks layernorm_multi_core_sharded(
             math_approx_mode = compute_kernel_config.math_approx_mode;
             fp32_dest_acc_en = in_data_format == tt::DataFormat::Float32 ? true : compute_kernel_config.fp32_dest_acc_en;
         } else {
-            TT_FATAL("arch not supported");
+            TT_FATAL(false, "arch not supported");
         }
 
     }, compute_kernel_config);

--- a/ttnn/cpp/ttnn/operations/normalization/layernorm/device/multi_core/layernorm_op_multi_core.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/layernorm/device/multi_core/layernorm_op_multi_core.cpp
@@ -95,7 +95,7 @@ operation::ProgramWithCallbacks layernorm_multi_core(
             math_approx_mode = compute_kernel_config.math_approx_mode;
             fp32_dest_acc_en = tt::tt_metal::datatype_to_dataformat_converter(a.get_dtype()) == tt::DataFormat::Float32 ? true : compute_kernel_config.fp32_dest_acc_en;
         } else {
-            TT_FATAL(false, "arch not supported");
+            TT_THROW("arch not supported");
         }
 
     }, compute_kernel_config);
@@ -451,7 +451,7 @@ operation::ProgramWithCallbacks layernorm_multi_core_sharded(
             math_approx_mode = compute_kernel_config.math_approx_mode;
             fp32_dest_acc_en = in_data_format == tt::DataFormat::Float32 ? true : compute_kernel_config.fp32_dest_acc_en;
         } else {
-            TT_FATAL(false, "arch not supported");
+            TT_THROW("arch not supported");
         }
 
     }, compute_kernel_config);

--- a/ttnn/cpp/ttnn/operations/normalization/layernorm_distributed/device/layernorm_post_all_gather_op.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/layernorm_distributed/device/layernorm_post_all_gather_op.cpp
@@ -29,54 +29,54 @@ void LayerNormPostAllGather::validate(const std::vector<Tensor> &input_tensors, 
     const auto& beta = optional_input_tensors.at(1);
 
     for (const auto& tensor: input_tensors) {
-        TT_FATAL(tensor.get_layout() == Layout::TILE);
-        TT_FATAL(tensor.get_dtype() == DataType::BFLOAT16 || tensor.get_dtype() == DataType::BFLOAT8_B);
+        TT_FATAL(tensor.get_layout() == Layout::TILE, "Error");
+        TT_FATAL(tensor.get_dtype() == DataType::BFLOAT16 || tensor.get_dtype() == DataType::BFLOAT8_B, "Error");
         TT_FATAL(tensor.storage_type() == StorageType::DEVICE, "Operands to layernorm need to be on device!");
         TT_FATAL(tensor.buffer() != nullptr, "Operands to layernorm need to be allocated in buffers on device!");
     }
 
     // stats has 2 or 1 tile columns per device if layernorm or rmsnorm
-    TT_FATAL(stats.get_legacy_shape()[-1] % TILE_WIDTH == 0);
-    TT_FATAL(stats.get_legacy_shape()[0] == a.get_legacy_shape()[0]);
-    TT_FATAL(stats.get_legacy_shape()[1] == a.get_legacy_shape()[1]);
-    TT_FATAL(stats.get_legacy_shape()[2] == a.get_legacy_shape()[2]);
+    TT_FATAL(stats.get_legacy_shape()[-1] % TILE_WIDTH == 0, "Error");
+    TT_FATAL(stats.get_legacy_shape()[0] == a.get_legacy_shape()[0], "Error");
+    TT_FATAL(stats.get_legacy_shape()[1] == a.get_legacy_shape()[1], "Error");
+    TT_FATAL(stats.get_legacy_shape()[2] == a.get_legacy_shape()[2], "Error");
     // TODO: How to check if number of tile columns is correct? Would have to know # of devices and is_rmsnorm
 
-    TT_FATAL(gamma.has_value());
+    TT_FATAL(gamma.has_value(), "Error");
     const auto& gamma_tensor = gamma.value();
 
-    TT_FATAL(gamma_tensor.get_layout() == Layout::ROW_MAJOR); // Only support packed RM right now
+    TT_FATAL(gamma_tensor.get_layout() == Layout::ROW_MAJOR, "Error"); // Only support packed RM right now
     if (gamma_tensor.get_layout() == Layout::TILE) {
         TT_FATAL(a.get_legacy_shape()[-1] == gamma.value().get_legacy_shape()[-1], fmt::format("{} != {}", a.get_legacy_shape()[-1], gamma.value().get_legacy_shape()[-1]));
         TT_FATAL(gamma.value().buffer() != nullptr, "Operands to layernorm need to be allocated in buffers on device!");
-        TT_FATAL(a.device() == gamma.value().device());
-        TT_FATAL(gamma.value().get_legacy_shape()[-2] == TILE_HEIGHT);
+        TT_FATAL(a.device() == gamma.value().device(), "Error");
+        TT_FATAL(gamma.value().get_legacy_shape()[-2] == TILE_HEIGHT, "Error");
     } else {
-        TT_FATAL(gamma_tensor.get_layout() == Layout::ROW_MAJOR);
-        TT_FATAL((gamma_tensor.get_legacy_shape()[-1] == TILE_WIDTH && gamma_tensor.volume() / TILE_WIDTH == a.get_legacy_shape()[-1] / TILE_WIDTH));
+        TT_FATAL(gamma_tensor.get_layout() == Layout::ROW_MAJOR, "Error");
+        TT_FATAL((gamma_tensor.get_legacy_shape()[-1] == TILE_WIDTH && gamma_tensor.volume() / TILE_WIDTH == a.get_legacy_shape()[-1] / TILE_WIDTH), "Error");
         TT_FATAL(gamma_tensor.buffer() != nullptr, "Operands to layernorm need to be allocated in buffers on device!");
-        TT_FATAL(a.device() == gamma_tensor.device());
-        TT_FATAL(gamma_tensor.get_dtype() == DataType::BFLOAT16);
+        TT_FATAL(a.device() == gamma_tensor.device(), "Error");
+        TT_FATAL(gamma_tensor.get_dtype() == DataType::BFLOAT16, "Error");
     }
     const bool is_layernorm = this->norm_type == LayerNormDistributedType::LAYERNORM;
     const bool has_beta = beta.has_value();
-    TT_FATAL(is_layernorm == has_beta); // TODO: Is this a necessary check?
+    TT_FATAL(is_layernorm == has_beta, "Error"); // TODO: Is this a necessary check?
 
     if (beta.has_value()) {
         const auto& beta_tensor = beta.value();
         TT_FATAL(gamma_tensor.get_layout() == beta_tensor.get_layout(), "Gamma and beta must have the same layout!");
-        TT_FATAL(beta_tensor.get_layout() == Layout::ROW_MAJOR);
+        TT_FATAL(beta_tensor.get_layout() == Layout::ROW_MAJOR, "Error");
         if (beta_tensor.get_layout() == Layout::TILE) {
-            TT_FATAL(a.get_legacy_shape()[-1] == beta_tensor.get_legacy_shape()[-1]);
+            TT_FATAL(a.get_legacy_shape()[-1] == beta_tensor.get_legacy_shape()[-1], "Error");
             TT_FATAL(beta_tensor.buffer() != nullptr, "Operands to layernorm need to be allocated in buffers on device!");
-            TT_FATAL(a.device() == beta_tensor.device());
-            TT_FATAL(beta.value().get_legacy_shape()[-2] == TILE_HEIGHT);
+            TT_FATAL(a.device() == beta_tensor.device(), "Error");
+            TT_FATAL(beta.value().get_legacy_shape()[-2] == TILE_HEIGHT, "Error");
         } else {
-            TT_FATAL(beta_tensor.get_layout() == Layout::ROW_MAJOR);
-            TT_FATAL((beta_tensor.get_legacy_shape()[-1] == TILE_WIDTH && beta_tensor.volume() / TILE_WIDTH == a.get_legacy_shape()[-1] / TILE_WIDTH));
+            TT_FATAL(beta_tensor.get_layout() == Layout::ROW_MAJOR, "Error");
+            TT_FATAL((beta_tensor.get_legacy_shape()[-1] == TILE_WIDTH && beta_tensor.volume() / TILE_WIDTH == a.get_legacy_shape()[-1] / TILE_WIDTH), "Error");
             TT_FATAL(beta_tensor.buffer() != nullptr, "Operands to layernorm need to be allocated in buffers on device!");
-            TT_FATAL(a.device() == beta_tensor.device());
-            TT_FATAL(beta_tensor.get_dtype() == DataType::BFLOAT16);
+            TT_FATAL(a.device() == beta_tensor.device(), "Error");
+            TT_FATAL(beta_tensor.get_dtype() == DataType::BFLOAT16, "Error");
         }
     }
 }

--- a/ttnn/cpp/ttnn/operations/normalization/layernorm_distributed/device/multi_core/layernorm_post_all_gather_op_multi_core.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/layernorm_distributed/device/multi_core/layernorm_post_all_gather_op_multi_core.cpp
@@ -108,7 +108,7 @@ operation::ProgramWithCallbacks layernorm_post_allgather_multi_core(
             math_approx_mode = compute_kernel_config.math_approx_mode;
             fp32_dest_acc_en = tt::tt_metal::datatype_to_dataformat_converter(a.get_dtype()) == tt::DataFormat::Float32 ? true : compute_kernel_config.fp32_dest_acc_en;
         } else {
-            TT_FATAL(false, "arch not supported");
+            TT_THROW("arch not supported");
         }
 
     }, compute_kernel_config);

--- a/ttnn/cpp/ttnn/operations/normalization/layernorm_distributed/device/multi_core/layernorm_post_all_gather_op_multi_core.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/layernorm_distributed/device/multi_core/layernorm_post_all_gather_op_multi_core.cpp
@@ -108,7 +108,7 @@ operation::ProgramWithCallbacks layernorm_post_allgather_multi_core(
             math_approx_mode = compute_kernel_config.math_approx_mode;
             fp32_dest_acc_en = tt::tt_metal::datatype_to_dataformat_converter(a.get_dtype()) == tt::DataFormat::Float32 ? true : compute_kernel_config.fp32_dest_acc_en;
         } else {
-            TT_FATAL("arch not supported");
+            TT_FATAL(false, "arch not supported");
         }
 
     }, compute_kernel_config);

--- a/ttnn/cpp/ttnn/operations/normalization/layernorm_distributed/device/multi_core/layernorm_pre_all_gather_op_multi_core.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/layernorm_distributed/device/multi_core/layernorm_pre_all_gather_op_multi_core.cpp
@@ -96,7 +96,7 @@ operation::ProgramWithCallbacks layernorm_pre_allgather_multi_core(
             math_approx_mode = compute_kernel_config.math_approx_mode;
             fp32_dest_acc_en = tt::tt_metal::datatype_to_dataformat_converter(a.get_dtype()) == tt::DataFormat::Float32 ? true : compute_kernel_config.fp32_dest_acc_en;
         } else {
-            TT_FATAL(false, "arch not supported");
+            TT_THROW("arch not supported");
         }
 
     }, compute_kernel_config);

--- a/ttnn/cpp/ttnn/operations/normalization/layernorm_distributed/device/multi_core/layernorm_pre_all_gather_op_multi_core.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/layernorm_distributed/device/multi_core/layernorm_pre_all_gather_op_multi_core.cpp
@@ -96,7 +96,7 @@ operation::ProgramWithCallbacks layernorm_pre_allgather_multi_core(
             math_approx_mode = compute_kernel_config.math_approx_mode;
             fp32_dest_acc_en = tt::tt_metal::datatype_to_dataformat_converter(a.get_dtype()) == tt::DataFormat::Float32 ? true : compute_kernel_config.fp32_dest_acc_en;
         } else {
-            TT_FATAL("arch not supported");
+            TT_FATAL(false, "arch not supported");
         }
 
     }, compute_kernel_config);

--- a/ttnn/cpp/ttnn/operations/normalization/softmax/device/multi_core/softmax_op_multi_core.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/softmax/device/multi_core/softmax_op_multi_core.cpp
@@ -83,7 +83,7 @@ operation::ProgramWithCallbacks scale_mask_softmax_multi_core(
             math_approx_mode = compute_kernel_config.math_approx_mode;
             fp32_dest_acc_en = in0_cb_data_format == tt::DataFormat::Float32 ? true : compute_kernel_config.fp32_dest_acc_en;
         } else {
-            TT_FATAL("arch not supported");
+            TT_FATAL(false, "arch not supported");
         }
 
     }, compute_kernel_config);
@@ -481,7 +481,7 @@ operation::ProgramWithCallbacks scale_mask_softmax_sharded_multi_core(
             if (fp32_dest_acc_en)
                 TT_FATAL(subblock_wt <= 4, "in fp32 mode, subblock width must be smaller/equal than 4");
         } else {
-            TT_FATAL("arch not supported");
+            TT_FATAL(false, "arch not supported");
         }
 
     }, compute_kernel_config);

--- a/ttnn/cpp/ttnn/operations/normalization/softmax/device/multi_core/softmax_op_multi_core.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/softmax/device/multi_core/softmax_op_multi_core.cpp
@@ -83,7 +83,7 @@ operation::ProgramWithCallbacks scale_mask_softmax_multi_core(
             math_approx_mode = compute_kernel_config.math_approx_mode;
             fp32_dest_acc_en = in0_cb_data_format == tt::DataFormat::Float32 ? true : compute_kernel_config.fp32_dest_acc_en;
         } else {
-            TT_FATAL(false, "arch not supported");
+            TT_THROW("arch not supported");
         }
 
     }, compute_kernel_config);
@@ -481,7 +481,7 @@ operation::ProgramWithCallbacks scale_mask_softmax_sharded_multi_core(
             if (fp32_dest_acc_en)
                 TT_FATAL(subblock_wt <= 4, "in fp32 mode, subblock width must be smaller/equal than 4");
         } else {
-            TT_FATAL(false, "arch not supported");
+            TT_THROW("arch not supported");
         }
 
     }, compute_kernel_config);

--- a/ttnn/cpp/ttnn/operations/normalization/softmax/device/softmax_op.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/softmax/device/softmax_op.cpp
@@ -29,22 +29,22 @@ void Softmax::validate(const std::vector<Tensor> &input_tensors, const std::vect
     TT_FATAL(input_tensor.storage_type() == StorageType::DEVICE, "Operands to softmax need to be on device!");
     TT_FATAL(input_tensor.buffer() != nullptr , "Operands to softmax need to be allocated in buffers on device!");
     TT_FATAL((input_tensor.get_layout() == Layout::TILE), "Inputs to softmax must be tilized");
-    TT_FATAL(input_tensor.get_dtype() == DataType::FLOAT32 || input_tensor.get_dtype() == DataType::BFLOAT16 || input_tensor.get_dtype() == DataType::BFLOAT8_B);
+    TT_FATAL(input_tensor.get_dtype() == DataType::FLOAT32 || input_tensor.get_dtype() == DataType::BFLOAT16 || input_tensor.get_dtype() == DataType::BFLOAT8_B, "Error");
     if (optional_input_tensors.size() == 1) {
         if (optional_input_tensors.at(0).has_value()) {
             auto& mask = optional_input_tensors.at(0).value();
             TT_FATAL(mask.storage_type() == StorageType::DEVICE, "Operands to softmax need to be on device!");
-            TT_FATAL(input_tensor.device() == mask.device());
+            TT_FATAL(input_tensor.device() == mask.device(), "Error");
             if (mask.is_sharded()) { // sharded mask
-                TT_FATAL(mask.get_layout() == Layout::TILE);
-                TT_FATAL(mask.get_legacy_shape() == input_tensor.get_legacy_shape());
+                TT_FATAL(mask.get_layout() == Layout::TILE, "Error");
+                TT_FATAL(mask.get_legacy_shape() == input_tensor.get_legacy_shape(), "Error");
             } else {
                 if (mask.get_layout() == Layout::ROW_MAJOR) {
                     tt::tt_metal::Shape expected_shape = {mask.get_legacy_shape()[0], 1, input_tensor.get_legacy_shape()[-1] / TILE_WIDTH, TILE_WIDTH};
-                    TT_FATAL(mask.get_legacy_shape() == expected_shape);
+                    TT_FATAL(mask.get_legacy_shape() == expected_shape, "Error");
                 }
                 for (uint32_t i = 1; i < input_tensor.get_legacy_shape().rank() - 2; i++) {
-                    TT_FATAL(mask.get_legacy_shape()[i] == 1);
+                    TT_FATAL(mask.get_legacy_shape()[i] == 1, "Error");
                 }
             }
 
@@ -54,8 +54,8 @@ void Softmax::validate(const std::vector<Tensor> &input_tensors, const std::vect
                     if constexpr (
                         std::is_same_v<ProgramConfigType, SoftmaxDefaultProgramConfig>
                     ) {
-                        TT_FATAL(input_tensor.get_legacy_shape()[0] == mask.get_legacy_shape()[0]);
-                        TT_FATAL(!this->is_scale_causal_mask_hw_dims_softmax);
+                        TT_FATAL(input_tensor.get_legacy_shape()[0] == mask.get_legacy_shape()[0], "Error");
+                        TT_FATAL(!this->is_scale_causal_mask_hw_dims_softmax, "Error");
                     } else if constexpr (
                         std::is_same_v<ProgramConfigType, SoftmaxShardedMultiCoreProgramConfig>
                     ) {
@@ -67,7 +67,7 @@ void Softmax::validate(const std::vector<Tensor> &input_tensors, const std::vect
                         TT_FATAL(K % TILE_WIDTH == 0, "K must be divisible by tile width.");
                         TT_FATAL(program_config.block_w % program_config.subblock_w == 0, "block_w must be divisible by subblock_w.");
                         TT_FATAL(program_config.block_w * TILE_WIDTH == shape[3], "shard width must equal to input tensor shape[3]!");
-                        TT_FATAL(this->inplace);
+                        TT_FATAL(this->inplace, "Error");
                         if (!this->is_scale_causal_mask_hw_dims_softmax) {
                             // grid
                             auto num_cores_c = program_config.compute_with_storage_grid_size.x;
@@ -75,24 +75,24 @@ void Softmax::validate(const std::vector<Tensor> &input_tensors, const std::vect
                             // check dims
                             TT_FATAL(M * K / ((program_config.block_w * program_config.block_h) * TILE_HW) == num_cores_r * num_cores_c, "number of shards must equal to number of cores. M = {}, K = {}, block_w = {}, block_h = {}, num_cores = {}", M, K, program_config.block_w, program_config.block_h, num_cores_r * num_cores_c);
                         } else {
-                            TT_FATAL(this->is_causal_mask);
-                            TT_FATAL(mask.get_layout() == Layout::TILE);
-                            TT_FATAL(mask.is_sharded() == false);
-                            TT_FATAL(input_tensor.get_layout() == Layout::TILE);
-                            TT_FATAL(input_tensor.is_sharded());
-                            TT_FATAL(input_tensor.shard_spec()->orientation == ShardOrientation::ROW_MAJOR);
-                            TT_FATAL(this->scale.has_value());
+                            TT_FATAL(this->is_causal_mask, "Error");
+                            TT_FATAL(mask.get_layout() == Layout::TILE, "Error");
+                            TT_FATAL(mask.is_sharded() == false, "Error");
+                            TT_FATAL(input_tensor.get_layout() == Layout::TILE, "Error");
+                            TT_FATAL(input_tensor.is_sharded(), "Error");
+                            TT_FATAL(input_tensor.shard_spec()->orientation == ShardOrientation::ROW_MAJOR, "Error");
+                            TT_FATAL(this->scale.has_value(), "Error");
                         }
                     }
                 },
                 this->program_config
             );
         } else {
-            TT_FATAL(not this->scale.has_value());
+            TT_FATAL(not this->scale.has_value(), "Error");
         }
     } else {
-        TT_FATAL(not this->scale.has_value());
-        TT_FATAL(not this->is_scale_causal_mask_hw_dims_softmax);
+        TT_FATAL(not this->scale.has_value(), "Error");
+        TT_FATAL(not this->is_scale_causal_mask_hw_dims_softmax, "Error");
     }
 }
 
@@ -201,11 +201,11 @@ Tensor scale_mask_softmax(const Tensor& input_tensor, std::optional<float> scale
             ttnn::operations::experimental::auto_format::FormatParams input_format_params = {.pad_shape=input_pad_shape, .pad_value=-std::numeric_limits<float>::infinity(), .target_layout=Layout::TILE};
             std::optional<ttnn::operations::experimental::auto_format::FormatParams> mask_format_params = std::nullopt;
             if (mask.has_value()) {
-                TT_FATAL(input_tensor.get_legacy_shape()[-1] == mask.value().get_legacy_shape()[-1]);
-                TT_FATAL(input_tensor.get_legacy_shape()[0] == mask.value().get_legacy_shape()[0]);
-                TT_FATAL(mask.value().get_legacy_shape()[-2] == 1 or mask.value().get_legacy_shape()[-2] == TILE_HEIGHT);
+                TT_FATAL(input_tensor.get_legacy_shape()[-1] == mask.value().get_legacy_shape()[-1], "Error");
+                TT_FATAL(input_tensor.get_legacy_shape()[0] == mask.value().get_legacy_shape()[0], "Error");
+                TT_FATAL(mask.value().get_legacy_shape()[-2] == 1 or mask.value().get_legacy_shape()[-2] == TILE_HEIGHT, "Error");
                 for (uint32_t i = 1; i < input_tensor.get_legacy_shape().rank() - 2; i++) {
-                    TT_FATAL(mask.value().get_legacy_shape()[i] == 1);
+                    TT_FATAL(mask.value().get_legacy_shape()[i] == 1, "Error");
                 }
                 tt::tt_metal::Shape mask_pad_shape = ttnn::operations::experimental::auto_format::AutoFormat::pad_to_tile_shape(mask.value().get_legacy_shape());
                 mask_format_params = {.pad_shape=mask_pad_shape, .pad_value=-std::numeric_limits<float>::infinity(), .target_layout=Layout::TILE};

--- a/ttnn/cpp/ttnn/operations/pool/downsample/device/downsample_op.cpp
+++ b/ttnn/cpp/ttnn/operations/pool/downsample/device/downsample_op.cpp
@@ -20,11 +20,13 @@ void Downsample::validate(const std::vector<Tensor>& input_tensors) const {
     TT_FATAL(input_tensor_a.buffer() != nullptr, "Operands to downsample need to be allocated in buffers on device!");
     TT_FATAL(input_tensor_a.get_layout() == Layout::TILE, "Can only downsample tile major data");
 
-    TT_FATAL(input_tensor_a.volume() % TILE_HW == 0);
-    TT_FATAL(input_tensor_a.memory_config().is_sharded());
+    TT_FATAL(input_tensor_a.volume() % TILE_HW == 0, "Error");
+    TT_FATAL(input_tensor_a.memory_config().is_sharded(), "Error");
     TT_FATAL(
         input_tensor_a.memory_config().memory_layout == TensorMemoryLayout::HEIGHT_SHARDED ||
-        input_tensor_a.memory_config().memory_layout == TensorMemoryLayout::BLOCK_SHARDED);
+        input_tensor_a.memory_config().memory_layout == TensorMemoryLayout::BLOCK_SHARDED,
+        "Unsupported memory layout {}.",
+        input_tensor_a.memory_config().memory_layout);
 }
 
 

--- a/ttnn/cpp/ttnn/operations/pool/maxpool/device/max_pool2d_multi_core_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/pool/maxpool/device/max_pool2d_multi_core_program_factory.cpp
@@ -72,7 +72,7 @@ MaxPool2D::MultiCore::cached_program_t max_pool_2d_multi_core_sharded_with_halo_
 
     uint32_t tile_w = tt::constants::TILE_WIDTH;
     if (input_shape[3] < tt::constants::TILE_WIDTH) {
-        TT_FATAL(input_shape[3] == 16);
+        TT_FATAL(input_shape[3] == 16, "Error");
         tile_w = tt::constants::FACE_WIDTH;
     }
     uint32_t out_w_loop_count = std::ceil((float)out_w / nblocks);
@@ -208,7 +208,7 @@ MaxPool2D::MultiCore::cached_program_t max_pool_2d_multi_core_sharded_with_halo_
     auto cb_out = tt::tt_metal::CreateCircularBuffer(program, all_cores, cb_out_config);
     log_debug(tt::LogOp, "CB {} :: PS = {}, NP = {}", out_cb_id, out_cb_pagesize, out_cb_npages);
 
-    TT_FATAL(output.memory_config().is_sharded());
+    TT_FATAL(output.memory_config().is_sharded(), "Error");
 
     #if 1
     {  // debug

--- a/ttnn/cpp/ttnn/operations/pool/upsample/device/upsample_op.cpp
+++ b/ttnn/cpp/ttnn/operations/pool/upsample/device/upsample_op.cpp
@@ -20,7 +20,7 @@ void UpSample::validate(const std::vector<Tensor> &input_tensors) const {
     const auto& input_tensor_a = input_tensors.at(0);
     TT_FATAL(input_tensor_a.storage_type() == StorageType::DEVICE, "Operands to copy need to be on device!");
     TT_FATAL(input_tensor_a.buffer() != nullptr , "Operands to copy need to be allocated in buffers on device!");
-    // TT_FATAL(input_tensor_a.memory_config().memory_layout == TensorMemoryLayout::INTERLEAVED);
+    // TT_FATAL(input_tensor_a.memory_config().memory_layout == TensorMemoryLayout::INTERLEAVED, "Error");
     TT_FATAL(input_tensor_a.get_layout() == Layout::ROW_MAJOR, "Input tensor layout should be ROW_MAJOR");
     TT_FATAL(input_tensor_a.get_dtype() == DataType::BFLOAT16, "Input tensor data type should be BFLOAT16");
     if (input_tensor_a.memory_config().is_sharded()) {

--- a/ttnn/cpp/ttnn/operations/pool/upsample/device/upsample_program_factory_multicore.cpp
+++ b/ttnn/cpp/ttnn/operations/pool/upsample/device/upsample_program_factory_multicore.cpp
@@ -69,7 +69,7 @@ operation::ProgramWithCallbacks upsample_multi_core(const Tensor &input, Tensor&
     // TODO: Support non-multiple case
     TT_FATAL(in_nsticks_per_core == input_nsticks_per_core, "Input sticks per shard {} should be same as input sticks per core {}", in_nsticks_per_core, input_nsticks_per_core);
     TT_FATAL(out_nsticks_per_core == output_nsticks_per_core, "Output sticks per shard {} should be same as output sticks per core {}", out_nsticks_per_core, output_nsticks_per_core);
-    TT_FATAL(input_nsticks_per_core % in_w == 0);
+    TT_FATAL(input_nsticks_per_core % in_w == 0, "Error");
 
     // CBs
 

--- a/ttnn/cpp/ttnn/operations/pool/upsample/upsample.cpp
+++ b/ttnn/cpp/ttnn/operations/pool/upsample/upsample.cpp
@@ -24,19 +24,19 @@ ttnn::Tensor ExecuteUpSample::invoke(const ttnn::Tensor& input_tensor,
                 } else if constexpr (std::is_same_v<T, tt::tt_metal::Array2D>) {
                     scale_w = sf.at(0);
                     int scale_c = sf.at(1);
-                    TT_FATAL(scale_c == 1);
+                    TT_FATAL(scale_c == 1, "Error");
                 } else if constexpr (std::is_same_v<T, tt::tt_metal::Array3D>) {
                     scale_h = sf.at(0);
                     scale_w = sf.at(1);
                     int scale_c = sf.at(2);
-                    TT_FATAL(scale_c == 1);
+                    TT_FATAL(scale_c == 1, "Error");
                 } else if constexpr (std::is_same_v<T, tt::tt_metal::Array4D>) {
                     int scale_n = sf.at(0);
                     scale_h = sf.at(1);
                     scale_w = sf.at(2);
                     int scale_c = sf.at(3);
-                    TT_FATAL(scale_n == 1);
-                    TT_FATAL(scale_c == 1);
+                    TT_FATAL(scale_n == 1, "Error");
+                    TT_FATAL(scale_c == 1, "Error");
                 } else {
                     // static_assert(false, "Unsupported scale factor");
                     static_assert(sizeof(T) != 0, "Type check failed.");
@@ -48,14 +48,14 @@ ttnn::Tensor ExecuteUpSample::invoke(const ttnn::Tensor& input_tensor,
         // fmt::print("scale_h: {}, scale_w: {}\n", scale_h, scale_w);
 
         if (input_tensor.is_sharded()) {
-            // TT_FATAL(not input_tensor.is_sharded());
+            // TT_FATAL(not input_tensor.is_sharded(), "Error");
             int shard_height = input_tensor.memory_config().shard_spec.value().shape[0];
             const auto batch_size = input_tensor.get_shape()[0];
             const auto input_h = input_tensor.get_shape()[1];
             const auto input_w = input_tensor.get_shape()[2];
             const auto num_channels = input_tensor.get_shape()[3];
             if (shard_height % input_w != 0) {
-                TT_FATAL(shard_height % input_w != 0);
+                TT_FATAL(shard_height % input_w != 0, "Error");
             }
         }
 

--- a/ttnn/cpp/ttnn/operations/reduction/generic/device/reduce_op.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/generic/device/reduce_op.cpp
@@ -46,13 +46,13 @@ void Reduce::validate(const std::vector<Tensor>& input_tensors) const {
     TT_FATAL((input_tensor.get_layout() == Layout::TILE), "Inputs to reduce must be tilized");
     if (this->dim == ReduceOpDim::H) {
         if (input_tensor.memory_config().is_sharded()) {
-            TT_FATAL(input_tensor.memory_config().memory_layout == TensorMemoryLayout::WIDTH_SHARDED);
+            TT_FATAL(input_tensor.memory_config().memory_layout == TensorMemoryLayout::WIDTH_SHARDED, "Error");
         } else {
-            TT_FATAL(input_tensor.memory_config().memory_layout == TensorMemoryLayout::INTERLEAVED);
+            TT_FATAL(input_tensor.memory_config().memory_layout == TensorMemoryLayout::INTERLEAVED, "Error");
         }
-        TT_FATAL(input_tensor.memory_config().memory_layout == this->output_mem_config.memory_layout);
+        TT_FATAL(input_tensor.memory_config().memory_layout == this->output_mem_config.memory_layout, "Error");
     } else {
-        TT_FATAL(input_tensor.memory_config().memory_layout == TensorMemoryLayout::INTERLEAVED);
+        TT_FATAL(input_tensor.memory_config().memory_layout == TensorMemoryLayout::INTERLEAVED, "Error");
     }
 }
 

--- a/ttnn/cpp/ttnn/operations/reduction/prod/device/prod_nc_op.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/prod/device/prod_nc_op.cpp
@@ -34,8 +34,8 @@ void Prod::validate(const std::vector<Tensor>& inputs) const {
     }
 
     for (int i = 0; i < input_shape.rank(); ++i) {
-        TT_FATAL(input_shape[i] == output_shape[i]);
-        // TT_FATAL(input_shape_wo_padding[i] == output_shape_wo_padding[i]);
+        TT_FATAL(input_shape[i] == output_shape[i], "Error");
+        // TT_FATAL(input_shape_wo_padding[i] == output_shape_wo_padding[i], "Error");
     }
 }
 

--- a/ttnn/cpp/ttnn/operations/reduction/prod/device/prod_op_all.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/prod/device/prod_op_all.cpp
@@ -23,8 +23,8 @@ void Prod_op::validate(const std::vector<Tensor>& input_tensors) const {
     TT_FATAL(input_tensor_a.storage_type() == StorageType::DEVICE, "Operands need to be on device!");
     TT_FATAL(input_tensor_a.buffer() != nullptr , "Operands need to be allocated in buffers on device!");
     TT_FATAL((input_tensor_a.get_layout() == Layout::TILE), "Input Layout must be tilized");
-    TT_FATAL(input_tensor_a.memory_config().memory_layout == TensorMemoryLayout::INTERLEAVED);
-    TT_FATAL(input_tensor_a.get_dtype() == DataType::BFLOAT16);
+    TT_FATAL(input_tensor_a.memory_config().memory_layout == TensorMemoryLayout::INTERLEAVED, "Error");
+    TT_FATAL(input_tensor_a.get_dtype() == DataType::BFLOAT16, "Error");
 }
 
 std::vector<Shape> Prod_op::compute_output_shapes(const std::vector<Tensor>& input_tensors) const {

--- a/ttnn/cpp/ttnn/operations/reduction/prod/prod.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/prod/prod.cpp
@@ -86,7 +86,7 @@ Tensor ProdOperation::invoke(const Tensor& input_a, bool all_dimensions, int64_t
     if (all_dimensions) {
         return prod_all(input_a, output_mem_config);
     }
-    TT_FATAL(dim >= -4 && dim <= 3 && "Dimension out of range (expected to be in range of [-4, 3]");
+    TT_FATAL(dim >= -4 && dim <= 3, "Dimension out of range (expected to be in range of [-4, 3]");
     Tensor temp = input_a;
     // Permute for dim 2,3
     if (dim == 2 || dim == -2) {

--- a/ttnn/cpp/ttnn/operations/sliding_window/halo/device/halo_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/sliding_window/halo/device/halo_device_operation.cpp
@@ -19,7 +19,7 @@ void HaloDeviceOperation::validate(const std::vector<Tensor> &input_tensors) con
         // skip the untilize, only do halo
         log_debug(tt::LogOp, "Input is ROW_MAJOR, no need to untilize.");
     } else {
-        TT_FATAL(input_tensor.volume() % tt::constants::TILE_HW == 0);
+        TT_FATAL(input_tensor.volume() % tt::constants::TILE_HW == 0, "Error");
     }
     TT_FATAL(input_tensor.memory_config().memory_layout == TensorMemoryLayout::HEIGHT_SHARDED || input_tensor.memory_config().memory_layout == TensorMemoryLayout::BLOCK_SHARDED || input_tensor.memory_config().memory_layout == TensorMemoryLayout::WIDTH_SHARDED, "Only height, width or block sharded tensors are supported.");
     TT_FATAL(input_tensor.shard_spec().has_value(), "Shard spec should not be empty");
@@ -58,7 +58,7 @@ std::vector<Tensor> HaloDeviceOperation::create_output_tensors(const std::vector
         auto output_core_range = *(output_memory_config_.shard_spec->grid.ranges().begin());
         auto input_core_w = input_core_range.end_coord.y - input_core_range.start_coord.y + 1;
         auto output_core_w = output_core_range.end_coord.y - output_core_range.start_coord.y + 1;
-        TT_FATAL(input_core_w == output_core_w);
+        TT_FATAL(input_core_w == output_core_w, "Error");
     }
 
     auto out_mem_config = output_memory_config_;

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/sdpa_op.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/sdpa_op.cpp
@@ -18,7 +18,7 @@ void ScaledDotProductAttention::validate(
         TT_FATAL(input_tensor.storage_type() == StorageType::DEVICE, "Operands to SDPA need to be on device");
         TT_FATAL(input_tensor.buffer() != nullptr, "Operands to SDPA need to be allocated in buffers on device");
         TT_FATAL((input_tensor.get_layout() == Layout::TILE), "Inputs to SDPA must be tilized");
-        TT_FATAL(input_tensor.get_dtype() == DataType::BFLOAT16 || input_tensor.get_dtype() == DataType::BFLOAT8_B);
+        TT_FATAL(input_tensor.get_dtype() == DataType::BFLOAT16 || input_tensor.get_dtype() == DataType::BFLOAT8_B, "Error");
     }
 
     const auto& mask_option = optional_input_tensors.at(0);
@@ -70,15 +70,15 @@ void ScaledDotProductAttention::validate(
 
         // Input 0 must be sharded by height. All other inputs must be in DRAM.
         const auto Q_memcfg = input_tensors.at(0).memory_config();
-        TT_FATAL(input_tensors.at(0).is_sharded() == true);
-        TT_FATAL(Q_memcfg.memory_layout == TensorMemoryLayout::HEIGHT_SHARDED);
+        TT_FATAL(input_tensors.at(0).is_sharded() == true, "Error");
+        TT_FATAL(Q_memcfg.memory_layout == TensorMemoryLayout::HEIGHT_SHARDED, "Error");
 
         for (std::size_t i = 1; i < input_tensors.size(); i++) {
-            TT_FATAL(input_tensors.at(i).buffer()->buffer_type() == tt::tt_metal::BufferType::DRAM);
+            TT_FATAL(input_tensors.at(i).buffer()->buffer_type() == tt::tt_metal::BufferType::DRAM, "Error");
         }
         // Output memconfig must be height sharded, same as input
-        TT_FATAL(this->output_mem_config.is_sharded());
-        TT_FATAL(this->output_mem_config.memory_layout == TensorMemoryLayout::HEIGHT_SHARDED);
+        TT_FATAL(this->output_mem_config.is_sharded(), "Error");
+        TT_FATAL(this->output_mem_config.memory_layout == TensorMemoryLayout::HEIGHT_SHARDED, "Error");
 
         // Assert we are in decode mode if not causal
         // Q: [1, B, NH, D]
@@ -88,27 +88,27 @@ void ScaledDotProductAttention::validate(
 
         // Batch must match
         const auto B = q_shape[1];
-        TT_FATAL(k_shape[1] == B);
-        TT_FATAL(v_shape[1] == B);
-        TT_FATAL(mask_shape[1] == B);
+        TT_FATAL(k_shape[1] == B, "Error");
+        TT_FATAL(v_shape[1] == B, "Error");
+        TT_FATAL(mask_shape[1] == B, "Error");
         TT_FATAL(Q_memcfg.shard_spec.value().grid.num_cores() == B, "Q must be height sharded by batch ");
 
         // NKV must be 1 if we are running in this decode mode
-        TT_FATAL(q_shape[0] == 1);
-        TT_FATAL(k_shape[0] == 1);
-        TT_FATAL(v_shape[0] == 1);
-        TT_FATAL(mask_shape[0] == 1);
+        TT_FATAL(q_shape[0] == 1, "Error");
+        TT_FATAL(k_shape[0] == 1, "Error");
+        TT_FATAL(v_shape[0] == 1, "Error");
+        TT_FATAL(mask_shape[0] == 1, "Error");
 
         // Check sequence lengths
-        TT_FATAL(k_shape[-2] == v_shape[-2]);
+        TT_FATAL(k_shape[-2] == v_shape[-2], "Error");
 
         // Check hidden size
         const auto D = q_shape[-1];
-        TT_FATAL(k_shape[-1] == D);
-        TT_FATAL(v_shape[-1] == D);
+        TT_FATAL(k_shape[-1] == D, "Error");
+        TT_FATAL(v_shape[-1] == D, "Error");
 
         // Check NH
-        TT_FATAL(q_shape[2] == mask_shape[2]);
+        TT_FATAL(q_shape[2] == mask_shape[2], "Error");
 
         // Check valid seqlen
         TT_FATAL(valid_seq_len.has_value(), "Non-causal SDPA must set valid_seq_len");
@@ -120,8 +120,8 @@ void ScaledDotProductAttention::validate(
         auto q_chunk_size = program_config->q_chunk_size;
         auto k_chunk_size = program_config->k_chunk_size;
 
-        TT_FATAL(q_shape[-2] % q_chunk_size == 0);
-        TT_FATAL(k_shape[-2] % k_chunk_size == 0);
+        TT_FATAL(q_shape[-2] % q_chunk_size == 0, "Error");
+        TT_FATAL(k_shape[-2] % k_chunk_size == 0, "Error");
 
         if (!this->is_causal) {
             TT_FATAL(q_chunk_size == q_shape[-2], "Non-causal SDPA must have q_chunk_size == q_shape[-2]");

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/sdpa_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/sdpa_program_factory.cpp
@@ -98,7 +98,7 @@ operation::ProgramWithCallbacks sdpa_multi_core(
                 math_approx_mode = compute_kernel_config.math_approx_mode;
                 fp32_dest_acc_en = compute_kernel_config.fp32_dest_acc_en;
             } else {
-                TT_FATAL(false, "arch not supported");
+                TT_THROW("arch not supported");
             }
         },
         compute_kernel_config);
@@ -116,7 +116,7 @@ operation::ProgramWithCallbacks sdpa_multi_core(
     auto core_grid = CoreRange({0, 0}, {grid_size.x - 1, grid_size.y - 1});
     uint32_t num_cores = grid_size.x * grid_size.y;
 
-    TT_FATAL(num_cores <= device->compute_with_storage_grid_size().x * device->compute_with_storage_grid_size().y);
+    TT_FATAL(num_cores <= device->compute_with_storage_grid_size().x * device->compute_with_storage_grid_size().y, "Error");
 
     // Parallelization scheme
     // We will choose parallelization factors for batch, num_heads, and q_seq_len in that order
@@ -124,7 +124,7 @@ operation::ProgramWithCallbacks sdpa_multi_core(
     uint32_t nh_parallel_factor = std::min(num_cores / batch_parallel_factor, NQH);
     uint32_t q_parallel_factor = std::min(num_cores / (batch_parallel_factor * nh_parallel_factor), q_num_chunks);
 
-    TT_FATAL(batch_parallel_factor * nh_parallel_factor * q_parallel_factor <= num_cores);
+    TT_FATAL(batch_parallel_factor * nh_parallel_factor * q_parallel_factor <= num_cores, "Error");
 
     tt::log_debug("Parallelization scheme:");
     tt::log_debug("batch_parallel_factor: {}", batch_parallel_factor);
@@ -205,15 +205,15 @@ operation::ProgramWithCallbacks sdpa_multi_core(
     // Find log2 of stats_granularity using std
     const uint32_t log2_stats_granularity = std::log2(stats_granularity);
     // Assert that this is a power of 2
-    TT_FATAL(stats_granularity == (1 << log2_stats_granularity));
+    TT_FATAL(stats_granularity == (1 << log2_stats_granularity), "Error");
 
     const uint32_t sub_exp_granularity = std::min(Sk_chunk_t, dst_size);
     const uint32_t log2_sub_exp_granularity = std::log2(sub_exp_granularity);
-    TT_FATAL(sub_exp_granularity == (1 << log2_sub_exp_granularity));
+    TT_FATAL(sub_exp_granularity == (1 << log2_sub_exp_granularity), "Error");
 
     const uint32_t mul_bcast_granularity = std::min(Sq_chunk_t * Sk_chunk_t, dst_size);
     const uint32_t log2_mul_bcast_granularity = std::log2(mul_bcast_granularity);
-    TT_FATAL(mul_bcast_granularity == (1 << log2_mul_bcast_granularity));
+    TT_FATAL(mul_bcast_granularity == (1 << log2_mul_bcast_granularity), "Error");
 
     const uint32_t dht_granularity = std::min(DHt, dst_size);
     const uint32_t log2_dht_granularity = std::log2(dht_granularity);

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/sdpa_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/sdpa_program_factory.cpp
@@ -98,7 +98,7 @@ operation::ProgramWithCallbacks sdpa_multi_core(
                 math_approx_mode = compute_kernel_config.math_approx_mode;
                 fp32_dest_acc_en = compute_kernel_config.fp32_dest_acc_en;
             } else {
-                TT_FATAL("arch not supported");
+                TT_FATAL(false, "arch not supported");
             }
         },
         compute_kernel_config);

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa_decode/device/sdpa_decode_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa_decode/device/sdpa_decode_program_factory.cpp
@@ -101,7 +101,7 @@ operation::ProgramWithCallbacks sdpa_decode_multi_core(
             math_approx_mode = compute_kernel_config.math_approx_mode;
             fp32_dest_acc_en = compute_kernel_config.fp32_dest_acc_en;
         } else {
-            TT_FATAL(false, "arch not supported");
+            TT_THROW("arch not supported");
         }
 
     }, compute_kernel_config);
@@ -122,7 +122,7 @@ operation::ProgramWithCallbacks sdpa_decode_multi_core(
     auto core_grid = CoreRange({0, 0}, {grid_size.x - 1, grid_size.y - 1});
     uint32_t num_cores_available = grid_size.x * grid_size.y;
 
-    TT_FATAL(num_cores_available <= device->compute_with_storage_grid_size().x * device->compute_with_storage_grid_size().y);
+    TT_FATAL(num_cores_available <= device->compute_with_storage_grid_size().x * device->compute_with_storage_grid_size().y, "Error");
 
     // balance the number of cores to use based on batch
     uint32_t num_cores_per_batch = num_cores_available / B;
@@ -229,15 +229,15 @@ operation::ProgramWithCallbacks sdpa_decode_multi_core(
     // Find log2 of stats_granularity using std
     const uint32_t log2_stats_granularity = std::log2(stats_granularity);
     // Assert that this is a power of 2
-    TT_FATAL(stats_granularity == (1 << log2_stats_granularity));
+    TT_FATAL(stats_granularity == (1 << log2_stats_granularity), "Error");
 
     const uint32_t sub_exp_granularity = std::min(Sk_chunk_t, dst_size);
     const uint32_t log2_sub_exp_granularity = std::log2(sub_exp_granularity);
-    TT_FATAL(sub_exp_granularity == (1 << log2_sub_exp_granularity));
+    TT_FATAL(sub_exp_granularity == (1 << log2_sub_exp_granularity), "Error");
 
     const uint32_t mul_bcast_granularity = std::min(PNHt * Sk_chunk_t, dst_size);
     const uint32_t log2_mul_bcast_granularity = std::log2(mul_bcast_granularity);
-    TT_FATAL(mul_bcast_granularity == (1 << log2_mul_bcast_granularity));
+    TT_FATAL(mul_bcast_granularity == (1 << log2_mul_bcast_granularity), "Error");
 
     const uint32_t dht_granularity = std::min(DHt, dst_size);
     const uint32_t log2_dht_granularity = std::log2(dht_granularity);
@@ -281,7 +281,7 @@ operation::ProgramWithCallbacks sdpa_decode_multi_core(
         pos_tensor_tile_size = tt_metal::detail::TileSize(pos_df);
         index_stick_size = pos_buffer->aligned_page_size();
         log2_page_size = std::log2(index_stick_size);
-        TT_FATAL(1 << log2_page_size == index_stick_size);
+        TT_FATAL(1 << log2_page_size == index_stick_size, "Error");
 
         //cb pos
         auto c_in8_config = CircularBufferConfig(pos_tensor_tile_size, {{CB::dataflow0, pos_df}}).set_page_size(CB::dataflow0, pos_tensor_tile_size);
@@ -298,7 +298,7 @@ operation::ProgramWithCallbacks sdpa_decode_multi_core(
         page_table_tile_size = tt_metal::detail::TileSize(page_table_df);
         page_table_stick_size = page_table_buffer->aligned_page_size();
         log2_page_table_page_size = std::log2(page_table_stick_size);
-        TT_FATAL(1 << log2_page_table_page_size == page_table_stick_size);
+        TT_FATAL(1 << log2_page_table_page_size == page_table_stick_size, "Error");
 
         //cb page_table
         auto c_in9_config = CircularBufferConfig(page_table_tile_size, {{CB::dataflow1, page_table_df}}).set_page_size(CB::dataflow1, page_table_tile_size);

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa_decode/device/sdpa_decode_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa_decode/device/sdpa_decode_program_factory.cpp
@@ -101,7 +101,7 @@ operation::ProgramWithCallbacks sdpa_decode_multi_core(
             math_approx_mode = compute_kernel_config.math_approx_mode;
             fp32_dest_acc_en = compute_kernel_config.fp32_dest_acc_en;
         } else {
-            TT_FATAL("arch not supported");
+            TT_FATAL(false, "arch not supported");
         }
 
     }, compute_kernel_config);

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa_decode_gqa/device/sdpa_decode_gqa_op.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa_decode_gqa/device/sdpa_decode_gqa_op.cpp
@@ -23,30 +23,30 @@ void ScaledDotProductAttentionGQADecode::validate(const std::vector<Tensor>& inp
 
     // All other inputs must be in DRAM.
     for (std::size_t i = 0; i < input_tensors.size(); i++) {
-        TT_FATAL(input_tensors.at(i).buffer()->buffer_type() == tt::tt_metal::BufferType::DRAM);
+        TT_FATAL(input_tensors.at(i).buffer()->buffer_type() == tt::tt_metal::BufferType::DRAM, "Error");
     }
 
     // Check dtype
     for (std::size_t i = 1; i < input_tensors.size(); i++) {
-        TT_FATAL(input_tensors.at(i).get_dtype() == DataType::BFLOAT8_B);
+        TT_FATAL(input_tensors.at(i).get_dtype() == DataType::BFLOAT8_B, "Error");
     }
-    TT_FATAL(input_tensors.at(0).get_dtype() == DataType::BFLOAT16);
+    TT_FATAL(input_tensors.at(0).get_dtype() == DataType::BFLOAT16, "Error");
 
     // Check sequence lengths
-    TT_FATAL(k_shape[-2] == v_shape[-2]);
+    TT_FATAL(k_shape[-2] == v_shape[-2], "Error");
 
     // Check hidden size
     const auto D = q_shape[-1];
-    TT_FATAL(k_shape[-1] == D);
-    TT_FATAL(v_shape[-1] == D);
+    TT_FATAL(k_shape[-1] == D, "Error");
+    TT_FATAL(v_shape[-1] == D, "Error");
 
     // Check num_heads
-    TT_FATAL(k_shape[1] == v_shape[1]);
-    TT_FATAL(q_shape[1] % k_shape[1] == 0);
-    TT_FATAL(q_shape[1] <= 32);
+    TT_FATAL(k_shape[1] == v_shape[1], "Error");
+    TT_FATAL(q_shape[1] % k_shape[1] == 0, "Error");
+    TT_FATAL(q_shape[1] <= 32, "Error");
 
     // Check batch size
-    TT_FATAL(k_shape[0] == v_shape[0]);
+    TT_FATAL(k_shape[0] == v_shape[0], "Error");
 
     // Check valid seqlen
     for (int i = 0; i < this->cur_pos.size(); i++) {

--- a/ttnn/cpp/ttnn/tensor/host_buffer/functions.hpp
+++ b/ttnn/cpp/ttnn/tensor/host_buffer/functions.hpp
@@ -19,17 +19,17 @@ namespace borrowed_buffer {
 template <typename T>
 void validate_datatype(const Tensor& tensor) {
     if constexpr (std::is_same_v<T, uint32_t>) {
-        TT_FATAL(tensor.get_dtype() == DataType::UINT32);
+        TT_FATAL(tensor.get_dtype() == DataType::UINT32, "Incorrect data type {}", tensor.get_dtype());
     } else if constexpr (std::is_same_v<T, int32_t>) {
-        TT_FATAL(tensor.get_dtype() == DataType::INT32);
+        TT_FATAL(tensor.get_dtype() == DataType::INT32, "Incorrect data type {}", tensor.get_dtype());
     } else if constexpr (std::is_same_v<T, float>) {
-        TT_FATAL(tensor.get_dtype() == DataType::FLOAT32);
+        TT_FATAL(tensor.get_dtype() == DataType::FLOAT32, "Incorrect data type {}", tensor.get_dtype());
     } else if constexpr (std::is_same_v<T, bfloat16>) {
-        TT_FATAL(tensor.get_dtype() == DataType::BFLOAT16);
+        TT_FATAL(tensor.get_dtype() == DataType::BFLOAT16, "Incorrect data type {}", tensor.get_dtype());
     } else if constexpr (std::is_same_v<T, uint16_t>) {
-        TT_FATAL(tensor.get_dtype() == DataType::UINT16);
+        TT_FATAL(tensor.get_dtype() == DataType::UINT16, "Incorrect data type {}", tensor.get_dtype());
     } else if constexpr (std::is_same_v<T, uint8_t>) {
-        TT_FATAL(tensor.get_dtype() == DataType::UINT8);
+        TT_FATAL(tensor.get_dtype() == DataType::UINT8, "Incorrect data type {}", tensor.get_dtype());
     } else {
         static_assert(tt::stl::concepts::always_false_v<T>, "Unsupported DataType");
     }
@@ -95,17 +95,17 @@ void validate_datatype(const Tensor& tensor) {
     if constexpr (std::is_same_v<T, uint32_t>) {
         TT_FATAL(
             tensor.get_dtype() == DataType::UINT32 or tensor.get_dtype() == DataType::BFLOAT8_B or
-            tensor.get_dtype() == DataType::BFLOAT4_B);
+            tensor.get_dtype() == DataType::BFLOAT4_B, "Incorrect data type {}", tensor.get_dtype());
     } else if constexpr (std::is_same_v<T, int32_t>) {
-        TT_FATAL(tensor.get_dtype() == DataType::INT32);
+        TT_FATAL(tensor.get_dtype() == DataType::INT32, "Incorrect data type {}", tensor.get_dtype());
     } else if constexpr (std::is_same_v<T, float>) {
-        TT_FATAL(tensor.get_dtype() == DataType::FLOAT32);
+        TT_FATAL(tensor.get_dtype() == DataType::FLOAT32, "Incorrect data type {}", tensor.get_dtype());
     } else if constexpr (std::is_same_v<T, bfloat16>) {
-        TT_FATAL(tensor.get_dtype() == DataType::BFLOAT16);
+        TT_FATAL(tensor.get_dtype() == DataType::BFLOAT16, "Incorrect data type {}", tensor.get_dtype());
     } else if constexpr (std::is_same_v<T, uint16_t>) {
-        TT_FATAL(tensor.get_dtype() == DataType::UINT16);
+        TT_FATAL(tensor.get_dtype() == DataType::UINT16, "Incorrect data type {}", tensor.get_dtype());
     } else if constexpr (std::is_same_v<T, uint8_t>) {
-        TT_FATAL(tensor.get_dtype() == DataType::UINT8);
+        TT_FATAL(tensor.get_dtype() == DataType::UINT8, "Incorrect data type {}", tensor.get_dtype());
     } else {
         static_assert(tt::stl::concepts::always_false_v<T>, "Unsupported DataType");
     }

--- a/ttnn/cpp/ttnn/tensor/tensor.cpp
+++ b/ttnn/cpp/ttnn/tensor/tensor.cpp
@@ -723,9 +723,9 @@ void write_tensor(Tensor host_tensor, Tensor device_tensor, uint8_t cq_id) {
                 device_tensor.storage_type() == StorageType::DEVICE or
                     device_tensor.storage_type() == StorageType::MULTI_DEVICE,
                 "write_tensor only supports host_tensor to device_tensor data transfer");
-            TT_FATAL(async_safe_tensor.get_shape() == device_tensor.get_shape());
-            TT_FATAL(async_safe_tensor.get_dtype() == device_tensor.get_dtype());
-            TT_FATAL(async_safe_tensor.get_layout() == device_tensor.get_layout());
+            TT_FATAL(async_safe_tensor.get_shape() == device_tensor.get_shape(), "Error");
+            TT_FATAL(async_safe_tensor.get_dtype() == device_tensor.get_dtype(), "Error");
+            TT_FATAL(async_safe_tensor.get_layout() == device_tensor.get_layout(), "Error");
             std::visit(
                 [worker_index, worker, cq_id, &async_safe_tensor](auto&& s) {
                     void* host_data = nullptr;

--- a/ttnn/cpp/ttnn/tensor/tensor_impl.cpp
+++ b/ttnn/cpp/ttnn/tensor/tensor_impl.cpp
@@ -172,7 +172,7 @@ void validate_sharded_buffer_allocation(
             (shard_shape[0] % constants::TILE_HEIGHT == 0 && shard_shape[1] % constants::TILE_WIDTH == 0),
             "Shard shape must be tile sized");
     } else if (layout == Layout::ROW_MAJOR) {
-        TT_FATAL(shard_shape[1] * tensor_impl::element_size_bytes(data_type) % sizeof(uint32_t) == 0);
+        TT_FATAL(shard_shape[1] * tensor_impl::element_size_bytes(data_type) % sizeof(uint32_t) == 0, "Error");
     }
 }
 

--- a/ttnn/cpp/ttnn/tensor/types.hpp
+++ b/ttnn/cpp/ttnn/tensor/types.hpp
@@ -548,9 +548,7 @@ struct MultiDeviceStorage {
 
     inline const MemoryConfig memory_config() const {
         std::lock_guard<std::mutex> lock(buffer_mtx);
-        if (this->ordered_device_ids.empty()) {
-            TT_FATAL("no such device...");
-        }
+        TT_FATAL(!this->ordered_device_ids.empty(), "No device ids in list. Please ensure fields are initialized properly.");
         auto first_device_id = this->ordered_device_ids[0];
         if (this->buffers.at(first_device_id).get() == nullptr) {
             TT_THROW("MemoryConfig can only be obtained if the buffer is not null");


### PR DESCRIPTION
### Ticket
Link to Github Issue https://github.com/tenstorrent/tt-metal/issues/12440

### Problem description
- many fatals are of the form `TT_FATAL("string")`, which would never be triggered even though they should be.

### What's changed
- changed them to be `TT_FATAL(false, ...` or equivalent
- a commented out one was deleted
- one that looked like it was intended to be ignored was turned into an info log message
- tried to add in extra information were it made sense (I assume people know what arch they're using)

### Checklist
- [x] Post commit CI passes https://github.com/tenstorrent/tt-metal/actions/runs/10813709590/ fails in the same way as main https://github.com/tenstorrent/tt-metal/actions/runs/10812845734/
- [x] Blackhole Post commit (if applicable) https://github.com/tenstorrent/tt-metal/actions/runs/10800629198
- [x] Model regression CI testing passes (if applicable) https://github.com/tenstorrent/tt-metal/actions/runs/10795440971 and after that fails with the same errors as main
- [x] New/Existing tests provide coverage for changes
