### PR TITLE
#12103: allow edm send state to short-circuit to later state when mul…

### DIFF
--- a/ttnn/cpp/ttnn/operations/ccl/kernels/edm/erisc_datamover.cpp
+++ b/ttnn/cpp/ttnn/operations/ccl/kernels/edm/erisc_datamover.cpp
@@ -260,28 +260,26 @@ void kernel_main() {
                 case ChannelBufferT::STATE::SENDER_WAITING_FOR_WORKER:
                 did_something_sender =
                     erisc::datamover::sender_noc_receive_payload_ack_check_sequence(current_sender, num_senders_complete);
-                senders_in_progress = senders_in_progress && num_senders_complete != sender_num_channels;
                 break;
 
                 case ChannelBufferT::STATE::SENDER_READY_FOR_ETH_TRANSFER:
-                did_something_sender = erisc::datamover::sender_eth_send_data_sequence(current_sender);
+                did_something_sender = erisc::datamover::sender_eth_send_data_sequence(current_sender, num_senders_complete);
                     break;
 
                 case ChannelBufferT::STATE::SENDER_SIGNALING_WORKER:
                 did_something_sender = erisc::datamover::sender_notify_workers_if_buffer_available_sequence(
                                     current_sender, num_senders_complete);
-                senders_in_progress = senders_in_progress && num_senders_complete != sender_num_channels;
                 break;
 
                 case ChannelBufferT::STATE::SENDER_WAITING_FOR_ETH:
                 did_something_sender =
                     erisc::datamover::sender_eth_check_receiver_ack_sequence(current_sender, num_senders_complete);
-                senders_in_progress = senders_in_progress && num_senders_complete != sender_num_channels;
                 break;
 
                 default:
                 break;
             };
+            senders_in_progress = senders_in_progress && num_senders_complete != sender_num_channels;
         }
 
         //////////////////////////////////////
@@ -302,7 +300,7 @@ void kernel_main() {
 
                 case ChannelBufferT::STATE::RECEIVER_WAITING_FOR_WORKER:
                 did_something_receiver = erisc::datamover::receiver_noc_read_worker_completion_check_sequence(
-                                    current_receiver, num_receivers_complete);
+                                    current_receiver, num_receivers_complete, eth_transaction_ack_word_addr);
                 receivers_in_progress = receivers_in_progress && num_receivers_complete != receiver_num_channels;
                 break;
 


### PR DESCRIPTION
…ti-buffering enabled

This change ideally would have been applied when multi-buffered channels were enabled but this was overlooked at the time. With multi-buffered channels, it is possible for the EDM to be able to signal sender worker cores inmmediately after sending a payload over ethernet, for their next messages.

Without this change the EDM main loop will exit handling the current channel and iterate through all other channels before revisiting the channel that just sent data, and (potentially) notifying workers of buffer availability. This can end up adding unnecessary delays.

### Ticket
[Link to Github Issue](https://github.com/tenstorrent/tt-metal/issues/12107)

### Problem description
See context. Perf improvement. Saves several thousand cycles for smaller all-gathers.

### What's changed
Short circuited a state.

### Checklist
- [ ] Post commit CI passes: https://github.com/tenstorrent/tt-metal/actions/runs/10805219474
- [ ] T3000 frequent: https://github.com/tenstorrent/tt-metal/actions/runs/10805226984
- [ ] T3000 nightly: https://github.com/tenstorrent/tt-metal/actions/runs/10805223172
- [ ] T3000 model perf: https://github.com/tenstorrent/tt-metal/actions/runs/10805224577
- [x] Blackhole Post commit (if applicable)
- [x] New/Existing tests provide coverage for changes
