### PR TITLE
mm_sfence->tt_driver_atomics::sfence();

### DIFF
--- a/tests/tt_metal/tt_metal/perf_microbenchmark/3_pcie_transfer/test_pull_from_pcie.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/3_pcie_transfer/test_pull_from_pcie.cpp
@@ -73,7 +73,7 @@ void nt_memcpy_128b(uint8_t *__restrict dst, const uint8_t *__restrict src, size
     }
 
     if (num_lines > 0)
-        _mm_sfence();
+        tt_driver_atomics::sfence();
 }
 
 template <bool stream_load, bool aligned_load>
@@ -105,7 +105,7 @@ void nt_memcpy_256b(uint8_t *__restrict dst, const uint8_t *__restrict src, size
     }
 
     if (num_lines > 0)
-        _mm_sfence();
+        tt_driver_atomics::sfence();
 }
 
 int main(int argc, char **argv) {

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/test_bw_and_latency.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/test_bw_and_latency.cpp
@@ -117,7 +117,7 @@ void nt_memcpy(uint8_t *__restrict dst, const uint8_t * __restrict src, size_t n
     }
 
     if (num_lines > 0)
-        _mm_sfence();
+        tt_driver_atomics::sfence();
 }
 
 int main(int argc, char **argv) {

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/test_prefetcher.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/test_prefetcher.cpp
@@ -200,7 +200,7 @@ void dirty_host_completion_buffer(uint32_t *host_hugepage_completion_buffer) {
     for (int i = 0; i < DEFAULT_HUGEPAGE_COMPLETION_BUFFER_SIZE / sizeof(uint32_t); i++) {
         host_hugepage_completion_buffer[i] = host_data_dirty_pattern;
     }
-    _mm_sfence();
+    tt_driver_atomics::sfence();
 }
 
 uint32_t round_cmd_size_up(uint32_t size) {
@@ -1344,7 +1344,7 @@ void nt_memcpy(uint8_t *__restrict dst, const uint8_t * __restrict src, size_t n
     }
 
     if (num_lines > 0)
-        _mm_sfence();
+        tt_driver_atomics::sfence();
 }
 
 void write_prefetcher_cmd(Device *device,


### PR DESCRIPTION
### Ticket
None

### Problem description
Non-portable intrinsics being used in some tests

### What's changed
Use UMD's version which is defined based on host arch

### Checklist
- [ ] Post commit CI passes
- [ ] Blackhole Post commit (if applicable)
- [ ] Model regression CI testing passes (if applicable)
- [ ] Device performance regression CI testing passes (if applicable)
- [ ] New/Existing tests provide coverage for changes
