### PR TITLE
#12497: ttnn.empty to use create_device_tensor

### DIFF
--- a/tests/tt_eager/python_api_testing/sweep_tests/tt_lib_ops.py
+++ b/tests/tt_eager/python_api_testing/sweep_tests/tt_lib_ops.py
@@ -1134,9 +1134,10 @@ def tril(x, *args, device, dtype, layout, input_mem_config, output_mem_config, *
 def empty(x, *args, device, dtype, layout, input_mem_config, output_mem_config, **kwargs):
     t1 = ttnn.empty(
         x.shape,
-        layout=layout[0],
-        device=device if input_mem_config[0] is not None else None,
-        memory_config=output_mem_config,
+        dtype,
+        layout[0],
+        device if input_mem_config[0] is not None else None,
+        output_mem_config,
     )
 
     return tt2torch_tensor(t1)

--- a/tests/tt_eager/python_api_testing/unit_testing/misc/test_concat.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/misc/test_concat.py
@@ -164,7 +164,7 @@ def test_concat_with_program_cache(
     shapes, dim, device, layout, dtype, input_mem_config, output_mem_config, use_program_cache, function_level_defaults
 ):
     run_concat(shapes, dim, device, layout, dtype, input_mem_config, output_mem_config)
-    tmp = ttnn.empty([1, 256, 32, 32], ttnn.bfloat16, ttnn.TILE_LAYOUT, device)
+    tmp = ttnn.zeros([1, 256, 32, 32], ttnn.bfloat16, ttnn.TILE_LAYOUT, device)
     run_concat(shapes, dim, device, layout, dtype, input_mem_config, output_mem_config)
 
 

--- a/tests/tt_eager/python_api_testing/unit_testing/misc/test_moreh_adamw.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/misc/test_moreh_adamw.py
@@ -36,7 +36,7 @@ def create_tt_tensors(cpu_grad, cpu_weight, cpu_exp_avg, cpu_exp_avg_sq, cpu_max
         return ret
 
     def create_empty_tensor(x, device):
-        ret = ttnn.empty(x.shape, ttnn.bfloat16, ttnn.TILE_LAYOUT, device)
+        ret = ttnn.zeros(x.shape, ttnn.bfloat16, ttnn.TILE_LAYOUT, device)
         return ret
 
     # input tensors

--- a/tests/tt_eager/python_api_testing/unit_testing/misc/test_repeat.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/misc/test_repeat.py
@@ -155,5 +155,5 @@ def test_repeat_with_program_cache(
     function_level_defaults,
 ):
     run_repeat(input_shape, repeats, device, layout, dtype, input_mem_config, output_mem_config)
-    tmp = ttnn.empty([1, 256, 32, 32], ttnn.bfloat16, ttnn.TILE_LAYOUT, device)
+    tmp = ttnn.zeros([1, 256, 32, 32], ttnn.bfloat16, ttnn.TILE_LAYOUT, device)
     run_repeat(input_shape, repeats, device, layout, dtype, input_mem_config, output_mem_config)

--- a/tests/ttnn/python_api_testing/sweep_tests/ttnn_ops.py
+++ b/tests/ttnn/python_api_testing/sweep_tests/ttnn_ops.py
@@ -2807,7 +2807,7 @@ def empty(
     output_mem_config,
     **kwargs,
 ):
-    t1 = ttnn.empty(shape=x.shape, memory_config=output_mem_config)
+    t1 = ttnn.empty(x.shape, dtype, layout, device, output_mem_config)
 
     result = ttnn_tensor_to_torch(t1)
     return ttnn_tensor_to_torch(t1)

--- a/tests/ttnn/sweep_tests/sweeps/sweeps/empty.py
+++ b/tests/ttnn/sweep_tests/sweeps/sweeps/empty.py
@@ -43,7 +43,7 @@ def run(
         torch_input_tensor, dtype=input_dtype, device=device, memory_config=input_memory_config, layout=layout
     )
 
-    output_tensor = ttnn.empty(input_tensor.shape, device=device, memory_config=output_memory_config)
+    output_tensor = ttnn.empty(input_shape, input_dtype, layout, device, output_memory_config)
     output_tensor = ttnn.to_torch(output_tensor)
 
     if torch_output_tensor.shape != output_tensor.shape:

--- a/tests/ttnn/sweep_tests/sweeps/sweeps/fold.py
+++ b/tests/ttnn/sweep_tests/sweeps/sweeps/fold.py
@@ -5,7 +5,6 @@
 import torch
 
 import ttnn
-import ttnn.experimental.tensor as tt_tensor
 from tests.ttnn.utils_for_testing import check_with_pcc
 
 
@@ -78,7 +77,7 @@ def run(N, H, W, C, shard_strategy, stride_h, stride_w, *, device):
         memory_config=memory_config,
     )
 
-    output = tt_tensor.fold(input_tensor, stride_h, stride_w)
+    output = ttnn.fold(input_tensor, stride_h, stride_w)
     output = ttnn.to_torch(output)
 
     return check_with_pcc(torch_output, output, 0.999)

--- a/tests/ttnn/unit_tests/operations/test_creation.py
+++ b/tests/ttnn/unit_tests/operations/test_creation.py
@@ -281,6 +281,30 @@ def test_arange(device, start, end, step):
 @pytest.mark.parametrize(
     "input_shapes",
     [
+        [1, 1, 32, 32],
+        [1, 1, 320, 384],
+        [1, 3, 320, 384],
+        [2, 640, 64, 64],
+        [2, 1280, 64, 64],
+    ],
+)
+def test_empty(device, input_shapes):
+    torch_input_tensor = torch.ones((input_shapes), dtype=torch.bfloat16)
+    torch_output_tensor = torch.empty(torch_input_tensor.shape, dtype=torch.bfloat16)
+
+    input_tensor = ttnn.from_torch(torch_input_tensor, layout=ttnn.TILE_LAYOUT)
+    input_tensor = ttnn.to_device(input_tensor, device)
+    output_tensor = ttnn.empty(input_shapes, ttnn.bfloat16, ttnn.TILE_LAYOUT, device, ttnn.DRAM_MEMORY_CONFIG)
+    output_tensor = ttnn.to_layout(output_tensor, ttnn.ROW_MAJOR_LAYOUT)
+    output_tensor = ttnn.from_device(output_tensor)
+    output_tensor = ttnn.to_torch(output_tensor)
+
+    assert list(torch_output_tensor.shape) == list(output_tensor.shape)
+
+
+@pytest.mark.parametrize(
+    "input_shapes",
+    [
         [2, 1, 4, 4],  # 256x256
         [2, 1280, 8, 8],
         [2, 640, 16, 16],
@@ -289,13 +313,13 @@ def test_arange(device, start, end, step):
         [2, 1280, 16, 16],
     ],
 )
-def test_empty(device, input_shapes):
-    torch_input_tensor = torch.rand((input_shapes), dtype=torch.bfloat16)
+def test_empty_like(device, input_shapes):
+    torch_input_tensor = torch.ones((input_shapes), dtype=torch.bfloat16)
     torch_output_tensor = torch.empty(torch_input_tensor.shape, dtype=torch.bfloat16)
 
     input_tensor = ttnn.from_torch(torch_input_tensor, layout=ttnn.TILE_LAYOUT)
     input_tensor = ttnn.to_device(input_tensor, device)
-    output_tensor = ttnn.empty(input_tensor.shape, device=device)
+    output_tensor = ttnn.empty_like(input_tensor, layout=ttnn.TILE_LAYOUT)
     output_tensor = ttnn.to_layout(output_tensor, ttnn.ROW_MAJOR_LAYOUT)
     output_tensor = ttnn.from_device(output_tensor)
     output_tensor = ttnn.to_torch(output_tensor)

--- a/ttnn/cpp/pybind11/operations/creation.hpp
+++ b/ttnn/cpp/pybind11/operations/creation.hpp
@@ -204,21 +204,76 @@ void bind_arange_operation(py::module& module, const creation_operation_t& opera
             py::arg("dtype") = ttnn::bfloat16,
             py::arg("device") = std::nullopt,
             py::arg("memory_config") = ttnn::DRAM_MEMORY_CONFIG});
