### PR TITLE
Account for CBs which shape space with sharded operands

### DIFF
--- a/tests/ttnn/unit_tests/gtests/CMakeLists.txt
+++ b/tests/ttnn/unit_tests/gtests/CMakeLists.txt
@@ -2,6 +2,7 @@
 set(TTNN_UNIT_TESTS_SRC
     ${CMAKE_CURRENT_SOURCE_DIR}/test_add.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/test_graph_add.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/test_mlir_interface.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/test_binary_interface.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/test_softmax_interface.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/test_unary_interface.cpp

--- a/ttnn/cpp/ttnn/operations/common/l1_interface_common.cpp
+++ b/ttnn/cpp/ttnn/operations/common/l1_interface_common.cpp
@@ -88,3 +88,12 @@ uint32_t calculate_tensor_l1_allocation_size_per_core(
     }
     return (uint32_t)0;  // dram not implemented yet
 }
+
+bool is_sharded(const L1InterfaceOperandParams& operand) {
+    return std::get<tt::tt_metal::MemoryConfig>(operand).is_sharded();
+}
+
+uint32_t get_tile_size(const L1InterfaceOperandParams& operand) {
+    return tt::tt_metal::detail::TileSize(
+        tt::tt_metal::datatype_to_dataformat_converter(std::get<tt::tt_metal::DataType>(operand)));
+}

--- a/ttnn/cpp/ttnn/operations/common/l1_interface_common.hpp
+++ b/ttnn/cpp/ttnn/operations/common/l1_interface_common.hpp
@@ -2,6 +2,7 @@
 
 #include <cstdint>
 #include <iostream>
+#include <limits>
 #include <optional>
 #include <tuple>
 #include <vector>
@@ -22,7 +23,9 @@ struct Shape;
 }
 }  // namespace ttnn
 
