### PR TITLE
Fix Post Commit Blackhole Workflow

### DIFF
--- a/.github/workflows/blackhole-post-commit.yaml
+++ b/.github/workflows/blackhole-post-commit.yaml
@@ -24,6 +24,12 @@ jobs:
     secrets: inherit
     with:
       arch: '["blackhole"]'
+  build-wheels:
+    uses: ./.github/workflows/_build-wheels-impl.yaml
+    with:
+      os: "ubuntu-20.04"
+      arch: "blackhole"
+      from-precompiled: true
 #   build-artifact-profiler:
 #     uses: ./.github/workflows/build-artifact.yaml
 #     with:
@@ -43,13 +49,13 @@ jobs:
       arch: blackhole
       runner-label: BH
       timeout: 30
-  # fd-unit-tests:
-  #   needs: build-artifact
-  #   uses: ./.github/workflows/fast-dispatch-build-and-unit-tests.yaml
-  #   secrets: inherit
-  #   with:
-  #     arch: blackhole
-  #     runner-label: BH
+  fd-unit-tests:
+    needs: build-wheels
+    uses: ./.github/workflows/fast-dispatch-build-and-unit-tests.yaml
+    secrets: inherit
+    with:
+      arch: blackhole
+      runner-label: BH
   # FD C++ Unit Tests
   cpp-unit-tests:
     needs: build-artifact

--- a/.github/workflows/blackhole-post-commit.yaml
+++ b/.github/workflows/blackhole-post-commit.yaml
@@ -25,6 +25,7 @@ jobs:
     with:
       arch: '["blackhole"]'
   build-wheels:
+    needs: build-artifact
     uses: ./.github/workflows/_build-wheels-impl.yaml
     with:
       os: "ubuntu-20.04"


### PR DESCRIPTION
### Ticket
#12611 

### Problem description

The Fast Dispatch workflow tests are run inside of the Docker and using the built wheel.

### What's changed
The Blackhole workflow also needed the step to build the wheels before calling the Fast Dispatch tests.

### Checklist
- [x] Post commit CI passes
- [ ] Blackhole Post commit (if applicable)
- [ ] Model regression CI testing passes (if applicable)
- [ ] Device performance regression CI testing passes (if applicable)
- [ ] New/Existing tests provide coverage for changes
