### PR TITLE
#0: Update timeout for default block sharded matmul sweep

### DIFF
--- a/tests/sweep_framework/sweeps/matmul/full/matmul_default_block_sharded.py
+++ b/tests/sweep_framework/sweeps/matmul/full/matmul_default_block_sharded.py
@@ -20,7 +20,7 @@ from tests.ttnn.utils_for_testing import (
 )
 from models.utility_functions import torch_random
 
-TIMEOUT = 5
+TIMEOUT = 15
 
 
 def get_block_sharded_specs(


### PR DESCRIPTION
### Ticket
Link to Github Issue. None.
Related to https://github.com/tenstorrent/tt-metal/issues/12220
Now that is fixed, 5 seconds is too short for some tests.

### Problem description
- Timeout was reduced to 5 seconds to have sweeps not take too long
- 5 seconds is too short for some tests

### What's changed
- Increased timeout to 15 seconds

### Checklist
- [ ] Post commit CI passes N/A
- [ ] Blackhole Post commit (if applicable) N/A
- [ ] Model regression CI testing passes (if applicable) N/A
- [ ] New/Existing tests provide coverage for changes N/A
