### PR TITLE
Added deallocation of kv cache for Mistral demo without prefill

### DIFF
--- a/models/demos/wormhole/mistral7b/demo/demo.py
+++ b/models/demos/wormhole/mistral7b/demo/demo.py
@@ -184,6 +184,9 @@ def run_mistral_demo(user_input, batch_size, device, instruct_mode, is_ci_env, n
                 k_cache = k_cache * 0
                 v_cache = v_cache * 0
                 layer.attention.layer_past_list[0] = [k_cache, v_cache]
+                layer.attention.layer_past_list[0][0].deallocate(True)
+                layer.attention.layer_past_list[0][1].deallocate(True)
+                layer.attention.layer_past_list[0] = [k_cache, v_cache]
 
         # Keep track of generated outputs to print out every iteration
         all_outputs = [[] for _ in range(batch_size)]


### PR DESCRIPTION
### Ticket
n/a

### Problem description
Deallocation of kv cache causing L1 cache OOM issues was present in `demo_with_prefill.py` but not `demo.py` 

### What's changed
This PR adds the deallocation of the kv cache to `demo.py`. 

### Checklist
- [ ] Post commit CI passes
