### PR TITLE
#12532: Change sweep new vector checking to use the serialized vector…

### DIFF
--- a/tests/sweep_framework/parameter_generator.py
+++ b/tests/sweep_framework/parameter_generator.py
@@ -87,7 +87,7 @@ def export_suite_vectors(module_name, suite_name, vectors):
         vector = dict()
         for elem in vectors[i].keys():
             vector[elem] = serialize(vectors[i][elem], warnings)
-        input_hash = hashlib.sha224(str(vectors[i]).encode("utf-8")).hexdigest()
+        input_hash = hashlib.sha224(str(vector).encode("utf-8")).hexdigest()
         new_vector_hashes.add(input_hash)
         vector["timestamp"] = current_time
         vector["input_hash"] = input_hash


### PR DESCRIPTION
… instead of unserialized

### Ticket
#12532 

### Problem description
See issue.

### What's changed
Use the hash of the serialized vector instead of unserialized vector to detect changes to the inputs.

### Checklist
- [ ] Post commit CI passes
- [ ] Blackhole Post commit (if applicable)
- [ ] Model regression CI testing passes (if applicable)
- [ ] Device performance regression CI testing passes (if applicable)
- [ ] New/Existing tests provide coverage for changes
