### PR TITLE
Generalize nlp create head decode

### DIFF
--- a/tests/tt_eager/python_api_testing/unit_testing/misc/test_nlp_create_qkv_heads_decode.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/misc/test_nlp_create_qkv_heads_decode.py
@@ -69,9 +69,9 @@ def run_test_create_head_max_width_shard(device, n_local_heads, n_local_kv_heads
         memory_config=HEIGHT_SHARDED_MEMCFG,
         # unpadded_batch_size=batch if batch != padded_batch else None,
     )
-    logger.info(f"q_heads_tt: {q_heads_tt.memory_config()}")
-    logger.info(f"k_heads_tt: {k_heads_tt.memory_config()}")
-    logger.info(f"v_heads_tt: {v_heads_tt.memory_config()}")
+    logger.info(f"q_heads_tt: {q_heads_tt.shape}, {q_heads_tt.memory_config()}")
+    logger.info(f"k_heads_tt: {k_heads_tt.shape}, {k_heads_tt.memory_config()}")
+    logger.info(f"v_heads_tt: {v_heads_tt.shape}, {v_heads_tt.memory_config()}")
 
     # torch operation
     q_heads_torch = proj_output[:, :, :batch, : head_dim * n_local_heads].view(seq_len, batch, n_local_heads, head_dim)
@@ -83,15 +83,15 @@ def run_test_create_head_max_width_shard(device, n_local_heads, n_local_kv_heads
     )
 
     # compare
-    q_heads_tt_cpu = tt2torch_tensor(q_heads_tt)[..., :n_local_heads, :]
+    q_heads_tt_cpu = ttnn.to_torch(q_heads_tt)
     out_pass_q, output_pcc_q = comp_pcc(q_heads_tt_cpu, q_heads_torch, pcc=0.9999)
     logger.info(f"PCC value: {output_pcc_q}")
 
-    k_heads_tt_cpu = tt2torch_tensor(k_heads_tt)[..., :n_local_kv_heads, :]
+    k_heads_tt_cpu = ttnn.to_torch(k_heads_tt)
     out_pass_k, output_pcc_k = comp_pcc(k_heads_tt_cpu, k_heads_torch, pcc=0.9999)
     logger.info(f"PCC value: {output_pcc_k}")
 
-    v_heads_tt_cpu = tt2torch_tensor(v_heads_tt)[..., :n_local_kv_heads, :]
+    v_heads_tt_cpu = ttnn.to_torch(v_heads_tt)
     out_pass_v, output_pcc_v = comp_pcc(v_heads_tt_cpu, v_heads_torch, pcc=0.9999)
     logger.info(f"PCC value: {output_pcc_v}")
 
