### PR TITLE
#0: Handling Absence of Prefill in Mistral Prefill Demo

### DIFF
--- a/models/demos/wormhole/mistral7b/demo/demo_with_prefill.py
+++ b/models/demos/wormhole/mistral7b/demo/demo_with_prefill.py
@@ -86,6 +86,7 @@ def preprocess_inputs_prefill(input_prompts, tokenizer, model_args, dtype, embd,
     for i, encoded in enumerate(encoded_prompts):
         if prefill_seq_len > 0:
             input_tokens_prefill[i] = torch.tensor(encoded[:prefill_seq_len]).to(input_tokens_prefill)
+            pt_tokenized_inputs_prefill = torch.tensor(input_tokens_prefill)
         input_tokens_decode[i, : len(encoded[prefill_seq_len:])] = torch.tensor(encoded[prefill_seq_len:]).to(
             input_tokens_decode
         )
@@ -97,7 +98,6 @@ def preprocess_inputs_prefill(input_prompts, tokenizer, model_args, dtype, embd,
 
     # Select the first token from the prompts for initial decoding
     pt_tokenized_inputs_decode = torch.tensor(input_tokens_decode)
-    pt_tokenized_inputs_prefill = torch.tensor(input_tokens_prefill)
     emb_inputs_decode = embd(pt_tokenized_inputs_decode[:, 0]).view(model_args.max_batch_size, 1, -1)
     if prefill_seq_len > 0:
         emb_prefill_inputs = [


### PR DESCRIPTION
### Ticket
N/A

### Problem description
In mistral7b `demo_with_prefill.py`, the variable `input_tokens_prefill` will be referenced before assignment in the case where there is no prefill (ie. `prefill_seq_len` = 0). 

### What's changed
I just updated where `pt_tokenized_inputs_prefill` is assigned to avoid this issue by putting it under the conditional. 
This will allow the demo to handle the case when it is run without prefill as well. This is relevant as the function in demo are used in https://github.com/tenstorrent/tt-inference-server . This change will allow the inference server to handle cases where there is and there isn't prefill. 

### Checklist
- [ ] Post commit CI passes