-using L1InterfaceOpParams =
+constexpr static uint32_t c_cb_shares_space_with_sharded_operand = std::numeric_limits<uint32_t>::max();
+
+using L1InterfaceOperandParams =
     std::tuple<ttnn::types::Shape, tt::tt_metal::DataType, tt::tt_metal::Layout, tt::tt_metal::MemoryConfig>;
 
 uint32_t calculate_circular_buffer_l1_allocation_size_per_core(
@@ -33,12 +36,12 @@ uint32_t calculate_circular_buffer_l1_allocation_size_per_core(
     const uint32_t max_block_size);
 
 inline uint32_t calculate_circular_buffer_l1_allocation_size_per_core(
-    L1InterfaceOpParams input, uint32_t max_block_size) {
+    L1InterfaceOperandParams operand, uint32_t max_block_size) {
     return calculate_circular_buffer_l1_allocation_size_per_core(
-        std::get<ttnn::types::Shape>(input),
-        std::get<tt::tt_metal::DataType>(input),
-        std::get<tt::tt_metal::Layout>(input),
-        std::get<tt::tt_metal::MemoryConfig>(input),
+        std::get<ttnn::types::Shape>(operand),
+        std::get<tt::tt_metal::DataType>(operand),
+        std::get<tt::tt_metal::Layout>(operand),
+        std::get<tt::tt_metal::MemoryConfig>(operand),
         max_block_size);
 }
 
@@ -48,12 +51,12 @@ uint32_t calculate_tensor_l1_allocation_size_per_core(
     const tt::tt_metal::Layout& layout,
     const tt::tt_metal::MemoryConfig& memory_config);
 
-inline uint32_t calculate_tensor_l1_allocation_size_per_core(L1InterfaceOpParams input) {
+inline uint32_t calculate_tensor_l1_allocation_size_per_core(const L1InterfaceOperandParams& operand) {
     return calculate_tensor_l1_allocation_size_per_core(
-        std::get<ttnn::types::Shape>(input),
-        std::get<tt::tt_metal::DataType>(input),
-        std::get<tt::tt_metal::Layout>(input),
-        std::get<tt::tt_metal::MemoryConfig>(input));
+        std::get<ttnn::types::Shape>(operand),
+        std::get<tt::tt_metal::DataType>(operand),
+        std::get<tt::tt_metal::Layout>(operand),
+        std::get<tt::tt_metal::MemoryConfig>(operand));
 }
 
 uint32_t get_num_of_cores(const std::optional<tt::tt_metal::ShardSpec>& shard_spec = std::nullopt);
@@ -63,3 +66,7 @@ uint32_t get_num_pages(const tt::tt_metal::ShardSpec& shard_spec);
 uint32_t calculate_repeat_circular_buffer_size(tt::tt_metal::DataType data_type);
 
 uint32_t calculate_max_block_size(const std::optional<tt::tt_metal::ShardSpec>& shard_spec);
+
+bool is_sharded(const L1InterfaceOperandParams& operand);
+
+uint32_t get_tile_size(const L1InterfaceOperandParams& operand);

--- a/ttnn/cpp/ttnn/operations/eltwise/binary/binary_l1_interface.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary/binary_l1_interface.hpp
@@ -5,28 +5,28 @@
 class EltwiseOpL1Usage {
    public:
     EltwiseOpL1Usage(
-        const L1InterfaceOpParams& input_a, const L1InterfaceOpParams& input_b, const L1InterfaceOpParams& output);
+        const L1InterfaceOperandParams& input_a, const L1InterfaceOperandParams& input_b, const L1InterfaceOperandParams& output);
     virtual ~EltwiseOpL1Usage() = default;
 
     virtual std::vector<std::tuple<uint32_t, uint32_t>> get_circular_buffer_l1_allocations_per_core() const = 0;
     virtual std::vector<std::tuple<uint32_t, uint32_t>> get_tensor_l1_allocations_per_core() const = 0;
 
    protected:
-    std::optional<L1InterfaceOpParams> calculate_repeat_buffer_impl(
-        const L1InterfaceOpParams& input_a, const L1InterfaceOpParams& input_b);
+    std::optional<L1InterfaceOperandParams> calculate_repeat_buffer_impl(
+        const L1InterfaceOperandParams& input_a, const L1InterfaceOperandParams& input_b);
 
     std::optional<ShardSpec> get_op_shard_spec() const;
 
-    L1InterfaceOpParams input_a;
-    L1InterfaceOpParams input_b;
-    L1InterfaceOpParams output;
-    std::optional<L1InterfaceOpParams> repeat;
+    L1InterfaceOperandParams input_a;
+    L1InterfaceOperandParams input_b;
+    L1InterfaceOperandParams output;
+    std::optional<L1InterfaceOperandParams> repeat;
 };
 
 class ElementWiseMultiCoreOpL1Usage : public EltwiseOpL1Usage {
    public:
     ElementWiseMultiCoreOpL1Usage(
-        const L1InterfaceOpParams& input_a, const L1InterfaceOpParams& input_b, const L1InterfaceOpParams& output);
+        const L1InterfaceOperandParams& input_a, const L1InterfaceOperandParams& input_b, const L1InterfaceOperandParams& output);
     virtual ~ElementWiseMultiCoreOpL1Usage() = default;
 
     virtual std::vector<std::tuple<uint32_t, uint32_t>> get_circular_buffer_l1_allocations_per_core() const override;
@@ -36,7 +36,7 @@ class ElementWiseMultiCoreOpL1Usage : public EltwiseOpL1Usage {
 class BroadcastWidthMultiCoreOpL1Usage : public EltwiseOpL1Usage {
    public:
     BroadcastWidthMultiCoreOpL1Usage(
-        const L1InterfaceOpParams& input_a, const L1InterfaceOpParams& input_b, const L1InterfaceOpParams& output);
+        const L1InterfaceOperandParams& input_a, const L1InterfaceOperandParams& input_b, const L1InterfaceOperandParams& output);
     virtual ~BroadcastWidthMultiCoreOpL1Usage() = default;
 
     virtual std::vector<std::tuple<uint32_t, uint32_t>> get_circular_buffer_l1_allocations_per_core() const override;
@@ -47,5 +47,5 @@ class EltwiseOpL1UsageFactory {
    public:
     EltwiseOpL1UsageFactory() = delete;
     static std::unique_ptr<EltwiseOpL1Usage> Make(
-        const L1InterfaceOpParams& input_a, const L1InterfaceOpParams& input_b, const L1InterfaceOpParams& output);
+        const L1InterfaceOperandParams& input_a, const L1InterfaceOperandParams& input_b, const L1InterfaceOperandParams& output);
 };

