### PR TITLE
Changing the constraint framework to include buffer size checks

### DIFF
--- a/tests/ttnn/unit_tests/gtests/test_binary_interface.cpp
+++ b/tests/ttnn/unit_tests/gtests/test_binary_interface.cpp
@@ -122,49 +122,6 @@ TEST_P(BinaryInterfaceTestFixture, BinaryInterfaceTest) {
                     // // get graph trace for ground truth
                     auto json_trace = graph::query_trace(call);
                     tt::log_info("Trace: {}", json_trace.dump(4));
-
-                    // L1 interface calls and checks against graph trace
-                    {
-                        auto l1_input_a = std::make_tuple(
-                            input_a.shape,
-                            op_constraint.getDataTypeA().value(),
-                            op_constraint.getTileLayoutA().value(),
-                            input_a.memory_config);
-                        auto l1_input_b = std::make_tuple(
-                            input_b.shape,
-                            op_constraint.getDataTypeB().value(),
-                            op_constraint.getTileLayoutB().value(),
-                            input_b.memory_config);
-                        auto l1_output = std::make_tuple(
-                            input_a.shape,
-                            op_constraint.getDataTypeA().value(),
-                            op_constraint.getTileLayoutA().value(),
-                            input_a.memory_config);
-
-                        auto l1_usage = EltwiseOpL1UsageFactory::Make(l1_input_a, l1_input_b, l1_output);
-
-                        auto l1_cb_usage = l1_usage->get_circular_buffer_l1_allocations_per_core();
-                        auto graph_circular_buffer_allocations =
-                            graph::extract_circular_buffer_allocations_per_core(json_trace);
-                        EXPECT_EQ(l1_cb_usage.size(), graph_circular_buffer_allocations.size());
-                        for (int i = 0; i < l1_cb_usage.size(); i++) {
-                            std::cout << "DBG cb[" << i << "]" << std::get<0>(l1_cb_usage[i])
-                                      << std::endl;  // << " " << graph_circular_buffer_allocations[i] << std::endl;
-                            EXPECT_EQ(std::get<0>(l1_cb_usage[i]), graph_circular_buffer_allocations[i]);
-                        }
-
-                        auto l1_tensor_usage =
-                            l1_usage->get_tensor_l1_allocations_per_core();  // what about output tensor allocation?
-                        auto graph_l1_buffer_allocations = graph::extract_l1_buffer_allocations(json_trace);  // total
-                        EXPECT_EQ(l1_tensor_usage.size(), graph_l1_buffer_allocations.size());
-                        for (int i = 0; i < l1_tensor_usage.size(); i++) {
-                            std::cout << "DBG l1[" << i << "]" << std::get<0>(l1_tensor_usage[i])
-                                      << std::endl;  // << " " << graph_l1_buffer_allocations[i] << std::endl;
-                            EXPECT_EQ(
-                                std::get<0>(l1_tensor_usage[i]) * std::get<1>(l1_tensor_usage[i]),
-                                graph_l1_buffer_allocations[i]);
-                        }
-                    }
                 }
             }
         } else {

--- a/tests/ttnn/unit_tests/gtests/test_binary_interface.cpp
+++ b/tests/ttnn/unit_tests/gtests/test_binary_interface.cpp
@@ -44,7 +44,6 @@ struct InputShapeTestParam {
     ttnn::types::Shape shape;
     tt::tt_metal::MemoryConfig memory_config;
     tt::tt_metal::DataType data_type = tt::tt_metal::DataType::BFLOAT16;
-    tt::tt_metal::Layout layout = tt::tt_metal::Layout::TILE;
 };
 
 class BinaryInterfaceTestFixture : public TTNNFixtureWithDevice,

--- a/tests/ttnn/unit_tests/gtests/test_matmul_interface.cpp
+++ b/tests/ttnn/unit_tests/gtests/test_matmul_interface.cpp
@@ -45,7 +45,6 @@ struct InputShapeTestParam {
     ttnn::types::Shape shape;
     tt::tt_metal::MemoryConfig memory_config;
     tt::tt_metal::DataType data_type = tt::tt_metal::DataType::BFLOAT16;
-    tt::tt_metal::Layout layout = tt::tt_metal::Layout::TILE;
 };
 
 class MatmulInterfaceTestFixture : public TTNNFixtureWithDevice,
@@ -118,16 +117,19 @@ TEST_P(MatmulInterfaceTestFixture, MatmulInterfaceTest) {
             // Run the test
             {
                 for (const auto& op_constraint : op_constraints) {
-                    auto input_tensor_a = ttnn::zeros(
-                        input_a.shape, input_a.data_type, input_a.layout, this->getDevice(), input_a.memory_config);
-                    auto input_tensor_b = ttnn::zeros(
-                        input_b.shape, input_b.data_type, input_b.layout, this->getDevice(), input_b.memory_config);
-
                     auto call = [&] {
                         auto input_tensor_a = ttnn::zeros(
-                            input_a.shape, input_a.data_type, input_a.layout, this->getDevice(), input_a.memory_config);
+                            input_a.shape,
+                            op_constraint.getDataTypeA().value(),
+                            op_constraint.getTileLayoutA().value(),
+                            this->getDevice(),
+                            input_a.memory_config);
                         auto input_tensor_b = ttnn::zeros(
-                            input_b.shape, input_b.data_type, input_b.layout, this->getDevice(), input_b.memory_config);
+                            input_b.shape,
+                            op_constraint.getDataTypeB().value(),
+                            op_constraint.getTileLayoutB().value(),
+                            this->getDevice(),
+                            input_b.memory_config);
                         const auto output_tensor = ttnn::matmul(
                             input_tensor_a,
                             input_tensor_b,

--- a/tests/ttnn/unit_tests/gtests/test_unary_interface.cpp
+++ b/tests/ttnn/unit_tests/gtests/test_unary_interface.cpp
@@ -44,7 +44,6 @@ struct InputShapeTestParam {
     ttnn::types::Shape shape;
     tt::tt_metal::MemoryConfig memory_config;
     tt::tt_metal::DataType data_type = tt::tt_metal::DataType::BFLOAT16;
-    tt::tt_metal::Layout layout = tt::tt_metal::Layout::TILE;
 };
 
 class UnaryInterfaceTestFixture

--- a/ttnn/cpp/ttnn/common/op_constraints.hpp
+++ b/ttnn/cpp/ttnn/common/op_constraints.hpp
@@ -57,7 +57,15 @@ class OpConstraint {
 };
 
 class OpConstraintsBuilder {
-   public:
+   private:
+    uint32_t get_packed_size_in_bytes(const tt::tt_metal::DataType& data_type, const ttnn::Shape& shape) const;
+    bool can_allocate_sharded_buffer(
+        const MemoryConfig& memory_config,
+        const ttnn::Shape& shape,
+        const Layout& layout,
+        const DataType& data_type) const;
+
+   protected:
     std::optional<tt::tt_metal::DataType> data_type_a;  // required
     std::optional<tt::tt_metal::Layout> tile_layout_a;
     std::optional<tt::tt_metal::StorageType> storage_type_a;
@@ -74,7 +82,7 @@ class OpConstraintsBuilder {
     virtual bool is_valid_external_constraint(const OpConstraint& constraint) const;
     virtual bool is_valid_op_constraint(const OpConstraint& constraint) const = 0;
 
-    virtual bool is_tensor_valid(
+    bool is_sharded_tensor_valid(
         const MemoryConfig& memory_config,
         const ttnn::Shape& shape,
         const Layout& layout,

--- a/ttnn/cpp/ttnn/operations/eltwise/binary/binary_constraints.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary/binary_constraints.cpp
@@ -238,7 +238,8 @@ EltwiseOpTypes EltwiseOpConstraintsFactory::GetEltwiseOpType(
             if (memory_config_o.memory_layout == TensorMemoryLayout::HEIGHT_SHARDED) {
                 return EltwiseOpTypes::NotSupported;
             }
-            // Check if we need this.
+            // TODO: Check if we need this. This will have the consequence that building the constraint framework will
+            // require a TT card in the system.
             /*uint32_t num_blocks = Volume(input_shape_a) / input_shape_a[-1] / tt::constants::TILE_HEIGHT;
             auto core_grid = input_tensor_a.device()->compute_with_storage_grid_size();
             uint32_t num_cores = core_grid.x * core_grid.y;

--- a/ttnn/cpp/ttnn/operations/eltwise/binary/binary_constraints.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary/binary_constraints.cpp
@@ -6,34 +6,28 @@ std::vector<OpConstraint> EltwiseOpConstraintsBuilder::build_constraints() {
     }
 
     std::vector<Layout> tile_layouts_a = {Layout::ROW_MAJOR, Layout::TILE};
-    if (tile_layout_a.has_value())
-    {
+    if (tile_layout_a.has_value()) {
         tile_layouts_a = {tile_layout_a.value()};
     }
     std::vector<Layout> tile_layouts_b = {Layout::ROW_MAJOR, Layout::TILE};
-    if (tile_layout_b.has_value())
-    {
+    if (tile_layout_b.has_value()) {
         tile_layouts_a = {tile_layout_b.value()};
     }
     std::vector<Layout> tile_layouts_o = {Layout::ROW_MAJOR, Layout::TILE};
-    if (tile_layout_o.has_value())
-    {
+    if (tile_layout_o.has_value()) {
         tile_layouts_o = {tile_layout_b.value()};
     }
     // Only two for now. TODO: add other storage types.
     std::vector<StorageType> storage_types_a = {StorageType::OWNED, StorageType::DEVICE};
-    if (storage_type_a.has_value())
-    {
+    if (storage_type_a.has_value()) {
         storage_types_a = {storage_type_a.value()};
     }
     std::vector<StorageType> storage_types_b = {StorageType::OWNED, StorageType::DEVICE};
-    if (storage_type_b.has_value())
-    {
+    if (storage_type_b.has_value()) {
         storage_types_b = {storage_type_b.value()};
     }
     std::vector<StorageType> storage_types_o = {StorageType::OWNED, StorageType::DEVICE};
-    if (storage_type_o.has_value())
-    {
+    if (storage_type_o.has_value()) {
         storage_types_o = {storage_type_a.value()};
     }
 
@@ -73,10 +67,12 @@ bool EltwiseOpConstraintsBuilder::is_valid_op_constraint(const OpConstraint& con
     const tt::tt_metal::Layout c_tile_layout_b = constraint.getTileLayoutB().value();
     const tt::tt_metal::DataType data_type_a = constraint.getDataTypeA().value();
     const tt::tt_metal::DataType data_type_b = constraint.getDataTypeB().value();
-    if (!is_tensor_valid(memory_config_a, shape_a, c_tile_layout_a, data_type_a)) {
+    if (memory_config_a.is_sharded() &&
+        !is_sharded_tensor_valid(memory_config_a, shape_a, c_tile_layout_a, data_type_a)) {
         return false;
     }
-    if (!is_tensor_valid(memory_config_b, shape_b, c_tile_layout_b, data_type_b)) {
+    if (memory_config_b.is_sharded() &&
+        !is_sharded_tensor_valid(memory_config_b, shape_b, c_tile_layout_b, data_type_b)) {
         return false;
     }
     if (c_tile_layout_a != tt::tt_metal::Layout::TILE) {

--- a/ttnn/cpp/ttnn/operations/eltwise/unary/unary_constraints.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary/unary_constraints.cpp
@@ -95,7 +95,8 @@ bool UnaryOpConstraintsBuilder::is_valid_op_constraint(const OpConstraint& const
     const tt::tt_metal::DataType data_type_a = constraint.getDataTypeA().value();
     const tt::tt_metal::StorageType storage_type_a = constraint.getStorageTypeA().value();
     tt::tt_metal::DataType data_type_o = constraint.getDataTypeO().value();
-    if (!is_tensor_valid(memory_config_a, shape_a, c_tile_layout_a, data_type_a)) {
+    if (memory_config_a.is_sharded() &&
+        !is_sharded_tensor_valid(memory_config_a, shape_a, c_tile_layout_a, data_type_a)) {
         return false;
     }
     if (!is_supported_dtype(data_type_a, data_type_o, op_type)) {

--- a/ttnn/cpp/ttnn/operations/matmul/matmul_constraints.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/matmul_constraints.cpp
@@ -68,10 +68,15 @@ bool MatmulOpConstraintsBuilder::is_valid_op_constraint(const OpConstraint& cons
     const tt::tt_metal::Layout c_tile_layout_b = constraint.getTileLayoutB().value();
     const tt::tt_metal::DataType data_type_a = constraint.getDataTypeA().value();
     const tt::tt_metal::DataType data_type_b = constraint.getDataTypeB().value();
-    if (!is_tensor_valid(memory_config_a, shape_a, c_tile_layout_a, data_type_a)) {
+    if (c_tile_layout_a != Layout::TILE || c_tile_layout_b != Layout::TILE) {
         return false;
     }
-    if (!is_tensor_valid(memory_config_b, shape_b, c_tile_layout_b, data_type_b)) {
+    if (memory_config_a.is_sharded() &&
+        !is_sharded_tensor_valid(memory_config_a, shape_a, c_tile_layout_a, data_type_a)) {
+        return false;
+    }
+    if (memory_config_b.is_sharded() &&
+        !is_sharded_tensor_valid(memory_config_b, shape_b, c_tile_layout_b, data_type_b)) {
         return false;
     }
     if (!is_floating_point(data_type_a)) {

--- a/ttnn/cpp/ttnn/operations/normalization/softmax/softmax_constraints.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/softmax/softmax_constraints.cpp
@@ -8,24 +8,20 @@ std::vector<OpConstraint> SoftmaxOpConstraintsBuilder::build_constraints() {
     // reducing search space
     // data types are required
     std::vector<Layout> tile_layouts_a = {Layout::ROW_MAJOR, Layout::TILE};
-    if (tile_layout_a.has_value())
-    {
+    if (tile_layout_a.has_value()) {
         tile_layouts_a = {tile_layout_a.value()};
     }
     std::vector<Layout> tile_layouts_o = {Layout::ROW_MAJOR, Layout::TILE};
-    if (tile_layout_o.has_value())
-    {
+    if (tile_layout_o.has_value()) {
         tile_layouts_o = {tile_layout_b.value()};
     }
     // Only two for now. TODO: add other storage types.
     std::vector<StorageType> storage_types_a = {StorageType::OWNED, StorageType::DEVICE};
-    if (storage_type_a.has_value())
-    {
+    if (storage_type_a.has_value()) {
         storage_types_a = {storage_type_a.value()};
     }
     std::vector<StorageType> storage_types_o = {StorageType::OWNED, StorageType::DEVICE};
-    if (storage_type_o.has_value())
-    {
+    if (storage_type_o.has_value()) {
         storage_types_o = {storage_type_a.value()};
     }
 
@@ -59,7 +55,8 @@ std::vector<OpConstraint> SoftmaxOpConstraintsBuilder::build_constraints() {
 bool SoftmaxConstraintsBuilder::is_valid_op_constraint(const OpConstraint& constraint) const {
     const tt::tt_metal::DataType data_type_a = constraint.getDataTypeA().value();
     const tt::tt_metal::Layout c_tile_layout_a = constraint.getTileLayoutA().value();
-    if (!is_tensor_valid(memory_config_a, shape_a, c_tile_layout_a, data_type_a)) {
+    if (memory_config_a.is_sharded() &&
+        !is_sharded_tensor_valid(memory_config_a, shape_a, c_tile_layout_a, data_type_a)) {
         return false;
     }
     // made-up constraint - tiles only
@@ -74,8 +71,7 @@ bool SoftmaxConstraintsBuilder::is_valid_op_constraint(const OpConstraint& const
     return true;
 }
 
-bool SoftmaxConstraintsBuilder::can_build_constraints() const
-{
+bool SoftmaxConstraintsBuilder::can_build_constraints() const {
     return data_type_a.has_value() && data_type_o.has_value();
 }
 


### PR DESCRIPTION
### Problem description
Changing the constraint framework to include buffer size checks

### What's changed
During testing of the constraint framework, it was noticed that the configurations that pass the checks still fail on silicon due to the lack of allocations considering buffer and page size in memory. This PR adds these checks.
