### PR TITLE
#12392: Shallov conv unet uts

### DIFF
--- a/tests/ttnn/unit_tests/operations/test_new_conv2d.py
+++ b/tests/ttnn/unit_tests/operations/test_new_conv2d.py
@@ -1310,9 +1310,9 @@ def test_unet_conv(
     (
         # unet convs with batch size 2
         # unique convs in unet (complete list)
-        (2, 16, 4, 1056, 160, 3, 3, 1, 1, 1, 1, True, {"act_block_h": 5 * 32}, False),
-        (2, 16, 16, 1056, 160, 3, 3, 1, 1, 1, 1, True, {"act_block_h": 5 * 32}, False),
-        (2, 16, 16, 528, 80, 3, 3, 1, 1, 1, 1, True, None, False),
+        (2, 16, 4, 1056, 160, 3, 3, 1, 1, 1, 1, True, {"act_block_h": 16 * 32}, True),
+        (2, 16, 16, 1056, 160, 3, 3, 1, 1, 1, 1, True, {"act_block_h": 16 * 32}, True),
+        (2, 16, 16, 528, 80, 3, 3, 1, 1, 1, 1, True, {"act_block_h": 16 * 32}, True),
         (2, 32, 16, 264, 40, 3, 3, 1, 1, 1, 1, True, None, False),
         (2, 32, 32, 264, 40, 3, 3, 1, 1, 1, 1, True, None, False),
         (2, 32, 32, 132, 20, 3, 3, 1, 1, 1, 1, True, None, False),
@@ -1322,25 +1322,10 @@ def test_unet_conv(
         (2, 32, 32, 132, 20, 3, 3, 1, 1, 1, 1, True, None, False),
         (2, 32, 64, 264, 40, 3, 3, 1, 1, 1, 1, True, None, False),
         (2, 32, 32, 264, 40, 3, 3, 1, 1, 1, 1, True, None, False),
-        (
-            2,
-            16,
-            48,
-            528,
-            80,
-            3,
-            3,
-            1,
-            1,
-            1,
-            1,
-            True,
-            {"act_block_h": 32},
-            False,
-        ),  # fails. mismatch. It passes when input_channels=64. Probably an issue with padding when input_channels % 32 != 0.
-        (2, 16, 16, 528, 80, 3, 3, 1, 1, 1, 1, True, None, False),
-        (2, 16, 32, 1056, 160, 3, 3, 1, 1, 1, 1, True, {"act_block_h": 5 * 32}, False),
-        (2, 16, 16, 1056, 160, 3, 3, 1, 1, 1, 1, True, {"act_block_h": 5 * 32}, False),
+        (2, 16, 48, 528, 80, 3, 3, 1, 1, 1, 1, True, {"act_block_h": 16 * 32}, True),
+        (2, 16, 16, 528, 80, 3, 3, 1, 1, 1, 1, True, {"act_block_h": 16 * 32}, True),
+        (2, 16, 32, 1056, 160, 3, 3, 1, 1, 1, 1, True, {"act_block_h": 16 * 32}, True),
+        (2, 16, 16, 1056, 160, 3, 3, 1, 1, 1, 1, True, {"act_block_h": 16 * 32}, True),
         # (2, 1, 16, 1056, 160, 1, 1, 1, 1, 0, 0, True, {"act_block_h": 5 * 32}, False) # Enable when issue #11490 resolved
     ),
 )


### PR DESCRIPTION
Adjust unet UTs to use shallow conv.
Adjusted convs improve device perf in 40%-50% range.

Green all post commit: https://github.com/tenstorrent/tt-metal/actions/runs/10832611570