--- a/ttnn/cpp/ttnn/operations/eltwise/unary/unary_l1_interface.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary/unary_l1_interface.cpp
@@ -6,22 +6,26 @@
 #include "ttnn/operations/common/l1_interface_common.hpp"
 
 std::vector<std::tuple<uint32_t, uint32_t>> get_circular_buffer_l1_allocations_per_core_unary_impl(
-    const L1InterfaceOpParams& input, const L1InterfaceOpParams& output) {
+    const L1InterfaceOperandParams& input, const L1InterfaceOperandParams& output) {
     std::vector<std::tuple<uint32_t, uint32_t>> sizes;
 
-    sizes.emplace_back(std::make_tuple(
-        calculate_circular_buffer_l1_allocation_size_per_core(input, 1 /* max_block_size */),
-        get_num_of_cores(std::get<tt::tt_metal::MemoryConfig>(input).shard_spec)));
+    const auto get_operand_cb_size = [](const L1InterfaceOperandParams& operand) {
+        return is_sharded(operand)
+                   ? c_cb_shares_space_with_sharded_operand
+                   : calculate_circular_buffer_l1_allocation_size_per_core(operand, 1 /* max_block_size */);
+    };
 
     sizes.emplace_back(std::make_tuple(
-        calculate_circular_buffer_l1_allocation_size_per_core(output, 1 /* max_block_size */),
-        get_num_of_cores(std::get<tt::tt_metal::MemoryConfig>(output).shard_spec)));
+        get_operand_cb_size(input), get_num_of_cores(std::get<tt::tt_metal::MemoryConfig>(input).shard_spec)));
+
+    sizes.emplace_back(std::make_tuple(
+        get_operand_cb_size(output), get_num_of_cores(std::get<tt::tt_metal::MemoryConfig>(output).shard_spec)));
 
     return sizes;
 }
 
 std::vector<std::tuple<uint32_t, uint32_t>> get_tensor_l1_allocations_per_core_unary_impl(
-    const L1InterfaceOpParams& output) {
+    const L1InterfaceOperandParams& output) {
     std::vector<std::tuple<uint32_t, uint32_t>> sizes;
 
     sizes.emplace_back(std::make_tuple(
@@ -32,7 +36,7 @@ std::vector<std::tuple<uint32_t, uint32_t>> get_tensor_l1_allocations_per_core_u
 }
 
 std::unique_ptr<UnaryOpL1Usage> UnaryOpL1UsageFactory::Make(
-    const L1InterfaceOpParams& input, const std::optional<L1InterfaceOpParams>& output) {
+    const L1InterfaceOperandParams& input, const std::optional<L1InterfaceOperandParams>& output) {
     const auto input_memory_config = std::get<tt::tt_metal::MemoryConfig>(input);
 
     if (input_memory_config.is_sharded()) {
@@ -42,11 +46,11 @@ std::unique_ptr<UnaryOpL1Usage> UnaryOpL1UsageFactory::Make(
     }
 };
 
-UnaryOpL1Usage::UnaryOpL1Usage(const L1InterfaceOpParams& input, const L1InterfaceOpParams& output) :
+UnaryOpL1Usage::UnaryOpL1Usage(const L1InterfaceOperandParams& input, const L1InterfaceOperandParams& output) :
     input(input), output(output) {}
 
 InterleavedUnaryOpL1Usage::InterleavedUnaryOpL1Usage(
-    const L1InterfaceOpParams& input, const std::optional<L1InterfaceOpParams>& output) :
+    const L1InterfaceOperandParams& input, const std::optional<L1InterfaceOperandParams>& output) :
     UnaryOpL1Usage(input, output.has_value() ? output.value() : input) {}
 
 std::vector<std::tuple<uint32_t, uint32_t>>
@@ -60,7 +64,7 @@ InterleavedUnaryOpL1Usage::InterleavedUnaryOpL1Usage::get_tensor_l1_allocations_
 }
 
 ShardedUnaryOpL1Usage::ShardedUnaryOpL1Usage(
-    const L1InterfaceOpParams& input, const std::optional<L1InterfaceOpParams>& output) :
+    const L1InterfaceOperandParams& input, const std::optional<L1InterfaceOperandParams>& output) :
     UnaryOpL1Usage(input, output.has_value() ? output.value() : input) {}
 
 std::vector<std::tuple<uint32_t, uint32_t>>

