### PR TITLE
#12448: Update 1d matmul sweep test to use CoreRangeSet for core range parameters

### DIFF
--- a/tests/sweep_framework/sweeps/matmul/short/matmul_user_program_config_mcast_1d.py
+++ b/tests/sweep_framework/sweeps/matmul/short/matmul_user_program_config_mcast_1d.py
@@ -77,7 +77,7 @@ parameters = {
                 memory_layout=ttnn.TensorMemoryLayout.WIDTH_SHARDED,
                 buffer_type=ttnn.BufferType.L1,
                 shard_spec=ttnn.ShardSpec(
-                    ttnn.num_cores_to_corerange_set(28, core_grid, row_wise=True),
+                    ttnn.CoreRangeSet(ttnn.num_cores_to_corerange_set(28, core_grid, row_wise=True)),
                     (64, IN0_INNER_DIM_PER_CORE),
                     ttnn.ShardOrientation.ROW_MAJOR,
                     False,
@@ -105,7 +105,7 @@ parameters = {
                 memory_layout=ttnn.TensorMemoryLayout.WIDTH_SHARDED,
                 buffer_type=ttnn.BufferType.L1,
                 shard_spec=ttnn.ShardSpec(
-                    ttnn.num_cores_to_corerange_set(35, core_grid, row_wise=True),
+                    ttnn.CoreRangeSet(ttnn.num_cores_to_corerange_set(35, core_grid, row_wise=True)),
                     (64, IN0_INNER_DIM_PER_CORE),
                     ttnn.ShardOrientation.ROW_MAJOR,
                     False,
@@ -134,7 +134,7 @@ parameters = {
                 memory_layout=ttnn.TensorMemoryLayout.WIDTH_SHARDED,
                 buffer_type=ttnn.BufferType.L1,
                 shard_spec=ttnn.ShardSpec(
-                    ttnn.num_cores_to_corerange_set(28, core_grid, row_wise=True),
+                    ttnn.CoreRangeSet(ttnn.num_cores_to_corerange_set(28, core_grid, row_wise=True)),
                     (64, IN0_INNER_DIM_PER_CORE),
                     ttnn.ShardOrientation.ROW_MAJOR,
                     False,
@@ -163,7 +163,7 @@ parameters = {
                 memory_layout=ttnn.TensorMemoryLayout.WIDTH_SHARDED,
                 buffer_type=ttnn.BufferType.L1,
                 shard_spec=ttnn.ShardSpec(
-                    ttnn.num_cores_to_corerange_set(30, core_grid, row_wise=True),
+                    ttnn.CoreRangeSet(ttnn.num_cores_to_corerange_set(30, core_grid, row_wise=True)),
                     (64, IN0_INNER_DIM_PER_CORE),
                     ttnn.ShardOrientation.ROW_MAJOR,
                     False,


### PR DESCRIPTION
### Ticket
Link to Github Issue https://github.com/tenstorrent/tt-metal/issues/12448

### Problem description
- a refactor broke the 1d matmul sweep test vector generation because some parameters were of the wrong type

### What's changed
- use ttnn.CoreRangeSet to get the right class for the parameters

### Checklist
- [ ] Post commit CI passes N/A
- [ ] Blackhole Post commit (if applicable) N/A
- [ ] Model regression CI testing passes (if applicable) N/A
- [ ] Device performance regression CI testing passes (if applicable) N/A
- [ ] New/Existing tests provide coverage for changes N/A