-}  // namespace creation
+}
+
+void bind_empty_operation(py::module& module) {
+    auto doc = fmt::format(
+        R"doc({0}(shape: List[int], dtype: ttnn.DataType, layout: ttnn.Layout, device: ttnn.Device, memory_config: ttnn.MemoryConfig)doc",
+        ttnn::empty.base_name());
+
+    using EmptyType = decltype(ttnn::empty);
+    bind_registered_operation(
+        module,
+        ttnn::empty,
+        doc,
+        ttnn::pybind_overload_t{
+            [](const EmptyType& self,
+               const std::vector<uint32_t>& shape,
+               const DataType& dtype,
+               const Layout& layout,
+               Device* device,
+               const MemoryConfig& memory_config) -> ttnn::Tensor {
+                return self(ttnn::Shape{tt::tt_metal::LegacyShape{shape}}, dtype, layout, device, memory_config);
+            },
+            py::arg("shape"),
+            py::arg("dtype") = DataType::BFLOAT16,
+            py::arg("layout") = Layout::ROW_MAJOR,
+            py::arg("device") = nullptr,
+            py::arg("memory_config") = ttnn::DRAM_MEMORY_CONFIG});
+}
+
+void bind_empty_like_operation(py::module& module) {
+    auto doc = fmt::format(
+        R"doc({0}(tensor: ttnn.Tensor, dtype: Optional[ttnn.DataType] = None, layout: Optional[ttnn.Layout] = None, device: Optional[ttnn.Device] = None, memory_config: Optional[ttnn.MemoryConfig] = None)doc",
+        ttnn::empty_like.base_name());
+
+    using EmptyLikeType = decltype(ttnn::empty_like);
+    bind_registered_operation(
+        module,
+        ttnn::empty_like,
+        doc,
+        ttnn::pybind_overload_t{
+            [](const EmptyLikeType& self,
+               const ttnn::Tensor& reference,
+               const std::optional<DataType>& dtype,
+               const std::optional<Layout>& layout,
+               const std::optional<std::reference_wrapper<Device>>& device,
+               const std::optional<MemoryConfig>& memory_config) -> ttnn::Tensor {
+                return self(reference, dtype, layout, device, memory_config);
+            },
+            py::arg("tensor"),
+            py::kw_only(),
+            py::arg("dtype") = DataType::BFLOAT16,
+            py::arg("layout") = Layout::ROW_MAJOR,
+            py::arg("device") = std::nullopt,
+            py::arg("memory_config") = ttnn::DRAM_MEMORY_CONFIG});
+}
+
 }  // namespace detail
 
 void py_module(py::module& module) {
     detail::bind_full_operation(module, ttnn::full);
     detail::bind_full_operation_with_hard_coded_value(module, ttnn::zeros);
     detail::bind_full_operation_with_hard_coded_value(module, ttnn::ones);
-    detail::bind_full_operation_with_hard_coded_value(module, ttnn::empty);
 
     detail::bind_full_like_operation(module, ttnn::full_like);
     detail::bind_full_like_operation_with_hard_coded_value(module, ttnn::zeros_like);
     detail::bind_full_like_operation_with_hard_coded_value(module, ttnn::ones_like);
-    detail::bind_full_like_operation_with_hard_coded_value(module, ttnn::empty_like);
 
     detail::bind_arange_operation(module, ttnn::arange);
+
+    detail::bind_empty_operation(module);
+    detail::bind_empty_like_operation(module);
 }
 
 }  // namespace creation