--- a/ttnn/cpp/ttnn/operations/eltwise/unary/unary_l1_interface.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary/unary_l1_interface.hpp
@@ -4,20 +4,20 @@
 
 class UnaryOpL1Usage {
    public:
-    UnaryOpL1Usage(const L1InterfaceOpParams& input, const L1InterfaceOpParams& output);
+    UnaryOpL1Usage(const L1InterfaceOperandParams& input, const L1InterfaceOperandParams& output);
     virtual ~UnaryOpL1Usage() = default;
 
     virtual std::vector<std::tuple<uint32_t, uint32_t>> get_circular_buffer_l1_allocations_per_core() const = 0;
     virtual std::vector<std::tuple<uint32_t, uint32_t>> get_tensor_l1_allocations_per_core() const = 0;
 
    protected:
-    L1InterfaceOpParams input;
-    L1InterfaceOpParams output;
+    L1InterfaceOperandParams input;
+    L1InterfaceOperandParams output;
 };
 
 class InterleavedUnaryOpL1Usage : public UnaryOpL1Usage {
    public:
-    InterleavedUnaryOpL1Usage(const L1InterfaceOpParams& input, const std::optional<L1InterfaceOpParams>& output);
+    InterleavedUnaryOpL1Usage(const L1InterfaceOperandParams& input, const std::optional<L1InterfaceOperandParams>& output);
     virtual ~InterleavedUnaryOpL1Usage() = default;
 
     virtual std::vector<std::tuple<uint32_t, uint32_t>> get_circular_buffer_l1_allocations_per_core() const override;
@@ -26,7 +26,7 @@ class InterleavedUnaryOpL1Usage : public UnaryOpL1Usage {
 
 class ShardedUnaryOpL1Usage : public UnaryOpL1Usage {
    public:
-    ShardedUnaryOpL1Usage(const L1InterfaceOpParams& input, const std::optional<L1InterfaceOpParams>& output);
+    ShardedUnaryOpL1Usage(const L1InterfaceOperandParams& input, const std::optional<L1InterfaceOperandParams>& output);
     virtual ~ShardedUnaryOpL1Usage() = default;
 
     virtual std::vector<std::tuple<uint32_t, uint32_t>> get_circular_buffer_l1_allocations_per_core() const override;
@@ -37,5 +37,5 @@ class UnaryOpL1UsageFactory {
    public:
     UnaryOpL1UsageFactory() = delete;
     static std::unique_ptr<UnaryOpL1Usage> Make(
-        const L1InterfaceOpParams& input, const std::optional<L1InterfaceOpParams>& output = std::nullopt);
+        const L1InterfaceOperandParams& input, const std::optional<L1InterfaceOperandParams>& output = std::nullopt);
 };

--- a/ttnn/cpp/ttnn/operations/normalization/softmax/softmax_l1_interface.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/softmax/softmax_l1_interface.cpp
@@ -4,11 +4,13 @@
 #include <memory>
 #include <tuple>
 
+#include "common/constants.hpp"
 #include "detail/util.hpp"
+#include "impl/buffers/buffer.hpp"
 #include "ttnn/operations/common/l1_interface_common.hpp"
 #include "ttnn/tensor/types.hpp"
 
-L1InterfaceOpParams get_softmax_output(const L1InterfaceOpParams& input) {
+L1InterfaceOperandParams get_softmax_output(const L1InterfaceOperandParams& input) {
     return std::make_tuple(
         std::get<ttnn::types::Shape>(input),
         std::get<tt::tt_metal::DataType>(input),
@@ -30,90 +32,98 @@ int find_max_divisor(uint32_t val, uint32_t start_max_div) {
     return result;
 }
 
-std::unique_ptr<SoftmaxOpL1Usage> SoftmaxOpL1UsageFactory::Make(const L1InterfaceOpParams& input, int dim_arg) {
+std::unique_ptr<SoftmaxOpL1Usage> SoftmaxOpL1UsageFactory::Make(const L1InterfaceOperandParams& input, int dim_arg) {
     return std::make_unique<SoftmaxOpL1Usage>(input, dim_arg);
 };
 
-SoftmaxOpL1Usage::SoftmaxOpL1Usage(const L1InterfaceOpParams& input, int dim_arg) :
-    input(input), output(get_softmax_output(input)), dim_arg(dim_arg) {}
+SoftmaxOpL1Usage::SoftmaxOpL1Usage(const L1InterfaceOperandParams& input, int dim_arg) :
+    input(input), output(get_softmax_output(input)), dim_arg(dim_arg), block_size(calculate_block_size_impl(input)) {}
 
-bool SoftmaxOpL1Usage::SoftmaxOpL1Usage::should_tilize_input() const {
+bool SoftmaxOpL1Usage::should_tilize_input() const {
     return std::get<tt::tt_metal::Layout>(input) != tt::tt_metal::Layout::TILE;
 }
 
-std::vector<std::tuple<uint32_t, uint32_t>>
-SoftmaxOpL1Usage::SoftmaxOpL1Usage::get_circular_buffer_l1_allocations_per_core() const {
-    std::vector<std::tuple<uint32_t, uint32_t>> sizes;
-
+uint32_t SoftmaxOpL1Usage::calculate_block_size_impl(const L1InterfaceOperandParams& input) const {
     const auto shape = std::get<ttnn::types::Shape>(input).value;
     const auto input_volume = std::get<ttnn::types::Shape>(input).volume();
 
-    uint32_t W = shape[-1], H = (input_volume / (shape[0] * shape[-1])), NC = shape[0];
-    uint32_t HW = H * W;
     uint32_t num_tiles = input_volume / tt::constants::TILE_HW;
-    uint32_t Wt = W / tt::constants::TILE_WIDTH;
-    uint32_t Ht = H / tt::constants::TILE_HEIGHT;
-    uint32_t block_size = false ? find_max_divisor(Wt, 4) : find_max_divisor(Wt, 8);
+    uint32_t Wt = shape[-1] / tt::constants::TILE_WIDTH;
+    uint32_t Ht = (input_volume / (shape[0] * shape[-1])) / tt::constants::TILE_HEIGHT;
+    uint32_t block_size = find_max_divisor(Wt, 8);
 
-    uint32_t in0_t = block_size * 2;
-    uint32_t out0_t = block_size * 2;
+    return block_size;
+}
+
+uint32_t SoftmaxOpL1Usage::get_input_cb_size() const {
+    return is_sharded(input) ? c_cb_shares_space_with_sharded_operand : 2 * block_size * get_tile_size(input);
+}
+
+uint32_t SoftmaxOpL1Usage::get_output_cb_size() const {
+    return is_sharded(output) ? c_cb_shares_space_with_sharded_operand : 2 * block_size * get_tile_size(output);
+}
+
+std::vector<uint32_t> SoftmaxOpL1Usage::get_intermediate_cb_sizes() const {
     uint32_t im1_t = 1;  // 1/sum(exp(x))
     uint32_t in2_t = 1;  // scaler for reduce coming from reader
-    uint32_t in3_t = 1;  // 1/sqrt() scaler tile cb for fused scale/mask/softmax variant
-    uint32_t in4_t =
-        tt::div_up(Wt, block_size) * block_size;  // attention mask (N,C,32,W) - Wt is reused for each Ht, NC is cycled
     uint32_t in5_t = 1;
-    uint32_t im0_t = block_size * tt::div_up(Wt, block_size);
-    uint32_t im3_t = block_size * (tt::div_up(Wt, block_size) + 1);
+    uint32_t im0_t =
+        block_size * tt::div_up(std::get<ttnn::Shape>(input).value[-1] / tt::constants::TILE_WIDTH, block_size);
 
-    uint32_t in0_tile_size = tt::tt_metal::detail::TileSize(
-        tt::tt_metal::datatype_to_dataformat_converter(std::get<tt::tt_metal::DataType>(input)));
     uint32_t scalar_tile_size = tt::tt_metal::detail::TileSize(tt::DataFormat::Float16_b);
-    uint32_t out0_tile_size = tt::tt_metal::detail::TileSize(
-        tt::tt_metal::datatype_to_dataformat_converter(std::get<tt::tt_metal::DataType>(output)));
     uint32_t mask_tile_size = tt::tt_metal::detail::TileSize(tt::DataFormat::Float16_b);
-
     // TODO: Support fp32 accumulation for WH B0 arch
     uint32_t im_tile_size = tt::tt_metal::detail::TileSize(tt::DataFormat::Float16_b);
 
-    if (should_tilize_input()) {
-        uint32_t stick_s = W;
-        uint32_t num_sticks = input_volume / W;
+    return {im1_t * im_tile_size, in2_t * scalar_tile_size, im0_t * im_tile_size, in5_t * mask_tile_size};
+}
 
-        uint32_t num_tiles_in_row = stick_s / tt::constants::TILE_WIDTH;
-        // TODO: Replace this with actual device L1 space query
-        uint32_t max_l1_size = 732 * 1024;
-        uint32_t max_tiles = max_l1_size / (in0_tile_size + out0_tile_size);  // 2 CBs
-        // Currently need the number of tiles in a row to be divisible by tiles in a block
-        uint32_t num_tiles_per_block = 1;
-        if (num_tiles_in_row <= max_tiles) {
-            num_tiles_per_block = num_tiles_in_row;
-        } else {
-            for (uint32_t n_t = max_tiles; n_t > 0; n_t--) {
-                if (num_tiles_in_row % n_t == 0) {
-                    num_tiles_per_block = n_t;
-                    break;
-                }
+uint32_t SoftmaxOpL1Usage::get_tilize_cb_size() const {
+    const auto shape = std::get<ttnn::types::Shape>(input).value;
+    const auto input_volume = std::get<ttnn::types::Shape>(input).volume();
+    uint32_t stick_s = shape[-1];
+    uint32_t num_sticks = input_volume / shape[-1];
+
+    uint32_t num_tiles_in_row = stick_s / tt::constants::TILE_WIDTH;
+    // TODO: Replace this with actual device L1 space query
+    uint32_t max_l1_size = 732 * 1024;
+    uint32_t max_tiles = max_l1_size / 2 * get_tile_size(input);  // 2 CBs
+    // Currently need the number of tiles in a row to be divisible by tiles in a block
+    uint32_t num_tiles_per_block = 1;
+    if (num_tiles_in_row <= max_tiles) {
+        num_tiles_per_block = num_tiles_in_row;
+    } else {
+        for (uint32_t n_t = max_tiles; n_t > 0; n_t--) {
+            if (num_tiles_in_row % n_t == 0) {
+                num_tiles_per_block = n_t;
+                break;
             }
         }
+    }
 
-        sizes.push_back(std::make_tuple(num_tiles_per_block * in0_tile_size, (uint32_t)1));
-        sizes.push_back(std::make_tuple(num_tiles_per_block * out0_tile_size, (uint32_t)1));
+    return num_tiles_per_block * get_tile_size(input);
+}
+
+std::vector<std::tuple<uint32_t, uint32_t>> SoftmaxOpL1Usage::get_circular_buffer_l1_allocations_per_core() const {
+    std::vector<std::tuple<uint32_t, uint32_t>> sizes;
+
+    if (should_tilize_input()) {
+        const uint32_t tilize_cb_size = get_tilize_cb_size();
+        sizes.push_back(std::make_tuple(tilize_cb_size, (uint32_t)1));
+        sizes.push_back(std::make_tuple(tilize_cb_size, (uint32_t)1));
     }
 
     const uint32_t num_cores_with_storage = get_num_of_cores();
-    sizes.push_back(std::make_tuple(in0_t * in0_tile_size, num_cores_with_storage));
-    sizes.push_back(std::make_tuple(out0_t * out0_tile_size, num_cores_with_storage));
-    sizes.push_back(std::make_tuple(im1_t * im_tile_size, num_cores_with_storage));
-    sizes.push_back(std::make_tuple(in2_t * scalar_tile_size, num_cores_with_storage));
-    sizes.push_back(std::make_tuple(im0_t * im_tile_size, num_cores_with_storage));
-    sizes.push_back(std::make_tuple(in5_t * mask_tile_size, num_cores_with_storage));
+    sizes.push_back(std::make_tuple(get_input_cb_size(), num_cores_with_storage));
+    sizes.push_back(std::make_tuple(get_output_cb_size(), num_cores_with_storage));
+    for (const uint32_t intermediate_cb_size : get_intermediate_cb_sizes()) {
+        sizes.push_back(std::make_tuple(intermediate_cb_size, num_cores_with_storage));
+    }
 
     return sizes;
 }
 
-std::vector<std::tuple<uint32_t, uint32_t>> SoftmaxOpL1Usage::SoftmaxOpL1Usage::get_tensor_l1_allocations_per_core()
-    const {
+std::vector<std::tuple<uint32_t, uint32_t>> SoftmaxOpL1Usage::get_tensor_l1_allocations_per_core() const {
     std::vector<std::tuple<uint32_t, uint32_t>> sizes;
 
     if (should_tilize_input()) {

--- a/ttnn/cpp/ttnn/operations/normalization/softmax/softmax_l1_interface.hpp
+++ b/ttnn/cpp/ttnn/operations/normalization/softmax/softmax_l1_interface.hpp
@@ -4,21 +4,28 @@
 
 class SoftmaxOpL1Usage {
    public:
-    SoftmaxOpL1Usage(const L1InterfaceOpParams& input, int dim_arg);
+    SoftmaxOpL1Usage(const L1InterfaceOperandParams& input, int dim_arg);
 
     std::vector<std::tuple<uint32_t, uint32_t>> get_circular_buffer_l1_allocations_per_core() const;
     std::vector<std::tuple<uint32_t, uint32_t>> get_tensor_l1_allocations_per_core() const;
 
    protected:
     bool should_tilize_input() const;
+    uint32_t calculate_block_size_impl(const L1InterfaceOperandParams& input) const;
+    uint32_t get_input_cb_size() const;
+    uint32_t get_output_cb_size() const;
+    std::vector<uint32_t> get_intermediate_cb_sizes() const;
+    uint32_t get_tilize_cb_size() const;
 
-    L1InterfaceOpParams input;
-    L1InterfaceOpParams output;
+    L1InterfaceOperandParams input;
+    L1InterfaceOperandParams output;
     int dim_arg;
+
+    uint32_t block_size;
 };
 
 class SoftmaxOpL1UsageFactory {
    public:
     SoftmaxOpL1UsageFactory() = delete;
-    static std::unique_ptr<SoftmaxOpL1Usage> Make(const L1InterfaceOpParams& input, int dim_arg);
+    static std::unique_ptr<SoftmaxOpL1Usage> Make(const L1InterfaceOperandParams& input, int dim_arg);
 };


### PR DESCRIPTION
To all folks who are code owners, no review required from the code owners, this is our internal branch that we are working on TTNN <-> optimiser interface.

Updated current L1 usage estimators to acount for CBs which share space with sharded input / output operands. Currently return size of c_cb_shares_space_with_sharded_operand (UINT32_MAX) for easier testing with graph capture (didn't use zero or some other number here as it we would skip some bugs that way, if we ignore comparison of such buffers).
