### PR TITLE
Distributed Sharded Layernorm/RMSNorm

### DIFF
--- a/tests/ttnn/unit_tests/operations/test_distributed_layernorm_sharded.py
+++ b/tests/ttnn/unit_tests/operations/test_distributed_layernorm_sharded.py
@@ -223,3 +223,181 @@ def test_pre_allgather_layernorm(
             all_close_passing = torch.equal(prev_tt_output_torch, tt_output_torch)
             assert all_close_passing, f"Output is non-deterministic!"
         prev_tt_output_torch = tt_output_torch
+
+
+@pytest.mark.parametrize("is_rmsnorm", [True])  # Layernorm not supported for now
+@pytest.mark.parametrize("seed", [0, 1234])  # Test across 5 different seeds
+@pytest.mark.parametrize("eps", [1e-6])
+@pytest.mark.parametrize("min_pcc", [0.9997])
+@pytest.mark.parametrize("max_atol", [0.38])
+@pytest.mark.parametrize("input_width", [2048])
+@pytest.mark.parametrize("num_devices", [4])
+@pytest.mark.parametrize(
+    "input_df",
+    [ttnn.bfloat8_b, ttnn.bfloat16],
+)
+@pytest.mark.parametrize(
+    "weights_df",
+    [ttnn.bfloat8_b, ttnn.bfloat16],
+)
+@pytest.mark.parametrize(("mean", "std"), ([0, 1],))
+@pytest.mark.parametrize("core_grid", ((8, 8),))
+def test_post_allgather_layernorm(
+    all_devices,
+    input_width,
+    num_devices,
+    is_rmsnorm,
+    input_df,
+    weights_df,
+    seed,
+    eps,
+    mean,
+    std,
+    min_pcc,
+    max_atol,
+    core_grid,
+):
+    device = all_devices[0]
+
+    if is_rmsnorm:
+        print("Testing RMSNorm")
+    else:
+        print("Testing LayerNorm")
+    torch.manual_seed(seed)
+    input_shape = (1, 1, 32, input_width * num_devices)
+    weights_shape = (1, 1, 1, input_width * num_devices)
+
+    torch_input_tensor = torch.normal(mean, std, size=input_shape, dtype=torch.bfloat16)
+    torch_weight = torch.normal(mean, std, size=weights_shape, dtype=torch.bfloat16)
+
+    torch_input_tensors = torch.chunk(torch_input_tensor, num_devices, dim=-1)
+    torch_weights = torch.chunk(torch_weight, num_devices, dim=-1)
+
+    # torch_input_tensor = torch.ones(input_shape, dtype=torch.bfloat16) * 2
+    # torch_weight = torch.ones(weights_shape, dtype=torch.bfloat16)
+
+    print(f" Mean : {torch_input_tensor.mean()}, Var : {torch_input_tensor.var()}")
+
+    if is_rmsnorm:
+        torch_output_tensor = rms_norm(torch_input_tensor, torch_weight, eps=eps)
+    else:
+        torch_output_tensor = torch.nn.functional.layer_norm(
+            torch_input_tensor, (input_width,), weight=torch_weight.squeeze(0).squeeze(0).squeeze(0), eps=eps
+        )
+
+    torch_output_tensor_chunks = torch.chunk(torch_output_tensor, num_devices, dim=-1)
+    torch_output_tensor = torch_output_tensor_chunks[0]
+
+    tt_input_tensor = ttnn.from_torch(
+        torch_input_tensors[0],
+        layout=ttnn.TILE_LAYOUT,
+        device=device,
+        memory_config=ttnn.L1_MEMORY_CONFIG,
+        dtype=input_df,
+    )
+
+    # shard to 32 cores
+    tt_sharded_config = ttnn.create_sharded_memory_config(
+        shape=(1, 1, 32, input_width),
+        core_grid=ttnn.CoreGrid(y=core_grid[0], x=core_grid[1]),
+        strategy=ttnn.ShardStrategy.WIDTH,
+    )
+    tt_input_tensor = ttnn.to_memory_config(tt_input_tensor, memory_config=tt_sharded_config)
+
+    SHARDED_NORM_PRGM_CFG = ttnn.LayerNormShardedMultiCoreProgramConfig(
+        compute_with_storage_grid_size=(core_grid[1], core_grid[0]),
+        subblock_w=(input_width // (core_grid[0] * core_grid[1])) // 32,
+        block_h=1,
+        block_w=(input_width // (core_grid[0] * core_grid[1])) // 32,
+        inplace=False,
+    )
+
+    tt_weights = ttnn.as_tensor(
+        torch_weights[0],
+        device=device,
+        layout=ttnn.TILE_LAYOUT,
+        memory_config=ttnn.DRAM_MEMORY_CONFIG,
+        dtype=weights_df,
+    )
+
+    # create E[x] and E[x^2] tensors
+    Ex_tensors = []
+    for d in range(num_devices):
+        Ex = torch.mean(torch_input_tensors[d], dim=-1, keepdim=True).to(torch.bfloat16)
+        Ex = torch.nn.functional.pad(Ex, (0, 31), "constant", 0)
+        Ex_tensors.append(Ex)
+
+    Ex2_tensors = []
+    for d in range(num_devices):
+        Ex2 = torch.mean(torch_input_tensors[d] ** 2, dim=-1, keepdim=True).to(torch.bfloat16)
+        Ex2 = torch.nn.functional.pad(Ex2, (0, 31), "constant", 0)
+        Ex2_tensors.append(Ex2)
+
+    if not is_rmsnorm:
+        for d in range(num_devices):
+            Ex_tensors[d] = ttnn.from_torch(
+                Ex_tensors[d],
+                layout=ttnn.TILE_LAYOUT,
+                device=device,
+                memory_config=ttnn.L1_MEMORY_CONFIG,
+            )
+
+    for d in range(num_devices):
+        Ex2_tensors[d] = ttnn.from_torch(
+            Ex2_tensors[d],
+            layout=ttnn.TILE_LAYOUT,
+            device=device,
+            memory_config=ttnn.L1_MEMORY_CONFIG,
+        )
+    if is_rmsnorm:
+        tt_stats_tensor = ttnn.concat(Ex2_tensors, -1)
+    else:
+        tt_stats_tensor = ttnn.concat([tt_tensor for pair in zip(Ex_tensors, Ex2_tensors) for tt_tensor in pair], -1)
+
+    # shard to 1 core
+    tt_stats_sharded_config = ttnn.create_sharded_memory_config(
+        shape=(1, 1, 32, tt_stats_tensor.get_legacy_shape()[-1]),
+        core_grid=ttnn.CoreGrid(y=1, x=1),
+        strategy=ttnn.ShardStrategy.WIDTH,
+    )
+    tt_stats_tensor = ttnn.to_memory_config(tt_stats_tensor, memory_config=tt_stats_sharded_config)
+
+    iterations = 1
+    prev_tt_output_torch = None
+    for iter in range(iterations):
+        if is_rmsnorm:
+            tt_output_tensor = ttnn.rms_norm_post_all_gather(
+                tt_input_tensor,
+                epsilon=eps,
+                weight=tt_weights,
+                program_config=SHARDED_NORM_PRGM_CFG,
+                memory_config=tt_sharded_config,
+                stats=tt_stats_tensor,
+            )
+        else:
+            tt_output_tensor = ttnn.layer_norm_post_all_gather(
+                tt_input_tensor,
+                epsilon=eps,
+                weight=tt_weights,
+                program_config=SHARDED_NORM_PRGM_CFG,
+                memory_config=tt_sharded_config,
+                stats=tt_stats_tensor,
+            )
+        tt_output_torch = ttnn.to_torch(tt_output_tensor).to(torch.bfloat16)
+        if iter == 0:
+            _, pcc_out = comp_pcc(torch_output_tensor, tt_output_torch, pcc=min_pcc)
+            all_close_passing = torch.allclose(torch_output_tensor, tt_output_torch, atol=max_atol, equal_nan=False)
+            atol_delta = torch.max(torch.abs(torch_output_tensor - tt_output_torch)).item()
+            print("torch_output_tensor", torch_output_tensor)
+            print("tt_output_torch", tt_output_torch)
+            print(f"PCC: {pcc_out}")
+            print(f"all_close : {all_close_passing}, Max ATOL: {atol_delta}")
+            assert pcc_out >= min_pcc, f"PCC test failed: {pcc_out} (threshold: {min_pcc})"
+            assert atol_delta <= max_atol, f"Max Atol exceeded: {atol_delta} (allowed: {max_atol})"
+
+        else:
+            all_close_passing = torch.allclose(prev_tt_output_torch, tt_output_torch, atol=0, equal_nan=False)
+            atol_delta = torch.max(torch.abs(prev_tt_output_torch - tt_output_torch)).item()
+            print(f"all_close_previous : {all_close_passing}, Max ATOL: {atol_delta}")
+            assert all_close_passing, f"Max Atol exceeded for previous : {atol_delta} (allowed: {0})"
+        prev_tt_output_torch = tt_output_torch

--- a/tests/ttnn/unit_tests/operations/test_distributed_layernorm_sharded.py
+++ b/tests/ttnn/unit_tests/operations/test_distributed_layernorm_sharded.py
@@ -133,7 +133,7 @@ def compute_reference_output(torch_input_tensor, torch_weight, is_rmsnorm, eps):
 @pytest.mark.parametrize(("min_pcc_ex", "max_atol_ex"), [(0.9997, 0.01)])
 @pytest.mark.parametrize(("min_pcc_ex2", "max_atol_ex2"), [(0.987, 0.04)])
 def test_pre_allgather_layernorm(
-    all_devices,
+    device,
     use_program_cache,
     input_width,
     num_devices,
@@ -148,8 +148,6 @@ def test_pre_allgather_layernorm(
     min_pcc_ex2,
     max_atol_ex2,
 ):
-    device = all_devices[0]
-
     torch_input_tensor, _, torch_input_chunks, _ = create_input_and_weight_tensors(
         input_width, num_devices, seed, mean, std
     )
@@ -201,7 +199,7 @@ def test_pre_allgather_layernorm(
 @pytest.mark.parametrize(("mean", "std"), ([0, 1],))
 @pytest.mark.parametrize("core_grid", ((4, 8),))
 def test_post_allgather_layernorm(
-    all_devices,
+    device,
     use_program_cache,
     input_width,
     num_devices,
@@ -216,8 +214,6 @@ def test_post_allgather_layernorm(
     max_atol,
     core_grid,
 ):
-    device = all_devices[0]
-
     torch_input_tensor, torch_weight, torch_input_chunks, torch_weight_chunks = create_input_and_weight_tensors(
         input_width, num_devices, seed, mean, std
     )
@@ -285,7 +281,7 @@ def test_post_allgather_layernorm(
 @pytest.mark.parametrize(("mean", "std"), ([0, 1],))
 @pytest.mark.parametrize("core_grid", ((4, 8),))
 def test_simulated_distributed_layernorm(
-    all_devices,
+    device,
     use_program_cache,
     input_width,
     num_devices,
@@ -300,8 +296,6 @@ def test_simulated_distributed_layernorm(
     max_atol,
     core_grid,
 ):
-    device = all_devices[0]
-
     # Create input and weight tensors
     torch_input_tensor, torch_weight, torch_input_chunks, torch_weight_chunks = create_input_and_weight_tensors(
         input_width, num_devices, seed, mean, std

--- a/tests/ttnn/unit_tests/operations/test_distributed_layernorm_sharded.py
+++ b/tests/ttnn/unit_tests/operations/test_distributed_layernorm_sharded.py
@@ -188,7 +188,6 @@ def run_pre_allgather_layernorm(
     "input_width, core_grid",
     [
         ([2048, (4, 8)]),
-        ([2048, (8, 8)]),
     ],
 )
 @pytest.mark.parametrize("input_df", [ttnn.bfloat8_b, ttnn.bfloat16])
@@ -372,10 +371,7 @@ def run_post_allgather_layernorm(
 @pytest.mark.parametrize(("mean", "std"), ([0, 1],))
 @pytest.mark.parametrize(
     "core_grid",
-    (
-        (4, 8),
-        (8, 8),
-    ),
+    ((4, 8),),
 )
 def test_post_allgather_layernorm(
     all_devices,

--- a/tests/ttnn/unit_tests/operations/test_distributed_layernorm_sharded.py
+++ b/tests/ttnn/unit_tests/operations/test_distributed_layernorm_sharded.py
@@ -15,9 +15,6 @@ from models.utility_functions import (
 
 from models.utility_functions import tt2torch_tensor, get_devices_for_t3000, skip_for_grayskull
 
-# create test for layer_norm for sharded input tensor [32, 2048]  and weight and bias tensors [2048]
-# sharded on 32 cores
-
 
 def rms_norm(x, gamma, eps):
     return x * torch.rsqrt(x.pow(2).mean(-1, keepdim=True) + eps) * gamma
@@ -27,6 +24,7 @@ def layer_norm(x, gamma, eps):
     return (x - x.mean(-1, keepdim=True)) * torch.rsqrt(x.var(-1, keepdim=True) + eps) * gamma
 
 
+@skip_for_grayskull()
 @pytest.mark.parametrize("is_rmsnorm", [True, False])
 @pytest.mark.parametrize("seed", [0, 2000, 50000])  # Test across 5 different seeds
 @pytest.mark.parametrize("eps", [1e-6])
@@ -181,6 +179,7 @@ def run_pre_allgather_layernorm(
         assert pcc_out2 >= min_pcc_Ex2, f"PCC of E(x^2) test failed: {pcc_out2} (threshold: {min_pcc_Ex2})"
 
 
+@skip_for_grayskull()
 @pytest.mark.parametrize("is_rmsnorm", [True, False])
 @pytest.mark.parametrize("seed", [0, 1234])
 @pytest.mark.parametrize(("min_pcc_Ex", "min_pcc_Ex2"), ([0.9997, 0.989],))
@@ -354,6 +353,7 @@ def run_post_allgather_layernorm(
         assert atol_delta <= max_atol, f"Max Atol exceeded: {atol_delta} (allowed: {max_atol})"
 
 
+@skip_for_grayskull()
 @pytest.mark.parametrize("is_rmsnorm", [True, False])  # Layernorm not supported for now
 @pytest.mark.parametrize("seed", [0, 1234])  # Test across 5 different seeds
 @pytest.mark.parametrize("eps", [1e-6])
@@ -412,6 +412,7 @@ def test_post_allgather_layernorm(
     )
 
 
+@skip_for_grayskull()
 @pytest.mark.parametrize("is_rmsnorm", [True, False])  # Layernorm not supported for now
 @pytest.mark.parametrize("seed", [0])  # Test across 5 different seeds
 @pytest.mark.parametrize("eps", [1e-6])

--- a/tests/ttnn/unit_tests/operations/test_distributed_layernorm_sharded.py
+++ b/tests/ttnn/unit_tests/operations/test_distributed_layernorm_sharded.py
@@ -1,0 +1,225 @@
+# SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
+
+# SPDX-License-Identifier: Apache-2.0
+import ttnn
+import torch
+import pytest
+from loguru import logger
+
+from models.utility_functions import (
+    skip_for_wormhole_b0,
+    comp_allclose_and_pcc,
+    comp_pcc,
+    comp_allclose,
+)
+
+from models.utility_functions import tt2torch_tensor, get_devices_for_t3000, skip_for_grayskull
+
+# create test for layer_norm for sharded input tensor [32, 2048]  and weight and bias tensors [2048]
+# sharded on 32 cores
+
+
+def rms_norm(x, gamma, eps):
+    return x * torch.rsqrt(x.pow(2).mean(-1, keepdim=True) + eps) * gamma
+
+
+def layer_norm(x, gamma, eps):
+    return (x - x.mean(-1, keepdim=True)) * torch.rsqrt(x.var(-1, keepdim=True) + eps) * gamma
+
+
+@pytest.mark.parametrize("is_rmsnorm", [True, False])
+@pytest.mark.parametrize("seed", [0, 2000, 50000])  # Test across 5 different seeds
+@pytest.mark.parametrize("eps", [1e-6])
+@pytest.mark.parametrize("min_pcc", [0.9997])
+@pytest.mark.parametrize("max_atol", [0.38])
+@pytest.mark.parametrize("input_width", [1024, 2048])
+@pytest.mark.parametrize("input_df", [ttnn.bfloat8_b, ttnn.bfloat16])
+@pytest.mark.parametrize("weights_df", [ttnn.bfloat8_b, ttnn.bfloat16])
+@pytest.mark.parametrize(("mean", "std"), ([0, 1], [10.0, 11.0], [100.0, 110.0]))
+def test_sharded_layernorm(
+    device, use_program_cache, input_width, is_rmsnorm, input_df, weights_df, seed, eps, mean, std, min_pcc, max_atol
+):
+    if is_rmsnorm:
+        print("Testing RMSNorm")
+    else:
+        print("Testing LayerNorm")
+    torch.manual_seed(seed)
+    input_shape = (1, 1, 32, input_width)
+    weights_shape = (1, 1, 1, input_width)
+
+    torch_input_tensor = torch.normal(mean, std, size=input_shape, dtype=torch.bfloat16)
+    torch_weight = torch.normal(mean, std, size=weights_shape, dtype=torch.bfloat16)
+
+    print(f" Mean : {torch_input_tensor.mean()}, Var : {torch_input_tensor.var()}")
+
+    if is_rmsnorm:
+        torch_output_tensor = rms_norm(torch_input_tensor, torch_weight, eps=eps)
+    else:
+        torch_output_tensor = torch.nn.functional.layer_norm(
+            torch_input_tensor, (input_width,), weight=torch_weight.squeeze(0).squeeze(0).squeeze(0), eps=eps
+        )
+        # torch_output_tensor = layer_norm(torch_input_tensor, torch_weight, eps=eps)
+
+    tt_input_tensor = ttnn.from_torch(
+        torch_input_tensor,
+        layout=ttnn.TILE_LAYOUT,
+        device=device,
+        memory_config=ttnn.L1_MEMORY_CONFIG,
+        dtype=input_df,
+    )
+    # shard to 32 cores
+    tt_sharded_config = ttnn.create_sharded_memory_config(
+        shape=(1, 1, 32, input_width),
+        core_grid=ttnn.CoreGrid(y=2, x=8),
+        strategy=ttnn.ShardStrategy.WIDTH,
+    )
+    tt_input_tensor = ttnn.to_memory_config(tt_input_tensor, memory_config=tt_sharded_config)
+
+    SHARDED_NORM_PRGM_CFG = ttnn.LayerNormShardedMultiCoreProgramConfig(
+        compute_with_storage_grid_size=[8, 2],
+        subblock_w=(input_width // 16) // 32,
+        block_h=1,
+        block_w=(input_width // 16) // 32,
+        inplace=False,
+    )
+
+    tt_weights = ttnn.as_tensor(
+        torch_weight,
+        device=device,
+        layout=ttnn.TILE_LAYOUT,
+        memory_config=ttnn.DRAM_MEMORY_CONFIG,
+        dtype=weights_df,
+        # cache_file_name="rms_weights_cache_1024",
+    )
+
+    if is_rmsnorm:
+        tt_output_tensor = ttnn.rms_norm(
+            tt_input_tensor,
+            epsilon=eps,
+            weight=tt_weights,
+            program_config=SHARDED_NORM_PRGM_CFG,
+            memory_config=tt_sharded_config,
+        )
+    else:
+        tt_output_tensor = ttnn.layer_norm(
+            tt_input_tensor,
+            epsilon=eps,
+            weight=tt_weights,
+            program_config=SHARDED_NORM_PRGM_CFG,
+            memory_config=tt_sharded_config,
+        )
+    tt_output_torch = ttnn.to_torch(tt_output_tensor).to(torch.bfloat16)
+
+    pcc_passing, pcc_out = comp_pcc(torch_output_tensor, tt_output_torch, pcc=min_pcc)
+    all_close_passing = torch.allclose(torch_output_tensor, tt_output_torch, atol=max_atol, equal_nan=False)
+    atol_delta = torch.max(torch.abs(torch_output_tensor - tt_output_torch)).item()
+    print(f"PCC: {pcc_out}")
+    print(f"all_close : {all_close_passing}, Max ATOL: {atol_delta}")
+
+    assert pcc_out >= min_pcc, f"PCC test failed: {pcc_out} (threshold: {min_pcc})"
+    # assert atol_delta <= max_atol, f"Max Atol exceeded: {atol_delta} (allowed: {max_atol})"
+
+
+@pytest.mark.parametrize("is_rmsnorm", [True, False])
+@pytest.mark.parametrize("seed", [1234])
+@pytest.mark.parametrize(("min_pcc_Ex", "min_pcc_Ex2"), ([0.9997, 0.989],))
+@pytest.mark.parametrize("max_atol", [0.38])
+@pytest.mark.parametrize(
+    "input_width, core_grid",
+    [
+        ([1024, (2, 8)]),
+        ([2048, (8, 8)]),
+    ],
+)
+@pytest.mark.parametrize("input_df", [ttnn.bfloat8_b, ttnn.bfloat16])
+@pytest.mark.parametrize(("mean", "std"), ([0, 1],))
+def test_pre_allgather_layernorm(
+    all_devices,
+    use_program_cache,
+    input_width,
+    core_grid,
+    is_rmsnorm,
+    input_df,
+    seed,
+    mean,
+    std,
+    min_pcc_Ex,
+    min_pcc_Ex2,
+    max_atol,
+):
+    device = all_devices[0]
+
+    if is_rmsnorm:
+        print("RMSNorm")
+    else:
+        print("LayerNorm")
+
+    torch.manual_seed(seed)
+    input_shape = (1, 1, 32, input_width)
+
+    torch_input_tensor = torch.normal(mean, std, size=input_shape, dtype=torch.bfloat16)
+
+    print(f" Mean : {torch_input_tensor.mean()}, Var : {torch_input_tensor.var()}")
+
+    tt_input_tensor = ttnn.from_torch(
+        torch_input_tensor,
+        layout=ttnn.TILE_LAYOUT,
+        device=device,
+        memory_config=ttnn.L1_MEMORY_CONFIG,
+        dtype=input_df,
+    )
+    # shard to 32 cores
+    tt_sharded_config = ttnn.create_sharded_memory_config(
+        shape=(1, 1, 32, input_width),
+        core_grid=ttnn.CoreGrid(y=core_grid[0], x=core_grid[1]),
+        strategy=ttnn.ShardStrategy.WIDTH,
+    )
+    tt_input_tensor = ttnn.to_memory_config(tt_input_tensor, memory_config=tt_sharded_config)
+
+    SHARDED_NORM_PRGM_CFG = ttnn.LayerNormShardedMultiCoreProgramConfig(
+        compute_with_storage_grid_size=[core_grid[1], core_grid[0]],
+        subblock_w=(input_width // (core_grid[0] * core_grid[1])) // 32,
+        block_h=1,
+        block_w=(input_width // (core_grid[0] * core_grid[1])) // 32,
+        inplace=False,
+    )
+
+    # create E(x) and E(x^2) tensors
+    Ex_tensor = torch.mean(torch_input_tensor, dim=-1, keepdim=True).to(torch.bfloat16)  # [1, 1, 32, 1]
+
+    Ex2_tensor = torch.mean(torch_input_tensor**2, dim=-1, keepdim=True).to(torch.bfloat16)  # [1, 1, 32, 1]
+
+    iterations = 10
+    prev_tt_output_torch = None
+    for iter in range(iterations):
+        if is_rmsnorm:
+            tt_output_tensor = ttnn.rms_norm_pre_all_gather(tt_input_tensor, program_config=SHARDED_NORM_PRGM_CFG)
+        else:
+            tt_output_tensor = ttnn.layer_norm_pre_all_gather(tt_input_tensor, program_config=SHARDED_NORM_PRGM_CFG)
+        tt_output_torch = ttnn.to_torch(tt_output_tensor).to(torch.bfloat16)  # [1, 1, 32, 64]
+
+        if is_rmsnorm:  # first tile contains E(xˆ2) in first column
+            tt_ex2_torch = tt_output_torch[..., :1]
+        else:  # first tile contains E(x) in first column (=index 0) and second tile contains E(xˆ2) in first column (=index 32)
+            tt_ex_torch = tt_output_torch[..., :1]
+            tt_ex2_torch = tt_output_torch[..., 32:33]
+
+        if iter == 0:
+            if not is_rmsnorm:
+                _, pcc_out1 = comp_pcc(Ex_tensor, tt_ex_torch, pcc=min_pcc_Ex)
+                all_close_passing = torch.allclose(Ex_tensor, tt_ex_torch, atol=max_atol, equal_nan=False)
+                atol_delta = torch.max(torch.abs(Ex_tensor - tt_ex_torch)).item()
+                print(f"PCC: {pcc_out1}")
+                print(f"all_close : {all_close_passing}, Max ATOL: {atol_delta}")
+                assert pcc_out1 >= min_pcc_Ex, f"PCC of E(x) test failed: {pcc_out1} (threshold: {min_pcc_Ex})"
+
+            _, pcc_out2 = comp_pcc(Ex2_tensor, tt_ex2_torch, pcc=min_pcc_Ex2)
+            all_close_passing = torch.allclose(Ex2_tensor, tt_ex2_torch, atol=max_atol, equal_nan=False)
+            atol_delta = torch.max(torch.abs(Ex2_tensor - tt_ex2_torch)).item()
+            print(f"PCC: {pcc_out2}")
+            print(f"all_close : {all_close_passing}, Max ATOL: {atol_delta}")
+            assert pcc_out2 >= min_pcc_Ex2, f"PCC of E(x^2) test failed: {pcc_out2} (threshold: {min_pcc_Ex2})"
+        else:
+            all_close_passing = torch.equal(prev_tt_output_torch, tt_output_torch)
+            assert all_close_passing, f"Output is non-deterministic!"
+        prev_tt_output_torch = tt_output_torch

--- a/ttnn/cpp/ttnn/operations/normalization/layernorm/device/kernels/compute/layernorm_sharded_post_allgather.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/layernorm/device/kernels/compute/layernorm_sharded_post_allgather.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+// SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/ttnn/cpp/ttnn/operations/normalization/layernorm/device/kernels/compute/layernorm_sharded_post_allgather.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/layernorm/device/kernels/compute/layernorm_sharded_post_allgather.cpp
@@ -59,7 +59,6 @@ void MAIN {
 
     constexpr uint32_t cb_in0 = tt::CB::c_in0;
     constexpr uint32_t cb_in1 = tt::CB::c_in1;
-    constexpr uint32_t cb_scaler = tt::CB::c_in2;
     constexpr uint32_t cb_eps = tt::CB::c_in3;
     constexpr uint32_t cb_scaler_global = tt::CB::c_in4;
     constexpr uint32_t cb_gamma = tt::CB::c_in5;
@@ -70,7 +69,6 @@ void MAIN {
     constexpr uint32_t cb_stats = tt::CB::c_in7; // E[(x-E[x])^2] global reduce
     constexpr uint32_t cb_stats_reduced = tt::CB::c_intermed4; // E[(x-E[x])^2] global reduce
     constexpr uint32_t cb_ex_global = tt::CB::dataflow7; // E[x] global reduce
-    constexpr uint32_t cb_ex2_global = tt::CB::dataflow6; // E[x^2] global reduce
     constexpr uint32_t cb_reciprocal = tt::CB::c_intermed3; // [E[x^2]-E[x]^2]+eps
     constexpr uint32_t cb_fusion = tt::CB::c_intermed1; // stream gamma/beta
     constexpr uint32_t cb_out = tt::CB::c_out0;

--- a/ttnn/cpp/ttnn/operations/normalization/layernorm/device/kernels/compute/layernorm_sharded_post_allgather.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/layernorm/device/kernels/compute/layernorm_sharded_post_allgather.cpp
@@ -112,8 +112,9 @@ void MAIN {
             cb_wait_front(cb_scaler_global, 1);
             reduce_init_delta<false>();
             tile_regs_acquire();
-            for (uint32_t w = 0; w < stats_tiles*num_distributed_blocks; w++) { // Need to read this interleaved now, we have SUM(X) and SUM(X^2) interleaved
-                reduce_tile(cb_stats, cb_scaler_global, 0, scaler0, w % stats_tiles); // E(x) and E(x^2) interleaved so we reduce each one into different dest reg
+            // striding over cb_stats, consisting [E(X), E(X^2)] from all the distributed devices in interleaved order
+            for (uint32_t w = 0; w < stats_tiles*num_distributed_blocks; w++) {
+                reduce_tile(cb_stats, cb_scaler_global, 0, scaler0, w % stats_tiles); // reducing E(x) and E(x^2) separately to different dst
                 cb_pop_front(cb_stats, 1);
             }
             tile_regs_commit();

--- a/ttnn/cpp/ttnn/operations/normalization/layernorm/device/kernels/compute/layernorm_sharded_post_allgather.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/layernorm/device/kernels/compute/layernorm_sharded_post_allgather.cpp
@@ -1,0 +1,343 @@
+// SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#define REDUCE_OP PoolType::SUM
+#define REDUCE_DIM ReduceDim::REDUCE_ROW
+
+#define BCAST_LLKOP EltwiseBinaryType::ELWMUL
+#define BCAST_DIM BroadcastType::COL
+
+#include "compute_kernel_api/reduce.h"
+#include "compute_kernel_api/bcast.h"
+#include "compute_kernel_api/eltwise_binary.h"
+#include "compute_kernel_api/layernorm.h"
+#include "compute_kernel_api/tile_move_copy.h"
+#include "debug/dprint.h"
+
+// SPLIT REDUCE across Cores
+namespace NAMESPACE {
+void MAIN {
+
+    constexpr uint32_t is_top_row                     = get_compile_time_arg_val(0);
+    constexpr uint32_t do_gamma                       = get_compile_time_arg_val(1);
+    constexpr uint32_t do_beta                        = get_compile_time_arg_val(2);
+    constexpr uint32_t num_blocks_first_stage         = get_compile_time_arg_val(3);
+    constexpr uint32_t block_w                        = get_compile_time_arg_val(5);
+    constexpr uint32_t block_h_const                  = get_compile_time_arg_val(4);
+    volatile uint32_t block_h_volatile                = get_compile_time_arg_val(4);
+    constexpr uint32_t subblock_w_const               = get_compile_time_arg_val(6);
+    volatile uint32_t subblock_w_volatile             = get_compile_time_arg_val(6);
+    constexpr uint32_t num_subblocks_w                = get_compile_time_arg_val(7);
+    const bool is_allgather_worker                    = get_compile_time_arg_val(8) == 1;
+    constexpr uint32_t num_tiles_per_block            = get_compile_time_arg_val(9);
+    constexpr bool FLOAT32_DTYPE                      = get_compile_time_arg_val(10) == 1;
+    constexpr uint32_t num_blocks_second_stage        = get_compile_time_arg_val(11);
+
+    const uint32_t num_reduce_tiles_per_block_h             = get_arg_val<uint32_t>(0); // This value is the same for all cores, except ones that have padding tiles in it. In that case, skip reduce for padding tiles.
+    const uint32_t num_tiles_per_allgather_worker           = is_allgather_worker ? get_arg_val<uint32_t>(1) : 0;
+    const bool use_two_stage_reduce                         = is_allgather_worker ? get_arg_val<uint32_t>(2) == 1 : false;
+    const bool is_second_stage_reader                       = is_allgather_worker ? get_arg_val<uint32_t>(3) == 1 : false;
+
+    uint32_t num_blocks_reduce;
+    if (is_second_stage_reader) {
+        num_blocks_reduce = num_blocks_first_stage + num_blocks_second_stage - 1;
+    } else {
+        num_blocks_reduce = num_blocks_first_stage;
+    }
+
+    bool enable_sqrt;
+    if (use_two_stage_reduce and not is_second_stage_reader) {
+        enable_sqrt = false;
+    } else {
+        enable_sqrt = true;
+    }
+
+    constexpr uint32_t dst0 = 0;
+    constexpr uint32_t scaler0 = 0;
+
+    constexpr uint32_t cb_in0 = tt::CB::c_in0;
+    constexpr uint32_t cb_in1 = tt::CB::c_in1;
+    constexpr uint32_t cb_scaler = tt::CB::c_in2;
+    constexpr uint32_t cb_eps = tt::CB::c_in3;
+    constexpr uint32_t cb_scaler_global = tt::CB::c_in4;
+    constexpr uint32_t cb_gamma = tt::CB::c_in5;
+    constexpr uint32_t cb_beta = tt::CB::c_in6;
+    constexpr uint32_t cb_x = tt::CB::c_intermed0; // x minus mean
+    #if defined RMSNORM
+    constexpr uint32_t cb_xmm = cb_in0; // x minus mean
+    #else
+    constexpr uint32_t cb_xmm = tt::CB::c_intermed1; // x minus mean
+    #endif
+    constexpr uint32_t cb_ex_partial = tt::CB::dataflow0; // E[x] partial reduce
+    constexpr uint32_t cb_ex = tt::CB::dataflow1; // E[x] global reduce
+    constexpr uint32_t cb_ex_external = tt::CB::dataflow2; // E[x] partials recieved from other cores
+    constexpr uint32_t cb_ex_partial2 = tt::CB::dataflow3; // E[x^2] partial reduce
+    constexpr uint32_t cb_stats = tt::CB::c_in7; // E[(x-E[x])^2] global reduce
+    constexpr uint32_t cb_stats2 = tt::CB::c_intermed4; // E[(x-E[x])^2] global reduce
+    constexpr uint32_t cb_ex_external2 = tt::CB::dataflow5; // E[x^2] partials recieved from other cores
+    constexpr uint32_t cb_ex_global = tt::CB::dataflow7; // E[x] global reduce
+    constexpr uint32_t cb_ex2_global = tt::CB::dataflow6; // E[x^2] global reduce
+    constexpr uint32_t cb_x2 = cb_x; // x^2
+    constexpr uint32_t cb_reciprocal = tt::CB::c_intermed3; // [E[x^2]-E[x]^2]+eps
+    constexpr uint32_t cb_fusion = tt::CB::c_intermed1; // stream gamma/beta
+    constexpr uint32_t cb_out = tt::CB::c_out0;
+    constexpr uint32_t cb_ex_sqr = cb_x2;
+
+    #ifdef RMSNORM
+    constexpr uint32_t cb_var = cb_stats;
+    constexpr uint32_t stats_tiles = 1;
+    binary_op_init_common(cb_var, cb_eps, cb_stats2);
+    #else
+    constexpr uint32_t cb_var = tt::CB::c_intermed2; // Var(x)
+    constexpr uint32_t stats_tiles = 2;
+    binary_op_init_common(cb_stats, cb_stats, cb_ex_sqr);
+    #endif
+
+    // set block_h to volatile to disable automatically unroll of the loops, avoid code overflow
+    const uint32_t block_h = (block_w == 1) ? block_h_volatile : block_h_const;
+    const uint32_t subblock_w = (block_w <= 2) ? subblock_w_volatile : subblock_w_const;
+
+    int index_subblock_w_offset = 0;
+    int index_h_offset = 0;
+    int index = 0;
+
+    constexpr uint32_t cb_im = (do_gamma | do_beta) ? cb_x : cb_out;
+    constexpr uint32_t cb_outgamma = do_beta ? cb_fusion : cb_out;
+
+
+
+    // global reduce, cb_ex <-- cb_ex_external, cb_ex_partial
+    if constexpr(is_allgather_worker) {
+        cb_reserve_back(cb_stats2, stats_tiles);
+        if (enable_sqrt) {
+            #ifndef RMSNORM
+            //copy E(x) to cb_stats2
+
+            tile_regs_acquire();
+            copy_tile_to_dst_init_short();
+            copy_tile(cb_stats, 0, dst0);
+            tile_regs_commit();
+            tile_regs_wait();
+            pack_tile(dst0, cb_stats2);
+            //cb_push_back(cb_stats2, 1);
+            tile_regs_release();
+            // cb_pop_front(cb_stats, 1);
+
+            // calculate var = E(x^2) - E(x)^2
+            // E(x)^2
+            // unpack_reconfig_data_format(cb_stats, cb_stats);
+            cb_reserve_back(cb_ex_sqr, 1);
+            tile_regs_acquire();
+            mul_tiles_init();
+            mul_tiles(cb_stats, cb_stats, 0, 0, dst0);  // first tile in stats is always E(x)
+            tile_regs_commit();
+            tile_regs_wait();
+            pack_tile(dst0, cb_ex_sqr);
+            cb_push_back(cb_ex_sqr, 1);
+            tile_regs_release();
+
+
+            // E(x^2) - E(x)^2
+            unpack_reconfig_data_format_srcb(cb_stats, cb_ex_sqr);
+            pack_reconfig_data_format(cb_var);
+            cb_wait_front(cb_ex_sqr, 1);
+            cb_reserve_back(cb_var, 1);
+            tile_regs_acquire();
+            sub_tiles_init();
+            sub_tiles(cb_stats, cb_ex_sqr, 1, 0, dst0);
+            tile_regs_commit();
+            tile_regs_wait();
+            pack_tile(dst0, cb_var);
+            cb_push_back(cb_var, 1);
+            tile_regs_release();
+            // UNPACK(DPRINT << " cb_var : "<<TSLICE(cb_var, 0, SliceRange::h0_w0_32()) << ENDL());
+            cb_pop_front(cb_ex_sqr, 1);
+            #endif
+
+
+            // 1/[sqrt(Var + eps)],
+            unpack_reconfig_data_format(cb_var, cb_eps);    // cb_var is cb_stats in case of RMS norm
+            pack_reconfig_data_format(cb_stats2);
+            #ifndef RMSNORM
+            cb_wait_front(cb_var, 1);
+            #endif
+            cb_wait_front(cb_eps, 1);
+
+            // UNPACK(DPRINT << "cb_var : "<<TSLICE(cb_var, 0, SliceRange::h0_w0_32()) << ENDL());
+            // UNPACK(DPRINT << "cb_eps : "<<TSLICE(cb_eps, 0, SliceRange::h0_w0_32()) << ENDL());
+            //cb_reserve_back(cb_stats2, 1);
+            add_tiles_init();
+            tile_regs_acquire();
+            add_tiles(cb_var, cb_eps, 0, 0, dst0);
+            tile_regs_wait();
+            // sqrt(Var + eps)
+            sqrt_tile_init();
+            sqrt_tile(dst0);
+            // tile_regs_wait();
+            // 1/[sqrt(Var + eps)]
+            recip_tile_init();
+            recip_tile(dst0);
+            tile_regs_commit();
+            tile_regs_wait();
+            pack_tile(dst0, cb_stats2);
+            tile_regs_release();
+
+            //cb_pop_front(cb_stats, stats_tiles); // pop the stats tiles we are done and pushed into cb_stats2
+            // PACK(DPRINT << " cb_stats E[x] : "<<TSLICE(cb_stats, 0, SliceRange::h0_w0_32()) << ENDL());
+            // PACK(DPRINT << "pack cb_stats Reci : "<<TSLICE(cb_ex, 0, SliceRange::h0_w0_32()) << ENDL());
+            // UNPACK(DPRINT << "unpack cb_stats Reci : "<<TSLICE(cb_ex, 0, SliceRange::h0_w0_32()) << ENDL());
+            cb_pop_front(cb_var, 1);
+            cb_pop_front(cb_eps, 1);
+            cb_push_back(cb_stats2, stats_tiles);
+            #ifndef RMSNORM
+            cb_pop_front(cb_stats, stats_tiles);
+            #endif
+
+
+            // cb_wait_front(cb_stats2, stats_tiles); //TODO remove
+            UNPACK(DPRINT << "EX : "<<TSLICE(cb_stats2, 0, SliceRange::h0_w0_32()) << ENDL());
+            // UNPACK(DPRINT << "EX2 : "<<TSLICE(cb_stats2, 1, SliceRange::h0_32_w0()) << ENDL());
+        }
+    }
+
+    #ifndef RMSNORM
+    // x - E[x]
+    unpack_reconfig_data_format(cb_in0, cb_ex2_global);
+    pack_reconfig_data_format(cb_xmm);
+    index_h_offset = 0;
+    sub_bcast_cols_init_short();
+    cb_reserve_back(cb_xmm, num_tiles_per_block);
+    for (uint32_t i = 0; i < block_h; i++) {
+        index_subblock_w_offset = 0;
+        cb_wait_front(cb_ex2_global, 1);
+        for (uint32_t j = 0; j < num_subblocks_w; j++) {
+            tile_regs_acquire();
+            for (uint32_t w = 0; w < subblock_w; w++) {
+                index = w + index_subblock_w_offset;
+                sub_tiles_bcast_cols(cb_in0, cb_ex2_global, index, 0, w);
+            }
+            tile_regs_commit();
+            tile_regs_wait();
+            for (uint32_t i = 0; i < subblock_w; i++) {
+                pack_tile(i, cb_xmm);
+            }
+            tile_regs_release();
+            index_subblock_w_offset += subblock_w;
+        }
+        cb_pop_front(cb_ex2_global, 1);
+        cb_pop_front(cb_in0, block_w);
+    }
+    cb_push_back(cb_xmm, num_tiles_per_block);
+    // UNPACK(DPRINT << " cb_xmm X-E[x] : "<<TSLICE(cb_xmm, 0, SliceRange::h0_w0_32()) << ENDL());
+    #endif
+
+    if constexpr(do_gamma == 0 && do_beta == 0) {
+        pack_reconfig_data_format(cb_out);
+    }
+    else{
+        pack_reconfig_data_format(cb_im);
+    }
+    // (x - Ex) * 1/[sqrt(Var + eps)]
+
+    unpack_reconfig_data_format(cb_xmm, cb_ex2_global);
+    mul_bcast_cols_init_short();
+    index_h_offset = 0;
+    cb_reserve_back(cb_im, num_tiles_per_block);
+    #ifndef RMSNORM
+    cb_wait_front(cb_xmm, num_tiles_per_block);
+    #endif
+    for (uint32_t i = 0; i < block_h; i++) {
+        index_subblock_w_offset = 0;
+        cb_wait_front(cb_ex2_global, 1);
+        UNPACK(DPRINT << " cb_xmm : "<<TSLICE(cb_xmm, 0, SliceRange::h0_w0_32()) << ENDL());
+        UNPACK(DPRINT << " cb_ex2_global Reci : "<<TSLICE(cb_ex2_global, 0, SliceRange::h0_32_w0()) << ENDL());
+        for (uint32_t j = 0; j < num_subblocks_w; j++) {
+            tile_regs_acquire();
+            for (uint32_t w = 0; w < subblock_w; w++) {
+                index = w + index_subblock_w_offset + index_h_offset;
+                mul_tiles_bcast_cols(cb_xmm, cb_ex2_global, index, 0, w);
+            }
+            tile_regs_commit();
+
+            tile_regs_wait();
+            for (uint32_t i = 0; i < subblock_w; i++) {
+                pack_tile(i, cb_im);
+            }
+            tile_regs_release();
+
+            index_subblock_w_offset += subblock_w;
+        }
+        index_h_offset += block_w;
+        cb_pop_front(cb_ex2_global, 1);
+    }
+    cb_push_back(cb_im, num_tiles_per_block);
+
+    cb_pop_front(cb_xmm, num_tiles_per_block);
+    cb_wait_front(cb_im, num_tiles_per_block);
+    UNPACK(DPRINT << " cb_im : "<<TSLICE(cb_im, 0, SliceRange::h0_w0_32()) << ENDL());
+
+    if constexpr(do_gamma) {
+        unpack_reconfig_data_format(cb_im, cb_gamma);
+        if constexpr(do_beta == 0) {
+            pack_reconfig_data_format(cb_out);
+        }
+        mul_bcast_rows_init_short();
+        cb_wait_front(cb_gamma, block_w);
+        index_h_offset = 0;
+        cb_reserve_back(cb_outgamma, num_tiles_per_block);
+        for (uint32_t i = 0; i < block_h; i++) {
+            index_subblock_w_offset = 0;
+            for (uint32_t j = 0; j < num_subblocks_w; j++) {
+                tile_regs_acquire();
+                for (uint32_t w = 0; w < subblock_w; w++) {
+                    index = w + index_subblock_w_offset;
+                    mul_tiles_bcast_rows(cb_im, cb_gamma, index+index_h_offset, index, w);
+                }
+                tile_regs_commit();
+                tile_regs_wait();
+                for (uint32_t i = 0; i < subblock_w; i++) {
+                    pack_tile(i, cb_outgamma);
+                }
+                tile_regs_release();
+                index_subblock_w_offset += subblock_w;
+            }
+            index_h_offset += block_w;
+        }
+        cb_push_back(cb_outgamma, num_tiles_per_block);
+        cb_pop_front(cb_im, num_tiles_per_block);
+        cb_wait_front(cb_outgamma, num_tiles_per_block);
+    }
+
+    if constexpr(do_beta) {
+        unpack_reconfig_data_format(cb_fusion, cb_beta);
+        pack_reconfig_data_format(cb_out);
+        add_bcast_rows_init_short();
+        cb_wait_front(cb_beta, block_w);
+        index_h_offset = 0;
+        cb_reserve_back(cb_out, num_tiles_per_block);
+        for (uint32_t i = 0; i < block_h; i++) {
+            index_subblock_w_offset = 0;
+            for (uint32_t j = 0; j < num_subblocks_w; j++) {
+                tile_regs_acquire();
+                for (uint32_t w = 0; w < subblock_w; w++) {
+                    index = w + index_subblock_w_offset;
+                    add_tiles_bcast_rows(cb_fusion, cb_beta, index + index_h_offset, index, w);
+                }
+                tile_regs_commit();
+                tile_regs_wait();
+                for (uint32_t i = 0; i < subblock_w; i++) {
+                    pack_tile(i, cb_out);
+                }
+                tile_regs_release();
+                index_subblock_w_offset += subblock_w;
+            }
+            index_h_offset += block_w;
+        }
+        cb_push_back(cb_out, num_tiles_per_block);
+        cb_pop_front(cb_fusion, num_tiles_per_block);
+        cb_wait_front(cb_out, num_tiles_per_block);
+    }
+}
+
+}

--- a/ttnn/cpp/ttnn/operations/normalization/layernorm/device/kernels/compute/layernorm_sharded_pre_allgather.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/layernorm/device/kernels/compute/layernorm_sharded_pre_allgather.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+// SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/ttnn/cpp/ttnn/operations/normalization/layernorm/device/kernels/compute/layernorm_sharded_pre_allgather.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/layernorm/device/kernels/compute/layernorm_sharded_pre_allgather.cpp
@@ -13,7 +13,6 @@
 #include "compute_kernel_api/eltwise_binary.h"
 #include "compute_kernel_api/layernorm.h"
 #include "compute_kernel_api/tile_move_copy.h"
-#include "debug/dprint.h"
 
 // SPLIT REDUCE across Cores
 namespace NAMESPACE {

--- a/ttnn/cpp/ttnn/operations/normalization/layernorm/device/kernels/compute/layernorm_sharded_pre_allgather.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/layernorm/device/kernels/compute/layernorm_sharded_pre_allgather.cpp
@@ -1,0 +1,189 @@
+// SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#define REDUCE_OP PoolType::SUM
+#define REDUCE_DIM ReduceDim::REDUCE_ROW
+
+#define BCAST_LLKOP EltwiseBinaryType::ELWMUL
+#define BCAST_DIM BroadcastType::COL
+
+#include "compute_kernel_api/reduce.h"
+#include "compute_kernel_api/bcast.h"
+#include "compute_kernel_api/eltwise_binary.h"
+#include "compute_kernel_api/layernorm.h"
+#include "compute_kernel_api/tile_move_copy.h"
+#include "debug/dprint.h"
+
+// SPLIT REDUCE across Cores
+namespace NAMESPACE {
+void MAIN {
+    constexpr uint32_t num_blocks_first_stage                     = get_compile_time_arg_val(3);
+    constexpr uint32_t block_w                        = get_compile_time_arg_val(5);
+    constexpr uint32_t block_h_const                  = get_compile_time_arg_val(4);
+    volatile uint32_t block_h_volatile                = get_compile_time_arg_val(4);
+    constexpr uint32_t subblock_w_const               = get_compile_time_arg_val(6);
+    volatile uint32_t subblock_w_volatile             = get_compile_time_arg_val(6);
+    constexpr uint32_t num_subblocks_w                = get_compile_time_arg_val(7);
+    const bool is_allgather_worker                    = get_compile_time_arg_val(8) == 1;
+    constexpr uint32_t num_tiles_per_block            = get_compile_time_arg_val(9);
+    constexpr bool FLOAT32_DTYPE                      = get_compile_time_arg_val(10) == 1;
+    constexpr uint32_t num_blocks_second_stage        = get_compile_time_arg_val(11);
+
+    const uint32_t num_reduce_tiles_per_block_h             = get_arg_val<uint32_t>(0); // This value is the same for all cores, except ones that have padding tiles in it. In that case, skip reduce for padding tiles.
+    const uint32_t num_tiles_per_allgather_worker           = is_allgather_worker ? get_arg_val<uint32_t>(1) : 0;
+    const bool use_two_stage_reduce                         = is_allgather_worker ? get_arg_val<uint32_t>(2) == 1 : false;
+    const bool is_second_stage_reader                       = is_allgather_worker ? get_arg_val<uint32_t>(3) == 1 : false;
+
+    uint32_t num_blocks_reduce;
+    if (is_second_stage_reader) {
+        num_blocks_reduce = num_blocks_first_stage + num_blocks_second_stage - 1;
+    } else {
+        num_blocks_reduce = num_blocks_first_stage;
+    }
+
+    bool enable_sqrt;
+    if (use_two_stage_reduce and not is_second_stage_reader) {
+        enable_sqrt = false;
+    } else {
+        enable_sqrt = true;
+    }
+
+    constexpr uint32_t dst0 = 0;
+    constexpr uint32_t dst1 = 1;
+    constexpr uint32_t scaler0 = 0;
+
+    constexpr uint32_t cb_in0 = tt::CB::c_in0;
+    constexpr uint32_t cb_scaler = tt::CB::c_in2;
+    constexpr uint32_t cb_scaler_global = tt::CB::c_in4;
+    constexpr uint32_t cb_x = tt::CB::c_intermed0; // x minus mean
+    constexpr uint32_t cb_ex = tt::CB::dataflow1; // E[x] global reduce
+
+    constexpr uint32_t cb_ex2 = tt::CB::dataflow4; // E[(x-E[x])^2] global reduce
+    constexpr uint32_t cb_x2 = cb_x; // x^2
+    constexpr uint32_t cb_out = tt::CB::c_out0;
+
+    constexpr uint32_t cb_ex_partial2 = tt::CB::dataflow3; // E[x^2] partial reduce
+    constexpr uint32_t cb_ex_external2 = tt::CB::dataflow5; // E[x^2] partials recieved from other cores
+    const uint32_t cb_reduction_out = is_second_stage_reader ? cb_out : cb_ex2;
+
+
+    binary_op_init_common(cb_in0, cb_in0, cb_x2);
+
+    // set block_h to volatile to disable automatically unroll of the loops, avoid code overflow
+    const uint32_t block_h = (block_w == 1) ? block_h_volatile : block_h_const;
+    const uint32_t subblock_w = (block_w <= 2) ? subblock_w_volatile : subblock_w_const;
+
+    int index_subblock_w_offset = 0;
+    int index_h_offset = 0;
+    int index = 0;
+
+    uint32_t num_tiles_per_partial_result = 2;
+    #ifdef RMSNORM
+    num_tiles_per_partial_result = 1;
+    #endif
+
+    cb_wait_front(cb_scaler, 1);
+    #ifndef RMSNORM
+    unpack_reconfig_data_format_srcb(cb_in0, cb_scaler);
+    // E[x],
+    index_h_offset = 0;
+    reduce_init_delta<false>();
+
+    cb_reserve_back(cb_ex_partial2, block_h);
+    for (uint32_t i = 0; i < block_h; i++) {
+        tile_regs_acquire();
+        for (uint32_t w = 0; w < num_reduce_tiles_per_block_h; w++) {
+            reduce_tile(cb_in0, cb_scaler, w+index_h_offset, scaler0, dst0);
+        }
+        tile_regs_commit();
+        tile_regs_wait();
+        pack_tile(dst0, cb_ex_partial2);
+        tile_regs_release();
+        index_h_offset += block_w;
+    }
+    reduce_revert_delta();
+    cb_push_back(cb_ex_partial2, block_h);
+    unpack_reconfig_data_format_srcb(cb_scaler, cb_in0);
+    #endif // not RMSNORM
+
+    // X^2
+    mul_tiles_init();
+    index_h_offset = 0;
+    cb_reserve_back(cb_x2, num_tiles_per_block);
+    for (uint32_t i = 0; i < block_h; i++) {
+        index_subblock_w_offset = 0;
+        for (uint32_t j = 0; j < num_subblocks_w; j++) {
+            tile_regs_acquire();
+            for (uint32_t w = 0; w < subblock_w; w++) {
+                index = w + index_subblock_w_offset + index_h_offset;
+                mul_tiles(cb_in0, cb_in0, index, index, w);
+            }
+            tile_regs_commit();
+            tile_regs_wait();
+            for (uint32_t i = 0; i < subblock_w; i++) {
+                pack_tile(i, cb_x2);
+            }
+            tile_regs_release();
+            index_subblock_w_offset += subblock_w;
+        }
+        index_h_offset += block_w;
+    }
+    cb_push_back(cb_x2, num_tiles_per_block);
+
+    // E(x^2)
+    unpack_reconfig_data_format_srca(cb_in0, cb_x2);
+    unpack_reconfig_data_format_srcb(cb_in0, cb_scaler);
+
+    cb_wait_front(cb_x2, num_tiles_per_block);
+
+    cb_reserve_back(cb_ex_partial2, block_h); // RMS E(x2) #Layernorm //E(x) and E(x^2)
+
+    reduce_init_delta<false>();
+    index_h_offset = 0;
+    for (uint32_t i = 0; i < block_h; i++) {
+        tile_regs_acquire();
+        for (uint32_t w = 0; w < num_reduce_tiles_per_block_h; w++) {
+            reduce_tile(cb_x2, cb_scaler, w+index_h_offset, scaler0, dst0);
+        }
+
+        tile_regs_commit();
+        tile_regs_wait();
+        pack_tile(dst0, cb_ex_partial2);
+        tile_regs_release();
+        index_h_offset += block_w;
+    }
+    reduce_revert_delta();
+    cb_pop_front(cb_x2, num_tiles_per_block);
+    cb_push_back(cb_ex_partial2, block_h);
+
+    // global reduce, cb_ex <-- cb_ex_external2, cb_ex_partial2
+    if constexpr(is_allgather_worker) {
+        cb_wait_front(cb_scaler_global, 1);
+        unpack_reconfig_data_format_srca(cb_x2, cb_ex_external2);
+        unpack_reconfig_data_format_srcb(cb_scaler, cb_scaler_global);
+        reduce_init_delta<false>();
+        cb_reserve_back(cb_reduction_out, num_tiles_per_partial_result*num_tiles_per_allgather_worker);
+
+        for (uint32_t i = 0; i < num_tiles_per_allgather_worker; i++) { // loops over height
+            tile_regs_acquire();
+            for (uint32_t w = 0; w < num_tiles_per_partial_result*num_blocks_reduce; w++) { // Need to read this interleaved now, we have SUM(X) and SUM(X^2) interleaved
+                cb_wait_front(cb_ex_external2, 1);
+                reduce_tile(cb_ex_external2, cb_scaler_global, 0, scaler0, w % num_tiles_per_partial_result); // E(x) and E(x^2) interleaved so we reduce each one into different dest reg
+                cb_pop_front(cb_ex_external2, 1);
+            }
+            tile_regs_commit();
+            tile_regs_wait();
+            pack_tile(dst0, cb_reduction_out);
+            #ifndef RMSNORM
+            pack_tile(dst1, cb_reduction_out);
+            #endif
+            tile_regs_release();
+        }
+        reduce_revert_delta();
+        cb_push_back(cb_reduction_out, num_tiles_per_partial_result*num_tiles_per_allgather_worker);
+    }
+
+}
+
+}

--- a/ttnn/cpp/ttnn/operations/normalization/layernorm/device/kernels/compute/layernorm_sharded_pre_allgather.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/layernorm/device/kernels/compute/layernorm_sharded_pre_allgather.cpp
@@ -41,13 +41,6 @@ void MAIN {
         num_blocks_reduce = num_blocks_first_stage;
     }
 
-    bool enable_sqrt;
-    if (use_two_stage_reduce and not is_second_stage_reader) {
-        enable_sqrt = false;
-    } else {
-        enable_sqrt = true;
-    }
-
     constexpr uint32_t dst0 = 0;
     constexpr uint32_t dst1 = 1;
     constexpr uint32_t scaler0 = 0;

--- a/ttnn/cpp/ttnn/operations/normalization/layernorm/device/kernels/dataflow/reader_mcast_receiver_unary_sharded_ln_post_allgather.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/layernorm/device/kernels/dataflow/reader_mcast_receiver_unary_sharded_ln_post_allgather.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+// SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/ttnn/cpp/ttnn/operations/normalization/layernorm/device/kernels/dataflow/reader_mcast_receiver_unary_sharded_ln_post_allgather.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/layernorm/device/kernels/dataflow/reader_mcast_receiver_unary_sharded_ln_post_allgather.cpp
@@ -10,43 +10,11 @@
 // split REDUCE across cores
 void kernel_main() {
 
-    uint32_t reduce_receiver_semaphore_addr  = get_semaphore(get_compile_time_arg_val(0));
     uint32_t reduce_sender_semaphore_addr    = get_semaphore(get_compile_time_arg_val(1));
-    constexpr uint32_t num_blocks                      = get_compile_time_arg_val(2);
     constexpr uint32_t block_h                         = get_compile_time_arg_val(3);
-    const bool is_all_to_all_worker                    = get_compile_time_arg_val(4) == 1;
-    constexpr uint32_t num_all_to_all_workers          = get_compile_time_arg_val(5);
-    constexpr uint32_t num_tiles_per_worker            = get_compile_time_arg_val(6);
-    constexpr uint32_t num_tiles_per_worker_last       = get_compile_time_arg_val(7);
-    constexpr bool row_major                           = (bool) get_compile_time_arg_val(8);
-    constexpr uint32_t num_x                           = get_compile_time_arg_val(9);
-    constexpr uint32_t num_y                           = get_compile_time_arg_val(10);
-    constexpr bool use_two_stage_reduce                              = (bool) get_compile_time_arg_val(11);
-    constexpr uint32_t num_blocks_first_stage                        = get_compile_time_arg_val(12);
-    constexpr uint32_t num_blocks_second_stage                       = get_compile_time_arg_val(13);
-    uint32_t reduce_second_stage_semaphore_addr            = get_semaphore(get_compile_time_arg_val(14));
 
-    const bool is_last_all_to_all_worker                = get_arg_val<uint32_t>(0);
-    const uint32_t all_to_all_tile_offset_bytes         = get_arg_val<uint32_t>(1);
-    const bool is_second_stage_reader                   = get_arg_val<uint32_t>(2);
-    const uint32_t start_x                              = get_arg_val<uint32_t>(3);
-    const uint32_t start_y                              = get_arg_val<uint32_t>(4);
-    volatile tt_l1_ptr uint32_t * in0_remote_noc_x          = (volatile tt_l1_ptr uint32_t*)(get_arg_addr(5));
-    volatile tt_l1_ptr uint32_t * in0_remote_noc_y          = (volatile tt_l1_ptr uint32_t*)(get_arg_addr(5 + num_x));
 
-    const uint32_t num_tiles_to_read = is_last_all_to_all_worker ? num_tiles_per_worker_last : num_tiles_per_worker;
-
-    constexpr uint32_t cb_ex_partial = tt::CB::dataflow0; // E[x] partial reduce
-    constexpr uint32_t cb_ex = tt::CB::dataflow1; // E[x] global reduce
-    constexpr uint32_t cb_ex_external = tt::CB::dataflow2;
-    constexpr uint32_t cb_ex_partial2 = tt::CB::dataflow3; // E[(x-E[x])^2] partial reduce
-    constexpr uint32_t cb_ex_external2 = tt::CB::dataflow5;
-    constexpr uint32_t cb_ex2pe = tt::CB::c_intermed3;
-    constexpr uint32_t cb_ex_global = tt::CB::dataflow7; // E[x] global reduce
-    constexpr uint32_t cb_ex2_global = tt::CB::dataflow6; // E[x2] global reduce
-
-    const uint32_t single_tile_size_bytes = get_tile_size(cb_ex_partial2); // tile size
-    const DataFormat data_format = get_dataformat(cb_ex_partial2); // data format
+    constexpr uint32_t cb_ex_global = tt::CB::dataflow7; // [E[x], E[X^2]] global to all cores
 
     #ifdef RMSNORM
     constexpr uint32_t stats_tiles = 1;
@@ -54,74 +22,7 @@ void kernel_main() {
     constexpr uint32_t stats_tiles = 2;
     #endif
 
-    uint64_t remote_noc_addrs_first_stage[is_all_to_all_worker ? num_blocks_first_stage : 1];
-    uint64_t remote_noc_addrs_second_stage[is_all_to_all_worker ? num_blocks_second_stage : 1];
-    if constexpr (is_all_to_all_worker) {
-        if constexpr (use_two_stage_reduce) {
-            uint32_t x = start_x, y = start_y;
-            for (uint32_t i = 0; i < num_blocks_first_stage; ++i) {
-                remote_noc_addrs_first_stage[i] = get_noc_addr(in0_remote_noc_x[x], in0_remote_noc_y[y], 0);
-                if constexpr(row_major) {
-                    ++x;
-                    if (x == num_x) {
-                        x = 0;
-                    }
-                } else {
-                    ++y;
-                    if (y == num_y) {
-                        y = 0;
-                    }
-                }
-            }
-            if constexpr(row_major) {
-                x = start_x;
-                y = 0;
-            } else {
-                x = 0;
-                y = start_y;
-            }
-            for (uint32_t i = 0; i < num_blocks_second_stage; ++i) {
-                remote_noc_addrs_second_stage[i] = get_noc_addr(in0_remote_noc_x[x], in0_remote_noc_y[y], 0);
-                if constexpr(row_major) {
-                    ++y;
-                } else {
-                    ++x;
-                }
-            }
-        } else {
-            uint32_t x = start_x, y = start_y;
-            for (uint32_t i = 0; i < num_blocks; ++i) {
-                remote_noc_addrs_first_stage[i] = get_noc_addr(in0_remote_noc_x[x], in0_remote_noc_y[y], 0);
-                if constexpr(row_major) {
-                    ++x;
-                    if (x == num_x) {
-                        x = 0;
-                        ++y;
-                        if (y == num_y) {
-                            y = 0;
-                        }
-                    }
-                } else {
-                    ++y;
-                    if (y == num_y) {
-                        y = 0;
-                        ++x;
-                        if (x == num_x) {
-                            x = 0;
-                        }
-                    }
-                }
-            }
-        }
-    } else {
-        remote_noc_addrs_first_stage[0] = get_noc_addr(in0_remote_noc_x[0], in0_remote_noc_y[0], 0);
-    }
-
-    volatile tt_l1_ptr uint32_t* reduce_receiver_semaphore_addr_ptr = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(reduce_receiver_semaphore_addr);
     volatile tt_l1_ptr uint32_t* reduce_sender_semaphore_addr_ptr = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(reduce_sender_semaphore_addr);
-    volatile tt_l1_ptr uint32_t* reduce_second_stage_semaphore_addr_ptr = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(reduce_second_stage_semaphore_addr);
-
-    const uint64_t reduce_receiver_semaphore_noc_addr = get_noc_addr(in0_remote_noc_x[0], in0_remote_noc_y[0], reduce_receiver_semaphore_addr);
 
     // inc mcast sender
     noc_semaphore_set(reduce_sender_semaphore_addr_ptr, INVALID);

--- a/ttnn/cpp/ttnn/operations/normalization/layernorm/device/kernels/dataflow/reader_mcast_receiver_unary_sharded_ln_post_allgather.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/layernorm/device/kernels/dataflow/reader_mcast_receiver_unary_sharded_ln_post_allgather.cpp
@@ -129,7 +129,6 @@ void kernel_main() {
     noc_semaphore_set(reduce_sender_semaphore_addr_ptr, INVALID);
     // inc remote sem
     cb_reserve_back(cb_ex2_global, stats_tiles*block_h);
-    DPRINT << "Receiver wait sem" << ENDL();
     noc_semaphore_wait(reduce_sender_semaphore_addr_ptr, VALID);
     cb_push_back(cb_ex2_global, stats_tiles*block_h);
 }

--- a/ttnn/cpp/ttnn/operations/normalization/layernorm/device/kernels/dataflow/reader_mcast_receiver_unary_sharded_ln_post_allgather.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/layernorm/device/kernels/dataflow/reader_mcast_receiver_unary_sharded_ln_post_allgather.cpp
@@ -40,8 +40,6 @@ void kernel_main() {
     constexpr uint32_t cb_ex = tt::CB::dataflow1; // E[x] global reduce
     constexpr uint32_t cb_ex_external = tt::CB::dataflow2;
     constexpr uint32_t cb_ex_partial2 = tt::CB::dataflow3; // E[(x-E[x])^2] partial reduce
-    constexpr uint32_t cb_stats = tt::CB::c_in7; // E[(x-E[x])^2] global reduce
-    constexpr uint32_t cb_stats2 = tt::CB::c_intermed4; // E[(x-E[x])^2] global reduce
     constexpr uint32_t cb_ex_external2 = tt::CB::dataflow5;
     constexpr uint32_t cb_ex2pe = tt::CB::c_intermed3;
     constexpr uint32_t cb_ex_global = tt::CB::dataflow7; // E[x] global reduce
@@ -128,7 +126,7 @@ void kernel_main() {
     // inc mcast sender
     noc_semaphore_set(reduce_sender_semaphore_addr_ptr, INVALID);
     // inc remote sem
-    cb_reserve_back(cb_ex2_global, stats_tiles*block_h);
+    cb_reserve_back(cb_ex_global, stats_tiles*block_h);
     noc_semaphore_wait(reduce_sender_semaphore_addr_ptr, VALID);
-    cb_push_back(cb_ex2_global, stats_tiles*block_h);
+    cb_push_back(cb_ex_global, stats_tiles*block_h);
 }

--- a/ttnn/cpp/ttnn/operations/normalization/layernorm/device/kernels/dataflow/reader_mcast_receiver_unary_sharded_ln_post_allgather.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/layernorm/device/kernels/dataflow/reader_mcast_receiver_unary_sharded_ln_post_allgather.cpp
@@ -1,0 +1,135 @@
+// SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <stdint.h>
+#include "dataflow_api.h"
+#include "hostdevcommon/common_values.hpp"
+
+
+// split REDUCE across cores
+void kernel_main() {
+
+    uint32_t reduce_receiver_semaphore_addr  = get_semaphore(get_compile_time_arg_val(0));
+    uint32_t reduce_sender_semaphore_addr    = get_semaphore(get_compile_time_arg_val(1));
+    constexpr uint32_t num_blocks                      = get_compile_time_arg_val(2);
+    constexpr uint32_t block_h                         = get_compile_time_arg_val(3);
+    const bool is_all_to_all_worker                    = get_compile_time_arg_val(4) == 1;
+    constexpr uint32_t num_all_to_all_workers          = get_compile_time_arg_val(5);
+    constexpr uint32_t num_tiles_per_worker            = get_compile_time_arg_val(6);
+    constexpr uint32_t num_tiles_per_worker_last       = get_compile_time_arg_val(7);
+    constexpr bool row_major                           = (bool) get_compile_time_arg_val(8);
+    constexpr uint32_t num_x                           = get_compile_time_arg_val(9);
+    constexpr uint32_t num_y                           = get_compile_time_arg_val(10);
+    constexpr bool use_two_stage_reduce                              = (bool) get_compile_time_arg_val(11);
+    constexpr uint32_t num_blocks_first_stage                        = get_compile_time_arg_val(12);
+    constexpr uint32_t num_blocks_second_stage                       = get_compile_time_arg_val(13);
+    uint32_t reduce_second_stage_semaphore_addr            = get_semaphore(get_compile_time_arg_val(14));
+
+    const bool is_last_all_to_all_worker                = get_arg_val<uint32_t>(0);
+    const uint32_t all_to_all_tile_offset_bytes         = get_arg_val<uint32_t>(1);
+    const bool is_second_stage_reader                   = get_arg_val<uint32_t>(2);
+    const uint32_t start_x                              = get_arg_val<uint32_t>(3);
+    const uint32_t start_y                              = get_arg_val<uint32_t>(4);
+    volatile tt_l1_ptr uint32_t * in0_remote_noc_x          = (volatile tt_l1_ptr uint32_t*)(get_arg_addr(5));
+    volatile tt_l1_ptr uint32_t * in0_remote_noc_y          = (volatile tt_l1_ptr uint32_t*)(get_arg_addr(5 + num_x));
+
+    const uint32_t num_tiles_to_read = is_last_all_to_all_worker ? num_tiles_per_worker_last : num_tiles_per_worker;
+
+    constexpr uint32_t cb_ex_partial = tt::CB::dataflow0; // E[x] partial reduce
+    constexpr uint32_t cb_ex = tt::CB::dataflow1; // E[x] global reduce
+    constexpr uint32_t cb_ex_external = tt::CB::dataflow2;
+    constexpr uint32_t cb_ex_partial2 = tt::CB::dataflow3; // E[(x-E[x])^2] partial reduce
+    constexpr uint32_t cb_stats = tt::CB::c_in7; // E[(x-E[x])^2] global reduce
+    constexpr uint32_t cb_stats2 = tt::CB::c_intermed4; // E[(x-E[x])^2] global reduce
+    constexpr uint32_t cb_ex_external2 = tt::CB::dataflow5;
+    constexpr uint32_t cb_ex2pe = tt::CB::c_intermed3;
+    constexpr uint32_t cb_ex_global = tt::CB::dataflow7; // E[x] global reduce
+    constexpr uint32_t cb_ex2_global = tt::CB::dataflow6; // E[x2] global reduce
+
+    const uint32_t single_tile_size_bytes = get_tile_size(cb_ex_partial2); // tile size
+    const DataFormat data_format = get_dataformat(cb_ex_partial2); // data format
+
+    #ifdef RMSNORM
+    constexpr uint32_t stats_tiles = 1;
+    #else
+    constexpr uint32_t stats_tiles = 2;
+    #endif
+
+    uint64_t remote_noc_addrs_first_stage[is_all_to_all_worker ? num_blocks_first_stage : 1];
+    uint64_t remote_noc_addrs_second_stage[is_all_to_all_worker ? num_blocks_second_stage : 1];
+    if constexpr (is_all_to_all_worker) {
+        if constexpr (use_two_stage_reduce) {
+            uint32_t x = start_x, y = start_y;
+            for (uint32_t i = 0; i < num_blocks_first_stage; ++i) {
+                remote_noc_addrs_first_stage[i] = get_noc_addr(in0_remote_noc_x[x], in0_remote_noc_y[y], 0);
+                if constexpr(row_major) {
+                    ++x;
+                    if (x == num_x) {
+                        x = 0;
+                    }
+                } else {
+                    ++y;
+                    if (y == num_y) {
+                        y = 0;
+                    }
+                }
+            }
+            if constexpr(row_major) {
+                x = start_x;
+                y = 0;
+            } else {
+                x = 0;
+                y = start_y;
+            }
+            for (uint32_t i = 0; i < num_blocks_second_stage; ++i) {
+                remote_noc_addrs_second_stage[i] = get_noc_addr(in0_remote_noc_x[x], in0_remote_noc_y[y], 0);
+                if constexpr(row_major) {
+                    ++y;
+                } else {
+                    ++x;
+                }
+            }
+        } else {
+            uint32_t x = start_x, y = start_y;
+            for (uint32_t i = 0; i < num_blocks; ++i) {
+                remote_noc_addrs_first_stage[i] = get_noc_addr(in0_remote_noc_x[x], in0_remote_noc_y[y], 0);
+                if constexpr(row_major) {
+                    ++x;
+                    if (x == num_x) {
+                        x = 0;
+                        ++y;
+                        if (y == num_y) {
+                            y = 0;
+                        }
+                    }
+                } else {
+                    ++y;
+                    if (y == num_y) {
+                        y = 0;
+                        ++x;
+                        if (x == num_x) {
+                            x = 0;
+                        }
+                    }
+                }
+            }
+        }
+    } else {
+        remote_noc_addrs_first_stage[0] = get_noc_addr(in0_remote_noc_x[0], in0_remote_noc_y[0], 0);
+    }
+
+    volatile tt_l1_ptr uint32_t* reduce_receiver_semaphore_addr_ptr = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(reduce_receiver_semaphore_addr);
+    volatile tt_l1_ptr uint32_t* reduce_sender_semaphore_addr_ptr = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(reduce_sender_semaphore_addr);
+    volatile tt_l1_ptr uint32_t* reduce_second_stage_semaphore_addr_ptr = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(reduce_second_stage_semaphore_addr);
+
+    const uint64_t reduce_receiver_semaphore_noc_addr = get_noc_addr(in0_remote_noc_x[0], in0_remote_noc_y[0], reduce_receiver_semaphore_addr);
+
+    // inc mcast sender
+    noc_semaphore_set(reduce_sender_semaphore_addr_ptr, INVALID);
+    // inc remote sem
+    cb_reserve_back(cb_ex2_global, stats_tiles*block_h);
+    DPRINT << "Receiver wait sem" << ENDL();
+    noc_semaphore_wait(reduce_sender_semaphore_addr_ptr, VALID);
+    cb_push_back(cb_ex2_global, stats_tiles*block_h);
+}

--- a/ttnn/cpp/ttnn/operations/normalization/layernorm/device/kernels/dataflow/reader_mcast_receiver_unary_sharded_ln_pre_allgather.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/layernorm/device/kernels/dataflow/reader_mcast_receiver_unary_sharded_ln_pre_allgather.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+// SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/ttnn/cpp/ttnn/operations/normalization/layernorm/device/kernels/dataflow/reader_mcast_receiver_unary_sharded_ln_pre_allgather.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/layernorm/device/kernels/dataflow/reader_mcast_receiver_unary_sharded_ln_pre_allgather.cpp
@@ -39,8 +39,6 @@ void kernel_main() {
     constexpr uint32_t cb_ex_partial2 = tt::CB::dataflow3; // E[(x-E[x])^2] partial reduce
     constexpr uint32_t cb_ex2 = tt::CB::dataflow4; // E[(x-E[x])^2] global reduce
     constexpr uint32_t cb_ex_external2 = tt::CB::dataflow5;
-    constexpr uint32_t cb_ex2pe = tt::CB::c_intermed3;
-    constexpr uint32_t cb_ex2_global = tt::CB::dataflow6; // E[x2] global reduce
 
     const uint32_t single_tile_size_bytes = get_tile_size(cb_ex_partial2); // tile size
     const DataFormat data_format = get_dataformat(cb_ex_partial2); // data format
@@ -116,7 +114,7 @@ void kernel_main() {
     const uint64_t reduce_receiver_semaphore_noc_addr = get_noc_addr(in0_remote_noc_x[0], in0_remote_noc_y[0], reduce_receiver_semaphore_addr);
     const uint64_t reduce_second_stage_receiver_semaphore_noc_addr = remote_noc_addrs_second_stage[0] | reduce_second_stage_semaphore_addr;
 
-    const auto& global_reduce_receiver = [&](const uint32_t cb_partial, const uint32_t cb_external, const uint32_t cb_ex, const uint32_t cb_ex_global, const uint32_t cb_reduce_first_stage) __attribute__((always_inline))
+    const auto& global_reduce_receiver = [&](const uint32_t cb_partial, const uint32_t cb_external, const uint32_t cb_reduce_first_stage) __attribute__((always_inline))
     {
         uint32_t num_tiles_per_partial_result = 2;
         #ifdef RMSNORM
@@ -189,5 +187,5 @@ void kernel_main() {
         }
 
     };
-    global_reduce_receiver(cb_ex_partial2, cb_ex_external2, cb_ex2, cb_ex2_global, cb_ex2);
+    global_reduce_receiver(cb_ex_partial2, cb_ex_external2, cb_ex2);
 }

--- a/ttnn/cpp/ttnn/operations/normalization/layernorm/device/kernels/dataflow/reader_mcast_receiver_unary_sharded_ln_pre_allgather.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/layernorm/device/kernels/dataflow/reader_mcast_receiver_unary_sharded_ln_pre_allgather.cpp
@@ -1,0 +1,195 @@
+// SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <stdint.h>
+#include "dataflow_api.h"
+#include "hostdevcommon/common_values.hpp"
+
+#include "debug/dprint.h"
+
+
+// split REDUCE across cores
+void kernel_main() {
+
+    uint32_t reduce_receiver_semaphore_addr  = get_semaphore(get_compile_time_arg_val(0));
+    uint32_t reduce_sender_semaphore_addr    = get_semaphore(get_compile_time_arg_val(1));
+    constexpr uint32_t num_blocks                      = get_compile_time_arg_val(2);
+    constexpr uint32_t block_h                         = get_compile_time_arg_val(3);
+    const bool is_all_to_all_worker                    = get_compile_time_arg_val(4) == 1;
+    constexpr uint32_t num_all_to_all_workers          = get_compile_time_arg_val(5);
+    constexpr uint32_t num_tiles_per_worker            = get_compile_time_arg_val(6);
+    constexpr uint32_t num_tiles_per_worker_last       = get_compile_time_arg_val(7);
+    constexpr bool row_major                           = (bool) get_compile_time_arg_val(8);
+    constexpr uint32_t num_x                           = get_compile_time_arg_val(9);
+    constexpr uint32_t num_y                           = get_compile_time_arg_val(10);
+    constexpr bool use_two_stage_reduce                              = (bool) get_compile_time_arg_val(11);
+    constexpr uint32_t num_blocks_first_stage                        = get_compile_time_arg_val(12);
+    constexpr uint32_t num_blocks_second_stage                       = get_compile_time_arg_val(13);
+    uint32_t reduce_second_stage_semaphore_addr            = get_semaphore(get_compile_time_arg_val(14));
+
+    const bool is_last_all_to_all_worker                = get_arg_val<uint32_t>(0);
+    const uint32_t all_to_all_tile_offset_bytes         = get_arg_val<uint32_t>(1);
+    const bool is_second_stage_reader                   = get_arg_val<uint32_t>(2);
+    const uint32_t start_x                              = get_arg_val<uint32_t>(3);
+    const uint32_t start_y                              = get_arg_val<uint32_t>(4);
+    volatile tt_l1_ptr uint32_t * in0_remote_noc_x          = (volatile tt_l1_ptr uint32_t*)(get_arg_addr(5));
+    volatile tt_l1_ptr uint32_t * in0_remote_noc_y          = (volatile tt_l1_ptr uint32_t*)(get_arg_addr(5 + num_x));
+
+    const uint32_t num_tiles_to_read = is_last_all_to_all_worker ? num_tiles_per_worker_last : num_tiles_per_worker;
+
+    constexpr uint32_t cb_ex_partial2 = tt::CB::dataflow3; // E[(x-E[x])^2] partial reduce
+    constexpr uint32_t cb_ex2 = tt::CB::dataflow4; // E[(x-E[x])^2] global reduce
+    constexpr uint32_t cb_ex_external2 = tt::CB::dataflow5;
+    constexpr uint32_t cb_ex2pe = tt::CB::c_intermed3;
+    constexpr uint32_t cb_ex2_global = tt::CB::dataflow6; // E[x2] global reduce
+
+    const uint32_t single_tile_size_bytes = get_tile_size(cb_ex_partial2); // tile size
+    const DataFormat data_format = get_dataformat(cb_ex_partial2); // data format
+
+    uint64_t remote_noc_addrs_first_stage[is_all_to_all_worker ? num_blocks_first_stage : 1];
+    uint64_t remote_noc_addrs_second_stage[is_all_to_all_worker ? num_blocks_second_stage : 1];
+    if constexpr (is_all_to_all_worker) {
+        if constexpr (use_two_stage_reduce) {
+            uint32_t x = start_x, y = start_y;
+            for (uint32_t i = 0; i < num_blocks_first_stage; ++i) {
+                remote_noc_addrs_first_stage[i] = get_noc_addr(in0_remote_noc_x[x], in0_remote_noc_y[y], 0);
+                if constexpr(row_major) {
+                    ++x;
+                    if (x == num_x) {
+                        x = 0;
+                    }
+                } else {
+                    ++y;
+                    if (y == num_y) {
+                        y = 0;
+                    }
+                }
+            }
+            if constexpr(row_major) {
+                x = start_x;
+                y = 0;
+            } else {
+                x = 0;
+                y = start_y;
+            }
+            for (uint32_t i = 0; i < num_blocks_second_stage; ++i) {
+                remote_noc_addrs_second_stage[i] = get_noc_addr(in0_remote_noc_x[x], in0_remote_noc_y[y], 0);
+                if constexpr(row_major) {
+                    ++y;
+                } else {
+                    ++x;
+                }
+            }
+        } else {
+            uint32_t x = start_x, y = start_y;
+            for (uint32_t i = 0; i < num_blocks; ++i) {
+                remote_noc_addrs_first_stage[i] = get_noc_addr(in0_remote_noc_x[x], in0_remote_noc_y[y], 0);
+                if constexpr(row_major) {
+                    ++x;
+                    if (x == num_x) {
+                        x = 0;
+                        ++y;
+                        if (y == num_y) {
+                            y = 0;
+                        }
+                    }
+                } else {
+                    ++y;
+                    if (y == num_y) {
+                        y = 0;
+                        ++x;
+                        if (x == num_x) {
+                            x = 0;
+                        }
+                    }
+                }
+            }
+        }
+    } else {
+        remote_noc_addrs_first_stage[0] = get_noc_addr(in0_remote_noc_x[0], in0_remote_noc_y[0], 0);
+        remote_noc_addrs_second_stage[0] = get_noc_addr(in0_remote_noc_x[0], in0_remote_noc_y[0], 0);
+    }
+
+    volatile tt_l1_ptr uint32_t* reduce_receiver_semaphore_addr_ptr = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(reduce_receiver_semaphore_addr);
+    volatile tt_l1_ptr uint32_t* reduce_sender_semaphore_addr_ptr = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(reduce_sender_semaphore_addr);
+    volatile tt_l1_ptr uint32_t* reduce_second_stage_semaphore_addr_ptr = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(reduce_second_stage_semaphore_addr);
+
+    const uint64_t reduce_receiver_semaphore_noc_addr = get_noc_addr(in0_remote_noc_x[0], in0_remote_noc_y[0], reduce_receiver_semaphore_addr);
+    const uint64_t reduce_second_stage_receiver_semaphore_noc_addr = remote_noc_addrs_second_stage[0] | reduce_second_stage_semaphore_addr;
+
+    const auto& global_reduce_receiver = [&](const uint32_t cb_partial, const uint32_t cb_external, const uint32_t cb_ex, const uint32_t cb_ex_global, const uint32_t cb_reduce_first_stage) __attribute__((always_inline))
+    {
+        uint32_t num_tiles_per_partial_result = 2;
+        #ifdef RMSNORM
+        num_tiles_per_partial_result = 1;
+        #endif
+        // global reduce
+        // wait for local data ready
+        cb_wait_front(cb_partial, num_tiles_per_partial_result*block_h); // two tiles * block_h
+
+
+        // inc mcast sender
+        noc_semaphore_set(reduce_sender_semaphore_addr_ptr, INVALID);
+        noc_semaphore_inc(reduce_receiver_semaphore_noc_addr, 1);
+        noc_semaphore_wait(reduce_sender_semaphore_addr_ptr, VALID);
+
+
+        if constexpr (is_all_to_all_worker) {
+            // read data from other cores - reduce first stage
+            uint32_t l1_read_addr_ex_par = get_read_ptr(cb_partial);
+            l1_read_addr_ex_par += all_to_all_tile_offset_bytes;
+            // read data from other cores - second stage reduce
+            uint32_t l1_read_addr_ex = 0;
+            uint32_t block_index_stride = 0;
+            if constexpr(use_two_stage_reduce) {
+                l1_read_addr_ex = get_read_ptr(cb_reduce_first_stage);
+                if constexpr(row_major) {
+                    block_index_stride = num_x;
+                } else {
+                    block_index_stride = num_y;
+                }
+            }
+            for (uint32_t i = 0; i < num_tiles_to_read; i++) {
+                cb_reserve_back(cb_external, num_tiles_per_partial_result*num_blocks_first_stage);
+                uint32_t l1_write_addr_external = get_write_ptr(cb_external);
+                for(uint32_t block = 0; block < num_blocks_first_stage; block++) {
+                    for(uint32_t tile_idx = 0; tile_idx < num_tiles_per_partial_result; tile_idx++) { // loops over Sum(X), Sum(X2) --> 2x
+                        uint64_t noc_addr_ex_par = remote_noc_addrs_first_stage[block] | (l1_read_addr_ex_par + tile_idx * single_tile_size_bytes); // Updating read address for reading SUm(X) and Sum(X2) per core
+                        noc_async_read_one_packet(noc_addr_ex_par, l1_write_addr_external, single_tile_size_bytes);
+                        l1_write_addr_external+=single_tile_size_bytes;
+                    }
+                }
+                l1_read_addr_ex_par += single_tile_size_bytes;
+                noc_async_read_barrier();
+                cb_push_back(cb_external, num_tiles_per_partial_result*num_blocks_first_stage);
+
+
+                // read data from other cores - reduce first stage
+                if constexpr(use_two_stage_reduce) {
+                    if (is_second_stage_reader) { // gather data from a column of cores (if row major)
+                        if (i == 0) {
+                            noc_semaphore_wait(reduce_second_stage_semaphore_addr_ptr, num_blocks_second_stage-1);
+                            noc_semaphore_set(reduce_second_stage_semaphore_addr_ptr, 0);
+                        }
+                        // read data from other cores - second stage reduce
+                        for(uint32_t block = 0; block < num_blocks_second_stage - 1; ++block) {
+                            uint64_t noc_addr_ex = remote_noc_addrs_second_stage[block + 1] | l1_read_addr_ex;
+                            noc_async_read_one_packet(noc_addr_ex, l1_write_addr_external, single_tile_size_bytes);
+                            l1_write_addr_external += single_tile_size_bytes;
+                        }
+                        l1_read_addr_ex += single_tile_size_bytes;
+                        noc_async_read_barrier();
+                        cb_push_back(cb_external, num_blocks_second_stage - 1);
+                    }
+                }
+            }
+
+            // sync with the gather worker
+            cb_wait_front(cb_reduce_first_stage, num_tiles_per_partial_result*num_tiles_to_read);
+            noc_semaphore_inc(reduce_second_stage_receiver_semaphore_noc_addr, 1);
+        }
+
+    };
+    global_reduce_receiver(cb_ex_partial2, cb_ex_external2, cb_ex2, cb_ex2_global, cb_ex2);
+}

--- a/ttnn/cpp/ttnn/operations/normalization/layernorm/device/kernels/dataflow/reader_mcast_receiver_unary_sharded_ln_pre_allgather.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/layernorm/device/kernels/dataflow/reader_mcast_receiver_unary_sharded_ln_pre_allgather.cpp
@@ -6,8 +6,6 @@
 #include "dataflow_api.h"
 #include "hostdevcommon/common_values.hpp"
 
-#include "debug/dprint.h"
-
 
 // split REDUCE across cores
 void kernel_main() {

--- a/ttnn/cpp/ttnn/operations/normalization/layernorm/device/kernels/dataflow/reader_mcast_sender_unary_sharded_ln_post_allgather.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/layernorm/device/kernels/dataflow/reader_mcast_sender_unary_sharded_ln_post_allgather.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+// SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/ttnn/cpp/ttnn/operations/normalization/layernorm/device/kernels/dataflow/reader_mcast_sender_unary_sharded_ln_post_allgather.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/layernorm/device/kernels/dataflow/reader_mcast_sender_unary_sharded_ln_post_allgather.cpp
@@ -1,0 +1,141 @@
+// SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <stdint.h>
+#include "dataflow_api.h"
+#include "hostdevcommon/common_values.hpp"
+#include "debug/dprint.h"
+
+// split REDUCE across cores
+void kernel_main() {
+
+    uint32_t reduce_receiver_semaphore_addr       = get_semaphore(get_compile_time_arg_val(0));
+    uint32_t reduce_sender_semaphore_addr         = get_semaphore(get_compile_time_arg_val(1));
+    constexpr uint32_t num_blocks                           = get_compile_time_arg_val(2);
+    constexpr uint32_t block_h                              = get_compile_time_arg_val(3);
+    constexpr uint32_t block_h_size_bytes                   = get_compile_time_arg_val(4);
+    constexpr uint32_t num_all_to_all_workers_first_stage   = get_compile_time_arg_val(5);
+    constexpr uint32_t num_tiles_per_worker                 = get_compile_time_arg_val(6);
+    constexpr uint32_t num_tiles_per_worker_bytes           = get_compile_time_arg_val(7);
+    constexpr uint32_t num_tiles_per_worker_last            = get_compile_time_arg_val(8);
+    constexpr uint32_t num_tiles_per_worker_last_bytes      = get_compile_time_arg_val(9);
+    constexpr bool row_major                                = (bool) get_compile_time_arg_val(10);
+    constexpr uint32_t num_x                                = get_compile_time_arg_val(11);
+    constexpr uint32_t num_y                                = get_compile_time_arg_val(12);
+    constexpr bool use_two_stage_reduce                     = (bool) get_compile_time_arg_val(13);
+    constexpr uint32_t num_blocks_first_stage               = get_compile_time_arg_val(14);
+    constexpr uint32_t num_blocks_second_stage              = get_compile_time_arg_val(15);
+    uint32_t reduce_second_stage_semaphore_addr   = get_semaphore(get_compile_time_arg_val(16));
+
+    const uint32_t mcast_dest_noc_start_x               = get_arg_val<uint32_t>(0);
+    const uint32_t mcast_dest_noc_start_y               = get_arg_val<uint32_t>(1);
+    const uint32_t mcast_dest_noc_end_x                 = get_arg_val<uint32_t>(2);
+    const uint32_t mcast_dest_noc_end_y                 = get_arg_val<uint32_t>(3);
+    const uint32_t start_x                              = get_arg_val<uint32_t>(4);
+    const uint32_t start_y                              = get_arg_val<uint32_t>(5);
+
+    tt_l1_ptr uint32_t * in0_remote_noc_x          = (tt_l1_ptr uint32_t*)(get_arg_addr(6));
+    tt_l1_ptr uint32_t * in0_remote_noc_y          = (tt_l1_ptr uint32_t*)(get_arg_addr(6 + num_x));
+
+    constexpr uint32_t cb_ex_partial = tt::CB::dataflow0;
+    constexpr uint32_t cb_ex = tt::CB::dataflow1;
+    constexpr uint32_t cb_ex_external = tt::CB::dataflow2;
+    constexpr uint32_t cb_ex_partial2 = tt::CB::dataflow3;
+    constexpr uint32_t cb_stats = tt::CB::c_in7;
+    constexpr uint32_t cb_stats2 = tt::CB::c_intermed4; // E[(x-E[x])^2] global reduce
+    constexpr uint32_t cb_ex_external2 = tt::CB::dataflow5;
+    constexpr uint32_t cb_ex2pe = tt::CB::c_intermed3;
+    constexpr uint32_t cb_ex_global = tt::CB::dataflow7; // E[x] global reduce
+    constexpr uint32_t cb_ex2_global = tt::CB::dataflow6; // E[x2] global reduce
+
+    const uint32_t single_tile_size_bytes = get_tile_size(cb_ex_partial2);
+    const DataFormat data_format = get_dataformat(cb_ex_partial2);
+
+    uint64_t remote_noc_addrs[num_blocks];
+
+    uint32_t x = start_x, y = start_y;
+    for (uint32_t i = 0; i < num_blocks; ++i) {
+        remote_noc_addrs[i] = get_noc_addr(in0_remote_noc_x[x], in0_remote_noc_y[y], 0);
+        if constexpr(row_major) {
+            ++x;
+            if (x == num_x) {
+                x = 0;
+                ++y;
+                if (y == num_y) {
+                    y = 0;
+                }
+            }
+        } else {
+            ++y;
+            if (y == num_y) {
+                y = 0;
+                ++x;
+                if (x == num_x) {
+                    x = 0;
+                }
+            }
+        }
+    }
+
+    const uint64_t multicast_data_noc = get_noc_multicast_addr(
+        mcast_dest_noc_start_x,
+        mcast_dest_noc_start_y,
+        mcast_dest_noc_end_x,
+        mcast_dest_noc_end_y,
+        0);
+
+    const uint64_t reduce_sender_semaphore_noc_addr = multicast_data_noc | reduce_sender_semaphore_addr;
+    #ifdef RMSNORM
+    constexpr uint32_t stats_tiles = 1;
+    #else
+    constexpr uint32_t stats_tiles = 2;
+    #endif
+
+    volatile tt_l1_ptr uint32_t* reduce_sender_semaphore_addr_ptr = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(reduce_sender_semaphore_addr);
+    volatile tt_l1_ptr uint32_t* reduce_receiver_semaphore_addr_ptr = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(reduce_receiver_semaphore_addr);
+    volatile tt_l1_ptr uint32_t* reduce_second_stage_semaphore_addr_ptr = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(reduce_second_stage_semaphore_addr);
+     const auto& global_semaphore_set = [&]() __attribute__((always_inline))
+    {
+        *reduce_sender_semaphore_addr_ptr = VALID;
+
+        noc_semaphore_set_multicast_loopback_src(
+                            reduce_sender_semaphore_addr,
+                            reduce_sender_semaphore_noc_addr,
+                            num_blocks,
+                            false,
+                            false);
+    };
+
+    const auto& global_reduce_sender = [&](const uint32_t cb_ex, const uint32_t cb_ex_global) __attribute__((always_inline))
+    {
+        // global reduce
+
+
+        uint32_t l1_read_addr_ex = get_read_ptr(cb_ex);
+        uint32_t l1_read_addr_ex_global = get_read_ptr(cb_ex_global);
+        // noc_semaphore_wait(reduce_receiver_semaphore_addr_ptr, num_blocks);
+        // noc_semaphore_set(reduce_receiver_semaphore_addr_ptr, 0);
+        noc_async_write_multicast_loopback_src(
+                            l1_read_addr_ex,
+                            multicast_data_noc | l1_read_addr_ex_global,
+                            stats_tiles*num_tiles_per_worker_bytes,
+                            num_blocks,
+                            false,
+                            false);
+        noc_async_write_barrier();
+
+    };
+
+
+    DPRINT << " Before Ex2 global mcast" << ENDL();
+    cb_wait_front(cb_stats2, stats_tiles*block_h);
+    DPRINT << " Before Ex2pe  global mcast" << ENDL();
+    cb_reserve_back(cb_ex2_global, block_h);
+    global_reduce_sender(cb_stats2, cb_ex2_global);
+    cb_push_back(cb_ex2_global, stats_tiles*block_h);
+    cb_pop_front(cb_stats2, stats_tiles*block_h);
+    global_semaphore_set();
+    DPRINT << "Sender core 0,0 done" << ENDL();
+
+}

--- a/ttnn/cpp/ttnn/operations/normalization/layernorm/device/kernels/dataflow/reader_mcast_sender_unary_sharded_ln_post_allgather.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/layernorm/device/kernels/dataflow/reader_mcast_sender_unary_sharded_ln_post_allgather.cpp
@@ -42,7 +42,7 @@ void kernel_main() {
     constexpr uint32_t cb_ex_external = tt::CB::dataflow2;
     constexpr uint32_t cb_ex_partial2 = tt::CB::dataflow3;
     constexpr uint32_t cb_stats = tt::CB::c_in7;
-    constexpr uint32_t cb_stats2 = tt::CB::c_intermed4; // E[(x-E[x])^2] global reduce
+    constexpr uint32_t cb_stats_reduced = tt::CB::c_intermed4; // E[(x-E[x])^2] global reduce
     constexpr uint32_t cb_ex_external2 = tt::CB::dataflow5;
     constexpr uint32_t cb_ex2pe = tt::CB::c_intermed3;
     constexpr uint32_t cb_ex_global = tt::CB::dataflow7; // E[x] global reduce
@@ -127,11 +127,11 @@ void kernel_main() {
     };
 
 
-    cb_wait_front(cb_stats2, stats_tiles*block_h);
-    cb_reserve_back(cb_ex2_global, block_h);
-    global_reduce_sender(cb_stats2, cb_ex2_global);
-    cb_push_back(cb_ex2_global, stats_tiles*block_h);
-    cb_pop_front(cb_stats2, stats_tiles*block_h);
+    cb_wait_front(cb_stats_reduced, stats_tiles*block_h);
+    cb_reserve_back(cb_ex_global, block_h);
+    global_reduce_sender(cb_stats_reduced, cb_ex_global);
+    cb_push_back(cb_ex_global, stats_tiles*block_h);
+    cb_pop_front(cb_stats_reduced, stats_tiles*block_h);
     global_semaphore_set();
 
 }

--- a/ttnn/cpp/ttnn/operations/normalization/layernorm/device/kernels/dataflow/reader_mcast_sender_unary_sharded_ln_post_allgather.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/layernorm/device/kernels/dataflow/reader_mcast_sender_unary_sharded_ln_post_allgather.cpp
@@ -9,73 +9,21 @@
 // split REDUCE across cores
 void kernel_main() {
 
-    uint32_t reduce_receiver_semaphore_addr       = get_semaphore(get_compile_time_arg_val(0));
     uint32_t reduce_sender_semaphore_addr         = get_semaphore(get_compile_time_arg_val(1));
     constexpr uint32_t num_blocks                           = get_compile_time_arg_val(2);
     constexpr uint32_t block_h                              = get_compile_time_arg_val(3);
     constexpr uint32_t block_h_size_bytes                   = get_compile_time_arg_val(4);
-    constexpr uint32_t num_all_to_all_workers_first_stage   = get_compile_time_arg_val(5);
     constexpr uint32_t num_tiles_per_worker                 = get_compile_time_arg_val(6);
     constexpr uint32_t num_tiles_per_worker_bytes           = get_compile_time_arg_val(7);
-    constexpr uint32_t num_tiles_per_worker_last            = get_compile_time_arg_val(8);
-    constexpr uint32_t num_tiles_per_worker_last_bytes      = get_compile_time_arg_val(9);
-    constexpr bool row_major                                = (bool) get_compile_time_arg_val(10);
-    constexpr uint32_t num_x                                = get_compile_time_arg_val(11);
-    constexpr uint32_t num_y                                = get_compile_time_arg_val(12);
-    constexpr bool use_two_stage_reduce                     = (bool) get_compile_time_arg_val(13);
-    constexpr uint32_t num_blocks_first_stage               = get_compile_time_arg_val(14);
-    constexpr uint32_t num_blocks_second_stage              = get_compile_time_arg_val(15);
-    uint32_t reduce_second_stage_semaphore_addr   = get_semaphore(get_compile_time_arg_val(16));
 
     const uint32_t mcast_dest_noc_start_x               = get_arg_val<uint32_t>(0);
     const uint32_t mcast_dest_noc_start_y               = get_arg_val<uint32_t>(1);
     const uint32_t mcast_dest_noc_end_x                 = get_arg_val<uint32_t>(2);
     const uint32_t mcast_dest_noc_end_y                 = get_arg_val<uint32_t>(3);
-    const uint32_t start_x                              = get_arg_val<uint32_t>(4);
-    const uint32_t start_y                              = get_arg_val<uint32_t>(5);
 
-    tt_l1_ptr uint32_t * in0_remote_noc_x          = (tt_l1_ptr uint32_t*)(get_arg_addr(6));
-    tt_l1_ptr uint32_t * in0_remote_noc_y          = (tt_l1_ptr uint32_t*)(get_arg_addr(6 + num_x));
 
-    constexpr uint32_t cb_ex_partial = tt::CB::dataflow0;
-    constexpr uint32_t cb_ex = tt::CB::dataflow1;
-    constexpr uint32_t cb_ex_external = tt::CB::dataflow2;
-    constexpr uint32_t cb_ex_partial2 = tt::CB::dataflow3;
-    constexpr uint32_t cb_stats = tt::CB::c_in7;
-    constexpr uint32_t cb_stats_reduced = tt::CB::c_intermed4; // E[(x-E[x])^2] global reduce
-    constexpr uint32_t cb_ex_external2 = tt::CB::dataflow5;
-    constexpr uint32_t cb_ex2pe = tt::CB::c_intermed3;
-    constexpr uint32_t cb_ex_global = tt::CB::dataflow7; // E[x] global reduce
-    constexpr uint32_t cb_ex2_global = tt::CB::dataflow6; // E[x2] global reduce
-
-    const uint32_t single_tile_size_bytes = get_tile_size(cb_ex_partial2);
-    const DataFormat data_format = get_dataformat(cb_ex_partial2);
-
-    uint64_t remote_noc_addrs[num_blocks];
-
-    uint32_t x = start_x, y = start_y;
-    for (uint32_t i = 0; i < num_blocks; ++i) {
-        remote_noc_addrs[i] = get_noc_addr(in0_remote_noc_x[x], in0_remote_noc_y[y], 0);
-        if constexpr(row_major) {
-            ++x;
-            if (x == num_x) {
-                x = 0;
-                ++y;
-                if (y == num_y) {
-                    y = 0;
-                }
-            }
-        } else {
-            ++y;
-            if (y == num_y) {
-                y = 0;
-                ++x;
-                if (x == num_x) {
-                    x = 0;
-                }
-            }
-        }
-    }
+    constexpr uint32_t cb_stats_reduced = tt::CB::c_intermed4; // [E[x], E[x^2]] local to sender
+    constexpr uint32_t cb_ex_global = tt::CB::dataflow7; // [E[x], E[X^2]] global to all cores
 
     const uint64_t multicast_data_noc = get_noc_multicast_addr(
         mcast_dest_noc_start_x,
@@ -92,8 +40,6 @@ void kernel_main() {
     #endif
 
     volatile tt_l1_ptr uint32_t* reduce_sender_semaphore_addr_ptr = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(reduce_sender_semaphore_addr);
-    volatile tt_l1_ptr uint32_t* reduce_receiver_semaphore_addr_ptr = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(reduce_receiver_semaphore_addr);
-    volatile tt_l1_ptr uint32_t* reduce_second_stage_semaphore_addr_ptr = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(reduce_second_stage_semaphore_addr);
      const auto& global_semaphore_set = [&]() __attribute__((always_inline))
     {
         *reduce_sender_semaphore_addr_ptr = VALID;
@@ -108,13 +54,8 @@ void kernel_main() {
 
     const auto& global_reduce_sender = [&](const uint32_t cb_ex, const uint32_t cb_ex_global) __attribute__((always_inline))
     {
-        // global reduce
-
-
         uint32_t l1_read_addr_ex = get_read_ptr(cb_ex);
         uint32_t l1_read_addr_ex_global = get_read_ptr(cb_ex_global);
-        // noc_semaphore_wait(reduce_receiver_semaphore_addr_ptr, num_blocks);
-        // noc_semaphore_set(reduce_receiver_semaphore_addr_ptr, 0);
         noc_async_write_multicast_loopback_src(
                             l1_read_addr_ex,
                             multicast_data_noc | l1_read_addr_ex_global,

--- a/ttnn/cpp/ttnn/operations/normalization/layernorm/device/kernels/dataflow/reader_mcast_sender_unary_sharded_ln_post_allgather.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/layernorm/device/kernels/dataflow/reader_mcast_sender_unary_sharded_ln_post_allgather.cpp
@@ -5,7 +5,6 @@
 #include <stdint.h>
 #include "dataflow_api.h"
 #include "hostdevcommon/common_values.hpp"
-#include "debug/dprint.h"
 
 // split REDUCE across cores
 void kernel_main() {
@@ -128,14 +127,11 @@ void kernel_main() {
     };
 
 
-    DPRINT << " Before Ex2 global mcast" << ENDL();
     cb_wait_front(cb_stats2, stats_tiles*block_h);
-    DPRINT << " Before Ex2pe  global mcast" << ENDL();
     cb_reserve_back(cb_ex2_global, block_h);
     global_reduce_sender(cb_stats2, cb_ex2_global);
     cb_push_back(cb_ex2_global, stats_tiles*block_h);
     cb_pop_front(cb_stats2, stats_tiles*block_h);
     global_semaphore_set();
-    DPRINT << "Sender core 0,0 done" << ENDL();
 
 }

--- a/ttnn/cpp/ttnn/operations/normalization/layernorm/device/kernels/dataflow/reader_mcast_sender_unary_sharded_ln_pre_allgather.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/layernorm/device/kernels/dataflow/reader_mcast_sender_unary_sharded_ln_pre_allgather.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+// SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/ttnn/cpp/ttnn/operations/normalization/layernorm/device/kernels/dataflow/reader_mcast_sender_unary_sharded_ln_pre_allgather.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/layernorm/device/kernels/dataflow/reader_mcast_sender_unary_sharded_ln_pre_allgather.cpp
@@ -41,7 +41,6 @@ void kernel_main() {
     constexpr uint32_t cb_ex_partial2 = tt::CB::dataflow3;
     constexpr uint32_t cb_ex2 = tt::CB::dataflow4;
     constexpr uint32_t cb_ex_external2 = tt::CB::dataflow5;
-    constexpr uint32_t cb_ex2pe = tt::CB::c_intermed3;
     constexpr uint32_t cb_ex2_global = tt::CB::dataflow6; // E[x2] global reduce
 
     const uint32_t single_tile_size_bytes = get_tile_size(cb_ex_partial2);
@@ -86,7 +85,7 @@ void kernel_main() {
     volatile tt_l1_ptr uint32_t* reduce_receiver_semaphore_addr_ptr = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(reduce_receiver_semaphore_addr);
     volatile tt_l1_ptr uint32_t* reduce_second_stage_semaphore_addr_ptr = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(reduce_second_stage_semaphore_addr);
 
-    const auto& global_reduce_sender = [&](const uint32_t cb_partial, const uint32_t cb_external, const uint32_t cb_ex, const uint32_t cb_ex_global, const uint32_t cb_reduce_first_stage) __attribute__((always_inline))
+    const auto& global_reduce_sender = [&](const uint32_t cb_partial, const uint32_t cb_external, const uint32_t cb_reduce_first_stage) __attribute__((always_inline))
     {
         uint32_t num_tiles_per_partial_result = 2;
         #ifdef RMSNORM
@@ -157,5 +156,5 @@ void kernel_main() {
         }
 
     };
-    global_reduce_sender(cb_ex_partial2, cb_ex_external2, cb_ex2, cb_ex2_global, cb_ex2);
+    global_reduce_sender(cb_ex_partial2, cb_ex_external2, cb_ex2);
 }

--- a/ttnn/cpp/ttnn/operations/normalization/layernorm/device/kernels/dataflow/reader_mcast_sender_unary_sharded_ln_pre_allgather.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/layernorm/device/kernels/dataflow/reader_mcast_sender_unary_sharded_ln_pre_allgather.cpp
@@ -6,9 +6,6 @@
 #include "dataflow_api.h"
 #include "hostdevcommon/common_values.hpp"
 
-#include "debug/dprint.h"
-
-
 // split REDUCE across cores
 void kernel_main() {
 

--- a/ttnn/cpp/ttnn/operations/normalization/layernorm/device/kernels/dataflow/reader_mcast_sender_unary_sharded_ln_pre_allgather.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/layernorm/device/kernels/dataflow/reader_mcast_sender_unary_sharded_ln_pre_allgather.cpp
@@ -1,0 +1,164 @@
+// SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <stdint.h>
+#include "dataflow_api.h"
+#include "hostdevcommon/common_values.hpp"
+
+#include "debug/dprint.h"
+
+
+// split REDUCE across cores
+void kernel_main() {
+
+    uint32_t reduce_receiver_semaphore_addr       = get_semaphore(get_compile_time_arg_val(0));
+    uint32_t reduce_sender_semaphore_addr         = get_semaphore(get_compile_time_arg_val(1));
+    constexpr uint32_t num_blocks                           = get_compile_time_arg_val(2);
+    constexpr uint32_t block_h                              = get_compile_time_arg_val(3);
+    constexpr uint32_t block_h_size_bytes                   = get_compile_time_arg_val(4);
+    constexpr uint32_t num_all_to_all_workers_first_stage   = get_compile_time_arg_val(5);
+    constexpr uint32_t num_tiles_per_worker                 = get_compile_time_arg_val(6);
+    constexpr uint32_t num_tiles_per_worker_bytes           = get_compile_time_arg_val(7);
+    constexpr uint32_t num_tiles_per_worker_last            = get_compile_time_arg_val(8);
+    constexpr uint32_t num_tiles_per_worker_last_bytes      = get_compile_time_arg_val(9);
+    constexpr bool row_major                                = (bool) get_compile_time_arg_val(10);
+    constexpr uint32_t num_x                                = get_compile_time_arg_val(11);
+    constexpr uint32_t num_y                                = get_compile_time_arg_val(12);
+    constexpr bool use_two_stage_reduce                     = (bool) get_compile_time_arg_val(13);
+    constexpr uint32_t num_blocks_first_stage               = get_compile_time_arg_val(14);
+    constexpr uint32_t num_blocks_second_stage              = get_compile_time_arg_val(15);
+    uint32_t reduce_second_stage_semaphore_addr   = get_semaphore(get_compile_time_arg_val(16));
+
+    const uint32_t mcast_dest_noc_start_x               = get_arg_val<uint32_t>(0);
+    const uint32_t mcast_dest_noc_start_y               = get_arg_val<uint32_t>(1);
+    const uint32_t mcast_dest_noc_end_x                 = get_arg_val<uint32_t>(2);
+    const uint32_t mcast_dest_noc_end_y                 = get_arg_val<uint32_t>(3);
+    const uint32_t start_x                              = get_arg_val<uint32_t>(4);
+    const uint32_t start_y                              = get_arg_val<uint32_t>(5);
+
+    tt_l1_ptr uint32_t * in0_remote_noc_x          = (tt_l1_ptr uint32_t*)(get_arg_addr(6));
+    tt_l1_ptr uint32_t * in0_remote_noc_y          = (tt_l1_ptr uint32_t*)(get_arg_addr(6 + num_x));
+
+
+    constexpr uint32_t cb_ex_partial2 = tt::CB::dataflow3;
+    constexpr uint32_t cb_ex2 = tt::CB::dataflow4;
+    constexpr uint32_t cb_ex_external2 = tt::CB::dataflow5;
+    constexpr uint32_t cb_ex2pe = tt::CB::c_intermed3;
+    constexpr uint32_t cb_ex2_global = tt::CB::dataflow6; // E[x2] global reduce
+
+    const uint32_t single_tile_size_bytes = get_tile_size(cb_ex_partial2);
+    const DataFormat data_format = get_dataformat(cb_ex_partial2);
+
+    uint64_t remote_noc_addrs[num_blocks];
+
+    uint32_t x = start_x, y = start_y;
+    for (uint32_t i = 0; i < num_blocks; ++i) {
+        remote_noc_addrs[i] = get_noc_addr(in0_remote_noc_x[x], in0_remote_noc_y[y], 0);
+        if constexpr(row_major) {
+            ++x;
+            if (x == num_x) {
+                x = 0;
+                ++y;
+                if (y == num_y) {
+                    y = 0;
+                }
+            }
+        } else {
+            ++y;
+            if (y == num_y) {
+                y = 0;
+                ++x;
+                if (x == num_x) {
+                    x = 0;
+                }
+            }
+        }
+    }
+
+    const uint64_t multicast_data_noc = get_noc_multicast_addr(
+        mcast_dest_noc_start_x,
+        mcast_dest_noc_start_y,
+        mcast_dest_noc_end_x,
+        mcast_dest_noc_end_y,
+        0);
+
+    const uint64_t reduce_sender_semaphore_noc_addr = multicast_data_noc | reduce_sender_semaphore_addr;
+
+    volatile tt_l1_ptr uint32_t* reduce_sender_semaphore_addr_ptr = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(reduce_sender_semaphore_addr);
+    volatile tt_l1_ptr uint32_t* reduce_receiver_semaphore_addr_ptr = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(reduce_receiver_semaphore_addr);
+    volatile tt_l1_ptr uint32_t* reduce_second_stage_semaphore_addr_ptr = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(reduce_second_stage_semaphore_addr);
+
+    const auto& global_reduce_sender = [&](const uint32_t cb_partial, const uint32_t cb_external, const uint32_t cb_ex, const uint32_t cb_ex_global, const uint32_t cb_reduce_first_stage) __attribute__((always_inline))
+    {
+        uint32_t num_tiles_per_partial_result = 2;
+        #ifdef RMSNORM
+        num_tiles_per_partial_result = 1;
+        #endif
+
+        // global reduce
+        // wait for local data ready
+        cb_wait_front(cb_partial, num_tiles_per_partial_result*block_h); // TODO test for layernorm
+
+        // inc semaphore of other cores, tell other all-to-all workers to start
+        if constexpr(num_blocks > 1) {
+            *reduce_sender_semaphore_addr_ptr = VALID;
+            noc_semaphore_wait(reduce_receiver_semaphore_addr_ptr, num_blocks-1);
+            noc_semaphore_set(reduce_receiver_semaphore_addr_ptr, 0);
+            noc_semaphore_set_multicast(reduce_sender_semaphore_addr, reduce_sender_semaphore_noc_addr, num_blocks-1);
+        }
+
+        // read data from other cores - first stage reduce
+        uint32_t l1_read_addr_ex_par = get_read_ptr(cb_partial);
+        // read data from other cores - second stage reduce
+        uint32_t l1_read_addr_ex = 0;
+        uint32_t block_index_stride = 0;
+        if constexpr(use_two_stage_reduce) {
+            l1_read_addr_ex = get_read_ptr(cb_reduce_first_stage);
+            if constexpr(row_major) {
+                block_index_stride = num_x;
+            } else {
+                block_index_stride = num_y;
+            }
+        }
+        // read from both stage
+        for (uint32_t i = 0; i < num_tiles_per_worker; ++i) {
+            // first stage
+            cb_reserve_back(cb_external, num_blocks_first_stage);
+            uint32_t l1_write_addr_external = get_write_ptr(cb_external);
+            for(uint32_t block = 0; block < num_blocks_first_stage; ++block) {
+                for(uint32_t tile_idx = 0; tile_idx < num_tiles_per_partial_result; ++tile_idx) {
+                    uint64_t noc_addr_ex_par = remote_noc_addrs[block] | (l1_read_addr_ex_par + tile_idx * single_tile_size_bytes);
+                    noc_async_read_one_packet(noc_addr_ex_par, l1_write_addr_external, single_tile_size_bytes);
+                    l1_write_addr_external += single_tile_size_bytes;
+                }
+            }
+            l1_read_addr_ex_par += single_tile_size_bytes;
+            noc_async_read_barrier();
+            cb_push_back(cb_external, num_tiles_per_partial_result*num_blocks_first_stage);
+
+            // sync with second-stage all-to-all workers
+            if constexpr(use_two_stage_reduce) {
+                if (i == 0) {
+                    noc_semaphore_wait(reduce_second_stage_semaphore_addr_ptr, num_blocks_second_stage-1);
+                    noc_semaphore_set(reduce_second_stage_semaphore_addr_ptr, 0);
+                }
+
+                uint32_t curr_block_index = block_index_stride;
+                for(uint32_t block = 0; block < num_blocks_second_stage - 1; ++block) {
+                    for(uint32_t tile_idx = 0; tile_idx < num_tiles_per_partial_result; ++tile_idx) {
+                        uint64_t noc_addr_ex = remote_noc_addrs[curr_block_index] | (l1_read_addr_ex + tile_idx * single_tile_size_bytes);
+                        noc_async_read_one_packet(noc_addr_ex, l1_write_addr_external, single_tile_size_bytes);
+                        l1_write_addr_external += single_tile_size_bytes;
+                    }
+                    curr_block_index += block_index_stride;
+                }
+                l1_read_addr_ex += single_tile_size_bytes;
+                noc_async_read_barrier();
+                cb_push_back(cb_external, num_tiles_per_partial_result * (num_blocks_second_stage - 1)); // push back partials from all cores -> compute can start reducing now
+            }
+        }
+
+    };
+    global_reduce_sender(cb_ex_partial2, cb_ex_external2, cb_ex2, cb_ex2_global, cb_ex2);
+}

--- a/ttnn/cpp/ttnn/operations/normalization/layernorm/device/kernels/dataflow/writer_unary_sharded_ln_pre_all_gather.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/layernorm/device/kernels/dataflow/writer_unary_sharded_ln_pre_all_gather.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+// SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/ttnn/cpp/ttnn/operations/normalization/layernorm/device/kernels/dataflow/writer_unary_sharded_ln_pre_all_gather.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/layernorm/device/kernels/dataflow/writer_unary_sharded_ln_pre_all_gather.cpp
@@ -1,0 +1,22 @@
+// SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <stdint.h>
+#include "dataflow_api.h"
+#include "hostdevcommon/common_values.hpp"
+#include "ttnn/cpp/ttnn/deprecated/tt_dnn/kernels/dataflow/generate_reduce_scaler.hpp"
+
+
+void kernel_main() {
+    constexpr bool is_all_to_all_worker = get_compile_time_arg_val(0) == 1;
+    constexpr uint32_t cb_in_2 = tt::CB::c_in2;
+    const uint32_t scalar_w = get_arg_val<uint32_t>(1);
+    generate_reduce_scaler(cb_in_2, scalar_w);
+
+    if constexpr(is_all_to_all_worker) {
+        constexpr uint32_t cb_in_4 = tt::CB::c_in4;
+        const uint32_t scalar_c = get_arg_val<uint32_t>(0);
+        generate_reduce_scaler(cb_in_4, scalar_c);
+    }
+}

--- a/ttnn/cpp/ttnn/operations/normalization/layernorm/device/layernorm_op.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/layernorm/device/layernorm_op.cpp
@@ -180,6 +180,10 @@ std::vector<Tensor> LayerNorm::create_output_tensors(const std::vector<Tensor> &
                     auto output_shape = this->compute_output_shapes(input_tensors).at(0);
                     auto shard_spec = input_tensor.shard_spec().value();
                     shard_spec.shape[1] = output_shape[3];
+
+                    CoreRange first_core_range(CoreCoord(0, 0), CoreCoord(1, 1));
+                    CoreRangeSet core_range_set({first_core_range});
+                    shard_spec.grid = core_range_set;
                     auto mem_config = this->output_mem_config;
                     mem_config.shard_spec = shard_spec;
                     return {

--- a/ttnn/cpp/ttnn/operations/normalization/layernorm/device/layernorm_op.hpp
+++ b/ttnn/cpp/ttnn/operations/normalization/layernorm/device/layernorm_op.hpp
@@ -31,8 +31,10 @@ operation::ProgramWithCallbacks layernorm_multi_core_sharded(
     const std::optional<const Tensor> b,
     const std::optional<const Tensor> gamma,
     const std::optional<const Tensor> beta,
+    const std::optional<const Tensor> stats,
     Tensor& output,
     LayerNormType norm_type,
+    DistributedLayerNormStage distributed_norm_stage,
     float eps,
     CoreCoord compute_grid_size,
     uint32_t subblock_wt,
@@ -43,6 +45,7 @@ operation::ProgramWithCallbacks layernorm_multi_core_sharded(
 
 struct LayerNorm {
     LayerNormType norm_type;
+    DistributedLayerNormStage distributed_norm_stage;
     float eps;
     MemoryConfig output_mem_config;
     LayerNormProgramConfig program_config;

--- a/ttnn/cpp/ttnn/operations/normalization/layernorm/device/layernorm_types.hpp
+++ b/ttnn/cpp/ttnn/operations/normalization/layernorm/device/layernorm_types.hpp
@@ -14,6 +14,10 @@ enum class LayerNormType {
     LAYERNORM, RMSNORM
 };
 
+enum class DistributedLayerNormStage {
+    NOT_DISTRIBUTED, PRE_ALL_GATHER, POST_ALL_GATHER
+};
+
 struct LayerNormDefaultProgramConfig{
 };
 struct LayerNormShardedMultiCoreProgramConfig {

--- a/ttnn/cpp/ttnn/operations/normalization/layernorm/device/multi_core/layernorm_op_multi_core.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/layernorm/device/multi_core/layernorm_op_multi_core.cpp
@@ -1168,8 +1168,13 @@ operation::ProgramWithCallbacks layernorm_multi_core_sharded(
     uint32_t output_cb_index = tt::CB::c_out0; // output operands start at index 16
     tt::tt_metal::CircularBufferConfig output_cb_config = tt::tt_metal::CircularBufferConfig(out_CB_size, {{output_cb_index, out_data_format}})
 		.set_page_size(output_cb_index, out_single_tile_size).set_globally_allocated_address(*output.buffer());
-    auto cb_output = tt::tt_metal::CreateCircularBuffer(program, all_cores, output_cb_config);
-
+    CBHandle cb_output = 0;
+    if (is_pre_all_gather) {
+        cb_output = tt::tt_metal::CreateCircularBuffer(program, sender_cores, output_cb_config);
+    }
+    else{
+        cb_output = tt::tt_metal::CreateCircularBuffer(program, all_cores, output_cb_config);
+    }
     const auto& cores = grid_to_cores(all_cores.num_cores(), num_cores_x, num_cores_y, row_wise);
 
     // Runtime Args

--- a/ttnn/cpp/ttnn/operations/normalization/layernorm/layernorm.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/layernorm/layernorm.cpp
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "layernorm.hpp"
+#include <optional>
 
 #include "device/layernorm_op.hpp"
 
@@ -22,12 +23,13 @@ ttnn::Tensor ExecuteLayerNorm::invoke(
     return operation::run(
                 LayerNorm{
                     .norm_type = LayerNormType::LAYERNORM,
+                    .distributed_norm_stage = DistributedLayerNormStage::NOT_DISTRIBUTED,
                     .eps = epsilon,
                     .output_mem_config = memory_config.value_or(input_tensor.memory_config()),
                     .program_config = program_config.value_or(LayerNormDefaultProgramConfig{}),
                     .compute_kernel_config = kernel_config_val},
                 {input_tensor},
-                {residual_input_tensor, weight, bias}).at(0);
+                {residual_input_tensor, weight, bias, std::nullopt}).at(0);
 }
 
 }  // namespace ttnn::operations::normalization

--- a/ttnn/cpp/ttnn/operations/normalization/layernorm_distributed/layernorm_distributed_pybind.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/layernorm_distributed/layernorm_distributed_pybind.cpp
@@ -24,7 +24,9 @@ void bind_normalization_layernorm_pre_all_gather_operation(py::module& module) {
             py::arg("input_tensor"),
             py::kw_only(),
             py::arg("dtype") = DataType::BFLOAT16,
-            py::arg("compute_kernel_config") = std::nullopt});
+            py::arg("compute_kernel_config") = std::nullopt,
+            py::arg("program_config") = std::nullopt,
+            py::arg("memory_config") = std::nullopt});
 }
 
 void bind_normalization_layernorm_post_all_gather_operation(py::module& module) {
@@ -43,7 +45,8 @@ void bind_normalization_layernorm_post_all_gather_operation(py::module& module) 
             py::arg("weight") = std::nullopt,
             py::arg("bias") = std::nullopt,
             py::arg("memory_config") = std::nullopt,
-            py::arg("compute_kernel_config") = std::nullopt});
+            py::arg("compute_kernel_config") = std::nullopt,
+            py::arg("program_config") = std::nullopt});
 }
 
 void bind_normalization_layernorm_distributed(py::module& module) {

--- a/ttnn/cpp/ttnn/operations/normalization/layernorm_distributed/layernorm_post_all_gather.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/layernorm_distributed/layernorm_post_all_gather.cpp
@@ -6,6 +6,7 @@
 
 #include "device/layernorm_post_all_gather_op.hpp"
 
+#include "ttnn/operations/normalization/layernorm/device/layernorm_op.hpp"
 namespace ttnn::operations::normalization {
 
 ttnn::Tensor ExecuteLayerNormPostAllGather::invoke(
@@ -15,17 +16,31 @@ ttnn::Tensor ExecuteLayerNormPostAllGather::invoke(
     const std::optional<const ttnn::Tensor>& weight,
     const std::optional<const ttnn::Tensor>& bias,
     const std::optional<MemoryConfig>& memory_config,
-    const std::optional<const DeviceComputeKernelConfig> compute_kernel_config) {
+    const std::optional<const DeviceComputeKernelConfig> compute_kernel_config,
+    const std::optional<const LayerNormProgramConfig>& program_config) {
     auto arch = input_tensor.storage_type() == StorageType::DEVICE ? input_tensor.device()->arch() : ttnn::operations::experimental::auto_format::AutoFormat::GetDefaultDevice()->arch();
     auto kernel_config_val = init_device_compute_kernel_config(arch, compute_kernel_config, MathFidelity::HiFi4, true, false, false);
-    return operation::run(
-                LayerNormPostAllGather{
-                    .norm_type = LayerNormDistributedType::LAYERNORM,
+    if (input_tensor.is_sharded()) {
+        return operation::run(
+                LayerNorm{
+                    .norm_type = LayerNormType::LAYERNORM,
+                    .distributed_norm_stage = DistributedLayerNormStage::POST_ALL_GATHER,
                     .eps = epsilon,
-                    .memory_config = memory_config.value_or(input_tensor.memory_config()),
+                    .output_mem_config = memory_config.value_or(input_tensor.memory_config()),
+                    .program_config = program_config.value_or(LayerNormDefaultProgramConfig{}),
                     .compute_kernel_config = kernel_config_val},
-                {input_tensor, stats},
-                {weight, bias}).at(0);
+                {input_tensor},
+                {std::nullopt, weight, bias, stats}).at(0);
+    } else {
+        return operation::run(
+                    LayerNormPostAllGather{
+                        .norm_type = LayerNormDistributedType::LAYERNORM,
+                        .eps = epsilon,
+                        .memory_config = memory_config.value_or(input_tensor.memory_config()),
+                        .compute_kernel_config = kernel_config_val},
+                    {input_tensor, stats},
+                    {weight, bias}).at(0);
+    }
 }
 
 }  // namespace ttnn::operations::normalization

--- a/ttnn/cpp/ttnn/operations/normalization/layernorm_distributed/layernorm_post_all_gather.hpp
+++ b/ttnn/cpp/ttnn/operations/normalization/layernorm_distributed/layernorm_post_all_gather.hpp
@@ -6,7 +6,7 @@
 
 #include "ttnn/decorators.hpp"
 #include "device/layernorm_distributed_types.hpp"
-
+#include "ttnn/operations/normalization/layernorm/device/layernorm_types.hpp"
 #include "ttnn/operations/core/compute_kernel/compute_kernel_config.hpp"
 
 namespace ttnn {
@@ -20,7 +20,8 @@ struct ExecuteLayerNormPostAllGather {
         const std::optional<const ttnn::Tensor>& weight = std::nullopt,
         const std::optional<const ttnn::Tensor>& bias = std::nullopt,
         const std::optional<MemoryConfig>& memory_config = std::nullopt,
-        const std::optional<const DeviceComputeKernelConfig> compute_kernel_config = std::nullopt);
+        const std::optional<const DeviceComputeKernelConfig> compute_kernel_config = std::nullopt,
+        const std::optional<const LayerNormProgramConfig>& program_config = std::nullopt);
 };
 
 }  // namespace operations::normalization

--- a/ttnn/cpp/ttnn/operations/normalization/layernorm_distributed/layernorm_pre_all_gather.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/layernorm_distributed/layernorm_pre_all_gather.cpp
@@ -5,21 +5,39 @@
 #include "layernorm_pre_all_gather.hpp"
 
 #include "device/layernorm_pre_all_gather_op.hpp"
+#include "ttnn/operations/normalization/layernorm/device/layernorm_op.hpp"
 
 namespace ttnn::operations::normalization {
 
 ttnn::Tensor ExecuteLayerNormPreAllGather::invoke(
     const ttnn::Tensor& input_tensor,
     const DataType dtype,
-    const std::optional<const DeviceComputeKernelConfig> compute_kernel_config) {
+    const std::optional<const DeviceComputeKernelConfig> compute_kernel_config,
+    const std::optional<const LayerNormProgramConfig>& program_config,
+    const std::optional<MemoryConfig>& memory_config) {
     auto arch = input_tensor.storage_type() == StorageType::DEVICE ? input_tensor.device()->arch() : ttnn::operations::experimental::auto_format::AutoFormat::GetDefaultDevice()->arch();
     auto kernel_config_val = init_device_compute_kernel_config(arch, compute_kernel_config, MathFidelity::HiFi4, true, false, false);
-    return operation::run(
-                LayerNormPreAllGather{
-                    .norm_type = LayerNormDistributedType::LAYERNORM,
-                    .dtype = dtype,
+    if(input_tensor.is_sharded()){
+        std::cout<< " Running LayerNorm and PRE_ALL_GATHER"<<std::endl;
+        return operation::run(
+                LayerNorm{
+                    .norm_type = LayerNormType::LAYERNORM,
+                    .distributed_norm_stage = DistributedLayerNormStage::PRE_ALL_GATHER,
+                    .eps = 1e-12,
+                    .output_mem_config = memory_config.value_or(input_tensor.memory_config()),
+                    .program_config = program_config.value_or(LayerNormDefaultProgramConfig{}),
                     .compute_kernel_config = kernel_config_val},
-                {input_tensor}).at(0);
+                {input_tensor},
+                {std::nullopt, std::nullopt, std::nullopt, std::nullopt}).at(0);
+    }
+    else{
+        return operation::run(
+                    LayerNormPreAllGather{
+                        .norm_type = LayerNormDistributedType::LAYERNORM,
+                        .dtype = dtype,
+                        .compute_kernel_config = kernel_config_val},
+                    {input_tensor}).at(0);
+    }
 }
 
 }  // namespace ttnn::operations::normalization

--- a/ttnn/cpp/ttnn/operations/normalization/layernorm_distributed/layernorm_pre_all_gather.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/layernorm_distributed/layernorm_pre_all_gather.cpp
@@ -18,7 +18,6 @@ ttnn::Tensor ExecuteLayerNormPreAllGather::invoke(
     auto arch = input_tensor.storage_type() == StorageType::DEVICE ? input_tensor.device()->arch() : ttnn::operations::experimental::auto_format::AutoFormat::GetDefaultDevice()->arch();
     auto kernel_config_val = init_device_compute_kernel_config(arch, compute_kernel_config, MathFidelity::HiFi4, true, false, false);
     if(input_tensor.is_sharded()){
-        std::cout<< " Running LayerNorm and PRE_ALL_GATHER"<<std::endl;
         return operation::run(
                 LayerNorm{
                     .norm_type = LayerNormType::LAYERNORM,

--- a/ttnn/cpp/ttnn/operations/normalization/layernorm_distributed/layernorm_pre_all_gather.hpp
+++ b/ttnn/cpp/ttnn/operations/normalization/layernorm_distributed/layernorm_pre_all_gather.hpp
@@ -6,7 +6,7 @@
 
 #include "ttnn/decorators.hpp"
 #include "device/layernorm_distributed_types.hpp"
-
+#include "ttnn/operations/normalization/layernorm/device/layernorm_types.hpp"
 #include "ttnn/operations/core/compute_kernel/compute_kernel_config.hpp"
 
 namespace ttnn {
@@ -16,7 +16,9 @@ struct ExecuteLayerNormPreAllGather {
     static ttnn::Tensor invoke(
         const ttnn::Tensor& input_tensor,
         const DataType dtype = DataType::BFLOAT16,
-        const std::optional<const DeviceComputeKernelConfig> compute_kernel_config = std::nullopt);
+        const std::optional<const DeviceComputeKernelConfig> compute_kernel_config = std::nullopt,
+        const std::optional<const LayerNormProgramConfig>& program_config = std::nullopt,
+        const std::optional<MemoryConfig>& memory_config = std::nullopt);
 };
 
 }  // namespace operations::normalization

--- a/ttnn/cpp/ttnn/operations/normalization/rmsnorm/rmsnorm.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/rmsnorm/rmsnorm.cpp
@@ -28,7 +28,7 @@ ttnn::Tensor ExecuteRMSNorm::invoke(
                     .program_config = program_config.value_or(LayerNormDefaultProgramConfig{}),
                     .compute_kernel_config = kernel_config_val},
                 {input_tensor},
-                {residual_input_tensor, weight, bias}).at(0);
+                {residual_input_tensor, weight, bias, std::nullopt}).at(0);
 }
 
 }  // namespace ttnn::operations::normalization

--- a/ttnn/cpp/ttnn/operations/normalization/rmsnorm_distributed/rmsnorm_distributed_pybind.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/rmsnorm_distributed/rmsnorm_distributed_pybind.cpp
@@ -28,7 +28,9 @@ void bind_normalization_rmsnorm_pre_all_gather_operation(py::module& module) {
             py::arg("input_tensor"),
             py::kw_only(),
             py::arg("dtype") = DataType::BFLOAT16,
-            py::arg("compute_kernel_config") = std::nullopt});
+            py::arg("compute_kernel_config") = std::nullopt,
+            py::arg("program_config") = std::nullopt,
+            py::arg("memory_config") = std::nullopt});
 }
 
 void bind_normalization_rmsnorm_post_all_gather_operation(py::module& module) {
@@ -47,7 +49,8 @@ void bind_normalization_rmsnorm_post_all_gather_operation(py::module& module) {
             py::arg("weight") = std::nullopt,
             py::arg("bias") = std::nullopt,
             py::arg("memory_config") = std::nullopt,
-            py::arg("compute_kernel_config") = std::nullopt});
+            py::arg("compute_kernel_config") = std::nullopt,
+            py::arg("program_config") = std::nullopt});
 }
 
 void bind_normalization_rms_norm_distributed(py::module& module) {

--- a/ttnn/cpp/ttnn/operations/normalization/rmsnorm_distributed/rmsnorm_post_all_gather.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/rmsnorm_distributed/rmsnorm_post_all_gather.cpp
@@ -21,7 +21,6 @@ ttnn::Tensor ExecuteRMSNormPostAllGather::invoke(
     auto arch = input_tensor.storage_type() == StorageType::DEVICE ? input_tensor.device()->arch() : ttnn::operations::experimental::auto_format::AutoFormat::GetDefaultDevice()->arch();
     auto kernel_config_val = init_device_compute_kernel_config(arch, compute_kernel_config, MathFidelity::HiFi4, true, false, false);
     if (input_tensor.is_sharded()) {
-        std::cout<< " Running LayerNorm with RMSNORM and POST_ALL_GATHER"<<std::endl;
         return operation::run(
                 LayerNorm{
                     .norm_type = LayerNormType::RMSNORM,

--- a/ttnn/cpp/ttnn/operations/normalization/rmsnorm_distributed/rmsnorm_post_all_gather.hpp
+++ b/ttnn/cpp/ttnn/operations/normalization/rmsnorm_distributed/rmsnorm_post_all_gather.hpp
@@ -20,7 +20,8 @@ struct ExecuteRMSNormPostAllGather {
         const std::optional<const ttnn::Tensor>& weight = std::nullopt,
         const std::optional<const ttnn::Tensor>& bias = std::nullopt,
         const std::optional<MemoryConfig>& memory_config = std::nullopt,
-        const std::optional<const DeviceComputeKernelConfig> compute_kernel_config = std::nullopt);
+        const std::optional<const DeviceComputeKernelConfig> compute_kernel_config = std::nullopt,
+        const std::optional<const LayerNormProgramConfig>& program_config = std::nullopt);
 };
 
 }  // namespace operations::normalization

--- a/ttnn/cpp/ttnn/operations/normalization/rmsnorm_distributed/rmsnorm_pre_all_gather.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/rmsnorm_distributed/rmsnorm_pre_all_gather.cpp
@@ -18,7 +18,6 @@ ttnn::Tensor ExecuteRMSNormPreAllGather::invoke(
     auto arch = input_tensor.storage_type() == StorageType::DEVICE ? input_tensor.device()->arch() : ttnn::operations::experimental::auto_format::AutoFormat::GetDefaultDevice()->arch();
     auto kernel_config_val = init_device_compute_kernel_config(arch, compute_kernel_config, MathFidelity::HiFi4, true, false, false);
     if(input_tensor.is_sharded()){
-        std::cout<< " Running LayerNorm with RMSNORM and PRE_ALL_GATHER"<<std::endl;
         return operation::run(
                 LayerNorm{
                     .norm_type = LayerNormType::RMSNORM,

--- a/ttnn/cpp/ttnn/operations/normalization/rmsnorm_distributed/rmsnorm_pre_all_gather.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/rmsnorm_distributed/rmsnorm_pre_all_gather.cpp
@@ -5,21 +5,39 @@
 #include "rmsnorm_pre_all_gather.hpp"
 
 #include "ttnn/operations/normalization/layernorm_distributed/device/layernorm_pre_all_gather_op.hpp"
+#include "ttnn/operations/normalization/layernorm/device/layernorm_op.hpp"
 
 namespace ttnn::operations::normalization {
 
 ttnn::Tensor ExecuteRMSNormPreAllGather::invoke(
     const ttnn::Tensor& input_tensor,
     const DataType dtype,
-    const std::optional<const DeviceComputeKernelConfig> compute_kernel_config) {
+    const std::optional<const DeviceComputeKernelConfig> compute_kernel_config,
+    const std::optional<const LayerNormProgramConfig>& program_config,
+    const std::optional<MemoryConfig>& memory_config) {
     auto arch = input_tensor.storage_type() == StorageType::DEVICE ? input_tensor.device()->arch() : ttnn::operations::experimental::auto_format::AutoFormat::GetDefaultDevice()->arch();
     auto kernel_config_val = init_device_compute_kernel_config(arch, compute_kernel_config, MathFidelity::HiFi4, true, false, false);
-    return operation::run(
-                LayerNormPreAllGather{
-                    .norm_type = LayerNormDistributedType::RMSNORM,
-                    .dtype = dtype,
+    if(input_tensor.is_sharded()){
+        std::cout<< " Running LayerNorm with RMSNORM and PRE_ALL_GATHER"<<std::endl;
+        return operation::run(
+                LayerNorm{
+                    .norm_type = LayerNormType::RMSNORM,
+                    .distributed_norm_stage = DistributedLayerNormStage::PRE_ALL_GATHER,
+                    .eps = 1e-12,
+                    .output_mem_config = memory_config.value_or(input_tensor.memory_config()),
+                    .program_config = program_config.value_or(LayerNormDefaultProgramConfig{}),
                     .compute_kernel_config = kernel_config_val},
-                {input_tensor}).at(0);
+                {input_tensor},
+                {std::nullopt, std::nullopt, std::nullopt, std::nullopt}).at(0);
+    }
+    else{
+        return operation::run(
+                    LayerNormPreAllGather{
+                        .norm_type = LayerNormDistributedType::RMSNORM,
+                        .dtype = dtype,
+                        .compute_kernel_config = kernel_config_val},
+                    {input_tensor}).at(0);
+    }
 }
 
 }  // namespace ttnn::operations::normalization

--- a/ttnn/cpp/ttnn/operations/normalization/rmsnorm_distributed/rmsnorm_pre_all_gather.hpp
+++ b/ttnn/cpp/ttnn/operations/normalization/rmsnorm_distributed/rmsnorm_pre_all_gather.hpp
@@ -16,7 +16,9 @@ struct ExecuteRMSNormPreAllGather {
     static ttnn::Tensor invoke(
         const ttnn::Tensor& input_tensor,
         const DataType dtype = DataType::BFLOAT16,
-        const std::optional<const DeviceComputeKernelConfig> compute_kernel_config = std::nullopt);
+        const std::optional<const DeviceComputeKernelConfig> compute_kernel_config = std::nullopt,
+        const std::optional<const LayerNormProgramConfig>& program_config = std::nullopt,
+        const std::optional<MemoryConfig>& memory_config = std::nullopt);
 };
 
 }  // namespace operations::normalization


### PR DESCRIPTION
## Summary
This PR introduces sharded distributed LayerNorm for pre/post-all-gather stages, leveraging existing single device sharded LayerNorm host code. The implementation includes new kernels and comprehensive test coverage.

## Key Changes
1. Implemented sharded distributed LayerNorm for pre/post-all-gather stages
   - Utilized existing single device sharded LayerNorm host code
   - Ensures compatibility with current implementation

2. Performance and Accuracy
   - No impact on performance or accuracy of existing single device sharded LayerNorm

3. New Kernel Development
   - Added new kernels specifically for pre/post-all-gather operations

4. Test Coverage
   - Implemented test coverage for pre/post-all-gather on single device
   - Added end-to-end (e2e) test coverage on galaxy (TG)

## Performance Benchmarks
```
Full Activation Shape : [1, 1, 32, 8192]
Activation and Weights dtype : ttnn.bfloat16
```
| Stages | Norm Type | Num Distributed Devices | Num Cores | FW Duration(ns) |
|--------|-----------|-------------------------|-----------|-------------|
| pre_all_gather | RMSnorm |  4 | 32|  6855|
| post_all_gather | RMSnorm | 4 | 32|  6396|
| pre_all_gather | Layernorm | 4 | 32 |  9441|
| post_all_gather | Layernorm |  4 | 32|  7944|

## Future Steps
1. Add normalization support for `batch_size` > 32
2. Create functions for CB creation to improve readability
### Checklist
- [x] Post commit CI passes https://github.com/tenstorrent/tt-metal/actions/runs/10886636636
- [x] New/Existing tests provide coverage for changes
