### PR TITLE
#12538: Separate out wheel tests from build so that other wheel-dependent jobs aren't blocked by the wheel smoke tests

### DIFF
--- a/.github/workflows/_test-wheels-impl.yaml
+++ b/.github/workflows/_test-wheels-impl.yaml
@@ -1,4 +1,4 @@
-name: "[internal] Python wheels build and test impl"
+name: "[internal] Python wheels test impl"
 
 on:
   workflow_call:
@@ -8,21 +8,20 @@ on:
         default: True
         type: boolean
 
+# Since pre-compiled assets are only built on ubuntu-20.04, we force tests
+# to only be run on ubuntu-20.04.
+#
+# Otherwise, we run across 20.04 and 22.04 as we should have assets for both
+# from previous wheel builds if from-precompiled is false.
+#
+# I chose the more heavy-handed approach because:
+# - This should all go away soon once we have more OSes + more Docker up and
+# running so we can matrix properly across more stuff
+# - though provides less flexibility to caller workflows, we want to be pretty
+# strict with the matrix + doesn't change often
+
 jobs:
-  build-wheels:
-    strategy:
-      matrix:
-        # Since pre-compiled builds only run on 20.04, we can only test on 20.04 for now
-        # The full 22.04 flow can be tested without precompiled
-        os: ${{ fromJson(inputs.from-precompiled && '["ubuntu-20.04"]' || '["ubuntu-20.04", "ubuntu-22.04"]') }}
-        arch: [grayskull, wormhole_b0]
-    uses: ./.github/workflows/_build-wheels-impl.yaml
-    with:
-      os: ${{ matrix.os }}
-      arch: ${{ matrix.arch }}
-      from-precompiled: ${{ inputs.from-precompiled }}
   test-wheels-host:
-    needs: build-wheels
     strategy:
       matrix:
         os: ${{ fromJson(inputs.from-precompiled && '["ubuntu-20.04"]' || '["ubuntu-20.04", "ubuntu-22.04"]') }}
@@ -51,6 +50,7 @@ jobs:
     needs: build-wheels
     strategy:
       matrix:
