### PR TITLE
#11144: Upgrade `pip` version to `21.2.4` to get around 22.04 import error

### DIFF
--- a/create_venv.sh
+++ b/create_venv.sh
@@ -26,7 +26,7 @@ $PYTHON_CMD -m venv $PYTHON_ENV_DIR
 source $PYTHON_ENV_DIR/bin/activate
 
 echo "Forcefully using a version of pip that will work with our view of editable installs"
-pip install --force-reinstall pip==20.1.1
+pip install --force-reinstall pip==21.2
 
 echo "Setting up virtual env"
 python3 -m pip config set global.extra-index-url https://download.pytorch.org/whl/cpu

--- a/create_venv.sh
+++ b/create_venv.sh
@@ -26,7 +26,7 @@ $PYTHON_CMD -m venv $PYTHON_ENV_DIR
 source $PYTHON_ENV_DIR/bin/activate
 
 echo "Forcefully using a version of pip that will work with our view of editable installs"
-pip install --force-reinstall pip==21.2
+pip install --force-reinstall pip==21.2.4
 
 echo "Setting up virtual env"
 python3 -m pip config set global.extra-index-url https://download.pytorch.org/whl/cpu

--- a/tt_metal/python_env/requirements-dev.txt
+++ b/tt_metal/python_env/requirements-dev.txt
@@ -57,3 +57,4 @@ fsspec==2023.9.2 # Temporary pin to 2023.9.2: https://github.com/tenstorrent/tt-
 docopt==0.6.2
 tabulate==0.9.0
 blobfile==2.1.1 # Required for llama3
+numpy>=1.24.4,<2


### PR DESCRIPTION
### Ticket
[Link to Github Issue
](https://github.com/tenstorrent/tt-metal/issues/11144)
### Problem description
On Ubuntu 22.04 with a fresh `venv` install, we could not import torch properly.

### What's changed
Upgrade pip version to 21.2.4 to avoid this issue.

### Checklist
- [x] Post commit CI passes
