### PR TITLE
Contiguous pages support in Reduce Scatter read/write

### DIFF
--- a/ttnn/cpp/ttnn/operations/ccl/all_gather/device/kernels/dataflow/worker_ring_gather_utils.hpp
+++ b/ttnn/cpp/ttnn/operations/ccl/all_gather/device/kernels/dataflow/worker_ring_gather_utils.hpp
@@ -472,7 +472,7 @@ FORCE_INLINE void read_wrapped_chunk_from_output_tensor(
         /*
          * num_pages - i: check if we are outside the number of pages remaining
          * contig_pages_: check if we are outside the max number of contig pages we can read in a row in a bank
-         * contig_edge_of_tensor_slice: check if we are outside the edge of the tensor slice (in which case, we wrap around if aren't at the end)
+         * contig_edge_of_tensor_slice: check if we are outside the edge of the tensor slice (in which case, we wrap around if we aren't at the end)
          */
         uint32_t flattened_offset_worker_slice = offset_worker_slice.x + (offset_worker_slice.y * tensor_slice_shape.x);
         uint32_t contig_edge_of_tensor_slice = tensor_slice_shape.x - ((flattened_offset_worker_slice + offset_into_worker_slice) % tensor_slice_shape.x);
@@ -490,8 +490,8 @@ FORCE_INLINE void read_wrapped_chunk_from_output_tensor(
             worker_slice_shape,
             tensor_slice_shape,
             tensor_shape,
-            last_page_of_worker,
-            contig_pages
+            contig_pages,
+            last_page_of_worker
         );
 
 #endif
@@ -558,8 +558,8 @@ FORCE_INLINE void write_wrapped_chunk(
             worker_slice_shape,
             tensor_slice_shape,
             tensor_shape,
-            last_page_of_worker,
-            contig_pages
+            contig_pages,
+            last_page_of_worker
         );
 #endif
         l1_read_addr += page_size * contig_pages;

--- a/ttnn/cpp/ttnn/operations/ccl/shared_with_host/hetergeneous_data_structs.hpp
+++ b/ttnn/cpp/ttnn/operations/ccl/shared_with_host/hetergeneous_data_structs.hpp
@@ -127,8 +127,8 @@ inline void advance_worker_global_page_interleaved (
 
     coord_t const &tensor_shape, // full tensor shape
 
-    bool &last_page_of_worker,
-    const uint32_t stride=1
+    const uint32_t stride,
+    bool &last_page_of_worker
   ) {
 
     uint32_t prev_offset_into_worker_slice = offset_into_worker_slice;


### PR DESCRIPTION
### Ticket
- #12223

### Problem description
Currently, the read/write chunk functions used in reduce scatter read in pages/tiles one at a time. An optimization is to instead read n contiguous pages until the end of the row, with respect to the dimensions of the shard, tensor slice, and worker slice.

### What's changed
The read/write chunk functions have been updated to use the optimized shard tensor addr generators, that return the number of contiguous pages until the end of the shard. Using this, we can now read/write in a contiguous fashion until the end of the row.

### Checklist
- [x] post-commit: https://github.com/tenstorrent/tt-metal/actions/runs/10800177371
- [x] t3k-frequent: https://github.com/tenstorrent/tt-metal/actions/runs/10800188520
- [x] t3k-perf: https://github.com/tenstorrent/tt-metal/actions/runs/10800211437 (same failure as main)
- [x] t3k-demo: https://github.com/tenstorrent/tt-metal/actions/runs/10800204981 (same failure as main)
- [x] t3k-nightly: https://github.com/tenstorrent/tt-metal/actions/runs/10800231521
