### PR TITLE
#12619: Update matmul sweep timeout and core range set usage

### DIFF
--- a/tests/sweep_framework/sweeps/matmul/full/matmul_default_height_sharded.py
+++ b/tests/sweep_framework/sweeps/matmul/full/matmul_default_height_sharded.py
@@ -88,7 +88,7 @@ def run(
     # TODO: row_wise=False and ROW_MAJOR shard orientation gives bad PCC
     # TODO: COL_MAJOR shard orientation doesn't work for get_matmul_program_config
     input_a_memory_config.shard_spec = ttnn.ShardSpec(
-        ttnn.num_cores_to_corerange_set(num_cores_height, core_grid, row_wise=True),
+        ttnn.CoreRangeSet(ttnn.num_cores_to_corerange_set(num_cores_height, core_grid, row_wise=True)),
         (per_core_height, k_size),
         ttnn.ShardOrientation.ROW_MAJOR,
         False,

--- a/tests/sweep_framework/sweeps/matmul/full/matmul_default_width_sharded.py
+++ b/tests/sweep_framework/sweeps/matmul/full/matmul_default_width_sharded.py
@@ -81,7 +81,7 @@ def run(
     # TODO: row_wise=False and ROW_MAJOR shard orientation gives bad PCC
     # TODO: COL_MAJOR shard orientation doesn't work for get_matmul_program_config
     input_a_memory_config.shard_spec = ttnn.ShardSpec(
-        ttnn.num_cores_to_corerange_set(num_cores_width, core_grid, row_wise=True),
+        ttnn.CoreRangeSet(ttnn.num_cores_to_corerange_set(num_cores_width, core_grid, row_wise=True)),
         (total_height, per_core_width),
         ttnn.ShardOrientation.ROW_MAJOR,
         False,

--- a/tests/sweep_framework/sweeps/matmul/short/matmul_default.py
+++ b/tests/sweep_framework/sweeps/matmul/short/matmul_default.py
@@ -12,7 +12,7 @@ from tests.ttnn.utils_for_testing import check_with_pcc, start_measuring_time, s
 from models.utility_functions import torch_random
 
 
-TIMEOUT = 5
+TIMEOUT = 15
 
 # TODO: Missing coverage for mixed precision; passed in dtype does nothing in current matmul path
 parameters = {


### PR DESCRIPTION
### Ticket
Link to Github Issue https://github.com/tenstorrent/tt-metal/issues/12619

### Problem description
- one of the sweeps has a lot of timeouts
- two sweeps do not deal with core range sets properly after a refactor

### What's changed
- update the timeout 
- fix the core range set usage

### Checklist
- [ ] Post commit CI passes N/A
- [ ] Blackhole Post commit (if applicable) N/A
- [ ] Model regression CI testing passes (if applicable) N/A
- [ ] Device performance regression CI testing passes (if applicable) N/A
- [ ] New/Existing tests provide coverage for changes N/A

### Testing
- verified that all matmul sweeps run