--- a/ttnn/cpp/ttnn/operations/creation.hpp
+++ b/ttnn/cpp/ttnn/operations/creation.hpp
@@ -124,11 +124,9 @@ struct FullWith {
 
 struct Zeros : FullWith<0.0f> {};
 struct Ones : FullWith<1.0f> {};
-struct Empty : FullWith<0.0f> {};
 
 inline constexpr Zeros zeros{};
 inline constexpr Ones ones{};
-inline constexpr Empty empty{};
 
 template <typename T>
 inline ttnn::Tensor full_like_impl(
@@ -203,11 +201,35 @@ struct FullLikeWith {
 
 struct ZerosLike : FullLikeWith<0.0f> {};
 struct OnesLike : FullLikeWith<1.0f> {};
-struct EmptyLike : FullLikeWith<0.0f> {};
 
 inline constexpr ZerosLike zeros_like{};
 inline constexpr OnesLike ones_like{};
-inline constexpr EmptyLike empty_like{};
+
+struct Empty {
+   static ttnn::Tensor invoke(
+    const ttnn::Shape& shape,
+    const DataType& dtype,
+    const Layout& layout,
+    Device* device,
+    const MemoryConfig& memory_config) {
+        return create_device_tensor(shape, dtype, layout, device, memory_config);
+    }
+};
+
+struct EmptyLike {
+   static ttnn::Tensor invoke(
+    const ttnn::Tensor& tensor,
+    const std::optional<DataType>& dtype = std::nullopt,
+    const std::optional<Layout>& layout = std::nullopt,
+    const std::optional<std::reference_wrapper<Device>>& device_arg = std::nullopt,
+    const std::optional<MemoryConfig>& memory_config = std::nullopt) {
+    Device* device = device_arg.has_value() ? &(device_arg.value().get()) : tensor.device();
+    Layout layout_value = layout.value_or(tensor.get_layout());
+    DataType dtype_value = dtype.value_or(tensor.get_dtype());
+    MemoryConfig mem_cfg = memory_config.value_or(tensor.memory_config());
+        return create_device_tensor(tensor.get_shape(), dtype_value, layout_value, device, mem_cfg);
+    }
+};
 
 struct Full {
     static ttnn::Tensor invoke(


### PR DESCRIPTION
### Ticket
Link to Github Issue #12497

### Problem description
ttnn.empty creates a zeros tensor

### What's changed
ttnn.empty to use `create_device_tensor` to create a device tensor instead of creating a zeros tensor.

### Checklist
- [ ] Post commit CI https://github.com/tenstorrent/tt-metal/actions/runs/10834027617
https://github.com/tenstorrent/tt-metal/actions/runs/10893839286
- [ ] Nightly fd https://github.com/tenstorrent/tt-metal/actions/runs/10831930871
- [ ] Model perf https://github.com/tenstorrent/tt-metal/actions/runs/10831933777
- [ ] Demos https://github.com/tenstorrent/tt-metal/actions/runs/10831956367
- [ ] Blackhole Post commit (if applicable)
- [ ] Model regression CI testing passes (if applicable)
- [ ] Device performance regression CI testing passes (if applicable)
- [ ] New/Existing tests provide coverage for changes
