### PR TITLE
Mamba CI hanging on Untilize fix

### DIFF
--- a/tests/ttnn/unit_tests/test_to_layout.py
+++ b/tests/ttnn/unit_tests/test_to_layout.py
@@ -62,14 +62,12 @@ def test_to_layout_2D(device, height, width, on_device, from_layout, to_layout, 
 
 @pytest.mark.parametrize(
     "shape",
-    [
-        (1, 1, 32, 128 * 1024),
-    ],
+    [(1, 1, 32, 128 * 1024), (1, 1, 128, 5120)],
 )
 @pytest.mark.parametrize("on_device", [True])
 @pytest.mark.parametrize("from_layout", [ttnn.TILE_LAYOUT])
 @pytest.mark.parametrize("to_layout", [ttnn.ROW_MAJOR_LAYOUT])
-def test_to_layout_llama(device, shape, on_device, from_layout, to_layout):
+def test_to_layout_wide_tensor(device, shape, on_device, from_layout, to_layout):
     torch.manual_seed(0)
     torch_input_tensor = torch.rand(shape, dtype=torch.bfloat16)
     input_tensor = ttnn.from_torch(torch_input_tensor)

--- a/tests/ttnn/unit_tests/test_to_layout.py
+++ b/tests/ttnn/unit_tests/test_to_layout.py
@@ -62,7 +62,7 @@ def test_to_layout_2D(device, height, width, on_device, from_layout, to_layout, 
 
 @pytest.mark.parametrize(
     "shape",
-    [(1, 1, 32, 128 * 1024), (1, 1, 128, 5120)],
+    [(1, 1, 32, 128 * 1024), (1, 1, 128, 5120), (1, 1, 512, 5120), (1, 1, 128, 128 * 1024)],
 )
 @pytest.mark.parametrize("on_device", [True])
 @pytest.mark.parametrize("from_layout", [ttnn.TILE_LAYOUT])


### PR DESCRIPTION
### Ticket
[Link to Github Issue](https://github.com/tenstorrent/tt-metal/issues/12467)

### Problem description
For wide tensors (previously unsupported but recent support was added) , it seems to hang if it's higher than a single tile. 
 

### What's changed
Prior to the recent change this would have crashed, now it hangs. Added a sub optimal work around for really wide tensors that are taller than a single tile, to use limited parallelization. 
This should be optimized in a future PR (Added the issue here: https://github.com/tenstorrent/tt-metal/issues/12676) 

### Checklist
- [ ] Post commit CI passes
- [ ] Blackhole Post commit (if applicable)
- [ ] Model regression CI testing passes (if applicable)
- [ ] Device performance regression CI testing passes (if applicable)
- [ ] New/Existing tests provide coverage for changes