@@ -101,7 +101,7 @@ def run_test_create_head_max_width_shard(device, n_local_heads, n_local_kv_heads
 @skip_for_grayskull("Requires eth connected devices to run")
 @pytest.mark.parametrize(
     "n_local_heads, n_local_kv_heads, head_dim, batch",
-    ((8, 1, 128, 32), (8, 4, 96, 32), (16, 2, 64, 32), (8, 1, 128, 16), (8, 1, 128, 8)),
+    ((8, 1, 128, 32), (8, 4, 96, 32), (16, 2, 64, 32), (8, 1, 128, 16), (8, 1, 128, 8), (32, 8, 128, 4)),
 )
 def test_create_head_max_width_shard(
     n_local_heads,
@@ -172,9 +172,9 @@ def run_test_create_min_width_shard(
         num_kv_heads=n_local_kv_heads,
         memory_config=HEIGHT_SHARDED_MEMCFG,
     )
-    logger.info(f"q_heads_tt: {q_heads_tt.memory_config()}")
-    logger.info(f"k_heads_tt: {k_heads_tt.memory_config()}")
-    logger.info(f"v_heads_tt: {v_heads_tt.memory_config()}")
+    logger.info(f"q_heads_tt: {q_heads_tt.shape}, {q_heads_tt.memory_config()}")
+    logger.info(f"k_heads_tt: {k_heads_tt.shape}, {k_heads_tt.memory_config()}")
+    logger.info(f"v_heads_tt: {v_heads_tt.shape}, {v_heads_tt.memory_config()}")
 
     # torch operation
     q_heads_torch = proj_output[:, :, :, : head_dim * n_local_heads].view(seq_len, batch, n_local_heads, head_dim)
@@ -186,15 +186,15 @@ def run_test_create_min_width_shard(
     )
 
     # compare
-    q_heads_tt_cpu = tt2torch_tensor(q_heads_tt)[..., :n_local_heads, :]
+    q_heads_tt_cpu = ttnn.to_torch(q_heads_tt)
     out_pass_q, output_pcc_q = comp_pcc(q_heads_tt_cpu, q_heads_torch)
     logger.info(f"PCC value: {output_pcc_q}")
 
-    k_heads_tt_cpu = tt2torch_tensor(k_heads_tt)[..., :n_local_kv_heads, :]
+    k_heads_tt_cpu = ttnn.to_torch(k_heads_tt)
     out_pass_k, output_pcc_k = comp_pcc(k_heads_tt_cpu, k_heads_torch)
     logger.info(f"PCC value: {output_pcc_k}")
 
-    v_heads_tt_cpu = tt2torch_tensor(v_heads_tt)[..., :n_local_kv_heads, :]
+    v_heads_tt_cpu = ttnn.to_torch(v_heads_tt)
     out_pass_v, output_pcc_v = comp_pcc(v_heads_tt_cpu, v_heads_torch)
     logger.info(f"PCC value: {output_pcc_v}")
 

--- a/ttnn/cpp/ttnn/operations/experimental/transformer/nlp_create_qkv_heads_decode/device/kernels/reader_interleaved_tm_tile_layout_nlp_create_qkv_heads_decode.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/nlp_create_qkv_heads_decode/device/kernels/reader_interleaved_tm_tile_layout_nlp_create_qkv_heads_decode.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+// SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/ttnn/cpp/ttnn/operations/experimental/transformer/nlp_create_qkv_heads_decode/device/kernels/reader_interleaved_tm_tile_layout_nlp_create_qkv_heads_decode.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/nlp_create_qkv_heads_decode/device/kernels/reader_interleaved_tm_tile_layout_nlp_create_qkv_heads_decode.cpp
@@ -1,0 +1,119 @@
+// SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <stdint.h>
+#include "dataflow_api.h"
+
+void kernel_main() {
+    uint32_t in_tile_offset_by_batch       = get_arg_val<uint32_t>(0);
+    uint32_t q_start_addr                  = get_arg_val<uint32_t>(1);
+
+    constexpr uint32_t ELEMENT_SIZE        = get_compile_time_arg_val(0);
+    constexpr uint32_t SUBTILE_LINE_BYTES  = get_compile_time_arg_val(1);
+    constexpr uint32_t cb_id_q_out         = get_compile_time_arg_val(2);
+    constexpr uint32_t cb_id_k_out         = get_compile_time_arg_val(3);
+    constexpr uint32_t cb_id_v_out         = get_compile_time_arg_val(4);
+    constexpr uint32_t head_size           = get_compile_time_arg_val(5);
+    constexpr uint32_t num_q_heads         = get_compile_time_arg_val(6);
+    constexpr uint32_t num_kv_heads        = get_compile_time_arg_val(7);
+    constexpr uint32_t head_size_num_tiles = get_compile_time_arg_val(8);
+    constexpr uint32_t PHASES_TO_READ      = get_compile_time_arg_val(9);  // 0 to read all phases, 1 to read only first phase, 2 to read only second phase
+    constexpr bool is_dram                 = get_compile_time_arg_val(10) == 1;
+    constexpr uint32_t tile_size = head_size/head_size_num_tiles;
+
+    // Q
+    constexpr uint32_t qkv_tile_bytes = get_tile_size(cb_id_q_out);
+    constexpr DataFormat qkv_data_format = get_dataformat(cb_id_q_out);
+
+    const InterleavedAddrGenFast<is_dram> qkv_reader = {
+        .bank_base_address = q_start_addr,
+        .page_size = qkv_tile_bytes,
+        .data_format = qkv_data_format
+    };
+
+    uint32_t q_write_addr = 0;
+    uint32_t qkv_tile_id = 0;
+
+    for (uint32_t q = 0; q < num_q_heads; ++q) {
+        uint32_t wptr_offset = q < 16 ? q * SUBTILE_LINE_BYTES : (q - 16) * SUBTILE_LINE_BYTES + 512*ELEMENT_SIZE;
+        uint32_t q_write_addr = get_write_ptr(cb_id_q_out) + wptr_offset;
+
+        for (uint32_t i = 0; i < head_size_num_tiles; ++i) {
+            uint64_t qkv_in_noc_addr = get_noc_addr(qkv_tile_id, qkv_reader) + in_tile_offset_by_batch;
+
+            // Read first phase
+            if constexpr (PHASES_TO_READ == 0 || PHASES_TO_READ == 1) {
+                noc_async_read(qkv_in_noc_addr, q_write_addr, SUBTILE_LINE_BYTES);
+                //noc_async_read_barrier();
+            }
+            // Read second phase
+            if constexpr (PHASES_TO_READ == 0 || PHASES_TO_READ == 2) {
+                noc_async_read(qkv_in_noc_addr+256*ELEMENT_SIZE, q_write_addr+256*ELEMENT_SIZE, SUBTILE_LINE_BYTES);
+                //noc_async_read_barrier();
+            }
+
+            qkv_tile_id += 1;
+            q_write_addr += tile_size;
+        }
+        noc_async_read_barrier();
+    }
+
+    // K
+    uint32_t k_write_addr = 0;
+
+    // Read 2 phases per tile, where there are num_q_heads * q_num_tiles tiles
+    for (uint32_t k = 0; k < num_kv_heads; ++k) {
+        uint32_t wptr_offset = k < 16 ? k * SUBTILE_LINE_BYTES : (k - 16) * SUBTILE_LINE_BYTES + 512*ELEMENT_SIZE;
+        uint32_t k_write_addr = get_write_ptr(cb_id_k_out) + wptr_offset;
+
+        for (uint32_t i = 0; i < head_size_num_tiles; ++i) {
+            uint64_t qkv_in_noc_addr = get_noc_addr(qkv_tile_id, qkv_reader) + in_tile_offset_by_batch;
+
+            // Read first phase
+            if constexpr (PHASES_TO_READ == 0 || PHASES_TO_READ == 1) {
+                noc_async_read(qkv_in_noc_addr, k_write_addr, SUBTILE_LINE_BYTES);
+                //noc_async_read_barrier();
+            }
+            // Read second phase
+            if constexpr (PHASES_TO_READ == 0 || PHASES_TO_READ == 2) {
+                noc_async_read(qkv_in_noc_addr+256*ELEMENT_SIZE, k_write_addr+256*ELEMENT_SIZE, SUBTILE_LINE_BYTES);
+                //noc_async_read_barrier();
+            }
+
+            qkv_tile_id += 1;
+            k_write_addr += tile_size;
+        }
+        noc_async_read_barrier();
+    }
+
+    // v
+    uint32_t v_write_addr = 0;
+
+    // Read 2 phases per tile, where there are num_q_heads * q_num_tiles tiles
+    for (uint32_t v = 0; v < num_kv_heads; ++v) {
+        uint32_t wptr_offset = v < 16 ? v * SUBTILE_LINE_BYTES : (v - 16) * SUBTILE_LINE_BYTES + 512*ELEMENT_SIZE;
+        uint32_t v_write_addr = get_write_ptr(cb_id_v_out) + wptr_offset;
+
+        for (uint32_t i = 0; i < head_size_num_tiles; ++i) {
+            uint64_t qkv_in_noc_addr = get_noc_addr(qkv_tile_id, qkv_reader) + in_tile_offset_by_batch;
+
+            // Read first phase
+            if constexpr (PHASES_TO_READ == 0 || PHASES_TO_READ == 1) {
+                noc_async_read(qkv_in_noc_addr, v_write_addr, SUBTILE_LINE_BYTES);
+                //noc_async_read_barrier();
+            }
+            // Read second phase
+            if constexpr (PHASES_TO_READ == 0 || PHASES_TO_READ == 2) {
+                noc_async_read(qkv_in_noc_addr+256*ELEMENT_SIZE, v_write_addr+256*ELEMENT_SIZE, SUBTILE_LINE_BYTES);
+                //noc_async_read_barrier();
+            }
+
+            qkv_tile_id += 1;
+            v_write_addr += tile_size;
+        }
+        noc_async_read_barrier();
+    }
+
+    noc_async_read_barrier();
+}

--- a/ttnn/cpp/ttnn/operations/experimental/transformer/nlp_create_qkv_heads_decode/device/nlp_create_qkv_heads_decode_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/nlp_create_qkv_heads_decode/device/nlp_create_qkv_heads_decode_device_operation.cpp
@@ -31,8 +31,6 @@ void NLPCreateHeadsDecodeDeviceOperation::validate(const std::vector<Tensor>& in
         TT_FATAL(QKV_memcfg.memory_layout == TensorMemoryLayout::WIDTH_SHARDED, "Error");
         TT_FATAL(input_tensor.shard_spec().value().shape[0] == input_tensor.volume() / input_tensor.get_legacy_shape()[-1], "Error");
         TT_FATAL(input_tensor.shard_spec().value().orientation == ShardOrientation::ROW_MAJOR, "Error");
-        // we either put everything in one shard or split it into minimum tile width accross as many cores as possible
-        TT_FATAL(input_tensor.shard_spec().value().shape[1] == (this->num_q_heads + this->num_kv_heads * 2) * this->head_dim || input_tensor.shard_spec().value().shape[1] == 32, "Error");
     }
     auto core_grid = input_tensor.device()->compute_with_storage_grid_size();
 

--- a/ttnn/cpp/ttnn/operations/experimental/transformer/nlp_create_qkv_heads_decode/device/nlp_create_qkv_heads_decode_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/nlp_create_qkv_heads_decode/device/nlp_create_qkv_heads_decode_device_operation.hpp
@@ -12,6 +12,9 @@
 namespace ttnn::operations::experimental::transformer {
 
     operation::ProgramWithCallbacks multi_core_nlp_create_qkv_heads_decode(const Tensor &input_tensor, const uint32_t num_q_heads, const uint32_t num_kv_heads, const uint32_t head_dim, std::vector<Tensor>& output, CoreCoord compute_with_storage_grid_size);
+    operation::ProgramWithCallbacks multi_core_nlp_create_qkv_heads_decode_interleaved_input(const Tensor &input_tensor, const uint32_t num_q_heads, const uint32_t num_kv_heads, const uint32_t head_dim, std::vector<Tensor>& output, CoreCoord compute_with_storage_grid_size);
+    operation::ProgramWithCallbacks multi_core_nlp_create_qkv_heads_decode_sharded_input(const Tensor &input_tensor, const uint32_t num_q_heads, const uint32_t num_kv_heads, const uint32_t head_dim, std::vector<Tensor>& output, CoreCoord compute_with_storage_grid_size);
+
 
     struct NLPCreateHeadsDecodeDeviceOperation {
         const uint32_t num_q_heads;

--- a/ttnn/cpp/ttnn/operations/experimental/transformer/nlp_create_qkv_heads_decode/device/nlp_create_qkv_heads_decode_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/nlp_create_qkv_heads_decode/device/nlp_create_qkv_heads_decode_program_factory.cpp
@@ -14,7 +14,168 @@ using namespace tt;
 namespace ttnn::operations::experimental::transformer {
 
     operation::ProgramWithCallbacks multi_core_nlp_create_qkv_heads_decode(const Tensor &input_tensor, const uint32_t num_q_heads, const uint32_t num_kv_heads, const uint32_t head_dim, std::vector<Tensor>& output, CoreCoord compute_with_storage_grid_size) {
+        bool is_input_sharded = input_tensor.is_sharded();
+        if (is_input_sharded) {
+            return multi_core_nlp_create_qkv_heads_decode_sharded_input(input_tensor, num_q_heads, num_kv_heads, head_dim, output, compute_with_storage_grid_size);
+        } else {
+            return multi_core_nlp_create_qkv_heads_decode_interleaved_input(input_tensor, num_q_heads, num_kv_heads, head_dim, output, compute_with_storage_grid_size);
+        }
+    }
 
+    operation::ProgramWithCallbacks multi_core_nlp_create_qkv_heads_decode_interleaved_input(const Tensor &input_tensor, const uint32_t num_q_heads, const uint32_t num_kv_heads, const uint32_t head_dim, std::vector<Tensor>& output, CoreCoord compute_with_storage_grid_size) {
+
+        tt_metal::Program program = tt_metal::CreateProgram();
+
+        const auto& input_shape = input_tensor.get_legacy_shape();
+
+        tt_metal::Device *device = input_tensor.device();
+
+        bool is_dram = input_tensor.memory_config().buffer_type == tt::tt_metal::BufferType::DRAM;
+
+        tt::DataFormat cb_data_format = tt_metal::datatype_to_dataformat_converter(input_tensor.get_dtype());
+
+        uint32_t single_tile_size = tt_metal::detail::TileSize(cb_data_format);
+
+        uint32_t head_tiles = head_dim / TILE_WIDTH;
+        uint32_t head_size = head_tiles * single_tile_size;
+
+        uint32_t element_size = input_tensor.element_size();
+        uint32_t sub_tile_line_bytes = 16 * element_size;
+        auto q_shard_spec = output[0].shard_spec().value();
+        auto q_cores = q_shard_spec.grid;
+        auto q_num_tiles = q_shard_spec.shape[0] * q_shard_spec.shape[1] / TILE_HW;
+        auto in_shape = input_tensor.get_legacy_shape();
+        auto in_num_tiles = in_shape[-2] * in_shape[-1] / TILE_HW;
+
+        uint32_t q_output_cb_index = CB::c_out0;
+        tt_metal::CircularBufferConfig cb_q_output_config =
+            tt_metal::CircularBufferConfig(
+                q_num_tiles * single_tile_size, {{q_output_cb_index, cb_data_format}})
+                .set_page_size(q_output_cb_index, single_tile_size).set_globally_allocated_address(*output[0].buffer());
+        auto cb_q_output = tt_metal::CreateCircularBuffer(program, q_cores, cb_q_output_config);
+
+        auto k_shard_spec = output[1].shard_spec().value();
+        auto k_cores = k_shard_spec.grid;
+        auto k_num_tiles = k_shard_spec.shape[0] * k_shard_spec.shape[1] / TILE_HW;
+
+        uint32_t k_output_cb_index = CB::c_out1;
+        tt_metal::CircularBufferConfig cb_k_output_config =
+            tt_metal::CircularBufferConfig(
+                k_num_tiles * single_tile_size, {{k_output_cb_index, cb_data_format}})
+                .set_page_size(k_output_cb_index, single_tile_size).set_globally_allocated_address(*output[1].buffer());
+        auto cb_k_output = tt_metal::CreateCircularBuffer(program, k_cores, cb_k_output_config);
+
+        auto v_shard_spec = output[2].shard_spec().value();
+        auto v_cores = q_shard_spec.grid;
+        auto v_num_tiles = v_shard_spec.shape[0] * v_shard_spec.shape[1] / TILE_HW;
+
+        uint32_t v_output_cb_index = CB::c_out2;
+        tt_metal::CircularBufferConfig cb_v_output_config =
+            tt_metal::CircularBufferConfig(
+                v_num_tiles * single_tile_size, {{v_output_cb_index, cb_data_format}})
+                .set_page_size(v_output_cb_index, single_tile_size).set_globally_allocated_address(*output[2].buffer());
+        auto cb_v_output = tt_metal::CreateCircularBuffer(program, v_cores, cb_v_output_config);
+
+        uint32_t q_base_addr = input_tensor.buffer()->address();
+
+        // We parallize the reader on risc0 and risc1, where each risc reads a sub-tile of the input (phase1 and phase2 of a tile respectively)
+        std::vector<uint32_t> reader_compile_time_args = {
+            (std::uint32_t) element_size,
+            (std::uint32_t) sub_tile_line_bytes,
+            q_output_cb_index,
+            k_output_cb_index,
+            v_output_cb_index,
+            head_size,
+            num_q_heads,
+            num_kv_heads,
+            head_tiles,
+            1, // read the first phase
+            is_dram ? 1 : 0
+        };
+        auto reader_kernel_id = tt_metal::CreateKernel(
+            program,
+            "ttnn/cpp/ttnn/operations/experimental/transformer/nlp_create_qkv_heads_decode/device/kernels/reader_interleaved_tm_tile_layout_nlp_create_qkv_heads_decode.cpp",
+            q_cores,
+            tt_metal::ReaderDataMovementConfig(reader_compile_time_args));
+        reader_compile_time_args[9] = 2;  // read the second phase
+        auto writer_kernel_id = tt_metal::CreateKernel(
+            program,
+            "ttnn/cpp/ttnn/operations/experimental/transformer/nlp_create_qkv_heads_decode/device/kernels/reader_interleaved_tm_tile_layout_nlp_create_qkv_heads_decode.cpp",
+            q_cores,
+            tt_metal::WriterDataMovementConfig(reader_compile_time_args));
+
+        uint32_t num_cores = q_cores.num_cores(); // number of cores of the output
+        auto core_grid = q_cores.bounding_box();
+        uint32_t num_cores_x = core_grid.end_coord.x + 1, num_cores_y = core_grid.end_coord.y + 1;
+        const auto &cores = grid_to_cores(num_cores, num_cores_x, num_cores_y, true);
+
+        for (uint32_t i = 0; i < num_cores; ++i) {
+            uint32_t in_tile_offset_by_batch = i < 16 ? i * sub_tile_line_bytes : (i - 16) * sub_tile_line_bytes + 512*element_size;
+
+            const auto& core = cores[i];
+            std::vector<uint32_t> reader_runtime_args;
+            reader_runtime_args.reserve(2);
+            reader_runtime_args = {
+                in_tile_offset_by_batch,
+                q_base_addr,
+            };
+
+            tt_metal::SetRuntimeArgs(program, reader_kernel_id, core, reader_runtime_args);
+            tt_metal::SetRuntimeArgs(program, writer_kernel_id, core, reader_runtime_args);
+        }
+
+        auto override_runtime_arguments_callback = [
+                reader_kernel_id,
+                writer_kernel_id,
+                num_cores,
+                cb_q_output,
+                cb_k_output,
+                cb_v_output,
+                cores,
+                element_size,
+                sub_tile_line_bytes
+        ]
+        (
+            const void* operation,
+            Program &program,
+            const std::vector<Tensor>& input_tensors,
+            const std::vector<std::optional<const Tensor>>& optional_input_tensors,
+            const std::vector<Tensor>& output_tensors
+        ) {
+
+            auto src_buffer = input_tensors.at(0).buffer();
+
+            uint32_t src_kv_buffer_addr = 0;
+
+            auto dst_buffer_query = output_tensors.at(0).buffer();
+            auto dst_buffer_key = output_tensors.at(1).buffer();
+            auto dst_buffer_value = output_tensors.at(2).buffer();
+
+            UpdateDynamicCircularBufferAddress(program, cb_q_output, *dst_buffer_query);
+            UpdateDynamicCircularBufferAddress(program, cb_k_output, *dst_buffer_key);
+            UpdateDynamicCircularBufferAddress(program, cb_v_output, *dst_buffer_value);
+
+            uint32_t q_base_addr = input_tensors[0].buffer()->address();
+            uint32_t q_start_addr = q_base_addr;
+
+            for (uint32_t i = 0; i < num_cores; ++i) {
+                uint32_t in_tile_offset_by_batch = i < 16 ? i * sub_tile_line_bytes : (i - 16) * sub_tile_line_bytes + 512*element_size;
+                const auto& core = cores[i];
+                auto &runtime_args = GetRuntimeArgs(program, reader_kernel_id, core);
+                runtime_args[0] = in_tile_offset_by_batch;
+                runtime_args[1] = q_start_addr;
+
+                auto &runtime_args_writer = GetRuntimeArgs(program, writer_kernel_id, core);
+                runtime_args_writer[0] = in_tile_offset_by_batch;
+                runtime_args_writer[1] = q_start_addr;
+            }
+        };
+
+        return {.program=std::move(program), .override_runtime_arguments_callback=override_runtime_arguments_callback};
+    }
+
+
+    operation::ProgramWithCallbacks multi_core_nlp_create_qkv_heads_decode_sharded_input(const Tensor &input_tensor, const uint32_t num_q_heads, const uint32_t num_kv_heads, const uint32_t head_dim, std::vector<Tensor>& output, CoreCoord compute_with_storage_grid_size) {
         tt_metal::Program program = tt_metal::CreateProgram();
 
         const auto& input_shape = input_tensor.get_legacy_shape();
@@ -185,4 +346,6 @@ namespace ttnn::operations::experimental::transformer {
 
         return {.program=std::move(program), .override_runtime_arguments_callback=override_runtime_arguments_callback};
     }
+
+
 } // namespace ttnn::operations::experimental::transformer


### PR DESCRIPTION
### Ticket
#12393

The following functionality and bug fixes are added:

- [x] bug 1: when passing in q_heads=32, the output shape is padded to 64 and has to be sliced. If we directly change the output shape to 32 in create_output_tensor function, the output has bad pcc. This is a trace of potential implementation flaws

In addition, the following optimzation should be made to the op:

- [x] allow interleaved input
- [x] allow input to be width sharded by arbitrary shape on core grid
- [x] should output tensor with padded shape if the number head is less than a full tile