### PR TITLE
#12628: Resolve arithmetic error in test_multi_cq_multi_dev causing T3K multi-CQ tests to fail

### DIFF
--- a/tests/ttnn/unit_tests/gtests/test_multi_cq_multi_dev.cpp
+++ b/tests/ttnn/unit_tests/gtests/test_multi_cq_multi_dev.cpp
@@ -21,15 +21,15 @@ Tensor dispatch_ops_to_device(Device* dev, Tensor input_tensor, uint8_t cq_id) {
     using ttnn::operations::unary::UnaryWithParam;
     using ttnn::operations::unary::UnaryOpType;
 
-    Tensor output_tensor = ttnn::mul_sfpu(cq_id, input_tensor);
+    Tensor output_tensor = ttnn::mul_sfpu(cq_id, input_tensor, 2);
     for (int i = 0; i < 3; i++) {
         output_tensor = ttnn::neg(cq_id, output_tensor);
         output_tensor = ttnn::neg(cq_id, output_tensor);
         output_tensor = ttnn::mul_sfpu(cq_id, output_tensor, 2);
     }
-    output_tensor = ttnn::neg(cq_id, input_tensor);
-    output_tensor = ttnn::mul_sfpu(cq_id, input_tensor, 2);
-    output_tensor = ttnn::add_sfpu(cq_id, input_tensor, 500);
+    output_tensor = ttnn::neg(cq_id, output_tensor);
+    output_tensor = ttnn::mul_sfpu(cq_id, output_tensor, 2);
+    output_tensor = ttnn::add_sfpu(cq_id, output_tensor, 500);
     return output_tensor;
 }
 

--- a/ttnn/cpp/ttnn/async_runtime.cpp
+++ b/ttnn/cpp/ttnn/async_runtime.cpp
@@ -56,7 +56,6 @@ DeviceBuffer allocate_buffer_on_device(
     Layout layout,
     const MemoryConfig& memory_config,
     const std::optional<ShardSpecBuffer>& shard_spec) {
-    std::cout << "buffer_size_bytes " << buffer_size_bytes << std::endl;
     if (memory_config.memory_layout == tt::tt_metal::TensorMemoryLayout::INTERLEAVED) {
         return allocate_interleaved_buffer_on_device(
             buffer_size_bytes, device, shape, data_type, layout, memory_config);


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/12628

### Problem description
`test_multi_cq_multi_device` is broken on main due to a mismatch between the ops sent to device and those used for golden calculation.

### What's changed
Modify the test to correctly compute device outputs.

### Checklist
- [ ] Post commit CI passes
- [ ] Blackhole Post commit (if applicable)
- [ ] Model regression CI testing passes (if applicable)
- [ ] Device performance regression CI testing passes (if applicable)
- [ ] New/Existing tests provide coverage for changes
