### PR TITLE
#12595: Run profiler gather after every sweep test regardless of status

### DIFF
--- a/tests/sweep_framework/runner.py
+++ b/tests/sweep_framework/runner.py
@@ -43,7 +43,7 @@ def get_devices(test_module):
         return default_device()
 
 
-def gather_single_test_perf(device):
+def gather_single_test_perf(device, test_passed):
     if not isinstance(device, ttnn.Device):
         print("SWEEPS: Multi-device perf is not supported. Failing.")
         return None
@@ -51,7 +51,12 @@ def gather_single_test_perf(device):
     opPerfData = get_device_data_generate_report(
         PROFILER_LOGS_DIR, None, None, None, export_csv=False, cleanup_device_log=True
     )
-    if len(opPerfData) != 1:
+    if not test_passed:
+        return None
+    elif opPerfData == []:
+        print("SWEEPS: No profiling data available. Ensure you are running with the profiler build.")
+        return None
+    elif len(opPerfData) > 1:
         print("SWEEPS: Composite op detected in device perf measurement. Composite op perf is not supported. Failing.")
         return None
     else:
@@ -81,8 +86,8 @@ def run(test_module, input_queue, output_queue):
             except Exception as e:
                 status, message = False, str(e)
                 e2e_perf = None
-            if MEASURE_DEVICE_PERF and status:
-                perf_result = gather_single_test_perf(device)
+            if MEASURE_DEVICE_PERF:
+                perf_result = gather_single_test_perf(device, status)
                 output_queue.put([status, message, e2e_perf, perf_result])
             else:
                 output_queue.put([status, message, e2e_perf, None])


### PR DESCRIPTION
### Ticket
#12595 

### Problem description
See issue.

### What's changed
Change the framework to call the profiler gather after every test, regardless of status. This will clear results after every test to make sure there is a clean state upon starting every test.

### Checklist
- [ ] Post commit CI passes
- [ ] Blackhole Post commit (if applicable)
- [ ] Model regression CI testing passes (if applicable)
- [ ] Device performance regression CI testing passes (if applicable)
- [ ] New/Existing tests provide coverage for changes
