### PR TITLE
#12554: Port `moreh_matmul_bw` from `tt_dnn` to `ttnn`

### DIFF
--- a/tests/ttnn/unit_tests/operations/test_moreh_dot_backward.py
+++ b/tests/ttnn/unit_tests/operations/test_moreh_dot_backward.py
@@ -117,8 +117,8 @@ def test_moreh_matmul_1d_backward(input_shape, requires_grad, device):
     torch_out.backward(torch_output_grad)
 
     # tt matmul backward
-    ttnn.experimental.operations.primary.moreh_matmul_backward(
-        tt_output_grad, tt_input, tt_other, (require_input_grad, require_other_grad), tt_input_grad, tt_other_grad
+    ttnn.operations.moreh.dot_backward(
+        tt_output_grad, tt_input, tt_other, input_grad=tt_input_grad, other_grad=tt_other_grad
     )
 
     # test for equivalance

--- a/tests/ttnn/unit_tests/operations/test_moreh_matmul.py
+++ b/tests/ttnn/unit_tests/operations/test_moreh_matmul.py
@@ -306,3 +306,78 @@ def test_moreh_matmul_1d(input_shape, device):
     logger.debug(f"Output pcc={output_pcc}")
 
     assert passing
+    
+    
+@pytest.mark.parametrize(
+    "params",
+    (
+        # input, other, output shape
+        ([3, 128, 96], [3, 4, 1, 96, 256], [3, 4, 3, 128, 256]),
+        ([3, 3, 313, 511], [3, 3, 511, 765], [3, 3, 313, 765]),
+        ([3, 1, 2, 1, 4, 1, 319, 95], [4, 2, 95, 470], [3, 1, 2, 1, 4, 2, 319, 470]),
+        ([3, 2, 1, 470, 95], [2, 1, 3, 1, 2, 2, 95, 319], [2, 1, 3, 3, 2, 2, 470, 319]),
+    ),
+)
+@pytest.mark.parametrize(
+    "requires_grad",
+    (
+        (True, False),
+        (False, True),
+        (True, True),
+    ),
+)
+def test_moreh_matmul_backward(params, requires_grad, device):
+    torch.manual_seed(3072)
+    input_shape, other_shape, output_shape = params
+    require_input_grad, require_other_grad = requires_grad
+
+    # get tensors
+    (
+        tt_input,
+        tt_other,
+        _,
+        tt_output_grad,
+        tt_input_grad,
+        tt_other_grad,
+        torch_input,
+        torch_other,
+        torch_output_grad,
+    ) = get_tensors(input_shape, other_shape, output_shape, require_input_grad, require_other_grad, False, device)
+
+    # torch matmul
+    torch_out = torch.matmul(
+        torch_input.requires_grad_(require_input_grad), torch_other.requires_grad_(require_other_grad)
+    )
+    torch_out.backward(torch_output_grad)
+
+    # tt matmul backward
+    tt_input_grad, tt_other_grad = ttnn.operations.moreh.matmul_backward(
+        tt_output_grad,
+        tt_input,
+        tt_other,
+        are_required_outputs=(require_input_grad, require_other_grad),
+        input_a_grad=tt_input_grad,
+        input_b_grad=tt_other_grad,
+    )
+
+    # test for equivalance
+    rtol = atol = 0.1
+    cpu_layout = ttnn.ROW_MAJOR_LAYOUT
+    if require_input_grad:
+        ttcpu_input_grad = tt_input_grad.cpu().to(cpu_layout).unpad_from_tile(input_shape).to_torch()
+        passing, output_pcc = comp_allclose_and_pcc(torch_input.grad, ttcpu_input_grad, pcc=0.999, rtol=rtol, atol=atol)
+        logger.debug(f"input_grad passing={passing}")
+        logger.debug(f"input_grad pcc={output_pcc}")
+        assert passing
+    else:
+        assert tt_input_grad is None
+
+    if require_other_grad:
+        ttcpu_other_grad = tt_other_grad.cpu().to(cpu_layout).unpad_from_tile(other_shape).to_torch()
+        passing, output_pcc = comp_allclose_and_pcc(torch_other.grad, ttcpu_other_grad, pcc=0.999, rtol=rtol, atol=atol)
+        logger.debug(f"other_grad passing={passing}")
+        logger.debug(f"other_grad pcc={output_pcc}")
+        assert passing
+    else:
+        assert tt_other_grad is None
+

--- a/tests/ttnn/unit_tests/operations/test_moreh_matmul.py
+++ b/tests/ttnn/unit_tests/operations/test_moreh_matmul.py
@@ -423,14 +423,15 @@ def test_moreh_matmul_1d_backward(input_shape, requires_grad, device):
     torch_out.backward(torch_output_grad)
 
     # tt matmul backward
-    ttnn.operations.moreh.matmul_backward(
-        tt_output_grad,
-        tt_input,
-        tt_other,
-        are_required_outputs=(require_input_grad, require_other_grad),
-        input_a_grad=tt_input_grad,
-        input_b_grad=tt_other_grad,
-    )
+    for _ in range(2):
+        ttnn.operations.moreh.matmul_backward(
+            tt_output_grad,
+            tt_input,
+            tt_other,
+            are_required_outputs=(require_input_grad, require_other_grad),
+            input_a_grad=tt_input_grad,
+            input_b_grad=tt_other_grad,
+        )
 
     # test for equivalance
     rtol = atol = 0.1

--- a/ttnn/CMakeLists.txt
+++ b/ttnn/CMakeLists.txt
@@ -421,6 +421,8 @@ set(ALL_TTNN_SRCS
     ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/moreh/moreh_matmul/device/moreh_matmul_program_factory.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/moreh/moreh_matmul/moreh_matmul_pybind.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/moreh/moreh_matmul/moreh_matmul.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/moreh/moreh_matmul_backward/moreh_matmul_backward.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/moreh/moreh_matmul_backward/moreh_matmul_backward_pybind.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/moreh/moreh_mean_backward/device/moreh_mean_backward_device_operation.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/moreh/moreh_mean_backward/device/moreh_mean_backward_program_factory.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/moreh/moreh_mean_backward/moreh_mean_backward_pybind.cpp
@@ -497,6 +499,7 @@ set(ALL_TTNN_SRCS
     ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/moreh/moreh_sum/device/moreh_sum_w_program_factory.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/moreh/moreh_sum/moreh_sum_pybind.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/moreh/moreh_sum/moreh_sum.cpp
+
 )
 
 #Split src and python bindings

--- a/ttnn/cpp/ttnn/operations/examples/example/example_pybind.hpp
+++ b/ttnn/cpp/ttnn/operations/examples/example/example_pybind.hpp
@@ -16,7 +16,6 @@ namespace py = pybind11;
 namespace ttnn::operations::examples {
 
 void bind_example_operation(py::module& module) {
-
     bind_registered_operation(
         module,
         ttnn::prim::example,
@@ -25,10 +24,12 @@ void bind_example_operation(py::module& module) {
         // Add pybind overloads for the C++ APIs that should be exposed to python
         // There should be no logic here, just a call to `self` with the correct arguments
         // The overload with `queue_id` argument will be added automatically for primitive operations
-        // This specific function can be called from python as `ttnn.prim.example(input_tensor)` or `ttnn.prim.example(input_tensor, queue_id=queue_id)`
+        // This specific function can be called from python as `ttnn.prim.example(input_tensor)` or
+        // `ttnn.prim.example(input_tensor, queue_id=queue_id)`
         ttnn::pybind_overload_t{
-            [](const decltype(ttnn::prim::example)& self, const ttnn::Tensor& input_tensor)
-                -> ttnn::Tensor { return self(input_tensor); },
+            [](const decltype(ttnn::prim::example)& self, const ttnn::Tensor& input_tensor) -> ttnn::Tensor {
+                return self(input_tensor);
+            },
             py::arg("input_tensor")});
 
     bind_registered_operation(
@@ -39,8 +40,9 @@ void bind_example_operation(py::module& module) {
         // Add pybind overloads for the C++ APIs that should be exposed to python
         // There should be no logic here, just a call to `self` with the correct arguments
         ttnn::pybind_overload_t{
-            [](const decltype(ttnn::composite_example)& self, const ttnn::Tensor& input_tensor)
-                -> ttnn::Tensor { return self(input_tensor); },
+            [](const decltype(ttnn::composite_example)& self, const ttnn::Tensor& input_tensor) -> ttnn::Tensor {
+                return self(input_tensor);
+            },
             py::arg("input_tensor")});
 }
 

--- a/ttnn/cpp/ttnn/operations/examples/example/example_pybind.hpp
+++ b/ttnn/cpp/ttnn/operations/examples/example/example_pybind.hpp
@@ -16,6 +16,7 @@ namespace py = pybind11;
 namespace ttnn::operations::examples {
 
 void bind_example_operation(py::module& module) {
+
     bind_registered_operation(
         module,
         ttnn::prim::example,
@@ -24,12 +25,10 @@ void bind_example_operation(py::module& module) {
         // Add pybind overloads for the C++ APIs that should be exposed to python
         // There should be no logic here, just a call to `self` with the correct arguments
         // The overload with `queue_id` argument will be added automatically for primitive operations
-        // This specific function can be called from python as `ttnn.prim.example(input_tensor)` or
-        // `ttnn.prim.example(input_tensor, queue_id=queue_id)`
+        // This specific function can be called from python as `ttnn.prim.example(input_tensor)` or `ttnn.prim.example(input_tensor, queue_id=queue_id)`
         ttnn::pybind_overload_t{
-            [](const decltype(ttnn::prim::example)& self, const ttnn::Tensor& input_tensor) -> ttnn::Tensor {
-                return self(input_tensor);
-            },
+            [](const decltype(ttnn::prim::example)& self, const ttnn::Tensor& input_tensor)
+                -> ttnn::Tensor { return self(input_tensor); },
             py::arg("input_tensor")});
 
     bind_registered_operation(
@@ -40,9 +39,8 @@ void bind_example_operation(py::module& module) {
         // Add pybind overloads for the C++ APIs that should be exposed to python
         // There should be no logic here, just a call to `self` with the correct arguments
         ttnn::pybind_overload_t{
-            [](const decltype(ttnn::composite_example)& self, const ttnn::Tensor& input_tensor) -> ttnn::Tensor {
-                return self(input_tensor);
-            },
+            [](const decltype(ttnn::composite_example)& self, const ttnn::Tensor& input_tensor)
+                -> ttnn::Tensor { return self(input_tensor); },
             py::arg("input_tensor")});
 }
 

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_dot_op_backward/device/moreh_dot_backward_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_dot_op_backward/device/moreh_dot_backward_device_operation.cpp
@@ -10,31 +10,21 @@
 namespace ttnn::operations::moreh::moreh_dot_backward {
 MorehDotBackwardOperation::program_factory_t MorehDotBackwardOperation::select_program_factory(
     const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args) {
-    // For now we litteraly don't care and return a single factory. Whatever
     return SingleCore{};
 }
 
-void MorehDotBackwardOperation::validate_on_program_cache_miss(
-    const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args) {
-    // TT_FATAL("INTENTIONAL: validate_on_program_cache_miss");
-}
-
-void MorehDotBackwardOperation::validate_on_program_cache_hit(
-    const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args) {
-    // TT_FATAL("INTENTIONAL: validate_on_program_cache_hit");
-}
-
 void grad_tensor_validate(const Tensor& tensor, const Tensor& grad_tensor) {
-    const auto& tensor_shape = tensor.get_shape().value.without_padding();
-    const auto& grad_tensor_shape = grad_tensor.get_shape().value.without_padding();
+    const auto& tensor_shape = tensor.get_legacy_shape().without_padding();
+    const auto& grad_tensor_shape = grad_tensor.get_legacy_shape().without_padding();
     TT_FATAL(tensor_shape == grad_tensor_shape, "Tensor shape and grad tensor shape should be the same.");
     TT_FATAL(grad_tensor.storage_type() == StorageType::DEVICE, "Operands to dot backward need to be on device!");
     TT_FATAL(grad_tensor.device() == tensor.device(), "Operands to dot backward need to be on the same device!");
     TT_FATAL(grad_tensor.buffer() != nullptr, "Operands to dot backward need to be allocated in buffers on device!");
 }
 
-void MorehDotBackwardOperation::validate(
-    const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args) {
+void validate_tensors(
+    const MorehDotBackwardOperation::operation_attributes_t& operation_attributes,
+    const MorehDotBackwardOperation::tensor_args_t& tensor_args) {
     const auto& output_grad = tensor_args.output_grad;
     const auto& input = tensor_args.input;
     const auto& other = tensor_args.other;
@@ -57,24 +47,38 @@ void MorehDotBackwardOperation::validate(
         output_grad.buffer() != nullptr and input.buffer() != nullptr and other.buffer() != nullptr,
         "Operands to dot backward need to be allocated in buffers on device!");
 
-    const auto& input_grad = tensor_args.input_grad;
-    const auto& other_grad = tensor_args.other_grad;
-    if (input_grad) {
+    // validate optional inputs
+    const auto& input_grad = tensor_args.output_tensors.at(0);
+    const auto& other_grad = tensor_args.output_tensors.at(1);
+    if (input_grad.has_value()) {
         grad_tensor_validate(input, input_grad.value());
     }
-    if (other_grad) {
+
+    if (other_grad.has_value()) {
         grad_tensor_validate(other, other_grad.value());
     }
 }
 
+void MorehDotBackwardOperation::validate_on_program_cache_miss(
+    const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args) {
+    validate_tensors(operation_attributes, tensor_args);
+}
+
+void MorehDotBackwardOperation::validate_on_program_cache_hit(
+    const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args) {
+    validate_tensors(operation_attributes, tensor_args);
+}
+
 MorehDotBackwardOperation::shape_return_value_t MorehDotBackwardOperation::compute_output_shapes(
     const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args) {
+    TT_FATAL(false, "This operation is in place, and as such, should not be computing output shapes.");
     return {};
 }
 
 MorehDotBackwardOperation::tensor_return_value_t MorehDotBackwardOperation::create_output_tensors(
     const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args) {
-    return {};
+    TT_FATAL(tensor_args.output_tensors.size() > 0, "Invalid number of output tensors.");
+    return tensor_args.output_tensors;
 }
 
 std::tuple<MorehDotBackwardOperation::operation_attributes_t, MorehDotBackwardOperation::tensor_args_t>
@@ -87,7 +91,7 @@ MorehDotBackwardOperation::invoke(
     const std::optional<MemoryConfig>& memory_config) {
     return {
         operation_attributes_t{memory_config.value_or(input.memory_config())},
-        tensor_args_t{output_grad, input, other, input_grad, other_grad}};
+        tensor_args_t{output_grad, input, other, {input_grad, other_grad}}};
 }
 
 }  // namespace ttnn::operations::moreh::moreh_dot_backward

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_dot_op_backward/device/moreh_dot_backward_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_dot_op_backward/device/moreh_dot_backward_device_operation.hpp
@@ -21,12 +21,13 @@ struct MorehDotBackwardOperation {
         const Tensor &output_grad;
         const Tensor &input;
         const Tensor &other;
-        const std::optional<const Tensor> &input_grad;
-        const std::optional<const Tensor> &other_grad;
+
+        // (o2buzzle): May I present: thanhnguyen's mistake that costed me 3 hours.
+        const std::vector<std::optional<Tensor>> output_tensors;
     };
 
-    using shape_return_value_t = std::vector<ttnn::Shape>;
-    using tensor_return_value_t = std::vector<Tensor>;
+    using shape_return_value_t = std::vector<std::optional<Shape>>;
+    using tensor_return_value_t = std::vector<std::optional<Tensor>>;
 
     struct SingleCore {
         struct shared_variables_t {
@@ -52,7 +53,6 @@ struct MorehDotBackwardOperation {
     static program_factory_t select_program_factory(const operation_attributes_t &, const tensor_args_t &);
     static void validate_on_program_cache_miss(const operation_attributes_t &, const tensor_args_t &);
     static void validate_on_program_cache_hit(const operation_attributes_t &, const tensor_args_t &);
-    static void validate(const operation_attributes_t &, const tensor_args_t &);
     static shape_return_value_t compute_output_shapes(const operation_attributes_t &, const tensor_args_t &);
     static tensor_return_value_t create_output_tensors(const operation_attributes_t &, const tensor_args_t &);
 

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_dot_op_backward/device/moreh_dot_backward_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_dot_op_backward/device/moreh_dot_backward_program_factory.cpp
@@ -96,9 +96,9 @@ MorehDotBackwardOperation::SingleCore::cached_program_t MorehDotBackwardOperatio
     };
 
     const auto reader_kernel_file =
-        "ttnn/cpp/ttnn/deprecated/tt_dnn/op_library/moreh_dot_backward/kernels/reader_moreh_dot_backward.cpp";
+        "ttnn/cpp/ttnn/operations/moreh/moreh_dot_op_backward/device/kernels/reader_moreh_dot_backward.cpp";
     const auto writer_kernel_file =
-        "ttnn/cpp/ttnn/deprecated/tt_dnn/op_library/moreh_dot_backward/kernels/writer_moreh_dot_backward.cpp";
+        "ttnn/cpp/ttnn/operations/moreh/moreh_dot_op_backward/device/kernels/writer_moreh_dot_backward.cpp";
 
     const auto reader_kernel_id =
         tt::operations::primary::CreateReadKernel(program, reader_kernel_file, core, reader_compile_time_args);
@@ -109,7 +109,7 @@ MorehDotBackwardOperation::SingleCore::cached_program_t MorehDotBackwardOperatio
     std::map<string, string> compute_defines;
 
     const auto compute_kernel_file =
-        "ttnn/cpp/ttnn/deprecated/tt_dnn/op_library/moreh_dot_backward/kernels/moreh_dot_backward.cpp";
+        "ttnn/cpp/ttnn/operations/moreh/moreh_dot_op_backward/device/kernels/moreh_dot_backward.cpp";
     const auto compute_kernel_id = tt::operations::primary::CreateComputeKernel(
         program, compute_kernel_file, {core, core_num, compute_kernel_args}, compute_defines);
 

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_dot_op_backward/device/moreh_dot_backward_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_dot_op_backward/device/moreh_dot_backward_program_factory.cpp
@@ -2,6 +2,8 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
+#include <cstdio>
+
 #include "moreh_dot_backward_device_operation.hpp"
 #include "tt_metal/detail/util.hpp"
 #include "ttnn/deprecated/tt_dnn/op_library/moreh_helper_functions.hpp"
@@ -17,9 +19,8 @@ MorehDotBackwardOperation::SingleCore::cached_program_t MorehDotBackwardOperatio
     const auto& output_grad = tensor_args.output_grad;
     const auto& input = tensor_args.input;
     const auto& other = tensor_args.other;
-    const auto& input_grad = tensor_args.input_grad;
-    const auto& other_grad = tensor_args.other_grad;
-
+    const auto& input_grad = tensor_return_value.at(0);
+    const auto& other_grad = tensor_return_value.at(1);
     Program program{};
     CoreCoord core = {0, 0};
     const uint32_t core_num = 1;
@@ -149,8 +150,8 @@ void MorehDotBackwardOperation::SingleCore::override_runtime_arguments(
     const auto& output_grad_buffer = tensor_args.output_grad.buffer();
     const auto& input_buffer = tensor_args.input.buffer();
     const auto& other_buffer = tensor_args.other.buffer();
-    const auto& input_grad_buffer = tensor_return_value.at(0).buffer();
-    const auto& other_grad_buffer = tensor_return_value.at(1).buffer();
+    const auto input_grad_buffer = tensor_return_value.at(0);
+    const auto other_grad_buffer = tensor_return_value.at(1);
 
     {
         auto& runtime_args = tt::tt_metal::GetRuntimeArgs(program, unary_reader_kernel_id, CoreCoord{0, 0});
@@ -161,8 +162,10 @@ void MorehDotBackwardOperation::SingleCore::override_runtime_arguments(
 
     {
         auto& runtime_args = tt::tt_metal::GetRuntimeArgs(program, unary_writer_kernel_id, CoreCoord{0, 0});
-        runtime_args[2] = input_grad_buffer->address();
-        runtime_args[3] = other_grad_buffer->address();
+        if (input_grad_buffer.has_value())
+            runtime_args[2] = input_grad_buffer.value().buffer()->address();
+        if (other_grad_buffer.has_value())
+            runtime_args[3] = other_grad_buffer.value().buffer()->address();
     }
 }
 

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_dot_op_backward/moreh_dot_backward.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_dot_op_backward/moreh_dot_backward.cpp
@@ -7,12 +7,12 @@
 #include "ttnn/operations/moreh/moreh_dot_op_backward/device/moreh_dot_backward_device_operation.hpp"
 
 namespace ttnn::operations::moreh::moreh_dot_backward {
-std::vector<Tensor> MorehDotBackward::invoke(
+std::vector<std::optional<Tensor>> MorehDotBackward::invoke(
     const Tensor &output_grad,
     const Tensor &input,
     const Tensor &other,
-    std::optional<const Tensor> input_grad,
-    std::optional<const Tensor> other_grad,
+    const std::optional<const Tensor> &input_grad,
+    const std::optional<const Tensor> &other_grad,
     const std::optional<MemoryConfig> &mem_config) {
     return ttnn::prim::moreh_dot_backward(output_grad, input, other, input_grad, other_grad, mem_config);
 }

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_dot_op_backward/moreh_dot_backward.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_dot_op_backward/moreh_dot_backward.cpp
@@ -16,4 +16,27 @@ std::vector<std::optional<Tensor>> MorehDotBackward::invoke(
     const std::optional<MemoryConfig> &mem_config) {
     return ttnn::prim::moreh_dot_backward(output_grad, input, other, input_grad, other_grad, mem_config);
 }
+
+std::vector<Tensor> MorehDotBackward::create_async_output_tensors(
+    const std::vector<Tensor> &input_tensors, const std::vector<std::optional<const Tensor>> &optional_inputs) {
+    auto output_grad = input_tensors.at(0);
+    auto input = input_tensors.at(1);
+    auto other = input_tensors.at(2);
+
+    return {
+        Tensor(operation::get_workers_for_op_output({output_grad, input, other})),
+        Tensor(operation::get_workers_for_op_output({output_grad, input, other})),
+    };
+}
+
+std::vector<bool> MorehDotBackward::create_async_return_flag(
+    const Tensor &output_grad,
+    const Tensor &input,
+    const Tensor &other,
+    const std::optional<const Tensor> &input_grad,
+    const std::optional<const Tensor> &other_grad,
+    const std::optional<MemoryConfig> &mem_config) {
+    return {input_grad.has_value(), other_grad.has_value()};
+}
+
 }  // namespace ttnn::operations::moreh::moreh_dot_backward

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_dot_op_backward/moreh_dot_backward.hpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_dot_op_backward/moreh_dot_backward.hpp
@@ -13,10 +13,22 @@ struct MorehDotBackward {
         const std::optional<const Tensor> &input_grad,
         const std::optional<const Tensor> &other_grad,
         const std::optional<MemoryConfig> &mem_config);
+
+    static std::vector<Tensor> create_async_output_tensors(
+        const std::vector<Tensor> &input_tensors, const std::vector<std::optional<const Tensor>> &optional_inputs);
+
+    static std::vector<bool> create_async_return_flag(
+        const Tensor &output_grad,
+        const Tensor &input,
+        const Tensor &other,
+        const std::optional<const Tensor> &input_grad,
+        const std::optional<const Tensor> &other_grad,
+        const std::optional<MemoryConfig> &mem_config);
 };
 }  // namespace ttnn::operations::moreh::moreh_dot_backward
 
 namespace ttnn {
-constexpr auto moreh_dot_backward = ttnn::
-    register_operation<"ttnn::moreh_dot_backward", ttnn::operations::moreh::moreh_dot_backward::MorehDotBackward>();
+constexpr auto moreh_dot_backward = ttnn::register_operation_with_auto_launch_op<
+    "ttnn::moreh_dot_backward",
+    ttnn::operations::moreh::moreh_dot_backward::MorehDotBackward>();
 }

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_dot_op_backward/moreh_dot_backward.hpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_dot_op_backward/moreh_dot_backward.hpp
@@ -6,12 +6,12 @@
 #include "ttnn/decorators.hpp"
 namespace ttnn::operations::moreh::moreh_dot_backward {
 struct MorehDotBackward {
-    static std::vector<Tensor> invoke(
+    static std::vector<std::optional<Tensor>> invoke(
         const Tensor &output_grad,
         const Tensor &input,
         const Tensor &other,
-        std::optional<const Tensor> input_grad,
-        std::optional<const Tensor> other_grad,
+        const std::optional<const Tensor> &input_grad,
+        const std::optional<const Tensor> &other_grad,
         const std::optional<MemoryConfig> &mem_config);
 };
 }  // namespace ttnn::operations::moreh::moreh_dot_backward

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_matmul/device/moreh_matmul_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_matmul/device/moreh_matmul_device_operation.cpp
@@ -237,7 +237,7 @@ MorehMatmulOperation::invoke(
             transpose_input,
             transpose_other,
             output_memory_config.value_or(input.memory_config()),
-            compute_kernel_config},
+            init_device_compute_kernel_config(input.device()->arch(), compute_kernel_config)},
         MorehMatmulOperation::tensor_args_t{input, other, output, bias}};
 }
 }  // namespace ttnn::operations::moreh::moreh_matmul

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_matmul/device/moreh_matmul_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_matmul/device/moreh_matmul_device_operation.hpp
@@ -17,7 +17,7 @@ struct MorehMatmulOperation {
         bool transpose_other;
 
         const MemoryConfig output_memory_config;
-        const std::optional<DeviceComputeKernelConfig> compute_kernel_config;
+        const DeviceComputeKernelConfig compute_kernel_config;
     };
 
     struct tensor_args_t {
@@ -73,7 +73,8 @@ struct MorehMatmulOperation {
 };
 
 void get_tensor_dim(std::vector<uint32_t>& dim, const tt::tt_metal::LegacyShape& shape);
-std::vector<int64_t> find_reduce_dim(const tt::tt_metal::LegacyShape& a_shape, const tt::tt_metal::LegacyShape& b_shape);
+std::vector<int64_t> find_reduce_dim(
+    const tt::tt_metal::LegacyShape& a_shape, const tt::tt_metal::LegacyShape& b_shape);
 bool is_same_batch_dim(const Tensor& tensor_a, const Tensor& tensor_b);
 
 }  // namespace ttnn::operations::moreh::moreh_matmul

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_matmul/device/moreh_matmul_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_matmul/device/moreh_matmul_program_factory.cpp
@@ -40,7 +40,7 @@ std::vector<int64_t> find_reduce_dim(
     // batch dims
     for (int i = 0; i < rank - 2; ++i) {
         int idx = rank - 1 - i;
-        TT_ASSERT(idx >= 0);
+        TT_ASSERT(idx >= 0, "idx < 0");
         if (a_dim[idx] != b_dim[idx]) {
             dims.push_back(i);
             log_debug(tt::LogOp, "find_reduce_dim :{} push {} dim", __LINE__, i);

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_matmul/device/moreh_matmul_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_matmul/device/moreh_matmul_program_factory.cpp
@@ -40,7 +40,7 @@ std::vector<int64_t> find_reduce_dim(
     // batch dims
     for (int i = 0; i < rank - 2; ++i) {
         int idx = rank - 1 - i;
-        TT_ASSERT(idx >= 0, "idx < 0");
+        TT_FATAL(idx >= 0, "idx < 0");
         if (a_dim[idx] != b_dim[idx]) {
             dims.push_back(i);
             log_debug(tt::LogOp, "find_reduce_dim :{} push {} dim", __LINE__, i);

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_matmul_backward/moreh_matmul_backward.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_matmul_backward/moreh_matmul_backward.cpp
@@ -1,0 +1,81 @@
+// SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "moreh_matmul_backward.hpp"
+
+#include "ttnn/operations/moreh/moreh_matmul/device/moreh_matmul_device_operation.hpp"
+#include "ttnn/operations/moreh/moreh_matmul/moreh_matmul.hpp"
+#include "ttnn/operations/moreh/moreh_sum/moreh_sum.hpp"
+
+namespace ttnn::operations::moreh::moreh_matmul_backward {
+/////////////////////////////////////////
+std::vector<std::optional<Tensor>> MorehMatmulBackward::invoke(
+    const Tensor& output_grad,
+    const Tensor& input,
+    const Tensor& other,
+    const std::vector<bool>& are_required_outputs,
+    const std::optional<const Tensor>& input_grad,
+    const std::optional<const Tensor>& other_grad,
+    const std::optional<ttnn::MemoryConfig>& output_mem_config,
+    const std::optional<ttnn::DeviceComputeKernelConfig> compute_kernel_config) {
+    std::vector<std::optional<Tensor>> outputs(2);
+    outputs.reserve(2);
+
+    const bool input_requires_grad = are_required_outputs.at(0);
+    const bool other_requires_grad = are_required_outputs.at(1);
+
+    if (input_requires_grad) {
+        TT_ASSERT(input_grad.has_value());
+        const auto& input_grad_tensor = input_grad.value();
+        if (moreh_matmul::is_same_batch_dim(output_grad, input_grad_tensor)) {
+            const auto& input_grad_shape = input_grad_tensor.get_legacy_shape().without_padding();
+            const auto& output_grad_shape = output_grad.get_legacy_shape().without_padding();
+            ttnn::moreh_matmul(
+                output_grad,
+                other,
+                false,
+                true,
+                input_grad_tensor,
+                std::nullopt,
+                output_mem_config,
+                compute_kernel_config);
+        } else {
+            const auto& input_shape = input.get_legacy_shape().without_padding();
+            const auto& temp_input_grad = ttnn::moreh_matmul(
+                output_grad, other, false, true, std::nullopt, std::nullopt, output_mem_config, compute_kernel_config);
+            auto reduce_dims =
+                moreh_matmul::find_reduce_dim(temp_input_grad.get_legacy_shape(), input_grad_tensor.get_legacy_shape());
+            ttnn::moreh_sum(
+                temp_input_grad, reduce_dims, true, input_grad_tensor, output_mem_config, compute_kernel_config);
+        }
+        outputs[0] = input_grad_tensor;
+    }
+
+    if (other_requires_grad) {
+        TT_ASSERT(other_grad.has_value());
+        const auto& other_grad_tensor = other_grad.value();
+        if (moreh_matmul::is_same_batch_dim(output_grad, other_grad_tensor)) {
+            ttnn::moreh_matmul(
+                input,
+                output_grad,
+                true,
+                false,
+                other_grad_tensor,
+                std::nullopt,
+                output_mem_config,
+                compute_kernel_config);
+        } else {
+            const auto& temp_other_grad = ttnn::moreh_matmul(
+                input, output_grad, true, false, std::nullopt, std::nullopt, output_mem_config, compute_kernel_config);
+            auto reduce_dims =
+                moreh_matmul::find_reduce_dim(temp_other_grad.get_legacy_shape(), other_grad_tensor.get_legacy_shape());
+            ttnn::moreh_sum(
+                temp_other_grad, reduce_dims, true, other_grad_tensor, output_mem_config, compute_kernel_config);
+        }
+        outputs[1] = other_grad_tensor;
+    }
+
+    return outputs;
+}
+}  // namespace ttnn::operations::moreh::moreh_matmul_backward

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_matmul_backward/moreh_matmul_backward.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_matmul_backward/moreh_matmul_backward.cpp
@@ -9,6 +9,7 @@
 #include "ttnn/operations/moreh/moreh_matmul/device/moreh_matmul_device_operation.hpp"
 #include "ttnn/operations/moreh/moreh_matmul/moreh_matmul.hpp"
 #include "ttnn/operations/moreh/moreh_sum/moreh_sum.hpp"
+#include "ttnn/run_operation.hpp"
 
 namespace ttnn::operations::moreh::moreh_matmul_backward {
 
@@ -29,69 +30,79 @@ std::vector<std::optional<Tensor>> MorehMatmulBackward::invoke(
     const std::vector<bool>& are_required_outputs,
     const std::optional<const Tensor>& input_grad,
     const std::optional<const Tensor>& other_grad,
-    const std::optional<ttnn::MemoryConfig>& output_mem_config,
+    const std::optional<ttnn::MemoryConfig>& memory_config,
     const std::optional<ttnn::DeviceComputeKernelConfig> compute_kernel_config) {
     if (is_dot_backward(output_grad, input, other)) {
-        return ttnn::moreh_dot_backward(output_grad, input, other, input_grad, other_grad, output_mem_config);
+        return ttnn::moreh_dot_backward(output_grad, input, other, input_grad, other_grad, memory_config);
     }
 
     std::vector<std::optional<Tensor>> outputs(2);
-    outputs.reserve(2);
 
     const bool input_requires_grad = are_required_outputs.at(0);
     const bool other_requires_grad = are_required_outputs.at(1);
 
     if (input_requires_grad) {
-        TT_ASSERT(input_grad.has_value());
+        TT_FATAL(input_grad.has_value(), "Input gradient is marked required but not provided.");
         const auto& input_grad_tensor = input_grad.value();
         if (moreh_matmul::is_same_batch_dim(output_grad, input_grad_tensor)) {
             const auto& input_grad_shape = input_grad_tensor.get_legacy_shape().without_padding();
             const auto& output_grad_shape = output_grad.get_legacy_shape().without_padding();
             ttnn::moreh_matmul(
-                output_grad,
-                other,
-                false,
-                true,
-                input_grad_tensor,
-                std::nullopt,
-                output_mem_config,
-                compute_kernel_config);
+                output_grad, other, false, true, input_grad_tensor, std::nullopt, memory_config, compute_kernel_config);
         } else {
             const auto& input_shape = input.get_legacy_shape().without_padding();
             const auto& temp_input_grad = ttnn::moreh_matmul(
-                output_grad, other, false, true, std::nullopt, std::nullopt, output_mem_config, compute_kernel_config);
+                output_grad, other, false, true, std::nullopt, std::nullopt, memory_config, compute_kernel_config);
             auto reduce_dims =
                 moreh_matmul::find_reduce_dim(temp_input_grad.get_legacy_shape(), input_grad_tensor.get_legacy_shape());
             ttnn::moreh_sum(
-                temp_input_grad, reduce_dims, true, input_grad_tensor, output_mem_config, compute_kernel_config);
+                temp_input_grad, reduce_dims, true, input_grad_tensor, memory_config, compute_kernel_config);
         }
         outputs[0] = input_grad_tensor;
     }
 
     if (other_requires_grad) {
-        TT_ASSERT(other_grad.has_value());
+        TT_FATAL(other_grad.has_value(), "Other gradient is marked required but not provided.");
         const auto& other_grad_tensor = other_grad.value();
         if (moreh_matmul::is_same_batch_dim(output_grad, other_grad_tensor)) {
             ttnn::moreh_matmul(
-                input,
-                output_grad,
-                true,
-                false,
-                other_grad_tensor,
-                std::nullopt,
-                output_mem_config,
-                compute_kernel_config);
+                input, output_grad, true, false, other_grad_tensor, std::nullopt, memory_config, compute_kernel_config);
         } else {
             const auto& temp_other_grad = ttnn::moreh_matmul(
-                input, output_grad, true, false, std::nullopt, std::nullopt, output_mem_config, compute_kernel_config);
+                input, output_grad, true, false, std::nullopt, std::nullopt, memory_config, compute_kernel_config);
             auto reduce_dims =
                 moreh_matmul::find_reduce_dim(temp_other_grad.get_legacy_shape(), other_grad_tensor.get_legacy_shape());
             ttnn::moreh_sum(
-                temp_other_grad, reduce_dims, true, other_grad_tensor, output_mem_config, compute_kernel_config);
+                temp_other_grad, reduce_dims, true, other_grad_tensor, memory_config, compute_kernel_config);
         }
         outputs[1] = other_grad_tensor;
     }
 
     return outputs;
 }
+
+std::vector<Tensor> MorehMatmulBackward::create_async_output_tensors(
+    const std::vector<Tensor>& input_tensors, const std::vector<std::optional<const Tensor>>& optional_inputs) {
+    const auto& output_grad = input_tensors.at(0);
+    const auto& input = input_tensors.at(1);
+    const auto& other = input_tensors.at(2);
+
+    return {
+        Tensor(operation::get_workers_for_op_output({output_grad, input, other})),
+        Tensor(operation::get_workers_for_op_output({output_grad, input, other})),
+    };
+}
+
+std::vector<bool> MorehMatmulBackward::create_async_return_flag(
+    const Tensor& output_grad,
+    const Tensor& input,
+    const Tensor& other,
+    const std::vector<bool>& are_required_outputs,
+    const std::optional<const Tensor>& input_grad,
+    const std::optional<const Tensor>& other_grad,
+    const std::optional<ttnn::MemoryConfig>& memory_config,
+    const std::optional<ttnn::DeviceComputeKernelConfig> compute_kernel_config) {
+    return {are_required_outputs.at(0), are_required_outputs.at(1)};
+}
+
 }  // namespace ttnn::operations::moreh::moreh_matmul_backward

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_matmul_backward/moreh_matmul_backward.hpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_matmul_backward/moreh_matmul_backward.hpp
@@ -14,13 +14,26 @@ struct MorehMatmulBackward {
         const std::vector<bool>& are_required_outputs,
         const std::optional<const Tensor>& input_grad,
         const std::optional<const Tensor>& other_grad,
-        const std::optional<ttnn::MemoryConfig>& output_mem_config,
+        const std::optional<ttnn::MemoryConfig>& memory_config,
+        const std::optional<ttnn::DeviceComputeKernelConfig> compute_kernel_config);
+
+    static std::vector<Tensor> create_async_output_tensors(
+        const std::vector<Tensor>& input_tensors, const std::vector<std::optional<const Tensor>>& optional_inputs);
+
+    static std::vector<bool> create_async_return_flag(
+        const Tensor& output_grad,
+        const Tensor& input,
+        const Tensor& other,
+        const std::vector<bool>& are_required_outputs,
+        const std::optional<const Tensor>& input_grad,
+        const std::optional<const Tensor>& other_grad,
+        const std::optional<ttnn::MemoryConfig>& memory_config,
         const std::optional<ttnn::DeviceComputeKernelConfig> compute_kernel_config);
 };
 }  // namespace ttnn::operations::moreh::moreh_matmul_backward
 
 namespace ttnn {
-constexpr auto moreh_matmul_backward = ttnn::register_operation<
+constexpr auto moreh_matmul_backward = ttnn::register_operation_with_auto_launch_op<
     "ttnn::moreh_matmul_backward",
     ttnn::operations::moreh::moreh_matmul_backward::MorehMatmulBackward>();
 }

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_matmul_backward/moreh_matmul_backward.hpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_matmul_backward/moreh_matmul_backward.hpp
@@ -1,0 +1,26 @@
+// SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+#include "ttnn/decorators.hpp"
+#include "ttnn/operations/core/compute_kernel/compute_kernel_config.hpp"
+namespace ttnn::operations::moreh::moreh_matmul_backward {
+struct MorehMatmulBackward {
+    static std::vector<std::optional<Tensor>> invoke(
+        const Tensor& output_grad,
+        const Tensor& input,
+        const Tensor& other,
+        const std::vector<bool>& are_required_outputs,
+        const std::optional<const Tensor>& input_grad,
+        const std::optional<const Tensor>& other_grad,
+        const std::optional<ttnn::MemoryConfig>& output_mem_config,
+        const std::optional<ttnn::DeviceComputeKernelConfig> compute_kernel_config);
+};
+}  // namespace ttnn::operations::moreh::moreh_matmul_backward
+
+namespace ttnn {
+constexpr auto moreh_matmul_backward = ttnn::register_operation<
+    "ttnn::moreh_matmul_backward",
+    ttnn::operations::moreh::moreh_matmul_backward::MorehMatmulBackward>();
+}

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_matmul_backward/moreh_matmul_backward_pybind.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_matmul_backward/moreh_matmul_backward_pybind.cpp
@@ -22,7 +22,7 @@ void bind_moreh_matmul_backward_operation(py::module& module) {
             py::arg("are_required_outputs") = std::vector<bool>{true, true},
             py::arg("input_a_grad") = std::nullopt,
             py::arg("input_b_grad") = std::nullopt,
-            py::arg("output_mem_config") = std::nullopt,
+            py::arg("memory_config") = std::nullopt,
             py::arg("compute_kernel_config") = std::nullopt});
 }
 }  // namespace ttnn::operations::moreh::moreh_matmul_backward

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_matmul_backward/moreh_matmul_backward_pybind.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_matmul_backward/moreh_matmul_backward_pybind.cpp
@@ -1,0 +1,28 @@
+// SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "moreh_matmul_backward_pybind.hpp"
+
+#include "pybind11/cast.h"
+#include "pybind11/decorators.hpp"
+#include "ttnn/operations/moreh/moreh_matmul_backward/moreh_matmul_backward.hpp"
+
+namespace ttnn::operations::moreh::moreh_matmul_backward {
+void bind_moreh_matmul_backward_operation(py::module& module) {
+    bind_registered_operation(
+        module,
+        ttnn::moreh_matmul_backward,
+        "Moreh moreh_matmul_backward Operation",
+        ttnn::pybind_arguments_t{
+            py::arg("output_grad"),
+            py::arg("input_a"),
+            py::arg("input_b"),
+            py::kw_only(),
+            py::arg("are_required_outputs") = std::vector<bool>{true, true},
+            py::arg("input_a_grad") = std::nullopt,
+            py::arg("input_b_grad") = std::nullopt,
+            py::arg("output_mem_config") = std::nullopt,
+            py::arg("compute_kernel_config") = std::nullopt});
+}
+}  // namespace ttnn::operations::moreh::moreh_matmul_backward

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_matmul_backward/moreh_matmul_backward_pybind.hpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_matmul_backward/moreh_matmul_backward_pybind.hpp
@@ -1,0 +1,13 @@
+// SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include "pybind11/pybind_fwd.hpp"
+
+namespace py = pybind11;
+
+namespace ttnn::operations::moreh::moreh_matmul_backward {
+void bind_moreh_matmul_backward_operation(py::module& module);
+}  // namespace ttnn::operations::moreh::moreh_matmul_backward

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_pybind.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_pybind.cpp
@@ -19,6 +19,7 @@
 #include "ttnn/operations/moreh/moreh_linear/moreh_linear_pybind.hpp"
 #include "ttnn/operations/moreh/moreh_linear_backward/moreh_linear_backward_pybind.hpp"
 #include "ttnn/operations/moreh/moreh_matmul/moreh_matmul_pybind.hpp"
+#include "ttnn/operations/moreh/moreh_matmul_backward/moreh_matmul_backward_pybind.hpp"
 #include "ttnn/operations/moreh/moreh_mean/moreh_mean_pybind.hpp"
 #include "ttnn/operations/moreh/moreh_mean_backward/moreh_mean_backward_pybind.hpp"
 #include "ttnn/operations/moreh/moreh_nll_loss/moreh_nll_loss_pybind.hpp"
@@ -49,6 +50,7 @@ void bind_moreh_operations(py::module &module) {
     moreh_linear_backward::bind_moreh_linear_backward_operation(module);
     moreh_linear::bind_moreh_linear_operation(module);
     moreh_matmul::bind_moreh_matmul_operation(module);
+    moreh_matmul_backward::bind_moreh_matmul_backward_operation(module);
     moreh_mean_backward::bind_moreh_mean_backward_operation(module);
     moreh_mean::bind_moreh_mean_operation(module);
     moreh_nll_loss_backward::bind_moreh_nll_loss_backward_operation(module);

--- a/ttnn/ttnn/operations/moreh.py
+++ b/ttnn/ttnn/operations/moreh.py
@@ -20,6 +20,7 @@ linear_backward = ttnn._ttnn.operations.moreh.moreh_linear_backward
 logsoftmax = ttnn._ttnn.operations.moreh.moreh_logsoftmax
 logsoftmax_backward = ttnn._ttnn.operations.moreh.moreh_logsoftmax_backward
 matmul = ttnn._ttnn.operations.moreh.moreh_matmul
+matmul_backward = ttnn._ttnn.operations.moreh.moreh_matmul_backward
 mean = ttnn._ttnn.operations.moreh.moreh_mean
 mean_backward = ttnn._ttnn.operations.moreh.moreh_mean_backward
 nll_loss = ttnn._ttnn.operations.moreh.moreh_nll_loss

--- a/ttnn/ttnn/operations/moreh.py
+++ b/ttnn/ttnn/operations/moreh.py
@@ -10,6 +10,7 @@ arange = ttnn._ttnn.operations.moreh.moreh_arange
 bmm = ttnn._ttnn.operations.moreh.moreh_bmm
 bmm_backward = ttnn._ttnn.operations.moreh.moreh_bmm_backward
 dot = ttnn._ttnn.operations.moreh.moreh_dot
+dot_backward = ttnn._ttnn.operations.moreh.moreh_dot_backward
 getitem = ttnn._ttnn.operations.moreh.moreh_getitem
 group_norm = ttnn._ttnn.operations.moreh.moreh_group_norm
 group_norm_backward = ttnn._ttnn.operations.moreh.moreh_group_norm_backward


### PR DESCRIPTION
### Ticket
#12554 

### Problem description
`moreh_matmul_backward` was deprecated alongside `tt_dnn`. This PR ports it to `ttnn` using its operation format.

### What's changed
 - Moved device code to `ttnn`
 - Created new wrapper code for `ttnn` with new modules
 - Ported unit tests to `ttnn`
 
### Checklist
- [x] Post commit CI passes
- [ ] Blackhole Post commit (if applicable)
- [ ] Model regression CI testing passes (if applicable)
- [ ] Device performance regression CI testing passes (if applicable)
- [x] New/Existing tests provide coverage for changes
