### PR TITLE
#0: Add FD nightly single-card pipeline to data pipeline

### DIFF
--- a/.github/workflows/_produce-data.yaml
+++ b/.github/workflows/_produce-data.yaml
@@ -19,6 +19,7 @@ on:
       - "(T3K) T3000 model perf tests"
       - "(Single-card) Model perf tests"
       - "(Single-card) Device perf tests"
+      - "Nightly fast dispatch tests"
     types:
       - completed
 

--- a/.github/workflows/fast-dispatch-full-regressions-and-models.yaml
+++ b/.github/workflows/fast-dispatch-full-regressions-and-models.yaml
@@ -149,3 +149,9 @@ jobs:
           cd $TT_METAL_HOME
           export PYTHONPATH=$TT_METAL_HOME
           ${{ matrix.test-group.cmd }}
+      - uses: ./.github/actions/upload-artifact-with-job-uuid
+        if: ${{ !cancelled() }}
+        with:
+          path: |
+            generated/test_reports/
+          prefix: "test_reports_"


### PR DESCRIPTION
### Ticket

Just adding a pipeline to data visibility.

### Problem description

We run nightly fast dispatch quite a bit.

It's worth having visibility on it.

### What's changed

- Add its name to workflow list so produce-data picks it up upon completion
- Add test reports to uploaded artifacts

### Checklist
- [ ] Post commit CI passes
- [ ] Blackhole Post commit (if applicable)
- [ ] Model regression CI testing passes (if applicable)
- [ ] Device performance regression CI testing passes (if applicable)
- [ ] New/Existing tests provide coverage for changes
