### PR TITLE
#12556: Add queue_id and optional output tensors to assign_bw

### DIFF
--- a/tests/ttnn/unit_tests/operations/backward/test_backward_assign.py
+++ b/tests/ttnn/unit_tests/operations/backward/test_backward_assign.py
@@ -49,3 +49,83 @@ def test_bw_binary_assign(input_shapes, device):
     golden_tensor = golden_function(grad_data, in_data, other_data)
     status = compare_pcc(tt_output_tensor_on_device, golden_tensor)
     assert status
+
+
+@pytest.mark.parametrize(
+    "input_shapes",
+    (
+        (torch.Size([1, 1, 32, 32])),
+        (torch.Size([1, 1, 320, 384])),
+        (torch.Size([1, 3, 320, 384])),
+    ),
+)
+def test_bw_unary_assign_opt_output(input_shapes, device):
+    in_data, input_tensor = data_gen_with_range(input_shapes, -100, 100, device, True)
+    grad_data, grad_tensor = data_gen_with_range(input_shapes, -100, 100, device)
+    opt_tensor = torch.zeros(input_shapes, dtype=torch.bfloat16)
+    input_grad = ttnn.from_torch(
+        opt_tensor, ttnn.bfloat16, layout=ttnn.TILE_LAYOUT, device=device, memory_config=ttnn.L1_MEMORY_CONFIG
+    )
+    pages_before = ttnn._ttnn.reports.get_buffer_pages()
+    ttnn.assign_bw(grad_tensor, input_tensor, input_a_grad=input_grad, queue_id=0)
+    assert len(pages_before) == len(ttnn._ttnn.reports.get_buffer_pages())
+
+    tt_output_tensor_on_device = [input_grad]
+    golden_function = ttnn.get_golden_function(ttnn.assign_bw)
+    golden_tensor = golden_function(grad_data, in_data)
+
+    status = compare_pcc(tt_output_tensor_on_device, golden_tensor)
+    assert status
+
+
+@pytest.mark.parametrize(
+    "input_shapes",
+    (
+        (torch.Size([1, 1, 32, 32])),
+        (torch.Size([1, 1, 320, 384])),
+        (torch.Size([1, 3, 320, 384])),
+    ),
+)
+@pytest.mark.parametrize("are_required_outputs", [[True, True], [True, False], [False, True]])
+def test_bw_binary_assign_opt_output(input_shapes, device, are_required_outputs):
+    in_data, input_tensor = data_gen_with_range(input_shapes, -100, 100, device, True)
+    other_data, other_tensor = data_gen_with_range(input_shapes, -100, 100, device, True)
+
+    grad_data, grad_tensor = data_gen_with_range(input_shapes, -100, 100, device)
+
+    opt_tensor = torch.zeros(input_shapes, dtype=torch.bfloat16)
+
+    input_grad = None
+    other_grad = None
+
+    if are_required_outputs[0]:
+        input_grad = ttnn.from_torch(
+            opt_tensor, ttnn.bfloat16, layout=ttnn.TILE_LAYOUT, device=device, memory_config=ttnn.L1_MEMORY_CONFIG
+        )
+    if are_required_outputs[1]:
+        other_grad = ttnn.from_torch(
+            opt_tensor, ttnn.bfloat16, layout=ttnn.TILE_LAYOUT, device=device, memory_config=ttnn.L1_MEMORY_CONFIG
+        )
+
+    cq_id = 0
+    pages_before = ttnn._ttnn.reports.get_buffer_pages()
+    ttnn.assign_bw(
+        grad_tensor,
+        input_tensor,
+        other_tensor,
+        are_required_outputs=are_required_outputs,
+        input_a_grad=input_grad,
+        input_b_grad=other_grad,
+        queue_id=cq_id,
+    )
+    assert len(pages_before) == len(ttnn._ttnn.reports.get_buffer_pages())
+    tt_output_tensor_on_device = [input_grad, other_grad]
+
+    golden_function = ttnn.get_golden_function(ttnn.assign_bw)
+    golden_tensor = golden_function(grad_data, in_data, other_data)
+
+    status = True
+    for i in range(len(are_required_outputs)):
+        if are_required_outputs[i]:
+            status = status & compare_pcc([tt_output_tensor_on_device[i]], [golden_tensor[i]])
+    assert status

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_backward/binary_backward.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_backward/binary_backward.hpp
@@ -112,18 +112,37 @@ struct ExecuteBackwardMul  {
 
 struct ExecuteBackwardAssign  {
 
-    static std::vector<ttnn::Tensor> invoke(
+    static std::vector<std::optional<ttnn::Tensor>> invoke(
         uint8_t queue_id,
         const Tensor &grad_tensor_arg,
         const Tensor &input_tensor_arg,
-        const std::optional<MemoryConfig> &memory_config = std::nullopt);
+        const std::optional<MemoryConfig> &memory_config = std::nullopt,
+        std::optional<Tensor> input_a_grad = std::nullopt);
 
-    static std::vector<ttnn::Tensor> invoke(
+    static std::vector<std::optional<ttnn::Tensor>> invoke(
         uint8_t queue_id,
         const Tensor &grad_tensor_arg,
         const Tensor &input_tensor_arg,
         const Tensor &other_tensor_arg,
-        const std::optional<MemoryConfig> &memory_config = std::nullopt);
+        const std::vector<bool> &are_required_outputs = std::vector<bool>{true, true},
+        const std::optional<MemoryConfig> &memory_config = std::nullopt,
+        std::optional<Tensor> input_a_grad = std::nullopt,
+        std::optional<Tensor> input_b_grad = std::nullopt);
+
+    static std::vector<std::optional<ttnn::Tensor>> invoke(
+        const Tensor &grad_tensor_arg,
+        const Tensor &input_tensor_arg,
+        const std::optional<MemoryConfig> &memory_config = std::nullopt,
+        std::optional<Tensor> input_a_grad = std::nullopt);
+
+    static std::vector<std::optional<ttnn::Tensor>> invoke(
+        const Tensor &grad_tensor_arg,
+        const Tensor &input_tensor_arg,
+        const Tensor &other_tensor_arg,
+        const std::vector<bool> &are_required_outputs = std::vector<bool>{true, true},
+        const std::optional<MemoryConfig> &memory_config = std::nullopt,
+        std::optional<Tensor> input_a_grad = std::nullopt,
+        std::optional<Tensor> input_b_grad = std::nullopt);
 
 };
 


### PR DESCRIPTION
### Ticket
Link to Github Issue #12556

### Problem description
Add queue_id and optional output tensors to assign_bw

### What's changed
Add queue_id and optional output tensors to assign_bw

Perf before vs after:
op,count,python min dispatch time (ms),python mean dispatch time(ms),python mean dispatch + sync time (ms)

- ttnn.assign_bw,800,0.003,0.004,0.006
- ttnn.assign_bw,800,0.004,0.004,0.006

### Checklist
- [x] Post commit CI https://github.com/tenstorrent/tt-metal/actions/runs/10833623616
https://github.com/tenstorrent/tt-metal/actions/runs/11027449774
- [ ] Blackhole Post commit (if applicable)
- [ ] Model regression CI testing passes (if applicable)
- [ ] Device performance regression CI testing passes (if applicable)
- [x] New/Existing tests provide coverage for changes
