### PR TITLE
#12187: Enabling cmd buffer fifo on bh

### DIFF
--- a/tests/tt_metal/tt_metal/unit_tests_common/compute/matmul/test_matmul_multi_core_multi_dram_in0_mcast_in1_mcast.cpp
+++ b/tests/tt_metal/tt_metal/unit_tests_common/compute/matmul/test_matmul_multi_core_multi_dram_in0_mcast_in1_mcast.cpp
@@ -349,18 +349,9 @@ bool matmul_multi_core_multi_dram_in0_mcast_in1_mcast(tt_metal::Device *device){
     uint32_t M = 16 * num_cores_r;
     uint32_t K = 16 * 12;
     uint32_t N = 16 * num_cores_c;
-    int out_subblock_h;
-    int out_subblock_w;
-    int in0_block_w;
-    if (device->arch() == tt::ARCH::BLACKHOLE and not getenv("TT_METAL_DISABLE_BH_ND_WORKAROUND")) {
-        out_subblock_h = 1;
-        out_subblock_w = 1;
-        in0_block_w = 1;
-    } else {
-        out_subblock_h = 4;
-        out_subblock_w = 2;
-        in0_block_w = 2;
-    }
+    int out_subblock_h = 4;
+    int out_subblock_w = 2;
+    int in0_block_w = 2;
     int per_core_M = M / num_cores_r;
     int per_core_N = N / num_cores_c;
     uint32_t single_tile_size = 2 * 1024;

--- a/tt_metal/hw/inc/blackhole/noc_nonblocking_api.h
+++ b/tt_metal/hw/inc/blackhole/noc_nonblocking_api.h
@@ -56,7 +56,9 @@ inline __attribute__((always_inline)) uint32_t NOC_CFG_READ_REG(uint32_t noc, ui
 }
 
 inline __attribute__((always_inline)) bool noc_cmd_buf_ready(uint32_t noc, uint32_t cmd_buf) {
-    return (NOC_CMD_BUF_READ_REG(noc, cmd_buf, NOC_CMD_CTRL) == NOC_CTRL_STATUS_READY);
+    // Command buffer FIFO supports 16 commands, once it is full the overflow register for the cmd_buf will be set
+    // CMD_BUF_AVAIL holds available buffer space in [28:24], [20:16], [12:8], [4:0] for buffers 3, 2, 1, 0 respectively
+    return bool((NOC_CMD_BUF_READ_REG(noc, cmd_buf, CMD_BUF_AVAIL) >> (cmd_buf << 3)) & 0x1F);
 }
 
 inline __attribute__((always_inline)) void ncrisc_noc_fast_read(
@@ -169,6 +171,10 @@ inline __attribute__((always_inline)) bool ncrisc_noc_nonposted_atomics_flushed(
 inline __attribute__((always_inline)) void noc_init() {
 #pragma GCC unroll 0
     for (int noc = 0; noc < NUM_NOCS; noc++) {
+        // Enable command buffer FIFO that has capacity of 16 per buffer
+        uint32_t niu_cfg0_reg_val = NOC_CFG_READ_REG(noc, NIU_CFG_0);
+        NOC_CMD_BUF_WRITE_REG(noc, 0, NOC_CFG(NIU_CFG_0), niu_cfg0_reg_val | (1 << NIU_CFG_0_CMD_BUFFER_FIFO_EN));
+
         uint32_t noc_id_reg = NOC_CMD_BUF_READ_REG(noc, 0, NOC_NODE_ID);
         uint32_t my_x = noc_id_reg & NOC_NODE_ID_MASK;
         uint32_t my_y = (noc_id_reg >> NOC_ADDR_NODE_ID_BITS) & NOC_NODE_ID_MASK;


### PR DESCRIPTION
### Ticket
#12187 

### Problem description
CMD buffer on BH has issues so we were suggested to enable CMD buffer FIFO instead. Without this change we see ND behaviour 

### What's changed
- Enable CMD buffer FIFO on noc init
- uplift noc_cmd_buf_ready to check for available space in FIFO (16 entries are available to each of the four buffers)
- enables `TT_METAL_DISABLE_BH_ND_WORKAROUND=1 TT_METAL_SLOW_DISPATCH_MODE=1 ./build/test/tt_metal/unit_tests --gtest_filter=CommonFixture.MatmulMultiCoreMultiDRAMIn0MCastIn1MCast --gtest_repeat=1000` (previously was only able to get around 20 iterations) 

Note: This doesn't try to use the cmd buffer FIFOs in a performant way

### Checklist
- [x] [Post commit CI passes](https://github.com/tenstorrent/tt-metal/actions/runs/10799423024)
- [x] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/runs/10799433487)