+        # We only have this for non-Docker silicon runners right now
         os: [ubuntu-20.04]
         runner-hw-info: [
           {arch: grayskull, type: E150},

--- a/.github/workflows/_test-wheels-impl.yaml
+++ b/.github/workflows/_test-wheels-impl.yaml
@@ -47,7 +47,6 @@ jobs:
           cd tests/end_to_end_tests
           pytest -c conftest.py . -m eager_host_side
   test-wheels-silicon:
-    needs: build-wheels
     strategy:
       matrix:
         # We only have this for non-Docker silicon runners right now

--- a/.github/workflows/all-post-commit-workflows.yaml
+++ b/.github/workflows/all-post-commit-workflows.yaml
@@ -17,9 +17,23 @@ jobs:
   static-checks:
     uses: ./.github/workflows/all-static-checks.yaml
     secrets: inherit
-  build-and-test-wheels:
+  build-wheels:
     needs: build-artifact
-    uses: ./.github/workflows/_build-and-test-wheels-impl.yaml
+    strategy:
+      matrix:
+        # Since pre-compiled builds only run on 20.04, we can only test on 20.04 for now
+        # The full 22.04 flow can be tested without precompiled
+        os: [ubuntu-20.04]
+        arch: [grayskull, wormhole_b0]
+    uses: ./.github/workflows/_build-wheels-impl.yaml
+    with:
+      os: ${{ matrix.os }}
+      arch: ${{ matrix.arch }}
+      from-precompiled: true
+    secrets: inherit
+  test-wheels:
+    needs: build-wheels
+    uses: ./.github/workflows/_test-wheels-impl.yaml
     with:
       from-precompiled: true
     secrets: inherit
@@ -64,7 +78,7 @@ jobs:
       runner-label: ${{ matrix.test-group.runner-label }}
   # Fast Dispatch Unit Tests
   fast-dispatch-unit-tests:
-    needs: build-and-test-wheels
+    needs: build-wheels
     secrets: inherit
     strategy:
       fail-fast: false
@@ -80,7 +94,7 @@ jobs:
       runner-label: ${{ matrix.test-group.runner-label }}
   # TTNN FD Unit tests
   ttnn-unit-tests:
-    needs: build-and-test-wheels
+    needs: build-wheels
     secrets: inherit
     strategy:
       fail-fast: false
@@ -96,7 +110,7 @@ jobs:
       runner-label: ${{ matrix.test-group.runner-label }}
   # FD Model Tests
   models-unit-tests:
-    needs: build-and-test-wheels
+    needs: build-wheels
     secrets: inherit
     strategy:
       fail-fast: false

--- a/.github/workflows/blackhole-post-commit.yaml
+++ b/.github/workflows/blackhole-post-commit.yaml
@@ -65,7 +65,7 @@ jobs:
 #     uses: ./.github/workflows/run-profiler-regression.yaml
 #     secrets: inherit
 #   build-and-test-wheels:
-#     uses: ./.github/workflows/_build-and-test-wheels-impl.yaml
+#     uses: Check all-post-commit yaml for directions
 #     secrets: inherit
 #   build-docs:
 #     needs: build-artifact

--- a/.github/workflows/build-and-test-wheels.yaml
+++ b/.github/workflows/build-and-test-wheels.yaml
@@ -28,7 +28,7 @@ jobs:
       arch: ${{ matrix.arch }}
       from-precompiled: ${{ inputs.from-precompiled }}
   test-wheels:
-    needs: build-artifact
+    needs: build-wheels
     if: ${{ always() }}
     uses: ./.github/workflows/_test-wheels-impl.yaml
     with:

--- a/.github/workflows/build-and-test-wheels.yaml
+++ b/.github/workflows/build-and-test-wheels.yaml
@@ -15,9 +15,21 @@ jobs:
     if: ${{ github.event_name == 'workflow_dispatch' && inputs.from-precompiled }}
     uses: ./.github/workflows/build-artifact.yaml
     secrets: inherit
-  build-and-test-wheels:
+  build-wheels:
+    strategy:
+      matrix:
+        # Since pre-compiled builds only run on 20.04, we can only test on 20.04 for now
+        # The full 22.04 flow can be tested without precompiled
+        os: ${{ fromJson((github.event_name == 'schedule' || inputs.from-precompiled) && '["ubuntu-20.04"]' || '["ubuntu-20.04", "ubuntu-22.04"]') }}
+        arch: [grayskull, wormhole_b0]
+    uses: ./.github/workflows/_build-wheels-impl.yaml
+    with:
+      os: ${{ matrix.os }}
+      arch: ${{ matrix.arch }}
+      from-precompiled: ${{ inputs.from-precompiled }}
+  test-wheels:
     needs: build-artifact
     if: ${{ always() }}
-    uses: ./.github/workflows/_build-and-test-wheels-impl.yaml
+    uses: ./.github/workflows/_test-wheels-impl.yaml
     with:
       from-precompiled: ${{ github.event_name == 'workflow_dispatch' && inputs.from-precompiled }}

--- a/.github/workflows/build-and-test-wheels.yaml
+++ b/.github/workflows/build-and-test-wheels.yaml
@@ -17,7 +17,7 @@ jobs:
     secrets: inherit
   build-wheels:
     needs: build-artifact
-    needs: ${{ always() }}
+    if: ${{ always() }}
     strategy:
       matrix:
         # Since pre-compiled builds only run on 20.04, we can only test on 20.04 for now

--- a/.github/workflows/build-and-test-wheels.yaml
+++ b/.github/workflows/build-and-test-wheels.yaml
@@ -16,6 +16,8 @@ jobs:
     uses: ./.github/workflows/build-artifact.yaml
     secrets: inherit
   build-wheels:
+    needs: build-artifact
+    needs: ${{ always() }}
     strategy:
       matrix:
         # Since pre-compiled builds only run on 20.04, we can only test on 20.04 for now


### PR DESCRIPTION
…

### Ticket

#12538

### Problem description

Wheel smoke tests are run after wheel build, but it blocks the downstream wheel jobs with docker like model post commit and FD unit tests.

### What's changed

We separated the wheel smoke test after the wheel build so that it doesn't block other jobs.

### Checklist
- [ ] Post commit CI passes
- [ ] Blackhole Post commit (if applicable)
- [ ] Model regression CI testing passes (if applicable)
- [ ] Device performance regression CI testing passes (if applicable)
- [ ] New/Existing tests provide coverage for changes
