### PR TITLE
#0: Revert "#0: Update to gcc-12.x (#12332)"

### DIFF
--- a/models/demos/metal_BERT_large_11/tests/test_perf_bert11.py
+++ b/models/demos/metal_BERT_large_11/tests/test_perf_bert11.py
@@ -184,7 +184,7 @@ def test_perf_bare_metal_wh(
 @pytest.mark.models_performance_bare_metal
 @pytest.mark.parametrize(
     "batch_size, model_config_str, expected_inference_time, expected_compile_time, inference_iterations",
-    ([12, "BFLOAT8_B-SHARDED", 0.0324, 6.5, 10],),
+    ([12, "BFLOAT8_B-SHARDED", 0.0324, 6, 10],),
 )
 def test_perf_bare_metal_gs(
     device,

--- a/tests/ttnn/integration_tests/bert/test_performance.py
+++ b/tests/ttnn/integration_tests/bert/test_performance.py
@@ -60,7 +60,7 @@ def get_expected_times(bert):
     return {
         ttnn_bert: (0.1, 0.1),
         ttnn_optimized_bert: (5.5, 0.07),
-        ttnn_optimized_sharded_bert: (5.7, 0.07),
+        ttnn_optimized_sharded_bert: (5.5, 0.07),
     }[bert]
 
 

--- a/tests/ttnn/integration_tests/whisper/test_performance.py
+++ b/tests/ttnn/integration_tests/whisper/test_performance.py
@@ -17,8 +17,8 @@ import ttnn
 
 def get_expected_times(functional_whisper):
     return {
-        ttnn_functional_whisper: (11.7, 4.16),
-        ttnn_optimized_functional_whisper: (1.3, 1.35),
+        ttnn_functional_whisper: (11, 4.16),
+        ttnn_optimized_functional_whisper: (1.2, 1.35),
     }[functional_whisper]
 
 


### PR DESCRIPTION
This reverts commit 85a5d2a6455e22be5f78ebfe9eb52bed0ad078d0.

### Ticket

Post commit breakage
erisc mem overflow

### Problem description

Need to get main back to green. @nathan-TT to fix on branch

### What's changed

Revert

### Checklist
- [ ] Post commit CI passes
- [ ] Blackhole Post commit (if applicable)
- [ ] Model regression CI testing passes (if applicable)
- [ ] Device performance regression CI testing passes (if applicable)
- [ ] New/Existing tests provide coverage for changes
