### PR TITLE
#12392: Use shallow convolution in upblock3 of UNet Shallow

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@
 | [ResNet-50 (224x224) (data parallel)](./models/demos/tgg/resnet50)          | 1024  | [Two Galaxies](https://tenstorrent.com/hardware/galaxy)  | 128,800 | 448,000    |             |
 | [ViT](./models/demos/grayskull/vit)                                         | 9     | [e150](https://tenstorrent.com/hardware/grayskull)       | 1,360   | 2,000      |             |
 | [Stable Diffusion 1.4 (512x512)](./models/demos/wormhole/stable_diffusion)  | 1     | [n150](https://tenstorrent.com/hardware/wormhole)        | 0.167   | 0.3        |             |
-| [Unet (shallow)](./models/experimental/functional_unet)                     | 2     | [n150](https://tenstorrent.com/hardware/wormhole)        | 51      | 1000       |             |
+| [Unet (shallow)](./models/experimental/functional_unet)                     | 2     | [n150](https://tenstorrent.com/hardware/wormhole)        | 190     | 1000       |             |
 
 ## NLPs
 | Model                                               | Batch | Hardware                                           | sen/sec   | Target sen/sec | Release     |

--- a/models/experimental/functional_unet/README.md
+++ b/models/experimental/functional_unet/README.md
@@ -5,12 +5,26 @@
 To run the demo, make sure to build the project, activate the environment, and set the appropriate environment variables.
 For more information, refer [installation and build guide](https://docs.tenstorrent.com/tt-metalium/latest/get_started/get_started.html#install-and-build).
 
-Use `pytest --disable-warnings models/experimental/functional_unet/tests/test_unet_model.py` to run the full UNet Shallow model.
+To run UNet Shallow for multiple iterations on single-chip at the best performance:
+
+```sh
+pytest --disable-warnings models/experimental/functional_unet/tests/test_unet_perf.py::test_unet_perf_e2e
+```
+
+To run UNet Shallow for multiple iterations on N300 and T3000 at the best performance:
+
+```sh
+pytest --disable-warnings models/experimental/functional_unet/tests/test_unet_perf.py::test_unet_data_parallel_perf_e2e
+````
+
+Use `pytest models/experimental/functional_unet/tests/test_unet_model.py` to run the functional UNet Shallow model on a single-chip.
 
 ## Supported Hardware
 
 - N150
 - N300
+  - Make sure to place dispatch on ethernet cores with `export WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml` for optimal performance
+- T3K
   - Make sure to place dispatch on ethernet cores with `export WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml` for optimal performance
 
 ## Other Details

--- a/models/experimental/functional_unet/tests/test_unet_bottleneck.py
+++ b/models/experimental/functional_unet/tests/test_unet_bottleneck.py
@@ -41,8 +41,9 @@ def test_unet_bottleneck(batch, groups, device, reset_seeds):
 
 @pytest.mark.parametrize("batch", [2])
 @pytest.mark.parametrize("groups", [1])
+@pytest.mark.parametrize("enable_async_mode", (True,), indirect=True)
 @pytest.mark.parametrize("device_params", [{"l1_small_size": 32768}], indirect=True)
-def test_unet_bottleneck_multi_device(batch, groups, mesh_device, reset_seeds):
+def test_unet_bottleneck_multi_device(batch, groups, mesh_device, reset_seeds, enable_async_mode):
     if not is_n300_with_eth_dispatch_cores(mesh_device):
         pytest.skip("Test is only valid for N300")
 

--- a/models/experimental/functional_unet/tests/test_unet_downblock.py
+++ b/models/experimental/functional_unet/tests/test_unet_downblock.py
@@ -30,7 +30,16 @@ from models.experimental.functional_unet.tests.common import (
     ],
 )
 @pytest.mark.parametrize("device_params", [{"l1_small_size": 32768}], indirect=True)
-def test_unet_downblock(batch, groups, block_name, input_channels, input_height, input_width, device, reset_seeds):
+def test_unet_downblock(
+    batch,
+    groups,
+    block_name,
+    input_channels,
+    input_height,
+    input_width,
+    device,
+    reset_seeds,
+):
     torch_input, ttnn_input = create_unet_input_tensors(device, batch, groups, pad_input=False)
     model = unet_shallow_torch.UNet.from_random_weights(groups=1)
 
@@ -65,9 +74,10 @@ def test_unet_downblock(batch, groups, block_name, input_channels, input_height,
         ("downblock4", 32, 132, 20),
     ],
 )
+@pytest.mark.parametrize("enable_async_mode", (False,), indirect=True)  # Enable when #12685 is resolved
 @pytest.mark.parametrize("device_params", [{"l1_small_size": 32768}], indirect=True)
 def test_unet_downblock_multi_device(
-    batch, groups, block_name, input_channels, input_height, input_width, mesh_device, reset_seeds
+    batch, groups, block_name, input_channels, input_height, input_width, mesh_device, reset_seeds, enable_async_mode
 ):
     if not is_n300_with_eth_dispatch_cores(mesh_device):
         pytest.skip("Test is only valid for N300")

--- a/models/experimental/functional_unet/tests/test_unet_model.py
+++ b/models/experimental/functional_unet/tests/test_unet_model.py
@@ -17,7 +17,7 @@ from models.experimental.functional_unet.tt import unet_shallow_ttnn
 
 @pytest.mark.parametrize("batch", [2])
 @pytest.mark.parametrize("groups", [1])
-@pytest.mark.parametrize("device_params", [{"l1_small_size": 64768}], indirect=True)
+@pytest.mark.parametrize("device_params", [{"l1_small_size": 68864}], indirect=True)
 def test_unet_model(batch, groups, device, use_program_cache, reset_seeds):
     torch_input, ttnn_input = create_unet_input_tensors(device, batch, groups, pad_input=True)
     model = unet_shallow_torch.UNet.from_random_weights(groups=1)
@@ -30,4 +30,4 @@ def test_unet_model(batch, groups, device, use_program_cache, reset_seeds):
 
     B, C, H, W = torch_output_tensor.shape
     ttnn_tensor = ttnn.to_torch(output_tensor).reshape(B, H, W, -1)[:, :, :, :C].permute(0, 3, 1, 2)
-    assert_with_pcc(torch_output_tensor, ttnn_tensor, 0.99)
+    assert_with_pcc(torch_output_tensor, ttnn_tensor, 0.986)

--- a/models/experimental/functional_unet/tests/test_unet_multi_device.py
+++ b/models/experimental/functional_unet/tests/test_unet_multi_device.py
@@ -51,4 +51,4 @@ def test_unet_multi_device_model(batch, groups, mesh_device, use_program_cache, 
     torch_output_tensor = model(torch_input)
     output_tensor = ttnn_model(ttnn_input)
 
-    check_pcc_conv(torch_output_tensor, output_tensor, mesh_composer=output_mesh_composer, pcc=0.99)
+    check_pcc_conv(torch_output_tensor, output_tensor, mesh_composer=output_mesh_composer, pcc=0.986)

--- a/models/experimental/functional_unet/tests/test_unet_output_layer.py
+++ b/models/experimental/functional_unet/tests/test_unet_output_layer.py
@@ -27,11 +27,12 @@ def test_unet_output_layer(batch, groups, device, reset_seeds):
     torch_input, ttnn_input = create_unet_input_tensors(device, batch, groups, pad_input=False, input_channels=16)
     torch_output = model.output_layer(torch_input)
 
-    ttnn_input = ttnn.to_device(ttnn_input, device)
+    ttnn_input = ttnn.to_device(ttnn_input, device=device)
+    ttnn_input = ttnn.to_layout(ttnn_input, ttnn.TILE_LAYOUT, memory_config=ttnn.L1_MEMORY_CONFIG)
     ttnn_output = ttnn_model.output_layer(ttnn_input)
 
     B, C, H, W = torch_output.shape
     ttnn_output = ttnn.to_torch(ttnn_output)
     assert list(ttnn_output.shape) == [1, 1, B * H * W, C], "Expected output layer to be [1, 1, BHW, C]"
     ttnn_output = ttnn_output.reshape(B, H, W, C).permute(0, 3, 1, 2)
-    assert_with_pcc(torch_output, ttnn_output, 0.99)
+    assert_with_pcc(torch_output, ttnn_output, 0.99995)

--- a/models/experimental/functional_unet/tests/test_unet_perf.py
+++ b/models/experimental/functional_unet/tests/test_unet_perf.py
@@ -18,6 +18,7 @@ from models.experimental.functional_unet.tt import unet_shallow_ttnn
 from models.experimental.functional_unet.tests.common import (
     check_pcc_conv,
     is_n300_with_eth_dispatch_cores,
+    is_t3k_with_eth_dispatch_cores,
 )
 
 from models.perf.perf_utils import prep_perf_report
@@ -28,11 +29,17 @@ from models.utility_functions import (
 )
 
 
+def synchronize_devices(device):
+    devices = device.get_devices()
+    for device in devices:
+        ttnn.synchronize_device(device)
+
+
 @skip_for_grayskull("UNet not currently supported on GS")
 @pytest.mark.models_device_performance_bare_metal
 @pytest.mark.parametrize(
     "batch, groups, expected_device_perf_fps",
-    ((2, 1, 443.0),),
+    ((2, 1, 556.0),),
 )
 def test_unet_perf_device(batch: int, groups: int, expected_device_perf_fps: float, reset_seeds):
     command = f"pytest models/experimental/functional_unet/tests/test_unet_model.py::test_unet_model[device_params0-{groups}-{batch}]"
@@ -57,10 +64,10 @@ def test_unet_perf_device(batch: int, groups: int, expected_device_perf_fps: flo
 
 @skip_for_grayskull("UNet not currently supported on GS")
 @pytest.mark.models_performance_bare_metal
-@pytest.mark.parametrize("device_params", [{"l1_small_size": 64768}], indirect=True)
+@pytest.mark.parametrize("device_params", [{"l1_small_size": 68864}], indirect=True)
 @pytest.mark.parametrize(
     "batch, groups, iterations, expected_compile_time, expected_inference_time_ms",
-    ((2, 1, 16, 16.0, 39.0),),
+    ((2, 1, 16, 25.0, 39.0),),
 )
 def test_unet_perf_e2e(
     batch: int,
@@ -89,7 +96,7 @@ def test_unet_perf_e2e(
 
     logger.info(f"Compiling model with warmup run")
     profiler.start(f"inference_and_compile_time")
-    output_tensor = ttnn_model(ttnn_input)
+    output_tensor = ttnn_model(ttnn_input).cpu()
     profiler.end(f"inference_and_compile_time")
 
     inference_and_compile_time = profiler.get("inference_and_compile_time")
@@ -99,7 +106,7 @@ def test_unet_perf_e2e(
     for idx in range(iterations):
         profiler.start("inference_time")
         profiler.start(f"inference_time_{idx}")
-        output_tensor = ttnn_model(ttnn_input)
+        output_tensor = ttnn_model(ttnn_input).cpu()
         profiler.end(f"inference_time_{idx}")
         profiler.end("inference_time")
 
@@ -126,15 +133,17 @@ def test_unet_perf_e2e(
     logger.info(f"Running sanity check against reference model output")
     B, C, H, W = torch_output_tensor.shape
     ttnn_tensor = ttnn.to_torch(output_tensor).reshape(B, H, W, -1)[:, :, :, :C].permute(0, 3, 1, 2)
-    assert_with_pcc(torch_output_tensor, ttnn_tensor, 0.99)
+    assert_with_pcc(torch_output_tensor, ttnn_tensor, 0.986)
 
 
+@pytest.mark.skip("Crashes on N300/T3K - see issue #12685")
 @skip_for_grayskull("UNet not currently supported on GS")
 @pytest.mark.models_performance_bare_metal
-@pytest.mark.parametrize("device_params", [{"l1_small_size": 64768}], indirect=True)
+@pytest.mark.parametrize("enable_async_mode", (True,), indirect=True)
+@pytest.mark.parametrize("device_params", [{"l1_small_size": 68864}], indirect=True)
 @pytest.mark.parametrize(
     "batch, groups, iterations, expected_compile_time, expected_inference_time_ms",
-    ((2, 1, 16, 16.0, 39.0),),
+    ((2, 1, 16, 25.0, 61.0),),
 )
 def test_unet_data_parallel_perf_e2e(
     batch: int,
@@ -145,9 +154,10 @@ def test_unet_data_parallel_perf_e2e(
     mesh_device,
     use_program_cache,
     reset_seeds,
+    enable_async_mode,
 ):
-    if not is_n300_with_eth_dispatch_cores(mesh_device):
-        pytest.skip("Test is only valid for N300")
+    if not is_n300_with_eth_dispatch_cores(mesh_device) and not is_t3k_with_eth_dispatch_cores(mesh_device):
+        pytest.skip("Test is only valid for N300 or T3000")
 
     profiler.clear()
 
@@ -180,7 +190,7 @@ def test_unet_data_parallel_perf_e2e(
 
     logger.info(f"Compiling model with warmup run")
     profiler.start(f"inference_and_compile_time")
-    output_tensor = ttnn_model(ttnn_input)
+    output_tensor = ttnn.from_device(ttnn_model(ttnn_input), blocking=True)
     profiler.end(f"inference_and_compile_time")
 
     inference_and_compile_time = profiler.get("inference_and_compile_time")
@@ -190,9 +200,12 @@ def test_unet_data_parallel_perf_e2e(
     for idx in range(iterations):
         profiler.start("inference_time")
         profiler.start(f"inference_time_{idx}")
-        output_tensor = ttnn_model(ttnn_input)
+        logger.info(f"running iter {idx}")
+        output_tensor = ttnn.from_device(ttnn_model(ttnn_input), blocking=True)
+        logger.info(f"done running iter {idx}")
         profiler.end(f"inference_time_{idx}")
         profiler.end("inference_time")
+    synchronize_devices(mesh_device)
 
     mean_inference_time = profiler.get("inference_time")
     inference_time = profiler.get(f"inference_time_{iterations - 1}")
@@ -211,8 +224,8 @@ def test_unet_data_parallel_perf_e2e(
         inference_time=inference_time,
         expected_compile_time=expected_compile_time,
         expected_inference_time=expected_inference_time,
-        comments="batch_{total_batch}-num_devices_{num_devices}",
+        comments=f"batch_{total_batch}-num_devices_{num_devices}",
     )
 
     logger.info(f"Running sanity check against reference model output")
-    check_pcc_conv(torch_output_tensor, output_tensor, mesh_composer=output_mesh_composer, pcc=0.99)
+    check_pcc_conv(torch_output_tensor, output_tensor, mesh_composer=output_mesh_composer, pcc=0.986)

--- a/models/experimental/functional_unet/tests/test_unet_upblock.py
+++ b/models/experimental/functional_unet/tests/test_unet_upblock.py
@@ -33,7 +33,15 @@ from models.experimental.functional_unet.tests.common import (
 )
 @pytest.mark.parametrize("device_params", [{"l1_small_size": 32768}], indirect=True)
 def test_unet_upblock(
-    batch, groups, block_name, input_channels, input_height, input_width, residual_channels, device, reset_seeds
+    batch,
+    groups,
+    block_name,
+    input_channels,
+    input_height,
+    input_width,
+    residual_channels,
+    device,
+    reset_seeds,
 ):
     torch_input, ttnn_input = create_unet_input_tensors(device, batch, groups, pad_input=False)
     model = unet_shallow_torch.UNet.from_random_weights(groups=groups)
@@ -77,9 +85,19 @@ def test_unet_upblock(
         ("upblock4", 16, 528, 80, 16),
     ],
 )
+@pytest.mark.parametrize("enable_async_mode", (False,), indirect=True)  # Enable when #12685 is resolved
 @pytest.mark.parametrize("device_params", [{"l1_small_size": 32768}], indirect=True)
 def test_unet_upblock_multi_device(
-    batch, groups, block_name, input_channels, input_height, input_width, residual_channels, mesh_device, reset_seeds
+    batch,
+    groups,
+    block_name,
+    input_channels,
+    input_height,
+    input_width,
+    residual_channels,
+    mesh_device,
+    reset_seeds,
+    enable_async_mode,
 ):
     if not is_n300_with_eth_dispatch_cores(mesh_device):
         pytest.skip("Test is only valid for N300")

--- a/models/experimental/functional_unet/tt/model_preprocessing.py
+++ b/models/experimental/functional_unet/tt/model_preprocessing.py
@@ -110,20 +110,24 @@ def create_unet_model_parameters(model: unet_shallow_torch.UNet, input_tensor: t
     parameters.c6_3["use_split_reader"] = True
     parameters.c6_3["use_activation_double_buffer"] = True
 
-    parameters.c7["conv_blocking_and_parallelization_config_override"] = {"act_block_h": 5 * 32}
+    parameters.c7["conv_blocking_and_parallelization_config_override"] = {"act_block_h": 8 * 32}
     parameters.c7["use_activation_double_buffer"] = True
+    parameters.c6_3["use_split_reader"] = True
+    parameters.c7["input_channels_alignment"] = 16
+
     parameters.c7_2["conv_blocking_and_parallelization_config_override"] = None
     parameters.c7_2["use_split_reader"] = True
     parameters.c7_2["use_activation_double_buffer"] = True
+
     parameters.c7_3["conv_blocking_and_parallelization_config_override"] = None
     parameters.c7_3["use_split_reader"] = True
     parameters.c7_3["use_activation_double_buffer"] = True
 
-    parameters.c8["conv_blocking_and_parallelization_config_override"] = {"act_block_h": 5 * 32}
+    parameters.c8["conv_blocking_and_parallelization_config_override"] = {"act_block_h": 4 * 32}
     parameters.c8["use_activation_double_buffer"] = True
-    parameters.c8_2["conv_blocking_and_parallelization_config_override"] = {"act_block_h": 5 * 32}
+    parameters.c8_2["conv_blocking_and_parallelization_config_override"] = {"act_block_h": 4 * 32}
     parameters.c8_2["use_activation_double_buffer"] = True
-    parameters.c8_3["conv_blocking_and_parallelization_config_override"] = {"act_block_h": 5 * 32}
+    parameters.c8_3["conv_blocking_and_parallelization_config_override"] = {"act_block_h": 4 * 32}
     parameters.c8_3["use_activation_double_buffer"] = True
 
     parameters.output_layer["conv_blocking_and_parallelization_config_override"] = None


### PR DESCRIPTION
### Ticket
- #12392

### What's changed
Using shallow conv variant avoids a slow sharded-to-interleaved op that was previously required to make sure channels of row-major inputs to convolution were multiples of 32.

Other changes:

- Improves end-to-end performance by sharding inputs directly into L1 and using sharded tensors on the output layer.

- Also update all multi-device tests to use async mode. Some of these tests are currently disabled until https://github.com/tenstorrent/tt-metal/issues/12685 is resolved.

### Checklist
- [x] Post commit CI passes
- [x] Model regression CI testing passes (if applicable)