### PR TITLE
#0: Update device creations functions to use num_command_queues instead of num_hw_cqs to match mesh_device creation functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@
 For the latest model updates and features, please see [MODEL_UPDATES.md](models/MODEL_UPDATES.md)
 
 ## TT-NN Tech Reports
-- [Advanced Performance Optimizations for Models](./tech_reports/AdvancedPerformanceOperationsForModels/AdvancedPerformanceOptimizationsForModels.md) (updated Sept 8th)
+- [Advanced Performance Optimizations for Models](./tech_reports/AdvancedPerformanceOperationsForModels/AdvancedPerformanceOptimizationsForModels.md) (updated Sept 11th)
 - [Programming Mesh of Devices](./tech_reports/Programming%20Mesh%20of%20Devices/Programming%20Mesh%20of%20Devices%20with%20TT-NN.md) (updated Sept 9th)
 ---
 

--- a/models/demos/grayskull/resnet50/tests/test_perf_e2e_resnet50.py
+++ b/models/demos/grayskull/resnet50/tests/test_perf_e2e_resnet50.py
@@ -71,7 +71,7 @@ def test_perf_trace(
 
 @run_for_grayskull()
 @pytest.mark.models_performance_bare_metal
-@pytest.mark.parametrize("device_params", [{"l1_small_size": 32768, "num_hw_cqs": 2}], indirect=True)
+@pytest.mark.parametrize("device_params", [{"l1_small_size": 32768, "num_command_queues": 2}], indirect=True)
 @pytest.mark.parametrize(
     "batch_size, expected_inference_time, expected_compile_time",
     ((20, 0.0100, 19),),
@@ -99,7 +99,7 @@ def test_perf_2cqs(
 @run_for_grayskull()
 @pytest.mark.models_performance_bare_metal
 @pytest.mark.parametrize(
-    "device_params", [{"l1_small_size": 32768, "trace_region_size": 1332224, "num_hw_cqs": 2}], indirect=True
+    "device_params", [{"l1_small_size": 32768, "trace_region_size": 1332224, "num_command_queues": 2}], indirect=True
 )
 @pytest.mark.parametrize(
     "batch_size, expected_inference_time, expected_compile_time",

--- a/models/demos/grayskull/resnet50/tests/test_resnet50_performant.py
+++ b/models/demos/grayskull/resnet50/tests/test_resnet50_performant.py
@@ -52,7 +52,7 @@ def test_run_resnet50_trace_inference(
 
 
 @run_for_grayskull()
-@pytest.mark.parametrize("device_params", [{"l1_small_size": 32768, "num_hw_cqs": 2}], indirect=True)
+@pytest.mark.parametrize("device_params", [{"l1_small_size": 32768, "num_command_queues": 2}], indirect=True)
 @pytest.mark.parametrize(
     "batch_size, act_dtype, weight_dtype, math_fidelity",
     ((20, ttnn.bfloat8_b, ttnn.bfloat8_b, ttnn.MathFidelity.LoFi),),
@@ -65,7 +65,7 @@ def test_run_resnet50_2cqs_inference(
 
 @run_for_grayskull()
 @pytest.mark.parametrize(
-    "device_params", [{"l1_small_size": 32768, "trace_region_size": 1332224, "num_hw_cqs": 2}], indirect=True
+    "device_params", [{"l1_small_size": 32768, "trace_region_size": 1332224, "num_command_queues": 2}], indirect=True
 )
 @pytest.mark.parametrize(
     "batch_size, act_dtype, weight_dtype, math_fidelity",

--- a/models/demos/wormhole/resnet50/tests/test_perf_e2e_resnet50.py
+++ b/models/demos/wormhole/resnet50/tests/test_perf_e2e_resnet50.py
@@ -70,7 +70,7 @@ def test_perf_trace(
 
 @run_for_wormhole_b0()
 @pytest.mark.models_performance_bare_metal
-@pytest.mark.parametrize("device_params", [{"l1_small_size": 32768, "num_hw_cqs": 2}], indirect=True)
+@pytest.mark.parametrize("device_params", [{"l1_small_size": 32768, "num_command_queues": 2}], indirect=True)
 @pytest.mark.parametrize(
     "batch_size, expected_inference_time, expected_compile_time",
     ((16, 0.0070, 26),),
@@ -98,7 +98,7 @@ def test_perf_2cqs(
 @run_for_wormhole_b0()
 @pytest.mark.models_performance_bare_metal
 @pytest.mark.parametrize(
-    "device_params", [{"l1_small_size": 32768, "num_hw_cqs": 2, "trace_region_size": 1332224}], indirect=True
+    "device_params", [{"l1_small_size": 32768, "num_command_queues": 2, "trace_region_size": 1332224}], indirect=True
 )
 @pytest.mark.parametrize(
     "batch_size, expected_inference_time, expected_compile_time",

--- a/models/demos/wormhole/resnet50/tests/test_resnet50_performant.py
+++ b/models/demos/wormhole/resnet50/tests/test_resnet50_performant.py
@@ -54,7 +54,7 @@ def test_run_resnet50_trace_inference(
 
 
 @run_for_wormhole_b0()
-@pytest.mark.parametrize("device_params", [{"l1_small_size": 24576, "num_hw_cqs": 2}], indirect=True)
+@pytest.mark.parametrize("device_params", [{"l1_small_size": 24576, "num_command_queues": 2}], indirect=True)
 @pytest.mark.parametrize(
     "batch_size, act_dtype, weight_dtype, math_fidelity",
     ((16, ttnn.bfloat8_b, ttnn.bfloat8_b, ttnn.MathFidelity.LoFi),),
@@ -67,7 +67,7 @@ def test_run_resnet50_2cqs_inference(
 
 @run_for_wormhole_b0()
 @pytest.mark.parametrize(
-    "device_params", [{"l1_small_size": 24576, "trace_region_size": 800768, "num_hw_cqs": 2}], indirect=True
+    "device_params", [{"l1_small_size": 24576, "trace_region_size": 800768, "num_command_queues": 2}], indirect=True
 )
 @pytest.mark.parametrize(
     "batch_size, act_dtype, weight_dtype, math_fidelity",

--- a/tech_reports/AdvancedPerformanceOperationsForModels/AdvancedPerformanceOptimizationsForModels.md
+++ b/tech_reports/AdvancedPerformanceOperationsForModels/AdvancedPerformanceOptimizationsForModels.md
@@ -156,7 +156,7 @@ Using a second command queue only for writes enables us to eliminate the gap bet
 
 In order to use multiple command queues, we need to be familiar with the following apis:
 
-* `num_hw_cqs`/`num_command_queues` (Currently dependent on whether we are running with single or multi device fixture)
+* `num_command_queues`
 
   This is a parameter to the device creation api, and sets how many command queues to create the device with. The default is one, and the max is two. In pytest, we can pass this using the `device_params` fixture:
 

--- a/tests/tt_eager/python_api_testing/trace_testing/misc/test_bert_ops.py
+++ b/tests/tt_eager/python_api_testing/trace_testing/misc/test_bert_ops.py
@@ -225,7 +225,7 @@ class TestBertOpsTrace:
         )
 
     @pytest.mark.parametrize("cq_id", [0])
-    @pytest.mark.parametrize("device_params", [{"trace_region_size": 34816, "num_hw_cqs": 2}], indirect=True)
+    @pytest.mark.parametrize("device_params", [{"trace_region_size": 34816, "num_command_queues": 2}], indirect=True)
     def test_bert_linear_2cqs_initialized(
         self,
         device,

--- a/tests/ttnn/unit_tests/test_device_synchronize.py
+++ b/tests/ttnn/unit_tests/test_device_synchronize.py
@@ -15,7 +15,7 @@ def is_eth_dispatch():
 
 
 @pytest.mark.skipif(is_wormhole_b0() and not is_eth_dispatch(), reason="Requires eth dispatch to run on WH")
-@pytest.mark.parametrize("device_params", [{"num_hw_cqs": 2}], indirect=True)
+@pytest.mark.parametrize("device_params", [{"num_command_queues": 2}], indirect=True)
 def test_read_write_full_synchronize(device):
     zeros = torch.zeros([1, 1, 65536, 2048]).bfloat16()
     input = torch.randn([1, 1, 65536, 2048]).bfloat16()
@@ -48,7 +48,7 @@ def test_read_write_full_synchronize(device):
 
 
 @pytest.mark.skipif(is_wormhole_b0() and not is_eth_dispatch(), reason="Requires eth dispatch to run on WH")
-@pytest.mark.parametrize("device_params", [{"num_hw_cqs": 2}], indirect=True)
+@pytest.mark.parametrize("device_params", [{"num_command_queues": 2}], indirect=True)
 def test_read_write_cq_synchronize(device):
     zeros = torch.zeros([1, 1, 65536, 2048]).bfloat16()
     input = torch.randn([1, 1, 65536, 2048]).bfloat16()

--- a/ttnn/cpp/pybind11/device.cpp
+++ b/ttnn/cpp/pybind11/device.cpp
@@ -132,7 +132,7 @@ void device_module(py::module &m_device) {
 
     m_device.def(
         "CreateDevice",
-        [](int device_id, uint8_t num_hw_cqs, size_t l1_small_size, size_t trace_region_size, tt::tt_metal::DispatchCoreType dispatch_core_type) { return tt::tt_metal::CreateDevice(device_id, num_hw_cqs, l1_small_size, trace_region_size, dispatch_core_type); },
+        [](int device_id, uint8_t num_command_queues, size_t l1_small_size, size_t trace_region_size, tt::tt_metal::DispatchCoreType dispatch_core_type) { return tt::tt_metal::CreateDevice(device_id, num_command_queues, l1_small_size, trace_region_size, dispatch_core_type); },
         R"doc(
         Creates an instance of TT device.
 
@@ -143,14 +143,14 @@ void device_module(py::module &m_device) {
         +------------------+------------------------+---------------------+------------------------------+----------+
     )doc",
         py::arg("device_id"),
-        py::arg("num_hw_cqs") = 1,
+        py::arg("num_command_queues") = 1,
         py::arg("l1_small_size") = DEFAULT_L1_SMALL_SIZE,
         py::arg("trace_region_size") = DEFAULT_TRACE_REGION_SIZE,
         py::arg("dispatch_core_type") = tt::tt_metal::DispatchCoreType::WORKER);
     m_device.def(
         "CreateDevices",
-        [](std::vector<int> device_ids, uint8_t num_hw_cqs, size_t l1_small_size, size_t trace_region_size, tt::tt_metal::DispatchCoreType dispatch_core_type) {
-            return tt::tt_metal::detail::CreateDevices(device_ids, num_hw_cqs, l1_small_size, trace_region_size, dispatch_core_type);
+        [](std::vector<int> device_ids, uint8_t num_command_queues, size_t l1_small_size, size_t trace_region_size, tt::tt_metal::DispatchCoreType dispatch_core_type) {
+            return tt::tt_metal::detail::CreateDevices(device_ids, num_command_queues, l1_small_size, trace_region_size, dispatch_core_type);
         },
         R"doc(
         Creates an instance of TT device.
@@ -162,7 +162,7 @@ void device_module(py::module &m_device) {
         +------------------+------------------------+---------------------+------------------------------+----------+
     )doc",
         py::arg("device_ids"),
-        py::arg("num_hw_cqs") = 1,
+        py::arg("num_command_queues") = 1,
         py::arg("l1_small_size") = DEFAULT_L1_SMALL_SIZE,
         py::arg("trace_region_size") = DEFAULT_TRACE_REGION_SIZE,
         py::arg("dispatch_core_type") = tt::tt_metal::DispatchCoreType::WORKER);

--- a/ttnn/ttnn/device.py
+++ b/ttnn/ttnn/device.py
@@ -90,22 +90,26 @@ def GetNumPCIeDevices():
 
 def CreateDevice(
     device_id: int,
-    num_hw_cqs: int = 1,
+    num_command_queues: int = 1,
     l1_small_size: int = ttnn._ttnn.device.DEFAULT_L1_SMALL_SIZE,
     trace_region_size: int = ttnn._ttnn.device.DEFAULT_TRACE_REGION_SIZE,
     dispatch_core_type: int = DispatchCoreType.WORKER,
 ):
-    return ttnn._ttnn.device.CreateDevice(device_id, num_hw_cqs, l1_small_size, trace_region_size, dispatch_core_type)
+    return ttnn._ttnn.device.CreateDevice(
+        device_id, num_command_queues, l1_small_size, trace_region_size, dispatch_core_type
+    )
 
 
 def CreateDevices(
     device_ids: List[int],
-    num_hw_cqs: int = 1,
+    num_command_queues: int = 1,
     l1_small_size: int = ttnn._ttnn.device.DEFAULT_L1_SMALL_SIZE,
     trace_region_size: int = ttnn._ttnn.device.DEFAULT_TRACE_REGION_SIZE,
     dispatch_core_type: int = DispatchCoreType.WORKER,
 ):
-    return ttnn._ttnn.device.CreateDevices(device_ids, num_hw_cqs, l1_small_size, trace_region_size, dispatch_core_type)
+    return ttnn._ttnn.device.CreateDevices(
+        device_ids, num_command_queues, l1_small_size, trace_region_size, dispatch_core_type
+    )
 
 
 def CloseDevice(device):


### PR DESCRIPTION
### Problem description
Different parameter names for specifying number of command queues between mesh/multi device vs regular/single device.
### What's changed
Update all python bindings/fns to use num_command_queues

### Checklist
- [x] Post commit CI passes
- [ ] Blackhole Post commit (if applicable)
- [x] Model regression CI testing passes (if applicable)
- [x] New/Existing tests provide coverage for changes
